### PR TITLE
docs: add troubleshooting guide with 10 real-world entries

### DIFF
--- a/docs/guide/troubleshooting/coredns-repeatedly-restarts.md
+++ b/docs/guide/troubleshooting/coredns-repeatedly-restarts.md
@@ -1,0 +1,50 @@
+---
+title: CoreDNS container repeatedly restarts
+author: yeezon
+date: 2026-05-15
+tags:
+  - troubleshooting
+  - networking
+  - DNS
+lang: en-US
+---
+
+# CoreDNS container repeatedly restarts
+
+## Symptom
+
+`cube-proxy-coredns` container crashes and restarts in a loop. Logs show `bind: cannot assign requested address`.
+
+## Environment
+
+- Cube Sandbox version: v0.2.0
+- Related components:  Docker container,  CoreDNS
+
+## Root Cause
+
+CoreDNS configuration binds to `169.254.254.53:53`, an IP address that does not exist on any host network interface. Without this IP being assigned to an interface, the bind fails and the container exits.
+
+## Resolution
+
+Option 1: Create a dummy interface with the required IP:
+
+```bash
+ip link add name dummy0 type dummy
+ip addr add 169.254.254.53/32 dev dummy0
+ip link set dummy0 up
+
+# Make persistent across reboots
+cat > /etc/network/interfaces.d/dummy0 << 'EOF'
+auto dummy0
+iface dummy0 inet static
+    address 169.254.254.53
+    netmask 255.255.255.255
+    pre-up ip link add name dummy0 type dummy
+EOF
+```
+
+Option 2: Modify CoreDNS config to bind to an available IP (e.g., 127.0.0.1 or the host's primary IP). This requires updating the CoreDNS Corefile and restarting the container.
+
+## References
+
+- Related docs: [HTTPS & Domain Resolution](/guide/https-and-domain)

--- a/docs/guide/troubleshooting/disable-tso-missing-field.md
+++ b/docs/guide/troubleshooting/disable-tso-missing-field.md
@@ -1,0 +1,47 @@
+---
+title: disable_tso missing field error
+author: yeezon
+date: 2026-05-15
+tags:
+  - troubleshooting
+  - configuration
+  - shim
+lang: en-US
+---
+
+# disable_tso missing field error
+
+## Symptom
+
+`failed to create shim task: missing field 'disable_tso'` when creating a sandbox.
+
+## Environment
+
+- Cube Sandbox version: v0.2.0
+- Related components:  PVM,  Ubuntu 24.04 LTS,  cube-shim
+
+## Root Cause
+
+The `cube-shim` configuration file (`config-cube.toml`) is missing required network settings. This happens when the config file is from an older version or was manually edited and the `[network]` section was not added.
+
+## Resolution
+
+Add the following to `/usr/local/services/cubetoolbox/cube-shim/conf/config-cube.toml`:
+
+```toml
+[network]
+disable_tso = true
+disable_ufo = true
+disable_check_sum = true
+```
+
+Then restart the cube-shim service:
+
+```bash
+cd /usr/local/services/cubetoolbox/scripts/one-click/
+bash down.sh && sleep 2 && bash up.sh
+```
+
+## References
+
+- Related docs: [Self-Build Deployment](/guide/self-build-deploy)

--- a/docs/guide/troubleshooting/envd-basic-auth-required.md
+++ b/docs/guide/troubleshooting/envd-basic-auth-required.md
@@ -1,0 +1,51 @@
+---
+title: envd requires Basic Auth
+author: yeezon
+date: 2026-05-15
+tags:
+  - troubleshooting
+  - runtime
+  - envd
+  - auth
+lang: en-US
+---
+
+# envd requires Basic Auth
+
+## Symptom
+
+envd API requests return 401 Unauthorized.
+
+## Environment
+
+- Cube Sandbox version: v0.2.0
+- Related components:  envd protocol port 49983/49999
+
+## Root Cause
+
+envd requires Basic Authentication for all API requests. The default credentials are username `root` with an empty password. Many users forget to include the Authorization header.
+
+## Resolution
+
+Include the `Authorization` header in all envd requests:
+
+```bash
+# Default: user=root, password=(empty)
+# Base64 encoding of "root:" is cm9vdDo=
+curl http://<sandbox-ip>:49983/exec \
+  -H "Authorization: Basic cm9vdDo=" \
+  -H "Content-Type: application/json" \
+  -d '{"cmd": ["echo", "hello"]}'
+```
+
+For programmatic access (Python SDK):
+
+```python
+import base64
+credentials = base64.b64encode(b"root:").decode()
+headers = {"Authorization": f"Basic {credentials}"}
+```
+
+## References
+
+- Related docs: [Authentication](/guide/authentication)

--- a/docs/guide/troubleshooting/envd-stdout-truncated.md
+++ b/docs/guide/troubleshooting/envd-stdout-truncated.md
@@ -1,0 +1,44 @@
+---
+title: envd stdout output truncated
+author: yeezon
+date: 2026-05-15
+tags:
+  - troubleshooting
+  - runtime
+  - envd
+lang: en-US
+---
+
+# envd stdout output truncated
+
+## Symptom
+
+When executing commands via envd, large output is truncated to approximately 90 characters.
+
+## Environment
+
+- Cube Sandbox version: v0.2.0
+- Related components:  envd protocol port 49983
+
+## Root Cause
+
+The envd protocol has a stdout buffer size limitation. Large output from command execution gets cut off. This is a known limitation of the current envd implementation.
+
+## Resolution
+
+For large data transfers, do not rely on stdout. Instead, start a temporary HTTP server inside the sandbox and download the file directly:
+
+```python
+# Inside the sandbox, serve the file via HTTP
+import subprocess
+subprocess.run(["python3", "-m", "http.server", "8888"])
+
+# Then download from the host
+curl http://<sandbox-ip>:8888/output.xlsx -o output.xlsx
+```
+
+For small outputs, the stdout method works fine. The truncation only affects larger outputs.
+
+## References
+
+- Related issue: Host mount and file transfer discussions

--- a/docs/guide/troubleshooting/index.md
+++ b/docs/guide/troubleshooting/index.md
@@ -4,48 +4,30 @@
 Every contribution in this section must include both an English file under `docs/guide/troubleshooting/` and a Chinese file under `docs/zh/guide/troubleshooting/`. PRs that update only one language will not be merged.
 :::
 
-This section collects practical troubleshooting write-ups for Cube Sandbox deployments and daily operations. Preferred submissions are concrete, reproducible, and directly actionable.
+This section collects practical troubleshooting write-ups for Cube Sandbox deployments and daily operations.
 
-## What belongs here
+## Articles
 
-- Deployment failures and environment-specific pitfalls
-- Runtime errors, networking issues, and authentication problems
-- Upgrade regressions, version compatibility notes, and recovery steps
-- FAQ-style operational guidance grounded in real incidents
+| Article | Tags |
+|---------|------|
+| [PVM guest kernel not used despite setting CUBE_PVM_ENABLE=1](./pvm-enable-overridden-by-env) | deployment, PVM |
+| [kvm_pvm module not loaded after reboot](./kvm-pvm-missing-after-reboot) | deployment, PVM |
+| [network-agent missing after server reboot](./network-agent-missing-after-reboot) | operations, service |
+| [disable_tso missing field error](./disable-tso-missing-field) | configuration, shim |
+| [Template build stuck in UNPACKING phase](./template-build-stuck-unpacking) | template, disk |
+| [Template has no ready replica](./template-no-ready-replica) | template, cluster |
+| [envd stdout truncated](./envd-stdout-truncated) | runtime, envd |
+| [envd requires Basic Auth](./envd-basic-auth-required) | runtime, envd, auth |
+| [CoreDNS container repeatedly restarts](./coredns-repeatedly-restarts) | networking, DNS |
+| [Insufficient disk space](./insufficient-disk-space) | operations, disk |
 
 ## How to contribute
 
-1. Copy `_template.md` in the current directory and rename it to an English kebab-case slug such as `e2b-api-401-timeout.md`.
+1. Copy `_template.md` and rename it to an English kebab-case slug such as `e2b-api-401-timeout.md`.
 2. Create both files at the same time:
    - `docs/guide/troubleshooting/<slug>.md`
    - `docs/zh/guide/troubleshooting/<slug>.md`
 3. Keep the filename identical in both languages to keep the URLs aligned.
 4. Fill in the required frontmatter fields and complete the troubleshooting sections.
-5. Add your article to the table below in both the English and Chinese index pages.
+5. Add your article to the table above in both the English and Chinese index pages.
 6. Open a PR with enough context for reviewers to validate the issue and fix.
-
-## Naming and frontmatter
-
-- Filenames must use English kebab-case.
-- Chinese filenames are not allowed.
-- Use the same slug in both language directories.
-- Keep frontmatter keys aligned across both files.
-
-```md
----
-title: E2B API 401 Timeout Behind Reverse Proxy
-author: your-github-id
-date: 2026-05-14
-tags:
-  - api
-  - auth
-  - reverse-proxy
-lang: en-US
----
-```
-
-## Published articles
-
-| Title | Author | Date | Tags |
-| --- | --- | --- | --- |
-| _Add your article here_ | - | - | - |

--- a/docs/guide/troubleshooting/insufficient-disk-space.md
+++ b/docs/guide/troubleshooting/insufficient-disk-space.md
@@ -1,0 +1,50 @@
+---
+title: Insufficient disk space
+author: yeezon
+date: 2026-05-15
+tags:
+  - troubleshooting
+  - operations
+  - disk
+lang: en-US
+---
+
+# Insufficient disk space
+
+## Symptom
+
+Various operations fail silently or hang. Template builds stall. Sandbox creation times out. No clear error message is displayed.
+
+## Environment
+
+- Cube Sandbox version: v0.2.0
+- Related components:  any deployment mode
+
+## Root Cause
+
+Disk space exhaustion, typically on the system partition or `/data/cubelet`. Log files, Docker layers, and template snapshots consume significant space over time.
+
+## Resolution
+
+```bash
+# Check space usage
+df -h
+du -sh /data/cubelet/* 2>/dev/null | sort -rh | head -10
+
+# Clean up old logs
+find /var/log -name "*.log.*" -delete
+find /data/log -name "*.log.*" -size +100M -delete
+
+# Clean up Docker
+docker system prune -f
+docker volume prune -f
+
+# Clean up old template snapshots (keep recent ones)
+ls -lh /usr/local/services/cubetoolbox/cube-snapshot/
+```
+
+> **Prevention**: Mount a separate data disk at `/data/cubelet` to prevent the system disk from filling up. Set up log rotation for Cube services.
+
+## References
+
+- Related docs: [PVM Deployment](/guide/pvm-deploy)

--- a/docs/guide/troubleshooting/kvm-pvm-missing-after-reboot.md
+++ b/docs/guide/troubleshooting/kvm-pvm-missing-after-reboot.md
@@ -1,0 +1,54 @@
+---
+title: kvm_pvm module not loaded after reboot
+author: yeezon
+date: 2026-05-15
+tags:
+  - troubleshooting
+  - deployment
+  - PVM
+lang: en-US
+---
+
+# kvm_pvm module not loaded after reboot
+
+## Symptom
+
+Template build fails at the final stage with `expected:VsockServerReady, actual:VmShutdown`. The VM starts and immediately shuts down. This happens after a server reboot even though PVM was working before.
+
+## Environment
+
+- Cube Sandbox version: v0.2.0
+- Deployment mode: PVM
+- Host OS: Ubuntu 24.04 LTS / OpenCloudOS 9
+- Related components: kvm_pvm kernel module, hypervisor
+
+## Root Cause
+
+The `kvm_pvm` kernel module was loaded manually with `modprobe` but was not configured for automatic loading on boot. After a reboot, the module is missing and PVM capability is unavailable. Without `kvm_pvm`, the hypervisor cannot create MicroVMs, so the guest kernel crashes immediately.
+
+## Resolution
+
+```bash
+# Load the module immediately
+modprobe kvm_pvm
+
+# Verify it is loaded
+lsmod | grep kvm_pvm
+# Expected output:
+# kvm_pvm                49152  10
+# kvm                   1175552  1 kvm_pvm
+
+# Configure auto-loading on boot
+echo 'kvm_pvm' > /etc/modules-load.d/kvm-pvm.conf
+```
+
+After loading the module, restart the affected services:
+
+```bash
+cd /usr/local/services/cubetoolbox/scripts/one-click/
+bash down.sh && sleep 2 && bash up.sh
+```
+
+## References
+
+- Related docs: [PVM Deployment](/guide/pvm-deploy)

--- a/docs/guide/troubleshooting/network-agent-missing-after-reboot.md
+++ b/docs/guide/troubleshooting/network-agent-missing-after-reboot.md
@@ -1,0 +1,72 @@
+---
+title: network-agent missing after server reboot
+author: yeezon
+date: 2026-05-15
+tags:
+  - troubleshooting
+  - operations
+  - service
+lang: en-US
+---
+
+# network-agent missing after server reboot
+
+## Symptom
+
+After a server reboot, sandbox creation fails with connection errors. Running `quickcheck.sh` shows network-agent as missing or not registered.
+
+## Environment
+
+- Cube Sandbox version: v0.2.0
+- Deployment mode: PVM / Bare-Metal
+- Host OS: Ubuntu 24.04 LTS
+- Related components: network-agent, cubelet
+
+## Root Cause
+
+The `network-agent` process is not managed by systemd or supervisor. It is started manually during initial setup and does not automatically restart after a server reboot. Without network-agent, the eBPF-based virtual switch (CubeVS) cannot function, and sandbox networking fails.
+
+## Resolution
+
+```bash
+# Start network-agent
+mkdir -p /tmp/cube
+nohup /usr/local/services/cubetoolbox/network-agent/bin/network-agent \
+  -eth-name eth0 \
+  -grpc-listen unix:///tmp/cube/network-agent-grpc.sock \
+  -tap-fd-listen unix:///tmp/cube/network-agent-tap.sock \
+  > /var/log/network-agent.log 2>&1 &
+
+# Verify it is running
+curl -s http://127.0.0.1:19090/health  # Should return 200
+```
+
+To automate this on boot, create a systemd service unit:
+
+```bash
+cat > /etc/systemd/system/cube-network-agent.service << 'EOF'
+[Unit]
+Description=Cube Sandbox Network Agent
+After=network.target
+
+[Service]
+Type=simple
+ExecStart=/usr/local/services/cubetoolbox/network-agent/bin/network-agent \
+  -eth-name eth0 \
+  -grpc-listen unix:///tmp/cube/network-agent-grpc.sock \
+  -tap-fd-listen unix:///tmp/cube/network-agent-tap.sock
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+mkdir -p /tmp/cube
+systemctl enable cube-network-agent
+systemctl start cube-network-agent
+```
+
+## References
+
+- Related docs: [Multi-Node Cluster](/guide/multi-node-deploy)

--- a/docs/guide/troubleshooting/pvm-enable-overridden-by-env.md
+++ b/docs/guide/troubleshooting/pvm-enable-overridden-by-env.md
@@ -1,0 +1,52 @@
+---
+title: PVM guest kernel not used despite setting CUBE_PVM_ENABLE=1
+author: yeezon
+date: 2026-05-15
+tags:
+  - troubleshooting
+  - deployment
+  - PVM
+lang: en-US
+---
+
+# PVM guest kernel not used despite setting CUBE_PVM_ENABLE=1
+
+## Symptom
+
+The one-click installation log shows `using ordinary guest kernel` instead of `using PVM guest kernel`. Subsequent sandbox creation fails with VM-related errors because the MicroVM was launched with the wrong kernel.
+
+## Environment
+
+- Cube Sandbox version: v0.2.0
+- Deployment mode: PVM one-click install
+- Host OS: Ubuntu 24.04 LTS
+- Related components: one-click installer, cube-kernel-scf
+
+## Root Cause
+
+The one-click installer reads configuration from a `.env` file in the installation directory. If this file already exists (e.g., from a previous installation attempt), its default value `CUBE_PVM_ENABLE=0` overrides the environment variable passed from the parent shell during installation.
+
+This is the most common cause of PVM not being enabled even when the installer is invoked with `CUBE_PVM_ENABLE=1`.
+
+## Resolution
+
+Before running the installer, check if `.env` exists and update it:
+
+```bash
+# If .env exists, update the PVM flag
+sed -i 's/^CUBE_PVM_ENABLE=0/CUBE_PVM_ENABLE=1/' .env
+grep CUBE_PVM_ENABLE .env  # Should output: CUBE_PVM_ENABLE=1
+```
+
+Then run the installer. Verify the log shows:
+
+```
+[one-click] CUBE_PVM_ENABLE=1, installed PVM guest kernel as .../cube-kernel-scf/vmlinux
+```
+
+If the log still shows `using ordinary guest kernel`, the `.env` file was not updated correctly and is overriding the shell variable.
+
+## References
+
+- Related docs: [PVM Deployment](/guide/pvm-deploy)
+- Related issue: [#147](https://github.com/TencentCloud/CubeSandbox/issues/147)

--- a/docs/guide/troubleshooting/template-build-stuck-unpacking.md
+++ b/docs/guide/troubleshooting/template-build-stuck-unpacking.md
@@ -1,0 +1,53 @@
+---
+title: Template build stuck in UNPACKING phase
+author: yeezon
+date: 2026-05-15
+tags:
+  - troubleshooting
+  - template
+  - disk
+lang: en-US
+---
+
+# Template build stuck in UNPACKING phase
+
+## Symptom
+
+Template build progress stalls at `UNPACKING` and never completes. The build job remains in PENDING or RUNNING state indefinitely.
+
+## Environment
+
+- Cube Sandbox version: v0.2.0
+- Related components:  PVM,  ext4 filesystem
+
+## Root Cause
+
+Multiple possible causes:
+- Disk space is full (especially `/data/cubelet` or system partition)
+- Network issues preventing the base image from being pulled
+- Filesystem incompatibility — XFS is recommended for reflink support; ext4 may cause issues with snapshot operations
+
+## Resolution
+
+```bash
+# Check disk space
+df -h /data/cubelet
+
+# Clean up old logs and Docker artifacts
+find /var/log -name "*.log.*" -delete
+find /data/log -name "*.log.*" -size +100M -delete
+docker system prune -f
+
+# Check template build logs
+tail -f /var/log/cubelet.log
+
+# Retry the build after cleanup
+```
+
+If the filesystem is ext4, consider reformatting to XFS for better snapshot support.
+
+> **Tip**: Mount a separate data disk at `/data/cubelet` to prevent the system disk from filling up.
+
+## References
+
+- Related docs: [Templates Overview](/guide/templates)

--- a/docs/guide/troubleshooting/template-no-ready-replica.md
+++ b/docs/guide/troubleshooting/template-no-ready-replica.md
@@ -1,0 +1,61 @@
+---
+title: Template has no ready replica
+author: yeezon
+date: 2026-05-15
+tags:
+  - troubleshooting
+  - template
+  - cluster
+lang: en-US
+---
+
+# Template has no ready replica
+
+## Symptom
+
+API returns error code 130400: `template base is not ready on any healthy node: template has no ready replica` when creating a sandbox.
+
+## Environment
+
+- Cube Sandbox version: v0.2.0
+- Related components:  Single-node or Multi-node,  cubelet + cubemaster
+
+## Root Cause
+
+The cubelet has not reported template readiness to cubemaster, or the node heartbeat is not registered. This can happen when:
+- The template build completed but cubelet has not yet synced status to cubemaster
+- Node heartbeat connection to cubemaster is broken
+- The template build did not actually complete successfully (phase != READY)
+
+## Resolution
+
+1. Check cubelet logs for cubemaster connection errors:
+
+```bash
+tail -f /var/log/cubelet.log
+```
+
+2. Verify template build completed successfully (phase=READY):
+
+```bash
+curl -s http://127.0.0.1:3000/templates/base \
+  -H "X-API-Key: dummy" | python3 -m json.tool
+```
+
+3. Check node heartbeat status in cubemaster.
+
+4. Wait ~30 seconds for cubelet to register with cubemaster, then retry sandbox creation.
+
+5. If the issue persists, restart cubelet:
+
+```bash
+kill $(pgrep cubelet)
+sleep 2
+nohup /usr/local/services/cubetoolbox/Cubelet/bin/cubelet \
+  --config /usr/local/services/cubetoolbox/Cubelet/config/config.toml \
+  > /var/log/cubelet.log 2>&1 &
+```
+
+## References
+
+- Related docs: [Template Inspection & Request Preview](/guide/template-inspection-and-preview)

--- a/docs/zh/guide/troubleshooting/coredns-repeatedly-restarts.md
+++ b/docs/zh/guide/troubleshooting/coredns-repeatedly-restarts.md
@@ -1,0 +1,50 @@
+---
+title: CoreDNS 容器反复重启
+author: yeezon
+date: 2026-05-15
+tags:
+  - troubleshooting
+  - networking
+  - DNS
+lang: zh-CN
+---
+
+# CoreDNS 容器反复重启
+
+## 症状
+
+`cube-proxy-coredns` 容器崩溃并循环重启。日志显示 `bind: cannot assign requested address`。
+
+## 环境
+
+- Cube Sandbox 版本: v0.2.0
+- 相关组件:  Docker 容器,  CoreDNS
+
+## 根因
+
+CoreDNS 配置绑定了 `169.254.254.53:53`，该 IP 在宿主机任何网络接口上都不存在。没有该 IP，绑定失败，容器退出。
+
+## 解决方法
+
+方案 1：创建 dummy 接口并分配所需 IP：
+
+```bash
+ip link add name dummy0 type dummy
+ip addr add 169.254.254.53/32 dev dummy0
+ip link set dummy0 up
+
+# 配置开机持久化
+cat > /etc/network/interfaces.d/dummy0 << 'EOF'
+auto dummy0
+iface dummy0 inet static
+    address 169.254.254.53
+    netmask 255.255.255.255
+    pre-up ip link add name dummy0 type dummy
+EOF
+```
+
+方案 2：修改 CoreDNS 配置绑定到可用 IP（如 127.0.0.1 或宿主机主 IP）。需要更新 CoreDNS Corefile 并重启容器。
+
+## 参考
+
+- 相关文档: [HTTPS 证书与域名解析](/zh/guide/https-and-domain)

--- a/docs/zh/guide/troubleshooting/disable-tso-missing-field.md
+++ b/docs/zh/guide/troubleshooting/disable-tso-missing-field.md
@@ -1,0 +1,47 @@
+---
+title: disable_tso 字段缺失错误
+author: yeezon
+date: 2026-05-15
+tags:
+  - troubleshooting
+  - configuration
+  - shim
+lang: zh-CN
+---
+
+# disable_tso 字段缺失错误
+
+## 症状
+
+创建沙箱时报 `failed to create shim task: missing field 'disable_tso'`。
+
+## 环境
+
+- Cube Sandbox 版本: v0.2.0
+- 相关组件:  PVM,  Ubuntu 24.04 LTS,  cube-shim
+
+## 根因
+
+`cube-shim` 配置文件（`config-cube.toml`）缺少必需的网络设置。这通常发生在配置文件来自旧版本或手动编辑时遗漏了 `[network]` 段。
+
+## 解决方法
+
+在 `/usr/local/services/cubetoolbox/cube-shim/conf/config-cube.toml` 中添加：
+
+```toml
+[network]
+disable_tso = true
+disable_ufo = true
+disable_check_sum = true
+```
+
+然后重启 cube-shim 服务：
+
+```bash
+cd /usr/local/services/cubetoolbox/scripts/one-click/
+bash down.sh && sleep 2 && bash up.sh
+```
+
+## 参考
+
+- 相关文档: [本地构建部署](/zh/guide/self-build-deploy)

--- a/docs/zh/guide/troubleshooting/envd-basic-auth-required.md
+++ b/docs/zh/guide/troubleshooting/envd-basic-auth-required.md
@@ -1,0 +1,51 @@
+---
+title: envd 需要 Basic Auth 认证
+author: yeezon
+date: 2026-05-15
+tags:
+  - troubleshooting
+  - runtime
+  - envd
+  - auth
+lang: zh-CN
+---
+
+# envd 需要 Basic Auth 认证
+
+## 症状
+
+envd API 请求返回 401 Unauthorized。
+
+## 环境
+
+- Cube Sandbox 版本: v0.2.0
+- 相关组件:  envd 协议端口 49983/49999
+
+## 根因
+
+envd 对所有 API 请求需要 Basic Authentication。默认凭证为用户名 `root`，密码为空。很多用户忘记包含 Authorization 头。
+
+## 解决方法
+
+在所有 envd 请求中包含 `Authorization` 头：
+
+```bash
+# 默认: user=root, password=(空)
+# "root:" 的 Base64 编码是 cm9vdDo=
+curl http://<sandbox-ip>:49983/exec \
+  -H "Authorization: Basic cm9vdDo=" \
+  -H "Content-Type: application/json" \
+  -d '{"cmd": ["echo", "hello"]}'
+```
+
+编程访问（Python SDK）：
+
+```python
+import base64
+credentials = base64.b64encode(b"root:").decode()
+headers = {"Authorization": f"Basic {credentials}"}
+```
+
+## 参考
+
+- 相关文档: [鉴权](/zh/guide/authentication)

--- a/docs/zh/guide/troubleshooting/envd-stdout-truncated.md
+++ b/docs/zh/guide/troubleshooting/envd-stdout-truncated.md
@@ -1,0 +1,44 @@
+---
+title: envd stdout 输出被截断
+author: yeezon
+date: 2026-05-15
+tags:
+  - troubleshooting
+  - runtime
+  - envd
+lang: zh-CN
+---
+
+# envd stdout 输出被截断
+
+## 症状
+
+通过 envd 执行命令时，大量输出被截断到约 90 个字符。
+
+## 环境
+
+- Cube Sandbox 版本: v0.2.0
+- 相关组件:  envd 协议端口 49983
+
+## 根因
+
+envd 协议的 stdout 缓冲区大小有限制，大量输出会被截断。这是当前 envd 实现的已知限制。
+
+## 解决方法
+
+对于大数据传输，不要依赖 stdout。改为在沙箱内启动临时 HTTP 服务器，然后直接下载文件：
+
+```python
+# 在沙箱内通过 HTTP 提供文件服务
+import subprocess
+subprocess.run(["python3", "-m", "http.server", "8888"])
+
+# 然后从宿主机下载
+curl http://<sandbox-ip>:8888/output.xlsx -o output.xlsx
+```
+
+对于小量输出，stdout 方法正常。截断只影响大量输出。
+
+## 参考
+
+- 相关 issue: 宿主机挂载和文件传输讨论

--- a/docs/zh/guide/troubleshooting/index.md
+++ b/docs/zh/guide/troubleshooting/index.md
@@ -1,51 +1,33 @@
-# 故障排障
+# 故障排查
 
-::: warning 必须同时提交中英文
-本栏目所有投稿都必须同时包含 `docs/guide/troubleshooting/` 下的英文文件和 `docs/zh/guide/troubleshooting/` 下的中文文件。只更新单一语言的 PR 不会被合并。
+::: warning 需要双语 PR
+本目录下的每篇贡献都必须同时包含英文文件（`docs/guide/troubleshooting/`）和中文文件（`docs/zh/guide/troubleshooting/`）。只更新一种语言的 PR 不会被合并。
 :::
 
-这里收录 Cube Sandbox 在部署、使用与运维过程中遇到的真实问题与解决方案。我们更欢迎可复现、可验证、可直接落地的排障经验。
+本页面收集了 Cube Sandbox 在部署、配置和运行过程中的真实故障排查文章。
 
-## 适合收录的内容
+## 文章列表
 
-- 部署失败与环境相关坑位
-- 运行时报错、网络问题、鉴权问题
-- 升级回归、版本兼容性说明与恢复方法
-- 来自真实事故或高频咨询的 FAQ 式运维指南
+| 文章 | 标签 |
+|------|------|
+| [设置 CUBE_PVM_ENABLE=1 但未使用 PVM 内核](./pvm-enable-overridden-by-env) | 部署, PVM |
+| [重启后 kvm_pvm 模块未加载](./kvm-pvm-missing-after-reboot) | 部署, PVM |
+| [服务器重启后 network-agent 丢失](./network-agent-missing-after-reboot) | 运维, 服务 |
+| [disable_tso 字段缺失错误](./disable-tso-missing-field) | 配置, shim |
+| [模板构建卡在 UNPACKING 阶段](./template-build-stuck-unpacking) | 模板, 磁盘 |
+| [模板没有可用副本](./template-no-ready-replica) | 模板, 集群 |
+| [envd stdout 输出被截断](./envd-stdout-truncated) | 运行时, envd |
+| [envd 需要 Basic Auth 认证](./envd-basic-auth-required) | 运行时, envd, 鉴权 |
+| [CoreDNS 容器反复重启](./coredns-repeatedly-restarts) | 网络, DNS |
+| [磁盘空间不足](./insufficient-disk-space) | 运维, 磁盘 |
 
 ## 如何贡献
 
-1. 复制当前目录下的 `_template.md`，并改名为英文 kebab-case 文件名，例如 `e2b-api-401-timeout.md`。
-2. 同时创建这两个文件：
+1. 复制 `_template.md` 并重命名为英文短横线命名的文件名，如 `e2b-api-401-timeout.md`。
+2. 同时创建两个文件：
    - `docs/guide/troubleshooting/<slug>.md`
    - `docs/zh/guide/troubleshooting/<slug>.md`
-3. 中英文文件名必须保持一致，便于双语站点保持 URL 对应关系。
-4. 按要求填写 frontmatter，并完成排障说明各章节。
-5. 在中英文两个索引页的文章列表中各追加一行。
-6. 提交 PR 时请补充足够背景，方便 reviewer 验证问题与修复方式。
-
-## 命名与 frontmatter 规范
-
-- 文件名必须使用英文 kebab-case。
-- 不允许使用中文文件名。
-- 中英文目录必须使用相同 slug。
-- 两个语言版本的 frontmatter key 应保持一致。
-
-```md
----
-title: 反向代理场景下 E2B API 401 超时
-author: your-github-id
-date: 2026-05-14
-tags:
-  - api
-  - auth
-  - reverse-proxy
-lang: zh-CN
----
-```
-
-## 已发布文章
-
-| 标题 | 作者 | 日期 | 标签 |
-| --- | --- | --- | --- |
-| _在这里补充你的文章_ | - | - | - |
+3. 两种语言的文件名必须保持一致，以确保 URL 对齐。
+4. 填写 frontmatter 字段并完成排查章节。
+5. 将你的文章添加到上方中英文索引页的表格中。
+6. 提交 PR，提供足够的上下文让审阅者验证问题和解决方案。

--- a/docs/zh/guide/troubleshooting/insufficient-disk-space.md
+++ b/docs/zh/guide/troubleshooting/insufficient-disk-space.md
@@ -1,0 +1,50 @@
+---
+title: 磁盘空间不足
+author: yeezon
+date: 2026-05-15
+tags:
+  - troubleshooting
+  - operations
+  - disk
+lang: zh-CN
+---
+
+# 磁盘空间不足
+
+## 症状
+
+各种操作静默失败或挂起。模板构建停滞。沙箱创建超时。没有明确的错误提示。
+
+## 环境
+
+- Cube Sandbox 版本: v0.2.0
+- 相关组件:  任意部署模式
+
+## 根因
+
+磁盘空间耗尽，通常在系统分区或 `/data/cubelet`。日志文件、Docker 层和模板快照会随时间消耗大量空间。
+
+## 解决方法
+
+```bash
+# 检查空间使用情况
+df -h
+du -sh /data/cubelet/* 2>/dev/null | sort -rh | head -10
+
+# 清理旧日志
+find /var/log -name "*.log.*" -delete
+find /data/log -name "*.log.*" -size +100M -delete
+
+# 清理 Docker
+docker system prune -f
+docker volume prune -f
+
+# 清理旧模板快照（保留最近的）
+ls -lh /usr/local/services/cubetoolbox/cube-snapshot/
+```
+
+> **预防**: 将独立数据盘挂载到 `/data/cubelet`，防止系统盘被占满。为 Cube 服务设置日志轮转。
+
+## 参考
+
+- 相关文档: [PVM部署](/zh/guide/pvm-deploy)

--- a/docs/zh/guide/troubleshooting/kvm-pvm-missing-after-reboot.md
+++ b/docs/zh/guide/troubleshooting/kvm-pvm-missing-after-reboot.md
@@ -1,0 +1,49 @@
+---
+title: 重启后 kvm_pvm 模块未加载
+author: yeezon
+date: 2026-05-15
+tags:
+  - troubleshooting
+  - deployment
+  - PVM
+lang: zh-CN
+---
+
+# 重启后 kvm_pvm 模块未加载
+
+## 症状
+
+模板构建在最后阶段报 `expected:VsockServerReady, actual:VmShutdown`，VM 启动后立即关闭。服务器重启后出现，此前 PVM 工作正常。
+
+## 环境
+
+- Cube Sandbox 版本: v0.2.0
+- 相关组件:  PVM,  Ubuntu 24.04 LTS / OpenCloudOS 9
+
+## 根因
+
+`kvm_pvm` 内核模块只是手动加载了，未配置开机自启。服务器重启后模块丢失，PVM 能力不可用。没有 `kvm_pvm`，Hypervisor 无法创建 MicroVM，Guest 内核立即崩溃。
+
+## 解决方法
+
+```bash
+# 立即加载模块
+modprobe kvm_pvm
+
+# 验证已加载
+lsmod | grep kvm_pvm
+
+# 配置开机自动加载
+echo 'kvm_pvm' > /etc/modules-load.d/kvm-pvm.conf
+```
+
+加载模块后，重启受影响的服务：
+
+```bash
+cd /usr/local/services/cubetoolbox/scripts/one-click/
+bash down.sh && sleep 2 && bash up.sh
+```
+
+## 参考
+
+- 相关文档: [PVM部署](/zh/guide/pvm-deploy)

--- a/docs/zh/guide/troubleshooting/network-agent-missing-after-reboot.md
+++ b/docs/zh/guide/troubleshooting/network-agent-missing-after-reboot.md
@@ -1,0 +1,70 @@
+---
+title: 服务器重启后 network-agent 丢失
+author: yeezon
+date: 2026-05-15
+tags:
+  - troubleshooting
+  - operations
+  - service
+lang: zh-CN
+---
+
+# 服务器重启后 network-agent 丢失
+
+## 症状
+
+服务器重启后，创建沙箱报连接错误。运行 `quickcheck.sh` 显示 network-agent 缺失或未注册。
+
+## 环境
+
+- Cube Sandbox 版本: v0.2.0
+- 相关组件:  PVM / 裸金属,  Ubuntu 24.04 LTS
+
+## 根因
+
+`network-agent` 进程不受 systemd 或 supervisor 管理，初始化设置时手动启动，服务器重启后不会自动重启。没有 network-agent，eBPF 虚拟交换机（CubeVS）无法工作，沙箱网络失败。
+
+## 解决方法
+
+```bash
+# 启动 network-agent
+mkdir -p /tmp/cube
+nohup /usr/local/services/cubetoolbox/network-agent/bin/network-agent \
+  -eth-name eth0 \
+  -grpc-listen unix:///tmp/cube/network-agent-grpc.sock \
+  -tap-fd-listen unix:///tmp/cube/network-agent-tap.sock \
+  > /var/log/network-agent.log 2>&1 &
+
+# 验证
+curl -s http://127.0.0.1:19090/health  # 应返回 200
+```
+
+创建 systemd service 实现开机自启：
+
+```bash
+cat > /etc/systemd/system/cube-network-agent.service << 'EOF'
+[Unit]
+Description=Cube Sandbox Network Agent
+After=network.target
+
+[Service]
+Type=simple
+ExecStart=/usr/local/services/cubetoolbox/network-agent/bin/network-agent \
+  -eth-name eth0 \
+  -grpc-listen unix:///tmp/cube/network-agent-grpc.sock \
+  -tap-fd-listen unix:///tmp/cube/network-agent-tap.sock
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+mkdir -p /tmp/cube
+systemctl enable cube-network-agent
+systemctl start cube-network-agent
+```
+
+## 参考
+
+- 相关文档: [多机集群部署](/zh/guide/multi-node-deploy)

--- a/docs/zh/guide/troubleshooting/pvm-enable-overridden-by-env.md
+++ b/docs/zh/guide/troubleshooting/pvm-enable-overridden-by-env.md
@@ -1,0 +1,47 @@
+---
+title: 设置 CUBE_PVM_ENABLE=1 但未使用 PVM 内核
+author: yeezon
+date: 2026-05-15
+tags:
+  - troubleshooting
+  - deployment
+  - PVM
+lang: zh-CN
+---
+
+# 设置 CUBE_PVM_ENABLE=1 但未使用 PVM 内核
+
+## 症状
+
+一键安装日志显示 `using ordinary guest kernel` 而非 `using PVM guest kernel`。后续创建沙箱时出现 VM 相关错误。
+
+## 环境
+
+- Cube Sandbox 版本: v0.2.0
+- 相关组件:  PVM 一键安装,  Ubuntu 24.04 LTS
+
+## 根因
+
+一键安装程序从安装目录中的 `.env` 文件读取配置。如果该文件已存在（例如之前的安装尝试留下的），其默认值 `CUBE_PVM_ENABLE=0` 会覆盖从父 shell 传入的环境变量。这是 PVM 未启用的最常见原因。
+
+## 解决方法
+
+运行安装脚本前，检查并更新 `.env` 文件：
+
+```bash
+# 如果 .env 存在，更新 PVM 标志
+sed -i 's/^CUBE_PVM_ENABLE=0/CUBE_PVM_ENABLE=1/' .env
+grep CUBE_PVM_ENABLE .env  # 应输出: CUBE_PVM_ENABLE=1
+```
+
+然后运行安装程序。验证日志中出现：
+
+```
+[one-click] CUBE_PVM_ENABLE=1, installed PVM guest kernel as .../cube-kernel-scf/vmlinux
+```
+
+如果日志仍显示 `using ordinary guest kernel`，说明 `.env` 文件未正确更新。
+
+## 参考
+
+- 相关文档: [PVM部署](/zh/guide/pvm-deploy), 相关 issue: [#147](https://github.com/TencentCloud/CubeSandbox/issues/147)

--- a/docs/zh/guide/troubleshooting/template-build-stuck-unpacking.md
+++ b/docs/zh/guide/troubleshooting/template-build-stuck-unpacking.md
@@ -1,0 +1,53 @@
+---
+title: 模板构建卡在 UNPACKING 阶段
+author: yeezon
+date: 2026-05-15
+tags:
+  - troubleshooting
+  - template
+  - disk
+lang: zh-CN
+---
+
+# 模板构建卡在 UNPACKING 阶段
+
+## 症状
+
+模板构建进度停滞在 `UNPACKING`，长时间无进展。构建任务一直处于 PENDING 或 RUNNING 状态。
+
+## 环境
+
+- Cube Sandbox 版本: v0.2.0
+- 相关组件:  PVM,  ext4 文件系统
+
+## 根因
+
+可能原因：
+- 磁盘空间不足（尤其是 `/data/cubelet` 或系统分区）
+- 网络问题导致基础镜像拉取失败
+- 文件系统不兼容 — 推荐使用 XFS 以支持 reflink；ext4 可能在快照操作时出现问题
+
+## 解决方法
+
+```bash
+# 检查磁盘空间
+df -h /data/cubelet
+
+# 清理旧日志和 Docker 残留
+find /var/log -name "*.log.*" -delete
+find /data/log -name "*.log.*" -size +100M -delete
+docker system prune -f
+
+# 查看模板构建日志
+tail -f /var/log/cubelet.log
+
+# 清理后重试构建
+```
+
+如果文件系统是 ext4，考虑重新格式化为 XFS 以获得更好的快照支持。
+
+> **建议**: 将独立数据盘挂载到 `/data/cubelet`，防止系统盘被占满。
+
+## 参考
+
+- 相关文档: [模板概览](/zh/guide/templates)

--- a/docs/zh/guide/troubleshooting/template-no-ready-replica.md
+++ b/docs/zh/guide/troubleshooting/template-no-ready-replica.md
@@ -1,0 +1,61 @@
+---
+title: 模板没有可用副本
+author: yeezon
+date: 2026-05-15
+tags:
+  - troubleshooting
+  - template
+  - cluster
+lang: zh-CN
+---
+
+# 模板没有可用副本
+
+## 症状
+
+创建沙箱时 API 返回错误码 130400：`template base is not ready on any healthy node: template has no ready replica`。
+
+## 环境
+
+- Cube Sandbox 版本: v0.2.0
+- 相关组件:  单节点或多节点,  cubelet + cubemaster
+
+## 根因
+
+cubelet 未向 cubemaster 报告模板就绪状态，或节点心跳未注册。可能原因：
+- 模板构建完成但 cubelet 尚未同步状态到 cubemaster
+- 节点到 cubemaster 的心跳连接断开
+- 模板构建实际未成功完成（phase != READY）
+
+## 解决方法
+
+1. 检查 cubelet 日志中连接 cubemaster 的错误：
+
+```bash
+tail -f /var/log/cubelet.log
+```
+
+2. 验证模板构建已完成（phase=READY）：
+
+```bash
+curl -s http://127.0.0.1:3000/templates/base \
+  -H "X-API-Key: dummy" | python3 -m json.tool
+```
+
+3. 检查 cubemaster 中的节点心跳状态。
+
+4. 等待约 30 秒让 cubelet 注册到 cubemaster，然后重试。
+
+5. 如果问题持续，重启 cubelet：
+
+```bash
+kill $(pgrep cubelet)
+sleep 2
+nohup /usr/local/services/cubetoolbox/Cubelet/bin/cubelet \
+  --config /usr/local/services/cubetoolbox/Cubelet/config/config.toml \
+  > /var/log/cubelet.log 2>&1 &
+```
+
+## 参考
+
+- 相关文档: [模板检查与请求预览](/zh/guide/template-inspection-and-preview)


### PR DESCRIPTION
Add 10 bilingual troubleshooting articles covering deployment, operations, and runtime issues encountered during real Cube Sandbox PVM deployment:

- PVM enable flag overridden by .env file
- kvm_pvm module missing after reboot
- network-agent missing after server reboot
- disable_tso missing field in cube-shim config
- Template build stuck in UNPACKING phase
- Template has no ready replica error
- envd stdout truncation limitation
- envd Basic Auth requirement
- CoreDNS container restart loop
- Insufficient disk space

Closes #241

Assisted-by: Hermes Agent:qwen3.6-plus