### PR TITLE
feat: add issue comment support to gh.sh and restrict workflow tools to scripts

### DIFF
--- a/.claude/commands/check-issue-duplicate.md
+++ b/.claude/commands/check-issue-duplicate.md
@@ -24,7 +24,7 @@ TASK OVERVIEW:
      - `./scripts/gh.sh issue view 123` — view issue details
      - `./scripts/gh.sh issue view 123 --comments` — view with comments
      - `./scripts/gh.sh search issues "query" --limit 10` — search for issues
-     - `./scripts/gh.sh issue comment 123 --body-file comment.md` — post a single comment
+     - `./scripts/gh.sh issue comment 123 --body-file /tmp/comment.md` — post a single comment
 
 3. If, based on TASK 1 below, the issue is NOT compliant, apply the compliance label:
 
@@ -74,7 +74,17 @@ Additionally, if the issue mentions keybinds, keyboard shortcuts, or key binding
 
 POSTING YOUR COMMENT:
 
-Based on your findings, post a SINGLE comment on issue #${{ github.event.issue.number }} using `./scripts/gh.sh issue comment ${{ github.event.issue.number }} --body-file <path-to-comment>`. Build the comment as follows:
+Based on your findings, post a SINGLE comment on issue #${{ github.event.issue.number }}.
+
+To create the comment file, write the body to an absolute path (e.g. `/tmp/comment.md`). Do NOT use shell variables like `$TMPDIR` in the command — the sandbox rejects commands containing variable expansion (`Contains simple_expansion`). Either:
+- Use the `Write` tool to create `/tmp/comment.md` directly, or
+- Use a heredoc with a literal absolute path: `cat > /tmp/comment.md << 'COMMENT_EOF' ... COMMENT_EOF`
+
+Then post it with:
+
+`./scripts/gh.sh issue comment ${{ github.event.issue.number }} --body-file /tmp/comment.md`
+
+Build the comment as follows:
 
 If the issue is NOT compliant, start the comment with:
 <!-- issue-compliance -->

--- a/.github/workflows/duplicate-issues.yml
+++ b/.github/workflows/duplicate-issues.yml
@@ -35,4 +35,4 @@ jobs:
           github_token: ${{ steps.app-token.outputs.token }}
           show_full_output: true
           claude_args: |
-            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh issue view:*),Bash(gh issue list:*)"
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(./scripts/gh.sh:*),Bash(./scripts/edit-issue-labels.sh:*)"

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -35,4 +35,4 @@ jobs:
           github_token: ${{ steps.app-token.outputs.token }}
           show_full_output: true
           claude_args: |
-            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh issue view:*),Bash(gh issue list:*)"
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(./scripts/gh.sh:*),Bash(./scripts/edit-issue-labels.sh:*)"

--- a/scripts/gh.sh
+++ b/scripts/gh.sh
@@ -10,6 +10,7 @@ set -euo pipefail
 #   ./scripts/gh.sh issue list --state open --limit 20
 #   ./scripts/gh.sh search issues "search query" --limit 10
 #   ./scripts/gh.sh label list --limit 100
+#   ./scripts/gh.sh issue comment 123 --body-file /tmp/comment.md
 
 export GH_HOST=github.com
 
@@ -20,17 +21,17 @@ if [[ -z "$REPO" || "$REPO" == */*/* || "$REPO" != */* ]]; then
 fi
 export GH_REPO="$REPO"
 
-ALLOWED_FLAGS=(--comments --state --limit --label)
-FLAGS_WITH_VALUES=(--state --limit --label)
+ALLOWED_FLAGS=(--comments --state --limit --label --body-file)
+FLAGS_WITH_VALUES=(--state --limit --label --body-file)
 
 SUB1="${1:-}"
 SUB2="${2:-}"
 CMD="$SUB1 $SUB2"
 case "$CMD" in
-  "issue view"|"issue list"|"search issues"|"label list")
+  "issue view"|"issue list"|"search issues"|"label list"|"issue comment")
     ;;
   *)
-    echo "Error: only 'issue view', 'issue list', 'search issues', 'label list' are allowed (e.g., ./scripts/gh.sh issue view 123)" >&2
+    echo "Error: only 'issue view', 'issue list', 'search issues', 'label list', 'issue comment' are allowed (e.g., ./scripts/gh.sh issue view 123)" >&2
     exit 1
     ;;
 esac
@@ -55,7 +56,7 @@ for arg in "$@"; do
       fi
     done
     if [[ "$matched" == false ]]; then
-      echo "Error: only --comments, --state, --limit, --label flags are allowed (e.g., ./scripts/gh.sh issue list --state open --limit 20)" >&2
+      echo "Error: only --comments, --state, --limit, --label, --body-file flags are allowed (e.g., ./scripts/gh.sh issue list --state open --limit 20)" >&2
       exit 1
     fi
     FLAGS+=("$arg")
@@ -84,6 +85,23 @@ if [[ "$CMD" == "search issues" ]]; then
 elif [[ "$CMD" == "issue view" ]]; then
   if [[ ${#POSITIONAL[@]} -ne 1 ]] || ! [[ "${POSITIONAL[0]}" =~ ^[0-9]+$ ]]; then
     echo "Error: issue view requires exactly one numeric issue number (e.g., ./scripts/gh.sh issue view 123)" >&2
+    exit 1
+  fi
+  gh "$SUB1" "$SUB2" "${POSITIONAL[0]}" "${FLAGS[@]}"
+elif [[ "$CMD" == "issue comment" ]]; then
+  if [[ ${#POSITIONAL[@]} -ne 1 ]] || ! [[ "${POSITIONAL[0]}" =~ ^[0-9]+$ ]]; then
+    echo "Error: issue comment requires exactly one numeric issue number (e.g., ./scripts/gh.sh issue comment 123 --body-file /tmp/comment.md)" >&2
+    exit 1
+  fi
+  has_body_file=false
+  for f in "${FLAGS[@]}"; do
+    if [[ "$f" == "--body-file" || "$f" == --body-file=* ]]; then
+      has_body_file=true
+      break
+    fi
+  done
+  if [[ "$has_body_file" == false ]]; then
+    echo "Error: issue comment requires --body-file <path> (e.g., ./scripts/gh.sh issue comment 123 --body-file /tmp/comment.md)" >&2
     exit 1
   fi
   gh "$SUB1" "$SUB2" "${POSITIONAL[0]}" "${FLAGS[@]}"


### PR DESCRIPTION


- Extend gh.sh to allow`issue comment`subcommand with`--body-file`flag
- Update workflow allowed tools to use script wrappers instead of direct gh commands
- Revise duplicate check prompt to use absolute paths for comment files