### PR TITLE
fix(deploy): align shrunk guest images to pmem boundary

### DIFF
--- a/deploy/one-click/build-vm-assets.sh
+++ b/deploy/one-click/build-vm-assets.sh
@@ -280,12 +280,22 @@ dump_ext4_header() {
 
 SHRINK_RESERVED_BYTES="${ONE_CLICK_GUEST_IMAGE_RESERVED_BYTES:-$((32 * 1024 * 1024))}"
 
+# The cube hypervisor exposes the guest image as a pmem device, and the device
+# manager rejects pmem regions whose size is not a multiple of 2 MiB (matches
+# the guest hugepage granularity, see hypervisor/vmm/src/device_manager.rs:
+# `if size % 0x20_0000 != 0 { Err(PmemSizeNotAligned) }`). The shrink path
+# below must therefore round the final image size *up* to a 2 MiB boundary
+# instead of stopping at ext4's natural block alignment (4 KiB), otherwise
+# template launch fails with PmemSizeNotAligned.
+PMEM_ALIGN_BYTES=$((2 * 1024 * 1024))
+
 # Shrink the ext4 image to its minimum size, then grow it by RESERVED bytes of
 # free headroom so the guest still has room for runtime writes.
 shrink_ext4_image() {
   local img="$1"
   local reserved_bytes="${2:-${SHRINK_RESERVED_BYTES}}"
   local dumpe2fs_out block_size min_blocks reserved_blocks target_blocks final_bytes min_bytes
+  local pmem_align_blocks
 
   run_as_root e2fsck -fy "${img}" >&2 || true
   run_as_root resize2fs -M "${img}" >&2
@@ -298,8 +308,22 @@ shrink_ext4_image() {
     die "failed to parse ext4 metadata from ${img}"
   fi
 
+  # ext4 block sizes are always a power of two (1/2/4 KiB), so 2 MiB is an
+  # exact multiple of every legal block size. Verify defensively so a future
+  # exotic block size produces a clear error instead of a subtly misaligned
+  # image that only fails inside the VMM.
+  if (( PMEM_ALIGN_BYTES % block_size != 0 )); then
+    die "pmem alignment ${PMEM_ALIGN_BYTES} not a multiple of ext4 block size ${block_size}"
+  fi
+  pmem_align_blocks="$(( PMEM_ALIGN_BYTES / block_size ))"
+
   reserved_blocks="$(( (reserved_bytes + block_size - 1) / block_size ))"
   target_blocks="$(( min_blocks + reserved_blocks ))"
+  # Round target_blocks UP to the pmem alignment so the resulting image size
+  # (target_blocks * block_size) is a multiple of 2 MiB. Rounding up only ever
+  # grows the headroom (worst case <2 MiB extra), so it cannot truncate live
+  # filesystem data.
+  target_blocks="$(( ((target_blocks + pmem_align_blocks - 1) / pmem_align_blocks) * pmem_align_blocks ))"
   final_bytes="$(( target_blocks * block_size ))"
   min_bytes="$(( min_blocks * block_size ))"
 
@@ -308,6 +332,9 @@ shrink_ext4_image() {
   # but we want a clear failure if future refactors break the invariant.
   if (( final_bytes < min_bytes )); then
     die "shrink target ${final_bytes} smaller than ext4 minimum ${min_bytes}"
+  fi
+  if (( final_bytes % PMEM_ALIGN_BYTES != 0 )); then
+    die "shrink target ${final_bytes} not aligned to pmem boundary ${PMEM_ALIGN_BYTES}"
   fi
 
   # The resulting ext4 file is sparse: ext4 free space inside the image
@@ -322,7 +349,7 @@ shrink_ext4_image() {
   local human_final human_reserved
   human_final="$(numfmt --to=iec --suffix=B "${final_bytes}" 2>/dev/null || echo "${final_bytes}")"
   human_reserved="$(numfmt --to=iec --suffix=B "${reserved_bytes}" 2>/dev/null || echo "${reserved_bytes}")"
-  log "guest image shrunk to ${human_final} (reserved ${human_reserved} headroom)"
+  log "guest image shrunk to ${human_final} (reserved ${human_reserved} headroom, 2MiB pmem aligned)"
 }
 
 remove_path_with_optional_sudo() {


### PR DESCRIPTION
## Summary
- Round shrunk one-click guest image sizes up to a 2MiB boundary before the final `truncate`/`resize2fs`.
- Add a defensive alignment check so future changes fail clearly if the generated `cube-guest-image.img` is not pmem aligned.
- This is needed because the hypervisor maps `cube-guest-image.img` as a pmem device and requires the image size to be 2MiB aligned; otherwise template launch can fail with `PmemSizeNotAligned`.

## Test plan
- `bash -n deploy/one-click/build-vm-assets.sh`
- Cursor lints for `deploy/one-click/build-vm-assets.sh`

Assisted-by: Cursor:GPT-5.5

Made with [Cursor](https://cursor.com)