### PR TITLE
fix(shim): use read_stderr for stderr stream forwarding

### DIFF
--- a/CubeShim/shim/src/container/exec.rs
+++ b/CubeShim/shim/src/container/exec.rs
@@ -253,7 +253,7 @@ impl Exec {
         };
         let ctx = Context::default();
         loop {
-            let res = client.read_stdout(ctx.clone(), &req).await;
+            let res = client.read_stderr(ctx.clone(), &req).await;
 
             if let Err(e) = res {
                 debugf!(


### PR DESCRIPTION
Found that commands executed via exec were missing stderr output, and sometimes stdout output was randomly split into the stderr stream. 

Investigated and discovered that the forward_stderr logic was incorrectly polling read_stdout instead of read_stderr