### PR TITLE
fix(one-click): persist MIRROR env to .one-click.env for image registry selection

### DIFF
--- a/deploy/one-click/env.example
+++ b/deploy/one-click/env.example
@@ -152,6 +152,15 @@ CUBE_API_SANDBOX_DOMAIN=cube.app
 # The default below points to the bundled one-click MySQL service.
 DATABASE_URL=mysql://cube:cube_pass@127.0.0.1:3306/cube_mvp
 
-# Optional Docker mirror.
+# Container image registry region selector.
+# Controls which regional registry is used for pulling CubeSandbox component
+# images (currently affects cube-egress).
+#   <empty> (default) → international registry (cube-sandbox-int.tencentcloudcr.com)
+#   cn                → China-region registry (cube-sandbox-cn.tencentcloudcr.com)
+# Other images (coredns, mysql, redis, webui) use the unified global registry
+# cube-sandbox-image.tencentcloudcr.com and are not affected by this setting.
+# MIRROR=cn
+
+# Optional Docker mirror (registry pull-through cache, separate from MIRROR above).
 ONE_CLICK_ENABLE_TENCENT_DOCKER_MIRROR=0
 ONE_CLICK_TENCENT_DOCKER_MIRROR_URL=https://mirror.ccs.tencentyun.com

--- a/deploy/one-click/install.sh
+++ b/deploy/one-click/install.sh
@@ -1042,6 +1042,12 @@ elif [[ -f "${SCRIPT_DIR}/release-manifest.json" ]]; then
 fi
 upsert_env_kv "${RUNTIME_ENV_FILE}" "ONE_CLICK_DEPLOY_ROLE" "${DEPLOY_ROLE}"
 upsert_env_kv "${RUNTIME_ENV_FILE}" "CUBE_PVM_ENABLE" "${CUBE_PVM_ENABLE}"
+MIRROR="${MIRROR:-}"
+case "${MIRROR}" in
+  ""|cn) ;;
+  *) die "unsupported MIRROR: ${MIRROR} (expected empty or cn)" ;;
+esac
+upsert_env_kv "${RUNTIME_ENV_FILE}" "MIRROR" "${MIRROR}"
 if [[ -n "${CUBE_SANDBOX_NODE_IP:-}" ]]; then
   upsert_env_kv "${RUNTIME_ENV_FILE}" "CUBE_SANDBOX_NODE_IP" "${CUBE_SANDBOX_NODE_IP}"
 fi

--- a/deploy/one-click/online-install.sh
+++ b/deploy/one-click/online-install.sh
@@ -6,6 +6,11 @@ GITHUB_API_BASE="https://api.github.com/repos/${GITHUB_REPO}"
 
 CN_MIRROR_LATEST_URL="https://download.cubesandbox.com/release/latest.json"
 MIRROR="${MIRROR:-}"
+case "${MIRROR}" in
+  ""|cn) ;;
+  *) echo "[online-install] ERROR: unsupported MIRROR '${MIRROR}' (expected empty or cn)." >&2; exit 2 ;;
+esac
+export MIRROR
 
 SKIP_PRECHECK="${ONE_CLICK_SKIP_PRECHECK:-0}"
 DOWNLOAD_URL="${CUBE_SANDBOX_DOWNLOAD_URL:-}"


### PR DESCRIPTION
## Problem

Setting `MIRROR=cn` during one-click deployment does not persist to the runtime
environment. After installation, the cube-egress systemd service defaults to the
international registry (`cube-sandbox-int.tencentcloudcr.com`) instead of the
China-region registry (`cube-sandbox-cn.tencentcloudcr.com`).

## Root Cause

`MIRROR` is used by two scripts:
- `online-install.sh` — selects the download URL (works correctly)
- `cube-egress-start.sh` — selects between `-int` and `-cn` image registries

But `install.sh` never persists `MIRROR` to `.one-click.env`. Since systemd
reads this file via `EnvironmentFile=`, the variable is lost when services
start. The `MIRROR` key is also missing from `env.example`, so users have no
documentation that it exists.

## Fix

1. **env.example**: Add `MIRROR` as a documented config key, with comments
   distinguishing it from the Docker registry mirror settings
2. **install.sh**: Validate `MIRROR` (accepts empty or `cn`) and persist it via
   `upsert_env_kv` to `.one-click.env`
3. **online-install.sh**: Validate `MIRROR` early and explicitly export it
   before launching the child `install.sh` process

## Scope

Only the cube-egress container image is affected. Other images (coredns,
mysql, redis, webui) use the unified global registry
`cube-sandbox-image.tencentcloudcr.com` which has no regional variant.

Closes: #618

🤖 Generated with [Claude Code](https://claude.com/claude-code)