### PR TITLE
fix(seccomp): set default action and handle empty syscalls

### DIFF
--- a/Cubelet/pkg/container/seccomp/seccomp.go
+++ b/Cubelet/pkg/container/seccomp/seccomp.go
@@ -9,33 +9,40 @@ import (
 
 	"github.com/tencentcloud/CubeSandbox/Cubelet/api/services/cubebox/v1"
 
+	cseccomp "github.com/containerd/containerd/v2/contrib/seccomp"
 	"github.com/containerd/containerd/v2/core/containers"
 	"github.com/containerd/containerd/v2/pkg/oci"
 	"github.com/opencontainers/runtime-spec/specs-go"
 )
 
-func GenOpt(ctx context.Context, reqSysCalls []*cubebox.SysCall) oci.SpecOpts {
-	var sysCalls []specs.LinuxSyscall
-	for _, v := range reqSysCalls {
+func GenOpt(_ context.Context, reqSysCalls []*cubebox.SysCall) oci.SpecOpts {
+	if len(reqSysCalls) == 0 {
+		return func(context.Context, oci.Client, *containers.Container, *specs.Spec) error {
+			return nil
+		}
+	}
+
+	sysCalls := make([]specs.LinuxSyscall, 0, len(reqSysCalls))
+	for _, sysCall := range reqSysCalls {
 		var args []specs.LinuxSeccompArg
-		if v.GetArgs() != nil {
-			for _, vv := range v.GetArgs() {
-				args = append(args, specs.LinuxSeccompArg{
-					Index:    uint(vv.Index),
-					Value:    vv.Value,
-					ValueTwo: vv.ValueTwo,
-					Op:       specs.LinuxSeccompOperator(vv.Op),
-				})
-			}
+		for _, arg := range sysCall.GetArgs() {
+			args = append(args, specs.LinuxSeccompArg{
+				Index:    uint(arg.Index),
+				Value:    arg.Value,
+				ValueTwo: arg.ValueTwo,
+				Op:       specs.LinuxSeccompOperator(arg.Op),
+			})
 		}
-		var errno *uint = nil
-		if v.Errno != 0 {
-			eTmp := uint(v.Errno)
-			errno = &eTmp
+
+		var errno *uint
+		if sysCall.Errno != 0 {
+			errnoValue := uint(sysCall.Errno)
+			errno = &errnoValue
 		}
+
 		sysCalls = append(sysCalls, specs.LinuxSyscall{
-			Names:    v.Names,
-			Action:   specs.LinuxSeccompAction(v.Action),
+			Names:    sysCall.Names,
+			Action:   specs.LinuxSeccompAction(sysCall.Action),
 			ErrnoRet: errno,
 			Args:     args,
 		})
@@ -49,10 +56,20 @@ func withSeccomp(sysCalls []specs.LinuxSyscall) oci.SpecOpts {
 			s.Linux = &specs.Linux{}
 		}
 		if s.Linux.Seccomp == nil {
-			s.Linux.Seccomp = &specs.LinuxSeccomp{}
+			ensureSeccompProfilePrereqs(s)
+			s.Linux.Seccomp = cseccomp.DefaultProfile(s)
 		}
 
 		s.Linux.Seccomp.Syscalls = append(s.Linux.Seccomp.Syscalls, sysCalls...)
 		return nil
+	}
+}
+
+func ensureSeccompProfilePrereqs(s *specs.Spec) {
+	if s.Process == nil {
+		s.Process = &specs.Process{}
+	}
+	if s.Process.Capabilities == nil {
+		s.Process.Capabilities = &specs.LinuxCapabilities{}
 	}
 }

--- a/Cubelet/pkg/container/seccomp/seccomp_test.go
+++ b/Cubelet/pkg/container/seccomp/seccomp_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/tencentcloud/CubeSandbox/Cubelet/api/services/cubebox/v1"
 
+	cseccomp "github.com/containerd/containerd/v2/contrib/seccomp"
 	"github.com/containerd/containerd/v2/pkg/oci"
 	"github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/stretchr/testify/assert"
@@ -30,11 +31,110 @@ func TestGenOpt(t *testing.T) {
 	err := specFunc(context.Background(), nil, nil, &s)
 	assert.Nil(t, err)
 	assert.NotNil(t, s.Linux)
-	syscalls := []specs.LinuxSyscall{
+	assert.NotNil(t, s.Linux.Seccomp)
+	assert.Equal(t, specs.ActErrno, s.Linux.Seccomp.DefaultAction)
+	syscall := specs.LinuxSyscall{
+		Names:  []string{"ptrace"},
+		Action: specs.ActAllow,
+	}
+	assert.Equal(t, syscall, s.Linux.Seccomp.Syscalls[len(s.Linux.Seccomp.Syscalls)-1])
+}
+
+func TestGenOptInitializesContainerdDefaultProfileWhenSeccompMissing(t *testing.T) {
+	in := []*cubebox.SysCall{
+		{
+			Names:  []string{"getpid"},
+			Action: string(specs.ActAllow),
+		},
+	}
+	specFunc := GenOpt(context.Background(), in)
+	s := oci.Spec{
+		Linux: &specs.Linux{},
+		Process: &specs.Process{
+			Capabilities: &specs.LinuxCapabilities{
+				Bounding: []string{"CAP_SYS_ADMIN"},
+			},
+		},
+	}
+	expectedBase := cseccomp.DefaultProfile(&specs.Spec{
+		Linux: &specs.Linux{},
+		Process: &specs.Process{
+			Capabilities: &specs.LinuxCapabilities{
+				Bounding: []string{"CAP_SYS_ADMIN"},
+			},
+		},
+	})
+
+	err := specFunc(context.Background(), nil, nil, &s)
+	assert.NoError(t, err)
+	assert.NotNil(t, s.Linux.Seccomp)
+	assert.Equal(t, expectedBase.DefaultAction, s.Linux.Seccomp.DefaultAction)
+	assert.Equal(t, expectedBase.Architectures, s.Linux.Seccomp.Architectures)
+	assert.Equal(t, append(expectedBase.Syscalls, specs.LinuxSyscall{
+		Names:  []string{"getpid"},
+		Action: specs.ActAllow,
+	}), s.Linux.Seccomp.Syscalls)
+}
+
+func TestGenOptAppendsToExistingSeccomp(t *testing.T) {
+	in := []*cubebox.SysCall{
+		{
+			Names:  []string{"getpid"},
+			Action: string(specs.ActAllow),
+		},
+	}
+	specFunc := GenOpt(context.Background(), in)
+	s := oci.Spec{
+		Linux: &specs.Linux{
+			Seccomp: &specs.LinuxSeccomp{
+				DefaultAction: specs.ActErrno,
+				Syscalls: []specs.LinuxSyscall{
+					{
+						Names:  []string{"ptrace"},
+						Action: specs.ActAllow,
+					},
+				},
+			},
+		},
+	}
+
+	err := specFunc(context.Background(), nil, nil, &s)
+	assert.NoError(t, err)
+	assert.Equal(t, specs.ActErrno, s.Linux.Seccomp.DefaultAction)
+	assert.Equal(t, []specs.LinuxSyscall{
 		{
 			Names:  []string{"ptrace"},
 			Action: specs.ActAllow,
 		},
+		{
+			Names:  []string{"getpid"},
+			Action: specs.ActAllow,
+		},
+	}, s.Linux.Seccomp.Syscalls)
+}
+
+func TestGenOptNoSyscallsIsNoop(t *testing.T) {
+	specFunc := GenOpt(context.Background(), nil)
+	s := oci.Spec{}
+
+	err := specFunc(context.Background(), nil, nil, &s)
+	assert.NoError(t, err)
+	assert.Nil(t, s.Linux)
+}
+
+func TestGenOptKeepsExistingSeccompWhenSyscallsEmpty(t *testing.T) {
+	specFunc := GenOpt(context.Background(), nil)
+	s := oci.Spec{
+		Linux: &specs.Linux{
+			Seccomp: &specs.LinuxSeccomp{
+				DefaultAction: specs.ActAllow,
+			},
+		},
 	}
-	assert.Equal(t, syscalls, s.Linux.Seccomp.Syscalls)
+
+	err := specFunc(context.Background(), nil, nil, &s)
+	assert.NoError(t, err)
+	assert.NotNil(t, s.Linux)
+	assert.NotNil(t, s.Linux.Seccomp)
+	assert.Equal(t, specs.ActAllow, s.Linux.Seccomp.DefaultAction)
 }


### PR DESCRIPTION
## Problem Background

When using `cubecli` to create a privileged container directly, if the security context is configured as:
```json
"security_context":{
        "readonly_rootfs":true,
        "capabilities": {
        }
      }
```

Since the requested syscall rules are empty, Cubelet still **unconditionally executes** `seccomp.GenOpt()`. Meanwhile, on the sandbox side, `CreateSandbox()` **unconditionally appends** `oci.WithPrivileged`. However, containerd's `WithPrivileged` calls `WithSeccompUnconfined`, which **wipes out** `s.Linux.Seccomp`.

The result is: the default seccomp profile is first added, then wiped out by the privileged flag, and finally `seccomp.GenOpt(nil)` reconstructs an empty `LinuxSeccomp{}`. During Go-side serialization, the `defaultAction` field is mandatory (non-omitempty), thus serializing to an empty string. When Rust's `oci-spec 0.6.8` reads `LinuxSeccompAction`, it treats the empty string as an invalid enum, causing container creation to fail. The shim throws a `serde failed` error during `load_spec`.

## Fix Solution

Correct the semantics of `GenOpt()` in `Cubelet/pkg/container/seccomp/seccomp.go`:

When `reqSysCalls` is empty, return a **no-op** without modifying `s.Linux.Seccomp`.
Only when there are explicitly provided user syscall rules should the seccomp configuration be created or merged.