### PR TITLE
feat(CubeMaster): support daemonless template image export via skopeo/umoci

### DIFF
--- a/CubeMaster/docker/Dockerfile
+++ b/CubeMaster/docker/Dockerfile
@@ -22,7 +22,9 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get install -y \
 	telnet \
 	tzdata \
 	vim \
-	wget
+	wget \
+	skopeo \
+	umoci
 
 RUN cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime
 RUN update-ca-certificates

--- a/CubeMaster/pkg/templatecenter/template_image.go
+++ b/CubeMaster/pkg/templatecenter/template_image.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/sha256"
+	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
@@ -17,6 +18,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -96,6 +98,7 @@ var deleteRootfsArtifactRecord = func(ctx context.Context, artifactID string) er
 	return store.db.WithContext(ctx).Unscoped().Table(constants.RootfsArtifactTableName).
 		Where("artifact_id = ?", artifactID).Delete(&models.RootfsArtifact{}).Error
 }
+var executableLookPath = exec.LookPath
 
 var ErrNoFailedTemplateReplicas = errors.New("no failed template replicas matched redo request")
 
@@ -103,6 +106,23 @@ type dockerInspectImage struct {
 	ID          string            `json:"Id"`
 	RepoDigests []string          `json:"RepoDigests"`
 	Config      dockerImageConfig `json:"Config"`
+}
+
+type skopeoInspectImage struct {
+	Name       string               `json:"Name"`
+	Digest     string               `json:"Digest"`
+	LayersData []skopeoInspectLayer `json:"LayersData"`
+}
+
+// skopeoInspectLayer mirrors a single entry of the LayersData array returned by
+// `skopeo inspect`. Size is the compressed (on-registry) size of the layer blob
+// in bytes.
+type skopeoInspectLayer struct {
+	Size int64 `json:"Size"`
+}
+
+type skopeoInspectConfig struct {
+	Config dockerImageConfig `json:"config"`
 }
 
 type dockerImageConfig struct {
@@ -114,12 +134,19 @@ type dockerImageConfig struct {
 }
 
 type resolvedSourceImage struct {
-	localRef     string
-	digest       string
-	config       dockerImageConfig
-	configJSON   string
-	masterNodeIP string
-	cleanup      func(context.Context)
+	localRef       string
+	digest         string
+	config         dockerImageConfig
+	configJSON     string
+	masterNodeIP   string
+	useDockerless  bool
+	skopeoAuthFile string
+	// compressedSizeBytes is the sum of the compressed layer blob sizes reported
+	// by `skopeo inspect` (LayersData[].Size). It is only populated on the
+	// dockerless path and lets the disk-space pre-check estimate the image size
+	// without invoking the docker daemon. Zero means "unknown".
+	compressedSizeBytes int64
+	cleanup             func(context.Context)
 }
 
 func nextAttemptNoFromLatest(latestAttemptNo int32) int32 {
@@ -578,6 +605,12 @@ func prepareLocalSourceImage(ctx context.Context, req *types.CreateTemplateFromI
 	if req == nil {
 		return nil, errors.New("request is nil")
 	}
+	// In dockerless mode there is no local docker daemon to hold the image, so a
+	// redo re-resolves the source from the registry via skopeo. This intentionally
+	// relaxes the docker-path requirement that the image still exist locally.
+	if hasDockerlessRootfsExportTools() {
+		return prepareDockerlessSourceImage(ctx, req, downloadBaseURL)
+	}
 	inspectOutput, err := dockerOutput(ctx, "", "image", "inspect", "--", req.SourceImageRef)
 	if err != nil {
 		return nil, fmt.Errorf("redo requires source image %s to still exist locally: %w", req.SourceImageRef, err)
@@ -590,7 +623,10 @@ func prepareLocalSourceImage(ctx context.Context, req *types.CreateTemplateFromI
 		return nil, fmt.Errorf("docker image inspect returned empty result for %s", req.SourceImageRef)
 	}
 	inspectInfo := inspectList[0]
-	configJSON, _ := json.Marshal(inspectInfo.Config)
+	configJSON, err := json.Marshal(inspectInfo.Config)
+	if err != nil {
+		return nil, fmt.Errorf("marshal image config: %w", err)
+	}
 	return &resolvedSourceImage{
 		localRef:     req.SourceImageRef,
 		digest:       firstNonEmptyDigest(inspectInfo),
@@ -936,6 +972,9 @@ func runRedoTemplateImageJob(ctx context.Context, jobID string, req *types.RedoT
 			failRedoTemplateImageJob(ctx, jobID, JobPhaseBuildingExt4, prepErr.Error())
 			return
 		}
+		if source.cleanup != nil {
+			defer source.cleanup(ctx)
+		}
 		var generatedReq *types.CreateCubeSandboxReq
 		var builtFresh bool
 		artifact, generatedReq, builtFresh, err = ensureRootfsArtifact(ctx, &workingReq, source, downloadBaseURL)
@@ -1236,7 +1275,15 @@ func buildRootfsArtifact(ctx context.Context, record *models.RootfsArtifact, req
 	keepStoreDir := false
 
 	// Phase 2: loop-mount streaming build (optional, auto-detects capability).
-	if loopMountExt4Enabled() && canUseLoopMount() {
+	//
+	// The streaming build relies on `docker create` + `docker export`, so it is
+	// only available on the docker path. For dockerless sources (skopeo+umoci)
+	// we deliberately skip Phase 2 and fall through to the daemonless Phase 1 to
+	// keep the dockerless path free of any docker binary dependency. umoci
+	// unpacks to an on-disk bundle rather than streaming to stdout, so a
+	// loop-mount "streaming" variant would not avoid the intermediate rootfs
+	// anyway.
+	if loopMountExt4Enabled() && canUseLoopMount() && !source.useDockerless {
 		estimatedPhase2, err := estimateImageSizeFromInspect(ctx, source)
 		if err != nil {
 			log.G(ctx).Warnf("cannot estimate image size for Phase 2, falling back to Phase 1: %v", err)
@@ -1263,7 +1310,8 @@ func buildRootfsArtifact(ctx context.Context, record *models.RootfsArtifact, req
 	}
 
 	// Phase 1: disk space pre-check.
-	// Use docker image inspect to get an approximate size for the check.
+	// Size estimate comes from skopeo inspect (dockerless) or docker image
+	// inspect (docker), selected by estimateImageSizeFromInspect.
 	estimatedSizeBytes, err := estimateImageSizeFromInspect(ctx, source)
 	if err != nil {
 		log.G(ctx).Warnf("cannot estimate image size for disk-space check, skipping: %v", err)
@@ -1379,28 +1427,100 @@ func finalizeArtifact(ctx context.Context, record *models.RootfsArtifact, source
 }
 
 func prepareSourceImage(ctx context.Context, req *types.CreateTemplateFromImageReq, downloadBaseURL string) (*resolvedSourceImage, error) {
+	if req == nil {
+		return nil, errors.New("request is nil")
+	}
+	if hasDockerlessRootfsExportTools() {
+		return prepareDockerlessSourceImage(ctx, req, downloadBaseURL)
+	}
+	return prepareDockerSourceImage(ctx, req, downloadBaseURL)
+}
+
+func prepareDockerlessSourceImage(ctx context.Context, req *types.CreateTemplateFromImageReq, downloadBaseURL string) (*resolvedSourceImage, error) {
+	if req == nil {
+		return nil, errors.New("request is nil")
+	}
+	if err := validateImageRef(req.SourceImageRef); err != nil {
+		return nil, err
+	}
+	authFile, cleanup, err := createSkopeoAuthFile(req.SourceImageRef, req.RegistryUsername, req.RegistryPassword)
+	if err != nil {
+		return nil, err
+	}
+	sourceRef := skopeoDockerImageRef(req.SourceImageRef)
+	inspectOutput, err := skopeoOutput(ctx, authFile, "inspect", sourceRef)
+	if err != nil {
+		cleanup()
+		return nil, fmt.Errorf("skopeo inspect %s failed: %w", req.SourceImageRef, err)
+	}
+	configOutput, err := skopeoOutput(ctx, authFile, "inspect", "--config", sourceRef)
+	if err != nil {
+		cleanup()
+		return nil, fmt.Errorf("skopeo inspect --config %s failed: %w", req.SourceImageRef, err)
+	}
+
+	var inspectInfo skopeoInspectImage
+	if err := json.Unmarshal(inspectOutput, &inspectInfo); err != nil {
+		cleanup()
+		return nil, fmt.Errorf("unmarshal skopeo inspect output: %w", err)
+	}
+	var configInfo skopeoInspectConfig
+	if err := json.Unmarshal(configOutput, &configInfo); err != nil {
+		cleanup()
+		return nil, fmt.Errorf("unmarshal skopeo inspect config output: %w", err)
+	}
+	configJSON, err := json.Marshal(configInfo.Config)
+	if err != nil {
+		cleanup()
+		return nil, fmt.Errorf("marshal image config: %w", err)
+	}
+	return &resolvedSourceImage{
+		localRef:            req.SourceImageRef,
+		digest:              skopeoImageDigest(inspectInfo, req.SourceImageRef),
+		config:              configInfo.Config,
+		configJSON:          string(configJSON),
+		masterNodeIP:        normalizeBaseURL(downloadBaseURL),
+		useDockerless:       true,
+		skopeoAuthFile:      authFile,
+		compressedSizeBytes: skopeoLayersTotalSize(inspectInfo),
+		cleanup: func(context.Context) {
+			cleanup()
+		},
+	}, nil
+}
+
+func prepareDockerSourceImage(ctx context.Context, req *types.CreateTemplateFromImageReq, downloadBaseURL string) (*resolvedSourceImage, error) {
+	if req == nil {
+		return nil, errors.New("request is nil")
+	}
 	var (
-		dockerConfigDir    string
-		imageExistsLocally bool
-		inspectOutput      []byte
-		err                error
+		dockerConfigDir       string
+		removeDockerConfigDir bool
+		imageExistsLocally    bool
+		inspectOutput         []byte
+		err                   error
 	)
+	defer func() {
+		if removeDockerConfigDir && dockerConfigDir != "" {
+			_ = os.RemoveAll(dockerConfigDir)
+		}
+	}()
 	inspectOutput, err = dockerOutput(ctx, "", "image", "inspect", "--", req.SourceImageRef)
 	if err == nil {
 		imageExistsLocally = true
 	}
-	if !imageExistsLocally {
-		if req.RegistryUsername != "" || req.RegistryPassword != "" {
-			tmpDir, err := os.MkdirTemp("", "cubemaster-docker-config-*")
-			if err != nil {
-				return nil, err
-			}
-			dockerConfigDir = tmpDir
-			defer os.RemoveAll(tmpDir)
-			if err := dockerLogin(ctx, dockerConfigDir, req.SourceImageRef, req.RegistryUsername, req.RegistryPassword); err != nil {
-				return nil, err
-			}
+	if req.RegistryUsername != "" || req.RegistryPassword != "" {
+		tmpDir, err := os.MkdirTemp("", "cubemaster-docker-config-*")
+		if err != nil {
+			return nil, err
 		}
+		dockerConfigDir = tmpDir
+		removeDockerConfigDir = true
+		if err := dockerLogin(ctx, dockerConfigDir, req.SourceImageRef, req.RegistryUsername, req.RegistryPassword); err != nil {
+			return nil, err
+		}
+	}
+	if !imageExistsLocally {
 		if err := dockerRun(ctx, dockerConfigDir, "pull", "--", req.SourceImageRef); err != nil {
 			return nil, fmt.Errorf("docker pull %s failed: %w", req.SourceImageRef, err)
 		}
@@ -1417,8 +1537,11 @@ func prepareSourceImage(ctx context.Context, req *types.CreateTemplateFromImageR
 		return nil, fmt.Errorf("docker image inspect returned empty result for %s", req.SourceImageRef)
 	}
 	inspectInfo := inspectList[0]
-	configJSON, _ := json.Marshal(inspectInfo.Config)
-	return &resolvedSourceImage{
+	configJSON, err := json.Marshal(inspectInfo.Config)
+	if err != nil {
+		return nil, fmt.Errorf("marshal image config: %w", err)
+	}
+	source := &resolvedSourceImage{
 		localRef:     req.SourceImageRef,
 		digest:       firstNonEmptyDigest(inspectInfo),
 		config:       inspectInfo.Config,
@@ -1432,15 +1555,213 @@ func prepareSourceImage(ctx context.Context, req *types.CreateTemplateFromImageR
 				_ = dockerRun(cleanupCtx, "", "image", "rm", "-f", "--", req.SourceImageRef)
 			}
 		},
-	}, nil
+	}
+	removeDockerConfigDir = false
+	return source, nil
+}
+
+// imageRefAllowedPattern is the strict character whitelist for image
+// references. It permits exactly the characters that appear in legitimate
+// registry/repository[:tag][@algo:hexdigest] references: alphanumerics and
+// `.`, `-`, `_`, `/`, `:`, `@`. Any other character (notably whitespace) is
+// rejected so the reference cannot be split into additional argv entries.
+var imageRefAllowedPattern = regexp.MustCompile(`^[A-Za-z0-9._:/@-]+$`)
+
+// validateImageRef guards against argument injection (CWE-88) when the image
+// reference is later passed as a positional argument to external CLIs
+// (skopeo/umoci/docker). Those tools accept flags interspersed with positional
+// arguments, so a ref such as `registry.example.com/image --authfile /etc/shadow`
+// would otherwise smuggle extra flags into the subprocess. To prevent this we
+// enforce a strict character whitelist (which excludes whitespace and other
+// argument delimiters) and reject any ref that begins with a dash.
+func validateImageRef(imageRef string) error {
+	trimmed := strings.TrimPrefix(imageRef, "docker://")
+	if trimmed == "" {
+		return errors.New("empty image reference")
+	}
+	if strings.HasPrefix(trimmed, "-") {
+		return fmt.Errorf("invalid image reference: %s", imageRef)
+	}
+	if !imageRefAllowedPattern.MatchString(trimmed) {
+		return fmt.Errorf("invalid image reference: %s", imageRef)
+	}
+	return nil
 }
 
 func exportImageRootfs(ctx context.Context, source *resolvedSourceImage, destRootfsDir string) error {
-	// Validate source.localRef to prevent argument injection.
-	if strings.HasPrefix(source.localRef, "-") {
-		return fmt.Errorf("invalid image reference: %s", source.localRef)
+	if source == nil {
+		return errors.New("resolved source image is nil")
+	}
+	if err := validateImageRef(source.localRef); err != nil {
+		return err
+	}
+	// Use the strategy chosen at prepare time rather than re-detecting, so the
+	// prepare and export phases never diverge (see resolvedSourceImage.useDockerless).
+	if source.useDockerless {
+		return dockerlessExportImageRootfs(ctx, source, destRootfsDir)
+	}
+	return dockerExportImageRootfs(ctx, source, destRootfsDir)
+}
+
+// dockerlessExportImageRootfs exports the source image's root filesystem
+// without a docker daemon. The flow is:
+//
+//  1. `skopeo copy docker://<ref> oci:<workDir>/image` pulls the image into a
+//     local OCI layout (honoring the optional skopeo auth file).
+//  2. `umoci unpack --rootless` materializes that layout into an OCI bundle
+//     under <workDir>/bundle, whose `rootfs` subdir holds the extracted files.
+//  3. The bundle's rootfs is moved into place at destRootfsDir via os.Rename.
+//
+// The scratch workDir is created under destRootfsDir's parent (rather than
+// $TMPDIR) so the final os.Rename stays on the same filesystem and cannot fail
+// with EXDEV, which would otherwise force a slow full copy across devices.
+func dockerlessExportImageRootfs(ctx context.Context, source *resolvedSourceImage, destRootfsDir string) error {
+	if err := os.MkdirAll(filepath.Dir(destRootfsDir), 0o755); err != nil {
+		return err
+	}
+	workDir, err := os.MkdirTemp(filepath.Dir(destRootfsDir), ".dockerless-rootfs-*")
+	if err != nil {
+		return err
+	}
+	defer os.RemoveAll(workDir)
+
+	ociDir := filepath.Join(workDir, "image")
+	bundleDir := filepath.Join(workDir, "bundle")
+
+	sourceRef := skopeoDockerImageRef(source.localRef)
+	ociImageRef := "oci:" + ociLayoutImageRef(ociDir, source.localRef)
+	skopeoArgs := []string{"copy"}
+	if source.skopeoAuthFile != "" {
+		skopeoArgs = append(skopeoArgs, "--authfile", source.skopeoAuthFile)
+	}
+	skopeoArgs = append(skopeoArgs, sourceRef, ociImageRef)
+	if err := runCommand(ctx, "", "skopeo", skopeoArgs...); err != nil {
+		return fmt.Errorf("skopeo copy %s failed: %w", source.localRef, err)
 	}
 
+	umociImageRef := ociLayoutImageRef(ociDir, source.localRef)
+	if err := runCommand(ctx, "", "umoci", "unpack", "--rootless", "--image", umociImageRef, bundleDir); err != nil {
+		return fmt.Errorf("umoci unpack %s failed: %w", source.localRef, err)
+	}
+	// The OCI layout is no longer needed once unpacked; drop it early to reduce
+	// peak disk usage on the artifact filesystem.
+	_ = os.RemoveAll(ociDir) // NOCC:Path Traversal()
+
+	unpackedRootfsDir := filepath.Join(bundleDir, "rootfs")
+	if err := os.RemoveAll(destRootfsDir); err != nil { // NOCC:Path Traversal()
+		return err
+	}
+	if err := os.Rename(unpackedRootfsDir, destRootfsDir); err != nil { // NOCC:Path Traversal()
+		return fmt.Errorf("move unpacked rootfs failed: %w", err)
+	}
+	return nil
+}
+
+// hasDockerlessRootfsExportTools reports whether both skopeo and umoci are
+// available on PATH. When they are, the build prefers the daemonless export
+// path (skopeo+umoci) over docker. This auto-detection means installing both
+// tools on a cubemaster node silently switches the source-image handling away
+// from the docker daemon; ensureArtifactBuildPreflight reflects the resulting
+// command requirements.
+func hasDockerlessRootfsExportTools() bool {
+	if _, err := executableLookPath("skopeo"); err != nil {
+		return false
+	}
+	if _, err := executableLookPath("umoci"); err != nil {
+		return false
+	}
+	return true
+}
+
+func skopeoDockerImageRef(imageRef string) string {
+	if strings.HasPrefix(imageRef, "docker://") {
+		return imageRef
+	}
+	return "docker://" + imageRef
+}
+
+func createSkopeoAuthFile(imageRef, username, password string) (string, func(), error) {
+	if username == "" && password == "" {
+		return "", func() {}, nil
+	}
+	tmpDir, err := os.MkdirTemp("", "cubemaster-skopeo-auth-*")
+	if err != nil {
+		return "", nil, err
+	}
+	cleanup := func() {
+		_ = os.RemoveAll(tmpDir)
+	}
+	authPayload := map[string]any{
+		"auths": map[string]any{
+			registryHostFromImageRef(imageRef): map[string]string{
+				"auth": base64.StdEncoding.EncodeToString([]byte(username + ":" + password)),
+			},
+		},
+	}
+	payload, err := json.Marshal(authPayload)
+	if err != nil {
+		cleanup()
+		return "", nil, err
+	}
+	authFile := filepath.Join(tmpDir, "auth.json")
+	if err := os.WriteFile(authFile, payload, 0o600); err != nil {
+		cleanup()
+		return "", nil, err
+	}
+	return authFile, cleanup, nil
+}
+
+func skopeoImageDigest(info skopeoInspectImage, imageRef string) string {
+	if info.Digest == "" {
+		return ""
+	}
+	name := info.Name
+	if name == "" {
+		name = imageNameWithoutTagDigest(imageRef)
+	}
+	if name == "" {
+		return info.Digest
+	}
+	return name + "@" + info.Digest
+}
+
+func ociLayoutImageRef(ociDir, imageRef string) string {
+	tag := imageTagFromRef(imageRef)
+	if tag == "" {
+		return ociDir
+	}
+	return ociDir + ":" + tag
+}
+
+// splitImageRef strips the docker:// transport prefix and any @digest suffix,
+// then splits the remainder into the repository name and the tag. The final
+// ":" is only treated as a tag separator when it appears after the last "/", so
+// a registry port (e.g. registry:5000/image) is not mistaken for a tag. When
+// the reference carries no tag, name is the whole remainder and tag is empty.
+func splitImageRef(imageRef string) (name, tag string) {
+	imageRef = strings.TrimPrefix(imageRef, "docker://")
+	if digestIndex := strings.LastIndex(imageRef, "@"); digestIndex >= 0 {
+		imageRef = imageRef[:digestIndex]
+	}
+	lastSlash := strings.LastIndex(imageRef, "/")
+	lastColon := strings.LastIndex(imageRef, ":")
+	if lastColon > lastSlash {
+		return imageRef[:lastColon], imageRef[lastColon+1:]
+	}
+	return imageRef, ""
+}
+
+func imageTagFromRef(imageRef string) string {
+	_, tag := splitImageRef(imageRef)
+	return tag
+}
+
+func imageNameWithoutTagDigest(imageRef string) string {
+	name, _ := splitImageRef(imageRef)
+	return name
+}
+
+func dockerExportImageRootfs(ctx context.Context, source *resolvedSourceImage, destRootfsDir string) error {
 	containerIDBytes, err := dockerOutput(ctx, "", "create", "--", source.localRef)
 	if err != nil {
 		return fmt.Errorf("docker create %s failed: %w", source.localRef, err)
@@ -2132,6 +2453,24 @@ func dockerOutput(ctx context.Context, configDir string, args ...string) ([]byte
 	return output, nil
 }
 
+func skopeoOutput(ctx context.Context, authFile string, args ...string) ([]byte, error) {
+	// skopeo expects global-ish flags such as --authfile to follow the
+	// subcommand (e.g. `skopeo inspect --authfile X docker://...`).
+	cmdArgs := make([]string, 0, len(args)+2)
+	if authFile != "" && len(args) > 0 {
+		cmdArgs = append(cmdArgs, args[0], "--authfile", authFile)
+		cmdArgs = append(cmdArgs, args[1:]...)
+	} else {
+		cmdArgs = append(cmdArgs, args...)
+	}
+	cmd := exec.CommandContext(ctx, "skopeo", cmdArgs...)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return nil, fmt.Errorf("%w: %s", err, strings.TrimSpace(string(output)))
+	}
+	return output, nil
+}
+
 func runCommand(ctx context.Context, dir, name string, args ...string) error {
 	cmd := exec.CommandContext(ctx, name, args...)
 	if dir != "" {
@@ -2303,11 +2642,56 @@ func getFileBlockSize(path string) int64 {
 	return stat.Blocks * 512
 }
 
-// estimateImageSizeFromInspect extracts an approximate image size from the
-// per-image cumulative Size field in docker inspect output.  A 4x multiplier
-// accounts for the expansion from the on-disk layer size to rootfs data, ext4
-// overhead, and temporary workspace.
+const (
+	// dockerInspectSizeMultiplier expands the uncompressed on-disk image size
+	// reported by `docker image inspect` to account for rootfs data, ext4
+	// overhead, and temporary workspace.
+	dockerInspectSizeMultiplier = 4
+	// skopeoInspectSizeMultiplier expands the *compressed* layer size reported
+	// by `skopeo inspect` (LayersData[].Size). Compressed layers typically
+	// decompress ~2-3x; the extra headroom covers ext4 overhead and temporary
+	// workspace, mirroring dockerInspectSizeMultiplier on top of decompression.
+	skopeoInspectSizeMultiplier = 8
+)
+
+// skopeoLayersTotalSize sums the compressed layer blob sizes from a
+// `skopeo inspect` result. Returns 0 when no LayersData is present.
+func skopeoLayersTotalSize(info skopeoInspectImage) int64 {
+	var total int64
+	for _, layer := range info.LayersData {
+		if layer.Size > 0 {
+			total += layer.Size
+		}
+	}
+	return total
+}
+
+// estimateImageSizeFromInspect returns an approximate on-disk size for the
+// source image, used for the disk-space pre-check and Phase 2 ext4 sizing.
+//
+// The dockerless path (skopeo+umoci) must not depend on the docker binary, so
+// it derives the estimate from the compressed layer sizes captured at prepare
+// time via `skopeo inspect`. The docker path keeps using the per-image
+// cumulative Size field from `docker image inspect`.
 func estimateImageSizeFromInspect(ctx context.Context, source *resolvedSourceImage) (int64, error) {
+	if source != nil && source.useDockerless {
+		return estimateImageSizeFromSkopeo(source)
+	}
+	return estimateImageSizeFromDocker(ctx, source)
+}
+
+// estimateImageSizeFromSkopeo derives the estimate from the compressed layer
+// sizes captured by `skopeo inspect`, avoiding any docker invocation.
+func estimateImageSizeFromSkopeo(source *resolvedSourceImage) (int64, error) {
+	if source == nil || source.compressedSizeBytes <= 0 {
+		return 0, fmt.Errorf("skopeo inspect did not report any layer sizes for %s", sourceRefForLog(source))
+	}
+	return source.compressedSizeBytes * skopeoInspectSizeMultiplier, nil
+}
+
+// estimateImageSizeFromDocker extracts an approximate image size from the
+// per-image cumulative Size field in docker inspect output.
+func estimateImageSizeFromDocker(ctx context.Context, source *resolvedSourceImage) (int64, error) {
 	// Try the per-image cumulative Size field first (fast, single call).
 	out, err := dockerOutput(ctx, "", "image", "inspect", "--format", "{{.Size}}", "--", source.localRef)
 	if err != nil {
@@ -2321,9 +2705,16 @@ func estimateImageSizeFromInspect(ctx context.Context, source *resolvedSourceIma
 		return 0, fmt.Errorf("docker image inspect reported zero or negative size (%d bytes)", sizeBytes)
 	}
 	// RootFS data plus writable layer overhead typically expands 3-4x from the
-	// on-disk layer size. Use a conservative 4x multiplier for the disk-space
+	// on-disk layer size. Use a conservative multiplier for the disk-space
 	// pre-check.
-	return sizeBytes * 4, nil
+	return sizeBytes * dockerInspectSizeMultiplier, nil
+}
+
+func sourceRefForLog(source *resolvedSourceImage) string {
+	if source == nil {
+		return "<nil>"
+	}
+	return source.localRef
 }
 
 // createExt4ImageStreaming uses loop-mount to stream docker export directly into
@@ -2540,6 +2931,7 @@ func artifactRootHostHint() string {
 }
 
 func registryHostFromImageRef(imageRef string) string {
+	imageRef = strings.TrimPrefix(imageRef, "docker://")
 	parts := strings.Split(imageRef, "/")
 	if len(parts) == 0 {
 		return "docker.io"
@@ -2651,9 +3043,14 @@ func detachTemplateImageJobContext(ctx context.Context, fields map[string]any) c
 }
 
 func ensureArtifactBuildPreflight(ctx context.Context) error {
-	requiredCommands := []string{"docker", "mkfs.ext4", "tar", "truncate", "cp"}
+	requiredCommands := []string{"mkfs.ext4", "truncate", "cp"}
+	if hasDockerlessRootfsExportTools() {
+		requiredCommands = append(requiredCommands, "skopeo", "umoci")
+	} else {
+		requiredCommands = append(requiredCommands, "docker", "tar")
+	}
 	for _, cmd := range requiredCommands {
-		if _, err := exec.LookPath(cmd); err != nil {
+		if _, err := executableLookPath(cmd); err != nil {
 			return fmt.Errorf("required command %q is not available on cubemaster node", cmd)
 		}
 	}

--- a/CubeMaster/pkg/templatecenter/template_image_test.go
+++ b/CubeMaster/pkg/templatecenter/template_image_test.go
@@ -6,6 +6,7 @@ package templatecenter
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"os"
@@ -34,6 +35,23 @@ func withTemplateImageConfig(t *testing.T, cfg *config.Config) {
 	t.Cleanup(func() {
 		getTemplateImageConfig = original
 	})
+}
+
+func withExecutableLookPath(t *testing.T, fn func(string) (string, error)) {
+	t.Helper()
+	original := executableLookPath
+	executableLookPath = fn
+	t.Cleanup(func() {
+		executableLookPath = original
+	})
+}
+
+func installFakeCommand(t *testing.T, dir, name, body string) {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte("#!/bin/sh\n"+body+"\n"), 0o755); err != nil {
+		t.Fatalf("install fake command %s failed: %v", name, err)
+	}
 }
 
 func TestNormalizeTemplateImageRequestDefaults(t *testing.T) {
@@ -492,6 +510,9 @@ func TestGenerateTemplateCreateRequestAppliesDNSConfigOverride(t *testing.T) {
 func TestPrepareSourceImageSkipsPullWhenImageExistsLocally(t *testing.T) {
 	patches := gomonkey.NewPatches()
 	defer patches.Reset()
+	withExecutableLookPath(t, func(file string) (string, error) {
+		return "", errors.New("not found")
+	})
 
 	inspectCalls := 0
 	inspectPayload := `[{"RepoDigests":["docker.io/library/nginx@sha256:abcd"],"Config":{"Env":["A=B"],"WorkingDir":"/workspace"}}]`
@@ -525,6 +546,9 @@ func TestPrepareSourceImageSkipsPullWhenImageExistsLocally(t *testing.T) {
 func TestPrepareSourceImagePullsAfterLocalInspectMiss(t *testing.T) {
 	patches := gomonkey.NewPatches()
 	defer patches.Reset()
+	withExecutableLookPath(t, func(file string) (string, error) {
+		return "", errors.New("not found")
+	})
 
 	inspectCalls := 0
 	pullCalled := false
@@ -566,6 +590,9 @@ func TestPrepareSourceImagePullsAfterLocalInspectMiss(t *testing.T) {
 func TestPrepareSourceImageReturnsPullErrorAfterInspectMiss(t *testing.T) {
 	patches := gomonkey.NewPatches()
 	defer patches.Reset()
+	withExecutableLookPath(t, func(file string) (string, error) {
+		return "", errors.New("not found")
+	})
 
 	inspectCalls := 0
 	patches.ApplyFunc(dockerOutput, func(ctx context.Context, configDir string, args ...string) ([]byte, error) {
@@ -591,6 +618,593 @@ func TestPrepareSourceImageReturnsPullErrorAfterInspectMiss(t *testing.T) {
 	}
 	if inspectCalls != 1 {
 		t.Fatalf("expected 1 inspect call before pull failure, got %d", inspectCalls)
+	}
+}
+
+func TestPrepareSourceImageUsesSkopeoWhenDockerlessToolsAvailable(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+	withExecutableLookPath(t, func(file string) (string, error) {
+		if file == "skopeo" || file == "umoci" {
+			return "/usr/bin/" + file, nil
+		}
+		return "", errors.New("not found")
+	})
+
+	var calls [][]string
+	patches.ApplyFunc(skopeoOutput, func(ctx context.Context, authFile string, args ...string) ([]byte, error) {
+		calls = append(calls, append([]string(nil), args...))
+		if len(args) == 2 && args[0] == "inspect" {
+			return []byte(`{"Name":"docker.io/library/nginx","Digest":"sha256:abcd"}`), nil
+		}
+		if len(args) == 3 && args[0] == "inspect" && args[1] == "--config" {
+			return []byte(`{"config":{"Env":["A=B"],"WorkingDir":"/workspace","Cmd":["nginx"]}}`), nil
+		}
+		t.Fatalf("unexpected skopeoOutput args=%v", args)
+		return nil, nil
+	})
+	patches.ApplyFunc(dockerOutput, func(ctx context.Context, configDir string, args ...string) ([]byte, error) {
+		t.Fatal("dockerOutput should not be called when dockerless tools are available")
+		return nil, nil
+	})
+
+	got, err := prepareSourceImage(context.Background(), &types.CreateTemplateFromImageReq{
+		SourceImageRef: "docker.io/library/nginx:1.27",
+	}, "http://master.example")
+	if err != nil {
+		t.Fatalf("prepareSourceImage failed: %v", err)
+	}
+	wantCalls := [][]string{
+		{"inspect", "docker://docker.io/library/nginx:1.27"},
+		{"inspect", "--config", "docker://docker.io/library/nginx:1.27"},
+	}
+	if !reflect.DeepEqual(calls, wantCalls) {
+		t.Fatalf("unexpected skopeo calls: got %#v want %#v", calls, wantCalls)
+	}
+	if got.digest != "docker.io/library/nginx@sha256:abcd" {
+		t.Fatalf("unexpected digest: %q", got.digest)
+	}
+	if got.config.WorkingDir != "/workspace" || !reflect.DeepEqual(got.config.Cmd, []string{"nginx"}) {
+		t.Fatalf("unexpected image config: %#v", got.config)
+	}
+}
+
+func TestExportImageRootfsUsesDockerlessSkopeoUmociWhenAvailable(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	workDir := t.TempDir()
+	rootfsDir := filepath.Join(workDir, "rootfs")
+	if err := os.MkdirAll(rootfsDir, 0o755); err != nil {
+		t.Fatalf("prepare rootfs dir failed: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(rootfsDir, "old"), []byte("old"), 0o644); err != nil {
+		t.Fatalf("prepare stale rootfs file failed: %v", err)
+	}
+
+	type commandCall struct {
+		dir  string
+		name string
+		args []string
+	}
+	var calls []commandCall
+	patches.ApplyFunc(runCommand, func(ctx context.Context, dir, name string, args ...string) error {
+		calls = append(calls, commandCall{
+			dir:  dir,
+			name: name,
+			args: append([]string(nil), args...),
+		})
+		if name == "umoci" {
+			bundleDir := args[len(args)-1]
+			unpackedRootfsDir := filepath.Join(bundleDir, "rootfs")
+			if err := os.MkdirAll(unpackedRootfsDir, 0o755); err != nil {
+				return err
+			}
+			return os.WriteFile(filepath.Join(unpackedRootfsDir, "etc-release"), []byte("ok"), 0o644)
+		}
+		return nil
+	})
+	patches.ApplyFunc(dockerOutput, func(ctx context.Context, configDir string, args ...string) ([]byte, error) {
+		t.Fatal("dockerOutput should not be called by default rootfs export")
+		return nil, nil
+	})
+
+	source := &resolvedSourceImage{
+		localRef:      "cube-sandbox-cn.tencentcloudcr.com/cube-sandbox/sandbox-code:v1.2.3",
+		useDockerless: true,
+	}
+	if err := exportImageRootfs(context.Background(), source, rootfsDir); err != nil {
+		t.Fatalf("exportImageRootfs failed: %v", err)
+	}
+
+	if len(calls) != 2 {
+		t.Fatalf("unexpected command calls: %#v", calls)
+	}
+	if calls[0].name != "skopeo" {
+		t.Fatalf("first command=%q, want skopeo", calls[0].name)
+	}
+	if len(calls[0].args) != 3 || calls[0].args[0] != "copy" || calls[0].args[1] != "docker://cube-sandbox-cn.tencentcloudcr.com/cube-sandbox/sandbox-code:v1.2.3" {
+		t.Fatalf("unexpected skopeo args: %#v", calls[0].args)
+	}
+	ociImageRef := strings.TrimPrefix(calls[0].args[2], "oci:")
+	ociDir := strings.TrimSuffix(ociImageRef, ":v1.2.3")
+	if ociImageRef == calls[0].args[2] || ociDir == ociImageRef || filepath.Base(ociDir) != "image" || filepath.Dir(filepath.Dir(ociDir)) != workDir {
+		t.Fatalf("unexpected OCI image ref: %q", calls[0].args[2])
+	}
+	wantUmociArgs := []string{
+		"unpack",
+		"--rootless",
+		"--image",
+		ociDir + ":v1.2.3",
+		filepath.Join(filepath.Dir(ociDir), "bundle"),
+	}
+	if calls[1].name != "umoci" || !reflect.DeepEqual(calls[1].args, wantUmociArgs) {
+		t.Fatalf("unexpected umoci call: %#v", calls[1])
+	}
+	if _, err := os.Stat(filepath.Join(rootfsDir, "etc-release")); err != nil {
+		t.Fatalf("expected unpacked rootfs file: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(rootfsDir, "old")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("expected stale rootfs file to be removed, stat err=%v", err)
+	}
+}
+
+func TestExportImageRootfsUsesDockerPathWhenSourceNotDockerless(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	dockerExportCalled := false
+	patches.ApplyFunc(dockerlessExportImageRootfs, func(ctx context.Context, source *resolvedSourceImage, destRootfsDir string) error {
+		t.Fatal("dockerlessExportImageRootfs should not be called when source was not prepared dockerless")
+		return nil
+	})
+	patches.ApplyFunc(dockerExportImageRootfs, func(ctx context.Context, source *resolvedSourceImage, destRootfsDir string) error {
+		dockerExportCalled = true
+		return nil
+	})
+
+	// useDockerless is false, so the export must honor the docker path chosen at
+	// prepare time even if skopeo/umoci happen to be installed.
+	if err := exportImageRootfs(context.Background(), &resolvedSourceImage{localRef: "example.com/app:latest"}, t.TempDir()); err != nil {
+		t.Fatalf("exportImageRootfs failed: %v", err)
+	}
+	if !dockerExportCalled {
+		t.Fatal("expected docker export path to be used")
+	}
+}
+
+func TestExportImageRootfsRejectsInjectableImageRef(t *testing.T) {
+	err := exportImageRootfs(context.Background(), &resolvedSourceImage{localRef: "-rm -rf"}, t.TempDir())
+	if err == nil || !strings.Contains(err.Error(), "invalid image reference") {
+		t.Fatalf("expected invalid image reference error, got %v", err)
+	}
+}
+
+func TestExportImageRootfsPassesAuthFileToSkopeoCopy(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	workDir := t.TempDir()
+	rootfsDir := filepath.Join(workDir, "rootfs")
+
+	var skopeoArgs []string
+	patches.ApplyFunc(runCommand, func(ctx context.Context, dir, name string, args ...string) error {
+		if name == "skopeo" {
+			skopeoArgs = append([]string(nil), args...)
+		}
+		if name == "umoci" {
+			bundleDir := args[len(args)-1]
+			return os.MkdirAll(filepath.Join(bundleDir, "rootfs"), 0o755)
+		}
+		return nil
+	})
+
+	source := &resolvedSourceImage{
+		localRef:       "example.com/app:latest",
+		useDockerless:  true,
+		skopeoAuthFile: "/tmp/auth-xyz/auth.json",
+	}
+	if err := exportImageRootfs(context.Background(), source, rootfsDir); err != nil {
+		t.Fatalf("exportImageRootfs failed: %v", err)
+	}
+	want := []string{"copy", "--authfile", "/tmp/auth-xyz/auth.json", "docker://example.com/app:latest"}
+	if len(skopeoArgs) != 5 || !reflect.DeepEqual(skopeoArgs[:4], want) {
+		t.Fatalf("expected skopeo copy to receive --authfile, got %#v", skopeoArgs)
+	}
+}
+
+func TestCreateSkopeoAuthFileWritesScopedCredentials(t *testing.T) {
+	authFile, cleanup, err := createSkopeoAuthFile("docker://example.com:5000/ns/app:tag", "alice", "s3cret")
+	if err != nil {
+		t.Fatalf("createSkopeoAuthFile failed: %v", err)
+	}
+	defer cleanup()
+
+	info, err := os.Stat(authFile)
+	if err != nil {
+		t.Fatalf("stat auth file: %v", err)
+	}
+	if perm := info.Mode().Perm(); perm != 0o600 {
+		t.Fatalf("auth file mode = %o, want 0600", perm)
+	}
+
+	raw, err := os.ReadFile(authFile) // NOCC:Path Traversal()
+	if err != nil {
+		t.Fatalf("read auth file: %v", err)
+	}
+	var payload struct {
+		Auths map[string]struct {
+			Auth string `json:"auth"`
+		} `json:"auths"`
+	}
+	if err := json.Unmarshal(raw, &payload); err != nil {
+		t.Fatalf("unmarshal auth file: %v", err)
+	}
+	entry, ok := payload.Auths["example.com:5000"]
+	if !ok {
+		t.Fatalf("auth file missing registry host key, got %#v", payload.Auths)
+	}
+	if entry.Auth != base64.StdEncoding.EncodeToString([]byte("alice:s3cret")) {
+		t.Fatalf("unexpected auth value: %q", entry.Auth)
+	}
+
+	cleanup()
+	if _, err := os.Stat(authFile); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("expected auth file removed after cleanup, stat err=%v", err)
+	}
+}
+
+func TestCreateSkopeoAuthFileNoCredentials(t *testing.T) {
+	authFile, cleanup, err := createSkopeoAuthFile("example.com/app:tag", "", "")
+	if err != nil {
+		t.Fatalf("createSkopeoAuthFile failed: %v", err)
+	}
+	if authFile != "" {
+		t.Fatalf("expected empty auth file path, got %q", authFile)
+	}
+	if cleanup == nil {
+		t.Fatal("expected non-nil cleanup func")
+	}
+	cleanup() // must be a safe no-op
+}
+
+func TestPrepareDockerlessSourceImageCleansAuthFileOnInspectFailure(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+	withExecutableLookPath(t, func(file string) (string, error) {
+		if file == "skopeo" || file == "umoci" {
+			return "/usr/bin/" + file, nil
+		}
+		return "", errors.New("not found")
+	})
+
+	cleanupCalled := false
+	patches.ApplyFunc(createSkopeoAuthFile, func(imageRef, username, password string) (string, func(), error) {
+		return "/tmp/fake-auth/auth.json", func() { cleanupCalled = true }, nil
+	})
+	patches.ApplyFunc(skopeoOutput, func(ctx context.Context, authFile string, args ...string) ([]byte, error) {
+		return nil, errors.New("inspect boom")
+	})
+
+	_, err := prepareSourceImage(context.Background(), &types.CreateTemplateFromImageReq{
+		SourceImageRef:   "example.com/app:tag",
+		RegistryUsername: "alice",
+		RegistryPassword: "s3cret",
+	}, "http://master.example")
+	if err == nil || !strings.Contains(err.Error(), "skopeo inspect") {
+		t.Fatalf("expected skopeo inspect error, got %v", err)
+	}
+	if !cleanupCalled {
+		t.Fatal("expected auth file cleanup on inspect failure")
+	}
+}
+
+func TestSkopeoOutputInsertsAuthFileAfterSubcommand(t *testing.T) {
+	binDir := t.TempDir()
+	t.Setenv("PATH", binDir)
+	installFakeCommand(t, binDir, "skopeo", `printf '%s\n' "$*"`)
+
+	out, err := skopeoOutput(context.Background(), "/tmp/auth.json", "inspect", "docker://example.com/app:latest")
+	if err != nil {
+		t.Fatalf("skopeoOutput failed: %v", err)
+	}
+	if got := strings.TrimSpace(string(out)); got != "inspect --authfile /tmp/auth.json docker://example.com/app:latest" {
+		t.Fatalf("unexpected skopeo arg ordering: %q", got)
+	}
+}
+
+func TestSkopeoOutputOmitsAuthFileWhenEmpty(t *testing.T) {
+	binDir := t.TempDir()
+	t.Setenv("PATH", binDir)
+	installFakeCommand(t, binDir, "skopeo", `printf '%s\n' "$*"`)
+
+	out, err := skopeoOutput(context.Background(), "", "inspect", "docker://example.com/app:latest")
+	if err != nil {
+		t.Fatalf("skopeoOutput failed: %v", err)
+	}
+	if got := strings.TrimSpace(string(out)); got != "inspect docker://example.com/app:latest" {
+		t.Fatalf("unexpected skopeo args: %q", got)
+	}
+}
+
+func TestSkopeoImageDigest(t *testing.T) {
+	tests := []struct {
+		name     string
+		info     skopeoInspectImage
+		imageRef string
+		want     string
+	}{
+		{
+			name:     "empty digest yields empty",
+			info:     skopeoInspectImage{Name: "example.com/app"},
+			imageRef: "example.com/app:tag",
+			want:     "",
+		},
+		{
+			name:     "prefers name from inspect output",
+			info:     skopeoInspectImage{Name: "example.com/app", Digest: "sha256:abcd"},
+			imageRef: "ignored:tag",
+			want:     "example.com/app@sha256:abcd",
+		},
+		{
+			name:     "falls back to ref name without tag",
+			info:     skopeoInspectImage{Digest: "sha256:abcd"},
+			imageRef: "example.com:5000/ns/app:tag",
+			want:     "example.com:5000/ns/app@sha256:abcd",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := skopeoImageDigest(tt.info, tt.imageRef); got != tt.want {
+				t.Fatalf("skopeoImageDigest()=%q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSkopeoLayersTotalSize(t *testing.T) {
+	info := skopeoInspectImage{
+		LayersData: []skopeoInspectLayer{
+			{Size: 100},
+			{Size: 250},
+			{Size: -5}, // ignored
+			{Size: 0},  // ignored
+		},
+	}
+	if got := skopeoLayersTotalSize(info); got != 350 {
+		t.Fatalf("skopeoLayersTotalSize()=%d, want 350", got)
+	}
+	if got := skopeoLayersTotalSize(skopeoInspectImage{}); got != 0 {
+		t.Fatalf("skopeoLayersTotalSize(empty)=%d, want 0", got)
+	}
+}
+
+func TestEstimateImageSizeFromInspectDockerlessUsesSkopeoSize(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	patches.ApplyFunc(dockerOutput, func(ctx context.Context, configDir string, args ...string) ([]byte, error) {
+		t.Fatal("dockerOutput must not be called for dockerless size estimation")
+		return nil, nil
+	})
+
+	source := &resolvedSourceImage{
+		localRef:            "example.com/app:latest",
+		useDockerless:       true,
+		compressedSizeBytes: 1000,
+	}
+	got, err := estimateImageSizeFromInspect(context.Background(), source)
+	if err != nil {
+		t.Fatalf("estimateImageSizeFromInspect failed: %v", err)
+	}
+	if want := int64(1000 * skopeoInspectSizeMultiplier); got != want {
+		t.Fatalf("estimateImageSizeFromInspect()=%d, want %d", got, want)
+	}
+}
+
+func TestEstimateImageSizeFromInspectDockerlessMissingSize(t *testing.T) {
+	source := &resolvedSourceImage{
+		localRef:      "example.com/app:latest",
+		useDockerless: true,
+	}
+	if _, err := estimateImageSizeFromInspect(context.Background(), source); err == nil {
+		t.Fatal("expected error when skopeo reports no layer sizes")
+	}
+}
+
+func TestEstimateImageSizeFromInspectDockerPath(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	patches.ApplyFunc(dockerOutput, func(ctx context.Context, configDir string, args ...string) ([]byte, error) {
+		return []byte("500\n"), nil
+	})
+
+	source := &resolvedSourceImage{localRef: "example.com/app:latest"}
+	got, err := estimateImageSizeFromInspect(context.Background(), source)
+	if err != nil {
+		t.Fatalf("estimateImageSizeFromInspect failed: %v", err)
+	}
+	if want := int64(500 * dockerInspectSizeMultiplier); got != want {
+		t.Fatalf("estimateImageSizeFromInspect()=%d, want %d", got, want)
+	}
+}
+
+func TestRegistryHostFromImageRefStripsDockerTransport(t *testing.T) {
+	if got := registryHostFromImageRef("docker://example.com:5000/ns/app:tag"); got != "example.com:5000" {
+		t.Fatalf("registryHostFromImageRef()=%q, want example.com:5000", got)
+	}
+	if got := registryHostFromImageRef("library/nginx:latest"); got != "docker.io" {
+		t.Fatalf("registryHostFromImageRef()=%q, want docker.io", got)
+	}
+}
+
+func TestSkopeoDockerImageRefKeepsExistingTransport(t *testing.T) {
+	got := skopeoDockerImageRef("docker://example.com/app:latest")
+	if got != "docker://example.com/app:latest" {
+		t.Fatalf("skopeoDockerImageRef()=%q", got)
+	}
+}
+
+func TestValidateImageRef(t *testing.T) {
+	valid := []string{
+		"docker://registry.example.com/image:latest",
+		"registry.example.com:5000/ns/app:1.2.3",
+		"library/nginx",
+		"library/nginx@sha256:" + strings.Repeat("a", 64),
+		"reg.io/my_app.name/sub-component:tag_1.0",
+	}
+	for _, ref := range valid {
+		if err := validateImageRef(ref); err != nil {
+			t.Errorf("validateImageRef(%q) returned error, want nil: %v", ref, err)
+		}
+	}
+
+	invalid := []string{
+		"",
+		"docker://",
+		"-rm -rf",
+		"--authfile=/etc/shadow",
+		"registry.example.com/image --authfile /etc/shadow",
+		"registry.example.com/image\t--flag",
+		"registry.example.com/image\n--flag",
+		"image;rm -rf /",
+		"image$(whoami)",
+		"image`whoami`",
+	}
+	for _, ref := range invalid {
+		if err := validateImageRef(ref); err == nil {
+			t.Errorf("validateImageRef(%q) returned nil, want error", ref)
+		}
+	}
+}
+
+func TestSplitImageRef(t *testing.T) {
+	tests := []struct {
+		name     string
+		imageRef string
+		wantName string
+		wantTag  string
+	}{
+		{
+			name:     "no colon",
+			imageRef: "library/nginx",
+			wantName: "library/nginx",
+			wantTag:  "",
+		},
+		{
+			name:     "port but no tag",
+			imageRef: "registry:5000/image",
+			wantName: "registry:5000/image",
+			wantTag:  "",
+		},
+		{
+			name:     "port with tag",
+			imageRef: "registry:5000/image:v1",
+			wantName: "registry:5000/image",
+			wantTag:  "v1",
+		},
+		{
+			name:     "tag and digest after docker prefix",
+			imageRef: "docker://example.com/ns/app:stable@sha256:abcd",
+			wantName: "example.com/ns/app",
+			wantTag:  "stable",
+		},
+		{
+			name:     "digest without tag",
+			imageRef: "example.com/ns/app@sha256:abcd",
+			wantName: "example.com/ns/app",
+			wantTag:  "",
+		},
+		{
+			name:     "bare name with tag",
+			imageRef: "nginx:latest",
+			wantName: "nginx",
+			wantTag:  "latest",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotName, gotTag := splitImageRef(tt.imageRef)
+			if gotName != tt.wantName || gotTag != tt.wantTag {
+				t.Fatalf("splitImageRef(%q)=(%q,%q), want (%q,%q)",
+					tt.imageRef, gotName, gotTag, tt.wantName, tt.wantTag)
+			}
+			if got := imageTagFromRef(tt.imageRef); got != tt.wantTag {
+				t.Fatalf("imageTagFromRef(%q)=%q, want %q", tt.imageRef, got, tt.wantTag)
+			}
+			if got := imageNameWithoutTagDigest(tt.imageRef); got != tt.wantName {
+				t.Fatalf("imageNameWithoutTagDigest(%q)=%q, want %q", tt.imageRef, got, tt.wantName)
+			}
+		})
+	}
+}
+
+func TestOciLayoutImageRefUsesExplicitSourceTag(t *testing.T) {
+	tests := []struct {
+		name     string
+		imageRef string
+		want     string
+	}{
+		{
+			name:     "tagged image",
+			imageRef: "example.com/app:v1.2.3",
+			want:     "/tmp/image:v1.2.3",
+		},
+		{
+			name:     "registry port with tag",
+			imageRef: "example.com:5000/ns/app:release",
+			want:     "/tmp/image:release",
+		},
+		{
+			name:     "digest with tag",
+			imageRef: "docker://example.com/ns/app:stable@sha256:abcd",
+			want:     "/tmp/image:stable",
+		},
+		{
+			name:     "untagged image",
+			imageRef: "example.com/ns/app",
+			want:     "/tmp/image",
+		},
+		{
+			name:     "digest without tag",
+			imageRef: "example.com/ns/app@sha256:abcd",
+			want:     "/tmp/image",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ociLayoutImageRef("/tmp/image", tt.imageRef)
+			if got != tt.want {
+				t.Fatalf("ociLayoutImageRef()=%q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestEnsureArtifactBuildPreflightAllowsDockerlessWithoutDockerOrTar(t *testing.T) {
+	binDir := t.TempDir()
+	t.Setenv("PATH", binDir)
+	for _, cmd := range []string{"truncate", "cp", "skopeo", "umoci"} {
+		installFakeCommand(t, binDir, cmd, "exit 0")
+	}
+	installFakeCommand(t, binDir, "mkfs.ext4", "echo 'mkfs.ext4 help supports -d'")
+
+	if err := ensureArtifactBuildPreflight(context.Background()); err != nil {
+		t.Fatalf("ensureArtifactBuildPreflight failed: %v", err)
+	}
+}
+
+func TestEnsureArtifactBuildPreflightRequiresTarForDockerFallback(t *testing.T) {
+	binDir := t.TempDir()
+	t.Setenv("PATH", binDir)
+	for _, cmd := range []string{"docker", "mkfs.ext4", "truncate", "cp", "skopeo"} {
+		installFakeCommand(t, binDir, cmd, "exit 0")
+	}
+
+	err := ensureArtifactBuildPreflight(context.Background())
+	if err == nil || !strings.Contains(err.Error(), `required command "tar"`) {
+		t.Fatalf("unexpected preflight error: %v", err)
 	}
 }
 


### PR DESCRIPTION
feat(CubeMaster): support daemonless template image export via skopeo/umoci

Building template images previously required a Docker daemon on the
cubemaster node to pull source images and export their root filesystem.
This adds an alternative, daemonless path that uses skopeo and umoci when
both are available, and falls back to Docker otherwise so existing
deployments keep working unchanged.

Running without a privileged Docker daemon reduces the node's attack
surface and runtime dependencies, and makes template builds easier to run
in restricted or rootless environments. The export strategy is chosen once
when the source image is resolved, so preparation and export stay
consistent.

Assisted-by: Cursor:claude-opus-4.8
Signed-off-by: Like Xu <likexu@tencent.com>