### PR TITLE
feat(CubeMaster): configurable overcommit ratio and ignore Redis allo…

### DIFF
--- a/CubeMaster/conf.yaml
+++ b/CubeMaster/conf.yaml
@@ -97,6 +97,24 @@ scheduler:
   priority_select_num: 1
   metric_update_timeout: 300s
   local_metric_update_timeout: 300s
+  # Whether to ignore the per-node allocated CPU/Mem usage recorded in Redis
+  # during scheduling. Defaults to false: account for the Redis allocation
+  # records when computing schedulable capacity.
+  ignore_redis_allocation: false
+  # Global CPU/Mem overcommit ratio applied to the node-reported quota capacity.
+  # Defaults to CPU=3, Mem=2.
+  overcommit_ratio:
+    cpu_ratio: 3.0
+    mem_ratio: 2.0
+  # Per-instance-type overcommit ratio (takes precedence over the global
+  # overcommit_ratio).
+  # overcommit_ratio_conf:
+  #   cubebox:
+  #     cpu_ratio: 6.0
+  #     mem_ratio: 4.0
+  #   cubebox_gpu:
+  #     cpu_ratio: 1.0
+  #     mem_ratio: 1.0
   filter:
     enable_filters:
       - "cpu"

--- a/CubeMaster/pkg/base/config/config.go
+++ b/CubeMaster/pkg/base/config/config.go
@@ -173,6 +173,121 @@ type SchedulerConf struct {
 	DisableBackoffFilterInstanceType map[string]bool                   `yaml:"disable_backoff_filter_instance_type"`
 	ThirtpartyFilterInstanceType     map[string]bool                   `yaml:"thirtparty_filter_instance_type"`
 	InstanceTypeConf                 map[string]InstanceTypeConf       `yaml:"instance_type_conf"`
+
+	// IgnoreRedisAllocation, when true, makes the scheduler ignore the
+	// per-node allocated CPU/Mem usage recorded in Redis (treat allocated as
+	// 0). A pointer is used so an unset value can default to false while still
+	// allowing operators to explicitly enable it. Defaults to false.
+	IgnoreRedisAllocation *bool `yaml:"ignore_redis_allocation"`
+	// OvercommitRatio is the global CPU/Mem overcommit ratio applied to the
+	// node-reported quota during scheduling. Defaults to CPU=3, Mem=2.
+	OvercommitRatio *OvercommitRatioConf `yaml:"overcommit_ratio"`
+	// OvercommitRatioByType overrides OvercommitRatio for specific instance
+	// types and takes precedence over the global ratio.
+	OvercommitRatioByType map[string]OvercommitRatioConf `yaml:"overcommit_ratio_conf"`
+}
+
+// OvercommitRatioConf describes the CPU/Mem overcommit multipliers applied to
+// a node's reported quota when computing schedulable capacity.
+type OvercommitRatioConf struct {
+	CPURatio float64 `yaml:"cpu_ratio"`
+	MemRatio float64 `yaml:"mem_ratio"`
+}
+
+const (
+	defaultCPUOvercommitRatio = 3.0
+	defaultMemOvercommitRatio = 2.0
+)
+
+// GetEffectiveOvercommitRatio returns the overcommit ratio for the given
+// instance type, falling back to the global ratio and then to the built-in
+// defaults (CPU=3, Mem=2).
+func (s *SchedulerConf) GetEffectiveOvercommitRatio(instanceType string) OvercommitRatioConf {
+	if s.OvercommitRatioByType != nil {
+		if v, ok := s.OvercommitRatioByType[instanceType]; ok {
+			return v.sanitized()
+		}
+	}
+	if s.OvercommitRatio != nil {
+		return s.OvercommitRatio.sanitized()
+	}
+	return OvercommitRatioConf{CPURatio: defaultCPUOvercommitRatio, MemRatio: defaultMemOvercommitRatio}
+}
+
+// sanitized guarantees non-positive, NaN, or infinite ratios fall back to the
+// defaults so a malformed config never shrinks a node's schedulable capacity to
+// zero or produces a garbage (NaN/Inf) capacity when multiplied with the quota.
+func (c OvercommitRatioConf) sanitized() OvercommitRatioConf {
+	out := c
+	if !isValidRatio(out.CPURatio) {
+		out.CPURatio = defaultCPUOvercommitRatio
+	}
+	if !isValidRatio(out.MemRatio) {
+		out.MemRatio = defaultMemOvercommitRatio
+	}
+	return out
+}
+
+// isValidRatio reports whether r is a usable overcommit multiplier: it must be
+// a finite, positive number. NaN and ±Inf (e.g. ".nan"/".inf" in YAML) are
+// rejected so they never propagate into capacity arithmetic.
+func isValidRatio(r float64) bool {
+	if math.IsNaN(r) || math.IsInf(r, 0) {
+		return false
+	}
+	return r > 0
+}
+
+// ShouldIgnoreRedisAllocation reports whether the scheduler must ignore the
+// allocated CPU/Mem usage recorded in Redis. Defaults to false when unset.
+func (s *SchedulerConf) ShouldIgnoreRedisAllocation() bool {
+	if s.IgnoreRedisAllocation == nil {
+		return false
+	}
+	return *s.IgnoreRedisAllocation
+}
+
+// EffectiveQuotaCpu returns the schedulable CPU capacity (milli-cores) for a
+// node after applying the configured overcommit ratio to its reported quota.
+func (s *SchedulerConf) EffectiveQuotaCpu(instanceType string, quotaCpu int64) int64 {
+	ratio := s.GetEffectiveOvercommitRatio(instanceType)
+	return floatToInt64Clamped(float64(quotaCpu) * ratio.CPURatio)
+}
+
+// EffectiveQuotaMem returns the schedulable memory capacity (MB) for a node
+// after applying the configured overcommit ratio to its reported quota.
+func (s *SchedulerConf) EffectiveQuotaMem(instanceType string, quotaMem int64) int64 {
+	ratio := s.GetEffectiveOvercommitRatio(instanceType)
+	return floatToInt64Clamped(float64(quotaMem) * ratio.MemRatio)
+}
+
+// floatToInt64Clamped safely converts a float64 to int64. Converting an
+// out-of-range or non-finite float64 to int64 is implementation-defined in Go
+// and yields a garbage value, so NaN maps to 0 and values beyond the int64
+// range (including ±Inf) are clamped to math.MaxInt64 / math.MinInt64. This
+// guards capacity computation against quota * ratio overflowing int64.
+func floatToInt64Clamped(f float64) int64 {
+	if math.IsNaN(f) {
+		return 0
+	}
+	// float64(math.MaxInt64) rounds up to 2^63, so use >= to treat the
+	// boundary and any larger value (incl. +Inf) as overflow.
+	if f >= float64(math.MaxInt64) {
+		return math.MaxInt64
+	}
+	if f <= float64(math.MinInt64) {
+		return math.MinInt64
+	}
+	return int64(f)
+}
+
+// EffectiveAllocated returns the allocated usage the scheduler should account
+// for, which is 0 when Redis allocation records are ignored.
+func (s *SchedulerConf) EffectiveAllocated(usage int64) int64 {
+	if s.ShouldIgnoreRedisAllocation() {
+		return 0
+	}
+	return usage
 }
 
 type WrapperSchedulerConf struct {
@@ -733,6 +848,29 @@ func preHandleScheduler(config *Config) error {
 	}
 
 	preHandOverhead(config)
+
+	// Account for Redis allocation records during scheduling by default.
+	if config.Scheduler.IgnoreRedisAllocation == nil {
+		ignore := false
+		config.Scheduler.IgnoreRedisAllocation = &ignore
+	}
+	// Default overcommit ratio: CPU=3, Mem=2. sanitized() guards against
+	// non-positive, NaN, or infinite values supplied by operators.
+	if config.Scheduler.OvercommitRatio == nil {
+		config.Scheduler.OvercommitRatio = &OvercommitRatioConf{
+			CPURatio: defaultCPUOvercommitRatio,
+			MemRatio: defaultMemOvercommitRatio,
+		}
+	} else {
+		sanitized := config.Scheduler.OvercommitRatio.sanitized()
+		config.Scheduler.OvercommitRatio = &sanitized
+	}
+	// Sanitize per-instance-type overrides at init time as well so malformed
+	// (non-positive/NaN/Inf) ratios are normalized once up front rather than
+	// relying solely on the lazy sanitize in GetEffectiveOvercommitRatio.
+	for k, v := range config.Scheduler.OvercommitRatioByType {
+		config.Scheduler.OvercommitRatioByType[k] = v.sanitized()
+	}
 
 	if config.Scheduler.NodeMaxMvmNum == 0 {
 		config.Scheduler.NodeMaxMvmNum = 3000

--- a/CubeMaster/pkg/base/config/config_test.go
+++ b/CubeMaster/pkg/base/config/config_test.go
@@ -7,6 +7,7 @@ package config
 
 import (
 	"fmt"
+	"math"
 	"os"
 	"path/filepath"
 	"testing"
@@ -64,4 +65,141 @@ func TestGetEffectiveNodeMaxMemReservedInMBKeepsConfiguredValue(t *testing.T) {
 
 	got := sconf.GetEffectiveNodeMaxMemReservedInMB("cubebox", 9450)
 	assert.Equal(t, int64(512), got)
+}
+
+func TestPreHandleSchedulerOvercommitAndIgnoreDefaults(t *testing.T) {
+	cfg := &Config{Scheduler: &WrapperSchedulerConf{}}
+	err := preHandleScheduler(cfg)
+	assert.NoError(t, err)
+
+	assert.NotNil(t, cfg.Scheduler.IgnoreRedisAllocation)
+	assert.False(t, cfg.Scheduler.ShouldIgnoreRedisAllocation())
+
+	ratio := cfg.Scheduler.GetEffectiveOvercommitRatio("cubebox")
+	assert.Equal(t, 3.0, ratio.CPURatio)
+	assert.Equal(t, 2.0, ratio.MemRatio)
+}
+
+func TestGetEffectiveOvercommitRatioPrecedence(t *testing.T) {
+	sconf := &SchedulerConf{
+		OvercommitRatio: &OvercommitRatioConf{CPURatio: 6.0, MemRatio: 4.0},
+		OvercommitRatioByType: map[string]OvercommitRatioConf{
+			"cubebox_gpu": {CPURatio: 1.0, MemRatio: 1.0},
+		},
+	}
+
+	// per-type override wins
+	gpu := sconf.GetEffectiveOvercommitRatio("cubebox_gpu")
+	assert.Equal(t, 1.0, gpu.CPURatio)
+	assert.Equal(t, 1.0, gpu.MemRatio)
+
+	// fall back to global ratio
+	other := sconf.GetEffectiveOvercommitRatio("cubebox")
+	assert.Equal(t, 6.0, other.CPURatio)
+	assert.Equal(t, 4.0, other.MemRatio)
+
+	// fall back to built-in default when nothing configured
+	empty := &SchedulerConf{}
+	def := empty.GetEffectiveOvercommitRatio("cubebox")
+	assert.Equal(t, 3.0, def.CPURatio)
+	assert.Equal(t, 2.0, def.MemRatio)
+}
+
+func TestEffectiveQuotaAndAllocated(t *testing.T) {
+	ignore := false
+	sconf := &SchedulerConf{
+		IgnoreRedisAllocation: &ignore,
+		OvercommitRatio:       &OvercommitRatioConf{CPURatio: 6.0, MemRatio: 4.0},
+	}
+
+	assert.Equal(t, int64(48000), sconf.EffectiveQuotaCpu("cubebox", 8000))
+	assert.Equal(t, int64(64000), sconf.EffectiveQuotaMem("cubebox", 16000))
+	// allocation kept when not ignoring
+	assert.Equal(t, int64(1234), sconf.EffectiveAllocated(1234))
+
+	// allocation kept by default (not ignoring)
+	defaultConf := &SchedulerConf{}
+	assert.Equal(t, int64(1234), defaultConf.EffectiveAllocated(1234))
+
+	// allocation zeroed when explicitly ignoring
+	ignoreTrue := true
+	ignoring := &SchedulerConf{IgnoreRedisAllocation: &ignoreTrue}
+	assert.Equal(t, int64(0), ignoring.EffectiveAllocated(1234))
+}
+
+func TestOvercommitRatioSanitizesNonPositive(t *testing.T) {
+	sconf := &SchedulerConf{
+		OvercommitRatio: &OvercommitRatioConf{CPURatio: 0, MemRatio: -1},
+	}
+	ratio := sconf.GetEffectiveOvercommitRatio("cubebox")
+	assert.Equal(t, 3.0, ratio.CPURatio)
+	assert.Equal(t, 2.0, ratio.MemRatio)
+}
+
+func TestOvercommitRatioSanitizesNaNAndInf(t *testing.T) {
+	cases := []OvercommitRatioConf{
+		{CPURatio: math.NaN(), MemRatio: math.NaN()},
+		{CPURatio: math.Inf(1), MemRatio: math.Inf(1)},
+		{CPURatio: math.Inf(-1), MemRatio: math.Inf(-1)},
+	}
+	for _, c := range cases {
+		sconf := &SchedulerConf{OvercommitRatio: &c}
+		ratio := sconf.GetEffectiveOvercommitRatio("cubebox")
+		assert.Equal(t, 3.0, ratio.CPURatio)
+		assert.Equal(t, 2.0, ratio.MemRatio)
+
+		// capacity arithmetic must stay finite after sanitizing
+		assert.Equal(t, int64(24000), sconf.EffectiveQuotaCpu("cubebox", 8000))
+		assert.Equal(t, int64(32000), sconf.EffectiveQuotaMem("cubebox", 16000))
+	}
+}
+
+func TestPreHandleSchedulerSanitizesPerTypeRatios(t *testing.T) {
+	cfg := &Config{Scheduler: &WrapperSchedulerConf{
+		SchedulerConf: SchedulerConf{
+			OvercommitRatioByType: map[string]OvercommitRatioConf{
+				"bad_zero": {CPURatio: 0, MemRatio: -1},
+				"bad_nan":  {CPURatio: math.NaN(), MemRatio: math.Inf(1)},
+				"good":     {CPURatio: 8, MemRatio: 5},
+			},
+		},
+	}}
+	err := preHandleScheduler(cfg)
+	assert.NoError(t, err)
+
+	// malformed per-type ratios are normalized to defaults at init time
+	bz := cfg.Scheduler.OvercommitRatioByType["bad_zero"]
+	assert.Equal(t, 3.0, bz.CPURatio)
+	assert.Equal(t, 2.0, bz.MemRatio)
+
+	bn := cfg.Scheduler.OvercommitRatioByType["bad_nan"]
+	assert.Equal(t, 3.0, bn.CPURatio)
+	assert.Equal(t, 2.0, bn.MemRatio)
+
+	// valid per-type ratios are preserved
+	g := cfg.Scheduler.OvercommitRatioByType["good"]
+	assert.Equal(t, 8.0, g.CPURatio)
+	assert.Equal(t, 5.0, g.MemRatio)
+}
+
+func TestFloatToInt64Clamped(t *testing.T) {
+	assert.Equal(t, int64(0), floatToInt64Clamped(math.NaN()))
+	assert.Equal(t, int64(math.MaxInt64), floatToInt64Clamped(math.Inf(1)))
+	assert.Equal(t, int64(math.MinInt64), floatToInt64Clamped(math.Inf(-1)))
+	// overflow beyond int64 range clamps instead of wrapping to garbage
+	assert.Equal(t, int64(math.MaxInt64), floatToInt64Clamped(1e30))
+	assert.Equal(t, int64(math.MinInt64), floatToInt64Clamped(-1e30))
+	// normal values convert (truncate toward zero) as usual
+	assert.Equal(t, int64(42), floatToInt64Clamped(42.9))
+	assert.Equal(t, int64(0), floatToInt64Clamped(0))
+}
+
+func TestEffectiveQuotaClampsOverflow(t *testing.T) {
+	// A huge quota combined with a large overcommit ratio must not wrap to a
+	// garbage int64; it clamps to MaxInt64 instead.
+	sconf := &SchedulerConf{
+		OvercommitRatio: &OvercommitRatioConf{CPURatio: 1e6, MemRatio: 1e6},
+	}
+	assert.Equal(t, int64(math.MaxInt64), sconf.EffectiveQuotaCpu("cubebox", math.MaxInt64))
+	assert.Equal(t, int64(math.MaxInt64), sconf.EffectiveQuotaMem("cubebox", math.MaxInt64))
 }

--- a/CubeMaster/pkg/selector/filter/cpufilter.go
+++ b/CubeMaster/pkg/selector/filter/cpufilter.go
@@ -40,7 +40,8 @@ func (l *cpuFilter) Select(selCtx *selctx.SelectorCtx) (node.NodeList, error) {
 	nodes := make(node.NodeList, 0, inList.Len())
 	for i := range inList {
 
-		quotaCpuFree := inList[i].QuotaCpu - inList[i].QuotaCpuUsage
+		quotaCpuFree := sconf.EffectiveQuotaCpu(inList[i].InstanceType, inList[i].QuotaCpu) -
+			sconf.EffectiveAllocated(inList[i].QuotaCpuUsage)
 		if quotaCpuFree <= cpuq.MilliValue() {
 			log.G(selCtx.Ctx).Warnf("%v select:%v, quotaCpuFree:%v, cpuq:%v",
 				l.ID(), inList[i].ID(), quotaCpuFree, cpuq.MilliValue())

--- a/CubeMaster/pkg/selector/filter/memfilter.go
+++ b/CubeMaster/pkg/selector/filter/memfilter.go
@@ -38,7 +38,8 @@ func (l *memFilter) Select(selCtx *selctx.SelectorCtx) (node.NodeList, error) {
 	inList := selCtx.Nodes()
 	nodes := make(node.NodeList, 0, inList.Len())
 	for i := range inList {
-		quotaMemFree := inList[i].QuotaMem - inList[i].QuotaMemUsage
+		quotaMemFree := sconf.EffectiveQuotaMem(inList[i].InstanceType, inList[i].QuotaMem) -
+			sconf.EffectiveAllocated(inList[i].QuotaMemUsage)
 
 		if quotaMemFree <= memq.Value()/1024/1024 {
 			log.G(selCtx.Ctx).Warnf("%v select:%v, quotaMemFree:%v, memq:%v",

--- a/CubeMaster/pkg/selector/score/realtimescore.go
+++ b/CubeMaster/pkg/selector/score/realtimescore.go
@@ -89,7 +89,11 @@ func (l *realTimeWeightedAverageScore) Select(selCtx *selctx.SelectorCtx) (nodes
 }
 
 func getRealTimeTotalWeight() (float64, error) {
-	sconf := config.GetConfig().Scheduler.Score.ScorePluginConf.RealTimeWeightedAverage
+	schedConf := config.GetConfig().Scheduler
+	if schedConf == nil || schedConf.Score == nil {
+		return 0, errors.New("scheduler score conf is nil")
+	}
+	sconf := schedConf.Score.ScorePluginConf.RealTimeWeightedAverage
 	if sconf == nil {
 		return 0, errors.New("RealTime conf is nil")
 	}
@@ -101,7 +105,11 @@ func getRealTimeTotalWeight() (float64, error) {
 }
 
 func getRealtimeWeightedAverageScore(n *node.Node, cpuq, memq *resource.Quantity) float64 {
-	sconf := config.GetConfig().Scheduler.Score.ScorePluginConf.RealTimeWeightedAverage
+	schedConf := config.GetConfig().Scheduler
+	if schedConf == nil || schedConf.Score == nil {
+		return 0
+	}
+	sconf := schedConf.Score.ScorePluginConf.RealTimeWeightedAverage
 	if sconf == nil {
 		return 0
 	}
@@ -111,14 +119,16 @@ func getRealtimeWeightedAverageScore(n *node.Node, cpuq, memq *resource.Quantity
 	if cpuq != nil {
 
 		cpuReqValue := cpuq.MilliValue()
-		cpuLeft := getReciprocal(n.QuotaCpu-n.QuotaCpuUsage-cpuReqValue, n.QuotaCpu)
+		effCpu := schedConf.EffectiveQuotaCpu(n.InstanceType, n.QuotaCpu)
+		cpuLeft := getReciprocal(effCpu-schedConf.EffectiveAllocated(n.QuotaCpuUsage)-cpuReqValue, effCpu)
 		scores += cpuLeft * getFactorWeight(constants.WeightFactorReqCpu)
 	}
 
 	if memq != nil {
 
 		memReqValue := memq.Value() / 1024 / 1024
-		memLeft := getReciprocal(n.QuotaMem-n.QuotaMemUsage-memReqValue, n.QuotaMem)
+		effMem := schedConf.EffectiveQuotaMem(n.InstanceType, n.QuotaMem)
+		memLeft := getReciprocal(effMem-schedConf.EffectiveAllocated(n.QuotaMemUsage)-memReqValue, effMem)
 		scores += memLeft * getFactorWeight(constants.WeightFactorReqMem)
 	}
 	return scores

--- a/CubeMaster/pkg/selector/score/utils.go
+++ b/CubeMaster/pkg/selector/score/utils.go
@@ -61,7 +61,7 @@ func getReciprocal(v int64, base int64) float64 {
 
 func getFactorWeight(k string) float64 {
 	sconf := config.GetConfig().Scheduler
-	if sconf == nil {
+	if sconf == nil || sconf.Score == nil {
 		return 0.0
 	}
 	v, ok := sconf.Score.ResourceWeights[k]
@@ -103,16 +103,29 @@ func getMvmNumScore(n *node.Node) float64 {
 }
 
 func getQuotaCpuUsageScore(n *node.Node) float64 {
-	if n.QuotaCpu <= 0 {
+	sconf := config.GetConfig().Scheduler
+	if sconf == nil {
+		return 0.0
+	}
+	effCpu := sconf.EffectiveQuotaCpu(n.InstanceType, n.QuotaCpu)
+	if effCpu <= 0 {
 
 		return 0.0
 	}
-	f := getReciprocal(n.QuotaCpuUsage, n.QuotaCpu)
+	f := getReciprocal(sconf.EffectiveAllocated(n.QuotaCpuUsage), effCpu)
 	return 100.0 - f*100.0
 }
 
 func getQuotaMemMbUsageScore(n *node.Node) float64 {
-	f := getReciprocal(n.QuotaMemUsage, n.QuotaMem)
+	sconf := config.GetConfig().Scheduler
+	if sconf == nil {
+		return 0.0
+	}
+	effMem := sconf.EffectiveQuotaMem(n.InstanceType, n.QuotaMem)
+	if effMem <= 0 {
+		return 0.0
+	}
+	f := getReciprocal(sconf.EffectiveAllocated(n.QuotaMemUsage), effMem)
 	return 100.0 - f*100.0
 }
 


### PR DESCRIPTION
…cation in scheduling

Sandbox scheduling previously sized each node's schedulable CPU/Mem from the node-reported quota minus the per-node allocated usage recorded in Redis, with no way to overcommit or to opt out of the Redis allocation records. This made it hard to densify placement without editing node-side factors.

Add two scheduler config knobs and wire them through the filter and score plugins so capacity is computed consistently:

- ignore_redis_allocation (default false): treat the Redis-recorded allocated CPU/Mem as 0 during scheduling.
- overcommit_ratio (default CPU=3, Mem=2) with optional per-instance-type overrides via overcommit_ratio_conf, applied to the node-reported quota.

Helper methods default unset values, sanitize non-positive ratios back to the defaults, and keep filter and score plugins aligned. Physical load guards (CPU util ceiling, real-time free memory) are intentionally left untouched to avoid scheduling onto truly overloaded nodes.

Assisted-by: CodeBuddy
Signed-off-by: Feng Jin(ronyjin@tencent.com)