### PR TITLE
fix(nodemeta): start periodic reload goroutine for cross-replica node sync

### DIFF
--- a/CubeMaster/pkg/nodemeta/service.go
+++ b/CubeMaster/pkg/nodemeta/service.go
@@ -180,6 +180,7 @@ func Init(ctx context.Context) error {
 	}
 	localcache.RegisterNodeLoader(ListSchedulerNodes)
 	global.ready = true
+	go global.loopReload(ctx)
 	return nil
 }
 
@@ -598,10 +599,79 @@ func (s *service) reload() error {
 	for _, snap := range next {
 		snap.versionsHash = versionsHash(snap.Versions)
 	}
-	s.mu.Lock()
-	s.nodes = next
-	s.mu.Unlock()
+	s.applyReloadResult(next)
 	return nil
+}
+
+// applyReloadResult merges a DB snapshot (next) into the live in-memory map.
+// Registration fields and versions always take the DB value; status/heartbeat
+// fields keep the in-memory value when it is fresher than the DB snapshot.
+func (s *service) applyReloadResult(next map[string]*NodeSnapshot) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for nodeID, newSnap := range next {
+		if existing, ok := s.nodes[nodeID]; ok {
+			// Registration fields: always take from DB.  RegisterNode writes to
+			// MySQL before updating in-memory, so any value appearing in the DB
+			// has already been committed and is safe to copy even when the
+			// in-memory heartbeat is fresher (arrived on this replica during the
+			// DB scan).
+			existing.Labels = cloneStringMap(newSnap.Labels)
+			existing.Capacity = newSnap.Capacity
+			existing.Allocatable = newSnap.Allocatable
+			existing.InstanceType = newSnap.InstanceType
+			existing.ClusterLabel = newSnap.ClusterLabel
+			existing.QuotaCPU = newSnap.QuotaCPU
+			existing.QuotaMemMB = newSnap.QuotaMemMB
+			existing.CreateConcurrentNum = newSnap.CreateConcurrentNum
+			existing.MaxMvmNum = newSnap.MaxMvmNum
+			existing.HostIP = newSnap.HostIP
+			existing.GRPCPort = newSnap.GRPCPort
+			existing.Versions = append([]ComponentVersion(nil), newSnap.Versions...)
+			existing.versionsHash = newSnap.versionsHash
+			// Status fields: keep in-memory version if fresher to avoid
+			// regressing heartbeat state that arrived during the DB scan.
+			if newSnap.HeartbeatTime.After(existing.HeartbeatTime) {
+				existing.Conditions = newSnap.Conditions
+				existing.Images = newSnap.Images
+				existing.LocalTemplates = newSnap.LocalTemplates
+				existing.HeartbeatTime = newSnap.HeartbeatTime
+				existing.ReportedReady = newSnap.ReportedReady
+			}
+			applyCurrentHealth(existing, time.Now())
+		} else {
+			// New node discovered from DB (registered on another replica).
+			s.nodes[nodeID] = newSnap
+		}
+	}
+}
+
+func (s *service) loopReload(ctx context.Context) {
+	ticker := time.NewTicker(time.Second)
+	defer ticker.Stop()
+
+	checkDeadline := time.Now().Add(config.GetConfig().Common.SyncMetaDataInterval)
+	for {
+		select {
+		case <-ticker.C:
+			recov.WithRecover(func() {
+				if checkDeadline.After(time.Now()) {
+					return
+				}
+				defer func() {
+					checkDeadline = time.Now().Add(config.GetConfig().Common.SyncMetaDataInterval)
+				}()
+				if err := s.reload(); err != nil {
+					log.G(ctx).Warnf("nodemeta periodic reload failed: %v", err)
+				}
+			}, func(panicError interface{}) {
+				checkDeadline = time.Now().Add(config.GetConfig().Common.SyncMetaDataInterval)
+				log.G(context.Background()).Fatalf("nodemeta loopReload panic: %v", panicError)
+			})
+		case <-ctx.Done():
+			return
+		}
+	}
 }
 
 func healthTimeout() time.Duration {

--- a/CubeMaster/pkg/nodemeta/service.go
+++ b/CubeMaster/pkg/nodemeta/service.go
@@ -22,6 +22,7 @@ import (
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/log"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/node"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/nodehealth"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/recov"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/localcache"
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
@@ -611,11 +612,13 @@ func (s *service) applyReloadResult(next map[string]*NodeSnapshot) {
 	defer s.mu.Unlock()
 	for nodeID, newSnap := range next {
 		if existing, ok := s.nodes[nodeID]; ok {
-			// Registration fields: always take from DB.  RegisterNode writes to
-			// MySQL before updating in-memory, so any value appearing in the DB
-			// has already been committed and is safe to copy even when the
-			// in-memory heartbeat is fresher (arrived on this replica during the
-			// DB scan).
+			// Registration fields: take from DB.  A theoretical race exists
+			// where the reload() DB scan captures a row before a concurrent
+			// RegisterNode write commits, causing applyReloadResult to
+			// overwrite a fresher in-memory value with a stale DB snapshot.
+			// This is an accepted trade-off: registration field changes are
+			// rare, and any inconsistency self-corrects on the next reload
+			// cycle (≤ SyncMetaDataInterval).
 			existing.Labels = cloneStringMap(newSnap.Labels)
 			existing.Capacity = newSnap.Capacity
 			existing.Allocatable = newSnap.Allocatable

--- a/CubeMaster/pkg/nodemeta/service_reload_test.go
+++ b/CubeMaster/pkg/nodemeta/service_reload_test.go
@@ -1,0 +1,211 @@
+package nodemeta
+
+import (
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+// newTestService returns a service with a pre-populated in-memory node map,
+// suitable for applyReloadResult unit tests (no DB required).
+func newTestService(snaps ...*NodeSnapshot) *service {
+	s := &service{nodes: make(map[string]*NodeSnapshot, len(snaps))}
+	for _, snap := range snaps {
+		s.nodes[snap.NodeID] = snap
+	}
+	return s
+}
+
+func TestApplyReloadResultUpdatesRegistrationFields(t *testing.T) {
+	s := newTestService(&NodeSnapshot{
+		NodeID:       "node-a",
+		Labels:       map[string]string{"zone": "old"},
+		InstanceType: "old-type",
+		HostIP:       "1.1.1.1",
+		GRPCPort:     9000,
+		QuotaCPU:     100,
+		QuotaMemMB:   512,
+	})
+
+	next := map[string]*NodeSnapshot{
+		"node-a": {
+			NodeID:       "node-a",
+			Labels:       map[string]string{"zone": "new", "env": "prod"},
+			InstanceType: "new-type",
+			HostIP:       "2.2.2.2",
+			GRPCPort:     9001,
+			QuotaCPU:     200,
+			QuotaMemMB:   1024,
+		},
+	}
+	s.applyReloadResult(next)
+
+	s.mu.RLock()
+	snap := s.nodes["node-a"]
+	s.mu.RUnlock()
+
+	if snap.Labels["zone"] != "new" || snap.Labels["env"] != "prod" {
+		t.Fatalf("Labels not updated: %v", snap.Labels)
+	}
+	if snap.InstanceType != "new-type" {
+		t.Fatalf("InstanceType not updated: %s", snap.InstanceType)
+	}
+	if snap.HostIP != "2.2.2.2" {
+		t.Fatalf("HostIP not updated: %s", snap.HostIP)
+	}
+	if snap.GRPCPort != 9001 {
+		t.Fatalf("GRPCPort not updated: %d", snap.GRPCPort)
+	}
+	if snap.QuotaCPU != 200 {
+		t.Fatalf("QuotaCPU not updated: %d", snap.QuotaCPU)
+	}
+	if snap.QuotaMemMB != 1024 {
+		t.Fatalf("QuotaMemMB not updated: %d", snap.QuotaMemMB)
+	}
+}
+
+func TestApplyReloadResultPreservesInMemoryHeartbeatWhenFresher(t *testing.T) {
+	inMemoryTime := time.Now()
+	dbTime := inMemoryTime.Add(-5 * time.Second)
+
+	s := newTestService(&NodeSnapshot{
+		NodeID:        "node-b",
+		HeartbeatTime: inMemoryTime,
+		ReportedReady: true,
+		Conditions: []corev1.NodeCondition{{
+			Type:   corev1.NodeReady,
+			Status: corev1.ConditionTrue,
+		}},
+	})
+
+	next := map[string]*NodeSnapshot{
+		"node-b": {
+			NodeID:        "node-b",
+			HeartbeatTime: dbTime,
+			ReportedReady: false,
+		},
+	}
+	s.applyReloadResult(next)
+
+	s.mu.RLock()
+	snap := s.nodes["node-b"]
+	s.mu.RUnlock()
+
+	if !snap.HeartbeatTime.Equal(inMemoryTime) {
+		t.Fatalf("HeartbeatTime regressed: got %v want %v", snap.HeartbeatTime, inMemoryTime)
+	}
+	if !snap.ReportedReady {
+		t.Fatal("ReportedReady regressed: in-memory value should be preserved")
+	}
+}
+
+func TestApplyReloadResultTakesDBHeartbeatWhenFresher(t *testing.T) {
+	oldTime := time.Now().Add(-10 * time.Second)
+	newTime := time.Now()
+
+	s := newTestService(&NodeSnapshot{
+		NodeID:        "node-c",
+		HeartbeatTime: oldTime,
+		ReportedReady: false,
+	})
+
+	next := map[string]*NodeSnapshot{
+		"node-c": {
+			NodeID:        "node-c",
+			HeartbeatTime: newTime,
+			ReportedReady: true,
+			Conditions: []corev1.NodeCondition{{
+				Type:   corev1.NodeReady,
+				Status: corev1.ConditionTrue,
+			}},
+		},
+	}
+	s.applyReloadResult(next)
+
+	s.mu.RLock()
+	snap := s.nodes["node-c"]
+	s.mu.RUnlock()
+
+	if !snap.HeartbeatTime.Equal(newTime) {
+		t.Fatalf("HeartbeatTime not updated: got %v want %v", snap.HeartbeatTime, newTime)
+	}
+	if !snap.ReportedReady {
+		t.Fatal("ReportedReady not updated from DB")
+	}
+}
+
+func TestApplyReloadResultSyncsVersionsForExistingNode(t *testing.T) {
+	s := newTestService(&NodeSnapshot{
+		NodeID: "node-d",
+		Versions: []ComponentVersion{
+			{Component: "cubelet", Version: "v1.0.0"},
+		},
+		versionsHash: "oldhash",
+	})
+
+	newVersions := []ComponentVersion{
+		{Component: "cubelet", Version: "v2.0.0"},
+		{Component: "cube-agent", Version: "v1.5.0"},
+	}
+	next := map[string]*NodeSnapshot{
+		"node-d": {
+			NodeID:       "node-d",
+			Versions:     newVersions,
+			versionsHash: versionsHash(newVersions),
+		},
+	}
+	s.applyReloadResult(next)
+
+	s.mu.RLock()
+	snap := s.nodes["node-d"]
+	s.mu.RUnlock()
+
+	if len(snap.Versions) != 2 {
+		t.Fatalf("Versions length = %d, want 2", len(snap.Versions))
+	}
+	found := false
+	for _, v := range snap.Versions {
+		if v.Component == "cubelet" && v.Version == "v2.0.0" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("updated cubelet version not found in %v", snap.Versions)
+	}
+	wantHash := versionsHash(newVersions)
+	if snap.versionsHash != wantHash {
+		t.Fatalf("versionsHash = %s, want %s", snap.versionsHash, wantHash)
+	}
+}
+
+func TestApplyReloadResultAddsNewNodeFromDB(t *testing.T) {
+	s := newTestService(&NodeSnapshot{NodeID: "node-existing"})
+
+	newTime := time.Now()
+	next := map[string]*NodeSnapshot{
+		"node-existing": {NodeID: "node-existing"},
+		"node-new": {
+			NodeID:        "node-new",
+			HostIP:        "3.3.3.3",
+			Labels:        map[string]string{"region": "us-east"},
+			HeartbeatTime: newTime,
+			ReportedReady: true,
+		},
+	}
+	s.applyReloadResult(next)
+
+	s.mu.RLock()
+	snap, ok := s.nodes["node-new"]
+	s.mu.RUnlock()
+
+	if !ok {
+		t.Fatal("new node from DB not added to in-memory map")
+	}
+	if snap.HostIP != "3.3.3.3" {
+		t.Fatalf("HostIP = %s, want 3.3.3.3", snap.HostIP)
+	}
+	if snap.Labels["region"] != "us-east" {
+		t.Fatalf("Labels = %v, want region=us-east", snap.Labels)
+	}
+}


### PR DESCRIPTION
## Problem
In a multi-replica cubemaster deployment, node metadata (labels, capacity, instance type, component versions, etc.) registered on one replica was never visible to other replicas.

The root cause: `loopReload` — the goroutine responsible for periodically syncing node metadata from MySQL into the in-memory map — was never started in `Init()`. Each replica only knew about nodes that contacted it directly, so scheduling decisions on other replicas operated on an incomplete view of the cluster.

A secondary bug compounded the problem: even if the goroutine had been running, `reload()` replaced the entire in-memory map with a DB snapshot (`s.nodes = next`). This meant any heartbeat that arrived on the current replica during the DB scan would be silently overwritten, potentially causing a healthy node to briefly appear unhealthy.

### Bug - loopReload goroutine never started
```mermaid
flowchart TD
    Node["Cubelet Node"]

    subgraph ReplicaA["CubeMaster Replica A"]
        RA_Reg["RegisterNode /\nUpdateNodeStatus"]
        RA_Mem["in-memory global.nodes\n✅ updated"]
        RA_MySQL_Write["MySQL write\n✅ persisted"]
    end

    subgraph ReplicaB["CubeMaster Replica B"]
        RB_Loop["❌ loopReload\nNEVER STARTED in Init()"]
        RB_Mem["in-memory global.nodes\n❌ stays empty forever"]
        RB_Sched["Scheduler\n❌ incomplete cluster view"]
    end

    MySQL[("MySQL")]

    Node -->|"register / heartbeat"| RA_Reg
    RA_Reg --> RA_MySQL_Write
    RA_Reg --> RA_Mem
    RA_MySQL_Write --> MySQL

    MySQL -.->|"sync never triggered"| RB_Loop
    RB_Loop -.->|"goroutine not running"| RB_Mem
    RB_Mem --> RB_Sched

    style RB_Loop fill:#ffcccc,color:#000
    style RB_Mem fill:#ffcccc,color:#000
    style RB_Sched fill:#ffcccc,color:#000
    style ReplicaA fill:#dceefb,color:#000
    style ReplicaB fill:#fff0f0,color:#000
    style MySQL fill:#f5a623,color:#000
```
**Consequence:** Replica B never learns about nodes registered on Replica A. Its scheduler operates on an empty or stale node list, causing missed scheduling opportunities or incorrect "no available node" errors.

## Fix
**Start the sync goroutine**
A dd `go global.loopReload(ctx)` in `Init()`. The goroutine fires every`SyncMetaDataInterval` (default 30 s) and pulls the latest state fromMySQL into `global.nodes`.

 **Replace full map swap with a field-level merge**
Introduce `applyReloadResult()` with the following strategy:
- *Registration fields* (labels, capacity, instance type, quota, versions, etc.) always take the DB value. `RegisterNode` and `persistVersions` write to MySQL before updating in-memory state, so the DB is the authoritative source for these fields.
- *Heartbeat / status fields* (`HeartbeatTime`, `Conditions`, `ReportedReady`) keep the in-memory value when it is fresher than the DB snapshot. This prevents a slow DB scan from overwriting a heartbeat that arrived on this replica while the scan was in progress.
- *New nodes* (present in DB but absent in the in-memory map) are added directly — this is the primary cross-replica sync path.

### Fix — Replace full map swap with field-level merge

#### When does the problem occur?

```mermaid
sequenceDiagram
    participant Node as Cubelet Node
    participant DB as MySQL
    participant Mem as Replica Memory

    Note over DB,Mem: reload() begins — scans DB, captures snapshot at T0

    DB->>Mem: next["node-a"].HeartbeatTime = T0  (snapshot)

    Node->>DB: heartbeat T1 arrives (T1 > T0), written to DB
    Node->>Mem: HeartbeatTime = T1 written to memory

    Note over Mem: Memory is now ahead of snapshot: T1 > T0 ✅

    Note over Mem: reload() finishes — applies s.nodes = next ❌
    Mem->>Mem: HeartbeatTime overwritten: T1 → T0 💥

    Note over Mem: applyCurrentHealth sees stale T0
    Note over Mem: now - T0 > healthTimeout → Healthy = false ❌
    Note over Mem: node excluded from scheduling 🚫
```

The race window opens whenever a heartbeat is written to DB and memory **after** the reload scan has already read past that row, but **before** `s.nodes = next` is applied. With a 30 s reload interval and hundreds of nodes heartbeating every 10 s, this window is hit on virtually every reload cycle.

#### How the fix works
```mermaid
flowchart TD
    Start(["applyReloadResult(next)"])
    Loop["for each nodeID in next"]
    Exists{"nodeID exists\nin s.nodes?"}

    subgraph ExistingPath["Existing node — field-level merge"]
        RegFields["Registration fields\nlabels / capacity / instanceType\nquota / hostIP / grpcPort / versions\n──────────────────────────\nAlways take DB value\nDB write happens before memory write\nso DB is always ≥ memory"]
        HBCheck{"newSnap.HeartbeatTime\n> existing.HeartbeatTime?"}
        TakeDB["Take DB heartbeat fields\nConditions / Images\nLocalTemplates / ReportedReady"]
        KeepMem["Keep in-memory heartbeat fields\nin-memory is fresher —\nheartbeat arrived during DB scan"]
        Health["applyCurrentHealth(existing)"]
    end

    subgraph NewPath["New node — cross-replica discovery"]
        AddNode["s.nodes[nodeID] = newSnap\nnode registered on another replica"]
    end

    Start --> Loop --> Exists
    Exists -->|yes| RegFields
    RegFields --> HBCheck
    HBCheck -->|yes| TakeDB --> Health
    HBCheck -->|no| KeepMem --> Health
    Exists -->|no| AddNode

    style ExistingPath fill:#e8f4e8,color:#000
    style NewPath fill:#dceefb,color:#000
    style HBCheck fill:#fff9e6,color:#000
    style KeepMem fill:#d4edda,color:#000
    style TakeDB fill:#d4edda,color:#000
    style AddNode fill:#cce5ff,color:#000
```

## How node data is synchronized across cubemaster replicas when fixed
```mermaid
flowchart TD
    Node["Cubelet Node"]

    subgraph ReplicaA["CubeMaster Replica A (receives request)"]
        RA_Reg["RegisterNode /\nUpdateNodeStatus"]
        RA_Mem["in-memory\nglobal.nodes"]
        RA_LC["localcache"]
        RA_Metric["fanOutResourceMetric"]
    end

    subgraph Storage["Shared Storage"]
        MySQL[("MySQL\nnode_registrations\nnode_status\nnode_component_versions")]
        Redis[("Redis\nNodeMetric")]
    end

    subgraph ReplicaB["CubeMaster Replica B (sync)"]
        RB_Loop["loopReload\nevery SyncMetaDataInterval"]
        RB_Merge["applyReloadResult()\n───────────────────────────\nregistration fields → DB wins\nversions          → DB wins\nheartbeat fields  → fresher wins\nnew node          → add directly"]
        RB_Mem["in-memory\nglobal.nodes"]
        RB_LC["localcache\nloop / loopUpdateMetric"]
    end

    Node -->|"register / heartbeat"| RA_Reg
    RA_Reg -->|"1 write first"| MySQL
    RA_Reg -->|"2 update"| RA_Mem
    RA_Mem -->|"syncLocalcache"| RA_LC

    RA_Reg -->|"resource metrics only"| RA_Metric
    RA_Metric -->|"WriteNodeMetric"| Redis
    RA_Metric -->|"UpdateNodeMetricInProcess"| RA_LC

    MySQL -->|"every SyncMetaDataInterval"| RB_Loop
    RB_Loop --> RB_Merge
    RB_Merge -->|"merge"| RB_Mem

    Redis -->|"loopUpdateMetric tick"| RB_LC
    RB_Mem -->|"ListSchedulerNodes\nevery SyncMetaDataInterval"| RB_LC

    style MySQL fill:#f5a623,color:#000
    style Redis fill:#d0021b,color:#fff
    style RB_Merge fill:#e8f4e8,color:#000
    style ReplicaA fill:#dceefb,color:#000
    style ReplicaB fill:#fdf3e3,color:#000
    style Storage fill:#f9f9f9,color:#000
```

| Data type | Cross-replica sync path | Latency |
|-----------|------------------------|---------|
| Registration / Versions | MySQL → loopReload → applyReloadResult | ≤ SyncMetaDataInterval |
| Heartbeat / Status | MySQL → loopReload → applyReloadResult (fresher wins) | ≤ SyncMetaDataInterval |
| Resource Metrics | Redis → loopUpdateMetric | near real-time (50 ms tick) |


## Testing
Five new unit tests added in `service_reload_test.go`, all exercising `applyReloadResult()` directly (no DB required):
- `TestApplyReloadResultUpdatesRegistrationFields` — labels, instance type, IP, port and quota fields are updated from the DB snapshot
- `TestApplyReloadResultPreservesInMemoryHeartbeatWhenFresher` — a fresher in-memory heartbeat is not overwritten by a stale DB value
- `TestApplyReloadResultTakesDBHeartbeatWhenFresher` — a fresher DB heartbeat is correctly applied to the in-memory snapshot
- `TestApplyReloadResultSyncsVersionsForExistingNode` — component versions and their content hash are synced from DB for existing nodes
- `TestApplyReloadResultAddsNewNodeFromDB` — a node registered on another replica is discovered and added to the local in-memory map