### PR TITLE
docs: improve installation instructions clarity and add download warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,18 +162,20 @@ cd CubeSandbox/dev-env && ./login.sh   # SSH into the VM as root
 
 2. **Start the Cube Sandbox Service**
 
-Run the following command inside the dev VM you just logged into:
+Run **one** of the following commands inside the dev VM you just logged into, depending on your location:
 
-```bash
-curl -sL https://github.com/tencentcloud/CubeSandbox/raw/master/deploy/one-click/online-install.sh | bash
-```
+- **Global Users** (downloads from GitHub):
 
-> Slow GitHub downloads from mainland China? Set `MIRROR=cn` to fetch the release bundle from China CDN:
->
-> ```bash
-> curl -sL https://cnb.cool/CubeSandbox/CubeSandbox/-/git/raw/master/deploy/one-click/online-install.sh | MIRROR=cn bash
-> ```
->
+  ```bash
+  curl -sL https://github.com/tencentcloud/CubeSandbox/raw/master/deploy/one-click/online-install.sh | bash
+  ```
+
+- **中国用户请执行这条命令 (Mainland China)**:
+
+  ```bash
+  curl -sL https://cnb.cool/CubeSandbox/CubeSandbox/-/git/raw/master/deploy/one-click/online-install.sh | MIRROR=cn bash
+  ```
+
 > See [Quick Start — China mainland mirror](./docs/guide/quickstart.md#step-2-install) for details.
 
 3. **Create a Code Interpreter Sandbox Template**
@@ -194,6 +196,8 @@ Then run the following command to monitor the build progress:
 ```bash
 cubemastercli tpl watch --job-id <job_id>
 ```
+
+**⚠ The image is fairly large** — downloading, extracting, and building the template may take a while; please be patient.
 
 Wait for the command above to finish and the template status to reach `READY`. Note the **template ID** (`template_id`) from the output — you will need it in the next step.
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -156,11 +156,19 @@ cd CubeSandbox/dev-env && ./login.sh   # 以 root 登录虚机
 
 2. **启动Cube沙箱服务**
 
-在上述login进去的虚拟机内执行：
+在上述 login 进去的虚拟机内，根据你的网络环境执行**其中一条**命令：
 
-```bash
-curl -sL https://cnb.cool/CubeSandbox/CubeSandbox/-/git/raw/master/deploy/one-click/online-install.sh | MIRROR=cn bash
-```
+- **国内用户**（走 CDN 镜像，推荐）：
+
+  ```bash
+  curl -sL https://cnb.cool/CubeSandbox/CubeSandbox/-/git/raw/master/deploy/one-click/online-install.sh | MIRROR=cn bash
+  ```
+
+- **海外用户**（从 GitHub 下载）：
+
+  ```bash
+  curl -sL https://github.com/tencentcloud/CubeSandbox/raw/master/deploy/one-click/online-install.sh | bash
+  ```
 
 
 3. **制作代码解释器沙箱模板**
@@ -181,6 +189,8 @@ cubemastercli tpl create-from-image \
 ```bash
 cubemastercli tpl watch --job-id <job_id>
 ```
+
+⚠ 注意：由于镜像比较大，下载、解压、模板制作过程可能比较久，请耐心等待。
 
 等待上述命令结束，模板状态变为 `READY`。记录输出中的**模板 ID** (`template_id`)，下一步会用到。
 

--- a/docs/guide/quickstart.md
+++ b/docs/guide/quickstart.md
@@ -2,15 +2,11 @@
 
 Get a fully functional Cube Sandbox running in four steps — no source build required.
 
-The default path below uses the **development VM** under `dev-env/`: you
-clone the repo on your laptop / WSL / Linux box, boot a disposable
-OpenCloudOS 9 VM, and run the installer inside that VM. This works on
-the widest range of machines.
+The steps below boot a **disposable Linux VM** on your development machine (WSL / Linux) and install Cube Sandbox inside that VM.
+Follow this guide step by step — you can be up and running with Cube Sandbox in just a few minutes!
 
-::: tip Already have a bare-metal Linux server?
-If you have a dedicated bare-metal server (x86_64) with KVM enabled,
-you can **skip Step 1** and run the Step 2 installer directly on that
-server.
+::: tip Already have a bare-metal server?
+If you already have an x86_64 Linux bare-metal server with KVM enabled, you can **skip Step 1** and run the Step 2 installer directly on that server.
 :::
 
 ## Prerequisites

--- a/docs/guide/quickstart.md
+++ b/docs/guide/quickstart.md
@@ -97,6 +97,9 @@ Then run the following command to monitor the build progress:
 cubemastercli tpl watch --job-id <job_id>
 ```
 
+**⚠ The image is fairly large** — downloading, extracting, and building the template may take a while; please be patient.
+
+
 Wait for the command above to finish and the template status to reach `READY`.
 
 Note the **template ID** (`template_id`) from the output — you will need it in the next step.

--- a/docs/zh/guide/quickstart.md
+++ b/docs/zh/guide/quickstart.md
@@ -97,6 +97,9 @@ cubemastercli tpl create-from-image \
 cubemastercli tpl watch --job-id <job_id>
 ```
 
+⚠ 注意：由于镜像比较大，下载、解压、模板制作过程可能比较久，请耐心等待。
+
+
 等待上述命令结束，模板状态变为 `READY`。
 
 记录输出中的**模板 ID** (`template_id`)，下一步会用到。

--- a/docs/zh/guide/quickstart.md
+++ b/docs/zh/guide/quickstart.md
@@ -2,13 +2,11 @@
 
 四步完成 Cube Sandbox 的完整部署，无需本地构建。
 
-默认路径走的是 `dev-env/` 下的**开发虚机**：在笔记本 / WSL / Linux 机
-器上拉代码、起一台一次性的 OpenCloudOS 9 虚机，然后在虚机里跑安装脚
-本。这条路径对宿主机要求最宽松。
+下面的流程会在你的开发机（ WSL / Linux 机器）上起一台**一次性的 Linux 虚机**，然后在这台虚机里安装并体验 Cube Sandbox。
+请严格按照文档操作，这样能让你在几分钟内快速体验到CubeSandbox！
 
-::: tip 已经有 bare-metal 服务器？
-如果你已经有一台 x86_64 的裸金属 Linux 服务器且已开启 KVM，可以
-**跳过第一步**，直接在那台机器上执行第二步的安装脚本。
+::: tip 已经有裸金属服务器？
+如果你已经有一台开启了 KVM 的 x86_64 Linux 物理服务器，可以**跳过第一步**，直接在那台机器上执行第二步的安装命令。
 :::
 
 ## 前置条件
@@ -16,8 +14,8 @@
 宿主机满足下列任一条件即可：
 
 - **Windows 上的 WSL 2**（Windows 11 22H2+，并在 WSL 里启用嵌套虚拟化）
-- **x86_64 Linux 物理机**
 - **已开启嵌套虚拟化的 Linux 虚拟机**（VMWare启动Ubuntu 22.04，并且在虚拟机CPU设置那里，启用 “Virtualize Intel VT-x/EPT or AMD-V/RVI”）
+- **x86_64 Linux 物理机**
 - **x86_64 裸金属 Linux 服务器** 
 
 通用要求：
@@ -68,7 +66,6 @@ root shell，Cube Sandbox 就装在这里。
 ```bash
 curl -sL https://cnb.cool/CubeSandbox/CubeSandbox/-/git/raw/master/deploy/one-click/online-install.sh | MIRROR=cn bash
 ```
-:::
 
 ::: details 安装了哪些组件
 - E2B 兼容 REST API 监听在 `3000` 端口


### PR DESCRIPTION
- Separate global and China CDN install commands with clear headers
- Add warning about large image download time in quickstart guides
- Update both English and Chinese documentation