### PR TITLE
feat: add CubeSandbox base image and entrypoint script

### DIFF
--- a/.github/workflows/build-envd-base-image.yml
+++ b/.github/workflows/build-envd-base-image.yml
@@ -1,0 +1,128 @@
+name: Build envd Base Image
+
+on:
+  push:
+    paths:
+      - 'docker/Dockerfile.cube-base'
+      - 'docker/cube-entrypoint.sh'
+      - '.github/workflows/build-envd-base-image.yml'
+  pull_request:
+    paths:
+      - 'docker/Dockerfile.cube-base'
+      - 'docker/cube-entrypoint.sh'
+      - '.github/workflows/build-envd-base-image.yml'
+  workflow_dispatch:
+    inputs:
+      envd_ref:
+        description: 'Upstream e2b-dev/infra ref (tag/branch/SHA) to compile envd from'
+        required: false
+        default: '2026.16'
+
+env:
+  ENVD_REF_DEFAULT: '2026.16'
+  IMAGE_NAME: ghcr.io/tencentcloud/cubesandbox-base
+  BASE_OS_TAG_SUFFIX: ubuntu22.04
+
+concurrency:
+  group: build-envd-base-image-${{ github.ref }}-${{ github.event.inputs.envd_ref || 'default' }}
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Resolve envd ref
+        id: meta_ref
+        run: |
+          envd_ref="${{ github.event.inputs.envd_ref || env.ENVD_REF_DEFAULT }}"
+          echo "envd_ref=${envd_ref}" >> "${GITHUB_OUTPUT}"
+          echo "Compiling envd from e2b-dev/infra@${envd_ref}"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        if: github.repository == 'TencentCloud/CubeSandbox' && github.ref == 'refs/heads/master'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract image metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=${{ steps.meta_ref.outputs.envd_ref }},enable=${{ github.repository == 'TencentCloud/CubeSandbox' && github.ref == 'refs/heads/master' }}
+            type=raw,value=${{ steps.meta_ref.outputs.envd_ref }}-${{ env.BASE_OS_TAG_SUFFIX }},enable=${{ github.repository == 'TencentCloud/CubeSandbox' && github.ref == 'refs/heads/master' }}
+            type=raw,value=latest,enable=${{ github.repository == 'TencentCloud/CubeSandbox' && github.ref == 'refs/heads/master' }}
+            type=sha,prefix=sha-,format=short
+          labels: |
+            io.cubesandbox.envd.ref=${{ steps.meta_ref.outputs.envd_ref }}
+
+      - name: Build image (load locally for smoke test)
+        uses: docker/build-push-action@v6
+        with:
+          context: docker
+          file: docker/Dockerfile.cube-base
+          platforms: linux/amd64
+          push: false
+          load: true
+          tags: cubesandbox-base:ci-smoke
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            ENVD_REF=${{ steps.meta_ref.outputs.envd_ref }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Smoke test envd /health
+        run: |
+          set -euo pipefail
+          cid="$(docker run -d --rm cubesandbox-base:ci-smoke)"
+          trap 'docker rm -f "${cid}" >/dev/null 2>&1 || true' EXIT
+
+          ok=""
+          for attempt in 1 2 3 4 5 6 7 8 9 10; do
+            code="$(docker exec "${cid}" curl -s -o /dev/null -w "%{http_code}" \
+                http://127.0.0.1:49983/health || true)"
+            echo "attempt ${attempt}: envd /health => ${code}"
+            if [ "${code}" = "204" ]; then
+              ok="yes"
+              break
+            fi
+            sleep 1
+          done
+
+          if [ -z "${ok}" ]; then
+            echo "envd /health probe never returned 204" >&2
+            docker exec "${cid}" cat /var/log/envd.log >&2 || true
+            exit 1
+          fi
+
+          echo "envd inside container:"
+          docker exec "${cid}" /usr/bin/envd -version
+          docker exec "${cid}" /usr/bin/envd -commit
+
+      - name: Push image
+        if: github.repository == 'TencentCloud/CubeSandbox' && github.ref == 'refs/heads/master'
+        uses: docker/build-push-action@v6
+        with:
+          context: docker
+          file: docker/Dockerfile.cube-base
+          platforms: linux/amd64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            ENVD_REF=${{ steps.meta_ref.outputs.envd_ref }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/docker/Dockerfile.cube-base
+++ b/docker/Dockerfile.cube-base
@@ -1,0 +1,96 @@
+# syntax=docker/dockerfile:1.7
+#
+# CubeSandbox base image: a minimal Ubuntu image with envd preinstalled so
+# that sandboxes built FROM this image expose :49983/health out of the box
+# and can be turned into Cube templates without any extra wiring.
+#
+# envd is compiled from e2b-dev/infra@${ENVD_REF} in a builder stage,
+# producing a static linux/amd64 binary that is copied into the final
+# ubuntu:22.04 runtime stage alongside a generic entrypoint.
+#
+# Build example:
+#   docker build \
+#     -f docker/Dockerfile.cube-base \
+#     -t ghcr.io/tencentcloud/cubesandbox-base:2026.16 \
+#     docker/
+
+ARG ENVD_REF=2026.16
+ARG GO_VERSION=1.25.4
+ARG UBUNTU_VERSION=22.04
+
+# -------- Stage 1: compile envd from e2b-dev/infra --------
+FROM golang:${GO_VERSION}-bookworm AS envd-builder
+
+ARG ENVD_REF
+ARG ENVD_UPSTREAM_REPO=https://github.com/e2b-dev/infra.git
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends git ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /src
+
+# Shallow-clone the upstream tag.
+RUN git clone --depth 1 --branch "${ENVD_REF}" "${ENVD_UPSTREAM_REPO}" infra
+
+WORKDIR /src/infra/packages/envd
+
+RUN --mount=type=cache,target=/root/.cache/go-build \
+    --mount=type=cache,target=/go/pkg/mod \
+    commit_sha="$(git -C /src/infra rev-parse --short HEAD)" \
+    && echo "Building envd from ${ENVD_UPSTREAM_REPO}@${ENVD_REF} (commit=${commit_sha})" \
+    && CGO_ENABLED=0 GOOS=linux GOARCH=amd64 \
+       go build -a \
+           -ldflags "-X=main.commitSHA=${commit_sha} -s -w" \
+           -o /out/envd \
+           . \
+    && chmod +x /out/envd \
+    && /out/envd -version \
+    && /out/envd -commit
+
+# -------- Stage 2: runtime image --------
+FROM ubuntu:${UBUNTU_VERSION}
+
+ARG ENVD_REF
+ARG DEBIAN_FRONTEND=noninteractive
+
+ENV ENVD_REF=${ENVD_REF} \
+    ENVD_PORT=49983 \
+    LANG=C.UTF-8 \
+    LC_ALL=C.UTF-8
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        curl \
+        sudo \
+        tini \
+    && rm -rf /var/lib/apt/lists/*
+
+# envd defaults to running file/command operations as the `user` account
+# (uid=1000) — the same convention used by e2b's official sandbox templates.
+# Provision it here so SDK calls like `sandbox.files.read(path)` work
+# out of the box without needing to pass `user="root"` everywhere.
+RUN useradd --create-home --uid 1000 --shell /bin/bash user \
+    && echo 'user ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/user \
+    && chmod 0440 /etc/sudoers.d/user
+
+COPY --from=envd-builder /out/envd /usr/bin/envd
+COPY cube-entrypoint.sh /usr/local/bin/cube-entrypoint.sh
+
+RUN chmod +x /usr/bin/envd /usr/local/bin/cube-entrypoint.sh \
+    && mkdir -p /var/log \
+    && printf '%s\n' "${ENVD_REF}" > /etc/cubesandbox-envd-ref \
+    && /usr/bin/envd -version \
+    && /usr/bin/envd -commit
+
+LABEL org.opencontainers.image.source="https://github.com/TencentCloud/CubeSandbox" \
+      org.opencontainers.image.title="cubesandbox-base" \
+      org.opencontainers.image.description="CubeSandbox base image with envd compiled from e2b-dev/infra@${ENVD_REF}" \
+      org.opencontainers.image.licenses="Apache-2.0" \
+      io.cubesandbox.envd.ref="${ENVD_REF}"
+
+EXPOSE 49983
+
+ENTRYPOINT ["/usr/bin/tini", "--", "/usr/local/bin/cube-entrypoint.sh"]
+CMD []

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,34 @@
+# docker/
+
+Dockerfiles used by CubeSandbox CI.
+
+## `Dockerfile.builder`
+
+Toolchain image used to compile CubeSandbox components (Go, Rust, kernel
+tooling, etc.). Published as `ghcr.io/tencentcloud/cubesandbox-builder`
+by [`.github/workflows/build-builder-image.yml`](../.github/workflows/build-builder-image.yml).
+
+## `Dockerfile.cube-base` (+ `cube-entrypoint.sh`)
+
+Base image for user-supplied sandbox templates. It is `ubuntu:22.04`
+with `envd` preinstalled on `:49983`, so any image built `FROM` it is
+already ready for Cube's readiness probe. Published as
+`ghcr.io/tencentcloud/cubesandbox-base` by
+[`.github/workflows/build-envd-base-image.yml`](../.github/workflows/build-envd-base-image.yml),
+which compiles `envd` in-place from
+[`e2b-dev/infra`](https://github.com/e2b-dev/infra) at tag `2026.16`
+(override via `workflow_dispatch` input `envd_ref`) before baking the
+image.
+
+Minimal consumer example:
+
+```dockerfile
+FROM ghcr.io/tencentcloud/cubesandbox-base:2026.16
+RUN pip install pandas
+```
+
+Full user-facing tutorial (path A vs path B, entrypoint contract,
+troubleshooting) lives in the Cube docs site:
+
+- English: [Bring Your Own Image (envd)](../docs/guide/tutorials/bring-your-own-image.md)
+- 中文：[自带镜像接入 (envd)](../docs/zh/guide/tutorials/bring-your-own-image.md)

--- a/docker/cube-entrypoint.sh
+++ b/docker/cube-entrypoint.sh
@@ -1,0 +1,77 @@
+#!/bin/sh
+# CubeSandbox base image entrypoint.
+#
+# Contract:
+#   1. Always start envd in the background on ${ENVD_PORT:-49983} so that
+#      CubeMaster's readiness probe (:49983/health) passes within ~1s.
+#   2. If a user CMD is provided (i.e. $# > 0), exec it as the foreground
+#      process; envd stays alive in the background. On SIGTERM/SIGINT we
+#      forward the signal to the user process; envd is reaped by tini.
+#   3. If no CMD is provided, wait on envd as the foreground process so the
+#      container stays up as a pure envd sandbox.
+#
+# Environment variables:
+#   ENVD_PORT       Port envd listens on (default: 49983).
+#   ENVD_EXTRA_ARGS Extra flags appended to the envd invocation (optional).
+#   ENVD_LOG_FILE   Where to redirect envd stdout/stderr (default:
+#                   /var/log/envd.log). Set to "-" to inherit the container
+#                   stdio.
+
+set -eu
+
+ENVD_BIN="${ENVD_BIN:-/usr/bin/envd}"
+ENVD_PORT="${ENVD_PORT:-49983}"
+ENVD_LOG_FILE="${ENVD_LOG_FILE:-/var/log/envd.log}"
+ENVD_EXTRA_ARGS="${ENVD_EXTRA_ARGS:-}"
+
+if [ ! -x "${ENVD_BIN}" ]; then
+    echo "cube-entrypoint: envd binary not found or not executable at ${ENVD_BIN}" >&2
+    exit 127
+fi
+
+start_envd() {
+    # shellcheck disable=SC2086
+    if [ "${ENVD_LOG_FILE}" = "-" ]; then
+        "${ENVD_BIN}" -port "${ENVD_PORT}" ${ENVD_EXTRA_ARGS} &
+    else
+        mkdir -p "$(dirname "${ENVD_LOG_FILE}")"
+        "${ENVD_BIN}" -port "${ENVD_PORT}" ${ENVD_EXTRA_ARGS} \
+            >>"${ENVD_LOG_FILE}" 2>&1 &
+    fi
+    ENVD_PID=$!
+    echo "cube-entrypoint: started envd (pid=${ENVD_PID}) on port ${ENVD_PORT}" >&2
+}
+
+start_envd
+
+if [ "$#" -eq 0 ]; then
+    # No user command: keep envd as the foreground process. tini is PID 1,
+    # so we simply wait for envd to exit (or be signalled).
+    wait "${ENVD_PID}"
+    exit $?
+fi
+
+# User command provided: forward termination signals so the user process can
+# shut down cleanly; envd will be reaped by tini when the container stops.
+USER_PID=""
+forward_signal() {
+    sig="$1"
+    if [ -n "${USER_PID}" ]; then
+        kill -s "${sig}" "${USER_PID}" 2>/dev/null || true
+    fi
+}
+
+trap 'forward_signal TERM' TERM
+trap 'forward_signal INT'  INT
+trap 'forward_signal HUP'  HUP
+
+"$@" &
+USER_PID=$!
+echo "cube-entrypoint: exec user command (pid=${USER_PID}): $*" >&2
+
+# Wait on the user command; propagate its exit status.
+set +e
+wait "${USER_PID}"
+rc=$?
+set -e
+exit "${rc}"

--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -43,7 +43,8 @@ export default withMermaid(defineConfig({
               text: 'Tutorials',
               items: [
                 { text: 'Create Templates from OCI Image', link: '/guide/tutorials/template-from-image' },
-                { text: 'Examples', link: '/guide/tutorials/examples' }
+                { text: 'Examples', link: '/guide/tutorials/examples' },
+                { text: 'Custom Image', link: '/guide/tutorials/bring-your-own-image' }
               ]
             },
             {
@@ -101,7 +102,8 @@ export default withMermaid(defineConfig({
               text: '场景教程',
               items: [
                 { text: '从 OCI 镜像制作模板', link: '/zh/guide/tutorials/template-from-image' },
-                { text: '示例项目', link: '/zh/guide/tutorials/examples' }
+                { text: '示例项目', link: '/zh/guide/tutorials/examples' },
+                { text: '自定义镜像', link: '/zh/guide/tutorials/bring-your-own-image' }
               ]
             },
             {

--- a/docs/guide/tutorials/bring-your-own-image.md
+++ b/docs/guide/tutorials/bring-your-own-image.md
@@ -1,0 +1,237 @@
+# Bring Your Own Image (envd)
+
+This tutorial shows how to take **your own application or container image**
+and turn it into a Cube-Sandbox template with the minimum amount of work.
+
+If you want the whole story about how OCI images become templates, read
+[Create Templates from OCI Image](./template-from-image.md) next. This
+tutorial is the prerequisite that gets your image **ready for the readiness
+probe** that tutorial requires.
+
+---
+
+## 1. Why does my image need `envd`?
+
+Cube-Sandbox talks to every running sandbox through an in-container daemon
+called `envd`. It is the only protocol endpoint that Cube Master, Cube
+SDKs and `cubemastercli` understand:
+
+| Cube capability                     | Endpoint inside the sandbox | If `envd` is missing              |
+| ----------------------------------- | --------------------------- | --------------------------------- |
+| Template readiness probe            | `GET :49983/health` → 204   | Template creation fails the probe |
+| `Sandbox.commands.run()`            | `POST :49983/process`       | Every SDK command returns 404     |
+| `Sandbox.files.read/write()`        | `POST :49983/files`         | File APIs are unusable            |
+| Sandbox init (env vars, time sync)  | `POST :49983/init`          | Sandbox never reaches Ready       |
+
+In other words: **any image you want to use as a Cube template must have
+`envd` listening on `:49983` at startup.** The easiest way to satisfy
+that is to build `FROM` the official `cubesandbox-base` image — the next
+section walks through the full happy path.
+
+---
+
+## 2. Quick start: build on top of `cubesandbox-base`
+
+`cubesandbox-base` is a plain `ubuntu:22.04` with `envd` preinstalled at
+`/usr/bin/envd` and a generic entrypoint that runs `envd` in the
+background while honoring any `CMD` you supply. Three steps get you to a
+working template: **write a Dockerfile → build and push → create the
+template**.
+
+> Prefer to read a runnable end-to-end example? See
+> [`examples/cubesandbox-base-nginx`](https://github.com/TencentCloud/CubeSandbox/tree/master/examples/cubesandbox-base-nginx)
+> in the repo — a minimal demo that stacks nginx on top of
+> `cubesandbox-base`.
+
+### 2.1 Write a Dockerfile
+
+```dockerfile
+FROM ghcr.io/tencentcloud/cubesandbox-base:2026.16
+
+# Install your own tooling
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends python3 python3-pip \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN pip install --no-cache-dir pandas matplotlib numpy
+
+# Optional: if your app needs to be the foreground process, set CMD here.
+# envd stays alive in the background.
+# CMD ["python3", "/srv/app.py"]
+```
+
+### 2.2 Build and push
+
+```bash
+docker build -t my-registry.example.com/my-team/my-sandbox:v1 .
+docker push   my-registry.example.com/my-team/my-sandbox:v1
+```
+
+The registry must be reachable from your Cube cluster.
+
+### 2.3 Create a Cube template
+
+Expose `49983` (envd) plus whatever ports your own application listens on:
+
+```bash
+cubemastercli tpl create-from-image \
+  --image       my-registry.example.com/my-team/my-sandbox:v1 \
+  --writable-layer-size 1G \
+  --expose-port 49983 \
+  --expose-port <your-custom-port> \
+  --probe       49983 \
+  --probe-path  /health
+```
+
+Once you have a `template_id` you can boot sandboxes from it with the
+Cube SDK or `cubemastercli`; the full SDK usage is covered in
+[Create Templates from OCI Image](./template-from-image.md).
+
+### Available base image tags
+
+| Tag                       | Base OS       | envd version |
+| ------------------------- | ------------- | ------------ |
+| `2026.16` / `latest`      | `ubuntu:22.04` | `2026.16`    |
+| `2026.16-ubuntu22.04`     | `ubuntu:22.04` | `2026.16`    |
+
+Pin the exact envd version (`2026.16`) for reproducible builds.
+
+---
+
+## 3. Alternative: inject `envd` into an existing image
+
+When you want to bring your own custom image, copy `envd` and the
+entrypoint **out of** `cubesandbox-base` with a `COPY --from=` stage:
+
+```dockerfile
+FROM e2bdev/code-interpreter:latest
+
+USER root
+
+# Pull envd and the generic entrypoint from cubesandbox-base.
+COPY --from=ghcr.io/tencentcloud/cubesandbox-base:2026.16 \
+     /usr/bin/envd /usr/bin/envd
+COPY --from=ghcr.io/tencentcloud/cubesandbox-base:2026.16 \
+     /usr/local/bin/cube-entrypoint.sh /usr/local/bin/cube-entrypoint.sh
+
+# The upstream image already has its own entrypoint/CMD. Either wrap it
+# with cube-entrypoint.sh (preferred), or start envd manually from your
+# own script — see section 4 for the manual pattern.
+ENTRYPOINT ["/usr/local/bin/cube-entrypoint.sh"]
+CMD ["/bin/sh", "-c", "sudo --preserve-env=E2B_LOCAL /root/.jupyter/start-up.sh"]
+```
+
+A second example, starting from a slim Python image:
+
+```dockerfile
+FROM python:3.11-slim
+
+COPY --from=ghcr.io/tencentcloud/cubesandbox-base:2026.16 \
+     /usr/bin/envd /usr/bin/envd
+COPY --from=ghcr.io/tencentcloud/cubesandbox-base:2026.16 \
+     /usr/local/bin/cube-entrypoint.sh /usr/local/bin/cube-entrypoint.sh
+
+RUN pip install --no-cache-dir fastapi uvicorn
+
+COPY app.py /srv/app.py
+
+EXPOSE 49983 8000
+ENTRYPOINT ["/usr/local/bin/cube-entrypoint.sh"]
+CMD ["uvicorn", "app:app", "--app-dir", "/srv", "--host", "0.0.0.0", "--port", "8000"]
+```
+
+Build, push and template creation are identical to sections 2.2 / 2.3.
+
+---
+
+## 4. The entrypoint contract
+
+`cube-entrypoint.sh` implements a simple "envd-in-the-background, your
+app in the foreground" pattern:
+
+1. It always starts `envd -port "${ENVD_PORT:-49983}"` in the background
+   so that `/health` is reachable within about a second of container
+   startup.
+2. If the container was started **with** a user `CMD`, the script
+   `exec`s that command. `envd` keeps running in the background; the
+   user process owns `stdout`/`stderr` and receives `SIGTERM` on stop.
+3. If the container was started **without** a `CMD`, the script simply
+   waits on `envd`, keeping it as the foreground process.
+
+Environment variables:
+
+| Variable           | Default             | Purpose                                              |
+| ------------------ | ------------------- | ---------------------------------------------------- |
+| `ENVD_PORT`        | `49983`             | Port `envd` listens on.                              |
+| `ENVD_EXTRA_ARGS`  | *(empty)*           | Extra flags passed after `-port`.                    |
+| `ENVD_LOG_FILE`    | `/var/log/envd.log` | File that captures envd stdout/stderr. Use `-` to inherit the container stdio. |
+| `ENVD_BIN`         | `/usr/bin/envd`     | Override if you install envd elsewhere.              |
+
+### Starting envd manually
+
+If you already have a non-trivial entrypoint of your own and don't want
+to delegate to `cube-entrypoint.sh`, just add one line before handing
+control to your main process:
+
+```bash
+#!/bin/bash
+# your-entrypoint.sh
+
+# Start envd in the background.
+/usr/bin/envd -port 49983 >/var/log/envd.log 2>&1 &
+
+# ... your usual startup sequence ...
+exec "$@"
+```
+
+---
+
+## 5. Verifying the image locally (optional)
+
+Before creating a template you can run the same smoke test that CI runs
+on the base image:
+
+```bash
+IMG=my-registry.example.com/my-team/my-sandbox:v1
+cid=$(docker run -d --rm "$IMG")
+
+docker exec "$cid" curl -s -o /dev/null -w "envd /health => %{http_code}\n" \
+    http://127.0.0.1:49983/health
+# => envd /health => 204
+
+docker exec "$cid" /usr/bin/envd -version
+# => 2026.16
+
+docker rm -f "$cid"
+```
+
+If `/health` does not reach `204` within a few seconds, inspect
+`/var/log/envd.log` inside the container:
+
+```bash
+docker exec "$cid" cat /var/log/envd.log
+```
+
+---
+
+## 6. Troubleshooting
+
+| Symptom                                       | Likely cause                                                          | Fix                                                                                 |
+| --------------------------------------------- | --------------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
+| Template creation fails the readiness probe   | envd did not start / started on the wrong port                        | Ensure `ENTRYPOINT` invokes `cube-entrypoint.sh` **or** your own script runs `envd -port 49983 &` before `exec`. |
+| `curl :49983/health` returns `000`            | Nothing is listening; entrypoint replaced                             | Check <code v-pre>docker inspect --format '{{json .Config.Entrypoint}}'</code>; keep `cube-entrypoint.sh` as the wrapper. |
+| envd exits immediately                        | Version mismatch between binary and kernel/init expectations          | Verify with `docker exec ... /usr/bin/envd -version`; re-copy from the pinned base tag. |
+| Port 49983 conflicts with your own service    | Your app also listens on 49983                                        | Move your app to a different port and expose both with `--expose-port`.             |
+| `sudo: command not found` in your CMD         | You started `FROM` a `-slim` / `-alpine` image without sudo           | Either `apt-get install -y sudo`, or drop `sudo` from your entrypoint — `cube-entrypoint.sh` doesn't require it. |
+| Template creation times out in `PULLING`      | Registry unreachable from Cube nodes                                  | Push to a registry the cluster can reach, or supply `--registry-username` / `--registry-password`. |
+
+---
+
+## 7. Advanced — rebuild the base image yourself
+
+The base image is produced by a single GitHub Actions workflow in this
+repository: [`.github/workflows/build-envd-base-image.yml`](https://github.com/TencentCloud/CubeSandbox/blob/master/.github/workflows/build-envd-base-image.yml).
+It checks out `e2b-dev/infra` at the chosen tag (default `2026.16`),
+compiles `envd` with Go 1.25.4 in-place, builds
+`docker/Dockerfile.cube-base`, runs a `:49983/health` smoke test, then
+pushes to `ghcr.io/tencentcloud/cubesandbox-base`.

--- a/docs/zh/guide/tutorials/bring-your-own-image.md
+++ b/docs/zh/guide/tutorials/bring-your-own-image.md
@@ -1,0 +1,225 @@
+# 自带镜像接入 (envd)
+
+本教程介绍如何用**最少的改动**把你自己的应用或容器镜像接入 Cube-Sandbox
+模板体系。
+
+想全面了解 OCI 镜像如何变成模板，请继续阅读
+[从 OCI 镜像制作模板](./template-from-image.md)。本教程是那篇文档的
+**前置步骤**：保证你的镜像满足它所要求的探活 (readiness probe) 条件。
+
+---
+
+## 1. 为什么我的镜像需要 `envd`？
+
+Cube-Sandbox 与沙箱容器之间的所有通信都是通过容器内的 `envd` 守护进程
+完成的。它是 Cube Master、Cube SDK 以及 `cubemastercli` 唯一识别的协议
+端点：
+
+| Cube 能力                         | 沙箱内端点                    | 没有 `envd` 会怎样             |
+| --------------------------------- | ----------------------------- | ------------------------------ |
+| 模板探活                          | `GET :49983/health` → 204     | 模板创建因探活失败而 FAILED    |
+| `Sandbox.commands.run()`          | `POST :49983/process`         | SDK 命令调用全部 404           |
+| `Sandbox.files.read/write()`      | `POST :49983/files`           | 文件操作不可用                 |
+| Sandbox 初始化（env、时间同步等） | `POST :49983/init`            | Sandbox 永远无法 Ready         |
+
+换句话说：**任何要用作 Cube 模板的镜像，启动时都必须有 `envd` 在
+`:49983` 上监听**。最简单的方式就是直接基于官方 `cubesandbox-base`
+构建——下一节就是完整流程。
+
+---
+
+## 2. 快速开始：基于 `cubesandbox-base`
+
+`cubesandbox-base` 是一个普通的 `ubuntu:22.04`，在 `/usr/bin/envd` 预装
+了 `envd`，并附带一个通用入口脚本——后台拉起 `envd`、前台 `exec` 你
+提供的 `CMD`。你只需要三步：**写 Dockerfile → 构建推送 → 创建模板**。
+
+> 想看一个能直接跑通的完整示例？可以参考仓库里的
+> [`examples/cubesandbox-base-nginx`](https://github.com/TencentCloud/CubeSandbox/tree/master/examples/cubesandbox-base-nginx)，
+> 里面是把 nginx 叠在 `cubesandbox-base` 上的最小 demo。
+
+### 2.1 写 Dockerfile
+
+```dockerfile
+FROM ghcr.io/tencentcloud/cubesandbox-base:2026.16
+
+# 安装你自己需要的工具链
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends python3 python3-pip \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN pip install --no-cache-dir pandas matplotlib numpy
+
+# 如果你的应用需要作为前台进程运行，在这里设置 CMD 即可。
+# envd 仍会作为后台进程持续运行。
+# CMD ["python3", "/srv/app.py"]
+```
+
+### 2.2 构建并推送
+
+```bash
+docker build -t my-registry.example.com/my-team/my-sandbox:v1 .
+docker push   my-registry.example.com/my-team/my-sandbox:v1
+```
+
+镜像仓库需要能被 Cube 集群拉到。
+
+### 2.3 创建 Cube 模板
+
+暴露 `49983`（envd），外加你自己应用监听的端口：
+
+```bash
+cubemastercli tpl create-from-image \
+  --image       my-registry.example.com/my-team/my-sandbox:v1 \
+  --writable-layer-size 1G \
+  --expose-port 49983 \
+  --expose-port <your-custom-port> \
+  --probe       49983 \
+  --probe-path  /health
+```
+
+拿到 `template_id` 就可以用 Cube SDK / `cubemastercli` 去创建沙箱了，
+完整 SDK 用法见
+[从 OCI 镜像制作模板](./template-from-image.md)。
+
+### 可用的基础镜像 tag
+
+| Tag                       | 基础系统       | envd 版本    |
+| ------------------------- | ------------- | ------------ |
+| `2026.16` / `latest`      | `ubuntu:22.04` | `2026.16`    |
+| `2026.16-ubuntu22.04`     | `ubuntu:22.04` | `2026.16`    |
+
+为了保证可复现构建，**推荐 pin 到精确的 envd 版本 (`2026.16`)**。
+
+---
+
+## 3. 备选：往现有镜像里注入 `envd`
+
+如果你想使用你自定义的镜像，可以用 `COPY --from=` 从 `cubesandbox-base`
+镜像中**拷贝** `envd` 和入口脚本：
+
+```dockerfile
+FROM e2bdev/code-interpreter:latest
+
+USER root
+
+# 从 cubesandbox-base 拉取 envd 与通用入口脚本
+COPY --from=ghcr.io/tencentcloud/cubesandbox-base:2026.16 \
+     /usr/bin/envd /usr/bin/envd
+COPY --from=ghcr.io/tencentcloud/cubesandbox-base:2026.16 \
+     /usr/local/bin/cube-entrypoint.sh /usr/local/bin/cube-entrypoint.sh
+
+# 上游镜像通常已有自己的 entrypoint/CMD。推荐用 cube-entrypoint.sh 包裹它；
+# 或者自己写 entrypoint 并手动拉起 envd —— 见第 4 节。
+ENTRYPOINT ["/usr/local/bin/cube-entrypoint.sh"]
+CMD ["/bin/sh", "-c", "sudo --preserve-env=E2B_LOCAL /root/.jupyter/start-up.sh"]
+```
+
+另一个例子，从轻量的 Python 镜像出发：
+
+```dockerfile
+FROM python:3.11-slim
+
+COPY --from=ghcr.io/tencentcloud/cubesandbox-base:2026.16 \
+     /usr/bin/envd /usr/bin/envd
+COPY --from=ghcr.io/tencentcloud/cubesandbox-base:2026.16 \
+     /usr/local/bin/cube-entrypoint.sh /usr/local/bin/cube-entrypoint.sh
+
+RUN pip install --no-cache-dir fastapi uvicorn
+
+COPY app.py /srv/app.py
+
+EXPOSE 49983 8000
+ENTRYPOINT ["/usr/local/bin/cube-entrypoint.sh"]
+CMD ["uvicorn", "app:app", "--app-dir", "/srv", "--host", "0.0.0.0", "--port", "8000"]
+```
+
+构建、推送、创建模板的流程和第 2.2 / 2.3 节一致。
+
+---
+
+## 4. 入口脚本契约
+
+`cube-entrypoint.sh` 实现了一个非常简单的 "envd 后台 + 用户应用前台" 的
+组合模式：
+
+1. 启动时一律后台拉起 `envd -port "${ENVD_PORT:-49983}"`，使 `/health`
+   在容器启动约 1 秒内就能响应。
+2. 如果启动时**带了** `CMD`，脚本会 `exec` 执行它：`envd` 在后台伴跑，
+   用户进程占用 `stdout`/`stderr`，并接收 `SIGTERM`。
+3. 如果**没有** `CMD`，脚本会 `wait` 住 `envd`，让它成为前台主进程。
+
+可用的环境变量：
+
+| 变量               | 默认值              | 说明                                                   |
+| ------------------ | ------------------- | ------------------------------------------------------ |
+| `ENVD_PORT`        | `49983`             | envd 监听的端口                                        |
+| `ENVD_EXTRA_ARGS`  | *(空)*              | 追加到 `-port` 之后的额外参数                          |
+| `ENVD_LOG_FILE`    | `/var/log/envd.log` | envd stdout/stderr 落盘位置；设为 `-` 则继承容器 stdio |
+| `ENVD_BIN`         | `/usr/bin/envd`     | 当 envd 安装在别处时覆盖                               |
+
+### 自己手动拉起 envd
+
+如果你已经有一个复杂的 entrypoint 不方便交给 `cube-entrypoint.sh`，
+只需要在交出控制权前加一行：
+
+```bash
+#!/bin/bash
+# your-entrypoint.sh
+
+# 后台启动 envd
+/usr/bin/envd -port 49983 >/var/log/envd.log 2>&1 &
+
+# ... 你原本的启动流程 ...
+exec "$@"
+```
+
+---
+
+## 5. 本地验证镜像（可选）
+
+创建模板前，可以跑一遍 CI 用于验证 base 镜像的同款 smoke test：
+
+```bash
+IMG=my-registry.example.com/my-team/my-sandbox:v1
+cid=$(docker run -d --rm "$IMG")
+
+docker exec "$cid" curl -s -o /dev/null -w "envd /health => %{http_code}\n" \
+    http://127.0.0.1:49983/health
+# => envd /health => 204
+
+docker exec "$cid" /usr/bin/envd -version
+# => 2026.16
+
+docker rm -f "$cid"
+```
+
+如果几秒之内 `/health` 没有返回 `204`，检查容器里 envd 的日志：
+
+```bash
+docker exec "$cid" cat /var/log/envd.log
+```
+
+---
+
+## 6. 排错速查
+
+| 现象                                   | 可能原因                                                   | 解决                                                                                    |
+| -------------------------------------- | ---------------------------------------------------------- | --------------------------------------------------------------------------------------- |
+| 模板创建探活失败                       | envd 未启动 / 起在错误端口                                  | 确认 `ENTRYPOINT` 为 `cube-entrypoint.sh`，或你自己的脚本里有 `envd -port 49983 &`      |
+| `curl :49983/health` 返回 `000`        | 端口无人监听；入口被用户 CMD 整个替换                      | 检查 <code v-pre>docker inspect --format '{{json .Config.Entrypoint}}'</code>，保留 `cube-entrypoint.sh` |
+| envd 立刻退出                          | 二进制版本与容器预期不匹配                                 | `docker exec ... /usr/bin/envd -version` 确认版本；从 pin 的 base tag 重新拷贝          |
+| 49983 端口冲突                         | 你自己的应用也在监听 49983                                 | 把自家应用迁到别的端口，并一起 `--expose-port` 暴露                                     |
+| `sudo: command not found`              | 基于 `-slim` / `-alpine` 这种无 sudo 的镜像构建            | `apt-get install -y sudo`，或直接把 `sudo` 从 CMD 里去掉——`cube-entrypoint.sh` 不依赖它 |
+| 模板创建长时间卡在 `PULLING`           | registry 从 Cube 节点不可达                                | 推送到集群可访问的 registry，或用 `--registry-username` / `--registry-password`         |
+
+---
+
+## 7. 进阶 —— 自己重建基础镜像
+
+基础镜像由仓库内单个 GitHub Actions workflow 自动构建：
+[`.github/workflows/build-envd-base-image.yml`](https://github.com/TencentCloud/CubeSandbox/blob/master/.github/workflows/build-envd-base-image.yml)。
+它会 checkout `e2b-dev/infra` 的指定 tag（默认 `2026.16`），用 Go 1.25.4
+在同一个 job 里直接把 envd 编译进来，构建 `docker/Dockerfile.cube-base`，
+对 `:49983/health` 做 smoke test，然后推送到
+`ghcr.io/tencentcloud/cubesandbox-base`。

--- a/examples/cubesandbox-base-nginx/Dockerfile
+++ b/examples/cubesandbox-base-nginx/Dockerfile
@@ -1,0 +1,39 @@
+# syntax=docker/dockerfile:1.7
+#
+# Demo: a Cube-ready sandbox image that runs nginx on :80 while the
+# cubesandbox-base entrypoint keeps envd running on :49983 in the
+# background. Good for smoke-testing `cubemastercli tpl create-from-image`.
+#
+# Build:
+#   docker build -t cubesandbox-demo-nginx:latest examples/cubesandbox-base-nginx
+#
+# Run locally:
+#   docker run --rm -d -p 8080:80 -p 49983:49983 \
+#     --name cube-demo-nginx cubesandbox-demo-nginx:latest
+#   curl http://127.0.0.1:8080/
+#   curl -o /dev/null -w "%{http_code}\n" http://127.0.0.1:49983/health  # => 204
+
+ARG CUBE_BASE_IMAGE=ghcr.io/tencentcloud/cubesandbox-base:2026.16
+FROM ${CUBE_BASE_IMAGE}
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends nginx \
+    && rm -rf /var/lib/apt/lists/*
+
+# Tiny landing page so you can eyeball that nginx really served the request.
+RUN printf '%s\n' \
+        '<!doctype html>' \
+        '<title>cubesandbox-demo-nginx</title>' \
+        '<h1>Hello from nginx inside a CubeSandbox base image</h1>' \
+        '<p>envd is running on :49983, nginx on :80.</p>' \
+    > /var/www/html/index.html
+
+EXPOSE 80 49983
+
+# cube-entrypoint.sh (inherited from the base image) will:
+#   1. Launch envd on ${ENVD_PORT:-49983} in the background.
+#   2. exec the CMD below as the foreground process, so nginx owns PID 1
+#      logs and receives SIGTERM on `docker stop`.
+CMD ["nginx", "-g", "daemon off;"]

--- a/examples/cubesandbox-base-nginx/README.md
+++ b/examples/cubesandbox-base-nginx/README.md
@@ -1,0 +1,70 @@
+# cubesandbox-base-nginx demo
+
+A minimal image that stacks nginx on top of [`cubesandbox-base`](../../docker/Dockerfile.cube-base),
+so you can test the "Bring Your Own Image" flow end-to-end without any
+real application.
+
+- envd listens on `:49983` (Cube readiness probe) — inherited from the base image.
+- nginx listens on `:80` and serves a tiny static page.
+
+See [Bring Your Own Image (envd)](../../docs/guide/tutorials/bring-your-own-image.md)
+for the full tutorial.
+
+## Build
+
+```bash
+docker build -t cubesandbox-demo-nginx:latest .
+```
+
+## Run & verify locally
+
+```bash
+docker run --rm -d \
+    -p 8080:80 \
+    -p 49983:49983 \
+    --name cube-demo-nginx \
+    cubesandbox-demo-nginx:latest
+
+# nginx: should print the demo landing page HTML
+curl -s http://127.0.0.1:8080/
+
+# envd readiness probe: should return 204
+curl -s -o /dev/null -w "envd /health => %{http_code}\n" \
+    http://127.0.0.1:49983/health
+
+docker rm -f cube-demo-nginx
+```
+
+## Register as a Cube template
+
+```bash
+cubemastercli tpl create-from-image \
+    --image       <your-registry>/cubesandbox-demo-nginx:latest \
+    --writable-layer-size 1G \
+    --expose-port 49983 \
+    --expose-port 80 \
+    --probe       49983 \
+    --probe-path  /health
+```
+
+`--probe 49983 --probe-path /health` points Cube at envd (guaranteed to
+return `204` within ~1s); nginx's `:80` stays exposed for your actual
+traffic.
+
+## Try it with the E2B SDK
+
+After registering the template, [`test_files.py`](./test_files.py)
+boots a sandbox from it and does two things:
+
+1. reads `/etc/nginx/nginx.conf` via `sandbox.files.read(...)`
+2. sends an HTTPS request to the sandbox's port `80` and prints the
+   nginx response
+
+```bash
+pip install -r requirements.txt
+
+cp env.example .env
+# fill in E2B_API_URL and CUBE_TEMPLATE_ID
+
+python3 test_files.py
+```

--- a/examples/cubesandbox-base-nginx/env.example
+++ b/examples/cubesandbox-base-nginx/env.example
@@ -1,0 +1,11 @@
+# Required: Cube API server address
+export E2B_API_URL="http://<your-node-ip>:3000"
+
+# Required: any non-empty value satisfies the SDK check
+export E2B_API_KEY="dummy"
+
+# Required: template ID from `cubemastercli tpl create-from-image ...`
+export CUBE_TEMPLATE_ID="<your-template-id>"
+
+
+export SSL_CERT_FILE="$(mkcert -CAROOT)/rootCA.pem"

--- a/examples/cubesandbox-base-nginx/requirements.txt
+++ b/examples/cubesandbox-base-nginx/requirements.txt
@@ -1,0 +1,2 @@
+e2b>=2.4.1
+python-dotenv

--- a/examples/cubesandbox-base-nginx/test_files.py
+++ b/examples/cubesandbox-base-nginx/test_files.py
@@ -1,0 +1,27 @@
+# Copyright (c) 2024 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+import urllib.request
+from pathlib import Path
+
+from dotenv import load_dotenv
+from e2b import Sandbox
+
+for candidate in (Path(__file__).with_name(".env"), Path.cwd() / ".env"):
+    if candidate.is_file():
+        load_dotenv(dotenv_path=candidate, override=False)
+        break
+
+template_id = os.environ["CUBE_TEMPLATE_ID"]
+
+with Sandbox.create(template=template_id) as sandbox:
+    print("=== read /etc/nginx/nginx.conf ===")
+    print(sandbox.files.read("/etc/nginx/nginx.conf", user="root"))
+
+    print("=== GET http://<sandbox>:80/ ===")
+    url = f"https://{sandbox.get_host(80)}/"
+    print(f"url: {url}")
+    with urllib.request.urlopen(url, timeout=10) as resp:
+        print(f"status: {resp.status}")
+        print(resp.read().decode())


### PR DESCRIPTION
- Introduced `Dockerfile.cube-base` for building a minimal Ubuntu image with `envd` preinstalled, facilitating CubeSandbox template creation.
- Added `cube-entrypoint.sh` to manage `envd` as a background process, ensuring readiness for Cube's health checks.
- Created GitHub Actions workflow `build-envd-base-image.yml` to automate the image build and push process.
- Updated documentation to include usage instructions for the new base image and entrypoint script, along with a tutorial for creating custom templates.
- Added example for a demo image using `nginx` on top of the base image.