### PR TITLE
feat(migrate): enforce immutable migration identities via UTC timestamps, out-of-order application, and content fingerprinting

### DIFF
--- a/.github/workflows/migration-check.yml
+++ b/.github/workflows/migration-check.yml
@@ -1,0 +1,132 @@
+name: Migration Check
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - 'CubeMaster/pkg/base/dao/migrate/**'
+      - '.github/workflows/migration-check.yml'
+  push:
+    branches: [master]
+    paths:
+      - 'CubeMaster/pkg/base/dao/migrate/**'
+      - '.github/workflows/migration-check.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: migration-check-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  migration-check:
+    name: Migration naming & immutability
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: CubeMaster/go.mod
+          cache-dependency-path: CubeMaster/go.sum
+
+      - name: Validate migration filenames
+        shell: bash
+        working-directory: CubeMaster
+        run: |
+          set -euo pipefail
+          go test ./pkg/base/dao/migrate/ \
+            -run 'TestMigrationFilenames|TestMigrationsDirHasReadme' -v
+
+      - name: Reject changes to already-merged migrations
+        # Applied migrations are immutable: goose tracks them by integer version
+        # only, so editing/renaming/deleting a merged migration silently changes
+        # what new environments apply (or skips it entirely). Only NEW migration
+        # files (status A) are allowed; M/D/R on existing *.sql is rejected.
+        # Runs on both PRs and direct pushes to master so the rule cannot be
+        # bypassed by pushing straight to a branch.
+        shell: bash
+        env:
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PUSH_BEFORE_SHA: ${{ github.event.before }}
+          PUSH_AFTER_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+
+          migrations_dir="CubeMaster/pkg/base/dao/migrate/migrations"
+
+          if [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]]; then
+            base_sha="${PR_BASE_SHA}"
+            head_sha="${PR_HEAD_SHA}"
+          elif [[ "${GITHUB_EVENT_NAME}" == "push" ]]; then
+            base_sha="${PUSH_BEFORE_SHA}"
+            head_sha="${PUSH_AFTER_SHA}"
+          else
+            echo "Event ${GITHUB_EVENT_NAME} has no diff base; skipping immutability check."
+            exit 0
+          fi
+
+          # New branch / initial push: no meaningful base to diff against.
+          if [[ -z "${base_sha}" || "${base_sha}" == "0000000000000000000000000000000000000000" ]]; then
+            echo "No base ref to diff against; skipping immutability check."
+            exit 0
+          fi
+
+          # On a force-push, github.event.before can point at a commit that is no
+          # longer reachable (orphaned/gc'd), which would make `git diff` fail or
+          # behave oddly. Verify the base is present; if not, fall back to the
+          # merge-base with origin/master, and skip only if even that is absent.
+          if ! git cat-file -e "${base_sha}^{commit}" 2>/dev/null; then
+            echo "::warning::base ${base_sha} is unreachable (likely a force-push); falling back to merge-base."
+            git fetch --no-tags --depth=1 origin master 2>/dev/null || true
+            if fallback_base="$(git merge-base "${head_sha}" origin/master 2>/dev/null)" && [[ -n "${fallback_base}" ]]; then
+              base_sha="${fallback_base}"
+            else
+              echo "::warning::No reachable base to diff against; skipping immutability check."
+              exit 0
+            fi
+          fi
+
+          # --find-renames so a rename shows up as R (which we reject), not as
+          # an add+delete pair.
+          changes="$(git diff --name-status --find-renames "${base_sha}" "${head_sha}" -- "${migrations_dir}")"
+
+          if [[ -z "${changes}" ]]; then
+            echo "No migration file changes."
+            exit 0
+          fi
+
+          printf 'Migration changes:\n%s\n\n' "${changes}"
+
+          violations=0
+          while IFS=$'\t' read -r status path rest; do
+            [[ -n "${status}" ]] || continue
+            # Only police versioned .sql migrations; docs/README may change.
+            case "${status}" in
+              A*)
+                # New file: allowed.
+                ;;
+              M*|D*|R*|C*)
+                # For renames/copies the original path is in $path.
+                if [[ "${path}" == *.sql ]]; then
+                  echo "::error file=${path}::Forbidden change (${status}) to an already-merged migration: ${path}. Applied migrations are immutable; add a new timestamped migration instead."
+                  violations=$((violations + 1))
+                fi
+                ;;
+            esac
+          done <<< "${changes}"
+
+          if [[ "${violations}" -gt 0 ]]; then
+            echo ""
+            echo "::error::${violations} forbidden migration change(s). See CubeMaster/pkg/base/dao/migrate/migrations/mysql/README.md"
+            exit 1
+          fi
+
+          echo "All migration changes are additive (new files only)."

--- a/CubeMaster/pkg/base/dao/migrate/fingerprint.go
+++ b/CubeMaster/pkg/base/dao/migrate/fingerprint.go
@@ -34,6 +34,7 @@ import (
 	"crypto/sha256"
 	"database/sql"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"io/fs"
 	"log"
@@ -59,6 +60,10 @@ const (
 	// disables the preflight check (recording still happens).
 	skipFingerprintEnv = "CUBEMASTER_MIGRATION_SKIP_FINGERPRINT_CHECK"
 )
+
+// ErrFingerprintMismatch is returned by the preflight check when the on-disk
+// content of an already-applied migration differs from the recorded fingerprint.
+var ErrFingerprintMismatch = errors.New("migration fingerprint check failed")
 
 // fileFingerprint is the on-disk view of a single migration file.
 type fileFingerprint struct {
@@ -236,8 +241,7 @@ func preflightFingerprints(
 	// Operational visibility: surface applied versions that have no fingerprint
 	// baseline (typically migrations applied before this feature existed, or one
 	// that lost its fingerprint to a partial-failure gap). They are NOT
-	// protected against silent content changes. See REMEDIATION.md for how to
-	// establish a one-time baseline.
+	// protected against silent content changes.
 	logUnprotectedVersions(applied, stored)
 
 	if len(stored) == 0 {
@@ -273,11 +277,11 @@ func preflightFingerprints(
 	}
 	sort.Strings(mismatches)
 	return fmt.Errorf(
-		"migration fingerprint check failed: an already-applied migration "+
+		"%w: an already-applied migration "+
 			"version was modified or reused, which goose would otherwise skip "+
 			"SILENTLY. Never edit/rename/reuse an applied migration; add a new "+
 			"timestamped migration instead. To bypass intentionally, set %s=1.\n  - %s",
-		skipFingerprintEnv, strings.Join(mismatches, "\n  - "),
+		ErrFingerprintMismatch, skipFingerprintEnv, strings.Join(mismatches, "\n  - "),
 	)
 }
 
@@ -302,7 +306,7 @@ func logUnprotectedVersions(applied map[int64]bool, stored map[int64]storedFinge
 	}
 	log.Printf("migrate: %d applied migration version(s) have no fingerprint "+
 		"baseline and are NOT content-checked (e.g. applied before fingerprinting "+
-		"existed): %s. See REMEDIATION.md to establish a baseline.",
+		"existed): %s",
 		len(unprotected), strings.Join(strs, ","))
 }
 

--- a/CubeMaster/pkg/base/dao/migrate/fingerprint.go
+++ b/CubeMaster/pkg/base/dao/migrate/fingerprint.go
@@ -1,0 +1,346 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package migrate
+
+// This file implements the "content fingerprint" defence layer described in
+// migrations/mysql/README.md.
+//
+// goose identifies a migration solely by the integer version parsed from its
+// filename. Once a version integer is recorded in goose_db_version, goose never
+// re-reads that file and never compares its content. That makes the following
+// failure mode SILENT: a developer reuses an integer version (e.g. via a rebase
+// rename) for a different file, and the new content is skipped forever.
+//
+// The fingerprint table records the sha256 of every migration that goose has
+// ACTUALLY applied. On every start, we verify that the on-disk content of each
+// currently-applied & previously-fingerprinted version still matches. A
+// mismatch turns the silent skip into a loud, actionable startup error.
+//
+// We deliberately do NOT backfill fingerprints for versions that were applied
+// before this feature existed: we have no record of what was truly applied, so
+// recording the current on-disk content would give false confidence and could
+// mask an environment that is already in the bad state.
+//
+// All SQL below is MySQL-specific (ON DUPLICATE KEY UPDATE, information_schema,
+// DATABASE(), ENGINE=InnoDB). It is gated behind dialectSpec.fingerprints.
+// BEFORE adding a second dialect, extract a fingerprintStore interface
+// (ensureTable / loadStored / currentlyApplied / recordOne) and provide a
+// per-dialect implementation rather than branching inside these functions.
+
+import (
+	"context"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/hex"
+	"fmt"
+	"io/fs"
+	"log"
+	"os"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/pressly/goose/v3"
+)
+
+const (
+	// fingerprintTable stores one row per migration version that goose has
+	// applied, together with the sha256 of the file content at apply time.
+	fingerprintTable = "t_cubemaster_migration_fingerprint"
+
+	// gooseVersionTable is goose's own bookkeeping table. We only read it.
+	gooseVersionTable = "goose_db_version"
+
+	// skipFingerprintEnv lets an operator bypass the content check when they
+	// intentionally need to change an already-applied migration (rare; an
+	// applied migration is supposed to be immutable). Any non-empty value
+	// disables the preflight check (recording still happens).
+	skipFingerprintEnv = "CUBEMASTER_MIGRATION_SKIP_FINGERPRINT_CHECK"
+)
+
+// fileFingerprint is the on-disk view of a single migration file.
+type fileFingerprint struct {
+	version int64
+	source  string // base filename, e.g. "0001_baseline_v0_2_2.sql"
+	sum     string // hex-encoded sha256 of the raw file bytes
+}
+
+// collectFSFingerprints enumerates the embedded migrations FS and returns a map
+// of version -> fileFingerprint. Files without a valid numeric version component
+// are ignored (mirroring goose's own collection rules).
+//
+// File discovery deliberately uses the SAME fs.Glob("*.sql") pattern goose uses
+// in collectFilesystemSources (provider_collect.go), not fs.ReadDir. Keeping the
+// two enumerations identical guarantees we fingerprint exactly the set of files
+// goose can apply, so goose can never apply a version we failed to collect.
+func collectFSFingerprints(subFS fs.FS) (map[int64]fileFingerprint, error) {
+	matches, err := fs.Glob(subFS, "*.sql")
+	if err != nil {
+		return nil, fmt.Errorf("glob migrations: %w", err)
+	}
+	out := make(map[int64]fileFingerprint, len(matches))
+	for _, name := range matches {
+		version, verr := goose.NumericComponent(name)
+		if verr != nil {
+			// Not a versioned migration file; ignore like goose does.
+			continue
+		}
+		if existing, ok := out[version]; ok {
+			// Mirror goose's duplicate-version guard so the failure mode is a
+			// clear error rather than a silently-dropped migration.
+			return nil, fmt.Errorf(
+				"duplicate migration version %d on disk: %q and %q",
+				version, existing.source, name,
+			)
+		}
+		b, rerr := fs.ReadFile(subFS, name)
+		if rerr != nil {
+			return nil, fmt.Errorf("read migration %q: %w", name, rerr)
+		}
+		sum := sha256.Sum256(b)
+		out[version] = fileFingerprint{
+			version: version,
+			source:  name,
+			sum:     hex.EncodeToString(sum[:]),
+		}
+	}
+	return out, nil
+}
+
+// ensureFingerprintTable idempotently creates the fingerprint bookkeeping
+// table. Created outside goose (like goose creates goose_db_version) so it is
+// available for the preflight that runs before goose.Up.
+func ensureFingerprintTable(ctx context.Context, db *sql.DB) error {
+	_, err := db.ExecContext(ctx, `CREATE TABLE IF NOT EXISTS `+fingerprintTable+` (
+  version bigint NOT NULL,
+  sha256 char(64) NOT NULL,
+  source varchar(255) NOT NULL DEFAULT '',
+  created_at datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (version)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4`)
+	if err != nil {
+		return fmt.Errorf("ensure %s: %w", fingerprintTable, err)
+	}
+	return nil
+}
+
+// storedFingerprint is a row from the fingerprint table.
+type storedFingerprint struct {
+	sum    string
+	source string
+}
+
+// loadStoredFingerprints returns the recorded fingerprints keyed by version.
+func loadStoredFingerprints(ctx context.Context, db *sql.DB) (map[int64]storedFingerprint, error) {
+	rows, err := db.QueryContext(ctx,
+		`SELECT version, sha256, source FROM `+fingerprintTable)
+	if err != nil {
+		return nil, fmt.Errorf("load fingerprints: %w", err)
+	}
+	defer rows.Close()
+	out := map[int64]storedFingerprint{}
+	for rows.Next() {
+		var v int64
+		var sum, source string
+		if err := rows.Scan(&v, &sum, &source); err != nil {
+			return nil, fmt.Errorf("scan fingerprint: %w", err)
+		}
+		out[v] = storedFingerprint{sum: sum, source: source}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate fingerprints: %w", err)
+	}
+	return out, nil
+}
+
+// currentlyAppliedVersions returns the set of versions whose most recent
+// goose_db_version row marks them as applied. If goose has not created its
+// version table yet (fresh database), it returns an empty set with no error.
+func currentlyAppliedVersions(ctx context.Context, db *sql.DB) (map[int64]bool, error) {
+	exists, err := tableExists(ctx, db, gooseVersionTable)
+	if err != nil {
+		return nil, err
+	}
+	if !exists {
+		return map[int64]bool{}, nil
+	}
+	// For each version_id keep only the latest row (max id) and require it to
+	// be applied. This mirrors goose's own "latest row wins" semantics, so a
+	// version that was applied and later rolled back (Down) is NOT reported as
+	// applied here.
+	rows, err := db.QueryContext(ctx, `
+SELECT g.version_id
+FROM `+gooseVersionTable+` g
+JOIN (
+  SELECT version_id, MAX(id) AS max_id
+  FROM `+gooseVersionTable+`
+  GROUP BY version_id
+) latest ON g.id = latest.max_id
+WHERE g.is_applied = 1`)
+	if err != nil {
+		return nil, fmt.Errorf("list applied versions: %w", err)
+	}
+	defer rows.Close()
+	out := map[int64]bool{}
+	for rows.Next() {
+		var v int64
+		if err := rows.Scan(&v); err != nil {
+			return nil, fmt.Errorf("scan applied version: %w", err)
+		}
+		out[v] = true
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate applied versions: %w", err)
+	}
+	return out, nil
+}
+
+func tableExists(ctx context.Context, db *sql.DB, name string) (bool, error) {
+	var n int
+	err := db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM information_schema.tables
+		  WHERE table_schema = DATABASE() AND table_name = ?`, name).Scan(&n)
+	if err != nil {
+		return false, fmt.Errorf("check table %q exists: %w", name, err)
+	}
+	return n > 0, nil
+}
+
+// preflightFingerprints fails fast if any currently-applied, previously-
+// fingerprinted version has different content on disk than what was recorded
+// when it was applied. This is the loud replacement for goose's silent skip.
+//
+// Versions that are NOT currently applied are intentionally skipped: this lets
+// the operator remediation runbook (delete a goose_db_version row to force a
+// re-apply) work without tripping the check.
+func preflightFingerprints(
+	ctx context.Context,
+	db *sql.DB,
+	fsFP map[int64]fileFingerprint,
+) error {
+	if v := os.Getenv(skipFingerprintEnv); v != "" {
+		return nil
+	}
+	applied, err := currentlyAppliedVersions(ctx, db)
+	if err != nil {
+		return err
+	}
+	stored, err := loadStoredFingerprints(ctx, db)
+	if err != nil {
+		return err
+	}
+
+	// Operational visibility: surface applied versions that have no fingerprint
+	// baseline (typically migrations applied before this feature existed, or one
+	// that lost its fingerprint to a partial-failure gap). They are NOT
+	// protected against silent content changes. See REMEDIATION.md for how to
+	// establish a one-time baseline.
+	logUnprotectedVersions(applied, stored)
+
+	if len(stored) == 0 {
+		return nil
+	}
+
+	var mismatches []string
+	for version, sf := range stored {
+		if !applied[version] {
+			continue
+		}
+		ff, ok := fsFP[version]
+		if !ok {
+			// A previously-applied migration file vanished from the tree. That
+			// is itself a dangerous change (renames/deletes of applied
+			// migrations are forbidden) and worth surfacing.
+			mismatches = append(mismatches, fmt.Sprintf(
+				"version %d: applied file %q is missing from the migrations tree",
+				version, sf.source,
+			))
+			continue
+		}
+		if ff.sum != sf.sum {
+			mismatches = append(mismatches, fmt.Sprintf(
+				"version %d: content changed since it was applied "+
+					"(recorded %q sha256=%s, on-disk %q sha256=%s)",
+				version, sf.source, sf.sum, ff.source, ff.sum,
+			))
+		}
+	}
+	if len(mismatches) == 0 {
+		return nil
+	}
+	sort.Strings(mismatches)
+	return fmt.Errorf(
+		"migration fingerprint check failed: an already-applied migration "+
+			"version was modified or reused, which goose would otherwise skip "+
+			"SILENTLY. Never edit/rename/reuse an applied migration; add a new "+
+			"timestamped migration instead. To bypass intentionally, set %s=1.\n  - %s",
+		skipFingerprintEnv, strings.Join(mismatches, "\n  - "),
+	)
+}
+
+// logUnprotectedVersions emits a single concise line listing currently-applied
+// versions that have no stored fingerprint and are therefore not covered by the
+// content-drift check. Empty input is a no-op (fresh database, or every applied
+// version is already fingerprinted).
+func logUnprotectedVersions(applied map[int64]bool, stored map[int64]storedFingerprint) {
+	var unprotected []int64
+	for v := range applied {
+		if _, ok := stored[v]; !ok {
+			unprotected = append(unprotected, v)
+		}
+	}
+	if len(unprotected) == 0 {
+		return
+	}
+	sort.Slice(unprotected, func(i, j int) bool { return unprotected[i] < unprotected[j] })
+	strs := make([]string, 0, len(unprotected))
+	for _, v := range unprotected {
+		strs = append(strs, strconv.FormatInt(v, 10))
+	}
+	log.Printf("migrate: %d applied migration version(s) have no fingerprint "+
+		"baseline and are NOT content-checked (e.g. applied before fingerprinting "+
+		"existed): %s. See REMEDIATION.md to establish a baseline.",
+		len(unprotected), strings.Join(strs, ","))
+}
+
+// recordFingerprints upserts the fingerprint for every version that goose
+// reported as successfully applied in this run. We only record what was
+// actually applied (no backfill of historical versions).
+func recordFingerprints(
+	ctx context.Context,
+	db *sql.DB,
+	fsFP map[int64]fileFingerprint,
+	results []*goose.MigrationResult,
+) error {
+	for _, r := range results {
+		if r == nil || r.Error != nil || r.Source == nil {
+			continue
+		}
+		ff, ok := fsFP[r.Source.Version]
+		if !ok {
+			// Should not happen: file discovery is aligned with goose
+			// (fs.Glob), so any version goose applied must be collectable. If
+			// it ever does happen, do NOT stay silent — that version would lose
+			// content-drift protection, defeating this defence layer. We log
+			// loudly rather than failing startup of an otherwise-successful
+			// migration run.
+			log.Printf("migrate: WARNING: applied migration version %d (%q) "+
+				"has no on-disk fingerprint source; it will NOT be protected "+
+				"against silent content changes",
+				r.Source.Version, r.Source.Path)
+			continue
+		}
+		if _, err := db.ExecContext(ctx,
+			`INSERT INTO `+fingerprintTable+` (version, sha256, source)
+			 VALUES (?, ?, ?)
+			 ON DUPLICATE KEY UPDATE sha256 = VALUES(sha256), source = VALUES(source)`,
+			ff.version, ff.sum, ff.source,
+		); err != nil {
+			return fmt.Errorf("record fingerprint for version %d: %w", ff.version, err)
+		}
+	}
+	return nil
+}

--- a/CubeMaster/pkg/base/dao/migrate/fingerprint_internal_test.go
+++ b/CubeMaster/pkg/base/dao/migrate/fingerprint_internal_test.go
@@ -1,0 +1,136 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package migrate
+
+import (
+	"fmt"
+	"io/fs"
+	"testing"
+	"testing/fstest"
+
+	"github.com/pressly/goose/v3"
+)
+
+// TestAppliedResults_PartialError proves we recover the successfully-applied
+// migrations from goose's PartialError (where Up returns nil results), so a
+// partial/interrupted run still fingerprints what actually applied.
+func TestAppliedResults_PartialError(t *testing.T) {
+	mkResult := func(v int64) *goose.MigrationResult {
+		return &goose.MigrationResult{Source: &goose.Source{Version: v}}
+	}
+
+	t.Run("success returns results", func(t *testing.T) {
+		results := []*goose.MigrationResult{mkResult(1), mkResult(2)}
+		got := appliedResults(results, nil)
+		if len(got) != 2 {
+			t.Fatalf("expected 2 applied, got %d", len(got))
+		}
+	})
+
+	t.Run("partial error returns Applied", func(t *testing.T) {
+		applied := []*goose.MigrationResult{mkResult(1)}
+		pErr := &goose.PartialError{
+			Applied: applied,
+			Failed:  mkResult(2),
+			Err:     fmt.Errorf("boom"),
+		}
+		// goose returns (nil, *PartialError) on partial failure.
+		got := appliedResults(nil, pErr)
+		if len(got) != 1 || got[0].Source.Version != 1 {
+			t.Fatalf("expected version 1 from PartialError.Applied, got %+v", got)
+		}
+	})
+
+	t.Run("wrapped partial error is unwrapped", func(t *testing.T) {
+		applied := []*goose.MigrationResult{mkResult(7)}
+		pErr := &goose.PartialError{Applied: applied, Failed: mkResult(8), Err: fmt.Errorf("x")}
+		wrapped := fmt.Errorf("migrate: %w", pErr)
+		got := appliedResults(nil, wrapped)
+		if len(got) != 1 || got[0].Source.Version != 7 {
+			t.Fatalf("expected version 7 from wrapped PartialError, got %+v", got)
+		}
+	})
+
+	t.Run("non-partial error returns results as-is", func(t *testing.T) {
+		results := []*goose.MigrationResult{mkResult(3)}
+		got := appliedResults(results, fmt.Errorf("some other error"))
+		if len(got) != 1 || got[0].Source.Version != 3 {
+			t.Fatalf("expected version 3, got %+v", got)
+		}
+	})
+}
+
+// TestCollectFSFingerprints_RealMigrations verifies the embedded migration set
+// is fingerprintable and deterministic (no docker required).
+func TestCollectFSFingerprints_RealMigrations(t *testing.T) {
+	spec := dialectSpecs["mysql"]
+	subFS, err := fs.Sub(spec.rootFS, spec.subdir)
+	if err != nil {
+		t.Fatalf("fs.Sub: %v", err)
+	}
+
+	fp, err := collectFSFingerprints(subFS)
+	if err != nil {
+		t.Fatalf("collectFSFingerprints: %v", err)
+	}
+	if len(fp) == 0 {
+		t.Fatal("expected at least one migration fingerprint")
+	}
+	// The frozen baseline must be present and parsed as version 1.
+	if _, ok := fp[1]; !ok {
+		t.Errorf("missing fingerprint for baseline version 1")
+	}
+	for v, f := range fp {
+		if f.version != v {
+			t.Errorf("version key %d != fingerprint.version %d", v, f.version)
+		}
+		if len(f.sum) != 64 {
+			t.Errorf("version %d: sha256 hex must be 64 chars, got %d", v, len(f.sum))
+		}
+	}
+
+	// Deterministic: a second pass yields identical sums.
+	again, err := collectFSFingerprints(subFS)
+	if err != nil {
+		t.Fatalf("collectFSFingerprints (2nd): %v", err)
+	}
+	for v, f := range fp {
+		if again[v].sum != f.sum {
+			t.Errorf("version %d sum not deterministic: %s vs %s", v, f.sum, again[v].sum)
+		}
+	}
+}
+
+// TestCollectFSFingerprints_DuplicateVersion ensures two files sharing one
+// integer version are rejected (mirrors goose's duplicate-version guard).
+func TestCollectFSFingerprints_DuplicateVersion(t *testing.T) {
+	mem := fstest.MapFS{
+		"0007_alpha.sql": {Data: []byte("-- a")},
+		"0007_beta.sql":  {Data: []byte("-- b")},
+	}
+	if _, err := collectFSFingerprints(mem); err == nil {
+		t.Fatal("expected duplicate-version error, got nil")
+	}
+}
+
+// TestCollectFSFingerprints_IgnoresNonMigrations confirms README/non-versioned
+// files are skipped rather than failing collection.
+func TestCollectFSFingerprints_IgnoresNonMigrations(t *testing.T) {
+	mem := fstest.MapFS{
+		"README.md":            {Data: []byte("# docs")},
+		"helpers.txt":          {Data: []byte("noise")},
+		"20260622143000_x.sql": {Data: []byte("-- x")},
+	}
+	fp, err := collectFSFingerprints(mem)
+	if err != nil {
+		t.Fatalf("collectFSFingerprints: %v", err)
+	}
+	if len(fp) != 1 {
+		t.Fatalf("expected exactly 1 fingerprint, got %d", len(fp))
+	}
+	if _, ok := fp[20260622143000]; !ok {
+		t.Errorf("expected timestamp version 20260622143000 to be collected")
+	}
+}

--- a/CubeMaster/pkg/base/dao/migrate/fingerprint_internal_test.go
+++ b/CubeMaster/pkg/base/dao/migrate/fingerprint_internal_test.go
@@ -5,8 +5,11 @@
 package migrate
 
 import (
+	"bytes"
 	"fmt"
 	"io/fs"
+	"log"
+	"strings"
 	"testing"
 	"testing/fstest"
 
@@ -133,4 +136,59 @@ func TestCollectFSFingerprints_IgnoresNonMigrations(t *testing.T) {
 	if _, ok := fp[20260622143000]; !ok {
 		t.Errorf("expected timestamp version 20260622143000 to be collected")
 	}
+}
+
+// TestLogUnprotectedVersions covers both branches of logUnprotectedVersions.
+func TestLogUnprotectedVersions(t *testing.T) {
+	t.Run("all protected, no output", func(t *testing.T) {
+		var buf bytes.Buffer
+		oldWriter := log.Writer()
+		log.SetOutput(&buf)
+		t.Cleanup(func() { log.SetOutput(oldWriter) })
+
+		applied := map[int64]bool{1: true, 2: true}
+		stored := map[int64]storedFingerprint{
+			1: {sum: "aa", source: "1.sql"},
+			2: {sum: "bb", source: "2.sql"},
+		}
+		logUnprotectedVersions(applied, stored)
+		if buf.Len() > 0 {
+			t.Errorf("expected no output, got: %s", buf.String())
+		}
+	})
+
+	t.Run("unprotected versions present, logs warning", func(t *testing.T) {
+		var buf bytes.Buffer
+		oldWriter := log.Writer()
+		log.SetOutput(&buf)
+		t.Cleanup(func() { log.SetOutput(oldWriter) })
+
+		applied := map[int64]bool{1: true, 2: true, 3: true}
+		stored := map[int64]storedFingerprint{
+			1: {sum: "aa", source: "1.sql"},
+		}
+		logUnprotectedVersions(applied, stored)
+		out := buf.String()
+		if !strings.Contains(out, "NOT content-checked") {
+			t.Errorf("expected warning about unprotected versions, got: %s", out)
+		}
+		if !strings.Contains(out, "2") || !strings.Contains(out, "3") {
+			t.Errorf("expected versions 2 and 3 to be listed, got: %s", out)
+		}
+	})
+
+	t.Run("all versions unprotected, logs warning", func(t *testing.T) {
+		var buf bytes.Buffer
+		oldWriter := log.Writer()
+		log.SetOutput(&buf)
+		t.Cleanup(func() { log.SetOutput(oldWriter) })
+
+		applied := map[int64]bool{1: true, 2: true, 3: true}
+		stored := map[int64]storedFingerprint{} // nothing fingerprinted
+		logUnprotectedVersions(applied, stored)
+		out := buf.String()
+		if !strings.Contains(out, "NOT content-checked") {
+			t.Errorf("expected warning about unprotected versions, got: %s", out)
+		}
+	})
 }

--- a/CubeMaster/pkg/base/dao/migrate/migrate.go
+++ b/CubeMaster/pkg/base/dao/migrate/migrate.go
@@ -23,6 +23,7 @@ import (
 	"context"
 	"database/sql"
 	"embed"
+	"errors"
 	"fmt"
 	"io/fs"
 
@@ -39,13 +40,19 @@ type dialectSpec struct {
 	dialect database.Dialect
 	rootFS  fs.FS
 	subdir  string
+	// fingerprints enables the content-fingerprint defence layer. The
+	// fingerprint store SQL is MySQL-specific (ON DUPLICATE KEY UPDATE,
+	// information_schema, ENGINE=InnoDB), so a future dialect must provide its
+	// own implementation before flipping this on.
+	fingerprints bool
 }
 
 var dialectSpecs = map[string]dialectSpec{
 	"mysql": {
-		dialect: database.DialectMySQL,
-		rootFS:  mysqlMigrations,
-		subdir:  "migrations/mysql",
+		dialect:      database.DialectMySQL,
+		rootFS:       mysqlMigrations,
+		subdir:       "migrations/mysql",
+		fingerprints: true,
 	},
 }
 
@@ -71,18 +78,71 @@ func Run(ctx context.Context, sqlDB *sql.DB, dialect string, locker lock.Session
 	}
 	opts := []goose.ProviderOption{
 		goose.WithVerbose(true),
+		// New migrations use immutable, globally-unique UTC-timestamp version
+		// numbers (see migrations/<dialect>/README.md), so a migration authored
+		// earlier but merged later can legitimately have a version lower than an
+		// environment's current max. Allow goose to apply such out-of-order
+		// migrations instead of hard-failing startup. Safe because every
+		// migration is written idempotently via the *_if_missing helpers.
+		goose.WithAllowOutofOrder(true),
 	}
 	if locker != nil {
 		opts = append(opts, goose.WithSessionLocker(locker))
 	}
+
+	// Defence layer (MySQL only): detect (and loudly reject) the case where an
+	// already-applied migration version's content changed on disk, which goose
+	// would otherwise skip silently. Must run before goose.Up.
+	//
+	// Note: the preflight reads goose_db_version / the fingerprint table WITHOUT
+	// holding goose's session lock (goose only takes it inside provider.Up). A
+	// concurrent instance's Up()/DownTo() could therefore move the bookkeeping
+	// between our read and goose's run. This is safe: InnoDB MVCC prevents dirty
+	// reads, and the worst case is a false-positive (startup blocked), never a
+	// false-negative (silent pass). Concurrent DownTo is an operator-only path.
+	var fsFP map[int64]fileFingerprint
+	if spec.fingerprints {
+		fsFP, err = collectFSFingerprints(subFS)
+		if err != nil {
+			return fmt.Errorf("migrate: collect migration fingerprints: %w", err)
+		}
+		if err := ensureFingerprintTable(ctx, sqlDB); err != nil {
+			return fmt.Errorf("migrate: %w", err)
+		}
+		if err := preflightFingerprints(ctx, sqlDB, fsFP); err != nil {
+			return fmt.Errorf("migrate: %w", err)
+		}
+	}
+
 	provider, err := goose.NewProvider(spec.dialect, sqlDB, subFS, opts...)
 	if err != nil {
 		return fmt.Errorf("migrate: new provider: %w", err)
 	}
-	if _, err := provider.Up(ctx); err != nil {
-		return fmt.Errorf("migrate: goose up: %w", err)
+	results, upErr := provider.Up(ctx)
+	// Record fingerprints for everything that actually applied — even on partial
+	// failure — so a fixed re-deploy never leaves an applied version
+	// unfingerprinted (which would reopen the silent-skip gap).
+	if spec.fingerprints {
+		if recErr := recordFingerprints(ctx, sqlDB, fsFP, appliedResults(results, upErr)); recErr != nil && upErr == nil {
+			return fmt.Errorf("migrate: %w", recErr)
+		}
+	}
+	if upErr != nil {
+		return fmt.Errorf("migrate: goose up: %w", upErr)
 	}
 	return nil
+}
+
+// appliedResults returns the migrations goose actually applied. On partial
+// failure goose returns (nil, *PartialError) with the successfully-applied
+// migrations in PartialError.Applied rather than in the results slice, so we
+// must unwrap it to avoid losing fingerprints for the migrations that did run.
+func appliedResults(results []*goose.MigrationResult, upErr error) []*goose.MigrationResult {
+	var pErr *goose.PartialError
+	if errors.As(upErr, &pErr) {
+		return pErr.Applied
+	}
+	return results
 }
 
 // DownTo rolls back migrations to (and including) the given version. It
@@ -97,7 +157,10 @@ func DownTo(ctx context.Context, sqlDB *sql.DB, dialect string, locker lock.Sess
 	if err != nil {
 		return fmt.Errorf("migrate: fs.Sub %q: %w", spec.subdir, err)
 	}
-	opts := []goose.ProviderOption{goose.WithVerbose(true)}
+	opts := []goose.ProviderOption{
+		goose.WithVerbose(true),
+		goose.WithAllowOutofOrder(true),
+	}
 	if locker != nil {
 		opts = append(opts, goose.WithSessionLocker(locker))
 	}

--- a/CubeMaster/pkg/base/dao/migrate/migrate.go
+++ b/CubeMaster/pkg/base/dao/migrate/migrate.go
@@ -56,25 +56,20 @@ var dialectSpecs = map[string]dialectSpec{
 	},
 }
 
-// Run applies every pending migration for the given dialect. The caller
-// is responsible for opening sqlDB; this function never closes it.
-//
-// Run is idempotent: if the database is already at HEAD it returns nil
-// without touching the schema, so it is safe to call on every process
-// start.
-//
-// When locker is non-nil, the goose Provider takes a cluster-wide lock
-// for the duration of the run (outer layer). Per-file inner locks are
-// asserted by the SQL migrations themselves via the helper procedure
-// established in the baseline migration.
-func Run(ctx context.Context, sqlDB *sql.DB, dialect string, locker lock.SessionLocker) error {
+// newProvider creates a goose Provider wired with this package's conventions:
+// verbose logging and allow-out-of-order for timestamped migrations.
+func newProvider(
+	dialect string,
+	sqlDB *sql.DB,
+	locker lock.SessionLocker,
+) (*goose.Provider, fs.FS, bool, error) {
 	spec, ok := dialectSpecs[dialect]
 	if !ok {
-		return fmt.Errorf("migrate: unknown dialect %q", dialect)
+		return nil, nil, false, fmt.Errorf("migrate: unknown dialect %q", dialect)
 	}
 	subFS, err := fs.Sub(spec.rootFS, spec.subdir)
 	if err != nil {
-		return fmt.Errorf("migrate: fs.Sub %q: %w", spec.subdir, err)
+		return nil, nil, false, fmt.Errorf("migrate: fs.Sub %q: %w", spec.subdir, err)
 	}
 	opts := []goose.ProviderOption{
 		goose.WithVerbose(true),
@@ -89,6 +84,29 @@ func Run(ctx context.Context, sqlDB *sql.DB, dialect string, locker lock.Session
 	if locker != nil {
 		opts = append(opts, goose.WithSessionLocker(locker))
 	}
+	provider, err := goose.NewProvider(spec.dialect, sqlDB, subFS, opts...)
+	if err != nil {
+		return nil, nil, false, fmt.Errorf("migrate: new provider: %w", err)
+	}
+	return provider, subFS, spec.fingerprints, nil
+}
+
+// Run applies every pending migration for the given dialect. The caller
+// is responsible for opening sqlDB; this function never closes it.
+//
+// Run is idempotent: if the database is already at HEAD it returns nil
+// without touching the schema, so it is safe to call on every process
+// start.
+//
+// When locker is non-nil, the goose Provider takes a cluster-wide lock
+// for the duration of the run (outer layer). Per-file inner locks are
+// asserted by the SQL migrations themselves via the helper procedure
+// established in the baseline migration.
+func Run(ctx context.Context, sqlDB *sql.DB, dialect string, locker lock.SessionLocker) error {
+	provider, subFS, fpEnabled, err := newProvider(dialect, sqlDB, locker)
+	if err != nil {
+		return err
+	}
 
 	// Defence layer (MySQL only): detect (and loudly reject) the case where an
 	// already-applied migration version's content changed on disk, which goose
@@ -101,7 +119,7 @@ func Run(ctx context.Context, sqlDB *sql.DB, dialect string, locker lock.Session
 	// reads, and the worst case is a false-positive (startup blocked), never a
 	// false-negative (silent pass). Concurrent DownTo is an operator-only path.
 	var fsFP map[int64]fileFingerprint
-	if spec.fingerprints {
+	if fpEnabled {
 		fsFP, err = collectFSFingerprints(subFS)
 		if err != nil {
 			return fmt.Errorf("migrate: collect migration fingerprints: %w", err)
@@ -114,16 +132,18 @@ func Run(ctx context.Context, sqlDB *sql.DB, dialect string, locker lock.Session
 		}
 	}
 
-	provider, err := goose.NewProvider(spec.dialect, sqlDB, subFS, opts...)
-	if err != nil {
-		return fmt.Errorf("migrate: new provider: %w", err)
-	}
 	results, upErr := provider.Up(ctx)
 	// Record fingerprints for everything that actually applied — even on partial
 	// failure — so a fixed re-deploy never leaves an applied version
 	// unfingerprinted (which would reopen the silent-skip gap).
-	if spec.fingerprints {
-		if recErr := recordFingerprints(ctx, sqlDB, fsFP, appliedResults(results, upErr)); recErr != nil && upErr == nil {
+	if fpEnabled {
+		recErr := recordFingerprints(ctx, sqlDB, fsFP, appliedResults(results, upErr))
+		if recErr != nil {
+			if upErr != nil {
+				// Both goose and fingerprinting failed: surface both so the
+				// operator sees the fingerprint gap alongside the goose error.
+				return fmt.Errorf("migrate: goose up: %w; fingerprint recording: %w", upErr, recErr)
+			}
 			return fmt.Errorf("migrate: %w", recErr)
 		}
 	}
@@ -149,24 +169,9 @@ func appliedResults(results []*goose.MigrationResult, upErr error) []*goose.Migr
 // is intended for tests and emergency operator use; production startup
 // only ever calls Run.
 func DownTo(ctx context.Context, sqlDB *sql.DB, dialect string, locker lock.SessionLocker, version int64) error {
-	spec, ok := dialectSpecs[dialect]
-	if !ok {
-		return fmt.Errorf("migrate: unknown dialect %q", dialect)
-	}
-	subFS, err := fs.Sub(spec.rootFS, spec.subdir)
+	provider, _, _, err := newProvider(dialect, sqlDB, locker)
 	if err != nil {
-		return fmt.Errorf("migrate: fs.Sub %q: %w", spec.subdir, err)
-	}
-	opts := []goose.ProviderOption{
-		goose.WithVerbose(true),
-		goose.WithAllowOutofOrder(true),
-	}
-	if locker != nil {
-		opts = append(opts, goose.WithSessionLocker(locker))
-	}
-	provider, err := goose.NewProvider(spec.dialect, sqlDB, subFS, opts...)
-	if err != nil {
-		return fmt.Errorf("migrate: new provider: %w", err)
+		return err
 	}
 	if _, err := provider.DownTo(ctx, version); err != nil {
 		return fmt.Errorf("migrate: goose down-to %d: %w", version, err)

--- a/CubeMaster/pkg/base/dao/migrate/migrate_naming_test.go
+++ b/CubeMaster/pkg/base/dao/migrate/migrate_naming_test.go
@@ -1,0 +1,129 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package migrate_test
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// TestMigrationFilenames enforces the migration naming policy documented in
+// migrations/mysql/README.md. It runs without a database (no docker needed) so
+// it can gate every PR in CI.
+//
+// Policy:
+//   - The historical sequential block 0001..0010 is FROZEN: those exact files
+//     must exist, must keep their 4-digit names, and no NEW 4-digit sequential
+//     file may be added (sequential numbers get reused on rebase and cause
+//     silently-skipped migrations).
+//   - Every NEW migration must use a 14-digit UTC timestamp prefix:
+//     YYYYMMDDhhmmss_<description>.sql.
+//   - No two migration files may share the same integer version.
+func TestMigrationFilenames(t *testing.T) {
+	// Path is relative to the package directory (Go runs `go test` with the cwd
+	// set to the package dir). In CI this is invoked as
+	// `working-directory: CubeMaster` + `go test ./pkg/base/dao/migrate/`.
+	const migrationsDir = "migrations/mysql"
+
+	// historicalMaxVersion is the last version of the frozen sequential block.
+	// Do NOT bump this; new migrations must be timestamp-based.
+	const historicalMaxVersion = 10
+
+	frozen := map[int64]bool{}
+	for v := int64(1); v <= historicalMaxVersion; v++ {
+		frozen[v] = true
+	}
+
+	// 14-digit timestamp prefix + lowercase snake_case description.
+	timestampRe := regexp.MustCompile(`^\d{14}_[a-z0-9]+(_[a-z0-9]+)*\.sql$`)
+	// 4-digit sequential prefix (only the frozen block may use this shape).
+	sequentialRe := regexp.MustCompile(`^(\d{4})_[a-z0-9]+(_[a-z0-9]+)*\.sql$`)
+
+	entries, err := os.ReadDir(migrationsDir)
+	if err != nil {
+		t.Fatalf("read %s: %v", migrationsDir, err)
+	}
+
+	versionToFile := map[int64]string{}
+	seenFrozen := map[int64]bool{}
+
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		name := e.Name()
+		if !strings.HasSuffix(name, ".sql") {
+			continue // README.md and other non-migration files are fine.
+		}
+
+		prefix, _, ok := strings.Cut(name, "_")
+		if !ok {
+			t.Errorf("%s: missing '_' separator in filename", name)
+			continue
+		}
+		version, perr := strconv.ParseInt(prefix, 10, 64)
+		if perr != nil {
+			t.Errorf("%s: version prefix %q is not numeric", name, prefix)
+			continue
+		}
+
+		if other, dup := versionToFile[version]; dup {
+			t.Errorf("duplicate migration version %d: %q and %q", version, other, name)
+			continue
+		}
+		versionToFile[version] = name
+
+		switch {
+		case len(prefix) == 4:
+			// Only the frozen sequential block may use the 4-digit shape.
+			if !sequentialRe.MatchString(name) {
+				t.Errorf("%s: invalid sequential filename shape", name)
+				continue
+			}
+			if !frozen[version] {
+				t.Errorf("%s: new 4-digit sequential migrations are forbidden; "+
+					"use a 14-digit UTC timestamp prefix instead (see %s/README.md)",
+					name, migrationsDir)
+				continue
+			}
+			seenFrozen[version] = true
+		case len(prefix) == 14:
+			if !timestampRe.MatchString(name) {
+				t.Errorf("%s: invalid timestamp filename; expected "+
+					"YYYYMMDDhhmmss_<snake_case>.sql", name)
+				continue
+			}
+			if version <= historicalMaxVersion {
+				t.Errorf("%s: timestamp version %d collides with frozen block", name, version)
+			}
+		default:
+			t.Errorf("%s: version prefix must be the 4-digit frozen block or a "+
+				"14-digit UTC timestamp (got %d-digit %q)", name, len(prefix), prefix)
+		}
+	}
+
+	// Every frozen migration must still be present (catches renames/deletes of
+	// the historical block even if CI git-diff is bypassed).
+	for v := range frozen {
+		if !seenFrozen[v] {
+			t.Errorf("frozen migration version %04d is missing or renamed; "+
+				"the historical block 0001..%04d must never change",
+				v, historicalMaxVersion)
+		}
+	}
+}
+
+// TestMigrationsDirHasReadme is a light guard so the naming policy stays
+// discoverable next to the files it governs.
+func TestMigrationsDirHasReadme(t *testing.T) {
+	readme := filepath.Join("migrations", "mysql", "README.md")
+	if _, err := os.Stat(readme); err != nil {
+		t.Errorf("expected migration policy doc at %s: %v", readme, err)
+	}
+}

--- a/CubeMaster/pkg/base/dao/migrate/migrate_test.go
+++ b/CubeMaster/pkg/base/dao/migrate/migrate_test.go
@@ -365,6 +365,61 @@ func TestRun_ContinuesFromPartialV022ToHeadDDL(t *testing.T) {
 	assertHeadSchema(t, db)
 }
 
+// TestRun_FingerprintDetectsContentDrift proves the content-fingerprint
+// defence: after a clean migrate, tampering with a recorded fingerprint so it
+// no longer matches the on-disk content makes the next Run fail loudly (instead
+// of goose silently skipping), and the escape-hatch env var bypasses the check.
+func TestRun_FingerprintDetectsContentDrift(t *testing.T) {
+	env := newMySQL(t)
+	defer env.teardown()
+	db := openDB(t, env.dsn)
+	defer db.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+
+	if err := migrate.Run(ctx, db, "mysql", testSessionLocker()); err != nil {
+		t.Fatalf("initial migrate.Run: %v", err)
+	}
+
+	// The fingerprint table must have been populated for applied versions.
+	var n int
+	if err := db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM t_cubemaster_migration_fingerprint`).Scan(&n); err != nil {
+		t.Fatalf("count fingerprints: %v", err)
+	}
+	if n == 0 {
+		t.Fatal("expected fingerprints to be recorded after fresh migrate")
+	}
+
+	// Simulate "version 2 was applied with different content than what is now on
+	// disk" by corrupting the stored hash for an applied version.
+	res, err := db.ExecContext(ctx,
+		`UPDATE t_cubemaster_migration_fingerprint SET sha256 = ? WHERE version = 2`,
+		"0000000000000000000000000000000000000000000000000000000000000000")
+	if err != nil {
+		t.Fatalf("corrupt fingerprint: %v", err)
+	}
+	if affected, _ := res.RowsAffected(); affected != 1 {
+		t.Fatalf("expected to corrupt exactly 1 fingerprint row, got %d", affected)
+	}
+
+	// Next Run must fail loudly.
+	err = migrate.Run(ctx, db, "mysql", testSessionLocker())
+	if err == nil {
+		t.Fatal("expected fingerprint mismatch error, got nil")
+	}
+	if !strings.Contains(err.Error(), "fingerprint check failed") {
+		t.Fatalf("expected fingerprint error, got: %v", err)
+	}
+
+	// The escape hatch lets an operator bypass the check.
+	t.Setenv("CUBEMASTER_MIGRATION_SKIP_FINGERPRINT_CHECK", "1")
+	if err := migrate.Run(ctx, db, "mysql", testSessionLocker()); err != nil {
+		t.Fatalf("migrate.Run with skip env should succeed: %v", err)
+	}
+}
+
 // assertHeadSchema verifies a set of HEAD-only signals: new tables exist,
 // new columns exist, deprecated columns are gone, expected indexes are
 // present. The intent is to catch drift between the SQL migrations and

--- a/CubeMaster/pkg/base/dao/migrate/migrate_test.go
+++ b/CubeMaster/pkg/base/dao/migrate/migrate_test.go
@@ -7,6 +7,7 @@ package migrate_test
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"os"
 	"sort"
@@ -400,7 +401,11 @@ func TestRun_FingerprintDetectsContentDrift(t *testing.T) {
 	if err != nil {
 		t.Fatalf("corrupt fingerprint: %v", err)
 	}
-	if affected, _ := res.RowsAffected(); affected != 1 {
+	affected, err := res.RowsAffected()
+	if err != nil {
+		t.Fatalf("RowsAffected: %v", err)
+	}
+	if affected != 1 {
 		t.Fatalf("expected to corrupt exactly 1 fingerprint row, got %d", affected)
 	}
 
@@ -409,8 +414,8 @@ func TestRun_FingerprintDetectsContentDrift(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected fingerprint mismatch error, got nil")
 	}
-	if !strings.Contains(err.Error(), "fingerprint check failed") {
-		t.Fatalf("expected fingerprint error, got: %v", err)
+	if !errors.Is(err, migrate.ErrFingerprintMismatch) {
+		t.Fatalf("expected fingerprint mismatch error, got: %v", err)
 	}
 
 	// The escape hatch lets an operator bypass the check.

--- a/CubeMaster/pkg/base/dao/migrate/migrations/mysql/README.md
+++ b/CubeMaster/pkg/base/dao/migrate/migrations/mysql/README.md
@@ -1,0 +1,100 @@
+<!--
+Copyright (c) 2026 Tencent Inc.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# CubeMaster MySQL Migration Conventions
+
+This directory is applied automatically at process startup by
+[`pkg/base/dao/migrate`](../../migrate.go) via
+[`github.com/pressly/goose/v3`](https://github.com/pressly/goose).
+
+## Background: why sequential numbers are no longer allowed
+
+goose uses the numeric prefix of a migration filename as its "version," and the
+`goose_db_version` table stores **only this integer**. The apply logic is
+`if dbAppliedVersions[v] { continue }`: once an integer version is recorded as
+applied, goose **never re-reads that file and never compares its content again**.
+
+Sequential numbers (`0001`, `0002`, …) get reused in concurrent, multi-branch
+development. A typical incident:
+
+1. Developer A writes `0010_aaaaa.sql` on top of upstream `0009` and deploys it
+   to a staging environment → the DB records version `10`.
+2. Upstream merges `0010_bbbb.sql` in parallel.
+3. Developer A rebases, renaming `0010_aaaaa.sql` → `0011_aaaaa.sql`.
+   On disk: `0010_bbbb.sql` (version 10) + `0011_aaaaa.sql` (version 11).
+4. Staging is redeployed: the DB already has version `10` →
+   `0010_bbbb.sql` is `continue`-d and **silently skipped, never executed**.
+
+Root cause: **the migration version identity is a reusable / reassignable
+integer**.
+
+## Naming conventions
+
+### Frozen historical block (do NOT modify)
+
+`0001` – `0010` are the v0.2.2 baseline and early increments that have already
+been applied in every environment. **These filenames and their contents must
+never be modified, renamed, or deleted** (CI enforces this). If you need to
+correct their behaviour, add a new timestamped migration instead of editing
+the old files.
+
+### New migrations: use UTC timestamps
+
+All new migrations **MUST** use a 14-digit UTC timestamp prefix:
+
+```
+YYYYMMDDhhmmss_<description>.sql
+```
+
+Example: `20260622143000_add_foo_column.sql`.
+
+Rationale:
+
+- A timestamp is determined at write time, globally unique, and **never needs
+  renaming on rebase** → the version identity cannot be reused, making the
+  incident above structurally impossible.
+- Timestamps (e.g. `20260622143000`) are orders of magnitude larger than the
+  frozen block's `1`–`10`, so they sort naturally after the historical block,
+  preserving ordering.
+- **Always use UTC** (e.g. `date -u +%Y%m%d%H%M%S`) to avoid ordering /
+  collision ambiguity across developer timezones.
+
+### Creating a new migration
+
+Use the helper script (generates a UTC-timestamped filename and template stub):
+
+```bash
+scripts/new-migration.sh add_foo_column
+```
+
+Manual creation is also fine, but you must follow the format above and the
+content rules below.
+
+## Migration content rules
+
+- Add `-- +goose NO TRANSACTION` at the top (MySQL DDL does implicit commits;
+  goose transactions are meaningless) together with `-- +goose Up`.
+- Use the idempotent stored procedures provided by the baseline:
+  `cubemaster_add_column_if_missing` / `cubemaster_drop_column_if_exists` /
+  `cubemaster_add_index_if_missing` / `cubemaster_drop_index_if_exists` /
+  `cubemaster_assert_table_exists`, etc. Idempotent migrations are the
+  prerequisite for out-of-order application (`WithAllowOutofOrder`) and safe
+  manual remediation.
+- Wrap every migration with
+  `CALL cubemaster_acquire_migration_lock('cubemaster_migration_<version>_<name>', 60);`
+  at the top and
+  `SELECT RELEASE_LOCK('cubemaster_migration_<version>_<name>');` at the
+  bottom. The lock name must match the filename.
+- Provide a symmetric `-- +goose Down` (the `0001` baseline is the only
+  exception — it is irreversible).
+
+## Applied migrations are immutable (runtime enforcement)
+
+The `migrate` package records a content fingerprint (table
+`t_cubemaster_migration_fingerprint`) for every version that goose has
+**actually applied**. If the on-disk content of an already-applied version is
+later changed, the next startup will **fail loudly** instead of skipping
+silently. Operators may temporarily bypass this check by setting
+`CUBEMASTER_MIGRATION_SKIP_FINGERPRINT_CHECK=1`.

--- a/scripts/new-migration.sh
+++ b/scripts/new-migration.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Create a new CubeMaster MySQL migration with a UTC timestamp version prefix.
+#
+# Why timestamps (not sequential numbers): goose tracks migrations only by the
+# integer filename prefix. Sequential numbers get reused across rebases, which
+# silently skips a migration. A UTC timestamp is unique and never needs renaming
+# on rebase. See migrations/mysql/README.md for the full rationale.
+#
+# Usage:
+#   scripts/new-migration.sh <description>
+#
+# Example:
+#   scripts/new-migration.sh add_foo_column
+#   -> CubeMaster/pkg/base/dao/migrate/migrations/mysql/20260622143000_add_foo_column.sql
+
+set -euo pipefail
+
+if [[ $# -ne 1 || -z "${1:-}" ]]; then
+  echo "usage: $0 <description>   (e.g. add_foo_column)" >&2
+  exit 2
+fi
+
+description="$1"
+
+# Enforce the same shape the CI naming check requires: lowercase letters,
+# digits and underscores only.
+if [[ ! "${description}" =~ ^[a-z0-9_]+$ ]]; then
+  echo "error: description must match ^[a-z0-9_]+$ (got: ${description})" >&2
+  exit 2
+fi
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "${script_dir}/.." && pwd)"
+mysql_dir="${repo_root}/CubeMaster/pkg/base/dao/migrate/migrations/mysql"
+
+if [[ ! -d "${mysql_dir}" ]]; then
+  echo "error: migrations dir not found: ${mysql_dir}" >&2
+  exit 1
+fi
+
+version="$(date -u +%Y%m%d%H%M%S)"
+file="${mysql_dir}/${version}_${description}.sql"
+
+if [[ -e "${file}" ]]; then
+  echo "error: ${file} already exists (run again in 1s for a new timestamp)" >&2
+  exit 1
+fi
+
+lock_name="cubemaster_migration_${version}_${description}"
+year="$(date -u +%Y)"
+
+cat > "${file}" <<EOF
+-- Copyright (c) ${year} Tencent Inc.
+-- SPDX-License-Identifier: Apache-2.0
+--
+-- TODO: describe what this migration does and why it is safe to apply
+-- out-of-order (it must be, because goose runs with WithAllowOutofOrder).
+
+-- +goose NO TRANSACTION
+-- +goose Up
+
+CALL cubemaster_acquire_migration_lock('${lock_name}', 60);
+
+-- TODO: use the idempotent helpers from the baseline, e.g.
+-- CALL cubemaster_add_column_if_missing('t_cube_foo', 'bar', "varchar(64) NOT NULL DEFAULT ''");
+
+SELECT RELEASE_LOCK('${lock_name}');
+
+-- +goose Down
+
+CALL cubemaster_acquire_migration_lock('${lock_name}', 60);
+
+-- TODO: reverse the Up changes idempotently, e.g.
+-- CALL cubemaster_drop_column_if_exists('t_cube_foo', 'bar');
+
+SELECT RELEASE_LOCK('${lock_name}');
+EOF
+
+echo "created ${file}"


### PR DESCRIPTION
Root cause: goose identifies migrations solely by integer filename prefix. Once version N is recorded as applied in goose_db_version, goose never re-reads that file, making sequential-number reuse across rebases silently skip migrations forever.

Three-layer defence:

1. Naming convention (prevent): freeze historical block 0001-0010; all new migrations MUST use a 14-digit UTC timestamp prefix (YYYYMMDDhhmmss) that is globally unique and never needs renaming on rebase.

2. Allow out-of-order application (accommodate): enable goose WithAllowOutofOrder so timestamped migrations authored earlier but merged later do not hard-fail startup. Safe because every migration uses idempotent *_if_missing helpers.

3. Content fingerprinting (detect): record sha256 of every migration goose actually applies in t_cubemaster_migration_fingerprint. On each startup, verify that on-disk content still matches the recorded fingerprint for every currently-applied version. A mismatch fails loudly instead of being silently skipped. Escape hatch: CUBEMASTER_MIGRATION_SKIP_FINGERPRINT_CHECK=1.

CI: new migration-check.yml workflow runs TestMigrationFilenames (no docker) and rejects M/D/R changes to already-merged migration files via git diff. New scripts/new-migration.sh enforces the timestamp convention at creation time.