### PR TITLE
fix(cubelog): avoid panic when request trace is missing

### DIFF
--- a/CubeMaster/pkg/templatecenter/image_job_runner.go
+++ b/CubeMaster/pkg/templatecenter/image_job_runner.go
@@ -8,6 +8,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
+	"time"
 
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/constants"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/log"
@@ -205,10 +207,31 @@ func errorString(err error) string {
 	return err.Error()
 }
 
-func detachTemplateImageJobContext(ctx context.Context, fields map[string]any) context.Context {
+func detachTemplateImageJobContext(ctx context.Context, name string, fields map[string]any) context.Context {
 	detached := context.Background()
-	if rt := CubeLog.GetTraceInfo(ctx); rt != nil {
-		detached = CubeLog.WithRequestTrace(detached, rt.DeepCopy())
+	rt := CubeLog.GetTraceInfo(ctx)
+	if rt == nil {
+		// Background workers (e.g. the snapshot reconciler) run without an
+		// incoming request and therefore carry no trace. Synthesize one so the
+		// detached context always has a usable trace and emits meaningful
+		// metric labels. The caller names the operation explicitly so each
+		// distinct job type gets its own trace label instead of sharing a
+		// generic fallback.
+		if strings.TrimSpace(name) == "" {
+			name = "template_job"
+		}
+		rt = &CubeLog.RequestTrace{
+			Action:         name,
+			Caller:         name,
+			Callee:         constants.CubeMasterServiceID,
+			CalleeEndpoint: "localhost",
+			Timestamp:      time.Now(),
+		}
+	} else {
+		// Copy the inherited trace so mutations on the detached context do not
+		// leak back into the originating request's trace.
+		rt = rt.DeepCopy()
 	}
+	detached = CubeLog.WithRequestTrace(detached, rt)
 	return log.WithLogger(detached, log.G(ctx).WithFields(fields))
 }

--- a/CubeMaster/pkg/templatecenter/snapshot_ops.go
+++ b/CubeMaster/pkg/templatecenter/snapshot_ops.go
@@ -1143,7 +1143,7 @@ func executeSnapshotCreateJob(ctx context.Context, info *sandboxtypes.TemplateIm
 	if !claimed {
 		return resolveExistingSnapshotJobByID(ctx, info.JobID)
 	}
-	jobCtx, cancel := synchronousSnapshotJobContext(ctx, map[string]any{
+	jobCtx, cancel := synchronousSnapshotJobContext(ctx, "snapshot_create", map[string]any{
 		"job_id":      info.JobID,
 		"snapshot_id": info.TemplateID,
 		"sandbox_id":  sandboxID,
@@ -1185,7 +1185,7 @@ func executeSnapshotRollbackJob(ctx context.Context, info *sandboxtypes.Template
 	if !claimed {
 		return resolveExistingSnapshotJobByID(ctx, info.JobID)
 	}
-	jobCtx, cancel := synchronousSnapshotJobContext(ctx, map[string]any{
+	jobCtx, cancel := synchronousSnapshotJobContext(ctx, "snapshot_rollback", map[string]any{
 		"job_id":      info.JobID,
 		"snapshot_id": snapshotID,
 		"sandbox_id":  sandboxID,
@@ -1223,7 +1223,7 @@ func executeSnapshotDeleteJob(ctx context.Context, info *sandboxtypes.TemplateIm
 	if !claimed {
 		return resolveExistingSnapshotJobByID(ctx, info.JobID)
 	}
-	jobCtx, cancel := synchronousSnapshotJobContext(ctx, map[string]any{
+	jobCtx, cancel := synchronousSnapshotJobContext(ctx, "snapshot_delete", map[string]any{
 		"job_id":      info.JobID,
 		"snapshot_id": snapshotID,
 	})
@@ -1242,8 +1242,8 @@ func resolveExistingSnapshotJobByID(ctx context.Context, jobID string) (*sandbox
 	return resolveExistingSnapshotJob(info)
 }
 
-func synchronousSnapshotJobContext(ctx context.Context, fields map[string]any) (context.Context, context.CancelFunc) {
-	return context.WithTimeout(detachTemplateImageJobContext(ctx, fields), snapshotOperationTimeout)
+func synchronousSnapshotJobContext(ctx context.Context, name string, fields map[string]any) (context.Context, context.CancelFunc) {
+	return context.WithTimeout(detachTemplateImageJobContext(ctx, name, fields), snapshotOperationTimeout)
 }
 
 func finalizeSnapshotJobByID(ctx context.Context, jobID string) (*sandboxtypes.TemplateImageJobInfo, error) {

--- a/CubeMaster/pkg/templatecenter/snapshot_ops_test.go
+++ b/CubeMaster/pkg/templatecenter/snapshot_ops_test.go
@@ -282,7 +282,7 @@ func TestSynchronousSnapshotJobContextDetachesFromParentCancellation(t *testing.
 	parent, cancelParent := context.WithCancel(context.Background())
 	cancelParent()
 
-	ctx, cancel := synchronousSnapshotJobContext(parent, map[string]any{"job_id": "job-1"})
+	ctx, cancel := synchronousSnapshotJobContext(parent, "snapshot_create", map[string]any{"job_id": "job-1"})
 	defer cancel()
 
 	select {

--- a/CubeMaster/pkg/templatecenter/snapshot_reconciler.go
+++ b/CubeMaster/pkg/templatecenter/snapshot_reconciler.go
@@ -92,9 +92,7 @@ var (
 func startSnapshotReconciler(ctx context.Context) {
 	snapshotReconcilerOnce.Do(func() {
 		go func() {
-			runSnapshotReconcilerPass(detachTemplateImageJobContext(ctx, map[string]any{
-				"component": "snapshot_reconciler",
-			}))
+			runSnapshotReconcilerPass(detachTemplateImageJobContext(ctx, "snapshot_reconciler", nil))
 			ticker := time.NewTicker(snapshotReconcilerInterval)
 			defer ticker.Stop()
 			for {
@@ -102,9 +100,7 @@ func startSnapshotReconciler(ctx context.Context) {
 				case <-ctx.Done():
 					return
 				case <-ticker.C:
-					runSnapshotReconcilerPass(detachTemplateImageJobContext(ctx, map[string]any{
-						"component": "snapshot_reconciler",
-					}))
+					runSnapshotReconcilerPass(detachTemplateImageJobContext(ctx, "snapshot_reconciler", nil))
 				}
 			}
 		}()

--- a/CubeMaster/pkg/templatecenter/template_commit.go
+++ b/CubeMaster/pkg/templatecenter/template_commit.go
@@ -151,7 +151,7 @@ func SubmitTemplateCommit(ctx context.Context, sandboxID, nodeID, nodeIP string,
 	// job invisible to the response. Match the sibling SubmitTemplateImage()
 	// path: detach the context (so HTTP client disconnects do not cancel the
 	// background work) and dispatch onto a fresh goroutine.
-	go runTemplateCommitJob(detachTemplateImageJobContext(ctx, map[string]any{
+	go runTemplateCommitJob(detachTemplateImageJobContext(ctx, "template_commit", map[string]any{
 		"job_id":          jobID,
 		"template_id":     templateID,
 		"attempt_no":      attemptNo,

--- a/CubeMaster/pkg/templatecenter/template_image.go
+++ b/CubeMaster/pkg/templatecenter/template_image.go
@@ -161,7 +161,7 @@ func SubmitTemplateFromImage(ctx context.Context, req *types.CreateTemplateFromI
 	if reusedExistingJob {
 		return GetTemplateImageJobInfo(ctx, jobID)
 	}
-	go runTemplateImageJob(detachTemplateImageJobContext(ctx, map[string]any{
+	go runTemplateImageJob(detachTemplateImageJobContext(ctx, "template_image_create", map[string]any{
 		"job_id":          jobID,
 		"template_id":     normalized.TemplateID,
 		"attempt_no":      attemptNo,
@@ -220,7 +220,7 @@ func SubmitRedoTemplateFromImage(ctx context.Context, req *types.RedoTemplateFro
 	}); err != nil {
 		return nil, err
 	}
-	go runRedoTemplateImageJob(detachTemplateImageJobContext(ctx, map[string]any{
+	go runRedoTemplateImageJob(detachTemplateImageJobContext(ctx, "template_image_redo", map[string]any{
 		"job_id":      jobID,
 		"template_id": normalized.TemplateID,
 	}), jobID, normalized, downloadBaseURL)

--- a/cubelog/metric.go
+++ b/cubelog/metric.go
@@ -54,7 +54,16 @@ type RequestTrace struct {
 	InstanceType   string
 }
 
+// DeepCopy returns an independent copy of the trace. A nil receiver is
+// intentionally tolerated: non-request paths (background workers, tests) have
+// no trace in context, and callers in those paths may invoke DeepCopy on the
+// nil result of GetTraceInfo. In that case we return a fresh, empty trace
+// rather than panicking, so this nil guard is deliberate and must not be
+// removed as dead code.
 func (rt *RequestTrace) DeepCopy() *RequestTrace {
+	if rt == nil {
+		return new(RequestTrace)
+	}
 	o := new(RequestTrace)
 	*o = *rt
 	return o


### PR DESCRIPTION
Background workers and detached job contexts could run without a request trace, leaving callers to dereference a nil trace and crash the worker goroutine. Make trace handling tolerant of a missing trace so these paths stay resilient instead of panicking.

This fixes the following cube-master panic:

```
panic:goroutine 2736 [running]:
runtime/debug.Stack()
	/usr/lib/golang/src/runtime/debug/stack.go:26 +0x5e
github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/service/sandbox.ListSandbox.func3({0x487992?, 0xc00051d808?})
	CubeMaster/pkg/service/sandbox/sandbox_list.go:97 +0x30
github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/recov.HandleCrash({0xc00031a1d0, 0x1, 0xc0006dd500?})
	CubeMaster/pkg/base/recov/runtime.go:30 +0xb6
panic({0x122ae20?, 0x1f3bd40?})
	/usr/lib/golang/src/runtime/panic.go:783 +0x132
github.com/tencentcloud/CubeSandbox/cubelog.(*RequestTrace).DeepCopy(...)
	cubelog/metric.go:62
github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/service/sandbox.doOneList({0x15f91d0, 0xc0000e4720}, 0xc000238190, 0xc000365688, 0xc0001187e0)
	CubeMaster/pkg/service/sandbox/sandbox_list.go:132 +0xd3
github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/service/sandbox.ListSandbox.func2()
	CubeMaster/pkg/service/sandbox/sandbox_list.go:95 +0x27
github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/recov.GoWithWaitGroup.func1.WithRecover.1({0xc00031a1d0?, 0xc0003f1cc0?, 0x15f91d0?}, 0xc0003e57d0?)
	CubeMaster/pkg/base/recov/runtime.go:42 +0x5a
github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/recov.WithRecover(...)
	CubeMaster/pkg/base/recov/runtime.go:43
github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/recov.GoWithWaitGroup.func1()
	CubeMaster/pkg/base/recov/runtime.go:75 +0x54
created by github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/recov.GoWithWaitGroup in goroutine 29
	CubeMaster/pkg/base/recov/runtime.go:73 +0xab
```

Assisted-by: Cursor:claude-opus-4.8