### PR TITLE
fix(template_image): add request_id field to prevent duplicate job creation

### DIFF
--- a/CubeMaster/pkg/base/db/models/template_image.go
+++ b/CubeMaster/pkg/base/db/models/template_image.go
@@ -37,6 +37,7 @@ type TemplateImageJob struct {
 	gorm.Model
 	JobID                   string `json:"job_id" gorm:"column:job_id"`
 	TemplateID              string `json:"template_id" gorm:"column:template_id"`
+	RequestID               string `json:"request_id" gorm:"column:request_id"`
 	AttemptNo               int32  `json:"attempt_no" gorm:"column:attempt_no"`
 	RetryOfJobID            string `json:"retry_of_job_id" gorm:"column:retry_of_job_id"`
 	Operation               string `json:"operation" gorm:"column:operation"`

--- a/CubeMaster/pkg/service/sandbox/types/types.go
+++ b/CubeMaster/pkg/service/sandbox/types/types.go
@@ -481,6 +481,7 @@ type RootfsArtifactInfo struct {
 type TemplateImageJobInfo struct {
 	JobID                   string              `json:"job_id,omitempty"`
 	TemplateID              string              `json:"template_id,omitempty"`
+	RequestID               string              `json:"request_id,omitempty"`
 	AttemptNo               int32               `json:"attempt_no,omitempty"`
 	RetryOfJobID            string              `json:"retry_of_job_id,omitempty"`
 	Operation               string              `json:"operation,omitempty"`

--- a/CubeMaster/pkg/templatecenter/template_image.go
+++ b/CubeMaster/pkg/templatecenter/template_image.go
@@ -79,6 +79,8 @@ var deleteRootfsArtifactRecord = func(ctx context.Context, artifactID string) er
 	return store.db.WithContext(ctx).Unscoped().Table(constants.RootfsArtifactTableName).
 		Where("artifact_id = ?", artifactID).Delete(&models.RootfsArtifact{}).Error
 }
+const legacyRequestIDPrefix = "legacy-"
+
 var ErrNoFailedTemplateReplicas = errors.New("no failed template replicas matched redo request")
 
 type dockerInspectImage struct {
@@ -146,6 +148,7 @@ func initTemplateImageJobTable(client *gorm.DB) error {
 			id bigint unsigned NOT NULL AUTO_INCREMENT,
 			job_id varchar(128) NOT NULL COMMENT 'job id',
 			template_id varchar(128) NOT NULL DEFAULT '' COMMENT 'template id',
+			request_id varchar(128) NOT NULL DEFAULT '' COMMENT 'idempotent request id',
 			attempt_no int NOT NULL DEFAULT 1 COMMENT 'attempt number',
 			retry_of_job_id varchar(128) NOT NULL DEFAULT '' COMMENT 'previous job id',
 			operation varchar(32) NOT NULL DEFAULT '' COMMENT 'job operation',
@@ -179,6 +182,7 @@ func initTemplateImageJobTable(client *gorm.DB) error {
 			PRIMARY KEY (id),
 			UNIQUE KEY idx_template_image_job_id (job_id),
 			UNIQUE KEY idx_template_image_template_attempt (template_id,attempt_no),
+			KEY idx_template_image_request_id (request_id),
 			KEY idx_template_image_status (status),
 			KEY idx_template_image_template_status (template_id,status)
 		) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3`).Error; err != nil {
@@ -190,8 +194,13 @@ func initTemplateImageJobTable(client *gorm.DB) error {
 
 func migrateTemplateImageJobTable(client *gorm.DB, tableName string) error {
 	jobModel := &models.TemplateImageJob{}
+	if !client.Migrator().HasColumn(jobModel, "request_id") {
+		if err := client.Exec(`ALTER TABLE ` + tableName + ` ADD COLUMN request_id varchar(128) NOT NULL DEFAULT '' AFTER template_id`).Error; err != nil {
+			return err
+		}
+	}
 	if !client.Migrator().HasColumn(jobModel, "attempt_no") {
-		if err := client.Exec(`ALTER TABLE ` + tableName + ` ADD COLUMN attempt_no int NOT NULL DEFAULT 1 AFTER template_id`).Error; err != nil {
+		if err := client.Exec(`ALTER TABLE ` + tableName + ` ADD COLUMN attempt_no int NOT NULL DEFAULT 1 AFTER request_id`).Error; err != nil {
 			return err
 		}
 	}
@@ -253,7 +262,135 @@ func migrateTemplateImageJobTable(client *gorm.DB, tableName string) error {
 			return err
 		}
 	}
+	if !client.Migrator().HasIndex(jobModel, "idx_template_image_request_id") {
+		if err := client.Exec(`ALTER TABLE ` + tableName + ` ADD KEY idx_template_image_request_id (request_id)`).Error; err != nil {
+			return err
+		}
+	}
+	if err := normalizeTemplateImageJobRequestIDs(client, tableName); err != nil {
+		return err
+	}
+	if !client.Migrator().HasIndex(jobModel, "idx_template_image_request_operation") {
+		if err := client.Exec(`ALTER TABLE ` + tableName + ` ADD UNIQUE KEY idx_template_image_request_operation (request_id,operation)`).Error; err != nil {
+			return err
+		}
+	}
 	return nil
+}
+
+func normalizeTemplateImageJobRequestIDs(client *gorm.DB, tableName string) error {
+	type requestBinding struct {
+		JobID     string
+		RequestID string
+		Operation string
+	}
+	var bindings []requestBinding
+	if err := client.Table(tableName).
+		Select("job_id, request_id, operation").
+		Order("id asc").
+		Find(&bindings).Error; err != nil {
+		return err
+	}
+	seen := make(map[string]struct{}, len(bindings))
+	for _, binding := range bindings {
+		jobID := strings.TrimSpace(binding.JobID)
+		if jobID == "" {
+			continue
+		}
+		requestID := strings.TrimSpace(binding.RequestID)
+		operation := strings.TrimSpace(binding.Operation)
+		normalized := requestID
+		switch {
+		case normalized == "":
+			normalized = legacyRequestIDPrefix + jobID
+		case hasSeenRequestBinding(seen, normalized, operation):
+			normalized = normalized + "#" + jobID
+		}
+		if normalized != requestID {
+			if err := client.Exec(`UPDATE `+tableName+` SET request_id = ? WHERE job_id = ?`, normalized, jobID).Error; err != nil {
+				return err
+			}
+		}
+		seen[requestBindingKey(normalized, operation)] = struct{}{}
+	}
+	return nil
+}
+
+func hasSeenRequestBinding(seen map[string]struct{}, requestID, operation string) bool {
+	_, ok := seen[requestBindingKey(requestID, operation)]
+	return ok
+}
+
+func requestBindingKey(requestID, operation string) string {
+	return strings.TrimSpace(requestID) + "\x00" + strings.TrimSpace(operation)
+}
+
+func nextAttemptNoFromLatest(latestAttemptNo int32) int32 {
+	if latestAttemptNo <= 0 {
+		return 2
+	}
+	return latestAttemptNo + 1
+}
+
+func distributionScopeFromTargets(targets []*node.Node) []string {
+	scope := make([]string, 0, len(targets))
+	for _, target := range targets {
+		if target == nil {
+			continue
+		}
+		scope = append(scope, target.ID())
+	}
+	return scope
+}
+
+func newRedoWorkingRequest(sourceReq *types.CreateTemplateFromImageReq, targets []*node.Node) types.CreateTemplateFromImageReq {
+	workingReq := *sourceReq
+	workingReq.Request = &types.Request{RequestID: uuid.NewString()}
+	workingReq.DistributionScope = distributionScopeFromTargets(targets)
+	return workingReq
+}
+
+func newCreateTemplateImageJobRecord(jobID string, normalized *types.CreateTemplateFromImageReq, requestSnapshot string, attemptNo int32, retryOfJobID string) *models.TemplateImageJob {
+	return &models.TemplateImageJob{
+		JobID:             jobID,
+		TemplateID:        normalized.TemplateID,
+		RequestID:         normalized.RequestID,
+		AttemptNo:         attemptNo,
+		RetryOfJobID:      retryOfJobID,
+		Operation:         JobOperationCreate,
+		SourceImageRef:    normalized.SourceImageRef,
+		WritableLayerSize: normalized.WritableLayerSize,
+		InstanceType:      normalized.InstanceType,
+		NetworkType:       normalized.NetworkType,
+		Status:            JobStatusPending,
+		Phase:             JobPhasePulling,
+		Progress:          0,
+		RequestJSON:       requestSnapshot,
+	}
+}
+
+func newRedoTemplateImageJobRecord(jobID string, normalized *types.RedoTemplateFromImageReq, latestJob *models.TemplateImageJob, sourceReq *types.CreateTemplateFromImageReq, requestSnapshot string, attemptNo int32, targetScope []string, replicas []models.TemplateReplica) *models.TemplateImageJob {
+	resumePhase := determineRedoResumePhase(latestJob, replicas)
+	return &models.TemplateImageJob{
+		JobID:             jobID,
+		TemplateID:        normalized.TemplateID,
+		RequestID:         normalized.RequestID,
+		AttemptNo:         attemptNo,
+		RetryOfJobID:      latestJob.JobID,
+		Operation:         JobOperationRedo,
+		RedoMode:          determineRedoMode(normalized),
+		RedoScopeJSON:     marshalRedoScope(targetScope),
+		ResumePhase:       resumePhase,
+		ArtifactID:        latestJob.ArtifactID,
+		SourceImageRef:    sourceReq.SourceImageRef,
+		WritableLayerSize: sourceReq.WritableLayerSize,
+		InstanceType:      sourceReq.InstanceType,
+		NetworkType:       sourceReq.NetworkType,
+		Status:            JobStatusPending,
+		Phase:             resumePhase,
+		Progress:          0,
+		RequestJSON:       requestSnapshot,
+	}
 }
 
 func SubmitTemplateFromImage(ctx context.Context, req *types.CreateTemplateFromImageReq, downloadBaseURL string) (*types.TemplateImageJobInfo, error) {
@@ -319,27 +456,10 @@ func SubmitTemplateFromImage(ctx context.Context, req *types.CreateTemplateFromI
 		}
 
 		if latestJob != nil {
-			attemptNo = latestJob.AttemptNo + 1
-			if attemptNo <= 1 {
-				attemptNo = 2
-			}
+			attemptNo = nextAttemptNoFromLatest(latestJob.AttemptNo)
 			retryOfJobID = latestJob.JobID
 		}
-		record := &models.TemplateImageJob{
-			JobID:             jobID,
-			TemplateID:        normalized.TemplateID,
-			AttemptNo:         attemptNo,
-			RetryOfJobID:      retryOfJobID,
-			Operation:         JobOperationCreate,
-			SourceImageRef:    normalized.SourceImageRef,
-			WritableLayerSize: normalized.WritableLayerSize,
-			InstanceType:      normalized.InstanceType,
-			NetworkType:       normalized.NetworkType,
-			Status:            JobStatusPending,
-			Phase:             JobPhasePulling,
-			Progress:          0,
-			RequestJSON:       requestSnapshot,
-		}
+		record := newCreateTemplateImageJobRecord(jobID, normalized, requestSnapshot, attemptNo, retryOfJobID)
 		return store.db.WithContext(ctx).Table(constants.TemplateImageJobTableName).Create(record).Error
 	}); err != nil {
 		return nil, err
@@ -395,13 +515,7 @@ func SubmitRedoTemplateFromImage(ctx context.Context, req *types.RedoTemplateFro
 		if err != nil {
 			return err
 		}
-		targetScope := make([]string, 0, len(targetNodes))
-		for _, target := range targetNodes {
-			if target == nil {
-				continue
-			}
-			targetScope = append(targetScope, target.ID())
-		}
+		targetScope := distributionScopeFromTargets(targetNodes)
 		attemptNo := latestJob.AttemptNo + 1
 		if attemptNo <= 1 {
 			attemptNo = 2
@@ -410,25 +524,7 @@ func SubmitRedoTemplateFromImage(ctx context.Context, req *types.RedoTemplateFro
 		if err != nil {
 			return err
 		}
-		redoJob = &models.TemplateImageJob{
-			JobID:             jobID,
-			TemplateID:        normalized.TemplateID,
-			AttemptNo:         attemptNo,
-			RetryOfJobID:      latestJob.JobID,
-			Operation:         JobOperationRedo,
-			RedoMode:          determineRedoMode(normalized),
-			RedoScopeJSON:     marshalRedoScope(targetScope),
-			ResumePhase:       determineRedoResumePhase(latestJob, replicas),
-			ArtifactID:        latestJob.ArtifactID,
-			SourceImageRef:    sourceReq.SourceImageRef,
-			WritableLayerSize: sourceReq.WritableLayerSize,
-			InstanceType:      sourceReq.InstanceType,
-			NetworkType:       sourceReq.NetworkType,
-			Status:            JobStatusPending,
-			Phase:             determineRedoResumePhase(latestJob, replicas),
-			Progress:          0,
-			RequestJSON:       requestSnapshot,
-		}
+		redoJob = newRedoTemplateImageJobRecord(jobID, normalized, latestJob, sourceReq, requestSnapshot, attemptNo, targetScope, replicas)
 		return store.db.WithContext(ctx).Table(constants.TemplateImageJobTableName).Create(redoJob).Error
 	}); err != nil {
 		return nil, err
@@ -1019,15 +1115,7 @@ func runRedoTemplateImageJob(ctx context.Context, jobID string, req *types.RedoT
 		failRedoTemplateImageJob(ctx, jobID, jobRecord.ResumePhase, err.Error())
 		return
 	}
-	workingReq := *sourceReq
-	workingReq.Request = &types.Request{RequestID: uuid.NewString()}
-	workingReq.DistributionScope = make([]string, 0, len(targets))
-	for _, target := range targets {
-		if target == nil {
-			continue
-		}
-		workingReq.DistributionScope = append(workingReq.DistributionScope, target.ID())
-	}
+	workingReq := newRedoWorkingRequest(sourceReq, targets)
 
 	var artifact *models.RootfsArtifact
 	resumePhase := jobRecord.ResumePhase
@@ -1068,15 +1156,7 @@ func runRedoTemplateImageJob(ctx context.Context, jobID string, req *types.RedoT
 			})
 			return
 		}
-		workingReq = *sourceReq
-		workingReq.Request = &types.Request{RequestID: uuid.NewString()}
-		workingReq.DistributionScope = make([]string, 0, len(targets))
-		for _, target := range targets {
-			if target == nil {
-				continue
-			}
-			workingReq.DistributionScope = append(workingReq.DistributionScope, target.ID())
-		}
+		workingReq = newRedoWorkingRequest(sourceReq, targets)
 		_ = generatedReq
 		_ = builtFresh
 		jobRecord.ArtifactID = artifact.ArtifactID
@@ -1958,6 +2038,7 @@ func jobModelToInfo(ctx context.Context, record *models.TemplateImageJob) (*type
 	info := &types.TemplateImageJobInfo{
 		JobID:                   record.JobID,
 		TemplateID:              record.TemplateID,
+		RequestID:               record.RequestID,
 		AttemptNo:               record.AttemptNo,
 		RetryOfJobID:            record.RetryOfJobID,
 		Operation:               record.Operation,

--- a/CubeMaster/pkg/templatecenter/template_image_test.go
+++ b/CubeMaster/pkg/templatecenter/template_image_test.go
@@ -239,6 +239,81 @@ func TestBuildTemplateSpecFingerprintUsesDNSConfig(t *testing.T) {
 	}
 }
 
+func TestNewCreateTemplateImageJobRecordPersistsRequestID(t *testing.T) {
+	record := newCreateTemplateImageJobRecord(
+		"job-1",
+		&types.CreateTemplateFromImageReq{
+			Request:           &types.Request{RequestID: "req-123"},
+			TemplateID:        "tpl-1",
+			SourceImageRef:    "docker.io/library/nginx:latest",
+			WritableLayerSize: "20Gi",
+			InstanceType:      cubeboxv1.InstanceType_cubebox.String(),
+			NetworkType:       cubeboxv1.NetworkType_tap.String(),
+		},
+		`{"template_id":"tpl-1"}`,
+		2,
+		"job-prev",
+	)
+	if record.RequestID != "req-123" {
+		t.Fatalf("RequestID=%q, want %q", record.RequestID, "req-123")
+	}
+	if record.Operation != JobOperationCreate {
+		t.Fatalf("Operation=%q, want %q", record.Operation, JobOperationCreate)
+	}
+	if record.AttemptNo != 2 {
+		t.Fatalf("AttemptNo=%d, want %d", record.AttemptNo, 2)
+	}
+	if record.RetryOfJobID != "job-prev" {
+		t.Fatalf("RetryOfJobID=%q, want %q", record.RetryOfJobID, "job-prev")
+	}
+}
+
+func TestNewRedoTemplateImageJobRecordPersistsRequestID(t *testing.T) {
+	record := newRedoTemplateImageJobRecord(
+		"job-redo-1",
+		&types.RedoTemplateFromImageReq{
+			Request:    &types.Request{RequestID: "req-redo-123"},
+			TemplateID: "tpl-1",
+			FailedOnly: true,
+		},
+		&models.TemplateImageJob{
+			JobID:      "job-prev",
+			ArtifactID: "artifact-1",
+			Phase:      JobPhaseDistributing,
+		},
+		&types.CreateTemplateFromImageReq{
+			Request:           &types.Request{RequestID: "req-create-1"},
+			TemplateID:        "tpl-1",
+			SourceImageRef:    "docker.io/library/nginx:latest",
+			WritableLayerSize: "20Gi",
+			InstanceType:      cubeboxv1.InstanceType_cubebox.String(),
+			NetworkType:       cubeboxv1.NetworkType_tap.String(),
+		},
+		`{"template_id":"tpl-1"}`,
+		3,
+		[]string{"node-a"},
+		[]models.TemplateReplica{{NodeID: "node-a", Status: ReplicaStatusFailed}},
+	)
+	if record.RequestID != "req-redo-123" {
+		t.Fatalf("RequestID=%q, want %q", record.RequestID, "req-redo-123")
+	}
+	if record.Operation != JobOperationRedo {
+		t.Fatalf("Operation=%q, want %q", record.Operation, JobOperationRedo)
+	}
+	if record.AttemptNo != 3 {
+		t.Fatalf("AttemptNo=%d, want %d", record.AttemptNo, 3)
+	}
+	if record.RetryOfJobID != "job-prev" {
+		t.Fatalf("RetryOfJobID=%q, want %q", record.RetryOfJobID, "job-prev")
+	}
+	if record.RedoMode != RedoModeFailedOnly {
+		t.Fatalf("RedoMode=%q, want %q", record.RedoMode, RedoModeFailedOnly)
+	}
+	if record.Phase == "" || record.ResumePhase == "" {
+		t.Fatalf("Phase=%q ResumePhase=%q, both should be set", record.Phase, record.ResumePhase)
+	}
+}
+
 func TestGenerateTemplateCreateRequestInjectsImmutableRootfsMetadata(t *testing.T) {
 	req := &types.CreateTemplateFromImageReq{
 		Request:           &types.Request{RequestID: "req-1"},


### PR DESCRIPTION

- Add request_id column to template_image_job table for idempotent request tracking
- Add unique index on (request_id, operation) to prevent duplicate submissions
- Implement migration logic for existing records with legacy request IDs
- Refactor job record creation into helper functions for clarity