### PR TITLE
Remove unused disable_tso/disable_ufo/disable_check_sum options

### DIFF
--- a/CubeShim/shim/src/sandbox/net.rs
+++ b/CubeShim/shim/src/sandbox/net.rs
@@ -124,9 +124,6 @@ pub struct Interface {
     #[serde(default)]
     pub ips: Vec<MVMIp>,
     pub qos: Option<NetQos>,
-    pub disable_tso: bool,
-    pub disable_ufo: bool,
-    pub disable_check_sum: bool,
 }
 
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]

--- a/Cubelet/config/config.toml
+++ b/Cubelet/config/config.toml
@@ -66,9 +66,6 @@ dynamic_config_path = "/usr/local/services/cubetoolbox/Cubelet/dynamicconf/conf.
     mvm_gw_mac_addr = "20:90:6f:cf:cf:cf"
     mvm_gw_dest_ip = "169.254.68.5"
     mvm_mtu = 1300
-    disable_tso = true
-    disable_ufo = true
-    disable_check_sum = true
     default_exposed_ports = [8080, 32000]
     # metric
     check_interval_in_sec = "5s"

--- a/Cubelet/network/plugin_tap.go
+++ b/Cubelet/network/plugin_tap.go
@@ -33,7 +33,7 @@ import (
 	networkstore "github.com/tencentcloud/CubeSandbox/Cubelet/pkg/store/network"
 	"github.com/tencentcloud/CubeSandbox/Cubelet/pkg/utils"
 	"github.com/tencentcloud/CubeSandbox/Cubelet/plugins/workflow"
-	"github.com/tencentcloud/CubeSandbox/cubelog"
+	CubeLog "github.com/tencentcloud/CubeSandbox/cubelog"
 	"github.com/vishvananda/netlink"
 	"golang.org/x/sys/unix"
 	"google.golang.org/grpc/codes"
@@ -269,9 +269,6 @@ type Config struct {
 	MvmGwMacAddr        string   `toml:"mvm_gw_mac_addr"`
 	MvmMask             int      `toml:"mvm_mask"`
 	MvmMtu              int      `toml:"mvm_mtu"`
-	DisableTso          bool     `toml:"disable_tso"`
-	DisableUfo          bool     `toml:"disable_ufo"`
-	DisableCheckSum     bool     `toml:"disable_check_sum"`
 	DefaultExposedPorts []uint16 `toml:"default_exposed_ports"`
 
 	CheckIntervalTime      tomlext.Duration `toml:"check_interval_in_sec"`
@@ -678,69 +675,6 @@ func appendUniqueString(base []string, extra []string) []string {
 	return out
 }
 
-func (l *local) generateShimNetReq(req *NetRequest, tap *Tap) (*ShimNetReq, error) {
-	shimReq := &ShimNetReq{
-		Interfaces: []*Interface{
-			{
-				Name:      tap.Name,
-				IPAddr:    tap.IP,
-				GuestName: eth0,
-				Mac:       l.Config.MVMMacAddr,
-
-				IP: l.Config.MVMInnerIP,
-
-				Family: 0,
-
-				Mask: l.Config.MvmMask,
-				IPs: []MVMIp{
-					{
-						IP:     l.Config.MVMInnerIP,
-						Mask:   l.Config.MvmMask,
-						Family: 0,
-					},
-				},
-				Mtu:             l.Config.MvmMtu,
-				DisableCheckSum: l.Config.DisableCheckSum,
-				DisableTso:      l.Config.DisableTso,
-				DisableUfo:      l.Config.DisableUfo,
-			},
-		},
-		Routes: []Route{
-			{
-				Family:  0,
-				Gateway: l.Config.MvmGwDestIP,
-				Source:  l.Config.MVMInnerIP,
-				Device:  eth0,
-				Scope:   0,
-			},
-		},
-		ARPs: []ARP{
-			{
-				DestIP: l.Config.MvmGwDestIP,
-				Device: eth0,
-				LlAddr: l.Config.MvmGwMacAddr,
-				State:  0,
-				Flags:  0,
-			},
-		},
-		PortMappings: tap.GetPortMappings(),
-	}
-	if req.Qos != nil {
-		bandwidthQos := req.Qos.BandWidth
-		opsQos := req.Qos.OPS
-		shimReq.Interfaces[0].Qos = &QosConfig{
-			BwSize:          bandwidthQos.Size,
-			BwOneTimeBurst:  bandwidthQos.OneTimeBurst,
-			BwRefillTime:    bandwidthQos.RefillTime,
-			OpsSize:         opsQos.Size,
-			OpsOneTimeBurst: opsQos.OneTimeBurst,
-			OpsRefillTime:   opsQos.RefillTime,
-		}
-	}
-
-	return shimReq, nil
-}
-
 func (l *local) Destroy(ctx context.Context, opts *workflow.DestroyContext) error {
 	if opts == nil {
 		return ret.Err(errorcode.ErrorCode_InvalidParamFormat, "workflow.DestroyContext nil")
@@ -905,18 +839,15 @@ func (l *local) buildShimNetReqFromEnsureResponse(resp *networkagentclient.Ensur
 	shimReq := &ShimNetReq{
 		Interfaces: []*Interface{
 			{
-				Name:            intf.Name,
-				IPAddr:          sandboxIP,
-				GuestName:       eth0,
-				Mac:             intf.MAC,
-				Mtu:             int(intf.MTU),
-				IP:              legacyIP,
-				Family:          0,
-				Mask:            legacyMask,
-				IPs:             mvmIPs,
-				DisableCheckSum: l.Config.DisableCheckSum,
-				DisableTso:      l.Config.DisableTso,
-				DisableUfo:      l.Config.DisableUfo,
+				Name:      intf.Name,
+				IPAddr:    sandboxIP,
+				GuestName: eth0,
+				Mac:       intf.MAC,
+				Mtu:       int(intf.MTU),
+				IP:        legacyIP,
+				Family:    0,
+				Mask:      legacyMask,
+				IPs:       mvmIPs,
 			},
 		},
 	}

--- a/Cubelet/network/proto/network.go
+++ b/Cubelet/network/proto/network.go
@@ -38,9 +38,6 @@ type Interface struct {
 
 	Mask            int        `json:"mask"`
 	IPs             []MVMIp    `json:"ips"`
-	DisableTso      bool       `json:"disable_tso"`
-	DisableUfo      bool       `json:"disable_ufo"`
-	DisableCheckSum bool       `json:"disable_check_sum"`
 	Qos             *QosConfig `json:"qos"`
 }
 

--- a/network-agent/cmd/network-agent/main.go
+++ b/network-agent/cmd/network-agent/main.go
@@ -212,7 +212,7 @@ func validateService(svc service.Service) error {
 
 func summarizeConfig(cfg service.Config) string {
 	return fmt.Sprintf(
-		"eth_name=%q object_dir=%q cidr=%q mvm_inner_ip=%q mvm_mac_addr=%q mvm_gw_dest_ip=%q mvm_gw_mac_addr=%q mvm_mask=%d mvm_mtu=%d tap_init_num=%d default_exposed_ports=%v state_dir=%q tap_fd_socket_path=%q host_proxy_bind_ip=%q disable_tso=%t disable_ufo=%t disable_check_sum=%t connect_timeout=%s",
+		"eth_name=%q object_dir=%q cidr=%q mvm_inner_ip=%q mvm_mac_addr=%q mvm_gw_dest_ip=%q mvm_gw_mac_addr=%q mvm_mask=%d mvm_mtu=%d tap_init_num=%d default_exposed_ports=%v state_dir=%q tap_fd_socket_path=%q host_proxy_bind_ip=%q connect_timeout=%s",
 		cfg.EthName,
 		cfg.ObjectDir,
 		cfg.CIDR,
@@ -227,9 +227,6 @@ func summarizeConfig(cfg service.Config) string {
 		cfg.StateDir,
 		cfg.TapFDSocketPath,
 		cfg.HostProxyBindIP,
-		cfg.DisableTso,
-		cfg.DisableUfo,
-		cfg.DisableCheckSum,
 		cfg.ConnectTimeout,
 	)
 }

--- a/network-agent/internal/service/config.go
+++ b/network-agent/internal/service/config.go
@@ -33,9 +33,6 @@ type Config struct {
 	StateDir            string
 	TapFDSocketPath     string
 	HostProxyBindIP     string
-	DisableTso          bool
-	DisableUfo          bool
-	DisableCheckSum     bool
 	ConnectTimeout      time.Duration
 }
 
@@ -55,9 +52,6 @@ func DefaultConfig() Config {
 		StateDir:            defaultStateDir,
 		TapFDSocketPath:     "/tmp/cube/network-agent-tap.sock",
 		HostProxyBindIP:     "127.0.0.1",
-		DisableTso:          true,
-		DisableUfo:          true,
-		DisableCheckSum:     true,
 		ConnectTimeout:      5 * time.Second,
 	}
 }
@@ -77,9 +71,6 @@ type cubeletNetworkConfig struct {
 	MvmGwMacAddr        string   `toml:"mvm_gw_mac_addr"`
 	MvmMask             int      `toml:"mvm_mask"`
 	MvmMtu              int      `toml:"mvm_mtu"`
-	DisableTso          bool     `toml:"disable_tso"`
-	DisableUfo          bool     `toml:"disable_ufo"`
-	DisableCheckSum     bool     `toml:"disable_check_sum"`
 	DefaultExposedPorts []uint16 `toml:"default_exposed_ports"`
 }
 
@@ -135,9 +126,6 @@ func LoadConfigFromCubeletTOML(base Config, path string) (Config, error) {
 	if networkCfg.TapInitNum != 0 {
 		base.TapInitNum = networkCfg.TapInitNum
 	}
-	base.DisableTso = networkCfg.DisableTso
-	base.DisableUfo = networkCfg.DisableUfo
-	base.DisableCheckSum = networkCfg.DisableCheckSum
 	if len(networkCfg.DefaultExposedPorts) > 0 {
 		base.DefaultExposedPorts = append([]uint16(nil), networkCfg.DefaultExposedPorts...)
 	}

--- a/network-agent/internal/service/config_test.go
+++ b/network-agent/internal/service/config_test.go
@@ -28,9 +28,6 @@ func TestLoadConfigFromCubeletTOML(t *testing.T) {
     mvm_gw_mac_addr = "02:aa:bb:cc:dd:ee"
     mvm_mask = 29
     mvm_mtu = 1450
-    disable_tso = false
-    disable_ufo = false
-    disable_check_sum = false
     default_exposed_ports = [81, 8081]
 `
 	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
@@ -71,15 +68,6 @@ func TestLoadConfigFromCubeletTOML(t *testing.T) {
 	}
 	if cfg.MvmMtu != 1450 {
 		t.Fatalf("MvmMtu=%d", cfg.MvmMtu)
-	}
-	if cfg.DisableTso {
-		t.Fatalf("DisableTso=%v, want false", cfg.DisableTso)
-	}
-	if cfg.DisableUfo {
-		t.Fatalf("DisableUfo=%v, want false", cfg.DisableUfo)
-	}
-	if cfg.DisableCheckSum {
-		t.Fatalf("DisableCheckSum=%v, want false", cfg.DisableCheckSum)
 	}
 	if len(cfg.DefaultExposedPorts) != 2 || cfg.DefaultExposedPorts[0] != 81 || cfg.DefaultExposedPorts[1] != 8081 {
 		t.Fatalf("DefaultExposedPorts=%v", cfg.DefaultExposedPorts)


### PR DESCRIPTION
Remove unused disable_tso/disable_ufo/disable_check_sum options from Cubelet/CubeShim/network-agent.
This is a cleanup, no functional change intended.