### PR TITLE
feat(guest-image): shrink ext4 image after creation and optimize Dockerfile

### DIFF
--- a/deploy/guest-image/Dockerfile
+++ b/deploy/guest-image/Dockerfile
@@ -1,17 +1,18 @@
 FROM cube-sandbox-image.tencentcloudcr.com/opensource/tencentos4-minimal:4.4-v20250331
-  
 
 WORKDIR /work
 
-RUN yum install -y \
-    util-linux \
-    busybox \
-    gawk \
-    gcc \
-    util-linux \
-    which \
-    vim \
-    sudo \
-    lsof
+# Keep only the runtime essentials:
+# - util-linux: mount/umount/blkid (referenced indirectly by agent)
+# - busybox:    /bin/sh plus awk/sed/grep applets replacing gawk/which/etc.
+RUN yum install -y --setopt=install_weak_deps=False --setopt=tsflags=nodocs \
+        util-linux \
+        busybox \
+ && yum clean all \
+ && rm -rf /var/cache/yum /var/cache/dnf /var/log/yum.log /var/log/dnf.* \
+           /usr/share/doc /usr/share/man /usr/share/info \
+           /usr/share/licenses /usr/share/groff \
+           /usr/share/locale/* /usr/lib/locale/* \
+           /tmp/* /var/tmp/*
 
 CMD ["bash"]

--- a/deploy/guest-image/Dockerfile
+++ b/deploy/guest-image/Dockerfile
@@ -4,7 +4,10 @@ WORKDIR /work
 
 # Keep only the runtime essentials:
 # - util-linux: mount/umount/blkid (referenced indirectly by agent)
-# - busybox:    /bin/sh plus awk/sed/grep applets replacing gawk/which/etc.
+# - busybox:    provides /bin/sh and core applets (awk/sed/grep, etc.).
+#               Note: busybox applets are lighter-weight reimplementations
+#               and do not cover every GNU extension; current guest startup
+#               (cube-agent + empty rc.local) does not rely on those.
 RUN yum install -y --setopt=install_weak_deps=False --setopt=tsflags=nodocs \
         util-linux \
         busybox \

--- a/deploy/one-click/build-vm-assets.sh
+++ b/deploy/one-click/build-vm-assets.sh
@@ -241,6 +241,49 @@ run_mkfs_ext4_with_optional_sudo() {
   sudo mkfs.ext4 "$@"
 }
 
+run_as_root() {
+  if [[ "${EUID}" -eq 0 ]]; then
+    "$@"
+    return $?
+  fi
+  require_cmd sudo
+  sudo "$@"
+}
+
+SHRINK_RESERVED_BYTES="${ONE_CLICK_GUEST_IMAGE_RESERVED_BYTES:-$((32 * 1024 * 1024))}"
+
+# Shrink the ext4 image to its minimum size, then grow it by RESERVED bytes of
+# free headroom so the guest still has room for runtime writes.
+shrink_ext4_image() {
+  local img="$1"
+  local reserved_bytes="${2:-${SHRINK_RESERVED_BYTES}}"
+  local dumpe2fs_out block_size min_blocks reserved_blocks target_blocks final_bytes
+
+  run_as_root e2fsck -fy "${img}" >&2 || true
+  run_as_root resize2fs -M "${img}" >&2
+
+  dumpe2fs_out="$(run_as_root dumpe2fs -h "${img}" 2>/dev/null)"
+  block_size="$(printf '%s\n' "${dumpe2fs_out}" | awk -F': *' '/^Block size/ {print $2; exit}')"
+  min_blocks="$(printf '%s\n' "${dumpe2fs_out}" | awk -F': *' '/^Block count/ {print $2; exit}')"
+
+  if [[ -z "${block_size}" || -z "${min_blocks}" ]]; then
+    die "failed to parse ext4 metadata from ${img}"
+  fi
+
+  reserved_blocks="$(( (reserved_bytes + block_size - 1) / block_size ))"
+  target_blocks="$(( min_blocks + reserved_blocks ))"
+  final_bytes="$(( target_blocks * block_size ))"
+
+  run_as_root truncate -s "${final_bytes}" "${img}"
+  run_as_root resize2fs "${img}" "${target_blocks}" >&2
+  run_as_root e2fsck -fy "${img}" >&2 || true
+
+  local human_final human_reserved
+  human_final="$(numfmt --to=iec --suffix=B "${final_bytes}" 2>/dev/null || echo "${final_bytes}")"
+  human_reserved="$(numfmt --to=iec --suffix=B "${reserved_bytes}" 2>/dev/null || echo "${reserved_bytes}")"
+  log "guest image shrunk to ${human_final} (reserved ${human_reserved} headroom)"
+}
+
 remove_path_with_optional_sudo() {
   if [[ "$#" -eq 0 ]]; then
     return 0
@@ -356,6 +399,8 @@ build_guest_image_artifacts() {
   truncate -s "${image_size_bytes}" "${output_img}"
   run_mkfs_ext4_with_optional_sudo -F -d "${GUEST_ROOTFS_DIR}" "${output_img}" >&2
 
+  shrink_ext4_image "${output_img}"
+
   printf '%s\n' "${GUEST_IMAGE_VERSION}" > "${output_version}"
 
   docker rm -f "${guest_container_id}" >/dev/null 2>&1 || true
@@ -368,6 +413,9 @@ require_cmd python3
 require_cmd truncate
 require_cmd ldd
 require_cmd mkfs.ext4
+require_cmd e2fsck
+require_cmd resize2fs
+require_cmd dumpe2fs
 require_cmd docker
 require_cmd tar
 

--- a/deploy/one-click/build-vm-assets.sh
+++ b/deploy/one-click/build-vm-assets.sh
@@ -246,8 +246,36 @@ run_as_root() {
     "$@"
     return $?
   fi
+
+  # Try without sudo first so the caller can still capture stdout via $(...).
+  # Only stderr is silenced so a permission error doesn't pollute the log
+  # before the sudo fallback retries.
+  local rc=0
+  "$@" 2>/dev/null
+  rc=$?
+  if [[ ${rc} -eq 0 ]]; then
+    return 0
+  fi
+
   require_cmd sudo
   sudo "$@"
+}
+
+# Locale-stable dumpe2fs wrapper: dumpe2fs translates field names under
+# non-C locales, which would break the awk parsing in shrink_ext4_image.
+dump_ext4_header() {
+  local img="$1"
+  if [[ "${EUID}" -eq 0 ]]; then
+    LC_ALL=C dumpe2fs -h "${img}" 2>/dev/null
+    return $?
+  fi
+
+  if LC_ALL=C dumpe2fs -h "${img}" 2>/dev/null; then
+    return 0
+  fi
+
+  require_cmd sudo
+  sudo LC_ALL=C dumpe2fs -h "${img}" 2>/dev/null
 }
 
 SHRINK_RESERVED_BYTES="${ONE_CLICK_GUEST_IMAGE_RESERVED_BYTES:-$((32 * 1024 * 1024))}"
@@ -257,12 +285,12 @@ SHRINK_RESERVED_BYTES="${ONE_CLICK_GUEST_IMAGE_RESERVED_BYTES:-$((32 * 1024 * 10
 shrink_ext4_image() {
   local img="$1"
   local reserved_bytes="${2:-${SHRINK_RESERVED_BYTES}}"
-  local dumpe2fs_out block_size min_blocks reserved_blocks target_blocks final_bytes
+  local dumpe2fs_out block_size min_blocks reserved_blocks target_blocks final_bytes min_bytes
 
   run_as_root e2fsck -fy "${img}" >&2 || true
   run_as_root resize2fs -M "${img}" >&2
 
-  dumpe2fs_out="$(run_as_root dumpe2fs -h "${img}" 2>/dev/null)"
+  dumpe2fs_out="$(dump_ext4_header "${img}")"
   block_size="$(printf '%s\n' "${dumpe2fs_out}" | awk -F': *' '/^Block size/ {print $2; exit}')"
   min_blocks="$(printf '%s\n' "${dumpe2fs_out}" | awk -F': *' '/^Block count/ {print $2; exit}')"
 
@@ -273,7 +301,20 @@ shrink_ext4_image() {
   reserved_blocks="$(( (reserved_bytes + block_size - 1) / block_size ))"
   target_blocks="$(( min_blocks + reserved_blocks ))"
   final_bytes="$(( target_blocks * block_size ))"
+  min_bytes="$(( min_blocks * block_size ))"
 
+  # Defensive sanity check: truncating below the shrunk filesystem size would
+  # chop live FS data. With reserved_blocks >= 0 this should never trigger,
+  # but we want a clear failure if future refactors break the invariant.
+  if (( final_bytes < min_bytes )); then
+    die "shrink target ${final_bytes} smaller than ext4 minimum ${min_bytes}"
+  fi
+
+  # The resulting ext4 file is sparse: ext4 free space inside the image
+  # corresponds to filesystem holes on the host. Packagers that don't
+  # preserve sparseness (e.g. plain tar without --sparse) will inflate
+  # the file back to its apparent size, but gzip still compresses the
+  # zeroed extents efficiently.
   run_as_root truncate -s "${final_bytes}" "${img}"
   run_as_root resize2fs "${img}" "${target_blocks}" >&2
   run_as_root e2fsck -fy "${img}" >&2 || true

--- a/deploy/one-click/env.example
+++ b/deploy/one-click/env.example
@@ -35,6 +35,8 @@ ONE_CLICK_CUBE_SHIM_BUILD_MODE=local
 # Optional PVM guest kernel. When present, it is packaged as cube-kernel-scf/vmlinux-pvm.
 # ONE_CLICK_CUBE_KERNEL_PVM_VMLINUX=/abs/path/to/vmlinux-pvm
 # ONE_CLICK_RUNTIME_CFG_SRC=/abs/path/to/config-cube.toml
+# Headroom in bytes left in the guest ext4 image after shrink (default 32MB).
+# ONE_CLICK_GUEST_IMAGE_RESERVED_BYTES=33554432
 
 # Target-machine install options.
 # New installations are always managed by systemd; there is no systemd/non-systemd mode switch.


### PR DESCRIPTION

## Summary

This PR shrinks the one-click guest image `cube-guest-image-cpu.img` by removing runtime-only packages from the guest rootfs and shrinking the generated ext4 image after creation.

## Motivation

The guest image used to be around `768MB`, while the actual rootfs contents were much smaller. That left a large amount of unused space in the released package and on disk.

## What changed

- Simplified `deploy/guest-image/Dockerfile` to keep only the runtime essentials.
- Added `yum clean all` and removed cache/docs/man/locale/temporary files during image build.
- Added an ext4 shrink step in `deploy/one-click/build-vm-assets.sh`.
- Made the post-shrink headroom configurable through `ONE_CLICK_GUEST_IMAGE_RESERVED_BYTES` and defaulted it to `32MB`.

## Results

Measured on the built package:

- `cube-guest-image-cpu.img`: `245MB`
- ext4 used space: `205MB`
- ext4 free space: `41MB`
- one-click release tarball: `261MB`

This reduces the guest image size from roughly `768MB` to `245MB` .
