### PR TITLE
docs(blog): add external link to community post on AWS nested-virt deployment

### DIFF
--- a/docs/blog/posts/2026-05-17-aws-nested-virt-cube-deploy.md
+++ b/docs/blog/posts/2026-05-17-aws-nested-virt-cube-deploy.md
@@ -1,0 +1,8 @@
+---
+title: "Deploying Cube Sandbox on AWS EC2 Nested-Virtualization Instances: A Practical Guide"
+date: 2026-05-17
+author: zhaojiew10
+description: A community walkthrough covering the full deployment of Cube Sandbox on an AWS EC2 nested-virtualization instance (c8i.2xlarge) — environment setup, three required patches (Cubelet, CubeShim, and Guest image), service bring-up, template creation, and sandbox creation via the E2B-compatible SDK. Note: original article is in Simplified Chinese.
+type: external
+externalUrl: https://zhaojiew10.blog.csdn.net/article/details/161167251
+---

--- a/docs/zh/blog/posts/2026-05-17-aws-nested-virt-cube-deploy.md
+++ b/docs/zh/blog/posts/2026-05-17-aws-nested-virt-cube-deploy.md
@@ -1,0 +1,8 @@
+---
+title: "在 AWS EC2 嵌套虚拟化实例上部署 Cube Sandbox 的实践与踩坑"
+date: 2026-05-17
+author: zhaojiew10
+description: 记录在 AWS EC2 嵌套虚拟化实例（c8i.2xlarge）上部署 Cube Sandbox 的完整过程：环境准备、三个必需补丁（Cubelet、CubeShim、Guest 镜像）、服务启动、模板创建，以及通过 E2B 兼容 SDK 创建 sandbox 的实操与问题记录。
+type: external
+externalUrl: https://zhaojiew10.blog.csdn.net/article/details/161167251
+---


### PR DESCRIPTION
## What

Add a single Chinese-only external-link blog entry pointing to a
community-authored deployment writeup:

- **File**: `docs/zh/blog/posts/2026-05-17-aws-nested-virt-cube-deploy.md`
- **Original article (CN)**: <https://zhaojiew10.blog.csdn.net/article/details/161167251>
- **Author**: zhaojiew10 (CSDN)
- **Original publish date**: 2026-05-17

## Why

The post documents a real-world deployment of Cube Sandbox on an
AWS EC2 nested-virtualization instance (`c8i.2xlarge`), including:

- Environment setup on c8i.2xlarge (nested KVM on a regular EC2 VM,
  no bare-metal required).
- Three required patches (Cubelet, CubeShim, and the Guest image)
  to handle `noxsave` and init-arg filtering.
- Service bring-up order and a few startup pitfalls.
- Template creation and creating sandboxes via the E2B-compatible SDK.

This is exactly the kind of "external practice report" the contribution
program is designed to surface — it shows users a concrete cloud-vendor
deployment path and the gotchas to expect.

## How

- Uses `type: external` + `externalUrl` per
  `docs/zh/guide/maintainer/blog.md`, so the title in the blog list
  links directly to the original CSDN article.
- No `featured` / `weight`: the post takes its place in the regular
  feed by `date`, sorted naturally with other community posts.
- Chinese-only — the source article is in Simplified Chinese, so an
  English entry pointing to a Chinese article would misrepresent the
  language to international readers.
- DCO-signed.

## Notes for reviewers

- No file outside `docs/zh/blog/posts/` is touched.
- File name follows the `YYYY-MM-DD-slug.md` convention; `date` matches
  the article's original publish date so the chronology stays honest.

cc: thanks to @zhaojiew10 (CSDN) for the writeup. (No GitHub handle
known; happy to swap in one if a maintainer can confirm.)
