### PR TITLE
ci: add DCO check workflow for pull requests

### DIFF
--- a/.github/workflows/dco-check.yml
+++ b/.github/workflows/dco-check.yml
@@ -7,6 +7,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: dco-check-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   dco:
     name: Developer Certificate of Origin
@@ -27,7 +31,7 @@ jobs:
           failed=0
           while IFS= read -r sha; do
             # Skip merge commits
-            parents=$(git cat-file -p "$sha" | grep -c '^parent ')
+            parents=$(git cat-file -p "$sha" | grep -c '^parent ' || true)
             if [[ "$parents" -gt 1 ]]; then
               continue
             fi

--- a/.github/workflows/dco-check.yml
+++ b/.github/workflows/dco-check.yml
@@ -1,0 +1,55 @@
+name: DCO Check
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+
+jobs:
+  dco:
+    name: Developer Certificate of Origin
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Check DCO sign-off
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+
+          failed=0
+          while IFS= read -r sha; do
+            # Skip merge commits
+            parents=$(git cat-file -p "$sha" | grep -c '^parent ')
+            if [[ "$parents" -gt 1 ]]; then
+              continue
+            fi
+
+            message=$(git log -1 --format='%B' "$sha")
+            if ! echo "$message" | grep -qP '^Signed-off-by: .+ <.+@.+>'; then
+              echo "::error::Commit $sha is missing a valid 'Signed-off-by:' line."
+              echo "  Subject: $(git log -1 --format='%s' "$sha")"
+              echo "  Author:  $(git log -1 --format='%an <%ae>' "$sha")"
+              echo ""
+              failed=1
+            fi
+          done < <(git rev-list "$BASE_SHA".."$HEAD_SHA")
+
+          if [[ "$failed" -eq 1 ]]; then
+            echo ""
+            echo "DCO check failed. Every commit must contain:"
+            echo "  Signed-off-by: Your Name <your.email@example.com>"
+            echo ""
+            echo "Fix with: git rebase --signoff HEAD~N && git push --force-with-lease"
+            echo "See: https://developercertificate.org/"
+            exit 1
+          fi
+
+          echo "All commits have valid DCO sign-off."


### PR DESCRIPTION
## Summary

- Add a dedicated CI workflow (`.github/workflows/dco-check.yml`) that enforces the DCO requirement as a hard merge gate
- Every non-merge commit in a PR must contain a valid `Signed-off-by:` trailer, as documented in `CONTRIBUTING.md`
- Pure shell implementation (`git log` + `grep`), zero external dependencies, completes in ~5s

## Motivation

The DCO sign-off requirement is documented in `CONTRIBUTING.md` but currently only enforced via advisory AI code-review feedback. This adds a blocking CI check so non-compliant PRs cannot be merged.

## Implementation

- Iterates all commits in the PR range (`base_sha..head_sha`)
- Skips merge commits (they never carry sign-offs)
- Validates format: `Signed-off-by: Name <email@domain>`
- On failure: reports exactly which commits are missing sign-off with actionable fix instructions (`git rebase --signoff`)
- Includes concurrency group to cancel stale runs on the same PR

## Test plan

- [x] PR with valid `Signed-off-by:` — workflow passes (verified on https://github.com/staryxchen/CubeSandbox/pull/2)
- [ ] PR with missing `Signed-off-by:` — workflow fails with clear error message