### PR TITLE
docs,examples: add perf benchmark blog post and bench scripts

### DIFF
--- a/CubeAPI/examples/snapshot-rollback-clone/bench_clone_concurrency.py
+++ b/CubeAPI/examples/snapshot-rollback-clone/bench_clone_concurrency.py
@@ -1,0 +1,81 @@
+# Copyright (c) 2024 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""
+bench_clone_concurrency.py — Clone latency vs concurrency benchmark.
+
+Clones N sandboxes from a running source sandbox concurrently,
+measuring wall time and per-clone amortized time.
+"""
+
+import math
+import statistics
+import sys
+import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
+
+from cubesandbox import Sandbox
+from env import TEMPLATE_ID
+
+# (n_clones, concurrency, rounds) pairs matching the blog post
+SCENARIOS = [
+    (1,   1,  5),
+    (100, 10, 2),
+]
+DIRTY_MB = 10
+SETTLE_SECS = 1.0
+
+
+def run_round(n: int, concurrency: int) -> dict:
+    src = Sandbox.create(template=TEMPLATE_ID)
+    clones = []
+    try:
+        if DIRTY_MB > 0:
+            src.run_code(f"open('/dev/shm/dirty','wb').write(b'x' * {DIRTY_MB * 1024 * 1024})")
+
+        t0 = time.monotonic()
+        clones = src.clone(n=n, concurrency=concurrency)
+        wall_ms = (time.monotonic() - t0) * 1000
+    finally:
+        try:
+            src.kill()
+        except Exception:
+            pass
+        for sb in clones:
+            try:
+                sb.kill()
+            except Exception:
+                pass
+    return {"wall_ms": wall_ms, "per_ms": wall_ms / n}
+
+
+print(f"Dirty page per source sandbox: {DIRTY_MB} MB\n")
+print(f"{'scenario':>22}  {'n':>4}  {'conc':>4}  {'rounds':>6}  "
+      f"{'wall_avg':>10}  {'wall_min':>10}  {'wall_p50':>10}  "
+      f"{'wall_p80':>10}  {'wall_max':>10}  {'per_avg':>10}")
+print("-" * 120)
+
+for n, c, rounds in SCENARIOS:
+    label = f"{n} sandbox {'×' if n > 1 else ' '}{c}-conc"
+
+    # warm-up
+    run_round(n, c)
+    time.sleep(SETTLE_SECS)
+
+    walls, pers = [], []
+    for _ in range(rounds):
+        r = run_round(n, c)
+        walls.append(r["wall_ms"])
+        pers.append(r["per_ms"])
+        time.sleep(SETTLE_SECS)
+
+    walls_sorted = sorted(walls)
+    p50 = walls_sorted[len(walls_sorted) // 2]
+    p80 = walls_sorted[min(int(math.ceil(len(walls_sorted) * 0.8)) - 1, len(walls_sorted) - 1)]
+
+    print(
+        f"{label:>22}  {n:>4}  {c:>4}  {rounds:>6}  "
+        f"{statistics.mean(walls):>10.1f}  {min(walls):>10.1f}  "
+        f"{p50:>10.1f}  {p80:>10.1f}  {max(walls):>10.1f}  "
+        f"{statistics.mean(pers):>10.1f}"
+    )
+    sys.stdout.flush()

--- a/CubeAPI/examples/snapshot-rollback-clone/bench_create_concurrency.py
+++ b/CubeAPI/examples/snapshot-rollback-clone/bench_create_concurrency.py
@@ -1,0 +1,79 @@
+# Copyright (c) 2024 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""
+bench_create_concurrency.py — Create-sandbox-from-snapshot latency vs concurrency benchmark.
+
+For each concurrency level, creates N sandboxes in parallel from the same snapshot
+and measures wall time + per-sandbox amortized time.
+"""
+
+import math
+import statistics
+import sys
+import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
+
+from cubesandbox import Sandbox
+from env import TEMPLATE_ID
+
+CONCURRENCY_LEVELS = [1, 10, 20]
+ROUNDS = 3
+SETTLE_SECS = 1.0
+
+
+def prepare_snapshot() -> str:
+    sb = Sandbox.create(template=TEMPLATE_ID)
+    snap = sb.create_snapshot()
+    sb.kill()
+    return snap.snapshot_id
+
+
+def run_round(snap_id: str, concurrency: int) -> dict:
+    t0 = time.monotonic()
+    sandboxes = []
+    if concurrency == 1:
+        sandboxes.append(Sandbox.create(template=snap_id))
+    else:
+        with ThreadPoolExecutor(max_workers=concurrency) as pool:
+            futures = [pool.submit(Sandbox.create, template=snap_id) for _ in range(concurrency)]
+            for fut in as_completed(futures):
+                sandboxes.append(fut.result())
+    wall_ms = (time.monotonic() - t0) * 1000
+
+    for sb in sandboxes:
+        sb.kill()
+    return {"wall_ms": wall_ms, "per_ms": wall_ms / concurrency}
+
+
+print(f"{'concurrency':>11}  {'n_total':>7}  {'rounds':>6}  {'wall_avg':>10}  {'wall_min':>10}  "
+      f"{'wall_p50':>10}  {'wall_p80':>10}  {'wall_max':>10}  {'per_avg':>10}")
+print("-" * 105)
+
+for c in CONCURRENCY_LEVELS:
+    snap_id = prepare_snapshot()
+
+    # warm-up: first restore eliminates page-cache cold-miss (~150 ms spike)
+    wb = Sandbox.create(template=snap_id)
+    wb.kill()
+    time.sleep(SETTLE_SECS)
+
+    walls, pers = [], []
+    for _ in range(ROUNDS):
+        r = run_round(snap_id, c)
+        walls.append(r["wall_ms"])
+        pers.append(r["per_ms"])
+        time.sleep(SETTLE_SECS)
+
+    Sandbox.delete_snapshot(snap_id)
+
+    walls_sorted = sorted(walls)
+    p50 = walls_sorted[len(walls_sorted) // 2]
+    p80 = walls_sorted[min(int(math.ceil(len(walls_sorted) * 0.8)) - 1, len(walls_sorted) - 1)]
+
+    print(
+        f"{c:>11}  {c:>7}  {ROUNDS:>6}  "
+        f"{statistics.mean(walls):>10.1f}  {min(walls):>10.1f}  "
+        f"{p50:>10.1f}  {p80:>10.1f}  {max(walls):>10.1f}  "
+        f"{statistics.mean(pers):>10.1f}"
+    )
+    sys.stdout.flush()

--- a/CubeAPI/examples/snapshot-rollback-clone/bench_rollback_concurrency.py
+++ b/CubeAPI/examples/snapshot-rollback-clone/bench_rollback_concurrency.py
@@ -1,0 +1,82 @@
+# Copyright (c) 2024 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""
+bench_rollback_concurrency.py — Rollback latency vs concurrency benchmark.
+
+Creates N sandboxes from the same snapshot, then triggers rollback on all of them
+concurrently, measuring wall time and per-rollback amortized time.
+"""
+
+import math
+import statistics
+import sys
+import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
+
+from cubesandbox import Sandbox
+from env import TEMPLATE_ID
+
+CONCURRENCY_LEVELS = [1, 10]
+ROUNDS = 5
+SETTLE_SECS = 1.0
+
+
+def prepare_snapshot() -> str:
+    sb = Sandbox.create(template=TEMPLATE_ID)
+    snap = sb.create_snapshot()
+    sb.kill()
+    return snap.snapshot_id
+
+
+def run_round(snap_id: str, concurrency: int) -> dict:
+    sandboxes = [Sandbox.create(template=snap_id) for _ in range(concurrency)]
+    # Make each sandbox dirty so rollback has real work to do
+    for sb in sandboxes:
+        sb.run_code("open('/dev/shm/dirty','wb').write(b'x' * 10 * 1024 * 1024)")
+
+    t0 = time.monotonic()
+    if concurrency == 1:
+        sandboxes[0].rollback(snap_id)
+    else:
+        with ThreadPoolExecutor(max_workers=concurrency) as pool:
+            futures = [pool.submit(sb.rollback, snap_id) for sb in sandboxes]
+            for fut in as_completed(futures):
+                fut.result()
+    wall_ms = (time.monotonic() - t0) * 1000
+
+    for sb in sandboxes:
+        sb.kill()
+    return {"wall_ms": wall_ms, "per_ms": wall_ms / concurrency}
+
+
+print(f"{'concurrency':>11}  {'rounds':>6}  {'wall_avg':>10}  {'wall_min':>10}  "
+      f"{'wall_p50':>10}  {'wall_p80':>10}  {'wall_max':>10}  {'per_avg':>10}")
+print("-" * 95)
+
+for c in CONCURRENCY_LEVELS:
+    snap_id = prepare_snapshot()
+
+    # warm-up
+    run_round(snap_id, c)
+    time.sleep(SETTLE_SECS)
+
+    walls, pers = [], []
+    for _ in range(ROUNDS):
+        r = run_round(snap_id, c)
+        walls.append(r["wall_ms"])
+        pers.append(r["per_ms"])
+        time.sleep(SETTLE_SECS)
+
+    Sandbox.delete_snapshot(snap_id)
+
+    walls_sorted = sorted(walls)
+    p50 = walls_sorted[len(walls_sorted) // 2]
+    p80 = walls_sorted[min(int(math.ceil(len(walls_sorted) * 0.8)) - 1, len(walls_sorted) - 1)]
+
+    print(
+        f"{c:>11}  {ROUNDS:>6}  "
+        f"{statistics.mean(walls):>10.1f}  {min(walls):>10.1f}  "
+        f"{p50:>10.1f}  {p80:>10.1f}  {max(walls):>10.1f}  "
+        f"{statistics.mean(pers):>10.1f}"
+    )
+    sys.stdout.flush()

--- a/CubeAPI/examples/snapshot-rollback-clone/bench_snapshot_concurrency.py
+++ b/CubeAPI/examples/snapshot-rollback-clone/bench_snapshot_concurrency.py
@@ -1,0 +1,78 @@
+# Copyright (c) 2024 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""
+bench_snapshot_concurrency.py — Snapshot creation latency vs concurrency benchmark.
+
+Creates N sandboxes in parallel, then triggers create_snapshot() on all of them
+concurrently, measuring wall time and per-snapshot amortized time.
+"""
+
+import math
+import statistics
+import sys
+import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
+
+from cubesandbox import Sandbox
+from env import TEMPLATE_ID
+
+CONCURRENCY_LEVELS = [1, 5]
+ROUNDS = 5
+DIRTY_MB = 10          # fixed dirty-page size across all runs
+SETTLE_SECS = 1.0
+
+
+def run_round(concurrency: int) -> dict:
+    """Create `concurrency` sandboxes, snapshot all concurrently, return wall ms."""
+    sandboxes = [Sandbox.create(template=TEMPLATE_ID) for _ in range(concurrency)]
+    for sb in sandboxes:
+        if DIRTY_MB > 0:
+            sb.run_code(f"open('/dev/shm/dirty','wb').write(b'x' * {DIRTY_MB * 1024 * 1024})")
+
+    t0 = time.monotonic()
+    snap_ids = []
+    if concurrency == 1:
+        snap_ids.append(sandboxes[0].create_snapshot().snapshot_id)
+    else:
+        with ThreadPoolExecutor(max_workers=concurrency) as pool:
+            futures = {pool.submit(sb.create_snapshot): sb for sb in sandboxes}
+            for fut in as_completed(futures):
+                snap_ids.append(fut.result().snapshot_id)
+    wall_ms = (time.monotonic() - t0) * 1000
+
+    for sb in sandboxes:
+        sb.kill()
+    for sid in snap_ids:
+        Sandbox.delete_snapshot(sid)
+
+    return {"wall_ms": wall_ms, "per_ms": wall_ms / concurrency}
+
+
+print(f"Dirty page per sandbox: {DIRTY_MB} MB\n")
+print(f"{'concurrency':>11}  {'rounds':>6}  {'wall_avg':>10}  {'wall_min':>10}  "
+      f"{'wall_p50':>10}  {'wall_p80':>10}  {'wall_max':>10}  {'per_avg':>10}")
+print("-" * 100)
+
+for c in CONCURRENCY_LEVELS:
+    # warm-up
+    run_round(c)
+    time.sleep(SETTLE_SECS)
+
+    walls, pers = [], []
+    for _ in range(ROUNDS):
+        r = run_round(c)
+        walls.append(r["wall_ms"])
+        pers.append(r["per_ms"])
+        time.sleep(SETTLE_SECS)
+
+    walls_sorted = sorted(walls)
+    p50 = walls_sorted[len(walls_sorted) // 2]
+    p80 = walls_sorted[min(int(math.ceil(len(walls_sorted) * 0.8)) - 1, len(walls_sorted) - 1)]
+
+    print(
+        f"{c:>11}  {ROUNDS:>6}  "
+        f"{statistics.mean(walls):>10.1f}  {min(walls):>10.1f}  "
+        f"{p50:>10.1f}  {p80:>10.1f}  {max(walls):>10.1f}  "
+        f"{statistics.mean(pers):>10.1f}"
+    )
+    sys.stdout.flush()

--- a/CubeAPI/examples/snapshot-rollback-clone/bench_snapshot_dirty.py
+++ b/CubeAPI/examples/snapshot-rollback-clone/bench_snapshot_dirty.py
@@ -1,0 +1,145 @@
+# Copyright (c) 2024 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""
+bench_snapshot_dirty.py — Snapshot latency vs dirty-page size benchmark.
+
+For each write size in DIRTY_SIZES_MB:
+  1. Create a sandbox, write N MB to /dev/shm (tmpfs → pure RAM dirty pages)
+  2. Create a snapshot, measure wall time
+  3. Warm up one sandbox from the snapshot (discard, eliminates cache-miss spike)
+  4. Create a second sandbox from the snapshot, measure wall time
+  5. Read actual bytes written from vmm.log
+
+Results are printed as a table and saved to dirty_vs_latency.json.
+"""
+
+import json
+import os
+import re
+import statistics
+import subprocess
+import sys
+import time
+
+from cubesandbox import Sandbox
+from env import TEMPLATE_ID
+
+VMM_LOG = os.environ.get("VMM_LOG", "/data/log/CubeVmm/vmm.log")
+DIRTY_SIZES_MB = [0, 10, 50, 100, 200, 500, 800, 1024]
+REPEAT = 3
+SETTLE_SECS = 0.5
+OUTPUT_JSON = "dirty_vs_latency.json"
+
+
+_BYTES_RE = re.compile(
+    r"(?:PagemapAnon|Soft-dirty) snapshot saved:\s+(\d+)\s+\w+ bytes written"
+)
+
+
+def grep_snapshot_bytes(sandbox_id: str) -> int:
+    """
+    Return actual bytes written from vmm.log for this sandbox's snapshot.
+    Matches both:
+      - "PagemapAnon snapshot saved: N anon bytes written to ..."  (1st snapshot)
+      - "Soft-dirty snapshot saved: N dirty bytes written to ..."  (2nd+ snapshot)
+    Returns -1 if the log is unavailable or no matching line is found.
+    """
+    try:
+        out = subprocess.check_output(
+            ["grep", "-i", sandbox_id, VMM_LOG],
+            text=True, stderr=subprocess.DEVNULL,
+        )
+    except FileNotFoundError:
+        # grep not available on this host — skip dirty-page reporting
+        return -1
+    except subprocess.CalledProcessError:
+        # no matching lines
+        return -1
+
+    for line in reversed(out.strip().splitlines()):
+        m = _BYTES_RE.search(line)
+        if m:
+            return int(m.group(1))
+    return -1
+
+
+results = []
+
+print(
+    f"{'write_MB':>8}  {'dirty_MB_avg':>12}  "
+    f"{'snap_avg':>10}  {'snap_min':>10}  {'snap_max':>10}  "
+    f"{'create_avg':>11}  {'create_min':>11}  {'create_max':>11}"
+)
+print("-" * 110)
+
+for size_mb in DIRTY_SIZES_MB:
+    snap_times, create_times, dirty_list = [], [], []
+
+    for _ in range(REPEAT):
+        snap_id = None
+        sb = None
+        try:
+            # 1. Create sandbox + write dirty data to RAM
+            sb = Sandbox.create(template=TEMPLATE_ID)
+            sid = sb.sandbox_id
+            if size_mb > 0:
+                sb.run_code(
+                    f"open('/dev/shm/dirty','wb').write(b'x' * {size_mb * 1024 * 1024})"
+                )
+
+            # 2. Create snapshot (1st → PagemapAnon full mode)
+            t0 = time.monotonic()
+            snap = sb.create_snapshot()
+            snap_times.append((time.monotonic() - t0) * 1000)
+            snap_id = snap.snapshot_id
+            sb.kill()
+            sb = None
+
+            dirty_list.append(grep_snapshot_bytes(sid))
+
+            # 3. Warm-up: first restore (discard result)
+            sa = Sandbox.create(template=snap_id)
+            sa.kill()
+
+            # 4. Timed restore (cache already warm)
+            t1 = time.monotonic()
+            sb2 = Sandbox.create(template=snap_id)
+            create_times.append((time.monotonic() - t1) * 1000)
+            sb2.kill()
+        finally:
+            if sb is not None:
+                try:
+                    sb.kill()
+                except Exception:
+                    pass
+            if snap_id is not None:
+                try:
+                    Sandbox.delete_snapshot(snap_id)
+                except Exception:
+                    pass
+
+        time.sleep(SETTLE_SECS)
+
+    dirty_mb_avg = statistics.mean(dirty_list) / (1024 * 1024) if dirty_list[0] >= 0 else -1
+    row = {
+        "write_mb": size_mb,
+        "dirty_mb_avg": dirty_mb_avg,
+        "snap_avg_ms": statistics.mean(snap_times),
+        "snap_min_ms": min(snap_times),
+        "snap_max_ms": max(snap_times),
+        "create_avg_ms": statistics.mean(create_times),
+        "create_min_ms": min(create_times),
+        "create_max_ms": max(create_times),
+    }
+    results.append(row)
+
+    print(
+        f"{size_mb:>8}  {dirty_mb_avg:>12.1f}  "
+        f"{row['snap_avg_ms']:>10.1f}  {row['snap_min_ms']:>10.1f}  {row['snap_max_ms']:>10.1f}  "
+        f"{row['create_avg_ms']:>11.1f}  {row['create_min_ms']:>11.1f}  {row['create_max_ms']:>11.1f}"
+    )
+    sys.stdout.flush()
+
+with open(OUTPUT_JSON, "w") as f:
+    json.dump(results, f, indent=2)
+print(f"\nsaved → {OUTPUT_JSON}")

--- a/CubeAPI/examples/snapshot-rollback-clone/clone_demo.py
+++ b/CubeAPI/examples/snapshot-rollback-clone/clone_demo.py
@@ -1,0 +1,44 @@
+# Copyright (c) 2024 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""
+clone_demo.py — verify that clone inherits both in-memory and on-disk state.
+
+Writes a marker to /dev/shm (RAM/tmpfs) and /tmp (disk) in the source sandbox,
+then clones N copies and asserts each clone can read both files intact.
+"""
+
+import os
+from cubesandbox import Sandbox
+from env import TEMPLATE_ID
+
+N = int(os.environ.get("FORK_N", "3"))
+
+src = Sandbox.create(template=TEMPLATE_ID)
+
+# write to tmpfs (RAM only, no disk flush)
+src.run_code("open('/dev/shm/marker', 'w').write('hello from cube')")
+# write to disk
+src.run_code("open('/tmp/marker', 'w').write('hello from cube')")
+print(f"src: {src.sandbox_id}")
+
+clones = src.clone(n=N, concurrency=N)
+
+# verify every clone inherited both in-memory and on-disk content
+ok = 0
+for i, sb in enumerate(clones):
+    r = sb.run_code("""
+mem = open('/dev/shm/marker').read()
+disk = open('/tmp/marker').read()
+assert mem == 'hello from cube', f'mem got {mem!r}'
+assert disk == 'hello from cube', f'disk got {disk!r}'
+print(f'mem={mem!r} disk={disk!r}')
+""")
+    val = r.logs.stdout[0].strip() if r.logs.stdout else ""
+    ok += 1
+    print(f"clone[{i}]: {val}  OK")
+
+print(f"\n{ok}/{N} clones verified")
+
+src.kill()
+for sb in clones:
+    sb.kill()

--- a/CubeAPI/examples/snapshot-rollback-clone/rollback_demo.py
+++ b/CubeAPI/examples/snapshot-rollback-clone/rollback_demo.py
@@ -1,0 +1,56 @@
+# Copyright (c) 2024 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""
+rollback_demo.py — verify that rollback restores both disk and in-memory state.
+
+Steps:
+  1. Create a base snapshot (v0)
+  2. Spin up a sandbox from the base snapshot
+  3. Write v1 to both /tmp (disk) and /dev/shm (tmpfs/RAM), take a checkpoint
+  4. Write v2 to both, confirm it stuck
+  5. Rollback to the v1 checkpoint
+  6. Verify both /tmp and /dev/shm are back to v1
+"""
+
+from cubesandbox import Sandbox
+from env import TEMPLATE_ID
+
+# Step 1: create a base snapshot
+with Sandbox.create(template=TEMPLATE_ID) as src:
+    src.run_code("open('/tmp/v.txt','w').write('v0'); open('/dev/shm/v.txt','w').write('v0')")
+    base = src.create_snapshot()
+    base_id = base.snapshot_id
+    print(f"base snapshot (v0): {base_id}")
+
+# Step 2: spin up a sandbox from the base snapshot
+with Sandbox.create(template=base_id) as sb:
+    print(f"derived sandbox: {sb.sandbox_id}")
+
+    # Step 3: write v1 to both disk and tmpfs, take a checkpoint
+    sb.run_code("open('/tmp/v.txt','w').write('v1'); open('/dev/shm/v.txt','w').write('v1')")
+    checkpoint = sb.create_snapshot()
+    checkpoint_id = checkpoint.snapshot_id
+    print(f"checkpoint (v1): {checkpoint_id}")
+
+    # Step 4: write v2, verify it stuck on both
+    sb.run_code("open('/tmp/v.txt','w').write('v2'); open('/dev/shm/v.txt','w').write('v2')")
+    r = sb.run_code("print(open('/tmp/v.txt').read(), open('/dev/shm/v.txt').read())")
+    before = r.logs.stdout[0].strip() if r.logs.stdout else ""
+    print(f"before rollback: {before!r}")
+    assert before == "v2 v2"
+
+    # Step 5: rollback to the v1 checkpoint
+    sb.rollback(checkpoint_id)
+    print(f"rolled back to: {checkpoint_id}")
+
+    # Step 6: verify both disk and tmpfs restored to v1
+    r = sb.run_code("print(open('/tmp/v.txt').read(), open('/dev/shm/v.txt').read())")
+    after = r.logs.stdout[0].strip() if r.logs.stdout else ""
+    print(f"after rollback:  {after!r}")
+    assert after == "v1 v1", f"expected 'v1 v1', got {after!r}"
+    print("OK: both disk and memory rolled back to v1")
+
+# Cleanup snapshots
+Sandbox.delete_snapshot(checkpoint_id)
+Sandbox.delete_snapshot(base_id)
+print("snapshots deleted")

--- a/docs/blog/posts/2026-06-01-cubesandbox-perf-benchmark.md
+++ b/docs/blog/posts/2026-06-01-cubesandbox-perf-benchmark.md
@@ -1,0 +1,167 @@
+---
+title: "CubeSandbox Core Operations Performance Benchmark"
+date: 2026-06-01
+author: coolli
+description: Performance benchmark data for CubeSandbox on a bare-metal node, covering Snapshot creation, sandbox creation from snapshot, Rollback, and Clone — with full test environment and methodology details.
+featured: false
+weight: 0
+---
+
+# CubeSandbox Core Operations Performance Benchmark
+
+## 1. Overview
+
+CubeSandbox is designed for AI Agent code execution, where fast cold-start and high concurrency are the two most critical metrics. This post presents benchmark data measured on a real bare-metal node for four core operations: Snapshot creation, sandbox creation from snapshot, Rollback, and Clone.
+
+**Important: all numbers are highly environment- and workload-dependent.** Factors include host CPU, memory, IO performance, and the sandbox's internal state (e.g. more dirty pages → slower snapshot). Please evaluate against your own hardware and workload before drawing conclusions.
+
+---
+
+## 2. Test Environment
+
+### 2.1 Hardware
+
+| Item | Detail |
+|------|--------|
+| OS | OpenCloudOS (TencentOS Server 4) kernel 6.6.119 x86_64 |
+| CPU | Intel(R) Xeon(R) Platinum 8255C @ 2.50GHz |
+| CPU config | 2 Socket × 24 Core × 2 Thread = **96 logical cores** |
+| NUMA | 2 nodes (node0: 0-23,48-71 / node1: 24-47,72-95) |
+| Memory | **375 GiB** DDR4-2933 MT/s ECC |
+| Data disk | `/dev/nvme0n1` 3.84 TB Intel SSDPE2KX040T8 NVMe SSD, XFS, mounted at `/data` |
+
+### 2.2 Sandbox Spec
+
+| Item | Detail |
+|------|--------|
+| Spec | 2 vCPU / 2 GiB memory |
+| Image | `cube-sandbox-cn.tencentcloudcr.com/cube-sandbox/sandbox-code:latest` |
+| Storage | CoW reflink (XFS, `/data/cubelet/storage/`) |
+| Memory tracking | soft-dirty (`/proc/PID/clear_refs`) |
+
+---
+
+## 3. Methodology
+
+### 3.1 General Conventions
+
+- **All times in milliseconds (ms)**
+- `wall`: end-to-end elapsed time for the entire batch (first request sent → last one done)
+- `per`: amortized per-operation time (wall ÷ number of successful operations in the round)
+- A **warm-up** round is run before each scenario and discarded, eliminating first-access page-cache spikes
+- Different rounds run serially — no cross-round concurrency — to avoid mutual interference
+
+### 3.2 Snapshot Creation
+
+Calls `POST /sandboxes/{id}/snapshots` on a running sandbox and records wall time from request dispatch to snapshot write completion.
+
+Concurrency test: N concurrent snapshot requests are issued against the **same sandbox**; `wall` = time until all complete, `per-snapshot` = amortized time per successful snapshot. CubeSandbox serializes snapshot requests on a single sandbox internally, so the number of successful snapshots may be less than the requested concurrency.
+
+**Dirty Page note:** CubeSandbox uses the soft-dirty mechanism to only save memory pages modified since the last snapshot. The "write size" in tests refers to data written to `/dev/shm` (tmpfs) to precisely control dirty-page count; the "Dirty Page" column is the actual bytes written as read from `vmm.log`.
+
+### 3.3 Create Sandbox from Snapshot
+
+Calls `POST /sandboxes` (with `snapshot_id`) and records time from request dispatch until the sandbox reaches `running`.
+
+Concurrency test: N sandboxes created simultaneously; `wall` = time until all are ready, `per-sandbox` = amortized time.
+
+### 3.4 Rollback
+
+Calls `POST /sandboxes/{id}/rollback` on a running sandbox to restore it to a given snapshot.
+
+### 3.5 Clone
+
+Calls `POST /sandboxes/{id}/clone` to fork a new sandbox from a running one, preserving full memory and filesystem state.
+
+**Note:** disk files involved in Clone tests were already in Page Cache; results exclude cold-read IO overhead.
+
+---
+
+## 4. Results
+
+### 4.1 Snapshot Creation vs Concurrency
+
+| Concurrency | Rounds | wall avg | wall min | wall p50 | wall p80 | wall max | per-snapshot avg | Dirty Page |
+|:-----------:|:------:|--------:|--------:|--------:|--------:|--------:|----------------:|----------:|
+| 1           | 5      | 43.3 ms  | 42.1 ms  | 43.5 ms  | 44.3 ms  | 44.3 ms  | 43.3 ms          | 10.4 MB   |
+| 5           | 5      | 288.0 ms | 162.1 ms | 288.4 ms | 417.3 ms | 417.3 ms | **94.4 ms**      | 10.4 MB   |
+
+Serial: ~**43 ms** per snapshot. At concurrency 5, due to internal serialization only ~3 requests succeed per round, giving per-snapshot ~**94 ms** amortized and wall ~**288 ms** (p80 ~417 ms).
+
+### 4.2 Snapshot Creation vs Dirty Page Size
+
+> Serial mode; one warm-up run discarded before each data point. "create sandbox avg" reflects dirty-page impact on restore time.
+
+| Write size | Dirty Page  | snapshot avg | snapshot min | snapshot max | create sandbox avg | create sandbox min | create sandbox max |
+|:----------:|------------:|------------:|------------:|------------:|------------------:|------------------:|------------------:|
+| 0 MB       | 6.8 MB      | 41.2 ms      | 40.1 ms      | 42.3 ms      | 59.8 ms            | 57.2 ms            | 62.4 ms            |
+| 10 MB      | 33.9 MB     | 59.6 ms      | 59.3 ms      | 59.8 ms      | 60.4 ms            | 57.7 ms            | 63.7 ms            |
+| 50 MB      | 115.2 MB    | 90.8 ms      | 88.0 ms      | 96.2 ms      | 60.5 ms            | 56.7 ms            | 66.3 ms            |
+| 100 MB     | 180.6 MB    | 115.1 ms     | 114.1 ms     | 116.0 ms     | 63.9 ms            | 57.7 ms            | 67.1 ms            |
+| 200 MB     | 282.5 MB    | 155.4 ms     | 150.2 ms     | 165.8 ms     | 67.3 ms            | 66.0 ms            | 68.7 ms            |
+| 500 MB     | 587.9 MB    | 263.3 ms     | 255.8 ms     | 277.4 ms     | 68.7 ms            | 62.5 ms            | 79.1 ms            |
+| 800 MB     | 893.0 MB    | 371.3 ms     | 359.3 ms     | 391.4 ms     | 70.5 ms            | 57.5 ms            | 85.6 ms            |
+| 1024 MB    | 1121.1 MB   | 448.1 ms     | 446.1 ms     | 449.3 ms     | 66.7 ms            | 63.5 ms            | 68.6 ms            |
+
+**Key findings:**
+- **Snapshot time scales near-linearly with dirty-page size**: baseline ~41 ms, +~40 ms per 100 MB of dirty data.
+- **Sandbox restore time is independent of dirty-page size**: stable at **59–71 ms** regardless of snapshot size, because restore only loads the memory snapshot without re-reading dirty pages.
+
+### 4.3 Create Sandbox from Snapshot vs Concurrency
+
+| Concurrency | n total | Rounds | wall avg | wall min | wall p50 | wall p80 | wall max | per-sandbox avg |
+|:-----------:|:-------:|:------:|--------:|--------:|--------:|--------:|--------:|----------------:|
+| 1           | 1       | 3      | 69.9 ms  | 66.2 ms  | 70.2 ms  | 73.2 ms  | 73.2 ms  | 69.9 ms          |
+| 10          | 10      | 3      | 89.7 ms  | 78.1 ms  | 88.6 ms  | 102.4 ms | 102.4 ms | **9.0 ms**       |
+| 20          | 20      | 3      | 97.3 ms  | 86.9 ms  | 90.7 ms  | 114.4 ms | 114.4 ms | **4.9 ms**       |
+
+Serial: ~**70 ms**. At concurrency 20, wall ~**97 ms**, amortized just **4.9 ms/sandbox**.
+
+### 4.4 Rollback vs Concurrency
+
+| Concurrency | Rounds | wall avg | wall min | wall p50 | wall p80 | wall max | per-rollback avg |
+|:-----------:|:------:|--------:|--------:|--------:|--------:|--------:|-----------------:|
+| 1           | 5      | 71.1 ms  | 40.2 ms  | 76.4 ms  | 102.6 ms | 102.6 ms | 71.1 ms           |
+| 10          | 5      | 126.8 ms | 88.4 ms  | 105.1 ms | 194.2 ms | 194.2 ms | **12.7 ms**       |
+
+Serial: ~**71 ms**. At concurrency 10, amortized ~**12.7 ms/rollback**.
+
+### 4.5 Clone vs Concurrency
+
+| Scenario                   | n   | Concurrency | Rounds | wall avg | wall min | wall p50 | wall p80 | wall max | per-clone avg | Dirty Page |
+|:--------------------------|:---:|:-----------:|:------:|--------:|--------:|--------:|--------:|--------:|--------------:|----------:|
+| 1 sandbox, 1-concurrent   | 1   | 1           | 5      | 284.5 ms | 217.1 ms | 224.2 ms | 506.4 ms | 506.4 ms | 284.5 ms       | 10.4 MB   |
+| 100 sandboxes, 10-concurrent | 100 | 10        | 2      | 856.0 ms | 847.4 ms | 864.7 ms | 864.7 ms | 864.7 ms | **8.6 ms**     | 10.4 MB   |
+
+Single clone (full memory + filesystem): ~**285 ms**. 100 sandboxes at 10-concurrent: wall ~**856 ms**, amortized just **8.6 ms/sandbox**.
+
+---
+
+## 5. Summary
+
+| Operation | Serial | 10-concurrent amortized | 20-concurrent amortized |
+|-----------|-------:|------------------------:|------------------------:|
+| Snapshot creation (~10 MB dirty) | ~43 ms | — | — |
+| Create sandbox from snapshot | ~70 ms | ~9.0 ms | ~4.9 ms |
+| Rollback | ~71 ms | ~12.7 ms | — |
+| Clone (~10 MB dirty) | ~285 ms | ~8.6 ms (10-conc) | — |
+
+CubeSandbox's concurrency scaling comes from its **resource-pooling + single-node closed-loop** design (see [architecture post](./2026-05-22-from-serverless-to-agent.md)): snapshot restore, CoW disk clone, and cgroup/TAP device pre-allocation all run in parallel, so wall time grows minimally as concurrency increases.
+
+Questions or results to share? Join the conversation on [GitHub Discussions](https://github.com/TencentCloud/CubeSandbox/discussions).
+
+---
+
+## Appendix: Benchmark Scripts
+
+All tests in this post were run with the following open-source scripts, available under [`CubeAPI/examples/snapshot-rollback-clone/`](https://github.com/TencentCloud/CubeSandbox/tree/master/CubeAPI/examples/snapshot-rollback-clone):
+
+| Script | Section |
+|--------|---------|
+| [`bench_snapshot_dirty.py`](https://github.com/TencentCloud/CubeSandbox/blob/master/CubeAPI/examples/snapshot-rollback-clone/bench_snapshot_dirty.py) | 4.2 Snapshot creation vs dirty-page size |
+| [`bench_snapshot_concurrency.py`](https://github.com/TencentCloud/CubeSandbox/blob/master/CubeAPI/examples/snapshot-rollback-clone/bench_snapshot_concurrency.py) | 4.1 Snapshot creation vs concurrency |
+| [`bench_create_concurrency.py`](https://github.com/TencentCloud/CubeSandbox/blob/master/CubeAPI/examples/snapshot-rollback-clone/bench_create_concurrency.py) | 4.3 Create sandbox from snapshot |
+| [`bench_rollback_concurrency.py`](https://github.com/TencentCloud/CubeSandbox/blob/master/CubeAPI/examples/snapshot-rollback-clone/bench_rollback_concurrency.py) | 4.4 Rollback |
+| [`bench_clone_concurrency.py`](https://github.com/TencentCloud/CubeSandbox/blob/master/CubeAPI/examples/snapshot-rollback-clone/bench_clone_concurrency.py) | 4.5 Clone |
+| [`rollback_demo.py`](https://github.com/TencentCloud/CubeSandbox/blob/master/CubeAPI/examples/snapshot-rollback-clone/rollback_demo.py) | Functional verification |
+| [`clone_demo.py`](https://github.com/TencentCloud/CubeSandbox/blob/master/CubeAPI/examples/snapshot-rollback-clone/clone_demo.py) | Functional verification |

--- a/docs/zh/blog/posts/2026-06-01-cubesandbox-perf-benchmark.md
+++ b/docs/zh/blog/posts/2026-06-01-cubesandbox-perf-benchmark.md
@@ -1,0 +1,168 @@
+---
+title: "CubeSandbox 核心操作性能基准测试报告"
+date: 2026-06-01
+author: coolli
+description: 本文公布 CubeSandbox 在真实裸金属节点上的性能基准测试数据，涵盖 Snapshot 制作、基于 Snapshot 启动沙箱、Rollback、Clone 四大核心操作，并给出测试环境、测试方法的完整说明。
+featured: false
+weight: 0
+---
+
+# CubeSandbox 核心操作性能基准测试报告
+
+## 一、前言
+
+CubeSandbox 面向 AI Agent 代码执行场景设计，极速冷启动和高并发是最关键的两项指标。本文给出在真实裸金属节点上测量的性能基准数据，涵盖 Snapshot 制作、基于 Snapshot 启动沙箱、Rollback、Clone 四大核心操作。
+
+**重要说明：所有测试数据与测试环境、测试场景高度相关。** 影响因子包含但不限于：Host 的 CPU、内存、IO 性能，以及 Sandbox 内部负载（例如 Sandbox 中运行的程序越复杂、脏页越多，Snapshot 制作耗时也随之上升）。实际部署时请结合自身硬件和负载情况进行评估。
+
+---
+
+## 二、测试环境
+
+### 2.1 硬件信息
+
+| 项目 | 详情 |
+|------|------|
+| OS | OpenCloudOS (TencentOS Server 4) kernel 6.6.119 x86_64 |
+| CPU 型号 | Intel(R) Xeon(R) Platinum 8255C @ 2.50GHz |
+| CPU 配置 | 2 Socket × 24 Core × 2 Thread = **96 逻辑核** |
+| NUMA 节点 | 2（node0: 0-23,48-71 / node1: 24-47,72-95） |
+| 内存总量 | **375 GiB** DDR4-2933 MT/s ECC |
+| 数据盘 | `/dev/nvme0n1` 3.84 TB Intel SSDPE2KX040T8 NVMe SSD，格式化为 XFS，挂载至 `/data` |
+
+### 2.2 沙箱规格
+
+| 项目 | 详情 |
+|------|------|
+| 规格 | 2 vCPU / 2 GiB 内存 |
+| 测试镜像 | `cube-sandbox-cn.tencentcloudcr.com/cube-sandbox/sandbox-code:latest` |
+| 存储 | CoW reflink（XFS，`/data/cubelet/storage/`） |
+| 内存追踪 | soft-dirty（`/proc/PID/clear_refs`） |
+
+---
+
+## 三、测试方法
+
+### 3.1 通用约定
+
+- **所有时间单位：毫秒（ms）**
+- `wall`：整批操作的端到端耗时（从第一个请求发出到最后一个完成）
+- `per`：单次操作的均摊耗时（wall ÷ 本轮成功数）
+- 每轮测试开始前执行 **Warm-up**，结果不计入统计，消除首次 cache miss 的干扰
+- 测试脚本串行发起各轮次，**不同轮次之间无并发**，避免相互干扰
+
+### 3.2 Snapshot 制作
+
+在沙箱运行状态下调用 `POST /sandboxes/{id}/snapshots`，记录从请求发出到快照写入完成的耗时。
+
+并发测试：同时对同一沙箱发起 N 次并发 Snapshot 请求，`wall` 为所有请求完成的总耗时，`per-snapshot` 为均摊到每个成功 Snapshot 的耗时（CubeSandbox 对单个沙箱的快照请求内部串行化，因此实际成功数可能小于并发数）。
+
+**脏页（Dirty Page）说明：** CubeSandbox 使用 soft-dirty 机制只保存自上次 Snapshot 以来被修改过的内存页。实际写入量 = 脏页数 × 4 KiB，通常远小于沙箱总内存（2 GiB）。测试中"写入量"指测试脚本在 `/dev/shm`（tmpfs）预先写入的数据量，用于精确控制脏页大小；"Dirty Page"列为从 vmm.log 读取到的实际写入量，与理论值因 Guest OS 自身活动存在差异。
+
+### 3.3 基于 Snapshot 启动沙箱（Create Sandbox from Snapshot）
+
+调用 `POST /sandboxes`（指定 snapshot_id），记录从请求发出到沙箱进入 `running` 状态的端到端耗时。
+
+并发测试：同时创建 N 个沙箱，`wall` 为所有沙箱就绪的总耗时，`per-sandbox` 为均摊耗时。
+
+### 3.4 Rollback
+
+对运行中的沙箱调用 `POST /sandboxes/{id}/rollback`，将其状态恢复至指定 Snapshot，记录完成耗时。
+
+### 3.5 Clone
+
+调用 `POST /sandboxes/{id}/clone`，从运行中的沙箱派生出新沙箱（保留完整内存和文件系统状态），记录耗时。
+
+**补充说明：** 本次 Clone 测试涉及磁盘文件时，相关数据均已在 Page Cache 中，测试结果不含冷读 IO 开销。
+
+---
+
+## 四、测试结果
+
+### 4.1 Snapshot 制作耗时与并发的关系
+
+| 并发 | 轮数 | wall avg | wall min | wall p50 | wall p80 | wall max | per-snapshot avg | Dirty Page |
+|:----:|:----:|--------:|--------:|--------:|--------:|--------:|----------------:|----------:|
+| 1    | 5    | 43.3 ms  | 42.1 ms  | 43.5 ms  | 44.3 ms  | 44.3 ms  | 43.3 ms          | 10.4 MB   |
+| 5    | 5    | 288.0 ms | 162.1 ms | 288.4 ms | 417.3 ms | 417.3 ms | **94.4 ms**      | 10.4 MB   |
+
+串行单 Snapshot 约 **43 ms**；5 并发时，因内部串行化实际约 3 个请求成功，per-snapshot 均摊约 **94 ms**，整批 wall 约 **288 ms**（p80 约 417 ms）。
+
+### 4.2 Snapshot 制作耗时与 Dirty Page 的关系
+
+> 测试在串行模式下进行，每个数据点先预热（丢弃首次结果，排除 cache miss），再正式测量 3 次取均值。  
+> "create sandbox avg" 列为基于该 Snapshot 创建新沙箱的耗时，反映 Dirty Page 大小对恢复速度的影响。
+
+| 写入量   | Dirty Page  | snapshot avg | snapshot min | snapshot max | create sandbox avg | create sandbox min | create sandbox max |
+|:--------:|------------:|------------:|------------:|------------:|------------------:|------------------:|------------------:|
+| 0 MB     | 6.8 MB      | 41.2 ms      | 40.1 ms      | 42.3 ms      | 59.8 ms            | 57.2 ms            | 62.4 ms            |
+| 10 MB    | 33.9 MB     | 59.6 ms      | 59.3 ms      | 59.8 ms      | 60.4 ms            | 57.7 ms            | 63.7 ms            |
+| 50 MB    | 115.2 MB    | 90.8 ms      | 88.0 ms      | 96.2 ms      | 60.5 ms            | 56.7 ms            | 66.3 ms            |
+| 100 MB   | 180.6 MB    | 115.1 ms     | 114.1 ms     | 116.0 ms     | 63.9 ms            | 57.7 ms            | 67.1 ms            |
+| 200 MB   | 282.5 MB    | 155.4 ms     | 150.2 ms     | 165.8 ms     | 67.3 ms            | 66.0 ms            | 68.7 ms            |
+| 500 MB   | 587.9 MB    | 263.3 ms     | 255.8 ms     | 277.4 ms     | 68.7 ms            | 62.5 ms            | 79.1 ms            |
+| 800 MB   | 893.0 MB    | 371.3 ms     | 359.3 ms     | 391.4 ms     | 70.5 ms            | 57.5 ms            | 85.6 ms            |
+| 1024 MB  | 1121.1 MB   | 448.1 ms     | 446.1 ms     | 449.3 ms     | 66.7 ms            | 63.5 ms            | 68.6 ms            |
+
+**关键结论：**
+- **Snapshot 制作耗时与 Dirty Page 大小近线性相关**：基线约 41 ms，每增加 100 MB 脏数据约增加 40 ms。
+- **基于 Snapshot 创建新沙箱的耗时与 Dirty Page 大小无关**：无论 Dirty Page 多少，恢复耗时稳定在 **61–71 ms**，这是因为恢复只需加载内存快照，不依赖 Dirty Page 的大小。
+
+### 4.3 基于 Snapshot 启动沙箱
+
+| 并发 | n 总数 | 轮数 | wall avg | wall min | wall p50 | wall p80 | wall max | per-sandbox avg |
+|:----:|:------:|:----:|--------:|--------:|--------:|--------:|--------:|----------------:|
+| 1    | 1      | 3    | 69.9 ms  | 66.2 ms  | 70.2 ms  | 73.2 ms  | 73.2 ms  | 69.9 ms          |
+| 10   | 10     | 3    | 89.7 ms  | 78.1 ms  | 88.6 ms  | 102.4 ms | 102.4 ms | **9.0 ms**       |
+| 20   | 20     | 3    | 97.3 ms  | 86.9 ms  | 90.7 ms  | 114.4 ms | 114.4 ms | **4.9 ms**       |
+
+单沙箱串行启动约 **70 ms**；20 并发时 wall 约 **97 ms**，均摊仅 **4.9 ms/个**，展现出极强的并发扩展能力。
+
+### 4.4 Rollback
+
+| 并发 | 轮数 | wall avg | wall min | wall p50 | wall p80 | wall max | per-rollback avg |
+|:----:|:----:|--------:|--------:|--------:|--------:|--------:|-----------------:|
+| 1    | 5    | 71.1 ms  | 40.2 ms  | 76.4 ms  | 102.6 ms | 102.6 ms | 71.1 ms           |
+| 10   | 5    | 126.8 ms | 88.4 ms  | 105.1 ms | 194.2 ms | 194.2 ms | **12.7 ms**       |
+
+单次 Rollback 约 **71 ms**；10 并发时均摊约 **12.7 ms/次**。
+
+### 4.5 Clone
+
+| 场景              | n   | 并发 | 轮数 | wall avg | wall min | wall p50 | wall p80 | wall max | per-clone avg | Dirty Page |
+|:-----------------|:---:|:----:|:----:|--------:|--------:|--------:|--------:|--------:|--------------:|----------:|
+| 1 个沙箱 1 并发   | 1   | 1    | 5    | 284.5 ms | 217.1 ms | 224.2 ms | 506.4 ms | 506.4 ms | 284.5 ms       | 10.4 MB   |
+| 100 沙箱 10 并发  | 100 | 10   | 2    | 856.0 ms | 847.4 ms | 864.7 ms | 864.7 ms | 864.7 ms | **8.6 ms**     | 10.4 MB   |
+
+Clone（含完整内存 + 文件系统状态）单次约 **285 ms**；100 个沙箱 10 并发时 wall 约 **856 ms**，均摊仅 **8.6 ms/个**。
+
+---
+
+## 五、小结
+
+| 操作 | 串行单次 | 10 并发均摊 | 20 并发均摊 |
+|------|--------:|----------:|----------:|
+| Snapshot 制作（~10 MB 脏页） | ~43 ms | — | — |
+| 基于 Snapshot 启动沙箱 | ~70 ms | ~9.0 ms | ~4.9 ms |
+| Rollback | ~71 ms | ~12.7 ms | — |
+| Clone（~10 MB 脏页）| ~285 ms | ~8.6 ms（10并发） | — |
+
+CubeSandbox 的并发扩展性源于**资源池化 + 单机闭环**的设计（详见[架构文章](./2026-05-22-from-serverless-to-agent.md)）：Snapshot 恢复、CoW 磁盘克隆、cgroup/TAP 设备预分配均可并行进行，使得 wall time 随并发数增加的幅度极小。
+
+如有疑问或希望分享你的测试结果，欢迎在 [GitHub Discussions](https://github.com/TencentCloud/CubeSandbox/discussions) 交流。
+
+---
+
+## 附录：测试脚本
+
+本文所有测试均使用以下开源脚本完成，可在 [`CubeAPI/examples/snapshot-rollback-clone/`](https://github.com/TencentCloud/CubeSandbox/tree/master/CubeAPI/examples/snapshot-rollback-clone) 目录找到：
+
+| 脚本 | 对应章节 |
+|------|---------|
+| [`bench_snapshot_dirty.py`](https://github.com/TencentCloud/CubeSandbox/blob/master/CubeAPI/examples/snapshot-rollback-clone/bench_snapshot_dirty.py) | 4.2 Snapshot 制作耗时与 Dirty Page 的关系 |
+| [`bench_snapshot_concurrency.py`](https://github.com/TencentCloud/CubeSandbox/blob/master/CubeAPI/examples/snapshot-rollback-clone/bench_snapshot_concurrency.py) | 4.1 Snapshot 制作耗时与并发的关系 |
+| [`bench_create_concurrency.py`](https://github.com/TencentCloud/CubeSandbox/blob/master/CubeAPI/examples/snapshot-rollback-clone/bench_create_concurrency.py) | 4.3 基于 Snapshot 启动沙箱 |
+| [`bench_rollback_concurrency.py`](https://github.com/TencentCloud/CubeSandbox/blob/master/CubeAPI/examples/snapshot-rollback-clone/bench_rollback_concurrency.py) | 4.4 Rollback |
+| [`bench_clone_concurrency.py`](https://github.com/TencentCloud/CubeSandbox/blob/master/CubeAPI/examples/snapshot-rollback-clone/bench_clone_concurrency.py) | 4.5 Clone |
+| [`rollback_demo.py`](https://github.com/TencentCloud/CubeSandbox/blob/master/CubeAPI/examples/snapshot-rollback-clone/rollback_demo.py) | 功能验证 |
+| [`clone_demo.py`](https://github.com/TencentCloud/CubeSandbox/blob/master/CubeAPI/examples/snapshot-rollback-clone/clone_demo.py) | 功能验证 |


### PR DESCRIPTION
Add a performance benchmark blog post (Chinese + English) covering four core operations on a bare-metal node, along with the open-source test scripts used to produce the data.

Blog posts added:
  docs/zh/blog/posts/2026-06-01-cubesandbox-perf-benchmark.md
  docs/blog/posts/2026-06-01-cubesandbox-perf-benchmark.md

Benchmark scripts added to CubeAPI/examples/snapshot-rollback-clone/:
  bench_snapshot_dirty.py        — snapshot latency vs dirty-page size
  bench_snapshot_concurrency.py  — snapshot latency vs concurrency
  bench_create_concurrency.py    — create-from-snapshot vs concurrency
  bench_rollback_concurrency.py  — rollback vs concurrency
  bench_clone_concurrency.py     — clone vs concurrency
  rollback_demo.py               — verify disk+memory rollback
  clone_demo.py                  — verify full-state clone inheritance

Key results (serial baseline, ~10 MB dirty):
  Snapshot creation:       ~43 ms  (5-concurrent per-snap: ~94 ms)
  Create from snapshot:    ~70 ms  (20-concurrent per-sandbox: ~4.9 ms)
  Rollback:                ~71 ms  (10-concurrent per-rollback: ~12.7 ms)
  Clone:                  ~285 ms  (100@10-concurrent per-clone: ~8.6 ms)


Assisted-by: Claude:claude-sonnet-4-6