### PR TITLE
(CubeAPI)examples,docs: add snapshot/rollback/clone demo suite and guide

### DIFF
--- a/CubeAPI/examples/snapshot-rollback-clone/01_create_snapshot.py
+++ b/CubeAPI/examples/snapshot-rollback-clone/01_create_snapshot.py
@@ -1,0 +1,22 @@
+# Copyright (c) 2024 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Demo 01: Create a snapshot from a running sandbox.
+#
+# sb.create_snapshot() pauses the sandbox, captures its full state
+# (memory + filesystem) and resumes it. The returned SnapshotInfo has a
+# `snapshot_id` that can be passed as `template=` to Sandbox.create().
+
+from cubesandbox import Sandbox
+from env import TEMPLATE_ID
+
+with Sandbox.create(template=TEMPLATE_ID) as sb:
+    print(f"sandbox: {sb.sandbox_id}")
+
+    snapshot = sb.create_snapshot()
+    print(f"snapshot created: {snapshot.snapshot_id}")
+    print(f"use as template:  Sandbox.create(template='{snapshot.snapshot_id}')")
+
+    # Cleanup
+    Sandbox.delete_snapshot(snapshot.snapshot_id)
+    print("snapshot deleted")

--- a/CubeAPI/examples/snapshot-rollback-clone/02_list_snapshots.py
+++ b/CubeAPI/examples/snapshot-rollback-clone/02_list_snapshots.py
@@ -1,0 +1,35 @@
+# Copyright (c) 2024 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Demo 02: List snapshots — global and filtered by sandbox_id.
+#
+# Sandbox.list_snapshots() returns (list[SnapshotInfo], next_token).
+# Pass next_token back to retrieve the next page; None means no more pages.
+
+from cubesandbox import Sandbox
+from env import TEMPLATE_ID
+
+# 2a. List all snapshots
+print("── all snapshots ──")
+items, token = Sandbox.list_snapshots()
+while True:
+    for snap in items:
+        print(f"  {snap.snapshot_id}")
+    if not token:
+        break
+    items, token = Sandbox.list_snapshots(next_token=token)
+
+# 2b. Filter by sandbox_id
+with Sandbox.create(template=TEMPLATE_ID) as sb:
+    snap = sb.create_snapshot()
+    sandbox_id = sb.sandbox_id
+    snapshot_id = snap.snapshot_id
+
+print(f"\n── filtered by sandbox_id={sandbox_id} ──")
+items, _ = Sandbox.list_snapshots(sandbox_id=sandbox_id)
+for snap in items:
+    print(f"  {snap.snapshot_id}")
+
+# Cleanup
+Sandbox.delete_snapshot(snapshot_id)
+print("snapshot deleted")

--- a/CubeAPI/examples/snapshot-rollback-clone/03_clone_from_snapshot.py
+++ b/CubeAPI/examples/snapshot-rollback-clone/03_clone_from_snapshot.py
@@ -1,0 +1,26 @@
+# Copyright (c) 2024 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Demo 03: Clone a new sandbox from a snapshot.
+#
+# Pass snapshot_id as the `template` argument to Sandbox.create() — the new
+# sandbox starts from the exact memory + filesystem state captured in the
+# snapshot.
+#
+# (The SDK also exposes sb.clone(n=...) as a one-shot helper that wraps
+# create_snapshot + create + delete_snapshot — see demo 06.)
+
+from cubesandbox import Sandbox
+from env import TEMPLATE_ID
+
+with Sandbox.create(template=TEMPLATE_ID) as src:
+    snapshot = src.create_snapshot()
+    snapshot_id = snapshot.snapshot_id
+    print(f"snapshot created: {snapshot_id}")
+
+with Sandbox.create(template=snapshot_id) as cloned:
+    print(f"cloned sandbox: {cloned.sandbox_id}")
+
+# Cleanup
+Sandbox.delete_snapshot(snapshot_id)
+print("snapshot deleted")

--- a/CubeAPI/examples/snapshot-rollback-clone/04_state_preserved.py
+++ b/CubeAPI/examples/snapshot-rollback-clone/04_state_preserved.py
@@ -1,0 +1,28 @@
+# Copyright (c) 2024 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Demo 04: Verify filesystem state is preserved across snapshot + clone.
+#
+# Write a marker file in the source sandbox, take a snapshot, spin up a
+# clone from that snapshot, and confirm the marker is visible.
+
+from cubesandbox import Sandbox
+from env import TEMPLATE_ID
+
+MARKER = "hello from snapshot"
+
+with Sandbox.create(template=TEMPLATE_ID) as src:
+    src.run_code(f"open('/tmp/marker.txt','w').write('{MARKER}')")
+    snapshot = src.create_snapshot()
+    snapshot_id = snapshot.snapshot_id
+    print(f"wrote marker, snapshot: {snapshot_id}")
+
+with Sandbox.create(template=snapshot_id) as cloned:
+    result = cloned.run_code("print(open('/tmp/marker.txt').read())")
+    content = result.logs.stdout[0].strip() if result.logs.stdout else ""
+    print(f"cloned sandbox read: {content!r}")
+    assert content == MARKER, f"state not preserved: got {content!r}"
+    print("OK: filesystem state preserved in cloned sandbox")
+
+Sandbox.delete_snapshot(snapshot_id)
+print("snapshot deleted")

--- a/CubeAPI/examples/snapshot-rollback-clone/05_snapshot_outlives_sandbox.py
+++ b/CubeAPI/examples/snapshot-rollback-clone/05_snapshot_outlives_sandbox.py
@@ -1,0 +1,35 @@
+# Copyright (c) 2024 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Demo 05: Snapshot lifecycle is independent of sandbox lifecycle.
+# After killing the source sandbox, its snapshot is still usable.
+
+from cubesandbox import Sandbox
+from env import TEMPLATE_ID
+
+sb = Sandbox.create(template=TEMPLATE_ID)
+sandbox_id = sb.sandbox_id
+snap = sb.create_snapshot()
+snapshot_id = snap.snapshot_id
+print(f"sandbox:  {sandbox_id}")
+print(f"snapshot: {snapshot_id}")
+
+sb.kill()
+print(f"sandbox killed: {sandbox_id}")
+
+# Snapshot must still be present
+all_ids = []
+items, token = Sandbox.list_snapshots()
+while True:
+    all_ids.extend(s.snapshot_id for s in items)
+    if not token:
+        break
+    items, token = Sandbox.list_snapshots(next_token=token)
+
+if snapshot_id in all_ids:
+    print(f"OK: snapshot {snapshot_id} still exists after sandbox kill")
+else:
+    print(f"FAIL: snapshot {snapshot_id} disappeared after sandbox kill")
+
+Sandbox.delete_snapshot(snapshot_id)
+print("snapshot deleted")

--- a/CubeAPI/examples/snapshot-rollback-clone/06_clone_n.py
+++ b/CubeAPI/examples/snapshot-rollback-clone/06_clone_n.py
@@ -1,0 +1,40 @@
+# Copyright (c) 2024 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Demo 06: Clone N sandboxes from a single source using sb.clone(n=...).
+#
+# Internally, clone(n) does:
+#   1. self.create_snapshot()
+#   2. Sandbox.create(template=snapshot_id) × n
+#   3. Sandbox.delete_snapshot(snapshot_id)  (best-effort cleanup)
+#   4. return list[Sandbox] of length n
+#
+# After return, the source sandbox keeps running and the ephemeral snapshot
+# has already been deleted — list_snapshots() will not show it.
+
+from cubesandbox import Sandbox
+from env import TEMPLATE_ID
+
+N = 3
+
+src = Sandbox.create(template=TEMPLATE_ID)
+src.run_code("open('/tmp/shared.txt','w').write('shared state')")
+print(f"src sandbox: {src.sandbox_id}")
+
+# ★ One-line clone — SDK handles snapshot/create/delete internally
+clones = src.clone(n=N)
+print(f"cloned {len(clones)} sandboxes")
+
+for i, sb in enumerate(clones):
+    result = sb.run_code("print(open('/tmp/shared.txt').read())")
+    content = result.logs.stdout[0].strip() if result.logs.stdout else ""
+    print(f"  clone {i+1}: {sb.sandbox_id}  file={content!r}")
+    assert content == "shared state"
+
+print(f"OK: {N} sandboxes cloned via sb.clone(n={N}), all share initial state")
+
+# Cleanup
+src.kill()
+for sb in clones:
+    sb.kill()
+print("all sandboxes killed")

--- a/CubeAPI/examples/snapshot-rollback-clone/07_clone_concurrent.py
+++ b/CubeAPI/examples/snapshot-rollback-clone/07_clone_concurrent.py
@@ -1,0 +1,51 @@
+# Copyright (c) 2024 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Demo 07: Concurrent clone — sb.clone(n=N, concurrency=C).
+#
+# The default sb.clone(n=N) creates the N child sandboxes serially. For
+# fan-out workloads (e.g. parallel agent rollouts) you can set
+# `concurrency=C` to fan the per-child Sandbox.create() out across a thread
+# pool of size min(N, C). The snapshot is taken once and deleted once;
+# only the create-N step runs in parallel.
+#
+# Semantics:
+#   - concurrency=1 (default) is byte-identical to the serial loop.
+#   - On any failure, every successfully-created clone is killed before
+#     the exception propagates. Caller gets exactly N sandboxes or an
+#     exception with no orphaned resources.
+
+import os
+
+from cubesandbox import Sandbox
+from env import TEMPLATE_ID
+
+N = int(os.environ.get("FORK_N", "10"))
+CONCURRENCY = int(os.environ.get("FORK_CONCURRENCY", "5"))
+
+src = Sandbox.create(template=TEMPLATE_ID)
+src.run_code("open('/tmp/origin.txt','w').write('I am from sandbox a')")
+print(f"src sandbox: {src.sandbox_id}")
+
+# ★ Concurrent clone — SDK fans Sandbox.create out internally
+clones = src.clone(n=N, concurrency=CONCURRENCY)
+print(f"cloned {len(clones)} sandboxes (concurrency={CONCURRENCY})")
+
+# Verify every clone inherited the origin marker
+expect = "I am from sandbox a"
+ok = 0
+for i, sb in enumerate(clones):
+    r = sb.run_code("print(open('/tmp/origin.txt').read())")
+    marker = r.logs.stdout[0].strip() if r.logs.stdout else ""
+    if marker == expect:
+        ok += 1
+    print(f"  clone[{i:>2}] {sb.sandbox_id}  marker={marker!r}")
+
+print(f"\n{ok}/{N} clones inherited the origin marker")
+assert ok == N, "some clones failed to inherit state"
+
+# Cleanup
+src.kill()
+for sb in clones:
+    sb.kill()
+print("all sandboxes killed")

--- a/CubeAPI/examples/snapshot-rollback-clone/08_fork_three_axis.py
+++ b/CubeAPI/examples/snapshot-rollback-clone/08_fork_three_axis.py
@@ -1,0 +1,48 @@
+# Copyright (c) 2024 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Demo 08: Fork semantics — inheritance and isolation.
+#
+# After a.clone(n=2) produces b and c:
+#   - Inheritance: b and c start with the same filesystem state as a at fork time.
+#   - Isolation:   writes in b are not visible in c, and vice versa.
+#   - Continuity:  a keeps running after the fork; its state is unaffected.
+#   - No leak:     clone() cleans up its internal snapshot automatically.
+
+from cubesandbox import Sandbox
+from env import TEMPLATE_ID
+
+a = Sandbox.create(template=TEMPLATE_ID)
+print(f"[a] created: {a.sandbox_id}")
+a.run_code("open('/tmp/origin.txt','w').write('from a')")
+
+b, c = a.clone(n=2)
+print(f"[b] cloned:  {b.sandbox_id}")
+print(f"[c] cloned:  {c.sandbox_id}")
+
+# Inheritance: b and c both see the file a wrote before the fork
+for sb, name in [(b, "b"), (c, "c")]:
+    r = sb.run_code("print(open('/tmp/origin.txt').read())")
+    marker = r.logs.stdout[0].strip() if r.logs.stdout else "<empty>"
+    print(f"[{name}] origin.txt = {marker!r}")
+    assert marker == "from a", f"[{name}] expected 'from a', got {marker!r}"
+
+# Isolation: writes in b are not visible in c
+b.run_code("open('/tmp/b_only.txt','w').write('b')")
+r = c.run_code("import os; print(os.path.exists('/tmp/b_only.txt'))")
+leaked = r.logs.stdout[0].strip() if r.logs.stdout else "<empty>"
+print(f"[c] sees b_only.txt: {leaked}  (expect False)")
+assert leaked == "False", "isolation violated"
+
+# Continuity: a is still running
+r = a.run_code("print(open('/tmp/origin.txt').read())")
+still = r.logs.stdout[0].strip() if r.logs.stdout else "<empty>"
+print(f"[a] still running, origin.txt = {still!r}")
+assert still == "from a"
+
+print("OK: inheritance, isolation and continuity all verified")
+
+# Cleanup
+for sb in [a, b, c]:
+    sb.kill()
+print("all sandboxes killed")

--- a/CubeAPI/examples/snapshot-rollback-clone/09_rollback.py
+++ b/CubeAPI/examples/snapshot-rollback-clone/09_rollback.py
@@ -1,0 +1,56 @@
+# Copyright (c) 2024 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Demo 09: Rollback a sandbox to a previous snapshot.
+#
+# sb.rollback(snapshot_id) restores the sandbox in place — its memory and
+# filesystem revert to the captured state. The sandbox keeps the same
+# sandbox_id, so you can keep using the same `sb` object after rollback.
+#
+# Internally, rollback also resets the SDK's pooled HTTP connections, so
+# the next run_code() on the same sandbox object Just Works without any
+# manual reconnect.
+
+from cubesandbox import Sandbox
+from env import TEMPLATE_ID
+
+# Step 1: create a base snapshot at v0
+with Sandbox.create(template=TEMPLATE_ID) as src:
+    src.run_code("open('/tmp/v.txt','w').write('v0')")
+    base = src.create_snapshot()
+    base_id = base.snapshot_id
+    print(f"base snapshot (v0): {base_id}")
+
+# Step 2: spin up a sandbox from the base snapshot
+sb = Sandbox.create(template=base_id)
+print(f"derived sandbox: {sb.sandbox_id}")
+
+# Step 3: write v1, take a checkpoint
+sb.run_code("open('/tmp/v.txt','w').write('v1')")
+checkpoint = sb.create_snapshot()
+checkpoint_id = checkpoint.snapshot_id
+print(f"checkpoint (v1): {checkpoint_id}")
+
+# Step 4: write v2, confirm it stuck
+sb.run_code("open('/tmp/v.txt','w').write('v2')")
+before = sb.run_code("print(open('/tmp/v.txt').read())").logs.stdout
+before = before[0].strip() if before else ""
+print(f"before rollback: {before!r}")
+assert before == "v2"
+
+# Step 5: rollback to the v1 checkpoint
+sb.rollback(checkpoint_id)
+print(f"rolled back to checkpoint {checkpoint_id}")
+
+# Step 6: verify state is v1
+after = sb.run_code("print(open('/tmp/v.txt').read())").logs.stdout
+after = after[0].strip() if after else ""
+print(f"after rollback:  {after!r}")
+assert after == "v1", f"expected 'v1', got {after!r}"
+print("OK: rollback restored state to checkpoint (v1)")
+
+# Cleanup
+sb.kill()
+Sandbox.delete_snapshot(checkpoint_id)
+Sandbox.delete_snapshot(base_id)
+print("snapshots deleted")

--- a/CubeAPI/examples/snapshot-rollback-clone/10_rollback_then_continue.py
+++ b/CubeAPI/examples/snapshot-rollback-clone/10_rollback_then_continue.py
@@ -1,0 +1,54 @@
+# Copyright (c) 2024 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Demo 10: Rollback and continue — write new state on the rolled-back branch,
+#           then take another snapshot from that branch.
+#
+# Timeline:
+#   v1 (checkpoint) -> v2 -> rollback to v1 -> write v3 -> snapshot
+
+from cubesandbox import Sandbox
+from env import TEMPLATE_ID
+
+sb = Sandbox.create(template=TEMPLATE_ID)
+
+# Write v1 and take a checkpoint
+sb.run_code("open('/tmp/v.txt','w').write('v1')")
+checkpoint = sb.create_snapshot()
+print(f"checkpoint (v1): {checkpoint.snapshot_id}")
+
+# Advance to v2, then roll back to v1
+sb.run_code("open('/tmp/v.txt','w').write('v2')")
+sb.rollback(checkpoint.snapshot_id)
+got = sb.run_code("print(open('/tmp/v.txt').read())").logs.stdout
+got = got[0].strip() if got else ""
+print(f"after rollback: {got!r}")
+assert got == "v1"
+
+# Continue on the rolled-back branch: write v3
+sb.run_code("open('/tmp/v.txt','w').write('v3')")
+got = sb.run_code("print(open('/tmp/v.txt').read())").logs.stdout
+got = got[0].strip() if got else ""
+print(f"after writing v3: {got!r}")
+assert got == "v3"
+
+# Take a new snapshot from this branch and verify it via a clone
+new_snap = sb.create_snapshot()
+print(f"new snapshot: {new_snap.snapshot_id}")
+
+with Sandbox.create(template=new_snap.snapshot_id) as forked:
+    got = forked.run_code("print(open('/tmp/v.txt').read())").logs.stdout
+    got = got[0].strip() if got else ""
+    print(f"clone of new snapshot reads: {got!r}")
+    assert got == "v3"
+
+print("OK: rollback + continue + re-snapshot all consistent")
+
+# Cleanup
+sb.kill()
+for sid in [checkpoint.snapshot_id, new_snap.snapshot_id]:
+    try:
+        Sandbox.delete_snapshot(sid)
+    except Exception as e:
+        print(f"  warn: delete {sid}: {e}")
+print("cleanup done")

--- a/CubeAPI/examples/snapshot-rollback-clone/11_delete_snapshot.py
+++ b/CubeAPI/examples/snapshot-rollback-clone/11_delete_snapshot.py
@@ -1,0 +1,28 @@
+# Copyright (c) 2024 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Demo 11: Delete a snapshot and verify it is removed from the list.
+
+from cubesandbox import Sandbox
+from env import TEMPLATE_ID
+
+sb = Sandbox.create(template=TEMPLATE_ID)
+snap = sb.create_snapshot()
+snapshot_id = snap.snapshot_id
+sb.kill()
+print(f"snapshot ready: {snapshot_id}")
+
+Sandbox.delete_snapshot(snapshot_id)
+print(f"delete_snapshot({snapshot_id}) -> ok")
+
+# Verify it no longer appears in list_snapshots()
+all_ids = []
+items, token = Sandbox.list_snapshots()
+while True:
+    all_ids.extend(s.snapshot_id for s in items)
+    if not token:
+        break
+    items, token = Sandbox.list_snapshots(next_token=token)
+
+assert snapshot_id not in all_ids
+print(f"OK: snapshot {snapshot_id} removed from list")

--- a/CubeAPI/examples/snapshot-rollback-clone/README.md
+++ b/CubeAPI/examples/snapshot-rollback-clone/README.md
@@ -1,0 +1,75 @@
+# Snapshot · Rollback · Clone
+
+[中文文档](README_zh.md)
+
+End-to-end examples for the `cubesandbox` Python SDK's snapshot, rollback,
+and clone APIs. Each script is standalone and runnable.
+
+## What you get
+
+| # | Demo | Topic |
+|---|------|-------|
+| 01 | `01_create_snapshot.py` | `sb.create_snapshot()` basics |
+| 02 | `02_list_snapshots.py` | `Sandbox.list_snapshots()` — global / per-sandbox / paginated |
+| 03 | `03_clone_from_snapshot.py` | Spawn a sandbox from a snapshot via `template=` |
+| 04 | `04_state_preserved.py` | Filesystem state survives snapshot + clone |
+| 05 | `05_snapshot_outlives_sandbox.py` | Snapshot lifecycle is independent of the sandbox |
+| 06 | `06_clone_n.py` | One-line `sb.clone(n=N)` to fan out N sandboxes |
+| 07 | `07_clone_concurrent.py` | Parallel clone via `sb.clone(n=N, concurrency=C)` |
+| 08 | `08_fork_three_axis.py` | Continuity / inheritance / isolation |
+| 09 | `09_rollback.py` | `sb.rollback(snapshot_id)` to revert in place |
+| 10 | `10_rollback_then_continue.py` | Rollback, keep running, re-snapshot the new branch |
+| 11 | `11_delete_snapshot.py` | `Sandbox.delete_snapshot()` basics |
+
+## Setup
+
+> These examples require [`cubesandbox`](https://pypi.org/project/cubesandbox/) **>= 0.2.0**.
+
+```bash
+pip install "cubesandbox>=0.2.0"
+# or:
+pip install -r requirements.txt
+
+export CUBE_API_URL=http://127.0.0.1:3000
+export CUBE_TEMPLATE_ID=tpl-xxxxxxxxxxxxxxxxxxxxxxxx
+```
+
+## Run
+
+Each demo is a self-contained script. From inside this directory:
+
+```bash
+python 01_create_snapshot.py
+python 04_state_preserved.py
+python 09_rollback.py
+# ...
+```
+
+## API cheat sheet
+
+```python
+from cubesandbox import Sandbox
+
+sb = Sandbox.create(template=TEMPLATE_ID)
+
+# Snapshot
+snap = sb.create_snapshot()              # → SnapshotInfo(snapshot_id=...)
+items, token = Sandbox.list_snapshots()  # paginated; token=None when done
+Sandbox.delete_snapshot(snap.snapshot_id)
+
+# Clone (fan-out from a running sandbox)
+clones = sb.clone(n=5)                   # serial
+clones = sb.clone(n=10, concurrency=4)   # parallel via thread pool
+
+# Rollback (in place — same sandbox_id afterwards)
+sb.rollback(snap.snapshot_id)
+
+# Spawn from a snapshot as a normal template
+fresh = Sandbox.create(template=snap.snapshot_id)
+```
+
+## See also
+
+- [Guide: Snapshot, Rollback & Clone](../../../docs/guide/snapshot-rollback-clone.md)
+- SDK source: [`sdk/python/cubesandbox`](../../../sdk/python/cubesandbox)
+- Other examples: [`examples/code-sandbox-quickstart`](../../../examples/code-sandbox-quickstart) for the basic E2B-compatible flow

--- a/CubeAPI/examples/snapshot-rollback-clone/README_zh.md
+++ b/CubeAPI/examples/snapshot-rollback-clone/README_zh.md
@@ -1,0 +1,75 @@
+# 快照 · 回滚 · 克隆
+
+[English](README.md)
+
+`cubesandbox` Python SDK 中 snapshot / rollback / clone 三组接口的端到端示例。
+每个脚本都是独立、可直接运行的。
+
+## 示例清单
+
+| # | 脚本 | 主题 |
+|---|------|------|
+| 01 | `01_create_snapshot.py` | `sb.create_snapshot()` 基础用法 |
+| 02 | `02_list_snapshots.py` | `Sandbox.list_snapshots()`：全量 / 按 sandbox_id 过滤 / 分页 |
+| 03 | `03_clone_from_snapshot.py` | 用 `template=` 参数从快照启动新沙箱 |
+| 04 | `04_state_preserved.py` | 文件系统状态在 snapshot + clone 后保留 |
+| 05 | `05_snapshot_outlives_sandbox.py` | 快照生命周期独立于源沙箱 |
+| 06 | `06_clone_n.py` | 一行 `sb.clone(n=N)` 派生 N 个沙箱 |
+| 07 | `07_clone_concurrent.py` | `sb.clone(n=N, concurrency=C)` 并发派生 |
+| 08 | `08_fork_three_axis.py` | 连续性 / 继承性 / 隔离性验证 |
+| 09 | `09_rollback.py` | `sb.rollback(snapshot_id)` 原地回滚 |
+| 10 | `10_rollback_then_continue.py` | 回滚后继续执行 + 在新分支上再次快照 |
+| 11 | `11_delete_snapshot.py` | `Sandbox.delete_snapshot()` 基础用法 |
+
+## 环境准备
+
+> 本目录示例依赖 [`cubesandbox`](https://pypi.org/project/cubesandbox/) **>= 0.2.0**。
+
+```bash
+pip install "cubesandbox>=0.2.0"
+# 或：
+pip install -r requirements.txt
+
+export CUBE_API_URL=http://127.0.0.1:3000
+export CUBE_TEMPLATE_ID=tpl-xxxxxxxxxxxxxxxxxxxxxxxx
+```
+
+## 运行
+
+每个 demo 都是独立脚本。在本目录下：
+
+```bash
+python 01_create_snapshot.py
+python 04_state_preserved.py
+python 09_rollback.py
+# ...
+```
+
+## API 速查
+
+```python
+from cubesandbox import Sandbox
+
+sb = Sandbox.create(template=TEMPLATE_ID)
+
+# 快照
+snap = sb.create_snapshot()              # → SnapshotInfo(snapshot_id=...)
+items, token = Sandbox.list_snapshots()  # 分页；token 为 None 表示结束
+Sandbox.delete_snapshot(snap.snapshot_id)
+
+# 克隆（从运行中的沙箱一对多派生）
+clones = sb.clone(n=5)                   # 串行
+clones = sb.clone(n=10, concurrency=4)   # 通过线程池并发
+
+# 回滚（原地，sandbox_id 保持不变）
+sb.rollback(snap.snapshot_id)
+
+# 把快照当作模板启动新沙箱
+fresh = Sandbox.create(template=snap.snapshot_id)
+```
+
+## 相关文档
+
+- [教程：快照、回滚与克隆](../../../docs/zh/guide/snapshot-rollback-clone.md)
+- SDK 源码：[`sdk/python/cubesandbox`](../../../sdk/python/cubesandbox)
+- 其他示例：[`examples/code-sandbox-quickstart`](../../../examples/code-sandbox-quickstart) 演示 E2B 兼容的基础用法

--- a/CubeAPI/examples/snapshot-rollback-clone/env.py
+++ b/CubeAPI/examples/snapshot-rollback-clone/env.py
@@ -1,0 +1,23 @@
+# Copyright (c) 2024 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Shared environment helper for the snapshot/rollback/clone demo suite.
+#
+# Required env vars:
+#   CUBE_API_URL       e.g. http://127.0.0.1:3000
+#   CUBE_TEMPLATE_ID   e.g. tpl-aa14fc963b9c443aaff65b17
+#                      Look one up with `cubemastercli tpl list`.
+# Optional:
+#   SSL_CERT_FILE      path to your cluster's root CA when CubeAPI is HTTPS
+
+import os
+import sys
+
+TEMPLATE_ID = os.environ.get("CUBE_TEMPLATE_ID")
+
+if not TEMPLATE_ID:
+    sys.stderr.write(
+        "ERROR: CUBE_TEMPLATE_ID is not set.\n"
+        "  Look one up with: cubemastercli tpl list | awk 'NR>1 && $1 ~ /^tpl-/{print $1; exit}'\n"
+    )
+    sys.exit(2)

--- a/CubeAPI/examples/snapshot-rollback-clone/requirements.txt
+++ b/CubeAPI/examples/snapshot-rollback-clone/requirements.txt
@@ -1,0 +1,1 @@
+cubesandbox>=0.2.0

--- a/docs/guide/snapshot-rollback-clone.md
+++ b/docs/guide/snapshot-rollback-clone.md
@@ -1,0 +1,150 @@
+# Snapshot, Rollback & Clone
+
+This guide covers three advanced APIs provided by the Cube Sandbox Python SDK:
+
+- **Snapshot**: Persists the complete state (memory + filesystem) of a running sandbox as a reusable image. The snapshot can later be used to spawn new sandboxes or trigger a rollback.
+- **Clone**: Calls `clone()` on a running sandbox to immediately derive N fully independent copies. Each copy starts from the source sandbox's current state and runs in isolation.
+- **Rollback**: Restores a running sandbox to a previously captured snapshot state in place — the sandbox ID stays the same and execution can continue right away.
+
+## Concept
+
+```mermaid
+flowchart LR
+    A[source sandbox<br/>running] -->|create_snapshot| S[(snapshot<br/>snap-xxx)]
+    A -->|clone n=N| C1[clone 1]
+    A -->|clone n=N| C2[clone 2]
+    A -->|clone n=N| Cn[clone N]
+    A -.->|rollback snap-xxx| A2[source sandbox<br/>restored to snapshot state]
+
+    classDef src fill:#e8f4fd,stroke:#3b82f6,stroke-width:2px;
+    classDef snap fill:#fef3c7,stroke:#f59e0b,stroke-width:2px;
+    classDef clone fill:#d1fae5,stroke:#10b981,stroke-width:1px;
+    class A,A2 src;
+    class S snap;
+    class C1,C2,Cn clone;
+```
+
+| API | Target | Sandbox ID | Typical use |
+|-----|--------|------------|-------------|
+| `sb.create_snapshot()` | The source sandbox itself | Unchanged | Create a checkpoint or persist state |
+| `sb.clone(n=N)` | Derive N new sandboxes from a running sandbox | N new IDs | Agent parallel rollout, repeatable experiments |
+| `sb.rollback(snap_id)` | Restore the current sandbox to a snapshot state | **Unchanged** | Undo a failed step, branch from a saved point |
+
+## Installation
+
+> **Note**: Snapshot, rollback, and clone are Cube Sandbox-exclusive capabilities — the e2b SDK has no equivalent APIs. The [`cubesandbox`](https://pypi.org/project/cubesandbox/) SDK is compatible with the e2b SDK and can be used as a drop-in replacement, while adding these advanced features.
+
+All APIs in this guide require [`cubesandbox`](https://pypi.org/project/cubesandbox/) **0.2.0 or later**.
+
+```bash
+pip install "cubesandbox>=0.2.0"
+```
+
+Environment variables used throughout the examples:
+
+```bash
+export CUBE_API_URL=http://127.0.0.1:3000
+export CUBE_TEMPLATE_ID=tpl-xxxxxxxxxxxxxxxxxxxxxxxx
+```
+
+## Snapshot
+
+`sb.create_snapshot()` persists the sandbox's current state (filesystem + memory) as a snapshot and returns a `SnapshotInfo` object. The `snapshot_id` field can be passed directly to `Sandbox.create(template=...)`.
+
+```python
+from cubesandbox import Sandbox
+
+with Sandbox.create(template=TEMPLATE_ID) as sb:
+    sb.run_code("open('/tmp/data.txt','w').write('hello')")
+    snap = sb.create_snapshot()
+    print(f"snapshot: {snap.snapshot_id}")
+```
+
+A snapshot's lifecycle is independent of the sandbox: the snapshot remains usable even after the source sandbox is `kill()`ed. Call `Sandbox.delete_snapshot(snapshot_id)` to clean up when it is no longer needed.
+
+### Listing snapshots
+
+```python
+# List snapshots (first page)
+items, next_token = Sandbox.list_snapshots()
+
+# Filter by sandbox_id
+items, _ = Sandbox.list_snapshots(sandbox_id=sb.sandbox_id)
+```
+
+`list_snapshots()` returns `(list[SnapshotInfo], next_token)`. Pass `next_token` back to retrieve subsequent pages; `None` means no more pages.
+
+## Clone
+
+Calling `sb.clone(n=N)` on a running sandbox immediately derives N independent copies. Each copy inherits the source sandbox's current filesystem state, but subsequent writes are fully isolated. The source sandbox keeps running unaffected.
+
+```python
+src = Sandbox.create(template=TEMPLATE_ID)
+src.run_code("open('/tmp/shared.txt','w').write('hello')")
+
+clones = src.clone(n=3)
+for sb in clones:
+    # Each clone inherits the file written in src
+    out = sb.run_code("print(open('/tmp/shared.txt').read())").logs.stdout[0]
+    assert out.strip() == "hello"
+```
+
+### Concurrent clone
+
+By default clones are created serially. Pass `concurrency=C` for fan-out scenarios:
+
+```python
+clones = src.clone(n=10, concurrency=5)
+```
+
+- If any sub-task fails, already-created clones are automatically `kill()`ed. The caller either gets all N sandboxes or an exception — no orphaned resources.
+
+### Inheritance and isolation
+
+Clones returned by `clone()` satisfy three properties:
+
+| Property | Meaning |
+|----------|---------|
+| **Inheritance** | Each clone's initial state is identical to the source sandbox at the moment of the clone call |
+| **Isolation** | Writes in one clone are invisible to others and to the source sandbox |
+| **Continuity** | The source sandbox keeps running after `clone()` returns, unaffected |
+
+## Rollback
+
+`sb.rollback(snapshot_id)` restores the sandbox **in place** to the specified snapshot state: the filesystem is fully reset, the **sandbox ID stays the same**, and the `sb` object remains usable.
+
+```python
+sb = Sandbox.create(template=TEMPLATE_ID)
+sb.run_code("open('/tmp/v.txt','w').write('v1')")
+checkpoint = sb.create_snapshot()
+
+sb.run_code("open('/tmp/v.txt','w').write('v2')")
+sb.rollback(checkpoint.snapshot_id)
+
+after = sb.run_code("print(open('/tmp/v.txt').read())").logs.stdout[0]
+assert after.strip() == "v1"
+```
+
+After a rollback the sandbox is still writable. You can continue execution and snapshot again — ideal for agent retry loops where you checkpoint at each key decision point, roll back on failure, and try a different branch:
+
+```python
+# Continue on the rolled-back branch
+sb.run_code("open('/tmp/v.txt','w').write('v3')")
+new_snap = sb.create_snapshot()
+
+with Sandbox.create(template=new_snap.snapshot_id) as forked:
+    out = forked.run_code("print(open('/tmp/v.txt').read())").logs.stdout[0]
+    assert out.strip() == "v3"
+```
+
+## Best practices
+
+- **Snapshots are not free.** Each snapshot corresponds to a full image in persistent storage. Delete snapshots when they are no longer needed, or run `list_snapshots()` periodically to clean up.
+- **`with` blocks do not delete snapshots.** The context manager only calls `kill()` on the sandbox. Snapshots created with `create_snapshot()` must be deleted explicitly with `Sandbox.delete_snapshot()`.
+- **`clone()` cleans up its internal snapshot automatically.** For temporary fan-out you do not need to manage snapshot lifecycle yourself — just call `clone()`.
+- **For large-scale fan-out**, prefer `clone(n=N, concurrency=C)`. The SDK handles cleanup on failure and avoids orphaned resources.
+
+## Reference
+
+- Example code: [`CubeAPI/examples/snapshot-rollback-clone/`](https://github.com/TencentCloud/CubeSandbox/tree/master/CubeAPI/examples/snapshot-rollback-clone)
+- SDK source: [`sdk/python/`](https://github.com/TencentCloud/CubeSandbox/tree/master/sdk/python)

--- a/docs/zh/guide/snapshot-rollback-clone.md
+++ b/docs/zh/guide/snapshot-rollback-clone.md
@@ -1,0 +1,150 @@
+# 快照、回滚与克隆
+
+本文介绍 Cube Sandbox Python SDK 提供的三组进阶接口：
+
+- **快照（Snapshot）**：把一个运行中的沙箱的完整状态（内存 + 文件系统）持久化为一份镜像，后续可以反复用来创建新沙箱或执行回滚。
+- **克隆（Clone）**：对一个正在运行的沙箱调用 `clone()`，可以立即派生出 N 个完全独立的副本，每个副本都从源沙箱的当前状态出发，互不干扰。
+- **回滚（Rollback）**：把一个正在运行的沙箱原地恢复到先前某次快照的状态，沙箱 ID 不变，可以继续执行。
+
+## 概念模型
+
+```mermaid
+flowchart LR
+    A[源沙箱<br/>running] -->|create_snapshot| S[(快照<br/>snap-xxx)]
+    A -->|clone n=N| C1[克隆 1]
+    A -->|clone n=N| C2[克隆 2]
+    A -->|clone n=N| Cn[克隆 N]
+    A -.->|rollback snap-xxx| A2[源沙箱<br/>恢复到快照状态]
+
+    classDef src fill:#e8f4fd,stroke:#3b82f6,stroke-width:2px;
+    classDef snap fill:#fef3c7,stroke:#f59e0b,stroke-width:2px;
+    classDef clone fill:#d1fae5,stroke:#10b981,stroke-width:1px;
+    class A,A2 src;
+    class S snap;
+    class C1,C2,Cn clone;
+```
+
+| 接口 | 作用对象 | 沙箱 ID | 典型用途 |
+|------|---------|--------|---------|
+| `sb.create_snapshot()` | 源沙箱本身 | 不变 | 制作 checkpoint 或持久化状态 |
+| `sb.clone(n=N)` | 从运行中的沙箱派生 N 个新沙箱 | 新建 N 个 | Agent 并行 rollout、可重复实验 |
+| `sb.rollback(snap_id)` | 把当前沙箱原地恢复到快照状态 | **不变** | 撤回失败一步、回到分支点继续 |
+
+## 安装
+
+> **注意**：快照、克隆、回滚是 Cube Sandbox 特有的能力，e2b SDK 没有对应接口。[`cubesandbox`](https://pypi.org/project/cubesandbox/) SDK 兼容 e2b SDK，可以直接替换使用，同时获得以下进阶能力。
+
+本文所有接口需要 [`cubesandbox`](https://pypi.org/project/cubesandbox/) **0.2.0 或更高版本**。
+
+```bash
+pip install "cubesandbox>=0.2.0"
+```
+
+环境变量约定：
+
+```bash
+export CUBE_API_URL=http://127.0.0.1:3000
+export CUBE_TEMPLATE_ID=tpl-xxxxxxxxxxxxxxxxxxxxxxxx
+```
+
+## 快照（Snapshot）
+
+`sb.create_snapshot()` 将沙箱的当前状态（文件系统 + 内存）持久化为一份快照，返回 `SnapshotInfo`，其中 `snapshot_id` 可以作为 `Sandbox.create(template=...)` 的入参。
+
+```python
+from cubesandbox import Sandbox
+
+with Sandbox.create(template=TEMPLATE_ID) as sb:
+    sb.run_code("open('/tmp/data.txt','w').write('hello')")
+    snap = sb.create_snapshot()
+    print(f"snapshot: {snap.snapshot_id}")
+```
+
+快照的生命周期独立于沙箱：源沙箱被 `kill()` 之后，快照仍然可用。不再需要时，调用 `Sandbox.delete_snapshot(snapshot_id)` 手动清理。
+
+### 列举快照
+
+```python
+# 获取快照列表（第一页）
+items, next_token = Sandbox.list_snapshots()
+
+# 按 sandbox_id 过滤
+items, _ = Sandbox.list_snapshots(sandbox_id=sb.sandbox_id)
+```
+
+`list_snapshots()` 返回 `(list[SnapshotInfo], next_token)`，将 `next_token` 传回可获取后续页；为 `None` 时表示没有更多页。
+
+## 克隆（Clone）
+
+对一个正在运行的沙箱调用 `sb.clone(n=N)`，可以立即派生出 N 个独立副本。每个副本都继承源沙箱当前的文件系统状态，但之后的写入互不影响，源沙箱也继续正常运行。
+
+```python
+src = Sandbox.create(template=TEMPLATE_ID)
+src.run_code("open('/tmp/shared.txt','w').write('hello')")
+
+clones = src.clone(n=3)
+for sb in clones:
+    # Each clone inherits the file written in src
+    out = sb.run_code("print(open('/tmp/shared.txt').read())").logs.stdout[0]
+    assert out.strip() == "hello"
+```
+
+### 并发克隆
+
+默认串行创建，对于 fan-out 场景可以传 `concurrency=C` 并发执行：
+
+```python
+clones = src.clone(n=10, concurrency=5)
+```
+
+- 任一子任务失败时，已成功创建的克隆会被自动 `kill()`，调用方拿到的要么是 N 个沙箱，要么是异常，不会留下孤儿资源。
+
+### 继承性与隔离性
+
+`clone()` 返回的副本满足以下性质：
+
+| 性质 | 含义 |
+|------|------|
+| **继承性** | 每个副本的初始状态与源沙箱在 clone 时刻完全一致 |
+| **隔离性** | 副本之间的写入互不可见，与源沙箱也互相隔离 |
+| **连续性** | 源沙箱在 `clone()` 返回后仍在运行，状态不受影响 |
+
+## 回滚（Rollback）
+
+`sb.rollback(snapshot_id)` 把当前沙箱**原地**恢复到指定快照的状态：文件系统完全还原，**沙箱 ID 不变**，`sb` 对象可以继续使用。
+
+```python
+sb = Sandbox.create(template=TEMPLATE_ID)
+sb.run_code("open('/tmp/v.txt','w').write('v1')")
+checkpoint = sb.create_snapshot()
+
+sb.run_code("open('/tmp/v.txt','w').write('v2')")
+sb.rollback(checkpoint.snapshot_id)
+
+after = sb.run_code("print(open('/tmp/v.txt').read())").logs.stdout[0]
+assert after.strip() == "v1"
+```
+
+回滚后沙箱仍然可写，可以继续执行并再次创建快照，非常适合 Agent 的回退-重试循环：
+
+```python
+# Continue on the rolled-back branch
+sb.run_code("open('/tmp/v.txt','w').write('v3')")
+new_snap = sb.create_snapshot()
+
+with Sandbox.create(template=new_snap.snapshot_id) as forked:
+    out = forked.run_code("print(open('/tmp/v.txt').read())").logs.stdout[0]
+    assert out.strip() == "v3"
+```
+
+## 最佳实践
+
+- **快照不是免费的**。每个快照对应底层的一份完整镜像，记得用完即删，或定期调用 `list_snapshots()` 清理。
+- **`with` 语句不会自动删快照**。上下文管理器只负责 `kill` 沙箱，快照需要显式调用 `Sandbox.delete_snapshot()` 清理。
+- **`clone()` 会自动清理内部快照**。临时派生几个副本时直接用 `clone()`，无需手动管理快照生命周期。
+- **大批量并发派生**优先用 `clone(n=N, concurrency=C)`，SDK 内部统一处理失败回滚，不会留下孤儿资源。
+
+## 参考
+
+- 示例代码：[`CubeAPI/examples/snapshot-rollback-clone/`](https://github.com/TencentCloud/CubeSandbox/tree/master/CubeAPI/examples/snapshot-rollback-clone)
+- SDK 源码：[`sdk/python/`](https://github.com/TencentCloud/CubeSandbox/tree/master/sdk/python)


### PR DESCRIPTION
- Add CubeAPI/examples/snapshot-rollback-clone/ with 11 runnable demos covering create, list, clone, state preservation, snapshot lifecycle, concurrent clone, fork, rollback, and delete workflows
- Add docs/guide/snapshot-rollback-clone.md (English) and docs/zh/guide/snapshot-rollback-clone.md (Chinese) with concept diagrams and minimal code snippets