### PR TITLE
fix(CubeMaster): register sandbox preview route

### DIFF
--- a/CubeMaster/pkg/server/server.go
+++ b/CubeMaster/pkg/server/server.go
@@ -91,6 +91,7 @@ func (s *internalHttp) registerHandlers() {
 	cubeGroup.HandleFunc(cube.SandboxUpdateAction, cube.HttpHandler).Methods(http.MethodPost)
 	cubeGroup.HandleFunc(cube.SandboxCommitAction, cube.HttpHandler).Methods(http.MethodPost)
 	cubeGroup.HandleFunc(cube.SandboxRollbackAction, cube.HttpHandler).Methods(http.MethodPost)
+	cubeGroup.HandleFunc(cube.SandboxPreviewAction, cube.HttpHandler).Methods(http.MethodPost)
 	cubeGroup.HandleFunc(cube.SandboxAction+"/{sandbox_id}/rollback", cube.HttpHandler).Methods(http.MethodPost)
 	cubeGroup.HandleFunc(cube.SnapshotAction, cube.HttpHandler).Methods(http.MethodGet, http.MethodPost)
 	cubeGroup.HandleFunc(cube.SnapshotAction+"/{snapshot_id}", cube.HttpHandler).Methods(http.MethodGet, http.MethodDelete)


### PR DESCRIPTION
## Motivation

`cubemastercli tpl render` currently always returns HTTP 404.

The template preview implementation already exists, but the `/cube/sandbox/preview` endpoint is not registered in the CubeMaster HTTP mux. As a result, requests are rejected by the router before they can reach the existing `HttpHandler` dispatch logic.

Observed on a cluster:

```text
$ cubemastercli tpl render --template-id tpl-543e65c9ccb3456e8418f1e1 --json
2026/06/15 17:39:46 template render request err. status code is not 200, but 404. RequestId: ec57efa0-e098-4ce0-b67a-dbd3f3199e19
cubemastercli run fail: status code is not 200, but 404
```

## Root Cause

CubeMaster uses `gorilla/mux` for HTTP routing. For a CubeMaster endpoint to be reachable, two pieces are needed:

1. a mux route registration in `registerHandlers()`
2. a dispatch branch in `cube.HttpHandler`

For the sandbox preview endpoint, the dispatch path already exists, but the mux route registration is missing.

| Part                   | Location                                                               | Status  |
| ---------------------- | ---------------------------------------------------------------------- | ------- |
| Action constant        | `cube.go` — `SandboxPreviewAction = "/sandbox/preview"`                | Present |
| HTTP dispatch          | `cube.go` — `case r.URL.Path == actionURI(SandboxPreviewAction)`       | Present |
| Handler implementation | `sandbox_preview.go` — `handleSandboxPreviewAction` / `previewSandbox` | Present |
| Handler tests          | `sandbox_preview_test.go`                                              | Present |
| CLI command            | `template.go` — `cubemastercli tpl render`                             | Present |
| Documentation          | `docs/guide/template-inspection-and-preview.md`                        | Present |
| Mux registration       | `server.go` — `cubeGroup.HandleFunc(...)`                              | Missing |

Because the mux route is not registered, the request returns `404 page not found` before it reaches `cube.HttpHandler`.

## What This PR Changes

This PR registers the existing sandbox preview endpoint in `CubeMaster/pkg/server/server.go`:

```go
cubeGroup.HandleFunc(cube.SandboxPreviewAction, cube.HttpHandler).Methods(http.MethodPost)
```

After this change, `POST /cube/sandbox/preview` reaches the existing `cube.HttpHandler` dispatch and is handled by `handleSandboxPreviewAction`.

## Scope

This PR only registers the existing `SandboxPreviewAction` endpoint.

It does not change the preview request/response format, CLI behavior, or handler implementation.

I noticed that another action prefix, `CADownloadActionPrefix`, also has handler-side code without a matching mux registration. I intentionally left that endpoint unchanged in this PR because it has different security implications and should be reviewed separately.

## Testing

Existing handler tests:

```bash
cd CubeMaster
go test ./pkg/service/httpservice/cube/ -run Preview
```

Static check:

```bash
cd CubeMaster
go vet ./pkg/service/httpservice/cube/
```

Manual cluster verification after deploying the change:

```bash
cubemastercli tpl render --template-id <template-id> --json
```

Expected result: the command returns the existing three-layer preview output instead of HTTP 404:

```json
{
  "api_request": { ... },
  "merged_request": { ... },
  "cubelet_request": { ... }
}
```

## Documentation

No documentation update is needed.

The CLI command and the three-layer preview model are already documented:

* `docs/guide/template-inspection-and-preview.md`
* `docs/zh/guide/template-inspection-and-preview.md`

## Compatibility

This change is backward compatible.

It only makes an already implemented read-only preview endpoint reachable through the existing CubeMaster HTTP router. There are no wire format changes, no new configuration options, and no behavior changes to existing endpoints.
