### PR TITLE
net: Disable GRO on primary NIC during initialization

### DIFF
--- a/network-agent/internal/service/local_service.go
+++ b/network-agent/internal/service/local_service.go
@@ -79,6 +79,10 @@ func NewLocalService(cfg Config) (Service, error) {
 	if err != nil {
 		return nil, err
 	}
+	err = disableGRO(cfg.EthName)
+	if err != nil {
+		CubeLog.WithContext(context.Background()).Warnf("network-agent failed to disable GRO on %s: %v", cfg.EthName, err)
+	}
 	cdev, err := getOrCreateCubeDev(allocator.GatewayIP(), allocator.mask, cfg.MvmMtu, cfg.MvmGwMacAddr)
 	if err != nil {
 		return nil, err

--- a/network-agent/internal/service/netdevice.go
+++ b/network-agent/internal/service/netdevice.go
@@ -65,6 +65,36 @@ type tapDevice struct {
 	LastStage    string
 }
 
+func disableGRO(ifName string) error {
+	const (
+		SIOCETHTOOL  = 0x8946
+		ETHTOOL_SGRO = 0x0000002c
+	)
+
+	type ethtoolValue struct {
+		Cmd  uint32
+		Data uint32
+	}
+
+	fd, err := unix.Socket(unix.AF_INET, unix.SOCK_DGRAM, 0)
+	if err != nil {
+		return fmt.Errorf("open socket for ethtool: %w", err)
+	}
+	defer unix.Close(fd)
+
+	value := ethtoolValue{Cmd: ETHTOOL_SGRO, Data: 0}
+
+	var ifr [40]byte
+	copy(ifr[:], ifName)
+	*(*uintptr)(unsafe.Pointer(&ifr[16])) = uintptr(unsafe.Pointer(&value))
+
+	_, _, errno := unix.Syscall(unix.SYS_IOCTL, uintptr(fd), SIOCETHTOOL, uintptr(unsafe.Pointer(&ifr[0])))
+	if errno != 0 {
+		return fmt.Errorf("disable GRO on %s: %w", ifName, errno)
+	}
+	return nil
+}
+
 func getGatewayMacAddr(ifName string) (string, error) {
 	link, err := netlinkLinkByName(ifName)
 	if err != nil {


### PR DESCRIPTION
Disable Generic Receive Offload (GRO) on the node uplink interface at service startup via ethtool ioctl (ETHTOOL_SGRO). This prevents the NIC from coalescing packets, which can cause issues with the TAP-based guest networking path.