### PR TITLE
network-agent: fix gateway MAC selection

### DIFF
--- a/network-agent/internal/service/netdevice.go
+++ b/network-agent/internal/service/netdevice.go
@@ -21,10 +21,12 @@ import (
 
 var netlinkRouteReplace = netlink.RouteReplace
 var netlinkRouteListFiltered = netlink.RouteListFiltered
+var netlinkRouteList = netlink.RouteList
 var netlinkLinkByIndex = netlink.LinkByIndex
 var netlinkLinkByName = netlink.LinkByName
 var netlinkLinkList = netlink.LinkList
 var netlinkLinkDel = netlink.LinkDel
+var netlinkNeighList = netlink.NeighList
 var unixOpen = unix.Open
 var unixClose = unix.Close
 var unixIoctlIfreq = unix.IoctlIfreq
@@ -100,16 +102,62 @@ func getGatewayMacAddr(ifName string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	neighs, err := netlink.NeighList(link.Attrs().Index, 0)
+	gatewayIP, err := defaultGatewayIP(link)
+	if err != nil {
+		return "", err
+	}
+	neighs, err := netlinkNeighList(link.Attrs().Index, netlink.FAMILY_V4)
 	if err != nil {
 		return "", err
 	}
 	for _, neigh := range neighs {
-		if neigh.Family == netlink.FAMILY_V4 && neigh.State == unix.NUD_REACHABLE {
+		if isUsableGatewayNeighbor(neigh, gatewayIP) {
 			return neigh.HardwareAddr.String(), nil
 		}
 	}
-	return "", fmt.Errorf("reachable gateway mac not found on %s", ifName)
+	return "", fmt.Errorf("gateway mac for %s via %s not found", ifName, gatewayIP.String())
+}
+
+func defaultGatewayIP(link netlink.Link) (net.IP, error) {
+	routes, err := netlinkRouteList(link, netlink.FAMILY_V4)
+	if err != nil {
+		return nil, err
+	}
+	var gatewayIP net.IP
+	var gatewayMetric int
+	for _, route := range routes {
+		if !isIPv4DefaultRoute(route.Dst) || route.Gw.To4() == nil {
+			continue
+		}
+		if gatewayIP == nil || route.Priority < gatewayMetric {
+			gatewayIP = route.Gw.To4()
+			gatewayMetric = route.Priority
+		}
+	}
+	if gatewayIP == nil {
+		return nil, fmt.Errorf("default gateway not found on %s", link.Attrs().Name)
+	}
+	return gatewayIP, nil
+}
+
+func isIPv4DefaultRoute(dst *net.IPNet) bool {
+	if dst == nil {
+		return true
+	}
+	ones, bits := dst.Mask.Size()
+	return bits == 32 && ones == 0
+}
+
+func isUsableGatewayNeighbor(neigh netlink.Neigh, gatewayIP net.IP) bool {
+	if neigh.Family != netlink.FAMILY_V4 || !neigh.IP.Equal(gatewayIP) || len(neigh.HardwareAddr) == 0 {
+		return false
+	}
+	switch neigh.State {
+	case unix.NUD_REACHABLE, unix.NUD_STALE, unix.NUD_DELAY, unix.NUD_PROBE, unix.NUD_PERMANENT:
+		return true
+	default:
+		return false
+	}
 }
 
 func getMachineDevice(ifName string) (*machineDevice, error) {

--- a/network-agent/internal/service/netdevice_test.go
+++ b/network-agent/internal/service/netdevice_test.go
@@ -6,6 +6,7 @@ package service
 
 import (
 	"net"
+	"strings"
 	"testing"
 
 	"github.com/vishvananda/netlink"
@@ -92,4 +93,262 @@ func TestEnsureRouteToCubeDevRequiresDevice(t *testing.T) {
 	if err == nil {
 		t.Fatal("ensureRouteToCubeDev error=nil, want missing device")
 	}
+}
+
+func TestGetGatewayMacAddrUsesDefaultRouteNeighbor(t *testing.T) {
+	originalLinkByName := netlinkLinkByName
+	originalRouteList := netlinkRouteList
+	originalNeighList := netlinkNeighList
+	defer func() {
+		netlinkLinkByName = originalLinkByName
+		netlinkRouteList = originalRouteList
+		netlinkNeighList = originalNeighList
+	}()
+
+	link := &netlink.Dummy{LinkAttrs: netlink.LinkAttrs{Name: "enp3s0", Index: 2}}
+	netlinkLinkByName = func(name string) (netlink.Link, error) {
+		if name != "enp3s0" {
+			t.Fatalf("LinkByName(%q), want enp3s0", name)
+		}
+		return link, nil
+	}
+	netlinkRouteList = func(gotLink netlink.Link, family int) ([]netlink.Route, error) {
+		if gotLink.Attrs().Index != 2 {
+			t.Fatalf("RouteList link index=%d, want 2", gotLink.Attrs().Index)
+		}
+		if family != netlink.FAMILY_V4 {
+			t.Fatalf("RouteList family=%d, want FAMILY_V4", family)
+		}
+		return []netlink.Route{{
+			LinkIndex: 2,
+			Gw:        net.ParseIP("10.2.0.1"),
+			Priority:  100,
+		}}, nil
+	}
+	netlinkNeighList = func(linkIndex, family int) ([]netlink.Neigh, error) {
+		if linkIndex != 2 {
+			t.Fatalf("NeighList linkIndex=%d, want 2", linkIndex)
+		}
+		if family != netlink.FAMILY_V4 {
+			t.Fatalf("NeighList family=%d, want FAMILY_V4", family)
+		}
+		return []netlink.Neigh{
+			{
+				Family:       netlink.FAMILY_V4,
+				IP:           net.ParseIP("10.2.127.241"),
+				HardwareAddr: mustParseMAC(t, "06:59:30:dd:fe:0b"),
+				State:        unix.NUD_REACHABLE,
+			},
+			{
+				Family:       netlink.FAMILY_V4,
+				IP:           net.ParseIP("10.2.0.1"),
+				HardwareAddr: mustParseMAC(t, "00:d0:4c:10:1f:a5"),
+				State:        unix.NUD_STALE,
+			},
+		}, nil
+	}
+
+	got, err := getGatewayMacAddr("enp3s0")
+	if err != nil {
+		t.Fatalf("getGatewayMacAddr error=%v", err)
+	}
+	if got != "00:d0:4c:10:1f:a5" {
+		t.Fatalf("gateway mac=%s, want 00:d0:4c:10:1f:a5", got)
+	}
+}
+
+func TestGetGatewayMacAddrRequiresDefaultRoute(t *testing.T) {
+	originalLinkByName := netlinkLinkByName
+	originalRouteList := netlinkRouteList
+	defer func() {
+		netlinkLinkByName = originalLinkByName
+		netlinkRouteList = originalRouteList
+	}()
+
+	link := &netlink.Dummy{LinkAttrs: netlink.LinkAttrs{Name: "enp3s0", Index: 2}}
+	netlinkLinkByName = func(string) (netlink.Link, error) {
+		return link, nil
+	}
+	netlinkRouteList = func(netlink.Link, int) ([]netlink.Route, error) {
+		return []netlink.Route{{
+			LinkIndex: 2,
+			Dst:       mustParseCIDR(t, "10.2.0.0/16"),
+		}}, nil
+	}
+
+	if _, err := getGatewayMacAddr("enp3s0"); err == nil {
+		t.Fatal("getGatewayMacAddr error=nil, want missing default route")
+	}
+}
+
+func TestGetGatewayMacAddrRequiresGatewayNeighbor(t *testing.T) {
+	originalLinkByName := netlinkLinkByName
+	originalRouteList := netlinkRouteList
+	originalNeighList := netlinkNeighList
+	defer func() {
+		netlinkLinkByName = originalLinkByName
+		netlinkRouteList = originalRouteList
+		netlinkNeighList = originalNeighList
+	}()
+
+	link := &netlink.Dummy{LinkAttrs: netlink.LinkAttrs{Name: "enp3s0", Index: 2}}
+	netlinkLinkByName = func(string) (netlink.Link, error) {
+		return link, nil
+	}
+	netlinkRouteList = func(netlink.Link, int) ([]netlink.Route, error) {
+		return []netlink.Route{{
+			LinkIndex: 2,
+			Gw:        net.ParseIP("10.2.0.1"),
+		}}, nil
+	}
+	netlinkNeighList = func(int, int) ([]netlink.Neigh, error) {
+		return []netlink.Neigh{{
+			Family:       netlink.FAMILY_V4,
+			IP:           net.ParseIP("10.2.127.241"),
+			HardwareAddr: mustParseMAC(t, "06:59:30:dd:fe:0b"),
+			State:        unix.NUD_REACHABLE,
+		}}, nil
+	}
+
+	_, err := getGatewayMacAddr("enp3s0")
+	if err == nil {
+		t.Fatal("getGatewayMacAddr error=nil, want missing gateway neighbor")
+	}
+	if !strings.Contains(err.Error(), "via 10.2.0.1") {
+		t.Fatalf("getGatewayMacAddr error=%q, want gateway IP", err.Error())
+	}
+}
+
+func TestGetGatewayMacAddrUsesLowestMetricDefaultRoute(t *testing.T) {
+	originalLinkByName := netlinkLinkByName
+	originalRouteList := netlinkRouteList
+	originalNeighList := netlinkNeighList
+	defer func() {
+		netlinkLinkByName = originalLinkByName
+		netlinkRouteList = originalRouteList
+		netlinkNeighList = originalNeighList
+	}()
+
+	link := &netlink.Dummy{LinkAttrs: netlink.LinkAttrs{Name: "enp3s0", Index: 2}}
+	netlinkLinkByName = func(string) (netlink.Link, error) {
+		return link, nil
+	}
+	netlinkRouteList = func(netlink.Link, int) ([]netlink.Route, error) {
+		return []netlink.Route{
+			{
+				LinkIndex: 2,
+				Gw:        net.ParseIP("10.2.0.254"),
+				Priority:  200,
+			},
+			{
+				LinkIndex: 2,
+				Gw:        net.ParseIP("10.2.0.1"),
+				Priority:  100,
+			},
+		}, nil
+	}
+	netlinkNeighList = func(int, int) ([]netlink.Neigh, error) {
+		return []netlink.Neigh{
+			{
+				Family:       netlink.FAMILY_V4,
+				IP:           net.ParseIP("10.2.0.254"),
+				HardwareAddr: mustParseMAC(t, "06:59:30:dd:fe:0b"),
+				State:        unix.NUD_REACHABLE,
+			},
+			{
+				Family:       netlink.FAMILY_V4,
+				IP:           net.ParseIP("10.2.0.1"),
+				HardwareAddr: mustParseMAC(t, "00:d0:4c:10:1f:a5"),
+				State:        unix.NUD_REACHABLE,
+			},
+		}, nil
+	}
+
+	got, err := getGatewayMacAddr("enp3s0")
+	if err != nil {
+		t.Fatalf("getGatewayMacAddr error=%v", err)
+	}
+	if got != "00:d0:4c:10:1f:a5" {
+		t.Fatalf("gateway mac=%s, want 00:d0:4c:10:1f:a5", got)
+	}
+}
+
+func TestIsUsableGatewayNeighbor(t *testing.T) {
+	gatewayIP := net.ParseIP("10.2.0.1")
+	gatewayMAC := mustParseMAC(t, "00:d0:4c:10:1f:a5")
+	for _, tc := range []struct {
+		name  string
+		neigh netlink.Neigh
+		want  bool
+	}{
+		{
+			name:  "reachable",
+			neigh: netlink.Neigh{Family: netlink.FAMILY_V4, IP: gatewayIP, HardwareAddr: gatewayMAC, State: unix.NUD_REACHABLE},
+			want:  true,
+		},
+		{
+			name:  "stale",
+			neigh: netlink.Neigh{Family: netlink.FAMILY_V4, IP: gatewayIP, HardwareAddr: gatewayMAC, State: unix.NUD_STALE},
+			want:  true,
+		},
+		{
+			name:  "delay",
+			neigh: netlink.Neigh{Family: netlink.FAMILY_V4, IP: gatewayIP, HardwareAddr: gatewayMAC, State: unix.NUD_DELAY},
+			want:  true,
+		},
+		{
+			name:  "probe",
+			neigh: netlink.Neigh{Family: netlink.FAMILY_V4, IP: gatewayIP, HardwareAddr: gatewayMAC, State: unix.NUD_PROBE},
+			want:  true,
+		},
+		{
+			name:  "permanent",
+			neigh: netlink.Neigh{Family: netlink.FAMILY_V4, IP: gatewayIP, HardwareAddr: gatewayMAC, State: unix.NUD_PERMANENT},
+			want:  true,
+		},
+		{
+			name:  "wrong ip",
+			neigh: netlink.Neigh{Family: netlink.FAMILY_V4, IP: net.ParseIP("10.2.127.241"), HardwareAddr: gatewayMAC, State: unix.NUD_REACHABLE},
+		},
+		{
+			name:  "wrong family",
+			neigh: netlink.Neigh{Family: netlink.FAMILY_V6, IP: gatewayIP, HardwareAddr: gatewayMAC, State: unix.NUD_REACHABLE},
+		},
+		{
+			name:  "empty mac",
+			neigh: netlink.Neigh{Family: netlink.FAMILY_V4, IP: gatewayIP, State: unix.NUD_REACHABLE},
+		},
+		{
+			name:  "incomplete",
+			neigh: netlink.Neigh{Family: netlink.FAMILY_V4, IP: gatewayIP, HardwareAddr: gatewayMAC, State: unix.NUD_INCOMPLETE},
+		},
+		{
+			name:  "failed",
+			neigh: netlink.Neigh{Family: netlink.FAMILY_V4, IP: gatewayIP, HardwareAddr: gatewayMAC, State: unix.NUD_FAILED},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isUsableGatewayNeighbor(tc.neigh, gatewayIP); got != tc.want {
+				t.Fatalf("isUsableGatewayNeighbor=%v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func mustParseMAC(t *testing.T, value string) net.HardwareAddr {
+	t.Helper()
+	mac, err := net.ParseMAC(value)
+	if err != nil {
+		t.Fatalf("ParseMAC(%q): %v", value, err)
+	}
+	return mac
+}
+
+func mustParseCIDR(t *testing.T, value string) *net.IPNet {
+	t.Helper()
+	_, cidr, err := net.ParseCIDR(value)
+	if err != nil {
+		t.Fatalf("ParseCIDR(%q): %v", value, err)
+	}
+	return cidr
 }


### PR DESCRIPTION
Fix CubeVS outbound traffic using a non-gateway destination MAC.

`getGatewayMacAddr()` previously returned the first reachable IPv4 neighbor on the configured node interface. When the interface has multiple reachable neighbors, network-agent can select a non-gateway MAC address and program CubeVS with the wrong L2 next hop. In that case sandbox SNAT packets leave the host NIC but do not reach the default gateway, so connections remain in `syn_sent` and eventually time out.

This resolves the gateway IP from the interface default route first, then looks up the neighbor entry for that exact gateway IP.

The PR also adds tests for a reachable non-gateway neighbor appearing before the actual gateway and for the missing default route case.

## Validation

```bash
go test -run 'TestGetGatewayMacAddr|TestEnsureRouteToCubeDev' -v ./internal/service
```

Assisted-by: Codex:GPT-5
