### PR TITLE
ci: add checkout step to publish jobs in pvm release workflows

### DIFF
--- a/.github/workflows/build-pvm-guest-vmlinux.yml
+++ b/.github/workflows/build-pvm-guest-vmlinux.yml
@@ -104,6 +104,9 @@ jobs:
       contents: write
 
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
       - name: Download PVM vmlinux artifact
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/release-pvm-host-kernel.yml
+++ b/.github/workflows/release-pvm-host-kernel.yml
@@ -85,6 +85,9 @@ jobs:
       contents: write
 
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
       - name: Download package artifacts
         uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
gh CLI requires a git repo context to resolve GITHUB_REPOSITORY and run 'gh release view/create/upload'. Both publish jobs were missing actions/checkout, causing:
  fatal: not a git repository (or any of the parent directories): .git