### PR TITLE
fix(python-sdk): buffer request body in IPOverrideTransport

### DIFF
--- a/sdk/python/cubesandbox/_transport.py
+++ b/sdk/python/cubesandbox/_transport.py
@@ -25,6 +25,9 @@ class IPOverrideTransport(httpx.HTTPTransport):
     def handle_request(self, request: httpx.Request) -> httpx.Response:
         original_host = request.url.host
         url = request.url.copy_with(host=self._ip, port=self._port)
+        # Buffer streaming request bodies before copying, otherwise
+        # request.content may raise RequestNotRead for multipart uploads.
+        request.read()
         proxied = httpx.Request(
             method=request.method,
             url=url,

--- a/sdk/python/tests/test_sandbox.py
+++ b/sdk/python/tests/test_sandbox.py
@@ -886,6 +886,50 @@ class TestFilesystem:
         assert isinstance(make_sandbox().files, Filesystem)
 
 
+# ── IPOverrideTransport ───────────────────────────────────────────────────────
+
+class TestIPOverrideTransport:
+    """IPOverrideTransport must copy request content for all body types."""
+
+    def _handle(self, request: httpx.Request) -> None:
+        """Run handle_request and assert the request body was copied successfully
+        before the connection attempt fails."""
+        from cubesandbox._transport import IPOverrideTransport
+
+        transport = IPOverrideTransport("127.0.0.1", 1)
+        with pytest.raises(httpx.ConnectError):
+            transport.handle_request(request)
+
+    def test_content_bytes(self):
+        """content=bytes (files.write first attempt) must not raise."""
+        req = httpx.Request(
+            "POST",
+            "http://49983-sb-test.cube.app/files",
+            params={"path": "/tmp/t.txt", "username": "root"},
+            content=b"hello",
+        )
+        self._handle(req)
+
+    def test_files_multipart(self):
+        """files= multipart (files.write fallback) must reach ConnectError."""
+        req = httpx.Request(
+            "POST",
+            "http://49983-sb-test.cube.app/files",
+            params={"path": "/tmp/t.txt", "username": "root"},
+            files={"file": ("t.txt", b"hello")},
+        )
+        self._handle(req)
+
+    def test_get_no_body(self):
+        """GET (files.read) with no body must reach ConnectError."""
+        req = httpx.Request(
+            "GET",
+            "http://49983-sb-test.cube.app/files",
+            params={"path": "/tmp/t.txt", "username": "root"},
+        )
+        self._handle(req)
+
+
 # ── close / __del__ ───────────────────────────────────────────────────────────
 
 class TestClose:


### PR DESCRIPTION
## Summary

This PR addresses #498 by updating `IPOverrideTransport.handle_request()` to read and buffer the incoming request body before copying it into the proxied request.

This prevents multipart uploads created with `files=` from failing with `httpx.RequestNotRead` before the transport reaches the expected connection attempt.

## Motivation

`IPOverrideTransport.handle_request()` currently copies `request.content` directly when creating the proxied request.

This works for buffered request bodies, but multipart uploads created with `files=` are streaming requests in `httpx`. Accessing `request.content` before the body has been read raises `httpx.RequestNotRead`.

## Changes

- call `request.read()` before copying the request body in `IPOverrideTransport.handle_request()`
- add focused coverage for:
  - `content=bytes`
  - `files=` multipart uploads
  - `GET` requests with no body
- keep the expected final failure mode as `httpx.ConnectError` for the test transport target, ensuring the request-copying path succeeds first

## Validation

Focused test:

```bash
PYTHONPATH=sdk/python \
python -m pytest sdk/python/tests/test_sandbox.py::TestIPOverrideTransport -vv
```

Also verified with a minimal multipart reproduction matching the issue report: after the fix, the request no longer raises `RequestNotRead` and instead reaches the expected `ConnectError`.

## Scope

This PR is limited to the Python SDK transport fix and its targeted tests.
