### PR TITLE
fix(one-click): avoid glibc preflight pipefail races

### DIFF
--- a/deploy/one-click/lib/common.sh
+++ b/deploy/one-click/lib/common.sh
@@ -13,6 +13,18 @@ die() {
   exit 1
 }
 
+# Avoid `ldd --version | head -1` under strict mode: `head` may exit early and
+# SIGPIPE `ldd`, which turns a valid glibc probe into a false failure.
+detect_glibc_version() {
+  local ldd_output glibc_ver
+  if ! ldd_output="$(ldd --version 2>&1)"; then
+    return 1
+  fi
+  glibc_ver="$(awk 'NR == 1 { print $NF; exit }' <<<"${ldd_output}")"
+  [[ -n "${glibc_ver}" ]] || return 1
+  printf '%s\n' "${glibc_ver}"
+}
+
 require_cmd() {
   local cmd="$1"
   command -v "${cmd}" >/dev/null 2>&1 || die "required command not found: ${cmd}"
@@ -608,9 +620,7 @@ check_glibc_preflight() {
   local min_minor=31
 
   local glibc_ver
-  glibc_ver="$(ldd --version 2>&1 | head -1 | awk '{print $NF}')"
-
-  if [[ -z "${glibc_ver}" ]]; then
+  if ! glibc_ver="$(detect_glibc_version)"; then
     die "unable to detect glibc version (ldd --version failed)"
   fi
 

--- a/deploy/one-click/online-install.sh
+++ b/deploy/one-click/online-install.sh
@@ -19,6 +19,18 @@ for arg in "$@"; do
   esac
 done
 
+# Avoid `ldd --version | head -1` here: under `set -euo pipefail`, `head`
+# can exit early and SIGPIPE `ldd`, causing a silent false failure.
+detect_glibc_version() {
+  local ldd_output glibc_ver
+  if ! ldd_output="$(ldd --version 2>&1)"; then
+    return 1
+  fi
+  glibc_ver="$(awk 'NR == 1 { print $NF; exit }' <<<"${ldd_output}")"
+  [[ -n "${glibc_ver}" ]] || return 1
+  printf '%s\n' "${glibc_ver}"
+}
+
 # ---------------------------------------------------------------------------
 # Pre-download preflight checks (lightweight, self-contained)
 # ---------------------------------------------------------------------------
@@ -38,8 +50,7 @@ check_early_preflight() {
 
   # Glibc version check (fail fast before download)
   local glibc_ver
-  glibc_ver="$(ldd --version 2>&1 | head -1 | awk '{print $NF}')"
-  if [[ -z "${glibc_ver}" ]]; then
+  if ! glibc_ver="$(detect_glibc_version)"; then
     echo "[online-install] ERROR: unable to detect glibc version (ldd --version failed)." >&2
     exit 3
   fi

--- a/deploy/one-click/tests/test_runtime_file_safety.sh
+++ b/deploy/one-click/tests/test_runtime_file_safety.sh
@@ -113,6 +113,25 @@ test_unit_dependency_order() {
   assert_contains "${ONE_CLICK_DIR}/systemd/cube-sandbox-webui.service" "After=docker.service network-online.target cube-sandbox-cube-api.service"
 }
 
+test_detect_glibc_version_consumes_full_ldd_output() {
+  ldd() {
+    printf 'ldd (GNU libc) 2.39\n'
+    seq 1 100000
+  }
+
+  local version
+  version="$(detect_glibc_version)" || fail "expected detect_glibc_version to succeed with long ldd output"
+  [[ "${version}" == "2.39" ]] || fail "expected glibc version 2.39, got ${version}"
+}
+
+test_online_install_glibc_detection_avoids_head_pipe() {
+  local path="${ONE_CLICK_DIR}/online-install.sh"
+
+  assert_contains "${path}" "detect_glibc_version()"
+  assert_contains "${path}" "ldd_output=\"\$(ldd --version 2>&1)\""
+  assert_not_contains "${path}" "ldd --version 2>&1 | head -1 | awk '{print \$NF}'"
+}
+
 test_render_template_replaces_empty_directory
 test_render_template_rejects_non_empty_directory
 test_unit_prepare_hooks_are_wired
@@ -120,5 +139,7 @@ test_support_compose_render_is_locked_and_atomic
 test_compose_wrappers_reject_directories
 test_coredns_direct_outputs_prepare_file_path
 test_unit_dependency_order
+test_detect_glibc_version_consumes_full_ldd_output
+test_online_install_glibc_detection_avoids_head_pipe
 
 echo "runtime file safety tests OK"


### PR DESCRIPTION
## Summary
- replace the `ldd --version | head -1` glibc parsing in both one-click install entrypoints with a strict-mode-safe helper that captures the full command output first
- prevent valid hosts from hitting a silent false failure when `head` closes the pipe early under `set -euo pipefail`
- add regression coverage for long `ldd` output and assert the online installer no longer uses the brittle pipeline

## Test plan
- [x] `bash -n deploy/one-click/online-install.sh deploy/one-click/lib/common.sh deploy/one-click/tests/test_runtime_file_safety.sh`
- [x] `set -euo pipefail && source deploy/one-click/lib/common.sh && ldd(){ printf "ldd (GNU libc) 2.39\\n"; seq 1 100000; } && version="$(detect_glibc_version)" && [[ "$version" == "2.39" ]]`
- [ ] `bash deploy/one-click/tests/test_runtime_file_safety.sh` (currently blocked by a pre-existing unrelated assertion about `cube-sandbox-mysql.service`)

Autonomously-by: Cursor:GPT-5.4
