### PR TITLE
docs: fix clone state description — include memory, not just filesystem

### DIFF
--- a/CubeAPI/examples/snapshot-rollback-clone/README.md
+++ b/CubeAPI/examples/snapshot-rollback-clone/README.md
@@ -12,7 +12,7 @@ and clone APIs. Each script is standalone and runnable.
 | 01 | `01_create_snapshot.py` | `sb.create_snapshot()` basics |
 | 02 | `02_list_snapshots.py` | `Sandbox.list_snapshots()` — global / per-sandbox / paginated |
 | 03 | `03_clone_from_snapshot.py` | Spawn a sandbox from a snapshot via `template=` |
-| 04 | `04_state_preserved.py` | Filesystem state survives snapshot + clone |
+| 04 | `04_state_preserved.py` | Filesystem and memory state survive snapshot + clone |
 | 05 | `05_snapshot_outlives_sandbox.py` | Snapshot lifecycle is independent of the sandbox |
 | 06 | `06_clone_n.py` | One-line `sb.clone(n=N)` to fan out N sandboxes |
 | 07 | `07_clone_concurrent.py` | Parallel clone via `sb.clone(n=N, concurrency=C)` |

--- a/CubeAPI/examples/snapshot-rollback-clone/README_zh.md
+++ b/CubeAPI/examples/snapshot-rollback-clone/README_zh.md
@@ -12,7 +12,7 @@
 | 01 | `01_create_snapshot.py` | `sb.create_snapshot()` 基础用法 |
 | 02 | `02_list_snapshots.py` | `Sandbox.list_snapshots()`：全量 / 按 sandbox_id 过滤 / 分页 |
 | 03 | `03_clone_from_snapshot.py` | 用 `template=` 参数从快照启动新沙箱 |
-| 04 | `04_state_preserved.py` | 文件系统状态在 snapshot + clone 后保留 |
+| 04 | `04_state_preserved.py` | 文件系统与内存状态在 snapshot + clone 后均得以保留 |
 | 05 | `05_snapshot_outlives_sandbox.py` | 快照生命周期独立于源沙箱 |
 | 06 | `06_clone_n.py` | 一行 `sb.clone(n=N)` 派生 N 个沙箱 |
 | 07 | `07_clone_concurrent.py` | `sb.clone(n=N, concurrency=C)` 并发派生 |

--- a/docs/guide/snapshot-rollback-clone.md
+++ b/docs/guide/snapshot-rollback-clone.md
@@ -76,7 +76,7 @@ items, _ = Sandbox.list_snapshots(sandbox_id=sb.sandbox_id)
 
 ## Clone
 
-Calling `sb.clone(n=N)` on a running sandbox immediately derives N independent copies. Each copy inherits the source sandbox's current filesystem state, but subsequent writes are fully isolated. The source sandbox keeps running unaffected.
+Calling `sb.clone(n=N)` on a running sandbox immediately derives N independent copies. Each copy fully inherits the source sandbox's runtime state at the moment of the clone call — memory and filesystem alike — but subsequent writes are fully isolated. The source sandbox keeps running unaffected.
 
 ```python
 src = Sandbox.create(template=TEMPLATE_ID)

--- a/docs/zh/guide/snapshot-rollback-clone.md
+++ b/docs/zh/guide/snapshot-rollback-clone.md
@@ -76,7 +76,7 @@ items, _ = Sandbox.list_snapshots(sandbox_id=sb.sandbox_id)
 
 ## 克隆（Clone）
 
-对一个正在运行的沙箱调用 `sb.clone(n=N)`，可以立即派生出 N 个独立副本。每个副本都继承源沙箱当前的文件系统状态，但之后的写入互不影响，源沙箱也继续正常运行。
+对一个正在运行的沙箱调用 `sb.clone(n=N)`，可以立即派生出 N 个独立副本。每个副本都完整继承源沙箱在 clone 时刻的运行状态（内存 + 文件系统），但之后的写入互不影响，源沙箱也继续正常运行。
 
 ```python
 src = Sandbox.create(template=TEMPLATE_ID)


### PR DESCRIPTION
The previous wording said clones inherit "filesystem state", which was inaccurate. Clone captures the full runtime state (memory + filesystem) of the source sandbox at the moment of the call.

Affected files:
- docs/guide/snapshot-rollback-clone.md (EN)
- docs/zh/guide/snapshot-rollback-clone.md (ZH)
- CubeAPI/examples/snapshot-rollback-clone/README.md (EN)
- CubeAPI/examples/snapshot-rollback-clone/README_zh.md (ZH)

Assisted-by: Claude:claude-sonnet-4-6