### PR TITLE
cubeapi: forward X-Request-Method to auth callback

### DIFF
--- a/CubeAPI/src/config/mod.rs
+++ b/CubeAPI/src/config/mod.rs
@@ -48,9 +48,16 @@ pub struct ServerConfig {
     ///   - `Authorization: Bearer <token>`, or
     ///   - `X-API-Key: <key>`
     ///
-    /// The middleware will POST to this URL with the credential headers plus
-    /// `X-Request-Path: <original request path>`. An HTTP 200 response grants
-    /// access; any other status code returns 401 to the client.
+    /// The middleware will POST to this URL with the credential headers plus:
+    ///   - `X-Request-Path: <original request path>`
+    ///   - `X-Request-Method: <HTTP method>` (e.g. GET, POST, DELETE, PATCH)
+    ///
+    /// An HTTP 200 response grants access; any other status code returns 401 to the client.
+    ///
+    /// **Security note**: Multiple HTTP methods (e.g. GET/POST/DELETE/PATCH) are mounted
+    /// on the same path (e.g. `/templates/:id`). Callbacks that only whitelist by path
+    /// cannot distinguish read from write/delete operations. Always validate both
+    /// `X-Request-Path` **and** `X-Request-Method` in your callback implementation.
     ///
     /// When unset (default), all requests are allowed through without authentication.
     ///

--- a/CubeAPI/src/middleware/auth.rs
+++ b/CubeAPI/src/middleware/auth.rs
@@ -9,7 +9,7 @@ use axum::{
     response::Response,
 };
 
-/// 鉴权凭证，从请求 header 中提取。
+/// Auth credential extracted from the request headers.
 #[derive(Debug)]
 enum AuthCredential {
     /// `Authorization: Bearer <token>`
@@ -18,11 +18,11 @@ enum AuthCredential {
     ApiKey(String),
 }
 
-/// 从请求 headers 中提取鉴权凭证（优先 Bearer，次选 X-API-Key）。
+/// Extract the auth credential from request headers (Bearer takes priority over X-API-Key).
 fn extract_credential(request: &Request) -> Option<AuthCredential> {
     let headers = request.headers();
 
-    // 优先检查 Authorization: Bearer
+    // Prefer Authorization: Bearer
     if let Some(auth_val) = headers.get("Authorization") {
         if let Ok(auth_str) = auth_val.to_str() {
             if let Some(token) = auth_str.strip_prefix("Bearer ") {
@@ -34,7 +34,7 @@ fn extract_credential(request: &Request) -> Option<AuthCredential> {
         }
     }
 
-    // 次选 X-API-Key
+    // Fall back to X-API-Key
     if let Some(key_val) = headers.get("X-API-Key") {
         if let Ok(key_str) = key_val.to_str() {
             let key = key_str.trim().to_string();
@@ -47,35 +47,44 @@ fn extract_credential(request: &Request) -> Option<AuthCredential> {
     None
 }
 
-/// 统一鉴权中间件。
+/// Unified auth middleware.
 ///
-/// 行为：
-/// - 如果 `config.auth_callback_url` 未配置（`None`），直接放行。
-/// - 如果已配置：
-///   1. 从请求 header 中提取 Bearer token 或 X-API-Key（优先 Bearer）。
-///   2. 向回调 URL 发送 HTTP POST，附带：
-///      - `Authorization: Bearer <token>`  （Bearer 模式时透传）
-///      - `X-API-Key: <key>`              （API Key 模式时透传）
-///      - `X-Request-Path: <原始请求路径>` （客户端访问的路径）
-///   3. 回调返回 HTTP 200 → 放行；其他状态码 → 401 Unauthorized。
+/// Behavior:
+/// - If `config.auth_callback_url` is not set (`None`), all requests are allowed through.
+/// - If set:
+///   1. Extract a Bearer token or X-API-Key from the request headers (Bearer takes priority).
+///   2. Forward a POST to the callback URL with:
+///      - `Authorization: Bearer <token>`  (when the client used Bearer auth)
+///      - `X-API-Key: <key>`              (when the client used API Key auth)
+///      - `X-Request-Path: <original path>` (the path the client requested)
+///      - `X-Request-Method: <HTTP method>` (the HTTP method the client used, e.g. GET/DELETE)
+///   3. HTTP 200 from callback → allow; any other status → 401 Unauthorized.
 ///
-/// 回调方无需额外的类型标识：`Authorization` header 存在即为 Bearer，
-/// `X-API-Key` header 存在即为 API Key，两者互斥。
+/// The two credential headers are mutually exclusive; the callback receives whichever
+/// one the client sent. No extra type discriminator is needed.
+///
+/// # Security note
+///
+/// Multiple HTTP methods (e.g. GET/POST/DELETE/PATCH) are mounted on the same path
+/// (e.g. `/templates/:id`). A callback that only whitelists by path cannot distinguish
+/// a read from a write or delete operation. Forwarding `X-Request-Method` allows the
+/// callback to enforce fine-grained (path + method) authorization.
 pub async fn unified_auth(
     State(state): State<AppState>,
     request: Request,
     next: Next,
 ) -> Result<Response, AppError> {
-    // 未配置回调地址，直接放行
+    // No callback configured — pass through immediately.
     let callback_url = match state.config.auth_callback_url.as_deref() {
         Some(url) if !url.is_empty() => url.to_string(),
         _ => return Ok(next.run(request).await),
     };
 
-    // 提取请求路径，透传给回调
+    // Capture the request path and HTTP method to forward to the callback.
     let request_path = request.uri().path().to_string();
+    let request_method = request.method().to_string();
 
-    // 提取鉴权凭证
+    // Require a credential when a callback is configured.
     let credential = extract_credential(&request).ok_or_else(|| {
         AppError::Unauthorized(
             "Missing authentication: provide 'Authorization: Bearer <token>' or 'X-API-Key: <key>'"
@@ -83,11 +92,14 @@ pub async fn unified_auth(
         )
     })?;
 
-    // 构造回调 POST 请求（仅透传标准凭证 header + 请求路径，不加自定义类型标识）
+    // Build the callback POST, forwarding the credential headers, request path, and HTTP method.
+    // X-Request-Method is required for correct authz: the same path (e.g. /templates/:id)
+    // serves GET/POST/DELETE/PATCH, so path alone is insufficient to distinguish read vs write.
     let req_builder = state
         .http_client
         .post(&callback_url)
-        .header("X-Request-Path", &request_path);
+        .header("X-Request-Path", &request_path)
+        .header("X-Request-Method", &request_method);
 
     let req_builder = match &credential {
         AuthCredential::Bearer(token) => {
@@ -109,6 +121,7 @@ pub async fn unified_auth(
     if callback_resp.status().as_u16() == 200 {
         tracing::debug!(
             path = %request_path,
+            method = %request_method,
             auth_type = auth_type,
             "auth callback approved"
         );
@@ -117,11 +130,219 @@ pub async fn unified_auth(
         tracing::warn!(
             status = %callback_resp.status(),
             path = %request_path,
+            method = %request_method,
             auth_type = auth_type,
             "auth callback rejected request"
         );
         Err(AppError::Unauthorized(
             "Authentication rejected by callback".to_string(),
         ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        config::ServerConfig,
+        logging::{arc, noop::NoopLogger},
+        state::AppState,
+    };
+    use axum::{
+        body::Body,
+        http::{Method, StatusCode},
+        routing::any,
+        Router,
+    };
+    use axum_test::TestServer;
+    use std::sync::Arc;
+    use tokio::net::TcpListener;
+
+    /// Spawn a callback server that responds with `respond_status` and records
+    /// all received request headers into `captured_headers`.
+    async fn spawn_callback_server(
+        respond_status: StatusCode,
+        captured_headers: Arc<tokio::sync::Mutex<Vec<(String, String)>>>,
+    ) -> String {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        let app = Router::new().route(
+            "/auth",
+            any(move |req: axum::http::Request<Body>| {
+                let headers = captured_headers.clone();
+                async move {
+                    let mut guard = headers.lock().await;
+                    for (k, v) in req.headers() {
+                        guard.push((k.to_string(), v.to_str().unwrap_or("").to_string()));
+                    }
+                    axum::http::Response::builder()
+                        .status(respond_status)
+                        .body(Body::empty())
+                        .unwrap()
+                }
+            }),
+        );
+
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+
+        format!("http://{}/auth", addr)
+    }
+
+    fn build_test_server_with_callback(callback_url: &str) -> TestServer {
+        let mut config = ServerConfig::default();
+        config.auth_callback_url = Some(callback_url.to_string());
+        let state = AppState::new(config, arc(NoopLogger));
+        let router = Router::new()
+            .route("/templates/:id", any(|| async { "ok" }))
+            .route("/sandboxes/:id", any(|| async { "ok" }))
+            .layer(axum::middleware::from_fn_with_state(
+                state.clone(),
+                unified_auth,
+            ))
+            .with_state(state);
+        TestServer::new(router).unwrap()
+    }
+
+    /// Core regression: GET and DELETE on the same path must produce distinct
+    /// X-Request-Method values at the callback, preventing read-to-delete escalation.
+    #[tokio::test]
+    async fn callback_receives_distinct_method_for_same_path() {
+        let captured = Arc::new(tokio::sync::Mutex::new(Vec::new()));
+        let callback_url = spawn_callback_server(StatusCode::OK, captured.clone()).await;
+        let server = build_test_server_with_callback(&callback_url);
+
+        server
+            .method(Method::GET, "/templates/demo")
+            .add_header(
+                axum::http::header::HeaderName::from_static("x-api-key"),
+                axum::http::HeaderValue::from_static("test-key"),
+            )
+            .await
+            .assert_status_ok();
+
+        server
+            .method(Method::DELETE, "/templates/demo")
+            .add_header(
+                axum::http::header::HeaderName::from_static("x-api-key"),
+                axum::http::HeaderValue::from_static("test-key"),
+            )
+            .await
+            .assert_status_ok();
+
+        let guard = captured.lock().await;
+        let methods: Vec<&str> = guard
+            .iter()
+            .filter(|(k, _)| k == "x-request-method")
+            .map(|(_, v)| v.as_str())
+            .collect();
+
+        assert_eq!(
+            methods,
+            ["GET", "DELETE"],
+            "callback must receive distinct X-Request-Method for GET vs DELETE on the same path"
+        );
+    }
+
+    /// The callback must receive X-Request-Path.
+    #[tokio::test]
+    async fn callback_receives_request_path() {
+        let captured = Arc::new(tokio::sync::Mutex::new(Vec::new()));
+        let callback_url = spawn_callback_server(StatusCode::OK, captured.clone()).await;
+        let server = build_test_server_with_callback(&callback_url);
+
+        server
+            .get("/templates/abc-123")
+            .add_header(
+                axum::http::header::HeaderName::from_static("x-api-key"),
+                axum::http::HeaderValue::from_static("key"),
+            )
+            .await
+            .assert_status_ok();
+
+        let guard = captured.lock().await;
+        let paths: Vec<&str> = guard
+            .iter()
+            .filter(|(k, _)| k == "x-request-path")
+            .map(|(_, v)| v.as_str())
+            .collect();
+        assert!(paths.contains(&"/templates/abc-123"));
+    }
+
+    /// A non-200 callback response must produce 401 Unauthorized.
+    #[tokio::test]
+    async fn callback_rejection_returns_401() {
+        let captured = Arc::new(tokio::sync::Mutex::new(Vec::new()));
+        let callback_url = spawn_callback_server(StatusCode::FORBIDDEN, captured.clone()).await;
+        let server = build_test_server_with_callback(&callback_url);
+
+        server
+            .delete("/templates/secret")
+            .add_header(
+                axum::http::header::HeaderName::from_static("x-api-key"),
+                axum::http::HeaderValue::from_static("bad-key"),
+            )
+            .await
+            .assert_status(StatusCode::UNAUTHORIZED);
+    }
+
+    /// When no callback is configured, requests without credentials must pass through.
+    #[tokio::test]
+    async fn no_callback_configured_passthrough() {
+        let config = ServerConfig::default(); // auth_callback_url = None
+        let state = AppState::new(config, arc(NoopLogger));
+        let router = Router::new()
+            .route("/sandboxes/:id", any(|| async { "ok" }))
+            .layer(axum::middleware::from_fn_with_state(
+                state.clone(),
+                unified_auth,
+            ))
+            .with_state(state);
+        let server = TestServer::new(router).unwrap();
+
+        server.get("/sandboxes/xyz").await.assert_status_ok();
+    }
+
+    /// When a callback is configured, a request without credentials must return 401.
+    #[tokio::test]
+    async fn missing_credential_returns_401() {
+        let captured = Arc::new(tokio::sync::Mutex::new(Vec::new()));
+        let callback_url = spawn_callback_server(StatusCode::OK, captured.clone()).await;
+        let server = build_test_server_with_callback(&callback_url);
+
+        server
+            .get("/templates/any")
+            .await
+            .assert_status(StatusCode::UNAUTHORIZED);
+    }
+
+    /// POST and PATCH (write operations) must also forward the correct method to the callback.
+    #[tokio::test]
+    async fn callback_receives_correct_method_for_write_operations() {
+        let captured = Arc::new(tokio::sync::Mutex::new(Vec::new()));
+        let callback_url = spawn_callback_server(StatusCode::OK, captured.clone()).await;
+        let server = build_test_server_with_callback(&callback_url);
+
+        for method in [Method::POST, Method::PATCH] {
+            server
+                .method(method.clone(), "/templates/tmpl-01")
+                .add_header(
+                    axum::http::header::HeaderName::from_static("authorization"),
+                    axum::http::HeaderValue::from_static("Bearer tok"),
+                )
+                .await
+                .assert_status_ok();
+        }
+
+        let guard = captured.lock().await;
+        let methods: Vec<&str> = guard
+            .iter()
+            .filter(|(k, _)| k == "x-request-method")
+            .map(|(_, v)| v.as_str())
+            .collect();
+        assert!(methods.contains(&"POST"), "should see POST");
+        assert!(methods.contains(&"PATCH"), "should see PATCH");
     }
 }

--- a/docs/guide/authentication.md
+++ b/docs/guide/authentication.md
@@ -22,7 +22,7 @@ When `AUTH_CALLBACK_URL` is not set (the default), all requests are allowed with
 When a request arrives, Cube API Server:
 
 1. Extracts the credential from the request header (`Authorization: Bearer` takes priority over `X-API-Key`).
-2. Forwards a `POST` request to the callback URL with the credential header and the original request path.
+2. Forwards a `POST` request to the callback URL with the credential header, the original request path, **and the HTTP method**.
 3. If the callback returns **HTTP 200**, the request is allowed through.
 4. Any other status code causes the request to be rejected with **HTTP 401 Unauthorized**.
 
@@ -30,6 +30,7 @@ When a request arrives, Cube API Server:
 Client ──→ Cube API Server
                 │
                 ├─ extract credential (Bearer / API Key)
+                ├─ capture method (GET / POST / DELETE / PATCH …)
                 │
                 └─ POST → your auth service
                                 │
@@ -61,33 +62,59 @@ Cube API Server sends a `POST` to your callback URL with the following headers:
 |--------|-------|
 | `Authorization` | `Bearer <token>` — present when the client used Bearer auth |
 | `X-API-Key` | `<key>` — present when the client used API Key auth |
-| `X-Request-Path` | The original request path (e.g. `/v1/sandboxes`) |
+| `X-Request-Path` | The original request path (e.g. `/templates/my-tmpl`) |
+| `X-Request-Method` | The HTTP method of the original request (e.g. `GET`, `DELETE`) |
 
 The two credential headers are mutually exclusive. Your callback receives whichever one the client sent.
+
+::: warning Validate both path **and** method
+Multiple HTTP methods are mounted on the same path — for example, `/templates/:id` handles `GET` (read), `POST` (rebuild), `DELETE` (delete), and `PATCH` (update). A callback that only whitelists by path cannot distinguish a read from a destructive operation: a caller with read-only access could escalate to delete or overwrite a template.
+
+Always check **both** `X-Request-Path` and `X-Request-Method` in your callback.
+:::
 
 ### Example callback (Python/FastAPI)
 
 ```python
 from fastapi import FastAPI, Request
+from fastapi.responses import Response
 
 app = FastAPI()
 
 VALID_KEYS = {"secret-key-1", "secret-key-2"}
 
+# Define which methods each key is allowed to use per path prefix.
+# Always check BOTH path and method — the same path (e.g. /templates/:id)
+# serves GET (read), DELETE, POST (rebuild), and PATCH (update).
+READ_METHODS = {"GET", "HEAD"}
+WRITE_METHODS = {"POST", "DELETE", "PATCH", "PUT"}
+
+READONLY_KEYS = {"readonly-key-1"}
+FULL_ACCESS_KEYS = {"secret-key-1", "secret-key-2"}
+
 @app.post("/verify")
 async def verify(request: Request):
-    # Bearer token
+    path = request.headers.get("X-Request-Path", "")
+    method = request.headers.get("X-Request-Method", "").upper()
+
+    # Extract credential (Bearer takes priority)
+    key = None
     auth = request.headers.get("Authorization", "")
     if auth.startswith("Bearer "):
-        token = auth.removeprefix("Bearer ").strip()
-        if token in VALID_KEYS:
-            return {}           # 200 → allow
-        return Response(status_code=403)
+        key = auth.removeprefix("Bearer ").strip()
+    else:
+        key = request.headers.get("X-API-Key", "")
 
-    # API Key
-    key = request.headers.get("X-API-Key", "")
-    if key in VALID_KEYS:
-        return {}               # 200 → allow
+    if not key:
+        return Response(status_code=401)
+
+    if key in FULL_ACCESS_KEYS:
+        return {}                           # 200 → allow all
+
+    if key in READONLY_KEYS:
+        if method in READ_METHODS:
+            return {}                       # 200 → allow reads
+        return Response(status_code=403)   # deny writes/deletes
 
     return Response(status_code=401)
 ```

--- a/docs/zh/guide/authentication.md
+++ b/docs/zh/guide/authentication.md
@@ -22,7 +22,7 @@ export AUTH_CALLBACK_URL=https://your-auth-service/verify
 请求到达时，Cube API Server 按以下流程处理：
 
 1. 从请求 header 中提取凭证（`Authorization: Bearer` 优先于 `X-API-Key`）。
-2. 向回调地址发送 `POST` 请求，透传凭证 header 和原始请求路径。
+2. 向回调地址发送 `POST` 请求，透传凭证 header、原始请求路径**以及 HTTP 方法**。
 3. 回调返回 **HTTP 200** → 放行请求。
 4. 其他状态码 → 返回客户端 **HTTP 401 Unauthorized**。
 
@@ -30,6 +30,7 @@ export AUTH_CALLBACK_URL=https://your-auth-service/verify
 客户端 ──→ Cube API Server
                 │
                 ├─ 提取凭证（Bearer / API Key）
+                ├─ 记录方法（GET / POST / DELETE / PATCH …）
                 │
                 └─ POST → 你的鉴权服务
                                 │
@@ -58,12 +59,19 @@ X-API-Key: your-actual-api-key
 Cube API Server 向回调地址发送的 `POST` 请求包含以下 header：
 
 | Header | 值 |
-|--------|----|
+|--------|---|
 | `Authorization` | `Bearer <token>` — 客户端使用 Bearer 鉴权时透传 |
 | `X-API-Key` | `<key>` — 客户端使用 API Key 鉴权时透传 |
-| `X-Request-Path` | 原始请求路径，如 `/v1/sandboxes` |
+| `X-Request-Path` | 原始请求路径，如 `/templates/my-tmpl` |
+| `X-Request-Method` | 原始请求的 HTTP 方法，如 `GET`、`DELETE` |
 
 两个凭证 header 互斥，回调方收到哪个取决于客户端发送的是哪种格式。
+
+::: warning 必须同时校验路径**和**方法
+同一路径上挂载了多个 HTTP 方法——例如 `/templates/:id` 同时处理 `GET`（读取）、`POST`（重建）、`DELETE`（删除）和 `PATCH`（更新）。如果回调仅按路径白名单授权，则读权限可能被放大为删除或覆写操作：持有只读凭证的调用方发送 `DELETE` 请求时，路径匹配不会拦截它。
+
+请在回调中**同时校验** `X-Request-Path` 和 `X-Request-Method`。
+:::
 
 ### 回调示例（Python/FastAPI）
 
@@ -73,22 +81,38 @@ from fastapi.responses import Response
 
 app = FastAPI()
 
-VALID_KEYS = {"secret-key-1", "secret-key-2"}
+# 读操作方法集合
+READ_METHODS = {"GET", "HEAD"}
+
+# 只读凭证与完全访问凭证分开管理。
+# 必须同时校验路径和方法——同一路径（如 /templates/:id）
+# 既有 GET（读取），也有 DELETE、POST（重建）、PATCH（更新）。
+READONLY_KEYS = {"readonly-key-1"}
+FULL_ACCESS_KEYS = {"secret-key-1", "secret-key-2"}
 
 @app.post("/verify")
 async def verify(request: Request):
-    # Bearer token
+    path = request.headers.get("X-Request-Path", "")
+    method = request.headers.get("X-Request-Method", "").upper()
+
+    # 提取凭证（Bearer 优先）
+    key = None
     auth = request.headers.get("Authorization", "")
     if auth.startswith("Bearer "):
-        token = auth.removeprefix("Bearer ").strip()
-        if token in VALID_KEYS:
-            return {}               # 200 → 放行
-        return Response(status_code=403)
+        key = auth.removeprefix("Bearer ").strip()
+    else:
+        key = request.headers.get("X-API-Key", "")
 
-    # API Key
-    key = request.headers.get("X-API-Key", "")
-    if key in VALID_KEYS:
-        return {}                   # 200 → 放行
+    if not key:
+        return Response(status_code=401)
+
+    if key in FULL_ACCESS_KEYS:
+        return {}                           # 200 → 放行所有操作
+
+    if key in READONLY_KEYS:
+        if method in READ_METHODS:
+            return {}                       # 200 → 允许读操作
+        return Response(status_code=403)   # 拒绝写/删操作
 
     return Response(status_code=401)
 ```


### PR DESCRIPTION
The auth callback only received X-Request-Path, not the HTTP method. Routes like /templates/:id and /sandboxes/:id multiplex multiple methods (GET/POST/DELETE/PATCH) on the same path, so a callback that whitelists by path alone cannot distinguish read from write/delete operations -- a caller with read-only credentials could escalate to delete/rebuild.

Fix: add X-Request-Method header to every outgoing callback POST so the callback implementation can enforce fine-grained (path + method) authz.

Changes:
- middleware/auth.rs: forward X-Request-Method in callback POST request
- config/mod.rs: update auth_callback_url doc comment with new header and privilege-escalation security note
- tracing log fields: add method to debug/warn entries
- 6 new unit tests covering GET-vs-DELETE same-path regression, path forwarding, rejection 401, no-callback passthrough, missing credential, and POST/PATCH write-method forwarding
- docs/guide/authentication.md: add X-Request-Method to callback format table, update flow diagram, add warning block about path-only authz risk, rewrite example callback with path+method fine-grained authz
- docs/zh/guide/authentication.md: same updates in Chinese