### PR TITLE
fix(ci): reuse auto review PR comments

### DIFF
--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -1,10 +1,11 @@
-name: Claude Auto Review with Tracking
+name: Claude Auto Review
 
 on:
   # IMPORTANT: pull_request_target makes secrets available to fork PRs.
   # SECURITY RULE: never add steps that EXECUTE code from the PR
   # (no npm install / make / cargo build / pre-commit / etc.).
-  # Claude only READS files (safe) and runs `gh pr *` via allowedTools.
+  # Claude only READS files (safe), reads PR metadata, and posts review output
+  # through the constrained scripts/gh.sh wrapper below.
   pull_request_target:
     types: [opened, synchronize, reopened]
 
@@ -46,9 +47,22 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ steps.app-token.outputs.token }}
           allowed_non_write_users: "*"
-          track_progress: true # ✨ Enables tracking comments
-          prompt: "/review-pr REPO: ${{ github.repository }} PR NUMBER: ${{ github.event.pull_request.number }}"
+          prompt: |
+            /review-pr REPO: ${{ github.repository }} PR NUMBER: ${{ github.event.pull_request.number }}
+
+            Comment management requirements:
+            - Use a single top-level PR review comment for this workflow.
+            - To publish top-level PR feedback, write the full review body to a
+              temporary file and run:
+              ./scripts/gh.sh pr review-comment ${{ github.event.pull_request.number }} --body-file <file>
+            - Wrap the review body with these exact hidden markers so future
+              runs can reliably recognize and update the same review comment:
+              <!-- cubesandbox-auto-review:start -->
+              <!-- cubesandbox-auto-review:end -->
+            - Do not call `gh pr comment` or `gh api` directly for top-level
+              comments; the wrapper enforces the current PR, fixed markers, and
+              the cubesandboxbot[bot] author check before editing any comment.
           show_full_output: true
 
           claude_args: |
-            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(./scripts/gh.sh pr review-comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"

--- a/scripts/gh.sh
+++ b/scripts/gh.sh
@@ -11,6 +11,7 @@ set -euo pipefail
 #   ./scripts/gh.sh search issues "search query" --limit 10
 #   ./scripts/gh.sh label list --limit 100
 #   ./scripts/gh.sh issue comment 123 --body-file /tmp/comment.md
+#   ./scripts/gh.sh pr review-comment 123 --body-file /tmp/comment.md
 
 export GH_HOST=github.com
 
@@ -21,6 +22,10 @@ if [[ -z "$REPO" || "$REPO" == */*/* || "$REPO" != */* ]]; then
 fi
 export GH_REPO="$REPO"
 
+AUTO_REVIEW_START_MARKER="<!-- cubesandbox-auto-review:start -->"
+AUTO_REVIEW_END_MARKER="<!-- cubesandbox-auto-review:end -->"
+AUTO_REVIEW_BOT_LOGIN="cubesandboxbot[bot]"
+
 ALLOWED_FLAGS=(--comments --state --limit --label --body-file)
 FLAGS_WITH_VALUES=(--state --limit --label --body-file)
 
@@ -28,10 +33,10 @@ SUB1="${1:-}"
 SUB2="${2:-}"
 CMD="$SUB1 $SUB2"
 case "$CMD" in
-  "issue view"|"issue list"|"search issues"|"label list"|"issue comment")
+  "issue view"|"issue list"|"search issues"|"label list"|"issue comment"|"pr review-comment")
     ;;
   *)
-    echo "Error: only 'issue view', 'issue list', 'search issues', 'label list', 'issue comment' are allowed (e.g., ./scripts/gh.sh issue view 123)" >&2
+    echo "Error: only 'issue view', 'issue list', 'search issues', 'label list', 'issue comment', 'pr review-comment' are allowed (e.g., ./scripts/gh.sh issue view 123)" >&2
     exit 1
     ;;
 esac
@@ -105,6 +110,115 @@ elif [[ "$CMD" == "issue comment" ]]; then
     exit 1
   fi
   gh "$SUB1" "$SUB2" "${POSITIONAL[0]}" "${FLAGS[@]}"
+elif [[ "$CMD" == "pr review-comment" ]]; then
+  if [[ ${#POSITIONAL[@]} -ne 1 ]] || ! [[ "${POSITIONAL[0]}" =~ ^[0-9]+$ ]]; then
+    echo "Error: pr review-comment requires exactly one numeric PR number (e.g., ./scripts/gh.sh pr review-comment 123 --body-file /tmp/comment.md)" >&2
+    exit 1
+  fi
+
+  pr_number="${POSITIONAL[0]}"
+  body_file=""
+  i=0
+  while [[ $i -lt ${#FLAGS[@]} ]]; do
+    f="${FLAGS[$i]}"
+    if [[ "$f" == "--body-file" ]]; then
+      i=$((i + 1))
+      body_file="${FLAGS[$i]:-}"
+    elif [[ "$f" == --body-file=* ]]; then
+      body_file="${f#--body-file=}"
+    else
+      echo "Error: pr review-comment only accepts --body-file" >&2
+      exit 1
+    fi
+    i=$((i + 1))
+  done
+
+  if [[ -z "$body_file" || ! -f "$body_file" ]]; then
+    echo "Error: pr review-comment requires an existing --body-file <path>" >&2
+    exit 1
+  fi
+
+  if [[ "${GITHUB_ACTIONS:-}" == "true" ]]; then
+    current_pr="$(
+      python3 - <<'PY'
+import json
+import os
+
+event_path = os.environ.get("GITHUB_EVENT_PATH")
+if not event_path:
+    print("")
+    raise SystemExit
+
+with open(event_path, encoding="utf-8") as f:
+    payload = json.load(f)
+
+print(payload.get("pull_request", {}).get("number", ""))
+PY
+    )"
+    if [[ -z "$current_pr" || "$pr_number" != "$current_pr" ]]; then
+      echo "Error: pr review-comment may only update the current pull_request event PR" >&2
+      exit 1
+    fi
+  fi
+
+  body="$(<"$body_file")"
+  if [[ "$body" != *"$AUTO_REVIEW_START_MARKER"* || "$body" != *"$AUTO_REVIEW_END_MARKER"* ]]; then
+    echo "Error: review comment body must contain the auto-review start and end markers" >&2
+    exit 1
+  fi
+
+  comments_file="$(mktemp)"
+  payload_file="$(mktemp)"
+  trap 'rm -f "$comments_file" "$payload_file"' EXIT
+
+  gh api "repos/$REPO/issues/$pr_number/comments?per_page=100" --paginate --slurp >"$comments_file"
+  comment_id="$(
+    python3 - "$comments_file" "$AUTO_REVIEW_START_MARKER" "$AUTO_REVIEW_BOT_LOGIN" <<'PY'
+import json
+import sys
+
+comments_path = sys.argv[1]
+marker = sys.argv[2]
+bot_login = sys.argv[3]
+
+with open(comments_path, encoding="utf-8") as f:
+    pages = json.load(f)
+
+matches = []
+
+for page in pages:
+    for comment in page:
+        user = comment.get("user") or {}
+        body = comment.get("body") or ""
+        if (
+            user.get("type") == "Bot"
+            and user.get("login") == bot_login
+            and marker in body
+        ):
+            matches.append(comment)
+
+if matches:
+    print(matches[-1]["id"])
+PY
+  )"
+
+  python3 - "$body_file" "$payload_file" <<'PY'
+import json
+import sys
+
+body_path, payload_path = sys.argv[1], sys.argv[2]
+with open(body_path, encoding="utf-8") as f:
+    body = f.read()
+
+with open(payload_path, "w", encoding="utf-8") as f:
+    json.dump({"body": body}, f)
+PY
+
+  if [[ -n "$comment_id" ]]; then
+    gh api --method PATCH "repos/$REPO/issues/comments/$comment_id" --input "$payload_file" >/dev/null
+  else
+    gh api --method POST "repos/$REPO/issues/$pr_number/comments" --input "$payload_file" >/dev/null
+  fi
 else
   if [[ ${#POSITIONAL[@]} -ne 0 ]]; then
     echo "Error: issue list and label list do not accept positional arguments (e.g., ./scripts/gh.sh issue list --state open, ./scripts/gh.sh label list --limit 100)" >&2


### PR DESCRIPTION
Route automated review comments through a constrained wrapper so repeated PR synchronizations update the bot's marked comment instead of creating new top-level comments.