### PR TITLE
CubeProxy: Remove cube_retcode to stop leaking implementation details

### DIFF
--- a/CubeProxy/lua/balancer_phase.lua
+++ b/CubeProxy/lua/balancer_phase.lua
@@ -2,8 +2,7 @@ local utils = require "utils"
 if (utils:is_null(ngx.var.backend_ip) or utils:is_null(ngx.var.backend_port)) then
     -- unlikely
     ngx.log(ngx.ERR, "LEVEL_ERROR||", string.format("bad addr (%s:%s)", ngx.var.backend_ip, ngx.var.backend_port))
-    ngx.var.cube_retcode = "310508"
-    ngx.exit(500)
+    ngx.exit(503)
 end
 
 local balancer = require "ngx.balancer"
@@ -11,6 +10,5 @@ local ok, err = balancer.set_current_peer(ngx.var.backend_ip, ngx.var.backend_po
 if not ok then
     ngx.log(ngx.ERR, "LEVEL_ERROR||", string.format("connect to backend (%s:%s) err: %s"), ngx.var.backend_ip,
         ngx.var.backend_port, err)
-    ngx.var.cube_retcode = "310509"
-    ngx.exit(500)
+    ngx.exit(503)
 end

--- a/CubeProxy/lua/header_filter_phase.lua
+++ b/CubeProxy/lua/header_filter_phase.lua
@@ -1,8 +1,1 @@
-if ngx.status ~= 200 then
-    if ngx.var.upstream_addr ~= nil and ngx.var.cube_retcode == "310200" then
-        ngx.var.cube_retcode = "330" .. ngx.status
-    end
-end
-
 ngx.header["X-Cube-Request-Id"] = ngx.var.http_x_cube_request_id
-ngx.header["X-Cube-Retcode"] = ngx.var.cube_retcode

--- a/CubeProxy/lua/path_rewrite_phase.lua
+++ b/CubeProxy/lua/path_rewrite_phase.lua
@@ -6,6 +6,7 @@
 -- then resolves the same Redis-backed backend metadata used by host-mode
 -- routing in rewrite_phase.lua.
 
+local utils = require "utils"
 local sb = require "sandbox_backend"
 local state = require "sandbox_state"
 
@@ -15,8 +16,7 @@ if not ins_id or not container_port then
     ngx.log(ngx.ERR, "LEVEL_WARN||",
         string.format("request %s invalid path for sandbox/<id>/<port> parse: %s",
             ngx.var.http_x_cube_request_id, uri))
-    ngx.var.cube_retcode = "310400"
-    ngx.exit(400)
+    utils:respond_bad_request()
 end
 
 if rest == nil or rest == "" then

--- a/CubeProxy/lua/rewrite_phase.lua
+++ b/CubeProxy/lua/rewrite_phase.lua
@@ -24,8 +24,7 @@ if not container_port or not ins_id then
     ngx.log(ngx.ERR, "LEVEL_WARN||",
         string.format("request %s invalid Host for port/instance parse: %s",
             ngx.var.http_x_cube_request_id, ngx.var.http_host))
-    ngx.var.cube_retcode = "310400"
-    ngx.exit(400)
+    utils:respond_bad_request()
 end
 
 -- log_phase reads ngx.var.ins_id to record activity. The host-based location

--- a/CubeProxy/lua/sandbox_backend.lua
+++ b/CubeProxy/lua/sandbox_backend.lua
@@ -12,15 +12,17 @@ local redis_keys = require "redis_keys"
 
 local _M = { _VERSION = "0.01" }
 
--- enforce_traffic_token rejects (403) requests targeting a sandbox whose
+-- enforce_traffic_token rejects requests targeting a sandbox whose
 -- AllowPublicTraffic flag is "false" unless the request carries a matching
 -- token in either the e2b-traffic-access-token (E2B-compatible) or
 -- cube-traffic-access-token (CubeSandbox-native) header.
 --
 -- Both args are the raw values stored in Redis (string form). expected_token
 -- being empty while allow_public is "false" indicates a server-side
--- inconsistency and yields 500 instead of 403, on the principle that
--- silently letting the request through would be worse.
+-- inconsistency. Both failure paths return 404 (not 403/500) so that a
+-- caller cannot distinguish "sandbox exists but access denied" from
+-- "sandbox does not exist"; silently letting the request through would be
+-- worse.
 local function enforce_traffic_token(allow_public, expected_token, ins_id)
     if allow_public ~= "false" then
         return
@@ -29,8 +31,7 @@ local function enforce_traffic_token(allow_public, expected_token, ins_id)
         ngx.log(ngx.ERR, "LEVEL_ERROR||",
             string.format("request %s sandbox %s marked restricted but token missing in metadata",
                 ngx.var.http_x_cube_request_id, ins_id))
-        ngx.var.cube_retcode = "310507"
-        ngx.exit(500)
+        utils:respond_not_found()
     end
     local provided = ngx.var.http_e2b_traffic_access_token
                   or ngx.var.http_cube_traffic_access_token
@@ -38,8 +39,7 @@ local function enforce_traffic_token(allow_public, expected_token, ins_id)
         ngx.log(ngx.ERR, "LEVEL_WARN||",
             string.format("request %s sandbox %s traffic token mismatch",
                 ngx.var.http_x_cube_request_id, ins_id))
-        ngx.var.cube_retcode = "310403"
-        ngx.exit(ngx.HTTP_FORBIDDEN)
+        utils:respond_not_found()
     end
 end
 
@@ -149,8 +149,7 @@ function _M.resolve_backend(ins_id, container_port)
     local metadata, err = load_sandbox_proxy_metadata(ins_id)
     if err then
         ngx.log(ngx.ERR, "LEVEL_ERROR||", err)
-        ngx.var.cube_retcode = "310500"
-        ngx.exit(500)
+        utils:respond_unavailable()
     end
 
     cache:set(ins_id .. ":meta_cached", "1", timeout)
@@ -177,8 +176,7 @@ function _M.resolve_backend(ins_id, container_port)
         ngx.log(ngx.ERR, "LEVEL_WARN||",
             string.format("request %s using instance %s misses HostIP",
                 ngx.var.http_x_cube_request_id, ins_id))
-        ngx.var.cube_retcode = "310507"
-        ngx.exit(500)
+        utils:respond_not_found()
     end
 
     if not utils:is_null(caller_host_ip) and caller_host_ip == target_host_ip then
@@ -186,8 +184,7 @@ function _M.resolve_backend(ins_id, container_port)
             ngx.log(ngx.ERR, "LEVEL_ERROR||",
                 string.format("request %s instance %s on local host %s misses SandboxIP",
                     ngx.var.http_x_cube_request_id, ins_id, caller_host_ip))
-            ngx.var.cube_retcode = "310507"
-            ngx.exit(500)
+            utils:respond_not_found()
         end
         host_ip = target_sandbox_ip
         host_port = container_port
@@ -198,8 +195,7 @@ function _M.resolve_backend(ins_id, container_port)
             ngx.log(ngx.ERR, "LEVEL_ERROR||",
                 string.format("request %s instance %s misses host port mapping for container_port %s",
                     ngx.var.http_x_cube_request_id, ins_id, container_port))
-            ngx.var.cube_retcode = "310507"
-            ngx.exit(500)
+            utils:respond_not_found()
         end
     end
 

--- a/CubeProxy/lua/sandbox_state.lua
+++ b/CubeProxy/lua/sandbox_state.lua
@@ -21,6 +21,8 @@
 --   * Sidecar resume fails / times out   -> 503 with Retry-After to let the
 --                                            client back off.
 
+local utils = require "utils"
+
 local _M = { _VERSION = "0.01" }
 
 -- gate runs from rewrite phase. On a successful resume it returns to the
@@ -51,9 +53,8 @@ function _M.gate(ins_id)
         ngx.log(ngx.WARN, "LEVEL_WARN||",
             string.format("request %s sandbox %s is pausing; returning 503",
                 ngx.var.http_x_cube_request_id or "-", ins_id))
-        ngx.var.cube_retcode = "310503"
         ngx.header["Retry-After"] = "2"
-        ngx.exit(503)
+        utils:respond_unavailable()
     end
 
     if state ~= "paused" then
@@ -104,9 +105,8 @@ function _M.gate(ins_id)
             string.format("request %s sidecar resume for sandbox %s failed: status=%s body=%s",
                 rid or "-", ins_id, tostring(status),
                 (res and res.body) and string.sub(res.body, 1, 200) or "-"))
-        ngx.var.cube_retcode = "310503"
         ngx.header["Retry-After"] = "5"
-        ngx.exit(503)
+        utils:respond_unavailable()
     end
 
     -- Resume succeeded. Optimistically mark the sandbox running locally so a

--- a/CubeProxy/lua/utils.lua
+++ b/CubeProxy/lua/utils.lua
@@ -42,4 +42,36 @@ function _M.is_null(self, str)
     return str == nil or str == ""
 end
 
+--[[
+    Terminates the request with a uniform JSON body and status. Used for all
+    client-facing error paths so that no implementation detail (which
+    subsystem failed, whether the sandbox exists, lifecycle state, etc.) is
+    distinguishable to the caller. The detailed reason stays in error.log
+    via the preceding ngx.log call.
+
+    2 args:
+        - status: HTTP status code to exit with
+        - body:   response body string (JSON)
+--]]
+function _M.respond_with(self, status, body)
+    ngx.header["Content-Type"] = "application/json"
+    ngx.say(body)
+    ngx.exit(status)
+end
+
+-- Convenience wrappers for the three error shapes the dataplane returns.
+-- 400 = malformed request; 404 hides sandbox existence; 503 hides the
+-- specific failing subsystem.
+function _M.respond_bad_request(self)
+    self:respond_with(400, '{"error":"bad request"}')
+end
+
+function _M.respond_not_found(self)
+    self:respond_with(404, '{"error":"not found"}')
+end
+
+function _M.respond_unavailable(self)
+    self:respond_with(503, '{"error":"service unavailable"}')
+end
+
 return _M

--- a/CubeProxy/nginx.conf
+++ b/CubeProxy/nginx.conf
@@ -21,7 +21,7 @@ http {
     '$http_x_forwarded_proto||$request_method||$request_uri||$args||$server_protocol||$uri||'
     '$status||$body_bytes_sent||$request_time||$connection_requests||'
     '$upstream_addr||$upstream_status||$upstream_response_time||$http_user_agent||'
-    '$http_x_cube_request_id||$http_x_cube_instance_id||$cube_retcode||$backend_ip';
+    '$http_x_cube_request_id||$http_x_cube_instance_id||$backend_ip';
 
     access_log /data/log/cube-proxy/access.log access;
 
@@ -137,7 +137,6 @@ http {
         # Lets clients reach a sandbox via a plain IP+port without wildcard DNS or TLS.
         location ^~ /sandbox/ {
             include /usr/local/openresty/nginx/conf/global/global.conf;
-            set $cube_retcode "310200";
             set $garyscale_test "none";
             set $backend_ip "";
             set $backend_port "";
@@ -172,7 +171,6 @@ http {
 
         location / {
             include /usr/local/openresty/nginx/conf/global/global.conf;
-            set $cube_retcode "310200";
             set $garyscale_test "none";
             set $backend_ip "";
             set $backend_port "";
@@ -232,7 +230,6 @@ http {
         # Lets clients reach a sandbox via a plain IP+port without wildcard DNS or TLS.
         location ^~ /sandbox/ {
             include /usr/local/openresty/nginx/conf/global/global.conf;
-            set $cube_retcode "310200";
             set $garyscale_test "none";
             set $backend_ip "";
             set $backend_port "";
@@ -267,7 +264,6 @@ http {
 
         location / {
             include /usr/local/openresty/nginx/conf/global/global.conf;
-            set $cube_retcode "310200";
             set $garyscale_test "none";
             set $backend_ip "";
             set $backend_port "";


### PR DESCRIPTION
The X-Cube-Retcode response header and the $cube_retcode access-log field exposed a 6-digit error code on every response that distinguished internal failure modes — token mismatch (310403), sandbox pausing (310503), Redis failure (310500), balancer peer failure (310509), missing metadata fields (310507), etc. An attacker could enumerate sandbox IDs and observe these codes to determine sandbox existence, lifecycle state, and backend infrastructure weak points.

Changes:

* Remove the X-Cube-Retcode header and the "330<status>" synthesis in header_filter_phase.lua; keep X-Cube-Request-Id (echoes the client's own id, no leak).
* Drop $cube_retcode from the access log_format and remove its 4 initializations in nginx.conf. Diagnostics are preserved via the existing ngx.log calls in error.log (request_id, sandbox_id, reason).
* Collapse HTTP status codes so callers cannot distinguish failure modes:
  - sandbox existence / config / token errors -> 404
  - infrastructure failures (Redis, balancer)   -> 503
  - malformed request                          -> 400
* Emit uniform JSON bodies ({"error":"..."}); balancer-phase 503 keeps
  the nginx default page (body emission is unreliable there).
* Add utils:respond_bad_request / respond_not_found / respond_unavailable
  helpers so every error path shares one response implementation.

Behavior changes to flag for downstream:
  - access.log loses one ||-delimited field ($cube_retcode); log-parsing pipelines (Filebeat/grok) need updating.
  - token-mismatch responses change from 403 to 404. In-repo SDKs have no dependency on the old code; external consumers should confirm.