### PR TITLE
bugfix(‎CubeMaster): optimize bufferqueue to fix high idle CPU usage and reduce GC pressure

### DIFF
--- a/CubeMaster/pkg/base/bufferqueue/bufferqueue.go
+++ b/CubeMaster/pkg/base/bufferqueue/bufferqueue.go
@@ -9,7 +9,6 @@ import (
 	"container/heap"
 	"context"
 	"errors"
-	"math/rand"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -27,7 +26,7 @@ type WorkHandler interface {
 type BufferQueue interface {
 	PushItem(i *Item)
 
-	Push(any interface{})
+	Push(value interface{})
 
 	Pop() interface{}
 
@@ -42,7 +41,14 @@ type BufferQueue interface {
 
 type Options struct {
 	Limit int64
+
+	// testHook is invoked at the end of each consumer loop iteration that
+	// dispatched work. Tests in this package set it to observe loop progress;
+	// production callers leave it nil.
+	testHook func()
 }
+
+var errQueueLimitExceeded = errors.New("buffer queue limit exceeded")
 
 func New(opt *Options) BufferQueue {
 	if opt == nil {
@@ -53,9 +59,12 @@ func New(opt *Options) BufferQueue {
 		opt.Limit = 10
 	}
 	sh := &bufferQueue{
-		queue:   &TimeSortedQueue{},
-		limiter: semaphore.NewWeighted(opt.Limit),
-		stopped: make(chan struct{}),
+		queue:    &TimeSortedQueue{},
+		limiter:  semaphore.NewWeighted(opt.Limit),
+		stopped:  make(chan struct{}),
+		notify:   make(chan struct{}, 1),
+		done:     make(chan struct{}),
+		testHook: opt.testHook,
 	}
 	heap.Init(sh.queue)
 	sh.start()
@@ -63,123 +72,137 @@ func New(opt *Options) BufferQueue {
 }
 
 func (sh *bufferQueue) start() {
-	randInterval := func() time.Duration {
-		return time.Duration(float64(5+rand.Intn(5))*(1+0.8*rand.Float64())) * time.Millisecond
-	}
 	loopFunc := func() {
 		for {
-			select {
-			case <-sh.stopped:
-				if sh.Len() > 0 || sh.Workings() > 0 {
-					break
-				}
-				return
-			default:
-			}
-
+			// Wait for work or stop signal when queue is empty.
 			if sh.Len() <= 0 {
-				time.Sleep(time.Millisecond)
+				if sh.isStopped() {
+					return
+				}
+
+				select {
+				case <-sh.stopped:
+				case <-sh.notify:
+				}
 				continue
 			}
 
+			// Fast-path: try non-blocking acquire first to avoid blocking on the limiter.
 			if err := sh.TryAcquire(); err != nil {
-				time.Sleep(time.Millisecond)
-				continue
+				if err := sh.Acquire(); err != nil {
+					continue
+				}
 			}
 
 			value := sh.Pop()
 			if value == nil {
 				sh.Release()
-				time.Sleep(time.Millisecond)
 				continue
 			}
 
 			wh, ok := value.(WorkHandler)
 			if !ok {
 				sh.Release()
-				time.Sleep(randInterval())
+				CubeLog.WithContext(context.Background()).Warnf(
+					"BufferWorker: item does not implement WorkHandler: %v",
+					utils.InterfaceToString(value))
 				continue
 			}
 
-			recov.GoWithRecover(func() {
+			recov.GoWithWaitGroup(&sh.wg, func() {
 				defer sh.Release()
 				sh.IncrWorking()
 				defer sh.DecrWorking()
 				wh.Handle()
 			}, func(panicError interface{}) {
-				defer sh.Release()
-				defer sh.DecrWorking()
 				CubeLog.WithContext(context.Background()).Fatalf("BufferWorker panic:%v,value:%v",
 					panicError, utils.InterfaceToString(value))
 			})
 
-			select {
-			case <-sh.stopped:
-				if sh.Len() > 0 || sh.Workings() > 0 {
-
-					break
-				}
-				return
-			default:
+			if sh.testHook != nil {
+				sh.testHook()
 			}
 		}
 	}
-	recov.GoWithRecover(loopFunc, func(panicError interface{}) {
+	recov.GoWithWaitGroup(&sh.wg, loopFunc, func(panicError interface{}) {
 		CubeLog.WithContext(context.Background()).Fatalf("BufferWorker panic:%v", panicError)
 	})
 }
 
+// GraceFullStop signals the consumer loop and any in-flight workers to drain,
+// then waits for completion or until ctx is done. Safe to call multiple times.
+//
+// Note: if ctx fires before the queue drains (e.g. a hung Handle), the internal
+// wg.Wait waiter goroutine remains until all workers eventually return — which
+// matches the existing trade-off, since WorkHandler has no cancellation channel.
 func (sh *bufferQueue) GraceFullStop(ctx context.Context) {
-	close(sh.stopped)
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		default:
-		}
+	sh.stopOnce.Do(func() {
+		atomic.StoreInt32(&sh.stoppedFlg, 1)
+		close(sh.stopped)
+		go func() {
+			sh.wg.Wait()
+			close(sh.done)
+		}()
+	})
 
-		if err := sh.Acquire(); err == nil {
-			sh.Release()
-			if sh.Len() <= 0 && sh.Workings() <= 0 {
-
-				return
-			}
-		}
-		time.Sleep(time.Millisecond * 10)
+	select {
+	case <-ctx.Done():
+	case <-sh.done:
 	}
 }
 
 type bufferQueue struct {
-	queue   *TimeSortedQueue
-	limiter *semaphore.Weighted
-	lock    sync.RWMutex
-	len     int32
-	working int32
-	stopped chan struct{}
+	queue      *TimeSortedQueue
+	limiter    *semaphore.Weighted
+	lock       sync.RWMutex
+	len        int32
+	working    int32
+	stopped    chan struct{}
+	notify     chan struct{}
+	done       chan struct{}
+	stoppedFlg int32 // atomic flag for fast stopped check without channel read
+	stopOnce   sync.Once
+	testHook   func() // test only: called at the end of each loop iteration that dispatched work
+	wg         sync.WaitGroup
+}
+
+func (sh *bufferQueue) isStopped() bool {
+	return atomic.LoadInt32(&sh.stoppedFlg) == 1
+}
+
+func (sh *bufferQueue) signal() {
+	select {
+	case sh.notify <- struct{}{}:
+	default:
+	}
 }
 
 func (sh *bufferQueue) PushItem(i *Item) {
 	sh.lock.Lock()
-	defer sh.lock.Unlock()
 	heap.Push(sh.queue, i)
 	atomic.AddInt32(&sh.len, 1)
+	sh.lock.Unlock()
+	sh.signal()
 }
 
-func (sh *bufferQueue) Push(x interface{}) {
+func (sh *bufferQueue) Push(value interface{}) {
 	sh.lock.Lock()
-	defer sh.lock.Unlock()
 	item := &Item{
-		value:    x,
+		value:    value,
 		priority: time.Now().UnixNano(),
 	}
 	heap.Push(sh.queue, item)
 	atomic.AddInt32(&sh.len, 1)
+	sh.lock.Unlock()
+	sh.signal()
 }
 
 func (sh *bufferQueue) Pop() interface{} {
 	sh.lock.Lock()
 	defer sh.lock.Unlock()
 	if sh.queue.Len() == 0 {
+		// Defensive: keep counter aligned with the actual heap state.
+		atomic.StoreInt32(&sh.len, 0)
 		return nil
 	}
 	atomic.AddInt32(&sh.len, -1)
@@ -198,13 +221,13 @@ func (sh *bufferQueue) Len() int {
 	return int(atomic.LoadInt32(&sh.len))
 }
 
+// Acquire blocks until a limiter slot is available. The notify-driven loop no
+// longer needs polling, so we use Background to avoid per-call ctx allocation.
 func (sh *bufferQueue) Acquire() error {
 	if sh.limiter == nil {
 		return nil
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
-	defer cancel()
-	return sh.limiter.Acquire(ctx, 1)
+	return sh.limiter.Acquire(context.Background(), 1)
 }
 
 func (sh *bufferQueue) TryAcquire() error {
@@ -214,7 +237,7 @@ func (sh *bufferQueue) TryAcquire() error {
 	if sh.limiter.TryAcquire(1) {
 		return nil
 	}
-	return errors.New("buffer queue limit exceeded")
+	return errQueueLimitExceeded
 }
 
 func (sh *bufferQueue) Release() {
@@ -275,6 +298,7 @@ func (pq *TimeSortedQueue) Pop() interface{} {
 	old := *pq
 	n := len(old)
 	item := old[n-1]
+	old[n-1] = nil // avoid memory leak
 	item.index = -1
 	*pq = old[0 : n-1]
 	return item

--- a/CubeMaster/pkg/base/bufferqueue/bufferqueue_test.go
+++ b/CubeMaster/pkg/base/bufferqueue/bufferqueue_test.go
@@ -38,11 +38,11 @@ func TestQueue(t *testing.T) {
 	for i := 1; i <= testnum; i++ {
 		bw.Push(&testReq{id: i, sleep: time.Second, worked: &worked})
 	}
-	waittime := time.Duration(testnum) * time.Second
+	waittime := time.Duration(testnum+2) * time.Second
 	ctx, cancel := context.WithTimeout(context.Background(), waittime)
 	defer cancel()
 	bw.GraceFullStop(ctx)
-	assert.Equal(t, int32(testnum), worked)
+	assert.Equal(t, int32(testnum), atomic.LoadInt32(&worked))
 }
 
 func TestQueueGracefullStopTimeout(t *testing.T) {
@@ -116,10 +116,10 @@ func TestQueueCheckTimestampPriority(t *testing.T) {
 	bw := New(&Options{Limit: 5})
 	for i := 1; i <= testnum; i++ {
 		randt := time.Duration(float64(rand.Intn(5)) * (1 + 0.8*rand.Float64()))
-		t := time.Now().Add(-randt)
+		ts := time.Now().Add(-randt)
 		item := &Item{
-			value:    &testReqWithTimestamp{id: i, sleep: 5 * time.Millisecond, worked: &worked, createTime: t, dealQ: dealQ},
-			priority: t.UnixNano(),
+			value:    &testReqWithTimestamp{id: i, sleep: 5 * time.Millisecond, worked: &worked, createTime: ts, dealQ: dealQ},
+			priority: ts.UnixNano(),
 		}
 		bw.PushItem(item)
 		time.Sleep(time.Millisecond * 10)
@@ -129,23 +129,178 @@ func TestQueueCheckTimestampPriority(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), waittime)
 	defer cancel()
 	go func() {
+		ticker := time.NewTicker(time.Second)
+		defer ticker.Stop()
 		for {
 			select {
 			case <-ctx.Done():
 				return
-			default:
-				time.Sleep(time.Second)
+			case <-ticker.C:
+				if atomic.LoadInt32(&worked) == int32(testnum) {
+					cancel()
+					return
+				}
 				t.Logf("workings:%d", bw.Workings())
-			}
-			if atomic.LoadInt32(&worked) == int32(testnum) {
-				cancel()
-				return
 			}
 		}
 	}()
 
 	bw.GraceFullStop(ctx)
-	assert.Equal(t, int32(testnum), worked)
+	assert.Equal(t, int32(testnum), atomic.LoadInt32(&worked))
 	assert.Equal(t, int32(0), bw.Workings())
 	assert.Equal(t, int(testnum), len(dealQ.list))
+}
+
+// TestQueueIdleCPU verifies that an idle queue blocks on the notify channel
+// instead of busy-looping. The consumer goroutine should consume near-zero CPU
+// when no items are enqueued.
+func TestQueueIdleCPU(t *testing.T) {
+	var loopCount int32
+	bw := New(&Options{
+		Limit: 5,
+		testHook: func() {
+			atomic.AddInt32(&loopCount, 1)
+		},
+	})
+
+	// Let the consumer goroutine idle for a reasonable window.
+	time.Sleep(200 * time.Millisecond)
+
+	// In an idle state, the loop should be blocked at the select statement
+	// before ever completing its first iteration.
+	assert.Equal(t, int32(0), atomic.LoadInt32(&loopCount), "Main loop should not spin while idle")
+	assert.Equal(t, 0, bw.Len())
+	assert.Equal(t, int32(0), bw.Workings())
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	bw.GraceFullStop(ctx)
+}
+
+// TestQueueDelayedPushWakesConsumer verifies that a Push into an idle queue
+// correctly signals the consumer goroutine via the notify channel and the item
+// gets processed promptly.
+func TestQueueDelayedPushWakesConsumer(t *testing.T) {
+	worked := int32(0)
+	bw := New(&Options{Limit: 5})
+
+	// Let the consumer enter its blocking select on the empty queue.
+	time.Sleep(100 * time.Millisecond)
+	assert.Equal(t, 0, bw.Len())
+
+	// Now push an item; the consumer should wake up and process it.
+	bw.Push(&testReq{id: 1, sleep: 10 * time.Millisecond, worked: &worked})
+
+	// Wait long enough for the item to be consumed.
+	time.Sleep(200 * time.Millisecond)
+	assert.Equal(t, int32(1), atomic.LoadInt32(&worked))
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	bw.GraceFullStop(ctx)
+}
+
+// TestGracefulStop uses table-driven sub-tests to verify different
+// GraceFullStop scenarios: full drain, concurrent push during stop, and
+// idempotency under repeated/concurrent stop calls.
+func TestGracefulStop(t *testing.T) {
+	tests := []struct {
+		name                string
+		limit               int64
+		initialItems        int
+		itemSleep           time.Duration
+		concurrentPush      int // items pushed concurrently during stop
+		extraStopCalls      int // additional sequential GraceFullStop calls
+		concurrentStopCalls int // additional GraceFullStop calls fired in parallel
+		stopTimeout         time.Duration
+		minWorkedAssert     int32 // minimum number of items that must be processed
+		exactWorked         bool  // if true, assert exact match instead of >=
+	}{
+		{
+			name:            "drains all items before returning",
+			limit:           10,
+			initialItems:    20,
+			itemSleep:       50 * time.Millisecond,
+			stopTimeout:     10 * time.Second,
+			minWorkedAssert: 20,
+			exactWorked:     true,
+		},
+		{
+			name:            "concurrent push during stop completes without race",
+			limit:           5,
+			initialItems:    10,
+			itemSleep:       20 * time.Millisecond,
+			concurrentPush:  10,
+			stopTimeout:     10 * time.Second,
+			minWorkedAssert: 10, // at least initial batch
+		},
+		{
+			name:                "repeated and concurrent stop calls are idempotent",
+			limit:               1,
+			stopTimeout:         time.Second,
+			extraStopCalls:      2,
+			concurrentStopCalls: 4,
+			exactWorked:         true, // no items pushed, expect 0 worked
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			worked := int32(0)
+			bw := New(&Options{Limit: tc.limit})
+
+			for i := 0; i < tc.initialItems; i++ {
+				bw.Push(&testReq{id: i, sleep: tc.itemSleep, worked: &worked})
+			}
+
+			var pushWg sync.WaitGroup
+			if tc.concurrentPush > 0 {
+				pushWg.Add(1)
+				go func() {
+					defer pushWg.Done()
+					for i := tc.initialItems; i < tc.initialItems+tc.concurrentPush; i++ {
+						bw.Push(&testReq{id: i, sleep: 10 * time.Millisecond, worked: &worked})
+						time.Sleep(5 * time.Millisecond)
+					}
+				}()
+				// Give the concurrent pusher a head start.
+				time.Sleep(30 * time.Millisecond)
+			}
+
+			stopOnce := func() {
+				ctx, cancel := context.WithTimeout(context.Background(), tc.stopTimeout)
+				defer cancel()
+				bw.GraceFullStop(ctx)
+			}
+
+			assert.NotPanics(t, stopOnce, "first GraceFullStop must not panic")
+
+			for i := 0; i < tc.extraStopCalls; i++ {
+				assert.NotPanics(t, stopOnce, "repeated GraceFullStop must be idempotent")
+			}
+
+			if tc.concurrentStopCalls > 0 {
+				var stopWg sync.WaitGroup
+				for i := 0; i < tc.concurrentStopCalls; i++ {
+					stopWg.Add(1)
+					go func() {
+						defer stopWg.Done()
+						stopOnce()
+					}()
+				}
+				stopWg.Wait()
+			}
+
+			pushWg.Wait()
+
+			got := atomic.LoadInt32(&worked)
+			if tc.exactWorked {
+				assert.Equal(t, tc.minWorkedAssert, got)
+				assert.Equal(t, 0, bw.Len())
+				assert.Equal(t, int32(0), bw.Workings())
+			} else {
+				assert.GreaterOrEqual(t, got, tc.minWorkedAssert)
+			}
+		})
+	}
 }


### PR DESCRIPTION
### Description

#### 1. Background
We accidentally discovered that `cubemaster` consumed approximately **70-80% of a CPU core** even when the system was idle (no sandbox creation or active tasks). 

```text
    PID USER      PR  NI    VIRT    RES    SHR S  %CPU  %MEM     TIME+ COMMAND
   6903 root      20   0 2209912  95496  11028 S  75.7   1.2     71,24 cubemaster
```

The root cause was identified in the `bufferqueue` implementation, where the consumer loop relied on busy-polling with a 1ms sleep interval when the queue was empty, leading to high context-switching and CPU overhead.

**Problematic Code Snippet:**
```go
// Original loop with busy-polling
for {
    if sh.Len() <= 0 {
        time.Sleep(time.Millisecond * 1) // High CPU overhead due to constant wakeups
        continue
    }
    // ... processing
}
```

#### 2. Optimization Summary
This PR refactors `bufferqueue` to use an event-driven architecture, replacing various polling mechanisms with blocking signals and improving memory efficiency.

**Key Optimizations:**
- **Zero-CPU Idle Loop**: Replaced the 1ms `time.Sleep` polling with a `notify` channel. The consumer now blocks on a `select` statement and is only woken up when a new item is pushed or the queue is stopped.
- **Polling-Free Graceful Shutdown**: Refactored the stop logic using `sync.WaitGroup` and `sync.Once`. It eliminates the 10ms polling interval during shutdown, using a pure blocking wait for in-flight workers.
- **Fast-Path Resource Acquisition**: Introduced a non-blocking `tryAcquire` check before calling the blocking `Acquire`. This bypasses `context` and `timer` allocations on the hot path when the semaphore has available capacity, significantly reducing GC pressure under high throughput.
- **Thread-Safe Idempotency**: Ensured `GraceFullStop` is safe to call concurrently and multiple times.
- **Memory Leak Fix**: Fixed a potential memory leak in `TimeSortedQueue.Pop` by explicitly nil-ing the removed element's reference in the underlying slice.