### PR TITLE
ci(workflows): add default shell bash and install unzip; optimize artifact retrieval

### DIFF
--- a/.github/workflows/build-vmlinux.yml
+++ b/.github/workflows/build-vmlinux.yml
@@ -12,6 +12,10 @@ env:
   KERNEL_ARCHIVE_URL: https://gitee.com/OpenCloudOS/OpenCloudOS-Kernel/repository/archive/6.6.119-49.6.zip
   VMLINUX_CACHE_PATH: kernel-cache/vmlinux
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   build:
     runs-on: arc-runner-set-16c32g-containerd
@@ -37,7 +41,7 @@ jobs:
           apt-get update
           apt-get install -y file sudo build-essential git bc bison flex \
             libelf-dev libssl-dev libncurses-dev dwarves cpio kmod \
-            fakeroot rsync dpkg-dev debhelper wget curl ca-certificates python3
+            fakeroot rsync dpkg-dev debhelper wget curl ca-certificates python3 unzip
 
       - name: Restore cached vmlinux
         id: restore_vmlinux

--- a/.github/workflows/release-one-click.yml
+++ b/.github/workflows/release-one-click.yml
@@ -162,9 +162,8 @@ jobs:
           VMLINUX_ARTIFACT_NAME: ${{ steps.vmlinux_metadata.outputs.artifact_name }}
         run: |
           get_latest_artifact_url() {
-            local json
-            json="$(gh api --paginate "/repos/${GITHUB_REPOSITORY}/actions/artifacts?per_page=100")"
-            python3 -c 'import json, sys; artifact_name = sys.argv[1]; data = json.load(sys.stdin); artifacts = [artifact for artifact in data.get("artifacts", []) if artifact.get("name") == artifact_name and not artifact.get("expired", False)]; artifacts.sort(key=lambda artifact: artifact.get("created_at", ""), reverse=True); print(artifacts[0].get("archive_download_url", "") if artifacts else "")' "${VMLINUX_ARTIFACT_NAME}" <<<"${json}"
+            gh api --paginate --slurp "/repos/${GITHUB_REPOSITORY}/actions/artifacts?per_page=100" | \
+              python3 -c 'import json, sys; artifact_name = sys.argv[1]; artifacts = [artifact for page in json.load(sys.stdin) for artifact in page.get("artifacts", []) if artifact.get("name") == artifact_name and not artifact.get("expired", False)]; artifacts.sort(key=lambda artifact: artifact.get("created_at", ""), reverse=True); print(artifacts[0].get("archive_download_url", "") if artifacts else "")' "${VMLINUX_ARTIFACT_NAME}"
           }
 
           artifact_url="$(get_latest_artifact_url)"


### PR DESCRIPTION

- Set default shell to bash for build-vmlinux workflow
- Install unzip package for build-vmlinux workflow
- Refactor artifact fetching using --slurp flag for better pagination handling