### PR TITLE
hypervisor: make available VIRTIO_BLK_F_SEG_MAX and VIRTIO_RING_F_INDIRECT_DESC

### DIFF
--- a/hypervisor/virtio-devices/src/block.rs
+++ b/hypervisor/virtio-devices/src/block.rs
@@ -47,6 +47,8 @@ use vmm_sys_util::eventfd::EventFd;
 const SECTOR_SHIFT: u8 = 9;
 pub const SECTOR_SIZE: u64 = 0x01 << SECTOR_SHIFT;
 
+pub const MINIMUM_BLOCK_QUEUE_SIZE: u16 = 2;
+
 // New descriptors are pending on the virtio queue.
 const QUEUE_AVAIL_EVENT: u16 = EPOLL_HELPER_EVENT_LAST + 1;
 // New completed tasks are pending on the completion ring.
@@ -508,6 +510,7 @@ impl Block {
                 | (1u64 << VIRTIO_BLK_F_CONFIG_WCE)
                 | (1u64 << VIRTIO_BLK_F_BLK_SIZE)
                 | (1u64 << VIRTIO_BLK_F_TOPOLOGY)
+                | (1u64 << VIRTIO_BLK_F_SEG_MAX)
                 | (1u64 << VIRTIO_RING_F_EVENT_IDX);
 
             if iommu {
@@ -543,6 +546,7 @@ impl Block {
                 physical_block_exp,
                 min_io_size: (topology.minimum_io_size / logical_block_size) as u16,
                 opt_io_size: (topology.optimal_io_size / logical_block_size) as u32,
+                seg_max: (queue_size - MINIMUM_BLOCK_QUEUE_SIZE) as u32,
                 ..Default::default()
             };
 

--- a/hypervisor/virtio-devices/src/block.rs
+++ b/hypervisor/virtio-devices/src/block.rs
@@ -37,7 +37,7 @@ use std::sync::{Arc, Barrier};
 use std::{collections::HashMap, convert::TryInto};
 use thiserror::Error;
 use virtio_bindings::bindings::virtio_blk::*;
-use virtio_bindings::bindings::virtio_ring::VIRTIO_RING_F_EVENT_IDX;
+use virtio_bindings::bindings::virtio_ring::{VIRTIO_RING_F_EVENT_IDX, VIRTIO_RING_F_INDIRECT_DESC};
 use virtio_queue::{Queue, QueueOwnedT, QueueT};
 use vm_memory::{ByteValued, Bytes, GuestAddressSpace, GuestMemoryAtomic, GuestMemoryError};
 use vm_migration::{Migratable, MigratableError, Pausable, Snapshot, Snapshottable, Transportable};
@@ -511,7 +511,8 @@ impl Block {
                 | (1u64 << VIRTIO_BLK_F_BLK_SIZE)
                 | (1u64 << VIRTIO_BLK_F_TOPOLOGY)
                 | (1u64 << VIRTIO_BLK_F_SEG_MAX)
-                | (1u64 << VIRTIO_RING_F_EVENT_IDX);
+                | (1u64 << VIRTIO_RING_F_EVENT_IDX)
+                | (1u64 << VIRTIO_RING_F_INDIRECT_DESC);
 
             if iommu {
                 avail_features |= 1u64 << VIRTIO_F_IOMMU_PLATFORM;

--- a/hypervisor/vmm/src/config.rs
+++ b/hypervisor/vmm/src/config.rs
@@ -10,6 +10,7 @@ pub use virtio_devices::fs::{
 };
 pub use virtio_devices::{RateLimiterConfig, TokenBucketConfig};
 
+use crate::vm_config::*;
 use clap::ArgMatches;
 use option_parser::{
     ByteSized, IntegerList, OptionParser, OptionParserError, StringList, Toggle, Tuple,
@@ -23,9 +24,8 @@ use std::result;
 use std::str::FromStr;
 use std::{fmt, fs};
 use thiserror::Error;
+use virtio_devices::block::MINIMUM_BLOCK_QUEUE_SIZE;
 use virtiofsd::passthrough::xattrmap::XattrMap;
-
-use crate::vm_config::*;
 
 const MAX_NUM_PCI_SEGMENTS: u16 = 16;
 
@@ -173,6 +173,8 @@ pub enum ValidationError {
     TdxFirmwareMissing,
     /// Insuffient vCPUs for queues
     TooManyQueues,
+    /// Invalid queue size
+    InvalidQueueSize(u16),
     /// Need shared memory for vfio-user
     UserDevicesRequireSharedMemory,
     /// Memory zone is reused across NUMA nodes
@@ -249,6 +251,12 @@ impl fmt::Display for ValidationError {
             }
             TooManyQueues => {
                 write!(f, "Number of vCPUs is insufficient for number of queues")
+            }
+            InvalidQueueSize(s) => {
+                write!(
+                    f,
+                    "Queue size is smaller than {MINIMUM_BLOCK_QUEUE_SIZE}: {s}"
+                )
             }
             UserDevicesRequireSharedMemory => {
                 write!(
@@ -1073,6 +1081,10 @@ impl DiskConfig {
     pub fn validate(&self, vm_config: &VmConfig) -> ValidationResult<()> {
         if self.num_queues > vm_config.cpus.boot_vcpus as usize {
             return Err(ValidationError::TooManyQueues);
+        }
+
+        if self.queue_size <= MINIMUM_BLOCK_QUEUE_SIZE {
+            return Err(ValidationError::InvalidQueueSize(self.queue_size));
         }
 
         if self.vhost_user && self.iommu {


### PR DESCRIPTION
block: make available VIRTIO_BLK_F_SEG_MAX and VIRTIO_RING_F_INDIRECT_DESC

VIRTIO_BLK_F_SEG_MAX allows the guest to put in more than one segment per request. It can improve the throughput of the system.