### PR TITLE
docs: add .md extension to internal documentation links in index.md

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -27,15 +27,15 @@ features:
 
 ## Get Started
 
-- [Quick Start](./guide/quickstart) — from zero to a running sandbox in minutes
-- [Self-Build Deployment](./guide/self-build-deploy) — build from source and deploy on a single machine
-- [Multi-Node Cluster](./guide/multi-node-deploy) — scale to multiple nodes
-- [Architecture Overview](./architecture/overview) — understand the system design and core components
+- [Quick Start](./guide/quickstart.md) — from zero to a running sandbox in minutes
+- [Self-Build Deployment](./guide/self-build-deploy.md) — build from source and deploy on a single machine
+- [Multi-Node Cluster](./guide/multi-node-deploy.md) — scale to multiple nodes
+- [Architecture Overview](./architecture/overview.md) — understand the system design and core components
 
 
 ## Examples
 
 For SDK examples and end-to-end scenarios, see:
 
-- [Example Projects](./guide/tutorials/examples) — code execution, browser automation, OpenClaw integration, RL training, and more
+- [Example Projects](./guide/tutorials/examples.md) — code execution, browser automation, OpenClaw integration, RL training, and more
 - [Repository examples](https://github.com/tencentcloud/CubeSandbox/tree/master/examples) — full collection on GitHub

--- a/docs/zh/index.md
+++ b/docs/zh/index.md
@@ -27,14 +27,14 @@ features:
 
 ## 开始使用
 
-- [快速开始](./guide/quickstart) — 几分钟内从零到运行沙箱
-- [本地构建部署](./guide/self-build-deploy) — 从源码构建并在单机上部署
-- [多机集群部署](./guide/multi-node-deploy) — 扩展到多节点集群
-- [架构概览](../architecture/overview) — 了解系统设计与核心组件
+- [快速开始](./guide/quickstart.md) — 几分钟内从零到运行沙箱
+- [本地构建部署](./guide/self-build-deploy.md) — 从源码构建并在单机上部署
+- [多机集群部署](./guide/multi-node-deploy.md) — 扩展到多节点集群
+- [架构概览](../architecture/overview.md) — 了解系统设计与核心组件
 
 ## 场景示例
 
 SDK 示例与端到端场景：
 
-- [示例项目](./guide/tutorials/examples) — 代码执行、浏览器自动化、OpenClaw 集成、RL 训练等场景
+- [示例项目](./guide/tutorials/examples.md) — 代码执行、浏览器自动化、OpenClaw 集成、RL 训练等场景
 - [仓库示例合集](https://github.com/tencentcloud/CubeSandbox/tree/master/examples) — GitHub 上的完整示例


### PR DESCRIPTION
Fix broken internal links in index.md (EN/ZH) by adding .md extension