### PR TITLE
feat(cubelet): release paused sandbox resources via a configurable ratio

### DIFF
--- a/CubeAPI/src/services/sandboxes.rs
+++ b/CubeAPI/src/services/sandboxes.rs
@@ -191,7 +191,7 @@ impl SandboxService {
             .cubemaster
             .update_sandbox(&self.build_update_request(sandbox_id, "pause", None))
             .await
-            .map_err(internal_error)?;
+            .map_err(|e| map_update_cubemaster_err(e, sandbox_id))?;
 
         ensure_update_result(
             resp.ret.ret_code,
@@ -206,7 +206,7 @@ impl SandboxService {
             .cubemaster
             .update_sandbox(&self.build_update_request(sandbox_id, "resume", Some(timeout)))
             .await
-            .map_err(internal_error)?;
+            .map_err(|e| map_update_cubemaster_err(e, sandbox_id))?;
 
         ensure_update_result(
             resp.ret.ret_code,
@@ -227,7 +227,7 @@ impl SandboxService {
                 .cubemaster
                 .update_sandbox(&self.build_update_request(sandbox_id, "resume", Some(timeout)))
                 .await
-                .map_err(internal_error)?;
+                .map_err(|e| map_update_cubemaster_err(e, sandbox_id))?;
 
             ensure_update_result(
                 resp.ret.ret_code,
@@ -497,6 +497,26 @@ fn sandbox_not_found_or_internal(e: CubeMasterError, sandbox_id: &str) -> AppErr
     }
 }
 
+// parse_response treats any non-success ret_code as CubeMasterError::Api before the
+// caller sees the envelope, so pause/resume/connect must remap business codes here
+// (ensure_update_result alone never runs on that path).
+fn map_update_cubemaster_err(e: CubeMasterError, sandbox_id: &str) -> AppError {
+    match e {
+        CubeMasterError::Api { ret_code, .. } if ret_code == RET_CODE_NOT_FOUND => {
+            AppError::NotFound(format!("sandbox {} not found", sandbox_id))
+        }
+        CubeMasterError::Api { ret_code, ret_msg } if ret_code == RET_CODE_CONFLICT => {
+            let detail = if ret_msg.trim().is_empty() {
+                format!("sandbox {} conflict", sandbox_id)
+            } else {
+                ret_msg // owned, moved out of e -- no clone
+            };
+            AppError::Conflict(detail)
+        }
+        other => sandbox_not_found_or_internal(other, sandbox_id),
+    }
+}
+
 fn ensure_update_result(
     ret_code: i32,
     ret_msg: String,
@@ -513,10 +533,15 @@ fn ensure_update_result(
         )));
     }
     if ret_code == RET_CODE_CONFLICT {
-        return Err(AppError::Conflict(format!(
-            "sandbox {} {}",
-            sandbox_id, conflict_message
-        )));
+        // Prefer the backend's own reason (e.g. the paused_resource_release_ratio
+        // capacity rejection on resume) so the client sees why it conflicted;
+        // fall back to the generic templated message when none was provided.
+        let detail = if ret_msg.trim().is_empty() {
+            format!("sandbox {} {}", sandbox_id, conflict_message)
+        } else {
+            ret_msg
+        };
+        return Err(AppError::Conflict(detail));
     }
     Err(AppError::Internal(anyhow::anyhow!(ret_msg)))
 }

--- a/Cubelet/dynamicconf/conf.yaml
+++ b/Cubelet/dynamicconf/conf.yaml
@@ -21,6 +21,19 @@ host:
     mem_limit: ""
     mvm_limit: 0
     creation_concurrent_num: 0
+    # Fraction of a paused sandbox's CPU/memory quota to release back to the
+    # scheduler, in [0,1], applied symmetrically to CPU and memory. A paused
+    # sandbox is snapshotted to disk with its MicroVM shut down, so the quota is
+    # physically free; this ratio trades density against resume headroom:
+    #   0.0 (default) release nothing -- paused keeps full quota, resume
+    #                 guaranteed (legacy behaviour, safe zero-value default).
+    #   1.0           release everything -- max density, resume best-effort and
+    #                 rejected when the node can no longer fit the sandbox.
+    #   0 < r < 1     release r, reserve (1-r) as headroom; the reserved quota
+    #                 still shows up in QuotaCpuUsage/QuotaMemUsage, so
+    #                 pause-heavy nodes are deprioritised by the cpu/mem scoring
+    #                 factors.
+    paused_resource_release_ratio: 0.0
   gc:
     code_expiration_time: "72h"
     image_expiration_time: "24h"

--- a/Cubelet/pkg/config/config.go
+++ b/Cubelet/pkg/config/config.go
@@ -50,6 +50,29 @@ type HostConfigQuota struct {
 	Mem                   string `yaml:"mem_limit"`
 	MvmLimit              int    `yaml:"mvm_limit"`
 	CreationConcurrentNum int    `yaml:"creation_concurrent_num"`
+
+	// PausedResourceReleaseRatio is the paused-resource scheduling dial.
+	// Pausing a sandbox snapshots it to disk and shuts the MicroVM down, so its
+	// host CPU/RAM is already reclaimed; this ratio decides how much of that
+	// quota is released back to the scheduler vs kept reserved as resume
+	// headroom. It is in [0,1] (out-of-range values are clamped) and is applied
+	// symmetrically to CPU and memory:
+	//   0.0 (default) -- release nothing: paused sandboxes keep their full
+	//                    quota, so resume is guaranteed. Identical to the legacy
+	//                    behaviour (the safe zero-value default).
+	//   1.0           -- release everything: maximum density, resume is purely
+	//                    best-effort and rejected when the node can no longer
+	//                    fit the sandbox (see UpdateWithResume admission).
+	//   0 < r < 1     -- release a fraction r and reserve (1-r) as headroom. A
+	//                    pause-heavy node then (a) keeps room for its own
+	//                    resumes and (b), because the reserved quota still shows
+	//                    up in QuotaCpuUsage/QuotaMemUsage, is naturally
+	//                    deprioritised by the cpu/mem quota scoring factors, so
+	//                    the scheduler stops piling new sandboxes onto nodes
+	//                    that already hold many paused ones.
+	// Disk is intentionally still counted (the pause snapshot occupies storage)
+	// and paused sandboxes still count toward MvmNum, regardless of the ratio.
+	PausedResourceReleaseRatio float64 `yaml:"paused_resource_release_ratio"`
 }
 
 type HostConfigGC struct {

--- a/Cubelet/services/cubebox/metric.go
+++ b/Cubelet/services/cubebox/metric.go
@@ -153,6 +153,15 @@ func scaleInt64(v int64, factor float64) int64 {
 	return int64(float64(v) * factor)
 }
 
+// bytesToMB is the single byte->MiB conversion shared by the accounting side
+// (aggregateSandboxResources) and the resume-admission side (admitResume), so
+// both truncate to MB at exactly the same point. Keeping it in one place
+// prevents the two paths from drifting on "scale-then-truncate" vs
+// "truncate-then-scale" ordering.
+func bytesToMB(b int64) int64 {
+	return b / 1024 / 1024
+}
+
 // aggregateSandboxResources is the pure accounting kernel behind
 // aggregateAllocated, split out so the release-ratio policy can be exercised
 // directly in tests without standing up the full config/store stack.
@@ -218,7 +227,7 @@ func aggregateSandboxResources(sbs []*cubeboxstore.CubeBox, releaseRatio float64
 	}
 	return aggregatedSandboxView{
 		MilliCPU:      cpuMilli,
-		MemoryMB:      memBytes / 1024 / 1024,
+		MemoryMB:      bytesToMB(memBytes),
 		MvmNum:        int64(len(sbs)),
 		MvmRunningNum: runningBox,
 		NicQueues:     nicQueues,

--- a/Cubelet/services/cubebox/metric.go
+++ b/Cubelet/services/cubebox/metric.go
@@ -6,6 +6,7 @@ package cubebox
 
 import (
 	"context"
+	"math"
 	"syscall"
 
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -15,6 +16,7 @@ import (
 	"github.com/tencentcloud/CubeSandbox/Cubelet/pkg/constants"
 	"github.com/tencentcloud/CubeSandbox/Cubelet/pkg/cubelet/resourcesource"
 	"github.com/tencentcloud/CubeSandbox/Cubelet/pkg/log"
+	cubeboxstore "github.com/tencentcloud/CubeSandbox/Cubelet/pkg/store/cubebox"
 	metrictype "github.com/tencentcloud/CubeSandbox/Cubelet/plugins/cube/internals/metric/types"
 	"github.com/tencentcloud/CubeSandbox/Cubelet/storage"
 	"github.com/tencentcloud/CubeSandbox/cubelog"
@@ -122,30 +124,101 @@ type aggregatedSandboxView struct {
 }
 
 func (l *local) aggregateAllocated() aggregatedSandboxView {
-	cpuUsage := resource.MustParse("0")
-	memUsage := resource.MustParse("0")
-	sbs := l.cubeboxManger.List()
+	return aggregateSandboxResources(
+		l.cubeboxManger.List(),
+		config.GetHostConf().Quota.PausedResourceReleaseRatio,
+	)
+}
+
+// clampRatio bounds the release ratio to [0,1], the operator's
+// density<->resume-headroom dial: 0 reserves everything (legacy, resume
+// guaranteed), 1 releases everything (max density, resume best-effort), and a
+// value in (0,1) releases that fraction while reserving the rest as headroom.
+// Out-of-range and non-finite inputs are clamped to the safe extremes
+// (NaN/-Inf -> 0, +Inf -> 1). The NaN guard is load-bearing: a malformed config
+// value (e.g. ".nan" from a templating error) would otherwise flow into
+// scaleInt64, where int64(v*NaN) collapses to math.MinInt64 and corrupts both
+// the reported quota and the resume admission decision.
+func clampRatio(r float64) float64 {
+	if math.IsNaN(r) || r < 0 {
+		return 0
+	}
+	if r > 1 {
+		return 1
+	}
+	return r
+}
+
+func scaleInt64(v int64, factor float64) int64 {
+	return int64(float64(v) * factor)
+}
+
+// aggregateSandboxResources is the pure accounting kernel behind
+// aggregateAllocated, split out so the release-ratio policy can be exercised
+// directly in tests without standing up the full config/store stack.
+//
+// releaseRatio drives how paused/pausing sandboxes are accounted. When it is >0
+// the policy is active: a paused sandbox counts only (1-releaseRatio) of its
+// CPU/memory quota and never as running / NIC queues, because it has been
+// snapshotted to disk and its MicroVM shut down, so it holds no live host
+// CPU/RAM. Lowering its reported quota lets cubemaster's scheduler reuse the
+// freed capacity, while a ratio in (0,1) keeps partial headroom so resume can
+// still land and pause-heavy nodes stay visible to the quota scoring factors.
+// Disk always counts (the pause snapshot occupies storage) and MvmNum always
+// counts them (the sandbox object lives on). When releaseRatio is 0 the result
+// is identical to the legacy behaviour: paused sandboxes keep their full quota
+// and count as running, so resume is guaranteed.
+func aggregateSandboxResources(sbs []*cubeboxstore.CubeBox, releaseRatio float64) aggregatedSandboxView {
+	// Resolve the ratio once: factor is the paused-quota fraction still counted
+	// (1-ratio), and the policy is active only for a strictly positive ratio.
+	ratio := clampRatio(releaseRatio)
+	factor := 1 - ratio
+	policyActive := ratio > 0
+	cpuMilli := int64(0)
+	memBytes := int64(0)
 	runningBox := int64(0)
 	nicQueues := int64(0)
 	dataDiskMB := int64(0)
 	storageDiskMB := int64(0)
 	for _, sb := range sbs {
-		if sb.GetStatus() == nil || !isContainerInGoodState(sb.GetStatus().Get().State()) {
+		status := sb.GetStatus()
+		if status == nil {
 			continue
 		}
-		runningBox++
+		// Snapshot the status once (single RLock + copy) and reuse it for both
+		// the good-state gate and the paused check below.
+		state := status.Get().State()
+		if !isContainerInGoodState(state) {
+			continue
+		}
+		// A paused sandbox under the policy keeps only `factor` of its quota.
+		paused := policyActive &&
+			(state == cubebox.ContainerState_CONTAINER_PAUSED ||
+				state == cubebox.ContainerState_CONTAINER_PAUSING)
 
 		if sb.ResourceWithOverHead != nil {
-			cpuUsage.Add(sb.ResourceWithOverHead.HostCpuQ)
-			memUsage.Add(sb.ResourceWithOverHead.HostMemQ)
+			if paused {
+				cpuMilli += scaleInt64(sb.ResourceWithOverHead.HostCpuQ.MilliValue(), factor)
+				memBytes += scaleInt64(sb.ResourceWithOverHead.HostMemQ.Value(), factor)
+			} else {
+				cpuMilli += sb.ResourceWithOverHead.HostCpuQ.MilliValue()
+				memBytes += sb.ResourceWithOverHead.HostMemQ.Value()
+			}
 			dataDiskMB += sb.ResourceWithOverHead.HostDataDiskMB
 			storageDiskMB += sb.ResourceWithOverHead.HostStorageDiskMB
 		}
+		if paused {
+			// Not running: a paused VM holds no live vCPU / NIC queues
+			// regardless of reserveRatio (the ratio only governs quota
+			// headroom, not liveness).
+			continue
+		}
+		runningBox++
 		nicQueues += sb.Queues
 	}
 	return aggregatedSandboxView{
-		MilliCPU:      cpuUsage.MilliValue(),
-		MemoryMB:      memUsage.Value() / 1024 / 1024,
+		MilliCPU:      cpuMilli,
+		MemoryMB:      memBytes / 1024 / 1024,
 		MvmNum:        int64(len(sbs)),
 		MvmRunningNum: runningBox,
 		NicQueues:     nicQueues,

--- a/Cubelet/services/cubebox/release_paused_resources_test.go
+++ b/Cubelet/services/cubebox/release_paused_resources_test.go
@@ -175,10 +175,69 @@ func TestScaleInt64(t *testing.T) {
 func TestAdmitResumeNoOpWhenPolicyDisabled(t *testing.T) {
 	// With no config loaded, GetHostConf() returns defaults where the policy is
 	// off, so resume must always be admitted regardless of node pressure.
-	s := &service{}
+	//
+	// Inject a real (empty) cubebox manager rather than leaving cubeboxMgr nil:
+	// the no-op must hold because the policy is off, not because admitResume
+	// happens to early-return before touching s.cubeboxMgr. A future refactor
+	// that reorders the policy-off check would otherwise nil-panic here instead
+	// of failing loudly on the actual behaviour.
+	s := &service{cubeboxMgr: &local{cubeboxManger: &fakeCubeboxAPI{}}}
 	sb := sandboxWithResourceForTest("sb", cubeboxstore.Status{PausedAt: time.Now().UnixNano()}, "1000m", "2Gi", 1, 0, 0)
 	rsp := &cubebox.UpdateCubeSandboxResponse{Ret: &errorcode.Ret{RetCode: errorcode.ErrorCode_Success}}
 
 	require.Nil(t, s.admitResume(context.Background(), sb, rsp))
 	assert.Equal(t, errorcode.ErrorCode_Success, rsp.Ret.RetCode)
+}
+
+// TestResumeDemandUsesBytePrecision locks the fix for the admission/accounting
+// precision mismatch: resumeDemand must scale at byte precision and truncate to
+// MB only at the end, exactly like aggregateSandboxResources, so the released
+// fraction (need) plus the reserved fraction equals the sandbox's full quota
+// with no off-by-one drift.
+func TestResumeDemandUsesBytePrecision(t *testing.T) {
+	// A HostMemQ deliberately NOT MiB-aligned (~101.9 MiB in raw bytes) so the
+	// legacy truncate-then-scale ordering and the byte-precision
+	// scale-then-truncate ordering diverge by 1 MB at this ratio.
+	r := &cubeboxstore.ResourceWithOverHead{
+		HostMemQ: resource.MustParse("106850713"),
+		HostCpuQ: resource.MustParse("2000m"),
+	}
+
+	needMemMB, needCPU := resumeDemand(r, 0.9)
+
+	// Byte precision: floor(floor(106850713 * 0.9) / 1MiB) = 91.
+	assert.Equal(t, int64(91), needMemMB)
+	assert.Equal(t, int64(1800), needCPU)
+
+	// The old truncate-then-scale path would have produced 90; assert the fix
+	// no longer matches it. Crucially this keeps need + reserved == full:
+	// reserved = bytesToMB(scaleInt64(bytes, 1-0.9)) = 10, full = 101.
+	legacyNeedMemMB := scaleInt64(r.HostMemQ.Value()/1024/1024, 0.9)
+	assert.Equal(t, int64(90), legacyNeedMemMB)
+	assert.NotEqual(t, legacyNeedMemMB, needMemMB)
+
+	reservedMemMB := bytesToMB(scaleInt64(r.HostMemQ.Value(), 1-0.9))
+	fullMemMB := bytesToMB(r.HostMemQ.Value())
+	assert.Equal(t, fullMemMB, needMemMB+reservedMemMB, "need + reserved must equal full quota")
+}
+
+// TestResumeQuotaRejectionMessageFormat locks the exact reason wording, which
+// is a cross-language contract parsed by regex in
+// web/src/lib/sandboxActionError.ts. If either format string changes, the
+// WebUI regex must change in lockstep or it silently falls back to a generic
+// message; this test fails first to flag the drift.
+func TestResumeQuotaRejectionMessageFormat(t *testing.T) {
+	mem := resumeQuotaRejection(resumeQuotaCheck{
+		usedMemMB:  6144,
+		needMemMB:  4096,
+		memQuotaMB: 8192,
+	})
+	assert.Equal(t, "need 4096MB + used 6144MB > mem quota 8192MB", mem)
+
+	cpu := resumeQuotaRejection(resumeQuotaCheck{
+		usedCPUMilli:  7000,
+		needCPUMilli:  2000,
+		cpuQuotaMilli: 8000,
+	})
+	assert.Equal(t, "need 2000m + used 7000m > cpu quota 8000m", cpu)
 }

--- a/Cubelet/services/cubebox/release_paused_resources_test.go
+++ b/Cubelet/services/cubebox/release_paused_resources_test.go
@@ -1,0 +1,184 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package cubebox
+
+import (
+	"context"
+	"math"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/api/resource"
+
+	"github.com/tencentcloud/CubeSandbox/Cubelet/api/services/cubebox/v1"
+	"github.com/tencentcloud/CubeSandbox/Cubelet/api/services/errorcode/v1"
+	cubeboxstore "github.com/tencentcloud/CubeSandbox/Cubelet/pkg/store/cubebox"
+)
+
+// sandboxWithResourceForTest builds a CubeBox carrying both a lifecycle status
+// and a per-sandbox resource footprint, so the accounting kernel can be driven
+// with realistic running/paused mixes.
+func sandboxWithResourceForTest(id string, status cubeboxstore.Status, cpu, mem string, queues, dataDiskMB, storageDiskMB int64) *cubeboxstore.CubeBox {
+	cb := newCubeboxWithStatusForTest(id, status)
+	cb.ResourceWithOverHead = &cubeboxstore.ResourceWithOverHead{
+		HostCpuQ:          resource.MustParse(cpu),
+		HostMemQ:          resource.MustParse(mem),
+		HostDataDiskMB:    dataDiskMB,
+		HostStorageDiskMB: storageDiskMB,
+	}
+	cb.Queues = queues
+	return cb
+}
+
+func TestAggregateSandboxResourcesRatioZeroCountsPausedQuota(t *testing.T) {
+	now := time.Now().UnixNano()
+	sbs := []*cubeboxstore.CubeBox{
+		sandboxWithResourceForTest("run", cubeboxstore.Status{StartedAt: now}, "1000m", "2Gi", 4, 10, 20),
+		sandboxWithResourceForTest("paused", cubeboxstore.Status{PausedAt: now}, "2000m", "4Gi", 8, 30, 40),
+	}
+
+	// releaseRatio 0 = legacy: a paused sandbox keeps reserving its full quota
+	// and counts as running, so the node still looks fully committed and resume
+	// is guaranteed.
+	got := aggregateSandboxResources(sbs, 0)
+
+	assert.Equal(t, int64(3000), got.MilliCPU)
+	assert.Equal(t, int64(6144), got.MemoryMB)
+	assert.Equal(t, int64(2), got.MvmNum)
+	assert.Equal(t, int64(2), got.MvmRunningNum)
+	assert.Equal(t, int64(12), got.NicQueues)
+	assert.Equal(t, int64(40), got.DataDiskMB)
+	assert.Equal(t, int64(60), got.StorageDiskMB)
+}
+
+func TestAggregateSandboxResourcesRatioOneReleasesPausedCPUAndMem(t *testing.T) {
+	now := time.Now().UnixNano()
+	sbs := []*cubeboxstore.CubeBox{
+		sandboxWithResourceForTest("run", cubeboxstore.Status{StartedAt: now}, "1000m", "2Gi", 4, 10, 20),
+		sandboxWithResourceForTest("paused", cubeboxstore.Status{PausedAt: now}, "2000m", "4Gi", 8, 30, 40),
+	}
+
+	// releaseRatio 1 = release everything: paused sandbox no longer reserves
+	// CPU/RAM/NIC queues nor counts as running, freeing scheduling capacity...
+	got := aggregateSandboxResources(sbs, 1)
+
+	assert.Equal(t, int64(1000), got.MilliCPU, "paused CPU quota must be released")
+	assert.Equal(t, int64(2048), got.MemoryMB, "paused mem quota must be released")
+	assert.Equal(t, int64(1), got.MvmRunningNum, "paused sandbox is not running")
+	assert.Equal(t, int64(4), got.NicQueues, "paused NIC queues must be released")
+	// ...but the sandbox object still exists and its pause snapshot occupies
+	// disk, so MvmNum and disk accounting are unchanged.
+	assert.Equal(t, int64(2), got.MvmNum, "paused sandbox object still counts")
+	assert.Equal(t, int64(40), got.DataDiskMB, "disk still counts under the policy")
+	assert.Equal(t, int64(60), got.StorageDiskMB, "disk still counts under the policy")
+}
+
+func TestAggregateSandboxResourcesRatioOneAlsoReleasesPausingQuota(t *testing.T) {
+	now := time.Now().UnixNano()
+	sbs := []*cubeboxstore.CubeBox{
+		// PAUSING is the in-flight pause transient; it must release quota too so
+		// the freed capacity is visible the moment the pause begins committing.
+		sandboxWithResourceForTest("pausing", cubeboxstore.Status{PausingAt: now}, "2000m", "4Gi", 8, 30, 40),
+	}
+
+	got := aggregateSandboxResources(sbs, 1)
+
+	assert.Equal(t, int64(0), got.MilliCPU)
+	assert.Equal(t, int64(0), got.MemoryMB)
+	assert.Equal(t, int64(0), got.MvmRunningNum)
+	assert.Equal(t, int64(1), got.MvmNum)
+}
+
+func TestAggregateSandboxResourcesPartialRelease(t *testing.T) {
+	now := time.Now().UnixNano()
+	sbs := []*cubeboxstore.CubeBox{
+		sandboxWithResourceForTest("run", cubeboxstore.Status{StartedAt: now}, "1000m", "2Gi", 4, 10, 20),
+		sandboxWithResourceForTest("paused", cubeboxstore.Status{PausedAt: now}, "2000m", "4Gi", 8, 30, 40),
+	}
+
+	// Release 50% of the paused sandbox's CPU/mem quota (reserve the other 50%).
+	got := aggregateSandboxResources(sbs, 0.5)
+
+	// running 1000m/2Gi + reserved 50% of paused 2000m/4Gi = 2000m/4096MB.
+	assert.Equal(t, int64(2000), got.MilliCPU, "running + reserved half of paused CPU")
+	assert.Equal(t, int64(4096), got.MemoryMB, "running + reserved half of paused mem")
+	// Liveness is unaffected by the ratio: paused is still not running and
+	// holds no NIC queues; the object and its disk snapshot still count.
+	assert.Equal(t, int64(1), got.MvmRunningNum)
+	assert.Equal(t, int64(4), got.NicQueues)
+	assert.Equal(t, int64(2), got.MvmNum)
+	assert.Equal(t, int64(40), got.DataDiskMB)
+	assert.Equal(t, int64(60), got.StorageDiskMB)
+}
+
+func TestClampRatio(t *testing.T) {
+	// In-range values pass through; out-of-range and non-finite inputs clamp to
+	// the safe extremes so a malformed config can never corrupt the accounting
+	// or bypass resume admission.
+	assert.Equal(t, 0.0, clampRatio(0))
+	assert.Equal(t, 1.0, clampRatio(1))
+	assert.Equal(t, 0.25, clampRatio(0.25))
+	assert.Equal(t, 0.0, clampRatio(-1), "negative clamps to 0")
+	assert.Equal(t, 1.0, clampRatio(2), "above 1 clamps to 1")
+	assert.Equal(t, 0.0, clampRatio(math.NaN()), "NaN clamps to 0 (no resume-admission bypass)")
+	assert.Equal(t, 1.0, clampRatio(math.Inf(1)), "+Inf clamps to 1")
+	assert.Equal(t, 0.0, clampRatio(math.Inf(-1)), "-Inf clamps to 0")
+}
+
+func TestResumeQuotaRejection(t *testing.T) {
+	cases := []struct {
+		name                                                                   string
+		usedMemMB, needMemMB, memQuotaMB, usedCPUMilli, needCPUMilli, cpuQuota int64
+		wantReject                                                             bool
+	}{
+		{"fits", 2048, 4096, 8192, 1000, 2000, 8000, false},
+		{"mem exceeds quota", 6000, 4096, 8192, 0, 0, 0, true},
+		{"cpu exceeds quota", 0, 0, 0, 7000, 2000, 8000, true},
+		{"exact fit is allowed", 4096, 4096, 8192, 6000, 2000, 8000, false},
+		{"unbounded quota never rejects", 999999, 999999, 0, 999999, 999999, 0, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			reason := resumeQuotaRejection(resumeQuotaCheck{
+				usedMemMB:     tc.usedMemMB,
+				needMemMB:     tc.needMemMB,
+				memQuotaMB:    tc.memQuotaMB,
+				usedCPUMilli:  tc.usedCPUMilli,
+				needCPUMilli:  tc.needCPUMilli,
+				cpuQuotaMilli: tc.cpuQuota,
+			})
+			if tc.wantReject {
+				assert.NotEmpty(t, reason)
+			} else {
+				assert.Empty(t, reason)
+			}
+		})
+	}
+}
+
+func TestScaleInt64(t *testing.T) {
+	// Normal multiplication and truncation toward zero.
+	assert.Equal(t, int64(2048), scaleInt64(4096, 0.5))
+	assert.Equal(t, int64(0), scaleInt64(1000, 0))
+	assert.Equal(t, int64(1000), scaleInt64(1000, 1))
+	assert.Equal(t, int64(7), scaleInt64(10, 0.75), "truncates toward zero")
+	// Guard the load-bearing contract that callers must pass a clamped factor:
+	// a non-finite factor collapses int64(v*NaN) to math.MinInt64, which is why
+	// clampRatio sanitises the ratio before it ever reaches scaleInt64.
+	assert.Equal(t, int64(math.MinInt64), scaleInt64(4096, math.NaN()))
+}
+
+func TestAdmitResumeNoOpWhenPolicyDisabled(t *testing.T) {
+	// With no config loaded, GetHostConf() returns defaults where the policy is
+	// off, so resume must always be admitted regardless of node pressure.
+	s := &service{}
+	sb := sandboxWithResourceForTest("sb", cubeboxstore.Status{PausedAt: time.Now().UnixNano()}, "1000m", "2Gi", 1, 0, 0)
+	rsp := &cubebox.UpdateCubeSandboxResponse{Ret: &errorcode.Ret{RetCode: errorcode.ErrorCode_Success}}
+
+	require.Nil(t, s.admitResume(context.Background(), sb, rsp))
+	assert.Equal(t, errorcode.ErrorCode_Success, rsp.Ret.RetCode)
+}

--- a/Cubelet/services/cubebox/update.go
+++ b/Cubelet/services/cubebox/update.go
@@ -13,8 +13,11 @@ import (
 	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/containerd/v2/pkg/namespaces"
 	"github.com/containerd/ttrpc"
+	"k8s.io/apimachinery/pkg/api/resource"
+
 	"github.com/tencentcloud/CubeSandbox/Cubelet/api/services/cubebox/v1"
 	"github.com/tencentcloud/CubeSandbox/Cubelet/api/services/errorcode/v1"
+	"github.com/tencentcloud/CubeSandbox/Cubelet/pkg/config"
 	"github.com/tencentcloud/CubeSandbox/Cubelet/pkg/constants"
 	"github.com/tencentcloud/CubeSandbox/Cubelet/pkg/log"
 	"github.com/tencentcloud/CubeSandbox/Cubelet/pkg/recov"
@@ -208,6 +211,10 @@ func (s *service) UpdateWithResume(ctx context.Context, req *cubebox.UpdateCubeS
 		return rsp, nil
 	}
 
+	if rejected := s.admitResume(ctx, sb, rsp); rejected != nil {
+		return rejected, nil
+	}
+
 	ns := sb.Namespace
 	if ns == "" {
 		ns = namespaces.Default
@@ -241,6 +248,108 @@ func (s *service) UpdateWithResume(ctx context.Context, req *cubebox.UpdateCubeS
 	}
 	convergeResumeStateAfterOpaqueRestore(sb, time.Now().UTC())
 	return rsp, nil
+}
+
+// admitResume enforces the resume side of the release-paused-resources policy.
+// When the policy is off it is a no-op (resume is always admitted, matching
+// the legacy guaranteed-resume behaviour). When on, pausing this sandbox
+// already released its CPU/memory quota so the scheduler could fill the node;
+// resuming would re-add that demand, so we re-check against the node's local,
+// real-time quota usage and reject when the sandbox no longer fits. Rejecting
+// here -- rather than overcommitting host RAM and risking an OOM -- is the
+// explicit trade-off the policy makes.
+//
+// It returns a non-nil response (already populated) when resume must be
+// rejected, or nil to proceed. Under a release ratio r the still-paused sandbox
+// already contributes (1-r) of its quota to aggregateAllocated, so resuming it
+// (a full reservation) only adds the remaining r fraction; we check that
+// incremental demand against the node quota to model the post-resume state.
+//
+// The check is best-effort, not a hard reservation: concurrent resumes of
+// different sandboxes each read their own snapshot of aggregateAllocated, so a
+// burst can momentarily admit past the quota (the OS/cgroup remains the hard
+// backstop). This matches how create scheduling is optimistic too; operators
+// who want more headroom can lower the release ratio so the reserved fraction
+// absorbs concurrent-resume overshoot.
+func (s *service) admitResume(
+	ctx context.Context,
+	sb *cubeboxstore.CubeBox,
+	rsp *cubebox.UpdateCubeSandboxResponse,
+) *cubebox.UpdateCubeSandboxResponse {
+	// GetHostConf always returns a non-nil config (it falls back to defaults).
+	hostConf := config.GetHostConf()
+	releaseRatio := clampRatio(hostConf.Quota.PausedResourceReleaseRatio)
+	if releaseRatio <= 0 {
+		// Policy off: paused sandboxes kept their full quota, so resume is
+		// guaranteed and needs no admission check (legacy behaviour).
+		return nil
+	}
+	if sb.ResourceWithOverHead == nil {
+		// Policy active but we cannot size this sandbox's demand. Fail closed
+		// (reject) rather than silently admit and risk overcommit; this also
+		// surfaces any sandbox missing resource metadata instead of hiding it.
+		rsp.Ret.RetMsg = "resume rejected by paused_resource_release_ratio policy: missing resource metadata"
+		rsp.Ret.RetCode = errorcode.ErrorCode_Conflict
+		log.G(ctx).Warnf("admitResume reject sandbox=%s: missing resource metadata under paused_resource_release_ratio policy", sb.ID)
+		return rsp
+	}
+
+	// Recomputed live (no cache) on purpose: admission must reflect the current
+	// allocation to avoid overcommit, and resume is far rarer than its VM-wake
+	// cost, so this O(n) scan is acceptable on this path.
+	alloc := s.cubeboxMgr.aggregateAllocated()
+	memQuotaMB := int64(0)
+	if memQuota, err := resource.ParseQuantity(hostConf.Quota.Mem); err == nil {
+		memQuotaMB = memQuota.Value() / 1024 / 1024
+	}
+	// Only the released fraction is the incremental demand of resuming.
+	needMemMB := scaleInt64(sb.ResourceWithOverHead.HostMemQ.Value()/1024/1024, releaseRatio)
+	needCPU := scaleInt64(sb.ResourceWithOverHead.HostCpuQ.MilliValue(), releaseRatio)
+
+	if reason := resumeQuotaRejection(resumeQuotaCheck{
+		usedMemMB:     alloc.MemoryMB,
+		needMemMB:     needMemMB,
+		memQuotaMB:    memQuotaMB,
+		usedCPUMilli:  alloc.MilliCPU,
+		needCPUMilli:  needCPU,
+		cpuQuotaMilli: int64(hostConf.Quota.Cpu),
+	}); reason != "" {
+		rsp.Ret.RetMsg = "resume rejected by paused_resource_release_ratio policy: " + reason
+		// Conflict (not TaskResumeFailed) so the capacity rejection surfaces as
+		// HTTP 409 at the API edge: this is an expected, retriable state (free
+		// up capacity and retry), not a backend failure that should read as a
+		// 500. The descriptive RetMsg is carried through to the client.
+		rsp.Ret.RetCode = errorcode.ErrorCode_Conflict
+		log.G(ctx).Warnf("admitResume reject sandbox=%s: %s", sb.ID, rsp.Ret.RetMsg)
+		return rsp
+	}
+
+	return nil
+}
+
+// resumeQuotaCheck bundles the post-resume quota inputs so call sites name each
+// value explicitly (six positional int64s are easy to transpose) and future
+// dimensions (e.g. disk) can be added without reshuffling arguments.
+type resumeQuotaCheck struct {
+	usedMemMB, needMemMB, memQuotaMB          int64
+	usedCPUMilli, needCPUMilli, cpuQuotaMilli int64
+}
+
+// resumeQuotaRejection is the pure decision behind admitResume: it returns a
+// non-empty human-readable reason when bringing a paused sandbox back would
+// push the node past its CPU or memory quota, or "" when the resume fits. A
+// non-positive quota means "unbounded" for that dimension and is skipped, which
+// matches how the rest of the cubelet treats an unset host quota.
+func resumeQuotaRejection(c resumeQuotaCheck) string {
+	if c.memQuotaMB > 0 && c.usedMemMB+c.needMemMB > c.memQuotaMB {
+		return fmt.Sprintf("need %dMB + used %dMB > mem quota %dMB",
+			c.needMemMB, c.usedMemMB, c.memQuotaMB)
+	}
+	if c.cpuQuotaMilli > 0 && c.usedCPUMilli+c.needCPUMilli > c.cpuQuotaMilli {
+		return fmt.Sprintf("need %dm + used %dm > cpu quota %dm",
+			c.needCPUMilli, c.usedCPUMilli, c.cpuQuotaMilli)
+	}
+	return ""
 }
 
 // Upper bound for the Pause/Resume ttrpc calls. 30s is used because cubeshim

--- a/Cubelet/services/cubebox/update.go
+++ b/Cubelet/services/cubebox/update.go
@@ -300,11 +300,10 @@ func (s *service) admitResume(
 	alloc := s.cubeboxMgr.aggregateAllocated()
 	memQuotaMB := int64(0)
 	if memQuota, err := resource.ParseQuantity(hostConf.Quota.Mem); err == nil {
-		memQuotaMB = memQuota.Value() / 1024 / 1024
+		memQuotaMB = bytesToMB(memQuota.Value())
 	}
 	// Only the released fraction is the incremental demand of resuming.
-	needMemMB := scaleInt64(sb.ResourceWithOverHead.HostMemQ.Value()/1024/1024, releaseRatio)
-	needCPU := scaleInt64(sb.ResourceWithOverHead.HostCpuQ.MilliValue(), releaseRatio)
+	needMemMB, needCPU := resumeDemand(sb.ResourceWithOverHead, releaseRatio)
 
 	if reason := resumeQuotaRejection(resumeQuotaCheck{
 		usedMemMB:     alloc.MemoryMB,
@@ -327,6 +326,19 @@ func (s *service) admitResume(
 	return nil
 }
 
+// resumeDemand returns the incremental CPU/memory a resume re-adds to the node
+// under releaseRatio. While paused, the sandbox already contributes (1-ratio)
+// of its quota to aggregateAllocated, so resuming it (a full reservation) only
+// adds back the released `ratio` fraction. The memory side scales at byte
+// precision and truncates to MB only at the very end, identical to
+// aggregateSandboxResources, so the admission and accounting paths cannot
+// disagree by a sub-MB rounding gap. Callers must pass a clamped ratio.
+func resumeDemand(r *cubeboxstore.ResourceWithOverHead, releaseRatio float64) (needMemMB, needCPUMilli int64) {
+	needMemMB = bytesToMB(scaleInt64(r.HostMemQ.Value(), releaseRatio))
+	needCPUMilli = scaleInt64(r.HostCpuQ.MilliValue(), releaseRatio)
+	return needMemMB, needCPUMilli
+}
+
 // resumeQuotaCheck bundles the post-resume quota inputs so call sites name each
 // value explicitly (six positional int64s are easy to transpose) and future
 // dimensions (e.g. disk) can be added without reshuffling arguments.
@@ -341,6 +353,13 @@ type resumeQuotaCheck struct {
 // non-positive quota means "unbounded" for that dimension and is skipped, which
 // matches how the rest of the cubelet treats an unset host quota.
 func resumeQuotaRejection(c resumeQuotaCheck) string {
+	// NOTE: these two reason formats are an explicit cross-language contract:
+	// the WebUI parses them by regex in web/src/lib/sandboxActionError.ts
+	// (formatSandboxActionError) to render the localized capacity banner. Keep
+	// the exact wording ("need %dMB + used %dMB > mem quota %dMB" and the "%dm"
+	// CPU variant) in sync with that regex, or the frontend silently falls back
+	// to a generic message. TestResumeQuotaRejectionMessageFormat locks the
+	// format on this side.
 	if c.memQuotaMB > 0 && c.usedMemMB+c.needMemMB > c.memQuotaMB {
 		return fmt.Sprintf("need %dMB + used %dMB > mem quota %dMB",
 			c.needMemMB, c.usedMemMB, c.memQuotaMB)

--- a/configs/single-node/cubelet.yaml
+++ b/configs/single-node/cubelet.yaml
@@ -10,6 +10,19 @@ host:
     mem_limit: ""
     mvm_limit: 0
     creation_concurrent_num: 0
+    # Fraction of a paused sandbox's CPU/memory quota to release back to the
+    # scheduler, in [0,1], applied symmetrically to CPU and memory. A paused
+    # sandbox is snapshotted to disk with its MicroVM shut down, so the quota is
+    # physically free; this ratio trades density against resume headroom:
+    #   0.0 (default) release nothing -- paused keeps full quota, resume
+    #                 guaranteed (legacy behaviour, safe zero-value default).
+    #   1.0           release everything -- max density, resume best-effort and
+    #                 rejected when the node can no longer fit the sandbox.
+    #   0 < r < 1     release r, reserve (1-r) as headroom; the reserved quota
+    #                 still shows up in QuotaCpuUsage/QuotaMemUsage, so
+    #                 pause-heavy nodes are deprioritised by the cpu/mem scoring
+    #                 factors.
+    paused_resource_release_ratio: 0.0
   gc:
     code_expiration_time: "72h"
     image_expiration_time: "24h"

--- a/web/src/components/SandboxActionErrorBanner.tsx
+++ b/web/src/components/SandboxActionErrorBanner.tsx
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2026 Tencent. All rights reserved.
+
+import { AlertTriangle, X } from 'lucide-react';
+
+export function SandboxActionErrorBanner({
+  message,
+  onDismiss,
+}: {
+  message: string | null;
+  onDismiss: () => void;
+}) {
+  if (!message) return null;
+
+  return (
+    <div
+      role="alert"
+      className="flex items-start gap-3 rounded-md border border-cube-amber/40 bg-cube-amber/10 px-4 py-3 text-sm text-cube-amber"
+    >
+      <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
+      <p className="flex-1 break-words leading-relaxed">{message}</p>
+      <button
+        type="button"
+        onClick={onDismiss}
+        className="shrink-0 rounded p-0.5 text-cube-amber/80 hover:text-cube-amber"
+        aria-label="dismiss"
+      >
+        <X size={14} />
+      </button>
+    </div>
+  );
+}

--- a/web/src/lib/sandboxActionError.ts
+++ b/web/src/lib/sandboxActionError.ts
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2026 Tencent. All rights reserved.
+
+import { ApiError } from '@/lib/api';
+
+type TranslateFn = (...args: any[]) => string;
+
+/** 将 pause/resume/kill 等 lifecycle 失败转成可展示的文案. */
+export function formatSandboxActionError(err: unknown, t: TranslateFn): string {
+  const raw = err instanceof Error ? err.message : String(err);
+  const status = err instanceof ApiError ? err.status : 0;
+
+  if (status === 409 && /resume rejected by paused_resource_release_ratio/i.test(raw)) {
+    // Cubelet rejects on whichever dimension overflows first, so handle both
+    // the memory (MB) and the CPU (milli, "m") reason formats.
+    const mem = raw.match(/need (\d+MB) \+ used (\d+MB) > mem quota (\d+MB)/);
+    if (mem) {
+      return t('errors.resumeCapacityDetail', {
+        need: mem[1],
+        used: mem[2],
+        quota: mem[3],
+      });
+    }
+    const cpu = raw.match(/need (\d+m) \+ used (\d+m) > cpu quota (\d+m)/);
+    if (cpu) {
+      return t('errors.resumeCapacityDetailCpu', {
+        need: cpu[1],
+        used: cpu[2],
+        quota: cpu[3],
+      });
+    }
+    return t('errors.resumeCapacity');
+  }
+
+  if (status === 409) {
+    return t('errors.conflict', { message: raw });
+  }
+
+  return t('errors.actionFailed', { message: raw || t('errors.unknown') });
+}

--- a/web/src/lib/sandboxActionError.ts
+++ b/web/src/lib/sandboxActionError.ts
@@ -13,6 +13,13 @@ export function formatSandboxActionError(err: unknown, t: TranslateFn): string {
   if (status === 409 && /resume rejected by paused_resource_release_ratio/i.test(raw)) {
     // Cubelet rejects on whichever dimension overflows first, so handle both
     // the memory (MB) and the CPU (milli, "m") reason formats.
+    //
+    // NOTE: these regexes mirror the exact reason strings produced by
+    // resumeQuotaRejection in Cubelet/services/cubebox/update.go. They are a
+    // cross-language contract; if the Go format strings change, update these
+    // regexes too (the Go side guards its format via
+    // TestResumeQuotaRejectionMessageFormat). On a mismatch we fall back to the
+    // generic errors.resumeCapacity message below.
     const mem = raw.match(/need (\d+MB) \+ used (\d+MB) > mem quota (\d+MB)/);
     if (mem) {
       return t('errors.resumeCapacityDetail', {

--- a/web/src/locales/en/sandboxDetail.json
+++ b/web/src/locales/en/sandboxDetail.json
@@ -26,5 +26,13 @@
     "resume": "Resume",
     "pause": "Pause",
     "kill": "Kill"
+  },
+  "errors": {
+    "unknown": "Unknown error",
+    "actionFailed": "Action failed: {{message}}",
+    "conflict": "{{message}}",
+    "resumeCapacity": "Insufficient node capacity to resume this sandbox. Free capacity and retry.",
+    "resumeCapacityDetail": "Insufficient memory to resume (need {{need}}, used {{used}}, quota {{quota}})",
+    "resumeCapacityDetailCpu": "Insufficient CPU to resume (need {{need}}, used {{used}}, quota {{quota}})"
   }
 }

--- a/web/src/locales/en/sandboxes.json
+++ b/web/src/locales/en/sandboxes.json
@@ -26,5 +26,13 @@
     "resume": "Resume",
     "pause": "Pause",
     "kill": "Kill"
+  },
+  "errors": {
+    "unknown": "Unknown error",
+    "actionFailed": "Action failed: {{message}}",
+    "conflict": "{{message}}",
+    "resumeCapacity": "Insufficient node capacity to resume this sandbox. Free capacity and retry.",
+    "resumeCapacityDetail": "Insufficient memory to resume (need {{need}}, used {{used}}, quota {{quota}})",
+    "resumeCapacityDetailCpu": "Insufficient CPU to resume (need {{need}}, used {{used}}, quota {{quota}})"
   }
 }

--- a/web/src/locales/zh/sandboxDetail.json
+++ b/web/src/locales/zh/sandboxDetail.json
@@ -26,5 +26,13 @@
     "resume": "恢复",
     "pause": "暂停",
     "kill": "终止"
+  },
+  "errors": {
+    "unknown": "未知错误",
+    "actionFailed": "操作失败: {{message}}",
+    "conflict": "{{message}}",
+    "resumeCapacity": "节点资源不足, 无法恢复该沙箱, 请先释放其他实例容量",
+    "resumeCapacityDetail": "节点内存不足, 无法恢复 (还需 {{need}}, 已用 {{used}}, 配额 {{quota}})",
+    "resumeCapacityDetailCpu": "节点 CPU 不足, 无法恢复 (还需 {{need}}, 已用 {{used}}, 配额 {{quota}})"
   }
 }

--- a/web/src/locales/zh/sandboxes.json
+++ b/web/src/locales/zh/sandboxes.json
@@ -26,5 +26,13 @@
     "resume": "恢复",
     "pause": "暂停",
     "kill": "终止"
+  },
+  "errors": {
+    "unknown": "未知错误",
+    "actionFailed": "操作失败: {{message}}",
+    "conflict": "{{message}}",
+    "resumeCapacity": "节点资源不足, 无法恢复该沙箱, 请先释放其他实例容量",
+    "resumeCapacityDetail": "节点内存不足, 无法恢复 (还需 {{need}}, 已用 {{used}}, 配额 {{quota}})",
+    "resumeCapacityDetailCpu": "节点 CPU 不足, 无法恢复 (还需 {{need}}, 已用 {{used}}, 配额 {{quota}})"
   }
 }

--- a/web/src/pages/SandboxDetail.tsx
+++ b/web/src/pages/SandboxDetail.tsx
@@ -13,6 +13,8 @@ import { Badge } from '@/components/ui/badge';
 import { Skeleton } from '@/components/ui/skeleton';
 import { ArrowLeft, Pause, Play, Trash2, RefreshCw } from 'lucide-react';
 import { cn, formatBytes, formatRelative } from '@/lib/utils';
+import { formatSandboxActionError } from '@/lib/sandboxActionError';
+import { SandboxActionErrorBanner } from '@/components/SandboxActionErrorBanner';
 
 // ── Log level colors ────────────────────────────────────────────────────────
 const LEVEL_CLASS: Record<string, string> = {
@@ -58,11 +60,16 @@ export default function SandboxDetailPage() {
     }
   }, [logs.data]);
 
-
+  const [actionError, setActionError] = useState<string | null>(null);
+  const onLifecycleError = (err: unknown) => {
+    setActionError(formatSandboxActionError(err, t));
+  };
 
   // ── Lifecycle mutations ─────────────────────────────────────────────────
   const kill = useMutation({
     mutationFn: () => sandboxApi.kill(sandboxID),
+    onMutate: () => setActionError(null),
+    onError: onLifecycleError,
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: ['sandboxes'] });
       nav('/sandboxes');
@@ -70,6 +77,8 @@ export default function SandboxDetailPage() {
   });
   const pause = useMutation({
     mutationFn: () => sandboxApi.pause(sandboxID),
+    onMutate: () => setActionError(null),
+    onError: onLifecycleError,
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: ['sandboxes'] });
       qc.invalidateQueries({ queryKey: ['sandbox', sandboxID] });
@@ -77,6 +86,8 @@ export default function SandboxDetailPage() {
   });
   const resume = useMutation({
     mutationFn: () => sandboxApi.resume(sandboxID),
+    onMutate: () => setActionError(null),
+    onError: onLifecycleError,
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: ['sandboxes'] });
       qc.invalidateQueries({ queryKey: ['sandbox', sandboxID] });
@@ -120,6 +131,8 @@ export default function SandboxDetailPage() {
           </Button>
         </div>
       </div>
+
+      <SandboxActionErrorBanner message={actionError} onDismiss={() => setActionError(null)} />
 
       {/* ── Info cards ── */}
       <div className="grid grid-cols-1 gap-4 lg:grid-cols-3">

--- a/web/src/pages/Sandboxes.tsx
+++ b/web/src/pages/Sandboxes.tsx
@@ -14,6 +14,8 @@ import { Skeleton } from '@/components/ui/skeleton';
 import { Pause, Play, Trash2, Search, Plus } from 'lucide-react';
 import { formatBytes, formatRelative, short } from '@/lib/utils';
 import { cn } from '@/lib/utils';
+import { formatSandboxActionError } from '@/lib/sandboxActionError';
+import { SandboxActionErrorBanner } from '@/components/SandboxActionErrorBanner';
 
 type StateFilter = 'all' | 'running' | 'paused';
 
@@ -31,17 +33,28 @@ export default function SandboxesPage() {
   });
 
   const [pendingId, setPendingId] = useState<string | null>(null);
+  const [actionError, setActionError] = useState<string | null>(null);
+
+  const onLifecycleError = (err: unknown) => {
+    setActionError(formatSandboxActionError(err, t));
+  };
 
   const killMut = useMutation({
     mutationFn: (id: string) => { setPendingId(id); return sandboxApi.kill(id); },
+    onMutate: () => setActionError(null),
+    onError: onLifecycleError,
     onSettled: () => { setPendingId(null); qc.invalidateQueries({ queryKey: ['sandboxes'] }); },
   });
   const pauseMut = useMutation({
     mutationFn: (id: string) => { setPendingId(id); return sandboxApi.pause(id); },
+    onMutate: () => setActionError(null),
+    onError: onLifecycleError,
     onSettled: () => { setPendingId(null); qc.invalidateQueries({ queryKey: ['sandboxes'] }); },
   });
   const resumeMut = useMutation({
     mutationFn: (id: string) => { setPendingId(id); return sandboxApi.resume(id); },
+    onMutate: () => setActionError(null),
+    onError: onLifecycleError,
     onSettled: () => { setPendingId(null); qc.invalidateQueries({ queryKey: ['sandboxes'] }); },
   });
 
@@ -75,6 +88,8 @@ export default function SandboxesPage() {
           </Button>
         </Link>
       </header>
+
+      <SandboxActionErrorBanner message={actionError} onDismiss={() => setActionError(null)} />
 
       <Card className="!p-3">
         <div className="flex items-center gap-2">


### PR DESCRIPTION
Pausing a sandbox snapshots its full memory state to disk and shuts the MicroVM down, so the host CPU/RAM it held is already reclaimed. The node resource accounting, however, still counted paused/pausing sandboxes against the node quota: aggregateAllocated() summed their HostCpuQ/HostMemQ because isContainerInGoodState() treats PAUSED/PAUSING as occupied. That inflated quota_mem_mb_usage flowed through the cubemaster heartbeat into the node's QuotaMemUsage, so memFilter kept rejecting new sandboxes even though the capacity was physically free. The net effect: pausing idle sandboxes did not let new ones be created.

Add an opt-in, node-local dial `host.quota.paused_resource_release_ratio` (in [0,1], default 0, so existing guaranteed-resume behaviour is unchanged) that controls how much of a paused/pausing sandbox's CPU/memory quota is released back to the scheduler vs kept reserved as resume headroom, applied symmetrically to CPU and memory:

- 0.0 (default) releases nothing: paused sandboxes keep their full quota and resume is guaranteed. Identical to the legacy behaviour (zero-value safe).
- 1.0 releases everything: maximum density, resume is purely best-effort.
- 0 < r < 1 releases r and reserves (1-r) as headroom. Because the reserved quota still shows up in QuotaCpuUsage/QuotaMemUsage, a pause-heavy node is naturally deprioritised by the cpu/mem quota scoring factors, so the scheduler stops piling new sandboxes onto nodes that already hold many paused ones.

When the ratio is > 0:

- aggregateAllocated: paused/pausing sandboxes count only (1-ratio) of their CPU/memory quota and are not counted as running, which drops the node's reported usage and lets the scheduler place new sandboxes into the freed capacity. Disk still counts (the pause snapshot occupies storage) and MvmNum still counts them (the object lives on).
- UpdateWithResume: resume becomes best-effort. A local, real-time admission check rejects the resume when the node can no longer fit the released fraction of the sandbox, preventing host memory overcommit / OOM instead of silently overcommitting.

Propagate the rejection cleanly to clients. Cubelet returns the capacity rejection as Conflict (130409) rather than TaskResumeFailed, carrying a descriptive ret_msg. On the CubeAPI side, parse_response turns any non-zero ret_code into an error before the response envelope is inspected, so the pause/resume/connect paths remap the business codes in map_update_cubemaster_err: 130409 -> HTTP 409 (forwarding the backend ret_msg verbatim, e.g. "resume rejected by paused_resource_release_ratio policy: need X > quota Y") and 130404 -> HTTP 404. Resume rejection is an expected, retriable state, so 409 is the right class instead of a misleading
500. The WebUI now surfaces pause/resume/kill lifecycle failures (previously silent) on the sandbox list and detail pages, formatting the 409 capacity rejection with the reported quota numbers. SDKs need no changes: they read the HTTP status and message and can distinguish a capacity conflict from a backend error.

This targets high-density, mostly-idle agent fleets (e.g. thousands of digital-employee agents): idle sandboxes can be paused to free scheduling capacity and resumed later when capacity is available, maximising utilisation. The scheduling and resume-admission logic are both node-local (resume does not traverse the scheduler), so cubemaster needs no changes.

The accounting and admission logic are extracted into pure functions (aggregateSandboxResources, clampRatio, resumeQuotaRejection) covered by unit tests for the zero/one/partial ratios, the pausing transient, quota boundaries, ratio clamping (including non-finite inputs), and the policy-disabled no-op.

Signed-off-by: xiaojunxiang <xiaojunxiang@kingsoft.com>