### PR TITLE
CubeVS: fix invalid TCP checksum on port-mapped sandbox replies

### DIFF
--- a/CubeNet/src/tcp.h
+++ b/CubeNet/src/tcp.h
@@ -234,7 +234,8 @@ static __always_inline long snat_tcp(struct __sk_buff *skb,
 	if (err)
 		return err;
 
-	flags = BPF_F_PSEUDO_HDR | sizeof(listen_port);
+	/* update TCP csum for port change (not part of pseudo-header) */
+	flags = sizeof(listen_port);
 	err = bpf_l4_csum_replace(skb, offset, listen_port, host_port, flags);
 	if (err)
 		return err;


### PR DESCRIPTION
Running SDK code through cube-proxy failed with HTTP 504 Gateway Time-out on /execute. Sandbox creation and in-guest health checks succeeded, but cube-proxy could not complete a TCP connection to the sandbox host port on the compute node:

```
  File "/usr/local/lib/python3.11/site-packages/cubesandbox/sandbox.py", line 310, in run_code
    raise ApiError(f"execute failed: HTTP {resp.status_code}", resp.status_code)
cubesandbox._exceptions.ApiError: execute failed: HTTP 504

# testcase:
cat <<EOF > /tmp/demo.py
from cubesandbox import Sandbox

with Sandbox.create() as sb:
  result = sb.run_code("1 + 1")
  print(result.text)   # "2
EOF
python3 /tmp/demo.py
```

Packet captures showed the inbound SYN arriving with a correct checksum, while the returning SYN-ACK left the node with an invalid TCP checksum. The receiving TKE pod silently dropped it, so the handshake never finished and the connection timed out. VPC routing, security groups, and the eBPF DNAT path were ruled out, as host-stack traffic to the same pod was unaffected; only eBPF-generated replies on the port-mapping path were corrupted.

The corruption was specific to the cross-node port-mapped reply path, which is why same-node access and other NAT paths kept working. This restores end-to-end cube-proxy to sandbox connectivity.

Debugged-by: Cursor:claude-opus-4.8