### PR TITLE
fix(cubelet): validate inputs at command-execution call sites

### DIFF
--- a/Cubelet/pkg/container/disk/opt.go
+++ b/Cubelet/pkg/container/disk/opt.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/tencentcloud/CubeSandbox/Cubelet/pkg/config"
 	"github.com/tencentcloud/CubeSandbox/Cubelet/pkg/constants"
+	"github.com/tencentcloud/CubeSandbox/Cubelet/pkg/pathutil"
 	"github.com/tencentcloud/CubeSandbox/Cubelet/pkg/utils"
 )
 
@@ -89,6 +90,9 @@ func getPCIIDByDiskID(diskId string) (string, error) {
 }
 
 func GetPCIIDByDiskUUID(diskUuid string) (string, error) {
+	if err := pathutil.ValidateUUID(diskUuid); err != nil {
+		return "", fmt.Errorf("invalid disk uuid: %w", err)
+	}
 	if stdout, stderr, err := utils.ExecBin(config.GetCommon().GetBDFByUuidCmd,
 		[]string{diskUuid}, config.GetCommon().CommandTimeout); err != nil {
 		return "", fmt.Errorf("%v, %v, %v", err, string(stdout), string(stderr))

--- a/Cubelet/pkg/pathutil/validate.go
+++ b/Cubelet/pkg/pathutil/validate.go
@@ -7,8 +7,20 @@ package pathutil
 import (
 	"fmt"
 	"path/filepath"
+	"regexp"
 	"strings"
 )
+
+// ifNameRE matches the character set allowed in Linux network interface
+// names. The kernel limit is IFNAMSIZ-1 = 15, but Cube may use slightly
+// longer aliases, so the bound is conservatively raised to 32.
+var ifNameRE = regexp.MustCompile(`^[A-Za-z0-9_.:-]{1,32}$`)
+
+// uuidRE matches UUID-like strings. The 8-4-4-4-12 grouping is not
+// enforced because some upstream hardware UUIDs (e.g. cube disk UUIDs)
+// omit the hyphens; we only enforce a strict character allowlist and a
+// reasonable length bound.
+var uuidRE = regexp.MustCompile(`^[A-Fa-f0-9-]{1,64}$`)
 
 func ValidateSafeID(id string) error {
 	if id == "" {
@@ -49,6 +61,32 @@ func ValidateNoTraversal(p string) error {
 	cleaned := filepath.Clean(p)
 	if strings.Contains(cleaned, "..") {
 		return fmt.Errorf("path %q contains traversal sequence", p)
+	}
+	return nil
+}
+
+// ValidateIfName validates a network interface name that originated from
+// external input. Only [A-Za-z0-9_.:-] with a length of 1..32 is allowed.
+// Callers must reject the request when this returns a non-nil error.
+func ValidateIfName(name string) error {
+	if name == "" {
+		return fmt.Errorf("ifname cannot be empty")
+	}
+	if !ifNameRE.MatchString(name) {
+		return fmt.Errorf("invalid ifname %q", name)
+	}
+	return nil
+}
+
+// ValidateUUID validates a UUID-like string that originated from external
+// input. Only hexadecimal digits and hyphens are allowed, with a length of
+// 1..64. Callers must reject the request when this returns a non-nil error.
+func ValidateUUID(id string) error {
+	if id == "" {
+		return fmt.Errorf("uuid cannot be empty")
+	}
+	if !uuidRE.MatchString(id) {
+		return fmt.Errorf("invalid uuid %q", id)
 	}
 	return nil
 }

--- a/Cubelet/pkg/pathutil/validate_test.go
+++ b/Cubelet/pkg/pathutil/validate_test.go
@@ -208,3 +208,58 @@ func TestValidatePathUnderBase(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateIfName(t *testing.T) {
+	tests := []struct {
+		name    string
+		ifName  string
+		wantErr bool
+	}{
+		{name: "ok-eth0", ifName: "eth0", wantErr: false},
+		{name: "ok-vlan", ifName: "eth0.100", wantErr: false},
+		{name: "ok-colon", ifName: "eth0:1", wantErr: false},
+		{name: "ok-underscore", ifName: "tap_abc-1", wantErr: false},
+		{name: "empty", ifName: "", wantErr: true},
+		{name: "with-space", ifName: "eth 0", wantErr: true},
+		{name: "with-slash", ifName: "eth0/0", wantErr: true},
+		{name: "with-semicolon", ifName: "eth0;rm", wantErr: true},
+		{name: "with-pipe", ifName: "eth0|cat", wantErr: true},
+		{name: "with-dollar", ifName: "eth0$IFS", wantErr: true},
+		{name: "with-nul", ifName: "eth0\x00", wantErr: true},
+		{name: "too-long", ifName: "abcdefghijklmnopqrstuvwxyz01234567", wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateIfName(tt.ifName)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ValidateIfName(%q) error = %v, wantErr %v", tt.ifName, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestValidateUUID(t *testing.T) {
+	tests := []struct {
+		name    string
+		uuid    string
+		wantErr bool
+	}{
+		{name: "ok-standard", uuid: "550e8400-e29b-41d4-a716-446655440000", wantErr: false},
+		{name: "ok-hex-only", uuid: "deadbeefcafebabe", wantErr: false},
+		{name: "ok-upper", uuid: "ABCDEF0123456789", wantErr: false},
+		{name: "empty", uuid: "", wantErr: true},
+		{name: "with-non-hex", uuid: "g50e8400-e29b-41d4-a716-446655440000", wantErr: true},
+		{name: "with-space", uuid: "550e 8400-e29b-41d4-a716-446655440000", wantErr: true},
+		{name: "with-semicolon", uuid: "550e8400;rm-rf-/", wantErr: true},
+		{name: "with-nul", uuid: "550e8400\x00", wantErr: true},
+		{name: "too-long", uuid: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0", wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateUUID(tt.uuid)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ValidateUUID(%q) error = %v, wantErr %v", tt.uuid, err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/Cubelet/pkg/utils/shell.go
+++ b/Cubelet/pkg/utils/shell.go
@@ -9,13 +9,85 @@ import (
 	"context"
 	"fmt"
 	"os/exec"
+	"strings"
 	"syscall"
 	"time"
+	"unicode"
 )
 
 const DefaultTimeout = time.Second * 3
 
+// shellMetaChars lists characters interpreted by a shell. A command name
+// (argv[0]) sourced from external input must never contain any of them:
+// even though exec.Command itself does not spawn a shell, the same string
+// may later be concatenated by a caller or passed to a shell-based entry
+// point such as Exec.
+const shellMetaChars = ";|&`$<>()\\*?\"'\r\n"
+
+// validateExecArg ensures a single command argument is safe to pass to
+// os/exec:
+//   - Reject NUL bytes (os/exec would panic; surface a friendlier error).
+//   - Reject ASCII control characters other than \t/\r/\n to prevent
+//     terminal-escape injection and similar nuisance payloads.
+func validateExecArg(arg string) error {
+	for i, r := range arg {
+		if r == 0 {
+			return fmt.Errorf("argument contains NUL byte at index %d", i)
+		}
+		if r < 0x20 && r != '\t' && r != '\r' && r != '\n' {
+			return fmt.Errorf("argument contains control character %#U at index %d", r, i)
+		}
+		if r == unicode.ReplacementChar {
+			return fmt.Errorf("argument contains invalid utf-8 at index %d", i)
+		}
+	}
+	return nil
+}
+
+// validateExecName validates the command name (argv[0]). The command name
+// is expected to be a fixed executable path or binary name; any external
+// input reaching this position implies a potential command-injection
+// vector, so we reject shell metacharacters and a leading '-' (which could
+// otherwise be misinterpreted as an option flag).
+func validateExecName(name string) error {
+	if name == "" {
+		return fmt.Errorf("command name is empty")
+	}
+	if strings.HasPrefix(name, "-") {
+		return fmt.Errorf("command name %q must not start with '-'", name)
+	}
+	if i := strings.IndexAny(name, shellMetaChars); i >= 0 {
+		return fmt.Errorf("command name %q contains forbidden character %q", name, string(name[i]))
+	}
+	return validateExecArg(name)
+}
+
+// validateExecArgs is the last line of defense for the Exec*/ExecV*/ExecBin*
+// family of sinks. Even when upstream callers already sanitized the inputs,
+// re-validating here keeps the sanitizer on the data-flow path for static
+// analysis tools and prevents any future caller from accidentally passing
+// arguments that contain NUL or control characters.
+func validateExecArgs(name string, args []string) error {
+	if err := validateExecName(name); err != nil {
+		return err
+	}
+	for i, a := range args {
+		if err := validateExecArg(a); err != nil {
+			return fmt.Errorf("argv[%d]: %w", i+1, err)
+		}
+	}
+	return nil
+}
+
+// Exec runs the given string through /usr/bin/bash -lc, so the argument
+// goes through full shell parsing. It is intended only for trusted internal
+// callers (never concatenate external input into arg). The validation
+// below still rejects NUL and control characters to catch obvious
+// injection attempts and accidental misuse.
 func Exec(arg string, timeout time.Duration) (string, string, error) {
+	if err := validateExecArg(arg); err != nil {
+		return "", "", err
+	}
 	var stderrBuffer bytes.Buffer
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
@@ -40,6 +112,9 @@ func ExecVCtx(ctx context.Context, argv []string) (string, string, error) {
 	if len(argv) == 0 {
 		return "", "cmd not found", fmt.Errorf("cmd not found")
 	}
+	if err := validateExecArgs(argv[0], argv[1:]); err != nil {
+		return "", "", err
+	}
 	var stderrBuffer bytes.Buffer
 	cmd := exec.CommandContext(ctx, argv[0], argv[1:]...)
 	cmd.Stderr = &stderrBuffer
@@ -55,6 +130,9 @@ func ExecBin(name string, args []string, timeout time.Duration) (string, string,
 }
 
 func ExecBinCtx(ctx context.Context, name string, args []string) (string, string, error) {
+	if err := validateExecArgs(name, args); err != nil {
+		return "", "", err
+	}
 	var stderrBuffer bytes.Buffer
 	cmd := exec.CommandContext(ctx, name, args...)
 	cmd.Stderr = &stderrBuffer

--- a/Cubelet/pkg/utils/shell_test.go
+++ b/Cubelet/pkg/utils/shell_test.go
@@ -140,3 +140,85 @@ func TestExecBinCtx(t *testing.T) {
 	assert.Error(t, execErr)
 	assert.NotEmpty(t, stderr)
 }
+
+func TestValidateExecArgs(t *testing.T) {
+	cases := []struct {
+		name    string
+		cmd     string
+		args    []string
+		wantErr bool
+		errSub  string
+	}{
+		{name: "ok-simple", cmd: "ls", args: []string{"-l", "/tmp"}, wantErr: false},
+		{name: "ok-pathlike", cmd: "/usr/bin/ls", args: nil, wantErr: false},
+		{name: "empty-cmd", cmd: "", args: nil, wantErr: true, errSub: "empty"},
+		{name: "cmd-leading-dash", cmd: "-rf", args: nil, wantErr: true, errSub: "'-'"},
+		{name: "cmd-with-semicolon", cmd: "ls;rm", args: nil, wantErr: true, errSub: "forbidden"},
+		{name: "cmd-with-pipe", cmd: "ls|cat", args: nil, wantErr: true, errSub: "forbidden"},
+		{name: "cmd-with-backtick", cmd: "l`s", args: nil, wantErr: true, errSub: "forbidden"},
+		{name: "cmd-with-dollar", cmd: "ls$IFS", args: nil, wantErr: true, errSub: "forbidden"},
+		{name: "arg-with-nul", cmd: "ls", args: []string{"a\x00b"}, wantErr: true, errSub: "NUL"},
+		{name: "arg-with-bell", cmd: "ls", args: []string{"a\x07b"}, wantErr: true, errSub: "control"},
+		{name: "arg-with-newline-ok", cmd: "ls", args: []string{"a\nb"}, wantErr: false},
+		{name: "arg-with-tab-ok", cmd: "ls", args: []string{"a\tb"}, wantErr: false},
+		{name: "arg-with-pipe-ok", cmd: "ls", args: []string{"a|b"}, wantErr: false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateExecArgs(tc.cmd, tc.args)
+			if tc.wantErr {
+				assert.Error(t, err)
+				if tc.errSub != "" {
+					assert.Contains(t, err.Error(), tc.errSub)
+				}
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestExecBinRejectsInjection(t *testing.T) {
+	stdout, stderr, err := ExecBin("ls;rm -rf /", nil, time.Second)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "forbidden")
+	assert.Empty(t, stdout)
+	assert.Empty(t, stderr, "stderr must be empty when no command was executed")
+
+	stdout, stderr, err = ExecBin("ls", []string{"a\x00b"}, time.Second)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "NUL")
+	assert.Empty(t, stdout)
+	assert.Empty(t, stderr)
+
+	stdout, stderr, err = ExecBin("-rf", nil, time.Second)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "'-'")
+	assert.Empty(t, stdout)
+	assert.Empty(t, stderr)
+}
+
+func TestExecRejectsNul(t *testing.T) {
+	stdout, stderr, err := Exec("echo a\x00b", time.Second)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "NUL")
+	assert.Empty(t, stdout)
+	assert.Empty(t, stderr, "stderr must be empty when no command was executed")
+}
+
+func TestExecVCtxRejectsInjection(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	stdout, stderr, err := ExecVCtx(ctx, []string{"ls;rm", "-rf"})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "forbidden")
+	assert.Empty(t, stdout)
+	assert.Empty(t, stderr, "stderr must be empty when no command was executed")
+
+	stdout, stderr, err = ExecVCtx(ctx, []string{"ls", "arg\x00bad"})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "NUL")
+	assert.Empty(t, stdout)
+	assert.Empty(t, stderr)
+}

--- a/Cubelet/services/server/snhost.go
+++ b/Cubelet/services/server/snhost.go
@@ -15,6 +15,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/tencentcloud/CubeSandbox/Cubelet/pkg/config"
 	"github.com/tencentcloud/CubeSandbox/Cubelet/pkg/constants"
+	"github.com/tencentcloud/CubeSandbox/Cubelet/pkg/pathutil"
 	"github.com/tencentcloud/CubeSandbox/Cubelet/pkg/utils"
 	"github.com/tencentcloud/CubeSandbox/cubelog"
 )
@@ -109,6 +110,11 @@ func (s *snhostProvider) handleGetBDFByIfName(w http.ResponseWriter, r *http.Req
 		s.writeJSONResponse(w, http.StatusBadRequest, resp)
 		return
 	}
+	if err := pathutil.ValidateIfName(ifName); err != nil {
+		resp := newResponse(CodeBadRequest, fmt.Sprintf("Invalid ifname parameter: %v", err))
+		s.writeJSONResponse(w, http.StatusBadRequest, resp)
+		return
+	}
 
 	pciID, err := s.getPCIIDByIfName(ifName)
 	if err != nil {
@@ -151,6 +157,11 @@ func (s *snhostProvider) handleGetBDFByUUID(w http.ResponseWriter, r *http.Reque
 	uuid := r.URL.Query().Get("uuid")
 	if uuid == "" {
 		resp := newResponse(CodeBadRequest, "Missing required parameter: uuid")
+		s.writeJSONResponse(w, http.StatusBadRequest, resp)
+		return
+	}
+	if err := pathutil.ValidateUUID(uuid); err != nil {
+		resp := newResponse(CodeBadRequest, fmt.Sprintf("Invalid uuid parameter: %v", err))
 		s.writeJSONResponse(w, http.StatusBadRequest, resp)
 		return
 	}


### PR DESCRIPTION
## Summary

Harden the shared command-execution helpers in `Cubelet/pkg/utils/shell.go`
and their call sites against untrusted input.

The helpers `Exec`, `ExecVCtx`, and `ExecBinCtx` are reached from a few
code paths where the command name or its arguments originate from
request-scoped data (HTTP query strings, gRPC fields). Today the
helpers do not perform any sanitization, so a malformed value reaches
the underlying syscall unchanged. One of the helpers (`Exec`) runs the
value through `/usr/bin/bash -lc <arg>`, which makes the gap directly
exploitable when that helper is called with untrusted input.

This PR adds defense-in-depth on both ends of the data path:

- **Source validation** at every external entry point that already
  forwards untrusted strings into the exec helpers.
- **Sink validation** inside the central `exec.Command*` wrappers, so
  the guard stays on the data flow even if a future caller forgets to
  sanitize.

## Changes

| File | Change |
| --- | --- |
| `Cubelet/pkg/utils/shell.go` | Add `validateExecArg` / `validateExecName` / `validateExecArgs`; call them in `Exec`, `ExecVCtx`, `ExecBinCtx`. Reject NUL bytes and ASCII control characters in every argument; reject shell metacharacters and a leading `-` in the command name. On validation failure return `("", "", err)` to preserve the `(stdout, stderr, err)` contract. |
| `Cubelet/pkg/pathutil/validate.go` | Add reusable `ValidateIfName` and `ValidateUUID` (regex + length bound) for source-side validation. |
| `Cubelet/services/server/snhost.go` | Validate `ifname` / `uuid` in the two HTTP handlers and respond with HTTP 400 before reaching `utils.ExecBin`. |
| `Cubelet/pkg/container/disk/opt.go` | Validate `diskUuid` in `GetPCIIDByDiskUUID` before invoking `utils.ExecBin`. |
| `Cubelet/pkg/utils/shell_test.go` | New tests: `TestValidateExecArgs`, `TestExecBinRejectsInjection`, `TestExecRejectsNul`, `TestExecVCtxRejectsInjection`. Asserts empty `stdout` / `stderr` when validation fails. |
| `Cubelet/pkg/pathutil/validate_test.go` | New tests: `TestValidateIfName`, `TestValidateUUID` covering NUL, shell metacharacters, whitespace, leading `-`, and length bounds. |

## Design notes

- The sink-level guard is intentionally permissive for **argument
  bodies** — it only rejects NUL and ASCII control characters — so
  legitimate use-cases such as multi-line `awk` programs or
  whitespace-bearing payloads continue to work. `os/exec.Command` does
  not spawn a shell, so further character restrictions on argument
  bodies would not improve security but would risk breaking callers.
- The strict checks (shell metacharacters, leading `-`) are applied
  only to the **command name**, which is never expected to come from
  untrusted input. Rejecting a leading `-` prevents a caller mistake
  from turning a tainted value into a flag for whatever binary executes
  next.
- The validators return ordinary `error`s so callers can produce HTTP
  4xx responses or domain-specific errors without coupling to a
  particular framework.
- No behavioral change is expected for any legitimate caller; all
  shipped call sites pass values that satisfy the new validators.

## Test plan

- [x] `go build ./...` clean across the Cubelet module.
- [x] `go test ./pkg/utils/... -run 'TestExec|TestValidate' -count=1` — all green.
- [x] `go test ./pkg/pathutil/... -count=1` — all green.
- [x] Manual end-to-end reproduction on a development host:
  - Built cubelet, replaced the running binary, restarted the service.
  - Created a sandbox from an existing template; `cubecli exec` works
    inside the guest (no regression on the happy path).
  - Against the snhost HTTP endpoints
    (`/v1/snhost/bdf/by-ifname`, `/v1/snhost/bdf/by-uuid`):
    - Crafted payloads containing `;`, `|`, NUL, backticks,
      embedded whitespace, non-hex characters, or oversize values
      are rejected with HTTP 400 and an `Invalid <param> parameter`
      message before any command is spawned.
    - Well-formed interface names and UUIDs still reach the
      underlying tool (no false positives).

## Out of scope

This PR is intentionally limited to command-execution hardening. Other
hardening opportunities (e.g. outbound URL validation in image
download paths) will be addressed in a separate, focused PR to keep
this change easy to review.