### PR TITLE
fix(cubemaster): make AgentHub migrations idempotent

### DIFF
--- a/CubeMaster/pkg/base/dao/migrate/migrations/mysql/0006_template_replica_compat.sql
+++ b/CubeMaster/pkg/base/dao/migrate/migrations/mysql/0006_template_replica_compat.sql
@@ -13,29 +13,56 @@
 
 CALL cubemaster_acquire_migration_lock('cubemaster_migration_0006_template_replica_compat', 60);
 
-ALTER TABLE `t_cube_template_replica`
-  ADD COLUMN `guest_image_version` VARCHAR(128) NOT NULL DEFAULT '' COMMENT 'guest-image version bound when this replica was created',
-  ADD COLUMN `agent_version` VARCHAR(128) NOT NULL DEFAULT '' COMMENT 'cube-agent version bound when this replica was created',
-  ADD COLUMN `kernel_version` VARCHAR(256) NOT NULL DEFAULT '' COMMENT 'kernel artifact identity bound when this replica was created',
-  ADD COLUMN `compat_status` VARCHAR(32) NOT NULL DEFAULT 'UNKNOWN' COMMENT 'template replica compatibility status: OK/STALE/UNKNOWN',
-  ADD COLUMN `compat_policy` VARCHAR(32) NOT NULL DEFAULT 'STRICT' COMMENT 'compatibility policy: STRICT/GUEST_ONLY',
-  ADD COLUMN `compat_checked_unix` BIGINT NOT NULL DEFAULT 0 COMMENT 'last compatibility check unix timestamp';
+CALL cubemaster_assert_table_exists('t_cube_template_replica');
 
-ALTER TABLE `t_cube_template_replica`
-  ADD INDEX `idx_node_compat` (`node_id`, `compat_status`);
+CALL cubemaster_add_column_if_missing(
+  't_cube_template_replica',
+  'guest_image_version',
+  "VARCHAR(128) NOT NULL DEFAULT '' COMMENT 'guest-image version bound when this replica was created'"
+);
+CALL cubemaster_add_column_if_missing(
+  't_cube_template_replica',
+  'agent_version',
+  "VARCHAR(128) NOT NULL DEFAULT '' COMMENT 'cube-agent version bound when this replica was created'"
+);
+CALL cubemaster_add_column_if_missing(
+  't_cube_template_replica',
+  'kernel_version',
+  "VARCHAR(256) NOT NULL DEFAULT '' COMMENT 'kernel artifact identity bound when this replica was created'"
+);
+CALL cubemaster_add_column_if_missing(
+  't_cube_template_replica',
+  'compat_status',
+  "VARCHAR(32) NOT NULL DEFAULT 'UNKNOWN' COMMENT 'template replica compatibility status: OK/STALE/UNKNOWN'"
+);
+CALL cubemaster_add_column_if_missing(
+  't_cube_template_replica',
+  'compat_policy',
+  "VARCHAR(32) NOT NULL DEFAULT 'STRICT' COMMENT 'compatibility policy: STRICT/GUEST_ONLY'"
+);
+CALL cubemaster_add_column_if_missing(
+  't_cube_template_replica',
+  'compat_checked_unix',
+  "BIGINT NOT NULL DEFAULT 0 COMMENT 'last compatibility check unix timestamp'"
+);
+
+CALL cubemaster_add_index_if_missing(
+  't_cube_template_replica',
+  'idx_node_compat',
+  'ADD INDEX `idx_node_compat` (`node_id`, `compat_status`)'
+);
 
 SELECT RELEASE_LOCK('cubemaster_migration_0006_template_replica_compat');
 
 -- +goose Down
 CALL cubemaster_acquire_migration_lock('cubemaster_migration_0006_template_replica_compat', 60);
 
-ALTER TABLE `t_cube_template_replica`
-  DROP INDEX `idx_node_compat`,
-  DROP COLUMN `guest_image_version`,
-  DROP COLUMN `agent_version`,
-  DROP COLUMN `kernel_version`,
-  DROP COLUMN `compat_status`,
-  DROP COLUMN `compat_policy`,
-  DROP COLUMN `compat_checked_unix`;
+CALL cubemaster_drop_index_if_exists('t_cube_template_replica', 'idx_node_compat');
+CALL cubemaster_drop_column_if_exists('t_cube_template_replica', 'compat_checked_unix');
+CALL cubemaster_drop_column_if_exists('t_cube_template_replica', 'compat_policy');
+CALL cubemaster_drop_column_if_exists('t_cube_template_replica', 'compat_status');
+CALL cubemaster_drop_column_if_exists('t_cube_template_replica', 'kernel_version');
+CALL cubemaster_drop_column_if_exists('t_cube_template_replica', 'agent_version');
+CALL cubemaster_drop_column_if_exists('t_cube_template_replica', 'guest_image_version');
 
 SELECT RELEASE_LOCK('cubemaster_migration_0006_template_replica_compat');

--- a/CubeMaster/pkg/base/dao/migrate/migrations/mysql/0008_agenthub_template_persistence_mode.sql
+++ b/CubeMaster/pkg/base/dao/migrate/migrations/mysql/0008_agenthub_template_persistence_mode.sql
@@ -10,6 +10,22 @@
 
 CALL cubemaster_acquire_migration_lock('cubemaster_migration_0008_agenthub_template_persistence_mode', 60);
 
+SET @agenthub_instance_persistence_mode_exists := (
+  SELECT COUNT(*)
+  FROM INFORMATION_SCHEMA.COLUMNS
+  WHERE TABLE_SCHEMA = DATABASE()
+    AND TABLE_NAME = 't_agenthub_instance'
+    AND COLUMN_NAME = 'persistence_mode'
+);
+SET @agenthub_instance_persistence_mode_sql := IF(
+  @agenthub_instance_persistence_mode_exists = 0,
+  'ALTER TABLE `t_agenthub_instance` ADD COLUMN `persistence_mode` varchar(32) DEFAULT NULL AFTER `gateway_token`',
+  'SELECT 1'
+);
+PREPARE stmt FROM @agenthub_instance_persistence_mode_sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
 SET @agenthub_template_persistence_mode_exists := (
   SELECT COUNT(*)
   FROM INFORMATION_SCHEMA.COLUMNS
@@ -51,6 +67,22 @@ SET @agenthub_template_persistence_mode_down_sql := IF(
   'SELECT 1'
 );
 PREPARE stmt FROM @agenthub_template_persistence_mode_down_sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+SET @agenthub_instance_persistence_mode_exists := (
+  SELECT COUNT(*)
+  FROM INFORMATION_SCHEMA.COLUMNS
+  WHERE TABLE_SCHEMA = DATABASE()
+    AND TABLE_NAME = 't_agenthub_instance'
+    AND COLUMN_NAME = 'persistence_mode'
+);
+SET @agenthub_instance_persistence_mode_down_sql := IF(
+  @agenthub_instance_persistence_mode_exists > 0,
+  'ALTER TABLE `t_agenthub_instance` DROP COLUMN `persistence_mode`',
+  'SELECT 1'
+);
+PREPARE stmt FROM @agenthub_instance_persistence_mode_down_sql;
 EXECUTE stmt;
 DEALLOCATE PREPARE stmt;
 


### PR DESCRIPTION
## Summary
- make AgentHub migration 0006 idempotent for partially migrated MySQL databases
- add compatibility handling for persistence mode migration 0008
- avoid duplicate-column / missing-column failures during CubeMaster startup

## Changes
- Update `0006_template_replica_compat.sql` with guarded DDL and compatibility logic
- Update `0008_agenthub_template_persistence_mode.sql` with idempotent migration behavior

## Test
- Not run in this step; PR created from existing latest commit on cubesandbox002: `8aed4f29a017f2dcbb13e1407d6b0acfe5e87d82`
