### PR TITLE
feat(cubeproxy): add path-based sandbox routing and shared backend resolution

### DIFF
--- a/CubeProxy/lua/path_rewrite_phase.lua
+++ b/CubeProxy/lua/path_rewrite_phase.lua
@@ -1,0 +1,41 @@
+-- file name: path_rewrite_phase.lua
+--
+-- Path-based sandbox routing. Accepts URIs shaped as:
+--     /sandbox/<sandbox-id>/<container-port>(/<rest>)?
+-- and rewrites the upstream URI to "/<rest>" (preserving the query string),
+-- then resolves the same Redis-backed backend metadata used by host-mode
+-- routing in rewrite_phase.lua.
+
+local sb = require "sandbox_backend"
+
+local uri = ngx.var.uri or ""
+local ins_id, container_port, rest = uri:match("^/sandbox/([%w_%-]+)/(%d+)(/?.*)$")
+if not ins_id or not container_port then
+    ngx.log(ngx.ERR, "LEVEL_WARN||",
+        string.format("request %s invalid path for sandbox/<id>/<port> parse: %s",
+            ngx.var.http_x_cube_request_id, uri))
+    ngx.var.cube_retcode = "310400"
+    ngx.exit(400)
+end
+
+if rest == nil or rest == "" then
+    rest = "/"
+end
+
+-- Expose parsed values so proxy_redirect / proxy_cookie_path in nginx.conf
+-- can rewrite Location headers and cookie Path values back into the
+-- /sandbox/<id>/<port>/ prefix on the response side.
+ngx.var.ins_id = ins_id
+ngx.var.container_port = container_port
+
+-- Strip the /sandbox/<id>/<port> prefix from the upstream URI. The second
+-- argument is false so nginx does NOT trigger an internal redirect, letting
+-- the remaining phases (balancer / header_filter / log) of this location
+-- continue to run as configured.
+ngx.req.set_uri(rest, false)
+
+local host_ip, host_port = sb.resolve_backend(ins_id, container_port)
+ngx.var.backend_ip = host_ip
+ngx.var.backend_port = host_port
+
+sb.assert_backend_healthy(host_ip, ins_id)

--- a/CubeProxy/lua/rewrite_phase.lua
+++ b/CubeProxy/lua/rewrite_phase.lua
@@ -1,4 +1,5 @@
 local utils = require "utils"
+local sb = require "sandbox_backend"
 
 -- Parse Host: <container_port>-<sandbox_id>.<domain> e.g. 49983-7c8fbcd45ffe450fb8f7fb223ad45507.cube.app
 -- Returns container_port, ins_id (sandbox / instance id), or nil, nil on failure.
@@ -17,125 +18,6 @@ local function parse_port_and_instance_from_host(host)
     return container_port, ins_id
 end
 
-local function get_cache_timeout()
-    return math.random(tonumber(ngx.var.timeout_min), tonumber(ngx.var.timeout_max))
-end
-
-local function get_caller_host_ip()
-    if not utils:is_null(ngx.var.cube_proxy_host_ip) then
-        return ngx.var.cube_proxy_host_ip
-    end
-    if not utils:is_null(ngx.var.server_addr) then
-        return ngx.var.server_addr
-    end
-    return ""
-end
-
-local function load_sandbox_proxy_metadata(ins_id)
-    local redis = require "redis_iresty"
-    local red = redis:new({
-        redis_ip = ngx.var.redis_ip,
-        redis_port = ngx.var.redis_port,
-        redis_pd = ngx.var.redis_pd,
-        redis_index = ngx.var.redis_index
-    })
-
-    local key = "bypass_host_proxy:" .. ins_id
-    local value, err
-    for i = 1, 3 do
-        value, err = red:hgetall(key)
-        if not err then
-            break
-        end
-        ngx.log(ngx.ERR, "LEVEL_WARN||",
-            string.format("request %s using key %s get redis err: %s, retry %d", ngx.var.http_x_cube_request_id, key, err, i))
-    end
-    if err then
-        return nil, string.format("request %s using key %s get redis err: %s",
-            ngx.var.http_x_cube_request_id, key, err)
-    end
-    if not value then
-        return nil, string.format("request %s using key %s get redis nil",
-            ngx.var.http_x_cube_request_id, key)
-    end
-    return value, nil
-end
-
---[[
-    Get upstream server address
-    2 args:
-        - ins_id: string
-        - container_port: string, "8080" or "32000"
-    2 return values:
-        - host_ip: string
-        - host_port: string
---]]
-local function get_backend_address(ins_id, container_port)
-    local caller_host_ip = get_caller_host_ip()
-    local cache = ngx.shared.local_cache
-    local timeout = get_cache_timeout()
-    local cache_backend_ip_key = string.format("%s:%s:%s", ins_id, container_port, "backend_ip")
-    local cache_backend_port_key = string.format("%s:%s:%s", ins_id, container_port, "backend_port")
-    local host_ip = cache:get(cache_backend_ip_key)
-    local host_port = cache:get(cache_backend_port_key)
-    if host_ip and host_port then
-        cache:set(cache_backend_ip_key, host_ip, timeout)
-        cache:set(cache_backend_port_key, host_port, timeout)
-        return host_ip, host_port
-    end
-
-    local metadata, err = load_sandbox_proxy_metadata(ins_id)
-    if err then
-        ngx.log(ngx.ERR, "LEVEL_ERROR||", err)
-        ngx.var.cube_retcode = "310500"
-        ngx.exit(500)
-    end
-
-    local metadata_map = {}
-    for i = 1, #metadata, 2 do
-        local k = metadata[i]
-        local v = metadata[i + 1]
-        metadata_map[k] = v
-        cache:set(ins_id .. ":" .. k, v, timeout)
-    end
-
-    local target_host_ip = metadata_map["HostIP"]
-    local target_sandbox_ip = metadata_map["SandboxIP"]
-    if utils:is_null(target_host_ip) then
-        ngx.log(ngx.ERR, "LEVEL_WARN||",
-            string.format("request %s using instance %s misses HostIP", ngx.var.http_x_cube_request_id, ins_id))
-        ngx.var.cube_retcode = "310507"
-        ngx.exit(500)
-    end
-
-    if not utils:is_null(caller_host_ip) and caller_host_ip == target_host_ip then
-        if utils:is_null(target_sandbox_ip) then
-            ngx.log(ngx.ERR, "LEVEL_ERROR||",
-                string.format("request %s instance %s on local host %s misses SandboxIP",
-                    ngx.var.http_x_cube_request_id, ins_id, caller_host_ip))
-            ngx.var.cube_retcode = "310507"
-            ngx.exit(500)
-        end
-        host_ip = target_sandbox_ip
-        host_port = container_port
-    else
-        host_ip = target_host_ip
-        host_port = metadata_map[container_port]
-        if utils:is_null(host_port) then
-            ngx.log(ngx.ERR, "LEVEL_ERROR||",
-                string.format("request %s instance %s misses host port mapping for container_port %s",
-                    ngx.var.http_x_cube_request_id, ins_id, container_port))
-            ngx.var.cube_retcode = "310507"
-            ngx.exit(500)
-        end
-    end
-
-    cache:set(cache_backend_ip_key, host_ip, timeout)
-    cache:set(cache_backend_port_key, host_port, timeout)
-    return host_ip, host_port
-end
-
--- resolve sandbox id and container port from Host: <port>-<sandbox_id>.<domain>
 local container_port, ins_id = parse_port_and_instance_from_host(ngx.var.http_host)
 if not container_port or not ins_id then
     ngx.log(ngx.ERR, "LEVEL_WARN||",
@@ -145,18 +27,8 @@ if not container_port or not ins_id then
     ngx.exit(400)
 end
 
-local host_ip, host_port = get_backend_address(ins_id, container_port)
+local host_ip, host_port = sb.resolve_backend(ins_id, container_port)
 ngx.var.backend_ip = host_ip
 ngx.var.backend_port = host_port
 
-local faulty_backend, err = utils:is_faulty_backend(host_ip, true)
-if err then
-    ngx.log(ngx.ERR, "LEVEL_ERROR||", "check backend fault err: ", err)
-end
-if faulty_backend == true then
-    ngx.log(ngx.ERR, "LEVEL_ERROR||",
-        string.format("request %s use instance %s hits faulty_backend %s", ngx.var.http_x_cube_request_id,
-            ins_id, host_ip))
-    ngx.var.cube_retcode = "340500"
-    ngx.exit(500)
-end
+sb.assert_backend_healthy(host_ip, ins_id)

--- a/CubeProxy/lua/sandbox_backend.lua
+++ b/CubeProxy/lua/sandbox_backend.lua
@@ -1,0 +1,160 @@
+-- file name: sandbox_backend.lua
+--
+-- Shared backend resolution helpers used by both host-based and path-based
+-- sandbox routing entry points (rewrite_phase.lua / path_rewrite_phase.lua).
+--
+-- Looks up the sandbox proxy metadata stored in Redis under
+-- "bypass_host_proxy:<sandbox_id>" (written by CubeMaster) and returns the
+-- upstream host:port that the nginx balancer phase should connect to.
+
+local utils = require "utils"
+
+local _M = { _VERSION = "0.01" }
+
+local function get_cache_timeout()
+    return math.random(tonumber(ngx.var.timeout_min), tonumber(ngx.var.timeout_max))
+end
+
+local function get_caller_host_ip()
+    if not utils:is_null(ngx.var.cube_proxy_host_ip) then
+        return ngx.var.cube_proxy_host_ip
+    end
+    if not utils:is_null(ngx.var.server_addr) then
+        return ngx.var.server_addr
+    end
+    return ""
+end
+
+local function load_sandbox_proxy_metadata(ins_id)
+    local redis = require "redis_iresty"
+    local red = redis:new({
+        redis_ip = ngx.var.redis_ip,
+        redis_port = ngx.var.redis_port,
+        redis_pd = ngx.var.redis_pd,
+        redis_index = ngx.var.redis_index
+    })
+
+    local key = "bypass_host_proxy:" .. ins_id
+    local value, err
+    for i = 1, 3 do
+        value, err = red:hgetall(key)
+        if not err then
+            break
+        end
+        ngx.log(ngx.ERR, "LEVEL_WARN||",
+            string.format("request %s using key %s get redis err: %s, retry %d",
+                ngx.var.http_x_cube_request_id, key, err, i))
+    end
+    if err then
+        return nil, string.format("request %s using key %s get redis err: %s",
+            ngx.var.http_x_cube_request_id, key, err)
+    end
+    if not value then
+        return nil, string.format("request %s using key %s get redis nil",
+            ngx.var.http_x_cube_request_id, key)
+    end
+    return value, nil
+end
+
+--[[
+    Resolve the upstream backend for a sandbox + container port.
+
+    2 args:
+        - ins_id: string, sandbox / instance id
+        - container_port: string, e.g. "8080" or "32000"
+    2 return values:
+        - host_ip: string
+        - host_port: string
+
+    On unrecoverable error this function calls ngx.exit() and does not return.
+--]]
+function _M.resolve_backend(ins_id, container_port)
+    local caller_host_ip = get_caller_host_ip()
+    local cache = ngx.shared.local_cache
+    local timeout = get_cache_timeout()
+    local cache_backend_ip_key = string.format("%s:%s:%s", ins_id, container_port, "backend_ip")
+    local cache_backend_port_key = string.format("%s:%s:%s", ins_id, container_port, "backend_port")
+    local host_ip = cache:get(cache_backend_ip_key)
+    local host_port = cache:get(cache_backend_port_key)
+    if host_ip and host_port then
+        cache:set(cache_backend_ip_key, host_ip, timeout)
+        cache:set(cache_backend_port_key, host_port, timeout)
+        return host_ip, host_port
+    end
+
+    local metadata, err = load_sandbox_proxy_metadata(ins_id)
+    if err then
+        ngx.log(ngx.ERR, "LEVEL_ERROR||", err)
+        ngx.var.cube_retcode = "310500"
+        ngx.exit(500)
+    end
+
+    local metadata_map = {}
+    for i = 1, #metadata, 2 do
+        local k = metadata[i]
+        local v = metadata[i + 1]
+        metadata_map[k] = v
+        cache:set(ins_id .. ":" .. k, v, timeout)
+    end
+
+    local target_host_ip = metadata_map["HostIP"]
+    local target_sandbox_ip = metadata_map["SandboxIP"]
+    if utils:is_null(target_host_ip) then
+        ngx.log(ngx.ERR, "LEVEL_WARN||",
+            string.format("request %s using instance %s misses HostIP",
+                ngx.var.http_x_cube_request_id, ins_id))
+        ngx.var.cube_retcode = "310507"
+        ngx.exit(500)
+    end
+
+    if not utils:is_null(caller_host_ip) and caller_host_ip == target_host_ip then
+        if utils:is_null(target_sandbox_ip) then
+            ngx.log(ngx.ERR, "LEVEL_ERROR||",
+                string.format("request %s instance %s on local host %s misses SandboxIP",
+                    ngx.var.http_x_cube_request_id, ins_id, caller_host_ip))
+            ngx.var.cube_retcode = "310507"
+            ngx.exit(500)
+        end
+        host_ip = target_sandbox_ip
+        host_port = container_port
+    else
+        host_ip = target_host_ip
+        host_port = metadata_map[container_port]
+        if utils:is_null(host_port) then
+            ngx.log(ngx.ERR, "LEVEL_ERROR||",
+                string.format("request %s instance %s misses host port mapping for container_port %s",
+                    ngx.var.http_x_cube_request_id, ins_id, container_port))
+            ngx.var.cube_retcode = "310507"
+            ngx.exit(500)
+        end
+    end
+
+    cache:set(cache_backend_ip_key, host_ip, timeout)
+    cache:set(cache_backend_port_key, host_port, timeout)
+    return host_ip, host_port
+end
+
+--[[
+    Check whether the resolved backend is currently marked faulty.
+
+    2 args:
+        - host_ip: string, the resolved upstream ip
+        - ins_id: string, sandbox id (for logging)
+
+    On a faulty backend this function calls ngx.exit() and does not return.
+--]]
+function _M.assert_backend_healthy(host_ip, ins_id)
+    local faulty_backend, err = utils:is_faulty_backend(host_ip, true)
+    if err then
+        ngx.log(ngx.ERR, "LEVEL_ERROR||", "check backend fault err: ", err)
+    end
+    if faulty_backend == true then
+        ngx.log(ngx.ERR, "LEVEL_ERROR||",
+            string.format("request %s use instance %s hits faulty_backend %s",
+                ngx.var.http_x_cube_request_id, ins_id, host_ip))
+        ngx.var.cube_retcode = "340500"
+        ngx.exit(500)
+    end
+end
+
+return _M

--- a/CubeProxy/nginx.conf
+++ b/CubeProxy/nginx.conf
@@ -90,6 +90,49 @@ http {
         listen 8081 reuseport;
         server_name _;
         set $cube_proxy_host_ip "";
+        # Populated by lua/path_rewrite_phase.lua for the /sandbox/<id>/<port>/ location.
+        # Declared at the server level so proxy_redirect / proxy_cookie_path can reference them.
+        set $ins_id "";
+        set $container_port "";
+
+        # Path-based routing: /sandbox/<sandbox-id>/<container-port>/<rest>
+        # Lets clients reach a sandbox via a plain IP+port without wildcard DNS or TLS.
+        location ^~ /sandbox/ {
+            include /usr/local/openresty/nginx/conf/global/global.conf;
+            set $cube_retcode "310200";
+            set $garyscale_test "none";
+            set $backend_ip "";
+            set $backend_port "";
+            set $access_time "";
+            set $cache_free_space "";
+            set $host_proxy_port 8081;
+
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection "upgrade";
+
+            proxy_send_timeout 7206s;
+            proxy_read_timeout 7206s;
+            proxy_connect_timeout 3s;
+            proxy_set_header Host $http_host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Prefix /sandbox/$ins_id/$container_port;
+
+            # Rewrite root-relative Location headers and cookie Path values back
+            # under the /sandbox/<id>/<port>/ prefix so the client stays scoped.
+            proxy_redirect    ~^/(.*)$  /sandbox/$ins_id/$container_port/$1;
+            proxy_cookie_path /         /sandbox/$ins_id/$container_port/;
+
+            rewrite_by_lua_file lua/path_rewrite_phase.lua;
+
+            proxy_pass http://backend;
+
+            header_filter_by_lua_file lua/header_filter_phase.lua;
+
+            log_by_lua_file lua/log_phase.lua;
+        }
+
         location / {
             include /usr/local/openresty/nginx/conf/global/global.conf;
             set $cube_retcode "310200";
@@ -125,8 +168,51 @@ http {
         listen 8080 ssl reuseport;
         server_name _;
         set $cube_proxy_host_ip "";
+        # Populated by lua/path_rewrite_phase.lua for the /sandbox/<id>/<port>/ location.
+        # Declared at the server level so proxy_redirect / proxy_cookie_path can reference them.
+        set $ins_id "";
+        set $container_port "";
         ssl_certificate     /usr/local/openresty/nginx/certs/cube.app+3.pem;
         ssl_certificate_key /usr/local/openresty/nginx/certs/cube.app+3-key.pem;
+
+        # Path-based routing: /sandbox/<sandbox-id>/<container-port>/<rest>
+        # Lets clients reach a sandbox via a plain IP+port without wildcard DNS or TLS.
+        location ^~ /sandbox/ {
+            include /usr/local/openresty/nginx/conf/global/global.conf;
+            set $cube_retcode "310200";
+            set $garyscale_test "none";
+            set $backend_ip "";
+            set $backend_port "";
+            set $access_time "";
+            set $cache_free_space "";
+            set $host_proxy_port 8080;
+
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection "upgrade";
+
+            proxy_send_timeout 7206s;
+            proxy_read_timeout 7206s;
+            proxy_connect_timeout 3s;
+            proxy_set_header Host $http_host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Prefix /sandbox/$ins_id/$container_port;
+
+            # Rewrite root-relative Location headers and cookie Path values back
+            # under the /sandbox/<id>/<port>/ prefix so the client stays scoped.
+            proxy_redirect    ~^/(.*)$  /sandbox/$ins_id/$container_port/$1;
+            proxy_cookie_path /         /sandbox/$ins_id/$container_port/;
+
+            rewrite_by_lua_file lua/path_rewrite_phase.lua;
+
+            proxy_pass http://backend;
+
+            header_filter_by_lua_file lua/header_filter_phase.lua;
+
+            log_by_lua_file lua/log_phase.lua;
+        }
+
         location / {
             include /usr/local/openresty/nginx/conf/global/global.conf;
             set $cube_retcode "310200";

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -10,7 +10,7 @@ Cube Sandbox follows a clear layered architecture from top to bottom.
 
 1. **CubeAPI**: E2B-compatible REST API gateway. Switch from E2B Cloud to Cube Sandbox seamlessly by simply replacing environment variables such as the URL.
 2. **CubeMaster**: Orchestration scheduler that receives E2B API requests and dispatches them to the corresponding Cubelet, handling resource scheduling and cluster state management.
-3. **CubeProxy**: Reverse proxy and request routing component that parses the `<port>-<sandbox_id>.<domain>` format in the Host header to forward SDK client requests to the target sandbox instance.
+3. **CubeProxy**: Reverse proxy and request routing component. It supports two routing modes that share the same Redis-backed sandbox metadata: a host-based mode that parses `<port>-<sandbox_id>.<domain>` from the `Host` header, and a path-based mode that parses `/sandbox/<sandbox_id>/<port>/...` from the URL path (useful when wildcard DNS and TLS are inconvenient — see the [HTTPS & Domain guide](../guide/https-and-domain.md)).
 4. **Cubelet**: Node-local scheduling component that manages the full lifecycle of all sandbox instances on a single node.
 5. **CubeVS**: eBPF-based kernel-level packet forwarding, providing comprehensive network isolation and security policy enforcement.
 6. **CubeHypervisor & CubeShim**: The virtualization layer of Cube Sandbox. CubeHypervisor manages KVM MicroVMs, CubeShim implements the containerd Shim v2 API to integrate sandboxes into the container runtime.

--- a/docs/guide/https-and-domain.md
+++ b/docs/guide/https-and-domain.md
@@ -56,6 +56,39 @@ With this in place, the `domain` field in API responses will return `your.domain
 
 ---
 
+## Path-Based Quick Access (No DNS / Cert)
+
+CubeProxy also accepts a **path-based** form that routes by URL path instead of `Host` header. It is intended for local demos, internal ad-hoc sharing, or any environment where wildcard DNS and TLS are inconvenient to set up.
+
+```
+http://<cube-proxy-host>:<http-port>/sandbox/<sandbox-id>/<container-port>/<rest>?<query>
+```
+
+For example, a sandbox `abc123` exposing port `49999` reachable through CubeProxy at `10.0.0.5:80`:
+
+```
+http://10.0.0.5/sandbox/abc123/49999/
+http://10.0.0.5/sandbox/abc123/49999/health
+http://10.0.0.5/sandbox/abc123/49999/api/v1/items?limit=10
+```
+
+CubeProxy strips the `/sandbox/<id>/<port>` prefix before forwarding the request, so the upstream sandbox application sees the URI it would normally see at the root. WebSocket upgrade is supported (the proxy preserves the `Upgrade` / `Connection` headers in this location).
+
+To help apps cooperate with the prefix, CubeProxy also:
+
+- Sets `X-Forwarded-Prefix: /sandbox/<id>/<port>` on the upstream request.
+- Rewrites root-relative `Location` headers in responses back under `/sandbox/<id>/<port>/...` (so server-side redirects to e.g. `/login` keep working).
+- Scopes upstream cookies sent with `Path=/` to `Path=/sandbox/<id>/<port>/` to avoid leaking across sandboxes that share the same CubeProxy host.
+
+When to use which:
+
+- **Host-based mode** (`<port>-<id>.<domain>`): preferred for SPAs and any frontend that loads assets via root-absolute paths (e.g. `/static/app.js`). CubeProxy does not rewrite HTML bodies, so those absolute paths would otherwise miss the prefix.
+- **Path-based mode** (`/sandbox/<id>/<port>/...`): preferred for HTTP APIs, simple HTML, quick previews, and one-off sharing where you do not want to manage DNS or certificates.
+
+Both modes coexist on every CubeProxy instance and share the same Redis-backed routing metadata; no additional configuration is required to enable the path form.
+
+---
+
 ## HTTPS Certificate Configuration
 
 CubeProxy serves both **HTTPS (port 443) and HTTP (port 80)** out of the box. The E2B SDK uses HTTPS by default. The one-click install pre-installs a `cube.app` test certificate so you can try HTTPS immediately.

--- a/docs/zh/architecture/overview.md
+++ b/docs/zh/architecture/overview.md
@@ -10,7 +10,7 @@ Cube Sandbox 遵循清晰的自上而下分层架构。
 
 1. **CubeAPI**: 兼容 E2B REST API 网关，替换 URL 等环境变量即可从 E2B 云无缝切换到 Cube Sandbox。
 2. **CubeMaster**: 编排调度器，接收 E2B API 请求并分发到对应 Cubelet，负责资源调度、集群状态维护。
-3. **CubeProxy**: 反向代理与请求路由组件，通过解析 Host 头中 `<port>-<sandbox_id>.<domain>` 的格式，将来自 SDK 客户端的请求转发到对应的沙箱实例。
+3. **CubeProxy**: 反向代理与请求路由组件。支持两种路由模式，共享同一份 Redis 沙箱元数据：Host 模式解析 Host 头中的 `<port>-<sandbox_id>.<domain>`，路径模式解析 URL 中的 `/sandbox/<sandbox_id>/<port>/...`（在不便配置泛解析 DNS 与 TLS 时尤其方便，详见 [HTTPS 与域名指南](../guide/https-and-domain.md)）。
 4. **Cubelet**: 计算节点本地调度组件，管理单节点所有沙箱实例的完整生命周期。
 5. **CubeVS**: 基于 eBPF 内核态转发，网络层面提供完整的隔离机制与安全策略支持。
 6. **CubeHypervisor & CubeShim**: Cube 沙箱的虚拟化层。CubeHypervisor 负责管理 KVM MicroVM，CubeShim 实现 containerd Shim v2 接口，将沙箱集成到容器运行时。

--- a/docs/zh/guide/https-and-domain.md
+++ b/docs/zh/guide/https-and-domain.md
@@ -56,6 +56,39 @@ export CUBE_API_SANDBOX_DOMAIN=your.domain.com
 
 ---
 
+## 路径式快速访问（免 DNS / 免证书）
+
+除 Host 模式外，CubeProxy 还支持通过 URL **路径**路由到沙箱，适用于本地 Demo、内网临时分享，以及不便配置泛解析 DNS 和 TLS 证书的场景。
+
+```
+http://<cube-proxy-host>:<http-port>/sandbox/<sandbox-id>/<container-port>/<剩余路径>?<query>
+```
+
+例如，沙箱 `abc123` 暴露了 `49999` 端口，CubeProxy 部署在 `10.0.0.5:80`：
+
+```
+http://10.0.0.5/sandbox/abc123/49999/
+http://10.0.0.5/sandbox/abc123/49999/health
+http://10.0.0.5/sandbox/abc123/49999/api/v1/items?limit=10
+```
+
+CubeProxy 会在转发时剥离 `/sandbox/<id>/<port>` 前缀，沙箱内的应用看到的 URI 与从根路径直接访问相同。同一 location 内复用了原有的 `Upgrade` / `Connection` 头处理，因此 WebSocket 升级也照常工作。
+
+为方便应用与前缀协作，CubeProxy 额外会：
+
+- 在转发到上游的请求里附加 `X-Forwarded-Prefix: /sandbox/<id>/<port>`。
+- 改写响应中以根开头的 `Location` 头，把它重新放回 `/sandbox/<id>/<port>/...` 前缀下（比如上游返回 `Location: /login` 时仍能正确跳转）。
+- 把上游 Set-Cookie 中的 `Path=/` 限定到 `Path=/sandbox/<id>/<port>/`，避免与同一 CubeProxy 上其他沙箱的 cookie 相互影响。
+
+两种模式如何选择：
+
+- **Host 模式**（`<port>-<id>.<domain>`）：更适合 SPA 以及任何用根绝对路径加载静态资源（如 `/static/app.js`）的前端，CubeProxy 不会改写 HTML body，使用 Host 模式可以避免这类引用被前缀拦腰打断。
+- **路径模式**（`/sandbox/<id>/<port>/...`）：更适合 HTTP API、简单页面、快速预览和一次性分享，省去 DNS 和证书配置的成本。
+
+两种模式在每个 CubeProxy 实例上同时启用，共享同一份 Redis 路由元数据，无需额外配置即可使用路径形式。
+
+---
+
 ## HTTPS 证书配置
 
 CubeProxy 开箱提供 **HTTPS（443 端口）和 HTTP（80 端口）** 两种访问方式。E2B SDK 默认使用 HTTPS。Cube 一键安装已预装 `cube.app` 测试证书，可直接体验 HTTPS。


### PR DESCRIPTION
**CubeProxy**: Reverse proxy and request routing component. It supports two routing modes that share the same Redis-backed sandbox metadata: a host-based mode that parses `<port>-<sandbox_id>.<domain>` from the `Host` header, and a path-based mode that parses `/sandbox/<sandbox_id>/<port>/...` from the URL path (useful when wildcard DNS and TLS are inconvenient)

- Introduce`/sandbox/<id>/<port>/...`path-based routing in CubeProxy
- Extract backend resolution and health check into reusable`sandbox_backend.lua`
- Update nginx.conf with new location for both HTTP and HTTPS listeners
- Document the new routing mode in architecture overview and user guides (en/zh)