### PR TITLE
fix(CubeProxy): disable buffering for envd streaming endpoints

### DIFF
--- a/CubeProxy/Dockerfile
+++ b/CubeProxy/Dockerfile
@@ -11,6 +11,7 @@ RUN sed -i 's#https\?://dl-cdn.alpinelinux.org#http://mirrors.tencent.com#g' /et
 
 WORKDIR /usr/local/openresty/nginx/
 COPY lua/ /usr/local/openresty/nginx/lua/
+COPY conf/includes/ /usr/local/openresty/nginx/conf/includes/
 COPY nginx.conf /usr/local/openresty/nginx/conf/nginx.conf
 COPY rotate_nginx_log.sh /usr/local/openresty/nginx/sbin/rotate_nginx_log.sh
 COPY root /etc/crontabs/root

--- a/CubeProxy/conf/includes/envd_streaming_host_route.inc
+++ b/CubeProxy/conf/includes/envd_streaming_host_route.inc
@@ -1,0 +1,24 @@
+proxy_buffering off;
+# Streaming envd errors must pass through verbatim; intercepting them here
+# would replace protocol-native error frames with nginx error pages and break
+# client-side parsing.
+proxy_intercept_errors off;
+
+proxy_http_version 1.1;
+proxy_set_header Upgrade $http_upgrade;
+proxy_set_header Connection "upgrade";
+
+proxy_send_timeout 7206s;
+proxy_read_timeout 7206s;
+proxy_connect_timeout 3s;
+proxy_set_header Host $http_host;
+proxy_set_header X-Real-IP $remote_addr;
+proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+
+rewrite_by_lua_file lua/rewrite_phase.lua;
+
+proxy_pass http://backend;
+
+header_filter_by_lua_file lua/header_filter_phase.lua;
+
+log_by_lua_file lua/log_phase.lua;

--- a/CubeProxy/conf/includes/envd_streaming_path_route.inc
+++ b/CubeProxy/conf/includes/envd_streaming_path_route.inc
@@ -1,0 +1,28 @@
+proxy_buffering off;
+# Streaming envd errors must pass through verbatim; intercepting them here
+# would replace protocol-native error frames with nginx error pages and break
+# client-side parsing.
+proxy_intercept_errors off;
+
+proxy_http_version 1.1;
+proxy_set_header Upgrade $http_upgrade;
+proxy_set_header Connection "upgrade";
+
+proxy_send_timeout 7206s;
+proxy_read_timeout 7206s;
+proxy_connect_timeout 3s;
+proxy_set_header Host $http_host;
+proxy_set_header X-Real-IP $remote_addr;
+proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+proxy_set_header X-Forwarded-Prefix /sandbox/$ins_id/$container_port;
+
+proxy_redirect    ~^/(.*)$  /sandbox/$ins_id/$container_port/$1;
+proxy_cookie_path /         /sandbox/$ins_id/$container_port/;
+
+rewrite_by_lua_file lua/path_rewrite_phase.lua;
+
+proxy_pass http://backend;
+
+header_filter_by_lua_file lua/header_filter_phase.lua;
+
+log_by_lua_file lua/log_phase.lua;

--- a/CubeProxy/nginx.conf
+++ b/CubeProxy/nginx.conf
@@ -133,9 +133,23 @@ http {
             proxy_pass http://$cube_sidecar_addr/internal/resume?$args;
         }
 
+        # Path-based server-streaming envd endpoints. Keep buffering enabled
+        # elsewhere under /sandbox/ and disable it only for these verified
+        # response streams.
+        location ~ ^/sandbox/[^/]+/\d+/(?:process\.Process/(?:Start|Connect)|filesystem\.Filesystem/WatchDir)$ {
+            include /usr/local/openresty/nginx/conf/global/global.conf;
+            set $garyscale_test "none";
+            set $backend_ip "";
+            set $backend_port "";
+            set $access_time "";
+            set $host_proxy_port 8081;
+
+            include /usr/local/openresty/nginx/conf/includes/envd_streaming_path_route.inc;
+        }
+
         # Path-based routing: /sandbox/<sandbox-id>/<container-port>/<rest>
         # Lets clients reach a sandbox via a plain IP+port without wildcard DNS or TLS.
-        location ^~ /sandbox/ {
+        location /sandbox/ {
             include /usr/local/openresty/nginx/conf/global/global.conf;
             set $garyscale_test "none";
             set $backend_ip "";
@@ -167,6 +181,25 @@ http {
             header_filter_by_lua_file lua/header_filter_phase.lua;
 
             log_by_lua_file lua/log_phase.lua;
+        }
+
+        # Verified server-streaming envd endpoints used by clients today.
+        # Keep buffering enabled elsewhere and disable it only for these
+        # response streams; otherwise nginx batches early frames until timeout
+        # or stream completion and breaks immediate-return semantics.
+        # Current unbuffered streaming endpoints:
+        #   - process.Process/Start
+        #   - process.Process/Connect
+        #   - filesystem.Filesystem/WatchDir
+        location ~ ^/(?:process\.Process/(?:Start|Connect)|filesystem\.Filesystem/WatchDir)$ {
+            include /usr/local/openresty/nginx/conf/global/global.conf;
+            set $garyscale_test "none";
+            set $backend_ip "";
+            set $backend_port "";
+            set $access_time "";
+            set $host_proxy_port 8081;
+
+            include /usr/local/openresty/nginx/conf/includes/envd_streaming_host_route.inc;
         }
 
         location / {
@@ -226,9 +259,23 @@ http {
             proxy_pass http://$cube_sidecar_addr/internal/resume?$args;
         }
 
+        # Path-based server-streaming envd endpoints. Keep buffering enabled
+        # elsewhere under /sandbox/ and disable it only for these verified
+        # response streams.
+        location ~ ^/sandbox/[^/]+/\d+/(?:process\.Process/(?:Start|Connect)|filesystem\.Filesystem/WatchDir)$ {
+            include /usr/local/openresty/nginx/conf/global/global.conf;
+            set $garyscale_test "none";
+            set $backend_ip "";
+            set $backend_port "";
+            set $access_time "";
+            set $host_proxy_port 8080;
+
+            include /usr/local/openresty/nginx/conf/includes/envd_streaming_path_route.inc;
+        }
+
         # Path-based routing: /sandbox/<sandbox-id>/<container-port>/<rest>
         # Lets clients reach a sandbox via a plain IP+port without wildcard DNS or TLS.
-        location ^~ /sandbox/ {
+        location /sandbox/ {
             include /usr/local/openresty/nginx/conf/global/global.conf;
             set $garyscale_test "none";
             set $backend_ip "";
@@ -260,6 +307,19 @@ http {
             header_filter_by_lua_file lua/header_filter_phase.lua;
 
             log_by_lua_file lua/log_phase.lua;
+        }
+
+        # Verified server-streaming envd endpoints. Must not be buffered; see
+        # the 8081 server block for the scope rationale and endpoint list.
+        location ~ ^/(?:process\.Process/(?:Start|Connect)|filesystem\.Filesystem/WatchDir)$ {
+            include /usr/local/openresty/nginx/conf/global/global.conf;
+            set $garyscale_test "none";
+            set $backend_ip "";
+            set $backend_port "";
+            set $access_time "";
+            set $host_proxy_port 8080;
+
+            include /usr/local/openresty/nginx/conf/includes/envd_streaming_host_route.inc;
         }
 
         location / {


### PR DESCRIPTION
## Motivation

CubeProxy currently enables `proxy_buffering on` globally. This is fine for ordinary unary envd endpoints, but it can delay response frames from envd server-streaming endpoints until the stream completes or the request times out.

Two regressions were verified on a real cluster:

1. `sandbox.commands.run(..., background=True)` did not return immediately. `run()` blocked until the command exited, and `handle.wait()` returned immediately afterwards.
2. `filesystem.Filesystem/WatchDir` did not deliver its initial `start` event or first filesystem event in real time. The first streamed events arrived only near the request timeout, even though the watched file changed much earlier.

## What Changed

This PR disables nginx response buffering only for the currently verified envd server-streaming endpoints:

* `process.Process/Start`
* `process.Process/Connect`
* `filesystem.Filesystem/WatchDir`

The change is applied in both CubeProxy data-plane server blocks. The global default buffering behavior remains unchanged for all other routes, keeping the scope narrow.

It covers both CubeProxy entrypoints for those verified streams:

* host-routed requests such as `/process.Process/Start`
* path-routed requests such as `/sandbox/<sandbox-id>/<container-port>/process.Process/Start`

## Testing

Real-cluster `background=True` repro:

* before the fix, `sandbox.commands.run(..., background=True)` still waited for the command to finish before returning, and `handle.wait()` returned immediately afterwards
* after the fix, `run()` returned promptly after the process started, and the waiting moved back to `handle.wait()`

Real-cluster `WatchDir` repro:

* the existing watcher path in the SDK continued to deliver `CREATE` / `WRITE` around the scheduled 1s file write before and after the fix
* before the fix, a direct `Filesystem.WatchDir` stream delivered `start` and the first filesystem event only around the 6s request timeout boundary
* after the fix, `start` arrived in about 15ms and the first streamed filesystem event arrived around the scheduled 1s file write

Follow-up validation for maintainer question: interactive `Process.Connect` + `SendInput`:

* ran a real-cluster repro for an interactive process stream with `Process.Connect` and delayed input
* after the deliberate 1s input delay, the stream delivered `echo:ping-from-sendinput` within the measurement resolution, and the control-file side effect appeared about 220ms later
* the process exited later, confirming the echoed output was streamed before process exit rather than flushed at the end
* this indicates the current `Process.Connect` unbuffering already covers the interactive input scenario, so a separate unbuffered `SendInput` route is not needed based on this validation

Follow-up validation for maintainer question: PTY path:

* ran a separate real-cluster repro through `sandbox.pty.create()` + `sandbox.pty.connect()` + `sandbox.pty.send_stdin()`
* with the current patch, `sandbox.pty.connect()` attached promptly
* after the deliberate 1s input delay, `sandbox.pty.send_stdin()` returned within about 10ms, the PTY stream delivered the marker within about 15ms, and the control-file side effect appeared within about 50ms
* the shell exited later, confirming the marker was streamed before process exit rather than flushed at the end
* after intentionally removing the unbuffering change, the same PTY repro no longer sustained a usable session: `sandbox.pty.create()` only returned near the timeout boundary, and the subsequent `sandbox.pty.connect()` / `sandbox.pty.send_stdin()` calls failed with `NotFoundException`
* no PTY stream events were delivered and the control-file side effect never appeared in that pre-fix run
* this indicates the PTY failure already happens at `Start` / `Connect` time under buffered proxy behavior, which is stronger evidence for targeting the streaming routes instead of adding a separate unbuffered `SendInput` route

## Example Repro

The clearest minimal repro for the buffering issue is the low-level envd `Filesystem.WatchDir` server stream.

The same sandbox is exercised through two paths:

* control path: `sandbox.files.watch_dir()` keeps working and sees the scheduled file write around the expected 1s point
* streaming path: direct `Filesystem.WatchDir` should emit `start` immediately and then emit the first filesystem event when the file is written

Minimal repro sketch:

```python
watch = sandbox.files.watch_dir("/tmp/watchdir")

stream = sandbox.files._rpc.watch_dir(
    filesystem_pb2.WatchDirRequest(path="/tmp/watchdir", recursive=False),
    headers=headers,
    timeout=6.0,
    request_timeout=sandbox.connection_config.get_request_timeout(6.0),
)

sandbox.commands.run(
    "sh -lc 'nohup sh -lc \"sleep 1; printf stream > /tmp/watchdir/stream.txt\" >/dev/null 2>&1 &'"
)
```

Observed behavior on a real cluster:

* before the fix, the control path still saw the file write around the scheduled 1s point, but the direct `WatchDir` stream did not deliver `start` or the first filesystem event until around the 6s request timeout boundary
* after the fix, `start` arrived in about 15ms and the first filesystem event arrived around the scheduled 1s write
