### PR TITLE
workaround(virtiofs): set rw virtiofs cache mode to always

### DIFF
--- a/Cubelet/plugins/cbri/cubeboxcbri/virtiofs.go
+++ b/Cubelet/plugins/cbri/cubeboxcbri/virtiofs.go
@@ -196,7 +196,7 @@ func generateEmptyVirtiofsDevices(ctx context.Context) (map[string]string, error
 	}
 	allVirtios = append(allVirtios, roVirtioCfg)
 
-	rwVirtioCfg, err := virtiofs.GenEmptyVirtiofsConfig(false, constants.VirtiofsCacheNone)
+	rwVirtioCfg, err := virtiofs.GenEmptyVirtiofsConfig(false, constants.VirtiofsCacheAlways)
 	if err != nil {
 		return nil, ret.Err(errorcode.ErrorCode_InvalidParamFormat, err.Error())
 	}


### PR DESCRIPTION
Change the cache mode of rwVirtioCfg in generateEmptyVirtiofsDevices
from VirtiofsCacheNone to VirtiofsCacheAlways. The ro channel keeps
VirtiofsCacheNone unchanged.

Signed-off-by: Songqian Li <sionli@tencent.com>