### PR TITLE
fix(templatecenter): preserve image uid/gid when building rootfs as root

### DIFF
--- a/CubeMaster/pkg/templatecenter/image/disk.go
+++ b/CubeMaster/pkg/templatecenter/image/disk.go
@@ -129,7 +129,15 @@ func createExt4ImageStreaming(ctx context.Context, source *PreparedSource, workD
 // directory via tar -xf -.
 func pipeExportToDir(ctx context.Context, containerID, destDir string) error {
 	exportCmd := exec.CommandContext(ctx, "docker", "export", containerID)
-	tarCmd := exec.CommandContext(ctx, "tar", "-xf", "-", "-C", destDir)
+	// --same-owner --numeric-owner preserves the image's original uid/gid.
+	// GNU tar restores ownership only with --same-owner (the default for root,
+	// set explicitly to be robust); --numeric-owner avoids name lookups
+	// against the host's passwd/group. Without this, files owned by non-root
+	// uids with restrictive modes (e.g. /home/user uid 1000 mode 0700)
+	// collapse to the extracting user and the in-sandbox account loses access
+	// to its own files (envd exec EACCES, chromium profile write failures).
+	// Mirrors the umoci (no --rootless) fix in export.go.
+	tarCmd := exec.CommandContext(ctx, "tar", "--same-owner", "--numeric-owner", "-xf", "-", "-C", destDir)
 
 	pipe, err := exportCmd.StdoutPipe()
 	if err != nil {

--- a/CubeMaster/pkg/templatecenter/image/export.go
+++ b/CubeMaster/pkg/templatecenter/image/export.go
@@ -65,7 +65,22 @@ func dockerlessExportImageRootfs(ctx context.Context, source *PreparedSource, de
 	}
 
 	umociImageRef := ociLayoutImageRef(ociDir, source.LocalRef)
-	if err := runCommand(ctx, "", "umoci", "unpack", "--rootless", "--image", umociImageRef, bundleDir); err != nil {
+	// Only pass --rootless when we are NOT running as root. --rootless makes
+	// umoci squash every file's owner to the unpacking user (and skip device
+	// nodes), so when cubemaster runs as root it rewrites every image uid/gid
+	// to 0. That silently mutates the image's ownership and breaks any image
+	// relying on non-root-owned files with restrictive modes — e.g. a
+	// python/browser image whose /home/user is uid 1000 mode 0700 becomes
+	// root:root 0700, so the in-sandbox "user" account can no longer access
+	// its own home: envd exec fails (fork/exec /bin/sh EACCES) and chromium
+	// can't write its profile (crash-loop, CDP port never binds). Running as
+	// root without --rootless preserves the image's original uid/gid exactly.
+	umociArgs := []string{"unpack"}
+	if os.Geteuid() != 0 {
+		umociArgs = append(umociArgs, "--rootless")
+	}
+	umociArgs = append(umociArgs, "--image", umociImageRef, bundleDir)
+	if err := runCommand(ctx, "", "umoci", umociArgs...); err != nil {
 		return fmt.Errorf("umoci unpack %s failed: %w", source.LocalRef, err)
 	}
 	// The OCI layout is no longer needed once unpacked; drop it early to reduce


### PR DESCRIPTION
create-from-image squashed every file's owner to root when cubemaster runs as root, silently mutating the source image's ownership. Images that rely on non-root-owned files with restrictive modes broke in the sandbox:

- A python image whose /home/user is uid 1000 mode 0700 became root:root 0700. The in-sandbox "user" account could no longer access its own home, so envd exec failed with `fork/exec /bin/sh: permission denied` (EACCES on the cwd).
- A browser image's Chromium (started by s6 as "user", HOME=/home/user) could not write its profile / crashpad dir, crash-looped, and never bound the remote-debugging port — so CDP was unreachable (502).

Root cause:
- export.go: `umoci unpack --rootless` maps every uid/gid to the unpacking user. Running as root that means uid/gid 0 for everything. Only pass --rootless when euid != 0; as root, unpack without it so umoci preserves the image's original ownership.
- disk.go: the docker-export fallback piped through `tar -xf` without `--same-owner --numeric-owner`, with the same ownership-collapse effect. Add both flags.

Verified on a real cluster: with the fix, a freshly built python-slim template has /home/user back to 1000:1000 and runs commands as the default "user" account, and a browser template's Chromium starts and serves CDP out of the box (both failed before).