### PR TITLE
chore(python-sdk): bump version to 0.2.0

### DIFF
--- a/sdk/python/cubesandbox/__init__.py
+++ b/sdk/python/cubesandbox/__init__.py
@@ -27,4 +27,4 @@ __all__ = [
     "TemplateBuild",
 ]
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "cubesandbox"
-version = "0.1.0"
+version = "0.2.0"
 description = "Python SDK for CubeSandbox"
 license = { text = "Apache-2.0" }
 requires-python = ">=3.9"


### PR DESCRIPTION
## Summary
- bump the Python SDK package version from 0.1.0 to 0.2.0
- keep `cubesandbox.__version__` aligned with `pyproject.toml`

## Context
This is a follow-up to #365, which has already been merged.

## Tests
- `python3 -m pytest tests -q` in `sdk/python` on cubesandbox002: 111 passed, 2 skipped
