### PR TITLE
feat(deploy): sync cubemaster custom ports with .env config

### DIFF
--- a/configs/single-node/cubemaster.yaml
+++ b/configs/single-node/cubemaster.yaml
@@ -43,7 +43,7 @@ req_template_conf:
     {"volumes":[{"name":"tmp","volume_source":{"empty_dir":{"medium":0}}}],"containers":[{"name":"cubebox-default","envs":[{"key":"TZ","value":"Asia/Shanghai"},{"key":"TERM","value":"xterm"}],"volume_mounts":[{"name":"tmp","container_path":"/"}],"security_context":{"privileged":true,"readonly_rootfs":false,"no_new_privs":false}}],"network_type":"tap","cubevs_context":{"allowInternetAccess":true,"denyOut":["10.0.0.0/8","100.64.0.0/10","172.16.0.0/12","192.168.0.0/18"]}}
 
 ossdb_config:
-  addr: "127.0.0.1:3306"
+  addr: "127.0.0.1:__CUBE_SANDBOX_MYSQL_PORT__"
   user: "cube"
   pwd: "cube_pass"
   db_name: "cube_mvp"
@@ -55,7 +55,7 @@ ossdb_config:
   max_conn_life_time_seconds: 300
 
 instance_db_config:
-  addr: "127.0.0.1:3306"
+  addr: "127.0.0.1:__CUBE_SANDBOX_MYSQL_PORT__"
   user: "cube"
   pwd: "cube_pass"
   db_name: "cube_mvp"
@@ -67,7 +67,7 @@ instance_db_config:
   max_conn_life_time_seconds: 300
 
 redis:
-  nodes: "127.0.0.1:6379"
+  nodes: "127.0.0.1:__CUBE_SANDBOX_REDIS_PORT__"
   password: "ceuhvu123"
   db_no: 0
   max_idle: 8
@@ -76,7 +76,7 @@ redis:
   max_retry: 2
 
 redis_read:
-  nodes: "127.0.0.1:6379"
+  nodes: "127.0.0.1:__CUBE_SANDBOX_REDIS_PORT__"
   password: "ceuhvu123"
   db_no: 0
   max_idle: 8
@@ -85,7 +85,7 @@ redis_read:
   max_retry: 2
 
 redis_write:
-  nodes: "127.0.0.1:6379"
+  nodes: "127.0.0.1:__CUBE_SANDBOX_REDIS_PORT__"
   password: "ceuhvu123"
   db_no: 0
   max_idle: 8

--- a/deploy/one-click/install.sh
+++ b/deploy/one-click/install.sh
@@ -109,6 +109,20 @@ check_proxy_cert_preflight() {
   :
 }
 
+generate_cubemaster_config_ports() {
+  [[ "${DEPLOY_ROLE}" != "compute" ]] || return 0
+
+  local cfg="${PKG_ROOT}/CubeMaster/conf.yaml"
+  local mysql_port="${CUBE_SANDBOX_MYSQL_PORT:-3306}"
+  local redis_port="${CUBE_SANDBOX_REDIS_PORT:-6379}"
+
+  ensure_file "${cfg}"
+  sed -i \
+    -e "s|__CUBE_SANDBOX_MYSQL_PORT__|${mysql_port}|g" \
+    -e "s|__CUBE_SANDBOX_REDIS_PORT__|${redis_port}|g" \
+    "${cfg}"
+}
+
 check_hardware_preflight() {
   if [[ ! -e /dev/kvm ]]; then
     log "KVM is not supported or not enabled (/dev/kvm not found)."
@@ -347,6 +361,7 @@ if [[ "${DEPLOY_ROLE}" == "compute" ]]; then
   copy_dir_contents "${PKG_ROOT}/cube-image" "${INSTALL_PREFIX}/cube-image"
   copy_dir_contents "${PKG_ROOT}/scripts" "${INSTALL_PREFIX}/scripts"
 else
+  generate_cubemaster_config_ports
   cp -a "${PKG_ROOT}/." "${INSTALL_PREFIX}/"
 fi
 


### PR DESCRIPTION
Related to https://github.com/TencentCloud/CubeSandbox/issues/172

## Problem

During self-build deployment, users may change `CUBE_SANDBOX_MYSQL_PORT` or `CUBE_SANDBOX_REDIS_PORT` to avoid host port conflicts. However, CubeMaster still uses the default hardcoded addresses (`127.0.0.1:3306` and `127.0.0.1:6379`) from the static config file, causing service startup failures.

As a result, CubeMaster cannot connect to MySQL during initialization and the one-click installation fails.

## Solution

This PR patches the generated CubeMaster config during installation and synchronizes the MySQL/Redis addresses with the values provided in the one-click environment configuration.