### PR TITLE
fix(python-sdk): align envd defaults and network policy

### DIFF
--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -66,6 +66,19 @@ with Sandbox.create() as sb:
     )
 ```
 
+### Run shell commands
+
+```python
+from cubesandbox import Sandbox
+
+with Sandbox.create() as sb:
+    result = sb.commands.run("echo hello cube")
+    print(result.stdout)  # "hello cube\n"
+```
+
+When `user` is omitted, the SDK sends requests as `root` for compatibility
+with envd versions that reject process/file requests without an explicit user.
+
 ### Persistent variables within a sandbox
 
 Variables assigned in one `run_code` call persist for the lifetime of the sandbox —
@@ -96,20 +109,25 @@ sb2 = Sandbox.connect(sb.sandbox_id)
 ### Network policy
 
 ```python
-import json
 from cubesandbox import Sandbox
 
 # Deny all outbound traffic
-with Sandbox.create(metadata={"network-policy": "deny-all"}) as sb:
+with Sandbox.create(allow_internet_access=False) as sb:
     result = sb.run_code(
         "import urllib.request; urllib.request.urlopen('http://example.com')"
     )
     print(result.error.name)   # "URLError"
 
 # Custom allow-list — NOTE: only IP addresses are supported, not domain names
-rules = json.dumps({"allow": ["151.101.0.0/16"]})
 with Sandbox.create(
-    metadata={"network-policy": "custom", "network-rules": rules}
+    allow_internet_access=False,
+    network={"allow_out": ["151.101.0.0/16"]},
+) as sb:
+    sb.run_code("import subprocess; subprocess.run(['pip', 'install', 'requests'])")
+
+# Custom deny-list
+with Sandbox.create(
+    network={"deny_out": ["169.254.0.0/16"]},
 ) as sb:
     sb.run_code("import subprocess; subprocess.run(['pip', 'install', 'requests'])")
 ```
@@ -121,7 +139,7 @@ import json
 from cubesandbox import Sandbox
 
 mounts = json.dumps([{"hostPath": "/data/shared", "mountPath": "/mnt/data"}])
-with Sandbox.create(metadata={"hostdir-mount": mounts}) as sb:
+with Sandbox.create(metadata={"host-mount": mounts}) as sb:
     result = sb.run_code("open('/mnt/data/hello.txt').read()")
     print(result.text)
 ```

--- a/sdk/python/cubesandbox/_commands.py
+++ b/sdk/python/cubesandbox/_commands.py
@@ -20,6 +20,7 @@ CONNECT_CONTENT_TYPE = "application/connect+json"
 CONNECT_END_STREAM_FLAG = 0x02
 CONNECT_COMPRESSED_FLAG = 0x01
 MAX_CONNECT_ENVELOPE_SIZE = 64 * 1024 * 1024
+DEFAULT_ENVD_USER = "root"
 
 
 @dataclass
@@ -52,15 +53,19 @@ class Commands:
 
         Args:
             env: Alias for envs, matching the E2B SDK command API.
+            user: Sandbox user for envd process auth. Defaults to ``"root"``
+                to keep old envd versions from rejecting requests with
+                ``"no user specified"``.
         """
         process_envs = envs if envs is not None else (env or {})
+        effective_user = user or DEFAULT_ENVD_USER
         try:
             return self._run_with_e2b_connect(
                 cmd,
                 timeout=timeout,
                 cwd=cwd,
                 envs=process_envs,
-                user=user,
+                user=effective_user,
             )
         except ImportError:
             return self._run_with_connect_fallback(
@@ -68,7 +73,7 @@ class Commands:
                 timeout=timeout,
                 cwd=cwd,
                 envs=process_envs,
-                user=user,
+                user=effective_user,
             )
 
     def _run_with_e2b_connect(

--- a/sdk/python/cubesandbox/_filesystem.py
+++ b/sdk/python/cubesandbox/_filesystem.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from ._commands import ENVD_PORT
+from ._commands import DEFAULT_ENVD_USER, ENVD_PORT
 
 if TYPE_CHECKING:
     from .sandbox import Sandbox
@@ -19,6 +19,7 @@ class Filesystem:
         """Read a file through envd's HTTP file API."""
         if self._sandbox._client is None:
             self._sandbox._client = self._sandbox._build_data_client()
+        effective_user = user or DEFAULT_ENVD_USER
 
         headers = {}
         access_token = self._sandbox._data.get("envdAccessToken")
@@ -27,7 +28,7 @@ class Filesystem:
 
         resp = self._sandbox._client.get(
             f"http://{self._sandbox.get_host(ENVD_PORT)}/files",
-            params={"path": path, **({"username": user} if user else {})},
+            params={"path": path, "username": effective_user},
             headers=headers,
         )
         if resp.status_code != 200:
@@ -44,6 +45,7 @@ class Filesystem:
         """Write a file through envd's HTTP file API."""
         if self._sandbox._client is None:
             self._sandbox._client = self._sandbox._build_data_client()
+        effective_user = user or DEFAULT_ENVD_USER
 
         headers = {"Content-Type": "application/octet-stream"}
         access_token = self._sandbox._data.get("envdAccessToken")
@@ -51,7 +53,7 @@ class Filesystem:
             headers["X-Access-Token"] = access_token
 
         body = data.encode("utf-8") if isinstance(data, str) else data
-        params = {"path": path, **({"username": user} if user else {})}
+        params = {"path": path, "username": effective_user}
         resp = self._sandbox._client.post(
             f"http://{self._sandbox.get_host(ENVD_PORT)}/files",
             params=params,

--- a/sdk/python/cubesandbox/sandbox.py
+++ b/sdk/python/cubesandbox/sandbox.py
@@ -101,7 +101,7 @@ class Sandbox:
             template: Template ID. Falls back to ``CUBE_TEMPLATE_ID`` env var.
             timeout: Sandbox TTL in seconds. Defaults to ``Config.timeout`` (300).
             env_vars: Environment variables injected into the sandbox.
-            metadata: Arbitrary key-value metadata (e.g. network-policy, hostdir-mount).
+            metadata: Arbitrary key-value metadata (e.g. network-policy, host-mount).
             config: SDK config. Uses default (env-based) config if omitted.
 
         Returns:
@@ -122,9 +122,11 @@ class Sandbox:
         if metadata:
             payload["metadata"] = metadata
         if not allow_internet_access:
-            payload["allowInternetAccess"] = False
+            payload["allow_internet_access"] = False
         if network:
             net: dict = {}
+            if "allow_public_traffic" in network:
+                net["allowPublicTraffic"] = network["allow_public_traffic"]
             if "allow_out" in network:
                 net["allowOut"] = network["allow_out"]
             if "deny_out" in network:

--- a/sdk/python/tests/test_sandbox.py
+++ b/sdk/python/tests/test_sandbox.py
@@ -132,13 +132,19 @@ class TestCreate:
         with patch("requests.Session.post", return_value=mock_response(SANDBOX_DATA, status=201)) as m:
             Sandbox.create(allow_internet_access=False, config=make_config())
         body = m.call_args.kwargs["json"]
-        assert body["allowInternetAccess"] is False
+        assert body["allow_internet_access"] is False
 
     def test_create_allow_internet_access_true_not_in_payload(self):
         with patch("requests.Session.post", return_value=mock_response(SANDBOX_DATA, status=201)) as m:
             Sandbox.create(config=make_config())
         body = m.call_args.kwargs["json"]
-        assert "allowInternetAccess" not in body
+        assert "allow_internet_access" not in body
+
+    def test_create_network_allow_public_traffic(self):
+        with patch("requests.Session.post", return_value=mock_response(SANDBOX_DATA, status=201)) as m:
+            Sandbox.create(network={"allow_public_traffic": False}, config=make_config())
+        body = m.call_args.kwargs["json"]
+        assert body["network"]["allowPublicTraffic"] is False
 
     def test_create_network_allow_out(self):
         with patch("requests.Session.post", return_value=mock_response(SANDBOX_DATA, status=201)) as m:
@@ -599,7 +605,7 @@ class TestCommands:
             patch.object(Commands, "_run_with_e2b_connect", side_effect=ImportError),
             patch.object(sb, "_build_data_client", return_value=client),
         ):
-            result = sb.commands.run("echo hello", cwd="/work", env={"A": "B"}, user="root")
+            result = sb.commands.run("echo hello", cwd="/work", env={"A": "B"})
 
         assert result.stdout == "hello\nworld\n"
         assert result.exit_code == 0
@@ -796,7 +802,7 @@ class TestFilesystem:
 
         client = httpx.Client(transport=httpx.MockTransport(handler))
         with patch.object(sb, "_build_data_client", return_value=client):
-            content = sb.files.read("/tmp/foo.txt", user="root")
+            content = sb.files.read("/tmp/foo.txt")
         assert content == "file content"
         assert seen["method"] == "GET"
         assert seen["host"] == f"49983-{SANDBOX_ID}.{DOMAIN}"
@@ -842,7 +848,7 @@ class TestFilesystem:
 
         client = httpx.Client(transport=httpx.MockTransport(handler))
         with patch.object(sb, "_build_data_client", return_value=client):
-            sb.files.write("/tmp/foo.txt", "file content", user="root")
+            sb.files.write("/tmp/foo.txt", "file content")
 
         assert seen["method"] == "POST"
         assert seen["host"] == f"49983-{SANDBOX_ID}.{DOMAIN}"


### PR DESCRIPTION
## Summary
- default envd process and filesystem requests to the root user for older envd compatibility
- document the Python SDK process/filesystem transport behavior and sandbox lifecycle helpers
- extend Python SDK tests for default user headers and network blocking behavior

## Tests
- `python3 -m compileall -q cubesandbox tests`
- `pytest -q tests` on cubesandbox002: 119 passed, 2 skipped
