### PR TITLE
feat(sdk/go): align Go SDK surface with the Python SDK

### DIFF
--- a/sdk/go/README.md
+++ b/sdk/go/README.md
@@ -1,6 +1,6 @@
 # cubesandbox Go SDK
 
-Go SDK for [CubeSandbox](https://github.com/TencentCloud/CubeSandbox). It matches the current Python SDK surface: sandbox lifecycle, code execution, commands, and file reads only.
+Go SDK for [CubeSandbox](https://github.com/TencentCloud/CubeSandbox). It matches the current Python SDK surface: sandbox lifecycle, code execution, commands, file read/write, snapshots, clone, rollback, and L7 egress policy.
 
 ## Install
 
@@ -75,9 +75,49 @@ fmt.Println(result.Stdout, result.Stderr, result.ExitCode)
 
 ```go
 content, err := sb.Files().Read(ctx, "/etc/hosts")
+
+err = sb.Files().Write(ctx, "/tmp/hello.txt", []byte("hi"))
 ```
 
 `Files.Read` downloads content through envd's `GET /files?path=...` file API.
+`Files.Write` uploads through `POST /files`, falling back to a multipart body when the envd version rejects a raw octet-stream.
+
+## Snapshots, Clone, Rollback
+
+```go
+snap, err := sb.CreateSnapshot(ctx, "") // POST /sandboxes/:id/snapshots
+
+snaps, nextToken, err := client.ListSnapshots(ctx, cubesandbox.ListSnapshotsOptions{
+	SandboxID: sb.SandboxID,
+	Limit:     100,
+})
+
+err = client.DeleteSnapshot(ctx, snap.SnapshotID) // DELETE /templates/:id
+
+_, err = sb.Rollback(ctx, snap.SnapshotID) // POST /sandboxes/:id/rollback
+
+clones, err := sb.Clone(ctx, cubesandbox.CloneOptions{N: 3, Concurrency: 3})
+```
+
+`Clone` snapshots the sandbox, creates `N` sandboxes from it (capped by `Concurrency`), then deletes the ephemeral snapshot. If any create fails, all successful siblings are killed and the first error is returned. `Rollback` restarts the sandbox process and drops pooled data-plane connections so the next call reconnects.
+
+## L7 Egress Policy
+
+```go
+sb, err := client.Create(ctx, cubesandbox.CreateOptions{
+	Network: cubesandbox.NetworkOptions{
+		Rules: []cubesandbox.Rule{{
+			Name:  "github-api",
+			Match: cubesandbox.Match{Host: "api.github.com", Scheme: "https"},
+			Action: cubesandbox.Action{
+				Allow:  true,
+				Audit:  "metadata",
+				Inject: []cubesandbox.Inject{{Header: "Authorization", Secret: "token", Format: "Bearer ${SECRET}"}},
+			},
+		}},
+	},
+})
+```
 
 ## Pause And Connect
 

--- a/sdk/go/aligned_test.go
+++ b/sdk/go/aligned_test.go
@@ -1,0 +1,246 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package cubesandbox
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"mime"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestCreateSerializesPolicyAndPublicTraffic(t *testing.T) {
+	var got map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewDecoder(r.Body).Decode(&got)
+		w.WriteHeader(http.StatusCreated)
+		fmt.Fprint(w, sandboxJSON(testSandboxID, "tpl-env"))
+	}))
+	defer server.Close()
+
+	allowPublic := false
+	client := NewClient(Config{APIURL: server.URL, TemplateID: "tpl-env", Timeout: 300 * time.Second})
+	_, err := client.Create(context.Background(), CreateOptions{
+		Network: NetworkOptions{
+			AllowPublicTraffic: &allowPublic,
+			AllowOut:           []string{"api.github.com"},
+			Rules: []Rule{{
+				Name:   "gh",
+				Match:  Match{Host: "api.github.com", Scheme: "https"},
+				Action: Action{Allow: true, Audit: "metadata", Inject: []Inject{{Header: "Authorization", Secret: "s", Format: "Bearer ${SECRET}"}}},
+			}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	network, ok := got["network"].(map[string]any)
+	if !ok {
+		t.Fatalf("network=%#v", got["network"])
+	}
+	if network["allowPublicTraffic"] != false {
+		t.Fatalf("allowPublicTraffic=%#v, want false", network["allowPublicTraffic"])
+	}
+	rules, ok := network["rules"].([]any)
+	if !ok || len(rules) != 1 {
+		t.Fatalf("rules=%#v", network["rules"])
+	}
+	rule := rules[0].(map[string]any)
+	assertString(t, rule, "name", "gh")
+	assertMapString(t, rule["match"], "host", "api.github.com")
+	action := rule["action"].(map[string]any)
+	if action["allow"] != true {
+		t.Fatalf("action.allow=%#v", action["allow"])
+	}
+}
+
+func TestCreateRejectsAllowOutDomainWithoutDenyAll(t *testing.T) {
+	called := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusCreated)
+		fmt.Fprint(w, sandboxJSON(testSandboxID, "tpl-env"))
+	}))
+	defer server.Close()
+
+	client := NewClient(Config{APIURL: server.URL, TemplateID: "tpl-env"})
+	_, err := client.Create(context.Background(), CreateOptions{
+		Network: NetworkOptions{AllowOut: []string{"example.com"}},
+	})
+	if err == nil || !strings.Contains(err.Error(), "deny_out") {
+		t.Fatalf("err=%v, want allow_out domain guard", err)
+	}
+	if called {
+		t.Fatal("request should not be sent when validation fails")
+	}
+}
+
+func TestInjectRender(t *testing.T) {
+	if got := (Inject{Secret: "tok"}).Render(); got != "tok" {
+		t.Fatalf("default render=%q", got)
+	}
+	if got := (Inject{Secret: "tok", Format: "Bearer ${SECRET}"}).Render(); got != "Bearer tok" {
+		t.Fatalf("formatted render=%q", got)
+	}
+}
+
+func TestSnapshotLifecycle(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/sandboxes/"+testSandboxID+"/snapshots":
+			var body map[string]any
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			fmt.Fprint(w, `{"snapshotID":"snap-1","names":["n1"]}`)
+		case r.Method == http.MethodGet && r.URL.Path == "/snapshots":
+			if r.URL.Query().Get("sandboxID") != testSandboxID || r.URL.Query().Get("limit") != "50" {
+				t.Fatalf("query=%s", r.URL.RawQuery)
+			}
+			w.Header().Set("x-next-token", "tok-2")
+			fmt.Fprint(w, `[{"snapshotID":"snap-1","names":["n1"]}]`)
+		case r.Method == http.MethodDelete && r.URL.Path == "/templates/snap-1":
+			w.WriteHeader(http.StatusNoContent)
+		case r.Method == http.MethodPost && r.URL.Path == "/sandboxes/"+testSandboxID+"/rollback":
+			var body map[string]string
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			if body["snapshotID"] != "snap-1" {
+				t.Fatalf("rollback body=%#v", body)
+			}
+			fmt.Fprint(w, `{"status":"success"}`)
+		default:
+			t.Fatalf("unexpected %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	client := NewClient(Config{APIURL: server.URL, Timeout: 300 * time.Second})
+	sb := &Sandbox{client: client, SandboxID: testSandboxID}
+	ctx := context.Background()
+
+	snap, err := sb.CreateSnapshot(ctx, "")
+	if err != nil || snap.SnapshotID != "snap-1" || len(snap.Names) != 1 {
+		t.Fatalf("CreateSnapshot=%#v err=%v", snap, err)
+	}
+
+	items, next, err := client.ListSnapshots(ctx, ListSnapshotsOptions{SandboxID: testSandboxID, Limit: 50})
+	if err != nil || len(items) != 1 || next != "tok-2" {
+		t.Fatalf("ListSnapshots items=%#v next=%q err=%v", items, next, err)
+	}
+
+	if err := client.DeleteSnapshot(ctx, "snap-1"); err != nil {
+		t.Fatalf("DeleteSnapshot: %v", err)
+	}
+	if err := client.DeleteSnapshot(ctx, ""); err == nil {
+		t.Fatal("DeleteSnapshot without id returned nil error")
+	}
+
+	result, err := sb.Rollback(ctx, "snap-1")
+	if err != nil || result["status"] != "success" {
+		t.Fatalf("Rollback=%#v err=%v", result, err)
+	}
+}
+
+func TestCloneKillsSiblingsOnFailure(t *testing.T) {
+	var created, killed int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/snapshots"):
+			fmt.Fprint(w, `{"snapshotID":"snap-1"}`)
+		case r.Method == http.MethodPost && r.URL.Path == "/sandboxes":
+			created++
+			if created == 2 { // fail the second clone
+				http.Error(w, `{"message":"boom"}`, http.StatusInternalServerError)
+				return
+			}
+			w.WriteHeader(http.StatusCreated)
+			fmt.Fprint(w, sandboxJSON(fmt.Sprintf("clone-%d", created), "snap-1"))
+		case r.Method == http.MethodDelete && strings.HasPrefix(r.URL.Path, "/sandboxes/"):
+			killed++
+			w.WriteHeader(http.StatusNoContent)
+		case r.Method == http.MethodDelete && r.URL.Path == "/templates/snap-1":
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			t.Fatalf("unexpected %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	client := NewClient(Config{APIURL: server.URL, Timeout: 300 * time.Second})
+	sb := &Sandbox{client: client, SandboxID: testSandboxID}
+	if _, err := sb.Clone(context.Background(), CloneOptions{N: 2}); err == nil {
+		t.Fatal("Clone with a failing create returned nil error")
+	}
+	if killed != 1 {
+		t.Fatalf("killed=%d, want 1 surviving sibling cleaned up", killed)
+	}
+}
+
+func TestFilesWriteOctetStreamThenMultipartFallback(t *testing.T) {
+	var contentTypes []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/files" {
+			t.Fatalf("request=%s %s", r.Method, r.URL.Path)
+		}
+		ct := r.Header.Get("Content-Type")
+		contentTypes = append(contentTypes, ct)
+		_, _ = io.Copy(io.Discard, r.Body)
+		if strings.HasPrefix(ct, "application/octet-stream") {
+			http.Error(w, "use multipart", http.StatusBadRequest) // force fallback
+			return
+		}
+		if !strings.HasPrefix(ct, "multipart/form-data") {
+			t.Fatalf("unexpected content-type %q", ct)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	host, port := serverHostPort(t, server.URL)
+	client := NewClient(Config{ProxyNodeIP: host, ProxyPortHTTP: port, SandboxDomain: "cube.test", RequestTimeout: time.Second})
+	sb := &Sandbox{client: client, SandboxID: "sb-files", EnvdAccessToken: "tok"}
+
+	if err := sb.Files().Write(context.Background(), "/tmp/x.txt", []byte("hi")); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	if len(contentTypes) != 2 {
+		t.Fatalf("attempts=%d, want 2 (octet-stream then multipart)", len(contentTypes))
+	}
+	if _, _, err := mime.ParseMediaType(contentTypes[1]); err != nil {
+		t.Fatalf("multipart content-type=%q: %v", contentTypes[1], err)
+	}
+}
+
+func TestCommandsRunSendsUserAuthHeader(t *testing.T) {
+	var auth string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		auth = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", connectContentType)
+		w.Write(connectEnvelope(0, `{"event":{"end":{"exitCode":0,"exited":true}}}`))
+		w.Write(connectEnvelope(connectEndStreamFlag, `{}`))
+	}))
+	defer server.Close()
+
+	host, port := serverHostPort(t, server.URL)
+	client := NewClient(Config{ProxyNodeIP: host, ProxyPortHTTP: port, SandboxDomain: "cube.test", RequestTimeout: time.Second})
+	sb := &Sandbox{client: client, SandboxID: "sb-proc"}
+
+	if _, err := sb.Commands().Run(context.Background(), "id", CommandOptions{User: "app"}); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if auth != basicAuthUser("app") {
+		t.Fatalf("Authorization=%q, want %q", auth, basicAuthUser("app"))
+	}
+	// Empty user defaults to root.
+	if basicAuthUser("") != basicAuthUser("root") {
+		t.Fatal("empty user should default to root")
+	}
+}

--- a/sdk/go/client.go
+++ b/sdk/go/client.go
@@ -138,12 +138,26 @@ func (c *Client) createPayload(opts CreateOptions) (map[string]any, error) {
 		payload["allowInternetAccess"] = false
 	}
 
+	// Allowing specific domains is only enforceable when all other egress is
+	// denied (public traffic off, or 0.0.0.0/0 in denyOut).
+	defaultDenyAll := (opts.AllowInternetAccess != nil && !*opts.AllowInternetAccess) ||
+		(opts.Network.AllowPublicTraffic != nil && !*opts.Network.AllowPublicTraffic)
+	if err := validateAllowOutDomainsRequireDenyAll(opts.Network.AllowOut, opts.Network.DenyOut, defaultDenyAll); err != nil {
+		return nil, err
+	}
+
 	network := map[string]any{}
+	if opts.Network.AllowPublicTraffic != nil {
+		network["allowPublicTraffic"] = *opts.Network.AllowPublicTraffic
+	}
 	if len(opts.Network.AllowOut) > 0 {
 		network["allowOut"] = opts.Network.AllowOut
 	}
 	if len(opts.Network.DenyOut) > 0 {
 		network["denyOut"] = opts.Network.DenyOut
+	}
+	if len(opts.Network.Rules) > 0 {
+		network["rules"] = opts.Network.Rules
 	}
 	if len(network) > 0 {
 		payload["network"] = network

--- a/sdk/go/envd.go
+++ b/sdk/go/envd.go
@@ -11,6 +11,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"mime/multipart"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -24,6 +25,7 @@ const (
 	connectEndStreamFlag   = byte(0x02)
 	connectCompressedFlag  = byte(0x01)
 	maxConnectEnvelopeSize = 64 * 1024 * 1024
+	defaultEnvdUser        = "root"
 )
 
 type processStartRequest struct {
@@ -105,6 +107,7 @@ func (s *Sandbox) startProcess(ctx context.Context, payload processStartRequest,
 	}
 	req.Header.Set("Content-Type", connectContentType)
 	req.Header.Set("Connect-Protocol-Version", connectProtocolVersion)
+	req.Header.Set("Authorization", basicAuthUser(opts.User))
 	setConnectTimeout(req, opts.Timeout)
 
 	resp, err := s.client.dataHTTP.Do(req)
@@ -156,6 +159,68 @@ func (s *Sandbox) readFile(ctx context.Context, path string) (string, error) {
 	return string(raw), nil
 }
 
+// writeFile uploads data through envd's POST /files API. It first tries a raw
+// octet-stream body and, if the envd version rejects that, retries as a
+// multipart upload — mirroring the Python SDK's fallback.
+func (s *Sandbox) writeFile(ctx context.Context, path string, data []byte) error {
+	if err := s.ensureClient(); err != nil {
+		return err
+	}
+	query := url.Values{"path": []string{path}}
+
+	resp, err := s.doEnvdUpload(ctx, query, bytes.NewReader(data), "application/octet-stream")
+	if err != nil {
+		return err
+	}
+	resp.Body.Close()
+	if resp.StatusCode < http.StatusBadRequest {
+		return nil
+	}
+
+	multipartBody, contentType, err := multipartFileBody(path, data)
+	if err != nil {
+		return err
+	}
+	resp, err = s.doEnvdUpload(ctx, query, multipartBody, contentType)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= http.StatusBadRequest {
+		message := readErrorMessage(resp)
+		if message == "" {
+			message = fmt.Sprintf("HTTP %d", resp.StatusCode)
+		}
+		return fmt.Errorf("failed to write %s: %s", path, message)
+	}
+	return nil
+}
+
+func (s *Sandbox) doEnvdUpload(ctx context.Context, query url.Values, body io.Reader, contentType string) (*http.Response, error) {
+	req, err := s.newEnvdRequest(ctx, http.MethodPost, "/files", query, body)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", contentType)
+	return s.client.dataHTTP.Do(req)
+}
+
+func multipartFileBody(path string, data []byte) (io.Reader, string, error) {
+	var buf bytes.Buffer
+	writer := multipart.NewWriter(&buf)
+	part, err := writer.CreateFormFile("file", path)
+	if err != nil {
+		return nil, "", err
+	}
+	if _, err := part.Write(data); err != nil {
+		return nil, "", err
+	}
+	if err := writer.Close(); err != nil {
+		return nil, "", err
+	}
+	return &buf, writer.FormDataContentType(), nil
+}
+
 func (s *Sandbox) newEnvdRequest(ctx context.Context, method, path string, query url.Values, body io.Reader) (*http.Request, error) {
 	target := url.URL{
 		Scheme:   s.client.config.ProxyScheme,
@@ -179,6 +244,15 @@ func setConnectTimeout(req *http.Request, timeout time.Duration) {
 		return
 	}
 	req.Header.Set("Connect-Timeout-Ms", strconv.FormatInt(timeout.Milliseconds(), 10))
+}
+
+// basicAuthUser builds the envd "Basic <user>:" auth header. An empty user
+// defaults to root to match the Python SDK.
+func basicAuthUser(user string) string {
+	if user == "" {
+		user = defaultEnvdUser
+	}
+	return "Basic " + base64.StdEncoding.EncodeToString([]byte(user+":"))
 }
 
 func parseProcessStartStream(r io.Reader) (*processStartResult, error) {

--- a/sdk/go/files.go
+++ b/sdk/go/files.go
@@ -10,10 +10,15 @@ import (
 
 type Files struct {
 	reader fileReader
+	writer fileWriter
 }
 
 type fileReader interface {
 	readFile(context.Context, string) (string, error)
+}
+
+type fileWriter interface {
+	writeFile(context.Context, string, []byte) error
 }
 
 func (f *Files) Read(ctx context.Context, path string) (string, error) {
@@ -21,4 +26,12 @@ func (f *Files) Read(ctx context.Context, path string) (string, error) {
 		return "", fmt.Errorf("files is not attached to a sandbox")
 	}
 	return f.reader.readFile(ctx, path)
+}
+
+// Write uploads data to path through envd's HTTP file API.
+func (f *Files) Write(ctx context.Context, path string, data []byte) error {
+	if f == nil || f.writer == nil {
+		return fmt.Errorf("files is not attached to a sandbox")
+	}
+	return f.writer.writeFile(ctx, path, data)
 }

--- a/sdk/go/models.go
+++ b/sdk/go/models.go
@@ -43,8 +43,13 @@ type VolumeMount struct {
 }
 
 type NetworkOptions struct {
-	AllowOut []string
-	DenyOut  []string
+	// AllowPublicTraffic gates default public egress; nil leaves it to the
+	// server default. AllowOut/DenyOut are L3/L4 CIDRs or hostnames; Rules are
+	// L7 host/path/SNI matches with audit and credential injection.
+	AllowPublicTraffic *bool
+	AllowOut           []string
+	DenyOut            []string
+	Rules              []Rule
 }
 
 type CreateOptions struct {
@@ -78,6 +83,9 @@ type CommandOptions struct {
 	Timeout time.Duration
 	Envs    map[string]string
 	Cwd     string
+	// User authenticates the envd process call (Basic auth). Empty defaults to
+	// "root" to match the Python SDK and avoid old-envd "no user specified".
+	User string
 }
 
 type CommandResult struct {

--- a/sdk/go/policy.go
+++ b/sdk/go/policy.go
@@ -1,0 +1,145 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package cubesandbox
+
+import (
+	"net"
+	"strings"
+)
+
+// L7 egress policy types — host/path/SNI matching, audit, credential
+// injection. They are pure data holders; matching happens server-side.
+// The JSON tags emit the camelCase shape that nests under network.rules,
+// so json.Marshal alone produces the same wire format as the Python SDK.
+
+// Match holds rule match conditions. All fields are optional; an empty Match
+// matches any request. Fields are AND-ed; Method values are OR-ed;
+// sni/host/scheme are compared case-insensitively server-side.
+type Match struct {
+	SNI    string   `json:"sni,omitempty"`
+	Host   string   `json:"host,omitempty"`
+	Method []string `json:"method,omitempty"`
+	Path   string   `json:"path,omitempty"`
+	Scheme string   `json:"scheme,omitempty"`
+}
+
+// Inject injects a credential header on an allowed HTTPS request whose
+// SNI/Host matches (server-enforced). Format defaults to "${SECRET}".
+type Inject struct {
+	Header string `json:"header"`
+	Secret string `json:"secret"`
+	Format string `json:"format,omitempty"`
+}
+
+// Render returns the final injected header value (preview helper).
+func (i Inject) Render() string {
+	format := i.Format
+	if format == "" {
+		format = "${SECRET}"
+	}
+	return strings.ReplaceAll(format, "${SECRET}", i.Secret)
+}
+
+// Action is a rule action. Allow passes the request through (optionally
+// injecting credentials); !Allow rejects it with HTTP 403. Audit defaults to
+// "metadata" server-side when empty.
+type Action struct {
+	Allow  bool     `json:"allow"`
+	Inject []Inject `json:"inject,omitempty"`
+	Audit  string   `json:"audit,omitempty"`
+}
+
+// Rule is one L7 egress rule. Name is a human-readable audit label.
+type Rule struct {
+	Name   string `json:"name"`
+	Match  Match  `json:"match"`
+	Action Action `json:"action"`
+}
+
+const (
+	denyAllIPv4CIDR               = "0.0.0.0/0"
+	allowOutDomainRequiresDenyAll = "When specifying allowed domains in allow_out, you must disable public " +
+		"outbound traffic or include '0.0.0.0/0' in deny_out to block all other traffic."
+)
+
+// validateAllowOutDomainsRequireDenyAll mirrors the Python guard: allowing
+// specific domains is meaningful only when all other egress is denied, either
+// by disabling public traffic (defaultDenyAll) or by listing 0.0.0.0/0 in
+// denyOut. Returns nil when allowOut carries no domain target.
+func validateAllowOutDomainsRequireDenyAll(allowOut, denyOut []string, defaultDenyAll bool) error {
+	hasDomain := false
+	for _, target := range allowOut {
+		if isDomainAllowOutTarget(target) {
+			hasDomain = true
+			break
+		}
+	}
+	if !hasDomain || defaultDenyAll {
+		return nil
+	}
+	for _, target := range denyOut {
+		if strings.TrimSpace(target) == denyAllIPv4CIDR {
+			return nil
+		}
+	}
+	return &APIError{StatusCode: 400, Message: allowOutDomainRequiresDenyAll, Kind: apiErrorKindAPI}
+}
+
+// isDomainAllowOutTarget reports whether target is a DNS name (vs. an IP or
+// CIDR). "*." wildcards are accepted; bare IPs and dotted-decimal-like values
+// are not domains.
+func isDomainAllowOutTarget(target string) bool {
+	target = strings.TrimSpace(target)
+	if target == "" || strings.Contains(target, "/") {
+		return false
+	}
+	if net.ParseIP(target) != nil {
+		return false
+	}
+	domain := strings.ToLower(strings.TrimRight(target, "."))
+	if isDottedDecimalLike(domain) {
+		return false
+	}
+	if strings.HasPrefix(domain, "*.") {
+		domain = domain[2:]
+	} else if strings.Contains(domain, "*") {
+		return false
+	}
+	return isValidDNSDomainName(domain)
+}
+
+func isDottedDecimalLike(target string) bool {
+	parts := strings.Split(strings.TrimRight(target, "."), ".")
+	if len(parts) != 4 {
+		return false
+	}
+	for _, part := range parts {
+		if part == "" {
+			return false
+		}
+		for _, ch := range part {
+			if ch < '0' || ch > '9' {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+func isValidDNSDomainName(domain string) bool {
+	if domain == "" || len(domain) >= 255 {
+		return false
+	}
+	for _, label := range strings.Split(domain, ".") {
+		if label == "" || len(label) > 63 || label[0] == '-' || label[len(label)-1] == '-' {
+			return false
+		}
+		for _, ch := range label {
+			if !(ch >= 'a' && ch <= 'z' || ch >= '0' && ch <= '9' || ch == '-') {
+				return false
+			}
+		}
+	}
+	return true
+}

--- a/sdk/go/sandbox.go
+++ b/sdk/go/sandbox.go
@@ -179,7 +179,7 @@ func (s *Sandbox) Commands() *Commands {
 }
 
 func (s *Sandbox) Files() *Files {
-	return &Files{reader: s}
+	return &Files{reader: s, writer: s}
 }
 
 func (s *Sandbox) ensureClient() error {

--- a/sdk/go/snapshot.go
+++ b/sdk/go/snapshot.go
@@ -1,0 +1,193 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package cubesandbox
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"sync"
+)
+
+// SnapshotInfo is the metadata returned by snapshot APIs. Snapshots are stored
+// as templates, so SnapshotID doubles as a template ID for create/delete.
+type SnapshotInfo struct {
+	SnapshotID string   `json:"snapshotID"`
+	Names      []string `json:"names"`
+}
+
+// ListSnapshotsOptions filters the snapshot listing. Zero values are omitted.
+type ListSnapshotsOptions struct {
+	SandboxID string
+	Limit     int
+	NextToken string
+}
+
+// CloneOptions controls Sandbox.Clone. N defaults to 1; Concurrency defaults to
+// 1 (sequential). Concurrency is capped at N.
+type CloneOptions struct {
+	N           int
+	Concurrency int
+}
+
+// CreateSnapshot captures the current sandbox state (POST
+// /sandboxes/:id/snapshots). The snapshot outlives the sandbox. An empty name
+// lets the server pick one; a known name attaches a new build to it.
+func (s *Sandbox) CreateSnapshot(ctx context.Context, name string) (*SnapshotInfo, error) {
+	if err := s.ensureClient(); err != nil {
+		return nil, err
+	}
+	var payload map[string]any
+	if name != "" {
+		payload = map[string]any{"name": name}
+	}
+	var info SnapshotInfo
+	path := "/sandboxes/" + url.PathEscape(s.SandboxID) + "/snapshots"
+	if err := s.client.doJSON(ctx, http.MethodPost, path, payload, &info, http.StatusOK, http.StatusCreated); err != nil {
+		return nil, err
+	}
+	return &info, nil
+}
+
+// ListSnapshots pages through snapshots (GET /snapshots). It returns the page
+// items plus the next-page token (empty when there are no more pages).
+func (c *Client) ListSnapshots(ctx context.Context, opts ListSnapshotsOptions) ([]SnapshotInfo, string, error) {
+	query := url.Values{}
+	if opts.SandboxID != "" {
+		query.Set("sandboxID", opts.SandboxID)
+	}
+	if opts.Limit > 0 {
+		query.Set("limit", strconv.Itoa(opts.Limit))
+	}
+	if opts.NextToken != "" {
+		query.Set("nextToken", opts.NextToken)
+	}
+	path := "/snapshots"
+	if encoded := query.Encode(); encoded != "" {
+		path += "?" + encoded
+	}
+
+	req, err := c.newRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, "", err
+	}
+	resp, err := c.controlHTTP.Do(req)
+	if err != nil {
+		return nil, "", err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, "", apiErrorFromResponse(resp)
+	}
+
+	var items []SnapshotInfo
+	if err := json.NewDecoder(resp.Body).Decode(&items); err != nil && !errors.Is(err, io.EOF) {
+		return nil, "", err
+	}
+	return items, resp.Header.Get("x-next-token"), nil
+}
+
+// DeleteSnapshot permanently removes a snapshot (DELETE /templates/:id).
+// Deleting the originating sandbox does not cascade-delete its snapshots.
+func (c *Client) DeleteSnapshot(ctx context.Context, snapshotID string) error {
+	if snapshotID == "" {
+		return errors.New("snapshotID is required")
+	}
+	path := "/templates/" + url.PathEscape(snapshotID)
+	return c.doJSON(ctx, http.MethodDelete, path, nil, nil, http.StatusOK, http.StatusNoContent)
+}
+
+// Rollback reverts the sandbox to a snapshot (POST /sandboxes/:id/rollback).
+// The sandbox process restarts, invalidating pooled data-plane connections, so
+// idle connections are dropped and rebuilt lazily on the next call.
+func (s *Sandbox) Rollback(ctx context.Context, snapshotID string) (map[string]any, error) {
+	if err := s.ensureClient(); err != nil {
+		return nil, err
+	}
+	var result map[string]any
+	path := "/sandboxes/" + url.PathEscape(s.SandboxID) + "/rollback"
+	if err := s.client.doJSON(ctx, http.MethodPost, path, map[string]any{"snapshotID": snapshotID}, &result, http.StatusOK); err != nil {
+		return nil, err
+	}
+	s.resetConnections()
+	return result, nil
+}
+
+// Clone snapshots this sandbox and spins up opts.N fresh sandboxes from it,
+// then deletes the ephemeral snapshot (best-effort). On any create failure all
+// successful siblings are killed and the first error is returned, so a partial
+// fan-out never leaks sandboxes.
+func (s *Sandbox) Clone(ctx context.Context, opts CloneOptions) ([]*Sandbox, error) {
+	if err := s.ensureClient(); err != nil {
+		return nil, err
+	}
+	n := opts.N
+	if n <= 0 {
+		n = 1
+	}
+	concurrency := opts.Concurrency
+	if concurrency <= 0 {
+		concurrency = 1
+	}
+
+	snapshot, err := s.CreateSnapshot(ctx, "")
+	if err != nil {
+		return nil, err
+	}
+	// Cleanup must run even if ctx is cancelled, matching the Python SDK's
+	// unconditional best-effort delete.
+	defer func() { _ = s.client.DeleteSnapshot(context.WithoutCancel(ctx), snapshot.SnapshotID) }()
+
+	createOne := func() (*Sandbox, error) {
+		return s.client.Create(ctx, CreateOptions{TemplateID: snapshot.SnapshotID})
+	}
+
+	var (
+		mu        sync.Mutex
+		clones    []*Sandbox
+		firstErr  error
+		wg        sync.WaitGroup
+		semaphore = make(chan struct{}, min(n, concurrency))
+	)
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			semaphore <- struct{}{}
+			defer func() { <-semaphore }()
+
+			clone, err := createOne()
+			mu.Lock()
+			defer mu.Unlock()
+			if err != nil {
+				if firstErr == nil {
+					firstErr = err
+				}
+				return
+			}
+			clones = append(clones, clone)
+		}()
+	}
+	wg.Wait()
+
+	if firstErr != nil {
+		for _, clone := range clones {
+			_ = clone.Kill(context.WithoutCancel(ctx))
+		}
+		return nil, firstErr
+	}
+	return clones, nil
+}
+
+// resetConnections drops pooled data-plane connections so the next request
+// reopens a fresh one. Used after rollback restarts the sandbox process.
+func (s *Sandbox) resetConnections() {
+	if s.client != nil && s.client.dataHTTP != nil {
+		s.client.dataHTTP.CloseIdleConnections()
+	}
+}


### PR DESCRIPTION
Add the Python-only surface that the Go SDK was missing, using stdlib only:

- Snapshots/clone/rollback (snapshot.go): SnapshotInfo, Sandbox.CreateSnapshot, Client.ListSnapshots (with x-next-token paging), Client.DeleteSnapshot, Sandbox.Rollback (drops pooled data-plane conns), and Sandbox.Clone with bounded concurrency and all-or-nothing sibling cleanup on failure.
- L7 egress policy (policy.go): Rule/Match/Action/Inject types whose JSON tags emit the same wire shape as the Python to_wire(), plus the allow_out-domain requires-deny-all guard. NetworkOptions gains Rules and AllowPublicTraffic.
- Files.Write via envd POST /files with octet-stream then multipart fallback.
- CommandOptions.User -> envd Basic auth header (defaults to root).

Update README to document the expanded surface and add focused unit tests.

Assisted-by: CodeBuddy
Signed-off-by: Feng Jin (ronyjin@tencent.com)