### PR TITLE
fix(templatecenter): use redo template ID in generated request and validate it

### DIFF
--- a/CubeMaster/pkg/templatecenter/redo.go
+++ b/CubeMaster/pkg/templatecenter/redo.go
@@ -217,7 +217,7 @@ func runRedoTemplateImageJob(ctx context.Context, jobID string, req *types.RedoT
 		failRedoTemplateImageJob(ctx, jobID, jobRecord.ResumePhase, err.Error())
 		return
 	}
-	workingReq := newRedoWorkingRequest(sourceReq, targets)
+	workingReq := newRedoWorkingRequest(sourceReq, req.TemplateID, targets)
 
 	var artifact *models.RootfsArtifact
 	resumePhase := jobRecord.ResumePhase
@@ -248,9 +248,7 @@ func runRedoTemplateImageJob(ctx context.Context, jobID string, req *types.RedoT
 		if source.Cleanup != nil {
 			defer source.Cleanup(ctx)
 		}
-		var generatedReq *types.CreateCubeSandboxReq
-		var builtFresh bool
-		artifact, generatedReq, builtFresh, err = ensureRootfsArtifact(ctx, &workingReq, source, downloadBaseURL)
+		artifact, _, _, err = ensureRootfsArtifact(ctx, &workingReq, source, downloadBaseURL)
 		if err != nil {
 			_ = updateTemplateImageJob(ctx, jobID, map[string]any{
 				"status":          JobStatusFailed,
@@ -261,9 +259,7 @@ func runRedoTemplateImageJob(ctx context.Context, jobID string, req *types.RedoT
 			})
 			return
 		}
-		workingReq = newRedoWorkingRequest(sourceReq, targets)
-		_ = generatedReq
-		_ = builtFresh
+		workingReq = newRedoWorkingRequest(sourceReq, req.TemplateID, targets)
 		jobRecord.ArtifactID = artifact.ArtifactID
 		if err := updateTemplateImageJob(ctx, jobID, map[string]any{
 			"artifact_id":               artifact.ArtifactID,
@@ -284,24 +280,24 @@ func runRedoTemplateImageJob(ctx context.Context, jobID string, req *types.RedoT
 		}
 	}
 
-	var generatedReq *types.CreateCubeSandboxReq
-	if strings.TrimSpace(artifact.GeneratedRequestJSON) != "" {
-		generatedReq = &types.CreateCubeSandboxReq{}
-		if err := json.Unmarshal([]byte(artifact.GeneratedRequestJSON), generatedReq); err != nil {
-			generatedReq = nil
+	var imageCfg image.DockerImageConfig
+	if strings.TrimSpace(artifact.ImageConfigJSON) != "" {
+		if err := json.Unmarshal([]byte(artifact.ImageConfigJSON), &imageCfg); err != nil {
+			failRedoTemplateImageJob(ctx, jobID, resumePhase, fmt.Sprintf("decode artifact image config fail: %v", err))
+			return
 		}
 	}
-	if generatedReq == nil {
-		generatedReq, err = generateTemplateCreateRequest(&workingReq, artifact, image.DockerImageConfig{}, downloadBaseURL)
-		if artifact.ImageConfigJSON != "" {
-			var imageCfg image.DockerImageConfig
-			if json.Unmarshal([]byte(artifact.ImageConfigJSON), &imageCfg) == nil {
-				generatedReq, err = generateTemplateCreateRequest(&workingReq, artifact, imageCfg, downloadBaseURL)
-			}
-		}
-	}
+	generatedReq, err := generateTemplateCreateRequest(&workingReq, artifact, imageCfg, downloadBaseURL)
 	if err != nil {
 		failRedoTemplateImageJob(ctx, jobID, resumePhase, err.Error())
+		return
+	}
+	generatedTemplateID := ""
+	if generatedReq.Annotations != nil {
+		generatedTemplateID = strings.TrimSpace(generatedReq.Annotations[constants.CubeAnnotationAppSnapshotTemplateID])
+	}
+	if generatedTemplateID != req.TemplateID {
+		failRedoTemplateImageJob(ctx, jobID, resumePhase, fmt.Sprintf("generated template request id mismatch: got %q, want %q", generatedTemplateID, req.TemplateID))
 		return
 	}
 

--- a/CubeMaster/pkg/templatecenter/template_image.go
+++ b/CubeMaster/pkg/templatecenter/template_image.go
@@ -37,8 +37,9 @@ func distributionScopeFromTargets(targets []*node.Node) []string {
 	return scope
 }
 
-func newRedoWorkingRequest(sourceReq *types.CreateTemplateFromImageReq, targets []*node.Node) types.CreateTemplateFromImageReq {
+func newRedoWorkingRequest(sourceReq *types.CreateTemplateFromImageReq, templateID string, targets []*node.Node) types.CreateTemplateFromImageReq {
 	workingReq := *sourceReq
+	workingReq.TemplateID = templateID
 	workingReq.Request = &types.Request{RequestID: uuid.NewString()}
 	workingReq.DistributionScope = distributionScopeFromTargets(targets)
 	return workingReq
@@ -201,6 +202,7 @@ func SubmitRedoTemplateFromImage(ctx context.Context, req *types.RedoTemplateFro
 		if err != nil {
 			return fmt.Errorf("decode latest template image request fail: %w", err)
 		}
+		sourceReq.TemplateID = normalized.TemplateID
 		replicas, err := ListReplicas(ctx, normalized.TemplateID)
 		if err != nil {
 			return err

--- a/CubeMaster/pkg/templatecenter/template_image_test.go
+++ b/CubeMaster/pkg/templatecenter/template_image_test.go
@@ -1201,6 +1201,116 @@ func TestRunRedoTemplateImageJobStopsOnArtifactCleanupFailure(t *testing.T) {
 	}
 }
 
+func TestRunRedoTemplateImageJobRegeneratesRequestForRedoTemplateID(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	const redoTemplateID = "tpl-redo"
+	const staleTemplateID = "tpl-stale"
+	targets := []*node.Node{{InsID: "node-a", IP: "10.0.0.1", Healthy: true}}
+	staleReqPayload, _ := json.Marshal(&types.CreateCubeSandboxReq{
+		InstanceType: cubeboxv1.InstanceType_cubebox.String(),
+		Annotations: map[string]string{
+			constants.CubeAnnotationAppSnapshotTemplateID:      staleTemplateID,
+			constants.CubeAnnotationAppSnapshotTemplateVersion: DefaultTemplateVersion,
+		},
+	})
+	imageConfigPayload, _ := json.Marshal(image.DockerImageConfig{
+		Entrypoint: []string{"/bin/sh"},
+		Cmd:        []string{"-c", "echo ok"},
+	})
+
+	patches.ApplyFunc(getTemplateImageJobRecordByID, func(ctx context.Context, jobID string) (*models.TemplateImageJob, error) {
+		return &models.TemplateImageJob{
+			JobID:       jobID,
+			TemplateID:  redoTemplateID,
+			ResumePhase: JobPhaseSnapshotting,
+			ArtifactID:  "artifact-1",
+		}, nil
+	})
+	patches.ApplyFunc(updateTemplateImageJob, func(ctx context.Context, jobID string, values map[string]any) error {
+		return nil
+	})
+	patches.ApplyFunc(unmarshalTemplateImageJobRequest, func(payload string) (*types.CreateTemplateFromImageReq, error) {
+		return &types.CreateTemplateFromImageReq{
+			Request:           &types.Request{RequestID: "req-1"},
+			TemplateID:        staleTemplateID,
+			InstanceType:      cubeboxv1.InstanceType_cubebox.String(),
+			NetworkType:       cubeboxv1.NetworkType_tap.String(),
+			WritableLayerSize: "20Gi",
+			SourceImageRef:    "docker.io/library/nginx:latest",
+		}, nil
+	})
+	patches.ApplyFunc(ListReplicas, func(ctx context.Context, templateID string) ([]models.TemplateReplica, error) {
+		return []models.TemplateReplica{{NodeID: "node-a", Status: ReplicaStatusFailed}}, nil
+	})
+	patches.ApplyFunc(resolveRedoTargets, func(instanceType string, req *types.RedoTemplateFromImageReq, replicas []models.TemplateReplica) ([]*node.Node, error) {
+		return targets, nil
+	})
+	patches.ApplyFunc(getRootfsArtifactByID, func(ctx context.Context, artifactID string) (*models.RootfsArtifact, error) {
+		return &models.RootfsArtifact{
+			ArtifactID:              artifactID,
+			TemplateSpecFingerprint: "fingerprint-1",
+			Ext4SHA256:              "sha256",
+			Ext4SizeBytes:           1024,
+			DownloadToken:           "token-1",
+			GeneratedRequestJSON:    string(staleReqPayload),
+			ImageConfigJSON:         string(imageConfigPayload),
+			SourceImageDigest:       "sha256:digest",
+			WritableLayerSize:       "20Gi",
+			Status:                  ArtifactStatusReady,
+		}, nil
+	})
+	patches.ApplyFunc(cleanupTemplateReplicasOnNodes, func(ctx context.Context, templateID string, replicas []models.TemplateReplica, targets []*node.Node) error {
+		if templateID != redoTemplateID {
+			t.Fatalf("cleanup templateID = %q, want %q", templateID, redoTemplateID)
+		}
+		return nil
+	})
+	patches.ApplyFunc(ensureTemplateDefinition, func(ctx context.Context, templateID string, storedReq *types.CreateCubeSandboxReq, instanceType, version string) (bool, error) {
+		if templateID != redoTemplateID {
+			t.Fatalf("definition templateID = %q, want %q", templateID, redoTemplateID)
+		}
+		if got := storedReq.Annotations[constants.CubeAnnotationAppSnapshotTemplateID]; got != redoTemplateID {
+			t.Fatalf("stored request templateID = %q, want %q", got, redoTemplateID)
+		}
+		return true, nil
+	})
+
+	var capturedReq *types.CreateCubeSandboxReq
+	patches.ApplyFunc(createTemplateReplicasOnNodes, func(ctx context.Context, templateID string, req *types.CreateCubeSandboxReq, targets []*node.Node, opts replicaRunOptions) ([]ReplicaStatus, error) {
+		if templateID != redoTemplateID {
+			t.Fatalf("replica templateID = %q, want %q", templateID, redoTemplateID)
+		}
+		capturedReq = req
+		return []ReplicaStatus{{NodeID: "node-a", Status: ReplicaStatusReady}}, nil
+	})
+	patches.ApplyFunc(refreshTemplateReplicaSummary, func(ctx context.Context, templateID string) error {
+		return nil
+	})
+	patches.ApplyFunc(GetTemplateInfo, func(ctx context.Context, templateID string) (*TemplateInfo, error) {
+		return &TemplateInfo{TemplateID: templateID, Status: StatusReady}, nil
+	})
+
+	runRedoTemplateImageJob(context.Background(), "job-1", &types.RedoTemplateFromImageReq{
+		Request:    &types.Request{RequestID: "req-redo"},
+		TemplateID: redoTemplateID,
+	}, "http://master.example")
+
+	if capturedReq == nil {
+		t.Fatal("expected generated request to be passed to replica creation")
+	}
+	if got := capturedReq.Annotations[constants.CubeAnnotationAppSnapshotTemplateID]; got != redoTemplateID {
+		t.Fatalf("generated request templateID = %q, want %q", got, redoTemplateID)
+	}
+	if got := capturedReq.Containers[0].Image.Annotations[constants.CubeAnnotationRootfsArtifactURL]; !strings.Contains(got, "artifact_id=artifact-1") {
+		t.Fatalf("generated request should rebuild artifact URL, got %q", got)
+	}
+	if got := capturedReq.Containers[0].Command; !reflect.DeepEqual(got, []string{"/bin/sh"}) {
+		t.Fatalf("generated request command = %v, want image config entrypoint", got)
+	}
+}
+
 func TestRunRedoTemplateImageJobRequiresLocalImageForBuildRedo(t *testing.T) {
 	patches := gomonkey.NewPatches()
 	defer patches.Reset()

--- a/deploy/one-click/scripts/systemd/cube-egress-start.sh
+++ b/deploy/one-click/scripts/systemd/cube-egress-start.sh
@@ -27,10 +27,10 @@ require_cmd docker
 #   3. default    → int.tencentcloudcr.com (overseas/international)
 #
 # Production-pushed by CubeEgress/Makefile's `make push` to BOTH repos
-# under the :latest tag, so either default resolves to the same digest
+# under the :v0.4.0 tag, so either default resolves to the same digest
 # the operator most recently published.
-CUBE_EGRESS_IMAGE_INT_DEFAULT="cube-sandbox-int.tencentcloudcr.com/cube-sandbox/cube-egress:latest"
-CUBE_EGRESS_IMAGE_CN_DEFAULT="cube-sandbox-cn.tencentcloudcr.com/cube-sandbox/cube-egress:latest"
+CUBE_EGRESS_IMAGE_INT_DEFAULT="cube-sandbox-int.tencentcloudcr.com/cube-sandbox/cube-egress:v0.4.0"
+CUBE_EGRESS_IMAGE_CN_DEFAULT="cube-sandbox-cn.tencentcloudcr.com/cube-sandbox/cube-egress:v0.4.0"
 if [[ -n "${CUBE_SANDBOX_CUBE_EGRESS_IMAGE:-}" ]]; then
   CUBE_EGRESS_IMAGE="${CUBE_SANDBOX_CUBE_EGRESS_IMAGE}"
 elif [[ "${MIRROR:-}" == "cn" ]]; then


### PR DESCRIPTION
## Summary

When redoing a template image, the artifact-cached `GeneratedRequestJSON` carries the **original source template ID**, not the **redo template ID**. Previously the code reused this stale request, causing template ID mismatches during replica creation and template definition.

## Changes

### `redo.go`
- Pass template ID through `newRedoWorkingRequest` so working requests carry the correct redo template ID
- Always regenerate the sandbox request via `generateTemplateCreateRequest` instead of reusing the artifact-cached `GeneratedRequestJSON`
- Treat undecodable image config as a hard error instead of silently falling back to an empty config
- **Validate** that the generated request template ID matches the redo target template ID before proceeding

### `template_image.go`
- Add `templateID` parameter to `newRedoWorkingRequest` and set it on the working request
- Set `sourceReq.TemplateID` to the normalized template ID in `SubmitRedoTemplateFromImage`

### `template_image_test.go`
- Add `TestRunRedoTemplateImageJobRegeneratesRequestForRedoTemplateID`: verifies that when the artifact carries a stale template ID, the redo still generates a request with the correct redo template ID

### `cube-egress-start.sh`
- Pin CubeEgress default image tag from `latest` to `v0.4.0` for deterministic deployments

## Test Plan
- New unit test covers the stale-template-ID scenario end-to-end through the redo job flow
- Verified generated request carries correct template ID, artifact URL, and image config commands