### PR TITLE
fix: map missing template cleanup locator to not found

### DIFF
--- a/CubeMaster/pkg/service/httpservice/cube/template.go
+++ b/CubeMaster/pkg/service/httpservice/cube/template.go
@@ -107,7 +107,7 @@ func deleteTemplate(w http.ResponseWriter, r *http.Request, rt *CubeLog.RequestT
 		case errors.Is(err, templatecenter.ErrTemplateAttemptInProgress):
 			code = int(errorcode.ErrorCode_MasterParamsError)
 		case errors.Is(err, templatecenter.ErrTemplateCleanupLocatorMissing):
-			code = int(errorcode.ErrorCode_MasterParamsError)
+			code = int(errorcode.ErrorCode_NotFound)
 		case errors.Is(err, templatecenter.ErrTemplateStoreNotInitialized):
 			code = int(errorcode.ErrorCode_DBError)
 		}

--- a/CubeMaster/pkg/service/httpservice/cube/template_test.go
+++ b/CubeMaster/pkg/service/httpservice/cube/template_test.go
@@ -75,7 +75,7 @@ func TestDeleteTemplateMapsAttemptInProgressToParamsError(t *testing.T) {
 	assert.Equal(t, int64(errorcode.ErrorCode_MasterParamsError), rt.RetCode)
 }
 
-func TestDeleteTemplateMapsCleanupLocatorMissingToParamsError(t *testing.T) {
+func TestDeleteTemplateMapsCleanupLocatorMissingToNotFound(t *testing.T) {
 	origDeleteTemplateFn := deleteTemplateFn
 	t.Cleanup(func() {
 		deleteTemplateFn = origDeleteTemplateFn
@@ -92,9 +92,9 @@ func TestDeleteTemplateMapsCleanupLocatorMissingToParamsError(t *testing.T) {
 	if !ok {
 		t.Fatalf("unexpected response type %T", resp)
 	}
-	assert.Equal(t, int(errorcode.ErrorCode_MasterParamsError), got.Ret.RetCode)
+	assert.Equal(t, int(errorcode.ErrorCode_NotFound), got.Ret.RetCode)
 	assert.Contains(t, got.Ret.RetMsg, "historical locator missing")
-	assert.Equal(t, int64(errorcode.ErrorCode_MasterParamsError), rt.RetCode)
+	assert.Equal(t, int64(errorcode.ErrorCode_NotFound), rt.RetCode)
 }
 
 func TestDeleteTemplateSuccessResponse(t *testing.T) {


### PR DESCRIPTION
## Summary
- map ErrTemplateCleanupLocatorMissing to ErrorCode_NotFound in deleteTemplate
- update delete template HTTP handler test expectation accordingly

## Why
A missing historical cleanup locator indicates stale or missing template cleanup state rather than an invalid client parameter, so returning NotFound better matches the actual condition and expected API behavior.