### PR TITLE
fix(docs): correct stale GitHub links and lifecycle anchor

### DIFF
--- a/docs/guide/lifecycle.md
+++ b/docs/guide/lifecycle.md
@@ -58,7 +58,7 @@ Key parameters of `Sandbox.create()`:
 |-------------------------|----------------------------------------------------------------------------------------------|
 | `template`              | Template ID used to boot the sandbox; defaults to env var `CUBE_TEMPLATE_ID`.                |
 | `timeout`               | Idle timeout in **seconds**. (Note: e2b's `timeoutMs` is milliseconds; Cube uses seconds.)   |
-| `lifecycle`             | Lifecycle policy — see [Platform-managed auto-pause / auto-resume](#platform-managed-auto-pause--auto-resume) below. |
+| `lifecycle`             | Lifecycle policy — see [Platform-managed auto-pause / auto-resume](#platform-managed-auto-pause-auto-resume) below. |
 | `metadata`              | Arbitrary key/value pairs stored on the sandbox; readable from the list / detail endpoints. |
 | `env_vars`              | Environment variables injected into the sandbox process.                                     |
 | `allow_internet_access` | Whether outbound internet is allowed; `network` provides finer-grained egress control.       |

--- a/docs/guide/restrict-public-access.md
+++ b/docs/guide/restrict-public-access.md
@@ -70,7 +70,7 @@ The full TUI version of this script — with side-by-side probe
 summaries and a verdict panel — lives at
 [`examples/code-sandbox-quickstart/restrict_public_access.py`][demo].
 
-[demo]: https://github.com/tencentcloud/CubeSandbox/blob/main/examples/code-sandbox-quickstart/restrict_public_access.py
+[demo]: https://github.com/tencentcloud/CubeSandbox/blob/master/examples/code-sandbox-quickstart/restrict_public_access.py
 
 ## Default behavior
 

--- a/docs/guide/security-proxy.md
+++ b/docs/guide/security-proxy.md
@@ -220,7 +220,7 @@ about:
 
 For host-level deployment of the proxy itself (systemd units, CA
 bootstrap, the iptables one-shot service), see the
-[`deploy/one-click`](https://github.com/tencentcloud/CubeSandbox/tree/main/deploy/one-click)
+[`deploy/one-click`](https://github.com/tencentcloud/CubeSandbox/tree/master/deploy/one-click)
 sources — those wire CubeEgress into both the control and compute
 targets automatically.
 

--- a/docs/zh/guide/restrict-public-access.md
+++ b/docs/zh/guide/restrict-public-access.md
@@ -65,7 +65,7 @@ assert resp.status_code == 200
 带 rich TUI 的完整版示例（含并排 probe 汇总和最终判定面板）位于
 [`examples/code-sandbox-quickstart/restrict_public_access.py`][demo]。
 
-[demo]: https://github.com/tencentcloud/CubeSandbox/blob/main/examples/code-sandbox-quickstart/restrict_public_access.py
+[demo]: https://github.com/tencentcloud/CubeSandbox/blob/master/examples/code-sandbox-quickstart/restrict_public_access.py
 
 ## 默认行为
 

--- a/docs/zh/guide/security-proxy.md
+++ b/docs/zh/guide/security-proxy.md
@@ -195,7 +195,7 @@ inject 的 `secret` 值在写入任何日志路径前都会被剥除。审计日
   HTTPS 在规则评估之前就会因 self-signed cert 报错。
 
 代理本身的部署（systemd 单元、CA 引导、iptables oneshot 服务）见
-[`deploy/one-click`](https://github.com/tencentcloud/CubeSandbox/tree/main/deploy/one-click)
+[`deploy/one-click`](https://github.com/tencentcloud/CubeSandbox/tree/master/deploy/one-click)
 源码 —— 那一套会自动把 CubeEgress 接到 control 和 compute target
 里。
 


### PR DESCRIPTION
## Motivation

Several documentation links still pointed to the non-existent `main` branch, resulting in 404 errors when users click through from the published docs site.

For example, the `examples/code-sandbox-quickstart/restrict_public_access.py` link on the Chinese restrict-public-access guide currently fails because it points to `blob/main` instead of `blob/master`.

While checking these invalid branch links, I also found a broken in-page anchor in the lifecycle guide.

## What Changed

This PR fixes:

* invalid GitHub links from `main` to `master` in:

  * `docs/guide/restrict-public-access.md`
  * `docs/zh/guide/restrict-public-access.md`
  * `docs/guide/security-proxy.md`
  * `docs/zh/guide/security-proxy.md`
* the lifecycle guide anchor for the `Platform-managed Auto-pause / Auto-resume` section

The lifecycle heading generates the slug `#platform-managed-auto-pause-auto-resume`, so the link should not use the double-dash form `#platform-managed-auto-pause--auto-resume`.

## Validation

* confirmed the affected published-docs link currently returns 404 before this fix
* `grep -rn "github.com/tencentcloud/CubeSandbox/\\(blob\\|tree\\)/main/" docs/` returns no matches after this fix
* verified that the lifecycle link points to the generated anchor `#platform-managed-auto-pause-auto-resume`

## Scope

This PR only updates documentation links. It does not change runtime behavior, APIs, CLI behavior, or documentation content semantics.

As a possible follow-up, we could add a docs check that validates GitHub `blob/<branch>` / `tree/<branch>` links against existing repository branches, so invalid branch references like `main` are caught before publishing.

