### PR TITLE
cubemastercli: add phase-oriented template watch output

### DIFF
--- a/CubeMaster/cmd/cubemastercli/commands/cubebox/template.go
+++ b/CubeMaster/cmd/cubemastercli/commands/cubebox/template.go
@@ -892,12 +892,18 @@ var TemplateRedoCommand = cli.Command{
 			if err != nil {
 				return err
 			}
-			current := fmt.Sprintf("%s/%s/%d/%d/%d", latest.Job.Status, latest.Job.Phase, latest.Job.Progress, latest.Job.ReadyNodeCount, latest.Job.ExpectedNodeCount)
+			if latest.Job == nil {
+				printTemplateImageJobWatchLine(nil)
+				printTemplateImageJobCompletionSummary(nil)
+				return errors.New("empty job")
+			}
+			current := formatTemplateImageJobWatchLine(latest.Job)
 			if current != lastPrinted {
-				printTemplateImageJob(latest.Job)
+				printTemplateImageJobWatchLine(latest.Job)
 				lastPrinted = current
 			}
 			if latest.Job.Status == "READY" || latest.Job.Status == "FAILED" {
+				printTemplateImageJobCompletionSummary(latest.Job)
 				if c.Bool("json") {
 					commands.PrintAsJSON(latest)
 				}
@@ -955,12 +961,18 @@ var TemplateWatchCommand = cli.Command{
 			if err != nil {
 				return err
 			}
-			current := fmt.Sprintf("%s/%s/%d/%d/%d", rsp.Job.Status, rsp.Job.Phase, rsp.Job.Progress, rsp.Job.ReadyNodeCount, rsp.Job.ExpectedNodeCount)
+			if rsp.Job == nil {
+				printTemplateImageJobWatchLine(nil)
+				printTemplateImageJobCompletionSummary(nil)
+				return errors.New("empty job")
+			}
+			current := formatTemplateImageJobWatchLine(rsp.Job)
 			if current != lastPrinted {
-				printTemplateImageJob(rsp.Job)
+				printTemplateImageJobWatchLine(rsp.Job)
 				lastPrinted = current
 			}
 			if rsp.Job.Status == "READY" || rsp.Job.Status == "FAILED" {
+				printTemplateImageJobCompletionSummary(rsp.Job)
 				if c.Bool("json") {
 					commands.PrintAsJSON(rsp)
 				}
@@ -1207,6 +1219,92 @@ func printTemplateImageJob(job *types.TemplateImageJobInfo) {
 	if job.ErrorMessage != "" {
 		log.Printf("error: %s\n", job.ErrorMessage)
 	}
+}
+
+func formatTemplateImageJobWatchPhase(job *types.TemplateImageJobInfo) string {
+	phase := "UNKNOWN"
+	if job != nil {
+		if job.Status == "READY" {
+			return "[7/7] READY"
+		}
+		if job.Phase != "" {
+			phase = job.Phase
+		}
+	}
+
+	phaseOrder := map[string]int{
+		"PULLING":           1,
+		"UNPACKING":         2,
+		"BUILDING_EXT4":     3,
+		"GENERATING_JSON":   4,
+		"DISTRIBUTING":      5,
+		"CREATING_TEMPLATE": 6,
+	}
+	if step, ok := phaseOrder[phase]; ok {
+		return fmt.Sprintf("[%d/7] %s", step, phase)
+	}
+	return fmt.Sprintf("[?/7] %s", phase)
+}
+
+func formatTemplateImageJobWatchLine(job *types.TemplateImageJobInfo) string {
+	if job == nil {
+		return "[?/7] UNKNOWN"
+	}
+	parts := []string{formatTemplateImageJobWatchPhase(job)}
+	parts = append(parts, fmt.Sprintf("progress=%d%%", job.Progress))
+	if job.ExpectedNodeCount > 0 || job.ReadyNodeCount > 0 || job.FailedNodeCount > 0 {
+		parts = append(parts, fmt.Sprintf("distribution=%d/%d ready, %d failed", job.ReadyNodeCount, job.ExpectedNodeCount, job.FailedNodeCount))
+	}
+	if job.TemplateID != "" {
+		parts = append(parts, fmt.Sprintf("template_id=%s", job.TemplateID))
+	}
+	if job.JobID != "" {
+		parts = append(parts, fmt.Sprintf("job_id=%s", job.JobID))
+	}
+	if job.ArtifactID != "" {
+		parts = append(parts, fmt.Sprintf("artifact_id=%s", job.ArtifactID))
+	}
+	if job.ErrorMessage != "" {
+		parts = append(parts, fmt.Sprintf("error=%s", job.ErrorMessage))
+	}
+	return strings.Join(parts, " ")
+}
+
+func formatTemplateImageJobCompletionSummary(job *types.TemplateImageJobInfo) string {
+	if job == nil {
+		return "template image job finished with empty response"
+	}
+	status := "finished"
+	if job.Status == "READY" {
+		status = "succeeded"
+	} else if job.Status == "FAILED" {
+		status = "failed"
+	}
+	parts := []string{fmt.Sprintf("template image job %s", status)}
+	if job.TemplateID != "" {
+		parts = append(parts, fmt.Sprintf("template_id=%s", job.TemplateID))
+	}
+	if job.JobID != "" {
+		parts = append(parts, fmt.Sprintf("job_id=%s", job.JobID))
+	}
+	if job.ArtifactID != "" {
+		parts = append(parts, fmt.Sprintf("artifact_id=%s", job.ArtifactID))
+	}
+	if job.ExpectedNodeCount > 0 || job.ReadyNodeCount > 0 || job.FailedNodeCount > 0 {
+		parts = append(parts, fmt.Sprintf("distribution=%d/%d ready, %d failed", job.ReadyNodeCount, job.ExpectedNodeCount, job.FailedNodeCount))
+	}
+	if job.ErrorMessage != "" {
+		parts = append(parts, fmt.Sprintf("error=%s", job.ErrorMessage))
+	}
+	return strings.Join(parts, " ")
+}
+
+func printTemplateImageJobWatchLine(job *types.TemplateImageJobInfo) {
+	log.Print(formatTemplateImageJobWatchLine(job) + "\n")
+}
+
+func printTemplateImageJobCompletionSummary(job *types.TemplateImageJobInfo) {
+	log.Print(formatTemplateImageJobCompletionSummary(job) + "\n")
 }
 
 func fetchTemplateBuildStatus(c *cli.Context, buildID string) (*templateBuildStatusResponse, error) {

--- a/CubeMaster/cmd/cubemastercli/commands/cubebox/template_test.go
+++ b/CubeMaster/cmd/cubemastercli/commands/cubebox/template_test.go
@@ -6,6 +6,7 @@ package cubebox
 
 import (
 	"flag"
+	"strings"
 	"testing"
 
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/service/sandbox/types"
@@ -272,5 +273,124 @@ func TestParseContainerOverridesNoDNS(t *testing.T) {
 	}
 	if overrides.DnsConfig != nil {
 		t.Fatalf("expected DnsConfig to be nil when --dns is not set, got %+v", overrides.DnsConfig)
+	}
+}
+
+func TestTemplateImageJobWatchPhaseLabel(t *testing.T) {
+	tests := []struct {
+		name string
+		job  *types.TemplateImageJobInfo
+		want string
+	}{
+		{name: "pulling", job: &types.TemplateImageJobInfo{Phase: "PULLING"}, want: "[1/7] PULLING"},
+		{name: "unpacking", job: &types.TemplateImageJobInfo{Phase: "UNPACKING"}, want: "[2/7] UNPACKING"},
+		{name: "building ext4", job: &types.TemplateImageJobInfo{Phase: "BUILDING_EXT4"}, want: "[3/7] BUILDING_EXT4"},
+		{name: "generating json", job: &types.TemplateImageJobInfo{Phase: "GENERATING_JSON"}, want: "[4/7] GENERATING_JSON"},
+		{name: "distributing", job: &types.TemplateImageJobInfo{Phase: "DISTRIBUTING"}, want: "[5/7] DISTRIBUTING"},
+		{name: "creating template", job: &types.TemplateImageJobInfo{Phase: "CREATING_TEMPLATE"}, want: "[6/7] CREATING_TEMPLATE"},
+		{name: "ready", job: &types.TemplateImageJobInfo{Status: "READY", Phase: "READY"}, want: "[7/7] READY"},
+		{name: "failed with ready phase", job: &types.TemplateImageJobInfo{Status: "FAILED", Phase: "READY"}, want: "[?/7] READY"},
+		{name: "unknown", job: &types.TemplateImageJobInfo{Phase: "SOMETHING_NEW"}, want: "[?/7] SOMETHING_NEW"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := formatTemplateImageJobWatchPhase(tt.job)
+			if got != tt.want {
+				t.Fatalf("phase label=%q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFormatTemplateImageJobWatchLineIncludesKeyFields(t *testing.T) {
+	job := &types.TemplateImageJobInfo{
+		JobID:             "job-1",
+		TemplateID:        "tpl-1",
+		ArtifactID:        "artifact-1",
+		Phase:             "DISTRIBUTING",
+		Progress:          73,
+		ExpectedNodeCount: 5,
+		ReadyNodeCount:    3,
+		FailedNodeCount:   1,
+	}
+
+	got := formatTemplateImageJobWatchLine(job)
+	for _, want := range []string{
+		"[5/7] DISTRIBUTING",
+		"progress=73%",
+		"distribution=3/5 ready, 1 failed",
+		"template_id=tpl-1",
+		"job_id=job-1",
+		"artifact_id=artifact-1",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("watch line=%q, want substring %q", got, want)
+		}
+	}
+}
+
+func TestFormatTemplateImageJobWatchLineIncludesError(t *testing.T) {
+	job := &types.TemplateImageJobInfo{
+		Status:       "FAILED",
+		Phase:        "BUILDING_EXT4",
+		Progress:     55,
+		ErrorMessage: "build ext4 failed",
+	}
+
+	got := formatTemplateImageJobWatchLine(job)
+	for _, want := range []string{"[3/7] BUILDING_EXT4", "progress=55%", "error=build ext4 failed"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("watch line=%q, want substring %q", got, want)
+		}
+	}
+}
+
+func TestFormatTemplateImageJobCompletionSummarySuccess(t *testing.T) {
+	job := &types.TemplateImageJobInfo{
+		Status:             "READY",
+		TemplateID:         "tpl-1",
+		JobID:              "job-1",
+		ArtifactID:         "artifact-1",
+		ExpectedNodeCount:  2,
+		ReadyNodeCount:     2,
+		FailedNodeCount:    0,
+		TemplateStatus:     "READY",
+		TemplateSpecFingerprint: "sha256:abc",
+	}
+
+	got := formatTemplateImageJobCompletionSummary(job)
+	for _, want := range []string{"template image job succeeded", "template_id=tpl-1", "job_id=job-1", "artifact_id=artifact-1", "distribution=2/2 ready, 0 failed"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("summary=%q, want substring %q", got, want)
+		}
+	}
+}
+
+func TestFormatTemplateImageJobCompletionSummaryFailure(t *testing.T) {
+	job := &types.TemplateImageJobInfo{
+		Status:       "FAILED",
+		TemplateID:   "tpl-1",
+		JobID:        "job-1",
+		ErrorMessage: "pull failed",
+	}
+
+	got := formatTemplateImageJobCompletionSummary(job)
+	for _, want := range []string{"template image job failed", "template_id=tpl-1", "job_id=job-1", "error=pull failed"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("summary=%q, want substring %q", got, want)
+		}
+	}
+}
+
+func TestFormatTemplateImageJobWatchHelpersHandleNil(t *testing.T) {
+	if got := formatTemplateImageJobWatchPhase(nil); got != "[?/7] UNKNOWN" {
+		t.Fatalf("nil phase label=%q, want [?/7] UNKNOWN", got)
+	}
+	if got := formatTemplateImageJobWatchLine(nil); got == "" {
+		t.Fatal("expected non-empty watch line for nil job")
+	}
+	if got := formatTemplateImageJobCompletionSummary(nil); got == "" {
+		t.Fatal("expected non-empty completion summary for nil job")
 	}
 }


### PR DESCRIPTION
## Summary
- add compact phase-oriented output for `cubemastercli tpl watch`
- print concise status lines on meaningful template image job changes
- add success/failure summaries when template image jobs reach terminal states

## Problem
`cubemastercli tpl watch` previously printed repeated full job dumps, making long-running template builds hard to follow.

## Old output

Before this change, every meaningful update printed the full job object again:

```text
job_id: job-abc-123
template_id: tpl-abc
status: RUNNING
phase: DISTRIBUTING
progress: 70%
distribution: 1/3 ready, 0 failed

job_id: job-abc-123
template_id: tpl-abc
status: RUNNING
phase: CREATING_TEMPLATE
progress: 85%
distribution: 3/3 ready, 0 failed
```

## New output

The watch output is now phase-oriented and more compact:

```text
[1/7] PULLING             progress=5%  distribution=0/0 ready, 0 failed template_id=tpl-abc job_id=job-abc-123
[2/7] UNPACKING           progress=20% artifact_id=rfs-xxxx template_id=tpl-abc job_id=job-abc-123
[3/7] BUILDING_EXT4       progress=55% artifact_id=rfs-xxxx template_id=tpl-abc job_id=job-abc-123
[4/7] GENERATING_JSON     progress=60% artifact_id=rfs-xxxx template_id=tpl-abc job_id=job-abc-123
[5/7] DISTRIBUTING        progress=70% distribution=1/3 ready, 0 failed template_id=tpl-abc job_id=job-abc-123
[6/7] CREATING_TEMPLATE   progress=85% distribution=3/3 ready, 0 failed template_id=tpl-abc job_id=job-abc-123
[7/7] READY               progress=100% distribution=3/3 ready, 0 failed template_id=tpl-abc job_id=job-abc-123
template image job succeeded template_id=tpl-abc job_id=job-abc-123 artifact_id=rfs-xxxx distribution=3/3 ready, 0 failed
```

Failure summary example:

```text
[6/7] CREATING_TEMPLATE progress=100% template_id=tpl-abc job_id=job-abc-123 error=failed to create shim task
template image job failed template_id=tpl-abc job_id=job-abc-123 error=failed to create shim task
```

## Fix

- map template image phases to step indicators
- format watch output as concise phase/status lines
- add terminal success/failure summaries with key fields such as `template_id`, `job_id`, `artifact_id`, distribution status, and error message
- apply the same formatting to the redo watch path because it watches the same template image job status

Closes #32

## Validation

- `cd CubeMaster && go test ./cmd/cubemastercli/commands/cubebox -run 'Template.*Watch|Template.*Summary|WatchLine|CompletionSummary|Phase' -count=1`
