### PR TITLE
fix(cubelet): use tomlext.Duration for NodeStatusUpdateFrequency

### DIFF
--- a/Cubelet/pkg/cubelet/cubelet.go
+++ b/Cubelet/pkg/cubelet/cubelet.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/utils/clock"
 
 	cubeimages "github.com/tencentcloud/CubeSandbox/Cubelet/internal/cube/server/images"
+	"github.com/tencentcloud/CubeSandbox/Cubelet/internal/tomlext"
 )
 
 const (
@@ -43,7 +44,7 @@ type KubeletConfig struct {
 
 	DisableCreateNode bool `toml:"disable_create_node,omitempty"`
 
-	NodeStatusUpdateFrequency time.Duration `toml:"node_status_update_frequency,omitempty"`
+	NodeStatusUpdateFrequency tomlext.Duration `toml:"node_status_update_frequency,omitempty"`
 }
 
 func DefaultCubeletConfig() *KubeletConfig {
@@ -51,7 +52,7 @@ func DefaultCubeletConfig() *KubeletConfig {
 		Insecurity:                true,
 		ResyncInterval:            10 * time.Hour,
 		DisableCreateNode:         false,
-		NodeStatusUpdateFrequency: 10 * time.Second,
+		NodeStatusUpdateFrequency: tomlext.FromStdTime(10 * time.Second),
 	}
 }
 
@@ -149,8 +150,8 @@ func NewCubelet(
 		masterClient:              client,
 		config:                    mconfig,
 		registerNode:              !mconfig.DisableCreateNode,
-		nodeStatusUpdateFrequency: mconfig.NodeStatusUpdateFrequency,
-		nodeStatusReportFrequency: mconfig.NodeStatusUpdateFrequency,
+		nodeStatusUpdateFrequency: tomlext.ToStdTime(mconfig.NodeStatusUpdateFrequency),
+		nodeStatusReportFrequency: tomlext.ToStdTime(mconfig.NodeStatusUpdateFrequency),
 
 		criImage:           criImage,
 		rtManager:          rtManager,

--- a/Cubelet/plugins/controller/cubelet_plugin.go
+++ b/Cubelet/plugins/controller/cubelet_plugin.go
@@ -11,6 +11,7 @@ import (
 	"github.com/containerd/plugin"
 	"github.com/containerd/plugin/registry"
 	"github.com/tencentcloud/CubeSandbox/Cubelet/internal/cube/server/images"
+	"github.com/tencentcloud/CubeSandbox/Cubelet/internal/tomlext"
 	"github.com/tencentcloud/CubeSandbox/Cubelet/pkg/config"
 	"github.com/tencentcloud/CubeSandbox/Cubelet/pkg/constants"
 	"github.com/tencentcloud/CubeSandbox/Cubelet/pkg/controller"
@@ -67,7 +68,7 @@ func registerCubelet() {
 			metaCfg := config.GetConfig().MetaServerConfig
 			var client *masterclient.Client
 			if metaCfg != nil && metaCfg.MetaServerEndpoint != "" {
-				client = masterclient.New("http://"+metaCfg.MetaServerEndpoint, cfg.NodeStatusUpdateFrequency)
+				client = masterclient.New("http://"+metaCfg.MetaServerEndpoint, tomlext.ToStdTime(cfg.NodeStatusUpdateFrequency))
 			}
 
 			var networkAgentClient networkagentclient.Client = networkagentclient.NewNoopClient()


### PR DESCRIPTION
time.Duration cannot be unmarshaled from a TOML string (e.g. "10s") directly. Switch the config field to tomlext.Duration so values like node_status_update_frequency = "10s" parse correctly, and convert back to time.Duration at the call sites.