### PR TITLE
fix(deploy): order cube-proxy.service after cube-sandbox-dns.service

### DIFF
--- a/deploy/one-click/systemd/cube-sandbox-cube-proxy.service
+++ b/deploy/one-click/systemd/cube-sandbox-cube-proxy.service
@@ -1,8 +1,8 @@
 [Unit]
 Description=Cube Sandbox cube-proxy container
-After=docker.service network-online.target cube-sandbox-redis.service
+After=docker.service network-online.target cube-sandbox-redis.service cube-sandbox-dns.service
 Requires=docker.service
-Wants=network-online.target cube-sandbox-redis.service
+Wants=network-online.target cube-sandbox-redis.service cube-sandbox-dns.service
 ConditionPathExists=/usr/local/services/cubetoolbox/.one-click.env
 PartOf=cube-sandbox-control.target
 


### PR DESCRIPTION
## Summary

- `cube-sandbox-cube-proxy.service` runs `cube-proxy-start.sh`, which calls `docker build` containing `apk update`. That step needs `/etc/resolv.conf` already rewritten away from the systemd-resolved loopback stub (`127.0.0.53`); otherwise Docker copies the loopback nameserver into the build container and `apk update` fails to resolve `mirrors.tencent.com`, breaking the one-click install on Ubuntu 24.04 and similar systemd-resolved hosts (#345).
- PR #331 introduced `cube-sandbox-dns.service` (oneshot running `dns-host-route-up.sh`) to perform that rewrite, but the two units were only co-pulled by `cube-sandbox-control.target` via `Wants=` with no explicit ordering — letting `cube-proxy` race ahead of the DNS rewrite.
- Add `cube-sandbox-dns.service` to `After=` so systemd waits for the oneshot to finish before starting `cube-proxy`, and to `Wants=` to match the file's existing `After=`/`Wants=` convention and keep the unit robust when started directly outside the control target.

## Test plan

- [ ] Fresh Ubuntu 24.04 (systemd-resolved active, `/etc/resolv.conf` → `127.0.0.53`): run `online-install.sh | MIRROR=cn bash` and confirm cube-proxy image build's `apk update` succeeds without manual `/etc/docker/daemon.json` workaround.
- [ ] `systemctl list-dependencies cube-sandbox-cube-proxy.service` shows `cube-sandbox-dns.service` in the resolved chain.
- [ ] After install, `systemctl show cube-sandbox-cube-proxy.service -p After` includes `cube-sandbox-dns.service`.
- [ ] `systemctl restart cube-sandbox-cube-proxy.service` (alone, outside the target) also brings up `cube-sandbox-dns.service` first.

Refs: #345, #331