### PR TITLE
fix(proxy): disable buffering for sandbox streams

### DIFF
--- a/CubeProxy/nginx.conf
+++ b/CubeProxy/nginx.conf
@@ -107,6 +107,8 @@ http {
             proxy_send_timeout 7206s;
             proxy_read_timeout 7206s;
             proxy_connect_timeout 3s;
+            proxy_buffering off;
+            proxy_request_buffering off;
             proxy_set_header Host $http_host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -163,6 +165,8 @@ http {
             proxy_send_timeout 7206s;
             proxy_read_timeout 7206s;
             proxy_connect_timeout 3s;
+            proxy_buffering off;
+            proxy_request_buffering off;
             # proxy_socket_keepalive may cause frequent vm exit
             # proxy_socket_keepalive on;
             proxy_set_header Host $http_host;


### PR DESCRIPTION
Patch for `nginx` config:

  - Adds proxy_buffering off;
  - Adds proxy_request_buffering off;
  - Applies to both HTTP and HTTPS CubeProxy sandbox locations in CubeProxy/nginx.conf

Interactive `envd` Connect streams (PTY) need chunks flushed immediately. With CubeProxy’s global proxy_buffering on, long-lived PTY streams can receive input but not deliver output
  promptly.

  Validated:

  - `nginx -t` inside the running cube-proxy container passed.
  - After reload, direct `envd` Process/Start returned 200 and streamed the start frame immediately.
