### PR TITLE
feat(affinity): support custom node affinity selector via annotation

### DIFF
--- a/CubeMaster/.gitignore
+++ b/CubeMaster/.gitignore
@@ -1,1 +1,2 @@
 /build/
+/test/

--- a/CubeMaster/pkg/base/config/config.go
+++ b/CubeMaster/pkg/base/config/config.go
@@ -16,6 +16,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/constants"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/hotswap"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/log"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/utils"
@@ -173,6 +174,7 @@ type SchedulerConf struct {
 	DisableBackoffFilterInstanceType map[string]bool                   `yaml:"disable_backoff_filter_instance_type"`
 	ThirtpartyFilterInstanceType     map[string]bool                   `yaml:"thirtparty_filter_instance_type"`
 	InstanceTypeConf                 map[string]InstanceTypeConf       `yaml:"instance_type_conf"`
+	NodeAffinitySelectorAllowedKeys  []string                          `yaml:"node_affinity_selector_allowed_keys"`
 
 	// IgnoreRedisAllocation, when true, makes the scheduler ignore the
 	// per-node allocated CPU/Mem usage recorded in Redis (treat allocated as
@@ -185,6 +187,15 @@ type SchedulerConf struct {
 	// OvercommitRatioByType overrides OvercommitRatio for specific instance
 	// types and takes precedence over the global ratio.
 	OvercommitRatioByType map[string]OvercommitRatioConf `yaml:"overcommit_ratio_conf"`
+}
+
+var defaultNodeAffinitySelectorAllowedKeys = []string{
+	constants.AffinityKeyZone,
+	constants.AffinityKeyClusterID,
+	constants.AffinityKeyCPUType,
+	constants.AffinityKeyMemorySize,
+	constants.AffinityKeyCPUCores,
+	constants.AffinityKeyInstanceType,
 }
 
 // OvercommitRatioConf describes the CPU/Mem overcommit multipliers applied to
@@ -342,6 +353,24 @@ func (s *SchedulerConf) GetLargeSizeAffinityConf(serviceName string) LargeSizeAf
 		}
 	}
 	return s.LargeSizeAffinityConf[serviceName]
+}
+
+func (s *SchedulerConf) NodeAffinitySelectorAllowedKeySet() map[string]struct{} {
+	extraKeyCount := 0
+	if s != nil {
+		extraKeyCount = len(s.NodeAffinitySelectorAllowedKeys)
+	}
+	allowed := make(map[string]struct{}, len(defaultNodeAffinitySelectorAllowedKeys)+extraKeyCount)
+	for _, key := range defaultNodeAffinitySelectorAllowedKeys {
+		allowed[key] = struct{}{}
+	}
+	if s == nil {
+		return allowed
+	}
+	for _, key := range s.NodeAffinitySelectorAllowedKeys {
+		allowed[key] = struct{}{}
+	}
+	return allowed
 }
 
 func (s *SchedulerConf) MaxMvmCPURes() resource.Quantity {

--- a/CubeMaster/pkg/base/config/config.go
+++ b/CubeMaster/pkg/base/config/config.go
@@ -355,20 +355,20 @@ func (s *SchedulerConf) GetLargeSizeAffinityConf(serviceName string) LargeSizeAf
 	return s.LargeSizeAffinityConf[serviceName]
 }
 
-func (s *SchedulerConf) NodeAffinitySelectorAllowedKeySet() map[string]struct{} {
-	extraKeyCount := 0
-	if s != nil {
-		extraKeyCount = len(s.NodeAffinitySelectorAllowedKeys)
-	}
-	allowed := make(map[string]struct{}, len(defaultNodeAffinitySelectorAllowedKeys)+extraKeyCount)
+func DefaultNodeAffinitySelectorAllowedKeySet() map[string]struct{} {
+	allowed := make(map[string]struct{}, len(defaultNodeAffinitySelectorAllowedKeys))
 	for _, key := range defaultNodeAffinitySelectorAllowedKeys {
 		allowed[key] = struct{}{}
 	}
-	if s == nil {
-		return allowed
-	}
-	for _, key := range s.NodeAffinitySelectorAllowedKeys {
-		allowed[key] = struct{}{}
+	return allowed
+}
+
+func (s *SchedulerConf) NodeAffinitySelectorAllowedKeySet() map[string]struct{} {
+	allowed := DefaultNodeAffinitySelectorAllowedKeySet()
+	if s != nil {
+		for _, key := range s.NodeAffinitySelectorAllowedKeys {
+			allowed[key] = struct{}{}
+		}
 	}
 	return allowed
 }

--- a/CubeMaster/pkg/base/config/config_test.go
+++ b/CubeMaster/pkg/base/config/config_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/constants"
 	"k8s.io/apimachinery/pkg/api/resource"
 )
 
@@ -202,4 +203,17 @@ func TestEffectiveQuotaClampsOverflow(t *testing.T) {
 	}
 	assert.Equal(t, int64(math.MaxInt64), sconf.EffectiveQuotaCpu("cubebox", math.MaxInt64))
 	assert.Equal(t, int64(math.MaxInt64), sconf.EffectiveQuotaMem("cubebox", math.MaxInt64))
+}
+
+func TestNodeAffinitySelectorAllowedKeySet(t *testing.T) {
+	sconf := &SchedulerConf{
+		NodeAffinitySelectorAllowedKeys: []string{"gpu"},
+	}
+
+	allowed := sconf.NodeAffinitySelectorAllowedKeySet()
+	assert.Contains(t, allowed, constants.AffinityKeyZone)
+	assert.Contains(t, allowed, constants.AffinityKeyClusterID)
+	assert.Contains(t, allowed, constants.AffinityKeyMemorySize)
+	assert.Contains(t, allowed, "gpu")
+	assert.NotContains(t, allowed, constants.AffinityKeyDisaterRecoverGroup)
 }

--- a/CubeMaster/pkg/base/config/config_test.go
+++ b/CubeMaster/pkg/base/config/config_test.go
@@ -217,3 +217,24 @@ func TestNodeAffinitySelectorAllowedKeySet(t *testing.T) {
 	assert.Contains(t, allowed, "gpu")
 	assert.NotContains(t, allowed, constants.AffinityKeyDisaterRecoverGroup)
 }
+
+func TestNodeAffinitySelectorAllowedKeySet_NilReceiver(t *testing.T) {
+	var sconf *SchedulerConf
+	allowed := sconf.NodeAffinitySelectorAllowedKeySet()
+	assert.Contains(t, allowed, constants.AffinityKeyZone)
+	assert.Contains(t, allowed, constants.AffinityKeyClusterID)
+	assert.Contains(t, allowed, constants.AffinityKeyInstanceType)
+	assert.NotContains(t, allowed, "gpu")
+}
+
+func TestDefaultNodeAffinitySelectorAllowedKeySet(t *testing.T) {
+	allowed := DefaultNodeAffinitySelectorAllowedKeySet()
+	assert.Contains(t, allowed, constants.AffinityKeyZone)
+	assert.Contains(t, allowed, constants.AffinityKeyClusterID)
+	assert.Contains(t, allowed, constants.AffinityKeyCPUType)
+	assert.Contains(t, allowed, constants.AffinityKeyMemorySize)
+	assert.Contains(t, allowed, constants.AffinityKeyCPUCores)
+	assert.Contains(t, allowed, constants.AffinityKeyInstanceType)
+	assert.NotContains(t, allowed, "gpu")
+	assert.NotContains(t, allowed, constants.AffinityKeyDisaterRecoverGroup)
+}

--- a/CubeMaster/pkg/base/constants/constants.go
+++ b/CubeMaster/pkg/base/constants/constants.go
@@ -31,6 +31,8 @@ const (
 	AnnotationsNodeAffinityClusterLabel = "com.nodeaffinity.cluster.label"
 
 	AnnotationsNodeAffinityInstanceType = "com.nodeaffinity.instancetype"
+
+	AnnotationsNodeAffinitySelector = "com.nodeaffinity.selector"
 )
 
 const (

--- a/CubeMaster/pkg/base/node/node.go
+++ b/CubeMaster/pkg/base/node/node.go
@@ -8,6 +8,7 @@ package node
 import (
 	"fmt"
 	"sort"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -88,7 +89,19 @@ type Node struct {
 	NicQueues      int64 `json:"nic_queues,omitempty"`
 
 	NodeLabels map[string]string `json:"NodeLabels,omitempty"`
+
+	labelsCache *nodeLabelsCacheStore
 }
+
+type nodeLabelsCache struct {
+	labels map[string]string
+}
+
+type nodeLabelsCacheStore struct {
+	cache atomic.Pointer[nodeLabelsCache]
+}
+
+var nodeLabelsCacheInitMu sync.Mutex
 
 func (n *Node) Clone() *Node {
 	if n == nil {
@@ -100,6 +113,7 @@ func (n *Node) Clone() *Node {
 	localCreateNum := atomic.LoadInt64(&n.LocalCreateNum)
 	cloned := *n
 	cloned.LocalCreateNum = localCreateNum
+	cloned.labelsCache = nil
 	if n.VirtualNodeQuotaArray != nil {
 		cloned.VirtualNodeQuotaArray = append([]int64(nil), n.VirtualNodeQuotaArray...)
 	}
@@ -110,6 +124,18 @@ func (n *Node) Clone() *Node {
 		}
 	}
 	return &cloned
+}
+
+func (n *Node) labelsCacheStore() *nodeLabelsCacheStore {
+	if n.labelsCache != nil {
+		return n.labelsCache
+	}
+	nodeLabelsCacheInitMu.Lock()
+	defer nodeLabelsCacheInitMu.Unlock()
+	if n.labelsCache == nil {
+		n.labelsCache = &nodeLabelsCacheStore{}
+	}
+	return n.labelsCache
 }
 
 func (n *Node) ID() string {
@@ -126,9 +152,14 @@ func (n *Node) LocalCreateNumIncrBy(i int64) int64 {
 }
 
 func (n *Node) Labels() map[string]string {
+	cacheStore := n.labelsCacheStore()
+	if cache := cacheStore.cache.Load(); cache != nil {
+		return cache.labels
+	}
+
 	// Canonical affinity keys derived from Node struct fields always take
 	// priority over node-reported labels, so they are written last.
-	labels := make(map[string]string)
+	labels := make(map[string]string, len(n.NodeLabels)+6)
 	for k, v := range n.NodeLabels {
 		labels[k] = v
 	}
@@ -138,7 +169,20 @@ func (n *Node) Labels() map[string]string {
 	labels[constants.AffinityKeyMemorySize] = fmt.Sprintf("%dMi", n.QuotaMem)
 	labels[constants.AffinityKeyCPUCores] = fmt.Sprintf("%dm", n.QuotaCpu)
 	labels[constants.AffinityKeyInstanceType] = n.InstanceType
+	cache := &nodeLabelsCache{labels: labels}
+	if cacheStore.cache.CompareAndSwap(nil, cache) {
+		return labels
+	}
+	if cache := cacheStore.cache.Load(); cache != nil {
+		return cache.labels
+	}
 	return labels
+}
+
+func (n *Node) InvalidateLabelsCache() {
+	if n.labelsCache != nil {
+		n.labelsCache.cache.Store(nil)
+	}
 }
 
 type NodeList []*Node

--- a/CubeMaster/pkg/base/node/node.go
+++ b/CubeMaster/pkg/base/node/node.go
@@ -86,6 +86,8 @@ type Node struct {
 
 	LocalCreateNum int64 `json:"LocalCreateNum,omitempty"`
 	NicQueues      int64 `json:"nic_queues,omitempty"`
+
+	NodeLabels map[string]string `json:"NodeLabels,omitempty"`
 }
 
 func (n *Node) Clone() *Node {
@@ -100,6 +102,12 @@ func (n *Node) Clone() *Node {
 	cloned.LocalCreateNum = localCreateNum
 	if n.VirtualNodeQuotaArray != nil {
 		cloned.VirtualNodeQuotaArray = append([]int64(nil), n.VirtualNodeQuotaArray...)
+	}
+	if n.NodeLabels != nil {
+		cloned.NodeLabels = make(map[string]string, len(n.NodeLabels))
+		for k, v := range n.NodeLabels {
+			cloned.NodeLabels[k] = v
+		}
 	}
 	return &cloned
 }
@@ -118,7 +126,12 @@ func (n *Node) LocalCreateNumIncrBy(i int64) int64 {
 }
 
 func (n *Node) Labels() map[string]string {
+	// Canonical affinity keys derived from Node struct fields always take
+	// priority over node-reported labels, so they are written last.
 	labels := make(map[string]string)
+	for k, v := range n.NodeLabels {
+		labels[k] = v
+	}
 	labels[constants.AffinityKeyZone] = n.Zone
 	labels[constants.AffinityKeyClusterID] = n.ClusterLabel
 	labels[constants.AffinityKeyCPUType] = n.CPUType

--- a/CubeMaster/pkg/base/node/node_test.go
+++ b/CubeMaster/pkg/base/node/node_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/constants"
 	"k8s.io/apimachinery/pkg/api/resource"
 )
 
@@ -304,4 +305,75 @@ func TestQuotaCpu(t *testing.T) {
 	afCpuSize := resource.MustParse(fmt.Sprintf("%dm", n.QuotaCpu))
 	gotCpu := resource.MustParse("90")
 	assert.Equal(t, gotCpu.Value(), afCpuSize.Value())
+}
+
+func TestNodeLabelsCachesMergedLabels(t *testing.T) {
+	n := &Node{
+		Zone:         "zone-a",
+		ClusterLabel: "cluster-a",
+		CPUType:      "x86",
+		QuotaMem:     4096,
+		QuotaCpu:     2000,
+		InstanceType: "SA2",
+		NodeLabels: map[string]string{
+			"gpu":                         "true",
+			constants.AffinityKeyZone:     "reported-zone",
+			constants.AffinityKeyCPUCores: "reported-cpu",
+		},
+	}
+
+	labels := n.Labels()
+	assert.Equal(t, "true", labels["gpu"])
+	assert.Equal(t, "zone-a", labels[constants.AffinityKeyZone])
+	assert.Equal(t, "2000m", labels[constants.AffinityKeyCPUCores])
+
+	labelsPtr := fmt.Sprintf("%p", labels)
+	assert.Equal(t, labelsPtr, fmt.Sprintf("%p", n.Labels()))
+	allocs := testing.AllocsPerRun(100, func() {
+		_ = n.Labels()
+	})
+	assert.Zero(t, allocs)
+}
+
+func TestNodeLabelsCacheInvalidation(t *testing.T) {
+	n := &Node{
+		Zone:       "zone-a",
+		QuotaMem:   4096,
+		QuotaCpu:   2000,
+		NodeLabels: map[string]string{"gpu": "true"},
+	}
+
+	oldLabels := n.Labels()
+	n.Zone = "zone-b"
+	n.QuotaMem = 8192
+	n.NodeLabels = map[string]string{"ssd": "true"}
+	n.InvalidateLabelsCache()
+
+	newLabels := n.Labels()
+	assert.NotEqual(t, fmt.Sprintf("%p", oldLabels), fmt.Sprintf("%p", newLabels))
+	assert.Equal(t, "zone-b", newLabels[constants.AffinityKeyZone])
+	assert.Equal(t, "8192Mi", newLabels[constants.AffinityKeyMemorySize])
+	assert.NotContains(t, newLabels, "gpu")
+	assert.Equal(t, "true", newLabels["ssd"])
+}
+
+func TestNodeCloneDoesNotShareLabelsCache(t *testing.T) {
+	n := &Node{
+		Zone:       "zone-a",
+		QuotaMem:   4096,
+		QuotaCpu:   2000,
+		NodeLabels: map[string]string{"gpu": "true"},
+	}
+	_ = n.Labels()
+
+	cloned := n.Clone()
+	cloned.Zone = "zone-b"
+	cloned.NodeLabels["gpu"] = "false"
+
+	sourceLabels := n.Labels()
+	clonedLabels := cloned.Labels()
+	assert.Equal(t, "zone-a", sourceLabels[constants.AffinityKeyZone])
+	assert.Equal(t, "true", sourceLabels["gpu"])
+	assert.Equal(t, "zone-b", clonedLabels[constants.AffinityKeyZone])
+	assert.Equal(t, "false", clonedLabels["gpu"])
 }

--- a/CubeMaster/pkg/localcache/node_cache.go
+++ b/CubeMaster/pkg/localcache/node_cache.go
@@ -311,6 +311,14 @@ func (l *local) updateNodeFromMetaData(n *node.Node) error {
 		old.CPUType = n.CPUType
 		old.InstanceType = n.InstanceType
 		old.OssClusterLabel = n.OssClusterLabel
+		var labels map[string]string
+		if n.NodeLabels != nil {
+			labels = make(map[string]string, len(n.NodeLabels))
+			for k, v := range n.NodeLabels {
+				labels[k] = v
+			}
+		}
+		old.NodeLabels = labels
 		l.lockMetaData.Unlock()
 
 		l.updateSortedNodes(old)

--- a/CubeMaster/pkg/localcache/node_cache.go
+++ b/CubeMaster/pkg/localcache/node_cache.go
@@ -319,6 +319,7 @@ func (l *local) updateNodeFromMetaData(n *node.Node) error {
 			}
 		}
 		old.NodeLabels = labels
+		old.InvalidateLabelsCache()
 		l.lockMetaData.Unlock()
 
 		l.updateSortedNodes(old)

--- a/CubeMaster/pkg/nodemeta/service.go
+++ b/CubeMaster/pkg/nodemeta/service.go
@@ -605,6 +605,7 @@ func toSchedulerNode(snap *NodeSnapshot) *node.Node {
 		CreateConcurrentNum: snap.CreateConcurrentNum,
 		MaxMvmLimit:         snap.MaxMvmNum,
 		MetaDataUpdateAt:    snap.HeartbeatTime,
+		NodeLabels:          cloneStringMap(snap.Labels),
 		// MetricUpdate / MetricLocalUpdateAt are intentionally left
 		// zero-valued here. They are owned by the resource-metric path
 		// (Redis tick or UpdateNodeMetricInProcess) so prefilter's

--- a/CubeMaster/pkg/scheduler/affinity/nodeaffinity.go
+++ b/CubeMaster/pkg/scheduler/affinity/nodeaffinity.go
@@ -146,9 +146,10 @@ func (w *wrapPreferredSchedulingTerms) Score(n NodeLabels) int64 {
 		return 0
 	}
 
-	if len(n.Labels()) == 0 {
+	labels := n.Labels()
+	if len(labels) == 0 {
 		return 0
 	}
 
-	return w.preferredSchedulingTerms.Score(&v1.Node{ObjectMeta: metav1.ObjectMeta{Labels: n.Labels()}})
+	return w.preferredSchedulingTerms.Score(&v1.Node{ObjectMeta: metav1.ObjectMeta{Labels: labels}})
 }

--- a/CubeMaster/pkg/service/httpservice/cube/affinityutil.go
+++ b/CubeMaster/pkg/service/httpservice/cube/affinityutil.go
@@ -161,10 +161,34 @@ type nodeSelectorRequirementJSON struct {
 	Values   []string                      `json:"values,omitempty"`
 }
 
+const (
+	// maxSelectorJSONSize limits the raw annotation value to prevent memory
+	// exhaustion from multi-megabyte JSON payloads (DoS hardening).
+	maxSelectorJSONSize = 4 * 1024
+
+	// maxSelectorRequirements caps the number of individual node selector
+	// requirements per sandbox create request.
+	maxSelectorRequirements = 10
+
+	// maxValuesPerRequirement caps the number of values for In / NotIn
+	// operators to prevent map inflation.
+	maxValuesPerRequirement = 50
+)
+
 func parseNodeAffinitySelector(selectorJSON string) ([]affinity.NodeSelectorRequirement, error) {
+	if len(selectorJSON) > maxSelectorJSONSize {
+		return nil, fmt.Errorf("annotation %s exceeds maximum size of %d bytes",
+			constants.AnnotationsNodeAffinitySelector, maxSelectorJSONSize)
+	}
+
 	var raw []nodeSelectorRequirementJSON
 	if err := json.Unmarshal([]byte(selectorJSON), &raw); err != nil {
-		return nil, fmt.Errorf("invalid com.nodeaffinity.selector JSON: %w", err)
+		return nil, fmt.Errorf("invalid %s JSON: %w", constants.AnnotationsNodeAffinitySelector, err)
+	}
+
+	if len(raw) > maxSelectorRequirements {
+		return nil, fmt.Errorf("annotation %s allows at most %d selector requirements, got %d",
+			constants.AnnotationsNodeAffinitySelector, maxSelectorRequirements, len(raw))
 	}
 
 	result := make([]affinity.NodeSelectorRequirement, 0, len(raw))
@@ -176,6 +200,10 @@ func parseNodeAffinitySelector(selectorJSON string) ([]affinity.NodeSelectorRequ
 		case affinity.NodeSelectorOpIn, affinity.NodeSelectorOpNotIn:
 			if len(r.Values) == 0 {
 				return nil, fmt.Errorf("operator %q requires non-empty values for key %q", r.Operator, r.Key)
+			}
+			if len(r.Values) > maxValuesPerRequirement {
+				return nil, fmt.Errorf("operator %q allows at most %d values, got %d",
+					r.Operator, maxValuesPerRequirement, len(r.Values))
 			}
 		case affinity.NodeSelectorOpExists, affinity.NodeSelectorOpDoesNotExist:
 			if len(r.Values) != 0 {
@@ -194,23 +222,9 @@ func parseNodeAffinitySelector(selectorJSON string) ([]affinity.NodeSelectorRequ
 		req := affinity.NodeSelectorRequirement{
 			Key:      r.Key,
 			Operator: r.Operator,
-			Values:   valuesSliceToMap(r.Values),
+			Values:   utils.SliceToMap(r.Values),
 		}
 		result = append(result, req)
 	}
 	return result, nil
-}
-
-// valuesSliceToMap converts a []string to map[string]any.
-// This bridges the gap between the JSON input format (values as array) and the
-// NodeSelectorRequirement.Values type (map[string]any).
-func valuesSliceToMap(vals []string) map[string]any {
-	if len(vals) == 0 {
-		return nil
-	}
-	m := make(map[string]any, len(vals))
-	for _, v := range vals {
-		m[v] = struct{}{}
-	}
-	return m
 }

--- a/CubeMaster/pkg/service/httpservice/cube/affinityutil.go
+++ b/CubeMaster/pkg/service/httpservice/cube/affinityutil.go
@@ -236,8 +236,7 @@ func parseNodeAffinitySelector(selectorJSON string) ([]affinity.NodeSelectorRequ
 func nodeAffinitySelectorAllowedKeys() map[string]struct{} {
 	cfg := config.GetConfig()
 	if cfg == nil || cfg.Scheduler == nil {
-		var schedulerConf *config.SchedulerConf
-		return schedulerConf.NodeAffinitySelectorAllowedKeySet()
+		return config.DefaultNodeAffinitySelectorAllowedKeySet()
 	}
 	return cfg.Scheduler.NodeAffinitySelectorAllowedKeySet()
 }

--- a/CubeMaster/pkg/service/httpservice/cube/affinityutil.go
+++ b/CubeMaster/pkg/service/httpservice/cube/affinityutil.go
@@ -6,6 +6,8 @@ package cube
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
 	"strings"
 
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/config"
@@ -17,8 +19,11 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 )
 
-func runInsReq2Affinity(ctx context.Context, req *types.CreateCubeSandboxReq) context.Context {
-	matchExpressionsWithANDed := constructNodeAffinity(ctx, req)
+func runInsReq2Affinity(ctx context.Context, req *types.CreateCubeSandboxReq) (context.Context, error) {
+	matchExpressionsWithANDed, err := constructNodeAffinity(ctx, req)
+	if err != nil {
+		return ctx, err
+	}
 
 	var nodeSelectorTerms []affinity.NodeSelectorTerm
 	if len(matchExpressionsWithANDed) > 0 {
@@ -28,8 +33,7 @@ func runInsReq2Affinity(ctx context.Context, req *types.CreateCubeSandboxReq) co
 	if len(nodeSelectorTerms) > 0 {
 		ns, err := affinity.NewNodeSelector(nodeSelectorTerms)
 		if err != nil {
-			log.G(ctx).Fatalf("runInsReq2Affinity NewNodeSelector fail:%s", err)
-			return ctx
+			return ctx, fmt.Errorf("runInsReq2Affinity NewNodeSelector fail: %w", err)
 		}
 		ctx = constants.WithNodeSelector(ctx, ns)
 
@@ -37,10 +41,10 @@ func runInsReq2Affinity(ctx context.Context, req *types.CreateCubeSandboxReq) co
 			ctx = constants.WithBackoffNodeSelector(ctx, ns)
 		}
 	}
-	return ctx
+	return ctx, nil
 }
 
-func constructNodeAffinity(ctx context.Context, req *types.CreateCubeSandboxReq) []affinity.NodeSelectorRequirement {
+func constructNodeAffinity(ctx context.Context, req *types.CreateCubeSandboxReq) ([]affinity.NodeSelectorRequirement, error) {
 	var matchExpressions []affinity.NodeSelectorRequirement
 
 	nodeClusterLabel := map[string]any{}
@@ -102,10 +106,18 @@ func constructNodeAffinity(ctx context.Context, req *types.CreateCubeSandboxReq)
 			}
 			matchExpressions = append(matchExpressions, requiredV)
 		}
+
+		if selectorJSON, ok := req.Annotations[constants.AnnotationsNodeAffinitySelector]; ok && selectorJSON != "" {
+			parsed, err := parseNodeAffinitySelector(selectorJSON)
+			if err != nil {
+				return nil, fmt.Errorf("parsing annotation %q: %w", constants.AnnotationsNodeAffinitySelector, err)
+			}
+			matchExpressions = append(matchExpressions, parsed...)
+		}
 	}
 
 	log.G(ctx).Debugf("constructNodeAffinity:%s", utils.InterfaceToString(matchExpressions))
-	return matchExpressions
+	return matchExpressions, nil
 }
 
 func isLargeMemSize(ctx context.Context, req *types.CreateCubeSandboxReq, largeMemSize string) bool {
@@ -138,4 +150,67 @@ func isLargeCpucores(ctx context.Context, req *types.CreateCubeSandboxReq, large
 		reqCpu.Add(ctncpuQuantity)
 	}
 	return reqCpu.Cmp(resource.MustParse(largeCpucores)) >= 0
+}
+
+// nodeSelectorRequirementJSON is an intermediate struct for JSON unmarshaling
+// where Values is a slice (matching the user-facing JSON format), which is then
+// converted to map[string]any to fit affinity.NodeSelectorRequirement.
+type nodeSelectorRequirementJSON struct {
+	Key      string                        `json:"key"`
+	Operator affinity.NodeSelectorOperator `json:"operator"`
+	Values   []string                      `json:"values,omitempty"`
+}
+
+func parseNodeAffinitySelector(selectorJSON string) ([]affinity.NodeSelectorRequirement, error) {
+	var raw []nodeSelectorRequirementJSON
+	if err := json.Unmarshal([]byte(selectorJSON), &raw); err != nil {
+		return nil, fmt.Errorf("invalid com.nodeaffinity.selector JSON: %w", err)
+	}
+
+	result := make([]affinity.NodeSelectorRequirement, 0, len(raw))
+	for _, r := range raw {
+		if r.Key == "" {
+			return nil, fmt.Errorf("node selector key must not be empty")
+		}
+		switch r.Operator {
+		case affinity.NodeSelectorOpIn, affinity.NodeSelectorOpNotIn:
+			if len(r.Values) == 0 {
+				return nil, fmt.Errorf("operator %q requires non-empty values for key %q", r.Operator, r.Key)
+			}
+		case affinity.NodeSelectorOpExists, affinity.NodeSelectorOpDoesNotExist:
+			if len(r.Values) != 0 {
+				return nil, fmt.Errorf("operator %q requires empty values for key %q", r.Operator, r.Key)
+			}
+		case affinity.NodeSelectorOpGt, affinity.NodeSelectorOpLt:
+			if len(r.Values) != 1 {
+				return nil, fmt.Errorf("operator %q requires exactly one value for key %q", r.Operator, r.Key)
+			}
+			if r.Key != constants.AffinityKeyMemorySize && r.Key != constants.AffinityKeyCPUCores {
+				return nil, fmt.Errorf("operator %q is only supported for keys %q and %q, got %q", r.Operator, constants.AffinityKeyMemorySize, constants.AffinityKeyCPUCores, r.Key)
+			}
+		default:
+			return nil, fmt.Errorf("unsupported operator %q for key %q", r.Operator, r.Key)
+		}
+		req := affinity.NodeSelectorRequirement{
+			Key:      r.Key,
+			Operator: r.Operator,
+			Values:   valuesSliceToMap(r.Values),
+		}
+		result = append(result, req)
+	}
+	return result, nil
+}
+
+// valuesSliceToMap converts a []string to map[string]any.
+// This bridges the gap between the JSON input format (values as array) and the
+// NodeSelectorRequirement.Values type (map[string]any).
+func valuesSliceToMap(vals []string) map[string]any {
+	if len(vals) == 0 {
+		return nil
+	}
+	m := make(map[string]any, len(vals))
+	for _, v := range vals {
+		m[v] = struct{}{}
+	}
+	return m
 }

--- a/CubeMaster/pkg/service/httpservice/cube/affinityutil.go
+++ b/CubeMaster/pkg/service/httpservice/cube/affinityutil.go
@@ -191,10 +191,14 @@ func parseNodeAffinitySelector(selectorJSON string) ([]affinity.NodeSelectorRequ
 			constants.AnnotationsNodeAffinitySelector, maxSelectorRequirements, len(raw))
 	}
 
+	allowedKeys := nodeAffinitySelectorAllowedKeys()
 	result := make([]affinity.NodeSelectorRequirement, 0, len(raw))
 	for _, r := range raw {
 		if r.Key == "" {
 			return nil, fmt.Errorf("node selector key must not be empty")
+		}
+		if _, ok := allowedKeys[r.Key]; !ok {
+			return nil, fmt.Errorf("node selector key %q is not allowed", r.Key)
 		}
 		switch r.Operator {
 		case affinity.NodeSelectorOpIn, affinity.NodeSelectorOpNotIn:
@@ -227,4 +231,13 @@ func parseNodeAffinitySelector(selectorJSON string) ([]affinity.NodeSelectorRequ
 		result = append(result, req)
 	}
 	return result, nil
+}
+
+func nodeAffinitySelectorAllowedKeys() map[string]struct{} {
+	cfg := config.GetConfig()
+	if cfg == nil || cfg.Scheduler == nil {
+		var schedulerConf *config.SchedulerConf
+		return schedulerConf.NodeAffinitySelectorAllowedKeySet()
+	}
+	return cfg.Scheduler.NodeAffinitySelectorAllowedKeySet()
 }

--- a/CubeMaster/pkg/service/httpservice/cube/affinityutil_test.go
+++ b/CubeMaster/pkg/service/httpservice/cube/affinityutil_test.go
@@ -6,6 +6,7 @@ package cube
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -538,7 +539,7 @@ func Test_parseNodeAffinitySelector(t *testing.T) {
 				assert.Len(t, result, 1)
 				assert.Equal(t, "gpu", result[0].Key)
 				assert.Equal(t, affinity.NodeSelectorOpExists, result[0].Operator)
-				assert.Nil(t, result[0].Values)
+				assert.Empty(t, result[0].Values)
 			},
 		},
 		{
@@ -548,7 +549,7 @@ func Test_parseNodeAffinitySelector(t *testing.T) {
 				assert.Len(t, result, 1)
 				assert.Equal(t, "tainted", result[0].Key)
 				assert.Equal(t, affinity.NodeSelectorOpDoesNotExist, result[0].Operator)
-				assert.Nil(t, result[0].Values)
+				assert.Empty(t, result[0].Values)
 			},
 		},
 		{
@@ -725,6 +726,38 @@ func Test_parseNodeAffinitySelector(t *testing.T) {
 			errMsg:  "unsupported operator",
 		},
 
+		// ---- size / complexity limits (DoS hardening) ----
+		{
+			name:    "JSON exceeds 4KB limit",
+			json:    `[{"key":"` + strings.Repeat("k", 4*1024) + `","operator":"Exists"}]`,
+			wantErr: true,
+			errMsg:  "exceeds maximum size",
+		},
+		{
+			name: "more than 10 selector requirements",
+			json: `[
+				{"key":"k0","operator":"Exists"},
+				{"key":"k1","operator":"Exists"},
+				{"key":"k2","operator":"Exists"},
+				{"key":"k3","operator":"Exists"},
+				{"key":"k4","operator":"Exists"},
+				{"key":"k5","operator":"Exists"},
+				{"key":"k6","operator":"Exists"},
+				{"key":"k7","operator":"Exists"},
+				{"key":"k8","operator":"Exists"},
+				{"key":"k9","operator":"Exists"},
+				{"key":"k10","operator":"Exists"}
+			]`,
+			wantErr: true,
+			errMsg: "allows at most",
+		},
+		{
+			name:    "In with more than 50 values",
+			json:    `[{"key":"label","operator":"In","values":[` + strings.Repeat(`"v",`, 50) + `"v"]}]`,
+			wantErr: true,
+			errMsg:  "allows at most",
+		},
+
 		// ---- second element fails validation ----
 		{
 			name: "first valid, second invalid",
@@ -752,51 +785,6 @@ func Test_parseNodeAffinitySelector(t *testing.T) {
 					tt.check(t, result)
 				}
 			}
-		})
-	}
-}
-
-// ---------------------------------------------------------------------------
-// valuesSliceToMap tests
-// ---------------------------------------------------------------------------
-
-func Test_valuesSliceToMap(t *testing.T) {
-	tests := []struct {
-		name string
-		vals []string
-		want map[string]any
-	}{
-		{
-			name: "nil slice",
-			vals: nil,
-			want: nil,
-		},
-		{
-			name: "empty slice",
-			vals: []string{},
-			want: nil,
-		},
-		{
-			name: "single value",
-			vals: []string{"a"},
-			want: map[string]any{"a": struct{}{}},
-		},
-		{
-			name: "multiple values",
-			vals: []string{"a", "b", "c"},
-			want: map[string]any{"a": struct{}{}, "b": struct{}{}, "c": struct{}{}},
-		},
-		{
-			name: "duplicate values collapse",
-			vals: []string{"a", "a", "b"},
-			want: map[string]any{"a": struct{}{}, "b": struct{}{}},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := valuesSliceToMap(tt.vals)
-			assert.Equal(t, tt.want, got)
 		})
 	}
 }

--- a/CubeMaster/pkg/service/httpservice/cube/affinityutil_test.go
+++ b/CubeMaster/pkg/service/httpservice/cube/affinityutil_test.go
@@ -16,6 +16,16 @@ import (
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/service/sandbox/types"
 )
 
+func withNodeAffinitySelectorAllowedKeys(t *testing.T, keys ...string) {
+	t.Helper()
+	scheduler := config.GetConfig().Scheduler
+	original := append([]string(nil), scheduler.NodeAffinitySelectorAllowedKeys...)
+	scheduler.NodeAffinitySelectorAllowedKeys = append([]string(nil), keys...)
+	t.Cleanup(func() {
+		scheduler.NodeAffinitySelectorAllowedKeys = original
+	})
+}
+
 func Test_isLargeMemSize(t *testing.T) {
 	type args struct {
 		ctx          context.Context
@@ -476,11 +486,12 @@ func TestGetTemplateVolumes(t *testing.T) {
 
 func Test_parseNodeAffinitySelector(t *testing.T) {
 	tests := []struct {
-		name    string
-		json    string
-		wantErr bool
-		errMsg  string
-		check   func(t *testing.T, result []affinity.NodeSelectorRequirement)
+		name        string
+		json        string
+		allowedKeys []string
+		wantErr     bool
+		errMsg      string
+		check       func(t *testing.T, result []affinity.NodeSelectorRequirement)
 	}{
 		// ---- valid cases ----
 		{
@@ -491,8 +502,9 @@ func Test_parseNodeAffinitySelector(t *testing.T) {
 			},
 		},
 		{
-			name: "In with single value",
-			json: `[{"key":"custom-label","operator":"In","values":["val1"]}]`,
+			name:        "In with single value",
+			json:        `[{"key":"custom-label","operator":"In","values":["val1"]}]`,
+			allowedKeys: []string{"custom-label"},
 			check: func(t *testing.T, result []affinity.NodeSelectorRequirement) {
 				assert.Len(t, result, 1)
 				assert.Equal(t, "custom-label", result[0].Key)
@@ -501,8 +513,9 @@ func Test_parseNodeAffinitySelector(t *testing.T) {
 			},
 		},
 		{
-			name: "In with multiple values",
-			json: `[{"key":"zone","operator":"In","values":["zone-a","zone-b","zone-c"]}]`,
+			name:        "In with multiple values",
+			json:        `[{"key":"zone","operator":"In","values":["zone-a","zone-b","zone-c"]}]`,
+			allowedKeys: []string{"zone"},
 			check: func(t *testing.T, result []affinity.NodeSelectorRequirement) {
 				assert.Len(t, result, 1)
 				assert.Equal(t, "zone", result[0].Key)
@@ -514,8 +527,9 @@ func Test_parseNodeAffinitySelector(t *testing.T) {
 			},
 		},
 		{
-			name: "In deduplicates values",
-			json: `[{"key":"label","operator":"In","values":["v","v","v"]}]`,
+			name:        "In deduplicates values",
+			json:        `[{"key":"label","operator":"In","values":["v","v","v"]}]`,
+			allowedKeys: []string{"label"},
 			check: func(t *testing.T, result []affinity.NodeSelectorRequirement) {
 				assert.Len(t, result, 1)
 				assert.Len(t, result[0].Values, 1)
@@ -523,8 +537,9 @@ func Test_parseNodeAffinitySelector(t *testing.T) {
 			},
 		},
 		{
-			name: "NotIn with values",
-			json: `[{"key":"instance-type","operator":"NotIn","values":["gpu","fpga"]}]`,
+			name:        "NotIn with values",
+			json:        `[{"key":"instance-type","operator":"NotIn","values":["gpu","fpga"]}]`,
+			allowedKeys: []string{"instance-type"},
 			check: func(t *testing.T, result []affinity.NodeSelectorRequirement) {
 				assert.Len(t, result, 1)
 				assert.Equal(t, "instance-type", result[0].Key)
@@ -533,8 +548,9 @@ func Test_parseNodeAffinitySelector(t *testing.T) {
 			},
 		},
 		{
-			name: "Exists operator",
-			json: `[{"key":"gpu","operator":"Exists"}]`,
+			name:        "Exists operator",
+			json:        `[{"key":"gpu","operator":"Exists"}]`,
+			allowedKeys: []string{"gpu"},
 			check: func(t *testing.T, result []affinity.NodeSelectorRequirement) {
 				assert.Len(t, result, 1)
 				assert.Equal(t, "gpu", result[0].Key)
@@ -543,8 +559,9 @@ func Test_parseNodeAffinitySelector(t *testing.T) {
 			},
 		},
 		{
-			name: "DoesNotExist operator",
-			json: `[{"key":"tainted","operator":"DoesNotExist"}]`,
+			name:        "DoesNotExist operator",
+			json:        `[{"key":"tainted","operator":"DoesNotExist"}]`,
+			allowedKeys: []string{"tainted"},
 			check: func(t *testing.T, result []affinity.NodeSelectorRequirement) {
 				assert.Len(t, result, 1)
 				assert.Equal(t, "tainted", result[0].Key)
@@ -590,6 +607,7 @@ func Test_parseNodeAffinitySelector(t *testing.T) {
 				{"key":"kubernetes.io/memory-size","operator":"Gt","values":["2048Mi"]},
 				{"key":"custom-label","operator":"In","values":["a","b"]}
 			]`,
+			allowedKeys: []string{"gpu", "custom-label"},
 			check: func(t *testing.T, result []affinity.NodeSelectorRequirement) {
 				assert.Len(t, result, 3)
 				assert.Equal(t, affinity.NodeSelectorOpExists, result[0].Operator)
@@ -622,42 +640,48 @@ func Test_parseNodeAffinitySelector(t *testing.T) {
 
 		// ---- In/NotIn with empty values ----
 		{
-			name:    "In with empty values array",
-			json:    `[{"key":"label","operator":"In","values":[]}]`,
-			wantErr: true,
-			errMsg:  "requires non-empty values",
+			name:        "In with empty values array",
+			json:        `[{"key":"label","operator":"In","values":[]}]`,
+			allowedKeys: []string{"label"},
+			wantErr:     true,
+			errMsg:      "requires non-empty values",
 		},
 		{
-			name:    "In with omitted values",
-			json:    `[{"key":"label","operator":"In"}]`,
-			wantErr: true,
-			errMsg:  "requires non-empty values",
+			name:        "In with omitted values",
+			json:        `[{"key":"label","operator":"In"}]`,
+			allowedKeys: []string{"label"},
+			wantErr:     true,
+			errMsg:      "requires non-empty values",
 		},
 		{
-			name:    "NotIn with empty values array",
-			json:    `[{"key":"label","operator":"NotIn","values":[]}]`,
-			wantErr: true,
-			errMsg:  "requires non-empty values",
+			name:        "NotIn with empty values array",
+			json:        `[{"key":"label","operator":"NotIn","values":[]}]`,
+			allowedKeys: []string{"label"},
+			wantErr:     true,
+			errMsg:      "requires non-empty values",
 		},
 		{
-			name:    "NotIn with omitted values",
-			json:    `[{"key":"label","operator":"NotIn"}]`,
-			wantErr: true,
-			errMsg:  "requires non-empty values",
+			name:        "NotIn with omitted values",
+			json:        `[{"key":"label","operator":"NotIn"}]`,
+			allowedKeys: []string{"label"},
+			wantErr:     true,
+			errMsg:      "requires non-empty values",
 		},
 
 		// ---- Exists/DoesNotExist with values ----
 		{
-			name:    "Exists with values",
-			json:    `[{"key":"label","operator":"Exists","values":["x"]}]`,
-			wantErr: true,
-			errMsg:  "requires empty values",
+			name:        "Exists with values",
+			json:        `[{"key":"label","operator":"Exists","values":["x"]}]`,
+			allowedKeys: []string{"label"},
+			wantErr:     true,
+			errMsg:      "requires empty values",
 		},
 		{
-			name:    "DoesNotExist with values",
-			json:    `[{"key":"label","operator":"DoesNotExist","values":["x"]}]`,
-			wantErr: true,
-			errMsg:  "requires empty values",
+			name:        "DoesNotExist with values",
+			json:        `[{"key":"label","operator":"DoesNotExist","values":["x"]}]`,
+			allowedKeys: []string{"label"},
+			wantErr:     true,
+			errMsg:      "requires empty values",
 		},
 
 		// ---- Gt/Lt with wrong value count ----
@@ -700,30 +724,46 @@ func Test_parseNodeAffinitySelector(t *testing.T) {
 			errMsg:  "is only supported for keys",
 		},
 		{
-			name:    "Gt on custom key",
-			json:    `[{"key":"custom-label","operator":"Gt","values":["100"]}]`,
-			wantErr: true,
-			errMsg:  "is only supported for keys",
+			name:        "Gt on custom key",
+			json:        `[{"key":"custom-label","operator":"Gt","values":["100"]}]`,
+			allowedKeys: []string{"custom-label"},
+			wantErr:     true,
+			errMsg:      "is only supported for keys",
 		},
 		{
-			name:    "Lt on custom key",
-			json:    `[{"key":"custom-label","operator":"Lt","values":["100"]}]`,
-			wantErr: true,
-			errMsg:  "is only supported for keys",
+			name:        "Lt on custom key",
+			json:        `[{"key":"custom-label","operator":"Lt","values":["100"]}]`,
+			allowedKeys: []string{"custom-label"},
+			wantErr:     true,
+			errMsg:      "is only supported for keys",
 		},
 
 		// ---- unsupported operator ----
 		{
-			name:    "unsupported operator",
-			json:    `[{"key":"label","operator":"BadOp"}]`,
-			wantErr: true,
-			errMsg:  "unsupported operator",
+			name:        "unsupported operator",
+			json:        `[{"key":"label","operator":"BadOp"}]`,
+			allowedKeys: []string{"label"},
+			wantErr:     true,
+			errMsg:      "unsupported operator",
 		},
 		{
-			name:    "empty operator string",
-			json:    `[{"key":"label","operator":""}]`,
+			name:        "empty operator string",
+			json:        `[{"key":"label","operator":""}]`,
+			allowedKeys: []string{"label"},
+			wantErr:     true,
+			errMsg:      "unsupported operator",
+		},
+		{
+			name:    "unauthorized custom key",
+			json:    `[{"key":"gpu","operator":"Exists"}]`,
 			wantErr: true,
-			errMsg:  "unsupported operator",
+			errMsg:  `node selector key "gpu" is not allowed`,
+		},
+		{
+			name:    "unauthorized internal key probe",
+			json:    `[{"key":"topology.kubernetes.io/disaster-recover-group-id","operator":"Exists"}]`,
+			wantErr: true,
+			errMsg:  `node selector key "topology.kubernetes.io/disaster-recover-group-id" is not allowed`,
 		},
 
 		// ---- size / complexity limits (DoS hardening) ----
@@ -749,13 +789,14 @@ func Test_parseNodeAffinitySelector(t *testing.T) {
 				{"key":"k10","operator":"Exists"}
 			]`,
 			wantErr: true,
-			errMsg: "allows at most",
+			errMsg:  "allows at most",
 		},
 		{
-			name:    "In with more than 50 values",
-			json:    `[{"key":"label","operator":"In","values":[` + strings.Repeat(`"v",`, 50) + `"v"]}]`,
-			wantErr: true,
-			errMsg:  "allows at most",
+			name:        "In with more than 50 values",
+			json:        `[{"key":"label","operator":"In","values":[` + strings.Repeat(`"v",`, 50) + `"v"]}]`,
+			allowedKeys: []string{"label"},
+			wantErr:     true,
+			errMsg:      "allows at most",
 		},
 
 		// ---- second element fails validation ----
@@ -765,13 +806,17 @@ func Test_parseNodeAffinitySelector(t *testing.T) {
 				{"key":"gpu","operator":"Exists"},
 				{"key":"","operator":"In","values":["v"]}
 			]`,
-			wantErr: true,
-			errMsg:  "node selector key must not be empty",
+			allowedKeys: []string{"gpu"},
+			wantErr:     true,
+			errMsg:      "node selector key must not be empty",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			if tt.allowedKeys != nil {
+				withNodeAffinitySelectorAllowedKeys(t, tt.allowedKeys...)
+			}
 			result, err := parseNodeAffinitySelector(tt.json)
 			if tt.wantErr {
 				assert.Error(t, err)
@@ -797,11 +842,12 @@ func Test_constructNodeAffinity(t *testing.T) {
 	ctx := context.Background()
 
 	tests := []struct {
-		name    string
-		req     *types.CreateCubeSandboxReq
-		wantErr bool
-		errMsg  string
-		check   func(t *testing.T, result []affinity.NodeSelectorRequirement)
+		name        string
+		req         *types.CreateCubeSandboxReq
+		allowedKeys []string
+		wantErr     bool
+		errMsg      string
+		check       func(t *testing.T, result []affinity.NodeSelectorRequirement)
 	}{
 		{
 			name: "nil annotations",
@@ -873,7 +919,8 @@ func Test_constructNodeAffinity(t *testing.T) {
 			},
 		},
 		{
-			name: "valid affinity selector only",
+			name:        "valid affinity selector only",
+			allowedKeys: []string{"gpu"},
 			req: &types.CreateCubeSandboxReq{
 				Request: &types.Request{RequestID: "req-5"},
 				Annotations: map[string]string{
@@ -894,7 +941,8 @@ func Test_constructNodeAffinity(t *testing.T) {
 			},
 		},
 		{
-			name: "cluster label + instance type + selector combined",
+			name:        "cluster label + instance type + selector combined",
+			allowedKeys: []string{"gpu", "custom"},
 			req: &types.CreateCubeSandboxReq{
 				Request: &types.Request{RequestID: "req-6"},
 				Annotations: map[string]string{
@@ -917,7 +965,8 @@ func Test_constructNodeAffinity(t *testing.T) {
 			},
 		},
 		{
-			name: "selector with Gt and Lt and Exists",
+			name:        "selector with Gt and Lt and Exists",
+			allowedKeys: []string{"ssd"},
 			req: &types.CreateCubeSandboxReq{
 				Request: &types.Request{RequestID: "req-7"},
 				Annotations: map[string]string{
@@ -999,7 +1048,8 @@ func Test_constructNodeAffinity(t *testing.T) {
 			errMsg:  "node selector key must not be empty",
 		},
 		{
-			name: "selector with unsupported Gt key returns error",
+			name:        "selector with unsupported Gt key returns error",
+			allowedKeys: []string{"bad-key"},
 			req: &types.CreateCubeSandboxReq{
 				Request: &types.Request{RequestID: "req-err-3"},
 				Annotations: map[string]string{
@@ -1010,6 +1060,19 @@ func Test_constructNodeAffinity(t *testing.T) {
 			},
 			wantErr: true,
 			errMsg:  "is only supported for keys",
+		},
+		{
+			name: "selector with unauthorized custom key returns error",
+			req: &types.CreateCubeSandboxReq{
+				Request: &types.Request{RequestID: "req-err-4"},
+				Annotations: map[string]string{
+					"com.nodeaffinity.selector": `[{"key":"gpu","operator":"Exists"}]`,
+				},
+				Containers:   []*types.Container{},
+				InstanceType: "cubebox",
+			},
+			wantErr: true,
+			errMsg:  `node selector key "gpu" is not allowed`,
 		},
 		{
 			name: "empty selector string is silently ignored",
@@ -1029,6 +1092,9 @@ func Test_constructNodeAffinity(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			if tt.allowedKeys != nil {
+				withNodeAffinitySelectorAllowedKeys(t, tt.allowedKeys...)
+			}
 			result, err := constructNodeAffinity(ctx, tt.req)
 			if tt.wantErr {
 				assert.Error(t, err)
@@ -1065,6 +1131,7 @@ func Test_runInsReq2Affinity(t *testing.T) {
 	})
 
 	t.Run("valid selector stores NodeSelector in context", func(t *testing.T) {
+		withNodeAffinitySelectorAllowedKeys(t, "gpu")
 		req := &types.CreateCubeSandboxReq{
 			Request: &types.Request{RequestID: "req-2"},
 			Annotations: map[string]string{
@@ -1097,6 +1164,7 @@ func Test_runInsReq2Affinity(t *testing.T) {
 	})
 
 	t.Run("instance type annotation also sets backoff NodeSelector", func(t *testing.T) {
+		withNodeAffinitySelectorAllowedKeys(t, "ssd")
 		req := &types.CreateCubeSandboxReq{
 			Request: &types.Request{RequestID: "req-4"},
 			Annotations: map[string]string{

--- a/CubeMaster/pkg/service/httpservice/cube/affinityutil_test.go
+++ b/CubeMaster/pkg/service/httpservice/cube/affinityutil_test.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/config"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/constants"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/scheduler/affinity"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/service/sandbox/types"
 )
 
@@ -465,4 +467,664 @@ func TestGetTemplateVolumes(t *testing.T) {
 			}
 		})
 	}
+}
+
+// ---------------------------------------------------------------------------
+// parseNodeAffinitySelector tests
+// ---------------------------------------------------------------------------
+
+func Test_parseNodeAffinitySelector(t *testing.T) {
+	tests := []struct {
+		name    string
+		json    string
+		wantErr bool
+		errMsg  string
+		check   func(t *testing.T, result []affinity.NodeSelectorRequirement)
+	}{
+		// ---- valid cases ----
+		{
+			name: "empty array",
+			json: `[]`,
+			check: func(t *testing.T, result []affinity.NodeSelectorRequirement) {
+				assert.Empty(t, result)
+			},
+		},
+		{
+			name: "In with single value",
+			json: `[{"key":"custom-label","operator":"In","values":["val1"]}]`,
+			check: func(t *testing.T, result []affinity.NodeSelectorRequirement) {
+				assert.Len(t, result, 1)
+				assert.Equal(t, "custom-label", result[0].Key)
+				assert.Equal(t, affinity.NodeSelectorOpIn, result[0].Operator)
+				assert.Equal(t, map[string]any{"val1": struct{}{}}, result[0].Values)
+			},
+		},
+		{
+			name: "In with multiple values",
+			json: `[{"key":"zone","operator":"In","values":["zone-a","zone-b","zone-c"]}]`,
+			check: func(t *testing.T, result []affinity.NodeSelectorRequirement) {
+				assert.Len(t, result, 1)
+				assert.Equal(t, "zone", result[0].Key)
+				assert.Equal(t, affinity.NodeSelectorOpIn, result[0].Operator)
+				assert.Len(t, result[0].Values, 3)
+				assert.Contains(t, result[0].Values, "zone-a")
+				assert.Contains(t, result[0].Values, "zone-b")
+				assert.Contains(t, result[0].Values, "zone-c")
+			},
+		},
+		{
+			name: "In deduplicates values",
+			json: `[{"key":"label","operator":"In","values":["v","v","v"]}]`,
+			check: func(t *testing.T, result []affinity.NodeSelectorRequirement) {
+				assert.Len(t, result, 1)
+				assert.Len(t, result[0].Values, 1)
+				assert.Contains(t, result[0].Values, "v")
+			},
+		},
+		{
+			name: "NotIn with values",
+			json: `[{"key":"instance-type","operator":"NotIn","values":["gpu","fpga"]}]`,
+			check: func(t *testing.T, result []affinity.NodeSelectorRequirement) {
+				assert.Len(t, result, 1)
+				assert.Equal(t, "instance-type", result[0].Key)
+				assert.Equal(t, affinity.NodeSelectorOpNotIn, result[0].Operator)
+				assert.Len(t, result[0].Values, 2)
+			},
+		},
+		{
+			name: "Exists operator",
+			json: `[{"key":"gpu","operator":"Exists"}]`,
+			check: func(t *testing.T, result []affinity.NodeSelectorRequirement) {
+				assert.Len(t, result, 1)
+				assert.Equal(t, "gpu", result[0].Key)
+				assert.Equal(t, affinity.NodeSelectorOpExists, result[0].Operator)
+				assert.Nil(t, result[0].Values)
+			},
+		},
+		{
+			name: "DoesNotExist operator",
+			json: `[{"key":"tainted","operator":"DoesNotExist"}]`,
+			check: func(t *testing.T, result []affinity.NodeSelectorRequirement) {
+				assert.Len(t, result, 1)
+				assert.Equal(t, "tainted", result[0].Key)
+				assert.Equal(t, affinity.NodeSelectorOpDoesNotExist, result[0].Operator)
+				assert.Nil(t, result[0].Values)
+			},
+		},
+		{
+			name: "Gt on memory-size",
+			json: `[{"key":"kubernetes.io/memory-size","operator":"Gt","values":["4096Mi"]}]`,
+			check: func(t *testing.T, result []affinity.NodeSelectorRequirement) {
+				assert.Len(t, result, 1)
+				assert.Equal(t, "kubernetes.io/memory-size", result[0].Key)
+				assert.Equal(t, affinity.NodeSelectorOpGt, result[0].Operator)
+				assert.Len(t, result[0].Values, 1)
+				assert.Contains(t, result[0].Values, "4096Mi")
+			},
+		},
+		{
+			name: "Lt on cpu-cores",
+			json: `[{"key":"kubernetes.io/cpu-cores","operator":"Lt","values":["8000m"]}]`,
+			check: func(t *testing.T, result []affinity.NodeSelectorRequirement) {
+				assert.Len(t, result, 1)
+				assert.Equal(t, "kubernetes.io/cpu-cores", result[0].Key)
+				assert.Equal(t, affinity.NodeSelectorOpLt, result[0].Operator)
+				assert.Len(t, result[0].Values, 1)
+				assert.Contains(t, result[0].Values, "8000m")
+			},
+		},
+		{
+			name: "Lt on memory-size",
+			json: `[{"key":"kubernetes.io/memory-size","operator":"Lt","values":["8192Mi"]}]`,
+			check: func(t *testing.T, result []affinity.NodeSelectorRequirement) {
+				assert.Len(t, result, 1)
+				assert.Equal(t, "kubernetes.io/memory-size", result[0].Key)
+				assert.Equal(t, affinity.NodeSelectorOpLt, result[0].Operator)
+			},
+		},
+		{
+			name: "multiple mixed requirements",
+			json: `[
+				{"key":"gpu","operator":"Exists"},
+				{"key":"kubernetes.io/memory-size","operator":"Gt","values":["2048Mi"]},
+				{"key":"custom-label","operator":"In","values":["a","b"]}
+			]`,
+			check: func(t *testing.T, result []affinity.NodeSelectorRequirement) {
+				assert.Len(t, result, 3)
+				assert.Equal(t, affinity.NodeSelectorOpExists, result[0].Operator)
+				assert.Equal(t, affinity.NodeSelectorOpGt, result[1].Operator)
+				assert.Equal(t, affinity.NodeSelectorOpIn, result[2].Operator)
+			},
+		},
+
+		// ---- invalid JSON ----
+		{
+			name:    "malformed JSON",
+			json:    `{not json`,
+			wantErr: true,
+			errMsg:  "invalid com.nodeaffinity.selector JSON",
+		},
+		{
+			name:    "JSON object instead of array",
+			json:    `{"key":"x","operator":"In"}`,
+			wantErr: true,
+			errMsg:  "invalid com.nodeaffinity.selector JSON",
+		},
+
+		// ---- empty key ----
+		{
+			name:    "empty key",
+			json:    `[{"key":"","operator":"In","values":["v"]}]`,
+			wantErr: true,
+			errMsg:  "node selector key must not be empty",
+		},
+
+		// ---- In/NotIn with empty values ----
+		{
+			name:    "In with empty values array",
+			json:    `[{"key":"label","operator":"In","values":[]}]`,
+			wantErr: true,
+			errMsg:  "requires non-empty values",
+		},
+		{
+			name:    "In with omitted values",
+			json:    `[{"key":"label","operator":"In"}]`,
+			wantErr: true,
+			errMsg:  "requires non-empty values",
+		},
+		{
+			name:    "NotIn with empty values array",
+			json:    `[{"key":"label","operator":"NotIn","values":[]}]`,
+			wantErr: true,
+			errMsg:  "requires non-empty values",
+		},
+		{
+			name:    "NotIn with omitted values",
+			json:    `[{"key":"label","operator":"NotIn"}]`,
+			wantErr: true,
+			errMsg:  "requires non-empty values",
+		},
+
+		// ---- Exists/DoesNotExist with values ----
+		{
+			name:    "Exists with values",
+			json:    `[{"key":"label","operator":"Exists","values":["x"]}]`,
+			wantErr: true,
+			errMsg:  "requires empty values",
+		},
+		{
+			name:    "DoesNotExist with values",
+			json:    `[{"key":"label","operator":"DoesNotExist","values":["x"]}]`,
+			wantErr: true,
+			errMsg:  "requires empty values",
+		},
+
+		// ---- Gt/Lt with wrong value count ----
+		{
+			name:    "Gt with zero values",
+			json:    `[{"key":"kubernetes.io/memory-size","operator":"Gt"}]`,
+			wantErr: true,
+			errMsg:  "requires exactly one value",
+		},
+		{
+			name:    "Gt with two values",
+			json:    `[{"key":"kubernetes.io/memory-size","operator":"Gt","values":["1Gi","2Gi"]}]`,
+			wantErr: true,
+			errMsg:  "requires exactly one value",
+		},
+		{
+			name:    "Lt with zero values",
+			json:    `[{"key":"kubernetes.io/cpu-cores","operator":"Lt"}]`,
+			wantErr: true,
+			errMsg:  "requires exactly one value",
+		},
+		{
+			name:    "Lt with two values",
+			json:    `[{"key":"kubernetes.io/cpu-cores","operator":"Lt","values":["1","2"]}]`,
+			wantErr: true,
+			errMsg:  "requires exactly one value",
+		},
+
+		// ---- Gt/Lt on unsupported keys ----
+		{
+			name:    "Gt on instance-type key",
+			json:    `[{"key":"kubernetes.io/instance-type","operator":"Gt","values":["1"]}]`,
+			wantErr: true,
+			errMsg:  "is only supported for keys",
+		},
+		{
+			name:    "Lt on zone key",
+			json:    `[{"key":"topology.kubernetes.io/zone","operator":"Lt","values":["1"]}]`,
+			wantErr: true,
+			errMsg:  "is only supported for keys",
+		},
+		{
+			name:    "Gt on custom key",
+			json:    `[{"key":"custom-label","operator":"Gt","values":["100"]}]`,
+			wantErr: true,
+			errMsg:  "is only supported for keys",
+		},
+		{
+			name:    "Lt on custom key",
+			json:    `[{"key":"custom-label","operator":"Lt","values":["100"]}]`,
+			wantErr: true,
+			errMsg:  "is only supported for keys",
+		},
+
+		// ---- unsupported operator ----
+		{
+			name:    "unsupported operator",
+			json:    `[{"key":"label","operator":"BadOp"}]`,
+			wantErr: true,
+			errMsg:  "unsupported operator",
+		},
+		{
+			name:    "empty operator string",
+			json:    `[{"key":"label","operator":""}]`,
+			wantErr: true,
+			errMsg:  "unsupported operator",
+		},
+
+		// ---- second element fails validation ----
+		{
+			name: "first valid, second invalid",
+			json: `[
+				{"key":"gpu","operator":"Exists"},
+				{"key":"","operator":"In","values":["v"]}
+			]`,
+			wantErr: true,
+			errMsg:  "node selector key must not be empty",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := parseNodeAffinitySelector(tt.json)
+			if tt.wantErr {
+				assert.Error(t, err)
+				if tt.errMsg != "" {
+					assert.Contains(t, err.Error(), tt.errMsg)
+				}
+				assert.Nil(t, result)
+			} else {
+				assert.NoError(t, err)
+				if tt.check != nil {
+					tt.check(t, result)
+				}
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// valuesSliceToMap tests
+// ---------------------------------------------------------------------------
+
+func Test_valuesSliceToMap(t *testing.T) {
+	tests := []struct {
+		name string
+		vals []string
+		want map[string]any
+	}{
+		{
+			name: "nil slice",
+			vals: nil,
+			want: nil,
+		},
+		{
+			name: "empty slice",
+			vals: []string{},
+			want: nil,
+		},
+		{
+			name: "single value",
+			vals: []string{"a"},
+			want: map[string]any{"a": struct{}{}},
+		},
+		{
+			name: "multiple values",
+			vals: []string{"a", "b", "c"},
+			want: map[string]any{"a": struct{}{}, "b": struct{}{}, "c": struct{}{}},
+		},
+		{
+			name: "duplicate values collapse",
+			vals: []string{"a", "a", "b"},
+			want: map[string]any{"a": struct{}{}, "b": struct{}{}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := valuesSliceToMap(tt.vals)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// constructNodeAffinity tests
+// ---------------------------------------------------------------------------
+
+func Test_constructNodeAffinity(t *testing.T) {
+	ctx := context.Background()
+
+	tests := []struct {
+		name    string
+		req     *types.CreateCubeSandboxReq
+		wantErr bool
+		errMsg  string
+		check   func(t *testing.T, result []affinity.NodeSelectorRequirement)
+	}{
+		{
+			name: "nil annotations",
+			req: &types.CreateCubeSandboxReq{
+				Request:      &types.Request{RequestID: "req-1"},
+				Annotations:  nil,
+				Containers:   []*types.Container{},
+				InstanceType: "cubebox",
+			},
+			check: func(t *testing.T, result []affinity.NodeSelectorRequirement) {
+				// nil annotations produce no annotation-derived expressions
+				// (Go nil slice is fine)
+			},
+		},
+		{
+			name: "empty annotations",
+			req: &types.CreateCubeSandboxReq{
+				Request:      &types.Request{RequestID: "req-2"},
+				Annotations:  map[string]string{},
+				Containers:   []*types.Container{},
+				InstanceType: "cubebox",
+			},
+			check: func(t *testing.T, result []affinity.NodeSelectorRequirement) {
+				// empty annotations produce no annotation-derived expressions
+			},
+		},
+		{
+			name: "only cluster label",
+			req: &types.CreateCubeSandboxReq{
+				Request: &types.Request{RequestID: "req-3"},
+				Annotations: map[string]string{
+					"com.nodeaffinity.cluster.label": "cls-a:cls-b",
+				},
+				Containers:   []*types.Container{},
+				InstanceType: "cubebox",
+			},
+			check: func(t *testing.T, result []affinity.NodeSelectorRequirement) {
+				found := false
+				for _, r := range result {
+					if r.Key == "topology.kubernetes.io/cluster-id" {
+						found = true
+						assert.Equal(t, affinity.NodeSelectorOpIn, r.Operator)
+						assert.NotEmpty(t, r.Values)
+					}
+				}
+				assert.True(t, found, "expected cluster-id requirement")
+			},
+		},
+		{
+			name: "only instance type",
+			req: &types.CreateCubeSandboxReq{
+				Request: &types.Request{RequestID: "req-4"},
+				Annotations: map[string]string{
+					"com.nodeaffinity.instancetype": "SA2:SA3",
+				},
+				Containers:   []*types.Container{},
+				InstanceType: "cubebox",
+			},
+			check: func(t *testing.T, result []affinity.NodeSelectorRequirement) {
+				found := false
+				for _, r := range result {
+					if r.Key == "kubernetes.io/instance-type" {
+						found = true
+						assert.Equal(t, affinity.NodeSelectorOpIn, r.Operator)
+						assert.NotEmpty(t, r.Values)
+					}
+				}
+				assert.True(t, found, "expected instance-type requirement")
+			},
+		},
+		{
+			name: "valid affinity selector only",
+			req: &types.CreateCubeSandboxReq{
+				Request: &types.Request{RequestID: "req-5"},
+				Annotations: map[string]string{
+					"com.nodeaffinity.selector": `[{"key":"gpu","operator":"Exists"}]`,
+				},
+				Containers:   []*types.Container{},
+				InstanceType: "cubebox",
+			},
+			check: func(t *testing.T, result []affinity.NodeSelectorRequirement) {
+				found := false
+				for _, r := range result {
+					if r.Key == "gpu" {
+						found = true
+						assert.Equal(t, affinity.NodeSelectorOpExists, r.Operator)
+					}
+				}
+				assert.True(t, found, "expected gpu Exists requirement from selector annotation")
+			},
+		},
+		{
+			name: "cluster label + instance type + selector combined",
+			req: &types.CreateCubeSandboxReq{
+				Request: &types.Request{RequestID: "req-6"},
+				Annotations: map[string]string{
+					"com.nodeaffinity.cluster.label": "cls-a",
+					"com.nodeaffinity.instancetype":  "SA2",
+					"com.nodeaffinity.selector":      `[{"key":"gpu","operator":"Exists"},{"key":"custom","operator":"In","values":["v1","v2"]}]`,
+				},
+				Containers:   []*types.Container{},
+				InstanceType: "cubebox",
+			},
+			check: func(t *testing.T, result []affinity.NodeSelectorRequirement) {
+				keys := make(map[string]int)
+				for _, r := range result {
+					keys[r.Key]++
+				}
+				assert.Equal(t, 1, keys["topology.kubernetes.io/cluster-id"], "cluster-id requirement")
+				assert.Equal(t, 1, keys["kubernetes.io/instance-type"], "instance-type requirement")
+				assert.Equal(t, 1, keys["gpu"], "gpu from selector")
+				assert.Equal(t, 1, keys["custom"], "custom from selector")
+			},
+		},
+		{
+			name: "selector with Gt and Lt and Exists",
+			req: &types.CreateCubeSandboxReq{
+				Request: &types.Request{RequestID: "req-7"},
+				Annotations: map[string]string{
+					"com.nodeaffinity.selector": `[
+						{"key":"kubernetes.io/memory-size","operator":"Gt","values":["4096Mi"]},
+						{"key":"kubernetes.io/cpu-cores","operator":"Lt","values":["16000m"]},
+						{"key":"ssd","operator":"Exists"}
+					]`,
+				},
+				Containers:   []*types.Container{},
+				InstanceType: "cubebox",
+			},
+			check: func(t *testing.T, result []affinity.NodeSelectorRequirement) {
+				gtFound, ltFound, existsFound := false, false, false
+				for _, r := range result {
+					switch r.Key {
+					case "kubernetes.io/memory-size":
+						gtFound = true
+						assert.Equal(t, affinity.NodeSelectorOpGt, r.Operator)
+					case "kubernetes.io/cpu-cores":
+						ltFound = true
+						assert.Equal(t, affinity.NodeSelectorOpLt, r.Operator)
+					case "ssd":
+						existsFound = true
+						assert.Equal(t, affinity.NodeSelectorOpExists, r.Operator)
+					}
+				}
+				assert.True(t, gtFound && ltFound && existsFound,
+					"all three selector requirements should be present")
+			},
+		},
+		{
+			name: "Gt on memory-size with Gi unit",
+			req: &types.CreateCubeSandboxReq{
+				Request: &types.Request{RequestID: "req-9"},
+				Annotations: map[string]string{
+					"com.nodeaffinity.selector": `[{"key":"kubernetes.io/memory-size","operator":"Gt","values":["4Gi"]}]`,
+				},
+				Containers:   []*types.Container{},
+				InstanceType: "cubebox",
+			},
+			check: func(t *testing.T, result []affinity.NodeSelectorRequirement) {
+				found := false
+				for _, r := range result {
+					if r.Key == "kubernetes.io/memory-size" {
+						found = true
+						assert.Contains(t, r.Values, "4Gi")
+					}
+				}
+				assert.True(t, found)
+			},
+		},
+
+		// ---- error cases ----
+		{
+			name: "invalid selector JSON returns error",
+			req: &types.CreateCubeSandboxReq{
+				Request: &types.Request{RequestID: "req-err-1"},
+				Annotations: map[string]string{
+					"com.nodeaffinity.selector": `not-valid-json`,
+				},
+				Containers:   []*types.Container{},
+				InstanceType: "cubebox",
+			},
+			wantErr: true,
+			errMsg:  "parsing annotation",
+		},
+		{
+			name: "selector with empty key returns error",
+			req: &types.CreateCubeSandboxReq{
+				Request: &types.Request{RequestID: "req-err-2"},
+				Annotations: map[string]string{
+					"com.nodeaffinity.selector": `[{"key":"","operator":"In","values":["v"]}]`,
+				},
+				Containers:   []*types.Container{},
+				InstanceType: "cubebox",
+			},
+			wantErr: true,
+			errMsg:  "node selector key must not be empty",
+		},
+		{
+			name: "selector with unsupported Gt key returns error",
+			req: &types.CreateCubeSandboxReq{
+				Request: &types.Request{RequestID: "req-err-3"},
+				Annotations: map[string]string{
+					"com.nodeaffinity.selector": `[{"key":"bad-key","operator":"Gt","values":["1"]}]`,
+				},
+				Containers:   []*types.Container{},
+				InstanceType: "cubebox",
+			},
+			wantErr: true,
+			errMsg:  "is only supported for keys",
+		},
+		{
+			name: "empty selector string is silently ignored",
+			req: &types.CreateCubeSandboxReq{
+				Request: &types.Request{RequestID: "req-8"},
+				Annotations: map[string]string{
+					"com.nodeaffinity.selector": "",
+				},
+				Containers:   []*types.Container{},
+				InstanceType: "cubebox",
+			},
+			check: func(t *testing.T, result []affinity.NodeSelectorRequirement) {
+				// Empty selector string → treated as not set, no extra requirements
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := constructNodeAffinity(ctx, tt.req)
+			if tt.wantErr {
+				assert.Error(t, err)
+				if tt.errMsg != "" {
+					assert.Contains(t, err.Error(), tt.errMsg)
+				}
+			} else {
+				assert.NoError(t, err)
+				if tt.check != nil {
+					tt.check(t, result)
+				}
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// runInsReq2Affinity tests
+// ---------------------------------------------------------------------------
+
+func Test_runInsReq2Affinity(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("no annotations returns context unchanged", func(t *testing.T) {
+		req := &types.CreateCubeSandboxReq{
+			Request:      &types.Request{RequestID: "req-1"},
+			Annotations:  nil,
+			Containers:   []*types.Container{},
+			InstanceType: "cubebox",
+		}
+		newCtx, err := runInsReq2Affinity(ctx, req)
+		assert.NoError(t, err)
+		assert.NotNil(t, newCtx)
+	})
+
+	t.Run("valid selector stores NodeSelector in context", func(t *testing.T) {
+		req := &types.CreateCubeSandboxReq{
+			Request: &types.Request{RequestID: "req-2"},
+			Annotations: map[string]string{
+				"com.nodeaffinity.selector": `[{"key":"gpu","operator":"Exists"}]`,
+			},
+			Containers:   []*types.Container{},
+			InstanceType: "cubebox",
+		}
+		newCtx, err := runInsReq2Affinity(ctx, req)
+		assert.NoError(t, err)
+		assert.NotNil(t, newCtx)
+
+		ns := constants.GetNodeSelector(newCtx)
+		assert.NotNil(t, ns, "NodeSelector should be stored in context")
+	})
+
+	t.Run("invalid selector returns error", func(t *testing.T) {
+		req := &types.CreateCubeSandboxReq{
+			Request: &types.Request{RequestID: "req-3"},
+			Annotations: map[string]string{
+				"com.nodeaffinity.selector": `[{"key":"","operator":"In","values":["v"]}]`,
+			},
+			Containers:   []*types.Container{},
+			InstanceType: "cubebox",
+		}
+		newCtx, err := runInsReq2Affinity(ctx, req)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "node selector key must not be empty")
+		assert.NotNil(t, newCtx)
+	})
+
+	t.Run("instance type annotation also sets backoff NodeSelector", func(t *testing.T) {
+		req := &types.CreateCubeSandboxReq{
+			Request: &types.Request{RequestID: "req-4"},
+			Annotations: map[string]string{
+				"com.nodeaffinity.instancetype": "SA2:SA3",
+				"com.nodeaffinity.selector":     `[{"key":"ssd","operator":"Exists"}]`,
+			},
+			Containers:   []*types.Container{},
+			InstanceType: "cubebox",
+		}
+		newCtx, err := runInsReq2Affinity(ctx, req)
+		assert.NoError(t, err)
+
+		ns := constants.GetNodeSelector(newCtx)
+		assert.NotNil(t, ns, "NodeSelector should be set")
+
+		bns := constants.GetBackoffNodeSelector(newCtx)
+		assert.Nil(t, bns, "BackoffNodeSelector should be nil when instance type annotation is present")
+	})
 }

--- a/CubeMaster/pkg/service/httpservice/cube/sandbox_create.go
+++ b/CubeMaster/pkg/service/httpservice/cube/sandbox_create.go
@@ -68,7 +68,14 @@ func createSandbox(w http.ResponseWriter, r *http.Request, rt *CubeLog.RequestTr
 		return rsp
 	}
 
-	ctx = runInsReq2Affinity(ctx, req)
+	ctx, err = runInsReq2Affinity(ctx, req)
+	if err != nil {
+		rsp.Ret.RetCode = int(errorcode.ErrorCode_MasterParamsError)
+		rsp.Ret.RetMsg = err.Error()
+		rt.RetCode = int64(errorcode.ErrorCode_MasterParamsError)
+		log.G(ctx).Error(err)
+		return rsp
+	}
 	ret := createSandboxRunFn(ctx, req)
 	if ret != nil && ret.Ret != nil && ret.Ret.RetCode == int(errorcode.ErrorCode_Success) {
 		if err := registerCreatedSandboxRuntimeRef(ctx, req, ret); err != nil {

--- a/CubeMaster/pkg/service/httpservice/cube/sandboxutil_test.go
+++ b/CubeMaster/pkg/service/httpservice/cube/sandboxutil_test.go
@@ -12,6 +12,24 @@ import (
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/config"
 )
 
+// minimalTestConfig is a bare-minimum configuration that passes validate().
+// It is written to disk on demand so that tests which require a non-nil
+// config.GetConfig() can run without an external fixture file.
+const minimalTestConfig = `common:
+  http_port: 8089
+  default_headless_service_nodes_num: 1
+
+log:
+  module: "cubemaster-test"
+  path: "/tmp"
+  file_size: 10
+  file_num: 2
+  level: "error"
+
+scheduler:
+  priority_select_num: 1
+`
+
 func init() {
 	mydir, err := os.Getwd()
 	if err != nil {
@@ -19,7 +37,18 @@ func init() {
 	}
 	fmt.Printf("mydir=%s\n", mydir)
 	if os.Getenv("CUBE_MASTER_CONFIG_PATH") == "" {
-		os.Setenv("CUBE_MASTER_CONFIG_PATH", filepath.Clean(filepath.Join(mydir, "../../../../test/conf.yaml")))
+		cfgPath := filepath.Clean(filepath.Join(mydir, "../../../../test/conf.yaml"))
+		os.Setenv("CUBE_MASTER_CONFIG_PATH", cfgPath)
+		// Create a minimal config file on the fly so that config.Init()
+		// succeeds regardless of whether a fixture file was checked in.
+		if _, statErr := os.Stat(cfgPath); os.IsNotExist(statErr) {
+			if err := os.MkdirAll(filepath.Dir(cfgPath), 0755); err != nil {
+				panic(fmt.Sprintf("cannot create test config dir: %v", err))
+			}
+			if err := os.WriteFile(cfgPath, []byte(minimalTestConfig), 0644); err != nil {
+				panic(fmt.Sprintf("cannot write test config: %v", err))
+			}
+		}
 	}
 	config.Init()
 }


### PR DESCRIPTION
Add com.nodeaffinity.selector annotation to allow specifying arbitrary NodeSelectorRequirements when creating a sandbox. The annotation value is a JSON array of {key, operator, values} objects, supporting all six operators (In, NotIn, Exists, DoesNotExist, Gt, Lt).

Also add NodeLabels field to node.Node and merge it into Labels() so that labels reported during node registration are visible to the scheduler for affinity matching. Deep-copy NodeLabels in Clone() to prevent data races.

Validate that In/NotIn operators have non-empty values and Exists/DoesNotExist have empty values, returning MasterParamsError on invalid input. Consolidate the repeated req.Annotations nil checks in constructNodeAffinity into a single block.

Supersedes #502 (previous PR was from a dirty branch with unrelated upstream commits; this is a clean single-commit PR from feat/node-affinity-selector).