### PR TITLE
CVE fix

### DIFF
--- a/CubeShim/Cargo.lock
+++ b/CubeShim/Cargo.lock
@@ -166,17 +166,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi 0.1.19",
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -784,12 +773,12 @@ checksum = "c7f84e12ccf0a7ddc17a6c41c93326024c42920d7ee630d04950e6926645c0fe"
 
 [[package]]
 name = "env_logger"
-version = "0.8.4"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a19187fea3ac7e84da7dacf48de0c45d63c6a76f9490dae389aead16c243fce3"
+checksum = "4cd405aab171cb85d6735e5c8d9db038c17d3ca007a4d2c25f337935c3d90580"
 dependencies = [
- "atty",
  "humantime",
+ "is-terminal",
  "log",
  "regex",
  "termcolor",
@@ -1077,15 +1066,6 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
-
-[[package]]
-name = "hermit-abi"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "hermit-abi"

--- a/CubeShim/Cargo.lock
+++ b/CubeShim/Cargo.lock
@@ -108,7 +108,7 @@ checksum = "86fdf8605db99b54d3cd748a44c6d04df638eb5dafb219b135d0149bd0db01f6"
 name = "api_client"
 version = "0.1.0"
 dependencies = [
- "vmm-sys-util 0.12.1",
+ "vmm-sys-util",
 ]
 
 [[package]]
@@ -136,7 +136,7 @@ dependencies = [
  "vm-fdt",
  "vm-memory 0.16.1",
  "vm-migration",
- "vmm-sys-util 0.12.1",
+ "vmm-sys-util",
 ]
 
 [[package]]
@@ -233,7 +233,7 @@ dependencies = [
  "virtio-queue 0.14.0",
  "vm-memory 0.16.1",
  "vm-virtio",
- "vmm-sys-util 0.12.1",
+ "vmm-sys-util",
 ]
 
 [[package]]
@@ -594,7 +594,7 @@ dependencies = [
  "tpm",
  "tracer",
  "vmm",
- "vmm-sys-util 0.12.1",
+ "vmm-sys-util",
 ]
 
 [[package]]
@@ -724,7 +724,7 @@ dependencies = [
  "vm-device",
  "vm-memory 0.16.1",
  "vm-migration",
- "vmm-sys-util 0.12.1",
+ "vmm-sys-util",
 ]
 
 [[package]]
@@ -1229,7 +1229,7 @@ dependencies = [
  "thiserror 1.0.69",
  "vfio-ioctls",
  "vm-memory 0.14.1",
- "vmm-sys-util 0.12.1",
+ "vmm-sys-util",
 ]
 
 [[package]]
@@ -1358,7 +1358,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a82e7e8725a39a0015e511a46cc1f7d90cecc180db1610c4d0d4339a9e48bd21"
 dependencies = [
  "serde",
- "vmm-sys-util 0.12.1",
+ "vmm-sys-util",
  "zerocopy 0.7.35",
 ]
 
@@ -1371,7 +1371,7 @@ dependencies = [
  "bitflags 2.7.0",
  "kvm-bindings",
  "libc",
- "vmm-sys-util 0.12.1",
+ "vmm-sys-util",
 ]
 
 [[package]]
@@ -1503,7 +1503,7 @@ version = "0.1.0"
 source = "git+https://github.com/firecracker-microvm/micro-http?branch=main#8182cd5523b63ceb52ad9d0e7eb6fb95683e6d1b"
 dependencies = [
  "libc",
- "vmm-sys-util 0.12.1",
+ "vmm-sys-util",
 ]
 
 [[package]]
@@ -1538,7 +1538,7 @@ checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
 name = "net_gen"
 version = "0.1.0"
 dependencies = [
- "vmm-sys-util 0.12.1",
+ "vmm-sys-util",
 ]
 
 [[package]]
@@ -1558,7 +1558,7 @@ dependencies = [
  "virtio-queue 0.14.0",
  "vm-memory 0.16.1",
  "vm-virtio",
- "vmm-sys-util 0.12.1",
+ "vmm-sys-util",
 ]
 
 [[package]]
@@ -1767,7 +1767,7 @@ dependencies = [
  "vm-device",
  "vm-memory 0.16.1",
  "vm-migration",
- "vmm-sys-util 0.12.1",
+ "vmm-sys-util",
 ]
 
 [[package]]
@@ -2073,7 +2073,7 @@ dependencies = [
  "libc",
  "log",
  "remain",
- "vmm-sys-util 0.12.1",
+ "vmm-sys-util",
 ]
 
 [[package]]
@@ -2121,7 +2121,7 @@ version = "0.1.0"
 dependencies = [
  "libc",
  "log",
- "vmm-sys-util 0.11.2",
+ "vmm-sys-util",
 ]
 
 [[package]]
@@ -2752,7 +2752,7 @@ dependencies = [
  "libc",
  "log",
  "thiserror 1.0.69",
- "vmm-sys-util 0.12.1",
+ "vmm-sys-util",
 ]
 
 [[package]]
@@ -2950,7 +2950,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43449b404c488f70507dca193debd4bea361fe8089869b947adc19720e464bce"
 dependencies = [
- "vmm-sys-util 0.12.1",
+ "vmm-sys-util",
 ]
 
 [[package]]
@@ -2971,7 +2971,7 @@ dependencies = [
  "thiserror 1.0.69",
  "vfio-bindings 0.4.0",
  "vm-memory 0.14.1",
- "vmm-sys-util 0.12.1",
+ "vmm-sys-util",
 ]
 
 [[package]]
@@ -2986,7 +2986,7 @@ dependencies = [
  "thiserror 1.0.69",
  "vfio-bindings 0.3.1",
  "vm-memory 0.14.1",
- "vmm-sys-util 0.12.1",
+ "vmm-sys-util",
 ]
 
 [[package]]
@@ -3011,7 +3011,7 @@ dependencies = [
  "bitflags 2.7.0",
  "libc",
  "vm-memory 0.14.1",
- "vmm-sys-util 0.12.1",
+ "vmm-sys-util",
 ]
 
 [[package]]
@@ -3023,7 +3023,7 @@ dependencies = [
  "libc",
  "uuid",
  "vm-memory 0.16.1",
- "vmm-sys-util 0.12.1",
+ "vmm-sys-util",
 ]
 
 [[package]]
@@ -3038,7 +3038,7 @@ dependencies = [
  "virtio-bindings 0.2.4",
  "virtio-queue 0.12.0",
  "vm-memory 0.14.1",
- "vmm-sys-util 0.12.1",
+ "vmm-sys-util",
 ]
 
 [[package]]
@@ -3085,7 +3085,7 @@ dependencies = [
  "vm-memory 0.16.1",
  "vm-migration",
  "vm-virtio",
- "vmm-sys-util 0.12.1",
+ "vmm-sys-util",
 ]
 
 [[package]]
@@ -3097,7 +3097,7 @@ dependencies = [
  "log",
  "virtio-bindings 0.2.4",
  "vm-memory 0.14.1",
- "vmm-sys-util 0.12.1",
+ "vmm-sys-util",
 ]
 
 [[package]]
@@ -3109,7 +3109,7 @@ dependencies = [
  "log",
  "virtio-bindings 0.2.4",
  "vm-memory 0.14.1",
- "vmm-sys-util 0.12.1",
+ "vmm-sys-util",
 ]
 
 [[package]]
@@ -3121,7 +3121,7 @@ dependencies = [
  "log",
  "virtio-bindings 0.2.4",
  "vm-memory 0.16.1",
- "vmm-sys-util 0.12.1",
+ "vmm-sys-util",
 ]
 
 [[package]]
@@ -3146,7 +3146,7 @@ dependencies = [
  "virtio-bindings 0.2.4",
  "virtio-queue 0.14.0",
  "vm-memory 0.16.1",
- "vmm-sys-util 0.12.1",
+ "vmm-sys-util",
 ]
 
 [[package]]
@@ -3168,7 +3168,7 @@ dependencies = [
  "thiserror 1.0.69",
  "vfio-ioctls",
  "vm-memory 0.16.1",
- "vmm-sys-util 0.12.1",
+ "vmm-sys-util",
 ]
 
 [[package]]
@@ -3268,18 +3268,8 @@ dependencies = [
  "vm-memory 0.16.1",
  "vm-migration",
  "vm-virtio",
- "vmm-sys-util 0.12.1",
+ "vmm-sys-util",
  "zerocopy 0.6.6",
-]
-
-[[package]]
-name = "vmm-sys-util"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48b7b084231214f7427041e4220d77dfe726897a6d41fddee450696e66ff2a29"
-dependencies = [
- "bitflags 1.3.2",
- "libc",
 ]
 
 [[package]]

--- a/CubeShim/Cargo.lock
+++ b/CubeShim/Cargo.lock
@@ -260,9 +260,9 @@ dependencies = [
 
 [[package]]
 name = "bytes"
-version = "1.9.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "325918d6fe32f23b19878fe4b34794ae41fc19ddbe53b10571a4874d44ffd39b"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "capng"
@@ -1016,7 +1016,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3c0b69cfcb4e1b9f1bf2f53f95f766e4661169728ec61cd3fe5a0166f2d1386"
 dependencies = [
  "atomic-waker",
- "bytes 1.9.0",
+ "bytes 1.11.1",
  "fnv",
  "futures-core",
  "futures-sink",
@@ -1125,7 +1125,7 @@ version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4a85d31aea989eead29a3aaf9e1115a180df8282431156e533de47660892565"
 dependencies = [
- "bytes 1.9.0",
+ "bytes 1.11.1",
  "fnv",
  "itoa",
 ]
@@ -1136,7 +1136,7 @@ version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
- "bytes 1.9.0",
+ "bytes 1.11.1",
  "http",
 ]
 
@@ -1146,7 +1146,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
- "bytes 1.9.0",
+ "bytes 1.11.1",
  "futures-core",
  "http",
  "http-body",
@@ -1178,7 +1178,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb3aa54a13a0dfe7fbe3a59e0c76093041720fdc77b110cc0fc260fafb4dc51e"
 dependencies = [
  "atomic-waker",
- "bytes 1.9.0",
+ "bytes 1.11.1",
  "futures-channel",
  "futures-core",
  "h2",
@@ -1200,7 +1200,7 @@ version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df2dcfbe0677734ab2f3ffa7fa7bfd4706bfdc1ef393f2ee30184aed67e631b4"
 dependencies = [
- "bytes 1.9.0",
+ "bytes 1.11.1",
  "futures-channel",
  "futures-util",
  "http",
@@ -1909,7 +1909,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de5e2533f59d08fcf364fd374ebda0692a70bd6d7e66ef97f306f45c6c5d8020"
 dependencies = [
- "bytes 1.9.0",
+ "bytes 1.11.1",
  "prost-derive",
 ]
 
@@ -1919,7 +1919,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "355f634b43cdd80724ee7848f95770e7e70eefa6dcf14fea676216573b8fd603"
 dependencies = [
- "bytes 1.9.0",
+ "bytes 1.11.1",
  "heck 0.3.3",
  "itertools",
  "log",
@@ -1950,7 +1950,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "603bbd6394701d13f3f25aada59c7de9d35a6a5887cfc156181234a44002771b"
 dependencies = [
- "bytes 1.9.0",
+ "bytes 1.11.1",
  "prost",
 ]
 
@@ -2676,7 +2676,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2b070231665d27ad9ec9b8df639893f46727666c6767db40317fbe920a5d998"
 dependencies = [
  "backtrace",
- "bytes 1.9.0",
+ "bytes 1.11.1",
  "libc",
  "mio",
  "parking_lot",
@@ -2704,7 +2704,7 @@ version = "0.7.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14307c986784f72ef81c89db7d9e28d6ac26d16213b109ea501696195e6e3ce5"
 dependencies = [
- "bytes 1.9.0",
+ "bytes 1.11.1",
  "futures-core",
  "futures-sink",
  "pin-project-lite",
@@ -2730,7 +2730,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52a15c15b1bc91f90902347eff163b5b682643aff0c8e972912cca79bd9208dd"
 dependencies = [
- "bytes 1.9.0",
+ "bytes 1.11.1",
  "futures",
  "libc",
  "tokio",

--- a/agent/Cargo.lock
+++ b/agent/Cargo.lock
@@ -167,9 +167,9 @@ dependencies = [
 
 [[package]]
 name = "bytes"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "capctl"
@@ -990,7 +990,7 @@ version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72452e012c2f8d612410d89eea01e2d9b56205274abb35d53f60200b2ec41d60"
 dependencies = [
- "bytes 1.11.0",
+ "bytes 1.11.1",
  "futures",
  "log",
  "netlink-packet-core",
@@ -1016,7 +1016,7 @@ version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "416060d346fbaf1f23f9512963e3e878f1a78e707cb699ba9215761754244307"
 dependencies = [
- "bytes 1.11.0",
+ "bytes 1.11.1",
  "futures",
  "libc",
  "log",
@@ -1409,7 +1409,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de5e2533f59d08fcf364fd374ebda0692a70bd6d7e66ef97f306f45c6c5d8020"
 dependencies = [
- "bytes 1.11.0",
+ "bytes 1.11.1",
  "prost-derive",
 ]
 
@@ -1419,7 +1419,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "355f634b43cdd80724ee7848f95770e7e70eefa6dcf14fea676216573b8fd603"
 dependencies = [
- "bytes 1.11.0",
+ "bytes 1.11.1",
  "heck 0.3.3",
  "itertools",
  "log",
@@ -1450,7 +1450,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "603bbd6394701d13f3f25aada59c7de9d35a6a5887cfc156181234a44002771b"
 dependencies = [
- "bytes 1.11.0",
+ "bytes 1.11.1",
  "prost",
 ]
 
@@ -2116,7 +2116,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75ef51a33ef1da925cea3e4eb122833cb377c61439ca401b770f54902b806779"
 dependencies = [
  "backtrace",
- "bytes 1.11.0",
+ "bytes 1.11.1",
  "libc",
  "mio",
  "parking_lot 0.12.5",
@@ -2168,7 +2168,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52a15c15b1bc91f90902347eff163b5b682643aff0c8e972912cca79bd9208dd"
 dependencies = [
- "bytes 1.11.0",
+ "bytes 1.11.1",
  "futures",
  "libc",
  "tokio",
@@ -2181,7 +2181,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e336ac4b36df625d5429a735dd5847732fe5f62010e3ce0c50f3705d44730f8"
 dependencies = [
- "bytes 1.11.0",
+ "bytes 1.11.1",
  "futures",
  "libc",
  "tokio",

--- a/agent/Cargo.lock
+++ b/agent/Cargo.lock
@@ -1109,9 +1109,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.1.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
 
 [[package]]
 name = "num-traits"
@@ -2080,30 +2080,30 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.44"
+version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e7d9e3bb61134e77bde20dd4825b97c010155709965fedf0f49bb138e52a9d"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
  "itoa",
  "num-conv",
  "powerfmt",
- "serde",
+ "serde_core",
  "time-core",
  "time-macros",
 ]
 
 [[package]]
 name = "time-core"
-version = "0.1.6"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40868e7c1d2f0b8d73e4a8c7f0ff63af4f6d19be117e90bd73eb1d62cf831c6b"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
 name = "time-macros"
-version = "0.2.24"
+version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30cfb0125f12d9c277f35663a0a33f8c30190f4e4574868a330595412d34ebf3"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",

--- a/agent/Cargo.toml
+++ b/agent/Cargo.toml
@@ -56,7 +56,7 @@ prometheus = { version = "0.13.0", features = ["process"] }
 procfs = "0.12.0"
 anyhow = "1.0.99"
 cgroups = { package = "cgroups-rs", version = "0.3.0" }
-time = "0.3.41"
+time = "0.3.47"
 
 # Tracing
 tracing = "0.1.26"

--- a/agent/libs/Cargo.lock
+++ b/agent/libs/Cargo.lock
@@ -90,9 +90,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.10.1"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cfg-if"

--- a/hypervisor/Cargo.lock
+++ b/hypervisor/Cargo.lock
@@ -160,17 +160,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi 0.1.19",
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -531,25 +520,12 @@ checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
 
 [[package]]
 name = "env_logger"
-version = "0.8.4"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a19187fea3ac7e84da7dacf48de0c45d63c6a76f9490dae389aead16c243fce3"
+checksum = "4cd405aab171cb85d6735e5c8d9db038c17d3ca007a4d2c25f337935c3d90580"
 dependencies = [
- "atty",
  "humantime",
- "log",
- "regex",
- "termcolor",
-]
-
-[[package]]
-name = "env_logger"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a12e6657c4c97ebab115a42dcee77225f7f482cdd841cf7088c657a42e9e00e7"
-dependencies = [
- "atty",
- "humantime",
+ "is-terminal",
  "log",
  "regex",
  "termcolor",
@@ -781,15 +757,6 @@ checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "hermit-abi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
@@ -823,7 +790,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "byteorder",
- "env_logger 0.9.3",
+ "env_logger",
  "iced-x86",
  "kvm-bindings",
  "kvm-ioctls",
@@ -2325,7 +2292,7 @@ version = "0.1.0"
 dependencies = [
  "block_util",
  "clap",
- "env_logger 0.9.3",
+ "env_logger",
  "epoll",
  "libc",
  "log",
@@ -2344,7 +2311,7 @@ name = "vhost_user_net"
 version = "0.1.0"
 dependencies = [
  "clap",
- "env_logger 0.9.3",
+ "env_logger",
  "epoll",
  "libc",
  "log",
@@ -2448,7 +2415,7 @@ dependencies = [
  "bitflags 1.3.2",
  "capng",
  "clap",
- "env_logger 0.8.4",
+ "env_logger",
  "futures",
  "libc",
  "libseccomp-sys",

--- a/hypervisor/Cargo.lock
+++ b/hypervisor/Cargo.lock
@@ -442,9 +442,9 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.3.11"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
 ]
@@ -1175,9 +1175,9 @@ checksum = "43794a0ace135be66a25d3ae77d41b91615fb68ae937f904090203e81f755b65"
 
 [[package]]
 name = "num-conv"
-version = "0.1.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
 
 [[package]]
 name = "num-traits"
@@ -1744,18 +1744,28 @@ checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
 
 [[package]]
 name = "serde"
-version = "1.0.209"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99fce0ffe7310761ca6bf9faf5115afbc19688edd00171d81b1bb1b116c63e09"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.209"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5831b979fd7b5439637af1752d535ff49f4860c0f341d1baeb6faf0f4242170"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1962,9 +1972,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "2.0.77"
+version = "2.0.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f35bcdf61fd8e7be6caf75f429fdca8beb3ed76584befb503b1569faee373ed"
+checksum = "25aa4ce346d03a6dcd68dd8b4010bcb74e54e62c90c573f394c46eae99aba32d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2067,9 +2077,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.36"
+version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
  "itoa",
@@ -2077,22 +2087,22 @@ dependencies = [
  "num-conv",
  "num_threads",
  "powerfmt",
- "serde",
+ "serde_core",
  "time-core",
  "time-macros",
 ]
 
 [[package]]
 name = "time-core"
-version = "0.1.2"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
 name = "time-macros"
-version = "0.2.18"
+version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",

--- a/hypervisor/Cargo.lock
+++ b/hypervisor/Cargo.lock
@@ -108,7 +108,7 @@ checksum = "b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da"
 name = "api_client"
 version = "0.1.0"
 dependencies = [
- "vmm-sys-util 0.12.1",
+ "vmm-sys-util",
 ]
 
 [[package]]
@@ -136,7 +136,7 @@ dependencies = [
  "vm-fdt",
  "vm-memory 0.16.1",
  "vm-migration",
- "vmm-sys-util 0.12.1",
+ "vmm-sys-util",
 ]
 
 [[package]]
@@ -218,7 +218,7 @@ dependencies = [
  "virtio-queue 0.14.0",
  "vm-memory 0.16.1",
  "vm-virtio",
- "vmm-sys-util 0.12.1",
+ "vmm-sys-util",
 ]
 
 [[package]]
@@ -401,7 +401,7 @@ dependencies = [
  "tpm",
  "tracer",
  "vmm",
- "vmm-sys-util 0.12.1",
+ "vmm-sys-util",
  "wait-timeout",
 ]
 
@@ -473,7 +473,7 @@ dependencies = [
  "vm-device",
  "vm-memory 0.16.1",
  "vm-migration",
- "vmm-sys-util 0.12.1",
+ "vmm-sys-util",
 ]
 
 [[package]]
@@ -836,7 +836,7 @@ dependencies = [
  "thiserror",
  "vfio-ioctls",
  "vm-memory 0.14.1",
- "vmm-sys-util 0.12.1",
+ "vmm-sys-util",
 ]
 
 [[package]]
@@ -944,7 +944,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a82e7e8725a39a0015e511a46cc1f7d90cecc180db1610c4d0d4339a9e48bd21"
 dependencies = [
  "serde",
- "vmm-sys-util 0.12.1",
+ "vmm-sys-util",
  "zerocopy 0.7.35",
 ]
 
@@ -957,7 +957,7 @@ dependencies = [
  "bitflags 2.6.0",
  "kvm-bindings",
  "libc",
- "vmm-sys-util 0.12.1",
+ "vmm-sys-util",
 ]
 
 [[package]]
@@ -1090,7 +1090,7 @@ version = "0.1.0"
 source = "git+https://github.com/firecracker-microvm/micro-http?branch=main#8182cd5523b63ceb52ad9d0e7eb6fb95683e6d1b"
 dependencies = [
  "libc",
- "vmm-sys-util 0.12.1",
+ "vmm-sys-util",
 ]
 
 [[package]]
@@ -1122,7 +1122,7 @@ dependencies = [
  "num_enum",
  "serde",
  "serde_derive",
- "vmm-sys-util 0.12.1",
+ "vmm-sys-util",
  "zerocopy 0.7.35",
 ]
 
@@ -1134,14 +1134,14 @@ dependencies = [
  "libc",
  "mshv-bindings",
  "thiserror",
- "vmm-sys-util 0.12.1",
+ "vmm-sys-util",
 ]
 
 [[package]]
 name = "net_gen"
 version = "0.1.0"
 dependencies = [
- "vmm-sys-util 0.12.1",
+ "vmm-sys-util",
 ]
 
 [[package]]
@@ -1164,7 +1164,7 @@ dependencies = [
  "virtio-queue 0.14.0",
  "vm-memory 0.16.1",
  "vm-virtio",
- "vmm-sys-util 0.12.1",
+ "vmm-sys-util",
 ]
 
 [[package]]
@@ -1340,7 +1340,7 @@ dependencies = [
  "vm-device",
  "vm-memory 0.16.1",
  "vm-migration",
- "vmm-sys-util 0.12.1",
+ "vmm-sys-util",
 ]
 
 [[package]]
@@ -1552,7 +1552,7 @@ dependencies = [
  "libc",
  "log",
  "remain",
- "vmm-sys-util 0.12.1",
+ "vmm-sys-util",
 ]
 
 [[package]]
@@ -1600,7 +1600,7 @@ version = "0.1.0"
 dependencies = [
  "libc",
  "log",
- "vmm-sys-util 0.11.2",
+ "vmm-sys-util",
 ]
 
 [[package]]
@@ -2041,7 +2041,7 @@ dependencies = [
  "serde",
  "serde_json",
  "ssh2",
- "vmm-sys-util 0.12.1",
+ "vmm-sys-util",
  "wait-timeout",
 ]
 
@@ -2146,7 +2146,7 @@ dependencies = [
  "libc",
  "log",
  "thiserror",
- "vmm-sys-util 0.12.1",
+ "vmm-sys-util",
 ]
 
 [[package]]
@@ -2212,7 +2212,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43449b404c488f70507dca193debd4bea361fe8089869b947adc19720e464bce"
 dependencies = [
- "vmm-sys-util 0.12.1",
+ "vmm-sys-util",
 ]
 
 [[package]]
@@ -2235,7 +2235,7 @@ dependencies = [
  "thiserror",
  "vfio-bindings 0.4.0",
  "vm-memory 0.14.1",
- "vmm-sys-util 0.12.1",
+ "vmm-sys-util",
 ]
 
 [[package]]
@@ -2250,7 +2250,7 @@ dependencies = [
  "thiserror",
  "vfio-bindings 0.3.1",
  "vm-memory 0.14.1",
- "vmm-sys-util 0.12.1",
+ "vmm-sys-util",
 ]
 
 [[package]]
@@ -2275,7 +2275,7 @@ dependencies = [
  "bitflags 2.6.0",
  "libc",
  "vm-memory 0.14.1",
- "vmm-sys-util 0.12.1",
+ "vmm-sys-util",
 ]
 
 [[package]]
@@ -2287,7 +2287,7 @@ dependencies = [
  "libc",
  "uuid",
  "vm-memory 0.16.1",
- "vmm-sys-util 0.12.1",
+ "vmm-sys-util",
 ]
 
 [[package]]
@@ -2302,7 +2302,7 @@ dependencies = [
  "virtio-bindings 0.2.4",
  "virtio-queue 0.12.0",
  "vm-memory 0.14.1",
- "vmm-sys-util 0.12.1",
+ "vmm-sys-util",
 ]
 
 [[package]]
@@ -2316,7 +2316,7 @@ dependencies = [
  "virtio-bindings 0.2.4",
  "virtio-queue 0.14.0",
  "vm-memory 0.16.1",
- "vmm-sys-util 0.12.1",
+ "vmm-sys-util",
 ]
 
 [[package]]
@@ -2336,7 +2336,7 @@ dependencies = [
  "virtio-bindings 0.1.0",
  "virtio-queue 0.14.0",
  "vm-memory 0.16.1",
- "vmm-sys-util 0.12.1",
+ "vmm-sys-util",
 ]
 
 [[package]]
@@ -2354,7 +2354,7 @@ dependencies = [
  "vhost-user-backend 0.16.1",
  "virtio-bindings 0.1.0",
  "vm-memory 0.16.1",
- "vmm-sys-util 0.12.1",
+ "vmm-sys-util",
 ]
 
 [[package]]
@@ -2401,7 +2401,7 @@ dependencies = [
  "vm-memory 0.16.1",
  "vm-migration",
  "vm-virtio",
- "vmm-sys-util 0.12.1",
+ "vmm-sys-util",
 ]
 
 [[package]]
@@ -2413,7 +2413,7 @@ dependencies = [
  "log",
  "virtio-bindings 0.2.4",
  "vm-memory 0.14.1",
- "vmm-sys-util 0.12.1",
+ "vmm-sys-util",
 ]
 
 [[package]]
@@ -2425,7 +2425,7 @@ dependencies = [
  "log",
  "virtio-bindings 0.2.4",
  "vm-memory 0.14.1",
- "vmm-sys-util 0.12.1",
+ "vmm-sys-util",
 ]
 
 [[package]]
@@ -2437,7 +2437,7 @@ dependencies = [
  "log",
  "virtio-bindings 0.2.4",
  "vm-memory 0.16.1",
- "vmm-sys-util 0.12.1",
+ "vmm-sys-util",
 ]
 
 [[package]]
@@ -2462,7 +2462,7 @@ dependencies = [
  "virtio-bindings 0.2.4",
  "virtio-queue 0.14.0",
  "vm-memory 0.16.1",
- "vmm-sys-util 0.12.1",
+ "vmm-sys-util",
 ]
 
 [[package]]
@@ -2484,7 +2484,7 @@ dependencies = [
  "thiserror",
  "vfio-ioctls",
  "vm-memory 0.16.1",
- "vmm-sys-util 0.12.1",
+ "vmm-sys-util",
 ]
 
 [[package]]
@@ -2502,7 +2502,7 @@ dependencies = [
  "bitflags 2.6.0",
  "libc",
  "thiserror",
- "vmm-sys-util 0.12.1",
+ "vmm-sys-util",
  "winapi",
 ]
 
@@ -2516,7 +2516,7 @@ dependencies = [
  "bitflags 2.6.0",
  "libc",
  "thiserror",
- "vmm-sys-util 0.12.1",
+ "vmm-sys-util",
  "winapi",
 ]
 
@@ -2590,18 +2590,8 @@ dependencies = [
  "vm-memory 0.16.1",
  "vm-migration",
  "vm-virtio",
- "vmm-sys-util 0.12.1",
+ "vmm-sys-util",
  "zerocopy 0.6.6",
-]
-
-[[package]]
-name = "vmm-sys-util"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48b7b084231214f7427041e4220d77dfe726897a6d41fddee450696e66ff2a29"
-dependencies = [
- "bitflags 1.3.2",
- "libc",
 ]
 
 [[package]]

--- a/hypervisor/Cargo.lock
+++ b/hypervisor/Cargo.lock
@@ -235,9 +235,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.10.1"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "capng"

--- a/hypervisor/hypervisor/Cargo.toml
+++ b/hypervisor/hypervisor/Cargo.toml
@@ -32,4 +32,4 @@ default-features = false
 features = ["std", "decoder", "op_code_info", "instr_info", "fast_fmt"]
 
 [dev-dependencies]
-env_logger = "0.9.3"
+env_logger = "0.10.2"

--- a/hypervisor/rate_limiter/Cargo.toml
+++ b/hypervisor/rate_limiter/Cargo.toml
@@ -6,4 +6,4 @@ edition = "2021"
 [dependencies]
 libc = "0.2.137"
 log = "0.4.17"
-vmm-sys-util = "0.11.1"
+vmm-sys-util = { workspace = true }

--- a/hypervisor/vhost_user_block/Cargo.toml
+++ b/hypervisor/vhost_user_block/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 [dependencies]
 block_util = { path = "../block_util" }
 clap = { version = "4.4.7", features = ["wrap_help", "cargo"] }
-env_logger = "0.9.3"
+env_logger = "0.10.2"
 epoll = "4.3.1"
 libc = "0.2.137"
 log = "0.4.17"

--- a/hypervisor/vhost_user_net/Cargo.toml
+++ b/hypervisor/vhost_user_net/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 
 [dependencies]
 clap = { version = "4.4.7", features = ["wrap_help", "cargo"] }
-env_logger = "0.9.3"
+env_logger = "0.10.2"
 epoll = "4.3.1"
 libc = "0.2.137"
 log = "0.4.17"

--- a/hypervisor/virtiofsd/Cargo.toml
+++ b/hypervisor/virtiofsd/Cargo.toml
@@ -20,7 +20,7 @@ xen = ["vhost-user-backend/xen", "vhost/xen", "vm-memory/xen"]
 anyhow = "1.0.66"
 bitflags = "1.2"
 capng = "0.2.2"
-env_logger = "0.8.4"
+env_logger = "0.10.2"
 futures = { version = "0.3", features = ["thread-pool"] }
 libc = "0.2.155"
 log = "0.4"


### PR DESCRIPTION
## Summary

Address five Dependabot security alerts reported against this repository.
All fixes are dependency-only (no business logic changes); each commit is
independently buildable via `make shim` to keep `git bisect` clean.

## Alerts Fixed

| Commit | Component | Advisory | Action |
| --- | --- | --- | --- |
| `ee9b9c4` | (multi) | CVE-2026-25727 | bump `time` 0.3.36 → 0.3.47 |
| `1725951` | hypervisor | CVE-2023-50711 / GHSA-875g-mfp6-g7f9 | bump `vmm-sys-util` in `rate_limiter` 0.11.1 → 0.12.1 |
| `a004cc4` | hypervisor + shim | CVE-2026-25541 / GHSA-434x-w66g-qw3r / RUSTSEC-2026-0007 | bump `bytes` to 1.11.1 (transitive) |
| `d195743` | agent | CVE-2026-25541 | bump `bytes` to 1.11.1 (transitive) |
| `70ffc5c` | hypervisor + shim | GHSA-g98v-hv3f-hcfr | bump `env_logger` to 0.10.2, dropping unmaintained `atty` |

## Notes on Commit Layout

- `bytes` and `env_logger` updates touch both `hypervisor/Cargo.lock` and
  `CubeShim/Cargo.lock` in a single commit, because CubeShim links
  `hypervisor` via a `path` dependency and `make shim --locked` requires
  both lockfiles to stay in sync. The `agent` workspace is independent and
  is upgraded in its own commit.
- No `Cargo.toml` change for `bytes` (transitive dep, lockfile only).
- `env_logger` upgrade also removes `atty` from the dependency graph for
  the hypervisor and shim builds; the codebase only uses
  `env_logger::init()` / `try_init()` which are stable across 0.8 → 0.10.

## Verification

- `make shim` passes for every commit in this PR (verified via
  `git checkout <SHA> && make shim` for each).
- No `Cargo.toml` API consumers need to change; `cargo build --release
  --locked` succeeds end-to-end.

## Checklist

- [x] All commits include `Signed-off-by` (DCO).
- [x] All commits include `Assisted-by: CodeBuddy:Claude-Opus-4.7` per
  AGENTS.md.
- [x] No business logic / source code changes.
