### PR TITLE
fix(cubelet): register chi image_forward_latency histogram

### DIFF
--- a/Cubelet/plugins/chi/chics/metrics.go
+++ b/Cubelet/plugins/chi/chics/metrics.go
@@ -38,6 +38,7 @@ func init() {
 			Buckets:   prometheus.ExponentialBuckets(1, 10, 8),
 		},
 	)
+	ns.Add(imageForwardLatency)
 	metrics.Register(ns)
 }
 


### PR DESCRIPTION
The chi_cubebox_image_forward_latency_milliseconds histogram was created via prometheus.NewHistogram but never added to the docker/go-metrics namespace, so metrics.Register(ns) never exposed it on /metrics. Even when image forwards occurred and Observe() was called, the metric was invisible to scraping.

Add the missing ns.Add(imageForwardLatency), matching the pattern in internal/cube/server/images/metrics.go.