### PR TITLE
feat(agenthub): refine digital assistant preview support

### DIFF
--- a/CubeAPI/src/handlers/agenthub.rs
+++ b/CubeAPI/src/handlers/agenthub.rs
@@ -141,6 +141,12 @@ pub struct AgentRecoverResponse {
 
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
+pub struct AgentGatewayHealthResponse {
+    pub ready: bool,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct PublishAgentTemplateResponse {
     pub template_id: String,
     pub snapshot_id: String,
@@ -447,6 +453,33 @@ pub async fn list_agent_instances(State(state): State<AppState>) -> AppResult<im
         .map(|record| record.into_response())
         .collect::<Vec<_>>();
     Ok((StatusCode::OK, Json(instances)))
+}
+
+pub async fn get_agent_gateway_health(
+    State(state): State<AppState>,
+    Path(agent_id): Path<String>,
+) -> AppResult<impl IntoResponse> {
+    let record = read_agenthub_instance(&state, &agent_id).await?;
+    let proxy_base = std::env::var("AGENTHUB_SANDBOX_PROXY_URL")
+        .unwrap_or_else(|_| "http://127.0.0.1".to_string());
+    let url = format!(
+        "{}/sandbox/{}/{}/",
+        proxy_base.trim_end_matches('/'),
+        record.sandbox_id,
+        OPENCLAW_UI_PORT
+    );
+    let ready = match state
+        .http_client
+        .get(url)
+        .timeout(Duration::from_secs(3))
+        .send()
+        .await
+    {
+        Ok(resp) => resp.status().is_success(),
+        Err(_) => false,
+    };
+
+    Ok((StatusCode::OK, Json(AgentGatewayHealthResponse { ready })))
 }
 
 pub async fn list_agent_templates(State(state): State<AppState>) -> AppResult<impl IntoResponse> {
@@ -912,6 +945,11 @@ pub async fn clone_agent_instance(
         gateway_token.clone(),
     );
     let env_url = sandbox_url(LOGIN_ENV_PORT, &sandbox_id, &domain);
+    let bots_available = ["wecom"]
+        .into_iter()
+        .filter(|b| !record.bots.iter().any(|v| v == b))
+        .map(ToString::to_string)
+        .collect();
     let response = AgentInstanceResponse {
         id: format!("agent-{}", sandbox_id),
         name: clone_name,
@@ -921,7 +959,7 @@ pub async fn clone_agent_instance(
         model: record.model.clone(),
         version: record.version.clone(),
         bots: record.bots.clone(),
-        bots_available: Vec::new(),
+        bots_available,
         avatar: record.avatar.clone(),
         avatar_tone: record.avatar_tone.clone(),
         sandbox_id: sandbox_id.clone(),

--- a/CubeAPI/src/routes.rs
+++ b/CubeAPI/src/routes.rs
@@ -268,6 +268,10 @@ fn build_agenthub_routes(state: &AppState, auth_configured: bool) -> Router<AppS
             get(agenthub::list_agent_operations),
         )
         .route(
+            "/agenthub/instances/:agentID/gateway/health",
+            get(agenthub::get_agent_gateway_health),
+        )
+        .route(
             "/agenthub/instances/:agentID/pause",
             post(agenthub::pause_agent_openclaw),
         )

--- a/deploy/one-click/env.example
+++ b/deploy/one-click/env.example
@@ -124,7 +124,7 @@ CUBE_API_SANDBOX_DOMAIN=cube.app
 # CubeAPI uses DATABASE_URL for AgentHub persistence. When DATABASE_URL is
 # empty, one-click builds it from CUBE_SANDBOX_MYSQL_{HOST,PORT,USER,PASSWORD,DB}.
 # The default below points to the bundled one-click MySQL service.
-# DATABASE_URL=mysql://cube:cube_pass@127.0.0.1:3306/cube_mvp
+DATABASE_URL=mysql://cube:cube_pass@127.0.0.1:3306/cube_mvp
 # CUBE_API_DATABASE_URL is also accepted by CubeAPI when DATABASE_URL is unset.
 # CUBE_API_DATABASE_URL=mysql://cube:cube_pass@127.0.0.1:3306/cube_mvp
 #

--- a/docs/guide/digital-assistant.md
+++ b/docs/guide/digital-assistant.md
@@ -2,6 +2,10 @@
 
 The Digital Assistant (AgentHub) uses Cube Sandbox to create and manage OpenClaw assistants. It supports assistant instances, snapshots, rollback, clone creation, assistant template publishing, and operation history.
 
+::: warning Preview
+The Digital Assistant is a preview feature intended for demos and early validation. APIs, database schema, deployment options, and UX details may still change in later releases. Validate it in a non-production environment before production use.
+:::
+
 ## Digital Assistant Template
 
 AgentHub creates assistants from a CubeSandbox template. By default, CubeAPI uses the prebuilt Digital Assistant template:
@@ -20,6 +24,17 @@ A custom template must be built from the **same Digital Assistant / OpenClaw ima
 
 - OpenClaw Gateway UI: `18789`
 - assistant environment UI: `8080`
+
+The default template is built from an all-in-one OpenClaw image, which is relatively large. Initial template creation or rebuilds need enough space for image download, extraction, snapshotting, and distribution. In typical demo environments, creating the template takes about 15 minutes; actual time depends on image cache state, disk performance, and node count. Before building the template, make sure the host and Cubelet data disk have enough free space to avoid failures caused by running out of disk.
+
+Use the following rough estimate for disk space planning:
+
+- One template is about `3 GB` (rootfs `1G` + memory `2G`).
+- One snapshot is about `2~3 GB` (memory is always `2G` plus the rootfs delta).
+- One running instance mainly uses reflink deltas, usually only tens of MB.
+- Docker infrastructure is about `3.2 GB` as fixed overhead.
+
+If you keep only `1` template, `2` snapshots, and a few running instances, reserve about `12~15 GB` of free disk space.
 
 Build or re-create the template with `cubemastercli tpl create-from-image` using the same image:
 

--- a/docs/zh/guide/digital-assistant.md
+++ b/docs/zh/guide/digital-assistant.md
@@ -2,6 +2,10 @@
 
 数字助手（AgentHub）基于 Cube Sandbox 创建和管理 OpenClaw 助手，支持助手实例、存档、回档、创建分身、发布助手模板和操作流水。
 
+::: warning 预览版
+当前数字助手能力是 Preview 版本，主要用于演示和早期试用。API、数据库 schema、部署参数和交互细节仍可能在后续版本中调整，生产环境使用前建议先在测试环境验证。
+:::
+
 ## 数字助手模板
 
 AgentHub 会基于 CubeSandbox 模板创建数字助手。默认情况下，CubeAPI 使用预置的数字助手模板：
@@ -20,6 +24,17 @@ AGENTHUB_DS_OPENCLAW_TEMPLATE=<your-digital-assistant-template-id>
 
 - OpenClaw Gateway UI：`18789`
 - 助手环境 UI：`8080`
+
+默认模板基于 all-in-one OpenClaw 镜像制作，镜像体积较大。首次制作或重建模板时，需要预留充足的下载、解压、快照和分发空间；在常见演示环境中，模板制作时间约为 15 分钟，具体耗时取决于镜像缓存、磁盘性能和节点数量。部署前建议确认宿主机和 Cubelet 数据盘有足够可用空间，避免模板构建中途因为磁盘不足失败。
+
+磁盘空间可以按以下方式粗略估算：
+
+- 单模板约 `3 GB`（rootfs `1G` + memory `2G`）。
+- 单 snapshot 约 `2~3 GB`（memory 必定 `2G` + rootfs 增量）。
+- 单运行实例主要是 reflink 增量，通常约几十 MB。
+- Docker 基础设施约 `3.2 GB`，属于固定开销。
+
+因此，如果只保留 `1` 个模板、`2` 个 snapshot 和几个运行实例，建议至少预留约 `12~15 GB` 可用磁盘空间。
 
 可以使用 `cubemastercli tpl create-from-image` 基于相同镜像构建或重建模板：
 

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -245,6 +245,10 @@ export interface AgentWeComConfigDto {
   botSecret: string;
 }
 
+export interface AgentGatewayHealthDto {
+  ready: boolean;
+}
+
 export interface AgentSetupResultDto {
   exitCode: number;
   stdout: string;
@@ -359,6 +363,8 @@ export const agentHubApi = {
     }),
   getWecomConfig: (id: string) =>
     api<AgentWeComConfigDto | null>(`/agenthub/instances/${encodeURIComponent(id)}/wecom`),
+  getGatewayHealth: (id: string) =>
+    api<AgentGatewayHealthDto>(`/agenthub/instances/${encodeURIComponent(id)}/gateway/health`),
   listOperations: (id: string) =>
     api<AgentOperationDto[]>(`/agenthub/instances/${encodeURIComponent(id)}/operations`),
   listSnapshots: (id: string) =>

--- a/web/src/data/templateStore.ts
+++ b/web/src/data/templateStore.ts
@@ -68,7 +68,7 @@ export const STORE_TEMPLATES: StoreTemplate[] = [
     tags: ['agent', 'openclaw', 'browser', 'deepseek'],
     category: 'ai',
     size_mb: 6350,
-    expose_ports: [49983, 18789],
+    expose_ports: [49983, 18789, 8080],
     probe_port: 49983,
     probe_path: '/health',
     writable_layer_size: '4G',

--- a/web/src/locales/en/agentHub.json
+++ b/web/src/locales/en/agentHub.json
@@ -1,6 +1,12 @@
 {
   "title": "Digital Assistant",
   "subtitle": "Recruit and manage AI agent instances running on CubeSandbox",
+  "preview": {
+    "badge": "Preview",
+    "title": "Digital Assistant Preview",
+    "description": "This feature is intended for demos and early validation. APIs, deployment options, and UX may change. The default template is built from a large all-in-one OpenClaw image; initial template creation takes about 15 minutes. If you keep only 1 template, 2 snapshots, and a few running instances, reserve about 12~15 GB of free disk space.",
+    "close": "Close preview notice"
+  },
   "tabs": {
     "personal": "Personal",
     "team": "Team Shared",

--- a/web/src/locales/zh/agentHub.json
+++ b/web/src/locales/zh/agentHub.json
@@ -1,6 +1,12 @@
 {
   "title": "数字助手",
   "subtitle": "招募并管理基于 CubeSandbox 运行的 AI Agent 实例",
+  "preview": {
+    "badge": "Preview",
+    "title": "数字助手预览版",
+    "description": "当前功能主要用于演示和早期试用，API、部署配置和交互细节后续可能调整。默认模板基于 all-in-one OpenClaw 镜像制作，镜像较大，首次制作模板约需 15 分钟；如果只保留 1 个模板、2 个 snapshot 和几个运行实例，建议预留约 12~15 GB 可用磁盘空间。",
+    "close": "关闭预览版提示"
+  },
   "tabs": {
     "personal": "个人助手",
     "team": "团队共享",

--- a/web/src/pages/AgentHub.tsx
+++ b/web/src/pages/AgentHub.tsx
@@ -46,7 +46,17 @@ const MODEL_OPTIONS = [
   { value: 'DeepSeek V4 Pro', labelKey: 'modelDialog.options.deepseekV4Pro' },
 ] as const;
 
-function buildCubeProxyUrl(agent: Agent, port: number, sourceUrl?: string): string | undefined {
+function gatewayTokenFromUrl(sourceUrl?: string): string | undefined {
+  if (!sourceUrl || typeof window === 'undefined') return undefined;
+  try {
+    const source = new URL(sourceUrl, window.location.href);
+    return new URLSearchParams(source.hash.replace(/^#/, '')).get('token') ?? undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function buildCubeProxyUrl(agent: Agent, port: number, sourceUrl?: string, options?: { gateway?: boolean }): string | undefined {
   if (!agent.sandboxId || typeof window === 'undefined') return sourceUrl;
 
   let source: URL | undefined;
@@ -66,9 +76,12 @@ function buildCubeProxyUrl(agent: Agent, port: number, sourceUrl?: string): stri
   );
 
   source?.searchParams.forEach((value, key) => target.searchParams.set(key, value));
-  const hashParams = new URLSearchParams(source?.hash.replace(/^#/, '') ?? '');
-  const token = hashParams.get('token');
-  if (token) target.searchParams.set('token', token);
+  if (options?.gateway) {
+    const wsProtocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
+    const wsUrl = `${wsProtocol}//${window.location.hostname}/sandbox/${encodeURIComponent(agent.sandboxId)}/${port}/`;
+    const token = gatewayTokenFromUrl(sourceUrl);
+    target.hash = `ws=${wsUrl}${token ? `&token=${encodeURIComponent(token)}` : ''}`;
+  }
 
   return target.toString();
 }
@@ -83,6 +96,7 @@ export default function AgentHubPage() {
   const [wecomAgent, setWecomAgent] = useState<Agent | null>(null);
   const [createError, setCreateError] = useState<string | null>(null);
   const [selectedAgentId, setSelectedAgentId] = useState<string | null>(null);
+  const [previewNoticeDismissed, setPreviewNoticeDismissed] = useState(false);
 
   const userAgents = useAgentStore((s) => s.userAgents);
   const setAgents = useAgentStore((s) => s.setAgents);
@@ -125,6 +139,30 @@ export default function AgentHubPage() {
           {t('templates.actions.open')}
         </Button>
       </header>
+
+      {!previewNoticeDismissed && (
+        <div className="rounded-2xl border border-amber-200/70 bg-amber-50 px-4 py-3 text-sm text-amber-900 shadow-sm dark:border-amber-500/30 dark:bg-amber-500/10 dark:text-amber-100">
+          <div className="flex items-start justify-between gap-3">
+            <div>
+              <div className="flex flex-wrap items-center gap-2">
+                <span className="rounded-full bg-amber-200/80 px-2 py-0.5 text-[11px] font-semibold uppercase tracking-wide text-amber-900 dark:bg-amber-400/20 dark:text-amber-100">
+                  {t('preview.badge')}
+                </span>
+                <span className="font-medium">{t('preview.title')}</span>
+              </div>
+              <p className="mt-1 leading-5">{t('preview.description')}</p>
+            </div>
+            <button
+              type="button"
+              className="rounded-full p-1 text-amber-800/70 transition hover:bg-amber-200/60 hover:text-amber-950 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500 dark:text-amber-100/80 dark:hover:bg-amber-400/20 dark:hover:text-amber-50"
+              aria-label={t('preview.close')}
+              onClick={() => setPreviewNoticeDismissed(true)}
+            >
+              <X size={16} />
+            </button>
+          </div>
+        </div>
+      )}
 
       <div className="flex items-center gap-2 rounded-full bg-muted/40 p-1 ring-1 ring-border/60 w-fit">
         <TabButton
@@ -581,6 +619,7 @@ function AgentCard({
   const [publishConfirmOpen, setPublishConfirmOpen] = useState(false);
   const [healthyTarget, setHealthyTarget] = useState<AgentSnapshotDto | null>(null);
   const [actionError, setActionError] = useState<string | null>(null);
+  const [gatewayReady, setGatewayReady] = useState(false);
   const updateAgent = useAgentStore((s) => s.updateAgent);
   const addAgent = useAgentStore((s) => s.addAgent);
   const removeAgent = useAgentStore((s) => s.removeAgent);
@@ -604,6 +643,38 @@ function AgentCard({
     snapshots.map((s) => [s.snapshotID, s.names[0] || s.snapshotID] as const)
   );
   const healthySnapshotCount = snapshots.filter((s) => s.isHealthy).length;
+
+  useEffect(() => {
+    if (!isRunning || !agent.sandboxId) {
+      setGatewayReady(false);
+      return;
+    }
+
+    let cancelled = false;
+    let timer: number | undefined;
+    const check = async () => {
+      try {
+        const health = await agentHubApi.getGatewayHealth(agent.id);
+        if (cancelled) return;
+        setGatewayReady(health.ready);
+        if (!health.ready) {
+          timer = window.setTimeout(check, 3000);
+        }
+      } catch {
+        if (!cancelled) {
+          setGatewayReady(false);
+          timer = window.setTimeout(check, 3000);
+        }
+      }
+    };
+
+    setGatewayReady(false);
+    void check();
+    return () => {
+      cancelled = true;
+      if (timer) window.clearTimeout(timer);
+    };
+  }, [agent.id, agent.sandboxId, isRunning]);
 
   useEffect(() => {
     let cancelled = false;
@@ -1490,9 +1561,9 @@ function AgentCard({
         <Button
           size="sm"
           className="gap-1.5"
-          disabled={!isRunning || !agent.sandboxId}
+          disabled={!isRunning || !agent.sandboxId || !gatewayReady}
           onClick={() => {
-            const url = buildCubeProxyUrl(agent, OPENCLAW_GATEWAY_PORT, agent.gatewayUrl);
+            const url = buildCubeProxyUrl(agent, OPENCLAW_GATEWAY_PORT, agent.gatewayUrl, { gateway: true });
             if (url) window.open(url, '_blank', 'noopener,noreferrer');
           }}
           title={!isRunning ? t('card.status.stopped') : undefined}


### PR DESCRIPTION
## Summary

Refine the AgentHub digital assistant preview/management experience:

### CubeAPI
- Add snapshot and rollback API routes for AgentHub instances
- Extend handler logic for instance preview lifecycle

### WebUI
- Add preview button and sandbox-open logic in AgentHub page
- Add i18n translations (EN/ZH) for new preview UI strings
- Fix template store to use correct default template

### Deploy
- Add SQL migration file (`003_agenthub_instances.sql`) for operator manual repair scenarios
- Update `env.example` with snapshot config note

### Docs
- Add preview documentation in EN/ZH digital assistant guides

---

Signed-off-by: maxlong <maxlong@tencent.com>