### PR TITLE
fix(cubelet): converge pause/resume state on ttrpc errors and shim events

### DIFF
--- a/Cubelet/services/cubebox/events.go
+++ b/Cubelet/services/cubebox/events.go
@@ -77,6 +77,8 @@ func (em *eventMonitor) subscribe(subscriber events.Subscriber) {
 	filters := []string{
 		`topic=="/tasks/exit"`,
 		`topic=="/tasks/oom"`,
+		`topic=="/tasks/paused"`,
+		`topic=="/tasks/resumed"`,
 		`topic~="/images/"`,
 	}
 	em.ch, em.errCh = subscriber.Subscribe(em.ctx, filters...)
@@ -101,6 +103,10 @@ func convertEvent(e typeurl.Any) (string, interface{}, error) {
 	case *eventtypes.ImageDelete:
 		id = e.Name
 	case *eventtypes.TaskExit:
+		id = e.ContainerID
+	case *eventtypes.TaskPaused:
+		id = e.ContainerID
+	case *eventtypes.TaskResumed:
 		id = e.ContainerID
 	default:
 		return "", nil, errors.New("unsupported event")
@@ -251,6 +257,77 @@ func (em *eventMonitor) handleEvent(ctx context.Context, any interface{}) error 
 			return status, nil
 		})
 		return em.c.cubeboxManger.SyncByID(ctx, cntr.ID)
+	case *eventtypes.TaskPaused:
+		if strings.HasPrefix(e.ContainerID, "exec-") {
+			return nil
+		}
+		cntr, cb, err = em.c.cubeboxManger.FindContainerOfCubebox(ctx, e.ContainerID)
+		if err != nil && !errdefs.IsNotFound(err) {
+			return fmt.Errorf("failed to find container of cubebox: %w", err)
+		}
+		if cb == nil {
+			return nil
+		}
+		if cb.Namespace != "" {
+			ctx = namespaces.WithNamespace(ctx, cb.Namespace)
+		}
+		cb.Lock()
+		defer cb.Unlock()
+		// Do not backfill paused semantics once it has entered a terminal state.
+		if cb.UserMarkDeletedTime != nil {
+			return nil
+		}
+		if cntr != nil && cntr.Status != nil && cntr.Status.IsTerminated() {
+			return nil
+		}
+		// Idempotent: converge PausedAt/PausingAt of all containers to PAUSED.
+		for _, c := range cb.AllContainers() {
+			if c.Status == nil {
+				continue
+			}
+			c.Status.Update(func(status cubeboxstore.Status) (cubeboxstore.Status, error) {
+				if status.PausedAt == 0 {
+					status.PausedAt = time.Now().UnixNano()
+				}
+				status.PausingAt = 0
+				return status, nil
+			})
+		}
+		return em.c.cubeboxManger.SyncByID(ctx, cb.ID)
+	case *eventtypes.TaskResumed:
+		if strings.HasPrefix(e.ContainerID, "exec-") {
+			return nil
+		}
+		cntr, cb, err = em.c.cubeboxManger.FindContainerOfCubebox(ctx, e.ContainerID)
+		if err != nil && !errdefs.IsNotFound(err) {
+			return fmt.Errorf("failed to find container of cubebox: %w", err)
+		}
+		if cb == nil {
+			return nil
+		}
+		if cb.Namespace != "" {
+			ctx = namespaces.WithNamespace(ctx, cb.Namespace)
+		}
+		cb.Lock()
+		defer cb.Unlock()
+		if cb.UserMarkDeletedTime != nil {
+			return nil
+		}
+		if cntr != nil && cntr.Status != nil && cntr.Status.IsTerminated() {
+			return nil
+		}
+		// Idempotent: converge PausedAt/PausingAt of all containers to RUNNING.
+		for _, c := range cb.AllContainers() {
+			if c.Status == nil {
+				continue
+			}
+			c.Status.Update(func(status cubeboxstore.Status) (cubeboxstore.Status, error) {
+				status.PausedAt = 0
+				status.PausingAt = 0
+				return status, nil
+			})
+		}
+		return em.c.cubeboxManger.SyncByID(ctx, cb.ID)
 	case *eventtypes.ImageCreate:
 		log.G(ctx).Infof("image create event: %+v", e)
 		return em.c.criImage.UpdateImage(ctx, e.Name)

--- a/Cubelet/services/cubebox/events.go
+++ b/Cubelet/services/cubebox/events.go
@@ -316,17 +316,10 @@ func (em *eventMonitor) handleEvent(ctx context.Context, any interface{}) error 
 		if cntr != nil && cntr.Status != nil && cntr.Status.IsTerminated() {
 			return nil
 		}
-		// Idempotent: converge PausedAt/PausingAt of all containers to RUNNING.
-		for _, c := range cb.AllContainers() {
-			if c.Status == nil {
-				continue
-			}
-			c.Status.Update(func(status cubeboxstore.Status) (cubeboxstore.Status, error) {
-				status.PausedAt = 0
-				status.PausingAt = 0
-				return status, nil
-			})
-		}
+		// Resume is an opaque restore from CubeShim's internal pause snapshot, so
+		// use the shared converger that also invalidates stale runtime snapshot
+		// bindings before the next CommitSandbox.
+		convergeResumeStateAfterOpaqueRestore(cb, time.Now().UTC())
 		return em.c.cubeboxManger.SyncByID(ctx, cb.ID)
 	case *eventtypes.ImageCreate:
 		log.G(ctx).Infof("image create event: %+v", e)

--- a/Cubelet/services/cubebox/resume_reconcile_test.go
+++ b/Cubelet/services/cubebox/resume_reconcile_test.go
@@ -1,0 +1,126 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package cubebox
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	eventtypes "github.com/containerd/containerd/api/events"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tencentcloud/CubeSandbox/Cubelet/pkg/constants"
+	cubeboxstore "github.com/tencentcloud/CubeSandbox/Cubelet/pkg/store/cubebox"
+	"github.com/tencentcloud/CubeSandbox/Cubelet/plugins/cube/internals/cubes"
+)
+
+type fakeCubeboxAPI struct {
+	cb      *cubeboxstore.CubeBox
+	syncIDs []string
+}
+
+func (f *fakeCubeboxAPI) Init(ctx context.Context) error {
+	return nil
+}
+
+func (f *fakeCubeboxAPI) Get(ctx context.Context, id string) (*cubeboxstore.CubeBox, error) {
+	if f.cb != nil && f.cb.ID == id {
+		return f.cb, nil
+	}
+	return nil, nil
+}
+
+func (f *fakeCubeboxAPI) FindContainerOfCubebox(ctx context.Context, id string) (*cubeboxstore.Container, *cubeboxstore.CubeBox, error) {
+	if f.cb == nil {
+		return nil, nil, nil
+	}
+	cntr, err := f.cb.Get(id)
+	if err != nil {
+		return nil, f.cb, nil
+	}
+	return cntr, f.cb, nil
+}
+
+func (f *fakeCubeboxAPI) List() []*cubeboxstore.CubeBox {
+	if f.cb == nil {
+		return nil
+	}
+	return []*cubeboxstore.CubeBox{f.cb}
+}
+
+func (f *fakeCubeboxAPI) Save(ctx context.Context, info *cubeboxstore.CubeBox, opts ...cubes.UpdateCubeboxOpt) error {
+	f.cb = info
+	return nil
+}
+
+func (f *fakeCubeboxAPI) SyncByID(ctx context.Context, id string, opts ...cubes.UpdateCubeboxOpt) error {
+	f.syncIDs = append(f.syncIDs, id)
+	return nil
+}
+
+func (f *fakeCubeboxAPI) Delete(ctx context.Context, opt *cubes.DeleteOption) error {
+	return nil
+}
+
+func TestConvergeResumeStateAfterOpaqueRestoreClearsPauseStateAndInvalidatesBindings(t *testing.T) {
+	cb := newCubeboxWithStatusForTest("sb-resume-helper", cubeboxstore.Status{
+		PausedAt:  time.Now().Add(-2 * time.Minute).UnixNano(),
+		PausingAt: time.Now().Add(-time.Minute).UnixNano(),
+	})
+	cb.Metadata.Labels = map[string]string{
+		constants.MasterAnnotationRuntimeSnapshotID:                "snap-before-resume",
+		constants.MasterAnnotationRuntimeRestoreSnapshotID:         "restore-before-resume",
+		constants.MasterAnnotationRuntimeSnapshotAttachedAt:        time.Now().Add(-3 * time.Minute).UTC().Format(time.RFC3339Nano),
+		constants.MasterAnnotationRuntimeRestoreSnapshotAttachedAt: time.Now().Add(-3 * time.Minute).UTC().Format(time.RFC3339Nano),
+		"keep": "value",
+	}
+	cb.ContainersMap.AddContainer(&cubeboxstore.Container{
+		Metadata: cubeboxstore.Metadata{ID: "sb-resume-helper-sidecar"},
+		Status: cubeboxstore.StoreStatus(cubeboxstore.Status{
+			PausedAt:  time.Now().Add(-90 * time.Second).UnixNano(),
+			PausingAt: time.Now().Add(-45 * time.Second).UnixNano(),
+		}),
+	})
+
+	attachedAt := time.Date(2026, 5, 31, 9, 30, 0, 0, time.UTC)
+	convergeResumeStateAfterOpaqueRestore(cb, attachedAt)
+
+	for id, cntr := range cb.AllContainers() {
+		got := cntr.Status.Get()
+		assert.Equal(t, int64(0), got.PausedAt, "PausedAt must be cleared for %s", id)
+		assert.Equal(t, int64(0), got.PausingAt, "PausingAt must be cleared for %s", id)
+	}
+	assert.Equal(t, runtimeSnapshotBindingInvalidID, cb.Labels[constants.MasterAnnotationRuntimeSnapshotID])
+	assert.Equal(t, runtimeSnapshotBindingInvalidID, cb.Labels[constants.MasterAnnotationRuntimeRestoreSnapshotID])
+	assert.Equal(t, attachedAt.Format(time.RFC3339Nano), cb.Labels[constants.MasterAnnotationRuntimeSnapshotAttachedAt])
+	assert.Equal(t, attachedAt.Format(time.RFC3339Nano), cb.Labels[constants.MasterAnnotationRuntimeRestoreSnapshotAttachedAt])
+	assert.Equal(t, "value", cb.Labels["keep"], "unrelated labels must be preserved")
+}
+
+func TestHandleEventTaskResumedConvergesOpaqueRestoreBindings(t *testing.T) {
+	cb := newCubeboxWithStatusForTest("sb-resume-event", cubeboxstore.Status{
+		PausedAt:  time.Now().Add(-2 * time.Minute).UnixNano(),
+		PausingAt: time.Now().Add(-time.Minute).UnixNano(),
+	})
+	cb.Metadata.Labels = map[string]string{
+		constants.MasterAnnotationRuntimeSnapshotID:        "snap-before-event",
+		constants.MasterAnnotationRuntimeRestoreSnapshotID: "restore-before-event",
+	}
+	manager := &fakeCubeboxAPI{cb: cb}
+	em := &eventMonitor{c: &local{cubeboxManger: manager}}
+
+	err := em.handleEvent(context.Background(), &eventtypes.TaskResumed{ContainerID: cb.FirstContainer().ID})
+	require.NoError(t, err)
+
+	got := cb.GetStatus().Get()
+	assert.Equal(t, int64(0), got.PausedAt, "TaskResumed must clear PausedAt")
+	assert.Equal(t, int64(0), got.PausingAt, "TaskResumed must clear PausingAt")
+	assert.Equal(t, runtimeSnapshotBindingInvalidID, cb.Labels[constants.MasterAnnotationRuntimeSnapshotID])
+	assert.Equal(t, runtimeSnapshotBindingInvalidID, cb.Labels[constants.MasterAnnotationRuntimeRestoreSnapshotID])
+	assert.NotEmpty(t, cb.Labels[constants.MasterAnnotationRuntimeSnapshotAttachedAt], "TaskResumed must stamp attached_at")
+	assert.NotEmpty(t, cb.Labels[constants.MasterAnnotationRuntimeRestoreSnapshotAttachedAt], "TaskResumed must stamp restore attached_at")
+	assert.Equal(t, []string{cb.ID}, manager.syncIDs, "TaskResumed must persist the converged cubebox")
+}

--- a/Cubelet/services/cubebox/service.go
+++ b/Cubelet/services/cubebox/service.go
@@ -874,8 +874,7 @@ func scanDeadContainer(ctx context.Context, dc []*cubeboxstore.CubeBox, client *
 		// Calling RecoverContainer -> shim state() while pause_vm() holds the
 		// sandbox mutex causes a ttrpc timeout; RecoverContainer then sets
 		// Unknown=true, making the sandbox appear Terminated and triggering a
-		// spurious Destroy cascade.  Skip paused/pausing sandboxes: DeadGC has
-		// nothing useful to do for them.
+		// spurious Destroy cascade.
 		//
 		// The same race exists for snapshot rollback: while updateShimForRollback
 		// runs, the shim holds its sandbox mutex doing delete_vm +
@@ -883,8 +882,33 @@ func scanDeadContainer(ctx context.Context, dc []*cubeboxstore.CubeBox, client *
 		// task status=Unknown. RollbackSandbox sets RollingBack on every
 		// container's Status before invoking the shim and clears it via defer,
 		// so DeadGC must respect the flag for the same reason.
-		if cb.GetStatus() != nil && (cb.GetStatus().IsPaused() || cb.GetStatus().Get().RollingBack) {
-			continue
+		if status := cb.GetStatus(); status != nil {
+			st := status.Get()
+			if st.RollingBack {
+				continue
+			}
+			switch st.State() {
+			case cubebox.ContainerState_CONTAINER_PAUSED:
+				// User-driven pause: a legitimate, possibly long-lived state.
+				// Nothing for DeadGC to do.
+				continue
+			case cubebox.ContainerState_CONTAINER_PAUSING:
+				// PAUSING is meant to be a short transient. While a pause is
+				// genuinely in flight the shim holds its sandbox mutex, so a
+				// state() query would time out and stamp Unknown=true (see
+				// above) -- within the safety window we still skip. Past
+				// pausingStuckThreshold the pause is no longer running (e.g. the
+				// cubelet restarted mid-pause and missed both the RPC and
+				// /tasks/paused reconcile windows); reconcile once against the
+				// shim's real status so the sandbox never stays stuck at PAUSING
+				// forever.
+				if st.PausingAt == 0 ||
+					time.Since(time.Unix(0, st.PausingAt)) < pausingStuckThreshold {
+					continue
+				}
+				reconcileStuckPausingSandbox(ctx, client, cb)
+				continue
+			}
 		}
 		ctx = namespaces.WithNamespace(ctx, cb.Namespace)
 		ctr, err := cubes.RecoverContainer(ctx, client, cb, cb.FirstContainer())

--- a/Cubelet/services/cubebox/update.go
+++ b/Cubelet/services/cubebox/update.go
@@ -270,6 +270,17 @@ const (
 	// Dedicated status-query timeout opened during reconcile. It MUST use a
 	// fresh ctx and never reuse the already-expired ctx.
 	reconcileStatusTimeout = 5 * time.Second
+
+	// pausingStuckThreshold bounds how long a sandbox may legitimately remain
+	// in the PAUSING transient. A real pause completes well within
+	// taskPauseTimeout; once PausingAt is older than this -- e.g. the cubelet
+	// restarted mid-pause and missed both the RPC-level reconcile and the
+	// /tasks/paused event window -- the pause is no longer in flight and DeadGC
+	// may safely query the shim to converge. It MUST stay comfortably larger
+	// than taskPauseTimeout so an in-flight pause (during which the shim holds
+	// its sandbox mutex and a ttrpc state() query would time out) is never
+	// reconciled prematurely.
+	pausingStuckThreshold = 2 * taskPauseTimeout
 )
 
 // reconcileStatusAfterPauseError, after task.Pause reports an error, actively
@@ -303,16 +314,35 @@ func reconcileStatusAfterPauseError(
 		return
 	}
 
-	switch st.Status {
+	// Delegate to the shared converger so the PAUSE-direction rules cannot
+	// drift between this RPC-level path and the DeadGC stuck-PAUSING fallback.
+	// TaskPauseFailed is still returned to the upstream so it can alert; the
+	// in-memory view here is merely straightened to match the real VM.
+	convergePauseStateFromShim(parentCtx, sb, st.Status, fmt.Sprintf("pause RPC error: %v", pauseErr))
+}
+
+// convergePauseStateFromShim straightens PausingAt/PausedAt across every
+// container of the sandbox so the in-memory view matches the shim's real task
+// status. It is the single source of truth for the PAUSE-direction
+// convergence rules, shared by reconcileStatusAfterPauseError (RPC path) and
+// reconcileStuckPausingSandbox (DeadGC fallback) so the two can never drift.
+// It never writes Unknown=true, so background scanners can use it without
+// risking a spurious Terminated/Destroy cascade. reason only adds logging
+// context.
+func convergePauseStateFromShim(
+	ctx context.Context,
+	sb *cubeboxstore.CubeBox,
+	shimStatus containerd.ProcessStatus,
+	reason string,
+) {
+	switch shimStatus {
 	case containerd.Paused:
-		// cubeshim actually succeeded -> write PausedAt as in the success path.
-		// Note: TaskPauseFailed is still returned to the upstream so it can
-		// alert; but the cubelet internal state is consistent with the real VM,
-		// and the next IsPaused() short-circuit becomes already-paused instead
-		// of staying stuck at PAUSING forever.
-		log.G(parentCtx).Warnf(
-			"reconcileStatusAfterPauseError: shim reports PAUSED despite pauseErr=%v, converging sandbox=%s",
-			pauseErr, sb.ID)
+		// cubeshim actually reached PAUSED -> write PausedAt exactly as the
+		// UpdateWithPause success path does, so the next IsPaused() check sees
+		// already-paused instead of staying stuck at PAUSING forever.
+		log.G(ctx).Warnf(
+			"convergePauseStateFromShim: shim reports PAUSED, converging to PAUSED sandbox=%s reason=%s",
+			sb.ID, reason)
 		for _, c := range sb.AllContainers() {
 			if c.Status == nil {
 				continue
@@ -324,10 +354,10 @@ func reconcileStatusAfterPauseError(
 			})
 		}
 	case containerd.Running, containerd.Created:
-		// Really not paused -> reset PausingAt to avoid it lingering forever.
-		log.G(parentCtx).Warnf(
-			"reconcileStatusAfterPauseError: shim reports %s, rolling PausingAt back sandbox=%s pauseErr=%v",
-			st.Status, sb.ID, pauseErr)
+		// Really not paused -> clear PausingAt so it cannot linger forever.
+		log.G(ctx).Warnf(
+			"convergePauseStateFromShim: shim reports %s, clearing PausingAt sandbox=%s reason=%s",
+			shimStatus, sb.ID, reason)
 		for _, c := range sb.AllContainers() {
 			if c.Status == nil {
 				continue
@@ -340,9 +370,9 @@ func reconcileStatusAfterPauseError(
 	default:
 		// Intermediate states such as Stopped/Unknown/Pausing: leave the status
 		// untouched and let TaskExit / the event subscription handle them.
-		log.G(parentCtx).Warnf(
-			"reconcileStatusAfterPauseError: shim reports %s, leaving status untouched sandbox=%s",
-			st.Status, sb.ID)
+		log.G(ctx).Warnf(
+			"convergePauseStateFromShim: shim reports %s, leaving status untouched sandbox=%s reason=%s",
+			shimStatus, sb.ID, reason)
 	}
 }
 
@@ -397,4 +427,62 @@ func reconcileStatusAfterResumeError(
 			"reconcileStatusAfterResumeError: shim reports %s, leaving status untouched sandbox=%s",
 			st.Status, sb.ID)
 	}
+}
+
+// reconcileStuckPausingSandbox is the startup/background fallback -- the third
+// line of defense for the PAUSING state behind reconcileStatusAfterPauseError
+// (RPC path) and the /tasks/paused event subscription (events.go). If the
+// cubelet crashes or restarts while a pause is in flight, neither of those
+// fires again (events are not replayed, the RPC caller is gone), so without
+// this a sandbox could stay stuck at PAUSING forever: DeadGC otherwise skips
+// paused/pausing sandboxes outright.
+//
+// The caller (DeadGC) MUST only invoke this once PausingAt has lingered past
+// pausingStuckThreshold, i.e. long after any genuine in-flight pause would
+// have released the shim's sandbox mutex, so the ttrpc status query below
+// cannot race it. Unlike cubes.RecoverContainer it never stamps Unknown=true,
+// so it cannot trigger a spurious Terminated/Destroy cascade.
+func reconcileStuckPausingSandbox(ctx context.Context, client *containerd.Client, cb *cubeboxstore.CubeBox) {
+	fc := cb.FirstContainer()
+	if fc == nil {
+		return
+	}
+	ns := cb.Namespace
+	if ns == "" {
+		ns = namespaces.Default
+	}
+	queryCtx, cancel := context.WithTimeout(context.Background(), reconcileStatusTimeout)
+	defer cancel()
+	queryCtx = namespaces.WithNamespace(queryCtx, ns)
+
+	cntr := fc.Container
+	if cntr == nil {
+		loaded, err := client.LoadContainer(queryCtx, fc.ID)
+		if err != nil {
+			log.G(ctx).Errorf(
+				"reconcileStuckPausingSandbox: load container %s failed sandbox=%s err=%v",
+				fc.ID, cb.ID, err)
+			return
+		}
+		cntr = loaded
+	}
+	task, err := cntr.Task(queryCtx, nil)
+	if err != nil {
+		log.G(ctx).Errorf(
+			"reconcileStuckPausingSandbox: load task failed sandbox=%s err=%v", cb.ID, err)
+		return
+	}
+	st, err := task.Status(queryCtx)
+	if err != nil {
+		log.G(ctx).Errorf(
+			"reconcileStuckPausingSandbox: task.Status failed sandbox=%s err=%v", cb.ID, err)
+		return
+	}
+
+	stuckFor := time.Duration(0)
+	if pausingAt := cb.GetStatus().Get().PausingAt; pausingAt != 0 {
+		stuckFor = time.Since(time.Unix(0, pausingAt))
+	}
+	convergePauseStateFromShim(ctx, cb, st.Status,
+		fmt.Sprintf("DeadGC stuck PAUSING for %s", stuckFor))
 }

--- a/Cubelet/services/cubebox/update.go
+++ b/Cubelet/services/cubebox/update.go
@@ -10,6 +10,7 @@ import (
 	"runtime/debug"
 	"time"
 
+	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/containerd/v2/pkg/namespaces"
 	"github.com/containerd/ttrpc"
 	"github.com/tencentcloud/CubeSandbox/Cubelet/api/services/cubebox/v1"
@@ -168,10 +169,20 @@ func (s *service) UpdateWithPause(ctx context.Context, req *cubebox.UpdateCubeSa
 
 	doPreStop(ctx, sb.FirstContainer())
 
-	if err := task.Pause(ctx); err != nil {
-		rsp.Ret.RetMsg = err.Error()
+	// Give task.Pause an explicit timeout so it cannot be stretched out
+	// arbitrarily by the upstream ctx; otherwise, once the upstream ctx is
+	// cancelled the cubelet view stays stuck at PAUSING while cubeshim is
+	// already PAUSED.
+	pauseCtx, pauseCancel := context.WithTimeout(ctx, taskPauseTimeout)
+	defer pauseCancel()
+	if pauseErr := task.Pause(pauseCtx); pauseErr != nil {
+		// Even when ttrpc reports an error (DeadlineExceeded / canceled /
+		// ttrpc closed), cubeshim may have actually paused the VM. Query the
+		// real status once with an independent, ctx-immune short timeout and
+		// persist the truth, so the state never stays stuck at PAUSING.
+		reconcileStatusAfterPauseError(ctx, sb, task, pauseErr)
+		rsp.Ret.RetMsg = pauseErr.Error()
 		rsp.Ret.RetCode = errorcode.ErrorCode_TaskPauseFailed
-
 		return rsp, nil
 	}
 	for _, c := range sb.AllContainers() {
@@ -217,7 +228,13 @@ func (s *service) UpdateWithResume(ctx context.Context, req *cubebox.UpdateCubeS
 	}()
 	defer utils.Recover()
 
-	if err := task.Resume(ctx); err != nil {
+	resumeCtx, resumeCancel := context.WithTimeout(ctx, taskResumeTimeout)
+	defer resumeCancel()
+	if err := task.Resume(resumeCtx); err != nil {
+		// Same as pause: resume may time out midway while cubeshim has already
+		// brought the VM back to RUNNING. Query the real status once and
+		// converge to the truth, so the state never stays stuck at PAUSED.
+		reconcileStatusAfterResumeError(ctx, sb, task, err)
 		rsp.Ret.RetMsg = err.Error()
 		rsp.Ret.RetCode = errorcode.ErrorCode_TaskResumeFailed
 		return rsp, nil
@@ -239,4 +256,145 @@ func (s *service) UpdateWithResume(ctx context.Context, req *cubebox.UpdateCubeS
 		}
 	}
 	return rsp, nil
+}
+
+// Upper bound for the Pause/Resume ttrpc calls. 30s is used because cubeshim
+// pausing a VM involves vCPU stop + device quiesce + memory eventual
+// consistency, which is normally < 5s; 30s is a safety net to prevent the
+// call from being stuck indefinitely when the upstream ctx is missing or
+// blocked. Used together with the reconcile* error convergence.
+const (
+	taskPauseTimeout  = 30 * time.Second
+	taskResumeTimeout = 30 * time.Second
+
+	// Dedicated status-query timeout opened during reconcile. It MUST use a
+	// fresh ctx and never reuse the already-expired ctx.
+	reconcileStatusTimeout = 5 * time.Second
+)
+
+// reconcileStatusAfterPauseError, after task.Pause reports an error, actively
+// queries cubeshim once for the real task status and straightens the cubelet
+// in-memory view to the truth, so PausingAt never lingers forever. Note: all
+// status writes here must stay consistent with the UpdateWithPause success
+// path.
+func reconcileStatusAfterPauseError(
+	parentCtx context.Context,
+	sb *cubeboxstore.CubeBox,
+	task containerd.Task,
+	pauseErr error,
+) {
+	// Deliberately start a fresh ctx from Background: parentCtx is very likely
+	// already Done.
+	queryCtx, cancel := context.WithTimeout(context.Background(), reconcileStatusTimeout)
+	defer cancel()
+	// Carry over the original ns to avoid namespaces.NamespaceRequired failing.
+	if ns, ok := namespaces.Namespace(parentCtx); ok && ns != "" {
+		queryCtx = namespaces.WithNamespace(queryCtx, ns)
+	}
+
+	st, qerr := task.Status(queryCtx)
+	if qerr != nil {
+		// Cannot determine the real status, so do not write blindly. Keep
+		// PausingAt visible to operators and wait for the event-driven
+		// reconcile (/tasks/paused subscription) to back it up.
+		log.G(parentCtx).Errorf(
+			"reconcileStatusAfterPauseError: task.Status failed sandbox=%s pauseErr=%v statusErr=%v",
+			sb.ID, pauseErr, qerr)
+		return
+	}
+
+	switch st.Status {
+	case containerd.Paused:
+		// cubeshim actually succeeded -> write PausedAt as in the success path.
+		// Note: TaskPauseFailed is still returned to the upstream so it can
+		// alert; but the cubelet internal state is consistent with the real VM,
+		// and the next IsPaused() short-circuit becomes already-paused instead
+		// of staying stuck at PAUSING forever.
+		log.G(parentCtx).Warnf(
+			"reconcileStatusAfterPauseError: shim reports PAUSED despite pauseErr=%v, converging sandbox=%s",
+			pauseErr, sb.ID)
+		for _, c := range sb.AllContainers() {
+			if c.Status == nil {
+				continue
+			}
+			c.Status.Update(func(status cubeboxstore.Status) (cubeboxstore.Status, error) {
+				status.PausedAt = time.Now().UnixNano()
+				status.PausingAt = 0
+				return status, nil
+			})
+		}
+	case containerd.Running, containerd.Created:
+		// Really not paused -> reset PausingAt to avoid it lingering forever.
+		log.G(parentCtx).Warnf(
+			"reconcileStatusAfterPauseError: shim reports %s, rolling PausingAt back sandbox=%s pauseErr=%v",
+			st.Status, sb.ID, pauseErr)
+		for _, c := range sb.AllContainers() {
+			if c.Status == nil {
+				continue
+			}
+			c.Status.Update(func(status cubeboxstore.Status) (cubeboxstore.Status, error) {
+				status.PausingAt = 0
+				return status, nil
+			})
+		}
+	default:
+		// Intermediate states such as Stopped/Unknown/Pausing: leave the status
+		// untouched and let TaskExit / the event subscription handle them.
+		log.G(parentCtx).Warnf(
+			"reconcileStatusAfterPauseError: shim reports %s, leaving status untouched sandbox=%s",
+			st.Status, sb.ID)
+	}
+}
+
+// reconcileStatusAfterResumeError is the dual of the pause case.
+func reconcileStatusAfterResumeError(
+	parentCtx context.Context,
+	sb *cubeboxstore.CubeBox,
+	task containerd.Task,
+	resumeErr error,
+) {
+	queryCtx, cancel := context.WithTimeout(context.Background(), reconcileStatusTimeout)
+	defer cancel()
+	if ns, ok := namespaces.Namespace(parentCtx); ok && ns != "" {
+		queryCtx = namespaces.WithNamespace(queryCtx, ns)
+	}
+
+	st, qerr := task.Status(queryCtx)
+	if qerr != nil {
+		log.G(parentCtx).Errorf(
+			"reconcileStatusAfterResumeError: task.Status failed sandbox=%s resumeErr=%v statusErr=%v",
+			sb.ID, resumeErr, qerr)
+		return
+	}
+
+	switch st.Status {
+	case containerd.Running:
+		// The shim has actually resumed successfully; likewise invalidate the
+		// runtime snapshot bindings to stay consistent with the
+		// UpdateWithResume success path.
+		log.G(parentCtx).Warnf(
+			"reconcileStatusAfterResumeError: shim reports RUNNING despite resumeErr=%v, converging sandbox=%s",
+			resumeErr, sb.ID)
+		invalidateRuntimeSnapshotBindingsAfterOpaqueRestore(sb, time.Now().UTC())
+		for _, c := range sb.AllContainers() {
+			if c.Status == nil {
+				continue
+			}
+			c.Status.Update(func(status cubeboxstore.Status) (cubeboxstore.Status, error) {
+				status.PausedAt = 0
+				status.PausingAt = 0
+				return status, nil
+			})
+		}
+	case containerd.Paused:
+		// Really not resumed, the state stays PAUSED and needs no rewrite (the
+		// success path has not run yet).
+		log.G(parentCtx).Warnf(
+			"reconcileStatusAfterResumeError: shim still PAUSED resumeErr=%v sandbox=%s",
+			resumeErr, sb.ID)
+	default:
+		log.G(parentCtx).Warnf(
+			"reconcileStatusAfterResumeError: shim reports %s, leaving status untouched sandbox=%s",
+			st.Status, sb.ID)
+	}
 }

--- a/Cubelet/services/cubebox/update.go
+++ b/Cubelet/services/cubebox/update.go
@@ -239,22 +239,7 @@ func (s *service) UpdateWithResume(ctx context.Context, req *cubebox.UpdateCubeS
 		rsp.Ret.RetCode = errorcode.ErrorCode_TaskResumeFailed
 		return rsp, nil
 	}
-	// CubeShim resumes paused VMs from an internal full snapshot under
-	// /data/cubelet/root/pausevm/<sandbox> and does not expose that memory file
-	// as a cubecow catalog entry. Any runtime/restore-base labels that still
-	// point to older template/snapshot memory files are now stale for
-	// pagemap_anon/soft-dirty purposes, so force the next commit to re-anchor
-	// with a full snapshot.
-	invalidateRuntimeSnapshotBindingsAfterOpaqueRestore(sb, time.Now().UTC())
-	for _, c := range sb.AllContainers() {
-		if c.Status != nil {
-			c.Status.Update(func(status cubeboxstore.Status) (cubeboxstore.Status, error) {
-				status.PausedAt = 0
-				status.PausingAt = 0
-				return status, nil
-			})
-		}
-	}
+	convergeResumeStateAfterOpaqueRestore(sb, time.Now().UTC())
 	return rsp, nil
 }
 
@@ -376,6 +361,31 @@ func convergePauseStateFromShim(
 	}
 }
 
+// convergeResumeStateAfterOpaqueRestore is the single source of truth for the
+// RESUME-direction convergence rules. CubeShim resumes paused VMs from an
+// internal full snapshot under /data/cubelet/root/pausevm/<sandbox> and does
+// not expose that memory file as a cubecow catalog entry, so every successful
+// resume convergence MUST both clear the paused markers and invalidate the
+// runtime/restore-base bindings. Shared by the normal UpdateWithResume success
+// path, the resume-RPC error reconcile path, and the /tasks/resumed event path
+// so these flows cannot drift again.
+func convergeResumeStateAfterOpaqueRestore(sb *cubeboxstore.CubeBox, attachedAt time.Time) {
+	if sb == nil {
+		return
+	}
+	invalidateRuntimeSnapshotBindingsAfterOpaqueRestore(sb, attachedAt)
+	for _, c := range sb.AllContainers() {
+		if c.Status == nil {
+			continue
+		}
+		c.Status.Update(func(status cubeboxstore.Status) (cubeboxstore.Status, error) {
+			status.PausedAt = 0
+			status.PausingAt = 0
+			return status, nil
+		})
+	}
+}
+
 // reconcileStatusAfterResumeError is the dual of the pause case.
 func reconcileStatusAfterResumeError(
 	parentCtx context.Context,
@@ -405,17 +415,7 @@ func reconcileStatusAfterResumeError(
 		log.G(parentCtx).Warnf(
 			"reconcileStatusAfterResumeError: shim reports RUNNING despite resumeErr=%v, converging sandbox=%s",
 			resumeErr, sb.ID)
-		invalidateRuntimeSnapshotBindingsAfterOpaqueRestore(sb, time.Now().UTC())
-		for _, c := range sb.AllContainers() {
-			if c.Status == nil {
-				continue
-			}
-			c.Status.Update(func(status cubeboxstore.Status) (cubeboxstore.Status, error) {
-				status.PausedAt = 0
-				status.PausingAt = 0
-				return status, nil
-			})
-		}
+		convergeResumeStateAfterOpaqueRestore(sb, time.Now().UTC())
 	case containerd.Paused:
 		// Really not resumed, the state stays PAUSED and needs no rewrite (the
 		// success path has not run yet).


### PR DESCRIPTION

When task.Pause/Resume returned a ttrpc error (DeadlineExceeded, canceled, ttrpc closed), the cubelet in-memory view could stay stuck at PAUSING/PAUSED while cubeshim had already switched the VM state, leaving PausingAt lingering forever.  close issue #403 

update.go:
- Wrap task.Pause/Resume with explicit 30s timeouts so the calls cannot be stretched arbitrarily by a missing or blocked upstream ctx.
- On error, reconcile against the shim's real status using a fresh Background ctx (carrying over the namespace) and straighten the in-memory view to the truth, while still returning TaskPauseFailed/TaskResumeFailed upstream for alerting.

events.go:
- Subscribe to /tasks/paused and /tasks/resumed and handle them in convertEvent/handleEvent as an event-driven fallback.
- Idempotently converge PausedAt/PausingAt for all containers, skipping terminal or user-deleted sandboxes.

Assisted-by: Claude Opus 4.8