### PR TITLE
fix(Cubelet): honor annotation key in GetQosFromReq

### DIFF
--- a/Cubelet/plugins/workflow/engine.go
+++ b/Cubelet/plugins/workflow/engine.go
@@ -190,7 +190,7 @@ func (b *CreateContext) GetRegion() string {
 }
 
 func (b *CreateContext) GetQos(key string) (*disk.RateLimiter, error) {
-	return GetQosFromReq(b.ReqInfo)
+	return GetQosFromReq(b.ReqInfo, key)
 }
 
 type metricInfo struct {

--- a/Cubelet/plugins/workflow/request_param.go
+++ b/Cubelet/plugins/workflow/request_param.go
@@ -8,13 +8,11 @@ import (
 	"fmt"
 
 	"github.com/tencentcloud/CubeSandbox/Cubelet/api/services/cubebox/v1"
-	"github.com/tencentcloud/CubeSandbox/Cubelet/pkg/constants"
 	"github.com/tencentcloud/CubeSandbox/Cubelet/pkg/container/disk"
 	"github.com/tencentcloud/CubeSandbox/Cubelet/pkg/utils"
 )
 
-func GetQosFromReq(req *cubebox.RunCubeSandboxRequest) (*disk.RateLimiter, error) {
-	key := constants.MasterAnnotationsFSQos
+func GetQosFromReq(req *cubebox.RunCubeSandboxRequest, key string) (*disk.RateLimiter, error) {
 	if req == nil {
 		return nil, fmt.Errorf("reqinfo is nil")
 	}

--- a/Cubelet/services/cubebox/cube_container_create.go
+++ b/Cubelet/services/cubebox/cube_container_create.go
@@ -609,7 +609,7 @@ func WithCubeFsAnnotation(ctx context.Context,
 	if err != nil {
 		return nil, ret.Errorf(errorcode.ErrorCode_InvalidParamFormat, "generate virtiofs config failed: %v", err)
 	}
-	limit, err := workflow.GetQosFromReq(realReq)
+	limit, err := workflow.GetQosFromReq(realReq, constants.MasterAnnotationsFSQos)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
GetQosFromReq hard-coded its lookup key to MasterAnnotationsFSQos and ignored the caller's intent. The CreateContext.GetQos(key) wrapper accepted a key parameter but then discarded it on the way into GetQosFromReq, so the only annotation ever read was cube.master.fs.qos.

This silently broke disk-side rate limiting:

  WithCubeFsAnnotation  -> reads fs.qos   (correct: drives virtiofs)
  GenStorageMediumAnnotation -> opts.GetQos(MasterAnnotationsBlkQos)
                             -> GetQosFromReq ignored the key,
                                still read fs.qos

Because CubeMaster defaults cube.master.fs.qos to the empty object "{}", the RateLimiter attached to every virtio-blk device deserialized to {Bandwidth: nil, Ops: nil} regardless of what extra_conf.blk_qos was set to. cloud-hypervisor reported rate_limiter_config = {bandwidth:null, ops:null} on disk-0, and the bucket was never populated.

Fix: make GetQosFromReq take the key as an argument, forward it from CreateContext.GetQos, and explicitly pass MasterAnnotationsFSQos at the one remaining virtiofs-specific call site in
WithCubeFsAnnotation. After the fix cube.master.blk.qos drives the disk rate limiter and cube.master.fs.qos drives the virtiofs one, each with its intended semantics.

Verified end-to-end on an allinone deployment by setting

  extra_conf:
    blk_qos: '{"ops":{"size":1000,"refill_time":1000},
               "bandwidth":{"size":5242880,"refill_time":1000}}'

Before fix: vm.info disk-0.rate_limiter_config = {bandwidth:null, ops:null}; in-guest dd bs=4k oflag=direct ran at ~170 MB/s / 40k IOPS.

After fix:  disk-0.rate_limiter_config carries the configured buckets; in-guest dd bs=4k oflag=direct settles at ~1000 IOPS (IOPS-bound) and bs=1M oflag=direct settles at ~5.5 MB/s (bandwidth-bound), matching the two caps independently.