### PR TITLE
fix(image): Remove WithNoSameOwner 

### DIFF
--- a/CubeMaster/pkg/base/config/config.go
+++ b/CubeMaster/pkg/base/config/config.go
@@ -43,18 +43,18 @@ type Config struct {
 }
 
 type CommonConf struct {
-	MockUpdateAction                bool              `yaml:"mock_update_action"`
-	DebugDumpHttpBody               bool              `yaml:"debug_dump_http_body"`
-	MockDebug                       bool              `yaml:"mock_debug"`
-	MockNodeNum                     int               `yaml:"mock_node_num"`
-	MockCreateDirect                bool              `yaml:"mock_create_direct"`
-	MockCreateDirectHandle          bool              `yaml:"mock_create_direct_handle"`
-	MockHttpDirect                  bool              `yaml:"mock_http_direct"`
-	MockCreateSleep                 time.Duration     `yaml:"mock_create_sleep"`
-	MockPercents                    []float64         `yaml:"mock_percents"`
-	CubeDestroyCheckFilter          bool              `yaml:"cube_destroy_check_filter"`
-	Debug                           Debug             `toml:"debug"`
-	HttpPort                        int               `yaml:"http_port"`
+	MockUpdateAction       bool          `yaml:"mock_update_action"`
+	DebugDumpHttpBody      bool          `yaml:"debug_dump_http_body"`
+	MockDebug              bool          `yaml:"mock_debug"`
+	MockNodeNum            int           `yaml:"mock_node_num"`
+	MockCreateDirect       bool          `yaml:"mock_create_direct"`
+	MockCreateDirectHandle bool          `yaml:"mock_create_direct_handle"`
+	MockHttpDirect         bool          `yaml:"mock_http_direct"`
+	MockCreateSleep        time.Duration `yaml:"mock_create_sleep"`
+	MockPercents           []float64     `yaml:"mock_percents"`
+	CubeDestroyCheckFilter bool          `yaml:"cube_destroy_check_filter"`
+	Debug                  Debug         `toml:"debug"`
+	HttpPort               int           `yaml:"http_port"`
 	// HttpBind is the HTTP listen address. Empty means 0.0.0.0 (all
 	// interfaces); set to 127.0.0.1 to keep the API loopback-only.
 	HttpBind                        string            `yaml:"http_bind"`

--- a/CubeMaster/pkg/templatecenter/image/native.go
+++ b/CubeMaster/pkg/templatecenter/image/native.go
@@ -275,8 +275,9 @@ func StreamRegistryToDir(ctx context.Context, source *PreparedSource, destDir st
 				_ = f.Close()
 				return fmt.Errorf("native export failed to decompress layer %d: %w", i, err)
 			}
-
-			_, applyErr := archive.Apply(egCtx, destDir, decompressed, archive.WithNoSameOwner())
+			// WithNoSameOwner,it squashes all uid/gid to the
+			// unpacking user (root), breaking images with non-root-owned files.
+			_, applyErr := archive.Apply(egCtx, destDir, decompressed)
 			_ = decompressed.Close()
 			_ = f.Close() // safe to double close, ensures FD is freed immediately
 


### PR DESCRIPTION
Remove the unconditional WithNoSameOwner() call so archive.Apply preserves the original uid/gid from the image layers when running as root.