### PR TITLE
docs: remove --template-id from create-from-image commands in docs and examples

### DIFF
--- a/docs/guide/digital-assistant.md
+++ b/docs/guide/digital-assistant.md
@@ -8,13 +8,7 @@ The Digital Assistant is a preview feature intended for demos and early validati
 
 ## Digital Assistant Template
 
-AgentHub creates assistants from a CubeSandbox template. By default, CubeAPI uses the prebuilt Digital Assistant template:
-
-```env
-AGENTHUB_DS_OPENCLAW_TEMPLATE=wecom-ds-openclaw
-```
-
-You can override it in `.env` when a deployment uses a different published template ID:
+AgentHub creates assistants from a CubeSandbox template. Before deployment, build the Digital Assistant template (see the command below), then copy the auto-generated `tpl-` prefixed template ID into `.env`:
 
 ```env
 AGENTHUB_DS_OPENCLAW_TEMPLATE=<your-digital-assistant-template-id>
@@ -43,7 +37,6 @@ OPENCLAW_IMAGE=cube-sandbox-image.tencentcloudcr.com/demo/aio-sandbox-envd-openc
 
 cubemastercli tpl create-from-image \
   --image "${OPENCLAW_IMAGE}" \
-  --template-id wecom-ds-openclaw \
   --writable-layer-size 20Gi \
   --expose-port 18789 \
   --expose-port 8080 \

--- a/docs/zh/guide/digital-assistant.md
+++ b/docs/zh/guide/digital-assistant.md
@@ -8,13 +8,7 @@
 
 ## 数字助手模板
 
-AgentHub 会基于 CubeSandbox 模板创建数字助手。默认情况下，CubeAPI 使用预置的数字助手模板：
-
-```env
-AGENTHUB_DS_OPENCLAW_TEMPLATE=wecom-ds-openclaw
-```
-
-如果部署环境使用其他已发布模板，可以在 `.env` 中覆盖：
+AgentHub 会基于 CubeSandbox 模板创建数字助手。部署前需要先制作数字助手模板（见下方命令），然后将自动生成的 `tpl-` 前缀模板 ID 写入 `.env`：
 
 ```env
 AGENTHUB_DS_OPENCLAW_TEMPLATE=<your-digital-assistant-template-id>
@@ -43,7 +37,6 @@ OPENCLAW_IMAGE=cube-sandbox-image.tencentcloudcr.com/demo/aio-sandbox-envd-openc
 
 cubemastercli tpl create-from-image \
   --image "${OPENCLAW_IMAGE}" \
-  --template-id wecom-ds-openclaw \
   --writable-layer-size 20Gi \
   --expose-port 18789 \
   --expose-port 8080 \

--- a/examples/openai-agents-code-interpreter/README.md
+++ b/examples/openai-agents-code-interpreter/README.md
@@ -58,7 +58,6 @@ cp .env.example .env
 cubemastercli template create-from-image \
   --image cube-sandbox-image.tencentcloudcr.com/demo/e2b-code-interpreter:v1.1-data \
   --writable-layer-size 1Gi \
-  --template-id e2b-code-interpreter \
   --expose-port 49983 \
   --expose-port 49999 \
   --probe 49983

--- a/examples/openai-agents-code-interpreter/README_zh.md
+++ b/examples/openai-agents-code-interpreter/README_zh.md
@@ -58,7 +58,6 @@ cp .env.example .env
 cubemastercli template create-from-image \
   --image cube-sandbox-image.tencentcloudcr.com/demo/e2b-code-interpreter:v1.1-data \
   --writable-layer-size 1Gi \
-  --template-id e2b-code-interpreter \
   --expose-port 49983 \
   --expose-port 49999 \
   --probe 49983

--- a/examples/openai-agents-example/openai-agents-sandbox-cube-integration.md
+++ b/examples/openai-agents-example/openai-agents-sandbox-cube-integration.md
@@ -333,7 +333,6 @@ Template registration example (taken from `openai-agents-code-interpreter/README
 cubemastercli template create-from-image \
   --image cube-sandbox-image.tencentcloudcr.com/demo/e2b-code-interpreter:v1.1-data \
   --writable-layer-size 1Gi \
-  --template-id e2b-code-interpreter \
   --expose-port 49983 \
   --expose-port 49999 \
   --probe 49983

--- a/examples/openai-agents-example/openai-agents-sandbox-cube-integration_zh.md
+++ b/examples/openai-agents-example/openai-agents-sandbox-cube-integration_zh.md
@@ -334,7 +334,6 @@ cube template 需要预装 / 暴露什么，取决于跑哪种形态：
 cubemastercli template create-from-image \
   --image cube-sandbox-image.tencentcloudcr.com/demo/e2b-code-interpreter:v1.1-data \
   --writable-layer-size 1Gi \
-  --template-id e2b-code-interpreter \
   --expose-port 49983 \
   --expose-port 49999 \
   --probe 49983


### PR DESCRIPTION


Template IDs are now auto-generated by the server with 'tpl-' prefix. Remove all --template-id flags from 'tpl create-from-image' / 'template create-from-image' commands across documentation and example READMEs. Update surrounding text to explain that the server generates the ID and users should copy it from the command output.