### PR TITLE
agent: upgrade libseccomp to 0.3.0 to fix GHSA-2r23-gqr7-wr4h

### DIFF
--- a/agent/Cargo.lock
+++ b/agent/Cargo.lock
@@ -801,21 +801,21 @@ checksum = "37c93d8daa9d8a012fd8ab92f088405fb202ea0b6ab73ee2482ae66af4f42091"
 
 [[package]]
 name = "libseccomp"
-version = "0.1.3"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36ad71a5b66ceef3acfe6a3178b29b4da063f8bcb2c36dab666d52a7a9cfdb86"
+checksum = "21c57fd8981a80019807b7b68118618d29a87177c63d704fc96e6ecd003ae5b3"
 dependencies = [
+ "bitflags 1.3.2",
  "libc",
  "libseccomp-sys",
- "nix 0.17.0",
  "pkg-config",
 ]
 
 [[package]]
 name = "libseccomp-sys"
-version = "0.1.1"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "539912de229a4fc16e507e8df12a394038a524a5b5b6c92045ad344472aac475"
+checksum = "9a7cbbd4ad467251987c6e5b47d53b11a5a05add08f2447a9e2d70aef1e0d138"
 
 [[package]]
 name = "linux-raw-sys"
@@ -1021,19 +1021,6 @@ dependencies = [
  "libc",
  "log",
  "tokio",
-]
-
-[[package]]
-name = "nix"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50e4785f2c3b7589a0d0c1dd60285e1188adac4006e8abd6dd578e1567027363"
-dependencies = [
- "bitflags 1.3.2",
- "cc",
- "cfg-if 0.1.10",
- "libc",
- "void",
 ]
 
 [[package]]
@@ -2357,12 +2344,6 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
-
-[[package]]
-name = "void"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 
 [[package]]
 name = "volatile"

--- a/agent/rustjail/Cargo.toml
+++ b/agent/rustjail/Cargo.toml
@@ -32,7 +32,7 @@ tokio = { version = "=1.45.1", features = ["full"] }
 futures = "=0.3.28"
 async-trait = "=0.1.68"
 inotify = "0.9.2"
-libseccomp = { version = "0.1.3", optional = true }
+libseccomp = { version = "0.3.0", optional = true }
 
 [dev-dependencies]
 serial_test = "0.5.0"

--- a/agent/rustjail/src/seccomp.rs
+++ b/agent/rustjail/src/seccomp.rs
@@ -26,12 +26,17 @@ fn get_rule_conditions(args: &[LinuxSeccompArg]) -> Result<Vec<ScmpArgCompare>> 
             return Err(anyhow!("seccomp opreator is required"));
         }
 
-        let cond = ScmpArgCompare::new(
-            arg.index,
-            ScmpCompareOp::from_str(&arg.op)?,
-            arg.value,
-            Some(arg.value_two),
-        );
+        let op = ScmpCompareOp::from_str(&arg.op)?;
+        // In libseccomp 0.2+, ScmpArgCompare::new takes a single datum.
+        // For MaskedEqual the mask is encoded inside the op variant; for all
+        // other operators value_two is unused so we only pass `value`.
+        let cond = match op {
+            ScmpCompareOp::MaskedEqual(mask) => {
+                let _ = mask; // mask already embedded in the op
+                ScmpArgCompare::new(arg.index, ScmpCompareOp::MaskedEqual(arg.value_two), arg.value)
+            }
+            _ => ScmpArgCompare::new(arg.index, op, arg.value),
+        };
 
         conditions.push(cond);
     }
@@ -44,7 +49,7 @@ pub fn get_unknown_syscalls(scmp: &LinuxSeccomp) -> Option<Vec<String>> {
 
     for syscall in &scmp.syscalls {
         for name in &syscall.names {
-            if get_syscall_from_name(name, None).is_err() {
+            if ScmpSyscall::from_name(name).is_err() {
                 unknown_syscalls.push(name.to_string());
             }
         }
@@ -60,7 +65,7 @@ pub fn get_unknown_syscalls(scmp: &LinuxSeccomp) -> Option<Vec<String>> {
 // init_seccomp creates a seccomp filter and loads it for the current process
 // including all the child processes.
 pub fn init_seccomp(scmp: &LinuxSeccomp) -> Result<()> {
-    let def_action = ScmpAction::from_str(scmp.default_action.as_str(), Some(libc::EPERM as u32))?;
+    let def_action = ScmpAction::from_str(scmp.default_action.as_str(), Some(libc::EPERM))?;
 
     // Create a new filter context
     let mut filter = ScmpFilterContext::new_filter(def_action)?;
@@ -68,11 +73,13 @@ pub fn init_seccomp(scmp: &LinuxSeccomp) -> Result<()> {
     // Add extra architectures
     for arch in &scmp.architectures {
         let scmp_arch = ScmpArch::from_str(arch)?;
+        // In libseccomp 0.3+, add_arch returns Ok(true/false) instead of Ok(());
+        // we ignore the bool (true = added, false = already present).
         filter.add_arch(scmp_arch)?;
     }
 
     // Unset no new privileges bit
-    filter.set_no_new_privs_bit(false)?;
+    filter.set_ctl_nnp(false)?;
 
     // Add a rule for each system call
     for syscall in &scmp.syscalls {
@@ -80,13 +87,13 @@ pub fn init_seccomp(scmp: &LinuxSeccomp) -> Result<()> {
             return Err(anyhow!("syscall name is required"));
         }
 
-        let action = ScmpAction::from_str(&syscall.action, Some(syscall.errno_ret))?;
+        let action = ScmpAction::from_str(&syscall.action, Some(syscall.errno_ret as i32))?;
         if action == def_action {
             continue;
         }
 
         for name in &syscall.names {
-            let syscall_num = match get_syscall_from_name(name, None) {
+            let syscall_num = match ScmpSyscall::from_name(name) {
                 Ok(num) => num,
                 Err(_) => {
                     // If we cannot resolve the given system call, we assume it is not supported
@@ -96,10 +103,12 @@ pub fn init_seccomp(scmp: &LinuxSeccomp) -> Result<()> {
             };
 
             if syscall.args.is_empty() {
-                filter.add_rule(action, syscall_num, None)?;
+                // libseccomp 0.2+: unconditional rule — use add_rule()
+                filter.add_rule(action, syscall_num)?;
             } else {
+                // libseccomp 0.2+: conditional rule — use add_rule_conditional()
                 let conditions = get_rule_conditions(&syscall.args)?;
-                filter.add_rule(action, syscall_num, Some(&conditions))?;
+                filter.add_rule_conditional(action, syscall_num, &conditions)?;
             }
         }
     }


### PR DESCRIPTION
nix < 0.20.2 (Rust) has an out-of-bounds write in getgrouplist when a user belongs to more than 16 groups (GHSA-2r23-gqr7-wr4h). The nix 0.17.0 dependency was pulled in transitively via libseccomp 0.1.3 in agent/rustjail.

Upgrade libseccomp from 0.1.3 to 0.3.0, which dropped the nix dependency entirely in favour of libseccomp-sys FFI. This removes nix 0.17.0 from the dependency tree and resolves the vulnerability.

API changes required in rustjail/src/seccomp.rs for libseccomp 0.2+:
- ScmpArgCompare::new() now takes a single datum (value_two is encoded inside ScmpCompareOp::MaskedEqual); updated get_rule_conditions().
- add_rule() no longer accepts Option<&[ScmpArgCompare]>; replaced with add_rule() for unconditional rules and add_rule_conditional() for conditional ones.
- ScmpAction::Errno now holds i32 instead of u32; cast errno_ret.
- Replaced deprecated get_syscall_from_name() with ScmpSyscall::from_name().
- Replaced deprecated set_no_new_privs_bit() with set_ctl_nnp().
- add_arch() now returns Ok(bool) instead of Ok(()); result ignored.

Fixes: GHSA-2r23-gqr7-wr4h