### PR TITLE
docs: fix doc links and surface snapshot-rollback-clone in sidebar

### DIFF
--- a/deploy/one-click/README.md
+++ b/deploy/one-click/README.md
@@ -405,7 +405,7 @@ sudo yum install -y e2fsprogs util-linux
 
 > **Security**: All core services bind `0.0.0.0` by default. Before deploying on
 > a machine reachable from untrusted networks, review the
-> [Network Hardening Guide](/guide/network-hardening) for bind-address
+> [Network Hardening Guide](https://cubesandbox.com/guide/network-hardening.html) for bind-address
 > configuration, firewall rules, and credential rotation.
 
 - The target machine requires `root` privileges.

--- a/deploy/one-click/README_zh.md
+++ b/deploy/one-click/README_zh.md
@@ -389,7 +389,7 @@ sudo yum install -y e2fsprogs util-linux
 ## 前置条件
 
 > **安全提示**：所有核心服务默认绑定 `0.0.0.0`。在将部署放到可被不可信网络访问的
-> 机器上之前，请参阅[网络加固指南](/zh/guide/network-hardening)，了解绑定地址
+> 机器上之前，请参阅[网络加固指南](https://cubesandbox.com/zh/guide/network-hardening.html)，了解绑定地址
 > 配置、防火墙规则与凭据轮换。
 
 - 目标机需要 `root` 权限。

--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -122,6 +122,7 @@ export default withMermaid(defineConfig({
               items: [
                 { text: 'Sandbox Lifecycle', link: '/guide/lifecycle' },
                 { text: 'Templates Overview', link: '/guide/templates' },
+                { text: 'Snapshot, Rollback & Clone', link: '/guide/snapshot-rollback-clone' },
                 { text: 'Digital Assistant', link: '/guide/digital-assistant' },
                 { text: 'Performance Benchmark', link: '/guide/performance-benchmark' }
               ]
@@ -246,6 +247,7 @@ export default withMermaid(defineConfig({
               items: [
                 { text: '沙箱生命周期', link: '/zh/guide/lifecycle' },
                 { text: '模板概览', link: '/zh/guide/templates' },
+                { text: '快照、回滚与克隆', link: '/zh/guide/snapshot-rollback-clone' },
                 { text: '数字助手', link: '/zh/guide/digital-assistant' },
                 { text: '性能测试', link: '/zh/guide/performance-benchmark' }
               ]

--- a/docs/zh/index.md
+++ b/docs/zh/index.md
@@ -30,7 +30,7 @@ features:
 - [快速开始](./guide/quickstart.md) — 几分钟内从零到运行沙箱
 - [本地构建部署](./guide/self-build-deploy.md) — 从源码构建并在单机上部署
 - [多机集群部署](./guide/multi-node-deploy.md) — 扩展到多节点集群
-- [架构概览](../architecture/overview.md) — 了解系统设计与核心组件
+- [架构概览](./architecture/overview.md) — 了解系统设计与核心组件
 
 ## 场景示例
 


### PR DESCRIPTION
- Fix zh homepage architecture link that resolved to the English page (../ -> ./)
- Add "Snapshot, Rollback & Clone" to the Core Concepts sidebar for both locales
- Replace site-absolute network-hardening paths in one-click README with full URLs to avoid 404 on GitHub

Signed-off-by: Feng Jin(ronyjin@tencent.com)