### PR TITLE
fix(shim): keep readiness handshake by not redirecting stdout (fd 1)

### DIFF
--- a/CubeShim/shim/src/log/mod.rs
+++ b/CubeShim/shim/src/log/mod.rs
@@ -146,8 +146,16 @@ impl Log {
 
         let (reader, writer) = UnixDatagram::pair().unwrap();
 
-        dup2(writer.as_raw_fd(), std::io::stdout().as_raw_fd()).expect("dup stdout failed");
-        dup2(writer.as_raw_fd(), std::io::stderr().as_raw_fd()).expect("dup stdout failed");
+        // Only take over stderr here. Do NOT dup2 over stdout (fd 1): in the shim
+        // daemon, fd 1 is the readiness pipe that containerd-shim's parent `start`
+        // process copies until EOF. Closing it before the ttrpc server has bound and
+        // started listening makes the parent return the socket address too early, so
+        // containerd dials a not-yet-bound socket and fails with
+        // "failed to create TTRPC connection: ... connect: no such file or directory".
+        // The crate's signal_server_started() runs dup2(STDERR->STDOUT) only after
+        // server.start(), which then redirects stdout onto this datagram for us while
+        // preserving the readiness handshake.
+        dup2(writer.as_raw_fd(), std::io::stderr().as_raw_fd()).expect("dup stderr failed");
         mem::forget(writer);
 
         tokio::spawn(Self::consumer(sender.clone(), receiver));

--- a/CubeShim/shim/src/sandbox/sb.rs
+++ b/CubeShim/shim/src/sandbox/sb.rs
@@ -1274,7 +1274,11 @@ impl SandBox {
         if let Some(ch_arc) = self.ch.as_ref() {
             let ch = ch_arc.lock().await;
             while let Ok(ev) = ch.try_wait_notify() {
-                infof!(self.log, "rollback: drained stale hypervisor event {:?}", ev);
+                infof!(
+                    self.log,
+                    "rollback: drained stale hypervisor event {:?}",
+                    ev
+                );
             }
         }
 


### PR DESCRIPTION
### Summary

The shim daemon could finish its parent-side `start` handshake **before**
its ttrpc server had bound and started listening on the control socket.
When that happened, the caller dialed a socket that did not exist yet and
the container failed to start:

```
failed to start shim: start failed: failed to create TTRPC connection:
dial unix /run/containerd/s/<id>: connect: no such file or directory
```

This was intermittent and more likely under load or on slower hosts, and a
failed start could leave an **orphaned shim process** still holding the
listening socket and host resources.

### Root cause

`Log::new()` runs very early during shim-daemon startup and redirected
**both** stdout (fd 1) and stderr (fd 2) onto an internal `UnixDatagram`
via `dup2`:

```rust
dup2(writer.as_raw_fd(), std::io::stdout().as_raw_fd()).expect("dup stdout failed");
dup2(writer.as_raw_fd(), std::io::stderr().as_raw_fd()).expect("dup stdout failed");
```

In the `containerd-shim` bootstrap protocol, **fd 1 of the daemon is the
readiness pipe**. The parent `start` process copies the daemon's stdout to
its own stdout until EOF; reaching EOF is what tells the parent the daemon
is ready, after which the parent prints the bound socket address back to
the caller.

By `dup2`-ing over fd 1 before the ttrpc server was listening, `Log::new()`
closed the original pipe write-end early. The parent then observed EOF
prematurely and reported the socket as ready while the server had not yet
called `bind()/listen()`. The caller dialed a non-existent socket → the
`ENOENT` ("no such file or directory") TTRPC failure above.

### Fix

Take over **only stderr (fd 2)** in `Log::new()`. The `containerd-shim`
crate already calls `signal_server_started()` after `server.start()`,
which performs `dup2(STDERR -> STDOUT)` **once the ttrpc server is
listening**. That:

- redirects stdout onto our logging datagram (logging still captured), and
- closes the readiness pipe at the correct moment, so the parent reports
  readiness only after the socket is actually bound.

The fix contains no retries, sleeps, or polling — it removes the premature
fd-1 redirect and lets the crate's intended handshake run, eliminating the
race at its source.

### Verification

Ran a create/delete stress loop against the built shim:

| Round | Config | Success | TTRPC failures | Leaked shims | Orphaned sockets |
|---|---|---|---|---|---|
| 1 | 20 concurrent × 200 create+delete | 100% | 0 | 0 | 0 |
| 2 | 50 concurrent × 500 create+delete | 75.8% | 0 | 0 | 0 |

Across 700 create cycles (including a 50-way concurrent burst) there were
**zero** `failed to create TTRPC connection` errors, **zero** leaked shim
processes, and **zero** new orphaned sockets.

The failures in round 2 were all backpressure from the control plane
(`no more resource`) when too many microVMs were requested concurrently on
one host — expected over-subscription behavior, unrelated to the shim
startup path.

### Risk / compatibility

- Logging behavior is preserved: stdout is still routed to the logging
  datagram, just at the correct point (after `server.start()`).
- No public API or config change.
- Restores the upstream `containerd-shim` readiness contract rather than
  working around it, so the change is conservative and low-risk.