### PR TITLE
fix(ci): push tags during CNB sync

### DIFF
--- a/.github/workflows/sync-to-cnb.yml
+++ b/.github/workflows/sync-to-cnb.yml
@@ -50,6 +50,7 @@ jobs:
             -e PLUGIN_USERNAME="cnb" \
             -e PLUGIN_PASSWORD="${{ secrets.CNB_GIT_PASSWORD }}" \
             -e PLUGIN_FORCE="true" \
+            -e PLUGIN_PUSH_TAGS="true" \
             tencentcom/git-sync
 
   resolve_release_context:


### PR DESCRIPTION
## Summary
- enable `PLUGIN_PUSH_TAGS` in the CNB mirror step so tag pushes are actually mirrored to CNB
- unblock CNB release creation jobs that wait for mirrored tags such as `v0.1.1`
- keep the fix scoped to the existing `sync_repo` path without changing the release/job split

## Test plan
- [x] validate `.github/workflows/sync-to-cnb.yml` with YAML parsing
- [x] run `actionlint` against `.github/workflows/sync-to-cnb.yml`
- [ ] create a new tag and verify it appears in the CNB mirror
- [ ] confirm `Sync to CNB.cool` can pass the `ensure_cnb_release` wait step for a tagged release

Autonomously-by: Cursor:GPT-5.4

Made with [Cursor](https://cursor.com)