### PR TITLE
CubeVS: create inner map with BTF key/value

### DIFF
--- a/CubeNet/cubevs/dnspolicy.go
+++ b/CubeNet/cubevs/dnspolicy.go
@@ -20,6 +20,8 @@ func newInnerDNSAllowMap() (*ebpf.Map, error) {
 		ValueSize:  uint32(unsafe.Sizeof(dnsAllowValue{})),
 		MaxEntries: maxDNSAllowEntries,
 		Flags:      unix.BPF_F_NO_PREALLOC,
+		Key:        btfTypeDNSAllowKey,
+		Value:      btfTypeDNSAllowValue,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("ebpf.NewMap(LPMTrie) failed: %w", err)

--- a/CubeNet/cubevs/miscs.go
+++ b/CubeNet/cubevs/miscs.go
@@ -7,7 +7,24 @@ import (
 	"strings"
 
 	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/btf"
 	"github.com/cilium/ebpf/rlimit"
+)
+
+const (
+	typeNameU32           = "__u32"
+	typeNameLPMKey        = "lpm_key"
+	typeNamePolicyValue   = "net_policy_value_v2"
+	typeNameDNSAllowKey   = "dns_allow_key"
+	typeNameDNSAllowValue = "dns_allow_value"
+)
+
+var (
+	btfTypeU32           btf.Type
+	btfTypeLPMKey        btf.Type
+	btfTypePolicyValue   btf.Type
+	btfTypeDNSAllowKey   btf.Type
+	btfTypeDNSAllowValue btf.Type
 )
 
 func init() {
@@ -134,6 +151,26 @@ func loadObject(params Params, loader func() (*ebpf.CollectionSpec, error), name
 	spec, err := loader()
 	if err != nil {
 		return fmt.Errorf("%s failed: %w", name, err)
+	}
+
+	btfSpec := spec.Types
+	iter := btfSpec.Iterate()
+	for iter.Next() {
+		if iter.Type.TypeName() == typeNameU32 {
+			btfTypeU32 = iter.Type
+		}
+		if iter.Type.TypeName() == typeNameLPMKey {
+			btfTypeLPMKey = iter.Type
+		}
+		if iter.Type.TypeName() == typeNamePolicyValue {
+			btfTypePolicyValue = iter.Type
+		}
+		if iter.Type.TypeName() == typeNameDNSAllowKey {
+			btfTypeDNSAllowKey = iter.Type
+		}
+		if iter.Type.TypeName() == typeNameDNSAllowValue {
+			btfTypeDNSAllowValue = iter.Type
+		}
 	}
 
 	err = populateDNSTailCalls(spec)

--- a/CubeNet/cubevs/netpolicy.go
+++ b/CubeNet/cubevs/netpolicy.go
@@ -8,6 +8,7 @@ import (
 	"unsafe"
 
 	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/btf"
 	"golang.org/x/sys/unix"
 )
 
@@ -23,16 +24,18 @@ var alwaysDeniedSandboxCIDRs = []string{
 
 // newInnerLPMMap creates a new LPM trie map with uint32 values for deny_out.
 func newInnerLPMMap() (*ebpf.Map, error) {
-	return newInnerLPMMapWithValueSize(uint32(unsafe.Sizeof(uint32(0))))
+	return newInnerLPMMapWithValueSize(uint32(unsafe.Sizeof(uint32(0))), btfTypeLPMKey, btfTypeU32)
 }
 
-func newInnerLPMMapWithValueSize(valueSize uint32) (*ebpf.Map, error) {
+func newInnerLPMMapWithValueSize(valueSize uint32, keyType, valueType btf.Type) (*ebpf.Map, error) {
 	m, err := ebpf.NewMap(&ebpf.MapSpec{
 		Type:       ebpf.LPMTrie,
 		KeySize:    uint32(unsafe.Sizeof(lpmKey{})),
 		ValueSize:  valueSize,
 		MaxEntries: maxNetPolicyEntries,
 		Flags:      unix.BPF_F_NO_PREALLOC,
+		Key:        keyType,
+		Value:      valueType,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("ebpf.NewMap(LPMTrie) failed: %w", err)
@@ -41,7 +44,7 @@ func newInnerLPMMapWithValueSize(valueSize uint32) (*ebpf.Map, error) {
 }
 
 func newInnerAllowOutMap() (*ebpf.Map, error) {
-	return newInnerLPMMapWithValueSize(uint32(unsafe.Sizeof(netPolicyValueV2{})))
+	return newInnerLPMMapWithValueSize(uint32(unsafe.Sizeof(netPolicyValueV2{})), btfTypeLPMKey, btfTypePolicyValue)
 }
 
 func ensureAllowOutV2InnerMap(outerMap *ebpf.Map, ifindex uint32) error {
@@ -50,12 +53,6 @@ func ensureAllowOutV2InnerMap(outerMap *ebpf.Map, ifindex uint32) error {
 
 func ensureDenyOutInnerMap(outerMap *ebpf.Map, ifindex uint32) error {
 	return ensureInnerMapWithFactory(outerMap, ifindex, MapNameDenyOut, newInnerLPMMap)
-}
-
-// ensureInnerMap checks whether the outer hash-of-maps already has an
-// inner map for the given ifindex.  If not, it creates one and inserts it.
-func ensureInnerMap(outerMap *ebpf.Map, ifindex uint32, mapName string) error {
-	return ensureInnerMapWithFactory(outerMap, ifindex, mapName, newInnerLPMMap)
 }
 
 func ensureInnerMapWithFactory(outerMap *ebpf.Map, ifindex uint32, mapName string,


### PR DESCRIPTION
User hit the following issue on Ubuntu 22.04 with kernel v5.15:
```
network-agent EnsureNetwork failed: grpc_code=Unknown grpc_msg=map.Put failed: update: invalid argument, name: allow_out_v2
```

This is probably kernel restriction. Workaround it in userspace.

See [1] for some background.

  [1]: https://lore.kernel.org/bpf/20221126105351.2578782-1-hengqi.chen@gmail.com/