### PR TITLE
fix(one-click): extend sandbox CIDR preflight to default config and host resolvers

### DIFF
--- a/deploy/one-click/install.sh
+++ b/deploy/one-click/install.sh
@@ -544,11 +544,29 @@ else
   log "primary network interface not detected; keeping packaged Cubelet eth_name"
 fi
 
-# Validate cubevs CIDR from env var (if set)
+PACKAGE_TAR="${ONE_CLICK_PACKAGE_TAR:-${SCRIPT_DIR}/assets/package/sandbox-package.tar.gz}"
+WORK_DIR="$(mktemp -d)"
+trap 'rm -rf "${WORK_DIR}"' EXIT
+
+require_cmd tar
+ensure_file "${PACKAGE_TAR}"
+
+log "extracting package ${PACKAGE_TAR}"
+tar -xzf "${PACKAGE_TAR}" -C "${WORK_DIR}"
+PKG_ROOT="${WORK_DIR}/sandbox-package"
+ensure_dir "${PKG_ROOT}"
+
+# Validate the effective cubevs CIDR before installing packages or replacing
+# the existing deployment. When the env var is unset, use the packaged Cubelet
+# config value so the default CIDR is checked too.
+CUBELET_PACKAGE_CONFIG="${PKG_ROOT}/Cubelet/config/config.toml"
 CUBE_SANDBOX_NETWORK_CIDR="${CUBE_SANDBOX_NETWORK_CIDR:-}"
 if [[ -n "${CUBE_SANDBOX_NETWORK_CIDR}" ]]; then
-  check_cidr_preflight "${CUBE_SANDBOX_NETWORK_CIDR}"
+  check_cidr_preflight "${CUBE_SANDBOX_NETWORK_CIDR}" "CUBE_SANDBOX_NETWORK_CIDR"
   export CUBE_SANDBOX_NETWORK_CIDR
+else
+  CUBE_SANDBOX_EFFECTIVE_NETWORK_CIDR="$(cubelet_network_cidr_from_config "${CUBELET_PACKAGE_CONFIG}")"
+  check_cidr_preflight "${CUBE_SANDBOX_EFFECTIVE_NETWORK_CIDR}" "Cubelet config cidr"
 fi
 
 install_required_dependencies
@@ -557,17 +575,7 @@ if needs_docker_for_install; then
   configure_tencent_docker_mirror
 fi
 
-PACKAGE_TAR="${ONE_CLICK_PACKAGE_TAR:-${SCRIPT_DIR}/assets/package/sandbox-package.tar.gz}"
-WORK_DIR="$(mktemp -d)"
-trap 'rm -rf "${WORK_DIR}"' EXIT
-
-ensure_file "${PACKAGE_TAR}"
 validate_declared_release_manifest "${SCRIPT_DIR}"
-
-log "extracting package ${PACKAGE_TAR}"
-tar -xzf "${PACKAGE_TAR}" -C "${WORK_DIR}"
-PKG_ROOT="${WORK_DIR}/sandbox-package"
-ensure_dir "${PKG_ROOT}"
 validate_cubelet_cow_startup_deps "${PKG_ROOT}/Cubelet/config/config.toml"
 
 installed_role="${DEPLOY_ROLE}"

--- a/deploy/one-click/lib/common.sh
+++ b/deploy/one-click/lib/common.sh
@@ -159,10 +159,20 @@ cubelet_network_cidr_from_config() {
     }
     in_network && /^[[:space:]]*cidr[[:space:]]*=/ {
       line = $0
-      sub(/^[^"]*"/, "", line)
-      sub(/".*$/, "", line)
-      print line
-      exit
+      quote = sprintf("%c", 39)
+      sub(/^[^=]*=[[:space:]]*/, "", line)
+      if (line ~ /^"/) {
+        sub(/^"/, "", line)
+        sub(/".*$/, "", line)
+        print line
+        exit
+      }
+      if (line ~ ("^" quote)) {
+        sub(("^" quote), "", line)
+        sub((quote ".*$"), "", line)
+        print line
+        exit
+      }
     }
   ' "${config_path}")"
 
@@ -570,8 +580,16 @@ _check_cidr_conflict() {
     while IFS= read -r route_line; do
       [[ -n "${route_line}" ]] || continue
 
-      local route_iface
-      route_iface="$(awk '{for (i = 1; i < NF; i++) if ($i == "dev") {print $(i + 1); exit}}' <<<"${route_line}")"
+      local route_iface=""
+      local route_fields=()
+      read -r -a route_fields <<<"${route_line}"
+      local i
+      for ((i = 0; i + 1 < ${#route_fields[@]}; i++)); do
+        if [[ "${route_fields[i]}" == "dev" ]]; then
+          route_iface="${route_fields[i + 1]}"
+          break
+        fi
+      done
       if [[ -n "${route_iface}" ]] && is_cube_owned_netdev "${route_iface}"; then
         skipped_cube_owned=$((skipped_cube_owned + 1))
         continue
@@ -594,7 +612,7 @@ _check_cidr_conflict() {
 
         local route_int
         route_int=$(ip_to_int "${route_ip}")
-        local route_host_bits=$(( 32 - route_mask ))
+        local route_host_bits=$(( 32 - 10#${route_mask} ))
         local route_mask_int=$(( (0xFFFFFFFF << route_host_bits) & 0xFFFFFFFF ))
         local route_net_start=$(( route_int & route_mask_int ))
         local route_net_end=$(( route_net_start | (0xFFFFFFFF & ~route_mask_int) ))
@@ -640,6 +658,10 @@ _check_cidr_conflict() {
     done < <(awk '$1 == "nameserver" {print $2}' "${resolv_path}")
   done < <(_resolv_conf_candidates)
 
+  if [[ "${skipped_cube_owned}" -gt 0 ]]; then
+    log "ignored ${skipped_cube_owned} existing Cube-owned network entries during CIDR conflict check"
+  fi
+
   if [[ "${#conflicts[@]}" -gt 0 ]]; then
     local conflict_list
     conflict_list="$(printf '\n  - %s' "${conflicts[@]}")"
@@ -651,16 +673,12 @@ _check_cidr_conflict() {
     172.16.0.0/12   (any subnet within)
     192.168.0.0/16  (any non-conflicting subnet)
 
-  For example, a commonly used CubeSandbox choice is `172.31.64.0/18`.
+  For example, a commonly used CubeSandbox choice is 172.31.64.0/18.
   You can apply it with:
     CUBE_SANDBOX_NETWORK_CIDR=172.31.64.0/18 ./install.sh
 
   To bypass this check (not recommended), set:
     CUBE_SANDBOX_NETWORK_CIDR_SKIP_CONFLICT_CHECK=1"
-  fi
-
-  if [[ "${skipped_cube_owned}" -gt 0 ]]; then
-    log "ignored ${skipped_cube_owned} existing Cube-owned network entries during CIDR conflict check"
   fi
 }
 

--- a/deploy/one-click/lib/common.sh
+++ b/deploy/one-click/lib/common.sh
@@ -143,6 +143,33 @@ ensure_dir() {
   [[ -d "${path}" ]] || die "required directory not found: ${path}"
 }
 
+cubelet_network_cidr_from_config() {
+  local config_path="$1"
+  ensure_file "${config_path}"
+  require_cmd awk
+
+  local cidr
+  cidr="$(awk '
+    /^[[:space:]]*\[plugins\."io\.cubelet\.internal\.v1\.network"\][[:space:]]*$/ {
+      in_network = 1
+      next
+    }
+    /^[[:space:]]*\[/ {
+      in_network = 0
+    }
+    in_network && /^[[:space:]]*cidr[[:space:]]*=/ {
+      line = $0
+      sub(/^[^"]*"/, "", line)
+      sub(/".*$/, "", line)
+      print line
+      exit
+    }
+  ' "${config_path}")"
+
+  [[ -n "${cidr}" ]] || die "Cubelet network cidr missing in ${config_path}"
+  printf '%s\n' "${cidr}"
+}
+
 copy_file() {
   local src="$1"
   local dst="$2"
@@ -450,11 +477,41 @@ ip_int_to_dot() {
   echo "$(( (n >> 24) & 255 )).$(( (n >> 16) & 255 )).$(( (n >> 8) & 255 )).$(( n & 255 ))"
 }
 
+is_cube_owned_netdev() {
+  local iface="$1"
+  iface="${iface%%@*}"
+  [[ "${iface}" == "cube-dev" || "${iface}" =~ ^z([0-9]{1,3}\.){3}[0-9]{1,3}$ ]]
+}
+
+_resolv_conf_candidates() {
+  printf '%s\n' \
+    "/run/systemd/resolve/resolv.conf" \
+    "/run/systemd/resolve/stub-resolv.conf" \
+    "/run/NetworkManager/no-stub-resolv.conf" \
+    "/var/run/NetworkManager/no-stub-resolv.conf" \
+    "/run/resolvconf/resolv.conf" \
+    "/etc/resolvconf/run/resolv.conf" \
+    "/etc/resolv.conf"
+}
+
+canonicalize_resolv_conf_path() {
+  local path="$1"
+  if command -v readlink >/dev/null 2>&1; then
+    readlink -f "${path}" 2>/dev/null || printf '%s\n' "${path}"
+    return 0
+  fi
+  printf '%s\n' "${path}"
+}
+
 # _check_cidr_conflict: Detect overlap between the specified CIDR and
-# existing host network interfaces + routes. Exits with die() on conflict.
+# existing host network interfaces, routes and DNS upstreams. Exits with die()
+# on conflict.
 _check_cidr_conflict() {
   local cidr="$1"
+  local cidr_label="${2:-CUBE_SANDBOX_NETWORK_CIDR}"
   require_cmd ip
+  require_cmd awk
+  require_cmd grep
 
   local ip="${cidr%/*}"
   local mask="${cidr#*/}"
@@ -469,6 +526,7 @@ _check_cidr_conflict() {
   local cidr_net_end=$(( cidr_net_start | (0xFFFFFFFF & ~cidr_mask_int) ))
 
   local conflicts=()
+  local skipped_cube_owned=0
 
   # --- Check interface addresses ---
   # Format: "IP/MASK IFACE" (e.g., "10.0.0.5/24 eth0")
@@ -477,6 +535,10 @@ _check_cidr_conflict() {
     [[ -n "${line}" ]] || continue
     local iface_cidr="${line%% *}"
     local iface_name="${line#* }"
+    if is_cube_owned_netdev "${iface_name}"; then
+      skipped_cube_owned=$((skipped_cube_owned + 1))
+      continue
+    fi
 
     local iface_ip="${iface_cidr%%/*}"
     local iface_mask="${iface_cidr##*/}"
@@ -505,59 +567,115 @@ _check_cidr_conflict() {
   local route_text
   route_text="$(ip -4 route show 2>/dev/null || true)"
   if [[ -n "${route_text}" ]]; then
-    while IFS= read -r route_cidr; do
-      [[ -n "${route_cidr}" ]] || continue
+    while IFS= read -r route_line; do
+      [[ -n "${route_line}" ]] || continue
 
-      # Skip well-known non-conflicting ranges
-      [[ "${route_cidr}" != 169.254.* ]] || continue
-      [[ "${route_cidr}" != 224.* ]] || continue
-      [[ "${route_cidr}" != 127.* ]] || continue
-      # Skip default route (0.0.0.0/0 should never conflict)
-      [[ "${route_cidr}" != "0.0.0.0/0" ]] || continue
-
-      local route_ip="${route_cidr%/*}"
-      local route_mask="${route_cidr#*/}"
-      [[ "${route_mask}" =~ ^[0-9]+$ ]] || continue
-
-      local route_int
-      route_int=$(ip_to_int "${route_ip}")
-      local route_host_bits=$(( 32 - route_mask ))
-      local route_mask_int=$(( (0xFFFFFFFF << route_host_bits) & 0xFFFFFFFF ))
-      local route_net_start=$(( route_int & route_mask_int ))
-      local route_net_end=$(( route_net_start | (0xFFFFFFFF & ~route_mask_int) ))
-
-      if (( cidr_net_start <= route_net_end && cidr_net_end >= route_net_start )); then
-        conflicts+=("route ${route_cidr}")
+      local route_iface
+      route_iface="$(awk '{for (i = 1; i < NF; i++) if ($i == "dev") {print $(i + 1); exit}}' <<<"${route_line}")"
+      if [[ -n "${route_iface}" ]] && is_cube_owned_netdev "${route_iface}"; then
+        skipped_cube_owned=$((skipped_cube_owned + 1))
+        continue
       fi
-    done < <(echo "${route_text}" | grep -oP '\b[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+/[0-9]+\b' || true)
+
+      local route_cidr
+      while IFS= read -r route_cidr; do
+        [[ -n "${route_cidr}" ]] || continue
+
+        # Skip well-known non-conflicting ranges
+        [[ "${route_cidr}" != 169.254.* ]] || continue
+        [[ "${route_cidr}" != 224.* ]] || continue
+        [[ "${route_cidr}" != 127.* ]] || continue
+        # Skip default route (0.0.0.0/0 should never conflict)
+        [[ "${route_cidr}" != "0.0.0.0/0" ]] || continue
+
+        local route_ip="${route_cidr%/*}"
+        local route_mask="${route_cidr#*/}"
+        [[ "${route_mask}" =~ ^[0-9]+$ ]] || continue
+
+        local route_int
+        route_int=$(ip_to_int "${route_ip}")
+        local route_host_bits=$(( 32 - route_mask ))
+        local route_mask_int=$(( (0xFFFFFFFF << route_host_bits) & 0xFFFFFFFF ))
+        local route_net_start=$(( route_int & route_mask_int ))
+        local route_net_end=$(( route_net_start | (0xFFFFFFFF & ~route_mask_int) ))
+
+        if (( cidr_net_start <= route_net_end && cidr_net_end >= route_net_start )); then
+          conflicts+=("route ${route_cidr}")
+        fi
+      done < <(grep -oP '\b[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+/[0-9]+\b' <<<"${route_line}" || true)
+    done <<<"${route_text}"
   fi
+
+  # --- Check host DNS upstreams ---
+  # A nameserver inside the sandbox CIDR is also unsafe: CoreDNS may inherit it
+  # as its upstream, or host DNS lookups may be routed to Cube-owned addresses.
+  local resolv_path
+  local seen_resolv_paths=()
+  while IFS= read -r resolv_path; do
+    [[ -n "${resolv_path}" && -f "${resolv_path}" ]] || continue
+
+    local canonical_resolv_path
+    canonical_resolv_path="$(canonicalize_resolv_conf_path "${resolv_path}")"
+
+    local already_seen=0
+    local seen_path
+    for seen_path in "${seen_resolv_paths[@]}"; do
+      if [[ "${seen_path}" == "${canonical_resolv_path}" ]]; then
+        already_seen=1
+        break
+      fi
+    done
+    [[ "${already_seen}" -eq 0 ]] || continue
+    seen_resolv_paths+=("${canonical_resolv_path}")
+
+    local nameserver
+    while IFS= read -r nameserver; do
+      [[ "${nameserver}" =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$ ]] || continue
+
+      local ns_int
+      ns_int=$(ip_to_int "${nameserver}")
+      if (( ns_int >= cidr_net_start && ns_int <= cidr_net_end )); then
+        conflicts+=("nameserver ${nameserver} (${resolv_path})")
+      fi
+    done < <(awk '$1 == "nameserver" {print $2}' "${resolv_path}")
+  done < <(_resolv_conf_candidates)
 
   if [[ "${#conflicts[@]}" -gt 0 ]]; then
     local conflict_list
     conflict_list="$(printf '\n  - %s' "${conflicts[@]}")"
-    die "CUBE_SANDBOX_NETWORK_CIDR '${cidr}' conflicts with existing host network:${conflict_list}
+    die "${cidr_label} '${cidr}' conflicts with existing host network:${conflict_list}
 
-  The cubevs CIDR must not overlap with any existing interface IPs or routes.
+  The cubevs CIDR must not overlap with any existing interface IPs, routes, or DNS nameservers.
   Choose a private IP range that does not conflict, such as:
     10.0.0.0/8      (any subnet within)
     172.16.0.0/12   (any subnet within)
     192.168.0.0/16  (any non-conflicting subnet)
 
+  For example, a commonly used CubeSandbox choice is `172.31.64.0/18`.
+  You can apply it with:
+    CUBE_SANDBOX_NETWORK_CIDR=172.31.64.0/18 ./install.sh
+
   To bypass this check (not recommended), set:
     CUBE_SANDBOX_NETWORK_CIDR_SKIP_CONFLICT_CHECK=1"
+  fi
+
+  if [[ "${skipped_cube_owned}" -gt 0 ]]; then
+    log "ignored ${skipped_cube_owned} existing Cube-owned network entries during CIDR conflict check"
   fi
 }
 
 # check_cidr_preflight: Validate CIDR format and detect host network conflicts.
 # Called during install preflight (before any system modification).
-# Only validates if CUBE_SANDBOX_NETWORK_CIDR is set; when unset, does nothing.
+# The caller should pass the effective CIDR, either from CUBE_SANDBOX_NETWORK_CIDR
+# or from Cubelet/config/config.toml.
 #
 # SECURITY: Format validation MUST run before the SKIP_CONFLICT_CHECK bypass
 # to prevent sed command injection (sed 'w' flag) and env file shell injection.
 check_cidr_preflight() {
   local cidr="${1:-}"
+  local cidr_label="${2:-CUBE_SANDBOX_NETWORK_CIDR}"
 
-  # When env var not set: skip validation, use config.toml default
+  # Empty CIDR means there is nothing to validate.
   if [[ -z "${cidr}" ]]; then
     return 0
   fi
@@ -574,7 +692,7 @@ check_cidr_preflight() {
 
   # 1. Format validation (IPv4 dotted + mask)
   if ! [[ "${cidr}" =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+/[0-9]+$ ]]; then
-    die "CUBE_SANDBOX_NETWORK_CIDR '${cidr}' is not a valid IPv4 CIDR format (e.g., 10.0.0.0/16)"
+    die "${cidr_label} '${cidr}' is not a valid IPv4 CIDR format (e.g., 10.0.0.0/16)"
   fi
 
   local ip="${cidr%/*}"
@@ -587,16 +705,16 @@ check_cidr_preflight() {
   for octet in "${octets[@]}"; do
     # Reject IP octets with more than 3 digits (bash arithmetic overflow)
     if [[ "${#octet}" -gt 3 ]]; then
-      die "CUBE_SANDBOX_NETWORK_CIDR '${cidr}' has an invalid IP octet: '${octet}' (max 3 digits)"
+      die "${cidr_label} '${cidr}' has an invalid IP octet: '${octet}' (max 3 digits)"
     fi
     if (( 10#${octet} < 0 || 10#${octet} > 255 )); then
-      die "CUBE_SANDBOX_NETWORK_CIDR '${cidr}' has an invalid IP octet: ${octet}"
+      die "${cidr_label} '${cidr}' has an invalid IP octet: ${octet}"
     fi
   done
 
   # 3. Valid mask range [8, 30] (use 10# prefix to prevent octal interpretation)
   if ! [[ "${mask}" =~ ^[0-9]+$ ]] || (( 10#${mask} < 8 || 10#${mask} > 30 )); then
-    die "CUBE_SANDBOX_NETWORK_CIDR mask must be between 8 and 30 (got: ${mask})"
+    die "${cidr_label} mask must be between 8 and 30 (got: ${mask})"
   fi
 
   # 4. Network address alignment check
@@ -611,7 +729,7 @@ check_cidr_preflight() {
   if (( ip_int != network_int )); then
     local suggested
     suggested=$(ip_int_to_dot ${network_int})
-    die "CUBE_SANDBOX_NETWORK_CIDR '${cidr}' is not aligned to its network address. Did you mean: ${suggested}/${mask}?"
+    die "${cidr_label} '${cidr}' is not aligned to its network address. Did you mean: ${suggested}/${mask}?"
   fi
 
   # NOTE: CUBE_SANDBOX_NETWORK_CIDR_SKIP_CONFLICT_CHECK is read from the
@@ -633,9 +751,9 @@ check_cidr_preflight() {
   fi
 
   # 6. CIDR conflict detection with host interfaces
-  _check_cidr_conflict "${cidr}"
+  _check_cidr_conflict "${cidr}" "${cidr_label}"
 
-  log "CUBE_SANDBOX_NETWORK_CIDR preflight OK: ${cidr}"
+  log "${cidr_label} preflight OK: ${cidr}"
 }
 
 # check_glibc_preflight: Verify the system glibc version meets the minimum

--- a/deploy/one-click/tests/test_cidr_preflight.sh
+++ b/deploy/one-click/tests/test_cidr_preflight.sh
@@ -45,6 +45,14 @@ assert_occurrence_count() {
   [[ "${count}" == "${expected}" ]] || fail "expected ${needle} to appear ${expected} times; got ${count}: ${text}"
 }
 
+assert_not_contains_text() {
+  local text="$1"
+  local needle="$2"
+  if grep -Fq -- "${needle}" <<<"${text}"; then
+    fail "expected text not to contain ${needle}; got: ${text}"
+  fi
+}
+
 line_number() {
   local path="$1"
   local needle="$2"
@@ -103,6 +111,14 @@ ip() {
             "${TEST_CUBE_ROUTE_CIDR:?}" \
             "${TEST_CUBE_DEV_IP:?}"
           printf '%s dev z%s scope link\n' "${TEST_TAP_ROUTE_CIDR:?}" "${TEST_TAP_IP:?}"
+          ;;
+        cube_route_then_plain)
+          printf '%s dev cube-dev proto static scope link src %s\n' \
+            "${TEST_CUBE_ROUTE_CIDR:?}" \
+            "${TEST_CUBE_DEV_IP:?}"
+          printf '%s proto static scope link src %s\n' \
+            "${TEST_PLAIN_ROUTE_CIDR:?}" \
+            "${TEST_PLAIN_ROUTE_SRC_IP:?}"
           ;;
         *)
           ;;
@@ -186,6 +202,78 @@ test_dedupes_equivalent_resolver_paths() {
   assert_occurrence_count "${output}" "nameserver ${nameserver}" 1
 }
 
+test_does_not_leak_route_iface_across_iterations() {
+  local cidr="10.77.0.0/16"
+  local cube_route_cidr="10.77.0.0/24"
+  local cube_dev_ip="10.77.0.1"
+  local plain_route_cidr="10.77.2.0/24"
+  local plain_route_src_ip="10.77.2.123"
+  local output
+
+  if output="$(
+    TEST_CUBE_ROUTE_CIDR="${cube_route_cidr}" \
+    TEST_CUBE_DEV_IP="${cube_dev_ip}" \
+    TEST_PLAIN_ROUTE_CIDR="${plain_route_cidr}" \
+    TEST_PLAIN_ROUTE_SRC_IP="${plain_route_src_ip}" \
+    IP_SCENARIO=cube_route_then_plain \
+    check_cidr_preflight "${cidr}" "Cubelet config cidr" 2>&1
+  )"; then
+    fail "expected plain route conflict to be detected after cube-owned route"
+  fi
+  assert_contains_text "${output}" "ignored 1 existing Cube-owned network entries during CIDR conflict check"
+  assert_contains_text "${output}" "route ${plain_route_cidr}"
+}
+
+test_accepts_empty_cidr() {
+  IP_SCENARIO=host_iface_conflict check_cidr_preflight "" "Cubelet config cidr" >/dev/null 2>&1
+}
+
+test_bypass_still_rejects_malformed_cidr() {
+  local output
+  if output="$(
+    CUBE_SANDBOX_NETWORK_CIDR_SKIP_CONFLICT_CHECK=1 \
+    IP_SCENARIO=empty \
+    check_cidr_preflight "10.77.1.99/24" "CUBE_SANDBOX_NETWORK_CIDR" 2>&1
+  )"; then
+    fail "expected malformed CIDR to be rejected even with bypass enabled"
+  fi
+  assert_contains_text "${output}" "Did you mean: 10.77.1.0/24?"
+  assert_not_contains_text "${output}" "conflict check SKIPPED"
+}
+
+test_bypass_skips_conflict_detection() {
+  local output
+  if ! output="$(
+    CUBE_SANDBOX_NETWORK_CIDR_SKIP_CONFLICT_CHECK=1 \
+    IP_SCENARIO=host_iface_conflict \
+    TEST_HOST_IFACE_CIDR="10.77.1.123/24" \
+    TEST_HOST_IFACE_BROADCAST="10.77.1.255" \
+    check_cidr_preflight "10.77.0.0/16" "Cubelet config cidr" 2>&1
+  )"; then
+    fail "expected bypass to skip conflict detection for a valid CIDR"
+  fi
+  assert_contains_text "${output}" "CUBE_SANDBOX_NETWORK_CIDR conflict check SKIPPED (bypass flag set)"
+  assert_not_contains_text "${output}" "conflicts with existing host network"
+}
+
+test_accepts_cidr_mask_boundaries() {
+  IP_SCENARIO=empty check_cidr_preflight "10.0.0.0/8" "Cubelet config cidr" >/dev/null 2>&1
+  IP_SCENARIO=empty check_cidr_preflight "10.77.1.0/30" "Cubelet config cidr" >/dev/null 2>&1
+}
+
+test_rejects_cidr_mask_outside_boundaries() {
+  local output
+  if output="$(IP_SCENARIO=empty check_cidr_preflight "10.0.0.0/31" "Cubelet config cidr" 2>&1)"; then
+    fail "expected /31 to be rejected"
+  fi
+  assert_contains_text "${output}" "mask must be between 8 and 30"
+
+  if output="$(IP_SCENARIO=empty check_cidr_preflight "10.0.0.0/32" "Cubelet config cidr" 2>&1)"; then
+    fail "expected /32 to be rejected"
+  fi
+  assert_contains_text "${output}" "mask must be between 8 and 30"
+}
+
 test_ignores_cube_owned_networks() {
   local cidr="10.77.0.0/16"
   local cube_dev_cidr="10.77.0.1/16"
@@ -241,6 +329,18 @@ EOF
   [[ "${cidr}" == "172.31.64.0/18" ]] || fail "expected 172.31.64.0/18, got ${cidr}"
 }
 
+test_reads_network_cidr_from_single_quoted_config() {
+  local config="${TMP_DIR}/single-quoted-config.toml"
+  cat >"${config}" <<'EOF'
+[plugins."io.cubelet.internal.v1.network"]
+  cidr = '172.31.64.0/18' # inline comment
+EOF
+
+  local cidr
+  cidr="$(cubelet_network_cidr_from_config "${config}")"
+  [[ "${cidr}" == "172.31.64.0/18" ]] || fail "expected 172.31.64.0/18, got ${cidr}"
+}
+
 test_install_wires_effective_cidr_preflight_before_mutations() {
   local install_script="${ONE_CLICK_DIR}/install.sh"
 
@@ -258,10 +358,17 @@ test_rejects_host_interface_overlap
 test_rejects_host_route_overlap
 test_rejects_nameserver_overlap
 test_dedupes_equivalent_resolver_paths
+test_does_not_leak_route_iface_across_iterations
+test_accepts_empty_cidr
+test_bypass_still_rejects_malformed_cidr
+test_bypass_skips_conflict_detection
+test_accepts_cidr_mask_boundaries
+test_rejects_cidr_mask_outside_boundaries
 test_ignores_cube_owned_networks
 test_cube_owned_netdev_matching_is_narrow
 test_rejects_invalid_cidr
 test_reads_network_cidr_from_cubelet_config
+test_reads_network_cidr_from_single_quoted_config
 test_install_wires_effective_cidr_preflight_before_mutations
 
 echo "cidr preflight tests OK"

--- a/deploy/one-click/tests/test_cidr_preflight.sh
+++ b/deploy/one-click/tests/test_cidr_preflight.sh
@@ -1,0 +1,267 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ONE_CLICK_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+TMP_DIR="$(mktemp -d)"
+cleanup() {
+  rm -rf "${TMP_DIR}"
+}
+trap cleanup EXIT
+
+# shellcheck source=../lib/common.sh
+source "${ONE_CLICK_DIR}/lib/common.sh"
+
+_resolv_conf_candidates() {
+  if [[ -n "${TEST_RESOLV_CONF:-}" ]]; then
+    printf '%s\n' "${TEST_RESOLV_CONF}"
+  fi
+}
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+assert_contains_text() {
+  local text="$1"
+  local needle="$2"
+  grep -Fq -- "${needle}" <<<"${text}" || fail "expected text to contain ${needle}; got: ${text}"
+}
+
+assert_contains_file() {
+  local path="$1"
+  local needle="$2"
+  grep -Fq -- "${needle}" "${path}" || fail "expected ${path} to contain ${needle}"
+}
+
+assert_occurrence_count() {
+  local text="$1"
+  local needle="$2"
+  local expected="$3"
+  local count
+  count="$(grep -Foc -- "${needle}" <<<"${text}")"
+  [[ "${count}" == "${expected}" ]] || fail "expected ${needle} to appear ${expected} times; got ${count}: ${text}"
+}
+
+line_number() {
+  local path="$1"
+  local needle="$2"
+  local line
+  line="$(grep -nF -- "${needle}" "${path}" | head -n1 | cut -d: -f1)"
+  [[ -n "${line}" ]] || fail "expected ${path} to contain ${needle}"
+  printf '%s\n' "${line}"
+}
+
+last_line_number() {
+  local path="$1"
+  local needle="$2"
+  local line
+  line="$(grep -nF -- "${needle}" "${path}" | tail -n1 | cut -d: -f1)"
+  [[ -n "${line}" ]] || fail "expected ${path} to contain ${needle}"
+  printf '%s\n' "${line}"
+}
+
+assert_line_before_last() {
+  local path="$1"
+  local before="$2"
+  local after="$3"
+  local before_line
+  local after_line
+  before_line="$(line_number "${path}" "${before}")"
+  after_line="$(last_line_number "${path}" "${after}")"
+  (( before_line < after_line )) || fail "expected ${before} before final ${after} in ${path}"
+}
+
+ip() {
+  case "$*" in
+    "-4 addr show scope global")
+      case "${IP_SCENARIO:-empty}" in
+        host_iface_conflict)
+          printf '    inet %s brd %s scope global eth0\n' \
+            "${TEST_HOST_IFACE_CIDR:?}" \
+            "${TEST_HOST_IFACE_BROADCAST:?}"
+          ;;
+        cube_owned_only)
+          printf '    inet %s scope global cube-dev\n' "${TEST_CUBE_DEV_CIDR:?}"
+          printf '    inet %s scope global z%s\n' "${TEST_TAP_CIDR:?}" "${TEST_TAP_IP:?}"
+          ;;
+        *)
+          ;;
+      esac
+      ;;
+    "-4 route show")
+      case "${IP_SCENARIO:-empty}" in
+        host_route_conflict)
+          printf '%s dev eth0 proto kernel scope link src %s\n' \
+            "${TEST_HOST_ROUTE_CIDR:?}" \
+            "${TEST_HOST_ROUTE_SRC_IP:?}"
+          ;;
+        cube_owned_only)
+          printf '%s dev cube-dev proto static scope link src %s\n' \
+            "${TEST_CUBE_ROUTE_CIDR:?}" \
+            "${TEST_CUBE_DEV_IP:?}"
+          printf '%s dev z%s scope link\n' "${TEST_TAP_ROUTE_CIDR:?}" "${TEST_TAP_IP:?}"
+          ;;
+        *)
+          ;;
+      esac
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+test_rejects_host_interface_overlap() {
+  local cidr="10.77.0.0/16"
+  local host_iface_cidr="10.77.1.123/24"
+  local host_iface_broadcast="10.77.1.255"
+  local output
+  if output="$(
+    TEST_HOST_IFACE_CIDR="${host_iface_cidr}" \
+    TEST_HOST_IFACE_BROADCAST="${host_iface_broadcast}" \
+    IP_SCENARIO=host_iface_conflict \
+    check_cidr_preflight "${cidr}" "Cubelet config cidr" 2>&1
+  )"; then
+    fail "expected host interface overlap to be rejected"
+  fi
+  assert_contains_text "${output}" "Cubelet config cidr '${cidr}' conflicts"
+  assert_contains_text "${output}" "interface eth0 (${host_iface_cidr})"
+}
+
+test_rejects_host_route_overlap() {
+  local cidr="10.77.0.0/16"
+  local host_route_cidr="10.77.2.0/24"
+  local host_route_src_ip="10.77.2.123"
+  local output
+  if output="$(
+    TEST_HOST_ROUTE_CIDR="${host_route_cidr}" \
+    TEST_HOST_ROUTE_SRC_IP="${host_route_src_ip}" \
+    IP_SCENARIO=host_route_conflict \
+    check_cidr_preflight "${cidr}" "Cubelet config cidr" 2>&1
+  )"; then
+    fail "expected host route overlap to be rejected"
+  fi
+  assert_contains_text "${output}" "Cubelet config cidr '${cidr}' conflicts"
+  assert_contains_text "${output}" "route ${host_route_cidr}"
+}
+
+test_rejects_nameserver_overlap() {
+  local resolv_conf="${TMP_DIR}/resolv.conf"
+  local cidr="10.77.0.0/16"
+  local nameserver="10.77.0.53"
+  local output
+  printf 'nameserver %s\n' "${nameserver}" > "${resolv_conf}"
+
+  if output="$(TEST_RESOLV_CONF="${resolv_conf}" IP_SCENARIO=empty check_cidr_preflight "${cidr}" "Cubelet config cidr" 2>&1)"; then
+    fail "expected nameserver overlap to be rejected"
+  fi
+  assert_contains_text "${output}" "Cubelet config cidr '${cidr}' conflicts"
+  assert_contains_text "${output}" "nameserver ${nameserver} (${resolv_conf})"
+}
+
+test_dedupes_equivalent_resolver_paths() {
+  local resolv_dir="${TMP_DIR}/resolv"
+  local real_resolv_conf="${resolv_dir}/real-resolv.conf"
+  local alias_resolv_conf="${resolv_dir}/alias-resolv.conf"
+  local resolv_candidates
+  local cidr="10.77.0.0/16"
+  local nameserver="10.77.0.53"
+  local output
+
+  mkdir -p "${resolv_dir}"
+  printf 'nameserver %s\n' "${nameserver}" > "${real_resolv_conf}"
+  ln -s "${real_resolv_conf}" "${alias_resolv_conf}"
+  resolv_candidates="${real_resolv_conf}"$'\n'"${alias_resolv_conf}"
+
+  if output="$(
+    TEST_RESOLV_CONF="${resolv_candidates}" \
+    IP_SCENARIO=empty \
+    check_cidr_preflight "${cidr}" "Cubelet config cidr" 2>&1
+  )"; then
+    fail "expected nameserver overlap to be rejected"
+  fi
+  assert_occurrence_count "${output}" "nameserver ${nameserver}" 1
+}
+
+test_ignores_cube_owned_networks() {
+  local cidr="10.77.0.0/16"
+  local cube_dev_cidr="10.77.0.1/16"
+  local cube_dev_ip="10.77.0.1"
+  local tap_ip="10.77.0.10"
+  local tap_cidr="${tap_ip}/32"
+  local tap_route_cidr="${tap_ip}/32"
+
+  TEST_CUBE_DEV_CIDR="${cube_dev_cidr}" \
+  TEST_CUBE_ROUTE_CIDR="${cidr}" \
+  TEST_CUBE_DEV_IP="${cube_dev_ip}" \
+  TEST_TAP_IP="${tap_ip}" \
+  TEST_TAP_CIDR="${tap_cidr}" \
+  TEST_TAP_ROUTE_CIDR="${tap_route_cidr}" \
+  IP_SCENARIO=cube_owned_only \
+  check_cidr_preflight "${cidr}" "Cubelet config cidr" >/dev/null 2>&1
+}
+
+test_cube_owned_netdev_matching_is_narrow() {
+  is_cube_owned_netdev "cube-dev" || fail "expected cube-dev to be Cube-owned"
+  is_cube_owned_netdev "z10.77.0.10" || fail "expected z10.77.0.10 to be Cube-owned"
+  is_cube_owned_netdev "z10.77.0.10@if123" || fail "expected peer suffix to be ignored"
+
+  if is_cube_owned_netdev "zfoo"; then
+    fail "expected zfoo not to be Cube-owned"
+  fi
+  if is_cube_owned_netdev "z10.77.0"; then
+    fail "expected incomplete z<ip> name not to be Cube-owned"
+  fi
+}
+
+test_rejects_invalid_cidr() {
+  local output
+  if output="$(IP_SCENARIO=empty check_cidr_preflight "10.77.1.99/24" "CUBE_SANDBOX_NETWORK_CIDR" 2>&1)"; then
+    fail "expected non-canonical CIDR to be rejected"
+  fi
+  assert_contains_text "${output}" "Did you mean: 10.77.1.0/24?"
+}
+
+test_reads_network_cidr_from_cubelet_config() {
+  local config="${TMP_DIR}/config.toml"
+  cat >"${config}" <<'EOF'
+[plugins."io.cubelet.internal.v1.other"]
+  cidr = "10.10.0.0/16"
+
+[plugins."io.cubelet.internal.v1.network"]
+  object_dir = "/usr/local/services/cubetoolbox/cube-vs/network"
+  cidr = "172.31.64.0/18"
+EOF
+
+  local cidr
+  cidr="$(cubelet_network_cidr_from_config "${config}")"
+  [[ "${cidr}" == "172.31.64.0/18" ]] || fail "expected 172.31.64.0/18, got ${cidr}"
+}
+
+test_install_wires_effective_cidr_preflight_before_mutations() {
+  local install_script="${ONE_CLICK_DIR}/install.sh"
+
+  assert_contains_file "${install_script}" 'CUBELET_PACKAGE_CONFIG="${PKG_ROOT}/Cubelet/config/config.toml"'
+  assert_contains_file "${install_script}" 'check_cidr_preflight "${CUBE_SANDBOX_NETWORK_CIDR}" "CUBE_SANDBOX_NETWORK_CIDR"'
+  assert_contains_file "${install_script}" 'CUBE_SANDBOX_EFFECTIVE_NETWORK_CIDR="$(cubelet_network_cidr_from_config "${CUBELET_PACKAGE_CONFIG}")"'
+  assert_contains_file "${install_script}" 'check_cidr_preflight "${CUBE_SANDBOX_EFFECTIVE_NETWORK_CIDR}" "Cubelet config cidr"'
+
+  assert_line_before_last "${install_script}" 'check_cidr_preflight "${CUBE_SANDBOX_NETWORK_CIDR}" "CUBE_SANDBOX_NETWORK_CIDR"' 'install_required_dependencies'
+  assert_line_before_last "${install_script}" 'check_cidr_preflight "${CUBE_SANDBOX_EFFECTIVE_NETWORK_CIDR}" "Cubelet config cidr"' 'install_required_dependencies'
+  assert_line_before_last "${install_script}" 'check_cidr_preflight "${CUBE_SANDBOX_EFFECTIVE_NETWORK_CIDR}" "Cubelet config cidr"' 'stop_existing_systemd_deployment'
+}
+
+test_rejects_host_interface_overlap
+test_rejects_host_route_overlap
+test_rejects_nameserver_overlap
+test_dedupes_equivalent_resolver_paths
+test_ignores_cube_owned_networks
+test_cube_owned_netdev_matching_is_narrow
+test_rejects_invalid_cidr
+test_reads_network_cidr_from_cubelet_config
+test_install_wires_effective_cidr_preflight_before_mutations
+
+echo "cidr preflight tests OK"

--- a/docs/guide/self-build-deploy.md
+++ b/docs/guide/self-build-deploy.md
@@ -285,7 +285,7 @@ You can also point to prebuilt binaries to skip compilation:
 | `ONE_CLICK_CONTROL_PLANE_IP` | empty | Compute-node mode only. See [Multi-Node Cluster Deployment](./multi-node-deploy.md#step-2-configure-environment-variables) |
 | `ONE_CLICK_CONTROL_PLANE_CUBEMASTER_ADDR` | empty | Compute-node mode only. See [Multi-Node Cluster Deployment](./multi-node-deploy.md#step-2-configure-environment-variables) |
 | `CUBE_SANDBOX_NODE_IP` | auto-detected from `eth0` | Node's primary network interface IP. Auto-detected if unset; set explicitly if your interface differs. |
-| `CUBE_SANDBOX_NETWORK_CIDR` | `192.168.0.0/18` (from `Cubelet/config/config.toml`) | cubevs local network CIDR for sandbox IP allocation. IPv4 CIDR format (e.g., `10.100.0.0/18`), mask range /8–/30. Automatically detected for host network conflicts at install time. Uses the `config.toml` default when unset. |
+| `CUBE_SANDBOX_NETWORK_CIDR` | `192.168.0.0/18` (from `Cubelet/config/config.toml`) | cubevs local network CIDR for sandbox IP allocation. IPv4 CIDR format (e.g., `10.100.0.0/18`), mask range /8–/30. Conflicts with host interfaces, routes, or resolver nameservers abort installation during preflight. Uses the `config.toml` default when unset. |
 | `CUBE_SANDBOX_NETWORK_CIDR_SKIP_CONFLICT_CHECK` | `0` | Set to `1` to skip CIDR conflict detection (not recommended). Used together with `CUBE_SANDBOX_NETWORK_CIDR`. |
 | `ONE_CLICK_INSTALL_PREFIX` | `/usr/local/services/cubetoolbox` | Installation directory |
 | `ONE_CLICK_RUN_QUICKCHECK` | `1` | Run health check after installation |

--- a/docs/guide/troubleshooting/local-network-cidr-conflict.md
+++ b/docs/guide/troubleshooting/local-network-cidr-conflict.md
@@ -160,4 +160,14 @@ Restart the services:
 sudo /usr/local/services/cubetoolbox/scripts/one-click/up-with-deps.sh
 ```
 
+For future reinstallations or when adding compute nodes, consider setting `CUBE_SANDBOX_NETWORK_CIDR` before running `install.sh` or `install-compute.sh`. Use a CIDR that does not overlap with the host LAN, and keep the same value across all nodes:
+
+```bash
+CUBE_SANDBOX_NETWORK_CIDR=<non-overlapping-cidr> ./install.sh
+# or
+CUBE_SANDBOX_NETWORK_CIDR=<non-overlapping-cidr> ./install-compute.sh
+```
+
+See [Self-Build Deployment — Configuration Reference](../self-build-deploy.md#configuration-reference) for the full one-click environment variable reference.
+
 After the sandbox CIDR no longer overlaps with the host LAN, recreate the template. The template creation should complete successfully.

--- a/docs/zh/guide/self-build-deploy.md
+++ b/docs/zh/guide/self-build-deploy.md
@@ -285,7 +285,7 @@ sudo ./down.sh
 | `ONE_CLICK_CONTROL_PLANE_IP` | 空 | 仅计算节点模式使用。详见[多机集群部署 — 配置环境变量](./multi-node-deploy.md#第二步配置环境变量) |
 | `ONE_CLICK_CONTROL_PLANE_CUBEMASTER_ADDR` | 空 | 仅计算节点模式使用。详见[多机集群部署 — 配置环境变量](./multi-node-deploy.md#第二步配置环境变量) |
 | `CUBE_SANDBOX_NODE_IP` | 自动从 `eth0` 探测 | 节点主网卡 IP 地址。未设置时自动探测；若网卡名称不同请显式指定。 |
-| `CUBE_SANDBOX_NETWORK_CIDR` | `192.168.0.0/18`（取自 `Cubelet/config/config.toml`） | cubevs 本地网络 CIDR，用于沙箱 IP 分配。格式为 IPv4 CIDR（如 `10.100.0.0/18`），掩码范围 /8~/30。安装时会自动检测是否与宿主机现有网络冲突。未设置时使用 `config.toml` 中的默认值。 |
+| `CUBE_SANDBOX_NETWORK_CIDR` | `192.168.0.0/18`（取自 `Cubelet/config/config.toml`） | cubevs 本地网络 CIDR，用于沙箱 IP 分配。格式为 IPv4 CIDR（如 `10.100.0.0/18`），掩码范围 /8~/30。若与宿主机网卡、路由或 DNS 解析器地址冲突，安装前置检测会直接中止安装。未设置时使用 `config.toml` 中的默认值。 |
 | `CUBE_SANDBOX_NETWORK_CIDR_SKIP_CONFLICT_CHECK` | `0` | 设为 `1` 可跳过 CIDR 冲突检测（不推荐）。与 `CUBE_SANDBOX_NETWORK_CIDR` 配合使用。 |
 | `ONE_CLICK_INSTALL_PREFIX` | `/usr/local/services/cubetoolbox` | 安装目录 |
 | `ONE_CLICK_RUN_QUICKCHECK` | `1` | 安装后是否执行健康检查 |

--- a/docs/zh/guide/troubleshooting/local-network-cidr-conflict.md
+++ b/docs/zh/guide/troubleshooting/local-network-cidr-conflict.md
@@ -160,4 +160,14 @@ sudo ip link delete cube-dev
 sudo /usr/local/services/cubetoolbox/scripts/one-click/up-with-deps.sh
 ```
 
+后续重新安装或扩展计算节点时，可以在执行 `install.sh` 或 `install-compute.sh` 前设置 `CUBE_SANDBOX_NETWORK_CIDR`。该 CIDR 不能和宿主机局域网冲突，并且所有节点需要保持一致：
+
+```bash
+CUBE_SANDBOX_NETWORK_CIDR=<不冲突的CIDR> ./install.sh
+# 或
+CUBE_SANDBOX_NETWORK_CIDR=<不冲突的CIDR> ./install-compute.sh
+```
+
+完整 one-click 环境变量说明请参阅[自构建部署 — 配置参考](../self-build-deploy.md#配置参考)。
+
 网段不再和宿主机局域网重叠后，重新创建模板，成功。


### PR DESCRIPTION
## Motivation

While troubleshooting a local network issue, I found that the effective sandbox CIDR can still conflict with the host network even when `ip route` does not make the conflict obvious.

In particular, the default Cubelet sandbox CIDR can overlap with host DNS resolver addresses such as `192.168.0.1`. When that happens, host DNS traffic may be routed through the sandbox network instead of the real LAN path, breaking host-side DNS resolution and causing operations such as image pulls to fail.

CubeSandbox `v0.3.1` already added preflight validation for `CUBE_SANDBOX_NETWORK_CIDR` when users explicitly override the CIDR. This leaves the default-CIDR path uncovered, because the installer previously skipped conflict validation when `CUBE_SANDBOX_NETWORK_CIDR` was not set.

This PR extends that protection to the remaining gap:

- validate the effective sandbox CIDR even when the user does not set `CUBE_SANDBOX_NETWORK_CIDR`
- detect conflicts not only from host interfaces and routes, but also from host resolver nameservers

## What Changed

- extract the packaged one-click bundle earlier so `install.sh` can read the packaged Cubelet `config.toml` and fail during preflight before stopping or replacing the existing deployment
- when `CUBE_SANDBOX_NETWORK_CIDR` is unset, read the default CIDR from the packaged Cubelet network plugin config and run the same preflight validation instead of skipping it
- extend CIDR conflict detection to check common host resolver sources:
  - `/run/systemd/resolve/resolv.conf`
  - `/run/systemd/resolve/stub-resolv.conf`
  - `/run/NetworkManager/no-stub-resolv.conf`
  - `/var/run/NetworkManager/no-stub-resolv.conf`
  - `/run/resolvconf/resolv.conf`
  - `/etc/resolvconf/run/resolv.conf`
  - `/etc/resolv.conf`
- avoid reporting known Cube-owned leftover devices such as `cube-dev` and `z<ip>` as host LAN conflicts during reinstall / recovery paths

## Design Note

This PR currently excludes known Cube-owned leftover virtual devices such as `cube-dev` and `z<ip>` from the host conflict check.

This is intended to keep reinstall / recovery paths usable when stale Cube-owned devices are present, while still detecting conflicts with the real host LAN, routes, and resolver nameservers.

If you prefer to keep explicit manual cleanup for old Cube virtual devices, I can drop this part and keep the PR focused only on:

- validating the packaged default CIDR when no override is set
- checking resolver nameservers in addition to interfaces / routes
- running that validation before the installer stops the existing deployment

## Validation

Real machine validation:

- confirmed that `install.sh` now fails before stopping the existing deployment when the packaged default CIDR `192.168.0.0/18` overlaps with host resolver nameservers such as `192.168.0.1`
- confirmed that the installer continues past preflight when the effective sandbox CIDR does not overlap with host interfaces, routes, or resolver nameservers
- confirmed that resolver overlap is now rejected during preflight instead of surfacing later as host-side DNS failures, such as image pull failures on the host machine
- confirmed the conflict is reported from the real resolver files, for example:
  - `/run/NetworkManager/no-stub-resolv.conf`
  - `/var/run/NetworkManager/no-stub-resolv.conf`
  - `/etc/resolv.conf`

Focused shell test:

```bash
bash deploy/one-click/tests/test_cidr_preflight.sh
```

This test covers:

- host interface overlap
- host route overlap
- resolver nameserver overlap
- avoiding false positives from known Cube-owned leftover devices
- reading the default CIDR from packaged Cubelet config
- ensuring preflight runs before the script stops the existing deployment

## Scope

This PR is limited to one-click CIDR preflight behavior. It does not change the CIDR format validation, mask validation, or alignment checks.

The existing `CUBE_SANDBOX_NETWORK_CIDR_SKIP_CONFLICT_CHECK` bypass remains unchanged.
