### PR TITLE
fix(network): resolve network resource leak on sandbox creation failure

### DIFF
--- a/Cubelet/network/plugin_tap.go
+++ b/Cubelet/network/plugin_tap.go
@@ -463,6 +463,26 @@ func (l *local) Create(ctx context.Context, opts *workflow.CreateContext) (err e
 		l.recordNetworkAgentFailure(naErr)
 		return ret.Errorf(errorcode.ErrorCode_CreateNetworkFailed, "network-agent EnsureNetwork failed: %s", classifyNetworkAgentError(naErr))
 	}
+
+	defer func() {
+		if err == nil {
+			return
+		}
+		// Use a detached context with a 15-second timeout to ensure rollback succeeds even if the parent context is cancelled, without hanging indefinitely.
+		rollbackCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 15*time.Second)
+		defer cancel()
+		releaseReq := &networkagentclient.ReleaseNetworkRequest{
+			SandboxID:       opts.SandboxID,
+			NetworkHandle:   ensureResp.NetworkHandle,
+			IdempotencyKey:  ensureReq.IdempotencyKey,
+			PersistMetadata: ensureResp.PersistMetadata,
+		}
+		if rErr := l.networkAgentClient.ReleaseNetwork(rollbackCtx, releaseReq); rErr != nil {
+			log.G(rollbackCtx).Warnf("failed to release network during rollback for sandbox %s: %v", opts.SandboxID, rErr)
+		}
+		l.unregisterNetworkAgentTapForPool(rollbackCtx, opts.SandboxID)
+	}()
+
 	log.G(ctx).Infof("tap create ensure response: sandbox_id=%s network_handle=%s interfaces=%d routes=%d arps=%d port_mappings=%d persist_metadata=%s",
 		ensureResp.SandboxID, ensureResp.NetworkHandle, len(ensureResp.Interfaces), len(ensureResp.Routes),
 		len(ensureResp.ARPNeighbors), len(ensureResp.PortMappings), utils.InterfaceToString(ensureResp.PersistMetadata))

--- a/Cubelet/network/plugin_tap_create_test.go
+++ b/Cubelet/network/plugin_tap_create_test.go
@@ -19,10 +19,12 @@ import (
 )
 
 type fakeNetworkAgentClient struct {
-	ensureCalled      bool
-	lastEnsureRequest *networkagentclient.EnsureNetworkRequest
-	healthErrs        []error
-	healthCalls       int
+	ensureCalled       bool
+	lastEnsureRequest  *networkagentclient.EnsureNetworkRequest
+	releaseCalled      bool
+	lastReleaseRequest *networkagentclient.ReleaseNetworkRequest
+	healthErrs         []error
+	healthCalls        int
 }
 
 func (c *fakeNetworkAgentClient) EnsureNetwork(_ context.Context, req *networkagentclient.EnsureNetworkRequest) (*networkagentclient.EnsureNetworkResponse, error) {
@@ -61,7 +63,9 @@ func (c *fakeNetworkAgentClient) EnsureNetwork(_ context.Context, req *networkag
 	}, nil
 }
 
-func (c *fakeNetworkAgentClient) ReleaseNetwork(context.Context, *networkagentclient.ReleaseNetworkRequest) error {
+func (c *fakeNetworkAgentClient) ReleaseNetwork(_ context.Context, req *networkagentclient.ReleaseNetworkRequest) error {
+	c.releaseCalled = true
+	c.lastReleaseRequest = req
 	return nil
 }
 
@@ -123,6 +127,15 @@ func TestTapCreateInNetworkAgentModeCallsEnsureNetwork(t *testing.T) {
 	}
 	if !fakeClient.ensureCalled {
 		t.Fatal("network-agent EnsureNetwork was not called")
+	}
+	if !fakeClient.releaseCalled {
+		t.Fatal("network-agent ReleaseNetwork was not called after downstream register failure")
+	}
+	if fakeClient.lastReleaseRequest == nil || fakeClient.lastReleaseRequest.NetworkHandle != "sandbox-1" {
+		t.Fatalf("ReleaseNetwork request invalid: %+v", fakeClient.lastReleaseRequest)
+	}
+	if fakeClient.lastReleaseRequest.IdempotencyKey != "req-1" {
+		t.Fatalf("ReleaseNetwork idempotency key=%q, want req-1", fakeClient.lastReleaseRequest.IdempotencyKey)
 	}
 }
 


### PR DESCRIPTION
If sandbox creation fails after `EnsureNetwork` succeeds but before the allocation is persisted in allocationStore, subsequent cleanup workflows cannot detect the network allocation, leading to leaked TAP, IP, and port mappings on the `network-agent`.

This PR introduces a deferred rollback mechanism in tapPlugin.Create to automatically invoke ReleaseNetwork and unregister any partially set up TAP device if the creation returns an error.