### PR TITLE
ci: allow auto review for external PRs

### DIFF
--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -45,6 +45,7 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ steps.app-token.outputs.token }}
+          allowed_non_write_users: "*"
           track_progress: true # ✨ Enables tracking comments
           prompt: "/review-pr REPO: ${{ github.repository }} PR NUMBER: ${{ github.event.pull_request.number }}"
           show_full_output: true


### PR DESCRIPTION
## Summary
- Allow the Claude auto-review workflow to run for fork PR authors by setting `allowed_non_write_users: "*"`.
- Keep the existing GitHub App token, `pull_request_target` trigger, minimal workflow permissions, and tool allowlist unchanged.

## Test plan
- Checked the workflow file diagnostics in Cursor; no linter errors were reported.
- Verified the PR diff only contains the intended workflow input addition.

Assisted-by: Cursor:GPT-5.5

Made with [Cursor](https://cursor.com)