### PR TITLE
feat(cubemaster): make HTTP listen address configurable via http_bind

### DIFF
--- a/CubeMaster/pkg/base/config/config.go
+++ b/CubeMaster/pkg/base/config/config.go
@@ -55,6 +55,9 @@ type CommonConf struct {
 	CubeDestroyCheckFilter          bool              `yaml:"cube_destroy_check_filter"`
 	Debug                           Debug             `toml:"debug"`
 	HttpPort                        int               `yaml:"http_port"`
+	// HttpBind is the HTTP listen address. Empty means 0.0.0.0 (all
+	// interfaces); set to 127.0.0.1 to keep the API loopback-only.
+	HttpBind                        string            `yaml:"http_bind"`
 	WriteTimeout                    int               `yaml:"http_writetimeout"`
 	ReadTimeout                     int               `yaml:"http_readtimeout"`
 	IdleTimeout                     int               `yaml:"http_idletimeout"`
@@ -752,6 +755,10 @@ func preComHandleConf(config *Config) error {
 	}
 	if config.Common.HttpPort == 0 {
 		config.Common.HttpPort = 8089
+	}
+	// Default to all interfaces; deployments can override via http_bind.
+	if config.Common.HttpBind == "" {
+		config.Common.HttpBind = "0.0.0.0"
 	}
 	if config.Common.ReadTimeout == 0 {
 		config.Common.ReadTimeout = 120

--- a/CubeMaster/pkg/server/server.go
+++ b/CubeMaster/pkg/server/server.go
@@ -59,7 +59,7 @@ func NewInternalHttp(ctx context.Context, cfg *config.Config) (*internalHttp, er
 	router := mux.NewRouter()
 	s := &internalHttp{
 		Server: &http.Server{
-			Addr:         fmt.Sprintf("0.0.0.0:%d", cfg.Common.HttpPort),
+			Addr:         fmt.Sprintf("%s:%d", cfg.Common.HttpBind, cfg.Common.HttpPort),
 			ReadTimeout:  time.Second * time.Duration(cfg.Common.ReadTimeout),
 			WriteTimeout: time.Second * time.Duration(cfg.Common.WriteTimeout),
 			IdleTimeout:  time.Second * time.Duration(cfg.Common.IdleTimeout),

--- a/configs/single-node/cubemaster.yaml
+++ b/configs/single-node/cubemaster.yaml
@@ -1,5 +1,8 @@
 common:
   http_port: 8089
+  # Listen address; 0.0.0.0 = all interfaces. Set to 127.0.0.1 to harden a
+  # single all-in-one node (breaks compute nodes / host-net proxy reaching it).
+  http_bind: __CUBEMASTER_HTTP_BIND__
   http_readtimeout: 120
   http_writetimeout: 360
   http_idletimeout: 360

--- a/deploy/one-click/env.example
+++ b/deploy/one-click/env.example
@@ -152,6 +152,11 @@ WEB_UI_UPSTREAM=http://host.docker.internal:3000
 
 # Process listen overrides.
 CUBEMASTER_ADDR=127.0.0.1:8089
+# CubeMaster HTTP listen address (decoupled from the Terraform/TKE path, which
+# always binds 0.0.0.0 inside the pod). Defaults to 0.0.0.0 so compute nodes and
+# the host-network cube-proxy can reach it. Set to 127.0.0.1 ONLY for a lone
+# all-in-one node where nothing external needs to reach CubeMaster.
+CUBEMASTER_HTTP_BIND=0.0.0.0
 NETWORK_AGENT_HEALTH_ADDR=127.0.0.1:19090
 NETWORK_AGENT_READY_TIMEOUT=120
 CUBE_API_BIND=0.0.0.0:3000

--- a/deploy/one-click/install.sh
+++ b/deploy/one-click/install.sh
@@ -279,11 +279,16 @@ generate_cubemaster_config_ports() {
   local cfg="${PKG_ROOT}/CubeMaster/conf.yaml"
   local mysql_port="${CUBE_SANDBOX_MYSQL_PORT:-3306}"
   local redis_port="${CUBE_SANDBOX_REDIS_PORT:-6379}"
+  # Decoupled from the TKE path: one-click decides CubeMaster's listen address
+  # here. Defaults to 0.0.0.0 to stay reachable from compute nodes / host-net
+  # cube-proxy; set CUBEMASTER_HTTP_BIND=127.0.0.1 to harden a lone node.
+  local http_bind="${CUBEMASTER_HTTP_BIND:-0.0.0.0}"
 
   ensure_file "${cfg}"
   sed -i \
     -e "s|__CUBE_SANDBOX_MYSQL_PORT__|${mysql_port}|g" \
     -e "s|__CUBE_SANDBOX_REDIS_PORT__|${redis_port}|g" \
+    -e "s|__CUBEMASTER_HTTP_BIND__|$(escape_sed "${http_bind}")|g" \
     "${cfg}"
 }
 


### PR DESCRIPTION
## Background / Motivation
The single-node (one-click) and Terraform/TKE deployment paths previously had a code-level coupling on port binding: CubeMaster's HTTP listen address was **hardcoded to `0.0.0.0`** in `server.go`, so it could not be adjusted per deployment shape. This meant one-click could never tighten its listening surface when needed, and any binding policy change required editing Go code.

This PR extracts the listen address into a config option so the two deployment paths can choose their binding policy **independently and fully decoupled**.

## What's changed
- **CubeMaster config**: add `common.http_bind` (`yaml:"http_bind"`); the defaulting logic fills in `0.0.0.0` when empty.
- **CubeMaster server**: `http.Server.Addr` changes from `fmt.Sprintf("0.0.0.0:%d", ...)` to `fmt.Sprintf("%s:%d", cfg.Common.HttpBind, ...)`.
- **one-click**:
  - `configs/single-node/cubemaster.yaml` adds a `http_bind: __CUBEMASTER_HTTP_BIND__` placeholder.
  - `install.sh` (`generate_cubemaster_config_ports`) renders the placeholder from the `CUBEMASTER_HTTP_BIND` env var (defaults to `0.0.0.0`), escaped via `escape_sed` to prevent sed injection.
  - `env.example` adds `CUBEMASTER_HTTP_BIND` with usage notes.
- **Terraform/TKE**: `tke-addons.tf` builds its own conf via `yamlencode` and does not read this template, so it needs **no changes**; with `http_bind` unset it falls back to the Go default `0.0.0.0`.

## Behavior & compatibility
- **Fully backward compatible**: all paths still bind `0.0.0.0` by default; existing one-click / TKE deployments are unaffected.
- **Decoupled**: one-click is driven by `CUBEMASTER_HTTP_BIND`, TKE by `tke-addons.tf`; the two no longer influence each other.

## Safety notes (why only CubeMaster is touched)
We intentionally did **not** tighten the default binding of Cubelet / CubeAPI / cube-proxy, because binding them to `127.0.0.1` would break reachability:
- Cubelet gRPC `:9999` must be reachable from the control node across the network -> binding `127.0.0.1` breaks multi-node (compute) deployments.
- CubeAPI must be reachable from the WebUI container via `host.docker.internal` -> binding `127.0.0.1` breaks the WebUI.
- Tightening single-node CubeMaster to `127.0.0.1` is only safe when there are no compute nodes and no host-network cube-proxy reaching it via NODE_IP; hence the default stays `0.0.0.0`, with `CUBEMASTER_HTTP_BIND=127.0.0.1` offered as an explicit opt-in.

## How to use (opt-in hardening)
```bash
# Tighten CubeMaster's listening surface on a lone all-in-one node
CUBEMASTER_HTTP_BIND=127.0.0.1 ./deploy/one-click/install.sh
```

## Testing
- `go vet ./pkg/base/config/` passes; no new lint warnings on the changed files.
- The `server.go` change is a lint-clean `fmt.Sprintf` tweak (the build error in `templatecenter/image` comes from Linux-only syscalls on darwin and is pre-existing/unrelated to this PR).

## Changed files
```
CubeMaster/pkg/base/config/config.go | 7 +++++++
CubeMaster/pkg/server/server.go      | 2 +-
configs/single-node/cubemaster.yaml  | 3 +++
deploy/one-click/env.example         | 5 +++++
deploy/one-click/install.sh          | 5 +++++
```

---

Assisted-by: CodeBuddy