### PR TITLE
docs(examples): add OpenAI Agents SDK + CubeSandbox examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,11 @@ runtime/agent/src/version.rs
 # Python cache and compiled binaries in examples
 API/examples/__pycache__/
 API/examples/go/go
+
+# OpenAI Agents SDK examples (runtime artifacts)
+examples/openai-agents-example/__pycache__/
+examples/openai-agents-example/output/
+examples/openai-agents-example/.scratch/
+examples/openai-agents-code-interpreter/__pycache__/
+examples/openai-agents-code-interpreter/output/
+examples/openai-agents-code-interpreter/.scratch/

--- a/docs/guide/tutorials/examples.md
+++ b/docs/guide/tutorials/examples.md
@@ -8,6 +8,8 @@ Hands-on examples demonstrating various Cube Sandbox use cases. Each example is 
 | [Browser Sandbox (Playwright)](https://github.com/tencentcloud/CubeSandbox/tree/master/examples/browser-sandbox) | Run a headless Chromium inside a MicroVM and control it remotely with Playwright via CDP. |
 | [OpenClaw Integration](https://github.com/tencentcloud/CubeSandbox/tree/master/examples/openclaw-integration) | Deploy Cube Sandbox and configure the OpenClaw skill so AI agents can execute code in isolated VM environments. |
 | [SWE-bench with mini-swe-agent](https://github.com/tencentcloud/CubeSandbox/tree/master/examples/mini-rl-training) | Automate SWE-bench coding tasks in isolated sandboxes using cube-sandbox + mini-swe-agent, with multi-model support and RL training vision. |
+| [OpenAI Agents SDK Integration](https://github.com/tencentcloud/CubeSandbox/tree/master/examples/openai-agents-example) | Wire OpenAI Agents SDK's `E2BSandboxClient` to Cube Sandbox. Ships a minimal Shell Agent with Pause/Resume and a full SWE-bench Django debugging agent with streaming + tracing. |
+| [OpenAI Agents + Code Interpreter](https://github.com/tencentcloud/CubeSandbox/tree/master/examples/openai-agents-code-interpreter) | Data-analysis Agent running pandas / matplotlib inside a Cube Sandbox. Provides two variants: generic E2B write+exec and Jupyter-kernel Code Interpreter with cross-turn state and auto image capture. |
 
 ::: tip
 All examples share the same environment variable conventions (`E2B_API_URL`, `E2B_API_KEY`, `CUBE_TEMPLATE_ID`). See the [Quick Start](../quickstart) guide to set up your Cube Sandbox deployment first.

--- a/docs/zh/guide/tutorials/examples.md
+++ b/docs/zh/guide/tutorials/examples.md
@@ -8,6 +8,8 @@
 | [浏览器沙箱（Playwright）](https://github.com/tencentcloud/CubeSandbox/tree/master/examples/browser-sandbox) | 在 MicroVM 中运行无头 Chromium，通过 CDP 协议使用 Playwright 远程控制浏览器。 |
 | [OpenClaw 集成](https://github.com/tencentcloud/CubeSandbox/tree/master/examples/openclaw-integration) | 部署 Cube Sandbox 并配置 OpenClaw Skill，让 AI Agent 能够在隔离的虚拟机环境中执行代码。 |
 | [SWE-bench + mini-swe-agent](https://github.com/tencentcloud/CubeSandbox/tree/master/examples/mini-rl-training) | 使用 cube-sandbox + mini-swe-agent 在隔离沙箱中自动化 SWE-bench 编码任务，支持多模型切换和 RL 训练愿景。 |
+| [OpenAI Agents SDK 集成](https://github.com/tencentcloud/CubeSandbox/tree/master/examples/openai-agents-example) | 将 OpenAI Agents SDK 的 `E2BSandboxClient` 对接 Cube Sandbox。包含最小 Shell Agent（含 Pause/Resume 演示）以及完整的 SWE-bench Django 调试 Agent（流式输出 + 全链路追踪）。 |
+| [OpenAI Agents + Code Interpreter](https://github.com/tencentcloud/CubeSandbox/tree/master/examples/openai-agents-code-interpreter) | 在 Cube Sandbox 中运行使用 pandas / matplotlib 的数据分析 Agent，提供通用 E2B（write+exec）与 Jupyter kernel（状态跨轮保留、图像自动捕获）两种执行形态。 |
 
 ::: tip
 所有示例共享相同的环境变量约定（`E2B_API_URL`、`E2B_API_KEY`、`CUBE_TEMPLATE_ID`）。请先参考[快速开始](../quickstart)指南搭建 Cube Sandbox 环境。

--- a/examples/openai-agents-code-interpreter/.env.example
+++ b/examples/openai-agents-code-interpreter/.env.example
@@ -1,0 +1,16 @@
+# TokenHub API (OpenAI-compatible, used as LLM backend)
+TOKENHUB_API_KEY="<your-tokenhub-api-key>"
+# Or set OPENAI_API_KEY + OPENAI_BASE_URL directly:
+# OPENAI_API_KEY="<your-api-key>"
+# OPENAI_BASE_URL="https://tokenhub.tencentmaas.com/v1"
+
+# cube-sandbox (E2B compatible) connection
+E2B_API_URL="http://<your-cube-sandbox-ip>:3000"
+E2B_API_KEY="<your-e2b-api-key>"
+
+# Cube template ID — must have Python + pandas/numpy/matplotlib/scikit-learn preinstalled
+# (typical data-science image, e.g. built from jupyter/scipy-notebook or similar)
+CUBE_TEMPLATE_ID="<your-code-interpreter-template-id>"
+
+# SSL cert for self-hosted cube-sandbox (optional)
+# CUBE_SSL_CERT_FILE="/etc/pki/tls/cert.pem"

--- a/examples/openai-agents-code-interpreter/README.md
+++ b/examples/openai-agents-code-interpreter/README.md
@@ -1,0 +1,212 @@
+# OpenAI Agents SDK + CubeSandbox: Code Interpreter Example
+
+[中文文档](README_zh.md)
+
+Run a data-analysis Agent inside [CubeSandbox](https://github.com/TencentCloud/CubeSandbox) (which exposes an E2B-compatible API), letting the LLM perform real computation and plotting with pandas / matplotlib inside a cloud Python sandbox.
+
+## The Two Demos
+
+This directory ships two runnable implementations. They are functionally equivalent; the only difference is the **Python execution backend**:
+
+| | [`code_interpreter_demo.py`](code_interpreter_demo.py) | [`code_interpreter_demo_ci.py`](code_interpreter_demo_ci.py) |
+|---|---|---|
+| Sandbox type | `E2BSandboxType.E2B` | `E2BSandboxType.CODE_INTERPRETER` |
+| Underlying SDK | `e2b.AsyncSandbox` | `e2b_code_interpreter.AsyncSandbox` |
+| Execution model | `session.write(script.py)` → `session.exec("python script.py")` | `sandbox.run_code(code)` (Jupyter kernel) |
+| Session state | Each exec is a fresh process | **Variables / imports / DataFrames persist across cells** |
+| Image capture | Agent calls `plt.savefig(...)` manually | Automatically decoded from `Execution.results` (base64) |
+| Error reporting | Full stderr stream | Structured `Execution.error` (name / value / traceback) |
+| Template ports | envd (49983) | envd (49983) + code-interpreter gateway (49999) |
+
+**Which one to pick?**
+- Template with plain Python only → use `code_interpreter_demo.py`
+- Template with the e2b code-interpreter service → use `code_interpreter_demo_ci.py` (Jupyter kernel experience, state preserved across turns)
+
+## Prerequisites
+
+- Python 3.10+
+- CubeSandbox platform deployed and CubeAPI reachable
+- A sandbox template with the data-science stack (python3 + pandas + numpy + matplotlib)
+- An API key for TokenHub or any OpenAI-compatible LLM
+
+## Quick Start
+
+### 1. Install dependencies
+
+```bash
+pip install -r requirements.txt
+```
+
+### 2. Configure environment variables
+
+```bash
+cp .env.example .env
+```
+
+| Variable | Description |
+|----------|-------------|
+| `TOKENHUB_API_KEY` | TokenHub API key (automatically mapped to `OPENAI_API_KEY`) |
+| `OPENAI_BASE_URL` | LLM endpoint (defaults to `https://tokenhub.tencentmaas.com/v1`) |
+| `E2B_API_URL` | CubeAPI URL, e.g. `http://<cube-host>:3000` |
+| `E2B_API_KEY` | CubeAPI auth key |
+| `CUBE_TEMPLATE_ID` | Sandbox template ID |
+| `CUBE_SSL_CERT_FILE` | (Optional) path to the CubeSandbox CA bundle |
+
+### 3. Create a sandbox template
+
+```bash
+cubemastercli template create-from-image \
+  --image cube-sandbox-image.tencentcloudcr.com/demo/e2b-code-interpreter:v1.1-data \
+  --writable-layer-size 1Gi \
+  --template-id e2b-code-interpreter \
+  --expose-port 49983 \
+  --expose-port 49999 \
+  --probe 49983
+```
+
+Copy the resulting template ID into `CUBE_TEMPLATE_ID` in your `.env`.
+
+> Note: `code_interpreter_demo.py` only requires port 49983; `code_interpreter_demo_ci.py` additionally needs 49999 (the Jupyter kernel gateway).
+
+### 4. Run
+
+```bash
+# Generic E2B variant (write + exec)
+python code_interpreter_demo.py
+
+# Jupyter kernel variant (run_code, state persists across turns)
+python code_interpreter_demo_ci.py
+
+# Custom prompt
+python code_interpreter_demo.py --question "Plot units sold per product as a bar chart."
+
+# Swap model
+python code_interpreter_demo_ci.py --model openai/deepseek-v3.2
+
+# Pause instead of destroy on exit (supports later resume)
+python code_interpreter_demo.py --pause-on-exit
+```
+
+### Command-line arguments
+
+| Argument | Default | Description |
+|----------|---------|-------------|
+| `--model` | `openai/glm-5.1` | LLM model name (TokenHub uses the `openai/` prefix) |
+| `--question` | Sales-data analysis (see below) | Prompt sent to the Agent |
+| `--template` | `CUBE_TEMPLATE_ID` env var | Sandbox template ID |
+| `--timeout` | `600` | Sandbox lifetime (seconds) |
+| `--pause-on-exit` | `False` | Pause the sandbox on exit instead of destroying it |
+
+## Sample Run
+
+```bash
+python code_interpreter_demo_ci.py
+```
+
+```
+Model:    openai/glm-5.1
+Template: e2b-code-interpreter-2
+CubeAPI:  http://localhost:3000
+Question: Analyze sales.csv with Python: (1) compute revenue = units * unit_price,
+          (2) plot monthly total revenue as a line chart, (3) report the top-3
+          products by total revenue as a Markdown table, (4) finish with a
+          2-sentence executive summary.
+
+Creating sandbox & running agent ...
+[python] code-interpreter ready: probe #3: HTTP_OK status=200 body[:300]='"OK"'
+[python] bootstrapped kernel cwd -> /workspace
+[python] running 121 bytes in kernel
+[python] (14, 4)
+[python] ['date', 'product', 'units', 'unit_price']
+[python] date           object
+[python] product        object
+[python] units           int64
+[python] unit_price    float64
+[python] dtype: object
+[python] (ok)
+[python] running 567 bytes in kernel
+[python] saved output/figure_01.png (32115 bytes)
+[python] (ok)
+[python] running 505 bytes in kernel
+[python] | Product      |   Total Revenue |
+[python] |:-------------|----------------:|
+[python] | Gamma Gizmo  |          2178   |
+[python] | Beta Gadget  |          2156   |
+[python] | Alpha Widget |          1512.4 |
+[python]
+[python] Total revenue: $7,007.40
+[python] Peak month: 2025-04 ($2,333.50)
+[python] (ok)
+================================================================
+Here are the results:
+
+**Monthly Revenue Line Chart** → `output/figure_01.png`
+
+**Top-3 Products by Total Revenue**
+
+| Product      | Total Revenue |
+|:-------------|--------------:|
+| Gamma Gizmo  |       2,178.00 |
+| Beta Gadget  |       2,156.00 |
+| Alpha Widget |       1,512.40 |
+
+**Executive Summary**
+
+Total revenue across the period was **$7,007.40**, with April 2025 as the
+strongest month at **$2,333.50**. Gamma Gizmo narrowly leads product revenue
+($2,178), followed closely by Beta Gadget ($2,156), while Alpha Widget
+trails at $1,512.40.
+================================================================
+```
+
+## Architecture
+
+```
+SandboxAgent
+├── WorkspaceShell            # session.exec("sh -lc ...") → ls/cat/pwd
+└── PythonRunner              # Custom Capability (FunctionTool)
+    ├── code_interpreter_demo.py:
+    │     session.write(script.py)
+    │     session.exec("python -I -B script.py")
+    │     → returns exit_code / stdout / stderr / output/*
+    └── code_interpreter_demo_ci.py:
+          sandbox.run_code(code)
+          → Execution.results (base64 images auto-decoded)
+          → Execution.logs (stdout/stderr)
+          → Execution.error (structured exception)
+```
+
+### Manifest seed files
+
+At startup the Agent uses `Manifest` to seed the workspace with:
+
+| File | Contents |
+|------|----------|
+| `sales.csv` | 14 rows of sales data (date, product, units, unit_price) |
+| `README.md` | Task description guiding the agent through the analysis |
+
+The default prompt asks the agent to use `sales.csv` to: compute revenue → plot the monthly trend → produce a Top-3 products table → summarise.
+
+## CubeSandbox Adaptations
+
+| Patch | Reason | Location |
+|-------|--------|----------|
+| `default_username = "root"` + Filesystem method wrappers | envd only serves the root user | Top of both files |
+| `Commands.run` injects `on_stdout/on_stderr` | Stream sandbox output live | Top of both files |
+| LLM client uses the system CA bundle | Isolates `SSL_CERT_FILE` | `make_model()` |
+| Force `OpenAIChatCompletionsModel` | TokenHub does not support the Responses API | `make_model()` |
+
+Extra adaptations specific to `code_interpreter_demo_ci.py`:
+
+| Adaptation | Description |
+|------------|-------------|
+| `_wait_for_jupyter_ready()` | Probes `127.0.0.1:49999/health` from inside the sandbox to confirm Jupyter is ready |
+| `_find_code_interpreter_sandbox()` | BFS through SDK wrappers to reach the underlying `AsyncSandbox` |
+| `_run_code_annotated()` | Rewrites cube 502 errors from "sandbox timeout" into "sandbox evicted" |
+| Kernel CWD alignment | `os.chdir` to the envd workspace root so relative paths match the Manifest files |
+
+## Related Documents
+
+- [OpenAI Agents SDK × CubeSandbox Integration Guide](../openai-agents-example/openai-agents-sandbox-cube-integration.md)
+- [OpenAI Sandbox Agents Concepts](../openai-agents-example/openai-agents.md)
+- [CubeSandbox](https://github.com/TencentCloud/CubeSandbox)

--- a/examples/openai-agents-code-interpreter/README_zh.md
+++ b/examples/openai-agents-code-interpreter/README_zh.md
@@ -1,0 +1,212 @@
+# OpenAI Agents SDK + CubeSandbox: Code Interpreter 示例
+
+[English](README.md)
+
+在 [CubeSandbox](https://github.com/TencentCloud/CubeSandbox)（E2B 兼容 API）中运行数据分析 Agent，让 LLM 在云端 Python 沙箱里用 pandas / matplotlib 做真实计算和绘图。
+
+## 两个 Demo 的区别
+
+本目录有两份可直接运行的实现，功能等价，差异在 **Python 执行后端**：
+
+| | [`code_interpreter_demo.py`](code_interpreter_demo.py) | [`code_interpreter_demo_ci.py`](code_interpreter_demo_ci.py) |
+|---|---|---|
+| 沙箱类型 | `E2BSandboxType.E2B` | `E2BSandboxType.CODE_INTERPRETER` |
+| 底层 SDK | `e2b.AsyncSandbox` | `e2b_code_interpreter.AsyncSandbox` |
+| 执行方式 | `session.write(script.py)` → `session.exec("python script.py")` | `sandbox.run_code(code)`（Jupyter kernel） |
+| 会话状态 | 每次 exec 都是新进程 | **变量 / imports / DataFrame 跨 cell 保留** |
+| 图像捕获 | agent 手动 `plt.savefig(...)` | 自动从 `Execution.results` 解 base64 |
+| 错误信息 | stderr 全量回传 | 结构化 `Execution.error`（name / value / traceback） |
+| 模板端口 | envd (49983) | envd (49983) + code-interpreter gateway (49999) |
+
+**选择建议**：
+- 模板只有普通 Python → 用 `code_interpreter_demo.py`
+- 模板带 e2b code-interpreter 服务 → 用 `code_interpreter_demo_ci.py`（Jupyter kernel 体验，状态跨轮保留）
+
+## 前置条件
+
+- Python 3.10+
+- CubeSandbox 平台已部署，CubeAPI 可访问
+- 已创建带数据科学栈的沙箱模板（python3 + pandas + numpy + matplotlib）
+- TokenHub 或其他 OpenAI 兼容 LLM 的 API Key
+
+## 快速开始
+
+### 1. 安装依赖
+
+```bash
+pip install -r requirements.txt
+```
+
+### 2. 配置环境变量
+
+```bash
+cp .env.example .env
+```
+
+| 变量 | 说明 |
+|------|------|
+| `TOKENHUB_API_KEY` | TokenHub API Key（自动映射为 `OPENAI_API_KEY`） |
+| `OPENAI_BASE_URL` | LLM 地址（默认 `https://tokenhub.tencentmaas.com/v1`） |
+| `E2B_API_URL` | CubeAPI 地址，如 `http://<cube-host>:3000` |
+| `E2B_API_KEY` | CubeAPI 鉴权 Key |
+| `CUBE_TEMPLATE_ID` | 沙箱模板 ID |
+| `CUBE_SSL_CERT_FILE` | （可选）CubeSandbox CA 证书路径 |
+
+### 3. 创建沙箱模板
+
+```bash
+cubemastercli template create-from-image \
+  --image cube-sandbox-image.tencentcloudcr.com/demo/e2b-code-interpreter:v1.1-data \
+  --writable-layer-size 1Gi \
+  --template-id e2b-code-interpreter \
+  --expose-port 49983 \
+  --expose-port 49999 \
+  --probe 49983
+```
+
+将输出的模板 ID 填入 `.env` 的 `CUBE_TEMPLATE_ID`。
+
+> 注意：`code_interpreter_demo.py` 只需要暴露 49983 端口；`code_interpreter_demo_ci.py` 还需要 49999（Jupyter kernel gateway）。
+
+### 4. 运行
+
+```bash
+# 通用 E2B 版（write+exec）
+python code_interpreter_demo.py
+
+# Jupyter kernel 版（run_code，状态跨轮保留）
+python code_interpreter_demo_ci.py
+
+# 自定义问题
+python code_interpreter_demo.py --question "Plot units sold per product as a bar chart."
+
+# 换模型
+python code_interpreter_demo_ci.py --model openai/deepseek-v3.2
+
+# 沙箱关停时暂停而非销毁（支持后续恢复）
+python code_interpreter_demo.py --pause-on-exit
+```
+
+### 命令行参数
+
+| 参数 | 默认值 | 说明 |
+|------|--------|------|
+| `--model` | `openai/glm-5.1` | LLM 模型名（TokenHub 用 `openai/` 前缀） |
+| `--question` | 销售数据分析（见下方） | 发送给 Agent 的 prompt |
+| `--template` | `CUBE_TEMPLATE_ID` 环境变量 | 沙箱模板 ID |
+| `--timeout` | `600` | 沙箱生命周期（秒） |
+| `--pause-on-exit` | `False` | 关停时暂停沙箱，保留状态 |
+
+## 运行示例
+
+```bash
+python code_interpreter_demo_ci.py
+```
+
+```
+Model:    openai/glm-5.1
+Template: e2b-code-interpreter-2
+CubeAPI:  http://localhost:3000
+Question: Analyze sales.csv with Python: (1) compute revenue = units * unit_price,
+          (2) plot monthly total revenue as a line chart, (3) report the top-3
+          products by total revenue as a Markdown table, (4) finish with a
+          2-sentence executive summary.
+
+Creating sandbox & running agent ...
+[python] code-interpreter ready: probe #3: HTTP_OK status=200 body[:300]='"OK"'
+[python] bootstrapped kernel cwd -> /workspace
+[python] running 121 bytes in kernel
+[python] (14, 4)
+[python] ['date', 'product', 'units', 'unit_price']
+[python] date           object
+[python] product        object
+[python] units           int64
+[python] unit_price    float64
+[python] dtype: object
+[python] (ok)
+[python] running 567 bytes in kernel
+[python] saved output/figure_01.png (32115 bytes)
+[python] (ok)
+[python] running 505 bytes in kernel
+[python] | Product      |   Total Revenue |
+[python] |:-------------|----------------:|
+[python] | Gamma Gizmo  |          2178   |
+[python] | Beta Gadget  |          2156   |
+[python] | Alpha Widget |          1512.4 |
+[python]
+[python] Total revenue: $7,007.40
+[python] Peak month: 2025-04 ($2,333.50)
+[python] (ok)
+================================================================
+Here are the results:
+
+**Monthly Revenue Line Chart** → `output/figure_01.png`
+
+**Top-3 Products by Total Revenue**
+
+| Product      | Total Revenue |
+|:-------------|--------------:|
+| Gamma Gizmo  |       2,178.00 |
+| Beta Gadget  |       2,156.00 |
+| Alpha Widget |       1,512.40 |
+
+**Executive Summary**
+
+Total revenue across the period was **$7,007.40**, with April 2025 as the
+strongest month at **$2,333.50**. Gamma Gizmo narrowly leads product revenue
+($2,178), followed closely by Beta Gadget ($2,156), while Alpha Widget
+trails at $1,512.40.
+================================================================
+```
+
+## 架构
+
+```
+SandboxAgent
+├── WorkspaceShell            # session.exec("sh -lc ...") → ls/cat/pwd
+└── PythonRunner              # 自定义 Capability (FunctionTool)
+    ├── code_interpreter_demo.py:
+    │     session.write(script.py)
+    │     session.exec("python -I -B script.py")
+    │     → 回传 exit_code / stdout / stderr / output/*
+    └── code_interpreter_demo_ci.py:
+          sandbox.run_code(code)
+          → Execution.results (base64 图像自动解码)
+          → Execution.logs (stdout/stderr)
+          → Execution.error (结构化异常)
+```
+
+### Manifest 种子文件
+
+Agent 启动时通过 `Manifest` 在沙箱工作区写入：
+
+| 文件 | 内容 |
+|------|------|
+| `sales.csv` | 14 行销售数据（date, product, units, unit_price） |
+| `README.md` | 任务说明，引导 agent 做数据分析 |
+
+默认 prompt 要求 agent 基于 `sales.csv` 完成：计算收入 → 画月度趋势图 → Top-3 产品表格 → 总结。
+
+## CubeSandbox 适配
+
+| 补丁 | 原因 | 代码位置 |
+|------|------|---------|
+| `default_username = "root"` + Filesystem 方法包装 | envd 只服务 root 用户 | 两个文件顶部 |
+| `Commands.run` 注入 `on_stdout/on_stderr` | 沙箱输出实时流式打印 | 两个文件顶部 |
+| LLM 客户端使用系统 CA bundle | `SSL_CERT_FILE` 隔离 | `make_model()` |
+| 强制 `OpenAIChatCompletionsModel` | TokenHub 不支持 Responses API | `make_model()` |
+
+以下为 `code_interpreter_demo_ci.py` 特有的适配：
+
+| 适配 | 说明 |
+|------|------|
+| `_wait_for_jupyter_ready()` | 沙箱内部探测 `127.0.0.1:49999/health`，确认 Jupyter 就绪 |
+| `_find_code_interpreter_sandbox()` | BFS 穿透 SDK wrapper 找到底层 `AsyncSandbox` |
+| `_run_code_annotated()` | 将 cube 502 错误从 "sandbox timeout" 改写为 "沙箱被驱逐" |
+| kernel CWD 对齐 | `os.chdir` 到 envd 工作区根，让相对路径匹配 Manifest 文件 |
+
+## 相关文档
+
+- [OpenAI Agents SDK × CubeSandbox 集成指南](../openai-agents-example/openai-agents-sandbox-cube-integration_zh.md)
+- [OpenAI Sandbox Agents 概念解析](../openai-agents-example/openai-agents_zh.md)
+- [CubeSandbox](https://github.com/TencentCloud/CubeSandbox)

--- a/examples/openai-agents-code-interpreter/code_interpreter_demo.py
+++ b/examples/openai-agents-code-interpreter/code_interpreter_demo.py
@@ -1,0 +1,506 @@
+"""Cube-sandbox code-interpreter demo: sales data analysis with matplotlib.
+
+Ports the E2B code-interpreter example to Cube Sandbox (E2B-compatible API).
+
+What it shows
+-------------
+- Uses a Cube template with pandas / numpy / matplotlib / scikit-learn preinstalled.
+- Exposes two custom capabilities:
+    * `WorkspaceShell` — a thin wrapper around `session.exec` for `ls` / `cat`.
+    * `PythonRunner`   — writes the model-generated snippet to disk and runs it
+                         via `python -I -B script.py`, then reports the new files
+                         created under `output/`.
+- Seeds the workspace via a Manifest (`sales.csv` + `README.md`).
+- Asks the model to compute monthly revenue, draw a line chart, and produce a
+  top-3 product table.
+
+Usage
+-----
+    cp .env.example .env   # fill in real values
+    pip install -r requirements.txt
+    python code_interpreter_demo.py
+
+Key env vars (see `.env.example`):
+    TOKENHUB_API_KEY   — LLM key (OpenAI-compatible via TokenHub)
+    E2B_API_URL        — CubeAPI endpoint, e.g. http://<ip>:3000
+    E2B_API_KEY        — CubeAPI key
+    CUBE_TEMPLATE_ID   — template ID with Python data-science stack preinstalled
+    CUBE_SSL_CERT_FILE — optional path to CA bundle for cube HTTPS
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import contextvars
+import functools
+import io
+import json
+import os
+import sys
+import uuid
+from pathlib import Path
+from textwrap import dedent
+from typing import Any
+
+os.environ.setdefault("OPENAI_AGENTS_DISABLE_TRACING", "1")
+
+from dotenv import load_dotenv
+
+# ---------------------------------------------------------------------------
+# cube-sandbox runtime patches:
+# 1. envd only serves the "root" user; the E2B SDK defaults to "user".
+#    Force all FS ops to user="root" by wrapping Filesystem methods.
+# 2. Inject on_stdout / on_stderr callbacks into commands.run so tool output
+#    streams to the local terminal in real time (prefixed per tool label).
+# ---------------------------------------------------------------------------
+import inspect as _inspect
+
+import e2b.envd.rpc as _e2b_rpc
+from e2b.sandbox_async.commands.command import Commands as _AsyncCommands
+from e2b.sandbox_async.filesystem.filesystem import Filesystem as _AsyncFS
+
+_e2b_rpc.default_username = "root"
+
+for _name in (
+    "read", "write", "write_files", "list", "exists",
+    "get_info", "remove", "rename", "make_dir", "watch_dir",
+):
+    _orig = getattr(_AsyncFS, _name, None)
+    if _orig is None:
+        continue
+    _params = list(_inspect.signature(_orig).parameters.keys())
+    _user_pos = _params.index("user") - 1 if "user" in _params else None  # -1 for self
+
+    def _make(fn, user_pos=_user_pos):
+        @functools.wraps(fn)
+        async def _wrapper(self, *a, **kw):
+            if user_pos is not None and len(a) > user_pos:
+                a = list(a)
+                if a[user_pos] is None:
+                    a[user_pos] = "root"
+                a = tuple(a)
+            else:
+                kw.setdefault("user", "root")
+            return await fn(self, *a, **kw)
+        return _wrapper
+    setattr(_AsyncFS, _name, _make(_orig))
+
+# Live-streaming context: tools set _stream_label.set("shell" | "python") and
+# every commands.run call inside that context gets on_stdout/on_stderr hooks
+# that mirror output to the local terminal with a `[<label>]` prefix.
+_stream_label: contextvars.ContextVar[str | None] = contextvars.ContextVar(
+    "_stream_label", default=None
+)
+
+
+def _make_stream_handler(label: str, stream):
+    def _handler(data):
+        text = data if isinstance(data, str) else data.decode("utf-8", errors="replace")
+        for line in text.splitlines():
+            print(f"[{label}] {line}", file=stream, flush=True)
+    return _handler
+
+
+_orig_commands_run = _AsyncCommands.run
+
+
+@functools.wraps(_orig_commands_run)
+async def _patched_commands_run(self, *a, **kw):
+    label = _stream_label.get()
+    if label is not None:
+        kw.setdefault("on_stdout", _make_stream_handler(label, sys.stdout))
+        kw.setdefault("on_stderr", _make_stream_handler(label, sys.stderr))
+    return await _orig_commands_run(self, *a, **kw)
+
+
+_AsyncCommands.run = _patched_commands_run
+
+# ---------------------------------------------------------------------------
+# SDK imports (after compat patches)
+# ---------------------------------------------------------------------------
+import httpx
+from openai import AsyncOpenAI
+from pydantic import BaseModel, Field
+
+from agents import ModelSettings, Runner, set_tracing_disabled
+from agents.models.openai_chatcompletions import OpenAIChatCompletionsModel
+from agents.run import RunConfig
+from agents.sandbox import Capability, Manifest, SandboxAgent, SandboxRunConfig
+from agents.sandbox.entries import File
+from agents.sandbox.session.base_sandbox_session import BaseSandboxSession
+from agents.tool import FunctionTool, Tool
+
+try:
+    from agents.extensions.sandbox import (
+        E2BSandboxClient,
+        E2BSandboxClientOptions,
+        E2BSandboxType,
+    )
+except Exception as exc:  # pragma: no cover
+    raise SystemExit(
+        "This example requires the E2B optional dependency:\n"
+        "    pip install 'openai-agents[e2b]'"
+    ) from exc
+
+set_tracing_disabled(True)
+
+
+# ---------------------------------------------------------------------------
+# Sample data & task
+# ---------------------------------------------------------------------------
+
+SALES_CSV = """date,product,units,unit_price
+2025-01-03,Alpha Widget,12,19.90
+2025-01-17,Beta Gadget,8,49.00
+2025-01-29,Gamma Gizmo,5,99.00
+2025-02-05,Alpha Widget,22,19.90
+2025-02-14,Beta Gadget,15,49.00
+2025-02-20,Delta Doohickey,3,129.00
+2025-03-04,Alpha Widget,17,19.90
+2025-03-11,Beta Gadget,9,49.00
+2025-03-18,Gamma Gizmo,7,99.00
+2025-03-27,Delta Doohickey,4,129.00
+2025-04-02,Alpha Widget,25,19.90
+2025-04-08,Beta Gadget,12,49.00
+2025-04-19,Gamma Gizmo,10,99.00
+2025-04-28,Delta Doohickey,2,129.00
+"""
+
+DEFAULT_QUESTION = (
+    "Analyze sales.csv with Python: "
+    "(1) compute revenue = units * unit_price, "
+    "(2) plot monthly total revenue as a line chart and save it to "
+    "output/monthly_revenue.png, "
+    "(3) report the top-3 products by total revenue as a Markdown table, "
+    "(4) finish with a 2-sentence executive summary. "
+    "Prefer one consolidated run_python call."
+)
+
+
+# ---------------------------------------------------------------------------
+# Capability 1: lightweight shell for ls / cat / pwd
+#
+# NOTE: We use a plain FunctionTool instead of ShellTool. ShellTool is a
+# "hosted tool" that requires the OpenAI Responses API. TokenHub (and most
+# 3rd-party OpenAI-compatible providers) only speak the Chat Completions API,
+# which rejects hosted tools.
+# ---------------------------------------------------------------------------
+class ShellRunRequest(BaseModel):
+    command: str = Field(
+        ...,
+        description="Shell command to run inside the sandbox (executed via `sh -lc`).",
+    )
+    timeout_s: int = Field(
+        60,
+        ge=1,
+        le=600,
+        description="Command timeout in seconds (default 60, max 600).",
+    )
+
+
+class WorkspaceShell(Capability):
+    """Expose the sandbox session's `exec` as a simple function tool."""
+
+    def __init__(self) -> None:
+        super().__init__(type="workspace_shell")
+
+    async def instructions(self, manifest: Manifest) -> str | None:
+        _ = manifest
+        return (
+            "Use the `shell` tool for light inspection (`ls`, `pwd`, `cat`, `head`).\n"
+            "The workspace root is the CWD; prefer relative paths."
+        )
+
+    def tools(self) -> list[Tool]:
+        return [
+            FunctionTool(
+                name="shell",
+                description=(
+                    "Run a shell command inside the sandbox and return exit code, "
+                    "stdout, stderr. Intended for quick inspection (`ls`, `cat`, "
+                    "`head`) of the workspace."
+                ),
+                params_json_schema=ShellRunRequest.model_json_schema(),
+                on_invoke_tool=self._invoke,
+            )
+        ]
+
+    async def _invoke(self, _ctx: Any, raw_args: str) -> str:
+        session = self.session
+        if session is None:
+            raise RuntimeError("workspace_shell is not bound to a sandbox session")
+
+        request = ShellRunRequest.model_validate_json(raw_args)
+        # Use `sh -lc "<cmd> </dev/null"` with shell=False so the SDK doesn't open
+        # stdin on its side and the shell closes stdin on the sandbox side — this
+        # avoids hangs when the model invokes commands that accidentally read stdin
+        # (e.g. `cat` without args, `grep` without a file).
+        print(f"[shell] $ {request.command}", flush=True)
+        token = _stream_label.set("shell")
+        try:
+            result = await session.exec(
+                "sh", "-lc", f"{request.command} </dev/null",
+                timeout=request.timeout_s,
+                shell=False,
+            )
+        finally:
+            _stream_label.reset(token)
+        print(f"[shell] (exit={result.exit_code})", flush=True)
+        payload = {
+            "exit_code": result.exit_code,
+            "stdout": result.stdout.decode("utf-8", errors="replace")[-4000:],
+            "stderr": result.stderr.decode("utf-8", errors="replace")[-4000:],
+        }
+        return json.dumps(payload, ensure_ascii=False)
+
+
+# ---------------------------------------------------------------------------
+# Capability 2: run_python — the heart of this demo
+# ---------------------------------------------------------------------------
+class PythonRunRequest(BaseModel):
+    code: str = Field(
+        ...,
+        description="Full Python source to execute. CWD is the workspace root; use relative paths.",
+    )
+    timeout_s: int = Field(60, ge=1, le=600)
+
+
+class PythonRunner(Capability):
+    """Write the model-generated Python code to disk, then run it with `python`.
+
+    Requires a Cube template with pandas / numpy / matplotlib / scikit-learn
+    preinstalled (typical data-science image).
+    """
+
+    def __init__(self) -> None:
+        super().__init__(type="python_runner")
+
+    async def instructions(self, manifest: Manifest) -> str | None:
+        _ = manifest
+        return dedent(
+            """
+            Call `run_python(code=..., timeout_s=60)` for computation and plotting.
+            - The workspace root is the CWD; use relative paths.
+            - pandas / numpy / matplotlib / scikit-learn are preinstalled.
+            - Save charts to `output/<name>.png` with `plt.savefig(...)`.
+            - Use `matplotlib.use("Agg")` before `import pyplot` so plotting works
+              in this headless environment.
+            - Print concise summaries to stdout for the user to inspect.
+            - Prefer one well-structured call over many tiny ones.
+            """
+        ).strip()
+
+    def tools(self) -> list[Tool]:
+        return [
+            FunctionTool(
+                name="run_python",
+                description=(
+                    "Execute a Python snippet inside the cube sandbox and return "
+                    "exit code, stdout tail, stderr tail, and newly created files "
+                    "under `output/`."
+                ),
+                params_json_schema=PythonRunRequest.model_json_schema(),
+                on_invoke_tool=self._invoke,
+            )
+        ]
+
+    async def _invoke(self, _ctx: Any, raw_args: str) -> str:
+        session = self.session
+        if session is None:
+            raise RuntimeError("python_runner is not bound to a sandbox session")
+
+        request = PythonRunRequest.model_validate_json(raw_args)
+
+        await session.mkdir(Path(".scratch"), parents=True)
+        await session.mkdir(Path("output"), parents=True)
+
+        script_rel = Path(f".scratch/{uuid.uuid4().hex}.py")
+        await session.write(
+            script_rel,
+            io.BytesIO(request.code.encode("utf-8")),
+        )
+
+        before = await _list_output_files(session)
+        print(f"[python] running {script_rel} ({len(request.code)} bytes)", flush=True)
+        token = _stream_label.set("python")
+        try:
+            result = await session.exec(
+                "python",
+                "-u",
+                "-I",
+                "-B",
+                str(script_rel),
+                shell=False,
+                timeout=request.timeout_s,
+            )
+        finally:
+            _stream_label.reset(token)
+        print(f"[python] (exit={result.exit_code})", flush=True)
+        after = await _list_output_files(session)
+        new_files = sorted(after - before)
+
+        payload = {
+            "exit_code": result.exit_code,
+            "stdout_tail": result.stdout.decode("utf-8", errors="replace")[-4000:],
+            "stderr_tail": result.stderr.decode("utf-8", errors="replace")[-4000:],
+            "new_files": new_files,
+        }
+        return json.dumps(payload, ensure_ascii=False)
+
+
+async def _list_output_files(session: BaseSandboxSession) -> set[str]:
+    """List files under `output/`, used to diff before/after run_python."""
+    result = await session.exec(
+        "sh",
+        "-lc",
+        "find output -maxdepth 2 -type f 2>/dev/null | sort",
+        shell=False,
+        timeout=10,
+    )
+    if result.exit_code != 0:
+        return set()
+    return {
+        line.strip()
+        for line in result.stdout.decode("utf-8", errors="replace").splitlines()
+        if line.strip()
+    }
+
+
+# ---------------------------------------------------------------------------
+# Manifest / env / model
+# ---------------------------------------------------------------------------
+def build_manifest() -> Manifest:
+    return Manifest(
+        entries={
+            "sales.csv": File(content=SALES_CSV.encode("utf-8")),
+            "README.md": File(
+                content=(
+                    b"# Sales review\n\n"
+                    b"`sales.csv` has 4 months of per-product sales.\n"
+                    b"Use run_python to compute revenue and plot the monthly trend.\n"
+                )
+            ),
+        }
+    )
+
+
+def load_env():
+    load_dotenv()
+    if os.environ.get("TOKENHUB_API_KEY") and not os.environ.get("OPENAI_API_KEY"):
+        os.environ["OPENAI_API_KEY"] = os.environ["TOKENHUB_API_KEY"]
+    if not os.environ.get("OPENAI_BASE_URL"):
+        os.environ["OPENAI_BASE_URL"] = "https://tokenhub.tencentmaas.com/v1"
+
+    for key in ("OPENAI_API_KEY", "E2B_API_KEY", "E2B_API_URL"):
+        if not os.environ.get(key):
+            raise SystemExit(f"Missing env var: {key}")
+
+    cube_ssl = os.environ.get("CUBE_SSL_CERT_FILE")
+    if cube_ssl and os.path.isfile(cube_ssl):
+        os.environ["SSL_CERT_FILE"] = cube_ssl
+
+
+def make_model(model_name: str) -> OpenAIChatCompletionsModel:
+    """TokenHub only supports Chat Completions API, not the Responses API.
+
+    Force the LLM http client to use the system CA bundle so that SSL_CERT_FILE
+    (set for cube gRPC) doesn't break TokenHub HTTPS calls.
+    """
+    import ssl
+    ssl_ctx = ssl.create_default_context()
+    client = AsyncOpenAI(
+        timeout=httpx.Timeout(120, connect=15),
+        http_client=httpx.AsyncClient(verify=ssl_ctx),
+    )
+    bare = model_name.split("/", 1)[-1] if "/" in model_name else model_name
+    return OpenAIChatCompletionsModel(model=bare, openai_client=client)
+
+
+# ---------------------------------------------------------------------------
+# Run
+# ---------------------------------------------------------------------------
+SYSTEM_INSTRUCTIONS = (
+    "You are a data analyst working inside a Python sandbox.\n"
+    "- Use `run_python` for computation and plotting. Use `shell` only for "
+    "quick inspection (`ls`, `cat`, `head`).\n"
+    "- pandas / numpy / matplotlib / scikit-learn are preinstalled; no need "
+    "to install anything.\n"
+    "- Save charts to `output/<name>.png` with `plt.savefig(...)`.\n"
+    "- Cite file names you actually read and include any files you produced."
+)
+
+
+async def main(
+    *,
+    model: str,
+    question: str,
+    template: str,
+    timeout: int,
+    pause_on_exit: bool,
+) -> None:
+    print(f"Model:    {model}")
+    print(f"Template: {template}")
+    print(f"CubeAPI:  {os.environ['E2B_API_URL']}")
+    print(f"Question: {question}\n")
+
+    agent = SandboxAgent(
+        name="Cube Code Interpreter Analyst",
+        model=make_model(model),
+        instructions=SYSTEM_INSTRUCTIONS,
+        default_manifest=build_manifest(),
+        capabilities=[WorkspaceShell(), PythonRunner()],
+        model_settings=ModelSettings(tool_choice="auto"),
+    )
+
+    run_config = RunConfig(
+        sandbox=SandboxRunConfig(
+            client=E2BSandboxClient(),
+            options=E2BSandboxClientOptions(
+                sandbox_type=E2BSandboxType.E2B,
+                template=template,
+                timeout=timeout,
+                pause_on_exit=pause_on_exit,
+            ),
+        ),
+        workflow_name="Cube code interpreter demo",
+    )
+
+    print("Creating sandbox & running agent ...")
+    result = await Runner.run(agent, question, run_config=run_config)
+    print("=" * 64)
+    print(result.final_output)
+    print("=" * 64)
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--model", default="openai/glm-5.1",
+                        help="LLM name (TokenHub models use 'openai/' prefix).")
+    parser.add_argument("--question", default=DEFAULT_QUESTION,
+                        help="Prompt to send to the agent.")
+    parser.add_argument("--template", default=None,
+                        help="Cube template ID (or set CUBE_TEMPLATE_ID).")
+    parser.add_argument("--timeout", type=int, default=600,
+                        help="Sandbox lifetime timeout in seconds.")
+    parser.add_argument("--pause-on-exit", action="store_true", default=False,
+                        help="Pause (not kill) the sandbox on shutdown, for later resume.")
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    args = _parse_args()
+    load_env()
+    template = args.template or os.environ.get("CUBE_TEMPLATE_ID")
+    if not template:
+        raise SystemExit("Missing template: set CUBE_TEMPLATE_ID or pass --template")
+
+    asyncio.run(
+        main(
+            model=args.model,
+            question=args.question,
+            template=template,
+            timeout=args.timeout,
+            pause_on_exit=args.pause_on_exit,
+        )
+    )

--- a/examples/openai-agents-code-interpreter/code_interpreter_demo_ci.py
+++ b/examples/openai-agents-code-interpreter/code_interpreter_demo_ci.py
@@ -1,0 +1,782 @@
+"""Cube-sandbox code-interpreter demo (Jupyter kernel variant).
+
+This is a simplified re-implementation of ``code_interpreter_demo.py`` that
+uses ``E2BSandboxType.CODE_INTERPRETER`` instead of the generic E2B sandbox.
+
+Why another file?
+-----------------
+``CODE_INTERPRETER`` is backed by ``e2b_code_interpreter.AsyncSandbox`` which
+hosts a long-lived Jupyter kernel. That gives us `run_code(...)`, a stateful
+execution primitive that returns a rich ``Execution`` object:
+
+    - ``logs.stdout`` / ``logs.stderr`` — captured per cell
+    - ``results``                       — display values (PNG/JPEG/SVG/HTML/text)
+    - ``error``                         — traceback (if any)
+
+So instead of:
+    write snippet to .scratch/*.py  ->  exec `python script.py`
+        ->  find new files under output/  ->  stitch everything together
+
+we do:
+    session._sandbox.run_code(code)    # stateful kernel
+    -> decode any png/jpeg results into output/figure_*.png
+
+Kernel state (variables, imports, `df`, fitted models...) persists across
+calls, matching the OpenAI code-interpreter UX.
+
+What stays the same
+-------------------
+- root-user FS patch (cube envd only serves `root`)
+- live-streaming `[shell]` / `[python]` output to the terminal
+- `WorkspaceShell` tool for quick `ls` / `cat`
+- Manifest seed (`sales.csv`, `README.md`)
+
+Usage
+-----
+    cp .env.example .env   # fill in real values (same vars as the other demo)
+    pip install -r requirements.txt
+    python code_interpreter_demo_ci.py
+
+Requires a Cube template with a Jupyter kernel runtime compatible with
+``e2b_code_interpreter`` (pandas / numpy / matplotlib preinstalled).
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import base64
+import contextvars
+import functools
+import io
+import json
+import os
+import sys
+from pathlib import Path
+from textwrap import dedent
+from typing import Any
+
+os.environ.setdefault("OPENAI_AGENTS_DISABLE_TRACING", "1")
+
+from dotenv import load_dotenv
+
+# ---------------------------------------------------------------------------
+# cube-sandbox runtime patches:
+# 1. envd only serves the "root" user; E2B SDK defaults to "user". Force all
+#    FS ops to user="root" by wrapping Filesystem methods. (Applies to both
+#    e2b.AsyncSandbox and e2b_code_interpreter.AsyncSandbox, since the latter
+#    inherits the former's Filesystem.)
+# 2. Inject on_stdout / on_stderr callbacks into Commands.run so the `shell`
+#    tool's output streams to the local terminal in real time. This ONLY
+#    affects `session.exec` (which the WorkspaceShell / probe code uses);
+#    run_code() talks to the code-interpreter HTTP gateway directly and
+#    uses its own on_stdout/on_stderr callbacks in PythonRunner._invoke.
+# ---------------------------------------------------------------------------
+import inspect as _inspect
+
+import e2b.envd.rpc as _e2b_rpc
+from e2b.sandbox_async.commands.command import Commands as _AsyncCommands
+from e2b.sandbox_async.filesystem.filesystem import Filesystem as _AsyncFS
+
+_e2b_rpc.default_username = "root"
+
+for _name in (
+    "read", "write", "write_files", "list", "exists",
+    "get_info", "remove", "rename", "make_dir", "watch_dir",
+):
+    _orig = getattr(_AsyncFS, _name, None)
+    if _orig is None:
+        continue
+    _params = list(_inspect.signature(_orig).parameters.keys())
+    _user_pos = _params.index("user") - 1 if "user" in _params else None  # -1 for self
+
+    def _make(fn, user_pos=_user_pos):
+        @functools.wraps(fn)
+        async def _wrapper(self, *a, **kw):
+            if user_pos is not None and len(a) > user_pos:
+                a = list(a)
+                if a[user_pos] is None:
+                    a[user_pos] = "root"
+                a = tuple(a)
+            else:
+                kw.setdefault("user", "root")
+            return await fn(self, *a, **kw)
+        return _wrapper
+    setattr(_AsyncFS, _name, _make(_orig))
+
+
+_stream_label: contextvars.ContextVar[str | None] = contextvars.ContextVar(
+    "_stream_label", default=None
+)
+
+
+def _make_stream_handler(label: str, stream):
+    def _handler(data):
+        text = data if isinstance(data, str) else data.decode("utf-8", errors="replace")
+        for line in text.splitlines():
+            print(f"[{label}] {line}", file=stream, flush=True)
+    return _handler
+
+
+_orig_commands_run = _AsyncCommands.run
+
+
+@functools.wraps(_orig_commands_run)
+async def _patched_commands_run(self, *a, **kw):
+    label = _stream_label.get()
+    if label is not None:
+        kw.setdefault("on_stdout", _make_stream_handler(label, sys.stdout))
+        kw.setdefault("on_stderr", _make_stream_handler(label, sys.stderr))
+    return await _orig_commands_run(self, *a, **kw)
+
+
+_AsyncCommands.run = _patched_commands_run
+
+# ---------------------------------------------------------------------------
+# SDK imports (after compat patches)
+# ---------------------------------------------------------------------------
+import httpx
+from openai import AsyncOpenAI
+from pydantic import BaseModel, Field
+
+from agents import ModelSettings, Runner, set_tracing_disabled
+from agents.models.openai_chatcompletions import OpenAIChatCompletionsModel
+from agents.run import RunConfig
+from agents.sandbox import Capability, Manifest, SandboxAgent, SandboxRunConfig
+from agents.sandbox.entries import File
+from agents.tool import FunctionTool, Tool
+
+try:
+    from agents.extensions.sandbox import (
+        E2BSandboxClient,
+        E2BSandboxClientOptions,
+        E2BSandboxType,
+    )
+except Exception as exc:  # pragma: no cover
+    raise SystemExit(
+        "This example requires the E2B optional dependency:\n"
+        "    pip install 'openai-agents[e2b]'"
+    ) from exc
+
+try:
+    import e2b_code_interpreter as _e2b_ci  # noqa: F401
+except Exception as exc:  # pragma: no cover
+    raise SystemExit(
+        "This demo uses the Jupyter-kernel sandbox and needs "
+        "`e2b-code-interpreter`:\n"
+        "    pip install e2b-code-interpreter\n"
+        "(older versions of openai-agents[e2b] don't pull it in.)"
+    ) from exc
+
+set_tracing_disabled(True)
+
+
+# ---------------------------------------------------------------------------
+# Sample data & task
+# ---------------------------------------------------------------------------
+
+SALES_CSV = """date,product,units,unit_price
+2025-01-03,Alpha Widget,12,19.90
+2025-01-17,Beta Gadget,8,49.00
+2025-01-29,Gamma Gizmo,5,99.00
+2025-02-05,Alpha Widget,22,19.90
+2025-02-14,Beta Gadget,15,49.00
+2025-02-20,Delta Doohickey,3,129.00
+2025-03-04,Alpha Widget,17,19.90
+2025-03-11,Beta Gadget,9,49.00
+2025-03-18,Gamma Gizmo,7,99.00
+2025-03-27,Delta Doohickey,4,129.00
+2025-04-02,Alpha Widget,25,19.90
+2025-04-08,Beta Gadget,12,49.00
+2025-04-19,Gamma Gizmo,10,99.00
+2025-04-28,Delta Doohickey,2,129.00
+"""
+
+DEFAULT_QUESTION = (
+    "Analyze sales.csv with Python: "
+    "(1) compute revenue = units * unit_price, "
+    "(2) plot monthly total revenue as a line chart (the plot will be captured "
+    "automatically), "
+    "(3) report the top-3 products by total revenue as a Markdown table, "
+    "(4) finish with a 2-sentence executive summary. "
+    "You can spread this across multiple run_python calls — kernel state is preserved."
+)
+
+
+# ---------------------------------------------------------------------------
+# Capability 1: lightweight shell for ls / cat / pwd (unchanged from sibling demo)
+# ---------------------------------------------------------------------------
+class ShellRunRequest(BaseModel):
+    command: str = Field(
+        ...,
+        description="Shell command to run inside the sandbox (executed via `sh -lc`).",
+    )
+    timeout_s: int = Field(
+        60,
+        ge=1,
+        le=600,
+        description="Command timeout in seconds (default 60, max 600).",
+    )
+
+
+class WorkspaceShell(Capability):
+    """Expose the sandbox session's `exec` as a simple function tool."""
+
+    def __init__(self) -> None:
+        super().__init__(type="workspace_shell")
+
+    async def instructions(self, manifest: Manifest) -> str | None:
+        _ = manifest
+        return (
+            "Use the `shell` tool for light inspection (`ls`, `pwd`, `cat`, `head`).\n"
+            "The workspace root is the CWD; prefer relative paths."
+        )
+
+    def tools(self) -> list[Tool]:
+        return [
+            FunctionTool(
+                name="shell",
+                description=(
+                    "Run a shell command inside the sandbox and return exit code, "
+                    "stdout, stderr. Intended for quick inspection (`ls`, `cat`, "
+                    "`head`) of the workspace."
+                ),
+                params_json_schema=ShellRunRequest.model_json_schema(),
+                on_invoke_tool=self._invoke,
+            )
+        ]
+
+    async def _invoke(self, _ctx: Any, raw_args: str) -> str:
+        session = self.session
+        if session is None:
+            raise RuntimeError("workspace_shell is not bound to a sandbox session")
+
+        request = ShellRunRequest.model_validate_json(raw_args)
+        print(f"[shell] $ {request.command}", flush=True)
+        token = _stream_label.set("shell")
+        try:
+            result = await session.exec(
+                "sh", "-lc", f"{request.command} </dev/null",
+                timeout=request.timeout_s,
+                shell=False,
+            )
+        finally:
+            _stream_label.reset(token)
+        print(f"[shell] (exit={result.exit_code})", flush=True)
+        payload = {
+            "exit_code": result.exit_code,
+            "stdout": result.stdout.decode("utf-8", errors="replace")[-4000:],
+            "stderr": result.stderr.decode("utf-8", errors="replace")[-4000:],
+        }
+        return json.dumps(payload, ensure_ascii=False)
+
+
+# ---------------------------------------------------------------------------
+# Capability 2: run_python backed by the Jupyter kernel (run_code)
+# ---------------------------------------------------------------------------
+class PythonRunRequest(BaseModel):
+    code: str = Field(
+        ...,
+        description=(
+            "Python source to execute inside a stateful Jupyter kernel. "
+            "Variables, imports, and dataframes persist across calls."
+        ),
+    )
+    timeout_s: int = Field(60, ge=1, le=600)
+
+
+# matplotlib image formats we know how to persist
+_IMAGE_KINDS: tuple[tuple[str, str], ...] = (
+    ("png", "png"),
+    ("jpeg", "jpg"),
+    ("svg", "svg"),
+)
+
+
+# In the e2b code-interpreter image, port 49999 is the "code interpreter"
+# HTTP gateway service (which in turn talks to Jupyter on 8888 internally).
+# The constant is still called JUPYTER_PORT in the SDK for historical
+# reasons, so we follow that naming here.
+_JUPYTER_PORT = 49999  # e2b_code_interpreter.constants.JUPYTER_PORT
+
+
+async def _probe_jupyter_internal(
+    session: Any, *, attempts: int, interval_s: float,
+) -> tuple[bool, str]:
+    """Probe the code-interpreter HTTP gateway from INSIDE the sandbox.
+
+    Runs one ``session.exec`` per attempt that does:
+      1. TCP accept via bash's ``/dev/tcp/127.0.0.1/49999`` (fast check
+         that the process is even listening),
+      2. an HTTP GET to ``/health`` via python stdlib.
+
+    Any HTTP response — including 4xx via ``HTTPError`` — counts as
+    "service is responding"; we only reject socket errors / timeouts
+    (i.e. process missing or wedged). This is intentional: 49999 is the
+    e2b code-interpreter gateway (POST /contexts, POST /execute, GET
+    /health; Jupyter itself sits behind it on 8888), so an endpoint like
+    ``/`` or ``/api`` legitimately 404s on a healthy server.
+    """
+    probe_sh = rf"""
+exec 3<>/dev/tcp/127.0.0.1/{_JUPYTER_PORT} 2>/dev/null || {{ echo "TCP_FAIL" >&2; exit 2; }}
+exec 3>&- 3<&-
+python3 - <<'PY' 2>&1
+import urllib.request, urllib.error, sys, socket
+socket.setdefaulttimeout(5)
+try:
+    with urllib.request.urlopen("http://127.0.0.1:{_JUPYTER_PORT}/health") as r:
+        body = r.read(300).decode("utf-8", "replace").replace("\n", " ")
+        print(f"HTTP_OK status={{r.status}} body[:300]={{body!r}}")
+except urllib.error.HTTPError as e:
+    # 4xx/5xx still means the HTTP server answered, i.e. not wedged.
+    print(f"HTTP_OK status={{e.code}} (HTTPError, server is responsive)")
+except Exception as e:
+    print(f"HTTP_FAIL {{type(e).__name__}}: {{e}}")
+    sys.exit(3)
+PY
+""".strip()
+
+    last_err = ""
+    for i in range(attempts):
+        try:
+            res = await session.exec(
+                "bash", "-lc", probe_sh, shell=False, timeout=10,
+            )
+            stdout = res.stdout.decode("utf-8", errors="replace").strip()
+            stderr = res.stderr.decode("utf-8", errors="replace").strip()
+            if res.exit_code == 0 and stdout.startswith("HTTP_OK"):
+                return True, f"probe #{i}: {stdout}"
+            last_err = (
+                f"exit={res.exit_code} stderr={stderr!r} stdout={stdout!r}"
+            )
+        except Exception as e:
+            last_err = f"{type(e).__name__}: {e}"
+        await asyncio.sleep(interval_s)
+    return False, last_err
+
+
+async def _run_code_annotated(inner: Any, code: str, **kwargs: Any) -> Any:
+    """Call ``inner.run_code`` and, on a cube gateway 502, re-raise with a
+    more actionable hint. The e2b SDK wraps 502 responses as a generic
+    ``TimeoutException`` with a misleading "sandbox timeout" message; for
+    cube deployments that usually means the sandbox was evicted / deleted,
+    not that the request timed out.
+    """
+    try:
+        return await inner.run_code(code, **kwargs)
+    except Exception as e:
+        msg = str(e)
+        if "502" in msg or "Bad Gateway" in msg or "openresty" in msg:
+            raise RuntimeError(
+                "run_code hit a 502 Bad Gateway from cube's gateway. "
+                "On cube this most commonly means the sandbox was evicted "
+                "(deleted or paused) before the call landed, even though "
+                "envd/session.exec may still look alive. "
+                "Double-check: sandbox `timeout=` is large enough for the "
+                "full run; nothing is calling .kill() / .pause() early; "
+                "and your cube cluster isn't evicting on idle."
+            ) from e
+        raise
+
+
+async def _wait_for_jupyter_ready(
+    session: Any,
+    *,
+    attempts: int = 10,
+    interval_s: float = 0.5,
+) -> None:
+    """Confirm the code-interpreter gateway is up and answering HTTP INSIDE
+    the sandbox before letting ``run_code`` touch it through the cube
+    gateway.
+
+    We intentionally don't probe the cube public URL ourselves — an
+    unauthenticated GET wouldn't carry the ``X-Access-Token`` /
+    ``E2B-Traffic-Access-Token`` headers the SDK sends, and might be
+    rejected by the gateway for that reason alone, producing a false
+    positive. If ``run_code`` subsequently 502s despite this probe
+    passing, the most likely cause is cube having evicted/deleted the
+    sandbox (despite envd still looking alive).
+    """
+    ok, detail = await _probe_jupyter_internal(
+        session, attempts=attempts, interval_s=interval_s,
+    )
+    if not ok:
+        raise RuntimeError(
+            f"code-interpreter gateway on 127.0.0.1:{_JUPYTER_PORT} inside "
+            f"the sandbox is not answering HTTP after {attempts} attempts "
+            f"(last probe: {detail}). "
+            "Either code-interpreter did not start (check the template's "
+            "boot script / supervisord config) or the jupyter process is "
+            "wedged."
+        )
+    print(f"[python] code-interpreter ready: {detail}", flush=True)
+
+
+def _find_code_interpreter_sandbox(session: Any, *, max_depth: int = 4) -> Any | None:
+    """Locate the underlying `e2b_code_interpreter.AsyncSandbox` on the session.
+
+    Different openai-agents versions stack several wrappers before the raw
+    sandbox:
+        SandboxSession._inner -> E2BSandboxSession._sandbox -> AsyncSandbox
+
+    So we BFS through a handful of known attribute names (and any object
+    attributes from __dict__) looking for something that exposes a callable
+    `run_code`. Limited to `max_depth` to avoid pathological cycles.
+    """
+    if session is None:
+        return None
+
+    preferred = ("_sandbox", "sandbox", "_inner", "inner", "_client", "_e2b_sandbox")
+
+    queue: list[tuple[Any, int]] = [(session, 0)]
+    seen: set[int] = {id(session)}
+
+    while queue:
+        obj, depth = queue.pop(0)
+
+        fn = getattr(obj, "run_code", None)
+        if callable(fn) and obj is not session:
+            return obj
+
+        if depth >= max_depth:
+            continue
+
+        next_objs: list[Any] = []
+        for name in preferred:
+            child = getattr(obj, name, None)
+            if child is not None:
+                next_objs.append(child)
+
+        try:
+            next_objs.extend(vars(obj).values())
+        except TypeError:
+            pass
+
+        for child in next_objs:
+            if child is None or id(child) in seen:
+                continue
+            if isinstance(child, (str, bytes, int, float, bool)) or child is type(None):
+                continue
+            seen.add(id(child))
+            queue.append((child, depth + 1))
+
+    return None
+
+
+class PythonRunner(Capability):
+    """Run Python in the sandbox's Jupyter kernel and capture rich outputs.
+
+    Uses ``e2b_code_interpreter.AsyncSandbox.run_code``, which we locate on
+    the ``SandboxSession`` via :func:`_find_code_interpreter_sandbox` (BFS
+    over the SDK's wrapper layers). The kernel is long-lived for the
+    session, so subsequent calls share state.
+
+    Image results returned by the kernel (e.g. matplotlib plots rendered by a
+    bare ``plt.show()`` / last-line ``fig`` cell output) are decoded from
+    base64 and written to ``output/figure_<n>.<ext>`` in the workspace.
+    """
+
+    def __init__(self) -> None:
+        super().__init__(type="python_runner")
+        self._figure_counter = 0
+        self._kernel_bootstrapped = False
+
+    async def instructions(self, manifest: Manifest) -> str | None:
+        entries = sorted((manifest.entries or {}).keys())
+        seeded = ", ".join(f"`{e}`" for e in entries) if entries else "(none)"
+        return dedent(
+            f"""
+            Call `run_python(code=..., timeout_s=60)` to execute Python.
+            - A stateful Jupyter kernel is used: variables, imports, and
+              dataframes persist across calls. Feel free to split work
+              across multiple small cells.
+            - The CWD is the sandbox workspace root and already contains the
+              seeded files: {seeded}. Read them with bare relative paths
+              (e.g. `pd.read_csv("sales.csv")`); do NOT invent prefixes like
+              `./data/`, `/mnt/data/`, `/workspace/`.
+            - pandas / numpy / matplotlib are preinstalled.
+            - For charts, end a cell with `plt.show()` (or leave a Figure as
+              the last expression). The plot is captured automatically and
+              saved to `output/figure_*.png`; no need to call `plt.savefig`.
+            - Print concise summaries; avoid dumping giant tables.
+            """
+        ).strip()
+
+    def tools(self) -> list[Tool]:
+        return [
+            FunctionTool(
+                name="run_python",
+                description=(
+                    "Execute Python in the sandbox's persistent Jupyter kernel "
+                    "and return stdout, stderr, any error traceback, and the "
+                    "names of chart/image files written to `output/`."
+                ),
+                params_json_schema=PythonRunRequest.model_json_schema(),
+                on_invoke_tool=self._invoke,
+            )
+        ]
+
+    async def _invoke(self, _ctx: Any, raw_args: str) -> str:
+        session = self.session
+        if session is None:
+            raise RuntimeError("python_runner is not bound to a sandbox session")
+
+        request = PythonRunRequest.model_validate_json(raw_args)
+
+        # Reach into the underlying e2b_code_interpreter.AsyncSandbox. The
+        # agents-SDK wrapper normalizes to exec/read/write, so we bypass it
+        # here to access run_code() and its Execution result.
+        inner = _find_code_interpreter_sandbox(session)
+        if inner is None:
+            def _describe(obj: Any, depth: int = 0) -> str:
+                if depth > 3 or obj is None:
+                    return f"{type(obj).__name__}"
+                try:
+                    attrs = sorted(vars(obj).keys())
+                except TypeError:
+                    attrs = []
+                parts = [f"{type(obj).__name__}[{','.join(attrs)}]"]
+                for name in ("_inner", "_sandbox", "sandbox"):
+                    nxt = getattr(obj, name, None)
+                    if nxt is not None and nxt is not obj:
+                        parts.append(f"{name}={_describe(nxt, depth + 1)}")
+                return " ".join(parts)
+            raise RuntimeError(
+                "Could not locate an inner sandbox exposing run_code(). "
+                f"session tree: {_describe(session)}. "
+                "Check that sandbox_type=E2BSandboxType.CODE_INTERPRETER and "
+                "that `e2b-code-interpreter` is installed."
+            )
+
+        await session.mkdir(Path("output"), parents=True)
+
+        # One OutputMessage can carry multiple lines (e.g. `print(df.dtypes)`
+        # delivers a single message whose `.line` has embedded newlines), so
+        # split and re-prefix each line to keep the `[python]` tag consistent.
+        def _emit(msg, stream):
+            text = getattr(msg, "line", None)
+            if text is None:
+                text = str(msg)
+            for line in text.splitlines() or [""]:
+                print(f"[python] {line}", file=stream, flush=True)
+
+        def _on_stdout(msg):  # msg: e2b_code_interpreter.OutputMessage
+            _emit(msg, sys.stdout)
+
+        def _on_stderr(msg):
+            _emit(msg, sys.stderr)
+
+        if not self._kernel_bootstrapped:
+            # 1. Make sure Jupyter is up and answering HTTP inside the
+            #    sandbox before run_code touches it through the gateway.
+            await _wait_for_jupyter_ready(session)
+
+            # 2. The Jupyter kernel's default CWD (e.g. /home/user) is not
+            #    guaranteed to match the envd workspace root where Manifest
+            #    files were seeded. Discover the envd CWD via exec("pwd")
+            #    and chdir the kernel there so relative paths like
+            #    "sales.csv" resolve to the seeded file.
+            pwd_res = await session.exec(
+                "sh", "-lc", "pwd", shell=False, timeout=10,
+            )
+            ws_root = pwd_res.stdout.decode("utf-8", errors="replace").strip() or "/"
+            boot = f"import os as _os\n_os.chdir({ws_root!r})\n"
+            await _run_code_annotated(inner, boot, timeout=10)
+            print(f"[python] bootstrapped kernel cwd -> {ws_root}", flush=True)
+            self._kernel_bootstrapped = True
+
+        print(f"[python] running {len(request.code)} bytes in kernel", flush=True)
+
+        execution = await _run_code_annotated(
+            inner,
+            request.code,
+            on_stdout=_on_stdout,
+            on_stderr=_on_stderr,
+            timeout=request.timeout_s,
+        )
+
+        saved_files: list[str] = []
+        for idx, result in enumerate(execution.results):
+            for kind, ext in _IMAGE_KINDS:
+                encoded = getattr(result, kind, None)
+                if not encoded:
+                    continue
+                self._figure_counter += 1
+                rel_path = Path(f"output/figure_{self._figure_counter:02d}.{ext}")
+                try:
+                    if kind == "svg":
+                        blob = encoded.encode("utf-8")
+                    else:
+                        blob = base64.b64decode(encoded)
+                except (ValueError, TypeError, base64.binascii.Error):
+                    continue
+                await session.write(rel_path, io.BytesIO(blob))
+                saved_files.append(str(rel_path))
+                print(f"[python] saved {rel_path} ({len(blob)} bytes)", flush=True)
+                # one image per result is enough; don't write png+jpeg of the same plot
+                break
+
+        err_payload: dict[str, str] | None = None
+        if execution.error is not None:
+            err_payload = {
+                "name": execution.error.name,
+                "value": execution.error.value,
+                "traceback": execution.error.traceback[-2000:],
+            }
+            print(f"[python] error: {execution.error.name}: {execution.error.value}", flush=True)
+        else:
+            print("[python] (ok)", flush=True)
+
+        stdout_tail = "".join(execution.logs.stdout)[-4000:]
+        stderr_tail = "".join(execution.logs.stderr)[-4000:]
+        text_result = execution.text  # last-expression text repr, if any
+
+        payload = {
+            "ok": execution.error is None,
+            "stdout_tail": stdout_tail,
+            "stderr_tail": stderr_tail,
+            "text_result": text_result,
+            "saved_figures": saved_files,
+            "error": err_payload,
+        }
+        return json.dumps(payload, ensure_ascii=False)
+
+
+# ---------------------------------------------------------------------------
+# Manifest / env / model
+# ---------------------------------------------------------------------------
+def build_manifest() -> Manifest:
+    return Manifest(
+        entries={
+            "sales.csv": File(content=SALES_CSV.encode("utf-8")),
+            "README.md": File(
+                content=(
+                    b"# Sales review\n\n"
+                    b"`sales.csv` has 4 months of per-product sales.\n"
+                    b"Use run_python to compute revenue and plot the monthly trend.\n"
+                )
+            ),
+        }
+    )
+
+
+def load_env():
+    load_dotenv()
+    if os.environ.get("TOKENHUB_API_KEY") and not os.environ.get("OPENAI_API_KEY"):
+        os.environ["OPENAI_API_KEY"] = os.environ["TOKENHUB_API_KEY"]
+    if not os.environ.get("OPENAI_BASE_URL"):
+        os.environ["OPENAI_BASE_URL"] = "https://tokenhub.tencentmaas.com/v1"
+
+    for key in ("OPENAI_API_KEY", "E2B_API_KEY", "E2B_API_URL"):
+        if not os.environ.get(key):
+            raise SystemExit(f"Missing env var: {key}")
+
+    cube_ssl = os.environ.get("CUBE_SSL_CERT_FILE")
+    if cube_ssl and os.path.isfile(cube_ssl):
+        os.environ["SSL_CERT_FILE"] = cube_ssl
+
+
+def make_model(model_name: str) -> OpenAIChatCompletionsModel:
+    """TokenHub only supports Chat Completions API, not the Responses API.
+
+    Force the LLM http client to use the system CA bundle so that SSL_CERT_FILE
+    (set for cube gRPC) doesn't break TokenHub HTTPS calls.
+    """
+    import ssl
+    ssl_ctx = ssl.create_default_context()
+    client = AsyncOpenAI(
+        timeout=httpx.Timeout(120, connect=15),
+        http_client=httpx.AsyncClient(verify=ssl_ctx),
+    )
+    bare = model_name.split("/", 1)[-1] if "/" in model_name else model_name
+    return OpenAIChatCompletionsModel(model=bare, openai_client=client)
+
+
+# ---------------------------------------------------------------------------
+# Run
+# ---------------------------------------------------------------------------
+SYSTEM_INSTRUCTIONS = (
+    "You are a data analyst working inside a stateful Python kernel.\n"
+    "- Use `run_python` for computation and plotting. Variables persist across "
+    "calls, so you can build up the analysis step by step.\n"
+    "- Use `shell` only for quick inspection (`ls`, `cat`, `head`).\n"
+    "- pandas / numpy / matplotlib are preinstalled; no installs needed.\n"
+    "- For charts, call `plt.show()` at the end of the cell — the figure is "
+    "captured automatically and saved to `output/figure_*.png`.\n"
+    "- Cite file names you actually read and include any files you produced."
+)
+
+
+async def main(
+    *,
+    model: str,
+    question: str,
+    template: str,
+    timeout: int,
+    pause_on_exit: bool,
+) -> None:
+    print(f"Model:    {model}")
+    print(f"Template: {template}")
+    print(f"CubeAPI:  {os.environ['E2B_API_URL']}")
+    print(f"Question: {question}\n")
+
+    agent = SandboxAgent(
+        name="Cube Code Interpreter Analyst (kernel)",
+        model=make_model(model),
+        instructions=SYSTEM_INSTRUCTIONS,
+        default_manifest=build_manifest(),
+        capabilities=[WorkspaceShell(), PythonRunner()],
+        model_settings=ModelSettings(tool_choice="auto"),
+    )
+
+    run_config = RunConfig(
+        sandbox=SandboxRunConfig(
+            client=E2BSandboxClient(),
+            options=E2BSandboxClientOptions(
+                sandbox_type=E2BSandboxType.CODE_INTERPRETER,
+                template=template,
+                timeout=timeout,
+                pause_on_exit=pause_on_exit,
+            ),
+        ),
+        workflow_name="Cube code interpreter demo (kernel)",
+    )
+
+    print("Creating sandbox & running agent ...")
+    result = await Runner.run(agent, question, run_config=run_config)
+    print("=" * 64)
+    print(result.final_output)
+    print("=" * 64)
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--model", default="openai/glm-5.1",
+                        help="LLM name (TokenHub models use 'openai/' prefix).")
+    parser.add_argument("--question", default=DEFAULT_QUESTION,
+                        help="Prompt to send to the agent.")
+    parser.add_argument("--template", default=None,
+                        help="Cube template ID (or set CUBE_TEMPLATE_ID).")
+    parser.add_argument("--timeout", type=int, default=600,
+                        help="Sandbox lifetime timeout in seconds.")
+    parser.add_argument("--pause-on-exit", action="store_true", default=False,
+                        help="Pause (not kill) the sandbox on shutdown, for later resume.")
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    args = _parse_args()
+    load_env()
+    template = args.template or os.environ.get("CUBE_TEMPLATE_ID")
+    if not template:
+        raise SystemExit("Missing template: set CUBE_TEMPLATE_ID or pass --template")
+
+    asyncio.run(
+        main(
+            model=args.model,
+            question=args.question,
+            template=template,
+            timeout=args.timeout,
+            pause_on_exit=args.pause_on_exit,
+        )
+    )

--- a/examples/openai-agents-code-interpreter/requirements.txt
+++ b/examples/openai-agents-code-interpreter/requirements.txt
@@ -1,0 +1,4 @@
+openai-agents[e2b]
+e2b-code-interpreter
+python-dotenv
+pydantic

--- a/examples/openai-agents-example/.env.example
+++ b/examples/openai-agents-example/.env.example
@@ -1,0 +1,15 @@
+# TokenHub API (OpenAI-compatible, used as LLM backend)
+TOKENHUB_API_KEY="<your-tokenhub-api-key>"
+# Or set OPENAI_API_KEY + OPENAI_BASE_URL directly:
+# OPENAI_API_KEY="<your-api-key>"
+# OPENAI_BASE_URL="https://tokenhub.tencentmaas.com/v1"
+
+# cube-sandbox (E2B compatible) connection
+E2B_API_URL="http://<your-cube-sandbox-ip>:3000"
+E2B_API_KEY="<your-e2b-api-key>"
+
+# SWE-bench Django template ID (created via cubemastercli)
+CUBE_TEMPLATE_ID="<your-template-id>"
+
+# SSL cert for self-hosted cube-sandbox (optional)
+# CUBE_SSL_CERT_FILE="/etc/pki/tls/cert.pem"

--- a/examples/openai-agents-example/README.md
+++ b/examples/openai-agents-example/README.md
@@ -1,0 +1,222 @@
+# OpenAI Agents SDK + CubeSandbox Example
+
+[中文文档](README_zh.md)
+
+This directory contains two example scripts showing how to connect the OpenAI Agents SDK's `E2BSandboxClient` to [CubeSandbox](https://github.com/TencentCloud/CubeSandbox).
+
+| Script | Scenario | Description |
+|--------|----------|-------------|
+| [`simple_demo.py`](simple_demo.py) | Quick start | Minimal Shell Agent + Pause/Resume demo |
+| [`main.py`](main.py) | SWE-bench debugging | Full streaming output + LLM preflight + end-to-end tracing |
+
+## Prerequisites
+
+- Python 3.10+
+- CubeSandbox platform deployed and CubeAPI reachable
+- A sandbox template created (see "Create a sandbox template" below)
+- An API key for TokenHub or any OpenAI-compatible LLM service
+
+## Quick Start
+
+### 1. Install dependencies
+
+```bash
+pip install -r requirements.txt
+```
+
+### 2. Configure environment variables
+
+```bash
+cp .env.example .env
+```
+
+Edit `.env`:
+
+| Variable | Description |
+|----------|-------------|
+| `TOKENHUB_API_KEY` | TokenHub API key (automatically mapped to `OPENAI_API_KEY`) |
+| `OPENAI_BASE_URL` | LLM endpoint (defaults to `https://tokenhub.tencentmaas.com/v1`) |
+| `E2B_API_URL` | CubeAPI URL, e.g. `http://<cube-host>:3000` |
+| `E2B_API_KEY` | CubeAPI auth key |
+| `CUBE_TEMPLATE_ID` | Sandbox template ID |
+| `CUBE_SSL_CERT_FILE` | (Optional) path to the CubeSandbox CA bundle |
+
+### 3. Create a sandbox template
+
+**simple_demo.py** works with any Linux template. **main.py** requires a SWE-bench image with the Django source code preinstalled:
+
+```bash
+cubemastercli tpl create-from-image \
+  --image cube-sandbox-image.tencentcloudcr.com/demo/django_1776_django-13447:latest \
+  --writable-layer-size 1G \
+  --expose-port 49983 \
+  --cpu 4000 --memory 8192 \
+  --probe 49983
+```
+
+Copy the template ID from the output into `CUBE_TEMPLATE_ID` in your `.env`.
+
+---
+
+## simple_demo.py — Minimal Example
+
+A minimal Shell Agent that demonstrates the core steps of integrating with CubeSandbox.
+
+### Usage
+
+```bash
+# Basic Agent Q&A
+python simple_demo.py
+python simple_demo.py --question "What Linux distro is this?"
+
+# Pause / Resume demo (write file → pause → resume → verify file)
+python simple_demo.py --pause-resume
+
+# SSL debug modes
+python simple_demo.py --no-ssl-patch        # Disable all SSL customisations
+python simple_demo.py --llm-cube-ssl        # Let LLM use the cube CA as well
+```
+
+### Arguments
+
+| Argument | Default | Description |
+|----------|---------|-------------|
+| `--model` | `openai/glm-5.1` | LLM model name |
+| `--question` | Check OS version | Prompt sent to the Agent |
+| `--template` | `CUBE_TEMPLATE_ID` | Sandbox template ID |
+| `--timeout` | `300` | Sandbox timeout (seconds) |
+| `--pause-resume` | — | Switch to Pause/Resume demo mode |
+| `--no-ssl-patch` | — | Disable SSL customisations |
+| `--llm-cube-ssl` | — | Make the LLM client also use the cube CA |
+
+### Core code
+
+```python
+agent = SandboxAgent(
+    name="Cube Demo Agent",
+    model=make_model("openai/glm-5.1"),
+    instructions="You are a helpful assistant running inside a cloud sandbox.",
+    default_manifest=Manifest(),
+    capabilities=[Shell()],
+)
+
+run_config = RunConfig(
+    sandbox=SandboxRunConfig(
+        client=E2BSandboxClient(),
+        options=E2BSandboxClientOptions(
+            sandbox_type=E2BSandboxType.E2B,
+            template=os.environ["CUBE_TEMPLATE_ID"],
+            timeout=300,
+        ),
+    ),
+)
+
+result = await Runner.run(agent, "What OS is running?", run_config=run_config)
+```
+
+### Pause/Resume flow
+
+```
+[step 1] Create sandbox
+[step 2] Write marker file pause-resume-test.txt
+[step 3] Pause sandbox (stop + shutdown, pause_on_exit=True)
+[step 4] Resume sandbox (client.resume)
+[step 5] Read the file and compare contents → PASS / FAIL
+[cleanup] Destroy sandbox
+```
+
+---
+
+## main.py — SWE-bench Django Debugging
+
+A full SWE-bench Agent that autonomously analyses a Django bug inside the sandbox and proposes a fix. Ships with an LLM preflight, streaming output, and end-to-end tracing.
+
+### Usage
+
+```bash
+# Analyse the Django bug (django__django-13447)
+python main.py
+
+# Custom question
+python main.py --question "What Python version is installed? Show the Django version too."
+
+# Specify model
+python main.py --model openai/deepseek-v3.2
+
+# Only test sandbox connectivity (do not call the LLM)
+python main.py --sandbox-only
+python main.py --sandbox-only --timeout 60
+
+# Limit tool-call turns
+python main.py --max-turns 20
+```
+
+### Arguments
+
+| Argument | Default | Description |
+|----------|---------|-------------|
+| `--model` | `openai/glm-5.1` | LLM model name (TokenHub uses the `openai/` prefix) |
+| `--question` | Analyse and fix the bug | Prompt sent to the Agent |
+| `--template` | `CUBE_TEMPLATE_ID` | SWE-bench Django template ID |
+| `--timeout` | `300` | Sandbox timeout (seconds) |
+| `--max-turns` | `50` | Maximum tool-call turns |
+| `--sandbox-only` | — | Only create/destroy the sandbox to verify connectivity |
+
+### Built-in features
+
+**LLM preflight**: Before the real run, validates LLM connectivity (plain text → tool-calling → streaming, three tests).
+
+**Streaming output**: Live-prints each step of the Agent:
+
+```
+[preflight] 1/3 plain ok — glm-5.1 @ https://tokenhub.tencentmaas.com/v1/  856 ms
+[preflight] 2/3 tool-call ok — 1204 ms: get_info({"cmd":"uname"})
+[preflight] 3/3 streaming ok — 623 ms, 12 chunks
+[status] creating sandbox & starting session ...
+[agent] SWE-bench Agent running
+[step 1] tool_call: exec_command({"cmd": "cat /testbed/django/contrib/admin/..."})
+  → output: ...
+[step 2] tool_call: exec_command({"cmd": "grep -n 'items_for_result' ..."})
+  → output: ...
+[answer] The bug is in the `items_for_result` function ...
+[done] 8 tool calls, 42350 ms total
+```
+
+**End-to-end tracing**: Automatically records the E2B lifecycle (create/start/exec/shutdown) and the LLM calls (HTTP request/response, time to first token).
+
+**Hang-guard timeout**: If no new event is observed for 30 seconds after the LLM answers, the run exits automatically — this prevents the Runner's internal finalisation from hanging forever.
+
+### About the SWE-bench scenario
+
+The default task is `django__django-13447`:
+
+> When `ModelAdmin` sets `list_display_links = None`, the Django admin still renders the first field as a link (it should render as plain text).
+
+The Agent will:
+1. Locate the `items_for_result` function in `/testbed/django/contrib/admin/templatetags/admin_list.py`
+2. Analyse the root cause
+3. Propose a fix
+
+The sandbox template image contains the full Django source code under `/testbed`.
+
+---
+
+## CubeSandbox Adaptations
+
+Both scripts include the following runtime patches:
+
+| Patch | Reason |
+|-------|--------|
+| `default_username = "root"` + Filesystem method wrappers | CubeSandbox envd only serves the `root` user |
+| `Commands.run` strips the `stdin` argument | Compatibility with older envd versions |
+| LLM client uses the system CA bundle | Prevents `SSL_CERT_FILE` (cube gRPC) from contaminating TokenHub HTTPS |
+| Force `OpenAIChatCompletionsModel` | TokenHub does not support the Responses API |
+
+See the [Integration Guide](openai-agents-sandbox-cube-integration.md) for details.
+
+## Related Documents
+
+- [OpenAI Agents SDK × CubeSandbox Integration Guide](openai-agents-sandbox-cube-integration.md)
+- [OpenAI Sandbox Agents Concepts](openai-agents.md)
+- [OpenAI Agents SDK on GitHub](https://github.com/openai/openai-agents-python)
+- [CubeSandbox](https://github.com/TencentCloud/CubeSandbox)

--- a/examples/openai-agents-example/README_zh.md
+++ b/examples/openai-agents-example/README_zh.md
@@ -1,0 +1,222 @@
+# OpenAI Agents SDK + CubeSandbox 示例
+
+[English](README.md)
+
+本目录包含两个示例脚本，演示如何通过 OpenAI Agents SDK 的 `E2BSandboxClient` 对接 [CubeSandbox](https://github.com/TencentCloud/CubeSandbox)。
+
+| 脚本 | 场景 | 说明 |
+|------|------|------|
+| [`simple_demo.py`](simple_demo.py) | 快速上手 | 最简 Shell Agent + Pause/Resume 演示 |
+| [`main.py`](main.py) | SWE-bench 调试 | 完整流式输出 + LLM 预检 + 全链路追踪 |
+
+## 前置条件
+
+- Python 3.10+
+- CubeSandbox 平台已部署，CubeAPI 可访问
+- 已创建沙箱模板（见下方「模板创建」）
+- TokenHub 或其他 OpenAI 兼容 LLM 服务的 API Key
+
+## 快速开始
+
+### 1. 安装依赖
+
+```bash
+pip install -r requirements.txt
+```
+
+### 2. 配置环境变量
+
+```bash
+cp .env.example .env
+```
+
+编辑 `.env`：
+
+| 变量 | 说明 |
+|------|------|
+| `TOKENHUB_API_KEY` | TokenHub API Key（自动映射为 `OPENAI_API_KEY`） |
+| `OPENAI_BASE_URL` | LLM 地址（默认 `https://tokenhub.tencentmaas.com/v1`） |
+| `E2B_API_URL` | CubeAPI 地址，如 `http://<cube-host>:3000` |
+| `E2B_API_KEY` | CubeAPI 鉴权 Key |
+| `CUBE_TEMPLATE_ID` | 沙箱模板 ID |
+| `CUBE_SSL_CERT_FILE` | （可选）CubeSandbox CA 证书路径 |
+
+### 3. 创建沙箱模板
+
+**simple_demo.py** 可用任意 Linux 模板。**main.py** 需要预装 Django 源码的 SWE-bench 镜像：
+
+```bash
+cubemastercli tpl create-from-image \
+  --image cube-sandbox-image.tencentcloudcr.com/demo/django_1776_django-13447:latest \
+  --writable-layer-size 1G \
+  --expose-port 49983 \
+  --cpu 4000 --memory 8192 \
+  --probe 49983
+```
+
+命令输出中的模板 ID 填入 `.env` 的 `CUBE_TEMPLATE_ID`。
+
+---
+
+## simple_demo.py — 最简示例
+
+最小化的 Shell Agent，展示 CubeSandbox 集成的核心步骤。
+
+### 用法
+
+```bash
+# 基础 Agent 问答
+python simple_demo.py
+python simple_demo.py --question "What Linux distro is this?"
+
+# Pause / Resume 演示（写入文件 → 暂停 → 恢复 → 验证文件）
+python simple_demo.py --pause-resume
+
+# SSL 调试模式
+python simple_demo.py --no-ssl-patch        # 禁用所有 SSL 自定义
+python simple_demo.py --llm-cube-ssl        # LLM 也用 cube 的证书
+```
+
+### 参数
+
+| 参数 | 默认值 | 说明 |
+|------|--------|------|
+| `--model` | `openai/glm-5.1` | LLM 模型名 |
+| `--question` | 查看 OS 版本 | 发送给 Agent 的问题 |
+| `--template` | `CUBE_TEMPLATE_ID` | 沙箱模板 ID |
+| `--timeout` | `300` | 沙箱超时（秒） |
+| `--pause-resume` | — | 切换到 Pause/Resume 演示模式 |
+| `--no-ssl-patch` | — | 禁用 SSL 自定义处理 |
+| `--llm-cube-ssl` | — | LLM 客户端也使用 cube 证书 |
+
+### 核心代码
+
+```python
+agent = SandboxAgent(
+    name="Cube Demo Agent",
+    model=make_model("openai/glm-5.1"),
+    instructions="You are a helpful assistant running inside a cloud sandbox.",
+    default_manifest=Manifest(),
+    capabilities=[Shell()],
+)
+
+run_config = RunConfig(
+    sandbox=SandboxRunConfig(
+        client=E2BSandboxClient(),
+        options=E2BSandboxClientOptions(
+            sandbox_type=E2BSandboxType.E2B,
+            template=os.environ["CUBE_TEMPLATE_ID"],
+            timeout=300,
+        ),
+    ),
+)
+
+result = await Runner.run(agent, "What OS is running?", run_config=run_config)
+```
+
+### Pause/Resume 流程
+
+```
+[step 1] 创建沙箱
+[step 2] 写入标记文件 pause-resume-test.txt
+[step 3] 暂停沙箱（stop + shutdown, pause_on_exit=True）
+[step 4] 恢复沙箱（client.resume）
+[step 5] 读取文件，验证内容一致 → PASS / FAIL
+[cleanup] 销毁沙箱
+```
+
+---
+
+## main.py — SWE-bench Django 调试
+
+完整的 SWE-bench Agent，在沙箱中自主分析 Django Bug 并提出修复方案。包含 LLM 预检、流式输出、全链路追踪。
+
+### 用法
+
+```bash
+# 分析 Django Bug（django__django-13447）
+python main.py
+
+# 自定义问题
+python main.py --question "What Python version is installed? Show the Django version too."
+
+# 指定模型
+python main.py --model openai/deepseek-v3.2
+
+# 仅测试沙箱连通性（不调用 LLM）
+python main.py --sandbox-only
+python main.py --sandbox-only --timeout 60
+
+# 限制工具调用轮数
+python main.py --max-turns 20
+```
+
+### 参数
+
+| 参数 | 默认值 | 说明 |
+|------|--------|------|
+| `--model` | `openai/glm-5.1` | LLM 模型名（TokenHub 用 `openai/` 前缀） |
+| `--question` | 分析 Bug 并修复 | 发送给 Agent 的问题 |
+| `--template` | `CUBE_TEMPLATE_ID` | SWE-bench Django 模板 ID |
+| `--timeout` | `300` | 沙箱超时（秒） |
+| `--max-turns` | `50` | 最大工具调用轮数 |
+| `--sandbox-only` | — | 仅创建/销毁沙箱，验证连通性 |
+
+### 内置功能
+
+**LLM 预检**：正式运行前验证 LLM 连通性（纯文本 → tool-calling → streaming 三项测试）。
+
+**流式输出**：实时打印 Agent 的每一步操作：
+
+```
+[preflight] 1/3 plain ok — glm-5.1 @ https://tokenhub.tencentmaas.com/v1/  856 ms
+[preflight] 2/3 tool-call ok — 1204 ms: get_info({"cmd":"uname"})
+[preflight] 3/3 streaming ok — 623 ms, 12 chunks
+[status] creating sandbox & starting session ...
+[agent] SWE-bench Agent running
+[step 1] tool_call: exec_command({"cmd": "cat /testbed/django/contrib/admin/..."})
+  → output: ...
+[step 2] tool_call: exec_command({"cmd": "grep -n 'items_for_result' ..."})
+  → output: ...
+[answer] The bug is in the `items_for_result` function ...
+[done] 8 tool calls, 42350 ms total
+```
+
+**全链路追踪**：自动记录 E2B 生命周期（create/start/exec/shutdown）和 LLM 调用（HTTP 请求/响应、首个 token 延迟）的耗时。
+
+**防挂超时**：LLM 回答后 30 秒无新事件自动退出，避免 Runner 内部 finalization 导致无限挂起。
+
+### SWE-bench 场景说明
+
+默认任务是 `django__django-13447`：
+
+> 当 `ModelAdmin` 设置 `list_display_links = None` 时，Django admin 仍然为第一个字段生成链接（应该显示为纯文本）。
+
+Agent 会：
+1. 在 `/testbed/django/contrib/admin/templatetags/admin_list.py` 中定位 `items_for_result` 函数
+2. 分析 Bug 根因
+3. 提出修复方案
+
+沙箱模板镜像中 `/testbed` 包含完整的 Django 源码。
+
+---
+
+## CubeSandbox 适配
+
+两个脚本都包含以下运行时补丁：
+
+| 补丁 | 原因 |
+|------|------|
+| `default_username = "root"` + Filesystem 方法包装 | CubeSandbox envd 只服务 `root` 用户 |
+| `Commands.run` 移除 `stdin` 参数 | 兼容老版本 envd |
+| LLM 客户端使用系统 CA bundle | 避免 `SSL_CERT_FILE`（cube gRPC）污染 TokenHub HTTPS |
+| 强制使用 `OpenAIChatCompletionsModel` | TokenHub 不支持 Responses API |
+
+详细说明见 [集成指南](openai-agents-sandbox-cube-integration_zh.md)。
+
+## 相关文档
+
+- [OpenAI Agents SDK × CubeSandbox 集成指南](openai-agents-sandbox-cube-integration_zh.md)
+- [OpenAI Sandbox Agents 概念解析](openai-agents_zh.md)
+- [OpenAI Agents SDK GitHub](https://github.com/openai/openai-agents-python)
+- [CubeSandbox](https://github.com/TencentCloud/CubeSandbox)

--- a/examples/openai-agents-example/main.py
+++ b/examples/openai-agents-example/main.py
@@ -1,0 +1,569 @@
+"""
+OpenAI Agents SDK + E2B + Cube Sandbox example.
+
+Uses E2BSandboxClient to run a SandboxAgent inside a cube-sandbox instance
+with a SWE-bench Django image. The agent explores the Django codebase,
+analyzes a bug, and proposes a fix.
+
+LLM API uses TokenHub (OpenAI-compatible).
+The sandbox template is built from:
+  cube-sandbox-image.tencentcloudcr.com/demo/django_1776_django-13447:latest
+
+Usage:
+    cp .env.example .env   # fill in real values
+    pip install -r requirements.txt
+    python main.py
+    python main.py --question "What Python version is installed?"
+    python main.py --model openai/glm-5.1
+    python main.py --sandbox-only              # just create & destroy sandbox
+    python main.py --sandbox-only --timeout 60 # with custom timeout
+"""
+
+import argparse
+import asyncio
+import functools
+import os
+import time
+
+os.environ.setdefault("OPENAI_AGENTS_DISABLE_TRACING", "1")
+
+from dotenv import load_dotenv
+
+# ---------------------------------------------------------------------------
+# cube-sandbox envd compatibility patches:
+# 1. envd only supports "root" user; E2B SDK defaults to "user"
+# 2. envd 0.2.0 doesn't support the `stdin` kwarg in commands.run()
+# ---------------------------------------------------------------------------
+import e2b.envd.rpc as _e2b_rpc  # noqa: E402
+from e2b.sandbox_async.filesystem.filesystem import Filesystem as _AsyncFS  # noqa: E402
+from e2b.sandbox_async.commands.command import Commands as _AsyncCommands  # noqa: E402
+
+_e2b_rpc.default_username = "root"
+
+import inspect as _inspect
+
+for _name in ("read", "write", "write_files", "list", "exists",
+              "get_info", "remove", "rename", "make_dir", "watch_dir"):
+    _orig = getattr(_AsyncFS, _name, None)
+    if _orig is None:
+        continue
+    _params = list(_inspect.signature(_orig).parameters.keys())
+    _user_pos = _params.index("user") - 1 if "user" in _params else None  # -1 for self
+
+    def _make(fn, user_pos=_user_pos):  # noqa: E301
+        @functools.wraps(fn)
+        async def _wrapper(self, *a, **kw):
+            if user_pos is not None and len(a) > user_pos:
+                a = list(a)
+                if a[user_pos] is None:
+                    a[user_pos] = "root"
+                a = tuple(a)
+            else:
+                kw.setdefault("user", "root")
+            return await fn(self, *a, **kw)
+        return _wrapper
+
+    setattr(_AsyncFS, _name, _make(_orig))
+
+_orig_commands_run = _AsyncCommands.run
+
+@functools.wraps(_orig_commands_run)
+async def _patched_commands_run(self, *a, **kw):
+    if hasattr(self, "_envd_version"):
+        from e2b.sandbox_async.commands.command import ENVD_COMMANDS_STDIN
+        if self._envd_version < ENVD_COMMANDS_STDIN:
+            kw.pop("stdin", None)
+    return await _orig_commands_run(self, *a, **kw)
+
+_AsyncCommands.run = _patched_commands_run
+# ---------------------------------------------------------------------------
+
+from agents import ModelSettings, Runner, set_tracing_disabled
+
+set_tracing_disabled(True)
+
+from openai import AsyncOpenAI
+from agents.models.openai_chatcompletions import OpenAIChatCompletionsModel
+from agents.run import RunConfig
+from agents.sandbox import Manifest, SandboxAgent, SandboxRunConfig
+from agents.sandbox.capabilities import Shell
+from agents.extensions.sandbox import (
+    E2BSandboxClient,
+    E2BSandboxClientOptions,
+    E2BSandboxType,
+)
+
+# ---------------------------------------------------------------------------
+# Wrap E2BSandboxClient lifecycle methods to log timing
+# ---------------------------------------------------------------------------
+_orig_e2b_create = E2BSandboxClient.create
+_orig_e2b_session_cls = None
+
+async def _traced_create(self, *, options, manifest, **kw):
+    print(f"  [e2b] create() called, template={getattr(options, 'template', '?')}", flush=True)
+    t0 = time.monotonic()
+    session = await _orig_e2b_create(self, options=options, manifest=manifest, **kw)
+    ms = (time.monotonic() - t0) * 1000
+    print(f"  [e2b] create() done in {ms:.0f} ms", flush=True)
+
+    # Wrap all session lifecycle methods
+    def _wrap(name):
+        orig = getattr(session, name)
+        async def _traced(*a, **k):
+            print(f"  [e2b] session.{name}() ...", flush=True)
+            t = time.monotonic()
+            try:
+                r = await orig(*a, **k)
+                print(f"  [e2b] session.{name}() done in {(time.monotonic()-t)*1000:.0f} ms", flush=True)
+                return r
+            except Exception as e:
+                print(f"  [e2b] session.{name}() FAILED in {(time.monotonic()-t)*1000:.0f} ms: {e}", flush=True)
+                raise
+        setattr(session, name, _traced)
+
+    for _m in ("start", "exec", "stop", "shutdown", "running",
+               "run_pre_stop_hooks"):
+        if hasattr(session, _m):
+            _wrap(_m)
+    return session
+
+E2BSandboxClient.create = _traced_create
+
+# Wrap OpenAIChatCompletionsModel to trace LLM calls.
+# stream_response is an ASYNC GENERATOR (yields events), not a regular coroutine.
+_orig_stream_response = OpenAIChatCompletionsModel.stream_response
+
+async def _traced_stream_response(self, *a, **kw):
+    print("  [model] stream_response() called ...", flush=True)
+    t0 = time.monotonic()
+    first_event = True
+    try:
+        async for event in _orig_stream_response(self, *a, **kw):
+            if first_event:
+                ms = (time.monotonic() - t0) * 1000
+                print(f"  [model] first event in {ms:.0f} ms", flush=True)
+                first_event = False
+            yield event
+        ms = (time.monotonic() - t0) * 1000
+        print(f"  [model] stream_response() complete ({ms:.0f} ms)", flush=True)
+    except Exception as e:
+        ms = (time.monotonic() - t0) * 1000
+        print(f"  [model] stream_response() FAILED in {ms:.0f} ms: {e}", flush=True)
+        raise
+
+OpenAIChatCompletionsModel.stream_response = _traced_stream_response
+# ---------------------------------------------------------------------------
+
+DJANGO_BUG_DESCRIPTION = """\
+Bug: django__django-13447
+
+When a model admin class has `list_display` containing a field name and a
+`list_display_links` set to `None`, Django should display the fields as
+plain text (not clickable). However, the current behavior still generates
+a link for the first field.
+
+The relevant code is in `django/contrib/admin/templatetags/admin_list.py`,
+specifically in the `items_for_result` function.
+"""
+
+
+def load_env(sandbox_only: bool = False):
+    load_dotenv()
+
+    if os.environ.get("TOKENHUB_API_KEY") and not os.environ.get("OPENAI_API_KEY"):
+        os.environ["OPENAI_API_KEY"] = os.environ["TOKENHUB_API_KEY"]
+    if not os.environ.get("OPENAI_BASE_URL"):
+        os.environ["OPENAI_BASE_URL"] = "https://tokenhub.tencentmaas.com/v1"
+
+    required = ("E2B_API_KEY", "E2B_API_URL")
+    if not sandbox_only:
+        required = ("OPENAI_API_KEY", *required)
+    for key in required:
+        if not os.environ.get(key):
+            raise SystemExit(f"Missing required env var: {key}")
+
+    cube_ssl = os.environ.get("CUBE_SSL_CERT_FILE")
+    if cube_ssl and os.path.isfile(cube_ssl):
+        os.environ["SSL_CERT_FILE"] = cube_ssl
+        print(f"[env] SSL_CERT_FILE={cube_ssl} (for cube-sandbox only)")
+
+
+_req_timers: dict[str, float] = {}
+
+
+def _llm_http_client(**kwargs):
+    """Build an httpx.AsyncClient that ignores CUBE_SSL_CERT_FILE.
+
+    SSL_CERT_FILE is set globally for cube-sandbox gRPC, but TokenHub
+    uses public CAs.  We must NOT let the custom cert break LLM calls.
+    Includes request/response event hooks for debugging.
+    """
+    import httpx
+    import ssl
+    ssl_ctx = ssl.create_default_context()  # system CA bundle
+
+    async def _on_request(request: httpx.Request):
+        _req_timers[str(id(request))] = time.monotonic()
+        body_len = len(request.content) if request.content else 0
+        print(f"  [http] → {request.method} {request.url} ({body_len} bytes)", flush=True)
+
+    async def _on_response(response: httpx.Response):
+        t0 = _req_timers.pop(str(id(response.request)), time.monotonic())
+        ms = (time.monotonic() - t0) * 1000
+        print(f"  [http] ← {response.status_code} ({ms:.0f} ms)", flush=True)
+
+    return httpx.AsyncClient(
+        verify=ssl_ctx,
+        event_hooks={"request": [_on_request], "response": [_on_response]},
+        **kwargs,
+    )
+
+
+def _make_chat_model(model_name: str) -> OpenAIChatCompletionsModel:
+    """Build a Chat Completions model adapter.
+
+    TokenHub (and most OpenAI-compatible providers) only support the
+    Chat Completions API, NOT the Responses API.  When a plain string
+    is passed to SandboxAgent, the SDK defaults to the Responses API
+    (POST /v1/responses) which will hang or 404.
+    """
+    import httpx
+    client = AsyncOpenAI(
+        timeout=httpx.Timeout(120, connect=15),
+        http_client=_llm_http_client(),
+    )
+    bare_name = model_name.split("/", 1)[-1] if "/" in model_name else model_name
+    return OpenAIChatCompletionsModel(model=bare_name, openai_client=client)
+
+
+async def _preflight_llm(model_name: str) -> None:
+    """Verify the LLM is reachable: plain call, then tool-calling + streaming."""
+    import httpx
+    bare = model_name.split("/", 1)[-1] if "/" in model_name else model_name
+    client = AsyncOpenAI(
+        timeout=httpx.Timeout(30, connect=10),
+        http_client=_llm_http_client(),
+    )
+    try:
+        # 1) plain, non-streaming
+        t0 = time.monotonic()
+        resp = await client.chat.completions.create(
+            model=bare,
+            messages=[{"role": "user", "content": "hi"}],
+            max_tokens=5,
+        )
+        ms = (time.monotonic() - t0) * 1000
+        text = resp.choices[0].message.content if resp.choices else "(empty)"
+        print(f"[preflight] 1/3 plain ok — {bare} @ {client.base_url}  {ms:.0f} ms: {text!r}", flush=True)
+
+        # 2) with tools (function calling)
+        test_tools = [{
+            "type": "function",
+            "function": {
+                "name": "get_info",
+                "description": "Get system info",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"cmd": {"type": "string"}},
+                    "required": ["cmd"],
+                },
+            },
+        }]
+        t1 = time.monotonic()
+        resp2 = await client.chat.completions.create(
+            model=bare,
+            messages=[{"role": "user", "content": "Run uname"}],
+            tools=test_tools,
+            max_tokens=50,
+        )
+        ms2 = (time.monotonic() - t1) * 1000
+        choice = resp2.choices[0] if resp2.choices else None
+        if choice and choice.message.tool_calls:
+            tc = choice.message.tool_calls[0]
+            print(f"[preflight] 2/3 tool-call ok — {ms2:.0f} ms: {tc.function.name}({tc.function.arguments})", flush=True)
+        else:
+            text2 = choice.message.content if choice else "(empty)"
+            print(f"[preflight] 2/3 tool-call ok (no tool used) — {ms2:.0f} ms: {text2!r}", flush=True)
+
+        # 3) streaming
+        t2 = time.monotonic()
+        stream = await client.chat.completions.create(
+            model=bare,
+            messages=[{"role": "user", "content": "Say OK"}],
+            max_tokens=5,
+            stream=True,
+        )
+        chunks = 0
+        async for chunk in stream:
+            chunks += 1
+        ms3 = (time.monotonic() - t2) * 1000
+        print(f"[preflight] 3/3 streaming ok — {ms3:.0f} ms, {chunks} chunks", flush=True)
+
+    except Exception as e:
+        ms = (time.monotonic() - t0) * 1000
+        print(f"[preflight] LLM FAILED after {ms:.0f} ms: {e}", flush=True)
+        raise SystemExit(1)
+    finally:
+        await client.close()
+
+
+def build_agent(model: str) -> SandboxAgent:
+    return SandboxAgent(
+        name="SWE-bench Agent",
+        model=_make_chat_model(model),
+        instructions=(
+            "You are a software engineer debugging a Django issue inside a "
+            "cube-sandbox environment. The Django source code is at /testbed.\n\n"
+            f"{DJANGO_BUG_DESCRIPTION}\n"
+            "Your task:\n"
+            "1. Find the `items_for_result` function in "
+            "`django/contrib/admin/templatetags/admin_list.py`.\n"
+            "2. Analyze the bug and explain the root cause.\n"
+            "3. Propose a fix.\n\n"
+            "Use shell commands to explore the codebase, read files, and run tests. "
+            "Be concise and cite the exact file paths and line numbers you inspected."
+        ),
+        default_manifest=Manifest(root="/testbed"),
+        capabilities=[Shell()],
+        model_settings=ModelSettings(tool_choice="auto"),
+    )
+
+
+def build_run_config(template: str | None, timeout: int) -> RunConfig:
+    options = E2BSandboxClientOptions(
+        sandbox_type=E2BSandboxType.E2B,
+        template=template or os.environ.get("CUBE_TEMPLATE_ID"),
+        timeout=timeout,
+        pause_on_exit=False,
+    )
+    return RunConfig(
+        sandbox=SandboxRunConfig(
+            client=E2BSandboxClient(),
+            options=options,
+        ),
+        workflow_name="SWE-bench Django demo",
+    )
+
+
+async def run_sandbox_only(template: str | None, timeout: int) -> None:
+    """Create a sandbox via OpenAI Agents SDK E2BSandboxClient, run a
+    health-check command, then destroy it."""
+    client = E2BSandboxClient()
+    options = E2BSandboxClientOptions(
+        sandbox_type=E2BSandboxType.E2B,
+        template=template or os.environ.get("CUBE_TEMPLATE_ID"),
+        timeout=timeout,
+        pause_on_exit=False,
+    )
+    manifest = Manifest()
+
+    print(f"Creating sandbox via E2BSandboxClient (template={options.template}) ...")
+    t0 = time.monotonic()
+    session = await client.create(options=options, manifest=manifest)
+    create_ms = (time.monotonic() - t0) * 1000
+
+    sandbox_id = getattr(session, "sandbox_id", None) or getattr(
+        getattr(session, "_inner", None), "state", None
+    ) and session._inner.state.sandbox_id
+    print(f"  sandbox_id = {sandbox_id}")
+    print(f"  created in {create_ms:.0f} ms")
+
+    try:
+        t1 = time.monotonic()
+        await session.start()
+        start_ms = (time.monotonic() - t1) * 1000
+        print(f"  session started in {start_ms:.0f} ms (workspace materialized)")
+    except Exception as e:
+        print(f"  session start failed: {e}")
+
+    try:
+        t2 = time.monotonic()
+        result = await session.exec("uname -a && cat /etc/os-release | head -3")
+        exec_ms = (time.monotonic() - t2) * 1000
+        stdout = result.stdout if hasattr(result, "stdout") else str(result)
+        print(f"  exec ({exec_ms:.0f} ms): {stdout.strip()}")
+    except Exception as e:
+        print(f"  exec failed: {e}")
+
+    t3 = time.monotonic()
+    try:
+        await session.shutdown()
+    except Exception as e:
+        print(f"  shutdown warning: {e}")
+    shutdown_ms = (time.monotonic() - t3) * 1000
+    print(f"  sandbox destroyed in {shutdown_ms:.0f} ms")
+
+    print(f"  total: {(time.monotonic() - t0) * 1000:.0f} ms")
+
+
+async def run_agent(
+    model: str,
+    question: str,
+    template: str | None,
+    timeout: int,
+    max_turns: int = 50,
+) -> None:
+    from openai.types.responses import ResponseTextDeltaEvent
+
+    base_url = os.environ.get("OPENAI_BASE_URL", "(default)")
+    print(f"[config] model={model}, base_url={base_url}")
+    print(f"[config] template={template or os.environ.get('CUBE_TEMPLATE_ID')}")
+    print(f"[question] {question}\n")
+
+    print("[preflight] verifying LLM connection ...", flush=True)
+    await _preflight_llm(model)
+
+    agent = build_agent(model)
+    run_config = build_run_config(template, timeout)
+
+    turn = 0
+    in_text = False
+    t_start = time.monotonic()
+
+    print("[status] creating sandbox & starting session ...", flush=True)
+    result = Runner.run_streamed(agent, question, run_config=run_config, max_turns=max_turns)
+
+    # Monitor the background run-loop task for silent exceptions
+    async def _watch_task():
+        task = result.run_loop_task
+        if task is None:
+            return
+        try:
+            await task
+        except Exception as e:
+            print(f"\n[ERROR] run loop task crashed: {type(e).__name__}: {e}", flush=True)
+            import traceback
+            traceback.print_exc()
+
+    watcher = asyncio.create_task(_watch_task())
+
+    got_first_event = False
+    idle_timeout = 30  # cancel if no new events for 30s after answer
+    got_answer = False
+
+    async def _consume_with_idle_timeout():
+        """Consume stream events with an idle timeout that kicks in after the
+        LLM produces an answer.  This works around the Runner hanging during
+        its internal finalization (get_single_step_result_from_response)."""
+        nonlocal got_first_event, in_text, turn, got_answer
+        event_iter = result.stream_events().__aiter__()
+        while True:
+            effective_timeout = idle_timeout if got_answer else timeout
+            try:
+                event = await asyncio.wait_for(
+                    event_iter.__anext__(), timeout=effective_timeout
+                )
+            except StopAsyncIteration:
+                break
+            except asyncio.TimeoutError:
+                if got_answer:
+                    print(f"\n[status] no new events for {idle_timeout}s after answer — finishing",
+                          flush=True)
+                else:
+                    print(f"\n[WARN] stream timed out after {timeout}s", flush=True)
+                break
+
+            if not got_first_event:
+                sandbox_ms = (time.monotonic() - t_start) * 1000
+                print(f"[status] first event received ({sandbox_ms:.0f} ms)\n", flush=True)
+                got_first_event = True
+
+            if event.type == "agent_updated_stream_event":
+                print(f"[agent] {event.new_agent.name} running", flush=True)
+                print("[status] waiting for LLM response ...", flush=True)
+
+            elif event.type == "run_item_stream_event":
+                if in_text:
+                    print()
+                    in_text = False
+
+                if event.name == "tool_called":
+                    turn += 1
+                    item = event.item
+                    call_name = getattr(getattr(item, "raw_item", None), "name", "tool")
+                    call_args = getattr(getattr(item, "raw_item", None), "arguments", "")
+                    if len(call_args) > 200:
+                        call_args = call_args[:200] + "..."
+                    print(f"[step {turn}] tool_call: {call_name}({call_args})", flush=True)
+
+                elif event.name == "tool_output":
+                    item = event.item
+                    output = getattr(item, "output", "")
+                    if isinstance(output, str) and len(output) > 300:
+                        output = output[:300] + "...(truncated)"
+                    print(f"  → output: {output}", flush=True)
+
+                else:
+                    print(f"[event] run_item: {event.name}", flush=True)
+
+            elif event.type == "raw_response_event":
+                if isinstance(event.data, ResponseTextDeltaEvent):
+                    if not in_text:
+                        print("\n[answer] ", end="", flush=True)
+                        in_text = True
+                    print(event.data.delta, end="", flush=True)
+                    got_answer = True
+
+            else:
+                print(f"[event] {event.type}", flush=True)
+
+    await _consume_with_idle_timeout()
+
+    if in_text:
+        print()
+
+    watcher.cancel()
+    elapsed = (time.monotonic() - t_start) * 1000
+    print(f"\n[done] {turn} tool calls, {elapsed:.0f} ms total")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="OpenAI Agents SDK + E2B + Cube Sandbox (SWE-bench Django)"
+    )
+    parser.add_argument(
+        "--model", default="openai/glm-5.1",
+        help="Model name (default: openai/glm-5.1 via TokenHub)",
+    )
+    parser.add_argument(
+        "--question",
+        default="Analyze the bug described in your instructions and propose a fix.",
+        help="Question to ask the agent",
+    )
+    parser.add_argument(
+        "--template", default=None,
+        help="E2B template ID (default: from CUBE_TEMPLATE_ID env)",
+    )
+    parser.add_argument(
+        "--timeout", type=int, default=300,
+        help="Sandbox timeout in seconds (default: 300)",
+    )
+    parser.add_argument(
+        "--max-turns", type=int, default=50, dest="max_turns",
+        help="Max tool-call rounds before the agent stops (default: 50)",
+    )
+    parser.add_argument(
+        "--sandbox-only", action="store_true", dest="sandbox_only",
+        help="Only create and destroy a sandbox (no LLM, no agent)",
+    )
+    args = parser.parse_args()
+
+    load_env(sandbox_only=args.sandbox_only)
+
+    if args.sandbox_only:
+        asyncio.run(run_sandbox_only(
+            template=args.template,
+            timeout=args.timeout,
+        ))
+    else:
+        asyncio.run(run_agent(
+            model=args.model,
+            question=args.question,
+            template=args.template,
+            timeout=args.timeout,
+            max_turns=args.max_turns,
+        ))
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/openai-agents-example/openai-agents-sandbox-cube-integration.md
+++ b/examples/openai-agents-example/openai-agents-sandbox-cube-integration.md
@@ -1,0 +1,358 @@
+# OpenAI Agents SDK × CubeSandbox Integration Guide
+
+[中文文档](openai-agents-sandbox-cube-integration_zh.md)
+
+> A field-tested guide distilled from the three runnable demos in this repository ([`simple_demo.py`](simple_demo.py), [`code_interpreter_demo.py`](../openai-agents-code-interpreter/code_interpreter_demo.py), [`code_interpreter_demo_ci.py`](../openai-agents-code-interpreter/code_interpreter_demo_ci.py)).
+>
+> For the conceptual background, see [`openai-agents.md`](openai-agents.md) (an analysis of OpenAI's official Sandbox Agents documentation). This document focuses on "how to run it on CubeSandbox".
+
+## TL;DR
+
+[CubeSandbox](https://github.com/TencentCloud/CubeSandbox) exposes an API that is compatible with [E2B](https://e2b.dev), so you can reuse the OpenAI Agents SDK's official `E2BSandboxClient` **without writing your own provider**. You only need three changes:
+
+1. Point `E2B_API_URL` at the CubeAPI endpoint.
+2. Pass a CubeSandbox template ID via `E2BSandboxClientOptions`.
+3. Apply a small number of runtime patches to align with CubeSandbox (root user, streaming output, SSL isolation, etc.).
+
+Two Python execution modes are supported:
+
+| Mode | Type | Characteristics |
+|------|------|-----------------|
+| **Generic E2B** | `E2BSandboxType.E2B` | `write + exec` a script, maximum compatibility |
+| **Code Interpreter** | `E2BSandboxType.CODE_INTERPRETER` | Jupyter kernel, state persists across turns, images captured automatically |
+
+## 1. Background
+
+```
+┌─────────────────────────┐                     ┌──────────────────────────┐
+│  OpenAI Agents SDK      │  E2B-compatible     │  CubeSandbox             │
+│  (Control plane/Harness)│  gRPC + HTTPS       │  (Execution plane/Compute)│
+│                         │ ──────────────▶     │                          │
+│  SandboxAgent           │                     │  envd (49983)            │
+│  ├── Runner             │ session.exec()      │  ├── sh / python         │
+│  ├── Capability         │ session.write()     │  ├── fs read/write       │
+│  └── Manifest           │ session.read()      │  └── expose port         │
+│                         │                     │                          │
+│  E2BSandboxClient ◀─────┘                     │  code-interpreter (49999)│
+│                                               │  └── run_code()          │
+└─────────────────────────┘                     └──────────────────────────┘
+```
+
+The OpenAI Agents SDK handles model calls, tool routing, and session resume. CubeSandbox provides filesystem operations, command execution, and port exposure. The two sides communicate via the E2B-compatible protocol, with CubeSandbox offering stronger isolation underneath.
+
+## 2. Integration Overview
+
+| Concern | Agents SDK side | CubeSandbox side |
+|---------|-----------------|------------------|
+| Client | `E2BSandboxClient()` | CubeAPI, pointed to by `E2B_API_URL` |
+| Template | `E2BSandboxClientOptions(template=...)` | Produced by `cubemastercli template create-from-image` |
+| Lifecycle | `RunConfig(sandbox=SandboxRunConfig(...))` | envd boot + template image startup |
+| Workspace seed | `Manifest(entries={...})` | envd writes into the rootfs |
+| Tools | `Capability` + `FunctionTool` | `session.exec / write / read` |
+| Session resume | `pause_on_exit=True` + resume | Sandbox state retained |
+
+## 3. Minimal Working Integration
+
+From [`simple_demo.py`](simple_demo.py) — an agent with only the `Shell` capability.
+
+```python
+from agents import Runner
+from agents.run import RunConfig
+from agents.sandbox import Manifest, SandboxAgent, SandboxRunConfig
+from agents.sandbox.capabilities import Shell
+from agents.extensions.sandbox import (
+    E2BSandboxClient, E2BSandboxClientOptions, E2BSandboxType,
+)
+
+agent = SandboxAgent(
+    name="Cube Shell Agent",
+    model=make_model("openai/glm-5.1"),
+    instructions="You can run shell commands in the sandbox.",
+    default_manifest=Manifest(entries={}),
+    capabilities=[Shell()],
+)
+
+run_config = RunConfig(
+    sandbox=SandboxRunConfig(
+        client=E2BSandboxClient(),
+        options=E2BSandboxClientOptions(
+            sandbox_type=E2BSandboxType.E2B,
+            template=os.environ["CUBE_TEMPLATE_ID"],
+            timeout=600,
+        ),
+    ),
+)
+result = await Runner.run(agent, "What Linux distro is this?", run_config=run_config)
+```
+
+As long as `E2B_API_URL` points at the CubeAPI, the code is **identical to what you would write against E2B SaaS**.
+
+## 4. Two Code Interpreter Variants
+
+The `openai-agents-code-interpreter/` directory contains two equivalent demos that differ as follows:
+
+| | [`code_interpreter_demo.py`](../openai-agents-code-interpreter/code_interpreter_demo.py) | [`code_interpreter_demo_ci.py`](../openai-agents-code-interpreter/code_interpreter_demo_ci.py) |
+|---|---|---|
+| Sandbox type | `E2BSandboxType.E2B` | `E2BSandboxType.CODE_INTERPRETER` |
+| Underlying SDK | `e2b.AsyncSandbox` | `e2b_code_interpreter.AsyncSandbox` |
+| Execution model | `session.write(script.py)` → `session.exec("python script.py")` | `sandbox.run_code(code)` (Jupyter kernel) |
+| Session state | Each `exec` is a fresh process | **Variables / imports / DataFrames persist across cells** |
+| Image capture | Agent calls `plt.savefig(...)` manually | Auto-decoded from `Execution.results` (base64) |
+| Template ports | envd (49983) | envd (49983) + code-interpreter (49999) |
+
+Both share the same `WorkspaceShell` + `PythonRunner` combination; only the implementation of `PythonRunner._invoke` differs.
+
+### Generic E2B style (`code_interpreter_demo.py`)
+
+```308:349:openai-agents-code-interpreter/code_interpreter_demo.py
+    async def _invoke(self, _ctx: Any, raw_args: str) -> str:
+        session = self.session
+        if session is None:
+            raise RuntimeError("python_runner is not bound to a sandbox session")
+
+        request = PythonRunRequest.model_validate_json(raw_args)
+
+        await session.mkdir(Path(".scratch"), parents=True)
+        await session.mkdir(Path("output"), parents=True)
+
+        script_rel = Path(f".scratch/{uuid.uuid4().hex}.py")
+        await session.write(
+            script_rel,
+            io.BytesIO(request.code.encode("utf-8")),
+        )
+        ...
+```
+
+Idea: `write` a temporary script → `exec("python script.py")` → diff `output/` to collect new artifacts.
+**Any cube template with Python installed can run this.**
+
+### Jupyter kernel style (`code_interpreter_demo_ci.py`)
+
+The trick is to punch through the SDK wrappers to reach the underlying `e2b_code_interpreter.AsyncSandbox`:
+
+```415:469:openai-agents-code-interpreter/code_interpreter_demo_ci.py
+def _find_code_interpreter_sandbox(session: Any, *, max_depth: int = 4) -> Any | None:
+    """Locate the underlying `e2b_code_interpreter.AsyncSandbox` on the session.
+
+    Different openai-agents versions stack several wrappers before the raw
+    sandbox:
+        SandboxSession._inner -> E2BSandboxSession._sandbox -> AsyncSandbox
+```
+
+Once you have it, you can call `await inner.run_code(code, on_stdout=..., on_stderr=..., timeout=...)`. The returned `Execution` structure carries `logs / results / error`, and image results are base64-decoded straight into `output/figure_*.png`.
+
+## 5. Key Integration Code Walkthrough (`code_interpreter_demo_ci.py`)
+
+The snippets below are excerpted from [`code_interpreter_demo_ci.py`](../openai-agents-code-interpreter/code_interpreter_demo_ci.py) and show the complete integration chain between the OpenAI Agents SDK and CubeSandbox.
+
+### 5.1 LLM model construction (SSL isolation + Chat Completions API)
+
+CubeSandbox's gRPC requires a custom CA, but setting `SSL_CERT_FILE` would contaminate the LLM's HTTPS requests. The fix is to give the LLM client its own system-CA context:
+
+```python
+def make_model(model_name: str) -> OpenAIChatCompletionsModel:
+    import ssl
+    ssl_ctx = ssl.create_default_context()  # System CAs, unaffected by SSL_CERT_FILE
+    client = AsyncOpenAI(
+        timeout=httpx.Timeout(120, connect=15),
+        http_client=httpx.AsyncClient(verify=ssl_ctx),
+    )
+    bare = model_name.split("/", 1)[-1] if "/" in model_name else model_name
+    return OpenAIChatCompletionsModel(model=bare, openai_client=client)
+```
+
+> Note: you must use `OpenAIChatCompletionsModel` rather than passing a plain model string — the latter routes via the Responses API (`/v1/responses`), but TokenHub only supports the Chat Completions API (`/v1/chat/completions`).
+
+### 5.2 Agent construction + RunConfig wired to CubeSandbox
+
+This is the entry point of the integration, tying together Agent, Capability, Manifest and CubeSandbox:
+
+```python
+agent = SandboxAgent(
+    name="Cube Code Interpreter Analyst (kernel)",
+    model=make_model(model),                     # The LLM model from §5.1
+    instructions=SYSTEM_INSTRUCTIONS,
+    default_manifest=build_manifest(),            # Seed files (sales.csv, README.md)
+    capabilities=[WorkspaceShell(), PythonRunner()],  # Custom capabilities
+    model_settings=ModelSettings(tool_choice="auto"),
+)
+
+run_config = RunConfig(
+    sandbox=SandboxRunConfig(
+        client=E2BSandboxClient(),                # Use the official E2B client directly
+        options=E2BSandboxClientOptions(
+            sandbox_type=E2BSandboxType.CODE_INTERPRETER,  # Jupyter kernel mode
+            template=template,                    # CubeSandbox template ID
+            timeout=timeout,                      # Sandbox lifetime (seconds)
+            pause_on_exit=pause_on_exit,          # True = pause instead of destroy (resumable)
+        ),
+    ),
+)
+
+result = await Runner.run(agent, question, run_config=run_config)
+```
+
+### 5.3 Manifest seed files
+
+The `Manifest` writes workspace files automatically when the sandbox starts; the agent can then read them by relative path:
+
+```python
+def build_manifest() -> Manifest:
+    return Manifest(
+        entries={
+            "sales.csv": File(content=SALES_CSV.encode("utf-8")),
+            "README.md": File(content=b"# Sales review\n\n`sales.csv` has ..."),
+        }
+    )
+```
+
+### 5.4 PythonRunner: Jupyter kernel execution capability
+
+`PythonRunner` is a custom `Capability`.
+
+**Call `run_code` and capture image results**:
+
+```python
+execution = await _run_code_annotated(
+    inner, request.code,
+    on_stdout=_on_stdout, on_stderr=_on_stderr,
+    timeout=request.timeout_s,
+)
+
+# Automatically decode matplotlib figures from base64 and save them
+for result in execution.results:
+    for kind, ext in _IMAGE_KINDS:        # png, jpeg, svg
+        encoded = getattr(result, kind, None)
+        if not encoded:
+            continue
+        blob = base64.b64decode(encoded)
+        rel_path = Path(f"output/figure_{counter:02d}.{ext}")
+        await session.write(rel_path, io.BytesIO(blob))
+```
+
+### 5.5 End-to-end call graph
+
+```
+main()
+ ├── load_env()                          # Env vars: E2B_API_URL → CubeAPI
+ ├── make_model()                        # LLM client (SSL isolated)
+ ├── build_manifest()                    # Seed files
+ ├── SandboxAgent(capabilities=[...])    # Agent + custom capabilities
+ ├── RunConfig(client=E2BSandboxClient)  # Wire to CubeSandbox
+ └── Runner.run(agent, question)
+      ├── CubeSandbox creates a sandbox instance
+      ├── envd writes Manifest files
+      ├── LLM emits tool calls
+      │    ├── WorkspaceShell → session.exec("sh -lc ...")
+      │    └── PythonRunner   → inner.run_code(code)
+      │         ├── Jupyter readiness probe
+      │         ├── Kernel CWD alignment
+      │         ├── Execute Python code
+      │         └── Auto-capture figures → output/figure_*.png
+      └── Return the final analysis result
+```
+
+## 6. End-to-End Sample Run
+
+### 6.1 Code Interpreter: data analysis + chart generation
+
+```bash
+python3 code_interpreter_demo_ci.py
+```
+
+```
+Model:    openai/glm-5.1
+Template: e2b-code-interpreter-2
+CubeAPI:  http://localhost:3000
+Question: Analyze sales.csv with Python: (1) compute revenue = units * unit_price,
+          (2) plot monthly total revenue as a line chart, (3) report the top-3
+          products by total revenue as a Markdown table, (4) finish with a
+          2-sentence executive summary.
+
+Creating sandbox & running agent ...
+[python] code-interpreter ready: probe #3: HTTP_OK status=200 body[:300]='"OK"'
+[python] bootstrapped kernel cwd -> /workspace
+[python] running 121 bytes in kernel
+[python] (14, 4)
+[python] ['date', 'product', 'units', 'unit_price']
+[python] date           object
+[python] product        object
+[python] units           int64
+[python] unit_price    float64
+[python] dtype: object
+[python] (ok)
+[python] running 567 bytes in kernel
+[python] saved output/figure_01.png (32115 bytes)
+[python] (ok)
+[python] running 505 bytes in kernel
+[python] | Product      |   Total Revenue |
+[python] |:-------------|----------------:|
+[python] | Gamma Gizmo  |          2178   |
+[python] | Beta Gadget  |          2156   |
+[python] | Alpha Widget |          1512.4 |
+[python]
+[python] Total revenue: $7,007.40
+[python] Peak month: 2025-04 ($2,333.50)
+[python] (ok)
+================================================================
+Here are the results:
+
+**Monthly Revenue Line Chart** → `output/figure_01.png`
+
+**Top-3 Products by Total Revenue**
+
+| Product      | Total Revenue |
+|:-------------|--------------:|
+| Gamma Gizmo  |       2,178.00 |
+| Beta Gadget  |       2,156.00 |
+| Alpha Widget |       1,512.40 |
+
+**Executive Summary**
+
+Total revenue across the period was **$7,007.40**, with April 2025 as the
+strongest month at **$2,333.50**. Gamma Gizmo narrowly leads product revenue
+($2,178), followed closely by Beta Gadget ($2,156), while Alpha Widget
+trails at $1,512.40.
+================================================================
+```
+
+End-to-end flow: Manifest seeds `sales.csv` → Jupyter kernel readiness probe → 3 rounds of `run_code` (load data → plot → summary table) → model emits the final analysis. The chart is captured automatically from kernel results and saved to `output/`.
+
+## 7. Template Requirements
+
+What your cube template must ship / expose depends on which mode you run:
+
+| Mode | Preinstalled software | Exposed ports | Probe |
+|------|-----------------------|---------------|-------|
+| Generic E2B | python3 + business deps (pandas / numpy / matplotlib ...) | 49983 (envd) | 49983 |
+| Code Interpreter | All of the above + the official `e2b-code-interpreter` runtime | 49983 + **49999** | 49983 |
+
+Template registration example (taken from `openai-agents-code-interpreter/README.md`):
+
+```bash
+cubemastercli template create-from-image \
+  --image cube-sandbox-image.tencentcloudcr.com/demo/e2b-code-interpreter:v1.1-data \
+  --writable-layer-size 1Gi \
+  --template-id e2b-code-interpreter \
+  --expose-port 49983 \
+  --expose-port 49999 \
+  --probe 49983
+```
+
+Key environment variables (see each demo's `.env.example`):
+
+| Variable | Purpose |
+|----------|---------|
+| `E2B_API_URL` | CubeAPI URL, e.g. `http://<cube-host>:3000` |
+| `E2B_API_KEY` | CubeAPI auth key |
+| `CUBE_TEMPLATE_ID` | cube template ID |
+| `CUBE_SSL_CERT_FILE` | (Optional) path to the cube CA bundle |
+| `TOKENHUB_API_KEY` | LLM key (auto-mapped to `OPENAI_API_KEY`) |
+| `OPENAI_BASE_URL` | Defaults to TokenHub, `https://tokenhub.tencentmaas.com/v1` |
+
+
+## 8. Further Reading
+
+- [OpenAI Sandbox Agents official docs](https://developers.openai.com/api/docs/guides/agents/sandboxes)
+- [E2B Sandbox docs](https://e2b.dev/docs) / [E2B × OpenAI Agents SDK](https://e2b.dev/docs/agents/openai-agents-sdk)
+- [CubeSandbox](https://github.com/TencentCloud/CubeSandbox)

--- a/examples/openai-agents-example/openai-agents-sandbox-cube-integration_zh.md
+++ b/examples/openai-agents-example/openai-agents-sandbox-cube-integration_zh.md
@@ -1,0 +1,359 @@
+# OpenAI Agents SDK × CubeSandbox 集成指南
+
+[English](openai-agents-sandbox-cube-integration.md)
+
+> 基于本仓库的三个可运行 demo（[`simple_demo.py`](simple_demo.py)、[`code_interpreter_demo.py`](../openai-agents-code-interpreter/code_interpreter_demo.py)、[`code_interpreter_demo_ci.py`](../openai-agents-code-interpreter/code_interpreter_demo_ci.py)）提炼出来的落地文档。
+>
+> 概念性介绍见 [`openai-agents_zh.md`](openai-agents_zh.md)（OpenAI 官方 Sandbox Agents 文档的中文解析）。本文主要讲"怎么把它跑在 CubeSandbox 上"。
+
+## 快速概览
+
+[CubeSandbox](https://github.com/TencentCloud/CubeSandbox) 的 API 与 [E2B](https://e2b.dev) 兼容，因此可以直接复用 OpenAI Agents SDK 官方的 `E2BSandboxClient`，**无需自己编写 Provider**。核心改动只有三步：
+
+1. 将 `E2B_API_URL` 指向 CubeAPI 地址；
+2. 在 `E2BSandboxClientOptions` 中填入 CubeSandbox 模板 ID；
+3. 添加少量运行时补丁以适配 CubeSandbox（root 用户、流式输出、SSL 隔离等）。
+
+支持两种 Python 执行形态：
+
+| 形态 | 类型 | 特点 |
+|------|------|------|
+| **通用 E2B** | `E2BSandboxType.E2B` | 脚本 `write + exec`，兼容性最好 |
+| **Code Interpreter** | `E2BSandboxType.CODE_INTERPRETER` | Jupyter kernel，状态跨轮保留、图像自动捕获 |
+
+## 1. 背景：
+
+```
+┌─────────────────────────┐                     ┌──────────────────────────┐
+│  OpenAI Agents SDK      │  E2B-compatible     │  CubeSandbox             │
+│  (控制面 / Harness)      │  gRPC + HTTPS       │  (执行面 / Compute)       │
+│                         │ ──────────────▶     │                          │
+│  SandboxAgent           │                     │  envd (49983)            │
+│  ├── Runner             │ session.exec()      │  ├── sh / python         │
+│  ├── Capability         │ session.write()     │  ├── fs read/write       │
+│  └── Manifest           │ session.read()      │  └── expose port         │
+│                         │                     │                          │
+│  E2BSandboxClient ◀─────┘                     │  code-interpreter (49999)│
+│                                               │  └── run_code()          │
+└─────────────────────────┘                     └──────────────────────────┘
+```
+
+OpenAI Agents SDK 负责模型调用、工具路由和会话恢复；CubeSandbox 负责文件读写、命令执行和端口暴露。两者通过 E2B 兼容协议对接，CubeSandbox 在底层提供更强的安全隔离。
+
+## 2. 集成总览
+
+| 环节 | Agents SDK 侧 | CubeSandbox 侧 |
+|---|---|---|
+| 客户端 | `E2BSandboxClient()` | CubeAPI，指向 `E2B_API_URL` |
+| 模板 | `E2BSandboxClientOptions(template=...)` | `cubemastercli template create-from-image` 生成 |
+| 生命周期 | `RunConfig(sandbox=SandboxRunConfig(...))` | envd 拉起 + 模板镜像启动 |
+| 工作区种子 | `Manifest(entries={...})` | envd 在 rootfs 写入 |
+| 工具 | `Capability` + `FunctionTool` | `session.exec / write / read` |
+| 会话恢复 | `pause_on_exit=True` + resume | 沙箱状态保留 |
+
+## 3. 最小可用集成
+
+来自 [`simple_demo.py`](simple_demo.py) —— 一个只带 `Shell` 能力的 agent。
+
+```python
+from agents import Runner
+from agents.run import RunConfig
+from agents.sandbox import Manifest, SandboxAgent, SandboxRunConfig
+from agents.sandbox.capabilities import Shell
+from agents.extensions.sandbox import (
+    E2BSandboxClient, E2BSandboxClientOptions, E2BSandboxType,
+)
+
+agent = SandboxAgent(
+    name="Cube Shell Agent",
+    model=make_model("openai/glm-5.1"),
+    instructions="You can run shell commands in the sandbox.",
+    default_manifest=Manifest(entries={}),
+    capabilities=[Shell()],
+)
+
+run_config = RunConfig(
+    sandbox=SandboxRunConfig(
+        client=E2BSandboxClient(),
+        options=E2BSandboxClientOptions(
+            sandbox_type=E2BSandboxType.E2B,
+            template=os.environ["CUBE_TEMPLATE_ID"],
+            timeout=600,
+        ),
+    ),
+)
+result = await Runner.run(agent, "What Linux distro is this?", run_config=run_config)
+```
+
+只要 `E2B_API_URL` 指向 CubeAPI，以上代码**和 E2B SaaS 上的写法完全一致**。
+
+## 4. Code Interpreter 两种形态
+
+本仓库 `openai-agents-code-interpreter/` 目录下有两份等价 demo，差异如下：
+
+| | [`code_interpreter_demo.py`](../openai-agents-code-interpreter/code_interpreter_demo.py) | [`code_interpreter_demo_ci.py`](../openai-agents-code-interpreter/code_interpreter_demo_ci.py) |
+|---|---|---|
+| 沙箱类型 | `E2BSandboxType.E2B` | `E2BSandboxType.CODE_INTERPRETER` |
+| 底层 SDK | `e2b.AsyncSandbox` | `e2b_code_interpreter.AsyncSandbox` |
+| 执行方式 | `session.write(script.py)` → `session.exec("python script.py")` | `sandbox.run_code(code)`（Jupyter kernel） |
+| 会话状态 | 每次 `exec` 都是新进程 | **变量 / imports / DataFrame 跨 cell 保留** |
+| 图像捕获 | agent 手动 `plt.savefig(...)` | 自动从 `Execution.results` 解 base64 |
+| 模板端口 | envd (49983) | envd (49983) + code-interpreter (49999) |
+
+两份都用同样的 `WorkspaceShell` + `PythonRunner` 组合，只是 `PythonRunner._invoke` 实现不同。
+
+### 通用 E2B 写法（`code_interpreter_demo.py`）
+
+```308:349:openai-agents-code-interpreter/code_interpreter_demo.py
+    async def _invoke(self, _ctx: Any, raw_args: str) -> str:
+        session = self.session
+        if session is None:
+            raise RuntimeError("python_runner is not bound to a sandbox session")
+
+        request = PythonRunRequest.model_validate_json(raw_args)
+
+        await session.mkdir(Path(".scratch"), parents=True)
+        await session.mkdir(Path("output"), parents=True)
+
+        script_rel = Path(f".scratch/{uuid.uuid4().hex}.py")
+        await session.write(
+            script_rel,
+            io.BytesIO(request.code.encode("utf-8")),
+        )
+        ...
+```
+
+思路：`write` 一个临时脚本 → `exec("python script.py")` → `find output/` diff 出新产物。
+**任何装了 python 的 cube 模板都能跑**。
+
+### Jupyter kernel 写法（`code_interpreter_demo_ci.py`）
+
+关键是要绕过 SDK 的 wrapper，拿到底层 `e2b_code_interpreter.AsyncSandbox`：
+
+```415:469:openai-agents-code-interpreter/code_interpreter_demo_ci.py
+def _find_code_interpreter_sandbox(session: Any, *, max_depth: int = 4) -> Any | None:
+    """Locate the underlying `e2b_code_interpreter.AsyncSandbox` on the session.
+
+    Different openai-agents versions stack several wrappers before the raw
+    sandbox:
+        SandboxSession._inner -> E2BSandboxSession._sandbox -> AsyncSandbox
+```
+
+拿到后就可以 `await inner.run_code(code, on_stdout=..., on_stderr=..., timeout=...)`，返回的 `Execution` 结构携带 `logs / results / error`，图像结果直接 base64 解码到 `output/figure_*.png`。
+
+## 5. 关键集成代码详解（`code_interpreter_demo_ci.py`）
+
+以下代码片段摘自 [`code_interpreter_demo_ci.py`](../openai-agents-code-interpreter/code_interpreter_demo_ci.py)，展示 OpenAI Agents SDK 与 CubeSandbox 对接的完整链路。
+
+
+### 5.1 LLM 模型构造（SSL 隔离 + Chat Completions API）
+
+CubeSandbox 的 gRPC 需要自定义 CA，但 `SSL_CERT_FILE` 会污染 LLM 的 HTTPS 请求。解法是给 LLM 客户端单独用系统 CA：
+
+```python
+def make_model(model_name: str) -> OpenAIChatCompletionsModel:
+    import ssl
+    ssl_ctx = ssl.create_default_context()  # 系统 CA，不受 SSL_CERT_FILE 影响
+    client = AsyncOpenAI(
+        timeout=httpx.Timeout(120, connect=15),
+        http_client=httpx.AsyncClient(verify=ssl_ctx),
+    )
+    bare = model_name.split("/", 1)[-1] if "/" in model_name else model_name
+    return OpenAIChatCompletionsModel(model=bare, openai_client=client)
+```
+
+> 注意：必须用 `OpenAIChatCompletionsModel` 而非直接传模型字符串——后者会走 Responses API（`/v1/responses`），而 TokenHub 只支持 Chat Completions API（`/v1/chat/completions`）。
+
+### 5.2 Agent 构建 + RunConfig 对接 CubeSandbox
+
+这是整个集成的核心入口，把 Agent、Capability、Manifest 和 CubeSandbox 连在一起：
+
+```python
+agent = SandboxAgent(
+    name="Cube Code Interpreter Analyst (kernel)",
+    model=make_model(model),                     # §5.1 的 LLM 模型
+    instructions=SYSTEM_INSTRUCTIONS,
+    default_manifest=build_manifest(),            # 种子文件 (sales.csv, README.md)
+    capabilities=[WorkspaceShell(), PythonRunner()],  # 自定义能力
+    model_settings=ModelSettings(tool_choice="auto"),
+)
+
+run_config = RunConfig(
+    sandbox=SandboxRunConfig(
+        client=E2BSandboxClient(),                # 直接用官方 E2B 客户端
+        options=E2BSandboxClientOptions(
+            sandbox_type=E2BSandboxType.CODE_INTERPRETER,  # Jupyter kernel 模式
+            template=template,                    # CubeSandbox 模板 ID
+            timeout=timeout,                      # 沙箱生命周期（秒）
+            pause_on_exit=pause_on_exit,          # True = 暂停而非销毁，支持恢复
+        ),
+    ),
+)
+
+result = await Runner.run(agent, question, run_config=run_config)
+```
+
+### 5.3 Manifest 种子文件
+
+通过 `Manifest` 在沙箱启动时自动写入工作区文件，agent 可直接以相对路径读取：
+
+```python
+def build_manifest() -> Manifest:
+    return Manifest(
+        entries={
+            "sales.csv": File(content=SALES_CSV.encode("utf-8")),
+            "README.md": File(content=b"# Sales review\n\n`sales.csv` has ..."),
+        }
+    )
+```
+
+### 5.4 PythonRunner：Jupyter kernel 执行能力
+
+`PythonRunner` 是一个自定义 `Capability`：
+
+**调用 `run_code` 并捕获图像结果**：
+
+```python
+execution = await _run_code_annotated(
+    inner, request.code,
+    on_stdout=_on_stdout, on_stderr=_on_stderr,
+    timeout=request.timeout_s,
+)
+
+# 自动将 matplotlib 图表从 base64 解码并保存
+for result in execution.results:
+    for kind, ext in _IMAGE_KINDS:        # png, jpeg, svg
+        encoded = getattr(result, kind, None)
+        if not encoded:
+            continue
+        blob = base64.b64decode(encoded)
+        rel_path = Path(f"output/figure_{counter:02d}.{ext}")
+        await session.write(rel_path, io.BytesIO(blob))
+```
+
+### 5.5 集成调用链路总结
+
+```
+main()
+ ├── load_env()                          # 环境变量：E2B_API_URL → CubeAPI
+ ├── make_model()                        # LLM 客户端（SSL 隔离）
+ ├── build_manifest()                    # 种子文件
+ ├── SandboxAgent(capabilities=[...])    # Agent + 自定义能力
+ ├── RunConfig(client=E2BSandboxClient)  # 对接 CubeSandbox
+ └── Runner.run(agent, question)
+      ├── CubeSandbox 创建沙箱实例
+      ├── envd 写入 Manifest 文件
+      ├── LLM 生成工具调用
+      │    ├── WorkspaceShell → session.exec("sh -lc ...")
+      │    └── PythonRunner   → inner.run_code(code)
+      │         ├── Jupyter 就绪探测
+      │         ├── kernel CWD 对齐
+      │         ├── 执行 Python 代码
+      │         └── 自动捕获图表 → output/figure_*.png
+      └── 返回最终分析结果
+```
+
+## 6. 端到端运行示例
+
+### 6.1 Code Interpreter：数据分析 + 图表生成
+
+```bash
+python3 code_interpreter_demo_ci.py
+```
+
+```
+Model:    openai/glm-5.1
+Template: e2b-code-interpreter-2
+CubeAPI:  http://localhost:3000
+Question: Analyze sales.csv with Python: (1) compute revenue = units * unit_price,
+          (2) plot monthly total revenue as a line chart, (3) report the top-3
+          products by total revenue as a Markdown table, (4) finish with a
+          2-sentence executive summary.
+
+Creating sandbox & running agent ...
+[python] code-interpreter ready: probe #3: HTTP_OK status=200 body[:300]='"OK"'
+[python] bootstrapped kernel cwd -> /workspace
+[python] running 121 bytes in kernel
+[python] (14, 4)
+[python] ['date', 'product', 'units', 'unit_price']
+[python] date           object
+[python] product        object
+[python] units           int64
+[python] unit_price    float64
+[python] dtype: object
+[python] (ok)
+[python] running 567 bytes in kernel
+[python] saved output/figure_01.png (32115 bytes)
+[python] (ok)
+[python] running 505 bytes in kernel
+[python] | Product      |   Total Revenue |
+[python] |:-------------|----------------:|
+[python] | Gamma Gizmo  |          2178   |
+[python] | Beta Gadget  |          2156   |
+[python] | Alpha Widget |          1512.4 |
+[python]
+[python] Total revenue: $7,007.40
+[python] Peak month: 2025-04 ($2,333.50)
+[python] (ok)
+================================================================
+Here are the results:
+
+**Monthly Revenue Line Chart** → `output/figure_01.png`
+
+**Top-3 Products by Total Revenue**
+
+| Product      | Total Revenue |
+|:-------------|--------------:|
+| Gamma Gizmo  |       2,178.00 |
+| Beta Gadget  |       2,156.00 |
+| Alpha Widget |       1,512.40 |
+
+**Executive Summary**
+
+Total revenue across the period was **$7,007.40**, with April 2025 as the
+strongest month at **$2,333.50**. Gamma Gizmo narrowly leads product revenue
+($2,178), followed closely by Beta Gadget ($2,156), while Alpha Widget
+trails at $1,512.40.
+================================================================
+```
+
+整个流程：Manifest 种入 `sales.csv` → Jupyter kernel 就绪探测 → 3 轮 `run_code`（加载数据 → 画图 → 汇总表格）→ 模型输出最终分析。图表自动从 kernel 结果中捕获并保存到 `output/`。
+
+## 7. 模板要求
+
+cube template 需要预装 / 暴露什么，取决于跑哪种形态：
+
+| 形态 | 预装软件 | 暴露端口 | 探针 |
+|---|---|---|---|
+| 通用 E2B | python3 + 业务依赖（pandas / numpy / matplotlib …） | 49983 (envd) | 49983 |
+| Code Interpreter | 以上 + 官方 `e2b-code-interpreter` runtime | 49983 + **49999** | 49983 |
+
+注册模板示例（取自 `openai-agents-code-interpreter/README.md`）：
+
+```bash
+cubemastercli template create-from-image \
+  --image cube-sandbox-image.tencentcloudcr.com/demo/e2b-code-interpreter:v1.1-data \
+  --writable-layer-size 1Gi \
+  --template-id e2b-code-interpreter \
+  --expose-port 49983 \
+  --expose-port 49999 \
+  --probe 49983
+```
+
+关键环境变量（在各 demo 的 `.env.example`）：
+
+| 变量 | 用途 |
+|---|---|
+| `E2B_API_URL` | CubeAPI 地址，例如 `http://<cube-host>:3000` |
+| `E2B_API_KEY` | CubeAPI 鉴权 key |
+| `CUBE_TEMPLATE_ID` | cube 模板 ID |
+| `CUBE_SSL_CERT_FILE` | （可选）cube 的 CA bundle 路径 |
+| `TOKENHUB_API_KEY` | LLM 密钥（会自动映射到 `OPENAI_API_KEY`） |
+| `OPENAI_BASE_URL` | 默认指向 TokenHub，`https://tokenhub.tencentmaas.com/v1` |
+
+
+## 8. 延伸
+
+- [OpenAI Sandbox Agents 官方文档](https://developers.openai.com/api/docs/guides/agents/sandboxes)
+- [E2B Sandbox 文档](https://e2b.dev/docs) / [E2B × OpenAI Agents SDK](https://e2b.dev/docs/agents/openai-agents-sdk)
+- [CubeSandbox](https://github.com/TencentCloud/CubeSandbox)

--- a/examples/openai-agents-example/openai-agents.md
+++ b/examples/openai-agents-example/openai-agents.md
@@ -1,0 +1,252 @@
+# OpenAI Agents SDK Sandbox Analysis
+
+[中文文档](openai-agents_zh.md)
+
+> Source: [OpenAI Sandbox Agents official docs](https://developers.openai.com/api/docs/guides/agents/sandboxes)
+
+## Overview
+
+A **Sandbox Agent** in the OpenAI Agents SDK runs inside an isolated Unix-like execution environment that provides a filesystem, a shell, package management, port exposure, snapshots, and resumable state. It fits scenarios where an Agent needs a persistent workspace, not just prompt context.
+
+## Core Architecture
+
+The key design of Sandbox Agents is the separation between **Harness (control plane)** and **Compute (execution plane)**:
+
+- **Harness (control plane)**: runs the Agent loop, model calls, tool routing, approvals, tracing, and resume.
+- **Compute (execution plane / Sandbox)**: handles filesystem I/O, command execution, dependency installation, port exposure, and state snapshots.
+
+This separation keeps sensitive control-plane work in trusted infrastructure while the sandbox focuses purely on execution.
+
+## When to Use a Sandbox
+
+- The task needs to operate on a body of documents, not just a single prompt
+- The Agent needs to write files for later inspection
+- You need to run commands, install packages, or execute scripts
+- The workflow produces artifacts (Markdown, CSV, screenshots, websites, etc.)
+- You need to expose ports to preview services (notebooks, reports, apps)
+- The work may be paused for human review and resumed later
+
+## Sandbox Components
+
+| Component | Responsibility |
+|-----------|----------------|
+| **SandboxAgent** | Agent definition + default sandbox configuration |
+| **Manifest** | Initial workspace content (files, Git repos, cloud-storage mounts, env vars) |
+| **Capabilities** | Sandbox capabilities: Shell, Filesystem, Skills, Memory, Compaction |
+| **Sandbox Client** | Provider integration (local Unix, Docker, managed services) |
+| **Sandbox Session** | The live execution environment |
+| **SandboxRunConfig** | Per-run configuration (session source, client options) |
+
+### Manifest (workspace declaration)
+
+| Type | Purpose |
+|------|---------|
+| File, Dir | Small synthetic inputs, helper files, output directories |
+| LocalFile, LocalDir | Map files/dirs from the host into the sandbox |
+| GitRepo | Clone a repository into the workspace |
+| S3Mount, GCSMount, R2Mount, AzureBlobMount | Mount external cloud storage |
+| environment | Environment variables set at sandbox startup |
+| users, groups | OS accounts and groups inside the sandbox |
+
+### Capabilities
+
+| Capability | Scenario | Description |
+|------------|----------|-------------|
+| Shell | Agent needs shell access | Command execution, supports interactive input |
+| Filesystem | Agent needs to edit files or view images | apply_patch + view_image |
+| Skills | Skill discovery and loading | Load from Git repos or local directories |
+| Memory | Read/write memory across runs | Learning across runs |
+| Compaction | Long-running flows need context compaction | Automatic context pruning |
+
+Default capabilities: `Filesystem()` + `Shell()` + `Compaction()`
+
+## Code Examples
+
+### Basic usage (Unix-local)
+
+```python
+import asyncio
+
+from agents import Runner
+from agents.run import RunConfig
+from agents.sandbox import Manifest, SandboxAgent, SandboxRunConfig
+from agents.sandbox.capabilities import Shell
+from agents.sandbox.entries import File
+from agents.sandbox.sandboxes.unix_local import UnixLocalSandboxClient
+
+manifest = Manifest(
+    entries={
+        "account_brief.md": File(
+            content=(
+                b"# Northwind Health\n\n"
+                b"- Segment: Mid-market healthcare analytics provider.\n"
+                b"- Renewal date: 2026-04-15.\n"
+            )
+        ),
+    }
+)
+
+agent = SandboxAgent(
+    name="Renewal Packet Analyst",
+    model="gpt-5.4",
+    instructions=(
+        "Review the workspace before answering. Keep the response concise, "
+        "business-focused, and cite the file names that support each conclusion."
+    ),
+    default_manifest=manifest,
+    capabilities=[Shell()],
+)
+
+
+async def main():
+    result = await Runner.run(
+        agent,
+        "Summarize the renewal blockers and recommend the next two actions.",
+        run_config=RunConfig(
+            sandbox=SandboxRunConfig(client=UnixLocalSandboxClient()),
+            workflow_name="Unix-local sandbox review",
+        ),
+    )
+    print(result.final_output)
+
+
+asyncio.run(main())
+```
+
+### Switching to the Docker provider
+
+```python
+from docker import from_env as docker_from_env
+
+from agents import Runner
+from agents.run import RunConfig
+from agents.sandbox import SandboxRunConfig
+from agents.sandbox.config import DEFAULT_PYTHON_SANDBOX_IMAGE
+from agents.sandbox.sandboxes.docker import DockerSandboxClient, DockerSandboxClientOptions
+
+docker_run_config = RunConfig(
+    sandbox=SandboxRunConfig(
+        client=DockerSandboxClient(docker_from_env()),
+        options=DockerSandboxClientOptions(image=DEFAULT_PYTHON_SANDBOX_IMAGE),
+    ),
+    workflow_name="Docker sandbox review",
+)
+
+result = await Runner.run(
+    agent,
+    "Summarize the renewal blockers and recommend the next two actions.",
+    run_config=docker_run_config,
+)
+```
+
+### Resume (pause and continue)
+
+```python
+# First run
+async with session:
+    first_result = await Runner.run(
+        agent,
+        "Build the first version of the app.",
+        max_turns=20,
+        run_config=RunConfig(
+            sandbox=SandboxRunConfig(session=session),
+        ),
+    )
+
+# Serialize session state
+frozen_session_state = client.deserialize_session_state(
+    client.serialize_session_state(session.state)
+)
+
+# Resume and continue
+resumed_session = await client.resume(frozen_session_state)
+async with resumed_session:
+    second_result = await Runner.run(
+        agent,
+        conversation + [{"role": "user", "content": "Add tests."}],
+        max_turns=20,
+        run_config=RunConfig(
+            sandbox=SandboxRunConfig(session=resumed_session),
+        ),
+    )
+```
+
+## State Management
+
+| State type | What it restores | Use case |
+|------------|------------------|----------|
+| **RunState** | Harness-side state (model transcript, tool state, approvals, agent position) | Resume a workflow across pauses |
+| **session_state** | Serialized sandbox session | Apps/task systems persist provider session state directly |
+| **snapshot** | Saved workspace contents | Start a new run from pre-existing files and artifacts |
+
+Session resolution priority:
+1. Explicit `session` → reuse the live session directly
+2. Recover from `RunState` → restore the stored session state
+3. Explicit `session_state` → restore from serialized state
+4. None of the above → create a new session (using the Manifest)
+
+## Memory (cross-run memory)
+
+Agents can retain what they learn across runs: user preferences, corrections, project experience, task summaries.
+
+```python
+from agents.sandbox.capabilities import Filesystem, Memory, Shell
+
+agent = SandboxAgent(
+    name="Memory-enabled reviewer",
+    instructions="Inspect the workspace and retain useful lessons.",
+    default_manifest=manifest,
+    capabilities=[Memory(), Filesystem(), Shell()],
+)
+```
+
+Memory file layout:
+
+```
+workspace/
+  sessions/
+    <rollout-id>.jsonl
+  memories/
+    memory_summary.md       # Summary (injected at the start of each run)
+    MEMORY.md               # Detailed memory
+    raw_memories/            # Raw memories
+    rollout_summaries/       # Run summaries
+    skills/                  # Learned skills
+```
+
+## Supported Sandbox Providers
+
+| Provider | SDK Client | Description |
+|----------|------------|-------------|
+| Unix-local | UnixLocalSandboxClient | Local development, fastest startup |
+| Docker | DockerSandboxClient | Local container isolation |
+| **E2B** | **E2BSandboxClient** | **Managed sandbox (cube-sandbox compatible)** |
+| Modal | ModalSandboxClient | Managed sandbox |
+| Cloudflare | CloudflareSandboxClient | Edge sandbox |
+| Daytona | DaytonaSandboxClient | Managed dev environments |
+| Vercel | VercelSandboxClient | Web-app sandbox |
+| Blaxel | BlaxelSandboxClient | Managed sandbox |
+| Runloop | RunloopSandboxClient | Managed dev environments |
+
+## Relationship with cube-sandbox
+
+cube-sandbox implements an **E2B-compatible API**, which means:
+
+1. **Protocol compatibility**: the OpenAI Agents SDK's `E2BSandboxClient` can talk to cube-sandbox directly.
+2. **Architectural alignment**: the harness/compute separation highlighted in the docs is exactly what cube-sandbox + mini-swe-agent do.
+3. **Capability coverage**: Shell, Filesystem, port exposure, and state resume are all supported.
+4. **Advantage of cube-sandbox**: it provides **hardware-level isolation** (not container-level), and high-density deployments can fit thousands of instances on a single host.
+
+### Evolution directions worth watching
+
+- **Memory persistence**: cross-run memory is extremely valuable for RL training.
+- **Snapshot/Resume**: workspace snapshots and resume for pause-and-continue flows.
+- **Skills loading**: loading reusable skill packs from Git repositories.
+- **Declarative workspaces via Manifest**: mounting S3/GCS/Azure Blob and other cloud storage.
+
+## References
+
+- [OpenAI Sandbox Agents official docs](https://developers.openai.com/api/docs/guides/agents/sandboxes)
+- [OpenAI Agents SDK on GitHub](https://github.com/openai/openai-agents-python)
+- [E2B Sandbox docs](https://e2b.dev/docs)
+- [E2B + OpenAI Agents SDK guide](https://e2b.dev/docs/agents/openai-agents-sdk)

--- a/examples/openai-agents-example/openai-agents_zh.md
+++ b/examples/openai-agents-example/openai-agents_zh.md
@@ -1,0 +1,252 @@
+# OpenAI Agents SDK Sandbox 分析
+
+[English](openai-agents.md)
+
+> 来源：[OpenAI Sandbox Agents 官方文档](https://developers.openai.com/api/docs/guides/agents/sandboxes)
+
+## 概述
+
+OpenAI Agents SDK 中的 **Sandbox Agent** 在隔离的类 Unix 执行环境中运行，拥有文件系统、Shell、包管理、端口暴露、快照和可恢复状态。适用于 Agent 需要持久化工作空间（而非仅靠 prompt 上下文）的场景。
+
+## 核心架构
+
+Sandbox Agent 的关键设计是 **Harness（控制面）** 与 **Compute（执行面）** 的分离：
+
+- **Harness（控制面）**：负责 Agent 循环、模型调用、工具路由、审批、追踪、恢复
+- **Compute（执行面/Sandbox）**：负责文件读写、命令执行、依赖安装、端口暴露、状态快照
+
+这种分离让敏感的控制面工作留在可信基础设施中，沙箱专注于执行。
+
+## 何时使用 Sandbox
+
+- 任务需要操作一组文档，而非单条 prompt
+- Agent 需要写文件供后续检查
+- 需要运行命令、安装包、执行脚本
+- 工作流产生制品（Markdown、CSV、截图、网站等）
+- 需要暴露端口预览服务（notebook、报告、应用）
+- 工作需要暂停供人审核，之后恢复
+
+## Sandbox 组成
+
+| 组件 | 职责 |
+|------|------|
+| **SandboxAgent** | Agent 定义 + 沙箱默认配置 |
+| **Manifest** | 工作空间初始内容（文件、Git 仓库、云存储挂载、环境变量） |
+| **Capabilities** | 沙箱能力：Shell、Filesystem、Skills、Memory、Compaction |
+| **Sandbox Client** | Provider 集成（本地 Unix、Docker、托管服务） |
+| **Sandbox Session** | 活跃的执行环境 |
+| **SandboxRunConfig** | 每次运行的配置（会话来源、客户端选项） |
+
+### Manifest（工作空间声明）
+
+| 类型 | 用途 |
+|------|------|
+| File, Dir | 小型合成输入、辅助文件、输出目录 |
+| LocalFile, LocalDir | 从宿主机映射文件/目录到沙箱 |
+| GitRepo | 克隆仓库到工作空间 |
+| S3Mount, GCSMount, R2Mount, AzureBlobMount | 挂载外部云存储 |
+| environment | 沙箱启动时的环境变量 |
+| users, groups | 沙箱内的 OS 账户和组 |
+
+### Capabilities（能力）
+
+| 能力 | 场景 | 说明 |
+|------|------|------|
+| Shell | Agent 需要 Shell 访问 | 命令执行，支持交互式输入 |
+| Filesystem | Agent 需要编辑文件或查看图片 | apply_patch + view_image |
+| Skills | 需要技能发现和加载 | 从 Git 仓库或本地目录加载 |
+| Memory | 后续运行需要读取/生成记忆 | 跨运行的学习能力 |
+| Compaction | 长运行流程需要上下文压缩 | 自动裁剪上下文 |
+
+默认能力：`Filesystem()` + `Shell()` + `Compaction()`
+
+## 代码示例
+
+### 基本用法（Unix-local）
+
+```python
+import asyncio
+
+from agents import Runner
+from agents.run import RunConfig
+from agents.sandbox import Manifest, SandboxAgent, SandboxRunConfig
+from agents.sandbox.capabilities import Shell
+from agents.sandbox.entries import File
+from agents.sandbox.sandboxes.unix_local import UnixLocalSandboxClient
+
+manifest = Manifest(
+    entries={
+        "account_brief.md": File(
+            content=(
+                b"# Northwind Health\n\n"
+                b"- Segment: Mid-market healthcare analytics provider.\n"
+                b"- Renewal date: 2026-04-15.\n"
+            )
+        ),
+    }
+)
+
+agent = SandboxAgent(
+    name="Renewal Packet Analyst",
+    model="gpt-5.4",
+    instructions=(
+        "Review the workspace before answering. Keep the response concise, "
+        "business-focused, and cite the file names that support each conclusion."
+    ),
+    default_manifest=manifest,
+    capabilities=[Shell()],
+)
+
+
+async def main():
+    result = await Runner.run(
+        agent,
+        "Summarize the renewal blockers and recommend the next two actions.",
+        run_config=RunConfig(
+            sandbox=SandboxRunConfig(client=UnixLocalSandboxClient()),
+            workflow_name="Unix-local sandbox review",
+        ),
+    )
+    print(result.final_output)
+
+
+asyncio.run(main())
+```
+
+### 切换到 Docker Provider
+
+```python
+from docker import from_env as docker_from_env
+
+from agents import Runner
+from agents.run import RunConfig
+from agents.sandbox import SandboxRunConfig
+from agents.sandbox.config import DEFAULT_PYTHON_SANDBOX_IMAGE
+from agents.sandbox.sandboxes.docker import DockerSandboxClient, DockerSandboxClientOptions
+
+docker_run_config = RunConfig(
+    sandbox=SandboxRunConfig(
+        client=DockerSandboxClient(docker_from_env()),
+        options=DockerSandboxClientOptions(image=DEFAULT_PYTHON_SANDBOX_IMAGE),
+    ),
+    workflow_name="Docker sandbox review",
+)
+
+result = await Runner.run(
+    agent,
+    "Summarize the renewal blockers and recommend the next two actions.",
+    run_config=docker_run_config,
+)
+```
+
+### Resume（暂停恢复）
+
+```python
+# 第一次运行
+async with session:
+    first_result = await Runner.run(
+        agent,
+        "Build the first version of the app.",
+        max_turns=20,
+        run_config=RunConfig(
+            sandbox=SandboxRunConfig(session=session),
+        ),
+    )
+
+# 序列化会话状态
+frozen_session_state = client.deserialize_session_state(
+    client.serialize_session_state(session.state)
+)
+
+# 恢复并继续
+resumed_session = await client.resume(frozen_session_state)
+async with resumed_session:
+    second_result = await Runner.run(
+        agent,
+        conversation + [{"role": "user", "content": "Add tests."}],
+        max_turns=20,
+        run_config=RunConfig(
+            sandbox=SandboxRunConfig(session=resumed_session),
+        ),
+    )
+```
+
+## 状态管理
+
+| 状态类型 | 恢复内容 | 使用场景 |
+|----------|----------|----------|
+| **RunState** | Harness 侧状态（模型对话、工具状态、审批、Agent 位置） | 跨暂停继续工作流 |
+| **session_state** | 序列化的沙箱会话 | 应用/任务系统直接存储 Provider 会话状态 |
+| **snapshot** | 保存的工作空间内容 | 从已有文件和制品开始新运行 |
+
+会话解析优先级：
+1. 传入 `session` → 直接复用活跃会话
+2. 从 `RunState` 恢复 → 恢复存储的会话状态
+3. 传入 `session_state` → 从序列化状态恢复
+4. 以上都没有 → 创建新会话（使用 Manifest）
+
+## Memory（跨运行记忆）
+
+Agent 可以在运行之间保留学习成果：用户偏好、纠正、项目经验、任务摘要。
+
+```python
+from agents.sandbox.capabilities import Filesystem, Memory, Shell
+
+agent = SandboxAgent(
+    name="Memory-enabled reviewer",
+    instructions="Inspect the workspace and retain useful lessons.",
+    default_manifest=manifest,
+    capabilities=[Memory(), Filesystem(), Shell()],
+)
+```
+
+记忆文件结构：
+
+```
+workspace/
+  sessions/
+    <rollout-id>.jsonl
+  memories/
+    memory_summary.md       # 摘要（注入到每次运行开始）
+    MEMORY.md               # 详细记忆
+    raw_memories/            # 原始记忆
+    rollout_summaries/       # 运行摘要
+    skills/                  # 学到的技能
+```
+
+## 支持的 Sandbox Provider
+
+| Provider | SDK Client | 说明 |
+|----------|------------|------|
+| Unix-local | UnixLocalSandboxClient | 本地开发，最快启动 |
+| Docker | DockerSandboxClient | 本地容器隔离 |
+| **E2B** | **E2BSandboxClient** | **托管沙箱（cube-sandbox 兼容）** |
+| Modal | ModalSandboxClient | 托管沙箱 |
+| Cloudflare | CloudflareSandboxClient | 边缘沙箱 |
+| Daytona | DaytonaSandboxClient | 托管开发环境 |
+| Vercel | VercelSandboxClient | Web 应用沙箱 |
+| Blaxel | BlaxelSandboxClient | 托管沙箱 |
+| Runloop | RunloopSandboxClient | 托管开发环境 |
+
+## 与 cube-sandbox 的关系
+
+cube-sandbox 实现了 **E2B 兼容的 API**，这意味着：
+
+1. **协议兼容**：OpenAI Agents SDK 的 `E2BSandboxClient` 可直接对接 cube-sandbox
+2. **架构对齐**：文档中强调的 harness/compute 分离，正是 cube-sandbox + mini-swe-agent 的做法
+3. **能力覆盖**：Shell、Filesystem、端口暴露、状态恢复等能力均已支持
+4. **差异优势**：cube-sandbox 提供**硬件级隔离**（非容器级），高密度部署可单机承载千级实例
+
+### 值得关注的演进方向
+
+- **Memory 持久化**：跨运行记忆对 RL 训练价值极大
+- **Snapshot/Resume**：工作空间快照和恢复，支持暂停后继续
+- **Skills 加载**：从 Git 仓库加载可复用技能包
+- **Manifest 声明式工作空间**：支持挂载 S3/GCS/Azure Blob 等云存储
+
+## 参考链接
+
+- [OpenAI Sandbox Agents 官方文档](https://developers.openai.com/api/docs/guides/agents/sandboxes)
+- [OpenAI Agents SDK GitHub](https://github.com/openai/openai-agents-python)
+- [E2B Sandbox 文档](https://e2b.dev/docs)
+- [E2B + OpenAI Agents SDK 指南](https://e2b.dev/docs/agents/openai-agents-sdk)

--- a/examples/openai-agents-example/requirements.txt
+++ b/examples/openai-agents-example/requirements.txt
@@ -1,0 +1,2 @@
+openai-agents[e2b]
+python-dotenv

--- a/examples/openai-agents-example/simple_demo.py
+++ b/examples/openai-agents-example/simple_demo.py
@@ -1,0 +1,319 @@
+"""
+Minimal demo: OpenAI Agents SDK + CubeAPI (E2B-compatible).
+
+CubeAPI provides an E2B-compatible API, so we use E2BSandboxClient directly —
+no client code changes needed, just point E2B_API_URL to the CubeAPI service.
+
+Usage:
+    cp .env.example .env   # fill in real values
+    pip install -r requirements.txt
+
+    # Basic agent demo
+    python simple_demo.py
+    python simple_demo.py --question "What Linux distro is this?"
+
+    # Pause / Resume demo
+    python simple_demo.py --pause-resume
+
+    # Test without any custom SSL handling (use raw defaults)
+    python simple_demo.py --no-ssl-patch
+
+    # Test with SSL_CERT_FILE injected but also used for LLM calls
+    python simple_demo.py --llm-cube-ssl
+"""
+
+import argparse
+import asyncio
+import functools
+import io
+import os
+import time
+from pathlib import Path
+
+os.environ.setdefault("OPENAI_AGENTS_DISABLE_TRACING", "1")
+
+from dotenv import load_dotenv
+
+# ---------------------------------------------------------------------------
+# cube-sandbox envd compatibility patches:
+# 1. envd only supports "root" user; E2B SDK defaults to "user"
+# 2. envd 0.2.0 doesn't support the `stdin` kwarg in commands.run()
+# ---------------------------------------------------------------------------
+import e2b.envd.rpc as _e2b_rpc
+from e2b.sandbox_async.filesystem.filesystem import Filesystem as _AsyncFS
+from e2b.sandbox_async.commands.command import Commands as _AsyncCommands
+
+_e2b_rpc.default_username = "root"
+
+import inspect as _inspect
+
+for _name in ("read", "write", "write_files", "list", "exists",
+              "get_info", "remove", "rename", "make_dir", "watch_dir"):
+    _orig = getattr(_AsyncFS, _name, None)
+    if _orig is None:
+        continue
+    _params = list(_inspect.signature(_orig).parameters.keys())
+    _user_pos = _params.index("user") - 1 if "user" in _params else None  # -1 for self
+
+    def _make(fn, user_pos=_user_pos):
+        @functools.wraps(fn)
+        async def _wrapper(self, *a, **kw):
+            if user_pos is not None and len(a) > user_pos:
+                a = list(a)
+                if a[user_pos] is None:
+                    a[user_pos] = "root"
+                a = tuple(a)
+            else:
+                kw.setdefault("user", "root")
+            return await fn(self, *a, **kw)
+        return _wrapper
+    setattr(_AsyncFS, _name, _make(_orig))
+
+_orig_commands_run = _AsyncCommands.run
+
+@functools.wraps(_orig_commands_run)
+async def _patched_commands_run(self, *a, **kw):
+    if hasattr(self, "_envd_version"):
+        from e2b.sandbox_async.commands.command import ENVD_COMMANDS_STDIN
+        if self._envd_version < ENVD_COMMANDS_STDIN:
+            kw.pop("stdin", None)
+    return await _orig_commands_run(self, *a, **kw)
+
+_AsyncCommands.run = _patched_commands_run
+
+from agents import ModelSettings, Runner, set_tracing_disabled
+
+set_tracing_disabled(True)
+
+import httpx
+from openai import AsyncOpenAI
+from agents.models.openai_chatcompletions import OpenAIChatCompletionsModel
+from agents.run import RunConfig
+from agents.sandbox import Manifest, SandboxAgent, SandboxRunConfig
+from agents.sandbox.capabilities import Shell
+from agents.extensions.sandbox import (
+    E2BSandboxClient,
+    E2BSandboxClientOptions,
+    E2BSandboxType,
+)
+
+
+def load_env(need_llm: bool = True, ssl_patch: bool = True):
+    load_dotenv()
+    if os.environ.get("TOKENHUB_API_KEY") and not os.environ.get("OPENAI_API_KEY"):
+        os.environ["OPENAI_API_KEY"] = os.environ["TOKENHUB_API_KEY"]
+    if not os.environ.get("OPENAI_BASE_URL"):
+        os.environ["OPENAI_BASE_URL"] = "https://tokenhub.tencentmaas.com/v1"
+
+    required = ("E2B_API_KEY", "E2B_API_URL")
+    if need_llm:
+        required = ("OPENAI_API_KEY", *required)
+    for key in required:
+        if not os.environ.get(key):
+            raise SystemExit(f"Missing env var: {key}")
+
+    if ssl_patch:
+        cube_ssl = os.environ.get("CUBE_SSL_CERT_FILE")
+        if cube_ssl and os.path.isfile(cube_ssl):
+            os.environ["SSL_CERT_FILE"] = cube_ssl
+            print(f"[ssl] SSL_CERT_FILE={cube_ssl}")
+    else:
+        print("[ssl] skipped — no custom cert handling")
+
+
+def make_model(model_name: str, ssl_patch: bool = True, llm_ssl_override: bool = True) -> OpenAIChatCompletionsModel:
+    """TokenHub only supports Chat Completions API, not the Responses API.
+
+    ssl_patch=True + llm_ssl_override=True (default):
+        Force the LLM http client to use the system CA bundle so that
+        SSL_CERT_FILE (set for cube gRPC) doesn't break TokenHub HTTPS calls.
+    ssl_patch=True + llm_ssl_override=False (--llm-cube-ssl):
+        SSL_CERT_FILE is still injected for cube gRPC, but the LLM client
+        also uses it — tests whether cube's cert is trusted for LLM calls too.
+    ssl_patch=False (--no-ssl-patch):
+        No SSL customisation at all; use raw httpx defaults.
+    """
+    if ssl_patch and llm_ssl_override:
+        import ssl
+        ssl_ctx = ssl.create_default_context()
+        client = AsyncOpenAI(
+            timeout=httpx.Timeout(120, connect=15),
+            http_client=httpx.AsyncClient(verify=ssl_ctx),
+        )
+        print("[ssl] LLM client: system CA bundle (SSL_CERT_FILE isolated)")
+    else:
+        client = AsyncOpenAI(timeout=httpx.Timeout(120, connect=15))
+        if ssl_patch:
+            print("[ssl] LLM client: httpx default (will use SSL_CERT_FILE if set)")
+        else:
+            print("[ssl] LLM client: httpx raw default (no SSL customisation)")
+    bare = model_name.split("/", 1)[-1] if "/" in model_name else model_name
+    return OpenAIChatCompletionsModel(model=bare, openai_client=client)
+
+
+# ---------------------------------------------------------------------------
+# Demo 1: Basic agent run
+# ---------------------------------------------------------------------------
+async def run_agent(model: str, question: str, template: str, timeout: int,
+                    ssl_patch: bool = True, llm_ssl_override: bool = True):
+    print(f"Model:    {model}")
+    print(f"Template: {template}")
+    print(f"CubeAPI:  {os.environ['E2B_API_URL']}")
+    print(f"Question: {question}\n")
+
+    agent = SandboxAgent(
+        name="Cube Demo Agent",
+        model=make_model(model, ssl_patch=ssl_patch, llm_ssl_override=llm_ssl_override),
+        instructions=(
+            "You are a helpful assistant running inside a cloud sandbox. "
+            "Use shell commands to explore the environment and answer questions. "
+            "Be concise."
+        ),
+        default_manifest=Manifest(),
+        capabilities=[Shell()],
+        model_settings=ModelSettings(tool_choice="auto"),
+    )
+
+    run_config = RunConfig(
+        sandbox=SandboxRunConfig(
+            client=E2BSandboxClient(),
+            options=E2BSandboxClientOptions(
+                sandbox_type=E2BSandboxType.E2B,
+                template=template,
+                timeout=timeout,
+            ),
+        ),
+        workflow_name="Cube simple demo",
+    )
+
+    print("Creating sandbox & running agent ...")
+    result = await Runner.run(agent, question, run_config=run_config)
+    print(f"\n{'='*60}")
+    print(result.final_output)
+
+
+# ---------------------------------------------------------------------------
+# Demo 2: Pause / Resume — verify sandbox state survives a stop/resume cycle
+# ---------------------------------------------------------------------------
+MARKER_PATH = Path("pause-resume-test.txt")
+MARKER_CONTENT = "cube sandbox pause/resume works!\n"
+
+
+async def run_pause_resume(template: str, timeout: int):
+    """Create sandbox → write file → pause → resume → verify file persists."""
+    print(f"Template: {template}")
+    print(f"CubeAPI:  {os.environ['E2B_API_URL']}")
+    print()
+
+    client = E2BSandboxClient()
+    options = E2BSandboxClientOptions(
+        sandbox_type=E2BSandboxType.E2B,
+        template=template,
+        timeout=timeout,
+        pause_on_exit=True,
+    )
+
+    # Step 1: Create sandbox and write a marker file
+    print("[step 1] Creating sandbox ...")
+    t0 = time.monotonic()
+    session = await client.create(options=options, manifest=Manifest())
+    print(f"         Created in {(time.monotonic()-t0)*1000:.0f} ms  (sandbox_id={session.state.sandbox_id})")
+
+    t1 = time.monotonic()
+    await session.start()
+    print(f"         Started in {(time.monotonic()-t1)*1000:.0f} ms")
+
+    # Write marker file
+    print(f"[step 2] Writing marker file: {MARKER_PATH}")
+    await session.write(MARKER_PATH, io.BytesIO(MARKER_CONTENT.encode("utf-8")))
+
+    result = await session.exec(f"cat {MARKER_PATH}")
+    stdout = result.stdout if hasattr(result, "stdout") else str(result)
+    if isinstance(stdout, bytes):
+        stdout = stdout.decode("utf-8")
+    print(f"         Content before pause: {stdout.strip()!r}")
+
+    # Step 3: Pause (stop + shutdown with pause_on_exit=True)
+    print("[step 3] Pausing sandbox ...")
+    t2 = time.monotonic()
+    saved_state = session.state
+    await session.stop()
+    await session.shutdown()
+    print(f"         Paused in {(time.monotonic()-t2)*1000:.0f} ms")
+
+    # Step 4: Resume
+    print("[step 4] Resuming sandbox ...")
+    t3 = time.monotonic()
+    resumed_session = await client.resume(saved_state)
+    await resumed_session.start()
+    print(f"         Resumed in {(time.monotonic()-t3)*1000:.0f} ms")
+
+    # Step 5: Verify marker file persists
+    print(f"[step 5] Reading marker file after resume: {MARKER_PATH}")
+    try:
+        restored = await resumed_session.read(MARKER_PATH)
+        restored_text = restored.read()
+        if isinstance(restored_text, bytes):
+            restored_text = restored_text.decode("utf-8")
+
+        if restored_text.strip() == MARKER_CONTENT.strip():
+            print(f"         Content after resume:  {restored_text.strip()!r}")
+            print(f"\n{'='*60}")
+            print("PASS: Pause/Resume round-trip succeeded!")
+            print(f"      File content preserved across pause/resume cycle.")
+        else:
+            print(f"         Expected: {MARKER_CONTENT.strip()!r}")
+            print(f"         Got:      {restored_text.strip()!r}")
+            print(f"\n{'='*60}")
+            print("FAIL: Content mismatch after resume.")
+    except Exception as e:
+        print(f"         Error reading file: {e}")
+        print(f"\n{'='*60}")
+        print("FAIL: Could not read marker file after resume.")
+    finally:
+        # Cleanup: kill (not pause) the sandbox
+        print("\n[cleanup] Destroying sandbox ...")
+        resumed_session.state.pause_on_exit = False
+        t4 = time.monotonic()
+        await resumed_session.shutdown()
+        print(f"          Done in {(time.monotonic()-t4)*1000:.0f} ms")
+
+    total = (time.monotonic() - t0) * 1000
+    print(f"          Total: {total:.0f} ms")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Minimal OpenAI Agents + CubeAPI demo")
+    parser.add_argument("--model", default="openai/glm-5.1")
+    parser.add_argument("--question", default="What OS is running? Show uname and the first 3 lines of /etc/os-release.")
+    parser.add_argument("--template", default=None, help="Cube template ID (or set CUBE_TEMPLATE_ID)")
+    parser.add_argument("--timeout", type=int, default=300, help="Sandbox timeout in seconds")
+    parser.add_argument("--pause-resume", action="store_true", dest="pause_resume",
+                        help="Run pause/resume demo instead of agent demo")
+    parser.add_argument("--no-ssl-patch", action="store_false", dest="ssl_patch",
+                        default=True,
+                        help="Disable custom SSL handling (no SSL_CERT_FILE override, "
+                             "no system-CA LLM client) — use raw defaults")
+    parser.add_argument("--llm-cube-ssl", action="store_false", dest="llm_ssl_override",
+                        default=True,
+                        help="Let LLM client use SSL_CERT_FILE (cube cert) instead of "
+                             "the system CA bundle — tests cube cert for TokenHub calls")
+    args = parser.parse_args()
+
+    load_env(need_llm=not args.pause_resume, ssl_patch=args.ssl_patch)
+
+    template = args.template or os.environ.get("CUBE_TEMPLATE_ID")
+    if not template:
+        raise SystemExit("Missing template: set CUBE_TEMPLATE_ID or pass --template")
+
+    if args.pause_resume:
+        asyncio.run(run_pause_resume(template=template, timeout=args.timeout))
+    else:
+        asyncio.run(run_agent(
+            ssl_patch=args.ssl_patch,
+            llm_ssl_override=args.llm_ssl_override,
+            model=args.model,
+            question=args.question,
+            template=template,
+            timeout=args.timeout,
+        ))


### PR DESCRIPTION
- Add openai-agents-example with simple_demo.py and main.py (SWE-bench Django debugging)
- Add openai-agents-code-interpreter with two demos (generic E2B + Jupyter kernel)
- Add bilingual docs (EN + zh) for READMEs, integration guide, and sandbox concepts
- Update .gitignore for examples runtime artifacts (__pycache__/output/.scratch)

