### PR TITLE
fix(build): clear Go build cache before each build to ensure fresh binaries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -100,15 +100,15 @@ all: cubemaster cubelet network-agent
 
 cubemaster: builder-image
 	@mkdir -p "$(OUTPUT_DIR)"
-	$(MAKE) builder-run BUILDER_CMD='mkdir -p /workspace/_output/bin && cd /workspace/CubeMaster && go mod download && make proto && go build -o /workspace/_output/bin/cubemaster ./cmd/cubemaster && go build -o /workspace/_output/bin/cubemastercli ./cmd/cubemastercli'
+	$(MAKE) builder-run BUILDER_CMD='mkdir -p /workspace/_output/bin && go clean -cache && cd /workspace/CubeMaster && go mod download && make proto && go build -o /workspace/_output/bin/cubemaster ./cmd/cubemaster && go build -o /workspace/_output/bin/cubemastercli ./cmd/cubemastercli'
 
 cubelet: builder-image
 	@mkdir -p "$(OUTPUT_DIR)"
-	$(MAKE) builder-run BUILDER_CMD='mkdir -p /workspace/_output/bin && cd /workspace/Cubelet && go mod download && make proto && go build -o /workspace/_output/bin/cubelet ./cmd/cubelet && go build -o /workspace/_output/bin/cubecli ./cmd/cubecli'
+	$(MAKE) builder-run BUILDER_CMD='mkdir -p /workspace/_output/bin && go clean -cache && cd /workspace/Cubelet && go mod download && make proto && go build -o /workspace/_output/bin/cubelet ./cmd/cubelet && go build -o /workspace/_output/bin/cubecli ./cmd/cubecli'
 
 network-agent: builder-image
 	@mkdir -p "$(OUTPUT_DIR)"
-	$(MAKE) builder-run BUILDER_CMD='mkdir -p /workspace/_output/bin && cd /workspace/network-agent && make proto && go build -o /workspace/_output/bin/network-agent ./cmd/network-agent'
+	$(MAKE) builder-run BUILDER_CMD='mkdir -p /workspace/_output/bin && go clean -cache && cd /workspace/network-agent && make proto && go build -o /workspace/_output/bin/network-agent ./cmd/network-agent'
 
 agent: builder-image
 	@mkdir -p "$(OUTPUT_DIR)"

--- a/deploy/one-click/build-release-bundle-builder.sh
+++ b/deploy/one-click/build-release-bundle-builder.sh
@@ -38,6 +38,9 @@ rm -f \
   "${PREBUILT_DIR}/containerd-shim-cube-rs" \
   "${PREBUILT_DIR}/cube-runtime"
 
+echo "[one-click] clearing Go build cache to ensure fresh builds" >&2
+go clean -cache
+
 echo "[one-click] building cubemaster in builder" >&2
 (cd /workspace/CubeMaster && go mod download && go build -o "${PREBUILT_DIR}/cubemaster" ./cmd/cubemaster)
 


### PR DESCRIPTION
The Go build cache is persisted in BUILDER_HOME across container runs. In Docker + volume mount scenarios, Go's cache invalidation based on file content hashes can be unreliable, causing stale compiled artifacts to be reused even after source code changes.

Add `go clean -cache` before Go builds in both the one-click release script and the Makefile targets to guarantee fresh compilation.