### PR TITLE
fix(python-sdk): avoid double-encoding execution logs and errors

### DIFF
--- a/sdk/python/cubesandbox/_models.py
+++ b/sdk/python/cubesandbox/_models.py
@@ -13,8 +13,11 @@ class Logs:
     stdout: list[str] = field(default_factory=list)
     stderr: list[str] = field(default_factory=list)
 
+    def to_dict(self) -> dict[str, list[str]]:
+        return {"stdout": self.stdout, "stderr": self.stderr}
+
     def to_json(self) -> str:
-        return jsonlib.dumps({"stdout": self.stdout, "stderr": self.stderr})
+        return jsonlib.dumps(self.to_dict())
 
 
 @dataclass
@@ -31,8 +34,11 @@ class ExecutionError:
         else:
             self.traceback = traceback or ""
 
+    def to_dict(self) -> dict[str, str]:
+        return {"name": self.name, "value": self.value, "traceback": self.traceback}
+
     def to_json(self) -> str:
-        return jsonlib.dumps({"name": self.name, "value": self.value, "traceback": self.traceback})
+        return jsonlib.dumps(self.to_dict())
 
 
 @dataclass
@@ -177,8 +183,8 @@ class Execution:
     def to_json(self) -> str:
         data = {
             "results": _serialize_results(self.results),
-            "logs": self.logs.to_json(),
-            "error": self.error.to_json() if self.error else None,
+            "logs": self.logs.to_dict(),
+            "error": self.error.to_dict() if self.error else None,
         }
         return jsonlib.dumps(data)
 

--- a/sdk/python/tests/test_sandbox.py
+++ b/sdk/python/tests/test_sandbox.py
@@ -642,6 +642,26 @@ class TestExecutionModel:
         assert '"results"' in ex.to_json()
         assert '"text": "2"' in ex.to_json()
 
+    def test_logs_to_json_returns_json_string(self):
+        logs = Logs(stdout=["a"], stderr=["b"])
+        assert json.loads(logs.to_json()) == {"stdout": ["a"], "stderr": ["b"]}
+
+    def test_execution_error_to_json_returns_json_string(self):
+        error = ExecutionError("e", "v")
+        assert json.loads(error.to_json()) == {"name": "e", "value": "v", "traceback": ""}
+
+    def test_execution_to_json_roundtrip_preserves_nested_objects(self):
+        execution = Execution(
+            results=[],
+            logs=Logs(stdout=["a"], stderr=["b"]),
+            error=ExecutionError("e", "v"),
+        )
+
+        parsed = json.loads(execution.to_json())
+        assert isinstance(parsed["logs"], dict)
+        assert parsed["logs"]["stdout"] == ["a"]
+        assert isinstance(parsed["error"], dict)
+
     def test_output_message_e2b_and_legacy_aliases(self):
         msg = OutputMessage("hello\n", 123, True)
         assert msg.line == "hello\n"


### PR DESCRIPTION
## Summary

This PR fixes a Python SDK serialization bug in `Execution.to_json()`.

Previously, `Logs.to_json()` and `ExecutionError.to_json()` returned JSON strings, and `Execution.to_json()` embedded those strings into another `json.dumps(...)` call. As a result, the nested `logs` and `error` fields were double-encoded.

This fix preserves the existing helper behavior: `Logs.to_json()` and `ExecutionError.to_json()` still return JSON strings. New `to_dict()` helpers provide the nested object representation that `Execution.to_json()` needs internally.

## Motivation

The old behavior produced an unexpected serialized JSON shape:

```python
parsed = json.loads(execution.to_json())

type(parsed["logs"])   # str
type(parsed["error"])  # str
```

Callers doing a JSON roundtrip would reasonably expect `logs` and `error` to be nested objects, not JSON-encoded strings inside the parent JSON payload.

## Changes

- Add `to_dict()` helpers for `Logs` and `ExecutionError`, so `Execution.to_json()` can embed nested objects without double-encoding.
- Keep `Logs.to_json()` and `ExecutionError.to_json()` returning JSON strings, matching their method names and previous behavior.
- Keep the existing `Execution.to_json()` public API unchanged.
- Add focused tests covering `Logs.to_json()`, `ExecutionError.to_json()`, and the `Execution.to_json()` roundtrip shape.

## Validation

Verified with:

```bash
PYTHONPATH=sdk/python python -m pytest sdk/python/tests/test_sandbox.py -q
```

Result:

```text
153 passed
```

Also verified the previous failure mode before the fix: after `json.loads(execution.to_json())`, `parsed["logs"]` was a JSON string instead of a dict.

## Scope

This PR is limited to the Python SDK execution model serialization fix and focused test coverage.

It does not change execution behavior, sandbox behavior, or the public return type of any existing `to_json()` method.
