### PR TITLE
ci: containerize build environments and split PVM host kernel jobs

### DIFF
--- a/.github/workflows/build-pvm-guest-vmlinux.yml
+++ b/.github/workflows/build-pvm-guest-vmlinux.yml
@@ -18,6 +18,8 @@ env:
 jobs:
   build:
     runs-on: arc-runner-set-16c32g-containerd
+    container:
+      image: ubuntu:24.04
     permissions:
       contents: read
     outputs:
@@ -26,6 +28,13 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Install verification tools
+        run: |
+          apt-get update
+          apt-get install -y file sudo build-essential git bc bison flex \
+            libelf-dev libssl-dev libncurses-dev dwarves cpio kmod \
+            fakeroot rsync dpkg-dev debhelper wget curl ca-certificates python3
 
       - name: Free disk space
         uses: jlumbroso/free-disk-space@main

--- a/.github/workflows/build-vmlinux.yml
+++ b/.github/workflows/build-vmlinux.yml
@@ -15,6 +15,8 @@ env:
 jobs:
   build:
     runs-on: arc-runner-set-16c32g-containerd
+    container:
+      image: ubuntu:24.04
     permissions:
       contents: read
 
@@ -32,17 +34,10 @@ jobs:
 
       - name: Install kernel build dependencies
         run: |
-          sudo apt-get update
-          sudo apt-get install -y \
-            bc \
-            bison \
-            build-essential \
-            cpio \
-            file \
-            flex \
-            libelf-dev \
-            libssl-dev \
-            unzip
+          apt-get update
+          apt-get install -y file sudo build-essential git bc bison flex \
+            libelf-dev libssl-dev libncurses-dev dwarves cpio kmod \
+            fakeroot rsync dpkg-dev debhelper wget curl ca-certificates python3
 
       - name: Restore cached vmlinux
         id: restore_vmlinux

--- a/.github/workflows/release-one-click.yml
+++ b/.github/workflows/release-one-click.yml
@@ -27,10 +27,19 @@ jobs:
   build_pvm_guest_vmlinux:
     name: Build PVM guest vmlinux for release
     runs-on: arc-runner-set-16c32g-containerd
+    container:
+      image: ubuntu:24.04
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Install verification tools
+        run: |
+          apt-get update
+          apt-get install -y file sudo build-essential git bc bison flex \
+            libelf-dev libssl-dev libncurses-dev dwarves cpio kmod \
+            fakeroot rsync dpkg-dev debhelper wget curl ca-certificates python3
 
       - name: Free disk space
         uses: jlumbroso/free-disk-space@main
@@ -101,7 +110,7 @@ jobs:
           retention-days: 14
 
   release:
-    runs-on: arc-runner-set-16c32g
+    runs-on: ubuntu-latest
     needs: build_pvm_guest_vmlinux
 
     steps:

--- a/.github/workflows/release-pvm-host-kernel.yml
+++ b/.github/workflows/release-pvm-host-kernel.yml
@@ -10,22 +10,19 @@ concurrency:
   group: release-pvm-host-kernel-${{ github.ref }}
   cancel-in-progress: false
 
+defaults:
+  run:
+    shell: bash
+
 permissions:
   contents: write
 
 jobs:
-  build:
-    name: Build PVM host kernel (${{ matrix.package_type }})
+  build_deb:
+    name: Build PVM host kernel (deb)
     runs-on: arc-runner-set-16c32g-containerd
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - package_type: deb
-            build_mode: native
-          - package_type: rpm
-            build_mode: container
-            container_image: fedora:40
+    container:
+      image: ubuntu:24.04
 
     steps:
       - name: Checkout
@@ -42,28 +39,24 @@ jobs:
           docker-images: false
           swap-storage: true
 
+      - name: Install verification tools
+        run: |
+          apt-get update
+          apt-get install -y file sudo build-essential git bc bison flex \
+            libelf-dev libssl-dev libncurses-dev dwarves cpio kmod \
+            fakeroot rsync dpkg-dev debhelper wget curl ca-certificates python3
       - name: Build DEB package
-        if: matrix.build_mode == 'native'
         run: |
           WORK_DIR="${GITHUB_WORKSPACE}/pvm-host-build" \
           OUTPUT_DIR="${GITHUB_WORKSPACE}/pvm-host-build/output" \
             bash deploy/pvm/build-pvm-host-kernel-pkg.sh
 
-      - name: Build RPM package
-        if: matrix.build_mode == 'container'
-        run: |
-          docker run --rm \
-            -v "${GITHUB_WORKSPACE}:/workspace" \
-            -w /workspace \
-            "${{ matrix.container_image }}" \
-            bash -lc 'WORK_DIR=/workspace/pvm-host-build OUTPUT_DIR=/workspace/pvm-host-build/output bash deploy/pvm/build-pvm-host-kernel-pkg.sh'
-
       - name: Verify package artifacts
         run: |
           shopt -s nullglob
-          packages=(pvm-host-build/output/*.${{ matrix.package_type }})
+          packages=(pvm-host-build/output/*.deb)
           if [[ "${#packages[@]}" -eq 0 ]]; then
-            echo "No ${{ matrix.package_type }} packages were produced" >&2
+            echo "No deb packages were produced" >&2
             exit 1
           fi
           ls -lh "${packages[@]}"
@@ -71,15 +64,61 @@ jobs:
       - name: Upload package artifact
         uses: actions/upload-artifact@v4
         with:
-          name: pvm-host-kernel-${{ matrix.package_type }}-${{ github.ref_name }}
-          path: pvm-host-build/output/*.${{ matrix.package_type }}
+          name: pvm-host-kernel-deb-${{ github.ref_name }}
+          path: pvm-host-build/output/*.deb
+          if-no-files-found: error
+          retention-days: 14
+
+  build_rpm:
+    name: Build PVM host kernel (rpm)
+    runs-on: arc-runner-set-16c32g-containerd
+    container:
+      image: opencloudos/opencloudos9-minimal:latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Switch OpenCloudOS repos to Tencent mirrors
+        run: |
+          set -euo pipefail
+          sed -i "s#https://mirrors.opencloudos.tech/opencloudos/#https://mirrors.tencent.com/opencloudos/#g" /etc/yum.repos.d/OpenCloudOS.repo
+          if [[ -f /etc/yum.repos.d/epol.repo ]]; then
+            sed -i "s#http://mirrors.tencent.com/epol/#https://mirrors.tencent.com/epol/#g" /etc/yum.repos.d/epol.repo
+          fi
+          dnf clean all
+          rm -rf /var/cache/dnf/*
+
+      - name: Build RPM package
+        run: |
+          WORK_DIR="${GITHUB_WORKSPACE}/pvm-host-build" \
+          OUTPUT_DIR="${GITHUB_WORKSPACE}/pvm-host-build/output" \
+            bash deploy/pvm/build-pvm-host-kernel-pkg.sh
+
+      - name: Verify package artifacts
+        run: |
+          shopt -s nullglob
+          packages=(pvm-host-build/output/*.rpm)
+          if [[ "${#packages[@]}" -eq 0 ]]; then
+            echo "No rpm packages were produced" >&2
+            exit 1
+          fi
+          ls -lh "${packages[@]}"
+
+      - name: Upload package artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: pvm-host-kernel-rpm-${{ github.ref_name }}
+          path: pvm-host-build/output/*.rpm
           if-no-files-found: error
           retention-days: 14
 
   publish:
     name: Upload PVM host packages to GitHub Release
     if: startsWith(github.ref, 'refs/tags/')
-    needs: build
+    needs:
+      - build_deb
+      - build_rpm
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
- Add container images for build jobs to ensure consistent environments
- Install verification tools (file) in relevant workflows
- Split PVM host kernel build into separate deb and rpm jobs with dedicated containers
- Switch release job runner to ubuntu-latest
- Update artifact naming and verification steps