### PR TITLE
ci: add build-check workflow for multi-component CI pipeline

### DIFF
--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -1,0 +1,202 @@
+name: Build Check
+
+on:
+  push:
+    paths:
+      - 'CubeMaster/**'
+      - 'Cubelet/**'
+      - 'CubeShim/**'
+      - 'agent/**'
+      - 'network-agent/**'
+      - 'docker/Dockerfile.builder'
+      - '.github/workflows/build-builder-image.yml'
+      - '.github/workflows/build-check.yml'
+      - 'Makefile'
+  pull_request:
+    paths:
+      - 'CubeMaster/**'
+      - 'Cubelet/**'
+      - 'CubeShim/**'
+      - 'agent/**'
+      - 'network-agent/**'
+      - 'docker/Dockerfile.builder'
+      - '.github/workflows/build-builder-image.yml'
+      - '.github/workflows/build-check.yml'
+      - 'Makefile'
+  workflow_dispatch:
+
+concurrency:
+  group: build-check-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  packages: read
+
+env:
+  BUILDER_IMAGE_REMOTE: ghcr.io/tencentcloud/cubesandbox-builder:latest
+  BUILDER_IMAGE_LOCAL: cube-sandbox-builder:ci
+
+jobs:
+  build:
+    name: Build ${{ matrix.component }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - component: CubeMaster
+            build_command: >-
+              mkdir -p /workspace/_output/bin &&
+              cd /workspace/CubeMaster &&
+              go mod download &&
+              make proto &&
+              go build -o /workspace/_output/bin/cubemaster ./cmd/cubemaster &&
+              go build -o /workspace/_output/bin/cubemastercli ./cmd/cubemastercli
+            expected_bins: |
+              _output/bin/cubemaster
+              _output/bin/cubemastercli
+          - component: Cubelet
+            build_command: >-
+              mkdir -p /workspace/_output/bin &&
+              cd /workspace/Cubelet &&
+              go mod download &&
+              make proto &&
+              go build -o /workspace/_output/bin/cubelet ./cmd/cubelet &&
+              go build -o /workspace/_output/bin/cubecli ./cmd/cubecli
+            expected_bins: |
+              _output/bin/cubelet
+              _output/bin/cubecli
+          - component: agent
+            build_command: >-
+              mkdir -p /workspace/_output/bin &&
+              cd /workspace/agent &&
+              make -j1 &&
+              install -m 0755 /workspace/agent/target/x86_64-unknown-linux-musl/release/cube-agent /workspace/_output/bin/cube-agent
+            expected_bins: |
+              _output/bin/cube-agent
+          - component: CubeShim
+            build_command: >-
+              mkdir -p /workspace/_output/bin &&
+              cd /workspace/CubeShim &&
+              cargo build --release --locked &&
+              install -m 0755 /workspace/CubeShim/target/release/containerd-shim-cube-rs /workspace/_output/bin/containerd-shim-cube-rs &&
+              install -m 0755 /workspace/CubeShim/target/release/cube-runtime /workspace/_output/bin/cube-runtime
+            expected_bins: |
+              _output/bin/containerd-shim-cube-rs
+              _output/bin/cube-runtime
+          - component: network-agent
+            build_command: >-
+              mkdir -p /workspace/_output/bin &&
+              cd /workspace/network-agent &&
+              make proto &&
+              go build -o /workspace/_output/bin/network-agent ./cmd/network-agent
+            expected_bins: |
+              _output/bin/network-agent
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Detect builder changes
+        id: builder_changes
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]]; then
+            base_ref="${{ github.event.pull_request.base.sha }}"
+            head_ref="${{ github.event.pull_request.head.sha }}"
+          else
+            base_ref="${{ github.event.before }}"
+            head_ref="${GITHUB_SHA}"
+          fi
+
+          if [[ -z "${base_ref}" || "${base_ref}" == "0000000000000000000000000000000000000000" ]]; then
+            changed_files="$(git diff-tree --no-commit-id --name-only -r "${head_ref}")"
+          else
+            changed_files="$(git diff --name-only "${base_ref}" "${head_ref}")"
+          fi
+
+          printf 'Changed files:\n%s\n' "${changed_files}"
+
+          builder_inputs_changed="false"
+          while IFS= read -r file; do
+            case "${file}" in
+              docker/Dockerfile.builder|.github/workflows/build-builder-image.yml)
+                builder_inputs_changed="true"
+                break
+                ;;
+            esac
+          done <<< "${changed_files}"
+
+          echo "changed=${builder_inputs_changed}" >> "${GITHUB_OUTPUT}"
+
+      - name: Log in to GitHub Container Registry
+        id: ghcr_login
+        if: steps.builder_changes.outputs.changed != 'true'
+        continue-on-error: true
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Warn about GHCR login failure
+        if: steps.ghcr_login.outcome == 'failure'
+        shell: bash
+        run: echo "::warning::GHCR login failed - will attempt pull as anonymous or build locally"
+
+      - name: Resolve builder image
+        id: builder_image
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          build_local_builder_image() {
+            docker build \
+              -t "${BUILDER_IMAGE_LOCAL}" \
+              -f docker/Dockerfile.builder \
+              --build-arg GITHUB_ACTIONS=true \
+              .
+          }
+
+          image="${BUILDER_IMAGE_REMOTE}"
+
+          if [[ "${{ steps.builder_changes.outputs.changed }}" == "true" ]]; then
+            echo "Builder inputs changed, building local builder image..."
+            build_local_builder_image
+            image="${BUILDER_IMAGE_LOCAL}"
+          elif docker pull "${BUILDER_IMAGE_REMOTE}"; then
+            echo "Using published builder image ${BUILDER_IMAGE_REMOTE}"
+          else
+            echo "Failed to pull ${BUILDER_IMAGE_REMOTE}, building local fallback image..."
+            build_local_builder_image
+            image="${BUILDER_IMAGE_LOCAL}"
+          fi
+
+          echo "image=${image}" >> "${GITHUB_OUTPUT}"
+
+      - name: Build ${{ matrix.component }}
+        shell: bash
+        env:
+          BUILD_COMMAND: ${{ matrix.build_command }}
+          EXPECTED_BINS: ${{ matrix.expected_bins }}
+        run: |
+          set -euo pipefail
+
+          echo "Component: ${{ matrix.component }}"
+          echo "Builder image: ${{ steps.builder_image.outputs.image }}"
+          make builder-run \
+            BUILDER_IMAGE="${{ steps.builder_image.outputs.image }}" \
+            BUILDER_CMD="${BUILD_COMMAND}"
+
+          while IFS= read -r binary; do
+            [[ -n "${binary}" ]] || continue
+            if ! test -x "${binary}"; then
+              echo "::error::Expected binary not found or not executable: ${binary}"
+              exit 1
+            fi
+          done <<< "${EXPECTED_BINS}"

--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -3,6 +3,7 @@ name: Build Check
 on:
   push:
     paths:
+      - 'CubeAPI/**'
       - 'CubeMaster/**'
       - 'Cubelet/**'
       - 'CubeShim/**'
@@ -14,6 +15,7 @@ on:
       - 'Makefile'
   pull_request:
     paths:
+      - 'CubeAPI/**'
       - 'CubeMaster/**'
       - 'Cubelet/**'
       - 'CubeShim/**'
@@ -45,6 +47,14 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - component: CubeAPI
+            build_command: >-
+              mkdir -p /workspace/_output/bin &&
+              cd /workspace/CubeAPI &&
+              cargo build --release --locked &&
+              install -m 0755 /workspace/CubeAPI/target/release/cube-api /workspace/_output/bin/cube-api
+            expected_bins: |
+              _output/bin/cube-api
           - component: CubeMaster
             build_command: >-
               mkdir -p /workspace/_output/bin &&


### PR DESCRIPTION
- Add GitHub Actions workflow to build and verify CubeMaster, Cubelet, agent, network-agent and CubeShim components
- Implement builder image caching with automatic rebuild on Dockerfile changes
- Use matrix strategy for parallel component builds with binary verification
- Configure path-based triggers for relevant source directories