### PR TITLE
feat(sandbox): add absolute TTL reaper with SetTimeout/Refresh endpoints and dashboard EndAt

### DIFF
--- a/CubeAPI/src/cubemaster/mod.rs
+++ b/CubeAPI/src/cubemaster/mod.rs
@@ -871,7 +871,7 @@ pub struct SandboxInfo {
     /// Unix nanoseconds from Cubelet container.created_at — used as fallback for started_at
     #[serde(default)]
     pub create_at: i64,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_end_at_nanos")]
     pub end_at: Option<DateTime<Utc>>,
     #[serde(default, alias = "cpuCount")]
     pub cpu_count: i32,
@@ -1027,6 +1027,41 @@ fn normalize_sandbox_status_text(raw: &str) -> String {
         "running" | "paused" | "pausing" | "stopped" | "error" => raw.trim().to_lowercase(),
         other => other.to_string(),
     }
+}
+
+fn deserialize_end_at_nanos<'de, D>(deserializer: D) -> Result<Option<DateTime<Utc>>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum EndAtRepr {
+        Number(i64),
+        Text(String),
+        Datetime(DateTime<Utc>),
+    }
+
+    let value = Option::<EndAtRepr>::deserialize(deserializer)?;
+    Ok(match value {
+        None => None,
+        Some(EndAtRepr::Number(n)) if n <= 0 => None,
+        Some(EndAtRepr::Number(n)) => datetime_from_unix_nanos(n),
+        Some(EndAtRepr::Text(s)) if s.trim().is_empty() => None,
+        Some(EndAtRepr::Text(s)) => {
+            if let Ok(n) = s.trim().parse::<i64>() {
+                if n <= 0 {
+                    None
+                } else {
+                    datetime_from_unix_nanos(n)
+                }
+            } else {
+                DateTime::parse_from_rfc3339(s.trim())
+                    .ok()
+                    .map(|d| d.with_timezone(&Utc))
+            }
+        }
+        Some(EndAtRepr::Datetime(dt)) => Some(dt),
+    })
 }
 
 pub(crate) fn extract_template_id(
@@ -1901,6 +1936,42 @@ mod tests {
             serde_json::from_value(payload).expect("sandbox info should deserialize aliases");
         assert_eq!(info.cpu_count, 4);
         assert_eq!(info.memory_mb, 4096);
+    }
+
+    #[test]
+    fn sandbox_info_decodes_end_at_in_every_supported_form() {
+        let payload = serde_json::json!({
+            "sandbox_id": "sb-1",
+            "end_at": 1_780_650_812_190_807_839_i64
+        });
+        let info: SandboxInfo = serde_json::from_value(payload).unwrap();
+        assert!(info.end_at.is_some());
+
+        let payload = serde_json::json!({
+            "sandbox_id": "sb-2",
+            "end_at": "1780650812190807839"
+        });
+        let info: SandboxInfo = serde_json::from_value(payload).unwrap();
+        assert!(info.end_at.is_some());
+
+        let payload = serde_json::json!({
+            "sandbox_id": "sb-3",
+            "end_at": "2026-06-05T08:14:03.198556093Z"
+        });
+        let info: SandboxInfo = serde_json::from_value(payload).unwrap();
+        assert!(info.end_at.is_some());
+
+        for raw in [
+            serde_json::json!({ "sandbox_id": "sb" }),
+            serde_json::json!({ "sandbox_id": "sb", "end_at": null }),
+            serde_json::json!({ "sandbox_id": "sb", "end_at": 0 }),
+            serde_json::json!({ "sandbox_id": "sb", "end_at": -1 }),
+            serde_json::json!({ "sandbox_id": "sb", "end_at": "" }),
+            serde_json::json!({ "sandbox_id": "sb", "end_at": "0" }),
+        ] {
+            let info: SandboxInfo = serde_json::from_value(raw).unwrap();
+            assert!(info.end_at.is_none(), "expected no TTL");
+        }
     }
 
     #[test]

--- a/CubeAPI/src/handlers/agenthub.rs
+++ b/CubeAPI/src/handlers/agenthub.rs
@@ -267,7 +267,7 @@ pub async fn create_agent_instance(
         .sandboxes
         .create_sandbox(NewSandbox {
             template_id: template_id.clone(),
-            timeout,
+            timeout: Some(timeout),
             auto_pause: false,
             auto_resume: None,
             secure: None,
@@ -903,7 +903,7 @@ pub async fn clone_agent_instance(
         .sandboxes
         .create_sandbox(NewSandbox {
             template_id: snapshot_id.clone(),
-            timeout,
+            timeout: Some(timeout),
             auto_pause: false,
             auto_resume: None,
             secure: None,

--- a/CubeAPI/src/handlers/agenthub.rs
+++ b/CubeAPI/src/handlers/agenthub.rs
@@ -267,7 +267,7 @@ pub async fn create_agent_instance(
         .sandboxes
         .create_sandbox(NewSandbox {
             template_id: template_id.clone(),
-            timeout: Some(timeout),
+            timeout,
             auto_pause: false,
             auto_resume: None,
             secure: None,
@@ -903,7 +903,7 @@ pub async fn clone_agent_instance(
         .sandboxes
         .create_sandbox(NewSandbox {
             template_id: snapshot_id.clone(),
-            timeout: Some(timeout),
+            timeout,
             auto_pause: false,
             auto_resume: None,
             secure: None,

--- a/CubeAPI/src/models/mod.rs
+++ b/CubeAPI/src/models/mod.rs
@@ -77,13 +77,14 @@ pub struct NewSandbox {
     #[serde(rename = "templateID")]
     pub template_id: String,
 
-    /// Sandbox lifetime in seconds. `None` (field omitted) means "no
-    /// automatic destroy" — the sandbox lives until killed explicitly
-    /// via DELETE /sandboxes/{id} or until SetTimeout/Refresh installs
-    /// a deadline. `Some(0)` is treated the same as `None`.
+    /// Sandbox lifetime in seconds. Defaults to 15 if the field is
+    /// omitted, matching the historical behavior every official SDK
+    /// relies on. `0` means "no automatic destroy" — the sandbox lives
+    /// until killed explicitly via DELETE /sandboxes/{id} or until
+    /// SetTimeout / Refresh installs a new deadline.
     #[validate(range(min = 0))]
-    #[serde(default)]
-    pub timeout: Option<i32>,
+    #[serde(default = "default_timeout")]
+    pub timeout: i32,
 
     #[serde(rename = "autoPause", default)]
     pub auto_pause: bool,
@@ -377,11 +378,17 @@ fn default_log_limit() -> i32 {
 
 // ─── Sandbox — timeout / refresh ──────────────────────────────────────────
 
-/// Request body for POST /sandboxes/{id}/timeout
+/// Request body for POST /sandboxes/{id}/timeout.
+///
+/// Field name is `timeout` (seconds, absolute). Earlier drafts also
+/// accepted a `duration` alias for cross-SDK compatibility, but this
+/// invited callers to confuse SetTimeout (absolute reset) with the
+/// /refreshes endpoint (which still uses `duration`). The two
+/// endpoints now keep their natural field names so the on-wire shape
+/// communicates the semantics.
 #[derive(Debug, Deserialize, Validate, ToSchema)]
 pub struct SetTimeoutRequest {
     #[validate(range(min = 0))]
-    #[serde(alias = "duration")]
     pub timeout: i32,
 }
 

--- a/CubeAPI/src/models/mod.rs
+++ b/CubeAPI/src/models/mod.rs
@@ -77,9 +77,13 @@ pub struct NewSandbox {
     #[serde(rename = "templateID")]
     pub template_id: String,
 
+    /// Sandbox lifetime in seconds. `None` (field omitted) means "no
+    /// automatic destroy" — the sandbox lives until killed explicitly
+    /// via DELETE /sandboxes/{id} or until SetTimeout/Refresh installs
+    /// a deadline. `Some(0)` is treated the same as `None`.
     #[validate(range(min = 0))]
-    #[serde(default = "default_timeout")]
-    pub timeout: i32,
+    #[serde(default)]
+    pub timeout: Option<i32>,
 
     #[serde(rename = "autoPause", default)]
     pub auto_pause: bool,
@@ -160,8 +164,10 @@ pub struct ListedSandbox {
     pub client_id: String,
     #[serde(rename = "startedAt")]
     pub started_at: DateTime<Utc>,
-    #[serde(rename = "endAt")]
-    pub end_at: DateTime<Utc>,
+    /// Absolute deadline when the TTL reaper will destroy this sandbox.
+    /// `None` means the sandbox has no automatic-destroy schedule.
+    #[serde(rename = "endAt", skip_serializing_if = "Option::is_none")]
+    pub end_at: Option<DateTime<Utc>>,
     #[serde(rename = "cpuCount")]
     pub cpu_count: i32,
     #[serde(rename = "memoryMB")]
@@ -190,8 +196,10 @@ pub struct SandboxDetail {
     pub client_id: String,
     #[serde(rename = "startedAt")]
     pub started_at: DateTime<Utc>,
-    #[serde(rename = "endAt")]
-    pub end_at: DateTime<Utc>,
+    /// Absolute deadline when the TTL reaper will destroy this sandbox.
+    /// `None` means the sandbox has no automatic-destroy schedule.
+    #[serde(rename = "endAt", skip_serializing_if = "Option::is_none")]
+    pub end_at: Option<DateTime<Utc>>,
     #[serde(rename = "envdVersion")]
     pub envd_version: String,
     #[serde(rename = "envdAccessToken", skip_serializing_if = "Option::is_none")]
@@ -373,13 +381,15 @@ fn default_log_limit() -> i32 {
 #[derive(Debug, Deserialize, Validate, ToSchema)]
 pub struct SetTimeoutRequest {
     #[validate(range(min = 0))]
+    #[serde(alias = "duration")]
     pub timeout: i32,
 }
 
 /// Request body for POST /sandboxes/{id}/refreshes
 #[derive(Debug, Deserialize, Validate, ToSchema)]
 pub struct RefreshRequest {
-    #[validate(range(min = 0, max = 3600))]
+    #[validate(range(min = 0, max = 86400))]
+    #[serde(default, alias = "timeout")]
     pub duration: Option<i32>,
 }
 

--- a/CubeAPI/src/services/sandboxes.rs
+++ b/CubeAPI/src/services/sandboxes.rs
@@ -91,8 +91,7 @@ impl SandboxService {
         let end_at = summary
             .as_ref()
             .and_then(|s| s.end_at.as_ref().cloned())
-            .or(d.end_at)
-            .unwrap_or(started_at);
+            .or(d.end_at);
 
         Ok(SandboxDetail {
             template_id: d.template_id,
@@ -136,7 +135,7 @@ impl SandboxService {
         let req = CreateSandboxRequest {
             request_id: new_request_id(),
             instance_type: self.instance_type.clone(),
-            timeout: Some(body.timeout),
+            timeout: body.timeout.filter(|t| *t > 0),
             annotations,
             labels,
             volumes: None,
@@ -520,7 +519,7 @@ pub(crate) fn from_cubemaster_info(s: SandboxInfo) -> crate::models::ListedSandb
         sandbox_id: s.sandbox_id,
         client_id: s.host_id,
         started_at,
-        end_at: s.end_at.unwrap_or(now),
+        end_at: s.end_at,
         cpu_count: s.cpu_count,
         memory_mb: s.memory_mb,
         disk_size_mb: Some(0),
@@ -679,6 +678,7 @@ mod tests {
             host_id: "host-1".to_string(),
             status: "running".to_string(),
             started_at: None,
+            create_at: 0,
             end_at: None,
             cpu_count: 2,
             memory_mb: 2048,
@@ -690,6 +690,7 @@ mod tests {
         assert_eq!(listed.cpu_count, 2);
         assert_eq!(listed.memory_mb, 2048);
         assert_eq!(listed.template_id, "tpl-1");
+        assert!(listed.end_at.is_none());
     }
 
     #[test]

--- a/CubeAPI/src/services/sandboxes.rs
+++ b/CubeAPI/src/services/sandboxes.rs
@@ -135,7 +135,7 @@ impl SandboxService {
         let req = CreateSandboxRequest {
             request_id: new_request_id(),
             instance_type: self.instance_type.clone(),
-            timeout: body.timeout.filter(|t| *t > 0),
+            timeout: Some(body.timeout).filter(|t| *t > 0),
             annotations,
             labels,
             volumes: None,

--- a/CubeMaster/cmd/cubemaster/app/main.go
+++ b/CubeMaster/cmd/cubemaster/app/main.go
@@ -52,7 +52,6 @@ func (a *App) Run() {
 	)
 	defer cancel()
 
-
 	cfg := config.GetConfig()
 
 	if err := coreInit(ctx, cfg); err != nil {
@@ -169,6 +168,11 @@ func coreInit(ctx context.Context, cfg *config.Config) error {
 		stdlog.Fatalf("cube init fail:%v", err)
 		return err
 	}
+
+	// Background TTL reaper: periodically destroys sandboxes whose
+	// EndAt deadline has elapsed. Cancelled with the same root context
+	// as the rest of the master loops so graceful shutdown ends it.
+	sandbox.StartTimeoutReaper(ctx)
 
 	return nil
 }

--- a/CubeMaster/pkg/base/types/id2ip.go
+++ b/CubeMaster/pkg/base/types/id2ip.go
@@ -10,6 +10,11 @@ type SandboxProxyMap struct {
 	SandboxIP   string `json:"SandboxIP,omitempty"`
 	SandboxPort string `json:"SandboxPort,omitempty"`
 
-	CreatedAt            string            `json:"CreatedAt,omitempty"`
+	CreatedAt string `json:"CreatedAt,omitempty"`
+	// EndAt is the absolute deadline (Unix nanoseconds, as decimal string)
+	// after which the TTL reaper will issue a DestroySandbox.
+	// Empty / "0" means the sandbox has no TTL and will live until killed
+	// explicitly via DELETE /sandboxes/{id}.
+	EndAt                string            `json:"EndAt,omitempty"`
 	ContainerToHostPorts map[string]string `json:"ContainerToHostPorts,omitempty"`
 }

--- a/CubeMaster/pkg/localcache/export.go
+++ b/CubeMaster/pkg/localcache/export.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"strconv"
 	"sync/atomic"
 	"time"
 
@@ -209,6 +210,10 @@ func NotifyEvent(e *Event) error {
 }
 
 func SetSandboxProxyMap(ctx context.Context, proxyInfo *types.SandboxProxyMap) error {
+	if proxyInfo == nil || proxyInfo.SandboxID == "" {
+		log.G(ctx).Errorf("SetSandboxProxyMap rejected: empty SandboxID, proxy=%+v", proxyInfo)
+		return errors.New("SetSandboxProxyMap: empty SandboxID")
+	}
 	keyByPass := "bypass_host_proxy" + ":" + proxyInfo.SandboxID
 	err := l.setByPassProsyToRedis(ctx, keyByPass, proxyInfo)
 	if err != nil {
@@ -226,6 +231,7 @@ func GetSandboxProxyMap(ctx context.Context, sandboxID string) (*types.SandboxPr
 	}
 
 	if proxyMap != nil {
+		proxyMap.SandboxID = sandboxID
 		return proxyMap, true
 	} else {
 		return nil, false
@@ -287,6 +293,40 @@ func DeleteSandboxProxyMap(ctx context.Context, sandboxID string) error {
 		return err
 	}
 	return nil
+}
+
+// ListExpiredSandboxIDs scans Redis for SandboxProxyMap entries whose
+// EndAt has elapsed and returns their sandbox IDs. Entries with empty
+// or unparseable EndAt are treated as having no TTL and skipped.
+func ListExpiredSandboxIDs(ctx context.Context, now time.Time) ([]string, error) {
+	keys, err := l.scanByPassProxyKeys(ctx)
+	if err != nil {
+		return nil, err
+	}
+	const prefix = "bypass_host_proxy:"
+	expired := make([]string, 0, len(keys))
+	for _, key := range keys {
+		if len(key) <= len(prefix) {
+			continue
+		}
+		sandboxID := key[len(prefix):]
+		proxy, err := l.getByPassProsyFromRedis(ctx, key)
+		if err != nil || proxy == nil || proxy.EndAt == "" {
+			continue
+		}
+		endNanos, err := strconv.ParseInt(proxy.EndAt, 10, 64)
+		if err != nil || endNanos <= 0 {
+			continue
+		}
+		if now.UnixNano() > endNanos {
+			log.G(ctx).Infof("reaper: sandbox=%s EndAt=%s (%s ago) -> mark expired",
+				sandboxID,
+				time.Unix(0, endNanos).UTC().Format(time.RFC3339Nano),
+				now.Sub(time.Unix(0, endNanos)))
+			expired = append(expired, sandboxID)
+		}
+	}
+	return expired, nil
 }
 
 func SetDescribeTask(ctx context.Context, taskInfo *types.DescribeTaskMap) error {

--- a/CubeMaster/pkg/localcache/export.go
+++ b/CubeMaster/pkg/localcache/export.go
@@ -10,7 +10,6 @@ import (
 	"errors"
 	"fmt"
 	"math"
-	"strconv"
 	"sync/atomic"
 	"time"
 
@@ -209,6 +208,14 @@ func NotifyEvent(e *Event) error {
 	}
 }
 
+// SetSandboxProxyMap upserts a sandbox's proxy hash. Callers MUST treat
+// this as a full overwrite: the EndAt / SandboxIP / port-mapping fields
+// of the supplied SandboxProxyMap are authoritative, and an empty EndAt
+// will explicitly drop the absolute deadline (HDEL + ZREM on the TTL
+// secondary index) — exactly what SetTimeout(0) / Refresh(0) wants.
+// New code paths that only mutate one field should always start from
+// GetSandboxProxyMap so they don't accidentally clobber another field
+// (most importantly EndAt) that they had no intention of touching.
 func SetSandboxProxyMap(ctx context.Context, proxyInfo *types.SandboxProxyMap) error {
 	if proxyInfo == nil || proxyInfo.SandboxID == "" {
 		log.G(ctx).Errorf("SetSandboxProxyMap rejected: empty SandboxID, proxy=%+v", proxyInfo)
@@ -288,45 +295,40 @@ func DeleteInstanceInfoMap(ctx context.Context, insID string) error {
 
 func DeleteSandboxProxyMap(ctx context.Context, sandboxID string) error {
 	keyByPass := "bypass_host_proxy" + ":" + sandboxID
-	err := l.deleteKeyFromRedis(ctx, keyByPass)
-	if err != nil {
+	if err := l.deleteKeyFromRedis(ctx, keyByPass); err != nil {
 		return err
 	}
+	// Best-effort: drop the TTL secondary-index entry so the reaper does
+	// not keep observing a phantom sandbox that no longer has a hash.
+	l.removeFromTTLIndex(ctx, sandboxID)
 	return nil
 }
 
-// ListExpiredSandboxIDs scans Redis for SandboxProxyMap entries whose
-// EndAt has elapsed and returns their sandbox IDs. Entries with empty
-// or unparseable EndAt are treated as having no TTL and skipped.
-func ListExpiredSandboxIDs(ctx context.Context, now time.Time) ([]string, error) {
-	keys, err := l.scanByPassProxyKeys(ctx)
-	if err != nil {
-		return nil, err
-	}
-	const prefix = "bypass_host_proxy:"
-	expired := make([]string, 0, len(keys))
-	for _, key := range keys {
-		if len(key) <= len(prefix) {
-			continue
-		}
-		sandboxID := key[len(prefix):]
-		proxy, err := l.getByPassProsyFromRedis(ctx, key)
-		if err != nil || proxy == nil || proxy.EndAt == "" {
-			continue
-		}
-		endNanos, err := strconv.ParseInt(proxy.EndAt, 10, 64)
-		if err != nil || endNanos <= 0 {
-			continue
-		}
-		if now.UnixNano() > endNanos {
-			log.G(ctx).Infof("reaper: sandbox=%s EndAt=%s (%s ago) -> mark expired",
-				sandboxID,
-				time.Unix(0, endNanos).UTC().Format(time.RFC3339Nano),
-				now.Sub(time.Unix(0, endNanos)))
-			expired = append(expired, sandboxID)
-		}
-	}
-	return expired, nil
+// ListExpiredSandboxIDs returns up to `limit` sandbox ids whose absolute
+// deadline has elapsed, by querying the TTL secondary index sorted set.
+// Compared to the previous SCAN+HGETALL strategy this is O(logN+K) in
+// the number of *expired* entries, so a reaper tick stays cheap even
+// with tens of thousands of running sandboxes. The bounded `limit`
+// guarantees a single tick never blocks for arbitrarily long; any
+// remaining expired ids are picked up on the next tick.
+func ListExpiredSandboxIDs(ctx context.Context, now time.Time, limit int) ([]string, error) {
+	return l.listExpiredSandboxIDsByZSet(ctx, now, limit)
+}
+
+// AcquireReaperLock tries to install a cluster-wide reaper lease in
+// Redis so that, in a multi-master deployment, only one CubeMaster
+// performs the destroy fan-out at any given moment. The lease auto-
+// expires after `ttl`, ensuring a crashed leader never permanently
+// stalls TTL-based destroys.
+func AcquireReaperLock(ctx context.Context, holder string, ttl time.Duration) (bool, error) {
+	return acquireReaperLock(ctx, holder, ttl)
+}
+
+// ReleaseReaperLock releases the reaper lease iff the caller still owns
+// it, using a CAS Lua script so a slow leader cannot accidentally drop
+// the lock the next leader has just acquired.
+func ReleaseReaperLock(ctx context.Context, holder string) {
+	releaseReaperLock(ctx, holder)
 }
 
 func SetDescribeTask(ctx context.Context, taskInfo *types.DescribeTaskMap) error {

--- a/CubeMaster/pkg/localcache/redis_cache.go
+++ b/CubeMaster/pkg/localcache/redis_cache.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strconv"
 	"time"
 
 	"github.com/gomodule/redigo/redis"
@@ -363,14 +364,37 @@ func (l *local) setByPassProsyToRedis(ctx context.Context, key string, byPassPro
 	if byPassProsy.SandboxIP != "" {
 		fieldValues = append(fieldValues, "SandboxIP", byPassProsy.SandboxIP)
 	}
-	fieldValues = append(fieldValues, "EndAt", byPassProsy.EndAt)
+	writeEndAt := byPassProsy.EndAt != "" && byPassProsy.EndAt != "0"
+	if writeEndAt {
+		fieldValues = append(fieldValues, "EndAt", byPassProsy.EndAt)
+	}
 	for k, v := range byPassProsy.ContainerToHostPorts {
 		fieldValues = append(fieldValues, k, v)
 	}
-	_, err = wrapredis.GetRedis(wrapredis.RedisWrite).Do("HSET", redis.Args{key}.AddFlat(fieldValues)...)
+	conn := wrapredis.GetRedis(wrapredis.RedisWrite)
+	_, err = conn.Do("HSET", redis.Args{key}.AddFlat(fieldValues)...)
 	if err != nil {
 		log.G(ctx).Errorf("redis set error, key: %s, err: %s", key, err)
 		return err
+	}
+	// Maintain the TTL secondary index in lock-step with the hash:
+	//   - HDEL EndAt + ZREM when the caller wants "no TTL", so we never
+	//     leave a stale empty string that would later be wrongly parsed
+	//     and never leak a ghost member into the index.
+	//   - ZADD score=EndAt-nanos when the caller asks for a deadline, so
+	//     the reaper can do O(logN+K) lookups via ZRANGEBYSCORE instead
+	//     of a full HGETALL scan over every sandbox.
+	if !writeEndAt {
+		if _, derr := conn.Do("HDEL", key, "EndAt"); derr != nil {
+			log.G(ctx).Warnf("setByPassProsyToRedis HDEL EndAt key=%s err:%s", key, derr)
+		}
+		if _, zerr := conn.Do("ZREM", sandboxTTLIndexKey, byPassProsy.SandboxID); zerr != nil {
+			log.G(ctx).Warnf("setByPassProsyToRedis ZREM ttl-index sandbox=%s err:%s", byPassProsy.SandboxID, zerr)
+		}
+	} else if score, perr := strconv.ParseInt(byPassProsy.EndAt, 10, 64); perr == nil && score > 0 {
+		if _, zerr := conn.Do("ZADD", sandboxTTLIndexKey, score, byPassProsy.SandboxID); zerr != nil {
+			log.G(ctx).Warnf("setByPassProsyToRedis ZADD ttl-index sandbox=%s err:%s", byPassProsy.SandboxID, zerr)
+		}
 	}
 	if log.IsDebug() {
 		log.G(ctx).Debugf("setByPassProsyToRedis:%s,%s", key, fieldValues)
@@ -456,35 +480,84 @@ func traceRedis(ctx context.Context, action, redisOp, key string, start time.Tim
 	CubeLog.Trace(baseRt)
 }
 
-func (l *local) scanByPassProxyKeys(ctx context.Context) ([]string, error) {
-	const pattern = "bypass_host_proxy:*"
-	const batch = 200
-	var (
-		cursor int64
-		keys   []string
-	)
+// sandboxTTLIndexKey is a redis sorted set whose member is the sandbox
+// id and whose score is its absolute deadline in unix-nanoseconds. The
+// reaper queries it with ZRANGEBYSCORE -inf <now>, which is O(logN+K)
+// in the number of *expired* sandboxes and avoids a full SCAN+HGETALL
+// over every running sandbox on every tick.
+const sandboxTTLIndexKey = "sandbox_ttl_index"
+
+// listExpiredSandboxIDsByZSet returns at most `limit` sandbox ids whose
+// EndAt has elapsed. The slice is bounded so a single reaper tick never
+// blocks on tens of thousands of entries; the next tick picks up the
+// rest.
+func (l *local) listExpiredSandboxIDsByZSet(ctx context.Context, now time.Time, limit int) ([]string, error) {
+	if limit <= 0 {
+		limit = 256
+	}
 	conn := wrapredis.GetRedis(wrapredis.RedisRead)
-	for {
-		values, err := redis.Values(conn.Do("SCAN", cursor, "MATCH", pattern, "COUNT", batch))
-		if err != nil {
-			log.G(ctx).Warnf("scanByPassProxyKeys err:%s", err)
-			return nil, err
+	ids, err := redis.Strings(conn.Do(
+		"ZRANGEBYSCORE", sandboxTTLIndexKey,
+		"-inf", now.UnixNano(),
+		"LIMIT", 0, limit,
+	))
+	if err != nil {
+		if errors.Is(err, redis.ErrNil) {
+			return nil, nil
 		}
-		if len(values) != 2 {
-			return nil, errors.New("scanByPassProxyKeys: malformed reply")
-		}
-		next, err := redis.Int64(values[0], nil)
-		if err != nil {
-			return nil, err
-		}
-		batchKeys, err := redis.Strings(values[1], nil)
-		if err != nil {
-			return nil, err
-		}
-		keys = append(keys, batchKeys...)
-		cursor = next
-		if cursor == 0 {
-			return keys, nil
-		}
+		log.G(ctx).Warnf("listExpiredSandboxIDsByZSet err:%s", err)
+		return nil, err
+	}
+	return ids, nil
+}
+
+// removeFromTTLIndex drops a sandbox from the TTL secondary index. It
+// is best-effort: a leftover member will simply be observed as "no
+// proxy / no EndAt" by the reaper on the next tick and pruned then.
+func (l *local) removeFromTTLIndex(ctx context.Context, sandboxID string) {
+	if sandboxID == "" {
+		return
+	}
+	if _, err := wrapredis.GetRedis(wrapredis.RedisWrite).Do("ZREM", sandboxTTLIndexKey, sandboxID); err != nil {
+		log.G(ctx).Warnf("removeFromTTLIndex sandbox=%s err:%s", sandboxID, err)
 	}
 }
+
+// acquireReaperLock attempts to acquire the cluster-wide reaper lease so
+// that, in a multi-master deployment, only one CubeMaster runs the
+// destroy fan-out at any given moment. The lease auto-expires after
+// ttl, so a crashed leader does not stall the reaper for long.
+func acquireReaperLock(ctx context.Context, holder string, ttl time.Duration) (bool, error) {
+	if holder == "" {
+		return false, errors.New("acquireReaperLock: empty holder")
+	}
+	reply, err := wrapredis.GetRedis(wrapredis.RedisWrite).Do(
+		"SET", reaperLockKey, holder, "NX", "EX", int(ttl.Seconds()),
+	)
+	if err != nil {
+		if errors.Is(err, redis.ErrNil) {
+			return false, nil
+		}
+		return false, err
+	}
+	if reply == nil {
+		return false, nil
+	}
+	s, ok := reply.(string)
+	return ok && s == "OK", nil
+}
+
+// releaseReaperLock releases the lease iff the caller still owns it.
+// The compare-and-delete script avoids the classic "deleted someone
+// else's lock after a long GC" race.
+func releaseReaperLock(ctx context.Context, holder string) {
+	if holder == "" {
+		return
+	}
+	const script = `if redis.call("GET", KEYS[1]) == ARGV[1] then return redis.call("DEL", KEYS[1]) else return 0 end`
+	if _, err := wrapredis.GetRedis(wrapredis.RedisWrite).Do("EVAL", script, 1, reaperLockKey, holder); err != nil {
+		log.G(ctx).Warnf("releaseReaperLock holder=%s err:%s", holder, err)
+	}
+}
+
+const reaperLockKey = "sandbox_reaper_lock"

--- a/CubeMaster/pkg/localcache/redis_cache.go
+++ b/CubeMaster/pkg/localcache/redis_cache.go
@@ -295,6 +295,10 @@ func (l *local) getByPassProsyFromRedis(ctx context.Context, key string) (*types
 		nodeIdIp.CreatedAt = createAt
 		delete(mapvalues, "CreatedAt")
 	}
+	if endAt, ok := mapvalues["EndAt"]; ok {
+		nodeIdIp.EndAt = endAt
+		delete(mapvalues, "EndAt")
+	}
 	if sandboxIP, ok := mapvalues["SandboxIP"]; ok {
 		nodeIdIp.SandboxIP = sandboxIP
 		delete(mapvalues, "SandboxIP")
@@ -359,6 +363,7 @@ func (l *local) setByPassProsyToRedis(ctx context.Context, key string, byPassPro
 	if byPassProsy.SandboxIP != "" {
 		fieldValues = append(fieldValues, "SandboxIP", byPassProsy.SandboxIP)
 	}
+	fieldValues = append(fieldValues, "EndAt", byPassProsy.EndAt)
 	for k, v := range byPassProsy.ContainerToHostPorts {
 		fieldValues = append(fieldValues, k, v)
 	}
@@ -433,7 +438,12 @@ func (l *local) deleteKeyFromRedis(ctx context.Context, key string) (err error) 
 
 func traceRedis(ctx context.Context, action, redisOp, key string, start time.Time, err error) {
 	cost := time.Since(start)
-	baseRt := CubeLog.GetTraceInfo(ctx).DeepCopy()
+	var baseRt *CubeLog.RequestTrace
+	if rt := CubeLog.GetTraceInfo(ctx); rt != nil {
+		baseRt = rt.DeepCopy()
+	} else {
+		baseRt = &CubeLog.RequestTrace{}
+	}
 	baseRt.Callee = constants.Redis
 	baseRt.Action = action
 	baseRt.CalleeAction = redisOp
@@ -444,4 +454,37 @@ func traceRedis(ctx context.Context, action, redisOp, key string, start time.Tim
 		baseRt.RetCode = int64(errorcode.ErrorCode_DBError)
 	}
 	CubeLog.Trace(baseRt)
+}
+
+func (l *local) scanByPassProxyKeys(ctx context.Context) ([]string, error) {
+	const pattern = "bypass_host_proxy:*"
+	const batch = 200
+	var (
+		cursor int64
+		keys   []string
+	)
+	conn := wrapredis.GetRedis(wrapredis.RedisRead)
+	for {
+		values, err := redis.Values(conn.Do("SCAN", cursor, "MATCH", pattern, "COUNT", batch))
+		if err != nil {
+			log.G(ctx).Warnf("scanByPassProxyKeys err:%s", err)
+			return nil, err
+		}
+		if len(values) != 2 {
+			return nil, errors.New("scanByPassProxyKeys: malformed reply")
+		}
+		next, err := redis.Int64(values[0], nil)
+		if err != nil {
+			return nil, err
+		}
+		batchKeys, err := redis.Strings(values[1], nil)
+		if err != nil {
+			return nil, err
+		}
+		keys = append(keys, batchKeys...)
+		cursor = next
+		if cursor == 0 {
+			return keys, nil
+		}
+	}
 }

--- a/CubeMaster/pkg/server/server.go
+++ b/CubeMaster/pkg/server/server.go
@@ -103,6 +103,8 @@ func (s *internalHttp) registerHandlers() {
 	cubeGroup.HandleFunc(cube.RootfsArtifactAction, cube.HttpHandler).Methods(http.MethodGet)
 	cubeGroup.HandleFunc(cube.ListInventoryAction, cube.HttpHandler).Methods(http.MethodPost)
 	cubeGroup.HandleFunc(cube.SandboxLogsAction, cube.HttpHandler).Methods(http.MethodGet, http.MethodPost)
+	cubeGroup.HandleFunc(cube.SandboxTimeoutAction, cube.HttpHandler).Methods(http.MethodPost)
+	cubeGroup.HandleFunc(cube.SandboxRefreshAction, cube.HttpHandler).Methods(http.MethodPost)
 
 	internalGroup := r.PathPrefix(inner.InnerURI()).Subrouter()
 	internalGroup.HandleFunc(inner.NodeAction, inner.HttpHandler).Methods(http.MethodGet)

--- a/CubeMaster/pkg/service/httpservice/cube/cube.go
+++ b/CubeMaster/pkg/service/httpservice/cube/cube.go
@@ -38,6 +38,8 @@ const (
 	RootfsArtifactAction           = "/rootfs-artifact"
 	ListInventoryAction            = "/listinventory"
 	SandboxLogsAction              = "/sandbox/logs"
+	SandboxTimeoutAction           = "/sandbox/timeout"
+	SandboxRefreshAction           = "/sandbox/refresh"
 )
 
 func CubeURI() string {
@@ -78,6 +80,10 @@ func HttpHandler(w http.ResponseWriter, r *http.Request) {
 		rsp = handleSandboxLogsAction(w, r, rt)
 	case r.URL.Path == actionURI(SandboxUpdateAction):
 		rsp = handleUpdateAction(w, r, rt)
+	case r.URL.Path == actionURI(SandboxTimeoutAction):
+		rsp = handleSandboxTimeoutAction(w, r, rt)
+	case r.URL.Path == actionURI(SandboxRefreshAction):
+		rsp = handleSandboxRefreshAction(w, r, rt)
 	case r.URL.Path == actionURI(SandboxCommitAction):
 		rsp = handleSandboxCommitAction(w, r, rt)
 	case r.URL.Path == actionURI(SandboxRollbackAction):

--- a/CubeMaster/pkg/service/httpservice/cube/sandbox_timeout.go
+++ b/CubeMaster/pkg/service/httpservice/cube/sandbox_timeout.go
@@ -1,0 +1,69 @@
+// Copyright (c) 2024 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package cube
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/google/uuid"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/api/services/cubebox/v1"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/log"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/utils"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/errorcode"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/service/sandbox"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/service/sandbox/types"
+	"github.com/tencentcloud/CubeSandbox/cubelog"
+)
+
+func handleSandboxTimeoutAction(_ http.ResponseWriter, r *http.Request, rt *CubeLog.RequestTrace) interface{} {
+	req := &types.SandboxTimeoutRequest{}
+	ctx, errRsp := decodeTTLRequest(r, rt, req, &req.RequestID, &req.SandboxID, &req.InstanceType)
+	if errRsp != nil {
+		return errRsp
+	}
+	out := sandbox.SetTimeout(ctx, req)
+	rt.RetCode = int64(out.Ret.RetCode)
+	return out
+}
+
+func handleSandboxRefreshAction(_ http.ResponseWriter, r *http.Request, rt *CubeLog.RequestTrace) interface{} {
+	req := &types.SandboxRefreshRequest{}
+	ctx, errRsp := decodeTTLRequest(r, rt, req, &req.RequestID, &req.SandboxID, &req.InstanceType)
+	if errRsp != nil {
+		return errRsp
+	}
+	out := sandbox.Refresh(ctx, req)
+	rt.RetCode = int64(out.Ret.RetCode)
+	return out
+}
+
+func decodeTTLRequest(
+	r *http.Request, rt *CubeLog.RequestTrace, body any,
+	requestID, sandboxID, instanceType *string,
+) (context.Context, interface{}) {
+	rt.RetCode = -1
+	if err := utils.DecodeHttpBody(r.Body, body); err != nil {
+		rt.RetCode = int64(errorcode.ErrorCode_MasterParamsError)
+		return nil, &types.Ret{
+			RetCode: int(errorcode.ErrorCode_MasterParamsError),
+			RetMsg:  "decode body fail: " + err.Error(),
+		}
+	}
+	if *requestID == "" {
+		*requestID = uuid.New().String()
+	}
+	if *instanceType == "" {
+		*instanceType = cubebox.InstanceType_cubebox.String()
+	}
+	rt.RequestID = *requestID
+	rt.InstanceType = *instanceType
+	ctx := log.WithLogger(r.Context(), log.G(r.Context()).WithFields(map[string]any{
+		"RequestId":    *requestID,
+		"InstanceId":   *sandboxID,
+		"InstanceType": *instanceType,
+	}))
+	return ctx, nil
+}

--- a/CubeMaster/pkg/service/sandbox/reaper.go
+++ b/CubeMaster/pkg/service/sandbox/reaper.go
@@ -1,0 +1,156 @@
+// Copyright (c) 2024 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package sandbox
+
+import (
+	"context"
+	"strconv"
+	"sync/atomic"
+	"time"
+
+	"github.com/google/uuid"
+	cubebox "github.com/tencentcloud/CubeSandbox/CubeMaster/api/services/cubebox/v1"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/config"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/log"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/recov"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/localcache"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/service/sandbox/types"
+	"github.com/tencentcloud/CubeSandbox/cubelog"
+)
+
+const (
+	defaultReapInterval = 5 * time.Second
+	maxConcurrentReaps  = 32
+)
+
+var reaperStarted atomic.Bool
+
+// StartTimeoutReaper launches the background goroutine that destroys
+// sandboxes whose EndAt deadline has passed.
+func StartTimeoutReaper(ctx context.Context) {
+	if !reaperStarted.CompareAndSwap(false, true) {
+		log.G(ctx).Warnf("sandbox TTL reaper already started, ignoring duplicate call")
+		return
+	}
+	go runTimeoutReaper(ctx, defaultReapInterval)
+}
+
+func runTimeoutReaper(ctx context.Context, interval time.Duration) {
+	if interval <= 0 {
+		interval = defaultReapInterval
+	}
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	log.G(ctx).Infof("sandbox TTL reaper started, interval=%s, max_concurrent=%d",
+		interval, maxConcurrentReaps)
+	for {
+		select {
+		case <-ctx.Done():
+			log.G(ctx).Infof("sandbox TTL reaper stopped: %v", ctx.Err())
+			return
+		case <-ticker.C:
+			recov.WithRecover(func() { reapOnce(ctx) }, func(p interface{}) {
+				log.G(ctx).Errorf("sandbox TTL reaper panic recovered: %v", p)
+			})
+		}
+	}
+}
+
+func withReaperTrace(ctx context.Context, action, sandboxID string) (context.Context, string) {
+	requestID := uuid.New().String()
+	rt := &CubeLog.RequestTrace{
+		RequestID:    requestID,
+		Action:       action,
+		Caller:       "cubemaster.reaper",
+		Callee:       "cubemaster",
+		InstanceID:   sandboxID,
+		InstanceType: cubebox.InstanceType_cubebox.String(),
+		Timestamp:    time.Now(),
+	}
+	return CubeLog.WithRequestTrace(ctx, rt), requestID
+}
+
+func reapOnce(ctx context.Context) {
+	if config.GetConfig().Common.MockUpdateAction {
+		return
+	}
+	ctx, _ = withReaperTrace(ctx, "SandboxReaperScan", "")
+
+	expired, err := localcache.ListExpiredSandboxIDs(ctx, time.Now())
+	if err != nil {
+		log.G(ctx).Warnf("sandbox TTL reaper: list expired failed: %v", err)
+		return
+	}
+	if len(expired) == 0 {
+		return
+	}
+	log.G(ctx).Infof("sandbox TTL reaper: %d expired sandbox(es) to destroy", len(expired))
+	sem := make(chan struct{}, maxConcurrentReaps)
+	for _, sandboxID := range expired {
+		select {
+		case <-ctx.Done():
+			return
+		case sem <- struct{}{}:
+		}
+		id := sandboxID
+		go func() {
+			defer func() { <-sem }()
+			recov.WithRecover(func() { destroyExpiredSandbox(ctx, id) }, func(p interface{}) {
+				log.G(ctx).Errorf("sandbox TTL reaper destroy panic %s: %v", id, p)
+			})
+		}()
+	}
+	for i := 0; i < cap(sem); i++ {
+		sem <- struct{}{}
+	}
+}
+
+func destroyExpiredSandbox(ctx context.Context, sandboxID string) {
+	ctx, requestID := withReaperTrace(ctx, "SandboxReaperDestroy", sandboxID)
+	ctx = log.WithLogger(ctx, log.G(ctx).WithFields(map[string]interface{}{
+		"RequestId":    requestID,
+		"InstanceId":   sandboxID,
+		"InstanceType": cubebox.InstanceType_cubebox.String(),
+		"Caller":       "reaper",
+	}))
+
+	proxy, ok := localcache.GetSandboxProxyMap(ctx, sandboxID)
+	if !ok || proxy == nil {
+		log.G(ctx).Infof("reaper: sandbox=%s already gone, skip", sandboxID)
+		return
+	}
+	if proxy.EndAt == "" {
+		log.G(ctx).Infof("reaper: sandbox=%s EndAt cleared, skip", sandboxID)
+		return
+	}
+	endNanos, err := strconv.ParseInt(proxy.EndAt, 10, 64)
+	if err != nil || endNanos <= 0 {
+		log.G(ctx).Warnf("reaper: sandbox=%s malformed EndAt=%q, skip", sandboxID, proxy.EndAt)
+		return
+	}
+	if time.Now().UnixNano() <= endNanos {
+		log.G(ctx).Infof("reaper: sandbox=%s EndAt was extended to %s, skip",
+			sandboxID, time.Unix(0, endNanos).UTC().Format(time.RFC3339Nano))
+		return
+	}
+
+	proxy.EndAt = ""
+	if err := localcache.SetSandboxProxyMap(ctx, proxy); err != nil {
+		log.G(ctx).Warnf("reaper clear EndAt sandbox=%s failed: %v", sandboxID, err)
+	}
+
+	rsp := DestroySandbox(ctx, &types.DeleteCubeSandboxReq{
+		RequestID:    requestID,
+		SandboxID:    sandboxID,
+		InstanceType: cubebox.InstanceType_cubebox.String(),
+		Sync:         false,
+	})
+	if rsp == nil || rsp.Ret == nil {
+		log.G(ctx).Warnf("reaper destroy sandbox=%s returned nil response", sandboxID)
+		return
+	}
+	log.G(ctx).Infof("reaper destroy sandbox=%s ret_code=%d ret_msg=%s",
+		sandboxID, rsp.Ret.RetCode, rsp.Ret.RetMsg)
+}

--- a/CubeMaster/pkg/service/sandbox/reaper.go
+++ b/CubeMaster/pkg/service/sandbox/reaper.go
@@ -7,6 +7,7 @@ package sandbox
 import (
 	"context"
 	"strconv"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -15,6 +16,7 @@ import (
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/config"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/log"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/recov"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/errorcode"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/localcache"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/service/sandbox/types"
 	"github.com/tencentcloud/CubeSandbox/cubelog"
@@ -23,9 +25,30 @@ import (
 const (
 	defaultReapInterval = 5 * time.Second
 	maxConcurrentReaps  = 32
+	// reapBatchLimit caps how many expired sandboxes a single tick will
+	// destroy. Anything beyond this rolls over to the next tick, which
+	// keeps a single replica from holding the cluster-wide reaper lease
+	// for an unbounded time when many sandboxes expire simultaneously.
+	reapBatchLimit = 256
+	// reaperLockTTL bounds how long a crashed leader can stall the
+	// reaper. The active leader refreshes the lease via SET NX EX every
+	// reapInterval, so any leader that is alive will keep extending it.
+	reaperLockTTL = 30 * time.Second
+	// reaperShutdownTimeout caps how long the reaper waits for in-flight
+	// destroy goroutines to drain on shutdown. The cubemaster process
+	// must not block forever just because Cubelet is unresponsive; if
+	// the deadline fires we log and exit, leaving the in-flight ids in
+	// the TTL index so the next-elected leader picks them up.
+	reaperShutdownTimeout = 15 * time.Second
 )
 
-var reaperStarted atomic.Bool
+var (
+	reaperStarted atomic.Bool
+	// reaperHolder uniquely identifies this CubeMaster process inside the
+	// reaper-lock CAS so we never accidentally release another replica's
+	// lease, even after a long GC pause that lets the lease expire.
+	reaperHolder = uuid.New().String()
+)
 
 // StartTimeoutReaper launches the background goroutine that destroys
 // sandboxes whose EndAt deadline has passed.
@@ -45,16 +68,48 @@ func runTimeoutReaper(ctx context.Context, interval time.Duration) {
 	defer ticker.Stop()
 	log.G(ctx).Infof("sandbox TTL reaper started, interval=%s, max_concurrent=%d",
 		interval, maxConcurrentReaps)
+
+	// destroyWG tracks every destroy goroutine spawned by reapOnce so
+	// graceful shutdown can wait for them. Without this WG a SIGTERM
+	// would orphan in-flight DestroySandbox RPCs, leaving the local
+	// task pipeline mid-flight and inflating the "ghost sandbox"
+	// rate after restart.
+	var destroyWG sync.WaitGroup
 	for {
 		select {
 		case <-ctx.Done():
-			log.G(ctx).Infof("sandbox TTL reaper stopped: %v", ctx.Err())
+			log.G(ctx).Infof("sandbox TTL reaper stopping: %v, waiting for in-flight destroys (timeout=%s)",
+				ctx.Err(), reaperShutdownTimeout)
+			waitWithTimeout(&destroyWG, reaperShutdownTimeout, func(drained bool) {
+				if drained {
+					log.G(ctx).Infof("sandbox TTL reaper stopped cleanly")
+				} else {
+					log.G(ctx).Warnf("sandbox TTL reaper shutdown timeout: leftover destroys may resume on next leader")
+				}
+			})
 			return
 		case <-ticker.C:
-			recov.WithRecover(func() { reapOnce(ctx) }, func(p interface{}) {
+			recov.WithRecover(func() { reapOnce(ctx, &destroyWG) }, func(p interface{}) {
 				log.G(ctx).Errorf("sandbox TTL reaper panic recovered: %v", p)
 			})
 		}
+	}
+}
+
+// waitWithTimeout blocks until either wg.Done() drained or the timeout
+// fires, then invokes report so the caller can emit a single log line
+// without duplicating the timer plumbing.
+func waitWithTimeout(wg *sync.WaitGroup, timeout time.Duration, report func(drained bool)) {
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+		report(true)
+	case <-time.After(timeout):
+		report(false)
 	}
 }
 
@@ -72,13 +127,30 @@ func withReaperTrace(ctx context.Context, action, sandboxID string) (context.Con
 	return CubeLog.WithRequestTrace(ctx, rt), requestID
 }
 
-func reapOnce(ctx context.Context) {
+func reapOnce(ctx context.Context, destroyWG *sync.WaitGroup) {
 	if config.GetConfig().Common.MockUpdateAction {
 		return
 	}
 	ctx, _ = withReaperTrace(ctx, "SandboxReaperScan", "")
 
-	expired, err := localcache.ListExpiredSandboxIDs(ctx, time.Now())
+	// In a multi-master HA deployment every replica boots its own reaper
+	// goroutine. Without coordination they would all enumerate the same
+	// expired set and race to DestroySandbox, producing duplicate
+	// requests and a flood of "sandbox not found" errors against
+	// CubeMaster / Cubelet. The Redis SET NX EX lease elects a single
+	// active reaper for `reaperLockTTL`; the other replicas simply skip
+	// this tick.
+	locked, err := localcache.AcquireReaperLock(ctx, reaperHolder, reaperLockTTL)
+	if err != nil {
+		log.G(ctx).Warnf("sandbox TTL reaper: acquire lease failed: %v", err)
+		return
+	}
+	if !locked {
+		return
+	}
+	defer localcache.ReleaseReaperLock(ctx, reaperHolder)
+
+	expired, err := localcache.ListExpiredSandboxIDs(ctx, time.Now(), reapBatchLimit)
 	if err != nil {
 		log.G(ctx).Warnf("sandbox TTL reaper: list expired failed: %v", err)
 		return
@@ -86,27 +158,54 @@ func reapOnce(ctx context.Context) {
 	if len(expired) == 0 {
 		return
 	}
-	log.G(ctx).Infof("sandbox TTL reaper: %d expired sandbox(es) to destroy", len(expired))
+	log.G(ctx).Infof("sandbox TTL reaper: %d expired sandbox(es) to destroy (cap=%d)",
+		len(expired), reapBatchLimit)
+
 	sem := make(chan struct{}, maxConcurrentReaps)
+	// localWG bounds the *current tick* so we know when this batch is
+	// fully drained; destroyWG is the process-level barrier the runner
+	// goroutine uses on shutdown. We add to both: localWG so the dispatch
+	// loop can return at end-of-tick without ditching live work, and
+	// destroyWG so a SIGTERM in the middle of a tick still has something
+	// to wait on.
+	var localWG sync.WaitGroup
 	for _, sandboxID := range expired {
 		select {
 		case <-ctx.Done():
-			return
+			goto drain
 		case sem <- struct{}{}:
 		}
 		id := sandboxID
+		localWG.Add(1)
+		destroyWG.Add(1)
 		go func() {
-			defer func() { <-sem }()
+			defer func() {
+				<-sem
+				localWG.Done()
+				destroyWG.Done()
+			}()
 			recov.WithRecover(func() { destroyExpiredSandbox(ctx, id) }, func(p interface{}) {
 				log.G(ctx).Errorf("sandbox TTL reaper destroy panic %s: %v", id, p)
 			})
 		}()
 	}
-	for i := 0; i < cap(sem); i++ {
-		sem <- struct{}{}
-	}
+drain:
+	localWG.Wait()
 }
 
+// destroyExpiredSandbox issues a synchronous DestroySandbox for one
+// sandbox whose TTL has elapsed and only clears the proxy/index entries
+// after the destroy itself reports success.
+//
+// The earlier version cleared EndAt *before* calling DestroySandbox in
+// async mode, which had two failure modes:
+//  1. async destroy fails silently → sandbox is leaked, never retried,
+//     because the TTL secondary index has already lost the member.
+//  2. SetTimeout extends the TTL between scan-tick and destroy-tick →
+//     the EndAt write race-killed a freshly-extended sandbox.
+//
+// Sync: true + post-success cleanup makes both failure modes self-heal
+// on the next reaper tick.
 func destroyExpiredSandbox(ctx context.Context, sandboxID string) {
 	ctx, requestID := withReaperTrace(ctx, "SandboxReaperDestroy", sandboxID)
 	ctx = log.WithLogger(ctx, log.G(ctx).WithFields(map[string]interface{}{
@@ -136,19 +235,24 @@ func destroyExpiredSandbox(ctx context.Context, sandboxID string) {
 		return
 	}
 
-	proxy.EndAt = ""
-	if err := localcache.SetSandboxProxyMap(ctx, proxy); err != nil {
-		log.G(ctx).Warnf("reaper clear EndAt sandbox=%s failed: %v", sandboxID, err)
-	}
-
+	// Synchronous destroy: we must observe success before we drop EndAt
+	// or the secondary index, otherwise a transient Cubelet failure
+	// would leak the sandbox forever. DestroySandbox returns rsp.Ret
+	// shaped exactly like the HTTP path; a non-Success ret_code just
+	// means we'll retry on the next tick because EndAt is still set.
 	rsp := DestroySandbox(ctx, &types.DeleteCubeSandboxReq{
 		RequestID:    requestID,
 		SandboxID:    sandboxID,
 		InstanceType: cubebox.InstanceType_cubebox.String(),
-		Sync:         false,
+		Sync:         true,
 	})
 	if rsp == nil || rsp.Ret == nil {
-		log.G(ctx).Warnf("reaper destroy sandbox=%s returned nil response", sandboxID)
+		log.G(ctx).Warnf("reaper destroy sandbox=%s returned nil response (will retry)", sandboxID)
+		return
+	}
+	if rsp.Ret.RetCode != int(errorcode.ErrorCode_Success) {
+		log.G(ctx).Warnf("reaper destroy sandbox=%s ret_code=%d ret_msg=%s (will retry next tick)",
+			sandboxID, rsp.Ret.RetCode, rsp.Ret.RetMsg)
 		return
 	}
 	log.G(ctx).Infof("reaper destroy sandbox=%s ret_code=%d ret_msg=%s",

--- a/CubeMaster/pkg/service/sandbox/sandbox_list.go
+++ b/CubeMaster/pkg/service/sandbox/sandbox_list.go
@@ -174,6 +174,12 @@ func doOneList(ctx context.Context, req *types.ListCubeSandboxReq, tmpNode *node
 				}
 				labels := sandboxViewLabels(sandboxLabels, container.GetLabels())
 				templateID := templateIDFromLabels(labels)
+				var endAt int64
+				if proxy, ok := localcache.GetSandboxProxyMap(ctx, sandbox.GetId()); ok && proxy != nil && proxy.EndAt != "" {
+					if v, err := strconv.ParseInt(proxy.EndAt, 10, 64); err == nil && v > 0 {
+						endAt = v
+					}
+				}
 				select {
 				case <-ctx.Done():
 					return
@@ -190,6 +196,7 @@ func doOneList(ctx context.Context, req *types.ListCubeSandboxReq, tmpNode *node
 					NameSpace:   sandbox.GetNamespace(),
 					CreateAt:    sandbox.GetCreatedAt(),
 					PauseAt:     container.GetPausedAt(),
+					EndAt:       endAt,
 				}:
 				}
 				break

--- a/CubeMaster/pkg/service/sandbox/sandbox_remove.go
+++ b/CubeMaster/pkg/service/sandbox/sandbox_remove.go
@@ -124,14 +124,15 @@ func dealScfSandbox(ctx context.Context, req *types.DeleteCubeSandboxReq, t *tas
 		if proxyMap.CreatedAt != "" {
 			created, err := strconv.ParseInt(proxyMap.CreatedAt, 10, 64)
 			if err == nil && created > 0 {
-				rt := CubeLog.GetTraceInfo(ctx)
-				rt.InstanceID = req.SandboxID
+				if rt := CubeLog.GetTraceInfo(ctx); rt != nil {
+					rt.InstanceID = req.SandboxID
 
-				tmpRt := rt.DeepCopy()
-				tmpRt.RetCode = int64(errorcode.ErrorCode_Success)
-				tmpRt.CalleeAction = "lifetime"
-				tmpRt.Cost = time.Duration(time.Now().UnixNano()-created) * time.Nanosecond
-				go CubeLog.Trace(tmpRt)
+					tmpRt := rt.DeepCopy()
+					tmpRt.RetCode = int64(errorcode.ErrorCode_Success)
+					tmpRt.CalleeAction = "lifetime"
+					tmpRt.Cost = time.Duration(time.Now().UnixNano()-created) * time.Nanosecond
+					go CubeLog.Trace(tmpRt)
+				}
 			}
 		}
 	}

--- a/CubeMaster/pkg/service/sandbox/sandbox_run.go
+++ b/CubeMaster/pkg/service/sandbox/sandbox_run.go
@@ -37,6 +37,12 @@ import (
 	"github.com/tencentcloud/CubeSandbox/cubelog"
 )
 
+// defaultCreateDeadline bounds the synchronous create flow when callers
+// do not specify a Timeout (or pass 0 to mean "no automatic destroy").
+// It only governs the create handshake with cubelet; it does NOT become
+// the sandbox's EndAt — see setProxyToRedis for that decision.
+const defaultCreateDeadline = 60 * time.Second
+
 type createSandboxContext struct {
 	selctx           *selctx.SelectorCtx
 	directHost       bool
@@ -521,12 +527,21 @@ func (c *createSandboxContext) setProxyToRedis() error {
 	}
 	switch c.cubeletReq.GetInstanceType() {
 	case cubebox.InstanceType_cubebox.String():
+		now := time.Now()
 		proxy := &proxytypes.SandboxProxyMap{
 			HostIP:      c.selectHost.HostIP(),
 			SandboxID:   c.masterRsp.SandboxID,
 			SandboxIP:   c.masterRsp.SandboxIP,
 			SandboxPort: "8080",
-			CreatedAt:   strconv.FormatInt(time.Now().UnixNano(), 10),
+			CreatedAt:   strconv.FormatInt(now.UnixNano(), 10),
+		}
+		// Stamp the absolute deadline used by the TTL reaper. The
+		// CreateCubeSandboxReq.Timeout is interpreted as "seconds from
+		// now"; <=0 means "no TTL" so the reaper will skip this sandbox.
+		if originReq := createOriginRequestFromContext(c.ctx); originReq != nil && originReq.Timeout > 0 {
+			proxy.EndAt = strconv.FormatInt(
+				now.Add(time.Duration(originReq.Timeout)*time.Second).UnixNano(), 10,
+			)
 		}
 
 		if config.GetConfig().CubeletConf.EnableExposedPort {

--- a/CubeMaster/pkg/service/sandbox/sandbox_timeout.go
+++ b/CubeMaster/pkg/service/sandbox/sandbox_timeout.go
@@ -1,0 +1,96 @@
+// Copyright (c) 2024 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package sandbox
+
+import (
+	"context"
+	"strconv"
+	"time"
+
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/log"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/utils"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/errorcode"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/localcache"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/service/sandbox/types"
+)
+
+// SetTimeout sets the absolute TTL of a running sandbox: the reaper will
+// destroy the sandbox once `now + timeout` is reached.
+//
+// Semantics (matches CubeAPI POST /sandboxes/{id}/timeout):
+//   - timeout >  0  → schedule destroy at now+timeout seconds
+//   - timeout == 0  → cancel any TTL (sandbox lives until killed explicitly)
+//   - timeout <  0  → 400 ParamsError
+func SetTimeout(ctx context.Context, req *types.SandboxTimeoutRequest) *types.SandboxTimeoutResponse {
+	rsp := &types.SandboxTimeoutResponse{RequestID: req.RequestID, SandboxID: req.SandboxID}
+	log.G(ctx).Infof("SetTimeout req:%s", utils.InterfaceToString(req))
+	rsp.Ret, rsp.EndAt = applyAbsoluteTTL(ctx, req.SandboxID, req.Timeout)
+	if rsp.Ret.RetCode == int(errorcode.ErrorCode_Success) {
+		log.G(ctx).Infof("SetTimeout ok sandbox=%s timeout=%d end_at=%s",
+			req.SandboxID, req.Timeout, rsp.EndAt)
+	} else {
+		log.G(ctx).Errorf("SetTimeout fail:%s rsp:%s",
+			utils.InterfaceToString(req), utils.InterfaceToString(rsp))
+	}
+	return rsp
+}
+
+// Refresh sets the absolute TTL of a running sandbox to `now + duration`.
+func Refresh(ctx context.Context, req *types.SandboxRefreshRequest) *types.SandboxRefreshResponse {
+	rsp := &types.SandboxRefreshResponse{RequestID: req.RequestID, SandboxID: req.SandboxID}
+	log.G(ctx).Infof("Refresh req:%s", utils.InterfaceToString(req))
+	rsp.Ret, rsp.EndAt = applyAbsoluteTTL(ctx, req.SandboxID, req.Duration)
+	if rsp.Ret.RetCode == int(errorcode.ErrorCode_Success) {
+		log.G(ctx).Infof("Refresh ok sandbox=%s duration=%d end_at=%s",
+			req.SandboxID, req.Duration, rsp.EndAt)
+	} else {
+		log.G(ctx).Errorf("Refresh fail:%s rsp:%s",
+			utils.InterfaceToString(req), utils.InterfaceToString(rsp))
+	}
+	return rsp
+}
+
+func applyAbsoluteTTL(ctx context.Context, sandboxID string, seconds int) (*types.Ret, string) {
+	if sandboxID == "" {
+		return paramsError("sandbox_id is empty"), ""
+	}
+	if seconds < 0 {
+		return paramsError("timeout must be >= 0"), ""
+	}
+	proxy, ok := localcache.GetSandboxProxyMap(ctx, sandboxID)
+	if !ok || proxy == nil {
+		return &types.Ret{
+			RetCode: int(errorcode.ErrorCode_NotFound),
+			RetMsg:  "sandbox not found",
+		}, ""
+	}
+
+	var endAtRFC string
+	if seconds == 0 {
+		proxy.EndAt = ""
+	} else {
+		endAt := time.Now().Add(time.Duration(seconds) * time.Second)
+		proxy.EndAt = strconv.FormatInt(endAt.UnixNano(), 10)
+		endAtRFC = endAt.UTC().Format(time.RFC3339Nano)
+	}
+
+	if err := localcache.SetSandboxProxyMap(ctx, proxy); err != nil {
+		return &types.Ret{
+			RetCode: int(errorcode.ErrorCode_DBError),
+			RetMsg:  err.Error(),
+		}, ""
+	}
+	return &types.Ret{
+		RetCode: int(errorcode.ErrorCode_Success),
+		RetMsg:  errorcode.ErrorCode_Success.String(),
+	}, endAtRFC
+}
+
+func paramsError(msg string) *types.Ret {
+	return &types.Ret{
+		RetCode: int(errorcode.ErrorCode_MasterParamsError),
+		RetMsg:  msg,
+	}
+}

--- a/CubeMaster/pkg/service/sandbox/sandbox_update.go
+++ b/CubeMaster/pkg/service/sandbox/sandbox_update.go
@@ -6,6 +6,8 @@ package sandbox
 
 import (
 	"context"
+	"strconv"
+	"time"
 
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/api/services/cubebox/v1"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/config"
@@ -89,5 +91,28 @@ func Update(ctx context.Context, req *types.UpdateRequest) (rsp *types.Res) {
 	}
 	rsp.Ret.RetCode = int(cubeRsp.GetRet().GetRetCode())
 	rsp.Ret.RetMsg = cubeRsp.GetRet().GetRetMsg()
+
+	// On a successful resume, refresh the absolute deadline so the
+	// TTL reaper aligns with the new lifetime requested by the caller.
+	// Pause does not touch EndAt; a later resume will rewrite it.
+	if req.Action == "resume" && req.Timeout > 0 &&
+		rsp.Ret.RetCode == int(errorcode.ErrorCode_Success) {
+		refreshSandboxEndAt(ctx, req.SandboxID, time.Duration(req.Timeout)*time.Second)
+	}
 	return
+}
+
+func refreshSandboxEndAt(ctx context.Context, sandboxID string, ttl time.Duration) {
+	if ttl <= 0 {
+		return
+	}
+	proxy, ok := localcache.GetSandboxProxyMap(ctx, sandboxID)
+	if !ok || proxy == nil {
+		log.G(ctx).Warnf("refreshSandboxEndAt: proxy map missing for %s", sandboxID)
+		return
+	}
+	proxy.EndAt = strconv.FormatInt(time.Now().Add(ttl).UnixNano(), 10)
+	if err := localcache.SetSandboxProxyMap(ctx, proxy); err != nil {
+		log.G(ctx).Warnf("refreshSandboxEndAt: rewrite proxy for %s failed: %v", sandboxID, err)
+	}
 }

--- a/CubeMaster/pkg/service/sandbox/types/types.go
+++ b/CubeMaster/pkg/service/sandbox/types/types.go
@@ -395,6 +395,7 @@ type SandboxBriefData struct {
 	NameSpace   string            `json:"namespace,omitempty"`
 	CreateAt    int64             `json:"create_at,omitempty"`
 	PauseAt     int64             `json:"pause_at,omitempty"`
+	EndAt       int64             `json:"end_at,omitempty"`
 }
 
 type GetCubeSandboxReq struct {
@@ -594,6 +595,45 @@ type UpdateRequest struct {
 	SandboxID    string `json:"sandbox_id" p:"sandbox_id"  v:"required"`
 	InstanceType string `json:"instance_type" p:"instance_type"  v:"required"`
 	Action       string `json:"action" p:"action"  v:"required"`
+	// Timeout is only meaningful for action="resume": new TTL in seconds
+	// from now. 0 keeps the previously-recorded EndAt unchanged.
+	Timeout int `json:"timeout,omitempty"`
+}
+
+// SandboxTimeoutRequest is the body of POST /cube/sandbox/timeout.
+type SandboxTimeoutRequest struct {
+	RequestID    string `json:"RequestID" p:"RequestID" v:"required"`
+	SandboxID    string `json:"sandboxID" p:"sandboxID" v:"required"`
+	InstanceType string `json:"instanceType,omitempty"`
+	// Timeout is the new absolute TTL in seconds from now. 0 cancels the TTL.
+	Timeout int `json:"timeout"`
+}
+
+type SandboxTimeoutResponse struct {
+	RequestID string `json:"RequestID,omitempty"`
+	SandboxID string `json:"sandboxID,omitempty"`
+	// EndAt is the new absolute deadline in RFC3339 (UTC). Empty when
+	// timeout==0 (TTL cancelled).
+	EndAt string `json:"end_at,omitempty"`
+	Ret   *Ret   `json:"ret,omitempty"`
+}
+
+// SandboxRefreshRequest is the body of POST /cube/sandbox/refresh.
+type SandboxRefreshRequest struct {
+	RequestID    string `json:"RequestID" p:"RequestID" v:"required"`
+	SandboxID    string `json:"sandboxID" p:"sandboxID" v:"required"`
+	InstanceType string `json:"instanceType,omitempty"`
+	// Duration is the new absolute TTL in seconds from now. 0 cancels the TTL.
+	// Despite the historical "refresh" name, the semantics match SetTimeout
+	// because that is what the e2b-style SDKs actually expect.
+	Duration int `json:"duration"`
+}
+
+type SandboxRefreshResponse struct {
+	RequestID string `json:"RequestID,omitempty"`
+	SandboxID string `json:"sandboxID,omitempty"`
+	EndAt     string `json:"end_at,omitempty"`
+	Ret       *Ret   `json:"ret,omitempty"`
 }
 
 type ListInventoryReq struct {

--- a/CubeMaster/pkg/task/handlers.go
+++ b/CubeMaster/pkg/task/handlers.go
@@ -148,7 +148,12 @@ func (l *localTask) workHandler(data interface{}) (err error) {
 func reportMetric(t *Task, err error) {
 
 	status, _ := ret.FromError(err)
-	rt := CubeLog.GetTraceInfo(t.Ctx).DeepCopy()
+	var rt *CubeLog.RequestTrace
+	if existing := CubeLog.GetTraceInfo(t.Ctx); existing != nil {
+		rt = existing.DeepCopy()
+	} else {
+		rt = &CubeLog.RequestTrace{}
+	}
 	rt.Callee = constants.CubeLet
 	rt.Cost = time.Since(t.start)
 	rt.RetCode = int64(status.Code())

--- a/web/src/api/generated/schema.ts
+++ b/web/src/api/generated/schema.ts
@@ -237,8 +237,12 @@ export interface components {
             cpuCount: number;
             /** Format: int32 */
             diskSizeMB?: number | null;
-            /** Format: date-time */
-            endAt: string;
+            /**
+             * Format: date-time
+             * @description Absolute deadline when the TTL reaper will destroy this sandbox.
+             *     `null` / omitted means the sandbox has no automatic-destroy schedule.
+             */
+            endAt?: string | null;
             envdVersion: string;
             /** Format: int32 */
             memoryMB: number;
@@ -322,8 +326,12 @@ export interface components {
             /** Format: int32 */
             diskSizeMB?: number | null;
             domain?: string | null;
-            /** Format: date-time */
-            endAt: string;
+            /**
+             * Format: date-time
+             * @description Absolute deadline when the TTL reaper will destroy this sandbox.
+             *     `null` / omitted means the sandbox has no automatic-destroy schedule.
+             */
+            endAt?: string | null;
             envdAccessToken?: string | null;
             envdVersion: string;
             /** Format: int32 */

--- a/web/src/lib/utils.ts
+++ b/web/src/lib/utils.ts
@@ -17,12 +17,24 @@ export function formatBytes(mib: number | undefined | null): string {
 export function formatRelative(ts?: string | number | null, locale?: string): string {
   if (!ts) return '—';
   const d = new Date(ts);
+  if (Number.isNaN(d.getTime())) return '—';
+  // diffSec > 0 ⇒ ts is in the past (e.g. startedAt)
+  // diffSec < 0 ⇒ ts is in the future (e.g. endAt with active TTL)
+  // The original implementation only handled the past branch and clamped
+  // every future timestamp into "1 second ago" via `-Math.max(1, …)`.
   const diffSec = (Date.now() - d.getTime()) / 1000;
   const rtf = new Intl.RelativeTimeFormat(locale ?? navigator.language, { numeric: 'auto' });
-  if (diffSec < 60) return rtf.format(-Math.max(1, Math.floor(diffSec)), 'second');
-  if (diffSec < 3600) return rtf.format(-Math.floor(diffSec / 60), 'minute');
-  if (diffSec < 86400) return rtf.format(-Math.floor(diffSec / 3600), 'hour');
-  return rtf.format(-Math.floor(diffSec / 86400), 'day');
+  const abs = Math.abs(diffSec);
+  // Intl.RelativeTimeFormat takes a SIGNED value: negative ⇒ past, positive ⇒ future.
+  // We invert `diffSec` because diffSec was computed as past-positive above.
+  const sign = diffSec >= 0 ? -1 : 1;
+  if (abs < 60) {
+    // Avoid the "0 seconds ago" / "in 0 seconds" edge by flooring to at least 1.
+    return rtf.format(sign * Math.max(1, Math.floor(abs)), 'second');
+  }
+  if (abs < 3600) return rtf.format(sign * Math.floor(abs / 60), 'minute');
+  if (abs < 86400) return rtf.format(sign * Math.floor(abs / 3600), 'hour');
+  return rtf.format(sign * Math.floor(abs / 86400), 'day');
 }
 
 export function short(id: string, head = 6, tail = 4): string {

--- a/web/src/locales/en/sandboxDetail.json
+++ b/web/src/locales/en/sandboxDetail.json
@@ -17,6 +17,7 @@
     "client": "Client",
     "alias": "Alias",
     "ends": "Ends",
+    "endsNever": "— No expiry",
     "domain": "Domain",
     "started": "Started",
     "state": "State",

--- a/web/src/locales/en/sandboxes.json
+++ b/web/src/locales/en/sandboxes.json
@@ -16,6 +16,8 @@
     "cpu": "CPU",
     "memory": "Memory",
     "started": "Started",
+    "endAt": "Ends",
+    "endAtNever": "— No expiry",
     "actions": "Actions",
     "node": "Node"
   },

--- a/web/src/locales/zh/sandboxDetail.json
+++ b/web/src/locales/zh/sandboxDetail.json
@@ -17,6 +17,7 @@
     "client": "客户端",
     "alias": "别名",
     "ends": "到期时间",
+    "endsNever": "— 永不过期",
     "domain": "域名",
     "started": "启动时间",
     "state": "状态",

--- a/web/src/locales/zh/sandboxes.json
+++ b/web/src/locales/zh/sandboxes.json
@@ -16,6 +16,8 @@
     "cpu": "CPU",
     "memory": "内存",
     "started": "启动时间",
+    "endAt": "结束时间",
+    "endAtNever": "— 永不过期",
     "actions": "操作",
     "node": "节点"
   },

--- a/web/src/pages/SandboxDetail.tsx
+++ b/web/src/pages/SandboxDetail.tsx
@@ -137,6 +137,7 @@ export default function SandboxDetailPage() {
               <Field label={t('fields.client')} value={data?.clientID ?? '—'} />
               <Field label={t('fields.alias')} value={data?.alias ?? '—'} />
               <Field label={t('fields.started')} value={formatRelative(data?.startedAt)} />
+              <Field label={t('fields.ends')} value={formatEndAtRelative(data?.endAt, t('fields.endsNever'))} />
               <Field label={t('fields.domain')} value={data?.domain ?? '—'} />
             </dl>
           )}
@@ -152,6 +153,10 @@ export default function SandboxDetailPage() {
             <li className="flex justify-between">
               <span className="text-muted-foreground">{t('fields.started')}</span>
               <span>{formatDateTime(data?.startedAt)}</span>
+            </li>
+            <li className="flex justify-between">
+              <span className="text-muted-foreground">{t('fields.ends')}</span>
+              <span>{formatEndAtAbsolute(data?.endAt, t('fields.endsNever'))}</span>
             </li>
 
             <li className="flex justify-between">
@@ -249,6 +254,26 @@ function formatDateTime(value?: string | null): string {
     hour: '2-digit', minute: '2-digit', second: '2-digit',
     hour12: false,
   }).format(date);
+}
+
+// `endAt` is `string | null | undefined`: a real ISO timestamp when the
+// sandbox has an active TTL, missing/null when the user opted into
+// "no automatic destroy". The two helpers below render the same value
+// in two different idioms — relative ("in 99 minutes") for the resources
+// summary, absolute wall-clock for the runtime audit row — collapsing
+// the missing case into the i18n-supplied "never" label.
+function formatEndAtRelative(value: string | null | undefined, neverLabel: string): string {
+  if (!value) return neverLabel;
+  const ts = Date.parse(value);
+  if (!Number.isFinite(ts) || ts <= 0) return neverLabel;
+  return formatRelative(value);
+}
+
+function formatEndAtAbsolute(value: string | null | undefined, neverLabel: string): string {
+  if (!value) return neverLabel;
+  const ts = Date.parse(value);
+  if (!Number.isFinite(ts) || ts <= 0) return neverLabel;
+  return formatDateTime(value);
 }
 
 function Field({ label, value, mono }: { label: string; value: string; mono?: boolean }) {

--- a/web/src/pages/Sandboxes.tsx
+++ b/web/src/pages/Sandboxes.tsx
@@ -15,6 +15,18 @@ import { Pause, Play, Trash2, Search, Plus } from 'lucide-react';
 import { formatBytes, formatRelative, short } from '@/lib/utils';
 import { cn } from '@/lib/utils';
 
+// `endAt` is `string | null | undefined` on the wire: a real ISO timestamp
+// when the sandbox has an active deadline, `null`/missing when it lives
+// forever (no SetTimeout / no Refresh, or explicitly set to 0). The
+// caller passes the already-translated "no expiry" label so this helper
+// stays decoupled from react-i18next's strongly-typed TFunction.
+function formatEndAt(endAt: string | null | undefined, neverLabel: string): string {
+  if (!endAt) return neverLabel;
+  const ts = Date.parse(endAt);
+  if (!Number.isFinite(ts) || ts <= 0) return neverLabel;
+  return formatRelative(endAt);
+}
+
 type StateFilter = 'all' | 'running' | 'paused';
 
 export default function SandboxesPage() {
@@ -124,7 +136,7 @@ export default function SandboxesPage() {
       </Card>
 
       <Card className="!p-0 overflow-hidden">
-        <div className="grid grid-cols-[120px_minmax(200px,1.2fr)_minmax(160px,1fr)_110px_120px_130px_120px_120px] gap-2 border-b border-border/60 px-4 py-3 text-xs uppercase tracking-wider font-medium text-muted-foreground/85">
+        <div className="grid grid-cols-[110px_minmax(180px,1.1fr)_minmax(140px,1fr)_90px_100px_120px_110px_140px_110px] gap-2 border-b border-border/60 px-4 py-3 text-xs uppercase tracking-wider font-medium text-muted-foreground/85">
           <div>{t('col.state')}</div>
           <div>{t('col.sandboxId')}</div>
           <div>{t('col.template')}</div>
@@ -132,6 +144,7 @@ export default function SandboxesPage() {
           <div>{t('col.memory')}</div>
           <div>{t('col.node')}</div>
           <div>{t('col.started')}</div>
+          <div>{t('col.endAt')}</div>
           <div className="text-right">{t('col.actions')}</div>
         </div>
         {isLoading &&
@@ -175,7 +188,7 @@ function Row({
   const state = sb.state ?? 'running';
   const tone = state === 'paused' ? 'warn' : state === 'running' ? 'ok' : 'mute';
   return (
-    <div className="grid grid-cols-[120px_minmax(200px,1.2fr)_minmax(160px,1fr)_110px_120px_130px_120px_120px] gap-2 border-b border-border/60 px-4 py-3 text-sm transition hover:bg-muted/50">
+    <div className="grid grid-cols-[110px_minmax(180px,1.1fr)_minmax(140px,1fr)_90px_100px_120px_110px_140px_110px] gap-2 border-b border-border/60 px-4 py-3 text-sm transition hover:bg-muted/50">
       <div>
         <Badge tone={tone as any}>{state}</Badge>
       </div>
@@ -197,6 +210,7 @@ function Row({
       <div className="text-xs text-muted-foreground text-num">{formatBytes(sb.memoryMB)}</div>
       <div className="text-xs text-muted-foreground/80 text-num">{sb.clientID || '—'}</div>
       <div className="text-xs text-muted-foreground">{formatRelative(sb.startedAt)}</div>
+      <div className="text-xs text-muted-foreground">{formatEndAt(sb.endAt, t('col.endAtNever'))}</div>
       <div className="flex justify-end gap-1">
         {state === 'paused' ? (
           <Button size="icon" variant="ghost" title={t('actions.resume')} onClick={onResume} disabled={busy}>


### PR DESCRIPTION
add `EndAt` for sandbox

<img width="1488" height="313" alt="image" src="https://github.com/user-attachments/assets/b7f0cc93-89cd-4045-a793-e345e4e0ec59" />

<img width="468" height="304" alt="image" src="https://github.com/user-attachments/assets/b45c89c1-e85e-49c5-bebc-35cdafb1868e" />

feat: #233 #232 
