### PR TITLE
cubemaster: redact CubeNetworkConfig inject secrets in safe log

### DIFF
--- a/CubeMaster/pkg/service/sandbox/util.go
+++ b/CubeMaster/pkg/service/sandbox/util.go
@@ -743,6 +743,22 @@ func safePrintCreateCubeSandboxReq(req *types.CreateCubeSandboxReq) string {
 			v.Image.Token = "*"
 		}
 	}
+
+	if tmpReq.CubeNetworkConfig != nil {
+		for _, r := range tmpReq.CubeNetworkConfig.Rules {
+			if r == nil || r.Action == nil {
+				continue
+			}
+			for _, inj := range r.Action.Inject {
+				if inj == nil {
+					continue
+				}
+				if inj.Secret != "" {
+					inj.Secret = "***REDACTED***"
+				}
+			}
+		}
+	}
 	return utils.InterfaceToString(tmpReq)
 }
 


### PR DESCRIPTION
Extend safePrintCreateCubeSandboxReq to mask credential material carried in CubeNetworkConfig egress rules. For each rule action's Inject entries, non-empty Secret fields are replaced with "***REDACTED***", consistent with the redaction pattern already used by CubeEgress/lua/admin.lua:56. Header and Format are preserved to retain diagnostic value.