### PR TITLE
fix(deploy): add semver_compare and version_lt functions for upgrade decision

### DIFF
--- a/deploy/one-click/lib/common.sh
+++ b/deploy/one-click/lib/common.sh
@@ -30,6 +30,211 @@ require_cmd() {
   command -v "${cmd}" >/dev/null 2>&1 || die "required command not found: ${cmd}"
 }
 
+_version_trim_leading_zeroes() {
+  local value="$1"
+  value="${value#${value%%[!0]*}}"
+  printf '%s\n' "${value:-0}"
+}
+
+_version_compare_numbers() {
+  local LC_ALL=C
+  local left right
+  left="$(_version_trim_leading_zeroes "$1")"
+  right="$(_version_trim_leading_zeroes "$2")"
+
+  if [[ "${#left}" -lt "${#right}" ]]; then
+    printf '%s\n' "-1"
+  elif [[ "${#left}" -gt "${#right}" ]]; then
+    printf '%s\n' "1"
+  elif [[ "${left}" < "${right}" ]]; then
+    printf '%s\n' "-1"
+  elif [[ "${left}" > "${right}" ]]; then
+    printf '%s\n' "1"
+  else
+    printf '%s\n' "0"
+  fi
+}
+
+# Parse [v]X.Y.Z[-PRERELEASE][+BUILD] into unit-separator-delimited fields:
+# major\037minor\037patch\037prerelease. Return 1 when the core has extra
+# fields, non-ASCII digits, or invalid prerelease identifiers.
+_version_split_semver() {
+  local LC_ALL=C
+  local version="$1"
+  version="${version#v}"
+  version="${version%%+*}"
+
+  local core="${version%%-*}"
+  local pre=""
+  if [[ "${version}" == *-* ]]; then
+    pre="${version#*-}"
+    [[ "${pre}" =~ ^[0123456789A-Za-z-]+(\.[0123456789A-Za-z-]+)*$ ]] || return 1
+  fi
+
+  local major minor patch extra
+  IFS='.' read -r major minor patch extra <<<"${core}"
+  [[ -z "${extra:-}" ]] || return 1
+  [[ "${major}" =~ ^[0123456789]+$ ]] || return 1
+  [[ "${minor}" =~ ^[0123456789]+$ ]] || return 1
+  [[ "${patch}" =~ ^[0123456789]+$ ]] || return 1
+
+  printf '%s\037%s\037%s\037%s\n' "${major}" "${minor}" "${patch}" "${pre}"
+}
+
+# C-locale lexical fallback for versions that do not match the semver subset.
+_version_compare_lexical() {
+  local LC_ALL=C
+  local left="$1"
+  local right="$2"
+
+  if [[ "${left}" < "${right}" ]]; then
+    printf '%s\n' "-1"
+  elif [[ "${left}" > "${right}" ]]; then
+    printf '%s\n' "1"
+  else
+    printf '%s\n' "0"
+  fi
+}
+
+_version_compare_prerelease_identifier() {
+  local LC_ALL=C
+  local left="$1"
+  local right="$2"
+
+  if [[ "${left}" == "${right}" ]]; then
+    printf '%s\n' "0"
+    return 0
+  fi
+
+  local left_numeric=0
+  local right_numeric=0
+  [[ "${left}" =~ ^[0123456789]+$ ]] && left_numeric=1
+  [[ "${right}" =~ ^[0123456789]+$ ]] && right_numeric=1
+
+  if [[ "${left_numeric}" == "1" && "${right_numeric}" == "1" ]]; then
+    _version_compare_numbers "${left}" "${right}"
+  elif [[ "${left_numeric}" == "1" ]]; then
+    printf '%s\n' "-1"
+  elif [[ "${right_numeric}" == "1" ]]; then
+    printf '%s\n' "1"
+  else
+    local left_prefix="" left_suffix="" right_prefix="" right_suffix=""
+    if [[ "${left}" =~ ^([A-Za-z-]+)([0123456789]+)$ ]]; then
+      left_prefix="${BASH_REMATCH[1]}"
+      left_suffix="${BASH_REMATCH[2]}"
+    fi
+    if [[ "${right}" =~ ^([A-Za-z-]+)([0123456789]+)$ ]]; then
+      right_prefix="${BASH_REMATCH[1]}"
+      right_suffix="${BASH_REMATCH[2]}"
+    fi
+
+    if [[ -n "${left_prefix}" && "${left_prefix}" == "${right_prefix}" ]]; then
+      # Deployment tags often use rc1/rc2; compare matching suffixes numerically
+      # so rc10 sorts after rc2, even though strict semver compares them lexically.
+      _version_compare_numbers "${left_suffix}" "${right_suffix}"
+    else
+      _version_compare_lexical "${left}" "${right}"
+    fi
+  fi
+}
+
+_version_compare_prerelease() {
+  local left="$1"
+  local right="$2"
+
+  if [[ -z "${left}" && -z "${right}" ]]; then
+    printf '%s\n' "0"
+    return 0
+  elif [[ -z "${left}" ]]; then
+    printf '%s\n' "1"
+    return 0
+  elif [[ -z "${right}" ]]; then
+    printf '%s\n' "-1"
+    return 0
+  fi
+
+  local left_ids right_ids
+  IFS='.' read -r -a left_ids <<<"${left}"
+  IFS='.' read -r -a right_ids <<<"${right}"
+
+  local max_count="${#left_ids[@]}"
+  if [[ "${#right_ids[@]}" -gt "${max_count}" ]]; then
+    max_count="${#right_ids[@]}"
+  fi
+
+  local i cmp
+  for ((i = 0; i < max_count; i++)); do
+    if [[ "${i}" -ge "${#left_ids[@]}" ]]; then
+      printf '%s\n' "-1"
+      return 0
+    elif [[ "${i}" -ge "${#right_ids[@]}" ]]; then
+      printf '%s\n' "1"
+      return 0
+    fi
+
+    cmp="$(_version_compare_prerelease_identifier "${left_ids[i]}" "${right_ids[i]}")"
+    [[ "${cmp}" == "0" ]] || {
+      printf '%s\n' "${cmp}"
+      return 0
+    }
+  done
+
+  printf '%s\n' "0"
+}
+
+# semver_compare: Compare two semantic versions and print -1, 0, or 1 to stdout.
+# The comparison accepts an optional leading "v" and ignores build metadata
+# after "+". If either input cannot be parsed as semver, both original inputs
+# are compared with a C-locale lexical fallback instead. Set
+# ONE_CLICK_VERSION_COMPARE_DEBUG=1 to log fallback diagnostics to stderr.
+# Matching prerelease identifiers such as rc1/rc10 sort by numeric suffix to
+# match deployment tag conventions.
+semver_compare() {
+  local left_parts right_parts
+  if ! left_parts="$(_version_split_semver "$1")" || ! right_parts="$(_version_split_semver "$2")"; then
+    # Preserve deterministic ordering for legacy/non-semver release strings.
+    if [[ "${ONE_CLICK_VERSION_COMPARE_DEBUG:-}" == "1" ]]; then
+      log "DEBUG: falling back to lexical version comparison for '$1' and '$2'"
+    fi
+    _version_compare_lexical "$1" "$2"
+    return 0
+  fi
+
+  local left_major left_minor left_patch left_pre
+  local right_major right_minor right_patch right_pre
+  local parts_sep=$'\037'
+  IFS="${parts_sep}" read -r left_major left_minor left_patch left_pre <<<"${left_parts}"
+  IFS="${parts_sep}" read -r right_major right_minor right_patch right_pre <<<"${right_parts}"
+
+  local cmp
+  cmp="$(_version_compare_numbers "${left_major}" "${right_major}")"
+  [[ "${cmp}" == "0" ]] || {
+    printf '%s\n' "${cmp}"
+    return 0
+  }
+
+  cmp="$(_version_compare_numbers "${left_minor}" "${right_minor}")"
+  [[ "${cmp}" == "0" ]] || {
+    printf '%s\n' "${cmp}"
+    return 0
+  }
+
+  cmp="$(_version_compare_numbers "${left_patch}" "${right_patch}")"
+  [[ "${cmp}" == "0" ]] || {
+    printf '%s\n' "${cmp}"
+    return 0
+  }
+
+  _version_compare_prerelease "${left_pre}" "${right_pre}"
+}
+
+# version_lt: Return success when the first version is lower than the second.
+# Delegates to semver_compare, including its v-prefix, build metadata, rc suffix,
+# and lexical fallback behavior.
+version_lt() {
+  [[ "$(semver_compare "$1" "$2")" == "-1" ]]
+}
+
 one_click_cow_required_commands() {
   printf '%s\n' \
     mkfs.ext4 \

--- a/deploy/one-click/tests/test_version_compare.sh
+++ b/deploy/one-click/tests/test_version_compare.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ONE_CLICK_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+# shellcheck source=../lib/common.sh
+source "${ONE_CLICK_DIR}/lib/common.sh"
+
+failures=0
+
+fail() {
+  echo "FAIL: $*" >&2
+  failures=$((failures + 1))
+}
+
+assert_lt() {
+  local left="$1"
+  local right="$2"
+  version_lt "${left}" "${right}" || fail "expected ${left} < ${right}"
+}
+
+assert_not_lt() {
+  local left="$1"
+  local right="$2"
+  if version_lt "${left}" "${right}"; then
+    fail "expected ${left} !< ${right}"
+  fi
+}
+
+assert_cmp() {
+  local left="$1"
+  local right="$2"
+  local expected="$3"
+  local actual
+  actual="$(semver_compare "${left}" "${right}")"
+  [[ "${actual}" == "${expected}" ]] || fail "expected compare(${left}, ${right})=${expected}, got ${actual}"
+}
+
+assert_cmp_without_stderr() {
+  local left="$1"
+  local right="$2"
+  local expected="$3"
+  local actual err_file err
+  err_file="$(mktemp)"
+  actual="$(semver_compare "${left}" "${right}" 2>"${err_file}")"
+  err="$(<"${err_file}")"
+  rm -f "${err_file}"
+
+  [[ "${actual}" == "${expected}" ]] || fail "expected compare(${left}, ${right})=${expected}, got ${actual}"
+  [[ -z "${err}" ]] || fail "expected compare(${left}, ${right}) to keep stderr empty, got: ${err}"
+}
+
+assert_debug_fallback_logs() {
+  local err_file err
+  err_file="$(mktemp)"
+  ONE_CLICK_VERSION_COMPARE_DEBUG=1 semver_compare "release-b" "release-a" > /dev/null 2>"${err_file}"
+  err="$(<"${err_file}")"
+  rm -f "${err_file}"
+
+  [[ "${err}" == *"DEBUG: falling back to lexical version comparison"* ]] || fail "expected debug fallback log, got: ${err}"
+}
+
+test_rc_to_stable_is_upgrade() {
+  assert_lt "v0.4.0-rc1" "v0.4.0"
+  assert_not_lt "v0.4.0" "v0.4.0-rc1"
+}
+
+test_stable_versions_and_true_downgrade() {
+  assert_lt "v0.4.0" "v0.5.0"
+  assert_cmp "v0.5.0" "v0.4.0" "1"
+  assert_not_lt "v0.5.0" "v0.4.0"
+  assert_not_lt "v0.4.0" "v0.4.0"
+}
+
+test_rc_identifier_ordering() {
+  assert_lt "v0.4.0-rc1" "v0.4.0-rc2"
+  assert_not_lt "v0.4.0-rc2" "v0.4.0-rc1"
+  assert_lt "v0.4.0-rc2" "v0.4.0-rc10"
+}
+
+test_optional_v_prefix() {
+  assert_lt "0.4.0" "v0.4.1"
+  assert_cmp "v0.4.0" "0.4.0" "0"
+}
+
+test_build_metadata_is_ignored() {
+  assert_cmp "v0.4.0+build.1" "v0.4.0+build.2" "0"
+  assert_not_lt "v0.4.0+build.1" "v0.4.0+build.2"
+  assert_lt "v0.4.0-rc1+build.1" "v0.4.0+build.2"
+}
+
+test_semver_prerelease_segments() {
+  assert_lt "v0.4.0-alpha" "v0.4.0-alpha.1"
+  assert_lt "v0.4.0-alpha.1" "v0.4.0-alpha.beta"
+  assert_lt "v0.4.0-alpha.9" "v0.4.0-alpha.10"
+}
+
+test_invalid_semver_falls_back_to_lexical() {
+  assert_cmp_without_stderr "release-b" "release-a" "1"
+  assert_cmp_without_stderr "release-a" "release-b" "-1"
+  assert_cmp_without_stderr "v0.4.0" "release-a" "1"
+  assert_debug_fallback_logs
+}
+
+test_rc_to_stable_is_upgrade
+test_stable_versions_and_true_downgrade
+test_rc_identifier_ordering
+test_optional_v_prefix
+test_build_metadata_is_ignored
+test_semver_prerelease_segments
+test_invalid_semver_falls_back_to_lexical
+
+if [[ "${failures}" -gt 0 ]]; then
+  echo "${failures} version compare test(s) failed" >&2
+  exit 1
+fi
+
+echo "version compare tests OK"


### PR DESCRIPTION


Implement full semver comparison in bash for one-click deploy:
- _version_trim_leading_zeroes, _version_compare_numbers
- _version_split_semver, _version_compare_prerelease
- semver_compare, version_lt public API
- Handles prerelease, build metadata, optional v-prefix
- Add comprehensive test suite