### PR TITLE
fix(web): align displayed version with release tag

### DIFF
--- a/.github/workflows/release-one-click.yml
+++ b/.github/workflows/release-one-click.yml
@@ -273,6 +273,10 @@ jobs:
         run: docker pull "${BUILDER_IMAGE}"
 
       - name: Build one-click release bundle
+        env:
+          # Align the dashboard's displayed version with the release tag; the
+          # value propagates to the web build (vite reads CUBE_RELEASE_VERSION).
+          CUBE_RELEASE_VERSION: ${{ github.ref_name }}
         run: ./deploy/one-click/build-release-bundle-builder.sh
 
       - name: Resolve bundle path

--- a/web/src/components/Rail.tsx
+++ b/web/src/components/Rail.tsx
@@ -75,7 +75,7 @@ export function Rail() {
             GitHub
           </span>
         </a>
-        <div className="text-xs tracking-wider text-muted-foreground/70 text-num">v0.1</div>
+        <div className="text-xs tracking-wider text-muted-foreground/70 text-num">v{__APP_VERSION__}</div>
       </div>
     </aside>
   );

--- a/web/src/pages/Settings.tsx
+++ b/web/src/pages/Settings.tsx
@@ -267,7 +267,7 @@ function AboutSection() {
 
       <div className="rounded-xl border border-border/60 bg-card/40 divide-y divide-border/40">
         {([
-          { label: t('about.version'),     value: 'v0.2.0',                                                  mono: true  },
+          { label: t('about.version'),     value: `v${__APP_VERSION__}`,                                     mono: true  },
           { label: t('about.cubeApi'),     value: cfg?.apiEndpoint ?? `${window.location.origin}/cubeapi/v1`, mono: true  },
           { label: t('about.instanceType'),value: cfg?.instanceType ?? '—',                                   mono: false },
         ] as Array<{ label: string; value: string; mono: boolean }>).map(({ label, value, mono }) => (

--- a/web/src/vite-env.d.ts
+++ b/web/src/vite-env.d.ts
@@ -2,3 +2,7 @@
 // Copyright (C) 2026 Tencent. All rights reserved.
 
 /// <reference types="vite/client" />
+
+// Injected at build time by Vite, aligned with the release tag (see
+// vite.config.ts `define` / resolveAppVersion).
+declare const __APP_VERSION__: string;

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -1,12 +1,38 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (C) 2026 Tencent. All rights reserved.
 
+import { execSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
 import path from 'node:path';
 
 import react from '@vitejs/plugin-react';
 import { defineConfig } from 'vite';
 
+const pkg = JSON.parse(readFileSync(path.resolve(__dirname, './package.json'), 'utf-8'));
+
+// Displayed app version, aligned with the release tag. Release builds inject the
+// tag via CUBE_RELEASE_VERSION (release-one-click.yml passes github.ref_name);
+// otherwise it derives from the nearest tag (`git describe --tags --abbrev=0`),
+// falling back to package.json only when no tag is reachable (e.g. forks).
+// A leading "v" is stripped so the UI can render a single canonical "v<x>".
+function resolveAppVersion(): string {
+  const fromEnv = process.env.CUBE_RELEASE_VERSION?.trim();
+  if (fromEnv) return fromEnv.replace(/^v/, '');
+  try {
+    const described = execSync('git describe --tags --abbrev=0', { stdio: ['ignore', 'pipe', 'ignore'] })
+      .toString()
+      .trim();
+    if (described) return described.replace(/^v/, '');
+  } catch {
+    // No reachable tag (e.g. a fork without tags) — fall back to package.json.
+  }
+  return pkg.version;
+}
+
 export default defineConfig({
+  define: {
+    __APP_VERSION__: JSON.stringify(resolveAppVersion()),
+  },
   plugins: [react()],
   resolve: {
     alias: {


### PR DESCRIPTION
The sidebar (bottom-left) and the Settings About section showed hardcoded, mismatched versions (v0.1 vs v0.2.0). Inject a build-time __APP_VERSION__ resolved from the release tag
(CUBE_RELEASE_VERSION > nearest git tag > package.json) and use it in both places, and have release-one-click.yml pass github.ref_name so the displayed version tracks the published release automatically.

Assisted-by: Cursor:claude-opus-4.8