### PR TITLE
fix(one-click): persist DATABASE_URL for local MySQL in install and systemd start

### DIFF
--- a/deploy/one-click/install.sh
+++ b/deploy/one-click/install.sh
@@ -1088,6 +1088,15 @@ if [[ -n "${CUBE_EXTERNAL_MYSQL_HOST}" ]]; then
   database_url_port="$(urlencode "${CUBE_EXTERNAL_MYSQL_PORT}")"
   database_url_db="$(urlencode "${CUBE_EXTERNAL_MYSQL_DB}")"
   upsert_env_kv "${RUNTIME_ENV_FILE}" "DATABASE_URL" "mysql://${database_url_user}:${database_url_pass}@${database_url_host}:${database_url_port}/${database_url_db}"
+else
+  # Local MySQL (bundled container): persist DATABASE_URL so CubeAPI and other
+  # components can reach the database without relying on per-script defaults.
+  local_mysql_host="127.0.0.1"
+  local_mysql_port="${CUBE_SANDBOX_MYSQL_PORT:-3306}"
+  local_mysql_user="${CUBE_SANDBOX_MYSQL_USER:-cube}"
+  local_mysql_password="${CUBE_SANDBOX_MYSQL_PASSWORD:-cube_pass}"
+  local_mysql_db="${CUBE_SANDBOX_MYSQL_DB:-cube_mvp}"
+  upsert_env_kv "${RUNTIME_ENV_FILE}" "DATABASE_URL" "mysql://$(urlencode "${local_mysql_user}"):$(urlencode "${local_mysql_password}")@$(urlencode "${local_mysql_host}"):$(urlencode "${local_mysql_port}")/$(urlencode "${local_mysql_db}")"
 fi
 
 # Persist external Redis config. cube-proxy reads CUBE_PROXY_REDIS_* from the

--- a/deploy/one-click/scripts/systemd/cube-api-start.sh
+++ b/deploy/one-click/scripts/systemd/cube-api-start.sh
@@ -25,5 +25,15 @@ fi
 if [[ -n "${AUTH_CALLBACK_URL:-}" ]]; then
   export AUTH_CALLBACK_URL
 fi
+if [[ -n "${DATABASE_URL:-}" ]]; then
+  export DATABASE_URL
+else
+  mysql_host="${CUBE_SANDBOX_MYSQL_HOST:-127.0.0.1}"
+  mysql_port="${CUBE_SANDBOX_MYSQL_PORT:-3306}"
+  mysql_user="${CUBE_SANDBOX_MYSQL_USER:-cube}"
+  mysql_password="${CUBE_SANDBOX_MYSQL_PASSWORD:-cube_pass}"
+  mysql_db="${CUBE_SANDBOX_MYSQL_DB:-cube_mvp}"
+  export DATABASE_URL="mysql://${mysql_user}:${mysql_password}@${mysql_host}:${mysql_port}/${mysql_db}"
+fi
 
 exec "${CUBE_API_BIN}"


### PR DESCRIPTION
## Summary

Persist `DATABASE_URL` for local MySQL in both the one-click install script and the CubeAPI systemd service, so components can reach the database without relying on per-script defaults.

## Changes

- **deploy/one-click/install.sh**: For local MySQL (bundled container), write `DATABASE_URL` into `RUNTIME_ENV_FILE` with the configured (or default) `CUBE_SANDBOX_MYSQL_*` values.
- **deploy/one-click/scripts/systemd/cube-api-start.sh**: If `DATABASE_URL` is not already set (e.g. from the env file), construct it from the `CUBE_SANDBOX_MYSQL_*` environment variables at service start.