### PR TITLE
feat(sdk): align Template.build with cubemastercli create-from-image options

### DIFF
--- a/CubeAPI/src/cubemaster/mod.rs
+++ b/CubeAPI/src/cubemaster/mod.rs
@@ -1565,6 +1565,14 @@ pub struct CreateTemplateFromImageReq {
     /// Ports exposed by the container.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub exposed_ports: Option<Vec<u16>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub network_type: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub registry_username: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub registry_password: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub distribution_scope: Option<Vec<String>>,
     /// Container-level overrides (probe, resources, envs).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub container_overrides: Option<CreateTemplateContainerOverrides>,
@@ -1577,11 +1585,17 @@ pub struct CreateTemplateFromImageReq {
 #[derive(Debug, Serialize)]
 pub struct CreateTemplateContainerOverrides {
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub command: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub args: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub probe: Option<Probe>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub resources: Option<CreateTemplateResources>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub envs: Option<Vec<CreateTemplateEnv>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub dns_config: Option<DnsConfig>,
 }
 
 /// CPU / memory resources for template container.
@@ -1610,6 +1624,10 @@ pub struct CreateTemplateCubeVSContext {
         skip_serializing_if = "Option::is_none"
     )]
     pub allow_internet_access: Option<bool>,
+    #[serde(rename = "allowOut", skip_serializing_if = "Vec::is_empty")]
+    pub allow_out: Vec<String>,
+    #[serde(rename = "denyOut", skip_serializing_if = "Vec::is_empty")]
+    pub deny_out: Vec<String>,
 }
 
 /// Body for POST /cube/template/redo (rebuild).

--- a/CubeAPI/src/models/mod.rs
+++ b/CubeAPI/src/models/mod.rs
@@ -487,7 +487,7 @@ pub struct CreateTemplateRequest {
     /// HTTP probe port.
     #[serde(rename = "probePort", default)]
     pub probe_port: Option<u16>,
-    /// HTTP probe path, e.g. "/health".
+    /// HTTP probe path, e.g. "/health". Defaults to "/health" when `probePort` is set.
     #[serde(rename = "probePath", default)]
     pub probe_path: Option<String>,
     /// CPU in millicores, e.g. 2000 means 2000m.
@@ -502,6 +502,33 @@ pub struct CreateTemplateRequest {
     /// Allow internet (public) access.
     #[serde(rename = "allowInternetAccess", default)]
     pub allow_internet_access: Option<bool>,
+    /// Network mode, e.g. "tap".
+    #[serde(rename = "networkType", default)]
+    pub network_type: Option<String>,
+    /// Limit template distribution to these node IDs or host IPs.
+    #[serde(default)]
+    pub nodes: Option<Vec<String>>,
+    /// Registry username for private source images.
+    #[serde(rename = "registryUsername", default)]
+    pub registry_username: Option<String>,
+    /// Registry password for private source images.
+    #[serde(rename = "registryPassword", default)]
+    pub registry_password: Option<String>,
+    /// Override container ENTRYPOINT.
+    #[serde(default)]
+    pub command: Option<Vec<String>>,
+    /// Override container CMD args.
+    #[serde(default)]
+    pub args: Option<Vec<String>>,
+    /// Container DNS nameservers.
+    #[serde(default)]
+    pub dns: Option<Vec<String>>,
+    /// Allowed outbound CIDRs for CubeVS egress policy.
+    #[serde(rename = "allowOut", default)]
+    pub allow_out: Option<Vec<String>>,
+    /// Denied outbound CIDRs for CubeVS egress policy.
+    #[serde(rename = "denyOut", default)]
+    pub deny_out: Option<Vec<String>>,
 }
 
 /// Body for POST /templates/:id (rebuild).

--- a/CubeAPI/src/services/sandboxes.rs
+++ b/CubeAPI/src/services/sandboxes.rs
@@ -679,6 +679,7 @@ mod tests {
             host_id: "host-1".to_string(),
             status: "running".to_string(),
             started_at: None,
+            create_at: 0,
             end_at: None,
             cpu_count: 2,
             memory_mb: 2048,

--- a/CubeAPI/src/services/templates.rs
+++ b/CubeAPI/src/services/templates.rs
@@ -8,8 +8,8 @@ use crate::{
     cubemaster::{
         CreateTemplateContainerOverrides, CreateTemplateCubeVSContext, CreateTemplateEnv,
         CreateTemplateFromImageReq, CreateTemplateResources, CubeMasterClient, CubeMasterError,
-        HttpGetAction, Probe, ProbeHandler, RedoTemplateReq, TemplateDeleteRequest, TemplateJob,
-        TemplateJobResponse,
+        DnsConfig, HttpGetAction, Probe, ProbeHandler, RedoTemplateReq, TemplateDeleteRequest,
+        TemplateJob, TemplateJobResponse,
     },
     error::{AppError, AppResult},
     models::{
@@ -109,74 +109,9 @@ impl TemplateService {
             return Err(AppError::BadRequest("image is required".to_string()));
         }
 
-        // probe
-        let probe = body
-            .probe_port
-            .or_else(|| body.exposed_ports.as_ref().and_then(|p| p.first().copied()))
-            .map(|port| Probe {
-                probe_handler: ProbeHandler {
-                    http_get: Some(HttpGetAction {
-                        path: body
-                            .probe_path
-                            .clone()
-                            .unwrap_or_else(|| "/health".to_string()),
-                        port,
-                        host: None,
-                        scheme: None,
-                    }),
-                    exec: None,
-                },
-                timeout_ms: Some(30000),
-                period_ms: Some(500),
-                success_threshold: Some(1),
-                failure_threshold: Some(60),
-            });
-
-        // resources
-        let resources = if body.cpu.is_some() || body.memory.is_some() {
-            Some(CreateTemplateResources {
-                cpu: body.cpu.map(|v| format!("{}m", v)),
-                mem: body.memory.map(|v| format!("{}Mi", v)),
-            })
-        } else {
-            None
-        };
-
-        // envs: parse "KEY=VALUE" strings
-        let envs = body
-            .env
-            .map(|envs| {
-                envs.into_iter()
-                    .filter_map(|s| {
-                        let mut parts = s.splitn(2, '=');
-                        let key = parts.next()?.trim().to_string();
-                        let value = parts.next().unwrap_or("").to_string();
-                        if key.is_empty() {
-                            None
-                        } else {
-                            Some(CreateTemplateEnv { key, value })
-                        }
-                    })
-                    .collect::<Vec<_>>()
-            })
-            .filter(|v| !v.is_empty());
-
-        let container_overrides = if probe.is_some() || resources.is_some() || envs.is_some() {
-            Some(CreateTemplateContainerOverrides {
-                probe,
-                resources,
-                envs,
-            })
-        } else {
-            None
-        };
-
-        // cubevs_context
-        let cubevs_context = body
-            .allow_internet_access
-            .map(|v| CreateTemplateCubeVSContext {
-                allow_internet_access: Some(v),
-            });
+        let dns_servers = validate_dns_servers(body.dns.as_deref())?;
+        let container_overrides = build_template_container_overrides(&body, dns_servers.as_deref());
+        let cubevs_context = build_template_cubevs_context(&body);
 
         let req = CreateTemplateFromImageReq {
             request_id: new_request_id(),
@@ -190,6 +125,10 @@ impl TemplateService {
             source_image_ref: body.image.trim().to_string(),
             writable_layer_size: body.writable_layer_size,
             exposed_ports: body.exposed_ports,
+            network_type: non_empty_option(body.network_type),
+            registry_username: non_empty_option(body.registry_username),
+            registry_password: non_empty_option(body.registry_password),
+            distribution_scope: non_empty_vec(body.nodes),
             container_overrides,
             cubevs_context,
         };
@@ -352,5 +291,212 @@ fn default_template_job() -> TemplateJob {
         error_message: String::new(),
         attempt_no: 0,
         retry_of_job_id: String::new(),
+    }
+}
+
+fn non_empty_option(value: Option<String>) -> Option<String> {
+    value.and_then(|s| non_empty(s))
+}
+
+fn non_empty_vec(values: Option<Vec<String>>) -> Option<Vec<String>> {
+    values.and_then(|items| {
+        let cleaned: Vec<String> = items
+            .into_iter()
+            .filter_map(|item| non_empty(item))
+            .collect();
+        if cleaned.is_empty() {
+            None
+        } else {
+            Some(cleaned)
+        }
+    })
+}
+
+fn validate_dns_servers(servers: Option<&[String]>) -> AppResult<Option<Vec<String>>> {
+    let Some(servers) = servers else {
+        return Ok(None);
+    };
+    let mut cleaned = Vec::new();
+    for server in servers {
+        let server = server.trim();
+        if server.is_empty() {
+            continue;
+        }
+        if server.parse::<std::net::IpAddr>().is_err() {
+            return Err(AppError::BadRequest(format!(
+                "invalid dns server {server:?}"
+            )));
+        }
+        cleaned.push(server.to_string());
+    }
+    if cleaned.is_empty() {
+        Ok(None)
+    } else {
+        Ok(Some(cleaned))
+    }
+}
+
+fn build_template_probe(body: &CreateTemplateRequest) -> Option<Probe> {
+    body.probe_port
+        .or_else(|| body.exposed_ports.as_ref().and_then(|p| p.first().copied()))
+        .map(|port| Probe {
+            probe_handler: ProbeHandler {
+                http_get: Some(HttpGetAction {
+                    path: body
+                        .probe_path
+                        .clone()
+                        .unwrap_or_else(|| "/health".to_string()),
+                    port,
+                    host: None,
+                    scheme: None,
+                }),
+                exec: None,
+            },
+            timeout_ms: Some(30000),
+            period_ms: Some(500),
+            success_threshold: Some(1),
+            failure_threshold: Some(60),
+        })
+}
+
+fn build_template_resources(body: &CreateTemplateRequest) -> Option<CreateTemplateResources> {
+    if body.cpu.is_none() && body.memory.is_none() {
+        return None;
+    }
+    Some(CreateTemplateResources {
+        cpu: body.cpu.map(|v| format!("{v}m")),
+        mem: body.memory.map(|v| format!("{v}Mi")),
+    })
+}
+
+fn build_template_envs(body: &CreateTemplateRequest) -> Option<Vec<CreateTemplateEnv>> {
+    body.env
+        .as_ref()
+        .map(|envs| {
+            envs.iter()
+                .filter_map(|s| {
+                    let mut parts = s.splitn(2, '=');
+                    let key = parts.next()?.trim().to_string();
+                    let value = parts.next().unwrap_or("").to_string();
+                    if key.is_empty() {
+                        None
+                    } else {
+                        Some(CreateTemplateEnv { key, value })
+                    }
+                })
+                .collect::<Vec<_>>()
+        })
+        .filter(|envs| !envs.is_empty())
+}
+
+fn build_template_container_overrides(
+    body: &CreateTemplateRequest,
+    dns_servers: Option<&[String]>,
+) -> Option<CreateTemplateContainerOverrides> {
+    let command = non_empty_vec(body.command.clone());
+    let args = non_empty_vec(body.args.clone());
+    let probe = build_template_probe(body);
+    let resources = build_template_resources(body);
+    let envs = build_template_envs(body);
+    let dns_config = dns_servers.map(|servers| DnsConfig {
+        servers: servers.to_vec(),
+        searches: Vec::new(),
+    });
+
+    if command.is_none()
+        && args.is_none()
+        && probe.is_none()
+        && resources.is_none()
+        && envs.is_none()
+        && dns_config.is_none()
+    {
+        return None;
+    }
+
+    Some(CreateTemplateContainerOverrides {
+        command,
+        args,
+        probe,
+        resources,
+        envs,
+        dns_config,
+    })
+}
+
+fn build_template_cubevs_context(body: &CreateTemplateRequest) -> Option<CreateTemplateCubeVSContext> {
+    let allow_out = body.allow_out.clone().unwrap_or_default();
+    let deny_out = body.deny_out.clone().unwrap_or_default();
+    if body.allow_internet_access.is_none() && allow_out.is_empty() && deny_out.is_empty() {
+        return None;
+    }
+    Some(CreateTemplateCubeVSContext {
+        allow_internet_access: body.allow_internet_access,
+        allow_out,
+        deny_out,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_request() -> CreateTemplateRequest {
+        CreateTemplateRequest {
+            template_id: String::new(),
+            instance_type: Some("cubebox".to_string()),
+            image: "python:3.11-slim".to_string(),
+            writable_layer_size: Some("1G".to_string()),
+            exposed_ports: Some(vec![8080]),
+            probe_port: Some(8080),
+            probe_path: Some("/health".to_string()),
+            cpu: Some(2000),
+            memory: Some(2048),
+            env: Some(vec!["A=1".to_string()]),
+            allow_internet_access: Some(true),
+            network_type: Some("tap".to_string()),
+            nodes: Some(vec!["node-1".to_string()]),
+            registry_username: Some("user".to_string()),
+            registry_password: Some("pass".to_string()),
+            command: Some(vec!["/bin/sh".to_string(), "-c".to_string()]),
+            args: Some(vec!["sleep infinity".to_string()]),
+            dns: Some(vec!["8.8.8.8".to_string(), "1.1.1.1".to_string()]),
+            allow_out: Some(vec!["172.67.0.0/16".to_string()]),
+            deny_out: Some(vec!["10.0.0.0/8".to_string()]),
+        }
+    }
+
+    #[test]
+    fn build_template_container_overrides_maps_cli_fields() {
+        let body = sample_request();
+        let overrides = build_template_container_overrides(&body, Some(&["8.8.8.8".to_string()]))
+            .expect("overrides");
+
+        assert_eq!(
+            overrides.command,
+            Some(vec!["/bin/sh".to_string(), "-c".to_string()])
+        );
+        assert_eq!(overrides.args, Some(vec!["sleep infinity".to_string()]));
+        assert_eq!(
+            overrides.dns_config.as_ref().map(|d| d.servers.clone()),
+            Some(vec!["8.8.8.8".to_string()])
+        );
+        assert!(overrides.probe.is_some());
+        assert!(overrides.resources.is_some());
+        assert_eq!(overrides.envs.as_ref().map(|envs| envs.len()), Some(1));
+    }
+
+    #[test]
+    fn build_template_cubevs_context_includes_egress_rules() {
+        let body = sample_request();
+        let ctx = build_template_cubevs_context(&body).expect("cubevs");
+        assert_eq!(ctx.allow_internet_access, Some(true));
+        assert_eq!(ctx.allow_out, vec!["172.67.0.0/16".to_string()]);
+        assert_eq!(ctx.deny_out, vec!["10.0.0.0/8".to_string()]);
+    }
+
+    #[test]
+    fn validate_dns_servers_rejects_invalid_ip() {
+        let err = validate_dns_servers(Some(&["not-an-ip".to_string()])).unwrap_err();
+        assert!(matches!(err, AppError::BadRequest(_)));
     }
 }

--- a/sdk/go/sdk_test.go
+++ b/sdk/go/sdk_test.go
@@ -851,3 +851,110 @@ func assertStringSlice(t *testing.T, value any, want []string) {
 		t.Fatalf("slice=%#v, want %#v", got, want)
 	}
 }
+
+func TestBuildTemplateForwardsCreateFromImageOptions(t *testing.T) {
+	var got map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/templates" {
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&got); err != nil {
+			t.Fatalf("decode body: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusAccepted)
+		fmt.Fprint(w, `{"jobID":"job-1","templateID":"tpl-1","status":"accepted","phase":"","progress":0}`)
+	}))
+	defer server.Close()
+
+	probePort := uint16(8080)
+	cpu := uint32(2000)
+	memory := uint32(2048)
+	allowInternet := true
+	client := NewClient(Config{APIURL: server.URL, Timeout: 300 * time.Second})
+	_, err := client.BuildTemplate(context.Background(), BuildTemplateOptions{
+		Image:               "registry.example.com/app:latest",
+		WritableLayerSize:   "20Gi",
+		ExposedPorts:        []uint16{8080},
+		ProbePort:           &probePort,
+		ProbePath:           "/health",
+		CPU:                 &cpu,
+		Memory:              &memory,
+		Env:                 map[string]string{"A": "1"},
+		AllowInternetAccess: &allowInternet,
+		NetworkType:         "tap",
+		Nodes:               []string{"node-a", "10.0.0.12"},
+		RegistryUsername:    "pull-user",
+		RegistryPassword:    "pull-pass",
+		Command:             []string{"/bin/sh", "-c"},
+		Args:                []string{"sleep infinity"},
+		DNS:                 []string{"8.8.8.8", "1.1.1.1"},
+		AllowOut:            []string{"172.67.0.0/16"},
+		DenyOut:             []string{"10.0.0.0/8"},
+	})
+	if err != nil {
+		t.Fatalf("BuildTemplate returned error: %v", err)
+	}
+
+	assertString(t, got, "image", "registry.example.com/app:latest")
+	assertString(t, got, "writableLayerSize", "20Gi")
+	assertString(t, got, "networkType", "tap")
+	assertString(t, got, "registryUsername", "pull-user")
+	assertString(t, got, "registryPassword", "pull-pass")
+	assertString(t, got, "probePath", "/health")
+	assertNumber(t, got, "probePort", 8080)
+	assertNumber(t, got, "cpu", 2000)
+	assertNumber(t, got, "memory", 2048)
+	assertStringSlice(t, got["nodes"], []string{"node-a", "10.0.0.12"})
+	assertStringSlice(t, got["command"], []string{"/bin/sh", "-c"})
+	assertStringSlice(t, got["args"], []string{"sleep infinity"})
+	assertStringSlice(t, got["dns"], []string{"8.8.8.8", "1.1.1.1"})
+	assertStringSlice(t, got["allowOut"], []string{"172.67.0.0/16"})
+	assertStringSlice(t, got["denyOut"], []string{"10.0.0.0/8"})
+	assertStringSlice(t, got["env"], []string{"A=1"})
+	if got["allowInternetAccess"] != true {
+		t.Fatalf("allowInternetAccess=%#v, want true", got["allowInternetAccess"])
+	}
+}
+
+func TestBuildTemplateRequiresImage(t *testing.T) {
+	client := NewClient(Config{APIURL: "http://example.com", Timeout: 300 * time.Second})
+	if _, err := client.BuildTemplate(context.Background(), BuildTemplateOptions{}); err == nil {
+		t.Fatal("BuildTemplate without image returned nil error")
+	}
+}
+
+func TestGetTemplateParsesNetworkFields(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/templates/tpl-network" {
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{
+			"templateID":"tpl-network",
+			"status":"READY",
+			"networkType":"tap",
+			"allowInternetAccess":false,
+			"createRequest":{
+				"network_type":"tap",
+				"cubevs_context":{"allowOut":["172.67.0.0/16"],"denyOut":["10.0.0.0/8"]}
+			}
+		}`)
+	}))
+	defer server.Close()
+
+	client := NewClient(Config{APIURL: server.URL, Timeout: 300 * time.Second})
+	info, err := client.GetTemplate(context.Background(), "tpl-network")
+	if err != nil {
+		t.Fatalf("GetTemplate returned error: %v", err)
+	}
+	if info.TemplateID != "tpl-network" {
+		t.Fatalf("TemplateID=%q, want tpl-network", info.TemplateID)
+	}
+	if info.NetworkType != "tap" {
+		t.Fatalf("NetworkType=%q, want tap", info.NetworkType)
+	}
+	if info.AllowInternetAccess == nil || *info.AllowInternetAccess {
+		t.Fatalf("AllowInternetAccess=%#v, want false", info.AllowInternetAccess)
+	}
+}

--- a/sdk/go/template.go
+++ b/sdk/go/template.go
@@ -1,0 +1,218 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package cubesandbox
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"sort"
+	"strings"
+)
+
+type TemplateBuildJob struct {
+	JobID        string `json:"jobID"`
+	TemplateID   string `json:"templateID"`
+	Status       string `json:"status"`
+	Phase        string `json:"phase"`
+	Progress     int    `json:"progress"`
+	ErrorMessage string `json:"errorMessage"`
+}
+
+type TemplateInfo struct {
+	TemplateID          string `json:"templateID"`
+	InstanceType        string `json:"instanceType,omitempty"`
+	Version             string `json:"version,omitempty"`
+	Status              string `json:"status,omitempty"`
+	LastError           string `json:"lastError,omitempty"`
+	CreatedAt           string `json:"createdAt,omitempty"`
+	ImageInfo           string `json:"imageInfo,omitempty"`
+	NetworkType         string `json:"networkType,omitempty"`
+	AllowInternetAccess *bool  `json:"allowInternetAccess,omitempty"`
+}
+
+type TemplateBuildStatus struct {
+	BuildID    string `json:"buildID"`
+	TemplateID string `json:"templateID"`
+	Status     string `json:"status"`
+	Progress   int    `json:"progress"`
+	Message    string `json:"message"`
+}
+
+type BuildTemplateOptions struct {
+	Image                string
+	InstanceType         string
+	WritableLayerSize    string
+	ExposedPorts         []uint16
+	ProbePort            *uint16
+	ProbePath            string
+	CPU                  *uint32
+	Memory               *uint32
+	Env                  map[string]string
+	AllowInternetAccess  *bool
+	NetworkType          string
+	Nodes                []string
+	RegistryUsername     string
+	RegistryPassword     string
+	Command              []string
+	Args                 []string
+	DNS                  []string
+	AllowOut             []string
+	DenyOut              []string
+	// Extra 在命名字段之后合并进请求体, 同名键会覆盖上方字段, 与 Python kwargs 行为一致.
+	Extra                map[string]any
+}
+
+func (c *Client) ListTemplates(ctx context.Context) ([]TemplateInfo, error) {
+	var templates []TemplateInfo
+	if err := c.doJSON(ctx, http.MethodGet, "/templates", nil, &templates, http.StatusOK); err != nil {
+		return nil, err
+	}
+	return templates, nil
+}
+
+func (c *Client) GetTemplate(ctx context.Context, templateID string) (*TemplateInfo, error) {
+	if strings.TrimSpace(templateID) == "" {
+		return nil, fmt.Errorf("templateID is required")
+	}
+	var templateInfo TemplateInfo
+	path := "/templates/" + url.PathEscape(templateID)
+	if err := c.doJSON(ctx, http.MethodGet, path, nil, &templateInfo, http.StatusOK); err != nil {
+		return nil, err
+	}
+	return &templateInfo, nil
+}
+
+func (c *Client) BuildTemplate(ctx context.Context, opts BuildTemplateOptions) (*TemplateBuildJob, error) {
+	payload, err := buildTemplatePayload(opts)
+	if err != nil {
+		return nil, err
+	}
+	var job TemplateBuildJob
+	if err := c.doJSON(ctx, http.MethodPost, "/templates", payload, &job, http.StatusAccepted); err != nil {
+		return nil, err
+	}
+	return &job, nil
+}
+
+func (c *Client) RebuildTemplate(ctx context.Context, templateID string, extra map[string]any) (*TemplateBuildJob, error) {
+	if strings.TrimSpace(templateID) == "" {
+		return nil, fmt.Errorf("templateID is required")
+	}
+	if extra == nil {
+		extra = map[string]any{}
+	}
+	var job TemplateBuildJob
+	path := "/templates/" + url.PathEscape(templateID)
+	if err := c.doJSON(ctx, http.MethodPost, path, extra, &job, http.StatusAccepted); err != nil {
+		return nil, err
+	}
+	return &job, nil
+}
+
+func (c *Client) DeleteTemplate(ctx context.Context, templateID string) error {
+	if strings.TrimSpace(templateID) == "" {
+		return fmt.Errorf("templateID is required")
+	}
+	path := "/templates/" + url.PathEscape(templateID)
+	return c.doJSON(ctx, http.MethodDelete, path, nil, nil, http.StatusNoContent)
+}
+
+func (c *Client) GetTemplateBuildStatus(ctx context.Context, templateID, buildID string) (*TemplateBuildStatus, error) {
+	if strings.TrimSpace(templateID) == "" || strings.TrimSpace(buildID) == "" {
+		return nil, fmt.Errorf("templateID and buildID are required")
+	}
+	var status TemplateBuildStatus
+	path := "/templates/" + url.PathEscape(templateID) + "/builds/" + url.PathEscape(buildID) + "/status"
+	if err := c.doJSON(ctx, http.MethodGet, path, nil, &status, http.StatusOK); err != nil {
+		return nil, err
+	}
+	return &status, nil
+}
+
+func buildTemplatePayload(opts BuildTemplateOptions) (map[string]any, error) {
+	image := strings.TrimSpace(opts.Image)
+	if image == "" {
+		return nil, fmt.Errorf("image is required")
+	}
+
+	payload := map[string]any{
+		"image": image,
+	}
+	if instanceType := strings.TrimSpace(opts.InstanceType); instanceType != "" {
+		payload["instanceType"] = instanceType
+	}
+	if writableLayerSize := strings.TrimSpace(opts.WritableLayerSize); writableLayerSize != "" {
+		payload["writableLayerSize"] = writableLayerSize
+	}
+	if len(opts.ExposedPorts) > 0 {
+		payload["exposedPorts"] = append([]uint16(nil), opts.ExposedPorts...)
+	}
+	if opts.ProbePort != nil {
+		payload["probePort"] = *opts.ProbePort
+	}
+	if probePath := strings.TrimSpace(opts.ProbePath); probePath != "" {
+		payload["probePath"] = probePath
+	}
+	if opts.CPU != nil {
+		payload["cpu"] = *opts.CPU
+	}
+	if opts.Memory != nil {
+		payload["memory"] = *opts.Memory
+	}
+	if env := templateEnvList(opts.Env); len(env) > 0 {
+		payload["env"] = env
+	}
+	if opts.AllowInternetAccess != nil {
+		payload["allowInternetAccess"] = *opts.AllowInternetAccess
+	}
+	if networkType := strings.TrimSpace(opts.NetworkType); networkType != "" {
+		payload["networkType"] = networkType
+	}
+	if len(opts.Nodes) > 0 {
+		payload["nodes"] = append([]string(nil), opts.Nodes...)
+	}
+	if registryUsername := strings.TrimSpace(opts.RegistryUsername); registryUsername != "" {
+		payload["registryUsername"] = registryUsername
+	}
+	if registryPassword := strings.TrimSpace(opts.RegistryPassword); registryPassword != "" {
+		payload["registryPassword"] = registryPassword
+	}
+	if len(opts.Command) > 0 {
+		payload["command"] = append([]string(nil), opts.Command...)
+	}
+	if len(opts.Args) > 0 {
+		payload["args"] = append([]string(nil), opts.Args...)
+	}
+	if len(opts.DNS) > 0 {
+		payload["dns"] = append([]string(nil), opts.DNS...)
+	}
+	if len(opts.AllowOut) > 0 {
+		payload["allowOut"] = append([]string(nil), opts.AllowOut...)
+	}
+	if len(opts.DenyOut) > 0 {
+		payload["denyOut"] = append([]string(nil), opts.DenyOut...)
+	}
+	for key, value := range opts.Extra {
+		payload[key] = value
+	}
+	return payload, nil
+}
+
+func templateEnvList(env map[string]string) []string {
+	if len(env) == 0 {
+		return nil
+	}
+	keys := make([]string, 0, len(env))
+	for key := range env {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	out := make([]string, 0, len(keys))
+	for _, key := range keys {
+		out = append(out, key+"="+env[key])
+	}
+	return out
+}

--- a/sdk/python/cubesandbox/_template.py
+++ b/sdk/python/cubesandbox/_template.py
@@ -87,9 +87,10 @@ class TemplateInfo:
     @classmethod
     def from_dict(cls, data: dict) -> "TemplateInfo":
         builds_raw = data.get("builds") or []
+        aliases = data.get("aliases") or []
         return cls(
             template_id=data.get("templateID") or data.get("template_id", ""),
-            name=data.get("name") or data.get("aliases", [None])[0] or "",
+            name=data.get("name") or (aliases[0] if aliases else "") or "",
             instance_type=data.get("instanceType") or data.get("instance_type", ""),
             version=data.get("version") or "",
             status=data.get("status") or "",
@@ -219,6 +220,15 @@ class Template:
         memory_mb: int | None = None,
         envs: Dict[str, str] | None = None,
         allow_internet_access: bool | None = None,
+        network_type: str | None = None,
+        nodes: list[str] | None = None,
+        registry_username: str | None = None,
+        registry_password: str | None = None,
+        command: list[str] | None = None,
+        args: list[str] | None = None,
+        dns: list[str] | None = None,
+        allow_out: list[str] | None = None,
+        deny_out: list[str] | None = None,
         config: Config | None = None,
         **kwargs: Any,
     ) -> TemplateBuild:
@@ -245,6 +255,15 @@ class Template:
             memory_mb: Memory limit in MiB for the sandbox.
             envs: Environment variables baked into the template.
             allow_internet_access: Whether sandboxes from this template may access internet.
+            network_type: Network mode for the generated template, e.g. ``"tap"``.
+            nodes: Limit template distribution to these node IDs or host IPs.
+            registry_username: Registry username for private source images.
+            registry_password: Registry password for private source images.
+            command: Override container ENTRYPOINT.
+            args: Override container CMD args.
+            dns: Container DNS nameservers.
+            allow_out: Allowed outbound CIDRs for CubeVS egress policy.
+            deny_out: Denied outbound CIDRs for CubeVS egress policy.
             config: SDK config.  Uses default (env-based) config if omitted.
             **kwargs: Extra fields forwarded verbatim to the request body.
 
@@ -282,6 +301,24 @@ class Template:
             payload["env"] = [f"{key}={value}" for key, value in envs.items()]
         if allow_internet_access is not None:
             payload["allowInternetAccess"] = allow_internet_access
+        if network_type is not None:
+            payload["networkType"] = network_type
+        if nodes is not None:
+            payload["nodes"] = nodes
+        if registry_username is not None:
+            payload["registryUsername"] = registry_username
+        if registry_password is not None:
+            payload["registryPassword"] = registry_password
+        if command is not None:
+            payload["command"] = command
+        if args is not None:
+            payload["args"] = args
+        if dns is not None:
+            payload["dns"] = dns
+        if allow_out is not None:
+            payload["allowOut"] = allow_out
+        if deny_out is not None:
+            payload["denyOut"] = deny_out
         payload.update(kwargs)
 
         s = requests.Session()

--- a/sdk/python/tests/test_sandbox.py
+++ b/sdk/python/tests/test_sandbox.py
@@ -20,6 +20,7 @@ import httpx
 import pytest
 
 from cubesandbox import CommandResult, Template
+from cubesandbox._template import TemplateInfo
 from cubesandbox._commands import Commands, _collect_process_events
 from cubesandbox._config import Config
 from cubesandbox._exceptions import (
@@ -1361,6 +1362,91 @@ class TestTemplateAPI:
         )
         assert job.job_id == "job-001"
         assert job.template_id == "tpl-python"
+
+    def test_build_forwards_create_from_image_options(self):
+        body = {
+            "jobID": "job-002",
+            "templateID": "tpl-network",
+            "status": "accepted",
+            "phase": "",
+            "progress": 0,
+        }
+        config = make_config()
+
+        with patch("requests.Session.post", return_value=mock_response(body)) as post:
+            Template.build(
+                image="registry.example.com/app:latest",
+                writable_layer_size="20Gi",
+                network_type="tap",
+                nodes=["node-a", "10.0.0.12"],
+                registry_username="pull-user",
+                registry_password="pull-pass",
+                command=["/bin/sh", "-c"],
+                args=["sleep infinity"],
+                dns=["8.8.8.8", "1.1.1.1"],
+                allow_out=["172.67.0.0/16"],
+                deny_out=["10.0.0.0/8"],
+                config=config,
+            )
+
+        post.assert_called_once_with(
+            "http://localhost:3000/templates",
+            json={
+                "image": "registry.example.com/app:latest",
+                "writableLayerSize": "20Gi",
+                "networkType": "tap",
+                "nodes": ["node-a", "10.0.0.12"],
+                "registryUsername": "pull-user",
+                "registryPassword": "pull-pass",
+                "command": ["/bin/sh", "-c"],
+                "args": ["sleep infinity"],
+                "dns": ["8.8.8.8", "1.1.1.1"],
+                "allowOut": ["172.67.0.0/16"],
+                "denyOut": ["10.0.0.0/8"],
+            },
+            headers={"Content-Type": "application/json"},
+        )
+
+    def test_template_info_from_dict_handles_empty_aliases(self):
+        info = TemplateInfo.from_dict({
+            "templateID": "tpl-test",
+            "aliases": [],
+            "networkType": "tap",
+            "allowInternetAccess": True,
+        })
+        assert info.template_id == "tpl-test"
+        assert info.name == ""
+        assert info.network_type == "tap"
+        assert info.allow_internet_access is True
+
+    def test_template_get_parses_network_fields(self):
+        body = {
+            "templateID": "tpl-network",
+            "status": "READY",
+            "networkType": "tap",
+            "allowInternetAccess": False,
+            "createRequest": {
+                "network_type": "tap",
+                "cubevs_context": {
+                    "allowInternetAccess": False,
+                    "allowOut": ["172.67.0.0/16"],
+                    "denyOut": ["10.0.0.0/8"],
+                },
+            },
+        }
+        config = make_config()
+
+        with patch("requests.Session.get", return_value=mock_response(body)) as get:
+            info = Template.get("tpl-network", config=config)
+
+        get.assert_called_once_with(
+            "http://localhost:3000/templates/tpl-network",
+            params={},
+        )
+        assert info.template_id == "tpl-network"
+        assert info.network_type == "tap"
+        assert info.allow_internet_access is False
+        assert info.create_request["cubevs_context"]["allowOut"] == ["172.67.0.0/16"]
 
     def test_build_rejects_unsupported_models(self):
         with pytest.raises(ValueError, match="image is required"):


### PR DESCRIPTION
### Summary

- Extend CubeAPI `POST /templates` to forward fields that `cubemastercli template create-from-image` already supports but the SDKs did not expose: DNS, egress CIDRs (`allowOut`/`denyOut`), registry credentials, `command`/`args` overrides, `networkType`, and node distribution scope (`nodes`).
- Add matching parameters to Python `Template.build()` and introduce Go SDK template APIs (`BuildTemplate`, `ListTemplates`, `GetTemplate`, `RebuildTemplate`, `DeleteTemplate`, `GetTemplateBuildStatus`).
- Fix a broken CubeAPI unit test on upstream `master` where a `SandboxInfo` initializer was missing `create_at`, which prevented `cargo test` from compiling.

### Changes

| Component | Change |
|-----------|--------|
| CubeAPI | Extend `CreateTemplateRequest`; map fields in `templates.rs` to CubeMaster `CreateTemplateFromImageReq` |
| Python SDK | Add `network_type`, `nodes`, `registry_*`, `command`, `args`, `dns`, `allow_out`, `deny_out` to `Template.build()` |
| Go SDK | Add `sdk/go/template.go` and unit tests |

### Verification

- [x] `cargo test services::templates::tests` (CubeAPI, 3 passed)
- [x] `go test -run TestBuildTemplate` (Go SDK)
- [x] `pytest tests/test_sandbox.py::TestTemplateAPI` (Python SDK)
- [x] Deployed on ubuntu22: new cube-api + `Template.build()`; confirmed `createRequest` persisted with `network_type`, `cubevs_context`, `dns_config`, and `envs`

### Test plan

- [ ] Reviewer: `POST /templates` with `dns` / `allowOut` / `denyOut` / `command` / `args` / `networkType` / `nodes`; verify persisted `createRequest` in CubeMaster
- [ ] Reviewer: Python `Template.build(...)` and Go `BuildTemplate(...)` match CLI behavior