### PR TITLE
docs: add network hardening guide and security notes

### DIFF
--- a/deploy/one-click/README.md
+++ b/deploy/one-click/README.md
@@ -403,6 +403,11 @@ sudo yum install -y e2fsprogs util-linux
 
 ## Prerequisites
 
+> **Security**: All core services bind `0.0.0.0` by default. Before deploying on
+> a machine reachable from untrusted networks, review the
+> [Network Hardening Guide](/guide/network-hardening) for bind-address
+> configuration, firewall rules, and credential rotation.
+
 - The target machine requires `root` privileges.
 - The target machine preferentially uses `systemd-resolved` / `resolvectl` for split DNS of `cube.app`. The current implementation creates a dedicated dummy link (default `cube-dns0`), assigns it a local `/32` address, binds CoreDNS to `169.254.254.53` on that link by default, and attaches that address plus `~cube.app` to the link. If that capability is unavailable, the installation script will fall back to `NetworkManager + dnsmasq`: the same dummy link is created and `dnsmasq` is configured (via `listen-address` / `bind-interfaces`) to listen on both `127.0.0.1` and `169.254.254.53`. `/etc/resolv.conf` is then written by the installer (NetworkManager runs with `rc-manager=unmanaged`) to point at `169.254.254.53`, so host applications and Docker containers see the same non-loopback resolver.
 - The target machine pulls `mysql:8.0` and `redis:7-alpine` from the internet by default.

--- a/deploy/one-click/README_zh.md
+++ b/deploy/one-click/README_zh.md
@@ -388,6 +388,10 @@ sudo yum install -y e2fsprogs util-linux
 
 ## 前置条件
 
+> **安全提示**：所有核心服务默认绑定 `0.0.0.0`。在将部署放到可被不可信网络访问的
+> 机器上之前，请参阅[网络加固指南](/zh/guide/network-hardening)，了解绑定地址
+> 配置、防火墙规则与凭据轮换。
+
 - 目标机需要 `root` 权限。
 - 目标机优先使用 `systemd-resolved` / `resolvectl` 做 `cube.app` 的 split DNS；当前实现会创建专用 dummy link（默认 `cube-dns0`）并为其添加本地 `/32` 地址，`CoreDNS` 默认绑定到 `169.254.254.53`，再把该地址和 `~cube.app` 绑定到该链路。若该能力不可用，则安装脚本会回退到 `NetworkManager + dnsmasq`：同样创建该 dummy link，并通过 `listen-address` / `bind-interfaces` 让 `dnsmasq` 同时绑定 `127.0.0.1` 和 `169.254.254.53`；随后安装器自己写 `/etc/resolv.conf`（NetworkManager 切到 `rc-manager=unmanaged`），把 nameserver 指向 `169.254.254.53`，让宿主应用和 Docker 容器看到同一个非 loopback 解析器。
 - 目标机默认联网拉取 `mysql:8.0` 和 `redis:7-alpine`。

--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -149,6 +149,7 @@ export default withMermaid(defineConfig({
                 { text: 'Service Management & Logs', link: '/guide/service-management' },
                 { text: 'Template Inspection & Request Preview', link: '/guide/template-inspection-and-preview' },
                 { text: 'HTTPS & Domain Resolution', link: '/guide/https-and-domain' },
+                { text: 'Network Hardening', link: '/guide/network-hardening' },
                 { text: 'Authentication', link: '/guide/authentication' }
               ]
             },
@@ -272,6 +273,7 @@ export default withMermaid(defineConfig({
                 { text: '服务管理与日志', link: '/zh/guide/service-management' },
                 { text: '模板检查与请求预览', link: '/zh/guide/template-inspection-and-preview' },
                 { text: 'HTTPS 证书与域名解析', link: '/zh/guide/https-and-domain' },
+                { text: '网络加固', link: '/zh/guide/network-hardening' },
                 { text: '鉴权', link: '/zh/guide/authentication' }
               ]
             },

--- a/docs/guide/network-hardening.md
+++ b/docs/guide/network-hardening.md
@@ -1,0 +1,310 @@
+# Network Hardening
+
+Cube Sandbox's control-plane and management services are optimized for fast
+local evaluation, and several of them bind to `0.0.0.0` by default. On a machine
+reachable from untrusted networks this exposes an attack surface: most
+management endpoints have no authentication or TLS. This guide explains the
+default listening surface and how to lock it down with **bind-address
+configuration** and **firewall rules**.
+
+::: warning
+The one-click / self-build deployments are designed for development and
+evaluation. Before placing a deployment on a public-facing machine, review this
+entire page and apply at least one of the hardening strategies below.
+:::
+
+## Default listening surface
+
+| Process | Default Bind | Port | Config Method | Notes |
+|---------|-------------|------|---------------|-------|
+| CubeMaster | `0.0.0.0` | 8089 | `CUBEMASTER_HTTP_BIND` in `.env` | Cluster management HTTP API, **no auth** |
+| CubeAPI | `0.0.0.0` | 3000 | `CUBE_API_BIND` in `.env` | Sandbox lifecycle API |
+| Cubelet gRPC | `0.0.0.0` | 9999 | `tcp_address` in `Cubelet/config/config.toml` | Node management RPC, **no TLS** |
+| Cubelet HTTP | `0.0.0.0` | 9998 | `[http] address` in `Cubelet/config/config.toml` | Debug / metrics |
+| cube-proxy | `0.0.0.0` | 80 / 443 | `CUBE_PROXY_HTTP_PORT` / `CUBE_PROXY_HTTPS_PORT` | Intentionally public-facing |
+| WebUI | `0.0.0.0` | 12088 | `WEB_UI_HOST_PORT` in `.env` (port only) | Dashboard |
+| MySQL | `127.0.0.1` | 3306 | Hardcoded in compose template | Already loopback-only |
+| Redis | `127.0.0.1` | 6379 | Hardcoded in compose template | Already loopback-only |
+
+MySQL and Redis are already bound to loopback by the bundled compose template
+and are not reachable from the network. The remaining services listed with a
+`0.0.0.0` default are the ones you need to consider.
+
+## Per-service bind address configuration
+
+### CubeMaster
+
+Set in `.env` before running `install.sh`:
+
+```bash
+# Bind to the private NIC (multi-node safe):
+CUBEMASTER_HTTP_BIND=10.0.0.11
+
+# Or loopback-only (single all-in-one node, no compute nodes):
+CUBEMASTER_HTTP_BIND=127.0.0.1
+```
+
+::: warning
+Do **not** set `CUBEMASTER_HTTP_BIND=127.0.0.1` if you have compute nodes or a
+host-network cube-proxy — they reach CubeMaster via the node's external/private
+IP, and loopback binding will break them.
+:::
+
+### CubeAPI
+
+Set in `.env`. The value is `<address>:<port>`:
+
+```bash
+# Bind to the private NIC:
+CUBE_API_BIND=10.0.0.11:3000
+```
+
+When changing `CUBE_API_BIND`, also update `CUBE_API_HEALTH_ADDR` to match:
+
+```bash
+CUBE_API_HEALTH_ADDR=10.0.0.11:3000
+```
+
+::: warning
+The WebUI container reaches CubeAPI via `host.docker.internal`. Binding CubeAPI
+to `127.0.0.1` will break the WebUI in bridge-mode Docker. Use a private-IP bind
+or a firewall rule instead.
+:::
+
+### Cubelet (gRPC + HTTP)
+
+Cubelet reads its listen addresses from `config/config.toml`. After
+installation the file lives at `<PKG_ROOT>/Cubelet/config/config.toml`. Edit:
+
+```toml
+[http]
+  # Default ":9998" means 0.0.0.0:9998
+  address = "10.0.0.11:9998"
+
+[grpc]
+  # Default ":9999" means 0.0.0.0:9999
+  tcp_address = "10.0.0.11:9999"
+```
+
+::: warning
+In multi-node deployments the control node connects to each compute node's
+Cubelet on `tcp_address`. If you bind to a private IP, ensure the control node
+can route to it. Binding to `127.0.0.1` **will break** multi-node communication.
+:::
+
+### WebUI
+
+The WebUI docker-compose template publishes the port as `<WEB_UI_HOST_PORT>:80`
+and the variable currently accepts a port number only. To restrict access, use a
+firewall rule:
+
+```bash
+sudo iptables -A INPUT -p tcp --dport 12088 -s 10.0.0.0/24 -j ACCEPT
+sudo iptables -A INPUT -p tcp --dport 12088 -j DROP
+```
+
+### cube-proxy (HTTP/HTTPS)
+
+cube-proxy uses host networking and is typically the public entry point for
+sandbox traffic. Keep it on `0.0.0.0` unless you front it with a dedicated
+reverse proxy:
+
+```bash
+CUBE_PROXY_HTTP_PORT=80
+CUBE_PROXY_HTTPS_PORT=443
+```
+
+If you need to restrict source IPs, use firewall rules.
+
+### MySQL / Redis
+
+The bundled containers already bind to `127.0.0.1` via the compose template — no
+extra configuration needed. If you use external MySQL/Redis
+(`CUBE_EXTERNAL_MYSQL_HOST`), enforce access control at the network level.
+
+## Hardening strategies
+
+Choose one or both of the following, depending on your environment.
+
+### Option A: Bind to the private network interface
+
+If the machine has both a public and a private NIC, bind management services to
+the **private (internal) IP** so only the internal network can reach them while
+the public interface stays unexposed:
+
+```bash
+# .env
+CUBEMASTER_HTTP_BIND=10.0.0.11
+CUBE_API_BIND=10.0.0.11:3000
+CUBE_API_HEALTH_ADDR=10.0.0.11:3000
+```
+
+```toml
+# Cubelet/config/config.toml
+[http]
+  address = "10.0.0.11:9998"
+[grpc]
+  tcp_address = "10.0.0.11:9999"
+```
+
+This keeps multi-node communication intact (compute nodes connect via the
+private network) while preventing public internet access.
+
+For a **single all-in-one node with no compute nodes**, you can bind to
+`127.0.0.1` for maximum restriction (subject to the caveats noted per service
+above).
+
+### Option B: Firewall source-IP whitelisting
+
+Keep the default `0.0.0.0` binding but allow connections **only from trusted
+source IPs** (your compute nodes and admin machine).
+
+Using `iptables`:
+
+```bash
+# Allow CubeMaster only from compute nodes + admin
+sudo iptables -A INPUT -p tcp --dport 8089 -s 10.0.0.12 -j ACCEPT       # compute-1
+sudo iptables -A INPUT -p tcp --dport 8089 -s 10.0.0.13 -j ACCEPT       # compute-2
+sudo iptables -A INPUT -p tcp --dport 8089 -s 192.168.1.100 -j ACCEPT   # admin
+sudo iptables -A INPUT -p tcp --dport 8089 -j DROP                      # deny others
+
+# Repeat the same pattern for 9999, 3000, 12088 as needed
+```
+
+Using `ufw`:
+
+```bash
+sudo ufw default deny incoming
+sudo ufw allow from 10.0.0.0/24 to any port 8089 proto tcp   # CubeMaster
+sudo ufw allow from 10.0.0.0/24 to any port 9999 proto tcp   # Cubelet
+sudo ufw allow from 10.0.0.0/24 to any port 3000 proto tcp   # CubeAPI
+sudo ufw allow from 10.0.0.0/24 to any port 12088 proto tcp  # WebUI
+sudo ufw allow 22/tcp     # SSH
+sudo ufw allow 80/tcp     # cube-proxy (public if needed)
+sudo ufw allow 443/tcp    # cube-proxy TLS
+sudo ufw enable
+```
+
+### Combining both approaches (recommended)
+
+For defense in depth, **bind to a private IP and set firewall rules**. Even if
+one layer is misconfigured, the other still protects you.
+
+## Multi-node port reachability requirements
+
+When deploying compute nodes, the following connectivity must remain open.
+Ensure your bind addresses and firewall rules do **not** block these paths:
+
+| Direction | Port | Service | Required for |
+|-----------|------|---------|-------------|
+| Compute → Control | 8089/tcp | CubeMaster | Sandbox metadata, node registration |
+| Control → Compute | 9999/tcp | Cubelet gRPC | Sandbox lifecycle operations |
+
+## Default credentials
+
+The following values in `env.example` are **examples only** — change them for
+any deployment beyond local evaluation:
+
+| Variable | Risk |
+|----------|------|
+| `CUBE_SANDBOX_MYSQL_ROOT_PASSWORD` | Full database access |
+| `CUBE_SANDBOX_MYSQL_PASSWORD` | Application database access |
+| `CUBE_SANDBOX_REDIS_PASSWORD` | Cache / session access |
+| `E2B_API_KEY` (defaults to `e2b_000000`) | API authentication |
+| `DATABASE_URL` | Embeds the MySQL user / password |
+
+## Custom Authentication (Auth Callback)
+
+By default CubeAPI accepts **every request without any credential check**. For
+any deployment beyond local evaluation you should delegate authentication to an
+external service via the **auth callback** mechanism. When configured, every API
+request (except `GET /health`) must carry a credential, and CubeAPI forwards it
+to your callback for a permit/deny decision.
+
+### Enabling
+
+Set the callback URL in `.env`, or pass it as a CLI flag (the flag overrides the
+environment variable):
+
+```bash
+# .env
+AUTH_CALLBACK_URL=https://your-auth-service/verify
+
+# Or CLI flag
+./cube-api --auth-callback-url https://your-auth-service/verify
+```
+
+When `AUTH_CALLBACK_URL` is **not set** (the default), all requests are allowed
+without any credential check.
+
+### How it works
+
+```
+Client ──→ CubeAPI
+               │
+               ├─ Extract credential (Authorization: Bearer / X-API-Key)
+               ├─ Capture path + HTTP method
+               │
+               └─ POST → AUTH_CALLBACK_URL
+                              │
+                     200 ─────┤──→ allow request
+                  non-200 ────┘──→ 401 Unauthorized
+```
+
+CubeAPI forwards these headers to your callback:
+
+| Header | Description |
+|--------|-------------|
+| `Authorization` | `Bearer <token>` (when client used Bearer auth) |
+| `X-API-Key` | `<key>` (when client used API Key auth) |
+| `X-Request-Path` | Original request path, e.g. `/templates/my-tmpl` |
+| `X-Request-Method` | HTTP method, e.g. `GET`, `DELETE`, `PATCH` |
+
+`Authorization` and `X-API-Key` are mutually exclusive — the callback receives
+whichever one the client sent (Bearer takes priority). If the client sends
+neither, CubeAPI returns `401` without calling your service.
+
+::: warning Always validate path **and** method
+The same path (e.g. `/templates/:id`) serves GET (read), POST (rebuild),
+DELETE, and PATCH (update). A callback that only checks the path cannot prevent
+a read-only key from escalating to a delete operation. Always check **both**
+`X-Request-Path` and `X-Request-Method`.
+:::
+
+::: warning Callback availability
+If the callback URL is unreachable, CubeAPI fails closed (the request is
+rejected). Host your auth service with sufficient availability and keep its
+latency low, since every API request waits on it.
+:::
+
+### SDK integration
+
+The E2B SDK sends `E2B_API_KEY` as `Authorization: Bearer <key>` automatically:
+
+```bash
+export E2B_API_KEY=your-actual-api-key
+```
+
+For non-SDK clients, send `X-API-Key: <key>` directly.
+
+::: tip Full guide
+For a complete callback implementation example (Python/FastAPI) and error
+response reference, see [Authentication](/guide/authentication).
+:::
+
+## TLS
+
+- CubeMaster and CubeAPI do not terminate TLS. Place them behind cube-proxy or a
+  separate reverse proxy if external TLS is required.
+- Cubelet gRPC is plaintext; rely on network-level isolation (bind address or
+  firewall) to protect it.
+- cube-proxy handles TLS termination via `mkcert`-generated certificates by
+  default; replace these with production certificates for public-facing
+  deployments.
+
+## Related
+
+- [Network Policy](/guide/network-policy) — sandbox outbound CIDR allow/deny.
+- [Security Proxy](/guide/security-proxy) — L7 rules on sandbox outbound HTTP/HTTPS.
+- [Restrict Public Access](/guide/restrict-public-access) — per-sandbox inbound token.
+- [Multi-Node Cluster Deployment](/guide/multi-node-deploy) — adding compute nodes.

--- a/docs/zh/guide/network-hardening.md
+++ b/docs/zh/guide/network-hardening.md
@@ -1,0 +1,293 @@
+# 网络加固
+
+Cube Sandbox 的控制面与管理类服务为了便于本地快速体验，部分服务默认绑定在
+`0.0.0.0` 上。当机器可被不可信网络访问时，这会暴露出攻击面：大多数管理端点
+既无鉴权也无 TLS。本文说明默认的监听面，并介绍如何通过**绑定地址配置**与
+**防火墙规则**进行收紧。
+
+::: warning
+一键部署 / 本地构建部署面向开发与评估场景。在将部署放到可被公网访问的机器上
+之前，请通读本文，并至少应用下文中的一种加固方案。
+:::
+
+## 默认监听面
+
+| 进程 | 默认绑定 | 端口 | 配置方式 | 说明 |
+|------|---------|------|----------|------|
+| CubeMaster | `0.0.0.0` | 8089 | `.env` 中的 `CUBEMASTER_HTTP_BIND` | 集群管理 HTTP API，**无鉴权** |
+| CubeAPI | `0.0.0.0` | 3000 | `.env` 中的 `CUBE_API_BIND` | 沙箱生命周期 API |
+| Cubelet gRPC | `0.0.0.0` | 9999 | `Cubelet/config/config.toml` 的 `tcp_address` | 节点管理 RPC，**无 TLS** |
+| Cubelet HTTP | `0.0.0.0` | 9998 | `Cubelet/config/config.toml` 的 `[http] address` | 调试 / metrics |
+| cube-proxy | `0.0.0.0` | 80 / 443 | `CUBE_PROXY_HTTP_PORT` / `CUBE_PROXY_HTTPS_PORT` | 设计上即面向公网 |
+| WebUI | `0.0.0.0` | 12088 | `.env` 中的 `WEB_UI_HOST_PORT`（仅端口） | 控制台 |
+| MySQL | `127.0.0.1` | 3306 | compose 模板中硬编码 | 已仅绑回环 |
+| Redis | `127.0.0.1` | 6379 | compose 模板中硬编码 | 已仅绑回环 |
+
+MySQL 与 Redis 已由内置 compose 模板绑定到回环地址，网络上不可达。需要重点关注
+的是表中默认为 `0.0.0.0` 的其余服务。
+
+## 各服务绑定地址配置
+
+### CubeMaster
+
+在运行 `install.sh` 之前，于 `.env` 中设置：
+
+```bash
+# 绑定到内网网卡（多机部署安全）：
+CUBEMASTER_HTTP_BIND=10.0.0.11
+
+# 或仅绑回环（单机一体化、无 compute 节点）：
+CUBEMASTER_HTTP_BIND=127.0.0.1
+```
+
+::: warning
+如果你有 compute 节点或使用 host 网络模式的 cube-proxy，**请勿**将
+`CUBEMASTER_HTTP_BIND` 设为 `127.0.0.1`——它们需要通过节点的外网/内网 IP 访问
+CubeMaster，绑回环会导致它们断联。
+:::
+
+### CubeAPI
+
+在 `.env` 中设置，取值为 `<地址>:<端口>`：
+
+```bash
+# 绑定到内网网卡：
+CUBE_API_BIND=10.0.0.11:3000
+```
+
+修改 `CUBE_API_BIND` 时，需同步更新 `CUBE_API_HEALTH_ADDR`：
+
+```bash
+CUBE_API_HEALTH_ADDR=10.0.0.11:3000
+```
+
+::: warning
+WebUI 容器通过 `host.docker.internal` 访问 CubeAPI。将 CubeAPI 绑定到
+`127.0.0.1` 会导致桥接模式 Docker 下的 WebUI 不可用。请改用内网 IP 绑定或
+防火墙规则。
+:::
+
+### Cubelet（gRPC + HTTP）
+
+Cubelet 从 `config/config.toml` 读取监听地址。安装完成后该文件位于
+`<PKG_ROOT>/Cubelet/config/config.toml`。编辑：
+
+```toml
+[http]
+  # 默认 ":9998" 即 0.0.0.0:9998
+  address = "10.0.0.11:9998"
+
+[grpc]
+  # 默认 ":9999" 即 0.0.0.0:9999
+  tcp_address = "10.0.0.11:9999"
+```
+
+::: warning
+多机部署中，控制节点通过 `tcp_address` 连接每个 compute 节点的 Cubelet。如果
+绑定到内网 IP，请确保控制节点能够路由到该地址。绑定到 `127.0.0.1`
+**会破坏**多机通信。
+:::
+
+### WebUI
+
+WebUI 的 docker-compose 模板以 `<WEB_UI_HOST_PORT>:80` 形式发布端口，该变量目前
+只接受端口号。如需限制访问，请使用防火墙规则：
+
+```bash
+sudo iptables -A INPUT -p tcp --dport 12088 -s 10.0.0.0/24 -j ACCEPT
+sudo iptables -A INPUT -p tcp --dport 12088 -j DROP
+```
+
+### cube-proxy（HTTP/HTTPS）
+
+cube-proxy 使用 host 网络模式，通常是沙箱流量的公网入口。除非你在其前面再放一层
+专用反向代理，否则保持 `0.0.0.0`：
+
+```bash
+CUBE_PROXY_HTTP_PORT=80
+CUBE_PROXY_HTTPS_PORT=443
+```
+
+若需限制来源 IP，请使用防火墙规则。
+
+### MySQL / Redis
+
+内置容器已通过 compose 模板绑定到 `127.0.0.1`，无需额外配置。若使用外部
+MySQL/Redis（`CUBE_EXTERNAL_MYSQL_HOST`），请在网络层做好访问控制。
+
+## 加固方案
+
+根据你的环境，选择以下一种或两种方案。
+
+### 方案 A：绑定到内网网卡
+
+若机器同时拥有公网与内网网卡，将管理类服务绑定到**内网 IP**，使其仅内网可达，
+公网接口不暴露：
+
+```bash
+# .env
+CUBEMASTER_HTTP_BIND=10.0.0.11
+CUBE_API_BIND=10.0.0.11:3000
+CUBE_API_HEALTH_ADDR=10.0.0.11:3000
+```
+
+```toml
+# Cubelet/config/config.toml
+[http]
+  address = "10.0.0.11:9998"
+[grpc]
+  tcp_address = "10.0.0.11:9999"
+```
+
+这样既保持多机通信正常（compute 节点经内网连接），又避免公网访问。
+
+对于**单机一体化、无 compute 节点**的场景，可以绑定到 `127.0.0.1` 实现最大限度
+收紧（注意上文各服务的相关限制）。
+
+### 方案 B：防火墙源 IP 白名单
+
+保持默认的 `0.0.0.0` 绑定，但通过防火墙规则只放通**可信来源 IP**（你的 compute
+节点和管理机）。
+
+使用 `iptables`：
+
+```bash
+# CubeMaster 只放通 compute 节点 + 管理机
+sudo iptables -A INPUT -p tcp --dport 8089 -s 10.0.0.12 -j ACCEPT       # compute-1
+sudo iptables -A INPUT -p tcp --dport 8089 -s 10.0.0.13 -j ACCEPT       # compute-2
+sudo iptables -A INPUT -p tcp --dport 8089 -s 192.168.1.100 -j ACCEPT   # 管理机
+sudo iptables -A INPUT -p tcp --dport 8089 -j DROP                      # 拒绝其余
+
+# 对 9999、3000、12088 按需重复同样的规则
+```
+
+使用 `ufw`：
+
+```bash
+sudo ufw default deny incoming
+sudo ufw allow from 10.0.0.0/24 to any port 8089 proto tcp   # CubeMaster
+sudo ufw allow from 10.0.0.0/24 to any port 9999 proto tcp   # Cubelet
+sudo ufw allow from 10.0.0.0/24 to any port 3000 proto tcp   # CubeAPI
+sudo ufw allow from 10.0.0.0/24 to any port 12088 proto tcp  # WebUI
+sudo ufw allow 22/tcp     # SSH
+sudo ufw allow 80/tcp     # cube-proxy（如需公网）
+sudo ufw allow 443/tcp    # cube-proxy TLS
+sudo ufw enable
+```
+
+### 两者结合（推荐）
+
+为实现纵深防御，**同时绑定内网 IP 并设置防火墙规则**。即使某一层配置失误，另一层
+仍能提供保护。
+
+## 多机端口可达性要求
+
+部署 compute 节点时，以下连通性必须保持开放。请确保你的绑定地址与防火墙规则
+**不会**阻断这些路径：
+
+| 方向 | 端口 | 服务 | 用途 |
+|------|------|------|------|
+| Compute → 控制节点 | 8089/tcp | CubeMaster | 沙箱元数据、节点注册 |
+| 控制节点 → Compute | 9999/tcp | Cubelet gRPC | 沙箱生命周期操作 |
+
+## 默认凭据
+
+`env.example` 中的以下取值均为**示例值**——任何超出本地评估范围的部署都必须修改：
+
+| 变量 | 风险 |
+|------|------|
+| `CUBE_SANDBOX_MYSQL_ROOT_PASSWORD` | 数据库完全访问权限 |
+| `CUBE_SANDBOX_MYSQL_PASSWORD` | 应用数据库访问权限 |
+| `CUBE_SANDBOX_REDIS_PASSWORD` | 缓存 / 会话访问权限 |
+| `E2B_API_KEY`（默认 `e2b_000000`） | API 鉴权 |
+| `DATABASE_URL` | 内含 MySQL 用户 / 密码 |
+
+## 自定义鉴权（Auth Callback）
+
+CubeAPI 默认**对所有请求放行、不做任何凭证校验**。对于任何超出本地评估范围的部署，
+都应通过 **Auth Callback** 机制将鉴权决策委托给你自己的鉴权服务。启用后，除
+`GET /health` 外的所有 API 请求都必须携带凭证，CubeAPI 将其转发到你的回调服务
+进行放行/拒绝判定。
+
+### 启用方式
+
+在 `.env` 中设置回调地址，或通过 CLI 参数传入（CLI 参数优先级高于环境变量）：
+
+```bash
+# .env
+AUTH_CALLBACK_URL=https://your-auth-service/verify
+
+# 或 CLI 参数
+./cube-api --auth-callback-url https://your-auth-service/verify
+```
+
+未设置 `AUTH_CALLBACK_URL` 时（默认），所有请求无需凭证即可通过。
+
+### 工作原理
+
+```
+客户端 ──→ CubeAPI
+               │
+               ├─ 提取凭证（Authorization: Bearer / X-API-Key）
+               ├─ 记录请求路径 + HTTP 方法
+               │
+               └─ POST → AUTH_CALLBACK_URL
+                              │
+                     200 ─────┤──→ 放行请求
+                  非 200 ─────┘──→ 401 Unauthorized
+```
+
+CubeAPI 向回调地址转发的 header：
+
+| Header | 说明 |
+|--------|------|
+| `Authorization` | `Bearer <token>` —— 客户端使用 Bearer 鉴权时透传 |
+| `X-API-Key` | `<key>` —— 客户端使用 API Key 鉴权时透传 |
+| `X-Request-Path` | 原始请求路径，如 `/templates/my-tmpl` |
+| `X-Request-Method` | HTTP 方法，如 `GET`、`DELETE`、`PATCH` |
+
+`Authorization` 与 `X-API-Key` 互斥——回调会收到客户端实际发送的那一个（Bearer
+优先）。若两者都未携带，CubeAPI 直接返回 `401`，不会调用你的服务。
+
+::: warning 必须同时校验路径和方法
+同一路径上挂载了多个 HTTP 方法——如 `/templates/:id` 同时处理 GET（读取）、
+POST（重建）、DELETE（删除）和 PATCH（更新）。仅按路径白名单授权无法阻止只读
+凭证发起删除操作。
+
+请在回调中**同时校验** `X-Request-Path` 和 `X-Request-Method`。
+:::
+
+::: warning 回调服务可用性
+回调地址不可达时，CubeAPI 采取"失败即拒绝"策略（请求被拒绝）。请保证鉴权服务
+具备足够的可用性并保持低延迟，因为每个 API 请求都会等待它返回。
+:::
+
+### SDK 侧配置
+
+E2B SDK 会自动将 `E2B_API_KEY` 以 `Authorization: Bearer <key>` 的形式附加到请求中：
+
+```bash
+export E2B_API_KEY=your-actual-api-key
+```
+
+非 SDK 客户端直接发送 `X-API-Key: <key>` 即可。
+
+::: tip 完整指南
+如需回调服务的完整实现示例（Python/FastAPI）和错误响应参考，请查阅
+[鉴权配置](/zh/guide/authentication)。
+:::
+
+## TLS
+
+- CubeMaster 与 CubeAPI 不做 TLS 终止。如需对外 TLS，请将其置于 cube-proxy 或
+  独立反向代理之后。
+- Cubelet gRPC 为明文传输；请依靠网络层隔离（绑定地址或防火墙）加以保护。
+- cube-proxy 默认通过 `mkcert` 生成的证书做 TLS 终止；面向公网部署时请替换为
+  生产环境证书。
+
+## 相关文档
+
+- [网络策略](/zh/guide/network-policy) —— 沙箱出站 CIDR 放通/拒绝。
+- [安全代理](/zh/guide/security-proxy) —— 对沙箱出站 HTTP/HTTPS 的 L7 规则。
+- [限制公开访问](/zh/guide/restrict-public-access) —— 单沙箱入站令牌。
+- [多机集群部署](/zh/guide/multi-node-deploy) —— 添加 compute 节点。


### PR DESCRIPTION
## Summary

Cube Sandbox's control-plane and management services (CubeMaster, CubeAPI,
Cubelet gRPC/HTTP, WebUI) bind to `0.0.0.0` by default and mostly have **no auth
or TLS**, to keep local evaluation friction-free. On a machine reachable from
untrusted networks this exposes a significant attack surface. This PR adds a
dedicated security guide and a deploy-time warning so users harden their
deployment before going public.

## Changes

- **New guide: Network Hardening (EN/ZH)** — `docs/guide/network-hardening.md`,
  `docs/zh/guide/network-hardening.md`:
  - Default listening surface table (bind address, port, config method, auth/TLS
    status per service).
  - Per-service bind-address configuration, with caveats about how binding to
    `127.0.0.1` can break multi-node, WebUI, or health checks.
  - Hardening strategies: bind to a private NIC, firewall source-IP whitelisting
    (`iptables` / `ufw`), and combining both for defense in depth.
  - Multi-node port reachability requirements that must stay open.
  - Default credentials to rotate, and the Auth Callback (`AUTH_CALLBACK_URL`)
    mechanism for delegating authentication, plus TLS notes.
- **One-click deploy README (EN/ZH)** — added a security callout in
  "Prerequisites" noting the default `0.0.0.0` binding and linking to the guide.

## Files

| File | Change |
| --- | --- |
| `docs/guide/network-hardening.md` | New (EN guide) |
| `docs/zh/guide/network-hardening.md` | New (ZH guide) |
| `deploy/one-click/README.md` | Security callout + link |
| `deploy/one-click/README_zh.md` | Same (ZH) |

## Verification

- Docs-only change; no code logic, no new dependencies.
- Build/preview with VitePress to confirm both pages render, internal links
  resolve, and example commands (`iptables` / `ufw` / `.env` / `config.toml`)
  are correct.

---

Signed-off-by: Feng Jin(ronyjin@tencent.com)