### PR TITLE
fix(deploy): tolerate concurrent DNS dummy link creation

### DIFF
--- a/deploy/one-click/scripts/one-click/up-dns.sh
+++ b/deploy/one-click/scripts/one-click/up-dns.sh
@@ -130,8 +130,11 @@ link_is_dummy() {
 ensure_resolved_link() {
   if link_exists "${RESOLVED_LINK_NAME}"; then
     link_is_dummy "${RESOLVED_LINK_NAME}" || die "existing link ${RESOLVED_LINK_NAME} is not a dummy link"
-  else
-    ip link add "${RESOLVED_LINK_NAME}" type dummy
+  elif ! ip link add "${RESOLVED_LINK_NAME}" type dummy; then
+    # CoreDNS and host DNS routing may start concurrently under systemd.
+    # If another helper created the link first, accept it after validation.
+    link_exists "${RESOLVED_LINK_NAME}" || die "failed to create dummy link ${RESOLVED_LINK_NAME}"
+    link_is_dummy "${RESOLVED_LINK_NAME}" || die "existing link ${RESOLVED_LINK_NAME} is not a dummy link"
   fi
 
   ip link set "${RESOLVED_LINK_NAME}" up

--- a/deploy/one-click/scripts/systemd/coredns-start.sh
+++ b/deploy/one-click/scripts/systemd/coredns-start.sh
@@ -113,8 +113,11 @@ link_is_dummy() {
 ensure_resolved_link() {
   if link_exists "${RESOLVED_LINK_NAME}"; then
     link_is_dummy "${RESOLVED_LINK_NAME}" || die "existing link ${RESOLVED_LINK_NAME} is not a dummy link"
-  else
-    ip link add "${RESOLVED_LINK_NAME}" type dummy
+  elif ! ip link add "${RESOLVED_LINK_NAME}" type dummy; then
+    # CoreDNS and host DNS routing may start concurrently under systemd.
+    # If another helper created the link first, accept it after validation.
+    link_exists "${RESOLVED_LINK_NAME}" || die "failed to create dummy link ${RESOLVED_LINK_NAME}"
+    link_is_dummy "${RESOLVED_LINK_NAME}" || die "existing link ${RESOLVED_LINK_NAME} is not a dummy link"
   fi
 
   ip link set "${RESOLVED_LINK_NAME}" up

--- a/deploy/one-click/scripts/systemd/dns-host-route-up.sh
+++ b/deploy/one-click/scripts/systemd/dns-host-route-up.sh
@@ -47,8 +47,11 @@ link_is_dummy() {
 ensure_resolved_link() {
   if link_exists "${RESOLVED_LINK_NAME}"; then
     link_is_dummy "${RESOLVED_LINK_NAME}" || die "existing link ${RESOLVED_LINK_NAME} is not a dummy link"
-  else
-    ip link add "${RESOLVED_LINK_NAME}" type dummy
+  elif ! ip link add "${RESOLVED_LINK_NAME}" type dummy; then
+    # CoreDNS and host DNS routing may start concurrently under systemd.
+    # If another helper created the link first, accept it after validation.
+    link_exists "${RESOLVED_LINK_NAME}" || die "failed to create dummy link ${RESOLVED_LINK_NAME}"
+    link_is_dummy "${RESOLVED_LINK_NAME}" || die "existing link ${RESOLVED_LINK_NAME} is not a dummy link"
   fi
 
   ip link set "${RESOLVED_LINK_NAME}" up


### PR DESCRIPTION
## Summary

- Fix a one-click DNS startup race where `coredns-start.sh` and `dns-host-route-up.sh` can both attempt to create `cube-dns0`.
- Re-check the link after `ip link add` fails, accepting an already-created dummy link while still rejecting non-dummy name conflicts.
- Apply the same idempotent helper behavior to the legacy `up-dns.sh` path.

## Test Plan

- `bash -n deploy/one-click/scripts/systemd/coredns-start.sh deploy/one-click/scripts/systemd/dns-host-route-up.sh deploy/one-click/scripts/one-click/up-dns.sh`
- `git diff --check`
- On Ubuntu 24.04 PVM host, ran 10 rounds of concurrent `dns-host-route-up.sh` invocations after deleting `cube-dns0`.
- Restarted `cube-sandbox-control.target` and verified `cube-sandbox-coredns.service` and `cube-sandbox-dns.service` are active.
- Ran `/usr/local/services/cubetoolbox/scripts/one-click/quickcheck.sh` and verified `[quickcheck] OK`.