### PR TITLE
docs: fix python imports and architecture diagrams space alignment

### DIFF
--- a/docs/guide/multi-node-deploy.md
+++ b/docs/guide/multi-node-deploy.md
@@ -11,8 +11,8 @@ You must have a working control node deployed via the [Self-Build Deployment Gui
 ```
 ┌─────────────────────────────────────────┐
 │           Control Node                  │
-│  CubeMaster, cube-api, CubeProxy,      │
-│  CoreDNS, MySQL, Redis,                │
+│  CubeMaster, cube-api, CubeProxy,       │
+│  CoreDNS, MySQL, Redis,                 │
 │  Cubelet, network-agent                 │
 └──────────────────┬──────────────────────┘
                    │  /internal/meta API

--- a/docs/guide/self-build-deploy.md
+++ b/docs/guide/self-build-deploy.md
@@ -181,6 +181,7 @@ export SSL_CERT_FILE=/root/.local/share/mkcert/rootCA.pem
 **Run code**
 
 ```python
+import os
 from e2b_code_interpreter import Sandbox
 
 template_id = os.environ["CUBE_TEMPLATE_ID"]
@@ -193,6 +194,7 @@ with Sandbox.create(template=template_id) as sandbox:
 **Run a shell command**
 
 ```python
+import os
 from e2b_code_interpreter import Sandbox
 
 template_id = os.environ["CUBE_TEMPLATE_ID"]
@@ -205,6 +207,7 @@ with Sandbox.create(template=template_id) as sandbox:
 **Read a file inside the sandbox**
 
 ```python
+import os
 from e2b_code_interpreter import Sandbox
 
 template_id = os.environ["CUBE_TEMPLATE_ID"]

--- a/docs/zh/guide/multi-node-deploy.md
+++ b/docs/zh/guide/multi-node-deploy.md
@@ -10,9 +10,9 @@
 
 ```
 ┌─────────────────────────────────────────┐
-│              控制节点                     │
-│  CubeMaster, cube-api, CubeProxy,      │
-│  CoreDNS, MySQL, Redis,                │
+│              控制节点                    │
+│  CubeMaster, cube-api, CubeProxy,       │
+│  CoreDNS, MySQL, Redis,                 │
 │  Cubelet, network-agent                 │
 └──────────────────┬──────────────────────┘
                    │  /internal/meta API

--- a/docs/zh/guide/self-build-deploy.md
+++ b/docs/zh/guide/self-build-deploy.md
@@ -181,6 +181,7 @@ export SSL_CERT_FILE=/root/.local/share/mkcert/rootCA.pem
 **执行代码**
 
 ```python
+import os
 from e2b_code_interpreter import Sandbox
 
 template_id = os.environ["CUBE_TEMPLATE_ID"]
@@ -193,6 +194,7 @@ with Sandbox.create(template=template_id) as sandbox:
 **执行 Shell 命令**
 
 ```python
+import os
 from e2b_code_interpreter import Sandbox
 
 template_id = os.environ["CUBE_TEMPLATE_ID"]
@@ -205,6 +207,7 @@ with Sandbox.create(template=template_id) as sandbox:
 **读取沙箱内文件**
 
 ```python
+import os
 from e2b_code_interpreter import Sandbox
 
 template_id = os.environ["CUBE_TEMPLATE_ID"]


### PR DESCRIPTION
miss `import os` in examples
ascii diagram is not aligned