### PR TITLE
feat(python-sdk): add template creation API

### DIFF
--- a/sdk/python/cubesandbox/_models.py
+++ b/sdk/python/cubesandbox/_models.py
@@ -3,7 +3,9 @@
 
 from __future__ import annotations
 
+import json as jsonlib
 from dataclasses import dataclass, field
+from typing import Any, Iterable
 
 
 @dataclass
@@ -11,12 +13,26 @@ class Logs:
     stdout: list[str] = field(default_factory=list)
     stderr: list[str] = field(default_factory=list)
 
+    def to_json(self) -> str:
+        return jsonlib.dumps({"stdout": self.stdout, "stderr": self.stderr})
+
 
 @dataclass
 class ExecutionError:
     name: str
     value: str
-    traceback: list[str] = field(default_factory=list)
+    traceback: str = ""
+
+    def __init__(self, name: str, value: str, traceback: str | list[str] | None = "", **_: Any):
+        self.name = name
+        self.value = value
+        if isinstance(traceback, list):
+            self.traceback = "\n".join(traceback)
+        else:
+            self.traceback = traceback or ""
+
+    def to_json(self) -> str:
+        return jsonlib.dumps({"name": self.name, "value": self.value, "traceback": self.traceback})
 
 
 @dataclass
@@ -31,8 +47,113 @@ class Result:
     latex: str | None = None
     json: dict | None = None
     javascript: str | None = None
+    data: dict | None = None
+    chart: Any | None = None
     is_main_result: bool = False
     extra: dict | None = None
+
+    def __init__(
+        self,
+        text: str | None = None,
+        html: str | None = None,
+        markdown: str | None = None,
+        svg: str | None = None,
+        png: str | None = None,
+        jpeg: str | None = None,
+        pdf: str | None = None,
+        latex: str | None = None,
+        json: dict | None = None,
+        json_data: dict | None = None,
+        javascript: str | None = None,
+        data: dict | None = None,
+        chart: Any | None = None,
+        is_main_result: bool = False,
+        extra: dict | None = None,
+        **_: Any,
+    ):
+        self.text = text
+        self.html = html
+        self.markdown = markdown
+        self.svg = svg
+        self.png = png
+        self.jpeg = jpeg
+        self.pdf = pdf
+        self.latex = latex
+        self.json = json if json is not None else json_data
+        self.javascript = javascript
+        self.data = data
+        self.chart = chart
+        self.is_main_result = is_main_result
+        self.extra = extra
+
+    def __getitem__(self, item: str) -> Any:
+        return getattr(self, item)
+
+    @property
+    def json_data(self) -> dict | None:
+        """Backward-compatible alias for E2B's ``json`` field."""
+        return self.json
+
+    @json_data.setter
+    def json_data(self, value: dict | None) -> None:
+        self.json = value
+
+    def formats(self) -> Iterable[str]:
+        formats: list[str] = []
+        for key in (
+            "text",
+            "html",
+            "markdown",
+            "svg",
+            "png",
+            "jpeg",
+            "pdf",
+            "latex",
+            "json",
+            "javascript",
+            "data",
+            "chart",
+        ):
+            if getattr(self, key):
+                formats.append(key)
+        if self.extra:
+            formats.extend(self.extra.keys())
+        return formats
+
+    def __str__(self) -> str:
+        return self.__repr__()
+
+    def __repr__(self) -> str:
+        if self.text:
+            return f"Result({self.text})"
+        return "Result(Formats: " + ", ".join(self.formats()) + ")"
+
+    def _repr_html_(self) -> str | None:
+        return self.html
+
+    def _repr_markdown_(self) -> str | None:
+        return self.markdown
+
+    def _repr_svg_(self) -> str | None:
+        return self.svg
+
+    def _repr_png_(self) -> str | None:
+        return self.png
+
+    def _repr_jpeg_(self) -> str | None:
+        return self.jpeg
+
+    def _repr_pdf_(self) -> str | None:
+        return self.pdf
+
+    def _repr_latex_(self) -> str | None:
+        return self.latex
+
+    def _repr_json_(self) -> dict | None:
+        return self.json
+
+    def _repr_javascript_(self) -> str | None:
+        return self.javascript
 
 
 @dataclass
@@ -51,12 +172,21 @@ class Execution:
         return None
 
     def __repr__(self) -> str:
-        return f"Execution(text={self.text!r}, error={self.error})"
+        return f"Execution(Results: {self.results}, Logs: {self.logs}, Error: {self.error})"
+
+    def to_json(self) -> str:
+        data = {
+            "results": _serialize_results(self.results),
+            "logs": self.logs.to_json(),
+            "error": self.error.to_json() if self.error else None,
+        }
+        return jsonlib.dumps(data)
 
 
 @dataclass
 class SnapshotInfo:
     """Metadata returned by snapshot-related APIs."""
+
     snapshot_id: str
     names: list[str] = field(default_factory=list)
 
@@ -68,8 +198,48 @@ class SnapshotInfo:
         )
 
 
-@dataclass
+@dataclass(init=False)
 class OutputMessage:
-    text: str
-    timestamp: str = ""
-    is_stderr: bool = False
+    line: str
+    timestamp: int | str = ""
+    error: bool = False
+
+    def __init__(
+        self,
+        line: str | None = None,
+        timestamp: int | str = "",
+        error: bool = False,
+        *,
+        text: str | None = None,
+        is_stderr: bool | None = None,
+    ):
+        self.line = line if line is not None else (text or "")
+        self.timestamp = timestamp
+        self.error = error if is_stderr is None else is_stderr
+
+    @property
+    def text(self) -> str:
+        """Backward-compatible alias for E2B's ``line`` field."""
+        return self.line
+
+    @property
+    def is_stderr(self) -> bool:
+        """Backward-compatible alias for E2B's ``error`` field."""
+        return self.error
+
+    def __str__(self) -> str:
+        return self.line
+
+
+def _serialize_results(results: list[Result]) -> list[dict[str, Any]]:
+    serialized = []
+    for result in results:
+        item: dict[str, Any] = {}
+        for key in result.formats():
+            value = result[key]
+            if key == "chart" and hasattr(value, "to_dict"):
+                value = value.to_dict()
+            item[key] = value
+        item["text"] = result.text
+        serialized.append(item)
+    return serialized

--- a/sdk/python/cubesandbox/_stream.py
+++ b/sdk/python/cubesandbox/_stream.py
@@ -31,7 +31,7 @@ def _parse_line(
     event_type = data.pop("type", None)
 
     if event_type == "result":
-        result = Result(**{k: v for k, v in data.items() if k in Result.__dataclass_fields__})
+        result = Result(**data)
         execution.results.append(result)
         if on_result:
             on_result(result)
@@ -46,7 +46,7 @@ def _parse_line(
         text = data.get("text", "")
         execution.logs.stderr.append(text)
         if on_stderr:
-            on_stderr(OutputMessage(text, data.get("timestamp", ""), is_stderr=True))
+            on_stderr(OutputMessage(text, data.get("timestamp", ""), True))
 
     elif event_type == "error":
         execution.error = ExecutionError(

--- a/sdk/python/cubesandbox/_template.py
+++ b/sdk/python/cubesandbox/_template.py
@@ -29,10 +29,15 @@ def _check_response(resp: requests.Response) -> None:
 
 @dataclass
 class TemplateBuild:
-    """A single build record for a template."""
+    """A template create/rebuild job or build status record."""
 
     build_id: str
     status: str
+    template_id: str = ""
+    phase: str = ""
+    progress: int = 0
+    error_message: str = ""
+    message: str = ""
     created_at: str = ""
     finished_at: str = ""
     logs: list[str] = field(default_factory=list)
@@ -40,12 +45,22 @@ class TemplateBuild:
     @classmethod
     def from_dict(cls, data: dict) -> "TemplateBuild":
         return cls(
-            build_id=data.get("buildID") or data.get("build_id", ""),
+            build_id=data.get("buildID") or data.get("jobID") or data.get("build_id", ""),
+            template_id=data.get("templateID") or data.get("template_id", ""),
             status=data.get("status", ""),
+            phase=data.get("phase", ""),
+            progress=data.get("progress", 0),
+            error_message=data.get("errorMessage") or data.get("error_message", ""),
+            message=data.get("message", ""),
             created_at=data.get("createdAt") or data.get("created_at", ""),
             finished_at=data.get("finishedAt") or data.get("finished_at", ""),
             logs=data.get("logs") or [],
         )
+
+    @property
+    def job_id(self) -> str:
+        """Alias for create/rebuild responses that use ``jobID``."""
+        return self.build_id
 
 
 @dataclass
@@ -54,9 +69,19 @@ class TemplateInfo:
 
     template_id: str
     name: str = ""
+    instance_type: str = ""
+    version: str = ""
+    status: str = ""
+    last_error: str = ""
+    created_at: str = ""
+    image_info: str = ""
     public: bool = False
     cpu_count: int = 0
     memory_mb: int = 0
+    replicas: list[dict] = field(default_factory=list)
+    create_request: dict | None = None
+    network_type: str | None = None
+    allow_internet_access: bool | None = None
     builds: list[TemplateBuild] = field(default_factory=list)
 
     @classmethod
@@ -65,9 +90,23 @@ class TemplateInfo:
         return cls(
             template_id=data.get("templateID") or data.get("template_id", ""),
             name=data.get("name") or data.get("aliases", [None])[0] or "",
+            instance_type=data.get("instanceType") or data.get("instance_type", ""),
+            version=data.get("version") or "",
+            status=data.get("status") or "",
+            last_error=data.get("lastError") or data.get("last_error", ""),
+            created_at=data.get("createdAt") or data.get("created_at", ""),
+            image_info=data.get("imageInfo") or data.get("image_info", ""),
             public=bool(data.get("public", False)),
             cpu_count=data.get("cpuCount") or data.get("cpu_count", 0),
             memory_mb=data.get("memoryMB") or data.get("memory_mb", 0),
+            replicas=data.get("replicas") or [],
+            create_request=data.get("createRequest") or data.get("create_request"),
+            network_type=data.get("networkType") or data.get("network_type"),
+            allow_internet_access=(
+                data.get("allowInternetAccess")
+                if "allowInternetAccess" in data
+                else data.get("allow_internet_access")
+            ),
             builds=[TemplateBuild.from_dict(b) for b in builds_raw],
         )
 
@@ -84,19 +123,19 @@ class Template:
         for t in templates:
             print(t.template_id, t.name)
 
-        # Build a new template from a docker image
-        info = Template.build(
+        # Build a new template from a container image
+        job = Template.build(
+            template_id="my-python-env",
             image="python:3.11-slim",
-            name="my-python-env",
         )
-        print(info.template_id)
+        print(job.job_id, job.status)
 
         # Query a specific template
         detail = Template.get("tpl-xxxxxxxxxxxxxxxxxxxxxxxx")
-        print(detail.builds)
+        print(detail.status, detail.image_info)
 
-        # Update template metadata
-        Template.update("tpl-xxx", name="new-name")
+        # Rebuild an existing template
+        Template.rebuild("tpl-xxx")
 
         # Delete a template
         Template.delete("tpl-xxx")
@@ -167,66 +206,146 @@ class Template:
     def build(
         cls,
         *,
+        template_id: str | None = None,
         name: str | None = None,
         image: str | None = None,
         dockerfile: str | None = None,
         start_cmd: str | None = None,
+        instance_type: str | None = None,
+        writable_layer_size: str | None = None,
+        exposed_ports: list[int] | None = None,
+        probe_port: int | None = None,
+        probe_path: str | None = None,
         cpu_count: int | None = None,
         memory_mb: int | None = None,
         envs: Dict[str, str] | None = None,
+        allow_internet_access: bool | None = None,
         config: Config | None = None,
         **kwargs: Any,
-    ) -> TemplateInfo:
-        """POST /v2/templates — Build (create) a new template.
+    ) -> TemplateBuild:
+        """POST /templates - Build (create) a new template from an image.
 
-        Submits a template build request and returns immediately with the
-        template info (status will be ``"building"``).  Poll
-        :meth:`get` to wait for the build to finish.
+        Submits CubeAPI's create-from-image request and returns the async job
+        accepted by CubeMaster. Poll :meth:`get_build_status` or :meth:`get`
+        to watch the build finish.
 
         Args:
-            name: Human-readable template name / alias.
+            template_id: Template ID. If omitted, CubeAPI/CubeMaster may assign one.
+            name: Deprecated alias for ``template_id``.
             image: Base container image URI (e.g. ``"python:3.11-slim"``).
-            dockerfile: Inline Dockerfile content.  Mutually exclusive with
-                *image*.
-            start_cmd: Command to run when the sandbox starts.
-            cpu_count: Number of vCPUs for the sandbox.
+            dockerfile: Not supported by CubeAPI's current template endpoint.
+            start_cmd: Not supported by CubeAPI's current template endpoint.
+            instance_type: CubeMaster instance type (defaults server-side).
+            writable_layer_size: Writable layer size, e.g. ``"1G"``.
+            exposed_ports: Container ports to expose.
+            probe_port: HTTP probe port.
+            probe_path: HTTP probe path.
+            cpu_count: CPU in millicores. Sent as CubeAPI ``cpu``.
             memory_mb: Memory limit in MiB for the sandbox.
             envs: Environment variables baked into the template.
+            allow_internet_access: Whether sandboxes from this template may access internet.
             config: SDK config.  Uses default (env-based) config if omitted.
             **kwargs: Extra fields forwarded verbatim to the request body.
 
         Returns:
-            :class:`TemplateInfo` with the new ``template_id``.
+            :class:`TemplateBuild` with ``job_id``, ``template_id`` and status fields.
 
         Raises:
+            ValueError: If ``image`` is missing or unsupported fields are used.
             ApiError: On unexpected backend error.
         """
-        cfg = config or Config()
-        payload: dict = {}
-        if name is not None:
-            payload["name"] = name
-        if image is not None:
-            payload["image"] = image
         if dockerfile is not None:
-            payload["dockerfile"] = dockerfile
+            raise ValueError("dockerfile builds are not supported by CubeAPI /templates")
         if start_cmd is not None:
-            payload["startCmd"] = start_cmd
+            raise ValueError("start_cmd is not supported by CubeAPI /templates")
+        if not image or not image.strip():
+            raise ValueError("image is required")
+
+        cfg = config or Config()
+        payload: dict = {"image": image.strip()}
+        tpl_id = template_id if template_id is not None else name
+        if tpl_id is not None:
+            payload["templateID"] = tpl_id
+        if instance_type is not None:
+            payload["instanceType"] = instance_type
+        if writable_layer_size is not None:
+            payload["writableLayerSize"] = writable_layer_size
+        if exposed_ports is not None:
+            payload["exposedPorts"] = exposed_ports
+        if probe_port is not None:
+            payload["probePort"] = probe_port
+        if probe_path is not None:
+            payload["probePath"] = probe_path
         if cpu_count is not None:
-            payload["cpuCount"] = cpu_count
+            payload["cpu"] = cpu_count
         if memory_mb is not None:
-            payload["memoryMB"] = memory_mb
+            payload["memory"] = memory_mb
         if envs is not None:
-            payload["envs"] = envs
+            payload["env"] = [f"{key}={value}" for key, value in envs.items()]
+        if allow_internet_access is not None:
+            payload["allowInternetAccess"] = allow_internet_access
         payload.update(kwargs)
 
         s = requests.Session()
         resp = s.post(
-            f"{cfg.api_url}/v2/templates",
+            f"{cfg.api_url}/templates",
             json=payload,
             headers={"Content-Type": "application/json"},
         )
         _check_response(resp)
-        return TemplateInfo.from_dict(resp.json())
+        return TemplateBuild.from_dict(resp.json())
+
+
+    @classmethod
+    def rebuild(
+        cls,
+        template_id: str,
+        *,
+        config: Config | None = None,
+        **extra: Any,
+    ) -> TemplateBuild:
+        """POST /templates/:templateID - Rebuild an existing template."""
+        cfg = config or Config()
+        s = requests.Session()
+        resp = s.post(
+            f"{cfg.api_url}/templates/{template_id}",
+            json=extra,
+            headers={"Content-Type": "application/json"},
+        )
+        _check_response(resp)
+        return TemplateBuild.from_dict(resp.json())
+
+
+    @classmethod
+    def get_build_status(
+        cls,
+        template_id: str,
+        build_id: str,
+        *,
+        config: Config | None = None,
+    ) -> TemplateBuild:
+        """GET /templates/:templateID/builds/:buildID/status."""
+        cfg = config or Config()
+        s = requests.Session()
+        resp = s.get(f"{cfg.api_url}/templates/{template_id}/builds/{build_id}/status")
+        _check_response(resp)
+        return TemplateBuild.from_dict(resp.json())
+
+
+    @classmethod
+    def get_build_logs(
+        cls,
+        template_id: str,
+        build_id: str,
+        *,
+        config: Config | None = None,
+    ) -> dict:
+        """GET /templates/:templateID/builds/:buildID/logs."""
+        cfg = config or Config()
+        s = requests.Session()
+        resp = s.get(f"{cfg.api_url}/templates/{template_id}/builds/{build_id}/logs")
+        _check_response(resp)
+        return resp.json()
 
 
     @classmethod
@@ -242,50 +361,16 @@ class Template:
         config: Config | None = None,
         **kwargs: Any,
     ) -> TemplateInfo:
-        """PATCH /v2/templates/:templateID — Update template metadata.
+        """Template metadata updates are not supported by current CubeAPI.
 
-        Only the fields you pass will be updated (PATCH semantics).
-
-        Args:
-            template_id: Template identifier.
-            name: New template name.
-            public: Whether the template is publicly accessible.
-            cpu_count: New vCPU count.
-            memory_mb: New memory limit in MiB.
-            start_cmd: New sandbox start command.
-            config: SDK config.  Uses default (env-based) config if omitted.
-            **kwargs: Extra fields forwarded verbatim to the request body.
-
-        Returns:
-            Updated :class:`TemplateInfo`.
-
-        Raises:
-            TemplateNotFoundError: If the template does not exist (HTTP 404).
-            ApiError: On unexpected backend error.
+        CubeAPI exposes ``PATCH /templates/:templateID`` but the handler
+        returns NotImplemented. Use :meth:`rebuild` to rebuild a template or
+        delete and recreate it.
         """
-        cfg = config or Config()
-        payload: dict = {}
-        if name is not None:
-            payload["name"] = name
-        if public is not None:
-            payload["public"] = public
-        if cpu_count is not None:
-            payload["cpuCount"] = cpu_count
-        if memory_mb is not None:
-            payload["memoryMB"] = memory_mb
-        if start_cmd is not None:
-            payload["startCmd"] = start_cmd
-        payload.update(kwargs)
-
-        s = requests.Session()
-        resp = s.patch(
-            f"{cfg.api_url}/v2/templates/{template_id}",
-            json=payload,
-            headers={"Content-Type": "application/json"},
+        raise NotImplementedError(
+            "CubeAPI does not support template metadata updates; use Template.rebuild() "
+            "or delete and recreate the template"
         )
-        _check_response(resp)
-        body = resp.json() if resp.content else {}
-        return TemplateInfo.from_dict(body) if body else TemplateInfo(template_id=template_id)
 
 
     @classmethod

--- a/sdk/python/cubesandbox/sandbox.py
+++ b/sdk/python/cubesandbox/sandbox.py
@@ -372,8 +372,17 @@ class Sandbox:
             self.kill()
         except CubeSandboxError:
             pass
-        if self._client:
-            self._client.close()
+        self.close()
+
+    def close(self) -> None:
+        """Close cached HTTP clients without destroying the sandbox."""
+        self._reset_connections()
+
+    def __del__(self) -> None:
+        try:
+            self.close()
+        except Exception:
+            pass
 
     def __repr__(self) -> str:
         return f"Sandbox(id={self.sandbox_id!r}, domain={self.domain!r})"

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -10,6 +10,7 @@ license = { text = "Apache-2.0" }
 requires-python = ">=3.9"
 dependencies = [
     "httpx>=0.27",
+    "requests>=2",
 ]
 
 [project.urls]
@@ -31,6 +32,9 @@ exclude = ["tests*", "examples*"]
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 addopts = "-v --tb=short"
+markers = [
+    "e2e: tests that hit a live CubeAPI instance",
+]
 
 [tool.ruff]
 line-length = 100

--- a/sdk/python/tests/conftest.py
+++ b/sdk/python/tests/conftest.py
@@ -1,0 +1,29 @@
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+
+def pytest_addoption(parser):
+    e2e = parser.getgroup("cubesandbox e2e")
+    e2e.addoption(
+        "--run-e2e",
+        action="store_true",
+        default=False,
+        help="run tests that hit a live CubeAPI instance",
+    )
+    e2e.addoption(
+        "--cube-api-url",
+        default=None,
+        help="CubeAPI URL for e2e tests; defaults to CUBE_API_URL or http://127.0.0.1:3000",
+    )
+    e2e.addoption(
+        "--cube-template-id",
+        default=None,
+        help="existing template ID for read-only e2e tests; defaults to CUBE_TEMPLATE_ID",
+    )
+    e2e.addoption(
+        "--cube-template-image",
+        default=None,
+        help="image used by template create e2e; defaults to CUBE_TEMPLATE_E2E_IMAGE",
+    )

--- a/sdk/python/tests/test_sandbox.py
+++ b/sdk/python/tests/test_sandbox.py
@@ -3,7 +3,7 @@
 """
 cubesandbox SDK unit tests.
 
-All HTTP calls are intercepted via httpx.MockTransport / unittest.mock.patch
+All HTTP calls are intercepted via requests/httpx mocks
 so no real network is needed.
 """
 
@@ -14,10 +14,9 @@ import threading
 import time
 from unittest.mock import MagicMock, patch
 
-import httpx
 import pytest
 
-from cubesandbox import CommandResult
+from cubesandbox import CommandResult, Template
 from cubesandbox._commands import Commands
 from cubesandbox._config import Config
 from cubesandbox._exceptions import (
@@ -52,15 +51,14 @@ def make_config(**kwargs) -> Config:
     return Config(**defaults)
 
 
-def mock_response(body=None, status: int = 200) -> httpx.Response:
-    """Build a fake httpx.Response."""
-    if body is None:
-        content = b""
-    elif isinstance(body, (dict, list)):
-        content = json.dumps(body).encode()
-    else:
-        content = str(body).encode()
-    return httpx.Response(status_code=status, content=content)
+def mock_response(body=None, status: int = 200):
+    """Build a duck-typed requests.Response for control-plane SDK calls."""
+    response = MagicMock()
+    response.ok = 200 <= status < 400
+    response.status_code = status
+    response.text = json.dumps(body) if body is not None else ""
+    response.json.return_value = body if body is not None else {}
+    return response
 
 
 def make_sandbox(**data_overrides) -> Sandbox:
@@ -72,7 +70,7 @@ def make_sandbox(**data_overrides) -> Sandbox:
 
 class TestCreate:
     def test_create_success(self):
-        with patch("httpx.Client.post", return_value=mock_response(SANDBOX_DATA, status=201)):
+        with patch("requests.Session.post", return_value=mock_response(SANDBOX_DATA, status=201)):
             sb = Sandbox.create(config=make_config())
         assert sb.sandbox_id == SANDBOX_ID
 
@@ -82,63 +80,63 @@ class TestCreate:
             Sandbox.create(config=cfg)
 
     def test_create_sends_template_and_timeout(self):
-        with patch("httpx.Client.post", return_value=mock_response(SANDBOX_DATA, status=201)) as m:
+        with patch("requests.Session.post", return_value=mock_response(SANDBOX_DATA, status=201)) as m:
             Sandbox.create(template="tpl-foo", timeout=600, config=make_config())
         body = m.call_args.kwargs["json"]
         assert body["templateID"] == "tpl-foo"
         assert body["timeout"] == 600
 
     def test_create_sends_env_vars(self):
-        with patch("httpx.Client.post", return_value=mock_response(SANDBOX_DATA, status=201)) as m:
+        with patch("requests.Session.post", return_value=mock_response(SANDBOX_DATA, status=201)) as m:
             Sandbox.create(env_vars={"FOO": "bar"}, config=make_config())
         body = m.call_args.kwargs["json"]
         assert body["envVars"] == {"FOO": "bar"}
 
     def test_create_sends_metadata(self):
         meta = {"network-policy": "deny-all"}
-        with patch("httpx.Client.post", return_value=mock_response(SANDBOX_DATA, status=201)) as m:
+        with patch("requests.Session.post", return_value=mock_response(SANDBOX_DATA, status=201)) as m:
             Sandbox.create(metadata=meta, config=make_config())
         body = m.call_args.kwargs["json"]
         assert body["metadata"] == meta
 
     def test_create_template_not_found(self):
-        with patch("httpx.Client.post",
+        with patch("requests.Session.post",
                    return_value=mock_response({"message": "template not found"}, status=404)):
             with pytest.raises(TemplateNotFoundError):
                 Sandbox.create(config=make_config())
 
     def test_create_server_error(self):
-        with patch("httpx.Client.post",
+        with patch("requests.Session.post",
                    return_value=mock_response({"message": "internal error"}, status=500)):
             with pytest.raises(ApiError):
                 Sandbox.create(config=make_config())
 
     def test_create_allow_internet_access_false(self):
-        with patch("httpx.Client.post", return_value=mock_response(SANDBOX_DATA, status=201)) as m:
+        with patch("requests.Session.post", return_value=mock_response(SANDBOX_DATA, status=201)) as m:
             Sandbox.create(allow_internet_access=False, config=make_config())
         body = m.call_args.kwargs["json"]
         assert body["allowInternetAccess"] is False
 
     def test_create_allow_internet_access_true_not_in_payload(self):
-        with patch("httpx.Client.post", return_value=mock_response(SANDBOX_DATA, status=201)) as m:
+        with patch("requests.Session.post", return_value=mock_response(SANDBOX_DATA, status=201)) as m:
             Sandbox.create(config=make_config())
         body = m.call_args.kwargs["json"]
         assert "allowInternetAccess" not in body
 
     def test_create_network_allow_out(self):
-        with patch("httpx.Client.post", return_value=mock_response(SANDBOX_DATA, status=201)) as m:
+        with patch("requests.Session.post", return_value=mock_response(SANDBOX_DATA, status=201)) as m:
             Sandbox.create(network={"allow_out": ["8.8.8.8/32"]}, config=make_config())
         body = m.call_args.kwargs["json"]
         assert body["network"]["allowOut"] == ["8.8.8.8/32"]
 
     def test_create_network_deny_out(self):
-        with patch("httpx.Client.post", return_value=mock_response(SANDBOX_DATA, status=201)) as m:
+        with patch("requests.Session.post", return_value=mock_response(SANDBOX_DATA, status=201)) as m:
             Sandbox.create(network={"deny_out": ["0.0.0.0/0"]}, config=make_config())
         body = m.call_args.kwargs["json"]
         assert body["network"]["denyOut"] == ["0.0.0.0/0"]
 
     def test_create_network_empty_not_in_payload(self):
-        with patch("httpx.Client.post", return_value=mock_response(SANDBOX_DATA, status=201)) as m:
+        with patch("requests.Session.post", return_value=mock_response(SANDBOX_DATA, status=201)) as m:
             Sandbox.create(network={}, config=make_config())
         body = m.call_args.kwargs["json"]
         assert "network" not in body
@@ -148,12 +146,12 @@ class TestCreate:
 
 class TestConnect:
     def test_connect_success(self):
-        with patch("httpx.Client.post", return_value=mock_response(SANDBOX_DATA)):
+        with patch("requests.Session.post", return_value=mock_response(SANDBOX_DATA)):
             sb = Sandbox.connect(SANDBOX_ID, config=make_config())
         assert sb.sandbox_id == SANDBOX_ID
 
     def test_connect_not_found(self):
-        with patch("httpx.Client.post",
+        with patch("requests.Session.post",
                    return_value=mock_response({"message": "not found"}, status=404)):
             with pytest.raises(SandboxNotFoundError):
                 Sandbox.connect(SANDBOX_ID, config=make_config())
@@ -161,7 +159,7 @@ class TestConnect:
     def test_connect_sends_timeout(self):
         cfg = make_config()
         cfg.timeout = 600
-        with patch("httpx.Client.post", return_value=mock_response(SANDBOX_DATA)) as m:
+        with patch("requests.Session.post", return_value=mock_response(SANDBOX_DATA)) as m:
             Sandbox.connect(SANDBOX_ID, config=cfg)
         body = m.call_args.kwargs["json"]
         assert body["timeout"] == 600
@@ -172,22 +170,22 @@ class TestConnect:
 class TestListSandboxesV1:
     def test_list_returns_list(self):
         data = [SANDBOX_DATA]
-        with patch("httpx.Client.get", return_value=mock_response(data)):
+        with patch("requests.Session.get", return_value=mock_response(data)):
             result = Sandbox.list(config=make_config())
         assert result == data
 
     def test_list_empty(self):
-        with patch("httpx.Client.get", return_value=mock_response([])):
+        with patch("requests.Session.get", return_value=mock_response([])):
             result = Sandbox.list(config=make_config())
         assert result == []
 
     def test_list_calls_correct_endpoint(self):
-        with patch("httpx.Client.get", return_value=mock_response([])) as m:
+        with patch("requests.Session.get", return_value=mock_response([])) as m:
             Sandbox.list(config=make_config())
         assert "/sandboxes" in str(m.call_args)
 
     def test_list_server_error(self):
-        with patch("httpx.Client.get",
+        with patch("requests.Session.get",
                    return_value=mock_response({"message": "error"}, status=500)):
             with pytest.raises(ApiError):
                 Sandbox.list(config=make_config())
@@ -198,12 +196,12 @@ class TestListSandboxesV1:
 class TestListSandboxesV2:
     def test_list_v2_returns_list(self):
         data = [SANDBOX_DATA]
-        with patch("httpx.Client.get", return_value=mock_response(data)):
+        with patch("requests.Session.get", return_value=mock_response(data)):
             result = Sandbox.list_v2(config=make_config())
         assert result == data
 
     def test_list_v2_calls_correct_endpoint(self):
-        with patch("httpx.Client.get", return_value=mock_response([])) as m:
+        with patch("requests.Session.get", return_value=mock_response([])) as m:
             Sandbox.list_v2(config=make_config())
         assert "/v2/sandboxes" in str(m.call_args)
 
@@ -212,14 +210,14 @@ class TestListSandboxesV2:
 
 class TestHealth:
     def test_health_ok(self):
-        with patch("httpx.Client.get",
+        with patch("requests.Session.get",
                    return_value=mock_response({"status": "ok", "sandboxes": 2})):
             result = Sandbox.health(config=make_config())
         assert result["status"] == "ok"
         assert result["sandboxes"] == 2
 
     def test_health_server_error(self):
-        with patch("httpx.Client.get",
+        with patch("requests.Session.get",
                    return_value=mock_response({"message": "error"}, status=500)):
             with pytest.raises(ApiError):
                 Sandbox.health(config=make_config())
@@ -260,7 +258,7 @@ class TestKill:
                 sb.kill()
 
     def test_context_manager_kills_on_exit(self):
-        with patch("httpx.Client.post", return_value=mock_response(SANDBOX_DATA, status=201)):
+        with patch("requests.Session.post", return_value=mock_response(SANDBOX_DATA, status=201)):
             sb = Sandbox.create(config=make_config())
         with patch.object(sb._session, "delete", return_value=mock_response(status=204)) as m:
             with sb:
@@ -268,7 +266,7 @@ class TestKill:
         m.assert_called_once()
 
     def test_context_manager_suppresses_kill_error(self):
-        with patch("httpx.Client.post", return_value=mock_response(SANDBOX_DATA, status=201)):
+        with patch("requests.Session.post", return_value=mock_response(SANDBOX_DATA, status=201)):
             sb = Sandbox.create(config=make_config())
         with patch.object(sb._session, "delete",
                           return_value=mock_response({"message": "gone"}, status=404)):
@@ -384,6 +382,10 @@ class TestExecutionModel:
         assert ex.error.name == "ZeroDivisionError"
         assert ex.text is None
 
+    def test_error_traceback_list_is_e2b_string(self):
+        err = ExecutionError("ValueError", "bad", ["line1", "line2"])
+        assert err.traceback == "line1\nline2"
+
     def test_logs_defaults_empty(self):
         ex = Execution()
         assert ex.logs.stdout == []
@@ -397,6 +399,34 @@ class TestExecutionModel:
         ex = Execution(error=ExecutionError("ValueError", "bad"))
         assert "ValueError" in repr(ex)
 
+    def test_result_e2b_fields_and_legacy_json_alias(self):
+        result = Result(json={"a": 1}, data={"b": 2}, chart={"type": "bar"})
+        assert result.json == {"a": 1}
+        assert result.json_data == {"a": 1}
+        assert set(result.formats()) == {"json", "data", "chart"}
+
+    def test_result_legacy_json_data_constructor(self):
+        result = Result(json_data={"a": 1})
+        assert result.json == {"a": 1}
+
+    def test_execution_to_json(self):
+        ex = Execution(results=[Result(text="2", is_main_result=True)])
+        assert '"results"' in ex.to_json()
+        assert '"text": "2"' in ex.to_json()
+
+    def test_output_message_e2b_and_legacy_aliases(self):
+        msg = OutputMessage("hello\n", 123, True)
+        assert msg.line == "hello\n"
+        assert msg.text == "hello\n"
+        assert msg.error is True
+        assert msg.is_stderr is True
+        assert str(msg) == "hello\n"
+
+    def test_output_message_legacy_constructor(self):
+        msg = OutputMessage(text="warn\n", is_stderr=True)
+        assert msg.line == "warn\n"
+        assert msg.error is True
+
 
 # ── _parse_line (ndjson stream) ───────────────────────────────────────────────
 
@@ -405,6 +435,18 @@ class TestParseStream:
         ex = Execution()
         _parse_line(ex, '{"type":"result","text":"2","is_main_result":true}')
         assert ex.text == "2"
+
+    def test_parses_e2b_result_fields(self):
+        ex = Execution()
+        _parse_line(
+            ex,
+            '{"type":"result","json":{"a":1},"data":{"b":2},"chart":{"type":"bar"},"is_main_result":true}',
+        )
+        result = ex.results[0]
+        assert result.json == {"a": 1}
+        assert result.json_data == {"a": 1}
+        assert result.data == {"b": 2}
+        assert result.chart == {"type": "bar"}
 
     def test_parses_stdout(self):
         ex = Execution()
@@ -444,8 +486,14 @@ class TestParseStream:
     def test_stdout_callback(self):
         ex, calls = Execution(), []
         _parse_line(ex, '{"type":"stdout","text":"hi\\n"}',
-                    on_stdout=lambda m: calls.append(m.text))
-        assert calls == ["hi\n"]
+                    on_stdout=lambda m: calls.append((m.line, m.text, m.error)))
+        assert calls == [("hi\n", "hi\n", False)]
+
+    def test_stderr_callback(self):
+        ex, calls = Execution(), []
+        _parse_line(ex, '{"type":"stderr","text":"warn\\n"}',
+                    on_stderr=lambda m: calls.append((m.line, m.text, m.error, m.is_stderr)))
+        assert calls == [("warn\n", "warn\n", True, True)]
 
     def test_result_callback(self):
         ex, calls = Execution(), []
@@ -1005,6 +1053,84 @@ class TestClone:
         with stack:
             with pytest.raises(TypeError, match="snapshot_name"):
                 sb.clone(n=1, snapshot_name="leaky")  # type: ignore[call-arg]
+
+
+# ── Templates ─────────────────────────────────────────────────────────────────
+
+class TestTemplateAPI:
+    def test_build_uses_current_templates_endpoint(self):
+        body = {
+            "jobID": "job-001",
+            "templateID": "tpl-python",
+            "status": "running",
+            "phase": "Pulling",
+            "progress": 10,
+        }
+        config = make_config()
+
+        with patch("requests.Session.post", return_value=mock_response(body)) as post:
+            job = Template.build(
+                template_id="tpl-python",
+                image="python:3.11-slim",
+                instance_type="default",
+                writable_layer_size="1G",
+                exposed_ports=[80],
+                probe_port=80,
+                probe_path="/health",
+                cpu_count=2000,
+                memory_mb=2048,
+                envs={"A": "1"},
+                allow_internet_access=True,
+                config=config,
+            )
+
+        post.assert_called_once_with(
+            "http://localhost:3000/templates",
+            json={
+                "image": "python:3.11-slim",
+                "templateID": "tpl-python",
+                "instanceType": "default",
+                "writableLayerSize": "1G",
+                "exposedPorts": [80],
+                "probePort": 80,
+                "probePath": "/health",
+                "cpu": 2000,
+                "memory": 2048,
+                "env": ["A=1"],
+                "allowInternetAccess": True,
+            },
+            headers={"Content-Type": "application/json"},
+        )
+        assert job.job_id == "job-001"
+        assert job.template_id == "tpl-python"
+
+    def test_build_rejects_unsupported_models(self):
+        with pytest.raises(ValueError, match="image is required"):
+            Template.build(config=make_config())
+        with pytest.raises(ValueError, match="dockerfile"):
+            Template.build(image="python:3.11-slim", dockerfile="FROM python", config=make_config())
+        with pytest.raises(ValueError, match="start_cmd"):
+            Template.build(image="python:3.11-slim", start_cmd="python app.py", config=make_config())
+
+    def test_rebuild_uses_post_templates_template_id(self):
+        body = {"jobID": "job-002", "templateID": "tpl-python", "status": "queued"}
+
+        with patch("requests.Session.post", return_value=mock_response(body)) as post:
+            job = Template.rebuild("tpl-python", force=True, config=make_config())
+
+        post.assert_called_once_with(
+            "http://localhost:3000/templates/tpl-python",
+            json={"force": True},
+            headers={"Content-Type": "application/json"},
+        )
+        assert job.job_id == "job-002"
+
+    def test_update_is_not_supported_locally(self):
+        with patch("requests.Session.patch") as patch_call:
+            with pytest.raises(NotImplementedError, match="does not support"):
+                Template.update("tpl-python", name="new-name", config=make_config())
+
+        patch_call.assert_not_called()
 
 
 # ── Exports ───────────────────────────────────────────────────────────────────

--- a/sdk/python/tests/test_template_e2e.py
+++ b/sdk/python/tests/test_template_e2e.py
@@ -1,0 +1,116 @@
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""End-to-end tests for CubeAPI template endpoints.
+
+These tests intentionally hit a real CubeAPI instance. They are skipped by
+default and can be enabled with ``--run-e2e`` or ``CUBE_E2E=1``.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+import uuid
+
+import pytest
+
+from cubesandbox import Config, Template
+from cubesandbox._exceptions import ApiError, TemplateNotFoundError
+
+
+pytestmark = pytest.mark.e2e
+
+
+def _option(pytestconfig: pytest.Config, option: str, env: str, default: str | None = None) -> str | None:
+    return pytestconfig.getoption(option) or os.environ.get(env) or default
+
+
+def _require_e2e(pytestconfig: pytest.Config) -> None:
+    if not pytestconfig.getoption("--run-e2e") and os.environ.get("CUBE_E2E") != "1":
+        pytest.skip("use --run-e2e or set CUBE_E2E=1 to run live CubeAPI e2e tests")
+
+
+def _config(pytestconfig: pytest.Config) -> Config:
+    api_url = _option(pytestconfig, "--cube-api-url", "CUBE_API_URL", "http://127.0.0.1:3000")
+    return Config(api_url=api_url)
+
+
+def _env_int(name: str) -> int | None:
+    value = os.environ.get(name)
+    return int(value) if value else None
+
+
+def _env_ports(name: str) -> list[int] | None:
+    value = os.environ.get(name)
+    if not value:
+        return None
+    return [int(port.strip()) for port in value.split(",") if port.strip()]
+
+
+def _env_bool(name: str) -> bool | None:
+    value = os.environ.get(name)
+    if value is None:
+        return None
+    return value == "1"
+
+
+def test_template_list_and_get_existing_template(pytestconfig: pytest.Config) -> None:
+    _require_e2e(pytestconfig)
+    config = _config(pytestconfig)
+
+    templates = Template.list(config=config)
+    assert isinstance(templates, list)
+
+    template_id = _option(pytestconfig, "--cube-template-id", "CUBE_TEMPLATE_ID")
+    if template_id is None:
+        if not templates:
+            pytest.skip("no templates available and CUBE_TEMPLATE_ID is not set")
+        template_id = templates[0].template_id
+
+    detail = Template.get(template_id, config=config)
+    assert detail.template_id == template_id
+    assert detail.status
+
+
+def test_template_create_from_image_and_cleanup(pytestconfig: pytest.Config) -> None:
+    _require_e2e(pytestconfig)
+    image = _option(pytestconfig, "--cube-template-image", "CUBE_TEMPLATE_E2E_IMAGE")
+    if not image:
+        pytest.skip("use --cube-template-image or set CUBE_TEMPLATE_E2E_IMAGE to create a template")
+
+    config = _config(pytestconfig)
+    template_id = os.environ.get("CUBE_TEMPLATE_E2E_ID") or f"e2e-python-{uuid.uuid4().hex[:8]}"
+
+    try:
+        job = Template.build(
+            template_id=template_id,
+            image=image,
+            instance_type=os.environ.get("CUBE_TEMPLATE_E2E_INSTANCE_TYPE"),
+            writable_layer_size=os.environ.get("CUBE_TEMPLATE_E2E_WRITABLE_LAYER_SIZE"),
+            exposed_ports=_env_ports("CUBE_TEMPLATE_E2E_EXPOSED_PORTS"),
+            probe_port=_env_int("CUBE_TEMPLATE_E2E_PROBE_PORT"),
+            probe_path=os.environ.get("CUBE_TEMPLATE_E2E_PROBE_PATH"),
+            cpu_count=_env_int("CUBE_TEMPLATE_E2E_CPU"),
+            memory_mb=_env_int("CUBE_TEMPLATE_E2E_MEMORY"),
+            allow_internet_access=_env_bool("CUBE_TEMPLATE_E2E_ALLOW_INTERNET"),
+            config=config,
+        )
+
+        assert job.job_id
+        assert job.template_id == template_id
+        assert job.status
+
+        detail = Template.get(template_id, config=config)
+        assert detail.template_id == template_id
+
+        if job.job_id:
+            status = Template.get_build_status(template_id, job.job_id, config=config)
+            assert status.build_id == job.job_id
+            assert status.template_id == template_id
+    finally:
+        # Give CubeAPI a short moment to persist the new template before cleanup.
+        time.sleep(1)
+        try:
+            Template.delete(template_id, config=config)
+        except (ApiError, TemplateNotFoundError):
+            pass


### PR DESCRIPTION
## Summary
- add Python SDK models and client helpers for template creation APIs
- support stream-based template creation flows
- add unit coverage and opt-in E2E tests for template APIs

## Tests
- `python3 -m pytest tests -q` in `sdk/python` on cubesandbox002: 111 passed, 2 skipped
- Local validation skipped because this host does not have pytest installed
