### PR TITLE
cubelet: add diagnostic context to newExt4RawByReflinkCopy errors

### DIFF
--- a/Cubelet/storage/shell.go
+++ b/Cubelet/storage/shell.go
@@ -8,7 +8,10 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"strings"
 	"time"
+
+	"golang.org/x/sys/unix"
 
 	"github.com/tencentcloud/CubeSandbox/Cubelet/pkg/utils"
 )
@@ -110,13 +113,64 @@ func newExt4RawByReflinkCopy(baseFormatFile, targetFile string, size int64) (err
 		cmds = append(cmds, []string{"e2fsck", "-fy", targetFile})
 		cmds = append(cmds, []string{"resize2fs", targetFile})
 	}
-	for _, cmd := range cmds {
+	started := time.Now()
+	for i, cmd := range cmds {
 		var stderr string
 		if _, stderr, err = utils.ExecV(cmd, cmdTimeout); err != nil {
-			return fmt.Errorf("newExt4RawByReflinkCopy failed:%s", stderr)
+			return fmt.Errorf("newExt4RawByReflinkCopy failed:%s%s",
+				stderr,
+				describeStorageFailure(cmds, i, targetFile, baseFormatFile, started))
 		}
 	}
 	return nil
+}
+
+// describeStorageFailure builds a single-line diagnostic suffix for
+// failures in the ext4-create command chain. Returned string starts
+// with " [" so callers append it directly after the existing
+// "<fnname> failed:<stderr>" prefix and the resulting message stays
+// on one line.
+//
+// Format:
+//
+//	[step=N/M cmd="<argv>" elapsed=<dur> target=<stat> base=<stat> free=<bytes>B]
+//
+// Best-effort: stat / statfs errors are reported inline ("missing",
+// "stat err=<msg>") instead of failing the diagnostic itself; the
+// caller already has a real error to return.
+func describeStorageFailure(cmds [][]string, idx int, target, base string, started time.Time) string {
+	var b strings.Builder
+	b.WriteString(" [step=")
+	fmt.Fprintf(&b, "%d/%d", idx+1, len(cmds))
+	fmt.Fprintf(&b, " cmd=%q", strings.Join(cmds[idx], " "))
+	fmt.Fprintf(&b, " elapsed=%s", time.Since(started).Truncate(time.Millisecond))
+	fmt.Fprintf(&b, " target=%s", describeFile(target))
+	fmt.Fprintf(&b, " base=%s", describeFile(base))
+	fmt.Fprintf(&b, " free=%s", describeFreeBytes(path.Dir(target)))
+	b.WriteString("]")
+	return b.String()
+}
+
+func describeFile(p string) string {
+	if p == "" {
+		return "<empty>"
+	}
+	fi, err := os.Stat(p)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "missing"
+		}
+		return fmt.Sprintf("stat err=%v", err)
+	}
+	return fmt.Sprintf("size=%d", fi.Size())
+}
+
+func describeFreeBytes(dir string) string {
+	var buf unix.Statfs_t
+	if err := unix.Statfs(dir, &buf); err != nil {
+		return fmt.Sprintf("statfs err=%v", err)
+	}
+	return fmt.Sprintf("%dB", buf.Bavail*uint64(buf.Bsize))
 }
 
 func newExt4BaseRawWithReplace(filePath, uuid string, size int64, replace bool) error {

--- a/Cubelet/storage/shell_test.go
+++ b/Cubelet/storage/shell_test.go
@@ -6,8 +6,11 @@ package storage
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/tencentcloud/CubeSandbox/Cubelet/pkg/utils"
@@ -77,4 +80,63 @@ func TestNewExt4RawByReflinkCopy(t *testing.T) {
 	targetFile = filepath.Join(testDir, "target3.raw")
 	err = newExt4RawByReflinkCopy(baseFile, targetFile, 128000)
 	assert.Errorf(t, err, "copy with size 128000")
+}
+
+func TestDescribeFile_Empty(t *testing.T) {
+	assert.Equal(t, "<empty>", describeFile(""))
+}
+
+func TestDescribeFile_Missing(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "does-not-exist.raw")
+	assert.Equal(t, "missing", describeFile(missing))
+}
+
+func TestDescribeFile_Size(t *testing.T) {
+	f := filepath.Join(t.TempDir(), "x.raw")
+	if err := os.WriteFile(f, []byte("hello"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(t, "size=5", describeFile(f))
+}
+
+func TestDescribeFreeBytes_Invalid(t *testing.T) {
+	got := describeFreeBytes(filepath.Join(t.TempDir(), "missing-dir"))
+	assert.Truef(t, strings.HasPrefix(got, "statfs err="),
+		"expected statfs err= prefix, got %q", got)
+}
+
+func TestDescribeFreeBytes_Valid(t *testing.T) {
+	got := describeFreeBytes(t.TempDir())
+	assert.Regexp(t, `^\d+B$`, got)
+}
+
+func TestDescribeStorageFailure_Format(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "target.raw")
+	base := filepath.Join(dir, "base.raw")
+	if err := os.WriteFile(target, []byte("xx"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(base, []byte("yyyyy"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cmds := [][]string{
+		{"cp", "--reflink=always", base, target},
+		{"truncate", "-s", "1073741824", target},
+		{"e2fsck", "-fy", target},
+		{"resize2fs", target},
+	}
+	started := time.Now().Add(-500 * time.Millisecond)
+
+	got := describeStorageFailure(cmds, 2, target, base, started)
+
+	assert.Truef(t, strings.HasPrefix(got, " [step=3/4 "),
+		"prefix: %q", got)
+	assert.Contains(t, got, `cmd="e2fsck -fy `)
+	assert.Contains(t, got, "target=size=2")
+	assert.Contains(t, got, "base=size=5")
+	assert.Contains(t, got, "elapsed=")
+	assert.Contains(t, got, " free=")
+	assert.Truef(t, strings.HasSuffix(got, "B]"),
+		"suffix: %q", got)
 }


### PR DESCRIPTION
Implements proposal **(2)** from #235.

## What it does

When `newExt4RawByReflinkCopy` fails, the returned error now appends a single-line diagnostic suffix:

```
newExt4RawByReflinkCopy failed:<stderr> [step=3/4 cmd="e2fsck -fy /a/target.raw" elapsed=812ms target=size=3221225472 base=size=536870912 free=5368709120B]
```

Fields: command index (1-of-N), the failing argv, elapsed time, target/base file stats (size or "missing"), and free bytes on the target's volume.

## Format choices

- **Suffix on the existing message**, not a replacement — any string-matching callers (none found in this repo, but defensive) still see the same `"newExt4RawByReflinkCopy failed:<stderr>"` prefix.
- **Single line** so audit / log pipelines that split on `\n` don't separate the diagnostic from the underlying error.
- **Best-effort stats** — `stat` / `statfs` errors are reported inline (`"stat err=<msg>"`) instead of failing the diagnostic itself; the caller already has a real error to return.

## Out of scope (deliberately)

- `newExt4BaseRaw` and `newExt4RawByCopy` have the same opaque-error shape and would benefit from the same `describeStorageFailure` helper, but the issue named `newExt4RawByReflinkCopy` specifically. Happy to extend to the other two in a follow-up if you'd like.
- The helper is diagnostic-only; no retry / structured error refactor.

## Tested

- `go vet ./storage/...` — clean
- `go build ./storage/...` — clean
- `gofmt -l` — clean

## Related

- Issue: #235
- Companion PR for proposal (1) (configurable `cmdTimeout`): #236