### PR TITLE
hypervisor: Disable TSO/UFO/CSUM offloads on virtio-net TAPs

### DIFF
--- a/hypervisor/virtio-devices/src/net.rs
+++ b/hypervisor/virtio-devices/src/net.rs
@@ -456,20 +456,8 @@ impl Net {
                 state.queue_size,
             )
         } else {
-            let mut avail_features = 1 << VIRTIO_NET_F_CSUM
-                | 1 << VIRTIO_NET_F_CTRL_GUEST_OFFLOADS
-                | 1 << VIRTIO_NET_F_GUEST_CSUM
-                | 1 << VIRTIO_NET_F_GUEST_ECN
-                | 1 << VIRTIO_NET_F_GUEST_TSO4
-                | 1 << VIRTIO_NET_F_GUEST_TSO6
-                | 1 << VIRTIO_NET_F_GUEST_UFO
-                | 1 << VIRTIO_NET_F_HOST_ECN
-                | 1 << VIRTIO_NET_F_HOST_TSO4
-                | 1 << VIRTIO_NET_F_HOST_TSO6
-                | 1 << VIRTIO_NET_F_HOST_UFO
-                | 1 << VIRTIO_NET_F_MTU
-                | 1 << VIRTIO_RING_F_EVENT_IDX
-                | 1 << VIRTIO_F_VERSION_1;
+            let mut avail_features =
+                1 << VIRTIO_NET_F_MTU | 1 << VIRTIO_RING_F_EVENT_IDX | 1 << VIRTIO_F_VERSION_1;
 
             if iommu {
                 avail_features |= 1u64 << VIRTIO_F_IOMMU_PLATFORM;


### PR DESCRIPTION
Stop advertising VIRTIO_NET_F_{CSUM,GUEST_CSUM,*_TSO4,*_TSO6,*_UFO, *_ECN,CTRL_GUEST_OFFLOADS} so the guest computes full checksums and segments its own packets. This avoids CHECKSUM_PARTIAL packets reaching host NIC (which may disable tx-checksumming).

See internal commit 9e0a1d495b734cb1e883c3b9876a9aac22f91e6e and #103 for more context.

Closes #103.