### PR TITLE
fix(one-click): delay host DNS switchover until coredns is ready

### DIFF
--- a/deploy/one-click/scripts/systemd/common.sh
+++ b/deploy/one-click/scripts/systemd/common.sh
@@ -72,6 +72,22 @@ ensure_executable() {
   [[ -x "${path}" ]] || die "required executable not found: ${path}"
 }
 
+is_reserved_nameserver() {
+  local nameserver="${1:-}"
+  shift || true
+
+  [[ -n "${nameserver}" ]] || return 0
+  [[ "${nameserver}" == 127.* ]] && return 0
+  [[ "${nameserver}" == "::1" ]] && return 0
+  [[ "${nameserver}" == "0:0:0:0:0:0:0:1" ]] && return 0
+
+  local reserved
+  for reserved in "$@"; do
+    [[ -n "${reserved}" && "${nameserver}" == "${reserved}" ]] && return 0
+  done
+  return 1
+}
+
 load_runtime_env() {
   local had_nounset=0
   if [[ ! -f "${ENV_FILE}" ]]; then

--- a/deploy/one-click/scripts/systemd/coredns-start.sh
+++ b/deploy/one-click/scripts/systemd/coredns-start.sh
@@ -35,13 +35,10 @@ if command -v resolvectl >/dev/null 2>&1; then
 fi
 
 is_stub_nameserver() {
-  local nameserver="$1"
-  [[ -n "${nameserver}" ]] || return 0
-  [[ "${nameserver}" == 127.* ]] && return 0
-  [[ "${nameserver}" == ::1 ]] && return 0
-  [[ "${nameserver}" == 0:0:0:0:0:0:0:1 ]] && return 0
-  [[ "${nameserver}" == "${COREDNS_BIND_ADDR}" ]] && return 0
-  return 1
+  is_reserved_nameserver \
+    "${1:-}" \
+    "${COREDNS_BIND_ADDR}" \
+    "${RESOLVED_COREDNS_BIND_ADDR}"
 }
 
 write_upstream_resolv_conf() {

--- a/deploy/one-click/scripts/systemd/dns-host-route-down.sh
+++ b/deploy/one-click/scripts/systemd/dns-host-route-down.sh
@@ -9,10 +9,13 @@ source "${SCRIPT_DIR}/common.sh"
 
 require_root
 require_cmd ip
+require_cmd awk
 
 COREDNS_DIR="${TOOLBOX_ROOT}/coredns"
 DNS_MODE_FILE="${COREDNS_DIR}/host-dns-mode"
 DNS_IFACE_FILE="${COREDNS_DIR}/host-dns-interface"
+DEFAULT_COREDNS_BIND_ADDR="${CUBE_PROXY_COREDNS_BIND_ADDR:-127.0.0.54}"
+RESOLVED_COREDNS_BIND_ADDR="${CUBE_PROXY_RESOLVED_DNS_ADDR:-169.254.254.53}"
 NM_MAIN_CONF="/etc/NetworkManager/conf.d/90-cubeproxy-dns.conf"
 NM_DOMAIN_CONF="/etc/NetworkManager/dnsmasq.d/90-cubeproxy-cube-app.conf"
 
@@ -32,12 +35,10 @@ link_is_dummy() {
 }
 
 is_stub_nameserver() {
-  local nameserver="$1"
-  [[ -n "${nameserver}" ]] || return 0
-  [[ "${nameserver}" == 127.* ]] && return 0
-  [[ "${nameserver}" == ::1 ]] && return 0
-  [[ "${nameserver}" == 0:0:0:0:0:0:0:1 ]] && return 0
-  return 1
+  is_reserved_nameserver \
+    "${1:-}" \
+    "${DEFAULT_COREDNS_BIND_ADDR}" \
+    "${RESOLVED_COREDNS_BIND_ADDR}"
 }
 
 copy_non_stub_resolv_conf_if_needed() {

--- a/deploy/one-click/scripts/systemd/dns-host-route-up.sh
+++ b/deploy/one-click/scripts/systemd/dns-host-route-up.sh
@@ -9,6 +9,7 @@ source "${SCRIPT_DIR}/common.sh"
 
 require_root
 require_cmd ip
+require_cmd awk
 
 COREDNS_DIR="${TOOLBOX_ROOT}/coredns"
 DNS_MODE_FILE="${COREDNS_DIR}/host-dns-mode"
@@ -75,10 +76,10 @@ wait_for_udp_listen() {
   return 1
 }
 
-# Render /etc/resolv.conf so its only nameserver is the dummy-link IP
-# we just bound dnsmasq to, while preserving search/options pulled from
-# NetworkManager's non-stub snapshot. Docker daemon will then propagate
-# this non-loopback nameserver into every container it spawns.
+# Render /etc/resolv.conf so the dummy-link IP is the primary nameserver,
+# while preserving search/options and keeping one upstream fallback for
+# recovery. Docker daemon will then propagate this non-loopback resolver
+# into every container it spawns without making host DNS single-homed.
 write_host_resolv_conf() {
   local primary="$1"
   local tmp="/etc/resolv.conf.cube-proxy.tmp"
@@ -88,14 +89,52 @@ write_host_resolv_conf() {
     "/run/systemd/resolve/resolv.conf"
     "/etc/resolv.conf"
   )
+  local src
+  local line
+  local nameserver
+  local fallback=""
+  local metadata=""
+
   : > "${tmp}"
   printf 'nameserver %s\n' "${primary}" >> "${tmp}"
-  local src
+
   for src in "${candidates[@]}"; do
     [[ -f "${src}" ]] || continue
-    awk '/^(search|domain|options|sortlist) /' "${src}" >> "${tmp}"
-    break
+
+    if [[ -z "${metadata}" ]]; then
+      metadata="$(awk '/^(search|domain|options|sortlist) / { print }' "${src}" 2>/dev/null || true)"
+    fi
+
+    while IFS= read -r line || [[ -n "${line}" ]]; do
+      case "${line}" in
+        nameserver\ *)
+          nameserver="${line#nameserver }"
+          nameserver="${nameserver%%#*}"
+          nameserver="${nameserver%%;*}"
+          nameserver="$(printf '%s' "${nameserver}" | awk '{print $1}')"
+          if ! is_reserved_nameserver \
+            "${nameserver}" \
+            "${primary}" \
+            "${DEFAULT_COREDNS_BIND_ADDR}" \
+            "${RESOLVED_COREDNS_BIND_ADDR}"; then
+            fallback="${nameserver}"
+            break
+          fi
+          ;;
+      esac
+    done < "${src}"
+
+    [[ -n "${fallback}" ]] && break
   done
+
+  if [[ -n "${fallback}" ]]; then
+    printf 'nameserver %s\n' "${fallback}" >> "${tmp}"
+  fi
+
+  if [[ -n "${metadata}" ]]; then
+    printf '%s\n' "${metadata}" >> "${tmp}"
+  fi
+
   install -m 0644 "${tmp}" /etc/resolv.conf
   rm -f "${tmp}"
 }
@@ -162,6 +201,10 @@ EOF
 
   wait_for_udp_listen "${RESOLVED_COREDNS_BIND_ADDR}" 53 30 || \
     die "dnsmasq did not bind ${RESOLVED_COREDNS_BIND_ADDR}:53 after NetworkManager restart"
+  # Keep the host on its original upstream DNS until CoreDNS is actually
+  # listening. Otherwise a failed/slow CoreDNS start can strand docker pulls.
+  wait_for_udp_port "${COREDNS_BIND_ADDR}" 53 20 1 || \
+    die "coredns did not become ready on ${COREDNS_BIND_ADDR}:53; refusing to switch host resolv.conf"
   write_host_resolv_conf "${RESOLVED_COREDNS_BIND_ADDR}"
 
   printf 'networkmanager-dnsmasq\n' > "${DNS_MODE_FILE}"


### PR DESCRIPTION
## Summary

- delay the NetworkManager DNS switchover until CoreDNS is actually listening, so first-install image pulls do not depend on an incomplete local DNS chain
- keep one non-reserved upstream resolver in `/etc/resolv.conf` as a fallback instead of making host DNS single-homed
- centralize reserved nameserver filtering and reuse it in CoreDNS startup and DNS route teardown to prevent proxy or stub addresses from being reused as upstream resolvers
