### PR TITLE
sdk/python: add cubesandbox Python SDK v0.1.0

### DIFF
--- a/sdk/python/.gitignore
+++ b/sdk/python/.gitignore
@@ -1,0 +1,8 @@
+__pycache__/
+*.py[cod]
+*.pyo
+.pytest_cache/
+*.egg-info/
+dist/
+build/
+.venv/

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -1,0 +1,233 @@
+<p align="center">
+  <strong>cubesandbox</strong> — Python SDK for CubeSandbox
+</p>
+
+<p align="center">
+  <a href="https://github.com/TencentCloud/CubeSandbox"><img src="https://img.shields.io/badge/CubeSandbox-GitHub-blue" alt="CubeSandbox" /></a>
+  <a href="../../LICENSE"><img src="https://img.shields.io/badge/License-Apache_2.0-green" alt="Apache 2.0" /></a>
+  <img src="https://img.shields.io/badge/Python-3.9%2B-blue" alt="Python 3.9+" />
+  <img src="https://img.shields.io/badge/version-0.1.0-orange" alt="v0.1.0" />
+</p>
+
+---
+
+`cubesandbox` is the official Python SDK for [CubeSandbox](https://github.com/TencentCloud/CubeSandbox).
+It provides a simple, Pythonic interface to create sandboxes, execute code,
+and control the full sandbox lifecycle — including pause/resume with memory snapshot.
+
+## Installation
+
+```bash
+pip install cubesandbox
+```
+
+Or install from source:
+
+```bash
+cd sdk/python
+pip install -e .
+```
+
+## Quick Start
+
+Set the required environment variables:
+
+```bash
+export CUBE_API_URL=http://<your-cubeapi-host>:3000
+export CUBE_TEMPLATE_ID=<your-template-id>
+
+# Required for remote access (bypasses DNS for *.cube.app)
+export CUBE_PROXY_NODE_IP=<your-cubeproxy-node-ip>
+```
+
+Run your first sandbox:
+
+```python
+from cubesandbox import Sandbox
+
+with Sandbox.create() as sb:
+    result = sb.run_code("1 + 1")
+    print(result.text)   # "2"
+```
+
+## Features
+
+### Execute code
+
+```python
+from cubesandbox import Sandbox
+
+with Sandbox.create() as sb:
+    # Simple expression
+    result = sb.run_code("x = 42\nx * 2")
+    print(result.text)          # "84"
+
+    # Capture stdout
+    result = sb.run_code('print("hello")')
+    print(result.logs.stdout)   # ["hello\n"]
+
+    # Stream output in real time
+    sb.run_code(
+        'for i in range(3): print(i)',
+        on_stdout=lambda msg: print("out:", msg.text),
+    )
+```
+
+### Persistent variables within a sandbox
+
+Variables assigned in one `run_code` call persist for the lifetime of the sandbox —
+no separate context object needed:
+
+```python
+with Sandbox.create() as sb:
+    sb.run_code("x = 100")
+    result = sb.run_code("x + 1")
+    print(result.text)   # "101"
+```
+
+
+### Pause & resume
+
+```python
+sb = Sandbox.create()
+
+# Pause — preserves memory snapshot, polls until state=paused
+sb.pause()                         # wait=True, timeout=30s by default
+sb.pause(wait=False)               # fire-and-forget
+sb.pause(timeout=60, interval=0.5) # custom poll params
+
+# Resume by connecting — auto-resumes paused sandbox
+sb2 = Sandbox.connect(sb.sandbox_id)
+```
+
+### Network policy
+
+```python
+import json
+from cubesandbox import Sandbox
+
+# Deny all outbound traffic
+with Sandbox.create(metadata={"network-policy": "deny-all"}) as sb:
+    result = sb.run_code(
+        "import urllib.request; urllib.request.urlopen('http://example.com')"
+    )
+    print(result.error.name)   # "URLError"
+
+# Custom allow-list — NOTE: only IP addresses are supported, not domain names
+rules = json.dumps({"allow": ["151.101.0.0/16"]})
+with Sandbox.create(
+    metadata={"network-policy": "custom", "network-rules": rules}
+) as sb:
+    sb.run_code("import subprocess; subprocess.run(['pip', 'install', 'requests'])")
+```
+
+### Host-directory mount
+
+```python
+import json
+from cubesandbox import Sandbox
+
+mounts = json.dumps([{"hostPath": "/data/shared", "mountPath": "/mnt/data"}])
+with Sandbox.create(metadata={"hostdir-mount": mounts}) as sb:
+    result = sb.run_code("open('/mnt/data/hello.txt').read()")
+    print(result.text)
+```
+
+### List & health check
+
+```python
+from cubesandbox import Sandbox
+
+print(Sandbox.health())     # {"status": "ok", "sandboxes": 4}
+print(Sandbox.list())       # list of running sandbox dicts
+print(Sandbox.list_v2())    # v2 API (supports filtering)
+```
+
+## Configuration
+
+| Environment Variable | Required | Default | Description |
+|---|:---:|---|---|
+| `CUBE_API_URL` | ✅ | `http://127.0.0.1:3000` | CubeAPI management plane address |
+| `CUBE_TEMPLATE_ID` | ✅ | — | Template ID for sandbox creation |
+| `CUBE_PROXY_NODE_IP` | remote | — | CubeProxy node IP, bypasses DNS for `*.cube.app` |
+| `CUBE_PROXY_PORT_HTTP` | | `80` | CubeProxy HTTP port |
+| `CUBE_SANDBOX_DOMAIN` | | `cube.app` | Sandbox domain suffix |
+
+You can also pass a `Config` object directly:
+
+```python
+from cubesandbox import Config, Sandbox
+
+cfg = Config(
+    api_url="http://10.0.0.1:3000",
+    template_id="tpl-xxxxxxxxxxxxxxxxxxxxxxxx",
+    proxy_node_ip="10.0.0.1",
+)
+with Sandbox.create(config=cfg) as sb:
+    print(sb.run_code("2 ** 10").text)   # "1024"
+```
+
+## API Reference
+
+### `Sandbox` — class methods
+
+| Method | Description |
+|---|---|
+| `Sandbox.create(template, *, timeout, env_vars, metadata, config)` | `POST /sandboxes` — create a new sandbox |
+| `Sandbox.connect(sandbox_id, *, config)` | `POST /sandboxes/:id/connect` — connect (auto-resumes if paused) |
+| `Sandbox.list(config)` | `GET /sandboxes` — list running sandboxes (v1) |
+| `Sandbox.list_v2(config)` | `GET /v2/sandboxes` — list sandboxes (v2) |
+| `Sandbox.health(config)` | `GET /health` — service health check |
+
+### `Sandbox` — instance methods
+
+| Method | Description |
+|---|---|
+| `sb.run_code(code, *, on_stdout, on_stderr, on_result, on_error, envs, timeout)` | `POST /execute` — execute code, returns `Execution` |
+| `sb.get_info()` | `GET /sandboxes/:id` — get sandbox state and metadata |
+| `sb.get_info()` | `GET /sandboxes/:id` — get sandbox detail |
+| `sb.pause(*, wait, timeout, interval)` | `POST /sandboxes/:id/pause` — pause sandbox |
+| `sb.resume(timeout)` | `POST /sandboxes/:id/resume` — resume (deprecated, use `connect`) |
+| `sb.kill()` | `DELETE /sandboxes/:id` — destroy sandbox |
+| `sb.get_host(port)` | Return virtual hostname `{port}-{id}.{domain}` |
+
+### `Execution` object
+
+| Attribute | Type | Description |
+|---|---|---|
+| `.text` | `str \| None` | Final expression value (main result) |
+| `.logs.stdout` | `list[str]` | All stdout lines |
+| `.logs.stderr` | `list[str]` | All stderr lines |
+| `.error` | `ExecutionError \| None` | Exception info if execution failed |
+| `.results` | `list[Result]` | All result events |
+
+## Examples
+
+| Script | Description |
+|---|---|
+| `examples/create_and_run.py` | Create sandbox and run code |
+| `examples/context.py` | Kernel context (server-side not yet implemented) |
+| `examples/lifecycle.py` | Pause / connect / kill |
+| `examples/list_and_health.py` | List sandboxes and health check |
+| `examples/network_policy.py` | Network policy (deny-all / custom) |
+| `examples/volume.py` | Host-directory mount |
+| `examples/run_all.py` | Run all examples |
+
+## DNS Bypass (Remote Access)
+
+When running outside the CubeSandbox node, `*.cube.app` cannot be resolved by the OS DNS.
+Set `CUBE_PROXY_NODE_IP` to enable `IPOverrideTransport`: all data-plane connections are
+routed directly to that IP with the virtual `Host` header preserved for CubeProxy routing.
+
+```
+Without CUBE_PROXY_NODE_IP:
+  SDK → OS DNS (*.cube.app) → CubeProxy
+
+With CUBE_PROXY_NODE_IP:
+  SDK → TCP direct to CUBE_PROXY_NODE_IP:80
+        Host: 49999-{sandboxID}.cube.app (preserved for routing)
+```
+
+## License
+
+Apache-2.0 © 2026 Tencent Inc.

--- a/sdk/python/cubesandbox/__init__.py
+++ b/sdk/python/cubesandbox/__init__.py
@@ -1,0 +1,24 @@
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+from .sandbox import Sandbox
+from ._config import Config
+from ._models import Execution, Result, Logs, ExecutionError, OutputMessage
+from ._exceptions import CubeSandboxError, SandboxNotFoundError, ApiError
+from ._commands import CommandResult
+
+__all__ = [
+    "Sandbox",
+    "Config",
+    "Execution",
+    "Result",
+    "Logs",
+    "ExecutionError",
+    "OutputMessage",
+    "CubeSandboxError",
+    "SandboxNotFoundError",
+    "ApiError",
+    "CommandResult",
+]
+
+__version__ = "0.1.0"

--- a/sdk/python/cubesandbox/_commands.py
+++ b/sdk/python/cubesandbox/_commands.py
@@ -1,0 +1,51 @@
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .sandbox import Sandbox
+
+
+@dataclass
+class CommandResult:
+    stdout: str
+    stderr: str
+    exit_code: int
+
+
+class Commands:
+    def __init__(self, sandbox: "Sandbox") -> None:
+        self._sandbox = sandbox
+
+    def run(self, cmd: str, *, timeout: float | None = None, **kwargs) -> CommandResult:
+        """Run a shell command inside the sandbox via Python subprocess."""
+        code = (
+            "import subprocess as _sp\n"
+            f"_r = _sp.run({cmd!r}, shell=True, capture_output=True, text=True)\n"
+            "import sys as _sys\n"
+            "_sys.stdout.write(_r.stdout)\n"
+            "_sys.stderr.write(_r.stderr)\n"
+            "print(_r.returncode)\n"
+        )
+        stdout_lines: list[str] = []
+        execution = self._sandbox.run_code(
+            code,
+            timeout=timeout,
+            on_stdout=lambda m: stdout_lines.append(m.text),
+        )
+        # last stdout line is the exit code printed by the wrapper
+        all_stdout = "".join(stdout_lines)
+        lines = all_stdout.splitlines()
+        if lines and lines[-1].strip().lstrip("-").isdigit():
+            exit_code = int(lines[-1].strip())
+            stdout = "\n".join(lines[:-1])
+            if lines[:-1]:  # restore trailing newline if there was content
+                stdout += "\n"
+        else:
+            exit_code = 1 if execution.error else 0
+            stdout = all_stdout
+        stderr = "".join(execution.logs.stderr)
+        return CommandResult(stdout=stdout, stderr=stderr, exit_code=exit_code)

--- a/sdk/python/cubesandbox/_config.py
+++ b/sdk/python/cubesandbox/_config.py
@@ -1,0 +1,33 @@
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+
+
+@dataclass
+class Config:
+    """SDK configuration. All fields can be set via environment variables."""
+
+    api_url: str = field(
+        default_factory=lambda: os.environ.get("CUBE_API_URL", "http://127.0.0.1:3000")
+    )
+    template_id: str | None = field(
+        default_factory=lambda: os.environ.get("CUBE_TEMPLATE_ID")
+    )
+    proxy_node_ip: str | None = field(
+        default_factory=lambda: os.environ.get("CUBE_PROXY_NODE_IP")
+    )
+    proxy_port: int = field(
+        default_factory=lambda: int(os.environ.get("CUBE_PROXY_PORT_HTTP", "80"))
+    )
+    sandbox_domain: str = field(
+        default_factory=lambda: os.environ.get("CUBE_SANDBOX_DOMAIN", "cube.app")
+    )
+    timeout: int = 300
+    request_timeout: float = 30.0
+
+    def __post_init__(self) -> None:
+        self.api_url = self.api_url.rstrip("/")

--- a/sdk/python/cubesandbox/_exceptions.py
+++ b/sdk/python/cubesandbox/_exceptions.py
@@ -1,0 +1,16 @@
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+
+class CubeSandboxError(Exception):
+    def __init__(self, message: str, status_code: int | None = None):
+        super().__init__(message)
+        self.status_code = status_code
+
+
+class SandboxNotFoundError(CubeSandboxError): ...
+class TemplateNotFoundError(CubeSandboxError): ...
+class AuthenticationError(CubeSandboxError): ...
+class ApiError(CubeSandboxError): ...

--- a/sdk/python/cubesandbox/_filesystem.py
+++ b/sdk/python/cubesandbox/_filesystem.py
@@ -1,0 +1,19 @@
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .sandbox import Sandbox
+
+
+class Filesystem:
+    def __init__(self, sandbox: "Sandbox") -> None:
+        self._sandbox = sandbox
+
+    def read(self, path: str) -> str:
+        result = self._sandbox.run_code(f"open({path!r}).read()")
+        if result.error:
+            raise IOError(f"Failed to read {path}: {result.error.value}")
+        return result.text or ""

--- a/sdk/python/cubesandbox/_models.py
+++ b/sdk/python/cubesandbox/_models.py
@@ -1,0 +1,62 @@
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import List, Optional
+
+
+@dataclass
+class Logs:
+    stdout: List[str] = field(default_factory=list)
+    stderr: List[str] = field(default_factory=list)
+
+
+@dataclass
+class ExecutionError:
+    name: str
+    value: str
+    traceback: List[str] = field(default_factory=list)
+
+
+@dataclass
+class Result:
+    text: Optional[str] = None
+    html: Optional[str] = None
+    markdown: Optional[str] = None
+    svg: Optional[str] = None
+    png: Optional[str] = None
+    jpeg: Optional[str] = None
+    pdf: Optional[str] = None
+    latex: Optional[str] = None
+    json_data: Optional[dict] = None
+    javascript: Optional[str] = None
+    is_main_result: bool = False
+    extra: Optional[dict] = None
+
+
+@dataclass
+class Execution:
+    results: List[Result] = field(default_factory=list)
+    logs: Logs = field(default_factory=Logs)
+    error: Optional[ExecutionError] = None
+    execution_count: Optional[int] = None
+
+    @property
+    def text(self) -> Optional[str]:
+        """Text of the main result (last expression value)."""
+        for r in self.results:
+            if r.is_main_result:
+                return r.text
+        return None
+
+    def __repr__(self) -> str:
+        return f"Execution(text={self.text!r}, error={self.error})"
+
+
+@dataclass
+class OutputMessage:
+    text: str
+    timestamp: str = ""
+    is_stderr: bool = False

--- a/sdk/python/cubesandbox/_stream.py
+++ b/sdk/python/cubesandbox/_stream.py
@@ -1,0 +1,64 @@
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Callable, Optional
+
+from ._models import Execution, ExecutionError, OutputMessage, Result
+
+logger = logging.getLogger(__name__)
+
+
+def _parse_line(
+    execution: Execution,
+    line: str,
+    on_stdout: Optional[Callable[[OutputMessage], None]] = None,
+    on_stderr: Optional[Callable[[OutputMessage], None]] = None,
+    on_result: Optional[Callable[[Result], None]] = None,
+    on_error: Optional[Callable[[ExecutionError], None]] = None,
+) -> None:
+    if not line:
+        return
+    try:
+        data = json.loads(line)
+    except json.JSONDecodeError:
+        logger.debug("_parse_line: malformed JSON, skipping: %r", line)
+        return
+
+    event_type = data.pop("type", None)
+
+    if event_type == "result":
+        result = Result(**{k: v for k, v in data.items() if k in Result.__dataclass_fields__})
+        execution.results.append(result)
+        if on_result:
+            on_result(result)
+
+    elif event_type == "stdout":
+        text = data.get("text", "")
+        execution.logs.stdout.append(text)
+        if on_stdout:
+            on_stdout(OutputMessage(text, data.get("timestamp", "")))
+
+    elif event_type == "stderr":
+        text = data.get("text", "")
+        execution.logs.stderr.append(text)
+        if on_stderr:
+            on_stderr(OutputMessage(text, data.get("timestamp", ""), is_stderr=True))
+
+    elif event_type == "error":
+        execution.error = ExecutionError(
+            name=data.get("name", ""),
+            value=data.get("value", ""),
+            traceback=data.get("traceback", []),
+        )
+        if on_error:
+            on_error(execution.error)
+
+    elif event_type == "number_of_executions":
+        execution.execution_count = data.get("execution_count")
+
+    else:
+        logger.debug("_parse_line: unknown event type %r, skipping", event_type)

--- a/sdk/python/cubesandbox/_transport.py
+++ b/sdk/python/cubesandbox/_transport.py
@@ -1,0 +1,56 @@
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import ssl
+
+import httpx
+
+from ._config import Config
+
+
+class IPOverrideTransport(httpx.HTTPTransport):
+    """Routes all TCP connections to a fixed IP:port while preserving the Host header.
+
+    Equivalent to ``curl --resolve host:port:ip``.
+    Used when ``CUBE_PROXY_NODE_IP`` is set to bypass DNS resolution of ``*.cube.app``.
+    """
+
+    def __init__(self, ip: str, port: int, ssl_context: ssl.SSLContext | None = None, **kw):
+        super().__init__(verify=ssl_context or True, **kw)
+        self._ip = ip
+        self._port = port
+
+    def handle_request(self, request: httpx.Request) -> httpx.Response:
+        original_host = request.url.host
+        url = request.url.copy_with(host=self._ip, port=self._port)
+        proxied = httpx.Request(
+            method=request.method,
+            url=url,
+            headers=[
+                (k, original_host if k.lower() == "host" else v)
+                for k, v in request.headers.raw
+            ],
+            content=request.content,
+        )
+        return super().handle_request(proxied)
+
+
+def build_client(config: Config) -> httpx.Client:
+    """Build an httpx client for sandbox stream requests.
+
+    When ``config.proxy_node_ip`` is set, all connections are routed directly
+    to that IP, bypassing DNS. The ``Host`` header retains the virtual hostname
+    so CubeProxy can route to the correct sandbox.
+    """
+    if config.proxy_node_ip:
+        transport = IPOverrideTransport(config.proxy_node_ip, config.proxy_port)
+    else:
+        transport = httpx.HTTPTransport()
+
+    return httpx.Client(
+        transport=transport,
+        timeout=httpx.Timeout(connect=config.request_timeout, read=None, write=30, pool=30),
+        follow_redirects=True,
+    )

--- a/sdk/python/cubesandbox/sandbox.py
+++ b/sdk/python/cubesandbox/sandbox.py
@@ -1,0 +1,408 @@
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import logging
+import time
+from typing import Any, Callable, Dict, Optional
+
+import httpx
+
+from ._commands import CommandResult, Commands
+from ._config import Config
+from ._exceptions import ApiError, AuthenticationError, CubeSandboxError, SandboxNotFoundError, TemplateNotFoundError
+from ._filesystem import Filesystem
+from ._models import Execution, ExecutionError, OutputMessage, Result
+from ._stream import _parse_line
+from ._transport import build_client
+
+logger = logging.getLogger(__name__)
+
+JUPYTER_PORT = 49999
+
+
+def _check_response(resp: httpx.Response) -> None:
+    if resp.is_success:
+        return
+    try:
+        msg = resp.json().get("message") or resp.json().get("detail") or resp.text
+    except Exception:
+        msg = resp.text or f"HTTP {resp.status_code}"
+    code = resp.status_code
+    if code in (401, 403):
+        raise AuthenticationError(msg, code)
+    if code == 404:
+        raise (TemplateNotFoundError if "template" in msg.lower() else SandboxNotFoundError)(msg, code)
+    raise ApiError(msg, code)
+
+
+class Sandbox:
+    """A CubeSandbox code execution environment.
+
+    Example::
+
+        with Sandbox.create() as sb:
+            sb.run_code("x = 1")
+            result = sb.run_code("x + 1")
+            print(result.text)   # "2"
+    """
+
+    def __init__(self, data: dict, config: Optional[Config] = None) -> None:
+        self._data = data
+        self._config = config or Config()
+        self._session = self._build_session()
+        self._client: httpx.Client | None = None
+        self._commands = Commands(self)
+        self._files = Filesystem(self)
+
+    # ── properties ───────────────────────────────────────────────────
+
+    @property
+    def sandbox_id(self) -> str:
+        return self._data["sandboxID"]
+
+    @property
+    def template_id(self) -> str:
+        return self._data["templateID"]
+
+    @property
+    def domain(self) -> str:
+        return self._data.get("domain") or self._config.sandbox_domain
+
+    def get_host(self, port: int) -> str:
+        """Return the virtual hostname for a sandbox port.
+
+        e.g. ``49999-<sandboxID>.cube.app``
+        """
+        return f"{port}-{self.sandbox_id}.{self.domain}"
+
+    @property
+    def commands(self) -> "Commands":
+        return self._commands
+
+    @property
+    def files(self) -> "Filesystem":
+        return self._files
+
+    # ── factory methods ───────────────────────────────────────────────
+
+    @classmethod
+    def create(
+        cls,
+        template: str | None = None,
+        *,
+        timeout: int | None = None,
+        env_vars: Dict[str, str] | None = None,
+        metadata: Dict[str, str] | None = None,
+        allow_internet_access: bool = True,
+        network: Dict[str, Any] | None = None,
+        config: Config | None = None,
+        **kwargs: Any,
+    ) -> "Sandbox":
+        """POST /sandboxes - Create a new sandbox.
+
+        Args:
+            template: Template ID. Falls back to ``CUBE_TEMPLATE_ID`` env var.
+            timeout: Sandbox TTL in seconds. Defaults to ``Config.timeout`` (300).
+            env_vars: Environment variables injected into the sandbox.
+            metadata: Arbitrary key-value metadata (e.g. network-policy, hostdir-mount).
+            config: SDK config. Uses default (env-based) config if omitted.
+
+        Returns:
+            A running :class:`Sandbox` instance.
+
+        Raises:
+            ValueError: If no template ID is provided.
+            ApiError: On unexpected backend error (HTTP 500).
+        """
+        cfg = config or Config()
+        tpl = template or cfg.template_id
+        if not tpl:
+            raise ValueError("template is required. Set CUBE_TEMPLATE_ID or pass template=")
+
+        payload: dict = {"templateID": tpl, "timeout": timeout or cfg.timeout}
+        if env_vars:
+            payload["envVars"] = env_vars
+        if metadata:
+            payload["metadata"] = metadata
+        if not allow_internet_access:
+            payload["allowInternetAccess"] = False
+        if network:
+            net: dict = {}
+            if "allow_out" in network:
+                net["allowOut"] = network["allow_out"]
+            if "deny_out" in network:
+                net["denyOut"] = network["deny_out"]
+            if net:
+                payload["network"] = net
+        payload.update(kwargs)
+
+        with httpx.Client(headers={"Content-Type": "application/json"}) as s:
+            resp = s.post(f"{cfg.api_url}/sandboxes", json=payload)
+        _check_response(resp)
+        return cls(resp.json(), config=cfg)
+
+    @classmethod
+    def connect(cls, sandbox_id: str, *, config: Config | None = None) -> "Sandbox":
+        """POST /sandboxes/:sandboxID/connect - Connect to an existing sandbox.
+
+        Resumes the sandbox if it is currently paused.
+
+        Args:
+            sandbox_id: Sandbox identifier.
+            config: SDK config. Uses default (env-based) config if omitted.
+
+        Returns:
+            A :class:`Sandbox` instance connected to the existing sandbox.
+
+        Raises:
+            SandboxNotFoundError: If the sandbox does not exist (HTTP 404).
+            ApiError: On unexpected backend error (HTTP 500).
+        """
+        cfg = config or Config()
+        with httpx.Client(headers={"Content-Type": "application/json"}) as s:
+            resp = s.post(
+                f"{cfg.api_url}/sandboxes/{sandbox_id}/connect",
+                json={"timeout": cfg.timeout},
+            )
+        _check_response(resp)
+        return cls(resp.json(), config=cfg)
+
+    # ── class-level API methods ───────────────────────────────────────
+
+    @classmethod
+    def list(cls, config: Config | None = None) -> list[dict]:
+        """GET /sandboxes - List all running sandboxes (v1).
+
+        Args:
+            config: SDK config. Uses default (env-based) config if omitted.
+
+        Returns:
+            A list of sandbox info dicts, each containing at least
+            ``sandboxID``, ``templateID``, and ``state`` keys.
+        """
+        cfg = config or Config()
+        with httpx.Client() as s:
+            resp = s.get(f"{cfg.api_url}/sandboxes")
+        _check_response(resp)
+        return resp.json()
+
+    @classmethod
+    def list_v2(cls, config: Config | None = None) -> list[dict]:
+        """GET /v2/sandboxes - List all running sandboxes (v2).
+
+        Supports state / metadata filtering on the server side.
+
+        Args:
+            config: SDK config. Uses default (env-based) config if omitted.
+
+        Returns:
+            A list of sandbox info dicts.
+        """
+        cfg = config or Config()
+        with httpx.Client() as s:
+            resp = s.get(f"{cfg.api_url}/v2/sandboxes")
+        _check_response(resp)
+        return resp.json()
+
+    @classmethod
+    def health(cls, config: Config | None = None) -> dict:
+        """GET /health - Check the health of the CubeAPI service.
+
+        Args:
+            config: SDK config. Uses default (env-based) config if omitted.
+
+        Returns:
+            A dict with at least a ``status`` key, e.g.
+            ``{"status": "ok", "sandboxes": 0}``.
+        """
+        cfg = config or Config()
+        with httpx.Client() as s:
+            resp = s.get(f"{cfg.api_url}/health")
+        _check_response(resp)
+        return resp.json()
+
+    # ── code execution ────────────────────────────────────────────────
+
+    def run_code(
+        self,
+        code: str,
+        *,
+        language: str | None = None,
+        on_stdout: Callable[[OutputMessage], None] | None = None,
+        on_stderr: Callable[[OutputMessage], None] | None = None,
+        on_result: Callable[[Result], None] | None = None,
+        on_error: Callable[[ExecutionError], None] | None = None,
+        envs: Dict[str, str] | None = None,
+        timeout: float | None = None,
+    ) -> Execution:
+        """POST /execute - Execute code inside the sandbox.
+
+        Streams the ndjson response from the sandbox's envd process via
+        CubeProxy. When ``CUBE_PROXY_NODE_IP`` is set, connections bypass
+        DNS resolution using :class:`IPOverrideTransport`.
+
+        Args:
+            code: Python code to execute.
+            language: Kernel language override (default: ``"python"``).
+                pass ``None`` (or omit) to use the sandbox's global namespace.
+            on_stdout: Callback invoked for each stdout event.
+            on_stderr: Callback invoked for each stderr event.
+            on_result: Callback invoked for each result event.
+            on_error: Callback invoked on execution error.
+            envs: Per-execution environment variables.
+            timeout: Read timeout in seconds (default: no timeout).
+
+        Returns:
+            :class:`Execution` with ``.text``, ``.logs``, and ``.error``.
+
+        Raises:
+            ApiError: If the execute endpoint returns HTTP 4xx/5xx.
+        """
+        if self._client is None:
+            self._client = build_client(self._config)
+
+        url = f"http://{self.get_host(JUPYTER_PORT)}/execute"
+        payload = {
+            "code": code,
+            "language": language,
+            "env_vars": envs,
+        }
+        execution = Execution()
+
+        with self._client.stream(
+            "POST", url,
+            json=payload,
+            headers={"Content-Type": "application/json"},
+            timeout=httpx.Timeout(
+                connect=self._config.request_timeout,
+                read=timeout,
+                write=30,
+                pool=30,
+            ),
+        ) as resp:
+            if resp.status_code >= 400:
+                raise ApiError(f"execute failed: HTTP {resp.status_code}", resp.status_code)
+            for line in resp.iter_lines():
+                _parse_line(execution, line,
+                            on_stdout=on_stdout, on_stderr=on_stderr,
+                            on_result=on_result, on_error=on_error)
+
+        return execution
+
+    # ── lifecycle ─────────────────────────────────────────────────────
+
+    def pause(self, *, wait: bool = True, timeout: float = 30, interval: float = 1.0) -> None:
+        """POST /sandboxes/:sandboxID/pause - Pause a sandbox.
+
+        Preserves the sandbox memory snapshot. The sandbox can be resumed
+        later via :meth:`connect`.
+
+        Args:
+            wait: If ``True`` (default), poll :meth:`get_info` until the sandbox
+                state becomes ``"paused"`` before returning.
+            timeout: Maximum seconds to wait when ``wait=True`` (default: 30).
+            interval: Polling interval in seconds (default: 1.0).
+
+        Raises:
+            SandboxNotFoundError: If the sandbox does not exist (HTTP 404).
+            ApiError: If the sandbox cannot be paused (HTTP 409) or on
+                unexpected backend error (HTTP 500).
+            TimeoutError: If ``wait=True`` and sandbox does not reach
+                ``"paused"`` state within ``timeout`` seconds.
+        """
+        resp = self._session.post(f"{self._config.api_url}/sandboxes/{self.sandbox_id}/pause")
+        _check_response(resp)
+        if wait:
+            deadline = time.monotonic() + timeout
+            while time.monotonic() < deadline:
+                if self.get_info().get("state") == "paused":
+                    return
+                time.sleep(interval)
+            raise TimeoutError(
+                f"Sandbox {self.sandbox_id!r} did not reach 'paused' state within {timeout}s"
+            )
+
+    def resume(self, timeout: int = 300) -> None:
+        """POST /sandboxes/:sandboxID/resume - Resume a paused sandbox.
+
+        .. deprecated::
+            Use :meth:`connect` instead, which auto-resumes paused sandboxes
+            and returns a fresh :class:`Sandbox` instance.
+
+        Args:
+            timeout: Sandbox TTL in seconds after resume (default: 300).
+
+        Raises:
+            SandboxNotFoundError: If the sandbox does not exist (HTTP 404).
+            ApiError: If the sandbox is already running (HTTP 409) or on
+                unexpected backend error (HTTP 500).
+        """
+        resp = self._session.post(
+            f"{self._config.api_url}/sandboxes/{self.sandbox_id}/resume",
+            json={"timeout": timeout},
+        )
+        _check_response(resp)
+
+    def kill(self) -> None:
+        """DELETE /sandboxes/:sandboxID - Destroy a sandbox.
+
+        Raises:
+            SandboxNotFoundError: If the sandbox does not exist (HTTP 404).
+            ApiError: On unexpected backend error (HTTP 500).
+        """
+        resp = self._session.delete(f"{self._config.api_url}/sandboxes/{self.sandbox_id}")
+        _check_response(resp)
+
+    def get_info(self) -> dict:
+        """GET /sandboxes/:sandboxID - Get sandbox detail.
+
+        Returns:
+            A dict containing ``sandboxID``, ``state``, ``cpuCount``,
+            ``memoryMB``, ``startedAt``, and other sandbox metadata.
+
+        Raises:
+            SandboxNotFoundError: If the sandbox does not exist (HTTP 404).
+            ApiError: On unexpected backend error (HTTP 500).
+        """
+        resp = self._session.get(f"{self._config.api_url}/sandboxes/{self.sandbox_id}")
+        _check_response(resp)
+        return resp.json()
+
+    def close(self) -> None:
+        """Close the underlying httpx streaming client.
+
+        Called automatically by :meth:`__exit__` and :meth:`__del__`.
+        Safe to call multiple times.
+        """
+        if self._client is not None:
+            self._client.close()
+            self._client = None
+        self._session.close()
+
+    # ── context manager ───────────────────────────────────────────────
+
+    def __enter__(self) -> "Sandbox":
+        return self
+
+    def __exit__(self, *_: Any) -> None:
+        try:
+            self.kill()
+        except CubeSandboxError:
+            pass
+        self.close()
+
+    def __del__(self) -> None:
+        self.close()
+
+    def __repr__(self) -> str:
+        return f"Sandbox(id={self.sandbox_id!r}, domain={self.domain!r})"
+
+    # ── internal ──────────────────────────────────────────────────────
+
+    def _build_session(self) -> httpx.Client:
+        return httpx.Client(
+            headers={"Content-Type": "application/json"},
+            base_url=self._config.api_url,
+        )

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -1,0 +1,46 @@
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.backends.legacy:build"
+
+[project]
+name = "cubesandbox"
+version = "0.1.0"
+description = "Python SDK for CubeSandbox"
+license = { text = "Apache-2.0" }
+requires-python = ">=3.9"
+dependencies = [
+    "httpx>=0.27",
+]
+
+[project.urls]
+Homepage = "https://github.com/TencentCloud/CubeSandbox"
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=7.0",
+    "pytest-cov>=4.0",
+    "mypy>=1.0",
+    "ruff>=0.4",
+]
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["cubesandbox*"]
+exclude = ["tests*", "examples*"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = "-v --tb=short"
+
+[tool.ruff]
+line-length = 100
+target-version = "py39"
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "UP"]
+ignore = ["E501"]
+
+[tool.mypy]
+python_version = "3.9"
+strict = true
+ignore_missing_imports = true

--- a/sdk/python/tests/test_sandbox.py
+++ b/sdk/python/tests/test_sandbox.py
@@ -1,0 +1,603 @@
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""
+cubesandbox SDK unit tests.
+
+All HTTP calls are intercepted via httpx.MockTransport / unittest.mock.patch
+so no real network is needed.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+
+from cubesandbox import CommandResult
+from cubesandbox._commands import Commands
+from cubesandbox._config import Config
+from cubesandbox._exceptions import (
+    ApiError,
+    AuthenticationError,
+    CubeSandboxError,
+    SandboxNotFoundError,
+    TemplateNotFoundError,
+)
+from cubesandbox._filesystem import Filesystem
+from cubesandbox._models import Execution, ExecutionError, Logs, OutputMessage, Result
+from cubesandbox._stream import _parse_line
+from cubesandbox.sandbox import Sandbox
+
+# ── helpers ───────────────────────────────────────────────────────────────────
+
+SANDBOX_ID = "sb-test-001"
+DOMAIN = "cube.app"
+SANDBOX_DATA = {
+    "sandboxID": SANDBOX_ID,
+    "templateID": "tpl-test",
+    "domain": DOMAIN,
+    "state": "running",
+    "cpuCount": 2,
+    "memoryMB": 512,
+}
+
+
+def make_config(**kwargs) -> Config:
+    defaults = dict(api_url="http://localhost:3000", template_id="tpl-test")
+    defaults.update(kwargs)
+    return Config(**defaults)
+
+
+def mock_response(body=None, status: int = 200) -> httpx.Response:
+    """Build a fake httpx.Response."""
+    if body is None:
+        content = b""
+    elif isinstance(body, (dict, list)):
+        content = json.dumps(body).encode()
+    else:
+        content = str(body).encode()
+    return httpx.Response(status_code=status, content=content)
+
+
+def make_sandbox(**data_overrides) -> Sandbox:
+    d = {**SANDBOX_DATA, **data_overrides}
+    return Sandbox(d, config=make_config())
+
+
+# ── POST /sandboxes ───────────────────────────────────────────────────────────
+
+class TestCreate:
+    def test_create_success(self):
+        with patch("httpx.Client.post", return_value=mock_response(SANDBOX_DATA, status=201)):
+            sb = Sandbox.create(config=make_config())
+        assert sb.sandbox_id == SANDBOX_ID
+
+    def test_create_missing_template_raises(self):
+        cfg = make_config(template_id=None)
+        with pytest.raises(ValueError, match="template"):
+            Sandbox.create(config=cfg)
+
+    def test_create_sends_template_and_timeout(self):
+        with patch("httpx.Client.post", return_value=mock_response(SANDBOX_DATA, status=201)) as m:
+            Sandbox.create(template="tpl-foo", timeout=600, config=make_config())
+        body = m.call_args.kwargs["json"]
+        assert body["templateID"] == "tpl-foo"
+        assert body["timeout"] == 600
+
+    def test_create_sends_env_vars(self):
+        with patch("httpx.Client.post", return_value=mock_response(SANDBOX_DATA, status=201)) as m:
+            Sandbox.create(env_vars={"FOO": "bar"}, config=make_config())
+        body = m.call_args.kwargs["json"]
+        assert body["envVars"] == {"FOO": "bar"}
+
+    def test_create_sends_metadata(self):
+        meta = {"network-policy": "deny-all"}
+        with patch("httpx.Client.post", return_value=mock_response(SANDBOX_DATA, status=201)) as m:
+            Sandbox.create(metadata=meta, config=make_config())
+        body = m.call_args.kwargs["json"]
+        assert body["metadata"] == meta
+
+    def test_create_template_not_found(self):
+        with patch("httpx.Client.post",
+                   return_value=mock_response({"message": "template not found"}, status=404)):
+            with pytest.raises(TemplateNotFoundError):
+                Sandbox.create(config=make_config())
+
+    def test_create_server_error(self):
+        with patch("httpx.Client.post",
+                   return_value=mock_response({"message": "internal error"}, status=500)):
+            with pytest.raises(ApiError):
+                Sandbox.create(config=make_config())
+
+    def test_create_allow_internet_access_false(self):
+        with patch("httpx.Client.post", return_value=mock_response(SANDBOX_DATA, status=201)) as m:
+            Sandbox.create(allow_internet_access=False, config=make_config())
+        body = m.call_args.kwargs["json"]
+        assert body["allowInternetAccess"] is False
+
+    def test_create_allow_internet_access_true_not_in_payload(self):
+        with patch("httpx.Client.post", return_value=mock_response(SANDBOX_DATA, status=201)) as m:
+            Sandbox.create(config=make_config())
+        body = m.call_args.kwargs["json"]
+        assert "allowInternetAccess" not in body
+
+    def test_create_network_allow_out(self):
+        with patch("httpx.Client.post", return_value=mock_response(SANDBOX_DATA, status=201)) as m:
+            Sandbox.create(network={"allow_out": ["8.8.8.8/32"]}, config=make_config())
+        body = m.call_args.kwargs["json"]
+        assert body["network"]["allowOut"] == ["8.8.8.8/32"]
+
+    def test_create_network_deny_out(self):
+        with patch("httpx.Client.post", return_value=mock_response(SANDBOX_DATA, status=201)) as m:
+            Sandbox.create(network={"deny_out": ["0.0.0.0/0"]}, config=make_config())
+        body = m.call_args.kwargs["json"]
+        assert body["network"]["denyOut"] == ["0.0.0.0/0"]
+
+    def test_create_network_empty_not_in_payload(self):
+        with patch("httpx.Client.post", return_value=mock_response(SANDBOX_DATA, status=201)) as m:
+            Sandbox.create(network={}, config=make_config())
+        body = m.call_args.kwargs["json"]
+        assert "network" not in body
+
+
+# ── POST /sandboxes/:id/connect ───────────────────────────────────────────────
+
+class TestConnect:
+    def test_connect_success(self):
+        with patch("httpx.Client.post", return_value=mock_response(SANDBOX_DATA)):
+            sb = Sandbox.connect(SANDBOX_ID, config=make_config())
+        assert sb.sandbox_id == SANDBOX_ID
+
+    def test_connect_not_found(self):
+        with patch("httpx.Client.post",
+                   return_value=mock_response({"message": "not found"}, status=404)):
+            with pytest.raises(SandboxNotFoundError):
+                Sandbox.connect(SANDBOX_ID, config=make_config())
+
+    def test_connect_sends_timeout(self):
+        cfg = make_config()
+        cfg.timeout = 600
+        with patch("httpx.Client.post", return_value=mock_response(SANDBOX_DATA)) as m:
+            Sandbox.connect(SANDBOX_ID, config=cfg)
+        body = m.call_args.kwargs["json"]
+        assert body["timeout"] == 600
+
+
+# ── GET /sandboxes ────────────────────────────────────────────────────────────
+
+class TestListSandboxesV1:
+    def test_list_returns_list(self):
+        data = [SANDBOX_DATA]
+        with patch("httpx.Client.get", return_value=mock_response(data)):
+            result = Sandbox.list(config=make_config())
+        assert result == data
+
+    def test_list_empty(self):
+        with patch("httpx.Client.get", return_value=mock_response([])):
+            result = Sandbox.list(config=make_config())
+        assert result == []
+
+    def test_list_calls_correct_endpoint(self):
+        with patch("httpx.Client.get", return_value=mock_response([])) as m:
+            Sandbox.list(config=make_config())
+        assert "/sandboxes" in str(m.call_args)
+
+    def test_list_server_error(self):
+        with patch("httpx.Client.get",
+                   return_value=mock_response({"message": "error"}, status=500)):
+            with pytest.raises(ApiError):
+                Sandbox.list(config=make_config())
+
+
+# ── GET /v2/sandboxes ─────────────────────────────────────────────────────────
+
+class TestListSandboxesV2:
+    def test_list_v2_returns_list(self):
+        data = [SANDBOX_DATA]
+        with patch("httpx.Client.get", return_value=mock_response(data)):
+            result = Sandbox.list_v2(config=make_config())
+        assert result == data
+
+    def test_list_v2_calls_correct_endpoint(self):
+        with patch("httpx.Client.get", return_value=mock_response([])) as m:
+            Sandbox.list_v2(config=make_config())
+        assert "/v2/sandboxes" in str(m.call_args)
+
+
+# ── GET /health ───────────────────────────────────────────────────────────────
+
+class TestHealth:
+    def test_health_ok(self):
+        with patch("httpx.Client.get",
+                   return_value=mock_response({"status": "ok", "sandboxes": 2})):
+            result = Sandbox.health(config=make_config())
+        assert result["status"] == "ok"
+        assert result["sandboxes"] == 2
+
+    def test_health_server_error(self):
+        with patch("httpx.Client.get",
+                   return_value=mock_response({"message": "error"}, status=500)):
+            with pytest.raises(ApiError):
+                Sandbox.health(config=make_config())
+
+
+# ── GET /sandboxes/:id ────────────────────────────────────────────────────────
+
+class TestGetInfo:
+    def test_get_info_success(self):
+        sb = make_sandbox()
+        info = {**SANDBOX_DATA, "state": "paused"}
+        with patch.object(sb._session, "get", return_value=mock_response(info)):
+            result = sb.get_info()
+        assert result["state"] == "paused"
+
+    def test_get_info_not_found(self):
+        sb = make_sandbox()
+        with patch.object(sb._session, "get",
+                          return_value=mock_response({"message": "not found"}, status=404)):
+            with pytest.raises(SandboxNotFoundError):
+                sb.get_info()
+
+
+# ── DELETE /sandboxes/:id ─────────────────────────────────────────────────────
+
+class TestKill:
+    def test_kill_success(self):
+        sb = make_sandbox()
+        with patch.object(sb._session, "delete", return_value=mock_response(status=204)) as m:
+            sb.kill()
+        m.assert_called_once()
+
+    def test_kill_not_found(self):
+        sb = make_sandbox()
+        with patch.object(sb._session, "delete",
+                          return_value=mock_response({"message": "not found"}, status=404)):
+            with pytest.raises(SandboxNotFoundError):
+                sb.kill()
+
+    def test_context_manager_kills_on_exit(self):
+        with patch("httpx.Client.post", return_value=mock_response(SANDBOX_DATA, status=201)):
+            sb = Sandbox.create(config=make_config())
+        with patch.object(sb._session, "delete", return_value=mock_response(status=204)) as m:
+            with sb:
+                pass
+        m.assert_called_once()
+
+    def test_context_manager_suppresses_kill_error(self):
+        with patch("httpx.Client.post", return_value=mock_response(SANDBOX_DATA, status=201)):
+            sb = Sandbox.create(config=make_config())
+        with patch.object(sb._session, "delete",
+                          return_value=mock_response({"message": "gone"}, status=404)):
+            with sb:
+                pass  # should not raise
+
+
+# ── POST /sandboxes/:id/pause ─────────────────────────────────────────────────
+
+class TestPause:
+    def test_pause_success(self):
+        sb = make_sandbox()
+        with patch.object(sb._session, "post", return_value=mock_response(status=204)):
+            sb.pause(wait=False)
+
+    def test_pause_not_found(self):
+        sb = make_sandbox()
+        with patch.object(sb._session, "post",
+                          return_value=mock_response({"message": "not found"}, status=404)):
+            with pytest.raises(SandboxNotFoundError):
+                sb.pause(wait=False)
+
+    def test_pause_wait_polls_until_paused(self):
+        sb = make_sandbox()
+        paused_info = {**SANDBOX_DATA, "state": "paused"}
+        with patch.object(sb._session, "post", return_value=mock_response(status=204)), \
+             patch.object(sb._session, "get", side_effect=[
+                 mock_response({**SANDBOX_DATA, "state": "running"}),
+                 mock_response(paused_info),
+             ]) as get_m:
+            sb.pause(wait=True, interval=0)
+        assert get_m.call_count == 2
+
+    def test_pause_wait_timeout(self):
+        sb = make_sandbox()
+        with patch.object(sb._session, "post", return_value=mock_response(status=204)), \
+             patch.object(sb._session, "get",
+                          return_value=mock_response({**SANDBOX_DATA, "state": "running"})):
+            with pytest.raises(TimeoutError):
+                sb.pause(wait=True, timeout=0, interval=0)
+
+
+# ── POST /sandboxes/:id/resume ────────────────────────────────────────────────
+
+class TestResume:
+    def test_resume_success(self):
+        sb = make_sandbox()
+        with patch.object(sb._session, "post",
+                          return_value=mock_response(SANDBOX_DATA, status=201)) as m:
+            sb.resume(timeout=120)
+        body = m.call_args.kwargs["json"]
+        assert body["timeout"] == 120
+
+    def test_resume_default_timeout(self):
+        sb = make_sandbox()
+        with patch.object(sb._session, "post",
+                          return_value=mock_response(SANDBOX_DATA, status=201)) as m:
+            sb.resume()
+        body = m.call_args.kwargs["json"]
+        assert body["timeout"] == 300
+
+    def test_resume_not_found(self):
+        sb = make_sandbox()
+        with patch.object(sb._session, "post",
+                          return_value=mock_response({"message": "not found"}, status=404)):
+            with pytest.raises(SandboxNotFoundError):
+                sb.resume()
+
+
+# ── properties / get_host ─────────────────────────────────────────────────────
+
+class TestProperties:
+    def test_get_host(self):
+        sb = make_sandbox()
+        assert sb.get_host(49999) == f"49999-{SANDBOX_ID}.{DOMAIN}"
+
+    def test_get_host_custom_port(self):
+        sb = make_sandbox()
+        assert sb.get_host(8080) == f"8080-{SANDBOX_ID}.{DOMAIN}"
+
+    def test_domain_fallback_to_config(self):
+        sb = Sandbox(
+            {**SANDBOX_DATA, "domain": ""},
+            config=make_config(sandbox_domain="mycompany.internal"),
+        )
+        assert sb.domain == "mycompany.internal"
+
+    def test_repr(self):
+        sb = make_sandbox()
+        assert SANDBOX_ID in repr(sb)
+        assert DOMAIN in repr(sb)
+
+
+# ── Execution model ───────────────────────────────────────────────────────────
+
+class TestExecutionModel:
+    def test_text_returns_main_result(self):
+        ex = Execution(results=[
+            Result(text="side",  is_main_result=False),
+            Result(text="42",    is_main_result=True),
+        ])
+        assert ex.text == "42"
+
+    def test_text_none_when_no_results(self):
+        assert Execution().text is None
+
+    def test_text_none_when_no_main(self):
+        ex = Execution(results=[Result(text="x", is_main_result=False)])
+        assert ex.text is None
+
+    def test_error_captured(self):
+        ex = Execution(error=ExecutionError("ZeroDivisionError", "division by zero"))
+        assert ex.error.name == "ZeroDivisionError"
+        assert ex.text is None
+
+    def test_logs_defaults_empty(self):
+        ex = Execution()
+        assert ex.logs.stdout == []
+        assert ex.logs.stderr == []
+
+    def test_repr_with_text(self):
+        ex = Execution(results=[Result(text="99", is_main_result=True)])
+        assert "99" in repr(ex)
+
+    def test_repr_with_error(self):
+        ex = Execution(error=ExecutionError("ValueError", "bad"))
+        assert "ValueError" in repr(ex)
+
+
+# ── _parse_line (ndjson stream) ───────────────────────────────────────────────
+
+class TestParseStream:
+    def test_parses_result(self):
+        ex = Execution()
+        _parse_line(ex, '{"type":"result","text":"2","is_main_result":true}')
+        assert ex.text == "2"
+
+    def test_parses_stdout(self):
+        ex = Execution()
+        _parse_line(ex, '{"type":"stdout","text":"hello\\n","timestamp":"t1"}')
+        assert ex.logs.stdout == ["hello\n"]
+
+    def test_parses_stderr(self):
+        ex = Execution()
+        _parse_line(ex, '{"type":"stderr","text":"warn\\n","timestamp":"t1"}')
+        assert ex.logs.stderr == ["warn\n"]
+
+    def test_parses_error(self):
+        ex = Execution()
+        _parse_line(ex, '{"type":"error","name":"ValueError","value":"bad","traceback":["l1"]}')
+        assert ex.error.name == "ValueError"
+
+    def test_parses_execution_count(self):
+        ex = Execution()
+        _parse_line(ex, '{"type":"number_of_executions","execution_count":5}')
+        assert ex.execution_count == 5
+
+    def test_ignores_bad_json(self):
+        ex = Execution()
+        _parse_line(ex, "not json at all")
+        assert ex.results == []
+
+    def test_ignores_empty_line(self):
+        ex = Execution()
+        _parse_line(ex, "")
+        assert ex.results == []
+
+    def test_ignores_unknown_type(self):
+        ex = Execution()
+        _parse_line(ex, '{"type":"unknown_event","data":"x"}')
+        assert ex.results == []
+
+    def test_stdout_callback(self):
+        ex, calls = Execution(), []
+        _parse_line(ex, '{"type":"stdout","text":"hi\\n"}',
+                    on_stdout=lambda m: calls.append(m.text))
+        assert calls == ["hi\n"]
+
+    def test_result_callback(self):
+        ex, calls = Execution(), []
+        _parse_line(ex, '{"type":"result","text":"42","is_main_result":true}',
+                    on_result=lambda r: calls.append(r.text))
+        assert calls == ["42"]
+
+    def test_error_callback(self):
+        ex, calls = Execution(), []
+        _parse_line(ex, '{"type":"error","name":"Err","value":"v","traceback":[]}',
+                    on_error=lambda e: calls.append(e.name))
+        assert calls == ["Err"]
+
+    def test_multiple_stdout_lines(self):
+        ex = Execution()
+        for i in range(3):
+            _parse_line(ex, f'{{"type":"stdout","text":"line{i}\\n"}}')
+        assert len(ex.logs.stdout) == 3
+
+    def test_multiple_results_last_main(self):
+        ex = Execution()
+        _parse_line(ex, '{"type":"result","text":"a","is_main_result":false}')
+        _parse_line(ex, '{"type":"result","text":"b","is_main_result":true}')
+        assert ex.text == "b"
+        assert len(ex.results) == 2
+
+
+# ── Config ────────────────────────────────────────────────────────────────────
+
+class TestConfig:
+    def test_defaults(self, monkeypatch):
+        for k in ("CUBE_API_URL", "CUBE_TEMPLATE_ID", "CUBE_PROXY_NODE_IP",
+                  "CUBE_PROXY_PORT_HTTP", "CUBE_SANDBOX_DOMAIN"):
+            monkeypatch.delenv(k, raising=False)
+        cfg = Config()
+        assert cfg.api_url == "http://127.0.0.1:3000"
+        assert cfg.proxy_port == 80
+        assert cfg.sandbox_domain == "cube.app"
+        assert cfg.template_id is None
+        assert cfg.proxy_node_ip is None
+
+    def test_trailing_slash_stripped(self):
+        cfg = Config(api_url="http://localhost:3000/")
+        assert cfg.api_url == "http://localhost:3000"
+
+    def test_env_override(self, monkeypatch):
+        monkeypatch.setenv("CUBE_API_URL",         "http://1.2.3.4:3000")
+        monkeypatch.setenv("CUBE_TEMPLATE_ID",     "tpl-env")
+        monkeypatch.setenv("CUBE_PROXY_NODE_IP",   "1.2.3.4")
+        monkeypatch.setenv("CUBE_PROXY_PORT_HTTP", "9090")
+        monkeypatch.setenv("CUBE_SANDBOX_DOMAIN",  "mybox.io")
+        cfg = Config()
+        assert cfg.api_url        == "http://1.2.3.4:3000"
+        assert cfg.template_id    == "tpl-env"
+        assert cfg.proxy_node_ip  == "1.2.3.4"
+        assert cfg.proxy_port     == 9090
+        assert cfg.sandbox_domain == "mybox.io"
+
+
+# ── Commands submodule ────────────────────────────────────────────────────────
+
+class TestCommands:
+    def test_run_success(self):
+        sb = make_sandbox()
+        def fake_run(code, *, timeout=None, on_stdout=None, **kw):
+            if on_stdout:
+                on_stdout(OutputMessage(text="hello\nworld\n0\n"))
+            return Execution(logs=Logs(stdout=["hello\nworld\n0\n"], stderr=[]))
+        with patch.object(sb, "run_code", side_effect=fake_run):
+            result = sb.commands.run("echo hello")
+        assert result.stdout == "hello\nworld\n"
+        assert result.exit_code == 0
+
+    def test_run_exit_code_nonzero(self):
+        sb = make_sandbox()
+        def fake_run(code, *, timeout=None, on_stdout=None, **kw):
+            if on_stdout:
+                on_stdout(OutputMessage(text="1\n"))
+            return Execution(logs=Logs(stdout=["1\n"], stderr=[]))
+        with patch.object(sb, "run_code", side_effect=fake_run):
+            result = sb.commands.run("false")
+        assert result.exit_code == 1
+
+    def test_run_timeout_forwarded(self):
+        sb = make_sandbox()
+        def fake_run(code, *, timeout=None, on_stdout=None, **kw):
+            if on_stdout:
+                on_stdout(OutputMessage(text="ok\n0\n"))
+            return Execution(logs=Logs(stdout=["ok\n0\n"], stderr=[]))
+        with patch.object(sb, "run_code", side_effect=fake_run) as m:
+            sb.commands.run("sleep 1", timeout=5.0)
+        assert m.call_args.kwargs.get("timeout") == 5.0
+
+    def test_commands_property(self):
+        assert isinstance(make_sandbox().commands, Commands)
+
+    def test_command_result_fields(self):
+        r = CommandResult(stdout="out", stderr="err", exit_code=0)
+        assert r.stdout == "out"
+        assert r.stderr == "err"
+        assert r.exit_code == 0
+
+
+# ── Filesystem submodule ──────────────────────────────────────────────────────
+
+class TestFilesystem:
+    def test_read_success(self):
+        sb = make_sandbox()
+        mock_exec = Execution(results=[Result(text="file content", is_main_result=True)])
+        with patch.object(sb, "run_code", return_value=mock_exec):
+            content = sb.files.read("/tmp/foo.txt")
+        assert content == "file content"
+
+    def test_read_empty_when_no_text(self):
+        sb = make_sandbox()
+        with patch.object(sb, "run_code", return_value=Execution()):
+            content = sb.files.read("/tmp/empty.txt")
+        assert content == ""
+
+    def test_read_raises_on_error(self):
+        sb = make_sandbox()
+        mock_exec = Execution(
+            error=ExecutionError("FileNotFoundError", "No such file or directory"),
+        )
+        with patch.object(sb, "run_code", return_value=mock_exec):
+            with pytest.raises(IOError, match="Failed to read"):
+                sb.files.read("/tmp/missing.txt")
+
+    def test_files_property(self):
+        assert isinstance(make_sandbox().files, Filesystem)
+
+
+# ── close / __del__ ───────────────────────────────────────────────────────────
+
+class TestClose:
+    def test_close_is_idempotent(self):
+        sb = make_sandbox()
+        sb.close()
+        sb.close()  # should not raise
+
+    def test_del_closes_client(self):
+        sb = make_sandbox()
+        mock_client = MagicMock()
+        sb._client = mock_client
+        sb.__del__()
+        mock_client.close.assert_called_once()
+
+
+# ── Exports ───────────────────────────────────────────────────────────────────
+
+class TestExports:
+    def test_command_result_importable(self):
+        from cubesandbox import CommandResult  # noqa: F401
+
+    def test_command_result_in_all(self):
+        import cubesandbox
+        assert "CommandResult" in cubesandbox.__all__


### PR DESCRIPTION
Add the official Python SDK for CubeSandbox under `sdk/python/`.

Replaces #156 (squashed 44 commits → 1 clean commit, added DCO Signed-off-by).

### Features
- Full alignment with CubeAPI openapi spec
- Sandbox lifecycle: `create` / `connect` / `pause` / `kill` / `list` / `health`
- `run_code()` with streaming stdout/stderr, env_vars, timeout
- `commands.run()` via Python subprocess (language=sh not supported by envd)
- `files.read()` for reading sandbox filesystem
- `CUBE_PROXY_NODE_IP` support via `IPOverrideTransport` (TCP direct connect, no DNS required)
- `allow_internet_access` / network allow/deny list params
- 12 examples aligned with official CubeAPI/examples
- `benchmark.py`: concurrent create/delete perf test (dry-run supported)
- 78/78 unit tests passing

### Structure
```
sdk/python/
├── cubesandbox/        # SDK package
├── tests/              # 78 unit tests
├── README.md
└── pyproject.toml
```