### PR TITLE
fix(deploy): wait for quickcheck containers to be ready

### DIFF
--- a/deploy/one-click/scripts/one-click/quickcheck.sh
+++ b/deploy/one-click/scripts/one-click/quickcheck.sh
@@ -21,9 +21,28 @@ check_unit_active() {
 
 check_container_ready() {
   local container="$1"
+  local timeout="${CUBE_QUICKCHECK_CONTAINER_TIMEOUT:-60}"
+  local interval=2
+  local elapsed=0
   local status
-  status="$(docker inspect --format '{{if .State.Health}}{{.State.Health.Status}}{{else}}{{.State.Status}}{{end}}' "${container}" 2>/dev/null || true)"
-  [[ "${status}" == "healthy" || "${status}" == "running" ]] || die "container is not ready: ${container} (status=${status:-unknown})"
+  while :; do
+    status="$(docker inspect --format '{{if .State.Health}}{{.State.Health.Status}}{{else}}{{.State.Status}}{{end}}' "${container}" 2>/dev/null || true)"
+    case "${status}" in
+      healthy|running)
+        return 0
+        ;;
+      starting)
+        ;;
+      *)
+        die "container is not ready: ${container} (status=${status:-unknown})"
+        ;;
+    esac
+    if (( elapsed >= timeout )); then
+      die "container is not ready within ${timeout}s: ${container} (status=${status:-unknown})"
+    fi
+    sleep "${interval}"
+    elapsed=$(( elapsed + interval ))
+  done
 }
 
 echo "[quickcheck] role=${ROLE}"


### PR DESCRIPTION
## Summary
- Poll one-click quickcheck container state while Docker reports `starting`.
- Fix a deployment race where `cube-webui` can still be `starting` because its container health check interval is 10s; the quickcheck script can also reach the container check at around 10s, before Docker has refreshed the health status, causing deployment to fail with:

```text
[one-click-runtime] ERROR: container is not ready: cube-webui (status=starting)
```

- Keep failing fast for missing or unhealthy containers, with a configurable timeout via `CUBE_QUICKCHECK_CONTAINER_TIMEOUT`.


Assisted-by: Cursor:GPT-5.5