### PR TITLE
fix(cube_egress_ca): seed CA bundle for distroless/scratch rootfs

### DIFF
--- a/CubeMaster/pkg/service/sandbox/types/types.go
+++ b/CubeMaster/pkg/service/sandbox/types/types.go
@@ -517,7 +517,9 @@ type CreateTemplateFromImageReq struct {
 	// three-state wire encoding so the CLI can ship a "default true"
 	// without ambiguating it with an explicit --with-cube-ca=false:
 	//   nil   → server-side default (true, see resolveWithCubeCA)
-	//   true  → bake; hard-error on missing CA file or distroless image
+	//   true  → bake; hard-error only on a missing host CA file.
+	//           Distroless / scratch images (no trust store of their
+	//           own) are seeded with a fresh bundle, not rejected.
 	//   false → skip the bake entirely
 	// See design/cube-egress-ca-bake.md.
 	WithCubeCA *bool `json:"with_cube_ca,omitempty"`

--- a/CubeMaster/pkg/templatecenter/cube_egress_ca/cube_egress_ca.go
+++ b/CubeMaster/pkg/templatecenter/cube_egress_ca/cube_egress_ca.go
@@ -26,6 +26,18 @@
 // Mozilla's public CA list; replacing it would break trust for every
 // public HTTPS endpoint a workload talks to. PEM bundles are designed
 // to be concatenated.
+//
+// Distroless / scratch seeding: an image that ships NEITHER a ca-bundle
+// file NOR any anchor directory (e.g. gcr.io/distroless/static, FROM
+// scratch) has no trust store to append to. Rather than fail the build,
+// we *seed* the canonical bundle path (seedBundlePath) from scratch with
+// just the CubeEgress root. This is safe and sufficient precisely
+// because CubeEgress is the egress MITM: it re-signs every outbound TLS
+// connection with this root, so the workload only needs to trust this
+// one CA — it does not need the public Mozilla set (egress to the wider
+// internet is brokered by CubeEgress, not made directly). Seeding only
+// kicks in when nothing else exists and the CA is not already present,
+// so it never clobbers an image's own roots.
 package cube_egress_ca
 
 import (
@@ -69,6 +81,13 @@ type Result struct {
 	// no-op). Surfaced via the cubemastercli template info command for
 	// triage; not load-bearing for any decision.
 	SkippedReasons []string
+
+	// Seeded is true iff the bake created a fresh ca-bundle from scratch
+	// at seedBundlePath because the image carried no trust store of its
+	// own (distroless / scratch). When Seeded is true, Baked is also
+	// true. Recorded for audit so operators can tell "appended to the
+	// image's bundle" apart from "we had to fabricate one".
+	Seeded bool
 }
 
 // AnchorFileName is the basename used for the dropped anchor copy,
@@ -101,6 +120,16 @@ var anchorDirs = []string{
 	"etc/ca-certificates/trust-source", // Arch
 }
 
+// seedBundlePath is the bundle file we *create* from scratch when an
+// image has no trust store of its own (distroless / scratch). It is the
+// Debian/Ubuntu canonical path, which is also Go's first-choice probe
+// location (crypto/x509) and the value distroless images point
+// SSL_CERT_FILE at — so seeding here is picked up by the widest set of
+// runtimes. It is intentionally identical to bundleFiles[0]: the append
+// pass runs first and, on a distroless image, records it "missing"; the
+// seed pass then creates it.
+const seedBundlePath = "etc/ssl/certs/ca-certificates.crt"
+
 // Bake runs against rootfsDir, applying caPEM to every bundle/anchor
 // location it finds. Returns the structured Result plus an error iff
 // the bake encountered a *hard* failure: i.e. either some target had a
@@ -109,6 +138,11 @@ var anchorDirs = []string{
 // or the input PEM is itself invalid. Targets that simply don't exist
 // in this image are NOT errors — they're recorded in
 // Result.SkippedReasons.
+//
+// Distroless / scratch images that ship no bundle and no anchor dir are
+// not skipped: Bake seeds seedBundlePath with the CA (Result.Seeded set)
+// so the trust root still lands. See the package doc for why this is
+// safe under the CubeEgress MITM model.
 //
 // Concurrency: not safe for parallel callers writing to the same
 // rootfsDir. The artifact-build pipeline serializes per-rootfs builds
@@ -130,6 +164,10 @@ func Bake(rootfsDir string, caPEM []byte) (Result, error) {
 	canonical := pem.EncodeToMemory(caBlock)
 
 	res := Result{Fingerprint: fingerprint}
+	// caPresent tracks whether the CA already lives in some bundle/anchor
+	// (idempotent no-op). It gates the distroless seed so a re-bake of an
+	// already-seeded image doesn't fabricate a second copy.
+	caPresent := false
 
 	for _, rel := range bundleFiles {
 		full := filepath.Join(rootfsDir, rel)
@@ -140,6 +178,9 @@ func Bake(rootfsDir string, caPEM []byte) (Result, error) {
 		if written {
 			res.TargetsWritten++
 			res.Baked = true
+		}
+		if reason == "present" {
+			caPresent = true
 		}
 		if reason != "" {
 			res.SkippedReasons = append(res.SkippedReasons, rel+": "+reason)
@@ -156,8 +197,33 @@ func Bake(rootfsDir string, caPEM []byte) (Result, error) {
 			res.TargetsWritten++
 			res.Baked = true
 		}
+		if reason == "present" {
+			caPresent = true
+		}
 		if reason != "" {
 			res.SkippedReasons = append(res.SkippedReasons, rel+": "+reason)
+		}
+	}
+
+	// Distroless / scratch fallback: the image had no trust store to
+	// append to and the CA isn't already present anywhere, so seed the
+	// canonical bundle from scratch. Safe under the CubeEgress MITM model
+	// (see package doc) and never clobbers an image's own roots because
+	// it only runs when nothing else matched.
+	if !res.Baked && !caPresent {
+		full := filepath.Join(rootfsDir, seedBundlePath)
+		written, reason, err := seedBundle(full, canonical)
+		if err != nil {
+			return res, fmt.Errorf("cube_egress_ca: seed %s: %w", seedBundlePath, err)
+		}
+		if written {
+			res.TargetsWritten++
+			res.Baked = true
+			res.Seeded = true
+			res.SkippedReasons = append(res.SkippedReasons,
+				seedBundlePath+": seeded (image shipped no trust store)")
+		} else if reason != "" {
+			res.SkippedReasons = append(res.SkippedReasons, seedBundlePath+": "+reason)
 		}
 	}
 
@@ -268,6 +334,41 @@ func dropAnchor(dir string, canonical []byte) (bool, string, error) {
 		return false, "present", nil
 	}
 	if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return false, "", err
+	}
+	tmp := full + ".cube-egress-tmp"
+	if err := os.WriteFile(tmp, canonical, 0o644); err != nil {
+		return false, "", err
+	}
+	if err := os.Rename(tmp, full); err != nil {
+		_ = os.Remove(tmp)
+		return false, "", err
+	}
+	return true, "", nil
+}
+
+// seedBundle creates a fresh ca-bundle at `full` containing only the
+// canonical CA, for distroless / scratch images that ship no trust
+// store of their own. It mkdir -p's the parent directory first and
+// writes atomically (temp + rename) for the same crash-safety reason as
+// appendBundle.
+//
+// Callers only reach this when no existing bundle/anchor matched, so the
+// file normally does not exist. We still guard the rare "already there"
+// case (identical content) to keep redo paths a no-op.
+//
+//	written=true,  reason=""        bundle was created
+//	written=false, reason="present" identical bundle already exists
+//	written=false, err!=nil         mkdir / write attempt failed
+func seedBundle(full string, canonical []byte) (bool, string, error) {
+	if existing, err := os.ReadFile(full); err == nil { // #nosec G304 — fixed path from a closed list
+		if bytes.Equal(existing, canonical) {
+			return false, "present", nil
+		}
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return false, "", err
+	}
+	if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
 		return false, "", err
 	}
 	tmp := full + ".cube-egress-tmp"

--- a/CubeMaster/pkg/templatecenter/cube_egress_ca/cube_egress_ca.go
+++ b/CubeMaster/pkg/templatecenter/cube_egress_ca/cube_egress_ca.go
@@ -55,15 +55,16 @@ import (
 // Result describes the outcome of a bake. Callers persist these onto
 // the RootfsArtifact row for audit / debug.
 type Result struct {
-	// Baked is true iff at least one bundle or anchor write succeeded.
-	// A baked=false result with no error is not a failure on its own
-	// (e.g. distroless image with no bundles to update); the caller
-	// decides whether that's acceptable based on the "required" flag.
+	// Baked is true iff at least one bundle or anchor write (or seed)
+	// succeeded this pass. A baked=false result with no error means
+	// every target was already up-to-date (idempotent no-op); the caller
+	// decides whether that's acceptable based on context.
 	Baked bool
 
-	// TargetsWritten counts the bundle and anchor locations that
-	// received the CA, including no-op idempotent skips (counted as
-	// "already there"). The exact number is informational; downstream
+	// TargetsWritten counts the bundle and anchor locations that were
+	// actually written to this pass (new append, new anchor, or fresh
+	// seed). Idempotent skips ("already there") are NOT counted because
+	// no write occurred. The exact number is informational; downstream
 	// alarms should care about Baked + the err path, not this number.
 	TargetsWritten int
 
@@ -85,8 +86,9 @@ type Result struct {
 	// Seeded is true iff the bake created a fresh ca-bundle from scratch
 	// at seedBundlePath because the image carried no trust store of its
 	// own (distroless / scratch). When Seeded is true, Baked is also
-	// true. Recorded for audit so operators can tell "appended to the
-	// image's bundle" apart from "we had to fabricate one".
+	// true. Surfaced in the bake log line for diagnostics; not persisted
+	// separately to the DB because Baked + TargetsWritten + image
+	// metadata are sufficient to infer how the trust root landed.
 	Seeded bool
 }
 

--- a/CubeMaster/pkg/templatecenter/cube_egress_ca/cube_egress_ca_test.go
+++ b/CubeMaster/pkg/templatecenter/cube_egress_ca/cube_egress_ca_test.go
@@ -205,10 +205,10 @@ func TestBakeMultiFamily(t *testing.T) {
 	}
 }
 
-// Distroless / scratch-style image: nothing for the bake to touch.
-// This is NOT an error — the design says it's a soft skip; the caller
-// upstream decides whether to treat it as fatal via the
-// cube_egress_ca_required flag.
+// Distroless / scratch-style image: nothing for the bake to append to.
+// Instead of failing, the bake SEEDS the canonical bundle from scratch
+// with the CubeEgress root (safe under the egress-MITM model), so the
+// trust root still lands.
 func TestBakeDistroless(t *testing.T) {
 	caPEM, _ := makeCA(t, "cube-egress-root")
 	root := t.TempDir() // empty rootfs
@@ -217,21 +217,36 @@ func TestBakeDistroless(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Bake err=%v", err)
 	}
-	if res.Baked {
-		t.Fatalf("Baked=true on empty rootfs; want false (no targets exist)")
+	if !res.Baked {
+		t.Fatal("Baked=false on empty rootfs; want true (seeded canonical bundle)")
 	}
-	if res.TargetsWritten != 0 {
-		t.Fatalf("TargetsWritten=%d, want 0", res.TargetsWritten)
+	if !res.Seeded {
+		t.Fatal("Seeded=false; want true (image had no trust store)")
 	}
-	if len(res.SkippedReasons) == 0 {
-		t.Fatal("expected SkippedReasons populated for triage")
+	if res.TargetsWritten != 1 {
+		t.Fatalf("TargetsWritten=%d, want 1 (seeded bundle)", res.TargetsWritten)
 	}
-	// Fingerprint is filled even on an empty bake — the CA itself was
-	// valid, just nothing to write to. This matters because the reuse
-	// cache needs a stable fingerprint regardless of whether anything
-	// landed on disk.
+	// The seeded bundle exists at the canonical path and is exactly our CA.
+	seeded := mustReadFile(t, filepath.Join(root, "etc/ssl/certs/ca-certificates.crt"))
+	if seeded != string(caPEM) {
+		t.Fatalf("seeded bundle content mismatch:\ngot=%q\nwant=%q", seeded, caPEM)
+	}
 	if res.Fingerprint == "" {
-		t.Fatal("Fingerprint empty on no-op bake; reuse cache would lose CA-rotation invalidation")
+		t.Fatal("Fingerprint empty on seeded bake; reuse cache would lose CA-rotation invalidation")
+	}
+
+	// Re-bake must be idempotent: the seeded bundle now contains the CA,
+	// so the second pass writes nothing and does not seed again.
+	res2, err := Bake(root, caPEM)
+	if err != nil {
+		t.Fatalf("second bake err=%v", err)
+	}
+	if res2.Baked || res2.Seeded || res2.TargetsWritten != 0 {
+		t.Fatalf("re-bake of seeded rootfs not idempotent: res=%+v", res2)
+	}
+	seededAgain := mustReadFile(t, filepath.Join(root, "etc/ssl/certs/ca-certificates.crt"))
+	if seededAgain != string(caPEM) {
+		t.Fatal("seeded bundle mutated on idempotent re-bake")
 	}
 }
 

--- a/CubeMaster/pkg/templatecenter/cube_egress_ca_bake.go
+++ b/CubeMaster/pkg/templatecenter/cube_egress_ca_bake.go
@@ -87,11 +87,13 @@ func loadCubeEgressCAFromPath(ctx context.Context, withCubeCA bool, caPath strin
 // with_cube_ca=false), this is a no-op and returns a zero Result.
 //
 // When pemBytes is non-empty, the caller has explicitly asked for the
-// CA to land in the rootfs, so we hard-error if the bake produces zero
-// writes. Distroless / scratch images that have neither a ca-bundle
-// nor any anchor dir fail the build under with_cube_ca=true; that's
-// the contract — the user asked for trust to be installed, the image
-// can't accept it, the request is unsatisfiable.
+// CA to land in the rootfs. Distroless / scratch images that have
+// neither a ca-bundle nor any anchor dir no longer fail: Bake seeds a
+// canonical bundle so the trust root still lands (res.Seeded=true) —
+// safe under the CubeEgress MITM model. The hard-error below therefore
+// only trips on a genuinely degenerate result (no write AND nothing
+// already present AND no seed), which in practice means the rootfs was
+// unwritable in a way Bake didn't already surface as an error.
 func applyCubeEgressCAToRootfs(ctx context.Context, rootfsDir string, pemBytes []byte, fingerprint string) (cube_egress_ca.Result, error) {
 	if len(pemBytes) == 0 {
 		return cube_egress_ca.Result{Fingerprint: fingerprint}, nil
@@ -102,12 +104,12 @@ func applyCubeEgressCAToRootfs(ctx context.Context, rootfsDir string, pemBytes [
 	}
 	if !res.Baked {
 		return res, fmt.Errorf(
-			"with_cube_ca=true but the image rootfs has no ca-bundle file and no anchor directory; "+
-				"distroless / scratch-style images cannot host the trust root. reasons=%v",
+			"with_cube_ca=true but the cube_egress CA could not be installed into the image rootfs; "+
+				"no trust store was written or seeded. reasons=%v",
 			res.SkippedReasons)
 	}
 	CubeLog.WithContext(ctx).Infof(
-		"cube_egress CA baked into rootfs: targets_written=%d fingerprint=%s",
-		res.TargetsWritten, res.Fingerprint)
+		"cube_egress CA baked into rootfs: targets_written=%d seeded=%t fingerprint=%s",
+		res.TargetsWritten, res.Seeded, res.Fingerprint)
 	return res, nil
 }

--- a/CubeMaster/pkg/templatecenter/cube_egress_ca_bake_test.go
+++ b/CubeMaster/pkg/templatecenter/cube_egress_ca_bake_test.go
@@ -137,17 +137,22 @@ func TestApplyCubeEgressCAToRootfsNoopWhenPemEmpty(t *testing.T) {
 	}
 }
 
-func TestApplyCubeEgressCAToRootfsHardErrorOnDistroless(t *testing.T) {
+func TestApplyCubeEgressCAToRootfsSeedsDistroless(t *testing.T) {
 	// Empty rootfs (no bundle, no anchor dir) → distroless equivalent.
-	// withCubeCA=true semantics: caller asked for trust to be installed,
-	// image can't host it → hard error.
+	// withCubeCA=true semantics: caller asked for trust to be installed;
+	// the bake seeds a canonical bundle so the root still lands instead
+	// of failing the build.
+	root := t.TempDir()
 	caPEM := makeCAForBakeTest(t)
-	_, err := applyCubeEgressCAToRootfs(context.Background(), t.TempDir(), caPEM, "")
-	if err == nil {
-		t.Fatal("expected hard error on distroless rootfs when CA was loaded")
+	res, err := applyCubeEgressCAToRootfs(context.Background(), root, caPEM, "")
+	if err != nil {
+		t.Fatalf("expected distroless rootfs to be seeded, got err=%v", err)
 	}
-	if !strings.Contains(err.Error(), "no ca-bundle") {
-		t.Fatalf("err=%v should mention 'no ca-bundle'", err)
+	if !res.Baked || !res.Seeded {
+		t.Fatalf("res=%+v, want Baked=true Seeded=true", res)
+	}
+	if _, err := os.Stat(filepath.Join(root, "etc/ssl/certs/ca-certificates.crt")); err != nil {
+		t.Fatalf("seeded bundle missing: %v", err)
 	}
 }
 


### PR DESCRIPTION
Bake previously hard-failed on images that ship neither a ca-bundle file nor any anchor directory (distroless / scratch), because it only appended to existing trust stores and wrote zero targets.

Now Bake seeds a fresh bundle at etc/ssl/certs/ca-certificates.crt with the CubeEgress root when nothing else matches and the CA is not already present (Result.Seeded). This is safe under the egress-MITM model: workloads only need to trust the CubeEgress root, not the public Mozilla set. Seeding is gated so re-bakes stay idempotent and never clobber an image's own roots.

Relax the caller hard-error accordingly, log seeded=%t, and update the WithCubeCA doc. Tests updated to assert seeding + idempotency.

Assisted-by: CodeBuddy
Signed-off-by: Feng Jin<ronyjin@tencent.com>