### PR TITLE
chore: bump Python SDK version to 0.2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
   <a href="https://github.com/tencentcloud/CubeSandbox/issues"><img src="https://img.shields.io/github/issues/tencentcloud/cubesandbox" alt="GitHub Issues" /></a>
   <a href="./LICENSE"><img src="https://img.shields.io/badge/License-Apache_2.0-green" alt="Apache 2.0 License" /></a>
   <a href="./CONTRIBUTING.md"><img src="https://img.shields.io/badge/PRs-welcome-brightgreen" alt="PRs Welcome" /></a>
+  <a href="https://pypi.org/project/cubesandbox/"><img src="https://img.shields.io/badge/PyPI-0.2.1-blue" alt="PyPI Version" /></a>
 </p>
 
 <p align="center">
@@ -220,6 +221,7 @@ Install the Python SDK:
 
 ```bash
 yum install -y python3 python3-pip
+pip install cubesandbox
 pip install e2b-code-interpreter
 ```
 

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -6,7 +6,7 @@
   <a href="https://github.com/TencentCloud/CubeSandbox"><img src="https://img.shields.io/badge/CubeSandbox-GitHub-blue" alt="CubeSandbox" /></a>
   <a href="../../LICENSE"><img src="https://img.shields.io/badge/License-Apache_2.0-green" alt="Apache 2.0" /></a>
   <img src="https://img.shields.io/badge/Python-3.9%2B-blue" alt="Python 3.9+" />
-  <img src="https://img.shields.io/badge/version-0.1.0-orange" alt="v0.1.0" />
+  <img src="https://img.shields.io/badge/version-0.2.1-orange" alt="v0.2.1" />
 </p>
 
 ---
@@ -17,13 +17,8 @@ and control the full sandbox lifecycle — including pause/resume with memory sn
 
 ## Installation
 
-> **Note:** `cubesandbox` is not yet published to PyPI.
-> Install from source until the first release is available:
-
 ```bash
-git clone https://github.com/TencentCloud/CubeSandbox.git
-cd CubeSandbox/sdk/python
-pip install -e .
+pip install cubesandbox
 ```
 
 ## Quick Start

--- a/sdk/python/cubesandbox/__init__.py
+++ b/sdk/python/cubesandbox/__init__.py
@@ -27,4 +27,4 @@ __all__ = [
     "TemplateBuild",
 ]
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "cubesandbox"
-version = "0.2.0"
+version = "0.2.1"
 description = "Python SDK for CubeSandbox"
 license = { text = "Apache-2.0" }
 requires-python = ">=3.9"


### PR DESCRIPTION
## Changes

- `README.md`: add PyPI `0.2.1` version badge; add `pip install cubesandbox` to Installation section
- `sdk/python/pyproject.toml`: version `0.2.0` → `0.2.1`
- `sdk/python/cubesandbox/__init__.py`: `__version__` `0.2.0` → `0.2.1`