### PR TITLE
fix(vmm): fix vmm panic QueueReader(FindMemoryRegion)

### DIFF
--- a/hypervisor/virtio-devices/src/fs.rs
+++ b/hypervisor/virtio-devices/src/fs.rs
@@ -29,12 +29,12 @@ use std::sync::{Arc, Barrier, Mutex};
 use std::time::Instant;
 use std::{collections::HashMap, convert::TryInto};
 use thiserror::Error;
-use virtio_queue::{Queue, QueueOwnedT, QueueT};
+use virtio_queue::{DescriptorChain, Queue, QueueOwnedT, QueueT};
 use virtiofsd::{
     descriptor_utils::{Error as VufDescriptorError, Reader, Writer},
     filesystem::SerializableFileSystem,
     fs_cache_req_handler::FsCacheReqHandler,
-    fuse::RemovemappingOne,
+    fuse::{InHeader, OutHeader, RemovemappingOne},
     limits,
     passthrough::{
         self, read_only::PassthroughFsRo, xattrmap::XattrMap, CachePolicy, PassthroughFs,
@@ -42,7 +42,7 @@ use virtiofsd::{
     server::Server,
     Error as VhostUserFsError,
 };
-use vm_memory::{ByteValued, GuestAddressSpace, GuestMemoryAtomic};
+use vm_memory::{ByteValued, GuestAddressSpace, GuestMemoryAtomic, GuestMemoryLoadGuard};
 use vm_migration::{Migratable, MigratableError, Pausable, Snapshot, Snapshottable, Transportable};
 use vmm_sys_util::eventfd::EventFd;
 
@@ -299,13 +299,68 @@ impl FsEpollHandler {
     }
 
     fn return_descriptor(queue: &mut Queue, mem: &GuestMemoryMmap, head_index: u16, len: usize) {
-        let used_len: u32 = match len.try_into() {
+        // In FUSE, a single response should never reach 4 GiB; if it ever does
+        // (most likely a bug or a malformed request) we saturate to u32::MAX
+        // and log a warning instead of panicking, so the worker thread keeps
+        // serving the rest of the queue.
+        let used_len: u32 = match u32::try_from(len) {
             Ok(l) => l,
-            Err(_) => panic!("Invalid used length, can't return used descritors to the ring"),
+            Err(_) => {
+                warn!(
+                    "virtio-fs: response length {} exceeds u32::MAX, saturating; \
+                     Guest may receive a truncated reply",
+                    len
+                );
+                u32::MAX
+            }
         };
 
         if queue.add_used(mem, head_index, used_len).is_err() {
             warn!("Couldn't return used descriptors to the ring");
+        }
+    }
+
+    /// Try to peek the FUSE InHeader from a fresh Reader built on a clone of
+    /// `desc_chain`, returning the request's `unique` id. The original reader
+    /// used by the FUSE server is unaffected (Reader keeps its own cursor).
+    ///
+    /// On any failure (descriptor chain too short, guest memory error, etc.)
+    /// returns `None`.
+    fn peek_in_header_unique(
+        mem: &GuestMemoryMmap,
+        desc_chain: DescriptorChain<GuestMemoryLoadGuard<GuestMemoryMmap>>,
+    ) -> Option<u64> {
+        let mut peek_reader = Reader::new(mem, desc_chain).ok()?;
+        let in_header: InHeader = peek_reader.read_obj().ok()?;
+        Some(in_header.unique)
+    }
+
+    /// Try to write a minimal FUSE error reply (`OutHeader { len: 16,
+    /// error: -EIO, unique }`) into a freshly built Writer over `desc_chain`,
+    /// returning the number of bytes actually written (always 16 on success,
+    /// 0 on failure).
+    ///
+    /// This is used as a best-effort recovery path when reader/writer
+    /// construction or `Server::handle_message` fails: instead of letting the
+    /// worker thread die, we try to surface a clean `-EIO` to the Guest so
+    /// the in-flight FUSE request is woken up immediately.
+    fn try_write_fuse_eio(
+        mem: &GuestMemoryMmap,
+        desc_chain: DescriptorChain<GuestMemoryLoadGuard<GuestMemoryMmap>>,
+        unique: u64,
+    ) -> usize {
+        let mut writer = match Writer::new(mem, desc_chain) {
+            Ok(w) => w,
+            Err(_) => return 0,
+        };
+        let header = OutHeader {
+            len: std::mem::size_of::<OutHeader>() as u32,
+            error: -libc::EIO,
+            unique,
+        };
+        match std::io::Write::write_all(&mut writer, header.as_slice()) {
+            Ok(()) => writer.bytes_written(),
+            Err(_) => 0,
         }
     }
 
@@ -322,28 +377,80 @@ impl FsEpollHandler {
 
         while let Some(desc_chain) = queue.pop_descriptor_chain(self.mem.memory()) {
             let head_index = desc_chain.head_index();
+            let mem_ref = desc_chain.memory();
 
-            let reader = Reader::new(desc_chain.memory(), desc_chain.clone())
-                .map_err(Error::QueueReader)
-                .unwrap();
-            let writer = Writer::new(desc_chain.memory(), desc_chain.clone())
-                .map_err(Error::QueueWriter)
-                .unwrap();
+            // Best-effort: peek the FUSE in_header.unique from a separate
+            // Reader built on a clone of desc_chain, so we can produce a
+            // matching FUSE error reply if anything below fails. If even the
+            // peek fails (bad descriptor chain), fall back to unique=0; the
+            // Guest driver will then fall back to its short-reply / unmatched
+            // reply path and complete the request with -EIO.
+            let peek_unique = Self::peek_in_header_unique(mem_ref, desc_chain.clone()).unwrap_or(0);
+
+            let reader = match Reader::new(mem_ref, desc_chain.clone()) {
+                Ok(r) => r,
+                Err(e) => {
+                    warn!(
+                        "virtio-fs: failed to build Reader for request (unique={}): {:?}; \
+                         replying -EIO and continuing",
+                        peek_unique, e
+                    );
+                    let written =
+                        Self::try_write_fuse_eio(mem_ref, desc_chain.clone(), peek_unique);
+                    Self::return_descriptor(queue, mem_ref, head_index, written);
+                    used_descs = true;
+                    continue;
+                }
+            };
+            let writer = match Writer::new(mem_ref, desc_chain.clone()) {
+                Ok(w) => w,
+                Err(e) => {
+                    // Without a working Writer there is no way to deliver any
+                    // reply at all; just hand the descriptor back with len=0
+                    // and let the Guest's FUSE layer recover (modern kernels
+                    // turn a short reply into -EIO).
+                    warn!(
+                        "virtio-fs: failed to build Writer for request (unique={}): {:?}; \
+                         returning descriptor with len=0",
+                        peek_unique, e
+                    );
+                    Self::return_descriptor(queue, mem_ref, head_index, 0);
+                    used_descs = true;
+                    continue;
+                }
+            };
 
             let mut rate_limited = BucketReduction::Success;
             let mut rate_limited_type = TokenType::Ops;
             let req_start = Instant::now();
-            let len = self
-                .server
-                .handle_message(
-                    reader,
-                    writer,
-                    cache_handler.as_mut(),
-                    &mut self.rate_limiter,
-                    &mut rate_limited,
-                    &mut rate_limited_type,
-                )
-                .map_err(Error::ProcessQueue)?;
+            let len = match self.server.handle_message(
+                reader,
+                writer,
+                cache_handler.as_mut(),
+                &mut self.rate_limiter,
+                &mut rate_limited,
+                &mut rate_limited_type,
+            ) {
+                Ok(n) => n,
+                Err(e) => {
+                    // The FUSE server failed mid-way; the original writer may
+                    // contain a partially-written reply with a stale `len`
+                    // field. Build a fresh Writer from a clone of desc_chain
+                    // (which always starts at the writable region's offset 0)
+                    // and write a minimal -EIO header there. This overwrites
+                    // whatever the server may have left behind, so the Guest
+                    // sees a single, well-formed FUSE error reply.
+                    warn!(
+                        "virtio-fs: handle_message failed (unique={}): {:?}; replying -EIO",
+                        peek_unique, e
+                    );
+                    let written =
+                        Self::try_write_fuse_eio(mem_ref, desc_chain.clone(), peek_unique);
+                    Self::return_descriptor(queue, mem_ref, head_index, written);
+                    used_descs = true;
+                    continue;
+                }
+            };
 
             if rate_limited != BucketReduction::Success {
                 match rate_limited_type {

--- a/hypervisor/virtio-devices/src/fs.rs
+++ b/hypervisor/virtio-devices/src/fs.rs
@@ -300,20 +300,21 @@ impl FsEpollHandler {
 
     fn return_descriptor(queue: &mut Queue, mem: &GuestMemoryMmap, head_index: u16, len: usize) {
         // In FUSE, a single response should never reach 4 GiB; if it ever does
-        // (most likely a bug or a malformed request) we saturate to u32::MAX
-        // and log a warning instead of panicking, so the worker thread keeps
-        // serving the rest of the queue.
-        let used_len: u32 = match u32::try_from(len) {
-            Ok(l) => l,
-            Err(_) => {
-                warn!(
-                    "virtio-fs: response length {} exceeds u32::MAX, saturating; \
-                     Guest may receive a truncated reply",
-                    len
-                );
-                u32::MAX
-            }
-        };
+        // (most likely a bug or a malformed request) we report 0 bytes used
+        // and log a warning instead of panicking. Reporting 0 is safer than
+        // saturating to u32::MAX because the Guest virtio-ring layer rejects
+        // any used_len that exceeds the descriptor chain's writable capacity;
+        // a 0-length reply makes the Guest FUSE driver fall back to its
+        // short-reply / unmatched-reply path and complete the request with
+        // -EIO, while the worker thread keeps serving the rest of the queue.
+        let used_len: u32 = u32::try_from(len).unwrap_or_else(|_| {
+            warn!(
+                "virtio-fs: response length {} exceeds u32::MAX, reporting 0 used bytes; \
+                 Guest will see a short reply and fail the request with -EIO",
+                len
+            );
+            0
+        });
 
         if queue.add_used(mem, head_index, used_len).is_err() {
             warn!("Couldn't return used descriptors to the ring");
@@ -353,15 +354,20 @@ impl FsEpollHandler {
             Ok(w) => w,
             Err(_) => return 0,
         };
+        // Bail out early when the descriptor chain has no room for a full
+        // OutHeader, otherwise write_obj would partially succeed and report
+        // a misleading bytes_written back to the Guest.
+        if writer.available_bytes() < std::mem::size_of::<OutHeader>() {
+            return 0;
+        }
         let header = OutHeader {
             len: std::mem::size_of::<OutHeader>() as u32,
             error: -libc::EIO,
             unique,
         };
-        match std::io::Write::write_all(&mut writer, header.as_slice()) {
-            Ok(()) => writer.bytes_written(),
-            Err(_) => 0,
-        }
+        writer
+            .write_obj(header)
+            .map_or(0, |_| writer.bytes_written())
     }
 
     fn process_queue_serial(&mut self) -> Result<bool> {

--- a/hypervisor/virtio-devices/src/pmem.rs
+++ b/hypervisor/virtio-devices/src/pmem.rs
@@ -14,7 +14,7 @@ use super::{
 };
 use crate::seccomp_filters::Thread;
 use crate::thread_helper::spawn_virtio_thread;
-use crate::{GuestMemoryMmap, MmapRegion};
+use crate::{GuestMemoryMmap, GuestRegionMmap};
 use crate::{VirtioInterrupt, VirtioInterruptType};
 use anyhow::anyhow;
 use seccompiler::SeccompAction;
@@ -30,7 +30,7 @@ use thiserror::Error;
 use virtio_queue::{DescriptorChain, Queue, QueueT};
 use vm_memory::{
     Address, ByteValued, Bytes, GuestAddress, GuestAddressSpace, GuestMemoryAtomic,
-    GuestMemoryError, GuestMemoryLoadGuard,
+    GuestMemoryError, GuestMemoryLoadGuard, GuestMemoryRegion,
 };
 use vm_migration::{Migratable, MigratableError, Pausable, Snapshot, Snapshottable, Transportable};
 use vm_virtio::{AccessPlatform, Translatable};
@@ -273,8 +273,11 @@ pub struct Pmem {
     exit_evt: EventFd,
 
     // Hold ownership of the memory that is allocated for the device
-    // which will be automatically dropped when the device is dropped
-    _region: MmapRegion,
+    // which will be automatically dropped when the device is dropped.
+    // The same Arc is also held by MemoryManager::device_memory so that
+    // virtio backends can dereference GPAs that fall inside this PMEM
+    // region.
+    _region: Arc<GuestRegionMmap>,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -291,7 +294,7 @@ impl Pmem {
         disk: File,
         addr: GuestAddress,
         mapping: UserspaceMapping,
-        _region: MmapRegion,
+        _region: Arc<GuestRegionMmap>,
         iommu: bool,
         seccomp_action: SeccompAction,
         exit_evt: EventFd,
@@ -303,7 +306,7 @@ impl Pmem {
         } else {
             let config = VirtioPmemConfig {
                 start: addr.raw_value().to_le(),
-                size: (_region.size() as u64).to_le(),
+                size: _region.len().to_le(),
             };
 
             let mut avail_features = 1u64 << VIRTIO_F_VERSION_1;

--- a/hypervisor/vmm/src/device_manager.rs
+++ b/hypervisor/vmm/src/device_manager.rs
@@ -321,6 +321,9 @@ pub enum DeviceManagerError {
     /// Failed to create a new MmapRegion instance.
     NewMmapRegion(vm_memory::mmap::MmapRegionError),
 
+    /// Failed to create a new GuestRegionMmap.
+    NewGuestRegion(vm_memory::Error),
+
     /// Failed to clone a File.
     CloneFile(io::Error),
 
@@ -2811,6 +2814,21 @@ impl DeviceManager {
             .create_userspace_mapping(region_base, region_size, host_addr, false, false, false)
             .map_err(DeviceManagerError::MemoryManager)?;
 
+        // Wrap the MmapRegion into a GuestRegionMmap so it can be inserted
+        // into MemoryManager::device_memory. Ownership is shared via Arc:
+        // the same Arc is also handed to virtio_devices::Pmem so that
+        // munmap happens automatically when the device (and the device_memory
+        // entry) are dropped.
+        let pmem_guest_region = Arc::new(
+            GuestRegionMmap::new(mmap_region, GuestAddress(region_base))
+                .map_err(DeviceManagerError::NewGuestRegion)?,
+        );
+        self.memory_manager
+            .lock()
+            .unwrap()
+            .add_device_region(pmem_guest_region.clone())
+            .map_err(DeviceManagerError::MemoryManager)?;
+
         let mapping = virtio_devices::UserspaceMapping {
             host_addr,
             mem_slot,
@@ -2825,7 +2843,7 @@ impl DeviceManager {
                 file,
                 GuestAddress(region_base),
                 mapping,
-                mmap_region,
+                pmem_guest_region,
                 self.force_iommu | pmem_cfg.iommu,
                 self.seccomp_action.clone(),
                 self.exit_evt
@@ -3113,7 +3131,7 @@ impl DeviceManager {
             virtio_devices::Vdpa::new(
                 id.clone(),
                 device_path,
-                self.memory_manager.lock().unwrap().guest_memory(),
+                self.memory_manager.lock().unwrap().device_memory(),
                 vdpa_cfg.num_queues as u16,
                 state_from_id(self.snapshot.as_ref(), id.as_str())
                     .map_err(DeviceManagerError::RestoreGetState)?,
@@ -3124,7 +3142,7 @@ impl DeviceManager {
         // Create the DMA handler that is required by the vDPA device
         let vdpa_mapping = Arc::new(VdpaDmaMapping::new(
             Arc::clone(&vdpa_device),
-            Arc::new(self.memory_manager.lock().unwrap().guest_memory()),
+            Arc::new(self.memory_manager.lock().unwrap().device_memory()),
         ));
 
         self.device_tree
@@ -3241,7 +3259,7 @@ impl DeviceManager {
 
             let vfio_mapping = Arc::new(VfioDmaMapping::new(
                 Arc::clone(&vfio_container),
-                Arc::new(self.memory_manager.lock().unwrap().guest_memory()),
+                Arc::new(self.memory_manager.lock().unwrap().device_memory()),
             ));
 
             if let Some(iommu) = &self.iommu_device {
@@ -3285,7 +3303,7 @@ impl DeviceManager {
 
             let vfio_mapping = Arc::new(VfioDmaMapping::new(
                 Arc::clone(&vfio_container),
-                Arc::new(self.memory_manager.lock().unwrap().guest_memory()),
+                Arc::new(self.memory_manager.lock().unwrap().device_memory()),
             ));
 
             for virtio_mem_device in self.virtio_mem_devices.iter() {
@@ -3490,7 +3508,7 @@ impl DeviceManager {
         )
         .map_err(DeviceManagerError::VfioUserCreate)?;
 
-        let memory = self.memory_manager.lock().unwrap().guest_memory();
+        let memory = self.memory_manager.lock().unwrap().device_memory();
         let vfio_user_mapping = Arc::new(VfioUserDmaMapping::new(client, Arc::new(memory)));
         for virtio_mem_device in self.virtio_mem_devices.iter() {
             virtio_mem_device
@@ -3605,7 +3623,11 @@ impl DeviceManager {
             None
         };
 
-        let memory = self.memory_manager.lock().unwrap().guest_memory();
+        // NOTE: use device_memory so that virtio backends and DMA handlers can
+        // resolve GPAs that fall inside device-mapped host memory (e.g. PMEM).
+        // The guest_memory() RAM-only view is reserved for snapshot, migration,
+        // coredump and firmware-loading paths.
+        let memory = self.memory_manager.lock().unwrap().device_memory();
 
         // Map DMA ranges if a DMA handler is available and if the device is
         // not attached to a virtual IOMMU.
@@ -3791,6 +3813,14 @@ impl DeviceManager {
                 false,
                 false,
             )
+            .map_err(DeviceManagerError::MemoryManager)?;
+        // Make ivshmem/zshm BAR2 visible through device_memory so that virtio
+        // backends and DMA-mapping helpers can dereference GPAs that fall
+        // inside this BAR.
+        self.memory_manager
+            .lock()
+            .unwrap()
+            .add_device_region(Arc::clone(&region))
             .map_err(DeviceManagerError::MemoryManager)?;
         let _mapping = virtio_devices::UserspaceMapping {
             host_addr: region.as_ptr() as u64,

--- a/hypervisor/vmm/src/memory_manager.rs
+++ b/hypervisor/vmm/src/memory_manager.rs
@@ -272,6 +272,13 @@ struct ArchMemRegion {
 pub struct MemoryManager {
     boot_guest_memory: GuestMemoryMmap,
     guest_memory: GuestMemoryAtomic<GuestMemoryMmap>,
+    // device_memory is a superset of guest_memory: it contains all RAM regions
+    // plus device-backed regions (e.g. virtio-pmem, virtio-fs DAX window,
+    // ivshmem). Use this view for any virtio backend that may need to
+    // dereference a GPA pointing into device-mapped host memory; use
+    // guest_memory for snapshot, migration, coredump and firmware-loading
+    // paths.
+    device_memory: GuestMemoryAtomic<GuestMemoryMmap>,
     next_memory_slot: u32,
     start_of_device_area: GuestAddress,
     end_of_device_area: GuestAddress,
@@ -1199,6 +1206,13 @@ impl MemoryManager {
         };
 
         let guest_memory = GuestMemoryAtomic::new(guest_memory);
+        // device_memory starts as an independent container holding the same
+        // RAM regions as guest_memory. Region Arcs are shared (no extra mmap),
+        // but the two containers evolve independently afterwards: RAM changes
+        // are double-written via add_region(), while device-backed regions
+        // (PMEM/SHM/...) are inserted into device_memory only via
+        // add_device_region().
+        let device_memory = GuestMemoryAtomic::new(guest_memory.memory().deref().clone());
 
         // Both MMIO and PIO address spaces start at address 0.
         let allocator = Arc::new(Mutex::new(
@@ -1252,6 +1266,7 @@ impl MemoryManager {
         let mut memory_manager = MemoryManager {
             boot_guest_memory,
             guest_memory,
+            device_memory,
             next_memory_slot,
             start_of_device_area,
             end_of_device_area,
@@ -1575,14 +1590,72 @@ impl MemoryManager {
     }
 
     // Update the GuestMemoryMmap with the new range
+    //
+    // RAM changes must be double-written: first into device_memory so any
+    // virtio backend activation immediately sees the new region, then into
+    // guest_memory (the RAM-only view used by snapshot/coredump/migration).
+    // The two containers are independent (see constructor); region Arcs are
+    // shared, so this only clones a small Vec and bumps refcounts.
     fn add_region(&mut self, region: Arc<GuestRegionMmap>) -> Result<(), Error> {
-        let guest_memory = self
+        // 1) Update device_memory first.
+        let new_device_memory = self
+            .device_memory
+            .memory()
+            .insert_region(Arc::clone(&region))
+            .map_err(Error::GuestMemory)?;
+        self.device_memory
+            .lock()
+            .unwrap()
+            .replace(new_device_memory);
+
+        // 2) Update guest_memory (RAM view).
+        let new_guest_memory = self
             .guest_memory
             .memory()
             .insert_region(region)
             .map_err(Error::GuestMemory)?;
-        self.guest_memory.lock().unwrap().replace(guest_memory);
+        self.guest_memory.lock().unwrap().replace(new_guest_memory);
 
+        Ok(())
+    }
+
+    /// Insert a device-backed region (e.g. virtio-pmem, virtio-fs DAX
+    /// window, ivshmem) into the device_memory view ONLY. The region will
+    /// NOT be visible through guest_memory(), so it does not affect
+    /// snapshot, migration, coredump, or firmware-loading paths.
+    pub fn add_device_region(&mut self, region: Arc<GuestRegionMmap>) -> Result<(), Error> {
+        let new_device_memory = self
+            .device_memory
+            .memory()
+            .insert_region(region)
+            .map_err(Error::GuestMemory)?;
+        self.device_memory
+            .lock()
+            .unwrap()
+            .replace(new_device_memory);
+        Ok(())
+    }
+
+    /// Remove a previously inserted device-backed region from device_memory.
+    /// `start_addr`/`size` must match the region exactly (vm-memory requires
+    /// an exact-size match, otherwise it returns `InvalidGuestRegion`).
+    /// Use this in the unmap path of dynamically-mapped device segments
+    /// (e.g. ivshmem unmap_region) so device_memory does not retain a dead
+    /// reference to a region whose KVM slot has just been removed.
+    pub fn remove_device_region(
+        &mut self,
+        start_addr: GuestAddress,
+        size: GuestUsize,
+    ) -> Result<(), Error> {
+        let (new_device_memory, _removed) = self
+            .device_memory
+            .memory()
+            .remove_region(start_addr, size)
+            .map_err(Error::GuestMemory)?;
+        self.device_memory
+            .lock()
+            .unwrap()
+            .replace(new_device_memory);
         Ok(())
     }
 
@@ -1702,6 +1775,13 @@ impl MemoryManager {
 
     pub fn guest_memory(&self) -> GuestMemoryAtomic<GuestMemoryMmap> {
         self.guest_memory.clone()
+    }
+
+    /// Return the device-memory view: RAM + device-backed regions.
+    /// Use this for any virtio/DMA backend that may need to access GPAs
+    /// pointing into device-mapped host memory (e.g. PMEM).
+    pub fn device_memory(&self) -> GuestMemoryAtomic<GuestMemoryMmap> {
+        self.device_memory.clone()
     }
 
     pub fn boot_guest_memory(&self) -> GuestMemoryMmap {


### PR DESCRIPTION
Add a second GuestMemoryAtomic<GuestMemoryMmap> in MemoryManager, called device_memory, which is a superset of guest_memory: it contains all RAM regions plus device-backed regions.
