### PR TITLE
fix(network-agent): guard against nil service before Health check

### DIFF
--- a/network-agent/cmd/network-agent/main.go
+++ b/network-agent/cmd/network-agent/main.go
@@ -106,6 +106,12 @@ func main() {
 	if err != nil {
 		CubeLog.Fatalf("network-agent init failed: %v", err)
 	}
+	if svc == nil {
+		CubeLog.Fatalf("network-agent init returned nil service without error")
+	}
+	if v := reflect.ValueOf(svc); v.Kind() == reflect.Ptr && v.IsNil() {
+		CubeLog.Fatalf("network-agent init returned typed-nil service (type=%T)", svc)
+	}
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 	defer cancel()
 


### PR DESCRIPTION
Add explicit nil and typed-nil checks after initService returns, before calling svc.Health(). Prevents SIGSEGV when initService returns a typed-nil service that passes the interface nil check but still dereferences nil on method call.