### PR TITLE
fix(dev-env): write cube-shim binaries to TOOLBOX_ROOT to preserve symlinks

### DIFF
--- a/dev-env/README.md
+++ b/dev-env/README.md
@@ -275,7 +275,6 @@ Subcommands: `enable` (default), `disable`, `status`.
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `TOOLBOX_ROOT` | `/usr/local/services/cubetoolbox` | Base install dir used to map known components in `bin` mode. |
 | `UNIT_NAME` | `cube-sandbox-oneclick.service` | Unit name shown in the final restart hint. |
 | `OUTPUT_BIN_DIR` | `_output/bin` | Where `bin` mode reads host-side binaries from. |
 

--- a/dev-env/README_zh.md
+++ b/dev-env/README_zh.md
@@ -263,7 +263,6 @@ dev-env/
 
 | 变量 | 默认值 | 说明 |
 |------|--------|------|
-| `TOOLBOX_ROOT` | `/usr/local/services/cubetoolbox` | `bin` 子命令里已知组件的安装根目录。 |
 | `UNIT_NAME` | `cube-sandbox-oneclick.service` | 脚本末尾打印的重启提示里会用到的 unit 名。 |
 | `OUTPUT_BIN_DIR` | `_output/bin` | `bin` 子命令读取宿主机二进制的目录。 |
 

--- a/dev-env/sync_to_vm.sh
+++ b/dev-env/sync_to_vm.sh
@@ -159,7 +159,8 @@ component_remote_dir() {
     cubelet|cubecli) printf '%s/Cubelet/bin\n' "${TOOLBOX_ROOT}" ;;
     network-agent) printf '%s/network-agent/bin\n' "${TOOLBOX_ROOT}" ;;
     cube-api) printf '%s/CubeAPI/bin\n' "${TOOLBOX_ROOT}" ;;
-    cube-runtime|containerd-shim-cube-rs) printf '/usr/local/bin\n' ;;
+    # Keep one-click's /usr/local/bin symlinks intact by updating the real install path.
+    cube-runtime|containerd-shim-cube-rs) printf '%s/cube-shim/bin\n' "${TOOLBOX_ROOT}" ;;
     *) return 1 ;;
   esac
 }


### PR DESCRIPTION

- Change sync destination for cube-runtime and containerd-shim-cube-rs to ${TOOLBOX_ROOT}/cube-shim/bin
- Update README documentation to reflect the new path behavior