### PR TITLE
docs: add TakoAPI directory badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Listed on TakoAPI](https://img.shields.io/badge/Listed%20on-TakoAPI-7c3aed)](https://takoapi.com/agents/tencentcloud-cubesandbox)
+
 <p align="center">
   <img src="docs/assets/cube-sandbox-logo.png" alt="Cube Sandbox Logo" width="140" />
 </p>


### PR DESCRIPTION
Hi! 👋 **CubeSandbox** is listed in the [TakoAPI](https://takoapi.com) open agent directory — a free, open catalog that helps people discover AI-agent projects ("one API to discover all agents").

Your listing: https://takoapi.com/agents/tencentcloud-cubesandbox

This PR adds a small badge near the top of the README that links back to that listing, so visitors can find the directory entry. It's entirely optional — if you'd prefer not to include it, just close this PR (no hard feelings, and apologies for the noise).

No tracking and no obligations. Thanks for building CubeSandbox! 🙏