### PR TITLE
fix(dev-env): update default OpenCloudOS image to 9.6-20260514.2 (9.4 download fails)

### DIFF
--- a/dev-env/prepare_image.sh
+++ b/dev-env/prepare_image.sh
@@ -33,7 +33,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 WORK_DIR="${WORK_DIR:-${SCRIPT_DIR}/.workdir}"
-IMAGE_URL="${IMAGE_URL:-https://mirrors.tencent.com/opencloudos/9/images/qcow2/x86_64/OpenCloudOS-GenericCloud-9.4-20251120.0.x86_64.qcow2}"
+IMAGE_URL="${IMAGE_URL:-https://mirrors.tencent.com/opencloudos/9.6/images/qcow2/x86_64/20260514.2/OpenCloudOS-GenericCloud-9.6-20260514.2.x86_64.qcow2}"
 TARGET_SIZE="${TARGET_SIZE:-100G}"
 AUTO_BOOT="${AUTO_BOOT:-1}"
 AUTO_RESIZE_IN_GUEST="${AUTO_RESIZE_IN_GUEST:-1}"

--- a/dev-env/run_vm.sh
+++ b/dev-env/run_vm.sh
@@ -27,7 +27,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 WORK_DIR="${WORK_DIR:-${SCRIPT_DIR}/.workdir}"
-IMAGE_URL="${IMAGE_URL:-https://mirrors.tencent.com/opencloudos/9/images/qcow2/x86_64/OpenCloudOS-GenericCloud-9.4-20251120.0.x86_64.qcow2}"
+IMAGE_URL="${IMAGE_URL:-https://mirrors.tencent.com/opencloudos/9.6/images/qcow2/x86_64/20260514.2/OpenCloudOS-GenericCloud-9.6-20260514.2.x86_64.qcow2}"
 IMAGE_NAME="$(basename "${IMAGE_URL}")"
 IMAGE_PATH="${IMAGE_PATH:-${WORK_DIR}/${IMAGE_NAME}}"
 


### PR DESCRIPTION
## 问题

`dev-env/` 下脚本默认的 OpenCloudOS 云镜像 `9.4-20251120.0` 在 `mirrors.tencent.com` 上已无法正常下载，导致拉取镜像失败。

## 改动

将以下两个脚本中默认 `IMAGE_URL` 升级为当前可用的最新镜像 `9.6-20260514.2`：

- `dev-env/prepare_image.sh`
- `dev-env/run_vm.sh`

```diff
-IMAGE_URL="${IMAGE_URL:-https://mirrors.tencent.com/opencloudos/9/images/qcow2/x86_64/OpenCloudOS-GenericCloud-9.4-20251120.0.x86_64.qcow2}"
+IMAGE_URL="${IMAGE_URL:-https://mirrors.tencent.com/opencloudos/9.6/images/qcow2/x86_64/20260514.2/OpenCloudOS-GenericCloud-9.6-20260514.2.x86_64.qcow2}"
```

## 验证

新链接已确认可正常下载（HTTP 200，Content-Length 约 806 MB）。
