### PR TITLE
fix(cubecli): nil-deref panic in exec StdinCloser on stdin EOF

### DIFF
--- a/Cubelet/cmd/cubecli/commands/container/exec.go
+++ b/Cubelet/cmd/cubecli/commands/container/exec.go
@@ -269,10 +269,8 @@ type StdinCloser struct {
 
 func (s *StdinCloser) Read(p []byte) (int, error) {
 	n, err := s.Stdin.Read(p)
-	if err == io.EOF {
-		if s.Stdin != nil {
-			s.Closer()
-		}
+	if err == io.EOF && s.Closer != nil {
+		s.Closer()
 	}
 	return n, err
 }

--- a/Cubelet/cmd/cubecli/commands/container/exec.go
+++ b/Cubelet/cmd/cubecli/commands/container/exec.go
@@ -269,7 +269,7 @@ type StdinCloser struct {
 
 func (s *StdinCloser) Read(p []byte) (int, error) {
 	n, err := s.Stdin.Read(p)
-	if err == io.EOF && s.Closer != nil {
+	if errors.Is(err, io.EOF) && s.Closer != nil {
 		s.Closer()
 	}
 	return n, err


### PR DESCRIPTION
When `cubecli container exec` runs in a non-interactive session (e.g. a piped shell, an SSH non-tty command), `os.Stdin` returns `io.EOF` on the first Read. StdinCloser.Read then enters the cleanup branch and calls `s.Closer()`, which is always nil at this point because `stdinC.Closer` is assigned after `task.Exec(...)` returns — while the containerd cio copy goroutine has already started reading from stdinC.

Root cause: the existing guard checks the wrong field (`if s.Stdin != nil`, always true) instead of guarding the function value itself (`s.Closer`).

Fix: guard on `s.Closer != nil` so a premature EOF no longer panics. If the race still drops a CloseIO call, `defer process.Delete(cntCtx)` cleans up the FIFO, matching the existing detach-mode lifecycle.

Verified in dev-env against a running redis sandbox: before the fix, every `cubecli container exec` triggered a SIGSEGV in StdinCloser.Read; after the fix, execs complete cleanly and the shim log now emits paired `exec req ...` and `wait container ... exit code` entries that were previously missing because the client aborted mid- lifecycle.