### PR TITLE
cubelet: allow read-only host_dir volumes in CommitSandbox

### DIFF
--- a/Cubelet/services/cubebox/service_test.go
+++ b/Cubelet/services/cubebox/service_test.go
@@ -301,6 +301,31 @@ func TestValidateCommitSandboxTargetRejectsHostDirVolume(t *testing.T) {
 	assert.Contains(t, err.Error(), "host_dir")
 }
 
+func TestValidateCommitSandboxTargetAllowsReadonlyHostDirVolume(t *testing.T) {
+	cb := newRunningCommitSandboxForTest([]*cubeboxv1.Volume{{
+		Name: "host",
+		VolumeSource: &cubeboxv1.VolumeSource{
+			HostDirVolumes: &cubeboxv1.HostDirVolumeSources{
+				VolumeSources: []*cubeboxv1.HostDirSource{{
+					Name:     "host",
+					HostPath: "/var/lib/data",
+				}},
+			},
+		},
+	}}, []*cubeboxv1.VolumeMounts{{
+		Name:          "root",
+		ContainerPath: "/",
+	}, {
+		Name:          "host",
+		ContainerPath: "/data",
+		Readonly:      true,
+	}})
+
+	rootVolume, err := validateCommitSandboxTarget(cb)
+	require.NoError(t, err)
+	assert.Equal(t, "root", rootVolume)
+}
+
 func TestValidateCommitSandboxTargetRejectsSandboxPathHostBind(t *testing.T) {
 	for _, sandboxPathType := range []string{
 		cubeboxv1.SandboxPathType_Directory.String(),

--- a/Cubelet/services/cubebox/template_ops.go
+++ b/Cubelet/services/cubebox/template_ops.go
@@ -334,6 +334,9 @@ func validateCommitVolumeSources(cb *cubeboxstore.CubeBox) error {
 		return nil
 	}
 	usedVolumes := map[string]struct{}{}
+	// Only a writable host_dir blocks commit; a read-only one holds no guest
+	// writes the snapshot could lose. Track which volumes are mounted writable.
+	writableVolumes := map[string]struct{}{}
 	for _, container := range cb.AllContainers() {
 		if container == nil || container.Config == nil {
 			continue
@@ -343,6 +346,9 @@ func validateCommitVolumeSources(cb *cubeboxstore.CubeBox) error {
 				continue
 			}
 			usedVolumes[mount.GetName()] = struct{}{}
+			if !mount.GetReadonly() {
+				writableVolumes[mount.GetName()] = struct{}{}
+			}
 		}
 	}
 	for _, volume := range cb.Volumes {
@@ -357,9 +363,11 @@ func validateCommitVolumeSources(cb *cubeboxstore.CubeBox) error {
 			continue
 		}
 		if hostDirs := source.GetHostDirVolumes(); hostDirs != nil {
-			for _, hostDir := range hostDirs.GetVolumeSources() {
-				if hostDir != nil && hostDir.GetHostPath() != "" {
-					return fmt.Errorf("host_dir volume %s is not supported by CommitSandbox", volume.GetName())
+			if _, writable := writableVolumes[volume.GetName()]; writable {
+				for _, hostDir := range hostDirs.GetVolumeSources() {
+					if hostDir != nil && hostDir.GetHostPath() != "" {
+						return fmt.Errorf("writable host_dir volume %s is not supported by CommitSandbox", volume.GetName())
+					}
 				}
 			}
 		}


### PR DESCRIPTION
## Problem

`CommitSandbox` refuses to snapshot any sandbox that has a mounted `host_dir` volume:

```
host_dir volume <name> is not supported by CommitSandbox
```

The intent is sound for a **writable** host_dir — its writes land on the host, so a self-contained snapshot can't reproduce them. But the check rejects **all** host_dir volumes, including **read-only** ones. A read-only host_dir cannot have received guest writes, so the snapshot loses no state by omitting it; the caller simply re-supplies the same mount on restore (create-from-snapshot re-passes the host-mount metadata).

This blocks a common, useful pattern: mounting a shared, host-supplied **read-only** directory (e.g. a tools dir shared across all sandboxes) while still snapshotting the user's writable rootfs. Today such a sandbox can never be committed.

## Change

`validateCommitVolumeSources` now records which volumes are mounted writable and rejects a `host_dir` volume only when it is mounted writable. Read-only host_dir volumes pass commit. Writable host_dir (and `sandbox_path` Directory/SharedBindMount) volumes remain rejected as before.

## Testing

```
CGO_ENABLED=0 go test ./services/cubebox/ -run TestValidateCommitSandboxTarget
```

All pass, including:
- new `TestValidateCommitSandboxTargetAllowsReadonlyHostDirVolume` (read-only host_dir → commit allowed)
- existing `TestValidateCommitSandboxTargetRejectsHostDirVolume` (writable host_dir → still rejected)
