### PR TITLE
network-agent: Bump go to 1.24.8

### DIFF
--- a/network-agent/go.mod
+++ b/network-agent/go.mod
@@ -1,6 +1,6 @@
 module github.com/tencentcloud/CubeSandbox/network-agent
 
-go 1.24.0
+go 1.24.8
 
 require (
 	github.com/cilium/ebpf v0.17.3

--- a/network-agent/go.sum
+++ b/network-agent/go.sum
@@ -49,8 +49,6 @@ github.com/jsimonetti/rtnetlink v0.0.0-20210525051524-4cc836578190/go.mod h1:NmK
 github.com/jsimonetti/rtnetlink v0.0.0-20211022192332-93da33804786/go.mod h1:v4hqbTdfQngbVSZJVWUhGE/lbTFf9jb+ygmNUDQMuOs=
 github.com/jsimonetti/rtnetlink v1.2.3 h1:JntWIxmljlDswWwebzpZCz2Aa3t2kThJ79f658zgsPU=
 github.com/jsimonetti/rtnetlink v1.2.3/go.mod h1:5r5Rj9WEseVOUzDk5RN9v0gVXbkBz9XtENwhC6PwvtU=
-github.com/jsimonetti/rtnetlink/v2 v2.0.1 h1:xda7qaHDSVOsADNouv7ukSuicKZO7GgVUCXxpaIEIlM=
-github.com/jsimonetti/rtnetlink/v2 v2.0.1/go.mod h1:7MoNYNbb3UaDHtF8udiJo/RH6VsTKP1pqKLUTVCvToE=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=


### PR DESCRIPTION
Align the network-agent module's Go directive with its cubevs dependency (CubeNet/cubevs/go.mod, go 1.24.8) and with Cubelet / CubeMaster. `go mod tidy` also drops an unused jsimonetti/rtnetlink/v2 entry from go.sum.

This fixes a breakage introduced by commit a6611761156.

Closes #201.