### PR TITLE
ci: limit push trigger to master to avoid duplicate runs on PRs

### DIFF
--- a/.github/workflows/build-builder-image.yml
+++ b/.github/workflows/build-builder-image.yml
@@ -2,6 +2,7 @@ name: Build Builder Image
 
 on:
   push:
+    branches: [master]
     paths:
       - 'docker/Dockerfile.builder'
       - '.github/workflows/build-builder-image.yml'

--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -2,6 +2,7 @@ name: Build Check
 
 on:
   push:
+    branches: [master]
     paths:
       - 'CubeAPI/**'
       - 'CubeMaster/**'

--- a/.github/workflows/build-envd-base-image.yml
+++ b/.github/workflows/build-envd-base-image.yml
@@ -2,6 +2,7 @@ name: Build envd Base Image
 
 on:
   push:
+    branches: [master]
     paths:
       - 'docker/Dockerfile.cube-base'
       - 'docker/cube-entrypoint.sh'

--- a/.github/workflows/hypervisor-integration.yaml
+++ b/.github/workflows/hypervisor-integration.yaml
@@ -2,6 +2,7 @@ name: Hypervisor Tests (x86-64)
 
 on:
   push:
+    branches: [master]
     paths:
       - 'hypervisor/**'
       - '.github/workflows/hypervisor-integration.yaml'


### PR DESCRIPTION
## Summary

Stops every CI check on PRs from being executed twice. After this fix, each affected workflow runs exactly once per PR (via `pull_request`), instead of once via `push` and once via `pull_request`.

## Why

Four workflows listen to both `push` and `pull_request` with the same `paths`. When a PR head branch is pushed (typical for Dependabot or any branch update), both events fire and produce two independent workflow runs. None of the existing `concurrency` blocks deduplicate them:

| Workflow | Concurrency status | Why it does not dedup |
|---|---|---|
| `build-check.yml` | `group: build-check-${{ github.ref }}` | `push` ref is `refs/heads/<branch>`; `pull_request` ref is `refs/pull/N/merge` — different groups |
| `build-builder-image.yml` | no concurrency block | nothing to dedup with |
| `build-envd-base-image.yml` | `group: ...${{ github.ref }}...` | same as `build-check` |
| `hypervisor-integration.yaml` | group includes `${{ github.event_name }}` | event_name itself is in the key, so push/pull_request never share a group |

Real-world examples on the Build Check workflow:

- PR #195 (Dependabot pygments bump): every `Build *` check appears twice — runs `25711649092` (event=push) and `25711650627` (event=pull_request).
- PR #196 (Dependabot grpc bump): same pattern — runs `25711913134` (push) and `25711914512` (pull_request).

The bug has existed since `build-check.yml` was first introduced in PR #61 (commit `85ab046`, 2026-04-23); it just became visible recently as Dependabot PRs piled up.

## What changed

For each of the four workflows, restrict `push` to the `master` branch only:

```yaml
on:
  push:
    branches: [master]   # added
    paths: [...]
  pull_request:
    paths: [...]
```

PR validation continues to run on `pull_request`. Direct pushes to `master` (post-merge) keep triggering builds as before.

Affected files (4 lines added in total):

- `.github/workflows/build-check.yml`
- `.github/workflows/build-builder-image.yml`
- `.github/workflows/build-envd-base-image.yml`
- `.github/workflows/hypervisor-integration.yaml`

## How to verify

This PR itself is the test case — it modifies all four workflow files, which are inside their own `paths` lists, so all four workflows will be triggered.

Note GitHub uses the **base branch** version of workflow files for `pull_request` events and the **head branch** version for `push` events. On this PR:

- `pull_request` runs use master's old config → still fire once (this is the run we want to keep).
- `push` event would use this branch's new config → skipped because the head branch is not `master`.

Net result: each workflow appears **once** in the PR checks list.

```bash
# Expect: count == 1 per workflow, events == ["pull_request"]
gh run list --branch worktree-fix-ci-double-trigger --repo TencentCloud/CubeSandbox \  --limit 50 --json event,name | \  jq 'group_by(.name) | map({name: .[0].name, count: length, events: [.[].event]})'

# Baseline (still 2 each, push + pull_request)
gh run list --branch dependabot/go_modules/network-agent/google.golang.org/grpc-1.79.3 \  --repo TencentCloud/CubeSandbox --limit 20 --json event,name
```

## Test plan

- [ ] On this PR, every workflow under "Checks" appears exactly once
- [ ] Compare against PR #195 / PR #196 to confirm 2 → 1 reduction
- [ ] After merge, a direct push of master triggers `build-check` once (`event: push, conclusion: success`)