### PR TITLE
perf: avoid SHA256 computation on every startup

### DIFF
--- a/CubeMaster/pkg/templatecenter/template_image.go
+++ b/CubeMaster/pkg/templatecenter/template_image.go
@@ -34,7 +34,7 @@ import (
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/cubelet"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/errorcode"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/service/sandbox/types"
-	"github.com/tencentcloud/CubeSandbox/cubelog"
+	CubeLog "github.com/tencentcloud/CubeSandbox/cubelog"
 	"gorm.io/gorm"
 )
 

--- a/Cubelet/internal/cube/server/images/ext4image/utils.go
+++ b/Cubelet/internal/cube/server/images/ext4image/utils.go
@@ -26,6 +26,14 @@ import (
 )
 
 func EnsurePmemFile(ctx context.Context, instanceType, imageRef string) error {
+	if err := EnsurePmemRootfs(ctx, instanceType, imageRef); err != nil {
+		return err
+	}
+	return validateArtifactRuntimeFilesPresent(ctx, instanceType, imageRef)
+}
+
+// EnsurePmemRootfs ensures the ext4 rootfs artifact exists locally.
+func EnsurePmemRootfs(ctx context.Context, instanceType, imageRef string) error {
 	if instanceType == "" || imageRef == "" {
 		return fmt.Errorf("instanceType or imageRef is empty")
 	}
@@ -56,7 +64,7 @@ func EnsurePmemFile(ctx context.Context, instanceType, imageRef string) error {
 			return fmt.Errorf("downloaded pmem file %s not exist", imagePath)
 		}
 	}
-	return ensureArtifactRuntimeFilesPresent(ctx, instanceType, imageRef)
+	return nil
 }
 
 func tryDownloadPmemFile(ctx context.Context, imagePath string, spec *cubeimages.ImageSpec) error {
@@ -117,14 +125,14 @@ func RefreshArtifactRuntimeFiles(ctx context.Context, instanceType, imageRef str
 	if err := refreshKernelFile(ctx, instanceType, imageRef); err != nil {
 		return err
 	}
-	return ensureImageVersionFile(ctx, instanceType, imageRef)
+	return refreshImageVersionFile(ctx, instanceType, imageRef)
 }
 
-func ensureArtifactRuntimeFilesPresent(ctx context.Context, instanceType, imageRef string) error {
+func validateArtifactRuntimeFilesPresent(ctx context.Context, instanceType, imageRef string) error {
 	if err := ensureKernelFilePresent(ctx, instanceType, imageRef); err != nil {
 		return err
 	}
-	return ensureImageVersionFile(ctx, instanceType, imageRef)
+	return validateImageVersionFilePresent(ctx, instanceType, imageRef)
 }
 
 func ensureKernelFilePresent(ctx context.Context, instanceType, imageRef string) error {
@@ -135,15 +143,20 @@ func refreshKernelFile(ctx context.Context, instanceType, imageRef string) error
 	return pmem.RefreshKernelFile(ctx, pmem.GetSharedKernelFilePath(), pmem.GetRawKernelFilePath(instanceType, imageRef))
 }
 
-func ensureImageVersionFile(ctx context.Context, instanceType, imageRef string) error {
+func validateImageVersionFilePresent(ctx context.Context, instanceType, imageRef string) error {
 	versionPath := pmem.GetRawImageVersionFilePath(instanceType, imageRef)
 	exist, err := fileExistsAndNonEmpty(versionPath)
 	if err != nil {
-		log.G(ctx).Warnf("image version file %s validation failed, try copy: %v", versionPath, err)
+		return fmt.Errorf("image version file %s validation failed: %v", versionPath, err)
 	}
 	if exist {
 		return nil
 	}
+	return fmt.Errorf("image version file %s not exist", versionPath)
+}
+
+func refreshImageVersionFile(ctx context.Context, instanceType, imageRef string) error {
+	versionPath := pmem.GetRawImageVersionFilePath(instanceType, imageRef)
 	sharedVersionPath := pmem.GetSharedImageVersionFilePath()
 	sharedExist, err := fileExistsAndNonEmpty(sharedVersionPath)
 	if err != nil {
@@ -155,7 +168,7 @@ func ensureImageVersionFile(ctx context.Context, instanceType, imageRef string) 
 	if err := copyLocalFileAtomically(ctx, sharedVersionPath, versionPath, "image version"); err != nil {
 		return err
 	}
-	exist, err = fileExistsAndNonEmpty(versionPath)
+	exist, err := fileExistsAndNonEmpty(versionPath)
 	if err != nil {
 		return fmt.Errorf("copied image version file %s validation failed: %v", versionPath, err)
 	}

--- a/Cubelet/internal/cube/server/images/ext4image/utils.go
+++ b/Cubelet/internal/cube/server/images/ext4image/utils.go
@@ -56,10 +56,7 @@ func EnsurePmemFile(ctx context.Context, instanceType, imageRef string) error {
 			return fmt.Errorf("downloaded pmem file %s not exist", imagePath)
 		}
 	}
-	if err := ensureKernelFile(ctx, instanceType, imageRef); err != nil {
-		return err
-	}
-	return ensureImageVersionFile(ctx, instanceType, imageRef)
+	return ensureArtifactRuntimeFilesPresent(ctx, instanceType, imageRef)
 }
 
 func tryDownloadPmemFile(ctx context.Context, imagePath string, spec *cubeimages.ImageSpec) error {
@@ -115,8 +112,27 @@ func tryDownloadPmemFile(ctx context.Context, imagePath string, spec *cubeimages
 	return nil
 }
 
-func ensureKernelFile(ctx context.Context, instanceType, imageRef string) error {
-	return pmem.SyncKernelFile(ctx, pmem.GetSharedKernelFilePath(), pmem.GetRawKernelFilePath(instanceType, imageRef))
+// RefreshArtifactRuntimeFiles rewrites runtime companion files from the current shared sources.
+func RefreshArtifactRuntimeFiles(ctx context.Context, instanceType, imageRef string) error {
+	if err := refreshKernelFile(ctx, instanceType, imageRef); err != nil {
+		return err
+	}
+	return ensureImageVersionFile(ctx, instanceType, imageRef)
+}
+
+func ensureArtifactRuntimeFilesPresent(ctx context.Context, instanceType, imageRef string) error {
+	if err := ensureKernelFilePresent(ctx, instanceType, imageRef); err != nil {
+		return err
+	}
+	return ensureImageVersionFile(ctx, instanceType, imageRef)
+}
+
+func ensureKernelFilePresent(ctx context.Context, instanceType, imageRef string) error {
+	return pmem.EnsureKernelFilePresent(ctx, pmem.GetSharedKernelFilePath(), pmem.GetRawKernelFilePath(instanceType, imageRef))
+}
+
+func refreshKernelFile(ctx context.Context, instanceType, imageRef string) error {
+	return pmem.RefreshKernelFile(ctx, pmem.GetSharedKernelFilePath(), pmem.GetRawKernelFilePath(instanceType, imageRef))
 }
 
 func ensureImageVersionFile(ctx context.Context, instanceType, imageRef string) error {

--- a/Cubelet/internal/cube/server/images/ext4image/utils_test.go
+++ b/Cubelet/internal/cube/server/images/ext4image/utils_test.go
@@ -11,10 +11,12 @@ import (
 	"path/filepath"
 	"testing"
 
+	cubeimages "github.com/tencentcloud/CubeSandbox/Cubelet/api/services/images/v1"
+	"github.com/tencentcloud/CubeSandbox/Cubelet/pkg/constants"
 	"github.com/tencentcloud/CubeSandbox/Cubelet/pkg/container/pmem"
 )
 
-func TestEnsureKernelFileRefreshesWhenSharedKernelChanges(t *testing.T) {
+func TestRefreshArtifactRuntimeFilesRefreshesKernelWhenSharedKernelChanges(t *testing.T) {
 	baseDir := t.TempDir()
 	pmem.Init(baseDir)
 
@@ -26,9 +28,16 @@ func TestEnsureKernelFileRefreshesWhenSharedKernelChanges(t *testing.T) {
 	if err := os.WriteFile(sharedKernelPath, kernelV1, 0o644); err != nil {
 		t.Fatalf("WriteFile shared kernel error=%v", err)
 	}
+	sharedVersionPath := pmem.GetSharedImageVersionFilePath()
+	if err := os.MkdirAll(filepath.Dir(sharedVersionPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll shared version dir error=%v", err)
+	}
+	if err := os.WriteFile(sharedVersionPath, []byte("2.2.0-20251010\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile shared version error=%v", err)
+	}
 
-	if err := ensureKernelFile(context.Background(), "cubebox", "artifact-1"); err != nil {
-		t.Fatalf("ensureKernelFile error=%v", err)
+	if err := RefreshArtifactRuntimeFiles(context.Background(), "cubebox", "artifact-1"); err != nil {
+		t.Fatalf("RefreshArtifactRuntimeFiles error=%v", err)
 	}
 
 	targetKernelPath := pmem.GetRawKernelFilePath("cubebox", "artifact-1")
@@ -44,8 +53,8 @@ func TestEnsureKernelFileRefreshesWhenSharedKernelChanges(t *testing.T) {
 	if err := os.WriteFile(sharedKernelPath, kernelV2, 0o644); err != nil {
 		t.Fatalf("WriteFile updated shared kernel error=%v", err)
 	}
-	if err := ensureKernelFile(context.Background(), "cubebox", "artifact-1"); err != nil {
-		t.Fatalf("ensureKernelFile second call error=%v", err)
+	if err := RefreshArtifactRuntimeFiles(context.Background(), "cubebox", "artifact-1"); err != nil {
+		t.Fatalf("RefreshArtifactRuntimeFiles second call error=%v", err)
 	}
 
 	got, err = os.ReadFile(targetKernelPath)
@@ -57,7 +66,7 @@ func TestEnsureKernelFileRefreshesWhenSharedKernelChanges(t *testing.T) {
 	}
 }
 
-func TestEnsureKernelFileRefreshesExistingTargetKernel(t *testing.T) {
+func TestEnsurePmemFilePreservesExistingKernelFile(t *testing.T) {
 	baseDir := t.TempDir()
 	pmem.Init(baseDir)
 
@@ -69,6 +78,20 @@ func TestEnsureKernelFileRefreshesExistingTargetKernel(t *testing.T) {
 	if err := os.WriteFile(sharedKernelPath, sharedKernel, 0o644); err != nil {
 		t.Fatalf("WriteFile shared kernel error=%v", err)
 	}
+	sharedVersionPath := pmem.GetSharedImageVersionFilePath()
+	if err := os.MkdirAll(filepath.Dir(sharedVersionPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll shared version dir error=%v", err)
+	}
+	if err := os.WriteFile(sharedVersionPath, []byte("2.2.0-20251010\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile shared version error=%v", err)
+	}
+	imagePath := pmem.GetRawImageFilePath("cubebox", "artifact-2")
+	if err := os.MkdirAll(filepath.Dir(imagePath), 0o755); err != nil {
+		t.Fatalf("MkdirAll image dir error=%v", err)
+	}
+	if err := os.WriteFile(imagePath, bytes.Repeat([]byte("e"), 2048), 0o644); err != nil {
+		t.Fatalf("WriteFile image error=%v", err)
+	}
 
 	targetKernelPath := pmem.GetRawKernelFilePath("cubebox", "artifact-2")
 	if err := os.MkdirAll(filepath.Dir(targetKernelPath), 0o755); err != nil {
@@ -78,27 +101,83 @@ func TestEnsureKernelFileRefreshesExistingTargetKernel(t *testing.T) {
 	if err := os.WriteFile(targetKernelPath, oldKernel, 0o644); err != nil {
 		t.Fatalf("WriteFile target kernel error=%v", err)
 	}
+	ctx := constants.WithImageSpec(context.Background(), &cubeimages.ImageSpec{
+		Annotations: map[string]string{
+			constants.MasterAnnotationRootfsArtifactURL:    "http://unused.example/artifact.ext4",
+			constants.MasterAnnotationRootfsArtifactSHA256: "deadbeef",
+		},
+	})
 
-	if err := ensureKernelFile(context.Background(), "cubebox", "artifact-2"); err != nil {
-		t.Fatalf("ensureKernelFile error=%v", err)
+	if err := EnsurePmemFile(ctx, "cubebox", "artifact-2"); err != nil {
+		t.Fatalf("EnsurePmemFile error=%v", err)
 	}
 
 	got, err := os.ReadFile(targetKernelPath)
 	if err != nil {
 		t.Fatalf("ReadFile target kernel error=%v", err)
 	}
-	if !bytes.Equal(got, sharedKernel) {
-		t.Fatal("target kernel should refresh from shared kernel")
+	if !bytes.Equal(got, oldKernel) {
+		t.Fatal("target kernel should stay unchanged when file already exists")
 	}
 }
 
-func TestEnsureKernelFileRequiresSharedKernel(t *testing.T) {
+func TestEnsurePmemFileCopiesMissingKernelFile(t *testing.T) {
 	baseDir := t.TempDir()
 	pmem.Init(baseDir)
 
-	err := ensureKernelFile(context.Background(), "cubebox", "artifact-2")
+	sharedKernelPath := pmem.GetSharedKernelFilePath()
+	if err := os.MkdirAll(filepath.Dir(sharedKernelPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll error=%v", err)
+	}
+	sharedKernel := bytes.Repeat([]byte("s"), 3072)
+	if err := os.WriteFile(sharedKernelPath, sharedKernel, 0o644); err != nil {
+		t.Fatalf("WriteFile shared kernel error=%v", err)
+	}
+	sharedVersionPath := pmem.GetSharedImageVersionFilePath()
+	if err := os.MkdirAll(filepath.Dir(sharedVersionPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll shared version dir error=%v", err)
+	}
+	versionData := []byte("2.2.0-20251010\n")
+	if err := os.WriteFile(sharedVersionPath, versionData, 0o644); err != nil {
+		t.Fatalf("WriteFile shared version error=%v", err)
+	}
+	imagePath := pmem.GetRawImageFilePath("cubebox", "artifact-3")
+	if err := os.MkdirAll(filepath.Dir(imagePath), 0o755); err != nil {
+		t.Fatalf("MkdirAll image dir error=%v", err)
+	}
+	if err := os.WriteFile(imagePath, bytes.Repeat([]byte("e"), 2048), 0o644); err != nil {
+		t.Fatalf("WriteFile image error=%v", err)
+	}
+
+	if err := EnsurePmemFile(context.Background(), "cubebox", "artifact-3"); err != nil {
+		t.Fatalf("EnsurePmemFile error=%v", err)
+	}
+
+	targetKernelPath := pmem.GetRawKernelFilePath("cubebox", "artifact-3")
+	gotKernel, err := os.ReadFile(targetKernelPath)
+	if err != nil {
+		t.Fatalf("ReadFile target kernel error=%v", err)
+	}
+	if !bytes.Equal(gotKernel, sharedKernel) {
+		t.Fatal("target kernel should be copied from shared kernel when missing")
+	}
+	targetVersionPath := pmem.GetRawImageVersionFilePath("cubebox", "artifact-3")
+	gotVersion, err := os.ReadFile(targetVersionPath)
+	if err != nil {
+		t.Fatalf("ReadFile target version error=%v", err)
+	}
+	if !bytes.Equal(gotVersion, versionData) {
+		t.Fatal("target version should be copied from shared version when missing")
+	}
+}
+
+func TestEnsureKernelFilePresentRequiresSharedKernel(t *testing.T) {
+	baseDir := t.TempDir()
+	pmem.Init(baseDir)
+
+	err := ensureKernelFilePresent(context.Background(), "cubebox", "artifact-2")
 	if err == nil {
-		t.Fatal("ensureKernelFile error=nil, want non-nil")
+		t.Fatal("ensureKernelFilePresent error=nil, want non-nil")
 	}
 }
 

--- a/Cubelet/internal/cube/server/images/ext4image/utils_test.go
+++ b/Cubelet/internal/cube/server/images/ext4image/utils_test.go
@@ -16,25 +16,48 @@ import (
 	"github.com/tencentcloud/CubeSandbox/Cubelet/pkg/container/pmem"
 )
 
+func writeTestFile(t *testing.T, path string, content []byte) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("MkdirAll %s error=%v", path, err)
+	}
+	if err := os.WriteFile(path, content, 0o644); err != nil {
+		t.Fatalf("WriteFile %s error=%v", path, err)
+	}
+}
+
+func writeSharedKernelFile(t *testing.T, content []byte) {
+	t.Helper()
+	writeTestFile(t, pmem.GetSharedKernelFilePath(), content)
+}
+
+func writeSharedVersionFile(t *testing.T, version string) {
+	t.Helper()
+	writeTestFile(t, pmem.GetSharedImageVersionFilePath(), []byte(version))
+}
+
+func writeRawImageFile(t *testing.T, instanceType, imageRef string, content []byte) {
+	t.Helper()
+	writeTestFile(t, pmem.GetRawImageFilePath(instanceType, imageRef), content)
+}
+
+func writeRawKernelFile(t *testing.T, instanceType, imageRef string, content []byte) {
+	t.Helper()
+	writeTestFile(t, pmem.GetRawKernelFilePath(instanceType, imageRef), content)
+}
+
+func writeRawVersionFile(t *testing.T, instanceType, imageRef, version string) {
+	t.Helper()
+	writeTestFile(t, pmem.GetRawImageVersionFilePath(instanceType, imageRef), []byte(version))
+}
+
 func TestRefreshArtifactRuntimeFilesRefreshesKernelWhenSharedKernelChanges(t *testing.T) {
 	baseDir := t.TempDir()
 	pmem.Init(baseDir)
 
-	sharedKernelPath := pmem.GetSharedKernelFilePath()
-	if err := os.MkdirAll(filepath.Dir(sharedKernelPath), 0o755); err != nil {
-		t.Fatalf("MkdirAll error=%v", err)
-	}
 	kernelV1 := bytes.Repeat([]byte("a"), 2048)
-	if err := os.WriteFile(sharedKernelPath, kernelV1, 0o644); err != nil {
-		t.Fatalf("WriteFile shared kernel error=%v", err)
-	}
-	sharedVersionPath := pmem.GetSharedImageVersionFilePath()
-	if err := os.MkdirAll(filepath.Dir(sharedVersionPath), 0o755); err != nil {
-		t.Fatalf("MkdirAll shared version dir error=%v", err)
-	}
-	if err := os.WriteFile(sharedVersionPath, []byte("2.2.0-20251010\n"), 0o644); err != nil {
-		t.Fatalf("WriteFile shared version error=%v", err)
-	}
+	writeSharedKernelFile(t, kernelV1)
+	writeSharedVersionFile(t, "2.2.0-20251010\n")
 
 	if err := RefreshArtifactRuntimeFiles(context.Background(), "cubebox", "artifact-1"); err != nil {
 		t.Fatalf("RefreshArtifactRuntimeFiles error=%v", err)
@@ -50,9 +73,7 @@ func TestRefreshArtifactRuntimeFilesRefreshesKernelWhenSharedKernelChanges(t *te
 	}
 
 	kernelV2 := bytes.Repeat([]byte("b"), 4096)
-	if err := os.WriteFile(sharedKernelPath, kernelV2, 0o644); err != nil {
-		t.Fatalf("WriteFile updated shared kernel error=%v", err)
-	}
+	writeSharedKernelFile(t, kernelV2)
 	if err := RefreshArtifactRuntimeFiles(context.Background(), "cubebox", "artifact-1"); err != nil {
 		t.Fatalf("RefreshArtifactRuntimeFiles second call error=%v", err)
 	}
@@ -66,47 +87,24 @@ func TestRefreshArtifactRuntimeFilesRefreshesKernelWhenSharedKernelChanges(t *te
 	}
 }
 
-func TestEnsurePmemFilePreservesExistingKernelFile(t *testing.T) {
+func TestEnsurePmemFilePreservesExistingRuntimeFiles(t *testing.T) {
 	baseDir := t.TempDir()
 	pmem.Init(baseDir)
 
-	sharedKernelPath := pmem.GetSharedKernelFilePath()
-	if err := os.MkdirAll(filepath.Dir(sharedKernelPath), 0o755); err != nil {
-		t.Fatalf("MkdirAll error=%v", err)
-	}
-	sharedKernel := bytes.Repeat([]byte("s"), 3072)
-	if err := os.WriteFile(sharedKernelPath, sharedKernel, 0o644); err != nil {
-		t.Fatalf("WriteFile shared kernel error=%v", err)
-	}
-	sharedVersionPath := pmem.GetSharedImageVersionFilePath()
-	if err := os.MkdirAll(filepath.Dir(sharedVersionPath), 0o755); err != nil {
-		t.Fatalf("MkdirAll shared version dir error=%v", err)
-	}
-	if err := os.WriteFile(sharedVersionPath, []byte("2.2.0-20251010\n"), 0o644); err != nil {
-		t.Fatalf("WriteFile shared version error=%v", err)
-	}
-	imagePath := pmem.GetRawImageFilePath("cubebox", "artifact-2")
-	if err := os.MkdirAll(filepath.Dir(imagePath), 0o755); err != nil {
-		t.Fatalf("MkdirAll image dir error=%v", err)
-	}
-	if err := os.WriteFile(imagePath, bytes.Repeat([]byte("e"), 2048), 0o644); err != nil {
-		t.Fatalf("WriteFile image error=%v", err)
-	}
-
+	writeSharedKernelFile(t, bytes.Repeat([]byte("s"), 3072))
+	writeSharedVersionFile(t, "2.2.0-20251010\n")
+	writeRawImageFile(t, "cubebox", "artifact-2", bytes.Repeat([]byte("e"), 2048))
 	targetKernelPath := pmem.GetRawKernelFilePath("cubebox", "artifact-2")
-	if err := os.MkdirAll(filepath.Dir(targetKernelPath), 0o755); err != nil {
-		t.Fatalf("MkdirAll target dir error=%v", err)
-	}
 	oldKernel := bytes.Repeat([]byte("o"), 3072)
-	if err := os.WriteFile(targetKernelPath, oldKernel, 0o644); err != nil {
-		t.Fatalf("WriteFile target kernel error=%v", err)
-	}
+	writeRawKernelFile(t, "cubebox", "artifact-2", oldKernel)
 	ctx := constants.WithImageSpec(context.Background(), &cubeimages.ImageSpec{
 		Annotations: map[string]string{
 			constants.MasterAnnotationRootfsArtifactURL:    "http://unused.example/artifact.ext4",
 			constants.MasterAnnotationRootfsArtifactSHA256: "deadbeef",
 		},
 	})
+	targetVersionPath := pmem.GetRawImageVersionFilePath("cubebox", "artifact-2")
+	writeRawVersionFile(t, "cubebox", "artifact-2", "2.2.0-20251010\n")
 
 	if err := EnsurePmemFile(ctx, "cubebox", "artifact-2"); err != nil {
 		t.Fatalf("EnsurePmemFile error=%v", err)
@@ -119,55 +117,53 @@ func TestEnsurePmemFilePreservesExistingKernelFile(t *testing.T) {
 	if !bytes.Equal(got, oldKernel) {
 		t.Fatal("target kernel should stay unchanged when file already exists")
 	}
-}
-
-func TestEnsurePmemFileCopiesMissingKernelFile(t *testing.T) {
-	baseDir := t.TempDir()
-	pmem.Init(baseDir)
-
-	sharedKernelPath := pmem.GetSharedKernelFilePath()
-	if err := os.MkdirAll(filepath.Dir(sharedKernelPath), 0o755); err != nil {
-		t.Fatalf("MkdirAll error=%v", err)
-	}
-	sharedKernel := bytes.Repeat([]byte("s"), 3072)
-	if err := os.WriteFile(sharedKernelPath, sharedKernel, 0o644); err != nil {
-		t.Fatalf("WriteFile shared kernel error=%v", err)
-	}
-	sharedVersionPath := pmem.GetSharedImageVersionFilePath()
-	if err := os.MkdirAll(filepath.Dir(sharedVersionPath), 0o755); err != nil {
-		t.Fatalf("MkdirAll shared version dir error=%v", err)
-	}
-	versionData := []byte("2.2.0-20251010\n")
-	if err := os.WriteFile(sharedVersionPath, versionData, 0o644); err != nil {
-		t.Fatalf("WriteFile shared version error=%v", err)
-	}
-	imagePath := pmem.GetRawImageFilePath("cubebox", "artifact-3")
-	if err := os.MkdirAll(filepath.Dir(imagePath), 0o755); err != nil {
-		t.Fatalf("MkdirAll image dir error=%v", err)
-	}
-	if err := os.WriteFile(imagePath, bytes.Repeat([]byte("e"), 2048), 0o644); err != nil {
-		t.Fatalf("WriteFile image error=%v", err)
-	}
-
-	if err := EnsurePmemFile(context.Background(), "cubebox", "artifact-3"); err != nil {
-		t.Fatalf("EnsurePmemFile error=%v", err)
-	}
-
-	targetKernelPath := pmem.GetRawKernelFilePath("cubebox", "artifact-3")
-	gotKernel, err := os.ReadFile(targetKernelPath)
-	if err != nil {
-		t.Fatalf("ReadFile target kernel error=%v", err)
-	}
-	if !bytes.Equal(gotKernel, sharedKernel) {
-		t.Fatal("target kernel should be copied from shared kernel when missing")
-	}
-	targetVersionPath := pmem.GetRawImageVersionFilePath("cubebox", "artifact-3")
 	gotVersion, err := os.ReadFile(targetVersionPath)
 	if err != nil {
 		t.Fatalf("ReadFile target version error=%v", err)
 	}
-	if !bytes.Equal(gotVersion, versionData) {
-		t.Fatal("target version should be copied from shared version when missing")
+	if !bytes.Equal(gotVersion, []byte("2.2.0-20251010\n")) {
+		t.Fatal("target version should stay unchanged when file already exists")
+	}
+}
+
+func TestEnsurePmemFileRejectsMissingKernelFile(t *testing.T) {
+	baseDir := t.TempDir()
+	pmem.Init(baseDir)
+
+	sharedKernel := bytes.Repeat([]byte("s"), 3072)
+	writeSharedKernelFile(t, sharedKernel)
+	writeSharedVersionFile(t, "2.2.0-20251010\n")
+	writeRawImageFile(t, "cubebox", "artifact-3", bytes.Repeat([]byte("e"), 2048))
+
+	err := EnsurePmemFile(context.Background(), "cubebox", "artifact-3")
+	if err == nil {
+		t.Fatal("EnsurePmemFile error=nil, want non-nil")
+	}
+}
+
+func TestEnsurePmemRootfsDoesNotRequireKernelFile(t *testing.T) {
+	baseDir := t.TempDir()
+	pmem.Init(baseDir)
+
+	writeRawImageFile(t, "cubebox", "artifact-4", bytes.Repeat([]byte("e"), 2048))
+
+	if err := EnsurePmemRootfs(context.Background(), "cubebox", "artifact-4"); err != nil {
+		t.Fatalf("EnsurePmemRootfs error=%v", err)
+	}
+}
+
+func TestEnsurePmemFileRejectsMissingImageVersionFile(t *testing.T) {
+	baseDir := t.TempDir()
+	pmem.Init(baseDir)
+
+	writeSharedKernelFile(t, bytes.Repeat([]byte("s"), 3072))
+	writeSharedVersionFile(t, "2.2.0-20251010\n")
+	writeRawImageFile(t, "cubebox", "artifact-5", bytes.Repeat([]byte("e"), 2048))
+	writeRawKernelFile(t, "cubebox", "artifact-5", bytes.Repeat([]byte("k"), 3072))
+
+	err := EnsurePmemFile(context.Background(), "cubebox", "artifact-5")
+	if err == nil {
+		t.Fatal("EnsurePmemFile error=nil, want non-nil")
 	}
 }
 
@@ -181,21 +177,15 @@ func TestEnsureKernelFilePresentRequiresSharedKernel(t *testing.T) {
 	}
 }
 
-func TestEnsureImageVersionFileCopiesSharedVersionOnce(t *testing.T) {
+func TestRefreshImageVersionFileRefreshesSharedVersion(t *testing.T) {
 	baseDir := t.TempDir()
 	pmem.Init(baseDir)
 
-	sharedVersionPath := pmem.GetSharedImageVersionFilePath()
-	if err := os.MkdirAll(filepath.Dir(sharedVersionPath), 0o755); err != nil {
-		t.Fatalf("MkdirAll error=%v", err)
-	}
 	versionV1 := []byte("2.2.0-20251010\n")
-	if err := os.WriteFile(sharedVersionPath, versionV1, 0o644); err != nil {
-		t.Fatalf("WriteFile shared version error=%v", err)
-	}
+	writeSharedVersionFile(t, string(versionV1))
 
-	if err := ensureImageVersionFile(context.Background(), "cubebox", "artifact-1"); err != nil {
-		t.Fatalf("ensureImageVersionFile error=%v", err)
+	if err := refreshImageVersionFile(context.Background(), "cubebox", "artifact-1"); err != nil {
+		t.Fatalf("refreshImageVersionFile error=%v", err)
 	}
 
 	targetVersionPath := pmem.GetRawImageVersionFilePath("cubebox", "artifact-1")
@@ -208,28 +198,41 @@ func TestEnsureImageVersionFileCopiesSharedVersionOnce(t *testing.T) {
 	}
 
 	versionV2 := []byte("2.2.0-20251011\n")
-	if err := os.WriteFile(sharedVersionPath, versionV2, 0o644); err != nil {
-		t.Fatalf("WriteFile updated shared version error=%v", err)
-	}
-	if err := ensureImageVersionFile(context.Background(), "cubebox", "artifact-1"); err != nil {
-		t.Fatalf("ensureImageVersionFile second call error=%v", err)
+	writeSharedVersionFile(t, string(versionV2))
+	if err := refreshImageVersionFile(context.Background(), "cubebox", "artifact-1"); err != nil {
+		t.Fatalf("refreshImageVersionFile second call error=%v", err)
 	}
 
 	got, err = os.ReadFile(targetVersionPath)
 	if err != nil {
 		t.Fatalf("ReadFile target version after second call error=%v", err)
 	}
-	if !bytes.Equal(got, versionV1) {
-		t.Fatal("target version should keep first copied content")
+	if !bytes.Equal(got, versionV2) {
+		t.Fatal("target version should refresh from shared version")
 	}
 }
 
-func TestEnsureImageVersionFileRequiresSharedVersion(t *testing.T) {
+func TestRefreshImageVersionFileRequiresSharedVersion(t *testing.T) {
 	baseDir := t.TempDir()
 	pmem.Init(baseDir)
 
-	err := ensureImageVersionFile(context.Background(), "cubebox", "artifact-2")
+	err := refreshImageVersionFile(context.Background(), "cubebox", "artifact-2")
 	if err == nil {
-		t.Fatal("ensureImageVersionFile error=nil, want non-nil")
+		t.Fatal("refreshImageVersionFile error=nil, want non-nil")
+	}
+}
+
+func TestValidateImageVersionFilePresentRequiresArtifactVersion(t *testing.T) {
+	baseDir := t.TempDir()
+	pmem.Init(baseDir)
+
+	err := validateImageVersionFilePresent(context.Background(), "cubebox", "artifact-2")
+	if err == nil {
+		t.Fatal("validateImageVersionFilePresent error=nil, want non-nil")
+	}
+
+	writeRawVersionFile(t, "cubebox", "artifact-2", "2.2.0-20251010\n")
+	if err := validateImageVersionFilePresent(context.Background(), "cubebox", "artifact-2"); err != nil {
+		t.Fatalf("validateImageVersionFilePresent error=%v", err)
 	}
 }

--- a/Cubelet/internal/cube/server/images/image_distribution_handler.go
+++ b/Cubelet/internal/cube/server/images/image_distribution_handler.go
@@ -38,14 +38,16 @@ type imageDistributionHandler struct {
 
 func defaultTemplateImageSpec(ns string, template *templatetypes.TemplateImage) *cubeimages.ImageSpec {
 	annotations := map[string]string{}
-	if template != nil && template.StorageMedia == cubeimages.ImageStorageMediaType_ext4.String() {
-		annotations[constants.MasterAnnotationInstanceType] = cubebox.InstanceType_cubebox.String()
-	}
-	var storageMedia string
-	var imageRef string
+	var (
+		storageMedia string
+		imageRef     string
+	)
 	if template != nil {
 		storageMedia = template.StorageMedia
 		imageRef = template.Image
+		if template.StorageMedia == cubeimages.ImageStorageMediaType_ext4.String() {
+			annotations[constants.MasterAnnotationInstanceType] = cubebox.InstanceType_cubebox.String()
+		}
 	}
 	return &cubeimages.ImageSpec{
 		StorageMedia: storageMedia,
@@ -60,6 +62,17 @@ func materializeDistributedTemplateRuntimeFiles(ctx context.Context, template *t
 		return nil
 	}
 	return ext4image.RefreshArtifactRuntimeFiles(ctx, cubebox.InstanceType_cubebox.String(), template.Image)
+}
+
+func ensureDistributedTemplateImage(ctx context.Context, c *CubeImageService, template *templatetypes.TemplateImage) error {
+	if template == nil {
+		return fmt.Errorf("template image is nil")
+	}
+	if template.StorageMedia == cubeimages.ImageStorageMediaType_ext4.String() {
+		return ext4image.EnsurePmemRootfs(ctx, cubebox.InstanceType_cubebox.String(), template.Image)
+	}
+	_, err := c.EnsureImage(ctx, template.Image, "", "", &runtime.PodSandboxConfig{})
+	return err
 }
 
 func (c *imageDistributionHandler) GetTaskExternObjByKey(ctx context.Context, key string) (any, error) {
@@ -120,8 +133,7 @@ func (c *imageDistributionHandler) Handle(ctx context.Context, task *distributio
 		ctx = constants.WithImageSpec(ctx, cubeSpec)
 
 		logEntry.Infof("ensuring image: %s", template.Image)
-		_, err = c.EnsureImage(ctx, template.Image, "", "", &runtime.PodSandboxConfig{})
-		if err != nil {
+		if err = ensureDistributedTemplateImage(ctx, c.CubeImageService, template); err != nil {
 			err = fmt.Errorf("ensure image failed: %w", err)
 			return
 		}

--- a/Cubelet/internal/cube/server/images/image_distribution_handler.go
+++ b/Cubelet/internal/cube/server/images/image_distribution_handler.go
@@ -9,7 +9,9 @@ import (
 	"fmt"
 
 	"github.com/containerd/containerd/v2/pkg/namespaces"
+	cubebox "github.com/tencentcloud/CubeSandbox/Cubelet/api/services/cubebox/v1"
 	cubeimages "github.com/tencentcloud/CubeSandbox/Cubelet/api/services/images/v1"
+	"github.com/tencentcloud/CubeSandbox/Cubelet/internal/cube/server/images/ext4image"
 	"github.com/tencentcloud/CubeSandbox/Cubelet/internal/cube/store/image"
 	"github.com/tencentcloud/CubeSandbox/Cubelet/pkg/constants"
 	"github.com/tencentcloud/CubeSandbox/Cubelet/pkg/controller/nodedistribution/distribution"
@@ -32,6 +34,32 @@ func afterImageRecoverForHandler(c *CubeImageService) {
 
 type imageDistributionHandler struct {
 	*CubeImageService
+}
+
+func defaultTemplateImageSpec(ns string, template *templatetypes.TemplateImage) *cubeimages.ImageSpec {
+	annotations := map[string]string{}
+	if template != nil && template.StorageMedia == cubeimages.ImageStorageMediaType_ext4.String() {
+		annotations[constants.MasterAnnotationInstanceType] = cubebox.InstanceType_cubebox.String()
+	}
+	var storageMedia string
+	var imageRef string
+	if template != nil {
+		storageMedia = template.StorageMedia
+		imageRef = template.Image
+	}
+	return &cubeimages.ImageSpec{
+		StorageMedia: storageMedia,
+		Image:        imageRef,
+		Namespace:    ns,
+		Annotations:  annotations,
+	}
+}
+
+func materializeDistributedTemplateRuntimeFiles(ctx context.Context, template *templatetypes.TemplateImage) error {
+	if template == nil || template.StorageMedia != cubeimages.ImageStorageMediaType_ext4.String() {
+		return nil
+	}
+	return ext4image.RefreshArtifactRuntimeFiles(ctx, cubebox.InstanceType_cubebox.String(), template.Image)
 }
 
 func (c *imageDistributionHandler) GetTaskExternObjByKey(ctx context.Context, key string) (any, error) {
@@ -88,17 +116,17 @@ func (c *imageDistributionHandler) Handle(ctx context.Context, task *distributio
 		})
 		ctx = log.WithLogger(ctx, logEntry)
 
-		cubeSpec := &cubeimages.ImageSpec{
-			StorageMedia: template.StorageMedia,
-			Image:        template.Image,
-			Namespace:    ns,
-		}
+		cubeSpec := defaultTemplateImageSpec(ns, template)
 		ctx = constants.WithImageSpec(ctx, cubeSpec)
 
 		logEntry.Infof("ensuring image: %s", template.Image)
 		_, err = c.EnsureImage(ctx, template.Image, "", "", &runtime.PodSandboxConfig{})
 		if err != nil {
 			err = fmt.Errorf("ensure image failed: %w", err)
+			return
+		}
+		if err = materializeDistributedTemplateRuntimeFiles(ctx, template); err != nil {
+			err = fmt.Errorf("materialize template runtime files failed: %w", err)
 			return
 		}
 

--- a/Cubelet/internal/cube/server/images/image_distribution_handler_test.go
+++ b/Cubelet/internal/cube/server/images/image_distribution_handler_test.go
@@ -19,6 +19,12 @@ import (
 	"github.com/tencentcloud/CubeSandbox/Cubelet/pkg/controller/runtemplate/templatetypes"
 )
 
+func writeImageTestFile(t *testing.T, path string, content []byte) {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	require.NoError(t, os.WriteFile(path, content, 0o644))
+}
+
 func TestDefaultTemplateImageSpecSetsExt4InstanceType(t *testing.T) {
 	spec := defaultTemplateImageSpec("test-ns", &templatetypes.TemplateImage{
 		Image:        "artifact-1",
@@ -36,16 +42,13 @@ func TestMaterializeDistributedTemplateRuntimeFilesRefreshesKernel(t *testing.T)
 		StorageMedia: cubeimages.ImageStorageMediaType_ext4.String(),
 	}
 	sharedKernelPath := pmem.GetSharedKernelFilePath()
-	require.NoError(t, os.MkdirAll(filepath.Dir(sharedKernelPath), 0o755))
-	require.NoError(t, os.WriteFile(sharedKernelPath, bytes.Repeat([]byte("s"), 4096), 0o644))
+	writeImageTestFile(t, sharedKernelPath, bytes.Repeat([]byte("s"), 4096))
 
 	sharedVersionPath := pmem.GetSharedImageVersionFilePath()
-	require.NoError(t, os.MkdirAll(filepath.Dir(sharedVersionPath), 0o755))
-	require.NoError(t, os.WriteFile(sharedVersionPath, []byte("2.2.0-20251010\n"), 0o644))
+	writeImageTestFile(t, sharedVersionPath, []byte("2.2.0-20251010\n"))
 
 	targetKernelPath := pmem.GetRawKernelFilePath(cubebox.InstanceType_cubebox.String(), template.Image)
-	require.NoError(t, os.MkdirAll(filepath.Dir(targetKernelPath), 0o755))
-	require.NoError(t, os.WriteFile(targetKernelPath, bytes.Repeat([]byte("o"), 2048), 0o644))
+	writeImageTestFile(t, targetKernelPath, bytes.Repeat([]byte("o"), 2048))
 
 	err := materializeDistributedTemplateRuntimeFiles(context.Background(), template)
 	require.NoError(t, err)
@@ -53,12 +56,31 @@ func TestMaterializeDistributedTemplateRuntimeFilesRefreshesKernel(t *testing.T)
 	gotKernel, err := os.ReadFile(targetKernelPath)
 	require.NoError(t, err)
 	require.Equal(t, bytes.Repeat([]byte("s"), 4096), gotKernel)
+
+	targetVersionPath := pmem.GetRawImageVersionFilePath(cubebox.InstanceType_cubebox.String(), template.Image)
+	gotVersion, err := os.ReadFile(targetVersionPath)
+	require.NoError(t, err)
+	require.Equal(t, []byte("2.2.0-20251010\n"), gotVersion)
 }
 
 func TestMaterializeDistributedTemplateRuntimeFilesSkipsNonExt4(t *testing.T) {
 	err := materializeDistributedTemplateRuntimeFiles(context.Background(), &templatetypes.TemplateImage{
 		Image:        "artifact-1",
 		StorageMedia: "overlayfs",
+	})
+	require.NoError(t, err)
+}
+
+func TestEnsureDistributedTemplateImageExt4DoesNotRequireKernelFile(t *testing.T) {
+	baseDir := t.TempDir()
+	pmem.Init(baseDir)
+
+	imagePath := pmem.GetRawImageFilePath(cubebox.InstanceType_cubebox.String(), "artifact-2")
+	writeImageTestFile(t, imagePath, bytes.Repeat([]byte("e"), 4096))
+
+	err := ensureDistributedTemplateImage(context.Background(), nil, &templatetypes.TemplateImage{
+		Image:        "artifact-2",
+		StorageMedia: cubeimages.ImageStorageMediaType_ext4.String(),
 	})
 	require.NoError(t, err)
 }

--- a/Cubelet/internal/cube/server/images/image_distribution_handler_test.go
+++ b/Cubelet/internal/cube/server/images/image_distribution_handler_test.go
@@ -1,0 +1,64 @@
+// Copyright (c) 2024 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package images
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	cubebox "github.com/tencentcloud/CubeSandbox/Cubelet/api/services/cubebox/v1"
+	cubeimages "github.com/tencentcloud/CubeSandbox/Cubelet/api/services/images/v1"
+	"github.com/stretchr/testify/require"
+	"github.com/tencentcloud/CubeSandbox/Cubelet/pkg/constants"
+	"github.com/tencentcloud/CubeSandbox/Cubelet/pkg/container/pmem"
+	"github.com/tencentcloud/CubeSandbox/Cubelet/pkg/controller/runtemplate/templatetypes"
+)
+
+func TestDefaultTemplateImageSpecSetsExt4InstanceType(t *testing.T) {
+	spec := defaultTemplateImageSpec("test-ns", &templatetypes.TemplateImage{
+		Image:        "artifact-1",
+		StorageMedia: cubeimages.ImageStorageMediaType_ext4.String(),
+	})
+	require.Equal(t, cubebox.InstanceType_cubebox.String(), spec.Annotations[constants.MasterAnnotationInstanceType])
+}
+
+func TestMaterializeDistributedTemplateRuntimeFilesRefreshesKernel(t *testing.T) {
+	baseDir := t.TempDir()
+	pmem.Init(baseDir)
+
+	template := &templatetypes.TemplateImage{
+		Image:        "artifact-1",
+		StorageMedia: cubeimages.ImageStorageMediaType_ext4.String(),
+	}
+	sharedKernelPath := pmem.GetSharedKernelFilePath()
+	require.NoError(t, os.MkdirAll(filepath.Dir(sharedKernelPath), 0o755))
+	require.NoError(t, os.WriteFile(sharedKernelPath, bytes.Repeat([]byte("s"), 4096), 0o644))
+
+	sharedVersionPath := pmem.GetSharedImageVersionFilePath()
+	require.NoError(t, os.MkdirAll(filepath.Dir(sharedVersionPath), 0o755))
+	require.NoError(t, os.WriteFile(sharedVersionPath, []byte("2.2.0-20251010\n"), 0o644))
+
+	targetKernelPath := pmem.GetRawKernelFilePath(cubebox.InstanceType_cubebox.String(), template.Image)
+	require.NoError(t, os.MkdirAll(filepath.Dir(targetKernelPath), 0o755))
+	require.NoError(t, os.WriteFile(targetKernelPath, bytes.Repeat([]byte("o"), 2048), 0o644))
+
+	err := materializeDistributedTemplateRuntimeFiles(context.Background(), template)
+	require.NoError(t, err)
+
+	gotKernel, err := os.ReadFile(targetKernelPath)
+	require.NoError(t, err)
+	require.Equal(t, bytes.Repeat([]byte("s"), 4096), gotKernel)
+}
+
+func TestMaterializeDistributedTemplateRuntimeFilesSkipsNonExt4(t *testing.T) {
+	err := materializeDistributedTemplateRuntimeFiles(context.Background(), &templatetypes.TemplateImage{
+		Image:        "artifact-1",
+		StorageMedia: "overlayfs",
+	})
+	require.NoError(t, err)
+}

--- a/Cubelet/pkg/container/pmem/kernel_sync.go
+++ b/Cubelet/pkg/container/pmem/kernel_sync.go
@@ -17,8 +17,10 @@ import (
 	"github.com/tencentcloud/CubeSandbox/Cubelet/pkg/utils"
 )
 
-// SyncKernelFile keeps targetKernelPath aligned with the current shared kernel.
-func SyncKernelFile(ctx context.Context, sharedKernelPath, targetKernelPath string) error {
+var compareKernelFiles = sameFileSHA256
+
+// EnsureKernelFilePresent copies the shared kernel only when the target is missing.
+func EnsureKernelFilePresent(ctx context.Context, sharedKernelPath, targetKernelPath string) error {
 	sharedExist, err := utils.FileExistAndValid(sharedKernelPath)
 	if err != nil {
 		return fmt.Errorf("local shared kernel validation failed: %w", err)
@@ -35,37 +37,67 @@ func SyncKernelFile(ctx context.Context, sharedKernelPath, targetKernelPath stri
 		if err := copyKernelFileAtomically(sharedKernelPath, targetKernelPath); err != nil {
 			return err
 		}
-		targetExist, err = utils.FileExistAndValid(targetKernelPath)
-		if err != nil {
-			return fmt.Errorf("copied kernel file %s validation failed: %v", targetKernelPath, err)
-		}
-		if !targetExist {
-			return fmt.Errorf("copied kernel file %s not exist", targetKernelPath)
+		if err := validateKernelFile(targetKernelPath, "copied"); err != nil {
+			return err
 		}
 		log.G(ctx).Infof("kernel file %s missing, copied latest shared kernel from %s", targetKernelPath, sharedKernelPath)
-		return nil
 	}
+	return nil
+}
 
-	same, err := sameFileSHA256(sharedKernelPath, targetKernelPath)
+// RefreshKernelFile rewrites the target from the current shared kernel.
+func RefreshKernelFile(ctx context.Context, sharedKernelPath, targetKernelPath string) error {
+	sharedExist, err := utils.FileExistAndValid(sharedKernelPath)
 	if err != nil {
-		return err
+		return fmt.Errorf("local shared kernel validation failed: %w", err)
 	}
-	if same {
-		log.G(ctx).Infof("kernel file %s already matches latest shared kernel %s", targetKernelPath, sharedKernelPath)
-		return nil
+	if !sharedExist {
+		return fmt.Errorf("local shared kernel not found: %s", sharedKernelPath)
 	}
-
 	if err := copyKernelFileAtomically(sharedKernelPath, targetKernelPath); err != nil {
 		return err
 	}
-	same, err = sameFileSHA256(sharedKernelPath, targetKernelPath)
-	if err != nil {
+	if err := validateRefreshedKernelFile(sharedKernelPath, targetKernelPath); err != nil {
+		cleanupErr := cleanupKernelFile(targetKernelPath)
+		if cleanupErr != nil {
+			log.G(ctx).Errorf(
+				"kernel file %s verification failed against shared kernel %s and cleanup failed: verifyErr=%v cleanupErr=%v",
+				targetKernelPath, sharedKernelPath, err, cleanupErr,
+			)
+			return fmt.Errorf("%w: cleanup invalid kernel file failed: %v", err, cleanupErr)
+		}
+		log.G(ctx).Errorf(
+			"kernel file %s verification failed against shared kernel %s, cleaned up invalid target: %v",
+			targetKernelPath, sharedKernelPath, err,
+		)
 		return err
 	}
-	if !same {
-		return fmt.Errorf("refreshed kernel file %s still differs from shared kernel %s", targetKernelPath, sharedKernelPath)
-	}
 	log.G(ctx).Infof("kernel file %s refreshed from latest shared kernel %s", targetKernelPath, sharedKernelPath)
+	return nil
+}
+
+func validateRefreshedKernelFile(sharedKernelPath, targetKernelPath string) error {
+	if err := validateKernelFile(targetKernelPath, "refreshed"); err != nil {
+		return err
+	}
+	same, err := compareKernelFiles(sharedKernelPath, targetKernelPath)
+	if err != nil {
+		return fmt.Errorf("refreshed kernel file %s verification failed against shared kernel %s: %w", targetKernelPath, sharedKernelPath, err)
+	}
+	if !same {
+		return fmt.Errorf("refreshed kernel file %s differs from shared kernel %s", targetKernelPath, sharedKernelPath)
+	}
+	return nil
+}
+
+func validateKernelFile(path, operation string) error {
+	exist, err := utils.FileExistAndValid(path)
+	if err != nil {
+		return fmt.Errorf("%s kernel file %s validation failed: %v", operation, path, err)
+	}
+	if !exist {
+		return fmt.Errorf("%s kernel file %s not exist", operation, path)
+	}
 	return nil
 }
 
@@ -93,6 +125,14 @@ func fileSHA256(path string) (string, error) {
 		return "", err
 	}
 	return hex.EncodeToString(hasher.Sum(nil)), nil
+}
+
+func cleanupKernelFile(path string) error {
+	err := os.Remove(path)
+	if err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	return nil
 }
 
 func copyKernelFileAtomically(srcPath, dstPath string) error {

--- a/Cubelet/pkg/container/pmem/kernel_sync.go
+++ b/Cubelet/pkg/container/pmem/kernel_sync.go
@@ -19,40 +19,32 @@ import (
 
 var compareKernelFiles = sameFileSHA256
 
-// EnsureKernelFilePresent copies the shared kernel only when the target is missing.
+// EnsureKernelFilePresent verifies that the target kernel file is already present and valid.
 func EnsureKernelFilePresent(ctx context.Context, sharedKernelPath, targetKernelPath string) error {
-	sharedExist, err := utils.FileExistAndValid(sharedKernelPath)
-	if err != nil {
-		return fmt.Errorf("local shared kernel validation failed: %w", err)
-	}
-	if !sharedExist {
-		return fmt.Errorf("local shared kernel not found: %s", sharedKernelPath)
+	if err := requireValidSharedKernel(sharedKernelPath); err != nil {
+		return err
 	}
 
-	targetExist, err := utils.FileExistAndValid(targetKernelPath)
+	targetState, err := inspectKernelFileState(targetKernelPath)
 	if err != nil {
-		log.G(ctx).Warnf("kernel file %s validation failed, refresh from shared kernel: %v", targetKernelPath, err)
+		return err
 	}
-	if !targetExist {
-		if err := copyKernelFileAtomically(sharedKernelPath, targetKernelPath); err != nil {
-			return err
-		}
-		if err := validateKernelFile(targetKernelPath, "copied"); err != nil {
-			return err
-		}
-		log.G(ctx).Infof("kernel file %s missing, copied latest shared kernel from %s", targetKernelPath, sharedKernelPath)
+	switch targetState {
+	case kernelFileStateValid:
+		return nil
+	case kernelFileStateMissing:
+		return fmt.Errorf("target kernel file %s not exist", targetKernelPath)
+	case kernelFileStateInvalid:
+		return fmt.Errorf("target kernel file %s is invalid", targetKernelPath)
+	default:
+		return fmt.Errorf("unknown kernel file state for %s", targetKernelPath)
 	}
-	return nil
 }
 
 // RefreshKernelFile rewrites the target from the current shared kernel.
 func RefreshKernelFile(ctx context.Context, sharedKernelPath, targetKernelPath string) error {
-	sharedExist, err := utils.FileExistAndValid(sharedKernelPath)
-	if err != nil {
-		return fmt.Errorf("local shared kernel validation failed: %w", err)
-	}
-	if !sharedExist {
-		return fmt.Errorf("local shared kernel not found: %s", sharedKernelPath)
+	if err := requireValidSharedKernel(sharedKernelPath); err != nil {
+		return err
 	}
 	if err := copyKernelFileAtomically(sharedKernelPath, targetKernelPath); err != nil {
 		return err
@@ -74,6 +66,40 @@ func RefreshKernelFile(ctx context.Context, sharedKernelPath, targetKernelPath s
 	}
 	log.G(ctx).Infof("kernel file %s refreshed from latest shared kernel %s", targetKernelPath, sharedKernelPath)
 	return nil
+}
+
+type kernelFileState string
+
+const (
+	kernelFileStateValid   kernelFileState = "valid"
+	kernelFileStateMissing kernelFileState = "missing"
+	kernelFileStateInvalid kernelFileState = "invalid"
+)
+
+func requireValidSharedKernel(sharedKernelPath string) error {
+	sharedState, err := inspectKernelFileState(sharedKernelPath)
+	if err != nil {
+		return err
+	}
+	switch sharedState {
+	case kernelFileStateValid:
+		return nil
+	case kernelFileStateMissing:
+		return fmt.Errorf("local shared kernel not found: %s", sharedKernelPath)
+	default:
+		return fmt.Errorf("local shared kernel validation failed: %w", validateKernelFile(sharedKernelPath, "local shared"))
+	}
+}
+
+func inspectKernelFileState(path string) (kernelFileState, error) {
+	exist, err := utils.FileExistAndValid(path)
+	if err != nil {
+		return kernelFileStateInvalid, nil
+	}
+	if exist {
+		return kernelFileStateValid, nil
+	}
+	return kernelFileStateMissing, nil
 }
 
 func validateRefreshedKernelFile(sharedKernelPath, targetKernelPath string) error {

--- a/Cubelet/pkg/container/pmem/kernel_sync_test.go
+++ b/Cubelet/pkg/container/pmem/kernel_sync_test.go
@@ -1,0 +1,70 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package pmem
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestRefreshKernelFileVerifiesCopiedContent(t *testing.T) {
+	baseDir := t.TempDir()
+	sharedKernelPath := filepath.Join(baseDir, "shared", "vmlinux")
+	targetKernelPath := filepath.Join(baseDir, "target", "artifact.vm")
+
+	writeKernelTestFile(t, sharedKernelPath, bytes.Repeat([]byte("s"), 4096))
+	writeKernelTestFile(t, targetKernelPath, bytes.Repeat([]byte("o"), 2048))
+
+	err := RefreshKernelFile(context.Background(), sharedKernelPath, targetKernelPath)
+	if err != nil {
+		t.Fatalf("RefreshKernelFile error=%v", err)
+	}
+
+	got, err := os.ReadFile(targetKernelPath)
+	if err != nil {
+		t.Fatalf("ReadFile target kernel error=%v", err)
+	}
+	if !bytes.Equal(got, bytes.Repeat([]byte("s"), 4096)) {
+		t.Fatal("target kernel should match shared kernel after refresh")
+	}
+}
+
+func TestRefreshKernelFileCleansTargetOnVerificationFailure(t *testing.T) {
+	baseDir := t.TempDir()
+	sharedKernelPath := filepath.Join(baseDir, "shared", "vmlinux")
+	targetKernelPath := filepath.Join(baseDir, "target", "artifact.vm")
+
+	writeKernelTestFile(t, sharedKernelPath, bytes.Repeat([]byte("s"), 4096))
+	writeKernelTestFile(t, targetKernelPath, bytes.Repeat([]byte("o"), 2048))
+
+	originalCompare := compareKernelFiles
+	compareKernelFiles = func(pathA, pathB string) (bool, error) {
+		return false, nil
+	}
+	defer func() {
+		compareKernelFiles = originalCompare
+	}()
+
+	err := RefreshKernelFile(context.Background(), sharedKernelPath, targetKernelPath)
+	if err == nil {
+		t.Fatal("RefreshKernelFile error=nil, want non-nil")
+	}
+	if _, statErr := os.Stat(targetKernelPath); !os.IsNotExist(statErr) {
+		t.Fatalf("target kernel should be removed after verification failure, statErr=%v", statErr)
+	}
+}
+
+func writeKernelTestFile(t *testing.T, path string, content []byte) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("MkdirAll error=%v", err)
+	}
+	if err := os.WriteFile(path, content, 0o644); err != nil {
+		t.Fatalf("WriteFile error=%v", err)
+	}
+}

--- a/Cubelet/pkg/container/pmem/kernel_sync_test.go
+++ b/Cubelet/pkg/container/pmem/kernel_sync_test.go
@@ -59,6 +59,69 @@ func TestRefreshKernelFileCleansTargetOnVerificationFailure(t *testing.T) {
 	}
 }
 
+func TestEnsureKernelFilePresentRejectsMissingTarget(t *testing.T) {
+	baseDir := t.TempDir()
+	sharedKernelPath := filepath.Join(baseDir, "shared", "vmlinux")
+	targetKernelPath := filepath.Join(baseDir, "target", "artifact.vm")
+
+	sharedKernel := bytes.Repeat([]byte("s"), 4096)
+	writeKernelTestFile(t, sharedKernelPath, sharedKernel)
+
+	err := EnsureKernelFilePresent(context.Background(), sharedKernelPath, targetKernelPath)
+	if err == nil {
+		t.Fatal("EnsureKernelFilePresent error=nil, want non-nil")
+	}
+}
+
+func TestEnsureKernelFilePresentRejectsSmallTarget(t *testing.T) {
+	baseDir := t.TempDir()
+	sharedKernelPath := filepath.Join(baseDir, "shared", "vmlinux")
+	targetKernelPath := filepath.Join(baseDir, "target", "artifact.vm")
+
+	sharedKernel := bytes.Repeat([]byte("s"), 4096)
+	writeKernelTestFile(t, sharedKernelPath, sharedKernel)
+	writeKernelTestFile(t, targetKernelPath, bytes.Repeat([]byte("o"), 128))
+
+	err := EnsureKernelFilePresent(context.Background(), sharedKernelPath, targetKernelPath)
+	if err == nil {
+		t.Fatal("EnsureKernelFilePresent error=nil, want non-nil")
+	}
+}
+
+func TestEnsureKernelFilePresentRejectsDirectoryTarget(t *testing.T) {
+	baseDir := t.TempDir()
+	sharedKernelPath := filepath.Join(baseDir, "shared", "vmlinux")
+	targetKernelPath := filepath.Join(baseDir, "target", "artifact.vm")
+
+	sharedKernel := bytes.Repeat([]byte("s"), 4096)
+	writeKernelTestFile(t, sharedKernelPath, sharedKernel)
+	if err := os.MkdirAll(targetKernelPath, 0o755); err != nil {
+		t.Fatalf("MkdirAll target kernel dir error=%v", err)
+	}
+
+	err := EnsureKernelFilePresent(context.Background(), sharedKernelPath, targetKernelPath)
+	if err == nil {
+		t.Fatal("EnsureKernelFilePresent error=nil, want non-nil")
+	}
+}
+
+func TestEnsureKernelFilePresentRequiresValidSharedKernel(t *testing.T) {
+	baseDir := t.TempDir()
+	sharedKernelPath := filepath.Join(baseDir, "shared", "vmlinux")
+	targetKernelPath := filepath.Join(baseDir, "target", "artifact.vm")
+
+	err := EnsureKernelFilePresent(context.Background(), sharedKernelPath, targetKernelPath)
+	if err == nil {
+		t.Fatal("EnsureKernelFilePresent error=nil for missing shared kernel")
+	}
+
+	writeKernelTestFile(t, sharedKernelPath, bytes.Repeat([]byte("s"), 128))
+	err = EnsureKernelFilePresent(context.Background(), sharedKernelPath, targetKernelPath)
+	if err == nil {
+		t.Fatal("EnsureKernelFilePresent error=nil for invalid shared kernel")
+	}
+}
+
 func writeKernelTestFile(t *testing.T, path string, content []byte) {
 	t.Helper()
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {

--- a/Cubelet/pkg/utils/dentry.go
+++ b/Cubelet/pkg/utils/dentry.go
@@ -38,11 +38,13 @@ func DenExist(path string) (bool, error) {
 func FileExistAndValid(path string) (bool, error) {
 	info, err := os.Stat(path)
 	if err == nil {
+		if info.IsDir() {
+			return false, fmt.Errorf("%s is a directory", path)
+		}
 		if info.Size() > 1024 {
 			return true, nil
-		} else {
-			return false, fmt.Errorf("invalid size:%d", info.Size())
 		}
+		return false, fmt.Errorf("invalid size:%d", info.Size())
 	}
 	if os.IsNotExist(err) {
 		return false, nil

--- a/Cubelet/pkg/utils/dentry_test.go
+++ b/Cubelet/pkg/utils/dentry_test.go
@@ -5,6 +5,8 @@
 package utils
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -12,8 +14,47 @@ import (
 
 func TestSupportPrepare(t *testing.T) {
 	flag := IsMountLoop("/proc")
-	assert.Equal(t, flag, true)
+	assert.True(t, flag)
 
 	flag = IsMountLoop("/xxx/yyy/zzz")
-	assert.Equal(t, flag, false)
+	assert.False(t, flag)
+}
+
+func TestFileExistAndValid(t *testing.T) {
+	t.Run("valid regular file", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "valid.bin")
+		assert.NoError(t, os.WriteFile(path, make([]byte, 2048), 0o644))
+
+		ok, err := FileExistAndValid(path)
+		assert.True(t, ok)
+		assert.NoError(t, err)
+	})
+
+	t.Run("small file is invalid", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "small.bin")
+		assert.NoError(t, os.WriteFile(path, make([]byte, 128), 0o644))
+
+		ok, err := FileExistAndValid(path)
+		assert.False(t, ok)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid size")
+	})
+
+	t.Run("directory is invalid", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "dir")
+		assert.NoError(t, os.MkdirAll(path, 0o755))
+
+		ok, err := FileExistAndValid(path)
+		assert.False(t, ok)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "is a directory")
+	})
+
+	t.Run("missing path", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "missing.bin")
+
+		ok, err := FileExistAndValid(path)
+		assert.False(t, ok)
+		assert.NoError(t, err)
+	})
 }

--- a/Cubelet/plugins/cbri/cubeboxcbri/create_sandbox_kernel_test.go
+++ b/Cubelet/plugins/cbri/cubeboxcbri/create_sandbox_kernel_test.go
@@ -116,6 +116,44 @@ func TestCreateSandboxRestoreDoesNotRefreshArtifactKernel(t *testing.T) {
 	require.Equal(t, "/template/kernel.vm", spec.Annotations[constants.AnnotationsVMKernelPath])
 }
 
+func TestCreateSandboxNormalStartDoesNotRefreshArtifactKernel(t *testing.T) {
+	t.Parallel()
+
+	plugin := newTestCubeboxPlugin(t)
+	artifactID := "artifact-3"
+	sharedKernelPath := filepath.Join(plugin.config.BasePath, "cube-kernel-scf", "vmlinux")
+	targetKernelPath := plugin.getKernelFilePath(artifactID)
+	oldKernel := bytes.Repeat([]byte("o"), 2048)
+	writeTestFile(t, sharedKernelPath, bytes.Repeat([]byte("s"), 4096))
+	writeTestFile(t, targetKernelPath, oldKernel)
+
+	flowOpts := &workflow.CreateContext{
+		ReqInfo: &cubebox.RunCubeSandboxRequest{
+			InstanceType: cubebox.InstanceType_cubebox.String(),
+			Containers: []*cubebox.ContainerConfig{
+				{
+					Resources: &cubebox.Resource{Cpu: "2000m", Mem: "2000Mi"},
+					Image: &cubeimages.ImageSpec{
+						Image:        artifactID,
+						StorageMedia: cubeimages.ImageStorageMediaType_ext4.String(),
+					},
+				},
+			},
+		},
+	}
+	ctx := constants.WithAppImageID(context.Background(), artifactID)
+
+	specOpts, err := plugin.CreateSandbox(ctx, flowOpts)
+	require.NoError(t, err)
+
+	gotKernel, err := os.ReadFile(targetKernelPath)
+	require.NoError(t, err)
+	require.Equal(t, oldKernel, gotKernel)
+
+	spec := applySpecOpts(t, ctx, specOpts)
+	require.Equal(t, targetKernelPath, spec.Annotations[constants.AnnotationsVMKernelPath])
+}
+
 func newTestCubeboxPlugin(t *testing.T) *cubeboxInstancePlugin {
 	t.Helper()
 

--- a/Cubelet/plugins/cbri/cubeboxcbri/cubebox.go
+++ b/Cubelet/plugins/cbri/cubeboxcbri/cubebox.go
@@ -32,7 +32,7 @@ import (
 	cubeboxstore "github.com/tencentcloud/CubeSandbox/Cubelet/pkg/store/cubebox"
 	"github.com/tencentcloud/CubeSandbox/Cubelet/pkg/utils"
 	"github.com/tencentcloud/CubeSandbox/Cubelet/plugins/workflow"
-	"github.com/tencentcloud/CubeSandbox/cubelog"
+	CubeLog "github.com/tencentcloud/CubeSandbox/cubelog"
 	"k8s.io/apimachinery/pkg/api/resource"
 )
 
@@ -383,7 +383,7 @@ func (e *cubeboxInstancePlugin) getImageFilePath(imageID string) string {
 }
 
 func (e *cubeboxInstancePlugin) syncLatestKernelForImage(ctx context.Context, imageID string) error {
-	return pmem.SyncKernelFile(
+	return pmem.RefreshKernelFile(
 		ctx,
 		filepath.Join(e.config.BasePath, "cube-kernel-scf", "vmlinux"),
 		e.getKernelFilePath(imageID),


### PR DESCRIPTION
- Split SyncKernelFile into EnsureKernelFilePresent (copy only if missing) and RefreshKernelFile (force refresh with verification)
- Use EnsureKernelFilePresent in EnsurePmemFile to skip SHA256 comparison on normal startup
- Add materializeDistributedTemplateRuntimeFiles to refresh kernel after image distribution

Fixed the performance regression in PR https://github.com/TencentCloud/CubeSandbox/pull/57

Before this PR (v0.2.0) in PVM (`INTEL(R) XEON(R) PLATINUM 8576C`): 
<img width="1827" height="413" alt="image" src="https://github.com/user-attachments/assets/929ddb8a-0ef0-4812-9f3b-841a6aebb1e1" />

After: 
<img width="1917" height="276" alt="image" src="https://github.com/user-attachments/assets/1883ec22-06e8-4009-ae0a-a09dffbce3cc" />
