### PR TITLE
feat(lifecycle): kill path, set_timeout/refresh, and stable endAt

### DIFF
--- a/CubeAPI/src/cubemaster/mod.rs
+++ b/CubeAPI/src/cubemaster/mod.rs
@@ -1020,12 +1020,12 @@ pub struct SandboxInfo {
     pub host_id: String,
     #[serde(default, deserialize_with = "deserialize_sandbox_status")]
     pub status: String,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_optional_datetime")]
     pub started_at: Option<DateTime<Utc>>,
     /// Unix nanoseconds from Cubelet container.created_at — used as fallback for started_at
     #[serde(default)]
     pub create_at: i64,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_optional_datetime")]
     pub end_at: Option<DateTime<Utc>>,
     #[serde(default, alias = "cpuCount")]
     pub cpu_count: i32,
@@ -1071,6 +1071,8 @@ pub struct GetSandboxDataItem {
     pub containers: Vec<GetSandboxContainerItem>,
     #[serde(default)]
     pub namespace: String,
+    #[serde(default, deserialize_with = "deserialize_optional_datetime")]
+    pub end_at: Option<DateTime<Utc>>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -1136,6 +1138,62 @@ pub(crate) fn datetime_from_unix_nanos(value: i64) -> Option<DateTime<Utc>> {
     let seconds = value.div_euclid(1_000_000_000);
     let nanos = value.rem_euclid(1_000_000_000) as u32;
     DateTime::<Utc>::from_timestamp(seconds, nanos)
+}
+
+pub(crate) fn datetime_from_unix_millis(value: i64) -> Option<DateTime<Utc>> {
+    if value <= 0 {
+        return None;
+    }
+    let seconds = value.div_euclid(1_000);
+    let nanos = (value.rem_euclid(1_000) as u32) * 1_000_000;
+    DateTime::<Utc>::from_timestamp(seconds, nanos)
+}
+
+/// Deserialise an `Option<DateTime<Utc>>` from one of three on-the-wire
+/// shapes our CubeMaster fleet has used over time:
+///
+///   * `null` or missing                 → `None`
+///   * RFC 3339 string  ("2026-..Z")     → parsed via `DateTime::parse_from_rfc3339`
+///   * integer / numeric string          → treated as unix-milliseconds
+///
+pub(crate) fn deserialize_optional_datetime<'de, D>(
+    deserializer: D,
+) -> Result<Option<DateTime<Utc>>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    use serde::de::Error;
+
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum DateTimeValue {
+        Null,
+        Int(i64),
+        Float(f64),
+        Str(String),
+    }
+
+    let raw = Option::<DateTimeValue>::deserialize(deserializer)?;
+    let parsed = match raw {
+        None | Some(DateTimeValue::Null) => None,
+        Some(DateTimeValue::Int(ms)) => datetime_from_unix_millis(ms),
+        Some(DateTimeValue::Float(ms)) => datetime_from_unix_millis(ms.round() as i64),
+        Some(DateTimeValue::Str(s)) => {
+            let trimmed = s.trim();
+            if trimmed.is_empty() {
+                None
+            } else if let Ok(ms) = trimmed.parse::<i64>() {
+                datetime_from_unix_millis(ms)
+            } else {
+                Some(
+                    DateTime::parse_from_rfc3339(trimmed)
+                        .map_err(D::Error::custom)?
+                        .with_timezone(&Utc),
+                )
+            }
+        }
+    };
+    Ok(parsed)
 }
 
 #[derive(Deserialize)]
@@ -1228,7 +1286,7 @@ impl GetSandboxResponse {
             status,
             template_id,
             started_at: primary_container.and_then(|c| datetime_from_unix_nanos(c.create_at)),
-            end_at: None,
+            end_at: item.end_at,
             cpu_count,
             memory_mb,
             disk_size_mb: 0,
@@ -1269,7 +1327,7 @@ pub struct SandboxUpdateResponse {
 }
 
 // ─── Set sandbox timeout (absolute) ───────────────────────────────────────
-// ❌ New API — not yet implemented on CubeMaster
+// ✅ Implemented: POST /cube/sandbox/timeout
 
 #[derive(Debug, Serialize)]
 pub struct SandboxTimeoutRequest {
@@ -1290,12 +1348,13 @@ pub struct SandboxTimeoutResponse {
     pub request_id: String,
     #[serde(rename = "sandboxID", default)]
     pub sandbox_id: String,
+    #[serde(default, deserialize_with = "deserialize_optional_datetime")]
     pub end_at: Option<DateTime<Utc>>,
     pub ret: RetCode,
 }
 
 // ─── Refresh sandbox TTL (relative extend) ────────────────────────────────
-// ❌ New API — not yet implemented on CubeMaster
+// ✅ Implemented: POST /cube/sandbox/refresh
 
 #[derive(Debug, Serialize)]
 pub struct SandboxRefreshRequest {
@@ -1316,6 +1375,7 @@ pub struct SandboxRefreshResponse {
     pub request_id: String,
     #[serde(rename = "sandboxID", default)]
     pub sandbox_id: String,
+    #[serde(default, deserialize_with = "deserialize_optional_datetime")]
     pub end_at: Option<DateTime<Utc>>,
     pub ret: RetCode,
 }

--- a/CubeMaster/pkg/base/constants/constants.go
+++ b/CubeMaster/pkg/base/constants/constants.go
@@ -47,6 +47,7 @@ const (
 	CubeAnnotationsInsDataDisk              = "cube.master.instance.data_disk"
 	CubeAnnotationsInsUserData              = "cube.master.instance.user_data"
 	CubeAnnotationsInsType                  = "cube.master.instance.type"
+	CubeAnnotationsKillReason               = "cube.master.instance.kill_reason"
 	CubeAnnotationsInsSecurityGroupIDS      = "cube.master.instance.sg_ids"
 	CubeAnnotationsInsRetainIP              = "cube.master.instance.retain_ip"
 	CubeAnnotationsInsRegion                = "cube.master.instance.region"

--- a/CubeMaster/pkg/lifecycle/init.go
+++ b/CubeMaster/pkg/lifecycle/init.go
@@ -44,9 +44,61 @@ func Init(ctx context.Context) error {
 	sandbox.RegisterAfterDestroySandboxSuccessHook(onAfterDestroy)
 	task.RegisterAfterDestroyTaskSuccessHook(onAfterDestroy)
 
+	sandbox.SetTimeoutProvider(&storeTimeoutProvider{store: store})
+
 	log.G(ctx).Infof("lifecycle: auto-pause metadata channel ready (key=%s, stream=%s)",
 		MetaKey, EventStreamKey)
 	return nil
+}
+
+// storeTimeoutProvider adapts our *Store to sandbox.TimeoutProvider.
+type storeTimeoutProvider struct {
+	store *Store
+}
+
+// RefreshTimeout reads the existing meta (preserving fields the request
+// doesn't carry: AutoPause / AutoResume / TemplateID / HostID / HostIP /
+// InstanceType), rewrites CreatedAt + TimeoutSeconds + EndAt, and publishes
+// an OpUpdate event so every sidecar replica converges on the new view.
+func (p *storeTimeoutProvider) RefreshTimeout(ctx context.Context, sandboxID string, timeoutSeconds int) (int64, error) {
+	if p == nil || p.store == nil {
+		return 0, nil
+	}
+	meta, err := p.store.LoadMeta(ctx, sandboxID)
+	if err != nil {
+		return 0, err
+	}
+	if meta == nil {
+		return 0, nil
+	}
+
+	now := time.Now().UnixMilli()
+	meta.TimeoutSeconds = timeoutSeconds
+	meta.CreatedAt = now
+	meta.EndAt = now + int64(timeoutSeconds)*1000
+	p.store.PublishUpdate(ctx, meta)
+	return meta.EndAt, nil
+}
+
+// LookupEndAt reads the latest meta.EndAt straight from the lifecycle snapshot in Redis.
+func (p *storeTimeoutProvider) LookupEndAt(ctx context.Context, sandboxID string) (int64, error) {
+	if p == nil || p.store == nil {
+		return 0, nil
+	}
+	meta, err := p.store.LoadMeta(ctx, sandboxID)
+	if err != nil {
+		return 0, err
+	}
+	if meta == nil {
+		return 0, nil
+	}
+	if meta.EndAt > 0 {
+		return meta.EndAt, nil
+	}
+	if meta.CreatedAt > 0 && meta.TimeoutSeconds > 0 {
+		return meta.CreatedAt + int64(meta.TimeoutSeconds)*1000, nil
+	}
+	return 0, nil
 }
 
 // isNilPool guards against wrapredis.GetRedis returning a typed-nil
@@ -61,6 +113,7 @@ func onAfterCreate(ctx context.Context, sandboxID, hostID, hostIP string, req *s
 	if store == nil || req == nil {
 		return nil
 	}
+	now := time.Now().UnixMilli()
 	meta := &SandboxLifecycleMeta{
 		SandboxID:      sandboxID,
 		HostID:         hostID,
@@ -69,7 +122,8 @@ func onAfterCreate(ctx context.Context, sandboxID, hostID, hostIP string, req *s
 		TimeoutSeconds: req.Timeout,
 		AutoPause:      req.AutoPause,
 		AutoResume:     req.AutoResume,
-		CreatedAt:      time.Now().UnixMilli(),
+		CreatedAt:      now,
+		EndAt:          now + int64(req.Timeout)*1000,
 	}
 	if req.Annotations != nil {
 		// Template ID is conventionally carried via annotations from CubeAPI;

--- a/CubeMaster/pkg/lifecycle/schema.go
+++ b/CubeMaster/pkg/lifecycle/schema.go
@@ -44,6 +44,7 @@ const (
 const (
 	OpCreate = "create"
 	OpDelete = "delete"
+	OpUpdate = "update"
 )
 
 // Stream entry field names. Stream values are flat key/value pairs in redigo,
@@ -70,4 +71,9 @@ type SandboxLifecycleMeta struct {
 	// CreatedAt is unix milliseconds. Sidecars use it as the initial
 	// "last active" baseline before they ever observe a real request.
 	CreatedAt int64 `json:"created_at,omitempty"`
+	// EndAt is unix milliseconds, the projected next-timeout instant
+	// (CreatedAt + TimeoutSeconds*1000). Filled in by the master so
+	// API consumers (and the SDK's get_info endpoint) can return it
+	// without recomputing.
+	EndAt int64 `json:"end_at,omitempty"`
 }

--- a/CubeMaster/pkg/lifecycle/store.go
+++ b/CubeMaster/pkg/lifecycle/store.go
@@ -84,6 +84,67 @@ func (s *Store) PublishDelete(ctx context.Context, sandboxID string) {
 	}
 }
 
+// PublishUpdate refreshes the snapshot for an already-existing sandbox: HSET
+// the new meta JSON, then XADD an OpUpdate event. Used by set_timeout /
+// refresh when only mutable fields (TimeoutSeconds, CreatedAt, EndAt) change.
+func (s *Store) PublishUpdate(ctx context.Context, meta *SandboxLifecycleMeta) {
+	if s == nil || !s.enabled.Load() || s.doer == nil || meta == nil || meta.SandboxID == "" {
+		return
+	}
+
+	payload, err := json.Marshal(meta)
+	if err != nil {
+		log.G(ctx).Warnf("lifecycle: marshal update meta sandbox=%s: %v", meta.SandboxID, err)
+		return
+	}
+
+	if _, err := s.doer.Do("HSET", MetaKey, meta.SandboxID, payload); err != nil {
+		log.G(ctx).Warnf("lifecycle: HSET (update) %s %s failed: %v", MetaKey, meta.SandboxID, err)
+	}
+
+	if _, err := s.xadd(OpUpdate, meta.SandboxID, payload); err != nil {
+		log.G(ctx).Warnf("lifecycle: XADD update %s failed: %v", meta.SandboxID, err)
+	}
+}
+
+// LoadMeta reads back the canonical meta snapshot for a sandbox. Returns nil
+// (no error) when the entry isn't present so callers can treat "missing" and
+// "stale" identically. Used by set_timeout / refresh to base the new meta on
+// the current values (preserving auto_pause, host_id, template_id, etc.)
+func (s *Store) LoadMeta(ctx context.Context, sandboxID string) (*SandboxLifecycleMeta, error) {
+	if s == nil || s.doer == nil || sandboxID == "" {
+		return nil, nil
+	}
+
+	v, err := s.doer.Do("HGET", MetaKey, sandboxID)
+	if err != nil {
+		return nil, err
+	}
+	if v == nil {
+		return nil, nil
+	}
+
+	var raw []byte
+	switch x := v.(type) {
+	case []byte:
+		raw = x
+	case string:
+		raw = []byte(x)
+	default:
+		log.G(ctx).Warnf("lifecycle: HGET %s %s unexpected type %T", MetaKey, sandboxID, v)
+		return nil, nil
+	}
+	if len(raw) == 0 {
+		return nil, nil
+	}
+
+	var meta SandboxLifecycleMeta
+	if err := json.Unmarshal(raw, &meta); err != nil {
+		return nil, err
+	}
+	return &meta, nil
+}
+
 // xadd builds an XADD ... MAXLEN ~ <N> * op <op> sandbox_id <id> [payload <p>]
 // ts <unix_ms> command and dispatches it.
 func (s *Store) xadd(op, sandboxID string, payload []byte) (interface{}, error) {

--- a/CubeMaster/pkg/server/server.go
+++ b/CubeMaster/pkg/server/server.go
@@ -89,6 +89,8 @@ func (s *internalHttp) registerHandlers() {
 	cubeGroup.HandleFunc(cube.SandboxInfoAction, cube.HttpHandler).Methods(http.MethodGet, http.MethodPost)
 	cubeGroup.HandleFunc(cube.SandboxExecAction, cube.HttpHandler).Methods(http.MethodPost)
 	cubeGroup.HandleFunc(cube.SandboxUpdateAction, cube.HttpHandler).Methods(http.MethodPost)
+	cubeGroup.HandleFunc(cube.SandboxTimeoutAction, cube.HttpHandler).Methods(http.MethodPost)
+	cubeGroup.HandleFunc(cube.SandboxRefreshAction, cube.HttpHandler).Methods(http.MethodPost)
 	cubeGroup.HandleFunc(cube.SandboxCommitAction, cube.HttpHandler).Methods(http.MethodPost)
 	cubeGroup.HandleFunc(cube.SandboxRollbackAction, cube.HttpHandler).Methods(http.MethodPost)
 	cubeGroup.HandleFunc(cube.SandboxPreviewAction, cube.HttpHandler).Methods(http.MethodPost)

--- a/CubeMaster/pkg/service/httpservice/cube/cube.go
+++ b/CubeMaster/pkg/service/httpservice/cube/cube.go
@@ -25,6 +25,8 @@ const (
 	SandboxInfoAction              = "/sandbox/info"
 	SandboxExecAction              = "/sandbox/exec"
 	SandboxUpdateAction            = "/sandbox/update"
+	SandboxTimeoutAction           = "/sandbox/timeout"
+	SandboxRefreshAction           = "/sandbox/refresh"
 	SandboxCommitAction            = "/sandbox/commit"
 	SandboxRollbackAction          = "/sandbox/rollback"
 	SnapshotAction                 = "/snapshot"
@@ -80,6 +82,10 @@ func HttpHandler(w http.ResponseWriter, r *http.Request) {
 		rsp = handleSandboxLogsAction(w, r, rt)
 	case r.URL.Path == actionURI(SandboxUpdateAction):
 		rsp = handleUpdateAction(w, r, rt)
+	case r.URL.Path == actionURI(SandboxTimeoutAction):
+		rsp = handleSandboxTimeoutAction(w, r, rt)
+	case r.URL.Path == actionURI(SandboxRefreshAction):
+		rsp = handleSandboxRefreshAction(w, r, rt)
 	case r.URL.Path == actionURI(SandboxCommitAction):
 		rsp = handleSandboxCommitAction(w, r, rt)
 	case r.URL.Path == actionURI(SandboxRollbackAction):

--- a/CubeMaster/pkg/service/httpservice/cube/sandbox_timeout.go
+++ b/CubeMaster/pkg/service/httpservice/cube/sandbox_timeout.go
@@ -1,0 +1,104 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package cube
+
+import (
+	"net/http"
+
+	"github.com/google/uuid"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/api/services/cubebox/v1"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/log"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/utils"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/errorcode"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/service/sandbox"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/service/sandbox/types"
+	"github.com/tencentcloud/CubeSandbox/cubelog"
+)
+
+func handleSandboxTimeoutAction(w http.ResponseWriter, r *http.Request, rt *CubeLog.RequestTrace) interface{} {
+	_ = w
+	if r.Method != http.MethodPost {
+		return &types.SetTimeoutRes{
+			Ret: &types.Ret{
+				RetCode: int(errorcode.ErrorCode_MasterParamsError),
+				RetMsg:  http.StatusText(http.StatusMethodNotAllowed),
+			},
+		}
+	}
+
+	req := &types.SetTimeoutRequest{}
+	if err := utils.DecodeHttpBody(r.Body, req); err != nil {
+		rt.RetCode = int64(errorcode.ErrorCode_MasterParamsError)
+		return &types.SetTimeoutRes{
+			Ret: &types.Ret{
+				RetCode: int(errorcode.ErrorCode_MasterParamsError),
+				RetMsg:  err.Error(),
+			},
+		}
+	}
+	if req.RequestID == "" {
+		req.RequestID = uuid.New().String()
+	}
+	if req.InstanceType == "" {
+		req.InstanceType = cubebox.InstanceType_cubebox.String()
+	}
+	rt.RequestID = req.RequestID
+	rt.InstanceID = req.SandboxID
+	rt.InstanceType = req.InstanceType
+
+	ctx := log.WithLogger(r.Context(), log.G(r.Context()).WithFields(map[string]interface{}{
+		"RequestId":    req.RequestID,
+		"InstanceId":   req.SandboxID,
+		"InstanceType": req.InstanceType,
+	}))
+	res := sandbox.SetTimeout(CubeLog.WithRequestTrace(ctx, rt), req)
+	if res != nil && res.Ret != nil {
+		rt.RetCode = int64(res.Ret.RetCode)
+	}
+	return res
+}
+
+func handleSandboxRefreshAction(w http.ResponseWriter, r *http.Request, rt *CubeLog.RequestTrace) interface{} {
+	_ = w
+	if r.Method != http.MethodPost {
+		return &types.RefreshSandboxRes{
+			Ret: &types.Ret{
+				RetCode: int(errorcode.ErrorCode_MasterParamsError),
+				RetMsg:  http.StatusText(http.StatusMethodNotAllowed),
+			},
+		}
+	}
+
+	req := &types.RefreshSandboxRequest{}
+	if err := utils.DecodeHttpBody(r.Body, req); err != nil {
+		rt.RetCode = int64(errorcode.ErrorCode_MasterParamsError)
+		return &types.RefreshSandboxRes{
+			Ret: &types.Ret{
+				RetCode: int(errorcode.ErrorCode_MasterParamsError),
+				RetMsg:  err.Error(),
+			},
+		}
+	}
+	if req.RequestID == "" {
+		req.RequestID = uuid.New().String()
+	}
+	if req.InstanceType == "" {
+		req.InstanceType = cubebox.InstanceType_cubebox.String()
+	}
+	rt.RequestID = req.RequestID
+	rt.InstanceID = req.SandboxID
+	rt.InstanceType = req.InstanceType
+
+	ctx := log.WithLogger(r.Context(), log.G(r.Context()).WithFields(map[string]interface{}{
+		"RequestId":    req.RequestID,
+		"InstanceId":   req.SandboxID,
+		"InstanceType": req.InstanceType,
+	}))
+	res := sandbox.Refresh(CubeLog.WithRequestTrace(ctx, rt), req)
+	if res != nil && res.Ret != nil {
+		rt.RetCode = int64(res.Ret.RetCode)
+	}
+	return res
+}

--- a/CubeMaster/pkg/service/sandbox/sandbox_info.go
+++ b/CubeMaster/pkg/service/sandbox/sandbox_info.go
@@ -172,6 +172,7 @@ func doget(ctx context.Context, calleep string, cubeletReq *cubebox.ListCubeSand
 		one.TemplateID = templateID
 		one.Annotations = buildAnnotationsFromLabels(sandboxLabels)
 		one.Labels = sandboxLabels
+		one.EndAt = LookupSandboxEndAt(ctx, sandbox.GetId())
 		rsp.Data = append(rsp.Data, one)
 	}
 	return nil

--- a/CubeMaster/pkg/service/sandbox/sandbox_list.go
+++ b/CubeMaster/pkg/service/sandbox/sandbox_list.go
@@ -190,6 +190,7 @@ func doOneList(ctx context.Context, req *types.ListCubeSandboxReq, tmpNode *node
 					NameSpace:   sandbox.GetNamespace(),
 					CreateAt:    sandbox.GetCreatedAt(),
 					PauseAt:     container.GetPausedAt(),
+					EndAt:       LookupSandboxEndAt(ctx, sandbox.GetId()),
 				}:
 				}
 				break

--- a/CubeMaster/pkg/service/sandbox/sandbox_remove.go
+++ b/CubeMaster/pkg/service/sandbox/sandbox_remove.go
@@ -44,6 +44,11 @@ func DestroySandbox(ctx context.Context, req *types.DeleteCubeSandboxReq) (rsp *
 		destroyReq.Annotations = make(map[string]string)
 		destroyReq.Annotations[constants.CubeAnnotationsInsType] = req.InstanceType
 	}
+	reason := req.KillReason
+	if reason == "" {
+		reason = "request"
+	}
+	destroyReq.Annotations[constants.CubeAnnotationsKillReason] = reason
 	collectMemoryOption(req, destroyReq)
 	if config.GetConfig().Common.CubeDestroyCheckFilter {
 

--- a/CubeMaster/pkg/service/sandbox/sandbox_timeout.go
+++ b/CubeMaster/pkg/service/sandbox/sandbox_timeout.go
@@ -1,0 +1,126 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package sandbox
+
+import (
+	"context"
+	"time"
+
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/log"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/utils"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/errorcode"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/localcache"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/service/sandbox/types"
+)
+
+// SetTimeout implements POST /cube/sandbox/timeout. It is the master-side
+// counterpart of CubeAPI's SetTimeoutRequest -> SetTimeoutResponse.
+func SetTimeout(ctx context.Context, req *types.SetTimeoutRequest) (rsp *types.SetTimeoutRes) {
+	rsp = &types.SetTimeoutRes{
+		RequestID: req.RequestID,
+		SandboxID: req.SandboxID,
+		Ret: &types.Ret{
+			RetCode: int(errorcode.ErrorCode_Success),
+			RetMsg:  errorcode.ErrorCode_Success.String(),
+		},
+	}
+	defer func() {
+		logger := log.G(ctx).WithFields(map[string]interface{}{
+			"RequestId": req.RequestID,
+			"RetCode":   int64(rsp.Ret.RetCode),
+		})
+		logger.Infof("SetTimeout:%+v", utils.InterfaceToString(req))
+		if rsp.Ret.RetCode != int(errorcode.ErrorCode_Success) {
+			logger.Errorf("SetTimeout fail:%+v", utils.InterfaceToString(rsp))
+		}
+	}()
+
+	if req.SandboxID == "" {
+		rsp.Ret.RetCode = int(errorcode.ErrorCode_MasterParamsError)
+		rsp.Ret.RetMsg = "should provide sandboxID"
+		return
+	}
+	if req.Timeout <= 0 {
+		rsp.Ret.RetCode = int(errorcode.ErrorCode_MasterParamsError)
+		rsp.Ret.RetMsg = "timeout must be positive (seconds)"
+		return
+	}
+
+	if !sandboxExists(ctx, req.SandboxID) {
+		rsp.Ret.RetCode = int(errorcode.ErrorCode_NotFound)
+		rsp.Ret.RetMsg = "sandbox not found"
+		return
+	}
+
+	endAt := refreshTimeoutMeta(ctx, req.SandboxID, int(req.Timeout))
+	rsp.EndAt = endAt
+	return
+}
+
+// Refresh implements POST /cube/sandbox/refresh. Semantically identical to
+// SetTimeout: refresh(d) rebases the idle clock and sets TimeoutSeconds = d.
+func Refresh(ctx context.Context, req *types.RefreshSandboxRequest) (rsp *types.RefreshSandboxRes) {
+	rsp = &types.RefreshSandboxRes{
+		RequestID: req.RequestID,
+		SandboxID: req.SandboxID,
+		Ret: &types.Ret{
+			RetCode: int(errorcode.ErrorCode_Success),
+			RetMsg:  errorcode.ErrorCode_Success.String(),
+		},
+	}
+	defer func() {
+		logger := log.G(ctx).WithFields(map[string]interface{}{
+			"RequestId": req.RequestID,
+			"RetCode":   int64(rsp.Ret.RetCode),
+		})
+		logger.Infof("RefreshSandbox:%+v", utils.InterfaceToString(req))
+		if rsp.Ret.RetCode != int(errorcode.ErrorCode_Success) {
+			logger.Errorf("RefreshSandbox fail:%+v", utils.InterfaceToString(rsp))
+		}
+	}()
+
+	if req.SandboxID == "" {
+		rsp.Ret.RetCode = int(errorcode.ErrorCode_MasterParamsError)
+		rsp.Ret.RetMsg = "should provide sandboxID"
+		return
+	}
+	if req.Duration <= 0 {
+		rsp.Ret.RetCode = int(errorcode.ErrorCode_MasterParamsError)
+		rsp.Ret.RetMsg = "duration must be positive (seconds)"
+		return
+	}
+
+	if !sandboxExists(ctx, req.SandboxID) {
+		rsp.Ret.RetCode = int(errorcode.ErrorCode_NotFound)
+		rsp.Ret.RetMsg = "sandbox not found"
+		return
+	}
+
+	endAt := refreshTimeoutMeta(ctx, req.SandboxID, int(req.Duration))
+	rsp.EndAt = endAt
+	return
+}
+
+func sandboxExists(ctx context.Context, sandboxID string) bool {
+	if v := localcache.GetSandboxCache(sandboxID); v != nil {
+		return true
+	}
+	if _, ok := localcache.GetSandboxProxyMap(ctx, sandboxID); ok {
+		return true
+	}
+	return false
+}
+
+func refreshTimeoutMeta(ctx context.Context, sandboxID string, timeoutSeconds int) int64 {
+	if p := getTimeoutProvider(); p != nil {
+		endAt, err := p.RefreshTimeout(ctx, sandboxID, timeoutSeconds)
+		if err != nil {
+			log.G(ctx).Warnf("lifecycle: RefreshTimeout sandbox=%s failed: %v", sandboxID, err)
+		} else if endAt > 0 {
+			return endAt
+		}
+	}
+	return time.Now().UnixMilli() + int64(timeoutSeconds)*1000
+}

--- a/CubeMaster/pkg/service/sandbox/timeout_provider.go
+++ b/CubeMaster/pkg/service/sandbox/timeout_provider.go
@@ -1,0 +1,51 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package sandbox
+
+import (
+	"context"
+	"sync"
+)
+
+// TimeoutProvider is the contract sandbox_timeout.go uses to mutate the
+// lifecycle metadata channel without taking a hard build-time dependency on
+// pkg/lifecycle. lifecycle.Init() injects a concrete implementation at startup;
+type TimeoutProvider interface {
+	RefreshTimeout(ctx context.Context, sandboxID string, timeoutSeconds int) (endAtMs int64, err error)
+	LookupEndAt(ctx context.Context, sandboxID string) (endAtMs int64, err error)
+}
+
+var (
+	timeoutProviderMu sync.RWMutex
+	timeoutProvider   TimeoutProvider
+)
+
+// SetTimeoutProvider installs the singleton implementation. lifecycle.Init
+// calls it exactly once during process startup.
+func SetTimeoutProvider(p TimeoutProvider) {
+	timeoutProviderMu.Lock()
+	timeoutProvider = p
+	timeoutProviderMu.Unlock()
+}
+
+func getTimeoutProvider() TimeoutProvider {
+	timeoutProviderMu.RLock()
+	defer timeoutProviderMu.RUnlock()
+	return timeoutProvider
+}
+
+// LookupSandboxEndAt is a thin convenience wrapper around the installed
+// TimeoutProvider's LookupEndAt.
+func LookupSandboxEndAt(ctx context.Context, sandboxID string) int64 {
+	p := getTimeoutProvider()
+	if p == nil || sandboxID == "" {
+		return 0
+	}
+	endAt, err := p.LookupEndAt(ctx, sandboxID)
+	if err != nil {
+		return 0
+	}
+	return endAt
+}

--- a/CubeMaster/pkg/service/sandbox/types/types.go
+++ b/CubeMaster/pkg/service/sandbox/types/types.go
@@ -404,6 +404,11 @@ type DeleteCubeSandboxReq struct {
 	InstanceType string             `json:"instance_type,omitempty"`
 
 	Sync bool `json:"sync,omitempty"`
+
+	// KillReason is a free-form string explaining why this destroy was
+	// initiated. Mirrors e2b's KillReason enum (request | timeout | orphaned
+	// | base_template_missing | ...).
+	KillReason string `json:"kill_reason,omitempty"`
 }
 
 type ListCubeSandboxReq struct {
@@ -439,6 +444,7 @@ type SandboxBriefData struct {
 	NameSpace   string            `json:"namespace,omitempty"`
 	CreateAt    int64             `json:"create_at,omitempty"`
 	PauseAt     int64             `json:"pause_at,omitempty"`
+	EndAt       int64             `json:"end_at,omitempty"`
 }
 
 type GetCubeSandboxReq struct {
@@ -469,6 +475,7 @@ type SandboxData struct {
 	ExposedPortEndpoint    string            `json:"exposed_port_endpoint,omitempty"`
 	ExposedPortMode        string            `json:"exposed_port_mode,omitempty"`
 	RequestedContainerPort int32             `json:"requested_container_port,omitempty"`
+	EndAt                  int64             `json:"end_at,omitempty"`
 }
 
 type ContainerInfo struct {
@@ -655,6 +662,50 @@ type UpdateRequest struct {
 	SandboxID    string `json:"sandbox_id" p:"sandbox_id"  v:"required"`
 	InstanceType string `json:"instance_type" p:"instance_type"  v:"required"`
 	Action       string `json:"action" p:"action"  v:"required"`
+}
+
+// SetTimeoutRequest is the wire shape for POST /cube/sandbox/timeout.
+// Mirrors CubeAPI's SandboxTimeoutRequest field-for-field. `timeout` is the
+// new idle TTL in seconds counted from "now": the master refreshes the
+// lifecycle meta's CreatedAt so the sweeper's
+//
+//	baseline = max(LastActiveMs, CreatedAt)
+//
+// rule treats the sandbox as freshly active and re-arms the
+// timeout-then-kill (or pause) ladder.
+type SetTimeoutRequest struct {
+	RequestID    string `json:"requestID" p:"requestID" v:"required"`
+	SandboxID    string `json:"sandboxID" p:"sandboxID" v:"required"`
+	InstanceType string `json:"instanceType" p:"instanceType"`
+	Timeout      int32  `json:"timeout" p:"timeout"`
+}
+
+// SetTimeoutRes is the master-side response for /cube/sandbox/timeout.
+// EndAt is unix milliseconds and lets CubeAPI / SDK return a deterministic
+type SetTimeoutRes struct {
+	RequestID string `json:"requestID,omitempty"`
+	SandboxID string `json:"sandboxID,omitempty"`
+	EndAt     int64  `json:"end_at,omitempty"`
+	Ret       *Ret   `json:"ret,omitempty"`
+}
+
+// RefreshSandboxRequest extends the sandbox idle window by `duration`
+// seconds. Semantically `refresh(d)` is identical to `set_timeout(d)` in
+// this implementation: both rebase CreatedAt to "now" and set the new
+// TimeoutSeconds. Mirrors e2b's refresh-then-set-timeout convergence.
+type RefreshSandboxRequest struct {
+	RequestID    string `json:"requestID" p:"requestID" v:"required"`
+	SandboxID    string `json:"sandboxID" p:"sandboxID" v:"required"`
+	InstanceType string `json:"instanceType" p:"instanceType"`
+	Duration     int32  `json:"duration" p:"duration"`
+}
+
+// RefreshSandboxRes mirrors SetTimeoutRes.
+type RefreshSandboxRes struct {
+	RequestID string `json:"requestID,omitempty"`
+	SandboxID string `json:"sandboxID,omitempty"`
+	EndAt     int64  `json:"end_at,omitempty"`
+	Ret       *Ret   `json:"ret,omitempty"`
 }
 
 type ListInventoryReq struct {

--- a/CubeProxy/lua/sandbox_state.lua
+++ b/CubeProxy/lua/sandbox_state.lua
@@ -56,6 +56,14 @@ function _M.gate(ins_id)
         ngx.exit(503)
     end
 
+    if state == "killing" or state == "killed" then
+        ngx.log(ngx.WARN, "LEVEL_WARN||",
+            string.format("request %s sandbox %s is %s; returning 410",
+                ngx.var.http_x_cube_request_id or "-", ins_id, state))
+        ngx.var.cube_retcode = "310410"
+        ngx.exit(410)
+    end
+
     if state ~= "paused" then
         -- Unknown state — log once and let the request through; resume logic
         -- only fires for the well-known "paused" value to keep behaviour

--- a/CubeProxy/sidecar/cmd/sidecar/main.go
+++ b/CubeProxy/sidecar/cmd/sidecar/main.go
@@ -232,6 +232,25 @@ func handleEvent(ctx context.Context, ev redisstream.Event, push *proxypush.Clie
 			log.Warn("delete event push failed",
 				zap.String("sandbox_id", ev.SandboxID), zap.Error(err))
 		}
+	case lifecycle.OpUpdate:
+		if ev.Meta == nil {
+			log.Warn("update event missing payload",
+				zap.String("sandbox_id", ev.SandboxID))
+			return
+		}
+		reg.Upsert(*ev.Meta)
+		reg.ResetLastActive(ev.SandboxID)
+		log.Info("update event applied",
+			zap.String("sandbox_id", ev.SandboxID),
+			zap.Bool("auto_pause", ev.Meta.AutoPause),
+			zap.Bool("auto_resume", ev.Meta.AutoResume),
+			zap.Int("timeout_seconds", ev.Meta.TimeoutSeconds),
+			zap.Int64("created_at_ms", ev.Meta.CreatedAt),
+			zap.Int64("end_at_ms", ev.Meta.EndAt))
+		if err := push.UpsertMeta(ctx, *ev.Meta); err != nil {
+			log.Warn("update event push failed",
+				zap.String("sandbox_id", ev.SandboxID), zap.Error(err))
+		}
 	default:
 		log.Warn("unknown event op",
 			zap.String("op", ev.Op),

--- a/CubeProxy/sidecar/internal/cubemasterclient/client.go
+++ b/CubeProxy/sidecar/internal/cubemasterclient/client.go
@@ -39,6 +39,21 @@ const (
 	RetCodeTaskStateInvalid = 130490
 )
 
+const (
+	// KillReasonRequest is an explicit Sandbox.kill() / DELETE call from a
+	// human or SDK client. Used by CubeAPI's kill_sandbox path.
+	KillReasonRequest = "request"
+
+	// KillReasonTimeout is the sidecar sweeper reaping an idle sandbox that
+	// did not opt into auto_pause (lifecycle.on_timeout=kill, the default).
+	KillReasonTimeout = "timeout"
+
+	// KillReasonOrphaned is reserved for future use: a sandbox observed on a
+	// node but missing from the registry / Redis source-of-truth. Mirrors
+	// e2b's orphan reaper.
+	KillReasonOrphaned = "orphaned"
+)
+
 // APIError is returned by the client whenever CubeMaster replies with a
 // non-success ret_code. Callers can errors.As-extract it to react to
 // specific conditions (e.g. "sandbox already paused" → treat as success).
@@ -93,6 +108,14 @@ type updateResponse struct {
 	} `json:"ret"`
 }
 
+type killRequest struct {
+	RequestID    string `json:"requestID"`
+	SandboxID    string `json:"sandbox_id"`
+	InstanceType string `json:"instance_type"`
+	Sync         bool   `json:"sync"`
+	KillReason   string `json:"kill_reason,omitempty"`
+}
+
 // Pause asks CubeMaster to pause the given sandbox. instanceType is required
 // by the master; for the cubebox runtime that's "cubebox".
 //
@@ -107,6 +130,54 @@ func (c *Client) Pause(ctx context.Context, sandboxID, instanceType string) erro
 // as Pause.
 func (c *Client) Resume(ctx context.Context, sandboxID, instanceType string) error {
 	return c.update(ctx, sandboxID, instanceType, "resume")
+}
+
+// Kill asks CubeMaster to destroy the given sandbox.
+func (c *Client) Kill(ctx context.Context, sandboxID, instanceType, reason string) error {
+	if sandboxID == "" || instanceType == "" {
+		return errors.New("sandbox_id and instance_type are required")
+	}
+
+	body, err := json.Marshal(killRequest{
+		RequestID:    uuid.NewString(),
+		SandboxID:    sandboxID,
+		InstanceType: instanceType,
+		Sync:         true,
+		KillReason:   reason,
+	})
+	if err != nil {
+		return fmt.Errorf("marshal: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodDelete,
+		c.baseURL+"/cube/sandbox", bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.httpc.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	raw, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return fmt.Errorf("read body: %w", err)
+	}
+	if resp.StatusCode/100 != 2 {
+		return fmt.Errorf("http %d: %s", resp.StatusCode, raw)
+	}
+
+	var ur updateResponse
+	if err := json.Unmarshal(raw, &ur); err != nil {
+		return fmt.Errorf("decode response: %w (body=%q)", err, raw)
+	}
+	if ur.Ret.RetCode == RetCodeSuccess {
+		return nil
+	}
+	return &APIError{RetCode: ur.Ret.RetCode, RetMsg: ur.Ret.RetMsg}
 }
 
 func (c *Client) update(ctx context.Context, sandboxID, instanceType, action string) error {

--- a/CubeProxy/sidecar/internal/cubemasterclient/client_test.go
+++ b/CubeProxy/sidecar/internal/cubemasterclient/client_test.go
@@ -1,0 +1,98 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package cubemasterclient
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestKill_Success(t *testing.T) {
+	var capturedMethod, capturedPath string
+	var capturedBody killRequest
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedMethod = r.Method
+		capturedPath = r.URL.Path
+		raw, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(raw, &capturedBody)
+		_, _ = w.Write([]byte(`{"ret":{"ret_code":200,"ret_msg":"ok"}}`))
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL, time.Second)
+	if err := c.Kill(context.Background(), "sbx-1", "cubebox", KillReasonTimeout); err != nil {
+		t.Fatalf("Kill returned err: %v", err)
+	}
+	if capturedMethod != http.MethodDelete {
+		t.Fatalf("expected DELETE, got %s", capturedMethod)
+	}
+	if capturedPath != "/cube/sandbox" {
+		t.Fatalf("expected path /cube/sandbox, got %s", capturedPath)
+	}
+	if capturedBody.SandboxID != "sbx-1" || capturedBody.InstanceType != "cubebox" {
+		t.Fatalf("unexpected body: %+v", capturedBody)
+	}
+	if !capturedBody.Sync {
+		t.Fatalf("Kill must request sync=true so the sweeper can evict on success: %+v", capturedBody)
+	}
+	if capturedBody.KillReason != KillReasonTimeout {
+		t.Fatalf("kill_reason should be propagated, got %q", capturedBody.KillReason)
+	}
+}
+
+func TestKill_NotFound(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"ret":{"ret_code":130483,"ret_msg":"key not found"}}`))
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL, time.Second)
+	err := c.Kill(context.Background(), "sbx-1", "cubebox", KillReasonRequest)
+	if err == nil {
+		t.Fatal("expected error for non-success ret_code")
+	}
+	var apiErr *APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("expected *APIError, got %T", err)
+	}
+	if !apiErr.IsNotFound() {
+		t.Fatalf("expected IsNotFound()=true, got false (%+v)", apiErr)
+	}
+}
+
+func TestKill_HTTPError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"ret":{"ret_code":500,"ret_msg":"boom"}}`))
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL, time.Second)
+	err := c.Kill(context.Background(), "sbx-1", "cubebox", "")
+	if err == nil {
+		t.Fatal("expected error on http 500")
+	}
+	var apiErr *APIError
+	if errors.As(err, &apiErr) {
+		t.Fatalf("HTTP-level error should NOT be an *APIError, got %v", err)
+	}
+}
+
+func TestKill_RequiresArgs(t *testing.T) {
+	c := New("http://unused", time.Second)
+	if err := c.Kill(context.Background(), "", "cubebox", ""); err == nil {
+		t.Fatal("Kill must error on empty sandbox_id")
+	}
+	if err := c.Kill(context.Background(), "sbx", "", ""); err == nil {
+		t.Fatal("Kill must error on empty instance_type")
+	}
+}

--- a/CubeProxy/sidecar/internal/lifecycle/parity_test.go
+++ b/CubeProxy/sidecar/internal/lifecycle/parity_test.go
@@ -23,6 +23,7 @@ func TestSchemaConstants(t *testing.T) {
 		{"StateKey", StateKey("test-id"), "cube:v1:shared:sandbox:lifecycle:state:test-id"},
 		{"OpCreate", OpCreate, "create"},
 		{"OpDelete", OpDelete, "delete"},
+		{"OpUpdate", OpUpdate, "update"},
 		{"FieldOp", FieldOp, "op"},
 		{"FieldSandboxID", FieldSandboxID, "sandbox_id"},
 		{"FieldPayload", FieldPayload, "payload"},

--- a/CubeProxy/sidecar/internal/lifecycle/schema.go
+++ b/CubeProxy/sidecar/internal/lifecycle/schema.go
@@ -12,7 +12,8 @@
 // pointer to the canonical definition) is cheaper than the cross-module wire.
 //
 // Source of truth:
-//   CubeMaster/pkg/lifecycle/schema.go
+//
+//	CubeMaster/pkg/lifecycle/schema.go
 //
 // Whenever you change one side, change the other in the same commit.
 package lifecycle
@@ -40,6 +41,7 @@ func StateKey(sandboxID string) string {
 const (
 	OpCreate = "create"
 	OpDelete = "delete"
+	OpUpdate = "update"
 )
 
 // Stream entry field names.
@@ -61,4 +63,5 @@ type SandboxLifecycleMeta struct {
 	AutoPause      bool   `json:"auto_pause,omitempty"`
 	AutoResume     bool   `json:"auto_resume,omitempty"`
 	CreatedAt      int64  `json:"created_at,omitempty"`
+	EndAt          int64  `json:"end_at,omitempty"`
 }

--- a/CubeProxy/sidecar/internal/redisstream/stream.go
+++ b/CubeProxy/sidecar/internal/redisstream/stream.go
@@ -184,7 +184,7 @@ func decodeEvent(msg redis.XMessage) *Event {
 			ev.Timestamp = t
 		}
 	}
-	if op == lifecycle.OpCreate {
+	if op == lifecycle.OpCreate || op == lifecycle.OpUpdate {
 		if payload, ok := msg.Values[lifecycle.FieldPayload].(string); ok && payload != "" {
 			var meta lifecycle.SandboxLifecycleMeta
 			if err := json.Unmarshal([]byte(payload), &meta); err == nil {

--- a/CubeProxy/sidecar/internal/registry/registry.go
+++ b/CubeProxy/sidecar/internal/registry/registry.go
@@ -90,6 +90,19 @@ func (r *Registry) MergeLastActive(sandboxID string, tsMs int64) bool {
 	return false
 }
 
+// ResetLastActive clears LastActiveMs back to 0 for a single sandbox.
+func (r *Registry) ResetLastActive(sandboxID string) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	e, ok := r.entries[sandboxID]
+	if !ok {
+		return false
+	}
+	e.LastActiveMs = 0
+	return true
+}
+
 // Get returns a copy of the entry for inspection. Returns nil when absent.
 func (r *Registry) Get(sandboxID string) *Entry {
 	r.mu.RLock()

--- a/CubeProxy/sidecar/internal/registry/registry_test.go
+++ b/CubeProxy/sidecar/internal/registry/registry_test.go
@@ -53,6 +53,24 @@ func TestMergeLastActive_TakesMaxAndIgnoresUnknown(t *testing.T) {
 	}
 }
 
+func TestResetLastActive(t *testing.T) {
+	r := New()
+	r.Upsert(lifecycle.SandboxLifecycleMeta{SandboxID: "sbx"})
+	if !r.MergeLastActive("sbx", 1234) {
+		t.Fatal("seed: MergeLastActive must advance")
+	}
+
+	if !r.ResetLastActive("sbx") {
+		t.Fatal("ResetLastActive must return true for an existing sandbox")
+	}
+	if got := r.Get("sbx").LastActiveMs; got != 0 {
+		t.Fatalf("ResetLastActive must zero LastActiveMs, got %d", got)
+	}
+	if r.ResetLastActive("nope") {
+		t.Fatal("ResetLastActive on unknown sandbox should return false")
+	}
+}
+
 func TestSnapshot_StableOrderAndCopy(t *testing.T) {
 	r := New()
 	r.Upsert(lifecycle.SandboxLifecycleMeta{SandboxID: "b"})

--- a/CubeProxy/sidecar/internal/sweeper/iface.go
+++ b/CubeProxy/sidecar/internal/sweeper/iface.go
@@ -20,9 +20,11 @@ type stateStore interface {
 	GetState(ctx context.Context, sandboxID string) (string, bool, error)
 }
 
-// pauser is the subset of cubemasterclient.Client that the sweeper needs.
-type pauser interface {
+// pauseKiller is the subset of cubemasterclient.Client that the sweeper needs.
+// Pause + Kill are the two terminal transitions the sweeper can trigger.
+type pauseKiller interface {
 	Pause(ctx context.Context, sandboxID, instanceType string) error
+	Kill(ctx context.Context, sandboxID, instanceType, reason string) error
 }
 
 // stateNotifier is the subset of proxypush.Client that the sweeper needs.

--- a/CubeProxy/sidecar/internal/sweeper/sweeper.go
+++ b/CubeProxy/sidecar/internal/sweeper/sweeper.go
@@ -25,7 +25,7 @@ import (
 type Options struct {
 	Registry           *registry.Registry
 	Redis              stateStore
-	CubeMaster         pauser
+	CubeMaster         pauseKiller
 	ProxyPush          stateNotifier
 	DefaultIdleTimeout time.Duration
 
@@ -59,6 +59,8 @@ type Sweeper struct {
 	// metrics — exposed for testing rather than via Prometheus for now.
 	pauseTriggered atomic.Int64
 	pauseFailed    atomic.Int64
+	killTriggered  atomic.Int64
+	killFailed     atomic.Int64
 }
 
 func New(o Options) *Sweeper {
@@ -107,9 +109,6 @@ func (s *Sweeper) sweepOnce(ctx context.Context) {
 	withinWarmup := now.Sub(s.o.StartedAt) < s.o.BootstrapWarmup
 
 	for _, e := range s.o.Registry.Snapshot() {
-		if !e.Meta.AutoPause {
-			continue
-		}
 		// Bootstrap entries during warmup → skip. `FirstSeenAt <= StartedAt`
 		// (we backdate FirstSeenAt during bootstrap, so equality means
 		// "loaded from HGETALL", inequality means "new event").
@@ -141,34 +140,54 @@ func (s *Sweeper) sweepOnce(ctx context.Context) {
 			continue
 		}
 
-		// Already-paused fast path: if Redis says the sandbox is parked
-		// at terminal "paused", there is nothing for us to do — the
-		// dataplane will resume it on demand. Without this guard the
-		// sweeper logs "idle threshold exceeded" every Interval and the
-		// state-key TTL (StateLockTTL=60s) expires periodically, causing
-		// a pointless RPC churn against CubeMaster every minute.
+		// Already-terminal fast path: if Redis says the sandbox is parked
+		// at "paused", "pausing", "killing", or "killed", there is nothing
+		// for us to do — either the dataplane will resume it on demand
+		// (paused) or the sandbox is on its way out (killing/killed).
+		// Without this guard the sweeper logs "idle threshold exceeded"
+		// every Interval and the state-key TTL (StateLockTTL=60s) expires
+		// periodically, causing a pointless RPC churn against CubeMaster
+		// every minute.
 		curState, _, stateErr := s.o.Redis.GetState(ctx, e.Meta.SandboxID)
 		if stateErr != nil {
-			s.o.Log.Warn("get state failed; will attempt pause anyway",
+			s.o.Log.Warn("get state failed; will attempt action anyway",
 				zap.String("sandbox_id", e.Meta.SandboxID),
 				zap.Error(stateErr))
-		} else if curState == "paused" || curState == "pausing" {
-			// Nothing to do. "pausing" means a peer (or our own previous
-			// invocation) is mid-flight; let it finish.
+		} else if curState == "paused" || curState == "pausing" ||
+			curState == "killing" || curState == "killed" {
+			// Nothing to do. "pausing" / "killing" mean a peer (or our own
+			// previous invocation) is mid-flight; let it finish.
 			continue
 		}
 
-		s.o.Log.Info("idle threshold exceeded; pausing",
-			zap.String("sandbox_id", e.Meta.SandboxID),
-			zap.Duration("idle_for", idleFor),
-			zap.Int("timeout_seconds", e.Meta.TimeoutSeconds))
-
-		if err := s.tryPause(ctx, e); err != nil {
-			s.pauseFailed.Add(1)
-			s.o.Log.Warn("auto-pause failed",
+		switch {
+		case e.Meta.AutoPause:
+			s.o.Log.Info("idle threshold exceeded; pausing",
 				zap.String("sandbox_id", e.Meta.SandboxID),
 				zap.Duration("idle_for", idleFor),
-				zap.Error(err))
+				zap.Int("timeout_seconds", e.Meta.TimeoutSeconds))
+
+			if err := s.tryPause(ctx, e); err != nil {
+				s.pauseFailed.Add(1)
+				s.o.Log.Warn("auto-pause failed",
+					zap.String("sandbox_id", e.Meta.SandboxID),
+					zap.Duration("idle_for", idleFor),
+					zap.Error(err))
+			}
+		default:
+			s.o.Log.Info("idle threshold exceeded; killing",
+				zap.String("sandbox_id", e.Meta.SandboxID),
+				zap.Duration("idle_for", idleFor),
+				zap.Int("timeout_seconds", e.Meta.TimeoutSeconds),
+				zap.String("kill_reason", cubemasterclient.KillReasonTimeout))
+
+			if err := s.tryKill(ctx, e); err != nil {
+				s.killFailed.Add(1)
+				s.o.Log.Warn("timeout-kill failed",
+					zap.String("sandbox_id", e.Meta.SandboxID),
+					zap.Duration("idle_for", idleFor),
+					zap.Error(err))
+			}
 		}
 	}
 }
@@ -260,4 +279,72 @@ func (s *Sweeper) tryPause(ctx context.Context, e registry.Entry) error {
 // Stats returns the running counters, useful for tests and /metrics.
 func (s *Sweeper) Stats() (triggered, failed int64) {
 	return s.pauseTriggered.Load(), s.pauseFailed.Load()
+}
+
+// KillStats returns the kill-path counters, kept separate from Stats() so
+// existing callers / tests that only care about the pause path don't have to
+// change. Mirrors the (triggered, failed) shape of Stats.
+func (s *Sweeper) KillStats() (triggered, failed int64) {
+	return s.killTriggered.Load(), s.killFailed.Load()
+}
+
+// tryKill is the kill-path counterpart of tryPause. Same coordination
+// pattern (SETNX → notify proxy → RPC → finalise), but the terminal state is
+// non-recoverable: on success we evict the registry entry and tell every
+// CubeProxy replica to forget the sandbox. The Lua gate maps `killing` /
+// `killed` to 410 Gone so any in-flight client request fails fast instead of
+// hanging on a doomed retry.
+func (s *Sweeper) tryKill(ctx context.Context, e registry.Entry) error {
+	sid := e.Meta.SandboxID
+	got, err := s.o.Redis.AcquireState(ctx, sid, "killing", s.o.StateLockTTL)
+	if err != nil {
+		return err
+	}
+	if !got {
+		// A peer sidecar (or our own resume / pause path) holds the state.
+		// Skip — the holder will drive the transition.
+		return nil
+	}
+
+	if err := s.o.ProxyPush.SetState(ctx, sid, "killing"); err != nil {
+		s.o.Log.Warn("push killing state failed",
+			zap.String("sandbox_id", sid), zap.Error(err))
+	}
+
+	killErr := s.o.CubeMaster.Kill(ctx, sid, e.Meta.InstanceType, cubemasterclient.KillReasonTimeout)
+	if killErr != nil {
+		var apiErr *cubemasterclient.APIError
+		switch {
+		case errors.As(killErr, &apiErr) && apiErr.IsNotFound():
+			s.o.Log.Info("sandbox not found on cubemaster during kill; evicting from registry",
+				zap.String("sandbox_id", sid),
+				zap.Int("ret_code", apiErr.RetCode),
+				zap.String("ret_msg", apiErr.RetMsg))
+		case errors.As(killErr, &apiErr) && apiErr.IsAlreadyInState():
+			s.o.Log.Info("sandbox already in terminal state on cubemaster; reconciling",
+				zap.String("sandbox_id", sid),
+				zap.Int("ret_code", apiErr.RetCode))
+		default:
+			_ = s.o.Redis.ClearState(ctx, sid)
+			_ = s.o.ProxyPush.SetState(ctx, sid, "running")
+			return errors.New("cubemaster kill: " + killErr.Error())
+		}
+	}
+
+	if err := s.o.Redis.SetState(ctx, sid, "killed", s.o.StateLockTTL); err != nil {
+		s.o.Log.Warn("write killed state failed",
+			zap.String("sandbox_id", sid), zap.Error(err))
+	}
+	if err := s.o.ProxyPush.DeleteMeta(ctx, sid); err != nil {
+		s.o.Log.Warn("delete meta after kill failed",
+			zap.String("sandbox_id", sid), zap.Error(err))
+	}
+	s.o.Registry.Delete(sid)
+
+	s.killTriggered.Add(1)
+	s.o.Log.Info("timeout-killed sandbox",
+		zap.String("sandbox_id", sid),
+		zap.Int("timeout_seconds", e.Meta.TimeoutSeconds),
+		zap.String("kill_reason", cubemasterclient.KillReasonTimeout))
+	return nil
 }

--- a/CubeProxy/sidecar/internal/sweeper/sweeper_test.go
+++ b/CubeProxy/sidecar/internal/sweeper/sweeper_test.go
@@ -75,12 +75,19 @@ func (f *fakeStore) state(sid string) string {
 	return f.states[sid]
 }
 
-// fakeMaster captures every Pause call and lets tests inject an error.
+// fakeMaster captures every Pause / Kill call and lets tests inject errors.
+// The same struct serves both paths so a single sweeper can drive either; the
+// pause-* tests assert on `calls`, the kill-* tests on `killCalls`.
 type fakeMaster struct {
 	mu        sync.Mutex
 	calls     []string
 	failNext  bool
 	failError error
+
+	killCalls    []string
+	killReasons  []string
+	failNextKill bool
+	failKillErr  error
 }
 
 func (f *fakeMaster) Pause(_ context.Context, sid, _ string) error {
@@ -90,6 +97,18 @@ func (f *fakeMaster) Pause(_ context.Context, sid, _ string) error {
 	if f.failNext {
 		f.failNext = false
 		return f.failError
+	}
+	return nil
+}
+
+func (f *fakeMaster) Kill(_ context.Context, sid, _ string, reason string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.killCalls = append(f.killCalls, sid)
+	f.killReasons = append(f.killReasons, reason)
+	if f.failNextKill {
+		f.failNextKill = false
+		return f.failKillErr
 	}
 	return nil
 }
@@ -217,6 +236,115 @@ func TestSweeper_SkipsSandboxWithoutAutoPause(t *testing.T) {
 
 	if len(master.calls) != 0 {
 		t.Fatalf("Pause must NOT fire when AutoPause=false: %v", master.calls)
+	}
+	if len(master.killCalls) != 1 || master.killCalls[0] != "sbx-2" {
+		t.Fatalf("Kill must fire when AutoPause=false: %v", master.killCalls)
+	}
+	if len(master.killReasons) != 1 || master.killReasons[0] != "timeout" {
+		t.Fatalf("sweeper must tag idle kills with reason=timeout: %v", master.killReasons)
+	}
+	if reg.Get("sbx-2") != nil {
+		t.Fatal("registry entry should have been evicted after kill")
+	}
+	if got := push.deletedIDs(); len(got) != 1 || got[0] != "sbx-2" {
+		t.Fatalf("expected DeleteMeta(sbx-2), got %v", got)
+	}
+	if got := store.state("sbx-2"); got != "killed" {
+		t.Fatalf("expected redis state=killed, got %q", got)
+	}
+	pushed := push.states("sbx-2")
+	if len(pushed) == 0 || pushed[0] != "killing" {
+		t.Fatalf("expected first push state=killing, got %v", pushed)
+	}
+	triggered, failed := s.KillStats()
+	if triggered != 1 || failed != 0 {
+		t.Fatalf("kill stats: triggered=%d failed=%d", triggered, failed)
+	}
+}
+
+func TestSweeper_KillRollsBackOnFailure(t *testing.T) {
+	reg := registry.New()
+	store := newFakeStore()
+	master := &fakeMaster{failNextKill: true, failKillErr: errors.New("master 500")}
+	push := newFakePush()
+
+	now := time.Now()
+	seedEntry(t, reg, lifecycle.SandboxLifecycleMeta{
+		SandboxID: "sbx-killfail", InstanceType: "cubebox",
+		AutoPause: false, TimeoutSeconds: 60,
+	}, now.Add(-10*time.Minute).UnixMilli())
+
+	s := newTestSweeper(reg, store, master, push, now)
+	s.sweepOnce(context.Background())
+
+	if got := store.state("sbx-killfail"); got != "" {
+		t.Fatalf("redis state should be cleared after rollback, got %q", got)
+	}
+	pushed := push.states("sbx-killfail")
+	if len(pushed) == 0 || pushed[len(pushed)-1] != "running" {
+		t.Fatalf("rollback should leave proxy at running, got %v", pushed)
+	}
+	if reg.Get("sbx-killfail") == nil {
+		t.Fatal("registry entry should NOT be evicted on kill failure")
+	}
+	_, failed := s.KillStats()
+	if failed != 1 {
+		t.Fatalf("expected kill failed=1, got %d", failed)
+	}
+}
+
+func TestSweeper_KillNotFoundEvictsRegistry(t *testing.T) {
+	reg := registry.New()
+	store := newFakeStore()
+	master := &fakeMaster{
+		failNextKill: true,
+		failKillErr: &cubemasterclient.APIError{
+			RetCode: cubemasterclient.RetCodeInvalidParamFormat,
+			RetMsg:  "key not found",
+		},
+	}
+	push := newFakePush()
+
+	now := time.Now()
+	seedEntry(t, reg, lifecycle.SandboxLifecycleMeta{
+		SandboxID: "sbx-killgone", InstanceType: "cubebox",
+		AutoPause: false, TimeoutSeconds: 60,
+	}, now.Add(-10*time.Minute).UnixMilli())
+
+	s := newTestSweeper(reg, store, master, push, now)
+	s.sweepOnce(context.Background())
+
+	if reg.Get("sbx-killgone") != nil {
+		t.Fatal("registry entry should be evicted on not-found")
+	}
+	if got := push.deletedIDs(); len(got) != 1 || got[0] != "sbx-killgone" {
+		t.Fatalf("expected DeleteMeta(sbx-killgone), got %v", got)
+	}
+	triggered, failed := s.KillStats()
+	if triggered != 1 || failed != 0 {
+		t.Fatalf("not-found is success: triggered=%d failed=%d", triggered, failed)
+	}
+}
+
+func TestSweeper_KillSkipsAlreadyKillingSandbox(t *testing.T) {
+	reg := registry.New()
+	store := newFakeStore()
+	store.states["sbx-killmid"] = "killing"
+
+	master := &fakeMaster{}
+	push := newFakePush()
+
+	now := time.Now()
+	seedEntry(t, reg, lifecycle.SandboxLifecycleMeta{
+		SandboxID: "sbx-killmid", InstanceType: "cubebox",
+		AutoPause: false, TimeoutSeconds: 60,
+	}, now.Add(-1*time.Hour).UnixMilli())
+
+	s := newTestSweeper(reg, store, master, push, now)
+	s.sweepOnce(context.Background())
+
+	if len(master.killCalls) != 0 {
+		t.Fatalf("sweeper must NOT call Kill when peer is mid-flight: %v", master.killCalls)
 	}
 }
 

--- a/docs/guide/lifecycle.md
+++ b/docs/guide/lifecycle.md
@@ -142,23 +142,31 @@ Any of these resets the idle clock:
 - SDK calls: `sandbox.run_code(...)`, `sandbox.commands.run(...)`, `sandbox.files.read(...)` / `write(...)`.
 - Direct HTTP traffic to a service inside the sandbox (e.g. via the URL returned by `getHost()`).
 
-Sandboxes that don't opt in (no `lifecycle` argument) keep the original behaviour: idle timeout → destroy.
+Sandboxes that don't opt in (no `lifecycle` argument) default to `on_timeout="kill"`: once they sit idle for `timeout` seconds the platform destroys them. This matches e2b's `lifecycle.on_timeout="kill"` semantic. If you want a sandbox that never gets reaped automatically, set `timeout` high enough or have the client send periodic activity to reset the idle clock.
 
-### End-to-end example
+### End-to-end examples
 
-[`examples/code-sandbox-quickstart/auto-resume.py`](https://github.com/tencentcloud/CubeSandbox/blob/master/examples/code-sandbox-quickstart/auto-resume.py) is a TUI demo that creates a `lifecycle.on_timeout=pause` sandbox, idles past the timeout to trigger auto-pause, then issues a fresh request to trigger auto-resume — and verifies that both kernel memory and the filesystem are byte-identical across the cycle.
+The platform ships two **mirror-image** end-to-end demos, one per `on_timeout` value:
+
+- [`examples/code-sandbox-quickstart/auto-resume.py`](https://github.com/tencentcloud/CubeSandbox/blob/master/examples/code-sandbox-quickstart/auto-resume.py) — `on_timeout="pause"` + `auto_resume=True`. Creates a sandbox, idles past the timeout to trigger **auto-pause**, then issues a fresh request to trigger **auto-resume**, and verifies that both kernel memory and the filesystem are byte-identical across the cycle.
+- [`examples/code-sandbox-quickstart/auto-kill.py`](https://github.com/tencentcloud/CubeSandbox/blob/master/examples/code-sandbox-quickstart/auto-kill.py) — `on_timeout="kill"` (the default). Creates a sandbox, idles past the timeout to trigger **auto-kill**, verifies that the next request fails fast with 410 Gone, that the sandbox no longer appears in `Sandbox.list()`, and spawns a control sandbox to rule out cluster-wide failures.
 
 ```bash
 export CUBE_TEMPLATE_ID=<your-template>
+
+# Auto-pause + auto-resume
 python examples/code-sandbox-quickstart/auto-resume.py
+
+# Auto-kill (irreversible)
+python examples/code-sandbox-quickstart/auto-kill.py
 ```
 
 ## Operational Notes
 
 - **Pause fidelity**: CPU registers, process memory, TCP state (with no external peer), and filesystem mutations all survive the snapshot. Outbound sockets the sandbox itself opened are dropped on pause and must be reopened by the application after resume.
 - **Cluster coordination**: auto-pause is driven by `cube-proxy-sidecar`, co-resident with each CubeProxy container. It consumes lifecycle events CubeMaster publishes via Redis stream and broadcasts state to every CubeProxy instance. Cross-replica races are resolved by Redis `SETNX` state locks so the same sandbox is never paused or resumed twice concurrently.
-- **Failure mode**: when an auto-resume RPC fails, CubeProxy returns `503 + Retry-After` to the client immediately rather than hanging on a long timeout.
-- **Diagnostics**: `/data/log/cube-proxy/sidecar.log` is the sidecar's runtime log. Look for `create event applied`, `auto-paused sandbox`, `auto-resumed sandbox`.
+- **Failure mode**: when an auto-resume RPC fails, CubeProxy returns `503 + Retry-After` to the client immediately rather than hanging on a long timeout. When the sandbox has already been killed (`killing` / `killed`) the proxy returns `410 Gone` instead, telling SDK clients to stop retrying.
+- **Diagnostics**: `/data/log/cube-proxy/sidecar.log` is the sidecar's runtime log. Look for `create event applied`, `auto-paused sandbox`, `auto-resumed sandbox`, `timeout-killed sandbox`.
 
 ## Next Steps
 

--- a/docs/zh/guide/lifecycle.md
+++ b/docs/zh/guide/lifecycle.md
@@ -141,23 +141,31 @@ sandbox = Sandbox.create(
 - 通过 SDK 调用：`sandbox.run_code(...)`、`sandbox.commands.run(...)`、`sandbox.files.read(...)` / `write(...)`。
 - 通过 HTTP 直连沙箱内的服务（例如 `getHost()` 返回的 URL）。
 
-未配置 `auto_pause` / 不传 `lifecycle` 的沙箱完全保留旧行为：空闲超时直接销毁。
+未配置 `auto_pause` / 不传 `lifecycle` 的沙箱默认行为是 `on_timeout="kill"`：空闲超过 `timeout` 秒后，平台会主动销毁该沙箱。这与 e2b `lifecycle.on_timeout="kill"` 语义一致。如果完全不希望被自动回收，请在创建时把 `timeout` 设得足够大、或主动在客户端发心跳调用刷新 idle 计时。
 
 ### 端到端示例
 
-[`examples/code-sandbox-quickstart/auto-resume.py`](https://github.com/tencentcloud/CubeSandbox/blob/master/examples/code-sandbox-quickstart/auto-resume.py) 是一个 TUI 演示：创建带 `lifecycle.on_timeout=pause` 的沙箱、空闲触发自动暂停、再发请求触发自动恢复，最终对比"内核内存 + 文件系统"两层状态，验证全状态保留。
+平台提供两个**互为镜像**的端到端演示，对应 `on_timeout` 的两种取值：
+
+- [`examples/code-sandbox-quickstart/auto-resume.py`](https://github.com/tencentcloud/CubeSandbox/blob/master/examples/code-sandbox-quickstart/auto-resume.py) —— `on_timeout="pause"` + `auto_resume=True`。创建沙箱、空闲触发**自动暂停**、再发请求触发**自动恢复**，最终对比"内核内存 + 文件系统"两层状态，验证全状态保留。
+- [`examples/code-sandbox-quickstart/auto-kill.py`](https://github.com/tencentcloud/CubeSandbox/blob/master/examples/code-sandbox-quickstart/auto-kill.py) —— `on_timeout="kill"`（默认行为）。创建沙箱、空闲触发**自动销毁**、验证后续请求以 410 Gone 快速失败、`Sandbox.list()` 不再返回该沙箱，并通过创建一个对照沙箱排除集群整体故障。
 
 ```bash
 export CUBE_TEMPLATE_ID=<your-template>
+
+# 自动暂停 + 自动恢复
 python examples/code-sandbox-quickstart/auto-resume.py
+
+# 自动销毁（不可恢复）
+python examples/code-sandbox-quickstart/auto-kill.py
 ```
 
 ## 设计与运维要点
 
 - **暂停的状态保真度**：CPU 寄存器、进程内存、TCP 连接（无外部对端）、文件系统改动都会随快照保留；面向外部的连接（如 sandbox 主动建立的 outbound socket）会在暂停时断开，恢复后由应用层自行重连。
 - **集群一致性**：自动暂停由部署在 CubeProxy 容器内的 `cube-proxy-sidecar` 协调；它消费 CubeMaster 通过 Redis stream 发布的生命周期事件，对所有 CubeProxy 实例广播状态。多副本环境下用 Redis SETNX 互斥锁确保同一沙箱不会被并发暂停或恢复。
-- **失败回退**：自动恢复 RPC 失败时，CubeProxy 直接对客户端返回 503 + `Retry-After`，不会让用户卡在长超时上。
-- **故障排查**：`/data/log/cube-proxy/sidecar.log` 是 sidecar 的运行日志，关键事件包括 `create event applied`、`auto-paused sandbox`、`auto-resumed sandbox`。
+- **失败回退**：自动恢复 RPC 失败时，CubeProxy 直接对客户端返回 503 + `Retry-After`，不会让用户卡在长超时上；当沙箱已经被销毁（`killing` / `killed`），则返回 410 Gone 让客户端立即停止重试。
+- **故障排查**：`/data/log/cube-proxy/sidecar.log` 是 sidecar 的运行日志，关键事件包括 `create event applied`、`auto-paused sandbox`、`auto-resumed sandbox`、`timeout-killed sandbox`。
 
 ## 下一步
 

--- a/examples/code-sandbox-quickstart/README.md
+++ b/examples/code-sandbox-quickstart/README.md
@@ -125,6 +125,7 @@ hello cube
 | `read.py` | `sandbox.files.read()` — read a file from the sandbox filesystem |
 | `pause.py` | `sandbox.pause()` / `sandbox.connect()` — snapshot and restore |
 | `auto_resume.py` | `lifecycle={"on_timeout": "pause", "auto_resume": True}` — let the platform pause idle sandboxes and resume them on the next request |
+| `auto_kill.py` | `lifecycle={"on_timeout": "kill"}` — let the platform tear down idle sandboxes (the default — destruction is irreversible, the sandbox cannot be resumed) |
 | `network_no_internet.py` | `allow_internet_access=False` — fully air-gapped sandbox |
 | `network_allowlist.py` | `allow_out` — whitelist specific CIDRs, block everything else |
 | `network_denylist.py` | `deny_out` — block specific CIDRs, allow the rest |
@@ -176,6 +177,30 @@ sandbox.run_code("print('back from a transparent resume')")
 sandbox.kill()
 ```
 
+### auto_kill.py — Auto Kill on Idle Timeout
+
+The destructive twin of `auto_resume.py`. Setting `on_timeout="kill"` (also the
+default when no `lifecycle` is passed) tells the platform to tear the sandbox
+down once it idles past `timeout` — no snapshot is kept, the next request
+fails fast with **410 Gone**:
+
+```python
+sandbox = Sandbox.create(
+    template=template_id,
+    timeout=30,             # idle threshold the sweeper uses
+    lifecycle={"on_timeout": "kill"},
+)
+sandbox.run_code("print('first call')")
+time.sleep(50)              # exceeds the timeout — sweeper kills the sandbox
+try:
+    sandbox.run_code("print('should never run')")
+except Exception as exc:
+    print(f"sandbox is gone: {exc!r}")  # destruction is final
+```
+
+The TUI version of this demo additionally cross-checks `Sandbox.list()` and
+spawns a control sandbox to rule out cluster-wide failures.
+
 ### Network Policies
 
 ```bash
@@ -210,6 +235,7 @@ code-sandbox-quickstart/
 ├── read.py                    # Read files from the sandbox filesystem
 ├── pause.py                   # Pause and resume a sandbox
 ├── auto_resume.py             # Auto-pause / auto-resume on idle timeout
+├── auto_kill.py               # Auto-kill on idle timeout (destruction is final)
 ├── network_no_internet.py     # Fully air-gapped sandbox
 ├── network_allowlist.py       # Outbound CIDR allowlist
 ├── network_denylist.py        # Outbound CIDR denylist

--- a/examples/code-sandbox-quickstart/README_zh.md
+++ b/examples/code-sandbox-quickstart/README_zh.md
@@ -120,6 +120,7 @@ hello cube
 | `read.py` | `sandbox.files.read()` — 读取沙箱文件系统中的文件 |
 | `pause.py` | `sandbox.pause()` / `sandbox.connect()` — 快照与恢复 |
 | `auto_resume.py` | `lifecycle={"on_timeout": "pause", "auto_resume": True}` — 平台在空闲超时后自动暂停沙箱，下一次请求自动恢复 |
+| `auto_kill.py` | `lifecycle={"on_timeout": "kill"}` — 平台在空闲超时后直接销毁沙箱（默认行为，销毁不可逆，沙箱无法恢复） |
 | `network_no_internet.py` | `allow_internet_access=False` — 完全断网沙箱 |
 | `network_allowlist.py` | `allow_out` — 白名单 CIDR，拦截其余所有出口 |
 | `network_denylist.py` | `deny_out` — 黑名单 CIDR，其余放行 |
@@ -170,6 +171,29 @@ sandbox.run_code("print('back from a transparent resume')")
 sandbox.kill()
 ```
 
+### auto_kill.py — 空闲超时后自动销毁
+
+`auto_resume.py` 的孪生销毁版本。`on_timeout="kill"`（不传 `lifecycle`
+时的默认值）告诉平台：沙箱空闲超过 `timeout` 后直接拆除 VM，不
+保留快照，下一次请求会以 **410 Gone** 快速失败：
+
+```python
+sandbox = Sandbox.create(
+    template=template_id,
+    timeout=30,             # 扫描器使用的空闲阈值
+    lifecycle={"on_timeout": "kill"},
+)
+sandbox.run_code("print('first call')")
+time.sleep(50)              # 超过空闲阈值，扫描器销毁沙箱
+try:
+    sandbox.run_code("print('should never run')")
+except Exception as exc:
+    print(f"sandbox is gone: {exc!r}")  # 销毁不可逆
+```
+
+TUI 版本额外交叉校验 `Sandbox.list()` 不再返回该沙箱，并创建一个对照
+沙箱来排除集群整体故障造成的假阳性。
+
 ### 网络策略
 
 ```bash
@@ -204,6 +228,7 @@ code-sandbox-quickstart/
 ├── read.py                    # 读取沙箱文件系统中的文件
 ├── pause.py                   # 暂停与恢复沙箱
 ├── auto_resume.py             # 自动暂停 / 自动恢复（基于空闲超时）
+├── auto_kill.py               # 空闲超时后自动销毁（不可恢复）
 ├── network_no_internet.py     # 完全断网沙箱
 ├── network_allowlist.py       # 出口 CIDR 白名单
 ├── network_denylist.py        # 出口 CIDR 黑名单

--- a/examples/code-sandbox-quickstart/auto-kill.py
+++ b/examples/code-sandbox-quickstart/auto-kill.py
@@ -1,0 +1,457 @@
+#!/bin/env python3
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Auto-kill (timeout → terminated) TUI demo.
+#
+# Sister demo to auto-resume.py — same five-step storyline, but flipped
+# to the *destructive* lifecycle path: when the sandbox idles past its
+# timeout the platform tears it down for good instead of parking it.
+#
+# Lifecycle config mirrors the e2b SDK
+# (https://e2b.dev/docs/sandbox/auto-resume — same `lifecycle` knob, just
+# `on_timeout="kill"`) so existing e2b code ports with minimal changes.
+# `on_timeout="kill"` is also the default when no lifecycle is supplied,
+# so this demo doubles as a contract-level check of that default.
+#
+# Run:
+#     export CUBE_API_URL=http://<your-cubeapi>:3000
+#     export CUBE_TEMPLATE_ID=<your-template>
+#     python auto-kill.py [--dark]
+
+import argparse
+import os
+import time
+
+from cubesandbox import Sandbox
+from rich import box
+from rich.console import Console
+from rich.panel import Panel
+from rich.progress import BarColumn, Progress, TextColumn
+from rich.syntax import Syntax
+from rich.table import Table
+
+parser = argparse.ArgumentParser(
+    description="Cube Sandbox Auto-Kill (timeout → terminated) TUI Demo"
+)
+parser.add_argument(
+    "--dark",
+    action="store_true",
+    help="Use dark-terminal color theme (default: light)",
+)
+parser.add_argument(
+    "--idle-timeout",
+    type=int,
+    default=30,
+    help="Sandbox idle timeout in seconds before the platform kills it",
+)
+args = parser.parse_args()
+
+# ── Color palette ────────────────────────────────────────────────────────────
+
+if args.dark:
+    PAL = dict(
+        accent="bold cyan",
+        ok="bold green",
+        warn="bold yellow",
+        danger="bold red",
+        layer="cyan",
+        key="magenta",
+        val="green",
+        muted="dim",
+        border_run="green",
+        border_kill="red",
+        border_code="blue",
+        border_out="green",
+        border_ok="green",
+        syntax="monokai",
+        match_yes="bold green",
+        match_no="bold red",
+    )
+else:
+    PAL = dict(
+        accent="bold #1e40af",       # deep blue
+        ok="bold #166534",           # forest green
+        warn="bold #9a3412",         # burnt sienna
+        danger="bold #b91c1c",       # crimson
+        layer="bold #155e75",        # dark teal
+        key="bold #6b21a8",          # dark purple
+        val="#15803d",               # medium green
+        muted="#6b7280",             # slate gray
+        border_run="#166534",
+        border_kill="#b91c1c",
+        border_code="#1e40af",
+        border_out="#166534",
+        border_ok="#166534",
+        syntax="friendly",
+        match_yes="bold #166534",
+        match_no="bold #b91c1c",
+    )
+
+console = Console()
+template_id = os.environ["CUBE_TEMPLATE_ID"]
+
+DEMO_CODE = """\
+import hashlib
+
+data = "Cube Sandbox auto-kill demo"
+hash_val = hashlib.sha256(data.encode()).hexdigest()[:16]
+pi_approx = 4 * sum((-1)**k / (2*k + 1) for k in range(500000))
+
+print(f"sha256    = {hash_val}")
+print(f"pi_approx = {pi_approx:.10f}")
+"""
+
+CHECKPOINT = "/tmp/checkpoint.txt"
+IDLE_TIMEOUT_SECONDS = args.idle_timeout
+
+# Once the platform decides a sandbox is over its idle window with
+# on_timeout="kill", any subsequent request to it should fail fast — typically
+# with 410 Gone surfaced through the SDK as a generic exception. We classify
+# *anything* non-success as "destruction confirmed" rather than trying to match
+# a specific exception subclass: the SDK's exception hierarchy isn't part of
+# Cube's public contract, but the *failure* is.
+TERMINAL_STATES = {"terminated", "killed", "killing", "stopped"}
+
+
+def collect_lines(raw_lines):
+    """on_stdout may deliver multi-line blobs; normalize to individual lines."""
+    return [l for l in "\n".join(raw_lines).splitlines() if l.strip()]
+
+
+def parse_kv(line):
+    """Extract value from 'key = value' formatted output line."""
+    return line.split("=", 1)[1].strip()
+
+
+def status_panel(status, sandbox_id, detail=None):
+    if status == "running":
+        indicator = f"[{PAL['ok']}]●  Running[/]"
+        border = PAL["border_run"]
+    elif status in TERMINAL_STATES:
+        indicator = f"[{PAL['danger']}]✖  {status.capitalize()}[/]"
+        border = PAL["border_kill"]
+    else:
+        indicator = f"[{PAL['muted']}]?  {status!s}[/]"
+        border = PAL["border_kill"]
+    body = f"  Status:  {indicator}\n  ID:      [bold]{sandbox_id}[/]"
+    if detail:
+        body += f"\n  Detail:  [{PAL['muted']}]{detail}[/]"
+    return Panel(body, title="Sandbox Status", border_style=border, padding=(0, 2))
+
+
+def lifecycle_panel():
+    """Render the lifecycle config the demo will pass to Sandbox.create."""
+    body = (
+        f"  [{PAL['key']}]on_timeout[/]  : "
+        f"[{PAL['val']}]\"kill\"[/]    "
+        f"[{PAL['muted']}]# tear the VM down (no snapshot kept)[/]\n"
+        f"  [{PAL['key']}]auto_resume[/] : "
+        f"[{PAL['val']}]N/A[/]       "
+        f"[{PAL['muted']}]# nothing to resume — destruction is final[/]\n"
+        f"  [{PAL['key']}]timeout[/]     : "
+        f"[{PAL['val']}]{IDLE_TIMEOUT_SECONDS}s[/]       "
+        f"[{PAL['muted']}]# idle threshold the sweeper uses[/]"
+    )
+    return Panel(
+        body,
+        title="Lifecycle Config (e2b-compatible)",
+        border_style=PAL["accent"],
+        padding=(0, 2),
+    )
+
+
+def fetch_state(sandbox):
+    """Best-effort state fetch — backend may briefly 5xx during transitions."""
+    try:
+        info = sandbox.get_info()
+        return info.get("state") or "unknown"
+    except Exception as exc:  # noqa: BLE001
+        # Once the sandbox is killed, get_info() typically raises (410 Gone).
+        # We surface that as a synthetic terminal state so the rest of the
+        # demo can pattern-match uniformly.
+        return f"unreachable ({type(exc).__name__})"
+
+
+def is_alive(sandbox_id):
+    """Return True iff the sandbox still appears in Sandbox.list().
+
+    Sandbox.list() filters out terminated sandboxes by default, so absence
+    from the listing is a strong signal that timeout-kill ran end-to-end
+    (sweeper → master → cubelet → list view) — strictly stronger than
+    "get_info raised an exception", which can happen during transient
+    network blips too.
+    """
+    try:
+        return any(sb.get("sandboxID") == sandbox_id for sb in Sandbox.list())
+    except Exception:  # noqa: BLE001
+        # If we can't list at all the cluster itself is in trouble; treat
+        # that as "we don't know" and let the caller decide.
+        return None
+
+
+# ── Title ────────────────────────────────────────────────────────────────────
+
+console.print()
+console.print(
+    Panel(
+        "[bold]Cube Sandbox · Auto-Kill (timeout → terminated) Demo[/]",
+        box=box.DOUBLE,
+        style=PAL["accent"],
+        expand=True,
+    )
+)
+
+# We deliberately do NOT use a `with` block here. The whole point of the
+# demo is that the *platform* tears the sandbox down at idle timeout, so
+# wrapping the run in a context manager that auto-kills on exit would
+# mask whether the lifecycle path actually fired.
+sandbox = Sandbox.create(
+    template=template_id,
+    timeout=IDLE_TIMEOUT_SECONDS,
+    lifecycle={"on_timeout": "kill"},
+)
+sid = sandbox.sandbox_id
+
+try:
+    # ── Step 1: Create Sandbox & Run Computation ─────────────────────────────
+
+    console.rule(f"[{PAL['accent']}]Step 1 · Create Sandbox & Run Computation[/]")
+    console.print(lifecycle_panel())
+    console.print(status_panel("running", sid))
+
+    console.print(
+        Panel(
+            Syntax(
+                DEMO_CODE.strip(),
+                "python",
+                theme=PAL["syntax"],
+                line_numbers=True,
+            ),
+            title="Executing in Sandbox",
+            border_style=PAL["border_code"],
+        )
+    )
+
+    stdout_raw = []
+    sandbox.run_code(DEMO_CODE, on_stdout=lambda m: stdout_raw.append(m.line))
+    output_lines = collect_lines(stdout_raw)
+
+    console.print(
+        Panel(
+            "\n".join(f"  {line}" for line in output_lines),
+            title="Sandbox Output",
+            border_style=PAL["border_out"],
+        )
+    )
+
+    hash_before = parse_kv(output_lines[0])
+    pi_before = parse_kv(output_lines[1])
+
+    ckpt_content = f"hash={hash_before}\npi={pi_before}\n"
+    sandbox.files.write(CHECKPOINT, ckpt_content)
+    console.print(f"  Writing checkpoint file... [{PAL['ok']}]✓[/]\n")
+
+    tbl = Table(title="State Snapshot (Before Idle)", box=box.ROUNDED)
+    tbl.add_column("Layer", style=PAL["layer"])
+    tbl.add_column("Key", style=PAL["key"])
+    tbl.add_column("Value", style=PAL["val"])
+    tbl.add_row("Kernel Memory", "hash_val", hash_before)
+    tbl.add_row("Kernel Memory", "pi_approx", pi_before)
+    tbl.add_row("Filesystem", CHECKPOINT, "2 lines")
+    console.print(tbl)
+    console.print()
+
+    # ── Step 2: Idle — Watch the Platform Kill It ────────────────────────────
+
+    console.rule(
+        f"[{PAL['danger']}]Step 2 · Idle — Watch the Platform Auto-Kill[/]"
+    )
+    console.print(
+        f"  Sandbox timeout is [{PAL['warn']}]{IDLE_TIMEOUT_SECONDS}s[/]. "
+        f"With [{PAL['key']}]on_timeout=\"kill\"[/] the lifecycle sweeper "
+        f"will tear the VM down once the idle window closes — no snapshot "
+        f"is kept, the sandbox cannot be resumed.\n"
+    )
+
+    # Pad the wait a bit past the timeout to give the sweeper its scan
+    # interval (default 5–10s in production) plus a safety margin.
+    wait_for = IDLE_TIMEOUT_SECONDS + 20
+    with Progress(
+        TextColumn("{task.description}"),
+        BarColumn(),
+        TextColumn("{task.completed:.0f}/{task.total:.0f}s"),
+        transient=False,
+    ) as progress:
+        task = progress.add_task(
+            f"[{PAL['warn']}]Idle (no SDK calls — sweeper is in charge)[/]",
+            total=wait_for,
+        )
+        for _ in range(wait_for):
+            time.sleep(1)
+            progress.advance(task)
+
+    state_after_idle = fetch_state(sandbox)
+    listed_alive = is_alive(sid)
+    console.print()
+
+    if state_after_idle.startswith("unreachable") or state_after_idle in TERMINAL_STATES:
+        detail = "Platform killed the VM after the idle window expired"
+    elif listed_alive is False:
+        # get_info may still 200 briefly because of a stale cache, but if
+        # it's gone from the listing the destruction has definitely landed.
+        state_after_idle = "terminated"
+        detail = "Sandbox no longer appears in Sandbox.list() — destruction confirmed"
+    else:
+        detail = (
+            "Sandbox did not get killed within the window — sweeper / "
+            "lifecycle config may be misconfigured"
+        )
+    console.print(status_panel(state_after_idle, sid, detail))
+
+    # ── Step 3: Issue a Request — Confirm It Cannot Be Resumed ───────────────
+
+    console.rule(
+        f"[{PAL['danger']}]Step 3 · Try to Use the Sandbox — Expect Hard Failure[/]"
+    )
+    console.print(
+        f"  Unlike [{PAL['ok']}]auto_resume=True[/], a kill is final. The "
+        f"next call should fail fast — typically with [bold]410 Gone[/] "
+        f"propagated as an SDK exception. We're verifying *failure*, not "
+        f"transparency.\n"
+    )
+
+    resume_failed = False
+    failure_reason = None
+    try:
+        with console.status(
+            f"[{PAL['warn']}]Sending exec — sandbox should be gone...[/]"
+        ):
+            sandbox.run_code('print("should never reach here")')
+    except Exception as exc:  # noqa: BLE001
+        resume_failed = True
+        failure_reason = f"{type(exc).__name__}: {exc}"
+
+    if resume_failed:
+        console.print(
+            Panel(
+                f"[{PAL['ok']}]Request rejected as expected.[/]\n"
+                f"  Reason: [{PAL['muted']}]{failure_reason}[/]",
+                title="Auto-Kill Verified",
+                border_style=PAL["border_ok"],
+                padding=(0, 2),
+            )
+        )
+    else:
+        console.print(
+            Panel(
+                f"[{PAL['danger']}]Request unexpectedly succeeded.[/] "
+                f"The sandbox is still serving traffic — auto-kill did not "
+                f"land. Check the lifecycle sweeper logs in "
+                f"[bold]/data/log/cube-proxy/sidecar.log[/].",
+                title="Auto-Kill Did Not Fire",
+                border_style=PAL["border_kill"],
+                padding=(0, 2),
+            )
+        )
+
+    # ── Step 4: Confirm Destruction Is Final ─────────────────────────────────
+
+    console.rule(f"[{PAL['danger']}]Step 4 · Confirm Destruction Is Final[/]")
+    console.print(
+        f"  Cross-checking against the cluster listing and a fresh sandbox "
+        f"to rule out network blips.\n"
+    )
+
+    cluster_alive = is_alive(sid)
+
+    # Spawn a control sandbox to prove the SDK / cluster are healthy — this
+    # rules out "the previous request failed because everything is broken".
+    control = Sandbox.create(template=template_id, timeout=60)
+    try:
+        control_state = fetch_state(control)
+    finally:
+        # Tidy up immediately; we just needed the create-then-info handshake.
+        try:
+            control.kill()
+        except Exception:  # noqa: BLE001
+            pass
+
+    cmp_tbl = Table(title="Destruction Audit", box=box.ROUNDED)
+    cmp_tbl.add_column("Check", style=PAL["layer"])
+    cmp_tbl.add_column("Expectation", style=PAL["key"])
+    cmp_tbl.add_column("Observed", style=PAL["val"])
+    cmp_tbl.add_column("Result", justify="center")
+
+    audits = [
+        (
+            "next request to original",
+            "raises (410 Gone)",
+            failure_reason or "succeeded",
+            resume_failed,
+        ),
+        (
+            "Sandbox.list() membership",
+            "absent",
+            (
+                "absent"
+                if cluster_alive is False
+                else ("present" if cluster_alive else "list unreachable")
+            ),
+            cluster_alive is False,
+        ),
+        (
+            "control sandbox sanity",
+            "running",
+            control_state,
+            control_state == "running",
+        ),
+    ]
+
+    all_pass = True
+    for name, want, got, ok in audits:
+        all_pass = all_pass and ok
+        mark = f"[{PAL['match_yes']}]PASS[/]" if ok else f"[{PAL['match_no']}]FAIL[/]"
+        cmp_tbl.add_row(name, want, got, mark)
+
+    console.print(cmp_tbl)
+    console.print()
+
+    if all_pass:
+        verdict = (
+            f"[{PAL['ok']}]Auto-kill behaved exactly as advertised: "
+            f"the original sandbox is gone for good and the cluster "
+            f"itself is healthy.[/]"
+        )
+        verdict_border = PAL["border_ok"]
+    else:
+        verdict = (
+            f"[{PAL['danger']}]One or more audits failed — auto-kill did "
+            f"not land cleanly. Inspect the sweeper / lifecycle logs "
+            f"before relying on this in production.[/]"
+        )
+        verdict_border = PAL["border_kill"]
+
+    console.print(
+        Panel(
+            verdict,
+            box=box.DOUBLE,
+            border_style=verdict_border,
+            expand=True,
+        )
+    )
+    console.print()
+
+finally:
+    # Best-effort cleanup. If auto-kill already fired this is a no-op (the
+    # sandbox doesn't exist anymore); if it didn't, we don't want to leak
+    # the VM. Either way swallow exceptions so the demo's verdict above
+    # stays the last thing the user sees.
+    try:
+        sandbox.kill()
+    except Exception as exc:  # noqa: BLE001
+        # Expected on the happy path — the sandbox is already gone.
+        console.print(
+            f"[{PAL['muted']}]cleanup: sandbox.kill() raised {exc!r} "
+            f"(expected if auto-kill already ran)[/]"
+        )


### PR DESCRIPTION
feat: #233 #232 

implement lifecycle:kill base on #613 

### Summary

Bring sandbox lifecycle management to parity with e2b: on top of the existing `auto_pause` flow, add a **timeout-then-kill** default path, implement the previously-stubbed **`set_timeout` / `refresh`** APIs, and surface a deterministic **`end_at`** timestamp across the entire stack.

The change spans four layers — CubeMaster (Go), CubeProxy sidecar (Go), CubeProxy data plane (Lua), CubeAPI (Rust) — plus documentation.

### Motivation

The previous implementation only handled `lifecycle.on_timeout="pause"`:
- Sandboxes **without** `auto_pause` were never reaped on idle timeout and held resources indefinitely.
- `SandboxTimeoutRequest` / `SandboxRefreshRequest` in CubeAPI were marked `❌ not implemented`, so `sandbox.set_timeout()` / `sandbox.refresh()` from the SDK were silent no-ops.
- `GetSandboxResponse.end_at` was always `None`, forcing SDK clients to guess the real expiry.

This PR closes those three gaps in one go, aligning with e2b's `on_timeout="kill"` default and the `set_timeout(duration)` API surface.

### What's changed

#### 1. New timeout → kill path (the new default)

| Component | Change |
|---|---|
| `CubeProxy/sidecar/sweeper` | Stop short-circuiting on `!AutoPause`; dispatch to `tryPause` or `tryKill` based on `auto_pause` when idle threshold is exceeded |
| `cubemasterclient.Kill` | New `DELETE /cube/sandbox` call with `kill_reason=timeout`, reusing the SETNX → push → RPC → finalise pattern from `Pause` |
| `sandbox_state.lua` | Gate recognises `killing` / `killed` states and returns `410 Gone` (retcode `310410`) so SDK clients stop retrying immediately |
| `CubeMaster/sandbox_remove` | `DestroyReq` carries `KillReason`, written into the `cube.master.instance.kill_reason` annotation for audit/billing |
| Terminal-state fast path | Existing fast path extended to `killing` / `killed` to avoid RPC churn after a kill is in flight |

#### 2. New `set_timeout` / `refresh` endpoints (CubeMaster)

| Route | Input | Behaviour |
|---|---|---|
| `POST /cube/sandbox/timeout` | `sandboxID`, `timeout` (seconds) |  set `TimeoutSeconds = timeout`, `EndAt = now + timeout*1000` |
| `POST /cube/sandbox/refresh` | `sandboxID`, `duration` (seconds) | Equivalent to `set_timeout` (matches e2b convergence) |

