### PR TITLE
virtio-devices: vsock: RST vsocks on snapshot restore

### DIFF
--- a/hypervisor/virtio-devices/src/vsock/device.rs
+++ b/hypervisor/virtio-devices/src/vsock/device.rs
@@ -362,6 +362,8 @@ pub struct Vsock<B: VsockBackend> {
 pub struct VsockState {
     pub avail_features: u64,
     pub acked_features: u64,
+    #[serde(default)]
+    pub connections: Vec<(u32, u32)>,
 }
 
 impl<B> Vsock<B>
@@ -375,7 +377,7 @@ where
         id: String,
         cid: u64,
         path: PathBuf,
-        backend: B,
+        mut backend: B,
         iommu: bool,
         seccomp_action: SeccompAction,
         exit_evt: EventFd,
@@ -383,6 +385,9 @@ where
     ) -> io::Result<Vsock<B>> {
         let (avail_features, acked_features) = if let Some(state) = state {
             debug!("Restoring virtio-vsock {}", id);
+            // Instead of letting the guest connection hang/timeout, proactively let
+            // the guest know the connection is gone.
+            backend.queue_rst_for_connections(state.connections.clone());
             (state.avail_features, state.acked_features)
         } else {
             let mut avail_features = 1u64 << VIRTIO_F_VERSION_1 | 1u64 << VIRTIO_F_IN_ORDER;
@@ -416,6 +421,7 @@ where
         VsockState {
             avail_features: self.common.avail_features,
             acked_features: self.common.acked_features,
+            connections: self.backend.read().unwrap().connections(),
         }
     }
 }

--- a/hypervisor/virtio-devices/src/vsock/mod.rs
+++ b/hypervisor/virtio-devices/src/vsock/mod.rs
@@ -174,7 +174,12 @@ pub trait VsockChannel {
 /// sendable through a mpsc channel (the latter due to how `vmm::EpollContext` works).
 /// Currently, the only implementation we have is `crate::virtio::unix::muxer::VsockMuxer`, which
 /// translates guest-side vsock connections to host-side Unix domain socket connections.
-pub trait VsockBackend: VsockChannel + Snapshottable + VsockEpollListener + Send {}
+pub trait VsockBackend: VsockChannel + Snapshottable + VsockEpollListener + Send {
+    fn connections(&self) -> Vec<(u32, u32)> {
+        Vec::new()
+    }
+    fn queue_rst_for_connections(&mut self, _conns: Vec<(u32, u32)>) {}
+}
 
 #[cfg(test)]
 mod tests {

--- a/hypervisor/virtio-devices/src/vsock/unix/muxer.rs
+++ b/hypervisor/virtio-devices/src/vsock/unix/muxer.rs
@@ -377,7 +377,23 @@ impl Snapshottable for VsockMuxer {
     }
 }
 
-impl VsockBackend for VsockMuxer {}
+impl VsockBackend for VsockMuxer {
+    fn connections(&self) -> Vec<(u32, u32)> {
+        self.conn_map
+            .keys()
+            .map(|k| (k.local_port, k.peer_port))
+            .collect()
+    }
+
+    fn queue_rst_for_connections(&mut self, conns: Vec<(u32, u32)>) {
+        for (local_port, peer_port) in conns {
+            self.rxq.push(MuxerRx::RstPkt {
+                local_port,
+                peer_port,
+            });
+        }
+    }
+}
 
 #[derive(Debug, Default, Deserialize, Serialize)]
 pub struct CubeVsockDbgConf {


### PR DESCRIPTION
Backport of upstream cloud-hypervisor PR #7958.

On snapshot restore the host-side Unix socket connections are gone, but the guest still believes its vsock connections are alive, which makes guest-side connections hang until they time out. Proactively queue an RST packet for every previously-recorded connection so the guest learns about the disconnection immediately, matching the virtio-vsock spec.

Save the active (local_port, peer_port) pairs into VsockState and queue MuxerRx::RstPkt for each of them when the device is restored. `#[serde(default)]` keeps old snapshots compatible, and the new VsockBackend trait methods carry default implementations so other backends (e.g. TestBackend) need no change.


Assisted-by: Anthropic:claude-opus-4-7