### PR TITLE
bugfix(CubeProxy): solve stale routing by removing refresh-on-hit and implementing proactive cache invalidation

### DIFF
--- a/CubeProxy/lua/header_filter_phase.lua
+++ b/CubeProxy/lua/header_filter_phase.lua
@@ -1,14 +1,47 @@
-if ngx.status ~= 200 then
-    if ngx.var.upstream_addr ~= nil and ngx.var.cube_retcode == "310200" then
-        local utils = require "utils"
-        local ok, err = utils:is_faulty_backend(ngx.var.backend_ip, false)
-        if err then
-            ngx.log(ngx.ERR, "LEVEL_WARN||", "check backend fault err: ", err)
+if ngx.status ~= 200 and ngx.var.upstream_addr and ngx.var.cube_retcode == "310200" then
+    local utils = require "utils"
+    local ok, err = utils:is_faulty_backend(ngx.var.backend_ip, false)
+    if err then
+        ngx.log(ngx.ERR, "LEVEL_WARN||", "check backend fault err: ", err)
+    end
+
+    local prefix = ok and "340" or "330"
+    ngx.var.cube_retcode = prefix .. ngx.status
+
+    if ngx.status == 502 or ngx.status == 504 then
+        local bytes_str = ngx.var.upstream_bytes_received
+        local upstream_status = ngx.var.upstream_status
+        local has_received_data = false
+        
+        -- Distinguish network failure (0 bytes) from business 5xx (bytes > 0).
+        -- As Nginx provides no direct flag, we use upstream_bytes_received to identify failures.
+        -- upstream_status is logged for observability but not used in the decision logic.
+        if bytes_str then
+            for v in string.gmatch(bytes_str, "%d+") do
+                if tonumber(v) > 0 then
+                    has_received_data = true
+                    break
+                end
+            end
         end
-        if ok == true then
-            ngx.var.cube_retcode = "340" .. ngx.status
+
+        if not has_received_data then
+            -- Network-level Failure (e.g. connection refused). Clear cache.
+            local ins_id = ngx.ctx.ins_id
+            local port = ngx.ctx.container_port
+            if ins_id and port then
+                local cache = ngx.shared.local_cache
+                local base_key = string.format("%s:%s:", ins_id, port)
+                cache:delete(base_key .. "backend_ip")
+                cache:delete(base_key .. "backend_port")
+                
+                ngx.log(ngx.WARN, "LEVEL_WARN||", string.format("Network Failure (5xx). Cache Cleared. Status: %d, UpstreamStatus: %s, Bytes: %s", 
+                    ngx.status, tostring(upstream_status), tostring(bytes_str)))
+            end
         else
-            ngx.var.cube_retcode = "330" .. ngx.status
+            -- Application-level 5xx. Keep cache.
+            ngx.log(ngx.INFO, "LEVEL_INFO||", string.format("App-level 5xx. Cache Kept. Status: %d, UpstreamStatus: %s", 
+                ngx.status, tostring(upstream_status)))
         end
     end
 end

--- a/CubeProxy/lua/rewrite_phase.lua
+++ b/CubeProxy/lua/rewrite_phase.lua
@@ -79,8 +79,6 @@ local function get_backend_address(ins_id, container_port)
     local host_ip = cache:get(cache_backend_ip_key)
     local host_port = cache:get(cache_backend_port_key)
     if host_ip and host_port then
-        cache:set(cache_backend_ip_key, host_ip, timeout)
-        cache:set(cache_backend_port_key, host_port, timeout)
         return host_ip, host_port
     end
 
@@ -148,6 +146,8 @@ end
 local host_ip, host_port = get_backend_address(ins_id, container_port)
 ngx.var.backend_ip = host_ip
 ngx.var.backend_port = host_port
+ngx.ctx.ins_id = ins_id
+ngx.ctx.container_port = container_port
 
 local faulty_backend, err = utils:is_faulty_backend(host_ip, true)
 if err then


### PR DESCRIPTION
#### 1. The Problem
`CubeProxy` suffered from stale routing issues when sandboxes were destroyed or migrated. The root cause was a "refresh-on-hit" pattern in the local routing cache:
- Every successful cache hit extended the entry's TTL.
- For active sandboxes, routing entries never naturally expired.
- When `CubeMaster` updated Redis with a new backend IP/Port, the Proxy would continue using the old cached data until a manual restart or an extremely long timeout.

#### 2. The Solution
This PR implements two major changes:
*   **Natural Expiry**: Removed the `cache:set` call on hits in `rewrite_phase.lua`. Routing entries now follow their original random TTL (60-300s).
*   **Proactive Invalidation**: Implemented a precise identification mechanism in `header_filter_phase.lua` to detect connection failures and clear the local cache immediately.

#### 3. Key Logic: Bytes vs. Status
To avoid "false positives" (app-level 5xx), we use `$upstream_bytes_received` as the primary signal:
- **Network Failure**: `upstream_bytes_received == 0`. Action: **Clear Cache.**
- **App-level Error**: `upstream_bytes_received > 0`. Action: **Keep Cache.**

Refactored with guard clauses for performance and detailed logging for observability.

#### 4. Verification Results (Manual E2E):
- [x] **Network Failures**: Confirmed connection failures trigger immediate cache invalidation.
- [x] **App-level 5xx**: Confirmed business 5xx responses preserve the cache.
- [x] **TTL Behavior**: Verified TTL no longer refreshes on hit.
- [x] **Convergence Speed**: Verified backend switching completes in a single request after Redis update.

