### PR TITLE
fix: make network-agent tap fd timeout configurable

### DIFF
--- a/Cubelet/config/config.toml
+++ b/Cubelet/config/config.toml
@@ -81,6 +81,7 @@ dynamic_config_path = "/usr/local/services/cubetoolbox/Cubelet/dynamicconf/conf.
     network_agent_tap_socket = "/tmp/cube/network-agent-tap.sock"
     network_agent_init_timeout = "120s"
     network_agent_retry_interval = "1s"
+    network_agent_tap_fd_timeout = "2s"
 
   [plugins."io.cubelet.internal.v1.storage"]
     #root_path=/data/cubelet/state/io.cubelet.internal.v1.storage

--- a/Cubelet/network/plugin_tap.go
+++ b/Cubelet/network/plugin_tap.go
@@ -275,11 +275,12 @@ type Config struct {
 
 	RootPath string `toml:"root_path"`
 
-	EnableNetworkAgent        bool             `toml:"enable_network_agent"`
-	NetworkAgentEndpoint      string           `toml:"network_agent_endpoint"`
-	NetworkAgentTapSocket     string           `toml:"network_agent_tap_socket"`
-	NetworkAgentInitTimeout   tomlext.Duration `toml:"network_agent_init_timeout"`
-	NetworkAgentRetryInterval tomlext.Duration `toml:"network_agent_retry_interval"`
+	EnableNetworkAgent          bool             `toml:"enable_network_agent"`
+	NetworkAgentEndpoint        string           `toml:"network_agent_endpoint"`
+	NetworkAgentTapSocket       string           `toml:"network_agent_tap_socket"`
+	NetworkAgentInitTimeout     tomlext.Duration `toml:"network_agent_init_timeout"`
+	NetworkAgentRetryInterval   tomlext.Duration `toml:"network_agent_retry_interval"`
+	NetworkAgentTapFDTimeout    tomlext.Duration `toml:"network_agent_tap_fd_timeout"`
 
 	ReconcileInterval tomlext.Duration `toml:"reconcile_interval"`
 }
@@ -327,6 +328,9 @@ func initTapPlugin(ic *plugin.InitContext) (*local, error) {
 	}
 	if config.NetworkAgentRetryInterval == 0 {
 		config.NetworkAgentRetryInterval = tomlext.FromStdTime(time.Second)
+	}
+	if config.NetworkAgentTapFDTimeout == 0 {
+		config.NetworkAgentTapFDTimeout = tomlext.FromStdTime(2 * time.Second)
 	}
 
 	if config.MvmMask == 0 {
@@ -956,7 +960,8 @@ func (l *local) registerNetworkAgentTapForPool(ctx context.Context, sandboxID st
 	if intf.IPAddr == nil {
 		return fmt.Errorf("shim network sandbox ip is empty")
 	}
-	file, err := requestNetworkAgentTapFile(l.Config.NetworkAgentTapSocket, sandboxID, intf.Name)
+	tapFDTimeout := time.Duration(l.Config.NetworkAgentTapFDTimeout)
+	file, err := requestNetworkAgentTapFile(l.Config.NetworkAgentTapSocket, sandboxID, intf.Name, tapFDTimeout)
 	if err != nil {
 		return fmt.Errorf("request original tap fd for %s: %w", intf.Name, err)
 	}
@@ -1014,7 +1019,7 @@ type networkAgentTapFDResponse struct {
 	ErrMsg  string `json:"errMsg"`
 }
 
-func requestNetworkAgentTapFile(socketPath, sandboxID, tapName string) (*os.File, error) {
+func requestNetworkAgentTapFile(socketPath, sandboxID, tapName string, timeout time.Duration) (*os.File, error) {
 	if socketPath == "" {
 		return nil, fmt.Errorf("network-agent tap socket is empty")
 	}
@@ -1024,7 +1029,7 @@ func requestNetworkAgentTapFile(socketPath, sandboxID, tapName string) (*os.File
 		return nil, err
 	}
 	defer conn.Close()
-	if err := conn.SetDeadline(time.Now().Add(2 * time.Second)); err != nil {
+	if err := conn.SetDeadline(time.Now().Add(timeout)); err != nil {
 		return nil, err
 	}
 	reqBody, err := json.Marshal(&networkAgentTapFDRequest{


### PR DESCRIPTION
## Problem

Cubelet hardcoded a 2s deadline when requesting tap fd from network-agent.
Under high concurrency (>40 sandboxes/node), requests queue behind the global
mutex (`s.mu`) in network-agent. Each lock hold takes ~50ms (dominated by
uncached `loadPinnedMap` bpffs I/O), causing requests to exceed the 2s deadline
with `i/o timeout` errors.

## Solution

Add `NetworkAgentTapFDTimeout` config field (`network_agent_tap_fd_timeout` in
TOML), defaulting to `2s` to preserve existing behavior. Operators can raise it
(e.g. `10s`) for high-concurrency deployments without recompiling.