### PR TITLE
docs(pvm): remove kernel headers from deploy guide

### DIFF
--- a/docs/guide/pvm-deploy.md
+++ b/docs/guide/pvm-deploy.md
@@ -44,18 +44,16 @@ Choose the package format that matches your Linux distribution:
 
 ### RPM-based (OpenCloudOS, RHEL, CentOS, TencentOS, Fedora)
 
-Find the following two files in the release assets, right-click each to copy its download link:
+Find the following file in the release assets, right-click it to copy its download link:
 
 - `kernel-*cube.pvm.host*.x86_64.rpm` (kernel package)
-- `kernel-headers-*cube.pvm.host*.x86_64.rpm` (kernel headers)
 
 ```bash
 # Replace the URLs below with the actual download links copied from the Releases page
 wget "<kernel rpm download URL>"
-wget "<kernel-headers rpm download URL>"
 
 # --oldpackage skips the version check if a newer kernel is already installed
-rpm -ivh --oldpackage kernel-*.rpm kernel-headers-*.rpm
+rpm -ivh --oldpackage kernel-*.rpm
 ```
 
 Set the PVM kernel as the default boot entry:
@@ -73,17 +71,15 @@ grubby --default-kernel
 
 ### DEB-based (Ubuntu, Debian)
 
-Find the following two files in the release assets, right-click each to copy its download link:
+Find the following file in the release assets, right-click it to copy its download link:
 
 - `linux-image-*cube.pvm.host*_amd64.deb` (kernel package)
-- `linux-headers-*cube.pvm.host*_amd64.deb` (kernel headers)
 
 ```bash
 # Replace the URLs below with the actual download links copied from the Releases page
 wget "<linux-image deb download URL>"
-wget "<linux-headers deb download URL>"
 
-dpkg -i linux-image-*cube.pvm.host*.deb linux-headers-*cube.pvm.host*.deb
+dpkg -i linux-image-*cube.pvm.host*.deb
 ```
 
 Set the PVM kernel as the default boot entry:
@@ -121,7 +117,7 @@ lsmod | grep kvm
 # Expected output includes kvm_pvm
 ```
 
-To load `kvm_pvm` automatically on boot:
+Configure `kvm_pvm` to load automatically on boot:
 
 ```bash
 echo 'kvm_pvm' > /etc/modules-load.d/kvm-pvm.conf

--- a/docs/zh/guide/pvm-deploy.md
+++ b/docs/zh/guide/pvm-deploy.md
@@ -52,10 +52,9 @@ sudo su root
 ```bash
 # 将下面的 URL 替换为你从 Releases 页面右键复制的实际下载链接
 wget "<kernel rpm 下载链接>"
-wget "<kernel-headers rpm 下载链接>"
 
 # 若宿主机已有更高版本内核，--oldpackage 跳过版本号比较
-rpm -ivh --oldpackage kernel-*.rpm kernel-headers-*.rpm
+rpm -ivh --oldpackage kernel-*.rpm
 ```
 
 设置 PVM 内核为默认启动项：
@@ -76,14 +75,12 @@ grubby --default-kernel
 在 Release 附件列表中找到以下两个文件，右键复制各自的下载链接后替换到命令中：
 
 - `linux-image-*cube.pvm.host*_amd64.deb`（内核主包）
-- `linux-headers-*cube.pvm.host*_amd64.deb`（内核头文件）
 
 ```bash
 # 将下面的 URL 替换为你从 Releases 页面右键复制的实际下载链接
 wget "<linux-image deb 下载链接>"
-wget "<linux-headers deb 下载链接>"
 
-dpkg -i linux-image-*cube.pvm.host*.deb linux-headers-*cube.pvm.host*.deb
+dpkg -i linux-image-*cube.pvm.host*.deb
 ```
 
 设置 PVM 内核为默认启动项：
@@ -121,7 +118,7 @@ lsmod | grep kvm
 # 期望输出中包含 kvm_pvm
 ```
 
-如需开机自动加载 `kvm_pvm` 模块：
+设置开机自动加载 `kvm_pvm` 模块：
 
 ```bash
 echo 'kvm_pvm' > /etc/modules-load.d/kvm-pvm.conf


### PR DESCRIPTION
- Remove kernel-headers and linux-headers installation steps
- Update wording for auto-loading kvm_pvm module