### PR TITLE
fix(cubelet): register metric plugin to enable /v1/metrics/scheduler endpoint

### DIFF
--- a/Cubelet/cmd/cubelet/builtins.go
+++ b/Cubelet/cmd/cubelet/builtins.go
@@ -64,6 +64,7 @@ import (
 	_ "github.com/tencentcloud/CubeSandbox/Cubelet/plugins/cube/internals/cgroup"
 	_ "github.com/tencentcloud/CubeSandbox/Cubelet/plugins/cube/internals/createid"
 	_ "github.com/tencentcloud/CubeSandbox/Cubelet/plugins/cube/internals/cubes"
+	_ "github.com/tencentcloud/CubeSandbox/Cubelet/plugins/cube/internals/metric"
 	_ "github.com/tencentcloud/CubeSandbox/Cubelet/plugins/cube/internals/netfile"
 	_ "github.com/tencentcloud/CubeSandbox/Cubelet/plugins/cube/multimeta"
 	_ "github.com/tencentcloud/CubeSandbox/Cubelet/plugins/cube/runtime"


### PR DESCRIPTION
The metric plugin was missing from builtins.go, so its init() never ran and the /v1/metrics/scheduler endpoint returned 404. Adding the blank import so the plugin registers with containerd's plugin system.