### PR TITLE
ci: free disk space before release bundle build

### DIFF
--- a/.github/workflows/release-one-click.yml
+++ b/.github/workflows/release-one-click.yml
@@ -32,6 +32,17 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Free disk space
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: false
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          docker-images: true
+          swap-storage: true
+
       - name: Compute PVM vmlinux cache metadata
         id: pvm_vmlinux_metadata
         run: |
@@ -98,6 +109,17 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
+      - name: Free disk space
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: false
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          docker-images: false
+          swap-storage: true
 
       - name: Compute vmlinux cache metadata
         id: vmlinux_metadata

--- a/.github/workflows/release-pvm-host-kernel.yml
+++ b/.github/workflows/release-pvm-host-kernel.yml
@@ -31,6 +31,17 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Free disk space
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: false
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          docker-images: false
+          swap-storage: true
+
       - name: Build DEB package
         if: matrix.build_mode == 'native'
         run: |


### PR DESCRIPTION
Add jlumbroso/free-disk-space step in the release job to reclaim ~20 GB consumed by pre-installed Android SDK, .NET, Haskell and large apt packages that are not needed for the build.  Docker images are kept because the builder image is pulled in a later step.

This fixes the out-of-disk failures seen when building the one-click release bundle on ubuntu-latest (~14 GB usable by default).