### PR TITLE
feat(CubeMaster): add node label management API

### DIFF
--- a/CubeMaster/pkg/base/config/config.go
+++ b/CubeMaster/pkg/base/config/config.go
@@ -206,6 +206,33 @@ var defaultNodeAffinitySelectorAllowedKeys = []string{
 	constants.AffinityKeyInstanceType,
 }
 
+// reservedLabelNamespaces defines label key prefixes that are owned by the
+// system. Labels whose namespace (the part before '/') matches any entry, or
+// whose whole key (when no '/' is present) matches any entry, are reserved and
+// cannot be created or deleted via the admin API.
+var reservedLabelNamespaces = []string{
+	"kubernetes.io",
+	"beta.kubernetes.io",
+	"cube.cloud.tencentcloud.com",
+}
+
+// IsReservedLabelKey reports whether k is a system-reserved label key
+// that cannot be created or deleted via the admin API.
+// It checks the namespace prefix of the key (the part before '/'),
+// or the whole key if no '/' is present.
+func IsReservedLabelKey(k string) bool {
+	ns := k
+	if prefix, _, ok := strings.Cut(k, "/"); ok {
+		ns = prefix
+	}
+	for _, reserved := range reservedLabelNamespaces {
+		if ns == reserved || strings.HasSuffix(ns, "."+reserved) {
+			return true
+		}
+	}
+	return false
+}
+
 // OvercommitRatioConf describes the CPU/Mem overcommit multipliers applied to
 // a node's reported quota when computing schedulable capacity.
 type OvercommitRatioConf struct {

--- a/CubeMaster/pkg/nodemeta/service.go
+++ b/CubeMaster/pkg/nodemeta/service.go
@@ -224,17 +224,25 @@ func RegisterNode(ctx context.Context, req *RegisterNodeRequest) (*NodeSnapshot,
 	}
 
 	// Read existing labels from DB, merge cubelet labels (cubelet wins on conflict),
-	// then write back the merged result.
-	existing, err := global.readLabelsJSON(req.NodeID)
-	if err != nil {
-		return nil, err
-	}
-	for k, v := range req.Labels {
-		existing[k] = v
-	}
-	if err := global.db.Table(constants.NodeMetaRegistrationTable).
-		Where("node_id = ?", req.NodeID).
-		Update("labels_json", mustJSON(existing)).Error; err != nil {
+	// then write back the merged result. Use SELECT ... FOR UPDATE inside a
+	// transaction to prevent concurrent admin label writes from being lost.
+	var mergedLabels map[string]string
+	if err := global.db.Transaction(func(tx *gorm.DB) error {
+		existing, err := readLabelsJSONForUpdate(tx, req.NodeID)
+		if err != nil {
+			return err
+		}
+		for k, v := range req.Labels {
+			existing[k] = v
+		}
+		if err := tx.Table(constants.NodeMetaRegistrationTable).
+			Where("node_id = ?", req.NodeID).
+			Update("labels_json", mustJSON(existing)).Error; err != nil {
+			return err
+		}
+		mergedLabels = existing
+		return nil
+	}); err != nil {
 		return nil, err
 	}
 
@@ -243,7 +251,7 @@ func RegisterNode(ctx context.Context, req *RegisterNodeRequest) (*NodeSnapshot,
 	snap.NodeID = req.NodeID
 	snap.HostIP = req.HostIP
 	snap.GRPCPort = req.GRPCPort
-	snap.Labels = cloneStringMap(existing)
+	snap.Labels = cloneStringMap(mergedLabels)
 	snap.Capacity = req.Capacity
 	snap.Allocatable = req.Allocatable
 	snap.InstanceType = req.InstanceType
@@ -625,24 +633,10 @@ func readLabelsJSONForUpdate(tx *gorm.DB, nodeID string) (map[string]string, err
 		return nil, err
 	}
 	m := map[string]string{}
-	_ = json.Unmarshal([]byte(raw), &m)
-	return m, nil
-}
-
-// readLabelsJSON reads the labels_json column for a node and returns it as a map.
-// Returns an empty map (not nil) if the column is empty. Returns an error if the
-// DB read itself fails, so callers never accidentally persist an empty map on
-// transient failures.
-func (s *service) readLabelsJSON(nodeID string) (map[string]string, error) {
-	var raw string
-	if err := s.db.Table(constants.NodeMetaRegistrationTable).
-		Select("labels_json").
-		Where("node_id = ?", nodeID).
-		Scan(&raw).Error; err != nil {
+	err := json.Unmarshal([]byte(raw), &m)
+	if err != nil {
 		return nil, err
 	}
-	m := map[string]string{}
-	_ = json.Unmarshal([]byte(raw), &m)
 	return m, nil
 }
 
@@ -722,8 +716,7 @@ func isQualifiedLabelKey(key string) []string {
 		errs = append(errs, "name part must not be empty")
 	} else if len(name) > qualifiedNameMaxLength {
 		errs = append(errs, fmt.Sprintf("name part must be no more than %d characters", qualifiedNameMaxLength))
-	}
-	if !qualifiedNameRegexp.MatchString(name) {
+	} else if !qualifiedNameRegexp.MatchString(name) {
 		errs = append(errs, "name part "+qualifiedNameErrMsg)
 	}
 

--- a/CubeMaster/pkg/nodemeta/service.go
+++ b/CubeMaster/pkg/nodemeta/service.go
@@ -625,15 +625,14 @@ func DeleteNodeLabel(ctx context.Context, nodeID, key string) error {
 // (SELECT ... FOR UPDATE) inside an ongoing transaction, preventing concurrent
 // read-modify-write races on the same node's labels.
 func readLabelsJSONForUpdate(tx *gorm.DB, nodeID string) (map[string]string, error) {
-	var raw string
-	if err := tx.Raw(
-		"SELECT labels_json FROM "+constants.NodeMetaRegistrationTable+" WHERE node_id = ? FOR UPDATE",
-		nodeID,
-	).Scan(&raw).Error; err != nil {
+	var reg models.NodeRegistration
+	if err := tx.Table(constants.NodeMetaRegistrationTable).
+		Where("node_id = ?", nodeID).
+		Take(&reg).Error; err != nil {
 		return nil, err
 	}
 	m := map[string]string{}
-	err := json.Unmarshal([]byte(raw), &m)
+	err := json.Unmarshal([]byte(reg.LabelsJSON), &m)
 	if err != nil {
 		return nil, err
 	}

--- a/CubeMaster/pkg/nodemeta/service.go
+++ b/CubeMaster/pkg/nodemeta/service.go
@@ -212,28 +212,30 @@ func RegisterNode(ctx context.Context, req *RegisterNodeRequest) (*NodeSnapshot,
 		CreateConcurrentNum: req.CreateConcurrentNum,
 		MaxMvmNum:           req.MaxMvmNum,
 	}
-	if err := global.db.Clauses(clause.OnConflict{
-		Columns: []clause.Column{{Name: "node_id"}},
-		DoUpdates: clause.AssignmentColumns([]string{
-			"host_ip", "grpc_port", "capacity_json", "allocatable_json",
-			"instance_type", "cluster_label", "quota_cpu", "quota_mem_mb",
-			"create_concurrent_num", "max_mvm_num", "updated_at",
-		}),
-	}).Create(reg).Error; err != nil {
-		return nil, err
-	}
-
 	// Read existing labels from DB, merge cubelet labels (cubelet wins on conflict),
 	// then write back the merged result. Use SELECT ... FOR UPDATE inside a
 	// transaction to prevent concurrent admin label writes from being lost.
 	var mergedLabels map[string]string
 	if err := global.db.Transaction(func(tx *gorm.DB) error {
+		if err := tx.Clauses(clause.OnConflict{
+			Columns: []clause.Column{{Name: "node_id"}},
+			DoUpdates: clause.AssignmentColumns([]string{
+				"host_ip", "grpc_port", "capacity_json", "allocatable_json",
+				"instance_type", "cluster_label", "quota_cpu", "quota_mem_mb",
+				"create_concurrent_num", "max_mvm_num", "updated_at",
+			}),
+		}).Create(reg).Error; err != nil {
+			return err
+		}
 		existing, err := readLabelsJSONForUpdate(tx, req.NodeID)
 		if err != nil {
 			return err
 		}
 		for k, v := range req.Labels {
 			existing[k] = v
+		}
+		if len(existing) > maxLabelsPerNode {
+			return fmt.Errorf("a node cannot have more than %d labels, got %d after merge", maxLabelsPerNode, len(existing))
 		}
 		if err := tx.Table(constants.NodeMetaRegistrationTable).
 			Where("node_id = ?", req.NodeID).
@@ -597,11 +599,8 @@ func DeleteNodeLabel(ctx context.Context, nodeID, key string) error {
 	if nodeID == "" {
 		return fmt.Errorf("node_id is required")
 	}
-	if key == "" {
-		return fmt.Errorf("label key is required")
-	}
-	if config.IsReservedLabelKey(key) {
-		return fmt.Errorf("label key %q is reserved for system use and cannot be deleted", key)
+	if err := validateNodeLabelKey(key); err != nil {
+		return err
 	}
 	var nodeLabels map[string]string
 	if err := global.db.Transaction(func(tx *gorm.DB) error {
@@ -642,10 +641,19 @@ func readLabelsJSONForUpdate(tx *gorm.DB, nodeID string) (map[string]string, err
 		Take(&reg).Error; err != nil {
 		return nil, err
 	}
+	return parseLabelsJSON(reg.LabelsJSON)
+}
+
+func parseLabelsJSON(raw string) (map[string]string, error) {
+	if strings.TrimSpace(raw) == "" {
+		return map[string]string{}, nil
+	}
 	m := map[string]string{}
-	err := json.Unmarshal([]byte(reg.LabelsJSON), &m)
-	if err != nil {
+	if err := json.Unmarshal([]byte(raw), &m); err != nil {
 		return nil, err
+	}
+	if m == nil {
+		return map[string]string{}, nil
 	}
 	return m, nil
 }
@@ -683,15 +691,22 @@ var (
 
 func validateNodeLabels(labels map[string]string) error {
 	if len(labels) > maxLabelsPerNode {
-		return fmt.Errorf("a node cannot have more than %d labels, got %d", maxLabelsPerNode, len(labels))
+		return fmt.Errorf("label update request cannot contain more than %d labels, got %d", maxLabelsPerNode, len(labels))
 	}
 	for k, v := range labels {
-		if errs := isQualifiedLabelKey(k); len(errs) != 0 {
-			return fmt.Errorf("label key %q is invalid: %s", k, strings.Join(errs, ", "))
+		if err := validateNodeLabelKey(k); err != nil {
+			return err
 		}
 		if errs := isValidLabelValue(v); len(errs) != 0 {
 			return fmt.Errorf("label value for key %q is invalid: %s", k, strings.Join(errs, ", "))
 		}
+	}
+	return nil
+}
+
+func validateNodeLabelKey(key string) error {
+	if errs := isQualifiedLabelKey(key); len(errs) != 0 {
+		return fmt.Errorf("label key %q is invalid: %s", key, strings.Join(errs, ", "))
 	}
 	return nil
 }

--- a/CubeMaster/pkg/nodemeta/service.go
+++ b/CubeMaster/pkg/nodemeta/service.go
@@ -559,14 +559,17 @@ func UpdateNodeLabels(ctx context.Context, nodeID string, labels map[string]stri
 	if err := validateNodeLabels(labels); err != nil {
 		return err
 	}
-
-	return global.db.Transaction(func(tx *gorm.DB) error {
+	var nodeLabels map[string]string
+	if err := global.db.Transaction(func(tx *gorm.DB) error {
 		existing, err := readLabelsJSONForUpdate(tx, nodeID)
 		if err != nil {
 			return err
 		}
 		for k, v := range labels {
 			existing[k] = v
+		}
+		if len(existing) > maxLabelsPerNode {
+			return fmt.Errorf("a node cannot have more than %d labels, got %d after merge", maxLabelsPerNode, len(existing))
 		}
 		if err := tx.Table(constants.NodeMetaRegistrationTable).
 			Where("node_id = ?", nodeID).
@@ -576,14 +579,18 @@ func UpdateNodeLabels(ctx context.Context, nodeID string, labels map[string]stri
 			}).Error; err != nil {
 			return err
 		}
-
-		snap := global.ensureNode(nodeID)
-		global.mu.Lock()
-		snap.Labels = cloneStringMap(existing)
-		global.mu.Unlock()
-		syncLocalcache(snap)
+		nodeLabels = existing
 		return nil
-	})
+	}); err != nil {
+		return err
+	}
+
+	snap := global.ensureNode(nodeID)
+	global.mu.Lock()
+	snap.Labels = cloneStringMap(nodeLabels)
+	global.mu.Unlock()
+	syncLocalcache(snap)
+	return nil
 }
 
 func DeleteNodeLabel(ctx context.Context, nodeID, key string) error {
@@ -596,8 +603,8 @@ func DeleteNodeLabel(ctx context.Context, nodeID, key string) error {
 	if config.IsReservedLabelKey(key) {
 		return fmt.Errorf("label key %q is reserved for system use and cannot be deleted", key)
 	}
-
-	return global.db.Transaction(func(tx *gorm.DB) error {
+	var nodeLabels map[string]string
+	if err := global.db.Transaction(func(tx *gorm.DB) error {
 		existing, err := readLabelsJSONForUpdate(tx, nodeID)
 		if err != nil {
 			return err
@@ -611,14 +618,17 @@ func DeleteNodeLabel(ctx context.Context, nodeID, key string) error {
 			}).Error; err != nil {
 			return err
 		}
-
-		snap := global.ensureNode(nodeID)
-		global.mu.Lock()
-		snap.Labels = cloneStringMap(existing)
-		global.mu.Unlock()
-		syncLocalcache(snap)
+		nodeLabels = existing
 		return nil
-	})
+	}); err != nil {
+		return err
+	}
+	snap := global.ensureNode(nodeID)
+	global.mu.Lock()
+	snap.Labels = cloneStringMap(nodeLabels)
+	global.mu.Unlock()
+	syncLocalcache(snap)
+	return nil
 }
 
 // readLabelsJSONForUpdate reads the labels_json column with a row-level lock
@@ -626,7 +636,8 @@ func DeleteNodeLabel(ctx context.Context, nodeID, key string) error {
 // read-modify-write races on the same node's labels.
 func readLabelsJSONForUpdate(tx *gorm.DB, nodeID string) (map[string]string, error) {
 	var reg models.NodeRegistration
-	if err := tx.Table(constants.NodeMetaRegistrationTable).
+	if err := tx.Clauses(clause.Locking{Strength: "UPDATE"}).
+		Table(constants.NodeMetaRegistrationTable).
 		Where("node_id = ?", nodeID).
 		Take(&reg).Error; err != nil {
 		return nil, err
@@ -661,6 +672,8 @@ const (
 	dns1123SubdomainFmt = `[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*`
 
 	dns1123SubdomainErrMsg = `a DNS-1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character`
+
+	maxLabelsPerNode = 64
 )
 
 var (
@@ -669,6 +682,9 @@ var (
 )
 
 func validateNodeLabels(labels map[string]string) error {
+	if len(labels) > maxLabelsPerNode {
+		return fmt.Errorf("a node cannot have more than %d labels, got %d", maxLabelsPerNode, len(labels))
+	}
 	for k, v := range labels {
 		if errs := isQualifiedLabelKey(k); len(errs) != 0 {
 			return fmt.Errorf("label key %q is invalid: %s", k, strings.Join(errs, ", "))

--- a/CubeMaster/pkg/nodemeta/service.go
+++ b/CubeMaster/pkg/nodemeta/service.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"hash/fnv"
+	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -202,7 +203,6 @@ func RegisterNode(ctx context.Context, req *RegisterNodeRequest) (*NodeSnapshot,
 		NodeID:              req.NodeID,
 		HostIP:              req.HostIP,
 		GRPCPort:            req.GRPCPort,
-		LabelsJSON:          mustJSON(req.Labels),
 		CapacityJSON:        mustJSON(req.Capacity),
 		AllocatableJSON:     mustJSON(req.Allocatable),
 		InstanceType:        req.InstanceType,
@@ -215,11 +215,23 @@ func RegisterNode(ctx context.Context, req *RegisterNodeRequest) (*NodeSnapshot,
 	if err := global.db.Clauses(clause.OnConflict{
 		Columns: []clause.Column{{Name: "node_id"}},
 		DoUpdates: clause.AssignmentColumns([]string{
-			"host_ip", "grpc_port", "labels_json", "capacity_json", "allocatable_json",
+			"host_ip", "grpc_port", "capacity_json", "allocatable_json",
 			"instance_type", "cluster_label", "quota_cpu", "quota_mem_mb",
 			"create_concurrent_num", "max_mvm_num", "updated_at",
 		}),
 	}).Create(reg).Error; err != nil {
+		return nil, err
+	}
+
+	// Read existing labels from DB, merge cubelet labels (cubelet wins on conflict),
+	// then write back the merged result.
+	existing := global.readLabelsJSON(req.NodeID)
+	for k, v := range req.Labels {
+		existing[k] = v
+	}
+	if err := global.db.Table(constants.NodeMetaRegistrationTable).
+		Where("node_id = ?", req.NodeID).
+		Update("labels_json", mustJSON(existing)).Error; err != nil {
 		return nil, err
 	}
 
@@ -228,7 +240,7 @@ func RegisterNode(ctx context.Context, req *RegisterNodeRequest) (*NodeSnapshot,
 	snap.NodeID = req.NodeID
 	snap.HostIP = req.HostIP
 	snap.GRPCPort = req.GRPCPort
-	snap.Labels = cloneStringMap(req.Labels)
+	snap.Labels = cloneStringMap(existing)
 	snap.Capacity = req.Capacity
 	snap.Allocatable = req.Allocatable
 	snap.InstanceType = req.InstanceType
@@ -523,6 +535,184 @@ func ListSchedulerNodes(ctx context.Context) ([]*node.Node, error) {
 		out = append(out, toSchedulerNode(snap))
 	}
 	return out, nil
+}
+
+type UpdateNodeLabelsRequest struct {
+	Labels map[string]string `json:"labels"`
+}
+
+func UpdateNodeLabels(ctx context.Context, nodeID string, labels map[string]string) error {
+	if nodeID == "" {
+		return fmt.Errorf("node_id is required")
+	}
+	if err := validateNodeLabels(labels); err != nil {
+		return err
+	}
+
+	existing := global.readLabelsJSON(nodeID)
+	for k, v := range labels {
+		existing[k] = v
+	}
+	if err := global.db.Table(constants.NodeMetaRegistrationTable).
+		Where("node_id = ?", nodeID).
+		Updates(map[string]interface{}{
+			"labels_json": mustJSON(existing),
+			"updated_at":  time.Now(),
+		}).Error; err != nil {
+		return err
+	}
+
+	snap := global.ensureNode(nodeID)
+	global.mu.Lock()
+	snap.Labels = cloneStringMap(existing)
+	global.mu.Unlock()
+	syncLocalcache(snap)
+	return nil
+}
+
+func DeleteNodeLabel(ctx context.Context, nodeID, key string) error {
+	if nodeID == "" {
+		return fmt.Errorf("node_id is required")
+	}
+	if key == "" {
+		return fmt.Errorf("label key is required")
+	}
+	if config.IsReservedLabelKey(key) {
+		return fmt.Errorf("label key %q is reserved for system use and cannot be deleted", key)
+	}
+
+	existing := global.readLabelsJSON(nodeID)
+	delete(existing, key)
+	if err := global.db.Table(constants.NodeMetaRegistrationTable).
+		Where("node_id = ?", nodeID).
+		Updates(map[string]interface{}{
+			"labels_json": mustJSON(existing),
+			"updated_at":  time.Now(),
+		}).Error; err != nil {
+		return err
+	}
+
+	snap := global.ensureNode(nodeID)
+	global.mu.Lock()
+	snap.Labels = existing
+	global.mu.Unlock()
+	syncLocalcache(snap)
+	return nil
+}
+
+// readLabelsJSON reads the labels_json column for a node and returns it as a map.
+// Returns an empty map (not nil) if the row is missing or the column is empty.
+func (s *service) readLabelsJSON(nodeID string) map[string]string {
+	var raw string
+	if err := s.db.Table(constants.NodeMetaRegistrationTable).
+		Select("labels_json").
+		Where("node_id = ?", nodeID).
+		Scan(&raw).Error; err != nil {
+		return map[string]string{}
+	}
+	m := map[string]string{}
+	_ = json.Unmarshal([]byte(raw), &m)
+	return m
+}
+
+// Label validation follows Kubernetes conventions.
+// See: k8s.io/apimachinery/pkg/util/validation, k8s.io/apimachinery/pkg/api/validate/content
+//
+// Key format:   [prefix/]name
+//   - prefix: optional, DNS1123 subdomain (lowercase alphanumeric, '-' or '.', max 253)
+//   - name:   required, qualified name (alphanumeric, '-' '_' or '.', max 63, must start/end with alphanumeric)
+//
+// Value format: empty string or qualified name (same constraints as name, max 63)
+
+const (
+	qualifiedNameMaxLength    = 63
+	dns1123SubdomainMaxLength = 253
+
+	// Matches a qualified name: alphanumeric, '-', '_', '.', must start and end with alphanumeric.
+	qualifiedNameFmt = `([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]`
+
+	qualifiedNameErrMsg = `a qualified name must consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character`
+
+	// Matches a DNS1123 subdomain: lowercase alphanumeric, '-' or '.', segments separated by '.'.
+	dns1123SubdomainFmt = `[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*`
+
+	dns1123SubdomainErrMsg = `a DNS-1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character`
+)
+
+var (
+	qualifiedNameRegexp    = regexp.MustCompile(`^` + qualifiedNameFmt + `$`)
+	dns1123SubdomainRegexp = regexp.MustCompile(`^` + dns1123SubdomainFmt + `$`)
+)
+
+func validateNodeLabels(labels map[string]string) error {
+	for k, v := range labels {
+		if errs := isQualifiedLabelKey(k); len(errs) != 0 {
+			return fmt.Errorf("label key %q is invalid: %s", k, strings.Join(errs, ", "))
+		}
+		if errs := isValidLabelValue(v); len(errs) != 0 {
+			return fmt.Errorf("label value for key %q is invalid: %s", k, strings.Join(errs, ", "))
+		}
+	}
+	return nil
+}
+
+// isQualifiedLabelKey validates a label key, matching K8s IsQualifiedName logic.
+// Returns a list of error strings if invalid, empty list if valid.
+func isQualifiedLabelKey(key string) []string {
+	var errs []string
+
+	if key == "" {
+		return append(errs, "must not be empty")
+	}
+	if config.IsReservedLabelKey(key) {
+		return append(errs, "is reserved for system use")
+	}
+
+	parts := strings.Split(key, "/")
+	var name string
+	switch len(parts) {
+	case 1:
+		name = parts[0]
+	case 2:
+		prefix := parts[0]
+		name = parts[1]
+		if prefix == "" {
+			errs = append(errs, "prefix part must not be empty")
+		} else if len(prefix) > dns1123SubdomainMaxLength {
+			errs = append(errs, fmt.Sprintf("prefix part must be no more than %d characters", dns1123SubdomainMaxLength))
+		} else if !dns1123SubdomainRegexp.MatchString(prefix) {
+			errs = append(errs, "prefix part "+dns1123SubdomainErrMsg)
+		}
+	default:
+		return append(errs, "must be in the form prefix/name or name (e.g. 'MyName' or 'example.com/MyName')")
+	}
+
+	if name == "" {
+		errs = append(errs, "name part must not be empty")
+	} else if len(name) > qualifiedNameMaxLength {
+		errs = append(errs, fmt.Sprintf("name part must be no more than %d characters", qualifiedNameMaxLength))
+	}
+	if !qualifiedNameRegexp.MatchString(name) {
+		errs = append(errs, "name part "+qualifiedNameErrMsg)
+	}
+
+	return errs
+}
+
+// isValidLabelValue validates a label value, matching K8s IsValidLabelValue logic.
+// Returns a list of error strings if invalid, empty list if valid.
+func isValidLabelValue(value string) []string {
+	var errs []string
+	if value == "" {
+		return errs
+	}
+	if len(value) > qualifiedNameMaxLength {
+		errs = append(errs, fmt.Sprintf("must be no more than %d characters", qualifiedNameMaxLength))
+	}
+	if !qualifiedNameRegexp.MatchString(value) {
+		errs = append(errs, qualifiedNameErrMsg)
+	}
+	return errs
 }
 
 func (s *service) ensureNode(nodeID string) *NodeSnapshot {

--- a/CubeMaster/pkg/nodemeta/service.go
+++ b/CubeMaster/pkg/nodemeta/service.go
@@ -225,7 +225,10 @@ func RegisterNode(ctx context.Context, req *RegisterNodeRequest) (*NodeSnapshot,
 
 	// Read existing labels from DB, merge cubelet labels (cubelet wins on conflict),
 	// then write back the merged result.
-	existing := global.readLabelsJSON(req.NodeID)
+	existing, err := global.readLabelsJSON(req.NodeID)
+	if err != nil {
+		return nil, err
+	}
 	for k, v := range req.Labels {
 		existing[k] = v
 	}
@@ -549,25 +552,30 @@ func UpdateNodeLabels(ctx context.Context, nodeID string, labels map[string]stri
 		return err
 	}
 
-	existing := global.readLabelsJSON(nodeID)
-	for k, v := range labels {
-		existing[k] = v
-	}
-	if err := global.db.Table(constants.NodeMetaRegistrationTable).
-		Where("node_id = ?", nodeID).
-		Updates(map[string]interface{}{
-			"labels_json": mustJSON(existing),
-			"updated_at":  time.Now(),
-		}).Error; err != nil {
-		return err
-	}
+	return global.db.Transaction(func(tx *gorm.DB) error {
+		existing, err := readLabelsJSONForUpdate(tx, nodeID)
+		if err != nil {
+			return err
+		}
+		for k, v := range labels {
+			existing[k] = v
+		}
+		if err := tx.Table(constants.NodeMetaRegistrationTable).
+			Where("node_id = ?", nodeID).
+			Updates(map[string]interface{}{
+				"labels_json": mustJSON(existing),
+				"updated_at":  time.Now(),
+			}).Error; err != nil {
+			return err
+		}
 
-	snap := global.ensureNode(nodeID)
-	global.mu.Lock()
-	snap.Labels = cloneStringMap(existing)
-	global.mu.Unlock()
-	syncLocalcache(snap)
-	return nil
+		snap := global.ensureNode(nodeID)
+		global.mu.Lock()
+		snap.Labels = cloneStringMap(existing)
+		global.mu.Unlock()
+		syncLocalcache(snap)
+		return nil
+	})
 }
 
 func DeleteNodeLabel(ctx context.Context, nodeID, key string) error {
@@ -581,38 +589,61 @@ func DeleteNodeLabel(ctx context.Context, nodeID, key string) error {
 		return fmt.Errorf("label key %q is reserved for system use and cannot be deleted", key)
 	}
 
-	existing := global.readLabelsJSON(nodeID)
-	delete(existing, key)
-	if err := global.db.Table(constants.NodeMetaRegistrationTable).
-		Where("node_id = ?", nodeID).
-		Updates(map[string]interface{}{
-			"labels_json": mustJSON(existing),
-			"updated_at":  time.Now(),
-		}).Error; err != nil {
-		return err
-	}
+	return global.db.Transaction(func(tx *gorm.DB) error {
+		existing, err := readLabelsJSONForUpdate(tx, nodeID)
+		if err != nil {
+			return err
+		}
+		delete(existing, key)
+		if err := tx.Table(constants.NodeMetaRegistrationTable).
+			Where("node_id = ?", nodeID).
+			Updates(map[string]interface{}{
+				"labels_json": mustJSON(existing),
+				"updated_at":  time.Now(),
+			}).Error; err != nil {
+			return err
+		}
 
-	snap := global.ensureNode(nodeID)
-	global.mu.Lock()
-	snap.Labels = existing
-	global.mu.Unlock()
-	syncLocalcache(snap)
-	return nil
+		snap := global.ensureNode(nodeID)
+		global.mu.Lock()
+		snap.Labels = cloneStringMap(existing)
+		global.mu.Unlock()
+		syncLocalcache(snap)
+		return nil
+	})
+}
+
+// readLabelsJSONForUpdate reads the labels_json column with a row-level lock
+// (SELECT ... FOR UPDATE) inside an ongoing transaction, preventing concurrent
+// read-modify-write races on the same node's labels.
+func readLabelsJSONForUpdate(tx *gorm.DB, nodeID string) (map[string]string, error) {
+	var raw string
+	if err := tx.Raw(
+		"SELECT labels_json FROM "+constants.NodeMetaRegistrationTable+" WHERE node_id = ? FOR UPDATE",
+		nodeID,
+	).Scan(&raw).Error; err != nil {
+		return nil, err
+	}
+	m := map[string]string{}
+	_ = json.Unmarshal([]byte(raw), &m)
+	return m, nil
 }
 
 // readLabelsJSON reads the labels_json column for a node and returns it as a map.
-// Returns an empty map (not nil) if the row is missing or the column is empty.
-func (s *service) readLabelsJSON(nodeID string) map[string]string {
+// Returns an empty map (not nil) if the column is empty. Returns an error if the
+// DB read itself fails, so callers never accidentally persist an empty map on
+// transient failures.
+func (s *service) readLabelsJSON(nodeID string) (map[string]string, error) {
 	var raw string
 	if err := s.db.Table(constants.NodeMetaRegistrationTable).
 		Select("labels_json").
 		Where("node_id = ?", nodeID).
 		Scan(&raw).Error; err != nil {
-		return map[string]string{}
+		return nil, err
 	}
 	m := map[string]string{}
 	_ = json.Unmarshal([]byte(raw), &m)
-	return m
+	return m, nil
 }
 
 // Label validation follows Kubernetes conventions.

--- a/CubeMaster/pkg/nodemeta/service_labels_test.go
+++ b/CubeMaster/pkg/nodemeta/service_labels_test.go
@@ -158,7 +158,7 @@ func TestValidateNodeLabels(t *testing.T) {
 				}
 				return m
 			}(),
-			wantErr: "a node cannot have more than 64 labels",
+			wantErr: "label update request cannot contain more than 64 labels",
 		},
 	}
 
@@ -167,6 +167,108 @@ func TestValidateNodeLabels(t *testing.T) {
 			err := validateNodeLabels(tt.labels)
 			if tt.wantErr == "" {
 				assert.NoError(t, err)
+			} else {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestValidateNodeLabelKey(t *testing.T) {
+	tests := []struct {
+		name    string
+		key     string
+		wantErr string
+	}{
+		{
+			name:    "empty key rejected",
+			key:     "",
+			wantErr: "must not be empty",
+		},
+		{
+			name:    "too many slashes rejected",
+			key:     "a//b/c/",
+			wantErr: "must be in the form prefix/name or name",
+		},
+		{
+			name:    "slash only rejected",
+			key:     "//",
+			wantErr: "must be in the form prefix/name or name",
+		},
+		{
+			name:    "invalid character rejected",
+			key:     "name@bad",
+			wantErr: "qualified name must consist of",
+		},
+		{
+			name:    "reserved key rejected",
+			key:     "kubernetes.io/os",
+			wantErr: "is reserved for system use",
+		},
+		{
+			name: "simple key accepted",
+			key:  "env",
+		},
+		{
+			name: "prefixed key accepted",
+			key:  "example.com/env",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateNodeLabelKey(tt.key)
+			if tt.wantErr == "" {
+				assert.NoError(t, err)
+			} else {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestParseLabelsJSON(t *testing.T) {
+	tests := []struct {
+		name    string
+		raw     string
+		want    map[string]string
+		wantErr string
+	}{
+		{
+			name: "empty string becomes empty map",
+			raw:  "",
+			want: map[string]string{},
+		},
+		{
+			name: "whitespace becomes empty map",
+			raw:  "   \n\t",
+			want: map[string]string{},
+		},
+		{
+			name: "json null becomes empty map",
+			raw:  "null",
+			want: map[string]string{},
+		},
+		{
+			name: "valid labels",
+			raw:  `{"env":"prod","zone":"ap-guangzhou"}`,
+			want: map[string]string{"env": "prod", "zone": "ap-guangzhou"},
+		},
+		{
+			name:    "invalid json returns error",
+			raw:     "{",
+			wantErr: "unexpected end of JSON input",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseLabelsJSON(tt.raw)
+			if tt.wantErr == "" {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.want, got)
 			} else {
 				assert.Error(t, err)
 				assert.Contains(t, err.Error(), tt.wantErr)

--- a/CubeMaster/pkg/nodemeta/service_labels_test.go
+++ b/CubeMaster/pkg/nodemeta/service_labels_test.go
@@ -1,0 +1,204 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package nodemeta
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/config"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/constants"
+)
+
+func TestValidateNodeLabels(t *testing.T) {
+	tests := []struct {
+		name    string
+		labels  map[string]string
+		wantErr string
+	}{
+		{
+			name:   "empty map is valid",
+			labels: map[string]string{},
+		},
+		{
+			name:   "nil map is valid",
+			labels: nil,
+		},
+		{
+			name:    "empty key rejected",
+			labels:  map[string]string{"": "val"},
+			wantErr: "must not be empty",
+		},
+		// -- reserved namespace prefix tests --
+		{
+			name:    "kubernetes.io prefix reserved",
+			labels:  map[string]string{"kubernetes.io/os": "linux"},
+			wantErr: "is reserved for system use",
+		},
+		{
+			name:    "kubernetes.io hostname reserved",
+			labels:  map[string]string{"kubernetes.io/hostname": "node-1"},
+			wantErr: "is reserved for system use",
+		},
+		{
+			name:    "beta.kubernetes.io prefix reserved",
+			labels:  map[string]string{"beta.kubernetes.io/arch": "amd64"},
+			wantErr: "is reserved for system use",
+		},
+		{
+			name:    "subdomain of kubernetes.io reserved",
+			labels:  map[string]string{"topology.kubernetes.io/zone": "us-west"},
+			wantErr: "is reserved for system use",
+		},
+		{
+			name:    "subdomain of beta.kubernetes.io reserved",
+			labels:  map[string]string{"failure-domain.beta.kubernetes.io/zone": "us-west"},
+			wantErr: "is reserved for system use",
+		},
+		{
+			name:    "cube.cloud.tencentcloud.com prefix reserved",
+			labels:  map[string]string{"cube.cloud.tencentcloud.com/instance-type": "cubebox"},
+			wantErr: "is reserved for system use",
+		},
+		// -- previously-enumerated canonical keys still blocked --
+		{
+			name:    "AffinityKeyZone still reserved",
+			labels:  map[string]string{constants.AffinityKeyZone: "us-west"},
+			wantErr: "is reserved for system use",
+		},
+		{
+			name:    "AffinityKeyCPUType still reserved",
+			labels:  map[string]string{constants.AffinityKeyCPUType: "intel"},
+			wantErr: "is reserved for system use",
+		},
+		// -- valid keys --
+		{
+			name:   "simple non-reserved key accepted",
+			labels: map[string]string{"env": "production"},
+		},
+		{
+			name:   "non-reserved domain prefix accepted",
+			labels: map[string]string{"example.com/env": "production"},
+		},
+		{
+			name:   "empty value is valid",
+			labels: map[string]string{"env": ""},
+		},
+		// -- key format tests --
+		{
+			name:    "too many slashes rejected",
+			labels:  map[string]string{"a/b/c": "val"},
+			wantErr: "must be in the form prefix/name or name",
+		},
+		{
+			name:    "empty prefix rejected",
+			labels:  map[string]string{"/name": "val"},
+			wantErr: "prefix part must not be empty",
+		},
+		{
+			name:    "empty name rejected",
+			labels:  map[string]string{"prefix/": "val"},
+			wantErr: "name part must not be empty",
+		},
+		{
+			name:    "name too long rejected",
+			labels:  map[string]string{strings.Repeat("a", 64): "val"},
+			wantErr: "name part must be no more than 63 characters",
+		},
+		{
+			name:    "prefix too long rejected",
+			labels:  map[string]string{strings.Repeat("a.", 127) + "a/name": "val"},
+			wantErr: "prefix part must be no more than 253 characters",
+		},
+		{
+			name:    "invalid name chars rejected",
+			labels:  map[string]string{"name@bad": "val"},
+			wantErr: "name part a qualified name must consist of",
+		},
+		{
+			name:    "name starts with dash rejected",
+			labels:  map[string]string{"-name": "val"},
+			wantErr: "name part a qualified name must consist of",
+		},
+		{
+			name:    "name ends with dash rejected",
+			labels:  map[string]string{"name-": "val"},
+			wantErr: "name part a qualified name must consist of",
+		},
+		{
+			name:    "invalid prefix format rejected",
+			labels:  map[string]string{"EXAMPLE.COM/name": "val"},
+			wantErr: "prefix part a DNS-1123 subdomain must consist of",
+		},
+		// -- value format tests --
+		{
+			name:    "value too long rejected",
+			labels:  map[string]string{"env": strings.Repeat("a", 64)},
+			wantErr: "must be no more than 63 characters",
+		},
+		{
+			name:    "invalid value chars rejected",
+			labels:  map[string]string{"env": "bad@val"},
+			wantErr: "a qualified name must consist of",
+		},
+		{
+			name:   "value with dots and dashes valid",
+			labels: map[string]string{"env": "prod-west.zone1"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateNodeLabels(tt.labels)
+			if tt.wantErr == "" {
+				assert.NoError(t, err)
+			} else {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestIsReservedLabelKey(t *testing.T) {
+	tests := []struct {
+		key  string
+		want bool
+	}{
+		// Direct namespace matches
+		{"kubernetes.io/os", true},
+		{"beta.kubernetes.io/arch", true},
+		{"cube.cloud.tencentcloud.com/instance-type", true},
+
+		// Subdomain suffix matches
+		{"topology.kubernetes.io/zone", true},
+		{"failure-domain.beta.kubernetes.io/region", true},
+		{"node.kubernetes.io/instance-type", true},
+
+		// Canonical keys from constants (they all have kubernetes.io prefix)
+		{constants.AffinityKeyCPUType, true},
+		{constants.AffinityKeyZone, true},
+		{constants.AffinityKeyClusterID, true},
+		{constants.AffinityKeyMemorySize, true},
+		{constants.AffinityKeyCPUCores, true},
+		{constants.AffinityKeyInstanceType, true},
+
+		// Removed from reserved list — no longer reserved
+		{"k8s.io/foo", false},
+		{"node.k8s.io/bar", false},
+
+		// Non-reserved keys
+		{"env", false},
+		{"example.com/env", false},
+		{"my-custom-label", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.key, func(t *testing.T) {
+			assert.Equal(t, tt.want, config.IsReservedLabelKey(tt.key))
+		})
+	}
+}

--- a/CubeMaster/pkg/nodemeta/service_labels_test.go
+++ b/CubeMaster/pkg/nodemeta/service_labels_test.go
@@ -5,6 +5,7 @@
 package nodemeta
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
@@ -147,6 +148,17 @@ func TestValidateNodeLabels(t *testing.T) {
 		{
 			name:   "value with dots and dashes valid",
 			labels: map[string]string{"env": "prod-west.zone1"},
+		},
+		{
+			name: "too many labels rejected",
+			labels: func() map[string]string {
+				m := make(map[string]string, 65)
+				for i := 0; i < 65; i++ {
+					m[fmt.Sprintf("k%d", i)] = "v"
+				}
+				return m
+			}(),
+			wantErr: "a node cannot have more than 64 labels",
 		},
 	}
 

--- a/CubeMaster/pkg/server/server.go
+++ b/CubeMaster/pkg/server/server.go
@@ -121,7 +121,7 @@ func (s *internalHttp) registerHandlers() {
 	metaGroup.HandleFunc(metahttp.NodeAction(), metahttp.GetNodeHandler).Methods(http.MethodGet)
 	metaGroup.HandleFunc(metahttp.NodeStatusAction(), metahttp.UpdateNodeStatusHandler).Methods(http.MethodPost)
 	metaGroup.HandleFunc(metahttp.NodeLabelsAction(), metahttp.UpdateNodeLabelsHandler).Methods(http.MethodPost)
-	metaGroup.HandleFunc(metahttp.NodeLabelKeyAction(), metahttp.DeleteNodeLabelHandler).Methods(http.MethodDelete)
+	metaGroup.HandleFunc(metahttp.NodeLabelsAction(), metahttp.DeleteNodeLabelHandler).Methods(http.MethodDelete)
 }
 
 func (s *internalHttp) Start() error {

--- a/CubeMaster/pkg/server/server.go
+++ b/CubeMaster/pkg/server/server.go
@@ -120,6 +120,8 @@ func (s *internalHttp) registerHandlers() {
 	metaGroup.HandleFunc(metahttp.VersionMatrixAction(), metahttp.VersionMatrixHandler).Methods(http.MethodGet)
 	metaGroup.HandleFunc(metahttp.NodeAction(), metahttp.GetNodeHandler).Methods(http.MethodGet)
 	metaGroup.HandleFunc(metahttp.NodeStatusAction(), metahttp.UpdateNodeStatusHandler).Methods(http.MethodPost)
+	metaGroup.HandleFunc(metahttp.NodeLabelsAction(), metahttp.UpdateNodeLabelsHandler).Methods(http.MethodPost)
+	metaGroup.HandleFunc(metahttp.NodeLabelKeyAction(), metahttp.DeleteNodeLabelHandler).Methods(http.MethodDelete)
 }
 
 func (s *internalHttp) Start() error {

--- a/CubeMaster/pkg/service/httpservice/meta/meta.go
+++ b/CubeMaster/pkg/service/httpservice/meta/meta.go
@@ -23,7 +23,6 @@ const (
 	nodeAction          = "/nodes/{node_id}"
 	nodeStatusAction    = "/nodes/{node_id}/status"
 	nodeLabelsAction    = "/nodes/{node_id}/labels"
-	nodeLabelKeyAction  = "/nodes/{node_id}/labels/{key}"
 	versionMatrixAction = "/version-matrix"
 )
 
@@ -75,10 +74,6 @@ func VersionMatrixAction() string {
 
 func NodeLabelsAction() string {
 	return nodeLabelsAction
-}
-
-func NodeLabelKeyAction() string {
-	return nodeLabelKeyAction
 }
 
 func ReadyzHandler(w http.ResponseWriter, r *http.Request) {
@@ -188,7 +183,7 @@ func UpdateNodeLabelsHandler(w http.ResponseWriter, r *http.Request) {
 
 func DeleteNodeLabelHandler(w http.ResponseWriter, r *http.Request) {
 	nodeID := mux.Vars(r)["node_id"]
-	key := mux.Vars(r)["key"]
+	key := r.URL.Query().Get("key")
 	if err := nodemeta.DeleteNodeLabel(r.Context(), nodeID, key); err != nil {
 		writeErr(w, http.StatusOK, err)
 		return

--- a/CubeMaster/pkg/service/httpservice/meta/meta.go
+++ b/CubeMaster/pkg/service/httpservice/meta/meta.go
@@ -22,6 +22,8 @@ const (
 	nodesAction         = "/nodes"
 	nodeAction          = "/nodes/{node_id}"
 	nodeStatusAction    = "/nodes/{node_id}/status"
+	nodeLabelsAction    = "/nodes/{node_id}/labels"
+	nodeLabelKeyAction  = "/nodes/{node_id}/labels/{key}"
 	versionMatrixAction = "/version-matrix"
 )
 
@@ -69,6 +71,14 @@ func NodeStatusAction() string {
 
 func VersionMatrixAction() string {
 	return versionMatrixAction
+}
+
+func NodeLabelsAction() string {
+	return nodeLabelsAction
+}
+
+func NodeLabelKeyAction() string {
+	return nodeLabelKeyAction
 }
 
 func ReadyzHandler(w http.ResponseWriter, r *http.Request) {
@@ -157,6 +167,34 @@ func VersionMatrixHandler(w http.ResponseWriter, r *http.Request) {
 	common.WriteResponse(w, http.StatusOK, &versionMatrixResponse{
 		Ret:  successRet(),
 		Data: data,
+	})
+}
+
+func UpdateNodeLabelsHandler(w http.ResponseWriter, r *http.Request) {
+	nodeID := mux.Vars(r)["node_id"]
+	req := &nodemeta.UpdateNodeLabelsRequest{}
+	if err := common.GetBodyReq(r, req); err != nil {
+		writeErr(w, http.StatusBadRequest, err)
+		return
+	}
+	if err := nodemeta.UpdateNodeLabels(r.Context(), nodeID, req.Labels); err != nil {
+		writeErr(w, http.StatusOK, err)
+		return
+	}
+	common.WriteResponse(w, http.StatusOK, &sandboxtypes.Res{
+		Ret: successRet(),
+	})
+}
+
+func DeleteNodeLabelHandler(w http.ResponseWriter, r *http.Request) {
+	nodeID := mux.Vars(r)["node_id"]
+	key := mux.Vars(r)["key"]
+	if err := nodemeta.DeleteNodeLabel(r.Context(), nodeID, key); err != nil {
+		writeErr(w, http.StatusOK, err)
+		return
+	}
+	common.WriteResponse(w, http.StatusOK, &sandboxtypes.Res{
+		Ret: successRet(),
 	})
 }
 


### PR DESCRIPTION
# feat(CubeMaster): add node label management API

## Summary

Add two internal CubeMaster endpoints for administrators to add and remove custom labels on nodes:

- **POST** `/internal/meta/nodes/{node_id}/labels` — merge new labels into a node
- **DELETE** `/internal/meta/nodes/{node_id}/labels?key=example.com%2Fenv` — remove a label from a node

## Motivation

In production deployments, cluster administrators often need to attach metadata to nodes that cubelet does not know about. Today the only way to influence scheduling is through canonical affinity keys (`kubernetes.io/cpu-type`, `topology.kubernetes.io/zone`, etc.) that cubelet derives from hardware. This covers infrastructure attributes but not operational or business attributes.

| Scenario | Example Label | Purpose |
|---|---|---|
| Environment segregation | `env=staging` or `env=production` | Prevent staging workloads from landing on production nodes |
| Maintenance mode | `maintenance=planned` | Taint nodes earmarked for downtime so no new sandboxes are scheduled |
| Tenant / team isolation | `team=ml-platform` | Pin a team's workloads to a subset of nodes via node affinity |
| Custom topology | `rack=rack-3` | Express physical topology that cubelet cannot detect |
| Gradual rollout | `canary=true` | Limit a canary deployment to specific nodes |

## Multi-Master Data Synchronization

CubeSandbox supports multiple CubeMaster replicas for HA. There is **no direct inter-master communication** — replicas converge through shared backing stores:

| Data Type | Store | Cross-Replica Mechanism | Latency |
|---|---|---|---|
| Node labels, registration, status | MySQL | `syncAllFromDB` periodic reload (default 30s) | ≤ 30s |
| Resource metrics (CPU, memory, disk) | Redis HSET | `loopUpdateMetric` tick (default 1s) | ~1s |

**Write path:** The receiving replica wraps the read-merge-write in a DB transaction with `SELECT ... FOR UPDATE` to prevent concurrent label updates from silently overwriting each other. The in-memory snapshot and localcache are updated immediately so the scheduler on this replica sees the change right away. Other replicas converge within the next `syncAllFromDB` cycle (≤ 30s).

**Cubelet interaction:** When cubelet sends `RegisterNode`, it merges its reported labels into the existing `labels_json` with **cubelet priority on conflicts**. Admin-set labels that cubelet does not report are preserved across heartbeats; if cubelet later reports the same key, it overwrites the admin value — system-critical labels always reflect the node's actual hardware state.

## Label Validation

Label key/value validation follows **Kubernetes conventions** ([`IsQualifiedName`](https://github.com/kubernetes/apimachinery/blob/master/pkg/util/validation/validation.go) / [`IsValidLabelValue`](https://github.com/kubernetes/kubernetes/blob/master/pkg/kubelet/apis/well_known_labels.go)).

**Key format:** `[prefix/]name`

| Component | Rules | Max Length | Example |
|---|---|---|---|
| `prefix` | Optional. DNS1123 subdomain: lowercase alphanumeric, `-` or `.` | 253 | `example.com`, `my-org.io` |
| `name` | Required. Qualified name: alphanumeric, `-`, `_`, or `.`; must start and end with alphanumeric | 63 | `env`, `my-label`, `rack_3` |

**Value format:** empty string or qualified name (same rules as `name`, max 63 chars).

**Note:** Labels from cubelet `RegisterNode` are **not** validated — they are trusted system input. Only labels set via the admin API are subject to the constraints above.

### Reserved Label Keys

Labels whose key **namespace** (prefix before `/`) matches a reserved namespace — or is a subdomain of one — cannot be created or deleted via the admin API.

| Reserved Namespace | Description | Example Blocked Keys |
|---|---|---|
| `kubernetes.io` | Standard K8s labels, includes all subdomains | `kubernetes.io/os`, `topology.kubernetes.io/zone`, `node.kubernetes.io/instance-type` |
| `beta.kubernetes.io` | Legacy beta K8s labels, includes all subdomains | `beta.kubernetes.io/arch`, `failure-domain.beta.kubernetes.io/region` |
| `cube.cloud.tencentcloud.com` | Cube-specific labels | `cube.cloud.tencentcloud.com/instance-type` |

Blocked:

```bash
# Rejected — kubernetes.io namespace is reserved
POST /internal/meta/nodes/node-1/labels
{"labels": {"kubernetes.io/os": "windows"}}

# Rejected — cannot delete a reserved label
DELETE /internal/meta/nodes/node-1/labels?key=kubernetes.io%2Fos
```

Allowed:

```bash
# Accepted — non-reserved key
POST /internal/meta/nodes/node-1/labels
{"labels": {"env": "production"}}

# Accepted — custom domain prefix
POST /internal/meta/nodes/node-1/labels
{"labels": {"example.com/team": "ml-platform"}}

# Accepted — delete a custom label
DELETE /internal/meta/nodes/node-1/labels?key=env
```

