### PR TITLE
fix(CubeMaster/cli): include missing fields in tpl info

### DIFF
--- a/CubeMaster/cmd/cubemastercli/commands/cubebox/template.go
+++ b/CubeMaster/cmd/cubemastercli/commands/cubebox/template.go
@@ -46,6 +46,9 @@ type templateResponse struct {
 	Version                    string                      `json:"version,omitempty"`
 	Status                     string                      `json:"status,omitempty"`
 	LastError                  string                      `json:"last_error,omitempty"`
+	DisplayName                string                      `json:"display_name,omitempty"`
+	CreatedAt                  string                      `json:"created_at,omitempty"`
+	ImageInfo                  string                      `json:"image_info,omitempty"`
 	Replicas                   []templateReplicaStatus     `json:"replicas,omitempty"`
 	CreateRequest              *types.CreateCubeSandboxReq `json:"create_request,omitempty"`
 	CubeEgressCABaked          bool                        `json:"cube_egress_ca_baked,omitempty"`
@@ -1103,9 +1106,18 @@ var TemplateListCommand = cli.Command{
 
 func printTemplateSummary(rsp *templateResponse) {
 	log.Printf("template_id: %s\n", rsp.TemplateID)
+	if rsp.DisplayName != "" {
+		log.Printf("display_name: %s\n", rsp.DisplayName)
+	}
 	log.Printf("instance_type: %s\n", rsp.InstanceType)
 	log.Printf("version: %s\n", rsp.Version)
 	log.Printf("status: %s\n", rsp.Status)
+	if rsp.CreatedAt != "" {
+		log.Printf("created_at: %s\n", rsp.CreatedAt)
+	}
+	if rsp.ImageInfo != "" {
+		log.Printf("image_info: %s\n", rsp.ImageInfo)
+	}
 	if rsp.LastError != "" {
 		log.Printf("last_error: %s\n", rsp.LastError)
 	}

--- a/CubeMaster/cmd/cubemastercli/commands/cubebox/template_test.go
+++ b/CubeMaster/cmd/cubemastercli/commands/cubebox/template_test.go
@@ -5,7 +5,9 @@
 package cubebox
 
 import (
+	"bytes"
 	"flag"
+	"log"
 	"strings"
 	"testing"
 
@@ -392,5 +394,41 @@ func TestFormatTemplateImageJobWatchHelpersHandleNil(t *testing.T) {
 	}
 	if got := formatTemplateImageJobCompletionSummary(nil); got == "" {
 		t.Fatal("expected non-empty completion summary for nil job")
+	}
+}
+
+func TestPrintTemplateSummaryIncludesOptionalMetadata(t *testing.T) {
+	var logBuf bytes.Buffer
+	oldWriter := log.Writer()
+	log.SetOutput(&logBuf)
+	t.Cleanup(func() {
+		log.SetOutput(oldWriter)
+	})
+
+	stdout := captureStdout(t, func() {
+		printTemplateSummary(&templateResponse{
+			TemplateID:   "tpl-1",
+			DisplayName:  "python-template",
+			InstanceType: "cubebox",
+			Version:      "v2",
+			Status:       "READY",
+			CreatedAt:    "2026-06-17 12:00:00",
+			ImageInfo:    "docker.io/library/python:3.12",
+		})
+	})
+
+	logOutput := logBuf.String()
+	for _, want := range []string{
+		"template_id: tpl-1",
+		"display_name: python-template",
+		"created_at: 2026-06-17 12:00:00",
+		"image_info: docker.io/library/python:3.12",
+	} {
+		if !strings.Contains(logOutput, want) {
+			t.Fatalf("log output=%q, missing %q", logOutput, want)
+		}
+	}
+	if !strings.Contains(stdout, "NODE_ID") {
+		t.Fatalf("stdout=%q, missing replica table header", stdout)
 	}
 }

--- a/CubeMaster/pkg/service/httpservice/cube/template.go
+++ b/CubeMaster/pkg/service/httpservice/cube/template.go
@@ -27,6 +27,9 @@ type templateResponse struct {
 	Version                    string                         `json:"version,omitempty"`
 	Status                     string                         `json:"status,omitempty"`
 	LastError                  string                         `json:"last_error,omitempty"`
+	DisplayName                string                         `json:"display_name,omitempty"`
+	CreatedAt                  string                         `json:"created_at,omitempty"`
+	ImageInfo                  string                         `json:"image_info,omitempty"`
 	Replicas                   []templatecenter.ReplicaStatus `json:"replicas,omitempty"`
 	CreateRequest              *types.CreateCubeSandboxReq    `json:"create_request,omitempty"`
 	CubeEgressCABaked          bool                           `json:"cube_egress_ca_baked,omitempty"`
@@ -255,6 +258,9 @@ func getTemplate(w http.ResponseWriter, r *http.Request, rt *CubeLog.RequestTrac
 		Version:                    info.Version,
 		Status:                     info.Status,
 		LastError:                  info.LastError,
+		DisplayName:                info.DisplayName,
+		CreatedAt:                  info.CreatedAt,
+		ImageInfo:                  info.ImageInfo,
 		Replicas:                   info.Replicas,
 		CreateRequest:              createReq,
 		CubeEgressCABaked:          info.CubeEgressCABaked,

--- a/CubeMaster/pkg/service/httpservice/cube/template_test.go
+++ b/CubeMaster/pkg/service/httpservice/cube/template_test.go
@@ -189,3 +189,34 @@ func TestGetTemplateIncludeRequest(t *testing.T) {
 	}
 	assert.Equal(t, int64(errorcode.ErrorCode_Success), rt.RetCode)
 }
+
+func TestGetTemplateIncludesDisplayMetadata(t *testing.T) {
+	origGetTemplateInfoFn := getTemplateInfoFn
+	t.Cleanup(func() {
+		getTemplateInfoFn = origGetTemplateInfoFn
+	})
+	getTemplateInfoFn = func(ctx context.Context, templateID string) (*templatecenter.TemplateInfo, error) {
+		return &templatecenter.TemplateInfo{
+			TemplateID:   templateID,
+			InstanceType: "cubebox",
+			Version:      "v2",
+			Status:       "READY",
+			DisplayName:  "python-template",
+			CreatedAt:    "2026-06-17 12:00:00",
+			ImageInfo:    "docker.io/library/python:3.12",
+		}, nil
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/cube/template?template_id=tpl-metadata", nil)
+	rt := &CubeLog.RequestTrace{}
+	resp := getTemplate(httptest.NewRecorder(), req, rt)
+
+	got, ok := resp.(*templateResponse)
+	if !ok {
+		t.Fatalf("unexpected response type %T", resp)
+	}
+	assert.Equal(t, "python-template", got.DisplayName)
+	assert.Equal(t, "2026-06-17 12:00:00", got.CreatedAt)
+	assert.Equal(t, "docker.io/library/python:3.12", got.ImageInfo)
+	assert.Equal(t, int64(errorcode.ErrorCode_Success), rt.RetCode)
+}


### PR DESCRIPTION
## Motivation

`cubemastercli tpl info --template-id <ID>` currently omits several basic metadata fields that are populated by `GetTemplateInfo()`, including fields such as `created_at` and `image_info` that are already visible in `tpl list`.

The root cause is that the server-side `templateResponse` struct in the `getTemplate` handler only maps a subset of `templatecenter.TemplateInfo` fields.

## What This PR Changes

**Server side** — `CubeMaster/pkg/service/httpservice/cube/template.go`

* Add `display_name`, `image_info`, and `created_at` to the `templateResponse` struct.
* Map these fields from the `TemplateInfo` returned by `GetTemplateInfo()` in the `getTemplate` handler.

**CLI side** — `CubeMaster/cmd/cubemastercli/commands/cubebox/template.go`

* Add matching fields to the CLI `templateResponse` struct so JSON deserialization captures them.
* Render the new fields in `printTemplateSummary` with conditional guards, like `last_error`.

`printTemplateSummary` is shared by `tpl info`, `tpl create`, and `tpl delete`, so the new fields are only printed when non-empty. This avoids adding empty lines to create/delete output.

## Fields Not Added

This PR does not expose every field from `TemplateInfo`. The following fields are left out because they are either internal, redundant, or lower-value for the normal `tpl info` view:

| Field                           | Reason                                                                  |
| ------------------------------- | ----------------------------------------------------------------------- |
| `kind`                          | Redundant with the template ID prefix (`tpl-` vs `snap-`)               |
| `origin_sandbox_id`             | Only meaningful for snapshot-kind templates; mostly internal            |
| `origin_node_id`                | Same as above                                                           |
| `storage_backend`               | Internal implementation detail                                          |
| `retain`                        | Internal lifecycle flag                                                 |
| `rootfs_size_bytes_at_snapshot` | Internal / low operational value                                        |
| `expose_port`                   | Stored inside request annotations and available via `--include-request` |

## Impact

* `templateResponse` is shared by create/info/delete handlers, but the new fields use `omitempty`, so create/delete JSON responses remain unchanged when these values are empty.
* `printTemplateSummary` is shared by `tpl info`, `tpl create`, and `tpl delete`; conditional rendering prevents empty lines in create/delete output.
* `--json` mode works through the updated response structs on both server and CLI sides.

## Validation

* Confirmed `tpl info` now carries and prints `display_name`, `created_at`, and `image_info`.
* Confirmed the new fields are only printed when non-empty, so `tpl create` and `tpl delete` output are unaffected.
* Added focused regression tests for server-side response mapping and CLI summary output.
