### PR TITLE
CubeProxy: switch apk mirror to tencentyun and remove debug packages

### DIFF
--- a/CubeProxy/Dockerfile
+++ b/CubeProxy/Dockerfile
@@ -2,16 +2,10 @@ FROM cube-sandbox-image.tencentcloudcr.com/opensource/openresty:1.21.4.1-6-alpin
 
 LABEL maintainer="staryxchen <staryxchen@tencent.com>"
 
-RUN mkdir -p /data/log/cube-proxy/ \
+RUN sed -i 's/dl-cdn.alpinelinux.org/mirrors.tencentyun.com/g' /etc/apk/repositories \
+    && mkdir -p /data/log/cube-proxy/ \
     && apk update \
-    && apk add tcpdump \
-    && apk add vim \
-    && apk add tzdata \
-    && apk add python3 \
-    && apk add py3-pip \
-    && apk add bpftrace busybox curl ethtool file gawk inetutils-telnet \
-        iperf iperf3 iproute2 netcat-openbsd net-tools sysstat wget \
-    && pip3 install pythonping requests \
+    && apk add --no-cache tzdata curl wget \
     && cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime \
     && echo "Asia/Shanghai" > /etc/timezone
 


### PR DESCRIPTION
## Problem

`apk add` in the Dockerfile uses the default upstream mirror
(dl-cdn.alpinelinux.org), which is unreliable from within the Tencent
Cloud build environment and frequently causes image build failures.

## Changes

- **Switch apk mirror**: replace `dl-cdn.alpinelinux.org` with
  `mirrors.tencentyun.com` (Tencent Cloud internal mirror, same network
  as the image registry)
- **Remove debug-only packages**: `tcpdump`, `vim`, `python3`, `py3-pip`,
  `bpftrace`, `ethtool`, `file`, `gawk`, `inetutils-telnet`, `iperf`,
  `iperf3`, `iproute2`, `netcat-openbsd`, `net-tools`, `sysstat`, and
  pip packages `pythonping` / `requests`
  - Verified: none of these are referenced in `start.sh`, `rotate_nginx_log.sh`,
    any `.lua` file, or `nginx.conf`
- **Keep**: `tzdata` (required for timezone setup), `curl`, `wget`
- **Add `--no-cache`** to avoid stale index artifacts in the image layer

## Impact

- Eliminates the network-related build failure
- Reduces image size significantly (removes Python runtime + ~15 debug tools)
- Reduces attack surface in the production image