### PR TITLE
fix(cubecli): remove dead listmd command

### DIFF
--- a/Cubelet/cmd/cubecli/commands/cubebox/cubebox.go
+++ b/Cubelet/cmd/cubecli/commands/cubebox/cubebox.go
@@ -15,7 +15,6 @@ var Command = &cli.Command{
 	Subcommands: []*cli.Command{
 		ListCommand,
 		ListSandboxCommand,
-		&listMetaData,
 		update,
 		Create,
 		&inspecMetaData,

--- a/Cubelet/cmd/cubecli/commands/cubebox/metadata.go
+++ b/Cubelet/cmd/cubecli/commands/cubebox/metadata.go
@@ -6,88 +6,13 @@ package cubebox
 
 import (
 	"fmt"
-	"log"
 	"strings"
 
-	"context"
-	"os"
-	"path"
-	"path/filepath"
-	"time"
-
-	containerd "github.com/containerd/containerd/v2/client"
-	"github.com/containerd/containerd/v2/pkg/namespaces"
-	"github.com/containerd/platforms"
-	jsoniter "github.com/json-iterator/go"
 	"github.com/urfave/cli/v2"
 
 	"github.com/tencentcloud/CubeSandbox/Cubelet/api/services/cubebox/v1"
 	"github.com/tencentcloud/CubeSandbox/Cubelet/cmd/cubecli/commands"
-	"github.com/tencentcloud/CubeSandbox/Cubelet/pkg/constants"
-	cubeboxstore "github.com/tencentcloud/CubeSandbox/Cubelet/pkg/store/cubebox"
-	"github.com/tencentcloud/CubeSandbox/Cubelet/pkg/utils"
-	"github.com/tencentcloud/CubeSandbox/Cubelet/plugins/cube/internals/cubes"
 )
-
-var (
-	cubeboxDir = "io.cubelet.internal.v1.cubebox"
-)
-
-var (
-	dbDir    = "db"
-	dbHandle *utils.CubeStore
-)
-
-type sandBoxInfo struct {
-	SandboxID  string
-	IP         string
-	PID        int
-	Namespace  string
-	Containers map[string]*containerInfo
-}
-
-type containerInfo struct {
-	ID  string
-	PID int
-}
-
-func copyDb(onlineBaseDir string) (func(), error) {
-	targedir := filepath.Join(os.TempDir(), dbDir)
-	if err := os.MkdirAll(path.Clean(targedir), os.ModeDir|0755); err != nil {
-		return nil, fmt.Errorf("init dir failed %s", err.Error())
-	}
-	clean := func() {
-		os.RemoveAll(path.Clean(targedir))
-	}
-
-	exist, er := utils.DenExist(targedir)
-	if er != nil || !exist {
-		log.Printf("failed to create temp dir: %v", er)
-		return nil, er
-	}
-
-	cmds := [][]string{
-		{"mkdir", "-p", targedir},
-		{"ls", "-l", onlineBaseDir},
-		{"cp", "-r", onlineBaseDir, targedir},
-	}
-	log.Printf("cmds:%v", cmds)
-	for _, cmd := range cmds {
-		if out, stderr, err := utils.ExecV(cmd, time.Minute); err == nil {
-			log.Printf("metadata: %v", out)
-		} else {
-			log.Printf("metadata: failed to exec %v: %v", cmd, err)
-			return clean, fmt.Errorf("metadata failed:%s", stderr)
-		}
-	}
-
-	var err error
-	if dbHandle, err = utils.NewCubeStoreExt(filepath.Join(targedir, dbDir), "meta.db", 10, nil); err != nil {
-		log.Printf("metadata: failed to open db: %v", err)
-		return clean, err
-	}
-	return clean, nil
-}
 
 var inspecMetaData = cli.Command{
 	Name:      "inspect",
@@ -149,59 +74,6 @@ var inspecMetaData = cli.Command{
 				fmt.Println(string(item.GetPrivateCubeboxStorageData()))
 			}
 		}
-		return nil
-	},
-}
-
-var listMetaData = cli.Command{
-	Name:    "listmd",
-	Aliases: []string{"lsmd"},
-	Usage:   "list metadata",
-	Action: func(clictx *cli.Context) error {
-		cntdClient, err := containerd.New(clictx.String("address"),
-			containerd.WithDefaultPlatform(platforms.Default()),
-		)
-		if err != nil {
-			return fmt.Errorf("init containerd connect failed.%s", err)
-		}
-
-		clean, err := copyDb(filepath.Join(clictx.String("state"), cubeboxDir, dbDir))
-		if err != nil {
-			log.Printf("fail copy db:%v", err)
-			return err
-		}
-		defer clean()
-
-		all, err := dbHandle.ReadAll("sandbox/v1")
-		if err != nil {
-			log.Printf("fail:%v", err)
-			return nil
-		}
-		for id, sandboxBytes := range all {
-			var cb = new(cubeboxstore.CubeBox)
-			if err := jsoniter.Unmarshal(sandboxBytes, cb); err != nil {
-				log.Printf("failed to unmarshal to cubebox %s from meta: %v", id, err)
-				continue
-			}
-
-			old := utils.InterfaceToString(cb)
-
-			if cb.Namespace == "" {
-				cb.Namespace = namespaces.Default
-			}
-			podCtx := namespaces.WithNamespace(context.TODO(), cb.Namespace)
-			podCtx = context.WithValue(podCtx, constants.CubeboxID, cb.ID)
-			if err := cubes.RecoverPod(podCtx, cntdClient, cb); err != nil {
-				log.Printf("failed to recover pod: %v", err)
-				continue
-			}
-			if cb.GetStatus().IsTerminated() {
-				log.Printf("sandbox %s is terminating, skip", cb.ID)
-				log.Printf("load sandbox %v", old)
-			}
-			log.Printf("Loaded sandbox %v", utils.InterfaceToString(&cb))
-		}
-
 		return nil
 	},
 }


### PR DESCRIPTION
The `cubecli cubebox listmd` command was introduced when each cubelet plugin persisted its own bbolt metadata file under a plugin-scoped directory. Cubebox metadata has since been migrated to a shared multimeta store (`<state>/io.cubelet.cubemetastore.v1.mutilmeta/db/{b..k}/meta.db`, exposed via the gRPC `MultiMetaDBServer` API). The `listmd` implementation — which still targets the old per-plugin layout — has rotted in two ways that make it unsafe to keep:

1. **Destructive side effects.** Despite the `list`-style name, the loop calls `cubes.RecoverPod` on every entry. For sandboxes in the `Stopped` state, `RecoverContainer` issues `t.Delete(ctx, containerd.WithProcessKill)` (`Cubelet/plugins/cube/internals/cubes/restart.go:232`), which SIGKILLs and reaps the containerd task. Pod recovery is already owned by cubelet startup; an operator CLI has no business doing it.

2. **Concurrency-unsafe DB access.** `copyDb` does `cp -r` on the live cubebox bbolt tree into `os.TempDir()` and opens it through a package-level `dbHandle *utils.CubeStore`. Copying a live bbolt file while cubelet holds it open can yield a torn snapshot, and the package-level handle is unguarded against concurrent invocations.

The functionality is fully covered by already-shipping commands that talk to the live gRPC services:

  - `cubecli meta dbs`                      list registered buckets
  - `cubecli meta view -db cubebox sandbox/v1`   dump cubebox sandbox entries
  - `cubecli cubebox inspect <id>`               pretty-print one sandbox

These are strictly better: they require no path guessing, are read-only by contract, and cannot be broken by further plugin-layout changes.

Remove `listMetaData`, its `copyDb` helper, and the unused `sandBoxInfo`/`containerInfo` types it dragged along. Deregister it from the subcommand list in `cubebox.go`. Drop imports that become unused. No net-new code.