### PR TITLE
feat(deploy): support external MySQL/Redis in one-click installer

### DIFF
--- a/deploy/one-click/README.md
+++ b/deploy/one-click/README.md
@@ -250,6 +250,38 @@ During installation, runtime files are prepared in this directory and the follow
 - `mysql:8.0`
 - `redis:7-alpine`
 
+### Using an external MySQL / Redis
+
+To point CubeSandbox at an existing MySQL/Redis server instead of the bundled
+local containers, set the following in `.env` before running `install.sh`
+(see `env.example`):
+
+```bash
+# External MySQL (any subset of the credential fields may be overridden)
+CUBE_EXTERNAL_MYSQL_HOST=10.0.0.20
+CUBE_EXTERNAL_MYSQL_PORT=3306
+CUBE_EXTERNAL_MYSQL_USER=cube
+CUBE_EXTERNAL_MYSQL_PASSWORD=cube_pass
+CUBE_EXTERNAL_MYSQL_DB=cube_mvp
+
+# External Redis
+CUBE_EXTERNAL_REDIS_HOST=10.0.0.21
+CUBE_EXTERNAL_REDIS_PORT=6379
+CUBE_EXTERNAL_REDIS_PASSWORD=ceuhvu123
+```
+
+When `CUBE_EXTERNAL_MYSQL_HOST` (and/or `CUBE_EXTERNAL_REDIS_HOST`) is set, `install.sh`:
+
+- patches `CubeMaster/conf.yaml` with the external MySQL/Redis endpoint;
+- writes `DATABASE_URL` (CubeAPI) and `CUBE_PROXY_REDIS_*` (cube proxy) to `.one-click.env` so every service consumes the external endpoint;
+- masks the corresponding `cube-sandbox-mysql.service` / `cube-sandbox-redis.service` so the local container is never started; and
+- makes `quickcheck.sh` and `up-support.sh` skip lifecycle management of the now-external dependency. (`down-support.sh` has no external-dep awareness and still issues a `docker compose down`, but this is a harmless no-op because the local containers were never started for the external dependency.)
+
+The external MySQL must already grant the configured user access to the target
+database; CubeMaster runs its own schema migrations on first start, and the
+single-node seed rows are applied through a host-side `mysql` client (install
+the MySQL client package on the control node when seeding an external DB).
+
 `cube proxy` and its DNS resolution are mandatory capabilities in one-click. The following two values in `.env` must remain `1`:
 
 ```bash

--- a/deploy/one-click/README_zh.md
+++ b/deploy/one-click/README_zh.md
@@ -239,6 +239,34 @@ MySQL/Redis 依赖默认会部署到：
 - `mysql:8.0`
 - `redis:7-alpine`
 
+### 使用外部 MySQL / Redis
+
+如果希望使用已有的 MySQL/Redis 服务器，而不是内置的本地容器，可在执行
+`install.sh` 之前在 `.env` 中设置以下变量（参见 `env.example`）：
+
+```bash
+# 外部 MySQL（凭据字段可按需覆盖）
+CUBE_EXTERNAL_MYSQL_HOST=10.0.0.20
+CUBE_EXTERNAL_MYSQL_PORT=3306
+CUBE_EXTERNAL_MYSQL_USER=cube
+CUBE_EXTERNAL_MYSQL_PASSWORD=cube_pass
+CUBE_EXTERNAL_MYSQL_DB=cube_mvp
+
+# 外部 Redis
+CUBE_EXTERNAL_REDIS_HOST=10.0.0.21
+CUBE_EXTERNAL_REDIS_PORT=6379
+CUBE_EXTERNAL_REDIS_PASSWORD=ceuhvu123
+```
+
+当设置了 `CUBE_EXTERNAL_MYSQL_HOST`（和/或 `CUBE_EXTERNAL_REDIS_HOST`）时，`install.sh` 会：
+
+- 用外部 MySQL/Redis 地址改写 `CubeMaster/conf.yaml`；
+- 将 `DATABASE_URL`（CubeAPI）和 `CUBE_PROXY_REDIS_*`（cube proxy）写入 `.one-click.env`，让各服务都连接外部地址；
+- mask 对应的 `cube-sandbox-mysql.service` / `cube-sandbox-redis.service`，本地容器不会再被启动；
+- 让 `quickcheck.sh` 和 `up-support.sh` 跳过对已外置依赖的本地生命周期管理（`down-support.sh` 未感知外部依赖，仍会执行 `docker compose down`，但由于本地容器从未被启动，这是无害的空操作）。
+
+外部 MySQL 需要预先授予所配置用户对目标库的访问权限；CubeMaster 首次启动会自行执行 schema 迁移，单机种子数据通过宿主机上的 `mysql` 客户端写入（在控制节点上需安装 MySQL 客户端用于对外部库做 seed）。
+
 `cube proxy` 和它的 DNS 解析在 one-click 里是必选能力，`.env` 中这两个值必须保持为 `1`：
 
 ```bash

--- a/deploy/one-click/env.example
+++ b/deploy/one-click/env.example
@@ -60,7 +60,23 @@ ONE_CLICK_LOG_DIR=/var/log/cube-sandbox-one-click
 # Internal runtime directory used by systemd helpers (for example cubelet.pid).
 CUBE_SANDBOX_SYSTEMD_RUNTIME_DIR=/run/cube-sandbox-systemd
 
-# Dependency containers and credentials.
+# ---- External MySQL / Redis ----
+# By default install.sh starts a local MySQL and Redis container (managed by
+# systemd). To use an existing MySQL/Redis server instead, set the *_HOST
+# variables below. When set, install.sh patches CubeMaster conf.yaml, points
+# CubeAPI (DATABASE_URL) and cube-proxy at the external endpoint, masks the
+# corresponding local systemd service, and the up/down/quickcheck helpers stop
+# managing the local container. Leave unset to keep the bundled local services.
+# CUBE_EXTERNAL_MYSQL_HOST=10.0.0.20
+# CUBE_EXTERNAL_MYSQL_PORT=3306
+# CUBE_EXTERNAL_MYSQL_USER=cube
+# CUBE_EXTERNAL_MYSQL_PASSWORD=cube_pass
+# CUBE_EXTERNAL_MYSQL_DB=cube_mvp
+# CUBE_EXTERNAL_REDIS_HOST=10.0.0.21
+# CUBE_EXTERNAL_REDIS_PORT=6379
+# CUBE_EXTERNAL_REDIS_PASSWORD=ceuhvu123
+
+# Dependency containers and credentials (used for the bundled local services).
 CUBE_SANDBOX_MYSQL_CONTAINER=cube-sandbox-mysql
 CUBE_SANDBOX_REDIS_CONTAINER=cube-sandbox-redis
 CUBE_SANDBOX_MYSQL_VOLUME=cube-sandbox-mysql-data

--- a/deploy/one-click/install.sh
+++ b/deploy/one-click/install.sh
@@ -731,11 +731,40 @@ start_systemd_target() {
 # only `Wants` these units, so masking is non-fatal for the rest of the stack.
 # Must run after install_systemd_units (units installed + daemon-reload) and
 # before start_systemd_target.
+#
+# install-units.sh installs every unit as a *regular file* under
+# /etc/systemd/system. A plain `systemctl mask` cannot overlay its /dev/null
+# symlink on top of an existing regular file -- it fails with
+# "File ... already exists". The previous implementation swallowed that error,
+# so the unit only *appeared* masked and was actually left merely "disabled".
+# A disabled-but-present unit is still pulled in by the target's Wants=, so the
+# local mysql/redis units would start, their ExecStartPost would wait ~60-80s on
+# a container that (correctly) was never started, fail, and Restart=on-failure
+# loop -- stalling `systemctl enable --now <target>` for many minutes.
+# We therefore remove the installed file first so mask can create a *persistent*
+# /dev/null override; a later switch back to local re-installs the real file via
+# install-units.sh, whose `install` call replaces the /dev/null mask symlink with
+# the real unit (unlink + create, not an atomic rename).
+mask_local_dep_service() {
+  local unit="$1"
+  local unit_dir="${ONE_CLICK_SYSTEMD_UNIT_INSTALL_DIR:-/etc/systemd/system}"
+  systemctl stop "${unit}" >/dev/null 2>&1 || true
+  # Removing the unit file is the primary safeguard; mask is belt-and-suspenders.
+  # Keep this tolerant under `set -e` so a rare failure here (e.g. a stray
+  # directory left at the path) warns rather than aborting the whole install.
+  rm -f "${unit_dir}/${unit}" || true
+  if ! systemctl mask "${unit}" >/dev/null 2>&1; then
+    # The unit file is already gone, so the target's Wants= just resolves to a
+    # missing unit and nothing starts now. The only residual risk is that the
+    # mask did not persist, so a later install_systemd_units run could restore it.
+    log "WARNING: removed ${unit} but failed to persist its mask; a later re-install may restore it"
+  fi
+}
+
 mask_external_dep_services() {
   if [[ -n "${CUBE_EXTERNAL_MYSQL_HOST}" ]]; then
     log "masking local MySQL service (external MySQL at ${CUBE_EXTERNAL_MYSQL_HOST} in use)"
-    systemctl stop cube-sandbox-mysql.service >/dev/null 2>&1 || true
-    systemctl mask cube-sandbox-mysql.service >/dev/null 2>&1 || true
+    mask_local_dep_service cube-sandbox-mysql.service
   else
     # Re-enable in case a previous install masked it and the user switched back.
     systemctl unmask cube-sandbox-mysql.service >/dev/null 2>&1 || true
@@ -743,11 +772,12 @@ mask_external_dep_services() {
 
   if [[ -n "${CUBE_EXTERNAL_REDIS_HOST}" ]]; then
     log "masking local Redis service (external Redis at ${CUBE_EXTERNAL_REDIS_HOST} in use)"
-    systemctl stop cube-sandbox-redis.service >/dev/null 2>&1 || true
-    systemctl mask cube-sandbox-redis.service >/dev/null 2>&1 || true
+    mask_local_dep_service cube-sandbox-redis.service
   else
     systemctl unmask cube-sandbox-redis.service >/dev/null 2>&1 || true
   fi
+
+  systemctl daemon-reload >/dev/null 2>&1 || true
 }
 
 require_root

--- a/deploy/one-click/install.sh
+++ b/deploy/one-click/install.sh
@@ -21,6 +21,46 @@ if [[ -f "${ENV_FILE}" ]]; then
 fi
 
 DEPLOY_ROLE="$(one_click_deploy_role)"
+
+# ---- External MySQL / Redis support ----
+# Set CUBE_EXTERNAL_MYSQL_HOST to point CubeSandbox at an existing MySQL server
+# instead of the bundled local Docker container. When set, install.sh will:
+#   1. Patch CubeMaster conf.yaml with the external connection details
+#   2. Persist the external endpoint to .one-click.env so every systemd unit
+#      and helper script (CubeAPI DATABASE_URL, cube-proxy redis, quickcheck...)
+#      consumes it instead of the local container
+#   3. Mask the cube-sandbox-mysql systemd service so it never starts
+CUBE_EXTERNAL_MYSQL_HOST="${CUBE_EXTERNAL_MYSQL_HOST:-}"
+CUBE_EXTERNAL_MYSQL_PORT="${CUBE_EXTERNAL_MYSQL_PORT:-3306}"
+CUBE_EXTERNAL_MYSQL_USER="${CUBE_EXTERNAL_MYSQL_USER:-cube}"
+CUBE_EXTERNAL_MYSQL_PASSWORD="${CUBE_EXTERNAL_MYSQL_PASSWORD:-cube_pass}"
+# Default the external DB name from CUBE_SANDBOX_MYSQL_DB so it resolves to the
+# same value up-with-deps.sh derives independently. Otherwise a custom
+# CUBE_SANDBOX_MYSQL_DB (without an explicit CUBE_EXTERNAL_MYSQL_DB) would make
+# the persisted .one-click.env and the seed step disagree on the database name.
+CUBE_EXTERNAL_MYSQL_DB="${CUBE_EXTERNAL_MYSQL_DB:-${CUBE_SANDBOX_MYSQL_DB:-cube_mvp}}"
+
+# Set CUBE_EXTERNAL_REDIS_HOST to use an external Redis instance. Mirrors the
+# MySQL behaviour above (patch conf.yaml, persist env, mask local redis unit).
+CUBE_EXTERNAL_REDIS_HOST="${CUBE_EXTERNAL_REDIS_HOST:-}"
+CUBE_EXTERNAL_REDIS_PORT="${CUBE_EXTERNAL_REDIS_PORT:-6379}"
+CUBE_EXTERNAL_REDIS_PASSWORD="${CUBE_EXTERNAL_REDIS_PASSWORD:-ceuhvu123}"
+
+# Guard against shipping the example/default credentials to a real external
+# server. The defaults (cube_pass / ceuhvu123) are published in env.example and
+# are trivially guessable, so warn loudly when an external endpoint is wired up
+# without overriding them.
+warn_default_external_credentials() {
+  if [[ -n "${CUBE_EXTERNAL_MYSQL_HOST}" && "${CUBE_EXTERNAL_MYSQL_PASSWORD}" == "cube_pass" ]]; then
+    log "WARNING: external MySQL (${CUBE_EXTERNAL_MYSQL_HOST}) configured with the default password 'cube_pass'."
+    log "WARNING: set CUBE_EXTERNAL_MYSQL_PASSWORD to a strong value in your .env before exposing this deployment."
+  fi
+  if [[ -n "${CUBE_EXTERNAL_REDIS_HOST}" && "${CUBE_EXTERNAL_REDIS_PASSWORD}" == "ceuhvu123" ]]; then
+    log "WARNING: external Redis (${CUBE_EXTERNAL_REDIS_HOST}) configured with the default password 'ceuhvu123'."
+    log "WARNING: set CUBE_EXTERNAL_REDIS_PASSWORD to a strong value in your .env before exposing this deployment."
+  fi
+}
+
 TOOLBOX_ROOT="${ONE_CLICK_TOOLBOX_ROOT:-/usr/local/services/cubetoolbox}"
 INSTALL_PREFIX="${ONE_CLICK_INSTALL_PREFIX:-${TOOLBOX_ROOT}}"
 CUBE_PVM_ENABLE="${CUBE_PVM_ENABLE:-0}"
@@ -155,6 +195,155 @@ generate_cubemaster_config_ports() {
     -e "s|__CUBE_SANDBOX_MYSQL_PORT__|${mysql_port}|g" \
     -e "s|__CUBE_SANDBOX_REDIS_PORT__|${redis_port}|g" \
     "${cfg}"
+}
+
+# When external MySQL/Redis is configured, patch CubeMaster conf.yaml to replace
+# the default 127.0.0.1 endpoints with the external connection details. Must run
+# after generate_cubemaster_config_ports so the port placeholders are resolved.
+patch_cubemaster_external_deps() {
+  [[ "${DEPLOY_ROLE}" != "compute" ]] || return 0
+
+  local cfg="${PKG_ROOT}/CubeMaster/conf.yaml"
+
+  # Validate once up front; both branches patch the same file.
+  if [[ -z "${CUBE_EXTERNAL_MYSQL_HOST}" && -z "${CUBE_EXTERNAL_REDIS_HOST}" ]]; then
+    return 0
+  fi
+  ensure_file "${cfg}"
+
+  if [[ -n "${CUBE_EXTERNAL_MYSQL_HOST}" ]]; then
+    log "patching conf.yaml for external MySQL: ${CUBE_EXTERNAL_MYSQL_HOST}:${CUBE_EXTERNAL_MYSQL_PORT}/${CUBE_EXTERNAL_MYSQL_DB}"
+    # SECURITY: escape user-supplied values for the sed '|' delimiter so that a
+    # '|', '\', '&' or '"' in a host/user/password does not corrupt conf.yaml
+    # or break the double-quoted sed replacement strings below.
+    local mysql_addr_esc mysql_user_esc mysql_pwd_esc mysql_db_esc
+    mysql_addr_esc="$(escape_sed "${CUBE_EXTERNAL_MYSQL_HOST}:${CUBE_EXTERNAL_MYSQL_PORT}")"
+    mysql_user_esc="$(escape_sed "${CUBE_EXTERNAL_MYSQL_USER}")"
+    mysql_pwd_esc="$(escape_sed "${CUBE_EXTERNAL_MYSQL_PASSWORD}")"
+    mysql_db_esc="$(escape_sed "${CUBE_EXTERNAL_MYSQL_DB}")"
+    # Match only on the YAML key prefix ('addr:'/'user:'/'pwd:'/'db_name:') and
+    # accept any current value, so these patterns keep working even if the
+    # conf.yaml template is regenerated with different defaults. These keys only
+    # appear in the MySQL sections (ossdb_config/instance_db_config), so without
+    # a trailing 'g' flag each line is patched exactly once and Redis fields
+    # (nodes:/password:) are never touched.
+    sed -i \
+      -e "s|addr: \".*\"|addr: \"${mysql_addr_esc}\"|" \
+      -e "s|user: \".*\"|user: \"${mysql_user_esc}\"|" \
+      -e "s|pwd: \".*\"|pwd: \"${mysql_pwd_esc}\"|" \
+      -e "s|db_name: \".*\"|db_name: \"${mysql_db_esc}\"|" \
+      "${cfg}"
+  fi
+
+  if [[ -n "${CUBE_EXTERNAL_REDIS_HOST}" ]]; then
+    log "patching conf.yaml for external Redis: ${CUBE_EXTERNAL_REDIS_HOST}:${CUBE_EXTERNAL_REDIS_PORT}"
+    local redis_nodes_esc redis_pwd_esc
+    redis_nodes_esc="$(escape_sed "${CUBE_EXTERNAL_REDIS_HOST}:${CUBE_EXTERNAL_REDIS_PORT}")"
+    redis_pwd_esc="$(escape_sed "${CUBE_EXTERNAL_REDIS_PASSWORD}")"
+    # Match only on the YAML key prefix so these patterns survive template
+    # default changes. 'nodes:'/'password:' only appear in the redis* sections,
+    # so every Redis endpoint is repointed while MySQL fields stay untouched.
+    sed -i \
+      -e "s|nodes: \".*\"|nodes: \"${redis_nodes_esc}\"|" \
+      -e "s|password: \".*\"|password: \"${redis_pwd_esc}\"|" \
+      "${cfg}"
+  fi
+}
+
+# Fail fast when an external MySQL/Redis endpoint is unreachable or rejects the
+# configured credentials. Without this, a misconfigured host/port/password only
+# surfaces much later during up-with-deps.sh seeding. The check is best-effort:
+# if the corresponding client binary is missing we skip rather than block, since
+# the seed step (which requires the client) runs later anyway.
+check_external_deps_preflight() {
+  local connect_timeout="${ONE_CLICK_EXTERNAL_DEP_TIMEOUT:-5}"
+
+  if [[ -n "${CUBE_EXTERNAL_MYSQL_HOST}" ]]; then
+    if command -v mysqladmin >/dev/null 2>&1; then
+      log "checking connectivity to external MySQL ${CUBE_EXTERNAL_MYSQL_HOST}:${CUBE_EXTERNAL_MYSQL_PORT}"
+      local mysql_cnf
+      # SECURITY: tighten umask before mktemp so the credential file is created
+      # 0600 from the start -- this closes the brief race window between mktemp's
+      # default (umask-derived) permissions and the chmod 600 below.
+      local old_umask
+      old_umask="$(umask)"
+      umask 077
+      mysql_cnf="$(mktemp)"
+      umask "${old_umask}"
+      # SECURITY: trap on EXIT so the plaintext password is removed even if the
+      # script is killed abruptly between here and the explicit rm-f below.
+      # Mirrors the trap pattern in up-with-deps.sh.
+      trap 'rm -f "${mysql_cnf}"' EXIT
+      chmod 600 "${mysql_cnf}"
+      cat > "${mysql_cnf}" <<EOF
+[client]
+password="${CUBE_EXTERNAL_MYSQL_PASSWORD}"
+EOF
+      if ! mysqladmin --defaults-extra-file="${mysql_cnf}" \
+          -h "${CUBE_EXTERNAL_MYSQL_HOST}" \
+          -P "${CUBE_EXTERNAL_MYSQL_PORT}" \
+          -u "${CUBE_EXTERNAL_MYSQL_USER}" \
+          --connect-timeout="${connect_timeout}" ping >/dev/null 2>&1; then
+        rm -f "${mysql_cnf}"
+        trap - EXIT
+        die "cannot reach external MySQL at ${CUBE_EXTERNAL_MYSQL_HOST}:${CUBE_EXTERNAL_MYSQL_PORT} as user '${CUBE_EXTERNAL_MYSQL_USER}'.
+  Verify CUBE_EXTERNAL_MYSQL_HOST / _PORT / _USER / _PASSWORD and that the server is reachable from this host."
+      fi
+      rm -f "${mysql_cnf}"
+      trap - EXIT
+      log "external MySQL connectivity OK"
+    else
+      log "mysqladmin not found; skipping external MySQL connectivity preflight"
+    fi
+  fi
+
+  if [[ -n "${CUBE_EXTERNAL_REDIS_HOST}" ]]; then
+    if command -v redis-cli >/dev/null 2>&1; then
+      log "checking connectivity to external Redis ${CUBE_EXTERNAL_REDIS_HOST}:${CUBE_EXTERNAL_REDIS_PORT}"
+      local redis_reply
+      if [[ -n "${CUBE_EXTERNAL_REDIS_PASSWORD}" ]]; then
+        # SECURITY: PING is NOT an authenticated command. A reachable server that
+        # has no 'requirepass' set answers PONG even when a (wrong/extraneous)
+        # password is configured, so a misconfigured credential would slip
+        # through this preflight and only surface much later when CubeMaster /
+        # cube-proxy actually try to use Redis. Validate the credential directly
+        # by issuing AUTH and requiring an "OK" reply.
+        #
+        # The password is fed via stdin (`-x AUTH`) rather than as a command-line
+        # argument so it is not exposed in /proc/<pid>/cmdline to other local
+        # users; --no-auth-warning keeps redis-cli from echoing it on stderr.
+        # --connect-timeout bounds the TCP handshake; --timeout bounds Redis
+        # protocol I/O so a middlebox that accepts the socket but stalls the
+        # response (broken proxy / overloaded server) cannot hang this preflight
+        # indefinitely.
+        redis_reply="$(printf '%s' "${CUBE_EXTERNAL_REDIS_PASSWORD}" | redis-cli \
+          -h "${CUBE_EXTERNAL_REDIS_HOST}" \
+          -p "${CUBE_EXTERNAL_REDIS_PORT}" \
+          --connect-timeout "${connect_timeout}" \
+          --timeout "${connect_timeout}" \
+          --no-auth-warning \
+          -x AUTH 2>&1 || true)"
+        if [[ "${redis_reply}" != "OK" ]]; then
+          die "external Redis at ${CUBE_EXTERNAL_REDIS_HOST}:${CUBE_EXTERNAL_REDIS_PORT} is unreachable or rejected the configured password (AUTH replied: ${redis_reply:-<no response>}).
+  Verify CUBE_EXTERNAL_REDIS_HOST / _PORT / _PASSWORD and that the server is reachable from this host."
+        fi
+      else
+        local redis_pong
+        redis_pong="$(redis-cli \
+          -h "${CUBE_EXTERNAL_REDIS_HOST}" \
+          -p "${CUBE_EXTERNAL_REDIS_PORT}" \
+          --connect-timeout "${connect_timeout}" \
+          --timeout "${connect_timeout}" ping 2>/dev/null || true)"
+        if [[ "${redis_pong}" != "PONG" ]]; then
+          die "cannot reach external Redis at ${CUBE_EXTERNAL_REDIS_HOST}:${CUBE_EXTERNAL_REDIS_PORT} (PING did not return PONG).
+  Verify CUBE_EXTERNAL_REDIS_HOST / _PORT and that the server is reachable from this host."
+        fi
+      fi
+      log "external Redis connectivity OK"
+    else
+      log "redis-cli not found; skipping external Redis connectivity preflight"
+    fi
+  fi
 }
 
 check_hardware_preflight() {
@@ -537,6 +726,30 @@ start_systemd_target() {
   systemctl enable --now "${target}"
 }
 
+# When external MySQL/Redis is configured, mask the local container systemd
+# services so the control target never starts (or restarts) them. The target
+# only `Wants` these units, so masking is non-fatal for the rest of the stack.
+# Must run after install_systemd_units (units installed + daemon-reload) and
+# before start_systemd_target.
+mask_external_dep_services() {
+  if [[ -n "${CUBE_EXTERNAL_MYSQL_HOST}" ]]; then
+    log "masking local MySQL service (external MySQL at ${CUBE_EXTERNAL_MYSQL_HOST} in use)"
+    systemctl stop cube-sandbox-mysql.service >/dev/null 2>&1 || true
+    systemctl mask cube-sandbox-mysql.service >/dev/null 2>&1 || true
+  else
+    # Re-enable in case a previous install masked it and the user switched back.
+    systemctl unmask cube-sandbox-mysql.service >/dev/null 2>&1 || true
+  fi
+
+  if [[ -n "${CUBE_EXTERNAL_REDIS_HOST}" ]]; then
+    log "masking local Redis service (external Redis at ${CUBE_EXTERNAL_REDIS_HOST} in use)"
+    systemctl stop cube-sandbox-redis.service >/dev/null 2>&1 || true
+    systemctl mask cube-sandbox-redis.service >/dev/null 2>&1 || true
+  else
+    systemctl unmask cube-sandbox-redis.service >/dev/null 2>&1 || true
+  fi
+}
+
 require_root
 
 # Run critical preflight checks that do not depend on dependency installation first
@@ -567,6 +780,8 @@ fi
 
 install_required_dependencies
 check_install_preflight
+warn_default_external_credentials
+check_external_deps_preflight
 if needs_docker_for_install; then
   configure_tencent_docker_mirror
 fi
@@ -627,6 +842,7 @@ if [[ "${DEPLOY_ROLE}" == "compute" ]]; then
   copy_dir_contents "${PKG_ROOT}/scripts" "${INSTALL_PREFIX}/scripts"
 else
   generate_cubemaster_config_ports
+  patch_cubemaster_external_deps
   cp -a "${PKG_ROOT}/." "${INSTALL_PREFIX}/"
 fi
 
@@ -654,6 +870,12 @@ if [[ -f "${ENV_FILE}" ]]; then
 else
   : > "${RUNTIME_ENV_FILE}"
 fi
+# SECURITY: this file holds DATABASE_URL and CUBE_EXTERNAL_*_PASSWORD secrets.
+# Restrict it to root before any secrets are written so they are never readable
+# by other local users. Note that upsert_env_kv rewrites the file via an atomic
+# mktemp+mv, which replaces the inode; it sets 0600 on its temp file so this
+# mode is preserved across every later upsert rather than reverting to 0644.
+chmod 600 "${RUNTIME_ENV_FILE}"
 
 # Install version files so the installed system can report its version.
 if [[ -f "${SCRIPT_DIR}/VERSION.txt" ]]; then
@@ -682,6 +904,39 @@ if [[ -n "${ONE_CLICK_CONTROL_PLANE_IP:-}" ]]; then
 fi
 if [[ -n "${ONE_CLICK_CONTROL_PLANE_CUBEMASTER_ADDR:-}" ]]; then
   upsert_env_kv "${RUNTIME_ENV_FILE}" "ONE_CLICK_CONTROL_PLANE_CUBEMASTER_ADDR" "${ONE_CLICK_CONTROL_PLANE_CUBEMASTER_ADDR}"
+fi
+
+# Persist external MySQL config so every systemd unit / helper picks it up
+# instead of the local container. The CUBE_EXTERNAL_* markers let quickcheck
+# and the up/down helpers skip the local service entirely; DATABASE_URL points
+# CubeAPI at the external server (CubeMaster reads the patched conf.yaml).
+if [[ -n "${CUBE_EXTERNAL_MYSQL_HOST}" ]]; then
+  upsert_env_kv "${RUNTIME_ENV_FILE}" "CUBE_EXTERNAL_MYSQL_HOST" "${CUBE_EXTERNAL_MYSQL_HOST}"
+  upsert_env_kv "${RUNTIME_ENV_FILE}" "CUBE_EXTERNAL_MYSQL_PORT" "${CUBE_EXTERNAL_MYSQL_PORT}"
+  upsert_env_kv "${RUNTIME_ENV_FILE}" "CUBE_EXTERNAL_MYSQL_USER" "${CUBE_EXTERNAL_MYSQL_USER}"
+  upsert_env_kv "${RUNTIME_ENV_FILE}" "CUBE_EXTERNAL_MYSQL_PASSWORD" "${CUBE_EXTERNAL_MYSQL_PASSWORD}"
+  upsert_env_kv "${RUNTIME_ENV_FILE}" "CUBE_EXTERNAL_MYSQL_DB" "${CUBE_EXTERNAL_MYSQL_DB}"
+  # Percent-encode every URI component so values containing URL metacharacters
+  # (@, :, /, #, %, ...) cannot corrupt the connection string. This covers the
+  # userinfo (user/password) as well as the host, port, and database name (e.g.
+  # a '/' in the db name would otherwise be parsed as a path separator).
+  database_url_user="$(urlencode "${CUBE_EXTERNAL_MYSQL_USER}")"
+  database_url_pass="$(urlencode "${CUBE_EXTERNAL_MYSQL_PASSWORD}")"
+  database_url_host="$(urlencode "${CUBE_EXTERNAL_MYSQL_HOST}")"
+  database_url_port="$(urlencode "${CUBE_EXTERNAL_MYSQL_PORT}")"
+  database_url_db="$(urlencode "${CUBE_EXTERNAL_MYSQL_DB}")"
+  upsert_env_kv "${RUNTIME_ENV_FILE}" "DATABASE_URL" "mysql://${database_url_user}:${database_url_pass}@${database_url_host}:${database_url_port}/${database_url_db}"
+fi
+
+# Persist external Redis config. cube-proxy reads CUBE_PROXY_REDIS_* from the
+# env file when rendering global.conf (CubeMaster reads the patched conf.yaml).
+if [[ -n "${CUBE_EXTERNAL_REDIS_HOST}" ]]; then
+  upsert_env_kv "${RUNTIME_ENV_FILE}" "CUBE_EXTERNAL_REDIS_HOST" "${CUBE_EXTERNAL_REDIS_HOST}"
+  upsert_env_kv "${RUNTIME_ENV_FILE}" "CUBE_EXTERNAL_REDIS_PORT" "${CUBE_EXTERNAL_REDIS_PORT}"
+  upsert_env_kv "${RUNTIME_ENV_FILE}" "CUBE_EXTERNAL_REDIS_PASSWORD" "${CUBE_EXTERNAL_REDIS_PASSWORD}"
+  upsert_env_kv "${RUNTIME_ENV_FILE}" "CUBE_PROXY_REDIS_IP" "${CUBE_EXTERNAL_REDIS_HOST}"
+  upsert_env_kv "${RUNTIME_ENV_FILE}" "CUBE_PROXY_REDIS_PORT" "${CUBE_EXTERNAL_REDIS_PORT}"
+  upsert_env_kv "${RUNTIME_ENV_FILE}" "CUBE_PROXY_REDIS_PASSWORD" "${CUBE_EXTERNAL_REDIS_PASSWORD}"
 fi
 
 chmod +x "${INSTALL_PREFIX}/network-agent/bin/"*
@@ -762,6 +1017,7 @@ fi
 
 restore_selinux_contexts
 install_systemd_units
+mask_external_dep_services
 check_runtime_file_paths_not_directories
 start_systemd_target
 

--- a/deploy/one-click/lib/common.sh
+++ b/deploy/one-click/lib/common.sh
@@ -101,6 +101,49 @@ ensure_file() {
   [[ -f "${path}" ]] || die "required file not found: ${path}"
 }
 
+# Escape a string so it can be used safely as the replacement text in a sed
+# `s|...|...|` expression. Escapes the delimiter '|', backslashes, '&' (the
+# whole-match reference) and '"'. Mirrors the escape_sed helper in
+# up-support.sh, which escapes for the '/' delimiter instead.
+#
+# The '"' is escaped because the only caller (patch_cubemaster_external_deps in
+# install.sh) embeds the result inside double-quoted sed replacement strings
+# such as `pwd: "${value}"`; escaping it keeps a value that itself contains a
+# '"' from corrupting the rendered YAML.
+#
+# SECURITY: embedded newlines / carriage returns are stripped first as
+# defense-in-depth. An unescaped newline in the replacement text would
+# terminate the sed `s` command and let a crafted value (e.g. a password read
+# from .env) inject arbitrary sed commands into the rendered config.
+escape_sed() {
+  printf '%s' "$1" | tr -d '\n\r' | sed 's/[|\\&"]/\\&/g'
+}
+
+# Percent-encode a string for safe use as a URL component (e.g. the userinfo
+# section of a connection string). Encodes every byte that is not an RFC 3986
+# unreserved character, so values containing '@', ':', '/', '%', etc. do not
+# corrupt the resulting URL. Operates byte-wise under the C locale so multibyte
+# input is encoded correctly.
+urlencode() {
+  local LC_ALL=C
+  local string="$1"
+  local len="${#string}"
+  local i char hex out=""
+  for (( i = 0; i < len; i++ )); do
+    char="${string:i:1}"
+    case "${char}" in
+      [a-zA-Z0-9._~-])
+        out+="${char}"
+        ;;
+      *)
+        printf -v hex '%02X' "'${char}"
+        out+="%${hex}"
+        ;;
+    esac
+  done
+  printf '%s' "${out}"
+}
+
 declared_release_manifest_relpath() {
   local version_file="$1"
   [[ -f "${version_file}" ]] || return 0
@@ -239,10 +282,24 @@ upsert_env_kv() {
   local key="$2"
   local value="$3"
   local tmp_file
+  # SECURITY: tighten umask before mktemp so the temp file is created 0600 from
+  # the start, closing the race window between creation and the chmod below.
+  # The atomic `mv` later replaces the target's inode with this temp file, so a
+  # permissive umask (e.g. 0022 -> 0644, or 0000 -> 0666) would otherwise leak
+  # every persisted secret (DATABASE_URL, CUBE_EXTERNAL_*_PASSWORD, ...) to other
+  # local users -- briefly here and permanently in env_file. Mirrors the pattern
+  # in install.sh's check_external_deps_preflight and up-with-deps.sh.
+  local old_umask
+  old_umask="$(umask)"
+  umask 077
   # Create temp file in the same directory as target to guarantee
   # atomic rename across filesystem boundaries (e.g., /tmp on tmpfs
   # and /usr/local on ext4/xfs).
   tmp_file="$(mktemp "${env_file}.XXXXXX")"
+  umask "${old_umask}"
+  # Defense-in-depth: enforce 0600 explicitly in case the temp file pre-existed
+  # with looser permissions or mktemp honored a non-default mode.
+  chmod 600 "${tmp_file}"
   local replaced=false
 
   if [[ -f "${env_file}" ]]; then

--- a/deploy/one-click/scripts/one-click/common.sh
+++ b/deploy/one-click/scripts/one-click/common.sh
@@ -120,6 +120,24 @@ ensure_bind_mount_file() {
   [[ -f "${path}" ]] || die "required bind mount source file not found: ${path}"
 }
 
+# Escape VALUE so it can be safely interpolated into the replacement text of a
+# sed `s<delim>...<delim>...<delim>` expression. Escapes backslashes, '&' (the
+# whole-match reference) and the substitution delimiter (default '/'); pass the
+# delimiter actually used at the call site (e.g. '#') so values containing it do
+# not terminate the command. Backslash is written as '\\' in the bracket
+# expression so it is unambiguously a member across POSIX and GNU sed (GNU sed
+# treats a bare '\<delim>' as the plain delimiter, dropping backslash from the
+# set). Embedded newlines / carriage returns are stripped as defense-in-depth:
+# an unescaped newline would terminate the sed command and allow a crafted value
+# (e.g. a password read from .env) to inject arbitrary sed script. This is the
+# single shared helper for every one-click runtime script; do not re-define it
+# per-script (that historically caused inconsistent escaping semantics).
+escape_sed() {
+  local value="$1"
+  local delim="${2:-/}"
+  printf '%s' "${value}" | tr -d '\n\r' | sed "s/[\\\\${delim}&]/\\\\&/g"
+}
+
 render_template_atomic() {
   local template="$1"
   local output="$2"

--- a/deploy/one-click/scripts/one-click/quickcheck.sh
+++ b/deploy/one-click/scripts/one-click/quickcheck.sh
@@ -12,6 +12,11 @@ CUBE_API_HEALTH_ADDR="${CUBE_API_HEALTH_ADDR:-127.0.0.1:3000}"
 ROLE="$(one_click_deploy_role)"
 NODE_ID="${CUBE_SANDBOX_NODE_IP:-}"
 
+# When external MySQL/Redis is configured the local container + systemd unit do
+# not exist, so the corresponding checks must be skipped.
+EXTERNAL_MYSQL_HOST="${CUBE_EXTERNAL_MYSQL_HOST:-}"
+EXTERNAL_REDIS_HOST="${CUBE_EXTERNAL_REDIS_HOST:-}"
+
 require_cmd systemctl
 
 check_unit_active() {
@@ -61,8 +66,16 @@ echo "[quickcheck] check systemd units"
 check_unit_active cube-sandbox-network-agent.service
 check_unit_active cube-sandbox-cubelet.service
 if [[ "${ROLE}" != "compute" ]]; then
-  check_unit_active cube-sandbox-mysql.service
-  check_unit_active cube-sandbox-redis.service
+  if [[ -n "${EXTERNAL_MYSQL_HOST}" ]]; then
+    echo "[quickcheck] external MySQL (${EXTERNAL_MYSQL_HOST}); skipping local mysql unit check"
+  else
+    check_unit_active cube-sandbox-mysql.service
+  fi
+  if [[ -n "${EXTERNAL_REDIS_HOST}" ]]; then
+    echo "[quickcheck] external Redis (${EXTERNAL_REDIS_HOST}); skipping local redis unit check"
+  else
+    check_unit_active cube-sandbox-redis.service
+  fi
   check_unit_active cube-sandbox-cubemaster.service
   check_unit_active cube-sandbox-cube-api.service
   check_unit_active cube-sandbox-cube-proxy.service
@@ -75,8 +88,8 @@ fi
 
 if command -v docker >/dev/null 2>&1 && [[ "${ROLE}" != "compute" ]]; then
   echo "[quickcheck] check container runtime state"
-  check_container_ready "${CUBE_SANDBOX_MYSQL_CONTAINER:-cube-sandbox-mysql}"
-  check_container_ready "${CUBE_SANDBOX_REDIS_CONTAINER:-cube-sandbox-redis}"
+  [[ -n "${EXTERNAL_MYSQL_HOST}" ]] || check_container_ready "${CUBE_SANDBOX_MYSQL_CONTAINER:-cube-sandbox-mysql}"
+  [[ -n "${EXTERNAL_REDIS_HOST}" ]] || check_container_ready "${CUBE_SANDBOX_REDIS_CONTAINER:-cube-sandbox-redis}"
   check_container_ready "${CUBE_PROXY_CONTAINER_NAME:-cube-proxy}"
   check_container_ready "${CUBE_PROXY_COREDNS_CONTAINER:-cube-proxy-coredns}"
   if [[ "${WEB_UI_ENABLE:-1}" == "1" ]]; then

--- a/deploy/one-click/scripts/one-click/up-cube-proxy.sh
+++ b/deploy/one-click/scripts/one-click/up-cube-proxy.sh
@@ -65,10 +65,6 @@ install_mkcert() {
   command -v mkcert >/dev/null 2>&1 || die "failed to install mkcert from bundled binary"
 }
 
-escape_sed() {
-  printf '%s' "$1" | sed 's/[\/&]/\\&/g'
-}
-
 prepare_proxy_certs() {
   mkdir -p "${CERT_DIR}"
   if [[ -f "${CERT_DIR}/${CUBE_PROXY_SSL_CERT}" && -f "${CERT_DIR}/${CUBE_PROXY_SSL_KEY}" ]]; then
@@ -114,12 +110,12 @@ render_template_atomic \
 render_template_atomic \
   "${COMPOSE_TEMPLATE}" \
   "${COMPOSE_FILE}" \
-  -e "s#__CUBE_PROXY_IMAGE__#$(escape_sed "${CUBE_PROXY_IMAGE_TAG}")#g" \
-  -e "s#__CUBE_PROXY_CONTAINER_NAME__#$(escape_sed "${CUBE_PROXY_CONTAINER_NAME}")#g" \
-  -e "s#__CUBE_PROXY_BUILD_CONTEXT__#$(escape_sed "${BUILD_CONTEXT_DIR}")#g" \
-  -e "s#__CUBE_PROXY_CERT_DIR__#$(escape_sed "${CERT_DIR}")#g" \
-  -e "s#__CUBE_PROXY_GLOBAL_CONF__#$(escape_sed "${GLOBAL_CONF}")#g" \
-  -e "s#__CUBE_PROXY_NGINX_CONF__#$(escape_sed "${NGINX_CONF}")#g"
+  -e "s#__CUBE_PROXY_IMAGE__#$(escape_sed "${CUBE_PROXY_IMAGE_TAG}" '#')#g" \
+  -e "s#__CUBE_PROXY_CONTAINER_NAME__#$(escape_sed "${CUBE_PROXY_CONTAINER_NAME}" '#')#g" \
+  -e "s#__CUBE_PROXY_BUILD_CONTEXT__#$(escape_sed "${BUILD_CONTEXT_DIR}" '#')#g" \
+  -e "s#__CUBE_PROXY_CERT_DIR__#$(escape_sed "${CERT_DIR}" '#')#g" \
+  -e "s#__CUBE_PROXY_GLOBAL_CONF__#$(escape_sed "${GLOBAL_CONF}" '#')#g" \
+  -e "s#__CUBE_PROXY_NGINX_CONF__#$(escape_sed "${NGINX_CONF}" '#')#g"
 
 if [[ "${PREPARE_ONLY}" == "1" ]]; then
   log "cube proxy runtime files prepared under ${PROXY_DIR}"

--- a/deploy/one-click/scripts/one-click/up-support.sh
+++ b/deploy/one-click/scripts/one-click/up-support.sh
@@ -38,10 +38,6 @@ ensure_dir "${SUPPORT_DIR}"
 ensure_dir "${SQL_DIR}"
 ensure_file "${SUPPORT_TEMPLATE}"
 
-escape_sed() {
-  printf '%s' "$1" | sed 's/[\/&]/\\&/g'
-}
-
 render_support_compose() {
   mkdir -p "$(dirname "${SUPPORT_COMPOSE_LOCK}")"
   (
@@ -51,8 +47,8 @@ render_support_compose() {
       "${SUPPORT_COMPOSE_FILE}" \
       -e "s/__MYSQL_CONTAINER__/$(escape_sed "${MYSQL_CONTAINER}")/g" \
       -e "s/__REDIS_CONTAINER__/$(escape_sed "${REDIS_CONTAINER}")/g" \
-      -e "s#__MYSQL_IMAGE__#$(escape_sed "${MYSQL_IMAGE}")#g" \
-      -e "s#__REDIS_IMAGE__#$(escape_sed "${REDIS_IMAGE}")#g" \
+      -e "s#__MYSQL_IMAGE__#$(escape_sed "${MYSQL_IMAGE}" '#')#g" \
+      -e "s#__REDIS_IMAGE__#$(escape_sed "${REDIS_IMAGE}" '#')#g" \
       -e "s/__MYSQL_VOLUME__/$(escape_sed "${MYSQL_VOLUME}")/g" \
       -e "s/__REDIS_VOLUME__/$(escape_sed "${REDIS_VOLUME}")/g" \
       -e "s/__MYSQL_PORT__/$(escape_sed "${MYSQL_PORT}")/g" \
@@ -62,7 +58,7 @@ render_support_compose() {
       -e "s/__MYSQL_USER__/$(escape_sed "${MYSQL_USER}")/g" \
       -e "s/__MYSQL_PASSWORD__/$(escape_sed "${MYSQL_PASSWORD}")/g" \
       -e "s/__MYSQL_ROOT_PASSWORD__/$(escape_sed "${MYSQL_ROOT_PASSWORD}")/g" \
-      -e "s#__SQL_DIR__#$(escape_sed "${SQL_DIR}")#g"
+      -e "s#__SQL_DIR__#$(escape_sed "${SQL_DIR}" '#')#g"
   ) 9>"${SUPPORT_COMPOSE_LOCK}"
 }
 
@@ -77,6 +73,42 @@ case "${COMPOSE_DETACH}" in
   0|1) ;;
   *) die "unsupported ONE_CLICK_COMPOSE_DETACH: ${COMPOSE_DETACH} (expected 0 or 1)" ;;
 esac
+
+# When MySQL/Redis is provided externally, never start the matching local
+# container. Filter it out of the requested service set; for the legacy
+# "all services" path (empty SUPPORT_SERVICES) restrict the run to the local
+# services only so we don't accidentally launch a conflicting container.
+CUBE_EXTERNAL_MYSQL_HOST="${CUBE_EXTERNAL_MYSQL_HOST:-}"
+CUBE_EXTERNAL_REDIS_HOST="${CUBE_EXTERNAL_REDIS_HOST:-}"
+if [[ -n "${CUBE_EXTERNAL_MYSQL_HOST}" || -n "${CUBE_EXTERNAL_REDIS_HOST}" ]]; then
+  requested_services="${SUPPORT_SERVICES:-mysql redis}"
+  filtered_services=""
+  # Split on whitespace into an array so SUPPORT_SERVICES (user-controllable) is
+  # not subject to glob expansion / pathname matching while iterating.
+  read -ra requested_services_arr <<< "${requested_services}"
+  for svc in "${requested_services_arr[@]}"; do
+    case "${svc}" in
+      mysql)
+        if [[ -n "${CUBE_EXTERNAL_MYSQL_HOST}" ]]; then
+          log "using external MySQL (${CUBE_EXTERNAL_MYSQL_HOST}), skipping local mysql container"
+          continue
+        fi
+        ;;
+      redis)
+        if [[ -n "${CUBE_EXTERNAL_REDIS_HOST}" ]]; then
+          log "using external Redis (${CUBE_EXTERNAL_REDIS_HOST}), skipping local redis container"
+          continue
+        fi
+        ;;
+    esac
+    filtered_services="${filtered_services}${filtered_services:+ }${svc}"
+  done
+  if [[ -z "${filtered_services}" ]]; then
+    log "all support services are external; nothing to start under ${SUPPORT_DIR}"
+    exit 0
+  fi
+  SUPPORT_SERVICES="${filtered_services}"
+fi
 
 if [[ -z "${SUPPORT_SERVICES}" ]]; then
   support_compose_run down --remove-orphans >/dev/null 2>&1 || true

--- a/deploy/one-click/scripts/one-click/up-webui.sh
+++ b/deploy/one-click/scripts/one-click/up-webui.sh
@@ -49,10 +49,6 @@ do
   ensure_file "${required_file}"
 done
 
-escape_sed() {
-  printf '%s' "$1" | sed 's/[\/&]/\\&/g'
-}
-
 wait_for_tcp_port() {
   local port="$1"
   local retries="${2:-30}"
@@ -69,13 +65,15 @@ wait_for_tcp_port() {
   return 1
 }
 
-WEB_UI_HOST_PORT_ESCAPED="$(escape_sed "${WEB_UI_HOST_PORT}")"
-WEB_UI_UPSTREAM_ESCAPED="$(escape_sed "${WEB_UI_UPSTREAM}")"
-SANDBOX_PROXY_UPSTREAM_ESCAPED="$(escape_sed "${SANDBOX_PROXY_UPSTREAM}")"
-WEB_UI_IMAGE_ESCAPED="$(escape_sed "${WEB_UI_IMAGE}")"
-WEB_UI_CONTAINER_NAME_ESCAPED="$(escape_sed "${WEB_UI_CONTAINER_NAME}")"
-WEB_UI_DIST_DIR_ESCAPED="$(escape_sed "${WEB_UI_DIST_DIR}")"
-NGINX_CONF_ESCAPED="$(escape_sed "${NGINX_CONF}")"
+# All render_template_atomic call sites below use '#' as the sed delimiter, so
+# escape against '#' (not the default '/').
+WEB_UI_HOST_PORT_ESCAPED="$(escape_sed "${WEB_UI_HOST_PORT}" '#')"
+WEB_UI_UPSTREAM_ESCAPED="$(escape_sed "${WEB_UI_UPSTREAM}" '#')"
+SANDBOX_PROXY_UPSTREAM_ESCAPED="$(escape_sed "${SANDBOX_PROXY_UPSTREAM}" '#')"
+WEB_UI_IMAGE_ESCAPED="$(escape_sed "${WEB_UI_IMAGE}" '#')"
+WEB_UI_CONTAINER_NAME_ESCAPED="$(escape_sed "${WEB_UI_CONTAINER_NAME}" '#')"
+WEB_UI_DIST_DIR_ESCAPED="$(escape_sed "${WEB_UI_DIST_DIR}" '#')"
+NGINX_CONF_ESCAPED="$(escape_sed "${NGINX_CONF}" '#')"
 
 render_template_atomic \
   "${NGINX_TEMPLATE}" \

--- a/deploy/one-click/scripts/one-click/up-with-deps.sh
+++ b/deploy/one-click/scripts/one-click/up-with-deps.sh
@@ -15,6 +15,25 @@ MYSQL_ROOT_PASSWORD="${CUBE_SANDBOX_MYSQL_ROOT_PASSWORD:-cube_root}"
 CUBE_SANDBOX_NODE_IP="${CUBE_SANDBOX_NODE_IP:-}"
 SQL_DIR="${TOOLBOX_ROOT}/sql"
 
+# External MySQL/Redis support: when configured, the local containers are not
+# started, so the single-node seed must go to the external server and cube-proxy
+# must be pointed at the external Redis.
+CUBE_EXTERNAL_MYSQL_HOST="${CUBE_EXTERNAL_MYSQL_HOST:-}"
+CUBE_EXTERNAL_MYSQL_PORT="${CUBE_EXTERNAL_MYSQL_PORT:-3306}"
+CUBE_EXTERNAL_MYSQL_USER="${CUBE_EXTERNAL_MYSQL_USER:-cube}"
+CUBE_EXTERNAL_MYSQL_PASSWORD="${CUBE_EXTERNAL_MYSQL_PASSWORD:-cube_pass}"
+CUBE_EXTERNAL_MYSQL_DB="${CUBE_EXTERNAL_MYSQL_DB:-${MYSQL_DB}}"
+CUBE_EXTERNAL_REDIS_HOST="${CUBE_EXTERNAL_REDIS_HOST:-}"
+CUBE_EXTERNAL_REDIS_PORT="${CUBE_EXTERNAL_REDIS_PORT:-6379}"
+CUBE_EXTERNAL_REDIS_PASSWORD="${CUBE_EXTERNAL_REDIS_PASSWORD:-ceuhvu123}"
+
+# Point cube-proxy at the external Redis (up-cube-proxy.sh reads these).
+if [[ -n "${CUBE_EXTERNAL_REDIS_HOST}" ]]; then
+  export CUBE_PROXY_REDIS_IP="${CUBE_EXTERNAL_REDIS_HOST}"
+  export CUBE_PROXY_REDIS_PORT="${CUBE_EXTERNAL_REDIS_PORT}"
+  export CUBE_PROXY_REDIS_PASSWORD="${CUBE_EXTERNAL_REDIS_PASSWORD}"
+fi
+
 # CubeMaster owns its own schema via the embedded goose migrations; we
 # only seed deployment-specific rows here (the single-node host_info /
 # sub_host_info rows that turn a fresh database into a usable single-box
@@ -25,6 +44,7 @@ CUBEMASTER_READY_TIMEOUT="${CUBEMASTER_READY_TIMEOUT:-120}"
 
 test -d "${SQL_DIR}" || die "sql dir missing: ${SQL_DIR}"
 [[ -n "${CUBE_SANDBOX_NODE_IP}" ]] || die "CUBE_SANDBOX_NODE_IP is required; set it to the current node private IP in .one-click.env"
+CUBE_SANDBOX_NODE_IP_SED="$(escape_sed "${CUBE_SANDBOX_NODE_IP}")"
 
 "${SCRIPT_DIR}/up-support.sh"
 
@@ -41,7 +61,43 @@ test -d "${SQL_DIR}" || die "sql dir missing: ${SQL_DIR}"
 wait_for_http "http://${CUBEMASTER_HEALTH_ADDR}/notify/health" "${CUBEMASTER_READY_TIMEOUT}" 1 \
   || die "cubemaster did not become ready before seeding, check logs under ${LOG_DIR}"
 
-sed "s/__CUBE_SANDBOX_NODE_IP__/${CUBE_SANDBOX_NODE_IP//\//\\/}/g" "${SQL_DIR}/002_seed_single_node.sql" \
-  | docker exec -i "${CUBE_SANDBOX_MYSQL_CONTAINER}" mysql -uroot "-p${MYSQL_ROOT_PASSWORD}" "${MYSQL_DB}"
+if [[ -n "${CUBE_EXTERNAL_MYSQL_HOST}" ]]; then
+  # External MySQL: the local container is absent, so seed via a host-side
+  # mysql client connecting to the external server.
+  require_cmd mysql
+  log "seeding single-node rows into external MySQL ${CUBE_EXTERNAL_MYSQL_HOST}:${CUBE_EXTERNAL_MYSQL_PORT}/${CUBE_EXTERNAL_MYSQL_DB}"
+  # SECURITY: pass the password via a temporary, 0600 my.cnf instead of
+  # "-p<pwd>" on the command line. Process arguments are world-readable via
+  # /proc/<pid>/cmdline, which would leak the MySQL password to any local user.
+  # Tighten umask before mktemp so the file is created 0600 from the start --
+  # this closes the brief race window between mktemp's default (umask-derived)
+  # permissions and the chmod 600 below. Mirrors install.sh's pattern.
+  OLD_UMASK="$(umask)"
+  umask 077
+  MYSQL_CNF="$(mktemp)"
+  umask "${OLD_UMASK}"
+  trap 'rm -f "${MYSQL_CNF}"' EXIT
+  chmod 600 "${MYSQL_CNF}"
+  cat > "${MYSQL_CNF}" <<EOF
+[client]
+password="${CUBE_EXTERNAL_MYSQL_PASSWORD}"
+EOF
+  # Fail fast if the external MySQL becomes slow/unreachable between the
+  # install.sh preflight and this seed step, instead of hanging indefinitely.
+  # Matches the preflight's connect timeout (ONE_CLICK_EXTERNAL_DEP_TIMEOUT).
+  sed "s/__CUBE_SANDBOX_NODE_IP__/${CUBE_SANDBOX_NODE_IP_SED}/g" "${SQL_DIR}/002_seed_single_node.sql" \
+    | mysql \
+        --defaults-extra-file="${MYSQL_CNF}" \
+        -h "${CUBE_EXTERNAL_MYSQL_HOST}" \
+        -P "${CUBE_EXTERNAL_MYSQL_PORT}" \
+        -u "${CUBE_EXTERNAL_MYSQL_USER}" \
+        --connect-timeout="${ONE_CLICK_EXTERNAL_DEP_TIMEOUT:-5}" \
+        "${CUBE_EXTERNAL_MYSQL_DB}"
+  rm -f "${MYSQL_CNF}"
+  trap - EXIT
+else
+  sed "s/__CUBE_SANDBOX_NODE_IP__/${CUBE_SANDBOX_NODE_IP_SED}/g" "${SQL_DIR}/002_seed_single_node.sql" \
+    | docker exec -i "${CUBE_SANDBOX_MYSQL_CONTAINER}" mysql -uroot "-p${MYSQL_ROOT_PASSWORD}" "${MYSQL_DB}"
+fi
 
 "${SCRIPT_DIR}/up-webui.sh"

--- a/deploy/one-click/scripts/systemd/mysql-postcheck.sh
+++ b/deploy/one-click/scripts/systemd/mysql-postcheck.sh
@@ -2,4 +2,10 @@
 set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${SCRIPT_DIR}/common.sh"
+# External MySQL: the local container is never started (see up-support.sh), so
+# there is nothing local to health-check. Skip rather than block ~80s on a
+# missing container and then trigger Restart=on-failure.
+if [[ -n "${CUBE_EXTERNAL_MYSQL_HOST:-}" ]]; then
+  exit 0
+fi
 wait_for_container_health "${CUBE_SANDBOX_MYSQL_CONTAINER:-cube-sandbox-mysql}" 40 2 || die "mysql container not ready"

--- a/deploy/one-click/scripts/systemd/redis-postcheck.sh
+++ b/deploy/one-click/scripts/systemd/redis-postcheck.sh
@@ -2,4 +2,10 @@
 set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${SCRIPT_DIR}/common.sh"
+# External Redis: the local container is never started (see up-support.sh), so
+# there is nothing local to health-check. Skip rather than block on a missing
+# container and then trigger Restart=on-failure.
+if [[ -n "${CUBE_EXTERNAL_REDIS_HOST:-}" ]]; then
+  exit 0
+fi
 wait_for_container_health "${CUBE_SANDBOX_REDIS_CONTAINER:-cube-sandbox-redis}" 40 2 || die "redis container not ready"

--- a/deploy/one-click/tests/test_runtime_file_safety.sh
+++ b/deploy/one-click/tests/test_runtime_file_safety.sh
@@ -227,6 +227,36 @@ CUBE_PROXY_POSTCHECK_DELAY=0" \
     8081
 }
 
+test_postcheck_skips_when_external_host_set() {
+  # When an external endpoint is configured the local container is never
+  # started, so the postcheck must short-circuit with exit 0 instead of
+  # blocking on wait_for_container_health (which would otherwise need docker
+  # and ~80s before failing into Restart=on-failure).
+  CUBE_EXTERNAL_MYSQL_HOST=db.example.com \
+    bash "${ONE_CLICK_DIR}/scripts/systemd/mysql-postcheck.sh" \
+    || fail "mysql-postcheck must exit 0 when CUBE_EXTERNAL_MYSQL_HOST is set"
+  CUBE_EXTERNAL_REDIS_HOST=cache.example.com \
+    bash "${ONE_CLICK_DIR}/scripts/systemd/redis-postcheck.sh" \
+    || fail "redis-postcheck must exit 0 when CUBE_EXTERNAL_REDIS_HOST is set"
+}
+
+test_mask_external_dep_services_remove_then_mask() {
+  local path="${ONE_CLICK_DIR}/install.sh"
+
+  # Both local dependency units are routed through the shared masking helper.
+  assert_contains "${path}" "mask_local_dep_service cube-sandbox-mysql.service"
+  assert_contains "${path}" "mask_local_dep_service cube-sandbox-redis.service"
+  # Core fix: remove the installed regular file BEFORE masking, otherwise plain
+  # `systemctl mask` fails to overlay its /dev/null symlink on an existing file.
+  assert_contains "${path}" "rm -f \"\${unit_dir}/\${unit}\""
+  assert_contains "${path}" "systemctl mask \"\${unit}\""
+  # Switch-back-to-local path still unmasks both units, and a daemon-reload
+  # follows so the new (un)masked state is picked up before the target starts.
+  assert_contains "${path}" "systemctl unmask cube-sandbox-mysql.service"
+  assert_contains "${path}" "systemctl unmask cube-sandbox-redis.service"
+  assert_contains "${path}" "systemctl daemon-reload"
+}
+
 test_render_template_replaces_empty_directory
 test_render_template_rejects_non_empty_directory
 test_unit_prepare_hooks_are_wired
@@ -243,5 +273,7 @@ test_cube_proxy_postcheck_follows_http_port
 test_cube_proxy_postcheck_ignores_https_port
 test_cube_proxy_postcheck_ignores_deprecated_host_port
 test_cube_proxy_postcheck_prefers_http_over_deprecated_host_port
+test_postcheck_skips_when_external_host_set
+test_mask_external_dep_services_remove_then_mask
 
 echo "runtime file safety tests OK"


### PR DESCRIPTION
The one-click installer always provisioned MySQL and Redis as bundled local containers, which forced every deployment to run its own database and cache even when a managed or shared instance was already available.

Add an opt-in path so operators can point CubeSandbox at an existing MySQL and/or Redis server via .env. When configured, the installer wires every service and helper to the external endpoint and stops managing the corresponding local container, while deployments that leave it unset keep the existing bundled behavior unchanged.

This makes one-click suitable for environments with centrally operated data stores and reduces redundant local resource usage. Documentation (en + zh) and env.example are updated to describe the new variables.

Note: this feature is also required for standalone deployment.

Assisted-by: Cursor:claude-opus-4.8