### PR TITLE
ci: fix pvm host/guest release workflows

### DIFF
--- a/.github/workflows/build-pvm-guest-vmlinux.yml
+++ b/.github/workflows/build-pvm-guest-vmlinux.yml
@@ -27,6 +27,17 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Free disk space
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: false
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          docker-images: true
+          swap-storage: true
+
       - name: Compute PVM vmlinux cache metadata
         id: pvm_vmlinux_metadata
         run: |

--- a/.github/workflows/release-pvm-host-kernel.yml
+++ b/.github/workflows/release-pvm-host-kernel.yml
@@ -78,8 +78,11 @@ jobs:
 
   publish:
     name: Upload PVM host packages to GitHub Release
+    if: startsWith(github.ref, 'refs/tags/')
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     steps:
       - name: Download package artifacts


### PR DESCRIPTION
release-pvm-host-kernel.yml:
- Add 'if: startsWith(github.ref, refs/tags/)' guard to publish job so it only runs on tag pushes, not workflow_dispatch or branch pushes
- Add 'permissions: contents: write' at job level for explicitness

build-pvm-guest-vmlinux.yml:
- Add free-disk-space step before the build to avoid out-of-disk failures when compiling the PVM guest vmlinux (mirrors one-click)