### PR TITLE
feat(release): standardize version injection across all components

### DIFF
--- a/.github/workflows/release-one-click.yml
+++ b/.github/workflows/release-one-click.yml
@@ -274,15 +274,15 @@ jobs:
 
       - name: Build one-click release bundle
         env:
-          # Align the dashboard's displayed version with the release tag; the
-          # value propagates to the web build (vite reads CUBE_RELEASE_VERSION).
+          # Propagates to Go ldflags, Rust build.rs, web build, and guest-image version.
           CUBE_RELEASE_VERSION: ${{ github.ref_name }}
+          ONE_CLICK_DIST_VERSION: ${{ github.ref_name }}
         run: ./deploy/one-click/build-release-bundle-builder.sh
 
       - name: Resolve bundle path
         id: bundle
         run: |
-          bundle_path="deploy/one-click/dist/cube-sandbox-one-click-$(git rev-parse --short HEAD).tar.gz"
+          bundle_path="deploy/one-click/dist/cube-sandbox-one-click-${{ github.ref_name }}.tar.gz"
           test -f "${bundle_path}"
           echo "path=${bundle_path}" >> "${GITHUB_OUTPUT}"
 

--- a/CubeAPI/Cargo.toml
+++ b/CubeAPI/Cargo.toml
@@ -5,6 +5,7 @@
 name = "cube-api"
 version = "0.1.0"
 edition = "2021"
+build = "build.rs"
 
 [[bin]]
 name = "cube-api"

--- a/CubeAPI/build.rs
+++ b/CubeAPI/build.rs
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2026 Tencent. All rights reserved.
+
+fn main() {
+    let version = std::env::var("CUBE_VERSION").unwrap_or_else(|_| "0.0.0-dev".to_string());
+    let commit = std::env::var("CUBE_COMMIT").unwrap_or_else(|_| "unknown".to_string());
+    let build_time =
+        std::env::var("CUBE_BUILD_TIME").unwrap_or_else(|_| "unknown".to_string());
+
+    // Do NOT include the binary name — clap prepends it automatically.
+    let version_full = format!("{} ({}) built at {}", version, commit, build_time);
+
+    println!("cargo:rustc-env=CUBE_VERSION_FULL={}", version_full);
+    println!("cargo:rustc-env=CUBE_VERSION={}", version);
+    println!("cargo:rustc-env=CUBE_COMMIT={}", commit);
+    println!("cargo:rustc-env=CUBE_BUILD_TIME={}", build_time);
+    println!("cargo:rerun-if-env-changed=CUBE_VERSION");
+    println!("cargo:rerun-if-env-changed=CUBE_COMMIT");
+    println!("cargo:rerun-if-env-changed=CUBE_BUILD_TIME");
+}

--- a/CubeAPI/src/main.rs
+++ b/CubeAPI/src/main.rs
@@ -30,7 +30,7 @@ use tracing_subscriber::{fmt, prelude::*, EnvFilter};
 /// Most settings are controlled via environment variables; only the most
 /// commonly overridden ones are exposed as CLI flags.
 #[derive(Parser, Debug)]
-#[command(name = "cube-api", version, about, long_about = None)]
+#[command(name = "cube-api", version = env!("CUBE_VERSION_FULL"), about, long_about = None)]
 struct Cli {
     /// Enable debug log level (overrides LOG_LEVEL env var and config).
     ///

--- a/CubeMaster/Makefile
+++ b/CubeMaster/Makefile
@@ -32,16 +32,17 @@ PKG=github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base
 PROTO=services/errorcode services/cubebox services/images types
 
 
-# Version
-APP_VERSION=1.4.9
+# Version — injected at build time via ldflags.
+# Priority: env var CUBE_RELEASE_VERSION > git tag > hardcoded fallback.
+CUBE_VERSION ?= $(or $(CUBE_RELEASE_VERSION),$(shell git describe --tags --abbrev=0 --match 'v*' 2>/dev/null),0.0.0-dev)
+CUBE_COMMIT ?= $(or $(CUBE_RELEASE_COMMIT),$(shell git rev-parse HEAD 2>/dev/null),unknown)
+CUBE_BUILD_TIME ?= $(or $(CUBE_RELEASE_BUILD_TIME),$(shell date -u +'%Y-%m-%dT%H:%M:%SZ'))
 
-GO_VERSION=$(shell go version | awk '{print $$3}')
-GIT_COMMIT=$(shell git rev-parse --short HEAD)
-BUILD_DATE=$(shell date +'%Y%m%d-%H:%M:%S')
-PROTOC = $(shell protoc --version|awk '{print "protoc.v"$$2}')
-VERSION=$(APP_VERSION)-$(GIT_COMMIT)-$(BUILD_DATE)-$(GO_VERSION)-$(PROTOC)
 VERSION_PKG=$(PKG)/version
-BUILD_FLAGS=-ldflags "-X '$(VERSION_PKG).Version=$(VERSION)'"
+BUILD_FLAGS=-ldflags "-s -w \
+  -X '$(VERSION_PKG).Version=$(CUBE_VERSION)' \
+  -X '$(VERSION_PKG).Commit=$(CUBE_COMMIT)' \
+  -X '$(VERSION_PKG).BuildTime=$(CUBE_BUILD_TIME)'"
 DATE:=$(shell date +'%Y%m%d-%H%M%S')
 
 NAMESPACE?=cubemaster
@@ -49,8 +50,10 @@ QCI_ENV_FILE?=stage-v0.1.0
 IMG-Cube-Master=cube-master-v2
 OBJ-Cube-Master=cubemaster
 
-TAG?=release-$(APP_VERSION)-$(GIT_COMMIT)-$(DATE)
-DEVTAG?=dev-$(APP_VERSION)-$(GIT_COMMIT)-$(DATE)
+APP_VERSION ?= $(CUBE_VERSION)
+GIT_COMMIT_SHORT ?= $(shell echo $(CUBE_COMMIT) | cut -c1-7)
+TAG?=release-$(APP_VERSION)-$(GIT_COMMIT_SHORT)-$(DATE)
+DEVTAG?=dev-$(APP_VERSION)-$(GIT_COMMIT_SHORT)-$(DATE)
 # COVERAGE_PACKAGES is the coverage we care about.
 COVERAGE_PACKAGES=$(shell go list ./... \
 	| grep -v github.com/tencentcloud/CubeSandbox/CubeMaster/cmd )
@@ -70,7 +73,7 @@ check-proto-tools:
 
 $(APPS): deps
 	@echo "${GOOS}"
-	@echo "${VERSION}"
+	@echo "${CUBE_VERSION}"
 	$(call msg,Build app,$@)
 	$(Q)go build -o $(BUILD_DIR)/$@ \
 		$(BUILD_FLAGS) \

--- a/CubeMaster/cmd/cubemaster/main.go
+++ b/CubeMaster/cmd/cubemaster/main.go
@@ -14,14 +14,16 @@ import (
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/config"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/recov"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/version"
-	_ "go.uber.org/automaxprocs"
 )
 
-var versionFlag = flag.Bool("v", false, "show version")
+var (
+	versionFlag     = flag.Bool("v", false, "show version")
+	longVersionFlag = flag.Bool("version", false, "show version")
+)
 
 func main() {
 	flag.Parse()
-	if *versionFlag {
+	if *versionFlag || *longVersionFlag {
 		version.ShowAndExit(true)
 	}
 

--- a/CubeMaster/cmd/cubemastercli/app/main.go
+++ b/CubeMaster/cmd/cubemastercli/app/main.go
@@ -19,7 +19,7 @@ var extraCmds = []cli.Command{}
 
 func init() {
 	cli.VersionPrinter = func(c *cli.Context) {
-		fmt.Println(c.App.Name, pkgv.Package, c.App.Version)
+		fmt.Println(pkgv.VersionString("cubemastercli"))
 	}
 }
 

--- a/CubeMaster/cmd/cubemastercli/commands/version/version.go
+++ b/CubeMaster/cmd/cubemastercli/commands/version/version.go
@@ -6,7 +6,7 @@
 package version
 
 import (
-	"strings"
+	"fmt"
 
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/version"
 	"github.com/urfave/cli"
@@ -26,13 +26,13 @@ var Command = cli.Command{
 		},
 	},
 	Action: func(context *cli.Context) error {
-		var buf strings.Builder
+		if context.Bool("versiononly") {
+			fmt.Println(version.Version)
+			return nil
+		}
 		if context.Bool("withclient") {
-			buf.WriteString(version.ShowVersion() + "\n")
-			buf.WriteString("Client:" + "\n")
-			buf.WriteString("  Version: " + version.Version + "\n")
-			buf.WriteString("  Revision :" + version.Revision + "\n")
-			buf.WriteString("  Go version: " + version.GoVersion + "\n")
+			fmt.Println(version.VersionString("cubemastercli"))
+			fmt.Println("  Go version: " + version.GoVersion)
 		}
 		return nil
 	},

--- a/CubeMaster/pkg/base/version/version.go
+++ b/CubeMaster/pkg/base/version/version.go
@@ -12,7 +12,15 @@ import (
 )
 
 var (
-	Version = "release"
+	// Version is the semantic release version, injected at build time via ldflags.
+	// Falls back to "0.0.0-dev" when not set (e.g. local development builds).
+	Version = "0.0.0-dev"
+
+	// Commit is the full git commit SHA, injected at build time via ldflags.
+	Commit = "unknown"
+
+	// BuildTime is the UTC ISO 8601 build timestamp, injected at build time via ldflags.
+	BuildTime = "unknown"
 
 	Package = "github.com/tencentcloud/CubeSandbox/CubeMaster"
 
@@ -21,9 +29,14 @@ var (
 	GoVersion = runtime.Version()
 )
 
+// VersionString returns the unified version string for the given binary name.
+func VersionString(binaryName string) string {
+	return fmt.Sprintf("%s %s (%s) built at %s", binaryName, Version, Commit, BuildTime)
+}
+
 func ShowAndExit(show bool) {
 	if show {
-		fmt.Println("Version: " + Version)
+		fmt.Println(VersionString("cubemaster"))
 		os.Exit(0)
 	}
 }

--- a/CubeShim/cube-runtime/Cargo.toml
+++ b/CubeShim/cube-runtime/Cargo.toml
@@ -2,6 +2,7 @@
 name = "cube-runtime"
 version = "0.1.0"
 edition = "2021"
+build = "build.rs"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/CubeShim/cube-runtime/build.rs
+++ b/CubeShim/cube-runtime/build.rs
@@ -1,0 +1,21 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+fn main() {
+    let version = std::env::var("CUBE_VERSION").unwrap_or_else(|_| "0.0.0-dev".to_string());
+    let commit = std::env::var("CUBE_COMMIT").unwrap_or_else(|_| "unknown".to_string());
+    let build_time =
+        std::env::var("CUBE_BUILD_TIME").unwrap_or_else(|_| "unknown".to_string());
+
+    // Do NOT include the binary name — clap prepends it automatically.
+    let version_full = format!("{} ({}) built at {}", version, commit, build_time);
+
+    println!("cargo:rustc-env=CUBE_VERSION_FULL={}", version_full);
+    println!("cargo:rustc-env=CUBE_VERSION={}", version);
+    println!("cargo:rustc-env=CUBE_COMMIT={}", commit);
+    println!("cargo:rustc-env=CUBE_BUILD_TIME={}", build_time);
+    println!("cargo:rerun-if-env-changed=CUBE_VERSION");
+    println!("cargo:rerun-if-env-changed=CUBE_COMMIT");
+    println!("cargo:rerun-if-env-changed=CUBE_BUILD_TIME");
+}

--- a/CubeShim/cube-runtime/src/parser.rs
+++ b/CubeShim/cube-runtime/src/parser.rs
@@ -6,7 +6,7 @@ use clap::{Args, Parser, Subcommand};
 use containerd_shim_cube_rs::snapshot::cmd::SnapshotArgs;
 
 #[derive(Parser, Debug)]
-#[command(version, about, long_about = None)]
+#[command(version = env!("CUBE_VERSION_FULL"), about, long_about = None)]
 pub struct CliArgs {
     #[command(subcommand)]
     pub command: SubCommands,

--- a/CubeShim/shim/build.rs
+++ b/CubeShim/shim/build.rs
@@ -6,54 +6,57 @@ use std::process::Command;
 
 const ENV_BUILD_ENV_K: &str = "BUILD_ENV";
 const ENV_BUILD_ENV_V: &str = "zhiyan";
+
 fn main() {
-    let output = Command::new("git")
-        .args(["rev-parse", "--short=8", "HEAD"])
-        .output()
-        .expect("Failed to execute git command");
+    // ── Version (priority: env var > git tag > fallback) ──
+    let version = std::env::var("CUBE_VERSION")
+        .unwrap_or_else(|_| "0.0.0-dev".to_string());
 
-    let commit_hash = String::from_utf8(output.stdout)
-        .expect("Invalid UTF-8")
-        .trim()
-        .to_string();
+    // ── Commit (priority: env var > git rev-parse > fallback) ──
+    let commit = std::env::var("CUBE_COMMIT").unwrap_or_else(|_| {
+        Command::new("git")
+            .args(["rev-parse", "HEAD"])
+            .output()
+            .ok()
+            .and_then(|o| String::from_utf8(o.stdout).ok())
+            .map(|s| s.trim().to_string())
+            .unwrap_or_else(|| "unknown".to_string())
+    });
 
-    let output = Command::new("git")
+    // ── Build time (priority: env var > fallback) ──
+    let build_time = std::env::var("CUBE_BUILD_TIME")
+        .unwrap_or_else(|_| "unknown".to_string());
+
+    // ── Short commit + dirty check (backward compatible GIT_COMMIT_INFO) ──
+    let short_commit: String = commit.chars().take(8).collect();
+    let zhiyan = std::env::var(ENV_BUILD_ENV_K)
+        .map(|v| v == ENV_BUILD_ENV_V)
+        .unwrap_or(false);
+
+    let dirty = Command::new("git")
         .args(["status", "--porcelain"])
         .output()
-        .expect("Failed to execute git command");
+        .ok()
+        .and_then(|o| String::from_utf8(o.stdout).ok())
+        .map(|s| {
+            let cleaned = s.replace([' ', '\t', '\n'], "");
+            !cleaned.is_empty()
+        })
+        .unwrap_or(false);
 
-    let mut zhiyan = false;
-    match std::env::var(ENV_BUILD_ENV_K) {
-        Ok(v) => {
-            if v == ENV_BUILD_ENV_V {
-                zhiyan = true
-            }
-        }
-        Err(_e) => {}
-    }
-    let status = String::from_utf8(output.stdout).expect("Invalid UTF-8");
-    let status = status.replace([' ', '\t', '\n'], "");
-    let commit_info = {
-        if !status.is_empty() && !zhiyan {
-            format!("{}--dirty", commit_hash)
-        } else {
-            commit_hash
-        }
+    let commit_info = if dirty && !zhiyan {
+        format!("{}--dirty", short_commit)
+    } else {
+        short_commit
     };
-    /*
-    let output = Command::new("/bin/bash")
-        .args(["-c", "cat Cargo.toml | grep cube-hypervisor | awk -F 'rev' '{print $2}' | awk -F '\"' '{print $2}'"])
-        .output()
-        .expect("Failed to execute cargo metadata command");
 
-    let ch_version = String::from_utf8(output.stdout)
-        .expect("Invalid UTF-8")
-        .trim()
-        .to_string();
-    */
-    println!("shim version: {}", commit_info.clone());
-    //println!("ch version:{}", &ch_version);
-    //println!("cargo:rustc-env=CH_GIT_COMMIT_INFO={}", ch_version);
+    // ── Emit env vars for the crate ──
+    println!("cargo:rustc-env=CUBE_VERSION={}", version);
+    println!("cargo:rustc-env=CUBE_COMMIT={}", commit);
+    println!("cargo:rustc-env=CUBE_BUILD_TIME={}", build_time);
     println!("cargo:rustc-env=GIT_COMMIT_INFO={}", commit_info);
+    println!("cargo:rerun-if-env-changed=CUBE_VERSION");
+    println!("cargo:rerun-if-env-changed=CUBE_COMMIT");
+    println!("cargo:rerun-if-env-changed=CUBE_BUILD_TIME");
     println!("cargo:rerun-if-changed=build.rs");
 }

--- a/CubeShim/shim/src/common/mod.rs
+++ b/CubeShim/shim/src/common/mod.rs
@@ -17,7 +17,9 @@ pub const MOUNT_TYPE_RBIND: &str = "rbind";
 pub const ANNO_ROOTFS_WLAYER_PATH: &str = "cube.rootfs.wlayer.path";
 pub const ANNO_ROOTFS_WLAYER_PATH_SUBDIR: &str = "cube.rootfs.wlayer.subdir";
 
-pub const SHIM_VERSION: &str = env!("GIT_COMMIT_INFO");
+pub const SHIM_VERSION: &str = env!("CUBE_VERSION");
+pub const SHIM_COMMIT: &str = env!("CUBE_COMMIT");
+pub const SHIM_BUILD_TIME: &str = env!("CUBE_BUILD_TIME");
 
 pub const ANNO_UPDATE_EXT_ACT: &str = "cube.shimapi.update.action";
 pub const ANNO_UPDATE_EXT_PARAM: &str = "cube.shimapi.update.param";

--- a/CubeShim/shim/src/main.rs
+++ b/CubeShim/shim/src/main.rs
@@ -23,6 +23,10 @@ fn main() {
 
     let mut thread_num = 1;
     let os_args: Vec<_> = std::env::args_os().collect();
+    if is_version_request(&os_args[1..]) {
+        print_version();
+        return;
+    }
     if is_runtime_info_request(&os_args[1..]) {
         if let Err(err) = handle_runtime_info_request() {
             eprintln!("handle runtime info request failed: {err}");
@@ -34,8 +38,7 @@ fn main() {
     }
     let flags = parse(&os_args[1..]).expect("Invalid params");
     if flags.version {
-        //println!("Version:{} ChVersion:{}", SHIM_VERSION, CH_VERSION);
-        println!("version:{}", common::SHIM_VERSION);
+        print_version();
         unsafe {
             libc::exit(0);
         }
@@ -53,10 +56,27 @@ fn main() {
     runtime.block_on(shim_run::<Service>("io.containerd.cube.rs", Some(c)));
 }
 
+fn is_version_request(args: &[OsString]) -> bool {
+    args.iter().any(|arg| {
+        arg.to_str()
+            .map(|value| matches!(value, "-v" | "-version" | "--version"))
+            .unwrap_or(false)
+    })
+}
+
+fn print_version() {
+    println!(
+        "containerd-shim-cube-rs {} ({}) built at {}",
+        common::SHIM_VERSION,
+        common::SHIM_COMMIT,
+        common::SHIM_BUILD_TIME
+    );
+}
+
 fn is_runtime_info_request(args: &[OsString]) -> bool {
     args.iter().any(|arg| {
         arg.to_str()
-            .map(|value| value == "-info" || value == "--info")
+            .map(|value| matches!(value, "-info" | "--info"))
             .unwrap_or(false)
     })
 }

--- a/CubeShim/shim/src/main.rs
+++ b/CubeShim/shim/src/main.rs
@@ -39,9 +39,7 @@ fn main() {
     let flags = parse(&os_args[1..]).expect("Invalid params");
     if flags.version {
         print_version();
-        unsafe {
-            libc::exit(0);
-        }
+        return;
     }
     if flags.action.is_empty() {
         thread_num = 2;

--- a/Cubelet/Makefile
+++ b/Cubelet/Makefile
@@ -39,20 +39,25 @@ COVERAGE_PACKAGES=$(shell go list ./... \
 	| grep -v github.com/tencentcloud/CubeSandbox/Cubelet/runtime \
 	| grep -v /integration)
 
-# Version
-APP_VERSION=0.4.24
-GIT_INIT=$(shell git config --global --add safe.directory $(PWD))
-GO_VERSION=$(shell go version | awk '{print $$3}')
-GIT_COMMIT=$(shell git rev-parse --short HEAD)
-BUILD_DATE=$(shell date +'%Y%m%d-%H:%M:%S')
-PROTOC = $(shell protoc --version|awk '{print "protoc.v"$$2}')
-VERSION=$(APP_VERSION)-$(GIT_COMMIT)-$(BUILD_DATE)-$(GO_VERSION)-$(PROTOC)
+# Version — injected at build time via ldflags.
+# Priority: env var CUBE_RELEASE_VERSION > git tag > hardcoded fallback.
+# Ensure workspace is a git safe.directory inside Docker containers.
+GIT_INIT=$(shell git config --global --add safe.directory $(PWD) 2>/dev/null || true)
+CUBE_VERSION ?= $(or $(CUBE_RELEASE_VERSION),$(shell git describe --tags --abbrev=0 --match 'v*' 2>/dev/null),0.0.0-dev)
+CUBE_COMMIT ?= $(or $(CUBE_RELEASE_COMMIT),$(shell git rev-parse HEAD 2>/dev/null),unknown)
+CUBE_BUILD_TIME ?= $(or $(CUBE_RELEASE_BUILD_TIME),$(shell date -u +'%Y-%m-%dT%H:%M:%SZ'))
+
 VERSION_PKG=$(PKG)/version
-BUILD_FLAGS=-ldflags "-X '$(VERSION_PKG).Version=$(VERSION)'"
+BUILD_FLAGS=-ldflags "-s -w \
+  -X '$(VERSION_PKG).Version=$(CUBE_VERSION)' \
+  -X '$(VERSION_PKG).Commit=$(CUBE_COMMIT)' \
+  -X '$(VERSION_PKG).BuildTime=$(CUBE_BUILD_TIME)'"
+APP_VERSION ?= $(CUBE_VERSION)
+GIT_COMMIT_SHORT ?= $(shell echo $(CUBE_COMMIT) | cut -c1-7)
 PUBLISH_NAME=cubelet-$(APP_VERSION).zip
 
 # use for mark docker image tags
-APP_BUILD_VERSION=$(APP_VERSION)-$(GIT_COMMIT)
+APP_BUILD_VERSION=$(APP_VERSION)-$(GIT_COMMIT_SHORT)
 
 #
 CONF_VERSION=1.1.7
@@ -74,7 +79,7 @@ check-proto-tools:
 
 $(APPS): deps
 	@echo "${GOOS}"
-	@echo "${VERSION}"
+	@echo "${CUBE_VERSION}"
 	$(call msg,Build app,$@)
 	mkdir -p $(BUILD_DIR)
 	$(Q)go build -o $(BUILD_DIR)/$@ \
@@ -103,7 +108,7 @@ pack:build
 packconf:
 	$(Q)mkdir -p $(DYNAMIC_CONF_DIR)
 	$(Q)cp -rf dynamicconf/* $(DYNAMIC_CONF_DIR)/
-	$(Q)echo $(CONF_VERSION)-$(GIT_COMMIT)-$(BUILD_DATE) > $(DYNAMIC_CONF_DIR)/version
+	$(Q)echo $(CONF_VERSION)-$(GIT_COMMIT_SHORT)-$(CUBE_BUILD_TIME) > $(DYNAMIC_CONF_DIR)/version
 	$(Q)cd ./build && zip -q -r  $(BUILD_DIR)/$(DYNAMIC_PUBLISH_NAME) ./cube-cubelet-conf
 	$(Q)rm -rf $(PACK_DIR)
 

--- a/Cubelet/Makefile
+++ b/Cubelet/Makefile
@@ -41,8 +41,6 @@ COVERAGE_PACKAGES=$(shell go list ./... \
 
 # Version — injected at build time via ldflags.
 # Priority: env var CUBE_RELEASE_VERSION > git tag > hardcoded fallback.
-# Ensure workspace is a git safe.directory inside Docker containers.
-GIT_INIT=$(shell git config --global --add safe.directory $(PWD) 2>/dev/null || true)
 CUBE_VERSION ?= $(or $(CUBE_RELEASE_VERSION),$(shell git describe --tags --abbrev=0 --match 'v*' 2>/dev/null),0.0.0-dev)
 CUBE_COMMIT ?= $(or $(CUBE_RELEASE_COMMIT),$(shell git rev-parse HEAD 2>/dev/null),unknown)
 CUBE_BUILD_TIME ?= $(or $(CUBE_RELEASE_BUILD_TIME),$(shell date -u +'%Y-%m-%dT%H:%M:%SZ'))

--- a/Cubelet/cmd/cubecli/app/main.go
+++ b/Cubelet/cmd/cubecli/app/main.go
@@ -33,7 +33,7 @@ var extraCmds = []*cli.Command{
 
 func init() {
 	cli.VersionPrinter = func(c *cli.Context) {
-		fmt.Println(c.App.Name, pkgv.Package, c.App.Version)
+		fmt.Println(pkgv.VersionString("cubecli"))
 	}
 }
 

--- a/Cubelet/cmd/cubelet/main.go
+++ b/Cubelet/cmd/cubelet/main.go
@@ -231,7 +231,7 @@ func init() {
 	grpclog.SetLoggerV2(grpclog.NewLoggerV2(io.Discard, io.Discard, io.Discard))
 
 	cli.VersionPrinter = func(c *cli.Context) {
-		fmt.Println(c.App.Name, c.App.Version)
+		fmt.Println(version.VersionString("cubelet"))
 	}
 }
 

--- a/Cubelet/pkg/version/version.go
+++ b/Cubelet/pkg/version/version.go
@@ -11,7 +11,14 @@ import (
 )
 
 var (
-	Version = "release"
+	// Version is the semantic release version, injected at build time via ldflags.
+	Version = "0.0.0-dev"
+
+	// Commit is the full git commit SHA, injected at build time via ldflags.
+	Commit = "unknown"
+
+	// BuildTime is the UTC ISO 8601 build timestamp, injected at build time via ldflags.
+	BuildTime = "unknown"
 
 	Package = "github.com/tencentcloud/CubeSandbox/Cubelet"
 
@@ -20,9 +27,14 @@ var (
 	GoVersion = runtime.Version()
 )
 
+// VersionString returns the unified version string for the given binary name.
+func VersionString(binaryName string) string {
+	return fmt.Sprintf("%s %s (%s) built at %s", binaryName, Version, Commit, BuildTime)
+}
+
 func ShowAndExit(show bool) {
 	if show {
-		fmt.Println("Version: " + Version)
+		fmt.Println(VersionString("cubelet"))
 		os.Exit(0)
 	}
 }

--- a/Makefile
+++ b/Makefile
@@ -100,6 +100,9 @@ builder-run: prepare-builder-home prepare-tmp-git-credentials
 		-e RUSTUP_HOME=/usr/local/rustup \
 		-e GOPATH=$(BUILDER_CONTAINER_HOME)/go \
 		-e BUILDER_CMD="$(BUILDER_CMD)" \
+		-e CUBE_RELEASE_VERSION \
+		-e CUBE_RELEASE_COMMIT \
+		-e CUBE_RELEASE_BUILD_TIME \
 		-v "$(ROOT_DIR)":/workspace \
 		-v "$(BUILDER_HOME)":$(BUILDER_CONTAINER_HOME) \
 		$(DOCKER_GIT_CRED) \
@@ -141,7 +144,7 @@ cubelet: builder-image
 
 network-agent: builder-image
 	@mkdir -p "$(OUTPUT_DIR)"
-	$(MAKE) builder-run BUILDER_CMD='mkdir -p /workspace/_output/bin && cd /workspace/network-agent && make proto && go build -o /workspace/_output/bin/network-agent ./cmd/network-agent'
+	$(MAKE) builder-run BUILDER_CMD='mkdir -p /workspace/_output/bin && cd /workspace/network-agent && make proto && make build && cp bin/network-agent /workspace/_output/bin/network-agent'
 
 agent: builder-image
 	@mkdir -p "$(OUTPUT_DIR)"

--- a/agent/Makefile
+++ b/agent/Makefile
@@ -20,10 +20,11 @@ UID = $(shell id -u)
 GID = $(shell id -g)
 PWD = $(shell pwd)
 
-VERSION := $(shell git describe --abbrev=0 --tags 2>/dev/null || echo "0.0.0")
+VERSION := $(if $(CUBE_RELEASE_VERSION),$(CUBE_RELEASE_VERSION),$(shell git describe --abbrev=0 --tags --match 'v*' 2>/dev/null || echo "0.0.0"))
 COMMIT_NO := $(shell git rev-parse HEAD 2>/dev/null || true)
 COMMIT := $(if $(shell git status --porcelain --untracked-files=no 2>/dev/null || true),${COMMIT_NO}-dirty,${COMMIT_NO})
 COMMIT_MSG = $(if $(COMMIT),$(COMMIT),unknown)
+BUILD_TIME := $(if $(CUBE_RELEASE_BUILD_TIME),$(CUBE_RELEASE_BUILD_TIME),$(shell date -u +'%Y-%m-%dT%H:%M:%SZ'))
 
 export VERSION_COMMIT := $(if $(COMMIT),$(COMMIT),$(VERSION))
 
@@ -88,7 +89,7 @@ AGENT_NAME = $(TARGET)
 API_VERSION = 0.0.1
 AGENT_VERSION = $(VERSION)
 
-GENERATED_REPLACEMENTS = AGENT_NAME AGENT_VERSION API_VERSION BINDIR COMMIT VERSION_COMMIT
+GENERATED_REPLACEMENTS = AGENT_NAME AGENT_VERSION API_VERSION BINDIR COMMIT VERSION_COMMIT BUILD_TIME
 GENERATED_FILES = $(GENERATED_CODE)
 
 define get_command_version

--- a/agent/src/main.rs
+++ b/agent/src/main.rs
@@ -285,9 +285,11 @@ fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
 
     if args.version {
         println!(
-            "version:{} ,commit: {})",
+            "{} {} ({}) built at {}",
+            version::AGENT_NAME,
             version::AGENT_VERSION,
             version::VERSION_COMMIT,
+            version::BUILD_TIME,
         );
         exit(0);
     }

--- a/agent/src/version.rs.in
+++ b/agent/src/version.rs.in
@@ -13,6 +13,7 @@ pub const AGENT_VERSION: &str = "@AGENT_VERSION@";
 pub const API_VERSION: &str = "@API_VERSION@";
 pub const VERSION_COMMIT: &str = "@VERSION_COMMIT@";
 pub const GIT_COMMIT: &str = "@COMMIT@";
+pub const BUILD_TIME: &str = "@BUILD_TIME@";
 pub const AGENT_NAME: &str = "@AGENT_NAME@";
 pub const AGENT_DIR: &str = "@BINDIR@";
 pub const AGENT_PATH: &str = "@BINDIR@/@AGENT_NAME@";

--- a/deploy/one-click/build-release-bundle-builder.sh
+++ b/deploy/one-click/build-release-bundle-builder.sh
@@ -15,15 +15,44 @@ PREBUILT_DIR="${SCRIPT_DIR}/.work/prebuilt"
 HELPER_SCRIPT="${SCRIPT_DIR}/.work/build-prebuilt-in-builder.sh"
 BUILDER_IMAGE_REF="${BUILDER_IMAGE:-cube-sandbox-builder:ubuntu2004}"
 
+CUBE_RELEASE_VERSION_FROM_ENV="${CUBE_RELEASE_VERSION:-}"
+LATEST_RELEASE_TAG="$(git -C "${ROOT_DIR}" describe --tags --abbrev=0 --match 'v*' 2>/dev/null || true)"
+: "${CUBE_RELEASE_VERSION:=${LATEST_RELEASE_TAG:-0.0.0-dev}}"
+: "${CUBE_RELEASE_COMMIT:=$(git -C "${ROOT_DIR}" rev-parse HEAD 2>/dev/null || echo 'unknown')}"
+: "${CUBE_RELEASE_BUILD_TIME:=$(date -u +'%Y-%m-%dT%H:%M:%SZ')}"
+: "${ONE_CLICK_DIST_VERSION:=${CUBE_RELEASE_VERSION_FROM_ENV:-${LATEST_RELEASE_TAG:-$(latest_git_revision "${ROOT_DIR}")}}}"
+export CUBE_RELEASE_VERSION CUBE_RELEASE_COMMIT CUBE_RELEASE_BUILD_TIME ONE_CLICK_DIST_VERSION
+
 require_cmd docker
 require_cmd make
 
 rm -rf "${PREBUILT_DIR}"
 mkdir -p "${PREBUILT_DIR}" "$(dirname "${HELPER_SCRIPT}")"
 
-cat > "${HELPER_SCRIPT}" <<'EOF'
+cat > "${HELPER_SCRIPT}" <<'SCRIPT_EOF'
 #!/usr/bin/env bash
 set -euo pipefail
+
+# Version values are resolved by the host script and passed into this helper.
+export CUBE_VERSION="${CUBE_RELEASE_VERSION}"
+export CUBE_COMMIT="${CUBE_RELEASE_COMMIT}"
+export CUBE_BUILD_TIME="${CUBE_RELEASE_BUILD_TIME}"
+
+go_version_ldflags() {
+  local version_pkg="$1"
+  printf -- "-s -w -X '%s.Version=%s' -X '%s.Commit=%s' -X '%s.BuildTime=%s'" \
+    "${version_pkg}" "${CUBE_VERSION}" \
+    "${version_pkg}" "${CUBE_COMMIT}" \
+    "${version_pkg}" "${CUBE_BUILD_TIME}"
+}
+
+CUBEMASTER_VERSION_PKG="github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/version"
+CUBELET_VERSION_PKG="github.com/tencentcloud/CubeSandbox/Cubelet/pkg/version"
+NETAGENT_VERSION_PKG="github.com/tencentcloud/CubeSandbox/network-agent/pkg/version"
+
+CUBEMASTER_LDFLAGS="$(go_version_ldflags "${CUBEMASTER_VERSION_PKG}")"
+CUBELET_LDFLAGS="$(go_version_ldflags "${CUBELET_VERSION_PKG}")"
+NETAGENT_LDFLAGS="$(go_version_ldflags "${NETAGENT_VERSION_PKG}")"
 
 PREBUILT_DIR="/workspace/deploy/one-click/.work/prebuilt"
 mkdir -p "${PREBUILT_DIR}"
@@ -39,15 +68,15 @@ rm -f \
   "${PREBUILT_DIR}/cube-runtime"
 
 echo "[one-click] building cubemaster in builder" >&2
-(cd /workspace/CubeMaster && go mod download && go build -o "${PREBUILT_DIR}/cubemaster" ./cmd/cubemaster)
+(cd /workspace/CubeMaster && go mod download && go build -ldflags "${CUBEMASTER_LDFLAGS}" -o "${PREBUILT_DIR}/cubemaster" ./cmd/cubemaster)
 
 echo "[one-click] building cubemastercli in builder" >&2
-(cd /workspace/CubeMaster && go build -o "${PREBUILT_DIR}/cubemastercli" ./cmd/cubemastercli)
+(cd /workspace/CubeMaster && go build -ldflags "${CUBEMASTER_LDFLAGS}" -o "${PREBUILT_DIR}/cubemastercli" ./cmd/cubemastercli)
 
 echo "[one-click] building cubelet and cubecli in builder" >&2
 mkdir -p /workspace/_output/bin
 (cd /workspace && IN_CUBE_SANDBOX_BUILDER=1 make cubecow-sdk)
-(cd /workspace/Cubelet && go mod download && make proto && go build -a -o /workspace/_output/bin/cubelet ./cmd/cubelet && go build -a -o /workspace/_output/bin/cubecli ./cmd/cubecli)
+(cd /workspace/Cubelet && go mod download && make proto && go build -ldflags "${CUBELET_LDFLAGS}" -o /workspace/_output/bin/cubelet ./cmd/cubelet && go build -ldflags "${CUBELET_LDFLAGS}" -o /workspace/_output/bin/cubecli ./cmd/cubecli)
 install -m 0755 /workspace/_output/bin/cubelet "${PREBUILT_DIR}/cubelet"
 install -m 0755 /workspace/_output/bin/cubecli "${PREBUILT_DIR}/cubecli"
 
@@ -56,17 +85,19 @@ echo "[one-click] building cube-api in builder" >&2
 install -m 0755 /workspace/CubeAPI/target/release/cube-api "${PREBUILT_DIR}/cube-api"
 
 echo "[one-click] building network-agent in builder" >&2
-(cd /workspace/network-agent && go build -o "${PREBUILT_DIR}/network-agent" ./cmd/network-agent)
+(cd /workspace/network-agent && go build -ldflags "${NETAGENT_LDFLAGS}" -o "${PREBUILT_DIR}/network-agent" ./cmd/network-agent)
 
 echo "[one-click] building cube-agent in builder" >&2
+# Agent Makefile reads CUBE_RELEASE_VERSION; CUBE_VERSION/COMMIT/BUILD_TIME already exported
 (cd /workspace/agent && make -j1)
 install -m 0755 /workspace/agent/target/x86_64-unknown-linux-musl/release/cube-agent "${PREBUILT_DIR}/cube-agent"
 
 echo "[one-click] building shim workspace in builder" >&2
+# CUBE_VERSION/COMMIT/BUILD_TIME picked up by shim/build.rs and cube-runtime/build.rs
 (cd /workspace/CubeShim && cargo build --release --locked)
 install -m 0755 /workspace/CubeShim/target/release/containerd-shim-cube-rs "${PREBUILT_DIR}/containerd-shim-cube-rs"
 install -m 0755 /workspace/CubeShim/target/release/cube-runtime "${PREBUILT_DIR}/cube-runtime"
-EOF
+SCRIPT_EOF
 
 chmod 0755 "${HELPER_SCRIPT}"
 

--- a/deploy/one-click/build-release-bundle.sh
+++ b/deploy/one-click/build-release-bundle.sh
@@ -30,7 +30,15 @@ WEB_DIST_OVERRIDE="${ONE_CLICK_WEB_DIST_DIR:-}"
 MKCERT_BIN_ASSET="${ONE_CLICK_MKCERT_BIN:-${SCRIPT_DIR}/assets/bin/mkcert}"
 CUBE_KERNEL_VMLINUX="${ONE_CLICK_CUBE_KERNEL_VMLINUX:-${RAW_ARTIFACTS_DIR}/vmlinux}"
 KERNEL_ARTIFACT_ZIP="${WORK_ROOT}/cube-kernel-scf.zip"
-DIST_VERSION="${ONE_CLICK_DIST_VERSION:-$(latest_git_revision "${ROOT_DIR}")}"
+
+CUBE_RELEASE_VERSION_FROM_ENV="${CUBE_RELEASE_VERSION:-}"
+LATEST_RELEASE_TAG="$(git -C "${ROOT_DIR}" describe --tags --abbrev=0 --match 'v*' 2>/dev/null || true)"
+: "${CUBE_RELEASE_VERSION:=${LATEST_RELEASE_TAG:-0.0.0-dev}}"
+: "${CUBE_RELEASE_COMMIT:=$(git -C "${ROOT_DIR}" rev-parse HEAD 2>/dev/null || echo 'unknown')}"
+: "${CUBE_RELEASE_BUILD_TIME:=$(date -u +'%Y-%m-%dT%H:%M:%SZ')}"
+export CUBE_RELEASE_VERSION CUBE_RELEASE_COMMIT CUBE_RELEASE_BUILD_TIME
+
+DIST_VERSION="${ONE_CLICK_DIST_VERSION:-${CUBE_RELEASE_VERSION_FROM_ENV:-${LATEST_RELEASE_TAG:-$(latest_git_revision "${ROOT_DIR}")}}}"
 DIST_ROOT="${SCRIPT_DIR}/dist/cube-sandbox-one-click-${DIST_VERSION}"
 DIST_TAR="${SCRIPT_DIR}/dist/cube-sandbox-one-click-${DIST_VERSION}.tar.gz"
 
@@ -46,15 +54,30 @@ CUBECLI_BIN_OVERRIDE="${ONE_CLICK_CUBECLI_BIN:-}"
 API_BIN_OVERRIDE="${ONE_CLICK_CUBE_API_BIN:-}"
 NETWORK_AGENT_BIN_OVERRIDE="${ONE_CLICK_NETWORK_AGENT_BIN:-}"
 
+go_version_ldflags() {
+  local version_pkg="$1"
+  printf -- "-s -w -X '%s.Version=%s' -X '%s.Commit=%s' -X '%s.BuildTime=%s'" \
+    "${version_pkg}" "${CUBE_RELEASE_VERSION}" \
+    "${version_pkg}" "${CUBE_RELEASE_COMMIT}" \
+    "${version_pkg}" "${CUBE_RELEASE_BUILD_TIME}"
+}
+
 build_go_binary() {
   local workdir="$1"
   local mode="$2"
   local output="$3"
-  shift 3
+  local version_pkg="$4"
+  shift 4
+
+  local ldflags="-s -w"
+  if [[ -n "${version_pkg}" ]]; then
+    ldflags="$(go_version_ldflags "${version_pkg}")"
+  fi
+
   case "${mode}" in
     local)
       require_cmd go
-      (cd "${workdir}" && go mod download && go build -o "${output}" "$@") >&2
+      (cd "${workdir}" && go mod download && go build -ldflags "${ldflags}" -o "${output}" "$@") >&2
       ;;
     *)
       die "unsupported build mode: ${mode}"
@@ -67,6 +90,11 @@ build_rust_binary() {
   local mode="$2"
   local binary_name="$3"
   local output="$4"
+
+  export CUBE_VERSION="${CUBE_RELEASE_VERSION}"
+  export CUBE_COMMIT="${CUBE_RELEASE_COMMIT}"
+  export CUBE_BUILD_TIME="${CUBE_RELEASE_BUILD_TIME}"
+
   case "${mode}" in
     local)
       require_cmd cargo
@@ -86,6 +114,7 @@ build_or_copy_go_binary() {
   local mode="$4"
   local output="$5"
   local package="$6"
+  local version_pkg="${7:-}"  # optional: Go import path for ldflags injection
 
   if [[ -n "${override_path}" ]]; then
     log "using prebuilt ${name}: ${override_path}"
@@ -94,7 +123,7 @@ build_or_copy_go_binary() {
   fi
 
   log "building ${name}"
-  build_go_binary "${workdir}" "${mode}" "${output}" "${package}"
+  build_go_binary "${workdir}" "${mode}" "${output}" "${version_pkg}" "${package}"
 }
 
 build_or_copy_rust_binary() {
@@ -112,6 +141,182 @@ build_or_copy_rust_binary() {
 
   log "building ${name}"
   build_rust_binary "${workdir}" "${mode}" "${name}" "${output}"
+}
+
+# ---------------------------------------------------------------------------
+# generate_release_manifest
+#
+# Produces a machine-readable release-manifest.json in DIST_ROOT with:
+#   - release_version (the git tag or DIST_VERSION)
+#   - per-component version / commit / build_time / sha256 digest
+#   - guest-image version + digest
+#   - kernel version metadata
+#
+# Prerequisites: CORE_BIN_DIR and RUNTIME_LAYOUT_DIR must be fully populated.
+# Call after build-vm-assets.sh completes and all binaries are in place.
+# ---------------------------------------------------------------------------
+generate_release_manifest() {
+  local dist_root="$1"
+  local release_version="$2"
+  local output="${dist_root}/release-manifest.json"
+
+  require_cmd python3
+
+  log "generating release manifest: ${output}"
+
+  local cube_version="${CUBE_RELEASE_VERSION}"
+  local cube_commit="${CUBE_RELEASE_COMMIT}"
+  local cube_build_time="${CUBE_RELEASE_BUILD_TIME}"
+
+  # Guest-image version file (single line, read by CubeShim::get_image_version()).
+  local guest_image_version="unknown"
+  local guest_image_ver_file="${RUNTIME_LAYOUT_DIR}/cube-image/version"
+  if [[ -f "${guest_image_ver_file}" ]]; then
+    guest_image_version="$(head -n1 "${guest_image_ver_file}" | tr -d '[:space:]')"
+  fi
+
+  local guest_agent_version="${cube_version}"
+  local guest_agent_ver_file="${RUNTIME_LAYOUT_DIR}/cube-image/agent-version"
+  if [[ -f "${guest_agent_ver_file}" ]]; then
+    guest_agent_version="$(head -n1 "${guest_agent_ver_file}" | tr -d '[:space:]')"
+  fi
+
+  # Guest-image path
+  local guest_image_path="${RUNTIME_LAYOUT_DIR}/cube-image/cube-guest-image-cpu.img"
+
+  # Kernel paths
+  local kernel_vmlinux="${RUNTIME_LAYOUT_DIR}/cube-kernel-scf/vmlinux"
+  local kernel_pvm_vmlinux="${RUNTIME_LAYOUT_DIR}/cube-kernel-scf/vmlinux-pvm"
+
+  # Kernel version (use CI env or hardcoded tag from release-one-click.yml)
+  local kernel_version="${KERNEL_TAG:-unknown}"
+
+  # Agent binary: prefer CI override, then search known build output paths.
+  local agent_bin="${ONE_CLICK_CUBE_AGENT_BIN:-}"
+  if [[ -z "${agent_bin}" ]]; then
+    for candidate in \
+      "${ROOT_DIR}/agent/target/x86_64-unknown-linux-musl/release/cube-agent" \
+      "${ROOT_DIR}/agent/target/release/cube-agent"; do
+      if [[ -f "${candidate}" ]]; then
+        agent_bin="${candidate}"
+        break
+      fi
+    done
+  fi
+
+  # Shim + runtime binaries: already copied to RUNTIME_LAYOUT_DIR by build-vm-assets.sh.
+  local shim_bin="${RUNTIME_LAYOUT_DIR}/cube-shim/bin/containerd-shim-cube-rs"
+  local runtime_bin="${RUNTIME_LAYOUT_DIR}/cube-shim/bin/cube-runtime"
+
+  python3 - "${output}" "${release_version}" "${cube_version}" "${cube_commit}" "${cube_build_time}" \
+      "${guest_image_version}" "${guest_agent_version}" "${kernel_version}" \
+      "${CORE_BIN_DIR}" \
+      "${agent_bin}" "${shim_bin}" "${runtime_bin}" \
+      "${guest_image_path}" "${kernel_vmlinux}" "${kernel_pvm_vmlinux}" <<'PY'
+import json, os, sys, hashlib
+
+output_path       = sys.argv[1]
+release_version   = sys.argv[2]
+cube_version      = sys.argv[3]
+cube_commit       = sys.argv[4]
+cube_build_time   = sys.argv[5]
+guest_image_ver   = sys.argv[6]
+guest_agent_ver   = sys.argv[7]
+kernel_version    = sys.argv[8]
+core_bin_dir      = sys.argv[9]
+agent_bin         = sys.argv[10]
+shim_bin          = sys.argv[11]
+runtime_bin       = sys.argv[12]
+guest_image_path  = sys.argv[13]
+kernel_vmlinux    = sys.argv[14]
+kernel_pvm_vmlinux = sys.argv[15] if len(sys.argv) > 15 else ""
+
+def sha256_hex(path):
+    """Return sha256:hexdigest, or None if the file is missing."""
+    if not path or not os.path.isfile(path):
+        return None
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        while True:
+            chunk = f.read(65536)
+            if not chunk:
+                break
+            h.update(chunk)
+    return "sha256:" + h.hexdigest()
+
+components = {}
+
+# ── Go binaries from CORE_BIN_DIR ──
+for name in ["cubemaster", "cubemastercli", "cubelet", "cubecli", "network-agent"]:
+    path = os.path.join(core_bin_dir, name)
+    components[name] = {
+        "version": cube_version,
+        "commit": cube_commit,
+        "build_time": cube_build_time,
+        "digest_sha256": sha256_hex(path),
+    }
+
+# ── cube-api from CORE_BIN_DIR ──
+components["cube-api"] = {
+    "version": cube_version,
+    "commit": cube_commit,
+    "build_time": cube_build_time,
+    "digest_sha256": sha256_hex(os.path.join(core_bin_dir, "cube-api")),
+}
+
+# ── Rust binaries from build-vm-assets.sh ──
+components["cube-agent"] = {
+    "version": cube_version,
+    "commit": cube_commit,
+    "build_time": cube_build_time,
+    "digest_sha256": sha256_hex(agent_bin),
+}
+components["containerd-shim-cube-rs"] = {
+    "version": cube_version,
+    "commit": cube_commit,
+    "build_time": cube_build_time,
+    "digest_sha256": sha256_hex(shim_bin),
+}
+components["cube-runtime"] = {
+    "version": cube_version,
+    "commit": cube_commit,
+    "build_time": cube_build_time,
+    "digest_sha256": sha256_hex(runtime_bin),
+}
+
+# ── Guest image ──
+guest_image = {
+    "version": guest_image_ver,
+    "digest_sha256": sha256_hex(guest_image_path),
+    "base_image": os.environ.get("ONE_CLICK_GUEST_IMAGE_REF", "cube-sandbox-guest-image:one-click"),
+    "agent_version": guest_agent_ver,
+}
+
+# ── Kernel ──
+kernel = {"version": kernel_version}
+if kernel_vmlinux:
+    kernel["vmlinux_digest_sha256"] = sha256_hex(kernel_vmlinux)
+if kernel_pvm_vmlinux:
+    kernel["vmlinux_pvm_digest_sha256"] = sha256_hex(kernel_pvm_vmlinux)
+
+manifest = {
+    "release_version": release_version,
+    "built_at": cube_build_time,
+    "built_by": "github-actions" if os.environ.get("GITHUB_ACTIONS") == "true" else "manual",
+    "git_commit": cube_commit,
+    "components": components,
+    "guest_image": guest_image,
+    "kernel": kernel,
+}
+
+os.makedirs(os.path.dirname(output_path), exist_ok=True)
+with open(output_path, "w") as f:
+    json.dump(manifest, f, indent=2)
+    f.write("\n")
+PY
+
+  ensure_file "${output}"
+  log "release manifest written: ${output}"
 }
 
 package_kernel_artifact_zip() {
@@ -219,22 +424,26 @@ package_kernel_artifact_zip \
 rm -rf "${CORE_BIN_DIR}" "${PACKAGE_ROOT}" "${PACKAGE_TAR}" "${DIST_ROOT}" "${DIST_TAR}"
 mkdir -p "${CORE_BIN_DIR}"
 
+CUBEMASTER_VERSION_PKG="github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/version"
+CUBELET_VERSION_PKG="github.com/tencentcloud/CubeSandbox/Cubelet/pkg/version"
+NETAGENT_VERSION_PKG="github.com/tencentcloud/CubeSandbox/network-agent/pkg/version"
+
 build_or_copy_go_binary \
   "cubemaster" "${CUBEMASTER_BIN_OVERRIDE}" \
   "${ROOT_DIR}/CubeMaster" "${CUBEMASTER_BUILD_MODE}" \
-  "${CORE_BIN_DIR}/cubemaster" ./cmd/cubemaster
+  "${CORE_BIN_DIR}/cubemaster" ./cmd/cubemaster "${CUBEMASTER_VERSION_PKG}"
 build_or_copy_go_binary \
   "cubemastercli" "${CUBEMASTERCLI_BIN_OVERRIDE}" \
   "${ROOT_DIR}/CubeMaster" "${CUBEMASTER_BUILD_MODE}" \
-  "${CORE_BIN_DIR}/cubemastercli" ./cmd/cubemastercli
+  "${CORE_BIN_DIR}/cubemastercli" ./cmd/cubemastercli "${CUBEMASTER_VERSION_PKG}"
 build_or_copy_go_binary \
   "cubelet" "${CUBELET_BIN_OVERRIDE}" \
   "${ROOT_DIR}/Cubelet" "${CUBELET_BUILD_MODE}" \
-  "${CORE_BIN_DIR}/cubelet" ./cmd/cubelet
+  "${CORE_BIN_DIR}/cubelet" ./cmd/cubelet "${CUBELET_VERSION_PKG}"
 build_or_copy_go_binary \
   "cubecli" "${CUBECLI_BIN_OVERRIDE}" \
   "${ROOT_DIR}/Cubelet" "${CUBELET_BUILD_MODE}" \
-  "${CORE_BIN_DIR}/cubecli" ./cmd/cubecli
+  "${CORE_BIN_DIR}/cubecli" ./cmd/cubecli "${CUBELET_VERSION_PKG}"
 build_or_copy_rust_binary \
   "cube-api" "${API_BIN_OVERRIDE}" \
   "${ROOT_DIR}/CubeAPI" "${API_BUILD_MODE}" \
@@ -242,7 +451,7 @@ build_or_copy_rust_binary \
 build_or_copy_go_binary \
   "network-agent" "${NETWORK_AGENT_BIN_OVERRIDE}" \
   "${ROOT_DIR}/network-agent" "${NETWORK_AGENT_BUILD_MODE}" \
-  "${CORE_BIN_DIR}/network-agent" ./cmd/network-agent
+  "${CORE_BIN_DIR}/network-agent" ./cmd/network-agent "${NETAGENT_VERSION_PKG}"
 
 mkdir -p \
   "${PACKAGE_ROOT}/network-agent/bin" \
@@ -343,10 +552,16 @@ chmod +x \
   "${DIST_ROOT}/online-install.sh"
 
 cat > "${DIST_ROOT}/VERSION.txt" <<EOF
-repo=${ROOT_DIR}
-revision=${DIST_VERSION}
-built_at=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+release_version=${DIST_VERSION}
+git_commit=${CUBE_RELEASE_COMMIT}
+built_at=${CUBE_RELEASE_BUILD_TIME}
+manifest=release-manifest.json
 EOF
+
+# Generate machine-readable release manifest (M1-2).
+# Depends on: CORE_BIN_DIR, RUNTIME_LAYOUT_DIR, and CUBE_*_PATH vars
+# exported by build-vm-assets.sh.
+generate_release_manifest "${DIST_ROOT}" "${DIST_VERSION}"
 
 tar -C "${SCRIPT_DIR}/dist" -czf "${DIST_TAR}" "cube-sandbox-one-click-${DIST_VERSION}"
 log "release bundle ready: ${DIST_TAR}"

--- a/deploy/one-click/build-release-bundle.sh
+++ b/deploy/one-click/build-release-bundle.sh
@@ -232,9 +232,7 @@ kernel_vmlinux    = sys.argv[14]
 kernel_pvm_vmlinux = sys.argv[15] if len(sys.argv) > 15 else ""
 
 def sha256_hex(path):
-    """Return sha256:hexdigest, or None if the file is missing."""
-    if not path or not os.path.isfile(path):
-        return None
+    """Return sha256:hexdigest for an existing file."""
     h = hashlib.sha256()
     with open(path, "rb") as f:
         while True:
@@ -243,6 +241,16 @@ def sha256_hex(path):
                 break
             h.update(chunk)
     return "sha256:" + h.hexdigest()
+
+def required_sha256(path):
+    if not path or not os.path.isfile(path):
+        raise FileNotFoundError(f"required release artifact is missing: {path}")
+    return sha256_hex(path)
+
+def optional_sha256(path):
+    if not path or not os.path.isfile(path):
+        return None
+    return sha256_hex(path)
 
 components = {}
 
@@ -253,7 +261,7 @@ for name in ["cubemaster", "cubemastercli", "cubelet", "cubecli", "network-agent
         "version": cube_version,
         "commit": cube_commit,
         "build_time": cube_build_time,
-        "digest_sha256": sha256_hex(path),
+        "digest_sha256": required_sha256(path),
     }
 
 # ── cube-api from CORE_BIN_DIR ──
@@ -261,7 +269,7 @@ components["cube-api"] = {
     "version": cube_version,
     "commit": cube_commit,
     "build_time": cube_build_time,
-    "digest_sha256": sha256_hex(os.path.join(core_bin_dir, "cube-api")),
+    "digest_sha256": required_sha256(os.path.join(core_bin_dir, "cube-api")),
 }
 
 # ── Rust binaries from build-vm-assets.sh ──
@@ -269,25 +277,25 @@ components["cube-agent"] = {
     "version": cube_version,
     "commit": cube_commit,
     "build_time": cube_build_time,
-    "digest_sha256": sha256_hex(agent_bin),
+    "digest_sha256": required_sha256(agent_bin),
 }
 components["containerd-shim-cube-rs"] = {
     "version": cube_version,
     "commit": cube_commit,
     "build_time": cube_build_time,
-    "digest_sha256": sha256_hex(shim_bin),
+    "digest_sha256": required_sha256(shim_bin),
 }
 components["cube-runtime"] = {
     "version": cube_version,
     "commit": cube_commit,
     "build_time": cube_build_time,
-    "digest_sha256": sha256_hex(runtime_bin),
+    "digest_sha256": required_sha256(runtime_bin),
 }
 
 # ── Guest image ──
 guest_image = {
     "version": guest_image_ver,
-    "digest_sha256": sha256_hex(guest_image_path),
+    "digest_sha256": required_sha256(guest_image_path),
     "base_image": os.environ.get("ONE_CLICK_GUEST_IMAGE_REF", "cube-sandbox-guest-image:one-click"),
     "agent_version": guest_agent_ver,
 }
@@ -295,9 +303,10 @@ guest_image = {
 # ── Kernel ──
 kernel = {"version": kernel_version}
 if kernel_vmlinux:
-    kernel["vmlinux_digest_sha256"] = sha256_hex(kernel_vmlinux)
-if kernel_pvm_vmlinux:
-    kernel["vmlinux_pvm_digest_sha256"] = sha256_hex(kernel_pvm_vmlinux)
+    kernel["vmlinux_digest_sha256"] = required_sha256(kernel_vmlinux)
+pvm_digest = optional_sha256(kernel_pvm_vmlinux)
+if pvm_digest:
+    kernel["vmlinux_pvm_digest_sha256"] = pvm_digest
 
 manifest = {
     "release_version": release_version,
@@ -308,6 +317,9 @@ manifest = {
     "guest_image": guest_image,
     "kernel": kernel,
 }
+
+if not kernel.get("vmlinux_digest_sha256"):
+    raise ValueError("missing kernel vmlinux digest")
 
 os.makedirs(os.path.dirname(output_path), exist_ok=True)
 with open(output_path, "w") as f:

--- a/deploy/one-click/build-vm-assets.sh
+++ b/deploy/one-click/build-vm-assets.sh
@@ -13,6 +13,15 @@ fi
 
 WORK_ROOT="${ONE_CLICK_WORK_ROOT:-${SCRIPT_DIR}/.work}"
 RUNTIME_LAYOUT_DIR="${ONE_CLICK_RUNTIME_LAYOUT_DIR:-${WORK_ROOT}/runtime-layout}"
+
+LATEST_RELEASE_TAG="$(git -C "${ROOT_DIR}" describe --tags --abbrev=0 --match 'v*' 2>/dev/null || true)"
+
+# Version injection for Rust build.rs (shim, cube-runtime) when built on host.
+# In CI these are prebuilt via the builder container; for local dev, provide
+# consistent fallbacks so all components share the same version information.
+export CUBE_VERSION="${CUBE_RELEASE_VERSION:-${LATEST_RELEASE_TAG:-0.0.0-dev}}"
+export CUBE_COMMIT="${CUBE_RELEASE_COMMIT:-$(git -C "${ROOT_DIR}" rev-parse HEAD 2>/dev/null || echo 'unknown')}"
+export CUBE_BUILD_TIME="${CUBE_RELEASE_BUILD_TIME:-$(date -u +'%Y-%m-%dT%H:%M:%SZ')}"
 GUEST_IMAGE_WORK_DIR="${WORK_ROOT}/guest-image-build"
 GUEST_ROOTFS_DIR="${GUEST_IMAGE_WORK_DIR}/rootfs"
 GUEST_ROOTFS_TAR="${GUEST_IMAGE_WORK_DIR}/rootfs.tar"
@@ -23,7 +32,7 @@ CUBE_KERNEL_PVM_VMLINUX="${ONE_CLICK_CUBE_KERNEL_PVM_VMLINUX:-${RAW_ARTIFACTS_DI
 GUEST_IMAGE_DOCKERFILE="${ONE_CLICK_GUEST_IMAGE_DOCKERFILE:-${ROOT_DIR}/deploy/guest-image/Dockerfile}"
 GUEST_IMAGE_CONTEXT_DIR="${ONE_CLICK_GUEST_IMAGE_CONTEXT_DIR:-$(dirname "${GUEST_IMAGE_DOCKERFILE}")}"
 GUEST_IMAGE_REF="${ONE_CLICK_GUEST_IMAGE_REF:-cube-sandbox-guest-image:one-click}"
-GUEST_IMAGE_VERSION="${ONE_CLICK_GUEST_IMAGE_VERSION:-$(latest_git_revision "${ROOT_DIR}")}"
+GUEST_IMAGE_VERSION="${ONE_CLICK_GUEST_IMAGE_VERSION:-${CUBE_RELEASE_VERSION:-${LATEST_RELEASE_TAG:-$(latest_git_revision "${ROOT_DIR}")}}}"
 
 CUBE_AGENT_BUILD_MODE="${ONE_CLICK_CUBE_AGENT_BUILD_MODE:-local}"
 CUBE_SHIM_BUILD_MODE="${ONE_CLICK_CUBE_SHIM_BUILD_MODE:-local}"
@@ -247,13 +256,8 @@ run_as_root() {
     return $?
   fi
 
-  # Try without sudo first so the caller can still capture stdout via $(...).
-  # Only stderr is silenced so a permission error doesn't pollute the log
-  # before the sudo fallback retries.
-  local rc=0
-  "$@" 2>/dev/null
-  rc=$?
-  if [[ ${rc} -eq 0 ]]; then
+  # Try without sudo first so command substitution still captures stdout.
+  if "$@" 2>/dev/null; then
     return 0
   fi
 
@@ -438,6 +442,7 @@ EOF
 build_guest_image_artifacts() {
   local output_img="$1"
   local output_version="$2"
+  local output_agent_version="$3"
   local rootfs_size_bytes
   local image_size_bytes
   local guest_container_id=""
@@ -445,7 +450,7 @@ build_guest_image_artifacts() {
   ensure_dir "${GUEST_IMAGE_CONTEXT_DIR}"
   ensure_file "${GUEST_IMAGE_DOCKERFILE}"
 
-  mkdir -p "${GUEST_IMAGE_WORK_DIR}" "$(dirname "${output_img}")" "$(dirname "${output_version}")"
+  mkdir -p "${GUEST_IMAGE_WORK_DIR}" "$(dirname "${output_img}")" "$(dirname "${output_version}")" "$(dirname "${output_agent_version}")"
   remove_path_with_optional_sudo "${GUEST_ROOTFS_DIR}" "${GUEST_ROOTFS_TAR}"
 
   log "building guest image from ${GUEST_IMAGE_DOCKERFILE}"
@@ -472,6 +477,7 @@ build_guest_image_artifacts() {
   shrink_ext4_image "${output_img}"
 
   printf '%s\n' "${GUEST_IMAGE_VERSION}" > "${output_version}"
+  printf '%s\n' "${CUBE_VERSION}" > "${output_agent_version}"
 
   docker rm -f "${guest_container_id}" >/dev/null 2>&1 || true
   guest_container_id=""
@@ -512,7 +518,8 @@ prepare_runtime_config "${RUNTIME_LAYOUT_DIR}/cube-shim/conf/config-cube.toml"
 log "building guest image artifacts"
 build_guest_image_artifacts \
   "${RUNTIME_LAYOUT_DIR}/cube-image/cube-guest-image-cpu.img" \
-  "${RUNTIME_LAYOUT_DIR}/cube-image/version"
+  "${RUNTIME_LAYOUT_DIR}/cube-image/version" \
+  "${RUNTIME_LAYOUT_DIR}/cube-image/agent-version"
 log "copying fixed kernel vmlinux"
 copy_file "${CUBE_KERNEL_VMLINUX}" "${RUNTIME_LAYOUT_DIR}/cube-kernel-scf/vmlinux"
 ensure_file "${RUNTIME_LAYOUT_DIR}/cube-kernel-scf/vmlinux"

--- a/deploy/one-click/install.sh
+++ b/deploy/one-click/install.sh
@@ -640,6 +640,16 @@ if [[ -f "${ENV_FILE}" ]]; then
 else
   : > "${RUNTIME_ENV_FILE}"
 fi
+
+# Install version files so the installed system can report its version.
+if [[ -f "${SCRIPT_DIR}/VERSION.txt" ]]; then
+  cp -f "${SCRIPT_DIR}/VERSION.txt" "${INSTALL_PREFIX}/VERSION.txt"
+  log "installed VERSION.txt to ${INSTALL_PREFIX}/VERSION.txt"
+fi
+if [[ -f "${SCRIPT_DIR}/release-manifest.json" ]]; then
+  cp -f "${SCRIPT_DIR}/release-manifest.json" "${INSTALL_PREFIX}/release-manifest.json"
+  log "installed release-manifest.json to ${INSTALL_PREFIX}/release-manifest.json"
+fi
 upsert_env_kv "${RUNTIME_ENV_FILE}" "ONE_CLICK_DEPLOY_ROLE" "${DEPLOY_ROLE}"
 upsert_env_kv "${RUNTIME_ENV_FILE}" "CUBE_PVM_ENABLE" "${CUBE_PVM_ENABLE}"
 if [[ -n "${CUBE_SANDBOX_NODE_IP:-}" ]]; then

--- a/deploy/one-click/online-install.sh
+++ b/deploy/one-click/online-install.sh
@@ -308,7 +308,7 @@ http_get() {
 #
 # Discovery order:
 #   1. MIRROR=cn   -> https://download.cubesandbox.com/release/latest.json
-#                     (JSON body: {"url": "https://.../cube-sandbox-one-click-<sha>.tar.gz"})
+#                     (JSON body: {"url": "https://.../cube-sandbox-one-click-<version-or-sha>.tar.gz"})
 #   2. default     -> GitHub API latest release asset
 # ---------------------------------------------------------------------------
 if [[ -z "${DOWNLOAD_URL}" ]]; then
@@ -351,7 +351,7 @@ PY
 import json, sys, re
 
 data = json.loads(sys.argv[1])
-pattern = re.compile(r'^cube-sandbox-one-click-[0-9a-f]+\.tar\.gz$')
+pattern = re.compile(r'^cube-sandbox-one-click-(?:[0-9a-f]+|v[0-9A-Za-z][0-9A-Za-z._-]*)\.tar\.gz$')
 for asset in data.get("assets", []):
     if pattern.match(asset.get("name", "")):
         print(asset["browser_download_url"])
@@ -359,7 +359,7 @@ for asset in data.get("assets", []):
 sys.exit(1)
 PY
     )" || {
-      echo "[online-install] ERROR: could not find a cube-sandbox-one-click-<sha>.tar.gz asset in the latest release." >&2
+      echo "[online-install] ERROR: could not find a cube-sandbox-one-click-<version-or-sha>.tar.gz asset in the latest release." >&2
       echo "[online-install] You can specify the URL manually:" >&2
       echo "[online-install]   online-install.sh --url=<download-url> [install.sh options...]" >&2
       exit 1
@@ -372,7 +372,7 @@ fi
 # ---------------------------------------------------------------------------
 # Derive the expected directory name from the tarball filename.
 # The tarball produced by build-release-bundle.sh is always named
-#   cube-sandbox-one-click-<git-short-sha>.tar.gz
+#   cube-sandbox-one-click-<version-or-sha>.tar.gz
 # and extracts to a single top-level directory with the same stem.
 # ---------------------------------------------------------------------------
 TARBALL_FILENAME="${DOWNLOAD_URL##*/}"   # basename of URL
@@ -380,7 +380,7 @@ BUNDLE_DIRNAME="${TARBALL_FILENAME%.tar.gz}"
 
 if [[ "${BUNDLE_DIRNAME}" != cube-sandbox-one-click-* ]]; then
   echo "[online-install] ERROR: unexpected tarball filename '${TARBALL_FILENAME}'." >&2
-  echo "[online-install] Expected: cube-sandbox-one-click-<sha>.tar.gz" >&2
+  echo "[online-install] Expected: cube-sandbox-one-click-<version-or-sha>.tar.gz" >&2
   exit 1
 fi
 

--- a/hypervisor/build.rs
+++ b/hypervisor/build.rs
@@ -9,21 +9,31 @@ extern crate clap;
 use std::process::Command;
 
 fn main() {
-    let mut version = "v".to_owned() + crate_version!();
-
-    if let Ok(git_out) = Command::new("git").args(["describe", "--dirty"]).output() {
+    // Priority: CUBE_VERSION env > git describe > crate_version > fallback
+    let version = if let Ok(v) = std::env::var("CUBE_VERSION") {
+        v
+    } else if let Ok(git_out) = Command::new("git").args(["describe", "--dirty"]).output() {
         if git_out.status.success() {
-            if let Ok(git_out_str) = String::from_utf8(git_out.stdout) {
-                version = git_out_str;
+            if let Ok(s) = String::from_utf8(git_out.stdout) {
+                s.trim().to_string()
+            } else {
+                "v".to_owned() + crate_version!()
             }
+        } else {
+            "v".to_owned() + crate_version!()
         }
-    }
+    } else {
+        "v".to_owned() + crate_version!()
+    };
 
-    // This println!() has a special behavior, as it will set the environment
-    // variable BUILT_VERSION, so that it can be reused from the binary.
-    // Particularly, this is used from src/main.rs to display the exact
-    // version.
-    println!("cargo:rustc-env=BUILT_VERSION={}", version);
+    let build_time =
+        std::env::var("CUBE_BUILD_TIME").unwrap_or_else(|_| "unknown".to_string());
 
+    // Embed build_time into BUILT_VERSION so clap's --version includes it.
+    let built_version = format!("{} built at {}", version, build_time);
+
+    println!("cargo:rustc-env=BUILT_VERSION={}", built_version);
     println!("cargo:rustc-env=SNAPSHOT_VERSION=1.0.0");
+    println!("cargo:rerun-if-env-changed=CUBE_VERSION");
+    println!("cargo:rerun-if-env-changed=CUBE_BUILD_TIME");
 }

--- a/hypervisor/build.rs
+++ b/hypervisor/build.rs
@@ -10,30 +10,38 @@ use std::process::Command;
 
 fn main() {
     // Priority: CUBE_VERSION env > git describe > crate_version > fallback
-    let version = if let Ok(v) = std::env::var("CUBE_VERSION") {
-        v
-    } else if let Ok(git_out) = Command::new("git").args(["describe", "--dirty"]).output() {
-        if git_out.status.success() {
-            if let Ok(s) = String::from_utf8(git_out.stdout) {
-                s.trim().to_string()
-            } else {
-                "v".to_owned() + crate_version!()
-            }
-        } else {
-            "v".to_owned() + crate_version!()
-        }
-    } else {
-        "v".to_owned() + crate_version!()
-    };
+    let version = std::env::var("CUBE_VERSION")
+        .ok()
+        .or_else(|| git_output(&["describe", "--dirty"]))
+        .unwrap_or_else(default_version);
 
-    let build_time =
-        std::env::var("CUBE_BUILD_TIME").unwrap_or_else(|_| "unknown".to_string());
+    let build_time = std::env::var("CUBE_BUILD_TIME").unwrap_or_else(|_| "unknown".to_string());
+    let commit = std::env::var("CUBE_COMMIT")
+        .ok()
+        .or_else(|| git_output(&["rev-parse", "HEAD"]).filter(|s| !s.is_empty()))
+        .unwrap_or_else(|| "unknown".to_string());
 
-    // Embed build_time into BUILT_VERSION so clap's --version includes it.
-    let built_version = format!("{} built at {}", version, build_time);
+    // Embed metadata into BUILT_VERSION so clap's --version includes it.
+    let built_version = format!("{} ({}) built at {}", version, commit, build_time);
 
     println!("cargo:rustc-env=BUILT_VERSION={}", built_version);
     println!("cargo:rustc-env=SNAPSHOT_VERSION=1.0.0");
     println!("cargo:rerun-if-env-changed=CUBE_VERSION");
+    println!("cargo:rerun-if-env-changed=CUBE_COMMIT");
     println!("cargo:rerun-if-env-changed=CUBE_BUILD_TIME");
+}
+
+fn git_output(args: &[&str]) -> Option<String> {
+    let output = Command::new("git").args(args).output().ok()?;
+    if !output.status.success() {
+        return None;
+    }
+
+    String::from_utf8(output.stdout)
+        .ok()
+        .map(|stdout| stdout.trim().to_string())
+}
+
+fn default_version() -> String {
+    "v".to_owned() + crate_version!()
 }

--- a/network-agent/Makefile
+++ b/network-agent/Makefile
@@ -15,6 +15,17 @@ CLIENT_PROTO := $(CLIENT_PROTO_DIR)/network_agent.proto
 APP := network-agent
 GO_BIN_DIR := $(shell if [ -n "$$(go env GOBIN)" ]; then printf "%s" "$$(go env GOBIN)"; else printf "%s/bin" "$$(go env GOPATH)"; fi)
 
+# Version — injected at build time via ldflags.
+CUBE_VERSION ?= $(or $(CUBE_RELEASE_VERSION),$(shell git describe --tags --abbrev=0 --match 'v*' 2>/dev/null),0.0.0-dev)
+CUBE_COMMIT ?= $(or $(CUBE_RELEASE_COMMIT),$(shell git rev-parse HEAD 2>/dev/null),unknown)
+CUBE_BUILD_TIME ?= $(or $(CUBE_RELEASE_BUILD_TIME),$(shell date -u +'%Y-%m-%dT%H:%M:%SZ'))
+
+VERSION_PKG := github.com/tencentcloud/CubeSandbox/network-agent/pkg/version
+LDFLAGS := -ldflags "-s -w \
+  -X '$(VERSION_PKG).Version=$(CUBE_VERSION)' \
+  -X '$(VERSION_PKG).Commit=$(CUBE_COMMIT)' \
+  -X '$(VERSION_PKG).BuildTime=$(CUBE_BUILD_TIME)'"
+
 export PATH := $(GO_BIN_DIR):$(PATH)
 
 .PHONY: build proto test clean check-proto-tools sync-client-proto
@@ -22,7 +33,7 @@ export PATH := $(GO_BIN_DIR):$(PATH)
 build:
 	$(call msg,Build app,$(APP))
 	$(Q)mkdir -p "$(BUILD_DIR)"
-	$(Q)go build -o "$(BUILD_DIR)/$(APP)" ./cmd/$(APP)
+	$(Q)go build $(LDFLAGS) -o "$(BUILD_DIR)/$(APP)" ./cmd/$(APP)
 
 check-proto-tools:
 	@command -v protoc >/dev/null 2>&1 || { echo "error: protoc not installed"; exit 1; }

--- a/network-agent/cmd/network-agent/main.go
+++ b/network-agent/cmd/network-agent/main.go
@@ -20,12 +20,16 @@ import (
 	"github.com/tencentcloud/CubeSandbox/network-agent/internal/grpcserver"
 	"github.com/tencentcloud/CubeSandbox/network-agent/internal/httpserver"
 	"github.com/tencentcloud/CubeSandbox/network-agent/internal/service"
+	"github.com/tencentcloud/CubeSandbox/network-agent/pkg/version"
 )
 
 var newLocalService = service.NewLocalService
 
 func main() {
 	defaultCfg := service.DefaultConfig()
+	var showVersion bool
+	flag.BoolVar(&showVersion, "version", false, "show version information")
+	flag.BoolVar(&showVersion, "v", false, "show version information")
 	var (
 		listenEndpoint = flag.String("listen", "unix:///tmp/cube/network-agent.sock", "network-agent listen endpoint")
 		healthListen   = flag.String("health-listen", "127.0.0.1:19090", "network-agent health server listen address")
@@ -48,6 +52,10 @@ func main() {
 		logRollSize    = flag.Int("log-roll-size", defaultRollSizeMB, "network-agent log files roll size(MB)")
 	)
 	flag.Parse()
+	if showVersion {
+		fmt.Println(version.String())
+		os.Exit(0)
+	}
 	if err := initLogger(*logPath, *logLevel, *logRollNum, *logRollSize); err != nil {
 		CubeLog.Fatalf("network-agent init logger failed: %v", err)
 	}

--- a/network-agent/pkg/version/version.go
+++ b/network-agent/pkg/version/version.go
@@ -1,0 +1,24 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+// Package version provides version information for network-agent.
+package version
+
+import "fmt"
+
+var (
+	// Version is the semantic release version, injected at build time via ldflags.
+	Version = "0.0.0-dev"
+
+	// Commit is the full git commit SHA, injected at build time via ldflags.
+	Commit = "unknown"
+
+	// BuildTime is the UTC ISO 8601 build timestamp, injected at build time via ldflags.
+	BuildTime = "unknown"
+)
+
+// String returns the unified version string.
+func String() string {
+	return fmt.Sprintf("network-agent %s (%s) built at %s", Version, Commit, BuildTime)
+}

--- a/network-agent/pkg/version/version.go
+++ b/network-agent/pkg/version/version.go
@@ -18,7 +18,12 @@ var (
 	BuildTime = "unknown"
 )
 
-// String returns the unified version string.
+// VersionString returns the unified version string for the given binary name.
+func VersionString(binaryName string) string {
+	return fmt.Sprintf("%s %s (%s) built at %s", binaryName, Version, Commit, BuildTime)
+}
+
+// String returns the version string for the network-agent binary.
 func String() string {
-	return fmt.Sprintf("network-agent %s (%s) built at %s", Version, Commit, BuildTime)
+	return VersionString("network-agent")
 }


### PR DESCRIPTION
Inject release version metadata (version, commit, build time) into all Go and Rust binaries via ldflags / build.rs, unify version output format, and generate a machine-readable release-manifest.json in one-click release bundles so every artifact can be traced to the same release.