### PR TITLE
chore(ci): make Rustup mirror configurable via build args

### DIFF
--- a/.github/workflows/build-builder-image.yml
+++ b/.github/workflows/build-builder-image.yml
@@ -55,5 +55,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             GITHUB_ACTIONS=true
+            RUSTUP_DIST_SERVER=https://static.rust-lang.org
+            RUSTUP_UPDATE_ROOT=https://static.rust-lang.org/rustup
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -170,6 +170,8 @@ jobs:
               -t "${BUILDER_IMAGE_LOCAL}" \
               -f docker/Dockerfile.builder \
               --build-arg GITHUB_ACTIONS=true \
+              --build-arg RUSTUP_DIST_SERVER=https://static.rust-lang.org \
+              --build-arg RUSTUP_UPDATE_ROOT=https://static.rust-lang.org/rustup \
               .
           }
 

--- a/docker/Dockerfile.builder
+++ b/docker/Dockerfile.builder
@@ -13,6 +13,8 @@ ARG RUST_TOOLCHAIN_HYPERVISOR=1.77.2
 ARG RUST_TOOLCHAIN_E2BAPI=1.85
 ARG RUST_TOOLCHAIN_AGENT=1.89
 ARG GITHUB_ACTIONS=false
+ARG RUSTUP_DIST_SERVER=https://rsproxy.cn
+ARG RUSTUP_UPDATE_ROOT=https://rsproxy.cn/rustup
 
 ENV LANG=C.UTF-8 \
     LC_ALL=C.UTF-8 \
@@ -110,8 +112,8 @@ RUN go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.36.11 \
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
     | sh -s -- -y --profile minimal --default-toolchain none
 
-ENV RUSTUP_DIST_SERVER="https://rsproxy.cn"
-ENV RUSTUP_UPDATE_ROOT="https://rsproxy.cn/rustup"
+ENV RUSTUP_DIST_SERVER="${RUSTUP_DIST_SERVER}"
+ENV RUSTUP_UPDATE_ROOT="${RUSTUP_UPDATE_ROOT}"
 
 RUN set -eux; \
     for toolchain in "${RUST_TOOLCHAIN_HYPERVISOR}" "${RUST_TOOLCHAIN_E2BAPI}" "${RUST_TOOLCHAIN_AGENT}"; do \


### PR DESCRIPTION
- Add RUSTUP_DIST_SERVER and RUSTUP_UPDATE_ROOT as ARG in Dockerfile
- Change hardcoded ENV values to reference ARG variables
- Allow CI workflows to override with official Rust servers ( [https://static.rust-lang.org)](https://static.rust-lang.org))