### PR TITLE
deploy: add one-click health check and diagnostic scripts

### DIFF
--- a/deploy/one-click/build-release-bundle.sh
+++ b/deploy/one-click/build-release-bundle.sh
@@ -254,10 +254,12 @@ copy_dir_contents "${RUNTIME_LAYOUT_DIR}/cube-kernel-scf" "${PACKAGE_ROOT}/cube-
 copy_dir_contents "${RUNTIME_LAYOUT_DIR}/cube-image" "${PACKAGE_ROOT}/cube-image"
 
 copy_dir_contents "${SCRIPT_DIR}/scripts/one-click" "${PACKAGE_ROOT}/scripts/one-click"
+copy_dir_contents "${SCRIPT_DIR}/scripts/cube-diag" "${PACKAGE_ROOT}/scripts/cube-diag"
 copy_dir_contents "${SCRIPT_DIR}/sql" "${PACKAGE_ROOT}/sql"
 
 find "${PACKAGE_ROOT}" -type f -path "*/bin/*" -exec chmod +x {} \;
 find "${PACKAGE_ROOT}/scripts/one-click" -type f -name "*.sh" -exec chmod +x {} \;
+find "${PACKAGE_ROOT}/scripts/cube-diag" -type f -name "*.sh" -exec chmod +x {} \;
 
 mkdir -p "$(dirname "${PACKAGE_TAR}")"
 tar -C "${WORK_ROOT}" -czf "${PACKAGE_TAR}" "sandbox-package"

--- a/deploy/one-click/scripts/cube-diag/check-deps.sh
+++ b/deploy/one-click/scripts/cube-diag/check-deps.sh
@@ -1,0 +1,354 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (C) 2026 Tencent. All rights reserved.
+#
+# check-deps.sh — Cube Sandbox environment dependency checker
+# Standalone script; no external dependencies.
+#
+# Checks:
+#   • Kernel version floor (>= 5.4)
+#   • Virtualization capability — three supported environments:
+#       Bare-metal KVM:   no hypervisor flag, has vmx/svm → /dev/kvm required
+#       PVM host VM:      kvm_pvm module loaded          → /dev/pvm required
+#       Nested KVM:       hypervisor flag, no kvm_pvm    → /dev/kvm present, WARN
+#   • cgroup v2 + subsystems actually required by Cubelet (cpu, memory, cpuset)
+#   • /data/cubesandbox must be XFS; /data/cubelet must exist; disk >= 20 GB
+#   • Required CLI tools (curl, ss, findmnt, awk, lsmod, modinfo)
+#
+# Exit: 0 = all pass/warn, 1 = one or more failures
+# All checks run even on failure; exit code is deferred to the end.
+
+set -uo pipefail
+
+# ── Help ───────────────────────────────────────────────────────────────────────
+usage() {
+  cat <<'EOF'
+Usage: check-deps.sh [OPTIONS]
+
+Verify host-level prerequisites for Cube Sandbox.
+
+Supported host environments:
+  Bare-metal KVM    No hypervisor CPU flag; has vmx/svm; /dev/kvm required.
+  PVM host VM       Host runs inside a VM but has kvm_pvm module loaded;
+                    /dev/kvm is backed by kvm_pvm (no separate /dev/pvm device).
+  Nested KVM        Host is a VM (hypervisor flag), no kvm_pvm; /dev/kvm
+                    present but nested virtualisation performance is degraded.
+
+Checks performed:
+  kernel       Kernel version >= 5.4
+  virt         Detect host environment; verify appropriate /dev/kvm or /dev/pvm;
+               warn explicitly on nested KVM (degraded performance)
+  cgroup       cgroup v2 with subsystems required by Cubelet: cpu, memory, cpuset
+  filesystem   /data/cubesandbox must be XFS; /data/cubelet must exist;
+               disk free >= 20 GB
+  commands     curl, ss, findmnt, awk, lsmod, modinfo, docker
+
+Options:
+  --quiet      Suppress OK lines; only print WARN and FAIL entries
+  --json       Print a machine-readable JSON summary to stdout after the run
+  --help       Show this help message and exit
+
+Environment variables:
+  CUBE_DATA_PATH   Override the XFS data path check (default: /data/cubesandbox)
+
+Exit codes:
+  0   All checks passed (warnings are allowed)
+  1   One or more checks failed
+
+Examples:
+  ./check-deps.sh
+  ./check-deps.sh --quiet
+  ./check-deps.sh --json
+  CUBE_DATA_PATH=/mnt/data ./check-deps.sh
+EOF
+}
+
+# ── Config (override via env) ──────────────────────────────────────────────────
+CUBE_DATA_PATH="${CUBE_DATA_PATH:-/data/cubesandbox}"
+
+# ── CLI flags ──────────────────────────────────────────────────────────────────
+QUIET=0
+JSON_OUT=0
+for _arg in "$@"; do
+  case "${_arg}" in
+    --quiet)   QUIET=1 ;;
+    --json)    JSON_OUT=1 ;;
+    --help|-h) usage; exit 0 ;;
+  esac
+done
+
+# ── Result tracking ────────────────────────────────────────────────────────────
+PASS_COUNT=0
+FAIL_COUNT=0
+WARN_COUNT=0
+declare -a RESULTS=()
+
+_record() {
+  local level="$1" name="$2" detail="$3"
+  RESULTS+=("${level}::${name}::${detail}")
+  case "${level}" in
+    PASS) PASS_COUNT=$((PASS_COUNT + 1)) ;;
+    WARN) WARN_COUNT=$((WARN_COUNT + 1)) ;;
+    FAIL) FAIL_COUNT=$((FAIL_COUNT + 1)) ;;
+  esac
+}
+
+pass() { _record PASS "$1" "${2:-OK}"; [[ "${QUIET}" -eq 1 ]] || printf '  [ OK ]  %s%s\n' "$1" "${2:+: $2}"; }
+warn() { _record WARN "$1" "$2";       printf '  [WARN]  %s: %s\n' "$1" "$2"; }
+fail() { _record FAIL "$1" "$2";       printf '  [FAIL]  %s: %s\n' "$1" "$2"; }
+section() { [[ "${QUIET}" -eq 1 ]] || printf '\n'; printf '── %s ──\n' "$*"; }
+
+emit_json() {
+  printf '{\n  "pass": %d,\n  "warn": %d,\n  "fail": %d,\n  "checks": [\n' \
+    "${PASS_COUNT}" "${WARN_COUNT}" "${FAIL_COUNT}"
+  local sep=""
+  for r in "${RESULTS[@]}"; do
+    local level name detail
+    level="${r%%::*}"; r="${r#*::}"
+    name="${r%%::*}"; detail="${r#*::}"
+    detail="${detail//\\/\\\\}"; detail="${detail//\"/\\\"}"
+    # strip control characters (newlines, tabs) to keep JSON on one line
+    detail="$(printf '%s' "${detail}" | tr -d '\000-\037')"
+    printf '%s    {"level":"%s","name":"%s","detail":"%s"}' \
+      "${sep}" "${level}" "${name}" "${detail}"
+    sep=$',\n'
+  done
+  printf '\n  ]\n}\n'
+}
+
+# ── Helpers ────────────────────────────────────────────────────────────────────
+kernel_version_ok() {
+  local req_major="$1" req_minor="$2"
+  local kver major minor
+  kver="$(uname -r)"
+  major="$(echo "${kver}" | cut -d. -f1)"
+  minor="$(echo "${kver}" | cut -d. -f2)"
+  if [[ "${major}" -gt "${req_major}" ]]; then return 0; fi
+  if [[ "${major}" -eq "${req_major}" && "${minor}" -ge "${req_minor}" ]]; then return 0; fi
+  return 1
+}
+
+# Detect host environment.
+# Sets globals: HOST_ENV (bare-metal | pvm-host | nested-kvm | unknown)
+detect_host_env() {
+  local has_hypervisor_flag=0
+  local has_vmx_or_svm=0
+  local has_kvm_pvm_mod=0
+
+  grep -q 'hypervisor' /proc/cpuinfo 2>/dev/null && has_hypervisor_flag=1
+  grep -qE '\bvmx\b|\bsvm\b' /proc/cpuinfo 2>/dev/null && has_vmx_or_svm=1
+  lsmod 2>/dev/null | grep -qE '^kvm_pvm[[:space:]]' && has_kvm_pvm_mod=1
+
+  if [[ "${has_kvm_pvm_mod}" -eq 1 ]]; then
+    # kvm_pvm loaded — this is a PVM host (may itself be inside a VM)
+    HOST_ENV="pvm-host"
+  elif [[ "${has_hypervisor_flag}" -eq 0 && "${has_vmx_or_svm}" -eq 1 ]]; then
+    # No hypervisor flag + native virt extensions → bare-metal
+    HOST_ENV="bare-metal"
+  elif [[ "${has_hypervisor_flag}" -eq 1 ]]; then
+    # Running inside a hypervisor but no kvm_pvm → nested KVM
+    HOST_ENV="nested-kvm"
+  else
+    HOST_ENV="unknown"
+  fi
+}
+
+# ── Checks ─────────────────────────────────────────────────────────────────────
+check_kernel() {
+  section "Kernel"
+  local kver; kver="$(uname -r)"
+  if kernel_version_ok 5 4; then
+    pass "kernel_version" "${kver}"
+  else
+    fail "kernel_version" "kernel ${kver} is below minimum 5.4"
+  fi
+}
+
+check_virtualization() {
+  section "Virtualization"
+
+  detect_host_env
+
+  case "${HOST_ENV}" in
+
+    bare-metal)
+      pass "host_env" "bare-metal (native vmx/svm, no hypervisor flag)"
+      # Must have /dev/kvm
+      if [[ -e /dev/kvm ]]; then
+        pass "dev_kvm" "/dev/kvm present"
+      else
+        fail "dev_kvm" "/dev/kvm not found — load kvm module or enable VT-x/AMD-V in BIOS"
+      fi
+      # kvm or kvm_intel/kvm_amd module
+      if lsmod 2>/dev/null | grep -qE '^kvm[[:space:]]'; then
+        local kmod; kmod="$(lsmod 2>/dev/null | grep -oE '^kvm[_a-z]+' | head -1)"
+        pass "kmod_kvm" "${kmod} module loaded"
+      else
+        fail "kmod_kvm" "kvm module not loaded — run: modprobe kvm_intel (or kvm_amd)"
+      fi
+      ;;
+
+    pvm-host)
+      pass "host_env" "PVM host (kvm_pvm module loaded — /dev/kvm provides PVM-accelerated virtualisation)"
+      # On a PVM host, kvm_pvm module replaces the standard KVM backend.
+      # /dev/kvm is the unified device node — there is no separate /dev/pvm.
+      # The presence and health of kvm_pvm is confirmed by the module check below.
+      pass "kmod_kvm_pvm" "kvm_pvm module loaded"
+      if [[ -e /dev/kvm ]]; then
+        pass "dev_kvm" "/dev/kvm present (backed by kvm_pvm)"
+      else
+        fail "dev_kvm" "/dev/kvm not found — kvm_pvm loaded but device missing; check dmesg"
+      fi
+      ;;
+
+    nested-kvm)
+      warn "host_env" \
+        "nested KVM detected (running inside a VM without kvm_pvm) — performance will be degraded; PVM host is strongly recommended"
+      if [[ -e /dev/kvm ]]; then
+        pass "dev_kvm" "/dev/kvm present (nested KVM, performance degraded)"
+      else
+        fail "dev_kvm" "/dev/kvm not found — nested virtualisation not enabled or kvm module not loaded"
+      fi
+      if lsmod 2>/dev/null | grep -qE '^kvm[[:space:]]'; then
+        local kmod; kmod="$(lsmod 2>/dev/null | grep -oE '^kvm[_a-z]+' | head -1)"
+        pass "kmod_kvm" "${kmod} module loaded"
+      else
+        fail "kmod_kvm" "kvm module not loaded"
+      fi
+      ;;
+
+    *)
+      warn "host_env" \
+        "could not determine host environment (no vmx/svm, no hypervisor flag, no kvm_pvm)"
+      if [[ -e /dev/kvm ]]; then
+        pass "dev_kvm" "/dev/kvm present"
+      else
+        fail "dev_kvm" "/dev/kvm not found and host environment unknown"
+      fi
+      ;;
+  esac
+}
+
+check_cgroup() {
+  section "cgroup v2"
+  local cgroot="/sys/fs/cgroup"
+
+  local fstype; fstype="$(stat -f -c '%T' "${cgroot}" 2>/dev/null || echo unknown)"
+  if [[ "${fstype}" == "cgroup2fs" ]]; then
+    pass "cgroup_v2" "cgroup v2 at ${cgroot}"
+  else
+    fail "cgroup_v2" "${cgroot} type=${fstype}; expected cgroup2fs — boot with systemd.unified_cgroup_hierarchy=1"
+    # Cannot check subsystems without cgroup v2; return early
+    return
+  fi
+
+  # Subsystems actually required by Cubelet (from cgroup/handle/v2/manager.go):
+  #   cpu     — CPU quota (cpu.max)
+  #   memory  — memory limit (memory.max)
+  #   cpuset  — CPU pinning (cpuset.cpus) when cpuset is requested
+  # pids / io / rdma / hugetlb are used when the corresponding resource field
+  # is set in the sandbox spec, but cpu+memory+cpuset are the mandatory minimum.
+  local controllers; controllers="$(cat "${cgroot}/cgroup.controllers" 2>/dev/null || true)"
+  for sub in cpu memory cpuset; do
+    if echo "${controllers}" | grep -qw "${sub}"; then
+      pass "cgroup_subsys_${sub}" "${sub} available in cgroup.controllers"
+    else
+      fail "cgroup_subsys_${sub}" "${sub} missing from cgroup.controllers (got: ${controllers:-<empty>})"
+    fi
+  done
+
+  # subtree_control must propagate cpu+memory+cpuset so child cgroups can be managed
+  local subtree; subtree="$(cat "${cgroot}/cgroup.subtree_control" 2>/dev/null || true)"
+  for sub in cpu memory cpuset; do
+    if echo "${subtree}" | grep -qw "${sub}"; then
+      pass "cgroup_subtree_${sub}" "${sub} in cgroup.subtree_control"
+    else
+      warn "cgroup_subtree_${sub}" \
+        "${sub} not in cgroup.subtree_control — Cubelet may fail to create child cgroups; " \
+        "fix: echo '+${sub}' > /sys/fs/cgroup/cgroup.subtree_control"
+    fi
+  done
+}
+
+check_filesystem() {
+  section "Filesystem"
+
+  if [[ -d "${CUBE_DATA_PATH}" ]]; then
+    local fstype
+    fstype="$(findmnt -n -o FSTYPE "${CUBE_DATA_PATH}" 2>/dev/null \
+              || df -T "${CUBE_DATA_PATH}" 2>/dev/null | awk 'NR==2{print $2}' \
+              || echo unknown)"
+    if [[ "${fstype}" == "xfs" ]]; then
+      pass "xfs_cubesandbox" "${CUBE_DATA_PATH} is XFS"
+    else
+      fail "xfs_cubesandbox" \
+        "${CUBE_DATA_PATH} is ${fstype}; Cube requires XFS for CoW/reflink (pool_type=copy_reflink)"
+    fi
+
+    local free_gb
+    free_gb="$(df -BG "${CUBE_DATA_PATH}" 2>/dev/null | awk 'NR==2{gsub(/G/,"",$4); print $4}' || echo 0)"
+    if [[ "${free_gb}" -ge 20 ]]; then
+      pass "disk_free" "${free_gb} GB free on ${CUBE_DATA_PATH}"
+    else
+      warn "disk_free" "only ${free_gb} GB free on ${CUBE_DATA_PATH}; >= 20 GB recommended"
+    fi
+  else
+    fail "xfs_cubesandbox" "${CUBE_DATA_PATH} does not exist"
+  fi
+
+  if [[ -d /data/cubelet ]]; then
+    pass "dir_data_cubelet" "/data/cubelet exists"
+  else
+    fail "dir_data_cubelet" "/data/cubelet missing; run installer first"
+  fi
+}
+
+check_commands() {
+  section "Required commands"
+  for cmd in curl ss findmnt awk lsmod modinfo; do
+    if command -v "${cmd}" >/dev/null 2>&1; then
+      pass "cmd_${cmd}" "$(command -v "${cmd}")"
+    else
+      fail "cmd_${cmd}" "'${cmd}' not found"
+    fi
+  done
+
+  # docker is required for cube-proxy / infra containers
+  if command -v docker >/dev/null 2>&1; then
+    local docker_ver
+    docker_ver="$(docker --version 2>/dev/null | head -1 || true)"
+    pass "cmd_docker" "${docker_ver}"
+  else
+    fail "cmd_docker" "docker not found — required for cube-proxy and infrastructure containers"
+  fi
+}
+
+# ── Main ───────────────────────────────────────────────────────────────────────
+main() {
+  echo "╔══════════════════════════════════════════════════════╗"
+  echo "║    Cube Sandbox — Dependency Check                  ║"
+  echo "╚══════════════════════════════════════════════════════╝"
+
+  check_kernel
+  check_virtualization
+  check_cgroup
+  check_filesystem
+  check_commands
+
+  echo
+  echo "──────────────────────────────────────────────────────"
+  printf "Summary: %d passed, %d warned, %d failed\n" \
+    "${PASS_COUNT}" "${WARN_COUNT}" "${FAIL_COUNT}"
+  echo "──────────────────────────────────────────────────────"
+
+  if [[ "${JSON_OUT}" -eq 1 ]]; then emit_json; fi
+
+  if [[ "${FAIL_COUNT}" -gt 0 ]]; then
+    echo "RESULT: FAIL"
+    exit 1
+  fi
+  echo "RESULT: PASS"
+}
+
+HOST_ENV="unknown"
+main "$@"

--- a/deploy/one-click/scripts/cube-diag/check-procs.sh
+++ b/deploy/one-click/scripts/cube-diag/check-procs.sh
@@ -1,0 +1,500 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (C) 2026 Tencent. All rights reserved.
+#
+# check-procs.sh — Cube Sandbox process readiness checker
+# Standalone script; no external dependencies.
+#
+# Checks whether all Cube Sandbox daemons are up and responding:
+#   • network-agent  (127.0.0.1:19090, /healthz, /readyz, UNIX sockets)
+#   • cubelet        (ports 9966/9998/9999, /data/cubelet/cubelet.sock, assets)
+#   • cubemaster     (port 8089, /notify/health)
+#   • cube-api       (port 3000, /health)
+#   • containerd-shim-cube-rs
+#
+# Role-aware: set ONE_CLICK_DEPLOY_ROLE=compute to check a compute node
+# (cube-api/cubemaster expected on control plane, not locally).
+#
+# Usage:
+#   ./check-procs.sh              # check all
+#   ./check-procs.sh --quiet      # suppress OK lines
+#   ./check-procs.sh --json       # machine-readable JSON to stdout
+#
+# Exit: 0 = all pass, 1 = one or more failures
+
+set -uo pipefail
+
+# ── Help ──────────────────────────────────────────────────────────────────────
+usage() {
+  cat <<'EOF'
+Usage: check-procs.sh [OPTIONS]
+
+Check whether all Cube Sandbox daemon processes are running and healthy.
+
+Processes / components checked:
+  network-agent        Port 19090, /healthz, /readyz, UNIX sockets
+  cubelet              Ports 9966/9998/9999, /data/cubelet/cubelet.sock,
+                       config files and runtime asset files
+  cubemaster           Port 8089, /notify/health HTTP endpoint
+  cube-api             Port 3000, /health HTTP endpoint, binary and config
+  cubeshim             containerd-shim-cube-rs binary and running instance count
+  cube-proxy           Docker containers for reverse proxy and routing:
+                         cube-proxy        nginx/openresty, ports 80/443
+                         cube-proxy-coredns internal DNS (no host port)
+                         cube-webui        management UI, port 12088
+  infrastructure       Docker containers for storage / metadata:
+                         cube-sandbox-redis  session state, port 6379
+                         cube-sandbox-mysql  metadata DB, port 3306
+  cube-kernel          vmlinux / vmlinux-pvm kernel image files;
+                       PVM variant checked against host environment
+
+Options:
+  --quiet      Suppress OK lines; only print WARN and FAIL entries
+  --json       Print a machine-readable JSON summary to stdout after the run
+  --help       Show this help message and exit
+
+Environment variables:
+  ONE_CLICK_DEPLOY_ROLE              control (default) or compute
+  ONE_CLICK_TOOLBOX_ROOT             Installation root (default: /usr/local/services/cubetoolbox)
+  ONE_CLICK_RUNTIME_DIR              PID file directory (default: /var/run/cube-sandbox-one-click)
+  NETWORK_AGENT_HEALTH_ADDR          network-agent health address (default: 127.0.0.1:19090)
+  CUBE_API_HEALTH_ADDR               cube-api health address (default: 127.0.0.1:3000)
+  CUBEMASTER_ADDR                    cubemaster address (default: 127.0.0.1:8089)
+  ONE_CLICK_CONTROL_PLANE_IP         Control plane IP for compute role
+  ONE_CLICK_CONTROL_PLANE_CUBEMASTER_ADDR  Full cubemaster address for compute role
+
+  When ONE_CLICK_DEPLOY_ROLE=compute, cubemaster and cube-api checks use the
+  control-plane address instead of localhost.
+
+Exit codes:
+  0   All checks passed (warnings are allowed)
+  1   One or more checks failed
+
+Examples:
+  ./check-procs.sh
+  ./check-procs.sh --quiet
+  ./check-procs.sh --json
+  ONE_CLICK_DEPLOY_ROLE=compute ONE_CLICK_CONTROL_PLANE_IP=10.0.0.1 ./check-procs.sh
+EOF
+}
+
+# ── Config (override via env) ──────────────────────────────────────────────────
+TOOLBOX_ROOT="${ONE_CLICK_TOOLBOX_ROOT:-/usr/local/services/cubetoolbox}"
+RUNTIME_DIR="${ONE_CLICK_RUNTIME_DIR:-/var/run/cube-sandbox-one-click}"
+NA_HEALTH_ADDR="${NETWORK_AGENT_HEALTH_ADDR:-127.0.0.1:19090}"
+CUBE_API_HEALTH_ADDR="${CUBE_API_HEALTH_ADDR:-127.0.0.1:3000}"
+CUBEMASTER_ADDR="${CUBEMASTER_ADDR:-127.0.0.1:8089}"
+
+# Load .one-click.env if present (for ROLE / CONTROL_PLANE_IP, etc.)
+_env_file="${TOOLBOX_ROOT}/.one-click.env"
+if [[ -f "${_env_file}" ]]; then
+  set +u; set -a
+  # shellcheck disable=SC1090
+  source "${_env_file}"
+  set +a; set -u
+fi
+
+# Role: control (default) or compute
+ROLE="${ONE_CLICK_DEPLOY_ROLE:-control}"
+case "${ROLE}" in control|compute) ;; *) ROLE=control ;; esac
+
+# For compute nodes, resolve the control-plane cubemaster address
+_resolve_master_addr() {
+  if [[ "${ROLE}" != "compute" ]]; then
+    printf '%s\n' "${CUBEMASTER_ADDR}"
+    return
+  fi
+  local addr="${ONE_CLICK_CONTROL_PLANE_CUBEMASTER_ADDR:-}"
+  local ip="${ONE_CLICK_CONTROL_PLANE_IP:-}"
+  local port="${CUBEMASTER_ADDR##*:}"
+  if [[ -n "${addr}" ]]; then printf '%s\n' "${addr}"; return; fi
+  if [[ -n "${ip}" ]];   then printf '%s:%s\n' "${ip}" "${port}"; return; fi
+  printf '%s\n' "${CUBEMASTER_ADDR}"
+}
+MASTER_ADDR="$(_resolve_master_addr)"
+
+# ── CLI flags ──────────────────────────────────────────────────────────────────
+QUIET=0
+JSON_OUT=0
+for _arg in "$@"; do
+  case "${_arg}" in
+    --quiet)   QUIET=1 ;;
+    --json)    JSON_OUT=1 ;;
+    --help|-h) usage; exit 0 ;;
+  esac
+done
+
+# ── Result tracking ────────────────────────────────────────────────────────────
+PASS_COUNT=0
+FAIL_COUNT=0
+WARN_COUNT=0
+declare -a RESULTS=()
+
+_record() {
+  local level="$1" name="$2" detail="$3"
+  RESULTS+=("${level}::${name}::${detail}")
+  case "${level}" in
+    PASS) PASS_COUNT=$((PASS_COUNT + 1)) ;;
+    WARN) WARN_COUNT=$((WARN_COUNT + 1)) ;;
+    FAIL) FAIL_COUNT=$((FAIL_COUNT + 1)) ;;
+  esac
+}
+
+pass() { _record PASS "$1" "${2:-OK}"; [[ "${QUIET}" -eq 1 ]] || printf '  [ OK ]  %s%s\n' "$1" "${2:+: $2}"; }
+warn() { _record WARN "$1" "$2"; printf '  [WARN]  %s: %s\n' "$1" "$2"; }
+fail() { _record FAIL "$1" "$2"; printf '  [FAIL]  %s: %s\n' "$1" "$2"; }
+section() { [[ "${QUIET}" -eq 1 ]] || echo; echo "── $* ──"; }
+
+emit_json() {
+  printf '{\n  "pass": %d,\n  "warn": %d,\n  "fail": %d,\n  "checks": [\n' \
+    "${PASS_COUNT}" "${WARN_COUNT}" "${FAIL_COUNT}"
+  local sep=""
+  for r in "${RESULTS[@]}"; do
+    local level name detail
+    level="${r%%::*}"; r="${r#*::}"
+    name="${r%%::*}"; detail="${r#*::}"
+    detail="${detail//\\/\\\\}"; detail="${detail//\"/\\\"}"
+    # strip control characters (newlines, tabs) to keep JSON on one line
+    detail="$(printf '%s' "${detail}" | tr -d '\000-\037')"
+    printf '%s    {"level":"%s","name":"%s","detail":"%s"}' \
+      "${sep}" "${level}" "${name}" "${detail}"
+    sep=$',\n'
+  done
+  printf '\n  ]\n}\n'
+}
+
+# ── Helpers ────────────────────────────────────────────────────────────────────
+_pidfile_alive() {
+  local pid_file="${RUNTIME_DIR}/$1.pid"
+  [[ -f "${pid_file}" ]] || return 1
+  local pid; pid="$(<"${pid_file}")"
+  [[ -n "${pid}" ]] && kill -0 "${pid}" 2>/dev/null
+}
+
+_pidfile_pid() {
+  cat "${RUNTIME_DIR}/$1.pid" 2>/dev/null || true
+}
+
+_proc_running() {
+  pgrep -f -- "$1" >/dev/null 2>&1
+}
+
+_http_ok() {
+  curl -fsS --max-time 5 "$1" >/dev/null 2>&1
+}
+
+_port_listening() {
+  ss -tlnp "sport = :$1" 2>/dev/null | grep -q ":$1"
+}
+
+# _check_container <name> <expected_state> <expected_health|empty> <host_ports|empty>
+# Checks a Docker container: state, optional health, and optional host-port listeners.
+_check_container() {
+  local name="$1" exp_state="$2" exp_health="$3" ports="$4"
+  local key; key="${name//-/_}"
+
+  local state
+  state="$(docker inspect --format '{{.State.Status}}' "${name}" 2>/dev/null || true)"
+  if [[ -z "${state}" ]]; then
+    fail "${key}_container" "container '${name}' not found"
+    return
+  fi
+
+  if [[ "${state}" == "${exp_state}" ]]; then
+    pass "${key}_container" "'${name}' is ${state}"
+  else
+    fail "${key}_container" "'${name}' state=${state} (expected ${exp_state})"
+  fi
+
+  # Health check (only when a HEALTHCHECK is configured and caller expects it)
+  if [[ -n "${exp_health}" ]]; then
+    local health
+    health="$(docker inspect --format '{{if .State.Health}}{{.State.Health.Status}}{{else}}none{{end}}' \
+      "${name}" 2>/dev/null || true)"
+    if [[ "${health}" == "${exp_health}" ]]; then
+      pass "${key}_health" "'${name}' health=${health}"
+    elif [[ "${health}" == "none" ]]; then
+      warn "${key}_health" "'${name}' has no HEALTHCHECK configured"
+    else
+      warn "${key}_health" "'${name}' health=${health} (expected ${exp_health})"
+    fi
+  fi
+
+  # Host port listeners
+  for port in ${ports}; do
+    if _port_listening "${port}"; then
+      pass "${key}_port_${port}" "0.0.0.0:${port} listening"
+    else
+      fail "${key}_port_${port}" "0.0.0.0:${port} not listening"
+    fi
+  done
+}
+
+# ── Check functions ────────────────────────────────────────────────────────────
+check_network_agent() {
+  section "network-agent"
+
+  if _pidfile_alive "network-agent"; then
+    pass "network_agent_pid" "pid=$(_pidfile_pid network-agent)"
+  elif _proc_running "${TOOLBOX_ROOT}/network-agent/bin/network-agent"; then
+    pass "network_agent_pid" "running (no pidfile)"
+  else
+    fail "network_agent_pid" "network-agent process not running"
+  fi
+
+  if _port_listening 19090; then
+    pass "network_agent_port" "127.0.0.1:19090 listening"
+  else
+    fail "network_agent_port" "127.0.0.1:19090 not listening"
+  fi
+
+  if _http_ok "http://${NA_HEALTH_ADDR}/healthz"; then
+    pass "network_agent_healthz" "/healthz → 200"
+  else
+    fail "network_agent_healthz" "http://${NA_HEALTH_ADDR}/healthz failed"
+  fi
+
+  if _http_ok "http://${NA_HEALTH_ADDR}/readyz"; then
+    pass "network_agent_readyz" "/readyz → 200"
+  else
+    fail "network_agent_readyz" "http://${NA_HEALTH_ADDR}/readyz failed (still initialising?)"
+  fi
+
+  for sock in network-agent-grpc.sock network-agent.sock; do
+    if [[ -S "/tmp/cube/${sock}" ]]; then
+      pass "sock_${sock%.sock}" "/tmp/cube/${sock} present"
+    else
+      warn "sock_${sock%.sock}" "/tmp/cube/${sock} missing"
+    fi
+  done
+}
+
+check_cubelet() {
+  section "Cubelet"
+
+  if _pidfile_alive "cubelet"; then
+    pass "cubelet_pid" "pid=$(_pidfile_pid cubelet)"
+  elif _proc_running "${TOOLBOX_ROOT}/Cubelet/bin/cubelet"; then
+    pass "cubelet_pid" "running (no pidfile)"
+  else
+    fail "cubelet_pid" "cubelet not running"
+  fi
+
+  for port in 9966 9998 9999; do
+    if _port_listening "${port}"; then
+      pass "cubelet_port_${port}" "0.0.0.0:${port} listening"
+    else
+      fail "cubelet_port_${port}" "0.0.0.0:${port} not listening"
+    fi
+  done
+
+  if [[ -S /data/cubelet/cubelet.sock ]]; then
+    pass "cubelet_sock" "/data/cubelet/cubelet.sock present"
+  else
+    fail "cubelet_sock" "/data/cubelet/cubelet.sock missing"
+  fi
+
+  for f in \
+    "${TOOLBOX_ROOT}/Cubelet/config/config.toml" \
+    "${TOOLBOX_ROOT}/Cubelet/dynamicconf/conf.yaml" \
+    "${TOOLBOX_ROOT}/cube-shim/conf/config-cube.toml" \
+    "${TOOLBOX_ROOT}/cube-kernel-scf/vmlinux" \
+    "${TOOLBOX_ROOT}/cube-image/cube-guest-image-cpu.img"; do
+    local label; label="$(basename "${f}")"
+    if [[ -f "${f}" ]]; then
+      pass "asset_${label}" "${f}"
+    else
+      warn "asset_${label}" "${f} not found"
+    fi
+  done
+}
+
+check_cubemaster() {
+  section "CubeMaster"
+
+  if [[ "${ROLE}" == "control" ]]; then
+    if _pidfile_alive "cubemaster"; then
+      pass "cubemaster_pid" "pid=$(_pidfile_pid cubemaster)"
+    elif _proc_running "${TOOLBOX_ROOT}/CubeMaster/bin/cubemaster"; then
+      pass "cubemaster_pid" "running (no pidfile)"
+    else
+      fail "cubemaster_pid" "cubemaster not running"
+    fi
+
+    if _port_listening 8089; then
+      pass "cubemaster_port" "0.0.0.0:8089 listening"
+    else
+      fail "cubemaster_port" "0.0.0.0:8089 not listening"
+    fi
+  else
+    pass "cubemaster_pid" "compute node — cubemaster on control plane (skipped)"
+  fi
+
+  if _http_ok "http://${MASTER_ADDR}/notify/health"; then
+    pass "cubemaster_health" "http://${MASTER_ADDR}/notify/health → 200"
+  else
+    fail "cubemaster_health" "http://${MASTER_ADDR}/notify/health failed"
+  fi
+}
+
+check_cube_api() {
+  section "cube-api"
+
+  if [[ "${ROLE}" == "compute" ]]; then
+    pass "cube_api_skip" "compute node — cube-api on control plane (skipped)"
+    return
+  fi
+
+  if _pidfile_alive "cube-api"; then
+    pass "cube_api_pid" "pid=$(_pidfile_pid cube-api)"
+  elif _proc_running "${TOOLBOX_ROOT}/CubeAPI/bin/cube-api"; then
+    pass "cube_api_pid" "running (no pidfile)"
+  else
+    fail "cube_api_pid" "cube-api not running"
+  fi
+
+  if _port_listening 3000; then
+    pass "cube_api_port" "0.0.0.0:3000 listening"
+  else
+    fail "cube_api_port" "0.0.0.0:3000 not listening"
+  fi
+
+  if _http_ok "http://${CUBE_API_HEALTH_ADDR}/health"; then
+    pass "cube_api_health" "http://${CUBE_API_HEALTH_ADDR}/health → 200"
+  else
+    fail "cube_api_health" "http://${CUBE_API_HEALTH_ADDR}/health failed"
+  fi
+
+  for f in \
+    "${TOOLBOX_ROOT}/CubeAPI/bin/cube-api" \
+    "${TOOLBOX_ROOT}/CubeMaster/conf.yaml"; do
+    local label; label="$(basename "${f}")"
+    if [[ -e "${f}" ]]; then
+      pass "file_${label}" "${f}"
+    else
+      warn "file_${label}" "${f} not found"
+    fi
+  done
+}
+
+check_shim() {
+  section "containerd-shim-cube-rs (CubeShim)"
+
+  local shim="${TOOLBOX_ROOT}/cube-shim/bin/containerd-shim-cube-rs"
+  if [[ -x "${shim}" ]]; then
+    pass "cubeshim_binary" "${shim}"
+  else
+    warn "cubeshim_binary" "${shim} not found (expected after first sandbox launch)"
+  fi
+
+  local cnt; cnt="$(pgrep -c -f 'containerd-shim-cube-rs' 2>/dev/null || echo 0)"
+  pass "cubeshim_instances" "${cnt} shim instance(s) running"
+}
+
+check_cube_proxy() {
+  section "cube-proxy (Docker containers)"
+
+  if ! command -v docker >/dev/null 2>&1; then
+    warn "cube_proxy_docker" "docker not found — cannot check cube-proxy containers"
+    return
+  fi
+
+  # ── cube-proxy ── nginx/openresty reverse proxy, ports 80/443
+  _check_container "cube-proxy" "running" "" "80 443"
+
+  # ── cube-proxy-coredns ── internal DNS for sandbox routing (no host port)
+  _check_container "cube-proxy-coredns" "running" "" ""
+
+  # ── cube-webui ── management Web UI, port 12088
+  _check_container "cube-webui" "running" "healthy" "12088"
+}
+
+check_cube_infra() {
+  section "Infrastructure (Docker containers)"
+
+  if ! command -v docker >/dev/null 2>&1; then
+    warn "cube_infra_docker" "docker not found — cannot check infrastructure containers"
+    return
+  fi
+
+  # ── cube-sandbox-redis ── session/routing state store, port 6379
+  _check_container "cube-sandbox-redis" "running" "healthy" "6379"
+
+  # ── cube-sandbox-mysql ── persistent metadata store, port 3306
+  _check_container "cube-sandbox-mysql" "running" "healthy" "3306"
+}
+
+check_cube_kernel() {
+  section "cube-kernel"
+
+  local kernel_dir="${TOOLBOX_ROOT}/cube-kernel-scf"
+
+  if [[ ! -d "${kernel_dir}" ]]; then
+    fail "cube_kernel_dir" "${kernel_dir} directory not found"
+    return
+  fi
+
+  # Determine which kernel variant is expected based on host environment.
+  # PVM hosts boot guests with vmlinux-pvm; KVM/bare-metal use vmlinux.
+  local pvm_host=0
+  lsmod 2>/dev/null | grep -qE '^kvm_pvm[[:space:]]' && pvm_host=1
+
+  # Always check the generic vmlinux (required for KVM/nested)
+  if [[ -f "${kernel_dir}/vmlinux" ]]; then
+    local sz; sz="$(du -sh "${kernel_dir}/vmlinux" 2>/dev/null | cut -f1)"
+    pass "cube_kernel_vmlinux" "${kernel_dir}/vmlinux (${sz})"
+  else
+    fail "cube_kernel_vmlinux" "${kernel_dir}/vmlinux not found"
+  fi
+
+  # Check PVM variant
+  if [[ -f "${kernel_dir}/vmlinux-pvm" ]]; then
+    local sz; sz="$(du -sh "${kernel_dir}/vmlinux-pvm" 2>/dev/null | cut -f1)"
+    if [[ "${pvm_host}" -eq 1 ]]; then
+      pass "cube_kernel_vmlinux_pvm" "${kernel_dir}/vmlinux-pvm (${sz}) — PVM host, this variant will be used"
+    else
+      pass "cube_kernel_vmlinux_pvm" "${kernel_dir}/vmlinux-pvm (${sz})"
+    fi
+  else
+    if [[ "${pvm_host}" -eq 1 ]]; then
+      fail "cube_kernel_vmlinux_pvm" \
+        "${kernel_dir}/vmlinux-pvm not found — required on PVM host for guest VM boot"
+    else
+      warn "cube_kernel_vmlinux_pvm" "${kernel_dir}/vmlinux-pvm not found (only needed on PVM hosts)"
+    fi
+  fi
+}
+
+# ── Main ───────────────────────────────────────────────────────────────────────
+main() {
+  echo "╔══════════════════════════════════════════════════════╗"
+  echo "║    Cube Sandbox — Process Readiness Check           ║"
+  echo "╚══════════════════════════════════════════════════════╝"
+  echo "  Role   : ${ROLE}"
+  echo "  Toolbox: ${TOOLBOX_ROOT}"
+
+  check_network_agent
+  check_cubelet
+  check_cubemaster
+  check_cube_api
+  check_shim
+  check_cube_proxy
+  check_cube_infra
+  check_cube_kernel
+
+  echo
+  echo "──────────────────────────────────────────────────────"
+  printf "Summary: %d passed, %d warned, %d failed\n" \
+    "${PASS_COUNT}" "${WARN_COUNT}" "${FAIL_COUNT}"
+  echo "──────────────────────────────────────────────────────"
+
+  if [[ "${JSON_OUT}" -eq 1 ]]; then emit_json; fi
+
+  if [[ "${FAIL_COUNT}" -gt 0 ]]; then
+    echo "RESULT: FAIL"
+    exit 1
+  fi
+  echo "RESULT: PASS"
+}
+
+main "$@"

--- a/deploy/one-click/scripts/cube-diag/collect-logs.sh
+++ b/deploy/one-click/scripts/cube-diag/collect-logs.sh
@@ -1,0 +1,393 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (C) 2026 Tencent. All rights reserved.
+#
+# collect-logs.sh — Cube Sandbox log & diagnostic collector
+# Standalone script; no external dependencies.
+#
+# Log sources collected:
+#   /var/log/cube-sandbox-one-click/   runtime logs (cubemaster, cubelet, cube-api, …)
+#   /data/log/CubeMaster/              CubeMaster request/stat logs
+#   /data/log/Cubelet/                 Cubelet request/stat/audit logs
+#   /data/log/CubeAPI/                 cube-api rotated daily logs
+#   /data/log/CubeShim/                CubeShim request/stat logs
+#   /data/log/CubeVmm/                 VMM logs
+#   /data/log/network-agent/           network-agent request logs
+#   /data/log/cube-proxy/              cube-proxy logs
+#   dmesg                              kernel ring buffer
+#   process/env snapshot               ps, ports, mounts, cgroup, cpuinfo, …
+#   config files                       with secrets redacted
+#
+# Usage:
+#   ./collect-logs.sh [OPTIONS]
+#
+# Options:
+#   --module <name>     Collect only the specified module(s); repeat for multiple.
+#                       Module names: cubemaster cubelet cube-api cubeshim
+#                       cubevmm network-agent cube-proxy runtime dmesg env configs
+#                       Default: all modules
+#   --lines <n>         Tail N lines per log file (default: 2000)
+#   --all-lines         Collect entire log files (may be very large)
+#   --dir <dir>         Output directory (default: /tmp/cube-diag-<timestamp>)
+#                       Must not already exist or be non-empty (exits with error if non-empty)
+#   --no-tar            Keep the directory, skip .tar.gz creation
+#
+# Exit: 0 = collection complete (partial source failures are warned, not fatal)
+
+set -uo pipefail
+
+# ── Help ──────────────────────────────────────────────────────────────────────
+usage() {
+  cat <<'EOF'
+Usage: collect-logs.sh [OPTIONS]
+
+Collect Cube Sandbox logs and diagnostic information into a .tar.gz bundle.
+
+Log sources:
+  /var/log/cube-sandbox-one-click/   Runtime startup logs
+  /data/log/CubeMaster/              CubeMaster request/stat logs
+  /data/log/Cubelet/                 Cubelet request/stat/audit logs
+  /data/log/CubeAPI/                 cube-api rotated daily logs
+  /data/log/CubeShim/                CubeShim request/stat logs
+  /data/log/CubeVmm/                 VMM logs
+  /data/log/network-agent/           network-agent request logs
+  /data/log/cube-proxy/              cube-proxy logs
+  dmesg                              Full kernel ring buffer + filtered views
+  env                                Process list, ports, mounts, cgroup, cpuinfo, ...
+  configs                            Config files with secrets redacted
+
+Options:
+  --module <name>   Collect only the specified module. Repeat to select multiple.
+                    Available modules:
+                      cubemaster  cubelet  cube-api  cubeshim  cubevmm
+                      network-agent  cube-proxy  runtime  dmesg  env  configs
+                    Default: all modules
+  --lines <n>       Tail N lines per log file (default: 2000)
+  --all-lines       Copy entire log files without truncation.
+                    WARNING: some logs exceed 1 million lines; bundle may be very large.
+  --dir <dir>       Output directory (default: /tmp/cube-diag-<timestamp>)
+                    Must not already exist or be non-empty (exits with error if non-empty)
+  --no-tar          Keep output directory; skip .tar.gz creation
+  --help            Show this help message and exit
+
+Environment variables:
+  ONE_CLICK_TOOLBOX_ROOT   Installation root (default: /usr/local/services/cubetoolbox)
+  ONE_CLICK_LOG_DIR        Runtime log directory (default: /var/log/cube-sandbox-one-click)
+  ONE_CLICK_RUNTIME_DIR    PID file directory (default: /var/run/cube-sandbox-one-click)
+  CUBE_DATA_LOG_DIR        Structured log root (default: /data/log)
+
+Exit codes:
+  0   Collection finished (individual source failures are warned, not fatal)
+
+Examples:
+  # Collect everything (default)
+  ./collect-logs.sh
+
+  # Only cubelet and dmesg, last 500 lines each
+  ./collect-logs.sh --module cubelet --module dmesg --lines 500
+
+  # Full cubemaster log (may be very large)
+  ./collect-logs.sh --module cubemaster --all-lines
+
+  # Save to a specific directory without creating a tarball
+  ./collect-logs.sh --dir /tmp/my-diag --no-tar
+
+EOF
+}
+
+
+# ── Config ─────────────────────────────────────────────────────────────────────
+TOOLBOX_ROOT="${ONE_CLICK_TOOLBOX_ROOT:-/usr/local/services/cubetoolbox}"
+RUNTIME_LOG_DIR="${ONE_CLICK_LOG_DIR:-/var/log/cube-sandbox-one-click}"
+RUNTIME_PID_DIR="${ONE_CLICK_RUNTIME_DIR:-/var/run/cube-sandbox-one-click}"
+DATA_LOG_DIR="${CUBE_DATA_LOG_DIR:-/data/log}"
+TS="$(date +%Y%m%d_%H%M%S)"
+
+# ── CLI flags ──────────────────────────────────────────────────────────────────
+TAIL_LINES=2000
+ALL_LINES=0
+OUT_DIR="/tmp/cube-diag-${TS}"
+NO_TAR=0
+ALLOW_EXISTING=0
+declare -a SELECTED_MODULES=()
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --module)    SELECTED_MODULES+=("$2"); shift 2 ;;
+    --lines)     TAIL_LINES="$2"; shift 2 ;;
+    --all-lines) ALL_LINES=1; shift ;;
+    --dir)       OUT_DIR="$2"; shift 2 ;;
+    --no-tar)        NO_TAR=1; shift ;;
+    --allow-existing) ALLOW_EXISTING=1; shift ;;
+    --help|-h)   usage; exit 0 ;;
+    *)           echo "[collect] WARNING: unrecognized option: $1" >&2; shift ;;
+  esac
+done
+
+# If no --module given, collect everything
+_ALL_MODULES=(cubemaster cubelet cube-api cubeshim cubevmm network-agent cube-proxy runtime dmesg env configs)
+if [[ "${#SELECTED_MODULES[@]}" -eq 0 ]]; then
+  SELECTED_MODULES=("${_ALL_MODULES[@]}")
+fi
+
+_module_selected() {
+  local m
+  for m in "${SELECTED_MODULES[@]}"; do
+    [[ "${m}" == "$1" ]] && return 0
+  done
+  return 1
+}
+
+# ── Setup ──────────────────────────────────────────────────────────────────────
+if [[ "${ALLOW_EXISTING}" -eq 0 ]] && [[ -e "${OUT_DIR}" ]] && [[ -n "$(ls -A "${OUT_DIR}" 2>/dev/null)" ]]; then
+  echo "[collect] ERROR: output directory already exists and is not empty: ${OUT_DIR}" >&2
+  echo "[collect] Use a different path with --dir, or remove the existing directory first." >&2
+  exit 1
+fi
+mkdir -p "${OUT_DIR}"
+SUMMARY="${OUT_DIR}/SUMMARY.txt"
+
+_info() { echo "[collect] INFO:  $*" | tee -a "${SUMMARY}" >&2; }
+_warn() { echo "[collect] WARN:  $*" | tee -a "${SUMMARY}" >&2; }
+
+_capture() {
+  # _capture <label> <dest_file> <cmd...>
+  local label="$1" dest="$2"; shift 2
+  if "$@" >"${dest}" 2>&1; then
+    _info "${label} → $(basename "${dest}")"
+  else
+    _warn "${label} failed (partial output may exist)"
+  fi
+}
+
+_redact() {
+  sed -E \
+    -e 's/(password|pwd|passwd|secret|token|key)[[:space:]]*[:=][[:space:]]*\S*/\1: [REDACTED]/gi' \
+    -e 's/"(Password|Pwd|Secret|Token|Key)"[[:space:]]*:[[:space:]]*"[^"]*/"\1": "[REDACTED]/g' \
+    -e 's/^([[:space:]]*)(password|secret|token|key)[[:space:]]*:[[:space:]]*\S*/\1\2: [REDACTED]/gmi'
+}
+
+# Collect one log file: tail N lines or full copy
+_collect_log() {
+  local src="$1" dest_dir="$2"
+  [[ -f "${src}" ]] || return 0
+  local base; base="$(basename "${src}")"
+  local dest="${dest_dir}/${base}"
+
+  if [[ "${ALL_LINES}" -eq 1 ]]; then
+    cp "${src}" "${dest}" 2>/dev/null \
+      && _info "full copy: ${src}" \
+      || _warn "could not copy ${src}"
+  else
+    tail -n "${TAIL_LINES}" "${src}" >"${dest}" 2>/dev/null \
+      && _info "tail -${TAIL_LINES}: ${src}" \
+      || _warn "could not tail ${src}"
+  fi
+}
+
+# Collect all logs under a /data/log/<Module>/ directory
+_collect_data_log_dir() {
+  local module_dir="$1" dest_dir="$2"
+  [[ -d "${module_dir}" ]] || { _warn "${module_dir} not found — skipping"; return; }
+  mkdir -p "${dest_dir}"
+  while IFS= read -r -d '' f; do
+    _collect_log "${f}" "${dest_dir}"
+  done < <(find "${module_dir}" -maxdepth 2 -name "*.log" -print0 2>/dev/null)
+}
+
+# ── Module collectors ─────────────────────────────────────────────────────────
+
+collect_cubemaster() {
+  _info "── CubeMaster ──"
+  local dest="${OUT_DIR}/CubeMaster"
+  mkdir -p "${dest}"
+  _collect_data_log_dir "${DATA_LOG_DIR}/CubeMaster" "${dest}"
+  # Also grab the runtime startup log if present
+  _collect_log "${RUNTIME_LOG_DIR}/cubemaster.log" "${dest}"
+}
+
+collect_cubelet() {
+  _info "── Cubelet ──"
+  local dest="${OUT_DIR}/Cubelet"
+  mkdir -p "${dest}"
+  _collect_data_log_dir "${DATA_LOG_DIR}/Cubelet" "${dest}"
+  _collect_log "${RUNTIME_LOG_DIR}/cubelet.log"       "${dest}"
+  _collect_log "${RUNTIME_LOG_DIR}/cubelet-debug.log" "${dest}"
+}
+
+collect_cube_api() {
+  _info "── CubeAPI ──"
+  local dest="${OUT_DIR}/CubeAPI"
+  mkdir -p "${dest}"
+  _collect_data_log_dir "${DATA_LOG_DIR}/CubeAPI" "${dest}"
+  _collect_log "${RUNTIME_LOG_DIR}/cube-api.log" "${dest}"
+}
+
+collect_cubeshim() {
+  _info "── CubeShim ──"
+  local dest="${OUT_DIR}/CubeShim"
+  mkdir -p "${dest}"
+  _collect_data_log_dir "${DATA_LOG_DIR}/CubeShim" "${dest}"
+}
+
+collect_cubevmm() {
+  _info "── CubeVmm ──"
+  local dest="${OUT_DIR}/CubeVmm"
+  mkdir -p "${dest}"
+  _collect_data_log_dir "${DATA_LOG_DIR}/CubeVmm" "${dest}"
+}
+
+collect_network_agent() {
+  _info "── network-agent ──"
+  local dest="${OUT_DIR}/network-agent"
+  mkdir -p "${dest}"
+  _collect_data_log_dir "${DATA_LOG_DIR}/network-agent" "${dest}"
+  _collect_log "${RUNTIME_LOG_DIR}/network-agent.log" "${dest}"
+}
+
+collect_cube_proxy() {
+  _info "── cube-proxy ──"
+  local dest="${OUT_DIR}/cube-proxy"
+  mkdir -p "${dest}"
+  _collect_data_log_dir "${DATA_LOG_DIR}/cube-proxy" "${dest}"
+}
+
+collect_runtime() {
+  _info "── Runtime logs ──"
+  local dest="${OUT_DIR}/runtime"
+  mkdir -p "${dest}"
+
+  # Remaining runtime logs not already pulled by per-module collectors
+  if [[ -d "${RUNTIME_LOG_DIR}" ]]; then
+    while IFS= read -r -d '' f; do
+      _collect_log "${f}" "${dest}"
+    done < <(find "${RUNTIME_LOG_DIR}" -maxdepth 1 -name "*.log" -print0 2>/dev/null)
+  fi
+
+  # Process snapshot
+  _capture "ps_cube" "${dest}/ps-cube.txt" \
+    bash -c 'ps auxww | grep -E "cube|cubelet|cubemaster|network-agent|containerd-shim" | grep -v grep || true'
+  _capture "ports"   "${dest}/ports.txt"   ss -tlnp
+
+  {
+    ls -la "${RUNTIME_PID_DIR}/" 2>/dev/null || echo "(${RUNTIME_PID_DIR} not found)"
+    for f in "${RUNTIME_PID_DIR}"/*.pid; do
+      [[ -f "${f}" ]] && printf '%s -> pid=%s\n' "$(basename "${f}")" "$(<"${f}")" || true
+    done
+  } > "${dest}/pidfiles.txt" 2>/dev/null
+  _info "pidfiles → runtime/pidfiles.txt"
+}
+
+collect_dmesg() {
+  _info "── dmesg ──"
+  local dest="${OUT_DIR}/dmesg"
+  mkdir -p "${dest}"
+
+  # Full dmesg
+  _capture "dmesg_full" "${dest}/dmesg.txt" \
+    bash -c 'dmesg --notime 2>/dev/null || dmesg 2>/dev/null || true'
+
+  # KVM/PVM/cube filtered
+  _capture "dmesg_kvm" "${dest}/dmesg-kvm-pvm.txt" \
+    bash -c 'dmesg --notime 2>/dev/null | grep -iE "kvm|pvm|cube|vmx|svm|hv_" | tail -200 || true'
+
+  # OOM / hardware errors
+  _capture "dmesg_errors" "${dest}/dmesg-errors.txt" \
+    bash -c 'dmesg --notime 2>/dev/null | grep -iE "oom|kill|error|fail|warn|segfault" | tail -200 || true'
+}
+
+collect_env() {
+  _info "── Environment snapshot ──"
+  local dest="${OUT_DIR}/env"
+  mkdir -p "${dest}"
+
+  _capture "uname"     "${dest}/uname.txt"    uname -a
+  _capture "cpuinfo"   "${dest}/cpuinfo.txt"  cat /proc/cpuinfo
+  _capture "meminfo"   "${dest}/meminfo.txt"  cat /proc/meminfo
+  _capture "lsmod"     "${dest}/lsmod.txt"    lsmod
+  _capture "df"        "${dest}/df.txt"       df -Th
+  _capture "mounts"    "${dest}/mounts.txt"   findmnt --notruncate
+  _capture "cgroup"    "${dest}/cgroup.txt" \
+    bash -c 'echo "=controllers="; cat /sys/fs/cgroup/cgroup.controllers 2>/dev/null
+             echo; echo "=subtree_control="; cat /sys/fs/cgroup/cgroup.subtree_control 2>/dev/null || true'
+  _capture "dev_virt"  "${dest}/dev-virt.txt" \
+    bash -c 'ls -la /dev/kvm /dev/pvm 2>/dev/null || echo "no /dev/kvm or /dev/pvm"'
+  _capture "ps_all"    "${dest}/ps-all.txt"   ps auxww
+}
+
+collect_configs() {
+  _info "── Config files (secrets redacted) ──"
+  local dest="${OUT_DIR}/configs"
+  mkdir -p "${dest}"
+
+  local -a files=(
+    "${TOOLBOX_ROOT}/Cubelet/config/config.toml"
+    "${TOOLBOX_ROOT}/Cubelet/dynamicconf/conf.yaml"
+    "${TOOLBOX_ROOT}/cube-shim/conf/config-cube.toml"
+    "${TOOLBOX_ROOT}/CubeMaster/conf.yaml"
+    "${TOOLBOX_ROOT}/.one-click.env"
+  )
+  for f in "${files[@]}"; do
+    if [[ -f "${f}" ]]; then
+      local base; base="$(basename "${f}")"
+      _redact < "${f}" > "${dest}/${base}" 2>/dev/null \
+        && _info "${f} (secrets redacted)" \
+        || _warn "could not read ${f}"
+    fi
+  done
+}
+
+# ── Tarball ────────────────────────────────────────────────────────────────────
+create_tarball() {
+  local tarball="${OUT_DIR}.tar.gz"
+  tar -czf "${tarball}" -C "$(dirname "${OUT_DIR}")" "$(basename "${OUT_DIR}")" 2>/dev/null
+  echo
+  echo "╔══════════════════════════════════════════════════════╗"
+  echo "║  Diagnostics bundle ready                           ║"
+  echo "╚══════════════════════════════════════════════════════╝"
+  printf "  File : %s\n" "${tarball}"
+  printf "  Size : %s\n" "$(du -sh "${tarball}" 2>/dev/null | cut -f1)"
+  echo
+  echo "  Share this bundle with the Cube Sandbox support team."
+  echo "  https://github.com/TencentCloud/CubeSandbox/issues"
+  echo "  Discord: https://discord.gg/kkapzDXShb"
+}
+
+# ── Main ───────────────────────────────────────────────────────────────────────
+main() {
+  echo "╔══════════════════════════════════════════════════════╗"
+  echo "║    Cube Sandbox — Log & Diagnostic Collector        ║"
+  echo "╚══════════════════════════════════════════════════════╝"
+  echo "  Output   : ${OUT_DIR}"
+  if [[ "${ALL_LINES}" -eq 1 ]]; then
+    echo "  Lines    : ALL (--all-lines)"
+  else
+    echo "  Lines    : ${TAIL_LINES} per file"
+  fi
+  echo "  Modules  : ${SELECTED_MODULES[*]}"
+  echo
+
+  _module_selected "cubemaster"    && collect_cubemaster
+  _module_selected "cubelet"       && collect_cubelet
+  _module_selected "cube-api"      && collect_cube_api
+  _module_selected "cubeshim"      && collect_cubeshim
+  _module_selected "cubevmm"       && collect_cubevmm
+  _module_selected "network-agent" && collect_network_agent
+  _module_selected "cube-proxy"    && collect_cube_proxy
+  _module_selected "runtime"       && collect_runtime
+  _module_selected "dmesg"         && collect_dmesg
+  _module_selected "env"           && collect_env
+  _module_selected "configs"       && collect_configs
+
+  _info "Collection complete"
+
+  if [[ "${NO_TAR}" -eq 0 ]]; then
+    create_tarball
+    rm -rf "${OUT_DIR}"
+  else
+    echo
+    echo "  Directory: ${OUT_DIR}"
+  fi
+}
+
+main "$@"

--- a/deploy/one-click/scripts/cube-diag/cube-check.sh
+++ b/deploy/one-click/scripts/cube-diag/cube-check.sh
@@ -1,0 +1,261 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (C) 2026 Tencent. All rights reserved.
+#
+# cube-check.sh - Cube Sandbox one-click health check (top-level entry point)
+# Standalone script; no external dependencies.
+#
+# Runs check modules in order and optionally collects diagnostic logs.
+# All output is written to stdout AND saved to an output directory when
+# --collect is given.
+#
+# Output directory layout (only created with --collect):
+#   <out>/check.log          combined stdout of all checks
+#   <out>/CubeMaster/        collected logs (per module sub-dirs)
+#   <out>/Cubelet/
+#   <out>/...
+#
+# Usage:
+#   ./cube-check.sh                  # deps + procs only; no log collection
+#   ./cube-check.sh --collect        # deps + procs + collect logs into <out>
+#   ./cube-check.sh --deps           # only dependency check
+#   ./cube-check.sh --procs          # only process check
+#   ./cube-check.sh --quiet          # suppress OK lines in sub-checks
+#   ./cube-check.sh --json           # JSON output from sub-checks
+#   ./cube-check.sh --collect        # deps + procs + collect logs, dir name = cube-diag-<ts>
+#   ./cube-check.sh --collect --dir <name>   # use custom directory name
+#   ./cube-check.sh --lines <n>      # lines per log file (default: 2000)
+#   ./cube-check.sh --since "<expr>" # journald since filter
+#
+# Exit: 0 = all selected checks passed, 1 = one or more failures
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# ── Help ───────────────────────────────────────────────────────────────────────
+usage() {
+  cat <<'EOF'
+Usage: cube-check.sh [OPTIONS]
+
+One-click Cube Sandbox health check.
+
+This script orchestrates the sub-scripts in the same directory:
+  check-deps.sh    Host environment dependency checker
+  check-procs.sh   Process readiness checker
+  collect-logs.sh  Log and diagnostic collector (only with --collect)
+
+Each sub-script can also be run independently. Use --help on any of them
+for its own detailed usage.
+
+Options:
+  --collect        Run collect-logs.sh and save everything (check output +
+                   collected logs) into a single output directory.
+                   Default: checks only, no log collection.
+  --deps           Run only check-deps.sh (no log collection)
+  --procs          Run only check-procs.sh (no log collection)
+  --quiet          Suppress OK lines in sub-checks; only print WARN/FAIL
+  --json           Pass --json to sub-checks for machine-readable output
+  --dir <dirname>  Output directory for --collect.
+                   Relative paths are resolved under the current working directory;
+                   absolute paths are used as-is.
+                   Must not already exist or be non-empty (exits with error if non-empty).
+                   Default: cube-diag-<timestamp>
+  --lines <n>      Lines per log file passed to collect-logs.sh (default: 2000)
+  --all-lines      Pass --all-lines to collect-logs.sh (collect full files)
+  --since <expr>   journald --since filter passed to collect-logs.sh
+  --help           Show this help message and exit
+
+Default behaviour (no flags):
+  Runs check-deps.sh then check-procs.sh.
+  Check output goes to stdout only. No files are written.
+
+With --collect:
+  Runs checks + collect-logs.sh.
+  All stdout is ALSO written to <out>/check.log.
+  Collected logs are written into subdirectories under <out>.
+  At the end, the directory path is printed so you can tar it yourself:
+    tar czf cube-diag-<ts>.tar.gz cube-diag-<ts>
+
+Exit codes:
+  0   All selected checks passed (warnings are allowed)
+  1   One or more checks failed
+
+Examples:
+  # Quick health check (stdout only)
+  ./cube-check.sh
+
+  # Full check + collect logs, default directory name (./cube-diag-<ts>/)
+  ./cube-check.sh --collect
+
+  # Full check + collect logs, custom directory name (./my-server-diag/)
+  ./cube-check.sh --collect --dir my-server-diag
+
+  # Only deps, suppress OK lines
+  ./cube-check.sh --deps --quiet
+
+  # CI mode: JSON output, no collection
+  ./cube-check.sh --json
+EOF
+}
+
+# ── CLI flags ──────────────────────────────────────────────────────────────────
+RUN_DEPS=1
+RUN_PROCS=1
+DO_COLLECT=0
+OUT_NAME=""
+declare -a SUB_FLAGS=()
+declare -a COLLECT_FLAGS=()
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --collect)    DO_COLLECT=1; shift ;;
+    --deps)       RUN_DEPS=1; RUN_PROCS=0; DO_COLLECT=0; shift ;;
+    --procs)      RUN_DEPS=0; RUN_PROCS=1; DO_COLLECT=0; shift ;;
+    --quiet)      SUB_FLAGS+=(--quiet); shift ;;
+    --json)       SUB_FLAGS+=(--json);  shift ;;
+    --dir)        OUT_NAME="$2"; shift 2 ;;
+    --lines)      COLLECT_FLAGS+=(--lines "$2"); shift 2 ;;
+    --all-lines)  COLLECT_FLAGS+=(--all-lines); shift ;;
+    --since)      COLLECT_FLAGS+=(--since "$2"); shift 2 ;;
+    --help|-h)    usage; exit 0 ;;
+    *)            echo "[cube-check] WARNING: unrecognized option: $1" >&2; shift ;;
+  esac
+done
+
+# ── Output directory (only used with --collect) ────────────────────────────────
+TS="$(date +%Y%m%d_%H%M%S)"
+# Resolve output directory: absolute path used as-is; relative path resolved under CWD
+_dirname="${OUT_NAME:-cube-diag-${TS}}"
+case "${_dirname}" in
+  /*) OUT_DIR="${_dirname}" ;;
+  *)  OUT_DIR="${PWD}/${_dirname}" ;;
+esac
+CHECK_LOG=""   # set after OUT_DIR is created (only with --collect)
+
+# ── Tee helpers ────────────────────────────────────────────────────────────────
+# _println: print a line to stdout; also append to check.log when collecting
+_println() { echo "$@"; [[ -n "${CHECK_LOG}" ]] && echo "$@" >> "${CHECK_LOG}"; }
+
+# ── Helpers ────────────────────────────────────────────────────────────────────
+OVERALL_RC=0
+
+_run_module() {
+  local name="$1"; shift
+  local script="${SCRIPT_DIR}/${name}"
+
+  if [[ ! -x "${script}" ]]; then
+    _println "[cube-check] ERROR: ${script} not found or not executable"
+    OVERALL_RC=1
+    return 1
+  fi
+
+  _println
+  _println "┌──────────────────────────────────────────────────────┐"
+  _println "│  Running: $(printf '%-42s' "${name}") │"
+  _println "└──────────────────────────────────────────────────────┘"
+
+  local rc=0
+  if [[ -n "${CHECK_LOG}" ]]; then
+    # tee sub-script stdout to both terminal and check.log
+    "${script}" "$@" 2>&1 | tee -a "${CHECK_LOG}" || rc=${PIPESTATUS[0]}
+  else
+    "${script}" "$@" || rc=$?
+  fi
+
+  if [[ "${rc}" -eq 0 ]]; then
+    _println "[cube-check] ${name}: PASS"
+  else
+    _println "[cube-check] ${name}: FAIL"
+    OVERALL_RC=1
+  fi
+  return "${rc}"
+}
+
+# ── Main ───────────────────────────────────────────────────────────────────────
+main() {
+  # Create output directory and start check.log only when collecting
+  if [[ "${DO_COLLECT}" -eq 1 ]]; then
+    if [[ -e "${OUT_DIR}" ]]; then
+      echo "[cube-check] ERROR: output directory already exists: ${OUT_DIR}" >&2
+      echo "[cube-check] Use a different name with --dir, or remove the existing directory first." >&2
+      exit 1
+    fi
+    mkdir -p "${OUT_DIR}"
+    CHECK_LOG="${OUT_DIR}/check.log"
+    : > "${CHECK_LOG}"   # truncate / create
+  fi
+
+  _println
+  _println "╔══════════════════════════════════════════════════════╗"
+  _println "║        Cube Sandbox — One-Click Health Check        ║"
+  _println "╚══════════════════════════════════════════════════════╝"
+  _println "  $(date '+%Y-%m-%d %H:%M:%S %Z')"
+  _println "  Host: $(hostname)"
+  _println "  Role: ${ONE_CLICK_DEPLOY_ROLE:-control}"
+  if [[ "${DO_COLLECT}" -eq 1 ]]; then
+    _println "  Output dir: ${OUT_DIR}"
+  fi
+
+  if [[ "${RUN_DEPS}"  -eq 1 ]]; then
+    _run_module "check-deps.sh"  "${SUB_FLAGS[@]+"${SUB_FLAGS[@]}"}"
+  fi
+  if [[ "${RUN_PROCS}" -eq 1 ]]; then
+    _run_module "check-procs.sh" "${SUB_FLAGS[@]+"${SUB_FLAGS[@]}"}"
+  fi
+
+  # Collect logs into the same output directory (only with --collect)
+  if [[ "${DO_COLLECT}" -eq 1 ]]; then
+    _println
+    _println "[cube-check] Collecting logs into ${OUT_DIR} ..."
+    if [[ -n "${CHECK_LOG}" ]]; then
+      "${SCRIPT_DIR}/collect-logs.sh" \
+        --dir "${OUT_DIR}" \
+        --no-tar \
+        --allow-existing \
+        "${COLLECT_FLAGS[@]+"${COLLECT_FLAGS[@]}"}" 2>&1 | tee -a "${CHECK_LOG}"
+    else
+      "${SCRIPT_DIR}/collect-logs.sh" \
+        --dir "${OUT_DIR}" \
+        --no-tar \
+        --allow-existing \
+        "${COLLECT_FLAGS[@]+"${COLLECT_FLAGS[@]}"}"
+    fi
+    _println "[cube-check] collect-logs.sh: done"
+  fi
+
+  # ── Summary ────────────────────────────────────────────────────────────────
+  _println
+  _println "══════════════════════════════════════════════════════"
+  if [[ "${OVERALL_RC}" -eq 0 ]]; then
+    _println "  OVERALL RESULT: PASS ✓"
+  else
+    _println "  OVERALL RESULT: FAIL ✗"
+  fi
+
+  if [[ "${DO_COLLECT}" -eq 1 ]]; then
+    _println
+    _println "  Diagnostic bundle directory:"
+    _println "    ${OUT_DIR}/"
+    _println
+    _println "  To package and share:"
+    _println "    tar czf $(basename "${OUT_DIR}").tar.gz $(basename "${OUT_DIR}")"
+  else
+    _println
+    if [[ "${OVERALL_RC}" -ne 0 ]]; then
+      _println "  To collect diagnostic logs, re-run with --collect:"
+      _println "    $(basename "$0") --collect"
+    else
+      _println "  To collect a diagnostic bundle: $(basename "$0") --collect"
+    fi
+  fi
+
+  _println
+  _println "  Issues: https://github.com/TencentCloud/CubeSandbox/issues"
+  _println "  Discord: https://discord.gg/kkapzDXShb"
+  _println "══════════════════════════════════════════════════════"
+
+  exit "${OVERALL_RC}"
+}
+
+main "$@"


### PR DESCRIPTION
Add a self-contained diagnostic toolkit for Cube Sandbox deployments under deploy/one-click/scripts/cube-diag/:

  cube-check.sh      Top-level entry point; runs check modules in order
                     and optionally collects logs (--collect).
  check-deps.sh      Host environment checker: kernel version, KVM/PVM,
                     cgroup v2, XFS, required commands, SELinux.
  check-procs.sh     Process readiness checker: network-agent, CubeMaster,
                     cube-api, Cubelet (with health-check endpoints).
  collect-logs.sh    Log and diagnostic collector: /data/log/* per component,
                     /var/log/cube-sandbox-one-click/, dmesg, journald,
                     process/env snapshot, redacted config files.

Key design points:
- Fully standalone; no external dependencies or common.sh required.
- --collect writes all output into a single directory (--dir <name>); exits with an error if the target directory already exists.
- --module flag on collect-logs.sh selects individual log sources.
- Tested on cube-test (9.135.78.206, TencentOS, kernel 6.6.69-cube).