### PR TITLE
cubemaster: support dns flag for template image creation

### DIFF
--- a/CubeMaster/cmd/cubemastercli/commands/cubebox/template.go
+++ b/CubeMaster/cmd/cubemastercli/commands/cubebox/template.go
@@ -765,6 +765,7 @@ var TemplateCreateFromImageCommand = cli.Command{
 		cli.StringSliceFlag{Name: "cmd", Usage: "override container ENTRYPOINT (command); repeat for multiple elements, e.g. --cmd /bin/sh --cmd -c"},
 		cli.StringSliceFlag{Name: "arg", Usage: "override container CMD (args); repeat for multiple elements"},
 		cli.StringSliceFlag{Name: "env", Usage: "set environment variable, KEY=VALUE format; repeat for multiple envs"},
+		cli.StringSliceFlag{Name: "dns", Usage: "set container DNS nameserver; repeat for multiple servers"},
 		cli.IntFlag{Name: "probe", Usage: "enable HTTP GET probe on the specified port (e.g. --probe 9000); sets timeout_ms=30000, period_ms=500"},
 		cli.StringFlag{Name: "probe-path", Value: "/health", Usage: "HTTP path for the readiness probe (default: /health); only effective when --probe is set"},
 		cli.IntFlag{Name: "cpu", Value: 2000, Usage: "CPU millicores for the template container (default: 2000, i.e. 2 cores)"},
@@ -1269,11 +1270,12 @@ func parseContainerOverrides(c *cli.Context) (*types.ContainerOverrides, error) 
 	cmds := c.StringSlice("cmd")
 	args := c.StringSlice("arg")
 	rawEnvs := c.StringSlice("env")
+	dnsServers := c.StringSlice("dns")
 	probePort := c.Int("probe")
 	cpuMillicores := c.Int("cpu")
 	memoryMB := c.Int("memory")
 
-	if len(cmds) == 0 && len(args) == 0 && len(rawEnvs) == 0 && probePort == 0 && !c.IsSet("cpu") && !c.IsSet("memory") {
+	if len(cmds) == 0 && len(args) == 0 && len(rawEnvs) == 0 && len(dnsServers) == 0 && probePort == 0 && !c.IsSet("cpu") && !c.IsSet("memory") {
 		return nil, nil
 	}
 
@@ -1293,6 +1295,14 @@ func parseContainerOverrides(c *cli.Context) (*types.ContainerOverrides, error) 
 			Key:   kv[:idx],
 			Value: kv[idx+1:],
 		})
+	}
+	if len(dnsServers) > 0 {
+		for _, dnsServer := range dnsServers {
+			if dnsServer == "" || net.ParseIP(dnsServer) == nil {
+				return nil, fmt.Errorf("invalid dns server %q", dnsServer)
+			}
+		}
+		overrides.DnsConfig = &types.DNSConfig{Servers: dnsServers}
 	}
 	if c.IsSet("cpu") || c.IsSet("memory") {
 		overrides.Resources = &types.Resource{

--- a/CubeMaster/cmd/cubemastercli/commands/cubebox/template_test.go
+++ b/CubeMaster/cmd/cubemastercli/commands/cubebox/template_test.go
@@ -229,3 +229,48 @@ func TestParseContainerOverridesCustomCpuAndMemory(t *testing.T) {
 		t.Fatalf("expected Mem=8192Mi, got %q", overrides.Resources.Mem)
 	}
 }
+
+func TestParseContainerOverridesDNS(t *testing.T) {
+	ctx := newCreateFromImageContext(t, []string{"--dns", "8.8.8.8", "--dns", "1.1.1.1"})
+	overrides, err := parseContainerOverrides(ctx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if overrides == nil || overrides.DnsConfig == nil {
+		t.Fatal("expected DnsConfig to be set")
+	}
+	want := []string{"8.8.8.8", "1.1.1.1"}
+	if len(overrides.DnsConfig.Servers) != len(want) {
+		t.Fatalf("expected %d DNS servers, got %v", len(want), overrides.DnsConfig.Servers)
+	}
+	for i := range want {
+		if overrides.DnsConfig.Servers[i] != want[i] {
+			t.Fatalf("expected DNS server %d to be %q, got %q", i, want[i], overrides.DnsConfig.Servers[i])
+		}
+	}
+}
+
+func TestParseContainerOverridesRejectsInvalidDNS(t *testing.T) {
+	ctx := newCreateFromImageContext(t, []string{"--dns", "not-an-ip"})
+	overrides, err := parseContainerOverrides(ctx)
+	if err == nil {
+		t.Fatal("expected error for invalid DNS server")
+	}
+	if overrides != nil {
+		t.Fatalf("expected overrides to be nil on invalid DNS, got %+v", overrides)
+	}
+}
+
+func TestParseContainerOverridesNoDNS(t *testing.T) {
+	ctx := newCreateFromImageContext(t, []string{"--env", "KEY=VALUE"})
+	overrides, err := parseContainerOverrides(ctx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if overrides == nil {
+		t.Fatal("expected overrides to be non-nil due to --env flag")
+	}
+	if overrides.DnsConfig != nil {
+		t.Fatalf("expected DnsConfig to be nil when --dns is not set, got %+v", overrides.DnsConfig)
+	}
+}

--- a/CubeMaster/pkg/service/sandbox/types/types.go
+++ b/CubeMaster/pkg/service/sandbox/types/types.go
@@ -428,6 +428,7 @@ type ContainerOverrides struct {
 	Args            []string                  `json:"args,omitempty"`
 	WorkingDir      string                    `json:"working_dir,omitempty"`
 	Envs            []*KeyValue               `json:"envs,omitempty"`
+	DnsConfig       *DNSConfig                `json:"dns_config,omitempty"`
 	Resources       *Resource                 `json:"resources,omitempty"`
 	SecurityContext *ContainerSecurityContext `json:"security_context,omitempty"`
 	Probe           *Probe                    `json:"probe,omitempty"`

--- a/CubeMaster/pkg/templatecenter/template_image.go
+++ b/CubeMaster/pkg/templatecenter/template_image.go
@@ -1615,6 +1615,7 @@ func generateTemplateCreateRequest(req *types.CreateTemplateFromImageReq, artifa
 		WorkingDir:      workingDir,
 		Envs:            envs,
 		VolumeMounts:    volumeMounts,
+		DnsConfig:       dnsConfigOrNil(req.ContainerOverrides),
 		RLimit:          defaultRLimit(req.ContainerOverrides),
 		Resources:       resources,
 		SecurityContext: securityContext,
@@ -1797,6 +1798,13 @@ func buildTemplateSpecFingerprint(req *types.CreateTemplateFromImageReq, sourceI
 	})
 	sum := sha256.Sum256(payload)
 	return hex.EncodeToString(sum[:])
+}
+
+func dnsConfigOrNil(overrides *types.ContainerOverrides) *types.DNSConfig {
+	if overrides == nil {
+		return nil
+	}
+	return overrides.DnsConfig
 }
 
 func buildArtifactID(fingerprint string) string {

--- a/CubeMaster/pkg/templatecenter/template_image_test.go
+++ b/CubeMaster/pkg/templatecenter/template_image_test.go
@@ -199,6 +199,46 @@ func TestBuildTemplateSpecFingerprintUsesExposedPorts(t *testing.T) {
 	}
 }
 
+func TestBuildTemplateSpecFingerprintUsesDNSConfig(t *testing.T) {
+	reqA := &types.CreateTemplateFromImageReq{
+		Request:           &types.Request{RequestID: "req-1"},
+		SourceImageRef:    "docker.io/library/nginx:latest",
+		TemplateID:        "template-1",
+		WritableLayerSize: "20Gi",
+		InstanceType:      cubeboxv1.InstanceType_cubebox.String(),
+		NetworkType:       cubeboxv1.NetworkType_tap.String(),
+		ContainerOverrides: &types.ContainerOverrides{
+			DnsConfig: &types.DNSConfig{Servers: []string{"8.8.8.8"}},
+		},
+	}
+	reqB := &types.CreateTemplateFromImageReq{
+		Request:           reqA.Request,
+		SourceImageRef:    reqA.SourceImageRef,
+		TemplateID:        reqA.TemplateID,
+		WritableLayerSize: reqA.WritableLayerSize,
+		InstanceType:      reqA.InstanceType,
+		NetworkType:       reqA.NetworkType,
+		ContainerOverrides: &types.ContainerOverrides{
+			DnsConfig: &types.DNSConfig{Servers: []string{"1.1.1.1"}},
+		},
+	}
+	reqC := &types.CreateTemplateFromImageReq{
+		Request:            reqA.Request,
+		SourceImageRef:     reqA.SourceImageRef,
+		TemplateID:         reqA.TemplateID,
+		WritableLayerSize:  reqA.WritableLayerSize,
+		InstanceType:       reqA.InstanceType,
+		NetworkType:        reqA.NetworkType,
+		ContainerOverrides: &types.ContainerOverrides{},
+	}
+	if gotA, gotB := buildTemplateSpecFingerprint(reqA, "repo@sha256:aaa"), buildTemplateSpecFingerprint(reqB, "repo@sha256:aaa"); gotA == gotB {
+		t.Fatalf("fingerprint should change when DNS config changes")
+	}
+	if gotA, gotC := buildTemplateSpecFingerprint(reqA, "repo@sha256:aaa"), buildTemplateSpecFingerprint(reqC, "repo@sha256:aaa"); gotA == gotC {
+		t.Fatalf("fingerprint should change when DNS config is removed")
+	}
+}
+
 func TestGenerateTemplateCreateRequestInjectsImmutableRootfsMetadata(t *testing.T) {
 	req := &types.CreateTemplateFromImageReq{
 		Request:           &types.Request{RequestID: "req-1"},
@@ -245,6 +285,41 @@ func TestGenerateTemplateCreateRequestInjectsImmutableRootfsMetadata(t *testing.
 	}
 	if got.Annotations[constants.AnnotationsExposedPort] != "80:8080" {
 		t.Fatalf("unexpected exposed ports annotation: %q", got.Annotations[constants.AnnotationsExposedPort])
+	}
+}
+
+func TestGenerateTemplateCreateRequestAppliesDNSConfigOverride(t *testing.T) {
+	req := &types.CreateTemplateFromImageReq{
+		Request:           &types.Request{RequestID: "req-1"},
+		SourceImageRef:    "docker.io/library/nginx:latest",
+		TemplateID:        "template-1",
+		WritableLayerSize: "20Gi",
+		InstanceType:      cubeboxv1.InstanceType_cubebox.String(),
+		NetworkType:       cubeboxv1.NetworkType_tap.String(),
+		ContainerOverrides: &types.ContainerOverrides{
+			DnsConfig: &types.DNSConfig{Servers: []string{"8.8.8.8", "1.1.1.1"}},
+		},
+	}
+	artifact := &models.RootfsArtifact{
+		ArtifactID:              "artifact-1",
+		TemplateSpecFingerprint: "fingerprint-1",
+		Ext4SHA256:              "sha256-1",
+		Ext4SizeBytes:           1024,
+		DownloadToken:           "token-1",
+	}
+	got, err := generateTemplateCreateRequest(req, artifact, dockerImageConfig{}, "http://master.example")
+	if err != nil {
+		t.Fatalf("generateTemplateCreateRequest failed: %v", err)
+	}
+	if len(got.Containers) != 1 {
+		t.Fatalf("unexpected container count: %d", len(got.Containers))
+	}
+	if got.Containers[0].DnsConfig == nil {
+		t.Fatal("expected container DnsConfig to be set")
+	}
+	want := []string{"8.8.8.8", "1.1.1.1"}
+	if !reflect.DeepEqual(got.Containers[0].DnsConfig.Servers, want) {
+		t.Fatalf("DnsConfig.Servers=%v, want %v", got.Containers[0].DnsConfig.Servers, want)
 	}
 }
 


### PR DESCRIPTION
## Summary

* add repeatable `--dns` support to `cubemastercli tpl create-from-image`
* propagate DNS server overrides into generated template container specs
* include DNS configuration in the template spec fingerprint

## Problem

`cubemastercli tpl create-from-image` previously had no way to specify DNS nameservers, even though the underlying container model already supports `DnsConfig`.

This makes it difficult to create templates for environments that require custom DNS resolution, such as private networks or internal service discovery.

## Fix

* add `DnsConfig` to `ContainerOverrides`
* parse repeated `--dns` values in the create-from-image CLI flow
* apply DNS server overrides when generating the template create request
* include DNS config in fingerprint generation so different DNS settings produce different template artifacts

Example:

```bash
cubemastercli tpl create-from-image \
  --image ccr.ccs.tencentyun.com/ags-image/sandbox-code:latest \
  --dns 8.8.8.8 \
  --dns 1.1.1.1
```

Closes #12

## Validation

* `cd CubeMaster && go test ./cmd/cubemastercli/commands/cubebox -run DNS -count=1`
* `cd CubeMaster && go test ./pkg/templatecenter -run DNS -count=1`

## Notes

* This PR only adds nameserver support via `--dns`.
* It intentionally does not add `--dns-search` or `--dns-option` to keep the scope focused.
