### PR TITLE
fix(cubeapi): forward with_cube_ca when creating templates

### DIFF
--- a/CubeAPI/src/cubemaster/mod.rs
+++ b/CubeAPI/src/cubemaster/mod.rs
@@ -1832,6 +1832,9 @@ pub struct CreateTemplateFromImageReq {
         skip_serializing_if = "Option::is_none"
     )]
     pub cube_network_config: Option<CreateTemplateCubeNetworkConfig>,
+    /// Whether CubeMaster bakes the CubeEgress root CA into the template rootfs.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub with_cube_ca: Option<bool>,
 }
 
 /// Minimal container overrides for template creation.

--- a/CubeAPI/src/models/mod.rs
+++ b/CubeAPI/src/models/mod.rs
@@ -648,6 +648,10 @@ pub struct CreateTemplateRequest {
     /// Denied outbound CIDRs for CubeVS egress policy.
     #[serde(rename = "denyOut", default)]
     pub deny_out: Option<Vec<String>>,
+    /// Whether CubeMaster bakes the CubeEgress root CA into the template rootfs.
+    /// Omitted or null defaults to true on CubeMaster.
+    #[serde(rename = "with_cube_ca", default)]
+    pub with_cube_ca: Option<bool>,
 }
 
 /// Body for POST /templates/:id (rebuild).

--- a/CubeAPI/src/services/templates.rs
+++ b/CubeAPI/src/services/templates.rs
@@ -133,6 +133,7 @@ impl TemplateService {
             distribution_scope: non_empty_vec(body.nodes),
             container_overrides,
             cube_network_config,
+            with_cube_ca: body.with_cube_ca,
         };
 
         let resp = self
@@ -530,6 +531,7 @@ mod tests {
             dns: Some(vec!["8.8.8.8".to_string(), "1.1.1.1".to_string()]),
             allow_out: Some(vec!["172.67.0.0/16".to_string()]),
             deny_out: Some(vec!["10.0.0.0/8".to_string()]),
+            with_cube_ca: Some(false),
         }
     }
 


### PR DESCRIPTION
## Summary

CubeMaster already supports the `with_cube_ca` flag on template creation, but CubeAPI did not accept or forward it when handling `POST /templates`. As a result, API clients could not control whether the CubeEgress root CA is baked into the template rootfs.

This change:
- Adds `with_cube_ca` to `CreateTemplateRequest`
- Adds the same field to `CreateTemplateFromImageReq` sent to CubeMaster
- Forwards the value in `TemplateService::create_template`

When omitted or `null`, CubeMaster keeps its existing default behavior (`true`).

## Test plan

- [x] `cd CubeAPI && cargo test` (70 passed)
- [x] `cd CubeMaster && go test ./pkg/templatecenter/... -run 'WithCubeCA|CubeEgress'`