### PR TITLE
cubeapi: fix paused state parsing in sandbox list

### DIFF
--- a/CubeAPI/src/cubemaster/mod.rs
+++ b/CubeAPI/src/cubemaster/mod.rs
@@ -869,9 +869,9 @@ enum SandboxStatusValue {
 fn sandbox_status_text_from_code(number: i32) -> &'static str {
     match number {
         1 => "running",
-        2 => "paused",
-        3 => "stopped",
-        4 => "error",
+        2 => "stopped",
+        4 => "pausing",
+        5 => "paused",
         _ => "unknown",
     }
 }
@@ -896,7 +896,8 @@ fn normalize_sandbox_status_text(raw: &str) -> String {
         "2" => sandbox_status_text_from_code(2).to_string(),
         "3" => sandbox_status_text_from_code(3).to_string(),
         "4" => sandbox_status_text_from_code(4).to_string(),
-        "running" | "paused" | "stopped" | "error" => raw.trim().to_lowercase(),
+        "5" => sandbox_status_text_from_code(5).to_string(),
+        "running" | "paused" | "pausing" | "stopped" | "error" => raw.trim().to_lowercase(),
         other => other.to_string(),
     }
 }

--- a/CubeAPI/src/services/sandboxes.rs
+++ b/CubeAPI/src/services/sandboxes.rs
@@ -682,8 +682,8 @@ mod tests {
     use std::collections::HashMap;
 
     use super::{build_cubevs_context, filter_by_metadata, from_cubemaster_info};
-    use crate::cubemaster::SandboxInfo;
-    use crate::models::SandboxNetworkConfig;
+    use crate::cubemaster::{ListSandboxResponse, SandboxInfo};
+    use crate::models::{SandboxNetworkConfig, SandboxState};
 
     #[test]
     fn metadata_filter_matches_all_pairs() {
@@ -736,5 +736,37 @@ mod tests {
         assert_eq!(listed.cpu_count, 2);
         assert_eq!(listed.memory_mb, 2048);
         assert_eq!(listed.template_id, "tpl-1");
+    }
+
+    #[test]
+    fn listed_sandbox_maps_paused_container_state_from_cubemaster_list() {
+        let payload = serde_json::json!({
+            "requestID": "req-1",
+            "ret": { "ret_code": 0, "ret_msg": "ok" },
+            "data": [{
+                "sandbox_id": "sb-paused",
+                "host_id": "host-1",
+                "status": 5,
+                "template_id": "tpl-1"
+            }, {
+                "sandbox_id": "sb-paused-string",
+                "host_id": "host-1",
+                "status": "5",
+                "template_id": "tpl-1"
+            }]
+        });
+
+        let response: ListSandboxResponse =
+            serde_json::from_value(payload).expect("list response should deserialize");
+        let listed: Vec<_> = response
+            .sandboxes
+            .into_iter()
+            .map(from_cubemaster_info)
+            .collect();
+
+        assert_eq!(listed.len(), 2);
+        assert!(listed
+            .iter()
+            .all(|sandbox| sandbox.state == SandboxState::Paused));
     }
 }


### PR DESCRIPTION
## Summary

- Fix CubeAPI list status parsing for CubeMaster/Cubelet container state values.
- Return `paused` for list entries whose CubeMaster status is `CONTAINER_PAUSED` (`5`).
- Add a focused regression test for numeric and string paused list status values.

Fixes #218

## Tests

- `cargo fmt --check`
- `cargo +stable test`
- `cargo +stable clippy --all-targets --all-features`
- Local HTTP verification with CubeAPI against a mock CubeMaster:
  - `GET /sandboxes` returns `state: paused`
  - `GET /sandboxes/{id}` still returns `state: paused`
  - `GET /v2/sandboxes?state=paused` returns the paused sandbox

Note: repo rust-toolchain `1.85.1` cannot run the current lockfile locally because `time@0.3.47` requires rustc 1.88+.
