### PR TITLE
cubemaster: skip docker pull when source image exists locally

### DIFF
--- a/CubeMaster/pkg/templatecenter/template_image.go
+++ b/CubeMaster/pkg/templatecenter/template_image.go
@@ -1425,28 +1425,35 @@ func buildRootfsArtifact(ctx context.Context, record *models.RootfsArtifact, req
 }
 
 func prepareSourceImage(ctx context.Context, req *types.CreateTemplateFromImageReq, downloadBaseURL string) (*resolvedSourceImage, error) {
-	dockerConfigDir := ""
-	imageExistedLocally := false
-	if _, err := dockerOutput(ctx, "", "image", "inspect", req.SourceImageRef); err == nil {
-		imageExistedLocally = true
+	var (
+		dockerConfigDir    string
+		imageExistsLocally bool
+		inspectOutput      []byte
+		err                error
+	)
+	inspectOutput, err = dockerOutput(ctx, "", "image", "inspect", req.SourceImageRef)
+	if err == nil {
+		imageExistsLocally = true
 	}
-	if req.RegistryUsername != "" || req.RegistryPassword != "" {
-		tmpDir, err := os.MkdirTemp("", "cubemaster-docker-config-*")
+	if !imageExistsLocally {
+		if req.RegistryUsername != "" || req.RegistryPassword != "" {
+			tmpDir, err := os.MkdirTemp("", "cubemaster-docker-config-*")
+			if err != nil {
+				return nil, err
+			}
+			dockerConfigDir = tmpDir
+			defer os.RemoveAll(tmpDir)
+			if err := dockerLogin(ctx, dockerConfigDir, req.SourceImageRef, req.RegistryUsername, req.RegistryPassword); err != nil {
+				return nil, err
+			}
+		}
+		if err := dockerRun(ctx, dockerConfigDir, "pull", req.SourceImageRef); err != nil {
+			return nil, fmt.Errorf("docker pull %s failed: %w", req.SourceImageRef, err)
+		}
+		inspectOutput, err = dockerOutput(ctx, dockerConfigDir, "image", "inspect", req.SourceImageRef)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("docker image inspect %s failed: %w", req.SourceImageRef, err)
 		}
-		dockerConfigDir = tmpDir
-		defer os.RemoveAll(tmpDir)
-		if err := dockerLogin(ctx, dockerConfigDir, req.SourceImageRef, req.RegistryUsername, req.RegistryPassword); err != nil {
-			return nil, err
-		}
-	}
-	if err := dockerRun(ctx, dockerConfigDir, "pull", req.SourceImageRef); err != nil {
-		return nil, fmt.Errorf("docker pull %s failed: %w", req.SourceImageRef, err)
-	}
-	inspectOutput, err := dockerOutput(ctx, dockerConfigDir, "image", "inspect", req.SourceImageRef)
-	if err != nil {
-		return nil, fmt.Errorf("docker image inspect %s failed: %w", req.SourceImageRef, err)
 	}
 	var inspectList []dockerInspectImage
 	if err := json.Unmarshal(inspectOutput, &inspectList); err != nil {
@@ -1467,7 +1474,7 @@ func prepareSourceImage(ctx context.Context, req *types.CreateTemplateFromImageR
 			if dockerConfigDir != "" {
 				_ = os.RemoveAll(dockerConfigDir)
 			}
-			if !imageExistedLocally {
+			if !imageExistsLocally {
 				_ = dockerRun(cleanupCtx, "", "image", "rm", "-f", req.SourceImageRef)
 			}
 		},

--- a/CubeMaster/pkg/templatecenter/template_image_test.go
+++ b/CubeMaster/pkg/templatecenter/template_image_test.go
@@ -323,6 +323,111 @@ func TestGenerateTemplateCreateRequestAppliesDNSConfigOverride(t *testing.T) {
 	}
 }
 
+func TestPrepareSourceImageSkipsPullWhenImageExistsLocally(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	inspectCalls := 0
+	inspectPayload := `[{"RepoDigests":["docker.io/library/nginx@sha256:abcd"],"Config":{"Env":["A=B"],"WorkingDir":"/workspace"}}]`
+
+	patches.ApplyFunc(dockerOutput, func(ctx context.Context, configDir string, args ...string) ([]byte, error) {
+		if len(args) == 3 && args[0] == "image" && args[1] == "inspect" && args[2] == "docker.io/library/nginx:latest" {
+			inspectCalls++
+			return []byte(inspectPayload), nil
+		}
+		if len(args) == 2 && args[0] == "pull" && args[1] == "docker.io/library/nginx:latest" {
+			t.Fatal("expected docker pull to be skipped when image exists locally")
+		}
+		t.Fatalf("unexpected dockerOutput args=%v", args)
+		return nil, nil
+	})
+
+	got, err := prepareSourceImage(context.Background(), &types.CreateTemplateFromImageReq{
+		SourceImageRef: "docker.io/library/nginx:latest",
+	}, "http://master.example")
+	if err != nil {
+		t.Fatalf("prepareSourceImage failed: %v", err)
+	}
+	if inspectCalls != 1 {
+		t.Fatalf("expected 1 inspect call, got %d", inspectCalls)
+	}
+	if got == nil || got.digest != "docker.io/library/nginx@sha256:abcd" {
+		t.Fatalf("unexpected resolved image: %#v", got)
+	}
+}
+
+func TestPrepareSourceImagePullsAfterLocalInspectMiss(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	inspectCalls := 0
+	pullCalled := false
+	inspectPayload := `[{"RepoDigests":["docker.io/library/nginx@sha256:abcd"],"Config":{"Cmd":["nginx"]}}]`
+
+	patches.ApplyFunc(dockerOutput, func(ctx context.Context, configDir string, args ...string) ([]byte, error) {
+		if len(args) == 3 && args[0] == "image" && args[1] == "inspect" && args[2] == "docker.io/library/nginx:latest" {
+			inspectCalls++
+			if inspectCalls == 1 {
+				return nil, errors.New("No such image")
+			}
+			return []byte(inspectPayload), nil
+		}
+		if len(args) == 2 && args[0] == "pull" && args[1] == "docker.io/library/nginx:latest" {
+			pullCalled = true
+			return nil, nil
+		}
+		t.Fatalf("unexpected dockerOutput args=%v", args)
+		return nil, nil
+	})
+
+	got, err := prepareSourceImage(context.Background(), &types.CreateTemplateFromImageReq{
+		SourceImageRef: "docker.io/library/nginx:latest",
+	}, "http://master.example")
+	if err != nil {
+		t.Fatalf("prepareSourceImage failed: %v", err)
+	}
+	if !pullCalled {
+		t.Fatal("expected docker pull to run after local inspect miss")
+	}
+	if inspectCalls != 2 {
+		t.Fatalf("expected 2 inspect calls, got %d", inspectCalls)
+	}
+	if got == nil || got.digest != "docker.io/library/nginx@sha256:abcd" {
+		t.Fatalf("unexpected resolved image: %#v", got)
+	}
+}
+
+func TestPrepareSourceImageReturnsPullErrorAfterInspectMiss(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	inspectCalls := 0
+	patches.ApplyFunc(dockerOutput, func(ctx context.Context, configDir string, args ...string) ([]byte, error) {
+		if len(args) == 3 && args[0] == "image" && args[1] == "inspect" && args[2] == "docker.io/library/nginx:latest" {
+			inspectCalls++
+			return nil, errors.New("No such image")
+		}
+		if len(args) == 2 && args[0] == "pull" && args[1] == "docker.io/library/nginx:latest" {
+			return nil, errors.New("pull denied")
+		}
+		t.Fatalf("unexpected dockerOutput args=%v", args)
+		return nil, nil
+	})
+
+	got, err := prepareSourceImage(context.Background(), &types.CreateTemplateFromImageReq{
+		SourceImageRef: "docker.io/library/nginx:latest",
+	}, "http://master.example")
+	if err == nil || !strings.Contains(err.Error(), "docker pull docker.io/library/nginx:latest failed") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != nil {
+		t.Fatalf("expected nil resolved image on error, got %#v", got)
+	}
+	if inspectCalls != 1 {
+		t.Fatalf("expected 1 inspect call before pull failure, got %d", inspectCalls)
+	}
+}
+
 func TestMarshalTemplateImageJobRequestIgnoresRequestIDAndPassword(t *testing.T) {
 	reqA := &types.CreateTemplateFromImageReq{
 		Request:            &types.Request{RequestID: "req-a"},


### PR DESCRIPTION
## Summary
- skip `docker pull` when the source image already exists locally
- fall back to pulling the image only when local inspect misses
- add focused tests for local-image reuse, pull fallback, and pull failure behavior

## Problem
Template creation currently pulls the source image even when the image is already available locally. This adds unnecessary network dependency and slows down repeated template builds.

## Fix
- try `docker image inspect` before pulling
- reuse the local image when inspect succeeds
- preserve the existing pull path when the image is missing locally
- keep the behavior scoped to template image preparation

Closes #99

## Validation
- `cd CubeMaster && go test ./pkg/templatecenter -run 'PrepareSourceImage|Image|Pull|Inspect|Source' -count=1`
