### PR TITLE
fix(one-click): make compute quickcheck tolerant of post-start races

### DIFF
--- a/deploy/one-click/env.example
+++ b/deploy/one-click/env.example
@@ -42,6 +42,21 @@ ONE_CLICK_CUBE_SHIM_BUILD_MODE=local
 # New installations are always managed by systemd; there is no systemd/non-systemd mode switch.
 ONE_CLICK_INSTALL_PREFIX=/usr/local/services/cubetoolbox
 ONE_CLICK_RUN_QUICKCHECK=1
+# quickcheck waits for each runtime signal (systemd units, health endpoints,
+# sockets, runtime files, node registration) to become ready within this overall
+# budget (seconds) before failing, so a transient post-start race does not abort
+# an otherwise-healthy install. The budget is shared across all probes in one
+# run. Values above 3600 are clamped to 3600; set to 0 to restore strict
+# fail-fast (probe exactly once) behaviour.
+# CUBE_QUICKCHECK_READY_TIMEOUT=120
+# Polling interval (seconds) between quickcheck readiness probes.
+# CUBE_QUICKCHECK_READY_INTERVAL=2
+# Per-container readiness budget (seconds) for the docker health/running check,
+# applied to each dependency container individually (cube-sandbox-mysql,
+# cube-sandbox-redis, cube-proxy, cube-proxy-coredns, cube-webui). Defaults to
+# CUBE_QUICKCHECK_READY_TIMEOUT and is always capped by it; set it lower to fail
+# a wedged container sooner than the overall budget.
+# CUBE_QUICKCHECK_CONTAINER_TIMEOUT=120
 # Install the packaged PVM guest kernel as cube-kernel-scf/vmlinux.
 # The default keeps the ordinary guest kernel.
 CUBE_PVM_ENABLE=0

--- a/deploy/one-click/scripts/one-click/quickcheck.sh
+++ b/deploy/one-click/scripts/one-click/quickcheck.sh
@@ -5,143 +5,399 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=./common.sh
 source "${SCRIPT_DIR}/common.sh"
 
-TOOLBOX_ROOT="${ONE_CLICK_TOOLBOX_ROOT:-/usr/local/services/cubetoolbox}"
-MASTER_ADDR="$(resolve_control_plane_cubemaster_addr)"
-NA_HEALTH_ADDR="${NETWORK_AGENT_HEALTH_ADDR:-127.0.0.1:19090}"
-CUBE_API_HEALTH_ADDR="${CUBE_API_HEALTH_ADDR:-127.0.0.1:3000}"
-ROLE="$(one_click_deploy_role)"
-NODE_ID="${CUBE_SANDBOX_NODE_IP:-}"
+# Readiness budget for the post-start quickcheck. quickcheck runs immediately
+# after the units are (re)started -- e.g. install.sh's `systemctl enable --now
+# <target>` -- but systemd considers a service "started" as soon as its
+# ExecStart is launched: the cubelet / network-agent daemons still need a brief
+# moment to bind their unix sockets (/data/cubelet/cubelet.sock,
+# /tmp/cube/network-agent-grpc.sock) and serve their HTTP health endpoints.
+# Probing exactly once therefore loses a startup race and returns a
+# false-negative install failure even though the node comes up healthy seconds
+# later.
+#
+# To remove that whole class of flakes for every caller (install.sh, smoke.sh,
+# deploy-manual.sh, up.sh, up-compute.sh), the probes are retried until they
+# pass or a single, shared wall-clock budget (QUICKCHECK_DEADLINE) is exhausted.
+# The budget is shared across all probes in one run -- not reset per probe -- so
+# the whole script is bounded by roughly CUBE_QUICKCHECK_READY_TIMEOUT seconds
+# regardless of how many probes run, and callers must not wrap quickcheck in
+# their own retry loop (that would multiply the budget on a genuinely broken
+# node). Set CUBE_QUICKCHECK_READY_TIMEOUT=0 to restore strict fail-fast (probe
+# exactly once) behaviour.
+#
+# The default is intentionally generous: the cold-start callers (install.sh,
+# smoke.sh, deploy-manual.sh) invoke quickcheck right after (re)starting the
+# units with no prior readiness wait, so the budget must cover the cumulative
+# time for units to activate, sockets to bind, health endpoints to serve, and
+# (on compute) the node to register with a remote cubemaster.
+QUICKCHECK_READY_TIMEOUT_DEFAULT=120
+QUICKCHECK_READY_INTERVAL_DEFAULT=2
+# Upper clamp so a typo/overflow cannot turn the budget into an effectively
+# infinite wait.
+QUICKCHECK_READY_TIMEOUT_MAX=3600
+# Per-request curl bounds so a black-holed endpoint (host up, port dropping
+# SYNs) cannot block a probe far past the readiness budget.
+QUICKCHECK_CURL_CONNECT_TIMEOUT=5
+QUICKCHECK_CURL_MAX_TIME=10
+# Per-call bound for `docker inspect` so a wedged docker daemon cannot block a
+# container probe indefinitely. Unlike curl, `docker inspect` has no built-in
+# request timeout, and the shared deadline is only re-checked between iterations,
+# so an unbounded inspect call could hang the whole run past QUICKCHECK_DEADLINE.
+QUICKCHECK_DOCKER_TIMEOUT=10
+# Cap the buffered node-registration response (it is a small JSON document).
+QUICKCHECK_CURL_MAX_FILESIZE=1048576
 
-# When external MySQL/Redis is configured the local container + systemd unit do
-# not exist, so the corresponding checks must be skipped.
-EXTERNAL_MYSQL_HOST="${CUBE_EXTERNAL_MYSQL_HOST:-}"
-EXTERNAL_REDIS_HOST="${CUBE_EXTERNAL_REDIS_HOST:-}"
+# Normalise CUBE_QUICKCHECK_READY_TIMEOUT / _INTERVAL into validated integers and
+# compute the single shared deadline. Numeric values are forced to base 10 so a
+# leading-zero value (e.g. "08") is not mis-parsed as octal and aborted under
+# `set -e`. Invalid values fall back to the defaults with a warning so an
+# operator typo is visible instead of silently ignored.
+quickcheck_init_budget() {
+  local raw_timeout="${CUBE_QUICKCHECK_READY_TIMEOUT:-${QUICKCHECK_READY_TIMEOUT_DEFAULT}}"
+  local raw_interval="${CUBE_QUICKCHECK_READY_INTERVAL:-${QUICKCHECK_READY_INTERVAL_DEFAULT}}"
+  local timeout interval
 
-require_cmd systemctl
+  QUICKCHECK_READY_TIMEOUT="$(quickcheck_sanitize_seconds \
+    "${raw_timeout}" "CUBE_QUICKCHECK_READY_TIMEOUT" "${QUICKCHECK_READY_TIMEOUT_DEFAULT}" 0)"
+  QUICKCHECK_READY_INTERVAL="$(quickcheck_sanitize_seconds \
+    "${raw_interval}" "CUBE_QUICKCHECK_READY_INTERVAL" "${QUICKCHECK_READY_INTERVAL_DEFAULT}" 1)"
+  timeout="${QUICKCHECK_READY_TIMEOUT}"
+  interval="${QUICKCHECK_READY_INTERVAL}"
+
+  # Never sleep past the overall budget.
+  if (( timeout > 0 && interval > timeout )); then
+    QUICKCHECK_READY_INTERVAL="${timeout}"
+  fi
+
+  QUICKCHECK_DEADLINE=$(( $(date +%s) + QUICKCHECK_READY_TIMEOUT ))
+}
+
+# Normalise a seconds value from operator-controlled env into a validated base-10
+# integer in [min, QUICKCHECK_READY_TIMEOUT_MAX], falling back to a default with a
+# warning. The `^[0-9]{1,7}$` pattern rejects empty / non-numeric / overflowing
+# (>7 digit) input in one shot, which both prevents an octal abort under `set -e`
+# (leading zeros via $((10#...))) and keeps the conversion well within int64 so it
+# cannot wrap into a negative/garbage budget. Echoes the sanitized integer.
+quickcheck_sanitize_seconds() {
+  local raw="$1"
+  local name="$2"
+  local default="$3"
+  local min="$4"
+  local value
+
+  if [[ "${raw}" =~ ^[0-9]{1,7}$ ]]; then
+    value=$((10#${raw}))
+  else
+    log "ignoring invalid ${name}='${raw}'; using default ${default}s"
+    value="${default}"
+  fi
+  if (( value < min )); then
+    log "ignoring out-of-range ${name}='${raw}'; using default ${default}s"
+    value="${default}"
+  fi
+  if (( value > QUICKCHECK_READY_TIMEOUT_MAX )); then
+    log "clamping ${name}='${raw}' to ${QUICKCHECK_READY_TIMEOUT_MAX}s"
+    value="${QUICKCHECK_READY_TIMEOUT_MAX}"
+  fi
+  printf '%s\n' "${value}"
+}
+
+# Retry an arbitrary predicate command until it succeeds or the shared readiness
+# budget is exhausted, then die with a descriptive message. The predicate must
+# return a status (it must NOT call die itself), so transient failures can be
+# retried.
+wait_until() {
+  local desc="$1"
+  shift
+  while :; do
+    if "$@"; then
+      return 0
+    fi
+    if (( $(date +%s) >= QUICKCHECK_DEADLINE )); then
+      die "${desc} (not ready within ${QUICKCHECK_READY_TIMEOUT}s)"
+    fi
+    # A sleep interrupted by a signal exits non-zero; tolerate it so `set -e`
+    # does not abort with a generic "sleep: interrupted" instead of the
+    # descriptive readiness failure the next deadline check would report.
+    sleep "${QUICKCHECK_READY_INTERVAL}" || true
+  done
+}
+
+unit_is_active() {
+  systemctl is-active --quiet "$1"
+}
 
 check_unit_active() {
   local unit="$1"
-  systemctl is-active --quiet "${unit}" || die "expected systemd unit not active: ${unit}"
+  wait_until "expected systemd unit not active: ${unit}" unit_is_active "${unit}"
+}
+
+http_ok() {
+  curl -fsS \
+    --connect-timeout "${QUICKCHECK_CURL_CONNECT_TIMEOUT}" \
+    --max-time "${QUICKCHECK_CURL_MAX_TIME}" \
+    "$1" >/dev/null 2>&1
+}
+
+check_http() {
+  local url="$1"
+  wait_until "endpoint not healthy: ${url}" http_ok "${url}"
+}
+
+check_socket() {
+  local path="$1"
+  wait_until "expected socket not ready: ${path}" test -S "${path}"
+}
+
+check_file() {
+  local path="$1"
+  local desc="${2:-expected file not ready: ${path}}"
+  wait_until "${desc}" test -f "${path}"
+}
+
+check_executable() {
+  local path="$1"
+  wait_until "expected executable not ready: ${path}" test -x "${path}"
+}
+
+# Read a container's effective status: its healthcheck status when a healthcheck
+# is defined, otherwise its lifecycle status. Bounded by QUICKCHECK_DOCKER_TIMEOUT
+# via `timeout` when available so a wedged docker daemon cannot hang the probe
+# past the shared deadline (which is only re-checked between iterations). Echoes
+# the status string (empty on any failure); never dies, so callers can retry.
+quickcheck_container_status() {
+  local container="$1"
+  local fmt='{{if .State.Health}}{{.State.Health.Status}}{{else}}{{.State.Status}}{{end}}'
+  # `timeout` can only bound an external binary, not a shell function, and
+  # functions are not inherited by this standalone script in production -- so a
+  # `docker` function only exists when the tests stub it. Skip the wrapper in
+  # that case so the stub is still invoked; in production docker is the external
+  # binary and gets the bound. `-k 5` forces SIGKILL if a wedged inspect ignores
+  # the initial SIGTERM. `--` stops a `-`-leading container-name override from
+  # being parsed as a docker option.
+  if ! declare -F docker >/dev/null 2>&1 && command -v timeout >/dev/null 2>&1; then
+    timeout -k 5 "${QUICKCHECK_DOCKER_TIMEOUT}" docker inspect --format "${fmt}" -- "${container}" 2>/dev/null || true
+  else
+    docker inspect --format "${fmt}" -- "${container}" 2>/dev/null || true
+  fi
 }
 
 check_container_ready() {
   local container="$1"
-  local timeout="${CUBE_QUICKCHECK_CONTAINER_TIMEOUT:-60}"
-  local interval=2
-  local elapsed=0
-  local status
+  # The per-container budget defaults to the overall readiness budget so a
+  # slow-but-healthy container (e.g. first-boot MySQL initialising its data dir)
+  # is not failed early just because the per-container default was lower than the
+  # generous overall budget. Set CUBE_QUICKCHECK_CONTAINER_TIMEOUT lower to fail a
+  # wedged container sooner; it is capped by the shared QUICKCHECK_DEADLINE below
+  # either way.
+  local container_timeout
+  container_timeout="$(quickcheck_sanitize_seconds \
+    "${CUBE_QUICKCHECK_CONTAINER_TIMEOUT:-${QUICKCHECK_READY_TIMEOUT}}" \
+    "CUBE_QUICKCHECK_CONTAINER_TIMEOUT" "${QUICKCHECK_READY_TIMEOUT}" 0)"
+  local start now status
+  # Measure the per-container budget as wall-clock elapsed (not a sleep-interval
+  # accumulator): each probe can spend up to QUICKCHECK_DOCKER_TIMEOUT inside
+  # `docker inspect`, so counting only the interval would let a slow daemon blow
+  # well past CUBE_QUICKCHECK_CONTAINER_TIMEOUT before it trips.
+  start="$(date +%s)"
   while :; do
-    status="$(docker inspect --format '{{if .State.Health}}{{.State.Health.Status}}{{else}}{{.State.Status}}{{end}}' "${container}" 2>/dev/null || true)"
+    status="$(quickcheck_container_status "${container}")"
     case "${status}" in
       healthy|running)
         return 0
         ;;
-      starting)
+      # Transient startup states (including an empty status, when the container
+      # has been launched but not yet created): keep waiting until a budget is
+      # exhausted, like every other probe.
+      starting|created|restarting|"")
         ;;
       *)
         die "container is not ready: ${container} (status=${status:-unknown})"
         ;;
     esac
-    if (( elapsed >= timeout )); then
-      die "container is not ready within ${timeout}s: ${container} (status=${status:-unknown})"
+    # Bounded by the per-container budget AND the shared overall deadline, so a
+    # wedged container fails fast without letting container checks blow past the
+    # whole-run budget. Attribute the failure to whichever bound tripped.
+    now="$(date +%s)"
+    if (( now - start >= container_timeout )); then
+      die "container is not ready within ${container_timeout}s: ${container} (status=${status:-unknown})"
     fi
-    sleep "${interval}"
-    elapsed=$(( elapsed + interval ))
+    if (( now >= QUICKCHECK_DEADLINE )); then
+      die "container is not ready within the ${QUICKCHECK_READY_TIMEOUT}s overall quickcheck budget: ${container} (status=${status:-unknown})"
+    fi
+    # Tolerate a signal-interrupted sleep so `set -e` does not abort here; the
+    # next iteration's deadline check reports the descriptive failure instead.
+    sleep "${QUICKCHECK_READY_INTERVAL}" || true
   done
 }
 
 check_bind_mount_source_file() {
   local path="$1"
-  [[ -f "${path}" ]] || die "expected bind mount source file not ready: ${path}"
+  check_file "${path}" "expected bind mount source file not ready: ${path}"
 }
 
-echo "[quickcheck] role=${ROLE}"
-echo "[quickcheck] cubemaster=${MASTER_ADDR}"
-echo "[quickcheck] network-agent-health=${NA_HEALTH_ADDR}"
-if [[ "${ROLE}" != "compute" ]]; then
-  echo "[quickcheck] cube-api-health=${CUBE_API_HEALTH_ADDR}"
-fi
+# Wait for the node to register with cubemaster. A dedicated loop (rather than
+# the generic wait_until) so the final failure preserves the distinction between
+# "could not reach cubemaster" and "registered but missing host_ip", which is
+# the difference between a connectivity problem and a cubelet/identity problem.
+# Once cubemaster has been reached at least once the more diagnostic
+# "missing host_ip" reason is kept sticky, so a momentary connectivity blip on
+# the final attempt does not mask the real (registration) problem.
+check_node_registration() {
+  local node_id="$1"
+  local master_addr="$2"
+  local registration
+  local reached=0
+  local last_reason="failed to query cubemaster node registration for ${node_id}"
+  while :; do
+    if registration="$(curl -fsS \
+        --connect-timeout "${QUICKCHECK_CURL_CONNECT_TIMEOUT}" \
+        --max-time "${QUICKCHECK_CURL_MAX_TIME}" \
+        --max-filesize "${QUICKCHECK_CURL_MAX_FILESIZE}" \
+        "http://${master_addr}/internal/meta/nodes/${node_id}" 2>/dev/null)"; then
+      if grep -Fq "\"host_ip\":\"${node_id}\"" <<<"${registration}"; then
+        return 0
+      fi
+      if grep -Fq '"host_ip":"' <<<"${registration}"; then
+        reached=1
+        last_reason="cubemaster node registration missing host_ip=${node_id}"
+      elif (( reached == 0 )); then
+        last_reason="cubemaster node registration response missing host_ip field for ${node_id}"
+      fi
+    elif (( reached == 0 )); then
+      last_reason="failed to query cubemaster node registration for ${node_id}"
+    fi
+    if (( $(date +%s) >= QUICKCHECK_DEADLINE )); then
+      die "${last_reason} (not ready within ${QUICKCHECK_READY_TIMEOUT}s)"
+    fi
+    # Tolerate a signal-interrupted sleep so `set -e` does not abort here; the
+    # next iteration's deadline check reports the descriptive failure instead.
+    sleep "${QUICKCHECK_READY_INTERVAL}" || true
+  done
+}
 
-echo "[quickcheck] check systemd units"
-check_unit_active cube-sandbox-network-agent.service
-check_unit_active cube-sandbox-cubelet.service
-if [[ "${ROLE}" != "compute" ]]; then
-  if [[ -n "${EXTERNAL_MYSQL_HOST}" ]]; then
-    echo "[quickcheck] external MySQL (${EXTERNAL_MYSQL_HOST}); skipping local mysql unit check"
+quickcheck_main() {
+  require_cmd systemctl
+  require_cmd curl
+  require_cmd grep
+
+  local TOOLBOX_ROOT="${ONE_CLICK_TOOLBOX_ROOT:-/usr/local/services/cubetoolbox}"
+  local MASTER_ADDR
+  MASTER_ADDR="$(resolve_control_plane_cubemaster_addr)"
+  local NA_HEALTH_ADDR="${NETWORK_AGENT_HEALTH_ADDR:-127.0.0.1:19090}"
+  local CUBE_API_HEALTH_ADDR="${CUBE_API_HEALTH_ADDR:-127.0.0.1:3000}"
+  local ROLE
+  ROLE="$(one_click_deploy_role)"
+  local NODE_ID="${CUBE_SANDBOX_NODE_IP:-}"
+
+  # When external MySQL/Redis is configured the local container + systemd unit do
+  # not exist, so the corresponding checks must be skipped.
+  local EXTERNAL_MYSQL_HOST="${CUBE_EXTERNAL_MYSQL_HOST:-}"
+  local EXTERNAL_REDIS_HOST="${CUBE_EXTERNAL_REDIS_HOST:-}"
+
+  # Validate the host:port / IP values before they are interpolated into curl
+  # URLs and grep patterns. resolve_control_plane_cubemaster_addr already
+  # validates the compute-role address, but the control-plane default and the
+  # health-endpoint overrides reach curl unchecked otherwise.
+  validate_host_port "${MASTER_ADDR}" "cubemaster address"
+  validate_host_port "${NA_HEALTH_ADDR}" "NETWORK_AGENT_HEALTH_ADDR"
+  if [[ "${ROLE}" != "compute" ]]; then
+    validate_host_port "${CUBE_API_HEALTH_ADDR}" "CUBE_API_HEALTH_ADDR"
+  fi
+
+  quickcheck_init_budget
+
+  echo "[quickcheck] role=${ROLE}"
+  echo "[quickcheck] cubemaster=${MASTER_ADDR}"
+  echo "[quickcheck] network-agent-health=${NA_HEALTH_ADDR}"
+  if [[ "${ROLE}" != "compute" ]]; then
+    echo "[quickcheck] cube-api-health=${CUBE_API_HEALTH_ADDR}"
+  fi
+
+  echo "[quickcheck] check systemd units"
+  check_unit_active cube-sandbox-network-agent.service
+  check_unit_active cube-sandbox-cubelet.service
+  if [[ "${ROLE}" != "compute" ]]; then
+    if [[ -n "${EXTERNAL_MYSQL_HOST}" ]]; then
+      echo "[quickcheck] external MySQL (${EXTERNAL_MYSQL_HOST}); skipping local mysql unit check"
+    else
+      check_unit_active cube-sandbox-mysql.service
+    fi
+    if [[ -n "${EXTERNAL_REDIS_HOST}" ]]; then
+      echo "[quickcheck] external Redis (${EXTERNAL_REDIS_HOST}); skipping local redis unit check"
+    else
+      check_unit_active cube-sandbox-redis.service
+    fi
+    check_unit_active cube-sandbox-cubemaster.service
+    check_unit_active cube-sandbox-cube-api.service
+    check_unit_active cube-sandbox-cube-proxy.service
+    check_unit_active cube-sandbox-coredns.service
+    check_unit_active cube-sandbox-dns.service
+    if [[ "${WEB_UI_ENABLE:-1}" == "1" ]]; then
+      check_unit_active cube-sandbox-webui.service
+    fi
+  fi
+
+  if command -v docker >/dev/null 2>&1 && [[ "${ROLE}" != "compute" ]]; then
+    echo "[quickcheck] check container runtime state"
+    [[ -n "${EXTERNAL_MYSQL_HOST}" ]] || check_container_ready "${CUBE_SANDBOX_MYSQL_CONTAINER:-cube-sandbox-mysql}"
+    [[ -n "${EXTERNAL_REDIS_HOST}" ]] || check_container_ready "${CUBE_SANDBOX_REDIS_CONTAINER:-cube-sandbox-redis}"
+    check_container_ready "${CUBE_PROXY_CONTAINER_NAME:-cube-proxy}"
+    check_container_ready "${CUBE_PROXY_COREDNS_CONTAINER:-cube-proxy-coredns}"
+    if [[ "${WEB_UI_ENABLE:-1}" == "1" ]]; then
+      check_container_ready "${WEB_UI_CONTAINER_NAME:-cube-webui}"
+    fi
+  fi
+
+  echo "[quickcheck] 1/5 check network-agent healthz"
+  check_http "http://${NA_HEALTH_ADDR}/healthz"
+
+  echo "[quickcheck] 2/5 check network-agent readyz"
+  check_http "http://${NA_HEALTH_ADDR}/readyz"
+
+  echo "[quickcheck] 3/5 check cubemaster /notify/health"
+  check_http "http://${MASTER_ADDR}/notify/health"
+
+  if [[ "${ROLE}" == "compute" ]]; then
+    [[ -n "${NODE_ID}" ]] || die "CUBE_SANDBOX_NODE_IP is required for compute quickcheck"
+    validate_ipv4_literal "${NODE_ID}" "CUBE_SANDBOX_NODE_IP"
+    echo "[quickcheck] 4/5 check cubemaster node registration"
+    check_node_registration "${NODE_ID}" "${MASTER_ADDR}"
+
+    echo "[quickcheck] 5/5 check essential sockets and runtime assets"
+    check_socket "/data/cubelet/cubelet.sock"
+    check_socket "/tmp/cube/network-agent-grpc.sock"
+    check_file "${TOOLBOX_ROOT}/Cubelet/config/config.toml"
+    check_file "${TOOLBOX_ROOT}/Cubelet/dynamicconf/conf.yaml"
+    check_file "${TOOLBOX_ROOT}/cube-shim/conf/config-cube.toml"
+    check_file "${TOOLBOX_ROOT}/cube-kernel-scf/vmlinux"
+    check_file "${TOOLBOX_ROOT}/cube-image/cube-guest-image-cpu.img"
   else
-    check_unit_active cube-sandbox-mysql.service
+    echo "[quickcheck] 4/5 check cube-api /health"
+    check_http "http://${CUBE_API_HEALTH_ADDR}/health"
+
+    echo "[quickcheck] 5/5 check essential sockets and config"
+    check_socket "/data/cubelet/cubelet.sock"
+    check_socket "/tmp/cube/network-agent-grpc.sock"
+    check_executable "${TOOLBOX_ROOT}/CubeAPI/bin/cube-api"
+    check_file "${TOOLBOX_ROOT}/CubeMaster/conf.yaml"
+    check_file "${TOOLBOX_ROOT}/Cubelet/config/config.toml"
+    check_file "${TOOLBOX_ROOT}/Cubelet/dynamicconf/conf.yaml"
+    check_file "${TOOLBOX_ROOT}/cube-shim/conf/config-cube.toml"
+    check_bind_mount_source_file "${TOOLBOX_ROOT}/cubeproxy/global.conf"
+    check_bind_mount_source_file "${TOOLBOX_ROOT}/cubeproxy/nginx.conf"
+    check_bind_mount_source_file "${TOOLBOX_ROOT}/coredns/Corefile"
+    check_bind_mount_source_file "${TOOLBOX_ROOT}/coredns/resolv.conf.upstream"
+    if [[ "${WEB_UI_ENABLE:-1}" == "1" ]]; then
+      check_bind_mount_source_file "${TOOLBOX_ROOT}/webui/nginx.generated.conf"
+    fi
   fi
-  if [[ -n "${EXTERNAL_REDIS_HOST}" ]]; then
-    echo "[quickcheck] external Redis (${EXTERNAL_REDIS_HOST}); skipping local redis unit check"
-  else
-    check_unit_active cube-sandbox-redis.service
-  fi
-  check_unit_active cube-sandbox-cubemaster.service
-  check_unit_active cube-sandbox-cube-api.service
-  check_unit_active cube-sandbox-cube-proxy.service
-  check_unit_active cube-sandbox-coredns.service
-  check_unit_active cube-sandbox-dns.service
-  if [[ "${WEB_UI_ENABLE:-1}" == "1" ]]; then
-    check_unit_active cube-sandbox-webui.service
-  fi
+
+  echo "[quickcheck] OK"
+}
+
+# Allow tests to source this file for its helper functions without executing the
+# probe sequence; only run when invoked directly.
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  quickcheck_main "$@"
 fi
-
-if command -v docker >/dev/null 2>&1 && [[ "${ROLE}" != "compute" ]]; then
-  echo "[quickcheck] check container runtime state"
-  [[ -n "${EXTERNAL_MYSQL_HOST}" ]] || check_container_ready "${CUBE_SANDBOX_MYSQL_CONTAINER:-cube-sandbox-mysql}"
-  [[ -n "${EXTERNAL_REDIS_HOST}" ]] || check_container_ready "${CUBE_SANDBOX_REDIS_CONTAINER:-cube-sandbox-redis}"
-  check_container_ready "${CUBE_PROXY_CONTAINER_NAME:-cube-proxy}"
-  check_container_ready "${CUBE_PROXY_COREDNS_CONTAINER:-cube-proxy-coredns}"
-  if [[ "${WEB_UI_ENABLE:-1}" == "1" ]]; then
-    check_container_ready "${WEB_UI_CONTAINER_NAME:-cube-webui}"
-  fi
-fi
-
-echo "[quickcheck] 1/5 check network-agent healthz"
-curl -fsS "http://${NA_HEALTH_ADDR}/healthz" >/dev/null
-
-echo "[quickcheck] 2/5 check network-agent readyz"
-curl -fsS "http://${NA_HEALTH_ADDR}/readyz" >/dev/null
-
-echo "[quickcheck] 3/5 check cubemaster /notify/health"
-curl -fsS "http://${MASTER_ADDR}/notify/health" >/dev/null
-
-if [[ "${ROLE}" == "compute" ]]; then
-  [[ -n "${NODE_ID}" ]] || die "CUBE_SANDBOX_NODE_IP is required for compute quickcheck"
-  echo "[quickcheck] 4/5 check cubemaster node registration"
-  node_registration="$(curl -fsS "http://${MASTER_ADDR}/internal/meta/nodes/${NODE_ID}")" \
-    || die "failed to query cubemaster node registration for ${NODE_ID}"
-  if ! grep -Fq "\"host_ip\":\"${NODE_ID}\"" <<<"${node_registration}"; then
-    die "cubemaster node registration missing host_ip=${NODE_ID}"
-  fi
-
-  echo "[quickcheck] 5/5 check essential sockets and runtime assets"
-  test -S "/data/cubelet/cubelet.sock"
-  test -S "/tmp/cube/network-agent-grpc.sock"
-  test -f "${TOOLBOX_ROOT}/Cubelet/config/config.toml"
-  test -f "${TOOLBOX_ROOT}/Cubelet/dynamicconf/conf.yaml"
-  test -f "${TOOLBOX_ROOT}/cube-shim/conf/config-cube.toml"
-  test -f "${TOOLBOX_ROOT}/cube-kernel-scf/vmlinux"
-  test -f "${TOOLBOX_ROOT}/cube-image/cube-guest-image-cpu.img"
-else
-  echo "[quickcheck] 4/5 check cube-api /health"
-  curl -fsS "http://${CUBE_API_HEALTH_ADDR}/health" >/dev/null
-
-  echo "[quickcheck] 5/5 check essential sockets and config"
-  test -S "/data/cubelet/cubelet.sock"
-  test -S "/tmp/cube/network-agent-grpc.sock"
-  test -x "${TOOLBOX_ROOT}/CubeAPI/bin/cube-api"
-  test -f "${TOOLBOX_ROOT}/CubeMaster/conf.yaml"
-  test -f "${TOOLBOX_ROOT}/Cubelet/config/config.toml"
-  test -f "${TOOLBOX_ROOT}/Cubelet/dynamicconf/conf.yaml"
-  test -f "${TOOLBOX_ROOT}/cube-shim/conf/config-cube.toml"
-  check_bind_mount_source_file "${TOOLBOX_ROOT}/cubeproxy/global.conf"
-  check_bind_mount_source_file "${TOOLBOX_ROOT}/cubeproxy/nginx.conf"
-  check_bind_mount_source_file "${TOOLBOX_ROOT}/coredns/Corefile"
-  check_bind_mount_source_file "${TOOLBOX_ROOT}/coredns/resolv.conf.upstream"
-  if [[ "${WEB_UI_ENABLE:-1}" == "1" ]]; then
-    check_bind_mount_source_file "${TOOLBOX_ROOT}/webui/nginx.generated.conf"
-  fi
-fi
-
-echo "[quickcheck] OK"

--- a/deploy/one-click/scripts/one-click/up-compute.sh
+++ b/deploy/one-click/scripts/one-click/up-compute.sh
@@ -62,13 +62,13 @@ start_with_pidfile \
 
 refresh_pidfile_from_pattern "cubelet" "^${CUBELET_BIN} --config" 10 1 || log "cubelet pidfile refresh skipped"
 
-for _ in {1..30}; do
-  if "${SCRIPT_DIR}/quickcheck.sh" >/dev/null 2>&1; then
-    "${SCRIPT_DIR}/quickcheck.sh"
-    log "compute services ready"
-    exit 0
-  fi
-  sleep 2
-done
+# quickcheck.sh now waits for each runtime signal to become ready within a single
+# shared budget (CUBE_QUICKCHECK_READY_TIMEOUT), so a single invocation is
+# already race-tolerant. Do NOT wrap it in an outer retry loop: that would
+# multiply quickcheck's budget on a genuinely broken node.
+if "${SCRIPT_DIR}/quickcheck.sh"; then
+  log "compute services ready"
+  exit 0
+fi
 
 die "compute services did not become ready, check logs under ${LOG_DIR}"

--- a/deploy/one-click/scripts/one-click/up.sh
+++ b/deploy/one-click/scripts/one-click/up.sh
@@ -94,13 +94,13 @@ refresh_pidfile_from_pattern "cubelet" "^${CUBELET_BIN} --config" 10 1 || log "c
 
 wait_for_http "http://${CUBE_API_HEALTH_ADDR}/health" 30 1 || die "cube-api did not become ready, check logs under ${LOG_DIR}"
 
-for _ in {1..30}; do
-  if "${SCRIPT_DIR}/quickcheck.sh" >/dev/null 2>&1; then
-    "${SCRIPT_DIR}/quickcheck.sh"
-    log "core services ready"
-    exit 0
-  fi
-  sleep 2
-done
+# quickcheck.sh now waits for each runtime signal to become ready within a single
+# shared budget (CUBE_QUICKCHECK_READY_TIMEOUT), so a single invocation is
+# already race-tolerant. Do NOT wrap it in an outer retry loop: that would
+# multiply quickcheck's budget on a genuinely broken node.
+if "${SCRIPT_DIR}/quickcheck.sh"; then
+  log "core services ready"
+  exit 0
+fi
 
 die "core services did not become ready, check logs under ${LOG_DIR}"

--- a/deploy/one-click/tests/test_runtime_file_safety.sh
+++ b/deploy/one-click/tests/test_runtime_file_safety.sh
@@ -1,4 +1,11 @@
 #!/usr/bin/env bash
+# Several behavioral tests below source one-click scripts and drive their helper
+# functions indirectly (dispatched via `"$@"`) inside subshells. shellcheck
+# cannot follow the dynamic `source` or the indirect dispatch, so it reports the
+# stub bodies as unreachable (SC2317), the budget variables as unused (SC2034),
+# and the in-subshell assignments as lost (SC2030/SC2031) even though the reads
+# happen in the same subshell. These are false positives for this test pattern.
+# shellcheck disable=SC2030,SC2031,SC2034,SC2317
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -40,6 +47,15 @@ assert_not_contains() {
   if grep -Fq -- "${needle}" "${path}"; then
     fail "expected ${path} not to contain ${needle}"
   fi
+}
+
+assert_stdout_contains() {
+  local haystack="$1"
+  local needle="$2"
+  case "${haystack}" in
+    *"${needle}"*) : ;;
+    *) fail "expected output to contain '${needle}', got: ${haystack}" ;;
+  esac
 }
 
 run_cube_proxy_postcheck_case() {
@@ -182,6 +198,553 @@ test_quickcheck_reports_node_registration_failure_explicitly() {
   assert_not_contains "${path}" "| rg -q"
 }
 
+# quickcheck runs once right after `systemctl enable --now <target>` returns, so
+# it must tolerate the brief startup race before cubelet/network-agent bind
+# their sockets and serve their health endpoints. Guard the retry semantics so a
+# future refactor cannot reintroduce one-shot probes (which produced spurious
+# "compute installation failed ... exit 1" failures on healthy nodes).
+test_quickcheck_probes_are_race_tolerant() {
+  local path="${ONE_CLICK_DIR}/scripts/one-click/quickcheck.sh"
+
+  assert_contains "${path}" "CUBE_QUICKCHECK_READY_TIMEOUT"
+  assert_contains "${path}" "wait_until"
+  # Socket / health probes must go through the retrying helpers, never a bare
+  # one-shot check that dies on the first transient miss.
+  assert_contains "${path}" "check_socket "
+  assert_contains "${path}" "check_http "
+  assert_not_contains "${path}" 'curl -fsS "http://${NA_HEALTH_ADDR}/healthz" >/dev/null'
+  assert_not_contains "${path}" 'test -S "/data/cubelet/cubelet.sock"'
+}
+
+# Source quickcheck.sh for its helper functions (its probe sequence is guarded
+# behind a BASH_SOURCE check) so the retry semantics can be exercised at
+# runtime, not just asserted as source text. `sleep` is stubbed to a no-op so
+# the retry loops run instantly.
+_quickcheck_source() {
+  # shellcheck source=../scripts/one-click/quickcheck.sh
+  source "${ONE_CLICK_DIR}/scripts/one-click/quickcheck.sh"
+}
+
+test_quickcheck_wait_until_retries_then_succeeds() {
+  local counter_file="${TMP_DIR}/wait-until-attempts"
+  printf '0\n' > "${counter_file}"
+  (
+    _quickcheck_source
+    sleep() { :; }
+    QUICKCHECK_READY_TIMEOUT=30
+    QUICKCHECK_READY_INTERVAL=1
+    QUICKCHECK_DEADLINE=$(( $(date +%s) + 30 ))
+    flaky() {
+      local n
+      n="$(<"${counter_file}")"
+      n=$(( n + 1 ))
+      printf '%s\n' "${n}" > "${counter_file}"
+      (( n >= 3 ))
+    }
+    wait_until "flaky predicate never ready" flaky
+  ) || fail "wait_until should succeed once the predicate passes"
+  local attempts
+  attempts="$(<"${counter_file}")"
+  (( attempts == 3 )) || fail "wait_until should retry until success (expected 3 attempts, got ${attempts})"
+}
+
+test_quickcheck_wait_until_times_out_with_descriptive_die() {
+  local out
+  if out="$(
+    exec 2>&1
+    _quickcheck_source
+    sleep() { :; }
+    QUICKCHECK_READY_TIMEOUT=4
+    QUICKCHECK_READY_INTERVAL=2
+    # Deadline already in the past -> fail on the first miss without hanging.
+    QUICKCHECK_DEADLINE=$(( $(date +%s) - 1 ))
+    wait_until "widget not ready" false
+  )"; then
+    fail "wait_until should die when the predicate never passes"
+  fi
+  assert_stdout_contains "${out}" "widget not ready (not ready within 4s)"
+}
+
+test_quickcheck_timeout_zero_is_fail_fast() {
+  # With timeout=0 wait_until must probe exactly once and die WITHOUT sleeping.
+  # All three guards (no sleep, descriptive die, single probe) are asserted in
+  # the parent shell so a regression of the `>=` deadline boundary is caught --
+  # an in-subshell `fail` inside the dying call would be swallowed by die's exit.
+  local counter_file="${TMP_DIR}/fail-fast-attempts"
+  local sleep_log="${TMP_DIR}/fail-fast-slept"
+  printf '0\n' > "${counter_file}"
+  : > "${sleep_log}"
+  local out
+  if out="$(
+    exec 2>&1
+    _quickcheck_source
+    CUBE_QUICKCHECK_READY_TIMEOUT=0
+    unset CUBE_QUICKCHECK_READY_INTERVAL || true
+    quickcheck_init_budget
+    sleep() { echo slept >> "${sleep_log}"; }
+    always_fail() {
+      local n
+      n="$(<"${counter_file}")"
+      n=$(( n + 1 ))
+      printf '%s\n' "${n}" > "${counter_file}"
+      return 1
+    }
+    wait_until "x not ready" always_fail
+  )"; then
+    fail "wait_until must fail-fast (die) with timeout=0"
+  fi
+  # The "within 0s" message confirms the budget normalized to 0.
+  assert_stdout_contains "${out}" "x not ready (not ready within 0s)"
+  [[ ! -s "${sleep_log}" ]] || fail "timeout=0 must not sleep before failing"
+  local attempts
+  attempts="$(<"${counter_file}")"
+  (( attempts == 1 )) || fail "timeout=0 must probe exactly once, got ${attempts}"
+}
+
+test_quickcheck_invalid_budget_falls_back_to_defaults() {
+  (
+    _quickcheck_source
+    CUBE_QUICKCHECK_READY_TIMEOUT="abc"
+    CUBE_QUICKCHECK_READY_INTERVAL="0"
+    quickcheck_init_budget 2>/dev/null
+    (( QUICKCHECK_READY_TIMEOUT == 120 )) || fail "invalid timeout should fall back to 120, got ${QUICKCHECK_READY_TIMEOUT}"
+    (( QUICKCHECK_READY_INTERVAL == 2 )) || fail "invalid/zero interval should fall back to 2, got ${QUICKCHECK_READY_INTERVAL}"
+  ) || fail "invalid budget fallback test failed"
+}
+
+test_quickcheck_budget_normalizes_leading_zeros() {
+  # Leading-zero values must be parsed as base 10, not octal (which would abort
+  # the arithmetic under set -e for digits 8/9).
+  (
+    _quickcheck_source
+    CUBE_QUICKCHECK_READY_TIMEOUT="0090"
+    CUBE_QUICKCHECK_READY_INTERVAL="08"
+    quickcheck_init_budget
+    (( QUICKCHECK_READY_TIMEOUT == 90 )) || fail "leading-zero timeout should normalize to 90, got ${QUICKCHECK_READY_TIMEOUT}"
+    (( QUICKCHECK_READY_INTERVAL == 8 )) || fail "leading-zero interval should normalize to 8, got ${QUICKCHECK_READY_INTERVAL}"
+  ) || fail "leading-zero normalization test failed"
+}
+
+test_quickcheck_interval_clamped_to_timeout() {
+  (
+    _quickcheck_source
+    CUBE_QUICKCHECK_READY_TIMEOUT=3
+    CUBE_QUICKCHECK_READY_INTERVAL=10
+    quickcheck_init_budget
+    (( QUICKCHECK_READY_INTERVAL == 3 )) || fail "interval should clamp to timeout (3), got ${QUICKCHECK_READY_INTERVAL}"
+  ) || fail "interval clamp test failed"
+}
+
+test_quickcheck_timeout_clamped_to_max() {
+  (
+    _quickcheck_source
+    CUBE_QUICKCHECK_READY_TIMEOUT=99999
+    unset CUBE_QUICKCHECK_READY_INTERVAL || true
+    quickcheck_init_budget 2>/dev/null
+    (( QUICKCHECK_READY_TIMEOUT == 3600 )) || fail "timeout should clamp to 3600, got ${QUICKCHECK_READY_TIMEOUT}"
+  ) || fail "timeout max clamp test failed"
+}
+
+test_quickcheck_timeout_overflow_falls_back_to_default() {
+  # An 8+ digit value fails the ^[0-9]{1,7}$ guard entirely, so it must fall back
+  # to the default (120) -- NOT be clamped to the 3600 max, which only applies to
+  # in-range values. This distinguishes the overflow-reject branch from the
+  # max-clamp branch.
+  (
+    _quickcheck_source
+    CUBE_QUICKCHECK_READY_TIMEOUT=12345678
+    unset CUBE_QUICKCHECK_READY_INTERVAL || true
+    quickcheck_init_budget 2>/dev/null
+    (( QUICKCHECK_READY_TIMEOUT == 120 )) || fail "overflow timeout should fall back to 120, got ${QUICKCHECK_READY_TIMEOUT}"
+  ) || fail "timeout overflow fallback test failed"
+}
+
+test_quickcheck_check_executable_behaviour() {
+  local exe="${TMP_DIR}/qc-exe"
+  printf '#!/bin/sh\n' > "${exe}"
+  chmod +x "${exe}"
+  (
+    _quickcheck_source
+    sleep() { :; }
+    QUICKCHECK_READY_TIMEOUT=5
+    QUICKCHECK_READY_INTERVAL=1
+    QUICKCHECK_DEADLINE=$(( $(date +%s) + 5 ))
+    check_executable "${exe}"
+  ) || fail "check_executable should pass for an executable file"
+
+  local missing="${TMP_DIR}/qc-missing-exe"
+  local out
+  if out="$(
+    exec 2>&1
+    _quickcheck_source
+    sleep() { :; }
+    QUICKCHECK_READY_TIMEOUT=2
+    QUICKCHECK_READY_INTERVAL=1
+    QUICKCHECK_DEADLINE=$(( $(date +%s) - 1 ))
+    check_executable "${missing}"
+  )"; then
+    fail "check_executable should die for a missing executable"
+  fi
+  assert_stdout_contains "${out}" "expected executable not ready: ${missing}"
+}
+
+test_quickcheck_bind_mount_file_uses_specific_message() {
+  # check_bind_mount_source_file must keep its specific message rather than the
+  # generic check_file default.
+  local missing="${TMP_DIR}/qc-missing-bind"
+  local out
+  if out="$(
+    exec 2>&1
+    _quickcheck_source
+    sleep() { :; }
+    QUICKCHECK_READY_TIMEOUT=2
+    QUICKCHECK_READY_INTERVAL=1
+    QUICKCHECK_DEADLINE=$(( $(date +%s) - 1 ))
+    check_bind_mount_source_file "${missing}"
+  )"; then
+    fail "check_bind_mount_source_file should die for a missing file"
+  fi
+  assert_stdout_contains "${out}" "expected bind mount source file not ready: ${missing}"
+}
+
+test_quickcheck_node_registration_keeps_missing_host_ip_after_blip() {
+  # Once cubemaster has been reached (registration present but host_ip wrong), a
+  # later connectivity blip must NOT downgrade the diagnostic reason back to
+  # "failed to query". Drive the wall clock deterministically with a stubbed
+  # date so the deadline is crossed exactly on the second iteration.
+  local curl_counter="${TMP_DIR}/reg-curl-calls"
+  local date_counter="${TMP_DIR}/reg-date-calls"
+  printf '0\n' > "${curl_counter}"
+  printf '0\n' > "${date_counter}"
+  local out
+  if out="$(
+    exec 2>&1
+    _quickcheck_source
+    sleep() { :; }
+    MASTER_ADDR="127.0.0.1:8089"
+    QUICKCHECK_READY_TIMEOUT=10
+    QUICKCHECK_READY_INTERVAL=2
+    QUICKCHECK_DEADLINE=101
+    date() {
+      local n
+      n="$(<"${date_counter}")"
+      n=$(( n + 1 ))
+      printf '%s\n' "${n}" > "${date_counter}"
+      printf '%s\n' "$(( 99 + n ))"
+    }
+    curl() {
+      local n
+      n="$(<"${curl_counter}")"
+      n=$(( n + 1 ))
+      printf '%s\n' "${n}" > "${curl_counter}"
+      if (( n == 1 )); then
+        # Iteration 1: reachable cubemaster, wrong host_ip -> reached=1.
+        printf '{"host_ip":"10.0.0.99"}\n'
+        return 0
+      fi
+      # Iteration 2: connectivity blip.
+      return 7
+    }
+    check_node_registration "10.0.0.10" "${MASTER_ADDR}"
+  )"; then
+    fail "check_node_registration should die when host_ip never matches"
+  fi
+  assert_stdout_contains "${out}" "cubemaster node registration missing host_ip=10.0.0.10"
+  case "${out}" in
+    *"failed to query cubemaster node registration"*)
+      fail "reason must stay sticky as 'missing host_ip' after cubemaster was reached" ;;
+  esac
+}
+
+test_quickcheck_container_ready_retries_transient_states() {
+  # Every transient startup status (empty/created/restarting/starting) must be
+  # retried (not an immediate die) until the container reports running. Covering
+  # each one guards the transient arm of the case statement against a refactor
+  # that moves one into the terminal `*)` branch.
+  local docker_calls="${TMP_DIR}/container-docker-calls"
+  printf '0\n' > "${docker_calls}"
+  (
+    _quickcheck_source
+    sleep() { :; }
+    QUICKCHECK_READY_TIMEOUT=30
+    QUICKCHECK_READY_INTERVAL=1
+    QUICKCHECK_DEADLINE=$(( $(date +%s) + 30 ))
+    docker() {
+      local n
+      n="$(<"${docker_calls}")"
+      n=$(( n + 1 ))
+      printf '%s\n' "${n}" > "${docker_calls}"
+      case "${n}" in
+        1) printf '\n' ;;           # not created yet -> empty status
+        2) printf 'created\n' ;;
+        3) printf 'restarting\n' ;;
+        4) printf 'starting\n' ;;
+        *) printf 'running\n' ;;
+      esac
+    }
+    check_container_ready "cube-sandbox-mysql"
+  ) || fail "check_container_ready should retry transient states then succeed"
+  local calls
+  calls="$(<"${docker_calls}")"
+  (( calls == 5 )) || fail "expected 5 docker inspect calls, got ${calls}"
+}
+
+test_quickcheck_container_ready_dies_on_terminal_status() {
+  # A terminal status (e.g. exited) must die immediately without retrying.
+  local out
+  if out="$(
+    exec 2>&1
+    _quickcheck_source
+    sleep() { fail "terminal status must not be retried"; }
+    QUICKCHECK_READY_TIMEOUT=30
+    QUICKCHECK_READY_INTERVAL=1
+    QUICKCHECK_DEADLINE=$(( $(date +%s) + 30 ))
+    docker() { printf 'exited\n'; }
+    check_container_ready "cube-sandbox-mysql"
+  )"; then
+    fail "check_container_ready should die on a terminal container status"
+  fi
+  assert_stdout_contains "${out}" "container is not ready: cube-sandbox-mysql (status=exited)"
+}
+
+test_quickcheck_container_ready_bounded_by_overall_deadline() {
+  # Even with a huge per-container budget, the shared overall deadline caps the
+  # wait and the failure is attributed to the overall budget.
+  local out
+  if out="$(
+    exec 2>&1
+    _quickcheck_source
+    sleep() { :; }
+    CUBE_QUICKCHECK_CONTAINER_TIMEOUT=9999
+    QUICKCHECK_READY_TIMEOUT=5
+    QUICKCHECK_READY_INTERVAL=2
+    QUICKCHECK_DEADLINE=$(( $(date +%s) - 1 ))
+    docker() { printf 'starting\n'; }
+    check_container_ready "cube-sandbox-mysql"
+  )"; then
+    fail "check_container_ready should die when the overall deadline has passed"
+  fi
+  assert_stdout_contains "${out}" "overall quickcheck budget"
+}
+
+test_quickcheck_container_ready_dies_on_per_container_timeout() {
+  # A small CUBE_QUICKCHECK_CONTAINER_TIMEOUT must fail a wedged-but-not-terminal
+  # container sooner than (and attributed to) the overall budget. Drive the wall
+  # clock with a stubbed date so the per-container budget trips before the much
+  # larger overall deadline.
+  local date_counter="${TMP_DIR}/per-container-date-calls"
+  printf '0\n' > "${date_counter}"
+  local out
+  if out="$(
+    exec 2>&1
+    _quickcheck_source
+    sleep() { :; }
+    CUBE_QUICKCHECK_CONTAINER_TIMEOUT=2
+    quickcheck_init_budget
+    QUICKCHECK_READY_INTERVAL=2
+    # Overall deadline far in the future so only the per-container budget can trip.
+    date() {
+      local n
+      n="$(<"${date_counter}")"
+      n=$(( n + 1 ))
+      printf '%s\n' "${n}" > "${date_counter}"
+      printf '%s\n' "$(( 1000 + n ))"
+    }
+    QUICKCHECK_DEADLINE=999999
+    docker() { printf 'starting\n'; }
+    check_container_ready "cube-sandbox-mysql"
+  )"; then
+    fail "check_container_ready should die when the per-container timeout is exhausted"
+  fi
+  assert_stdout_contains "${out}" "container is not ready within 2s: cube-sandbox-mysql (status=starting)"
+  case "${out}" in
+    *"overall quickcheck budget"*)
+      fail "per-container timeout failure must not be attributed to the overall budget" ;;
+  esac
+}
+
+test_quickcheck_container_ready_accepts_healthy_status() {
+  # A docker healthcheck reporting "healthy" must be accepted, not just "running".
+  (
+    _quickcheck_source
+    sleep() { :; }
+    QUICKCHECK_READY_TIMEOUT=30
+    QUICKCHECK_READY_INTERVAL=1
+    QUICKCHECK_DEADLINE=$(( $(date +%s) + 30 ))
+    docker() { printf 'healthy\n'; }
+    check_container_ready "cube-sandbox-mysql"
+  ) || fail "check_container_ready should accept a healthy container"
+}
+
+test_quickcheck_budget_is_shared_across_sequential_probes() {
+  # The headline invariant: QUICKCHECK_DEADLINE is computed once and is NOT reset
+  # per probe, so a later probe runs against the same (already-elapsing) deadline
+  # rather than getting a fresh window. A stubbed clock advances 1s per call;
+  # wait_until is invoked WITHOUT recomputing the deadline between calls, exactly
+  # as quickcheck_main does. The second probe must die once the shared deadline
+  # passes -- a per-probe reset would let it loop forever against this stub.
+  local date_counter="${TMP_DIR}/shared-budget-date-calls"
+  printf '0\n' > "${date_counter}"
+  local out
+  if out="$(
+    exec 2>&1
+    _quickcheck_source
+    sleep() { :; }
+    QUICKCHECK_READY_TIMEOUT=3
+    QUICKCHECK_READY_INTERVAL=1
+    date() {
+      local n
+      n="$(<"${date_counter}")"
+      n=$(( n + 1 ))
+      printf '%s\n' "${n}" > "${date_counter}"
+      printf '%s\n' "${n}"
+    }
+    # Shared deadline at "second" 3. Re-running quickcheck_init_budget here would
+    # move it; the production code does not, and neither does this test.
+    QUICKCHECK_DEADLINE=3
+    # An earlier probe that succeeds, then a later probe that never does. The
+    # later probe inherits the same deadline and must terminate.
+    wait_until "first probe" true
+    wait_until "second probe" false
+  )"; then
+    fail "second probe must die against the shared (already-elapsing) deadline"
+  fi
+  assert_stdout_contains "${out}" "second probe (not ready"
+}
+
+test_quickcheck_callers_do_not_wrap_in_retry_loop() {
+  # quickcheck self-retries now; up.sh / up-compute.sh must call it exactly once
+  # and must not re-introduce the old outer retry loop.
+  local up="${ONE_CLICK_DIR}/scripts/one-click/up.sh"
+  local upc="${ONE_CLICK_DIR}/scripts/one-click/up-compute.sh"
+  assert_contains "${up}" '"${SCRIPT_DIR}/quickcheck.sh"'
+  assert_contains "${upc}" '"${SCRIPT_DIR}/quickcheck.sh"'
+  assert_not_contains "${up}" 'for _ in {1..30}'
+  assert_not_contains "${upc}" 'for _ in {1..30}'
+}
+
+test_quickcheck_node_registration_prefers_missing_host_ip_reason() {
+  local out
+  if out="$(
+    exec 2>&1
+    _quickcheck_source
+    sleep() { :; }
+    MASTER_ADDR="127.0.0.1:8089"
+    QUICKCHECK_READY_TIMEOUT=4
+    QUICKCHECK_READY_INTERVAL=2
+    QUICKCHECK_DEADLINE=$(( $(date +%s) - 1 ))
+    # Reachable cubemaster, but the registered host_ip never matches.
+    curl() { printf '{"host_ip":"10.0.0.99"}\n'; }
+    check_node_registration "10.0.0.10" "${MASTER_ADDR}"
+  )"; then
+    fail "check_node_registration should die when host_ip never matches"
+  fi
+  assert_stdout_contains "${out}" "cubemaster node registration missing host_ip=10.0.0.10"
+}
+
+test_quickcheck_node_registration_reports_unreachable_reason() {
+  local out
+  if out="$(
+    exec 2>&1
+    _quickcheck_source
+    sleep() { :; }
+    MASTER_ADDR="127.0.0.1:8089"
+    QUICKCHECK_READY_TIMEOUT=4
+    QUICKCHECK_READY_INTERVAL=2
+    QUICKCHECK_DEADLINE=$(( $(date +%s) - 1 ))
+    # Simulate a refused connection (curl exit 7).
+    curl() { return 7; }
+    check_node_registration "10.0.0.10" "${MASTER_ADDR}"
+  )"; then
+    fail "check_node_registration should die when cubemaster is unreachable"
+  fi
+  assert_stdout_contains "${out}" "failed to query cubemaster node registration for 10.0.0.10"
+}
+
+test_quickcheck_node_registration_succeeds_on_first_match() {
+  (
+    _quickcheck_source
+    sleep() { :; }
+    MASTER_ADDR="127.0.0.1:8089"
+    QUICKCHECK_READY_TIMEOUT=30
+    QUICKCHECK_READY_INTERVAL=1
+    QUICKCHECK_DEADLINE=$(( $(date +%s) + 30 ))
+    curl() { printf '{"host_ip":"10.0.0.10"}\n'; }
+    check_node_registration "10.0.0.10" "${MASTER_ADDR}"
+  ) || fail "check_node_registration should succeed when host_ip matches on the first attempt"
+}
+
+test_quickcheck_node_registration_response_missing_host_ip_field() {
+  # When curl returns valid JSON without a host_ip field, the reason must
+  # distinguish "unrecognized response" from "known format, wrong IP".
+  local out
+  if out="$(
+    exec 2>&1
+    _quickcheck_source
+    sleep() { :; }
+    MASTER_ADDR="127.0.0.1:8089"
+    QUICKCHECK_READY_TIMEOUT=4
+    QUICKCHECK_READY_INTERVAL=2
+    QUICKCHECK_DEADLINE=$(( $(date +%s) - 1 ))
+    curl() { printf '{"error":"not ready"}\n'; }
+    check_node_registration "10.0.0.10" "${MASTER_ADDR}"
+  )"; then
+    fail "check_node_registration should die when response lacks host_ip"
+  fi
+  assert_stdout_contains "${out}" "response missing host_ip field"
+}
+
+test_quickcheck_check_socket_retries_then_succeeds() {
+  local test_counter="${TMP_DIR}/socket-test-calls"
+  printf '0\n' > "${test_counter}"
+  local sock="${TMP_DIR}/qc-test-sock"
+  (
+    _quickcheck_source
+    sleep() { :; }
+    QUICKCHECK_READY_TIMEOUT=30
+    QUICKCHECK_READY_INTERVAL=1
+    QUICKCHECK_DEADLINE=$(( $(date +%s) + 30 ))
+    test() {
+      if [[ "$1" == "-S" ]]; then
+        local n
+        n="$(<"${test_counter}")"
+        n=$(( n + 1 ))
+        printf '%s\n' "${n}" > "${test_counter}"
+        (( n >= 3 ))
+      else
+        command test "$@"
+      fi
+    }
+    check_socket "${sock}"
+  ) || fail "check_socket should retry then succeed once the socket appears"
+  local calls
+  calls="$(<"${test_counter}")"
+  (( calls == 3 )) || fail "check_socket should retry 3 times, got ${calls}"
+}
+
+test_quickcheck_check_http_retries_then_succeeds() {
+  local curl_counter="${TMP_DIR}/http-test-calls"
+  printf '0\n' > "${curl_counter}"
+  (
+    _quickcheck_source
+    sleep() { :; }
+    QUICKCHECK_READY_TIMEOUT=30
+    QUICKCHECK_READY_INTERVAL=1
+    QUICKCHECK_DEADLINE=$(( $(date +%s) + 30 ))
+    curl() {
+      local n
+      n="$(<"${curl_counter}")"
+      n=$(( n + 1 ))
+      printf '%s\n' "${n}" > "${curl_counter}"
+      (( n >= 3 ))
+    }
+    check_http "http://127.0.0.1:19090/healthz"
+  ) || fail "check_http should retry then succeed once the endpoint responds"
+  local calls
+  calls="$(<"${curl_counter}")"
+  (( calls == 3 )) || fail "check_http should retry 3 times, got ${calls}"
+}
+
 test_cube_proxy_postcheck_defaults_to_http_port_80() {
   run_cube_proxy_postcheck_case \
     "CUBE_PROXY_POSTCHECK_RETRIES=1
@@ -268,6 +831,31 @@ test_detect_glibc_version_consumes_full_ldd_output
 test_online_install_glibc_detection_avoids_head_pipe
 test_one_click_scripts_do_not_require_ripgrep
 test_quickcheck_reports_node_registration_failure_explicitly
+test_quickcheck_probes_are_race_tolerant
+test_quickcheck_wait_until_retries_then_succeeds
+test_quickcheck_wait_until_times_out_with_descriptive_die
+test_quickcheck_timeout_zero_is_fail_fast
+test_quickcheck_invalid_budget_falls_back_to_defaults
+test_quickcheck_budget_normalizes_leading_zeros
+test_quickcheck_interval_clamped_to_timeout
+test_quickcheck_timeout_clamped_to_max
+test_quickcheck_timeout_overflow_falls_back_to_default
+test_quickcheck_check_executable_behaviour
+test_quickcheck_bind_mount_file_uses_specific_message
+test_quickcheck_node_registration_prefers_missing_host_ip_reason
+test_quickcheck_node_registration_reports_unreachable_reason
+test_quickcheck_node_registration_keeps_missing_host_ip_after_blip
+test_quickcheck_container_ready_retries_transient_states
+test_quickcheck_container_ready_dies_on_terminal_status
+test_quickcheck_container_ready_bounded_by_overall_deadline
+test_quickcheck_container_ready_dies_on_per_container_timeout
+test_quickcheck_container_ready_accepts_healthy_status
+test_quickcheck_budget_is_shared_across_sequential_probes
+test_quickcheck_callers_do_not_wrap_in_retry_loop
+test_quickcheck_node_registration_succeeds_on_first_match
+test_quickcheck_node_registration_response_missing_host_ip_field
+test_quickcheck_check_socket_retries_then_succeeds
+test_quickcheck_check_http_retries_then_succeeds
 test_cube_proxy_postcheck_defaults_to_http_port_80
 test_cube_proxy_postcheck_follows_http_port
 test_cube_proxy_postcheck_ignores_https_port


### PR DESCRIPTION
The multi-node deployer reported "compute installation failed ... exit 1" [1] on compute nodes that had actually come up healthy. The post-start quickcheck runs immediately after the systemd target is enabled, but systemd treats a service as started the moment its ExecStart is launched, while cubelet and network-agent still need a brief moment to bind their unix sockets and serve their health endpoints. A single-shot probe therefore lost this startup race and aborted an otherwise-working install.

The legacy up.sh / up-compute.sh paths already wrapped quickcheck in a retry loop, but the systemd install path and the other one-shot callers (install.sh, smoke.sh, deploy-manual.sh, create.sh) did not, leaving them exposed to the same transient failure.

Make quickcheck wait for its runtime signals to become ready within a bounded, configurable budget instead of probing exactly once. This removes the whole class of false-negative install failures for every caller, while still failing fast and clearly when a node is genuinely broken, and adds a regression test that guards the retry behaviour.

Output [1]
```
Created symlink /etc/systemd/system/multi-user.target.wants/cube-sandbox-compute.target → /etc/systemd/system/cube-sandbox-compute.target.
[quickcheck] role=compute
[quickcheck] cubemaster=10.0.1.8:8089
[quickcheck] network-agent-health=127.0.0.1:19090
[quickcheck] check systemd units
[quickcheck] 1/5 check network-agent healthz
[quickcheck] 2/5 check network-agent readyz
[quickcheck] 3/5 check cubemaster /notify/health
[quickcheck] 4/5 check cubemaster node registration
[quickcheck] 5/5 check essential sockets and runtime assets
  ✗ compute installation failed on node 2 (10.0.1.5, exit 1)

  [2.4] Local verification...
  systemctl status:
● cube-sandbox-compute.target - Cube Sandbox compute-node stack
     Loaded: loaded (/etc/systemd/system/cube-sandbox-compute.target; enabled; preset: disabled)
     Active: active since Tue 2026-06-23 16:51:47 CST; 1s ago

Jun 23 16:51:47 VM-1-5-opencloudos systemd[1]: Reached target cube-sandbox-compute.target - Cube Sandbox compute-node stack.
  ✓ Tagged: CubeSandboxRole=compute
```
Debugged-by: Cursor:claude-opus-4.8