### PR TITLE
fix(nodemeta): preserve admin-configured MaxMvmNum across cubelet restarts

### DIFF
--- a/CubeMaster/pkg/nodemeta/service.go
+++ b/CubeMaster/pkg/nodemeta/service.go
@@ -129,6 +129,9 @@ func RegisterNode(ctx context.Context, req *RegisterNodeRequest) (*NodeSnapshot,
 	if req.HostIP == "" {
 		req.HostIP = req.NodeID
 	}
+
+	effectiveMaxMvmNum := resolveMaxMvmNum(global.getNode(req.NodeID), req.MaxMvmNum)
+
 	reg := &models.NodeRegistration{
 		NodeID:              req.NodeID,
 		HostIP:              req.HostIP,
@@ -141,7 +144,7 @@ func RegisterNode(ctx context.Context, req *RegisterNodeRequest) (*NodeSnapshot,
 		QuotaCPU:            req.QuotaCPU,
 		QuotaMemMB:          req.QuotaMemMB,
 		CreateConcurrentNum: req.CreateConcurrentNum,
-		MaxMvmNum:           req.MaxMvmNum,
+		MaxMvmNum:           effectiveMaxMvmNum,
 	}
 	if err := global.db.Clauses(clause.OnConflict{
 		Columns: []clause.Column{{Name: "node_id"}},
@@ -167,7 +170,7 @@ func RegisterNode(ctx context.Context, req *RegisterNodeRequest) (*NodeSnapshot,
 	snap.QuotaCPU = req.QuotaCPU
 	snap.QuotaMemMB = req.QuotaMemMB
 	snap.CreateConcurrentNum = req.CreateConcurrentNum
-	snap.MaxMvmNum = req.MaxMvmNum
+	snap.MaxMvmNum = effectiveMaxMvmNum
 	global.mu.Unlock()
 	syncLocalcache(snap)
 	return cloneSnapshot(snap), nil
@@ -248,6 +251,23 @@ func ListSchedulerNodes(ctx context.Context) ([]*node.Node, error) {
 		out = append(out, toSchedulerNode(snap))
 	}
 	return out, nil
+}
+
+func (s *service) getNode(nodeID string) *NodeSnapshot {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.nodes[nodeID]
+}
+
+// resolveMaxMvmNum preserves the existing MaxMvmNum when the incoming request
+// doesn't specify one (<=0). This allows admin-configured limits (set via DB
+// or config) to survive cubelet restarts where the cubelet calculates a
+// different value from available memory.
+func resolveMaxMvmNum(existing *NodeSnapshot, reqMaxMvmNum int64) int64 {
+	if existing != nil && existing.MaxMvmNum > 0 && reqMaxMvmNum <= 0 {
+		return existing.MaxMvmNum
+	}
+	return reqMaxMvmNum
 }
 
 func (s *service) ensureNode(nodeID string) *NodeSnapshot {

--- a/CubeMaster/pkg/nodemeta/service_maxmvm_test.go
+++ b/CubeMaster/pkg/nodemeta/service_maxmvm_test.go
@@ -1,0 +1,73 @@
+package nodemeta
+
+import (
+	"testing"
+)
+
+func TestGetNodeReturnsNilForMissing(t *testing.T) {
+	s := &service{nodes: make(map[string]*NodeSnapshot)}
+	if got := s.getNode("nonexistent"); got != nil {
+		t.Errorf("expected nil for missing node, got %+v", got)
+	}
+}
+
+func TestGetNodeReturnsExisting(t *testing.T) {
+	s := &service{nodes: make(map[string]*NodeSnapshot)}
+	s.nodes["node-1"] = &NodeSnapshot{NodeID: "node-1", MaxMvmNum: 500}
+	got := s.getNode("node-1")
+	if got == nil {
+		t.Fatal("expected non-nil for existing node")
+	}
+	if got.MaxMvmNum != 500 {
+		t.Errorf("expected MaxMvmNum=500, got %d", got.MaxMvmNum)
+	}
+}
+
+func TestResolveMaxMvmNum(t *testing.T) {
+	tests := []struct {
+		name          string
+		existing      *NodeSnapshot
+		reqMaxMvmNum  int64
+		wantMaxMvmNum int64
+	}{
+		{
+			name:          "preserve existing when request is zero",
+			existing:      &NodeSnapshot{MaxMvmNum: 500},
+			reqMaxMvmNum:  0,
+			wantMaxMvmNum: 500,
+		},
+		{
+			name:          "preserve existing when request is negative",
+			existing:      &NodeSnapshot{MaxMvmNum: 500},
+			reqMaxMvmNum:  -1,
+			wantMaxMvmNum: 500,
+		},
+		{
+			name:          "use request when request has value",
+			existing:      &NodeSnapshot{MaxMvmNum: 500},
+			reqMaxMvmNum:  300,
+			wantMaxMvmNum: 300,
+		},
+		{
+			name:          "use request when no existing node",
+			existing:      nil,
+			reqMaxMvmNum:  200,
+			wantMaxMvmNum: 200,
+		},
+		{
+			name:          "use request when existing has no limit",
+			existing:      &NodeSnapshot{MaxMvmNum: 0},
+			reqMaxMvmNum:  200,
+			wantMaxMvmNum: 200,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := resolveMaxMvmNum(tt.existing, tt.reqMaxMvmNum)
+			if got != tt.wantMaxMvmNum {
+				t.Errorf("resolveMaxMvmNum() = %d, want %d", got, tt.wantMaxMvmNum)
+			}
+		})
+	}
+}


### PR DESCRIPTION
When a cubelet registers with the scheduler, RegisterNode unconditionally overwrites MaxMvmNum from the request. This means any admin-configured limit (set directly in the database) is lost when the cubelet restarts, because the cubelet calculates its own value from available memory.

The fix preserves the existing MaxMvmNum when the incoming request doesn't specify one (<=0), allowing scheduler-side limits to survive cubelet restarts.