### PR TITLE
storage: make cmdTimeout configurable via plugin config

### DIFF
--- a/Cubelet/storage/local.go
+++ b/Cubelet/storage/local.go
@@ -75,6 +75,7 @@ var (
 	defaultPoolTriggerIntervalInMs = 1000
 	defaultWarningPercent          = 100
 	defaultFormatSize              = "1Gi"
+	defaultCmdTimeout              = 3 * time.Second
 
 	unifiedStorageSize        = resource.MustParse(defaultFormatSize)
 	otherFormatSize           = "othersv2"

--- a/Cubelet/storage/plugin.go
+++ b/Cubelet/storage/plugin.go
@@ -50,6 +50,14 @@ type Config struct {
 
 	FreeInodesThreshold int32            `toml:"free_inodes_threshold"`
 	ReconcileInterval   tomlext.Duration `toml:"reconcile_interval"`
+
+	// CmdTimeout overrides the per-command timeout for utils.ExecV
+	// invocations in shell.go (cp / truncate / e2fsck / resize2fs /
+	// mkfs.ext4). Defaults to defaultCmdTimeout when zero. The slow
+	// ext4-create path on multi-GiB images can need noticeably more
+	// than the 3s default; this knob lets operators bump it without
+	// recompiling.
+	CmdTimeout tomlext.Duration `toml:"cmd_timeout"`
 }
 
 func init() {
@@ -76,6 +84,14 @@ func init() {
 			if localStorage.config.PoolType == "" {
 				localStorage.config.PoolType = cp_type
 			}
+			if localStorage.config.CmdTimeout == 0 {
+				localStorage.config.CmdTimeout = tomlext.FromStdTime(defaultCmdTimeout)
+			}
+			if tomlext.ToStdTime(localStorage.config.CmdTimeout) < 0 {
+				return nil, fmt.Errorf("cmd_timeout must be non-negative, got %v",
+					tomlext.ToStdTime(localStorage.config.CmdTimeout))
+			}
+			cmdTimeout = tomlext.ToStdTime(localStorage.config.CmdTimeout)
 			checkPoolType(localStorage.config)
 
 			cubeboxAPIObj, err := ic.GetByID(constants.CubeStorePlugin, constants.CubeboxID.ID())

--- a/Cubelet/storage/shell.go
+++ b/Cubelet/storage/shell.go
@@ -13,7 +13,14 @@ import (
 	"github.com/tencentcloud/CubeSandbox/Cubelet/pkg/utils"
 )
 
-const cmdTimeout = time.Second * 3
+// cmdTimeout is the per-command timeout for utils.ExecV calls in this
+// package (cp, truncate, e2fsck, resize2fs, mkfs.ext4, ...). The
+// default of 3s is fine for the small pre-formatted images on the
+// pool fast path; the live `mkfs + reflink-copy + e2fsck + resize2fs`
+// slow path on multi-GiB images can need longer. Override via the
+// storage plugin config `cmd_timeout` (see Config.CmdTimeout); set
+// during plugin initialization.
+var cmdTimeout = 3 * time.Second
 
 const diskSizeOverheadInBytes = 1024 * 1024 * 100
 


### PR DESCRIPTION
Implements proposal **(1)** from #235.

Adds a new optional `cmd_timeout` field to the storage plugin's TOML config. When unset (or zero) the existing 3 s default is preserved exactly — no behavior change for current deployments.

## Motivation

`shell.go`'s `cp / truncate / e2fsck / resize2fs / mkfs.ext4` chain shares a single 3 s timeout per command. On the pre-formatted pool fast path the small images comfortably finish inside 3 s. On the live-create slow path (`writable_layer_size` that doesn't match `pool_default_format_size_list`), 3 s on multi-GiB images is tight under concurrent load — that's the contention window where the reflink-copy race in #235 surfaces.

Letting operators raise the per-command timeout from config is the smallest knob that lets the live-create path survive without recompiling cubelet.

## Config example

```toml
[plugins."io.cubelet.internal.v1.storage"]
  cmd_timeout = "30s"
```

## What's deliberately not changed

- **Default value stays 3 s.** Bumping the default is a behavior change you may want to do separately after measuring P95 on a host that actually hits the slow path.
- **Single timeout shared by all the commands.** Splitting per-command (e.g. faster `cp`, slower `e2fsck`) is doable but expands scope; happy to do as a follow-up PR if you'd like.
- `shell.go`'s `cmdTimeout` is now `var` instead of `const`, set during `(*local).init`. Other styles (passing timeout into each function, plumbing through a `context`) are also options; this matches the existing package-level state in this package (`localStorage`, `defaultPoolSize`, ...).

## Out-of-scope observations

- `shell.go`'s three create-image functions (`newExt4BaseRaw`, `newExt4RawByCopy`, `newExt4RawByReflinkCopy`) all swallow stderr into a short string error without command index / file stat / elapsed time. Proposal **(2)** from #235 covers that — **separate PR coming, keeping this one focused.**

## Tested

- `go vet ./storage/...` — clean
- `go build ./storage/...` — clean
- `gofmt -l` — clean