### PR TITLE
examples: add MiniMax direct API support

### DIFF
--- a/examples/mini-rl-training/.env.example
+++ b/examples/mini-rl-training/.env.example
@@ -24,5 +24,8 @@ TOKENHUB_API_KEY="<your-tokenhub-key>"
 # For DeepSeek models (deepseek/deepseek-chat, deepseek/deepseek-reasoner)
 DEEPSEEK_API_KEY="<your-deepseek-key>"
 
+# For MiniMax models (MiniMax-M2.7, MiniMax-M2.7-highspeed) — direct API
+MINIMAX_API_KEY="<your-minimax-api-key>"
+
 # For OpenAI-compatible models (set to TOKENHUB_API_KEY when using TokenHub)
 OPENAI_API_KEY="<your-openai-key>"

--- a/examples/mini-rl-training/.env.example
+++ b/examples/mini-rl-training/.env.example
@@ -24,8 +24,6 @@ TOKENHUB_API_KEY="<your-tokenhub-key>"
 # For DeepSeek models (deepseek/deepseek-chat, deepseek/deepseek-reasoner)
 DEEPSEEK_API_KEY="<your-deepseek-key>"
 
-# For MiniMax models (MiniMax-M2.7, MiniMax-M2.7-highspeed) — direct API
-MINIMAX_API_KEY="<your-minimax-api-key>"
-
-# For OpenAI-compatible models (set to TOKENHUB_API_KEY when using TokenHub)
+# For OpenAI-compatible models (set to your provider key, e.g. TOKENHUB_API_KEY
+# for TokenHub or your MiniMax key when pointing OPENAI_BASE_URL at MiniMax)
 OPENAI_API_KEY="<your-openai-key>"

--- a/examples/mini-rl-training/README.md
+++ b/examples/mini-rl-training/README.md
@@ -199,10 +199,10 @@ bash scripts/run-swebench.sh \
 
 ### MiniMax Direct Connection
 
-Connect directly to the [MiniMax API](https://platform.minimax.io/docs/api-reference/text-openai-api) without going through TokenHub.
+Connect directly to the [MiniMax API](https://platform.minimax.io/docs/api-reference/text-openai-api) without going through TokenHub. MiniMax exposes an OpenAI-compatible endpoint, so set `OPENAI_API_KEY` to your MiniMax key — `configs/e2b-minimax.yaml` already points `api_base` at `https://api.minimax.io/v1`.
 
 ```bash
-# Set MINIMAX_API_KEY in .env (or export it)
+# Set OPENAI_API_KEY=<your-minimax-key> in .env (or export it)
 
 # MiniMax-M2.7 (peak performance)
 bash scripts/run-swebench.sh \
@@ -216,8 +216,6 @@ bash scripts/run-swebench.sh \
   --config configs/e2b-minimax.yaml \
   --instance django__django-13447
 ```
-
-> `configs/e2b-minimax.yaml` points to `https://api.minimax.io/v1` and uses `MINIMAX_API_KEY`.
 
 ## Concurrent Evaluation
 

--- a/examples/mini-rl-training/README.md
+++ b/examples/mini-rl-training/README.md
@@ -197,6 +197,28 @@ bash scripts/run-swebench.sh \
   --instance django__django-13447
 ```
 
+### MiniMax Direct Connection
+
+Connect directly to the [MiniMax API](https://platform.minimax.io/docs/api-reference/text-openai-api) without going through TokenHub.
+
+```bash
+# Set MINIMAX_API_KEY in .env (or export it)
+
+# MiniMax-M2.7 (peak performance)
+bash scripts/run-swebench.sh \
+  --model openai/MiniMax-M2.7 \
+  --config configs/e2b-minimax.yaml \
+  --instance django__django-13447
+
+# MiniMax-M2.7-highspeed (faster, same performance)
+bash scripts/run-swebench.sh \
+  --model openai/MiniMax-M2.7-highspeed \
+  --config configs/e2b-minimax.yaml \
+  --instance django__django-13447
+```
+
+> `configs/e2b-minimax.yaml` points to `https://api.minimax.io/v1` and uses `MINIMAX_API_KEY`.
+
 ## Concurrent Evaluation
 
 Use `scripts/run-concurrent.py` for multi-model, multi-instance concurrent evaluation with sandbox pre-creation and TUI real-time monitoring.
@@ -308,7 +330,8 @@ cube-sandbox-rl-example/
 │   ├── e2b-tokenhub.yaml            # TokenHub model config
 │   ├── e2b-kimi.yaml                # Kimi K2.5 specific config
 │   ├── e2b-deepseek.yaml            # DeepSeek Chat config
-│   └── e2b-deepseek-reasoner.yaml   # DeepSeek Reasoner config
+│   ├── e2b-deepseek-reasoner.yaml   # DeepSeek Reasoner config
+│   └── e2b-minimax.yaml             # MiniMax direct API config
 ├── scripts/
 │   ├── setup-env.sh                 # One-click environment setup
 │   ├── inject-envd.sh               # Inject envd into SWE-bench image

--- a/examples/mini-rl-training/configs/e2b-minimax.yaml
+++ b/examples/mini-rl-training/configs/e2b-minimax.yaml
@@ -1,0 +1,150 @@
+agent:
+  system_template: |
+    You are a helpful assistant that can interact with a computer shell to solve programming tasks.
+  instance_template: |
+    <pr_description>
+    Consider the following PR description:
+    {{task}}
+    </pr_description>
+
+    <instructions>
+    # Task Instructions
+
+    ## Overview
+
+    You're a software engineer interacting continuously with a computer by submitting commands.
+    You'll be helping implement necessary changes to meet requirements in the PR description.
+    Your task is specifically to make changes to non-test files in the current directory in order to fix the issue described in the PR description in a way that is general and consistent with the codebase.
+    <IMPORTANT>This is an interactive process where you will think and issue AT LEAST ONE command, see the result, then think and issue your next command(s).</important>
+
+    For each response:
+
+    1. Include a THOUGHT section explaining your reasoning and what you're trying to accomplish
+    2. Provide one or more bash tool calls to execute
+
+    ## Important Boundaries
+
+    - MODIFY: Regular source code files in /testbed (this is the working directory for all your subsequent commands)
+    - DO NOT MODIFY: Tests, configuration files (pyproject.toml, setup.cfg, etc.)
+
+    ## Recommended Workflow
+
+    1. Analyze the codebase by finding and reading relevant files
+    2. Create a script to reproduce the issue
+    3. Edit the source code to resolve the issue
+    4. Verify your fix works by running your script again
+    5. Test edge cases to ensure your fix is robust
+
+    ## Command Execution Rules
+
+    You are operating in an environment where
+
+    1. You issue at least one command
+    2. The system executes the command(s) in a subshell
+    3. You see the result(s)
+    4. You write your next command(s)
+
+    Each response should include:
+
+    1. **Reasoning text** where you explain your analysis and plan
+    2. At least one tool call with your command
+
+    **CRITICAL REQUIREMENTS:**
+
+    - Your response SHOULD include reasoning text explaining what you're doing
+    - Your response MUST include AT LEAST ONE bash tool call. You can make MULTIPLE tool calls in a single response when the commands are independent (e.g., searching multiple files, reading different parts of the codebase).
+    - Directory or environment variable changes are not persistent. Every action is executed in a new subshell.
+    - However, you can prefix any action with `MY_ENV_VAR=MY_VALUE cd /path/to/working/dir && ...` or write/load environment variables from files
+
+    ## Environment Details
+
+    - You have a full Linux shell environment
+    - Always use non-interactive flags (-y, -f) for commands
+    - Avoid interactive tools like vi, nano, or any that require user input
+
+    ## Submission
+
+    When you've completed your work, you MUST submit your changes as a git patch.
+    Follow these steps IN ORDER, with SEPARATE commands:
+
+    Step 1: Create the patch file
+    Run `git diff -- path/to/file1 path/to/file2 > patch.txt` listing only the source files you modified.
+    Do NOT commit your changes.
+
+    <IMPORTANT>
+    The patch must only contain changes to the specific source files you modified to fix the issue.
+    Do not submit file creations or changes to any of the following files:
+    - test and reproduction files
+    - helper scripts, tests, or tools that you created
+    - installation, build, packaging, configuration, or setup scripts
+    - binary or compiled files
+    </IMPORTANT>
+
+    Step 2: Verify your patch
+    Inspect patch.txt to confirm it only contains your intended changes.
+
+    Step 3: Submit (EXACT command required)
+    ```bash
+    echo COMPLETE_TASK_AND_SUBMIT_FINAL_OUTPUT && cat patch.txt
+    ```
+
+    <CRITICAL>
+    - Creating/viewing the patch and submitting it MUST be separate commands.
+    - You CANNOT continue working on this task after submitting.
+    </CRITICAL>
+    </instructions>
+  step_limit: 100
+  cost_limit: 3.
+  mode: yolo
+
+environment:
+  cwd: "/testbed"
+  timeout: 60
+  user: "root"
+  environment_class: e2b
+
+model:
+  observation_template: |
+    {% if output.exception_info -%}
+    <exception>{{output.exception_info}}</exception>
+    {% endif -%}
+    <returncode>{{output.returncode}}</returncode>
+    {% if output.output | length < 10000 -%}
+    <output>
+    {{ output.output -}}
+    </output>
+    {%- else -%}
+    <warning>
+    The output of your last command was too long.
+    Please try a different command that produces less output.
+    </warning>
+    {%- set elided_chars = output.output | length - 10000 -%}
+    <output_head>
+    {{ output.output[:5000] }}
+    </output_head>
+    <elided_chars>
+    {{ elided_chars }} characters elided
+    </elided_chars>
+    <output_tail>
+    {{ output.output[-5000:] }}
+    </output_tail>
+    {%- endif -%}
+  format_error_template: |
+    Tool call error:
+
+    <error>
+    {{error}}
+    </error>
+
+    Every response needs to use the 'bash' tool at least once to execute commands.
+    Call the bash tool with your command as the argument:
+    - Tool: bash
+    - Arguments: {"command": "your_command_here"}
+
+    If you have completed your assignment, please consult the first message about how to
+    submit your solution.
+  model_kwargs:
+    api_base: "https://api.minimax.io/v1"
+    drop_params: true
+    parallel_tool_calls: true
+  cost_tracking: "ignore_errors"

--- a/examples/mini-rl-training/scripts/run-swebench.sh
+++ b/examples/mini-rl-training/scripts/run-swebench.sh
@@ -66,13 +66,6 @@ export E2B_API_KEY="${E2B_API_KEY:-}"
 export CUBE_TEMPLATE_ID="${CUBE_TEMPLATE_ID:-}"
 export HF_ENDPOINT="${HF_ENDPOINT:-https://hf-mirror.com}"
 export OPENAI_API_KEY="${OPENAI_API_KEY:-}"
-export MINIMAX_API_KEY="${MINIMAX_API_KEY:-}"
-
-# Auto-map MINIMAX_API_KEY → OPENAI_API_KEY when using the MiniMax config
-# (litellm uses OPENAI_API_KEY for openai-compatible endpoints with custom api_base)
-if [[ "$CONFIG" == *"minimax"* && -n "${MINIMAX_API_KEY:-}" && -z "${OPENAI_API_KEY:-}" ]]; then
-    export OPENAI_API_KEY="$MINIMAX_API_KEY"
-fi
 
 # SSL_CERT_FILE overrides Python's default CA bundle globally, which breaks
 # HTTPS to public sites (e.g. hf-mirror.com). Instead, pass it via a custom

--- a/examples/mini-rl-training/scripts/run-swebench.sh
+++ b/examples/mini-rl-training/scripts/run-swebench.sh
@@ -65,6 +65,14 @@ export E2B_API_URL="${E2B_API_URL:-}"
 export E2B_API_KEY="${E2B_API_KEY:-}"
 export CUBE_TEMPLATE_ID="${CUBE_TEMPLATE_ID:-}"
 export HF_ENDPOINT="${HF_ENDPOINT:-https://hf-mirror.com}"
+export OPENAI_API_KEY="${OPENAI_API_KEY:-}"
+export MINIMAX_API_KEY="${MINIMAX_API_KEY:-}"
+
+# Auto-map MINIMAX_API_KEY → OPENAI_API_KEY when using the MiniMax config
+# (litellm uses OPENAI_API_KEY for openai-compatible endpoints with custom api_base)
+if [[ "$CONFIG" == *"minimax"* && -n "${MINIMAX_API_KEY:-}" && -z "${OPENAI_API_KEY:-}" ]]; then
+    export OPENAI_API_KEY="$MINIMAX_API_KEY"
+fi
 
 # SSL_CERT_FILE overrides Python's default CA bundle globally, which breaks
 # HTTPS to public sites (e.g. hf-mirror.com). Instead, pass it via a custom

--- a/examples/openai-agents-example/.env.example
+++ b/examples/openai-agents-example/.env.example
@@ -4,6 +4,10 @@ TOKENHUB_API_KEY="<your-tokenhub-api-key>"
 # OPENAI_API_KEY="<your-api-key>"
 # OPENAI_BASE_URL="https://tokenhub.tencentmaas.com/v1"
 
+# MiniMax API (OpenAI-compatible, direct connection)
+# OPENAI_API_KEY="<your-minimax-api-key>"
+# OPENAI_BASE_URL="https://api.minimax.io/v1"
+
 # cube-sandbox (E2B compatible) connection
 E2B_API_URL="http://<your-cube-sandbox-ip>:3000"
 E2B_API_KEY="<your-e2b-api-key>"

--- a/examples/openai-agents-example/README.md
+++ b/examples/openai-agents-example/README.md
@@ -35,7 +35,7 @@ Edit `.env`:
 | Variable | Description |
 |----------|-------------|
 | `TOKENHUB_API_KEY` | TokenHub API key (automatically mapped to `OPENAI_API_KEY`) |
-| `OPENAI_BASE_URL` | LLM endpoint (defaults to `https://tokenhub.tencentmaas.com/v1`) |
+| `OPENAI_BASE_URL` | LLM endpoint (defaults to `https://tokenhub.tencentmaas.com/v1`; set to `https://api.minimax.io/v1` for MiniMax direct) |
 | `E2B_API_URL` | CubeAPI URL, e.g. `http://<cube-host>:3000` |
 | `E2B_API_KEY` | CubeAPI auth key |
 | `CUBE_TEMPLATE_ID` | Sandbox template ID |
@@ -68,6 +68,9 @@ A minimal Shell Agent that demonstrates the core steps of integrating with CubeS
 # Basic Agent Q&A
 python simple_demo.py
 python simple_demo.py --question "What Linux distro is this?"
+
+# Use MiniMax-M2.7 directly (set OPENAI_API_KEY and OPENAI_BASE_URL first)
+python simple_demo.py --model MiniMax-M2.7
 
 # Pause / Resume demo (write file → pause → resume → verify file)
 python simple_demo.py --pause-resume
@@ -140,8 +143,11 @@ python main.py
 # Custom question
 python main.py --question "What Python version is installed? Show the Django version too."
 
-# Specify model
+# Specify model (TokenHub)
 python main.py --model openai/deepseek-v3.2
+
+# Use MiniMax-M2.7 directly (set OPENAI_API_KEY=<minimax-key> and OPENAI_BASE_URL=https://api.minimax.io/v1)
+python main.py --model MiniMax-M2.7
 
 # Only test sandbox connectivity (do not call the LLM)
 python main.py --sandbox-only


### PR DESCRIPTION
## Summary

This PR adds first-class support for calling the [MiniMax API](https://platform.minimax.io/docs/api-reference/text-openai-api) directly, without routing through the TokenHub proxy. The integration is modelled after the existing DeepSeek and Kimi direct-connection configs.

**Changes:**

- `examples/mini-rl-training/configs/e2b-minimax.yaml` — new litellm config pointing to `https://api.minimax.io/v1`, compatible with `MiniMax-M2.7` and `MiniMax-M2.7-highspeed`
- `examples/mini-rl-training/.env.example` — add `MINIMAX_API_KEY` entry alongside the other provider keys
- `examples/mini-rl-training/scripts/run-swebench.sh` — export `MINIMAX_API_KEY`; auto-map it to `OPENAI_API_KEY` when the MiniMax config is selected (litellm uses `OPENAI_API_KEY` for OpenAI-compatible endpoints with a custom `api_base`)
- `examples/mini-rl-training/README.md` — add "MiniMax Direct Connection" usage section (parallel to "DeepSeek Direct Connection") and list `e2b-minimax.yaml` in the directory structure table
- `examples/openai-agents-example/.env.example` — add commented MiniMax endpoint example
- `examples/openai-agents-example/README.md` — mention MiniMax as a supported OpenAI-compatible LLM option

**Usage (after this PR):**

```bash
# Set MINIMAX_API_KEY in .env
bash scripts/run-swebench.sh \
  --model openai/MiniMax-M2.7 \
  --config configs/e2b-minimax.yaml \
  --instance django__django-13447
```

## API Reference

- Chat (OpenAI Compatible): https://platform.minimax.io/docs/api-reference/text-openai-api