### PR TITLE
fix(cube_egress_ca): suppress default x509v3 extensions to prevent duplicate extensions

### DIFF
--- a/CubeEgress/gen-ca.sh
+++ b/CubeEgress/gen-ca.sh
@@ -10,12 +10,26 @@ CRT_FILE="ca.crt"
 openssl ecparam -name "$CURVE" -genkey -noout -out "$KEY_FILE"
 chmod 600 "$KEY_FILE"
 
+# Minimal config to suppress the system openssl.cnf's default x509v3
+# extensions (specifically [v3_ca]'s basicConstraints + subjectKeyIdentifier).
+# Without this, OpenSSL 1.1.1 doubles them up with our -addext values and
+# produces a certificate that Go's crypto/x509 parser rejects (RFC 5280
+# prohibits duplicate extensions).
+cat > "${KEY_FILE}.cnf" <<'EOF'
+[req]
+distinguished_name = req_distinguished_name
+prompt = no
+[req_distinguished_name]
+EOF
+
 openssl req -x509 -new -key "$KEY_FILE" \
     -sha256 -days "$DAYS" \
+    -config "${KEY_FILE}.cnf" \
     -subj "$SUBJ" \
     -addext "basicConstraints=critical,CA:TRUE" \
     -addext "keyUsage=critical,keyCertSign,cRLSign" \
     -addext "subjectKeyIdentifier=hash" \
     -out "$CRT_FILE"
+rm -f "${KEY_FILE}.cnf"
 
 openssl x509 -in "$CRT_FILE" -noout -subject -issuer -dates

--- a/deploy/one-click/scripts/systemd/cube-egress-prepare.sh
+++ b/deploy/one-click/scripts/systemd/cube-egress-prepare.sh
@@ -114,10 +114,25 @@ else
   # cert-store inspection inside a sandbox.
   tmp_key="$(mktemp -p "${CA_DIR}" .ca.key.XXXXXX)"
   tmp_crt="$(mktemp -p "${CA_DIR}" .ca.crt.XXXXXX)"
-  trap 'rm -f "${tmp_key}" "${tmp_crt}"' EXIT
+  tmp_cnf="$(mktemp -p "${CA_DIR}" .ca.cnf.XXXXXX)"
+  trap 'rm -f "${tmp_key}" "${tmp_crt}" "${tmp_cnf}"' EXIT
+
+  # Minimal config to suppress the system openssl.cnf's default x509v3
+  # extensions (specifically [v3_ca]'s basicConstraints + subjectKeyIdentifier).
+  # Without this, OpenSSL 1.1.1 doubles them up with our -addext values and
+  # produces a certificate that Go's crypto/x509 parser rejects (RFC 5280
+  # prohibits duplicate extensions).
+  cat > "${tmp_cnf}" <<'EOF'
+[req]
+distinguished_name = req_distinguished_name
+prompt = no
+[req_distinguished_name]
+EOF
+
   openssl ecparam -name prime256v1 -genkey -noout -out "${tmp_key}"
   openssl req -x509 -new -key "${tmp_key}" \
     -sha256 -days 3650 \
+    -config "${tmp_cnf}" \
     -subj '/CN=CubeSandbox Egress MITM CA' \
     -addext 'basicConstraints=critical,CA:TRUE' \
     -addext 'keyUsage=critical,keyCertSign,cRLSign' \
@@ -125,7 +140,7 @@ else
     -out "${tmp_crt}"
   install -m 0644 -o root -g root "${tmp_crt}" "${CA_CERT}"
   install -m 0640 -o root -g "${WORKER_GID}" "${tmp_key}" "${CA_KEY}"
-  rm -f "${tmp_key}" "${tmp_crt}"
+  rm -f "${tmp_key}" "${tmp_crt}" "${tmp_cnf}"
   trap - EXIT
 fi
 


### PR DESCRIPTION

On Ubuntu 20.04 (OpenSSL 1.1.1f), the system openssl.cnf [v3_ca] section auto-adds basicConstraints and subjectKeyIdentifier when generating a self-signed CA certificate via "openssl req -x509". The explicit -addext flags in cube-egress-prepare.sh and gen-ca.sh then append the same extensions a second time, producing a certificate with duplicate x509v3 extensions that Go's crypto/x509 parser rejects per RFC 5280.

Fix: supply a minimal OpenSSL config file via -config that has no x509_extensions directive, suppressing system defaults so only the explicitly listed -addext extensions appear in the output certificate.

This only manifests on distributions whose default openssl.cnf includes x509_extensions=v3_ca with pre-populated basicConstraints and subjectKeyIdentifier (e.g. Ubuntu 20.04). OpenSSL 3.x-based distros are not affected.

Verified on both Ubuntu 20.04 (OpenSSL 1.1.1f) and OpenSSL 3.6.0: before fix, duplicate extensions on 1.1.1f; after fix, each extension appears exactly once on both platforms.