### PR TITLE
fix(template-commit): enforce requestID uniqueness and add idempotent commit resue

### DIFF
--- a/CubeMaster/pkg/service/httpservice/cube/template_commit.go
+++ b/CubeMaster/pkg/service/httpservice/cube/template_commit.go
@@ -127,13 +127,8 @@ func handleSandboxCommitAction(w http.ResponseWriter, r *http.Request, rt *CubeL
 	}))
 	job, err := templatecenter.SubmitTemplateCommit(ctx, req.SandboxID, hostID, hostIP, req.CreateRequest)
 	if err != nil {
-		code := int(errorcode.ErrorCode_MasterInternalError)
-		switch {
-		case errors.Is(err, templatecenter.ErrTemplateIDRequired), errors.Is(err, templatecenter.ErrDuplicateTemplate):
-			code = int(errorcode.ErrorCode_MasterParamsError)
-		case errors.Is(err, templatecenter.ErrTemplateStoreNotInitialized):
-			code = int(errorcode.ErrorCode_DBError)
-		}
+		code := commitTemplateErrorCode(err)
+		rt.RetCode = int64(code)
 		return &commitTemplateResponse{
 			Res: &types.Res{
 				RequestID: req.RequestID,
@@ -151,6 +146,19 @@ func handleSandboxCommitAction(w http.ResponseWriter, r *http.Request, rt *CubeL
 		},
 		TemplateID: req.TemplateID,
 		BuildID:    job.JobID,
+	}
+}
+
+func commitTemplateErrorCode(err error) int {
+	switch {
+	case errors.Is(err, templatecenter.ErrTemplateIDRequired),
+		errors.Is(err, templatecenter.ErrDuplicateTemplate),
+		errors.Is(err, templatecenter.ErrTemplateAttemptInProgress):
+		return int(errorcode.ErrorCode_MasterParamsError)
+	case errors.Is(err, templatecenter.ErrTemplateStoreNotInitialized):
+		return int(errorcode.ErrorCode_DBError)
+	default:
+		return int(errorcode.ErrorCode_MasterInternalError)
 	}
 }
 

--- a/CubeMaster/pkg/service/httpservice/cube/template_commit.go
+++ b/CubeMaster/pkg/service/httpservice/cube/template_commit.go
@@ -60,6 +60,15 @@ func handleSandboxCommitAction(w http.ResponseWriter, r *http.Request, rt *CubeL
 			}},
 		}
 	}
+	if strings.TrimSpace(req.RequestID) == "" {
+		return &commitTemplateResponse{
+			Res: &types.Res{Ret: &types.Ret{
+				RetCode: int(errorcode.ErrorCode_MasterParamsError),
+				RetMsg:  "requestID is required for commit; retry should generate a new request id",
+			}},
+			TemplateID: req.TemplateID,
+		}
+	}
 	if req.CreateRequest.Request == nil {
 		req.CreateRequest.Request = &types.Request{RequestID: req.RequestID}
 	}

--- a/CubeMaster/pkg/service/httpservice/cube/template_commit_test.go
+++ b/CubeMaster/pkg/service/httpservice/cube/template_commit_test.go
@@ -1,0 +1,58 @@
+// Copyright (c) 2024 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package cube
+
+import (
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/errorcode"
+	CubeLog "github.com/tencentcloud/CubeSandbox/cubelog"
+)
+
+func TestHandleSandboxCommitActionRejectsEmptyRequestID(t *testing.T) {
+	body := `{
+		"sandbox_id":"sb-1",
+		"template_id":"tpl-1",
+		"create_request":{
+			"instance_type":"cubebox",
+			"network_type":"tap",
+			"annotations":{
+				"cube.master.appsnapshot.template.id":"tpl-1",
+				"cube.master.appsnapshot.template.version":"v2"
+			}
+		}
+	}`
+	req := httptest.NewRequest("POST", "/cube/sandbox/commit", strings.NewReader(body))
+	rt := &CubeLog.RequestTrace{}
+	resp := handleSandboxCommitAction(httptest.NewRecorder(), req, rt)
+
+	got, ok := resp.(*commitTemplateResponse)
+	if !ok {
+		t.Fatalf("unexpected response type %T", resp)
+	}
+	if got.Res == nil || got.Res.Ret == nil {
+		t.Fatalf("missing Ret in response: %#v", got)
+	}
+	assert.Equal(t, int(errorcode.ErrorCode_MasterParamsError), got.Res.Ret.RetCode)
+	assert.Contains(t, got.Res.Ret.RetMsg, "requestID is required")
+	assert.Equal(t, "tpl-1", got.TemplateID)
+}
+
+func TestHandleSandboxCommitActionRejectsMissingFields(t *testing.T) {
+	body := `{"requestID":"req-1"}`
+	req := httptest.NewRequest("POST", "/cube/sandbox/commit", strings.NewReader(body))
+	rt := &CubeLog.RequestTrace{}
+	resp := handleSandboxCommitAction(httptest.NewRecorder(), req, rt)
+
+	got, ok := resp.(*commitTemplateResponse)
+	if !ok {
+		t.Fatalf("unexpected response type %T", resp)
+	}
+	assert.Equal(t, int(errorcode.ErrorCode_MasterParamsError), got.Res.Ret.RetCode)
+	assert.Contains(t, got.Res.Ret.RetMsg, "sandbox_id, template_id and create_request are required")
+}

--- a/CubeMaster/pkg/service/httpservice/cube/template_commit_test.go
+++ b/CubeMaster/pkg/service/httpservice/cube/template_commit_test.go
@@ -5,12 +5,14 @@
 package cube
 
 import (
+	"fmt"
 	"net/http/httptest"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/errorcode"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/templatecenter"
 	CubeLog "github.com/tencentcloud/CubeSandbox/cubelog"
 )
 
@@ -55,4 +57,43 @@ func TestHandleSandboxCommitActionRejectsMissingFields(t *testing.T) {
 	}
 	assert.Equal(t, int(errorcode.ErrorCode_MasterParamsError), got.Res.Ret.RetCode)
 	assert.Contains(t, got.Res.Ret.RetMsg, "sandbox_id, template_id and create_request are required")
+}
+
+func TestCommitTemplateErrorCode(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want int
+	}{
+		{
+			name: "template id required is params error",
+			err:  templatecenter.ErrTemplateIDRequired,
+			want: int(errorcode.ErrorCode_MasterParamsError),
+		},
+		{
+			name: "duplicate template is params error",
+			err:  templatecenter.ErrDuplicateTemplate,
+			want: int(errorcode.ErrorCode_MasterParamsError),
+		},
+		{
+			name: "attempt in progress is params error",
+			err:  fmt.Errorf("commit conflict: %w", templatecenter.ErrTemplateAttemptInProgress),
+			want: int(errorcode.ErrorCode_MasterParamsError),
+		},
+		{
+			name: "store not initialized is db error",
+			err:  templatecenter.ErrTemplateStoreNotInitialized,
+			want: int(errorcode.ErrorCode_DBError),
+		},
+		{
+			name: "unknown error is internal error",
+			err:  fmt.Errorf("unexpected"),
+			want: int(errorcode.ErrorCode_MasterInternalError),
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, commitTemplateErrorCode(tc.err))
+		})
+	}
 }

--- a/CubeMaster/pkg/templatecenter/template_commit.go
+++ b/CubeMaster/pkg/templatecenter/template_commit.go
@@ -30,6 +30,10 @@ func SubmitTemplateCommit(ctx context.Context, sandboxID, nodeID, nodeIP string,
 	if !isReady() {
 		return nil, ErrTemplateStoreNotInitialized
 	}
+	if req == nil || req.Request == nil || strings.TrimSpace(req.RequestID) == "" {
+		return nil, errors.New("requestID is required for commit; retry should generate a new request id")
+	}
+	requestID := strings.TrimSpace(req.RequestID)
 	createReq, templateID, err := NormalizeRequest(req)
 	if err != nil {
 		return nil, err
@@ -47,6 +51,19 @@ func SubmitTemplateCommit(ctx context.Context, sandboxID, nodeID, nodeIP string,
 	retryOfJobID := ""
 	reusedExistingJob := false
 	if err := withTemplateWriteLock(templateID, func() error {
+		// Idempotency: the same (request_id, COMMIT) tuple uniquely identifies a
+		// commit attempt. Reuse a prior job when payload matches; reject on drift.
+		if job, err := getTemplateImageJobByRequestOperation(ctx, requestID, JobOperationCommit); err == nil {
+			if job.RequestJSON == requestSnapshot {
+				jobID = job.JobID
+				reusedExistingJob = true
+				return nil
+			}
+			return fmt.Errorf("%w: request_id=%s already used with a different commit payload (job_id=%s)", ErrTemplateAttemptInProgress, requestID, job.JobID)
+		} else if !errors.Is(err, gorm.ErrRecordNotFound) {
+			return err
+		}
+
 		definitionFailed := false
 		if def, err := GetDefinition(ctx, templateID); err == nil {
 			if strings.EqualFold(def.Status, StatusFailed) {
@@ -86,28 +103,26 @@ func SubmitTemplateCommit(ctx context.Context, sandboxID, nodeID, nodeIP string,
 		}
 
 		if latestJob != nil {
-			attemptNo = latestJob.AttemptNo + 1
-			if attemptNo <= 1 {
-				attemptNo = 2
-			}
+			attemptNo = nextAttemptNoFromLatest(latestJob.AttemptNo)
 			retryOfJobID = latestJob.JobID
 		}
-		record := &models.TemplateImageJob{
-			JobID:                   jobID,
-			TemplateID:              templateID,
-			AttemptNo:               attemptNo,
-			RetryOfJobID:            retryOfJobID,
-			NodeID:                  nodeID,
-			NodeIP:                  nodeIP,
-			TemplateSpecFingerprint: buildCommitTemplateSpecFingerprint(storedReq),
-			InstanceType:            createReq.InstanceType,
-			NetworkType:             createReq.NetworkType,
-			Status:                  JobStatusPending,
-			Phase:                   JobPhaseSnapshotting,
-			Progress:                0,
-			RequestJSON:             requestSnapshot,
+		record := newCommitTemplateImageJobRecord(jobID, requestID, templateID, nodeID, nodeIP, storedReq, createReq, requestSnapshot, attemptNo, retryOfJobID)
+		if createErr := store.db.WithContext(ctx).Table(constants.TemplateImageJobTableName).Create(record).Error; createErr != nil {
+			// Concurrent writer may have inserted the same (request_id, COMMIT)
+			// tuple between our lookup and create. Fall back to idempotent reuse.
+			if isDuplicateKeyError(createErr) {
+				if job, lookupErr := getTemplateImageJobByRequestOperation(ctx, requestID, JobOperationCommit); lookupErr == nil {
+					if job.RequestJSON == requestSnapshot {
+						jobID = job.JobID
+						reusedExistingJob = true
+						return nil
+					}
+					return fmt.Errorf("%w: request_id=%s already used with a different commit payload (job_id=%s)", ErrTemplateAttemptInProgress, requestID, job.JobID)
+				}
+			}
+			return createErr
 		}
-		return store.db.WithContext(ctx).Table(constants.TemplateImageJobTableName).Create(record).Error
+		return nil
 	}); err != nil {
 		return nil, err
 	}
@@ -259,4 +274,52 @@ func max(a, b int32) int32 {
 		return a
 	}
 	return b
+}
+
+func newCommitTemplateImageJobRecord(
+	jobID, requestID, templateID, nodeID, nodeIP string,
+	storedReq, createReq *sandboxtypes.CreateCubeSandboxReq,
+	requestSnapshot string,
+	attemptNo int32,
+	retryOfJobID string,
+) *models.TemplateImageJob {
+	return &models.TemplateImageJob{
+		JobID:                   jobID,
+		TemplateID:              templateID,
+		RequestID:               requestID,
+		AttemptNo:               attemptNo,
+		RetryOfJobID:            retryOfJobID,
+		Operation:               JobOperationCommit,
+		NodeID:                  nodeID,
+		NodeIP:                  nodeIP,
+		TemplateSpecFingerprint: buildCommitTemplateSpecFingerprint(storedReq),
+		InstanceType:            createReq.InstanceType,
+		NetworkType:             createReq.NetworkType,
+		Status:                  JobStatusPending,
+		Phase:                   JobPhaseSnapshotting,
+		Progress:                0,
+		RequestJSON:             requestSnapshot,
+	}
+}
+
+func getTemplateImageJobByRequestOperation(ctx context.Context, requestID, operation string) (*models.TemplateImageJob, error) {
+	record := &models.TemplateImageJob{}
+	err := store.db.WithContext(ctx).Table(constants.TemplateImageJobTableName).
+		Where("request_id = ? AND operation = ?", requestID, operation).
+		Order("id desc").First(record).Error
+	if err != nil {
+		return nil, err
+	}
+	return record, nil
+}
+
+func isDuplicateKeyError(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, gorm.ErrDuplicatedKey) {
+		return true
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "Duplicate entry") || strings.Contains(msg, "1062")
 }

--- a/CubeMaster/pkg/templatecenter/template_commit.go
+++ b/CubeMaster/pkg/templatecenter/template_commit.go
@@ -121,7 +121,7 @@ func SubmitTemplateCommit(ctx context.Context, sandboxID, nodeID, nodeIP string,
 			attemptNo = nextAttemptNoFromLatest(latestJob.AttemptNo)
 			retryOfJobID = latestJob.JobID
 		}
-		record := newCommitTemplateImageJobRecord(jobID, requestID, templateID, nodeID, nodeIP, storedReq, createReq, requestSnapshot, attemptNo, retryOfJobID)
+		record := newCommitTemplateImageJobRecord(jobID, requestID, templateID, nodeID, nodeIP, createReq, requestSnapshot, attemptNo, retryOfJobID)
 		if createErr := store.db.WithContext(ctx).Table(constants.TemplateImageJobTableName).Create(record).Error; createErr != nil {
 			// Concurrent writer may have inserted the same (request_id, COMMIT)
 			// tuple between our lookup and create. Fall back to idempotent reuse.
@@ -346,7 +346,7 @@ func buildCommitFailureMessage(commitRsp *cubeboxv1.CommitSandboxResponse) strin
 
 func newCommitTemplateImageJobRecord(
 	jobID, requestID, templateID, nodeID, nodeIP string,
-	storedReq, createReq *sandboxtypes.CreateCubeSandboxReq,
+	createReq *sandboxtypes.CreateCubeSandboxReq,
 	requestSnapshot string,
 	attemptNo int32,
 	retryOfJobID string,
@@ -360,7 +360,7 @@ func newCommitTemplateImageJobRecord(
 		Operation:               JobOperationCommit,
 		NodeID:                  nodeID,
 		NodeIP:                  nodeIP,
-		TemplateSpecFingerprint: buildCommitTemplateSpecFingerprint(storedReq),
+		TemplateSpecFingerprint: buildCommitTemplateSpecFingerprintFromSnapshot(requestSnapshot),
 		InstanceType:            createReq.InstanceType,
 		NetworkType:             createReq.NetworkType,
 		Status:                  JobStatusPending,

--- a/CubeMaster/pkg/templatecenter/template_commit.go
+++ b/CubeMaster/pkg/templatecenter/template_commit.go
@@ -8,7 +8,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"runtime/debug"
 	"strings"
+	"time"
 
 	"github.com/google/uuid"
 	cubeboxv1 "github.com/tencentcloud/CubeSandbox/CubeMaster/api/services/cubebox/v1"
@@ -16,10 +18,23 @@ import (
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/db/models"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/log"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/cubelet"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/errorcode"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/localcache"
 	sandboxtypes "github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/service/sandbox/types"
 	"gorm.io/gorm"
 )
+
+// commitSandboxRPCTimeout caps how long runTemplateCommitJob waits on the
+// cubelet CommitSandbox RPC. The detached background context has no deadline
+// of its own, so a hung cubelet would otherwise leave the job stuck in
+// SNAPSHOTTING forever. Typical successful snapshots complete in 5-15s; the
+// generous 5 minute ceiling accommodates large memory footprints while still
+// guaranteeing eventual failure resolution.
+const commitSandboxRPCTimeout = 5 * time.Minute
+
+// cleanupTemplateRPCTimeout bounds the best-effort cleanup RPC used when the
+// commit job rolls back after a partial success.
+const cleanupTemplateRPCTimeout = 1 * time.Minute
 
 const (
 	JobPhaseSnapshotting = "SNAPSHOTTING"
@@ -130,7 +145,14 @@ func SubmitTemplateCommit(ctx context.Context, sandboxID, nodeID, nodeIP string,
 		return GetTemplateImageJobInfo(ctx, jobID)
 	}
 
-	runTemplateCommitJob(detachTemplateImageJobContext(ctx, map[string]any{
+	// runTemplateCommitJob historically ran synchronously on the HTTP handler
+	// goroutine, which (a) blocked the caller for the full snapshot duration
+	// (≈10–30s for a 2C2000M sandbox) defeating the asynchronous build_id +
+	// poll contract introduced by PR #227, and (b) made any panic inside the
+	// job invisible to the response. Match the sibling SubmitTemplateImage()
+	// path: detach the context (so HTTP client disconnects do not cancel the
+	// background work) and dispatch onto a fresh goroutine.
+	go runTemplateCommitJob(detachTemplateImageJobContext(ctx, map[string]any{
 		"job_id":          jobID,
 		"template_id":     templateID,
 		"attempt_no":      attemptNo,
@@ -152,37 +174,55 @@ func runTemplateCommitJob(ctx context.Context, jobID, sandboxID, nodeID, nodeIP 
 		"node_id":     nodeID,
 		"node_ip":     nodeIP,
 	})
+	defer func() {
+		if r := recover(); r != nil {
+			stack := string(debug.Stack())
+			logger.Errorf("template commit job panic: %v\n%s", r, stack)
+			_ = updateTemplateImageJob(ctx, jobID, map[string]any{
+				"status":        JobStatusFailed,
+				"phase":         JobPhaseSnapshotting,
+				"progress":      100,
+				"error_message": fmt.Sprintf("template commit job panic: %v", r),
+			})
+		}
+	}()
 	_ = updateTemplateImageJob(ctx, jobID, map[string]any{
 		"status":   JobStatusRunning,
 		"phase":    JobPhaseSnapshotting,
 		"progress": 10,
 	})
 
-	commitRsp, err := cubelet.CommitSandbox(ctx, cubelet.GetCubeletAddr(nodeIP), &cubeboxv1.CommitSandboxRequest{
+	commitCtx, commitCancel := context.WithTimeout(ctx, commitSandboxRPCTimeout)
+	commitRsp, err := cubelet.CommitSandbox(commitCtx, cubelet.GetCubeletAddr(nodeIP), &cubeboxv1.CommitSandboxRequest{
 		RequestID:   uuid.NewString(),
 		SandboxID:   sandboxID,
 		TemplateID:  templateID,
 		SnapshotDir: createReq.SnapshotDir,
 	})
+	commitCancel()
 	if err != nil {
+		errMsg := fmt.Sprintf("cubelet CommitSandbox transport error: %v", err)
+		logger.Errorf("%s", errMsg)
 		_ = updateTemplateImageJob(ctx, jobID, map[string]any{
 			"status":        JobStatusFailed,
 			"phase":         JobPhaseSnapshotting,
 			"progress":      100,
-			"error_message": err.Error(),
+			"error_message": errMsg,
 		})
 		return
 	}
-	if commitRsp.GetRet() == nil || commitRsp.GetRet().GetRetCode() != 0 {
-		msg := "commit sandbox failed"
-		if commitRsp.GetRet() != nil {
-			msg = commitRsp.GetRet().GetRetMsg()
-		}
+	// Cubelet returns errorcode.ErrorCode_Success (=200) on success, not 0.
+	// All other call sites in CubeMaster compare against int(ErrorCode_Success);
+	// this site is the only one that historically wrote `!= 0`, which silently
+	// flipped every successful commit into a FAILED job with empty error_message.
+	if ret := commitRsp.GetRet(); ret == nil || int(ret.GetRetCode()) != int(errorcode.ErrorCode_Success) {
+		errMsg := buildCommitFailureMessage(commitRsp)
+		logger.Errorf("cubelet CommitSandbox returned non-success: %s snapshot_path=%q", errMsg, commitRsp.GetSnapshotPath())
 		_ = updateTemplateImageJob(ctx, jobID, map[string]any{
 			"status":        JobStatusFailed,
 			"phase":         JobPhaseSnapshotting,
 			"progress":      100,
-			"error_message": msg,
+			"error_message": errMsg,
 		})
 		return
 	}
@@ -198,12 +238,18 @@ func runTemplateCommitJob(ctx context.Context, jobID, sandboxID, nodeID, nodeIP 
 
 	definitionCreated := false
 	cleanupOnFailure := func(cause error) {
+		if cause == nil {
+			cause = errors.New("template commit job failed: unknown cause")
+		}
 		if snapshotPath != "" {
-			if _, cleanupErr := cubelet.CleanupTemplate(ctx, cubelet.GetCubeletAddr(nodeIP), &cubeboxv1.CleanupTemplateRequest{
+			cleanupCtx, cleanupCancel := context.WithTimeout(ctx, cleanupTemplateRPCTimeout)
+			_, cleanupErr := cubelet.CleanupTemplate(cleanupCtx, cubelet.GetCubeletAddr(nodeIP), &cubeboxv1.CleanupTemplateRequest{
 				RequestID:    uuid.NewString(),
 				TemplateID:   templateID,
 				SnapshotPath: snapshotPath,
-			}); cleanupErr != nil {
+			})
+			cleanupCancel()
+			if cleanupErr != nil {
 				cause = errors.Join(cause, cleanupErr)
 			}
 		}
@@ -212,6 +258,7 @@ func runTemplateCommitJob(ctx context.Context, jobID, sandboxID, nodeID, nodeIP 
 				cause = errors.Join(cause, cleanupErr)
 			}
 		}
+		logger.Errorf("template commit job rolling back to FAILED: %v", cause)
 		_ = updateTemplateImageJob(ctx, jobID, map[string]any{
 			"status":          JobStatusFailed,
 			"phase":           JobPhaseRegistering,
@@ -274,6 +321,27 @@ func max(a, b int32) int32 {
 		return a
 	}
 	return b
+}
+
+// buildCommitFailureMessage produces a never-empty error message for the failure
+// branch of runTemplateCommitJob. Cubelet's CommitSandbox sometimes returns a
+// non-success Ret with empty RetMsg; the previous implementation silently
+// overwrote the fallback message with that empty string and stored an empty
+// error_message in t_cube_template_image_job, making post-mortem impossible.
+func buildCommitFailureMessage(commitRsp *cubeboxv1.CommitSandboxResponse) string {
+	if commitRsp == nil {
+		return "commit sandbox failed: cubelet returned nil response"
+	}
+	ret := commitRsp.GetRet()
+	if ret == nil {
+		return "commit sandbox failed: cubelet returned empty Ret"
+	}
+	retCode := int(ret.GetRetCode())
+	retMsg := strings.TrimSpace(ret.GetRetMsg())
+	if retMsg == "" {
+		return fmt.Sprintf("commit sandbox failed: retCode=%d (empty retMsg)", retCode)
+	}
+	return fmt.Sprintf("commit sandbox failed: retCode=%d retMsg=%s", retCode, retMsg)
 }
 
 func newCommitTemplateImageJobRecord(

--- a/CubeMaster/pkg/templatecenter/template_commit_test.go
+++ b/CubeMaster/pkg/templatecenter/template_commit_test.go
@@ -1,0 +1,134 @@
+// Copyright (c) 2024 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package templatecenter
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	cubeboxv1 "github.com/tencentcloud/CubeSandbox/CubeMaster/api/services/cubebox/v1"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/constants"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/service/sandbox/types"
+	"gorm.io/gorm"
+)
+
+func newCommitFixtureRequests() (*types.CreateCubeSandboxReq, *types.CreateCubeSandboxReq) {
+	createReq := &types.CreateCubeSandboxReq{
+		Request:      &types.Request{RequestID: "req-1"},
+		InstanceType: cubeboxv1.InstanceType_cubebox.String(),
+		NetworkType:  cubeboxv1.NetworkType_tap.String(),
+		Annotations: map[string]string{
+			constants.CubeAnnotationAppSnapshotTemplateID:      "tpl-commit-1",
+			constants.CubeAnnotationAppSnapshotTemplateVersion: DefaultTemplateVersion,
+		},
+	}
+	storedReq := *createReq
+	storedReq.Request = nil
+	return createReq, &storedReq
+}
+
+func TestNewCommitTemplateImageJobRecordPersistsIdentityFields(t *testing.T) {
+	createReq, storedReq := newCommitFixtureRequests()
+	record := newCommitTemplateImageJobRecord(
+		"job-commit-1",
+		"req-123",
+		"tpl-commit-1",
+		"node-a",
+		"10.0.0.1",
+		storedReq,
+		createReq,
+		`{"template_id":"tpl-commit-1"}`,
+		2,
+		"job-prev",
+	)
+	if record.RequestID != "req-123" {
+		t.Fatalf("RequestID=%q, want %q", record.RequestID, "req-123")
+	}
+	if record.Operation != JobOperationCommit {
+		t.Fatalf("Operation=%q, want %q", record.Operation, JobOperationCommit)
+	}
+	if record.NodeID != "node-a" || record.NodeIP != "10.0.0.1" {
+		t.Fatalf("Node identity not persisted: %#v", record)
+	}
+	if record.AttemptNo != 2 || record.RetryOfJobID != "job-prev" {
+		t.Fatalf("Attempt metadata not persisted: %+v", record)
+	}
+	if record.TemplateSpecFingerprint == "" {
+		t.Fatal("TemplateSpecFingerprint should be populated for commit jobs")
+	}
+	if record.Status != JobStatusPending || record.Phase != JobPhaseSnapshotting {
+		t.Fatalf("unexpected initial state: status=%q phase=%q", record.Status, record.Phase)
+	}
+}
+
+func TestIsDuplicateKeyErrorClassifiesMySQLAndGormErrors(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"gorm duplicated key sentinel", gorm.ErrDuplicatedKey, true},
+		{"raw mysql 1062 text", errors.New("Error 1062 (23000): Duplicate entry '' for key 'idx_x'"), true},
+		{"just contains 1062", errors.New("driver: 1062 conflict"), true},
+		{"contains Duplicate entry", errors.New("Duplicate entry 'x' for key 'idx_y'"), true},
+		{"unrelated error", errors.New("some other failure"), false},
+	}
+	for _, tc := range tests {
+		if got := isDuplicateKeyError(tc.err); got != tc.want {
+			t.Fatalf("%s: isDuplicateKeyError(%v)=%v, want %v", tc.name, tc.err, got, tc.want)
+		}
+	}
+}
+
+func TestInferLegacyJobOperationCoversAllShapes(t *testing.T) {
+	tests := []struct {
+		name           string
+		nodeID         string
+		sourceImageRef string
+		retryOfJobID   string
+		want           string
+	}{
+		{"commit row has node but no source image", "node-a", "", "", JobOperationCommit},
+		{"create row has source image without retry parent", "", "docker.io/nginx", "", JobOperationCreate},
+		{"redo row has source image and retry parent", "", "docker.io/nginx", "job-prev", JobOperationRedo},
+		{"fallback when nothing matches", "", "", "", JobOperationLegacy},
+	}
+	for _, tc := range tests {
+		if got := inferLegacyJobOperation(tc.nodeID, tc.sourceImageRef, tc.retryOfJobID); got != tc.want {
+			t.Fatalf("%s: inferLegacyJobOperation()=%q, want %q", tc.name, got, tc.want)
+		}
+	}
+}
+
+func TestSubmitTemplateCommitRejectsEmptyRequestID(t *testing.T) {
+	// Pretend the store is initialised so we exercise the requestID guard
+	// instead of the "store not initialised" early return.
+	origDB := store.db
+	store.db = &gorm.DB{}
+	defer func() { store.db = origDB }()
+
+	tests := []struct {
+		name string
+		req  *types.CreateCubeSandboxReq
+	}{
+		{"nil request", nil},
+		{"missing Request envelope", &types.CreateCubeSandboxReq{}},
+		{
+			name: "empty request id",
+			req: &types.CreateCubeSandboxReq{
+				Request: &types.Request{RequestID: "   "},
+			},
+		},
+	}
+	for _, tc := range tests {
+		_, err := SubmitTemplateCommit(context.Background(), "sb-1", "node-a", "10.0.0.1", tc.req)
+		if err == nil || !strings.Contains(err.Error(), "requestID is required") {
+			t.Fatalf("%s: expected requestID guard error, got %v", tc.name, err)
+		}
+	}
+}

--- a/CubeMaster/pkg/templatecenter/template_commit_test.go
+++ b/CubeMaster/pkg/templatecenter/template_commit_test.go
@@ -34,15 +34,18 @@ func newCommitFixtureRequests() (*types.CreateCubeSandboxReq, *types.CreateCubeS
 
 func TestNewCommitTemplateImageJobRecordPersistsIdentityFields(t *testing.T) {
 	createReq, storedReq := newCommitFixtureRequests()
+	requestSnapshot, err := marshalTemplateCommitJobRequest(storedReq)
+	if err != nil {
+		t.Fatalf("marshalTemplateCommitJobRequest failed: %v", err)
+	}
 	record := newCommitTemplateImageJobRecord(
 		"job-commit-1",
 		"req-123",
 		"tpl-commit-1",
 		"node-a",
 		"10.0.0.1",
-		storedReq,
 		createReq,
-		`{"template_id":"tpl-commit-1"}`,
+		requestSnapshot,
 		2,
 		"job-prev",
 	)
@@ -60,6 +63,9 @@ func TestNewCommitTemplateImageJobRecordPersistsIdentityFields(t *testing.T) {
 	}
 	if record.TemplateSpecFingerprint == "" {
 		t.Fatal("TemplateSpecFingerprint should be populated for commit jobs")
+	}
+	if record.TemplateSpecFingerprint != buildCommitTemplateSpecFingerprintFromSnapshot(requestSnapshot) {
+		t.Fatalf("TemplateSpecFingerprint=%q, want fingerprint from request snapshot", record.TemplateSpecFingerprint)
 	}
 	if record.Status != JobStatusPending || record.Phase != JobPhaseSnapshotting {
 		t.Fatalf("unexpected initial state: status=%q phase=%q", record.Status, record.Phase)
@@ -149,15 +155,17 @@ func TestBuildCommitFailureMessageNeverEmpty(t *testing.T) {
 		},
 	}
 	for _, tc := range tests {
-		got := buildCommitFailureMessage(tc.rsp)
-		if got == "" {
-			t.Fatalf("%s: error_message must never be empty", tc.name)
-		}
-		for _, part := range tc.wantParts {
-			if !strings.Contains(got, part) {
-				t.Fatalf("%s: missing %q in %q", tc.name, part, got)
+		t.Run(tc.name, func(t *testing.T) {
+			got := buildCommitFailureMessage(tc.rsp)
+			if got == "" {
+				t.Fatal("error_message must never be empty")
 			}
-		}
+			for _, part := range tc.wantParts {
+				if !strings.Contains(got, part) {
+					t.Fatalf("missing %q in %q", part, got)
+				}
+			}
+		})
 	}
 }
 

--- a/CubeMaster/pkg/templatecenter/template_commit_test.go
+++ b/CubeMaster/pkg/templatecenter/template_commit_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	cubeboxv1 "github.com/tencentcloud/CubeSandbox/CubeMaster/api/services/cubebox/v1"
+	errorcodev1 "github.com/tencentcloud/CubeSandbox/CubeMaster/api/services/errorcode/v1"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/constants"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/service/sandbox/types"
 	"gorm.io/gorm"
@@ -101,6 +102,61 @@ func TestInferLegacyJobOperationCoversAllShapes(t *testing.T) {
 	for _, tc := range tests {
 		if got := inferLegacyJobOperation(tc.nodeID, tc.sourceImageRef, tc.retryOfJobID); got != tc.want {
 			t.Fatalf("%s: inferLegacyJobOperation()=%q, want %q", tc.name, got, tc.want)
+		}
+	}
+}
+
+// TestBuildCommitFailureMessageNeverEmpty pins the regression that produced
+// FAILED jobs with empty error_message: when cubelet returned a non-success Ret
+// without filling RetMsg (or returned nil Ret entirely), the previous code path
+// stored "" in t_cube_template_image_job, defeating post-mortem.
+func TestBuildCommitFailureMessageNeverEmpty(t *testing.T) {
+	tests := []struct {
+		name      string
+		rsp       *cubeboxv1.CommitSandboxResponse
+		wantParts []string
+	}{
+		{
+			name:      "nil response",
+			rsp:       nil,
+			wantParts: []string{"commit sandbox failed", "nil response"},
+		},
+		{
+			name:      "nil Ret",
+			rsp:       &cubeboxv1.CommitSandboxResponse{},
+			wantParts: []string{"commit sandbox failed", "empty Ret"},
+		},
+		{
+			name: "non-success code with empty retMsg",
+			rsp: &cubeboxv1.CommitSandboxResponse{
+				Ret: &errorcodev1.Ret{RetCode: 500, RetMsg: ""},
+			},
+			wantParts: []string{"commit sandbox failed", "retCode=500", "empty retMsg"},
+		},
+		{
+			name: "non-success code with retMsg",
+			rsp: &cubeboxv1.CommitSandboxResponse{
+				Ret: &errorcodev1.Ret{RetCode: 500, RetMsg: "snapshot timed out"},
+			},
+			wantParts: []string{"commit sandbox failed", "retCode=500", "snapshot timed out"},
+		},
+		{
+			name: "non-success code with whitespace-only retMsg is treated as empty",
+			rsp: &cubeboxv1.CommitSandboxResponse{
+				Ret: &errorcodev1.Ret{RetCode: 130599, RetMsg: "   \t\n"},
+			},
+			wantParts: []string{"commit sandbox failed", "retCode=130599", "empty retMsg"},
+		},
+	}
+	for _, tc := range tests {
+		got := buildCommitFailureMessage(tc.rsp)
+		if got == "" {
+			t.Fatalf("%s: error_message must never be empty", tc.name)
+		}
+		for _, part := range tc.wantParts {
+			if !strings.Contains(got, part) {
+				t.Fatalf("%s: missing %q in %q", tc.name, part, got)
+			}
 		}
 	}
 }

--- a/CubeMaster/pkg/templatecenter/template_image.go
+++ b/CubeMaster/pkg/templatecenter/template_image.go
@@ -51,6 +51,8 @@ const (
 
 	JobOperationCreate = "CREATE"
 	JobOperationRedo   = "REDO"
+	JobOperationCommit = "COMMIT"
+	JobOperationLegacy = "LEGACY"
 
 	RedoModeAll         = "ALL"
 	RedoModeNodes       = "NODES"
@@ -280,13 +282,16 @@ func migrateTemplateImageJobTable(client *gorm.DB, tableName string) error {
 
 func normalizeTemplateImageJobRequestIDs(client *gorm.DB, tableName string) error {
 	type requestBinding struct {
-		JobID     string
-		RequestID string
-		Operation string
+		JobID          string
+		RequestID      string
+		Operation      string
+		NodeID         string
+		SourceImageRef string
+		RetryOfJobID   string
 	}
 	var bindings []requestBinding
 	if err := client.Table(tableName).
-		Select("job_id, request_id, operation").
+		Select("job_id, request_id, operation, node_id, source_image_ref, retry_of_job_id").
 		Order("id asc").
 		Find(&bindings).Error; err != nil {
 		return err
@@ -299,21 +304,50 @@ func normalizeTemplateImageJobRequestIDs(client *gorm.DB, tableName string) erro
 		}
 		requestID := strings.TrimSpace(binding.RequestID)
 		operation := strings.TrimSpace(binding.Operation)
-		normalized := requestID
+		normalizedRequest := requestID
+		normalizedOperation := operation
 		switch {
-		case normalized == "":
-			normalized = legacyRequestIDPrefix + jobID
-		case hasSeenRequestBinding(seen, normalized, operation):
-			normalized = normalized + "#" + jobID
+		case normalizedRequest == "":
+			normalizedRequest = legacyRequestIDPrefix + jobID
+		case hasSeenRequestBinding(seen, normalizedRequest, normalizedOperation):
+			normalizedRequest = normalizedRequest + "#" + jobID
 		}
-		if normalized != requestID {
-			if err := client.Exec(`UPDATE `+tableName+` SET request_id = ? WHERE job_id = ?`, normalized, jobID).Error; err != nil {
+		if normalizedOperation == "" {
+			normalizedOperation = inferLegacyJobOperation(binding.NodeID, binding.SourceImageRef, binding.RetryOfJobID)
+		}
+		if normalizedRequest != requestID || normalizedOperation != operation {
+			if err := client.Exec(
+				`UPDATE `+tableName+` SET request_id = ?, operation = ? WHERE job_id = ?`,
+				normalizedRequest, normalizedOperation, jobID,
+			).Error; err != nil {
 				return err
 			}
 		}
-		seen[requestBindingKey(normalized, operation)] = struct{}{}
+		seen[requestBindingKey(normalizedRequest, normalizedOperation)] = struct{}{}
 	}
 	return nil
+}
+
+// inferLegacyJobOperation guesses the operation column for legacy rows that
+// pre-date the explicit Operation field. It mirrors the producer-side semantics:
+// commit jobs always carry a node assignment but no source image ref;
+// create-from-image jobs carry a source image ref without a retry_of_job_id.
+// Anything else is treated as a generic LEGACY entry so the unique
+// (request_id, operation) index can be created without conflicts.
+func inferLegacyJobOperation(nodeID, sourceImageRef, retryOfJobID string) string {
+	nodeID = strings.TrimSpace(nodeID)
+	sourceImageRef = strings.TrimSpace(sourceImageRef)
+	retryOfJobID = strings.TrimSpace(retryOfJobID)
+	switch {
+	case nodeID != "" && sourceImageRef == "":
+		return JobOperationCommit
+	case sourceImageRef != "" && retryOfJobID == "":
+		return JobOperationCreate
+	case sourceImageRef != "" && retryOfJobID != "":
+		return JobOperationRedo
+	default:
+		return JobOperationLegacy
+	}
 }
 
 func hasSeenRequestBinding(seen map[string]struct{}, requestID, operation string) bool {

--- a/CubeMaster/pkg/templatecenter/template_image.go
+++ b/CubeMaster/pkg/templatecenter/template_image.go
@@ -81,6 +81,7 @@ var deleteRootfsArtifactRecord = func(ctx context.Context, artifactID string) er
 	return store.db.WithContext(ctx).Unscoped().Table(constants.RootfsArtifactTableName).
 		Where("artifact_id = ?", artifactID).Delete(&models.RootfsArtifact{}).Error
 }
+
 const legacyRequestIDPrefix = "legacy-"
 
 var ErrNoFailedTemplateReplicas = errors.New("no failed template replicas matched redo request")
@@ -1962,9 +1963,8 @@ func marshalTemplateCommitJobRequest(req *types.CreateCubeSandboxReq) (string, e
 	return string(payload), nil
 }
 
-func buildCommitTemplateSpecFingerprint(req *types.CreateCubeSandboxReq) string {
-	payload, _ := marshalTemplateCommitJobRequest(req)
-	sum := sha256.Sum256([]byte(payload))
+func buildCommitTemplateSpecFingerprintFromSnapshot(requestSnapshot string) string {
+	sum := sha256.Sum256([]byte(requestSnapshot))
 	return hex.EncodeToString(sum[:])
 }
 

--- a/CubeMaster/pkg/templatecenter/template_image_test.go
+++ b/CubeMaster/pkg/templatecenter/template_image_test.go
@@ -576,7 +576,15 @@ func TestBuildCommitTemplateSpecFingerprintIgnoresRequestID(t *testing.T) {
 			constants.CubeAnnotationAppSnapshotTemplateVersion: DefaultTemplateVersion,
 		},
 	}
-	if gotA, gotB := buildCommitTemplateSpecFingerprint(reqA), buildCommitTemplateSpecFingerprint(reqB); gotA != gotB {
+	payloadA, err := marshalTemplateCommitJobRequest(reqA)
+	if err != nil {
+		t.Fatalf("marshalTemplateCommitJobRequest(reqA) failed: %v", err)
+	}
+	payloadB, err := marshalTemplateCommitJobRequest(reqB)
+	if err != nil {
+		t.Fatalf("marshalTemplateCommitJobRequest(reqB) failed: %v", err)
+	}
+	if gotA, gotB := buildCommitTemplateSpecFingerprintFromSnapshot(payloadA), buildCommitTemplateSpecFingerprintFromSnapshot(payloadB); gotA != gotB {
 		t.Fatalf("expected identical fingerprint, got %q vs %q", gotA, gotB)
 	}
 }


### PR DESCRIPTION
Close: https://github.com/TencentCloud/CubeSandbox/issues/332

- Validate requestID is non-empty in HTTP handler and service layer
- Add unique (request_id, operation) index handling for COMMIT jobs
- Reuse existing job on duplicate request payload; reject on payload drift
- Introduce commit-specific job record builder and duplicate-key detection