### PR TITLE
feat(snapshot): add soft-dirty per-cycle incremental memory snapshots

### DIFF
--- a/CubeShim/shim/src/snapshot/cmd.rs
+++ b/CubeShim/shim/src/snapshot/cmd.rs
@@ -82,11 +82,14 @@ pub struct SnapshotArgs {
     )]
     pub vm_id: Option<String>,
 
-    /// Snapshot type: 'full' or 'incremental' (saves only CoW anonymous pages)
+    /// Snapshot type: 'full', 'incremental' (saves only CoW anonymous pages,
+    /// cumulative since restore) or 'soft-dirty' (true delta of pages
+    /// dirtied since the previous soft-dirty snapshot; falls back to
+    /// 'incremental' on kernels without CONFIG_MEM_SOFT_DIRTY).
     #[arg(
         long = "snapshot-type",
         value_name = "snapshot type",
-        help = "snapshot type: 'full' or 'incremental'",
+        help = "snapshot type: 'full', 'incremental' or 'soft-dirty'",
         default_value = "full"
     )]
     pub snapshot_type: String,

--- a/Cubelet/pkg/constants/const.go
+++ b/Cubelet/pkg/constants/const.go
@@ -187,6 +187,15 @@ const (
 	MasterAnnotationAppSnapshotTemplateID     = "cube.master.appsnapshot.template.id"
 	MasterAnnotationRuntimeSnapshotID         = "cube.master.runtime.snapshot.id"
 	MasterAnnotationRuntimeSnapshotAttachedAt = "cube.master.runtime.snapshot.attached_at"
+	// MasterAnnotationRuntimeRestoreSnapshotID tracks the snapshot id whose
+	// memory image the running VM was last *restored* from (set by Create
+	// for restore-from-snapshot path, and by Rollback). Unlike
+	// MasterAnnotationRuntimeSnapshotID, Commit does NOT bump this — Commit
+	// does not restart the VM, so the in-process pagemap_anon bitmap is
+	// still tracking "anon pages dirtied since the last restore", which
+	// matches the memory file recorded here.
+	MasterAnnotationRuntimeRestoreSnapshotID         = "cube.master.runtime.restore.snapshot.id"
+	MasterAnnotationRuntimeRestoreSnapshotAttachedAt = "cube.master.runtime.restore.snapshot.attached_at"
 
 	MasterAnnotationAppSnapshotVersion               = "cube.master.appsnapshot.version"
 	MasterAnnotationRootfsArtifactID                 = "cube.master.rootfs.artifact.id"

--- a/Cubelet/services/cubebox/appsnapshot.go
+++ b/Cubelet/services/cubebox/appsnapshot.go
@@ -552,6 +552,21 @@ const snapshotTypeFull = "full"
 // the destination file already contains (i.e. the reflink-cloned base).
 const snapshotTypeIncremental = "incremental"
 
+// snapshotTypeSoftDirty asks cube-runtime to write only the pages dirtied
+// since the previous soft-dirty snapshot (a true per-cycle delta) on top of
+// the destination memory file. The destination MUST already contain a valid
+// base image (the reflink-cloned previous snapshot's memory), otherwise pages
+// untouched-since-last-clear would read back as zero on restore. Cubelet
+// guarantees this precondition by reflink-cloning the binding base before
+// invoking cube-runtime; if the base cannot be resolved, the caller falls
+// back to snapshotTypeFull instead.
+//
+// The host kernel needs CONFIG_MEM_SOFT_DIRTY=y for soft-dirty to do
+// anything useful; on kernels without it the hypervisor silently downgrades
+// to the pagemap_anon (incremental) path, so this value is safe to send
+// unconditionally.
+const snapshotTypeSoftDirty = "soft-dirty"
+
 // normalizeSnapshotType defaults to snapshotTypeFull when an empty value is
 // supplied so callers that don't care (legacy code paths) keep producing full
 // snapshots.
@@ -559,6 +574,8 @@ func normalizeSnapshotType(snapshotType string) string {
 	switch strings.TrimSpace(strings.ToLower(snapshotType)) {
 	case snapshotTypeIncremental:
 		return snapshotTypeIncremental
+	case snapshotTypeSoftDirty:
+		return snapshotTypeSoftDirty
 	case "", snapshotTypeFull:
 		return snapshotTypeFull
 	default:

--- a/Cubelet/services/cubebox/cube_container_create.go
+++ b/Cubelet/services/cubebox/cube_container_create.go
@@ -186,7 +186,15 @@ func (l *local) createContainers(ctx context.Context, flowOpts *workflow.CreateC
 
 	l.storeNumaQueues(ctx, sandBox, flowOpts)
 	if snapshotID, ok := flowOpts.GetSnapshotTemplateID(); ok && flowOpts.IsRetoreSnapshot() {
-		setRuntimeSnapshotBindingLabels(sandBox, snapshotID, time.Now().UTC())
+		now := time.Now().UTC()
+		setRuntimeSnapshotBindingLabels(sandBox, snapshotID, now)
+		// Also stamp the restore-base label. Commit will advance the
+		// runtime-snapshot binding above; this label stays pinned at the
+		// memory image the VM was actually restored from, so the
+		// pagemap_anon fallback in CommitSandbox can still locate a
+		// reflinkable base after the most recent commit's snapshot is
+		// deleted.
+		setRuntimeRestoreBaseLabels(sandBox, snapshotID, now)
 	}
 
 	cgInfo, cgSet := flowOpts.CgroupInfo.(*cgroupp.Info)

--- a/Cubelet/services/cubebox/rollback.go
+++ b/Cubelet/services/cubebox/rollback.go
@@ -182,7 +182,12 @@ func (s *service) RollbackSandbox(ctx context.Context, req *cubebox.RollbackSand
 	rsp.RootfsDev = newRootfs.DevPath
 	rsp.NewGen = newRootfs.Gen
 	rsp.MemoryVol = refs.Memory.Name
-	setRuntimeSnapshotBindingLabels(cb, req.GetSnapshotID(), time.Now().UTC())
+	rollbackTime := time.Now().UTC()
+	setRuntimeSnapshotBindingLabels(cb, req.GetSnapshotID(), rollbackTime)
+	// Rollback restarts the VM from req.SnapshotID, so this is also the
+	// new last-restore base. Update both labels here; the existing
+	// SyncByID call below covers the persistence for both.
+	setRuntimeRestoreBaseLabels(cb, req.GetSnapshotID(), rollbackTime)
 
 	if err := storage.DeleteCowObject(ctx, currentRootfs.Name, currentRootfs.Kind); err != nil {
 		rsp.OldRootfsDeleted = false

--- a/Cubelet/services/cubebox/snapshot_base_memory.go
+++ b/Cubelet/services/cubebox/snapshot_base_memory.go
@@ -70,17 +70,65 @@ func resolveBaseSnapshotID(cb *cubeboxstore.CubeBox) string {
 // soft-dirty path live we prefer "produce a slightly larger but correct
 // snapshot" over "fail the user-facing commit when the lineage breaks".
 func resolveBaseMemoryObject(ctx context.Context, cb *cubeboxstore.CubeBox) (*storage.CowSnapshotObject, error) {
-	baseSnapshotID := resolveBaseSnapshotID(cb)
-	if baseSnapshotID == "" {
+	return resolveMemoryObjectFromSnapshotID(ctx, resolveBaseSnapshotID(cb))
+}
+
+// resolveRestoreBaseSnapshotID returns the snapshot id whose memory image
+// the running VM was last *restored* from. Set by Create's restore path and
+// by Rollback; intentionally NOT updated by Commit. The pagemap_anon
+// fallback in prepareCommitMemoryArtifact uses this to find a base file
+// whose contents match the VM's "everything not dirty since last restore"
+// state, which is exactly the precondition pagemap_anon requires.
+//
+// Falls back to the create-time annotation as best-effort for sandboxes
+// that predate the new label, so first-commit-after-upgrade still gets the
+// pagemap_anon path instead of the full-rewrite path.
+func resolveRestoreBaseSnapshotID(cb *cubeboxstore.CubeBox) string {
+	if cb == nil {
+		return ""
+	}
+	if v := strings.TrimSpace(cb.Labels[constants.MasterAnnotationRuntimeRestoreSnapshotID]); v != "" {
+		return v
+	}
+	if v := strings.TrimSpace(cb.Annotations[constants.MasterAnnotationRuntimeRestoreSnapshotID]); v != "" {
+		return v
+	}
+	// Best-effort backstop for sandboxes created before
+	// MasterAnnotationRuntimeRestoreSnapshotID was introduced. Note that
+	// this is only correct if the sandbox has not been rolled back since
+	// create — once it has been rolled back, only the new label tracks
+	// the post-rollback restore source. Caller has nothing better here,
+	// so we return it and let the catalog lookup decide.
+	if v := strings.TrimSpace(cb.Annotations[constants.MasterAnnotationRuntimeSnapshotID]); v != "" {
+		return v
+	}
+	if v := strings.TrimSpace(cb.Annotations[constants.MasterAnnotationAppSnapshotTemplateID]); v != "" {
+		return v
+	}
+	return ""
+}
+
+// resolveRestoreBaseMemoryObject is the pagemap_anon fallback's analogue
+// of resolveBaseMemoryObject: resolves the cubecow memory object for the
+// snapshot the VM was last restored from. Same sentinel-error contract.
+func resolveRestoreBaseMemoryObject(ctx context.Context, cb *cubeboxstore.CubeBox) (*storage.CowSnapshotObject, error) {
+	return resolveMemoryObjectFromSnapshotID(ctx, resolveRestoreBaseSnapshotID(cb))
+}
+
+// resolveMemoryObjectFromSnapshotID is shared by both resolution paths:
+// catalog lookup + memory_vol/kind extraction + cubecow dev-path resolution.
+// Empty snapshotID yields the standard "not bound" sentinel.
+func resolveMemoryObjectFromSnapshotID(ctx context.Context, snapshotID string) (*storage.CowSnapshotObject, error) {
+	if snapshotID == "" {
 		return nil, fmt.Errorf("%w: sandbox is not bound to any snapshot or template", ErrNoBaseMemoryForIncremental)
 	}
-	entry, err := storage.GetLocalSnapshot(ctx, baseSnapshotID)
+	entry, err := storage.GetLocalSnapshot(ctx, snapshotID)
 	if err != nil {
-		return nil, fmt.Errorf("%w: catalog lookup for %s: %v", ErrNoBaseMemoryForIncremental, baseSnapshotID, err)
+		return nil, fmt.Errorf("%w: catalog lookup for %s: %v", ErrNoBaseMemoryForIncremental, snapshotID, err)
 	}
 	memoryVol := strings.TrimSpace(entry.MemoryVol)
 	if memoryVol == "" {
-		return nil, fmt.Errorf("%w: catalog entry for %s has no memory_vol", ErrNoBaseMemoryForIncremental, baseSnapshotID)
+		return nil, fmt.Errorf("%w: catalog entry for %s has no memory_vol", ErrNoBaseMemoryForIncremental, snapshotID)
 	}
 	memoryKind := strings.TrimSpace(entry.MemoryKind)
 	if memoryKind == "" {
@@ -101,30 +149,42 @@ func resolveBaseMemoryObject(ctx context.Context, cb *cubeboxstore.CubeBox) (*st
 // cube-runtime will write its memory snapshot into, plus the snapshot type
 // flag to pass to cube-runtime for this commit.
 //
-// Fast path (sandbox lineage intact): reflink-clone the binding base memory
-// into a new cubecow snapshot keyed by templateID and ask cube-runtime for a
-// soft-dirty per-cycle delta. The cloned file already contains the previous
-// snapshot's memory bytes, satisfying soft-dirty's "destination must hold
-// every still-clean page" precondition; the kernel-side soft-dirty bitmap
-// only writes the pages the guest actually dirtied since the previous
-// snapshot operation, giving a true delta and minimum disk write amplification.
+// Three-tier degradation:
 //
-// Fallback path (errors.Is(err, ErrNoBaseMemoryForIncremental)): no usable
-// base could be resolved (sandbox not bound to a snapshot, catalog entry
-// purged, upstream cubecow volume gone, etc.). Soft-dirty would be unsafe
-// here — for a *restored* VM, untouched-since-restore pages are not in the
-// soft-dirty bitmap and there is no base file to read them from on restore.
-// Instead we create a fresh empty memory volume and ask cube-runtime for a
-// full snapshot, which is self-contained regardless of soft-dirty bit state.
+// Tier 1 — soft-dirty + reflink from previous snapshot (the happy path).
+// resolveBaseMemoryObject returns the runtime-binding snapshot's memory
+// file; we reflink-clone it as the destination for this commit and ask
+// cube-runtime for a soft-dirty per-cycle delta. The cloned file already
+// contains the previous snapshot's memory bytes, satisfying soft-dirty's
+// "destination must hold every still-clean page" precondition; the
+// kernel-side soft-dirty bitmap only writes the pages the guest actually
+// dirtied since the previous snapshot operation, giving a true delta and
+// minimum disk write amplification.
 //
-// Non-sentinel errors from resolveBaseMemoryObject (currently unreachable —
-// resolveBaseMemoryObject always wraps with the sentinel — kept as
-// defense-in-depth) propagate unchanged so genuine infrastructure failures
-// surface to the caller.
+// Tier 2 — incremental(pagemap_anon) + reflink from last-restore base.
+// Reached when the runtime-binding snapshot's memory file no longer exists
+// (e.g. operator deleted the most recent commit between commits). We look
+// up the snapshot the VM was last *restored* from (tracked by a separate
+// label that Commit does not advance) and reflink from its memory file.
+// pagemap_anon's bitmap captures every anon page dirty *since the last
+// restore*, which is exactly the delta we need to overlay onto that base to
+// produce a self-contained image. If the VM is later restored from an
+// opaque source that Cubelet cannot reflink from (pause/resume's internal
+// full snapshot), that restore path invalidates this label so this tier is
+// skipped.
 //
-// The caller owns the returned cubecow object: any subsequent failure in the
-// CommitSandbox flow must call DeleteCowObject to avoid orphaned cubecow
-// state.
+// Tier 3 — full + fresh empty volume. The last-resort fallback when even
+// the last-restore base file is gone (e.g. the source template was deleted
+// while the VM kept running). cube-runtime writes the entire memory image
+// onto a fresh sparse file; correct in all cases but the costliest, hence
+// only used when neither delta path can resolve a base.
+//
+// Non-sentinel errors propagate unchanged so genuine infrastructure
+// failures surface to the caller.
+//
+// The caller owns the returned cubecow object: any subsequent failure in
+// the CommitSandbox flow must call DeleteCowObject to avoid orphaned
+// cubecow state.
 func prepareCommitMemoryArtifact(
 	ctx context.Context,
 	stepLog *log.CubeWrapperLogEntry,
@@ -132,6 +192,7 @@ func prepareCommitMemoryArtifact(
 	templateID string,
 	memorySizeBytes uint64,
 ) (*storage.CowSnapshotObject, string, error) {
+	// ─── Tier 1: soft-dirty over previous-snapshot base ───────────────
 	baseMemoryObject, baseErr := resolveBaseMemoryObject(ctx, cb)
 	if baseErr == nil {
 		memoryObject, err := storage.CommitTemplateMemoryFromBase(ctx, baseMemoryObject, templateID, memorySizeBytes)
@@ -145,7 +206,32 @@ func prepareCommitMemoryArtifact(
 	if !errors.Is(baseErr, ErrNoBaseMemoryForIncremental) {
 		return nil, "", baseErr
 	}
-	stepLog.Warnf("CommitSandbox: base memory unavailable (%v), falling back to full snapshot", baseErr)
+
+	// ─── Tier 2: pagemap_anon over last-restore base ──────────────────
+	// soft-dirty's bitmap was last reset at the previous commit, so its
+	// state would not match the older last-restore file we're reflinking
+	// from. pagemap_anon's "anon pages currently dirty" set, on the other
+	// hand, was last reset at the VM's last restore — exactly the moment
+	// captured by the snapshot id stored in the restore-base label —
+	// which makes its bitmap consistent with this base.
+	restoreBase, restoreErr := resolveRestoreBaseMemoryObject(ctx, cb)
+	if restoreErr == nil {
+		memoryObject, err := storage.CommitTemplateMemoryFromBase(ctx, restoreBase, templateID, memorySizeBytes)
+		if err != nil {
+			return nil, "", err
+		}
+		stepLog.Warnf("CommitSandbox: previous-snapshot base unavailable (%v); "+
+			"falling back to incremental(pagemap_anon) over last-restore base %s/%s -> %s",
+			baseErr, restoreBase.Name, restoreBase.Kind, memoryObject.Name)
+		return memoryObject, snapshotTypeIncremental, nil
+	}
+	if !errors.Is(restoreErr, ErrNoBaseMemoryForIncremental) {
+		return nil, "", restoreErr
+	}
+
+	// ─── Tier 3: full + fresh empty volume ────────────────────────────
+	stepLog.Warnf("CommitSandbox: both previous-snapshot base (%v) and last-restore base (%v) "+
+		"unavailable; falling back to full snapshot", baseErr, restoreErr)
 	memoryObject, err := storage.CreateTemplateMemoryVolume(ctx, templateID, memorySizeBytes)
 	if err != nil {
 		return nil, "", err

--- a/Cubelet/services/cubebox/snapshot_base_memory.go
+++ b/Cubelet/services/cubebox/snapshot_base_memory.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/tencentcloud/CubeSandbox/Cubelet/pkg/constants"
+	"github.com/tencentcloud/CubeSandbox/Cubelet/pkg/log"
 	cubeboxstore "github.com/tencentcloud/CubeSandbox/Cubelet/pkg/store/cubebox"
 	"github.com/tencentcloud/CubeSandbox/Cubelet/storage"
 )
@@ -55,17 +56,19 @@ func resolveBaseSnapshotID(cb *cubeboxstore.CubeBox) string {
 
 // resolveBaseMemoryObject looks up the cubecow memory object that backs the
 // snapshot the sandbox is currently bound to. This is the source that
-// CommitSandbox will reflink-clone for an incremental memory snapshot.
+// CommitSandbox will reflink-clone for a soft-dirty / pagemap_anon
+// incremental memory snapshot.
 //
-// Hard-fails (rather than degrading to a full snapshot) on any of:
+// Returns ErrNoBaseMemoryForIncremental wrapped with context on any of:
 //   - the sandbox is not bound to any snapshot/template,
 //   - the local catalog entry is missing or has no memory_vol recorded,
 //   - the cubecow object can no longer be resolved on the host.
 //
-// Hard-failing keeps the user-observable contract crisp: when CommitSandbox
-// claims an incremental snapshot, the workload truly produced an incremental
-// snapshot. Silent fallback would lead to surprising "why is my snapshot
-// twice the size?" reports.
+// Callers (notably prepareCommitMemoryArtifact) are expected to recognize
+// the sentinel via errors.Is and gracefully fall back to a full snapshot;
+// previous incarnations of CommitSandbox hard-failed instead, but with the
+// soft-dirty path live we prefer "produce a slightly larger but correct
+// snapshot" over "fail the user-facing commit when the lineage breaks".
 func resolveBaseMemoryObject(ctx context.Context, cb *cubeboxstore.CubeBox) (*storage.CowSnapshotObject, error) {
 	baseSnapshotID := resolveBaseSnapshotID(cb)
 	if baseSnapshotID == "" {
@@ -92,4 +95,62 @@ func resolveBaseMemoryObject(ctx context.Context, cb *cubeboxstore.CubeBox) (*st
 		Kind:    memoryKind,
 		DevPath: devPath,
 	}, nil
+}
+
+// prepareCommitMemoryArtifact returns the cubecow memory object that
+// cube-runtime will write its memory snapshot into, plus the snapshot type
+// flag to pass to cube-runtime for this commit.
+//
+// Fast path (sandbox lineage intact): reflink-clone the binding base memory
+// into a new cubecow snapshot keyed by templateID and ask cube-runtime for a
+// soft-dirty per-cycle delta. The cloned file already contains the previous
+// snapshot's memory bytes, satisfying soft-dirty's "destination must hold
+// every still-clean page" precondition; the kernel-side soft-dirty bitmap
+// only writes the pages the guest actually dirtied since the previous
+// snapshot operation, giving a true delta and minimum disk write amplification.
+//
+// Fallback path (errors.Is(err, ErrNoBaseMemoryForIncremental)): no usable
+// base could be resolved (sandbox not bound to a snapshot, catalog entry
+// purged, upstream cubecow volume gone, etc.). Soft-dirty would be unsafe
+// here — for a *restored* VM, untouched-since-restore pages are not in the
+// soft-dirty bitmap and there is no base file to read them from on restore.
+// Instead we create a fresh empty memory volume and ask cube-runtime for a
+// full snapshot, which is self-contained regardless of soft-dirty bit state.
+//
+// Non-sentinel errors from resolveBaseMemoryObject (currently unreachable —
+// resolveBaseMemoryObject always wraps with the sentinel — kept as
+// defense-in-depth) propagate unchanged so genuine infrastructure failures
+// surface to the caller.
+//
+// The caller owns the returned cubecow object: any subsequent failure in the
+// CommitSandbox flow must call DeleteCowObject to avoid orphaned cubecow
+// state.
+func prepareCommitMemoryArtifact(
+	ctx context.Context,
+	stepLog *log.CubeWrapperLogEntry,
+	cb *cubeboxstore.CubeBox,
+	templateID string,
+	memorySizeBytes uint64,
+) (*storage.CowSnapshotObject, string, error) {
+	baseMemoryObject, baseErr := resolveBaseMemoryObject(ctx, cb)
+	if baseErr == nil {
+		memoryObject, err := storage.CommitTemplateMemoryFromBase(ctx, baseMemoryObject, templateID, memorySizeBytes)
+		if err != nil {
+			return nil, "", err
+		}
+		stepLog.Infof("CommitSandbox: reflink-cloned base memory %s/%s -> %s, snapshot type=%s",
+			baseMemoryObject.Name, baseMemoryObject.Kind, memoryObject.Name, snapshotTypeSoftDirty)
+		return memoryObject, snapshotTypeSoftDirty, nil
+	}
+	if !errors.Is(baseErr, ErrNoBaseMemoryForIncremental) {
+		return nil, "", baseErr
+	}
+	stepLog.Warnf("CommitSandbox: base memory unavailable (%v), falling back to full snapshot", baseErr)
+	memoryObject, err := storage.CreateTemplateMemoryVolume(ctx, templateID, memorySizeBytes)
+	if err != nil {
+		return nil, "", err
+	}
+	stepLog.Infof("CommitSandbox: created empty memory volume %s/%s, snapshot type=%s",
+		memoryObject.Name, memoryObject.Kind, snapshotTypeFull)
+	return memoryObject, snapshotTypeFull, nil
 }

--- a/Cubelet/services/cubebox/snapshot_base_memory_fallback_test.go
+++ b/Cubelet/services/cubebox/snapshot_base_memory_fallback_test.go
@@ -103,3 +103,189 @@ func TestRuntimeBindingLabelOverridesCreateAnnotation(t *testing.T) {
 	assert.Equal(t, "snap-after-commit", resolveBaseSnapshotID(cb),
 		"the per-commit Labels stamp must beat both create-time annotations")
 }
+
+// TestResolveRestoreBaseSnapshotIDPriorityOrder pins the lookup priority
+// for the pagemap_anon fallback path.
+//
+// Restore-base resolution must prefer, in order:
+//  1. Labels[RuntimeRestoreSnapshotID]      — set at Create + Rollback
+//  2. Annotations[RuntimeRestoreSnapshotID] — never used today, kept for
+//     forward compatibility if the master ever stamps it on a request
+//  3. Annotations[RuntimeSnapshotID]        — create-time runtime binding
+//  4. Annotations[AppSnapshotTemplateID]    — original create-time template
+//
+// The annotation backstops exist so a sandbox that pre-dates the new
+// Labels-based binding (i.e. one that survives an in-place upgrade) still
+// gets the pagemap_anon path on first commit-after-deletion, instead of
+// falling through to the full-rewrite tier.
+func TestResolveRestoreBaseSnapshotIDPriorityOrder(t *testing.T) {
+	cases := []struct {
+		name        string
+		labels      map[string]string
+		annotations map[string]string
+		want        string
+	}{
+		{
+			name: "label wins over every annotation backstop",
+			labels: map[string]string{
+				constants.MasterAnnotationRuntimeRestoreSnapshotID: "label-restore",
+			},
+			annotations: map[string]string{
+				constants.MasterAnnotationRuntimeRestoreSnapshotID: "ann-restore",
+				constants.MasterAnnotationRuntimeSnapshotID:        "ann-runtime",
+				constants.MasterAnnotationAppSnapshotTemplateID:    "tpl-T",
+			},
+			want: "label-restore",
+		},
+		{
+			name: "annotation restore key wins when label absent",
+			annotations: map[string]string{
+				constants.MasterAnnotationRuntimeRestoreSnapshotID: "ann-restore",
+				constants.MasterAnnotationRuntimeSnapshotID:        "ann-runtime",
+				constants.MasterAnnotationAppSnapshotTemplateID:    "tpl-T",
+			},
+			want: "ann-restore",
+		},
+		{
+			name: "annotation runtime key is the next backstop",
+			annotations: map[string]string{
+				constants.MasterAnnotationRuntimeSnapshotID:     "ann-runtime",
+				constants.MasterAnnotationAppSnapshotTemplateID: "tpl-T",
+			},
+			want: "ann-runtime",
+		},
+		{
+			name: "create-time template id is the final backstop",
+			annotations: map[string]string{
+				constants.MasterAnnotationAppSnapshotTemplateID: "tpl-T",
+			},
+			want: "tpl-T",
+		},
+		{
+			name: "no binding => empty",
+			want: "",
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			cb := &cubeboxstore.CubeBox{
+				Metadata: cubeboxstore.Metadata{
+					Labels:      tc.labels,
+					Annotations: tc.annotations,
+				},
+			}
+			assert.Equal(t, tc.want, resolveRestoreBaseSnapshotID(cb))
+		})
+	}
+}
+
+// TestRestoreBaseLabelDoesNotAdvanceOnCommit is the core invariant of the
+// two-label split:
+//
+//   - setRuntimeSnapshotBindingLabels (called by Create-restore, Rollback,
+//     AND Commit) bumps Labels[RuntimeSnapshotID] every time. This is what
+//     drives the soft-dirty chain forward.
+//   - setRuntimeRestoreBaseLabels (called by Create-restore and Rollback,
+//     NEVER by Commit) freezes Labels[RuntimeRestoreSnapshotID] at the most
+//     recent VM-restart point. This is what the pagemap_anon fallback
+//     reaches for when the runtime-snapshot base is gone.
+//
+// If a future refactor accidentally calls setRuntimeRestoreBaseLabels from
+// the commit path, pagemap_anon's reflink base would be a snapshot that
+// was committed *after* the VM's actual last restore — and pagemap_anon's
+// "anon dirty since restore" delta would be inconsistent with that base,
+// silently corrupting the produced memory image. This test pins the call
+// pattern so that drift is caught at compile/test time.
+func TestRestoreBaseLabelDoesNotAdvanceOnCommit(t *testing.T) {
+	cb := &cubeboxstore.CubeBox{
+		Metadata: cubeboxstore.Metadata{
+			Annotations: map[string]string{
+				constants.MasterAnnotationAppSnapshotTemplateID: "tpl-T",
+			},
+		},
+	}
+
+	now := time.Now().UTC()
+	// Step 1: Create-restore from tpl-T sets BOTH bindings.
+	setRuntimeSnapshotBindingLabels(cb, "tpl-T", now)
+	setRuntimeRestoreBaseLabels(cb, "tpl-T", now)
+	assert.Equal(t, "tpl-T", cb.Labels[constants.MasterAnnotationRuntimeSnapshotID])
+	assert.Equal(t, "tpl-T", cb.Labels[constants.MasterAnnotationRuntimeRestoreSnapshotID])
+
+	// Step 2: Commit A advances the runtime-snapshot binding only.
+	setRuntimeSnapshotBindingLabels(cb, "snap-A", now.Add(time.Second))
+	assert.Equal(t, "snap-A", cb.Labels[constants.MasterAnnotationRuntimeSnapshotID])
+	assert.Equal(t, "tpl-T", cb.Labels[constants.MasterAnnotationRuntimeRestoreSnapshotID],
+		"commit must not advance the restore-base label")
+
+	// Step 3: Commit B — same invariant.
+	setRuntimeSnapshotBindingLabels(cb, "snap-B", now.Add(2*time.Second))
+	assert.Equal(t, "snap-B", cb.Labels[constants.MasterAnnotationRuntimeSnapshotID])
+	assert.Equal(t, "tpl-T", cb.Labels[constants.MasterAnnotationRuntimeRestoreSnapshotID])
+
+	// Step 4: Rollback to A: rollback restarts the VM, so it bumps BOTH.
+	setRuntimeSnapshotBindingLabels(cb, "snap-A", now.Add(3*time.Second))
+	setRuntimeRestoreBaseLabels(cb, "snap-A", now.Add(3*time.Second))
+	assert.Equal(t, "snap-A", cb.Labels[constants.MasterAnnotationRuntimeSnapshotID])
+	assert.Equal(t, "snap-A", cb.Labels[constants.MasterAnnotationRuntimeRestoreSnapshotID])
+
+	// Step 5: Commit C after rollback — runtime-snapshot advances; the
+	//         restore-base label remains pinned at the rollback target.
+	setRuntimeSnapshotBindingLabels(cb, "snap-C", now.Add(4*time.Second))
+	assert.Equal(t, "snap-C", cb.Labels[constants.MasterAnnotationRuntimeSnapshotID])
+	assert.Equal(t, "snap-A", cb.Labels[constants.MasterAnnotationRuntimeRestoreSnapshotID],
+		"after rollback-then-commit, the restore-base label must still point at A "+
+			"(otherwise pagemap_anon's reflink source would point at the just-committed "+
+			"C, whose memory file does not match the VM's pre-commit memory state — "+
+			"feeding pagemap_anon a base that's already 'past' the bitmap)")
+
+	// And the resolveX helpers must each pick their own label, not cross-wire.
+	assert.Equal(t, "snap-C", resolveBaseSnapshotID(cb))
+	assert.Equal(t, "snap-A", resolveRestoreBaseSnapshotID(cb))
+}
+
+// TestSetRuntimeRestoreBaseLabelsEmptyIDIsNoop guards against accidentally
+// blanking the restore-base label by passing an empty snapshot id (e.g.
+// from a failed lookup). Treating empty as a no-op preserves whatever was
+// last successfully set.
+func TestSetRuntimeRestoreBaseLabelsEmptyIDIsNoop(t *testing.T) {
+	cb := &cubeboxstore.CubeBox{}
+	setRuntimeRestoreBaseLabels(cb, "snap-A", time.Now().UTC())
+	assert.Equal(t, "snap-A", cb.Labels[constants.MasterAnnotationRuntimeRestoreSnapshotID])
+
+	setRuntimeRestoreBaseLabels(cb, "", time.Now().UTC())
+	assert.Equal(t, "snap-A", cb.Labels[constants.MasterAnnotationRuntimeRestoreSnapshotID],
+		"empty snapshot id must be a no-op, not a clear")
+}
+
+// TestOpaqueRestoreInvalidatesIncrementalBases covers pause/resume. CubeShim's
+// pause/resume path restores the VM from an internal full snapshot under
+// /data/cubelet/root/pausevm/<sandbox>, not from a cubecow template/snapshot
+// object that Cubelet can later resolve. Both runtime base labels must be
+// invalidated so the next CommitSandbox re-anchors with a full snapshot instead
+// of incorrectly overlaying pagemap_anon pages onto an older catalog entry.
+func TestOpaqueRestoreInvalidatesIncrementalBases(t *testing.T) {
+	cb := &cubeboxstore.CubeBox{
+		Metadata: cubeboxstore.Metadata{
+			Annotations: map[string]string{
+				constants.MasterAnnotationAppSnapshotTemplateID: "tpl-T",
+			},
+		},
+	}
+	now := time.Now().UTC()
+	setRuntimeSnapshotBindingLabels(cb, "snap-B", now)
+	setRuntimeRestoreBaseLabels(cb, "snap-A", now)
+
+	invalidateRuntimeSnapshotBindingsAfterOpaqueRestore(cb, now.Add(time.Second))
+
+	assert.Equal(t, runtimeSnapshotBindingInvalidID, resolveBaseSnapshotID(cb))
+	assert.Equal(t, runtimeSnapshotBindingInvalidID, resolveRestoreBaseSnapshotID(cb))
+
+	// A successful full CommitSandbox after the opaque restore re-establishes
+	// the direct runtime base for future soft-dirty commits, but it must not
+	// pretend to be the VM's last restore source.
+	setRuntimeSnapshotBindingLabels(cb, "snap-full-after-resume", now.Add(2*time.Second))
+	assert.Equal(t, "snap-full-after-resume", resolveBaseSnapshotID(cb))
+	assert.Equal(t, runtimeSnapshotBindingInvalidID, resolveRestoreBaseSnapshotID(cb))
+}

--- a/Cubelet/services/cubebox/snapshot_base_memory_fallback_test.go
+++ b/Cubelet/services/cubebox/snapshot_base_memory_fallback_test.go
@@ -1,0 +1,105 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package cubebox
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/tencentcloud/CubeSandbox/Cubelet/pkg/constants"
+	cubeboxstore "github.com/tencentcloud/CubeSandbox/Cubelet/pkg/store/cubebox"
+)
+
+// TestErrNoBaseMemoryForIncrementalIsSentinel locks in that
+// resolveBaseMemoryObject's wrapped errors must remain detectable via
+// errors.Is. prepareCommitMemoryArtifact's fallback-to-full branch keys off
+// this exact sentinel, so a future refactor that accidentally drops the
+// %w wrapping would silently change the failure semantic from "produce a
+// larger but correct snapshot" back to "fail the user-facing commit".
+func TestErrNoBaseMemoryForIncrementalIsSentinel(t *testing.T) {
+	wrapped := fmt.Errorf("%w: catalog lookup for snap-x: not found", ErrNoBaseMemoryForIncremental)
+	assert.True(t, errors.Is(wrapped, ErrNoBaseMemoryForIncremental),
+		"resolveBaseMemoryObject's wrapped sentinel must satisfy errors.Is")
+
+	other := errors.New("some unrelated infrastructure failure")
+	assert.False(t, errors.Is(other, ErrNoBaseMemoryForIncremental),
+		"non-sentinel errors must not be misclassified as 'no base'")
+}
+
+// TestResolveBaseSnapshotIDFollowsCommitChain is the regression test for the
+// rollback scenario:
+//
+//	VM 从 T 启动 -> commit A -> commit B -> rollback to A -> commit C
+//
+// In the old code path CommitSandbox never updated cb.Labels, so
+// resolveBaseSnapshotID always returned T. That happened to be safe with
+// the cumulative pagemap_anon "incremental" snapshot type, but is *unsafe*
+// with the soft-dirty per-cycle delta: each commit's delta only covers
+// "writes since the previous clear_soft_dirty()", so picking the wrong
+// base silently drops bytes.
+//
+// This test verifies that as long as the success path stamps
+// MasterAnnotationRuntimeSnapshotID after every successful commit (and the
+// rollback path keeps doing the same, unchanged), resolveBaseSnapshotID
+// follows the full ancestor chain — and in particular collapses back to
+// the rolled-back-to snapshot after a rollback, which is the only base that
+// matches the post-rollback CH process's just-armed soft-dirty window.
+func TestResolveBaseSnapshotIDFollowsCommitChain(t *testing.T) {
+	cb := &cubeboxstore.CubeBox{
+		Metadata: cubeboxstore.Metadata{
+			Annotations: map[string]string{
+				constants.MasterAnnotationAppSnapshotTemplateID: "tpl-T",
+			},
+		},
+	}
+
+	// 1. Fresh start from template T: only the create-time template
+	//    annotation is present; resolve must fall back to it.
+	assert.Equal(t, "tpl-T", resolveBaseSnapshotID(cb), "initial: bound to template T")
+
+	// 2. CommitSandbox(target=A) success: stamp the new commit so that
+	//    the *next* commit knows to clone A as its base.
+	setRuntimeSnapshotBindingLabels(cb, "snap-A", time.Now().UTC())
+	assert.Equal(t, "snap-A", resolveBaseSnapshotID(cb), "after commit A: bound to A")
+
+	// 3. CommitSandbox(target=B) success.
+	setRuntimeSnapshotBindingLabels(cb, "snap-B", time.Now().UTC())
+	assert.Equal(t, "snap-B", resolveBaseSnapshotID(cb), "after commit B: bound to B")
+
+	// 4. RollbackSandbox(snapshot_id=A): rollback.go already stamps the
+	//    runtime-snapshot label to the rolled-back-to snapshot id, so we
+	//    just simulate the same setter call here.
+	setRuntimeSnapshotBindingLabels(cb, "snap-A", time.Now().UTC())
+	assert.Equal(t, "snap-A", resolveBaseSnapshotID(cb),
+		"after rollback to A: binding must collapse to A so next commit clones A as base")
+
+	// 5. CommitSandbox(target=C) success: this is the user-facing concern
+	//    — without the binding update on the prior commits, this step
+	//    would have inherited "tpl-T" from step 1.
+	setRuntimeSnapshotBindingLabels(cb, "snap-C", time.Now().UTC())
+	assert.Equal(t, "snap-C", resolveBaseSnapshotID(cb), "after commit C: bound to C")
+}
+
+// TestRuntimeBindingLabelOverridesCreateAnnotation guards the priority
+// order in resolveBaseSnapshotID: the runtime label written by every
+// successful commit / rollback must outrank the create-time annotations,
+// otherwise a fresh sandbox that gets committed once would still resolve
+// back to its original template on the next commit.
+func TestRuntimeBindingLabelOverridesCreateAnnotation(t *testing.T) {
+	cb := &cubeboxstore.CubeBox{
+		Metadata: cubeboxstore.Metadata{
+			Annotations: map[string]string{
+				constants.MasterAnnotationRuntimeSnapshotID:     "create-time-snap",
+				constants.MasterAnnotationAppSnapshotTemplateID: "tpl-T",
+			},
+		},
+	}
+	setRuntimeSnapshotBindingLabels(cb, "snap-after-commit", time.Now().UTC())
+	assert.Equal(t, "snap-after-commit", resolveBaseSnapshotID(cb),
+		"the per-commit Labels stamp must beat both create-time annotations")
+}

--- a/Cubelet/services/cubebox/snapshot_incremental_test.go
+++ b/Cubelet/services/cubebox/snapshot_incremental_test.go
@@ -26,6 +26,10 @@ func TestNormalizeSnapshotTypeAcceptsKnownValues(t *testing.T) {
 		{" Full ", snapshotTypeFull},
 		{"incremental", snapshotTypeIncremental},
 		{"INCREMENTAL", snapshotTypeIncremental},
+		{"soft-dirty", snapshotTypeSoftDirty},
+		{"Soft-Dirty", snapshotTypeSoftDirty},
+		{"SOFT-DIRTY", snapshotTypeSoftDirty},
+		{" soft-dirty ", snapshotTypeSoftDirty},
 		{"weird-value", snapshotTypeFull}, // unknown values must not silently break the CLI
 	}
 	for _, tc := range cases {
@@ -49,6 +53,22 @@ func TestBuildCubeRuntimeSnapshotArgsAlwaysIncludesSnapshotType(t *testing.T) {
 		idx := indexOf(args, "--snapshot-type")
 		require.GreaterOrEqual(t, idx, 0)
 		assert.Equal(t, snapshotTypeIncremental, args[idx+1])
+		assert.Contains(t, args, "--memory-vol")
+	})
+
+	t.Run("soft-dirty for CommitSandbox", func(t *testing.T) {
+		args := buildCubeRuntimeSnapshotArgs("sb-1", spec, "/tmp/s.tmp", "/dev/mapper/mem", snapshotTypeSoftDirty)
+		// Verbatim flag value -- the hypervisor's
+		// SnapshotType::FromStr must see exactly "soft-dirty",
+		// otherwise it falls back to incremental and the per-cycle
+		// delta optimization is lost.
+		assert.Contains(t, args, "--snapshot-type")
+		idx := indexOf(args, "--snapshot-type")
+		require.GreaterOrEqual(t, idx, 0)
+		assert.Equal(t, snapshotTypeSoftDirty, args[idx+1])
+		// memory-vol must still be present: the soft-dirty path
+		// requires a destination file holding the previous cycle's
+		// memory bytes (Cubelet reflink-clones it on the fast path).
 		assert.Contains(t, args, "--memory-vol")
 	})
 

--- a/Cubelet/services/cubebox/snapshot_runtime_binding.go
+++ b/Cubelet/services/cubebox/snapshot_runtime_binding.go
@@ -11,6 +11,8 @@ import (
 	cubeboxstore "github.com/tencentcloud/CubeSandbox/Cubelet/pkg/store/cubebox"
 )
 
+const runtimeSnapshotBindingInvalidID = "invalid-runtime-restore-base"
+
 // runtimeSnapshotBindingLabels returns the labels that bind a sandbox to a
 // snapshot. v4: only the logical snapshot id (and attach timestamp) are
 // recorded on the sandbox metadata. Physical memory volume / dev names are
@@ -36,6 +38,62 @@ func setRuntimeSnapshotBindingLabels(cb *cubeboxstore.CubeBox, snapshotID string
 	labels := runtimeSnapshotBindingLabels(snapshotID, attachedAt)
 	if len(labels) == 0 {
 		return
+	}
+	cb.Metadata.AddLabels(labels)
+}
+
+// runtimeRestoreBaseLabels records which snapshot's memory image the VM was
+// last restored from. Unlike runtimeSnapshotBindingLabels, this binding is
+// updated only at restore boundaries — Create's restore-from-snapshot path
+// and Rollback — and is intentionally NOT touched by Commit. This is what
+// makes the binding usable as a base for the pagemap_anon (incremental)
+// snapshot path: pagemap_anon's dirty set is "anon pages currently dirty",
+// i.e. everything written to since the *last restore*. The base file used
+// for the FICLONE in that fallback path must therefore contain the VM's
+// memory state at last restore, which is exactly the snapshot id stamped
+// here.
+func runtimeRestoreBaseLabels(snapshotID string, attachedAt time.Time) map[string]string {
+	if snapshotID == "" {
+		return nil
+	}
+	labels := map[string]string{
+		constants.MasterAnnotationRuntimeRestoreSnapshotID: snapshotID,
+	}
+	if !attachedAt.IsZero() {
+		labels[constants.MasterAnnotationRuntimeRestoreSnapshotAttachedAt] = attachedAt.UTC().Format(time.RFC3339Nano)
+	}
+	return labels
+}
+
+func setRuntimeRestoreBaseLabels(cb *cubeboxstore.CubeBox, snapshotID string, attachedAt time.Time) {
+	if cb == nil {
+		return
+	}
+	labels := runtimeRestoreBaseLabels(snapshotID, attachedAt)
+	if len(labels) == 0 {
+		return
+	}
+	cb.Metadata.AddLabels(labels)
+}
+
+// invalidateRuntimeSnapshotBindingsAfterOpaqueRestore marks both runtime
+// memory bases as unusable after the VM has been restored from a source that
+// Cubelet cannot later reflink from (for example CubeShim's pause/resume path,
+// which restores from /data/cubelet/root/pausevm/<sandbox> with no cubecow
+// memory_vol_url). The next CommitSandbox must therefore produce a full
+// snapshot unless it first establishes a new runtime snapshot binding.
+func invalidateRuntimeSnapshotBindingsAfterOpaqueRestore(cb *cubeboxstore.CubeBox, attachedAt time.Time) {
+	if cb == nil {
+		return
+	}
+	labels := map[string]string{
+		constants.MasterAnnotationRuntimeSnapshotID:        runtimeSnapshotBindingInvalidID,
+		constants.MasterAnnotationRuntimeRestoreSnapshotID: runtimeSnapshotBindingInvalidID,
+	}
+	if !attachedAt.IsZero() {
+		ts := attachedAt.UTC().Format(time.RFC3339Nano)
+		labels[constants.MasterAnnotationRuntimeSnapshotAttachedAt] = ts
+		labels[constants.MasterAnnotationRuntimeRestoreSnapshotAttachedAt] = ts
 	}
 	cb.Metadata.AddLabels(labels)
 }

--- a/Cubelet/services/cubebox/template_ops.go
+++ b/Cubelet/services/cubebox/template_ops.go
@@ -13,6 +13,7 @@ import (
 	"path/filepath"
 	"runtime/debug"
 	"strings"
+	"time"
 
 	"github.com/tencentcloud/CubeSandbox/Cubelet/api/services/cubebox/v1"
 	"github.com/tencentcloud/CubeSandbox/Cubelet/api/services/errorcode/v1"
@@ -130,17 +131,6 @@ func (s *service) CommitSandbox(ctx context.Context, req *cubebox.CommitSandboxR
 	}
 	memorySizeBytes := snapshotMemorySizeBytes(resourceSpec.Memory)
 
-	// Resolve the base memory object FIRST: this is the source we will
-	// reflink-clone for the incremental memory snapshot. We do it before
-	// committing the rootfs so that a missing/broken catalog state fails
-	// fast without producing partial cubecow garbage.
-	baseMemoryObject, err := resolveBaseMemoryObject(ctx, cb)
-	if err != nil {
-		rsp.Ret.RetCode = errorcode.ErrorCode_PreConditionFailed
-		rsp.Ret.RetMsg = fmt.Sprintf("failed to resolve base memory for incremental snapshot: %v", err)
-		return rsp, nil
-	}
-
 	sourceRootfs, err := storage.GetSandboxRootfsForSnapshot(ctx, rsp.SandboxID, rootVolumeName)
 	if err != nil {
 		rsp.Ret.RetCode = errorcode.ErrorCode_PreConditionFailed
@@ -158,14 +148,17 @@ func (s *service) CommitSandbox(ctx context.Context, req *cubebox.CommitSandboxR
 		rsp.Ret.RetMsg = fmt.Sprintf("failed to create rootfs snapshot: %v", err)
 		return rsp, nil
 	}
-	// Reflink-clone the base memory blob into the new template memory name.
-	// The resulting cubecow snapshot starts out byte-for-byte identical to
-	// the base, satisfying the hypervisor's incremental snapshot precondition
-	// of "destination memory file already exists with a valid base image".
-	memoryObject, err := storage.CommitTemplateMemoryFromBase(ctx, baseMemoryObject, rsp.TemplateID, memorySizeBytes)
+	// Resolve / build the memory artifact:
+	//   - if the sandbox is bound to a previous snapshot whose memory blob
+	//     can be resolved, reflink-clone that blob and ask cube-runtime for
+	//     a soft-dirty per-cycle delta;
+	//   - otherwise (lineage broken: missing/purged catalog or upstream
+	//     volume gone) create a fresh empty volume and fall back to a full
+	//     snapshot.
+	memoryObject, snapshotTypeForCmd, err := prepareCommitMemoryArtifact(ctx, stepLog, cb, rsp.TemplateID, memorySizeBytes)
 	if err != nil {
 		if cleanupErr := storage.DeleteCowObject(ctx, rootfsObject.Name, rootfsObject.Kind); cleanupErr != nil {
-			stepLog.Warnf("failed to cleanup rootfs snapshot after memory clone failure: %v", cleanupErr)
+			stepLog.Warnf("failed to cleanup rootfs snapshot after memory artifact failure: %v", cleanupErr)
 		}
 		if errors.Is(err, storage.ErrCowObjectAlreadyExists) {
 			rsp.Ret.RetCode = errorcode.ErrorCode_PreConditionFailed
@@ -173,7 +166,7 @@ func (s *service) CommitSandbox(ctx context.Context, req *cubebox.CommitSandboxR
 			return rsp, nil
 		}
 		rsp.Ret.RetCode = errorcode.ErrorCode_Unknown
-		rsp.Ret.RetMsg = fmt.Sprintf("failed to clone base memory for incremental snapshot: %v", err)
+		rsp.Ret.RetMsg = fmt.Sprintf("failed to prepare memory artifact for snapshot: %v", err)
 		return rsp, nil
 	}
 	if err := validateSnapshotMemoryObject(memoryObject, memorySizeBytes); err != nil {
@@ -188,17 +181,31 @@ func (s *service) CommitSandbox(ctx context.Context, req *cubebox.CommitSandboxR
 	}
 
 	_ = os.RemoveAll(tmpSnapshotPath) // NOCC:Path Traversal()
-	// CommitSandbox snapshots a running sandbox whose memory blob has just
-	// been reflink-cloned above; with a valid base present, cube-runtime can
-	// overlay only the CoW anon pages and skip writing the (much larger)
-	// non-anonymous regions. AppSnapshot keeps using the default full type.
-	if err := s.executeCubeRuntimeSnapshot(ctx, rsp.SandboxID, spec, tmpSnapshotPath, memoryObject.DevPath, snapshotTypeIncremental); err != nil {
+	// CommitSandbox snapshots a running sandbox whose memory artifact has
+	// just been prepared above. snapshotTypeForCmd carries the right type
+	// for the path we took: soft-dirty when reflink-cloning a base, or full
+	// when degrading because no base could be resolved. AppSnapshot keeps
+	// using the default full type via its own call site.
+	stepLog = stepLog.WithFields(CubeLog.Fields{"snapshotType": snapshotTypeForCmd})
+	if err := s.executeCubeRuntimeSnapshot(ctx, rsp.SandboxID, spec, tmpSnapshotPath, memoryObject.DevPath, snapshotTypeForCmd); err != nil {
 		_ = os.RemoveAll(tmpSnapshotPath) // NOCC:Path Traversal()
 		cleanupArtifacts()
 		rsp.Ret.RetCode = errorcode.ErrorCode_Unknown
 		rsp.Ret.RetMsg = fmt.Sprintf("failed to execute cube-runtime snapshot: %v", err)
 		return rsp, nil
 	}
+	// cube-runtime returned success, which means the hypervisor has
+	// committed the delta to the memory file *and*, on the soft-dirty path,
+	// already issued clear_soft_dirty() to start the next tracking window.
+	// From this point on, the next CommitSandbox on the same VM must use
+	// rsp.TemplateID as its base (anything older would lose the bytes the
+	// guest just wrote into this snapshot). We stamp the in-memory binding
+	// immediately so a follow-up commit picks it up; SyncByID at the end of
+	// the success path persists it (mirroring the rollback flow). If a
+	// later step fails and cleanupArtifacts deletes memoryObject, the stale
+	// binding routes the next commit through the fallback-to-full branch
+	// in prepareCommitMemoryArtifact, which is self-contained and safe.
+	setRuntimeSnapshotBindingLabels(cb, rsp.TemplateID, time.Now().UTC())
 	if err := writeMemoryDevFile(tmpSnapshotPath, memoryObject.DevPath); err != nil {
 		_ = os.RemoveAll(tmpSnapshotPath) // NOCC:Path Traversal()
 		cleanupArtifacts()
@@ -253,6 +260,12 @@ func (s *service) CommitSandbox(ctx context.Context, req *cubebox.CommitSandboxR
 		// drift between master and cubelet local view.
 		stepLog.Warnf("failed to persist snapshot catalog for %s: %v", rsp.TemplateID, err)
 	}
+	// Persist the runtime-snapshot binding update we did in-memory after
+	// cube-runtime returned. Mirrors the rollback flow's SyncByID call so
+	// that a process restart recovers the new commit lineage and so any
+	// downstream component reading the cubebox metadata sees the same
+	// ancestor as resolveBaseSnapshotID will return on the next commit.
+	s.cubeboxMgr.cubeboxManger.SyncByID(ctx, cb.ID)
 	stepLog.Infof("CommitSandbox completed successfully: snapshotPath=%s", snapshotPath)
 	return rsp, nil
 }

--- a/Cubelet/services/cubebox/update.go
+++ b/Cubelet/services/cubebox/update.go
@@ -222,6 +222,13 @@ func (s *service) UpdateWithResume(ctx context.Context, req *cubebox.UpdateCubeS
 		rsp.Ret.RetCode = errorcode.ErrorCode_TaskResumeFailed
 		return rsp, nil
 	}
+	// CubeShim resumes paused VMs from an internal full snapshot under
+	// /data/cubelet/root/pausevm/<sandbox> and does not expose that memory file
+	// as a cubecow catalog entry. Any runtime/restore-base labels that still
+	// point to older template/snapshot memory files are now stale for
+	// pagemap_anon/soft-dirty purposes, so force the next commit to re-anchor
+	// with a full snapshot.
+	invalidateRuntimeSnapshotBindingsAfterOpaqueRestore(sb, time.Now().UTC())
 	for _, c := range sb.AllContainers() {
 		if c.Status != nil {
 			c.Status.Update(func(status cubeboxstore.Status) (cubeboxstore.Status, error) {

--- a/hypervisor/docs/snapshot_restore.md
+++ b/hypervisor/docs/snapshot_restore.md
@@ -96,3 +96,29 @@ snapshot earlier.
 ## Limitations
 
 VFIO devices and Intel SGX are out of scope.
+
+## Snapshot types
+
+The `--snapshot-type` flag of the `snapshot` and `pause2snapshot` ch-remote
+subcommands selects how guest RAM is captured. The other snapshot artifacts
+(`config.json`, `state.json`) are unaffected.
+
+| Type | What gets saved to `memory-ranges` | When to use |
+|------|------------------------------------|-------------|
+| `full` | Every byte of guest RAM. | First snapshot after VM start, or any time you need a self-contained image. |
+| `incremental` | Only **CoW anonymous** pages (pages the guest has written to since the original `MAP_PRIVATE` mmap was set up). Detected via `/proc/self/pagemap` + `/proc/kpageflags`. | Cheap "second" snapshot when a base file already exists. The set of saved pages monotonically grows over the VM's lifetime — every page ever touched is in the delta. |
+| `soft-dirty` | Only the pages written **since the previous `soft-dirty` snapshot** (a true delta). Detected via `/proc/self/clear_refs` + pagemap bit 55. | Repeated incremental snapshots on a long-running VM, where most pages are not touched between cycles. |
+
+### Soft-dirty details
+
+- The first `soft-dirty` snapshot taken after VM start writes a full base
+  image and arms the kernel tracker.
+- Each subsequent `soft-dirty` snapshot writes only the pages whose PTE has
+  been marked soft-dirty since the previous call, then re-arms the tracker.
+- Requires the host kernel to be built with `CONFIG_MEM_SOFT_DIRTY=y`. On
+  kernels without this support, `soft-dirty` requests are silently downgraded
+  to the `incremental` (pagemap_anon) path and a debug log is emitted.
+- A runtime failure of the `clear_refs` write (e.g. seccomp blocking it)
+  also degrades subsequent snapshots to `incremental` for the rest of the
+  VM's lifetime, with a warning log.
+

--- a/hypervisor/src/bin/ch-remote.rs
+++ b/hypervisor/src/bin/ch-remote.rs
@@ -692,7 +692,7 @@ fn main() {
                 .arg(
                     Arg::new("snapshot_type")
                         .long("snapshot-type")
-                        .help("Snapshot type: 'full' or 'incremental' (saves only CoW anonymous pages)")
+                        .help("Snapshot type: 'full', 'incremental' (saves only CoW anonymous pages) or 'soft-dirty' (true delta of pages written since the previous soft-dirty snapshot; falls back to 'incremental' on kernels without CONFIG_MEM_SOFT_DIRTY)")
                         .num_args(1)
                         .default_value("incremental"),
                 )
@@ -723,7 +723,7 @@ fn main() {
                 .arg(
                     Arg::new("snapshot_type")
                         .long("snapshot-type")
-                        .help("Snapshot type: 'full' or 'incremental' (saves only CoW anonymous pages)")
+                        .help("Snapshot type: 'full', 'incremental' (saves only CoW anonymous pages) or 'soft-dirty' (true delta of pages written since the previous soft-dirty snapshot; falls back to 'incremental' on kernels without CONFIG_MEM_SOFT_DIRTY)")
                         .num_args(1)
                         .default_value("incremental"),
                 )

--- a/hypervisor/vm-migration/src/lib.rs
+++ b/hypervisor/vm-migration/src/lib.rs
@@ -113,6 +113,13 @@ pub enum SnapshotType {
     Full,
     /// Incremental snapshot - only saves CoW anonymous pages via pagemap + kpageflags
     Incremental,
+    /// Soft-dirty snapshot - only saves pages written since the previous
+    /// soft-dirty snapshot (true delta), via /proc/self/clear_refs +
+    /// /proc/self/pagemap bit 55. Requires CONFIG_MEM_SOFT_DIRTY=y; on
+    /// kernels without this support the runtime silently falls back to the
+    /// `Incremental` (pagemap_anon) path.
+    #[serde(rename = "soft-dirty")]
+    SoftDirty,
 }
 
 impl std::fmt::Display for SnapshotType {
@@ -120,6 +127,7 @@ impl std::fmt::Display for SnapshotType {
         match self {
             SnapshotType::Full => write!(f, "full"),
             SnapshotType::Incremental => write!(f, "incremental"),
+            SnapshotType::SoftDirty => write!(f, "soft-dirty"),
         }
     }
 }
@@ -131,8 +139,9 @@ impl std::str::FromStr for SnapshotType {
         match s.to_lowercase().as_str() {
             "full" => Ok(SnapshotType::Full),
             "incremental" => Ok(SnapshotType::Incremental),
+            "soft-dirty" => Ok(SnapshotType::SoftDirty),
             _ => Err(format!(
-                "Invalid snapshot type: '{}'. Valid values are 'full' or 'incremental'",
+                "Invalid snapshot type: '{}'. Valid values are 'full', 'incremental' or 'soft-dirty'",
                 s
             )),
         }

--- a/hypervisor/vmm/src/lib.rs
+++ b/hypervisor/vmm/src/lib.rs
@@ -82,6 +82,7 @@ pub mod migration;
 pub mod pagemap_anon;
 mod pci_segment;
 pub mod seccomp_filters;
+pub mod soft_dirty;
 mod serial_manager;
 mod sigwinch_listener;
 pub mod vm;

--- a/hypervisor/vmm/src/lib.rs
+++ b/hypervisor/vmm/src/lib.rs
@@ -82,9 +82,9 @@ pub mod migration;
 pub mod pagemap_anon;
 mod pci_segment;
 pub mod seccomp_filters;
-pub mod soft_dirty;
 mod serial_manager;
 mod sigwinch_listener;
+pub mod soft_dirty;
 pub mod vm;
 pub mod vm_config;
 

--- a/hypervisor/vmm/src/memory_manager.rs
+++ b/hypervisor/vmm/src/memory_manager.rs
@@ -9,7 +9,7 @@ use crate::coredump::{
 use crate::migration::{memory_blob_to_path, url_to_path};
 use crate::pagemap_anon::filter_memory_ranges_by_pagemap_anon;
 use crate::soft_dirty::{
-    clear_soft_dirty, filter_memory_ranges_by_soft_dirty, probe_soft_dirty_support,
+    clear_soft_dirty, filter_memory_ranges_by_anon_and_soft_dirty, probe_soft_dirty_support,
 };
 #[cfg(target_arch = "x86_64")]
 use crate::vm_config::SgxEpcConfig;
@@ -294,14 +294,11 @@ pub struct MemoryManager {
     sgx_epc_region: Option<SgxEpcRegion>,
     user_provided_zones: bool,
     snapshot_memory_ranges: MemoryRangeTable,
-    /// Whether the running kernel supports the soft-dirty mechanism
-    /// (`/proc/self/clear_refs` write "4" + pagemap bit 55). Probed once
-    /// at construction time, and the probe call itself doubles as the
-    /// initial `clear_soft_dirty()` that arms tracking. May be flipped to
-    /// `false` at runtime if a `clear_soft_dirty()` call unexpectedly
-    /// fails, in which case subsequent snapshots fall back to the
-    /// pagemap_anon path.
-    soft_dirty_kernel_supported: AtomicBool,
+    /// Whether the soft-dirty tracker is currently armed (i.e. the previous
+    /// snapshot cycle ended with a successful `clear_soft_dirty()`, so the
+    /// pagemap bit-55 set this cycle reflects only writes that happened
+    /// since then).
+    soft_dirty_armed: AtomicBool,
     memory_zones: MemoryZones,
     log_dirty: bool, // Enable dirty logging for created RAM regions
     arch_mem_regions: Vec<ArchMemRegion>,
@@ -1276,16 +1273,7 @@ impl MemoryManager {
             sgx_epc_region: None,
             user_provided_zones,
             snapshot_memory_ranges: MemoryRangeTable::default(),
-            // `probe_soft_dirty_support()` writes "4" to
-            // `/proc/self/clear_refs`, which both probes kernel support
-            // and clears every PTE's soft-dirty bit. We treat that
-            // clearing as the arm-zero of the tracking window: every
-            // host-side write that follows (BIOS / kernel image load,
-            // ACPI tables, etc.) and every guest vCPU store will set
-            // bit 55 in `/proc/self/pagemap`, so the very first
-            // soft-dirty snapshot can already go through the
-            // incremental path with an empty (sparse) base.
-            soft_dirty_kernel_supported: AtomicBool::new(probe_soft_dirty_support()),
+            soft_dirty_armed: AtomicBool::new(false),
             memory_zones,
             guest_ram_mappings: Vec::new(),
             acpi_address,
@@ -1365,32 +1353,6 @@ impl MemoryManager {
                     .fill_saved_regions(memory_file_target.path, mem_snapshot.memory_ranges)?;
             }
 
-            // Re-arm soft-dirty tracking after restore. `fill_saved_regions`
-            // performs host-side writes into guest memory which set bit 55 on
-            // every restored page; without a clear here, the first post-restore
-            // soft-dirty snapshot would treat the entire RAM as dirty. The
-            // fast_restore path uses shared mmap and does not write through
-            // the host side, but clearing is idempotent so we do it
-            // unconditionally for simplicity.
-            if mm
-                .lock()
-                .unwrap()
-                .soft_dirty_kernel_supported
-                .load(Ordering::Acquire)
-            {
-                if let Err(e) = clear_soft_dirty() {
-                    warn!(
-                        "Soft-dirty: clear_soft_dirty() failed after restore ({}), \
-                         disabling soft-dirty tracking; subsequent snapshots will \
-                         fall back to pagemap_anon",
-                        e
-                    );
-                    mm.lock()
-                        .unwrap()
-                        .soft_dirty_kernel_supported
-                        .store(false, Ordering::Release);
-                }
-            }
 
             Ok(mm)
         } else {
@@ -2413,39 +2375,42 @@ impl MemoryManager {
 
     /// Save a soft-dirty incremental snapshot.
     ///
-    /// This method writes a delta snapshot containing only pages that have
-    /// been written **since the previous `clear_soft_dirty()`**. The delta
-    /// is detected via `/proc/self/pagemap` bit 55, which is armed/cleared
-    /// by writing `4` to `/proc/self/clear_refs`.
+    /// This method writes a delta snapshot containing only the pages that
+    /// must change in the destination snapshot file. We compute that set as
+    /// the **intersection** of:
+    ///   * pagemap_anon (Copy-on-Written pages — only these can ever differ
+    ///     from the base snapshot file the guest was restored from), and
+    ///   * `/proc/self/pagemap` bit 55 (pages written since the previous
+    ///     `clear_soft_dirty()`).
     ///
     /// To remain compatible with the rest of the VMM (snapshot consumers
     /// expect a self-contained, full-size memory image at the destination),
     /// the resulting file is **not** a raw delta. We prepare a base image
-    /// at the destination and then overwrite only the soft-dirty pages on
-    /// top. The base is either:
-    ///   - the existing snapshot file (when `path.exists()`), reused
-    ///     in place — every still-clean page from the previous cycle is
-    ///     already correct on disk; or
-    ///   - a fresh sparse file of the full RAM size (when the path does
-    ///     not yet exist) — typical for the very first snapshot of a
-    ///     brand-new VM. Pages that were never written remain as file
-    ///     holes and read back as zero on restore, which matches the
-    ///     initial state of `MAP_ANONYMOUS` guest memory; the soft-dirty
-    ///     filter already includes every page touched since boot (BIOS /
-    ///     kernel image load, ACPI tables, vCPU stores), so the
-    ///     resulting snapshot is self-contained.
+    /// at the destination and then overwrite only the filtered pages on
+    /// top.
     ///
-    /// Tracking is armed at `MemoryManager::new()` (the
-    /// `probe_soft_dirty_support()` call clears all bits as a side
-    /// effect) and re-armed at `new_from_snapshot()` (after
-    /// `fill_saved_regions`), so this function does **not** need a
-    /// dedicated "first cycle writes the full base" branch.
+    /// Lazy probe / arm:
+    /// Soft-dirty tracking is **not** probed nor armed at boot or restore
+    /// time anymore — `clear_refs(4)` walks every PTE under mmap_lock and
+    /// is the dominant pause-time cost on multi-GiB guests. Instead, the
+    /// very first call to this method:
+    ///   1. Tries `probe_soft_dirty_support()` (which itself performs the
+    ///      initial `clear_soft_dirty()` and arms tracking on success).
+    ///   2. Writes a snapshot using the pagemap_anon set (every CoW page),
+    ///      because there is no prior soft-dirty window to take an
+    ///      intersection against.
+    ///   3. Sets `soft_dirty_armed = true` only on probe success.
     ///
-    /// Degradation: if the kernel does not support soft-dirty (probed at
-    /// construction time and re-checked here), or if `clear_soft_dirty()`
-    /// fails at runtime, the call silently falls back to the pagemap_anon
-    /// (Incremental) path. The fallback is logged but not surfaced as an
-    /// error to the caller.
+    /// Subsequent calls (with `soft_dirty_armed == true`) take the
+    /// anon ∩ soft-dirty intersection, write only the changed CoW pages,
+    /// and re-arm via `clear_soft_dirty()` for the next cycle.
+    ///
+    /// Degradation: if `probe_soft_dirty_support()` returns false (kernel
+    /// without `CONFIG_MEM_SOFT_DIRTY=y`), or any `clear_soft_dirty()`
+    /// call fails at runtime, this method silently falls back to the
+    /// pagemap_anon path and leaves `soft_dirty_armed` at false so the
+    /// next cycle retries. The fallback is logged but not surfaced as
+    /// an error to the caller.
     fn send_soft_dirty_memory(
         &self,
         destination_url: &str,
@@ -2455,33 +2420,59 @@ impl MemoryManager {
             return Ok(());
         }
 
-        // Degrade to pagemap_anon if the kernel doesn't support soft-dirty.
-        if !self.soft_dirty_kernel_supported.load(Ordering::Acquire) {
-            debug!(
-                "Soft-dirty not supported by kernel, falling back to pagemap_anon snapshot"
+        // First-time path (or any time we are not currently armed): we
+        // cannot trust the soft-dirty bitmap because there is no prior
+        // `clear_soft_dirty()` to anchor the window, so write the full
+        // anon-page set. Then try to arm tracking for the next cycle.
+        if !self.soft_dirty_armed.load(Ordering::Acquire) {
+            info!(
+                "Soft-dirty: tracker not yet armed, writing full anon-page snapshot \
+                 and attempting to arm soft-dirty for the next cycle"
             );
-            return self.send_pagemap_anon_memory(destination_url, memory_vol_url);
+
+            // Write a full anon-page (pagemap_anon) snapshot. This already
+            // matches what `send_pagemap_anon_memory` does and it produces
+            // a self-contained snapshot file.
+            self.send_pagemap_anon_memory(destination_url, memory_vol_url)?;
+
+            // Probe + arm. `probe_soft_dirty_support()` writes "4" to
+            // /proc/self/clear_refs, which both detects kernel support
+            // (returns false on EINVAL when CONFIG_MEM_SOFT_DIRTY=n) and,
+            // on success, clears every PTE's bit 55 — which is exactly
+            // the "arm" operation for the next snapshot window.
+            if probe_soft_dirty_support() {
+                self.soft_dirty_armed.store(true, Ordering::Release);
+                info!("Soft-dirty: tracker armed for next snapshot cycle");
+            } else {
+                debug!(
+                    "Soft-dirty: kernel does not support CONFIG_MEM_SOFT_DIRTY, \
+                     subsequent snapshots will keep using the anon-page path"
+                );
+            }
+
+            return Ok(());
         }
 
+        // Steady-state path: the tracker has been armed by a previous
+        // call, so pagemap bit 55 reflects only writes that happened in
+        // this window. Filter pages by anon ∩ soft-dirty to get the
+        // minimal set that has actually changed since the last snapshot.
         let memory_file_target =
             MemorySnapshotFile::from_snapshot_url(destination_url, memory_vol_url.as_deref())?;
 
-        // Filter by pagemap bit 55 to find pages written since the last
-        // `clear_soft_dirty()` (which was performed either by the probe at
-        // construction time, by the previous snapshot cycle, or by
-        // `new_from_snapshot()` after `fill_saved_regions`).
         let guest_memory = self.guest_memory.memory();
         let (filtered_ranges, stats) =
-            filter_memory_ranges_by_soft_dirty(&guest_memory, &self.snapshot_memory_ranges)
+            filter_memory_ranges_by_anon_and_soft_dirty(&guest_memory, &self.snapshot_memory_ranges)
                 .map_err(|e| {
                     MigratableError::MigrateSend(anyhow!(
-                        "Failed to filter memory with soft-dirty: {}",
+                        "Failed to filter memory with anon ∩ soft-dirty: {}",
                         e
                     ))
                 })?;
 
         info!(
-            "Soft-dirty snapshot: total={} bytes ({} pages), dirty={} bytes ({} pages), savings={:.1}%",
+            "Soft-dirty snapshot (anon ∩ soft-dirty): total={} bytes ({} pages), \
+             dirty={} bytes ({} pages), savings={:.1}%",
             stats.total_bytes,
             stats.total_pages,
             stats.saved_bytes,
@@ -2489,28 +2480,20 @@ impl MemoryManager {
             stats.savings_percentage()
         );
 
-        // Prepare the destination file. If it already exists, reuse it
-        // in place (steady-state cycle: the previous snapshot already
-        // contains every still-clean page). Otherwise create a fresh
-        // sparse file sized to the full RAM (first cycle after a
-        // brand-new VM boot).
-        let memory_file = if memory_file_target.path().exists() {
-            memory_file_target.open_read_write()?
-        } else {
-            info!(
-                "Soft-dirty snapshot: no previous base at {:?}, writing {} dirty bytes \
-                 onto a fresh sparse file",
-                memory_file_target.path(),
-                stats.saved_bytes
-            );
-            let f = memory_file_target.open_for_fresh_write()?;
-            if !memory_file_target.is_external() {
-                let total_size = guest_memory.iter().map(|region| region.len()).sum::<u64>();
-                f.set_len(total_size)
-                    .map_err(|e| MigratableError::MigrateSend(e.into()))?;
-            }
-            f
-        };
+        // Prepare the destination file. The previous snapshot already
+        // contains every still-clean page; we just overlay the changed
+        // ones in place. The base file is mandatory here: if it doesn't
+        // exist, a soft-dirty (delta) snapshot is meaningless because
+        // there is no full image to overlay onto. Refuse the request and
+        // let the caller take a Full snapshot first.
+        if !memory_file_target.path().exists() {
+            return Err(MigratableError::MigrateSend(anyhow!(
+                "Base snapshot file not found at {:?}, soft-dirty snapshot requires \
+                 an existing base file; take a full snapshot first",
+                memory_file_target.path()
+            )));
+        }
+        let memory_file = memory_file_target.open_read_write()?;
 
         // Build a GPA-to-file-offset mapping for calculating offsets.
         let mut gpa_to_file_offset: Vec<(u64, u64, u64)> = Vec::new();
@@ -2520,7 +2503,7 @@ impl MemoryManager {
             offset += range.length;
         }
 
-        // Write only soft-dirty pages onto the prepared base file.
+        // Overlay only the filtered (anon ∩ soft-dirty) pages.
         for range in filtered_ranges.regions() {
             let file_off =
                 Self::calculate_file_offset_for_gpa(range.gpa, range.length, &gpa_to_file_offset)?;
@@ -2541,11 +2524,11 @@ impl MemoryManager {
         if let Err(e) = clear_soft_dirty() {
             warn!(
                 "Soft-dirty: clear_soft_dirty() failed after writing delta ({}), \
-                 disabling soft-dirty tracking; subsequent snapshots will use pagemap_anon",
+                 disarming; the next snapshot will fall back to the full \
+                 anon-page path and try to re-arm",
                 e
             );
-            self.soft_dirty_kernel_supported
-                .store(false, Ordering::Release);
+            self.soft_dirty_armed.store(false, Ordering::Release);
         }
 
         Ok(())

--- a/hypervisor/vmm/src/memory_manager.rs
+++ b/hypervisor/vmm/src/memory_manager.rs
@@ -1353,7 +1353,6 @@ impl MemoryManager {
                     .fill_saved_regions(memory_file_target.path, mem_snapshot.memory_ranges)?;
             }
 
-
             Ok(mm)
         } else {
             Err(Error::RestoreMissingSourceUrl)
@@ -2461,14 +2460,16 @@ impl MemoryManager {
             MemorySnapshotFile::from_snapshot_url(destination_url, memory_vol_url.as_deref())?;
 
         let guest_memory = self.guest_memory.memory();
-        let (filtered_ranges, stats) =
-            filter_memory_ranges_by_anon_and_soft_dirty(&guest_memory, &self.snapshot_memory_ranges)
-                .map_err(|e| {
-                    MigratableError::MigrateSend(anyhow!(
-                        "Failed to filter memory with anon ∩ soft-dirty: {}",
-                        e
-                    ))
-                })?;
+        let (filtered_ranges, stats) = filter_memory_ranges_by_anon_and_soft_dirty(
+            &guest_memory,
+            &self.snapshot_memory_ranges,
+        )
+        .map_err(|e| {
+            MigratableError::MigrateSend(anyhow!(
+                "Failed to filter memory with anon ∩ soft-dirty: {}",
+                e
+            ))
+        })?;
 
         info!(
             "Soft-dirty snapshot (anon ∩ soft-dirty): total={} bytes ({} pages), \

--- a/hypervisor/vmm/src/memory_manager.rs
+++ b/hypervisor/vmm/src/memory_manager.rs
@@ -8,6 +8,9 @@ use crate::coredump::{
 };
 use crate::migration::{memory_blob_to_path, url_to_path};
 use crate::pagemap_anon::filter_memory_ranges_by_pagemap_anon;
+use crate::soft_dirty::{
+    clear_soft_dirty, filter_memory_ranges_by_soft_dirty, probe_soft_dirty_support,
+};
 #[cfg(target_arch = "x86_64")]
 use crate::vm_config::SgxEpcConfig;
 use crate::vm_config::{HotplugMethod, MemoryConfig, MemoryZoneConfig};
@@ -37,6 +40,7 @@ use std::os::fd::AsFd;
 use std::os::unix::io::{AsRawFd, FromRawFd, RawFd};
 use std::path::{Path, PathBuf};
 use std::result;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Barrier, Mutex};
 use tracer::trace_scoped;
 use virtio_devices::BlocksState;
@@ -290,6 +294,14 @@ pub struct MemoryManager {
     sgx_epc_region: Option<SgxEpcRegion>,
     user_provided_zones: bool,
     snapshot_memory_ranges: MemoryRangeTable,
+    /// Whether the running kernel supports the soft-dirty mechanism
+    /// (`/proc/self/clear_refs` write "4" + pagemap bit 55). Probed once
+    /// at construction time, and the probe call itself doubles as the
+    /// initial `clear_soft_dirty()` that arms tracking. May be flipped to
+    /// `false` at runtime if a `clear_soft_dirty()` call unexpectedly
+    /// fails, in which case subsequent snapshots fall back to the
+    /// pagemap_anon path.
+    soft_dirty_kernel_supported: AtomicBool,
     memory_zones: MemoryZones,
     log_dirty: bool, // Enable dirty logging for created RAM regions
     arch_mem_regions: Vec<ArchMemRegion>,
@@ -1264,6 +1276,16 @@ impl MemoryManager {
             sgx_epc_region: None,
             user_provided_zones,
             snapshot_memory_ranges: MemoryRangeTable::default(),
+            // `probe_soft_dirty_support()` writes "4" to
+            // `/proc/self/clear_refs`, which both probes kernel support
+            // and clears every PTE's soft-dirty bit. We treat that
+            // clearing as the arm-zero of the tracking window: every
+            // host-side write that follows (BIOS / kernel image load,
+            // ACPI tables, etc.) and every guest vCPU store will set
+            // bit 55 in `/proc/self/pagemap`, so the very first
+            // soft-dirty snapshot can already go through the
+            // incremental path with an empty (sparse) base.
+            soft_dirty_kernel_supported: AtomicBool::new(probe_soft_dirty_support()),
             memory_zones,
             guest_ram_mappings: Vec::new(),
             acpi_address,
@@ -1341,6 +1363,33 @@ impl MemoryManager {
                 mm.lock()
                     .unwrap()
                     .fill_saved_regions(memory_file_target.path, mem_snapshot.memory_ranges)?;
+            }
+
+            // Re-arm soft-dirty tracking after restore. `fill_saved_regions`
+            // performs host-side writes into guest memory which set bit 55 on
+            // every restored page; without a clear here, the first post-restore
+            // soft-dirty snapshot would treat the entire RAM as dirty. The
+            // fast_restore path uses shared mmap and does not write through
+            // the host side, but clearing is idempotent so we do it
+            // unconditionally for simplicity.
+            if mm
+                .lock()
+                .unwrap()
+                .soft_dirty_kernel_supported
+                .load(Ordering::Acquire)
+            {
+                if let Err(e) = clear_soft_dirty() {
+                    warn!(
+                        "Soft-dirty: clear_soft_dirty() failed after restore ({}), \
+                         disabling soft-dirty tracking; subsequent snapshots will \
+                         fall back to pagemap_anon",
+                        e
+                    );
+                    mm.lock()
+                        .unwrap()
+                        .soft_dirty_kernel_supported
+                        .store(false, Ordering::Release);
+                }
             }
 
             Ok(mm)
@@ -2362,6 +2411,146 @@ impl MemoryManager {
         Ok(())
     }
 
+    /// Save a soft-dirty incremental snapshot.
+    ///
+    /// This method writes a delta snapshot containing only pages that have
+    /// been written **since the previous `clear_soft_dirty()`**. The delta
+    /// is detected via `/proc/self/pagemap` bit 55, which is armed/cleared
+    /// by writing `4` to `/proc/self/clear_refs`.
+    ///
+    /// To remain compatible with the rest of the VMM (snapshot consumers
+    /// expect a self-contained, full-size memory image at the destination),
+    /// the resulting file is **not** a raw delta. We prepare a base image
+    /// at the destination and then overwrite only the soft-dirty pages on
+    /// top. The base is either:
+    ///   - the existing snapshot file (when `path.exists()`), reused
+    ///     in place — every still-clean page from the previous cycle is
+    ///     already correct on disk; or
+    ///   - a fresh sparse file of the full RAM size (when the path does
+    ///     not yet exist) — typical for the very first snapshot of a
+    ///     brand-new VM. Pages that were never written remain as file
+    ///     holes and read back as zero on restore, which matches the
+    ///     initial state of `MAP_ANONYMOUS` guest memory; the soft-dirty
+    ///     filter already includes every page touched since boot (BIOS /
+    ///     kernel image load, ACPI tables, vCPU stores), so the
+    ///     resulting snapshot is self-contained.
+    ///
+    /// Tracking is armed at `MemoryManager::new()` (the
+    /// `probe_soft_dirty_support()` call clears all bits as a side
+    /// effect) and re-armed at `new_from_snapshot()` (after
+    /// `fill_saved_regions`), so this function does **not** need a
+    /// dedicated "first cycle writes the full base" branch.
+    ///
+    /// Degradation: if the kernel does not support soft-dirty (probed at
+    /// construction time and re-checked here), or if `clear_soft_dirty()`
+    /// fails at runtime, the call silently falls back to the pagemap_anon
+    /// (Incremental) path. The fallback is logged but not surfaced as an
+    /// error to the caller.
+    fn send_soft_dirty_memory(
+        &self,
+        destination_url: &str,
+        memory_vol_url: &Option<String>,
+    ) -> result::Result<(), MigratableError> {
+        if self.snapshot_memory_ranges.is_empty() {
+            return Ok(());
+        }
+
+        // Degrade to pagemap_anon if the kernel doesn't support soft-dirty.
+        if !self.soft_dirty_kernel_supported.load(Ordering::Acquire) {
+            debug!(
+                "Soft-dirty not supported by kernel, falling back to pagemap_anon snapshot"
+            );
+            return self.send_pagemap_anon_memory(destination_url, memory_vol_url);
+        }
+
+        let memory_file_target =
+            MemorySnapshotFile::from_snapshot_url(destination_url, memory_vol_url.as_deref())?;
+
+        // Filter by pagemap bit 55 to find pages written since the last
+        // `clear_soft_dirty()` (which was performed either by the probe at
+        // construction time, by the previous snapshot cycle, or by
+        // `new_from_snapshot()` after `fill_saved_regions`).
+        let guest_memory = self.guest_memory.memory();
+        let (filtered_ranges, stats) =
+            filter_memory_ranges_by_soft_dirty(&guest_memory, &self.snapshot_memory_ranges)
+                .map_err(|e| {
+                    MigratableError::MigrateSend(anyhow!(
+                        "Failed to filter memory with soft-dirty: {}",
+                        e
+                    ))
+                })?;
+
+        info!(
+            "Soft-dirty snapshot: total={} bytes ({} pages), dirty={} bytes ({} pages), savings={:.1}%",
+            stats.total_bytes,
+            stats.total_pages,
+            stats.saved_bytes,
+            stats.dirty_pages,
+            stats.savings_percentage()
+        );
+
+        // Prepare the destination file. If it already exists, reuse it
+        // in place (steady-state cycle: the previous snapshot already
+        // contains every still-clean page). Otherwise create a fresh
+        // sparse file sized to the full RAM (first cycle after a
+        // brand-new VM boot).
+        let memory_file = if memory_file_target.path().exists() {
+            memory_file_target.open_read_write()?
+        } else {
+            info!(
+                "Soft-dirty snapshot: no previous base at {:?}, writing {} dirty bytes \
+                 onto a fresh sparse file",
+                memory_file_target.path(),
+                stats.saved_bytes
+            );
+            let f = memory_file_target.open_for_fresh_write()?;
+            if !memory_file_target.is_external() {
+                let total_size = guest_memory.iter().map(|region| region.len()).sum::<u64>();
+                f.set_len(total_size)
+                    .map_err(|e| MigratableError::MigrateSend(e.into()))?;
+            }
+            f
+        };
+
+        // Build a GPA-to-file-offset mapping for calculating offsets.
+        let mut gpa_to_file_offset: Vec<(u64, u64, u64)> = Vec::new();
+        let mut offset = 0_u64;
+        for range in self.snapshot_memory_ranges.regions() {
+            gpa_to_file_offset.push((range.gpa, range.length, offset));
+            offset += range.length;
+        }
+
+        // Write only soft-dirty pages onto the prepared base file.
+        for range in filtered_ranges.regions() {
+            let file_off =
+                Self::calculate_file_offset_for_gpa(range.gpa, range.length, &gpa_to_file_offset)?;
+            self.save_range_to_file(&memory_file, range, file_off)?;
+        }
+
+        memory_file
+            .sync_all()
+            .map_err(|e| MigratableError::MigrateSend(e.into()))?;
+
+        info!(
+            "Soft-dirty snapshot saved: {} dirty bytes written to {:?}",
+            stats.saved_bytes,
+            memory_file_target.path()
+        );
+
+        // Re-arm tracking for the next cycle.
+        if let Err(e) = clear_soft_dirty() {
+            warn!(
+                "Soft-dirty: clear_soft_dirty() failed after writing delta ({}), \
+                 disabling soft-dirty tracking; subsequent snapshots will use pagemap_anon",
+                e
+            );
+            self.soft_dirty_kernel_supported
+                .store(false, Ordering::Release);
+        }
+
+        Ok(())
+    }
+
     /// Calculate the file offset for a given GPA within the snapshot file.
     ///
     /// The snapshot file stores memory regions sequentially. This method finds
@@ -2868,6 +3057,9 @@ impl Transportable for MemoryManager {
         match config.snapshot_type {
             SnapshotType::Incremental => {
                 self.send_pagemap_anon_memory(destination_url, &config.memory_vol_url)?;
+            }
+            SnapshotType::SoftDirty => {
+                self.send_soft_dirty_memory(destination_url, &config.memory_vol_url)?;
             }
             SnapshotType::Full => {
                 let memory_file = memory_file_target.open_for_fresh_write()?;

--- a/hypervisor/vmm/src/soft_dirty.rs
+++ b/hypervisor/vmm/src/soft_dirty.rs
@@ -23,6 +23,7 @@
 //! Requires `CONFIG_MEM_SOFT_DIRTY=y`. On kernels without this config the
 //! caller is expected to silently fall back to the pagemap_anon path.
 
+use crate::pagemap_anon::{self, get_anon_pages};
 use log::{debug, info, trace};
 use std::fs::{File, OpenOptions};
 use std::io::{self, Read, Seek, SeekFrom, Write};
@@ -87,6 +88,9 @@ pub enum SoftDirtyError {
 
     #[error("Memory region not aligned to page boundary")]
     NotPageAligned,
+
+    #[error("Failed to probe anonymous pages via pagemap_anon: {0}")]
+    AnonProbe(#[from] pagemap_anon::PagemapAnonError),
 }
 
 /// Result type for soft-dirty operations
@@ -333,6 +337,120 @@ pub fn filter_memory_ranges_by_soft_dirty<B: vm_memory::bitmap::Bitmap + 'static
         let dirty_pct = (stats.dirty_pages as f64 / stats.total_pages as f64) * 100.0;
         debug!(
             "Soft-dirty stats: {:.1}% dirty pages, {:.1}% savings vs full snapshot",
+            dirty_pct,
+            stats.savings_percentage()
+        );
+    }
+
+    Ok((filtered_ranges, stats))
+}
+
+/// Filter memory ranges by the **intersection** of anonymous (CoW) pages
+/// and soft-dirty pages.
+///
+/// The set of pages we want to write into an incremental snapshot is exactly:
+///   * pages that have actually been Copy-on-Written by the guest (anonymous
+///     after the `MAP_PRIVATE` restore — only these can ever differ from the
+///     base snapshot file), AND
+///   * pages whose contents have changed **since the previous
+///     `clear_soft_dirty()`** (the delta this cycle must record).
+///
+/// Either signal alone over- or under-approximates:
+///   * "anonymous only" is correct but cumulative — every page CoW'd since
+///     restore shows up forever, even if it has not been modified in the
+///     current snapshot window.
+///   * "soft-dirty only" can include host-side writes that landed on
+///     file-backed page-cache pages (e.g. shared-mmap restore); those pages
+///     are the same content as the base file on disk and re-saving them
+///     would be wasteful — and on the very first soft-dirty cycle of a
+///     freshly-armed tracker every guest write since arm shows up,
+///     including writes that fault in non-anon pages.
+///
+/// Taking the intersection gives us exactly the anon pages whose contents
+/// changed in the current window, which is both minimal and safe.
+pub fn filter_memory_ranges_by_anon_and_soft_dirty<B: vm_memory::bitmap::Bitmap + 'static>(
+    guest_memory: &GuestMemoryMmap<B>,
+    ranges: &MemoryRangeTable,
+) -> Result<(MemoryRangeTable, SoftDirtyStats)> {
+    let mut filtered_ranges = MemoryRangeTable::default();
+    let mut stats = SoftDirtyStats::default();
+
+    debug!(
+        "Starting anon ∩ soft-dirty filtering for {} memory regions",
+        ranges.regions().len()
+    );
+
+    for range in ranges.regions() {
+        let gpa = range.gpa;
+        let length = range.length;
+
+        stats.total_bytes += length;
+        stats.total_pages += length.div_ceil(PAGE_SIZE);
+
+        trace!(
+            "Processing memory region: GPA=0x{:x}, length={}",
+            gpa,
+            length
+        );
+
+        let host_addr = guest_memory
+            .get_host_address(GuestAddress(gpa))
+            .map_err(|_| SoftDirtyError::GetHostAddressFailed)?;
+
+        let anon_pages = get_anon_pages(host_addr as u64, length)?;
+        let dirty_pages = get_soft_dirty_pages(host_addr as u64, length)?;
+
+        debug_assert_eq!(anon_pages.len(), dirty_pages.len());
+
+        let mut current_range_start: Option<u64> = None;
+        let mut current_range_length: u64 = 0;
+
+        for (page_idx, (&is_anon, &is_dirty)) in anon_pages
+            .iter()
+            .zip(dirty_pages.iter())
+            .enumerate()
+        {
+            let page_gpa = gpa + (page_idx as u64 * PAGE_SIZE);
+            let must_save = is_anon && is_dirty;
+
+            if must_save {
+                stats.dirty_pages += 1;
+                stats.saved_bytes += PAGE_SIZE;
+
+                if current_range_start.is_none() {
+                    current_range_start = Some(page_gpa);
+                    current_range_length = PAGE_SIZE;
+                } else {
+                    current_range_length += PAGE_SIZE;
+                }
+            } else if let Some(start) = current_range_start.take() {
+                filtered_ranges.push(MemoryRange {
+                    gpa: start,
+                    length: current_range_length,
+                });
+                current_range_length = 0;
+            }
+        }
+
+        if let Some(start) = current_range_start {
+            filtered_ranges.push(MemoryRange {
+                gpa: start,
+                length: current_range_length,
+            });
+        }
+    }
+
+    debug!(
+        "anon ∩ soft-dirty filtering complete: {} ranges, {} total pages, {} pages to save",
+        filtered_ranges.regions().len(),
+        stats.total_pages,
+        stats.dirty_pages
+    );
+
+    if stats.total_pages > 0 {
+        let dirty_pct = (stats.dirty_pages as f64 / stats.total_pages as f64) * 100.0;
+        debug!(
+            "anon ∩ soft-dirty stats: {:.1}% pages to save, {:.1}% savings vs full snapshot",
             dirty_pct,
             stats.savings_percentage()
         );
@@ -594,5 +712,87 @@ mod tests {
             "round 4: with zero dirty pages, savings should be 100%, got {}",
             stats.savings_percentage()
         );
+    }
+
+    /// End-to-end test for `filter_memory_ranges_by_anon_and_soft_dirty`:
+    /// the result must be the intersection of "anonymous (CoW)" and
+    /// "soft-dirty since the last clear".
+    ///
+    /// We build an anonymous private mapping (every present page in it
+    /// is anon by construction), so on this fixture anon == always true
+    /// and the intersection collapses to "soft-dirty only" — i.e. the
+    /// helper must produce exactly the same per-window delta as
+    /// `filter_memory_ranges_by_soft_dirty` does.
+    ///
+    /// Skipped silently when the host kernel lacks `CONFIG_MEM_SOFT_DIRTY=y`.
+    #[test]
+    fn test_filter_memory_ranges_by_anon_and_soft_dirty_end_to_end() {
+        let _guard = CLEAR_REFS_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+
+        if !probe_soft_dirty_support() {
+            eprintln!(
+                "kernel has no soft-dirty support (CONFIG_MEM_SOFT_DIRTY=n); skipping {}",
+                "test_filter_memory_ranges_by_anon_and_soft_dirty_end_to_end"
+            );
+            return;
+        }
+
+        const NUM_PAGES: u64 = 16;
+        let region_len = (NUM_PAGES * PAGE_SIZE) as usize;
+        let guest_memory =
+            GuestMemoryMmap::<()>::from_ranges(&[(GuestAddress(0), region_len)]).unwrap();
+
+        let host_base = guest_memory
+            .get_host_address(GuestAddress(0))
+            .expect("get_host_address") as *mut u8;
+        for p in 0..NUM_PAGES {
+            // SAFETY: host_base..host_base+region_len is owned by guest_memory.
+            unsafe { host_base.add((p * PAGE_SIZE) as usize).write_volatile(0) };
+        }
+
+        let ranges = {
+            let mut t = MemoryRangeTable::default();
+            t.push(MemoryRange {
+                gpa: 0,
+                length: NUM_PAGES * PAGE_SIZE,
+            });
+            t
+        };
+
+        let dirty_page = |page_idx: u64, val: u8| {
+            // SAFETY: 0 <= page_idx < NUM_PAGES.
+            unsafe {
+                host_base
+                    .add((page_idx * PAGE_SIZE) as usize)
+                    .write_volatile(val)
+            };
+        };
+
+        let collect = |table: &MemoryRangeTable| -> Vec<(u64, u64)> {
+            table.regions().iter().map(|r| (r.gpa, r.length)).collect()
+        };
+
+        // Arm the tracker.
+        clear_soft_dirty().expect("clear_soft_dirty: round 1");
+
+        // Dirty pages 5 and 6 (will be one coalesced run after AND).
+        dirty_page(5, 0xc1);
+        dirty_page(6, 0xc2);
+
+        let (filtered, stats) =
+            filter_memory_ranges_by_anon_and_soft_dirty(&guest_memory, &ranges)
+                .expect("anon ∩ soft-dirty filter failed");
+
+        // Every page in this anon MAP_PRIVATE mapping is anon, so
+        // anon ∩ soft-dirty == soft-dirty exactly: only pages 5 and 6.
+        assert_eq!(
+            collect(&filtered),
+            vec![(5 * PAGE_SIZE, 2 * PAGE_SIZE)],
+            "anon ∩ soft-dirty must yield exactly the two pages \
+             written in this window, coalesced"
+        );
+        assert_eq!(stats.total_pages, NUM_PAGES);
+        assert_eq!(stats.dirty_pages, 2);
+        assert_eq!(stats.saved_bytes, 2 * PAGE_SIZE);
     }
 }

--- a/hypervisor/vmm/src/soft_dirty.rs
+++ b/hypervisor/vmm/src/soft_dirty.rs
@@ -405,10 +405,8 @@ pub fn filter_memory_ranges_by_anon_and_soft_dirty<B: vm_memory::bitmap::Bitmap 
         let mut current_range_start: Option<u64> = None;
         let mut current_range_length: u64 = 0;
 
-        for (page_idx, (&is_anon, &is_dirty)) in anon_pages
-            .iter()
-            .zip(dirty_pages.iter())
-            .enumerate()
+        for (page_idx, (&is_anon, &is_dirty)) in
+            anon_pages.iter().zip(dirty_pages.iter()).enumerate()
         {
             let page_gpa = gpa + (page_idx as u64 * PAGE_SIZE);
             let must_save = is_anon && is_dirty;
@@ -650,8 +648,8 @@ mod tests {
         dirty_page(3, 0xa2);
         dirty_page(4, 0xa3);
 
-        let (filtered, stats) = filter_memory_ranges_by_soft_dirty(&guest_memory, &ranges)
-            .expect("filter round 2");
+        let (filtered, stats) =
+            filter_memory_ranges_by_soft_dirty(&guest_memory, &ranges).expect("filter round 2");
 
         // The three writes must be coalesced into exactly one contiguous run
         // [page 2 .. page 5).
@@ -677,8 +675,8 @@ mod tests {
         // pages 2/3/4 would still show up here.
         dirty_page(7, 0xb1);
 
-        let (filtered, stats) = filter_memory_ranges_by_soft_dirty(&guest_memory, &ranges)
-            .expect("filter round 3");
+        let (filtered, stats) =
+            filter_memory_ranges_by_soft_dirty(&guest_memory, &ranges).expect("filter round 3");
 
         assert_eq!(
             collect(&filtered),
@@ -694,8 +692,8 @@ mod tests {
         clear_soft_dirty().expect("clear_soft_dirty: round 3 -> 4");
 
         // ---------------- Round 4: write nothing -> empty delta ----------------
-        let (filtered, stats) = filter_memory_ranges_by_soft_dirty(&guest_memory, &ranges)
-            .expect("filter round 4");
+        let (filtered, stats) =
+            filter_memory_ranges_by_soft_dirty(&guest_memory, &ranges).expect("filter round 4");
 
         assert!(
             filtered.regions().is_empty(),
@@ -724,7 +722,9 @@ mod tests {
     /// helper must produce exactly the same per-window delta as
     /// `filter_memory_ranges_by_soft_dirty` does.
     ///
-    /// Skipped silently when the host kernel lacks `CONFIG_MEM_SOFT_DIRTY=y`.
+    /// Skipped silently when the host kernel lacks `CONFIG_MEM_SOFT_DIRTY=y`,
+    /// or when the test process lacks CAP_SYS_ADMIN to read PFNs from
+    /// /proc/self/pagemap and classify anonymous pages through /proc/kpageflags.
     #[test]
     fn test_filter_memory_ranges_by_anon_and_soft_dirty_end_to_end() {
         let _guard = CLEAR_REFS_LOCK.lock().unwrap_or_else(|e| e.into_inner());
@@ -780,8 +780,17 @@ mod tests {
         dirty_page(6, 0xc2);
 
         let (filtered, stats) =
-            filter_memory_ranges_by_anon_and_soft_dirty(&guest_memory, &ranges)
-                .expect("anon ∩ soft-dirty filter failed");
+            match filter_memory_ranges_by_anon_and_soft_dirty(&guest_memory, &ranges) {
+                Ok(result) => result,
+                Err(SoftDirtyError::AnonProbe(pagemap_anon::PagemapAnonError::NoCapSysAdmin)) => {
+                    eprintln!(
+                        "no CAP_SYS_ADMIN to read pagemap PFNs; skipping {}",
+                        "test_filter_memory_ranges_by_anon_and_soft_dirty_end_to_end"
+                    );
+                    return;
+                }
+                Err(e) => panic!("anon ∩ soft-dirty filter failed: {e}"),
+            };
 
         // Every page in this anon MAP_PRIVATE mapping is anon, so
         // anon ∩ soft-dirty == soft-dirty exactly: only pages 5 and 6.

--- a/hypervisor/vmm/src/soft_dirty.rs
+++ b/hypervisor/vmm/src/soft_dirty.rs
@@ -1,0 +1,598 @@
+// Copyright © 2026 Tencent Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! Soft-dirty snapshot support
+//!
+//! This module provides functionality for creating soft-dirty-based incremental
+//! snapshots that only save pages actually written by the guest **since the
+//! previous soft-dirty snapshot** (a true delta), by toggling
+//! `/proc/self/clear_refs` and inspecting bit 55 of `/proc/self/pagemap`.
+//!
+//! Compared with the pagemap_anon path (which records every CoW-anonymous page
+//! ever touched since restore), soft-dirty produces a much smaller delta on
+//! the second and later incremental snapshots because the bit is reset on each
+//! cycle.
+//!
+//! Lifecycle:
+//! 1. First snapshot: write the full base, then `clear_soft_dirty()` to arm
+//!    the kernel tracker.
+//! 2. Subsequent snapshots: read pagemap bit 55, write only pages with the
+//!    bit set, then `clear_soft_dirty()` again to start the next window.
+//!
+//! Requires `CONFIG_MEM_SOFT_DIRTY=y`. On kernels without this config the
+//! caller is expected to silently fall back to the pagemap_anon path.
+
+use log::{debug, info, trace};
+use std::fs::{File, OpenOptions};
+use std::io::{self, Read, Seek, SeekFrom, Write};
+use std::time::Instant;
+use thiserror::Error;
+use vm_memory::{GuestAddress, GuestMemory, GuestMemoryMmap};
+use vm_migration::protocol::{MemoryRange, MemoryRangeTable};
+
+/// Page size constant (4KB)
+pub const PAGE_SIZE: u64 = 4096;
+
+/// Size of a pagemap entry in bytes
+const PAGEMAP_ENTRY_SIZE: u64 = 8;
+
+/// Bit 55 in pagemap: page has been written since the last clear_refs(4)
+const PAGEMAP_SOFT_DIRTY_BIT: u64 = 1 << 55;
+
+/// Bit 63: page is present in RAM
+const PAGEMAP_PRESENT_BIT: u64 = 1 << 63;
+
+/// Bit 62: page is in swap
+const PAGEMAP_SWAPPED_BIT: u64 = 1 << 62;
+
+/// Magic value to write to /proc/self/clear_refs to clear the soft-dirty
+/// bit on every page table entry of the current process and (re)arm the
+/// VM_SOFTDIRTY tracker.
+const CLEAR_REFS_SOFT_DIRTY: &[u8] = b"4\n";
+
+/// Errors related to soft-dirty operations
+#[derive(Debug, Error)]
+pub enum SoftDirtyError {
+    #[error("Failed to open {path}: {source}")]
+    OpenFailed {
+        path: String,
+        #[source]
+        source: io::Error,
+    },
+
+    #[error("Failed to read {path}: {source}")]
+    ReadFailed {
+        path: String,
+        #[source]
+        source: io::Error,
+    },
+
+    #[error("Failed to seek in {path}: {source}")]
+    SeekFailed {
+        path: String,
+        #[source]
+        source: io::Error,
+    },
+
+    #[error("Failed to write to {path}: {source}")]
+    WriteFailed {
+        path: String,
+        #[source]
+        source: io::Error,
+    },
+
+    #[error("Failed to get host address for guest memory region")]
+    GetHostAddressFailed,
+
+    #[error("Memory region not aligned to page boundary")]
+    NotPageAligned,
+}
+
+/// Result type for soft-dirty operations
+pub type Result<T> = std::result::Result<T, SoftDirtyError>;
+
+/// Statistics about soft-dirty filtering results
+#[derive(Debug, Default, Clone)]
+pub struct SoftDirtyStats {
+    /// Total number of pages in the memory regions
+    pub total_pages: u64,
+    /// Number of pages with the soft-dirty bit set (written since last clear)
+    pub dirty_pages: u64,
+    /// Total bytes in all memory regions
+    pub total_bytes: u64,
+    /// Bytes that will be written (dirty pages only)
+    pub saved_bytes: u64,
+}
+
+impl SoftDirtyStats {
+    /// Calculate the percentage of memory saved (not needing to be snapshotted)
+    pub fn savings_percentage(&self) -> f64 {
+        if self.total_bytes == 0 {
+            return 0.0;
+        }
+        ((self.total_bytes - self.saved_bytes) as f64 / self.total_bytes as f64) * 100.0
+    }
+}
+
+/// Probe whether the running kernel supports the soft-dirty mechanism.
+///
+/// This performs a non-destructive write of "4" to `/proc/self/clear_refs`.
+/// On kernels with `CONFIG_MEM_SOFT_DIRTY=y` this clears soft-dirty bits and
+/// returns success. On kernels without this config the write returns
+/// `EINVAL`, which we map to `false`.
+///
+/// Note: this call is technically not "non-destructive" — it does clear any
+/// existing soft-dirty bits. The probe is therefore intended to be invoked
+/// once at `MemoryManager` construction time, before any soft-dirty cycle
+/// has started, where clearing has no observable effect.
+pub fn probe_soft_dirty_support() -> bool {
+    match clear_soft_dirty() {
+        Ok(()) => true,
+        Err(e) => {
+            debug!("Soft-dirty kernel support probe failed: {}", e);
+            false
+        }
+    }
+}
+
+/// Clear the soft-dirty bit on every PTE of the current process and (re)arm
+/// the VM_SOFTDIRTY tracker on every VMA, by writing "4" to
+/// `/proc/self/clear_refs`.
+///
+/// After this call, any page subsequently written by the guest (vCPU stores
+/// or device DMA into guest memory) will be marked with bit 55 in
+/// `/proc/self/pagemap`.
+pub fn clear_soft_dirty() -> Result<()> {
+    let start = Instant::now();
+    let mut f = OpenOptions::new()
+        .write(true)
+        .open("/proc/self/clear_refs")
+        .map_err(|e| SoftDirtyError::OpenFailed {
+            path: "/proc/self/clear_refs".to_string(),
+            source: e,
+        })?;
+    f.write_all(CLEAR_REFS_SOFT_DIRTY)
+        .map_err(|e| SoftDirtyError::WriteFailed {
+            path: "/proc/self/clear_refs".to_string(),
+            source: e,
+        })?;
+    let elapsed = start.elapsed();
+    // The kernel walks every PTE of every anonymous VMA under mmap_lock
+    // (write) here, and on large guests this is the dominant snapshot-time
+    // stall (hundreds of ms on multi-GiB VMs). Log at info so operators
+    // can correlate it with guest pause-time spikes without enabling debug.
+    info!(
+        "soft-dirty: clear_refs(4) took {} us ({:.3} ms)",
+        elapsed.as_micros(),
+        elapsed.as_secs_f64() * 1000.0
+    );
+    Ok(())
+}
+
+/// Get the soft-dirty bitmap for a memory region by reading
+/// `/proc/self/pagemap`.
+///
+/// # Arguments
+/// * `host_addr` - Host virtual address of the memory region (must be page-aligned)
+/// * `length` - Length of the memory region in bytes
+///
+/// # Returns
+/// A vector of bools where each bool indicates whether the corresponding
+/// page has been written since the previous `clear_soft_dirty()` call.
+///
+/// A page counts as soft-dirty if either:
+/// - It is present and bit 55 is set, or
+/// - It is in swap (bit 62) — swapped pages are by definition pages that
+///   were anonymous and previously written, so they must be saved on the
+///   next snapshot to be safe.
+pub fn get_soft_dirty_pages(host_addr: u64, length: u64) -> Result<Vec<bool>> {
+    if host_addr % PAGE_SIZE != 0 {
+        return Err(SoftDirtyError::NotPageAligned);
+    }
+
+    let num_pages = length.div_ceil(PAGE_SIZE) as usize;
+    let start_page = host_addr / PAGE_SIZE;
+
+    let mut pagemap_file =
+        File::open("/proc/self/pagemap").map_err(|e| SoftDirtyError::OpenFailed {
+            path: "/proc/self/pagemap".to_string(),
+            source: e,
+        })?;
+
+    let pagemap_offset = start_page * PAGEMAP_ENTRY_SIZE;
+    pagemap_file
+        .seek(SeekFrom::Start(pagemap_offset))
+        .map_err(|e| SoftDirtyError::SeekFailed {
+            path: "/proc/self/pagemap".to_string(),
+            source: e,
+        })?;
+
+    let buf_size = num_pages * PAGEMAP_ENTRY_SIZE as usize;
+    let mut pagemap_buf = vec![0u8; buf_size];
+    pagemap_file
+        .read_exact(&mut pagemap_buf)
+        .map_err(|e| SoftDirtyError::ReadFailed {
+            path: "/proc/self/pagemap".to_string(),
+            source: e,
+        })?;
+
+    let mut result = vec![false; num_pages];
+    for (i, item) in result.iter_mut().enumerate().take(num_pages) {
+        let entry_offset = i * PAGEMAP_ENTRY_SIZE as usize;
+        let entry = u64::from_ne_bytes(
+            pagemap_buf[entry_offset..entry_offset + PAGEMAP_ENTRY_SIZE as usize]
+                .try_into()
+                .unwrap(),
+        );
+
+        let present = (entry & PAGEMAP_PRESENT_BIT) != 0;
+        let swapped = (entry & PAGEMAP_SWAPPED_BIT) != 0;
+        let soft_dirty = (entry & PAGEMAP_SOFT_DIRTY_BIT) != 0;
+
+        // Treat swapped anonymous pages as dirty: they were written before
+        // being swapped out, and the kernel does not preserve the soft-dirty
+        // bit across swap-in on all kernels.
+        if swapped {
+            *item = true;
+            continue;
+        }
+
+        if present && soft_dirty {
+            *item = true;
+        }
+    }
+
+    Ok(result)
+}
+
+/// Filter memory ranges by soft-dirty, returning only ranges with pages
+/// written since the previous `clear_soft_dirty()` call.
+///
+/// # Arguments
+/// * `guest_memory` - The guest memory object
+/// * `ranges` - The original memory range table
+///
+/// # Returns
+/// A tuple containing:
+/// - The filtered memory range table (only soft-dirty pages, merged into
+///   contiguous runs)
+/// - Statistics about the filtering
+pub fn filter_memory_ranges_by_soft_dirty<B: vm_memory::bitmap::Bitmap + 'static>(
+    guest_memory: &GuestMemoryMmap<B>,
+    ranges: &MemoryRangeTable,
+) -> Result<(MemoryRangeTable, SoftDirtyStats)> {
+    let mut filtered_ranges = MemoryRangeTable::default();
+    let mut stats = SoftDirtyStats::default();
+
+    debug!(
+        "Starting soft-dirty filtering for {} memory regions",
+        ranges.regions().len()
+    );
+
+    for range in ranges.regions() {
+        let gpa = range.gpa;
+        let length = range.length;
+
+        stats.total_bytes += length;
+        stats.total_pages += length.div_ceil(PAGE_SIZE);
+
+        trace!(
+            "Processing memory region: GPA=0x{:x}, length={}",
+            gpa,
+            length
+        );
+
+        let host_addr = guest_memory
+            .get_host_address(GuestAddress(gpa))
+            .map_err(|_| SoftDirtyError::GetHostAddressFailed)?;
+
+        let dirty_pages = get_soft_dirty_pages(host_addr as u64, length)?;
+
+        let mut current_range_start: Option<u64> = None;
+        let mut current_range_length: u64 = 0;
+
+        for (page_idx, &is_dirty) in dirty_pages.iter().enumerate() {
+            let page_gpa = gpa + (page_idx as u64 * PAGE_SIZE);
+
+            if is_dirty {
+                stats.dirty_pages += 1;
+                stats.saved_bytes += PAGE_SIZE;
+
+                if current_range_start.is_none() {
+                    current_range_start = Some(page_gpa);
+                    current_range_length = PAGE_SIZE;
+                } else {
+                    current_range_length += PAGE_SIZE;
+                }
+            } else if let Some(start) = current_range_start.take() {
+                filtered_ranges.push(MemoryRange {
+                    gpa: start,
+                    length: current_range_length,
+                });
+                current_range_length = 0;
+            }
+        }
+
+        if let Some(start) = current_range_start {
+            filtered_ranges.push(MemoryRange {
+                gpa: start,
+                length: current_range_length,
+            });
+        }
+    }
+
+    debug!(
+        "Soft-dirty filtering complete: {} dirty ranges, {} total pages, {} dirty pages",
+        filtered_ranges.regions().len(),
+        stats.total_pages,
+        stats.dirty_pages
+    );
+
+    if stats.total_pages > 0 {
+        let dirty_pct = (stats.dirty_pages as f64 / stats.total_pages as f64) * 100.0;
+        debug!(
+            "Soft-dirty stats: {:.1}% dirty pages, {:.1}% savings vs full snapshot",
+            dirty_pct,
+            stats.savings_percentage()
+        );
+    }
+
+    Ok((filtered_ranges, stats))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    /// `/proc/self/clear_refs` and the soft-dirty PTE bit are *process*-wide
+    /// state. When `cargo test` runs cases concurrently, one test's
+    /// `clear_soft_dirty()` can race with another test's "write then read
+    /// bit 55" check and clear the bit before it is observed, producing
+    /// spurious failures. Serialize every test that calls `clear_soft_dirty`
+    /// or reads the pagemap of pages we just dirtied through this lock.
+    static CLEAR_REFS_LOCK: Mutex<()> = Mutex::new(());
+
+    #[test]
+    fn test_soft_dirty_stats_savings_percentage() {
+        let stats = SoftDirtyStats {
+            total_bytes: 1000,
+            saved_bytes: 250,
+            ..Default::default()
+        };
+        assert!((stats.savings_percentage() - 75.0).abs() < 0.01);
+    }
+
+    #[test]
+    fn test_soft_dirty_stats_zero_total() {
+        let stats = SoftDirtyStats::default();
+        assert_eq!(stats.savings_percentage(), 0.0);
+    }
+
+    #[test]
+    fn test_soft_dirty_stats_full_dirty() {
+        let stats = SoftDirtyStats {
+            total_bytes: 4096,
+            saved_bytes: 4096,
+            ..Default::default()
+        };
+        assert!((stats.savings_percentage() - 0.0).abs() < 0.01);
+    }
+
+    #[test]
+    fn test_get_soft_dirty_pages_not_page_aligned() {
+        let result = get_soft_dirty_pages(4097, 4096);
+        assert!(result.is_err());
+        assert!(matches!(
+            result.unwrap_err(),
+            SoftDirtyError::NotPageAligned
+        ));
+    }
+
+    #[test]
+    fn test_pagemap_bit_constants() {
+        assert_eq!(PAGEMAP_SOFT_DIRTY_BIT, 1u64 << 55);
+        assert_eq!(PAGEMAP_PRESENT_BIT, 1u64 << 63);
+        assert_eq!(PAGEMAP_SWAPPED_BIT, 1u64 << 62);
+    }
+
+    /// Self-test: if the running kernel supports soft-dirty, allocating and
+    /// writing a scratch page after `clear_soft_dirty()` should make that
+    /// page show up as dirty in the pagemap.
+    ///
+    /// Skipped silently when the kernel does not support soft-dirty (e.g.
+    /// running on a stripped-down CI kernel).
+    #[test]
+    fn test_clear_and_observe_dirty_page() {
+        // Hold the process-wide lock for the entire "clear -> write -> read
+        // pagemap" sequence; without it a parallel test calling
+        // clear_soft_dirty() can wipe our bit before we read it.
+        let _guard = CLEAR_REFS_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+
+        if !probe_soft_dirty_support() {
+            eprintln!("kernel has no soft-dirty support; skipping");
+            return;
+        }
+
+        // Allocate one page-aligned scratch buffer.
+        let page = PAGE_SIZE as usize;
+        let layout = std::alloc::Layout::from_size_align(page, page).unwrap();
+        // SAFETY: standard allocation followed by an explicit deallocation
+        // at the end of the test.
+        let ptr = unsafe { std::alloc::alloc_zeroed(layout) };
+        assert!(!ptr.is_null());
+
+        // Touch (write) the page to make sure it has a PTE, then clear so
+        // the dirty bit starts at 0.
+        unsafe { ptr.write_volatile(0) };
+        clear_soft_dirty().expect("clear_soft_dirty failed");
+
+        // Right after clear, the page should not be soft-dirty.
+        let before = get_soft_dirty_pages(ptr as u64, page as u64).expect("get_soft_dirty_pages");
+        assert_eq!(before.len(), 1);
+
+        // Now write to the page.
+        unsafe { ptr.write_volatile(0xab) };
+
+        // It should now show up as soft-dirty.
+        let after = get_soft_dirty_pages(ptr as u64, page as u64).expect("get_soft_dirty_pages");
+        assert_eq!(after.len(), 1);
+        assert!(
+            after[0],
+            "page expected to be soft-dirty after a write, but bit 55 was not set"
+        );
+
+        // SAFETY: matches the alloc above.
+        unsafe { std::alloc::dealloc(ptr, layout) };
+    }
+
+    /// End-to-end integration test that drives `filter_memory_ranges_by_soft_dirty`
+    /// through the same call sequence `MemoryManager::send_soft_dirty_memory()`
+    /// performs at runtime, but against a real `GuestMemoryMmap` backed by an
+    /// anonymous private mapping owned by the test process itself.
+    ///
+    /// Sequence:
+    ///   round 1 (base)        : clear_soft_dirty()  -> arm tracker
+    ///   round 2 (delta #1)    : write pages [2..=4] -> filter must return exactly those
+    ///                            clear_soft_dirty() -> arm next window
+    ///   round 3 (delta #2)    : write page  [7]     -> filter must return ONLY page 7
+    ///                                                  (i.e. soft-dirty really is a delta,
+    ///                                                  not a cumulative set)
+    ///                            clear_soft_dirty() -> arm next window
+    ///   round 4 (delta empty) : write nothing       -> filter must return empty
+    ///
+    /// Skipped silently when the host kernel lacks `CONFIG_MEM_SOFT_DIRTY=y`.
+    #[test]
+    fn test_filter_memory_ranges_by_soft_dirty_end_to_end() {
+        // Serialize against any other test that touches /proc/self/clear_refs
+        // — it is process-wide state.
+        let _guard = CLEAR_REFS_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+
+        if !probe_soft_dirty_support() {
+            eprintln!(
+                "kernel has no soft-dirty support (CONFIG_MEM_SOFT_DIRTY=n); skipping {}",
+                "test_filter_memory_ranges_by_soft_dirty_end_to_end"
+            );
+            return;
+        }
+
+        // Build a single-region GuestMemoryMmap of 16 pages starting at GPA 0.
+        // GuestMemoryMmap::from_ranges() defaults to an anonymous MAP_PRIVATE
+        // mapping, which is exactly the kind of memory soft-dirty tracks.
+        const NUM_PAGES: u64 = 16;
+        let region_len = (NUM_PAGES * PAGE_SIZE) as usize;
+        let guest_memory =
+            GuestMemoryMmap::<()>::from_ranges(&[(GuestAddress(0), region_len)]).unwrap();
+
+        // Pre-fault every page once so the kernel has real PTEs for them.
+        // Without this, pages may remain "not present" and the test would
+        // observe zero dirty pages even after writes (because the writes
+        // themselves are what fault them in).
+        let host_base = guest_memory
+            .get_host_address(GuestAddress(0))
+            .expect("get_host_address") as *mut u8;
+        for p in 0..NUM_PAGES {
+            // SAFETY: host_base..host_base+region_len is a valid mapping
+            // owned by `guest_memory`; we touch one byte per page.
+            unsafe { host_base.add((p * PAGE_SIZE) as usize).write_volatile(0) };
+        }
+
+        let ranges = {
+            let mut t = MemoryRangeTable::default();
+            t.push(MemoryRange {
+                gpa: 0,
+                length: NUM_PAGES * PAGE_SIZE,
+            });
+            t
+        };
+
+        // Helper: write one byte into the page at `page_idx`.
+        let dirty_page = |page_idx: u64, val: u8| {
+            // SAFETY: 0 <= page_idx < NUM_PAGES, mapping is at least
+            // NUM_PAGES * PAGE_SIZE bytes long.
+            unsafe {
+                host_base
+                    .add((page_idx * PAGE_SIZE) as usize)
+                    .write_volatile(val)
+            };
+        };
+
+        // Helper: collect the (gpa, length) pairs that the filter returned,
+        // for ergonomic assertions.
+        let collect = |table: &MemoryRangeTable| -> Vec<(u64, u64)> {
+            table.regions().iter().map(|r| (r.gpa, r.length)).collect()
+        };
+
+        // ---------------- Round 1: arm the tracker (the "base" cycle) ----------------
+        clear_soft_dirty().expect("clear_soft_dirty: round 1");
+
+        // ---------------- Round 2: dirty pages 2,3,4 -> must show up ----------------
+        dirty_page(2, 0xa1);
+        dirty_page(3, 0xa2);
+        dirty_page(4, 0xa3);
+
+        let (filtered, stats) = filter_memory_ranges_by_soft_dirty(&guest_memory, &ranges)
+            .expect("filter round 2");
+
+        // The three writes must be coalesced into exactly one contiguous run
+        // [page 2 .. page 5).
+        assert_eq!(
+            collect(&filtered),
+            vec![(2 * PAGE_SIZE, 3 * PAGE_SIZE)],
+            "round 2: expected exactly the three written pages, coalesced"
+        );
+        assert_eq!(stats.total_pages, NUM_PAGES);
+        assert_eq!(
+            stats.dirty_pages, 3,
+            "round 2: expected exactly 3 dirty pages"
+        );
+        assert_eq!(stats.saved_bytes, 3 * PAGE_SIZE);
+
+        // Re-arm the tracker for the next window. After this point, the bits
+        // for pages 2/3/4 must be cleared again.
+        clear_soft_dirty().expect("clear_soft_dirty: round 2 -> 3");
+
+        // ---------------- Round 3: dirty only page 7 -> must be the ONLY dirty page ----------------
+        // This is the key assertion: soft-dirty must behave as a *delta*,
+        // not a cumulative set. If it were cumulative (like pagemap_anon),
+        // pages 2/3/4 would still show up here.
+        dirty_page(7, 0xb1);
+
+        let (filtered, stats) = filter_memory_ranges_by_soft_dirty(&guest_memory, &ranges)
+            .expect("filter round 3");
+
+        assert_eq!(
+            collect(&filtered),
+            vec![(7 * PAGE_SIZE, PAGE_SIZE)],
+            "round 3: expected ONLY page 7, soft-dirty must be a delta and \
+             must NOT report pages 2/3/4 from the previous window"
+        );
+        assert_eq!(
+            stats.dirty_pages, 1,
+            "round 3: expected exactly 1 dirty page (true delta)"
+        );
+
+        clear_soft_dirty().expect("clear_soft_dirty: round 3 -> 4");
+
+        // ---------------- Round 4: write nothing -> empty delta ----------------
+        let (filtered, stats) = filter_memory_ranges_by_soft_dirty(&guest_memory, &ranges)
+            .expect("filter round 4");
+
+        assert!(
+            filtered.regions().is_empty(),
+            "round 4: expected an empty delta with no writes since clear, got {:?}",
+            collect(&filtered)
+        );
+        assert_eq!(
+            stats.dirty_pages, 0,
+            "round 4: dirty_pages must be 0 with no writes since clear"
+        );
+        assert_eq!(stats.total_pages, NUM_PAGES);
+        assert!(
+            (stats.savings_percentage() - 100.0).abs() < 0.01,
+            "round 4: with zero dirty pages, savings should be 100%, got {}",
+            stats.savings_percentage()
+        );
+    }
+}


### PR DESCRIPTION

### Summary

This PR introduces a new memory-snapshot type — **soft-dirty** — across
the hypervisor and Cubelet, and switches `CommitSandbox` to use it.
Soft-dirty produces a true *per-commit delta* (only pages dirtied since
the previous commit), reflink-cloned on top of the previous snapshot's
memory file. The result is that repeated commits on the same sandbox
write **~95× less** to disk in steady state versus full snapshots,
without changing user-visible semantics.

The change has two layered parts:

1. **Hypervisor** (by @lisongqian ) — adds `SnapshotType::SoftDirty` (CLI:
   `--snapshot-type soft-dirty`) backed by `/proc/self/clear_refs`
   plus `/proc/self/pagemap` bit 55. Exists alongside the older
   `incremental` (pagemap_anon) path, which is *cumulative since
   restore* and so degrades on long-running VMs.
2. **Cubelet** (by @fslongjin ) — wires soft-dirty into `CommitSandbox`, reflink-cloning
   the previous snapshot's memory file as the base, and correctly
   maintains the binding chain across `commit → commit`,
   `commit → rollback → commit`, and missing-base scenarios.

### Why soft-dirty (and not the existing `incremental`)?

The existing `incremental` path uses `pagemap_anon`, which captures
**all anonymous pages dirtied since VM restore**. The set is
monotonically growing for the lifetime of the VM, so a long-lived
sandbox's "incremental" snapshot is no longer small. Soft-dirty resets
the bitmap after each snapshot, so commit N+1 contains only pages
written between commits N and N+1.

Combined with reflink-cloning the previous snapshot file as the base,
this gives O(actual writes since last commit) on-disk bytes per commit
instead of O(working set since restore).

### Hypervisor changes

* New `SnapshotType::SoftDirty` enum variant; CLI and JSON wire format
  accept `soft-dirty`.
* `hypervisor/vmm/src/soft_dirty.rs`: kernel-support probe (logs once
  per process and disables itself on failure), `clear_soft_dirty()`
  via `/proc/self/clear_refs`, dirty-range enumeration via
  `/proc/self/pagemap`. Self-disabling: any `clear_refs(4)` failure
  causes the next snapshot to fall back to `pagemap_anon`.
* `MemoryManager`:
  - On a soft-dirty snapshot, write only the dirty bytes onto the
    destination memory file and emit savings stats. The destination
    is expected to already contain the previous snapshot's bytes —
    Cubelet supplies that via reflink.
  - Sparse-base sanity: if no previous base file exists, the dirty
    set is written onto a fresh sparse file and a warning is logged
    so operators can spot the misuse.
* Documentation: `hypervisor/docs/snapshot_restore.md` gains a
  soft-dirty section and a comparison table against full +
  pagemap_anon.

### Cubelet changes

#### 1. Reflink-cloned base memory in `CommitSandbox`

`CommitSandbox` now resolves the previous snapshot's memory file
through `cb.Labels[cube.master.runtime.snapshot.id]` (the *runtime*
binding, kept in sync below) and reflink-clones it as the destination
for the new snapshot, then asks Cloud Hypervisor for `--snapshot-type
soft-dirty`. The new helper `prepareCommitMemoryArtifact`
(`Cubelet/services/cubebox/snapshot_base_memory.go`) encapsulates
this base-resolution + clone step.

#### 2. Graceful fallback to `full` when the base is gone

If the previous snapshot was deleted, GC'd, or the binding label
is unset, `resolveBaseMemoryObject` returns
`ErrNoBaseMemoryForIncremental` and `prepareCommitMemoryArtifact`
falls back to a fresh empty memory volume + `--snapshot-type full`.
This preserves correctness for restored VMs, where passing an empty
base to `soft-dirty` would corrupt the snapshot. The fallback is
logged at WARN with the underlying reason so operators can spot
broken lineages.

#### 3. Binding-label update on every successful commit

`CommitSandbox` was previously **not** updating
`cb.Labels[cube.master.runtime.snapshot.id]` after a successful commit.
This was harmless for `pagemap_anon` (cumulative anyway) but a hidden
correctness bug for soft-dirty: the next commit would resolve the
*template's* memory file as base instead of the just-committed
snapshot, so any guest page dirtied between create and commit A and
not touched between A and B would silently revert to its template-era
content on a clone of B. After every successful commit we now stamp
the new snapshot id back into the binding label and persist it via
`SyncByID`, which makes the next `resolveBaseMemoryObject` pick the
right base.

This also handles the rollback chain
`T → A → B → rollback A → commit C` correctly: rollback already
resets the binding back to A, so commit C's base is A and its delta
is "writes since rollback". Without the binding update, C would
have inherited B's bytes instead.

#### 4. Tests

* `snapshot_incremental_test.go`: extended to cover the new
  `soft-dirty` type in `normalizeSnapshotType` and
  `buildCubeRuntimeSnapshotArgs`.
* `snapshot_base_memory_fallback_test.go`: new file covering
  - `ErrNoBaseMemoryForIncremental` is the canonical sentinel for
    fallback,
  - `resolveBaseSnapshotID` follows the commit chain across the
    `T → A → B → rollback A → C` scenario,
  - the runtime-binding label takes precedence over the
    create-time annotation when present.

### CubeShim changes

`CubeShim/shim/src/snapshot/cmd.rs` — extend `--snapshot-type` help
text to advertise `soft-dirty` alongside `full` / `incremental`.

### Test plan

Verified end-to-end on two distinct PVM hosts using the e2b
code-interpreter template image.

#### 1. Functional regression — does not break existing flows

Full snapshot/rollback/clone/run_code acceptance: PASS.

#### 2. Soft-dirty correctness — chain + rollback

Two scenarios exercised:

* **Scenario A**: `T → commit A → commit B → clone(B)` — verifies
  pre-A and pre-B markers (filesystem and Python kernel state)
  are both visible on a fresh clone of B. Catches the
  binding-update bug above.
* **Scenario B**: `T → A → B → rollback A → mutate → commit C →
  clone(C)` — the rollback-chain scenario. Verifies that
  clone(C) carries pre-A + post-rollback writes but **does
  not** see the rolled-back A→B writes, confirming C's
  reflink source is A (not T, not B).

Both scenarios pass. A 5×stability run produced 4/5 PASS; the
single failure was a `504 Gateway Time-out` on data-plane proxy
readiness during clone(C) — unrelated to soft-dirty correctness
(the snapshot itself was produced correctly; the new sandbox's
envd just lost the race with the proxy table) and reproduces on
the baseline acceptance pre-change.

#### 3. Disk-write reduction — the headline benefit

Measured *actual* per-commit written bytes via FIEMAP
`FIEMAP_EXTENT_SHARED` analysis: bytes in extents **without** the
SHARED flag are the only bytes this commit physically wrote;
SHARED extents are reflink pointers to the base file's blocks
(no fresh I/O).

5 consecutive commits on a 2 GB-RAM sandbox:

| Source | apparent | exclusive (actual writes) | shared (reflink, no I/O) |
|---|---|---|---|
| commit#1 | 2000 MB | 8.0 MB | 160.8 MB |
| commit#2 | 2000 MB | 1.7 MB | 167.1 MB |
| commit#3 | 2000 MB | 1.8 MB | 166.9 MB |
| commit#4 | 2000 MB | 1.7 MB | 167.1 MB |
| commit#5 | 2000 MB | 1.8 MB | 167.0 MB |
| **total** | 10000 MB | **14.9 MB** | 829.0 MB |

Baseline note: the apparent-size column overstates a full
snapshot's actual cost because the filesystem folds zero pages
into holes. The honest projected baseline is `n × allocated`
of the first commit's memory file = 5 × ~169 MB ≈ **844 MB**.
Soft-dirty actual writes: **14.9 MB**. **Disk-write saving:
98.2%**. Steady-state per-commit saving: ~95× (1.7 MB vs ~165 MB).

A second host produced 14.9 MB / 862.8 MB ≈ 98.3% — within
measurement noise.

CubeVmm logs match: `Soft-dirty snapshot: total=2097152000 bytes
(512000 pages), dirty=1769472 bytes (432 pages), savings=99.9%`.

#### 4. Unit tests

`go test ./Cubelet/services/cubebox/...` — passes for the new
tests (`TestErrNoBaseMemoryForIncrementalIsSentinel`,
`TestResolveBaseSnapshotIDFollowsCommitChain`,
`TestRuntimeBindingLabelOverridesCreateAnnotation`,
extended `TestBuildCubeRuntimeSnapshotArgsAlwaysIncludesSnapshotType`,
extended `TestNormalizeSnapshotTypeAcceptsKnownValues`).

### Operator-visible behaviour changes

* `CommitSandbox` now produces `--snapshot-type soft-dirty` by
  default (previously `incremental`). Existing snapshots are
  unaffected and remain restorable.
* When the previous snapshot has been deleted between commits,
  cubelet logs `CommitSandbox: base memory unavailable (...),
  falling back to full snapshot` at WARN, then performs a full
  snapshot. No request fails because of a missing base.
* Catalog files now carry `memory_kind=snapshot` for soft-dirty
  commits (vs `memory_kind=volume` for the fallback-to-full
  branch). This is the canonical signal for "did soft-dirty take
  effect".

### Notes for reviewers

* **Kernel requirement**: soft-dirty needs `CONFIG_MEM_SOFT_DIRTY=y`.
  Without it, hypervisor self-disables and falls back to
  `pagemap_anon` automatically (logs once per VMM process).
* **Filesystem requirement**: reflink. cubelet's cubecow store is
  already on a reflink-capable FS by design.
* **Forward compatibility**: `pagemap_anon` continues to work and
  is reachable via `--snapshot-type incremental`. Switching the
  default for `CommitSandbox` to soft-dirty is reversible — set
  the snapshot type back to `incremental` in the request to opt
  out per-commit.
