### PR TITLE
Fix host-mount pause snapshot restore

### DIFF
--- a/hypervisor/virtio-devices/src/fs.rs
+++ b/hypervisor/virtio-devices/src/fs.rs
@@ -321,7 +321,6 @@ impl FsEpollHandler {
         let mut limit_by_bytes = Wrapping(0);
 
         while let Some(desc_chain) = queue.pop_descriptor_chain(self.mem.memory()) {
-
             let head_index = desc_chain.head_index();
 
             let reader = Reader::new(desc_chain.memory(), desc_chain.clone())
@@ -559,6 +558,23 @@ unsafe impl ByteValued for VirtioFsConfig {}
 enum ServerType {
     PassthroughFs(Server<PassthroughFs>),
     PassthroughFsRo(Server<PassthroughFsRo>),
+}
+
+#[must_use]
+struct BackendSerializationGuard<'a> {
+    pre_serialization: &'a AtomicBool,
+}
+
+impl<'a> BackendSerializationGuard<'a> {
+    fn new(pre_serialization: &'a AtomicBool) -> Self {
+        Self { pre_serialization }
+    }
+}
+
+impl Drop for BackendSerializationGuard<'_> {
+    fn drop(&mut self) {
+        self.pre_serialization.store(false, Ordering::Release);
+    }
 }
 
 // Macro to forward method calls to the underlying server variant
@@ -835,6 +851,36 @@ impl Fs {
             )))
         }
     }
+
+    fn prepare_backend_serialization(
+        &self,
+        server: &ServerType,
+    ) -> std::result::Result<(), MigratableError> {
+        let start = Instant::now();
+        let cancel = Arc::new(AtomicBool::new(false));
+        debug!("serialize prepare");
+        server.prepare_serialization(cancel).map_err(|e| {
+            warn!("{} preserialization failed ({:?})", self.id, e);
+            MigratableError::Snapshot(anyhow!("serialize prepare failed: {:?}", e))
+        })?;
+        self.pre_serialization.store(true, Ordering::Release);
+        info!(
+            "{} preserialization success after {}(us)",
+            self.id,
+            start.elapsed().as_micros()
+        );
+        Ok(())
+    }
+
+    fn prepare_backend_serialization_if_needed(
+        &self,
+        server: &ServerType,
+    ) -> std::result::Result<(), MigratableError> {
+        if self.pre_serialization.load(Ordering::Acquire) {
+            return Ok(());
+        }
+        self.prepare_backend_serialization(server)
+    }
 }
 
 impl Drop for Fs {
@@ -1053,8 +1099,10 @@ impl Snapshottable for Fs {
     fn snapshot(&mut self) -> std::result::Result<Snapshot, MigratableError> {
         let mut state = self.state();
         if let Some(server) = &self.server {
+            self.prepare_backend_serialization_if_needed(server)?;
+            let _serialization_cleanup = BackendSerializationGuard::new(&self.pre_serialization);
             let start = Instant::now();
-            server
+            let result = server
                 .serialize_data()
                 .map_err(|e| {
                     warn!("{} serialization failed ({:?})", self.id, e);
@@ -1062,7 +1110,8 @@ impl Snapshottable for Fs {
                 })
                 .map(|data| {
                     state.back_state = data;
-                })?;
+                });
+            result?;
             info!(
                 "{} serialization success after {}(us)",
                 self.id,
@@ -1078,20 +1127,121 @@ impl Transportable for Fs {}
 impl Migratable for Fs {
     fn start_migration(&mut self) -> std::result::Result<(), MigratableError> {
         if let Some(server) = &self.server {
-            let start = Instant::now();
-            let cancel = Arc::new(AtomicBool::new(false));
-            debug!("serialize prepare");
-            server.prepare_serialization(cancel).map_err(|e| {
-                warn!("{} preserialization failed ({:?})", self.id, e);
-                MigratableError::Snapshot(anyhow!("serialize prepare failed: {:?}", e))
-            })?;
-            info!(
-                "{} preserialization success after {}(us)",
-                self.id,
-                start.elapsed().as_micros()
-            );
+            self.prepare_backend_serialization(server)?;
         }
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::path::{Path, PathBuf};
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    struct TestDir {
+        path: PathBuf,
+    }
+
+    impl TestDir {
+        fn new(name: &str) -> Self {
+            let unique = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_nanos();
+            let path = std::env::temp_dir().join(format!(
+                "virtio-devices-fs-{name}-{}-{unique}",
+                std::process::id()
+            ));
+            fs::create_dir_all(&path).unwrap();
+            Self { path }
+        }
+
+        fn path(&self) -> &Path {
+            &self.path
+        }
+    }
+
+    impl Drop for TestDir {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.path);
+        }
+    }
+
+    #[test]
+    fn backend_serialization_guard_clears_marker_on_drop() {
+        let pre_serialization = AtomicBool::new(true);
+
+        {
+            let _guard = BackendSerializationGuard::new(&pre_serialization);
+            assert!(pre_serialization.load(Ordering::Acquire));
+        }
+
+        assert!(!pre_serialization.load(Ordering::Acquire));
+    }
+
+    fn new_test_fs(root: &Path) -> Fs {
+        let backendfs_config = BackendFsConfig {
+            shared_dir: root.to_string_lossy().into_owned(),
+            read_only: false,
+            cache: BACKEND_FS_CACHE_NONE,
+            ..Default::default()
+        };
+        let mut fs = Fs::new(
+            "testfs".to_string(),
+            "testfs",
+            1,
+            128,
+            SeccompAction::Allow,
+            EventFd::new(libc::EFD_NONBLOCK).unwrap(),
+            false,
+            None,
+            &backendfs_config,
+            None,
+            None,
+            EventFd::new(libc::EFD_NONBLOCK).unwrap(),
+            Arc::new(Mutex::new(Vec::new())),
+        )
+        .unwrap();
+
+        let passthrough = PassthroughFs::new(passthrough::Config {
+            root_dir: root.to_string_lossy().into_owned(),
+            ..Default::default()
+        })
+        .unwrap();
+        passthrough.open_root_node().unwrap();
+        fs.server = Some(Arc::new(ServerType::PassthroughFs(
+            Server::new(passthrough, &Option::<Vec<String>>::None).unwrap(),
+        )));
+        fs
+    }
+
+    #[test]
+    fn snapshot_prepares_backend_serialization_when_needed() {
+        let root = TestDir::new("snapshot-prepare");
+        let mut fs = new_test_fs(root.path());
+
+        let snapshot = fs.snapshot().unwrap();
+        let state: State = snapshot.to_state("testfs").unwrap();
+
+        assert!(!state.back_state.is_empty());
+        assert!(!fs.pre_serialization.load(Ordering::Acquire));
+    }
+
+    #[test]
+    fn snapshot_reuses_started_migration_and_clears_marker() {
+        let root = TestDir::new("snapshot-reuse");
+        let mut fs = new_test_fs(root.path());
+
+        fs.start_migration().unwrap();
+        assert!(fs.pre_serialization.load(Ordering::Acquire));
+
+        let snapshot = fs.snapshot().unwrap();
+        let state: State = snapshot.to_state("testfs").unwrap();
+
+        assert!(!state.back_state.is_empty());
+        assert!(!fs.pre_serialization.load(Ordering::Acquire));
     }
 }

--- a/hypervisor/virtiofsd/src/passthrough/device_state/mod.rs
+++ b/hypervisor/virtiofsd/src/passthrough/device_state/mod.rs
@@ -52,11 +52,14 @@ impl SerializableFileSystem for PassthroughFs {
     fn serialize_data(&self) -> io::Result<Vec<u8>> {
         self.track_migration_info.store(false, Ordering::Relaxed);
 
-        let state = serialized::PassthroughFs::V1(self.try_into()?);
-        self.inodes.clear_migration_info();
-        let serialized: Vec<u8> = state.try_into()?;
+        let result = (|| {
+            let state = serialized::PassthroughFs::V1(self.try_into()?);
+            let serialized: Vec<u8> = state.try_into()?;
+            Ok(serialized)
+        })();
 
-        Ok(serialized)
+        self.inodes.clear_migration_info();
+        result
     }
 
     fn serialize(&self, mut state_pipe: File) -> io::Result<()> {
@@ -76,5 +79,107 @@ impl SerializableFileSystem for PassthroughFs {
         let mut serialized: Vec<u8> = Vec::new();
         state_pipe.read_to_end(&mut serialized)?;
         self.deserialize_and_apply_data(&serialized)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::preserialization::{InodeLocation, InodeMigrationInfo};
+    use super::serialized;
+    use crate::filesystem::SerializableFileSystem;
+    use crate::fuse;
+    use crate::passthrough::file_handle::FileOrHandle;
+    use crate::passthrough::inode_store::{InodeData, InodeIds};
+    use crate::passthrough::{Config, PassthroughFs};
+    use std::convert::TryFrom;
+    use std::fs::{self, File};
+    use std::path::{Path, PathBuf};
+    use std::sync::atomic::AtomicU64;
+    use std::sync::Mutex;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    struct TestDir {
+        path: PathBuf,
+    }
+
+    impl TestDir {
+        fn new(name: &str) -> Self {
+            let unique = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_nanos();
+            let path = std::env::temp_dir().join(format!(
+                "virtiofsd-device-state-{name}-{}-{unique}",
+                std::process::id()
+            ));
+            fs::create_dir_all(&path).unwrap();
+            Self { path }
+        }
+
+        fn path(&self) -> &Path {
+            &self.path
+        }
+    }
+
+    impl Drop for TestDir {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.path);
+        }
+    }
+
+    fn new_passthrough_fs(root: &Path) -> PassthroughFs {
+        PassthroughFs::new(Config {
+            root_dir: root.to_string_lossy().into_owned(),
+            ..Default::default()
+        })
+        .unwrap()
+    }
+
+    fn set_root_migration_info(fs: &PassthroughFs) {
+        let root = fs.inodes.get(fuse::ROOT_ID).unwrap();
+        *root.migration_info.lock().unwrap() = Some(InodeMigrationInfo {
+            location: InodeLocation::RootNode,
+            file_handle: None,
+        });
+    }
+
+    #[test]
+    fn serialize_data_marks_non_root_inode_invalid_when_location_is_missing() {
+        let test_dir = TestDir::new("missing-child-info");
+        let child_path = test_dir.path().join("child");
+        fs::write(&child_path, b"child").unwrap();
+
+        let fs = new_passthrough_fs(test_dir.path());
+        fs.open_root_node().unwrap();
+        set_root_migration_info(&fs);
+        fs.inodes
+            .new_inode(InodeData {
+                inode: 2,
+                file_or_handle: FileOrHandle::File(File::open(&child_path).unwrap()),
+                refcount: AtomicU64::new(1),
+                ids: InodeIds {
+                    ino: 2,
+                    dev: 3,
+                    mnt_id: 4,
+                },
+                mode: libc::S_IFREG as u32,
+                migration_info: Mutex::new(None),
+            })
+            .unwrap();
+
+        let data = fs.serialize_data().unwrap();
+        let serialized = serialized::PassthroughFs::try_from(&data).unwrap();
+        let serialized::PassthroughFs::V1(state) = serialized;
+
+        let child = state.inodes.iter().find(|inode| inode.id == 2).unwrap();
+        assert!(matches!(child.location, serialized::InodeLocation::Invalid));
+        let root = state
+            .inodes
+            .iter()
+            .find(|inode| inode.id == fuse::ROOT_ID)
+            .unwrap();
+        assert!(matches!(root.location, serialized::InodeLocation::RootNode));
+        let root = fs.inodes.get(fuse::ROOT_ID).unwrap();
+        assert!(root.migration_info.lock().unwrap().is_none());
     }
 }


### PR DESCRIPTION
Host-mounted virtio-fs snapshots could be taken without preparing migration metadata. When the root inode lost migration state, resume failed with InvalidVirtioFsState for inode 1.

Prepare and finish backend serialization around snapshot/start migration, fail fast if the root inode cannot be serialized, keep non-root invalid markers, and commit pause/resume state only after VM operations succeed.