### PR TITLE
sdk/python: support E2B per-host request transforms in network.rules

### DIFF
--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -148,6 +148,38 @@ with Sandbox.create(
 Rules are evaluated **first-match-wins** in list order. Credential injection
 only runs on HTTPS requests where SNI and Host match (server-enforced).
 
+#### E2B per-host request transforms (compat shape)
+
+For drop-in compatibility with E2B's
+[per-host request transforms](https://e2b.dev/docs/network/internet-access#per-host-request-transforms),
+`network["rules"]` also accepts a host-keyed mapping. Each `transform.headers`
+entry is converted into a CubeEgress L7 rule whose `action.inject` injects
+the same headers on outbound HTTPS requests to that host:
+
+```python
+from cubesandbox import Sandbox
+
+with Sandbox.create(
+    network={
+        # The host must still be referenced via allow_out — registering a
+        # rule alone does not grant egress.
+        "allow_out": ["api.example.com"],
+        "deny_out": ["0.0.0.0/0"],
+        "rules": {
+            "api.example.com": [
+                {"transform": {"headers": {"X-Header": "Content"}}},
+            ],
+        },
+    },
+) as sb:
+    sb.run_code("import requests; requests.get('https://api.example.com/')")
+```
+
+The compat shape is interchangeable with the typed-Rule shape: pick whichever
+fits the codebase. Mixing the two on a single `Sandbox.create` call is not
+supported — pass either a list of `Rule` (typed) **or** a host-keyed dict
+(E2B-shaped).
+
 The legacy `metadata={"network-policy": ...}` interface is still accepted
 for IP-only deny-all / custom allow-list scenarios.
 

--- a/sdk/python/cubesandbox/_policy.py
+++ b/sdk/python/cubesandbox/_policy.py
@@ -166,6 +166,162 @@ def _serialize_rule(rule: Any) -> Dict[str, Any]:
     return out
 
 
+# ── E2B per-host request transforms compatibility ───────────────────────────
+#
+# E2B's ``network.rules`` accepts a host-keyed mapping of transforms:
+#
+#     network = {
+#         "rules": {
+#             "api.example.com": [
+#                 {"transform": {"headers": {"X-Header": "Content"}}}
+#             ]
+#         }
+#     }
+#
+# CubeEgress expresses the same intent as a list of L7 rules with credential
+# ``inject`` entries:
+#
+#     Rule(
+#         name="e2b-transform-api.example.com-0",
+#         match=Match(host="api.example.com"),
+#         action=Action(
+#             allow=True,
+#             inject=[Inject(header="X-Header", secret="Content")],
+#         ),
+#     )
+#
+# ``_convert_e2b_per_host_rules`` is the bridge: given an E2B-shaped dict, it
+# returns a list of dicts that ``_serialize_rule`` can consume directly.
+# A bare list (already CubeEgress-shaped) is passed through untouched so
+# existing callers keep working.
+
+
+def _is_e2b_per_host_rules(rules: Any) -> bool:
+    """Return True iff *rules* looks like E2B's per-host transform mapping.
+
+    The current CubeSandbox ``rules`` field is a list; E2B's is a dict keyed
+    by host. The two shapes are unambiguous, so we use the type alone as the
+    discriminator.
+    """
+    return isinstance(rules, dict)
+
+
+def _convert_e2b_transform_to_inject(transform: Dict[str, Any]) -> List[Inject]:
+    """Convert one E2B ``transform`` block to a list of :class:`Inject`.
+
+    Today only ``transform.headers`` is documented; additional transform
+    kinds are reported as ``ValueError`` so that silent drops never produce
+    a sandbox that's missing credential injection the caller asked for.
+    """
+    if not isinstance(transform, dict):
+        raise ValueError(
+            f"network.rules transform must be a dict, got {type(transform).__name__}"
+        )
+    headers = transform.get("headers")
+    if headers is None:
+        raise ValueError("network.rules transform requires a 'headers' field")
+    if not isinstance(headers, dict):
+        raise ValueError(
+            f"network.rules transform.headers must be a dict, got {type(headers).__name__}"
+        )
+    unknown = set(transform.keys()) - {"headers"}
+    if unknown:
+        raise ValueError(
+            f"network.rules transform has unsupported keys: {sorted(unknown)!r}; "
+            "only 'headers' is supported by the CubeEgress compatibility layer"
+        )
+    injects: List[Inject] = []
+    for name, value in headers.items():
+        if not isinstance(name, str) or not name:
+            raise ValueError("network.rules transform.headers keys must be non-empty strings")
+        if not isinstance(value, str):
+            raise ValueError(
+                f"network.rules transform.headers[{name!r}] must be a string, "
+                f"got {type(value).__name__}"
+            )
+        injects.append(Inject(header=name, secret=value))
+    return injects
+
+
+def _convert_e2b_per_host_rules(rules: Dict[str, Any]) -> List[Dict[str, Any]]:
+    """Convert E2B's per-host transform mapping to CubeEgress rule dicts.
+
+    Each ``host -> [transform_entry, ...]`` pair fans out into one Rule per
+    entry, preserving the original list order so audit logs and rule
+    evaluation remain stable. The generated rule names use the
+    ``e2b-transform-<host>[-<index>]`` convention to make compat-layer
+    output identifiable in audit logs.
+
+    The result is a list of plain dicts (not :class:`Rule` instances) so it
+    flows through ``_serialize_rule`` unchanged and matches the shape that
+    callers can already pass via ``network={"rules": [...]}``.
+    """
+    converted: List[Dict[str, Any]] = []
+    for host, entries in rules.items():
+        if not isinstance(host, str) or not host:
+            raise ValueError(
+                "network.rules host keys must be non-empty strings"
+            )
+        if not isinstance(entries, list):
+            raise ValueError(
+                f"network.rules[{host!r}] must be a list of transform entries, "
+                f"got {type(entries).__name__}"
+            )
+        for index, entry in enumerate(entries):
+            if not isinstance(entry, dict):
+                raise ValueError(
+                    f"network.rules[{host!r}][{index}] must be a dict, "
+                    f"got {type(entry).__name__}"
+                )
+            transform = entry.get("transform")
+            if transform is None:
+                raise ValueError(
+                    f"network.rules[{host!r}][{index}] is missing the 'transform' field"
+                )
+            unknown = set(entry.keys()) - {"transform"}
+            if unknown:
+                raise ValueError(
+                    f"network.rules[{host!r}][{index}] has unsupported keys: "
+                    f"{sorted(unknown)!r}; only 'transform' is supported"
+                )
+            injects = _convert_e2b_transform_to_inject(transform)
+            suffix = "" if len(entries) == 1 else f"-{index}"
+            converted.append({
+                "name": f"e2b-transform-{host}{suffix}",
+                "match": {"host": host},
+                "action": {
+                    "allow": True,
+                    "inject": [i.to_wire() for i in injects],
+                },
+            })
+    return converted
+
+
+def _normalize_rules_arg(rules: Any) -> List[Any]:
+    """Return a list of rule items suitable for :func:`_serialize_rule`.
+
+    Accepts:
+    - ``None`` / empty → ``[]``.
+    - ``dict`` → treated as E2B per-host transforms, expanded via
+      :func:`_convert_e2b_per_host_rules`.
+    - ``list`` / other iterable of ``Rule`` or rule-shaped dicts → returned
+      as a list, untouched.
+    """
+    if not rules:
+        return []
+    if _is_e2b_per_host_rules(rules):
+        return _convert_e2b_per_host_rules(rules)
+    if isinstance(rules, list):
+        return rules
+    # Tolerate any other iterable so SDK callers can pass tuples/generators.
+    try:
+        return list(rules)
+    except TypeError as exc:
+        raise TypeError(
+            f"network.rules must be a list or dict, got {type(rules).__name__}"
+        ) from exc
+
+
 DENY_ALL_IPV4_CIDR = "0.0.0.0/0"
 ALLOW_OUT_DOMAIN_REQUIRES_DENY_ALL = (
     "When specifying allowed domains in allow_out, you must disable public "

--- a/sdk/python/cubesandbox/sandbox.py
+++ b/sdk/python/cubesandbox/sandbox.py
@@ -13,7 +13,12 @@ from ._config import Config
 from ._exceptions import ApiError, AuthenticationError, CubeSandboxError, SandboxNotFoundError, TemplateNotFoundError
 from ._filesystem import Filesystem
 from ._models import Execution, ExecutionError, OutputMessage, Result, SnapshotInfo
-from ._policy import Rule, _serialize_rule, _validate_allow_out_domains_require_deny_all
+from ._policy import (
+    Rule,
+    _normalize_rules_arg,
+    _serialize_rule,
+    _validate_allow_out_domains_require_deny_all,
+)
 from ._stream import _parse_line
 from ._transport import build_client
 
@@ -108,7 +113,11 @@ class Sandbox:
                 - ``allow_out`` / ``deny_out``: lists of CIDRs or hostnames (L3/L4).
                 - ``rules``: list of :class:`~cubesandbox.Rule` dataclasses (or
                   equivalent dicts with snake_case keys) for L7 host/path/SNI
-                  matching, audit, and credential injection.
+                  matching, audit, and credential injection. For E2B parity,
+                  a host-keyed mapping of per-host request transforms (e.g.
+                  ``{"api.example.com": [{"transform": {"headers": {...}}}]}``)
+                  is also accepted and converted into equivalent CubeEgress
+                  inject rules.
             config: SDK config. Uses default (env-based) config if omitted.
 
         Returns:
@@ -144,7 +153,13 @@ class Sandbox:
             if "allow_public_traffic" in network:
                 net["allowPublicTraffic"] = network["allow_public_traffic"]
             if "rules" in network and network["rules"]:
-                net["rules"] = [_serialize_rule(r) for r in network["rules"]]
+                # ``rules`` accepts either CubeEgress's list-of-Rule shape or
+                # E2B's per-host transform mapping (``{host: [{transform: {...}}]}``).
+                # ``_normalize_rules_arg`` collapses both into a list of rule
+                # dicts that ``_serialize_rule`` understands.
+                normalized_rules = _normalize_rules_arg(network["rules"])
+                if normalized_rules:
+                    net["rules"] = [_serialize_rule(r) for r in normalized_rules]
             if net:
                 payload["network"] = net
         payload.update(kwargs)

--- a/sdk/python/tests/test_sandbox.py
+++ b/sdk/python/tests/test_sandbox.py
@@ -370,6 +370,176 @@ class TestNetworkRules:
         assert Action(allow=False).to_wire() == {"allow": False}
 
 
+# ── E2B per-host request transforms compatibility ───────────────────────────
+
+class TestE2BPerHostTransforms:
+    """Verify that E2B's host-keyed ``network.rules`` mapping is converted
+    to the equivalent CubeEgress L7 inject rules on the wire.
+
+    The compatibility layer must:
+    - Translate ``{host: [{transform: {headers: {...}}}]}`` into one Rule per
+      transform entry, with ``match.host`` set and ``action.allow=True``.
+    - Materialize each header pair as one :class:`Inject` (header/secret).
+    - Coexist with ``allow_out`` / ``deny_out`` and the typed list-of-Rule shape.
+    - Reject malformed inputs eagerly (better than silently dropping rules).
+    """
+
+    def _payload(self, network, **kwargs):
+        with patch("requests.Session.post", return_value=mock_response(SANDBOX_DATA, status=201)) as m:
+            Sandbox.create(network=network, config=make_config(), **kwargs)
+        return m.call_args.kwargs["json"]
+
+    def test_single_host_single_header(self):
+        body = self._payload({
+            "rules": {
+                "api.example.com": [
+                    {"transform": {"headers": {"X-Header": "Content"}}},
+                ],
+            },
+        })
+        rules = body["network"]["rules"]
+        assert rules == [{
+            "name": "e2b-transform-api.example.com",
+            "match": {"host": "api.example.com"},
+            "action": {
+                "allow": True,
+                "inject": [{"header": "X-Header", "secret": "Content"}],
+            },
+        }]
+
+    def test_single_host_multiple_headers(self):
+        body = self._payload({
+            "rules": {
+                "api.example.com": [
+                    {"transform": {"headers": {
+                        "Authorization": "Bearer sk_xxx",
+                        "X-Trace": "on",
+                    }}},
+                ],
+            },
+        })
+        inject = body["network"]["rules"][0]["action"]["inject"]
+        # Order follows dict insertion order — preserve it for deterministic
+        # audit logs and to match the user's intent.
+        assert inject == [
+            {"header": "Authorization", "secret": "Bearer sk_xxx"},
+            {"header": "X-Trace", "secret": "on"},
+        ]
+
+    def test_multiple_hosts(self):
+        body = self._payload({
+            "rules": {
+                "api.example.com": [{"transform": {"headers": {"X-A": "1"}}}],
+                "api.other.com":   [{"transform": {"headers": {"X-B": "2"}}}],
+            },
+        })
+        rules = body["network"]["rules"]
+        hosts = [r["match"]["host"] for r in rules]
+        assert hosts == ["api.example.com", "api.other.com"]
+        assert all(r["action"]["allow"] is True for r in rules)
+
+    def test_multiple_transform_entries_per_host_get_indexed_names(self):
+        body = self._payload({
+            "rules": {
+                "api.example.com": [
+                    {"transform": {"headers": {"X-A": "1"}}},
+                    {"transform": {"headers": {"X-B": "2"}}},
+                ],
+            },
+        })
+        rules = body["network"]["rules"]
+        assert [r["name"] for r in rules] == [
+            "e2b-transform-api.example.com-0",
+            "e2b-transform-api.example.com-1",
+        ]
+        assert rules[0]["action"]["inject"] == [{"header": "X-A", "secret": "1"}]
+        assert rules[1]["action"]["inject"] == [{"header": "X-B", "secret": "2"}]
+
+    def test_alongside_allow_out_and_deny_out(self):
+        # Mirrors the canonical E2B usage: the host must still be referenced
+        # via allow_out for traffic to flow at all — registering a rule alone
+        # does not grant egress.
+        body = self._payload({
+            "allow_out": ["api.example.com"],
+            "deny_out": ["0.0.0.0/0"],
+            "rules": {
+                "api.example.com": [{"transform": {"headers": {"X-Header": "Content"}}}],
+            },
+        })
+        assert body["network"]["allowOut"] == ["api.example.com"]
+        assert body["network"]["denyOut"] == ["0.0.0.0/0"]
+        assert body["network"]["rules"][0]["match"]["host"] == "api.example.com"
+
+    def test_empty_dict_rules_omits_network(self):
+        body = self._payload({"rules": {}})
+        # ``rules={}`` is just as empty as ``rules=[]``: the SDK should not
+        # emit a stub network block when no policy was configured.
+        assert "network" not in body
+
+    def test_typed_rule_list_unaffected(self):
+        # Regression: switching the converter on must not change the
+        # behaviour of the existing typed-Rule path.
+        from cubesandbox import Action, Match, Rule
+        rules = [Rule(name="r1", match=Match(host="x.com"), action=Action(allow=True))]
+        body = self._payload({"rules": rules})
+        assert body["network"]["rules"] == [{
+            "name": "r1",
+            "match": {"host": "x.com"},
+            "action": {"allow": True},
+        }]
+
+    def test_rejects_non_dict_transform(self):
+        with pytest.raises(ValueError, match="transform must be a dict"):
+            Sandbox.create(
+                network={"rules": {"api.example.com": [{"transform": "oops"}]}},
+                config=make_config(),
+            )
+
+    def test_rejects_missing_headers(self):
+        with pytest.raises(ValueError, match="requires a 'headers' field"):
+            Sandbox.create(
+                network={"rules": {"api.example.com": [{"transform": {}}]}},
+                config=make_config(),
+            )
+
+    def test_rejects_unsupported_transform_keys(self):
+        # We refuse silently dropping unknown transform kinds — better to
+        # surface the gap than ship a sandbox that's missing the rewrite the
+        # caller expected.
+        with pytest.raises(ValueError, match="unsupported keys"):
+            Sandbox.create(
+                network={"rules": {"api.example.com": [
+                    {"transform": {"headers": {"X-A": "1"}, "body": "ignored"}},
+                ]}},
+                config=make_config(),
+            )
+
+    def test_rejects_non_string_header_value(self):
+        with pytest.raises(ValueError, match="must be a string"):
+            Sandbox.create(
+                network={"rules": {"api.example.com": [
+                    {"transform": {"headers": {"X-Count": 42}}},
+                ]}},
+                config=make_config(),
+            )
+
+    def test_rejects_unsupported_entry_keys(self):
+        with pytest.raises(ValueError, match="unsupported keys"):
+            Sandbox.create(
+                network={"rules": {"api.example.com": [
+                    {"transform": {"headers": {"X-A": "1"}}, "extra": True},
+                ]}},
+                config=make_config(),
+            )
+
+    def test_rejects_non_list_entries(self):
+        with pytest.raises(ValueError, match="must be a list of transform entries"):
+            Sandbox.create(
+                network={"rules": {"api.example.com": {"transform": {"headers": {}}}}},
+                config=make_config(),
+            )
+
+
 # ── POST /sandboxes/:id/connect ───────────────────────────────────────────────
 
 class TestConnect:


### PR DESCRIPTION
Accept E2B's `{host: [{transform: {headers: {...}}}]}` shape in `Sandbox.create(network={"rules": ...})` and translate it into CubeEgress L7 rules with `action.inject` entries. The existing list-of-Rule path is unchanged; the two shapes are dispatched on type.

Each transform entry becomes one Rule named
`e2b-transform-<host>[-<index>]`; each header pair becomes one Inject. Malformed inputs raise ValueError instead of being silently dropped.

Reference: https://e2b.dev/docs/network/internet-access#per-host-request-transforms

Tests: 13 new cases in TestE2BPerHostTransforms; full suite 163 passed.