### PR TITLE
feat(template): support --user flag and respect image User field

### DIFF
--- a/CubeMaster/cmd/cubemastercli/commands/cubebox/template.go
+++ b/CubeMaster/cmd/cubemastercli/commands/cubebox/template.go
@@ -770,6 +770,7 @@ var TemplateCreateFromImageCommand = cli.Command{
 		cli.StringFlag{Name: "probe-path", Value: "/health", Usage: "HTTP path for the readiness probe (default: /health); only effective when --probe is set"},
 		cli.IntFlag{Name: "cpu", Value: 2000, Usage: "CPU millicores for the template container (default: 2000, i.e. 2 cores)"},
 		cli.IntFlag{Name: "memory", Value: 2000, Usage: "Memory for the template container in MB (default: 2000 MB)"},
+		cli.StringFlag{Name: "user", Usage: "override the user (UID or username) for the container process, e.g. --user 1000 or --user node"},
 		cli.BoolFlag{Name: "json", Usage: "print raw json response"},
 	},
 	Action: func(c *cli.Context) error {
@@ -1372,8 +1373,9 @@ func parseContainerOverrides(c *cli.Context) (*types.ContainerOverrides, error) 
 	probePort := c.Int("probe")
 	cpuMillicores := c.Int("cpu")
 	memoryMB := c.Int("memory")
+	userFlag := c.String("user")
 
-	if len(cmds) == 0 && len(args) == 0 && len(rawEnvs) == 0 && len(dnsServers) == 0 && probePort == 0 && !c.IsSet("cpu") && !c.IsSet("memory") {
+	if len(cmds) == 0 && len(args) == 0 && len(rawEnvs) == 0 && len(dnsServers) == 0 && probePort == 0 && !c.IsSet("cpu") && !c.IsSet("memory") && userFlag == "" {
 		return nil, nil
 	}
 
@@ -1426,6 +1428,25 @@ func parseContainerOverrides(c *cli.Context) (*types.ContainerOverrides, error) 
 			PeriodMs:         500,
 			FailureThreshold: 60,
 			SuccessThreshold: 1,
+		}
+	}
+	if userFlag != "" {
+		overrides.SecurityContext = &types.ContainerSecurityContext{}
+		userPart := userFlag
+		groupPart := ""
+		if idx := strings.IndexByte(userFlag, ':'); idx >= 0 {
+			userPart = userFlag[:idx]
+			groupPart = userFlag[idx+1:]
+		}
+		if uid, err := strconv.ParseInt(userPart, 10, 64); err == nil {
+			overrides.SecurityContext.RunAsUser = &types.Int64Value{Value: uid}
+		} else {
+			overrides.SecurityContext.RunAsUsername = userPart
+		}
+		if groupPart != "" {
+			if gid, err := strconv.ParseInt(groupPart, 10, 64); err == nil {
+				overrides.SecurityContext.RunAsGroup = &types.Int64Value{Value: gid}
+			}
 		}
 	}
 	return overrides, nil

--- a/CubeMaster/pkg/templatecenter/template_image.go
+++ b/CubeMaster/pkg/templatecenter/template_image.go
@@ -97,6 +97,27 @@ type dockerImageConfig struct {
 	User       string   `json:"User"`
 }
 
+// applyUserToSecurityContext parses a Docker USER string (e.g. "node", "1000", "node:group", "1000:1000")
+// and sets the corresponding RunAsUser/RunAsUsername/RunAsGroup fields on the SecurityContext.
+func applyUserToSecurityContext(securityContext *types.ContainerSecurityContext, user string) {
+	userPart := user
+	groupPart := ""
+	if idx := strings.IndexByte(user, ':'); idx >= 0 {
+		userPart = user[:idx]
+		groupPart = user[idx+1:]
+	}
+	if uid, err := strconv.ParseInt(userPart, 10, 64); err == nil {
+		securityContext.RunAsUser = &types.Int64Value{Value: uid}
+	} else {
+		securityContext.RunAsUsername = userPart
+	}
+	if groupPart != "" {
+		if gid, err := strconv.ParseInt(groupPart, 10, 64); err == nil {
+			securityContext.RunAsGroup = &types.Int64Value{Value: gid}
+		}
+	}
+}
+
 type resolvedSourceImage struct {
 	localRef     string
 	digest       string
@@ -1670,8 +1691,34 @@ func generateTemplateCreateRequest(req *types.CreateTemplateFromImageReq, artifa
 		resources = req.ContainerOverrides.Resources
 	}
 	securityContext := &types.ContainerSecurityContext{Privileged: true, ReadonlyRootfs: false}
+	// Apply image User as default RunAsUser/RunAsUsername, can be overridden by ContainerOverrides.SecurityContext
+	// Docker USER format: "user", "uid", "user:group", "uid:gid"
+	if imageCfg.User != "" {
+		applyUserToSecurityContext(securityContext, imageCfg.User)
+	}
 	if req.ContainerOverrides != nil && req.ContainerOverrides.SecurityContext != nil {
-		securityContext = req.ContainerOverrides.SecurityContext
+		override := req.ContainerOverrides.SecurityContext
+		// Only merge user-related and pointer fields; Privileged/NoNewPrivs are bool
+		// with zero-value false, so we cannot distinguish "not set" from "explicitly false".
+		// Keep the default Privileged=true unless explicitly overridden via API.
+		if override.Privileged {
+			securityContext.Privileged = true
+		}
+		if override.RunAsUser != nil {
+			securityContext.RunAsUser = override.RunAsUser
+		}
+		if override.RunAsGroup != nil {
+			securityContext.RunAsGroup = override.RunAsGroup
+		}
+		if override.RunAsUsername != "" {
+			securityContext.RunAsUsername = override.RunAsUsername
+		}
+		if override.Capabilities != nil {
+			securityContext.Capabilities = override.Capabilities
+		}
+		if override.NoNewPrivs {
+			securityContext.NoNewPrivs = true
+		}
 		securityContext.ReadonlyRootfs = false
 	}
 	if req.ContainerOverrides != nil && req.ContainerOverrides.VolumeMounts != nil {

--- a/CubeMaster/pkg/templatecenter/template_image_test.go
+++ b/CubeMaster/pkg/templatecenter/template_image_test.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -1194,5 +1195,173 @@ func TestRunRedoTemplateImageJobRequiresLocalImageForBuildRedo(t *testing.T) {
 	}
 	if got, _ := lastUpdate["error_message"].(string); !strings.Contains(got, "still exist locally") {
 		t.Fatalf("unexpected error message: %q", got)
+	}
+}
+
+func TestApplyUserToSecurityContext(t *testing.T) {
+	tests := []struct {
+		name           string
+		user           string
+		wantRunAsUser  int64
+		wantUsername   string
+		wantRunAsGroup int64
+	}{
+		{
+			name:          "numeric UID only",
+			user:          "1000",
+			wantRunAsUser: 1000,
+		},
+		{
+			name:         "username only",
+			user:         "node",
+			wantUsername: "node",
+		},
+		{
+			name:           "UID:GID format",
+			user:           "1000:1000",
+			wantRunAsUser:  1000,
+			wantRunAsGroup: 1000,
+		},
+		{
+			name:         "username:group format",
+			user:         "node:node",
+			wantUsername: "node",
+		},
+		{
+			name:          "UID:groupname format (group ignored since not numeric)",
+			user:          "1000:node",
+			wantRunAsUser: 1000,
+		},
+		{
+			name:          "root user",
+			user:          "0",
+			wantRunAsUser: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sc := &types.ContainerSecurityContext{}
+			applyUserToSecurityContext(sc, tt.user)
+
+			if tt.wantRunAsUser != 0 || tt.wantUsername == "" {
+				if sc.RunAsUser == nil {
+					t.Errorf("RunAsUser is nil, want %d", tt.wantRunAsUser)
+				} else if sc.RunAsUser.Value != tt.wantRunAsUser {
+					t.Errorf("RunAsUser.Value = %d, want %d", sc.RunAsUser.Value, tt.wantRunAsUser)
+				}
+			}
+			if tt.wantUsername != "" {
+				if sc.RunAsUsername != tt.wantUsername {
+					t.Errorf("RunAsUsername = %q, want %q", sc.RunAsUsername, tt.wantUsername)
+				}
+			}
+			if tt.wantRunAsGroup != 0 {
+				if sc.RunAsGroup == nil {
+					t.Errorf("RunAsGroup is nil, want %d", tt.wantRunAsGroup)
+				} else if sc.RunAsGroup.Value != tt.wantRunAsGroup {
+					t.Errorf("RunAsGroup.Value = %d, want %d", sc.RunAsGroup.Value, tt.wantRunAsGroup)
+				}
+			}
+		})
+	}
+}
+
+func TestSecurityContextMerge(t *testing.T) {
+	// Simulate the merge logic from generateTemplateCreateRequest
+	tests := []struct {
+		name            string
+		imageUser       string
+		overrideUser    string // CLI --user
+		wantRunAsUser   int64
+		wantUsername    string
+		wantPrivileged  bool
+	}{
+		{
+			name:           "image user only",
+			imageUser:      "node",
+			overrideUser:   "",
+			wantUsername:   "node",
+			wantPrivileged: true,
+		},
+		{
+			name:           "CLI --user overrides image user",
+			imageUser:      "node",
+			overrideUser:   "2000",
+			wantRunAsUser:  2000,
+			wantPrivileged: true,
+		},
+		{
+			name:           "no user set, privileged default",
+			imageUser:      "",
+			overrideUser:   "",
+			wantPrivileged: true,
+		},
+		{
+			name:           "image UID:GID",
+			imageUser:      "1000:1000",
+			overrideUser:   "",
+			wantRunAsUser:  1000,
+			wantPrivileged: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Simulate generateTemplateCreateRequest logic
+			securityContext := &types.ContainerSecurityContext{Privileged: true, ReadonlyRootfs: false}
+			if tt.imageUser != "" {
+				applyUserToSecurityContext(securityContext, tt.imageUser)
+			}
+			// Simulate ContainerOverrides from CLI --user
+			if tt.overrideUser != "" {
+				override := &types.ContainerSecurityContext{}
+				userPart := tt.overrideUser
+				groupPart := ""
+				if idx := strings.IndexByte(tt.overrideUser, ':'); idx >= 0 {
+					userPart = tt.overrideUser[:idx]
+					groupPart = tt.overrideUser[idx+1:]
+				}
+				if uid, err := strconv.ParseInt(userPart, 10, 64); err == nil {
+					override.RunAsUser = &types.Int64Value{Value: uid}
+				} else {
+					override.RunAsUsername = userPart
+				}
+				if groupPart != "" {
+					if gid, err := strconv.ParseInt(groupPart, 10, 64); err == nil {
+						override.RunAsGroup = &types.Int64Value{Value: gid}
+					}
+				}
+				// Merge logic (same as template_image.go)
+				// Privileged is bool with zero-value false, so only set if true
+				if override.Privileged {
+					securityContext.Privileged = true
+				}
+				if override.RunAsUser != nil {
+					securityContext.RunAsUser = override.RunAsUser
+				}
+				if override.RunAsGroup != nil {
+					securityContext.RunAsGroup = override.RunAsGroup
+				}
+				if override.RunAsUsername != "" {
+					securityContext.RunAsUsername = override.RunAsUsername
+				}
+				securityContext.ReadonlyRootfs = false
+			}
+
+			if securityContext.Privileged != tt.wantPrivileged {
+				t.Errorf("Privileged = %v, want %v", securityContext.Privileged, tt.wantPrivileged)
+			}
+			if tt.wantRunAsUser != 0 {
+				if securityContext.RunAsUser == nil || securityContext.RunAsUser.Value != tt.wantRunAsUser {
+					t.Errorf("RunAsUser = %v, want %d", securityContext.RunAsUser, tt.wantRunAsUser)
+				}
+			}
+			if tt.wantUsername != "" {
+				if securityContext.RunAsUsername != tt.wantUsername {
+					t.Errorf("RunAsUsername = %q, want %q", securityContext.RunAsUsername, tt.wantUsername)
+				}
+			}
+		})
 	}
 }


### PR DESCRIPTION
- Add --user flag to cubemastercli tpl create-from-image command Supports both UID (e.g. --user 1000) and username (e.g. --user node)
- Apply Docker image User field as default RunAsUser/RunAsUsername in generateTemplateCreateRequest, previously imageCfg.User was parsed but ignored
- ContainerOverrides.SecurityContext from --user takes precedence over image User, consistent with env/cmd/workingdir override pattern

Fixes: container always runs as root because imageCfg.User was discarded