### PR TITLE
feat(cubeapi): promote cube.vm.kernel.cmdline.append from sandbox metadata to annotation

### DIFF
--- a/CubeAPI/src/services/sandboxes.rs
+++ b/CubeAPI/src/services/sandboxes.rs
@@ -26,6 +26,12 @@ const RET_CODE_HTTP_OK: i32 = 200;
 const RET_CODE_NOT_FOUND: i32 = 130404;
 const RET_CODE_CONFLICT: i32 = 130409;
 const HOSTDIR_MOUNT_KEY: &str = "host-mount";
+/// Sandbox-metadata key promoted to a CubeMaster annotation so callers can
+/// append guest kernel cmdline parameters (e.g. a per-sandbox identity nonce the
+/// guest reads from `/proc/cmdline`) without a shared host mount. Mirrors the
+/// `host-mount` promotion below. The annotation is consumed by Cubelet
+/// (`cube.vm.kernel.cmdline.append`) and appended to the guest boot args.
+const KERNEL_CMDLINE_APPEND_KEY: &str = "cube.vm.kernel.cmdline.append";
 
 #[derive(Clone)]
 pub struct SandboxService {
@@ -129,6 +135,9 @@ impl SandboxService {
         let labels = body.metadata.map(|mut meta| {
             if let Some(value) = meta.remove(HOSTDIR_MOUNT_KEY) {
                 annotations.insert(HOSTDIR_MOUNT_KEY.to_string(), value);
+            }
+            if let Some(value) = meta.remove(KERNEL_CMDLINE_APPEND_KEY) {
+                annotations.insert(KERNEL_CMDLINE_APPEND_KEY.to_string(), value);
             }
             meta
         });


### PR DESCRIPTION
## What

`CubeAPI`'s `create_sandbox` already promotes the `host-mount` metadata key to a CubeMaster annotation, but everything else in `metadata` falls through to `labels`. Annotations are the only sandbox metadata that reach the shim (and thus influence the guest), so a caller currently has **no way to inject guest kernel cmdline parameters** through the sandbox API.

This promotes the well-known `cube.vm.kernel.cmdline.append` key the same way `host-mount` is promoted.

## Why

`Cubelet` already consumes `cube.vm.kernel.cmdline.append` (`AnnotationVMKernelCmdlineAppend` in `pkg/constants/const.go`) and appends it to the guest boot args — where any guest process can read it from `/proc/cmdline`. The only missing link was the API surface: `create_sandbox` hard-codes `annotations: None` and drops `metadata` into `labels`.

With this change a caller can pass, e.g., a per-sandbox identity/bootstrap datum into the guest **without a shared host mount** — useful for agent runtimes that want the guest to self-identify at boot without an injected file or volume.

## Change

`CubeAPI/src/services/sandboxes.rs`: add the `KERNEL_CMDLINE_APPEND_KEY` const and promote it from `metadata` → `annotations`, mirroring the existing `HOSTDIR_MOUNT_KEY` promotion (the only other promoted key). ~7 lines; no behavior change for existing callers (they don't set this key). `cargo check` passes.