### PR TITLE
chore: bump Python SDK to 0.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
   <a href="https://github.com/tencentcloud/CubeSandbox/issues"><img src="https://img.shields.io/github/issues/tencentcloud/cubesandbox" alt="GitHub Issues" /></a>
   <a href="./LICENSE"><img src="https://img.shields.io/badge/License-Apache_2.0-green" alt="Apache 2.0 License" /></a>
   <a href="./CONTRIBUTING.md"><img src="https://img.shields.io/badge/PRs-welcome-brightgreen" alt="PRs Welcome" /></a>
-  <a href="https://pypi.org/project/cubesandbox/"><img src="https://img.shields.io/badge/PyPI-0.2.1-blue" alt="PyPI Version" /></a>
+  <a href="https://pypi.org/project/cubesandbox/"><img src="https://img.shields.io/badge/PyPI-0.3.0-blue" alt="PyPI Version" /></a>
   <a href="https://landscape.cncf.io/?landscape=observability-and-analysis&group=ai-native&item=ai-native-infra--workload-runtime--cubesandbox"><img src="https://img.shields.io/badge/CNCF-Landscape-0C66E4" alt="CNCF Landscape" /></a>
 </p>
 

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -6,7 +6,7 @@
   <a href="https://github.com/TencentCloud/CubeSandbox"><img src="https://img.shields.io/badge/CubeSandbox-GitHub-blue" alt="CubeSandbox" /></a>
   <a href="../../LICENSE"><img src="https://img.shields.io/badge/License-Apache_2.0-green" alt="Apache 2.0" /></a>
   <img src="https://img.shields.io/badge/Python-3.9%2B-blue" alt="Python 3.9+" />
-  <img src="https://img.shields.io/badge/version-0.2.1-orange" alt="v0.2.1" />
+  <img src="https://img.shields.io/badge/version-0.3.0-orange" alt="v0.3.0" />
 </p>
 
 ---

--- a/sdk/python/cubesandbox/__init__.py
+++ b/sdk/python/cubesandbox/__init__.py
@@ -32,4 +32,4 @@ __all__ = [
     "Inject",
 ]
 
-__version__ = "0.2.1"
+__version__ = "0.3.0"

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "cubesandbox"
-version = "0.2.1"
+version = "0.3.0"
 description = "Python SDK for CubeSandbox"
 license = { text = "Apache-2.0" }
 requires-python = ">=3.9"


### PR DESCRIPTION
We introduce new APIs for security proxy. Bump SDK version to reflect that.