### PR TITLE
fix(shim): allow delete on PAUSED sandboxes to prevent destroy timeout

### DIFF
--- a/CubeShim/shim/src/service/task_srv.rs
+++ b/CubeShim/shim/src/service/task_srv.rs
@@ -294,10 +294,9 @@ impl Task for TaskService {
             self.log.clone(),
         );
         let mut sb = self.sandbox.lock().await;
-        if sb.paused().await {
-            errf!(self.log, "sandbox not in normal state");
-            return Err(Others(format!("sandbox not in normal state")));
-        }
+        // Allow delete on PAUSED sandboxes. During destroy, signal_container(SIGKILL)
+        // returns Ok() without contacting the agent when the sandbox is not running,
+        // so deletion is safe even when the VM is paused.
         let (exit_code, exit_tm) = {
             if req.exec_id.is_empty() {
                 match sb.delete_container(&req.id).await {


### PR DESCRIPTION
When a sandbox enters PAUSED state at CubeShim level (e.g., VM pause during Nydus operations), the destroy path fails because the delete handler rejects requests with "sandbox not in normal state". This causes the Cubelet destroy to fall back to stopTask(), where container.Task() blocks waiting for the sandbox mutex held by pause_vm(), hitting the 30-second ttrpc client timeout.

Remove the sb.paused() guard from the delete handler. During destroy, signal_container(SIGKILL) already returns Ok() without contacting the in-VM agent when the sandbox is not running (container/mod.rs:466-472), so deletion is safe even when the VM is paused. The agent will be cleaned up when the VM is eventually terminated.