### PR TITLE
network-agent: disable GRO on bond slaves, not just the upper device

### DIFF
--- a/network-agent/internal/service/netdevice.go
+++ b/network-agent/internal/service/netdevice.go
@@ -68,6 +68,101 @@ type tapDevice struct {
 }
 
 func disableGRO(ifName string) error {
+	link, err := netlinkLinkByName(ifName)
+	if err != nil {
+		return fmt.Errorf("lookup link %s: %w", ifName, err)
+	}
+	targets, err := resolveGROTargets(link)
+	if err != nil {
+		return err
+	}
+	logger := CubeLog.WithContext(context.Background())
+	var firstErr error
+	for _, name := range targets {
+		if err := disableGROOnDev(name); err != nil {
+			logger.Warnf("network-agent failed to disable GRO on underlying dev %s (root=%s): %v", name, ifName, err)
+			if firstErr == nil {
+				firstErr = err
+			}
+			continue
+		}
+		if name != ifName {
+			logger.Infof("network-agent disabled GRO on underlying dev %s (root=%s)", name, ifName)
+		}
+	}
+	return firstErr
+}
+
+// resolveGROTargets returns the list of netdev names that should actually have
+// GRO turned off. For bond/vlan upper devices, GRO must be disabled on the
+// underlying physical netdev because ethtool SGRO on the upper device does not
+// propagate down — GRO aggregation happens in the NAPI poll of the underlying
+// driver. For any other link type, we default to operating on the device
+// itself.
+func resolveGROTargets(link netlink.Link) ([]string, error) {
+	seen := make(map[string]struct{})
+	var out []string
+	add := func(name string) {
+		if name == "" {
+			return
+		}
+		if _, ok := seen[name]; ok {
+			return
+		}
+		seen[name] = struct{}{}
+		out = append(out, name)
+	}
+
+	var walk func(netlink.Link) error
+	walk = func(l netlink.Link) error {
+		// Always include the device itself so its feature flag stays consistent.
+		add(l.Attrs().Name)
+		switch typed := l.(type) {
+		case *netlink.Bond:
+			slaves, err := bondSlaves(typed.Attrs().Index)
+			if err != nil {
+				return err
+			}
+			for _, s := range slaves {
+				if err := walk(s); err != nil {
+					return err
+				}
+			}
+		case *netlink.Vlan:
+			parent, err := netlinkLinkByIndex(typed.ParentIndex)
+			if err != nil {
+				return fmt.Errorf("lookup vlan parent of %s: %w", typed.Name, err)
+			}
+			if err := walk(parent); err != nil {
+				return err
+			}
+		default:
+			// Physical NIC, virtio-net, or anything else we don't recursively
+			// unwrap: operate on the device itself (already added above).
+		}
+		return nil
+	}
+	if err := walk(link); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func bondSlaves(masterIndex int) ([]netlink.Link, error) {
+	all, err := netlinkLinkList()
+	if err != nil {
+		return nil, fmt.Errorf("list links for bond slaves: %w", err)
+	}
+	var slaves []netlink.Link
+	for _, l := range all {
+		if l.Attrs().MasterIndex == masterIndex {
+			slaves = append(slaves, l)
+		}
+	}
+	return slaves, nil
+}
+
+func disableGROOnDev(ifName string) error {
 	const (
 		SIOCETHTOOL  = 0x8946
 		ETHTOOL_SGRO = 0x0000002c


### PR DESCRIPTION
disableGRO() previously issued a single ETHTOOL_SGRO ioctl against cfg.EthName. For bond uplinks this only flips the feature flag on the bond netdev — GRO actually happens in the NAPI poll of the underlying slaves, so packets still get coalesced before reaching cubevs/tap and the original goal (preserve MTU-sized frames into the guest) is not met.

Resolve the configured interface, recursively walk into bond slaves and vlan parents, and call ethtool SGRO on every underlying netdev as well as the device itself (to keep the upper-layer feature flag consistent). For anything else (physical NIC, virtio-net, etc.) we fall through the default branch and just operate on the device itself, matching the previous behavior.

A per-slave failure is logged at Warn and the first error is returned, mirroring the existing Warn-only handling at the call site so a single bad NIC does not block service startup.