### PR TITLE
[codex] Expose host CPU burst

### DIFF
--- a/CubeMaster/cmd/cubemastercli/commands/cubebox/template.go
+++ b/CubeMaster/cmd/cubemastercli/commands/cubebox/template.go
@@ -769,6 +769,7 @@ var TemplateCreateFromImageCommand = cli.Command{
 		cli.IntFlag{Name: "probe", Usage: "enable HTTP GET probe on the specified port (e.g. --probe 9000); sets timeout_ms=30000, period_ms=500"},
 		cli.StringFlag{Name: "probe-path", Value: "/health", Usage: "HTTP path for the readiness probe (default: /health); only effective when --probe is set"},
 		cli.IntFlag{Name: "cpu", Value: 2000, Usage: "CPU millicores for the template container (default: 2000, i.e. 2 cores)"},
+		cli.IntFlag{Name: "host-burst-cpu", Usage: "Host CPU burst ceiling in millicores for the template container, e.g. 4000 for 4 cores"},
 		cli.IntFlag{Name: "memory", Value: 2000, Usage: "Memory for the template container in MB (default: 2000 MB)"},
 		cli.BoolFlag{Name: "json", Usage: "print raw json response"},
 	},
@@ -1371,9 +1372,10 @@ func parseContainerOverrides(c *cli.Context) (*types.ContainerOverrides, error) 
 	dnsServers := c.StringSlice("dns")
 	probePort := c.Int("probe")
 	cpuMillicores := c.Int("cpu")
+	hostBurstCPUMillicores := c.Int("host-burst-cpu")
 	memoryMB := c.Int("memory")
 
-	if len(cmds) == 0 && len(args) == 0 && len(rawEnvs) == 0 && len(dnsServers) == 0 && probePort == 0 && !c.IsSet("cpu") && !c.IsSet("memory") {
+	if len(cmds) == 0 && len(args) == 0 && len(rawEnvs) == 0 && len(dnsServers) == 0 && probePort == 0 && !c.IsSet("cpu") && !c.IsSet("host-burst-cpu") && !c.IsSet("memory") {
 		return nil, nil
 	}
 
@@ -1402,10 +1404,21 @@ func parseContainerOverrides(c *cli.Context) (*types.ContainerOverrides, error) 
 		}
 		overrides.DnsConfig = &types.DNSConfig{Servers: dnsServers}
 	}
-	if c.IsSet("cpu") || c.IsSet("memory") {
+	if c.IsSet("cpu") || c.IsSet("host-burst-cpu") || c.IsSet("memory") {
 		overrides.Resources = &types.Resource{
 			Cpu: fmt.Sprintf("%dm", cpuMillicores),
 			Mem: fmt.Sprintf("%dMi", memoryMB),
+		}
+		if c.IsSet("host-burst-cpu") {
+			if hostBurstCPUMillicores < cpuMillicores {
+				return nil, fmt.Errorf("host-burst-cpu must be >= cpu")
+			}
+			if hostBurstCPUMillicores > cpuMillicores*2 {
+				return nil, fmt.Errorf("host-burst-cpu must be <= 2 * cpu")
+			}
+			overrides.Resources.HostBurst = &types.HostResourceBurst{
+				Cpu: fmt.Sprintf("%dm", hostBurstCPUMillicores),
+			}
 		}
 	}
 	if probePort > 0 {

--- a/CubeMaster/cmd/cubemastercli/commands/cubebox/template_test.go
+++ b/CubeMaster/cmd/cubemastercli/commands/cubebox/template_test.go
@@ -231,6 +231,57 @@ func TestParseContainerOverridesCustomCpuAndMemory(t *testing.T) {
 	}
 }
 
+func TestParseContainerOverridesHostBurstCPU(t *testing.T) {
+	ctx := newCreateFromImageContext(t, []string{"--cpu", "2000", "--memory", "2048", "--host-burst-cpu", "4000"})
+	overrides, err := parseContainerOverrides(ctx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if overrides == nil || overrides.Resources == nil || overrides.Resources.HostBurst == nil {
+		t.Fatal("expected host burst resources to be set")
+	}
+	if overrides.Resources.Cpu != "2000m" {
+		t.Fatalf("expected Cpu=2000m, got %q", overrides.Resources.Cpu)
+	}
+	if overrides.Resources.Mem != "2048Mi" {
+		t.Fatalf("expected Mem=2048Mi, got %q", overrides.Resources.Mem)
+	}
+	if overrides.Resources.HostBurst.Cpu != "4000m" {
+		t.Fatalf("expected HostBurst.Cpu=4000m, got %q", overrides.Resources.HostBurst.Cpu)
+	}
+}
+
+func TestParseContainerOverridesHostBurstCPUUsesDefaultResources(t *testing.T) {
+	ctx := newCreateFromImageContext(t, []string{"--host-burst-cpu", "4000"})
+	overrides, err := parseContainerOverrides(ctx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if overrides == nil || overrides.Resources == nil || overrides.Resources.HostBurst == nil {
+		t.Fatal("expected host burst resources to be set")
+	}
+	if overrides.Resources.Cpu != "2000m" {
+		t.Fatalf("expected Cpu=2000m, got %q", overrides.Resources.Cpu)
+	}
+	if overrides.Resources.Mem != "2000Mi" {
+		t.Fatalf("expected Mem=2000Mi, got %q", overrides.Resources.Mem)
+	}
+	if overrides.Resources.HostBurst.Cpu != "4000m" {
+		t.Fatalf("expected HostBurst.Cpu=4000m, got %q", overrides.Resources.HostBurst.Cpu)
+	}
+}
+
+func TestParseContainerOverridesRejectsHostBurstCPUBelowCPU(t *testing.T) {
+	ctx := newCreateFromImageContext(t, []string{"--cpu", "2000", "--host-burst-cpu", "1000"})
+	_, err := parseContainerOverrides(ctx)
+	if err == nil {
+		t.Fatal("expected error for host-burst-cpu below cpu")
+	}
+	if !strings.Contains(err.Error(), "host-burst-cpu must be >= cpu") {
+		t.Fatalf("error = %q, want host-burst lower bound error", err.Error())
+	}
+}
+
 func TestParseContainerOverridesDNS(t *testing.T) {
 	ctx := newCreateFromImageContext(t, []string{"--dns", "8.8.8.8", "--dns", "1.1.1.1"})
 	overrides, err := parseContainerOverrides(ctx)
@@ -348,14 +399,14 @@ func TestFormatTemplateImageJobWatchLineIncludesError(t *testing.T) {
 
 func TestFormatTemplateImageJobCompletionSummarySuccess(t *testing.T) {
 	job := &types.TemplateImageJobInfo{
-		Status:             "READY",
-		TemplateID:         "tpl-1",
-		JobID:              "job-1",
-		ArtifactID:         "artifact-1",
-		ExpectedNodeCount:  2,
-		ReadyNodeCount:     2,
-		FailedNodeCount:    0,
-		TemplateStatus:     "READY",
+		Status:                  "READY",
+		TemplateID:              "tpl-1",
+		JobID:                   "job-1",
+		ArtifactID:              "artifact-1",
+		ExpectedNodeCount:       2,
+		ReadyNodeCount:          2,
+		FailedNodeCount:         0,
+		TemplateStatus:          "READY",
 		TemplateSpecFingerprint: "sha256:abc",
 	}
 

--- a/CubeMaster/pkg/base/constants/constants.go
+++ b/CubeMaster/pkg/base/constants/constants.go
@@ -52,6 +52,7 @@ const (
 	CubeAnnotationsInsHostUUID              = "cube.master.instance.host_uuid"
 	CubeAnnotationsInsHostCpuTotal          = "cube.master.instance.host_cpu_total"
 	CubeAnnotationsInsHostVirtualQuotaArray = "cube.master.instance.host_virtual_quota_array"
+	CubeAnnotationsHostCPUBurst             = "cube.master.instance.host_cpu_burst"
 	CubeAnnotationsPICMode                  = "cube.master.instance.pic_mode"
 	CubeAnnotationsDisableVmCgroup          = "cube.master.disable_vm_cgroup"
 	CubeAnnotationsDisableHostCgroup        = "cube.master.disable_host_cgroup"

--- a/CubeMaster/pkg/service/httpservice/cube/cubeboxutil.go
+++ b/CubeMaster/pkg/service/httpservice/cube/cubeboxutil.go
@@ -192,6 +192,9 @@ func applyTemplateResources(resourceIn *types.Resource, resourceOut *types.Resou
 	if resourceIn.Limit != nil {
 		resourceOut.Limit = resourceIn.Limit
 	}
+	if resourceIn.HostBurst != nil {
+		resourceOut.HostBurst = resourceIn.HostBurst
+	}
 }
 
 func applyTemplateImageSpec(imageSpecIn *types.ImageSpec, imageSpecOut *types.ImageSpec) {

--- a/CubeMaster/pkg/service/sandbox/sandbox_test.go
+++ b/CubeMaster/pkg/service/sandbox/sandbox_test.go
@@ -11,11 +11,13 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/api/services/cubebox/v1"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/config"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/constants"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/log"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/utils"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/service/sandbox/types"
@@ -90,6 +92,68 @@ func TestReqResource(t *testing.T) {
 
 	assert.Equal(t, cpu.String(), "5")
 }
+
+func TestCheckAndGetContainersSetsHostCPUBurstAnnotation(t *testing.T) {
+	req := &types.CreateCubeSandboxReq{
+		Containers: []*types.Container{
+			{
+				Name:  "runtime-sidecar",
+				Image: &types.ImageSpec{Image: "busybox:latest"},
+				Resources: &types.Resource{
+					Cpu: "1",
+					Mem: "128Mi",
+					HostBurst: &types.HostResourceBurst{
+						Cpu: "2",
+					},
+				},
+			},
+			{
+				Name:  "worker",
+				Image: &types.ImageSpec{Image: "busybox:latest"},
+				Resources: &types.Resource{
+					Cpu: "1",
+					Mem: "128Mi",
+				},
+			},
+		},
+	}
+	out := &cubebox.RunCubeSandboxRequest{Annotations: map[string]string{}}
+
+	if err := checkAndGetContainers(req, out); err != nil {
+		t.Fatalf("checkAndGetContainers returned error: %v", err)
+	}
+
+	if got := out.Annotations[constants.CubeAnnotationsHostCPUBurst]; got != "3" {
+		t.Fatalf("host cpu burst annotation = %q, want %q", got, "3")
+	}
+}
+
+func TestCheckAndGetContainersRejectsHostCPUBurstBelowCPU(t *testing.T) {
+	req := &types.CreateCubeSandboxReq{
+		Containers: []*types.Container{
+			{
+				Name: "runtime-sidecar",
+				Resources: &types.Resource{
+					Cpu: "1",
+					Mem: "128Mi",
+					HostBurst: &types.HostResourceBurst{
+						Cpu: "500m",
+					},
+				},
+			},
+		},
+	}
+	out := &cubebox.RunCubeSandboxRequest{Annotations: map[string]string{}}
+
+	err := checkAndGetContainers(req, out)
+	if err == nil {
+		t.Fatal("checkAndGetContainers returned nil error, want error")
+	}
+	if !strings.Contains(err.Error(), "host cpu burst must be >= cpu") {
+		t.Fatalf("error = %q, want host cpu burst validation error", err.Error())
+	}
+}
+
 func TestBackoffRetryDelay(t *testing.T) {
 	c := &createSandboxContext{}
 	for i := 0; i < int(config.GetConfig().CubeletConf.LoopMaxRetries); i++ {

--- a/CubeMaster/pkg/service/sandbox/types/types.go
+++ b/CubeMaster/pkg/service/sandbox/types/types.go
@@ -70,12 +70,18 @@ type Resource struct {
 	Mem string `json:"mem,omitempty"`
 
 	Limit *RequestLimit `json:"limit,omitempty"`
+
+	HostBurst *HostResourceBurst `json:"host_burst,omitempty"`
 }
 
 type RequestLimit struct {
 	Cpu string `json:"cpu,omitempty"`
 
 	Mem string `json:"mem,omitempty"`
+}
+
+type HostResourceBurst struct {
+	Cpu string `json:"cpu,omitempty"`
 }
 
 type CubeVSContext struct {

--- a/CubeMaster/pkg/service/sandbox/util.go
+++ b/CubeMaster/pkg/service/sandbox/util.go
@@ -219,6 +219,16 @@ func getExposedPorts(req *types.CreateCubeSandboxReq, out *cubebox.RunCubeSandbo
 	return nil
 }
 func checkAndGetContainers(req *types.CreateCubeSandboxReq, out *cubebox.RunCubeSandboxRequest) error {
+	hostCPUBurst, hasHostCPUBurst, err := aggregateHostCPUBurst(req.Containers)
+	if err != nil {
+		return err
+	}
+	if hasHostCPUBurst {
+		if out.Annotations == nil {
+			out.Annotations = make(map[string]string)
+		}
+		out.Annotations[constants.CubeAnnotationsHostCPUBurst] = hostCPUBurst.String()
+	}
 
 	for _, cnt := range req.Containers {
 		if cnt.Resources == nil {
@@ -282,6 +292,64 @@ func checkAndGetContainers(req *types.CreateCubeSandboxReq, out *cubebox.RunCube
 		out.Containers = append(out.Containers, c)
 	}
 	return nil
+}
+
+func aggregateHostCPUBurst(containers []*types.Container) (resource.Quantity, bool, error) {
+	total := resource.MustParse("0")
+	hasHostCPUBurst := false
+
+	for _, ctr := range containers {
+		if ctr.Resources == nil {
+			continue
+		}
+		if ctr.Resources.HostBurst != nil && strings.TrimSpace(ctr.Resources.HostBurst.Cpu) != "" {
+			hasHostCPUBurst = true
+			break
+		}
+	}
+	if !hasHostCPUBurst {
+		return total, false, nil
+	}
+
+	for _, ctr := range containers {
+		if ctr.Resources == nil {
+			continue
+		}
+
+		cpuQuantity, err := resource.ParseQuantity(ctr.Resources.Cpu)
+		if err != nil {
+			return total, false, fmt.Errorf("parse container %q cpu limit: %w", ctr.Name, err)
+		}
+
+		hostCPUBurst := ""
+		if ctr.Resources.HostBurst != nil {
+			hostCPUBurst = strings.TrimSpace(ctr.Resources.HostBurst.Cpu)
+		}
+		if hostCPUBurst == "" {
+			total.Add(cpuQuantity)
+			continue
+		}
+
+		cpuBurstQuantity, err := resource.ParseQuantity(hostCPUBurst)
+		if err != nil {
+			return total, false, fmt.Errorf("parse container %q host cpu burst: %w", ctr.Name, err)
+		}
+		if cpuBurstQuantity.Sign() <= 0 {
+			return total, false, fmt.Errorf("container %q host cpu burst must be > 0", ctr.Name)
+		}
+		if cpuBurstQuantity.Cmp(cpuQuantity) < 0 {
+			return total, false, fmt.Errorf("container %q host cpu burst must be >= cpu", ctr.Name)
+		}
+		maxBurstQuantity := cpuQuantity.DeepCopy()
+		maxBurstQuantity.Add(cpuQuantity)
+		if cpuBurstQuantity.Cmp(maxBurstQuantity) > 0 {
+			return total, false, fmt.Errorf("container %q host cpu burst must be <= 2 * cpu", ctr.Name)
+		}
+
+		total.Add(cpuBurstQuantity)
+	}
+
+	return total, true, nil
 }
 
 func checkAndGetImageSpec(c *cubebox.ContainerConfig, cnt *types.Container) error {

--- a/Cubelet/pkg/constants/const.go
+++ b/Cubelet/pkg/constants/const.go
@@ -179,6 +179,7 @@ const (
 	MasterAnnotationsInsHostUUID              = "cube.master.instance.host_uuid"
 	MasterAnnotationsInsHostCpuTotal          = "cube.master.instance.host_cpu_total"
 	MasterAnnotationsInsHostVirtualQuotaArray = "cube.master.instance.host_virtual_quota_array"
+	MasterAnnotationsHostCPUBurst             = "cube.master.instance.host_cpu_burst"
 	MasterAnnotationsDisableVmCgroup          = "cube.master.disable_vm_cgroup"
 	MasterAnnotationsDisableHostCgroup        = "cube.master.disable_host_cgroup"
 	MasterAnnotationsUpdateAction             = "cube.master.update_action"

--- a/Cubelet/pkg/store/cubebox/cubebox.go
+++ b/Cubelet/pkg/store/cubebox/cubebox.go
@@ -87,6 +87,7 @@ func (m *Metadata) AddLabels(labels map[string]string) {
 type ResourceWithOverHead struct {
 	MemReq,
 	HostCpuQ,
+	HostCpuBurstQ,
 	HostMemQ,
 	VmCpuQ,
 	VmMemQ,
@@ -94,8 +95,8 @@ type ResourceWithOverHead struct {
 }
 
 func (rq *ResourceWithOverHead) String() string {
-	return fmt.Sprintf("MemReq: %v, HostCpuQ: %v, HostMemQ: %v, VmCpuQ: %v, VmMemQ: %v, PmemPageQ: %v",
-		rq.MemReq.String(), rq.HostCpuQ.String(), rq.HostMemQ.String(), rq.VmCpuQ.String(), rq.VmMemQ.String(), rq.PmemPageQ.String())
+	return fmt.Sprintf("MemReq: %v, HostCpuQ: %v, HostCpuBurstQ: %v, HostMemQ: %v, VmCpuQ: %v, VmMemQ: %v, PmemPageQ: %v",
+		rq.MemReq.String(), rq.HostCpuQ.String(), rq.HostCpuBurstQ.String(), rq.HostMemQ.String(), rq.VmCpuQ.String(), rq.VmMemQ.String(), rq.PmemPageQ.String())
 }
 
 type CubeBox struct {

--- a/Cubelet/pkg/store/cubebox/deepcopy.go
+++ b/Cubelet/pkg/store/cubebox/deepcopy.go
@@ -155,12 +155,13 @@ func (r *ResourceWithOverHead) DeepCopy() *ResourceWithOverHead {
 		return nil
 	}
 	return &ResourceWithOverHead{
-		MemReq:    r.MemReq.DeepCopy(),
-		HostCpuQ:  r.HostCpuQ.DeepCopy(),
-		HostMemQ:  r.HostMemQ.DeepCopy(),
-		VmCpuQ:    r.VmCpuQ.DeepCopy(),
-		VmMemQ:    r.VmMemQ.DeepCopy(),
-		PmemPageQ: r.PmemPageQ.DeepCopy(),
+		MemReq:        r.MemReq.DeepCopy(),
+		HostCpuQ:      r.HostCpuQ.DeepCopy(),
+		HostCpuBurstQ: r.HostCpuBurstQ.DeepCopy(),
+		HostMemQ:      r.HostMemQ.DeepCopy(),
+		VmCpuQ:        r.VmCpuQ.DeepCopy(),
+		VmMemQ:        r.VmMemQ.DeepCopy(),
+		PmemPageQ:     r.PmemPageQ.DeepCopy(),
 	}
 }
 

--- a/Cubelet/plugins/cube/internals/cgroup/cgroup.go
+++ b/Cubelet/plugins/cube/internals/cgroup/cgroup.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"strings"
 	"time"
 
 	jsoniter "github.com/json-iterator/go"
@@ -131,8 +132,14 @@ func (overhead *OverheadConfig) GetResourceWithOverhead(ctx context.Context, rea
 		rq.VmCpuQ = cpuQuantity.DeepCopy()
 		rq.VmMemQ = memQuantity.DeepCopy()
 		rq.PmemPageQ = resource.MustParse("0")
+		if err := applyHostCPUBurst(realReq, rq, resource.MustParse("0")); err != nil {
+			return nil, err
+		}
 		return rq, nil
 	}
+
+	hostCPUOverhead := overhead.VmCpu.DeepCopy()
+	hostCPUOverhead.Add(overhead.HostCpu)
 
 	cpuQuantity.Add(overhead.VmCpu)
 	rq.VmCpuQ = cpuQuantity.DeepCopy()
@@ -153,7 +160,38 @@ func (overhead *OverheadConfig) GetResourceWithOverhead(ctx context.Context, rea
 	memOverheadVarQuantity.Add(rq.PmemPageQ)
 	rq.VmMemQ = ceilMemQuota(*memOverheadVarQuantity)
 
+	if err := applyHostCPUBurst(realReq, rq, hostCPUOverhead); err != nil {
+		return nil, err
+	}
+
 	return rq, nil
+}
+
+func applyHostCPUBurst(realReq *cubebox.RunCubeSandboxRequest, rq *cubeboxstore.ResourceWithOverHead, overhead resource.Quantity) error {
+	hostCPUBurst := strings.TrimSpace(realReq.GetAnnotations()[constants.MasterAnnotationsHostCPUBurst])
+	if hostCPUBurst == "" {
+		return nil
+	}
+
+	hostCPUBurstQuantity, err := resource.ParseQuantity(hostCPUBurst)
+	if err != nil {
+		return fmt.Errorf("parse host cpu burst: %w", err)
+	}
+	if hostCPUBurstQuantity.Sign() <= 0 {
+		return fmt.Errorf("host cpu burst must be > 0")
+	}
+	hostCPUBurstQuantity.Add(overhead)
+	if hostCPUBurstQuantity.Cmp(rq.HostCpuQ) < 0 {
+		return fmt.Errorf("host cpu burst must be >= host cpu quota")
+	}
+	hostCPUBurstExtra := hostCPUBurstQuantity.DeepCopy()
+	hostCPUBurstExtra.Sub(rq.HostCpuQ)
+	if hostCPUBurstExtra.Cmp(rq.HostCpuQ) > 0 {
+		return fmt.Errorf("host cpu burst extra must be <= host cpu quota")
+	}
+
+	rq.HostCpuBurstQ = hostCPUBurstQuantity
+	return nil
 }
 
 func (overhead *OverheadConfig) MatchVMSnapshotSpec(ctx context.Context, req cubeboxstore.ResourceWithOverHead,
@@ -216,11 +254,11 @@ func (overhead *OverheadConfig) MatchVMSnapshotSpec(ctx context.Context, req cub
 	return vmResource, &req
 }
 
-func SetCubeboxCgroupLimit(ctx context.Context, group string, cpuQ resource.Quantity, memQ resource.Quantity, usePoolV2 bool) error {
+func SetCubeboxCgroupLimit(ctx context.Context, group string, cpuQ resource.Quantity, memQ resource.Quantity, cpuBurstQ resource.Quantity, usePoolV2 bool) error {
 	if usePoolV2 {
-		return l.poolV2Handle.Update(ctx, group, cpuQ, memQ)
+		return l.poolV2Handle.Update(ctx, group, cpuQ, memQ, cpuBurstQ)
 	}
-	return l.poolV1Handle.Update(ctx, group, cpuQ, memQ)
+	return l.poolV1Handle.Update(ctx, group, cpuQ, memQ, cpuBurstQ)
 }
 
 func AddProc(path string, pid uint64) error {

--- a/Cubelet/plugins/cube/internals/cgroup/cgroup_test.go
+++ b/Cubelet/plugins/cube/internals/cgroup/cgroup_test.go
@@ -1,0 +1,99 @@
+// Copyright (c) 2024 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package cgroup
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/tencentcloud/CubeSandbox/Cubelet/api/services/cubebox/v1"
+	"github.com/tencentcloud/CubeSandbox/Cubelet/pkg/constants"
+)
+
+func TestGetResourceWithOverheadUsesHostCPUBurstAnnotation(t *testing.T) {
+	req := &cubebox.RunCubeSandboxRequest{
+		InstanceType: cubebox.InstanceType_cubebox.String(),
+		Annotations: map[string]string{
+			constants.MasterAnnotationsHostCPUBurst: "2",
+		},
+		Containers: []*cubebox.ContainerConfig{
+			{
+				Name: "runtime-sidecar",
+				Resources: &cubebox.Resource{
+					Cpu: "1",
+					Mem: "128Mi",
+				},
+			},
+		},
+	}
+
+	rq, err := (&OverheadConfig{}).GetResourceWithOverhead(context.Background(), req, nil)
+	if err != nil {
+		t.Fatalf("GetResourceWithOverhead returned error: %v", err)
+	}
+
+	if got := rq.HostCpuQ.String(); got != "1" {
+		t.Fatalf("HostCpuQ = %q, want %q", got, "1")
+	}
+	if got := rq.HostCpuBurstQ.String(); got != "2" {
+		t.Fatalf("HostCpuBurstQ = %q, want %q", got, "2")
+	}
+	if got := rq.VmCpuQ.String(); got != "1" {
+		t.Fatalf("VmCpuQ = %q, want %q", got, "1")
+	}
+}
+
+func TestGetResourceWithOverheadRejectsInvalidHostCPUBurstAnnotation(t *testing.T) {
+	req := &cubebox.RunCubeSandboxRequest{
+		InstanceType: cubebox.InstanceType_cubebox.String(),
+		Annotations: map[string]string{
+			constants.MasterAnnotationsHostCPUBurst: "not-a-cpu",
+		},
+		Containers: []*cubebox.ContainerConfig{
+			{
+				Name: "runtime-sidecar",
+				Resources: &cubebox.Resource{
+					Cpu: "1",
+					Mem: "128Mi",
+				},
+			},
+		},
+	}
+
+	_, err := (&OverheadConfig{}).GetResourceWithOverhead(context.Background(), req, nil)
+	if err == nil {
+		t.Fatal("GetResourceWithOverhead returned nil error, want error")
+	}
+	if !strings.Contains(err.Error(), "parse host cpu burst") {
+		t.Fatalf("error = %q, want host cpu burst parse error", err.Error())
+	}
+}
+
+func TestGetResourceWithOverheadRejectsExcessiveHostCPUBurstAnnotation(t *testing.T) {
+	req := &cubebox.RunCubeSandboxRequest{
+		InstanceType: cubebox.InstanceType_cubebox.String(),
+		Annotations: map[string]string{
+			constants.MasterAnnotationsHostCPUBurst: "3",
+		},
+		Containers: []*cubebox.ContainerConfig{
+			{
+				Name: "runtime-sidecar",
+				Resources: &cubebox.Resource{
+					Cpu: "1",
+					Mem: "128Mi",
+				},
+			},
+		},
+	}
+
+	_, err := (&OverheadConfig{}).GetResourceWithOverhead(context.Background(), req, nil)
+	if err == nil {
+		t.Fatal("GetResourceWithOverhead returned nil error, want error")
+	}
+	if !strings.Contains(err.Error(), "host cpu burst extra must be <= host cpu quota") {
+		t.Fatalf("error = %q, want host cpu burst range error", err.Error())
+	}
+}

--- a/Cubelet/plugins/cube/internals/cgroup/handle/interface.go
+++ b/Cubelet/plugins/cube/internals/cgroup/handle/interface.go
@@ -6,6 +6,7 @@ package handle
 
 import (
 	"context"
+	"fmt"
 
 	"k8s.io/apimachinery/pkg/api/resource"
 )
@@ -14,7 +15,7 @@ type Interface interface {
 	IsExist(ctx context.Context, group string) bool
 	Create(ctx context.Context, group string) error
 	CreateWithCpuSet(ctx context.Context, group string, cpuset string, numaId int) error
-	Update(ctx context.Context, group string, cpu, mem resource.Quantity) error
+	Update(ctx context.Context, group string, cpu, mem, cpuBurst resource.Quantity) error
 	Delete(ctx context.Context, group string) error
 	List() ([]string, error)
 	ListSubdir(subdir string) ([]string, error)
@@ -39,3 +40,19 @@ var (
 	DefaultCPUPeriod  uint64 = 100000
 	DefaultMCPUPeriod uint64 = 100
 )
+
+func CPUBurstQuota(cpu, cpuBurst resource.Quantity) (uint64, bool, error) {
+	if cpuBurst.IsZero() {
+		return 0, false, nil
+	}
+	if cpuBurst.Cmp(cpu) < 0 {
+		return 0, false, fmt.Errorf("cpu burst %s must be >= cpu quota %s", cpuBurst.String(), cpu.String())
+	}
+
+	extra := cpuBurst.DeepCopy()
+	extra.Sub(cpu)
+	if extra.Cmp(cpu) > 0 {
+		return 0, false, fmt.Errorf("cpu burst extra %s must be <= cpu quota %s", extra.String(), cpu.String())
+	}
+	return uint64(extra.MilliValue()) * DefaultMCPUPeriod, true, nil
+}

--- a/Cubelet/plugins/cube/internals/cgroup/handle/v1/manager.go
+++ b/Cubelet/plugins/cube/internals/cgroup/handle/v1/manager.go
@@ -127,7 +127,7 @@ func SingleSubsystem(baseHierarchy cgroup1.Hierarchy, needSystemName []cgroup1.N
 	}
 }
 
-func (h *handler) Update(ctx context.Context, group string, cpu, mem resource.Quantity) error {
+func (h *handler) Update(ctx context.Context, group string, cpu, mem, cpuBurst resource.Quantity) error {
 	cpuQuota := cpu.MilliValue() * 100
 	memMax := mem.Value()
 	res := &specs.LinuxResources{
@@ -152,6 +152,31 @@ func (h *handler) Update(ctx context.Context, group string, cpu, mem resource.Qu
 	}
 	err = m.Update(res)
 	if err != nil {
+		return err
+	}
+	if err = h.updateCPUBurst(ctx, group, cpu, cpuBurst); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (h *handler) updateCPUBurst(ctx context.Context, group string, cpu, cpuBurst resource.Quantity) error {
+	cpuBurstQuota, configured, err := handle.CPUBurstQuota(cpu, cpuBurst)
+	if err != nil {
+		return err
+	}
+
+	cpuBurstFilePath := path.Join(h.root, "cpu", group, "cpu.cfs_burst_us")
+	if exist, _ := utils.DenExist(cpuBurstFilePath); !exist {
+		if configured {
+			return fmt.Errorf("cpu burst unsupported: %s not found", cpuBurstFilePath)
+		}
+		return nil
+	}
+
+	err = os.WriteFile(cpuBurstFilePath, []byte(strconv.FormatUint(cpuBurstQuota, 10)), 0644)
+	if err != nil {
+		log.G(ctx).Errorf("set cpu burst error %v", err)
 		return err
 	}
 	return nil
@@ -218,11 +243,19 @@ func (h *handler) AddProc(group string, pid uint64) error {
 
 func (h *handler) RemoveLimit(ctx context.Context, group string) error {
 	cpuLimitFilePath := path.Join(h.root, "cpu", group, "cpu.cfs_quota_us")
+	cpuBurstFilePath := path.Join(h.root, "cpu", group, "cpu.cfs_burst_us")
 	memLimitFilePath := path.Join(h.root, "memory", group, "memory.limit_in_bytes")
 	if exist, _ := utils.DenExist(cpuLimitFilePath); exist {
 		err := os.WriteFile(cpuLimitFilePath, []byte("-1"), 0644)
 		if err != nil {
 			log.G(ctx).Errorf("remove cpu limit error %v", err)
+			return err
+		}
+	}
+	if exist, _ := utils.DenExist(cpuBurstFilePath); exist {
+		err := os.WriteFile(cpuBurstFilePath, []byte("0"), 0644)
+		if err != nil {
+			log.G(ctx).Errorf("remove cpu burst error %v", err)
 			return err
 		}
 	}

--- a/Cubelet/plugins/cube/internals/cgroup/handle/v1/manager_test.go
+++ b/Cubelet/plugins/cube/internals/cgroup/handle/v1/manager_test.go
@@ -101,14 +101,18 @@ func TestHandler_Base(t *testing.T) {
 			t.Fatalf("subsystem %q for %q not created", string(s.Name()), testGroup)
 		}
 	}
+	err = os.WriteFile(path.Join(mock.root, "cpu", testGroup, "cpu.cfs_burst_us"), []byte("0"), 0644)
+	assert.NoError(t, err, "create cpu burst file")
 
 	cpu := resource.MustParse("100m")
 	mem := resource.MustParse("128Mi")
-	err = h.Update(ctx, testGroup, cpu, mem)
+	cpuBurst := resource.MustParse("200m")
+	err = h.Update(ctx, testGroup, cpu, mem, cpuBurst)
 	assert.NoError(t, err, "update")
 
 	checkValue(t, mock, path.Join("cpu", testGroup, "cpu.cfs_period_us"), "100000")
 	checkValue(t, mock, path.Join("cpu", testGroup, "cpu.cfs_quota_us"), "10000")
+	checkValue(t, mock, path.Join("cpu", testGroup, "cpu.cfs_burst_us"), "10000")
 	checkValue(t, mock, path.Join("memory", testGroup, "memory.limit_in_bytes"), "134217728")
 
 	assert.Equal(t, 100, h.GetAllocatedCpuNum(testGroup), "get cpu")
@@ -118,6 +122,7 @@ func TestHandler_Base(t *testing.T) {
 	assert.NoError(t, err, "remove limit")
 	assert.Equal(t, 0, h.GetAllocatedCpuNum(testGroup), "get cpu")
 	assert.Equal(t, int64(0), h.GetAllocatedMem(testGroup), "get mem")
+	checkValue(t, mock, path.Join("cpu", testGroup, "cpu.cfs_burst_us"), "0")
 
 	err = h.Delete(ctx, testGroup)
 	assert.NoError(t, err, "delete")

--- a/Cubelet/plugins/cube/internals/cgroup/handle/v2/manager.go
+++ b/Cubelet/plugins/cube/internals/cgroup/handle/v2/manager.go
@@ -194,7 +194,7 @@ func toggleFunc(controllers []string, prefix string) []string {
 	return out
 }
 
-func (h *handler) Update(ctx context.Context, group string, cpu, mem resource.Quantity) error {
+func (h *handler) Update(ctx context.Context, group string, cpu, mem, cpuBurst resource.Quantity) error {
 	cpuQuota := cpu.MilliValue() * 100
 	memMax := mem.Value()
 	cpuMax := cgroup2.NewCPUMax(&cpuQuota, &handle.DefaultCPUPeriod)
@@ -209,11 +209,39 @@ func (h *handler) Update(ctx context.Context, group string, cpu, mem resource.Qu
 	}
 	cgroupv2Path := path.Join(h.root, group)
 	if exist, _ := utils.DenExist(cgroupv2Path); exist {
-		return m.Update(res)
+		if err := m.Update(res); err != nil {
+			return err
+		}
+		return h.updateCPUBurst(ctx, group, cpu, cpuBurst)
 	}
 
 	log.G(ctx).Infof("cgroup %s not exist while update, create one", group)
-	return h.createWithResource(ctx, group, res)
+	if err := h.createWithResource(ctx, group, res); err != nil {
+		return err
+	}
+	return h.updateCPUBurst(ctx, group, cpu, cpuBurst)
+}
+
+func (h *handler) updateCPUBurst(ctx context.Context, group string, cpu, cpuBurst resource.Quantity) error {
+	cpuBurstQuota, configured, err := handle.CPUBurstQuota(cpu, cpuBurst)
+	if err != nil {
+		return err
+	}
+
+	cpuBurstFilePath := path.Join(h.root, group, "cpu.max.burst")
+	if exist, _ := utils.DenExist(cpuBurstFilePath); !exist {
+		if configured {
+			return fmt.Errorf("cpu burst unsupported: %s not found", cpuBurstFilePath)
+		}
+		return nil
+	}
+
+	err = os.WriteFile(cpuBurstFilePath, []byte(strconv.FormatUint(cpuBurstQuota, 10)), 0644)
+	if err != nil {
+		log.G(ctx).Errorf("set cpu burst error %v", err)
+		return err
+	}
+	return nil
 }
 
 func (h *handler) Delete(ctx context.Context, group string) error {
@@ -273,11 +301,19 @@ func (h *handler) AddProc(group string, pid uint64) error {
 
 func (h *handler) RemoveLimit(ctx context.Context, group string) error {
 	cpuLimitFilePath := path.Join(h.root, group, "cpu.max")
+	cpuBurstFilePath := path.Join(h.root, group, "cpu.max.burst")
 	memLimitFilePath := path.Join(h.root, group, "memory.max")
 	if exist, _ := utils.DenExist(cpuLimitFilePath); exist {
 		err := os.WriteFile(cpuLimitFilePath, []byte("max 100000"), 0644)
 		if err != nil {
 			log.G(ctx).Errorf("remove cpu limit error %v", err)
+			return err
+		}
+	}
+	if exist, _ := utils.DenExist(cpuBurstFilePath); exist {
+		err := os.WriteFile(cpuBurstFilePath, []byte("0"), 0644)
+		if err != nil {
+			log.G(ctx).Errorf("remove cpu burst error %v", err)
 			return err
 		}
 	}

--- a/Cubelet/plugins/cube/internals/cgroup/handle/v2/manager_test.go
+++ b/Cubelet/plugins/cube/internals/cgroup/handle/v2/manager_test.go
@@ -53,7 +53,7 @@ func TestHandler_Base(t *testing.T) {
 
 	cpu := resource.MustParse("100m")
 	mem := resource.MustParse("128Mi")
-	err = h.Update(ctx, testGroup, cpu, mem)
+	err = h.Update(ctx, testGroup, cpu, mem, resource.Quantity{})
 	assert.NoError(t, err, "update")
 
 	checkValue(t, path.Join(h.root, testGroup, "cpu.max"), "10000 100000")

--- a/Cubelet/services/cubebox/cube_container_create.go
+++ b/Cubelet/services/cubebox/cube_container_create.go
@@ -117,7 +117,7 @@ func (l *local) Create(ctx context.Context, opts *workflow.CreateContext) error 
 		if !config.GetCommon().DisableHostCgroup && !constants.GetDisableHostCgroup(ctx) {
 			startTime := time.Now()
 			err := cgroupp.SetCubeboxCgroupLimit(ctx, cgInfo.CgroupID, cgInfo.ResourceQuantity.HostCpuQ,
-				cgInfo.ResourceQuantity.HostMemQ, cgInfo.UsePoolV2)
+				cgInfo.ResourceQuantity.HostMemQ, cgInfo.ResourceQuantity.HostCpuBurstQ, cgInfo.UsePoolV2)
 			if err != nil {
 				err = ret.Errorf(errorcode.ErrorCode_SetCubeboxCgroupLimitFailed,
 					"set cubebox cgroup limit error: %s", err)
@@ -125,8 +125,9 @@ func (l *local) Create(ctx context.Context, opts *workflow.CreateContext) error 
 				return err
 			}
 			workflow.RecordCreateMetric(ctx, nil, constants.CubeRunCgroupId, time.Since(startTime))
-			log.G(ctx).Debugf("set cubebox cgroup %s limit: mem %s, cpu %s", cgInfo.CgroupID,
-				cgInfo.ResourceQuantity.HostMemQ.String(), cgInfo.ResourceQuantity.HostCpuQ.String())
+			log.G(ctx).Debugf("set cubebox cgroup %s limit: mem %s, cpu %s, cpu burst %s", cgInfo.CgroupID,
+				cgInfo.ResourceQuantity.HostMemQ.String(), cgInfo.ResourceQuantity.HostCpuQ.String(),
+				cgInfo.ResourceQuantity.HostCpuBurstQ.String())
 		}
 	}
 


### PR DESCRIPTION
## Summary

Adds an optional per-container `resources.host_burst.cpu` field. CubeMaster aggregates the per-container burst ceilings into `cube.master.instance.host_cpu_burst` and leaves `resources.cpu` as the normal scheduler/request CPU.

Cubelet stores the normal host quota in `HostCpuQ`, stores the burst ceiling in `HostCpuBurstQ`, and converts the difference into the cgroup burst file:

- cgroup v2: `cpu.max.burst`
- cgroup v1, when supported by the kernel: `cpu.cfs_burst_us`

The API validates `host_burst.cpu >= cpu` and `host_burst.cpu <= 2 * cpu`, matching cgroup burst credit limits. For example, `cpu=2` and `host_burst.cpu=4` keeps average CPU at 2 while allowing bounded burst credit up to 4 CPUs.

Also adds `cubemastercli tpl create-from-image --host-burst-cpu` so template authors can set the burst ceiling when creating templates from images.

## Validation

- `go test ./pkg/service/sandbox -run 'TestCheckAndGetContainers'`
- `go test ./pkg/service/httpservice/cube -run '^$'`
- `GOOS=linux GOARCH=amd64 go test -c -o /tmp/cubelet-cgroup.test ./plugins/cube/internals/cgroup`
- `GOOS=linux GOARCH=amd64 go test -c -o /tmp/cubelet-cgroup-handle-v1.test ./plugins/cube/internals/cgroup/handle/v1`
- `GOOS=linux GOARCH=amd64 go test -c -o /tmp/cubelet-cgroup-handle-v2.test ./plugins/cube/internals/cgroup/handle/v2`
- `GOOS=linux GOARCH=amd64 go test -c -o /tmp/cubelet-services-cubebox.test ./services/cubebox`
- `GOOS=linux GOARCH=amd64 go test -c -o /tmp/cubelet-store-cubebox.test ./pkg/store/cubebox`
- `GOOS=linux GOARCH=amd64 go test -c -o /tmp/cubemastercli-cubebox.test ./cmd/cubemastercli/commands/cubebox`
- `git diff --check`

Note: `go test ./cmd/cubemastercli/commands/cubebox -run 'TestParseContainerOverrides'` does not compile on this Darwin/arm64 host because the package depends on `github.com/agiledragon/gomonkey`, which fails with `undefined: buildJmpDirective` for this local toolchain. The Linux compile check above passes.

Assisted-by: Codex:GPT-5