### PR TITLE
fix: fix cubelet ci compile error

### DIFF
--- a/Cubelet/storage/local.go
+++ b/Cubelet/storage/local.go
@@ -851,7 +851,7 @@ func (l *local) cleanupCreateResult(ctx context.Context, result *StorageInfo) er
 	if err := l.destroy(ctx, result, cleanupOpts); err != nil {
 		errs = errors.Join(errs, err)
 	}
-	l.cleanupHostDirVolumes(ctx, result.SandboxID)
+	l.cleanupHostDirVolumes(ctx, result)
 	if _, err := l.readBackendFileInfoRaw(ctx, result.SandboxID); err == nil {
 		if err := l.deleteBackendFileInfo(ctx, result.SandboxID); err != nil {
 			errs = errors.Join(errs, fmt.Errorf("delete storage metadata after create rollback: %w", err))


### PR DESCRIPTION
fix cublet ci compile error introduced by PR #333

storage/local.go:854:31: cannot use result.SandboxID (variable of type string) as *StorageInfo value in argument to l.cleanupHostDirVolumes
make: *** [Makefile:80: cubelet] Error 1
make[1]: *** [Makefile:96: builder-run] Error 2
make[1]: Leaving directory '/home/runner/work/CubeSandbox/CubeSandbox'
make: *** [Makefile:140: cubelet] Error 2