### PR TITLE
fix(Cubelet): stop network plugin bootstrap unknown-key warnings

### DIFF
--- a/Cubelet/cmd/cubelet/main.go
+++ b/Cubelet/cmd/cubelet/main.go
@@ -36,6 +36,7 @@ import (
 	"github.com/containerd/log"
 	"github.com/moby/sys/mountinfo"
 	"github.com/sirupsen/logrus"
+	"github.com/tencentcloud/CubeSandbox/Cubelet/network"
 	dynamConf "github.com/tencentcloud/CubeSandbox/Cubelet/pkg/config"
 	"github.com/tencentcloud/CubeSandbox/Cubelet/pkg/constants"
 	_ "github.com/tencentcloud/CubeSandbox/Cubelet/pkg/nsenter"
@@ -60,11 +61,6 @@ const (
 	CubeMainProcMutexLock = "/run/cubelock.db"
 	networkPluginKey      = "io.cubelet.internal.v1.network"
 )
-
-type networkPluginBootstrapConfig struct {
-	EnableNetworkAgent   bool   `toml:"enable_network_agent"`
-	NetworkAgentEndpoint string `toml:"network_agent_endpoint"`
-}
 
 func main() {
 	if len(os.Args) > 1 {
@@ -550,19 +546,18 @@ func criticalCubeletPluginURIs() []string {
 	}
 }
 
-func loadNetworkPluginBootstrapConfig(cfg *srvconfig.Config) (*networkPluginBootstrapConfig, bool, error) {
+func loadNetworkPluginBootstrapConfig(cfg *srvconfig.Config) (*network.Config, bool, error) {
 	if cfg == nil || cfg.Plugins == nil {
 		return nil, false, nil
 	}
-	_, ok := cfg.Plugins[networkPluginKey]
-	if !ok {
+	if _, ok := cfg.Plugins[networkPluginKey]; !ok {
 		return nil, false, nil
 	}
-	var networkCfg networkPluginBootstrapConfig
-	if _, err := cfg.Decode(gocontext.Background(), networkPluginKey, &networkCfg); err != nil {
+	networkCfg := &network.Config{}
+	if _, err := cfg.Decode(gocontext.Background(), networkPluginKey, networkCfg); err != nil {
 		return nil, false, fmt.Errorf("decode %s plugin config: %w", networkPluginKey, err)
 	}
-	return &networkCfg, true, nil
+	return networkCfg, true, nil
 }
 
 func serve(ctx gocontext.Context, l net.Listener, serveFunc func(net.Listener) error) {

--- a/Cubelet/cmd/cubelet/main_test.go
+++ b/Cubelet/cmd/cubelet/main_test.go
@@ -5,10 +5,14 @@
 package main
 
 import (
+	"context"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/tencentcloud/CubeSandbox/Cubelet/pkg/constants"
+	srvconfig "github.com/tencentcloud/CubeSandbox/Cubelet/services/server/config"
 )
 
 func TestEnsureRequiredPluginsAddsCriticalCubeletPlugins(t *testing.T) {
@@ -21,4 +25,18 @@ func TestEnsureRequiredPluginsAddsCriticalCubeletPlugins(t *testing.T) {
 	assert.Contains(t, cfg.RequiredPlugins, string(constants.InternalPlugin)+"."+constants.CubeboxID.ID())
 	assert.Contains(t, cfg.RequiredPlugins, string(constants.WorkflowPlugin)+"."+constants.WorkflowID.ID())
 	assert.Contains(t, cfg.RequiredPlugins, string(constants.CubeboxServicePlugin)+"."+constants.CubeboxServiceID.ID())
+}
+
+func TestLoadNetworkPluginBootstrapConfigDecodesNetworkPluginSection(t *testing.T) {
+	cfg := platformAgnosticDefaultConfig()
+	configPath := filepath.Join("..", "..", "config", "config.toml")
+
+	require.NoError(t, srvconfig.LoadConfig(context.Background(), configPath, cfg))
+
+	networkCfg, ok, err := loadNetworkPluginBootstrapConfig(cfg)
+	require.NoError(t, err)
+	assert.True(t, ok)
+	require.NotNil(t, networkCfg)
+	assert.True(t, networkCfg.EnableNetworkAgent)
+	assert.Equal(t, "grpc+unix:///tmp/cube/network-agent-grpc.sock", networkCfg.NetworkAgentEndpoint)
 }


### PR DESCRIPTION
## Motivation

`Cubelet` currently emits noisy TOML unknown-key warnings during startup when it reads the network plugin config through a partial bootstrap struct.

These warnings do not affect functionality, but they are misleading. They make the network plugin config appear invalid, even though the same full config is later accepted by the actual network plugin.

## Reproduction

Restart `cubelet` with the default config containing a full `[plugins."io.cubelet.internal.v1.network"]` section:

```bash
systemctl restart cube-sandbox-cubelet.service
journalctl -u cube-sandbox-cubelet.service -b -n 200 | grep 'Ignoring unknown key in TOML for plugin'
```

Example output:

```text
level=warning msg="Ignoring unknown key in TOML for plugin" error="strict mode: fields in the document are missing in the target struct" key=object_dir plugin=io.cubelet.internal.v1.network
level=warning msg="Ignoring unknown key in TOML for plugin" error="strict mode: fields in the document are missing in the target struct" key=redis_conf_path plugin=io.cubelet.internal.v1.network
level=warning msg="Ignoring unknown key in TOML for plugin" error="strict mode: fields in the document are missing in the target struct" key=report_stat_interval_in_sec plugin=io.cubelet.internal.v1.network
level=warning msg="Ignoring unknown key in TOML for plugin" error="strict mode: fields in the document are missing in the target struct" key=stream_block_time plugin=io.cubelet.internal.v1.network
level=warning msg="Ignoring unknown key in TOML for plugin" error="strict mode: fields in the document are missing in the target struct" key=stream_key plugin=io.cubelet.internal.v1.network
level=warning msg="Ignoring unknown key in TOML for plugin" error="strict mode: fields in the document are missing in the target struct" key=stream_name_prefix plugin=io.cubelet.internal.v1.network
level=warning msg="Ignoring unknown key in TOML for plugin" error="strict mode: fields in the document are missing in the target struct" key=tap_init_num plugin=io.cubelet.internal.v1.network
level=warning msg="Ignoring unknown key in TOML for plugin" error="strict mode: fields in the document are missing in the target struct" key=watch_stream plugin=io.cubelet.internal.v1.network
```

## Root Cause

The Cubelet startup path decodes the full `io.cubelet.internal.v1.network` plugin section into a partial bootstrap struct that only declares a subset of the plugin's TOML keys.

Because plugin config decoding runs in strict mode first, every valid key that is missing from the partial bootstrap struct is reported as an unknown-key warning before the decode falls back.

## What this PR changes

- reuses the existing full `network.Config` when reading the network plugin config for Cubelet bootstrap
- keeps the bootstrap behaviour unchanged
- stops valid network plugin config keys from being reported as misleading unknown-key warnings during Cubelet startup

## Testing

Added a targeted unit test to cover decoding a full `io.cubelet.internal.v1.network` plugin config section through the Cubelet bootstrap config loader.

The test verifies that valid network plugin config keys are accepted when loading the bootstrap config, instead of being treated as unknown keys due to partial struct decoding.

Targeted test:

```bash
go test -vet=off ./cmd/cubelet -run TestLoadNetworkPluginBootstrapConfigDecodesNetworkPluginSection
```

Also validated on a Linux node by replacing the cubelet binary and fully restarting the service:

```bash
systemctl restart cube-sandbox-cubelet.service
journalctl -u cube-sandbox-cubelet.service -b -n 200 | grep 'Ignoring unknown key in TOML for plugin'
```

After the restart, the grep command produced no matching startup warnings.

## Out of Scope

A similar warning can also be reproduced in some cubecli network-agent related commands, such as:

```bash
cubecli container taps | grep "Ignoring unknown key in TOML for plugin"
```

That path is intentionally left unchanged in this PR because it goes through a separate `cubecli` network-agent config loading path. Fixing it cleanly would require deciding whether `cubecli` should also reuse the network plugin's full `network.Config`, or whether the CLI should keep its own bootstrap/agent-specific config shape.

This PR is limited to the Cubelet startup path to avoid mixing that broader CLI config-sharing decision into this fix.

## Documentation

No documentation update is needed because this change only removes misleading warnings during config decoding. It does not change command behaviour, plugin config shape, APIs, or runtime semantics.