### PR TITLE
docs: fix probe path in create-from-image tutorial

### DIFF
--- a/docs/guide/tutorials/template-from-image.md
+++ b/docs/guide/tutorials/template-from-image.md
@@ -86,7 +86,7 @@ cubemastercli tpl create-from-image \
   --expose-port 49999 \
   --expose-port 49983 \
   --probe      49999 \
-  --probe-path /healthz \
+  --probe-path /health \
   --env        MY_ENV=production
 ```
 

--- a/docs/zh/guide/tutorials/template-from-image.md
+++ b/docs/zh/guide/tutorials/template-from-image.md
@@ -71,7 +71,7 @@ cubemastercli tpl create-from-image \
   --expose-port 49999 \
   --expose-port 49983 \
   --probe      49999 \
-  --probe-path /healthz \
+  --probe-path /health \
   --env        MY_ENV=production
 ```
 


### PR DESCRIPTION
Fixes #397. The sandbox-code:latest image exposes `/health` instead of `/healthz`.
