### PR TITLE
chore: update alpine package repository mirror in Dockerfile

### DIFF
--- a/CubeProxy/Dockerfile
+++ b/CubeProxy/Dockerfile
@@ -2,7 +2,7 @@ FROM cube-sandbox-image.tencentcloudcr.com/opensource/openresty:1.21.4.1-6-alpin
 
 LABEL maintainer="staryxchen <staryxchen@tencent.com>"
 
-RUN sed -i 's/dl-cdn.alpinelinux.org/mirrors.tencentyun.com/g' /etc/apk/repositories \
+RUN sed -i 's#https\?://dl-cdn.alpinelinux.org#http://mirrors.tencent.com#g' /etc/apk/repositories \
     && mkdir -p /data/log/cube-proxy/ \
     && apk update \
     && apk add --no-cache tzdata curl wget \


### PR DESCRIPTION
- Change APK repository mirror from dl-cdn.alpinelinux.org to mirrors.tencent.com