### PR TITLE
docs(blog): add v0.2.2 release post (en/zh)

### DIFF
--- a/docs/blog/posts/2026-05-15-welcome.md
+++ b/docs/blog/posts/2026-05-15-welcome.md
@@ -4,7 +4,7 @@ date: 2026-05-15
 author: Cube Sandbox Team
 description: We are launching a blog to share release notes, technical deep-dives, and community stories around Cube Sandbox.
 featured: true
-weight: 1
+weight: 2
 ---
 
 # Welcome to the Cube Sandbox Blog

--- a/docs/blog/posts/2026-05-19-cubesandbox-v0.2.2-release.md
+++ b/docs/blog/posts/2026-05-19-cubesandbox-v0.2.2-release.md
@@ -1,0 +1,61 @@
+---
+title: "Cube Sandbox v0.2.2: One Step Closer to Drop-in E2B Compatibility, with a Stability Sweep"
+date: 2026-05-19
+author: Cube Sandbox Team
+description: Following v0.2.0, Cube Sandbox shipped v0.2.2 on May 18. This release extends E2B compatibility from the SDK layer down to the wire-protocol layer, fixes seven recurring stability issues from the v0.1.x era, and lands the first round of CVE remediations for the 0.2 series.
+featured: true
+weight: 1
+---
+
+# Cube Sandbox v0.2.2: One Step Closer to Drop-in E2B Compatibility, with a Stability Sweep
+
+Following v0.2.0, Cube Sandbox shipped v0.2.2 on the evening of May 18.
+
+Compared with v0.2.0, this release focuses on three things: extending E2B compatibility from the SDK layer down to the wire-protocol layer; closing out a handful of recurring stability issues reported since v0.1.x; and shipping the first round of CVE remediations for the 0.2 series.
+
+## 1. Compatibility down to the protocol layer — one step closer to drop-in E2B migration
+
+In v0.2.0, our E2B compatibility only covered the SDK layer — you could swap the client from E2B to Cube without touching a line of code, but reverse proxies, firewall rules, and any client that hard-coded ports still needed adjusting.
+
+v0.2.2 changes the sandbox's default exposed port from `8080/32000` to `49983`, aligning it with the E2B sandbox protocol. That means you no longer need to touch your config files when migrating to Cube.
+
+We also unified the source of truth for the "default port" into CubeMaster. Previously, Cubelet and network-agent each hard-coded their own default, which occasionally caused the two sides to drift. After this refactor, neither component holds a default any more — behavior is governed by CubeMaster.
+
+## 2. Stability: seven recurring user-reported issues, all fixed in one go
+
+A handful of issues that the community kept hitting between v0.1.x and v0.2.0 have been swept up in this release:
+
+1. **`cubecli exec` nil-deref panic on stdin EOF** ([#188](https://github.com/TencentCloud/CubeSandbox/pull/188)): the `exec` command panicked the moment stdin closed; the process was killed but no error showed up in logs, leading users to misdiagnose it as a network or permission issue. The fix uses `errors.Is(err, io.EOF)` to handle wrapped errors, and the shim now reliably emits paired exec-request / exit-code log entries.
+
+2. **Duplicate template-image jobs in CubeMaster** ([#227](https://github.com/TencentCloud/CubeSandbox/pull/227)): concurrent or retried API calls could enqueue the same build twice. We added a `request_id` column and a `(request_id, operation)` unique index on the `template_image` table to enforce idempotency at the data layer. Legacy rows missing the new ID are handled by a migration script — no manual intervention is required when upgrading.
+
+3. **Runtime-file materialization for PVM template ext4 artifacts** ([#282](https://github.com/TencentCloud/CubeSandbox/pull/282)): `RefreshArtifactRuntimeFiles`, `validateArtifactRuntimeFilesPresent`, and `ensureArtifactRuntimeFiles` used to live on three separate code paths whose state could drift. They have been consolidated into a single path that only handles kernel files, with the unit tests rewritten to match. PVM deployments now have a much more predictable template lifecycle.
+
+4. **Configurable command timeout for the storage plugin** ([#236](https://github.com/TencentCloud/CubeSandbox/pull/236)): the 3-second timeout on ext4 operations was hard-coded, which could falsely kill the slow path of large-file `live-create` under concurrency. The plugin's TOML config now accepts a `cmd_timeout` field, so operators can tune it without rebuilding. When the field is absent, behavior is unchanged.
+
+5. **Better diagnostics on storage failures** ([#237](https://github.com/TencentCloud/CubeSandbox/pull/237)): error logs from `newExt4RawByReflinkCopy` are now structured rather than a single-line message, with new unit tests for `describeStorageFailure`, `describeFile`, and `describeFreeBytes`.
+
+6. **Deploy scripts now honor `.env` port placeholders** ([#210](https://github.com/TencentCloud/CubeSandbox/pull/210)): the MySQL/Redis ports in `cubemaster.yaml` are now `__CUBE_SANDBOX_MYSQL_PORT__` and `__CUBE_SANDBOX_REDIS_PORT__` placeholders that `install.sh` substitutes from `.env`. Non-default port deployments no longer require hand-editing the YAML.
+
+7. **Smaller, faster template images**: the quick-start image dropped from ~4 GB to ~100 MB. Download failures and first-launch wait times went down noticeably. Combined with the overseas image registry that came online two weeks ago, the pull experience for users outside mainland China has also improved.
+
+## 3. Security: first batch of CVE fixes for the 0.2 series
+
+- **`vmm-sys-util` 0.11.x → 0.12.1**: closes CVE-2023-50711. The previous version's `FamStructWrapper::deserialize` did not check that the header length matched the flexible-array length, which could lead to out-of-bounds memory access from safe Rust.
+- **`bytes` and `env_logger` upgraded** in the same PR ([#267](https://github.com/TencentCloud/CubeSandbox/pull/267)).
+- **`time` crate upgrade deferred (CVE-2026-25727)**: the upgrade requires an MSRV bump. After review, we confirmed Cube only uses `time::format_description::well_known::Rfc3339` for outbound timestamp formatting and never calls `Rfc2822` parsing on untrusted input — the affected attack vector is unreachable. We will land the upgrade once the MSRV is ready.
+
+## 4. Phase-1 community contribution program now live
+
+Alongside v0.2.2, we have launched the first phase of the Cube Sandbox community contribution program. The repo now has three new doc tracks aimed at community contributors:
+
+- **Troubleshooting**: postmortems and tips on deployment, configuration, and error scenarios.
+- **Use Cases**: end-to-end stories of real-world problems solved with Cube.
+- **Integrations**: hands-on integration playbooks for combinations like Cube × LangChain / Dify / Claude Code / OpenHands.
+
+Each track ships with a template and an index page; contribution instructions live in `CONTRIBUTING.md` at the repo root.
+
+We would love your contributions. Once your PR is merged, you become eligible for: an official Cube Sandbox contributor certificate, a permanent name on the website's wall of contributors, early access to upcoming releases, and a piece of limited-edition open-source swag.
+
+- Task board: <https://github.com/TencentCloud/CubeSandbox/contribute>
+- Full release notes: <https://github.com/TencentCloud/CubeSandbox/releases/tag/v0.2.2>

--- a/docs/zh/blog/posts/2026-05-15-welcome.md
+++ b/docs/zh/blog/posts/2026-05-15-welcome.md
@@ -4,7 +4,7 @@ date: 2026-05-15
 author: Cube Sandbox 团队
 description: 我们开通博客栏目，用来发布版本说明、技术解读以及围绕 Cube Sandbox 的社区故事。
 featured: true
-weight: 1
+weight: 2
 ---
 
 # 欢迎来到 Cube Sandbox 博客

--- a/docs/zh/blog/posts/2026-05-19-cubesandbox-v0.2.2-release.md
+++ b/docs/zh/blog/posts/2026-05-19-cubesandbox-v0.2.2-release.md
@@ -1,0 +1,61 @@
+---
+title: "Cube Sandbox v0.2.2：E2B 兼容更进一步，高频踩坑集中收敛"
+date: 2026-05-19
+author: Cube Sandbox 团队
+description: 继 v0.2.0 之后，Cube Sandbox 在 5 月 18 日发布了 v0.2.2。本次更新把 E2B 兼容性从 SDK 层延伸到端口协议层，集中修复了 v0.1.x 以来用户反馈的 7 个高频稳定性问题，并完成了 0.2 系列首批 CVE 处置。
+featured: true
+weight: 1
+---
+
+# Cube Sandbox v0.2.2：E2B 兼容更进一步，高频踩坑集中收敛
+
+继 v0.2.0 之后，Cube Sandbox 在 5 月 18 日晚间发布了 v0.2.2。
+
+相比 v0.2.0，这一版核心做了几方面更新：把 E2B 兼容性从 SDK 层延伸到了端口协议层；闭合了 v0.1.x 以来用户反复反馈的几个高频稳定性问题；处理了 0.2 系列首批 CVE。下面分别展开。
+
+## 一、兼容性做到协议层，离 E2B "零改造迁移" 又近一步
+
+v0.2.0 时，Cube 的 E2B 兼容只覆盖到 SDK 层——你可以一行代码不改，把客户端从 E2B 切到 Cube，但反向代理、防火墙规则、客户端中写死的端口仍要跟着调整。
+
+v0.2.2 把 sandbox 默认暴露端口从 `8080/32000` 改为 `49983`，与 E2B sandbox 协议对齐。意味着切到 Cube 时，配置文件也不用动了。
+
+这一版还把"默认端口"的来源统一到了 CubeMaster——在此之前，Cubelet 和 network-agent 各自硬编码了一份默认值，运行时容易出现两边不一致。重构后，Cubelet 与 network-agent 不再持有默认值，行为以 CubeMaster 为准。
+
+## 二、稳定性：集中修复用户高频踩到的 7 个坑
+
+v0.1.x 到 v0.2.0 期间，社区反馈的几个反复踩到的问题，这一版我们做了集中处理：
+
+1. **`cubecli exec` 在 stdin EOF 时的 nil-deref panic**（[#188](https://github.com/TencentCloud/CubeSandbox/pull/188)）：exec 命令在 stdin 关闭瞬间触发空指针，进程被中止但日志不报错，导致用户误以为是网络或权限问题。修复后改用 `errors.Is(err, io.EOF)` 兼容 error wrapping，shim 日志能正常输出成对的 exec req / exit code 条目。
+
+2. **CubeMaster 模板镜像任务重复创建**（[#227](https://github.com/TencentCloud/CubeSandbox/pull/227)）：并发或重试 API 调用会让同一个构建任务被入队两次。这一版给 `template_image` 表加了 `request_id` 列和 `(request_id, operation)` 唯一索引，从数据层做幂等。已有遗留 ID 的旧记录由迁移脚本处理，老用户升级后无需手工干预。
+
+3. **PVM 模板的 ext4 artifact 运行时文件物化**（[#282](https://github.com/TencentCloud/CubeSandbox/pull/282)）：原先 `RefreshArtifactRuntimeFiles`、`validateArtifactRuntimeFilesPresent`、`ensureArtifactRuntimeFiles` 三处逻辑独立、状态不一致。这一版收敛为只处理 kernel 文件，配套单测同步重写。对 PVM 部署用户而言，模板生命周期更可预测。
+
+4. **存储插件命令超时可配置**（[#236](https://github.com/TencentCloud/CubeSandbox/pull/236)）：原本 ext4 操作的 3 秒超时硬编码在代码里，并发场景下大文件 live-create 慢路径会被误杀。新增 `cmd_timeout` 字段写入存储插件的 TOML 配置，运维不需要重新编译就能调整。字段不存在时行为不变。
+
+5. **存储失败的诊断信息**（[#237](https://github.com/TencentCloud/CubeSandbox/pull/237)）：`newExt4RawByReflinkCopy` 失败时的错误日志，从单行 message 改为结构化输出。配套新增 `describeStorageFailure`、`describeFile`、`describeFreeBytes` 单测。
+
+6. **部署脚本支持 `.env` 端口占位符**（[#210](https://github.com/TencentCloud/CubeSandbox/pull/210)）：`cubemaster.yaml` 里的 MySQL/Redis 端口改为 `__CUBE_SANDBOX_MYSQL_PORT__` 和 `__CUBE_SANDBOX_REDIS_PORT__` 占位符，由 `install.sh` 从 `.env` 读取替换。非默认端口部署不再需要手工改 YAML。
+
+7. **模板镜像下载体验优化**：快速体验镜像从 4G 瘦身到 100M 左右，下载失败率和首次启动等待时间都明显下降。配合两周前上线的海外镜像仓库地址，海外用户拉镜像的卡顿问题也一并改善。
+
+## 三、安全：v0.2 系列首批 CVE 处置
+
+- **`vmm-sys-util` 0.11.x → 0.12.1**：闭合 CVE-2023-50711。原版本 `FamStructWrapper::deserialize` 不校验 header 长度与 flexible-array 长度匹配，安全 Rust 代码可能产生越界内存访问。
+- **`bytes`、`env_logger` 同步升级**：同一轮 PR（[#267](https://github.com/TencentCloud/CubeSandbox/pull/267)）刷新依赖。
+- **`time` crate 升级回滚（CVE-2026-25727）**：升级需要 MSRV bump，团队评估后确认 Cube 仅使用 `time::format_description::well_known::Rfc3339` 做出站时间戳格式化，从不对不可信输入调用 `Rfc2822` 解析，受影响攻击向量不可达。等 MSRV 准备好再单独推。
+
+## 四、第一期共建计划同步上线
+
+v0.2.2 同时上线了 Cube Sandbox 第一期共建计划，仓库新增了三个面向社区贡献的文档专区：
+
+- **Troubleshooting**：避坑指南，用户分享部署、配置、报错的踩坑记录；
+- **Use Cases**：应用案例，用户分享真实业务场景下用 Cube 解决的具体问题；
+- **Integrations**：生态集成，用户分享 Cube × LangChain / Dify / Claude Code / OpenHands 等组合的接入实践。
+
+每个专区都有模板和 index 页，提交方式参考仓库根目录 `CONTRIBUTING_zh.md`。
+
+欢迎大家前来贡献，你的 PR 合入后即有机会获得：Cube Sandbox 官方贡献者证书 + 官网荣誉墙永久署名 + 新版本优先体验 + 限量开源周边。
+
+- 任务大厅：<https://github.com/TencentCloud/CubeSandbox/contribute>
+- 完整 Release Note：<https://github.com/TencentCloud/CubeSandbox/releases/tag/v0.2.2>


### PR DESCRIPTION
## What

Add a new blog post announcing **Cube Sandbox v0.2.2** in both English
and Simplified Chinese, plus a small weight tweak to the existing
welcome post so the release post can take the top featured slot.

Files touched:

- `docs/blog/posts/2026-05-19-cubesandbox-v0.2.2-release.md` (new, EN)
- `docs/zh/blog/posts/2026-05-19-cubesandbox-v0.2.2-release.md` (new, ZH)
- `docs/blog/posts/2026-05-15-welcome.md` (`weight: 1` → `weight: 2`)
- `docs/zh/blog/posts/2026-05-15-welcome.md` (`weight: 1` → `weight: 2`)

## Why

v0.2.2 was released on 2026-05-18 with several user-visible improvements:

- **Protocol-level E2B compatibility**: default sandbox port aligned to
  `49983` so reverse proxies / firewall rules / hard-coded clients can
  migrate from E2B without config changes; default-port source unified
  in CubeMaster.
- **Seven recurring stability fixes** from the v0.1.x era — `cubecli
  exec` nil-deref panic on stdin EOF (#188), `.env` port placeholders
  in deploy scripts (#210), idempotent template-image jobs (#227),
  configurable storage `cmd_timeout` (#236), structured storage failure
  diagnostics (#237), PVM ext4 artifact runtime-file consolidation
  (#282), and a smaller (≈4G → ≈100M) quick-start template image.
- **First batch of CVE remediations** for the 0.2 series (#267):
  `vmm-sys-util` 0.11.x → 0.12.1 closing CVE-2023-50711, plus `bytes`
  and `env_logger` upgrades; `time` crate upgrade deliberately deferred
  (CVE-2026-25727 vector unreachable in Cube).
- **Phase-1 community contribution program** now live.

A blog post helps existing users understand what changed and helps
landing visitors discover the protocol-level E2B compatibility story.

## How

- File names follow the `YYYY-MM-DD-slug.md` convention required by
  `docs/zh/guide/maintainer/blog.md`.
- Cross-language files share the same slug.
- Frontmatter uses only the documented fields (`title`, `date`,
  `author`, `description`, `featured`, `weight`).
- All referenced PR / issue numbers verified to be merged on master:
  #188 #210 #227 #236 #237 #267 #282.
- All commits are DCO-signed.

## Notes for reviewers

- The welcome post stays `featured: true` — only its `weight` changes,
  so it still renders in the featured area, just below the release news.
- The post intentionally links every fix to its merged PR for
  traceability; no internal-only links.
- No images/assets added (the source doc's screenshot is decorative
  and lives on the release page itself).
