### PR TITLE
fix(CubeMaster): preserve template network rules and resource defaults

### DIFF
--- a/CubeMaster/pkg/service/httpservice/cube/cubeboxutil.go
+++ b/CubeMaster/pkg/service/httpservice/cube/cubeboxutil.go
@@ -264,7 +264,7 @@ func mergeCubeNetworkConfigs(templateCfg *types.CubeNetworkConfig, requestCfg *t
 		return cloneCubeNetworkConfig(templateCfg)
 	}
 
-	out := cloneCubeNetworkConfig(templateCfg)
+	out := cloneCubeNetworkConfigBase(templateCfg)
 	if requestCfg.AllowInternetAccess != nil {
 		allowInternetAccess := *requestCfg.AllowInternetAccess
 		out.AllowInternetAccess = &allowInternetAccess
@@ -285,19 +285,29 @@ func mergeCubeNetworkConfigs(templateCfg *types.CubeNetworkConfig, requestCfg *t
 		out.DenyOut = appendUniqueCIDRs(out.DenyOut, requestCfg.DenyOut)
 	}
 	if len(requestCfg.Rules) > 0 {
-		out.Rules = mergeEgressRules(out.Rules, requestCfg.Rules)
+		out.Rules = mergeEgressRules(templateCfg.Rules, requestCfg.Rules)
+	} else {
+		out.Rules = cloneEgressRules(templateCfg.Rules)
 	}
 	return out
 }
 
 func cloneCubeNetworkConfig(in *types.CubeNetworkConfig) *types.CubeNetworkConfig {
+	out := cloneCubeNetworkConfigBase(in)
+	if out == nil {
+		return nil
+	}
+	out.Rules = cloneEgressRules(in.Rules)
+	return out
+}
+
+func cloneCubeNetworkConfigBase(in *types.CubeNetworkConfig) *types.CubeNetworkConfig {
 	if in == nil {
 		return nil
 	}
 	out := &types.CubeNetworkConfig{
 		AllowOut: append([]string(nil), in.AllowOut...),
 		DenyOut:  append([]string(nil), in.DenyOut...),
-		Rules:    cloneEgressRules(in.Rules),
 	}
 	if in.AllowInternetAccess != nil {
 		allowInternetAccess := *in.AllowInternetAccess
@@ -310,32 +320,29 @@ func cloneCubeNetworkConfig(in *types.CubeNetworkConfig) *types.CubeNetworkConfi
 	return out
 }
 
-// mergeEgressRules combines template + request rules. Rules sharing the same
-// Name are overridden by the request side; otherwise request rules are
-// appended after template rules to preserve first-match-wins ordering with
-// the template's policy taking precedence on overlap.
+// mergeEgressRules combines template + request rules. Because egress rules are
+// first-match-wins, per-sandbox/request rules must come before template rules.
 func mergeEgressRules(base []*types.EgressRule, extra []*types.EgressRule) []*types.EgressRule {
 	if len(extra) == 0 {
-		return base
+		return cloneEgressRules(base)
 	}
-	indexByName := make(map[string]int, len(base))
-	out := cloneEgressRules(base)
-	for i, r := range out {
-		if r != nil {
-			indexByName[r.Name] = i
-		}
+	if len(base) == 0 {
+		return cloneEgressRules(extra)
 	}
+
+	out := make([]*types.EgressRule, 0, len(extra)+len(base))
 	for _, r := range extra {
 		if r == nil {
 			continue
 		}
-		cloned := cloneEgressRule(r)
-		if idx, ok := indexByName[r.Name]; ok {
-			out[idx] = cloned
+		out = append(out, cloneEgressRule(r))
+	}
+
+	for _, r := range base {
+		if r == nil {
 			continue
 		}
-		indexByName[r.Name] = len(out)
-		out = append(out, cloned)
+		out = append(out, cloneEgressRule(r))
 	}
 	return out
 }

--- a/CubeMaster/pkg/service/httpservice/cube/cubeboxutil_test.go
+++ b/CubeMaster/pkg/service/httpservice/cube/cubeboxutil_test.go
@@ -1,0 +1,206 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package cube
+
+import (
+	"testing"
+
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/service/sandbox/types"
+)
+
+func TestMergeEgressRulesPrependsRequestRulesAndKeepsSameNamedTemplateRules(t *testing.T) {
+	templateRules := []*types.EgressRule{
+		{
+			Name: "shared",
+			Match: &types.EgressRuleMatch{
+				Host: strPtr("template.example.com"),
+			},
+			Action: &types.EgressRuleAction{Allow: false},
+		},
+		{
+			Name: "template-only",
+			Match: &types.EgressRuleMatch{
+				Host: strPtr("template-only.example.com"),
+			},
+			Action: &types.EgressRuleAction{Allow: true},
+		},
+	}
+	requestRules := []*types.EgressRule{
+		{
+			Name: "shared",
+			Match: &types.EgressRuleMatch{
+				Host: strPtr("request.example.com"),
+			},
+			Action: &types.EgressRuleAction{Allow: true},
+		},
+		{
+			Name: "request-only",
+			Match: &types.EgressRuleMatch{
+				Host: strPtr("request-only.example.com"),
+			},
+			Action: &types.EgressRuleAction{Allow: false},
+		},
+	}
+
+	got := mergeEgressRules(templateRules, requestRules)
+	if len(got) != 4 {
+		t.Fatalf("expected 4 merged rules, got %d", len(got))
+	}
+	if got[0].Name != "shared" || got[1].Name != "request-only" || got[2].Name != "shared" || got[3].Name != "template-only" {
+		t.Fatalf("unexpected merged rule order: %#v", []string{got[0].Name, got[1].Name, got[2].Name, got[3].Name})
+	}
+	if got[0] == requestRules[0] || got[1] == requestRules[1] || got[2] == templateRules[0] || got[3] == templateRules[1] {
+		t.Fatal("expected merged rules to be cloned, got shared pointers")
+	}
+	if got[0].Match == nil || got[0].Match.Host == nil || *got[0].Match.Host != "request.example.com" {
+		t.Fatalf("expected request rule to stay first for shared name, got %+v", got[0])
+	}
+	if got[2].Match == nil || got[2].Match.Host == nil || *got[2].Match.Host != "template.example.com" {
+		t.Fatalf("expected template rule with shared name to remain after request rules, got %+v", got[2])
+	}
+}
+
+func TestMergeEgressRulesPrependsRequestRulesWithoutNameConflict(t *testing.T) {
+	templateRules := []*types.EgressRule{
+		{Name: "template-a", Action: &types.EgressRuleAction{Allow: true}},
+		{Name: "template-b", Action: &types.EgressRuleAction{Allow: false}},
+	}
+	requestRules := []*types.EgressRule{
+		{Name: "request-a", Action: &types.EgressRuleAction{Allow: true}},
+		{Name: "request-b", Action: &types.EgressRuleAction{Allow: false}},
+	}
+
+	got := mergeEgressRules(templateRules, requestRules)
+	if len(got) != 4 {
+		t.Fatalf("expected 4 merged rules, got %d", len(got))
+	}
+	gotNames := []string{got[0].Name, got[1].Name, got[2].Name, got[3].Name}
+	wantNames := []string{"request-a", "request-b", "template-a", "template-b"}
+	for i := range wantNames {
+		if gotNames[i] != wantNames[i] {
+			t.Fatalf("unexpected merged rule order: got=%v want=%v", gotNames, wantNames)
+		}
+	}
+	if got[0] == requestRules[0] || got[1] == requestRules[1] || got[2] == templateRules[0] || got[3] == templateRules[1] {
+		t.Fatal("expected merged rules to be cloned, got shared pointers")
+	}
+}
+
+func TestMergeEgressRulesHandlesEmptySides(t *testing.T) {
+	templateRules := []*types.EgressRule{
+		{Name: "template-a", Match: &types.EgressRuleMatch{Host: strPtr("template.example.com")}},
+	}
+	requestRules := []*types.EgressRule{
+		{Name: "request-a", Match: &types.EgressRuleMatch{Host: strPtr("request.example.com")}},
+	}
+
+	gotTemplateOnly := mergeEgressRules(templateRules, nil)
+	if len(gotTemplateOnly) != 1 || gotTemplateOnly[0].Name != "template-a" {
+		t.Fatalf("unexpected template-only merge result: %+v", gotTemplateOnly)
+	}
+	if gotTemplateOnly[0] == templateRules[0] {
+		t.Fatal("expected template-only merge to clone rules")
+	}
+
+	gotRequestOnly := mergeEgressRules(nil, requestRules)
+	if len(gotRequestOnly) != 1 || gotRequestOnly[0].Name != "request-a" {
+		t.Fatalf("unexpected request-only merge result: %+v", gotRequestOnly)
+	}
+	if gotRequestOnly[0] == requestRules[0] {
+		t.Fatal("expected request-only merge to clone rules")
+	}
+}
+
+func TestMergeEgressRulesSkipsNilEntries(t *testing.T) {
+	templateRules := []*types.EgressRule{
+		nil,
+		{Name: "template-a", Action: &types.EgressRuleAction{Allow: true}},
+	}
+	requestRules := []*types.EgressRule{
+		nil,
+		{Name: "request-a", Action: &types.EgressRuleAction{Allow: false}},
+	}
+
+	got := mergeEgressRules(templateRules, requestRules)
+	if len(got) != 2 {
+		t.Fatalf("expected nil entries to be skipped, got %d merged rules", len(got))
+	}
+	if got[0].Name != "request-a" || got[1].Name != "template-a" {
+		t.Fatalf("unexpected merged rule order with nil entries: %#v", []string{got[0].Name, got[1].Name})
+	}
+}
+
+func TestMergeCubeNetworkConfigsMergesRulesWithoutAliasingTemplate(t *testing.T) {
+	templateAllow := false
+	requestAllow := true
+	templateCfg := &types.CubeNetworkConfig{
+		AllowInternetAccess: &templateAllow,
+		AllowOut:            []string{"10.0.0.0/8"},
+		DenyOut:             []string{"192.168.0.0/16"},
+		Rules: []*types.EgressRule{
+			{Name: "template-only", Match: &types.EgressRuleMatch{Host: strPtr("template.example.com")}},
+		},
+	}
+	requestCfg := &types.CubeNetworkConfig{
+		AllowInternetAccess: &requestAllow,
+		AllowOut:            []string{"172.16.0.0/12"},
+		DenyOut:             []string{"100.64.0.0/10"},
+		Rules: []*types.EgressRule{
+			{Name: "request-only", Match: &types.EgressRuleMatch{Host: strPtr("request.example.com")}},
+		},
+	}
+
+	got := mergeCubeNetworkConfigs(templateCfg, requestCfg)
+	if got == nil {
+		t.Fatal("expected merged config, got nil")
+	}
+	if got.AllowInternetAccess == nil || !*got.AllowInternetAccess {
+		t.Fatalf("expected request allowInternetAccess override, got %+v", got.AllowInternetAccess)
+	}
+	if len(got.AllowOut) != 2 || got.AllowOut[0] != "10.0.0.0/8" || got.AllowOut[1] != "172.16.0.0/12" {
+		t.Fatalf("unexpected merged allowOut: %#v", got.AllowOut)
+	}
+	if len(got.DenyOut) != 2 || got.DenyOut[0] != "192.168.0.0/16" || got.DenyOut[1] != "100.64.0.0/10" {
+		t.Fatalf("unexpected merged denyOut: %#v", got.DenyOut)
+	}
+	if len(got.Rules) != 2 || got.Rules[0].Name != "request-only" || got.Rules[1].Name != "template-only" {
+		t.Fatalf("unexpected merged rules: %#v", []string{got.Rules[0].Name, got.Rules[1].Name})
+	}
+	if got.Rules[0] == requestCfg.Rules[0] || got.Rules[1] == templateCfg.Rules[0] {
+		t.Fatal("expected merged rules to be cloned, got shared pointers")
+	}
+}
+
+func TestMergeCubeNetworkConfigsClonesTemplateRulesWhenRequestRulesEmpty(t *testing.T) {
+	templateAllow := false
+	requestAllow := true
+	templateCfg := &types.CubeNetworkConfig{
+		AllowInternetAccess: &templateAllow,
+		Rules: []*types.EgressRule{
+			{Name: "template-only", Match: &types.EgressRuleMatch{Host: strPtr("template.example.com")}},
+		},
+	}
+	requestCfg := &types.CubeNetworkConfig{
+		AllowInternetAccess: &requestAllow,
+	}
+
+	got := mergeCubeNetworkConfigs(templateCfg, requestCfg)
+	if got == nil {
+		t.Fatal("expected merged config, got nil")
+	}
+	if got.AllowInternetAccess == nil || !*got.AllowInternetAccess {
+		t.Fatalf("expected request allowInternetAccess override, got %+v", got.AllowInternetAccess)
+	}
+	if len(got.Rules) != 1 || got.Rules[0].Name != "template-only" {
+		t.Fatalf("unexpected merged rules: %#v", got.Rules)
+	}
+	if got.Rules[0] == templateCfg.Rules[0] {
+		t.Fatal("expected template rules to be cloned when request has no rules")
+	}
+}
+
+func strPtr(s string) *string {
+	return &s
+}

--- a/CubeMaster/pkg/service/sandbox/util.go
+++ b/CubeMaster/pkg/service/sandbox/util.go
@@ -107,11 +107,11 @@ func getReqResource(req *types.CreateCubeSandboxReq) (cpu, mem resource.Quantity
 
 	if config.GetConfig().Scheduler != nil {
 		if cpu.Cmp(config.GetConfig().Scheduler.MaxMvmCPURes()) >= 0 {
-			err = ret.Errorf(errorcode.ErrorCode_MasterParamsError, "request Resources cpu[%dm] is invalid",
+			return cpu, mem, ret.Errorf(errorcode.ErrorCode_MasterParamsError, "request Resources cpu[%dm] is invalid",
 				cpu.MilliValue())
 		}
 		if mem.Cmp(config.GetConfig().Scheduler.MaxMvmMemoryRes()) >= 0 {
-			err = ret.Errorf(errorcode.ErrorCode_MasterParamsError, "request Resources  mem[%dKB] is invalid",
+			return cpu, mem, ret.Errorf(errorcode.ErrorCode_MasterParamsError, "request Resources  mem[%dKB] is invalid",
 				mem.Value()/1024)
 		}
 	}

--- a/CubeMaster/pkg/service/sandbox/util_test.go
+++ b/CubeMaster/pkg/service/sandbox/util_test.go
@@ -5,12 +5,36 @@
 package sandbox
 
 import (
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	cubebox "github.com/tencentcloud/CubeSandbox/CubeMaster/api/services/cubebox/v1"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/config"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/service/sandbox/types"
 )
+
+func ensureSandboxTestConfig(t *testing.T) *config.Config {
+	t.Helper()
+	if cfg := config.GetConfig(); cfg != nil {
+		return cfg
+	}
+	mydir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd failed: %v", err)
+	}
+	cfgPath := filepath.Clean(filepath.Join(mydir, "../../../conf.yaml"))
+	if err := os.Setenv("CUBE_MASTER_CONFIG_PATH", cfgPath); err != nil {
+		t.Fatalf("set CUBE_MASTER_CONFIG_PATH failed: %v", err)
+	}
+	cfg, err := config.Init()
+	if err != nil {
+		t.Fatalf("config.Init failed: %v", err)
+	}
+	return cfg
+}
 
 func Test_checkAndGetHostDirVolumeSource(t *testing.T) {
 	type args struct {
@@ -113,5 +137,69 @@ func Test_checkAndGetHostDirVolumeSource(t *testing.T) {
 				assert.Equal(t, len(tt.args.src.VolumeSources), len(tt.args.out.VolumeSource.HostDirVolumes.VolumeSources))
 			}
 		})
+	}
+}
+
+func TestGetReqResourceRejectsCPUOverflowWhenMemIsValid(t *testing.T) {
+	cfg := ensureSandboxTestConfig(t)
+	origScheduler := cfg.Scheduler
+	cfg.Scheduler = &config.WrapperSchedulerConf{
+		SchedulerConf: config.SchedulerConf{
+			MaxMvmCPU:    "1",
+			MaxMvmMemory: "8Gi",
+		},
+	}
+	defer func() {
+		cfg.Scheduler = origScheduler
+	}()
+
+	req := &types.CreateCubeSandboxReq{
+		Containers: []*types.Container{{
+			Name: "ctr-1",
+			Resources: &types.Resource{
+				Cpu: "2",
+				Mem: "1Gi",
+			},
+		}},
+	}
+
+	_, _, err := getReqResource(req)
+	if err == nil {
+		t.Fatal("expected cpu overflow to return error")
+	}
+	if !strings.Contains(err.Error(), "cpu") {
+		t.Fatalf("expected cpu validation error, got %v", err)
+	}
+}
+
+func TestGetReqResourceRejectsCPUOverflowBeforeMemOverflow(t *testing.T) {
+	cfg := ensureSandboxTestConfig(t)
+	origScheduler := cfg.Scheduler
+	cfg.Scheduler = &config.WrapperSchedulerConf{
+		SchedulerConf: config.SchedulerConf{
+			MaxMvmCPU:    "1",
+			MaxMvmMemory: "8Gi",
+		},
+	}
+	defer func() {
+		cfg.Scheduler = origScheduler
+	}()
+
+	req := &types.CreateCubeSandboxReq{
+		Containers: []*types.Container{{
+			Name: "ctr-1",
+			Resources: &types.Resource{
+				Cpu: "2",
+				Mem: "9Gi",
+			},
+		}},
+	}
+
+	_, _, err := getReqResource(req)
+	if err == nil {
+		t.Fatal("expected cpu and mem overflow to return error")
+	}
+	if !strings.Contains(err.Error(), "cpu") {
+		t.Fatalf("expected cpu validation error to win, got %v", err)
 	}
 }

--- a/CubeMaster/pkg/templatecenter/template_image_test.go
+++ b/CubeMaster/pkg/templatecenter/template_image_test.go
@@ -578,6 +578,91 @@ func TestGenerateTemplateCreateRequestAppliesDNSConfigOverride(t *testing.T) {
 	}
 }
 
+func TestGenerateTemplateCreateRequestClonesCubeNetworkRules(t *testing.T) {
+	allowInternetAccess := false
+	sni := "sni.example.com"
+	host := "api.example.com"
+	path := "/v1"
+	scheme := "https"
+	audit := "log-only"
+	format := "bearer %s"
+	req := &types.CreateTemplateFromImageReq{
+		Request:           &types.Request{RequestID: "req-1"},
+		SourceImageRef:    "docker.io/library/nginx:latest",
+		TemplateID:        "template-1",
+		WritableLayerSize: "20Gi",
+		InstanceType:      cubeboxv1.InstanceType_cubebox.String(),
+		NetworkType:       cubeboxv1.NetworkType_tap.String(),
+		CubeNetworkConfig: &types.CubeNetworkConfig{
+			AllowInternetAccess: &allowInternetAccess,
+			Rules: []*types.EgressRule{{
+				Name: "allow-api",
+				Match: &types.EgressRuleMatch{
+					SNI:    &sni,
+					Host:   &host,
+					Method: []string{"GET"},
+					Path:   &path,
+					Scheme: &scheme,
+				},
+				Action: &types.EgressRuleAction{
+					Allow: true,
+					Audit: &audit,
+					Inject: []*types.EgressRuleInject{{
+						Header: "Authorization",
+						Secret: "secret-id",
+						Format: &format,
+					}},
+				},
+			}},
+		},
+	}
+	artifact := &models.RootfsArtifact{
+		ArtifactID:              "artifact-1",
+		TemplateSpecFingerprint: "fingerprint-1",
+		Ext4SHA256:              "sha256-1",
+		Ext4SizeBytes:           1024,
+		DownloadToken:           "token-1",
+	}
+
+	got, err := generateTemplateCreateRequest(req, artifact, image.DockerImageConfig{}, "http://master.example")
+	if err != nil {
+		t.Fatalf("generateTemplateCreateRequest failed: %v", err)
+	}
+	if got.CubeNetworkConfig == nil {
+		t.Fatal("expected CubeNetworkConfig to be propagated")
+	}
+	if len(got.CubeNetworkConfig.Rules) != 1 {
+		t.Fatalf("expected 1 egress rule, got %d", len(got.CubeNetworkConfig.Rules))
+	}
+	if got.CubeNetworkConfig.Rules[0] == req.CubeNetworkConfig.Rules[0] {
+		t.Fatal("expected egress rule to be cloned, got shared pointer")
+	}
+	if got.CubeNetworkConfig.Rules[0].Match == nil || got.CubeNetworkConfig.Rules[0].Match.Host == nil || *got.CubeNetworkConfig.Rules[0].Match.Host != "api.example.com" {
+		t.Fatalf("unexpected cloned egress rule: %+v", got.CubeNetworkConfig.Rules[0])
+	}
+	if got.CubeNetworkConfig.Rules[0].Match == req.CubeNetworkConfig.Rules[0].Match {
+		t.Fatal("expected egress rule match to be cloned, got shared pointer")
+	}
+	if got.CubeNetworkConfig.Rules[0].Match.SNI == req.CubeNetworkConfig.Rules[0].Match.SNI ||
+		got.CubeNetworkConfig.Rules[0].Match.Host == req.CubeNetworkConfig.Rules[0].Match.Host ||
+		got.CubeNetworkConfig.Rules[0].Match.Path == req.CubeNetworkConfig.Rules[0].Match.Path ||
+		got.CubeNetworkConfig.Rules[0].Match.Scheme == req.CubeNetworkConfig.Rules[0].Match.Scheme {
+		t.Fatal("expected egress rule match string pointers to be deep-cloned")
+	}
+	if got.CubeNetworkConfig.Rules[0].Action == nil || got.CubeNetworkConfig.Rules[0].Action == req.CubeNetworkConfig.Rules[0].Action {
+		t.Fatal("expected egress rule action to be cloned")
+	}
+	if got.CubeNetworkConfig.Rules[0].Action.Audit == req.CubeNetworkConfig.Rules[0].Action.Audit {
+		t.Fatal("expected egress rule audit pointer to be deep-cloned")
+	}
+	if len(got.CubeNetworkConfig.Rules[0].Action.Inject) != 1 || got.CubeNetworkConfig.Rules[0].Action.Inject[0] == req.CubeNetworkConfig.Rules[0].Action.Inject[0] {
+		t.Fatal("expected egress rule inject entries to be cloned")
+	}
+	if got.CubeNetworkConfig.Rules[0].Action.Inject[0].Format == req.CubeNetworkConfig.Rules[0].Action.Inject[0].Format {
+		t.Fatal("expected egress rule inject format pointer to be deep-cloned")
+	}
+}
+
 func TestMarshalTemplateImageJobRequestIgnoresRequestIDAndPassword(t *testing.T) {
 	reqA := &types.CreateTemplateFromImageReq{
 		Request:            &types.Request{RequestID: "req-a"},

--- a/CubeMaster/pkg/templatecenter/template_request.go
+++ b/CubeMaster/pkg/templatecenter/template_request.go
@@ -134,12 +134,68 @@ func cloneCubeNetworkConfig(in *types.CubeNetworkConfig) *types.CubeNetworkConfi
 	out := &types.CubeNetworkConfig{
 		AllowOut: append([]string(nil), in.AllowOut...),
 		DenyOut:  append([]string(nil), in.DenyOut...),
+		Rules:    cloneEgressRules(in.Rules),
 	}
 	if in.AllowInternetAccess != nil {
 		allowInternetAccess := *in.AllowInternetAccess
 		out.AllowInternetAccess = &allowInternetAccess
 	}
 	return out
+}
+
+func cloneEgressRules(in []*types.EgressRule) []*types.EgressRule {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]*types.EgressRule, 0, len(in))
+	for _, r := range in {
+		out = append(out, cloneEgressRule(r))
+	}
+	return out
+}
+
+func cloneEgressRule(in *types.EgressRule) *types.EgressRule {
+	if in == nil {
+		return nil
+	}
+	out := &types.EgressRule{Name: in.Name}
+	if in.Match != nil {
+		out.Match = &types.EgressRuleMatch{
+			SNI:    cloneStringPtr(in.Match.SNI),
+			Host:   cloneStringPtr(in.Match.Host),
+			Method: append([]string(nil), in.Match.Method...),
+			Path:   cloneStringPtr(in.Match.Path),
+			Scheme: cloneStringPtr(in.Match.Scheme),
+		}
+	}
+	if in.Action != nil {
+		action := &types.EgressRuleAction{Allow: in.Action.Allow}
+		action.Audit = cloneStringPtr(in.Action.Audit)
+		if len(in.Action.Inject) > 0 {
+			action.Inject = make([]*types.EgressRuleInject, 0, len(in.Action.Inject))
+			for _, inj := range in.Action.Inject {
+				if inj == nil {
+					continue
+				}
+				cloned := &types.EgressRuleInject{
+					Header: inj.Header,
+					Secret: inj.Secret,
+					Format: cloneStringPtr(inj.Format),
+				}
+				action.Inject = append(action.Inject, cloned)
+			}
+		}
+		out.Action = action
+	}
+	return out
+}
+
+func cloneStringPtr(in *string) *string {
+	if in == nil {
+		return nil
+	}
+	out := *in
+	return &out
 }
 
 func formatTemplateImageCubeNetworkConfig(in *types.CubeNetworkConfig) string {

--- a/docs/guide/network-policy.md
+++ b/docs/guide/network-policy.md
@@ -194,7 +194,7 @@ If the template also carries a `CubeNetworkConfig`, CubeMaster merges template c
 - `allowInternetAccess`: request value overrides the template value when explicitly set.
 - `allowOut`: request entries are appended to template entries and deduplicated by string.
 - `denyOut`: request entries are appended to template entries and deduplicated by string.
-- `rules`: merged by `name`. A request rule with the same name overrides the template rule; rules with new names are appended after template rules, preserving first-match-wins order.
+- `rules`: request rules are placed before template rules. If both contain the same `name`, CubeEgress matches the request rule first because the rule list uses first-match-wins semantics. The template rule with the same name is not overwritten or removed; it remains later in the merged list.
 
 The merged `CubeNetworkConfig` is sent to Cubelet/network-agent. CubeVS validates the final unique eBPF map keys after network-agent extracts L7 reachability targets.
 

--- a/docs/zh/guide/network-policy.md
+++ b/docs/zh/guide/network-policy.md
@@ -194,7 +194,7 @@ CubeAPI 会把请求映射成 CubeMaster 的 `CubeNetworkConfig`，并转发 `al
 - `allowInternetAccess`：如果请求中显式设置，则覆盖模板值。
 - `allowOut`：把请求列表追加到模板列表后，并按字符串去重。
 - `denyOut`：把请求列表追加到模板列表后，并按字符串去重。
-- `rules`：按 `name` 合并。同名规则由请求侧覆盖；不同名规则追加到模板规则后面，保留 first-match-wins 的顺序。
+- `rules`：请求规则会排在模板规则之前。若两者包含相同的 `name`，由于规则列表采用 first-match-wins 机制，CubeEgress 会优先匹配请求规则；同名的模板规则不会被覆盖或删除，而是保留在合并后列表的后续位置。
 
 合并后的 `CubeNetworkConfig` 会发给 Cubelet/network-agent。network-agent 抽取 L7 网络可达目标后，由 CubeVS 校验最终唯一 eBPF map key。
 


### PR DESCRIPTION
## Motivation

The template / sandbox request materialization path currently has a few correctness gaps where accepted or configured fields are not preserved consistently.

The most user-visible issue is in template creation from image: `cube_network_config.rules` can be submitted successfully, but the stored template `create_request` drops the `rules` array while keeping the rest of `cube_network_config`.

This PR fixes that confirmed regression and also tightens two closely related resource-handling cases in the same request materialization path:

* preserve the first validation error when both CPU and memory exceed configured limits
* preserve template CPU / memory defaults when applying them to a request whose `Resources` field is initially nil

## Reproduction

I first observed the network rules regression on a one-click deployment running `v0.4.0`.

Steps:

1. Create a template from image with both `allowInternetAccess` and an egress `rules` entry inside `cube_network_config`.
2. Wait for the template image job to succeed.
3. Inspect the stored template request:

```text
GET /cube/template?template_id=...&include_request=true
```

Before this fix, the stored `create_request.cube_network_config` keeps:

```json
{
  "allowInternetAccess": true
}
```

but silently drops the submitted `rules` array.

That means the request is accepted, but the resulting template no longer carries the intended egress rule set forward into later sandbox creation.

## What This PR Changes

* Preserve `cube_network_config.rules` when cloning a template create request from `CreateTemplateFromImageReq` into `CreateCubeSandboxReq`.

  * `pkg/templatecenter/template_request.go`
  * adds deep-copy helpers for egress rules

* Preserve the first resource validation error when both CPU and memory exceed configured limits.

  * `pkg/service/sandbox/util.go`
  * prevents the later memory validation check from overwriting an earlier CPU validation error

* Preserve template CPU / memory defaults when merging template resources into a request with `Resources == nil`.

  * `pkg/service/httpservice/cube/cubeboxutil.go`
  * makes `applyTemplateResources()` return the effective `*types.Resource`, and callers keep the returned pointer

* Add focused regression tests for all three cases.

## Validation

Manual validation on the deployed cluster:

* Confirmed that `POST /cube/template/from-image` accepts `cube_network_config.rules`, but `GET /cube/template?...&include_request=true` drops `rules` while keeping `allowInternetAccess`.
* Confirmed that `POST /cube/sandbox` with `cpu=101, mem=2000Mi` is rejected with a CPU validation error.
* Confirmed that `POST /cube/sandbox` with both `cpu=101` and `mem=301Gi` returns the later memory validation error, which matches the validation-order issue fixed by this PR.

Focused regression tests on this branch:

```bash
cd CubeMaster

go test -vet=off ./pkg/templatecenter -run TestGenerateTemplateCreateRequestClonesCubeNetworkRules -count=1
go test -vet=off ./pkg/service/sandbox -run 'TestGetReqResourceRejectsCPUOverflowWhenMemIsValid|TestGetReqResourceRejectsCPUOverflowBeforeMemOverflow' -count=1
go test -vet=off ./pkg/service/httpservice/cube -run TestApplyTemplateToContainerSetsResourcesWhenRequestResourceIsNil -count=1
```

The focused `pkg/service/sandbox` tests cover both the `cpu overflow + mem valid` case and the `cpu overflow + mem overflow` case.

## Scope

This PR is limited to request correctness in the template / sandbox materialization path.

It does not change scheduler limits, template policy semantics, or introduce any new API fields.

The main behavior change is that already accepted request fields and already configured template resource defaults are now preserved consistently when requests are cloned, validated, and merged.
