### PR TITLE
fix(Cubelet): propagate host mount events into cubelet's mount namespace

### DIFF
--- a/Cubelet/cmd/cubelet/main.go
+++ b/Cubelet/cmd/cubelet/main.go
@@ -161,9 +161,16 @@ func newCubeMnt() error {
 		cmd.Stdin = os.Stdin
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr
+		// Use Cloneflags only (not Unshareflags) so that Go does not run
+		// its automatic post-unshare mount("none", "/", MS_REC|MS_PRIVATE)
+		// (see runtime.forkAndExecInChild1 in the Go stdlib). CLONE_NEWNS
+		// in Cloneflags still gives us a fresh mount namespace, and the
+		// kernel preserves the shared-propagation peer group relationship
+		// for mounts copied from the parent. That is a prerequisite for
+		// the subsequent `mount --make-rslave /` to slave this ns's root
+		// back to the host's shared group.
 		cmd.SysProcAttr = &syscall.SysProcAttr{
-			Cloneflags:   syscall.CLONE_NEWPID | syscall.CLONE_NEWNS,
-			Unshareflags: syscall.CLONE_NEWNS,
+			Cloneflags: syscall.CLONE_NEWPID | syscall.CLONE_NEWNS,
 		}
 		if err := cmd.Start(); err != nil {
 			newMntErr = fmt.Errorf("start newCubeMnt job error: %v", err)
@@ -189,6 +196,17 @@ func newCubeMnt() error {
 	cmds := [][]string{
 		{"mkdir", "-p", CubeShimTopdir},
 		{"mkdir", "-p", CubeShimSandboxes},
+		// Re-slave the root of cubelet's new mount namespace so that mount
+		// events happening in the host (init) namespace — e.g. operators
+		// mounting a new network storage volume after cubelet has started —
+		// propagate into this ns and become visible to prepareHostDirVolume.
+		// Without this, a freshly-added host mount is invisible here and
+		// any sandbox requesting a hostPath under it fails with ENOENT.
+		// Propagation is one-way (slave): mounts performed inside this ns
+		// (shim bind-mounts etc.) do not flow back to the host ns.
+		// Prerequisite: the host's "/" must be shared (true on systemd-based
+		// distros by default; our compute nodes confirm shared:1).
+		{"nsenter", "-t", fmt.Sprintf("%d", newMntPID), "-m", "mount", "--make-rslave", "/"},
 		{"nsenter", "-t", fmt.Sprintf("%d", newMntPID), "-m", "mount", "--bind", "--make-shared", CubeShimTopdir, CubeShimTopdir},
 		{"mkdir", "-p", CubeMntNsDirPath},
 		{"touch", CubeMntNsFilePath},


### PR DESCRIPTION
Previously, volumes mounted on the host after cubelet had started were invisible inside cubelet's persisted mount namespace. The first sandbox requesting such a path failed with
  prepareHostDirVolume: bind mount /mnt/<vol> -> /data/cubelet/hostdir/…:
  no such file or directory
and the only known recovery was to drain sandboxes, unmount the persisted ns file, and restart cubelet so a fresh ns picked up the host's current mount tree.

Root cause: in newCubeMnt, the sleep placeholder was spawned with both Cloneflags: CLONE_NEWNS and Unshareflags: CLONE_NEWNS. Go's stdlib applies an automatic mount("none", "/", MS_REC|MS_PRIVATE) after the unshare step, which detached the new ns's root from the host's shared peer group. Once private, subsequent `mount --make-rslave /` is a no-op because there is no peer group to slave to.

Fix:
  * Drop Unshareflags, keep only Cloneflags. CLONE_NEWNS via clone() preserves the shared-propagation peer group that the kernel copies from the parent ns, so the new ns's "/" stays in shared:1.
  * Add `mount --make-rslave /` in the new ns (via nsenter) before persisting it. The root becomes a one-way slave of the host's "/" peer group, so subsequent host mounts propagate in, while mounts the shim performs inside this ns do not flow back out.

Verified on 4-node cluster:
  - cubelet ns /proc/self/mountinfo shows `/` with `master:1`
  - `mount -t tmpfs tmpfs /mnt/new` on host becomes instantly visible in cubelet ns with real content
  - sandbox with metadata[host-mount] pointing at a post-start mount succeeds and binds the real overlay, not the empty underlying dir
  - existing JFS mount / sandbox flow regressed clean