### PR TITLE
network-agent: fix existing sandbox network drop on restart

### DIFF
--- a/network-agent/internal/service/netdevice.go
+++ b/network-agent/internal/service/netdevice.go
@@ -450,7 +450,13 @@ func restoreTap(tap *tapDevice, mtu int, mvmMacAddr string, cubeDevIdx int) (*ta
 		PortMappings: append([]PortMapping(nil), tap.PortMappings...),
 	}
 
-	if restored.File == nil {
+	// If the tap is currently in use (IFF_LOWER_UP set), another process
+	// (typically sandbox spawned by cubelet) holds the original fd. Issuing
+	// TUNSETIFF here would fail with EBUSY for IFF_ONE_QUEUE taps, so we skip
+	// fd acquisition. Callers that actually need the fd later (e.g. fresh
+	// allocation from the pool, or GetTapFile) will retry once the tap is
+	// idle again.
+	if restored.File == nil && !restored.InUse {
 		restored.File, err = getTapFd(name)
 		if err != nil {
 			return nil, err

--- a/network-agent/internal/service/tap_fd_provider.go
+++ b/network-agent/internal/service/tap_fd_provider.go
@@ -43,5 +43,11 @@ func (s *localService) GetTapFile(sandboxID, tapName string) (*os.File, error) {
 		}
 		state.tap = tap
 	}
+	// restoreTap intentionally skips fd acquisition when the tap is held by
+	// another process. If we still have no fd at this point, surface a clear
+	// error rather than handing back a nil file.
+	if state.tap.File == nil {
+		return nil, fmt.Errorf("tap fd unavailable for sandbox %q: tap %s is currently held by another process", sandboxID, state.TapName)
+	}
 	return state.tap.File, nil
 }


### PR DESCRIPTION
When network-agent restarts, recover() can mistakenly treat a TAP that is still held by a running sandbox as abnormal or stale, removing its ifindex_to_mvmmeta BPF map entry. Egress traffic from the sandbox then hits a NULL lookup in the from_cube program and is silently dropped via TC_ACT_SHOT. This produced the observed behavior where stopping network-agent kept the network alive but restarting it broke it.

Root cause:
restoreTap() unconditionally tried to acquire the tap fd via TUNSETIFF even when IFF_LOWER_UP was set (i.e. sandbox already owned the fd). With IFF_ONE_QUEUE the kernel rejects the second open with EBUSY. The TAP was pushed into the abnormal pool and never entered the recovered set, so the second pass of recover() concluded the sandbox state was stale and called cubevsDelTAPDevice, wiping the BPF map entry and the persisted state.

Fix:
- restoreTap: skip getTapFd when tap.InUse is true (IFF_LOWER_UP set) and reuse the fd held by the existing owner. With this, restoreTap no longer fails with EBUSY for live sandboxes, the TAP joins the recovered set, and the stale-cleanup branch never fires.
- GetTapFile: if restoreTap intentionally returned without an fd, surface a clear error to the caller instead of handing back a nil *os.File.