### PR TITLE
feat(egress): integrate CubeEgress into component version reporting

### DIFF
--- a/CubeEgress/Dockerfile
+++ b/CubeEgress/Dockerfile
@@ -1,5 +1,9 @@
 FROM cube-egress/openresty:1.29.2.5-tproxy
 
+ARG CUBE_EGRESS_VERSION=0.0.0-dev
+ARG CUBE_EGRESS_COMMIT=unknown
+ARG CUBE_EGRESS_BUILD_TIME=unknown
+
 RUN apt update && \
 	DEBIAN_FRONTEND=noninteractive apt install -y --no-install-recommends \
 		bash \
@@ -13,6 +17,9 @@ RUN luarocks install lua-resty-http
 RUN luarocks install lua-resty-openssl
 
 RUN mkdir -p /data/log/cube-egress /var/run/openresty /etc/cube/ca
+
+RUN echo "{\"version\":\"${CUBE_EGRESS_VERSION}\",\"commit\":\"${CUBE_EGRESS_COMMIT}\",\"build_time\":\"${CUBE_EGRESS_BUILD_TIME}\"}" \
+    > /etc/cube/version.json
 
 RUN groupadd --system --gid 8049 cube-proxy && \
 	useradd --system --uid 8049 --gid cube-proxy --no-create-home \

--- a/CubeEgress/Makefile
+++ b/CubeEgress/Makefile
@@ -1,5 +1,8 @@
-IMAGE_TAG   := latest
-IMAGE_LOCAL := cube-egress
+IMAGE_TAG              ?= latest
+IMAGE_LOCAL             := cube-egress
+CUBE_EGRESS_VERSION     ?= 0.0.0-dev
+CUBE_EGRESS_COMMIT      ?= unknown
+CUBE_EGRESS_BUILD_TIME  ?= unknown
 
 IMAGES := \
 	cube-sandbox-cn.tencentcloudcr.com/cube-sandbox/cube-egress \
@@ -23,8 +26,11 @@ endif
 .PHONY: build
 build:
 	$(call msg,BUILD IMAGE $(IMAGE_LOCAL):$(IMAGE_TAG))
-	$(Q)docker build --rm $(QUIET) --network host	\
-		-t $(IMAGE_LOCAL):$(IMAGE_TAG)		\
+	$(Q)docker build --rm $(QUIET) --network host \
+		--build-arg CUBE_EGRESS_VERSION=$(CUBE_EGRESS_VERSION) \
+		--build-arg CUBE_EGRESS_COMMIT=$(CUBE_EGRESS_COMMIT) \
+		--build-arg CUBE_EGRESS_BUILD_TIME=$(CUBE_EGRESS_BUILD_TIME) \
+		-t $(IMAGE_LOCAL):$(IMAGE_TAG) \
 		.
 
 .PHONY: push

--- a/CubeEgress/lua/admin.lua
+++ b/CubeEgress/lua/admin.lua
@@ -149,10 +149,26 @@ end
 local function h_health()
     local meta = ngx.shared.meta_store
     local bootstrap_status = (meta and meta:get("bootstrap_status")) or "unknown"
+
+    -- Read version info from the build-time metadata file.
+    local version_info = {version = "unknown", commit = "unknown", build_time = "unknown"}
+    local f, err = io.open("/etc/cube/version.json", "rb")
+    if f then
+        local raw = f:read("*a")
+        f:close()
+        local decoded = cjson.decode(raw)
+        if decoded then
+            version_info = decoded
+        end
+    end
+
     return send_json(200, {
         status            = "ok",
         bootstrap_status  = bootstrap_status,
         policy_count      = policy.count(),
+        version           = version_info.version,
+        commit            = version_info.commit,
+        build_time        = version_info.build_time,
     })
 end
 

--- a/Cubelet/pkg/cubelet/versioninfo/collector.go
+++ b/Cubelet/pkg/cubelet/versioninfo/collector.go
@@ -50,12 +50,14 @@ const (
 	ComponentCubeAgent  = "cube-agent"
 	ComponentGuestImage = "guest-image"
 	ComponentKernel     = "kernel"
+	ComponentCubeEgress = "cube-egress"
 )
 
 const (
 	manifestFileName  = "release-manifest.json"
 	guestImageVerPath = "cube-image/version"
 	kernelVmlinuxPath = "cube-kernel-scf/vmlinux"
+	cubeEgressVerPath = "cube-egress/version"
 )
 
 // oneClickInstallLayout maps manifest component keys to the concrete one-click
@@ -71,6 +73,7 @@ var oneClickInstallLayout = map[string][][]string{
 	"network-agent":           {{"network-agent", "bin", "network-agent"}},
 	"containerd-shim-cube-rs": {{"cube-shim", "bin", "containerd-shim-cube-rs"}},
 	"cube-runtime":            {{"cube-shim", "bin", "cube-runtime"}},
+	"cube-egress":             {{"cube-egress", "version"}},
 }
 
 // ComponentVersion is a pure-data version record. It mirrors
@@ -156,7 +159,7 @@ func (c *Collector) Collect() []ComponentVersion {
 		// installed on this node. cubelet handled above; cube-agent handled
 		// from guest_image.agent_version below.
 		for name, mc := range man.Components {
-			if name == ComponentCubelet || name == ComponentCubeAgent {
+			if name == ComponentCubelet || name == ComponentCubeAgent || name == ComponentCubeEgress {
 				continue
 			}
 			if !c.componentInstalledLocked(name) {
@@ -189,6 +192,18 @@ func (c *Collector) Collect() []ComponentVersion {
 	if ver := c.guestImageVersionLocked(); ver != "" {
 		out = append(out, ComponentVersion{
 			Component: ComponentGuestImage,
+			Version:   ver,
+			Source:    SourceFile,
+		})
+	}
+
+	// (6) cube-egress: version marker written by the deploy system.
+	// The marker file cube-egress/version is present only when the
+	// CubeEgress container is deployed on this node; when absent the
+	// component is silently omitted (graceful degradation).
+	if ver := c.cubeEgressVersionLocked(); ver != "" {
+		out = append(out, ComponentVersion{
+			Component: ComponentCubeEgress,
 			Version:   ver,
 			Source:    SourceFile,
 		})
@@ -318,6 +333,18 @@ func (c *Collector) guestImageVersionLocked() string {
 	}
 	c.guestImageVer = firstLine(data)
 	return c.guestImageVer
+}
+
+// cubeEgressVersionLocked returns the single-line cube-egress version from the
+// host-side marker file written by the deploy system at install time. The file
+// is static between deployments, so we read it directly without mtime caching.
+func (c *Collector) cubeEgressVersionLocked() string {
+	path := filepath.Join(c.baseDir, cubeEgressVerPath)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return ""
+	}
+	return firstLine(data)
 }
 
 // firstLine returns the first line of data, trimmed of surrounding

--- a/Cubelet/pkg/cubelet/versioninfo/collector_test.go
+++ b/Cubelet/pkg/cubelet/versioninfo/collector_test.go
@@ -34,6 +34,7 @@ func writeManifest(t *testing.T, dir string) {
     "network-agent": {"version": "v0.5.0", "commit": "abc", "build_time": "t"},
     "containerd-shim-cube-rs": {"version": "v0.5.0", "commit": "abc", "build_time": "t"},
     "cube-runtime": {"version": "v0.5.0", "commit": "abc", "build_time": "t"},
+    "cube-egress": {"version": "v0.5.0", "commit": "abc", "build_time": "t"},
     "cube-agent": {"version": "v0.5.0", "commit": "abc", "build_time": "t"}
   },
   "guest_image": {"version": "cube-image/2026.01", "agent_version": "agent-1.2.3"},
@@ -123,6 +124,7 @@ func TestCollectRecognizesOneClickInstallLayout(t *testing.T) {
 	mkComponentFile(t, dir, "network-agent", "bin", "network-agent")
 	mkComponentFile(t, dir, "cube-shim", "bin", "containerd-shim-cube-rs")
 	mkComponentFile(t, dir, "cube-shim", "bin", "cube-runtime")
+	mkComponentFile(t, dir, "cube-egress", "version")
 
 	c := NewCollector(dir)
 	got := c.Collect()
@@ -139,6 +141,13 @@ func TestCollectRecognizesOneClickInstallLayout(t *testing.T) {
 		if _, ok := versionOf(t, got, name); !ok {
 			t.Errorf("%s should be reported when the one-click install path exists", name)
 		}
+	}
+	// cube-egress is reported from the host-side version marker file (Source=File),
+	// not from the manifest loop, so check it separately.
+	if v, ok := versionOf(t, got, "cube-egress"); !ok {
+		t.Errorf("cube-egress should be reported when the version marker exists")
+	} else if v.Source != SourceFile {
+		t.Errorf("cube-egress Source should be file, got %s", v.Source)
 	}
 }
 
@@ -353,5 +362,56 @@ func TestGuestImageMTimeReread(t *testing.T) {
 	}
 	if img, _ := versionOf(t, c.Collect(), ComponentGuestImage); img.Version != "v2" {
 		t.Errorf("expected v2 after mtime change, got %q", img.Version)
+	}
+}
+
+func TestCollectCubeEgressFromVersionMarker(t *testing.T) {
+	dir := t.TempDir()
+	writeManifest(t, dir)
+	// Create the version marker file that the deploy system writes.
+	markerDir := filepath.Join(dir, "cube-egress")
+	if err := os.MkdirAll(markerDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(markerDir, "version"), []byte("v0.5.0\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	c := NewCollector(dir)
+	got := c.Collect()
+
+	egress, ok := versionOf(t, got, ComponentCubeEgress)
+	if !ok {
+		t.Fatalf("cube-egress must be reported when version marker exists")
+	}
+	if egress.Version != "v0.5.0" {
+		t.Errorf("cube-egress version should be v0.5.0, got %q", egress.Version)
+	}
+	if egress.Source != SourceFile {
+		t.Errorf("cube-egress Source should be file, got %s", egress.Source)
+	}
+
+	// cube-egress must not appear twice (manifest skip verification).
+	count := 0
+	for _, v := range got {
+		if v.Component == ComponentCubeEgress {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("cube-egress should appear exactly once, got %d", count)
+	}
+}
+
+func TestCollectCubeEgressDegradesWithoutMarker(t *testing.T) {
+	dir := t.TempDir()
+	writeManifest(t, dir)
+	// Deliberately do NOT create cube-egress/version.
+
+	c := NewCollector(dir)
+	got := c.Collect()
+
+	if _, ok := versionOf(t, got, ComponentCubeEgress); ok {
+		t.Errorf("cube-egress must NOT be reported when version marker is absent")
 	}
 }

--- a/deploy/one-click/build-release-bundle.sh
+++ b/deploy/one-click/build-release-bundle.sh
@@ -299,6 +299,13 @@ components["cube-runtime"] = {
     "digest_sha256": required_sha256(runtime_bin),
 }
 
+# ── Docker-based components (no single-binary digest) ──
+components["cube-egress"] = {
+    "version": cube_version,
+    "commit": cube_commit,
+    "build_time": cube_build_time,
+}
+
 # ── Guest image ──
 guest_image = {
     "version": guest_image_ver,
@@ -498,6 +505,7 @@ mkdir -p \
   "${PACKAGE_ROOT}/scripts/one-click" \
   "${PACKAGE_ROOT}/scripts/systemd" \
   "${PACKAGE_ROOT}/scripts/cube-egress" \
+  "${PACKAGE_ROOT}/cube-egress" \
   "${PACKAGE_ROOT}/sql"
 
 copy_file "${CORE_BIN_DIR}/network-agent" "${PACKAGE_ROOT}/network-agent/bin/network-agent"
@@ -557,6 +565,13 @@ copy_dir_contents "${SCRIPT_DIR}/scripts/cube-diag" "${PACKAGE_ROOT}/scripts/cub
 # integration.
 copy_file "${CUBE_EGRESS_SOURCE_DIR}/scripts/cube-proxy-iptables-init.sh" \
           "${PACKAGE_ROOT}/scripts/cube-egress/cube-proxy-iptables-init.sh"
+
+# Host-side version marker for cube-egress: cubelet's versioninfo.Collector
+# detects the component by the presence of cube-egress/version and reports
+# the content as the installed version. Must match cube_version so the
+# declared-vs-actual comparison in CubeMaster's version matrix works.
+printf '%s\n' "${DIST_VERSION}" > "${PACKAGE_ROOT}/cube-egress/version"
+
 copy_dir_contents "${SCRIPT_DIR}/sql" "${PACKAGE_ROOT}/sql"
 
 find "${PACKAGE_ROOT}" -type f -path "*/bin/*" -exec chmod +x {} \;

--- a/deploy/one-click/install.sh
+++ b/deploy/one-click/install.sh
@@ -622,6 +622,7 @@ if [[ "${DEPLOY_ROLE}" == "compute" ]]; then
   copy_dir_contents "${PKG_ROOT}/cube-shim" "${INSTALL_PREFIX}/cube-shim"
   copy_dir_contents "${PKG_ROOT}/cube-kernel-scf" "${INSTALL_PREFIX}/cube-kernel-scf"
   copy_dir_contents "${PKG_ROOT}/cube-image" "${INSTALL_PREFIX}/cube-image"
+  copy_dir_contents "${PKG_ROOT}/cube-egress" "${INSTALL_PREFIX}/cube-egress"
   copy_dir_contents "${PKG_ROOT}/systemd" "${INSTALL_PREFIX}/systemd"
   copy_dir_contents "${PKG_ROOT}/scripts" "${INSTALL_PREFIX}/scripts"
 else


### PR DESCRIPTION
## Summary

Integrate CubeEgress into the existing node-component version reporting mechanism. CubeEgress (a Lua/OpenResty Docker container) was previously completely absent from the version reporting pipeline.

## Changes

### Layer 1: CubeEgress container metadata
- `CubeEgress/Dockerfile`: inject `CUBE_EGRESS_VERSION`/`COMMIT`/`BUILD_TIME` build args, write `/etc/cube/version.json`
- `CubeEgress/Makefile`: accept version variables and pass as `--build-arg`
- `CubeEgress/lua/admin.lua`: extend `/admin/v1/health` with `version`/`commit`/`build_time` fields

### Layer 2: Release manifest & deploy
- `deploy/one-click/build-release-bundle.sh`: add `cube-egress` to `release-manifest.json` components; write host-side `cube-egress/version` marker file
- `deploy/one-click/install.sh`: copy `cube-egress/` directory on compute-role nodes

### Layer 3: Cubelet version collection
- `Cubelet/pkg/cubelet/versioninfo/collector.go`: add `ComponentCubeEgress` constant, file-based collection via `cubeEgressVersionLocked()`, manifest-loop dedup skip
- `Cubelet/pkg/cubelet/versioninfo/collector_test.go`: 2 new tests (marker present → reported; marker absent → silent skip)

## Design
- Version follows `cube_version` (same as all other components), ensuring `versionIsDeclared()` consistency in CubeMaster
- Graceful degradation: missing version marker file → component silently omitted (never blocks heartbeat)
- Full plan: `docs/cube-egress-version-reporting-plan.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)