### PR TITLE
fix: change default artifact temp dir to storage partition to prevent…

### DIFF
--- a/CubeMaster/pkg/templatecenter/template_image.go
+++ b/CubeMaster/pkg/templatecenter/template_image.go
@@ -2005,7 +2005,8 @@ func artifactWorkRootDir() string {
 	if value := strings.TrimSpace(os.Getenv("CUBEMASTER_ROOTFS_ARTIFACT_DIR")); value != "" {
 		return value
 	}
-	return filepath.Join(os.TempDir(), "cubemaster-rootfs-artifacts")
+	storeRoot := artifactStoreRootDir()
+	return filepath.Join(storeRoot, "tmp", "cubemaster-rootfs-artifacts")
 }
 
 func artifactStoreRootDir() string {

--- a/CubeMaster/pkg/templatecenter/template_image.go
+++ b/CubeMaster/pkg/templatecenter/template_image.go
@@ -72,6 +72,7 @@ const (
 	fallbackArtifactStoreDir   = "cubemaster-rootfs-artifacts-store"
 	rootfsWritableVolumeName   = "cube_rootfs_rw"
 	defaultDistributionWorkers = 4
+	requiredExtractionSpace    = 20 << 30
 )
 
 var getTemplateImageConfig = config.GetConfig
@@ -2000,13 +2001,29 @@ func artifactModelToInfo(record *models.RootfsArtifact) *types.RootfsArtifactInf
 		LastError:               record.LastError,
 	}
 }
+func checkPartition(tempPath string) error {
+	var stat syscall.Statfs_t
+	err := syscall.Statfs(tempPath, &stat)
+	if err != nil {
+		return fmt.Errorf("error! Failed to check disk space at %s: %w", tempPath, err)
+	}
+	available := stat.Bavail * uint64(stat.Bsize)
+	if available < requiredExtractionSpace {
+		return fmt.Errorf("error: not enough space on %s\nRequired 20GiB\n Available: %dGiB", tempPath, available>>30)
+	}
+	return nil
+}
 
 func artifactWorkRootDir() string {
+	tempDir := os.TempDir()
 	if value := strings.TrimSpace(os.Getenv("CUBEMASTER_ROOTFS_ARTIFACT_DIR")); value != "" {
 		return value
 	}
-	storeRoot := artifactStoreRootDir()
-	return filepath.Join(storeRoot, "tmp", "cubemaster-rootfs-artifacts")
+	if err := checkPartition(tempDir); err == nil{
+		return filepath.Join(tempDir, "cubemaster-rootfs-artifacts")
+	}
+	fallbackDir := artifactStoreRootDir()
+	return filepath.Join(fallbackDir, "tmp", "cubemaster-rootfs-artifacts")
 }
 
 func artifactStoreRootDir() string {

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ Cube Sandbox requires an x86_64 Linux environment with KVM support — **WSL 2**
 > - **Bare-metal / physical machine users**: grab an x86_64 Linux physical machine, or rent a bare-metal server from a cloud provider.
 > - **Ordinary cloud VM users**: no bare-metal required — install the PVM host kernel to enable KVM on any standard cloud VM. See [PVM Deployment](./docs/guide/pvm-deploy.md).
 >
-> **NOTE on storage**: Ensure the partition hosting the CubeMaster storage directory (usually `/data`) has at least 20GB of free space for template creation.
+> **NOTE on storage**: Ensure the partition hosting the CubeMaster storage directory (usually `/data`) has at least 20GiB of free space for template creation.
 
 Once your environment is ready, launch your first sandbox in four steps:
 

--- a/README.md
+++ b/README.md
@@ -146,6 +146,8 @@ Cube Sandbox requires an x86_64 Linux environment with KVM support — **WSL 2**
 > - **Windows users**: run `wsl --install` in an admin PowerShell to set up WSL 2 (requires Windows 11 22H2+, with nested virtualization enabled in BIOS / WSL).
 > - **Bare-metal / physical machine users**: grab an x86_64 Linux physical machine, or rent a bare-metal server from a cloud provider.
 > - **Ordinary cloud VM users**: no bare-metal required — install the PVM host kernel to enable KVM on any standard cloud VM. See [PVM Deployment](./docs/guide/pvm-deploy.md).
+>
+> **NOTE on storage**: Ensure the partition hosting the CubeMaster storage directory (usually `/data`) has at least 20GB of free space for template creation.
 
 Once your environment is ready, launch your first sandbox in four steps:
 


### PR DESCRIPTION
… disk full errors during extraction
Fixes #240

**What this PR does:**
This PR addresses the issue where template creation fails due to `/tmp` running out of space. 

Instead of defaulting to `os.TempDir()` (which would cause issues when disk space isn't enough), `artifactWorkRootDir()` in `template_image.go` will now dynamically default to creating a `tmp` folder inside the configured `artifactStoreRootDir` unless an environment variable is explicitly set by the user. 

**Why this is better:**
1. It prevents root partition disk exhaustion.
2. It improves performance by keeping intermediate files on the same disk as the final storage, avoiding cross-device copy penalties.

(Note: This is my first open-source contribution! Let me know if any changes are needed to the code style or structure.)