### PR TITLE
fix(CubeAPI): align sandbox status code mapping with protobuf ContainerState enum

### DIFF
--- a/CubeAPI/src/cubemaster/mod.rs
+++ b/CubeAPI/src/cubemaster/mod.rs
@@ -867,11 +867,15 @@ enum SandboxStatusValue {
 }
 
 fn sandbox_status_text_from_code(number: i32) -> &'static str {
+    // Align with protobuf ContainerState enum:
+    //   0=CREATED, 1=RUNNING, 2=EXITED, 3=UNKNOWN, 4=PAUSING, 5=PAUSED
     match number {
+        0 => "created",
         1 => "running",
-        2 => "paused",
-        3 => "stopped",
-        4 => "error",
+        2 => "exited",
+        3 => "unknown",
+        4 => "pausing",
+        5 => "paused",
         _ => "unknown",
     }
 }
@@ -891,14 +895,12 @@ where
 }
 
 fn normalize_sandbox_status_text(raw: &str) -> String {
-    match raw.trim().to_lowercase().as_str() {
-        "1" => sandbox_status_text_from_code(1).to_string(),
-        "2" => sandbox_status_text_from_code(2).to_string(),
-        "3" => sandbox_status_text_from_code(3).to_string(),
-        "4" => sandbox_status_text_from_code(4).to_string(),
-        "running" | "paused" | "stopped" | "error" => raw.trim().to_lowercase(),
-        other => other.to_string(),
+    let trimmed = raw.trim();
+    // Handle string-encoded numeric codes (e.g. "5" instead of 5)
+    if let Ok(code) = trimmed.parse::<i32>() {
+        return sandbox_status_text_from_code(code).to_string();
     }
+    trimmed.to_lowercase()
 }
 
 pub(crate) fn extract_template_id(
@@ -1437,7 +1439,8 @@ pub struct NodeResponse {
 
 #[cfg(test)]
 mod tests {
-    use super::{validate_path_segment, CubeMasterError, GetSandboxResponse, SandboxInfo};
+    use super::{validate_path_segment, CubeMasterError, GetSandboxResponse, SandboxInfo,
+             normalize_sandbox_status_text, sandbox_status_text_from_code};
 
     #[test]
     fn build_id_path_segment_accepts_alphanumeric_and_hyphen() {
@@ -1538,5 +1541,31 @@ mod tests {
                 .timestamp_nanos_opt(),
             Some(1713953785140309977)
         );
+    }
+
+    #[test]
+    fn status_code_matches_protobuf_container_state_enum() {
+        // Verify alignment with cubebox.proto ContainerState:
+        //   0=CREATED, 1=RUNNING, 2=EXITED, 3=UNKNOWN, 4=PAUSING, 5=PAUSED
+        assert_eq!(sandbox_status_text_from_code(0), "created");
+        assert_eq!(sandbox_status_text_from_code(1), "running");
+        assert_eq!(sandbox_status_text_from_code(2), "exited");
+        assert_eq!(sandbox_status_text_from_code(3), "unknown");
+        assert_eq!(sandbox_status_text_from_code(4), "pausing");
+        assert_eq!(sandbox_status_text_from_code(5), "paused");
+        assert_eq!(sandbox_status_text_from_code(99), "unknown");
+    }
+
+    #[test]
+    fn normalize_status_text_handles_string_encoded_codes() {
+        // Numeric strings should be decoded via sandbox_status_text_from_code
+        assert_eq!(normalize_sandbox_status_text("0"), "created");
+        assert_eq!(normalize_sandbox_status_text("1"), "running");
+        assert_eq!(normalize_sandbox_status_text("5"), "paused");
+        assert_eq!(normalize_sandbox_status_text("99"), "unknown");
+        // Text statuses should be lowercased
+        assert_eq!(normalize_sandbox_status_text("Running"), "running");
+        assert_eq!(normalize_sandbox_status_text("PAUSED"), "paused");
+        assert_eq!(normalize_sandbox_status_text(" Pausing "), "pausing");
     }
 }

--- a/CubeAPI/src/services/sandboxes.rs
+++ b/CubeAPI/src/services/sandboxes.rs
@@ -625,7 +625,7 @@ fn sandbox_state_from_status(status: SandboxStatus) -> SandboxState {
 
 fn sandbox_state_from_str(status: &str) -> SandboxState {
     match status.to_lowercase().as_str() {
-        "paused" => SandboxState::Paused,
+        "paused" | "pausing" => SandboxState::Paused,
         _ => SandboxState::Running,
     }
 }
@@ -681,9 +681,10 @@ pub(crate) fn build_cubevs_context(
 mod tests {
     use std::collections::HashMap;
 
-    use super::{build_cubevs_context, filter_by_metadata, from_cubemaster_info};
+    use super::{build_cubevs_context, filter_by_metadata, from_cubemaster_info,
+                 sandbox_state_from_str, parse_state_filter};
     use crate::cubemaster::SandboxInfo;
-    use crate::models::SandboxNetworkConfig;
+    use crate::models::{SandboxNetworkConfig, SandboxState};
 
     #[test]
     fn metadata_filter_matches_all_pairs() {
@@ -736,5 +737,24 @@ mod tests {
         assert_eq!(listed.cpu_count, 2);
         assert_eq!(listed.memory_mb, 2048);
         assert_eq!(listed.template_id, "tpl-1");
+    }
+
+    #[test]
+    fn sandbox_state_from_str_maps_paused_and_pausing() {
+        assert_eq!(sandbox_state_from_str("paused"), SandboxState::Paused);
+        assert_eq!(sandbox_state_from_str("pausing"), SandboxState::Paused);
+        assert_eq!(sandbox_state_from_str("PAUSED"), SandboxState::Paused);
+        assert_eq!(sandbox_state_from_str("Pausing"), SandboxState::Paused);
+        assert_eq!(sandbox_state_from_str("running"), SandboxState::Running);
+        assert_eq!(sandbox_state_from_str("created"), SandboxState::Running);
+        assert_eq!(sandbox_state_from_str("unknown"), SandboxState::Running);
+    }
+
+    #[test]
+    fn parse_state_filter_recognizes_paused() {
+        assert_eq!(parse_state_filter(Some("paused")), Some(SandboxState::Paused));
+        assert_eq!(parse_state_filter(Some("running")), Some(SandboxState::Running));
+        assert_eq!(parse_state_filter(None), None);
+        assert_eq!(parse_state_filter(Some("invalid")), None);
     }
 }


### PR DESCRIPTION
## Summary

Fix `GET /v2/sandboxes?state=paused` returning an empty list even when paused sandboxes exist.

Closes #177

## Root Cause

`sandbox_status_text_from_code()` in `CubeAPI/src/cubemaster/mod.rs` used an incorrect status code mapping that did not match the protobuf `ContainerState` enum defined in `cubebox.proto`:

| Code | Before (wrong) | After (correct, per proto) |
|------|---------------|---------------------------|
| 0 | (unmapped) | created |
| 1 | running | running |
| 2 | paused | exited |
| 3 | stopped | unknown |
| 4 | error | pausing |
| 5 | (unknown) | **paused** |

CubeMaster list returns `status=5` for paused sandboxes (matching `CONTAINER_PAUSED=5` in proto). CubeAPI was mapping `5` to `"unknown"`, then `sandbox_state_from_str("unknown")` fell through to `SandboxState::Running`. This caused:

1. Paused sandboxes reported as `running` in list responses (masked the true state)
2. `state=paused` filter found no matches since all paused sandboxes had `state=Running` internally

## Changes

- **`CubeAPI/src/cubemaster/mod.rs`**: Rewrite `sandbox_status_text_from_code()` to align with protobuf `ContainerState` enum values (0-5)
- **`CubeAPI/src/services/sandboxes.rs`**: Add `"pausing"` to `sandbox_state_from_str()` so transitional state is also categorized as Paused

## Testing

Verified on cubesandbox002:
- Before fix: `pytest TestBug0002ListPausedReturnsEmpty` → XFAIL (bug present)
- After fix: same test → XPASS (bug resolved, `state=paused` filter now returns paused sandboxes correctly)

## Impact

This also fixes the related issue where list endpoint misreports paused sandboxes as running (previously tracked internally as BUG-0003).