### PR TITLE
feat(template): enforce minimum resource constraints for templates and sandbox creation

### DIFF
--- a/CubeMaster/pkg/base/config/config.go
+++ b/CubeMaster/pkg/base/config/config.go
@@ -163,11 +163,55 @@ type SchedulerConf struct {
 	DisableBackoffFilterInstanceType map[string]bool                   `yaml:"disable_backoff_filter_instance_type"`
 	ThirtpartyFilterInstanceType     map[string]bool                   `yaml:"thirtparty_filter_instance_type"`
 	InstanceTypeConf                 map[string]InstanceTypeConf       `yaml:"instance_type_conf"`
+	ResourceConstraints              *ResourceConstraints              `yaml:"resource_constraints"`
 }
 
 type WrapperSchedulerConf struct {
 	SchedulerConf           `yaml:",inline"`
 	labelRefInstanceTypeMap map[string]string
+}
+
+// ResourceConstraints defines minimum CPU and memory requirements for templates
+// and sandbox creation. When configured, any container with resources below
+// these thresholds will be rejected.
+type ResourceConstraints struct {
+	MinCPU    string `yaml:"min_cpu"`    // e.g., "100m"
+	MinMemory string `yaml:"min_memory"` // e.g., "128Mi"
+	minCPU    resource.Quantity
+	minMem    resource.Quantity
+	parsed    bool
+}
+
+// MinCPURes returns the parsed minimum CPU quantity. If preHandleScheduler has
+// already cached the value, it is returned directly. Otherwise the string is
+// parsed on demand (e.g. in tests that construct ResourceConstraints directly).
+func (rc *ResourceConstraints) MinCPURes() (resource.Quantity, error) {
+	if rc.parsed {
+		return rc.minCPU, nil
+	}
+	if rc.MinCPU == "" {
+		return resource.Quantity{}, nil
+	}
+	q, err := resource.ParseQuantity(rc.MinCPU)
+	if err != nil {
+		return resource.Quantity{}, fmt.Errorf("invalid min_cpu %q: %w", rc.MinCPU, err)
+	}
+	return q, nil
+}
+
+// MinMemoryRes returns the parsed minimum memory quantity. See MinCPURes.
+func (rc *ResourceConstraints) MinMemoryRes() (resource.Quantity, error) {
+	if rc.parsed {
+		return rc.minMem, nil
+	}
+	if rc.MinMemory == "" {
+		return resource.Quantity{}, nil
+	}
+	q, err := resource.ParseQuantity(rc.MinMemory)
+	if err != nil {
+		return resource.Quantity{}, fmt.Errorf("invalid min_memory %q: %w", rc.MinMemory, err)
+	}
+	return q, nil
 }
 
 type InstanceTypeConf struct {
@@ -742,6 +786,31 @@ func preHandleScheduler(config *Config) error {
 		config.Scheduler.maxMem = resource.MustParse(config.Scheduler.MaxMvmMemory)
 	}
 
+	if config.Scheduler.ResourceConstraints != nil {
+		rc := config.Scheduler.ResourceConstraints
+		if rc.MinCPU != "" {
+			q, err := resource.ParseQuantity(rc.MinCPU)
+			if err != nil {
+				return fmt.Errorf("Scheduler.ResourceConstraints.MinCPU invalid: %w", err)
+			}
+			if q.Cmp(resource.MustParse("0")) <= 0 {
+				return fmt.Errorf("Scheduler.ResourceConstraints.MinCPU must be positive, got %s", rc.MinCPU)
+			}
+			rc.minCPU = q
+		}
+		if rc.MinMemory != "" {
+			q, err := resource.ParseQuantity(rc.MinMemory)
+			if err != nil {
+				return fmt.Errorf("Scheduler.ResourceConstraints.MinMemory invalid: %w", err)
+			}
+			if q.Cmp(resource.MustParse("0")) <= 0 {
+				return fmt.Errorf("Scheduler.ResourceConstraints.MinMemory must be positive, got %s", rc.MinMemory)
+			}
+			rc.minMem = q
+		}
+		rc.parsed = true
+	}
+
 	if config.Scheduler.LargeSizeAffinityConf != nil {
 		for _, v := range config.Scheduler.LargeSizeAffinityConf {
 			if !v.Enable {
@@ -874,6 +943,11 @@ func validate(cfg *Config) error {
 //go:noinline
 func GetConfig() *Config {
 	return cfg
+}
+
+// SetConfigForTest injects a Config for testing purposes.
+func SetConfigForTest(c *Config) {
+	cfg = c
 }
 
 func notify(config *Config) {

--- a/CubeMaster/pkg/service/httpservice/cube/sandbox_create.go
+++ b/CubeMaster/pkg/service/httpservice/cube/sandbox_create.go
@@ -103,6 +103,9 @@ func constructCreateReq(r *http.Request) (*types.CreateCubeSandboxReq, error) {
 	if req.Namespace == "" {
 		req.Namespace = "default"
 	}
+	if err := templatecenter.ValidateResourceConstraints(req.Containers); err != nil {
+		return nil, err
+	}
 	return req, nil
 }
 

--- a/CubeMaster/pkg/templatecenter/resource_validation.go
+++ b/CubeMaster/pkg/templatecenter/resource_validation.go
@@ -1,0 +1,74 @@
+// Copyright (c) 2024 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package templatecenter
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/config"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/service/sandbox/types"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+// ValidateResourceConstraints checks that container resources meet minimum
+// requirements defined in the scheduler config. Returns nil if no constraints
+// are configured or if all containers pass validation. All violations across
+// containers are collected into a single error.
+func ValidateResourceConstraints(containers []*types.Container) error {
+	cfg := config.GetConfig()
+	if cfg == nil || cfg.Scheduler == nil || cfg.Scheduler.ResourceConstraints == nil {
+		return nil
+	}
+	rc := cfg.Scheduler.ResourceConstraints
+
+	var errs []string
+	for _, ctr := range containers {
+		if ctr == nil || ctr.Resources == nil {
+			continue
+		}
+		if err := validateContainerResource(ctr.Name, ctr.Resources, rc); err != nil {
+			errs = append(errs, err.Error())
+		}
+	}
+	if len(errs) > 0 {
+		return fmt.Errorf("resource constraint violations:\n%s", strings.Join(errs, "\n"))
+	}
+	return nil
+}
+
+func validateContainerResource(name string, res *types.Resource, rc *config.ResourceConstraints) error {
+	var errs []string
+
+	if res.Cpu != "" && rc.MinCPU != "" {
+		cpu, err := resource.ParseQuantity(res.Cpu)
+		if err != nil {
+			return fmt.Errorf("container '%s' has invalid cpu value '%s': %w", name, res.Cpu, err)
+		}
+		minCPU, err := rc.MinCPURes()
+		if err != nil {
+			return fmt.Errorf("container '%s': %w", name, err)
+		}
+		if cpu.Cmp(minCPU) < 0 {
+			errs = append(errs, fmt.Sprintf("container '%s' cpu '%s' is below minimum '%s'", name, res.Cpu, rc.MinCPU))
+		}
+	}
+	if res.Mem != "" && rc.MinMemory != "" {
+		mem, err := resource.ParseQuantity(res.Mem)
+		if err != nil {
+			return fmt.Errorf("container '%s' has invalid memory value '%s': %w", name, res.Mem, err)
+		}
+		minMem, err := rc.MinMemoryRes()
+		if err != nil {
+			return fmt.Errorf("container '%s': %w", name, err)
+		}
+		if mem.Cmp(minMem) < 0 {
+			errs = append(errs, fmt.Sprintf("container '%s' memory '%s' is below minimum '%s'", name, res.Mem, rc.MinMemory))
+		}
+	}
+	if len(errs) > 0 {
+		return fmt.Errorf("%s", strings.Join(errs, "; "))
+	}
+	return nil
+}

--- a/CubeMaster/pkg/templatecenter/resource_validation_test.go
+++ b/CubeMaster/pkg/templatecenter/resource_validation_test.go
@@ -1,0 +1,204 @@
+// Copyright (c) 2024 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package templatecenter
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/config"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/service/sandbox/types"
+)
+
+func TestMain(m *testing.M) {
+	config.SetConfigForTest(&config.Config{
+		Scheduler: &config.WrapperSchedulerConf{},
+	})
+	os.Exit(m.Run())
+}
+
+// withConstraints sets ResourceConstraints for the duration of fn, then
+// restores the original value. Centralises the save/restore boilerplate.
+func withConstraints(t *testing.T, rc *config.ResourceConstraints, fn func(*testing.T)) {
+	t.Helper()
+	cfg := config.GetConfig()
+	orig := cfg.Scheduler.ResourceConstraints
+	cfg.Scheduler.ResourceConstraints = rc
+	defer func() { cfg.Scheduler.ResourceConstraints = orig }()
+	fn(t)
+}
+
+func TestValidateResourceConstraints_NilConstraints(t *testing.T) {
+	withConstraints(t, nil, func(t *testing.T) {
+		containers := []*types.Container{
+			{Name: "c1", Resources: &types.Resource{Cpu: "1m", Mem: "1Mi"}},
+		}
+		if err := ValidateResourceConstraints(containers); err != nil {
+			t.Fatalf("expected nil error when constraints not configured, got: %v", err)
+		}
+	})
+}
+
+func TestValidateResourceConstraints_NilContainers(t *testing.T) {
+	rc := &config.ResourceConstraints{MinCPU: "100m", MinMemory: "128Mi"}
+	withConstraints(t, rc, func(t *testing.T) {
+		if err := ValidateResourceConstraints(nil); err != nil {
+			t.Fatalf("expected nil error for nil containers, got: %v", err)
+		}
+	})
+}
+
+func TestValidateResourceConstraints_ContainerWithNilResources(t *testing.T) {
+	rc := &config.ResourceConstraints{MinCPU: "100m", MinMemory: "128Mi"}
+	withConstraints(t, rc, func(t *testing.T) {
+		containers := []*types.Container{
+			{Name: "c1", Resources: nil},
+		}
+		if err := ValidateResourceConstraints(containers); err != nil {
+			t.Fatalf("expected nil error for nil resources, got: %v", err)
+		}
+	})
+}
+
+func TestValidateResourceConstraints_BelowMinCPU(t *testing.T) {
+	rc := &config.ResourceConstraints{MinCPU: "100m", MinMemory: "128Mi"}
+	withConstraints(t, rc, func(t *testing.T) {
+		containers := []*types.Container{
+			{Name: "c1", Resources: &types.Resource{Cpu: "50m", Mem: "256Mi"}},
+		}
+		err := ValidateResourceConstraints(containers)
+		if err == nil {
+			t.Fatal("expected error for cpu below minimum")
+		}
+		if !strings.Contains(err.Error(), "cpu '50m' is below minimum '100m'") {
+			t.Fatalf("unexpected error message: %v", err)
+		}
+	})
+}
+
+func TestValidateResourceConstraints_BelowMinMemory(t *testing.T) {
+	rc := &config.ResourceConstraints{MinCPU: "100m", MinMemory: "128Mi"}
+	withConstraints(t, rc, func(t *testing.T) {
+		containers := []*types.Container{
+			{Name: "c1", Resources: &types.Resource{Cpu: "2000m", Mem: "64Mi"}},
+		}
+		err := ValidateResourceConstraints(containers)
+		if err == nil {
+			t.Fatal("expected error for memory below minimum")
+		}
+		if !strings.Contains(err.Error(), "memory '64Mi' is below minimum '128Mi'") {
+			t.Fatalf("unexpected error message: %v", err)
+		}
+	})
+}
+
+func TestValidateResourceConstraints_AtExactMinimum(t *testing.T) {
+	rc := &config.ResourceConstraints{MinCPU: "100m", MinMemory: "128Mi"}
+	withConstraints(t, rc, func(t *testing.T) {
+		containers := []*types.Container{
+			{Name: "c1", Resources: &types.Resource{Cpu: "100m", Mem: "128Mi"}},
+		}
+		if err := ValidateResourceConstraints(containers); err != nil {
+			t.Fatalf("expected nil error at exact minimum, got: %v", err)
+		}
+	})
+}
+
+func TestValidateResourceConstraints_AboveMinimum(t *testing.T) {
+	rc := &config.ResourceConstraints{MinCPU: "100m", MinMemory: "128Mi"}
+	withConstraints(t, rc, func(t *testing.T) {
+		containers := []*types.Container{
+			{Name: "c1", Resources: &types.Resource{Cpu: "2000m", Mem: "2000Mi"}},
+		}
+		if err := ValidateResourceConstraints(containers); err != nil {
+			t.Fatalf("expected nil error above minimum, got: %v", err)
+		}
+	})
+}
+
+func TestValidateResourceConstraints_MultipleContainers(t *testing.T) {
+	rc := &config.ResourceConstraints{MinCPU: "100m", MinMemory: "128Mi"}
+	withConstraints(t, rc, func(t *testing.T) {
+		containers := []*types.Container{
+			{Name: "c1", Resources: &types.Resource{Cpu: "50m", Mem: "64Mi"}},
+			{Name: "c2", Resources: &types.Resource{Cpu: "50m", Mem: "256Mi"}},
+		}
+		err := ValidateResourceConstraints(containers)
+		if err == nil {
+			t.Fatal("expected error for containers below minimum")
+		}
+		errStr := err.Error()
+		if !strings.Contains(errStr, "container 'c1'") {
+			t.Fatalf("expected error to reference container 'c1', got: %v", err)
+		}
+		if !strings.Contains(errStr, "container 'c2'") {
+			t.Fatalf("expected error to reference container 'c2', got: %v", err)
+		}
+	})
+}
+
+func TestValidateResourceConstraints_BothCPUAndMemoryViolation(t *testing.T) {
+	rc := &config.ResourceConstraints{MinCPU: "100m", MinMemory: "128Mi"}
+	withConstraints(t, rc, func(t *testing.T) {
+		containers := []*types.Container{
+			{Name: "c1", Resources: &types.Resource{Cpu: "50m", Mem: "64Mi"}},
+		}
+		err := ValidateResourceConstraints(containers)
+		if err == nil {
+			t.Fatal("expected error for both cpu and memory below minimum")
+		}
+		errStr := err.Error()
+		if !strings.Contains(errStr, "cpu '50m'") {
+			t.Fatalf("expected cpu violation in error, got: %v", err)
+		}
+		if !strings.Contains(errStr, "memory '64Mi'") {
+			t.Fatalf("expected memory violation in error, got: %v", err)
+		}
+	})
+}
+
+func TestValidateResourceConstraints_InvalidCPUString(t *testing.T) {
+	rc := &config.ResourceConstraints{MinCPU: "100m", MinMemory: "128Mi"}
+	withConstraints(t, rc, func(t *testing.T) {
+		containers := []*types.Container{
+			{Name: "c1", Resources: &types.Resource{Cpu: "invalid", Mem: "256Mi"}},
+		}
+		err := ValidateResourceConstraints(containers)
+		if err == nil {
+			t.Fatal("expected error for invalid cpu value")
+		}
+		if !strings.Contains(err.Error(), "invalid cpu value") {
+			t.Fatalf("unexpected error message: %v", err)
+		}
+	})
+}
+
+func TestValidateResourceConstraints_InvalidMemoryString(t *testing.T) {
+	rc := &config.ResourceConstraints{MinCPU: "100m", MinMemory: "128Mi"}
+	withConstraints(t, rc, func(t *testing.T) {
+		containers := []*types.Container{
+			{Name: "c1", Resources: &types.Resource{Cpu: "200m", Mem: "invalid"}},
+		}
+		err := ValidateResourceConstraints(containers)
+		if err == nil {
+			t.Fatal("expected error for invalid memory value")
+		}
+		if !strings.Contains(err.Error(), "invalid memory value") {
+			t.Fatalf("unexpected error message: %v", err)
+		}
+	})
+}
+
+func TestValidateResourceConstraints_EmptyResourceValues(t *testing.T) {
+	rc := &config.ResourceConstraints{MinCPU: "100m", MinMemory: "128Mi"}
+	withConstraints(t, rc, func(t *testing.T) {
+		containers := []*types.Container{
+			{Name: "c1", Resources: &types.Resource{Cpu: "", Mem: ""}},
+		}
+		if err := ValidateResourceConstraints(containers); err != nil {
+			t.Fatalf("expected nil error for empty resource values, got: %v", err)
+		}
+	})
+}

--- a/CubeMaster/pkg/templatecenter/store.go
+++ b/CubeMaster/pkg/templatecenter/store.go
@@ -311,6 +311,9 @@ func NormalizeRequest(req *sandboxtypes.CreateCubeSandboxReq) (*sandboxtypes.Cre
 		version = DefaultTemplateVersion
 	}
 	constants.SetAppSnapshotVersion(cloned.Annotations, version)
+	if err := ValidateResourceConstraints(cloned.Containers); err != nil {
+		return nil, "", err
+	}
 	return cloned, templateID, nil
 }
 


### PR DESCRIPTION
Add configurable minimum CPU/memory validation to prevent resource starvation.
- Add ResourceConstraints config in SchedulerConf (min_cpu, min_memory)
- Validate in NormalizeRequest (template creation) and constructCreateReq (sandbox creation)
- Backward compatible: skipped when resource_constraints not configured
- Unit tests for all validation paths