### PR TITLE
docs: document host mount permission fixes

### DIFF
--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -158,7 +158,8 @@ export default withMermaid(defineConfig({
                   link: '/guide/troubleshooting/',
                   items: [
                     { text: 'Deployment', link: '/guide/troubleshooting/deployment' },
-                    { text: 'Templates', link: '/guide/troubleshooting/templates' }
+                    { text: 'Templates', link: '/guide/troubleshooting/templates' },
+                    { text: 'Host Mount Permissions', link: '/guide/troubleshooting/host-mount-permissions' }
                   ]
                 },
                 {
@@ -263,7 +264,8 @@ export default withMermaid(defineConfig({
                   link: '/zh/guide/troubleshooting/',
                   items: [
                     { text: '部署相关', link: '/zh/guide/troubleshooting/deployment' },
-                    { text: '模板相关', link: '/zh/guide/troubleshooting/templates' }
+                    { text: '模板相关', link: '/zh/guide/troubleshooting/templates' },
+                    { text: 'Host Mount 权限', link: '/zh/guide/troubleshooting/host-mount-permissions' }
                   ]
                 },
                 {

--- a/docs/guide/troubleshooting/host-mount-permissions.md
+++ b/docs/guide/troubleshooting/host-mount-permissions.md
@@ -1,0 +1,168 @@
+---
+title: Host Mounts Fail with Permission Denied
+author: barry166
+date: 2026-06-14
+tags:
+  - runtime
+  - host-mount
+  - permissions
+lang: en-US
+---
+
+# Host Mounts Fail with Permission Denied
+
+## Symptom
+
+A sandbox can see a host-mounted directory, but writing to it fails with `Permission denied`:
+
+```text
+/bin/bash: line 1: /mnt/rw/1.txt: Permission denied
+```
+
+This often appears after creating a sandbox with a writable host mount:
+
+```python
+import json
+from cubesandbox import Sandbox
+
+mounts = json.dumps([
+    {
+        "hostPath": "/tmp/rw",
+        "mountPath": "/mnt/rw",
+        "readOnly": False,
+    },
+])
+
+with Sandbox.create(metadata={"host-mount": mounts}) as sandbox:
+    sandbox.commands.run("echo hello > /mnt/rw/1.txt")
+```
+
+## Environment
+
+- Cube Sandbox version: v0.4.0 or later
+- Deployment mode: one-click, bare-metal, or multi-node deployment
+- Host OS / kernel: Linux host running Cubelet
+- Related components: Cubelet, host mount metadata, sandbox command user
+
+## Root Cause
+
+`metadata["host-mount"]` maps an existing path on the Cubelet host into the sandbox. It does not copy files, create a workspace snapshot, or rewrite ownership.
+
+For a read-write mount, Linux permissions still apply:
+
+- `hostPath` must already exist on the Cubelet node that runs the sandbox.
+- The mounted directory keeps its host-side owner, group, and mode bits.
+- Commands inside the sandbox run as the sandbox user by default.
+- If the host directory is owned by a different UID/GID, the sandbox user may be able to read the path but not write to it.
+
+For example, if `/tmp/rw` is owned by host user `uid=1002`, but the sandbox command runs as `uid=1000`, a write to `/mnt/rw` can fail even when `readOnly` is `False`.
+
+This is expected Linux mount behavior. The `readOnly` flag controls whether Cube mounts the path read-only or read-write; it does not grant write permission to users that the host filesystem would reject.
+
+## Resolution
+
+First, confirm the host path exists on the Cubelet node:
+
+```bash
+sudo test -d /tmp/rw
+sudo stat -c 'owner=%u:%g mode=%a path=%n' /tmp/rw
+```
+
+Then choose one of the following patterns.
+
+### Option 1: Use a read-only mount for source workspaces
+
+For agent workloads that only need to inspect code, mount the workspace read-only:
+
+```python
+import json
+from cubesandbox import Sandbox
+
+mounts = json.dumps([
+    {
+        "hostPath": "/srv/workspaces/my-repo",
+        "mountPath": "/workspace",
+        "readOnly": True,
+    },
+])
+
+with Sandbox.create(metadata={"host-mount": mounts}) as sandbox:
+    result = sandbox.commands.run("ls /workspace")
+    print(result.stdout)
+```
+
+This is the safest default for sharing a host repository with a sandbox.
+
+### Option 2: Align ownership for read-write mounts
+
+If the sandbox must write back to the host directory, make the host directory writable by the sandbox command user.
+
+One common setup is to create a dedicated host directory owned by the sandbox UID/GID:
+
+```bash
+sudo mkdir -p /tmp/rw
+sudo chown 1000:1000 /tmp/rw
+sudo chmod 0755 /tmp/rw
+```
+
+Then mount it read-write:
+
+```python
+mounts = json.dumps([
+    {
+        "hostPath": "/tmp/rw",
+        "mountPath": "/mnt/rw",
+        "readOnly": False,
+    },
+])
+```
+
+If your sandbox image uses a different user, check it from inside the sandbox:
+
+```python
+with Sandbox.create(metadata={"host-mount": mounts}) as sandbox:
+    result = sandbox.commands.run("id && stat -c '%u:%g %a %n' /mnt/rw")
+    print(result.stdout)
+```
+
+Use the reported UID/GID when preparing the host directory.
+
+### Option 3: Use ACLs when the host owner must stay unchanged
+
+If you cannot change the directory owner, grant write access to the sandbox UID with POSIX ACLs:
+
+```bash
+sudo setfacl -m u:1000:rwx /tmp/rw
+sudo setfacl -d -m u:1000:rwx /tmp/rw
+```
+
+This keeps the existing host owner while allowing the sandbox user to write new files.
+
+### Option 4: Run the write as root only when appropriate
+
+For administrative operations, you can run the command as `root` if your SDK path and policy allow it:
+
+```python
+with Sandbox.create(metadata={"host-mount": mounts}) as sandbox:
+    sandbox.commands.run("echo hello > /mnt/rw/1.txt", user="root")
+```
+
+Use this only for trusted workloads. It can create root-owned files on the host mount, which may surprise later host-side tools.
+
+## Workspace Mapping Notes
+
+Host mounts are node-local. In a multi-node cluster, the `hostPath` must exist on the Cubelet node where the sandbox is scheduled.
+
+If you want the sandbox to work with the same repository as your local development machine, use one of these approaches:
+
+- Sync the repository to a known directory on each Cubelet node, then mount that directory.
+- Place the repository on shared storage that is mounted at the same path on every Cubelet node.
+- Build the repository into a template image if the sandbox only needs a fixed snapshot.
+- Copy files into the sandbox at runtime if the workspace is small and does not need host-side write-back.
+
+Do not rely on `host-mount` alone to transfer files from your laptop to a remote Cubelet node.
+
+## References
+
+- Related issue: [#239](https://github.com/TencentCloud/CubeSandbox/issues/239)
+- Example: [`examples/host-mount`](https://github.com/TencentCloud/CubeSandbox/tree/master/examples/host-mount)

--- a/docs/guide/troubleshooting/index.md
+++ b/docs/guide/troubleshooting/index.md
@@ -56,4 +56,5 @@ lang: en-US
 | Title | Author | Date | Tags |
 | --- | --- | --- | --- |
 | [Template Creation Times Out When the Sandbox CIDR Overlaps the LAN](./local-network-cidr-conflict.md) | luzhixing12345 | 2026-05-20 | deployment, networking, one-click |
+| [Host Mounts Fail with Permission Denied](./host-mount-permissions.md) | barry166 | 2026-06-14 | runtime, host-mount, permissions |
 | _Add your article here_ | - | - | - |

--- a/docs/zh/guide/troubleshooting/host-mount-permissions.md
+++ b/docs/zh/guide/troubleshooting/host-mount-permissions.md
@@ -1,0 +1,168 @@
+---
+title: Host Mount 写入时报 Permission Denied
+author: barry166
+date: 2026-06-14
+tags:
+  - runtime
+  - host-mount
+  - permissions
+lang: zh-CN
+---
+
+# Host Mount 写入时报 Permission Denied
+
+## 问题现象
+
+沙箱里可以看到 host mount 目录，但写入时报 `Permission denied`：
+
+```text
+/bin/bash: line 1: /mnt/rw/1.txt: Permission denied
+```
+
+常见复现方式是创建了一个可写 host mount：
+
+```python
+import json
+from cubesandbox import Sandbox
+
+mounts = json.dumps([
+    {
+        "hostPath": "/tmp/rw",
+        "mountPath": "/mnt/rw",
+        "readOnly": False,
+    },
+])
+
+with Sandbox.create(metadata={"host-mount": mounts}) as sandbox:
+    sandbox.commands.run("echo hello > /mnt/rw/1.txt")
+```
+
+## 环境信息
+
+- Cube Sandbox 版本：v0.4.0 或更新版本
+- 部署模式：one-click、裸金属或多机集群部署
+- 宿主机 OS / 内核：运行 Cubelet 的 Linux 宿主机
+- 相关组件：Cubelet、host mount metadata、沙箱命令执行用户
+
+## 根因分析
+
+`metadata["host-mount"]` 会把 Cubelet 宿主机上的已有路径映射到沙箱内。它不会复制文件、创建工作区快照，也不会自动改写文件 owner。
+
+对于读写挂载，Linux 文件权限仍然生效：
+
+- `hostPath` 必须已经存在于运行该沙箱的 Cubelet 节点上。
+- 挂载目录会保留宿主机侧的 owner、group 和 mode bits。
+- 沙箱里的命令默认以沙箱用户身份运行。
+- 如果宿主机目录属于另一个 UID/GID，沙箱用户可能能读到目录，但不能写入。
+
+例如 `/tmp/rw` 在宿主机上属于 `uid=1002`，但沙箱命令以 `uid=1000` 运行，即使 `readOnly` 是 `False`，写 `/mnt/rw` 也可能失败。
+
+这是预期的 Linux 挂载行为。`readOnly` 只控制 Cube 用只读还是读写方式挂载目录；它不会绕过宿主机文件系统权限。
+
+## 解决方案
+
+先确认 host path 确实存在于 Cubelet 节点上：
+
+```bash
+sudo test -d /tmp/rw
+sudo stat -c 'owner=%u:%g mode=%a path=%n' /tmp/rw
+```
+
+然后根据场景选择一种处理方式。
+
+### 方案 1：代码工作区优先使用只读挂载
+
+如果 agent 只需要读取和分析代码，建议把工作区只读挂载进沙箱：
+
+```python
+import json
+from cubesandbox import Sandbox
+
+mounts = json.dumps([
+    {
+        "hostPath": "/srv/workspaces/my-repo",
+        "mountPath": "/workspace",
+        "readOnly": True,
+    },
+])
+
+with Sandbox.create(metadata={"host-mount": mounts}) as sandbox:
+    result = sandbox.commands.run("ls /workspace")
+    print(result.stdout)
+```
+
+这是把宿主机仓库共享给沙箱时最安全的默认方式。
+
+### 方案 2：读写挂载时对齐目录 owner
+
+如果沙箱必须把结果写回宿主机目录，需要让该目录对沙箱命令用户可写。
+
+常见做法是准备一个由沙箱 UID/GID 拥有的专用宿主机目录：
+
+```bash
+sudo mkdir -p /tmp/rw
+sudo chown 1000:1000 /tmp/rw
+sudo chmod 0755 /tmp/rw
+```
+
+然后按读写方式挂载：
+
+```python
+mounts = json.dumps([
+    {
+        "hostPath": "/tmp/rw",
+        "mountPath": "/mnt/rw",
+        "readOnly": False,
+    },
+])
+```
+
+如果你的沙箱镜像使用了不同用户，可以在沙箱内检查：
+
+```python
+with Sandbox.create(metadata={"host-mount": mounts}) as sandbox:
+    result = sandbox.commands.run("id && stat -c '%u:%g %a %n' /mnt/rw")
+    print(result.stdout)
+```
+
+再用实际输出的 UID/GID 准备宿主机目录。
+
+### 方案 3：宿主机 owner 不能改时使用 ACL
+
+如果不能修改目录 owner，可以用 POSIX ACL 给沙箱 UID 授权：
+
+```bash
+sudo setfacl -m u:1000:rwx /tmp/rw
+sudo setfacl -d -m u:1000:rwx /tmp/rw
+```
+
+这样可以保留原有宿主机 owner，同时允许沙箱用户写入新文件。
+
+### 方案 4：仅在合适场景下用 root 写入
+
+对于管理类操作，如果 SDK 路径和安全策略允许，可以指定以 `root` 执行命令：
+
+```python
+with Sandbox.create(metadata={"host-mount": mounts}) as sandbox:
+    sandbox.commands.run("echo hello > /mnt/rw/1.txt", user="root")
+```
+
+只建议在可信 workload 中使用。它可能在 host mount 中创建 root-owned 文件，后续宿主机工具处理这些文件时可能会遇到权限差异。
+
+## 工作区映射注意事项
+
+Host mount 是节点本地能力。在多机集群中，`hostPath` 必须存在于实际调度运行该沙箱的 Cubelet 节点上。
+
+如果希望沙箱使用和本地开发机一致的仓库，可以选择：
+
+- 先把仓库同步到每个 Cubelet 节点上的固定目录，再挂载该目录。
+- 使用共享存储，并确保所有 Cubelet 节点上路径一致。
+- 如果沙箱只需要固定版本的代码快照，可以把仓库构建进 template image。
+- 如果工作区较小且不需要写回宿主机，可以在运行时把文件复制进沙箱。
+
+不要只依赖 `host-mount` 把本地笔记本上的文件传到远端 Cubelet 节点。
+
+## 参考
+
+- 相关 issue：[#239](https://github.com/TencentCloud/CubeSandbox/issues/239)
+- 示例：[`examples/host-mount`](https://github.com/TencentCloud/CubeSandbox/tree/master/examples/host-mount)

--- a/docs/zh/guide/troubleshooting/index.md
+++ b/docs/zh/guide/troubleshooting/index.md
@@ -56,4 +56,5 @@ lang: zh-CN
 | 标题 | 作者 | 日期 | 标签 |
 | --- | --- | --- | --- |
 | [沙箱网段和局域网冲突导致创建模板超时](./local-network-cidr-conflict.md) | luzhixing12345 | 2026-05-20 | deployment, networking, one-click |
+| [Host Mount 写入时报 Permission Denied](./host-mount-permissions.md) | barry166 | 2026-06-14 | runtime, host-mount, permissions |
 | _在这里补充你的文章_ | - | - | - |


### PR DESCRIPTION
## Summary

- add an English troubleshooting guide for host mount write failures caused by host-side UID/GID and mode mismatches
- add the matching Chinese troubleshooting guide with the same slug and frontmatter shape
- link the guide from the troubleshooting index and VitePress sidebars

## Context

Closes #239.

The guide clarifies that `metadata["host-mount"]` maps an existing path on the Cubelet node and does not copy files, create a workspace snapshot, or rewrite ownership. It also documents safe read-only workspace mounts, read-write ownership alignment, ACLs, and root-command tradeoffs.

## Testing

- `npm --prefix docs install --registry=https://registry.npmjs.org/ --fetch-retries=3 --fetch-timeout=600000`
- `npm --prefix docs run docs:build`
- `git diff --check`

## Notes

- The local npm default registry pointed at `npmmirror`, which timed out during verification, so the install command above used the official npm registry for this local build only.
