### PR TITLE
agent: upgrade prometheus to 0.14.0 to drop vulnerable protobuf 2.28.0

### DIFF
--- a/agent/Cargo.lock
+++ b/agent/Cargo.lock
@@ -387,7 +387,7 @@ dependencies = [
  "opentelemetry",
  "procfs 0.12.0",
  "prometheus",
- "protobuf 3.7.2",
+ "protobuf",
  "protocols",
  "regex",
  "rtnetlink",
@@ -1352,22 +1352,21 @@ dependencies = [
 
 [[package]]
 name = "procfs"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "731e0d9356b0c25f16f33b5be79b1c57b562f141ebfcdb0ad8ac2c13a24293b4"
+checksum = "cc5b72d8145275d844d4b5f6d4e1eef00c8cd889edb6035c21675d1bb1f45c9f"
 dependencies = [
  "bitflags 2.10.0",
  "hex",
- "lazy_static",
  "procfs-core",
  "rustix 0.38.44",
 ]
 
 [[package]]
 name = "procfs-core"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d3554923a69f4ce04c4a754260c338f505ce22642d3830e049a399fc2059a29"
+checksum = "239df02d8349b06fc07398a3a1697b06418223b1c7725085e801e7c0fc6a12ec"
 dependencies = [
  "bitflags 2.10.0",
  "hex",
@@ -1375,9 +1374,9 @@ dependencies = [
 
 [[package]]
 name = "prometheus"
-version = "0.13.4"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d33c28a30771f7f96db69893f78b857f7450d7e0237e9c8fc6427a81bae7ed1"
+checksum = "3ca5326d8d0b950a9acd87e6a3f94745394f62e4dae1b1ee22b2bc0c394af43a"
 dependencies = [
  "cfg-if 1.0.4",
  "fnv",
@@ -1385,9 +1384,9 @@ dependencies = [
  "libc",
  "memchr",
  "parking_lot 0.12.5",
- "procfs 0.16.0",
- "protobuf 2.28.0",
- "thiserror 1.0.69",
+ "procfs 0.17.0",
+ "protobuf",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -1443,12 +1442,6 @@ dependencies = [
 
 [[package]]
 name = "protobuf"
-version = "2.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
-
-[[package]]
-name = "protobuf"
 version = "3.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d65a1d4ddae7d8b5de68153b48f6aa3bba8cb002b243dbdbc55a5afbc98f99f4"
@@ -1466,7 +1459,7 @@ checksum = "5d3976825c0014bbd2f3b34f0001876604fe87e0c86cd8fa54251530f1544ace"
 dependencies = [
  "anyhow",
  "once_cell",
- "protobuf 3.7.2",
+ "protobuf",
  "protobuf-parse",
  "regex",
  "tempfile",
@@ -1482,7 +1475,7 @@ dependencies = [
  "anyhow",
  "indexmap 2.12.1",
  "log",
- "protobuf 3.7.2",
+ "protobuf",
  "protobuf-support",
  "tempfile",
  "thiserror 1.0.69",
@@ -1503,7 +1496,7 @@ name = "protocols"
 version = "0.1.0"
 dependencies = [
  "async-trait",
- "protobuf 3.7.2",
+ "protobuf",
  "serde",
  "serde_json",
  "ttrpc",
@@ -1715,7 +1708,7 @@ dependencies = [
  "nix 0.23.2",
  "oci",
  "path-absolutize",
- "protobuf 3.7.2",
+ "protobuf",
  "protocols",
  "regex",
  "rlimit",
@@ -2286,7 +2279,7 @@ dependencies = [
  "libc",
  "log",
  "nix 0.26.4",
- "protobuf 3.7.2",
+ "protobuf",
  "protobuf-codegen",
  "thiserror 1.0.69",
  "tokio",
@@ -2300,7 +2293,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e5c657ef5cea6f6c6073c1be0787ba4482f42a569d4821e467daec795271f86"
 dependencies = [
- "protobuf 3.7.2",
+ "protobuf",
  "protobuf-codegen",
  "protobuf-support",
  "ttrpc-compiler",
@@ -2316,7 +2309,7 @@ dependencies = [
  "prost",
  "prost-build",
  "prost-types",
- "protobuf 3.7.2",
+ "protobuf",
  "protobuf-codegen",
  "tempfile",
 ]

--- a/agent/Cargo.toml
+++ b/agent/Cargo.toml
@@ -52,7 +52,7 @@ slog-scope = "4.1.2"
 slog-stdlog = "4.0.0"
 log = "0.4.11"
 
-prometheus = { version = "0.13.0", features = ["process"] }
+prometheus = { version = "0.14.0", features = ["process"] }
 procfs = "0.12.0"
 anyhow = "1.0.99"
 cgroups = { package = "cgroups-rs", version = "0.3.0" }


### PR DESCRIPTION
Dependabot alert https://github.com/TencentCloud/CubeSandbox/security/dependabot/23  flagged protobuf 2.28.0 in agent/Cargo.lock (stack overflow on uncontrolled recursion when parsing unknown fields, fixed upstream in 3.7.2).

cube-agent already pins protobuf = "3.7.2" directly. The 2.x copy came in transitively via prometheus 0.13.4 -> protobuf ^2. prometheus 0.14.0 switched to protobuf ^3.7.2 (and made it optional), so bumping the direct dep is the minimal fix.

Changes:
  - Cargo.toml: prometheus 0.13.0 -> 0.14.0 (features unchanged)
  - Cargo.lock: prometheus 0.13.4 -> 0.14.0, procfs/procfs-core 0.16.0 -> 0.17.0, protobuf 2.28.0 removed.

Public API used (Encoder, TextEncoder, register_*! macros, gather, GaugeVec, IntCounter) is source-compatible across 0.13 -> 0.14; no code changes required.

Attack surface in cube-agent is effectively nil: prometheus is used only as an exporter, and the protobuf feature is not enabled. Upgrading anyway to clear the alert.

Verified: cargo build --release --locked clean under RUSTFLAGS="--deny warnings"; only protobuf 3.7.2 remains in Cargo.lock; libs/* unit tests pass.