### PR TITLE
fix(one-click): improve external MySQL/Redis deployment compatibility

### DIFF
--- a/deploy/one-click/install.sh
+++ b/deploy/one-click/install.sh
@@ -395,7 +395,43 @@ EOF
   if [[ -n "${CUBE_EXTERNAL_REDIS_HOST}" ]]; then
     if command -v redis-cli >/dev/null 2>&1; then
       log "checking connectivity to external Redis ${CUBE_EXTERNAL_REDIS_HOST}:${CUBE_EXTERNAL_REDIS_PORT}"
+      local redis_help_output
       local redis_reply
+      local redis_base_cmd=()
+      local redis_timeout_args=()
+      local use_timeout_wrapper=0
+      local supports_redis_connect_timeout=0
+      local supports_redis_timeout=0
+      redis_help_output="$(redis_cli_help_output)"
+      if redis_cli_help_supports_flag "${redis_help_output}" "--connect-timeout"; then
+        redis_timeout_args+=(--connect-timeout "${connect_timeout}")
+        supports_redis_connect_timeout=1
+      fi
+      if redis_cli_help_supports_flag "${redis_help_output}" "--timeout"; then
+        redis_timeout_args+=(--timeout "${connect_timeout}")
+        supports_redis_timeout=1
+      fi
+      if [[ "${supports_redis_connect_timeout}" != "1" ]]; then
+        log "redis-cli does not support --connect-timeout; continuing without that client-side timeout bound"
+      fi
+      if [[ "${supports_redis_timeout}" != "1" ]]; then
+        log "redis-cli does not support --timeout; continuing without that client-side timeout bound"
+      fi
+      if [[ "${supports_redis_connect_timeout}" != "1" || "${supports_redis_timeout}" != "1" ]]; then
+        if command -v timeout >/dev/null 2>&1; then
+          # Some redis-cli builds lack one or both timeout flags. Bound the
+          # whole client process so connectivity preflight still fails fast.
+          use_timeout_wrapper=1
+        else
+          log "timeout command not found; Redis preflight may block longer when redis-cli lacks timeout flags"
+        fi
+      fi
+      redis_base_cmd=(
+        redis-cli
+        -h "${CUBE_EXTERNAL_REDIS_HOST}"
+        -p "${CUBE_EXTERNAL_REDIS_PORT}"
+        "${redis_timeout_args[@]}"
+      )
       if [[ -n "${CUBE_EXTERNAL_REDIS_PASSWORD}" ]]; then
         # SECURITY: PING is NOT an authenticated command. A reachable server that
         # has no 'requirepass' set answers PONG even when a (wrong/extraneous)
@@ -407,15 +443,13 @@ EOF
         # The password is fed via stdin (`-x AUTH`) rather than as a command-line
         # argument so it is not exposed in /proc/<pid>/cmdline to other local
         # users; --no-auth-warning keeps redis-cli from echoing it on stderr.
-        # --connect-timeout bounds the TCP handshake; --timeout bounds Redis
-        # protocol I/O so a middlebox that accepts the socket but stalls the
-        # response (broken proxy / overloaded server) cannot hang this preflight
-        # indefinitely.
-        redis_reply="$(printf '%s' "${CUBE_EXTERNAL_REDIS_PASSWORD}" | redis-cli \
-          -h "${CUBE_EXTERNAL_REDIS_HOST}" \
-          -p "${CUBE_EXTERNAL_REDIS_PORT}" \
-          --connect-timeout "${connect_timeout}" \
-          --timeout "${connect_timeout}" \
+        # When the local redis-cli supports them, timeout flags bound the TCP
+        # handshake and Redis protocol I/O so a middlebox that accepts the
+        # socket but stalls the response cannot hang this preflight indefinitely.
+        redis_reply="$(printf '%s' "${CUBE_EXTERNAL_REDIS_PASSWORD}" | run_redis_preflight_cmd \
+          "${use_timeout_wrapper}" \
+          "${connect_timeout}" \
+          "${redis_base_cmd[@]}" \
           --no-auth-warning \
           -x AUTH 2>&1 || true)"
         if [[ "${redis_reply}" != "OK" ]]; then
@@ -424,11 +458,7 @@ EOF
         fi
       else
         local redis_pong
-        redis_pong="$(redis-cli \
-          -h "${CUBE_EXTERNAL_REDIS_HOST}" \
-          -p "${CUBE_EXTERNAL_REDIS_PORT}" \
-          --connect-timeout "${connect_timeout}" \
-          --timeout "${connect_timeout}" ping 2>/dev/null || true)"
+        redis_pong="$(run_redis_preflight_cmd "${use_timeout_wrapper}" "${connect_timeout}" "${redis_base_cmd[@]}" ping 2>/dev/null || true)"
         if [[ "${redis_pong}" != "PONG" ]]; then
           die "cannot reach external Redis at ${CUBE_EXTERNAL_REDIS_HOST}:${CUBE_EXTERNAL_REDIS_PORT} (PING did not return PONG).
   Verify CUBE_EXTERNAL_REDIS_HOST / _PORT and that the server is reachable from this host."

--- a/deploy/one-click/lib/common.sh
+++ b/deploy/one-click/lib/common.sh
@@ -548,10 +548,42 @@ is_compute_role() {
   [[ "$(one_click_deploy_role)" == "compute" ]]
 }
 
+env_value_is_plain_scalar() {
+  local value="${1-}"
+  [[ -z "${value}" ]] && return 0
+  [[ "${value}" =~ ^[A-Za-z0-9_./:@%+=,-]*$ ]]
+}
+
+render_env_assignment_value() {
+  local key="$1"
+  local value="$2"
+
+  if [[ "${value}" == *$'\n'* || "${value}" == *$'\r'* ]]; then
+    die "env value for ${key} must not contain newlines"
+  fi
+
+  # Keep shell-safe scalars unquoted so preflight readers that deliberately do
+  # not source the file (for example, ONE_CLICK_DEPLOY_ROLE checks during
+  # upgrade preflight) continue to see plain values.
+  if env_value_is_plain_scalar "${value}"; then
+    printf '%s' "${value}"
+    return 0
+  fi
+
+  # Runtime helpers load .one-click.env via `set -a; source`, so persist any
+  # shell-sensitive value in a quoted form that preserves bytes literally.
+  value="${value//\\/\\\\}"
+  value="${value//\"/\\\"}"
+  value="${value//\$/\\$}"
+  value="${value//\`/\\\`}"
+  printf '"%s"' "${value}"
+}
+
 upsert_env_kv() {
   local env_file="$1"
   local key="$2"
   local value="$3"
+  local rendered_value
   local tmp_file
   # SECURITY: tighten umask before mktemp so the temp file is created 0600 from
   # the start, closing the race window between creation and the chmod below.
@@ -572,11 +604,12 @@ upsert_env_kv() {
   # with looser permissions or mktemp honored a non-default mode.
   chmod 600 "${tmp_file}"
   local replaced=false
+  rendered_value="$(render_env_assignment_value "${key}" "${value}")"
 
   if [[ -f "${env_file}" ]]; then
     while IFS= read -r line || [[ -n "${line}" ]]; do
       if [[ "${line}" == "${key}="* ]]; then
-        printf '%s=%s\n' "${key}" "${value}" >> "${tmp_file}"
+        printf '%s=%s\n' "${key}" "${rendered_value}" >> "${tmp_file}"
         replaced=true
       else
         printf '%s\n' "${line}" >> "${tmp_file}"
@@ -585,10 +618,49 @@ upsert_env_kv() {
   fi
 
   if [[ "${replaced}" != "true" ]]; then
-    printf '%s=%s\n' "${key}" "${value}" >> "${tmp_file}"
+    printf '%s=%s\n' "${key}" "${rendered_value}" >> "${tmp_file}"
   fi
 
   mv -f "${tmp_file}" "${env_file}"
+}
+
+redis_cli_help_output() {
+  command -v redis-cli >/dev/null 2>&1 || return 1
+  redis-cli --help 2>&1 || true
+}
+
+redis_cli_help_supports_flag() {
+  local help_output="$1"
+  local flag="$2"
+
+  printf '%s\n' "${help_output}" | grep -Eq "(^|[[:space:]])${flag}([[:space:]]|$)"
+}
+
+run_with_timeout_if_available() {
+  local timeout_secs="$1"
+  shift
+
+  if command -v timeout >/dev/null 2>&1; then
+    if timeout --help 2>&1 | grep -q -- '-k'; then
+      timeout -k 1 "${timeout_secs}" "$@"
+    else
+      timeout "${timeout_secs}" "$@"
+    fi
+  else
+    "$@"
+  fi
+}
+
+run_redis_preflight_cmd() {
+  local use_timeout_wrapper="$1"
+  local connect_timeout="$2"
+  shift 2
+
+  if [[ "${use_timeout_wrapper}" == "1" ]]; then
+    run_with_timeout_if_available "${connect_timeout}" "$@"
+  else
+    "$@"
+  fi
 }
 
 validate_interface_name() {

--- a/deploy/one-click/tests/test_env_merge.sh
+++ b/deploy/one-click/tests/test_env_merge.sh
@@ -166,6 +166,56 @@ EOF
   ) || fail "merged env did not source/expand correctly"
 }
 
+test_upsert_env_kv_preserves_shell_sensitive_values() {
+  local env_file="${TMP_DIR}/upsert-sensitive.env"
+  local secret=$'p@$$ word `tick` "quote" #hash;\\slash'
+
+  upsert_env_kv "${env_file}" "CUBE_EXTERNAL_MYSQL_PASSWORD" "${secret}"
+
+  assert_contains "${env_file}" 'CUBE_EXTERNAL_MYSQL_PASSWORD="'
+  (
+    unset CUBE_EXTERNAL_MYSQL_PASSWORD
+    load_env_file "${env_file}"
+    [[ "${CUBE_EXTERNAL_MYSQL_PASSWORD}" == "${secret}" ]] || {
+      echo "expected '${secret}', got '${CUBE_EXTERNAL_MYSQL_PASSWORD:-}'" >&2
+      exit 1
+    }
+  ) || fail "upsert_env_kv did not preserve shell-sensitive value"
+}
+
+test_upsert_env_kv_quotes_shell_metachar_only_values() {
+  local env_file="${TMP_DIR}/upsert-metachar.env"
+  local secret='CubeSandbox123;'
+
+  upsert_env_kv "${env_file}" "CUBE_EXTERNAL_REDIS_PASSWORD" "${secret}"
+
+  assert_contains "${env_file}" 'CUBE_EXTERNAL_REDIS_PASSWORD="CubeSandbox123;'
+  (
+    unset CUBE_EXTERNAL_REDIS_PASSWORD
+    load_env_file "${env_file}"
+    [[ "${CUBE_EXTERNAL_REDIS_PASSWORD}" == "${secret}" ]] || {
+      echo "expected '${secret}', got '${CUBE_EXTERNAL_REDIS_PASSWORD:-}'" >&2
+      exit 1
+    }
+  ) || fail "shell metachar-only value should still be quoted safely"
+}
+
+test_upsert_env_kv_keeps_plain_scalars_readable() {
+  local env_file="${TMP_DIR}/upsert-plain.env"
+
+  cat > "${env_file}" <<'EOF'
+ONE_CLICK_DEPLOY_ROLE=control
+KEEP_ME=1
+EOF
+
+  upsert_env_kv "${env_file}" "ONE_CLICK_DEPLOY_ROLE" "compute"
+
+  assert_value "${env_file}" ONE_CLICK_DEPLOY_ROLE compute
+  assert_value "${env_file}" KEEP_ME 1
+  [[ "$(read_env_key "${env_file}" ONE_CLICK_DEPLOY_ROLE)" == "compute" ]] \
+    || fail "read_env_key should keep seeing plain scalar values"
+}
+
 test_keeps_old_only_host_keys() {
   local new="${TMP_DIR}/new6.example" old="${TMP_DIR}/old6.env"
   local out="${TMP_DIR}/out6.env" diff="${TMP_DIR}/diff6.txt"
@@ -476,6 +526,9 @@ test_adds_new_keys_with_defaults
 test_three_way_adopts_new_default_for_untouched_key
 test_three_way_keeps_customized_over_new_default
 test_preserves_shell_sensitive_values
+test_upsert_env_kv_preserves_shell_sensitive_values
+test_upsert_env_kv_quotes_shell_metachar_only_values
+test_upsert_env_kv_keeps_plain_scalars_readable
 test_keeps_old_only_host_keys
 test_preserves_comments_and_structure
 test_two_way_fallback_without_baseline

--- a/deploy/one-click/tests/test_install_mode.sh
+++ b/deploy/one-click/tests/test_install_mode.sh
@@ -409,6 +409,110 @@ test_validation_library_fallback_die() {
   fi
 }
 
+test_redis_cli_help_supports_flag() {
+  local stub_dir="${TMP_DIR}/redis-cli-help"
+  local help_output=""
+  mkdir -p "${stub_dir}"
+
+  cat > "${stub_dir}/redis-cli" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "--help" ]]; then
+  cat <<'HELP'
+Usage: redis-cli [OPTIONS]
+  --connect-timeout <seconds>
+  --timeout <seconds>
+HELP
+  exit 0
+fi
+exit 1
+EOF
+  chmod +x "${stub_dir}/redis-cli"
+
+  help_output="$(PATH="${stub_dir}:${PATH}" redis_cli_help_output)"
+  redis_cli_help_supports_flag "${help_output}" "--connect-timeout" \
+    || fail "redis_cli_help_supports_flag should detect --connect-timeout"
+  redis_cli_help_supports_flag "${help_output}" "--timeout" \
+    || fail "redis_cli_help_supports_flag should detect --timeout"
+  if redis_cli_help_supports_flag "${help_output}" "--time"; then
+    fail "redis_cli_help_supports_flag should not substring-match partial flags"
+  fi
+
+  cat > "${stub_dir}/redis-cli" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "--help" ]]; then
+  cat <<'HELP'
+Usage: redis-cli [OPTIONS]
+  --connect-timeout <seconds>
+  -h <hostname>
+HELP
+  exit 0
+fi
+exit 1
+EOF
+  chmod +x "${stub_dir}/redis-cli"
+
+  help_output="$(PATH="${stub_dir}:${PATH}" redis_cli_help_output)"
+  if redis_cli_help_supports_flag "${help_output}" "--connect-timeout"; then
+    :
+  else
+    fail "redis_cli_help_supports_flag should still detect explicitly listed flags"
+  fi
+  if redis_cli_help_supports_flag "${help_output}" "--timeout"; then
+    fail "redis_cli_help_supports_flag should not treat --connect-timeout as --timeout"
+  fi
+}
+
+test_run_with_timeout_if_available() {
+  local timeout_log="${TMP_DIR}/timeout-wrapper.log"
+  local direct_log="${TMP_DIR}/timeout-direct.log"
+  local timeout_plain_log="${TMP_DIR}/timeout-plain.log"
+
+  if ! (
+    timeout() {
+      if [[ "${1:-}" == "--help" ]]; then
+        printf '%s\n' 'usage: timeout [-k DURATION] DURATION COMMAND'
+        return 0
+      fi
+      printf '%s\n' "$*" > "${timeout_log}"
+    }
+    redis-cli() {
+      fail "run_with_timeout_if_available should prefer timeout when available"
+    }
+    run_with_timeout_if_available 3 redis-cli -h 127.0.0.1 -p 6389 ping
+  ) >/dev/null 2>&1; then
+    fail "run_with_timeout_if_available should succeed through timeout wrapper"
+  fi
+  assert_contains "${timeout_log}" "-k 1 3 redis-cli -h 127.0.0.1 -p 6389 ping"
+
+  if ! (
+    timeout() {
+      if [[ "${1:-}" == "--help" ]]; then
+        printf '%s\n' 'usage: timeout DURATION COMMAND'
+        return 0
+      fi
+      printf '%s\n' "$*" > "${timeout_plain_log}"
+    }
+    redis-cli() {
+      fail "run_with_timeout_if_available should still use timeout without -k support"
+    }
+    run_with_timeout_if_available 3 redis-cli -h 127.0.0.1 -p 6389 ping
+  ) >/dev/null 2>&1; then
+    fail "run_with_timeout_if_available should succeed through plain timeout wrapper"
+  fi
+  assert_contains "${timeout_plain_log}" "3 redis-cli -h 127.0.0.1 -p 6389 ping"
+
+  if ! (
+    PATH="${TMP_DIR}/no-timeout-path"
+    redis-cli() {
+      printf '%s\n' "$*" > "${direct_log}"
+    }
+    run_with_timeout_if_available 3 redis-cli -h 127.0.0.1 -p 6389 ping
+  ) >/dev/null 2>&1; then
+    fail "run_with_timeout_if_available should fall back to direct command"
+  fi
+  assert_contains "${direct_log}" "-h 127.0.0.1 -p 6389 ping"
+}
+
 test_install_sh_wires_upgrade_flow() {
   local f="${ONE_CLICK_DIR}/install.sh"
   assert_contains "${f}" "resolve_install_mode"
@@ -430,6 +534,13 @@ test_install_sh_wires_upgrade_flow() {
   assert_contains "${f}" 'cp -f "${SCRIPT_DIR}/env.example" "${INSTALL_PREFIX}/env.example"'
   # upgrade writes the merged env as the runtime env
   assert_contains "${f}" 'cp -f "${MERGED_ENV}" "${RUNTIME_ENV_FILE}"'
+  # External Redis preflight must tolerate older redis-cli binaries that lack
+  # timeout flags instead of failing before connectivity is checked.
+  assert_contains "${f}" 'redis_help_output="$(redis_cli_help_output)"'
+  assert_contains "${f}" 'redis_cli_help_supports_flag "${redis_help_output}" "--connect-timeout"'
+  assert_contains "${f}" 'redis_timeout_args+=(--connect-timeout "${connect_timeout}")'
+  assert_contains "${f}" 'redis_timeout_args+=(--timeout "${connect_timeout}")'
+  assert_contains "${f}" 'run_redis_preflight_cmd "${use_timeout_wrapper}" "${connect_timeout}"'
   # on upgrade, CIDR host-conflict detection is skipped (M2)
   assert_contains "${f}" 'check_cidr_preflight "${CUBE_SANDBOX_NETWORK_CIDR}" "${cidr_skip_conflict}" "CUBE_SANDBOX_NETWORK_CIDR"'
   assert_contains "${f}" 'check_cidr_preflight "192.168.0.0/18" "${cidr_skip_conflict}" "default CubeSandbox network CIDR"'
@@ -453,6 +564,8 @@ test_compute_control_plane_preflight
 test_patch_cubelet_config_template_refuses_symlink
 test_upgrade_preflight_and_backup
 test_validation_library_fallback_die
+test_redis_cli_help_supports_flag
+test_run_with_timeout_if_available
 test_install_sh_wires_upgrade_flow
 
 echo "install mode tests OK"


### PR DESCRIPTION
## Motivation

While validating the external MySQL/Redis one-click flow added in #514, I found a couple of installer compatibility gaps. These can fail installation even when the remote services themselves are healthy:

* `.one-click.env` persisted raw values, so shell-sensitive passwords containing characters such as `$`, backticks, quotes, or spaces could break later env loading
* external Redis preflight assumed the local `redis-cli` supports `--connect-timeout` / `--timeout`, but some builds do not provide those flags

## What Changed

* persist shell-sensitive `.one-click.env` values in a source-safe form while keeping plain scalar values readable
* detect local `redis-cli` timeout-flag support before using `--connect-timeout` / `--timeout`
* fall back to a compatible Redis preflight command when those timeout flags are unavailable
* add regression coverage for env persistence and Redis timeout-flag detection

## Validation

* `bash tests/test_env_merge.sh`
* `bash tests/test_install_mode.sh`

Also validated on a real host with a `redis-cli` build whose `--help` output did not advertise either timeout flag. Direct invocations with `--connect-timeout` / `--timeout` failed with `Unrecognized option or bad number of args`, and the updated preflight path handled that build correctly.

## Scope

This PR is limited to one-click external dependency deployment compatibility. It does not change the MySQL/Redis service configuration, credentials format, runtime behavior, or deployment topology.
