### PR TITLE
fix(CubeMaster): align hostdir-mount annotation key with CubeAPI

### DIFF
--- a/CubeMaster/pkg/service/sandbox/hostdir_mount.go
+++ b/CubeMaster/pkg/service/sandbox/hostdir_mount.go
@@ -16,7 +16,12 @@ import (
 )
 
 const (
-	AnnotationHostDirMount = "hostdir-mount"
+	// AnnotationHostDirMount must match the annotation key that CubeAPI
+	// writes when it lifts metadata["host-mount"] onto the sandbox
+	// CreateSandboxRequest; see CubeAPI/src/handlers/sandboxes.rs
+	// (const HOSTDIR_MOUNT_KEY). Keep these in lockstep, otherwise
+	// host-mount requests are silently dropped.
+	AnnotationHostDirMount = "host-mount"
 )
 
 type HostDirMountOption struct {


### PR DESCRIPTION
CubeAPI (handlers/sandboxes.rs, const HOSTDIR_MOUNT_KEY) lifts the caller's metadata["host-mount"] onto the CreateSandbox annotation map under the key "host-mount". CubeMaster's injectHostDirMounts was reading "hostdir-mount" instead, so every host-mount request was silently dropped (only logged as "annotation absent or empty, skip").

Switch the constant to "host-mount" to match CubeAPI, and note the cross-component invariant in a comment so future renames keep the two sides in lockstep.