### PR TITLE
cubeapi: map missing sandbox template to bad request on create

### DIFF
--- a/CubeAPI/src/handlers/sandboxes.rs
+++ b/CubeAPI/src/handlers/sandboxes.rs
@@ -340,11 +340,21 @@ pub async fn create_sandbox(
 
     let resp = state.cubemaster.create_sandbox(&req).await.map_err(|e| {
         tracing::error!(error = %e, "create_sandbox: cubemaster error");
-        AppError::Internal(anyhow::anyhow!(e.to_string()))
+        if e.is_not_found() {
+            AppError::BadRequest(format!("template {} not found", body.template_id))
+        } else {
+            AppError::Internal(anyhow::anyhow!(e.to_string()))
+        }
     })?;
     resp.ret
         .into_result()
-        .map_err(|e| AppError::Internal(anyhow::anyhow!(e.to_string())))?;
+        .map_err(|e| {
+            if e.is_not_found() {
+                AppError::BadRequest(format!("template {} not found", body.template_id))
+            } else {
+                AppError::Internal(anyhow::anyhow!(e.to_string()))
+            }
+        })?;
 
     let sandbox_id = resp.sandbox_id.clone();
 

--- a/CubeMaster/pkg/service/httpservice/cube/sandbox_create.go
+++ b/CubeMaster/pkg/service/httpservice/cube/sandbox_create.go
@@ -16,7 +16,13 @@ import (
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/service/httpservice/common"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/service/sandbox"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/service/sandbox/types"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/templatecenter"
 	"github.com/tencentcloud/CubeSandbox/cubelog"
+)
+
+var (
+	createSandboxDealCubeboxCreateReqWithTemplateFn = dealCubeboxCreateReqWithTemplate
+	createSandboxRunFn                              = sandbox.CreateSandbox
 )
 
 func createSandbox(w http.ResponseWriter, r *http.Request, rt *CubeLog.RequestTrace) interface{} {
@@ -44,16 +50,20 @@ func createSandbox(w http.ResponseWriter, r *http.Request, rt *CubeLog.RequestTr
 		"InstanceType": req.InstanceType,
 	}))
 
-	if err := dealCubeboxCreateReqWithTemplate(ctx, req); err != nil {
-		rsp.Ret.RetCode = int(errorcode.ErrorCode_MasterParamsError)
+	if err := createSandboxDealCubeboxCreateReqWithTemplateFn(ctx, req); err != nil {
+		retCode := errorcode.ErrorCode_MasterParamsError
+		if errors.Is(err, templatecenter.ErrTemplateNotFound) {
+			retCode = errorcode.ErrorCode_NotFound
+		}
+		rsp.Ret.RetCode = int(retCode)
 		rsp.Ret.RetMsg = err.Error()
-		rt.RetCode = int64(errorcode.ErrorCode_MasterParamsError)
+		rt.RetCode = int64(retCode)
 		log.G(ctx).Error(err)
 		return rsp
 	}
 
 	ctx = runInsReq2Affinity(ctx, req)
-	ret := sandbox.CreateSandbox(ctx, req)
+	ret := createSandboxRunFn(ctx, req)
 	rt.RetCode = int64(ret.Ret.RetCode)
 	return ret
 }

--- a/CubeMaster/pkg/service/httpservice/cube/sandbox_create_test.go
+++ b/CubeMaster/pkg/service/httpservice/cube/sandbox_create_test.go
@@ -1,0 +1,89 @@
+// Copyright (c) 2024 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package cube
+
+import (
+	"context"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/constants"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/errorcode"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/service/sandbox/types"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/templatecenter"
+	CubeLog "github.com/tencentcloud/CubeSandbox/cubelog"
+)
+
+func TestCreateSandboxMapsMissingTemplateToNotFound(t *testing.T) {
+	origDealFn := createSandboxDealCubeboxCreateReqWithTemplateFn
+	origCreateFn := createSandboxRunFn
+	t.Cleanup(func() {
+		createSandboxDealCubeboxCreateReqWithTemplateFn = origDealFn
+		createSandboxRunFn = origCreateFn
+	})
+
+	createSandboxDealCubeboxCreateReqWithTemplateFn = func(ctx context.Context, req *types.CreateCubeSandboxReq) error {
+		return templatecenter.ErrTemplateNotFound
+	}
+	createSandboxRunFn = func(ctx context.Context, req *types.CreateCubeSandboxReq) *types.CreateCubeSandboxRes {
+		t.Fatalf("sandbox.CreateSandbox should not be called when template lookup fails")
+		return nil
+	}
+
+	req := httptest.NewRequest("POST", "/cube/sandbox", strings.NewReader(`{
+		"requestID":"req-1",
+		"annotations":{
+			"` + constants.CubeAnnotationAppSnapshotTemplateID + `":"tpl-missing",
+			"` + constants.CubeAnnotationAppSnapshotTemplateVersion + `":"v2"
+		}
+	}`))
+	rt := &CubeLog.RequestTrace{}
+	resp := createSandbox(httptest.NewRecorder(), req, rt)
+
+	got, ok := resp.(*types.Res)
+	if !ok {
+		t.Fatalf("unexpected response type %T", resp)
+	}
+	assert.Equal(t, int(errorcode.ErrorCode_NotFound), got.Ret.RetCode)
+	assert.Equal(t, templatecenter.ErrTemplateNotFound.Error(), got.Ret.RetMsg)
+	assert.Equal(t, int64(errorcode.ErrorCode_NotFound), rt.RetCode)
+}
+
+func TestCreateSandboxKeepsOtherTemplateErrorsAsParamsError(t *testing.T) {
+	origDealFn := createSandboxDealCubeboxCreateReqWithTemplateFn
+	origCreateFn := createSandboxRunFn
+	t.Cleanup(func() {
+		createSandboxDealCubeboxCreateReqWithTemplateFn = origDealFn
+		createSandboxRunFn = origCreateFn
+	})
+
+	createSandboxDealCubeboxCreateReqWithTemplateFn = func(ctx context.Context, req *types.CreateCubeSandboxReq) error {
+		return assert.AnError
+	}
+	createSandboxRunFn = func(ctx context.Context, req *types.CreateCubeSandboxReq) *types.CreateCubeSandboxRes {
+		t.Fatalf("sandbox.CreateSandbox should not be called when template resolution fails")
+		return nil
+	}
+
+	req := httptest.NewRequest("POST", "/cube/sandbox", strings.NewReader(`{
+		"requestID":"req-2",
+		"annotations":{
+			"` + constants.CubeAnnotationAppSnapshotTemplateID + `":"tpl-other-error",
+			"` + constants.CubeAnnotationAppSnapshotTemplateVersion + `":"v2"
+		}
+	}`))
+	rt := &CubeLog.RequestTrace{}
+	resp := createSandbox(httptest.NewRecorder(), req, rt)
+
+	got, ok := resp.(*types.Res)
+	if !ok {
+		t.Fatalf("unexpected response type %T", resp)
+	}
+	assert.Equal(t, int(errorcode.ErrorCode_MasterParamsError), got.Ret.RetCode)
+	assert.Equal(t, assert.AnError.Error(), got.Ret.RetMsg)
+	assert.Equal(t, int64(errorcode.ErrorCode_MasterParamsError), rt.RetCode)
+}

--- a/CubeMaster/pkg/service/httpservice/cube/sandbox_preview_test.go
+++ b/CubeMaster/pkg/service/httpservice/cube/sandbox_preview_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/constants"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/errorcode"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/service/sandbox/types"
+	CubeLog "github.com/tencentcloud/CubeSandbox/cubelog"
 )
 
 func TestPreviewSandboxReturnsResolvedRequests(t *testing.T) {


### PR DESCRIPTION
## Summary
- return a proper not-found error code from CubeMaster when sandbox creation references a missing template
- remove the previous CubeAPI-side string matching approach
- map the missing-template create-sandbox error according to the E2B API behavior for `POST /sandboxes`
## Problem
When creating a sandbox with a non-existent template, CubeMaster previously returned a params error and CubeAPI ended up returning an incorrect HTTP response.
## Fix
- classify the missing-template case in CubeMaster using the proper error code
- keep other template resolution failures as params errors
- update CubeAPI `create_sandbox` to rely on CubeMaster error codes instead of string matching
- map the `POST /sandboxes` missing-template case according to the E2B spec for this endpoint
Closes #10
## Validation
- `cd CubeAPI && cargo +1.88.0 test`
- `cd CubeAPI && cargo +1.88.0 check`
- `cd CubeMaster && go test ./pkg/templatecenter -run TestGetTemplateRequestAssignsRuntimeRequestID`
## Notes
- This PR intentionally keeps the fix scoped to sandbox creation.
- Existing unrelated test failures in `CubeMaster/pkg/service/httpservice/cube` were not expanded beyond the minimum necessary scope.
