### PR TITLE
style: add fmt targets and CI format check workflow

### DIFF
--- a/.github/workflows/fmt-check.yml
+++ b/.github/workflows/fmt-check.yml
@@ -28,7 +28,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  BUILDER_IMAGE_REMOTE: ghcr.io/tencentcloud/cubesandbox-builder:latest
+  BUILDER_IMAGE_REMOTE: ghcr.io/tencentcloud/cubesandbox-builder:ubuntu2004
   BUILDER_IMAGE_LOCAL: cube-sandbox-builder:ci
 
 jobs:

--- a/.github/workflows/fmt-check.yml
+++ b/.github/workflows/fmt-check.yml
@@ -1,0 +1,149 @@
+name: Format Check
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - '**/*.go'
+      - '**/*.rs'
+      - 'Makefile'
+      - 'agent/Makefile'
+      - 'CubeAPI/Makefile'
+      - 'Cubelet/Makefile'
+      - 'CubeMaster/Makefile'
+      - 'CubeShim/Makefile'
+      - 'cubecow/Makefile'
+      - 'cubelog/Makefile'
+      - 'hypervisor/Makefile'
+      - 'network-agent/Makefile'
+      - '.github/workflows/fmt-check.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: read
+
+concurrency:
+  group: fmt-check-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  BUILDER_IMAGE_REMOTE: ghcr.io/tencentcloud/cubesandbox-builder:latest
+  BUILDER_IMAGE_LOCAL: cube-sandbox-builder:ci
+
+jobs:
+  fmt:
+    name: Code Format Check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Detect builder changes
+        id: builder_changes
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]]; then
+            base_ref="${{ github.event.pull_request.base.sha }}"
+            head_ref="${{ github.event.pull_request.head.sha }}"
+          else
+            base_ref="${{ github.event.before }}"
+            head_ref="${GITHUB_SHA}"
+          fi
+
+          if [[ -z "${base_ref}" || "${base_ref}" == "0000000000000000000000000000000000000000" ]]; then
+            changed_files="$(git diff-tree --no-commit-id --name-only -r "${head_ref}")"
+          else
+            changed_files="$(git diff --name-only "${base_ref}" "${head_ref}")"
+          fi
+
+          printf 'Changed files:\n%s\n' "${changed_files}"
+
+          builder_inputs_changed="false"
+          while IFS= read -r file; do
+            case "${file}" in
+              docker/Dockerfile.builder|.github/workflows/build-builder-image.yml)
+                builder_inputs_changed="true"
+                break
+                ;;
+            esac
+          done <<< "${changed_files}"
+
+          echo "changed=${builder_inputs_changed}" >> "${GITHUB_OUTPUT}"
+
+      - name: Log in to GitHub Container Registry
+        id: ghcr_login
+        if: steps.builder_changes.outputs.changed != 'true'
+        continue-on-error: true
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Warn about GHCR login failure
+        if: steps.ghcr_login.outcome == 'failure'
+        shell: bash
+        run: echo "::warning::GHCR login failed - will attempt pull as anonymous or build locally"
+
+      - name: Resolve builder image
+        id: builder_image
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          build_local_builder_image() {
+            docker build \
+              -t "${BUILDER_IMAGE_LOCAL}" \
+              -f docker/Dockerfile.builder \
+              --build-arg GITHUB_ACTIONS=true \
+              --build-arg RUSTUP_DIST_SERVER=https://static.rust-lang.org \
+              --build-arg RUSTUP_UPDATE_ROOT=https://static.rust-lang.org/rustup \
+              .
+          }
+
+          image="${BUILDER_IMAGE_REMOTE}"
+
+          if [[ "${{ steps.builder_changes.outputs.changed }}" == "true" ]]; then
+            echo "Builder inputs changed, building local builder image..."
+            build_local_builder_image
+            image="${BUILDER_IMAGE_LOCAL}"
+          elif docker pull "${BUILDER_IMAGE_REMOTE}"; then
+            echo "Using published builder image ${BUILDER_IMAGE_REMOTE}"
+          else
+            echo "Failed to pull ${BUILDER_IMAGE_REMOTE}, building local fallback image..."
+            build_local_builder_image
+            image="${BUILDER_IMAGE_LOCAL}"
+          fi
+
+          echo "image=${image}" >> "${GITHUB_OUTPUT}"
+
+      - name: Run make fmt in builder
+        shell: bash
+        run: |
+          set -euo pipefail
+          make builder-run \
+            BUILDER_IMAGE="${{ steps.builder_image.outputs.image }}" \
+            BUILDER_CMD='make fmt'
+
+      - name: Check for uncommitted formatting changes
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if ! git diff --exit-code; then
+            echo ""
+            echo "::error::Code is not properly formatted. Run 'make fmt' locally and commit the changes."
+            echo ""
+            echo "Unformatted files listed above. To fix:"
+            echo "  make fmt"
+            echo "  git add -u"
+            echo "  git commit -m 'chore: apply code formatting'"
+            exit 1
+          fi
+
+          echo "All files are properly formatted."

--- a/CubeAPI/Makefile
+++ b/CubeAPI/Makefile
@@ -1,0 +1,4 @@
+.PHONY: fmt
+
+fmt:
+	cargo fmt

--- a/CubeAPI/build.rs
+++ b/CubeAPI/build.rs
@@ -4,8 +4,7 @@
 fn main() {
     let version = std::env::var("CUBE_VERSION").unwrap_or_else(|_| "0.0.0-dev".to_string());
     let commit = std::env::var("CUBE_COMMIT").unwrap_or_else(|_| "unknown".to_string());
-    let build_time =
-        std::env::var("CUBE_BUILD_TIME").unwrap_or_else(|_| "unknown".to_string());
+    let build_time = std::env::var("CUBE_BUILD_TIME").unwrap_or_else(|_| "unknown".to_string());
 
     // Do NOT include the binary name — clap prepends it automatically.
     let version_full = format!("{} ({}) built at {}", version, commit, build_time);

--- a/CubeAPI/src/cubemaster/mod.rs
+++ b/CubeAPI/src/cubemaster/mod.rs
@@ -621,7 +621,10 @@ pub struct CreateSandboxRequest {
     pub network_type: Option<String>,
 
     /// Network egress policy.
-    #[serde(rename = "cube_network_config", skip_serializing_if = "Option::is_none")]
+    #[serde(
+        rename = "cube_network_config",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub cube_network_config: Option<CubeNetworkConfig>,
 }
 
@@ -1632,7 +1635,10 @@ pub struct CreateTemplateFromImageReq {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub container_overrides: Option<CreateTemplateContainerOverrides>,
     /// Network / internet-access context.
-    #[serde(rename = "cube_network_config", skip_serializing_if = "Option::is_none")]
+    #[serde(
+        rename = "cube_network_config",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub cube_network_config: Option<CreateTemplateCubeNetworkConfig>,
 }
 
@@ -1674,7 +1680,10 @@ pub struct CreateTemplateEnv {
 /// Network config for template creation.
 #[derive(Debug, Serialize)]
 pub struct CreateTemplateCubeNetworkConfig {
-    #[serde(rename = "allowInternetAccess", skip_serializing_if = "Option::is_none")]
+    #[serde(
+        rename = "allowInternetAccess",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub allow_internet_access: Option<bool>,
     #[serde(rename = "allowOut", skip_serializing_if = "Vec::is_empty")]
     pub allow_out: Vec<String>,

--- a/CubeAPI/src/services/sandboxes.rs
+++ b/CubeAPI/src/services/sandboxes.rs
@@ -9,11 +9,11 @@ use uuid::Uuid;
 use crate::{
     constants::ENVD_VERSION,
     cubemaster::{
-        datetime_from_unix_nanos, extract_template_id, CreateSandboxRequest, CubeMasterClient, CubeMasterError,
-        DeleteSandboxRequest, ListSandboxRequest, SandboxInfo, SandboxLogsRequest,
-        SandboxRefreshRequest, SandboxStatus, SandboxTimeoutRequest, SandboxUpdateRequest,
-        CubeEgressRule, CubeEgressRuleAction, CubeEgressRuleInject, CubeEgressRuleMatch,
-        CubeNetworkConfig,
+        datetime_from_unix_nanos, extract_template_id, CreateSandboxRequest, CubeEgressRule,
+        CubeEgressRuleAction, CubeEgressRuleInject, CubeEgressRuleMatch, CubeMasterClient,
+        CubeMasterError, CubeNetworkConfig, DeleteSandboxRequest, ListSandboxRequest, SandboxInfo,
+        SandboxLogsRequest, SandboxRefreshRequest, SandboxStatus, SandboxTimeoutRequest,
+        SandboxUpdateRequest,
     },
     error::{AppError, AppResult},
     models::{
@@ -144,7 +144,10 @@ impl SandboxService {
             containers: vec![],
             exposed_ports: vec![],
             network_type: Some("tap".to_string()),
-            cube_network_config: build_cube_network_config(body.allow_internet_access, body.network.as_ref()),
+            cube_network_config: build_cube_network_config(
+                body.allow_internet_access,
+                body.network.as_ref(),
+            ),
         };
 
         let resp = self

--- a/CubeAPI/src/services/templates.rs
+++ b/CubeAPI/src/services/templates.rs
@@ -74,8 +74,16 @@ impl TemplateService {
             .as_ref()
             .and_then(|v| v.get("network_type"))
             .and_then(|v| v.as_str())
-            .and_then(|s| if s.is_empty() { None } else { Some(s.to_string()) });
-        let allow_internet_access = resp.create_request.as_ref()
+            .and_then(|s| {
+                if s.is_empty() {
+                    None
+                } else {
+                    Some(s.to_string())
+                }
+            });
+        let allow_internet_access = resp
+            .create_request
+            .as_ref()
             .and_then(|v| v.get("cube_network_config"))
             .and_then(|v| v.get("allowInternetAccess"))
             .and_then(|v| v.as_bool());

--- a/CubeMaster/Makefile
+++ b/CubeMaster/Makefile
@@ -59,7 +59,7 @@ COVERAGE_PACKAGES=$(shell go list ./... \
 	| grep -v github.com/tencentcloud/CubeSandbox/CubeMaster/cmd )
 
 
-.PHONY: build deps check-proto-tools
+.PHONY: build deps check-proto-tools fmt lint clean
 build: $(APPS)
 deps:
 	$(call msg,Download modules)

--- a/CubeMaster/Makefile
+++ b/CubeMaster/Makefile
@@ -81,6 +81,9 @@ $(APPS): deps
 
 
 
+fmt:
+	$(Q)go fmt ./...
+
 lint:
 	$(Q)go fmt ./...
 	$(Q)golangci-lint run

--- a/CubeMaster/cmd/cubemaster/app/main.go
+++ b/CubeMaster/cmd/cubemaster/app/main.go
@@ -52,7 +52,6 @@ func (a *App) Run() {
 	)
 	defer cancel()
 
-
 	cfg := config.GetConfig()
 
 	if err := coreInit(ctx, cfg); err != nil {

--- a/CubeMaster/cmd/cubemastercli/commands/cubebox/template_test.go
+++ b/CubeMaster/cmd/cubemastercli/commands/cubebox/template_test.go
@@ -348,14 +348,14 @@ func TestFormatTemplateImageJobWatchLineIncludesError(t *testing.T) {
 
 func TestFormatTemplateImageJobCompletionSummarySuccess(t *testing.T) {
 	job := &types.TemplateImageJobInfo{
-		Status:             "READY",
-		TemplateID:         "tpl-1",
-		JobID:              "job-1",
-		ArtifactID:         "artifact-1",
-		ExpectedNodeCount:  2,
-		ReadyNodeCount:     2,
-		FailedNodeCount:    0,
-		TemplateStatus:     "READY",
+		Status:                  "READY",
+		TemplateID:              "tpl-1",
+		JobID:                   "job-1",
+		ArtifactID:              "artifact-1",
+		ExpectedNodeCount:       2,
+		ReadyNodeCount:          2,
+		FailedNodeCount:         0,
+		TemplateStatus:          "READY",
 		TemplateSpecFingerprint: "sha256:abc",
 	}
 

--- a/CubeMaster/pkg/service/httpservice/cube/sandbox_create_test.go
+++ b/CubeMaster/pkg/service/httpservice/cube/sandbox_create_test.go
@@ -37,8 +37,8 @@ func TestCreateSandboxMapsMissingTemplateToNotFound(t *testing.T) {
 	req := httptest.NewRequest("POST", "/cube/sandbox", strings.NewReader(`{
 		"requestID":"req-1",
 		"annotations":{
-			"` + constants.CubeAnnotationAppSnapshotTemplateID + `":"tpl-missing",
-			"` + constants.CubeAnnotationAppSnapshotTemplateVersion + `":"v2"
+			"`+constants.CubeAnnotationAppSnapshotTemplateID+`":"tpl-missing",
+			"`+constants.CubeAnnotationAppSnapshotTemplateVersion+`":"v2"
 		}
 	}`))
 	rt := &CubeLog.RequestTrace{}
@@ -72,8 +72,8 @@ func TestCreateSandboxKeepsOtherTemplateErrorsAsParamsError(t *testing.T) {
 	req := httptest.NewRequest("POST", "/cube/sandbox", strings.NewReader(`{
 		"requestID":"req-2",
 		"annotations":{
-			"` + constants.CubeAnnotationAppSnapshotTemplateID + `":"tpl-other-error",
-			"` + constants.CubeAnnotationAppSnapshotTemplateVersion + `":"v2"
+			"`+constants.CubeAnnotationAppSnapshotTemplateID+`":"tpl-other-error",
+			"`+constants.CubeAnnotationAppSnapshotTemplateVersion+`":"v2"
 		}
 	}`))
 	rt := &CubeLog.RequestTrace{}

--- a/CubeMaster/pkg/service/httpservice/cube/snapshot.go
+++ b/CubeMaster/pkg/service/httpservice/cube/snapshot.go
@@ -437,7 +437,7 @@ func getSnapshot(r *http.Request, rt *CubeLog.RequestTrace) interface{} {
 // running, please poll" outcome.  `GET /cube/operation/{operation_id}` is
 // kept around purely for human audit; programmatic clients have no reason
 // to poll.  The snapshot API is synchronous — CubeAPI waits for a
-	// terminal state and does not expose a polling interface to callers.
+// terminal state and does not expose a polling interface to callers.
 func deleteSnapshot(r *http.Request, rt *CubeLog.RequestTrace) interface{} {
 	snapshotID := resourceIDFromPath(r.URL.Path, actionURI(SnapshotAction))
 	if snapshotID == "" {

--- a/CubeMaster/pkg/service/httpservice/cube/snapshot_test.go
+++ b/CubeMaster/pkg/service/httpservice/cube/snapshot_test.go
@@ -320,7 +320,6 @@ func TestBindSnapshotCreateReplicaInjectsRuntimeAnnotations(t *testing.T) {
 	assert.NotEmpty(t, req.Annotations[constants.CubeAnnotationRuntimeSnapshotAttachedAt])
 }
 
-
 // TestBindAppSnapshotTemplateReplicaRequiresReadyReplica verifies that even
 // though no physical refs are written, the replica resolution still runs as
 // a fail-fast gate (no ready replica -> error).

--- a/CubeMaster/pkg/service/sandbox/types/types.go
+++ b/CubeMaster/pkg/service/sandbox/types/types.go
@@ -35,12 +35,12 @@ type HostChangeEvent struct {
 type CreateCubeSandboxReq struct {
 	*Request
 
-	Timeout            int                `json:"timeout,omitempty" d:"60"`
-	SnapshotDir        string             `json:"snapshot_dir,omitempty"`
-	InsId              string             `json:"ins_id,omitempty"`
-	InsIp              string             `json:"ins_ip,omitempty"`
-	Volumes            []*Volume          `json:"volumes,omitempty"`
-	CubeNetworkConfig  *CubeNetworkConfig `json:"cube_network_config,omitempty"`
+	Timeout           int                `json:"timeout,omitempty" d:"60"`
+	SnapshotDir       string             `json:"snapshot_dir,omitempty"`
+	InsId             string             `json:"ins_id,omitempty"`
+	InsIp             string             `json:"ins_ip,omitempty"`
+	Volumes           []*Volume          `json:"volumes,omitempty"`
+	CubeNetworkConfig *CubeNetworkConfig `json:"cube_network_config,omitempty"`
 
 	Containers []*Container `json:"containers,omitempty"`
 

--- a/CubeMaster/pkg/templatecenter/cube_egress_ca/cube_egress_ca.go
+++ b/CubeMaster/pkg/templatecenter/cube_egress_ca/cube_egress_ca.go
@@ -96,9 +96,9 @@ var bundleFiles = []string{
 // a workload that runs apt install some-package and triggers a
 // post-install hook) pick the CA up too.
 var anchorDirs = []string{
-	"usr/local/share/ca-certificates",       // Debian/Ubuntu
-	"etc/pki/ca-trust/source/anchors",       // RHEL/Fedora/CentOS
-	"etc/ca-certificates/trust-source",      // Arch
+	"usr/local/share/ca-certificates",  // Debian/Ubuntu
+	"etc/pki/ca-trust/source/anchors",  // RHEL/Fedora/CentOS
+	"etc/ca-certificates/trust-source", // Arch
 }
 
 // Bake runs against rootfsDir, applying caPEM to every bundle/anchor

--- a/CubeMaster/pkg/templatecenter/cube_egress_ca/cube_egress_ca_test.go
+++ b/CubeMaster/pkg/templatecenter/cube_egress_ca/cube_egress_ca_test.go
@@ -28,12 +28,12 @@ func makeCA(t *testing.T, cn string) (pemBytes, der []byte) {
 		t.Fatalf("ecdsa.GenerateKey: %v", err)
 	}
 	tmpl := &x509.Certificate{
-		SerialNumber: big.NewInt(time.Now().UnixNano()),
-		Subject:      pkix.Name{CommonName: cn},
-		NotBefore:    time.Now().Add(-time.Hour),
-		NotAfter:     time.Now().Add(time.Hour),
-		IsCA:         true,
-		KeyUsage:     x509.KeyUsageCertSign,
+		SerialNumber:          big.NewInt(time.Now().UnixNano()),
+		Subject:               pkix.Name{CommonName: cn},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		IsCA:                  true,
+		KeyUsage:              x509.KeyUsageCertSign,
 		BasicConstraintsValid: true,
 	}
 	der, err = x509.CreateCertificate(rand.Reader, tmpl, tmpl, &priv.PublicKey, priv)

--- a/CubeMaster/pkg/templatecenter/snapshot_ops.go
+++ b/CubeMaster/pkg/templatecenter/snapshot_ops.go
@@ -567,7 +567,7 @@ func runSnapshotRollbackJob(ctx context.Context, jobID, sandboxID, snapshotID, n
 //     next `DeleteSnapshot` call for the same id will re-attempt cleanly.
 //
 // The snapshot API is synchronous — CubeAPI waits for a terminal state
-	// and does not expose a polling interface to callers.
+// and does not expose a polling interface to callers.
 func DeleteSnapshot(ctx context.Context, requestID, snapshotID, instanceType string) (*sandboxtypes.TemplateImageJobInfo, error) {
 	if !isReady() {
 		return nil, ErrTemplateStoreNotInitialized
@@ -1337,4 +1337,3 @@ func snapshotDeleteRequestMatches(raw, requestID, snapshotID string) bool {
 	}
 	return existing.RequestID == requestID && existing.SnapshotID == snapshotID
 }
-

--- a/CubeMaster/pkg/templatecenter/snapshot_ops_test.go
+++ b/CubeMaster/pkg/templatecenter/snapshot_ops_test.go
@@ -197,7 +197,7 @@ func TestSubmitSandboxSnapshotReturnsStoredFailureForExistingRequest(t *testing.
 // error.  This is the load-bearing invariant that lets CubeAPI / external
 // SDKs treat `DeleteSnapshot` as a synchronous RPC — see
 // SDKs treat `DeleteSnapshot` as a synchronous RPC — CubeAPI waits for
-	// a terminal state and does not expose a polling interface.  If a future refactor
+// a terminal state and does not expose a polling interface.  If a future refactor
 // would start observing "the API said success but the snapshot is still
 // being deleted" races; this test fails first.
 func TestFinalizeSynchronousSnapshotJobEnforcesTerminalContract(t *testing.T) {

--- a/CubeMaster/pkg/templatecenter/snapshot_reconciler_test.go
+++ b/CubeMaster/pkg/templatecenter/snapshot_reconciler_test.go
@@ -13,9 +13,9 @@ import (
 	"github.com/agiledragon/gomonkey/v2"
 	cubeboxv1 "github.com/tencentcloud/CubeSandbox/CubeMaster/api/services/cubebox/v1"
 	errorcodev1 "github.com/tencentcloud/CubeSandbox/CubeMaster/api/services/errorcode/v1"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/node"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/cubelet"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/localcache"
-	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/node"
 )
 
 // resetSnapshotStorageCachesForTest clears the in-process snapshotStorageCache
@@ -68,7 +68,7 @@ func TestGetOrRefreshSkipsTTLForUnknown(t *testing.T) {
 	})
 
 	// Seed an unknown entry within TTL: under the old short-circuit logic,
-		// GetStorageMetrics would not be called and Mode would never flip to healthy.
+	// GetStorageMetrics would not be called and Mode would never flip to healthy.
 	cacheSnapshotStorageState("node-1", "10.0.0.1", snapshotStorageState{
 		NodeID:        "node-1",
 		NodeIP:        "10.0.0.1",
@@ -157,7 +157,7 @@ func TestRefreshSnapshotStorageMetricsRetriesCachedUnknown(t *testing.T) {
 	})
 
 	// Write an unknown node directly into localcache (simulating dirty state left
-		// from a previous cold-start failure; snapshotStorageCache retains a copy too).
+	// from a previous cold-start failure; snapshotStorageCache retains a copy too).
 	cacheSnapshotStorageState("stale-node", "10.0.0.7", snapshotStorageState{
 		NodeID:        "stale-node",
 		NodeIP:        "10.0.0.7",

--- a/CubeMaster/pkg/templatecenter/store_test.go
+++ b/CubeMaster/pkg/templatecenter/store_test.go
@@ -40,7 +40,7 @@ func TestNormalizeStoredTemplateRequestStripsPhysicalAnnotations(t *testing.T) {
 			constants.CubeAnnotationsAppSnapshotCreate:        "true",
 			constants.CubeAnnotationRuntimeSnapshotID:         "snap-stale",
 			constants.CubeAnnotationRuntimeSnapshotAttachedAt: "2026-05-01T00:00:00Z",
-			"unrelated":                                       "keep-me",
+			"unrelated": "keep-me",
 		},
 	}
 

--- a/CubeShim/Makefile
+++ b/CubeShim/Makefile
@@ -9,9 +9,12 @@ UID = $(shell id -u)
 GID = $(shell id -g)
 PWD = $(shell pwd)
 
-.PHONY: all
+.PHONY: all fmt
 all:
 	cargo build --release
+
+fmt:
+	cargo fmt
 
 .PHONY: all-docker
 all-docker:

--- a/CubeShim/cube-runtime/build.rs
+++ b/CubeShim/cube-runtime/build.rs
@@ -5,8 +5,7 @@
 fn main() {
     let version = std::env::var("CUBE_VERSION").unwrap_or_else(|_| "0.0.0-dev".to_string());
     let commit = std::env::var("CUBE_COMMIT").unwrap_or_else(|_| "unknown".to_string());
-    let build_time =
-        std::env::var("CUBE_BUILD_TIME").unwrap_or_else(|_| "unknown".to_string());
+    let build_time = std::env::var("CUBE_BUILD_TIME").unwrap_or_else(|_| "unknown".to_string());
 
     // Do NOT include the binary name — clap prepends it automatically.
     let version_full = format!("{} ({}) built at {}", version, commit, build_time);

--- a/CubeShim/shim/build.rs
+++ b/CubeShim/shim/build.rs
@@ -9,8 +9,7 @@ const ENV_BUILD_ENV_V: &str = "zhiyan";
 
 fn main() {
     // ── Version (priority: env var > git tag > fallback) ──
-    let version = std::env::var("CUBE_VERSION")
-        .unwrap_or_else(|_| "0.0.0-dev".to_string());
+    let version = std::env::var("CUBE_VERSION").unwrap_or_else(|_| "0.0.0-dev".to_string());
 
     // ── Commit (priority: env var > git rev-parse > fallback) ──
     let commit = std::env::var("CUBE_COMMIT").unwrap_or_else(|_| {
@@ -24,8 +23,7 @@ fn main() {
     });
 
     // ── Build time (priority: env var > fallback) ──
-    let build_time = std::env::var("CUBE_BUILD_TIME")
-        .unwrap_or_else(|_| "unknown".to_string());
+    let build_time = std::env::var("CUBE_BUILD_TIME").unwrap_or_else(|_| "unknown".to_string());
 
     // ── Short commit + dirty check (backward compatible GIT_COMMIT_INFO) ──
     let short_commit: String = commit.chars().take(8).collect();

--- a/Cubelet/Makefile
+++ b/Cubelet/Makefile
@@ -63,7 +63,7 @@ DYNAMIC_CONF_DIR=$(BUILD_DIR)/cube-cubelet-conf
 DYNAMIC_PUBLISH_NAME=cube-cubelet-conf-$(CONF_VERSION).zip
 
 
-.PHONY: build deps check-proto-tools
+.PHONY: build deps check-proto-tools fmt lint dep clean
 build: $(APPS)
 deps:
 	$(call msg,Download modules)

--- a/Cubelet/Makefile
+++ b/Cubelet/Makefile
@@ -150,6 +150,10 @@ view:
 	$(call msg,Show coverage report)
 	$(Q)go tool cover -html=$(COVERAGE_PROFILE)
 
+fmt:
+	$(call msg,Format code)
+	$(Q)go fmt ./...
+
 lint:
 	$(call msg,Run linters)
 	$(Q)go fmt ./...

--- a/Cubelet/network/proto/network.go
+++ b/Cubelet/network/proto/network.go
@@ -36,9 +36,9 @@ type Interface struct {
 
 	Family int `json:"family"`
 
-	Mask            int        `json:"mask"`
-	IPs             []MVMIp    `json:"ips"`
-	Qos             *QosConfig `json:"qos"`
+	Mask int        `json:"mask"`
+	IPs  []MVMIp    `json:"ips"`
+	Qos  *QosConfig `json:"qos"`
 }
 
 type MVMIp struct {

--- a/Cubelet/pkg/utils/io.go
+++ b/Cubelet/pkg/utils/io.go
@@ -18,7 +18,7 @@ func SafeCopyFile(dst, src string) (err error) {
 	}
 	defer srcFile.Close()
 
-	dstNewFile := dst + ".new" // NOCC:Path Traversal()
+	dstNewFile := dst + ".new"                                                        // NOCC:Path Traversal()
 	dstFile, err := os.OpenFile(dstNewFile, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644) // NOCC:Path Traversal()
 	if err != nil {
 		return err

--- a/Cubelet/storage/cubecow_snapshot_artifacts_test.go
+++ b/Cubelet/storage/cubecow_snapshot_artifacts_test.go
@@ -17,7 +17,7 @@ func useTestCowStorage(t *testing.T, engine *fakeCowEngine) {
 	t.Helper()
 	previousLocalStorage := localStorage
 	localStorage = &local{
-		config:         &Config{StorageBackend: "cubecow"},
+		config:     &Config{StorageBackend: "cubecow"},
 		cowManager: &CowVolumeManager{engine: engine},
 	}
 	t.Cleanup(func() {

--- a/Cubelet/storage/local.go
+++ b/Cubelet/storage/local.go
@@ -64,8 +64,8 @@ type local struct {
 	hostInfo             *HostStorageMeta
 	cubeboxAPI           cubes.CubeboxAPI
 	multiLock            *multilock.MultiLock
-	cowEngine        *cubecow.Engine
-	cowManager       cowVolumeManager
+	cowEngine            *cubecow.Engine
+	cowManager           cowVolumeManager
 }
 
 type HostStorageMeta struct {

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ ifneq ($(wildcard $(HOME)/.git-credentials),)
 DOCKER_GIT_CRED += -v $(TMP_GIT_CREDENTIALS):$(BUILDER_CONTAINER_HOME)/.git-credentials
 endif
 
-.PHONY: help builder-image builder-shell builder-run prepare-builder-home prepare-tmp-git-credentials all cubemaster cubelet cubecow-sdk cubecow-clean cubecow-smoke cubecow-test-native network-agent agent cubeapi cube-api shim manual-release web-install web-dev web-build web-preview web-lint web-api-sync web-sync-dev-env cubevsmapdump
+.PHONY: help builder-image builder-shell builder-run prepare-builder-home prepare-tmp-git-credentials all cubemaster cubelet cubecow-sdk cubecow-clean cubecow-smoke cubecow-test-native network-agent agent cubeapi cube-api shim manual-release web-install web-dev web-build web-preview web-lint web-api-sync web-sync-dev-env cubevsmapdump fmt
 
 help:
 	@printf "Targets:\n"
@@ -59,6 +59,7 @@ help:
 	@printf "  web-build     Build WebUI static assets\n"
 	@printf "  web-preview   Preview built WebUI assets\n"
 	@printf "  web-lint      Run WebUI lint checks\n"
+	@printf "  fmt            Format code in all component directories\n"
 	@printf "  web-api-sync  Export OpenAPI and regenerate WebUI schema types\n"
 	@printf "  web-sync-dev-env Build and deploy WebUI into dev-env VM\n"
 	@printf "\nNotes:\n"
@@ -208,3 +209,25 @@ web-api-sync:
 
 web-sync-dev-env:
 	"$(ROOT_DIR)/dev-env/internal/sync_web_to_vm.sh"
+
+# Run make fmt in each component directory that has a fmt target.
+# Components without formattable code (e.g. CubeProxy) are skipped.
+fmt:
+	@printf '  %-8s %s\n' "FMT" "agent"
+	@$(MAKE) -C agent fmt
+	@printf '  %-8s %s\n' "FMT" "cubecow"
+	@$(MAKE) -C cubecow fmt
+	@printf '  %-8s %s\n' "FMT" "CubeAPI"
+	@$(MAKE) -C CubeAPI fmt
+	@printf '  %-8s %s\n' "FMT" "Cubelet"
+	@$(MAKE) -C Cubelet fmt
+	@printf '  %-8s %s\n' "FMT" "cubelog"
+	@$(MAKE) -C cubelog fmt
+	@printf '  %-8s %s\n' "FMT" "CubeMaster"
+	@$(MAKE) -C CubeMaster fmt
+	@printf '  %-8s %s\n' "FMT" "CubeShim"
+	@$(MAKE) -C CubeShim fmt
+	@printf '  %-8s %s\n' "FMT" "hypervisor"
+	@$(MAKE) -C hypervisor fmt
+	@printf '  %-8s %s\n' "FMT" "network-agent"
+	@$(MAKE) -C network-agent fmt

--- a/agent/Makefile
+++ b/agent/Makefile
@@ -133,6 +133,10 @@ clean:
 test:
 	@cargo test --all $(EXTRA_RUSTFEATURES) -- --nocapture
 
+##TARGET fmt: format code
+fmt:
+	cargo fmt
+
 ##TARGET check: run lint/fmt check
 check: $(GENERATED_FILES)
 	cargo fmt -- --check
@@ -176,6 +180,7 @@ generate-protocols:
 	clean \
 	default \
 	docker \
+	fmt \
 	FORCE \
 	generate-protocols \
 	help \

--- a/agent/Makefile
+++ b/agent/Makefile
@@ -134,7 +134,8 @@ test:
 	@cargo test --all $(EXTRA_RUSTFEATURES) -- --nocapture
 
 ##TARGET fmt: format code
-fmt:
+fmt: $(GENERATED_FILES)
+	@if [ ! -f libs/protocols/src/agent.rs ]; then cargo check -p protocols; fi
 	cargo fmt
 
 ##TARGET check: run lint/fmt check

--- a/agent/rustjail/src/seccomp.rs
+++ b/agent/rustjail/src/seccomp.rs
@@ -33,7 +33,11 @@ fn get_rule_conditions(args: &[LinuxSeccompArg]) -> Result<Vec<ScmpArgCompare>> 
         let cond = match op {
             ScmpCompareOp::MaskedEqual(mask) => {
                 let _ = mask; // mask already embedded in the op
-                ScmpArgCompare::new(arg.index, ScmpCompareOp::MaskedEqual(arg.value_two), arg.value)
+                ScmpArgCompare::new(
+                    arg.index,
+                    ScmpCompareOp::MaskedEqual(arg.value_two),
+                    arg.value,
+                )
             }
             _ => ScmpArgCompare::new(arg.index, op, arg.value),
         };

--- a/cubecow/Makefile
+++ b/cubecow/Makefile
@@ -1,0 +1,4 @@
+.PHONY: fmt
+
+fmt:
+	cargo fmt

--- a/cubecow/benches/reflink_ops.rs
+++ b/cubecow/benches/reflink_ops.rs
@@ -211,8 +211,7 @@ impl ReflinkBench {
         let tag = unique_suffix();
         let backing_file = PathBuf::from(format!("/tmp/reflink-bench-{tag}.img"));
         let mount_point = PathBuf::from(format!("/tmp/reflink-bench-mnt-{tag}"));
-        std::fs::create_dir_all(&mount_point)
-            .map_err(|e| format!("create mount_point: {e}"))?;
+        std::fs::create_dir_all(&mount_point).map_err(|e| format!("create mount_point: {e}"))?;
 
         // Sparse `truncate`: a 4 GiB declared size only costs a few
         // MiB of real disk because every block we never touch stays
@@ -371,7 +370,9 @@ impl Drop for ReflinkBench {
 
         // Detach loop device.
         for _ in 0..10 {
-            let st = Command::new("losetup").args(["-d", &self.loop_dev]).status();
+            let st = Command::new("losetup")
+                .args(["-d", &self.loop_dev])
+                .status();
             if matches!(st, Ok(s) if s.success()) {
                 break;
             }
@@ -628,9 +629,7 @@ fn bench_concurrent_sweep(bench: &ReflinkBench, sweep: &[usize], per_worker: usi
     }
     let mut summary: Vec<(usize, Duration, Duration, f64)> = Vec::new(); // (threads, p50, p99, ops_per_s)
     for &threads in sweep {
-        let label = format!(
-            "create_snapshot concurrent threads={threads} per_worker={per_worker}"
-        );
+        let label = format!("create_snapshot concurrent threads={threads} per_worker={per_worker}");
         let (samples, wall) = run_concurrent_fanout(bench, threads, per_worker);
         report(&label, &samples);
         let total_ops = samples.len() as f64;
@@ -654,7 +653,10 @@ fn bench_concurrent_sweep(bench: &ReflinkBench, sweep: &[usize], per_worker: usi
     // didn't include threads=1 in the sweep, fall back to the smallest
     // configured count.
     println!();
-    println!("# concurrency scaling (relative to threads={}):", summary[0].0);
+    println!(
+        "# concurrency scaling (relative to threads={}):",
+        summary[0].0
+    );
     println!(
         "  {:<10}  {:<12}  {:<12}  {:<14}  {:<10}",
         "threads", "p50", "p99", "throughput", "speedup"
@@ -689,12 +691,7 @@ fn bench_concurrent_sweep(bench: &ReflinkBench, sweep: &[usize], per_worker: usi
 /// that's bookkeeping-stable should have first-half p99 ≈
 /// second-half p99; a regressor will show the second half noticeably
 /// slower.
-fn bench_dirty_io_interleave(
-    bench: &ReflinkBench,
-    n: usize,
-    dirty_bytes: u64,
-    block: u64,
-) {
+fn bench_dirty_io_interleave(bench: &ReflinkBench, n: usize, dirty_bytes: u64, block: u64) {
     if n == 0 || dirty_bytes == 0 {
         return;
     }
@@ -707,8 +704,7 @@ fn bench_dirty_io_interleave(
         .expect("scenario 4 create_volume");
 
     let main_path = bench.vol_main_file(origin);
-    let f =
-        open_volume_for_dirty_io(&main_path).expect("scenario 4 open volume for dirty-IO");
+    let f = open_volume_for_dirty_io(&main_path).expect("scenario 4 open volume for dirty-IO");
 
     // Pre-fill a single block of payload data once. We pwrite the same
     // buffer at different offsets each iteration; the *content* doesn't
@@ -771,10 +767,8 @@ fn bench_dirty_io_interleave(
         let second: Vec<_> = samples[half..].to_vec();
         let first_p99 = percentile(first.clone(), 0.99);
         let second_p99 = percentile(second.clone(), 0.99);
-        let first_mean: Duration =
-            first.iter().copied().sum::<Duration>() / first.len() as u32;
-        let second_mean: Duration =
-            second.iter().copied().sum::<Duration>() / second.len() as u32;
+        let first_mean: Duration = first.iter().copied().sum::<Duration>() / first.len() as u32;
+        let second_mean: Duration = second.iter().copied().sum::<Duration>() / second.len() as u32;
         let drift_pct = if first_p99.as_nanos() > 0 {
             (second_p99.as_secs_f64() / first_p99.as_secs_f64() - 1.0) * 100.0
         } else {

--- a/cubecow/src/engine/reflink.rs
+++ b/cubecow/src/engine/reflink.rs
@@ -63,8 +63,8 @@ use crate::config::AppConfig;
 use crate::engine::Engine;
 use crate::pkg::errors::{CubecowError, CubecowResult};
 use crate::pkg::metrics::{
-    MetricsCollector, METRIC_SNAPSHOT_COUNT, METRIC_TOTAL_BYTES,
-    METRIC_USED_BYTES, METRIC_VOLUME_COUNT,
+    MetricsCollector, METRIC_SNAPSHOT_COUNT, METRIC_TOTAL_BYTES, METRIC_USED_BYTES,
+    METRIC_VOLUME_COUNT,
 };
 use crate::{Snapshot, Volume, VolumeBlockInfo};
 
@@ -226,9 +226,7 @@ impl ReflinkEngine {
 
     /// Path to a snapshot file: `<volumes_dir>/<origin>/<snap>`.
     fn snap_file(&self, origin_volume: &str, snapshot_name: &str) -> PathBuf {
-        self.volumes_dir
-            .join(origin_volume)
-            .join(snapshot_name)
+        self.volumes_dir.join(origin_volume).join(snapshot_name)
     }
 
     // -----------------------------------------------------------------------
@@ -527,7 +525,8 @@ impl Engine for ReflinkEngine {
             .write(true)
             .open(&main)
             .map_err(CubecowError::IoError)?;
-        file.set_len(new_size_bytes).map_err(CubecowError::IoError)?;
+        file.set_len(new_size_bytes)
+            .map_err(CubecowError::IoError)?;
         file.sync_all().map_err(CubecowError::IoError)?;
         info!(
             volume = name,
@@ -656,10 +655,9 @@ impl Engine for ReflinkEngine {
                 .read()
                 .expect("reflink name_index lock poisoned");
             match idx.get(source_name) {
-                Some(NameKind::Volume) => (
-                    self.vol_main_file(source_name),
-                    source_name.to_string(),
-                ),
+                Some(NameKind::Volume) => {
+                    (self.vol_main_file(source_name), source_name.to_string())
+                }
                 Some(NameKind::Snapshot { origin_volume }) => (
                     self.snap_file(origin_volume, source_name),
                     origin_volume.clone(),
@@ -1124,9 +1122,7 @@ fn statvfs_total_used(path: &Path) -> std::io::Result<(u64, u64)> {
 //     origin's main file is non-zero           → orphan from a crashed FICLONE;
 //                                                 unlink.
 // ---------------------------------------------------------------------------
-fn scan_and_rebuild_index(
-    volumes_dir: &Path,
-) -> std::io::Result<HashMap<String, NameKind>> {
+fn scan_and_rebuild_index(volumes_dir: &Path) -> std::io::Result<HashMap<String, NameKind>> {
     let mut index: HashMap<String, NameKind> = HashMap::new();
 
     let read = match std::fs::read_dir(volumes_dir) {
@@ -1418,7 +1414,10 @@ mod tests {
         assert_eq!(new, 4 * 1024 * 1024);
 
         // Volume reflects new size; snapshot stays at original size.
-        assert_eq!(engine.get_volume_info("v").unwrap().size_bytes, 4 * 1024 * 1024);
+        assert_eq!(
+            engine.get_volume_info("v").unwrap().size_bytes,
+            4 * 1024 * 1024
+        );
         let (snaps, _) = engine.list_snapshots("v", 0, None);
         assert_eq!(snaps.len(), 1);
         assert_eq!(snaps[0].size_bytes, 1024 * 1024);
@@ -1458,7 +1457,10 @@ mod tests {
             Some(NameKind::Snapshot { origin_volume }) => assert_eq!(origin_volume, "vol1"),
             other => panic!("expected snapA snapshot of vol1, got {other:?}"),
         }
-        assert!(idx.get("orphan").is_none(), "zero-byte orphan must be skipped");
+        assert!(
+            idx.get("orphan").is_none(),
+            "zero-byte orphan must be skipped"
+        );
         assert!(!orphan.exists(), "scan must remove the orphan file");
 
         let _ = std::fs::remove_dir_all(&root);

--- a/cubecow/src/ffi.rs
+++ b/cubecow/src/ffi.rs
@@ -660,8 +660,7 @@ pub extern "C" fn cubecow_list_volumes(
             Some(unsafe { c_str_to_str(page_token) }?)
         };
 
-        let (volumes, next_token, total) =
-            eng.list_volumes(page_size as usize, token_filter);
+        let (volumes, next_token, total) = eng.list_volumes(page_size as usize, token_filter);
 
         // Serialize volumes to JSON
         let json_items: Vec<serde_json::Value> = volumes

--- a/cubelog/Makefile
+++ b/cubelog/Makefile
@@ -1,9 +1,12 @@
 
 SOURCE:=$(shell ./test.sh)
-.PHONY: test
+.PHONY: test fmt
 
 version:
 	go version
+
+fmt:
+	go fmt ./...
 
 unittest: version
 	#@export GO111MODULE=off

--- a/cubelog/buffer_pool.go
+++ b/cubelog/buffer_pool.go
@@ -13,7 +13,6 @@ var (
 	bufferPool BufferPool
 )
 
-
 type BufferPool interface {
 	Put(buffer *bytes.Buffer)
 	Get() *bytes.Buffer

--- a/cubelog/common.go
+++ b/cubelog/common.go
@@ -8,24 +8,22 @@ import (
 	"net"
 )
 
-
 type Region string
 
-
 const (
-	RegionGuangzhou       Region = "ap-guangzhou"
-	RegionShanghai        Region = "ap-shanghai"
-	RegionBeijing         Region = "ap-beijing"
-	RegionHongKong        Region = "ap-hongkong"
-	RegionChengdu         Region = "ap-chengdu"
-	RegionIndia           Region = "ap-mumbai"
-	RegionChongqing       Region = "ap-chongqing"
-	RegionSeoul           Region = "ap-seoul"
-	RegionSingapore       Region = "ap-singapore"
-	RegionToronto         Region = "na-toronto"
-	RegionSiliconValley   Region = "na-siliconvalley"
-	RegionFrankfurt       Region = "eu-frankfurt"
-	RegionBangkok         Region = "ap-bangkok"
+	RegionGuangzhou     Region = "ap-guangzhou"
+	RegionShanghai      Region = "ap-shanghai"
+	RegionBeijing       Region = "ap-beijing"
+	RegionHongKong      Region = "ap-hongkong"
+	RegionChengdu       Region = "ap-chengdu"
+	RegionIndia         Region = "ap-mumbai"
+	RegionChongqing     Region = "ap-chongqing"
+	RegionSeoul         Region = "ap-seoul"
+	RegionSingapore     Region = "ap-singapore"
+	RegionToronto       Region = "na-toronto"
+	RegionSiliconValley Region = "na-siliconvalley"
+	RegionFrankfurt     Region = "eu-frankfurt"
+	RegionBangkok       Region = "ap-bangkok"
 )
 
 var defaultRegion Region
@@ -33,7 +31,6 @@ var cluster string
 var moduleName string
 var moduleVersion string
 var reportLevel LogLevel
-
 
 var LocalIP string
 
@@ -72,37 +69,25 @@ func getLocalIP() string {
 	return fallbackIP
 }
 
-
 func SetRegion(r Region) {
 	defaultRegion = r
 }
-
 
 func SetCluster(c string) {
 	cluster = c
 }
 
-
 func SetModuleName(n string) {
 	moduleName = n
 }
-
 
 func GetModuleName() string {
 	return moduleName
 }
 
-
 func SetVersion(version string) {
 	moduleVersion = version
 }
-
-
-
-
-
-
-
 
 func (r Region) String() string {
 	return string(r)

--- a/cubelog/context.go
+++ b/cubelog/context.go
@@ -10,12 +10,10 @@ import (
 
 type traceCtxKey struct{}
 
-
 func WithRequestTrace(ctx context.Context, trace *RequestTrace) context.Context {
 	ctx = context.WithValue(ctx, traceCtxKey{}, trace)
 	return ctx
 }
-
 
 func GetTraceInfo(ctx context.Context) *RequestTrace {
 	rt := ctx.Value(traceCtxKey{})

--- a/cubelog/entry.go
+++ b/cubelog/entry.go
@@ -14,7 +14,6 @@ import (
 	"time"
 )
 
-
 type Entry struct {
 	ctx    context.Context
 	logger *Logger
@@ -37,19 +36,12 @@ const (
 
 	KeyNamespace contextKey = "namespace"
 
-
 	KeyInstanceId contextKey = "instance_id"
-
-
 
 	KeyAppID contextKey = "app_id"
 
 	KeyModuleVersion contextKey = "version"
 	KeyContainerId   contextKey = "container_id"
-
-
-
-
 
 	KeyRegion        contextKey = "region"
 	KeyCluster       contextKey = "cluster"
@@ -59,7 +51,6 @@ const (
 	KeyInstanceType  contextKey = "instance_type"
 )
 
-
 func SuccinctCallerPath(f *runtime.Frame) string {
 	s := strings.Split(f.File, "/")
 	len := len(s)
@@ -68,7 +59,6 @@ func SuccinctCallerPath(f *runtime.Frame) string {
 	}
 	return strings.Join(s[(len-2):], "/")
 }
-
 
 func (entry *Entry) WithFields(fields Fields) *Entry {
 	data := make(Fields, len(entry.data)+len(fields))
@@ -100,7 +90,6 @@ func (entry *Entry) WithFields(fields Fields) *Entry {
 	return &Entry{ctx: entry.ctx, logger: entry.logger, data: data, err: fieldErr}
 }
 
-
 func NewEntry(logger *Logger) *Entry {
 	return &Entry{
 		ctx:    context.TODO(),
@@ -108,7 +97,6 @@ func NewEntry(logger *Logger) *Entry {
 		data:   make(Fields, 7),
 	}
 }
-
 
 func (entry *Entry) WithContext(ctx context.Context) *Entry {
 	data := make(Fields, len(entry.data)+16)
@@ -129,12 +117,10 @@ func (entry *Entry) WithContext(ctx context.Context) *Entry {
 	return &Entry{ctx: ctx, logger: entry.logger, data: data, err: entry.err}
 }
 
-
 func getCallerPath() string {
 	if !reportCaller {
 		return ""
 	}
-
 
 	pcs := make([]uintptr, maximumCallerDepth)
 	depth := runtime.Callers(minimumCallerDepth, pcs)
@@ -143,7 +129,6 @@ func getCallerPath() string {
 	sd := skipCallerDepth
 	for f, again := frames.Next(); again; f, again = frames.Next() {
 		pkg := getPackageName(f.Function)
-
 
 		if pkg != cubelogPackage {
 			if sd == 0 {
@@ -156,7 +141,6 @@ func getCallerPath() string {
 			sd = sd - 1
 		}
 	}
-
 
 	return "errorCallerPath"
 }
@@ -188,16 +172,8 @@ func makeLogFields(ctx context.Context) Fields {
 	namespace, _ := ctx.Value(KeyNamespace).(string)
 	fields["Namespace"] = namespace
 
-
-
-
 	instanceId, _ := ctx.Value(KeyInstanceId).(string)
 	fields["InstanceId"] = instanceId
-
-
-
-
-
 
 	version, _ := ctx.Value(KeyModuleVersion).(string)
 	if version == "" {
@@ -209,21 +185,6 @@ func makeLogFields(ctx context.Context) Fields {
 	fields["ContainerId"] = containerId
 	functionType, _ := ctx.Value(KeyFunctionType).(string)
 	fields["FunctionType"] = functionType
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 
 	if region, ok := ctx.Value(KeyRegion).(string); ok {
 		fields["Region"] = region
@@ -255,7 +216,6 @@ func makeLogFieldsFromTrace(rt *RequestTrace) Fields {
 	}
 	fields["Version"] = version
 	fields["InstanceType"] = rt.InstanceType
-
 
 	if rt.AppID > 0 {
 		fields["AppId"] = rt.AppID
@@ -298,18 +258,9 @@ func (entry *Entry) writef(ctx context.Context, level LogLevel, format string, v
 	fields["@timestamp"] = now.Format(time.RFC3339Nano)
 	fields["LogLevel"] = level.String()
 
-
-
-
-
-
-
-
-
 	for k, v := range entry.data {
 		fields[k] = v
 	}
-
 
 	if format == "" {
 		fields["LogContent"] = fmt.Sprint(v...)
@@ -363,51 +314,41 @@ func (entry *Entry) writef(ctx context.Context, level LogLevel, format string, v
 	}
 }
 
-
 func (entry *Entry) Debug(v ...interface{}) {
 	entry.writef(entry.ctx, DEBUG, "", v)
 }
-
 
 func (entry *Entry) Info(v ...interface{}) {
 	entry.writef(entry.ctx, INFO, "", v)
 }
 
-
 func (entry *Entry) Warn(v ...interface{}) {
 	entry.writef(entry.ctx, WARN, "", v)
 }
-
 
 func (entry *Entry) Error(v ...interface{}) {
 	entry.writef(entry.ctx, ERROR, "", v)
 }
 
-
 func (entry *Entry) Fatal(v ...interface{}) {
 	entry.writef(entry.ctx, FATAL, "", v)
 }
-
 
 func (entry *Entry) Debugf(format string, v ...interface{}) {
 	entry.writef(entry.ctx, DEBUG, format, v)
 }
 
-
 func (entry *Entry) Infof(format string, v ...interface{}) {
 	entry.writef(entry.ctx, INFO, format, v)
 }
-
 
 func (entry *Entry) Warnf(format string, v ...interface{}) {
 	entry.writef(entry.ctx, WARN, format, v)
 }
 
-
 func (entry *Entry) Errorf(format string, v ...interface{}) {
 	entry.writef(entry.ctx, ERROR, format, v)
 }
-
 
 func (entry *Entry) Fatalf(format string, v ...interface{}) {
 	entry.writef(entry.ctx, FATAL, format, v)

--- a/cubelog/error.go
+++ b/cubelog/error.go
@@ -4,9 +4,7 @@
 
 package CubeLog
 
-
 type ErrorCode int
-
 
 const (
 	CodeSuccess ErrorCode = iota
@@ -25,11 +23,9 @@ const (
 	CodeResourceInsufficient
 	CodeUnknownError
 
-
 	codeXingYunAlarmError
 	codeHaboWriteMetricError
 )
-
 
 func (s ErrorCode) String() string {
 	switch s {

--- a/cubelog/exported.go
+++ b/cubelog/exported.go
@@ -20,7 +20,6 @@ func init() {
 	std = GetLogger("")
 }
 
-
 func Create(path string) {
 	var err error
 	if _, err = os.Stat(path); os.IsNotExist(err) {
@@ -31,18 +30,13 @@ func Create(path string) {
 	}
 }
 
-
 func GetDefaultLogger() *Logger {
 	return std
 }
 
-
 func SetReportCaller(b bool) {
 	reportCaller = b
 }
-
-
-
 
 func SetOutputLogger(l *Logger) {
 	if l != nil {
@@ -50,95 +44,70 @@ func SetOutputLogger(l *Logger) {
 	}
 }
 
-
-
-
-
-
-
 func SetLogFormat(format logFormat) {
 	std.SetLogFormat(format)
 }
 
-
-
-
 func SetOutput(w io.Writer) {
 	std.writer = w
 }
-
-
 
 func SetCustomFields(fields Fields) {
 	std.SetCustomFields(fields)
 	traceStd.SetCustomFields(fields)
 }
 
-
 func GetCustomFields() Fields {
 	return std.GetCustomFields()
 }
-
 
 func EnableFileLog() {
 	std.EnableFileLog()
 }
 
-
 func WithContext(ctx context.Context) *Entry {
 	return std.WithContext(ctx)
 }
-
 
 func WithFields(fields Fields) *Entry {
 	return std.WithFields(fields)
 }
 
-
 func Debug(args ...interface{}) {
 	std.Debug(args...)
 }
-
 
 func Info(args ...interface{}) {
 	std.Info(args...)
 }
 
-
 func Warn(args ...interface{}) {
 	std.Warn(args...)
 }
-
 
 func Error(args ...interface{}) {
 	std.Error(args...)
 }
 
-
 func Fatal(args ...interface{}) {
 	std.Fatal(args...)
 }
-
 
 func Debugf(format string, args ...interface{}) {
 	std.Debugf(format, args...)
 }
 
-
 func Infof(format string, args ...interface{}) {
 	std.Infof(format, args...)
 }
-
 
 func Warnf(format string, args ...interface{}) {
 	std.Warnf(format, args...)
 }
 
-
 func Errorf(format string, args ...interface{}) {
 	std.Errorf(format, args...)
 }
-
 
 func Fatalf(format string, args ...interface{}) {
 	std.Fatalf(format, args...)

--- a/cubelog/log.go
+++ b/cubelog/log.go
@@ -22,31 +22,18 @@ const (
 	CloudSupport Net = "CloudSupport"
 )
 
-
 type Config struct {
-
 	Net Net
 
-
-
-
-
 	Path string
-
 
 	Count int
 
 	Size int
 
-
-
-
-
 	AsyncFlush string
 	asyncFlush bool
 }
-
-
 
 func Init(cfg Config) {
 	config = cfg
@@ -67,19 +54,15 @@ func Init(cfg Config) {
 		return
 	}
 
-
 	config.asyncFlush = false
 	if cfg.AsyncFlush == "true" {
 		config.asyncFlush = true
 	}
 }
 
-
 type RemoteConfig struct {
-
 	EnableLocal string
 	enablelocal bool
-
 
 	RetmoteLogAddr string
 	RetmoteLogPort int
@@ -89,9 +72,7 @@ type RemoteConfig struct {
 
 var config Config
 
-
 func GetLoggerByName(name string) *Logger {
-
 
 	if name == "" || name == "Trace" {
 		return GetLogger(name)

--- a/cubelog/logger.go
+++ b/cubelog/logger.go
@@ -15,21 +15,13 @@ import (
 )
 
 var (
-
 	cubelogPackage string = "github.com/tencentcloud/CubeSandbox/cubelog"
-
 
 	minimumCallerDepth int
 
-
 	callerInitOnce sync.Once
 
-
 	skipCallerDepth int
-
-
-
-
 
 	CallerPrettyfier func(*runtime.Frame) (file string)
 )
@@ -38,21 +30,17 @@ const (
 	maximumCallerDepth int = 25
 )
 
-
 const (
 	KeyAlarmType contextKey = "alarm_type"
 	KeyAlarmName contextKey = "alarm_name"
 )
 
-
 type logFormat int
-
 
 const (
 	TextFormat logFormat = iota
 	JSONFormat
 )
-
 
 const (
 	DEBUG LogLevel = iota
@@ -66,7 +54,6 @@ const (
 var (
 	logLevel = DEBUG
 
-
 	longFilePath = false
 
 	mu           sync.Mutex
@@ -74,7 +61,6 @@ var (
 	logQueueSize = 10000
 	logQueue     = make(chan *logValue, logQueueSize)
 )
-
 
 type Logger struct {
 	name         string
@@ -84,9 +70,7 @@ type Logger struct {
 	mu           sync.Mutex
 	entryPool    sync.Pool
 	customFields Fields
-
 }
-
 
 type LogLevel uint8
 
@@ -104,7 +88,6 @@ func init() {
 	go flushLog(true)
 }
 
-
 func (lv *LogLevel) String() string {
 	switch *lv {
 	case DEBUG:
@@ -121,7 +104,6 @@ func (lv *LogLevel) String() string {
 		return "UNKNOWN"
 	}
 }
-
 
 func GetLogger(name string) *Logger {
 	mu.Lock()
@@ -141,32 +123,25 @@ func GetLogger(name string) *Logger {
 	return lg
 }
 
-
 func SetLevel(level LogLevel) {
 	logLevel = level
 }
-
 
 func GetLevel() LogLevel {
 	return logLevel
 }
 
-
 func SetSkipCallerDepth(depth int) {
 	skipCallerDepth = depth
 }
-
 
 func SetCallerPrettyfier(f func(*runtime.Frame) (file string)) {
 	CallerPrettyfier = f
 }
 
-
-
 func EnableLongFilePath() {
 	longFilePath = true
 }
-
 
 func StringToLevel(level string) LogLevel {
 	switch level {
@@ -185,21 +160,17 @@ func StringToLevel(level string) LogLevel {
 	}
 }
 
-
 func (logger *Logger) SetLogName(name string) {
 	logger.name = name
 }
-
 
 func (logger *Logger) SetLogFormat(format logFormat) {
 	logger.format = format
 }
 
-
 func (logger *Logger) EnableFileLog() {
 	logger.debug = true
 }
-
 
 func (logger *Logger) SetFileRoller(logpath string, num int, sizeMB int) error {
 	if err := os.MkdirAll(logpath, 0755); err != nil {
@@ -210,7 +181,6 @@ func (logger *Logger) SetFileRoller(logpath string, num int, sizeMB int) error {
 	return nil
 }
 
-
 func (logger *Logger) IsConsoleWriter() bool {
 	if reflect.TypeOf(logger.writer) == reflect.TypeOf(&ConsoleWriter{}) {
 		return true
@@ -218,11 +188,9 @@ func (logger *Logger) IsConsoleWriter() bool {
 	return false
 }
 
-
 func (logger *Logger) SetOutput(w io.Writer) {
 	logger.writer = w
 }
-
 
 func (logger *Logger) SetDayRoller(logpath string, num int) error {
 	if err := os.MkdirAll(logpath, 0755); err != nil {
@@ -233,7 +201,6 @@ func (logger *Logger) SetDayRoller(logpath string, num int) error {
 	return nil
 }
 
-
 func (logger *Logger) SetHourRoller(logpath string, num int) error {
 	if err := os.MkdirAll(logpath, 0755); err != nil {
 		return err
@@ -243,11 +210,9 @@ func (logger *Logger) SetHourRoller(logpath string, num int) error {
 	return nil
 }
 
-
 func (logger *Logger) SetConsole() {
 	logger.writer = &ConsoleWriter{}
 }
-
 
 func (logger *Logger) SetCustomFields(fields Fields) {
 	logger.mu.Lock()
@@ -255,19 +220,16 @@ func (logger *Logger) SetCustomFields(fields Fields) {
 	logger.customFields = fields
 }
 
-
 func (logger *Logger) GetCustomFields() Fields {
 	logger.mu.Lock()
 	defer logger.mu.Unlock()
 	return logger.customFields
 }
 
-
 func (logger *Logger) WithContext(ctx context.Context) *Entry {
 	e := logger.newEntry()
 	defer logger.releaseEntry(e)
 	entry := e.WithContext(ctx)
-
 
 	if logger.customFields != nil && len(logger.customFields) > 0 {
 		entry = entry.WithFields(logger.customFields)
@@ -276,11 +238,9 @@ func (logger *Logger) WithContext(ctx context.Context) *Entry {
 	return entry
 }
 
-
 func (logger *Logger) WithFields(fields Fields) *Entry {
 	e := logger.newEntry()
 	defer logger.releaseEntry(e)
-
 
 	if logger.customFields != nil && len(logger.customFields) > 0 {
 		mergedFields := make(Fields, len(logger.customFields)+len(fields))
@@ -300,7 +260,6 @@ func (logger *Logger) writef(ctx context.Context, level LogLevel, format string,
 	e := logger.newEntry()
 	defer logger.releaseEntry(e)
 
-
 	if logger.customFields != nil && len(logger.customFields) > 0 {
 		e = e.WithFields(logger.customFields)
 	}
@@ -308,57 +267,45 @@ func (logger *Logger) writef(ctx context.Context, level LogLevel, format string,
 	e.writef(ctx, level, format, v)
 }
 
-
 func (logger *Logger) Debug(v ...interface{}) {
 	logger.writef(context.TODO(), DEBUG, "", v)
 }
-
 
 func (logger *Logger) Info(v ...interface{}) {
 	logger.writef(context.TODO(), INFO, "", v)
 }
 
-
 func (logger *Logger) Warn(v ...interface{}) {
 	logger.writef(context.TODO(), WARN, "", v)
 }
-
 
 func (logger *Logger) Error(v ...interface{}) {
 	logger.writef(context.TODO(), ERROR, "", v)
 }
 
-
 func (logger *Logger) Fatal(v ...interface{}) {
 	logger.writef(context.TODO(), FATAL, "", v)
 }
-
 
 func (logger *Logger) Debugf(format string, v ...interface{}) {
 	logger.writef(context.TODO(), DEBUG, format, v)
 }
 
-
 func (logger *Logger) Infof(format string, v ...interface{}) {
 	logger.writef(context.TODO(), INFO, format, v)
 }
-
 
 func (logger *Logger) Warnf(format string, v ...interface{}) {
 	logger.writef(context.TODO(), WARN, format, v)
 }
 
-
 func (logger *Logger) Errorf(format string, v ...interface{}) {
 	logger.writef(context.TODO(), ERROR, format, v)
 }
 
-
 func (logger *Logger) Fatalf(format string, v ...interface{}) {
 	logger.writef(context.TODO(), FATAL, format, v)
 }
-
-
 
 func getPackageName(f string) string {
 	for {
@@ -374,9 +321,6 @@ func getPackageName(f string) string {
 	return f
 }
 
-
-
-
 func (logger *Logger) newEntry() *Entry {
 	entry, ok := logger.entryPool.Get().(*Entry)
 	if ok {
@@ -389,7 +333,6 @@ func (logger *Logger) releaseEntry(entry *Entry) {
 	entry.data = map[string]interface{}{}
 	logger.entryPool.Put(entry)
 }
-
 
 func (l *Logger) WriteLog(msg []byte) {
 	select {
@@ -408,12 +351,6 @@ func flushLog(sync bool) {
 		for {
 			select {
 			case v := <-logQueue:
-
-
-
-
-
-
 
 				v.logger.writer.Write(v.value)
 				continue

--- a/cubelog/logger_test.go
+++ b/cubelog/logger_test.go
@@ -20,7 +20,6 @@ func makeLogContext() context.Context {
 	return ctx
 }
 
-
 func BenchmarkLogger_Infof(b *testing.B) {
 	ctx := makeLogContext()
 

--- a/cubelog/logwriter.go
+++ b/cubelog/logwriter.go
@@ -13,16 +13,13 @@ import (
 	"time"
 )
 
-
 const (
 	DAY DateType = iota
 	HOUR
 )
 
-
 type ConsoleWriter struct {
 }
-
 
 type RollFileWriter struct {
 	logpath  string
@@ -33,7 +30,6 @@ type RollFileWriter struct {
 	currFile *os.File
 	openTime int64
 }
-
 
 type DateWriter struct {
 	logpath   string
@@ -46,10 +42,8 @@ type DateWriter struct {
 	hasPrefix bool
 }
 
-
 type HourWriter struct {
 }
-
 
 type DateType uint8
 
@@ -66,11 +60,9 @@ func reOpenFile(path string, currFile **os.File, openTime *int64) {
 	}
 }
 
-
 func (w *ConsoleWriter) Write(v []byte) (int, error) {
 	return os.Stdout.Write(v)
 }
-
 
 func (w *RollFileWriter) Write(v []byte) (int, error) {
 	if w.currFile == nil || w.openTime+10 < currUnixTime {
@@ -109,7 +101,6 @@ func (w *RollFileWriter) Write(v []byte) (int, error) {
 	return n, nil
 }
 
-
 func NewRollFileWriter(logpath, name string, num, sizeMB int) *RollFileWriter {
 	w := &RollFileWriter{
 		logpath: logpath,
@@ -124,7 +115,6 @@ func NewRollFileWriter(logpath, name string, num, sizeMB int) *RollFileWriter {
 	}
 	return w
 }
-
 
 func (w *DateWriter) Write(v []byte) (int, error) {
 	if w.currFile == nil || w.openTime+10 < currUnixTime {
@@ -146,7 +136,6 @@ func (w *DateWriter) Write(v []byte) (int, error) {
 	n, _ := w.currFile.Write(v)
 	return n, nil
 }
-
 
 func NewDateWriter(logpath, name string, dateType DateType, num int) *DateWriter {
 	w := &DateWriter{

--- a/cubelog/metric.go
+++ b/cubelog/metric.go
@@ -14,12 +14,10 @@ import (
 )
 
 var (
-
 	enableLogMetric = false
 
 	traceStd *Logger
 )
-
 
 type RequestTrace struct {
 	DestID         int64
@@ -56,13 +54,11 @@ type RequestTrace struct {
 	InstanceType   string
 }
 
-
 func (rt *RequestTrace) DeepCopy() *RequestTrace {
 	o := new(RequestTrace)
 	*o = *rt
 	return o
 }
-
 
 func (rt *RequestTrace) WithCallee(callee string) *RequestTrace {
 	rt.Callee = callee
@@ -181,8 +177,6 @@ func init() {
 
 }
 
-
-
 func Trace(trace *RequestTrace) {
 	cost := float64(trace.Cost.Nanoseconds()/1000) / 1000
 
@@ -199,52 +193,9 @@ func Trace(trace *RequestTrace) {
 		version = moduleVersion
 	}
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 	if enableLogMetric {
 		fields := makeLogFieldsFromTrace(trace)
 		fields["CostTime"] = cost
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 
 		if traceStd.writer != nil {
 			traceStd.WithFields(fields).Errorf("")
@@ -254,19 +205,13 @@ func Trace(trace *RequestTrace) {
 	}
 }
 
-
-
-
-
 func EnableLogMetric() {
 	enableLogMetric = true
 }
 
-
 func DisableLogMetric() {
 	enableLogMetric = false
 }
-
 
 func SetTraceOutput(w io.Writer) {
 	traceStd.writer = w

--- a/cubelog/time.go
+++ b/cubelog/time.go
@@ -7,7 +7,6 @@ package CubeLog
 import "time"
 
 var (
-
 	currUnixTime int64
 	currDateTime string
 	currDateHour string

--- a/hypervisor/Makefile
+++ b/hypervisor/Makefile
@@ -1,0 +1,4 @@
+.PHONY: fmt
+
+fmt:
+	cargo fmt

--- a/network-agent/Makefile
+++ b/network-agent/Makefile
@@ -29,12 +29,16 @@ LDFLAGS := -ldflags "-s -w \
 
 export PATH := $(GO_BIN_DIR):$(PATH)
 
-.PHONY: build proto test clean check-proto-tools sync-client-proto
+.PHONY: build fmt proto test clean check-proto-tools sync-client-proto
 
 build:
 	$(call msg,Build app,$(APP))
 	$(Q)mkdir -p "$(BUILD_DIR)"
 	$(Q)go build $(LDFLAGS) -o "$(BUILD_DIR)/$(APP)" ./cmd/$(APP)
+
+fmt:
+	$(call msg,Format code,$(APP))
+	$(Q)go fmt ./...
 
 check-proto-tools:
 	@command -v protoc >/dev/null 2>&1 || { echo "error: protoc not installed"; exit 1; }

--- a/network-agent/cmd/network-agent/main_test.go
+++ b/network-agent/cmd/network-agent/main_test.go
@@ -87,4 +87,3 @@ func TestInitServiceRejectsNilFactoryResult(t *testing.T) {
 		})
 	}
 }
-

--- a/network-agent/internal/cubeegress/client_test.go
+++ b/network-agent/internal/cubeegress/client_test.go
@@ -212,4 +212,3 @@ func TestClientHonorsContextDeadline(t *testing.T) {
 		t.Fatalf("elapsed=%s; deadline was 50ms", elapsed)
 	}
 }
-

--- a/network-agent/internal/service/state_store.go
+++ b/network-agent/internal/service/state_store.go
@@ -37,18 +37,18 @@ type persistedState struct {
 //
 // Drop the legacy field one release after this lands.
 type persistedStateOnDisk struct {
-	SandboxID             string             `json:"sandboxID"`
-	NetworkHandle         string             `json:"networkHandle"`
-	TapName               string             `json:"tapName"`
-	TapIfIndex            int                `json:"tapIfIndex"`
-	SandboxIP             string             `json:"sandboxIP"`
-	Interfaces            []Interface        `json:"interfaces"`
-	Routes                []Route            `json:"routes"`
-	ARPNeighbors          []ARPNeighbor      `json:"arpNeighbors"`
-	PortMappings          []PortMapping      `json:"portMappings"`
-	CubeNetworkConfig     *CubeNetworkConfig `json:"cubeNetworkConfig,omitempty"`
-	LegacyCubeVSContext   *CubeNetworkConfig `json:"cubevsContext,omitempty"` // TODO: remove after one release
-	PersistMetadata       map[string]string  `json:"persistMetadata"`
+	SandboxID           string             `json:"sandboxID"`
+	NetworkHandle       string             `json:"networkHandle"`
+	TapName             string             `json:"tapName"`
+	TapIfIndex          int                `json:"tapIfIndex"`
+	SandboxIP           string             `json:"sandboxIP"`
+	Interfaces          []Interface        `json:"interfaces"`
+	Routes              []Route            `json:"routes"`
+	ARPNeighbors        []ARPNeighbor      `json:"arpNeighbors"`
+	PortMappings        []PortMapping      `json:"portMappings"`
+	CubeNetworkConfig   *CubeNetworkConfig `json:"cubeNetworkConfig,omitempty"`
+	LegacyCubeVSContext *CubeNetworkConfig `json:"cubevsContext,omitempty"` // TODO: remove after one release
+	PersistMetadata     map[string]string  `json:"persistMetadata"`
 }
 
 func (s *persistedState) MarshalJSON() ([]byte, error) {


### PR DESCRIPTION
- Add fmt target to agent/Cubelet/CubeMaster/CubeShim/network-agent/cubelog Makefiles
- Create minimal Makefiles with fmt target for CubeAPI/cubecow/hypervisor
- Add top-level make fmt that iterates over all component directories
- Add CI workflow (.github/workflows/fmt-check.yml) for format checking on PRs