### PR TITLE
fix(cubelet): improve probe timeout error messages

### DIFF
--- a/Cubelet/go.sum
+++ b/Cubelet/go.sum
@@ -301,7 +301,7 @@ github.com/containerd/console v1.0.5 h1:R0ymNeydRqH2DmakFNdmjR2k0t7UPuiOV/N/27/q
 github.com/containerd/console v1.0.5/go.mod h1:YynlIjWYF8myEu6sdkwKIvGQq+cOckRm6So2avqoYAk=
 github.com/containerd/containerd/api v1.10.0 h1:5n0oHYVBwN4VhoX9fFykCV9dF1/BvAXeg2F8W6UYq1o=
 github.com/containerd/containerd/api v1.10.0/go.mod h1:NBm1OAk8ZL+LG8R0ceObGxT5hbUYj7CzTmR3xh0DlMM=
-github.com/containerd/containerd/v2 v2.2.2 h1:mjVQdtfryzT7lOqs5EYUFZm8ioPVjOpkSoG1GJPxEMY=
+github.com/containerd/containerd/v2 v2.2.2 h1:meFug2XLSdedu+6ESe68YXZqFj9TwJkkSIz371GSn8s=
 github.com/containerd/containerd/v2 v2.2.2/go.mod h1:5Jhevmv6/2J+Iu/A2xXAdUIdI5Ah/hfyO7okJ4AFIdY=
 github.com/containerd/continuity v0.4.5 h1:ZRoN1sXq9u7V6QoHMcVWGhOwDFqZ4B9i5H6un1Wh0x4=
 github.com/containerd/continuity v0.4.5/go.mod h1:/lNJvtJKUQStBzpVQ1+rasXO1LAWtUQssk28EZvJ3nE=

--- a/Cubelet/services/cubebox/probe.go
+++ b/Cubelet/services/cubebox/probe.go
@@ -114,14 +114,21 @@ func (l *local) doProbe(ctx context.Context, c *cubebox.ContainerConfig, ci *cub
 		} else {
 			log.G(ctx).Errorf("probe [%s] failed[context canceled], costtime:%+v",
 				ci.IP, time.Since(startTime))
-			return ret.Errorf(errorcode.ErrorCode_PortBindingFailed, "The initialization timeout or"+
-				" detecting %s failed.", ci.IP)
+			return ret.Errorf(errorcode.ErrorCode_PortBindingFailed,
+				"Sandbox probe canceled after %v on %s. "+
+					"The parent context was canceled, possibly due to a timeout. "+
+					"Check sandbox networking (cube-dev, CIDR, routes) if this persists.",
+				time.Since(startTime).Round(time.Second), ci.IP)
 		}
 	case <-ctx.Done():
-		log.G(ctx).Errorf("probe [%s] timeout, costtime:%+v, err:%v",
-			ci.IP, time.Since(startTime), ctx.Err())
-		return ret.Errorf(errorcode.ErrorCode_PortBindingFailed, "The initialization timeout or"+
-			" detecting %s port failed.", ci.IP)
+		probeDesc := describeProbe(c.GetProbe())
+		log.G(ctx).Errorf("probe [%s] timeout, costtime:%+v, err:%v, probe_config=%s",
+			ci.IP, time.Since(startTime), ctx.Err(), probeDesc)
+		return ret.Errorf(errorcode.ErrorCode_PortBindingFailed,
+			"Sandbox probe timed out after %v on %s. %s "+
+				"This may indicate a network connectivity issue between the host and sandbox. "+
+				"Check that the cube-dev interface and CIDR configuration are consistent.",
+			time.Since(startTime).Round(time.Second), ci.IP, probeDesc)
 	}
 
 	select {
@@ -134,8 +141,10 @@ func (l *local) doProbe(ctx context.Context, c *cubebox.ContainerConfig, ci *cub
 		} else {
 			log.G(ctx).Errorf("probe [%s] failed[context canceled], costtime:%+v",
 				ci.IP, time.Since(startTime))
-			return ret.Errorf(errorcode.ErrorCode_PortBindingFailed, "The initialization timeout or"+
-				" detecting %s failed.", ci.IP)
+			return ret.Errorf(errorcode.ErrorCode_PortBindingFailed,
+				"Sandbox probe canceled after %v on %s. "+
+					"Check sandbox networking (cube-dev, CIDR, routes) if this persists.",
+				time.Since(startTime).Round(time.Second), ci.IP)
 		}
 	default:
 	}
@@ -305,4 +314,25 @@ func formatURL(scheme string, host string, port int, path string) *url.URL {
 	u.Scheme = scheme
 	u.Host = net.JoinHostPort(host, strconv.Itoa(port))
 	return u
+}
+
+// describeProbe returns a human-readable summary of the probe configuration
+// for diagnostic logging.
+func describeProbe(p *cubebox.Probe) string {
+	if p == nil {
+		return "no probe configured"
+	}
+	handler := p.GetProbeHandler()
+	if handler == nil {
+		return "no probe handler"
+	}
+	switch {
+	case handler.GetTcpSocket() != nil:
+		return fmt.Sprintf("tcp_socket:%d", handler.GetTcpSocket().GetPort())
+	case handler.GetHttpGet() != nil:
+		hg := handler.GetHttpGet()
+		return fmt.Sprintf("http_get:%s:%d%s", hg.GetHost(), hg.GetPort(), hg.GetPath())
+	default:
+		return "unknown probe handler"
+	}
 }

--- a/Cubelet/services/cubebox/probe_describe_test.go
+++ b/Cubelet/services/cubebox/probe_describe_test.go
@@ -1,0 +1,81 @@
+// Copyright (c) 2024 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package cubebox
+
+import (
+	"testing"
+
+	"github.com/tencentcloud/CubeSandbox/Cubelet/api/services/cubebox/v1"
+)
+
+func TestDescribeProbe(t *testing.T) {
+	tests := []struct {
+		name string
+		probe *cubebox.Probe
+		want  string
+	}{
+		{
+			name:  "nil probe",
+			probe: nil,
+			want:  "no probe configured",
+		},
+		{
+			name:  "nil handler",
+			probe: &cubebox.Probe{},
+			want:  "no probe handler",
+		},
+		{
+			name: "tcp socket probe",
+			probe: &cubebox.Probe{
+				ProbeHandler: &cubebox.ProbeHandler{
+					TcpSocket: &cubebox.TCPSocketAction{
+						Port: 49983,
+					},
+				},
+			},
+			want: "tcp_socket:49983",
+		},
+		{
+			name: "http get probe",
+			probe: &cubebox.Probe{
+				ProbeHandler: &cubebox.ProbeHandler{
+					HttpGet: &cubebox.HTTPGetAction{
+						Port: 8080,
+						Path: "/health",
+					},
+				},
+			},
+			want: "http_get::8080/health",
+		},
+		{
+			name: "http get probe with host",
+			probe: &cubebox.Probe{
+				ProbeHandler: &cubebox.ProbeHandler{
+					HttpGet: &cubebox.HTTPGetAction{
+						Host: "10.0.0.1",
+						Port: 9000,
+						Path: "/ready",
+					},
+				},
+			},
+			want: "http_get:10.0.0.1:9000/ready",
+		},
+		{
+			name: "unknown handler type",
+			probe: &cubebox.Probe{
+				ProbeHandler: &cubebox.ProbeHandler{},
+			},
+			want: "unknown probe handler",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := describeProbe(tt.probe)
+			if got != tt.want {
+				t.Errorf("describeProbe() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem

Probe timeout errors provided no context about how long the timeout was or what to check, making it hard for operators to diagnose issues.

## Changes

- Add elapsed time and actionable hints to timeout error messages
- Add `describeProbe()` to produce human-readable probe state summaries
- Add unit tests in `probe_describe_test.go`
- Update `go.sum` checksum for `containerd v2.2.2`

## Testing

- Unit tests in `probe_describe_test.go` cover all probe state descriptions