### PR TITLE
feat(envd): report collected envd versions

### DIFF
--- a/CubeAPI/src/constants.rs
+++ b/CubeAPI/src/constants.rs
@@ -4,5 +4,11 @@
 
 //! API-facing constants shared across sandbox responses.
 
-/// Reported `envdVersion` for sandbox APIs (create, connect, list, get, resume, etc.).
-pub const ENVD_VERSION: &str = "0.2.0";
+/// Conservative fallback `envdVersion` used when a sandbox carries no collected
+/// version annotation (e.g. legacy templates). Kept at the historical value so
+/// e2b SDK feature gating degrades safely.
+pub const ENVD_VERSION_FALLBACK: &str = "0.2.0";
+
+/// Sandbox annotation key carrying the real envd version, collected at template
+/// creation time by CubeMaster/Cubelet and propagated to sandbox instances.
+pub const ENVD_VERSION_ANNOTATION: &str = "cube.master.components.envd.version";

--- a/CubeAPI/src/cubemaster/mod.rs
+++ b/CubeAPI/src/cubemaster/mod.rs
@@ -961,6 +961,10 @@ pub struct CreateSandboxResponse {
     #[serde(default)]
     pub traffic_access_token: Option<String>,
     pub ret: RetCode,
+    /// Generic extension metadata echoed by CubeMaster on success (e.g. the
+    /// collected envd version). Not surfaced wholesale to the external API.
+    #[serde(default)]
+    pub ext_info: HashMap<String, String>,
 }
 
 // ─── Delete sandbox ────────────────────────────────────────────────────────

--- a/CubeAPI/src/services/sandboxes.rs
+++ b/CubeAPI/src/services/sandboxes.rs
@@ -8,7 +8,7 @@ use uuid::Uuid;
 
 use super::validate_allow_out_domains_require_deny_all;
 use crate::{
-    constants::ENVD_VERSION,
+    constants::{ENVD_VERSION_ANNOTATION, ENVD_VERSION_FALLBACK},
     cubemaster::{
         datetime_from_unix_nanos, extract_template_id, CreateSandboxRequest, CubeEgressRule,
         CubeEgressRuleAction, CubeEgressRuleInject, CubeEgressRuleMatch, CubeMasterClient,
@@ -96,6 +96,7 @@ impl SandboxService {
             .or(d.end_at)
             .unwrap_or(started_at);
 
+        let envd_version = envd_version_from_annotations(&d.annotations);
         Ok(SandboxDetail {
             template_id: d.template_id,
             alias: None,
@@ -103,7 +104,7 @@ impl SandboxService {
             client_id: d.host_id,
             started_at,
             end_at,
-            envd_version: ENVD_VERSION.to_string(),
+            envd_version,
             envd_access_token: None,
             domain: Some(self.sandbox_domain.clone()),
             cpu_count: d.cpu_count,
@@ -177,10 +178,12 @@ impl SandboxService {
 
         resp.ret.into_result().map_err(internal_error)?;
 
+        let envd_version = envd_version_from_annotations(&resp.ext_info);
         Ok(self.sandbox_response(
             template_id,
             resp.sandbox_id,
             resp.request_id,
+            envd_version,
             resp.traffic_access_token,
         ))
     }
@@ -238,11 +241,18 @@ impl SandboxService {
         )?;
 
         let d = self.fetch_sandbox_detail(sandbox_id).await?;
+        let envd_version = envd_version_from_annotations(&d.annotations);
         // resume/connect paths reload the sandbox via fetch_sandbox_detail,
         // which does not surface the traffic_access_token. The token only
         // matters at create time (so the caller can persist it); afterward
         // CubeProxy reads it directly from Redis. None here is correct.
-        Ok(self.sandbox_response(d.template_id, sandbox_id.to_string(), d.host_id, None))
+        Ok(self.sandbox_response(
+            d.template_id,
+            sandbox_id.to_string(),
+            d.host_id,
+            envd_version,
+            None,
+        ))
     }
 
     pub async fn connect_sandbox(&self, sandbox_id: &str, timeout: i32) -> AppResult<Sandbox> {
@@ -265,7 +275,14 @@ impl SandboxService {
             d = self.fetch_sandbox_detail(sandbox_id).await?;
         }
 
-        Ok(self.sandbox_response(d.template_id, sandbox_id.to_string(), d.host_id, None))
+        let envd_version = envd_version_from_annotations(&d.annotations);
+        Ok(self.sandbox_response(
+            d.template_id,
+            sandbox_id.to_string(),
+            d.host_id,
+            envd_version,
+            None,
+        ))
     }
 
     pub async fn get_logs(
@@ -456,6 +473,7 @@ impl SandboxService {
         template_id: String,
         sandbox_id: String,
         client_id: String,
+        envd_version: String,
         traffic_access_token: Option<String>,
     ) -> Sandbox {
         Sandbox {
@@ -463,7 +481,7 @@ impl SandboxService {
             sandbox_id,
             alias: None,
             client_id,
-            envd_version: ENVD_VERSION.to_string(),
+            envd_version,
             envd_access_token: None,
             // Empty string from CubeMaster (publicly reachable sandbox) is
             // normalized to None so the JSON field is omitted on the wire.
@@ -575,11 +593,24 @@ fn ensure_update_result(
     Err(AppError::Internal(anyhow::anyhow!(ret_msg)))
 }
 
+/// Resolve the reported `envdVersion` from a sandbox/template annotation map,
+/// falling back to the conservative default when the annotation is absent or
+/// blank (e.g. legacy templates created before version collection existed).
+pub(crate) fn envd_version_from_annotations(annotations: &HashMap<String, String>) -> String {
+    annotations
+        .get(ENVD_VERSION_ANNOTATION)
+        .map(|v| v.trim())
+        .filter(|v| !v.is_empty())
+        .map(|v| v.to_string())
+        .unwrap_or_else(|| ENVD_VERSION_FALLBACK.to_string())
+}
+
 pub(crate) fn from_cubemaster_info(s: SandboxInfo) -> crate::models::ListedSandbox {
     use crate::models::ListedSandbox;
 
     let now = chrono::Utc::now();
     let template_id = extract_template_id(&s.template_id, &s.annotations, &s.labels);
+    let envd_version = envd_version_from_annotations(&s.annotations);
 
     // Prefer explicit started_at; fall back to create_at (Unix nanos from Cubelet); last resort: now
     let started_at = s
@@ -599,7 +630,7 @@ pub(crate) fn from_cubemaster_info(s: SandboxInfo) -> crate::models::ListedSandb
         disk_size_mb: Some(0),
         metadata: optional_metadata(s.labels),
         state: sandbox_state_from_str(&s.status),
-        envd_version: ENVD_VERSION.to_string(),
+        envd_version,
         volume_mounts: None,
     }
 }
@@ -1038,7 +1069,7 @@ mod tests {
     /// covers each meaningful combination.
     #[test]
     fn lifecycle_object_translates_to_cubemaster_bools() {
-        use crate::models::{NewSandbox, SandboxLifecycleConfig, SandboxOnTimeout};
+        use crate::models::{NewSandbox, SandboxOnTimeout};
 
         // Helper that mimics services::create_sandbox's lifecycle decoding.
         fn translate(body: &NewSandbox) -> (bool, bool) {

--- a/CubeMaster/api/services/cubebox/v1/cubebox.pb.go
+++ b/CubeMaster/api/services/cubebox/v1/cubebox.pb.go
@@ -4351,6 +4351,8 @@ type AppSnapshotResponse struct {
 	AgentVersion string `protobuf:"bytes,12,opt,name=agent_version,json=agentVersion,proto3" json:"agent_version,omitempty"`
 	// Guest kernel artifact identity bound when this snapshot was created.
 	KernelVersion string `protobuf:"bytes,13,opt,name=kernel_version,json=kernelVersion,proto3" json:"kernel_version,omitempty"`
+	// envd semantic version collected in-guest at snapshot time (best-effort).
+	EnvdVersion   string `protobuf:"bytes,14,opt,name=envd_version,json=envdVersion,proto3" json:"envd_version,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -4476,6 +4478,13 @@ func (x *AppSnapshotResponse) GetKernelVersion() string {
 	return ""
 }
 
+func (x *AppSnapshotResponse) GetEnvdVersion() string {
+	if x != nil {
+		return x.EnvdVersion
+	}
+	return ""
+}
+
 type CommitSandboxRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// requestID reqID
@@ -4580,6 +4589,8 @@ type CommitSandboxResponse struct {
 	AgentVersion string `protobuf:"bytes,14,opt,name=agent_version,json=agentVersion,proto3" json:"agent_version,omitempty"`
 	// Guest kernel artifact identity bound when this snapshot was created.
 	KernelVersion string `protobuf:"bytes,15,opt,name=kernel_version,json=kernelVersion,proto3" json:"kernel_version,omitempty"`
+	// envd semantic version collected in-guest at commit time (best-effort).
+	EnvdVersion   string `protobuf:"bytes,16,opt,name=envd_version,json=envdVersion,proto3" json:"envd_version,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -4715,6 +4726,13 @@ func (x *CommitSandboxResponse) GetAgentVersion() string {
 func (x *CommitSandboxResponse) GetKernelVersion() string {
 	if x != nil {
 		return x.KernelVersion
+	}
+	return ""
+}
+
+func (x *CommitSandboxResponse) GetEnvdVersion() string {
+	if x != nil {
+		return x.EnvdVersion
 	}
 	return ""
 }
@@ -6769,7 +6787,7 @@ const file_api_services_cubebox_v1_cubebox_proto_rawDesc = "" +
 	"\x03ret\x18\x02 \x01(\v2\".cubelet.services.errorcode.v1.RetR\x03ret\"\x92\x01\n" +
 	"\x12AppSnapshotRequest\x12Y\n" +
 	"\x0ecreate_request\x18\x01 \x01(\v22.cubelet.services.cubebox.v1.RunCubeSandboxRequestR\rcreateRequest\x12!\n" +
-	"\fsnapshot_dir\x18\x02 \x01(\tR\vsnapshotDir\"\xf3\x03\n" +
+	"\fsnapshot_dir\x18\x02 \x01(\tR\vsnapshotDir\"\x96\x04\n" +
 	"\x13AppSnapshotResponse\x12\x1c\n" +
 	"\trequestID\x18\x01 \x01(\tR\trequestID\x124\n" +
 	"\x03ret\x18\x02 \x01(\v2\".cubelet.services.errorcode.v1.RetR\x03ret\x12\x1c\n" +
@@ -6790,14 +6808,15 @@ const file_api_services_cubebox_v1_cubebox_proto_rawDesc = "" +
 	" \x01(\x04R\x0frootfsSizeBytes\x12.\n" +
 	"\x13guest_image_version\x18\v \x01(\tR\x11guestImageVersion\x12#\n" +
 	"\ragent_version\x18\f \x01(\tR\fagentVersion\x12%\n" +
-	"\x0ekernel_version\x18\r \x01(\tR\rkernelVersion\"\x95\x01\n" +
+	"\x0ekernel_version\x18\r \x01(\tR\rkernelVersion\x12!\n" +
+	"\fenvd_version\x18\x0e \x01(\tR\venvdVersion\"\x95\x01\n" +
 	"\x14CommitSandboxRequest\x12\x1c\n" +
 	"\trequestID\x18\x01 \x01(\tR\trequestID\x12\x1c\n" +
 	"\tsandboxID\x18\x02 \x01(\tR\tsandboxID\x12\x1e\n" +
 	"\n" +
 	"templateID\x18\x03 \x01(\tR\n" +
 	"templateID\x12!\n" +
-	"\fsnapshot_dir\x18\x04 \x01(\tR\vsnapshotDir\"\xb3\x04\n" +
+	"\fsnapshot_dir\x18\x04 \x01(\tR\vsnapshotDir\"\xd6\x04\n" +
 	"\x15CommitSandboxResponse\x12\x1c\n" +
 	"\trequestID\x18\x01 \x01(\tR\trequestID\x124\n" +
 	"\x03ret\x18\x02 \x01(\v2\".cubelet.services.errorcode.v1.RetR\x03ret\x12\x1c\n" +
@@ -6822,7 +6841,8 @@ const file_api_services_cubebox_v1_cubebox_proto_rawDesc = "" +
 	"\x11rootfs_size_bytes\x18\f \x01(\x04R\x0frootfsSizeBytes\x12.\n" +
 	"\x13guest_image_version\x18\r \x01(\tR\x11guestImageVersion\x12#\n" +
 	"\ragent_version\x18\x0e \x01(\tR\fagentVersion\x12%\n" +
-	"\x0ekernel_version\x18\x0f \x01(\tR\rkernelVersion\"\x89\x02\n" +
+	"\x0ekernel_version\x18\x0f \x01(\tR\rkernelVersion\x12!\n" +
+	"\fenvd_version\x18\x10 \x01(\tR\venvdVersion\"\x89\x02\n" +
 	"\x16RollbackSandboxRequest\x12\x1c\n" +
 	"\trequestID\x18\x01 \x01(\tR\trequestID\x12\x1c\n" +
 	"\tsandboxID\x18\x02 \x01(\tR\tsandboxID\x12\x1e\n" +

--- a/CubeMaster/api/services/cubebox/v1/cubebox.proto
+++ b/CubeMaster/api/services/cubebox/v1/cubebox.proto
@@ -830,6 +830,8 @@ message AppSnapshotResponse {
   string agent_version = 12;
   // Guest kernel artifact identity bound when this snapshot was created.
   string kernel_version = 13;
+  // envd semantic version collected in-guest at snapshot time (best-effort).
+  string envd_version = 14;
 }
 
 message CommitSandboxRequest {
@@ -874,6 +876,8 @@ message CommitSandboxResponse {
   string agent_version = 14;
   // Guest kernel artifact identity bound when this snapshot was created.
   string kernel_version = 15;
+  // envd semantic version collected in-guest at commit time (best-effort).
+  string envd_version = 16;
 }
 
 message RollbackSandboxRequest {

--- a/CubeMaster/pkg/base/constants/constants.go
+++ b/CubeMaster/pkg/base/constants/constants.go
@@ -80,6 +80,13 @@ const (
 	CubeAnnotationTemplateSpecFingerprint    = "cube.master.template.spec_fingerprint"
 
 	CubeAnnotationsVirtiofsCache = "cube.master.virtiofs.cache"
+
+	// CubeAnnotationComponentsPrefix is the namespace for pre-installed
+	// runtime-component metadata carried on templates/sandboxes.
+	CubeAnnotationComponentsPrefix = "cube.master.components."
+	// CubeAnnotationComponentEnvdVersion carries the real envd semantic version
+	// collected at template-creation time and propagated to sandbox instances.
+	CubeAnnotationComponentEnvdVersion = "cube.master.components.envd.version"
 )
 const (
 	CubeAnnotationsUseNetFileCache = "cube.instance.use_netfile_cache"

--- a/CubeMaster/pkg/service/httpservice/cube/cubeboxutil.go
+++ b/CubeMaster/pkg/service/httpservice/cube/cubeboxutil.go
@@ -254,6 +254,12 @@ func applyTemplateAnnotationsAndLabels(reqIn *types.CreateCubeSandboxReq, reqOut
 		}
 		maps.Copy(reqOut.Labels, reqIn.Labels)
 	}
+	if v := strings.TrimSpace(reqOut.Annotations[constants.CubeAnnotationComponentEnvdVersion]); v != "" {
+		if reqOut.Labels == nil {
+			reqOut.Labels = make(map[string]string)
+		}
+		reqOut.Labels[constants.CubeAnnotationComponentEnvdVersion] = v
+	}
 }
 
 func mergeCubeNetworkConfigs(templateCfg *types.CubeNetworkConfig, requestCfg *types.CubeNetworkConfig) *types.CubeNetworkConfig {

--- a/CubeMaster/pkg/service/httpservice/cube/sandbox_create.go
+++ b/CubeMaster/pkg/service/httpservice/cube/sandbox_create.go
@@ -83,6 +83,15 @@ func createSandbox(w http.ResponseWriter, r *http.Request, rt *CubeLog.RequestTr
 		if err := registerCreatedSandboxRuntimeRef(ctx, req, ret); err != nil {
 			log.G(ctx).Warnf("register snapshot runtime ref after create failed: %v", err)
 		}
+		// Echo the envd version (propagated from the template annotation onto the
+		// create request) back to the caller via the existing ext_info map, so
+		// CubeAPI can surface it without an extra round-trip. Success branch only.
+		if v := strings.TrimSpace(req.Annotations[constants.CubeAnnotationComponentEnvdVersion]); v != "" {
+			if ret.ExtInfo == nil {
+				ret.ExtInfo = make(map[string]string)
+			}
+			ret.ExtInfo[constants.CubeAnnotationComponentEnvdVersion] = v
+		}
 	}
 	rt.RetCode = int64(ret.Ret.RetCode)
 	return ret

--- a/CubeMaster/pkg/service/sandbox/template_identity.go
+++ b/CubeMaster/pkg/service/sandbox/template_identity.go
@@ -16,6 +16,7 @@ import "github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/constants"
 var runtimeSnapshotAnnotationKeys = []string{
 	constants.CubeAnnotationRuntimeSnapshotID,
 	constants.CubeAnnotationRuntimeSnapshotAttachedAt,
+	constants.CubeAnnotationComponentEnvdVersion,
 }
 
 func cloneStringMap(in map[string]string) map[string]string {

--- a/CubeMaster/pkg/templatecenter/snapshot_ops.go
+++ b/CubeMaster/pkg/templatecenter/snapshot_ops.go
@@ -322,6 +322,13 @@ func runSnapshotCreateJob(ctx context.Context, jobID, sandboxID, nodeID, nodeIP 
 	}); err != nil {
 		return failSnapshotCreateJob(ctx, jobID, snapshotID, nodeIP, snapshotPath, commitRsp, err)
 	}
+	// Commit yields a single authoritative envd version; persist it (best-effort)
+	// to the snapshot definition annotation so created sandboxes inherit it.
+	if envdVersion := sanitizeEnvdVersion(commitRsp.GetEnvdVersion()); envdVersion != "" {
+		if err := persistTemplateEnvdVersion(ctx, snapshotID, envdVersion); err != nil {
+			logger.Warnf("persist snapshot envd version fail, snapshot=%s err=%v", snapshotID, err)
+		}
+	}
 	resultPayload, _ := json.Marshal(map[string]any{
 		"snapshot_path":     snapshotPath,
 		"rootfs_vol":        commitRsp.GetRootfsVol(),

--- a/CubeMaster/pkg/templatecenter/store.go
+++ b/CubeMaster/pkg/templatecenter/store.go
@@ -132,10 +132,6 @@ type ReplicaStatus struct {
 	GuestImageVersion string `json:"guest_image_version,omitempty"`
 	AgentVersion      string `json:"agent_version,omitempty"`
 	KernelVersion     string `json:"kernel_version,omitempty"`
-	// EnvdVersion is a transient per-node collection result. It is NOT persisted
-	// to the replica row; the template-level value is converged and written once
-	// to the definition annotation (see createTemplateReplicasOnNodes).
-	EnvdVersion       string `json:"envd_version,omitempty"`
 	CompatStatus      string `json:"compat_status,omitempty"`
 	CompatPolicy      string `json:"compat_policy,omitempty"`
 	CompatCheckedUnix int64  `json:"compat_checked_unix,omitempty"`
@@ -460,6 +456,7 @@ func healthyTemplateNodes(instanceType string) []*node.Node {
 
 func createTemplateReplicasOnNodes(ctx context.Context, templateID string, req *sandboxtypes.CreateCubeSandboxReq, targets []*node.Node, opts replicaRunOptions) ([]ReplicaStatus, error) {
 	replicas := make([]ReplicaStatus, 0, len(targets))
+	envdVersions := make([]nodeEnvdVersion, 0, len(targets))
 	var lock sync.Mutex
 	var persistErr error
 	sem := make(chan struct{}, 4)
@@ -476,9 +473,13 @@ func createTemplateReplicasOnNodes(ctx context.Context, templateID string, req *
 			sem <- struct{}{}
 			defer func() { <-sem }()
 
-			replica := createReplicaOnNode(ctx, target, req, opts)
+			replica, envdVersion := createReplicaOnNode(ctx, target, req, opts)
 			lock.Lock()
 			replicas = append(replicas, replica)
+			envdVersions = append(envdVersions, nodeEnvdVersion{
+				NodeID:  target.ID(),
+				Version: envdVersion,
+			})
 			lock.Unlock()
 
 			if upsertErr := UpsertReplica(ctx, templateID, req.InstanceType, replica); upsertErr != nil {
@@ -492,7 +493,7 @@ func createTemplateReplicasOnNodes(ctx context.Context, templateID string, req *
 	wg.Wait()
 	// Converge per-node envd versions into a single template value and persist it
 	// once to the definition annotation (idempotent; covers create and redo).
-	if envdVersion := convergeEnvdVersion(ctx, replicas); envdVersion != "" {
+	if envdVersion := convergeEnvdVersion(ctx, envdVersions); envdVersion != "" {
 		if err := persistTemplateEnvdVersion(ctx, templateID, envdVersion); err != nil {
 			log.G(ctx).Warnf("persist template envd version fail, template=%s err=%v", templateID, err)
 		}
@@ -500,13 +501,18 @@ func createTemplateReplicasOnNodes(ctx context.Context, templateID string, req *
 	return replicas, persistErr
 }
 
+type nodeEnvdVersion struct {
+	NodeID  string
+	Version string
+}
+
 // convergeEnvdVersion picks a single template-level envd version from the
-// per-node replica results: the first valid semver wins, and any divergence
+// per-node collection results: the first valid semver wins, and any divergence
 // across nodes is logged but not treated as an error.
-func convergeEnvdVersion(ctx context.Context, replicas []ReplicaStatus) string {
+func convergeEnvdVersion(ctx context.Context, versions []nodeEnvdVersion) string {
 	chosen := ""
-	for _, replica := range replicas {
-		v := sanitizeEnvdVersion(replica.EnvdVersion)
+	for _, item := range versions {
+		v := sanitizeEnvdVersion(item.Version)
 		if v == "" {
 			continue
 		}
@@ -515,7 +521,7 @@ func convergeEnvdVersion(ctx context.Context, replicas []ReplicaStatus) string {
 			continue
 		}
 		if v != chosen {
-			log.G(ctx).Warnf("envd version mismatch across nodes: keeping=%s saw=%s", chosen, v)
+			log.G(ctx).Warnf("envd version mismatch across nodes: keeping=%s saw=%s node=%s", chosen, v, item.NodeID)
 		}
 	}
 	return chosen
@@ -562,7 +568,7 @@ func persistTemplateEnvdVersion(ctx context.Context, templateID, version string)
 	})
 }
 
-func createReplicaOnNode(ctx context.Context, target *node.Node, req *sandboxtypes.CreateCubeSandboxReq, opts replicaRunOptions) ReplicaStatus {
+func createReplicaOnNode(ctx context.Context, target *node.Node, req *sandboxtypes.CreateCubeSandboxReq, opts replicaRunOptions) (ReplicaStatus, string) {
 	replica := ReplicaStatus{
 		NodeID:          target.ID(),
 		NodeIP:          target.HostIP(),
@@ -579,14 +585,14 @@ func createReplicaOnNode(ctx context.Context, target *node.Node, req *sandboxtyp
 	if err != nil {
 		replica.Phase = ReplicaPhaseFailed
 		replica.ErrorMessage = err.Error()
-		return replica
+		return replica, ""
 	}
 	ensureRuntimeTemplateRequest(nodeReq)
 	cubeletReq, err := sandbox.ConstructCubeletReq(ctx, nodeReq)
 	if err != nil {
 		replica.Phase = ReplicaPhaseFailed
 		replica.ErrorMessage = err.Error()
-		return replica
+		return replica, ""
 	}
 	rsp, err := cubelet.AppSnapshot(ctx, cubelet.GetCubeletAddr(target.HostIP()), &cubeboxv1.AppSnapshotRequest{
 		CreateRequest: cubeletReq,
@@ -595,7 +601,7 @@ func createReplicaOnNode(ctx context.Context, target *node.Node, req *sandboxtyp
 	if err != nil {
 		replica.Phase = ReplicaPhaseFailed
 		replica.ErrorMessage = err.Error()
-		return replica
+		return replica, ""
 	}
 	if rsp.GetRet() == nil || int(rsp.GetRet().GetRetCode()) != int(errorcode.ErrorCode_Success) {
 		replica.Phase = ReplicaPhaseFailed
@@ -604,14 +610,12 @@ func createReplicaOnNode(ctx context.Context, target *node.Node, req *sandboxtyp
 		} else {
 			replica.ErrorMessage = "empty appsnapshot response"
 		}
-		return replica
+		return replica, ""
 	}
 	replica.Status = ReplicaStatusReady
 	replica.Phase = ReplicaPhaseReady
 	bindGuestVersionToReplica(&replica, rsp.GetGuestImageVersion(), rsp.GetAgentVersion(), rsp.GetKernelVersion())
-	// Stash the per-node envd version in-memory only; convergence + the single
-	// definition write happen in createTemplateReplicasOnNodes after wg.Wait().
-	replica.EnvdVersion = sanitizeEnvdVersion(rsp.GetEnvdVersion())
+	envdVersion := sanitizeEnvdVersion(rsp.GetEnvdVersion())
 	// v4: AppSnapshot replica is "thin" -- physical refs are owned by cubelet's
 	// local catalog. Master only persists control-plane state (status / phase /
 	// last job / error) so we deliberately ignore SnapshotPath/RootfsVol/
@@ -619,7 +623,7 @@ func createReplicaOnNode(ctx context.Context, target *node.Node, req *sandboxtyp
 	replica.LastErrorPhase = ""
 	replica.CleanupRequired = false
 	replica.ErrorMessage = ""
-	return replica
+	return replica, envdVersion
 }
 
 func summarizeStatus(replicas []ReplicaStatus) (status string, lastError string) {

--- a/CubeMaster/pkg/templatecenter/store.go
+++ b/CubeMaster/pkg/templatecenter/store.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"regexp"
 	"sort"
 	"strings"
 	"sync"
@@ -131,6 +132,10 @@ type ReplicaStatus struct {
 	GuestImageVersion string `json:"guest_image_version,omitempty"`
 	AgentVersion      string `json:"agent_version,omitempty"`
 	KernelVersion     string `json:"kernel_version,omitempty"`
+	// EnvdVersion is a transient per-node collection result. It is NOT persisted
+	// to the replica row; the template-level value is converged and written once
+	// to the definition annotation (see createTemplateReplicasOnNodes).
+	EnvdVersion       string `json:"envd_version,omitempty"`
 	CompatStatus      string `json:"compat_status,omitempty"`
 	CompatPolicy      string `json:"compat_policy,omitempty"`
 	CompatCheckedUnix int64  `json:"compat_checked_unix,omitempty"`
@@ -485,7 +490,76 @@ func createTemplateReplicasOnNodes(ctx context.Context, templateID string, req *
 		}()
 	}
 	wg.Wait()
+	// Converge per-node envd versions into a single template value and persist it
+	// once to the definition annotation (idempotent; covers create and redo).
+	if envdVersion := convergeEnvdVersion(ctx, replicas); envdVersion != "" {
+		if err := persistTemplateEnvdVersion(ctx, templateID, envdVersion); err != nil {
+			log.G(ctx).Warnf("persist template envd version fail, template=%s err=%v", templateID, err)
+		}
+	}
 	return replicas, persistErr
+}
+
+// convergeEnvdVersion picks a single template-level envd version from the
+// per-node replica results: the first valid semver wins, and any divergence
+// across nodes is logged but not treated as an error.
+func convergeEnvdVersion(ctx context.Context, replicas []ReplicaStatus) string {
+	chosen := ""
+	for _, replica := range replicas {
+		v := sanitizeEnvdVersion(replica.EnvdVersion)
+		if v == "" {
+			continue
+		}
+		if chosen == "" {
+			chosen = v
+			continue
+		}
+		if v != chosen {
+			log.G(ctx).Warnf("envd version mismatch across nodes: keeping=%s saw=%s", chosen, v)
+		}
+	}
+	return chosen
+}
+
+// persistTemplateEnvdVersion writes the converged envd version into the template
+// definition's request_json annotation exactly once (read-modify-write), then
+// invalidates the cached request so new sandboxes inherit the annotation. It is
+// idempotent: a no-op when the annotation already holds the same value.
+func persistTemplateEnvdVersion(ctx context.Context, templateID, version string) error {
+	version = sanitizeEnvdVersion(version)
+	if templateID == "" || version == "" {
+		return nil
+	}
+	// Serialize the request_json read-modify-write against concurrent template
+	// request reads/writes for the same template to avoid a lost update.
+	return withTemplateWriteLock(templateID, func() error {
+		def, err := GetDefinition(ctx, templateID)
+		if err != nil {
+			return err
+		}
+		req := &sandboxtypes.CreateCubeSandboxReq{}
+		if err := json.Unmarshal([]byte(def.RequestJSON), req); err != nil {
+			return err
+		}
+		if req.Annotations == nil {
+			req.Annotations = make(map[string]string)
+		}
+		if req.Annotations[constants.CubeAnnotationComponentEnvdVersion] == version {
+			return nil
+		}
+		req.Annotations[constants.CubeAnnotationComponentEnvdVersion] = version
+		payload, err := json.Marshal(req)
+		if err != nil {
+			return err
+		}
+		if err := updateDefinitionFields(ctx, templateID, map[string]any{"request_json": string(payload)}); err != nil {
+			return err
+		}
+		// Drop the stale cache entry so the next GetTemplateRequest reloads the
+		// definition (now carrying the envd annotation) from the database.
+		templateDefinitionCache.Delete(templateID)
+		return nil
+	})
 }
 
 func createReplicaOnNode(ctx context.Context, target *node.Node, req *sandboxtypes.CreateCubeSandboxReq, opts replicaRunOptions) ReplicaStatus {
@@ -535,6 +609,9 @@ func createReplicaOnNode(ctx context.Context, target *node.Node, req *sandboxtyp
 	replica.Status = ReplicaStatusReady
 	replica.Phase = ReplicaPhaseReady
 	bindGuestVersionToReplica(&replica, rsp.GetGuestImageVersion(), rsp.GetAgentVersion(), rsp.GetKernelVersion())
+	// Stash the per-node envd version in-memory only; convergence + the single
+	// definition write happen in createTemplateReplicasOnNodes after wg.Wait().
+	replica.EnvdVersion = sanitizeEnvdVersion(rsp.GetEnvdVersion())
 	// v4: AppSnapshot replica is "thin" -- physical refs are owned by cubelet's
 	// local catalog. Master only persists control-plane state (status / phase /
 	// last job / error) so we deliberately ignore SnapshotPath/RootfsVol/
@@ -869,6 +946,18 @@ func normalizeComponentVersion(value string) string {
 		return ""
 	}
 	return value
+}
+
+// envdSemverRe matches a major.minor.patch semantic version anywhere in the
+// input; the captured group is the version we keep.
+var envdSemverRe = regexp.MustCompile(`\d+\.\d+\.\d+`)
+
+// sanitizeEnvdVersion validates an envd version reported by the collection side
+// and returns the extracted semver, or "" when absent/malformed. This is a
+// defense-in-depth check on top of the cubelet-side validation, run before the
+// value is persisted into a template annotation.
+func sanitizeEnvdVersion(value string) string {
+	return envdSemverRe.FindString(strings.TrimSpace(value))
 }
 
 func normalizeCompatStatus(status string) string {

--- a/CubeMaster/pkg/templatecenter/store_test.go
+++ b/CubeMaster/pkg/templatecenter/store_test.go
@@ -62,6 +62,16 @@ func TestNormalizeStoredTemplateRequestStripsPhysicalAnnotations(t *testing.T) {
 	assert.Empty(t, out.SnapshotDir)
 }
 
+func TestConvergeEnvdVersionUsesNodeCollectionResults(t *testing.T) {
+	got := convergeEnvdVersion(context.Background(), []nodeEnvdVersion{
+		{NodeID: "node-a", Version: ""},
+		{NodeID: "node-b", Version: "envd version 0.5.11"},
+		{NodeID: "node-c", Version: "0.6.0"},
+	})
+
+	assert.Equal(t, "0.5.11", got)
+}
+
 func TestResolveTemplateNodesFiltersRequestedHealthyNodes(t *testing.T) {
 	patches := gomonkey.NewPatches()
 	defer patches.Reset()

--- a/CubeShim/shim/src/service/task_srv.rs
+++ b/CubeShim/shim/src/service/task_srv.rs
@@ -30,6 +30,7 @@ use std::time::Instant;
 use tokio::sync::mpsc::{channel, Receiver, Sender};
 use tokio::sync::Mutex;
 const MODULE: &str = "Shim";
+const INTERNAL_PROBE_EXEC_ID_PREFIX: &str = "cubesandbox-internal-probe-";
 
 #[derive(Clone)]
 pub struct TaskService {
@@ -510,7 +511,7 @@ impl Task for TaskService {
             req.exec_id()
         );
         let sb = self.sandbox.lock().await;
-        if sb.app_snapshot_create() {
+        if sb.app_snapshot_create() && !is_internal_probe_exec_id(req.exec_id()) {
             infof!(self.log, "exec disabled while app snapshotting");
             return Err(Others("exec disabled while app snapshotting".to_string()));
         }
@@ -622,6 +623,26 @@ impl Task for TaskService {
         })?;
         infof!(self.log, "resume req finish");
         Ok(api::Empty::default())
+    }
+}
+
+fn is_internal_probe_exec_id(exec_id: &str) -> bool {
+    exec_id.starts_with(INTERNAL_PROBE_EXEC_ID_PREFIX)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn internal_probe_exec_requires_exec_id_prefix() {
+        assert!(is_internal_probe_exec_id(
+            "cubesandbox-internal-probe-4e7d6a"
+        ));
+        assert!(!is_internal_probe_exec_id("internal-probe-4e7d6a"));
+        assert!(!is_internal_probe_exec_id(
+            "user-cubesandbox-internal-probe-4e7d6a"
+        ));
     }
 }
 

--- a/Cubelet/api/services/cubebox/v1/cubebox.pb.go
+++ b/Cubelet/api/services/cubebox/v1/cubebox.pb.go
@@ -4351,6 +4351,8 @@ type AppSnapshotResponse struct {
 	AgentVersion string `protobuf:"bytes,12,opt,name=agent_version,json=agentVersion,proto3" json:"agent_version,omitempty"`
 	// Guest kernel artifact identity bound when this snapshot was created.
 	KernelVersion string `protobuf:"bytes,13,opt,name=kernel_version,json=kernelVersion,proto3" json:"kernel_version,omitempty"`
+	// envd semantic version collected in-guest at snapshot time (best-effort).
+	EnvdVersion   string `protobuf:"bytes,14,opt,name=envd_version,json=envdVersion,proto3" json:"envd_version,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -4476,6 +4478,13 @@ func (x *AppSnapshotResponse) GetKernelVersion() string {
 	return ""
 }
 
+func (x *AppSnapshotResponse) GetEnvdVersion() string {
+	if x != nil {
+		return x.EnvdVersion
+	}
+	return ""
+}
+
 type CommitSandboxRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// requestID reqID
@@ -4580,6 +4589,8 @@ type CommitSandboxResponse struct {
 	AgentVersion string `protobuf:"bytes,14,opt,name=agent_version,json=agentVersion,proto3" json:"agent_version,omitempty"`
 	// Guest kernel artifact identity bound when this snapshot was created.
 	KernelVersion string `protobuf:"bytes,15,opt,name=kernel_version,json=kernelVersion,proto3" json:"kernel_version,omitempty"`
+	// envd semantic version collected in-guest at commit time (best-effort).
+	EnvdVersion   string `protobuf:"bytes,16,opt,name=envd_version,json=envdVersion,proto3" json:"envd_version,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -4715,6 +4726,13 @@ func (x *CommitSandboxResponse) GetAgentVersion() string {
 func (x *CommitSandboxResponse) GetKernelVersion() string {
 	if x != nil {
 		return x.KernelVersion
+	}
+	return ""
+}
+
+func (x *CommitSandboxResponse) GetEnvdVersion() string {
+	if x != nil {
+		return x.EnvdVersion
 	}
 	return ""
 }
@@ -6797,7 +6815,7 @@ const file_api_services_cubebox_v1_cubebox_proto_rawDesc = "" +
 	"\x03ret\x18\x02 \x01(\v2\".cubelet.services.errorcode.v1.RetR\x03ret\"\x92\x01\n" +
 	"\x12AppSnapshotRequest\x12Y\n" +
 	"\x0ecreate_request\x18\x01 \x01(\v22.cubelet.services.cubebox.v1.RunCubeSandboxRequestR\rcreateRequest\x12!\n" +
-	"\fsnapshot_dir\x18\x02 \x01(\tR\vsnapshotDir\"\xf3\x03\n" +
+	"\fsnapshot_dir\x18\x02 \x01(\tR\vsnapshotDir\"\x96\x04\n" +
 	"\x13AppSnapshotResponse\x12\x1c\n" +
 	"\trequestID\x18\x01 \x01(\tR\trequestID\x124\n" +
 	"\x03ret\x18\x02 \x01(\v2\".cubelet.services.errorcode.v1.RetR\x03ret\x12\x1c\n" +
@@ -6818,14 +6836,15 @@ const file_api_services_cubebox_v1_cubebox_proto_rawDesc = "" +
 	" \x01(\x04R\x0frootfsSizeBytes\x12.\n" +
 	"\x13guest_image_version\x18\v \x01(\tR\x11guestImageVersion\x12#\n" +
 	"\ragent_version\x18\f \x01(\tR\fagentVersion\x12%\n" +
-	"\x0ekernel_version\x18\r \x01(\tR\rkernelVersion\"\x95\x01\n" +
+	"\x0ekernel_version\x18\r \x01(\tR\rkernelVersion\x12!\n" +
+	"\fenvd_version\x18\x0e \x01(\tR\venvdVersion\"\x95\x01\n" +
 	"\x14CommitSandboxRequest\x12\x1c\n" +
 	"\trequestID\x18\x01 \x01(\tR\trequestID\x12\x1c\n" +
 	"\tsandboxID\x18\x02 \x01(\tR\tsandboxID\x12\x1e\n" +
 	"\n" +
 	"templateID\x18\x03 \x01(\tR\n" +
 	"templateID\x12!\n" +
-	"\fsnapshot_dir\x18\x04 \x01(\tR\vsnapshotDir\"\xb3\x04\n" +
+	"\fsnapshot_dir\x18\x04 \x01(\tR\vsnapshotDir\"\xd6\x04\n" +
 	"\x15CommitSandboxResponse\x12\x1c\n" +
 	"\trequestID\x18\x01 \x01(\tR\trequestID\x124\n" +
 	"\x03ret\x18\x02 \x01(\v2\".cubelet.services.errorcode.v1.RetR\x03ret\x12\x1c\n" +
@@ -6850,7 +6869,8 @@ const file_api_services_cubebox_v1_cubebox_proto_rawDesc = "" +
 	"\x11rootfs_size_bytes\x18\f \x01(\x04R\x0frootfsSizeBytes\x12.\n" +
 	"\x13guest_image_version\x18\r \x01(\tR\x11guestImageVersion\x12#\n" +
 	"\ragent_version\x18\x0e \x01(\tR\fagentVersion\x12%\n" +
-	"\x0ekernel_version\x18\x0f \x01(\tR\rkernelVersion\"\x89\x02\n" +
+	"\x0ekernel_version\x18\x0f \x01(\tR\rkernelVersion\x12!\n" +
+	"\fenvd_version\x18\x10 \x01(\tR\venvdVersion\"\x89\x02\n" +
 	"\x16RollbackSandboxRequest\x12\x1c\n" +
 	"\trequestID\x18\x01 \x01(\tR\trequestID\x12\x1c\n" +
 	"\tsandboxID\x18\x02 \x01(\tR\tsandboxID\x12\x1e\n" +

--- a/Cubelet/api/services/cubebox/v1/cubebox.proto
+++ b/Cubelet/api/services/cubebox/v1/cubebox.proto
@@ -830,6 +830,8 @@ message AppSnapshotResponse {
   string agent_version = 12;
   // Guest kernel artifact identity bound when this snapshot was created.
   string kernel_version = 13;
+  // envd semantic version collected in-guest at snapshot time (best-effort).
+  string envd_version = 14;
 }
 
 message CommitSandboxRequest {
@@ -874,6 +876,8 @@ message CommitSandboxResponse {
   string agent_version = 14;
   // Guest kernel artifact identity bound when this snapshot was created.
   string kernel_version = 15;
+  // envd semantic version collected in-guest at commit time (best-effort).
+  string envd_version = 16;
 }
 
 message RollbackSandboxRequest {

--- a/Cubelet/doc/cubelet-api.md
+++ b/Cubelet/doc/cubelet-api.md
@@ -243,6 +243,7 @@ AppSnapshotResponse is the response for app snapshot creation.
 | guest_image_version | [string](#string) |  | guest-image version bound when this snapshot was created. |
 | agent_version | [string](#string) |  | cube-agent version bound when this snapshot was created. |
 | kernel_version | [string](#string) |  | Guest kernel artifact identity bound when this snapshot was created. |
+| envd_version | [string](#string) |  | envd semantic version collected in-guest at snapshot time (best-effort). |
 
 
 
@@ -392,6 +393,7 @@ Capability contains the container capabilities to add or drop
 | guest_image_version | [string](#string) |  | guest-image version bound when this snapshot was created. |
 | agent_version | [string](#string) |  | cube-agent version bound when this snapshot was created. |
 | kernel_version | [string](#string) |  | Guest kernel artifact identity bound when this snapshot was created. |
+| envd_version | [string](#string) |  | envd semantic version collected in-guest at commit time (best-effort). |
 
 
 

--- a/Cubelet/services/cubebox/appsnapshot.go
+++ b/Cubelet/services/cubebox/appsnapshot.go
@@ -276,6 +276,10 @@ func (s *service) AppSnapshot(ctx context.Context, req *cubebox.AppSnapshotReque
 		return rsp, nil
 	}
 
+	// collectEnvdVersion uses containerd Exec, which must run before
+	// cube-runtime marks the guest as app-snapshotting and disables exec.
+	envdVersion := s.collectEnvdVersion(ctx, sandboxID)
+
 	stepLog.Info("Step 4: Executing cube-runtime snapshot...")
 	// AppSnapshot builds a brand-new template from a fresh sandbox: there is
 	// no base memory blob to overlay onto, so we always ask for a full memory
@@ -389,6 +393,7 @@ func (s *service) AppSnapshot(ctx context.Context, req *cubebox.AppSnapshotReque
 	rsp.GuestImageVersion = versions.GuestImage
 	rsp.AgentVersion = versions.Agent
 	rsp.KernelVersion = versions.Kernel
+	rsp.EnvdVersion = envdVersion
 
 	// Persist the catalog entry so subsequent create-from-template and
 	// CleanupTemplate calls can resolve physical refs locally. The build

--- a/Cubelet/services/cubebox/envd_version.go
+++ b/Cubelet/services/cubebox/envd_version.go
@@ -7,6 +7,8 @@ package cubebox
 import (
 	"bytes"
 	"context"
+	"errors"
+	"fmt"
 	"regexp"
 	"sync"
 	"syscall"
@@ -16,6 +18,7 @@ import (
 	"github.com/containerd/containerd/v2/pkg/namespaces"
 	"github.com/google/uuid"
 
+	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/tencentcloud/CubeSandbox/Cubelet/pkg/log"
 )
 
@@ -60,6 +63,70 @@ func (b *boundedBuffer) String() string {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	return b.buf.String()
+}
+
+// parseEnvdVersionFromOutput prefers semver from stdout; falls back to stderr
+// only when stdout has no match (e.g. envd logs warnings to stderr).
+func parseEnvdVersionFromOutput(stdout, stderr string) string {
+	if v := envdSemverRe.FindString(stdout); v != "" {
+		return v
+	}
+	return envdSemverRe.FindString(stderr)
+}
+
+// runProbeCall runs fn in a goroutine so a blocking containerd/shim RPC cannot
+// stall the snapshot/commit path past execCtx's deadline.
+func runProbeCall[T any](ctx context.Context, fn func() (T, error)) (T, error) {
+	type probeResult struct {
+		value T
+		err   error
+	}
+	done := make(chan probeResult, 1)
+	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				var zero T
+				done <- probeResult{value: zero, err: fmt.Errorf("probe panic: %v", r)}
+			}
+		}()
+		v, err := fn()
+		done <- probeResult{value: v, err: err}
+	}()
+	select {
+	case <-ctx.Done():
+		var zero T
+		return zero, ctx.Err()
+	case r := <-done:
+		return r.value, r.err
+	}
+}
+
+func probeCallTimedOut(err error) bool {
+	return errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled)
+}
+
+// killProbeProcess sends SIGKILL and, when statusCh is available, waits for the
+// exec to reap so the deferred Delete does not race a still-running process.
+func killProbeProcess(process containerd.Process, statusCh <-chan containerd.ExitStatus, logger *log.CubeWrapperLogEntry) {
+	_ = process.Kill(context.Background(), syscall.SIGKILL)
+	if statusCh == nil {
+		return
+	}
+	select {
+	case <-statusCh:
+	case <-time.After(envdVersionExecTimeout):
+		logger.Warnf("collect envd version: exec did not reap after kill")
+	}
+}
+
+// abortProbe logs a wait/start failure and best-effort kills the probe process.
+func abortProbe(process containerd.Process, statusCh <-chan containerd.ExitStatus, logger *log.CubeWrapperLogEntry, phase string, err error) {
+	if probeCallTimedOut(err) {
+		logger.Warnf("collect envd version: %s timed out: %v", phase, err)
+	} else {
+		logger.Warnf("collect envd version: %s failed: %v", phase, err)
+	}
+	killProbeProcess(process, statusCh, logger)
 }
 
 // collectEnvdVersion runs `envd --version` inside the running guest of sandboxID
@@ -122,11 +189,18 @@ func (s *service) collectEnvdVersion(ctx context.Context, sandboxID string) (ver
 	pspec.Terminal = true
 	pspec.Args = []string{"envd", "--version"}
 
-	out := &boundedBuffer{limit: envdVersionOutputLimit}
+	stdout := &boundedBuffer{limit: envdVersionOutputLimit}
+	stderr := &boundedBuffer{limit: envdVersionOutputLimit}
 	execID := envdVersionExecIDPrefix + uuid.New().String()
-	process, err := task.Exec(execCtx, execID, pspec, cio.NewCreator(cio.WithStreams(nil, out, out), cio.WithTerminal))
+	process, err := runProbeCall(execCtx, func() (containerd.Process, error) {
+		return task.Exec(execCtx, execID, pspec, cio.NewCreator(cio.WithStreams(nil, stdout, stderr), cio.WithTerminal))
+	})
 	if err != nil {
-		logger.Warnf("collect envd version: exec failed: %v", err)
+		if probeCallTimedOut(err) {
+			logger.Warnf("collect envd version: exec timed out: %v", err)
+		} else {
+			logger.Warnf("collect envd version: exec failed: %v", err)
+		}
 		return ""
 	}
 	defer func() {
@@ -136,26 +210,24 @@ func (s *service) collectEnvdVersion(ctx context.Context, sandboxID string) (ver
 		}
 	}()
 
-	statusCh, err := process.Wait(execCtx)
+	statusCh, err := runProbeCall(execCtx, func() (<-chan containerd.ExitStatus, error) {
+		return process.Wait(execCtx)
+	})
 	if err != nil {
-		logger.Warnf("collect envd version: wait failed: %v", err)
+		abortProbe(process, nil, logger, "wait", err)
 		return ""
 	}
-	if err := process.Start(execCtx); err != nil {
-		logger.Warnf("collect envd version: start failed: %v", err)
+	_, err = runProbeCall(execCtx, func() (struct{}, error) {
+		return struct{}{}, process.Start(execCtx)
+	})
+	if err != nil {
+		abortProbe(process, statusCh, logger, "start", err)
 		return ""
 	}
 
 	select {
 	case <-execCtx.Done():
-		// Kill the exec process and wait for it to reap so the deferred Delete
-		// does not race a still-running process and leak shim resources.
-		_ = process.Kill(context.Background(), syscall.SIGKILL)
-		select {
-		case <-statusCh:
-		case <-time.After(envdVersionExecTimeout):
-			logger.Warnf("collect envd version: exec did not reap after kill")
-		}
+		killProbeProcess(process, statusCh, logger)
 		logger.Warnf("collect envd version: timed out after %s", envdVersionExecTimeout)
 		return ""
 	case status := <-statusCh:
@@ -165,7 +237,7 @@ func (s *service) collectEnvdVersion(ctx context.Context, sandboxID string) (ver
 		}
 	}
 
-	version = envdSemverRe.FindString(out.String())
+	version = parseEnvdVersionFromOutput(stdout.String(), stderr.String())
 	if version == "" {
 		logger.Warnf("collect envd version: no semver in output")
 		return ""

--- a/Cubelet/services/cubebox/envd_version.go
+++ b/Cubelet/services/cubebox/envd_version.go
@@ -1,0 +1,175 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package cubebox
+
+import (
+	"bytes"
+	"context"
+	"regexp"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/containerd/containerd/v2/pkg/cio"
+	"github.com/containerd/containerd/v2/pkg/namespaces"
+	"github.com/google/uuid"
+
+	"github.com/tencentcloud/CubeSandbox/Cubelet/pkg/log"
+)
+
+const (
+	envdVersionExecIDPrefix = "cubesandbox-internal-probe-"
+	// envdVersionExecTimeout caps the in-guest `envd --version` probe so a hung
+	// or unresponsive guest can never stall snapshot/commit.
+	envdVersionExecTimeout = 5 * time.Second
+	// envdVersionOutputLimit bounds the captured stdout/stderr to defend against
+	// an image that floods the probe with output.
+	envdVersionOutputLimit = 4 << 10 // 4 KiB
+)
+
+// envdSemverRe extracts a semantic version (major.minor.patch) from arbitrary
+// `envd --version` output.
+var envdSemverRe = regexp.MustCompile(`\d+\.\d+\.\d+`)
+
+// boundedBuffer is a concurrency-safe io.Writer that retains at most limit bytes
+// and silently discards the rest.
+type boundedBuffer struct {
+	mu    sync.Mutex
+	buf   bytes.Buffer
+	limit int
+}
+
+func (b *boundedBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if remain := b.limit - b.buf.Len(); remain > 0 {
+		if len(p) > remain {
+			b.buf.Write(p[:remain])
+		} else {
+			b.buf.Write(p)
+		}
+	}
+	// Always report a full write so the IO copy loop never blocks/errors once
+	// the cap is reached.
+	return len(p), nil
+}
+
+func (b *boundedBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
+}
+
+// collectEnvdVersion runs `envd --version` inside the running guest of sandboxID
+// via containerd task.Exec and returns the parsed semantic version.
+//
+// It is strictly best-effort: any failure, timeout, non-zero exit, or malformed
+// output yields "" (the caller falls back to a default) and a warning log; it
+// never returns an error and never interrupts the snapshot/commit main flow.
+//
+// Security: the command always executes inside the microVM guest (task.Exec),
+// never on the host, so an untrusted custom-image binary stays confined to the
+// sandbox.
+func (s *service) collectEnvdVersion(ctx context.Context, sandboxID string) (version string) {
+	logger := log.G(ctx).WithField("sandboxID", sandboxID)
+
+	// Self-contained panic guard: this runs inside the AppSnapshot/CommitSandbox
+	// success path, so a panic here must NOT bubble up and fail an already-good
+	// snapshot. Swallow it and degrade to the empty/fallback version.
+	defer func() {
+		if r := recover(); r != nil {
+			logger.Warnf("collect envd version: recovered from panic: %v", r)
+			version = ""
+		}
+	}()
+
+	cb, err := s.cubeboxMgr.cubeboxManger.Get(ctx, sandboxID)
+	if err != nil {
+		logger.Warnf("collect envd version: get cubebox failed: %v", err)
+		return ""
+	}
+	ns := cb.Namespace
+	if ns == "" {
+		ns = namespaces.Default
+	}
+	execCtx, cancel := context.WithTimeout(namespaces.WithNamespace(ctx, ns), envdVersionExecTimeout)
+	defer cancel()
+
+	container, err := s.cubeboxMgr.client.LoadContainer(execCtx, sandboxID)
+	if err != nil {
+		logger.Warnf("collect envd version: load container failed: %v", err)
+		return ""
+	}
+	task, err := container.Task(execCtx, nil)
+	if err != nil {
+		logger.Warnf("collect envd version: get task failed: %v", err)
+		return ""
+	}
+	spec, err := container.Spec(execCtx)
+	if err != nil {
+		logger.Warnf("collect envd version: get container spec failed: %v", err)
+		return ""
+	}
+	if spec.Process == nil {
+		logger.Warnf("collect envd version: container spec has no process")
+		return ""
+	}
+	pspecCopy := *spec.Process
+	pspecCopy.Env = append([]string{}, spec.Process.Env...)
+	pspec := &pspecCopy
+	pspec.Terminal = true
+	pspec.Args = []string{"envd", "--version"}
+
+	out := &boundedBuffer{limit: envdVersionOutputLimit}
+	execID := envdVersionExecIDPrefix + uuid.New().String()
+	process, err := task.Exec(execCtx, execID, pspec, cio.NewCreator(cio.WithStreams(nil, out, out), cio.WithTerminal))
+	if err != nil {
+		logger.Warnf("collect envd version: exec failed: %v", err)
+		return ""
+	}
+	defer func() {
+		deleteCtx := namespaces.WithNamespace(context.Background(), ns)
+		if _, derr := process.Delete(deleteCtx); derr != nil {
+			logger.Warnf("collect envd version: delete exec process failed: %v", derr)
+		}
+	}()
+
+	statusCh, err := process.Wait(execCtx)
+	if err != nil {
+		logger.Warnf("collect envd version: wait failed: %v", err)
+		return ""
+	}
+	if err := process.Start(execCtx); err != nil {
+		logger.Warnf("collect envd version: start failed: %v", err)
+		return ""
+	}
+
+	select {
+	case <-execCtx.Done():
+		// Kill the exec process and wait for it to reap so the deferred Delete
+		// does not race a still-running process and leak shim resources.
+		_ = process.Kill(context.Background(), syscall.SIGKILL)
+		select {
+		case <-statusCh:
+		case <-time.After(envdVersionExecTimeout):
+			logger.Warnf("collect envd version: exec did not reap after kill")
+		}
+		logger.Warnf("collect envd version: timed out after %s", envdVersionExecTimeout)
+		return ""
+	case status := <-statusCh:
+		if code, _, serr := status.Result(); serr != nil || code != 0 {
+			logger.Warnf("collect envd version: non-zero exit (code=%d err=%v)", code, serr)
+			return ""
+		}
+	}
+
+	version = envdSemverRe.FindString(out.String())
+	if version == "" {
+		logger.Warnf("collect envd version: no semver in output")
+		return ""
+	}
+	logger.Infof("collect envd version: %s", version)
+	return version
+}

--- a/Cubelet/services/cubebox/envd_version_test.go
+++ b/Cubelet/services/cubebox/envd_version_test.go
@@ -1,0 +1,171 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package cubebox
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"syscall"
+	"testing"
+	"time"
+
+	containerd "github.com/containerd/containerd/v2/client"
+	"github.com/containerd/containerd/v2/pkg/cio"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/tencentcloud/CubeSandbox/Cubelet/pkg/log"
+	CubeLog "github.com/tencentcloud/CubeSandbox/cubelog"
+)
+
+type stubProbeProcess struct {
+	mu        sync.Mutex
+	killCalls int
+}
+
+func (p *stubProbeProcess) ID() string { return "stub" }
+func (p *stubProbeProcess) Pid() uint32 {
+	return 0
+}
+func (p *stubProbeProcess) Start(context.Context) error { return nil }
+func (p *stubProbeProcess) Delete(context.Context, ...containerd.ProcessDeleteOpts) (*containerd.ExitStatus, error) {
+	return nil, nil
+}
+func (p *stubProbeProcess) Kill(context.Context, syscall.Signal, ...containerd.KillOpts) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.killCalls++
+	return nil
+}
+func (p *stubProbeProcess) Wait(context.Context) (<-chan containerd.ExitStatus, error) {
+	return nil, nil
+}
+func (p *stubProbeProcess) CloseIO(context.Context, ...containerd.IOCloserOpts) error { return nil }
+func (p *stubProbeProcess) Resize(context.Context, uint32, uint32) error              { return nil }
+func (p *stubProbeProcess) IO() cio.IO                                                { return nil }
+func (p *stubProbeProcess) Status(context.Context) (containerd.Status, error) {
+	return containerd.Status{}, nil
+}
+
+func (p *stubProbeProcess) killCount() int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.killCalls
+}
+
+func testProbeLogger() *log.CubeWrapperLogEntry {
+	return log.NewWrapperLogEntry(CubeLog.WithContext(context.Background()))
+}
+
+func TestRunProbeCallReturnsResult(t *testing.T) {
+	ctx := context.Background()
+	got, err := runProbeCall(ctx, func() (string, error) {
+		return "ok", nil
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "ok", got)
+}
+
+func TestRunProbeCallPropagatesError(t *testing.T) {
+	ctx := context.Background()
+	want := errors.New("boom")
+	_, err := runProbeCall(ctx, func() (int, error) {
+		return 0, want
+	})
+	assert.ErrorIs(t, err, want)
+}
+
+func TestRunProbeCallTimesOutOnBlockingCall(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	_, err := runProbeCall(ctx, func() (struct{}, error) {
+		time.Sleep(2 * time.Second)
+		return struct{}{}, nil
+	})
+	elapsed := time.Since(start)
+
+	require.Error(t, err)
+	assert.True(t, probeCallTimedOut(err))
+	assert.Less(t, elapsed, time.Second)
+}
+
+func TestRunProbeCallRecoversPanic(t *testing.T) {
+	ctx := context.Background()
+	_, err := runProbeCall(ctx, func() (string, error) {
+		panic("probe exploded")
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "probe panic")
+	assert.Contains(t, err.Error(), "probe exploded")
+}
+
+func TestParseEnvdVersionFromOutputPrefersStdout(t *testing.T) {
+	t.Parallel()
+
+	stdout := "envd version 1.2.3\n"
+	stderr := "WARN: noise 9.9.9\n"
+	assert.Equal(t, "1.2.3", parseEnvdVersionFromOutput(stdout, stderr))
+}
+
+func TestParseEnvdVersionFromOutputFallsBackToStderr(t *testing.T) {
+	t.Parallel()
+
+	stdout := ""
+	stderr := "WARN: starting envd 4.5.6\n"
+	assert.Equal(t, "4.5.6", parseEnvdVersionFromOutput(stdout, stderr))
+}
+
+func TestBoundedBufferEnforcesPerStreamLimit(t *testing.T) {
+	t.Parallel()
+
+	buf := &boundedBuffer{limit: 8}
+	_, err := buf.Write([]byte("12345678"))
+	require.NoError(t, err)
+	_, err = buf.Write([]byte("extra"))
+	require.NoError(t, err)
+	assert.Equal(t, "12345678", buf.String())
+}
+
+func TestAbortProbeKillsOnProbeError(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		err  error
+	}{
+		{
+			name: "non-timeout start failure",
+			err:  errors.New("start rpc failed"),
+		},
+		{
+			name: "timeout start failure",
+			err:  context.DeadlineExceeded,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			process := &stubProbeProcess{}
+			statusCh := make(chan containerd.ExitStatus, 1)
+			statusCh <- *containerd.NewExitStatus(137, time.Now(), nil)
+
+			abortProbe(process, statusCh, testProbeLogger(), "start", tt.err)
+
+			assert.Equal(t, 1, process.killCount())
+		})
+	}
+}
+
+func TestKillProbeProcessNilStatusCh(t *testing.T) {
+	t.Parallel()
+
+	process := &stubProbeProcess{}
+	killProbeProcess(process, nil, testProbeLogger())
+	assert.Equal(t, 1, process.killCount())
+}

--- a/Cubelet/services/cubebox/template_ops.go
+++ b/Cubelet/services/cubebox/template_ops.go
@@ -245,6 +245,9 @@ func (s *service) CommitSandbox(ctx context.Context, req *cubebox.CommitSandboxR
 	rsp.GuestImageVersion = versions.GuestImage
 	rsp.AgentVersion = versions.Agent
 	rsp.KernelVersion = versions.Kernel
+	// The source sandbox stays running through commit, so probe its real envd
+	// version in-guest after the memory snapshot. Best-effort: empty on failure.
+	rsp.EnvdVersion = s.collectEnvdVersion(ctx, rsp.SandboxID)
 	if err := storage.WriteSnapshotCatalog(&storage.SnapshotCatalogEntry{
 		SnapshotID:      rsp.TemplateID,
 		InstanceType:    "cubebox",


### PR DESCRIPTION
## Summary
- Collect the real envd semantic version during template snapshot/commit inside the guest and propagate it through template annotations.
- Return the collected version from CubeAPI `envdVersion` for create/get/list/connect/resume, with the existing `0.2.0` value kept as a conservative fallback for legacy templates.
- Use an internal exec-id prefix for the shim-side probe path without matching command arguments, so the probe remains explicit metadata rather than command-specific handling.

## Problem
CubeAPI previously reported a fixed `envdVersion` of `0.2.0` for all sandboxes. e2b SDKs use this field for client-side feature gating, so newer envd versions in template images were treated as legacy versions and newer capabilities could be disabled incorrectly. Custom template images can also ship different envd versions, so a global constant is not accurate.

## Design
The version is collected once on low-frequency template creation paths, not during sandbox create/query hot paths:

- Cubelet executes `envd --version` inside the guest during AppSnapshot and CommitSandbox, then returns the parsed semver in the cubebox proto response.
- CubeMaster stores the value as the template annotation `cube.master.components.envd.version` and lets the existing template-to-sandbox annotation propagation carry it to sandbox instances.
- Multi-node template creation collects on each replica, converges to a template-level single value after replica creation completes, and writes the template definition once.
- CubeMaster echoes the collected annotation through the existing create response `ext_info` map; CubeAPI reads create from `ext_info` and get/list/connect/resume from sandbox annotations.
- If the annotation is absent or invalid, CubeAPI falls back to `0.2.0` to preserve legacy behavior.

### Diagram 1: Architecture

```mermaid
graph LR
    subgraph TPL["Template creation (low-frequency, one-time)"]
        ROOTFS["envd inside the template image<br/>(version may differ by image)"]
        CAP["Run envd --version inside the isolated guest<br/>(containerd task.Exec)<br/>create-from-image: AppSnapshot temporary microVM<br/>commit: running source sandbox VM"]
        ANNO["Template annotation<br/>cube.master.components.envd.version"]
        ROOTFS --> CAP --> ANNO
    end

    subgraph CREATE["Sandbox creation (hot path, no envd RPC)"]
        MERGE["applyTemplateAnnotationsAndLabels<br/>template annotations -> sandbox instance"]
        SBXANNO["Sandbox instance annotations<br/>carry envd version"]
        MERGE --> SBXANNO
    end

    subgraph API["CubeAPI"]
        READ["Read annotations[components.envd.version]<br/>create reads ext_info[same key]<br/>missing -> fallback 0.2.0"]
        RESP["Fill envdVersion<br/>create/get/list/resume/connect"]
        READ --> RESP
    end

    ANNO -->|"stored in TemplateDefinition request_json"| MERGE
    SBXANNO -->|"SandboxInfo/SandboxDetail.annotations"| READ
    RESP -->|"create/get/list/resume/connect"| SDK["e2b SDK<br/>uses envdVersion for feature gating"]
```

### Diagram 2: Sequence

```mermaid
sequenceDiagram
    participant TB as Template create/commit
    participant CL as Cubelet
    participant TC as CubeMaster template center
    participant CM as CubeMaster(create)
    participant API as CubeAPI
    participant SDK as e2b SDK

    Note over TB,TC: Template creation phase (one-time, low-frequency)
    TB->>CL: AppSnapshot / CommitSandbox (image is booted as an isolated guest)
    CL->>CL: After snapshot capture, run envd --version via containerd task.Exec (timeout + bounded output)
    alt collection succeeds
        CL-->>TC: return envd_version -> write template annotation
    else collection fails
        CL-->>TC: do not write annotation (later fallback applies)
    end

    Note over SDK,API: Sandbox creation phase (hot path, no envd round trip)
    SDK->>CM: create sandbox(template_id)
    CM->>TC: load template request (with annotations)
    CM->>CM: applyTemplateAnnotationsAndLabels: annotations -> sandbox instance
    CM-->>API: CreateCubeSandboxRes(ext_info[components.envd.version])
    API-->>SDK: envdVersion = ext_info[key] (missing -> 0.2.0)

    Note over SDK,API: get/list/resume/connect
    SDK->>API: get/list/...
    API->>CM: fetch sandbox info (annotations already included)
    API-->>SDK: envdVersion = annotations[components.envd.version] (missing -> 0.2.0)
```

### Diagram 3: Data Flow

```mermaid
graph TB
    SRC["envd binary in template rootfs<br/>real semver"]
    SRC -->|"in-guest collection during template creation"| CAP["containerd task.Exec runs envd --version<br/>create-from-image: AppSnapshot temporary microVM<br/>commit: running source sandbox VM<br/>nothing recorded at image build time; never execute on host"]
    CAP -->|"collect per node -> return envd_version<br/>after wg.Wait(), converge to one template value and write once"| TANNO["Template annotation<br/>cube.master.components.envd.version<br/>(TemplateDefinition request_json, one row per template)"]
    TANNO -->|"existing propagation on create"| SANNO["Sandbox instance annotations"]
    SANNO -->|"returned by CubeMaster"| INFO["SandboxInfo / SandboxDetail<br/>.annotations (already parsed by CubeAPI)"]
    INFO --> RESOLVE{"Has components.envd.version?"}
    RESOLVE -->|"yes"| REAL["Use collected version"]
    RESOLVE -->|"no (legacy template / collection failed)"| FB["ENVD_VERSION_FALLBACK = 0.2.0"]
    REAL --> OUT["Fill envdVersion -> API response"]
    FB --> OUT

    CREATE["create response"] -.->|"reuse existing ext_info map with the same key"| RESOLVE
```

## Validation
- `make cubemaster`
- `make cubelet`
- `make cubeapi`
- `make shim`
- Shim unit test for the internal probe exec-id prefix
- Deployed the changed services to a test environment and verified new template creation, existing template redo, and CubeAPI create/get/list/connect/resume all returned the collected envd version.
- Service health checks passed after deployment.

Known note: unrelated pre-existing package test failures were observed in existing CubeMaster/Cubelet tests during broader validation; the targeted builds and relevant checks above passed.

Assisted-by: Cursor:GPT-5.5