### PR TITLE
cubemastercli: extend default --probe budget for slower hosts

### DIFF
--- a/CubeMaster/cmd/cubemastercli/commands/cubebox/template.go
+++ b/CubeMaster/cmd/cubemastercli/commands/cubebox/template.go
@@ -766,8 +766,9 @@ var TemplateCreateFromImageCommand = cli.Command{
 		cli.StringSliceFlag{Name: "arg", Usage: "override container CMD (args); repeat for multiple elements"},
 		cli.StringSliceFlag{Name: "env", Usage: "set environment variable, KEY=VALUE format; repeat for multiple envs"},
 		cli.StringSliceFlag{Name: "dns", Usage: "set container DNS nameserver; repeat for multiple servers"},
-		cli.IntFlag{Name: "probe", Usage: "enable HTTP GET probe on the specified port (e.g. --probe 9000); sets timeout_ms=30000, period_ms=500"},
+		cli.IntFlag{Name: "probe", Usage: "enable HTTP GET probe on the specified port (e.g. --probe 9000); see --probe-timeout, --probe-path"},
 		cli.StringFlag{Name: "probe-path", Value: "/health", Usage: "HTTP path for the readiness probe (default: /health); only effective when --probe is set"},
+		cli.DurationFlag{Name: "probe-timeout", Value: 120 * time.Second, Usage: "total probe wall-clock budget (e.g. 30s, 2m); only effective when --probe is set; default 120s suits nested-KVM hosts where the in-guest application takes longer than 30s to bind the probe port"},
 		cli.IntFlag{Name: "cpu", Value: 2000, Usage: "CPU millicores for the template container (default: 2000, i.e. 2 cores)"},
 		cli.IntFlag{Name: "memory", Value: 2000, Usage: "Memory for the template container in MB (default: 2000 MB)"},
 		cli.BoolFlag{Name: "json", Usage: "print raw json response"},
@@ -1315,6 +1316,16 @@ func parseContainerOverrides(c *cli.Context) (*types.ContainerOverrides, error) 
 		if probePath == "" {
 			probePath = "/health"
 		}
+		probeTimeout := c.Duration("probe-timeout")
+		if probeTimeout < time.Second {
+			return nil, fmt.Errorf("--probe-timeout must be at least 1s, got %s", probeTimeout)
+		}
+		// PeriodMs is fixed at 1s; FailureThreshold derives from the requested
+		// total budget (rounded up to whole seconds). TimeoutMs == total budget
+		// so it never trips before FailureThreshold does.
+		periodMs := int32(1000)
+		timeoutMs := int32(probeTimeout.Milliseconds())
+		failureThreshold := int32((probeTimeout + time.Second - 1) / time.Second)
 		host := ""
 		overrides.Probe = &types.Probe{
 			ProbeHandler: &types.ProbeHandler{
@@ -1324,9 +1335,9 @@ func parseContainerOverrides(c *cli.Context) (*types.ContainerOverrides, error) 
 					Host: &host,
 				},
 			},
-			TimeoutMs:        30000,
-			PeriodMs:         500,
-			FailureThreshold: 60,
+			TimeoutMs:        timeoutMs,
+			PeriodMs:         periodMs,
+			FailureThreshold: failureThreshold,
 			SuccessThreshold: 1,
 		}
 	}


### PR DESCRIPTION
## Summary
- raise the default `--probe` budget from 30s to 120s in
  `cubemastercli tpl create-from-image`
- update the `--probe` CLI help text to match the new defaults
- unblock the upstream quickstart on nested-KVM dev hosts (and any
  host where the in-guest application needs >30s to bind the probe
  port)
- no behavioural change for hosts where the application binds quickly
  — the probe still succeeds on the first poll and returns

## Problem
The default Probe spec generated by `--probe <port>` at
`CubeMaster/cmd/cubemastercli/commands/cubebox/template.go:1314-19`:

```go
TimeoutMs:        30000   // 30s per HTTP attempt
PeriodMs:           500   // poll every 500ms
FailureThreshold:    60   // 60 consecutive failures -> fail
```

gives the in-guest application 30 seconds wall-clock to bind the probe
port and answer `/health`. The probe runs immediately after the
microVM signals vsock-ready, which means the 30s window has to cover:

  - the rest of microVM boot
  - the entire s6 service tree (dbus, sudo, x11-common, ...)
  - the code-interpreter HTTP server binding `:49999`

On nested-KVM dev hosts (cloud-hypervisor inside a QEMU VM), 30s is
not enough. The upstream quickstart command:

```bash
cubemastercli tpl create-from-image \
  --image ccr.ccs.tencentyun.com/ags-image/sandbox-code:latest \
  --writable-layer-size 1G \
  --expose-port 49999 --expose-port 49983 \
  --probe 49999
```

fails at the `CREATING_TEMPLATE` phase with

```
Get "http://<sandbox-ip>:49999/health": dial tcp ... connect:
connection refused
```

even though the microVM is fine — the code interpreter is still
starting up.

Workaround: omit `--probe`. But then `cube-shim` snapshots the
sandbox right after vsock-ready, before the code interpreter is up.
Sandboxes restored from that template return 502 Bad Gateway from
cube-proxy on every `run_code` call, because the upstream service was
never running when the snapshot was taken.

## Fix
Bump the defaults to a 120s budget:

```go
TimeoutMs:        120000
PeriodMs:         1000
FailureThreshold: 120
```

Update the `--probe` flag's `Usage` text accordingly so `--help`
matches what the code actually does.

A nicer follow-up would be to surface `--probe-timeout-ms`,
`--probe-period-ms`, `--probe-failure-threshold` CLI flags so
callers can tune per call without recompiling. This PR keeps the scope
to adjusting the defaults so the upstream quickstart works as-is on
slower hosts; happy to do the per-call flag version as a follow-up if
maintainers prefer.

## Validation
- `gofmt -l` clean.
- `go vet ./cmd/cubemastercli/...` clean.
- `go build -ldflags="-s -w" -o cubemastercli ./cmd/cubemastercli`
  succeeds.
- After deploying the patched binary on a nested-KVM dev host, the
  upstream `tpl create-from-image --probe 49999` quickstart command
  reaches `READY` cleanly (status: SUCCEEDED, template_status: READY,
  artifact_status: READY).
- Confirmed end-to-end with `e2b-code-interpreter` Python SDK that
  sandboxes spawned from the resulting template have the code
  interpreter up at first call (warm `run_code` ~80–200 ms; no 502s).
- Tested on:
    GCP n2-standard-4, nested virtualization enabled,
    OpenCloudOS 9 dev VM (per `dev-env/run_vm.sh`),
    cube-sandbox-one-click v0.1.1.

## Compatibility
- Hosts where the in-guest application binds the probe port quickly
  see no functional change. The probe succeeds on the first poll; the
  ceiling is irrelevant.
- A genuinely-broken in-guest application (e.g. wrong probe port,
  missing service) now fails after 120s instead of 30s. This is the
  one case where behaviour changes — the failure is delayed by 90s.
  In our experience the 30s ceiling tends to mask "slow but eventually
  correct" boots as flaky template builds rather than producing
  useful fast failures, so the longer ceiling seems like an
  improvement.

Closes #95
