### PR TITLE
fix(templatecenter): strip canonical prefix from image digest

### DIFF
--- a/CubeMaster/pkg/templatecenter/store.go
+++ b/CubeMaster/pkg/templatecenter/store.go
@@ -680,6 +680,12 @@ func composeImageInfo(ref, digest string) string {
 	if imageDigest == "" {
 		return imageRef
 	}
+	// Tolerate historical rows where SourceImageDigest was stored as a
+	// full canonical reference ("name@sha256:..."). Strip the "name@"
+	// prefix so we never produce "name:tag@name@sha256:...".
+	if at := strings.Index(imageDigest, "@"); at >= 0 && at+1 < len(imageDigest) {
+		imageDigest = imageDigest[at+1:]
+	}
 	if strings.Contains(imageRef, "@") {
 		return imageRef
 	}

--- a/CubeMaster/pkg/templatecenter/template_image.go
+++ b/CubeMaster/pkg/templatecenter/template_image.go
@@ -2199,7 +2199,15 @@ func directorySize(root string) (int64, error) {
 
 func firstNonEmptyDigest(info dockerInspectImage) string {
 	if len(info.RepoDigests) > 0 && info.RepoDigests[0] != "" {
-		return info.RepoDigests[0]
+		rd := info.RepoDigests[0]
+		// RepoDigests entries are canonical references of the form
+		// "name@sha256:...". We only want the digest portion so that
+		// callers can compose "ref@digest" without producing
+		// "name:tag@name@sha256:..." style duplication.
+		if at := strings.Index(rd, "@"); at >= 0 && at+1 < len(rd) {
+			return rd[at+1:]
+		}
+		return rd
 	}
 	return info.ID
 }

--- a/CubeMaster/pkg/templatecenter/template_image_test.go
+++ b/CubeMaster/pkg/templatecenter/template_image_test.go
@@ -443,7 +443,7 @@ func TestPrepareSourceImageSkipsPullWhenImageExistsLocally(t *testing.T) {
 	if inspectCalls != 1 {
 		t.Fatalf("expected 1 inspect call, got %d", inspectCalls)
 	}
-	if got == nil || got.digest != "docker.io/library/nginx@sha256:abcd" {
+	if got == nil || got.digest != "sha256:abcd" {
 		t.Fatalf("unexpected resolved image: %#v", got)
 	}
 }
@@ -484,7 +484,7 @@ func TestPrepareSourceImagePullsAfterLocalInspectMiss(t *testing.T) {
 	if inspectCalls != 2 {
 		t.Fatalf("expected 2 inspect calls, got %d", inspectCalls)
 	}
-	if got == nil || got.digest != "docker.io/library/nginx@sha256:abcd" {
+	if got == nil || got.digest != "sha256:abcd" {
 		t.Fatalf("unexpected resolved image: %#v", got)
 	}
 }

--- a/CubeMaster/pkg/templatecenter/template_image_test.go
+++ b/CubeMaster/pkg/templatecenter/template_image_test.go
@@ -631,6 +631,12 @@ func TestComposeImageInfo(t *testing.T) {
 			digest: "sha256:abcd",
 			want:   "docker.io/library/nginx@sha256:abcd",
 		},
+		{
+			name:   "digest carries canonical name prefix",
+			ref:    "docker.io/library/nginx:latest",
+			digest: "docker.io/library/nginx@sha256:abcd",
+			want:   "docker.io/library/nginx:latest@sha256:abcd",
+		},
 	}
 	for _, tc := range tests {
 		if got := composeImageInfo(tc.ref, tc.digest); got != tc.want {


### PR DESCRIPTION
The IMAGE_INFO column in 'cubemastercli tpl ls' could render as
  name:tag@name@sha256:...
when docker inspect returned a populated RepoDigests array.

firstNonEmptyDigest() returned RepoDigests[0] verbatim (a canonical reference of the form 'name@sha256:...') and stored it in SourceImageDigest. composeImageInfo() then concatenated the source ref and that 'digest', producing the duplicated name and double '@'.

Fix the root cause by extracting only the digest portion of RepoDigests[0] before returning. Also harden composeImageInfo() to strip a 'name@' prefix from any digest argument so historical rows already persisted with the malformed value render correctly without a database migration.

Add a regression test covering the canonical-prefix case.