### PR TITLE
fix(deploy): add docker-compose version declaration to one-click templates

### DIFF
--- a/deploy/one-click/coredns/docker-compose.yaml.template
+++ b/deploy/one-click/coredns/docker-compose.yaml.template
@@ -1,3 +1,4 @@
+version: "3"
 services:
   coredns:
     image: cube-sandbox-image.tencentcloudcr.com/opensource/coredns/coredns:1.14.2

--- a/deploy/one-click/cubeproxy/docker-compose.yaml.template
+++ b/deploy/one-click/cubeproxy/docker-compose.yaml.template
@@ -1,3 +1,4 @@
+version: "3"
 services:
   cube-proxy:
     image: __CUBE_PROXY_IMAGE__

--- a/deploy/one-click/support/docker-compose.yaml.template
+++ b/deploy/one-click/support/docker-compose.yaml.template
@@ -1,3 +1,4 @@
+version: "3"
 services:
   mysql:
     image: __MYSQL_IMAGE__

--- a/deploy/one-click/webui/docker-compose.yaml.template
+++ b/deploy/one-click/webui/docker-compose.yaml.template
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (C) 2026 Tencent. All rights reserved.
 
+version: "3"
 services:
   webui:
     image: __WEB_UI_IMAGE__


### PR DESCRIPTION

Add version: "3" to all one-click docker-compose.yaml.template files (coredns, cubeproxy, support, webui) for explicit Compose file format specification.

Fixed docker containers start failed on Ubuntu20.04