### PR TITLE
feat(cube-bench): add host-mount flag for create requests

### DIFF
--- a/examples/cube-bench/README.md
+++ b/examples/cube-bench/README.md
@@ -54,6 +54,7 @@ All env vars can be overridden by the corresponding flag.
 | `-w`, `--warmup` | `0` | Warmup rounds before measurement |
 | `-m`, `--mode` | `create-delete` | `create-delete` or `create-only` |
 | `-o`, `--output` | *(none)* | Export JSON report to file |
+| `--host-mount` | *(none)* | Host mount list as a JSON array |
 | `--api-url` | *(env)* | CubeAPI base URL |
 | `--api-key` | *(env)* | API key |
 | `--theme` | `auto` | Color theme: `dark`, `light`, or `auto` |
@@ -77,12 +78,34 @@ export CUBE_TEMPLATE_ID=<your-template-id>
 # Create-only mode, export JSON report
 ./bin/cube-bench --dry-run -c 20 -n 200 -m create-only -o report.json
 
+# Benchmark host-mount create requests
+./bin/cube-bench -c 10 -n 50 --host-mount '[{"hostPath":"/tmp/data","mountPath":"/mnt/data","readOnly":false}]'
+
 # Non-interactive output (CI / pipe)
 ./bin/cube-bench --dry-run --no-tui -c 10 -n 50
 
 # Light terminal theme
 ./bin/cube-bench --dry-run --theme light -c 10 -n 100
 ```
+
+For `host-mount`, this CLI form is equivalent to the Python SDK pattern:
+
+```python
+metadata = {
+    "host-mount": json.dumps([
+        {"hostPath": "/tmp/data", "mountPath": "/mnt/data", "readOnly": False},
+    ])
+}
+```
+
+`cube-bench` accepts the friendlier JSON array above, compacts it once, and
+sends it as `metadata["host-mount"]` in the create request. The backend
+contract still receives `metadata` as strings:
+
+- `CubeAPI/src/services/sandboxes.rs` accepts `metadata` as `map[string]string`
+- it lifts `metadata["host-mount"]` into the sandbox annotation `host-mount`
+- `CubeMaster/pkg/service/sandbox/hostdir_mount.go` parses that annotation as
+  a JSON string into mount descriptors
 
 ## Features
 

--- a/examples/cube-bench/main.go
+++ b/examples/cube-bench/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"encoding/json"
 	"flag"
 	"fmt"
@@ -33,6 +34,10 @@ type Config struct {
 	APIURL         string
 	APIKey         string
 	ThemeName      string
+	HostMount      string // raw JSON array for config display and report export
+	hostMountValue string // compacted once for request-time reuse
+	requestBody    []byte
+	requestHeaders map[string]string
 	DryRun         bool
 	DryLatencyMean float64
 	DryLatencyStd  float64
@@ -40,6 +45,39 @@ type Config struct {
 	NoTUI          bool
 
 	elapsed float64
+}
+
+type createRequest struct {
+	TemplateID string            `json:"templateID"`
+	Metadata   map[string]string `json:"metadata,omitempty"`
+}
+
+func prepareHostMount(rawJSON string) (string, error) {
+	if rawJSON == "" {
+		return "", nil
+	}
+
+	var mounts []json.RawMessage
+	if err := json.Unmarshal([]byte(rawJSON), &mounts); err != nil {
+		return "", fmt.Errorf("--host-mount must be a JSON array: %w", err)
+	}
+	if len(mounts) == 0 {
+		return "", fmt.Errorf("--host-mount must be a non-empty JSON array")
+	}
+
+	var compact bytes.Buffer
+	if err := json.Compact(&compact, []byte(rawJSON)); err != nil {
+		return "", fmt.Errorf("--host-mount must be valid JSON: %w", err)
+	}
+	return compact.String(), nil
+}
+
+func buildCreateRequestBody(template string, hostMount string) ([]byte, error) {
+	reqBody := createRequest{TemplateID: template}
+	if hostMount != "" {
+		reqBody.Metadata = map[string]string{"host-mount": hostMount}
+	}
+	return json.Marshal(reqBody)
 }
 
 func parseConfig() *Config {
@@ -57,6 +95,7 @@ func parseConfig() *Config {
 	flag.StringVar(&cfg.Mode, "mode", "create-delete", "Benchmark mode: create-delete | create-only")
 	flag.StringVar(&cfg.Output, "o", "", "Export JSON report to file")
 	flag.StringVar(&cfg.Output, "output", "", "Export JSON report to file")
+	flag.StringVar(&cfg.HostMount, "host-mount", "", "Host mount list as a JSON array")
 	flag.StringVar(&cfg.APIURL, "api-url", "", "CubeAPI base URL (overrides E2B_API_URL)")
 	flag.StringVar(&cfg.APIKey, "api-key", "", "API key (overrides E2B_API_KEY)")
 	flag.StringVar(&cfg.ThemeName, "theme", "auto", "Color theme: dark | light | auto")
@@ -112,6 +151,25 @@ func parseConfig() *Config {
 		cfg.Total = 1
 	}
 
+	// Validate host-mount early so the CLI fails fast on bad input while still
+	// preserving the original JSON for config display and exported reports.
+	// Cache the compacted JSON string once so benchmark throughput is not
+	// polluted by repeating client-side conversion on every request.
+	hostMountValue, err := prepareHostMount(cfg.HostMount)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "ERROR: %v\n", err)
+		os.Exit(1)
+	}
+	cfg.hostMountValue = hostMountValue
+	cfg.requestHeaders = map[string]string{"Authorization": "Bearer " + cfg.APIKey}
+
+	requestBody, err := buildCreateRequestBody(cfg.Template, cfg.hostMountValue)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "ERROR: create request body build failed: %v\n", err)
+		os.Exit(1)
+	}
+	cfg.requestBody = requestBody
+
 	return cfg
 }
 
@@ -131,10 +189,21 @@ func renderConfig(cfg *Config) {
 		{"Total Requests", fmt.Sprintf("%d", cfg.Total)},
 		{"Warmup Rounds", fmt.Sprintf("%d", cfg.Warmup)},
 		{"Mode", cfg.Mode},
-		{"Host", hostname},
-		{"Go", runtime.Version()},
-		{"Time", time.Now().UTC().Format("2006-01-02 15:04:05 UTC")},
 	}
+	if cfg.HostMount != "" {
+		// Pretty-print the original host-mount JSON for readability.
+		var pretty bytes.Buffer
+		if err := json.Indent(&pretty, []byte(cfg.HostMount), "    ", "  "); err == nil {
+			kvs = append(kvs, kvPair{"Host Mount", pretty.String()})
+		} else {
+			kvs = append(kvs, kvPair{"Host Mount", cfg.HostMount})
+		}
+	}
+	kvs = append(kvs,
+		kvPair{"Host", hostname},
+		kvPair{"Go", runtime.Version()},
+		kvPair{"Time", time.Now().UTC().Format("2006-01-02 15:04:05 UTC")},
+	)
 
 	var content strings.Builder
 	for _, kv := range kvs {
@@ -231,6 +300,7 @@ func exportJSON(results []IterResult, cfg *Config) {
 			"total":       cfg.Total,
 			"warmup":      cfg.Warmup,
 			"mode":        cfg.Mode,
+			"host_mount":  cfg.HostMount,
 		},
 		"summary": map[string]interface{}{
 			"total_time_s":   cfg.elapsed,

--- a/examples/cube-bench/main_test.go
+++ b/examples/cube-bench/main_test.go
@@ -1,0 +1,57 @@
+package main
+
+import "testing"
+
+func TestPrepareHostMountCompactsValidArray(t *testing.T) {
+	got, err := prepareHostMount(`[
+		{"hostPath":"/tmp/data","mountPath":"/mnt/data","readOnly":false}
+	]`)
+	if err != nil {
+		t.Fatalf("prepareHostMount returned error: %v", err)
+	}
+
+	want := `[{"hostPath":"/tmp/data","mountPath":"/mnt/data","readOnly":false}]`
+	if got != want {
+		t.Fatalf("prepareHostMount=%q, want %q", got, want)
+	}
+}
+
+func TestPrepareHostMountPreservesCompactedArray(t *testing.T) {
+	got, err := prepareHostMount(`[{"hostPath":"/tmp/data","mountPath":"/mnt/data","readOnly":false}]`)
+	if err != nil {
+		t.Fatalf("prepareHostMount returned error: %v", err)
+	}
+
+	want := `[{"hostPath":"/tmp/data","mountPath":"/mnt/data","readOnly":false}]`
+	if got != want {
+		t.Fatalf("prepareHostMount=%q, want %q", got, want)
+	}
+}
+
+func TestPrepareHostMountRejectsInvalidJSON(t *testing.T) {
+	if _, err := prepareHostMount(`[{"hostPath":]`); err == nil {
+		t.Fatal("prepareHostMount returned nil error, want invalid JSON error")
+	}
+}
+
+func TestPrepareHostMountRejectsNonArrayJSON(t *testing.T) {
+	if _, err := prepareHostMount(`{"hostPath":"/tmp/data","mountPath":"/mnt/data","readOnly":false}`); err == nil {
+		t.Fatal("prepareHostMount returned nil error, want non-array error")
+	}
+}
+
+func TestPrepareHostMountAllowsEmptyInput(t *testing.T) {
+	got, err := prepareHostMount("")
+	if err != nil {
+		t.Fatalf("prepareHostMount returned error: %v", err)
+	}
+	if got != "" {
+		t.Fatalf("prepareHostMount returned %q, want empty string", got)
+	}
+}
+
+func TestPrepareHostMountRejectsEmptyArray(t *testing.T) {
+	if _, err := prepareHostMount(`[]`); err == nil {
+		t.Fatal("prepareHostMount returned nil error, want empty array error")
+	}
+}

--- a/examples/cube-bench/runner.go
+++ b/examples/cube-bench/runner.go
@@ -25,19 +25,16 @@ type createResp struct {
 func benchOne(client *http.Client, cfg *Config, seq int) IterResult {
 	r := IterResult{Seq: seq}
 	apiURL := cfg.APIURL
-	headers := map[string]string{"Authorization": "Bearer " + cfg.APIKey}
-
-	body, _ := json.Marshal(map[string]string{"templateID": cfg.Template})
 
 	// CREATE
 	t0 := time.Now()
-	req, err := http.NewRequest("POST", apiURL+"/sandboxes", bytes.NewReader(body))
+	req, err := http.NewRequest("POST", apiURL+"/sandboxes", bytes.NewReader(cfg.requestBody))
 	if err != nil {
 		r.Err = fmt.Sprintf("create request build: %v", err)
 		return r
 	}
 	req.Header.Set("Content-Type", "application/json")
-	for k, v := range headers {
+	for k, v := range cfg.requestHeaders {
 		req.Header.Set(k, v)
 	}
 
@@ -73,7 +70,7 @@ func benchOne(client *http.Client, cfg *Config, seq int) IterResult {
 			r.Err = fmt.Sprintf("delete request build: %v", err)
 			return r
 		}
-		for k, v := range headers {
+		for k, v := range cfg.requestHeaders {
 			dreq.Header.Set(k, v)
 		}
 		dresp, err := client.Do(dreq)
@@ -82,7 +79,7 @@ func benchOne(client *http.Client, cfg *Config, seq int) IterResult {
 			r.Err = fmt.Sprintf("delete: %v", err)
 			return r
 		}
-		dresp.Body.Close()
+		defer dresp.Body.Close()
 		if dresp.StatusCode != 200 && dresp.StatusCode != 204 {
 			r.Err = fmt.Sprintf("delete HTTP %d", dresp.StatusCode)
 			return r

--- a/examples/cube-bench/runner_test.go
+++ b/examples/cube-bench/runner_test.go
@@ -1,0 +1,136 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestBenchOneSendsHostMountMetadata(t *testing.T) {
+	rawHostMount := `[
+		{"hostPath":"/tmp/data","mountPath":"/mnt/data","readOnly":false}
+	]`
+	hostMountValue, err := prepareHostMount(rawHostMount)
+	if err != nil {
+		t.Fatalf("prepareHostMount returned error: %v", err)
+	}
+	requestBody, err := buildCreateRequestBody("tpl-test", hostMountValue)
+	if err != nil {
+		t.Fatalf("buildCreateRequestBody returned error: %v", err)
+	}
+
+	var got map[string]any
+	handlerErrCh := make(chan error, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/sandboxes" {
+			select {
+			case handlerErrCh <- fmt.Errorf("request = %s %s", r.Method, r.URL.Path):
+			default:
+			}
+			http.Error(w, "unexpected request", http.StatusBadRequest)
+			return
+		}
+		if auth := r.Header.Get("Authorization"); auth != "Bearer test-key" {
+			select {
+			case handlerErrCh <- fmt.Errorf("Authorization=%q, want Bearer test-key", auth):
+			default:
+			}
+			http.Error(w, "unexpected auth", http.StatusUnauthorized)
+			return
+		}
+		if err := json.NewDecoder(r.Body).Decode(&got); err != nil {
+			select {
+			case handlerErrCh <- fmt.Errorf("decode body: %v", err):
+			default:
+			}
+			http.Error(w, "decode body failed", http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		fmt.Fprint(w, `{"sandboxID":"sb-test-001"}`)
+	}))
+	defer server.Close()
+
+	cfg := &Config{
+		Template:       "tpl-test",
+		Mode:           "create-only",
+		APIURL:         server.URL,
+		APIKey:         "test-key",
+		HostMount:      rawHostMount,
+		hostMountValue: hostMountValue,
+		requestBody:    requestBody,
+		requestHeaders: map[string]string{"Authorization": "Bearer test-key"},
+	}
+
+	result := benchOne(server.Client(), cfg, 1)
+	if result.Err != "" {
+		t.Fatalf("benchOne returned error: %s", result.Err)
+	}
+	select {
+	case err := <-handlerErrCh:
+		t.Fatal(err)
+	default:
+	}
+
+	metadata, ok := got["metadata"].(map[string]any)
+	if !ok {
+		t.Fatalf("metadata=%#v, want map[string]any", got["metadata"])
+	}
+	wantHostMount := `[{"hostPath":"/tmp/data","mountPath":"/mnt/data","readOnly":false}]`
+	if got := metadata["host-mount"]; got != wantHostMount {
+		t.Fatalf("metadata.host-mount=%#v, want %q", got, wantHostMount)
+	}
+}
+
+func TestBenchOneDeletePath(t *testing.T) {
+	requestBody, err := buildCreateRequestBody("tpl-delete", "")
+	if err != nil {
+		t.Fatalf("buildCreateRequestBody returned error: %v", err)
+	}
+
+	handlerErrCh := make(chan error, 1)
+	deleteCalled := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/sandboxes":
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusCreated)
+			fmt.Fprint(w, `{"sandboxID":"sb-delete-001"}`)
+		case r.Method == http.MethodDelete && r.URL.Path == "/sandboxes/sb-delete-001":
+			deleteCalled = true
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			select {
+			case handlerErrCh <- fmt.Errorf("unexpected request = %s %s", r.Method, r.URL.Path):
+			default:
+			}
+			http.Error(w, "unexpected request", http.StatusBadRequest)
+		}
+	}))
+	defer server.Close()
+
+	cfg := &Config{
+		Template:       "tpl-delete",
+		Mode:           "create-delete",
+		APIURL:         server.URL,
+		APIKey:         "test-key",
+		requestBody:    requestBody,
+		requestHeaders: map[string]string{"Authorization": "Bearer test-key"},
+	}
+
+	result := benchOne(server.Client(), cfg, 1)
+	if result.Err != "" {
+		t.Fatalf("benchOne returned error: %s", result.Err)
+	}
+	select {
+	case err := <-handlerErrCh:
+		t.Fatal(err)
+	default:
+	}
+	if !deleteCalled {
+		t.Fatal("benchOne did not issue the delete request")
+	}
+}


### PR DESCRIPTION
## Motivation

`examples/cube-bench` currently benchmarks the default raw sandbox create path. That makes it hard to measure create-time overhead for `host-mount`, which is the concrete create-time variation we want to compare.

CubeAPI already accepts `host-mount` through `metadata["host-mount"]` as a JSON string. `cube-bench` should be able to send that same create-time payload so host-mount sandbox setups can be benchmarked directly.

## What Changed

This PR adds a `--host-mount '<json-array>'` flag to `cube-bench` and includes the provided host-mount payload in sandbox create requests.

Implementation highlights:

* `examples/cube-bench/main.go` adds the new flag, validates a non-empty host-mount JSON array once during config parsing, preserves the original JSON for config display and exported reports, and caches the compacted `host-mount` string plus request body for request-time reuse
* `examples/cube-bench/runner.go` sends the cached request body and headers on sandbox create requests, so benchmark throughput is not distorted by re-building host-mount metadata on every request
* `examples/cube-bench/main_test.go` covers valid host-mount arrays, invalid JSON, non-array input, empty input, and empty-array rejection
* `examples/cube-bench/README.md` documents the new flag and a host-mount example

This keeps the benchmark helper focused on the current benchmark need without changing the backend metadata contract.

## Validation

* `go test ./...` passed in `examples/cube-bench`
* focused tests cover:
  * valid host-mount arrays being compacted once before request-time use
  * invalid host-mount JSON being rejected
  * non-array host-mount input being rejected
  * empty host-mount arrays being rejected
  * final create requests keeping `metadata["host-mount"]` as a string value
* real-machine validation passed with the `cube-bench` binary using a `--host-mount '[...]'` payload
