### PR TITLE
feat(one-click): add glibc version preflight check to fail fast on unsupported distros

### DIFF
--- a/deploy/one-click/install.sh
+++ b/deploy/one-click/install.sh
@@ -430,6 +430,7 @@ require_root
 check_hardware_preflight
 check_cubelet_fs_preflight
 check_cgroup_cpu_preflight
+check_glibc_preflight
 
 CUBE_SANDBOX_NODE_IP="$(detect_node_ip)"
 export CUBE_SANDBOX_NODE_IP

--- a/deploy/one-click/lib/common.sh
+++ b/deploy/one-click/lib/common.sh
@@ -597,3 +597,47 @@ check_cidr_preflight() {
 
   log "CUBE_SANDBOX_NETWORK_CIDR preflight OK: ${cidr}"
 }
+
+# check_glibc_preflight: Verify the system glibc version meets the minimum
+# requirement (2.34, matching the highest GLIBC_X.Y symbol version required
+# by cubelet / cubecli binaries).  Fails fast to prevent installation on
+# unsupported older distributions (Ubuntu 20.04, CentOS 7/8, Debian 11).
+check_glibc_preflight() {
+  local min_major=2
+  local min_minor=34
+
+  local glibc_ver
+  glibc_ver="$(ldd --version 2>&1 | head -1 | awk '{print $NF}')"
+
+  if [[ -z "${glibc_ver}" ]]; then
+    die "unable to detect glibc version (ldd --version failed)"
+  fi
+
+  # glibc version format is MAJOR.MINOR (e.g., 2.34, 2.39).
+  # Strip any patch level or distro suffix beyond the second component.
+  local major="${glibc_ver%%.*}"
+  local minor="${glibc_ver#*.}"
+  minor="${minor%%.*}"
+  [[ "${minor}" =~ ^[0-9]+$ ]] || minor=0
+  [[ "${major}" =~ ^[0-9]+$ ]] || major=0
+
+  if (( major < min_major )) || { (( major == min_major )) && (( minor < min_minor )); }; then
+    cat >&2 <<EOF
+[one-click] ERROR: glibc version ${glibc_ver} is too old (minimum required: ${min_major}.${min_minor}).
+[one-click]
+[one-click]   This system has glibc ${glibc_ver}, but Cube Sandbox requires
+[one-click]   glibc >= ${min_major}.${min_minor} (Ubuntu 22.04 LTS baseline).
+[one-click]
+[one-click]   Supported distributions include:
+[one-click]     - Ubuntu 22.04+
+[one-click]     - Debian 12+
+[one-click]     - RHEL / CentOS 9+
+[one-click]     - OpenCloudOS 9+
+[one-click]
+[one-click]   Please upgrade to a newer distribution and retry.
+EOF
+    exit 3
+  fi
+
+  log "glibc version ${glibc_ver} OK (>= ${min_major}.${min_minor})"
+}

--- a/deploy/one-click/online-install.sh
+++ b/deploy/one-click/online-install.sh
@@ -36,6 +36,29 @@ check_early_preflight() {
     exit 3
   fi
 
+  # Glibc version check (fail fast before download)
+  local glibc_ver
+  glibc_ver="$(ldd --version 2>&1 | head -1 | awk '{print $NF}')"
+  if [[ -z "${glibc_ver}" ]]; then
+    echo "[online-install] ERROR: unable to detect glibc version (ldd --version failed)." >&2
+    exit 3
+  fi
+  local gc_major="${glibc_ver%%.*}"
+  local gc_minor="${glibc_ver#*.}"
+  gc_minor="${gc_minor%%.*}"
+  [[ "${gc_minor}" =~ ^[0-9]+$ ]] || gc_minor=0
+  [[ "${gc_major}" =~ ^[0-9]+$ ]] || gc_major=0
+  if (( gc_major < 2 )) || { (( gc_major == 2 )) && (( gc_minor < 34 )); }; then
+    cat >&2 <<EOF
+[online-install] ERROR: glibc version ${glibc_ver} is too old (minimum required: 2.34).
+[online-install]   The system must have glibc >= 2.34 (Ubuntu 22.04 LTS baseline).
+[online-install]   Detected: glibc ${glibc_ver}.
+[online-install]   Supported: Ubuntu 22.04+, Debian 12+, RHEL/CentOS 9+, OpenCloudOS 9+.
+EOF
+    exit 3
+  fi
+  echo "[online-install] glibc version ${glibc_ver} OK (>= 2.34)" >&2
+
   # 2. Root check (install.sh and services require root anyway)
   if [[ "${EUID}" -ne 0 ]]; then
     echo "[online-install] ERROR: This script must run as root." >&2


### PR DESCRIPTION

Check glibc >= 2.34 before installation to prevent installing on distributions where binaries won't run (e.g., CentOS 7, Ubuntu 20.04).

The minimum version 2.34 matches the highest GLIBC_X.Y symbol required by cubelet/cubecli binaries (verified via objdump -T).

Changes:
- lib/common.sh: add check_glibc_preflight() function
- install.sh: invoke check during early preflight (before any system mod)
- online-install.sh: invoke check in check_early_preflight() before download