### PR TITLE
docs: fix broken changelog links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
   <a href="./README_zh.md"><strong>中文文档</strong></a> ·
   <a href="./docs/guide/quickstart.md"><strong>Quick Start</strong></a> ·
   <a href="./docs/index.md"><strong>Documentation</strong></a> ·
-  <a href="./docs/changelog.md"><strong>Changelog</strong></a> ·
+  <a href="./docs/changelog/index.md"><strong>Changelog</strong></a> ·
   <a href="https://x.com/CubeSandbox_AI"><strong>X(Twitter)</strong></a>
 </p>
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -26,7 +26,7 @@
   <a href="./README.md"><strong>English</strong></a> ·
   <a href="./docs/zh/guide/quickstart.md"><strong>快速开始</strong></a> ·
   <a href="./docs/zh/index.md"><strong>文档</strong></a> ·
-  <a href="./docs/zh/changelog.md"><strong>变更日志</strong></a> ·
+  <a href="./docs/zh/changelog/index.md"><strong>变更日志</strong></a> ·
   <a href="#wechat-group"><strong>微信交流群</strong></a> ·
   <a href="https://x.com/CubeSandbox_AI"><strong>X(Twitter)</strong></a>
 </p>


### PR DESCRIPTION
The changelog has been reorganized from a single file into a directory with per-version files. Update the README links from docs/changelog.md to docs/changelog/index.md (and the zh variant) accordingly.

Assisted-by: CodeBuddy