### PR TITLE
shim: bump VsockServerReady wait from 10s to 60s for nested-KVM hosts

### DIFF
--- a/CubeShim/shim/src/sandbox/sb.rs
+++ b/CubeShim/shim/src/sandbox/sb.rs
@@ -777,7 +777,7 @@ impl SandBox {
             let ch = self.ch.as_mut().unwrap().lock().await;
             let start = Instant::now();
             let ev = ch
-                .wait_notify(Duration::from_nanos(1000 * 1000 * 1000 * 10 as u64))
+                .wait_notify(Duration::from_nanos(1000 * 1000 * 1000 * 60 as u64))
                 .await?;
 
             if CH::NotifyEvent::VsockServerReady != ev {


### PR DESCRIPTION
## Summary
- raise the cold-boot `wait_notify` timeout in cube-shim from 10s to 60s
- unblock `tpl create-from-image` on nested-KVM dev hosts where the
  in-guest agent legitimately takes ~18s to signal `VsockServerReady`
- no behavioural change for bare-metal callers (cold boot is well
  under 10s there, so the wait still returns as soon as the agent is
  ready)

## Problem
On nested-KVM hosts (cloud-hypervisor running inside a QEMU dev VM,
e.g. on a GCP n2 with nested virtualization), the cold-boot wait at
`CubeShim/shim/src/sandbox/sb.rs:780` is hardcoded to 10 seconds:

```rust
.wait_notify(Duration::from_nanos(1000 * 1000 * 1000 * 10 as u64))
```

Every page fault inside a nested guest VM-exits twice, so a microVM
boot that takes ~1s on bare metal takes ~18s in this environment.
Measurements from `cube-shim-req.log` on a GCP n2:

```
"vm ready, vsock is listening, cost:18152"
"vm ready, vsock is listening, cost:18690"
```

The result: every `cubemastercli tpl create-from-image` fails with

```
failed to create shim task: Others("Other: Create sandbox failed:
Receive event timeout after 10000ms")
```

even though the microVM kernel and agent are starting fine. This blocks
the entire upstream `dev-env/` quickstart flow on nested-KVM dev hosts.

## Fix
Bump the timeout to 60 seconds. The wait still returns as soon as the
agent is ready, so steady-state latency is unchanged on every host.

A nicer follow-up would be to make this configurable (env var like
`CUBE_SHIM_BOOT_TIMEOUT_SECS`, defaulting to 10) so callers can tune
without recompiling. This PR keeps the scope to the minimum-viable fix
that unblocks the dev-env path; happy to do the env-var version as a
follow-up if maintainers prefer.

## Validation
- `cargo fmt --check` clean for the touched lines (the rustfmt diff
  reported on master at line 313 is unrelated to this change).
- `cargo build --release --bin containerd-shim-cube-rs` succeeds.
- `cubemastercli tpl create-from-image` (with `--probe 49999`) reaches
  `READY` consistently after deploying the patched binary, in repeated
  tests on:
    GCP n2-standard-4, nested virtualization enabled,
    OpenCloudOS 9 dev VM (per `dev-env/run_vm.sh`),
    cube-sandbox-one-click v0.1.1.
- Confirmed in `cube-shim-req.log` that the agent reports ready within
  the new window (cost:18152, 18690 ms in our runs).
- End-to-end `e2b-code-interpreter` Python SDK round-trip works after
  the change (warm `run_code` ~80–200 ms).

## Compatibility
- Bare-metal callers see no functional change. Cold boot completes in
  well under the new 60s window, the `wait_notify` returns as soon as
  the agent is ready, and steady-state behavior is identical.
- A buggy/wedged microVM that previously failed-fast at 10s will now
  fail at 60s. In our experience the 10s ceiling tends to mask real
  boot issues (genuinely-slow but eventually-correct boots) as flaky
  template builds rather than producing faster useful failures, so the
  longer ceiling seems like an improvement on slower hosts.

Closes #94
