### PR TITLE
fix(install): fail-fast when compute node missing control plane address

### DIFF
--- a/deploy/one-click/install.sh
+++ b/deploy/one-click/install.sh
@@ -876,6 +876,7 @@ check_pvm_consistency_preflight
 check_cubelet_fs_preflight
 check_cgroup_cpu_preflight
 check_glibc_preflight
+check_compute_control_plane_preflight
 
 CUBE_SANDBOX_NODE_IP="$(detect_node_ip)"
 export CUBE_SANDBOX_NODE_IP

--- a/deploy/one-click/lib/common.sh
+++ b/deploy/one-click/lib/common.sh
@@ -1756,3 +1756,71 @@ EOF
 
   log "glibc version ${glibc_ver} OK (>= ${min_major}.${min_minor})"
 }
+
+# check_compute_control_plane_preflight: fail fast when a compute node is
+# missing the mandatory control plane address. This mirrors the resolution
+# logic in resolve_control_plane_cubemaster_addr() (both scripts/one-click/
+# and scripts/systemd/) and must run before package extraction or dependency
+# installation so the user gets a friendly, actionable error before any
+# destructive change.
+check_compute_control_plane_preflight() {
+  local role
+  role="$(one_click_deploy_role)"
+
+  [[ "${role}" == "compute" ]] || return 0
+
+  local addr="${ONE_CLICK_CONTROL_PLANE_CUBEMASTER_ADDR:-}"
+  local ip="${ONE_CLICK_CONTROL_PLANE_IP:-}"
+  # 8089 is the cubemaster protocol port (a fixed constant); do not derive it
+  # from CUBEMASTER_ADDR, which is the control node's local listen address.
+  local cubemaster_port=8089
+
+  # Guard: when both variables are set they MUST resolve to the same address.
+  # ONE_CLICK_CONTROL_PLANE_CUBEMASTER_ADDR takes priority at runtime; silently
+  # ignoring a conflicting ONE_CLICK_CONTROL_PLANE_IP would be a configuration
+  # trap — the user would believe they are connecting to IP when they are not.
+  if [[ -n "${addr}" && -n "${ip}" ]]; then
+    local ip_resolved="${ip}:${cubemaster_port}"
+    if [[ "${addr}" != "${ip_resolved}" ]]; then
+      die "ONE_CLICK_CONTROL_PLANE_IP (resolves to ${ip_resolved}) and ONE_CLICK_CONTROL_PLANE_CUBEMASTER_ADDR (${addr}) conflict. Use only one of them; if you need a custom port, use ONE_CLICK_CONTROL_PLANE_CUBEMASTER_ADDR=<host>:<port>."
+    fi
+  fi
+
+  if [[ -n "${addr}" ]]; then
+    validate_host_port "${addr}" "ONE_CLICK_CONTROL_PLANE_CUBEMASTER_ADDR"
+    log "control plane cubemaster address preflight OK: ${addr}"
+    return 0
+  fi
+
+  if [[ -n "${ip}" ]]; then
+    validate_ipv4_literal "${ip}" "ONE_CLICK_CONTROL_PLANE_IP"
+    validate_host_port "${ip}:${cubemaster_port}" "ONE_CLICK_CONTROL_PLANE_IP-derived cubemaster address"
+    log "control plane IP preflight OK: ${ip} (cubemaster port ${cubemaster_port})"
+    return 0
+  fi
+
+  cat >&2 <<'EOF'
+
+╔══════════════════════════════════════════════════════════════════╗
+║  [!!] CONTROL PLANE ADDRESS NOT CONFIGURED                     ║
+╠══════════════════════════════════════════════════════════════════╣
+║                                                                  ║
+║  This is a COMPUTE node (ONE_CLICK_DEPLOY_ROLE=compute).         ║
+║  The control plane address is REQUIRED but not configured.       ║
+║                                                                  ║
+║  Set ONE of these variables in your .env file:                   ║
+║                                                                  ║
+║    Option A — control plane IP (recommended):                    ║
+║      ONE_CLICK_CONTROL_PLANE_IP=<control-plane-ip>               ║
+║                                                                  ║
+║    Option B — full CubeMaster host:port:                         ║
+║      ONE_CLICK_CONTROL_PLANE_CUBEMASTER_ADDR=<host>:<port>       ║
+║                                                                  ║
+║  Or pass as environment variables:                               ║
+║    ONE_CLICK_CONTROL_PLANE_IP=10.0.0.11 ./install-compute.sh     ║
+║                                                                  ║
+╚══════════════════════════════════════════════════════════════════╝
+
+EOF
+  die "ONE_CLICK_CONTROL_PLANE_IP or ONE_CLICK_CONTROL_PLANE_CUBEMASTER_ADDR is required for compute role"
+}

--- a/deploy/one-click/scripts/cube-diag/check-procs.sh
+++ b/deploy/one-click/scripts/cube-diag/check-procs.sh
@@ -106,7 +106,8 @@ _resolve_master_addr() {
   fi
   local addr="${ONE_CLICK_CONTROL_PLANE_CUBEMASTER_ADDR:-}"
   local ip="${ONE_CLICK_CONTROL_PLANE_IP:-}"
-  local port="${CUBEMASTER_ADDR##*:}"
+  # 8089 is the cubemaster protocol port (fixed), not derived from CUBEMASTER_ADDR.
+  local port=8089
   if [[ -n "${addr}" ]]; then printf '%s\n' "${addr}"; return; fi
   if [[ -n "${ip}" ]];   then printf '%s:%s\n' "${ip}" "${port}"; return; fi
   printf '%s\n' "${CUBEMASTER_ADDR}"

--- a/deploy/one-click/scripts/one-click/common.sh
+++ b/deploy/one-click/scripts/one-click/common.sh
@@ -183,7 +183,10 @@ resolve_control_plane_cubemaster_addr() {
   local addr="${ONE_CLICK_CONTROL_PLANE_CUBEMASTER_ADDR:-}"
   local ip="${ONE_CLICK_CONTROL_PLANE_IP:-}"
   local default_addr="${CUBEMASTER_ADDR:-127.0.0.1:8089}"
-  local port="${default_addr##*:}"
+  # 8089 is the cubemaster protocol port (a fixed constant), NOT derived from
+  # CUBEMASTER_ADDR -- that variable is the control node's local listen address;
+  # using its port here was an accidental coupling that broke when they differed.
+  local cubemaster_port=8089
 
   if [[ "${role}" != "compute" ]]; then
     printf '%s\n' "${default_addr}"
@@ -198,8 +201,8 @@ resolve_control_plane_cubemaster_addr() {
 
   if [[ -n "${ip}" ]]; then
     validate_ipv4_literal "${ip}" "ONE_CLICK_CONTROL_PLANE_IP"
-    validate_host_port "${ip}:${port}" "ONE_CLICK_CONTROL_PLANE_IP-derived cubemaster address"
-    printf '%s:%s\n' "${ip}" "${port}"
+    validate_host_port "${ip}:${cubemaster_port}" "ONE_CLICK_CONTROL_PLANE_IP-derived cubemaster address"
+    printf '%s:%s\n' "${ip}" "${cubemaster_port}"
     return 0
   fi
 

--- a/deploy/one-click/scripts/systemd/common.sh
+++ b/deploy/one-click/scripts/systemd/common.sh
@@ -130,7 +130,10 @@ resolve_control_plane_cubemaster_addr() {
   local addr="${ONE_CLICK_CONTROL_PLANE_CUBEMASTER_ADDR:-}"
   local ip="${ONE_CLICK_CONTROL_PLANE_IP:-}"
   local default_addr="${CUBEMASTER_ADDR:-127.0.0.1:8089}"
-  local port="${default_addr##*:}"
+  # 8089 is the cubemaster protocol port (a fixed constant), NOT derived from
+  # CUBEMASTER_ADDR -- that variable is the control node's local listen address;
+  # using its port here was an accidental coupling that broke when they differed.
+  local cubemaster_port=8089
 
   if [[ "${role}" != "compute" ]]; then
     printf '%s\n' "${default_addr}"
@@ -145,8 +148,8 @@ resolve_control_plane_cubemaster_addr() {
 
   if [[ -n "${ip}" ]]; then
     validate_ipv4_literal "${ip}" "ONE_CLICK_CONTROL_PLANE_IP"
-    validate_host_port "${ip}:${port}" "ONE_CLICK_CONTROL_PLANE_IP-derived cubemaster address"
-    printf '%s:%s\n' "${ip}" "${port}"
+    validate_host_port "${ip}:${cubemaster_port}" "ONE_CLICK_CONTROL_PLANE_IP-derived cubemaster address"
+    printf '%s:%s\n' "${ip}" "${cubemaster_port}"
     return 0
   fi
 

--- a/deploy/one-click/tests/test_install_mode.sh
+++ b/deploy/one-click/tests/test_install_mode.sh
@@ -237,6 +237,72 @@ test_control_plane_validators() {
   fi
 }
 
+test_compute_control_plane_preflight() {
+  # Control role: always passes (no-op).
+  ONE_CLICK_DEPLOY_ROLE=control check_compute_control_plane_preflight \
+    || fail "control role should pass without control plane addr"
+
+  # Compute role without either variable: must fail.
+  if ( ONE_CLICK_DEPLOY_ROLE=compute check_compute_control_plane_preflight ) >/dev/null 2>&1; then
+    fail "compute role should fail without control plane addr"
+  fi
+
+  # Compute role with ONE_CLICK_CONTROL_PLANE_IP: should pass.
+  ONE_CLICK_DEPLOY_ROLE=compute \
+  ONE_CLICK_CONTROL_PLANE_IP=10.0.0.11 \
+    check_compute_control_plane_preflight \
+    || fail "compute role should pass with ONE_CLICK_CONTROL_PLANE_IP"
+
+  # Compute role with ONE_CLICK_CONTROL_PLANE_CUBEMASTER_ADDR: should pass.
+  ONE_CLICK_DEPLOY_ROLE=compute \
+  ONE_CLICK_CONTROL_PLANE_CUBEMASTER_ADDR=10.0.0.11:8089 \
+    check_compute_control_plane_preflight \
+    || fail "compute role should pass with ONE_CLICK_CONTROL_PLANE_CUBEMASTER_ADDR"
+
+  # Both set and resolve to the same address: should pass (env.example pattern).
+  ONE_CLICK_DEPLOY_ROLE=compute \
+  ONE_CLICK_CONTROL_PLANE_IP=10.0.0.11 \
+  ONE_CLICK_CONTROL_PLANE_CUBEMASTER_ADDR=10.0.0.11:8089 \
+    check_compute_control_plane_preflight \
+    || fail "should pass when both vars resolve to the same address"
+
+  # Both set to different addresses: must fail (configuration conflict).
+  if ( ONE_CLICK_DEPLOY_ROLE=compute \
+    ONE_CLICK_CONTROL_PLANE_IP=10.0.0.11 \
+    ONE_CLICK_CONTROL_PLANE_CUBEMASTER_ADDR=10.0.0.99:8089 \
+    check_compute_control_plane_preflight ) >/dev/null 2>&1; then
+    fail "should fail when ONE_CLICK_CONTROL_PLANE_IP and _CUBEMASTER_ADDR conflict"
+  fi
+
+  # IP-branch port is ALWAYS 8089: CUBEMASTER_ADDR must not leak into the
+  # compute IP branch. Previously CUBEMASTER_ADDR=...:9999 made the resolved
+  # port 9999; now it is ignored and the fixed cubemaster protocol port is used.
+  local preflight_out
+  preflight_out="$(ONE_CLICK_DEPLOY_ROLE=compute \
+    ONE_CLICK_CONTROL_PLANE_IP=10.0.0.11 \
+    CUBEMASTER_ADDR=192.168.1.1:9999 \
+    check_compute_control_plane_preflight 2>&1)" \
+    || fail "compute role IP branch should pass regardless of CUBEMASTER_ADDR"
+  if grep -Fq "9999" <<<"${preflight_out}"; then
+    fail "CUBEMASTER_ADDR port 9999 must not leak into IP-branch resolution (got: ${preflight_out})"
+  fi
+  grep -Fq "cubemaster port 8089" <<<"${preflight_out}" \
+    || fail "IP branch should resolve to fixed cubemaster port 8089 (got: ${preflight_out})"
+
+  # Compute role with invalid IP: must fail.
+  if ( ONE_CLICK_DEPLOY_ROLE=compute ONE_CLICK_CONTROL_PLANE_IP=999.0.0.1 \
+    check_compute_control_plane_preflight ) >/dev/null 2>&1; then
+    fail "compute role should fail with invalid IP"
+  fi
+
+  # Compute role with invalid addr format: must fail.
+  if ( ONE_CLICK_DEPLOY_ROLE=compute \
+    ONE_CLICK_CONTROL_PLANE_CUBEMASTER_ADDR='bad/host:8089' \
+    check_compute_control_plane_preflight ) >/dev/null 2>&1; then
+    fail "compute role should fail with invalid addr"
+  fi
+}
+
 test_patch_cubelet_config_template_refuses_symlink() {
   local cfg="${TMP_DIR}/cubelet-config.toml"
   cat > "${cfg}" <<'EOF'
@@ -366,6 +432,7 @@ test_parse_args_unknown_is_ignored
 test_assert_safe_install_prefix
 test_wipe_custom_install_prefix_contents
 test_control_plane_validators
+test_compute_control_plane_preflight
 test_patch_cubelet_config_template_refuses_symlink
 test_upgrade_preflight_and_backup
 test_validation_library_fallback_die


### PR DESCRIPTION
## Summary

This PR fixes a long-standing issue where `install-compute.sh` silently succeeded even when the user forgot to configure the control plane address, only failing much later when systemd tried to start the services.

## Changes

### 1. Fail-fast preflight for compute nodes

Added `check_compute_control_plane_preflight()` — a preflight called during `install.sh` that validates the control plane address configuration (via `ONE_CLICK_CONTROL_PLANE_IP` or `ONE_CLICK_CONTROL_PLANE_CUBEMASTER_ADDR`) **before** any package installation or extraction. If neither variable is set for a compute role, the installer dies immediately with a clear, actionable error message.

### 2. Decouple port derivation from CUBEMASTER_ADDR

The compute-node IP-branch port was previously derived from `CUBEMASTER_ADDR` via `${CUBEMASTER_ADDR##*:}`. `CUBEMASTER_ADDR` is the control node local listen address; borrowing its port for the remote connection was accidental coupling. The port is now a fixed constant (`8089` — the cubemaster protocol port) in all 4 copies of the resolution logic.

Note: `ONE_CLICK_CONTROL_PLANE_CUBEMASTER_ADDR` (which accepts an explicit `host:port`) is completely unaffected.

### 3. Guard against conflicting dual-variable config

When both `ONE_CLICK_CONTROL_PLANE_IP` and `ONE_CLICK_CONTROL_PLANE_CUBEMASTER_ADDR` are set but resolve to different addresses, the preflight now dies with a clear error. Previously the addr would silently take priority, hiding the IP mismatch from the user.

## Files changed

| File | Change |
|------|--------|
| `install.sh` | Wire new preflight into the fail-fast block |
| `lib/common.sh` | New `check_compute_control_plane_preflight()` function + conflict guard |
| `scripts/one-click/common.sh` | `port="${CUBEMASTER_ADDR##*:}"` → `cubemaster_port=8089` |
| `scripts/systemd/common.sh` | Same constant fix |
| `scripts/cube-diag/check-procs.sh` | Same constant fix (standalone function, kept independent) |
| `tests/test_install_mode.sh` | 10 new test cases covering all branches |

## Backward compatibility

- `ONE_CLICK_CONTROL_PLANE_IP=x` → still resolves to `x:8089` (value unchanged)
- `ONE_CLICK_CONTROL_PLANE_CUBEMASTER_ADDR=host:port` → still passed through verbatim
- Control node `CUBEMASTER_ADDR` health check usage is untouched
- Compatible with the Terraform deployer (PR #629) which uses `ONE_CLICK_CONTROL_PLANE_IP`