### PR TITLE
docs(quickstart): add apt (DEB) install instructions alongside yum (RPM) for Python SDK setup

### DIFF
--- a/docs/guide/quickstart.md
+++ b/docs/guide/quickstart.md
@@ -218,9 +218,16 @@ For the full template creation workflow and more options, see [Creating Template
 
 Install the Python SDK:
 
-```bash
+::: code-group
+```bash [yum (RPM)]
 yum install -y python3 python3-pip
+```
+```bash [apt (DEB)]
+apt update && apt install -y python3 python3-pip
+```
+:::
 
+```bash
 pip install e2b-code-interpreter
 ```
 

--- a/docs/zh/guide/quickstart.md
+++ b/docs/zh/guide/quickstart.md
@@ -220,8 +220,16 @@ cubemastercli tpl watch --job-id <job_id>
 
 安装 Python SDK：
 
-```bash
+::: code-group
+```bash [yum (RPM)]
 yum install -y python3 python3-pip
+```
+```bash [apt (DEB)]
+apt update && apt install -y python3 python3-pip
+```
+:::
+
+```bash
 pip config set global.index-url https://mirrors.ustc.edu.cn/pypi/simple
 
 pip install e2b-code-interpreter


### PR DESCRIPTION
Added apt (DEB) package manager install instructions alongside the existing yum (RPM) instructions in both the English and Chinese quickstart guides for Python SDK setup.

## Changes
- docs/guide/quickstart.md: Added code-group with yum and apt options
- docs/zh/guide/quickstart.md: Added code-group with yum and apt options

🤖 Generated with [Claude Code](https://claude.com/claude-code)