### PR TITLE
feat(one-click): add --mode upgrade with three-way env merge and pre-upgrade backup

### DIFF
--- a/deploy/one-click/install.sh
+++ b/deploy/one-click/install.sh
@@ -919,6 +919,10 @@ tar -xzf "${PACKAGE_TAR}" -C "${WORK_DIR}"
 PKG_ROOT="${WORK_DIR}/sandbox-package"
 ensure_dir "${PKG_ROOT}"
 validate_cubelet_cow_startup_deps "${PKG_ROOT}/Cubelet/config/config.toml"
+patch_cubelet_config_template \
+  "${PKG_ROOT}/Cubelet/config/config.toml" \
+  "${CUBE_SANDBOX_ETH_NAME:-}" \
+  "${CUBE_SANDBOX_NETWORK_CIDR:-}"
 
 installed_role="${DEPLOY_ROLE}"
 detected_installed_role="$(detect_installed_role)"
@@ -960,9 +964,7 @@ if [[ "${INSTALL_PREFIX%/}" == "${TOOLBOX_ROOT%/}" ]]; then
 else
   # Full wipe of a custom prefix, but preserve any upgrade backup directory so
   # the config snapshot survives for recovery/rollback.
-  # SAFETY: validate the prefix is not a system root before the destructive wipe.
-  assert_safe_install_prefix "${INSTALL_PREFIX}"
-  find "${INSTALL_PREFIX}" -mindepth 1 -maxdepth 1 ! -name '.backup' -exec rm -rf {} +
+  wipe_custom_install_prefix_contents "${INSTALL_PREFIX}"
 fi
 
 mkdir -p "${INSTALL_PREFIX}"
@@ -1041,13 +1043,26 @@ if [[ -n "${CUBE_SANDBOX_NODE_IP:-}" ]]; then
   upsert_env_kv "${RUNTIME_ENV_FILE}" "CUBE_SANDBOX_NODE_IP" "${CUBE_SANDBOX_NODE_IP}"
 fi
 if [[ -n "${CUBE_SANDBOX_ETH_NAME:-}" ]]; then
+  validate_interface_name "${CUBE_SANDBOX_ETH_NAME}" "CUBE_SANDBOX_ETH_NAME"
   upsert_env_kv "${RUNTIME_ENV_FILE}" "CUBE_SANDBOX_ETH_NAME" "${CUBE_SANDBOX_ETH_NAME}"
 fi
 if [[ -n "${ONE_CLICK_CONTROL_PLANE_IP:-}" ]]; then
+  validate_ipv4_literal "${ONE_CLICK_CONTROL_PLANE_IP}" "ONE_CLICK_CONTROL_PLANE_IP"
   upsert_env_kv "${RUNTIME_ENV_FILE}" "ONE_CLICK_CONTROL_PLANE_IP" "${ONE_CLICK_CONTROL_PLANE_IP}"
 fi
 if [[ -n "${ONE_CLICK_CONTROL_PLANE_CUBEMASTER_ADDR:-}" ]]; then
+  validate_host_port "${ONE_CLICK_CONTROL_PLANE_CUBEMASTER_ADDR}" "ONE_CLICK_CONTROL_PLANE_CUBEMASTER_ADDR"
   upsert_env_kv "${RUNTIME_ENV_FILE}" "ONE_CLICK_CONTROL_PLANE_CUBEMASTER_ADDR" "${ONE_CLICK_CONTROL_PLANE_CUBEMASTER_ADDR}"
+fi
+if [[ -n "${CUBE_SANDBOX_NETWORK_CIDR:-}" ]]; then
+  upsert_env_kv "${RUNTIME_ENV_FILE}" "CUBE_SANDBOX_NETWORK_CIDR" "${CUBE_SANDBOX_NETWORK_CIDR}"
+  if [[ -n "${CUBE_SANDBOX_NETWORK_CIDR_SKIP_CONFLICT_CHECK:-}" ]]; then
+    case "${CUBE_SANDBOX_NETWORK_CIDR_SKIP_CONFLICT_CHECK}" in
+      0|1) ;;
+      *) die "CUBE_SANDBOX_NETWORK_CIDR_SKIP_CONFLICT_CHECK must be 0 or 1 (got: '${CUBE_SANDBOX_NETWORK_CIDR_SKIP_CONFLICT_CHECK}')" ;;
+    esac
+    upsert_env_kv "${RUNTIME_ENV_FILE}" "CUBE_SANDBOX_NETWORK_CIDR_SKIP_CONFLICT_CHECK" "${CUBE_SANDBOX_NETWORK_CIDR_SKIP_CONFLICT_CHECK}"
+  fi
 fi
 
 # Persist external MySQL config so every systemd unit / helper picks it up
@@ -1090,60 +1105,7 @@ chmod +x "${INSTALL_PREFIX}/scripts/one-click/"*.sh
 chmod +x "${INSTALL_PREFIX}/scripts/systemd/"*.sh
 chmod +x "${INSTALL_PREFIX}/scripts/cube-egress/"*.sh 2>/dev/null || true
 
-if [[ -n "${CUBE_SANDBOX_ETH_NAME:-}" ]]; then
-  cubelet_config="${INSTALL_PREFIX}/Cubelet/config/config.toml"
-  # SECURITY: refuse to patch a symlink -- sed -i follows symlinks, which could
-  # let an attacker with write access to the prefix overwrite arbitrary files.
-  if [[ -L "${cubelet_config}" ]]; then
-    die "refusing to patch a symlink target: ${cubelet_config} -> $(readlink "${cubelet_config}")"
-  fi
-  if grep -Eq '^[[:space:]]*eth_name = "' "${cubelet_config}"; then
-    sed -i "s/eth_name = \"[^\"]*\"/eth_name = \"${CUBE_SANDBOX_ETH_NAME}\"/" "${cubelet_config}"
-    if ! grep -Fq "eth_name = \"${CUBE_SANDBOX_ETH_NAME}\"" "${cubelet_config}"; then
-      log "WARNING: failed to patch eth_name in Cubelet config (${cubelet_config})"
-    fi
-  else
-    log "WARNING: Cubelet config missing eth_name key; skipped NIC patch (${cubelet_config})"
-  fi
-fi
-
-# Patch cubevs CIDR if env var is set
-if [[ -n "${CUBE_SANDBOX_NETWORK_CIDR:-}" ]]; then
-  cubelet_config="${INSTALL_PREFIX}/Cubelet/config/config.toml"
-
-  # SECURITY: Refuse to patch a symlink -- sed -i follows symlinks, which
-  # could allow an attacker with write access to ONE_CLICK_INSTALL_PREFIX
-  # to overwrite arbitrary files via symlink.
-  if [[ -L "${cubelet_config}" ]]; then
-    die "refusing to patch a symlink target: ${cubelet_config} -> $(readlink "${cubelet_config}")"
-  fi
-
-  if grep -Eq '^[[:space:]]*cidr = "' "${cubelet_config}"; then
-    # NOTE: Use '|' as sed delimiter -- CIDR values always contain '/', so
-    # the default '/' delimiter would break the sed command.
-    sed -i "s|cidr = \"[^\"]*\"|cidr = \"${CUBE_SANDBOX_NETWORK_CIDR}\"|" "${cubelet_config}"
-    if ! grep -Fq "cidr = \"${CUBE_SANDBOX_NETWORK_CIDR}\"" "${cubelet_config}"; then
-      log "WARNING: failed to patch cidr in Cubelet config (${cubelet_config})"
-    fi
-    log "patched cubevs CIDR: ${CUBE_SANDBOX_NETWORK_CIDR}"
-  else
-    log "WARNING: Cubelet config missing cidr key; skipped CIDR patch (${cubelet_config})"
-  fi
-
-  # Persist CIDR to env file AFTER successful config patch (defense-in-depth:
-  # env file and config.toml should always be in sync; if the script crashes
-  # between patching and persistence, the env file stays clean).
-  if [[ -n "${CUBE_SANDBOX_NETWORK_CIDR:-}" ]]; then
-    upsert_env_kv "${RUNTIME_ENV_FILE}" "CUBE_SANDBOX_NETWORK_CIDR" "${CUBE_SANDBOX_NETWORK_CIDR}"
-  fi
-  if [[ -n "${CUBE_SANDBOX_NETWORK_CIDR_SKIP_CONFLICT_CHECK:-}" ]]; then
-    case "${CUBE_SANDBOX_NETWORK_CIDR_SKIP_CONFLICT_CHECK}" in
-      0|1) ;;
-      *) die "CUBE_SANDBOX_NETWORK_CIDR_SKIP_CONFLICT_CHECK must be 0 or 1 (got: '${CUBE_SANDBOX_NETWORK_CIDR_SKIP_CONFLICT_CHECK}')" ;;
-    esac
-    upsert_env_kv "${RUNTIME_ENV_FILE}" "CUBE_SANDBOX_NETWORK_CIDR_SKIP_CONFLICT_CHECK" "${CUBE_SANDBOX_NETWORK_CIDR_SKIP_CONFLICT_CHECK}"
-  fi
-else
+if [[ -z "${CUBE_SANDBOX_NETWORK_CIDR:-}" ]]; then
   # Log current CIDR for debugging
   current_cidr="$(sed -nE '/^[[:space:]]*cidr[[:space:]]*=[[:space:]]*"/{s/.*"([^"]+)".*/\1/p;q;}' "${INSTALL_PREFIX}/Cubelet/config/config.toml" 2>/dev/null || echo "unknown")"
   log "using cubevs CIDR from config.toml: ${current_cidr} (CUBE_SANDBOX_NETWORK_CIDR not set)"

--- a/deploy/one-click/install.sh
+++ b/deploy/one-click/install.sh
@@ -19,25 +19,21 @@ ONE_CLICK_ASSUME_YES="${ONE_CLICK_ASSUME_YES:-0}"
 ONE_CLICK_ALLOW_DOWNGRADE="${ONE_CLICK_ALLOW_DOWNGRADE:-0}"
 ONE_CLICK_ALLOW_ROLE_CHANGE="${ONE_CLICK_ALLOW_ROLE_CHANGE:-0}"
 
-for arg in "$@"; do
-  case "${arg}" in
-    --node-ip=*)
-      export CUBE_SANDBOX_NODE_IP="${arg#--node-ip=}"
-      ;;
-    --mode=*)
-      ONE_CLICK_MODE="${arg#--mode=}"
-      ;;
-    -y|--yes)
-      ONE_CLICK_ASSUME_YES=1
-      ;;
-    --allow-downgrade)
-      ONE_CLICK_ALLOW_DOWNGRADE=1
-      ;;
-    --allow-role-change)
-      ONE_CLICK_ALLOW_ROLE_CHANGE=1
-      ;;
-  esac
-done
+# Parse CLI flags into CLI_* globals (supports both `--flag=value` and
+# `--flag value`). The values are applied to the canonical variables here AND
+# re-applied after the .env file is sourced below, establishing the precedence:
+#   CLI flags > .env file > process environment > built-in defaults.
+one_click_parse_args "$@"
+
+apply_cli_overrides() {
+  [[ -n "${CLI_MODE}" ]] && ONE_CLICK_MODE="${CLI_MODE}"
+  [[ -n "${CLI_ASSUME_YES}" ]] && ONE_CLICK_ASSUME_YES="${CLI_ASSUME_YES}"
+  [[ -n "${CLI_ALLOW_DOWNGRADE}" ]] && ONE_CLICK_ALLOW_DOWNGRADE="${CLI_ALLOW_DOWNGRADE}"
+  [[ -n "${CLI_ALLOW_ROLE_CHANGE}" ]] && ONE_CLICK_ALLOW_ROLE_CHANGE="${CLI_ALLOW_ROLE_CHANGE}"
+  [[ -n "${CLI_NODE_IP}" ]] && export CUBE_SANDBOX_NODE_IP="${CLI_NODE_IP}"
+  return 0
+}
+apply_cli_overrides
 
 case "${ONE_CLICK_MODE}" in
   ""|install|upgrade|auto) ;;
@@ -49,6 +45,13 @@ require_root
 ENV_FILE="${ONE_CLICK_ENV_FILE:-${SCRIPT_DIR}/.env}"
 if [[ -f "${ENV_FILE}" ]]; then
   load_env_file "${ENV_FILE}"
+  # CLI flags must win over .env values: load_env_file uses `set -a; source`,
+  # which would otherwise clobber the CLI-provided values set above.
+  apply_cli_overrides
+  case "${ONE_CLICK_MODE}" in
+    ""|install|upgrade|auto) ;;
+    *) die "unsupported --mode: ${ONE_CLICK_MODE} (expected install|upgrade|auto)" ;;
+  esac
 fi
 
 DEPLOY_ROLE="$(one_click_deploy_role)"
@@ -957,6 +960,8 @@ if [[ "${INSTALL_PREFIX%/}" == "${TOOLBOX_ROOT%/}" ]]; then
 else
   # Full wipe of a custom prefix, but preserve any upgrade backup directory so
   # the config snapshot survives for recovery/rollback.
+  # SAFETY: validate the prefix is not a system root before the destructive wipe.
+  assert_safe_install_prefix "${INSTALL_PREFIX}"
   find "${INSTALL_PREFIX}" -mindepth 1 -maxdepth 1 ! -name '.backup' -exec rm -rf {} +
 fi
 

--- a/deploy/one-click/install.sh
+++ b/deploy/one-click/install.sh
@@ -7,13 +7,44 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=./lib/common.sh
 source "${SCRIPT_DIR}/lib/common.sh"
 
+# Install mode and upgrade-related flags (M3-1/M3-2/M3-3).
+#   --mode=install   full reinstall (default; existing config is reset)
+#   --mode=upgrade   config-preserving upgrade (requires an existing install)
+#   --mode=auto      upgrade when an existing install is detected, else install
+# When --mode is omitted and an existing install is detected, the installer
+# prompts on a TTY and falls back to a full reinstall (with a warning) when
+# running non-interactively.
+ONE_CLICK_MODE="${ONE_CLICK_MODE:-}"
+ONE_CLICK_ASSUME_YES="${ONE_CLICK_ASSUME_YES:-0}"
+ONE_CLICK_ALLOW_DOWNGRADE="${ONE_CLICK_ALLOW_DOWNGRADE:-0}"
+ONE_CLICK_ALLOW_ROLE_CHANGE="${ONE_CLICK_ALLOW_ROLE_CHANGE:-0}"
+
 for arg in "$@"; do
   case "${arg}" in
     --node-ip=*)
       export CUBE_SANDBOX_NODE_IP="${arg#--node-ip=}"
       ;;
+    --mode=*)
+      ONE_CLICK_MODE="${arg#--mode=}"
+      ;;
+    -y|--yes)
+      ONE_CLICK_ASSUME_YES=1
+      ;;
+    --allow-downgrade)
+      ONE_CLICK_ALLOW_DOWNGRADE=1
+      ;;
+    --allow-role-change)
+      ONE_CLICK_ALLOW_ROLE_CHANGE=1
+      ;;
   esac
 done
+
+case "${ONE_CLICK_MODE}" in
+  ""|install|upgrade|auto) ;;
+  *) die "unsupported --mode: ${ONE_CLICK_MODE} (expected install|upgrade|auto)" ;;
+esac
+
+require_root
 
 ENV_FILE="${ONE_CLICK_ENV_FILE:-${SCRIPT_DIR}/.env}"
 if [[ -f "${ENV_FILE}" ]]; then
@@ -23,28 +54,27 @@ fi
 DEPLOY_ROLE="$(one_click_deploy_role)"
 
 # ---- External MySQL / Redis support ----
-# Set CUBE_EXTERNAL_MYSQL_HOST to point CubeSandbox at an existing MySQL server
-# instead of the bundled local Docker container. When set, install.sh will:
-#   1. Patch CubeMaster conf.yaml with the external connection details
-#   2. Persist the external endpoint to .one-click.env so every systemd unit
-#      and helper script (CubeAPI DATABASE_URL, cube-proxy redis, quickcheck...)
-#      consumes it instead of the local container
-#   3. Mask the cube-sandbox-mysql systemd service so it never starts
-CUBE_EXTERNAL_MYSQL_HOST="${CUBE_EXTERNAL_MYSQL_HOST:-}"
-CUBE_EXTERNAL_MYSQL_PORT="${CUBE_EXTERNAL_MYSQL_PORT:-3306}"
-CUBE_EXTERNAL_MYSQL_USER="${CUBE_EXTERNAL_MYSQL_USER:-cube}"
-CUBE_EXTERNAL_MYSQL_PASSWORD="${CUBE_EXTERNAL_MYSQL_PASSWORD:-cube_pass}"
-# Default the external DB name from CUBE_SANDBOX_MYSQL_DB so it resolves to the
-# same value up-with-deps.sh derives independently. Otherwise a custom
-# CUBE_SANDBOX_MYSQL_DB (without an explicit CUBE_EXTERNAL_MYSQL_DB) would make
-# the persisted .one-click.env and the seed step disagree on the database name.
-CUBE_EXTERNAL_MYSQL_DB="${CUBE_EXTERNAL_MYSQL_DB:-${CUBE_SANDBOX_MYSQL_DB:-cube_mvp}}"
+# Set CUBE_EXTERNAL_MYSQL_HOST / CUBE_EXTERNAL_REDIS_HOST to use external
+# services instead of the bundled local Docker containers. Defaults are filled
+# after the optional upgrade env merge so they are based on the final runtime
+# configuration.
+init_external_dep_defaults() {
+  CUBE_EXTERNAL_MYSQL_HOST="${CUBE_EXTERNAL_MYSQL_HOST:-}"
+  CUBE_EXTERNAL_MYSQL_PORT="${CUBE_EXTERNAL_MYSQL_PORT:-3306}"
+  CUBE_EXTERNAL_MYSQL_USER="${CUBE_EXTERNAL_MYSQL_USER:-cube}"
+  CUBE_EXTERNAL_MYSQL_PASSWORD="${CUBE_EXTERNAL_MYSQL_PASSWORD:-cube_pass}"
+  # Default the external DB name from CUBE_SANDBOX_MYSQL_DB so it resolves to the
+  # same value up-with-deps.sh derives independently. Otherwise a custom
+  # CUBE_SANDBOX_MYSQL_DB (without an explicit CUBE_EXTERNAL_MYSQL_DB) would make
+  # the persisted .one-click.env and the seed step disagree on the database name.
+  CUBE_EXTERNAL_MYSQL_DB="${CUBE_EXTERNAL_MYSQL_DB:-${CUBE_SANDBOX_MYSQL_DB:-cube_mvp}}"
 
-# Set CUBE_EXTERNAL_REDIS_HOST to use an external Redis instance. Mirrors the
-# MySQL behaviour above (patch conf.yaml, persist env, mask local redis unit).
-CUBE_EXTERNAL_REDIS_HOST="${CUBE_EXTERNAL_REDIS_HOST:-}"
-CUBE_EXTERNAL_REDIS_PORT="${CUBE_EXTERNAL_REDIS_PORT:-6379}"
-CUBE_EXTERNAL_REDIS_PASSWORD="${CUBE_EXTERNAL_REDIS_PASSWORD:-ceuhvu123}"
+  # Mirrors the MySQL behaviour above (patch conf.yaml, persist env, mask local
+  # redis unit).
+  CUBE_EXTERNAL_REDIS_HOST="${CUBE_EXTERNAL_REDIS_HOST:-}"
+  CUBE_EXTERNAL_REDIS_PORT="${CUBE_EXTERNAL_REDIS_PORT:-6379}"
+  CUBE_EXTERNAL_REDIS_PASSWORD="${CUBE_EXTERNAL_REDIS_PASSWORD:-ceuhvu123}"
+}
 
 # Guard against shipping the example/default credentials to a real external
 # server. The defaults (cube_pass / ceuhvu123) are published in env.example and
@@ -63,6 +93,62 @@ warn_default_external_credentials() {
 
 TOOLBOX_ROOT="${ONE_CLICK_TOOLBOX_ROOT:-/usr/local/services/cubetoolbox}"
 INSTALL_PREFIX="${ONE_CLICK_INSTALL_PREFIX:-${TOOLBOX_ROOT}}"
+
+# Resolve install vs upgrade mode and, for upgrades, run preflight + backup and
+# build the config-preserving merged env BEFORE any destructive change. The
+# merged env is sourced so the rest of the installer operates with the user's
+# existing values (ports, CIDR, node IP, role, ...).
+PACKAGE_TAR="${ONE_CLICK_PACKAGE_TAR:-${SCRIPT_DIR}/assets/package/sandbox-package.tar.gz}"
+WORK_DIR="$(mktemp -d)"
+trap 'rm -rf "${WORK_DIR}"' EXIT
+
+INSTALL_MODE="$(resolve_install_mode "${ONE_CLICK_MODE}" "${INSTALL_PREFIX}" "${ONE_CLICK_ASSUME_YES}")"
+log "install mode: ${INSTALL_MODE}"
+
+MERGED_ENV=""
+ENV_DIFF_FILE=""
+UPGRADE_BACKUP_DIR=""
+if [[ "${INSTALL_MODE}" == "upgrade" ]]; then
+  RUNTIME_ENV_OLD="${INSTALL_PREFIX}/.one-click.env"
+  ensure_file "${RUNTIME_ENV_OLD}"
+
+  preflight_upgrade \
+    "${INSTALL_PREFIX}" \
+    "${SCRIPT_DIR}" \
+    "${PACKAGE_TAR}" \
+    "${DEPLOY_ROLE}" \
+    "${ONE_CLICK_ALLOW_ROLE_CHANGE}" \
+    "${ONE_CLICK_ALLOW_DOWNGRADE}"
+
+  # Build the merged env into WORK_DIR (the on-disk config backup is taken later,
+  # only after all fail-fast preflights pass, to avoid leaving stray backups).
+  MERGED_ENV="${WORK_DIR}/merged.env"
+  ENV_DIFF_FILE="${WORK_DIR}/env-diff.txt"
+
+  MERGE_NEW_DOTENV=""
+  [[ -f "${ENV_FILE}" ]] && MERGE_NEW_DOTENV="${ENV_FILE}"
+  MERGE_OLD_BASELINE=""
+  [[ -f "${INSTALL_PREFIX}/env.example" ]] && MERGE_OLD_BASELINE="${INSTALL_PREFIX}/env.example"
+
+  merge_env_three_way \
+    "${SCRIPT_DIR}/env.example" \
+    "${RUNTIME_ENV_OLD}" \
+    "${MERGE_OLD_BASELINE}" \
+    "${MERGE_NEW_DOTENV}" \
+    "${MERGED_ENV}" \
+    "${ENV_DIFF_FILE}"
+  if [[ -z "${MERGE_OLD_BASELINE}" ]]; then
+    log "note: no env.example baseline from the previous install; used two-way merge. Future upgrades will use a full three-way merge."
+  fi
+
+  # Override bundle/default values with the merged (old-priority) env so the
+  # rest of the installer keeps the user's existing configuration.
+  load_env_file "${MERGED_ENV}"
+  DEPLOY_ROLE="$(one_click_deploy_role)"
+fi
+
+init_external_dep_defaults
+
 CUBE_PVM_ENABLE="${CUBE_PVM_ENABLE:-0}"
 case "${CUBE_PVM_ENABLE}" in
   0|1) ;;
@@ -780,8 +866,6 @@ mask_external_dep_services() {
   systemctl daemon-reload >/dev/null 2>&1 || true
 }
 
-require_root
-
 # Run critical preflight checks that do not depend on dependency installation first
 # to ensure we fail fast before installing or modifying any local system packages.
 check_hardware_preflight
@@ -804,7 +888,15 @@ fi
 # Validate cubevs CIDR from env var (if set)
 CUBE_SANDBOX_NETWORK_CIDR="${CUBE_SANDBOX_NETWORK_CIDR:-}"
 if [[ -n "${CUBE_SANDBOX_NETWORK_CIDR}" ]]; then
-  check_cidr_preflight "${CUBE_SANDBOX_NETWORK_CIDR}"
+  # On upgrade the CIDR is the cluster's own (preserved from the old install);
+  # its existing cubevs bridge/route would self-trigger the host-conflict scan,
+  # so skip conflict detection (format validation still runs) while still
+  # honoring an explicit user bypass flag.
+  cidr_skip_conflict=0
+  if [[ "${INSTALL_MODE}" == "upgrade" || "${CUBE_SANDBOX_NETWORK_CIDR_SKIP_CONFLICT_CHECK:-0}" == "1" ]]; then
+    cidr_skip_conflict=1
+  fi
+  check_cidr_preflight "${CUBE_SANDBOX_NETWORK_CIDR}" "${cidr_skip_conflict}"
   export CUBE_SANDBOX_NETWORK_CIDR
 fi
 
@@ -815,10 +907,6 @@ check_external_deps_preflight
 if needs_docker_for_install; then
   configure_tencent_docker_mirror
 fi
-
-PACKAGE_TAR="${ONE_CLICK_PACKAGE_TAR:-${SCRIPT_DIR}/assets/package/sandbox-package.tar.gz}"
-WORK_DIR="$(mktemp -d)"
-trap 'rm -rf "${WORK_DIR}"' EXIT
 
 ensure_file "${PACKAGE_TAR}"
 validate_declared_release_manifest "${SCRIPT_DIR}"
@@ -839,6 +927,16 @@ log "stopping existing systemd deployment under ${INSTALL_PREFIX}"
 stop_existing_systemd_deployment
 stop_existing_legacy_deployment "${installed_role}"
 
+# Upgrade: snapshot existing config now that all fail-fast preflights have
+# passed and right before any destructive change, then stash the env diff.
+if [[ "${INSTALL_MODE}" == "upgrade" ]]; then
+  UPGRADE_BACKUP_DIR="$(backup_before_upgrade "${INSTALL_PREFIX}")"
+  if [[ -n "${ENV_DIFF_FILE}" && -f "${ENV_DIFF_FILE}" ]]; then
+    cp -f "${ENV_DIFF_FILE}" "${UPGRADE_BACKUP_DIR}/env-diff.txt"
+    log "env merge diff written to ${UPGRADE_BACKUP_DIR}/env-diff.txt"
+  fi
+fi
+
 if [[ "${INSTALL_PREFIX%/}" == "${TOOLBOX_ROOT%/}" ]]; then
   rm -rf \
     "${INSTALL_PREFIX}/network-agent" \
@@ -857,7 +955,9 @@ if [[ "${INSTALL_PREFIX%/}" == "${TOOLBOX_ROOT%/}" ]]; then
     "${INSTALL_PREFIX}/sql" \
     "${INSTALL_PREFIX}/.one-click.env"
 else
-  rm -rf "${INSTALL_PREFIX}"
+  # Full wipe of a custom prefix, but preserve any upgrade backup directory so
+  # the config snapshot survives for recovery/rollback.
+  find "${INSTALL_PREFIX}" -mindepth 1 -maxdepth 1 ! -name '.backup' -exec rm -rf {} +
 fi
 
 mkdir -p "${INSTALL_PREFIX}"
@@ -895,7 +995,10 @@ if [[ "${DEPLOY_ROLE}" != "compute" ]]; then
 fi
 
 RUNTIME_ENV_FILE="${INSTALL_PREFIX}/.one-click.env"
-if [[ -f "${ENV_FILE}" ]]; then
+if [[ "${INSTALL_MODE}" == "upgrade" && -n "${MERGED_ENV}" ]]; then
+  # Upgrade: write the config-preserving merged env as the runtime env.
+  cp -f "${MERGED_ENV}" "${RUNTIME_ENV_FILE}"
+elif [[ -f "${ENV_FILE}" ]]; then
   cp -f "${ENV_FILE}" "${RUNTIME_ENV_FILE}"
 else
   : > "${RUNTIME_ENV_FILE}"
@@ -911,6 +1014,12 @@ chmod 600 "${RUNTIME_ENV_FILE}"
 if [[ -f "${SCRIPT_DIR}/VERSION.txt" ]]; then
   cp -f "${SCRIPT_DIR}/VERSION.txt" "${INSTALL_PREFIX}/VERSION.txt"
   log "installed VERSION.txt to ${INSTALL_PREFIX}/VERSION.txt"
+fi
+# Persist the env template as a baseline so the NEXT upgrade can perform a full
+# three-way merge (distinguishing user-customized values from old defaults).
+if [[ -f "${SCRIPT_DIR}/env.example" ]]; then
+  cp -f "${SCRIPT_DIR}/env.example" "${INSTALL_PREFIX}/env.example"
+  log "installed env.example baseline to ${INSTALL_PREFIX}/env.example"
 fi
 manifest_rel="$(declared_release_manifest_relpath "${SCRIPT_DIR}/VERSION.txt")"
 if [[ -n "${manifest_rel}" ]]; then
@@ -978,6 +1087,11 @@ chmod +x "${INSTALL_PREFIX}/scripts/cube-egress/"*.sh 2>/dev/null || true
 
 if [[ -n "${CUBE_SANDBOX_ETH_NAME:-}" ]]; then
   cubelet_config="${INSTALL_PREFIX}/Cubelet/config/config.toml"
+  # SECURITY: refuse to patch a symlink -- sed -i follows symlinks, which could
+  # let an attacker with write access to the prefix overwrite arbitrary files.
+  if [[ -L "${cubelet_config}" ]]; then
+    die "refusing to patch a symlink target: ${cubelet_config} -> $(readlink "${cubelet_config}")"
+  fi
   if grep -Eq '^[[:space:]]*eth_name = "' "${cubelet_config}"; then
     sed -i "s/eth_name = \"[^\"]*\"/eth_name = \"${CUBE_SANDBOX_ETH_NAME}\"/" "${cubelet_config}"
     if ! grep -Fq "eth_name = \"${CUBE_SANDBOX_ETH_NAME}\"" "${cubelet_config}"; then

--- a/deploy/one-click/lib/common.sh
+++ b/deploy/one-click/lib/common.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
-set -euo pipefail
+#
+# This file is a sourced library. Do not set shell options here: entrypoint
+# scripts/tests that source it are responsible for their own strict mode
+# (`set -euo pipefail`) policy.
 
 ONE_CLICK_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ONE_CLICK_DIR="$(cd "${ONE_CLICK_LIB_DIR}/.." && pwd)"
@@ -12,6 +15,9 @@ die() {
   echo "[one-click] ERROR: $*" >&2
   exit 1
 }
+
+# shellcheck source=../scripts/common/validation.sh
+source "${ONE_CLICK_DIR}/scripts/common/validation.sh"
 
 # Avoid `ldd --version | head -1` under strict mode: `head` may exit early and
 # SIGPIPE `ldd`, which turns a valid glibc probe into a false failure.
@@ -228,10 +234,14 @@ semver_compare() {
   _version_compare_prerelease "${left_pre}" "${right_pre}"
 }
 
-# version_lt: Return success when the first version is lower than the second.
-# Delegates to semver_compare, including its v-prefix, build metadata, rc suffix,
-# and lexical fallback behavior.
+# version_lt: Return success when the first version is lower than the second
+# ONLY when both inputs are comparable semantic versions. This is used by the
+# upgrade downgrade guard, so legacy/SHA-like versions must not block upgrades.
+# Use semver_compare directly when lexical fallback for non-semver labels is
+# desired.
 version_lt() {
+  _version_split_semver "$1" >/dev/null || return 1
+  _version_split_semver "$2" >/dev/null || return 1
   [[ "$(semver_compare "$1" "$2")" == "-1" ]]
 }
 
@@ -577,6 +587,51 @@ upsert_env_kv() {
   mv -f "${tmp_file}" "${env_file}"
 }
 
+validate_interface_name() {
+  local value="$1"
+  local name="${2:-interface name}"
+  [[ -n "${value}" ]] || die "${name} must not be empty"
+  # Linux IFNAMSIZ is 16 including NUL, so names are at most 15 bytes. Restrict
+  # to characters that are safe in the TOML replacement and shell logs.
+  [[ "${value}" =~ ^[A-Za-z0-9_.:-]{1,15}$ ]] \
+    || die "invalid ${name}: ${value} (expected 1-15 chars: letters, digits, '_', '.', ':', '-')"
+}
+
+patch_cubelet_config_template() {
+  local cubelet_config="$1"
+  local eth_name="${2:-}"
+  local network_cidr="${3:-}"
+
+  ensure_file "${cubelet_config}"
+  if [[ -L "${cubelet_config}" ]]; then
+    die "refusing to patch a symlink target: ${cubelet_config} -> $(readlink "${cubelet_config}")"
+  fi
+
+  if [[ -n "${eth_name}" ]]; then
+    validate_interface_name "${eth_name}" "CUBE_SANDBOX_ETH_NAME"
+    if grep -Eq '^[[:space:]]*eth_name = "' "${cubelet_config}"; then
+      sed -i "s/eth_name = \"[^\"]*\"/eth_name = \"${eth_name}\"/" "${cubelet_config}"
+      if ! grep -Fq "eth_name = \"${eth_name}\"" "${cubelet_config}"; then
+        log "WARNING: failed to patch eth_name in Cubelet config (${cubelet_config})"
+      fi
+    else
+      log "WARNING: Cubelet config missing eth_name key; skipped NIC patch (${cubelet_config})"
+    fi
+  fi
+
+  if [[ -n "${network_cidr}" ]]; then
+    if grep -Eq '^[[:space:]]*cidr = "' "${cubelet_config}"; then
+      sed -i "s|cidr = \"[^\"]*\"|cidr = \"${network_cidr}\"|" "${cubelet_config}"
+      if ! grep -Fq "cidr = \"${network_cidr}\"" "${cubelet_config}"; then
+        log "WARNING: failed to patch cidr in Cubelet config (${cubelet_config})"
+      fi
+      log "patched cubevs CIDR: ${network_cidr}"
+    else
+      log "WARNING: Cubelet config missing cidr key; skipped CIDR patch (${cubelet_config})"
+    fi
+  fi
+}
+
 # ---------------------------------------------------------------------------
 # Config-preserving upgrade helpers (M3-1/M3-2/M3-3).
 #
@@ -606,10 +661,12 @@ assert_safe_install_prefix() {
 
   [[ -n "${prefix}" ]] || die "refusing to wipe an empty install prefix"
   [[ "${prefix}" == /* ]] || die "refusing to wipe a non-absolute install prefix: ${prefix}"
+  [[ ! -L "${prefix}" ]] || die "refusing to wipe a symlink install prefix: ${prefix}"
 
   # Normalize: drop a single trailing slash (but keep "/" detectable).
   local norm="${prefix%/}"
   [[ -n "${norm}" ]] || die "refusing to wipe the filesystem root: ${prefix}"
+  [[ ! -L "${norm}" ]] || die "refusing to wipe a symlink install prefix: ${prefix}"
 
   case "${norm}" in
     /usr|/bin|/sbin|/lib|/lib64|/etc|/var|/boot|/dev|/proc|/sys|/run|/root|/home|/opt)
@@ -635,22 +692,57 @@ assert_safe_install_prefix() {
   # closes the denylist gap -- e.g. /usr/local or /var/lib are deep enough and
   # not blacklisted, but hold foreign content with no CubeSandbox markers.
   if [[ -d "${norm}" ]]; then
-    local cube_marker=""
-    local m
-    for m in .one-click.env CubeMaster CubeAPI Cubelet; do
-      if [[ -e "${norm}/${m}" ]]; then
-        cube_marker=1
-        break
-      fi
-    done
-    if [[ -z "${cube_marker}" ]]; then
-      local stray
-      stray="$(find "${norm}" -mindepth 1 -maxdepth 1 ! -name '.backup' -print -quit 2>/dev/null || true)"
-      if [[ -n "${stray}" ]]; then
-        die "refusing to wipe custom install prefix ${prefix}: directory is not empty and contains no CubeSandbox installation markers (.one-click.env / CubeMaster / CubeAPI / Cubelet). Point ONE_CLICK_INSTALL_PREFIX at a dedicated CubeSandbox prefix, or remove the foreign content first."
-      fi
+    _assert_cube_prefix_marker_or_empty "${norm}" "${prefix}"
+  fi
+}
+
+_assert_cube_prefix_marker_or_empty() {
+  local dir="$1"
+  local display="$2"
+  local cube_marker=""
+  local m
+  for m in .one-click.env CubeMaster CubeAPI Cubelet; do
+    if [[ -e "${dir}/${m}" ]]; then
+      cube_marker=1
+      break
+    fi
+  done
+  if [[ -z "${cube_marker}" ]]; then
+    local stray
+    stray="$(find "${dir}" -mindepth 1 -maxdepth 1 ! -name '.backup' -print -quit 2>/dev/null || true)"
+    if [[ -n "${stray}" ]]; then
+      die "refusing to wipe custom install prefix ${display}: directory is not empty and contains no CubeSandbox installation markers (.one-click.env / CubeMaster / CubeAPI / Cubelet). Point ONE_CLICK_INSTALL_PREFIX at a dedicated CubeSandbox prefix, or remove the foreign content first."
     fi
   fi
+}
+
+wipe_custom_install_prefix_contents() {
+  local prefix="$1"
+  local norm before after
+
+  assert_safe_install_prefix "${prefix}"
+  norm="${prefix%/}"
+
+  if [[ ! -d "${norm}" ]]; then
+    mkdir -p "${norm}"
+    return 0
+  fi
+
+  before="$(stat -c '%d:%i' -- "${norm}")" \
+    || die "failed to stat install prefix before wipe: ${prefix}"
+
+  (
+    cd -- "${norm}" || die "failed to enter install prefix: ${prefix}"
+    after="$(stat -c '%d:%i' -- .)" \
+      || die "failed to stat install prefix after cd: ${prefix}"
+    [[ "${before}" == "${after}" ]] \
+      || die "install prefix changed while preparing to wipe: ${prefix}"
+
+    # Re-run the marker/empty check against the pinned cwd. This closes the
+    # gap between path validation and destructive deletion.
+    _assert_cube_prefix_marker_or_empty "." "${prefix}"
+    find . -mindepth 1 -maxdepth 1 ! -name '.backup' -exec rm -rf -- {} +
+  )
 }
 
 # detect_existing_install: an install is "present" when its runtime env file
@@ -681,22 +773,6 @@ read_version_field() {
   [[ "${field}" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]] || die "invalid version field name: ${field}"
   [[ -f "${file}" ]] || return 0
   sed -n "/^${field}=/{s/^${field}=//;p;q;}" "${file}" 2>/dev/null || true
-}
-
-# version_lt: return success when version $1 is strictly less than $2.
-# Only compares when BOTH look like dotted numeric versions (optionally
-# v-prefixed / with a pre-release suffix). Non-comparable inputs (e.g. git
-# SHAs) return failure so callers never block on them.
-version_lt() {
-  local a="${1#v}"
-  local b="${2#v}"
-  local ver_re='^[0-9]+(\.[0-9]+)*([.-].*)?$'
-  [[ "${a}" =~ ${ver_re} ]] || return 1
-  [[ "${b}" =~ ${ver_re} ]] || return 1
-  [[ "${a}" == "${b}" ]] && return 1
-  local first
-  first="$(printf '%s\n%s\n' "${a}" "${b}" | sort -V | head -n1)"
-  [[ "${first}" == "${a}" ]]
 }
 
 # merge_env_three_way: produce a merged runtime env that preserves the user's
@@ -730,6 +806,23 @@ new_example, old_runtime, old_baseline, new_dotenv, out_file, diff_file = sys.ar
 KV_RE = re.compile(r'^([A-Za-z_][A-Za-z0-9_]*)=(.*)$')
 
 
+def fail(message):
+    sys.stderr.write("[one-click] ERROR: %s\n" % message)
+    sys.exit(1)
+
+
+def read_lines(path, required=True):
+    try:
+        with open(path, "r", encoding="utf-8") as fh:
+            return fh.read().splitlines()
+    except FileNotFoundError:
+        if required:
+            fail("env merge input not found: %s" % path)
+        return []
+    except UnicodeDecodeError:
+        fail("env merge input is not valid UTF-8: %s" % path)
+
+
 def parse(path):
     """Ordered dict key -> raw value for active KEY=VALUE lines (last wins).
 
@@ -740,20 +833,13 @@ def parse(path):
     kv = {}
     if not path:
         return kv
-    try:
-        with open(path, "r", encoding="utf-8") as fh:
-            for raw in fh:
-                # Strip both \n and a trailing \r so CRLF inputs compare and
-                # serialize consistently with the template's splitlines().
-                line = raw.rstrip("\r\n")
-                stripped = line.lstrip()
-                if not stripped or stripped.startswith("#"):
-                    continue
-                m = KV_RE.match(line)
-                if m:
-                    kv[m.group(1)] = m.group(2)
-    except FileNotFoundError:
-        pass
+    for line in read_lines(path, required=False):
+        stripped = line.lstrip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        m = KV_RE.match(line)
+        if m:
+            kv[m.group(1)] = m.group(2)
     return kv
 
 
@@ -769,8 +855,7 @@ preserved = []
 explicit = []
 
 out_lines = []
-with open(new_example, "r", encoding="utf-8") as fh:
-    template = fh.read().splitlines()
+template = read_lines(new_example)
 
 for line in template:
     stripped = line.lstrip()
@@ -823,7 +908,8 @@ with open(out_file, "w", encoding="utf-8") as fh:
 # passwords/tokens/connection strings in plaintext. The merged output file
 # (out_file) intentionally keeps the real values -- it IS the runtime env.
 SECRET_RE = re.compile(
-    r'(PASSWORD|PASSWD|SECRET|TOKEN|CREDENTIAL|PRIVATE_KEY|DATABASE_URL)', re.I)
+    r'(PASSWORD|PASSWD|SECRET|TOKEN|CREDENTIAL|PRIVATE_KEY|DATABASE_URL|API_KEY|ACCESS_KEY|CLIENT_SECRET|AUTH_TOKEN)',
+    re.I)
 
 
 def redact(key, val):

--- a/deploy/one-click/lib/common.sh
+++ b/deploy/one-click/lib/common.sh
@@ -466,6 +466,58 @@ wait_for_pidfile() {
   return 1
 }
 
+# one_click_parse_args: parse install.sh CLI flags into CLI_* globals.
+#
+# Supports BOTH `--flag=value` and space-separated `--flag value` forms so
+# that documented invocations like `--mode upgrade` work as expected. Value
+# flags reported missing a value fail fast (no silent empty assignment).
+# Unknown tokens are warned about but ignored to preserve backward
+# compatibility with existing callers that pass extra positional arguments.
+#
+# Resets and populates the following globals (caller declares/uses them):
+#   CLI_MODE CLI_NODE_IP CLI_ASSUME_YES CLI_ALLOW_DOWNGRADE CLI_ALLOW_ROLE_CHANGE
+one_click_parse_args() {
+  CLI_MODE=""
+  CLI_NODE_IP=""
+  CLI_ASSUME_YES=""
+  CLI_ALLOW_DOWNGRADE=""
+  CLI_ALLOW_ROLE_CHANGE=""
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --node-ip=*)
+        CLI_NODE_IP="${1#--node-ip=}"
+        ;;
+      --node-ip)
+        [[ $# -ge 2 ]] || die "--node-ip requires a value"
+        shift
+        CLI_NODE_IP="$1"
+        ;;
+      --mode=*)
+        CLI_MODE="${1#--mode=}"
+        ;;
+      --mode)
+        [[ $# -ge 2 ]] || die "--mode requires a value (install|upgrade|auto)"
+        shift
+        CLI_MODE="$1"
+        ;;
+      -y|--yes)
+        CLI_ASSUME_YES=1
+        ;;
+      --allow-downgrade)
+        CLI_ALLOW_DOWNGRADE=1
+        ;;
+      --allow-role-change)
+        CLI_ALLOW_ROLE_CHANGE=1
+        ;;
+      *)
+        log "WARNING: ignoring unknown argument: $1"
+        ;;
+    esac
+    shift
+  done
+}
+
 one_click_deploy_role() {
   local role="${ONE_CLICK_DEPLOY_ROLE:-control}"
   case "${role}" in
@@ -539,6 +591,68 @@ upsert_env_kv() {
 #   * backup_before_upgrade    - snapshot config before replacing artifacts
 # ---------------------------------------------------------------------------
 
+# assert_safe_install_prefix: refuse to perform a destructive full wipe of an
+# obviously unsafe install prefix. Guards against a mis-set
+# ONE_CLICK_INSTALL_PREFIX (e.g. "/" or "/usr", or a foreign dir like
+# "/usr/local" / "/var/lib") turning the custom-prefix wipe into a
+# system-destroying `rm -rf`. Beyond the root/system/top-level denylist, a
+# non-empty existing prefix is only wiped when it is a recognised CubeSandbox
+# install (presence of a marker artifact such as .one-click.env / CubeMaster)
+# or effectively empty -- the wipe preserves '.backup', so a lone '.backup'
+# left over from an interrupted upgrade is fine. Non-existent prefixes are
+# allowed (a fresh path the installer is about to create).
+assert_safe_install_prefix() {
+  local prefix="$1"
+
+  [[ -n "${prefix}" ]] || die "refusing to wipe an empty install prefix"
+  [[ "${prefix}" == /* ]] || die "refusing to wipe a non-absolute install prefix: ${prefix}"
+
+  # Normalize: drop a single trailing slash (but keep "/" detectable).
+  local norm="${prefix%/}"
+  [[ -n "${norm}" ]] || die "refusing to wipe the filesystem root: ${prefix}"
+
+  case "${norm}" in
+    /usr|/bin|/sbin|/lib|/lib64|/etc|/var|/boot|/dev|/proc|/sys|/run|/root|/home|/opt)
+      die "refusing to wipe a system directory: ${prefix}"
+      ;;
+  esac
+
+  if [[ -n "${HOME:-}" && "${norm}" == "${HOME%/}" ]]; then
+    die "refusing to wipe the home directory: ${prefix}"
+  fi
+
+  # Require at least two non-empty path components (e.g. /a/b), so shallow
+  # top-level directories cannot be wiped wholesale.
+  local trimmed="${norm#/}"
+  if [[ "${trimmed}" != */* ]]; then
+    die "refusing to wipe a top-level directory: ${prefix} (install prefix must be at least two levels deep)"
+  fi
+
+  # Content sanity check: the custom-prefix wipe deletes every top-level entry
+  # except '.backup'. Refuse unless the prefix is a recognised CubeSandbox
+  # install (a marker artifact is present) or effectively empty (nothing to
+  # destroy; '.backup' alone is harmless since the wipe preserves it). This
+  # closes the denylist gap -- e.g. /usr/local or /var/lib are deep enough and
+  # not blacklisted, but hold foreign content with no CubeSandbox markers.
+  if [[ -d "${norm}" ]]; then
+    local cube_marker=""
+    local m
+    for m in .one-click.env CubeMaster CubeAPI Cubelet; do
+      if [[ -e "${norm}/${m}" ]]; then
+        cube_marker=1
+        break
+      fi
+    done
+    if [[ -z "${cube_marker}" ]]; then
+      local stray
+      stray="$(find "${norm}" -mindepth 1 -maxdepth 1 ! -name '.backup' -print -quit 2>/dev/null || true)"
+      if [[ -n "${stray}" ]]; then
+        die "refusing to wipe custom install prefix ${prefix}: directory is not empty and contains no CubeSandbox installation markers (.one-click.env / CubeMaster / CubeAPI / Cubelet). Point ONE_CLICK_INSTALL_PREFIX at a dedicated CubeSandbox prefix, or remove the foreign content first."
+      fi
+    fi
+  fi
+}
+
 # detect_existing_install: an install is "present" when its runtime env file
 # exists under the given prefix.
 detect_existing_install() {
@@ -551,6 +665,10 @@ detect_existing_install() {
 read_env_key() {
   local file="$1"
   local key="$2"
+  # Validate the key is a plain env identifier before interpolating it into the
+  # sed address; this prevents sed pattern/command injection if a future caller
+  # passes user-controlled data.
+  [[ "${key}" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]] || die "invalid env key name: ${key}"
   [[ -f "${file}" ]] || return 0
   sed -n "/^${key}=/{s/^${key}=//;p;q;}" "${file}" 2>/dev/null || true
 }
@@ -559,6 +677,8 @@ read_env_key() {
 read_version_field() {
   local file="$1"
   local field="$2"
+  # Validate the field name before interpolating it into the sed address.
+  [[ "${field}" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]] || die "invalid version field name: ${field}"
   [[ -f "${file}" ]] || return 0
   sed -n "/^${field}=/{s/^${field}=//;p;q;}" "${file}" 2>/dev/null || true
 }
@@ -698,24 +818,36 @@ if extra:
 with open(out_file, "w", encoding="utf-8") as fh:
     fh.write("\n".join(out_lines) + "\n")
 
+# Redact secret-bearing values in the human-readable diff report. The report
+# is persisted to the (on-disk) upgrade backup directory, so it must not leak
+# passwords/tokens/connection strings in plaintext. The merged output file
+# (out_file) intentionally keeps the real values -- it IS the runtime env.
+SECRET_RE = re.compile(
+    r'(PASSWORD|PASSWD|SECRET|TOKEN|CREDENTIAL|PRIVATE_KEY|DATABASE_URL)', re.I)
+
+
+def redact(key, val):
+    return "***REDACTED***" if SECRET_RE.search(key) else val
+
+
 report = []
 report.append("env merge report (mode=%s)" % ("three-way" if has_baseline else "two-way-fallback"))
 report.append("")
 report.append("[added] new keys filled with new defaults: %d" % len(added))
 for k, v in added:
-    report.append("  + %s=%s" % (k, v))
+    report.append("  + %s=%s" % (k, redact(k, v)))
 report.append("[default-updated] untouched keys adopting new default: %d" % len(updated_default))
 for k, ov, nv in updated_default:
-    report.append("  ~ %s: %s -> %s" % (k, ov, nv))
+    report.append("  ~ %s: %s -> %s" % (k, redact(k, ov), redact(k, nv)))
 report.append("[preserved] kept your customized values: %d" % len(preserved))
 for k, v in preserved:
-    report.append("  = %s=%s" % (k, v))
+    report.append("  = %s=%s" % (k, redact(k, v)))
 report.append("[explicit] taken from new .env overrides: %d" % len(explicit))
 for k in explicit:
     report.append("  ! %s" % k)
 report.append("[kept-extra] old-only keys not in new env.example (kept): %d" % len(extra))
 for k, v in extra:
-    report.append("  > %s=%s" % (k, v))
+    report.append("  > %s=%s" % (k, redact(k, v)))
 
 with open(diff_file, "w", encoding="utf-8") as fh:
     fh.write("\n".join(report) + "\n")
@@ -891,6 +1023,10 @@ backup_before_upgrade() {
   ts="$(date +%Y%m%d-%H%M%S)"
   backup_dir="${install_prefix}/.backup/upgrade-${ts}"
   mkdir -p "${backup_dir}"
+  # The backup holds secret-bearing config (.one-click.env, conf files); keep
+  # it owner-only so secrets are not world/group readable on disk.
+  chmod 700 "${install_prefix}/.backup" 2>/dev/null || true
+  chmod 700 "${backup_dir}" 2>/dev/null || true
 
   for rel in \
     ".one-click.env" \
@@ -910,6 +1046,12 @@ backup_before_upgrade() {
     if [[ -f "${install_prefix}/${rel}" ]]; then
       mkdir -p "${backup_dir}/$(dirname "${rel}")"
       cp -a "${install_prefix}/${rel}" "${backup_dir}/${rel}"
+      # Secret-bearing config files: restrict to owner-only in the backup.
+      case "${rel}" in
+        ".one-click.env"|"env.example"|*conf.yaml|*config.toml|*.yaml|*.conf)
+          chmod 600 "${backup_dir}/${rel}" 2>/dev/null || true
+          ;;
+      esac
     fi
   done
 

--- a/deploy/one-click/lib/common.sh
+++ b/deploy/one-click/lib/common.sh
@@ -653,9 +653,9 @@ patch_cubelet_config_template() {
 # system-destroying `rm -rf`. Beyond the root/system/top-level denylist, a
 # non-empty existing prefix is only wiped when it is a recognised CubeSandbox
 # install (presence of a marker artifact such as .one-click.env / CubeMaster)
-# or effectively empty -- the wipe preserves '.backup', so a lone '.backup'
-# left over from an interrupted upgrade is fine. Non-existent prefixes are
-# allowed (a fresh path the installer is about to create).
+# or effectively empty. A lone '.backup' left over from an interrupted upgrade
+# is fine only when it is a real directory, not a symlink. Non-existent prefixes
+# are allowed (a fresh path the installer is about to create).
 assert_safe_install_prefix() {
   local prefix="$1"
 
@@ -688,11 +688,22 @@ assert_safe_install_prefix() {
   # Content sanity check: the custom-prefix wipe deletes every top-level entry
   # except '.backup'. Refuse unless the prefix is a recognised CubeSandbox
   # install (a marker artifact is present) or effectively empty (nothing to
-  # destroy; '.backup' alone is harmless since the wipe preserves it). This
+  # destroy; '.backup' alone is accepted only when it is a real directory). This
   # closes the denylist gap -- e.g. /usr/local or /var/lib are deep enough and
   # not blacklisted, but hold foreign content with no CubeSandbox markers.
   if [[ -d "${norm}" ]]; then
+    _assert_no_top_level_symlinks "${norm}" "${prefix}"
     _assert_cube_prefix_marker_or_empty "${norm}" "${prefix}"
+  fi
+}
+
+_assert_no_top_level_symlinks() {
+  local dir="$1"
+  local display="$2"
+  local symlink
+  symlink="$(find "${dir}" -mindepth 1 -maxdepth 1 -type l -print -quit 2>/dev/null || true)"
+  if [[ -n "${symlink}" ]]; then
+    die "refusing to wipe custom install prefix ${display}: contains top-level symlink (${symlink}); move it away and retry"
   fi
 }
 
@@ -740,6 +751,7 @@ wipe_custom_install_prefix_contents() {
 
     # Re-run the marker/empty check against the pinned cwd. This closes the
     # gap between path validation and destructive deletion.
+    _assert_no_top_level_symlinks "." "${prefix}"
     _assert_cube_prefix_marker_or_empty "." "${prefix}"
     find . -mindepth 1 -maxdepth 1 ! -name '.backup' -exec rm -rf -- {} +
   )
@@ -1105,13 +1117,15 @@ preflight_upgrade_disk_space() {
 # metadata into a timestamped backup dir. Prints the backup dir to stdout.
 backup_before_upgrade() {
   local install_prefix="$1"
-  local ts backup_dir rel
+  local ts backup_root backup_dir rel
   ts="$(date +%Y%m%d-%H%M%S)"
-  backup_dir="${install_prefix}/.backup/upgrade-${ts}"
+  backup_root="${install_prefix}/.backup"
+  [[ ! -L "${backup_root}" ]] || die "refusing to use symlink backup directory: ${backup_root}"
+  backup_dir="${backup_root}/upgrade-${ts}"
   mkdir -p "${backup_dir}"
   # The backup holds secret-bearing config (.one-click.env, conf files); keep
   # it owner-only so secrets are not world/group readable on disk.
-  chmod 700 "${install_prefix}/.backup" 2>/dev/null || true
+  chmod 700 "${backup_root}" 2>/dev/null || true
   chmod 700 "${backup_dir}" 2>/dev/null || true
 
   for rel in \

--- a/deploy/one-click/lib/common.sh
+++ b/deploy/one-click/lib/common.sh
@@ -525,6 +525,403 @@ upsert_env_kv() {
   mv -f "${tmp_file}" "${env_file}"
 }
 
+# ---------------------------------------------------------------------------
+# Config-preserving upgrade helpers (M3-1/M3-2/M3-3).
+#
+# These power install.sh's `--mode upgrade` flow:
+#   * detect_existing_install  - is there a prior one-click install?
+#   * read_env_key             - read a KEY from an env file without sourcing
+#   * read_version_field       - read a field from VERSION.txt
+#   * version_lt               - best-effort semver "<" comparison
+#   * merge_env_three_way      - merge old runtime env with new env.example
+#   * resolve_install_mode     - decide install vs upgrade (with TTY prompt)
+#   * preflight_upgrade        - role/downgrade/disk checks before upgrade
+#   * backup_before_upgrade    - snapshot config before replacing artifacts
+# ---------------------------------------------------------------------------
+
+# detect_existing_install: an install is "present" when its runtime env file
+# exists under the given prefix.
+detect_existing_install() {
+  local install_prefix="$1"
+  [[ -f "${install_prefix}/.one-click.env" ]]
+}
+
+# read_env_key: extract the raw value of an active KEY=VALUE line from a file
+# WITHOUT sourcing it (avoids executing arbitrary shell during preflight).
+read_env_key() {
+  local file="$1"
+  local key="$2"
+  [[ -f "${file}" ]] || return 0
+  sed -n "/^${key}=/{s/^${key}=//;p;q;}" "${file}" 2>/dev/null || true
+}
+
+# read_version_field: read `field=value` from a VERSION.txt-style file.
+read_version_field() {
+  local file="$1"
+  local field="$2"
+  [[ -f "${file}" ]] || return 0
+  sed -n "/^${field}=/{s/^${field}=//;p;q;}" "${file}" 2>/dev/null || true
+}
+
+# version_lt: return success when version $1 is strictly less than $2.
+# Only compares when BOTH look like dotted numeric versions (optionally
+# v-prefixed / with a pre-release suffix). Non-comparable inputs (e.g. git
+# SHAs) return failure so callers never block on them.
+version_lt() {
+  local a="${1#v}"
+  local b="${2#v}"
+  local ver_re='^[0-9]+(\.[0-9]+)*([.-].*)?$'
+  [[ "${a}" =~ ${ver_re} ]] || return 1
+  [[ "${b}" =~ ${ver_re} ]] || return 1
+  [[ "${a}" == "${b}" ]] && return 1
+  local first
+  first="$(printf '%s\n%s\n' "${a}" "${b}" | sort -V | head -n1)"
+  [[ "${first}" == "${a}" ]]
+}
+
+# merge_env_three_way: produce a merged runtime env that preserves the user's
+# existing values while adopting new keys/defaults from the new env.example.
+#
+#   merge_env_three_way NEW_EXAMPLE OLD_RUNTIME OLD_BASELINE NEW_DOTENV OUT DIFF
+#
+# OLD_BASELINE / NEW_DOTENV may be empty strings (absent). The merge is purely
+# line-based: every value is preserved with its original right-hand side, so
+# shell-sensitive payloads (${VAR} expansions, URLs with ://@, quotes) survive
+# untouched. The new env.example provides the structural template (comments,
+# ordering, new keys); old-only keys are appended verbatim and never dropped.
+merge_env_three_way() {
+  local new_example="$1"
+  local old_runtime="$2"
+  local old_baseline="$3"
+  local new_dotenv="$4"
+  local out_file="$5"
+  local diff_file="$6"
+
+  require_cmd python3
+  ensure_file "${new_example}"
+  ensure_file "${old_runtime}"
+
+  python3 - "${new_example}" "${old_runtime}" "${old_baseline}" "${new_dotenv}" "${out_file}" "${diff_file}" <<'PY'
+import re
+import sys
+
+new_example, old_runtime, old_baseline, new_dotenv, out_file, diff_file = sys.argv[1:7]
+
+KV_RE = re.compile(r'^([A-Za-z_][A-Za-z0-9_]*)=(.*)$')
+
+
+def parse(path):
+    """Ordered dict key -> raw value for active KEY=VALUE lines (last wins).
+
+    KEY must start at column 0 (KV_RE is anchored); indented `KEY=value` lines
+    are treated as structural text and preserved verbatim. The one-click env
+    files never indent keys, so this is safe.
+    """
+    kv = {}
+    if not path:
+        return kv
+    try:
+        with open(path, "r", encoding="utf-8") as fh:
+            for raw in fh:
+                # Strip both \n and a trailing \r so CRLF inputs compare and
+                # serialize consistently with the template's splitlines().
+                line = raw.rstrip("\r\n")
+                stripped = line.lstrip()
+                if not stripped or stripped.startswith("#"):
+                    continue
+                m = KV_RE.match(line)
+                if m:
+                    kv[m.group(1)] = m.group(2)
+    except FileNotFoundError:
+        pass
+    return kv
+
+
+new_defaults = parse(new_example)
+old_values = parse(old_runtime)
+old_baseline_vals = parse(old_baseline) if old_baseline else {}
+new_overrides = parse(new_dotenv) if new_dotenv else {}
+has_baseline = bool(old_baseline_vals)
+
+added = []
+updated_default = []
+preserved = []
+explicit = []
+
+out_lines = []
+with open(new_example, "r", encoding="utf-8") as fh:
+    template = fh.read().splitlines()
+
+for line in template:
+    stripped = line.lstrip()
+    if not stripped or stripped.startswith("#"):
+        out_lines.append(line)
+        continue
+    m = KV_RE.match(line)
+    if not m:
+        out_lines.append(line)
+        continue
+    key = m.group(1)
+    tmpl_val = m.group(2)
+    chosen = tmpl_val
+    # Treat a new-bundle .env value as an explicit operator override ONLY when it
+    # differs from the new env.example default. This is intentional: the common
+    # way to create a .env is `cp env.example .env`, which would otherwise make
+    # every key an "override" and clobber the user's existing customizations.
+    if key in new_overrides and new_overrides[key] != new_defaults.get(key):
+        chosen = new_overrides[key]
+        explicit.append(key)
+    elif key in old_values:
+        ov = old_values[key]
+        if (has_baseline and key in old_baseline_vals
+                and ov == old_baseline_vals[key] and ov != tmpl_val):
+            chosen = tmpl_val
+            updated_default.append((key, ov, tmpl_val))
+        else:
+            chosen = ov
+            if ov != tmpl_val:
+                preserved.append((key, ov))
+    else:
+        added.append((key, tmpl_val))
+    out_lines.append("%s=%s" % (key, chosen))
+
+# Old-only keys (present in old runtime, absent from the new template) are
+# host/user specific (NODE_IP, ROLE, control-plane addr, custom vars). Never
+# drop them: append verbatim so the running system keeps working.
+extra = [(k, v) for k, v in old_values.items() if k not in new_defaults]
+if extra:
+    out_lines.append("")
+    out_lines.append("# --- preserved custom settings (not in env.example) ---")
+    for k, v in extra:
+        out_lines.append("%s=%s" % (k, v))
+
+with open(out_file, "w", encoding="utf-8") as fh:
+    fh.write("\n".join(out_lines) + "\n")
+
+report = []
+report.append("env merge report (mode=%s)" % ("three-way" if has_baseline else "two-way-fallback"))
+report.append("")
+report.append("[added] new keys filled with new defaults: %d" % len(added))
+for k, v in added:
+    report.append("  + %s=%s" % (k, v))
+report.append("[default-updated] untouched keys adopting new default: %d" % len(updated_default))
+for k, ov, nv in updated_default:
+    report.append("  ~ %s: %s -> %s" % (k, ov, nv))
+report.append("[preserved] kept your customized values: %d" % len(preserved))
+for k, v in preserved:
+    report.append("  = %s=%s" % (k, v))
+report.append("[explicit] taken from new .env overrides: %d" % len(explicit))
+for k in explicit:
+    report.append("  ! %s" % k)
+report.append("[kept-extra] old-only keys not in new env.example (kept): %d" % len(extra))
+for k, v in extra:
+    report.append("  > %s=%s" % (k, v))
+
+with open(diff_file, "w", encoding="utf-8") as fh:
+    fh.write("\n".join(report) + "\n")
+
+sys.stderr.write(
+    "[one-click] env merge: +%d new, ~%d default-updated, =%d preserved, >%d kept-extra%s\n" % (
+        len(added), len(updated_default), len(preserved), len(extra),
+        "" if has_baseline else " (two-way fallback: no baseline)"))
+PY
+}
+
+# resolve_install_mode: decide between "install" (full reinstall) and
+# "upgrade" (config preserving). Prints the resolved mode to stdout; all
+# human-facing output goes to stderr so it can be captured via $(...).
+#
+#   resolve_install_mode REQUESTED_MODE INSTALL_PREFIX ASSUME_YES
+#
+# REQUESTED_MODE is one of "", install, upgrade, auto. When empty and an
+# existing install is detected, prompts on a TTY (default: upgrade) and falls
+# back to a full reinstall (with a loud warning) when non-interactive.
+resolve_install_mode() {
+  local requested="$1"
+  local install_prefix="$2"
+  local assume_yes="$3"
+
+  local existing="no"
+  detect_existing_install "${install_prefix}" && existing="yes"
+
+  case "${requested}" in
+    install)
+      printf 'install\n'
+      return 0
+      ;;
+    upgrade)
+      if [[ "${existing}" != "yes" ]]; then
+        die "no existing installation found under ${install_prefix} (missing .one-click.env); cannot upgrade. Run without --mode=upgrade for a fresh install."
+      fi
+      printf 'upgrade\n'
+      return 0
+      ;;
+    auto)
+      if [[ "${existing}" == "yes" ]]; then
+        printf 'upgrade\n'
+      else
+        printf 'install\n'
+      fi
+      return 0
+      ;;
+  esac
+
+  # Unset mode: default to install, but protect an existing install.
+  if [[ "${existing}" != "yes" ]]; then
+    printf 'install\n'
+    return 0
+  fi
+
+  if [[ "${assume_yes}" == "1" ]]; then
+    log "existing installation detected; --yes given, running config-preserving upgrade."
+    printf 'upgrade\n'
+    return 0
+  fi
+
+  if [[ -t 0 ]]; then
+    printf '%s' "[one-click] Existing installation detected under ${install_prefix}.
+[one-click] Run a config-preserving UPGRADE (keep your .one-click.env)? [Y/n]: " >&2
+    local reply=""
+    read -r reply || reply=""
+    case "${reply}" in
+      [Nn]|[Nn][Oo])
+        log "proceeding with full reinstall; existing config WILL be reset."
+        printf 'install\n'
+        ;;
+      *)
+        log "proceeding with config-preserving upgrade."
+        printf 'upgrade\n'
+        ;;
+    esac
+    return 0
+  fi
+
+  log "WARNING: existing installation detected but running non-interactively without --mode."
+  log "WARNING: defaulting to a full REINSTALL; your .one-click.env customizations WILL be reset."
+  log "WARNING: to preserve configuration, re-run with --mode=upgrade (or --yes)."
+  printf 'install\n'
+  return 0
+}
+
+# preflight_upgrade: fail-fast checks before a config-preserving upgrade.
+#
+#   preflight_upgrade INSTALL_PREFIX BUNDLE_DIR PACKAGE_TAR NEW_ROLE \
+#                     ALLOW_ROLE_CHANGE ALLOW_DOWNGRADE
+preflight_upgrade() {
+  local install_prefix="$1"
+  local bundle_dir="$2"
+  local package_tar="$3"
+  local new_role="$4"
+  local allow_role_change="$5"
+  local allow_downgrade="$6"
+
+  if [[ ! -d "${install_prefix}/scripts" ]]; then
+    log "WARNING: ${install_prefix}/scripts not found; existing install may be incomplete"
+  fi
+
+  local old_role
+  old_role="$(read_env_key "${install_prefix}/.one-click.env" ONE_CLICK_DEPLOY_ROLE)"
+  old_role="${old_role:-control}"
+  if [[ "${old_role}" != "${new_role}" ]]; then
+    if [[ "${allow_role_change}" == "1" ]]; then
+      log "WARNING: changing node role on upgrade: ${old_role} -> ${new_role} (--allow-role-change)"
+    else
+      die "refusing to change node role on upgrade: installed=${old_role}, requested=${new_role}. Re-run with the matching role, or pass --allow-role-change to override."
+    fi
+  fi
+
+  local old_ver new_ver
+  old_ver="$(read_version_field "${install_prefix}/VERSION.txt" release_version)"
+  new_ver="$(read_version_field "${bundle_dir}/VERSION.txt" release_version)"
+  if [[ -n "${old_ver}" && -n "${new_ver}" ]]; then
+    log "upgrade version: ${old_ver} -> ${new_ver}"
+    if [[ "${old_ver}" == "${new_ver}" ]]; then
+      log "note: re-installing the same version (${new_ver})."
+    elif version_lt "${new_ver}" "${old_ver}"; then
+      if [[ "${allow_downgrade}" == "1" ]]; then
+        log "WARNING: downgrade allowed: ${old_ver} -> ${new_ver} (--allow-downgrade)"
+      else
+        die "refusing to downgrade: installed=${old_ver}, package=${new_ver}. Pass --allow-downgrade to override."
+      fi
+    fi
+  else
+    log "version comparison skipped (missing/unparseable VERSION.txt); proceeding."
+  fi
+
+  preflight_upgrade_disk_space "${install_prefix}" "${package_tar}"
+}
+
+# preflight_upgrade_disk_space: ensure enough free space for extract + copy +
+# backup. Best-effort: skips silently when df/stat are unavailable.
+preflight_upgrade_disk_space() {
+  local install_prefix="$1"
+  local package_tar="$2"
+
+  command -v df >/dev/null 2>&1 || { log "df unavailable; skipping disk space preflight"; return 0; }
+  command -v stat >/dev/null 2>&1 || { log "stat unavailable; skipping disk space preflight"; return 0; }
+  [[ -f "${package_tar}" ]] || return 0
+
+  local pkg_bytes need_kb avail_kb check
+  pkg_bytes="$(stat -c %s "${package_tar}" 2>/dev/null || echo 0)"
+  # New artifacts + extraction headroom: ~3x the compressed package + 100MB.
+  need_kb=$(( (pkg_bytes / 1024) * 3 + 102400 ))
+
+  check="${install_prefix}"
+  while [[ ! -e "${check}" ]]; do
+    local parent
+    parent="$(dirname "${check}")"
+    [[ "${parent}" != "${check}" ]] || break
+    check="${parent}"
+  done
+
+  avail_kb="$(df -Pk "${check}" 2>/dev/null | awk 'NR==2 {print $4}')"
+  if [[ -n "${avail_kb}" && "${avail_kb}" =~ ^[0-9]+$ && "${need_kb}" -gt 0 && "${avail_kb}" -lt "${need_kb}" ]]; then
+    die "insufficient disk space for upgrade under ${check}: need ~$((need_kb / 1024))MB, available $((avail_kb / 1024))MB"
+  fi
+  if [[ -n "${avail_kb}" && "${avail_kb}" =~ ^[0-9]+$ ]]; then
+    log "disk space preflight OK ($((avail_kb / 1024))MB available, ~$((need_kb / 1024))MB required)"
+  fi
+}
+
+# backup_before_upgrade: snapshot the runtime env + component configs + version
+# metadata into a timestamped backup dir. Prints the backup dir to stdout.
+backup_before_upgrade() {
+  local install_prefix="$1"
+  local ts backup_dir rel
+  ts="$(date +%Y%m%d-%H%M%S)"
+  backup_dir="${install_prefix}/.backup/upgrade-${ts}"
+  mkdir -p "${backup_dir}"
+
+  for rel in \
+    ".one-click.env" \
+    "env.example" \
+    "VERSION.txt" \
+    "release-manifest.json" \
+    "CubeMaster/conf.yaml" \
+    "Cubelet/config/config.toml" \
+    "cube-shim/conf/config-cube.toml" \
+    "network-agent/network-agent.yaml" \
+    "cubeproxy/global.conf" \
+    "cubeproxy/nginx.conf" \
+    "coredns/Corefile" \
+    "coredns/resolv.conf.upstream" \
+    "webui/nginx.generated.conf"
+  do
+    if [[ -f "${install_prefix}/${rel}" ]]; then
+      mkdir -p "${backup_dir}/$(dirname "${rel}")"
+      cp -a "${install_prefix}/${rel}" "${backup_dir}/${rel}"
+    fi
+  done
+
+  if [[ -d "${install_prefix}/Cubelet/dynamicconf" ]]; then
+    mkdir -p "${backup_dir}/Cubelet"
+    cp -a "${install_prefix}/Cubelet/dynamicconf" "${backup_dir}/Cubelet/dynamicconf"
+  fi
+
+  log "backed up existing config to ${backup_dir}"
+  printf '%s\n' "${backup_dir}"
+}
+
 detect_pkg_manager() {
   if command -v apt-get >/dev/null 2>&1; then
     printf 'apt'
@@ -818,6 +1215,12 @@ _check_cidr_conflict() {
 # to prevent sed command injection (sed 'w' flag) and env file shell injection.
 check_cidr_preflight() {
   local cidr="${1:-}"
+  # Optional second arg forces skipping host-conflict detection (format
+  # validation is always enforced). Defaults to the env bypass flag. The
+  # upgrade flow passes 1 here: the preserved CIDR is already in use by this
+  # cluster's own cubevs bridge/route, which would otherwise be misdetected as
+  # a conflict and block the upgrade.
+  local skip_conflict="${2:-${CUBE_SANDBOX_NETWORK_CIDR_SKIP_CONFLICT_CHECK:-0}}"
 
   # When env var not set: skip validation, use config.toml default
   if [[ -z "${cidr}" ]]; then
@@ -889,8 +1292,8 @@ check_cidr_preflight() {
   # ======================================================================
 
   # 5. Check bypass flag -- only skips conflict detection, not format validation
-  if [[ "${CUBE_SANDBOX_NETWORK_CIDR_SKIP_CONFLICT_CHECK:-0}" == "1" ]]; then
-    log "CUBE_SANDBOX_NETWORK_CIDR conflict check SKIPPED (bypass flag set) -- CIDR: ${cidr}"
+  if [[ "${skip_conflict}" == "1" ]]; then
+    log "CUBE_SANDBOX_NETWORK_CIDR conflict check SKIPPED -- CIDR: ${cidr}"
     return 0
   fi
 

--- a/deploy/one-click/scripts/common/validation.sh
+++ b/deploy/one-click/scripts/common/validation.sh
@@ -9,6 +9,13 @@ if [[ "${ONE_CLICK_VALIDATION_LIB_LOADED:-0}" == "1" ]]; then
 fi
 ONE_CLICK_VALIDATION_LIB_LOADED=1
 
+if ! type die >/dev/null 2>&1; then
+  die() {
+    echo "[validation] ERROR: $*" >&2
+    exit 1
+  }
+fi
+
 validate_ipv4_literal() {
   local value="$1"
   local name="${2:-IPv4 address}"

--- a/deploy/one-click/scripts/common/validation.sh
+++ b/deploy/one-click/scripts/common/validation.sh
@@ -1,0 +1,42 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (C) 2026 Tencent. All rights reserved.
+#
+# Shared validation helpers for one-click installer/runtime scripts.
+# This file is sourced by callers that already define die().
+
+if [[ "${ONE_CLICK_VALIDATION_LIB_LOADED:-0}" == "1" ]]; then
+  return 0
+fi
+ONE_CLICK_VALIDATION_LIB_LOADED=1
+
+validate_ipv4_literal() {
+  local value="$1"
+  local name="${2:-IPv4 address}"
+  local a b c d
+  [[ "${value}" =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$ ]] \
+    || die "invalid ${name}: ${value} (expected IPv4 address)"
+  IFS=. read -r a b c d <<< "${value}"
+  local octet
+  for octet in "${a}" "${b}" "${c}" "${d}"; do
+    [[ "${octet}" =~ ^[0-9]{1,3}$ ]] || die "invalid ${name}: ${value}"
+    (( 10#${octet} >= 0 && 10#${octet} <= 255 )) \
+      || die "invalid ${name}: ${value} (octet out of range)"
+  done
+}
+
+validate_host_port() {
+  local value="$1"
+  local name="${2:-host:port}"
+  local host port
+  [[ -n "${value}" ]] || die "${name} must not be empty"
+  # This value is written into env files and later into YAML/TOML snippets.
+  # Keep it intentionally narrow: hostnames/IPv4 plus :port, no quotes,
+  # whitespace, slash, comments, or control characters.
+  [[ "${value}" =~ ^[A-Za-z0-9.-]+:[0-9]+$ ]] \
+    || die "invalid ${name}: ${value} (expected host:port)"
+  host="${value%:*}"
+  port="${value##*:}"
+  [[ -n "${host}" && -n "${port}" ]] || die "invalid ${name}: ${value}"
+  (( 10#${port} >= 1 && 10#${port} <= 65535 )) \
+    || die "invalid ${name}: ${value} (port out of range)"
+}

--- a/deploy/one-click/scripts/one-click/common.sh
+++ b/deploy/one-click/scripts/one-click/common.sh
@@ -30,6 +30,9 @@ die() {
   exit 1
 }
 
+# shellcheck source=../common/validation.sh
+source "${ONE_CLICK_RUNTIME_SCRIPT_DIR}/../common/validation.sh"
+
 require_cmd() {
   local cmd="$1"
   command -v "${cmd}" >/dev/null 2>&1 || die "required command not found: ${cmd}"
@@ -188,11 +191,14 @@ resolve_control_plane_cubemaster_addr() {
   fi
 
   if [[ -n "${addr}" ]]; then
+    validate_host_port "${addr}" "ONE_CLICK_CONTROL_PLANE_CUBEMASTER_ADDR"
     printf '%s\n' "${addr}"
     return 0
   fi
 
   if [[ -n "${ip}" ]]; then
+    validate_ipv4_literal "${ip}" "ONE_CLICK_CONTROL_PLANE_IP"
+    validate_host_port "${ip}:${port}" "ONE_CLICK_CONTROL_PLANE_IP-derived cubemaster address"
     printf '%s:%s\n' "${ip}" "${port}"
     return 0
   fi

--- a/deploy/one-click/scripts/systemd/common.sh
+++ b/deploy/one-click/scripts/systemd/common.sh
@@ -20,6 +20,9 @@ die() {
   exit 1
 }
 
+# shellcheck source=../common/validation.sh
+source "${SYSTEMD_HELPER_DIR}/../common/validation.sh"
+
 require_cmd() {
   local cmd="$1"
   command -v "${cmd}" >/dev/null 2>&1 || die "required command not found: ${cmd}"
@@ -135,11 +138,14 @@ resolve_control_plane_cubemaster_addr() {
   fi
 
   if [[ -n "${addr}" ]]; then
+    validate_host_port "${addr}" "ONE_CLICK_CONTROL_PLANE_CUBEMASTER_ADDR"
     printf '%s\n' "${addr}"
     return 0
   fi
 
   if [[ -n "${ip}" ]]; then
+    validate_ipv4_literal "${ip}" "ONE_CLICK_CONTROL_PLANE_IP"
+    validate_host_port "${ip}:${port}" "ONE_CLICK_CONTROL_PLANE_IP-derived cubemaster address"
     printf '%s:%s\n' "${ip}" "${port}"
     return 0
   fi

--- a/deploy/one-click/tests/test_env_merge.sh
+++ b/deploy/one-click/tests/test_env_merge.sh
@@ -238,9 +238,10 @@ test_version_lt() {
   version_lt v0.2.2 v0.2.3 || fail "v0.2.2 < v0.2.3 should be true"
   ! version_lt 2.0.0 1.0.0 || fail "2.0.0 < 1.0.0 should be false"
   ! version_lt 1.2.3 1.2.3 || fail "equal versions should not be <"
-  # non-comparable (git shas) -> never less-than (no downgrade block)
-  ! version_lt a1b2c3d e5f6a7b || fail "non-semver should not compare as <"
-  ! version_lt 1.0.0 a1b2c3d || fail "mixed semver/sha should not compare as <"
+  # non-semver / SHA-like inputs are intentionally not comparable by version_lt:
+  # the upgrade downgrade guard must not block on legacy labels.
+  ! version_lt a1b2c3d e5f6a7b || fail "git SHA-like versions should not compare as <"
+  ! version_lt 1.0.0 a1b2c3d || fail "mixed semver/SHA-like inputs should not compare as <"
 }
 
 test_diff_report_redacts_secrets() {
@@ -251,6 +252,8 @@ test_diff_report_redacts_secrets() {
   cat > "${old}" <<'EOF'
 CUBE_SANDBOX_REDIS_PASSWORD=topsecret123
 DATABASE_URL=mysql://u:p@host:3306/realdb
+AGENTHUB_DEEPSEEK_API_KEY=sk-agenthub-secret
+OPENCLAW_DEEPSEEK_API_KEY=sk-openclaw-secret
 EOF
 
   merge_env_three_way "${new}" "${old}" "" "" "${out}" "${diff}" 2>/dev/null
@@ -258,12 +261,32 @@ EOF
   # The diff report must NOT leak plaintext secrets...
   assert_contains "${diff}" "CUBE_SANDBOX_REDIS_PASSWORD=***REDACTED***"
   assert_contains "${diff}" "DATABASE_URL=***REDACTED***"
+  assert_contains "${diff}" "AGENTHUB_DEEPSEEK_API_KEY=***REDACTED***"
+  assert_contains "${diff}" "OPENCLAW_DEEPSEEK_API_KEY=***REDACTED***"
   assert_not_contains "${diff}" "topsecret123"
   assert_not_contains "${diff}" "realdb"
+  assert_not_contains "${diff}" "sk-agenthub-secret"
+  assert_not_contains "${diff}" "sk-openclaw-secret"
 
   # ...but the merged runtime env MUST keep the real values intact.
   assert_value "${out}" CUBE_SANDBOX_REDIS_PASSWORD topsecret123
   assert_value "${out}" DATABASE_URL "mysql://u:p@host:3306/realdb"
+  assert_value "${out}" AGENTHUB_DEEPSEEK_API_KEY "sk-agenthub-secret"
+  assert_value "${out}" OPENCLAW_DEEPSEEK_API_KEY "sk-openclaw-secret"
+}
+
+test_non_utf8_env_fails_cleanly() {
+  local new="${TMP_DIR}/new_bad_utf8.example" old="${TMP_DIR}/old_bad_utf8.env"
+  local out="${TMP_DIR}/out_bad_utf8.env" diff="${TMP_DIR}/diff_bad_utf8.txt" err="${TMP_DIR}/bad_utf8.err"
+  write_new_example "${new}"
+  printf 'CUBE_SANDBOX_MYSQL_PORT=3307\nBAD=\xff\n' > "${old}"
+
+  if merge_env_three_way "${new}" "${old}" "" "" "${out}" "${diff}" 2>"${err}"; then
+    fail "merge_env_three_way should reject non-UTF-8 input"
+  fi
+  assert_contains "${err}" "env merge input is not valid UTF-8"
+  assert_contains "${err}" "${old}"
+  [[ ! -e "${out}" || ! -s "${out}" ]] || fail "merged env should not be written for invalid UTF-8 input"
 }
 
 test_read_helpers_reject_invalid_key() {
@@ -345,6 +368,7 @@ test_two_way_fallback_without_baseline
 test_new_dotenv_overrides_take_priority
 test_version_lt
 test_diff_report_redacts_secrets
+test_non_utf8_env_fails_cleanly
 test_read_helpers_reject_invalid_key
 test_read_helpers
 test_detect_existing_install

--- a/deploy/one-click/tests/test_env_merge.sh
+++ b/deploy/one-click/tests/test_env_merge.sh
@@ -243,6 +243,42 @@ test_version_lt() {
   ! version_lt 1.0.0 a1b2c3d || fail "mixed semver/sha should not compare as <"
 }
 
+test_diff_report_redacts_secrets() {
+  local new="${TMP_DIR}/new_sec.example" old="${TMP_DIR}/old_sec.env"
+  local out="${TMP_DIR}/out_sec.env" diff="${TMP_DIR}/diff_sec.txt"
+  write_new_example "${new}"
+  # User customized the secret values -> they appear in [preserved].
+  cat > "${old}" <<'EOF'
+CUBE_SANDBOX_REDIS_PASSWORD=topsecret123
+DATABASE_URL=mysql://u:p@host:3306/realdb
+EOF
+
+  merge_env_three_way "${new}" "${old}" "" "" "${out}" "${diff}" 2>/dev/null
+
+  # The diff report must NOT leak plaintext secrets...
+  assert_contains "${diff}" "CUBE_SANDBOX_REDIS_PASSWORD=***REDACTED***"
+  assert_contains "${diff}" "DATABASE_URL=***REDACTED***"
+  assert_not_contains "${diff}" "topsecret123"
+  assert_not_contains "${diff}" "realdb"
+
+  # ...but the merged runtime env MUST keep the real values intact.
+  assert_value "${out}" CUBE_SANDBOX_REDIS_PASSWORD topsecret123
+  assert_value "${out}" DATABASE_URL "mysql://u:p@host:3306/realdb"
+}
+
+test_read_helpers_reject_invalid_key() {
+  local f="${TMP_DIR}/inv.env"
+  cat > "${f}" <<'EOF'
+ONE_CLICK_DEPLOY_ROLE=control
+EOF
+  if ( read_env_key "${f}" 'bad/key' ) >/dev/null 2>&1; then
+    fail "read_env_key should reject an invalid key name"
+  fi
+  if ( read_version_field "${f}" 'bad.field' ) >/dev/null 2>&1; then
+    fail "read_version_field should reject an invalid field name"
+  fi
+}
+
 test_read_helpers() {
   local f="${TMP_DIR}/ver.txt"
   cat > "${f}" <<'EOF'
@@ -308,6 +344,8 @@ test_preserves_comments_and_structure
 test_two_way_fallback_without_baseline
 test_new_dotenv_overrides_take_priority
 test_version_lt
+test_diff_report_redacts_secrets
+test_read_helpers_reject_invalid_key
 test_read_helpers
 test_detect_existing_install
 test_crlf_inputs_do_not_leak_carriage_returns

--- a/deploy/one-click/tests/test_env_merge.sh
+++ b/deploy/one-click/tests/test_env_merge.sh
@@ -1,0 +1,316 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (C) 2026 Tencent. All rights reserved.
+#
+# Unit tests for the config-preserving env merge used by `install.sh --mode upgrade`
+# (M3-1/M3-3). These exercise merge_env_three_way and the version/env helpers in
+# lib/common.sh without touching the system.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ONE_CLICK_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+TMP_DIR="$(mktemp -d)"
+cleanup() {
+  rm -rf "${TMP_DIR}"
+}
+trap cleanup EXIT
+
+# shellcheck source=../lib/common.sh
+source "${ONE_CLICK_DIR}/lib/common.sh"
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+# get_value FILE KEY -> prints raw RHS of the last active KEY= line.
+get_value() {
+  local file="$1" key="$2"
+  sed -n "/^${key}=/{s/^${key}=//;p;}" "${file}" | tail -n 1
+}
+
+assert_value() {
+  local file="$1" key="$2" expected="$3"
+  local actual
+  actual="$(get_value "${file}" "${key}")"
+  [[ "${actual}" == "${expected}" ]] || fail "expected ${key}='${expected}', got '${actual}'"
+}
+
+assert_contains() {
+  grep -Fq -- "$2" "$1" || fail "expected $1 to contain: $2"
+}
+
+assert_not_contains() {
+  if grep -Fq -- "$2" "$1"; then
+    fail "expected $1 NOT to contain: $2"
+  fi
+}
+
+write_new_example() {
+  cat > "$1" <<'EOF'
+# sample env template
+ONE_CLICK_INSTALL_PREFIX=/usr/local/services/cubetoolbox
+ONE_CLICK_DEPLOY_ROLE=control
+CUBE_PVM_ENABLE=0
+CUBE_SANDBOX_MYSQL_PORT=3306
+CUBE_SANDBOX_REDIS_PASSWORD=ceuhvu123
+WEB_UI_IMAGE=registry/openresty:1.21.4.1-6
+CUBE_PROXY_CERT_DIR="${ONE_CLICK_INSTALL_PREFIX}/cubeproxy/certs"
+DATABASE_URL=mysql://cube:cube_pass@127.0.0.1:3306/cube_mvp
+NEW_FEATURE_FLAG=on
+# CUBE_SANDBOX_NODE_IP=10.0.0.10
+EOF
+}
+
+test_preserves_user_customized_value() {
+  local new="${TMP_DIR}/new1.example" old="${TMP_DIR}/old1.env"
+  local out="${TMP_DIR}/out1.env" diff="${TMP_DIR}/diff1.txt"
+  write_new_example "${new}"
+  cat > "${old}" <<'EOF'
+CUBE_SANDBOX_MYSQL_PORT=3307
+CUBE_SANDBOX_REDIS_PASSWORD=mysecret
+ONE_CLICK_DEPLOY_ROLE=control
+EOF
+
+  merge_env_three_way "${new}" "${old}" "" "" "${out}" "${diff}" 2>/dev/null
+
+  assert_value "${out}" CUBE_SANDBOX_MYSQL_PORT 3307
+  assert_value "${out}" CUBE_SANDBOX_REDIS_PASSWORD mysecret
+  # untouched key keeps new default
+  assert_value "${out}" NEW_FEATURE_FLAG on
+}
+
+test_adds_new_keys_with_defaults() {
+  local new="${TMP_DIR}/new2.example" old="${TMP_DIR}/old2.env"
+  local out="${TMP_DIR}/out2.env" diff="${TMP_DIR}/diff2.txt"
+  write_new_example "${new}"
+  cat > "${old}" <<'EOF'
+CUBE_SANDBOX_MYSQL_PORT=3306
+EOF
+
+  merge_env_three_way "${new}" "${old}" "" "" "${out}" "${diff}" 2>/dev/null
+
+  assert_value "${out}" NEW_FEATURE_FLAG on
+  assert_contains "${diff}" "[added]"
+  assert_contains "${diff}" "NEW_FEATURE_FLAG=on"
+}
+
+test_three_way_adopts_new_default_for_untouched_key() {
+  local new="${TMP_DIR}/new3.example" old="${TMP_DIR}/old3.env" base="${TMP_DIR}/base3.example"
+  local out="${TMP_DIR}/out3.env" diff="${TMP_DIR}/diff3.txt"
+  write_new_example "${new}"
+  # baseline (old defaults) had the OLD image tag
+  cat > "${base}" <<'EOF'
+WEB_UI_IMAGE=registry/openresty:1.21.4.0-OLD
+CUBE_SANDBOX_MYSQL_PORT=3306
+EOF
+  # user never touched WEB_UI_IMAGE -> still equals old default
+  cat > "${old}" <<'EOF'
+WEB_UI_IMAGE=registry/openresty:1.21.4.0-OLD
+CUBE_SANDBOX_MYSQL_PORT=3306
+EOF
+
+  merge_env_three_way "${new}" "${old}" "${base}" "" "${out}" "${diff}" 2>/dev/null
+
+  # adopts the NEW default since the user never customized it
+  assert_value "${out}" WEB_UI_IMAGE "registry/openresty:1.21.4.1-6"
+  assert_contains "${diff}" "three-way"
+  assert_contains "${diff}" "[default-updated]"
+}
+
+test_three_way_keeps_customized_over_new_default() {
+  local new="${TMP_DIR}/new4.example" old="${TMP_DIR}/old4.env" base="${TMP_DIR}/base4.example"
+  local out="${TMP_DIR}/out4.env" diff="${TMP_DIR}/diff4.txt"
+  write_new_example "${new}"
+  cat > "${base}" <<'EOF'
+WEB_UI_IMAGE=registry/openresty:1.21.4.0-OLD
+EOF
+  # user DID customize WEB_UI_IMAGE
+  cat > "${old}" <<'EOF'
+WEB_UI_IMAGE=registry/my-custom-openresty:9.9
+EOF
+
+  merge_env_three_way "${new}" "${old}" "${base}" "" "${out}" "${diff}" 2>/dev/null
+
+  assert_value "${out}" WEB_UI_IMAGE "registry/my-custom-openresty:9.9"
+  assert_contains "${diff}" "[preserved]"
+}
+
+test_preserves_shell_sensitive_values() {
+  local new="${TMP_DIR}/new5.example" old="${TMP_DIR}/old5.env"
+  local out="${TMP_DIR}/out5.env" diff="${TMP_DIR}/diff5.txt"
+  write_new_example "${new}"
+  # user customized a value containing '=' and a URL with ://@
+  cat > "${old}" <<'EOF'
+DATABASE_URL=mysql://u:p@host:3306/db2
+WEIRD_KEY=a=b=c
+EOF
+
+  merge_env_three_way "${new}" "${old}" "" "" "${out}" "${diff}" 2>/dev/null
+
+  # ${} expansion in an untouched key is kept verbatim (not expanded/mangled)
+  assert_contains "${out}" 'CUBE_PROXY_CERT_DIR="${ONE_CLICK_INSTALL_PREFIX}/cubeproxy/certs"'
+  assert_value "${out}" DATABASE_URL "mysql://u:p@host:3306/db2"
+  # WEIRD_KEY is old-only -> appended verbatim, value with '=' intact
+  assert_value "${out}" WEIRD_KEY "a=b=c"
+
+  # The merged file must remain valid shell that sources cleanly and expands ${}
+  # using the (preserved) ONE_CLICK_INSTALL_PREFIX line from the template itself.
+  (
+    set -a
+    # shellcheck disable=SC1090
+    source "${out}"
+    set +a
+    [[ "${CUBE_PROXY_CERT_DIR}" == "/usr/local/services/cubetoolbox/cubeproxy/certs" ]] \
+      || { echo "expansion failed: ${CUBE_PROXY_CERT_DIR}" >&2; exit 1; }
+    [[ "${DATABASE_URL}" == "mysql://u:p@host:3306/db2" ]] || exit 1
+    [[ "${WEIRD_KEY}" == "a=b=c" ]] || exit 1
+  ) || fail "merged env did not source/expand correctly"
+}
+
+test_keeps_old_only_host_keys() {
+  local new="${TMP_DIR}/new6.example" old="${TMP_DIR}/old6.env"
+  local out="${TMP_DIR}/out6.env" diff="${TMP_DIR}/diff6.txt"
+  write_new_example "${new}"
+  # NODE_IP is commented in the template; it must survive as an active key.
+  cat > "${old}" <<'EOF'
+CUBE_SANDBOX_NODE_IP=10.0.0.5
+ONE_CLICK_CONTROL_PLANE_IP=10.0.0.11
+EOF
+
+  merge_env_three_way "${new}" "${old}" "" "" "${out}" "${diff}" 2>/dev/null
+
+  assert_value "${out}" CUBE_SANDBOX_NODE_IP 10.0.0.5
+  assert_value "${out}" ONE_CLICK_CONTROL_PLANE_IP 10.0.0.11
+  assert_contains "${out}" "preserved custom settings"
+  assert_contains "${diff}" "[kept-extra]"
+}
+
+test_preserves_comments_and_structure() {
+  local new="${TMP_DIR}/new7.example" old="${TMP_DIR}/old7.env"
+  local out="${TMP_DIR}/out7.env" diff="${TMP_DIR}/diff7.txt"
+  write_new_example "${new}"
+  : > "${old}"
+
+  merge_env_three_way "${new}" "${old}" "" "" "${out}" "${diff}" 2>/dev/null
+
+  assert_contains "${out}" "# sample env template"
+  assert_contains "${out}" "# CUBE_SANDBOX_NODE_IP=10.0.0.10"
+}
+
+test_two_way_fallback_without_baseline() {
+  local new="${TMP_DIR}/new8.example" old="${TMP_DIR}/old8.env"
+  local out="${TMP_DIR}/out8.env" diff="${TMP_DIR}/diff8.txt"
+  write_new_example "${new}"
+  # untouched-by-user key equals OLD default; with no baseline we cannot tell,
+  # so the old value must be kept (two-way: old wins).
+  cat > "${old}" <<'EOF'
+WEB_UI_IMAGE=registry/openresty:1.21.4.0-OLD
+EOF
+
+  merge_env_three_way "${new}" "${old}" "" "" "${out}" "${diff}" 2>/dev/null
+
+  assert_value "${out}" WEB_UI_IMAGE "registry/openresty:1.21.4.0-OLD"
+  assert_contains "${diff}" "two-way-fallback"
+}
+
+test_new_dotenv_overrides_take_priority() {
+  local new="${TMP_DIR}/new9.example" old="${TMP_DIR}/old9.env" dotenv="${TMP_DIR}/new9.env"
+  local out="${TMP_DIR}/out9.env" diff="${TMP_DIR}/diff9.txt"
+  write_new_example "${new}"
+  cat > "${old}" <<'EOF'
+CUBE_SANDBOX_MYSQL_PORT=3307
+EOF
+  # operator explicitly sets a different value in the new bundle .env
+  cat > "${dotenv}" <<'EOF'
+CUBE_SANDBOX_MYSQL_PORT=3399
+EOF
+
+  merge_env_three_way "${new}" "${old}" "" "${dotenv}" "${out}" "${diff}" 2>/dev/null
+
+  assert_value "${out}" CUBE_SANDBOX_MYSQL_PORT 3399
+  assert_contains "${diff}" "[explicit]"
+}
+
+test_version_lt() {
+  version_lt 1.0.0 2.0.0 || fail "1.0.0 < 2.0.0 should be true"
+  version_lt v0.2.2 v0.2.3 || fail "v0.2.2 < v0.2.3 should be true"
+  ! version_lt 2.0.0 1.0.0 || fail "2.0.0 < 1.0.0 should be false"
+  ! version_lt 1.2.3 1.2.3 || fail "equal versions should not be <"
+  # non-comparable (git shas) -> never less-than (no downgrade block)
+  ! version_lt a1b2c3d e5f6a7b || fail "non-semver should not compare as <"
+  ! version_lt 1.0.0 a1b2c3d || fail "mixed semver/sha should not compare as <"
+}
+
+test_read_helpers() {
+  local f="${TMP_DIR}/ver.txt"
+  cat > "${f}" <<'EOF'
+release_version=v0.5.0
+git_commit=abc123
+EOF
+  [[ "$(read_version_field "${f}" release_version)" == "v0.5.0" ]] || fail "read_version_field"
+  [[ "$(read_version_field "${f}" missing)" == "" ]] || fail "read_version_field missing"
+
+  local e="${TMP_DIR}/role.env"
+  cat > "${e}" <<'EOF'
+ONE_CLICK_DEPLOY_ROLE=compute
+EOF
+  [[ "$(read_env_key "${e}" ONE_CLICK_DEPLOY_ROLE)" == "compute" ]] || fail "read_env_key"
+}
+
+test_detect_existing_install() {
+  local d="${TMP_DIR}/inst"
+  mkdir -p "${d}"
+  ! detect_existing_install "${d}" || fail "should not detect install without .one-click.env"
+  : > "${d}/.one-click.env"
+  detect_existing_install "${d}" || fail "should detect install with .one-click.env"
+}
+
+test_crlf_inputs_do_not_leak_carriage_returns() {
+  local new="${TMP_DIR}/new10.example" old="${TMP_DIR}/old10.env"
+  local out="${TMP_DIR}/out10.env" diff="${TMP_DIR}/diff10.txt"
+  write_new_example "${new}"
+  # old runtime written with CRLF line endings
+  printf 'CUBE_SANDBOX_MYSQL_PORT=3307\r\nCUSTOM_ONLY=keepme\r\n' > "${old}"
+
+  merge_env_three_way "${new}" "${old}" "" "" "${out}" "${diff}" 2>/dev/null
+
+  # No carriage returns should survive into the merged output
+  if grep -q $'\r' "${out}"; then
+    fail "merged output contains carriage returns"
+  fi
+  assert_value "${out}" CUBE_SANDBOX_MYSQL_PORT 3307
+  assert_value "${out}" CUSTOM_ONLY keepme
+}
+
+test_cidr_preflight_skip_conflict_param() {
+  # skip=1 must still enforce format validation (invalid format -> die)
+  if ( check_cidr_preflight "not-a-cidr" 1 ) >/dev/null 2>&1; then
+    fail "invalid CIDR should fail format validation even with skip=1"
+  fi
+  # misaligned network address -> die even with skip=1
+  if ( check_cidr_preflight "10.0.0.5/16" 1 ) >/dev/null 2>&1; then
+    fail "misaligned CIDR should fail even with skip=1"
+  fi
+  # valid + skip=1 -> passes without touching host interfaces/routes
+  ( check_cidr_preflight "10.123.0.0/16" 1 ) >/dev/null 2>&1 \
+    || fail "valid CIDR with skip=1 should pass"
+}
+
+test_preserves_user_customized_value
+test_adds_new_keys_with_defaults
+test_three_way_adopts_new_default_for_untouched_key
+test_three_way_keeps_customized_over_new_default
+test_preserves_shell_sensitive_values
+test_keeps_old_only_host_keys
+test_preserves_comments_and_structure
+test_two_way_fallback_without_baseline
+test_new_dotenv_overrides_take_priority
+test_version_lt
+test_read_helpers
+test_detect_existing_install
+test_crlf_inputs_do_not_leak_carriage_returns
+test_cidr_preflight_skip_conflict_param
+
+echo "env merge tests OK"

--- a/deploy/one-click/tests/test_install_mode.sh
+++ b/deploy/one-click/tests/test_install_mode.sh
@@ -99,13 +99,93 @@ test_assume_yes_existing_is_upgrade() {
   [[ "${got}" == "upgrade" ]] || fail "default+existing+--yes should be upgrade (got ${got})"
 }
 
+test_parse_args_space_and_equals_forms() {
+  one_click_parse_args --mode upgrade
+  [[ "${CLI_MODE}" == "upgrade" ]] || fail "--mode upgrade (space) should set CLI_MODE (got '${CLI_MODE}')"
+  one_click_parse_args --mode=upgrade
+  [[ "${CLI_MODE}" == "upgrade" ]] || fail "--mode=upgrade should set CLI_MODE (got '${CLI_MODE}')"
+
+  one_click_parse_args --node-ip 10.0.0.7
+  [[ "${CLI_NODE_IP}" == "10.0.0.7" ]] || fail "--node-ip (space) should set CLI_NODE_IP (got '${CLI_NODE_IP}')"
+  one_click_parse_args --node-ip=10.0.0.8
+  [[ "${CLI_NODE_IP}" == "10.0.0.8" ]] || fail "--node-ip= should set CLI_NODE_IP (got '${CLI_NODE_IP}')"
+
+  one_click_parse_args -y --allow-downgrade --allow-role-change
+  [[ "${CLI_ASSUME_YES}" == "1" ]] || fail "-y should set CLI_ASSUME_YES"
+  [[ "${CLI_ALLOW_DOWNGRADE}" == "1" ]] || fail "--allow-downgrade should set CLI_ALLOW_DOWNGRADE"
+  [[ "${CLI_ALLOW_ROLE_CHANGE}" == "1" ]] || fail "--allow-role-change should set CLI_ALLOW_ROLE_CHANGE"
+}
+
+test_parse_args_missing_value_fails() {
+  if ( one_click_parse_args --mode ) >/dev/null 2>&1; then
+    fail "bare --mode should fail (missing value)"
+  fi
+  if ( one_click_parse_args --node-ip ) >/dev/null 2>&1; then
+    fail "bare --node-ip should fail (missing value)"
+  fi
+}
+
+test_parse_args_unknown_is_ignored() {
+  # Unknown tokens warn but do not fail, and do not set any CLI_* value.
+  one_click_parse_args --not-a-flag positional 2>/dev/null
+  [[ -z "${CLI_MODE}" ]] || fail "unknown args should not set CLI_MODE"
+}
+
+test_assert_safe_install_prefix() {
+  for bad in "/" "/usr" "/etc" "/home" "relative/path" "/toplevel"; do
+    if ( assert_safe_install_prefix "${bad}" ) >/dev/null 2>&1; then
+      fail "assert_safe_install_prefix should reject: ${bad}"
+    fi
+  done
+  ( assert_safe_install_prefix "/usr/local/services/cubetoolbox" ) >/dev/null 2>&1 \
+    || fail "assert_safe_install_prefix should accept a normal deep prefix"
+  ( assert_safe_install_prefix "/opt/cube/custom/" ) >/dev/null 2>&1 \
+    || fail "assert_safe_install_prefix should accept a deep prefix with trailing slash"
+
+  # Content sanity check: a non-empty prefix with no CubeSandbox marker is
+  # foreign (e.g. a mis-set ONE_CLICK_INSTALL_PREFIX=/usr/local) and must be
+  # refused so the wipe does not rm -rf unrelated content.
+  local foreign="${TMP_DIR}/foreign"
+  mkdir -p "${foreign}/somedir"
+  : > "${foreign}/notes.txt"
+  if ( assert_safe_install_prefix "${foreign}" ) >/dev/null 2>&1; then
+    fail "assert_safe_install_prefix should reject a non-empty foreign prefix (no CubeSandbox marker)"
+  fi
+
+  # A real CubeSandbox install (marker present) is accepted even when non-empty.
+  local cube="${TMP_DIR}/cube"
+  mkdir -p "${cube}/cubeproxy"
+  : > "${cube}/.one-click.env"
+  : > "${cube}/CubeMaster"
+  ( assert_safe_install_prefix "${cube}" ) >/dev/null 2>&1 \
+    || fail "assert_safe_install_prefix should accept a prefix with a CubeSandbox marker"
+
+  # An empty prefix is accepted (fresh install, nothing to destroy).
+  local empty="${TMP_DIR}/empty"
+  mkdir -p "${empty}"
+  ( assert_safe_install_prefix "${empty}" ) >/dev/null 2>&1 \
+    || fail "assert_safe_install_prefix should accept an empty prefix"
+
+  # A prefix holding only '.backup' is accepted (the wipe preserves .backup,
+  # e.g. after an interrupted upgrade).
+  local onlybak="${TMP_DIR}/onlybak"
+  mkdir -p "${onlybak}/.backup"
+  ( assert_safe_install_prefix "${onlybak}" ) >/dev/null 2>&1 \
+    || fail "assert_safe_install_prefix should accept a prefix holding only .backup"
+}
+
 test_install_sh_wires_upgrade_flow() {
   local f="${ONE_CLICK_DIR}/install.sh"
   assert_contains "${f}" "resolve_install_mode"
   assert_contains "${f}" "preflight_upgrade"
   assert_contains "${f}" "backup_before_upgrade"
   assert_contains "${f}" "merge_env_three_way"
-  assert_contains "${f}" '--mode=*'
+  # CLI parsing is delegated to one_click_parse_args (supports --mode/--node-ip
+  # in both = and space forms) and CLI values are re-applied after .env load.
+  assert_contains "${f}" 'one_click_parse_args "$@"'
+  assert_contains "${f}" "apply_cli_overrides"
+  # custom-prefix wipe is guarded against unsafe install prefixes
+  assert_contains "${f}" 'assert_safe_install_prefix "${INSTALL_PREFIX}"'
   # env.example baseline is installed for future three-way merges
   assert_contains "${f}" 'cp -f "${SCRIPT_DIR}/env.example" "${INSTALL_PREFIX}/env.example"'
   # upgrade writes the merged env as the runtime env
@@ -123,6 +203,10 @@ test_auto_mode
 test_default_fresh_is_install
 test_default_existing_non_interactive_is_install
 test_assume_yes_existing_is_upgrade
+test_parse_args_space_and_equals_forms
+test_parse_args_missing_value_fails
+test_parse_args_unknown_is_ignored
+test_assert_safe_install_prefix
 test_install_sh_wires_upgrade_flow
 
 echo "install mode tests OK"

--- a/deploy/one-click/tests/test_install_mode.sh
+++ b/deploy/one-click/tests/test_install_mode.sh
@@ -137,9 +137,9 @@ test_assert_safe_install_prefix() {
       fail "assert_safe_install_prefix should reject: ${bad}"
     fi
   done
-  ( assert_safe_install_prefix "/usr/local/services/cubetoolbox" ) >/dev/null 2>&1 \
+  ( assert_safe_install_prefix "${TMP_DIR}/usr/local/services/cubetoolbox" ) >/dev/null 2>&1 \
     || fail "assert_safe_install_prefix should accept a normal deep prefix"
-  ( assert_safe_install_prefix "/opt/cube/custom/" ) >/dev/null 2>&1 \
+  ( assert_safe_install_prefix "${TMP_DIR}/opt/cube/custom/" ) >/dev/null 2>&1 \
     || fail "assert_safe_install_prefix should accept a deep prefix with trailing slash"
 
   # Content sanity check: a non-empty prefix with no CubeSandbox marker is
@@ -174,24 +174,126 @@ test_assert_safe_install_prefix() {
     || fail "assert_safe_install_prefix should accept a prefix holding only .backup"
 }
 
+test_wipe_custom_install_prefix_contents() {
+  local prefix="${TMP_DIR}/wipe-prefix"
+  mkdir -p "${prefix}/.backup/keep" "${prefix}/Cubelet" "${prefix}/foreign"
+  : > "${prefix}/.one-click.env"
+  : > "${prefix}/foreign/file.txt"
+
+  wipe_custom_install_prefix_contents "${prefix}"
+  [[ -d "${prefix}/.backup" ]] || fail "wipe should preserve .backup"
+  [[ ! -e "${prefix}/Cubelet" ]] || fail "wipe should remove Cubelet"
+  [[ ! -e "${prefix}/foreign" ]] || fail "wipe should remove foreign top-level entries inside a marker-bearing prefix"
+  [[ ! -e "${prefix}/.one-click.env" ]] || fail "wipe should remove runtime env"
+
+  local foreign="${TMP_DIR}/wipe-foreign"
+  mkdir -p "${foreign}"
+  : > "${foreign}/file.txt"
+  if ( wipe_custom_install_prefix_contents "${foreign}" ) >/dev/null 2>&1; then
+    fail "wipe should reject a non-empty prefix without CubeSandbox markers"
+  fi
+  [[ -e "${foreign}/file.txt" ]] || fail "rejected foreign prefix must remain untouched"
+}
+
+test_control_plane_validators() {
+  validate_ipv4_literal "10.0.0.11" "ONE_CLICK_CONTROL_PLANE_IP"
+  validate_host_port "control.example.internal:8089" "ONE_CLICK_CONTROL_PLANE_CUBEMASTER_ADDR"
+  validate_host_port "10.0.0.11:8089" "ONE_CLICK_CONTROL_PLANE_CUBEMASTER_ADDR"
+
+  if ( validate_ipv4_literal "999.0.0.1" "ONE_CLICK_CONTROL_PLANE_IP" ) >/dev/null 2>&1; then
+    fail "validate_ipv4_literal should reject out-of-range octets"
+  fi
+  if ( validate_host_port 'bad/host:8089' "ONE_CLICK_CONTROL_PLANE_CUBEMASTER_ADDR" ) >/dev/null 2>&1; then
+    fail "validate_host_port should reject slash-containing hosts"
+  fi
+  if ( validate_host_port "host:70000" "ONE_CLICK_CONTROL_PLANE_CUBEMASTER_ADDR" ) >/dev/null 2>&1; then
+    fail "validate_host_port should reject out-of-range ports"
+  fi
+}
+
+test_patch_cubelet_config_template_refuses_symlink() {
+  local cfg="${TMP_DIR}/cubelet-config.toml"
+  cat > "${cfg}" <<'EOF'
+eth_name = "eth0"
+cidr = "192.168.0.0/18"
+EOF
+
+  patch_cubelet_config_template "${cfg}" "ens3" "10.123.0.0/16" >/dev/null 2>&1
+  grep -Fq 'eth_name = "ens3"' "${cfg}" || fail "patch should update eth_name"
+  grep -Fq 'cidr = "10.123.0.0/16"' "${cfg}" || fail "patch should update cidr"
+
+  local target="${TMP_DIR}/symlink-target.toml" link="${TMP_DIR}/symlink-config.toml"
+  cat > "${target}" <<'EOF'
+eth_name = "eth0"
+cidr = "192.168.0.0/18"
+EOF
+  ln -s "${target}" "${link}"
+  if ( patch_cubelet_config_template "${link}" "ens4" "10.124.0.0/16" ) >/dev/null 2>&1; then
+    fail "patch_cubelet_config_template should reject symlink configs"
+  fi
+  grep -Fq 'eth_name = "eth0"' "${target}" || fail "symlink target must not be modified"
+  grep -Fq 'cidr = "192.168.0.0/18"' "${target}" || fail "symlink target CIDR must not be modified"
+}
+
+test_upgrade_preflight_and_backup() {
+  local inst="${TMP_DIR}/preflight-inst" bundle="${TMP_DIR}/preflight-bundle" pkg="${TMP_DIR}/pkg.tar.gz"
+  mkdir -p "${inst}/scripts" "${inst}/Cubelet/config" "${bundle}"
+  cat > "${inst}/.one-click.env" <<'EOF'
+ONE_CLICK_DEPLOY_ROLE=control
+EOF
+  cat > "${inst}/VERSION.txt" <<'EOF'
+release_version=v0.4.0
+EOF
+  cat > "${bundle}/VERSION.txt" <<'EOF'
+release_version=v0.5.0
+EOF
+  printf 'fake-package' > "${pkg}"
+  printf 'config' > "${inst}/Cubelet/config/config.toml"
+
+  preflight_upgrade "${inst}" "${bundle}" "${pkg}" control 0 0 >/dev/null 2>&1 \
+    || fail "preflight_upgrade should pass for matching role and upgrade version"
+
+  if ( preflight_upgrade "${inst}" "${bundle}" "${pkg}" compute 0 0 ) >/dev/null 2>&1; then
+    fail "preflight_upgrade should reject role change without allow flag"
+  fi
+
+  cat > "${bundle}/VERSION.txt" <<'EOF'
+release_version=v0.3.0
+EOF
+  if ( preflight_upgrade "${inst}" "${bundle}" "${pkg}" control 0 0 ) >/dev/null 2>&1; then
+    fail "preflight_upgrade should reject downgrade without allow flag"
+  fi
+
+  local backup_dir
+  backup_dir="$(backup_before_upgrade "${inst}" 2>/dev/null)"
+  [[ -f "${backup_dir}/.one-click.env" ]] || fail "backup should include .one-click.env"
+  [[ -f "${backup_dir}/Cubelet/config/config.toml" ]] || fail "backup should include Cubelet config"
+  local mode
+  mode="$(stat -c '%a' "${backup_dir}" 2>/dev/null || echo "")"
+  [[ "${mode}" == "700" ]] || fail "backup dir should be 700 (got ${mode})"
+  mode="$(stat -c '%a' "${backup_dir}/.one-click.env" 2>/dev/null || echo "")"
+  [[ "${mode}" == "600" ]] || fail ".one-click.env backup should be 600 (got ${mode})"
+}
+
 test_install_sh_wires_upgrade_flow() {
   local f="${ONE_CLICK_DIR}/install.sh"
   assert_contains "${f}" "resolve_install_mode"
   assert_contains "${f}" "preflight_upgrade"
   assert_contains "${f}" "backup_before_upgrade"
   assert_contains "${f}" "merge_env_three_way"
+  assert_contains "${f}" "patch_cubelet_config_template"
   # CLI parsing is delegated to one_click_parse_args (supports --mode/--node-ip
   # in both = and space forms) and CLI values are re-applied after .env load.
   assert_contains "${f}" 'one_click_parse_args "$@"'
   assert_contains "${f}" "apply_cli_overrides"
   # custom-prefix wipe is guarded against unsafe install prefixes
-  assert_contains "${f}" 'assert_safe_install_prefix "${INSTALL_PREFIX}"'
+  assert_contains "${f}" 'wipe_custom_install_prefix_contents "${INSTALL_PREFIX}"'
   # env.example baseline is installed for future three-way merges
   assert_contains "${f}" 'cp -f "${SCRIPT_DIR}/env.example" "${INSTALL_PREFIX}/env.example"'
   # upgrade writes the merged env as the runtime env
   assert_contains "${f}" 'cp -f "${MERGED_ENV}" "${RUNTIME_ENV_FILE}"'
-  # full-wipe branch preserves the upgrade backup directory (M1)
-  assert_contains "${f}" "! -name '.backup'"
+  # full-wipe branch delegates to the helper that preserves the upgrade backup.
+  assert_contains "${ONE_CLICK_DIR}/lib/common.sh" "! -name '.backup'"
   # on upgrade, CIDR host-conflict detection is skipped (M2)
   assert_contains "${f}" 'check_cidr_preflight "${CUBE_SANDBOX_NETWORK_CIDR}" "${cidr_skip_conflict}"'
 }
@@ -207,6 +309,10 @@ test_parse_args_space_and_equals_forms
 test_parse_args_missing_value_fails
 test_parse_args_unknown_is_ignored
 test_assert_safe_install_prefix
+test_wipe_custom_install_prefix_contents
+test_control_plane_validators
+test_patch_cubelet_config_template_refuses_symlink
+test_upgrade_preflight_and_backup
 test_install_sh_wires_upgrade_flow
 
 echo "install mode tests OK"

--- a/deploy/one-click/tests/test_install_mode.sh
+++ b/deploy/one-click/tests/test_install_mode.sh
@@ -167,11 +167,27 @@ test_assert_safe_install_prefix() {
     || fail "assert_safe_install_prefix should accept an empty prefix"
 
   # A prefix holding only '.backup' is accepted (the wipe preserves .backup,
-  # e.g. after an interrupted upgrade).
+  # e.g. after an interrupted upgrade) when .backup is a real directory.
   local onlybak="${TMP_DIR}/onlybak"
   mkdir -p "${onlybak}/.backup"
   ( assert_safe_install_prefix "${onlybak}" ) >/dev/null 2>&1 \
     || fail "assert_safe_install_prefix should accept a prefix holding only .backup"
+
+  local symlink_target="${TMP_DIR}/symlink-target"
+  mkdir -p "${symlink_target}"
+  local symlink_prefix="${TMP_DIR}/symlink-prefix"
+  mkdir -p "${symlink_prefix}"
+  ln -s "${symlink_target}" "${symlink_prefix}/linked"
+  if ( assert_safe_install_prefix "${symlink_prefix}" ) >/dev/null 2>&1; then
+    fail "assert_safe_install_prefix should reject top-level symlinks"
+  fi
+
+  local backup_link_prefix="${TMP_DIR}/backup-link-prefix"
+  mkdir -p "${backup_link_prefix}" "${TMP_DIR}/backup-link-target"
+  ln -s "${TMP_DIR}/backup-link-target" "${backup_link_prefix}/.backup"
+  if ( assert_safe_install_prefix "${backup_link_prefix}" ) >/dev/null 2>&1; then
+    fail "assert_safe_install_prefix should reject a .backup symlink"
+  fi
 }
 
 test_wipe_custom_install_prefix_contents() {
@@ -193,6 +209,16 @@ test_wipe_custom_install_prefix_contents() {
     fail "wipe should reject a non-empty prefix without CubeSandbox markers"
   fi
   [[ -e "${foreign}/file.txt" ]] || fail "rejected foreign prefix must remain untouched"
+
+  local with_symlink="${TMP_DIR}/wipe-with-symlink" external="${TMP_DIR}/external-target"
+  mkdir -p "${with_symlink}" "${external}"
+  : > "${with_symlink}/.one-click.env"
+  : > "${external}/keep.txt"
+  ln -s "${external}" "${with_symlink}/linked"
+  if ( wipe_custom_install_prefix_contents "${with_symlink}" ) >/dev/null 2>&1; then
+    fail "wipe should reject a marker-bearing prefix with a top-level symlink"
+  fi
+  [[ -e "${external}/keep.txt" ]] || fail "wipe must not touch symlink target content"
 }
 
 test_control_plane_validators() {
@@ -273,6 +299,34 @@ EOF
   [[ "${mode}" == "700" ]] || fail "backup dir should be 700 (got ${mode})"
   mode="$(stat -c '%a' "${backup_dir}/.one-click.env" 2>/dev/null || echo "")"
   [[ "${mode}" == "600" ]] || fail ".one-click.env backup should be 600 (got ${mode})"
+
+  local bad_inst="${TMP_DIR}/backup-symlink-inst" outside="${TMP_DIR}/backup-outside"
+  mkdir -p "${bad_inst}" "${outside}"
+  : > "${bad_inst}/.one-click.env"
+  ln -s "${outside}" "${bad_inst}/.backup"
+  if ( backup_before_upgrade "${bad_inst}" ) >/dev/null 2>&1; then
+    fail "backup_before_upgrade should reject a symlink .backup directory"
+  fi
+  if compgen -G "${outside}/upgrade-*" >/dev/null; then
+    fail "backup_before_upgrade must not write through a .backup symlink"
+  fi
+}
+
+test_validation_library_fallback_die() {
+  local err="${TMP_DIR}/validation-fallback.err"
+  if (
+    unset -f die 2>/dev/null || true
+    unset ONE_CLICK_VALIDATION_LIB_LOADED
+    # shellcheck source=../scripts/common/validation.sh
+    source "${ONE_CLICK_DIR}/scripts/common/validation.sh"
+    validate_host_port "bad/host:8089" "TEST_ADDR"
+  ) >/dev/null 2>"${err}"; then
+    fail "validation.sh fallback die should fail invalid input"
+  fi
+  assert_contains "${err}" "[validation] ERROR:"
+  if grep -Fq "command not found" "${err}"; then
+    fail "validation.sh fallback should not produce command-not-found"
+  fi
 }
 
 test_install_sh_wires_upgrade_flow() {
@@ -313,6 +367,7 @@ test_wipe_custom_install_prefix_contents
 test_control_plane_validators
 test_patch_cubelet_config_template_refuses_symlink
 test_upgrade_preflight_and_backup
+test_validation_library_fallback_die
 test_install_sh_wires_upgrade_flow
 
 echo "install mode tests OK"

--- a/deploy/one-click/tests/test_install_mode.sh
+++ b/deploy/one-click/tests/test_install_mode.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (C) 2026 Tencent. All rights reserved.
+#
+# Unit tests for install-mode resolution and the static wiring of install.sh's
+# config-preserving upgrade flow (M3-1/M3-2). resolve_install_mode is exercised
+# directly; install.sh itself is checked structurally (it requires root/KVM to
+# actually run).
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ONE_CLICK_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+TMP_DIR="$(mktemp -d)"
+cleanup() {
+  rm -rf "${TMP_DIR}"
+}
+trap cleanup EXIT
+
+# shellcheck source=../lib/common.sh
+source "${ONE_CLICK_DIR}/lib/common.sh"
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+assert_contains() {
+  grep -Fq -- "$2" "$1" || fail "expected $1 to contain: $2"
+}
+
+make_install_dir() {
+  local d="$1"
+  mkdir -p "${d}"
+  : > "${d}/.one-click.env"
+}
+
+# resolve_install_mode reads stdin for the interactive prompt; run all
+# resolution tests with stdin closed so they take the non-interactive paths.
+
+test_explicit_install_mode() {
+  local d="${TMP_DIR}/a"
+  make_install_dir "${d}"
+  local got
+  got="$(resolve_install_mode install "${d}" 0 < /dev/null 2>/dev/null)"
+  [[ "${got}" == "install" ]] || fail "explicit install should resolve to install (got ${got})"
+}
+
+test_explicit_upgrade_requires_existing() {
+  local d="${TMP_DIR}/missing"
+  mkdir -p "${d}"
+  # Subshell: resolve_install_mode calls die (exit 1) on this path; isolate it.
+  if ( resolve_install_mode upgrade "${d}" 0 ) < /dev/null >/dev/null 2>&1; then
+    fail "upgrade without existing install should fail"
+  fi
+}
+
+test_explicit_upgrade_with_existing() {
+  local d="${TMP_DIR}/b"
+  make_install_dir "${d}"
+  local got
+  got="$(resolve_install_mode upgrade "${d}" 0 < /dev/null 2>/dev/null)"
+  [[ "${got}" == "upgrade" ]] || fail "upgrade with existing should resolve to upgrade (got ${got})"
+}
+
+test_auto_mode() {
+  local existing="${TMP_DIR}/c" fresh="${TMP_DIR}/d"
+  make_install_dir "${existing}"
+  mkdir -p "${fresh}"
+  local got
+  got="$(resolve_install_mode auto "${existing}" 0 < /dev/null 2>/dev/null)"
+  [[ "${got}" == "upgrade" ]] || fail "auto+existing should be upgrade (got ${got})"
+  got="$(resolve_install_mode auto "${fresh}" 0 < /dev/null 2>/dev/null)"
+  [[ "${got}" == "install" ]] || fail "auto+fresh should be install (got ${got})"
+}
+
+test_default_fresh_is_install() {
+  local d="${TMP_DIR}/e"
+  mkdir -p "${d}"
+  local got
+  got="$(resolve_install_mode "" "${d}" 0 < /dev/null 2>/dev/null)"
+  [[ "${got}" == "install" ]] || fail "default+fresh should be install (got ${got})"
+}
+
+test_default_existing_non_interactive_is_install() {
+  local d="${TMP_DIR}/f"
+  make_install_dir "${d}"
+  local got
+  got="$(resolve_install_mode "" "${d}" 0 < /dev/null 2>/dev/null)"
+  [[ "${got}" == "install" ]] \
+    || fail "default+existing+non-interactive should default to install (got ${got})"
+}
+
+test_assume_yes_existing_is_upgrade() {
+  local d="${TMP_DIR}/g"
+  make_install_dir "${d}"
+  local got
+  got="$(resolve_install_mode "" "${d}" 1 < /dev/null 2>/dev/null)"
+  [[ "${got}" == "upgrade" ]] || fail "default+existing+--yes should be upgrade (got ${got})"
+}
+
+test_install_sh_wires_upgrade_flow() {
+  local f="${ONE_CLICK_DIR}/install.sh"
+  assert_contains "${f}" "resolve_install_mode"
+  assert_contains "${f}" "preflight_upgrade"
+  assert_contains "${f}" "backup_before_upgrade"
+  assert_contains "${f}" "merge_env_three_way"
+  assert_contains "${f}" '--mode=*'
+  # env.example baseline is installed for future three-way merges
+  assert_contains "${f}" 'cp -f "${SCRIPT_DIR}/env.example" "${INSTALL_PREFIX}/env.example"'
+  # upgrade writes the merged env as the runtime env
+  assert_contains "${f}" 'cp -f "${MERGED_ENV}" "${RUNTIME_ENV_FILE}"'
+  # full-wipe branch preserves the upgrade backup directory (M1)
+  assert_contains "${f}" "! -name '.backup'"
+  # on upgrade, CIDR host-conflict detection is skipped (M2)
+  assert_contains "${f}" 'check_cidr_preflight "${CUBE_SANDBOX_NETWORK_CIDR}" "${cidr_skip_conflict}"'
+}
+
+test_explicit_install_mode
+test_explicit_upgrade_requires_existing
+test_explicit_upgrade_with_existing
+test_auto_mode
+test_default_fresh_is_install
+test_default_existing_non_interactive_is_install
+test_assume_yes_existing_is_upgrade
+test_install_sh_wires_upgrade_flow
+
+echo "install mode tests OK"


### PR DESCRIPTION

## Overview

Adds `--mode upgrade` (install | upgrade | auto) to `deploy/one-click/install.sh`:

### Upgrade Flow
- **Installation detection**: Auto-detect existing installations via `.one-click.env`
- **Three-way `.env` merge**: Preserves user customizations, adopts new defaults for untouched keys, applies explicit new-bundle overrides; falls back to two-way merge when baseline is unavailable

### Pre-upgrade Backup
- Backs up old `.one-click.env`, component configs, and DB/key directories to a timestamped backup directory

### Preflight Checks
- Disk space, version compatibility (semver), service health
- CIDR conflict detection with skip option for upgrades

### New Flags
- `-y` / `--yes`
- `--allow-downgrade`
- `--allow-role-change`

### Tests
- Unit tests for env merge (three-way, two-way, CRLF handling, version comparison)
- Install mode resolution tests