### PR TITLE
fix(CubeMaster): populate tpl info created_at and image_info

### DIFF
--- a/CubeMaster/pkg/templatecenter/store.go
+++ b/CubeMaster/pkg/templatecenter/store.go
@@ -696,6 +696,11 @@ func GetTemplateInfo(ctx context.Context, templateID string) (*TemplateInfo, err
 	}
 	info := templateInfoFromDefinition(*def)
 	out := &info
+	out.CreatedAt = formatUTCRFC3339(def.CreatedAt)
+	out.ImageInfo = extractImageInfoFromRequestJSON(def.RequestJSON)
+	if latestJob, jobErr := getLatestTemplateImageJobByTemplateID(ctx, templateID); jobErr == nil && latestJob != nil {
+		out.ImageInfo = composeImageInfo(latestJob.SourceImageRef, latestJob.SourceImageDigest)
+	}
 	out.Replicas = make([]ReplicaStatus, 0, len(replicas))
 	for _, replica := range replicas {
 		out.Replicas = append(out.Replicas, replicaModelToStatus(replica))

--- a/CubeMaster/pkg/templatecenter/store_test.go
+++ b/CubeMaster/pkg/templatecenter/store_test.go
@@ -10,11 +10,13 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/agiledragon/gomonkey/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/constants"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/db/models"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/node"
 	sandboxtypes "github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/service/sandbox/types"
 	"gorm.io/gorm"
@@ -199,5 +201,50 @@ func TestGetTemplateRequestAssignsRuntimeRequestID(t *testing.T) {
 	}
 	if first.RequestID == second.RequestID {
 		t.Fatalf("expected a fresh runtime requestID per fetch, got duplicate %q", first.RequestID)
+	}
+}
+
+func TestGetTemplateInfoPopulatesCreatedAtAndImageInfoFromDefinitionAndLatestJob(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	createdAt := time.Date(2026, time.June, 17, 15, 53, 40, 0, time.FixedZone("UTC+8", 8*3600))
+	patches.ApplyFunc(GetDefinition, func(ctx context.Context, templateID string) (*models.TemplateDefinition, error) {
+		return &models.TemplateDefinition{
+			TemplateID:   templateID,
+			InstanceType: "cubebox",
+			Version:      "v2",
+			Status:       "READY",
+			RequestJSON: `{
+				"containers":[
+					{"image":{"image":"rfs-deadbeef"}}
+				]
+			}`,
+			Model: gorm.Model{CreatedAt: createdAt},
+		}, nil
+	})
+	patches.ApplyFunc(ListReplicas, func(ctx context.Context, templateID string) ([]models.TemplateReplica, error) {
+		return nil, nil
+	})
+	patches.ApplyFunc(getLatestTemplateImageJobByTemplateID, func(ctx context.Context, templateID string) (*models.TemplateImageJob, error) {
+		return &models.TemplateImageJob{
+			TemplateID:        templateID,
+			SourceImageRef:    "docker.io/library/python:3.12",
+			SourceImageDigest: "sha256:abcd",
+		}, nil
+	})
+
+	info, err := GetTemplateInfo(context.Background(), "tpl-a")
+	if err != nil {
+		t.Fatalf("GetTemplateInfo returned error: %v", err)
+	}
+	if info == nil {
+		t.Fatal("expected template info, got nil")
+	}
+	if info.CreatedAt != "2026-06-17T07:53:40Z" {
+		t.Fatalf("unexpected created_at: %q", info.CreatedAt)
+	}
+	if info.ImageInfo != "docker.io/library/python:3.12@sha256:abcd" {
+		t.Fatalf("unexpected image_info: %q", info.ImageInfo)
 	}
 }


### PR DESCRIPTION
## Motivation

Follow-up to #592.

`tpl info` was updated to expose `display_name`, `created_at`, and `image_info` in the API/CLI response, but real-cluster verification showed that `templatecenter.GetTemplateInfo()` still did not populate the backing `created_at` and `image_info` fields for persisted templates.

As a result, the response/CLI layer was ready, but the data path behind `tpl info` was still incomplete.

## What Changed

* Populate `CreatedAt` from the persisted template definition in `GetTemplateInfo()`.
* Populate `ImageInfo` from the stored request and latest image job, matching the existing `ListTemplates()` behavior.
* Add a focused regression test for the `GetTemplateInfo()` backing-field path.

This makes `tpl info` consistent with `tpl list` for `created_at` and `image_info`.

## Validation

* Real-cluster verification:
  * before the fix, `/cube/template` and `cubemastercli tpl info` still returned empty / omitted values for `created_at` and `image_info`
  * after the fix, both surfaces returned the expected values for the same template
* Added a focused regression test for `GetTemplateInfo()` backing-field population.