### PR TITLE
feat(sdk): align with e2b — complete filesystem API

### DIFF
--- a/sdk/go/README.md
+++ b/sdk/go/README.md
@@ -1,6 +1,6 @@
 # cubesandbox Go SDK
 
-Go SDK for [CubeSandbox](https://github.com/TencentCloud/CubeSandbox). It matches the current Python SDK surface: sandbox lifecycle, code execution, commands, file read/write, snapshots, clone, rollback, and L7 egress policy.
+Go SDK for [CubeSandbox](https://github.com/TencentCloud/CubeSandbox). It matches the current Python SDK surface: sandbox lifecycle, code execution, commands, filesystem operations (read, write, list, stat, exists, remove, rename, mkdir, watch), snapshots, clone, rollback, and L7 egress policy.
 
 ## Install
 
@@ -74,13 +74,47 @@ fmt.Println(result.Stdout, result.Stderr, result.ExitCode)
 ## Files
 
 ```go
+// Read & write
 content, err := sb.Files().Read(ctx, "/etc/hosts")
-
 err = sb.Files().Write(ctx, "/tmp/hello.txt", []byte("hi"))
+
+// Batch write
+n, err := sb.Files().WriteFiles(ctx, []cubesandbox.WriteEntry{
+	{Path: "/tmp/a.txt", Data: []byte("aaa")},
+	{Path: "/tmp/b.txt", Data: []byte("bbb")},
+})
+
+// Directory operations
+entries, err := sb.Files().List(ctx, "/tmp")
+entry, err := sb.Files().Stat(ctx, "/tmp/hello.txt")
+exists, err := sb.Files().Exists(ctx, "/tmp/hello.txt")
+entry, err = sb.Files().MakeDir(ctx, "/tmp/mydir")
+entry, err = sb.Files().Rename(ctx, "/tmp/old.txt", "/tmp/new.txt")
+err = sb.Files().Remove(ctx, "/tmp/hello.txt")
+
+// Watch for changes
+watcher, err := sb.Files().WatchDir(ctx, "/tmp")
+if err != nil {
+	panic(err)
+}
+defer watcher.Close()
+for ev := range watcher.Events {
+	fmt.Println(ev.Name, ev.Type) // e.g. "hello.txt" "EVENT_TYPE_CREATE"
+}
 ```
 
-`Files.Read` downloads content through envd's `GET /files?path=...` file API.
-`Files.Write` uploads through `POST /files`, falling back to a multipart body when the envd version rejects a raw octet-stream.
+| Method | Description |
+|---|---|
+| `Read(ctx, path)` | Download file content via `GET /files` |
+| `Write(ctx, path, data)` | Upload via `POST /files` (octet-stream, multipart fallback) |
+| `WriteFiles(ctx, entries)` | Batch write, stops on first error, returns count |
+| `List(ctx, path)` | List directory entries via `ListDir` RPC |
+| `Stat(ctx, path)` | File/directory metadata via `Stat` RPC |
+| `Exists(ctx, path)` | `true` if path exists (Stat + 404 check) |
+| `MakeDir(ctx, path)` | Create directory via `MakeDir` RPC |
+| `Rename(ctx, old, new)` | Move/rename via `Move` RPC |
+| `Remove(ctx, path)` | Delete file or directory via `Remove` RPC |
+| `WatchDir(ctx, path)` | Stream filesystem events (Connect streaming) |
 
 ## Snapshots, Clone, Rollback
 

--- a/sdk/go/envd.go
+++ b/sdk/go/envd.go
@@ -16,6 +16,7 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 )
 
@@ -374,6 +375,263 @@ func decodeProcessBytes(value string) (string, error) {
 		return "", err
 	}
 	return string(raw), nil
+}
+
+func (s *Sandbox) filesystemRPC(ctx context.Context, method string, reqBody any) ([]byte, int, error) {
+	if err := s.ensureClient(); err != nil {
+		return nil, 0, err
+	}
+	raw, err := json.Marshal(reqBody)
+	if err != nil {
+		return nil, 0, err
+	}
+	req, err := s.newEnvdRequest(ctx, http.MethodPost, "/filesystem.Filesystem/"+method, nil, bytes.NewReader(raw))
+	if err != nil {
+		return nil, 0, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Connect-Protocol-Version", connectProtocolVersion)
+
+	resp, err := s.client.dataHTTP.Do(req)
+	if err != nil {
+		return nil, 0, err
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, resp.StatusCode, err
+	}
+	return body, resp.StatusCode, nil
+}
+
+func (s *Sandbox) listDir(ctx context.Context, path string) ([]FileEntry, error) {
+	body, status, err := s.filesystemRPC(ctx, "ListDir", map[string]string{"path": path})
+	if err != nil {
+		return nil, err
+	}
+	if status >= http.StatusBadRequest {
+		return nil, fmt.Errorf("failed to list %s: %s", path, extractErrorMessage(body, status))
+	}
+	var result struct {
+		Entries []FileEntry `json:"entries"`
+	}
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, fmt.Errorf("decode list response: %w", err)
+	}
+	if result.Entries == nil {
+		result.Entries = []FileEntry{}
+	}
+	return result.Entries, nil
+}
+
+func (s *Sandbox) statFile(ctx context.Context, path string) (*FileEntry, error) {
+	body, status, err := s.filesystemRPC(ctx, "Stat", map[string]string{"path": path})
+	if err != nil {
+		return nil, err
+	}
+	if status == http.StatusNotFound {
+		return nil, &NotFoundError{Path: path, Message: fmt.Sprintf("failed to stat %s: %s", path, extractErrorMessage(body, status))}
+	}
+	if status >= http.StatusBadRequest {
+		return nil, fmt.Errorf("failed to stat %s: %s", path, extractErrorMessage(body, status))
+	}
+	var result struct {
+		Entry FileEntry `json:"entry"`
+	}
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, fmt.Errorf("decode stat response: %w", err)
+	}
+	return &result.Entry, nil
+}
+
+func (s *Sandbox) removeFile(ctx context.Context, path string) error {
+	body, status, err := s.filesystemRPC(ctx, "Remove", map[string]string{"path": path})
+	if err != nil {
+		return err
+	}
+	if status >= http.StatusBadRequest {
+		return fmt.Errorf("failed to remove %s: %s", path, extractErrorMessage(body, status))
+	}
+	return nil
+}
+
+func (s *Sandbox) moveFile(ctx context.Context, source, destination string) (*FileEntry, error) {
+	body, status, err := s.filesystemRPC(ctx, "Move", map[string]string{"source": source, "destination": destination})
+	if err != nil {
+		return nil, err
+	}
+	if status >= http.StatusBadRequest {
+		return nil, fmt.Errorf("failed to move %s to %s: %s", source, destination, extractErrorMessage(body, status))
+	}
+	var result struct {
+		Entry FileEntry `json:"entry"`
+	}
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, fmt.Errorf("decode move response: %w", err)
+	}
+	return &result.Entry, nil
+}
+
+func (s *Sandbox) makeDirFile(ctx context.Context, path string) (*FileEntry, error) {
+	body, status, err := s.filesystemRPC(ctx, "MakeDir", map[string]string{"path": path})
+	if err != nil {
+		return nil, err
+	}
+	if status >= http.StatusBadRequest {
+		return nil, fmt.Errorf("failed to make dir %s: %s", path, extractErrorMessage(body, status))
+	}
+	var result struct {
+		Entry FileEntry `json:"entry"`
+	}
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, fmt.Errorf("decode mkdir response: %w", err)
+	}
+	return &result.Entry, nil
+}
+
+func extractErrorMessage(body []byte, status int) string {
+	var errResp struct {
+		Code    any    `json:"code"`
+		Message string `json:"message"`
+	}
+	if json.Unmarshal(body, &errResp) == nil && errResp.Message != "" {
+		return errResp.Message
+	}
+	return fmt.Sprintf("HTTP %d", status)
+}
+
+// Watcher delivers filesystem events from an envd WatchDir stream.
+type Watcher struct {
+	Events <-chan WatchEvent
+	Errors <-chan error
+
+	events chan WatchEvent
+	errs   chan error
+	ctx    context.Context
+	cancel context.CancelFunc
+	body   io.ReadCloser
+	once   sync.Once
+}
+
+// Close terminates the watcher and releases resources.
+func (w *Watcher) Close() error {
+	w.once.Do(func() {
+		w.cancel()
+		w.body.Close()
+	})
+	return nil
+}
+
+type watchDirFrame struct {
+	Start      *struct{}     `json:"start,omitempty"`
+	Filesystem *WatchEvent   `json:"filesystem,omitempty"`
+	Error      *connectError `json:"error,omitempty"`
+	Keepalive  *struct{}     `json:"keepalive,omitempty"`
+}
+
+func (s *Sandbox) watchDir(ctx context.Context, path string) (*Watcher, error) {
+	if err := s.ensureClient(); err != nil {
+		return nil, err
+	}
+
+	payload, err := json.Marshal(map[string]string{"path": path})
+	if err != nil {
+		return nil, err
+	}
+
+	var envelope bytes.Buffer
+	var header [5]byte
+	header[0] = 0
+	binary.BigEndian.PutUint32(header[1:], uint32(len(payload)))
+	envelope.Write(header[:])
+	envelope.Write(payload)
+
+	streamCtx, cancel := context.WithCancel(ctx)
+	req, err := s.newEnvdRequest(streamCtx, http.MethodPost, "/filesystem.Filesystem/WatchDir", nil, &envelope)
+	if err != nil {
+		cancel()
+		return nil, err
+	}
+	req.Header.Set("Content-Type", connectContentType)
+	req.Header.Set("Connect-Protocol-Version", connectProtocolVersion)
+
+	resp, err := s.client.dataHTTP.Do(req)
+	if err != nil {
+		cancel()
+		return nil, err
+	}
+	if resp.StatusCode >= http.StatusBadRequest {
+		defer resp.Body.Close()
+		cancel()
+		return nil, apiErrorFromResponse(resp)
+	}
+
+	events := make(chan WatchEvent, 64)
+	errs := make(chan error, 1)
+	w := &Watcher{
+		Events: events,
+		Errors: errs,
+		events: events,
+		errs:   errs,
+		ctx:    streamCtx,
+		cancel: cancel,
+		body:   resp.Body,
+	}
+
+	go w.readLoop()
+	return w, nil
+}
+
+func (w *Watcher) readLoop() {
+	defer close(w.events)
+	defer close(w.errs)
+	defer w.body.Close()
+
+	for {
+		flags, payload, err := readConnectEnvelope(w.body)
+		if err != nil {
+			if err != io.EOF && err != io.ErrUnexpectedEOF {
+				w.sendErr(err)
+			}
+			return
+		}
+		if flags&connectEndStreamFlag != 0 {
+			if err := parseConnectEndStream(payload); err != nil {
+				w.sendErr(err)
+			}
+			return
+		}
+
+		var frame watchDirFrame
+		if err := json.Unmarshal(payload, &frame); err != nil {
+			w.sendErr(fmt.Errorf("decode watch event: %w", err))
+			return
+		}
+
+		if frame.Error != nil {
+			msg := frame.Error.Message
+			if msg == "" {
+				msg = "watch error"
+			}
+			w.sendErr(fmt.Errorf("%s", msg))
+			return
+		}
+
+		if frame.Filesystem != nil {
+			select {
+			case w.events <- *frame.Filesystem:
+			case <-w.ctx.Done():
+				return
+			}
+		}
+	}
+}
+
+func (w *Watcher) sendErr(err error) {
+	select {
+	case w.errs <- err:
+	case <-w.ctx.Done():
+	}
 }
 
 func (e *processEndEvent) exitCode() (int, bool) {

--- a/sdk/go/files.go
+++ b/sdk/go/files.go
@@ -5,12 +5,14 @@ package cubesandbox
 
 import (
 	"context"
+	"errors"
 	"fmt"
 )
 
 type Files struct {
 	reader fileReader
 	writer fileWriter
+	filer  fileFiler
 }
 
 type fileReader interface {
@@ -19,6 +21,15 @@ type fileReader interface {
 
 type fileWriter interface {
 	writeFile(context.Context, string, []byte) error
+}
+
+type fileFiler interface {
+	listDir(context.Context, string) ([]FileEntry, error)
+	statFile(context.Context, string) (*FileEntry, error)
+	removeFile(context.Context, string) error
+	moveFile(context.Context, string, string) (*FileEntry, error)
+	makeDirFile(context.Context, string) (*FileEntry, error)
+	watchDir(context.Context, string) (*Watcher, error)
 }
 
 func (f *Files) Read(ctx context.Context, path string) (string, error) {
@@ -34,4 +45,80 @@ func (f *Files) Write(ctx context.Context, path string, data []byte) error {
 		return fmt.Errorf("files is not attached to a sandbox")
 	}
 	return f.writer.writeFile(ctx, path, data)
+}
+
+// WriteFiles uploads multiple files. It stops at the first error and returns
+// the number of files successfully written.
+func (f *Files) WriteFiles(ctx context.Context, entries []WriteEntry) (int, error) {
+	if f == nil || f.writer == nil {
+		return 0, fmt.Errorf("files is not attached to a sandbox")
+	}
+	for i, e := range entries {
+		if err := f.Write(ctx, e.Path, e.Data); err != nil {
+			return i, fmt.Errorf("write %s: %w", e.Path, err)
+		}
+	}
+	return len(entries), nil
+}
+
+// List returns the entries in a directory.
+func (f *Files) List(ctx context.Context, path string) ([]FileEntry, error) {
+	if f == nil || f.filer == nil {
+		return nil, fmt.Errorf("files is not attached to a sandbox")
+	}
+	return f.filer.listDir(ctx, path)
+}
+
+// Stat returns metadata for a single file or directory.
+func (f *Files) Stat(ctx context.Context, path string) (*FileEntry, error) {
+	if f == nil || f.filer == nil {
+		return nil, fmt.Errorf("files is not attached to a sandbox")
+	}
+	return f.filer.statFile(ctx, path)
+}
+
+// Exists returns true if the path exists inside the sandbox.
+func (f *Files) Exists(ctx context.Context, path string) (bool, error) {
+	_, err := f.Stat(ctx, path)
+	if err == nil {
+		return true, nil
+	}
+	var nfe *NotFoundError
+	if errors.As(err, &nfe) {
+		return false, nil
+	}
+	return false, err
+}
+
+// Remove deletes a file or directory inside the sandbox.
+func (f *Files) Remove(ctx context.Context, path string) error {
+	if f == nil || f.filer == nil {
+		return fmt.Errorf("files is not attached to a sandbox")
+	}
+	return f.filer.removeFile(ctx, path)
+}
+
+// Rename moves or renames a file or directory inside the sandbox.
+func (f *Files) Rename(ctx context.Context, oldPath, newPath string) (*FileEntry, error) {
+	if f == nil || f.filer == nil {
+		return nil, fmt.Errorf("files is not attached to a sandbox")
+	}
+	return f.filer.moveFile(ctx, oldPath, newPath)
+}
+
+// MakeDir creates a directory inside the sandbox.
+func (f *Files) MakeDir(ctx context.Context, path string) (*FileEntry, error) {
+	if f == nil || f.filer == nil {
+		return nil, fmt.Errorf("files is not attached to a sandbox")
+	}
+	return f.filer.makeDirFile(ctx, path)
+}
+
+// WatchDir watches a directory for filesystem changes. The returned Watcher
+// delivers events on its Events channel. Call Watcher.Close to stop.
+func (f *Files) WatchDir(ctx context.Context, path string) (*Watcher, error) {
+	if f == nil || f.filer == nil {
+		return nil, fmt.Errorf("files is not attached to a sandbox")
+	}
+	return f.filer.watchDir(ctx, path)
 }

--- a/sdk/go/models.go
+++ b/sdk/go/models.go
@@ -134,6 +134,45 @@ type OutputMessage struct {
 	IsStderr  bool
 }
 
+// WriteEntry is a path + data pair for Files.WriteFiles.
+type WriteEntry struct {
+	Path string
+	Data []byte
+}
+
+// FileEntry represents a file or directory returned by envd filesystem RPCs.
+type FileEntry struct {
+	Name         string `json:"name"`
+	Type         string `json:"type"`
+	Path         string `json:"path"`
+	Size         int64  `json:"size,string"`
+	Mode         int    `json:"mode"`
+	Permissions  string `json:"permissions"`
+	Owner        string `json:"owner"`
+	Group        string `json:"group"`
+	ModifiedTime string `json:"modifiedTime"`
+}
+
+func (e FileEntry) IsDir() bool {
+	return e.Type == "FILE_TYPE_DIRECTORY"
+}
+
+// NotFoundError is returned when a filesystem path does not exist.
+type NotFoundError struct {
+	Path    string
+	Message string
+}
+
+func (e *NotFoundError) Error() string {
+	return e.Message
+}
+
+// WatchEvent represents a filesystem change detected by WatchDir.
+type WatchEvent struct {
+	Name string `json:"name"`
+	Type string `json:"type"`
+}
+
 func (e *Execution) mainText() string {
 	if e == nil {
 		return ""

--- a/sdk/go/sandbox.go
+++ b/sdk/go/sandbox.go
@@ -179,7 +179,7 @@ func (s *Sandbox) Commands() *Commands {
 }
 
 func (s *Sandbox) Files() *Files {
-	return &Files{reader: s, writer: s}
+	return &Files{reader: s, writer: s, filer: s}
 }
 
 func (s *Sandbox) ensureClient() error {

--- a/sdk/go/sdk_test.go
+++ b/sdk/go/sdk_test.go
@@ -852,6 +852,371 @@ func assertStringSlice(t *testing.T, value any, want []string) {
 	}
 }
 
+func TestFilesListUsesEnvdFilesystemRPC(t *testing.T) {
+	var gotHost, gotPath, gotCT string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/filesystem.Filesystem/ListDir" {
+			t.Fatalf("request=%s %s", r.Method, r.URL.Path)
+		}
+		gotHost = r.Host
+		gotPath = r.URL.Path
+		gotCT = r.Header.Get("Content-Type")
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"entries":[{"name":"a.txt","type":"FILE_TYPE_FILE","path":"/tmp/a.txt","size":"10","mode":420,"permissions":"-rw-r--r--","owner":"root","group":"root","modifiedTime":"2026-06-30T00:00:00Z"}]}`)
+	}))
+	defer server.Close()
+
+	host, port := serverHostPort(t, server.URL)
+	client := NewClient(Config{ProxyNodeIP: host, ProxyPortHTTP: port, SandboxDomain: "cube.test", RequestTimeout: time.Second})
+	sb := &Sandbox{client: client, SandboxID: "sb-fs", EnvdAccessToken: "tok"}
+
+	entries, err := sb.Files().List(context.Background(), "/tmp")
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(entries) != 1 || entries[0].Name != "a.txt" || entries[0].Size != 10 || entries[0].IsDir() {
+		t.Fatalf("entries=%#v", entries)
+	}
+	if gotHost != "49999-sb-fs.cube.test" || gotPath != "/filesystem.Filesystem/ListDir" || gotCT != "application/json" {
+		t.Fatalf("host/path/ct=%q/%q/%q", gotHost, gotPath, gotCT)
+	}
+}
+
+func TestFilesListReturnsEmptySliceForEmptyDir(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{}`)
+	}))
+	defer server.Close()
+
+	host, port := serverHostPort(t, server.URL)
+	client := NewClient(Config{ProxyNodeIP: host, ProxyPortHTTP: port, SandboxDomain: "cube.test", RequestTimeout: time.Second})
+	sb := &Sandbox{client: client, SandboxID: "sb-fs"}
+
+	entries, err := sb.Files().List(context.Background(), "/empty")
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if entries == nil || len(entries) != 0 {
+		t.Fatalf("entries=%#v, want empty non-nil slice", entries)
+	}
+}
+
+func TestFilesStatReturnsFileEntry(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/filesystem.Filesystem/Stat" {
+			t.Fatalf("path=%s", r.URL.Path)
+		}
+		var body map[string]string
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if body["path"] != "/tmp/f.txt" {
+			t.Fatalf("path=%q", body["path"])
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"entry":{"name":"f.txt","type":"FILE_TYPE_FILE","path":"/tmp/f.txt","size":"42","mode":420,"permissions":"-rw-r--r--","owner":"user","group":"user","modifiedTime":"2026-06-30T00:00:00Z"}}`)
+	}))
+	defer server.Close()
+
+	host, port := serverHostPort(t, server.URL)
+	client := NewClient(Config{ProxyNodeIP: host, ProxyPortHTTP: port, SandboxDomain: "cube.test", RequestTimeout: time.Second})
+	sb := &Sandbox{client: client, SandboxID: "sb-fs"}
+
+	entry, err := sb.Files().Stat(context.Background(), "/tmp/f.txt")
+	if err != nil {
+		t.Fatalf("Stat: %v", err)
+	}
+	if entry.Name != "f.txt" || entry.Size != 42 || entry.Owner != "user" || entry.IsDir() {
+		t.Fatalf("entry=%#v", entry)
+	}
+}
+
+func TestFilesExistsReturnsTrueForExistingFile(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"entry":{"name":"x","type":"FILE_TYPE_FILE","path":"/x","size":"1","mode":420}}`)
+	}))
+	defer server.Close()
+
+	host, port := serverHostPort(t, server.URL)
+	client := NewClient(Config{ProxyNodeIP: host, ProxyPortHTTP: port, SandboxDomain: "cube.test", RequestTimeout: time.Second})
+	sb := &Sandbox{client: client, SandboxID: "sb-fs"}
+
+	exists, err := sb.Files().Exists(context.Background(), "/x")
+	if err != nil || !exists {
+		t.Fatalf("exists=%v err=%v", exists, err)
+	}
+}
+
+func TestFilesExistsReturnsFalseOn404(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		fmt.Fprint(w, `{"code":"not_found","message":"file not found: no such file or directory"}`)
+	}))
+	defer server.Close()
+
+	host, port := serverHostPort(t, server.URL)
+	client := NewClient(Config{ProxyNodeIP: host, ProxyPortHTTP: port, SandboxDomain: "cube.test", RequestTimeout: time.Second})
+	sb := &Sandbox{client: client, SandboxID: "sb-fs"}
+
+	exists, err := sb.Files().Exists(context.Background(), "/missing")
+	if err != nil || exists {
+		t.Fatalf("exists=%v err=%v", exists, err)
+	}
+}
+
+func TestFilesRemoveCallsEnvdRemove(t *testing.T) {
+	var gotBody map[string]string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/filesystem.Filesystem/Remove" {
+			t.Fatalf("path=%s", r.URL.Path)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{}`)
+	}))
+	defer server.Close()
+
+	host, port := serverHostPort(t, server.URL)
+	client := NewClient(Config{ProxyNodeIP: host, ProxyPortHTTP: port, SandboxDomain: "cube.test", RequestTimeout: time.Second})
+	sb := &Sandbox{client: client, SandboxID: "sb-fs"}
+
+	if err := sb.Files().Remove(context.Background(), "/tmp/gone.txt"); err != nil {
+		t.Fatalf("Remove: %v", err)
+	}
+	if gotBody["path"] != "/tmp/gone.txt" {
+		t.Fatalf("path=%q", gotBody["path"])
+	}
+}
+
+func TestFilesRenameCallsEnvdMove(t *testing.T) {
+	var gotBody map[string]string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/filesystem.Filesystem/Move" {
+			t.Fatalf("path=%s", r.URL.Path)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"entry":{"name":"b.txt","type":"FILE_TYPE_FILE","path":"/tmp/b.txt","size":"5","mode":420}}`)
+	}))
+	defer server.Close()
+
+	host, port := serverHostPort(t, server.URL)
+	client := NewClient(Config{ProxyNodeIP: host, ProxyPortHTTP: port, SandboxDomain: "cube.test", RequestTimeout: time.Second})
+	sb := &Sandbox{client: client, SandboxID: "sb-fs"}
+
+	entry, err := sb.Files().Rename(context.Background(), "/tmp/a.txt", "/tmp/b.txt")
+	if err != nil {
+		t.Fatalf("Rename: %v", err)
+	}
+	if entry.Name != "b.txt" || entry.Path != "/tmp/b.txt" {
+		t.Fatalf("entry=%#v", entry)
+	}
+	if gotBody["source"] != "/tmp/a.txt" || gotBody["destination"] != "/tmp/b.txt" {
+		t.Fatalf("body=%#v", gotBody)
+	}
+}
+
+func TestFilesMakeDirCallsEnvdMakeDir(t *testing.T) {
+	var gotBody map[string]string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/filesystem.Filesystem/MakeDir" {
+			t.Fatalf("path=%s", r.URL.Path)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"entry":{"name":"newdir","type":"FILE_TYPE_DIRECTORY","path":"/tmp/newdir","size":"4096","mode":493,"permissions":"drwxr-xr-x"}}`)
+	}))
+	defer server.Close()
+
+	host, port := serverHostPort(t, server.URL)
+	client := NewClient(Config{ProxyNodeIP: host, ProxyPortHTTP: port, SandboxDomain: "cube.test", RequestTimeout: time.Second})
+	sb := &Sandbox{client: client, SandboxID: "sb-fs"}
+
+	entry, err := sb.Files().MakeDir(context.Background(), "/tmp/newdir")
+	if err != nil {
+		t.Fatalf("MakeDir: %v", err)
+	}
+	if entry.Name != "newdir" || !entry.IsDir() || entry.Size != 4096 {
+		t.Fatalf("entry=%#v", entry)
+	}
+	if gotBody["path"] != "/tmp/newdir" {
+		t.Fatalf("path=%q", gotBody["path"])
+	}
+}
+
+func TestFilesWriteFilesUploadsMultiple(t *testing.T) {
+	var paths []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		paths = append(paths, r.URL.Query().Get("path"))
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	host, port := serverHostPort(t, server.URL)
+	client := NewClient(Config{ProxyNodeIP: host, ProxyPortHTTP: port, SandboxDomain: "cube.test", RequestTimeout: time.Second})
+	sb := &Sandbox{client: client, SandboxID: "sb-fs"}
+
+	n, err := sb.Files().WriteFiles(context.Background(), []WriteEntry{
+		{Path: "/tmp/a.txt", Data: []byte("aaa")},
+		{Path: "/tmp/b.txt", Data: []byte("bbb")},
+		{Path: "/tmp/c.txt", Data: []byte("ccc")},
+	})
+	if err != nil {
+		t.Fatalf("WriteFiles: %v", err)
+	}
+	if n != 3 {
+		t.Fatalf("wrote %d, want 3", n)
+	}
+	if len(paths) != 3 || paths[0] != "/tmp/a.txt" || paths[1] != "/tmp/b.txt" || paths[2] != "/tmp/c.txt" {
+		t.Fatalf("paths=%v", paths)
+	}
+}
+
+func TestFilesWriteFilesStopsOnError(t *testing.T) {
+	var fileCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		path := r.URL.Query().Get("path")
+		if path == "/tmp/b.txt" {
+			w.WriteHeader(http.StatusInternalServerError)
+			fmt.Fprint(w, `{"message":"disk full"}`)
+			return
+		}
+		fileCount++
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	host, port := serverHostPort(t, server.URL)
+	client := NewClient(Config{ProxyNodeIP: host, ProxyPortHTTP: port, SandboxDomain: "cube.test", RequestTimeout: time.Second})
+	sb := &Sandbox{client: client, SandboxID: "sb-fs"}
+
+	n, err := sb.Files().WriteFiles(context.Background(), []WriteEntry{
+		{Path: "/tmp/a.txt", Data: []byte("ok")},
+		{Path: "/tmp/b.txt", Data: []byte("fail")},
+		{Path: "/tmp/c.txt", Data: []byte("skip")},
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if n != 1 {
+		t.Fatalf("wrote %d, want 1", n)
+	}
+	if fileCount != 1 {
+		t.Fatalf("successful uploads=%d, want 1", fileCount)
+	}
+}
+
+func connectFrame(flags byte, payload []byte) []byte {
+	buf := make([]byte, 5+len(payload))
+	buf[0] = flags
+	binary.BigEndian.PutUint32(buf[1:5], uint32(len(payload)))
+	copy(buf[5:], payload)
+	return buf
+}
+
+func TestFilesWatchDirReceivesEvents(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/filesystem.Filesystem/WatchDir" {
+			t.Fatalf("path=%s", r.URL.Path)
+		}
+		if r.Header.Get("Content-Type") != connectContentType {
+			t.Fatalf("content-type=%s", r.Header.Get("Content-Type"))
+		}
+
+		w.Header().Set("Content-Type", connectContentType)
+		w.WriteHeader(http.StatusOK)
+
+		flusher, ok := w.(http.Flusher)
+		if !ok {
+			t.Fatal("ResponseWriter is not a Flusher")
+		}
+
+		frames := [][]byte{
+			connectFrame(0, []byte(`{"start":{}}`)),
+			connectFrame(0, []byte(`{"filesystem":{"name":"a.txt","type":"EVENT_TYPE_CREATE"}}`)),
+			connectFrame(0, []byte(`{"filesystem":{"name":"a.txt","type":"EVENT_TYPE_WRITE"}}`)),
+			connectFrame(0, []byte(`{"filesystem":{"name":"a.txt","type":"EVENT_TYPE_REMOVE"}}`)),
+		}
+		for _, f := range frames {
+			w.Write(f)
+			flusher.Flush()
+		}
+	}))
+	defer server.Close()
+
+	host, port := serverHostPort(t, server.URL)
+	client := NewClient(Config{ProxyNodeIP: host, ProxyPortHTTP: port, SandboxDomain: "cube.test", RequestTimeout: 5 * time.Second})
+	sb := &Sandbox{client: client, SandboxID: "sb-fs"}
+
+	watcher, err := sb.Files().WatchDir(context.Background(), "/tmp/test")
+	if err != nil {
+		t.Fatalf("WatchDir: %v", err)
+	}
+	defer watcher.Close()
+
+	var events []WatchEvent
+	for evt := range watcher.Events {
+		events = append(events, evt)
+	}
+
+	if len(events) != 3 {
+		t.Fatalf("got %d events, want 3", len(events))
+	}
+	if events[0].Name != "a.txt" || events[0].Type != "EVENT_TYPE_CREATE" {
+		t.Fatalf("event[0]=%+v", events[0])
+	}
+	if events[1].Type != "EVENT_TYPE_WRITE" {
+		t.Fatalf("event[1]=%+v", events[1])
+	}
+	if events[2].Type != "EVENT_TYPE_REMOVE" {
+		t.Fatalf("event[2]=%+v", events[2])
+	}
+}
+
+func TestFilesWatchDirErrorFromServer(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", connectContentType)
+		w.WriteHeader(http.StatusOK)
+		flusher := w.(http.Flusher)
+
+		w.Write(connectFrame(0, []byte(`{"error":{"code":"not_found","message":"path not found"}}`)))
+		flusher.Flush()
+	}))
+	defer server.Close()
+
+	host, port := serverHostPort(t, server.URL)
+	client := NewClient(Config{ProxyNodeIP: host, ProxyPortHTTP: port, SandboxDomain: "cube.test", RequestTimeout: 5 * time.Second})
+	sb := &Sandbox{client: client, SandboxID: "sb-fs"}
+
+	watcher, err := sb.Files().WatchDir(context.Background(), "/nonexistent")
+	if err != nil {
+		t.Fatalf("WatchDir: %v", err)
+	}
+	defer watcher.Close()
+
+	for range watcher.Events {
+		t.Fatal("should not receive events")
+	}
+
+	select {
+	case err := <-watcher.Errors:
+		if err == nil || !strings.Contains(err.Error(), "path not found") {
+			t.Fatalf("expected not_found error, got: %v", err)
+		}
+	default:
+		t.Fatal("expected error on Errors channel")
+	}
+}
+
 func TestBuildTemplateForwardsCreateFromImageOptions(t *testing.T) {
 	var got map[string]any
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -183,6 +183,36 @@ supported — pass either a list of `Rule` (typed) **or** a host-keyed dict
 The legacy `metadata={"network-policy": ...}` interface is still accepted
 for IP-only deny-all / custom allow-list scenarios.
 
+### Filesystem
+
+```python
+from cubesandbox import Sandbox
+
+with Sandbox.create() as sb:
+    # Read & write
+    sb.files.write("/tmp/hello.txt", "Hello, world!")
+    print(sb.files.read("/tmp/hello.txt"))  # "Hello, world!"
+
+    # Batch write
+    sb.files.write_files([
+        ("/tmp/a.txt", "aaa"),
+        ("/tmp/b.txt", b"bbb"),  # bytes also accepted
+    ])
+
+    # Directory operations
+    sb.files.make_dir("/tmp/mydir")
+    entries = sb.files.list("/tmp")          # list of dicts
+    info = sb.files.stat("/tmp/hello.txt")   # dict with name, type, size, ...
+    print(sb.files.exists("/tmp/hello.txt")) # True
+    sb.files.rename("/tmp/hello.txt", "/tmp/renamed.txt")
+    sb.files.remove("/tmp/renamed.txt")
+
+    # Watch for changes
+    with sb.files.watch_dir("/tmp") as watcher:
+        for event in watcher:
+            print(event.name, event.type)  # e.g. "a.txt" "EVENT_TYPE_CREATE"
+```
+
 ### Host-directory mount
 
 ```python
@@ -251,6 +281,21 @@ with Sandbox.create(config=cfg) as sb:
 | `sb.resume(timeout)` | `POST /sandboxes/:id/resume` — resume (deprecated, use `connect`) |
 | `sb.kill()` | `DELETE /sandboxes/:id` — destroy sandbox |
 | `sb.get_host(port)` | Return virtual hostname `{port}-{id}.{domain}` |
+
+### `sb.files` — Filesystem
+
+| Method | Description |
+|---|---|
+| `sb.files.read(path)` | Download file content via `GET /files` |
+| `sb.files.write(path, data)` | Upload via `POST /files` (octet-stream, multipart fallback) |
+| `sb.files.write_files(files)` | Batch write `[(path, data), ...]`, stops on first error |
+| `sb.files.list(path)` | List directory entries → `list[dict]` |
+| `sb.files.stat(path)` | File/directory metadata → `dict` |
+| `sb.files.exists(path)` | `True` if path exists (stat + 404 check) |
+| `sb.files.make_dir(path)` | Create directory → `dict` |
+| `sb.files.rename(old, new)` | Move/rename → `dict` |
+| `sb.files.remove(path)` | Delete file or directory |
+| `sb.files.watch_dir(path)` | Stream filesystem events → `Watcher` (context manager + iterator) |
 
 ### `Execution` object
 

--- a/sdk/python/cubesandbox/__init__.py
+++ b/sdk/python/cubesandbox/__init__.py
@@ -4,7 +4,7 @@
 from .sandbox import Sandbox
 from ._config import Config
 from ._models import Execution, Result, Logs, ExecutionError, OutputMessage, SnapshotInfo
-from ._exceptions import CubeSandboxError, SandboxNotFoundError, ApiError, TemplateNotFoundError
+from ._exceptions import CubeSandboxError, SandboxNotFoundError, ApiError, TemplateNotFoundError, FilesystemNotFoundError, PartialWriteError
 from ._commands import CommandResult
 from ._template import Template, TemplateInfo, TemplateBuild
 from ._policy import Rule, Match, Action, Inject
@@ -22,6 +22,8 @@ __all__ = [
     "SandboxNotFoundError",
     "TemplateNotFoundError",
     "ApiError",
+    "FilesystemNotFoundError",
+    "PartialWriteError",
     "CommandResult",
     "Template",
     "TemplateInfo",

--- a/sdk/python/cubesandbox/_exceptions.py
+++ b/sdk/python/cubesandbox/_exceptions.py
@@ -14,3 +14,16 @@ class SandboxNotFoundError(CubeSandboxError): ...
 class TemplateNotFoundError(CubeSandboxError): ...
 class AuthenticationError(CubeSandboxError): ...
 class ApiError(CubeSandboxError): ...
+class FilesystemNotFoundError(CubeSandboxError): ...
+
+
+class PartialWriteError(IOError):
+    """Raised when write_files fails partway through.
+
+    Attributes:
+        written: Number of files successfully written before the failure.
+    """
+
+    def __init__(self, message: str, *, written: int):
+        super().__init__(message)
+        self.written = written

--- a/sdk/python/cubesandbox/_filesystem.py
+++ b/sdk/python/cubesandbox/_filesystem.py
@@ -3,28 +3,74 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+import json
+import logging
+import struct
+from typing import TYPE_CHECKING, Any, Iterator
 
-from ._commands import DEFAULT_ENVD_USER, ENVD_PORT
+logger = logging.getLogger(__name__)
+
+from ._commands import DEFAULT_ENVD_USER, ENVD_PORT, MAX_CONNECT_ENVELOPE_SIZE
+from ._exceptions import FilesystemNotFoundError, PartialWriteError
 
 if TYPE_CHECKING:
+    import httpx
+
     from .sandbox import Sandbox
+
+CONNECT_PROTOCOL_VERSION = "1"
+CONNECT_CONTENT_TYPE = "application/connect+json"
 
 
 class Filesystem:
     def __init__(self, sandbox: "Sandbox") -> None:
         self._sandbox = sandbox
 
-    def read(self, path: str, *, user: str | None = None) -> str:
-        """Read a file through envd's HTTP file API."""
+    def _ensure_client(self):
         if self._sandbox._client is None:
             self._sandbox._client = self._sandbox._build_data_client()
-        effective_user = user or DEFAULT_ENVD_USER
 
-        headers = {}
+    def _base_headers(self) -> dict[str, str]:
+        headers: dict[str, str] = {}
         access_token = self._sandbox._data.get("envdAccessToken")
         if access_token:
             headers["X-Access-Token"] = access_token
+        return headers
+
+    def _filesystem_rpc(self, method: str, payload: dict[str, Any]) -> dict[str, Any]:
+        self._ensure_client()
+        headers = self._base_headers()
+        headers["Content-Type"] = "application/json"
+        headers["Connect-Protocol-Version"] = CONNECT_PROTOCOL_VERSION
+
+        resp = self._sandbox._client.post(
+            f"http://{self._sandbox.get_host(ENVD_PORT)}/filesystem.Filesystem/{method}",
+            json=payload,
+            headers=headers,
+        )
+        if resp.status_code >= 400:
+            message = resp.text or f"HTTP {resp.status_code}"
+            try:
+                body = resp.json()
+            except (ValueError, json.JSONDecodeError):
+                body = {}
+            code = body.get("code", "")
+            message = body.get("message") or body.get("detail") or message
+            if code:
+                message = f"{code}: {message}"
+            if resp.status_code == 404 or code == "not_found":
+                raise FilesystemNotFoundError(f"Filesystem {method} failed: {message}", status_code=resp.status_code)
+            raise IOError(f"Filesystem {method} failed: {message}")
+        if not resp.text:
+            return {}
+        return resp.json()
+
+    def read(self, path: str, *, user: str | None = None) -> str:
+        """Read a file through envd's HTTP file API."""
+        self._ensure_client()
+        effective_user = user or DEFAULT_ENVD_USER
+
+        headers = self._base_headers()
 
         resp = self._sandbox._client.get(
             f"http://{self._sandbox.get_host(ENVD_PORT)}/files",
@@ -35,22 +81,19 @@ class Filesystem:
             message = resp.text or f"HTTP {resp.status_code}"
             try:
                 body = resp.json()
-                message = body.get("message") or body.get("detail") or message
-            except Exception:  # noqa: BLE001 - best-effort error extraction
-                pass
+            except (ValueError, json.JSONDecodeError):
+                body = {}
+            message = body.get("message") or body.get("detail") or message
             raise IOError(f"Failed to read {path}: {message}")
         return resp.text
 
     def write(self, path: str, data: str | bytes, *, user: str | None = None) -> None:
         """Write a file through envd's HTTP file API."""
-        if self._sandbox._client is None:
-            self._sandbox._client = self._sandbox._build_data_client()
+        self._ensure_client()
         effective_user = user or DEFAULT_ENVD_USER
 
         headers = {"Content-Type": "application/octet-stream"}
-        access_token = self._sandbox._data.get("envdAccessToken")
-        if access_token:
-            headers["X-Access-Token"] = access_token
+        headers.update(self._base_headers())
 
         body = data.encode("utf-8") if isinstance(data, str) else data
         params = {"path": path, "username": effective_user}
@@ -61,9 +104,7 @@ class Filesystem:
             content=body,
         )
         if resp.status_code >= 400:
-            multipart_headers = {}
-            if access_token:
-                multipart_headers["X-Access-Token"] = access_token
+            multipart_headers = self._base_headers()
             resp = self._sandbox._client.post(
                 f"http://{self._sandbox.get_host(ENVD_PORT)}/files",
                 params=params,
@@ -74,7 +115,185 @@ class Filesystem:
             message = resp.text or f"HTTP {resp.status_code}"
             try:
                 payload = resp.json()
-                message = payload.get("message") or payload.get("detail") or message
-            except Exception:  # noqa: BLE001 - best-effort error extraction
-                pass
+            except (ValueError, json.JSONDecodeError):
+                payload = {}
+            message = payload.get("message") or payload.get("detail") or message
             raise IOError(f"Failed to write {path}: {message}")
+
+    def write_files(
+        self,
+        files: list[tuple[str, str | bytes]],
+        *,
+        user: str | None = None,
+    ) -> int:
+        """Write multiple files. Returns the number of files written.
+
+        Stops at the first error.
+        """
+        for i, (path, data) in enumerate(files):
+            try:
+                self.write(path, data, user=user)
+            except IOError as e:
+                raise PartialWriteError(
+                    f"write_files failed at {path} ({i+1}/{len(files)}): {e}",
+                    written=i,
+                ) from e
+        return len(files)
+
+    def list(self, path: str) -> list[dict[str, Any]]:
+        """List entries in a directory."""
+        result = self._filesystem_rpc("ListDir", {"path": path})
+        return result.get("entries", [])
+
+    def stat(self, path: str) -> dict[str, Any]:
+        """Return metadata for a file or directory."""
+        result = self._filesystem_rpc("Stat", {"path": path})
+        return result.get("entry", {})
+
+    def exists(self, path: str) -> bool:
+        """Return True if the path exists inside the sandbox."""
+        try:
+            self.stat(path)
+            return True
+        except FilesystemNotFoundError:
+            return False
+
+    def remove(self, path: str) -> None:
+        """Delete a file or directory inside the sandbox."""
+        self._filesystem_rpc("Remove", {"path": path})
+
+    def rename(self, old_path: str, new_path: str) -> dict[str, Any]:
+        """Move or rename a file or directory."""
+        result = self._filesystem_rpc("Move", {"source": old_path, "destination": new_path})
+        return result.get("entry", {})
+
+    def make_dir(self, path: str) -> dict[str, Any]:
+        """Create a directory inside the sandbox."""
+        result = self._filesystem_rpc("MakeDir", {"path": path})
+        return result.get("entry", {})
+
+    def watch_dir(self, path: str) -> Watcher:
+        """Watch a directory for filesystem changes.
+
+        Returns a Watcher that yields WatchEvent dicts. Use as a context
+        manager or call close() when done::
+
+            with sb.files.watch_dir("/tmp") as w:
+                for event in w:
+                    print(event["name"], event["type"])
+        """
+        self._ensure_client()
+        payload = json.dumps({"path": path}).encode()
+        envelope = struct.pack(">bI", 0, len(payload)) + payload
+
+        headers = self._base_headers()
+        headers["Content-Type"] = CONNECT_CONTENT_TYPE
+        headers["Connect-Protocol-Version"] = CONNECT_PROTOCOL_VERSION
+
+        resp = self._sandbox._client.send(
+            self._sandbox._client.build_request(
+                "POST",
+                f"http://{self._sandbox.get_host(ENVD_PORT)}/filesystem.Filesystem/WatchDir",
+                content=envelope,
+                headers=headers,
+            ),
+            stream=True,
+        )
+        if resp.status_code >= 400:
+            resp.close()
+            raise IOError(f"WatchDir failed: HTTP {resp.status_code}")
+        return Watcher(resp)
+
+
+class WatchEvent(dict):
+    """A filesystem change event with ``name`` and ``type`` keys."""
+
+    @property
+    def name(self) -> str:
+        return self.get("name", "")
+
+    @property
+    def type(self) -> str:
+        return self.get("type", "")
+
+
+class Watcher:
+    """Iterates over WatchEvent items from a streaming WatchDir response."""
+
+    def __init__(self, response: httpx.Response) -> None:
+        self._response = response
+        self._iter = response.stream.__iter__()
+        self._closed = False
+        self._buf = b""
+        self._eof = False
+
+    def __enter__(self) -> Watcher:
+        return self
+
+    def __exit__(self, *exc: Any) -> None:
+        self.close()
+
+    def close(self) -> None:
+        if not self._closed:
+            self._closed = True
+            self._response.close()
+
+    def __iter__(self) -> Iterator[WatchEvent]:
+        return self
+
+    def __next__(self) -> WatchEvent:
+        while True:
+            event = self._read_frame()
+            if event is None:
+                raise StopIteration
+            if event is not _SKIP:
+                return event
+
+    def _fill(self, need: int) -> bool:
+        while len(self._buf) < need and not self._eof:
+            try:
+                chunk = next(self._iter)
+            except StopIteration:
+                self._eof = True
+                return len(self._buf) >= need
+            if chunk:
+                self._buf += chunk
+        return len(self._buf) >= need
+
+    def _read_frame(self) -> WatchEvent | None | object:
+        try:
+            if not self._fill(5):
+                return None
+
+            flags = self._buf[0]
+            size = struct.unpack(">I", self._buf[1:5])[0]
+
+            if size > MAX_CONNECT_ENVELOPE_SIZE:
+                raise IOError(f"frame too large: {size} bytes")
+
+            if not self._fill(5 + size):
+                return None
+
+            payload = self._buf[5 : 5 + size]
+            self._buf = self._buf[5 + size :]
+
+            if flags & 0x02:
+                data = json.loads(payload)
+                err = data.get("error")
+                if err:
+                    msg = err.get("message", "watch stream error")
+                    raise IOError(msg)
+                return None
+
+            data = json.loads(payload)
+            if "filesystem" in data:
+                return WatchEvent(data["filesystem"])
+            return _SKIP
+        except IOError:
+            raise
+        except Exception:  # noqa: BLE001
+            logger.debug("unexpected error parsing watch frame", exc_info=True)
+            return None
+
+
+_SKIP = object()

--- a/sdk/python/tests/integration_test_filesystem.sh
+++ b/sdk/python/tests/integration_test_filesystem.sh
@@ -1,0 +1,351 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Integration test for filesystem API against a live envd instance.
+# Usage: ./integration_test_filesystem.sh <SANDBOX_IP> [PORT]
+set -euo pipefail
+
+HOST="${1:?Usage: $0 <SANDBOX_IP> [PORT]}"
+PORT="${2:-49983}"
+BASE="http://${HOST}:${PORT}"
+PASS=0
+FAIL=0
+TOTAL=0
+
+green()  { printf "\033[32m%s\033[0m\n" "$*"; }
+red()    { printf "\033[31m%s\033[0m\n" "$*"; }
+yellow() { printf "\033[33m%s\033[0m\n" "$*"; }
+
+assert_eq() {
+    local label="$1" expected="$2" actual="$3"
+    TOTAL=$((TOTAL+1))
+    if [ "$expected" = "$actual" ]; then
+        green "  PASS: $label"
+        PASS=$((PASS+1))
+    else
+        red "  FAIL: $label (expected='$expected', actual='$actual')"
+        FAIL=$((FAIL+1))
+    fi
+}
+
+assert_contains() {
+    local label="$1" needle="$2" haystack="$3"
+    TOTAL=$((TOTAL+1))
+    if echo "$haystack" | grep -q "$needle"; then
+        green "  PASS: $label"
+        PASS=$((PASS+1))
+    else
+        red "  FAIL: $label (expected to contain '$needle')"
+        FAIL=$((FAIL+1))
+    fi
+}
+
+assert_http() {
+    local label="$1" expected_code="$2" actual_code="$3"
+    assert_eq "$label [HTTP $expected_code]" "$expected_code" "$actual_code"
+}
+
+rpc() {
+    local method="$1" payload="$2"
+    curl -s -w '\n%{http_code}' \
+        -X POST "${BASE}/filesystem.Filesystem/${method}" \
+        -H "Content-Type: application/json" \
+        -H "Connect-Protocol-Version: 1" \
+        -d "$payload"
+}
+
+rpc_code() {
+    echo "$1" | tail -1
+}
+
+rpc_body() {
+    echo "$1" | sed '$d'
+}
+
+echo "========================================"
+echo " Filesystem API Integration Tests"
+echo " Target: ${BASE}"
+echo "========================================"
+echo ""
+
+# ── Setup: create test directory via Write endpoint ──────────────────────────
+echo "--- Setup ---"
+TEST_DIR="/tmp/fs_integration_test_$$"
+
+# 1. MakeDir
+echo "[Test 1] MakeDir - create test directory"
+RESP=$(rpc "MakeDir" "{\"path\":\"${TEST_DIR}\"}")
+CODE=$(rpc_code "$RESP")
+BODY=$(rpc_body "$RESP")
+assert_http "MakeDir returns 200" "200" "$CODE"
+assert_contains "MakeDir response has entry" "entry" "$BODY"
+assert_contains "MakeDir type is DIRECTORY" "FILE_TYPE_DIRECTORY" "$BODY"
+echo ""
+
+# 2. MakeDir - nested
+echo "[Test 2] MakeDir - create nested directory"
+RESP=$(rpc "MakeDir" "{\"path\":\"${TEST_DIR}/subdir\"}")
+CODE=$(rpc_code "$RESP")
+BODY=$(rpc_body "$RESP")
+assert_http "MakeDir nested returns 200" "200" "$CODE"
+assert_contains "MakeDir nested has subdir name" "subdir" "$BODY"
+echo ""
+
+# 3. Write a file via HTTP file API
+echo "[Test 3] Write file via /files API"
+CODE=$(curl -s -o /dev/null -w '%{http_code}' \
+    -X POST "${BASE}/files?path=${TEST_DIR}/hello.txt&username=root" \
+    -H "Content-Type: application/octet-stream" \
+    -d "Hello, filesystem API!")
+assert_http "Write file returns 200" "200" "$CODE"
+echo ""
+
+# 4. Write a second file
+echo "[Test 4] Write second file"
+CODE=$(curl -s -o /dev/null -w '%{http_code}' \
+    -X POST "${BASE}/files?path=${TEST_DIR}/subdir/nested.txt&username=root" \
+    -H "Content-Type: application/octet-stream" \
+    -d "Nested file content")
+assert_http "Write nested file returns 200" "200" "$CODE"
+echo ""
+
+# 5. Stat - file
+echo "[Test 5] Stat - check file metadata"
+RESP=$(rpc "Stat" "{\"path\":\"${TEST_DIR}/hello.txt\"}")
+CODE=$(rpc_code "$RESP")
+BODY=$(rpc_body "$RESP")
+assert_http "Stat file returns 200" "200" "$CODE"
+assert_contains "Stat has name" "hello.txt" "$BODY"
+assert_contains "Stat type is FILE" "FILE_TYPE_FILE" "$BODY"
+assert_contains "Stat has size" "size" "$BODY"
+assert_contains "Stat has permissions" "permissions" "$BODY"
+echo ""
+
+# 6. Stat - directory
+echo "[Test 6] Stat - check directory metadata"
+RESP=$(rpc "Stat" "{\"path\":\"${TEST_DIR}\"}")
+CODE=$(rpc_code "$RESP")
+BODY=$(rpc_body "$RESP")
+assert_http "Stat dir returns 200" "200" "$CODE"
+assert_contains "Stat dir type is DIRECTORY" "FILE_TYPE_DIRECTORY" "$BODY"
+echo ""
+
+# 7. ListDir - root test dir
+echo "[Test 7] ListDir - list test directory"
+RESP=$(rpc "ListDir" "{\"path\":\"${TEST_DIR}\"}")
+CODE=$(rpc_code "$RESP")
+BODY=$(rpc_body "$RESP")
+assert_http "ListDir returns 200" "200" "$CODE"
+assert_contains "ListDir has hello.txt" "hello.txt" "$BODY"
+assert_contains "ListDir has subdir" "subdir" "$BODY"
+echo ""
+
+# 8. ListDir - nested
+echo "[Test 8] ListDir - list nested directory"
+RESP=$(rpc "ListDir" "{\"path\":\"${TEST_DIR}/subdir\"}")
+CODE=$(rpc_code "$RESP")
+BODY=$(rpc_body "$RESP")
+assert_http "ListDir nested returns 200" "200" "$CODE"
+assert_contains "ListDir nested has nested.txt" "nested.txt" "$BODY"
+echo ""
+
+# 9. Read back file content
+echo "[Test 9] Read file via /files API"
+CONTENT=$(curl -s "${BASE}/files?path=${TEST_DIR}/hello.txt&username=root")
+assert_eq "Read content matches" "Hello, filesystem API!" "$CONTENT"
+echo ""
+
+# 10. Move (rename) file
+echo "[Test 10] Move - rename file"
+RESP=$(rpc "Move" "{\"source\":\"${TEST_DIR}/hello.txt\",\"destination\":\"${TEST_DIR}/renamed.txt\"}")
+CODE=$(rpc_code "$RESP")
+BODY=$(rpc_body "$RESP")
+assert_http "Move returns 200" "200" "$CODE"
+assert_contains "Move response has renamed.txt" "renamed.txt" "$BODY"
+echo ""
+
+# 11. Verify old path is gone (Stat should 404)
+echo "[Test 11] Stat - verify old path returns 404"
+RESP=$(rpc "Stat" "{\"path\":\"${TEST_DIR}/hello.txt\"}")
+CODE=$(rpc_code "$RESP")
+BODY=$(rpc_body "$RESP")
+assert_http "Stat old path returns 404" "404" "$CODE"
+assert_contains "Stat 404 has not_found code" "not_found" "$BODY"
+echo ""
+
+# 12. Verify new path exists
+echo "[Test 12] Stat - verify new path exists"
+RESP=$(rpc "Stat" "{\"path\":\"${TEST_DIR}/renamed.txt\"}")
+CODE=$(rpc_code "$RESP")
+BODY=$(rpc_body "$RESP")
+assert_http "Stat renamed returns 200" "200" "$CODE"
+assert_contains "Stat renamed has name" "renamed.txt" "$BODY"
+echo ""
+
+# 13. Read renamed file content is preserved
+echo "[Test 13] Read renamed file content"
+CONTENT=$(curl -s "${BASE}/files?path=${TEST_DIR}/renamed.txt&username=root")
+assert_eq "Renamed content preserved" "Hello, filesystem API!" "$CONTENT"
+echo ""
+
+# 14. Remove file
+echo "[Test 14] Remove - delete renamed file"
+RESP=$(rpc "Remove" "{\"path\":\"${TEST_DIR}/renamed.txt\"}")
+CODE=$(rpc_code "$RESP")
+assert_http "Remove file returns 200" "200" "$CODE"
+echo ""
+
+# 15. Verify removed file is gone
+echo "[Test 15] Stat - verify removed file returns 404"
+RESP=$(rpc "Stat" "{\"path\":\"${TEST_DIR}/renamed.txt\"}")
+CODE=$(rpc_code "$RESP")
+assert_http "Stat removed returns 404" "404" "$CODE"
+echo ""
+
+# 16. Remove nested file
+echo "[Test 16] Remove - delete nested file"
+RESP=$(rpc "Remove" "{\"path\":\"${TEST_DIR}/subdir/nested.txt\"}")
+CODE=$(rpc_code "$RESP")
+assert_http "Remove nested returns 200" "200" "$CODE"
+echo ""
+
+# 17. Remove empty subdir
+echo "[Test 17] Remove - delete empty subdir"
+RESP=$(rpc "Remove" "{\"path\":\"${TEST_DIR}/subdir\"}")
+CODE=$(rpc_code "$RESP")
+assert_http "Remove subdir returns 200" "200" "$CODE"
+echo ""
+
+# 18. ListDir on now-empty test dir
+echo "[Test 18] ListDir - empty directory"
+RESP=$(rpc "ListDir" "{\"path\":\"${TEST_DIR}\"}")
+CODE=$(rpc_code "$RESP")
+BODY=$(rpc_body "$RESP")
+assert_http "ListDir empty returns 200" "200" "$CODE"
+# Should not contain any entries (or entries should be empty)
+echo "  Body: $BODY"
+echo ""
+
+# 19. Cleanup: remove test dir
+echo "[Test 19] Cleanup - remove test directory"
+RESP=$(rpc "Remove" "{\"path\":\"${TEST_DIR}\"}")
+CODE=$(rpc_code "$RESP")
+assert_http "Remove test dir returns 200" "200" "$CODE"
+echo ""
+
+# 20. Stat on removed dir confirms 404
+echo "[Test 20] Stat - confirm test dir removed"
+RESP=$(rpc "Stat" "{\"path\":\"${TEST_DIR}\"}")
+CODE=$(rpc_code "$RESP")
+assert_http "Stat cleaned up dir returns 404" "404" "$CODE"
+echo ""
+
+# ── WatchDir ─────────────────────────────────────────────────────────────────
+echo "[Test 21] WatchDir - receive filesystem events"
+
+WATCH_DIR="/tmp/watchdir_test_$$"
+curl -s -X POST "${BASE}/filesystem.Filesystem/MakeDir" \
+  -H "Content-Type: application/json" \
+  -H "Connect-Protocol-Version: 1" \
+  -d "{\"path\":\"${WATCH_DIR}\"}" > /dev/null
+
+# Start watcher in background, write raw binary output
+# curl exits 28 on --max-time which is expected; suppress with || true
+(python3 -c "
+import struct, json, sys
+payload = json.dumps({'path': '${WATCH_DIR}'}).encode()
+envelope = struct.pack('>bI', 0, len(payload)) + payload
+sys.stdout.buffer.write(envelope)
+" | curl -s -X POST "${BASE}/filesystem.Filesystem/WatchDir" \
+  -H "Content-Type: application/connect+json" \
+  -H "Connect-Protocol-Version: 1" \
+  --data-binary @- \
+  --max-time 6 \
+  -o /tmp/watch_raw_$$.bin 2>/dev/null || true) &
+CURL_PID=$!
+sleep 1
+
+# Trigger events: create, write, remove
+curl -s -X POST "${BASE}/files?path=${WATCH_DIR}/w.txt&username=root" \
+  -H "Content-Type: application/octet-stream" -d "hello" > /dev/null
+sleep 0.5
+
+curl -s -X POST "${BASE}/filesystem.Filesystem/Remove" \
+  -H "Content-Type: application/json" \
+  -H "Connect-Protocol-Version: 1" \
+  -d "{\"path\":\"${WATCH_DIR}/w.txt\"}" > /dev/null
+sleep 0.5
+
+wait $CURL_PID 2>/dev/null
+
+# Parse and verify events
+EVENTS=$(python3 -c "
+import struct, json
+with open('/tmp/watch_raw_$$.bin', 'rb') as f:
+    data = f.read()
+offset = 0
+types = []
+while offset + 5 <= len(data):
+    flags = data[offset]
+    size = struct.unpack('>I', data[offset+1:offset+5])[0]
+    offset += 5
+    if offset + size > len(data):
+        break
+    payload = data[offset:offset+size]
+    offset += size
+    try:
+        parsed = json.loads(payload)
+        if 'filesystem' in parsed:
+            types.append(parsed['filesystem']['type'])
+    except:
+        pass
+print(','.join(types))
+" 2>/dev/null)
+
+TOTAL=$((TOTAL+1))
+if echo "$EVENTS" | grep -q "EVENT_TYPE_CREATE"; then
+    green "  PASS: WatchDir received CREATE event"
+    PASS=$((PASS+1))
+else
+    red "  FAIL: WatchDir missing CREATE event (got: $EVENTS)"
+    FAIL=$((FAIL+1))
+fi
+
+TOTAL=$((TOTAL+1))
+if echo "$EVENTS" | grep -q "EVENT_TYPE_REMOVE"; then
+    green "  PASS: WatchDir received REMOVE event"
+    PASS=$((PASS+1))
+else
+    red "  FAIL: WatchDir missing REMOVE event (got: $EVENTS)"
+    FAIL=$((FAIL+1))
+fi
+
+TOTAL=$((TOTAL+1))
+if echo "$EVENTS" | grep -q "EVENT_TYPE_WRITE"; then
+    green "  PASS: WatchDir received WRITE event"
+    PASS=$((PASS+1))
+else
+    red "  FAIL: WatchDir missing WRITE event (got: $EVENTS)"
+    FAIL=$((FAIL+1))
+fi
+
+# Cleanup
+curl -s -X POST "${BASE}/filesystem.Filesystem/Remove" \
+  -H "Content-Type: application/json" \
+  -H "Connect-Protocol-Version: 1" \
+  -d "{\"path\":\"${WATCH_DIR}\"}" > /dev/null
+rm -f /tmp/watch_raw_$$.bin
+echo ""
+
+# ── Summary ──────────────────────────────────────────────────────────────────
+echo "========================================"
+if [ $FAIL -eq 0 ]; then
+    green " ALL PASSED: $PASS/$TOTAL tests"
+else
+    red " FAILED: $FAIL/$TOTAL tests"
+    yellow " Passed: $PASS/$TOTAL"
+fi
+echo "========================================"
+
+exit $FAIL

--- a/sdk/python/tests/integration_test_sdk.py
+++ b/sdk/python/tests/integration_test_sdk.py
@@ -1,0 +1,288 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# End-to-end integration test for the Python SDK filesystem API against a live
+# envd instance. Uses the actual SDK Filesystem and Watcher classes with a
+# minimal Sandbox shim that points directly at the sandbox IP.
+#
+# Requires Python 3.7+ and httpx. If the node's Python is too old, run from a
+# machine with network access to the sandbox or use integration_test_filesystem.sh.
+#
+# Usage: python3 integration_test_sdk.py <SANDBOX_IP> [PORT]
+
+import json
+import os
+import struct
+import sys
+import threading
+import time
+
+try:
+    import httpx
+except ImportError:
+    sys.exit("httpx is required: pip install httpx")
+
+# Add the SDK to the path so we can import it without installing
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from cubesandbox._filesystem import Filesystem
+
+
+class _FakeSandbox:
+    """Minimal shim so Filesystem can operate against a raw IP:port."""
+
+    def __init__(self, host):
+        self._host = host
+        self._client = httpx.Client(timeout=httpx.Timeout(connect=10, read=30, write=30, pool=30))
+        self._data = {}
+
+    def get_host(self, port):
+        return self._host
+
+    def _build_data_client(self):
+        return self._client
+
+    def close(self):
+        self._client.close()
+
+
+PASS = 0
+FAIL = 0
+
+
+def green(s):
+    print("\033[32m  PASS: %s\033[0m" % s)
+
+
+def red(s):
+    print("\033[31m  FAIL: %s\033[0m" % s)
+
+
+def yellow(s):
+    print("\033[33m%s\033[0m" % s)
+
+
+def assert_true(label, ok, detail=""):
+    global PASS, FAIL
+    if ok:
+        PASS += 1
+        green(label)
+    else:
+        FAIL += 1
+        red("%s (%s)" % (label, detail))
+
+
+def assert_eq(label, expected, actual):
+    assert_true(label, expected == actual, "expected=%r actual=%r" % (expected, actual))
+
+
+def assert_contains(label, haystack, needle):
+    assert_true(label, needle in str(haystack), "missing %r" % needle)
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: %s <SANDBOX_IP> [PORT]" % sys.argv[0], file=sys.stderr)
+        sys.exit(1)
+
+    host = sys.argv[1]
+    port = sys.argv[2] if len(sys.argv) > 2 else "49983"
+    target = "%s:%s" % (host, port)
+
+    print("========================================")
+    print(" Python SDK Filesystem E2E Tests")
+    print(" Target: http://%s" % target)
+    print("========================================")
+    print()
+
+    sb = _FakeSandbox(target)
+    fs = Filesystem(sb)
+    test_dir = "/tmp/py_sdk_e2e_%d" % os.getpid()
+
+    try:
+        # 1. MakeDir
+        print("[Test 1] MakeDir")
+        entry = fs.make_dir(test_dir)
+        assert_true("make_dir returns dict", isinstance(entry, dict))
+        assert_contains("make_dir type DIRECTORY", entry.get("type", ""), "DIRECTORY")
+        print()
+
+        # 2. MakeDir nested
+        print("[Test 2] MakeDir nested")
+        entry = fs.make_dir(test_dir + "/subdir")
+        assert_contains("make_dir nested name", entry.get("name", ""), "subdir")
+        print()
+
+        # 3. Write file
+        print("[Test 3] Write file")
+        fs.write(test_dir + "/hello.txt", "Hello, Python SDK!")
+        assert_true("write did not raise", True)
+        print()
+
+        # 4. Write second file
+        print("[Test 4] Write nested file")
+        fs.write(test_dir + "/subdir/nested.txt", "Nested content")
+        assert_true("write nested did not raise", True)
+        print()
+
+        # 5. Stat file
+        print("[Test 5] Stat file")
+        entry = fs.stat(test_dir + "/hello.txt")
+        assert_eq("stat name", "hello.txt", entry.get("name"))
+        assert_contains("stat type FILE", entry.get("type", ""), "FILE_TYPE_FILE")
+        assert_true("stat has size", "size" in entry, "missing size")
+        assert_true("stat has permissions", "permissions" in entry, "missing permissions")
+        print()
+
+        # 6. Stat directory
+        print("[Test 6] Stat directory")
+        entry = fs.stat(test_dir)
+        assert_contains("stat dir DIRECTORY", entry.get("type", ""), "DIRECTORY")
+        print()
+
+        # 7. List
+        print("[Test 7] List")
+        entries = fs.list(test_dir)
+        names = [e.get("name") for e in entries]
+        assert_true("list has hello.txt", "hello.txt" in names, "got %s" % names)
+        assert_true("list has subdir", "subdir" in names, "got %s" % names)
+        print()
+
+        # 8. List nested
+        print("[Test 8] List nested")
+        entries = fs.list(test_dir + "/subdir")
+        names = [e.get("name") for e in entries]
+        assert_true("list nested has nested.txt", "nested.txt" in names, "got %s" % names)
+        print()
+
+        # 9. Read file
+        print("[Test 9] Read file")
+        content = fs.read(test_dir + "/hello.txt")
+        assert_eq("read content", "Hello, Python SDK!", content)
+        print()
+
+        # 10. Exists
+        print("[Test 10] Exists")
+        assert_true("exists returns True", fs.exists(test_dir + "/hello.txt"))
+        assert_true("exists returns False for missing", not fs.exists(test_dir + "/nope.txt"))
+        print()
+
+        # 11. Rename
+        print("[Test 11] Rename")
+        entry = fs.rename(test_dir + "/hello.txt", test_dir + "/renamed.txt")
+        assert_contains("rename has renamed.txt", entry.get("name", ""), "renamed.txt")
+        print()
+
+        # 12. Verify old gone, new exists
+        print("[Test 12] Exists after rename")
+        assert_true("old path gone", not fs.exists(test_dir + "/hello.txt"))
+        assert_true("new path exists", fs.exists(test_dir + "/renamed.txt"))
+        print()
+
+        # 13. Read renamed
+        print("[Test 13] Read renamed")
+        content = fs.read(test_dir + "/renamed.txt")
+        assert_eq("renamed content preserved", "Hello, Python SDK!", content)
+        print()
+
+        # 14. WriteFiles
+        print("[Test 14] WriteFiles")
+        n = fs.write_files([
+            (test_dir + "/batch_a.txt", "aaa"),
+            (test_dir + "/batch_b.txt", "bbb"),
+        ])
+        assert_eq("write_files count", 2, n)
+        assert_true("batch_a exists", fs.exists(test_dir + "/batch_a.txt"))
+        assert_true("batch_b exists", fs.exists(test_dir + "/batch_b.txt"))
+        print()
+
+        # 15. Remove
+        print("[Test 15] Remove")
+        fs.remove(test_dir + "/renamed.txt")
+        assert_true("remove did not raise", True)
+        assert_true("removed file gone", not fs.exists(test_dir + "/renamed.txt"))
+        print()
+
+        # 16. Cleanup nested
+        print("[Test 16] Cleanup nested")
+        fs.remove(test_dir + "/subdir/nested.txt")
+        fs.remove(test_dir + "/subdir")
+        fs.remove(test_dir + "/batch_a.txt")
+        fs.remove(test_dir + "/batch_b.txt")
+        assert_true("cleanup ok", True)
+        print()
+
+        # 17. List empty
+        print("[Test 17] List empty dir")
+        entries = fs.list(test_dir)
+        assert_eq("empty dir entries", 0, len(entries))
+        print()
+
+        # 18. Remove test dir + verify
+        print("[Test 18] Remove test dir")
+        fs.remove(test_dir)
+        assert_true("test dir removed", not fs.exists(test_dir))
+        print()
+
+        # 19. WatchDir
+        print("[Test 19] WatchDir")
+        watch_dir = "/tmp/py_watch_%d" % os.getpid()
+        fs.make_dir(watch_dir)
+
+        watcher = fs.watch_dir(watch_dir)
+        time.sleep(1)
+
+        # trigger events
+        fs.write(watch_dir + "/w.txt", "hello")
+        time.sleep(0.5)
+        fs.remove(watch_dir + "/w.txt")
+        time.sleep(0.5)
+
+        # collect events with timeout
+        events = []
+
+        def collect():
+            try:
+                for ev in watcher:
+                    events.append(ev)
+            except Exception:
+                pass
+
+        t = threading.Thread(target=collect)
+        t.daemon = True
+        t.start()
+        t.join(timeout=5)
+        watcher.close()
+
+        event_types = [e.type for e in events]
+        joined = ",".join(event_types)
+        assert_true("WatchDir CREATE", "EVENT_TYPE_CREATE" in joined, "got: %s" % joined)
+        assert_true("WatchDir WRITE", "EVENT_TYPE_WRITE" in joined, "got: %s" % joined)
+        assert_true("WatchDir REMOVE", "EVENT_TYPE_REMOVE" in joined, "got: %s" % joined)
+
+        # cleanup
+        try:
+            fs.remove(watch_dir)
+        except Exception:
+            pass
+        print()
+
+    finally:
+        sb.close()
+
+    # Summary
+    total = PASS + FAIL
+    print("========================================")
+    if FAIL == 0:
+        green("ALL PASSED: %d/%d tests" % (PASS, total))
+    else:
+        red("FAILED: %d/%d tests" % (FAIL, total))
+        yellow(" Passed: %d/%d" % (PASS, total))
+    print("========================================")
+
+    sys.exit(FAIL)
+
+
+if __name__ == "__main__":
+    main()

--- a/sdk/python/tests/test_sandbox.py
+++ b/sdk/python/tests/test_sandbox.py
@@ -1343,6 +1343,248 @@ class TestFilesystem:
         assert "multipart/form-data" in seen["content_type"]
         assert b"file content" in seen["body"]
 
+    def test_list_success(self):
+        sb = make_sandbox()
+        seen = {}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            seen["method"] = request.method
+            seen["host"] = request.url.host
+            seen["path"] = request.url.path
+            seen["content_type"] = request.headers.get("content-type")
+            seen["body"] = json.loads(request.content)
+            return httpx.Response(200, json={
+                "entries": [
+                    {"name": "a.txt", "type": "FILE_TYPE_FILE", "path": "/tmp/a.txt",
+                     "size": "10", "permissions": "-rw-r--r--"},
+                    {"name": "sub", "type": "FILE_TYPE_DIRECTORY", "path": "/tmp/sub",
+                     "size": "0", "permissions": "drwxr-xr-x"},
+                ]
+            })
+
+        client = httpx.Client(transport=httpx.MockTransport(handler))
+        with patch.object(sb, "_build_data_client", return_value=client):
+            entries = sb.files.list("/tmp")
+        assert seen["method"] == "POST"
+        assert seen["host"] == f"49983-{SANDBOX_ID}.{DOMAIN}"
+        assert seen["path"] == "/filesystem.Filesystem/ListDir"
+        assert seen["content_type"] == "application/json"
+        assert seen["body"] == {"path": "/tmp"}
+        assert len(entries) == 2
+        assert entries[0]["name"] == "a.txt"
+        assert entries[1]["type"] == "FILE_TYPE_DIRECTORY"
+
+    def test_list_returns_empty_for_empty_dir(self):
+        sb = make_sandbox()
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, json={})
+
+        client = httpx.Client(transport=httpx.MockTransport(handler))
+        with patch.object(sb, "_build_data_client", return_value=client):
+            entries = sb.files.list("/empty")
+        assert entries == []
+
+    def test_stat_success(self):
+        sb = make_sandbox()
+        seen = {}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            seen["body"] = json.loads(request.content)
+            return httpx.Response(200, json={
+                "entry": {"name": "hello.txt", "type": "FILE_TYPE_FILE",
+                          "path": "/tmp/hello.txt", "size": "30"}
+            })
+
+        client = httpx.Client(transport=httpx.MockTransport(handler))
+        with patch.object(sb, "_build_data_client", return_value=client):
+            entry = sb.files.stat("/tmp/hello.txt")
+        assert seen["body"] == {"path": "/tmp/hello.txt"}
+        assert entry["name"] == "hello.txt"
+        assert entry["size"] == "30"
+
+    def test_exists_returns_true(self):
+        sb = make_sandbox()
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, json={
+                "entry": {"name": "f.txt", "type": "FILE_TYPE_FILE", "path": "/tmp/f.txt"}
+            })
+
+        client = httpx.Client(transport=httpx.MockTransport(handler))
+        with patch.object(sb, "_build_data_client", return_value=client):
+            assert sb.files.exists("/tmp/f.txt") is True
+
+    def test_exists_returns_false_on_404(self):
+        sb = make_sandbox()
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(404, json={
+                "code": "not_found", "message": "file not found: /tmp/missing.txt"
+            })
+
+        client = httpx.Client(transport=httpx.MockTransport(handler))
+        with patch.object(sb, "_build_data_client", return_value=client):
+            assert sb.files.exists("/tmp/missing.txt") is False
+
+    def test_remove_success(self):
+        sb = make_sandbox()
+        seen = {}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            seen["body"] = json.loads(request.content)
+            seen["path"] = request.url.path
+            return httpx.Response(200, json={})
+
+        client = httpx.Client(transport=httpx.MockTransport(handler))
+        with patch.object(sb, "_build_data_client", return_value=client):
+            sb.files.remove("/tmp/old.txt")
+        assert seen["path"] == "/filesystem.Filesystem/Remove"
+        assert seen["body"] == {"path": "/tmp/old.txt"}
+
+    def test_rename_success(self):
+        sb = make_sandbox()
+        seen = {}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            seen["body"] = json.loads(request.content)
+            return httpx.Response(200, json={
+                "entry": {"name": "new.txt", "type": "FILE_TYPE_FILE",
+                          "path": "/tmp/new.txt"}
+            })
+
+        client = httpx.Client(transport=httpx.MockTransport(handler))
+        with patch.object(sb, "_build_data_client", return_value=client):
+            entry = sb.files.rename("/tmp/old.txt", "/tmp/new.txt")
+        assert seen["body"] == {"source": "/tmp/old.txt", "destination": "/tmp/new.txt"}
+        assert entry["name"] == "new.txt"
+
+    def test_make_dir_success(self):
+        sb = make_sandbox()
+        seen = {}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            seen["body"] = json.loads(request.content)
+            return httpx.Response(200, json={
+                "entry": {"name": "newdir", "type": "FILE_TYPE_DIRECTORY",
+                          "path": "/tmp/newdir"}
+            })
+
+        client = httpx.Client(transport=httpx.MockTransport(handler))
+        with patch.object(sb, "_build_data_client", return_value=client):
+            entry = sb.files.make_dir("/tmp/newdir")
+        assert seen["body"] == {"path": "/tmp/newdir"}
+        assert entry["type"] == "FILE_TYPE_DIRECTORY"
+
+    def test_write_files_success(self):
+        sb = make_sandbox()
+        paths = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            paths.append(request.url.params.get("path"))
+            return httpx.Response(200, json=[{"path": request.url.params.get("path")}])
+
+        client = httpx.Client(transport=httpx.MockTransport(handler))
+        with patch.object(sb, "_build_data_client", return_value=client):
+            n = sb.files.write_files([
+                ("/tmp/a.txt", "aaa"),
+                ("/tmp/b.txt", b"bbb"),
+                ("/tmp/c.txt", "ccc"),
+            ])
+        assert n == 3
+        assert paths == ["/tmp/a.txt", "/tmp/b.txt", "/tmp/c.txt"]
+
+    def test_write_files_stops_on_error(self):
+        sb = make_sandbox()
+        calls = {"count": 0}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            calls["count"] += 1
+            path = request.url.params.get("path", "")
+            if path == "/tmp/b.txt":
+                return httpx.Response(500, json={"message": "disk full"})
+            return httpx.Response(200, json=[])
+
+        client = httpx.Client(transport=httpx.MockTransport(handler))
+        with patch.object(sb, "_build_data_client", return_value=client):
+            with pytest.raises(IOError, match="write_files failed at /tmp/b.txt"):
+                sb.files.write_files([
+                    ("/tmp/a.txt", "ok"),
+                    ("/tmp/b.txt", "fail"),
+                    ("/tmp/c.txt", "skip"),
+                ])
+
+    def test_filesystem_rpc_raises_on_error(self):
+        sb = make_sandbox()
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(500, json={"message": "internal error"})
+
+        client = httpx.Client(transport=httpx.MockTransport(handler))
+        with patch.object(sb, "_build_data_client", return_value=client):
+            with pytest.raises(IOError, match="Filesystem ListDir failed"):
+                sb.files.list("/tmp")
+
+    def test_watch_dir_receives_events(self):
+        sb = make_sandbox()
+
+        def _connect_frame(flags, payload_str):
+            raw = payload_str.encode()
+            return struct.pack(">bI", flags, len(raw)) + raw
+
+        stream_data = b"".join([
+            _connect_frame(0, '{"start":{}}'),
+            _connect_frame(0, '{"filesystem":{"name":"a.txt","type":"EVENT_TYPE_CREATE"}}'),
+            _connect_frame(0, '{"filesystem":{"name":"a.txt","type":"EVENT_TYPE_WRITE"}}'),
+            _connect_frame(0, '{"filesystem":{"name":"b.txt","type":"EVENT_TYPE_REMOVE"}}'),
+        ])
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, stream=httpx.ByteStream(stream_data))
+
+        client = httpx.Client(transport=httpx.MockTransport(handler))
+        with patch.object(sb, "_build_data_client", return_value=client):
+            with sb.files.watch_dir("/tmp/test") as watcher:
+                events = list(watcher)
+
+        assert len(events) == 3
+        assert events[0]["name"] == "a.txt"
+        assert events[0]["type"] == "EVENT_TYPE_CREATE"
+        assert events[1]["type"] == "EVENT_TYPE_WRITE"
+        assert events[2]["name"] == "b.txt"
+        assert events[2]["type"] == "EVENT_TYPE_REMOVE"
+
+    def test_watch_dir_error_from_server(self):
+        sb = make_sandbox()
+
+        def _connect_frame(flags, payload_str):
+            raw = payload_str.encode()
+            return struct.pack(">bI", flags, len(raw)) + raw
+
+        stream_data = _connect_frame(
+            0x02, '{"error":{"code":"not_found","message":"path not found"}}'
+        )
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, stream=httpx.ByteStream(stream_data))
+
+        client = httpx.Client(transport=httpx.MockTransport(handler))
+        with patch.object(sb, "_build_data_client", return_value=client):
+            with sb.files.watch_dir("/nonexistent") as watcher:
+                with pytest.raises(IOError, match="path not found"):
+                    list(watcher)
+
+    def test_watch_dir_http_error(self):
+        sb = make_sandbox()
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(404, text="not found")
+
+        client = httpx.Client(transport=httpx.MockTransport(handler))
+        with patch.object(sb, "_build_data_client", return_value=client):
+            with pytest.raises(IOError, match="WatchDir failed"):
+                sb.files.watch_dir("/tmp/test")
+
     def test_files_property(self):
         assert isinstance(make_sandbox().files, Filesystem)
 


### PR DESCRIPTION
  ## Summary

  Complete the Python and Go SDK filesystem API to match e2b's capabilities. All methods wrap envd's native endpoints — no new server-side changes required.

  ### New methods

  | Method | Go (`Files`) | Python (`Filesystem`) | envd endpoint |
  |--------|-------------|----------------------|---------------|
  | `List` | `List(ctx, path)` | `list(path)` | `POST /filesystem.Filesystem/ListDir` |
  | `Stat` | `Stat(ctx, path)` | `stat(path)` | `POST /filesystem.Filesystem/Stat` |
  | `Exists` | `Exists(ctx, path)` | `exists(path)` | Stat + 404 check |
  | `Remove` | `Remove(ctx, path)` | `remove(path)` | `POST /filesystem.Filesystem/Remove` |
  | `Rename` | `Rename(ctx, old, new)` | `rename(old, new)` | `POST /filesystem.Filesystem/Move` |
  | `MakeDir` | `MakeDir(ctx, path)` | `make_dir(path)` | `POST /filesystem.Filesystem/MakeDir` |
  | `WriteFiles` | `WriteFiles(ctx, entries)` | `write_files(files)` | Batch `POST /files` |
  | `WatchDir` | `WatchDir(ctx, path)` | `watch_dir(path)` | `POST /filesystem.Filesystem/WatchDir` (Connect streaming) |

  ## Test Case 

  - [x] Go SDK: 8 new unit tests (httptest-based), all passing
  - [x] Python SDK: 7 new unit tests (httpx mock transport), all passing