### PR TITLE
fix(one-click): support non-eth0 NIC and stable CubeProxy CAROOT

### DIFF
--- a/deploy/one-click/install.sh
+++ b/deploy/one-click/install.sh
@@ -224,6 +224,13 @@ require_root
 CUBE_SANDBOX_NODE_IP="$(detect_node_ip)"
 export CUBE_SANDBOX_NODE_IP
 log "using node IP: ${CUBE_SANDBOX_NODE_IP}"
+CUBE_SANDBOX_ETH_NAME="${CUBE_SANDBOX_ETH_NAME:-$(detect_primary_interface || true)}"
+if [[ -n "${CUBE_SANDBOX_ETH_NAME}" ]]; then
+  export CUBE_SANDBOX_ETH_NAME
+  log "using primary network interface: ${CUBE_SANDBOX_ETH_NAME}"
+else
+  log "primary network interface not detected; keeping packaged Cubelet eth_name"
+fi
 
 install_dependencies
 check_hardware_preflight
@@ -320,6 +327,9 @@ upsert_env_kv "${RUNTIME_ENV_FILE}" "ONE_CLICK_DEPLOY_ROLE" "${DEPLOY_ROLE}"
 if [[ -n "${CUBE_SANDBOX_NODE_IP:-}" ]]; then
   upsert_env_kv "${RUNTIME_ENV_FILE}" "CUBE_SANDBOX_NODE_IP" "${CUBE_SANDBOX_NODE_IP}"
 fi
+if [[ -n "${CUBE_SANDBOX_ETH_NAME:-}" ]]; then
+  upsert_env_kv "${RUNTIME_ENV_FILE}" "CUBE_SANDBOX_ETH_NAME" "${CUBE_SANDBOX_ETH_NAME}"
+fi
 if [[ -n "${ONE_CLICK_CONTROL_PLANE_IP:-}" ]]; then
   upsert_env_kv "${RUNTIME_ENV_FILE}" "ONE_CLICK_CONTROL_PLANE_IP" "${ONE_CLICK_CONTROL_PLANE_IP}"
 fi
@@ -331,6 +341,11 @@ chmod +x "${INSTALL_PREFIX}/network-agent/bin/network-agent"
 chmod +x "${INSTALL_PREFIX}/Cubelet/bin/"*
 chmod +x "${INSTALL_PREFIX}/cube-shim/bin/containerd-shim-cube-rs" "${INSTALL_PREFIX}/cube-shim/bin/cube-runtime"
 chmod +x "${INSTALL_PREFIX}/scripts/one-click/"*.sh
+
+if [[ -n "${CUBE_SANDBOX_ETH_NAME:-}" ]]; then
+  sed -i "s/eth_name = \"[^\"]*\"/eth_name = \"${CUBE_SANDBOX_ETH_NAME}\"/" \
+    "${INSTALL_PREFIX}/Cubelet/config/config.toml"
+fi
 
 if [[ "${DEPLOY_ROLE}" != "compute" ]]; then
   chmod +x "${INSTALL_PREFIX}/CubeAPI/bin/cube-api"

--- a/deploy/one-click/install.sh
+++ b/deploy/one-click/install.sh
@@ -343,8 +343,15 @@ chmod +x "${INSTALL_PREFIX}/cube-shim/bin/containerd-shim-cube-rs" "${INSTALL_PR
 chmod +x "${INSTALL_PREFIX}/scripts/one-click/"*.sh
 
 if [[ -n "${CUBE_SANDBOX_ETH_NAME:-}" ]]; then
-  sed -i "s/eth_name = \"[^\"]*\"/eth_name = \"${CUBE_SANDBOX_ETH_NAME}\"/" \
-    "${INSTALL_PREFIX}/Cubelet/config/config.toml"
+  cubelet_config="${INSTALL_PREFIX}/Cubelet/config/config.toml"
+  if rg -q '^[[:space:]]*eth_name = "' "${cubelet_config}"; then
+    sed -i "s/eth_name = \"[^\"]*\"/eth_name = \"${CUBE_SANDBOX_ETH_NAME}\"/" "${cubelet_config}"
+    if ! grep -Fq "eth_name = \"${CUBE_SANDBOX_ETH_NAME}\"" "${cubelet_config}"; then
+      log "WARNING: failed to patch eth_name in Cubelet config (${cubelet_config})"
+    fi
+  else
+    log "WARNING: Cubelet config missing eth_name key; skipped NIC patch (${cubelet_config})"
+  fi
 fi
 
 if [[ "${DEPLOY_ROLE}" != "compute" ]]; then

--- a/deploy/one-click/lib/common.sh
+++ b/deploy/one-click/lib/common.sh
@@ -243,17 +243,51 @@ detect_node_ip() {
 
   local detected_ip=""
   if command -v ip >/dev/null 2>&1; then
-    detected_ip="$(ip -4 addr show dev eth0 2>/dev/null \
+    local detected_iface
+    detected_iface="$(detect_primary_interface || true)"
+    if [[ -n "${detected_iface}" ]]; then
+      detected_ip="$(ip -4 addr show dev "${detected_iface}" 2>/dev/null \
+        | grep -oP 'inet \K[0-9.]+' | head -1 || true)"
+      if [[ -n "${detected_ip}" ]]; then
+        log "auto-detected node IP from ${detected_iface}: ${detected_ip}"
+        printf '%s\n' "${detected_ip}"
+        return 0
+      fi
+    fi
+
+    detected_ip="$(ip -4 addr show scope global 2>/dev/null \
       | grep -oP 'inet \K[0-9.]+' | head -1 || true)"
   fi
 
   if [[ -n "${detected_ip}" ]]; then
-    log "auto-detected node IP from eth0: ${detected_ip}"
+    log "auto-detected node IP from first global IPv4 address: ${detected_ip}"
     printf '%s\n' "${detected_ip}"
     return 0
   fi
 
-  die "cannot auto-detect node IP (eth0 not found or has no IPv4). Please set CUBE_SANDBOX_NODE_IP or pass --node-ip=<ip>"
+  die "cannot auto-detect node IP. Please set CUBE_SANDBOX_NODE_IP or pass --node-ip=<ip>"
+}
+
+detect_primary_interface() {
+  if [[ -n "${CUBE_SANDBOX_ETH_NAME:-}" ]]; then
+    printf '%s\n' "${CUBE_SANDBOX_ETH_NAME}"
+    return 0
+  fi
+
+  command -v ip >/dev/null 2>&1 || return 1
+
+  local iface
+  iface="$(ip -o -4 route show to default 2>/dev/null | awk '{print $5; exit}')"
+  if [[ -n "${iface}" ]]; then
+    printf '%s\n' "${iface}"
+    return 0
+  fi
+
+  iface="$(ip -o link show up 2>/dev/null \
+    | awk -F': ' '$2 != "lo" {print $2; exit}' \
+    | cut -d@ -f1)"
+  [[ -n "${iface}" ]] || return 1
+  printf '%s\n' "${iface}"
 }
 
 ensure_kernel_vmlinux() {

--- a/deploy/one-click/lib/common.sh
+++ b/deploy/one-click/lib/common.sh
@@ -269,20 +269,24 @@ detect_node_ip() {
 }
 
 detect_primary_interface() {
+  # Honor explicit override first.
   if [[ -n "${CUBE_SANDBOX_ETH_NAME:-}" ]]; then
     printf '%s\n' "${CUBE_SANDBOX_ETH_NAME}"
     return 0
   fi
 
+  # `ip` is required for auto-detection.
   command -v ip >/dev/null 2>&1 || return 1
 
   local iface
+  # Preferred path: resolve interface from default IPv4 route.
   iface="$(ip -o -4 route show to default 2>/dev/null | awk '{print $5; exit}')"
   if [[ -n "${iface}" ]]; then
     printf '%s\n' "${iface}"
     return 0
   fi
 
+  # Fallback: first non-loopback interface that is currently up.
   iface="$(ip -o link show up 2>/dev/null \
     | awk -F': ' '$2 != "lo" {print $2; exit}' \
     | cut -d@ -f1)"

--- a/deploy/one-click/scripts/one-click/up-cube-proxy.sh
+++ b/deploy/one-click/scripts/one-click/up-cube-proxy.sh
@@ -33,6 +33,8 @@ CUBE_PROXY_REDIS_IP="${CUBE_PROXY_REDIS_IP:-${CUBE_SANDBOX_NODE_IP}}"
 CUBE_PROXY_REDIS_PORT="${CUBE_PROXY_REDIS_PORT:-${CUBE_SANDBOX_REDIS_PORT:-6379}}"
 CUBE_PROXY_REDIS_PASSWORD="${CUBE_PROXY_REDIS_PASSWORD:-${CUBE_SANDBOX_REDIS_PASSWORD:-ceuhvu123}}"
 MKCERT_BUNDLED_BIN="${TOOLBOX_ROOT}/support/bin/mkcert"
+CAROOT="${CAROOT:-${TOOLBOX_ROOT}/cubeproxy/caroot}"
+export CAROOT
 ALPINE_MIRROR_URL="${ALPINE_MIRROR_URL:-https://mirrors.tuna.tsinghua.edu.cn/alpine}"
 PIP_INDEX_URL="${PIP_INDEX_URL:-https://pypi.tuna.tsinghua.edu.cn/simple}"
 
@@ -65,6 +67,7 @@ escape_sed() {
 
 prepare_proxy_certs() {
   mkdir -p "${CERT_DIR}"
+  mkdir -p "${CAROOT}"
   if [[ -f "${CERT_DIR}/cube.app+3.pem" && -f "${CERT_DIR}/cube.app+3-key.pem" ]]; then
     return 0
   fi


### PR DESCRIPTION
## Summary

This PR improves one-click deployment robustness on cloud hosts where the primary NIC is not `eth0`, and makes CubeProxy certificate generation deterministic across restarts.

## Motivation

In AWS and other environments, the primary interface is often `ens5`/`enp*` instead of `eth0`.
The current one-click flow may assume `eth0`, which can lead to incorrect node networking config.

Also, CubeProxy cert generation relied on implicit mkcert CA location. Setting a stable `CAROOT` makes behavior more predictable in automated deployments.

## Changes

1. Add primary NIC detection in `deploy/one-click/lib/common.sh`
   - New `detect_primary_interface()`:
      - Prefer `CUBE_SANDBOX_ETH_NAME` when explicitly provided
      - Otherwise use default route interface
      - Fallback to first non-loopback up interface
   - Update `detect_node_ip()` to detect IPv4 from the detected primary NIC first, then fallback to first global IPv4.

2. Wire NIC detection into install flow in `deploy/one-click/install.sh`
   - Detect/export `CUBE_SANDBOX_ETH_NAME`
   - Persist it into one-click runtime env file
   - Patch `Cubelet/config/config.toml` (`eth_name = ...`) during install when value is available

3. Stabilize mkcert CA root in `deploy/one-click/scripts/one-click/up-cube-proxy.sh`
   - Set/export `CAROOT` default to `${TOOLBOX_ROOT}/cubeproxy/caroot`
   - Ensure `CAROOT` directory exists before cert generation

## Validation

- `bash -n` passed for all modified scripts
- Function smoke test:
   - `detect_primary_interface` returns host primary NIC
   - `detect_node_ip` returns expected IPv4

## Compatibility

- Backward compatible for environments already using `eth0`
- Users can still override NIC explicitly via `CUBE_SANDBOX_ETH_NAME`
