### PR TITLE
docs: fix probe port in quickstart examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ cubemastercli tpl create-from-image \
   --writable-layer-size 1G \
   --expose-port 49999 \
   --expose-port 49983 \
-  --probe 49999
+  --probe 49983
 ```
 
 3. **Run Your First Agent Code**

--- a/README_zh.md
+++ b/README_zh.md
@@ -157,7 +157,7 @@ cubemastercli tpl create-from-image \
   --writable-layer-size 1G \
   --expose-port 49999 \
   --expose-port 49983 \
-  --probe 49999
+  --probe 49983
 ```
 
 3. **运行你的第一段 Agent 代码**

--- a/docs/guide/quickstart.md
+++ b/docs/guide/quickstart.md
@@ -59,7 +59,7 @@ cubemastercli tpl create-from-image \
   --writable-layer-size 1G \
   --expose-port 49999 \
   --expose-port 49983 \
-  --probe 49999
+  --probe 49983
 ```
 
 Monitor the build until the status reaches `READY`:

--- a/docs/zh/guide/quickstart.md
+++ b/docs/zh/guide/quickstart.md
@@ -57,7 +57,7 @@ cubemastercli tpl create-from-image \
   --writable-layer-size 1G \
   --expose-port 49999 \
   --expose-port 49983 \
-  --probe 49999
+  --probe 49983
 ```
 
 监控构建进度，等待状态变为 `READY`：

--- a/examples/code-sandbox-quickstart/README.md
+++ b/examples/code-sandbox-quickstart/README.md
@@ -50,7 +50,7 @@ cubemastercli tpl create-from-image \
   --writable-layer-size 1G \
   --expose-port 49999 \
   --expose-port 49983 \
-  --probe 49999
+  --probe 49983
 ```
 
 Note the `template_id` printed on success.

--- a/examples/code-sandbox-quickstart/README_zh.md
+++ b/examples/code-sandbox-quickstart/README_zh.md
@@ -44,7 +44,7 @@ cubemastercli tpl create-from-image \
   --writable-layer-size 1G \
   --expose-port 49999 \
   --expose-port 49983 \
-  --probe 49999
+  --probe 49983
 ```
 
 记录输出的 `template_id`。

--- a/examples/openclaw-integration/README.md
+++ b/examples/openclaw-integration/README.md
@@ -82,7 +82,7 @@ cubemastercli tpl create-from-image \
   --writable-layer-size 1G \
   --expose-port 49999 \
   --expose-port 49983 \
-  --probe 49999
+  --probe 49983
 ```
 
 Note the `template_id` printed on success.

--- a/examples/openclaw-integration/README_zh.md
+++ b/examples/openclaw-integration/README_zh.md
@@ -74,7 +74,7 @@ cubemastercli tpl create-from-image \
   --writable-layer-size 1G \
   --expose-port 49999 \
   --expose-port 49983 \
-  --probe 49999
+  --probe 49983
 ```
 
 记录输出的 `template_id`。


### PR DESCRIPTION
- Update --probe argument from 49999 to 49983 in README.md files
- Update --probe argument from 49999 to 49983 in quickstart.md guides
- Correct port matches the exposed port in example commands