### PR TITLE
cubelet: skip paused/pausing sandboxes in DeadGC scanDeadContainer

### DIFF
--- a/Cubelet/services/cubebox/service.go
+++ b/Cubelet/services/cubebox/service.go
@@ -863,6 +863,16 @@ func scanDeadContainer(ctx context.Context, dc []*cubeboxstore.CubeBox, client *
 		if cb.FirstContainer() == nil {
 			continue
 		}
+		// Cubelet itself initiated the pause and already tracks the in-progress
+		// state via PausingAt (CONTAINER_PAUSING) or PausedAt (CONTAINER_PAUSED).
+		// Calling RecoverContainer -> shim state() while pause_vm() holds the
+		// sandbox mutex causes a ttrpc timeout; RecoverContainer then sets
+		// Unknown=true, making the sandbox appear Terminated and triggering a
+		// spurious Destroy cascade.  Skip paused/pausing sandboxes: DeadGC has
+		// nothing useful to do for them.
+		if cb.GetStatus() != nil && cb.GetStatus().IsPaused() {
+			continue
+		}
 		ctx = namespaces.WithNamespace(ctx, cb.Namespace)
 		ctr, err := cubes.RecoverContainer(ctx, client, cb, cb.FirstContainer())
 		if err != nil {


### PR DESCRIPTION
When UpdateWithPause calls task.Pause() via ttrpc, the CubeShim holds the sandbox mutex for the entire duration of pause_vm() (writing the VMM memory snapshot).

During this window, DeadGC's scanDeadContainer fires every 10s and calls RecoverContainer on every sandbox.  RecoverContainer calls loadStatus -> containerd task.Status() -> ttrpc state() on the same shim.  The state() handler contends for the same sandbox mutex, hits a context deadline (5s timeout), and loadStatus sets Unknown=true on the container status.  Because Status.State() checks Unknown first, the sandbox appears as CONTAINER_UNKNOWN to CubeMaster/CubeAPI, which then skips the resume call in connect_sandbox and leaves the sandbox frozen.

Fix: skip sandboxes where GetStatus().IsPaused() is true in scanDeadContainer.  Cubelet already tracks the in-progress state via PausingAt (CONTAINER_PAUSING) or PausedAt (CONTAINER_PAUSED) — it initiated the pause itself and owns the lifecycle.  Querying the shim state() during this window serves no purpose and causes the spurious Unknown classification.

Closes #13