### PR TITLE
docs: add package documentation for image package

### DIFF
--- a/Cubelet/pkg/store/image/util.go
+++ b/Cubelet/pkg/store/image/util.go
@@ -2,4 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+// Package image provides utilities for image storage and management in the CubeSandbox system.
+
 package image


### PR DESCRIPTION
### 问题背景
公共包 `image` 缺少包级别文档，这降低了代码的可读性和可维护性，使其他开发者难以快速理解包的目的、功能和用法。在Go中，提供包文档是标准实践，有助于促进开源协作和代码重用。

### 修改内容
- **修改文件**: `Cubelet/pkg/store/image/util.go`
- **具体更改**: 在包声明前添加了一行包文档注释，描述了包的用途为“提供图像存储和管理工具”。
- **为什么这样改**: 遵循Go语言的最佳实践，通过添加清晰的包文档来提升代码质量，使包的功能自描述，便于其他开发者理解和集成。
- **提升效果**: 提高了代码的可读性和可维护性，支持更高效的团队协作和开源贡献，但不影响性能或安全性。

### 验证方式
- 由于修改仅涉及添加注释，没有改变任何代码逻辑或API，因此现有测试应继续通过。可以通过运行 `go test` 在相关目录下验证。
- 没有添加新的测试，因为文档修改不需要功能测试。
- 手动验证：检查文件内容，确保注释正确添加且格式符合Go规范。

### 其他信息
- 没有breaking changes，所有现有功能保持不变。
- 不需要更新额外文档，因为此修改是包文档的直接添加。
- 没有已知限制。