### PR TITLE
fix(kernel-sync): ensure latest shared vmlinux is used when recreating templates

### DIFF
--- a/Cubelet/internal/cube/server/images/ext4image/utils.go
+++ b/Cubelet/internal/cube/server/images/ext4image/utils.go
@@ -116,33 +116,7 @@ func tryDownloadPmemFile(ctx context.Context, imagePath string, spec *cubeimages
 }
 
 func ensureKernelFile(ctx context.Context, instanceType, imageRef string) error {
-	kernelPath := pmem.GetRawKernelFilePath(instanceType, imageRef)
-	exist, err := utils.FileExistAndValid(kernelPath)
-	if err != nil {
-		log.G(ctx).Warnf("kernel file %s validation failed, try copy: %v", kernelPath, err)
-	}
-	if exist {
-		return nil
-	}
-	sharedKernelPath := pmem.GetSharedKernelFilePath()
-	sharedExist, err := utils.FileExistAndValid(sharedKernelPath)
-	if err != nil {
-		return fmt.Errorf("local shared kernel validation failed: %w", err)
-	}
-	if !sharedExist {
-		return fmt.Errorf("local shared kernel not found: %s", sharedKernelPath)
-	}
-	if err := copyLocalKernelAtomically(ctx, sharedKernelPath, kernelPath); err != nil {
-		return err
-	}
-	exist, err = utils.FileExistAndValid(kernelPath)
-	if err != nil {
-		return fmt.Errorf("copied kernel file %s validation failed: %v", kernelPath, err)
-	}
-	if !exist {
-		return fmt.Errorf("copied kernel file %s not exist", kernelPath)
-	}
-	return nil
+	return pmem.SyncKernelFile(ctx, pmem.GetSharedKernelFilePath(), pmem.GetRawKernelFilePath(instanceType, imageRef))
 }
 
 func ensureImageVersionFile(ctx context.Context, instanceType, imageRef string) error {
@@ -173,10 +147,6 @@ func ensureImageVersionFile(ctx context.Context, instanceType, imageRef string) 
 		return fmt.Errorf("copied image version file %s not exist", versionPath)
 	}
 	return nil
-}
-
-func copyLocalKernelAtomically(ctx context.Context, srcPath, dstPath string) error {
-	return copyLocalFileAtomically(ctx, srcPath, dstPath, "shared kernel")
 }
 
 func copyLocalFileAtomically(ctx context.Context, srcPath, dstPath, fileType string) error {

--- a/Cubelet/internal/cube/server/images/ext4image/utils_test.go
+++ b/Cubelet/internal/cube/server/images/ext4image/utils_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/tencentcloud/CubeSandbox/Cubelet/pkg/container/pmem"
 )
 
-func TestEnsureKernelFileCopiesSharedKernelOnce(t *testing.T) {
+func TestEnsureKernelFileRefreshesWhenSharedKernelChanges(t *testing.T) {
 	baseDir := t.TempDir()
 	pmem.Init(baseDir)
 
@@ -52,8 +52,43 @@ func TestEnsureKernelFileCopiesSharedKernelOnce(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ReadFile target kernel after second call error=%v", err)
 	}
-	if !bytes.Equal(got, kernelV1) {
-		t.Fatal("target kernel should keep first copied content")
+	if !bytes.Equal(got, kernelV2) {
+		t.Fatal("target kernel should refresh to latest shared content")
+	}
+}
+
+func TestEnsureKernelFileRefreshesExistingTargetKernel(t *testing.T) {
+	baseDir := t.TempDir()
+	pmem.Init(baseDir)
+
+	sharedKernelPath := pmem.GetSharedKernelFilePath()
+	if err := os.MkdirAll(filepath.Dir(sharedKernelPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll error=%v", err)
+	}
+	sharedKernel := bytes.Repeat([]byte("s"), 3072)
+	if err := os.WriteFile(sharedKernelPath, sharedKernel, 0o644); err != nil {
+		t.Fatalf("WriteFile shared kernel error=%v", err)
+	}
+
+	targetKernelPath := pmem.GetRawKernelFilePath("cubebox", "artifact-2")
+	if err := os.MkdirAll(filepath.Dir(targetKernelPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll target dir error=%v", err)
+	}
+	oldKernel := bytes.Repeat([]byte("o"), 3072)
+	if err := os.WriteFile(targetKernelPath, oldKernel, 0o644); err != nil {
+		t.Fatalf("WriteFile target kernel error=%v", err)
+	}
+
+	if err := ensureKernelFile(context.Background(), "cubebox", "artifact-2"); err != nil {
+		t.Fatalf("ensureKernelFile error=%v", err)
+	}
+
+	got, err := os.ReadFile(targetKernelPath)
+	if err != nil {
+		t.Fatalf("ReadFile target kernel error=%v", err)
+	}
+	if !bytes.Equal(got, sharedKernel) {
+		t.Fatal("target kernel should refresh from shared kernel")
 	}
 }
 

--- a/Cubelet/pkg/container/pmem/kernel_sync.go
+++ b/Cubelet/pkg/container/pmem/kernel_sync.go
@@ -1,0 +1,135 @@
+// Copyright (c) 2024 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package pmem
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/tencentcloud/CubeSandbox/Cubelet/pkg/log"
+	"github.com/tencentcloud/CubeSandbox/Cubelet/pkg/utils"
+)
+
+// SyncKernelFile keeps targetKernelPath aligned with the current shared kernel.
+func SyncKernelFile(ctx context.Context, sharedKernelPath, targetKernelPath string) error {
+	sharedExist, err := utils.FileExistAndValid(sharedKernelPath)
+	if err != nil {
+		return fmt.Errorf("local shared kernel validation failed: %w", err)
+	}
+	if !sharedExist {
+		return fmt.Errorf("local shared kernel not found: %s", sharedKernelPath)
+	}
+
+	targetExist, err := utils.FileExistAndValid(targetKernelPath)
+	if err != nil {
+		log.G(ctx).Warnf("kernel file %s validation failed, refresh from shared kernel: %v", targetKernelPath, err)
+	}
+	if !targetExist {
+		if err := copyKernelFileAtomically(sharedKernelPath, targetKernelPath); err != nil {
+			return err
+		}
+		targetExist, err = utils.FileExistAndValid(targetKernelPath)
+		if err != nil {
+			return fmt.Errorf("copied kernel file %s validation failed: %v", targetKernelPath, err)
+		}
+		if !targetExist {
+			return fmt.Errorf("copied kernel file %s not exist", targetKernelPath)
+		}
+		log.G(ctx).Infof("kernel file %s missing, copied latest shared kernel from %s", targetKernelPath, sharedKernelPath)
+		return nil
+	}
+
+	same, err := sameFileSHA256(sharedKernelPath, targetKernelPath)
+	if err != nil {
+		return err
+	}
+	if same {
+		log.G(ctx).Infof("kernel file %s already matches latest shared kernel %s", targetKernelPath, sharedKernelPath)
+		return nil
+	}
+
+	if err := copyKernelFileAtomically(sharedKernelPath, targetKernelPath); err != nil {
+		return err
+	}
+	same, err = sameFileSHA256(sharedKernelPath, targetKernelPath)
+	if err != nil {
+		return err
+	}
+	if !same {
+		return fmt.Errorf("refreshed kernel file %s still differs from shared kernel %s", targetKernelPath, sharedKernelPath)
+	}
+	log.G(ctx).Infof("kernel file %s refreshed from latest shared kernel %s", targetKernelPath, sharedKernelPath)
+	return nil
+}
+
+func sameFileSHA256(pathA, pathB string) (bool, error) {
+	shaA, err := fileSHA256(pathA)
+	if err != nil {
+		return false, err
+	}
+	shaB, err := fileSHA256(pathB)
+	if err != nil {
+		return false, err
+	}
+	return shaA == shaB, nil
+}
+
+func fileSHA256(path string) (string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+
+	hasher := sha256.New()
+	if _, err := io.Copy(hasher, f); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(hasher.Sum(nil)), nil
+}
+
+func copyKernelFileAtomically(srcPath, dstPath string) error {
+	if err := os.MkdirAll(filepath.Dir(dstPath), 0o755); err != nil {
+		return err
+	}
+	tmpPath := dstPath + ".tmp"
+	if err := os.RemoveAll(tmpPath); err != nil { // NOCC:Path Traversal()
+		return err
+	}
+
+	srcFile, err := os.Open(srcPath)
+	if err != nil {
+		return err
+	}
+	defer srcFile.Close()
+
+	srcInfo, err := srcFile.Stat()
+	if err != nil {
+		return err
+	}
+	dstFile, err := os.OpenFile(tmpPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, srcInfo.Mode()) // NOCC:Path Traversal()
+	if err != nil {
+		return err
+	}
+	if _, err := io.Copy(dstFile, srcFile); err != nil {
+		dstFile.Close()
+		_ = os.RemoveAll(tmpPath) // NOCC:Path Traversal()
+		return err
+	}
+	if err := dstFile.Close(); err != nil {
+		_ = os.RemoveAll(tmpPath) // NOCC:Path Traversal()
+		return err
+	}
+	if err := os.Rename(tmpPath, dstPath); err != nil {
+		_ = os.RemoveAll(tmpPath) // NOCC:Path Traversal()
+		return err
+	}
+	return nil
+}

--- a/Cubelet/plugins/cbri/cubeboxcbri/create_sandbox_kernel_test.go
+++ b/Cubelet/plugins/cbri/cubeboxcbri/create_sandbox_kernel_test.go
@@ -1,0 +1,152 @@
+// Copyright (c) 2024 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package cubeboxcbri
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/containerd/containerd/v2/core/containers"
+	"github.com/containerd/containerd/v2/pkg/oci"
+	"github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/stretchr/testify/require"
+
+	"github.com/tencentcloud/CubeSandbox/Cubelet/api/services/cubebox/v1"
+	cubeimages "github.com/tencentcloud/CubeSandbox/Cubelet/api/services/images/v1"
+	"github.com/tencentcloud/CubeSandbox/Cubelet/pkg/constants"
+	"github.com/tencentcloud/CubeSandbox/Cubelet/pkg/controller/runtemplate/templatetypes"
+	"github.com/tencentcloud/CubeSandbox/Cubelet/plugins/workflow"
+)
+
+func TestCreateSandboxCreateSnapshotRefreshesArtifactKernel(t *testing.T) {
+	t.Parallel()
+
+	plugin := newTestCubeboxPlugin(t)
+	artifactID := "artifact-1"
+	sharedKernelPath := filepath.Join(plugin.config.BasePath, "cube-kernel-scf", "vmlinux")
+	targetKernelPath := plugin.getKernelFilePath(artifactID)
+	writeTestFile(t, sharedKernelPath, bytes.Repeat([]byte("s"), 4096))
+	writeTestFile(t, targetKernelPath, bytes.Repeat([]byte("o"), 2048))
+
+	flowOpts := &workflow.CreateContext{
+		ReqInfo: &cubebox.RunCubeSandboxRequest{
+			InstanceType: cubebox.InstanceType_cubebox.String(),
+			Annotations: map[string]string{
+				constants.MasterAnnotationsAppSnapshotCreate:    "true",
+				constants.MasterAnnotationAppSnapshotTemplateID: "tpl-1",
+			},
+			Containers: []*cubebox.ContainerConfig{
+				{
+					Resources: &cubebox.Resource{Cpu: "2000m", Mem: "2000Mi"},
+					Image: &cubeimages.ImageSpec{
+						Image:        artifactID,
+						StorageMedia: cubeimages.ImageStorageMediaType_ext4.String(),
+					},
+				},
+			},
+		},
+	}
+	ctx := constants.WithAppImageID(context.Background(), artifactID)
+
+	specOpts, err := plugin.CreateSandbox(ctx, flowOpts)
+	require.NoError(t, err)
+
+	gotKernel, err := os.ReadFile(targetKernelPath)
+	require.NoError(t, err)
+	require.Equal(t, bytes.Repeat([]byte("s"), 4096), gotKernel)
+
+	spec := applySpecOpts(t, ctx, specOpts)
+	require.Equal(t, targetKernelPath, spec.Annotations[constants.AnnotationsVMKernelPath])
+}
+
+func TestCreateSandboxRestoreDoesNotRefreshArtifactKernel(t *testing.T) {
+	t.Parallel()
+
+	plugin := newTestCubeboxPlugin(t)
+	artifactID := "artifact-2"
+	sharedKernelPath := filepath.Join(plugin.config.BasePath, "cube-kernel-scf", "vmlinux")
+	targetKernelPath := plugin.getKernelFilePath(artifactID)
+	oldKernel := bytes.Repeat([]byte("o"), 2048)
+	writeTestFile(t, sharedKernelPath, bytes.Repeat([]byte("s"), 4096))
+	writeTestFile(t, targetKernelPath, oldKernel)
+
+	flowOpts := &workflow.CreateContext{
+		ReqInfo: &cubebox.RunCubeSandboxRequest{
+			InstanceType: cubebox.InstanceType_cubebox.String(),
+			Annotations: map[string]string{
+				constants.MasterAnnotationAppSnapshotTemplateID: "tpl-restore",
+				constants.MasterAnnotationAppSnapshotVersion:    "v2",
+			},
+			Containers: []*cubebox.ContainerConfig{
+				{
+					Resources: &cubebox.Resource{Cpu: "2000m", Mem: "2000Mi"},
+					Image: &cubeimages.ImageSpec{
+						Image:        artifactID,
+						StorageMedia: cubeimages.ImageStorageMediaType_ext4.String(),
+					},
+				},
+			},
+		},
+		LocalRunTemplate: &templatetypes.LocalRunTemplate{
+			Componts: map[string]templatetypes.LocalComponent{
+				templatetypes.CubeComponentCubeKernel: {
+					Component: templatetypes.MachineComponent{Path: "/template/kernel.vm"},
+				},
+				templatetypes.CubeComponentCubeImage: {
+					Component: templatetypes.MachineComponent{Path: "/template/image.ext4"},
+				},
+			},
+		},
+	}
+	ctx := constants.WithAppImageID(context.Background(), artifactID)
+
+	specOpts, err := plugin.CreateSandbox(ctx, flowOpts)
+	require.NoError(t, err)
+
+	gotKernel, err := os.ReadFile(targetKernelPath)
+	require.NoError(t, err)
+	require.Equal(t, oldKernel, gotKernel)
+
+	spec := applySpecOpts(t, ctx, specOpts)
+	require.Equal(t, "/template/kernel.vm", spec.Annotations[constants.AnnotationsVMKernelPath])
+}
+
+func newTestCubeboxPlugin(t *testing.T) *cubeboxInstancePlugin {
+	t.Helper()
+
+	basePath := t.TempDir()
+	return &cubeboxInstancePlugin{
+		config: &cubeboxInstancePluginConfig{
+			BasePath:         basePath,
+			ImageBasePath:    filepath.Join(basePath, "cubebox_os_image"),
+			KernelBasePath:   filepath.Join(basePath, "cubebox_os_image"),
+			SnapShotBasePath: filepath.Join(basePath, "cube-snapshot"),
+			instanceType:     cubebox.InstanceType_cubebox.String(),
+		},
+	}
+}
+
+func writeTestFile(t *testing.T, path string, content []byte) {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	require.NoError(t, os.WriteFile(path, content, 0o644))
+}
+
+func applySpecOpts(t *testing.T, ctx context.Context, specOpts []oci.SpecOpts) *specs.Spec {
+	t.Helper()
+
+	spec := &specs.Spec{
+		Annotations: map[string]string{},
+		Linux:       &specs.Linux{},
+		Process:     &specs.Process{},
+	}
+	for _, specOpt := range specOpts {
+		require.NoError(t, specOpt(ctx, nil, &containers.Container{}, spec))
+	}
+	return spec
+}

--- a/Cubelet/plugins/cbri/cubeboxcbri/cubebox.go
+++ b/Cubelet/plugins/cbri/cubeboxcbri/cubebox.go
@@ -146,12 +146,17 @@ func (e *cubeboxInstancePlugin) CreateSandbox(ctx context.Context, flowOpts *wor
 		kernelPath  string
 	)
 
-	if constants.GetAppImageID(ctx) == "" {
+	appImageID := constants.GetAppImageID(ctx)
+	if appImageID == "" {
 		kernelPath = filepath.Join(e.config.BasePath, "cube-kernel-scf", "vmlinux")
 	} else {
-
-		kernelPath = e.getKernelFilePath(constants.GetAppImageID(ctx))
-		rootfs := filepath.Join(e.config.ImageBasePath, constants.GetAppImageID(ctx))
+		if flowOpts.IsCreateSnapshot() {
+			if err := e.syncLatestKernelForImage(ctx, appImageID); err != nil {
+				return nil, err
+			}
+		}
+		kernelPath = e.getKernelFilePath(appImageID)
+		rootfs := filepath.Join(e.config.ImageBasePath, appImageID)
 		specOpts = append(specOpts, oci.WithRootFSPath(rootfs))
 		logEntry = logEntry.WithField("rootfs", rootfs)
 	}
@@ -169,8 +174,7 @@ func (e *cubeboxInstancePlugin) CreateSandbox(ctx context.Context, flowOpts *wor
 
 	} else if templateID, ok := flowOpts.GetSnapshotTemplateID(); ok {
 
-		var snapBasePath string
-		var snapSpecPath string
+		var snapBasePath, snapSpecPath string
 
 		if flowOpts.IsCubeboxV2() {
 			if flowOpts.LocalRunTemplate == nil {
@@ -203,7 +207,7 @@ func (e *cubeboxInstancePlugin) CreateSandbox(ctx context.Context, flowOpts *wor
 
 		annotations[constants.AnnotationAppSnapshotRestore] = "true"
 
-		annotations[constants.AnnotationAppSnapshotContainerID] = templateID + "_" + "0"
+		annotations[constants.AnnotationAppSnapshotContainerID] = templateID + "_0"
 
 		sandbox := cubeboxstore.GetCubeBox(ctx)
 		if sandbox != nil && sandbox.FirstContainer() != nil {
@@ -377,6 +381,15 @@ func (e *cubeboxInstancePlugin) genPmemOpt(ctx context.Context, imageID string) 
 func (e *cubeboxInstancePlugin) getImageFilePath(imageID string) string {
 	return filepath.Join(e.config.ImageBasePath, imageID, imageID+".ext4")
 }
+
+func (e *cubeboxInstancePlugin) syncLatestKernelForImage(ctx context.Context, imageID string) error {
+	return pmem.SyncKernelFile(
+		ctx,
+		filepath.Join(e.config.BasePath, "cube-kernel-scf", "vmlinux"),
+		e.getKernelFilePath(imageID),
+	)
+}
+
 func (e *cubeboxInstancePlugin) getKernelFilePath(imageID string) string {
 	return filepath.Join(e.config.KernelBasePath, imageID, imageID+".vm")
 }
@@ -471,11 +484,13 @@ func inferSnapshotResDirFromRequest(req *cubebox.RunCubeSandboxRequest) (string,
 		return "", fmt.Errorf("local snapshot not exist")
 	}
 
-	cpuQ, err := resource.ParseQuantity(req.Containers[0].GetResources().GetCpu())
+	resources := req.Containers[0].GetResources()
+
+	cpuQ, err := resource.ParseQuantity(resources.GetCpu())
 	if err != nil {
 		return "", fmt.Errorf("parse snapshot cpu resource failed: %w", err)
 	}
-	memQ, err := resource.ParseQuantity(req.Containers[0].GetResources().GetMem())
+	memQ, err := resource.ParseQuantity(resources.GetMem())
 	if err != nil {
 		return "", fmt.Errorf("parse snapshot memory resource failed: %w", err)
 	}

--- a/dev-env/README.md
+++ b/dev-env/README.md
@@ -123,42 +123,65 @@ Other subcommands:
 
 This is the main reason `dev-env/` exists.
 
-After editing code in this repo on your host, push your changes into the
-running VM with one command:
+Recommended terminal setup:
 
 ```bash
-./sync_to_vm.sh
+./login.sh    # keep this shell open; by default it lands in a root shell
 ```
 
-What it does, in order:
-
-1. Runs `make all` in the repo root
-2. Backs up old binaries inside the guest as `*.bak` (only the most
-   recent backup is kept)
-3. Copies the new binaries to the matching paths under
-   `/usr/local/services/cubetoolbox/`
-4. Restarts `cube-sandbox-oneclick.service`
-5. Runs `quickcheck.sh`; if it fails, **automatically restores the
-   `.bak` files** and restarts again
-
-Common shortcuts:
+Then iterate from your host shell:
 
 ```bash
-# Skip the local build, reuse what's already in _output/bin/
-BUILD=0 ./sync_to_vm.sh
+make all
+./sync_to_vm.sh bin cubelet cubemaster
+```
+
+`sync_to_vm.sh` now has a single job: copy files into the VM. It does not
+build on the host, restart services, run `quickcheck.sh`, or roll back
+automatically.
+
+After the copy finishes, paste the printed restart command into your
+`./login.sh` session:
+
+```bash
+systemctl restart cube-sandbox-oneclick.service
+```
+
+Useful examples:
+
+```bash
+# Sync all known binaries from _output/bin/
+./sync_to_vm.sh bin
 
 # Sync only specific components
-COMPONENTS="cubemaster cubelet" ./sync_to_vm.sh
+./sync_to_vm.sh bin cubemaster cubelet
 
-# Push arbitrary files (no service restart)
-MODE=files FILES="./configs/foo.toml" REMOTE_DIR=/tmp ./sync_to_vm.sh
-
-# Use the official manual-release flow instead of raw binaries
-MODE=release ./sync_to_vm.sh
+# Push arbitrary files into the guest
+./sync_to_vm.sh files --remote-dir /tmp ./configs/foo.toml
 ```
+
+The previous binary is still kept on the VM as `*.bak`, but the script no
+longer surfaces rollback or verification steps in its output.
 
 Prerequisite: Step 4 finished and (recommended) `./cube-autostart.sh`
 has been run.
+
+## Manual release flow
+
+From your host shell:
+
+```bash
+make manual-release
+./sync_to_vm.sh files \
+  _output/release/cube-manual-update-*.tar.gz \
+  deploy/one-click/deploy-manual.sh
+```
+
+Then in your `./login.sh` session:
+
+```bash
+bash /tmp/deploy-manual.sh /tmp/cube-manual-update-*.tar.gz
+```
 
 ## Collect logs from the VM
 
@@ -178,7 +201,7 @@ README as `data-log-<timestamp>.tar.gz`.
 | `df -h /` inside the guest is still small | `prepare_image.sh` never finished the auto-grow step | Inspect `.workdir/qemu-serial.log`, then `scp internal/grow_rootfs.sh` into the guest and run it manually |
 | Host port 13000 / 11080 / 11443 already taken | Some other service binds the forwarded dev-env ports | Start with `CUBE_API_PORT=23000 CUBE_PROXY_HTTP_PORT=21080 CUBE_PROXY_HTTPS_PORT=21443 ./run_vm.sh` |
 | Cube components gone after VM reboot | Autostart not enabled | Run `./cube-autostart.sh` once |
-| `sync_to_vm.sh` rolled back | `quickcheck` failed with new binaries | Check `/data/log/` in the guest, fix the bug, then re-run `sync_to_vm.sh` |
+| New binaries fail after restart | The new build is bad, or `quickcheck` fails when you run it manually | Check `/data/log/` in the guest, and if needed restore the previous `*.bak` binary manually before restarting again |
 
 ## Reference
 
@@ -191,7 +214,7 @@ dev-env/
 ├── run_vm.sh               # Step 2
 ├── login.sh                # Step 3
 ├── cube-autostart.sh       # enable / disable / status the systemd autostart unit
-├── sync_to_vm.sh           # Develop loop
+├── sync_to_vm.sh           # Copy host artifacts into the guest (no build/restart)
 ├── copy_logs.sh            # Pull /data/log from the guest
 └── internal/               # Run inside the guest by prepare_image.sh
     ├── grow_rootfs.sh         # grow rootfs to qcow2 virtual size
@@ -247,12 +270,15 @@ Subcommands: `enable` (default), `disable`, `status`.
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `MODE` | `binaries` | `binaries` / `release` / `files`. |
-| `BUILD` | `1` | `0` skips `make all` / `make manual-release`. |
-| `RESTART` | `1` | `0` skips the remote `systemctl restart`. |
-| `COMPONENTS` | (all) | `binaries` mode: subset of binaries to push. |
-| `FILES` | — | `files` mode: paths to scp. |
-| `REMOTE_DIR` | `/tmp` | `files` mode: destination dir in the guest. |
+| `TOOLBOX_ROOT` | `/usr/local/services/cubetoolbox` | Base install dir used to map known components in `bin` mode. |
+| `UNIT_NAME` | `cube-sandbox-oneclick.service` | Unit name shown in the final restart hint. |
+| `OUTPUT_BIN_DIR` | `_output/bin` | Where `bin` mode reads host-side binaries from. |
+
+Subcommands:
+
+- `bin [NAME ...]`: copy pre-built binaries into their install paths in the guest. If `NAME` is omitted, sync all known components.
+- `files [--remote-dir DIR] PATH [PATH ...]`: copy arbitrary files or directories into the guest.
+- `-h`, `--help`: show the built-in help text.
 
 #### `copy_logs.sh`
 

--- a/dev-env/README_zh.md
+++ b/dev-env/README_zh.md
@@ -114,37 +114,62 @@ coredns、network-agent、cubemaster、cube-api、cubelet 一并拉起。
 
 这才是 `dev-env/` 存在的真正价值。
 
-在宿主机上改完代码后，一行命令把改动推进虚机：
+推荐的终端分工：
 
 ```bash
-./sync_to_vm.sh
+./login.sh    # 常驻开着；默认会直接进 guest 的 root shell
 ```
 
-它会按顺序做：
-
-1. 在仓库根目录跑 `make all`
-2. 在 guest 内把旧二进制原地 `mv` 成 `*.bak`（**只保留最近一份**备份）
-3. 把新二进制 scp 到 `/usr/local/services/cubetoolbox/` 下对应路径
-4. `systemctl restart cube-sandbox-oneclick.service`
-5. 跑 `quickcheck.sh`；如果失败，**自动用 `.bak` 回滚**并重启
-
-常用快捷方式：
+然后在宿主机终端里做开发循环：
 
 ```bash
-# 跳过本地构建，直接用 _output/bin/ 里已有的产物
-BUILD=0 ./sync_to_vm.sh
+make all
+./sync_to_vm.sh bin cubelet cubemaster
+```
+
+现在的 `sync_to_vm.sh` 只有一个职责：把文件拷进虚机。它**不会**在宿主机
+构建、不会重启服务、不会跑 `quickcheck.sh`，也不会自动回滚。
+
+拷贝结束后，把脚本打印出来的重启命令粘进 `./login.sh` 那个终端里：
+
+```bash
+systemctl restart cube-sandbox-oneclick.service
+```
+
+常用示例：
+
+```bash
+# 同步 _output/bin/ 里所有已知组件
+./sync_to_vm.sh bin
 
 # 只同步指定组件
-COMPONENTS="cubemaster cubelet" ./sync_to_vm.sh
+./sync_to_vm.sh bin cubemaster cubelet
 
-# 推任意文件（不重启服务）
-MODE=files FILES="./configs/foo.toml" REMOTE_DIR=/tmp ./sync_to_vm.sh
-
-# 不走裸二进制，走官方 manual-release 流程
-MODE=release ./sync_to_vm.sh
+# 推任意文件到 guest
+./sync_to_vm.sh files --remote-dir /tmp ./configs/foo.toml
 ```
 
+旧二进制仍然会在 guest 里保留成 `*.bak`，但脚本输出不再主动教你怎么
+verify / rollback；需要的话你自己在虚机里处理。
+
 前置：第 4 步已完成；推荐先跑过 `./cube-autostart.sh`。
+
+## manual-release 流程
+
+先在宿主机终端里：
+
+```bash
+make manual-release
+./sync_to_vm.sh files \
+  _output/release/cube-manual-update-*.tar.gz \
+  deploy/one-click/deploy-manual.sh
+```
+
+然后切到 `./login.sh` 的 root 终端里：
+
+```bash
+bash /tmp/deploy-manual.sh /tmp/cube-manual-update-*.tar.gz
+```
 
 ## 从虚机收日志
 
@@ -164,7 +189,7 @@ MODE=release ./sync_to_vm.sh
 | 虚机里 `df -h /` 还是很小 | `prepare_image.sh` 没走完自动扩容 | 查看 `.workdir/qemu-serial.log`，然后把 `internal/grow_rootfs.sh` scp 进去手动跑一次 |
 | 宿主机 13000 / 11080 / 11443 端口被占 | 本机有别的服务在用这些 dev-env 转发端口 | 用 `CUBE_API_PORT=23000 CUBE_PROXY_HTTP_PORT=21080 CUBE_PROXY_HTTPS_PORT=21443 ./run_vm.sh` |
 | 虚机重启后 cube 组件没了 | 还没开启 autostart | 跑一次 `./cube-autostart.sh` |
-| `sync_to_vm.sh` 自动回滚了 | `quickcheck` 用新二进制失败 | 看 guest 里 `/data/log/`，修 bug 后重新跑 `sync_to_vm.sh` |
+| 重启后新二进制不好使 | 新构建有问题，或你手动跑 `quickcheck` 失败了 | 看 guest 里 `/data/log/`，必要时把对应的 `*.bak` 手动移回去，再重新 `systemctl restart` |
 
 ## 参考
 
@@ -177,7 +202,7 @@ dev-env/
 ├── run_vm.sh               # 第 2 步
 ├── login.sh                # 第 3 步
 ├── cube-autostart.sh       # enable / disable / status systemd autostart unit
-├── sync_to_vm.sh           # 开发循环
+├── sync_to_vm.sh           # 只负责把宿主机产物拷进虚机，不 build/不 restart
 ├── copy_logs.sh            # 拉 /data/log
 └── internal/               # 由 prepare_image.sh 传进虚机执行
     ├── grow_rootfs.sh         # 扩根文件系统到 qcow2 虚拟大小
@@ -233,12 +258,15 @@ dev-env/
 
 | 变量 | 默认值 | 说明 |
 |------|--------|------|
-| `MODE` | `binaries` | `binaries` / `release` / `files`。 |
-| `BUILD` | `1` | `0` 跳过 `make all` / `make manual-release`。 |
-| `RESTART` | `1` | `0` 不在远端 `systemctl restart`。 |
-| `COMPONENTS` | （全部） | `binaries` 模式：只推这些组件。 |
-| `FILES` | — | `files` 模式：要 scp 的路径。 |
-| `REMOTE_DIR` | `/tmp` | `files` 模式：远端落点目录。 |
+| `TOOLBOX_ROOT` | `/usr/local/services/cubetoolbox` | `bin` 子命令里已知组件的安装根目录。 |
+| `UNIT_NAME` | `cube-sandbox-oneclick.service` | 脚本末尾打印的重启提示里会用到的 unit 名。 |
+| `OUTPUT_BIN_DIR` | `_output/bin` | `bin` 子命令读取宿主机二进制的目录。 |
+
+子命令：
+
+- `bin [NAME ...]`：把预构建好的二进制推到 guest 对应安装路径；不写 `NAME` 时同步全部已知组件。
+- `files [--remote-dir DIR] PATH [PATH ...]`：把任意文件或目录推到 guest。
+- `-h`、`--help`：查看内置帮助。
 
 #### `copy_logs.sh`
 

--- a/dev-env/sync_to_vm.sh
+++ b/dev-env/sync_to_vm.sh
@@ -2,37 +2,10 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (C) 2026 Tencent. All rights reserved.
 #
-# sync_to_vm.sh — Push locally-built artifacts into the CubeSandbox dev VM.
+# sync_to_vm.sh — Copy pre-built artifacts into the CubeSandbox dev VM.
 #
-# This is the core inner-loop tool for development: rebuild on the host, sync
-# binaries into the guest, restart services, and run quickcheck — with
-# automatic rollback from .bak if the health check fails.
-#
-# Modes (selected via MODE env, default "binaries"):
-#   binaries  Copy Go binaries from _output/bin/ to their install paths in
-#             the guest; previous file is kept as <name>.bak (only 1 backup).
-#             Restarts cube-sandbox-oneclick.service and runs quickcheck.sh.
-#             On failure, .bak files are restored and the unit restarted again.
-#   release   Run `make manual-release` then deploy the tarball via
-#             deploy-manual.sh inside the guest.
-#   files     Free-form scp of a list of files to REMOTE_DIR (default /tmp).
-#
-# Usage:
-#   ./sync_to_vm.sh                                  # binaries mode, build + restart
-#   MODE=binaries COMPONENTS="cubelet cubemaster" ./sync_to_vm.sh
-#   MODE=binaries BUILD=0 RESTART=0 ./sync_to_vm.sh  # sync only, no build/restart
-#   MODE=release ./sync_to_vm.sh
-#   MODE=files FILES="foo.yaml bar.conf" REMOTE_DIR=/tmp ./sync_to_vm.sh
-#
-# Common environment variables:
-#   MODE                       binaries | release | files (default: binaries)
-#   BUILD                      Run `make all` before syncing (default: 1)
-#   RESTART                    Restart unit + quickcheck after sync (default: 1; 0 or "systemd")
-#   COMPONENTS                 Space-separated binary names to sync (default: all in _output/bin/)
-#   FILES                      Files to send in "files" mode
-#   REMOTE_DIR                 Remote dir for "files" mode (default: /tmp)
-#   VM_USER, VM_PASSWORD       Guest credentials (default: opencloudos / opencloudos)
-#   SSH_HOST, SSH_PORT         Host-side forward target (default: 127.0.0.1:10022)
+# This script only copies files. It does not build on the host, restart
+# services, run quickcheck, or roll back automatically.
 
 set -euo pipefail
 
@@ -45,22 +18,12 @@ VM_PASSWORD="${VM_PASSWORD:-opencloudos}"
 SSH_HOST="${SSH_HOST:-127.0.0.1}"
 SSH_PORT="${SSH_PORT:-10022}"
 
-MODE="${MODE:-binaries}"
-BUILD="${BUILD:-1}"
-RESTART="${RESTART:-1}"
-COMPONENTS="${COMPONENTS:-}"
-FILES="${FILES:-}"
-REMOTE_DIR="${REMOTE_DIR:-/tmp}"
-
 TOOLBOX_ROOT="${TOOLBOX_ROOT:-/usr/local/services/cubetoolbox}"
 UNIT_NAME="${UNIT_NAME:-cube-sandbox-oneclick.service}"
-QUICKCHECK="${TOOLBOX_ROOT}/scripts/one-click/quickcheck.sh"
-
 OUTPUT_BIN_DIR="${OUTPUT_BIN_DIR:-${REPO_ROOT}/_output/bin}"
-RELEASE_DIR="${RELEASE_DIR:-${REPO_ROOT}/_output/release}"
-DEPLOY_MANUAL_SCRIPT="${REPO_ROOT}/deploy/one-click/deploy-manual.sh"
 
 ASKPASS_SCRIPT="${WORK_DIR}/.ssh-askpass.sh"
+REMOTE_DIR_DEFAULT="/tmp"
 
 LOG_TAG="sync_to_vm"
 
@@ -91,6 +54,47 @@ log_success() { _log "${LOG_COLOR_SUCCESS}" "OK"    "$@"; }
 log_warn()    { _log "${LOG_COLOR_WARN}"    "WARN"  "$@" >&2; }
 log_error()   { _log "${LOG_COLOR_ERROR}"   "ERROR" "$@" >&2; }
 
+usage() {
+  cat <<EOF
+Usage: $(basename "$0") <subcommand> [args]
+
+Subcommands:
+  bin [NAME ...]                Copy pre-built binaries from ${OUTPUT_BIN_DIR}
+                                into the VM. If NAME is omitted, sync all
+                                known components.
+  files [--remote-dir DIR] PATH [PATH ...]
+                                Copy arbitrary files or directories into the VM.
+  -h, --help                    Show this help.
+
+Known components:
+  cubemaster, cubemastercli, cubelet, cubecli,
+  network-agent, cube-api, cube-runtime, containerd-shim-cube-rs
+
+Environment overrides:
+  VM_USER, VM_PASSWORD, SSH_HOST, SSH_PORT
+  TOOLBOX_ROOT       default: ${TOOLBOX_ROOT}
+  UNIT_NAME          default: ${UNIT_NAME}
+  OUTPUT_BIN_DIR     default: ${OUTPUT_BIN_DIR}
+
+Notes:
+  - This script only copies files. Build on the host first.
+  - Previous binary is kept as <name>.bak on the VM.
+EOF
+}
+
+usage_error() {
+  log_error "$1"
+  usage >&2
+  exit 2
+}
+
+is_help_arg() {
+  case "${1:-}" in
+    -h|--help|help) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
 need_cmd() {
   if ! command -v "$1" >/dev/null 2>&1; then
     log_error "Missing required command: $1"
@@ -98,22 +102,24 @@ need_cmd() {
   fi
 }
 
-need_cmd ssh
-need_cmd scp
-need_cmd setsid
-
-mkdir -p "${WORK_DIR}"
-
-cat >"${ASKPASS_SCRIPT}" <<EOF
-#!/usr/bin/env bash
-printf '%s\n' '${VM_PASSWORD}'
-EOF
-chmod 700 "${ASKPASS_SCRIPT}"
-
 cleanup() {
   rm -f "${ASKPASS_SCRIPT}"
 }
-trap cleanup EXIT
+
+setup_ssh_support() {
+  need_cmd ssh
+  need_cmd scp
+  need_cmd setsid
+
+  mkdir -p "${WORK_DIR}"
+
+  cat >"${ASKPASS_SCRIPT}" <<EOF
+#!/usr/bin/env bash
+printf '%s\n' '${VM_PASSWORD}'
+EOF
+  chmod 700 "${ASKPASS_SCRIPT}"
+  trap cleanup EXIT
+}
 
 SSH_COMMON_OPTS=(
   -o StrictHostKeyChecking=no
@@ -132,28 +138,27 @@ SCP_OPTS=(
   -P "${SSH_PORT}"
 )
 
-run_ssh() {
+run_with_askpass() {
   DISPLAY="${DISPLAY:-cubesandbox-dev-env}" \
   SSH_ASKPASS="${ASKPASS_SCRIPT}" \
   SSH_ASKPASS_REQUIRE=force \
-  setsid -w ssh "${SSH_OPTS[@]}" "${VM_USER}@${SSH_HOST}" "$@"
+  setsid -w "$@"
+}
+
+run_ssh() {
+  run_with_askpass ssh "${SSH_OPTS[@]}" "${VM_USER}@${SSH_HOST}" "$@"
 }
 
 run_scp() {
-  DISPLAY="${DISPLAY:-cubesandbox-dev-env}" \
-  SSH_ASKPASS="${ASKPASS_SCRIPT}" \
-  SSH_ASKPASS_REQUIRE=force \
-  setsid -w scp "${SCP_OPTS[@]}" "$@"
+  run_with_askpass scp "${SCP_OPTS[@]}" "$@"
 }
 
-# Component layout: name -> remote install dir.
-# Mirrors deploy/one-click/scripts/one-click/up.sh.
 component_remote_dir() {
   case "$1" in
-    cubemaster|cubemastercli)   printf '%s/CubeMaster/bin\n' "${TOOLBOX_ROOT}" ;;
-    cubelet|cubecli)            printf '%s/Cubelet/bin\n' "${TOOLBOX_ROOT}" ;;
-    network-agent)              printf '%s/network-agent/bin\n' "${TOOLBOX_ROOT}" ;;
-    cube-api)                   printf '%s/CubeAPI/bin\n' "${TOOLBOX_ROOT}" ;;
+    cubemaster|cubemastercli) printf '%s/CubeMaster/bin\n' "${TOOLBOX_ROOT}" ;;
+    cubelet|cubecli) printf '%s/Cubelet/bin\n' "${TOOLBOX_ROOT}" ;;
+    network-agent) printf '%s/network-agent/bin\n' "${TOOLBOX_ROOT}" ;;
+    cube-api) printf '%s/CubeAPI/bin\n' "${TOOLBOX_ROOT}" ;;
     cube-runtime|containerd-shim-cube-rs) printf '/usr/local/bin\n' ;;
     *) return 1 ;;
   esac
@@ -167,85 +172,74 @@ ALL_COMPONENTS=(
   cube-runtime containerd-shim-cube-rs
 )
 
-restart_remote() {
-  case "${RESTART}" in
-    0)
-      log_info "RESTART=0, skipping remote restart"
-      return 0
-      ;;
-    1|systemd)
-      log_info "Restarting ${UNIT_NAME} on the guest..."
-      if ! run_ssh "sudo systemctl restart '${UNIT_NAME}'"; then
-        log_error "systemctl restart ${UNIT_NAME} failed"
-        return 1
-      fi
-      log_success "${UNIT_NAME} restarted"
-      ;;
-    *)
-      log_error "Unknown RESTART value: ${RESTART} (expected 0|1|systemd)"
-      return 1
-      ;;
-  esac
-
-  if run_ssh "sudo test -x '${QUICKCHECK}'"; then
-    log_info "Running quickcheck on the guest..."
-    if run_ssh "sudo '${QUICKCHECK}'"; then
-      log_success "quickcheck passed"
-      return 0
-    fi
-    log_error "quickcheck failed"
-    return 1
+validate_component() {
+  local name="$1"
+  if ! component_remote_dir "${name}" >/dev/null; then
+    log_error "Unknown component: ${name}"
+    log_error "Known components: ${ALL_COMPONENTS[*]}"
+    exit 1
   fi
-
-  log_warn "quickcheck script not found at ${QUICKCHECK}, skipping verification"
 }
 
-mode_binaries() {
-  if [[ "${BUILD}" == "1" ]]; then
-    log_info "Running 'make all' in ${REPO_ROOT}..."
-    ( cd "${REPO_ROOT}" && make all )
-    log_success "Local build finished"
-  else
-    log_info "BUILD=0, skipping 'make all'"
+print_bin_next_step() {
+  printf '\nNext step - paste into your ./login.sh session (root shell in the VM):\n\n'
+  printf '  systemctl restart %s\n' "${UNIT_NAME}"
+}
+
+mode_bin() {
+  local -a target_components=("$@")
+  local name=""
+  local remote_dir=""
+  local local_path=""
+  local remote_path=""
+
+  if [[ "${#target_components[@]}" -eq 1 ]] && is_help_arg "${target_components[0]}"; then
+    usage
+    exit 0
   fi
 
   if [[ ! -d "${OUTPUT_BIN_DIR}" ]]; then
-    log_error "Output dir not found: ${OUTPUT_BIN_DIR}"
-    log_error "Run 'make all' first or set BUILD=1."
+    log_error "Binary output directory not found: ${OUTPUT_BIN_DIR}"
+    log_error "Build on the host first, for example: make all"
     exit 1
   fi
 
-  local -a target_components
-  if [[ -n "${COMPONENTS}" ]]; then
-    # shellcheck disable=SC2206
-    target_components=(${COMPONENTS})
-  else
+  if [[ "${#target_components[@]}" -eq 0 ]]; then
     target_components=("${ALL_COMPONENTS[@]}")
   fi
 
-  local -a synced=()
-  local -a synced_remote_paths=()
-  local name remote_dir local_path remote_path
-
   for name in "${target_components[@]}"; do
-    if ! remote_dir="$(component_remote_dir "${name}")"; then
-      log_warn "Unknown component '${name}', skipping"
-      continue
+    if [[ "${name}" == -* ]]; then
+      usage_error "Unknown option for 'bin': ${name}"
     fi
+    validate_component "${name}"
     local_path="${OUTPUT_BIN_DIR}/${name}"
     if [[ ! -f "${local_path}" ]]; then
-      log_warn "Local binary missing, skipping: ${local_path}"
-      continue
+      log_error "Binary not found: ${local_path}"
+      log_error "Build it on the host first, for example: make all"
+      exit 1
+    fi
+  done
+
+  setup_ssh_support
+
+  log_info "Target VM : ${VM_USER}@${SSH_HOST}:${SSH_PORT}"
+  log_info "Subcommand: bin"
+
+  for name in "${target_components[@]}"; do
+    remote_dir="$(component_remote_dir "${name}")"
+    local_path="${OUTPUT_BIN_DIR}/${name}"
+    remote_path="${remote_dir}/${name}"
+
+    log_info "Copying ${local_path} -> ${VM_USER}@${SSH_HOST}:${remote_path}"
+
+    local stage_path="/tmp/${name}.sync_to_vm.$$"
+    if ! run_scp "${local_path}" "${VM_USER}@${SSH_HOST}:${stage_path}"; then
+      log_error "Failed to upload ${local_path} to the VM"
+      log_error "Check that the VM is running and SSH settings are correct."
+      exit 1
     fi
 
-    remote_path="${remote_dir}/${name}"
-    log_info "Syncing ${name} -> ${VM_USER}@${SSH_HOST}:${remote_path}"
-
-    # Stage to /tmp first (we cannot scp directly as root via password auth).
-    local stage_path="/tmp/${name}.sync_to_vm.$$"
-    run_scp "${local_path}" "${VM_USER}@${SSH_HOST}:${stage_path}"
-
-    # Backup existing -> .bak (overwrites previous .bak), then move into place.
     if ! run_ssh "
       set -e
       sudo mkdir -p '${remote_dir}'
@@ -256,122 +250,105 @@ mode_binaries() {
       sudo chmod +x '${remote_path}'
       sudo chown root:root '${remote_path}' || true
     "; then
-      log_error "Failed to install ${name} on the guest"
+      log_error "Failed to install ${name} on the VM"
       run_ssh "sudo rm -f '${stage_path}'" || true
       exit 1
     fi
-    synced+=("${name}")
-    synced_remote_paths+=("${remote_path}")
   done
 
-  if [[ "${#synced[@]}" -eq 0 ]]; then
-    log_warn "No binaries were synced. Nothing to restart."
-    return 0
-  fi
-
-  log_success "Synced binaries: ${synced[*]}"
-
-  if ! restart_remote; then
-    log_error "Remote restart/quickcheck failed; rolling back .bak files..."
-    local p
-    for p in "${synced_remote_paths[@]}"; do
-      log_warn "Restoring ${p}.bak -> ${p}"
-      run_ssh "
-        if sudo test -f '${p}.bak'; then
-          sudo mv -f '${p}.bak' '${p}'
-          sudo chmod +x '${p}' || true
-        fi
-      " || log_error "Failed to restore ${p}"
-    done
-    log_warn "Attempting to restart with previous binaries..."
-    run_ssh "sudo systemctl restart '${UNIT_NAME}'" || \
-      log_error "Restart with previous binaries also failed; manual intervention required."
-    exit 1
-  fi
-}
-
-mode_release() {
-  if [[ "${BUILD}" == "1" ]]; then
-    log_info "Running 'make manual-release' in ${REPO_ROOT}..."
-    ( cd "${REPO_ROOT}" && make manual-release )
-    log_success "Manual release built"
-  else
-    log_info "BUILD=0, skipping 'make manual-release'"
-  fi
-
-  if [[ ! -d "${RELEASE_DIR}" ]]; then
-    log_error "Release dir not found: ${RELEASE_DIR}"
-    exit 1
-  fi
-
-  local pkg
-  pkg="$(ls -t "${RELEASE_DIR}"/cube-manual-update-*.tar.gz 2>/dev/null | head -n 1 || true)"
-  if [[ -z "${pkg}" ]]; then
-    log_error "No cube-manual-update-*.tar.gz found in ${RELEASE_DIR}"
-    exit 1
-  fi
-
-  if [[ ! -f "${DEPLOY_MANUAL_SCRIPT}" ]]; then
-    log_error "deploy-manual.sh not found: ${DEPLOY_MANUAL_SCRIPT}"
-    exit 1
-  fi
-
-  local remote_pkg="/tmp/$(basename "${pkg}")"
-  local remote_script="/tmp/deploy-manual.sh"
-
-  log_info "Uploading $(basename "${pkg}") to ${remote_pkg}"
-  run_scp "${pkg}" "${VM_USER}@${SSH_HOST}:${remote_pkg}"
-  log_info "Uploading deploy-manual.sh to ${remote_script}"
-  run_scp "${DEPLOY_MANUAL_SCRIPT}" "${VM_USER}@${SSH_HOST}:${remote_script}"
-
-  log_info "Running deploy-manual.sh on the guest..."
-  run_ssh "sudo bash '${remote_script}' '${remote_pkg}'"
-  log_success "Manual deploy finished"
-
-  if [[ "${RESTART}" != "0" ]]; then
-    # deploy-manual.sh already restarts services, but if the user enabled the
-    # systemd unit we additionally re-sync its state so that the unit reflects
-    # the new processes.
-    log_info "Refreshing ${UNIT_NAME} state..."
-    run_ssh "sudo systemctl restart '${UNIT_NAME}'" || \
-      log_warn "systemctl restart ${UNIT_NAME} failed (unit may not be enabled)"
-  fi
+  log_success "Synced ${#target_components[@]} binaries: ${target_components[*]}"
+  print_bin_next_step
 }
 
 mode_files() {
-  if [[ -z "${FILES}" ]]; then
-    log_error "MODE=files requires FILES=\"path1 path2 ...\""
-    exit 1
+  local remote_dir="${REMOTE_DIR_DEFAULT}"
+  local -a paths=()
+  local f=""
+
+  while [[ "$#" -gt 0 ]]; do
+    case "$1" in
+      --remote-dir)
+        if [[ "$#" -lt 2 ]]; then
+          usage_error "Missing value for --remote-dir"
+        fi
+        remote_dir="$2"
+        shift 2
+        ;;
+      -h|--help|help)
+        usage
+        exit 0
+        ;;
+      --)
+        shift
+        while [[ "$#" -gt 0 ]]; do
+          paths+=("$1")
+          shift
+        done
+        ;;
+      -*)
+        usage_error "Unknown option for 'files': $1"
+        ;;
+      *)
+        paths+=("$1")
+        shift
+        ;;
+    esac
+  done
+
+  if [[ "${#paths[@]}" -eq 0 ]]; then
+    usage_error "'files' requires at least one PATH"
   fi
 
-  log_info "Remote dir: ${REMOTE_DIR}"
-  run_ssh "sudo mkdir -p '${REMOTE_DIR}' && sudo chown ${VM_USER}:${VM_USER} '${REMOTE_DIR}' || true"
-
-  local f
-  # shellcheck disable=SC2206
-  local -a paths=(${FILES})
   for f in "${paths[@]}"; do
     if [[ ! -e "${f}" ]]; then
       log_error "Local path not found: ${f}"
+      log_error "Check the path and try again."
       exit 1
     fi
-    log_info "Copying ${f} -> ${VM_USER}@${SSH_HOST}:${REMOTE_DIR}/"
-    run_scp -r "${f}" "${VM_USER}@${SSH_HOST}:${REMOTE_DIR}/"
   done
-  log_success "Files synced"
+
+  setup_ssh_support
+
+  log_info "Target VM : ${VM_USER}@${SSH_HOST}:${SSH_PORT}"
+  log_info "Subcommand: files"
+  log_info "Remote dir: ${remote_dir}"
+
+  if ! run_ssh "sudo mkdir -p '${remote_dir}' && sudo chown ${VM_USER}:${VM_USER} '${remote_dir}' || true"; then
+    log_error "Failed to prepare remote directory: ${remote_dir}"
+    log_error "Check that the VM is reachable and the directory is writable."
+    exit 1
+  fi
+
+  for f in "${paths[@]}"; do
+    log_info "Copying ${f} -> ${VM_USER}@${SSH_HOST}:${remote_dir}/"
+    if ! run_scp -r "${f}" "${VM_USER}@${SSH_HOST}:${remote_dir}/"; then
+      log_error "Failed to upload ${f} to the VM"
+      log_error "Check that the VM is running and SSH settings are correct."
+      exit 1
+    fi
+  done
+
+  log_success "Copied ${#paths[@]} path(s) into ${remote_dir}/ on the VM"
 }
 
-log_info "Target VM : ${VM_USER}@${SSH_HOST}:${SSH_PORT}"
-log_info "Mode      : ${MODE}"
+ACTION="${1:-}"
+if is_help_arg "${ACTION}"; then
+  usage
+  exit 0
+fi
+if [[ -z "${ACTION}" ]]; then
+  usage_error "Missing subcommand. Use 'bin' or 'files'."
+fi
+shift
 
-case "${MODE}" in
-  binaries) mode_binaries ;;
-  release)  mode_release  ;;
-  files)    mode_files    ;;
+case "${ACTION}" in
+  bin)
+    mode_bin "$@"
+    ;;
+  files)
+    mode_files "$@"
+    ;;
   *)
-    log_error "Unknown MODE: ${MODE} (expected binaries|release|files)"
-    exit 1
+    usage_error "Unknown subcommand: ${ACTION}"
     ;;
 esac
-
-log_success "sync_to_vm finished"


### PR DESCRIPTION


- Add`SyncKernelFile` to compare SHA256 and refresh target kernel when it differs from shared kernel
- Simplify`ensureKernelFile`to delegate to`pmem.SyncKernelFile`
- Call`syncLatestKernelForImage`in`CreateSandbox` when creating snapshots to ensure latest kernel is used
- Update tests to verify kernel refresh behavior


Close: https://github.com/TencentCloud/CubeSandbox/issues/33