### PR TITLE
ci: add docs build check workflow on pull request

### DIFF
--- a/.github/workflows/docs-build-check.yml
+++ b/.github/workflows/docs-build-check.yml
@@ -1,0 +1,37 @@
+name: Docs Build Check
+
+on:
+  pull_request:
+    paths:
+      - 'docs/**'
+      - '.github/workflows/docs-build-check.yml'
+
+concurrency:
+  group: docs-build-check-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  build-check:
+    name: Build Check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: docs/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+        working-directory: docs
+
+      - name: Build with VitePress
+        run: npm run docs:build
+        working-directory: docs


### PR DESCRIPTION
## Summary
- Add a new GitHub Actions workflow `docs-build-check.yml` to automatically verify VitePress builds on pull requests that modify files in the `docs` directory.
- Configure Node 22 environment and caching of npm packages to optimize the build check speed.

## Test plan
- Manually verified that the workflow triggers on pull requests targeting `docs/**` and `.github/workflows/docs-build-check.yml`.
- Verified VitePress configuration builds successfully using `npm run docs:build` locally.

Autonomously-by: CursorAgent:gemini-3.5-flash

Made with [Cursor](https://cursor.com)