### PR TITLE
docs(cubemaster): add multi-node scheduler scoring guidance

### DIFF
--- a/docs/guide/multi-node-deploy.md
+++ b/docs/guide/multi-node-deploy.md
@@ -117,6 +117,38 @@ curl http://127.0.0.1:8089/internal/meta/nodes
 
 The response should include the compute node's IP and a healthy status.
 
+## Configure CubeMaster Scheduler Scoring
+
+For multi-node deployments, configure CubeMaster's `scheduler.score` on the control node. If scoring is omitted, CubeMaster filters eligible nodes and then selects from the filtered node order, which can concentrate new sandboxes on the first eligible node until resource filters push traffic elsewhere.
+
+Merge the following scheduler fields into the existing `scheduler` section of `cubemaster.yaml`. Keep your existing `filter`, timeout, overcommit, and other scheduler settings.
+
+```yaml
+scheduler:
+  # Keep your existing filter, timeout, overcommit, and other scheduler settings.
+  priority_select_num: 3
+  score:
+    enable_scorers:
+      - real_time_weighted_average
+    resource_weights:
+      mvm_num: 2
+      local_create_num: 3
+      quota_cpu_usage: 1
+      quota_mem_usage: 1
+    plugin_conf:
+      real_time_weighted_average:
+        weight: 1.0
+        enable_weight_factors:
+          - mvm_num
+          - local_create_num
+          - quota_cpu_usage
+          - quota_mem_usage
+```
+
+For multi-node clusters, set `scheduler.priority_select_num` to a value greater than `1` so CubeMaster randomly selects from the top scored nodes. The shipped default config uses `priority_select_num: 1`, which means scoring only determines which single node receives the next sandbox. Use `3` as a starting point for small clusters and tune it based on your node count. `scheduler.least_select_name` defaults to `random`, so it usually does not need to be set explicitly.
+
+After updating `cubemaster.yaml`, restart CubeMaster with your normal deployment procedure so the scheduler loads the new scoring configuration.
+
 ## Common Operations
 
 ### Stop Compute Node Services

--- a/docs/zh/guide/multi-node-deploy.md
+++ b/docs/zh/guide/multi-node-deploy.md
@@ -117,6 +117,38 @@ curl http://127.0.0.1:8089/internal/meta/nodes
 
 返回结果中应包含计算节点的 IP 和健康状态。
 
+## 配置 CubeMaster 调度评分
+
+多机部署时，应在控制节点的 CubeMaster 配置中设置 `scheduler.score`。如果未配置评分，CubeMaster 会先过滤可用节点，再按照过滤后的节点顺序进行选择，新的沙箱可能集中到第一个可用节点，直到资源过滤器把流量推到其他节点。
+
+可以将下面这些调度字段合并到 `cubemaster.yaml` 中已有的 `scheduler` 段。请保留当前部署已有的 `filter`、超时、overcommit 和其他 scheduler 配置。
+
+```yaml
+scheduler:
+  # 保留当前部署已有的 filter、超时、overcommit 和其他 scheduler 配置。
+  priority_select_num: 3
+  score:
+    enable_scorers:
+      - real_time_weighted_average
+    resource_weights:
+      mvm_num: 2
+      local_create_num: 3
+      quota_cpu_usage: 1
+      quota_mem_usage: 1
+    plugin_conf:
+      real_time_weighted_average:
+        weight: 1.0
+        enable_weight_factors:
+          - mvm_num
+          - local_create_num
+          - quota_cpu_usage
+          - quota_mem_usage
+```
+
+对于多机集群，建议将 `scheduler.priority_select_num` 设置为大于 `1` 的值，让 CubeMaster 从评分最高的一组节点中随机选择。随项目提供的默认配置使用 `priority_select_num: 1`，这意味着评分只会决定下一个沙箱落到哪一个节点，而不会在多个高分节点之间分散放置。小规模集群可以从 `3` 开始，并根据节点数量继续调整。`scheduler.least_select_name` 默认值为 `random`，通常不需要显式设置。
+
+更新 `cubemaster.yaml` 后，请按当前部署方式重启 CubeMaster，让调度器加载新的评分配置。
+
 ## 常用操作
 
 ### 停止计算节点服务


### PR DESCRIPTION
## Summary

- Document that multi-node CubeMaster deployments should configure `scheduler.score`
- Explain why an unconfigured scheduler score may lead to deterministic placement on the first sorted node
- Add a baseline scoring example based on the workaround discussed in #573

Refs #573

## Checks

- `git diff --check`

Assisted-by: codex:gpt-5.5