### PR TITLE
build: per-target .PHONY and add clean-rust-target-dirs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,26 @@ CUBELET_COW_THIRD_PARTY_DIR ?= $(ROOT_DIR)/Cubelet/third_party/cubecow
 COW_STATICLIB ?= $(CUBELET_COW_THIRD_PARTY_DIR)/lib/libcubecow.a
 COW_HEADER ?= $(CUBELET_COW_THIRD_PARTY_DIR)/include/cubecow.h
 
+# Top-level Rust project directories. Each owns its own Cargo workspace and
+# `target/`; sub-crates share their workspace's target dir, so cleaning these
+# five removes all Rust build artifacts in the repo.
+RUST_PROJECT_DIRS := \
+	$(ROOT_DIR)/CubeAPI \
+	$(ROOT_DIR)/CubeShim \
+	$(ROOT_DIR)/agent \
+	$(ROOT_DIR)/cubecow \
+	$(ROOT_DIR)/hypervisor
+
+BINARIES := \
+	agent \
+	cubeapi \
+	cubelet \
+	cubemaster \
+	cubevsmapdump \
+	network-agent \
+	shim \
+	#
+
 # All versioned binaries should consume the canonical CUBE_VERSION /
 # CUBE_COMMIT / CUBE_BUILD_TIME triplet. Keep the root Makefile's ad-hoc
 # builder path aligned with the one-click release path so `_output/bin/* --version`
@@ -34,8 +54,10 @@ ifneq ($(wildcard $(HOME)/.git-credentials),)
 DOCKER_GIT_CRED += -v $(TMP_GIT_CREDENTIALS):$(BUILDER_CONTAINER_HOME)/.git-credentials
 endif
 
-.PHONY: help builder-image builder-shell builder-run prepare-builder-home prepare-tmp-git-credentials all cubemaster cubelet cubecow-sdk cubecow-clean cubecow-smoke cubecow-test-native network-agent agent cubeapi cube-api shim manual-release web-install web-dev web-build web-preview web-lint web-api-sync web-sync-dev-env cubevsmapdump fmt
+.PHONY: all
+all: $(BINARIES)
 
+.PHONY: help
 help:
 	@printf "Targets:\n"
 	@printf "  builder-image  Build unified builder image (%s)\n" "$(BUILDER_IMAGE)"
@@ -54,6 +76,7 @@ help:
 	@printf "  shim          Build containerd-shim-cube-rs and cube-runtime in Docker\n"
 	@printf "  all           Build cubemaster, cubelet, network-agent and cubevsmapdump in Docker\n"
 	@printf "  manual-release Build binaries and package manual update tarball\n"
+	@printf "  clean-rust-target-dirs Remove target/ in every top-level Rust project\n"
 	@printf "  web-install   Install WebUI npm dependencies\n"
 	@printf "  web-dev       Start WebUI Vite dev server\n"
 	@printf "  web-build     Build WebUI static assets\n"
@@ -69,6 +92,7 @@ help:
 	@printf "  - release outputs are written to %s\n" "$(RELEASE_DIR)"
 	@printf "  - Run 'make builder-image' first if image %s is missing\n" "$(BUILDER_IMAGE)"
 
+.PHONY: builder-image
 builder-image:
 	@if [ -z "$(BUILDER_FORCE_REBUILD)" ] && docker image inspect $(BUILDER_IMAGE) >/dev/null 2>&1; then \
 		printf 'Builder image %s already present, skipping build (set BUILDER_FORCE_REBUILD=1 to rebuild)\n' "$(BUILDER_IMAGE)"; \
@@ -76,6 +100,7 @@ builder-image:
 		docker build -t $(BUILDER_IMAGE) -f $(BUILDER_DOCKERFILE) ./docker; \
 	fi
 
+.PHONY: prepare-builder-home
 prepare-builder-home:
 	@mkdir -p "$(BUILDER_HOME)" \
 		"$(BUILDER_HOME)/.cache" \
@@ -83,6 +108,7 @@ prepare-builder-home:
 		"$(BUILDER_HOME)/.cargo" \
 		"$(BUILDER_HOME)/go"
 
+.PHONY: prepare-tmp-git-credentials
 prepare-tmp-git-credentials:
 	@rm -f $(TMP_GIT_CREDENTIALS)
 	@if [ -f "$(HOME)/.git-credentials" ]; then \
@@ -90,6 +116,7 @@ prepare-tmp-git-credentials:
 		chmod 600 $(TMP_GIT_CREDENTIALS); \
 	fi
 
+.PHONY: builder-shell
 builder-shell: prepare-builder-home prepare-tmp-git-credentials
 	docker run --rm -it \
 		--user "$(UID):$(GID)" \
@@ -104,6 +131,7 @@ builder-shell: prepare-builder-home prepare-tmp-git-credentials
 		$(BUILDER_IMAGE) \
 		bash -lc 'mkdir -p "$$HOME" "$$CARGO_HOME" "$$GOPATH" "$$HOME/.cache" "$$HOME/.config" && exec bash'
 
+.PHONY: builder-run
 builder-run: prepare-builder-home prepare-tmp-git-credentials
 	@test -n "$(strip $(BUILDER_CMD))" || { echo "BUILDER_CMD must not be empty"; exit 1; }
 	docker run --rm -i \
@@ -123,8 +151,7 @@ builder-run: prepare-builder-home prepare-tmp-git-credentials
 		$(BUILDER_IMAGE) \
 		bash -lc 'mkdir -p "$$HOME" "$$CARGO_HOME" "$$GOPATH" "$$HOME/.cache" "$$HOME/.config" && exec bash -lc "$$BUILDER_CMD"'
 
-all: cubemaster cubelet network-agent cubevsmapdump
-
+.PHONY: cubecow-sdk
 cubecow-sdk:
 ifeq ($(IN_CUBE_SANDBOX_BUILDER),1)
 	@mkdir -p "$(CUBELET_COW_THIRD_PARTY_DIR)/lib" "$(CUBELET_COW_THIRD_PARTY_DIR)/include"
@@ -136,47 +163,68 @@ else
 	$(MAKE) builder-run BUILDER_CMD='cd /workspace && IN_CUBE_SANDBOX_BUILDER=1 make cubecow-sdk'
 endif
 
+.PHONY: cubecow-clean
 cubecow-clean:
 	rm -rf "$(CUBELET_COW_THIRD_PARTY_DIR)"
 	cd "$(CUBECOW_DIR)" && cargo clean
 
+.PHONY: clean-rust-target-dirs
+clean-rust-target-dirs:
+	@for dir in $(RUST_PROJECT_DIRS); do \
+		if [ -d "$$dir/target" ]; then \
+			printf '  %-8s %s\n' "RM" "$$dir/target"; \
+			rm -rf "$$dir/target"; \
+		fi; \
+	done
+
+.PHONY: cubecow-smoke
 cubecow-smoke: builder-image
 	@mkdir -p "$(OUTPUT_DIR)"
 	$(MAKE) builder-run BUILDER_CMD='cd /workspace && IN_CUBE_SANDBOX_BUILDER=1 make cubecow-sdk && cd /workspace/Cubelet && go mod download && go build -a -o /workspace/_output/bin/cubecow-smoke ./pkg/cubecow/cmd/cubecow-smoke'
 
+.PHONY: cubecow-test-native
 cubecow-test-native: builder-image
 	$(MAKE) builder-run BUILDER_CMD='cd /workspace && IN_CUBE_SANDBOX_BUILDER=1 make cubecow-sdk && cd /workspace/Cubelet && go mod download && go test -a ./pkg/cubecow -run Test -count=1'
 
+.PHONY: cubemaster
 cubemaster: builder-image
 	@mkdir -p "$(OUTPUT_DIR)"
 	$(MAKE) builder-run BUILDER_CMD='cd /workspace/CubeMaster && make proto && make build && mkdir -p /workspace/_output/bin && cp build/cubemaster build/cubemastercli /workspace/_output/bin/'
 
+.PHONY: cubelet
 cubelet: builder-image
 	@mkdir -p "$(OUTPUT_DIR)"
 	$(MAKE) builder-run BUILDER_CMD='mkdir -p /workspace/_output/bin && cd /workspace && IN_CUBE_SANDBOX_BUILDER=1 make cubecow-sdk && cd /workspace/Cubelet && go mod download && make proto && make build && cp build/cubelet build/cubecli /workspace/_output/bin/'
 
+.PHONY: cubevsmapdump
 cubevsmapdump: builder-image
 	@mkdir -p "$(OUTPUT_DIR)"
 	$(MAKE) builder-run BUILDER_CMD='mkdir -p /workspace/_output/bin && cd /workspace/CubeNet/cubevs && go build -o /workspace/_output/bin/cubevsmapdump ./cmd/cubevsmapdump'
 
+.PHONY: network-agent
 network-agent: builder-image
 	@mkdir -p "$(OUTPUT_DIR)"
 	$(MAKE) builder-run BUILDER_CMD='mkdir -p /workspace/_output/bin && cd /workspace/network-agent && make proto && make build && cp bin/network-agent /workspace/_output/bin/network-agent'
 
+.PHONY: agent
 agent: builder-image
 	@mkdir -p "$(OUTPUT_DIR)"
 	$(MAKE) builder-run BUILDER_CMD='mkdir -p /workspace/_output/bin && cd /workspace/agent && make -j1 && install -m 0755 /workspace/agent/target/x86_64-unknown-linux-musl/release/cube-agent /workspace/_output/bin/cube-agent'
 
+.PHONY: cubeapi
 cubeapi: builder-image
 	@mkdir -p "$(OUTPUT_DIR)"
 	$(MAKE) builder-run BUILDER_CMD='mkdir -p /workspace/_output/bin && cd /workspace/CubeAPI && cargo build --release --locked && install -m 0755 /workspace/CubeAPI/target/release/cube-api /workspace/_output/bin/cube-api'
 
+.PHONY: cube-api
 cube-api: cubeapi
 
+.PHONY: shim
 shim: builder-image
 	@mkdir -p "$(OUTPUT_DIR)"
 	$(MAKE) builder-run BUILDER_CMD='mkdir -p /workspace/_output/bin && cd /workspace/CubeShim && cargo build --release --locked && install -m 0755 /workspace/CubeShim/target/release/containerd-shim-cube-rs /workspace/_output/bin/containerd-shim-cube-rs && install -m 0755 /workspace/CubeShim/target/release/cube-runtime /workspace/_output/bin/cube-runtime'
 
+.PHONY: manual-release
 manual-release: all
 	@mkdir -p "$(RELEASE_DIR)"
 	@PKG_TS="$$(date +%Y%m%d-%H%M%S)"; \
@@ -189,29 +237,37 @@ manual-release: all
 		"$(RELEASE_DIR)/$${PKG_NAME}.sha256" \
 		"$(RELEASE_DIR)/deploy-manual.sh"
 
+.PHONY: web-install
 web-install:
 	cd "$(WEB_DIR)" && npm install
 
+.PHONY: web-dev
 web-dev:
 	cd "$(WEB_DIR)" && npm run dev
 
+.PHONY: web-build
 web-build:
 	cd "$(WEB_DIR)" && npm run build
 
+.PHONY: web-preview
 web-preview:
 	cd "$(WEB_DIR)" && npm run preview
 
+.PHONY: web-lint
 web-lint:
 	cd "$(WEB_DIR)" && npm run lint
 
+.PHONY: web-api-sync
 web-api-sync:
 	cd "$(WEB_DIR)" && npm run api:sync
 
+.PHONY: web-sync-dev-env
 web-sync-dev-env:
 	"$(ROOT_DIR)/dev-env/internal/sync_web_to_vm.sh"
 
 # Run make fmt in each component directory that has a fmt target.
 # Components without formattable code (e.g. CubeProxy) are skipped.
+.PHONY: fmt
 fmt:
 	@printf '  %-8s %s\n' "FMT" "agent"
 	@$(MAKE) -C agent fmt


### PR DESCRIPTION
Reorganize the root Makefile and add a convenience cleanup target:

- Split the single bulk `.PHONY: ...` line into a per-target declaration placed immediately above each rule. Easier to keep in sync when adding or renaming targets, and a missing `.PHONY` now affects only its own rule instead of silently dropping from the shared list.
- Move the `all` target to the top of the rule section and drive it from a new `BINARIES` list so adding a binary is a one-line change.
- Add `clean-rust-target-dirs`, which removes `target/` under each top-level Rust workspace (CubeAPI, CubeShim, agent, cubecow, hypervisor). Sub-crates share their workspace's target dir, so this covers all Rust build artifacts in the repo. Skips dirs that don't have `target/` and prints what it removes.
- Surface the new target in `make help`.

No behavior change for existing build targets.