### PR TITLE
fix(python-sdk): run commands through envd process API

### DIFF
--- a/sdk/python/cubesandbox/_commands.py
+++ b/sdk/python/cubesandbox/_commands.py
@@ -152,7 +152,9 @@ class Commands:
             timeout=timeout,
         ) as resp:
             if resp.status_code >= 400:
-                raise RuntimeError(f"command failed: HTTP {resp.status_code}")
+                detail = _http_error_detail(resp)
+                suffix = f": {detail}" if detail else ""
+                raise RuntimeError(f"command failed: HTTP {resp.status_code}{suffix}")
             return _parse_process_start_stream(resp.iter_raw())
 
 
@@ -184,11 +186,7 @@ def _collect_process_events(events) -> CommandResult:
             if event.data.stderr:
                 stderr.append(event.data.stderr.decode("utf-8", "replace"))
         if event.HasField("end"):
-            if event.end.exit_code != 0:
-                exit_code = int(event.end.exit_code)
-            else:
-                parsed = _exit_code_from_status(event.end.status)
-                exit_code = 0 if parsed is None and event.end.exited else parsed
+            exit_code = _exit_code_from_end_event(event.end)
             if exit_code is None:
                 if event.end.error:
                     raise RuntimeError(f"process failed: {event.end.error}")
@@ -271,6 +269,27 @@ def _raise_connect_end_stream(raw: bytes) -> None:
     raise RuntimeError(message)
 
 
+def _http_error_detail(resp) -> str:
+    raw = resp.read()
+    if not raw:
+        return ""
+    text = raw.decode("utf-8", "replace").strip()
+    try:
+        payload = json.loads(text)
+    except Exception:
+        return text
+    if isinstance(payload, dict):
+        message = payload.get("message")
+        if isinstance(message, str) and message.strip():
+            return message.strip()
+        error = payload.get("error")
+        if isinstance(error, dict):
+            message = error.get("message")
+            if isinstance(message, str) and message.strip():
+                return message.strip()
+    return text
+
+
 def _decode_process_bytes(value: str) -> str:
     return base64.b64decode(value).decode("utf-8", "replace")
 
@@ -281,9 +300,37 @@ def _exit_code_from_status(status: object) -> int | None:
     match = re.search(r"(?:exit status|exited with code)\s+(-?\d+)", status)
     if match:
         return int(match.group(1))
+    signal_match = re.search(r"(?:signal|terminated by signal)\s+(\d+)", status)
+    if signal_match:
+        return 128 + int(signal_match.group(1))
     if status == "exited":
         return 0
     return None
+
+
+def _exit_code_from_end_event(end) -> int | None:
+    if _has_proto_field(end, "exit_code"):
+        return int(end.exit_code)
+
+    parsed = _exit_code_from_status(end.status)
+    if parsed is not None:
+        return parsed
+
+    # Some generated proto3 bindings do not expose scalar field presence.
+    # Preserve the legacy non-zero path while still allowing status strings to
+    # override an unset default value of 0.
+    if getattr(end, "exit_code", 0) != 0:
+        return int(end.exit_code)
+    if end.exited:
+        return 0
+    return None
+
+
+def _has_proto_field(message, field_name: str) -> bool:
+    try:
+        return bool(message.HasField(field_name))
+    except (AttributeError, ValueError):
+        return False
 
 
 def _basic_auth_user(user: str) -> str:

--- a/sdk/python/cubesandbox/_commands.py
+++ b/sdk/python/cubesandbox/_commands.py
@@ -2,11 +2,24 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from __future__ import annotations
+
+import base64
+import json
+import re
+import struct
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from .sandbox import Sandbox
+
+
+ENVD_PORT = 49983
+CONNECT_PROTOCOL_VERSION = "1"
+CONNECT_CONTENT_TYPE = "application/connect+json"
+CONNECT_END_STREAM_FLAG = 0x02
+CONNECT_COMPRESSED_FLAG = 0x01
+MAX_CONNECT_ENVELOPE_SIZE = 64 * 1024 * 1024
 
 
 @dataclass
@@ -20,32 +33,263 @@ class Commands:
     def __init__(self, sandbox: "Sandbox") -> None:
         self._sandbox = sandbox
 
-    def run(self, cmd: str, *, timeout: float | None = None, **kwargs) -> CommandResult:
-        """Run a shell command inside the sandbox via Python subprocess."""
-        code = f"""
-import subprocess as _sp
-_r = _sp.run({cmd!r}, shell=True, capture_output=True, text=True)
-import sys as _sys
-_sys.stdout.write(_r.stdout)
-_sys.stderr.write(_r.stderr)
-print(_r.returncode)
-"""
-        stdout_lines: list[str] = []
-        execution = self._sandbox.run_code(
-            code,
+    def run(
+        self,
+        cmd: str,
+        *,
+        timeout: float | None = None,
+        cwd: str | None = None,
+        envs: dict[str, str] | None = None,
+        env: dict[str, str] | None = None,
+        user: str | None = None,
+        **kwargs,
+    ) -> CommandResult:
+        """Run a shell command inside the sandbox through envd's process API.
+
+        This mirrors E2B's SDK path by using the generated envd ProcessClient
+        when the E2B protocol package is available. The hand-written Connect
+        fallback is kept for source-tree usage without the optional dependency.
+        """
+        process_envs = envs if envs is not None else (env or {})
+        try:
+            return self._run_with_e2b_connect(
+                cmd,
+                timeout=timeout,
+                cwd=cwd,
+                envs=process_envs,
+                user=user,
+            )
+        except ImportError:
+            return self._run_with_connect_fallback(
+                cmd,
+                timeout=timeout,
+                cwd=cwd,
+                envs=process_envs,
+                user=user,
+            )
+
+    def _run_with_e2b_connect(
+        self,
+        cmd: str,
+        *,
+        timeout: float | None,
+        cwd: str | None,
+        envs: dict[str, str],
+        user: str | None,
+    ) -> CommandResult:
+        from httpcore import ConnectionPool
+        from e2b.envd.process import process_connect, process_pb2
+
+        base_url, headers = _envd_rpc_base_url_and_headers(self._sandbox)
+        pool = ConnectionPool()
+        try:
+            rpc = process_connect.ProcessClient(
+                base_url,
+                pool=pool,
+                json=True,
+                headers=headers,
+            )
+            request = process_pb2.StartRequest(
+                process=process_pb2.ProcessConfig(
+                    cmd="/bin/bash",
+                    args=["-l", "-c", cmd],
+                    envs=envs,
+                    cwd=cwd or "",
+                ),
+                stdin=False,
+            )
+            events = rpc.start(
+                request,
+                headers=_user_headers(user),
+                timeout=timeout,
+                request_timeout=self._sandbox._config.request_timeout,
+            )
+            return _collect_process_events(events)
+        finally:
+            pool.close()
+
+    def _run_with_connect_fallback(
+        self,
+        cmd: str,
+        *,
+        timeout: float | None,
+        cwd: str | None,
+        envs: dict[str, str],
+        user: str | None,
+    ) -> CommandResult:
+        if self._sandbox._client is None:
+            self._sandbox._client = self._sandbox._build_data_client()
+
+        payload: dict = {
+            "process": {
+                "cmd": "/bin/bash",
+                "args": ["-l", "-c", cmd],
+                "envs": envs,
+            },
+            "stdin": False,
+        }
+        if cwd:
+            payload["process"]["cwd"] = cwd
+
+        headers = {
+            "Content-Type": CONNECT_CONTENT_TYPE,
+            "Connect-Protocol-Version": CONNECT_PROTOCOL_VERSION,
+            "Connect-Content-Encoding": "identity",
+        }
+        if timeout is not None:
+            headers["Connect-Timeout-Ms"] = str(int(timeout * 1000))
+        access_token = self._sandbox._data.get("envdAccessToken")
+        if access_token:
+            headers["X-Access-Token"] = access_token
+        headers.update(_user_headers(user))
+
+        url = f"http://{self._sandbox.get_host(ENVD_PORT)}/process.Process/Start"
+        with self._sandbox._client.stream(
+            "POST",
+            url,
+            content=_encode_connect_envelope(json.dumps(payload).encode("utf-8")),
+            headers=headers,
             timeout=timeout,
-            on_stdout=lambda m: stdout_lines.append(m.text),
-        )
-        # last stdout line is the exit code printed by the wrapper
-        all_stdout = "".join(stdout_lines)
-        lines = all_stdout.splitlines()
-        if lines and lines[-1].strip().lstrip("-").isdigit():
-            exit_code = int(lines[-1].strip())
-            stdout = "\n".join(lines[:-1])
-            if lines[:-1]:  # restore trailing newline if there was content
-                stdout += "\n"
-        else:
-            exit_code = 1 if execution.error else 0
-            stdout = all_stdout
-        stderr = "".join(execution.logs.stderr)
-        return CommandResult(stdout=stdout, stderr=stderr, exit_code=exit_code)
+        ) as resp:
+            if resp.status_code >= 400:
+                raise RuntimeError(f"command failed: HTTP {resp.status_code}")
+            return _parse_process_start_stream(resp.iter_raw())
+
+
+def _envd_rpc_base_url_and_headers(sandbox: "Sandbox") -> tuple[str, dict[str, str]]:
+    headers: dict[str, str] = {}
+    access_token = sandbox._data.get("envdAccessToken")
+    if access_token:
+        headers["X-Access-Token"] = access_token
+
+    if sandbox._config.proxy_node_ip:
+        headers["Host"] = sandbox.get_host(ENVD_PORT)
+        return f"http://{sandbox._config.proxy_node_ip}:{sandbox._config.proxy_port}", headers
+
+    return f"http://{sandbox.get_host(ENVD_PORT)}", headers
+
+
+def _collect_process_events(events) -> CommandResult:
+    stdout: list[str] = []
+    stderr: list[str] = []
+    exit_code: int | None = None
+
+    for response in events:
+        if not response.HasField("event"):
+            continue
+        event = response.event
+        if event.HasField("data"):
+            if event.data.stdout:
+                stdout.append(event.data.stdout.decode("utf-8", "replace"))
+            if event.data.stderr:
+                stderr.append(event.data.stderr.decode("utf-8", "replace"))
+        if event.HasField("end"):
+            if event.end.exit_code != 0:
+                exit_code = int(event.end.exit_code)
+            else:
+                parsed = _exit_code_from_status(event.end.status)
+                exit_code = 0 if parsed is None and event.end.exited else parsed
+            if exit_code is None:
+                if event.end.error:
+                    raise RuntimeError(f"process failed: {event.end.error}")
+                raise RuntimeError("process EndEvent missing exit code")
+
+    if exit_code is None:
+        raise RuntimeError("process stream ended without EndEvent")
+    return CommandResult(stdout="".join(stdout), stderr="".join(stderr), exit_code=exit_code)
+
+
+def _parse_process_start_stream(chunks) -> CommandResult:
+    stdout: list[str] = []
+    stderr: list[str] = []
+    exit_code: int | None = None
+    buffer = bytearray()
+
+    for chunk in chunks:
+        if not chunk:
+            continue
+        buffer.extend(chunk)
+        while len(buffer) >= 5:
+            flags = buffer[0]
+            size = struct.unpack(">I", buffer[1:5])[0]
+            if size > MAX_CONNECT_ENVELOPE_SIZE:
+                raise RuntimeError(f"Connect stream message too large: {size} bytes")
+            if len(buffer) < 5 + size:
+                break
+
+            raw = bytes(buffer[5 : 5 + size])
+            del buffer[: 5 + size]
+
+            if flags & CONNECT_COMPRESSED_FLAG:
+                raise RuntimeError("unsupported compressed Connect stream message")
+            if flags & CONNECT_END_STREAM_FLAG:
+                _raise_connect_end_stream(raw)
+                continue
+
+            event = json.loads(raw.decode("utf-8")).get("event") or {}
+            data = event.get("data") or {}
+            if data.get("stdout"):
+                stdout.append(_decode_process_bytes(data["stdout"]))
+            if data.get("stderr"):
+                stderr.append(_decode_process_bytes(data["stderr"]))
+            end = event.get("end")
+            if end is not None:
+                if "exitCode" in end:
+                    exit_code = int(end["exitCode"])
+                elif "exit_code" in end:
+                    exit_code = int(end["exit_code"])
+                elif _exit_code_from_status(end.get("status")) is not None:
+                    exit_code = _exit_code_from_status(end.get("status"))
+                elif end.get("error"):
+                    raise RuntimeError(f"process failed: {end['error']}")
+                else:
+                    raise RuntimeError("process EndEvent missing exit code")
+
+    if buffer:
+        raise RuntimeError("Connect stream ended with a partial message")
+    if exit_code is None:
+        raise RuntimeError("process stream ended without EndEvent")
+
+    return CommandResult(stdout="".join(stdout), stderr="".join(stderr), exit_code=exit_code)
+
+
+def _encode_connect_envelope(data: bytes, flags: int = 0) -> bytes:
+    return bytes([flags]) + struct.pack(">I", len(data)) + data
+
+
+def _raise_connect_end_stream(raw: bytes) -> None:
+    if not raw:
+        return
+    payload = json.loads(raw.decode("utf-8"))
+    error = payload.get("error")
+    if not error:
+        return
+    message = (error.get("message") or "Connect stream error").strip()
+    code = error.get("code")
+    if code:
+        raise RuntimeError(f"{code}: {message}")
+    raise RuntimeError(message)
+
+
+def _decode_process_bytes(value: str) -> str:
+    return base64.b64decode(value).decode("utf-8", "replace")
+
+
+def _exit_code_from_status(status: object) -> int | None:
+    if not isinstance(status, str):
+        return None
+    match = re.search(r"(?:exit status|exited with code)\s+(-?\d+)", status)
+    if match:
+        return int(match.group(1))
+    if status == "exited":
+        return 0
+    return None
+
+
+def _basic_auth_user(user: str) -> str:
+    token = base64.b64encode(f"{user}:".encode("utf-8")).decode("utf-8")
+    return f"Basic {token}"
+
+
+def _user_headers(user: str | None) -> dict[str, str]:
+    return {"Authorization": _basic_auth_user(user)} if user else {}

--- a/sdk/python/cubesandbox/_commands.py
+++ b/sdk/python/cubesandbox/_commands.py
@@ -49,6 +49,9 @@ class Commands:
         This mirrors E2B's SDK path by using the generated envd ProcessClient
         when the E2B protocol package is available. The hand-written Connect
         fallback is kept for source-tree usage without the optional dependency.
+
+        Args:
+            env: Alias for envs, matching the E2B SDK command API.
         """
         process_envs = envs if envs is not None else (env or {})
         try:
@@ -270,6 +273,8 @@ def _raise_connect_end_stream(raw: bytes) -> None:
 
 
 def _http_error_detail(resp) -> str:
+    # Only called on HTTP error responses. Reading the body here is safe because
+    # successful command streams are parsed incrementally by iter_raw().
     raw = resp.read()
     if not raw:
         return ""

--- a/sdk/python/cubesandbox/_filesystem.py
+++ b/sdk/python/cubesandbox/_filesystem.py
@@ -2,7 +2,10 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from __future__ import annotations
+
 from typing import TYPE_CHECKING
+
+from ._commands import ENVD_PORT
 
 if TYPE_CHECKING:
     from .sandbox import Sandbox
@@ -12,8 +15,64 @@ class Filesystem:
     def __init__(self, sandbox: "Sandbox") -> None:
         self._sandbox = sandbox
 
-    def read(self, path: str) -> str:
-        result = self._sandbox.run_code(f"open({path!r}).read()")
-        if result.error:
-            raise IOError(f"Failed to read {path}: {result.error.value}")
-        return result.text or ""
+    def read(self, path: str, *, user: str | None = None) -> str:
+        """Read a file through envd's HTTP file API."""
+        if self._sandbox._client is None:
+            self._sandbox._client = self._sandbox._build_data_client()
+
+        headers = {}
+        access_token = self._sandbox._data.get("envdAccessToken")
+        if access_token:
+            headers["X-Access-Token"] = access_token
+
+        resp = self._sandbox._client.get(
+            f"http://{self._sandbox.get_host(ENVD_PORT)}/files",
+            params={"path": path, **({"username": user} if user else {})},
+            headers=headers,
+        )
+        if resp.status_code != 200:
+            message = resp.text or f"HTTP {resp.status_code}"
+            try:
+                body = resp.json()
+                message = body.get("message") or body.get("detail") or message
+            except Exception:  # noqa: BLE001 - best-effort error extraction
+                pass
+            raise IOError(f"Failed to read {path}: {message}")
+        return resp.text
+
+    def write(self, path: str, data: str | bytes, *, user: str | None = None) -> None:
+        """Write a file through envd's HTTP file API."""
+        if self._sandbox._client is None:
+            self._sandbox._client = self._sandbox._build_data_client()
+
+        headers = {"Content-Type": "application/octet-stream"}
+        access_token = self._sandbox._data.get("envdAccessToken")
+        if access_token:
+            headers["X-Access-Token"] = access_token
+
+        body = data.encode("utf-8") if isinstance(data, str) else data
+        params = {"path": path, **({"username": user} if user else {})}
+        resp = self._sandbox._client.post(
+            f"http://{self._sandbox.get_host(ENVD_PORT)}/files",
+            params=params,
+            headers=headers,
+            content=body,
+        )
+        if resp.status_code >= 400 and "multipart/form-data" in resp.text:
+            multipart_headers = {}
+            if access_token:
+                multipart_headers["X-Access-Token"] = access_token
+            resp = self._sandbox._client.post(
+                f"http://{self._sandbox.get_host(ENVD_PORT)}/files",
+                params=params,
+                headers=multipart_headers,
+                files={"file": (path, body)},
+            )
+        if resp.status_code >= 400:
+            message = resp.text or f"HTTP {resp.status_code}"
+            try:
+                payload = resp.json()
+                message = payload.get("message") or payload.get("detail") or message
+            except Exception:  # noqa: BLE001 - best-effort error extraction
+                pass
+            raise IOError(f"Failed to write {path}: {message}")

--- a/sdk/python/cubesandbox/_filesystem.py
+++ b/sdk/python/cubesandbox/_filesystem.py
@@ -58,7 +58,7 @@ class Filesystem:
             headers=headers,
             content=body,
         )
-        if resp.status_code >= 400 and "multipart/form-data" in resp.text:
+        if resp.status_code >= 400:
             multipart_headers = {}
             if access_token:
                 multipart_headers["X-Access-Token"] = access_token

--- a/sdk/python/cubesandbox/sandbox.py
+++ b/sdk/python/cubesandbox/sandbox.py
@@ -254,7 +254,7 @@ class Sandbox:
             ApiError: If the execute endpoint returns HTTP 4xx/5xx.
         """
         if self._client is None:
-            self._client = build_client(self._config)
+            self._client = self._build_data_client()
 
         url = f"http://{self.get_host(JUPYTER_PORT)}/execute"
         payload = {
@@ -644,3 +644,7 @@ class Sandbox:
         s = requests.Session()
         s.headers.update({"Content-Type": "application/json"})
         return s
+
+    def _build_data_client(self) -> httpx.Client:
+        """Build an HTTP client for CubeProxy-routed sandbox data-plane APIs."""
+        return build_client(self._config)

--- a/sdk/python/tests/test_sandbox.py
+++ b/sdk/python/tests/test_sandbox.py
@@ -20,7 +20,7 @@ import httpx
 import pytest
 
 from cubesandbox import CommandResult, Template
-from cubesandbox._commands import Commands
+from cubesandbox._commands import Commands, _collect_process_events
 from cubesandbox._config import Config
 from cubesandbox._exceptions import (
     ApiError,
@@ -657,6 +657,55 @@ class TestCommands:
             result = sb.commands.run("false")
         assert result.exit_code == 7
 
+    def test_run_exit_code_from_signal_status(self):
+        sb = make_sandbox()
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            body = b"".join(
+                [
+                    connect_envelope(0, '{"event":{"start":{"pid":123}}}'),
+                    connect_envelope(
+                        0,
+                        '{"event":{"end":{"exited":false,"status":"signal 9 (SIGKILL)"}}}',
+                    ),
+                    connect_envelope(0x02, "{}"),
+                ]
+            )
+            return httpx.Response(200, stream=httpx.ByteStream(body))
+
+        client = httpx.Client(transport=httpx.MockTransport(handler))
+        with (
+            patch.object(Commands, "_run_with_e2b_connect", side_effect=ImportError),
+            patch.object(sb, "_build_data_client", return_value=client),
+        ):
+            result = sb.commands.run("kill")
+        assert result.exit_code == 137
+
+    def test_collect_process_events_prefers_status_when_exit_code_unset(self):
+        class End:
+            exit_code = 0
+            status = "exit status 7"
+            exited = True
+            error = ""
+
+            def HasField(self, name):
+                return False
+
+        class Event:
+            end = End()
+
+            def HasField(self, name):
+                return name == "end"
+
+        class Response:
+            event = Event()
+
+            def HasField(self, name):
+                return name == "event"
+
+        result = _collect_process_events([Response()])
+        assert result.exit_code == 7
+
     def test_run_timeout_forwarded(self):
         sb = make_sandbox()
         seen = {}
@@ -679,6 +728,20 @@ class TestCommands:
         ):
             sb.commands.run("sleep 1", timeout=5.0)
         assert seen["headers"]["connect-timeout-ms"] == "5000"
+
+    def test_run_http_error_includes_response_body(self):
+        sb = make_sandbox()
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(400, json={"message": "sandbox is not ready"})
+
+        client = httpx.Client(transport=httpx.MockTransport(handler))
+        with (
+            patch.object(Commands, "_run_with_e2b_connect", side_effect=ImportError),
+            patch.object(sb, "_build_data_client", return_value=client),
+        ):
+            with pytest.raises(RuntimeError, match="HTTP 400: sandbox is not ready"):
+                sb.commands.run("echo hello")
 
     def test_commands_property(self):
         assert isinstance(make_sandbox().commands, Commands)

--- a/sdk/python/tests/test_sandbox.py
+++ b/sdk/python/tests/test_sandbox.py
@@ -9,11 +9,14 @@ so no real network is needed.
 
 from __future__ import annotations
 
+import base64
 import json
+import struct
 import threading
 import time
 from unittest.mock import MagicMock, patch
 
+import httpx
 import pytest
 
 from cubesandbox import CommandResult, Template
@@ -64,6 +67,20 @@ def mock_response(body=None, status: int = 200):
 def make_sandbox(**data_overrides) -> Sandbox:
     d = {**SANDBOX_DATA, **data_overrides}
     return Sandbox(d, config=make_config())
+
+
+def connect_envelope(flags: int, payload: str) -> bytes:
+    raw = payload.encode("utf-8")
+    return bytes([flags]) + struct.pack(">I", len(raw)) + raw
+
+
+def decode_connect_payload(raw: bytes) -> dict:
+    assert len(raw) >= 5
+    flags = raw[0]
+    size = struct.unpack(">I", raw[1:5])[0]
+    assert flags == 0
+    assert len(raw) == 5 + size
+    return json.loads(raw[5:].decode("utf-8"))
 
 
 # ── POST /sandboxes ───────────────────────────────────────────────────────────
@@ -558,34 +575,110 @@ class TestConfig:
 class TestCommands:
     def test_run_success(self):
         sb = make_sandbox()
-        def fake_run(code, *, timeout=None, on_stdout=None, **kw):
-            if on_stdout:
-                on_stdout(OutputMessage(text="hello\nworld\n0\n"))
-            return Execution(logs=Logs(stdout=["hello\nworld\n0\n"], stderr=[]))
-        with patch.object(sb, "run_code", side_effect=fake_run):
-            result = sb.commands.run("echo hello")
+        seen = {}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            seen["method"] = request.method
+            seen["host"] = request.url.host
+            seen["path"] = request.url.path
+            seen["headers"] = request.headers
+            seen["payload"] = decode_connect_payload(request.content)
+            stdout = base64.b64encode(b"hello\nworld\n").decode()
+            body = b"".join(
+                [
+                    connect_envelope(0, '{"event":{"start":{"pid":123}}}'),
+                    connect_envelope(0, json.dumps({"event": {"data": {"stdout": stdout}}})),
+                    connect_envelope(0, '{"event":{"end":{"exitCode":0,"exited":true}}}'),
+                    connect_envelope(0x02, "{}"),
+                ]
+            )
+            return httpx.Response(200, stream=httpx.ByteStream(body))
+
+        client = httpx.Client(transport=httpx.MockTransport(handler))
+        with (
+            patch.object(Commands, "_run_with_e2b_connect", side_effect=ImportError),
+            patch.object(sb, "_build_data_client", return_value=client),
+        ):
+            result = sb.commands.run("echo hello", cwd="/work", env={"A": "B"}, user="root")
+
         assert result.stdout == "hello\nworld\n"
         assert result.exit_code == 0
+        assert seen["method"] == "POST"
+        assert seen["host"] == f"49983-{SANDBOX_ID}.{DOMAIN}"
+        assert seen["path"] == "/process.Process/Start"
+        assert seen["headers"]["content-type"] == "application/connect+json"
+        assert seen["headers"]["connect-protocol-version"] == "1"
+        assert seen["headers"]["connect-content-encoding"] == "identity"
+        assert seen["headers"]["authorization"] == "Basic cm9vdDo="
+        assert seen["payload"]["process"]["cmd"] == "/bin/bash"
+        assert seen["payload"]["process"]["cwd"] == "/work"
+        assert seen["payload"]["process"]["envs"] == {"A": "B"}
+        assert seen["payload"]["process"]["args"] == ["-l", "-c", "echo hello"]
 
     def test_run_exit_code_nonzero(self):
         sb = make_sandbox()
-        def fake_run(code, *, timeout=None, on_stdout=None, **kw):
-            if on_stdout:
-                on_stdout(OutputMessage(text="1\n"))
-            return Execution(logs=Logs(stdout=["1\n"], stderr=[]))
-        with patch.object(sb, "run_code", side_effect=fake_run):
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            body = b"".join(
+                [
+                    connect_envelope(0, '{"event":{"start":{"pid":123}}}'),
+                    connect_envelope(0, '{"event":{"end":{"exitCode":1,"exited":true}}}'),
+                    connect_envelope(0x02, "{}"),
+                ]
+            )
+            return httpx.Response(200, stream=httpx.ByteStream(body))
+
+        client = httpx.Client(transport=httpx.MockTransport(handler))
+        with (
+            patch.object(Commands, "_run_with_e2b_connect", side_effect=ImportError),
+            patch.object(sb, "_build_data_client", return_value=client),
+        ):
             result = sb.commands.run("false")
         assert result.exit_code == 1
 
+    def test_run_exit_code_from_status_string(self):
+        sb = make_sandbox()
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            body = b"".join(
+                [
+                    connect_envelope(0, '{"event":{"start":{"pid":123}}}'),
+                    connect_envelope(0, '{"event":{"end":{"exited":true,"status":"exit status 7"}}}'),
+                    connect_envelope(0x02, "{}"),
+                ]
+            )
+            return httpx.Response(200, stream=httpx.ByteStream(body))
+
+        client = httpx.Client(transport=httpx.MockTransport(handler))
+        with (
+            patch.object(Commands, "_run_with_e2b_connect", side_effect=ImportError),
+            patch.object(sb, "_build_data_client", return_value=client),
+        ):
+            result = sb.commands.run("false")
+        assert result.exit_code == 7
+
     def test_run_timeout_forwarded(self):
         sb = make_sandbox()
-        def fake_run(code, *, timeout=None, on_stdout=None, **kw):
-            if on_stdout:
-                on_stdout(OutputMessage(text="ok\n0\n"))
-            return Execution(logs=Logs(stdout=["ok\n0\n"], stderr=[]))
-        with patch.object(sb, "run_code", side_effect=fake_run) as m:
+        seen = {}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            seen["headers"] = request.headers
+            body = b"".join(
+                [
+                    connect_envelope(0, '{"event":{"start":{"pid":123}}}'),
+                    connect_envelope(0, '{"event":{"end":{"exitCode":0,"exited":true}}}'),
+                    connect_envelope(0x02, "{}"),
+                ]
+            )
+            return httpx.Response(200, stream=httpx.ByteStream(body))
+
+        client = httpx.Client(transport=httpx.MockTransport(handler))
+        with (
+            patch.object(Commands, "_run_with_e2b_connect", side_effect=ImportError),
+            patch.object(sb, "_build_data_client", return_value=client),
+        ):
             sb.commands.run("sleep 1", timeout=5.0)
-        assert m.call_args.kwargs.get("timeout") == 5.0
+        assert seen["headers"]["connect-timeout-ms"] == "5000"
 
     def test_commands_property(self):
         assert isinstance(make_sandbox().commands, Commands)
@@ -602,25 +695,96 @@ class TestCommands:
 class TestFilesystem:
     def test_read_success(self):
         sb = make_sandbox()
-        mock_exec = Execution(results=[Result(text="file content", is_main_result=True)])
-        with patch.object(sb, "run_code", return_value=mock_exec):
-            content = sb.files.read("/tmp/foo.txt")
+        seen = {}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            seen["method"] = request.method
+            seen["host"] = request.url.host
+            seen["path"] = request.url.path
+            seen["query_path"] = request.url.params.get("path")
+            seen["query_user"] = request.url.params.get("username")
+            return httpx.Response(200, text="file content")
+
+        client = httpx.Client(transport=httpx.MockTransport(handler))
+        with patch.object(sb, "_build_data_client", return_value=client):
+            content = sb.files.read("/tmp/foo.txt", user="root")
         assert content == "file content"
+        assert seen["method"] == "GET"
+        assert seen["host"] == f"49983-{SANDBOX_ID}.{DOMAIN}"
+        assert seen["path"] == "/files"
+        assert seen["query_path"] == "/tmp/foo.txt"
+        assert seen["query_user"] == "root"
 
     def test_read_empty_when_no_text(self):
         sb = make_sandbox()
-        with patch.object(sb, "run_code", return_value=Execution()):
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, text="")
+
+        client = httpx.Client(transport=httpx.MockTransport(handler))
+        with patch.object(sb, "_build_data_client", return_value=client):
             content = sb.files.read("/tmp/empty.txt")
         assert content == ""
 
     def test_read_raises_on_error(self):
         sb = make_sandbox()
-        mock_exec = Execution(
-            error=ExecutionError("FileNotFoundError", "No such file or directory"),
-        )
-        with patch.object(sb, "run_code", return_value=mock_exec):
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(404, json={"message": "No such file or directory"})
+
+        client = httpx.Client(transport=httpx.MockTransport(handler))
+        with patch.object(sb, "_build_data_client", return_value=client):
             with pytest.raises(IOError, match="Failed to read"):
                 sb.files.read("/tmp/missing.txt")
+
+    def test_write_uses_envd_file_api(self):
+        sb = make_sandbox()
+        seen = {}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            seen["method"] = request.method
+            seen["host"] = request.url.host
+            seen["path"] = request.url.path
+            seen["query_path"] = request.url.params.get("path")
+            seen["query_user"] = request.url.params.get("username")
+            seen["content_type"] = request.headers.get("content-type")
+            seen["body"] = request.content
+            return httpx.Response(200, json=[{"path": "/tmp/foo.txt"}])
+
+        client = httpx.Client(transport=httpx.MockTransport(handler))
+        with patch.object(sb, "_build_data_client", return_value=client):
+            sb.files.write("/tmp/foo.txt", "file content", user="root")
+
+        assert seen["method"] == "POST"
+        assert seen["host"] == f"49983-{SANDBOX_ID}.{DOMAIN}"
+        assert seen["path"] == "/files"
+        assert seen["query_path"] == "/tmp/foo.txt"
+        assert seen["query_user"] == "root"
+        assert seen["content_type"] == "application/octet-stream"
+        assert seen["body"] == b"file content"
+
+    def test_write_falls_back_to_multipart_for_old_envd(self):
+        sb = make_sandbox()
+        seen = {"calls": 0}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            seen["calls"] += 1
+            if seen["calls"] == 1:
+                return httpx.Response(
+                    400,
+                    text="error parsing multipart form: request Content-Type isn't multipart/form-data",
+                )
+            seen["content_type"] = request.headers.get("content-type")
+            seen["body"] = request.content
+            return httpx.Response(200, json=[{"path": "/tmp/foo.txt"}])
+
+        client = httpx.Client(transport=httpx.MockTransport(handler))
+        with patch.object(sb, "_build_data_client", return_value=client):
+            sb.files.write("/tmp/foo.txt", "file content", user="root")
+
+        assert seen["calls"] == 2
+        assert "multipart/form-data" in seen["content_type"]
+        assert b"file content" in seen["body"]
 
     def test_files_property(self):
         assert isinstance(make_sandbox().files, Filesystem)

--- a/sdk/python/tests/test_sandbox.py
+++ b/sdk/python/tests/test_sandbox.py
@@ -615,6 +615,32 @@ class TestCommands:
         assert seen["payload"]["process"]["envs"] == {"A": "B"}
         assert seen["payload"]["process"]["args"] == ["-l", "-c", "echo hello"]
 
+    def test_run_stderr_event(self):
+        sb = make_sandbox()
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            stderr = base64.b64encode(b"warn\nerror\n").decode()
+            body = b"".join(
+                [
+                    connect_envelope(0, '{"event":{"start":{"pid":123}}}'),
+                    connect_envelope(0, json.dumps({"event": {"data": {"stderr": stderr}}})),
+                    connect_envelope(0, '{"event":{"end":{"exitCode":0,"exited":true}}}'),
+                    connect_envelope(0x02, "{}"),
+                ]
+            )
+            return httpx.Response(200, stream=httpx.ByteStream(body))
+
+        client = httpx.Client(transport=httpx.MockTransport(handler))
+        with (
+            patch.object(Commands, "_run_with_e2b_connect", side_effect=ImportError),
+            patch.object(sb, "_build_data_client", return_value=client),
+        ):
+            result = sb.commands.run("echo warn >&2")
+
+        assert result.stdout == ""
+        assert result.stderr == "warn\nerror\n"
+        assert result.exit_code == 0
+
     def test_run_exit_code_nonzero(self):
         sb = make_sandbox()
 
@@ -834,8 +860,8 @@ class TestFilesystem:
             seen["calls"] += 1
             if seen["calls"] == 1:
                 return httpx.Response(
-                    400,
-                    text="error parsing multipart form: request Content-Type isn't multipart/form-data",
+                    415,
+                    text="unsupported media type",
                 )
             seen["content_type"] = request.headers.get("content-type")
             seen["body"] = request.content


### PR DESCRIPTION
## Summary

- Route Python SDK `commands.run()` through envd `process.Process/Start` instead of wrapping `subprocess.run()` with `run_code()`.
- Preserve stdout/stderr/exit code boundaries by parsing envd Connect stream events directly.
- Move Python filesystem read/write helpers to envd `/files` APIs.
- Add unit coverage for Connect envelope parsing, command execution, timeouts, and filesystem read/write behavior.

## Motivation

The previous Python SDK command runner serialized command stdout and the exit code over the same stdout stream. When command stdout did not end with a newline, the exit code could be appended to the stdout tail, corrupting user output silently.

Using envd's process API aligns the Python SDK with the Go SDK implementation and avoids guessing the exit code from stdout contents.

## Tests

- `python3 -m pytest tests/test_sandbox.py -q`
  - Passed on `cubesandbox002` under `/data/cubesandbox/code/max_test/CubeSandbox/sdk/python`
  - Result: `114 passed in 0.34s`


