### PR TITLE
fix(CubeMaster/templatecenter): serialize concurrent rootfs builds for the same artifact_id

### DIFF
--- a/CubeMaster/pkg/templatecenter/artifact_build.go
+++ b/CubeMaster/pkg/templatecenter/artifact_build.go
@@ -9,6 +9,10 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
+	"sync"
+	"time"
+
 	"github.com/google/uuid"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/constants"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/db/models"
@@ -17,9 +21,23 @@ import (
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/templatecenter/image"
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
-	"strings"
-	"time"
 )
+
+// artifactBuildLocks serializes ensureRootfsArtifact callers that target the
+// same artifactID. Without this, two templates submitted in quick succession
+// for the same image spec race on buildRootfsArtifact: both goroutines share
+// the same workDir/storeDir/ext4Path, and one goroutine's defer cleanup can
+// wipe the ext4 file while the other is still relying on it — the surviving
+// caller then reaches distributeRootfsArtifact with a partial record
+// (ext4_size_bytes=0, download_token=""), cubelet rejects the pull with
+// "invalid size:0", and the template is marked FAILED.
+//
+// The lock is keyed by artifactID (deterministic from image+spec fingerprint)
+// so only racing submits for the same image spec are serialized; different
+// images build in parallel as before. DB claimRootfsArtifactForBuild only
+// covers a short FOR UPDATE transaction and does not protect the filesystem
+// build in image.BuildExt4.
+var artifactBuildLocks sync.Map // map[string]*sync.Mutex
 
 func ensureRootfsArtifact(ctx context.Context, req *types.CreateTemplateFromImageReq, source *image.PreparedSource, downloadBaseURL string) (*models.RootfsArtifact, *types.CreateCubeSandboxReq, bool, error) {
 	var generatedReq *types.CreateCubeSandboxReq
@@ -30,6 +48,15 @@ func ensureRootfsArtifact(ctx context.Context, req *types.CreateTemplateFromImag
 	}
 	fingerprint := buildTemplateSpecFingerprintWithCA(req, source.Digest, caFingerprint)
 	artifactID := buildArtifactID(fingerprint)
+	// Serialize concurrent builds of the same artifactID. Without this, two
+	// submits of the same image spec race on workDir/storeDir/ext4Path; the
+	// losing goroutine's defer cleanup can wipe the ext4 file while the
+	// winner is still relying on it. See artifactBuildLocks comment for the
+	// full failure mode.
+	muV, _ := artifactBuildLocks.LoadOrStore(artifactID, &sync.Mutex{})
+	mu := muV.(*sync.Mutex)
+	mu.Lock()
+	defer mu.Unlock()
 	record, wasDeleted, err := findReusableRootfsArtifact(ctx, fingerprint, artifactID)
 	if err == nil && wasDeleted {
 		if restoreErr := restoreRootfsArtifact(ctx, artifactID); restoreErr != nil {

--- a/CubeMaster/pkg/templatecenter/distribution.go
+++ b/CubeMaster/pkg/templatecenter/distribution.go
@@ -140,6 +140,24 @@ func cleanupTemplateReplicasOnNodes(ctx context.Context, templateID string, repl
 }
 
 func distributeRootfsArtifact(ctx context.Context, req *types.CreateTemplateFromImageReq, generatedReq *types.CreateCubeSandboxReq, artifact *models.RootfsArtifact, templateID, jobID string) ([]*node.Node, int32, int32, int32, error) {
+	// Defense-in-depth: refuse to push a CreateImage to cubelets when the
+	// artifact record is obviously incomplete. Without this guard the call
+	// proceeds with ext4_size_bytes=0 / download_token=""; cubelet then
+	// tries to pull with an empty token against a URL that falls back to
+	// os.Hostname() (buildDownloadURL) and reports "invalid size:0", which
+	// marks the template FAILED and masks the real cause (concurrent build
+	// race; see artifactBuildLocks). Fail here with a clear diagnostic
+	// instead.
+	if artifact == nil {
+		return nil, 0, 0, 0, fmt.Errorf("distributeRootfsArtifact: artifact is nil")
+	}
+	if artifact.Status != ArtifactStatusReady || artifact.Ext4SizeBytes == 0 || strings.TrimSpace(artifact.Ext4SHA256) == "" || strings.TrimSpace(artifact.DownloadToken) == "" || strings.TrimSpace(artifact.MasterNodeIP) == "" {
+		return nil, 0, 0, 0, fmt.Errorf(
+			"artifact %s is not ready for distribution (status=%s size_bytes=%d sha256_set=%t token_set=%t master_node_ip=%q); template build likely did not complete — check cubemaster logs for buildRootfsArtifact errors",
+			artifact.ArtifactID, artifact.Status, artifact.Ext4SizeBytes,
+			strings.TrimSpace(artifact.Ext4SHA256) != "", strings.TrimSpace(artifact.DownloadToken) != "", artifact.MasterNodeIP,
+		)
+	}
 	targets, err := resolveTemplateNodes(req.InstanceType, req.DistributionScope)
 	if err != nil {
 		return nil, 0, 0, 0, err


### PR DESCRIPTION
## Motivation
  Quick-succession `cubemastercli tpl create-from-image` calls against the same OCI image spec race inside `ensureRootfsArtifact`: both goroutines resolve to the same `artifact_id`, share the same workDir/ext4Path, and one's `defer
  cleanupIntermediateArtifacts` wipes the ext4 file out from under the other. The surviving caller reaches `distributeRootfsArtifact` with a partial record (`ext4_size_bytes=0`, empty `download_token`, empty `master_node_ip`); `buildDownloadURL` falls back
   to `os.Hostname()`, and cubelet rejects the pull with `invalid size:0` — the template is marked FAILED with no clear signal of the underlying race.

  ## Changes
  - `artifactBuildLocks sync.Map` (keyed by `artifact_id`) serializes the full find-or-build flow in `ensureRootfsArtifact`. Granularity is `artifact_id` only — concurrent builds for different image specs still run in parallel.
  - Defense-in-depth guard at the top of `distributeRootfsArtifact`: refuse to push a `CreateImage` when the artifact record is obviously incomplete, returning a diagnostic error instead of relying on cubelet's opaque `invalid size:0`.

  ## Verification
  - `go build ./CubeMaster/pkg/templatecenter/...` clean
  - `go vet ./CubeMaster/pkg/templatecenter/...` clean
  - Reproduced on an internal deployment before the fix; after the fix, concurrent submits serialize as expected and no partial artifact reaches cubelet.