### PR TITLE
docs(cubecow): remove License section from README

### DIFF
--- a/cubecow/README.md
+++ b/cubecow/README.md
@@ -173,7 +173,3 @@ cargo build --release
 cd examples/go-test
 make run
 ```
-
-## License
-
-MIT


### PR DESCRIPTION
The "## License" section (MIT) has been removed from cubecow/README.md
since licensing is tracked elsewhere in the repository and the section
duplicated information that does not belong in the per-crate README.

Signed-off-by: Songqian Li <sionli@tencent.com>