### PR TITLE
pci: msix: harden MSI-X table/PBA access against guest-triggered panics

### DIFF
--- a/hypervisor/pci/src/msix.rs
+++ b/hypervisor/pci/src/msix.rs
@@ -207,6 +207,12 @@ impl MsixConfig {
         let index: usize = (offset / MSIX_TABLE_ENTRIES_MODULO) as usize;
         let modulo_offset = offset % MSIX_TABLE_ENTRIES_MODULO;
 
+        if index >= self.table_entries.len() {
+            debug!("Invalid MSI-X table entry index {index}");
+            data.copy_from_slice(&[0xff; 8][..data.len()]);
+            return;
+        }
+
         match data.len() {
             4 => {
                 let value = match modulo_offset {
@@ -253,6 +259,11 @@ impl MsixConfig {
 
         let index: usize = (offset / MSIX_TABLE_ENTRIES_MODULO) as usize;
         let modulo_offset = offset % MSIX_TABLE_ENTRIES_MODULO;
+
+        if index >= self.table_entries.len() {
+            debug!("Invalid MSI-X table entry index {index}");
+            return;
+        }
 
         // Store the value of the entry before modification
         let old_entry = self.table_entries[index].clone();
@@ -343,6 +354,12 @@ impl MsixConfig {
 
         let index: usize = (offset / MSIX_PBA_ENTRIES_MODULO) as usize;
         let modulo_offset = offset % MSIX_PBA_ENTRIES_MODULO;
+
+        if index >= self.pba_entries.len() {
+            debug!("Invalid MSI-X PBA entry index {index}");
+            data.copy_from_slice(&[0xff; 8][..data.len()]);
+            return;
+        }
 
         match data.len() {
             4 => {

--- a/hypervisor/pci/src/msix.rs
+++ b/hypervisor/pci/src/msix.rs
@@ -202,7 +202,14 @@ impl MsixConfig {
     }
 
     pub fn read_table(&self, offset: u64, data: &mut [u8]) {
-        assert!((data.len() == 4 || data.len() == 8));
+        if data.len() != 4 && data.len() != 8 {
+            error!(
+                "invalid MSI-X table read size: {} (allowed: 4 or 8)",
+                data.len()
+            );
+            data.fill(0xff);
+            return;
+        }
 
         let index: usize = (offset / MSIX_TABLE_ENTRIES_MODULO) as usize;
         let modulo_offset = offset % MSIX_TABLE_ENTRIES_MODULO;
@@ -356,7 +363,14 @@ impl MsixConfig {
     }
 
     pub fn read_pba(&mut self, offset: u64, data: &mut [u8]) {
-        assert!((data.len() == 4 || data.len() == 8));
+        if data.len() != 4 && data.len() != 8 {
+            error!(
+                "invalid MSI-X PBA read size: {} (allowed: 4 or 8)",
+                data.len()
+            );
+            data.fill(0xff);
+            return;
+        }
 
         let index: usize = (offset / MSIX_PBA_ENTRIES_MODULO) as usize;
         let modulo_offset = offset % MSIX_PBA_ENTRIES_MODULO;

--- a/hypervisor/pci/src/msix.rs
+++ b/hypervisor/pci/src/msix.rs
@@ -255,7 +255,13 @@ impl MsixConfig {
     }
 
     pub fn write_table(&mut self, offset: u64, data: &[u8]) {
-        assert!((data.len() == 4 || data.len() == 8));
+        if data.len() != 4 && data.len() != 8 {
+            error!(
+                "invalid MSI-X table write size: {} (allowed: 4 or 8)",
+                data.len()
+            );
+            return;
+        }
 
         let index: usize = (offset / MSIX_TABLE_ENTRIES_MODULO) as usize;
         let modulo_offset = offset % MSIX_TABLE_ENTRIES_MODULO;


### PR DESCRIPTION
# pci: msix: harden MSI-X table/PBA access against guest-triggered panics

A security report (privately disclosed) pointed out that a guest can crash
its own VMM process via the PCI MSI-X handling: an MSI-X table/PBA MMIO access
whose computed index lands past the end of the allocated arrays triggers a Rust
out-of-bounds panic (e.g. `read_table` / `write_table` / `read_pba` in
`pci/src/msix.rs`).

This is a guest self-DoS only — no host escape or memory disclosure. The same
issue was already fixed upstream in cloud-hypervisor; this PR syncs those fixes.

## Changes (3 commits, ported from upstream)

- `78a30012f` — validate index before accessing MSI-X arrays (bounds-check
  `table_entries` / `pba_entries`; the reported OOB).
- `7fbc5a135` — replace `assert!()` with a graceful error on invalid
  (mis-sized) table writes.
- `61193de6e` — same treatment for mis-sized table/PBA reads.

The last two close a sibling vector: a 1/2-byte MMIO access to the MSI-X region
would otherwise hit the size `assert!()` and panic.

Each commit keeps the original upstream author and message, with an
`upstream commit: <sha>` reference.

## Impact

Guest-triggerable DoS of the VMM/shim process; behavior now matches upstream.