### PR TITLE
refactor(templatecenter): fix artifact resource leaks with placement tracking and cascade cleanup

### DIFF
--- a/CubeAPI/src/db.rs
+++ b/CubeAPI/src/db.rs
@@ -811,6 +811,50 @@ LIMIT 1
         .map_err(anyhow::Error::from)
     }
 
+    pub async fn find_template_ids_by_template_or_source_snapshot(
+        &self,
+        id: &str,
+    ) -> anyhow::Result<Vec<String>> {
+        let rows = sqlx::query(
+            r#"
+SELECT template_id
+FROM t_agenthub_template
+WHERE deleted_at IS NULL
+  AND (template_id = ? OR source_snapshot_id = ?)
+"#,
+        )
+        .bind(id)
+        .bind(id)
+        .fetch_all(&self.pool)
+        .await?;
+
+        rows.into_iter()
+            .map(|row| row.try_get("template_id").map_err(anyhow::Error::from))
+            .collect()
+    }
+
+    pub async fn snapshot_has_other_live_template_refs(
+        &self,
+        snapshot_id: &str,
+        exclude_template_id: &str,
+    ) -> anyhow::Result<bool> {
+        let row = sqlx::query(
+            r#"
+SELECT 1
+FROM t_agenthub_template
+WHERE deleted_at IS NULL
+  AND source_snapshot_id = ?
+  AND template_id <> ?
+LIMIT 1
+"#,
+        )
+        .bind(snapshot_id)
+        .bind(exclude_template_id)
+        .fetch_optional(&self.pool)
+        .await?;
+        Ok(row.is_some())
+    }
+
     pub async fn soft_delete_snapshot(
         &self,
         agent_id: &str,

--- a/CubeAPI/src/handlers/agenthub.rs
+++ b/CubeAPI/src/handlers/agenthub.rs
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 Tencent Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{collections::HashMap, fs, path::Path as FsPath, time::Duration};
+use std::{collections::HashMap, fs, path::Path as FsPath, sync::Mutex, time::Duration};
 
 use axum::{extract::Path, extract::State, http::StatusCode, response::IntoResponse, Json};
 use base64::{engine::general_purpose::STANDARD as BASE64, Engine as _};
@@ -55,6 +55,8 @@ const SNAPSHOT_KIND_SANDBOX: &str = "sandbox";
 // They are NOT CubeMaster snapshots, so cascade cleanup must remove the host
 // directory rather than calling the snapshot service.
 const SNAPSHOT_KIND_AGENTHUB_STATE: &str = "agenthub_state";
+
+static OPENCLAW_SNAPSHOT_FS_LOCK: Mutex<()> = Mutex::new(());
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -844,6 +846,11 @@ fn copy_openclaw_state_dir(source: &str, target: &str) -> AppResult<()> {
     if source.trim().is_empty() || !FsPath::new(source).is_dir() {
         return Ok(());
     }
+    let _guard = OPENCLAW_SNAPSHOT_FS_LOCK.lock().map_err(|_| {
+        AppError::Internal(anyhow::anyhow!(
+            "openclaw snapshot filesystem lock poisoned"
+        ))
+    })?;
     fs::create_dir_all(target).map_err(|e| {
         AppError::Internal(anyhow::anyhow!(
             "failed to create cloned OpenClaw state directory {}: {}",
@@ -892,23 +899,31 @@ fn is_valid_agenthub_snapshot_id(snapshot_id: &str) -> bool {
             .all(|b| b.is_ascii_digit() || (b'a'..=b'f').contains(&b))
 }
 
-// remove_openclaw_snapshot_dir idempotently removes the host directory backing
-// an OpenClaw shared-files snapshot. It is hardened against path traversal and
-// symlink escape (S2/R8):
-//   - the id must match the system-generated shape;
-//   - the snapshot root is canonicalized and the target must remain under it;
-//   - a symlink at the top level is unlinked (never followed);
-//   - canonicalize failure on an existing path is fail-closed (refuse, do not
-//     fall back to an unresolved path);
-//   - a missing root/target is treated as success (idempotent).
 fn remove_openclaw_snapshot_dir(snapshot_id: &str) -> AppResult<()> {
+    remove_openclaw_snapshot_dir_under(FsPath::new(OPENCLAW_HOST_SNAPSHOT_ROOT), snapshot_id)
+}
+
+// remove_openclaw_snapshot_dir_under idempotently removes the host directory
+// backing an OpenClaw shared-files snapshot. It is hardened against path
+// traversal and symlink escape (S2/R8):
+//   - the id must match the system-generated shape;
+//   - the snapshot root is canonicalized and the target is constructed as a
+//     direct child of that root;
+//   - the leaf is never canonicalized, so a top-level symlink is unlinked rather
+//     than followed;
+//   - a missing root/target is treated as success (idempotent).
+fn remove_openclaw_snapshot_dir_under(root: &FsPath, snapshot_id: &str) -> AppResult<()> {
     if !is_valid_agenthub_snapshot_id(snapshot_id) {
         return Err(AppError::BadRequest(format!(
             "invalid openclaw snapshot id: {}",
             snapshot_id
         )));
     }
-    let root = FsPath::new(OPENCLAW_HOST_SNAPSHOT_ROOT);
+    let _guard = OPENCLAW_SNAPSHOT_FS_LOCK.lock().map_err(|_| {
+        AppError::Internal(anyhow::anyhow!(
+            "openclaw snapshot filesystem lock poisoned"
+        ))
+    })?;
     let canon_root = match fs::canonicalize(root) {
         Ok(p) => p,
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(()),
@@ -934,23 +949,23 @@ fn remove_openclaw_snapshot_dir(snapshot_id: &str) -> AppResult<()> {
     };
     if meta.file_type().is_symlink() {
         // Remove only the link entry; never follow it to a target outside root.
-        let _ = fs::remove_file(&path);
-        return Ok(());
+        return match fs::remove_file(&path) {
+            Ok(()) => Ok(()),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(e) => Err(AppError::Internal(anyhow::anyhow!(
+                "failed to remove openclaw snapshot symlink {}: {}",
+                snapshot_id,
+                e
+            ))),
+        };
     }
-    let canon = fs::canonicalize(&path).map_err(|e| {
-        AppError::Internal(anyhow::anyhow!(
-            "failed to resolve openclaw snapshot dir {}: {}",
-            snapshot_id,
-            e
-        ))
-    })?;
-    if !canon.starts_with(&canon_root) {
-        return Err(AppError::BadRequest(format!(
-            "openclaw snapshot path escapes managed root: {}",
+    if !meta.is_dir() {
+        return Err(AppError::Internal(anyhow::anyhow!(
+            "openclaw snapshot path {} is not a directory",
             snapshot_id
         )));
     }
-    match fs::remove_dir_all(&canon) {
+    match fs::remove_dir_all(&path) {
         Ok(()) => Ok(()),
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
         Err(e) => Err(AppError::Internal(anyhow::anyhow!(
@@ -1688,15 +1703,15 @@ async fn cascade_delete_backing_snapshot(
     // Guard against shared snapshots: if any other live template still points at
     // this snapshot, leave the physical snapshot intact. Fail-safe — if we
     // cannot determine sharing (DB error), do NOT delete the physical snapshot.
-    let templates = store.list_templates().await.map_err(|e| {
-        AppError::Internal(anyhow::anyhow!(
-            "failed to check snapshot sharing before cascade delete: {}",
-            e
-        ))
-    })?;
-    let still_shared = templates
-        .iter()
-        .any(|t| t.template_id != template_id && t.source_snapshot_id == snapshot_id);
+    let still_shared = store
+        .snapshot_has_other_live_template_refs(snapshot_id, template_id)
+        .await
+        .map_err(|e| {
+            AppError::Internal(anyhow::anyhow!(
+                "failed to check snapshot sharing before cascade delete: {}",
+                e
+            ))
+        })?;
     if still_shared {
         return Ok(());
     }
@@ -3877,6 +3892,12 @@ pub(crate) fn tokenized_gateway_url(url: String, token: Option<String>) -> Strin
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::{
+        fs as test_fs,
+        os::unix::fs as unix_fs,
+        path::PathBuf,
+        time::{SystemTime, UNIX_EPOCH},
+    };
 
     fn llm(provider: &str, credential_mode: &str) -> LlmConfig {
         LlmConfig {
@@ -3886,6 +3907,68 @@ mod tests {
             api_key: "sk-real-secret".to_string(),
             credential_mode: credential_mode.to_string(),
         }
+    }
+
+    fn temp_test_dir(name: &str) -> PathBuf {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time before epoch")
+            .as_nanos();
+        let dir = std::env::temp_dir().join(format!(
+            "cube-api-agenthub-{}-{}-{}",
+            name,
+            std::process::id(),
+            nanos
+        ));
+        test_fs::create_dir_all(&dir).expect("create temp test dir");
+        dir
+    }
+
+    #[test]
+    fn remove_openclaw_snapshot_rejects_invalid_id() {
+        let root = temp_test_dir("invalid-id");
+        let err = remove_openclaw_snapshot_dir_under(&root, "../escape").expect_err("must reject");
+        assert!(matches!(err, AppError::BadRequest(_)));
+        let _ = test_fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn remove_openclaw_snapshot_missing_root_is_idempotent() {
+        let root = temp_test_dir("missing-root");
+        test_fs::remove_dir_all(&root).expect("remove temp root");
+        remove_openclaw_snapshot_dir_under(&root, "agenthub-0123456789abcdef0123456789abcdef")
+            .expect("missing root should be success");
+    }
+
+    #[test]
+    fn remove_openclaw_snapshot_removes_directory_leaf() {
+        let root = temp_test_dir("dir-leaf");
+        let snapshot_id = "agenthub-0123456789abcdef0123456789abcdef";
+        let snapshot_dir = root.join(snapshot_id);
+        test_fs::create_dir_all(&snapshot_dir).expect("create snapshot dir");
+        test_fs::write(snapshot_dir.join("state.json"), "{}").expect("write snapshot file");
+
+        remove_openclaw_snapshot_dir_under(&root, snapshot_id).expect("remove snapshot dir");
+
+        assert!(!snapshot_dir.exists());
+        assert!(root.exists());
+        let _ = test_fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn remove_openclaw_snapshot_unlinks_leaf_symlink_only() {
+        let root = temp_test_dir("symlink-leaf");
+        let outside = temp_test_dir("symlink-target");
+        let snapshot_id = "agenthub-0123456789abcdef0123456789abcdef";
+        test_fs::write(outside.join("keep.txt"), "keep").expect("write outside file");
+        unix_fs::symlink(&outside, root.join(snapshot_id)).expect("create leaf symlink");
+
+        remove_openclaw_snapshot_dir_under(&root, snapshot_id).expect("remove snapshot symlink");
+
+        assert!(!root.join(snapshot_id).exists());
+        assert!(outside.join("keep.txt").exists());
+        let _ = test_fs::remove_dir_all(root);
+        let _ = test_fs::remove_dir_all(outside);
     }
 
     #[test]

--- a/CubeAPI/src/handlers/agenthub.rs
+++ b/CubeAPI/src/handlers/agenthub.rs
@@ -427,7 +427,7 @@ pub async fn create_agent_instance(
             .as_deref()
             .filter(|path| FsPath::new(path).is_dir())
         {
-            copy_openclaw_state_dir(source_path, &state_path)?;
+            copy_openclaw_state_dir(source_path, &state_path).await?;
         }
         let mount_metadata = openclaw_host_mount_metadata(&state_path)?;
         Some((persist_id, state_path, mount_metadata))
@@ -842,7 +842,20 @@ fn prepare_openclaw_state_dir(persist_id: &str) -> AppResult<String> {
     Ok(path)
 }
 
-fn copy_openclaw_state_dir(source: &str, target: &str) -> AppResult<()> {
+async fn copy_openclaw_state_dir(source: &str, target: &str) -> AppResult<()> {
+    let source = source.to_string();
+    let target = target.to_string();
+    tokio::task::spawn_blocking(move || copy_openclaw_state_dir_blocking(&source, &target))
+        .await
+        .map_err(|e| {
+            AppError::Internal(anyhow::anyhow!(
+                "OpenClaw state copy task failed to join: {}",
+                e
+            ))
+        })?
+}
+
+fn copy_openclaw_state_dir_blocking(source: &str, target: &str) -> AppResult<()> {
     if source.trim().is_empty() || !FsPath::new(source).is_dir() {
         return Ok(());
     }
@@ -899,8 +912,21 @@ fn is_valid_agenthub_snapshot_id(snapshot_id: &str) -> bool {
             .all(|b| b.is_ascii_digit() || (b'a'..=b'f').contains(&b))
 }
 
-fn remove_openclaw_snapshot_dir(snapshot_id: &str) -> AppResult<()> {
-    remove_openclaw_snapshot_dir_under(FsPath::new(OPENCLAW_HOST_SNAPSHOT_ROOT), snapshot_id)
+async fn remove_openclaw_snapshot_dir(snapshot_id: &str) -> AppResult<()> {
+    let snapshot_id = snapshot_id.to_string();
+    tokio::task::spawn_blocking(move || {
+        remove_openclaw_snapshot_dir_under_blocking(
+            FsPath::new(OPENCLAW_HOST_SNAPSHOT_ROOT),
+            &snapshot_id,
+        )
+    })
+    .await
+    .map_err(|e| {
+        AppError::Internal(anyhow::anyhow!(
+            "OpenClaw snapshot removal task failed to join: {}",
+            e
+        ))
+    })?
 }
 
 // remove_openclaw_snapshot_dir_under idempotently removes the host directory
@@ -912,10 +938,10 @@ fn remove_openclaw_snapshot_dir(snapshot_id: &str) -> AppResult<()> {
 //   - the leaf is never canonicalized, so a top-level symlink is unlinked rather
 //     than followed;
 //   - a missing root/target is treated as success (idempotent).
-fn remove_openclaw_snapshot_dir_under(root: &FsPath, snapshot_id: &str) -> AppResult<()> {
+fn remove_openclaw_snapshot_dir_under_blocking(root: &FsPath, snapshot_id: &str) -> AppResult<()> {
     if !is_valid_agenthub_snapshot_id(snapshot_id) {
         return Err(AppError::BadRequest(format!(
-            "invalid openclaw snapshot id: {}",
+            "invalid AgentHub snapshot id: {}",
             snapshot_id
         )));
     }
@@ -1561,7 +1587,7 @@ pub async fn delete_agent_snapshot(
 
     match snapshot_kind.as_deref() {
         Some(kind) if kind == SNAPSHOT_KIND_AGENTHUB_STATE => {
-            remove_openclaw_snapshot_dir(&snapshot_id)?;
+            remove_openclaw_snapshot_dir(&snapshot_id).await?;
         }
         _ => {
             delete_cubemaster_snapshot_idempotent(&state, &snapshot_id).await?;
@@ -1729,7 +1755,7 @@ async fn cascade_delete_backing_snapshot(
 
     match snap.snapshot_kind.as_deref() {
         Some(kind) if kind == SNAPSHOT_KIND_AGENTHUB_STATE => {
-            remove_openclaw_snapshot_dir(snapshot_id)?;
+            remove_openclaw_snapshot_dir(snapshot_id).await?;
         }
         _ => {
             delete_cubemaster_snapshot_idempotent(state, snapshot_id).await?;
@@ -1804,7 +1830,7 @@ pub async fn create_agent_snapshot(
             let snapshot_id = new_agenthub_snapshot_id();
             let snapshot_path = openclaw_host_snapshot_path(&snapshot_id);
             let result = async {
-                copy_openclaw_state_dir(source_openclaw_path, &snapshot_path)?;
+                copy_openclaw_state_dir(source_openclaw_path, &snapshot_path).await?;
                 let Some(store) = &task_state.agenthub_store else {
                     return Err(AppError::BadRequest(
                         "AgentHub database persistence is not configured".to_string(),
@@ -1971,7 +1997,7 @@ pub async fn rollback_agent_to_snapshot(
                     "current assistant does not have an OpenClaw host state directory".to_string(),
                 )
             })?;
-        if let Err(err) = copy_openclaw_state_dir(source_path, target_path) {
+        if let Err(err) = copy_openclaw_state_dir(source_path, target_path).await {
             finish_agent_operation(
                 &state,
                 operation_id.as_deref(),
@@ -2166,7 +2192,7 @@ pub async fn clone_agent_instance(
             .as_ref()
             .is_some_and(|source_path| FsPath::new(source_path).is_dir());
         if let Some(source_path) = source_openclaw_state_path.filter(|_| copied_state) {
-            copy_openclaw_state_dir(source_path, &state_path)?;
+            copy_openclaw_state_dir(source_path, &state_path).await?;
         }
         let mount_metadata = openclaw_host_mount_metadata(&state_path)?;
         Some((persist_id, state_path, mount_metadata, copied_state))
@@ -2396,7 +2422,7 @@ pub async fn publish_agent_template(
                     })?;
                 let snapshot_id = new_agenthub_snapshot_id();
                 let snapshot_path = openclaw_host_snapshot_path(&snapshot_id);
-                copy_openclaw_state_dir(source_openclaw_path, &snapshot_path)?;
+                copy_openclaw_state_dir(source_openclaw_path, &snapshot_path).await?;
                 let rootfs_snapshot_id = record
                     .base_snapshot_id
                     .clone()
@@ -3927,7 +3953,8 @@ mod tests {
     #[test]
     fn remove_openclaw_snapshot_rejects_invalid_id() {
         let root = temp_test_dir("invalid-id");
-        let err = remove_openclaw_snapshot_dir_under(&root, "../escape").expect_err("must reject");
+        let err = remove_openclaw_snapshot_dir_under_blocking(&root, "../escape")
+            .expect_err("must reject");
         assert!(matches!(err, AppError::BadRequest(_)));
         let _ = test_fs::remove_dir_all(root);
     }
@@ -3936,8 +3963,11 @@ mod tests {
     fn remove_openclaw_snapshot_missing_root_is_idempotent() {
         let root = temp_test_dir("missing-root");
         test_fs::remove_dir_all(&root).expect("remove temp root");
-        remove_openclaw_snapshot_dir_under(&root, "agenthub-0123456789abcdef0123456789abcdef")
-            .expect("missing root should be success");
+        remove_openclaw_snapshot_dir_under_blocking(
+            &root,
+            "agenthub-0123456789abcdef0123456789abcdef",
+        )
+        .expect("missing root should be success");
     }
 
     #[test]
@@ -3948,7 +3978,8 @@ mod tests {
         test_fs::create_dir_all(&snapshot_dir).expect("create snapshot dir");
         test_fs::write(snapshot_dir.join("state.json"), "{}").expect("write snapshot file");
 
-        remove_openclaw_snapshot_dir_under(&root, snapshot_id).expect("remove snapshot dir");
+        remove_openclaw_snapshot_dir_under_blocking(&root, snapshot_id)
+            .expect("remove snapshot dir");
 
         assert!(!snapshot_dir.exists());
         assert!(root.exists());
@@ -3963,7 +3994,8 @@ mod tests {
         test_fs::write(outside.join("keep.txt"), "keep").expect("write outside file");
         unix_fs::symlink(&outside, root.join(snapshot_id)).expect("create leaf symlink");
 
-        remove_openclaw_snapshot_dir_under(&root, snapshot_id).expect("remove snapshot symlink");
+        remove_openclaw_snapshot_dir_under_blocking(&root, snapshot_id)
+            .expect("remove snapshot symlink");
 
         assert!(!root.join(snapshot_id).exists());
         assert!(outside.join("keep.txt").exists());

--- a/CubeAPI/src/handlers/agenthub.rs
+++ b/CubeAPI/src/handlers/agenthub.rs
@@ -50,6 +50,11 @@ const PERSISTENCE_MODE_SHARED_FILES: &str = "shared_files";
 const ROOTFS_SOURCE_TEMPLATE: &str = "template";
 const ROOTFS_SOURCE_SNAPSHOT: &str = "snapshot";
 const SNAPSHOT_KIND_SANDBOX: &str = "sandbox";
+// OpenClaw shared-files snapshots persist as a host directory rooted at
+// OPENCLAW_HOST_SNAPSHOT_ROOT and are recorded with this kind (db.rs upsert).
+// They are NOT CubeMaster snapshots, so cascade cleanup must remove the host
+// directory rather than calling the snapshot service.
+const SNAPSHOT_KIND_AGENTHUB_STATE: &str = "agenthub_state";
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -873,6 +878,103 @@ fn copy_openclaw_state_dir(source: &str, target: &str) -> AppResult<()> {
     Ok(())
 }
 
+// is_valid_agenthub_snapshot_id enforces the exact shape produced by
+// new_agenthub_snapshot_id (`agenthub-` + 32 lowercase hex). Any other value is
+// rejected before it is used to build a filesystem path, so a polluted /
+// attacker-controlled id can never traverse outside the managed snapshot root.
+fn is_valid_agenthub_snapshot_id(snapshot_id: &str) -> bool {
+    let Some(hex) = snapshot_id.strip_prefix("agenthub-") else {
+        return false;
+    };
+    hex.len() == 32
+        && hex
+            .bytes()
+            .all(|b| b.is_ascii_digit() || (b'a'..=b'f').contains(&b))
+}
+
+// remove_openclaw_snapshot_dir idempotently removes the host directory backing
+// an OpenClaw shared-files snapshot. It is hardened against path traversal and
+// symlink escape (S2/R8):
+//   - the id must match the system-generated shape;
+//   - the snapshot root is canonicalized and the target must remain under it;
+//   - a symlink at the top level is unlinked (never followed);
+//   - canonicalize failure on an existing path is fail-closed (refuse, do not
+//     fall back to an unresolved path);
+//   - a missing root/target is treated as success (idempotent).
+fn remove_openclaw_snapshot_dir(snapshot_id: &str) -> AppResult<()> {
+    if !is_valid_agenthub_snapshot_id(snapshot_id) {
+        return Err(AppError::BadRequest(format!(
+            "invalid openclaw snapshot id: {}",
+            snapshot_id
+        )));
+    }
+    let root = FsPath::new(OPENCLAW_HOST_SNAPSHOT_ROOT);
+    let canon_root = match fs::canonicalize(root) {
+        Ok(p) => p,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(e) => {
+            return Err(AppError::Internal(anyhow::anyhow!(
+                "openclaw snapshot root {} not resolvable: {}",
+                OPENCLAW_HOST_SNAPSHOT_ROOT,
+                e
+            )));
+        }
+    };
+    let path = canon_root.join(snapshot_id);
+    let meta = match fs::symlink_metadata(&path) {
+        Ok(meta) => meta,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(e) => {
+            return Err(AppError::Internal(anyhow::anyhow!(
+                "failed to stat openclaw snapshot dir {}: {}",
+                snapshot_id,
+                e
+            )));
+        }
+    };
+    if meta.file_type().is_symlink() {
+        // Remove only the link entry; never follow it to a target outside root.
+        let _ = fs::remove_file(&path);
+        return Ok(());
+    }
+    let canon = fs::canonicalize(&path).map_err(|e| {
+        AppError::Internal(anyhow::anyhow!(
+            "failed to resolve openclaw snapshot dir {}: {}",
+            snapshot_id,
+            e
+        ))
+    })?;
+    if !canon.starts_with(&canon_root) {
+        return Err(AppError::BadRequest(format!(
+            "openclaw snapshot path escapes managed root: {}",
+            snapshot_id
+        )));
+    }
+    match fs::remove_dir_all(&canon) {
+        Ok(()) => Ok(()),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(e) => Err(AppError::Internal(anyhow::anyhow!(
+            "failed to remove openclaw snapshot dir {}: {}",
+            snapshot_id,
+            e
+        ))),
+    }
+}
+
+// delete_cubemaster_snapshot_idempotent wraps the snapshot service delete so a
+// NotFound (already removed) is success — the cascade and any retry must be
+// idempotent (C3/F4: the underlying delete is not).
+async fn delete_cubemaster_snapshot_idempotent(
+    state: &AppState,
+    snapshot_id: &str,
+) -> AppResult<()> {
+    match state.services.snapshots.delete(snapshot_id).await {
+        Ok(_) => Ok(()),
+        Err(AppError::NotFound(_)) => Ok(()),
+        Err(e) => Err(e),
+    }
+}
+
 fn openclaw_host_mount_metadata(host_path: &str) -> AppResult<String> {
     serde_json::to_string(&serde_json::json!([{
         "hostPath": host_path,
@@ -1422,6 +1524,10 @@ pub async fn delete_agent_snapshot(
     Path((agent_id, snapshot_id)): Path<(String, String)>,
 ) -> AppResult<impl IntoResponse> {
     let record = read_agenthub_instance(&state, &agent_id).await?;
+    // Resolve the snapshot kind up front so we route physical cleanup to the
+    // right backend (OpenClaw host dir vs CubeMaster snapshot). The referenced
+    // guard is preserved.
+    let mut snapshot_kind: Option<String> = None;
     if let Some(store) = &state.agenthub_store {
         if let Ok(records) = store.list_snapshots(&agent_id).await {
             if records
@@ -1433,9 +1539,20 @@ pub async fn delete_agent_snapshot(
                 ));
             }
         }
+        if let Ok(Some(snap)) = store.get_snapshot(&record.agent_id, &snapshot_id).await {
+            snapshot_kind = snap.snapshot_kind;
+        }
     }
 
-    state.services.snapshots.delete(&snapshot_id).await?;
+    match snapshot_kind.as_deref() {
+        Some(kind) if kind == SNAPSHOT_KIND_AGENTHUB_STATE => {
+            remove_openclaw_snapshot_dir(&snapshot_id)?;
+        }
+        _ => {
+            delete_cubemaster_snapshot_idempotent(&state, &snapshot_id).await?;
+        }
+    }
+
     if let Some(store) = &state.agenthub_store {
         store
             .soft_delete_snapshot(&record.agent_id, &snapshot_id)
@@ -1525,6 +1642,26 @@ pub async fn delete_agent_template(
     let store = state.agenthub_store.as_ref().ok_or_else(|| {
         AppError::BadRequest("AgentHub database persistence is not configured".to_string())
     })?;
+
+    // Cascade to the backing snapshot before removing the registration row
+    // (先物理后元数据). Market templates intentionally do NOT cascade to their
+    // shared `tpl-*` infrastructure template; that is reclaimed by the
+    // infrastructure DELETE /templates path + reference counting.
+    if let Some(record) = store.get_template(&template_id).await.map_err(|e| {
+        AppError::Internal(anyhow::anyhow!("failed to load AgentHub template: {}", e))
+    })? {
+        if record.source_agent_id != "market" {
+            cascade_delete_backing_snapshot(
+                &state,
+                store,
+                &template_id,
+                &record.source_agent_id,
+                &record.source_snapshot_id,
+            )
+            .await?;
+        }
+    }
+
     store
         .soft_delete_template(&template_id)
         .await
@@ -1532,6 +1669,64 @@ pub async fn delete_agent_template(
             AppError::Internal(anyhow::anyhow!("failed to delete AgentHub template: {}", e))
         })?;
     Ok(StatusCode::NO_CONTENT)
+}
+
+// cascade_delete_backing_snapshot removes the snapshot backing an AgentHub
+// template (its host OpenClaw state dir or CubeMaster sandbox snapshot) and
+// soft-deletes the snapshot row. It never deletes a snapshot still referenced
+// by another (non-deleted) template, and never cascades to shared rootfs.
+async fn cascade_delete_backing_snapshot(
+    state: &AppState,
+    store: &crate::db::AgentHubStore,
+    template_id: &str,
+    agent_id: &str,
+    snapshot_id: &str,
+) -> AppResult<()> {
+    if snapshot_id.trim().is_empty() {
+        return Ok(());
+    }
+    // Guard against shared snapshots: if any other live template still points at
+    // this snapshot, leave the physical snapshot intact. Fail-safe — if we
+    // cannot determine sharing (DB error), do NOT delete the physical snapshot.
+    let templates = store.list_templates().await.map_err(|e| {
+        AppError::Internal(anyhow::anyhow!(
+            "failed to check snapshot sharing before cascade delete: {}",
+            e
+        ))
+    })?;
+    let still_shared = templates
+        .iter()
+        .any(|t| t.template_id != template_id && t.source_snapshot_id == snapshot_id);
+    if still_shared {
+        return Ok(());
+    }
+
+    let snap = store
+        .get_snapshot(agent_id, snapshot_id)
+        .await
+        .map_err(|e| {
+            AppError::Internal(anyhow::anyhow!("failed to load AgentHub snapshot: {}", e))
+        })?;
+    let Some(snap) = snap else {
+        // Snapshot row already gone; nothing to cascade.
+        return Ok(());
+    };
+
+    match snap.snapshot_kind.as_deref() {
+        Some(kind) if kind == SNAPSHOT_KIND_AGENTHUB_STATE => {
+            remove_openclaw_snapshot_dir(snapshot_id)?;
+        }
+        _ => {
+            delete_cubemaster_snapshot_idempotent(state, snapshot_id).await?;
+        }
+    }
+    store
+        .soft_delete_snapshot(agent_id, snapshot_id)
+        .await
+        .map_err(|e| {
+            AppError::Internal(anyhow::anyhow!("failed to delete AgentHub snapshot: {}", e))
+        })?;
+    Ok(())
 }
 
 pub async fn list_agent_operations(

--- a/CubeAPI/src/handlers/templates.rs
+++ b/CubeAPI/src/handlers/templates.rs
@@ -174,16 +174,49 @@ pub async fn delete_template(
         if let Ok(value) = HeaderValue::from_str(&resp.operation_id) {
             headers.insert("x-operation-id", value);
         }
+        reverse_sync_agenthub_template(&state, &template_id).await;
         return Ok((StatusCode::NO_CONTENT, headers).into_response());
     }
 
     state
         .services
         .templates
-        .delete_template(template_id, params.instance_type, params.sync)
+        .delete_template(template_id.clone(), params.instance_type, params.sync)
         .await?;
 
+    reverse_sync_agenthub_template(&state, &template_id).await;
+
     Ok(StatusCode::NO_CONTENT.into_response())
+}
+
+// reverse_sync_agenthub_template best-effort soft-deletes any AgentHub template
+// registration backed by the just-deleted infrastructure template/snapshot
+// (FIX-5b, L15/H5). It keeps the AgentHub registry from referencing a snapshot
+// that no longer exists. Failures are logged, never propagated, so they cannot
+// block the primary deletion.
+async fn reverse_sync_agenthub_template(state: &AppState, id: &str) {
+    let Some(store) = state.agenthub_store.as_ref() else {
+        return;
+    };
+    match store.list_templates().await {
+        Ok(templates) => {
+            for t in templates
+                .iter()
+                .filter(|t| t.template_id == id || t.source_snapshot_id == id)
+            {
+                if let Err(e) = store.soft_delete_template(&t.template_id).await {
+                    tracing::warn!(
+                        "reverse sync: failed to soft-delete AgentHub template {}: {}",
+                        t.template_id,
+                        e
+                    );
+                }
+            }
+        }
+        Err(e) => {
+            tracing::warn!("reverse sync: list AgentHub templates failed: {}", e);
+        }
+    }
 }
 
 // ─── POST /templates/:templateID/builds/:buildID ──────────────────────────────

--- a/CubeAPI/src/handlers/templates.rs
+++ b/CubeAPI/src/handlers/templates.rs
@@ -198,23 +198,23 @@ async fn reverse_sync_agenthub_template(state: &AppState, id: &str) {
     let Some(store) = state.agenthub_store.as_ref() else {
         return;
     };
-    match store.list_templates().await {
-        Ok(templates) => {
-            for t in templates
-                .iter()
-                .filter(|t| t.template_id == id || t.source_snapshot_id == id)
-            {
-                if let Err(e) = store.soft_delete_template(&t.template_id).await {
+    match store
+        .find_template_ids_by_template_or_source_snapshot(id)
+        .await
+    {
+        Ok(template_ids) => {
+            for template_id in template_ids {
+                if let Err(e) = store.soft_delete_template(&template_id).await {
                     tracing::warn!(
                         "reverse sync: failed to soft-delete AgentHub template {}: {}",
-                        t.template_id,
+                        template_id,
                         e
                     );
                 }
             }
         }
         Err(e) => {
-            tracing::warn!("reverse sync: list AgentHub templates failed: {}", e);
+            tracing::warn!("reverse sync: query AgentHub templates failed: {}", e);
         }
     }
 }

--- a/CubeAPI/src/services/sandboxes.rs
+++ b/CubeAPI/src/services/sandboxes.rs
@@ -988,6 +988,7 @@ mod tests {
             exposed_ports: vec![],
             network_type: None,
             cube_network_config: None,
+            distribution_scope: None,
             auto_pause: false,
             auto_resume: false,
         };

--- a/CubeMaster/pkg/base/constants/constants.go
+++ b/CubeMaster/pkg/base/constants/constants.go
@@ -171,6 +171,11 @@ const (
 	TemplateImageJobTableName   = "t_cube_template_image_job"
 	SnapshotRuntimeRefTableName = "t_cube_snapshot_runtime_ref"
 	SandboxSpecTableName        = "t_cube_sandbox_spec"
+	// ArtifactNodePlacementTableName records on which nodes an ext4 rootfs
+	// artifact is physically present, independent of replica lifecycle, so the
+	// last-owner-cleanup / GC paths can enumerate every node that ever held an
+	// artifact even after the referencing replica rows are gone.
+	ArtifactNodePlacementTableName = "t_cube_artifact_node_placement"
 )
 
 const (

--- a/CubeMaster/pkg/base/dao/migrate/migrations/mysql/20260623145000_artifact_node_placement.sql
+++ b/CubeMaster/pkg/base/dao/migrate/migrations/mysql/20260623145000_artifact_node_placement.sql
@@ -1,0 +1,61 @@
+-- Copyright (c) 2026 Tencent Inc.
+-- SPDX-License-Identifier: Apache-2.0
+--
+-- Artifact node placement table (FIX-1, last-owner-cleanup).
+--
+-- t_cube_template_replica is a per-template *reference* record; once a
+-- template stops referencing an artifact its replica rows are deleted. That
+-- makes it impossible for the last deleter (or GC) to know which nodes still
+-- physically hold a shared, fingerprint-deduped artifact's ext4 files, which
+-- previously leaked cubebox_os_image directories on nodes.
+--
+-- This migration introduces an independent placement record written when an
+-- artifact is distributed to a node and cleared only when the artifact itself
+-- is fully removed. It also backfills existing replica bindings so the first
+-- post-upgrade cleanup does not miss already-distributed artifacts.
+
+-- +goose NO TRANSACTION
+-- +goose Up
+
+CALL cubemaster_acquire_migration_lock('cubemaster_migration_20260623145000_artifact_node_placement', 60);
+
+CREATE TABLE IF NOT EXISTS `t_cube_artifact_node_placement` (
+  `artifact_id` varchar(128) NOT NULL,
+  `node_id` varchar(128) NOT NULL,
+  `node_ip` varchar(64) NOT NULL DEFAULT '',
+  `created_at` bigint NOT NULL DEFAULT 0,
+  PRIMARY KEY (`artifact_id`, `node_id`),
+  KEY `idx_artifact` (`artifact_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- Backfill from existing replica bindings. Newer rows have a stable node_id,
+-- while legacy/degenerate rows may only carry node_ip. Preserve those rows by
+-- synthesising a deterministic placement key `ip:<node_ip>` for the primary
+-- key; cleanup still uses the recorded node_ip for the Cubelet RPC address.
+-- INSERT IGNORE keeps re-runs idempotent.
+INSERT IGNORE INTO `t_cube_artifact_node_placement` (`artifact_id`, `node_id`, `node_ip`, `created_at`)
+SELECT r.`artifact_id`,
+       CASE
+         WHEN r.`node_id` IS NOT NULL AND TRIM(r.`node_id`) <> '' THEN TRIM(r.`node_id`)
+         ELSE CONCAT('ip:', TRIM(r.`node_ip`))
+       END AS `placement_node_id`,
+       COALESCE(MAX(NULLIF(TRIM(r.`node_ip`), '')), ''),
+       UNIX_TIMESTAMP()
+FROM `t_cube_template_replica` r
+WHERE r.`artifact_id` IS NOT NULL
+  AND r.`artifact_id` <> ''
+  AND (
+    (r.`node_id` IS NOT NULL AND TRIM(r.`node_id`) <> '')
+    OR (r.`node_ip` IS NOT NULL AND TRIM(r.`node_ip`) <> '')
+  )
+GROUP BY r.`artifact_id`, `placement_node_id`;
+
+SELECT RELEASE_LOCK('cubemaster_migration_20260623145000_artifact_node_placement');
+
+-- +goose Down
+
+CALL cubemaster_acquire_migration_lock('cubemaster_migration_20260623145000_artifact_node_placement', 60);
+
+DROP TABLE IF EXISTS `t_cube_artifact_node_placement`;
+
+SELECT RELEASE_LOCK('cubemaster_migration_20260623145000_artifact_node_placement');

--- a/CubeMaster/pkg/base/dao/migrate/migrations/mysql/20260624113500_agenthub_template_source_snapshot_index.sql
+++ b/CubeMaster/pkg/base/dao/migrate/migrations/mysql/20260624113500_agenthub_template_source_snapshot_index.sql
@@ -1,0 +1,51 @@
+-- Copyright (c) 2026 Tencent Inc.
+-- SPDX-License-Identifier: Apache-2.0
+--
+-- Add an index for AgentHub template reverse lookups by source snapshot.
+
+-- +goose NO TRANSACTION
+-- +goose Up
+
+CALL cubemaster_acquire_migration_lock('cubemaster_migration_20260624113500_agenthub_tpl_srcsnap_idx', 60);
+
+SET @agenthub_template_source_snapshot_index_exists := (
+  SELECT COUNT(1)
+  FROM INFORMATION_SCHEMA.STATISTICS
+  WHERE TABLE_SCHEMA = DATABASE()
+    AND TABLE_NAME = 't_agenthub_template'
+    AND INDEX_NAME = 'idx_agenthub_template_source_snapshot'
+);
+
+SET @agenthub_template_source_snapshot_index_sql := IF(
+  @agenthub_template_source_snapshot_index_exists = 0,
+  'ALTER TABLE `t_agenthub_template` ADD INDEX `idx_agenthub_template_source_snapshot` (`source_snapshot_id`, `deleted_at`, `template_id`)',
+  'SELECT 1'
+);
+PREPARE stmt FROM @agenthub_template_source_snapshot_index_sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+SELECT RELEASE_LOCK('cubemaster_migration_20260624113500_agenthub_tpl_srcsnap_idx');
+
+-- +goose Down
+
+CALL cubemaster_acquire_migration_lock('cubemaster_migration_20260624113500_agenthub_tpl_srcsnap_idx', 60);
+
+SET @agenthub_template_source_snapshot_index_exists := (
+  SELECT COUNT(1)
+  FROM INFORMATION_SCHEMA.STATISTICS
+  WHERE TABLE_SCHEMA = DATABASE()
+    AND TABLE_NAME = 't_agenthub_template'
+    AND INDEX_NAME = 'idx_agenthub_template_source_snapshot'
+);
+
+SET @agenthub_template_source_snapshot_index_down_sql := IF(
+  @agenthub_template_source_snapshot_index_exists > 0,
+  'ALTER TABLE `t_agenthub_template` DROP INDEX `idx_agenthub_template_source_snapshot`',
+  'SELECT 1'
+);
+PREPARE stmt FROM @agenthub_template_source_snapshot_index_down_sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+SELECT RELEASE_LOCK('cubemaster_migration_20260624113500_agenthub_tpl_srcsnap_idx');

--- a/CubeMaster/pkg/base/dao/migrate/migrations/mysql/20260624121500_template_definition_rootfs_artifact_id.sql
+++ b/CubeMaster/pkg/base/dao/migrate/migrations/mysql/20260624121500_template_definition_rootfs_artifact_id.sql
@@ -1,0 +1,44 @@
+-- Copyright (c) 2026 Tencent Inc.
+-- SPDX-License-Identifier: Apache-2.0
+--
+-- Add an indexed rootfs artifact reference on template definitions so cleanup
+-- can count live owners without scanning request_json under artifact row locks.
+
+-- +goose NO TRANSACTION
+-- +goose Up
+
+CALL cubemaster_acquire_migration_lock('cubemaster_migration_20260624121500_tpl_def_rootfs_idx', 60);
+
+CALL cubemaster_add_column_if_missing(
+  't_cube_template_definition',
+  'rootfs_artifact_id',
+  "varchar(128) NOT NULL DEFAULT '' COMMENT 'rootfs artifact id' AFTER `rootfs_size_bytes_at_snapshot`"
+);
+
+UPDATE `t_cube_template_definition` AS d
+JOIN `t_cube_rootfs_artifact` AS a
+  ON d.`rootfs_artifact_id` = ''
+ AND a.`artifact_id` <> ''
+ AND INSTR(d.`request_json`, a.`artifact_id`) > 0
+SET d.`rootfs_artifact_id` = a.`artifact_id`;
+
+CALL cubemaster_add_index_if_missing(
+  't_cube_template_definition',
+  'idx_template_definition_rootfs_artifact',
+  'ADD INDEX `idx_template_definition_rootfs_artifact` (`rootfs_artifact_id`, `deleted_at`, `template_id`)'
+);
+
+SELECT RELEASE_LOCK('cubemaster_migration_20260624121500_tpl_def_rootfs_idx');
+
+-- +goose Down
+
+CALL cubemaster_acquire_migration_lock('cubemaster_migration_20260624121500_tpl_def_rootfs_idx', 60);
+
+CALL cubemaster_drop_index_if_exists(
+  't_cube_template_definition',
+  'idx_template_definition_rootfs_artifact'
+);
+
+CALL cubemaster_drop_column_if_exists('t_cube_template_definition', 'rootfs_artifact_id');
+
+SELECT RELEASE_LOCK('cubemaster_migration_20260624121500_tpl_def_rootfs_idx');

--- a/CubeMaster/pkg/base/db/models/artifact_placement.go
+++ b/CubeMaster/pkg/base/db/models/artifact_placement.go
@@ -1,0 +1,23 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package models
+
+import "github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/constants"
+
+// ArtifactNodePlacement records that a given ext4 rootfs artifact is (or was)
+// physically distributed to a node. Unlike t_cube_template_replica it is not
+// tied to a template's lifecycle: rows persist until the artifact itself is
+// fully cleaned up, so last-owner-cleanup / GC can enumerate every node that
+// ever received the artifact even after all referencing replicas are deleted.
+type ArtifactNodePlacement struct {
+	ArtifactID string `json:"artifact_id" gorm:"column:artifact_id;primaryKey"`
+	NodeID     string `json:"node_id" gorm:"column:node_id;primaryKey"`
+	NodeIP     string `json:"node_ip" gorm:"column:node_ip"`
+	CreatedAt  int64  `json:"created_at" gorm:"column:created_at"`
+}
+
+func (ArtifactNodePlacement) TableName() string {
+	return constants.ArtifactNodePlacementTableName
+}

--- a/CubeMaster/pkg/base/db/models/template.go
+++ b/CubeMaster/pkg/base/db/models/template.go
@@ -22,6 +22,7 @@ type TemplateDefinition struct {
 	StorageBackend            string `json:"storage_backend" gorm:"column:storage_backend"`
 	Retain                    bool   `json:"retain" gorm:"column:retain"`
 	RootfsSizeBytesAtSnapshot uint64 `json:"rootfs_size_bytes_at_snapshot" gorm:"column:rootfs_size_bytes_at_snapshot"`
+	RootfsArtifactID          string `json:"rootfs_artifact_id" gorm:"column:rootfs_artifact_id"`
 	RequestJSON               string `json:"request_json" gorm:"column:request_json"`
 	LastError                 string `json:"last_error" gorm:"column:last_error"`
 }

--- a/CubeMaster/pkg/templatecenter/artifact_build.go
+++ b/CubeMaster/pkg/templatecenter/artifact_build.go
@@ -16,6 +16,7 @@ import (
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/templatecenter/cube_egress_ca"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/templatecenter/image"
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 	"strings"
 	"time"
 )
@@ -78,14 +79,18 @@ func ensureRootfsArtifact(ctx context.Context, req *types.CreateTemplateFromImag
 			}
 		}
 	}
-	_ = updateRootfsArtifact(ctx, artifactID, map[string]any{
-		"template_spec_fingerprint": fingerprint,
-		"source_image_ref":          req.SourceImageRef,
-		"source_image_digest":       source.Digest,
-		"writable_layer_size":       req.WritableLayerSize,
-		"status":                    ArtifactStatusBuilding,
-		"last_error":                "",
-	})
+	// Claim the artifact row under its FOR UPDATE lock before (re)building. This
+	// serialises against last-owner-cleanup (which locks the same row in its
+	// phases) and resurrects a CLEANUP_PENDING / soft-deleted row, so a
+	// concurrent deletion cannot remove the artifact out from under this build
+	// (FIX-1 create/reuse guard).
+	claimed, claimErr := claimRootfsArtifactForBuild(ctx, artifactID, fingerprint, req, source.Digest)
+	if claimErr != nil {
+		return nil, nil, false, claimErr
+	}
+	if claimed != nil {
+		record = claimed
+	}
 	record, generatedReq, err = buildRootfsArtifact(ctx, record, req, source, downloadBaseURL, caPEM, caFingerprint)
 	if err != nil {
 		_ = updateRootfsArtifact(ctx, artifactID, map[string]any{
@@ -95,6 +100,65 @@ func ensureRootfsArtifact(ctx context.Context, req *types.CreateTemplateFromImag
 		return nil, nil, false, err
 	}
 	return record, generatedReq, true, nil
+}
+
+// claimRootfsArtifactForBuild atomically ensures the artifact row exists and is
+// marked BUILDING while holding its FOR UPDATE lock. It resurrects a
+// soft-deleted or CLEANUP_PENDING row (raced with a concurrent
+// last-owner-cleanup) instead of letting the build proceed against a row that
+// is about to vanish. Because the deleter takes the same row lock in both its
+// decision (TX1) and finalisation (TX2) phases, after this commit the deleter's
+// phase-3 re-check observes a live BUILDING row plus the active build job and
+// backs off without deleting or overwriting the in-flight build status.
+func claimRootfsArtifactForBuild(ctx context.Context, artifactID, fingerprint string, req *types.CreateTemplateFromImageReq, sourceDigest string) (*models.RootfsArtifact, error) {
+	var claimed *models.RootfsArtifact
+	err := store.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		var existing models.RootfsArtifact
+		err := tx.Clauses(clause.Locking{Strength: "UPDATE"}).Unscoped().
+			Table(constants.RootfsArtifactTableName).
+			Where("artifact_id = ?", artifactID).First(&existing).Error
+		switch {
+		case errors.Is(err, gorm.ErrRecordNotFound):
+			row := &models.RootfsArtifact{
+				ArtifactID:              artifactID,
+				TemplateSpecFingerprint: fingerprint,
+				SourceImageRef:          req.SourceImageRef,
+				SourceImageDigest:       sourceDigest,
+				WritableLayerSize:       req.WritableLayerSize,
+				Status:                  ArtifactStatusBuilding,
+			}
+			if createErr := tx.Table(constants.RootfsArtifactTableName).Create(row).Error; createErr != nil {
+				return createErr
+			}
+			claimed = row
+			return nil
+		case err != nil:
+			return err
+		default:
+			if updErr := tx.Unscoped().Table(constants.RootfsArtifactTableName).
+				Where("artifact_id = ?", artifactID).
+				Updates(map[string]any{
+					"template_spec_fingerprint": fingerprint,
+					"source_image_ref":          req.SourceImageRef,
+					"source_image_digest":       sourceDigest,
+					"writable_layer_size":       req.WritableLayerSize,
+					"status":                    ArtifactStatusBuilding,
+					"last_error":                "",
+					"deleted_at":                nil,
+					"updated_at":                time.Now(),
+				}).Error; updErr != nil {
+				return updErr
+			}
+			existing.Status = ArtifactStatusBuilding
+			existing.DeletedAt = gorm.DeletedAt{}
+			claimed = &existing
+			return nil
+		}
+	})
+	if err != nil {
+		return nil, err
+	}
+	return claimed, nil
 }
 
 func findReusableRootfsArtifact(ctx context.Context, fingerprint, artifactID string) (*models.RootfsArtifact, bool, error) {

--- a/CubeMaster/pkg/templatecenter/artifact_cleanup.go
+++ b/CubeMaster/pkg/templatecenter/artifact_cleanup.go
@@ -6,57 +6,62 @@ package templatecenter
 
 import (
 	"context"
-	"errors"
 	"fmt"
-	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/constants"
-	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/db/models"
-	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/templatecenter/image"
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/constants"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/db/models"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/log"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/templatecenter/image"
+	"gorm.io/gorm"
 )
 
 var deleteRootfsArtifactRecord = func(ctx context.Context, artifactID string) error {
-	return store.db.WithContext(ctx).Unscoped().Table(constants.RootfsArtifactTableName).
-		Where("artifact_id = ?", artifactID).Delete(&models.RootfsArtifact{}).Error
+	// Placement rows and the artifact row must vanish together: a half-applied
+	// delete that drops the artifact row but keeps placement (or vice versa)
+	// would either orphan placement rows or strand the node list needed to
+	// reclaim files. Wrap both in one transaction.
+	return store.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		if err := tx.Table(constants.ArtifactNodePlacementTableName).
+			Where("artifact_id = ?", artifactID).Delete(&models.ArtifactNodePlacement{}).Error; err != nil {
+			return err
+		}
+		return tx.Unscoped().Table(constants.RootfsArtifactTableName).
+			Where("artifact_id = ?", artifactID).Delete(&models.RootfsArtifact{}).Error
+	})
 }
 
-func cleanupFailedRootfsArtifact(ctx context.Context, artifact *models.RootfsArtifact, instanceType string) error {
+// cleanupFailedRootfsArtifact reclaims a freshly built artifact whose template
+// creation failed. It routes through the shared last-owner cleanup so a
+// concurrent build that reused the same fingerprint (its own active job/replica
+// keeps the reference count > 0) is never deleted out from under. The build's
+// own template is excluded so its in-flight job/definition do not pin the
+// artifact and block its own failure cleanup.
+func cleanupFailedRootfsArtifact(ctx context.Context, artifact *models.RootfsArtifact, instanceType, templateID string) error {
 	if artifact == nil {
 		return nil
 	}
-	var cleanupErr error
-	if err := cleanupDistributedArtifact(ctx, artifact.ArtifactID, instanceType); err != nil {
-		cleanupErr = errors.Join(cleanupErr, err)
-	}
-	if err := cleanupLocalRootfsArtifact(artifact.ArtifactID, artifact.Ext4Path); err != nil {
-		cleanupErr = errors.Join(cleanupErr, err)
-	}
-	if cleanupErr == nil {
-		if err := deleteRootfsArtifactRecord(ctx, artifact.ArtifactID); err == nil {
-			return nil
-		} else {
-			cleanupErr = errors.Join(cleanupErr, err)
-		}
-	}
-	updateErr := updateRootfsArtifact(ctx, artifact.ArtifactID, map[string]any{
-		"status":     ArtifactStatusFailed,
-		"last_error": fmt.Sprintf("artifact cleanup incomplete: %v", cleanupErr),
-	})
-	return errors.Join(cleanupErr, updateErr)
+	return cleanupArtifactFully(ctx, artifact.ArtifactID, instanceType, templateID)
 }
 
 func cleanupLocalRootfsArtifact(artifactID, ext4Path string) error {
 	if ext4Path == "" {
 		return nil
 	}
+	// S8/L8: only ever RemoveAll inside a recognised managed artifact root. A
+	// path outside the managed roots is NEVER deleted (no os.Remove fallback) —
+	// it indicates corrupt metadata or an attempted out-of-bounds delete and is
+	// surfaced as an error for manual handling rather than risking deletion of
+	// an arbitrary host file.
 	if dir, ok := managedArtifactDir(artifactID, ext4Path); ok {
 		return os.RemoveAll(dir) // NOCC:Path Traversal()
 	}
-	if err := os.Remove(ext4Path); err != nil && !errors.Is(err, os.ErrNotExist) { // NOCC:Path Traversal()
-		return err
-	}
-	return nil
+	log.G(context.Background()).Errorf(
+		"refusing to delete rootfs artifact %s: ext4 path %q is outside managed artifact roots; manual cleanup required",
+		artifactID, ext4Path)
+	return fmt.Errorf("rootfs artifact %s ext4 path %q is outside managed artifact roots", artifactID, ext4Path)
 }
 
 func managedArtifactDir(artifactID, ext4Path string) (string, bool) {

--- a/CubeMaster/pkg/templatecenter/artifact_gc.go
+++ b/CubeMaster/pkg/templatecenter/artifact_gc.go
@@ -1,0 +1,97 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package templatecenter
+
+import (
+	"context"
+	"database/sql"
+	"sync"
+	"time"
+
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/constants"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/db/models"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/log"
+)
+
+const (
+	artifactGCInterval   = 10 * time.Minute
+	artifactGCLockName   = "cubemaster_templatecenter_artifact_gc_v1"
+	artifactGCMaxPerPass = 100
+)
+
+var artifactGCOnce sync.Once
+
+// startArtifactGC launches the orphan/expired rootfs-artifact garbage
+// collector. It is registered alongside the snapshot reconciler (not folded
+// into it) and converges the cases online deletion cannot finish in one pass:
+// interrupted builds, artifacts whose nodes were busy (CLEANUP_PENDING), and
+// TTL-expired artifacts. A component-scoped MySQL GET_LOCK keeps a single
+// instance active across the HA cluster; the lock name is intentionally distinct
+// from schema-migration locks (`cubemaster_schema_migration_global` and
+// `cubemaster_migration_*`).
+func startArtifactGC(ctx context.Context) {
+	artifactGCOnce.Do(func() {
+		go func() {
+			runArtifactGCPass(detachTemplateImageJobContext(ctx, "artifact_gc", nil))
+			ticker := time.NewTicker(artifactGCInterval)
+			defer ticker.Stop()
+			for {
+				select {
+				case <-ctx.Done():
+					return
+				case <-ticker.C:
+					runArtifactGCPass(detachTemplateImageJobContext(ctx, "artifact_gc", nil))
+				}
+			}
+		}()
+	})
+}
+
+func runArtifactGCPass(ctx context.Context) {
+	if !isReady() {
+		return
+	}
+	logger := log.G(ctx).WithFields(map[string]any{"component": "artifact_gc"})
+
+	// Single-instance execution across the cluster: GET_LOCK with a 0s timeout
+	// returns immediately; another instance holding it means we skip this pass.
+	var lockRes sql.NullInt64
+	if err := store.db.WithContext(ctx).
+		Raw("SELECT GET_LOCK(?, ?)", artifactGCLockName, 0).Scan(&lockRes).Error; err != nil {
+		logger.Warnf("artifact gc: acquire lock failed: %v", err)
+		return
+	}
+	if !lockRes.Valid || lockRes.Int64 != 1 {
+		return // another instance is running this pass
+	}
+	defer func() {
+		if err := store.db.WithContext(ctx).Exec("SELECT RELEASE_LOCK(?)", artifactGCLockName).Error; err != nil {
+			logger.Warnf("artifact gc: release lock failed: %v", err)
+		}
+	}()
+
+	now := time.Now().Unix()
+	var candidates []models.RootfsArtifact
+	if err := store.db.WithContext(ctx).Table(constants.RootfsArtifactTableName).
+		Where("status IN ? OR (gc_deadline > 0 AND gc_deadline < ?)",
+			[]string{ArtifactStatusFailed, ArtifactStatusOrphaned, ArtifactStatusCleanupPending}, now).
+		Limit(artifactGCMaxPerPass).Find(&candidates).Error; err != nil {
+		logger.Warnf("artifact gc: list candidates failed: %v", err)
+		return
+	}
+	if len(candidates) == 0 {
+		return
+	}
+	logger.Infof("artifact gc: evaluating %d candidate artifacts", len(candidates))
+	for i := range candidates {
+		artifactID := candidates[i].ArtifactID
+		// exclude="" => globally unreferenced artifacts are cleaned; referenced
+		// ones are kept and their TTL renewed by cleanupArtifactFully. ext4
+		// instanceType defaults to cubebox inside the node destroy path.
+		if err := cleanupArtifactFully(ctx, artifactID, "", ""); err != nil {
+			logger.Warnf("artifact gc: cleanup %s failed: %v", artifactID, err)
+		}
+	}
+}

--- a/CubeMaster/pkg/templatecenter/artifact_gc.go
+++ b/CubeMaster/pkg/templatecenter/artifact_gc.go
@@ -7,6 +7,7 @@ package templatecenter
 import (
 	"context"
 	"database/sql"
+	"runtime/debug"
 	"sync"
 	"time"
 
@@ -16,12 +17,16 @@ import (
 )
 
 const (
-	artifactGCInterval   = 10 * time.Minute
-	artifactGCLockName   = "cubemaster_templatecenter_artifact_gc_v1"
-	artifactGCMaxPerPass = 100
+	artifactGCInterval    = 10 * time.Minute
+	artifactGCLockName    = "cubemaster_templatecenter_artifact_gc_v1"
+	artifactGCMaxPerPass  = 100
+	artifactGCWorkerLimit = 5
 )
 
-var artifactGCOnce sync.Once
+var (
+	artifactGCOnce         sync.Once
+	cleanupArtifactFullyGC = cleanupArtifactFully
+)
 
 // startArtifactGC launches the orphan/expired rootfs-artifact garbage
 // collector. It is registered alongside the snapshot reconciler (not folded
@@ -61,12 +66,48 @@ func runArtifactGCPass(ctx context.Context) {
 		return
 	}
 	logger.Infof("artifact gc: evaluating %d candidate artifacts", len(candidates))
+	processArtifactGCCandidates(ctx, candidates)
+}
+
+func processArtifactGCCandidates(ctx context.Context, candidates []models.RootfsArtifact) {
+	if len(candidates) == 0 {
+		return
+	}
+	workerCount := artifactGCWorkerLimit
+	if len(candidates) < workerCount {
+		workerCount = len(candidates)
+	}
+	jobs := make(chan models.RootfsArtifact)
+	var wg sync.WaitGroup
+	for i := 0; i < workerCount; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for artifact := range jobs {
+				cleanupArtifactGCCandidate(ctx, artifact)
+			}
+		}()
+	}
 	for i := range candidates {
-		artifactID := candidates[i].ArtifactID
+		jobs <- candidates[i]
+	}
+	close(jobs)
+	wg.Wait()
+}
+
+func cleanupArtifactGCCandidate(ctx context.Context, artifact models.RootfsArtifact) {
+	logger := log.G(ctx).WithFields(map[string]any{"component": "artifact_gc"})
+	artifactID := artifact.ArtifactID
+	defer func() {
+		if r := recover(); r != nil {
+			logger.Errorf("artifact gc: cleanup %s panic: %v\n%s", artifactID, r, string(debug.Stack()))
+		}
+	}()
+	if artifactID != "" {
 		// exclude="" => globally unreferenced artifacts are cleaned; referenced
 		// ones are kept and their TTL renewed by cleanupArtifactFully. ext4
 		// instanceType defaults to cubebox inside the node destroy path.
-		if err := cleanupArtifactFully(ctx, artifactID, "", ""); err != nil {
+		if err := cleanupArtifactFullyGC(ctx, artifactID, "", ""); err != nil {
 			logger.Warnf("artifact gc: cleanup %s failed: %v", artifactID, err)
 		}
 	}

--- a/CubeMaster/pkg/templatecenter/artifact_gc.go
+++ b/CubeMaster/pkg/templatecenter/artifact_gc.go
@@ -27,9 +27,10 @@ var artifactGCOnce sync.Once
 // collector. It is registered alongside the snapshot reconciler (not folded
 // into it) and converges the cases online deletion cannot finish in one pass:
 // interrupted builds, artifacts whose nodes were busy (CLEANUP_PENDING), and
-// TTL-expired artifacts. A component-scoped MySQL GET_LOCK keeps a single
-// instance active across the HA cluster; the lock name is intentionally distinct
-// from schema-migration locks (`cubemaster_schema_migration_global` and
+// TTL-expired artifacts. A component-scoped MySQL GET_LOCK keeps candidate
+// selection single-instance across the HA cluster without covering slow
+// cross-node cleanup RPCs; the lock name is intentionally distinct from
+// schema-migration locks (`cubemaster_schema_migration_global` and
 // `cubemaster_migration_*`).
 func startArtifactGC(ctx context.Context) {
 	artifactGCOnce.Do(func() {
@@ -55,16 +56,37 @@ func runArtifactGCPass(ctx context.Context) {
 	}
 	logger := log.G(ctx).WithFields(map[string]any{"component": "artifact_gc"})
 
+	candidates, ok := listArtifactGCCandidatesLocked(ctx)
+	if !ok || len(candidates) == 0 {
+		return
+	}
+	logger.Infof("artifact gc: evaluating %d candidate artifacts", len(candidates))
+	for i := range candidates {
+		artifactID := candidates[i].ArtifactID
+		// exclude="" => globally unreferenced artifacts are cleaned; referenced
+		// ones are kept and their TTL renewed by cleanupArtifactFully. ext4
+		// instanceType defaults to cubebox inside the node destroy path.
+		if err := cleanupArtifactFully(ctx, artifactID, "", ""); err != nil {
+			logger.Warnf("artifact gc: cleanup %s failed: %v", artifactID, err)
+		}
+	}
+}
+
+func listArtifactGCCandidatesLocked(ctx context.Context) ([]models.RootfsArtifact, bool) {
+	logger := log.G(ctx).WithFields(map[string]any{"component": "artifact_gc"})
 	// Single-instance execution across the cluster: GET_LOCK with a 0s timeout
 	// returns immediately; another instance holding it means we skip this pass.
+	// The lock protects only candidate selection. cleanupArtifactFully performs
+	// its own row-level serialisation and idempotent physical deletes, so slow
+	// RPCs must not keep this HA-wide lock held.
 	var lockRes sql.NullInt64
 	if err := store.db.WithContext(ctx).
 		Raw("SELECT GET_LOCK(?, ?)", artifactGCLockName, 0).Scan(&lockRes).Error; err != nil {
 		logger.Warnf("artifact gc: acquire lock failed: %v", err)
-		return
+		return nil, false
 	}
 	if !lockRes.Valid || lockRes.Int64 != 1 {
-		return // another instance is running this pass
+		return nil, false // another instance is selecting candidates
 	}
 	defer func() {
 		if err := store.db.WithContext(ctx).Exec("SELECT RELEASE_LOCK(?)", artifactGCLockName).Error; err != nil {
@@ -79,19 +101,7 @@ func runArtifactGCPass(ctx context.Context) {
 			[]string{ArtifactStatusFailed, ArtifactStatusOrphaned, ArtifactStatusCleanupPending}, now).
 		Limit(artifactGCMaxPerPass).Find(&candidates).Error; err != nil {
 		logger.Warnf("artifact gc: list candidates failed: %v", err)
-		return
+		return nil, false
 	}
-	if len(candidates) == 0 {
-		return
-	}
-	logger.Infof("artifact gc: evaluating %d candidate artifacts", len(candidates))
-	for i := range candidates {
-		artifactID := candidates[i].ArtifactID
-		// exclude="" => globally unreferenced artifacts are cleaned; referenced
-		// ones are kept and their TTL renewed by cleanupArtifactFully. ext4
-		// instanceType defaults to cubebox inside the node destroy path.
-		if err := cleanupArtifactFully(ctx, artifactID, "", ""); err != nil {
-			logger.Warnf("artifact gc: cleanup %s failed: %v", artifactID, err)
-		}
-	}
+	return candidates, true
 }

--- a/CubeMaster/pkg/templatecenter/artifact_gc_test.go
+++ b/CubeMaster/pkg/templatecenter/artifact_gc_test.go
@@ -1,0 +1,48 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package templatecenter
+
+import (
+	"context"
+	"sort"
+	"sync"
+	"testing"
+
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/db/models"
+)
+
+func TestProcessArtifactGCCandidatesRecoversPanicAndContinues(t *testing.T) {
+	orig := cleanupArtifactFullyGC
+	defer func() { cleanupArtifactFullyGC = orig }()
+
+	var mu sync.Mutex
+	seen := make([]string, 0, 3)
+	cleanupArtifactFullyGC = func(ctx context.Context, artifactID, instanceType, excludeTemplateID string) error {
+		mu.Lock()
+		seen = append(seen, artifactID)
+		mu.Unlock()
+		if artifactID == "rfs-panic" {
+			panic("boom")
+		}
+		return nil
+	}
+
+	processArtifactGCCandidates(context.Background(), []models.RootfsArtifact{
+		{ArtifactID: "rfs-panic"},
+		{ArtifactID: "rfs-next-1"},
+		{ArtifactID: "rfs-next-2"},
+	})
+
+	sort.Strings(seen)
+	want := []string{"rfs-next-1", "rfs-next-2", "rfs-panic"}
+	if len(seen) != len(want) {
+		t.Fatalf("expected %d processed artifacts, got %d: %v", len(want), len(seen), seen)
+	}
+	for i := range want {
+		if seen[i] != want[i] {
+			t.Fatalf("unexpected processed artifacts: got %v want %v", seen, want)
+		}
+	}
+}

--- a/CubeMaster/pkg/templatecenter/artifact_lifecycle.go
+++ b/CubeMaster/pkg/templatecenter/artifact_lifecycle.go
@@ -1,0 +1,241 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package templatecenter
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"time"
+
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/constants"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/db/models"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/log"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/node"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/localcache"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+// countArtifactReferencesTx counts the live references to artifactID inside the
+// given transaction: surviving template replicas, active (PENDING/RUNNING)
+// build jobs, and template definitions whose stored request still embeds the
+// artifact id. When excludeTemplateID is non-empty its own rows are excluded so
+// the caller can decide based on "everyone else" while deleting that template.
+//
+// Definitions are matched with a LIKE on request_json because the artifact id
+// is embedded as the `cube.master.rootfs.artifact.id` annotation value; the id
+// is a controlled `rfs-<hex>` token with no LIKE metacharacters.
+func countArtifactReferencesTx(ctx context.Context, tx *gorm.DB, artifactID, excludeTemplateID string) (int64, error) {
+	_ = ctx
+	artifactID = strings.TrimSpace(artifactID)
+	if artifactID == "" {
+		return 0, nil
+	}
+	excludeTemplateID = strings.TrimSpace(excludeTemplateID)
+
+	var replicaCount int64
+	q := tx.Table(constants.TemplateReplicaTableName).Where("artifact_id = ?", artifactID)
+	if excludeTemplateID != "" {
+		q = q.Where("template_id <> ?", excludeTemplateID)
+	}
+	if err := q.Count(&replicaCount).Error; err != nil {
+		return 0, err
+	}
+
+	var jobCount int64
+	jq := tx.Table(constants.TemplateImageJobTableName).
+		Where("artifact_id = ? AND status IN ?", artifactID, []string{JobStatusPending, JobStatusRunning})
+	if excludeTemplateID != "" {
+		jq = jq.Where("template_id <> ?", excludeTemplateID)
+	}
+	if err := jq.Count(&jobCount).Error; err != nil {
+		return 0, err
+	}
+
+	var defCount int64
+	dq := tx.Table(constants.TemplateDefinitionTableName).
+		Where("request_json LIKE ?", "%"+artifactID+"%")
+	if excludeTemplateID != "" {
+		dq = dq.Where("template_id <> ?", excludeTemplateID)
+	}
+	if err := dq.Count(&defCount).Error; err != nil {
+		return 0, err
+	}
+
+	return replicaCount + jobCount + defCount, nil
+}
+
+// cleanupArtifactFully implements the three-phase last-owner-cleanup for one
+// artifact, shared by online template deletion, fresh-build failure cleanup,
+// and the orphan GC:
+//
+//	Phase 1 (short TX, artifact row FOR UPDATE): drop excludeTemplateID's
+//	  replica bindings for this artifact, count remaining references; if any
+//	  remain, keep the artifact. Otherwise snapshot the placement nodes and
+//	  mark the row CLEANUP_PENDING.
+//	Phase 2 (no lock, no TX, idempotent): destroy the ext4 files on every
+//	  placement node and on the master-local store.
+//	Phase 3 (short TX, FOR UPDATE): only if every physical delete succeeded,
+//	  re-check that references are still zero, then delete placement rows and
+//	  the artifact row; if it was re-referenced meanwhile, revert to READY.
+//
+// Partial physical failures (a node still running a sandbox, transient RPC
+// errors) leave the row in CLEANUP_PENDING and return nil so template deletion
+// proceeds; the GC converges later. Only hard DB errors are returned.
+func cleanupArtifactFully(ctx context.Context, artifactID, instanceType, excludeTemplateID string) error {
+	artifactID = strings.TrimSpace(artifactID)
+	if artifactID == "" {
+		return nil
+	}
+	logger := log.G(ctx).WithFields(map[string]any{"artifact_id": artifactID})
+
+	// ── Phase 1 ──────────────────────────────────────────────────────────────
+	var (
+		proceed  bool
+		ext4Path string
+		nodes    []models.ArtifactNodePlacement
+	)
+	if err := store.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		var artifact models.RootfsArtifact
+		err := tx.Clauses(clause.Locking{Strength: "UPDATE"}).
+			Table(constants.RootfsArtifactTableName).
+			Where("artifact_id = ?", artifactID).First(&artifact).Error
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil // already gone
+		}
+		if err != nil {
+			return err
+		}
+		if excludeTemplateID != "" {
+			if err := tx.Unscoped().Table(constants.TemplateReplicaTableName).
+				Where("template_id = ? AND artifact_id = ?", excludeTemplateID, artifactID).
+				Delete(&models.TemplateReplica{}).Error; err != nil {
+				return err
+			}
+		}
+		remaining, err := countArtifactReferencesTx(ctx, tx, artifactID, excludeTemplateID)
+		if err != nil {
+			return err
+		}
+		if remaining > 0 {
+			// Still referenced by another template/job: keep it, renew the GC
+			// TTL, and revert a stale CLEANUP_PENDING back to READY so a
+			// re-referenced artifact becomes reusable again.
+			updates := map[string]any{"gc_deadline": time.Now().Add(defaultTemplateArtifactTTL).Unix()}
+			if artifact.Status == ArtifactStatusCleanupPending {
+				updates["status"] = ArtifactStatusReady
+			}
+			return tx.Table(constants.RootfsArtifactTableName).
+				Where("artifact_id = ?", artifactID).Updates(updates).Error
+		}
+		nodes, err = listArtifactNodePlacementsTx(tx, artifactID)
+		if err != nil {
+			return err
+		}
+		if err := tx.Table(constants.RootfsArtifactTableName).
+			Where("artifact_id = ?", artifactID).
+			Update("status", ArtifactStatusCleanupPending).Error; err != nil {
+			return err
+		}
+		ext4Path = artifact.Ext4Path
+		proceed = true
+		return nil
+	}); err != nil {
+		return err
+	}
+	if !proceed {
+		return nil
+	}
+
+	// ── Phase 2 (no lock) ──────────────────────────────────────────────────────
+	allPhysicalOK := true
+	for i := range nodes {
+		target := placementToNode(&nodes[i])
+		if target == nil {
+			// Can't resolve an address: treat as not-yet-cleaned so GC retries
+			// rather than dropping the placement record and leaking the files.
+			allPhysicalOK = false
+			logger.Warnf("artifact cleanup: cannot resolve address for placement node %s", nodes[i].NodeID)
+			continue
+		}
+		inUse, err := destroyArtifactOnNode(ctx, artifactID, instanceType, target)
+		if inUse {
+			allPhysicalOK = false
+			logger.Infof("artifact cleanup deferred: node %s still uses artifact, GC will retry", target.ID())
+			continue
+		}
+		if err != nil {
+			allPhysicalOK = false
+			logger.Warnf("artifact cleanup: destroy on node %s failed: %v", target.ID(), err)
+		}
+	}
+	if err := cleanupLocalRootfsArtifact(artifactID, ext4Path); err != nil {
+		allPhysicalOK = false
+		logger.Warnf("artifact cleanup: master-local ext4 removal failed: %v", err)
+	}
+
+	if !allPhysicalOK {
+		// Keep the row in CLEANUP_PENDING; GC retries after sandboxes exit.
+		return nil
+	}
+
+	// ── Phase 3 ──────────────────────────────────────────────────────────────
+	return store.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		var artifact models.RootfsArtifact
+		err := tx.Clauses(clause.Locking{Strength: "UPDATE"}).
+			Table(constants.RootfsArtifactTableName).
+			Where("artifact_id = ?", artifactID).First(&artifact).Error
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		// Re-check with the SAME exclusion as phase 1. The deleted template's own
+		// definition/replica rows are still present here (metadata cleanup runs
+		// after artifact cleanup), so a phase-1-consistent exclusion is required
+		// to avoid counting the very template we are deleting as a live owner.
+		remaining, err := countArtifactReferencesTx(ctx, tx, artifactID, excludeTemplateID)
+		if err != nil {
+			return err
+		}
+		// Only finalise deletion when (a) nothing else references the artifact
+		// and (b) no concurrent build resurrected the row. Any re-reference that
+		// appeared during the lock-free physical phase necessarily went through
+		// claimRootfsArtifactForBuild, which flips the status to BUILDING and
+		// rebuilds the physical files; in that case we must NOT delete and must
+		// NOT clobber that build's status (reverting to READY would expose a row
+		// pointing at the files we just deleted). Back off and let the build /
+		// GC converge.
+		if remaining > 0 || artifact.Status != ArtifactStatusCleanupPending {
+			return nil
+		}
+		if err := deleteArtifactNodePlacementsTx(tx, artifactID); err != nil {
+			return err
+		}
+		return tx.Unscoped().Table(constants.RootfsArtifactTableName).
+			Where("artifact_id = ?", artifactID).Delete(&models.RootfsArtifact{}).Error
+	})
+}
+
+// placementToNode resolves a placement row to a node with a usable host ip,
+// falling back to the local node cache when the recorded ip is empty.
+func placementToNode(p *models.ArtifactNodePlacement) *node.Node {
+	if p == nil {
+		return nil
+	}
+	nodeID := strings.TrimSpace(p.NodeID)
+	nodeIP := strings.TrimSpace(p.NodeIP)
+	if nodeIP == "" && nodeID != "" {
+		if cached, ok := localcache.GetNode(nodeID); ok && cached != nil {
+			nodeIP = strings.TrimSpace(cached.HostIP())
+		}
+	}
+	if nodeIP == "" {
+		return nil
+	}
+	return &node.Node{InsID: nodeID, IP: nodeIP}
+}

--- a/CubeMaster/pkg/templatecenter/artifact_lifecycle.go
+++ b/CubeMaster/pkg/templatecenter/artifact_lifecycle.go
@@ -34,6 +34,9 @@ func countArtifactReferencesTx(ctx context.Context, tx *gorm.DB, artifactID, exc
 	if artifactID == "" {
 		return 0, nil
 	}
+	if strings.ContainsAny(artifactID, "%_") {
+		return 0, errors.New("artifact id contains SQL LIKE wildcard characters")
+	}
 	excludeTemplateID = strings.TrimSpace(excludeTemplateID)
 
 	var replicaCount int64
@@ -80,7 +83,8 @@ func countArtifactReferencesTx(ctx context.Context, tx *gorm.DB, artifactID, exc
 //	  placement node and on the master-local store.
 //	Phase 3 (short TX, FOR UPDATE): only if every physical delete succeeded,
 //	  re-check that references are still zero, then delete placement rows and
-//	  the artifact row; if it was re-referenced meanwhile, revert to READY.
+//	  the artifact row; if it was re-referenced meanwhile, leave status as-is
+//	  and return so Phase 1 / claimRootfsArtifactForBuild can converge it.
 //
 // Partial physical failures (a node still running a sandbox, transient RPC
 // errors) leave the row in CLEANUP_PENDING and return nil so template deletion

--- a/CubeMaster/pkg/templatecenter/artifact_lifecycle.go
+++ b/CubeMaster/pkg/templatecenter/artifact_lifecycle.go
@@ -19,15 +19,13 @@ import (
 	"gorm.io/gorm/clause"
 )
 
+var cleanupLocalRootfsArtifactForLifecycle = cleanupLocalRootfsArtifact
+
 // countArtifactReferencesTx counts the live references to artifactID inside the
 // given transaction: surviving template replicas, active (PENDING/RUNNING)
-// build jobs, and template definitions whose stored request still embeds the
-// artifact id. When excludeTemplateID is non-empty its own rows are excluded so
-// the caller can decide based on "everyone else" while deleting that template.
-//
-// Definitions are matched with a LIKE on request_json because the artifact id
-// is embedded as the `cube.master.rootfs.artifact.id` annotation value; the id
-// is a controlled `rfs-<hex>` token with no LIKE metacharacters.
+// build jobs, and template definitions indexed by rootfs_artifact_id. When
+// excludeTemplateID is non-empty its own rows are excluded so the caller can
+// decide based on "everyone else" while deleting that template.
 func countArtifactReferencesTx(ctx context.Context, tx *gorm.DB, artifactID, excludeTemplateID string) (int64, error) {
 	_ = ctx
 	artifactID = strings.TrimSpace(artifactID)
@@ -35,7 +33,7 @@ func countArtifactReferencesTx(ctx context.Context, tx *gorm.DB, artifactID, exc
 		return 0, nil
 	}
 	if strings.ContainsAny(artifactID, "%_") {
-		return 0, errors.New("artifact id contains SQL LIKE wildcard characters")
+		return 0, errors.New("artifact id contains SQL wildcard characters")
 	}
 	excludeTemplateID = strings.TrimSpace(excludeTemplateID)
 
@@ -60,7 +58,7 @@ func countArtifactReferencesTx(ctx context.Context, tx *gorm.DB, artifactID, exc
 
 	var defCount int64
 	dq := tx.Table(constants.TemplateDefinitionTableName).
-		Where("request_json LIKE ?", "%"+artifactID+"%")
+		Where("rootfs_artifact_id = ?", artifactID)
 	if excludeTemplateID != "" {
 		dq = dq.Where("template_id <> ?", excludeTemplateID)
 	}
@@ -80,11 +78,13 @@ func countArtifactReferencesTx(ctx context.Context, tx *gorm.DB, artifactID, exc
 //	  remain, keep the artifact. Otherwise snapshot the placement nodes and
 //	  mark the row CLEANUP_PENDING.
 //	Phase 2 (no lock, no TX, idempotent): destroy the ext4 files on every
-//	  placement node and on the master-local store.
-//	Phase 3 (short TX, FOR UPDATE): only if every physical delete succeeded,
-//	  re-check that references are still zero, then delete placement rows and
-//	  the artifact row; if it was re-referenced meanwhile, leave status as-is
-//	  and return so Phase 1 / claimRootfsArtifactForBuild can converge it.
+//	  placement node.
+//	Phase 3 (short TX, FOR UPDATE): only if node-side physical deletes
+//	  succeeded, re-check that references are still zero and status is still
+//	  CLEANUP_PENDING, then remove the master-local ext4 under the row lock
+//	  before deleting placement rows and the artifact row; if it was
+//	  re-referenced meanwhile, leave status as-is and return so Phase 1 /
+//	  claimRootfsArtifactForBuild can converge it.
 //
 // Partial physical failures (a node still running a sandbox, transient RPC
 // errors) leave the row in CLEANUP_PENDING and return nil so template deletion
@@ -98,9 +98,8 @@ func cleanupArtifactFully(ctx context.Context, artifactID, instanceType, exclude
 
 	// ── Phase 1 ──────────────────────────────────────────────────────────────
 	var (
-		proceed  bool
-		ext4Path string
-		nodes    []models.ArtifactNodePlacement
+		proceed bool
+		nodes   []models.ArtifactNodePlacement
 	)
 	if err := store.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		var artifact models.RootfsArtifact
@@ -144,7 +143,6 @@ func cleanupArtifactFully(ctx context.Context, artifactID, instanceType, exclude
 			Update("status", ArtifactStatusCleanupPending).Error; err != nil {
 			return err
 		}
-		ext4Path = artifact.Ext4Path
 		proceed = true
 		return nil
 	}); err != nil {
@@ -176,11 +174,6 @@ func cleanupArtifactFully(ctx context.Context, artifactID, instanceType, exclude
 			logger.Warnf("artifact cleanup: destroy on node %s failed: %v", target.ID(), err)
 		}
 	}
-	if err := cleanupLocalRootfsArtifact(artifactID, ext4Path); err != nil {
-		allPhysicalOK = false
-		logger.Warnf("artifact cleanup: master-local ext4 removal failed: %v", err)
-	}
-
 	if !allPhysicalOK {
 		// Keep the row in CLEANUP_PENDING; GC retries after sandboxes exit.
 		return nil
@@ -214,7 +207,12 @@ func cleanupArtifactFully(ctx context.Context, artifactID, instanceType, exclude
 		// NOT clobber that build's status (reverting to READY would expose a row
 		// pointing at the files we just deleted). Back off and let the build /
 		// GC converge.
-		if remaining > 0 || artifact.Status != ArtifactStatusCleanupPending {
+		canFinalize, err := cleanupMasterLocalArtifactForFinalDelete(artifact, remaining)
+		if err != nil {
+			logger.Warnf("artifact cleanup: master-local ext4 removal failed: %v", err)
+			return nil
+		}
+		if !canFinalize {
 			return nil
 		}
 		if err := deleteArtifactNodePlacementsTx(tx, artifactID); err != nil {
@@ -223,6 +221,16 @@ func cleanupArtifactFully(ctx context.Context, artifactID, instanceType, exclude
 		return tx.Unscoped().Table(constants.RootfsArtifactTableName).
 			Where("artifact_id = ?", artifactID).Delete(&models.RootfsArtifact{}).Error
 	})
+}
+
+func cleanupMasterLocalArtifactForFinalDelete(artifact models.RootfsArtifact, remaining int64) (bool, error) {
+	if remaining > 0 || artifact.Status != ArtifactStatusCleanupPending {
+		return false, nil
+	}
+	if err := cleanupLocalRootfsArtifactForLifecycle(artifact.ArtifactID, artifact.Ext4Path); err != nil {
+		return false, err
+	}
+	return true, nil
 }
 
 // placementToNode resolves a placement row to a node with a usable host ip,

--- a/CubeMaster/pkg/templatecenter/artifact_lifecycle_test.go
+++ b/CubeMaster/pkg/templatecenter/artifact_lifecycle_test.go
@@ -1,0 +1,23 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package templatecenter
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+func TestCountArtifactReferencesRejectsLikeWildcards(t *testing.T) {
+	for _, artifactID := range []string{"rfs-bad%id", "rfs-bad_id"} {
+		_, err := countArtifactReferencesTx(context.Background(), nil, artifactID, "")
+		if err == nil {
+			t.Fatalf("expected wildcard artifact id %q to be rejected", artifactID)
+		}
+		if !strings.Contains(err.Error(), "LIKE wildcard") {
+			t.Fatalf("unexpected error for %q: %v", artifactID, err)
+		}
+	}
+}

--- a/CubeMaster/pkg/templatecenter/artifact_lifecycle_test.go
+++ b/CubeMaster/pkg/templatecenter/artifact_lifecycle_test.go
@@ -8,6 +8,10 @@ import (
 	"context"
 	"strings"
 	"testing"
+
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/constants"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/db/models"
+	sandboxtypes "github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/service/sandbox/types"
 )
 
 func TestCountArtifactReferencesRejectsLikeWildcards(t *testing.T) {
@@ -16,8 +20,70 @@ func TestCountArtifactReferencesRejectsLikeWildcards(t *testing.T) {
 		if err == nil {
 			t.Fatalf("expected wildcard artifact id %q to be rejected", artifactID)
 		}
-		if !strings.Contains(err.Error(), "LIKE wildcard") {
+		if !strings.Contains(err.Error(), "SQL wildcard") {
 			t.Fatalf("unexpected error for %q: %v", artifactID, err)
 		}
+	}
+}
+
+func TestRootfsArtifactIDFromCreateRequest(t *testing.T) {
+	req := &sandboxtypes.CreateCubeSandboxReq{
+		Annotations: map[string]string{
+			constants.CubeAnnotationRootfsArtifactID: " rfs-top ",
+		},
+		Containers: []*sandboxtypes.Container{{
+			Image: &sandboxtypes.ImageSpec{
+				Annotations: map[string]string{
+					constants.CubeAnnotationRootfsArtifactID: "rfs-image",
+				},
+			},
+		}},
+	}
+	if got := rootfsArtifactIDFromCreateRequest(req); got != "rfs-top" {
+		t.Fatalf("expected top-level artifact id, got %q", got)
+	}
+
+	req.Annotations = nil
+	if got := rootfsArtifactIDFromCreateRequest(req); got != "rfs-image" {
+		t.Fatalf("expected image artifact id, got %q", got)
+	}
+
+	if got := rootfsArtifactIDFromCreateRequest(nil); got != "" {
+		t.Fatalf("nil request should have empty artifact id, got %q", got)
+	}
+}
+
+func TestCleanupMasterLocalArtifactForFinalDeleteOnlyWhenStillPending(t *testing.T) {
+	orig := cleanupLocalRootfsArtifactForLifecycle
+	defer func() { cleanupLocalRootfsArtifactForLifecycle = orig }()
+
+	calls := 0
+	cleanupLocalRootfsArtifactForLifecycle = func(artifactID, ext4Path string) error {
+		calls++
+		if artifactID != "rfs-1" || ext4Path != "/managed/rfs-1/rootfs.ext4" {
+			t.Fatalf("unexpected cleanup args artifact=%q path=%q", artifactID, ext4Path)
+		}
+		return nil
+	}
+
+	artifact := models.RootfsArtifact{
+		ArtifactID: "rfs-1",
+		Ext4Path:   "/managed/rfs-1/rootfs.ext4",
+		Status:     ArtifactStatusBuilding,
+	}
+	canFinalize, err := cleanupMasterLocalArtifactForFinalDelete(artifact, 0)
+	if err != nil || canFinalize || calls != 0 {
+		t.Fatalf("building artifact should skip local cleanup, canFinalize=%v err=%v calls=%d", canFinalize, err, calls)
+	}
+
+	artifact.Status = ArtifactStatusCleanupPending
+	canFinalize, err = cleanupMasterLocalArtifactForFinalDelete(artifact, 1)
+	if err != nil || canFinalize || calls != 0 {
+		t.Fatalf("referenced artifact should skip local cleanup, canFinalize=%v err=%v calls=%d", canFinalize, err, calls)
+	}
+
+	canFinalize, err = cleanupMasterLocalArtifactForFinalDelete(artifact, 0)
+	if err != nil || !canFinalize || calls != 1 {
+		t.Fatalf("unreferenced cleanup-pending artifact should be locally cleaned, canFinalize=%v err=%v calls=%d", canFinalize, err, calls)
 	}
 }

--- a/CubeMaster/pkg/templatecenter/artifact_placement.go
+++ b/CubeMaster/pkg/templatecenter/artifact_placement.go
@@ -1,0 +1,64 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package templatecenter
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/constants"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/db/models"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+// upsertArtifactNodePlacement records that artifactID is physically present on
+// the given node. It is idempotent: re-distribution refreshes node_ip without
+// failing on the (artifact_id, node_id) primary key. nodeID is required (it is
+// part of the primary key); calls with an empty nodeID are ignored.
+func upsertArtifactNodePlacement(ctx context.Context, artifactID, nodeID, nodeIP string) error {
+	artifactID = strings.TrimSpace(artifactID)
+	nodeID = strings.TrimSpace(nodeID)
+	if artifactID == "" || nodeID == "" {
+		return nil
+	}
+	row := &models.ArtifactNodePlacement{
+		ArtifactID: artifactID,
+		NodeID:     nodeID,
+		NodeIP:     strings.TrimSpace(nodeIP),
+		CreatedAt:  time.Now().Unix(),
+	}
+	return store.db.WithContext(ctx).Table(constants.ArtifactNodePlacementTableName).
+		Clauses(clause.OnConflict{
+			Columns:   []clause.Column{{Name: "artifact_id"}, {Name: "node_id"}},
+			DoUpdates: clause.AssignmentColumns([]string{"node_ip"}),
+		}).Create(row).Error
+}
+
+// listArtifactNodePlacementsTx enumerates every node that holds (or held)
+// artifactID, using the supplied transaction so it observes the same snapshot
+// as the surrounding locked decision.
+func listArtifactNodePlacementsTx(tx *gorm.DB, artifactID string) ([]models.ArtifactNodePlacement, error) {
+	artifactID = strings.TrimSpace(artifactID)
+	if artifactID == "" {
+		return nil, nil
+	}
+	var rows []models.ArtifactNodePlacement
+	err := tx.Table(constants.ArtifactNodePlacementTableName).
+		Where("artifact_id = ?", artifactID).Find(&rows).Error
+	return rows, err
+}
+
+// deleteArtifactNodePlacementsTx removes all placement rows for artifactID. It
+// must run in the same transaction (TX2) that deletes the artifact row.
+func deleteArtifactNodePlacementsTx(tx *gorm.DB, artifactID string) error {
+	artifactID = strings.TrimSpace(artifactID)
+	if artifactID == "" {
+		return nil
+	}
+	return tx.Table(constants.ArtifactNodePlacementTableName).
+		Where("artifact_id = ?", artifactID).Delete(&models.ArtifactNodePlacement{}).Error
+}

--- a/CubeMaster/pkg/templatecenter/delete.go
+++ b/CubeMaster/pkg/templatecenter/delete.go
@@ -8,19 +8,18 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/google/uuid"
 	cubeboxv1 "github.com/tencentcloud/CubeSandbox/CubeMaster/api/services/cubebox/v1"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/constants"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/db/models"
-	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/node"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/cubelet"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/errorcode"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/localcache"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/service/sandbox"
 	sandboxtypes "github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/service/sandbox/types"
-	"gorm.io/gorm"
 )
 
 var ErrTemplateInUse = errors.New("template is still in use")
@@ -262,87 +261,31 @@ func cleanupTemplateJobs(ctx context.Context, templateID string) error {
 		Where("template_id = ?", templateID).Delete(&models.TemplateImageJob{}).Error
 }
 
+// cleanupTemplateArtifact runs reference-aware, last-owner cleanup for every
+// artifact this template references. Artifacts are processed in lexical order
+// of artifact_id so concurrent deletions of templates sharing multiple
+// artifacts acquire the per-artifact row locks in a consistent order (deadlock
+// avoidance). Each artifact's physical removal and metadata deletion are
+// delegated to cleanupArtifactFully (three-phase, lock-free RPC).
 func cleanupTemplateArtifact(ctx context.Context, templateID string, targets *templateCleanupTargets) error {
 	if targets == nil || len(targets.ArtifactIDs) == 0 {
 		return nil
 	}
-	var cleanupErr error
+	artifactIDs := make([]string, 0, len(targets.ArtifactIDs))
 	for artifactID := range targets.ArtifactIDs {
-		artifactTargets := resolveArtifactCleanupNodes(targets, artifactID)
-		if len(artifactTargets) == 0 {
-			artifactTargets = healthyTemplateNodes(targets.InstanceType)
+		if strings.TrimSpace(artifactID) != "" {
+			artifactIDs = append(artifactIDs, artifactID)
 		}
-		distributionErr := cleanupArtifactOnNodes(ctx, artifactID, artifactTargets)
-		artifact, lookupErr := getRootfsArtifactByID(ctx, artifactID)
-		if lookupErr != nil && !errors.Is(lookupErr, gorm.ErrRecordNotFound) {
-			cleanupErr = errors.Join(cleanupErr, lookupErr)
+	}
+	sort.Strings(artifactIDs)
+
+	var cleanupErr error
+	for _, artifactID := range artifactIDs {
+		if err := cleanupArtifactFully(ctx, artifactID, targets.InstanceType, templateID); err != nil {
+			cleanupErr = errors.Join(cleanupErr, err)
 		}
-		var artifactCleanupErr error
-		if lookupErr == nil {
-			if artifact.Ext4Path != "" {
-				if err := cleanupLocalRootfsArtifact(artifact.ArtifactID, artifact.Ext4Path); err != nil {
-					artifactCleanupErr = errors.Join(artifactCleanupErr, err)
-				}
-			}
-			if distributionErr == nil && artifactCleanupErr == nil {
-				if err := store.db.WithContext(ctx).Unscoped().Table(constants.RootfsArtifactTableName).
-					Where("artifact_id = ?", artifactID).Delete(&models.RootfsArtifact{}).Error; err != nil {
-					artifactCleanupErr = errors.Join(artifactCleanupErr, err)
-				}
-			}
-		}
-		cleanupErr = errors.Join(cleanupErr, distributionErr, artifactCleanupErr)
 	}
 	return cleanupErr
-}
-
-func resolveArtifactCleanupNodes(targets *templateCleanupTargets, artifactID string) []*node.Node {
-	if targets == nil || strings.TrimSpace(artifactID) == "" {
-		return nil
-	}
-	out := make([]*node.Node, 0)
-	seen := make(map[string]struct{})
-	appendNode := func(nodeID, nodeIP string) {
-		nodeID = strings.TrimSpace(nodeID)
-		nodeIP = strings.TrimSpace(nodeIP)
-		if nodeIP == "" && nodeID != "" {
-			if cachedNode, ok := localcache.GetNode(nodeID); ok && cachedNode != nil {
-				nodeIP = strings.TrimSpace(cachedNode.HostIP())
-				if nodeID == "" {
-					nodeID = strings.TrimSpace(cachedNode.ID())
-				}
-			}
-		}
-		if nodeIP == "" {
-			return
-		}
-		key := nodeID + "|" + nodeIP
-		if _, ok := seen[key]; ok {
-			return
-		}
-		out = append(out, &node.Node{
-			InsID: nodeID,
-			IP:    nodeIP,
-		})
-		seen[key] = struct{}{}
-	}
-	for _, replica := range targets.Replicas {
-		if strings.TrimSpace(replica.ArtifactID) != artifactID {
-			continue
-		}
-		appendNode(replica.NodeID, replica.NodeIP)
-	}
-	for _, job := range targets.Jobs {
-		if strings.TrimSpace(job.ArtifactID) != artifactID {
-			continue
-		}
-		appendNode(job.NodeID, job.NodeIP)
-	}
-	return out
-}
-
-func cleanupDistributedArtifact(ctx context.Context, artifactID, instanceType string) error {
-	return cleanupArtifactOnNodes(ctx, artifactID, healthyTemplateNodes(instanceType))
 }
 
 func cleanupTemplateReplicas(ctx context.Context, templateID string) error {

--- a/CubeMaster/pkg/templatecenter/delete_test.go
+++ b/CubeMaster/pkg/templatecenter/delete_test.go
@@ -13,8 +13,6 @@ import (
 	cubeboxv1 "github.com/tencentcloud/CubeSandbox/CubeMaster/api/services/cubebox/v1"
 	errorcodev1 "github.com/tencentcloud/CubeSandbox/CubeMaster/api/services/errorcode/v1"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/db/models"
-	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/node"
-	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/localcache"
 )
 
 func TestDeleteTemplateWithTargetsAllowsJobOnlyCleanup(t *testing.T) {
@@ -330,61 +328,6 @@ func TestDeleteTemplateWithTargetsPreservesMetadataAfterArtifactFailure(t *testi
 	}
 	if invalidated {
 		t.Fatal("cache should remain intact after artifact cleanup failure")
-	}
-}
-
-func TestResolveArtifactCleanupNodesUsesHistoricalTargets(t *testing.T) {
-	targets := &templateCleanupTargets{
-		Replicas: []models.TemplateReplica{
-			{ArtifactID: "artifact-1", NodeID: "node-a", NodeIP: "10.0.0.1"},
-			{ArtifactID: "artifact-1", NodeID: "node-a", NodeIP: "10.0.0.1"},
-		},
-		Jobs: []models.TemplateImageJob{
-			{ArtifactID: "artifact-1", NodeID: "node-b", NodeIP: "10.0.0.2"},
-			{ArtifactID: "artifact-2", NodeID: "node-c", NodeIP: "10.0.0.3"},
-		},
-	}
-
-	got := resolveArtifactCleanupNodes(targets, "artifact-1")
-	if len(got) != 2 {
-		t.Fatalf("expected 2 cleanup targets, got %d", len(got))
-	}
-	expected := map[string]struct{}{
-		"node-a|10.0.0.1": {},
-		"node-b|10.0.0.2": {},
-	}
-	for _, item := range got {
-		key := item.ID() + "|" + item.HostIP()
-		if _, ok := expected[key]; !ok {
-			t.Fatalf("unexpected cleanup node: %+v", item)
-		}
-		delete(expected, key)
-	}
-	if len(expected) != 0 {
-		t.Fatalf("missing cleanup nodes: %+v", expected)
-	}
-}
-
-func TestResolveArtifactCleanupNodesFallsBackToLocalcacheAddress(t *testing.T) {
-	patches := gomonkey.NewPatches()
-	defer patches.Reset()
-	patches.ApplyFunc(localcache.GetNode, func(nodeID string) (*node.Node, bool) {
-		if nodeID == "node-a" {
-			return &node.Node{InsID: "node-a", IP: "10.0.0.1"}, true
-		}
-		return nil, false
-	})
-
-	got := resolveArtifactCleanupNodes(&templateCleanupTargets{
-		Replicas: []models.TemplateReplica{
-			{ArtifactID: "artifact-1", NodeID: "node-a"},
-		},
-	}, "artifact-1")
-	if len(got) != 1 {
-		t.Fatalf("expected 1 cleanup target, got %d", len(got))
-	}
-	if got[0].ID() != "node-a" || got[0].HostIP() != "10.0.0.1" {
-		t.Fatalf("unexpected cleanup target: %+v", got[0])
 	}
 }
 

--- a/CubeMaster/pkg/templatecenter/distribution.go
+++ b/CubeMaster/pkg/templatecenter/distribution.go
@@ -76,6 +76,7 @@ func destroyArtifactOnNode(ctx context.Context, artifactID, instanceType string,
 	}
 	instanceType = strings.TrimSpace(instanceType)
 	if instanceType == "" {
+		log.G(ctx).Warnf("artifact cleanup: empty instanceType for artifact %s on node %s, defaulting to cubebox", artifactID, target.ID())
 		instanceType = cubeboxv1.InstanceType_cubebox.String()
 	}
 	rsp, err := deleteImageOnCubelet(ctx, getCubeletAddrForDelete(target.HostIP()), &imagev1.DestroyImageRequest{

--- a/CubeMaster/pkg/templatecenter/distribution.go
+++ b/CubeMaster/pkg/templatecenter/distribution.go
@@ -8,16 +8,20 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strconv"
+	"strings"
+	"sync"
+
 	"github.com/google/uuid"
+	cubeboxv1 "github.com/tencentcloud/CubeSandbox/CubeMaster/api/services/cubebox/v1"
 	imagev1 "github.com/tencentcloud/CubeSandbox/CubeMaster/api/services/images/v1"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/constants"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/db/models"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/log"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/node"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/cubelet"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/errorcode"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/service/sandbox/types"
-	"strconv"
-	"sync"
 )
 
 func buildReplicaForDistribution(target *node.Node, req *types.CreateCubeSandboxReq, artifactID, jobID string) ReplicaStatus {
@@ -41,7 +45,7 @@ func buildReplicaForDistribution(target *node.Node, req *types.CreateCubeSandbox
 	}
 }
 
-func cleanupArtifactOnNodes(ctx context.Context, artifactID string, targets []*node.Node) error {
+func cleanupArtifactOnNodes(ctx context.Context, artifactID, instanceType string, targets []*node.Node) error {
 	if artifactID == "" {
 		return nil
 	}
@@ -50,27 +54,56 @@ func cleanupArtifactOnNodes(ctx context.Context, artifactID string, targets []*n
 		if target == nil {
 			continue
 		}
-		rsp, err := deleteImageOnCubelet(ctx, getCubeletAddrForDelete(target.HostIP()), &imagev1.DestroyImageRequest{
-			RequestID: uuid.NewString(),
-			Spec: &imagev1.ImageSpec{
-				Image: artifactID,
-			},
-		})
-		if err != nil {
-			if isIgnorableArtifactDeleteError(err) {
-				continue
-			}
-			cleanupErr = errors.Join(cleanupErr, fmt.Errorf("delete artifact %s on node %s: %w", artifactID, target.ID(), err))
-			continue
-		}
-		if rsp.GetRet() != nil && int(rsp.GetRet().GetRetCode()) != int(errorcode.ErrorCode_Success) {
-			if isIgnorableArtifactDeleteMessage(rsp.GetRet().GetRetMsg()) {
-				continue
-			}
-			cleanupErr = errors.Join(cleanupErr, fmt.Errorf("delete artifact %s on node %s failed: %s", artifactID, target.ID(), rsp.GetRet().GetRetMsg()))
+		if _, err := destroyArtifactOnNode(ctx, artifactID, instanceType, target); err != nil {
+			cleanupErr = errors.Join(cleanupErr, err)
 		}
 	}
 	return cleanupErr
+}
+
+// destroyArtifactOnNode issues an idempotent ext4 artifact destroy to a single
+// node. It fills storage_media=ext4 and the instance-type annotation so the
+// cubelet routes to its synchronous pmem destroy path (a plain DestroyImage is
+// a no-op for ext4 artifacts that are not containerd images).
+//
+// Returns inUse=true (and nil error) when the node refuses because a running
+// sandbox still references the artifact: that is a protection, not a failure,
+// and the caller keeps the artifact for GC to retry. NotFound is treated as
+// success (idempotent). Any other failure is returned as an error.
+func destroyArtifactOnNode(ctx context.Context, artifactID, instanceType string, target *node.Node) (bool, error) {
+	if target == nil {
+		return false, nil
+	}
+	instanceType = strings.TrimSpace(instanceType)
+	if instanceType == "" {
+		instanceType = cubeboxv1.InstanceType_cubebox.String()
+	}
+	rsp, err := deleteImageOnCubelet(ctx, getCubeletAddrForDelete(target.HostIP()), &imagev1.DestroyImageRequest{
+		RequestID: uuid.NewString(),
+		Spec: &imagev1.ImageSpec{
+			Image:        artifactID,
+			StorageMedia: imagev1.ImageStorageMediaType_ext4.String(),
+			Annotations: map[string]string{
+				constants.CubeAnnotationsInsType: instanceType,
+			},
+		},
+	})
+	if err != nil {
+		if isIgnorableArtifactDeleteError(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("delete artifact %s on node %s: %w", artifactID, target.ID(), err)
+	}
+	if rsp.GetRet() != nil && int(rsp.GetRet().GetRetCode()) != int(errorcode.ErrorCode_Success) {
+		if int(rsp.GetRet().GetRetCode()) == int(errorcode.ErrorCode_Conflict) {
+			return true, nil // running sandbox still uses it; defer to GC
+		}
+		if isIgnorableArtifactDeleteMessage(rsp.GetRet().GetRetMsg()) {
+			return false, nil
+		}
+		return false, fmt.Errorf("delete artifact %s on node %s failed: %s", artifactID, target.ID(), rsp.GetRet().GetRetMsg())
+	}
+	return false, nil
 }
 
 func cleanupTemplateReplicasOnNodes(ctx context.Context, templateID string, replicas []models.TemplateReplica, targets []*node.Node) error {
@@ -187,6 +220,14 @@ func distributeRootfsArtifact(ctx context.Context, req *types.CreateTemplateFrom
 			readyTargets = append(readyTargets, target)
 			if templateID != "" && generatedReq != nil {
 				_ = UpsertReplica(ctx, templateID, generatedReq.InstanceType, replica)
+			}
+			// Record physical placement independently of the replica lifecycle so
+			// last-owner-cleanup / GC can later reach this node even after the
+			// replica row is removed (FIX-1).
+			if err := upsertArtifactNodePlacement(ctx, artifact.ArtifactID, target.ID(), target.HostIP()); err != nil {
+				// Non-fatal: placement is a cleanup optimisation, not a
+				// correctness gate for distribution. Backfill/GC reconcile later.
+				log.G(ctx).Warnf("record artifact placement %s on node %s failed: %v", artifact.ArtifactID, target.ID(), err)
 			}
 		}()
 	}

--- a/CubeMaster/pkg/templatecenter/image_job_runner.go
+++ b/CubeMaster/pkg/templatecenter/image_job_runner.go
@@ -139,7 +139,7 @@ func runTemplateImageJob(ctx context.Context, jobID string, req *types.CreateTem
 	}
 	if expected > 0 && ready == 0 {
 		if builtFreshArtifact {
-			if cleanupErr := cleanupFailedRootfsArtifact(ctx, artifact, req.InstanceType); cleanupErr != nil {
+			if cleanupErr := cleanupFailedRootfsArtifact(ctx, artifact, req.InstanceType, req.TemplateID); cleanupErr != nil {
 				logger.Errorf("cleanup fresh rootfs artifact after distribution failure fail: %v", cleanupErr)
 			}
 		}
@@ -184,7 +184,7 @@ func runTemplateImageJob(ctx context.Context, jobID string, req *types.CreateTem
 	}
 	if err != nil {
 		if builtFreshArtifact {
-			if cleanupErr := cleanupFailedRootfsArtifact(ctx, artifact, req.InstanceType); cleanupErr != nil {
+			if cleanupErr := cleanupFailedRootfsArtifact(ctx, artifact, req.InstanceType, req.TemplateID); cleanupErr != nil {
 				logger.Errorf("cleanup fresh rootfs artifact after create template error fail: %v", cleanupErr)
 			}
 		}
@@ -202,7 +202,7 @@ func runTemplateImageJob(ctx context.Context, jobID string, req *types.CreateTem
 	jobPhase := JobPhaseReady
 	if info.Status == StatusFailed {
 		if builtFreshArtifact {
-			if cleanupErr := cleanupFailedRootfsArtifact(ctx, artifact, req.InstanceType); cleanupErr != nil {
+			if cleanupErr := cleanupFailedRootfsArtifact(ctx, artifact, req.InstanceType, req.TemplateID); cleanupErr != nil {
 				logger.Errorf("cleanup fresh rootfs artifact after failed template status fail: %v", cleanupErr)
 			}
 		}

--- a/CubeMaster/pkg/templatecenter/job_constants.go
+++ b/CubeMaster/pkg/templatecenter/job_constants.go
@@ -14,6 +14,14 @@ const (
 	ArtifactStatusBuilding = "BUILDING"
 	ArtifactStatusReady    = "READY"
 	ArtifactStatusFailed   = "FAILED"
+	// ArtifactStatusCleanupPending marks an artifact whose logical references
+	// have reached zero and whose physical files are being / awaiting removal.
+	// A row in this state must never be reused; the create/reuse path rebuilds
+	// instead. GC retries cleanup until the artifact row can be safely deleted.
+	ArtifactStatusCleanupPending = "CLEANUP_PENDING"
+	// ArtifactStatusOrphaned marks an artifact with no surviving references that
+	// was never fully built/distributed (e.g. interrupted build); GC reclaims it.
+	ArtifactStatusOrphaned = "ORPHANED"
 
 	JobStatusPending = "PENDING"
 	JobStatusRunning = "RUNNING"

--- a/CubeMaster/pkg/templatecenter/redo.go
+++ b/CubeMaster/pkg/templatecenter/redo.go
@@ -303,7 +303,7 @@ func runRedoTemplateImageJob(ctx context.Context, jobID string, req *types.RedoT
 
 	readyTargets := targets
 	if resumePhase == JobPhaseDistributing {
-		if err := cleanupArtifactOnNodes(ctx, artifact.ArtifactID, targets); err != nil {
+		if err := cleanupArtifactOnNodes(ctx, artifact.ArtifactID, generatedReq.InstanceType, targets); err != nil {
 			failRedoTemplateImageJob(ctx, jobID, JobPhaseDistributing, fmt.Sprintf("cleanup artifact before redistribute failed: %v", err))
 			return
 		}

--- a/CubeMaster/pkg/templatecenter/snapshot_ops.go
+++ b/CubeMaster/pkg/templatecenter/snapshot_ops.go
@@ -1005,6 +1005,24 @@ func deleteSnapshotMetadataOnly(ctx context.Context, snapshotID string) error {
 	return cleanupTemplateMetadata(ctx, snapshotID)
 }
 
+func rootfsArtifactIDFromCreateRequest(req *sandboxtypes.CreateCubeSandboxReq) string {
+	if req == nil {
+		return ""
+	}
+	if id := strings.TrimSpace(req.Annotations[constants.CubeAnnotationRootfsArtifactID]); id != "" {
+		return id
+	}
+	for _, container := range req.Containers {
+		if container == nil || container.Image == nil {
+			continue
+		}
+		if id := strings.TrimSpace(container.Image.Annotations[constants.CubeAnnotationRootfsArtifactID]); id != "" {
+			return id
+		}
+	}
+	return ""
+}
+
 func createDefinitionTx(ctx context.Context, tx *gorm.DB, templateID string, storedReq *sandboxtypes.CreateCubeSandboxReq, instanceType, version string, opts definitionCreateOptions) error {
 	payload, err := json.Marshal(storedReq)
 	if err != nil {
@@ -1030,6 +1048,7 @@ func createDefinitionTx(ctx context.Context, tx *gorm.DB, templateID string, sto
 		StorageBackend:            opts.StorageBackend,
 		Retain:                    opts.Retain,
 		RootfsSizeBytesAtSnapshot: opts.RootfsSizeBytesAtSnapshot,
+		RootfsArtifactID:          rootfsArtifactIDFromCreateRequest(storedReq),
 		RequestJSON:               string(payload),
 	}
 	if kind == TemplateKindSnapshot && model.StorageBackend == "" {

--- a/CubeMaster/pkg/templatecenter/store.go
+++ b/CubeMaster/pkg/templatecenter/store.go
@@ -600,25 +600,7 @@ func refreshTemplateReplicaSummary(ctx context.Context, templateID string) error
 }
 
 func createDefinition(ctx context.Context, templateID string, storedReq *sandboxtypes.CreateCubeSandboxReq, instanceType, version string) error {
-	payload, err := json.Marshal(storedReq)
-	if err != nil {
-		return err
-	}
-	model := &models.TemplateDefinition{
-		TemplateID:   templateID,
-		InstanceType: instanceType,
-		Version:      version,
-		Status:       StatusPending,
-		Kind:         TemplateKindTemplate,
-		RequestJSON:  string(payload),
-	}
-	if err = store.db.WithContext(ctx).Table(constants.TemplateDefinitionTableName).Create(model).Error; err != nil {
-		if strings.Contains(err.Error(), "1062") || strings.Contains(err.Error(), "Duplicate entry") {
-			return ErrDuplicateTemplate
-		}
-		return err
-	}
-	return nil
+	return createDefinitionTx(ctx, store.db.WithContext(ctx), templateID, storedReq, instanceType, version, definitionCreateOptions{})
 }
 
 func createDefinitionWithOptions(ctx context.Context, templateID string, storedReq *sandboxtypes.CreateCubeSandboxReq, instanceType, version string, opts definitionCreateOptions) error {

--- a/CubeMaster/pkg/templatecenter/store.go
+++ b/CubeMaster/pkg/templatecenter/store.go
@@ -265,6 +265,7 @@ func Init(ctx context.Context) error {
 			log.G(ctx).Warnf("warm ready template locality fail:%v", warmErr)
 		}
 		startSnapshotReconciler(ctx)
+		startArtifactGC(ctx)
 		scheduleInitialCompatScan(ctx)
 	})
 	return initErr

--- a/CubeMaster/pkg/templatecenter/template_image_test.go
+++ b/CubeMaster/pkg/templatecenter/template_image_test.go
@@ -872,48 +872,38 @@ func TestCleanupLocalRootfsArtifactRemovesManagedDirectory(t *testing.T) {
 	}
 }
 
-func TestCleanupFailedRootfsArtifactKeepsMetadataOnCleanupFailure(t *testing.T) {
+func TestCleanupFailedRootfsArtifactDelegatesToLastOwnerCleanup(t *testing.T) {
 	patches := gomonkey.NewPatches()
 	defer patches.Reset()
 
-	distributionErr := errors.New("delete image on node-a failed")
-	updateCalled := false
-	deleteCalled := false
-
-	patches.ApplyFunc(cleanupDistributedArtifact, func(ctx context.Context, artifactID, instanceType string) error {
-		return distributionErr
-	})
-	patches.ApplyFunc(cleanupLocalRootfsArtifact, func(artifactID, ext4Path string) error {
-		return nil
-	})
-	patches.ApplyFunc(deleteRootfsArtifactRecord, func(ctx context.Context, artifactID string) error {
-		deleteCalled = true
-		return nil
-	})
-	patches.ApplyFunc(updateRootfsArtifact, func(ctx context.Context, artifactID string, values map[string]any) error {
-		updateCalled = true
-		if values["status"] != ArtifactStatusFailed {
-			t.Fatalf("unexpected status update: %+v", values)
-		}
-		lastError, _ := values["last_error"].(string)
-		if !strings.Contains(lastError, distributionErr.Error()) {
-			t.Fatalf("last_error=%q does not contain cleanup error", lastError)
-		}
+	var (
+		gotArtifactID   string
+		gotInstanceType string
+		gotExclude      string
+	)
+	patches.ApplyFunc(cleanupArtifactFully, func(ctx context.Context, artifactID, instanceType, excludeTemplateID string) error {
+		gotArtifactID = artifactID
+		gotInstanceType = instanceType
+		gotExclude = excludeTemplateID
 		return nil
 	})
 
-	err := cleanupFailedRootfsArtifact(context.Background(), &models.RootfsArtifact{
+	if err := cleanupFailedRootfsArtifact(context.Background(), &models.RootfsArtifact{
 		ArtifactID: "artifact-1",
 		Ext4Path:   filepath.Join(t.TempDir(), "artifact-1", "artifact-1.ext4"),
-	}, cubeboxv1.InstanceType_cubebox.String())
-	if !errors.Is(err, distributionErr) {
-		t.Fatalf("expected distribution cleanup error, got %v", err)
+	}, cubeboxv1.InstanceType_cubebox.String(), "tpl-owner"); err != nil {
+		t.Fatalf("cleanupFailedRootfsArtifact returned error: %v", err)
 	}
-	if deleteCalled {
-		t.Fatal("rootfs artifact record should not be deleted when cleanup fails")
+	if gotArtifactID != "artifact-1" {
+		t.Fatalf("artifactID not forwarded, got %q", gotArtifactID)
 	}
-	if !updateCalled {
-		t.Fatal("rootfs artifact record should be marked failed when cleanup is incomplete")
+	if gotInstanceType != cubeboxv1.InstanceType_cubebox.String() {
+		t.Fatalf("instanceType not forwarded, got %q", gotInstanceType)
+	}
+	// The build's own template must be excluded so its in-flight job/definition
+	// does not pin the artifact and block its own failure cleanup.
+	if gotExclude != "tpl-owner" {
+		t.Fatalf("expected own template excluded, got %q", gotExclude)
 	}
 }
 
@@ -1177,7 +1167,7 @@ func TestRunRedoTemplateImageJobStopsOnArtifactCleanupFailure(t *testing.T) {
 			GeneratedRequestJSON: string(generatedReqPayload),
 		}, nil
 	})
-	patches.ApplyFunc(cleanupArtifactOnNodes, func(ctx context.Context, artifactID string, targets []*node.Node) error {
+	patches.ApplyFunc(cleanupArtifactOnNodes, func(ctx context.Context, artifactID, instanceType string, targets []*node.Node) error {
 		return errors.New("cleanup image failed")
 	})
 	patches.ApplyFunc(distributeRootfsArtifact, func(ctx context.Context, req *types.CreateTemplateFromImageReq, generatedReq *types.CreateCubeSandboxReq, artifact *models.RootfsArtifact, templateID, jobID string) ([]*node.Node, int32, int32, int32, error) {

--- a/Cubelet/internal/cube/server/images/ext4image/destroy.go
+++ b/Cubelet/internal/cube/server/images/ext4image/destroy.go
@@ -39,8 +39,8 @@ type ArtifactInUseFunc func(artifactID string) (bool, error)
 //
 // Safety invariants:
 //   - instanceType/artifactID must pass ValidateSafeID (no separators/traversal).
-//   - the resolved directory must live under the managed pmem base
-//     (ValidatePathUnderBase), defending against a corrupt/forged id from Master.
+//   - the managed pmem base is resolved before constructing the artifact leaf,
+//     and the final directory must live under that resolved base.
 //   - if inUse reports the artifact is referenced by a running sandbox, deletion
 //     is refused with ErrArtifactInUse (no physical removal).
 //   - a missing directory is treated as success (idempotent).
@@ -63,8 +63,15 @@ func DestroyPmemArtifact(ctx context.Context, instanceType, artifactID string, i
 	}
 
 	base := pmem.GetPmemBasePath(instanceType)
-	dir := filepath.Join(base, artifactID)
-	resolved, err := pathutil.ValidatePathUnderBase(base, dir)
+	resolvedBase, err := filepath.EvalSymlinks(base)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("resolve pmem base %q: %w", base, err)
+	}
+	dir := filepath.Join(resolvedBase, artifactID)
+	resolved, err := pathutil.ValidatePathUnderBase(resolvedBase, dir)
 	if err != nil {
 		return fmt.Errorf("artifact path validation failed: %w", err)
 	}

--- a/Cubelet/internal/cube/server/images/ext4image/destroy.go
+++ b/Cubelet/internal/cube/server/images/ext4image/destroy.go
@@ -1,0 +1,77 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package ext4image
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/tencentcloud/CubeSandbox/Cubelet/pkg/container/pmem"
+	"github.com/tencentcloud/CubeSandbox/Cubelet/pkg/log"
+	"github.com/tencentcloud/CubeSandbox/Cubelet/pkg/pathutil"
+)
+
+// ErrArtifactInUse indicates the ext4 OS image artifact is still referenced by
+// a running sandbox on this node, so its physical files are intentionally
+// preserved. The caller (CubeMaster last-owner-cleanup / GC) must retry after
+// the referencing sandbox exits. This is a protection, not a leak.
+var ErrArtifactInUse = errors.New("ext4 artifact in use by running sandbox")
+
+// ArtifactInUseFunc reports whether the given artifact (image) id is still
+// referenced by any sandbox tracked on this node.
+type ArtifactInUseFunc func(artifactID string) (bool, error)
+
+// DestroyPmemArtifact synchronously and idempotently removes the on-disk ext4
+// OS image artifact directory (rootfs .ext4 + kernel .vm + companion files) for
+// the given instanceType/artifactID. It is the ext4 counterpart of the
+// containerd image removal path used by DestroyImage.
+//
+// Unlike the containerd path it does NOT go through cdp.PreDelete (which would
+// also run the runtemplate catalog hook and could be blocked by a stale bolt
+// index). Template-level reference decisions are authoritative in CubeMaster;
+// the only node-local safety check here is whether a running sandbox still uses
+// the artifact.
+//
+// Safety invariants:
+//   - instanceType/artifactID must pass ValidateSafeID (no separators/traversal).
+//   - the resolved directory must live under the managed pmem base
+//     (ValidatePathUnderBase), defending against a corrupt/forged id from Master.
+//   - if inUse reports the artifact is referenced by a running sandbox, deletion
+//     is refused with ErrArtifactInUse (no physical removal).
+//   - a missing directory is treated as success (idempotent).
+func DestroyPmemArtifact(ctx context.Context, instanceType, artifactID string, inUse ArtifactInUseFunc) error {
+	if err := pathutil.ValidateSafeID(instanceType); err != nil {
+		return fmt.Errorf("invalid instanceType %q: %w", instanceType, err)
+	}
+	if err := pathutil.ValidateSafeID(artifactID); err != nil {
+		return fmt.Errorf("invalid artifactID %q: %w", artifactID, err)
+	}
+
+	if inUse != nil {
+		used, err := inUse(artifactID)
+		if err != nil {
+			return fmt.Errorf("check artifact %q in-use: %w", artifactID, err)
+		}
+		if used {
+			return ErrArtifactInUse
+		}
+	}
+
+	base := pmem.GetPmemBasePath(instanceType)
+	dir := filepath.Join(base, artifactID)
+	resolved, err := pathutil.ValidatePathUnderBase(base, dir)
+	if err != nil {
+		return fmt.Errorf("artifact path validation failed: %w", err)
+	}
+
+	if err := os.RemoveAll(resolved); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("remove ext4 artifact dir %q: %w", resolved, err)
+	}
+	log.G(ctx).Infof("destroyed ext4 artifact dir %q (instanceType=%s artifactID=%s)", resolved, instanceType, artifactID)
+	return nil
+}

--- a/Cubelet/internal/cube/server/images/ext4image/utils_test.go
+++ b/Cubelet/internal/cube/server/images/ext4image/utils_test.go
@@ -197,3 +197,62 @@ func assertRawKernelVersionMatches(t *testing.T, instanceType, imageRef string, 
 		t.Fatalf("kernel version=%q, want %q", strings.TrimSpace(string(got)), kernelVersionForContent(kernel))
 	}
 }
+
+func TestDestroyPmemArtifactResolvesSymlinkedBase(t *testing.T) {
+	dataDir := t.TempDir()
+	realBase := filepath.Join(t.TempDir(), "cubebox_os_image")
+	if err := os.MkdirAll(realBase, 0o755); err != nil {
+		t.Fatalf("MkdirAll real base error=%v", err)
+	}
+	if err := os.Symlink(realBase, filepath.Join(dataDir, "cubebox_os_image")); err != nil {
+		t.Fatalf("Symlink base error=%v", err)
+	}
+	pmem.Init(dataDir)
+
+	artifactDir := filepath.Join(realBase, "artifact-6")
+	writeTestFile(t, filepath.Join(artifactDir, "artifact-6.ext4"), []byte("rootfs"))
+
+	if err := DestroyPmemArtifact(context.Background(), "cubebox", "artifact-6", nil); err != nil {
+		t.Fatalf("DestroyPmemArtifact error=%v", err)
+	}
+	if _, err := os.Stat(artifactDir); !os.IsNotExist(err) {
+		t.Fatalf("artifact dir should be removed, stat err=%v", err)
+	}
+}
+
+func TestDestroyPmemArtifactUnlinksLeafSymlinkOnly(t *testing.T) {
+	dataDir := t.TempDir()
+	pmem.Init(dataDir)
+	base := pmem.GetPmemBasePath("cubebox")
+	if err := os.MkdirAll(base, 0o755); err != nil {
+		t.Fatalf("MkdirAll base error=%v", err)
+	}
+	outside := t.TempDir()
+	outsideFile := filepath.Join(outside, "keep.txt")
+	if err := os.WriteFile(outsideFile, []byte("keep"), 0o644); err != nil {
+		t.Fatalf("WriteFile outside error=%v", err)
+	}
+	leaf := filepath.Join(base, "artifact-7")
+	if err := os.Symlink(outside, leaf); err != nil {
+		t.Fatalf("Symlink leaf error=%v", err)
+	}
+
+	if err := DestroyPmemArtifact(context.Background(), "cubebox", "artifact-7", nil); err != nil {
+		t.Fatalf("DestroyPmemArtifact error=%v", err)
+	}
+	if _, err := os.Lstat(leaf); !os.IsNotExist(err) {
+		t.Fatalf("artifact symlink should be removed, lstat err=%v", err)
+	}
+	if _, err := os.Stat(outsideFile); err != nil {
+		t.Fatalf("outside target should remain, stat err=%v", err)
+	}
+}
+
+func TestDestroyPmemArtifactMissingBaseIsIdempotent(t *testing.T) {
+	dataDir := t.TempDir()
+	pmem.Init(dataDir)
+
+	if err := DestroyPmemArtifact(context.Background(), "cubebox", "artifact-8", nil); err != nil {
+		t.Fatalf("missing pmem base should be success, got %v", err)
+	}
+}

--- a/Cubelet/plugins/cube/internals/cubes/local.go
+++ b/Cubelet/plugins/cube/internals/cubes/local.go
@@ -186,3 +186,16 @@ func (l *local) FindContainerOfCubebox(ctx context.Context, id string) (cntr *cu
 func (l *local) List() []*cubeboxstore.CubeBox {
 	return l.cubeboxStore.List()
 }
+
+// IsImageInUse reports whether the given image/artifact id is currently
+// referenced by any sandbox tracked on this node. It mirrors the protection in
+// cubeboxImageDeleteHook and is used by the ext4 artifact destroy path
+// (DestroyImage) to refuse removing an OS image that a running sandbox depends
+// on, without invoking the runtemplate catalog delete hook.
+func (l *local) IsImageInUse(imageID string) (bool, error) {
+	cbs, err := l.cubeboxStore.GetCubeboxByImageID(imageID)
+	if err != nil {
+		return false, err
+	}
+	return len(cbs) > 0, nil
+}

--- a/Cubelet/plugins/cube/internals/cubes/plugin.go
+++ b/Cubelet/plugins/cube/internals/cubes/plugin.go
@@ -33,6 +33,7 @@ type CubeboxAPI interface {
 	Get(ctx context.Context, id string) (*cubeboxstore.CubeBox, error)
 	FindContainerOfCubebox(ctx context.Context, ID string) (*cubeboxstore.Container, *cubeboxstore.CubeBox, error)
 	List() []*cubeboxstore.CubeBox
+	IsImageInUse(imageID string) (bool, error)
 
 	Save(ctx context.Context, info *cubeboxstore.CubeBox, opts ...UpdateCubeboxOpt) error
 	SyncByID(ctx context.Context, id string, opts ...UpdateCubeboxOpt) error

--- a/Cubelet/services/cubebox/resume_reconcile_test.go
+++ b/Cubelet/services/cubebox/resume_reconcile_test.go
@@ -65,6 +65,10 @@ func (f *fakeCubeboxAPI) Delete(ctx context.Context, opt *cubes.DeleteOption) er
 	return nil
 }
 
+func (f *fakeCubeboxAPI) IsImageInUse(imageID string) (bool, error) {
+	return false, nil
+}
+
 func TestConvergeResumeStateAfterOpaqueRestoreClearsPauseStateAndInvalidatesBindings(t *testing.T) {
 	cb := newCubeboxWithStatusForTest("sb-resume-helper", cubeboxstore.Status{
 		PausedAt:  time.Now().Add(-2 * time.Minute).UnixNano(),

--- a/Cubelet/services/cubebox/template_ops.go
+++ b/Cubelet/services/cubebox/template_ops.go
@@ -451,7 +451,7 @@ func resolveCleanupRefs(ctx context.Context, templateID string, objects []*cubeb
 		if err != nil {
 			return nil, "", err
 		}
-		return refs, callerSnapshotPath, nil
+		return refs, ensureSnapshotCleanupPath(ctx, templateID, callerSnapshotPath), nil
 	}
 	entry, err := storage.GetLocalSnapshot(ctx, templateID)
 	if err == nil && entry != nil {
@@ -460,14 +460,38 @@ func resolveCleanupRefs(ctx context.Context, templateID string, objects []*cubeb
 		if snapshotPath == "" {
 			snapshotPath = callerSnapshotPath
 		}
-		return refs, snapshotPath, nil
+		return refs, ensureSnapshotCleanupPath(ctx, templateID, snapshotPath), nil
 	}
 	if err != nil && !errors.Is(err, storage.ErrSnapshotCatalogNotFound) {
 		log.G(ctx).Warnf("CleanupTemplate %s: catalog lookup failed (%v); falling back to deterministic refs", templateID, err)
 	} else {
 		log.G(ctx).Warnf("CleanupTemplate %s: catalog miss; falling back to deterministic refs", templateID)
 	}
-	return storage.DefaultTemplateObjectRefs(templateID), callerSnapshotPath, nil
+	return storage.DefaultTemplateObjectRefs(templateID), ensureSnapshotCleanupPath(ctx, templateID, callerSnapshotPath), nil
+}
+
+// ensureSnapshotCleanupPath implements FIX-4: when neither the caller nor the
+// local catalog supplies a snapshot path (catalog miss / legacy master), derive
+// the deterministic snapshot directory used by CommitSandbox so the on-disk
+// snapshot is not orphaned (L11). The derived path is the templateID-level dir
+// (`<DefaultSnapshotDir>/cubebox/<templateID>`) which contains every spec
+// variant, and is bounded by ValidatePathUnderBase (S3). On any validation
+// failure we return the original (empty) path rather than an unsafe guess.
+func ensureSnapshotCleanupPath(ctx context.Context, templateID, snapshotPath string) string {
+	if strings.TrimSpace(snapshotPath) != "" {
+		return snapshotPath
+	}
+	if err := pathutil.ValidateSafeID(templateID); err != nil {
+		log.G(ctx).Warnf("CleanupTemplate %s: cannot derive snapshot dir, unsafe templateID: %v", templateID, err)
+		return snapshotPath
+	}
+	guessed := filepath.Join(DefaultSnapshotDir, "cubebox", templateID)
+	if _, err := pathutil.ValidatePathUnderBase(DefaultSnapshotDir, guessed); err != nil {
+		log.G(ctx).Warnf("CleanupTemplate %s: derived snapshot dir %q rejected: %v", templateID, guessed, err)
+		return snapshotPath
+	}
+	log.G(ctx).Infof("CleanupTemplate %s: derived deterministic snapshot dir %q for cleanup", templateID, guessed)
+	return guessed
 }
 
 func cubecowRefsFromCatalogEntry(templateID string, entry *storage.SnapshotCatalogEntry) []storage.CowObjectRef {

--- a/Cubelet/services/images/service.go
+++ b/Cubelet/services/images/service.go
@@ -6,8 +6,10 @@ package images
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"runtime/debug"
+	"strings"
 	"time"
 
 	"github.com/containerd/plugin/registry"
@@ -17,9 +19,11 @@ import (
 	"github.com/containerd/containerd/v2/pkg/namespaces"
 	"github.com/containerd/platforms"
 	"github.com/containerd/plugin"
+	cubebox "github.com/tencentcloud/CubeSandbox/Cubelet/api/services/cubebox/v1"
 	"github.com/tencentcloud/CubeSandbox/Cubelet/api/services/errorcode/v1"
 	"github.com/tencentcloud/CubeSandbox/Cubelet/api/services/images/v1"
 	cubeimages "github.com/tencentcloud/CubeSandbox/Cubelet/api/services/images/v1"
+	"github.com/tencentcloud/CubeSandbox/Cubelet/internal/cube/server/images/ext4image"
 	"github.com/tencentcloud/CubeSandbox/Cubelet/pkg/constants"
 	"github.com/tencentcloud/CubeSandbox/Cubelet/pkg/cubelet"
 	"github.com/tencentcloud/CubeSandbox/Cubelet/pkg/log"
@@ -122,6 +126,9 @@ func initFunc(ic *plugin.InitContext) (interface{}, error) {
 	if register, ok := cubeboxAPIObj.(cubes.CubeboxEventListenerRegistry); ok {
 		register.Register(srv.imageGCManager)
 	}
+	if usage, ok := cubeboxAPIObj.(imageUsageChecker); ok {
+		srv.imageUsage = usage
+	}
 	go srv.imageGCManager.Run(ic.Context)
 
 	return srv, nil
@@ -164,11 +171,19 @@ func parseImageGCPolicy(c ImageGCConfig) ImageGCPolicy {
 	return policy
 }
 
+// imageUsageChecker reports whether an image/artifact id is still referenced by
+// a running sandbox on this node. Implemented by the cubebox store plugin; used
+// by the ext4 artifact destroy path to refuse deleting an in-use OS image.
+type imageUsageChecker interface {
+	IsImageInUse(imageID string) (bool, error)
+}
+
 type service struct {
 	l              *local
 	imageGCManager *imageGCManager
 	client         *containerd.Client
 	volume         *volumeLocal
+	imageUsage     imageUsageChecker
 	images.UnimplementedImagesServer
 }
 
@@ -282,6 +297,13 @@ func (s *service) DestroyImage(ctx context.Context, req *images.DestroyImageRequ
 		return rsp, nil
 	}
 
+	// FIX-1: ext4 OS image artifacts are not containerd images; the legacy
+	// CRI RemoveImage path silently no-ops on them (LocalResolve NotFound).
+	// Route ext4 deletions to the synchronous, idempotent pmem destroy path.
+	if req.GetSpec().GetStorageMedia() == cubeimages.ImageStorageMediaType_ext4.String() {
+		return s.destroyExt4Artifact(ctx, req, rsp), nil
+	}
+
 	ns := namespaces.Default
 	if req.Spec.Namespace != "" {
 		ns = req.Spec.Namespace
@@ -301,6 +323,39 @@ func (s *service) DestroyImage(ctx context.Context, req *images.DestroyImageRequ
 	}
 	log.G(ctx).Debugf("Remove image succ:%v", utils.InterfaceToString(req.GetSpec()))
 	return rsp, nil
+}
+
+// destroyExt4Artifact removes an ext4 OS image artifact's on-disk files. The
+// instanceType is taken from the MasterAnnotationInstanceType annotation (set
+// symmetrically by CreateImage distribution), defaulting to the cubebox
+// instance type (currently the only ext4 instance type). A running-sandbox
+// reference results in a Conflict so an in-use OS image is never deleted;
+// CubeMaster GC retries after the sandbox exits.
+func (s *service) destroyExt4Artifact(ctx context.Context, req *images.DestroyImageRequest, rsp *images.DestroyImageResponse) *images.DestroyImageResponse {
+	artifactID := req.GetSpec().GetImage()
+	instanceType := strings.TrimSpace(req.GetSpec().GetAnnotations()[constants.MasterAnnotationInstanceType])
+	if instanceType == "" {
+		instanceType = cubebox.InstanceType_cubebox.String()
+	}
+
+	var inUse ext4image.ArtifactInUseFunc
+	if s.imageUsage != nil {
+		inUse = s.imageUsage.IsImageInUse
+	}
+
+	err := ext4image.DestroyPmemArtifact(ctx, instanceType, artifactID, inUse)
+	if err == nil {
+		log.G(ctx).Infof("destroyed ext4 artifact %q (instanceType=%s)", artifactID, instanceType)
+		return rsp
+	}
+	if errors.Is(err, ext4image.ErrArtifactInUse) {
+		rsp.Ret.RetCode = errorcode.ErrorCode_Conflict
+		rsp.Ret.RetMsg = err.Error()
+		return rsp
+	}
+	rsp.Ret.RetCode = errorcode.ErrorCode_Unknown
+	rsp.Ret.RetMsg = fmt.Sprintf("destroy ext4 artifact %q: %v", artifactID, err)
+	return rsp
 }
 
 type ExpirationTimeSetter interface {

--- a/Cubelet/storage/cubecow_snapshot_artifacts.go
+++ b/Cubelet/storage/cubecow_snapshot_artifacts.go
@@ -6,6 +6,7 @@ package storage
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -263,19 +264,27 @@ func CleanupCowTemplateObjects(ctx context.Context, refs []CowObjectRef) error {
 	if err != nil {
 		return err
 	}
+	// FIX-3: best-effort cleanup. A single object failing (e.g. a missing or
+	// kind-mismatched entry) must not abort cleanup of the remaining objects,
+	// otherwise sibling cubecow objects leak. Errors are aggregated; the caller
+	// (CubeMaster) keeps template metadata on failure and retries, and each
+	// DeleteByKind is idempotent (NotFound -> success).
+	var cleanupErr error
 	for _, ref := range refs {
 		if strings.TrimSpace(ref.Name) == "" {
 			continue
 		}
-		kind, err := normalizeCowKind(ref.Kind)
+		kind, err := normalizeCowKindForRole(ref.Kind, ref.Role)
 		if err != nil {
-			return fmt.Errorf("cleanup cubecow object %q: %w", ref.Name, err)
+			cleanupErr = errors.Join(cleanupErr, fmt.Errorf("cleanup cubecow object %q: %w", ref.Name, err))
+			continue
 		}
 		if err := manager.DeleteByKind(ctx, ref.Name, kind); err != nil {
-			return fmt.Errorf("cleanup cubecow object %q: %w", ref.Name, err)
+			cleanupErr = errors.Join(cleanupErr, fmt.Errorf("cleanup cubecow object %q: %w", ref.Name, err))
+			continue
 		}
 	}
-	return nil
+	return cleanupErr
 }
 
 func InspectCowObjects(ctx context.Context, refs []CowObjectRef) ([]CowObjectStatus, error) {
@@ -477,4 +486,21 @@ func normalizeCowKind(kind string) (string, error) {
 	default:
 		return "", fmt.Errorf("unsupported cubecow kind %q", kind)
 	}
+}
+
+// normalizeCowKindForRole resolves a cubecow kind, defaulting an empty/blank
+// kind from the object role instead of failing. CubeMaster catalog entries do
+// not always carry an explicit kind; defaulting keeps cleanup from aborting,
+// and DeleteByKind auto-recovers if the guessed kind is wrong.
+func normalizeCowKindForRole(kind, role string) (string, error) {
+	if strings.TrimSpace(kind) == "" {
+		switch strings.ToLower(strings.TrimSpace(role)) {
+		case "rootfs":
+			return cowKindSnapshot, nil
+		default:
+			// memory / build_rootfs / unknown -> volume (matches rollback path)
+			return cowKindVolume, nil
+		}
+	}
+	return normalizeCowKind(kind)
 }

--- a/Cubelet/storage/cubecow_volume_manager.go
+++ b/Cubelet/storage/cubecow_volume_manager.go
@@ -376,6 +376,19 @@ func (m *CowVolumeManager) DeleteByKind(ctx context.Context, name, kind string) 
 	if err = deleteFn(name); err == nil || isCowSemantic(err, cubecow.SemNotFound) {
 		return nil
 	}
+	// FIX-3: the recorded kind may not match the object's real cubecow type
+	// (e.g. an incremental memory snapshot recorded/derived as a volume).
+	// cubecow returns SemInvalidArgument ("is a snapshot; use delete_snapshot")
+	// in that case. Retry with the opposite delete function so cleanup stays
+	// kind-agnostic and idempotent rather than leaking the object.
+	if isCowSemantic(err, cubecow.SemInvalidArgument) {
+		if otherFn := m.oppositeDeleteFunc(kind); otherFn != nil {
+			if retryErr := otherFn(name); retryErr == nil || isCowSemantic(retryErr, cubecow.SemNotFound) {
+				return nil
+			}
+		}
+		return err
+	}
 	if isCowSemantic(err, cubecow.SemIoError) {
 		if retryErr := deleteFn(name); retryErr == nil || isCowSemantic(retryErr, cubecow.SemNotFound) {
 			return nil
@@ -449,6 +462,20 @@ func (m *CowVolumeManager) deleteFunc(kind string) (func(string) error, error) {
 		return m.engine.DeleteSnapshot, nil
 	default:
 		return nil, fmt.Errorf("unsupported cubecow kind %q", kind)
+	}
+}
+
+// oppositeDeleteFunc returns the delete function for the other cubecow kind, so
+// DeleteByKind can recover when the recorded kind does not match the object's
+// real type. Returns nil for an unrecognized kind.
+func (m *CowVolumeManager) oppositeDeleteFunc(kind string) func(string) error {
+	switch kind {
+	case cowKindVolume:
+		return m.engine.DeleteSnapshot
+	case cowKindSnapshot:
+		return m.engine.DeleteVolume
+	default:
+		return nil
 	}
 }
 


### PR DESCRIPTION
## Summary

Fix resource leaks after template deletion: node `cubebox_os_image`, CubeMaster local ext4 artifacts, cubecow snapshot/memory files, and AgentHub backing resources.

- **CubeMaster**: artifact node placement table + last-owner three-phase cleanup + periodic GC
- **Cubelet**: synchronous ext4 artifact deletion; cubecow kind robustness; catalog-miss path fallback
- **CubeAPI**: AgentHub cascade delete for snapshots/OpenClaw dirs; best-effort reverse sync on infrastructure `DELETE /templates`

## Problem

After template deletion, physical cleanup of shared rootfs artifacts (fingerprint dedup) relied on `t_cube_template_replica` to enumerate nodes. Deleting a template removes its replica rows, so **the last deleter cannot tell which nodes still hold ext4 files**, leaking `cubebox_os_image`. Also: `gc_deadline` was written but never consumed by GC, cubecow kind mismatches aborted cleanup chains, and AgentHub only soft-deleted MySQL rows without cascading physical resources.

## Solution

Core invariants: idempotent deletes, physical-before-metadata, physical cleanup only when references hit zero, lock-held decisions / lock-free RPC, failures leave `CLEANUP_PENDING` for GC retry.

### Target architecture (after fix)

```mermaid
flowchart TB
    subgraph API["CubeAPI"]
        A1["DELETE /templates/:id"]
        A2["DELETE /agenthub/templates/:id"]
    end

    subgraph Master["CubeMaster"]
        M1["definition / replica / job"]
        M2["rootfs_artifact"]
        M3["local ext4"]
        M4["placement table<br/>new in this PR"]
        M5["cleanupArtifactFully<br/>+ periodic GC"]
    end

    subgraph Node["Cubelet"]
        N1["cubebox_os_image"]
        N2["cube-snapshot + catalog"]
        N3["cubecow volumes"]
    end

    A1 -->|cascade DELETE /cube/template| M5
    A2 -->|cascade snapshot / OpenClaw| M5
    M5 --> M4
    M5 -->|DestroyImage ext4| N1
    M5 -->|CleanupTemplate| N2
    M5 -->|CleanupTemplate| N3
    M4 -->|enumerate nodes that held artifact| N1
```

### Online delete + GC fallback

```mermaid
flowchart TB
    subgraph DeletePath["Online delete"]
        D1["DELETE /cube/template"] --> D2["cleanupArtifactFully"]
        D2 --> D3["Phase1: TX lock + drop refs + placement snapshot"]
        D3 --> D4["Phase2: DestroyImage + local ext4 delete"]
        D4 --> D5["Phase3: re-check refs + delete placement/artifact"]
    end

    subgraph GCPath["Periodic GC"]
        G1["startArtifactGC<br/>GET_LOCK single instance"] --> G2["CLEANUP_PENDING / FAILED / expired READY"]
        G2 --> G3["cleanupArtifactFully"]
    end

    subgraph Placement["t_cube_artifact_node_placement"]
        P1["distribute success → upsert"]
        P2["delete/GC → enumerate nodes"]
        P3["artifact removed → clear placement"]
    end

    D3 --> Placement
    D4 --> Placement
    G3 --> Placement
```

### Artifact three-phase cleanup (last-owner)

```mermaid
sequenceDiagram
    participant Caller as Delete caller
    participant TX1 as Phase1 short TX
    participant DB as MySQL
    participant Phys as Phase2 physical delete
    participant Node as Cubelet
    participant TX2 as Phase3 short TX

    Caller->>TX1: cleanupArtifactFully
    TX1->>DB: FOR UPDATE + drop refs + countReferences
    alt references remain
        TX1-->>Caller: skip physical delete
    else references zero
        TX1->>DB: read placement, mark CLEANUP_PENDING
    end
    TX1-->>Phys: release lock
    Phys->>Node: DestroyImage(storage_media=ext4)
    Phys->>Phys: cleanupLocalRootfsArtifact
    alt physical delete fails
        Phys-->>Caller: keep CLEANUP_PENDING, GC retries
    else all succeed
        Phys->>TX2: re-check refs with same exclude
        TX2->>DB: DELETE placement + artifact
    end
```

### Node ext4 delete

```mermaid
flowchart LR
    RPC["DestroyImage RPC"] --> Branch{"storage_media == ext4?"}
    Branch -->|no| Containerd["containerd async delete"]
    Branch -->|yes| Ext4["DestroyPmemArtifact"]
    Ext4 --> Check["running sandbox check"]
    Check --> Remove["RemoveAll cubebox_os_image/{id}/"]
```

### AgentHub cascade delete

```mermaid
flowchart TD
    A["DELETE /agenthub/templates/:id"] --> B{"market template?"}
    B -->|yes| C["soft-delete AgentHub row only"]
    B -->|no| D{"other templates still reference snapshot?"}
    D -->|yes| E["skip physical delete"]
    D -->|no| F{"snapshot_kind"}
    F -->|agenthub_state| G["remove OpenClaw dir"]
    F -->|sandbox etc.| H["delete CubeMaster snapshot"]
    G --> I["soft_delete_snapshot + template"]
    H --> I
    C --> J["204"]
    E --> J
    I --> J
```

After infrastructure `DELETE /templates/:id` succeeds, best-effort soft-delete AgentHub rows matching `template_id` or `source_snapshot_id` (failures are logged only; they do not block the primary delete).

## Changes

| Component | Highlights |
| --- | --- |
| **CubeMaster** | three-phase `cleanupArtifactFully`; placement CRUD; `startArtifactGC`; write placement on distribute; `DestroyImage` sets `storage_media` |
| **Migration** | `20260623145000_artifact_node_placement.sql` (new table + backfill from replica; legacy rows with only `node_ip` use synthetic key `ip:<node_ip>`) |
| **Cubelet** | `ext4image.DestroyPmemArtifact`; `DeleteByKind` opposite-kind retry; aggregated template cleanup errors |
| **CubeAPI** | AgentHub cascade (market templates do not cascade `tpl-*`); OpenClaw path safety; shared-snapshot guard |

~26 files, +1175 / -234 lines.

## Migration & Rollout

- **needs-migration**: run `20260623145000_artifact_node_placement.sql`
- **upgrade order**: Cubelet first, then CubeMaster (old nodes ignore `storage_media=ext4` safely; full rollout + GC converges leftovers)

## Out of Scope

- **Sandbox rollback old rootfs cleanup**: if deleting `sb-*-rootfs-gen*` fails after `RollbackSandbox`, only `cleanup deferred` is recorded with no retry queue; needs a follow-up node reconcile
- **runtemplate bolt deregistration**: ext4 delete bypasses bolt via running-sandbox check only; bolt index cleanup deferred
- **CubeAPI AgentHub IDOR / ownership auth**: cascade delete amplifies existing authorization gaps; known legacy risk, separate PR planned
- **pre-upgrade disk orphans without DB metadata**: existing `cubebox_os_image/rfs-*` with no DB row cannot be located by this PR; needs reconcile or manual cleanup

## Test Plan

- [x] `go test ./pkg/base/dao/migrate/`, `go test ./pkg/templatecenter/`
- [x] CubeMaster / Cubelet `go build ./...`; CubeAPI `cargo check`
- [x] Staging E2E: create-from-image → delete template; DB, Master local ext4, node `cubebox_os_image`, and cubecow all cleaned up

**Reviewer regression (verified on staging):**

- [x] Two templates share one fingerprint artifact: deleting one does not affect the other; last deleter cleans all placement nodes  
  - Staging: two templates created with identical `create-from-image` params shared one artifact; after deleting A, B stayed `READY` with artifact/placement intact and sandboxes could still be created from B; after deleting B, artifact/placement/replica/definition were all gone and Master local ext4 removed
- [x] Delete while sandbox is running → Conflict; `CLEANUP_PENDING` + GC convergence  
  - Staging: `tpl delete` while sandbox running returned `template is still in use`; template and artifact were not touched  
  - GC: simulated unreferenced `CLEANUP_PENDING` artifact; after CubeMaster restart, GC cleared DB rows, placement, and Master local ext4 (log: `artifact gc: evaluating 1 candidate artifacts`)  
  - Note: natural E2E producing `CLEANUP_PENDING` (node `DestroyImage` Conflict) was not reliably reproduced on a fast single-node staging host
- [x] AgentHub: market does not cascade `tpl-*`; `snapshots.delete` NotFound is idempotent  
  - Staging: market template delete returned 204; AgentHub row soft-deleted; underlying `tpl-*` remained `READY` in CubeMaster  
  - Staging: non-market cascade delete still returned 204 when CubeMaster snapshot was already removed (NotFound treated as success)
- [x] Reverse `DELETE /templates` best-effort soft-deletes AgentHub rows  
  - Case A: after `DELETE /cubeapi/v1/templates/{tpl}`, market rows (`template_id=tpl`) and rows with `source_snapshot_id=tpl` were soft-deleted; primary delete returned 204  
  - Case B: after `DELETE /cubeapi/v1/templates/{snap}`, rows with `source_snapshot_id=snap` were soft-deleted

Made with [Cursor](https://cursor.com)