### PR TITLE
fix(one-click): force 4K block size when building guest rootfs

### DIFF
--- a/deploy/one-click/build-vm-assets.sh
+++ b/deploy/one-click/build-vm-assets.sh
@@ -465,7 +465,9 @@ build_guest_image_artifacts() {
   image_size_bytes="$(calculate_guest_image_size_bytes "${rootfs_size_bytes}")"
 
   truncate -s "${image_size_bytes}" "${output_img}"
-  run_mkfs_ext4_with_optional_sudo -F -d "${GUEST_ROOTFS_DIR}" "${output_img}" >&2
+  # Force 4K block size: CubeShim boots the kernel with rootflags=dax, which
+  # does not support 1K block sizes and would panic at boot time.
+  run_mkfs_ext4_with_optional_sudo -F -b 4096 -d "${GUEST_ROOTFS_DIR}" "${output_img}" >&2
 
   shrink_ext4_image "${output_img}"
 


### PR DESCRIPTION
mkfs.ext4 picks the block size based on filesystem size, so small guest images end up with 1K blocks. CubeShim boots the guest kernel with rootflags=dax, and the DAX path requires the ext4 block size to match the page size (4K on x86_64) — a 1K-block rootfs panics at boot time.

Pass -b 4096 explicitly in build_guest_image_artifacts. The downstream shrink_ext4_image already reads block size dynamically via dumpe2fs, and the 2 MiB pmem alignment it enforces is a multiple of 4096, so no other changes are needed.