### PR TITLE
feat(dev-env): add CubeProxy HTTP/HTTPS port forwarding and dev-sidecar example

### DIFF
--- a/dev-env/README.md
+++ b/dev-env/README.md
@@ -12,6 +12,8 @@ Linux host, with SSH and the Cube API port-forwarded back to localhost:
 ```text
 SSH      : 127.0.0.1:10022 -> guest:22
 Cube API : 127.0.0.1:13000 -> guest:3000
+Cube HTTP: 127.0.0.1:11080 -> guest:80
+Cube TLS : 127.0.0.1:11443 -> guest:443
 ```
 
 Use this when you want to:
@@ -174,7 +176,7 @@ README as `data-log-<timestamp>.tar.gz`.
 | No `/dev/kvm` inside the guest | Nested KVM disabled on the host | Enable nested virtualization on the host, then reboot the VM |
 | `./login.sh` fails to connect | VM not booted yet, or host port 10022 is busy | Check that `./run_vm.sh` is still running, or set `SSH_PORT` |
 | `df -h /` inside the guest is still small | `prepare_image.sh` never finished the auto-grow step | Inspect `.workdir/qemu-serial.log`, then `scp internal/grow_rootfs.sh` into the guest and run it manually |
-| Host port 13000 already taken | Some other service binds `13000` | Start with `CUBE_API_PORT=23000 ./run_vm.sh` |
+| Host port 13000 / 11080 / 11443 already taken | Some other service binds the forwarded dev-env ports | Start with `CUBE_API_PORT=23000 CUBE_PROXY_HTTP_PORT=21080 CUBE_PROXY_HTTPS_PORT=21443 ./run_vm.sh` |
 | Cube components gone after VM reboot | Autostart not enabled | Run `./cube-autostart.sh` once |
 | `sync_to_vm.sh` rolled back | `quickcheck` failed with new binaries | Check `/data/log/` in the guest, fix the bug, then re-run `sync_to_vm.sh` |
 
@@ -221,6 +223,8 @@ Generated artifacts (qcow2, pid file, serial log) live in `.workdir/`.
 | `VM_CPUS` | `4` | Guest vCPUs. |
 | `SSH_PORT` | `10022` | Host -> guest SSH. |
 | `CUBE_API_PORT` | `13000` | Host -> guest Cube API. |
+| `CUBE_PROXY_HTTP_PORT` | `11080` | Host -> guest CubeProxy HTTP (`guest:80`). |
+| `CUBE_PROXY_HTTPS_PORT` | `11443` | Host -> guest CubeProxy HTTPS (`guest:443`). |
 | `REQUIRE_NESTED_KVM` | `1` | Refuse to boot if host nested KVM is off. `0` to bypass (sandboxes won't run). |
 
 #### `login.sh`

--- a/dev-env/README_zh.md
+++ b/dev-env/README_zh.md
@@ -12,6 +12,8 @@
 ```text
 SSH      : 127.0.0.1:10022 -> guest:22
 Cube API : 127.0.0.1:13000 -> guest:3000
+Cube HTTP: 127.0.0.1:11080 -> guest:80
+Cube TLS : 127.0.0.1:11443 -> guest:443
 ```
 
 适用场景：
@@ -160,7 +162,7 @@ MODE=release ./sync_to_vm.sh
 | 虚机内没有 `/dev/kvm` | 宿主机未开启 nested KVM | 在宿主机启用 nested virtualization，再重启虚机 |
 | `./login.sh` 连不上 | 虚机还没启动，或宿主机 10022 端口被占用 | 确认 `./run_vm.sh` 还在运行，或换 `SSH_PORT` |
 | 虚机里 `df -h /` 还是很小 | `prepare_image.sh` 没走完自动扩容 | 查看 `.workdir/qemu-serial.log`，然后把 `internal/grow_rootfs.sh` scp 进去手动跑一次 |
-| 宿主机 13000 端口被占 | 本机有别的服务在用 | 用 `CUBE_API_PORT=23000 ./run_vm.sh` |
+| 宿主机 13000 / 11080 / 11443 端口被占 | 本机有别的服务在用这些 dev-env 转发端口 | 用 `CUBE_API_PORT=23000 CUBE_PROXY_HTTP_PORT=21080 CUBE_PROXY_HTTPS_PORT=21443 ./run_vm.sh` |
 | 虚机重启后 cube 组件没了 | 还没开启 autostart | 跑一次 `./cube-autostart.sh` |
 | `sync_to_vm.sh` 自动回滚了 | `quickcheck` 用新二进制失败 | 看 guest 里 `/data/log/`，修 bug 后重新跑 `sync_to_vm.sh` |
 
@@ -207,6 +209,8 @@ dev-env/
 | `VM_CPUS` | `4` | guest vCPU 数。 |
 | `SSH_PORT` | `10022` | 宿主机 → guest SSH。 |
 | `CUBE_API_PORT` | `13000` | 宿主机 → guest Cube API。 |
+| `CUBE_PROXY_HTTP_PORT` | `11080` | 宿主机 → guest CubeProxy HTTP（`guest:80`）。 |
+| `CUBE_PROXY_HTTPS_PORT` | `11443` | 宿主机 → guest CubeProxy HTTPS（`guest:443`）。 |
 | `REQUIRE_NESTED_KVM` | `1` | 宿主机未开 nested KVM 时拒绝启动。`0` 跳过（沙箱跑不起来）。 |
 
 #### `login.sh`

--- a/dev-env/run_vm.sh
+++ b/dev-env/run_vm.sh
@@ -8,6 +8,8 @@
 # mode networking with port forwards:
 #   - host :10022 -> guest :22  (ssh, used by login.sh / sync_to_vm.sh / copy_logs.sh)
 #   - host :13000 -> guest :3000 (cube-api HTTP endpoint)
+#   - host :11080 -> guest :80   (cube-proxy HTTP endpoint)
+#   - host :11443 -> guest :443  (cube-proxy HTTPS endpoint)
 #
 # Run prepare_image.sh first to produce the image. This script is the normal
 # way to start the VM for day-to-day development.
@@ -33,6 +35,8 @@ VM_MEMORY_MB="${VM_MEMORY_MB:-8192}"
 VM_CPUS="${VM_CPUS:-4}"
 SSH_PORT="${SSH_PORT:-10022}"
 CUBE_API_PORT="${CUBE_API_PORT:-13000}"
+CUBE_PROXY_HTTP_PORT="${CUBE_PROXY_HTTP_PORT:-11080}"
+CUBE_PROXY_HTTPS_PORT="${CUBE_PROXY_HTTPS_PORT:-11443}"
 REQUIRE_NESTED_KVM="${REQUIRE_NESTED_KVM:-1}"
 VM_BACKGROUND="${VM_BACKGROUND:-0}"
 QEMU_PIDFILE="${QEMU_PIDFILE:-${WORK_DIR}/qemu.pid}"
@@ -119,6 +123,8 @@ log_info "  Login user : opencloudos"
 log_info "  Password   : opencloudos"
 log_info "  SSH        : ssh -p ${SSH_PORT} opencloudos@127.0.0.1"
 log_info "  Cube API   : http://127.0.0.1:${CUBE_API_PORT} -> guest:3000"
+log_info "  CubeProxy  : http://127.0.0.1:${CUBE_PROXY_HTTP_PORT} -> guest:80"
+log_info "  CubeProxy  : https://127.0.0.1:${CUBE_PROXY_HTTPS_PORT} -> guest:443"
 if [[ "${VM_BACKGROUND}" == "1" ]]; then
   log_info "Background mode:"
   log_info "  PID file   : ${QEMU_PIDFILE}"
@@ -136,7 +142,7 @@ QEMU_ARGS=(
   -smp "${VM_CPUS}"
   -device virtio-rng-pci
   -drive if=virtio,format=qcow2,file="${IMAGE_PATH}"
-  -nic user,model=virtio-net-pci,hostfwd=tcp::"${SSH_PORT}"-:22,hostfwd=tcp::"${CUBE_API_PORT}"-:3000
+  -nic user,model=virtio-net-pci,hostfwd=tcp::"${SSH_PORT}"-:22,hostfwd=tcp::"${CUBE_API_PORT}"-:3000,hostfwd=tcp::"${CUBE_PROXY_HTTP_PORT}"-:80,hostfwd=tcp::"${CUBE_PROXY_HTTPS_PORT}"-:443
 )
 
 if [[ "${VM_BACKGROUND}" == "1" ]]; then

--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -33,7 +33,7 @@ export default withMermaid(defineConfig({
                 { text: 'Multi-Node Cluster', link: '/guide/multi-node-deploy' },
                 { text: 'Development Environment (QEMU VM)', link: '/guide/dev-environment' }
               ]
-            },
+            },            
             {
               text: 'Core Concepts',
               items: [
@@ -54,6 +54,12 @@ export default withMermaid(defineConfig({
                 { text: 'Template Inspection & Request Preview', link: '/guide/template-inspection-and-preview' },
                 { text: 'CubeProxy TLS', link: '/guide/cubeproxy-tls' },
                 { text: 'Authentication', link: '/guide/authentication' }
+              ]
+            },
+            {
+              text: 'Developer Docs',
+              items: [
+                { text: 'Connect to an Existing Cube Cluster', link: '/guide/connect-existing-cluster' }
               ]
             }
           ],
@@ -94,6 +100,7 @@ export default withMermaid(defineConfig({
                 { text: '开发环境（QEMU 虚机）', link: '/zh/guide/dev-environment' }
               ]
             },
+            
             {
               text: '核心概念',
               items: [
@@ -114,6 +121,12 @@ export default withMermaid(defineConfig({
                 { text: '模板检查与请求预览', link: '/zh/guide/template-inspection-and-preview' },
                 { text: 'CubeProxy TLS 配置', link: '/zh/guide/cubeproxy-tls' },
                 { text: '鉴权', link: '/zh/guide/authentication' }
+              ]
+            },
+            {
+              text: '开发文档',
+              items: [
+                { text: '连接到已有 Cube 集群', link: '/zh/guide/connect-existing-cluster' }
               ]
             }
           ],

--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -33,7 +33,7 @@ export default withMermaid(defineConfig({
                 { text: 'Multi-Node Cluster', link: '/guide/multi-node-deploy' },
                 { text: 'Development Environment (QEMU VM)', link: '/guide/dev-environment' }
               ]
-            },            
+            },
             {
               text: 'Core Concepts',
               items: [
@@ -100,7 +100,6 @@ export default withMermaid(defineConfig({
                 { text: '开发环境（QEMU 虚机）', link: '/zh/guide/dev-environment' }
               ]
             },
-            
             {
               text: '核心概念',
               items: [

--- a/docs/guide/connect-existing-cluster.md
+++ b/docs/guide/connect-existing-cluster.md
@@ -1,6 +1,6 @@
 # Connect to an Existing Cube Cluster
 
-If you just want the fastest path, start with the example directory:
+To get started quickly, check out the example directory:
 
 - Example: [examples/e2b-dev-sidecar](https://github.com/tencentcloud/CubeSandbox/tree/master/examples/e2b-dev-sidecar)
 - Chinese README: [README_zh.md](https://github.com/tencentcloud/CubeSandbox/tree/master/examples/e2b-dev-sidecar/README_zh.md)

--- a/docs/guide/connect-existing-cluster.md
+++ b/docs/guide/connect-existing-cluster.md
@@ -1,0 +1,105 @@
+# Connect to an Existing Cube Cluster
+
+If you just want the fastest path, start with the example directory:
+
+- Example: [examples/e2b-dev-sidecar](https://github.com/tencentcloud/CubeSandbox/tree/master/examples/e2b-dev-sidecar)
+- Chinese README: [README_zh.md](https://github.com/tencentcloud/CubeSandbox/tree/master/examples/e2b-dev-sidecar/README_zh.md)
+- English README: [README.md](https://github.com/tencentcloud/CubeSandbox/tree/master/examples/e2b-dev-sidecar/README.md)
+
+## Why we need `dev-sidecar`
+
+E2B expects sandbox URLs to resolve to the target cluster's public IP through wildcard DNS. In a production deployment, that usually means adding a private DNS A record like:
+
+```text
+*.cube.app => <your cube master node ip>
+```
+
+That is inconvenient during local development. Setting up wildcard DNS on a developer machine is usually the annoying part, so `dev-sidecar` exists to let you connect your local machine to a Cube cluster and create sandboxes without changing the E2B SDK itself.
+
+This page only does one thing: help you quickly decide how to fill the `dev-sidecar` environment variables.
+
+## Start With the Happy Path
+
+### Case 1: You started Cube locally with `dev-env`
+
+This is the most natural and recommended development path for `dev-sidecar`.
+
+If you followed [Development Environment (QEMU VM)](./dev-environment), the defaults in `examples/e2b-dev-sidecar/env.example` were already chosen for this exact case.
+
+Do this:
+
+```bash
+cd examples/e2b-dev-sidecar
+pip install -r requirements.txt
+cp env.example .env
+```
+
+Then usually you only need to fill in the template ID:
+
+```bash
+E2B_API_URL="http://127.0.0.1:13000"
+CUBE_REMOTE_PROXY_BASE="https://127.0.0.1:11443"
+E2B_API_KEY="dummy"
+CUBE_TEMPLATE_ID="<your-template-id>"
+```
+
+Run:
+
+```bash
+python demo.py
+```
+
+The key point is:
+
+- `127.0.0.1:13000` is not arbitrary. It is the CubeAPI endpoint exposed by `dev-env`.
+- `127.0.0.1:11443` is not arbitrary. It is the CubeProxy endpoint exposed by `dev-env`.
+
+So if you already booted local `dev-env`, you usually do not need to change the addresses. You mostly just fill in the template ID.
+
+### Case 2: You want to connect to a Cube cluster on another machine
+
+You still use the same `dev-sidecar` example. You only replace the default addresses with the real endpoints of that remote cluster:
+
+```bash
+E2B_API_URL="http://<node-ip>:3000"
+CUBE_REMOTE_PROXY_BASE="https://<node-ip>:443"
+E2B_API_KEY="dummy"
+CUBE_TEMPLATE_ID="<your-template-id>"
+```
+
+Then run the same command:
+
+```bash
+python demo.py
+```
+
+## Just Remember These
+
+- `E2B_API_URL`
+  Control-plane endpoint. In `dev-env`, the default is `http://127.0.0.1:13000`.
+- `CUBE_REMOTE_PROXY_BASE`
+  Data-plane endpoint. In `dev-env`, the default is `https://127.0.0.1:11443`.
+- `E2B_API_KEY`
+  Must be non-empty for the SDK. If auth is enabled, use the real key.
+- `CUBE_TEMPLATE_ID`
+  The template ID used when creating the sandbox.
+
+You usually do not need to think about the other variables first. For most development flows, getting these four values right is enough.
+
+## Common Mistakes
+
+- You are using local `dev-env`, but configured the in-VM addresses instead of the host-exposed `13000/11443` ports
+- You pointed `CUBE_REMOTE_PROXY_BASE` at the sidecar's own listening address instead of CubeProxy
+- You forgot to set `CUBE_TEMPLATE_ID`
+- Auth is enabled on the cluster, but `E2B_API_KEY` is still `dummy`
+
+## Further Reading
+
+If you want the easiest explanation, go straight to the example README:
+
+- [examples/e2b-dev-sidecar/README.md](https://github.com/tencentcloud/CubeSandbox/tree/master/examples/e2b-dev-sidecar/README.md)
+
+If you are ready to wire the sidecar into your own code, then look at:
+
+- `demo.py`
+- `dev_sidecar.py`

--- a/docs/zh/guide/connect-existing-cluster.md
+++ b/docs/zh/guide/connect-existing-cluster.md
@@ -1,0 +1,101 @@
+# 连接到已有 Cube 集群
+
+如果你只是想尽快跑通，先看示例目录：
+
+- 示例代码：[examples/e2b-dev-sidecar](https://github.com/tencentcloud/CubeSandbox/tree/master/examples/e2b-dev-sidecar)
+- 中文说明：[README_zh.md](https://github.com/tencentcloud/CubeSandbox/tree/master/examples/e2b-dev-sidecar/README_zh.md)
+- 英文说明：[README.md](https://github.com/tencentcloud/CubeSandbox/tree/master/examples/e2b-dev-sidecar/README.md)
+
+## 为什么需要dev-sidecar?
+
+由于E2B需要沙箱URL是通过泛解析去解析到目标集群的public-ip，因此如果您是在生产环境中部署，您需要在私有dns中，添加一条A记录： `*.cube.app => <your cube master node ip>`.
+
+而我们在开发阶段，在自己电脑上加泛解析是很麻烦的。因此我们做了个dev-sidecar,帮助您在不更改 E2B SDK的情况下，轻松的在开发机上连接Cube集群来创建实例。
+
+这篇文档只做一件事：帮你更快判断自己该怎么填 `dev-sidecar` 的环境变量。
+
+## 先走成功路径
+
+### 场景一：你是在本机先用 `dev-env` 起的 Cube
+
+这是 `dev-sidecar` 最自然、也最推荐的开发路径。
+
+如果你是按 [开发环境（QEMU 虚机）](./dev-environment) 启动的本地开发环境，那么 `examples/e2b-dev-sidecar/env.example` 里的默认值本来就是为这个场景准备的。
+
+直接这样做：
+
+```bash
+cd examples/e2b-dev-sidecar
+pip install -r requirements.txt
+cp env.example .env
+```
+
+然后只需要补上模板 ID：
+
+```bash
+E2B_API_URL="http://127.0.0.1:13000"
+CUBE_REMOTE_PROXY_BASE="https://127.0.0.1:11443"
+E2B_API_KEY="dummy"
+CUBE_TEMPLATE_ID="<your-template-id>"
+```
+
+运行：
+
+```bash
+python demo.py
+```
+
+这里最关键的一点是：
+
+- `127.0.0.1:13000` 不是随便写的，它对应 `dev-env` 暴露出来的 CubeAPI
+- `127.0.0.1:11443` 不是随便写的，它对应 `dev-env` 暴露出来的 CubeProxy
+
+也就是说，如果你本机已经起了 `dev-env`，通常不需要改地址，只需要填模板 ID。
+
+### 场景二：你要连接另一台机器上的已有 Cube 集群
+
+这时也还是用同一个 `dev-sidecar` 示例，只是把默认地址替换成远端集群的地址：
+
+```bash
+E2B_API_URL="http://<node-ip>:3000"
+CUBE_REMOTE_PROXY_BASE="https://<node-ip>:443"
+E2B_API_KEY="dummy"
+CUBE_TEMPLATE_ID="<your-template-id>"
+```
+
+然后同样运行：
+
+```bash
+python demo.py
+```
+
+## 只记这几件事
+
+- `E2B_API_URL`
+  控制面地址。`dev-env` 默认就是 `http://127.0.0.1:13000`。
+- `CUBE_REMOTE_PROXY_BASE`
+  数据面地址。`dev-env` 默认就是 `https://127.0.0.1:11443`。
+- `E2B_API_KEY`
+  SDK 要求非空；如果你的集群开启鉴权，就填真实值，否则写`dummy`。
+- `CUBE_TEMPLATE_ID`
+  你要创建沙箱时使用的模板 ID。
+
+其他配置项先不用急着看。绝大多数开发接入，先把这四个值弄对就够了。
+
+## 最容易踩的坑
+
+- 本机明明跑的是 `dev-env`，却把地址写成了虚机内地址，而不是宿主机暴露出来的 `13000/11443`
+- 把 `CUBE_REMOTE_PROXY_BASE` 错写成 sidecar 自己的监听地址
+- 忘了填 `CUBE_TEMPLATE_ID`
+- 集群开启了鉴权，但 `E2B_API_KEY` 还在用 dummy
+
+## 进一步阅读
+
+如果你想直接看最容易理解的版本，优先看示例 README：
+
+- [examples/e2b-dev-sidecar/README_zh.md](https://github.com/tencentcloud/CubeSandbox/tree/master/examples/e2b-dev-sidecar/README_zh.md)
+
+如果你已经准备把 sidecar 接到自己的代码里，再回头看示例里的：
+
+- `demo.py`
+- `dev_sidecar.py`

--- a/examples/e2b-dev-sidecar/.gitignore
+++ b/examples/e2b-dev-sidecar/.gitignore
@@ -1,0 +1,2 @@
+/__pycache__/
+.env

--- a/examples/e2b-dev-sidecar/README.md
+++ b/examples/e2b-dev-sidecar/README.md
@@ -1,0 +1,98 @@
+[English](./README.md) | [中文](./README_zh.md)
+
+# E2B Dev Sidecar
+
+This demo shows one thing: reuse the local `e2b_code_interpreter` SDK to access CubeSandbox directly, while forwarding sandbox data-plane traffic to CubeProxy through a local sidecar.
+
+## Why we need `dev-sidecar`
+
+
+E2B expects sandbox URLs to resolve to the target cluster's public IP through wildcard DNS. In a production deployment, that usually means adding a private DNS A record like:
+
+```text
+*.cube.app => <your cube master node ip>
+```
+
+That is inconvenient during local development. Setting up wildcard DNS on a developer machine is usually the annoying part, so `dev-sidecar` exists to let you connect your local machine to a Cube cluster and create sandboxes without changing the E2B SDK itself.
+
+Applicable scenarios:
+
+- The control plane is already reachable through `E2B_API_URL` to access CubeAPI.
+- The data plane must go through a local sidecar that rewrites the `Host` header before forwarding to CubeProxy.
+
+## Files
+
+- `demo.py`: minimal runnable example
+- `dev_sidecar.py`: starts an embedded sidecar and rewrites the SDK's data-plane access to the sidecar
+- `env.example`: example environment variables
+
+## Quick Start
+
+```bash
+cd examples/e2b-dev-sidecar
+pip install -r requirements.txt
+cp env.example .env
+```
+
+Edit `.env` and fill in at least these three values:
+
+```bash
+# **If you are running Cube on remote machine,** replace this with: http://<node-ip>:3000
+E2B_API_URL="http://127.0.0.1:13000"
+# **If you are running Cube on remote machine,** replace this with: https://<node-ip>:443
+CUBE_REMOTE_PROXY_BASE="https://127.0.0.1:11443"
+CUBE_TEMPLATE_ID="<your-template-id>"
+```
+
+Then run:
+
+```bash
+python demo.py
+```
+
+On success, you should see output similar to:
+
+```text
+Hello world Cube!
+```
+
+## What This Demo Does
+
+When `demo.py` starts, it first calls `setup_dev_sidecar()`. That function does two things:
+
+1. Starts a local sidecar. By default it listens on `127.0.0.1:12580`. If the port is already in use, it automatically picks the next available port.
+2. Monkey patches `ConnectionConfig.get_host()` so that when the SDK accesses sandbox ports, it sends requests to:
+
+```text
+http://127.0.0.1:<local-port>/sandboxes/router/<sandbox_id>/<port>
+```
+
+The sidecar then forwards those requests to `CUBE_REMOTE_PROXY_BASE` and rewrites the `Host` header to:
+
+```text
+<port>-<sandbox_id>.<sandbox-domain>
+```
+
+## Configuration
+
+- `E2B_API_URL`
+  Control-plane endpoint. The SDK sends requests to CubeAPI directly and does not go through the sidecar.
+- `CUBE_REMOTE_PROXY_BASE`
+  CubeProxy endpoint used by the sidecar when forwarding data-plane requests.
+- `CUBE_TEMPLATE_ID`
+  Template ID used when creating the sandbox.
+- `CUBE_REMOTE_SANDBOX_DOMAIN`
+  Optional. Defaults to `cube.app`.
+- `CUBE_REMOTE_PROXY_VERIFY_SSL`
+  Optional. Defaults to `false`, which is convenient for self-signed certificates or local development environments.
+- `CUBE_DEV_PROXY_HOST`
+  Optional. Listen address of the embedded sidecar. Defaults to `127.0.0.1`.
+- `CUBE_DEV_PROXY_PORT`
+  Optional. Preferred port of the embedded sidecar. Defaults to `12580`.
+- `CUBE_DEV_PROXY_URL`
+  Optional. If you already have an external sidecar, point to it directly. In that case, the embedded sidecar will not be started.
+
+## Development Boundary
+
+- This demo proxies only the data plane, not the control plane.
+- This sidecar is a minimal dev-only implementation, not a production gateway.

--- a/examples/e2b-dev-sidecar/README.md
+++ b/examples/e2b-dev-sidecar/README.md
@@ -44,6 +44,8 @@ CUBE_REMOTE_PROXY_BASE="https://127.0.0.1:11443"
 CUBE_TEMPLATE_ID="<your-template-id>"
 ```
 
+If your cluster has auth enabled, replace `E2B_API_KEY="dummy"` in `.env` with a real key before running the demo.
+
 Then run:
 
 ```bash

--- a/examples/e2b-dev-sidecar/README.md
+++ b/examples/e2b-dev-sidecar/README.md
@@ -61,7 +61,7 @@ Hello world Cube!
 When `demo.py` starts, it first calls `setup_dev_sidecar()`. That function does two things:
 
 1. Starts a local sidecar. By default it listens on `127.0.0.1:12580`. If the port is already in use, it automatically picks the next available port.
-2. Monkey patches `ConnectionConfig.get_host()` so that when the SDK accesses sandbox ports, it sends requests to:
+2. Monkey patches the SDK helpers that need data-plane routing. In sidecar mode, envd, file URLs, MCP URLs, and sandbox port access are routed to:
 
 ```text
 http://127.0.0.1:<local-port>/sandboxes/router/<sandbox_id>/<port>
@@ -72,6 +72,14 @@ The sidecar then forwards those requests to `CUBE_REMOTE_PROXY_BASE` and rewrite
 ```text
 <port>-<sandbox_id>.<sandbox-domain>
 ```
+
+This applies to:
+
+- envd API traffic
+- file upload/download URLs
+- MCP URLs
+- regular sandbox HTTP traffic
+- WebSocket traffic proxied through the same router path
 
 ## Configuration
 
@@ -91,6 +99,13 @@ The sidecar then forwards those requests to `CUBE_REMOTE_PROXY_BASE` and rewrite
   Optional. Preferred port of the embedded sidecar. Defaults to `12580`.
 - `CUBE_DEV_PROXY_URL`
   Optional. If you already have an external sidecar, point to it directly. In that case, the embedded sidecar will not be started.
+
+## Sidecar URL Semantics
+
+- `sandbox.get_host(port)` returns a host-plus-router-path fragment in sidecar mode, not a plain DNS hostname.
+- `download_url()`, `upload_url()`, and `get_mcp_url()` return full routed URLs and preserve the sidecar scheme.
+- The embedded sidecar always listens on `http://...`.
+- If you use `CUBE_DEV_PROXY_URL`, the generated file and MCP URLs follow that URL's scheme.
 
 ## Development Boundary
 

--- a/examples/e2b-dev-sidecar/README_zh.md
+++ b/examples/e2b-dev-sidecar/README_zh.md
@@ -1,0 +1,96 @@
+[English](./README.md) | [中文](./README_zh.md)
+
+# E2B Dev Sidecar
+
+这个 demo 展示一件事：本地直接复用 `e2b_code_interpreter` SDK 访问 CubeSandbox，同时把沙箱数据面流量转发到 CubeProxy。
+## 为什么需要dev-sidecar?
+
+由于 E2B 需要把沙箱 URL 通过泛解析解析到目标集群的 public IP，因此如果你是在生产环境中部署，通常需要在私有 DNS 中添加一条 A 记录：
+
+```text
+*.cube.app => <your cube master node ip>
+```
+
+但在开发阶段，在自己电脑上配置泛解析通常很麻烦。`dev-sidecar` 的作用，就是帮助你在不修改 E2B SDK 的情况下，直接从开发机连接 Cube 集群并创建实例。
+
+适用场景：
+
+- 控制面已经能通过 `E2B_API_URL` 访问 CubeAPI
+- 数据面需要经过一个本地 sidecar 改写 `Host` 后再转发到 CubeProxy
+
+## 文件
+
+- `demo.py`：最小可运行示例
+- `dev_sidecar.py`：启动内嵌 sidecar，并把 SDK 的数据面访问改写到 sidecar
+- `env.example`：示例环境变量
+
+## 快速开始
+
+```bash
+cd examples/e2b-dev-sidecar
+pip install -r requirements.txt
+cp env.example .env
+```
+
+编辑 `.env`，至少填这三个值：
+
+```bash
+# **If you are running Cube on remote machine,** replace this with:  http://<node-ip>:3000
+E2B_API_URL="http://127.0.0.1:13000"
+# **If you are running Cube on remote machine,** replace this with:  https://<node-ip>:443
+CUBE_REMOTE_PROXY_BASE="https://127.0.0.1:11443"
+CUBE_TEMPLATE_ID="<your-template-id>"
+```
+
+然后运行：
+
+```bash
+python demo.py
+```
+
+成功时会输出类似：
+
+```text
+Hello world Cube！
+```
+
+## 这个 demo 做了什么
+
+`demo.py` 启动时会先调用 `setup_dev_sidecar()`，它会做两件事：
+
+1. 在本地启动一个 sidecar；默认监听 `127.0.0.1:12580`，端口被占用时自动换下一个可用端口。
+2. monkey patch `ConnectionConfig.get_host()`，让 SDK 访问沙箱端口时改为请求：
+
+```text
+http://127.0.0.1:<local-port>/sandboxes/router/<sandbox_id>/<port>
+```
+
+sidecar 再把这类请求转发到 `CUBE_REMOTE_PROXY_BASE`，并把 `Host` 改写为：
+
+```text
+<port>-<sandbox_id>.<sandbox-domain>
+```
+
+## 配置说明
+
+- `E2B_API_URL`
+  控制面地址，SDK 会直接请求 CubeAPI，不经过 sidecar。
+- `CUBE_REMOTE_PROXY_BASE`
+  sidecar 转发数据面请求时使用的 CubeProxy 地址。
+- `CUBE_TEMPLATE_ID`
+  创建 sandbox 时使用的模板 ID。
+- `CUBE_REMOTE_SANDBOX_DOMAIN`
+  可选，默认 `cube.app`。
+- `CUBE_REMOTE_PROXY_VERIFY_SSL`
+  可选，默认 `false`，方便自签证书或本地开发环境。
+- `CUBE_DEV_PROXY_HOST`
+  可选，内嵌 sidecar 的监听地址，默认 `127.0.0.1`。
+- `CUBE_DEV_PROXY_PORT`
+  可选，内嵌 sidecar 的首选端口，默认 `12580`。
+- `CUBE_DEV_PROXY_URL`
+  可选。如果你已经有外部 sidecar，可以直接指向它；此时不会再启动内嵌 sidecar。
+
+## 开发边界
+
+- 这个 demo 只代理数据面，不代理控制面。
+- 这个 sidecar 是 dev-only 的最小实现，不是生产网关。

--- a/examples/e2b-dev-sidecar/README_zh.md
+++ b/examples/e2b-dev-sidecar/README_zh.md
@@ -59,7 +59,7 @@ Hello world Cube！
 `demo.py` 启动时会先调用 `setup_dev_sidecar()`，它会做两件事：
 
 1. 在本地启动一个 sidecar；默认监听 `127.0.0.1:12580`，端口被占用时自动换下一个可用端口。
-2. monkey patch `ConnectionConfig.get_host()`，让 SDK 访问沙箱端口时改为请求：
+2. monkey patch 那些确实需要经过数据面的 SDK helper。sidecar 模式下，envd、文件 URL、MCP URL 和沙箱端口访问都会改为请求：
 
 ```text
 http://127.0.0.1:<local-port>/sandboxes/router/<sandbox_id>/<port>
@@ -70,6 +70,14 @@ sidecar 再把这类请求转发到 `CUBE_REMOTE_PROXY_BASE`，并把 `Host` 改
 ```text
 <port>-<sandbox_id>.<sandbox-domain>
 ```
+
+这包括：
+
+- envd API 流量
+- 文件上传/下载 URL
+- MCP URL
+- 普通沙箱 HTTP 流量
+- 通过同一路由转发的 WebSocket 流量
 
 ## 配置说明
 
@@ -89,6 +97,13 @@ sidecar 再把这类请求转发到 `CUBE_REMOTE_PROXY_BASE`，并把 `Host` 改
   可选，内嵌 sidecar 的首选端口，默认 `12580`。
 - `CUBE_DEV_PROXY_URL`
   可选。如果你已经有外部 sidecar，可以直接指向它；此时不会再启动内嵌 sidecar。
+
+## Sidecar URL 语义
+
+- sidecar 模式下，`sandbox.get_host(port)` 返回的是 host 加 router path 片段，不是纯 DNS host。
+- `download_url()`、`upload_url()`、`get_mcp_url()` 返回的是完整 routed URL，并保留 sidecar 自己的 scheme。
+- 内嵌 sidecar 默认始终监听在 `http://...`。
+- 如果使用 `CUBE_DEV_PROXY_URL`，生成出来的文件 URL 和 MCP URL 会跟随这个 URL 的 scheme。
 
 ## 开发边界
 

--- a/examples/e2b-dev-sidecar/README_zh.md
+++ b/examples/e2b-dev-sidecar/README_zh.md
@@ -3,6 +3,7 @@
 # E2B Dev Sidecar
 
 这个 demo 展示一件事：本地直接复用 `e2b_code_interpreter` SDK 访问 CubeSandbox，同时把沙箱数据面流量转发到 CubeProxy。
+
 ## 为什么需要dev-sidecar?
 
 由于 E2B 需要把沙箱 URL 通过泛解析解析到目标集群的 public IP，因此如果你是在生产环境中部署，通常需要在私有 DNS 中添加一条 A 记录：

--- a/examples/e2b-dev-sidecar/README_zh.md
+++ b/examples/e2b-dev-sidecar/README_zh.md
@@ -42,6 +42,8 @@ CUBE_REMOTE_PROXY_BASE="https://127.0.0.1:11443"
 CUBE_TEMPLATE_ID="<your-template-id>"
 ```
 
+如果目标集群开启了鉴权，运行前要把 `.env` 里的 `E2B_API_KEY="dummy"` 换成真实 API key。
+
 然后运行：
 
 ```bash

--- a/examples/e2b-dev-sidecar/demo.py
+++ b/examples/e2b-dev-sidecar/demo.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import os
+
+from dotenv import load_dotenv
+from dev_sidecar import setup_dev_sidecar
+
+
+def main() -> None:
+    load_dotenv()
+    setup_dev_sidecar()
+
+    from e2b_code_interpreter import Sandbox
+
+    template = os.environ["CUBE_TEMPLATE_ID"]
+
+    with Sandbox.create(template=template) as sandbox:
+        execution = sandbox.run_code(
+            "'Hello world Cube！'\n"
+        )
+        print(execution.text)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/e2b-dev-sidecar/demo.py
+++ b/examples/e2b-dev-sidecar/demo.py
@@ -12,7 +12,9 @@ def main() -> None:
 
     from e2b_code_interpreter import Sandbox
 
-    template = os.environ["CUBE_TEMPLATE_ID"]
+    template = os.environ.get("CUBE_TEMPLATE_ID")
+    if not template:
+        raise RuntimeError("CUBE_TEMPLATE_ID is required; set it in .env or your environment")
 
     with Sandbox.create(template=template) as sandbox:
         execution = sandbox.run_code(

--- a/examples/e2b-dev-sidecar/dev_sidecar.py
+++ b/examples/e2b-dev-sidecar/dev_sidecar.py
@@ -4,9 +4,16 @@ import asyncio
 import os
 import threading
 from typing import Iterable
-from urllib.parse import urlsplit
+from urllib.parse import urlencode, urlsplit
 
-from aiohttp import ClientSession, ClientTimeout, TCPConnector, web
+from aiohttp import (
+    ClientSession,
+    ClientTimeout,
+    TCPConnector,
+    WSMsgType,
+    hdrs,
+    web,
+)
 
 
 HOP_BY_HOP_HEADERS = {
@@ -19,13 +26,29 @@ HOP_BY_HOP_HEADERS = {
     "transfer-encoding",
     "upgrade",
 }
-
+WEBSOCKET_REQUEST_HEADERS = {
+    hdrs.CONNECTION,
+    hdrs.SEC_WEBSOCKET_ACCEPT,
+    hdrs.SEC_WEBSOCKET_EXTENSIONS,
+    hdrs.SEC_WEBSOCKET_KEY,
+    hdrs.SEC_WEBSOCKET_PROTOCOL,
+    hdrs.SEC_WEBSOCKET_VERSION,
+    hdrs.UPGRADE,
+}
 _PATCHED = False
-_ORIGINAL_GET_HOST = None
+_ORIGINAL_CONNECTION_CONFIG_GET_SANDBOX_URL = None
+_ORIGINAL_SANDBOX_BASE_GET_HOST = None
+_ORIGINAL_SANDBOX_BASE_FILE_URL = None
+_ORIGINAL_SANDBOX_BASE_GET_MCP_URL = None
+_ORIGINAL_CODE_INTERPRETER_JUPYTER_URL = None
+_ORIGINAL_ASYNC_CODE_INTERPRETER_JUPYTER_URL = None
+
 _SIDECAR_LOCK = threading.Lock()
 _SIDECAR_READY = threading.Event()
 _SIDECAR_URL = ""
 _SIDECAR_ERROR: BaseException | None = None
+CONFIG_KEY = web.AppKey("config", dict)
+SESSION_KEY = web.AppKey("session", ClientSession)
 
 
 def _env(name: str, default: str = "") -> str:
@@ -43,30 +66,72 @@ def _strip_slash(value: str) -> str:
     return value.rstrip("/")
 
 
-def _normalize_proxy_host(value: str) -> str:
+def _normalize_proxy_url(value: str) -> str:
     raw = value.strip().rstrip("/")
     if not raw:
         return ""
+    return raw if "://" in raw else f"http://{raw}"
 
-    parsed = urlsplit(raw if "://" in raw else f"http://{raw}")
+
+def _normalize_proxy_host(value: str) -> str:
+    parsed = urlsplit(_normalize_proxy_url(value))
     host = parsed.netloc or parsed.path
     path = parsed.path if parsed.netloc else ""
     return f"{host}{path}".rstrip("/")
 
 
-def _join_url(base: str, path: str, query: str) -> str:
+def _join_url(base: str, path: str, query: str = "") -> str:
     url = f"{_strip_slash(base)}{path}"
     if query:
         url = f"{url}?{query}"
     return url
 
 
-def _copy_headers(headers: Iterable[tuple[str, str]], *, host: str | None) -> dict[str, str]:
+def _build_router_path(sandbox_id: str, port: int, tail: str = "") -> str:
+    normalized_tail = tail.lstrip("/")
+    path = f"/sandboxes/router/{sandbox_id}/{port}"
+    if normalized_tail:
+        path = f"{path}/{normalized_tail}"
+    return path
+
+
+def _build_router_url(
+    base_url: str,
+    sandbox_id: str,
+    port: int,
+    tail: str = "",
+    query: str = "",
+) -> str:
+    return _join_url(base_url, _build_router_path(sandbox_id, port, tail), query)
+
+
+def _build_router_host(base_url: str, sandbox_id: str, port: int) -> str:
+    return f"{_normalize_proxy_host(base_url)}{_build_router_path(sandbox_id, port)}"
+
+
+def _build_upstream_ws_url(url: str) -> str:
+    parsed = urlsplit(url)
+    if parsed.scheme == "https":
+        scheme = "wss"
+    elif parsed.scheme == "http":
+        scheme = "ws"
+    else:
+        scheme = parsed.scheme
+    return parsed._replace(scheme=scheme).geturl()
+
+
+def _copy_headers(
+    headers: Iterable[tuple[str, str]],
+    *,
+    host: str | None,
+    hop_by_hop: bool,
+) -> dict[str, str]:
     copied: dict[str, str] = {}
     for key, value in headers:
-        if key.lower() in HOP_BY_HOP_HEADERS:
+        lowered = key.lower()
+        if lowered == "host":
             continue
-        if key.lower() == "host":
+        if hop_by_hop and lowered in HOP_BY_HOP_HEADERS:
             continue
         copied[key] = value
     if host:
@@ -74,7 +139,13 @@ def _copy_headers(headers: Iterable[tuple[str, str]], *, host: str | None) -> di
     return copied
 
 
-async def _stream_proxy(
+def _is_websocket_request(request: web.Request) -> bool:
+    connection = request.headers.get(hdrs.CONNECTION, "")
+    upgrade = request.headers.get(hdrs.UPGRADE, "")
+    return "upgrade" in connection.lower() and upgrade.lower() == "websocket"
+
+
+async def _stream_http_proxy(
     request: web.Request,
     session: ClientSession,
     target_url: str,
@@ -82,7 +153,7 @@ async def _stream_proxy(
     host: str | None,
 ) -> web.StreamResponse:
     body = await request.read()
-    headers = _copy_headers(request.headers.items(), host=host)
+    headers = _copy_headers(request.headers.items(), host=host, hop_by_hop=True)
 
     async with session.request(
         method=request.method,
@@ -93,9 +164,8 @@ async def _stream_proxy(
     ) as upstream:
         response = web.StreamResponse(status=upstream.status, reason=upstream.reason)
         for key, value in upstream.headers.items():
-            if key.lower() in HOP_BY_HOP_HEADERS:
-                continue
-            if key.lower() == "content-length":
+            lowered = key.lower()
+            if lowered in HOP_BY_HOP_HEADERS or lowered == "content-length":
                 continue
             response.headers[key] = value
 
@@ -106,15 +176,103 @@ async def _stream_proxy(
         return response
 
 
+async def _pump_websocket_to_upstream(
+    downstream: web.WebSocketResponse,
+    upstream,
+) -> None:
+    async for msg in downstream:
+        if msg.type == WSMsgType.TEXT:
+            await upstream.send_str(msg.data)
+        elif msg.type == WSMsgType.BINARY:
+            await upstream.send_bytes(msg.data)
+        elif msg.type == WSMsgType.PING:
+            await upstream.ping(msg.data)
+        elif msg.type == WSMsgType.PONG:
+            await upstream.pong(msg.data)
+        elif msg.type == WSMsgType.CLOSE:
+            await upstream.close(code=downstream.close_code or 1000)
+            return
+
+
+async def _pump_websocket_to_downstream(
+    upstream,
+    downstream: web.WebSocketResponse,
+) -> None:
+    async for msg in upstream:
+        if msg.type == WSMsgType.TEXT:
+            await downstream.send_str(msg.data)
+        elif msg.type == WSMsgType.BINARY:
+            await downstream.send_bytes(msg.data)
+        elif msg.type == WSMsgType.PING:
+            await downstream.ping(msg.data)
+        elif msg.type == WSMsgType.PONG:
+            await downstream.pong(msg.data)
+        elif msg.type == WSMsgType.CLOSE:
+            await downstream.close(code=upstream.close_code or 1000)
+            return
+
+
+async def _stream_websocket_proxy(
+    request: web.Request,
+    session: ClientSession,
+    target_url: str,
+    *,
+    host: str | None,
+) -> web.StreamResponse:
+    request_headers = _copy_headers(
+        request.headers.items(),
+        host=host,
+        hop_by_hop=False,
+    )
+    request_headers = {
+        key: value
+        for key, value in request_headers.items()
+        if key in WEBSOCKET_REQUEST_HEADERS or key.lower() not in HOP_BY_HOP_HEADERS
+    }
+
+    async with session.ws_connect(
+        _build_upstream_ws_url(target_url),
+        headers=request_headers,
+        protocols=request.headers.getall(hdrs.SEC_WEBSOCKET_PROTOCOL, []),
+    ) as upstream:
+        protocols = (upstream.protocol,) if upstream.protocol else ()
+        downstream = web.WebSocketResponse(
+            protocols=protocols,
+            autoclose=True,
+            autoping=True,
+        )
+        await downstream.prepare(request)
+
+        forward_tasks = (
+            asyncio.create_task(_pump_websocket_to_upstream(downstream, upstream)),
+            asyncio.create_task(_pump_websocket_to_downstream(upstream, downstream)),
+        )
+        done, pending = await asyncio.wait(
+            forward_tasks,
+            return_when=asyncio.FIRST_COMPLETED,
+        )
+        for task in pending:
+            task.cancel()
+        for task in done:
+            task.result()
+
+        if not downstream.closed:
+            await downstream.close(code=upstream.close_code or 1000)
+        return downstream
+
+
 async def proxy_sandbox(request: web.Request) -> web.StreamResponse:
-    config = request.app["config"]
+    config = request.app[CONFIG_KEY]
     sandbox_id = request.match_info["sandbox_id"]
-    port = request.match_info["port"]
+    port = int(request.match_info["port"])
     tail = request.match_info.get("tail", "")
     upstream_path = f"/{tail}" if tail else "/"
     url = _join_url(config["cube_proxy_base"], upstream_path, request.query_string)
     host = f"{port}-{sandbox_id}.{config['sandbox_domain']}"
-    return await _stream_proxy(request, request.app["session"], url, host=host)
+
+    if _is_websocket_request(request):
+        return await _stream_websocket_proxy(request, request.app[SESSION_KEY], url, host=host)
+    return await _stream_http_proxy(request, request.app[SESSION_KEY], url, host=host)
 
 
 async def health(_request: web.Request) -> web.Response:
@@ -122,14 +280,14 @@ async def health(_request: web.Request) -> web.Response:
 
 
 async def on_startup(app: web.Application) -> None:
-    config = app["config"]
+    config = app[CONFIG_KEY]
     connector = TCPConnector(ssl=config["verify_ssl"])
     timeout = ClientTimeout(total=None, connect=30, sock_read=None)
-    app["session"] = ClientSession(connector=connector, timeout=timeout)
+    app[SESSION_KEY] = ClientSession(connector=connector, timeout=timeout)
 
 
 async def on_cleanup(app: web.Application) -> None:
-    await app["session"].close()
+    await app[SESSION_KEY].close()
 
 
 def build_app() -> web.Application:
@@ -138,7 +296,7 @@ def build_app() -> web.Application:
     verify_ssl = _bool_env("CUBE_REMOTE_PROXY_VERIFY_SSL", False)
 
     app = web.Application(client_max_size=64 * 1024 * 1024)
-    app["config"] = {
+    app[CONFIG_KEY] = {
         "cube_proxy_base": cube_proxy_base,
         "sandbox_domain": sandbox_domain,
         "verify_ssl": verify_ssl,
@@ -172,10 +330,10 @@ async def _start_embedded_sidecar(host: str, preferred_port: int) -> int:
             last_error = exc
             continue
 
-        sockets = getattr(site._server, "sockets", None)
-        if not sockets:
-            raise RuntimeError("Embedded dev sidecar started without a bound socket")
-        return int(sockets[0].getsockname()[1])
+        for address in runner.addresses:
+            if isinstance(address, tuple) and len(address) >= 2:
+                return int(address[1])
+        raise RuntimeError("Embedded dev sidecar started without a bound address")
 
     raise RuntimeError("Failed to bind embedded dev sidecar") from last_error
 
@@ -205,11 +363,12 @@ def _run_embedded_sidecar(host: str, preferred_port: int) -> None:
 
 
 def _ensure_embedded_sidecar() -> str:
-    global _SIDECAR_ERROR
+    global _SIDECAR_ERROR, _SIDECAR_URL
 
-    explicit_url = _env("CUBE_DEV_PROXY_URL", "").rstrip("/")
+    explicit_url = _normalize_proxy_url(_env("CUBE_DEV_PROXY_URL", ""))
     if explicit_url:
-        return explicit_url if "://" in explicit_url else f"http://{explicit_url}"
+        _SIDECAR_URL = explicit_url
+        return explicit_url
 
     if _SIDECAR_URL:
         return _SIDECAR_URL
@@ -240,34 +399,122 @@ def _ensure_embedded_sidecar() -> str:
     return _SIDECAR_URL
 
 
+def _current_sidecar_url() -> str:
+    return _ensure_embedded_sidecar().rstrip("/")
+
+
+def _build_sandbox_file_url(
+    sandbox_base,
+    path: str,
+    user: str | None = None,
+    signature: str | None = None,
+    signature_expiration: int | None = None,
+) -> str:
+    query = {"path": path} if path else {}
+    if user:
+        query["username"] = user
+    if signature:
+        query["signature"] = signature
+    if signature_expiration:
+        if signature is None:
+            raise ValueError("signature_expiration requires signature to be set")
+        query["signature_expiration"] = str(signature_expiration)
+
+    return _build_router_url(
+        _current_sidecar_url(),
+        sandbox_base.sandbox_id,
+        sandbox_base.connection_config.envd_port,
+        "files",
+        urlencode(query),
+    )
+
+
+def _build_code_interpreter_url(sandbox_base, port: int, tail: str = "") -> str:
+    return _build_router_url(
+        _current_sidecar_url(),
+        sandbox_base.sandbox_id,
+        port,
+        tail,
+    )
+
+
 def setup_dev_sidecar() -> None:
     from e2b import ConnectionConfig
+    from e2b.sandbox.main import SandboxBase
 
-    global _PATCHED, _ORIGINAL_GET_HOST
+    global _PATCHED
+    global _ORIGINAL_CONNECTION_CONFIG_GET_SANDBOX_URL
+    global _ORIGINAL_SANDBOX_BASE_GET_HOST
+    global _ORIGINAL_SANDBOX_BASE_FILE_URL
+    global _ORIGINAL_SANDBOX_BASE_GET_MCP_URL
+    global _ORIGINAL_CODE_INTERPRETER_JUPYTER_URL
+    global _ORIGINAL_ASYNC_CODE_INTERPRETER_JUPYTER_URL
 
-    base_url = _ensure_embedded_sidecar().rstrip("/")
-    normalized_host = _normalize_proxy_host(base_url)
+    base_url = _current_sidecar_url()
 
     if not _PATCHED:
-        _ORIGINAL_GET_HOST = ConnectionConfig.get_host
+        _ORIGINAL_CONNECTION_CONFIG_GET_SANDBOX_URL = ConnectionConfig.get_sandbox_url
+        _ORIGINAL_SANDBOX_BASE_GET_HOST = SandboxBase.get_host
+        _ORIGINAL_SANDBOX_BASE_FILE_URL = SandboxBase._file_url
+        _ORIGINAL_SANDBOX_BASE_GET_MCP_URL = SandboxBase.get_mcp_url
+        try:
+            from e2b_code_interpreter.code_interpreter_sync import Sandbox as CodeInterpreterSandbox
+            from e2b_code_interpreter.constants import JUPYTER_PORT
+        except ImportError:
+            CodeInterpreterSandbox = None
+            JUPYTER_PORT = None
+        try:
+            from e2b_code_interpreter.code_interpreter_async import AsyncSandbox as AsyncCodeInterpreterSandbox
+        except ImportError:
+            AsyncCodeInterpreterSandbox = None
 
-        def __connection_config_get_host(
+        def __connection_config_get_sandbox_url(self, sandbox_id: str, sandbox_domain: str) -> str:
+            if self._sandbox_url:
+                return self._sandbox_url
+            return _build_router_url(_current_sidecar_url(), sandbox_id, self.envd_port)
+
+        def __sandbox_base_get_host(self, port: int) -> str:
+            return _build_router_host(_current_sidecar_url(), self.sandbox_id, port)
+
+        def __sandbox_base_file_url(
             self,
-            sandbox_id: str,
-            sandbox_domain: str,
-            port: int,
+            path: str,
+            user: str | None = None,
+            signature: str | None = None,
+            signature_expiration: int | None = None,
         ) -> str:
-            current_proxy = _normalize_proxy_host(_ensure_embedded_sidecar())
-            if not current_proxy:
-                return _ORIGINAL_GET_HOST(self, sandbox_id, sandbox_domain, port)
-            return f"{current_proxy}/sandboxes/router/{sandbox_id}/{port}"
+            return _build_sandbox_file_url(
+                self,
+                path,
+                user,
+                signature,
+                signature_expiration,
+            )
 
-        ConnectionConfig.get_host = __connection_config_get_host
+        def __sandbox_base_get_mcp_url(self) -> str:
+            return _build_router_url(
+                _current_sidecar_url(),
+                self.sandbox_id,
+                self.mcp_port,
+                "mcp",
+            )
+
+        def __code_interpreter_jupyter_url(self) -> str:
+            return _build_code_interpreter_url(self, JUPYTER_PORT)
+
+        ConnectionConfig.get_sandbox_url = __connection_config_get_sandbox_url
+        SandboxBase.get_host = __sandbox_base_get_host
+        SandboxBase._file_url = __sandbox_base_file_url
+        SandboxBase.get_mcp_url = __sandbox_base_get_mcp_url
+        if CodeInterpreterSandbox is not None and JUPYTER_PORT is not None:
+            _ORIGINAL_CODE_INTERPRETER_JUPYTER_URL = CodeInterpreterSandbox._jupyter_url
+            CodeInterpreterSandbox._jupyter_url = property(__code_interpreter_jupyter_url)
+        if AsyncCodeInterpreterSandbox is not None and JUPYTER_PORT is not None:
+            _ORIGINAL_ASYNC_CODE_INTERPRETER_JUPYTER_URL = AsyncCodeInterpreterSandbox._jupyter_url
+            AsyncCodeInterpreterSandbox._jupyter_url = property(__code_interpreter_jupyter_url)
         _PATCHED = True
 
     os.environ["CUBE_DEV_PROXY_URL"] = base_url
-    os.environ["E2B_DEBUG"] = "true"
-    os.environ["E2B_DOMAIN"] = normalized_host
 
 
 def main() -> None:

--- a/examples/e2b-dev-sidecar/dev_sidecar.py
+++ b/examples/e2b-dev-sidecar/dev_sidecar.py
@@ -1,0 +1,281 @@
+from __future__ import annotations
+
+import asyncio
+import os
+import threading
+from typing import Iterable
+from urllib.parse import urlsplit
+
+from aiohttp import ClientSession, ClientTimeout, TCPConnector, web
+
+
+HOP_BY_HOP_HEADERS = {
+    "connection",
+    "keep-alive",
+    "proxy-authenticate",
+    "proxy-authorization",
+    "te",
+    "trailer",
+    "transfer-encoding",
+    "upgrade",
+}
+
+_PATCHED = False
+_ORIGINAL_GET_HOST = None
+_SIDECAR_LOCK = threading.Lock()
+_SIDECAR_READY = threading.Event()
+_SIDECAR_URL = ""
+_SIDECAR_ERROR: BaseException | None = None
+
+
+def _env(name: str, default: str = "") -> str:
+    return os.environ.get(name, default).strip()
+
+
+def _bool_env(name: str, default: bool) -> bool:
+    value = _env(name)
+    if not value:
+        return default
+    return value.lower() in {"1", "true", "yes", "on"}
+
+
+def _strip_slash(value: str) -> str:
+    return value.rstrip("/")
+
+
+def _normalize_proxy_host(value: str) -> str:
+    raw = value.strip().rstrip("/")
+    if not raw:
+        return ""
+
+    parsed = urlsplit(raw if "://" in raw else f"http://{raw}")
+    host = parsed.netloc or parsed.path
+    path = parsed.path if parsed.netloc else ""
+    return f"{host}{path}".rstrip("/")
+
+
+def _join_url(base: str, path: str, query: str) -> str:
+    url = f"{_strip_slash(base)}{path}"
+    if query:
+        url = f"{url}?{query}"
+    return url
+
+
+def _copy_headers(headers: Iterable[tuple[str, str]], *, host: str | None) -> dict[str, str]:
+    copied: dict[str, str] = {}
+    for key, value in headers:
+        if key.lower() in HOP_BY_HOP_HEADERS:
+            continue
+        if key.lower() == "host":
+            continue
+        copied[key] = value
+    if host:
+        copied["Host"] = host
+    return copied
+
+
+async def _stream_proxy(
+    request: web.Request,
+    session: ClientSession,
+    target_url: str,
+    *,
+    host: str | None,
+) -> web.StreamResponse:
+    body = await request.read()
+    headers = _copy_headers(request.headers.items(), host=host)
+
+    async with session.request(
+        method=request.method,
+        url=target_url,
+        headers=headers,
+        data=body if body else None,
+        allow_redirects=False,
+    ) as upstream:
+        response = web.StreamResponse(status=upstream.status, reason=upstream.reason)
+        for key, value in upstream.headers.items():
+            if key.lower() in HOP_BY_HOP_HEADERS:
+                continue
+            if key.lower() == "content-length":
+                continue
+            response.headers[key] = value
+
+        await response.prepare(request)
+        async for chunk in upstream.content.iter_chunked(64 * 1024):
+            await response.write(chunk)
+        await response.write_eof()
+        return response
+
+
+async def proxy_sandbox(request: web.Request) -> web.StreamResponse:
+    config = request.app["config"]
+    sandbox_id = request.match_info["sandbox_id"]
+    port = request.match_info["port"]
+    tail = request.match_info.get("tail", "")
+    upstream_path = f"/{tail}" if tail else "/"
+    url = _join_url(config["cube_proxy_base"], upstream_path, request.query_string)
+    host = f"{port}-{sandbox_id}.{config['sandbox_domain']}"
+    return await _stream_proxy(request, request.app["session"], url, host=host)
+
+
+async def health(_request: web.Request) -> web.Response:
+    return web.json_response({"ok": True})
+
+
+async def on_startup(app: web.Application) -> None:
+    config = app["config"]
+    connector = TCPConnector(ssl=config["verify_ssl"])
+    timeout = ClientTimeout(total=None, connect=30, sock_read=None)
+    app["session"] = ClientSession(connector=connector, timeout=timeout)
+
+
+async def on_cleanup(app: web.Application) -> None:
+    await app["session"].close()
+
+
+def build_app() -> web.Application:
+    cube_proxy_base = _strip_slash(_env("CUBE_REMOTE_PROXY_BASE", "https://127.0.0.1:11443"))
+    sandbox_domain = _env("CUBE_REMOTE_SANDBOX_DOMAIN", "cube.app")
+    verify_ssl = _bool_env("CUBE_REMOTE_PROXY_VERIFY_SSL", False)
+
+    app = web.Application(client_max_size=64 * 1024 * 1024)
+    app["config"] = {
+        "cube_proxy_base": cube_proxy_base,
+        "sandbox_domain": sandbox_domain,
+        "verify_ssl": verify_ssl,
+    }
+    app.on_startup.append(on_startup)
+    app.on_cleanup.append(on_cleanup)
+
+    app.router.add_get("/healthz", health)
+    app.router.add_route("*", "/sandboxes/router/{sandbox_id}/{port}", proxy_sandbox)
+    app.router.add_route(
+        "*",
+        "/sandboxes/router/{sandbox_id}/{port}/{tail:.*}",
+        proxy_sandbox,
+    )
+    return app
+
+
+async def _start_embedded_sidecar(host: str, preferred_port: int) -> int:
+    app = build_app()
+    runner = web.AppRunner(app)
+    await runner.setup()
+
+    ports_to_try = list(range(preferred_port, preferred_port + 32)) + [0]
+    last_error: OSError | None = None
+
+    for port in ports_to_try:
+        site = web.TCPSite(runner, host=host, port=port)
+        try:
+            await site.start()
+        except OSError as exc:
+            last_error = exc
+            continue
+
+        sockets = getattr(site._server, "sockets", None)
+        if not sockets:
+            raise RuntimeError("Embedded dev sidecar started without a bound socket")
+        return int(sockets[0].getsockname()[1])
+
+    raise RuntimeError("Failed to bind embedded dev sidecar") from last_error
+
+
+def _run_embedded_sidecar(host: str, preferred_port: int) -> None:
+    global _SIDECAR_ERROR, _SIDECAR_URL
+
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+
+    async def _bootstrap() -> None:
+        global _SIDECAR_URL
+        port = await _start_embedded_sidecar(host, preferred_port)
+        _SIDECAR_URL = f"http://{host}:{port}"
+        _SIDECAR_READY.set()
+
+    try:
+        loop.run_until_complete(_bootstrap())
+        loop.run_forever()
+    except BaseException as exc:  # pragma: no cover
+        _SIDECAR_ERROR = exc
+        _SIDECAR_READY.set()
+        raise
+    finally:  # pragma: no cover
+        loop.stop()
+        loop.close()
+
+
+def _ensure_embedded_sidecar() -> str:
+    global _SIDECAR_ERROR
+
+    explicit_url = _env("CUBE_DEV_PROXY_URL", "").rstrip("/")
+    if explicit_url:
+        return explicit_url if "://" in explicit_url else f"http://{explicit_url}"
+
+    if _SIDECAR_URL:
+        return _SIDECAR_URL
+
+    with _SIDECAR_LOCK:
+        if _SIDECAR_URL:
+            return _SIDECAR_URL
+
+        _SIDECAR_READY.clear()
+        _SIDECAR_ERROR = None
+
+        host = _env("CUBE_DEV_PROXY_HOST", "127.0.0.1")
+        preferred_port = int(_env("CUBE_DEV_PROXY_PORT", "12580"))
+
+        thread = threading.Thread(
+            target=_run_embedded_sidecar,
+            args=(host, preferred_port),
+            name="cube-dev-sidecar",
+            daemon=True,
+        )
+        thread.start()
+
+    _SIDECAR_READY.wait(timeout=10)
+    if _SIDECAR_ERROR is not None:
+        raise RuntimeError("Embedded dev sidecar failed to start") from _SIDECAR_ERROR
+    if not _SIDECAR_URL:
+        raise RuntimeError("Embedded dev sidecar did not become ready in time")
+    return _SIDECAR_URL
+
+
+def setup_dev_sidecar() -> None:
+    from e2b import ConnectionConfig
+
+    global _PATCHED, _ORIGINAL_GET_HOST
+
+    base_url = _ensure_embedded_sidecar().rstrip("/")
+    normalized_host = _normalize_proxy_host(base_url)
+
+    if not _PATCHED:
+        _ORIGINAL_GET_HOST = ConnectionConfig.get_host
+
+        def __connection_config_get_host(
+            self,
+            sandbox_id: str,
+            sandbox_domain: str,
+            port: int,
+        ) -> str:
+            current_proxy = _normalize_proxy_host(_ensure_embedded_sidecar())
+            if not current_proxy:
+                return _ORIGINAL_GET_HOST(self, sandbox_id, sandbox_domain, port)
+            return f"{current_proxy}/sandboxes/router/{sandbox_id}/{port}"
+
+        ConnectionConfig.get_host = __connection_config_get_host
+        _PATCHED = True
+
+    os.environ["CUBE_DEV_PROXY_URL"] = base_url
+    os.environ["E2B_DEBUG"] = "true"
+    os.environ["E2B_DOMAIN"] = normalized_host
+
+
+def main() -> None:
+    host = _env("CUBE_DEV_PROXY_HOST", "127.0.0.1")
+    port = int(_env("CUBE_DEV_PROXY_PORT", "12580"))
+    app = build_app()
+    web.run_app(app, host=host, port=port)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/e2b-dev-sidecar/dev_sidecar.py
+++ b/examples/e2b-dev-sidecar/dev_sidecar.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import os
 import threading
+import warnings
 from typing import Iterable
 from urllib.parse import urlencode, urlsplit
 
@@ -353,7 +354,7 @@ def _run_embedded_sidecar(host: str, preferred_port: int) -> None:
     try:
         loop.run_until_complete(_bootstrap())
         loop.run_forever()
-    except BaseException as exc:  # pragma: no cover
+    except Exception as exc:  # pragma: no cover
         _SIDECAR_ERROR = exc
         _SIDECAR_READY.set()
         raise
@@ -453,6 +454,22 @@ def setup_dev_sidecar() -> None:
     base_url = _current_sidecar_url()
 
     if not _PATCHED:
+        required_attrs = [
+            (ConnectionConfig, "get_sandbox_url"),
+            (SandboxBase, "get_host"),
+            (SandboxBase, "_file_url"),
+            (SandboxBase, "get_mcp_url"),
+        ]
+        for owner, attr in required_attrs:
+            if not hasattr(owner, attr):
+                warnings.warn(
+                    f"{owner.__name__}.{attr} not found; the installed E2B SDK is incompatible "
+                    "with this dev sidecar example.",
+                    RuntimeWarning,
+                    stacklevel=2,
+                )
+                return
+
         _ORIGINAL_CONNECTION_CONFIG_GET_SANDBOX_URL = ConnectionConfig.get_sandbox_url
         _ORIGINAL_SANDBOX_BASE_GET_HOST = SandboxBase.get_host
         _ORIGINAL_SANDBOX_BASE_FILE_URL = SandboxBase._file_url

--- a/examples/e2b-dev-sidecar/env.example
+++ b/examples/e2b-dev-sidecar/env.example
@@ -1,0 +1,34 @@
+
+# Where the sidecar should forward CubeProxy traffic.
+# dev-env default: host 11443 -> guest 443
+# **If you are running Cube on remote machine,** replace this with:  https://<node-ip>:443
+CUBE_REMOTE_PROXY_BASE="https://127.0.0.1:11443"
+
+
+# Where the E2B SDK should send control-plane API traffic.
+# dev-env default: host 13000 -> guest 3000
+# **If you are running Cube on remote machine,** replace this with:  http://<node-ip>:3000
+E2B_API_URL="http://127.0.0.1:13000"
+
+# Any non-empty value satisfies the SDK check.
+E2B_API_KEY="dummy"
+
+# Template ID for your code-interpreter template.
+CUBE_TEMPLATE_ID="<your-template-id>"
+
+# Optional. Sandbox domain returned by CubeAPI / expected by CubeProxy.
+# Defaults to cube.app.
+# CUBE_REMOTE_SANDBOX_DOMAIN="cube.app"
+
+# Default false is friendlier for self-hosted TLS on IPs / mkcert.
+# CUBE_REMOTE_PROXY_VERIFY_SSL="false"
+
+# Optional: use an already-running external dev sidecar instead of the
+# embedded one started by setup_dev_sidecar().
+# CUBE_DEV_PROXY_URL="http://127.0.0.1:12580"
+
+# Optional: host/preferred port for the embedded sidecar. If the port is busy,
+# setup_dev_sidecar() will automatically try the next available local port.
+# CUBE_DEV_PROXY_HOST="127.0.0.1"
+# CUBE_DEV_PROXY_PORT="12580"
+

--- a/examples/e2b-dev-sidecar/env.example
+++ b/examples/e2b-dev-sidecar/env.example
@@ -10,7 +10,8 @@ CUBE_REMOTE_PROXY_BASE="https://127.0.0.1:11443"
 # **If you are running Cube on remote machine,** replace this with:  http://<node-ip>:3000
 E2B_API_URL="http://127.0.0.1:13000"
 
-# Any non-empty value satisfies the SDK check.
+# Any non-empty value satisfies the SDK check for local dev-env only.
+# Replace this with a real API key when cluster auth is enabled.
 E2B_API_KEY="dummy"
 
 # Template ID for your code-interpreter template.
@@ -31,4 +32,3 @@ CUBE_TEMPLATE_ID="<your-template-id>"
 # setup_dev_sidecar() will automatically try the next available local port.
 # CUBE_DEV_PROXY_HOST="127.0.0.1"
 # CUBE_DEV_PROXY_PORT="12580"
-

--- a/examples/e2b-dev-sidecar/requirements.txt
+++ b/examples/e2b-dev-sidecar/requirements.txt
@@ -1,3 +1,3 @@
 aiohttp>=3.9
-e2b-code-interpreter
+e2b-code-interpreter>=2.4,<3
 python-dotenv

--- a/examples/e2b-dev-sidecar/requirements.txt
+++ b/examples/e2b-dev-sidecar/requirements.txt
@@ -1,0 +1,3 @@
+aiohttp>=3.9
+e2b-code-interpreter
+python-dotenv

--- a/examples/e2b-dev-sidecar/test_dev_sidecar.py
+++ b/examples/e2b-dev-sidecar/test_dev_sidecar.py
@@ -1,0 +1,235 @@
+from __future__ import annotations
+
+import importlib
+import json
+import os
+import sys
+from pathlib import Path
+
+import httpx
+import pytest
+from aiohttp import ClientSession, WSMsgType, web
+from packaging.version import Version
+
+from e2b import ConnectionConfig
+from e2b.sandbox.main import SandboxBase
+from e2b_code_interpreter import Sandbox as CodeInterpreterSandbox
+
+
+EXAMPLE_DIR = Path(__file__).resolve().parent
+if str(EXAMPLE_DIR) not in sys.path:
+    sys.path.insert(0, str(EXAMPLE_DIR))
+
+
+@pytest.fixture
+def dev_sidecar():
+    if "dev_sidecar" in sys.modules:
+        module = importlib.reload(sys.modules["dev_sidecar"])
+    else:
+        module = importlib.import_module("dev_sidecar")
+    return module
+
+
+@pytest.fixture
+def patched_sidecar(monkeypatch, dev_sidecar):
+    monkeypatch.setenv("E2B_API_URL", "http://127.0.0.1:13000")
+    monkeypatch.setenv("CUBE_REMOTE_PROXY_BASE", "https://127.0.0.1:11443")
+    monkeypatch.setenv("CUBE_DEV_PROXY_URL", "http://127.0.0.1:12580")
+    monkeypatch.delenv("E2B_DEBUG", raising=False)
+    monkeypatch.delenv("E2B_DOMAIN", raising=False)
+    dev_sidecar.setup_dev_sidecar()
+    return dev_sidecar
+
+
+def _make_sandbox() -> SandboxBase:
+    class DummySandbox(SandboxBase):
+        pass
+
+    return DummySandbox(
+        sandbox_id="sandbox-123",
+        envd_version=Version("1.0.0"),
+        envd_access_token=None,
+        sandbox_domain="cube.app",
+        connection_config=ConnectionConfig(api_url="http://127.0.0.1:13000"),
+    )
+
+
+async def _start_web_app(app: web.Application) -> tuple[web.AppRunner, str]:
+    runner = web.AppRunner(app)
+    await runner.setup()
+    site = web.TCPSite(runner, host="127.0.0.1", port=0)
+    await site.start()
+    host, port = runner.addresses[0][:2]
+    return runner, f"http://{host}:{port}"
+
+
+@pytest.mark.asyncio
+async def test_embedded_sidecar_binds_with_runner_addresses(monkeypatch, dev_sidecar):
+    async def upstream_ok(_request: web.Request) -> web.Response:
+        return web.Response(text="ok")
+
+    upstream = web.Application()
+    upstream.router.add_get("/", upstream_ok)
+    upstream_runner, upstream_url = await _start_web_app(upstream)
+
+    monkeypatch.setenv("CUBE_REMOTE_PROXY_BASE", upstream_url)
+    monkeypatch.setenv("CUBE_DEV_PROXY_HOST", "127.0.0.1")
+    monkeypatch.setenv("CUBE_DEV_PROXY_PORT", "12580")
+    monkeypatch.delenv("CUBE_DEV_PROXY_URL", raising=False)
+
+    try:
+        dev_sidecar.setup_dev_sidecar()
+        assert dev_sidecar._SIDECAR_URL.startswith("http://127.0.0.1:")
+    finally:
+        await upstream_runner.cleanup()
+
+
+def test_setup_dev_sidecar_is_idempotent(monkeypatch, patched_sidecar):
+    patched_sidecar.setup_dev_sidecar()
+
+    assert patched_sidecar._PATCHED is True
+    assert os.environ.get("CUBE_DEV_PROXY_URL") == "http://127.0.0.1:12580"
+    assert os.environ.get("E2B_DEBUG") is None
+    assert os.environ.get("E2B_DOMAIN") is None
+
+
+def test_connection_config_and_sandbox_helpers_use_routed_urls(patched_sidecar):
+    config = ConnectionConfig(api_url="http://127.0.0.1:13000")
+    sandbox = _make_sandbox()
+
+    assert (
+        config.get_sandbox_url("sandbox-123", "cube.app")
+        == "http://127.0.0.1:12580/sandboxes/router/sandbox-123/49983"
+    )
+    assert (
+        sandbox.get_host(8080)
+        == "127.0.0.1:12580/sandboxes/router/sandbox-123/8080"
+    )
+    assert (
+        sandbox.download_url("/tmp/data.txt")
+        == "http://127.0.0.1:12580/sandboxes/router/sandbox-123/49983/files?path=%2Ftmp%2Fdata.txt"
+    )
+    assert (
+        sandbox.upload_url("/tmp/data.txt")
+        == "http://127.0.0.1:12580/sandboxes/router/sandbox-123/49983/files?path=%2Ftmp%2Fdata.txt"
+    )
+    assert (
+        sandbox.get_mcp_url()
+        == "http://127.0.0.1:12580/sandboxes/router/sandbox-123/50005/mcp"
+    )
+
+
+def test_external_sidecar_scheme_is_preserved(monkeypatch, dev_sidecar):
+    monkeypatch.setenv("E2B_API_URL", "http://127.0.0.1:13000")
+    monkeypatch.setenv("CUBE_REMOTE_PROXY_BASE", "https://127.0.0.1:11443")
+    monkeypatch.setenv("CUBE_DEV_PROXY_URL", "https://proxy.example:8443/base")
+
+    dev_sidecar.setup_dev_sidecar()
+    sandbox = _make_sandbox()
+
+    assert (
+        sandbox.download_url("/tmp/data.txt")
+        == "https://proxy.example:8443/base/sandboxes/router/sandbox-123/49983/files?path=%2Ftmp%2Fdata.txt"
+    )
+    assert (
+        sandbox.get_mcp_url()
+        == "https://proxy.example:8443/base/sandboxes/router/sandbox-123/50005/mcp"
+    )
+
+
+def test_code_interpreter_uses_routed_http_jupyter_url(patched_sidecar):
+    sandbox = CodeInterpreterSandbox(
+        sandbox_id="sandbox-123",
+        envd_version=Version("1.0.0"),
+        envd_access_token=None,
+        sandbox_domain="cube.app",
+        connection_config=ConnectionConfig(api_url="http://127.0.0.1:13000"),
+        traffic_access_token=None,
+    )
+
+    assert (
+        sandbox._jupyter_url
+        == "http://127.0.0.1:12580/sandboxes/router/sandbox-123/49999"
+    )
+
+
+@pytest.mark.asyncio
+async def test_http_proxy_forwards_path_query_body_and_host(monkeypatch, dev_sidecar):
+    async def upstream_handler(request: web.Request) -> web.Response:
+        payload = {
+            "host": request.headers["Host"],
+            "path_qs": request.path_qs,
+            "body": (await request.read()).decode(),
+        }
+        return web.json_response(payload)
+
+    upstream = web.Application()
+    upstream.router.add_route("*", "/{tail:.*}", upstream_handler)
+    upstream_runner, upstream_url = await _start_web_app(upstream)
+
+    monkeypatch.setenv("CUBE_REMOTE_PROXY_BASE", upstream_url)
+    monkeypatch.setenv("CUBE_REMOTE_SANDBOX_DOMAIN", "cube.app")
+    sidecar_runner, sidecar_url = await _start_web_app(dev_sidecar.build_app())
+
+    try:
+        async with httpx.AsyncClient() as client:
+            response = await client.post(
+                f"{sidecar_url}/sandboxes/router/sbx-1/8080/api/v1/run?hello=1",
+                content=b"payload",
+            )
+
+        assert response.status_code == 200
+        assert response.json() == {
+            "host": "8080-sbx-1.cube.app",
+            "path_qs": "/api/v1/run?hello=1",
+            "body": "payload",
+        }
+    finally:
+        await sidecar_runner.cleanup()
+        await upstream_runner.cleanup()
+
+
+@pytest.mark.asyncio
+async def test_websocket_proxy_forwards_frames_and_host(monkeypatch, dev_sidecar):
+    async def upstream_ws(request: web.Request) -> web.StreamResponse:
+        ws = web.WebSocketResponse()
+        await ws.prepare(request)
+
+        async for message in ws:
+            if message.type == WSMsgType.TEXT:
+                await ws.send_str(
+                    json.dumps(
+                        {
+                            "host": request.headers["Host"],
+                            "path_qs": request.path_qs,
+                            "body": message.data,
+                        }
+                    )
+                )
+                await ws.close()
+        return ws
+
+    upstream = web.Application()
+    upstream.router.add_get("/{tail:.*}", upstream_ws)
+    upstream_runner, upstream_url = await _start_web_app(upstream)
+
+    monkeypatch.setenv("CUBE_REMOTE_PROXY_BASE", upstream_url)
+    monkeypatch.setenv("CUBE_REMOTE_SANDBOX_DOMAIN", "cube.app")
+    sidecar_runner, sidecar_url = await _start_web_app(dev_sidecar.build_app())
+
+    try:
+        async with ClientSession() as session:
+            async with session.ws_connect(
+                f"{sidecar_url}/sandboxes/router/sbx-1/9000/ws?room=red"
+            ) as ws:
+                await ws.send_str("hello")
+                message = await ws.receive()
+
+        assert json.loads(message.data) == {
+            "host": "9000-sbx-1.cube.app",
+            "path_qs": "/ws?room=red",
+            "body": "hello",
+        }
+    finally:
+        await sidecar_runner.cleanup()
+        await upstream_runner.cleanup()


### PR DESCRIPTION


- Added HTTP/HTTPS port forwarding (11080/11443) to dev-env configuration
- Created new e2b-dev-sidecar example for connecting to Cube clusters
- Updated documentation with new port forwarding details and dev-sidecar guide