### PR TITLE
Add Gin API sandbox example

### DIFF
--- a/examples/gin-api-sandbox/.dockerignore
+++ b/examples/gin-api-sandbox/.dockerignore
@@ -1,0 +1,6 @@
+.env
+__pycache__/
+*.pyc
+*.pyo
+*.log
+*.bak.*

--- a/examples/gin-api-sandbox/.env.example
+++ b/examples/gin-api-sandbox/.env.example
@@ -1,0 +1,11 @@
+# CubeSandbox / E2B SDK endpoint.
+# For local CubeSandbox deployment, this is usually the local API gateway.
+E2B_API_URL=http://127.0.0.1:3000
+
+# API key used by the local E2B-compatible API service.
+# Replace it if your deployment uses a custom key.
+E2B_API_KEY=e2b_000000
+
+# Replace this with the template ID created by:
+# cubemastercli tpl create-from-image ...
+CUBE_TEMPLATE_ID=tpl-xxxxxxxxxxxxxxxxxxxxxxxx

--- a/examples/gin-api-sandbox/Dockerfile
+++ b/examples/gin-api-sandbox/Dockerfile
@@ -1,0 +1,86 @@
+# syntax=docker/dockerfile:1.7
+#
+# Gin API sandbox image for CubeSandbox.
+#
+# Purpose:
+#   Provide a clean Go runtime environment for Agent-generated Gin APIs.
+#   This image does NOT contain business code or preinstalled Gin dependencies.
+#
+# Runtime flow:
+#   1. cubesandbox-base entrypoint starts envd on :49983.
+#   2. SDK writes Agent-generated Go project files into /workspace/app.
+#   3. SDK runs go mod tidy / go build.
+#   4. SDK starts the generated Gin service on :8080.
+#   5. SDK verifies the API endpoints with HTTP requests and reads /tmp/gin.log.
+#
+# Build:
+#   docker build -t gin-api-sandbox:latest .
+
+ARG CUBE_BASE_IMAGE=cube-sandbox-cn.tencentcloudcr.com/cube-sandbox/sandbox-code:latest
+FROM ${CUBE_BASE_IMAGE}
+
+ARG GO_VERSION=1.22.11
+ARG GO_SHA256=0fc88d966d33896384fbde56e9a8d80a305dc17a9f48f1832e061724b1719991
+ARG DEBIAN_FRONTEND=noninteractive
+
+ENV GOPATH=/workspace/go
+ENV GOCACHE=/workspace/.cache/go-build
+ENV GOMODCACHE=/workspace/go/pkg/mod
+ENV PATH=/usr/local/go/bin:${GOPATH}/bin:${PATH}
+ENV GOPROXY=https://goproxy.cn,direct
+
+# Minimal tools:
+#   curl            -> download Go toolchain and run HTTP checks
+#   ca-certificates -> HTTPS downloads
+#   git          -> fallback for Go modules when GOPROXY falls back to direct
+#   tar             -> extract Go toolchain archive
+#   procps       -> pkill / ps for managing generated Gin process
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        ca-certificates=20230311+deb12u1 \
+        curl=7.88.1-10+deb12u14 \
+        git=1:2.39.5-0+deb12u3 \
+        tar=1.34+dfsg-1.2+deb12u1 \
+        procps=2:4.0.2-3 \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Go, configure shell environment, and prepare SDK workspace.
+# This does not install project dependencies; it only configures the Go runtime.
+RUN curl -fsSL --retry 3 --connect-timeout 20 --max-time 180 \
+        -o /tmp/go.tgz \
+        https://dl.google.com/go/go${GO_VERSION}.linux-amd64.tar.gz \
+    && echo "${GO_SHA256}  /tmp/go.tgz" | sha256sum -c - \
+    && rm -rf /usr/local/go \
+    && tar -C /usr/local -xzf /tmp/go.tgz \
+    && rm -f /tmp/go.tgz \
+    && ln -sf /usr/local/go/bin/go /usr/local/bin/go \
+    && ln -sf /usr/local/go/bin/gofmt /usr/local/bin/gofmt \
+    && printf '%s\n' \
+        'export GOROOT=/usr/local/go' \
+        'export GOPATH=/workspace/go' \
+        'export GOCACHE=/workspace/.cache/go-build' \
+        'export GOMODCACHE=/workspace/go/pkg/mod' \
+        'export PATH=/usr/local/go/bin:/workspace/go/bin:$PATH' \
+        > /etc/profile.d/go.sh \
+    && mkdir -p /workspace/app /workspace/go /workspace/.cache/go-build \
+    && chown -R user:user /workspace \
+    && touch /var/log/envd.log /var/log/jupyter.log \
+    && chown user:user /var/log/envd.log /var/log/jupyter.log \
+    && chmod 644 /var/log/envd.log /var/log/jupyter.log \
+    && chmod 755 /workspace \
+    && chmod -R 755 /workspace/app /workspace/go /workspace/.cache/go-build \
+    && go env -w GOPROXY=https://goproxy.cn,direct GOSUMDB=sum.golang.google.cn
+
+ENV HOME=/home/user
+USER user
+WORKDIR /workspace/app
+
+# envd uses 49983.
+# Port 49999 is reserved for the CubeSandbox template health probe.
+# Agent-generated Gin services will usually listen on 8080.
+EXPOSE 49983 49999 8080
+
+# Do NOT override the cubesandbox-base entrypoint.
+# The inherited cube-entrypoint.sh starts envd on ${ENVD_PORT:-49983},
+# then execs this CMD as the foreground process.
+

--- a/examples/gin-api-sandbox/README.md
+++ b/examples/gin-api-sandbox/README.md
@@ -1,0 +1,177 @@
+# Gin API Sandbox Example
+
+This example provides a CubeSandbox template for running Go Gin API projects. It shows how to build a Go/Gin runtime image, create a CubeSandbox template from it, and use the E2B-compatible SDK to create a sandbox, write a multi-file Gin project, build it, start the API service, and test HTTP endpoints.
+
+This example focuses on a common Go web development scenario and can be used as a starting point for API development, API testing, and generated Gin project validation.
+
+## Files
+
+```text
+.
+├── Dockerfile
+├── .dockerignore
+├── .env.example
+├── requirements.txt
+├── official_sdk_gin_run.py
+└── README.md
+```
+
+## Use Cases
+
+This template is suitable for:
+
+- running Go Gin API projects inside CubeSandbox
+- testing generated or temporary Web API code
+- validating multi-file Go projects in an isolated sandbox
+- using CubeSandbox as a lightweight runtime for Go-based API examples
+
+## Prerequisites
+
+- CubeSandbox is deployed and CubeAPI is reachable.
+
+- Docker is available on the machine used to build the image.
+
+- `cubemastercli` is available.
+
+- Python dependencies are installed:
+
+  ```bash
+  pip install -r requirements.txt
+  ```
+
+- The local environment can access Go module mirrors.
+
+## Quick Start
+
+### 1. Build the image
+
+```bash
+docker build -t gin-api-sandbox:latest .
+```
+
+### 2. Create the template
+
+```bash
+cubemastercli tpl create-from-image \
+  --image gin-api-sandbox:latest \
+  --writable-layer-size 5Gi \
+  --expose-port 49983 \
+  --expose-port 49999 \
+  --expose-port 8080 \
+  --probe 49999 \
+  --probe-path /health \
+  --allow-internet-access
+```
+
+Check the template status:
+
+```bash
+cubemastercli tpl list
+```
+
+Wait until the template becomes `READY`.
+
+### 3. Configure environment variables
+
+```bash
+cp .env.example .env
+```
+
+Edit `.env`:
+
+```env
+E2B_API_URL=http://127.0.0.1:3000
+E2B_API_KEY=e2b_000000
+CUBE_TEMPLATE_ID=tpl-xxxxxxxxxxxxxxxxxxxxxxxx
+```
+
+Replace `CUBE_TEMPLATE_ID` with the template ID created in the previous step.
+
+### 4. Run the SDK example
+
+```bash
+python3 official_sdk_gin_run.py
+```
+
+## What the Example Does
+
+`official_sdk_gin_run.py` creates a sandbox from the template and writes a multi-file Gin project into `/workspace/app`:
+
+```text
+/workspace/app
+├── go.mod
+├── main.go
+├── routes
+│   ├── health.go
+│   └── user.go
+├── handlers
+│   └── user_handler.go
+└── models
+    └── user.go
+```
+
+Then it runs the build and start commands inside the sandbox:
+
+```bash
+cd /workspace/app && go mod tidy
+cd /workspace/app && go build -o /tmp/gin-app .
+nohup /tmp/gin-app > /tmp/gin.log 2>&1 &
+```
+
+The command above is a simplified view of how the Gin service is started. In `official_sdk_gin_run.py`, the script also stops any previous `/tmp/gin-app` process, removes the old `/tmp/gin.log`, starts the new binary, and polls `GET /health` with `curl -fsS` for up to 10 seconds before running endpoint checks.
+
+Finally, it tests the Gin API:
+
+```bash
+curl -fsS http://127.0.0.1:8080/health
+curl -fsS http://127.0.0.1:8080/users/1001
+curl -fsS -X POST http://127.0.0.1:8080/users \
+  -H 'Content-Type: application/json' \
+  -d '{"name":"demo-user","age":20}'
+```
+
+The Go files in `official_sdk_gin_run.py` are hard-coded for demonstration. In other use cases, they can be replaced with dynamically generated project files before being written into the sandbox.
+
+## Expected Output
+
+The example should show:
+
+- The sandbox is created successfully.
+- Go is available in the sandbox.
+- Project files are written to `/workspace/app`.
+- `go mod tidy` succeeds.
+- `go build` succeeds.
+- Gin starts on port `8080`.
+- `/health`, `/users/:id`, and `POST /users` return JSON responses.
+- `/tmp/gin.log` can be read.
+
+## Resource Recommendations
+
+The example is designed to run with the default `cubebox` instance type.
+
+Recommended starting configuration:
+
+- CPU: `2 vCPU`
+- Memory: `2 GB`
+- Writable layer size: `5Gi`
+- Service port: `8080`
+
+For larger Gin projects with more dependencies, increase the writable layer size or memory as needed.
+
+## Known Limitations
+
+- This example runs a single Gin service on port `8080`.
+- Database, Redis, message queue, and multi-container scenarios are not included.
+- Go module download requires outbound network access from the sandbox.
+- The sample project is intended for template validation and API runtime testing, not for production deployment.
+- Long-running tasks, checkpoint/resume workflows, and stateful workspace examples are not covered in this template.
+
+## Deployment Notes
+
+- This example assumes that CubeSandbox and CubeAPI have already been deployed.
+- The template must expose port `8080`, which is used by the Gin API service.
+- Port `49999` is reserved for the CubeSandbox template health probe. It is handled automatically by the CubeSandbox infrastructure; the generated Gin application does not need to bind to this port.
+- The generated Gin project is written to `/workspace/app` inside the sandbox.
+- The compiled binary is written to `/tmp/gin-app`.
+- Runtime logs are written to `/tmp/gin.log`.
+- If `go mod tidy` times out, check whether the sandbox has outbound network access and whether the Go module mirror is reachable.

--- a/examples/gin-api-sandbox/official_sdk_gin_run.py
+++ b/examples/gin-api-sandbox/official_sdk_gin_run.py
@@ -1,0 +1,337 @@
+import os
+import time
+import json
+import shlex
+from dotenv import load_dotenv
+from e2b_code_interpreter import Sandbox
+
+script_dir = os.path.dirname(os.path.abspath(__file__))
+load_dotenv(os.path.join(script_dir, ".env"), override=False)
+
+def require_env(name: str) -> str:
+    value = os.getenv(name)
+    if not value:
+        raise RuntimeError(
+            f"Missing required environment variable: {name}. "
+            "Copy examples/gin-api-sandbox/.env.example to examples/gin-api-sandbox/.env and fill in the values, "
+            "or export it in your shell environment."
+        )
+    return value
+
+
+def write_file_checked(sandbox: Sandbox, path: str, content: str) -> None:
+    try:
+        result = sandbox.files.write(path, content)
+    except Exception as exc:
+        raise RuntimeError(f"Failed to write file {path}: {exc}") from exc
+
+    if result is not None:
+        print(f"write result for {path}: {result}")
+
+    if os.getenv("VERIFY_FILE_WRITES") != "1":
+        return
+
+    verify = sandbox.commands.run(
+        f"test -f {shlex.quote(path)}",
+        timeout=30,
+    )
+    if verify.exit_code != 0:
+        raise RuntimeError(
+            f"File write verification failed for {path}\n"
+            f"stdout: {verify.stdout}\n"
+            f"stderr: {verify.stderr}"
+        )
+
+def run_http_check(
+    sandbox: Sandbox,
+    name: str,
+    command: str,
+    expected_fields: dict[str, object],
+) -> None:
+    result = sandbox.commands.run(command, timeout=30)
+    print(f"\n== test {name} ==")
+    print("exit_code:", result.exit_code)
+    print(result.stdout)
+    print(result.stderr)
+
+    if result.exit_code != 0:
+        raise RuntimeError(
+            f"HTTP check failed for {name}\n"
+            f"stdout: {result.stdout}\n"
+            f"stderr: {result.stderr}"
+        )
+
+    try:
+        response = json.loads(result.stdout.strip())
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(
+            f"Invalid JSON response for {name}: {exc}\n"
+            f"stdout: {result.stdout}"
+        ) from exc
+
+    if not isinstance(response, dict):
+        raise RuntimeError(
+            f"Unexpected JSON response type for {name}. Expected object.\n"
+            f"stdout: {result.stdout}"
+        )
+
+    for field, expected_value in expected_fields.items():
+        actual_value = response.get(field)
+        if actual_value != expected_value:
+            raise RuntimeError(
+                f"Unexpected JSON field for {name}. "
+                f"Expected {field}={expected_value!r}, got {actual_value!r}\n"
+                f"response: {response}"
+            )
+
+
+def read_gin_log(sandbox: Sandbox) -> str:
+    try:
+        return sandbox.files.read("/tmp/gin.log")
+    except Exception as exc:
+        return f"Failed to read /tmp/gin.log: {exc}"
+
+
+def start_gin_server(sandbox: Sandbox) -> None:
+    print("\n== start gin server ==")
+
+    result = sandbox.commands.run(
+        "pkill -f '^/tmp/gin-app$' >/dev/null 2>&1 || true; "
+        "rm -f /tmp/gin.log; "
+        "nohup /tmp/gin-app > /tmp/gin.log 2>&1 & echo $!",
+        timeout=30,
+    )
+    print("exit_code:", result.exit_code)
+    print(result.stdout)
+    print(result.stderr)
+
+    if result.exit_code != 0:
+        raise RuntimeError(
+            "Failed to start Gin server\n"
+            f"stdout: {result.stdout}\n"
+            f"stderr: {result.stderr}"
+        )
+
+    app_pid = result.stdout.strip().splitlines()[-1] if result.stdout.strip() else ""
+    if not app_pid:
+        raise RuntimeError("Failed to capture Gin server process id")
+
+    for _ in range(20):
+        health = sandbox.commands.run(
+            "curl -fsS --max-time 2 http://127.0.0.1:8080/health",
+            timeout=5,
+        )
+        if health.exit_code == 0:
+            print(f"server ready, pid={app_pid}")
+            return
+
+        proc = sandbox.commands.run(
+            f"kill -0 {shlex.quote(app_pid)} >/dev/null 2>&1",
+            timeout=5,
+        )
+        if proc.exit_code != 0:
+            raise RuntimeError(
+                "server process exited before becoming ready\n"
+                f"{read_gin_log(sandbox)}"
+            )
+
+        time.sleep(0.5)
+
+    raise RuntimeError(
+        "server failed to become ready within 10 seconds\n"
+        f"{read_gin_log(sandbox)}"
+    )
+
+# Agent generated file: go.mod
+go_mod = """module gin-multi-file-demo
+
+go 1.22
+
+require github.com/gin-gonic/gin v1.10.0
+"""
+
+# Agent generated file: main.go
+main_go = r'''package main
+
+import (
+    "gin-multi-file-demo/routes"
+
+    "github.com/gin-gonic/gin"
+)
+
+func main() {
+    r := gin.Default()
+
+    routes.RegisterHealthRoutes(r)
+    routes.RegisterUserRoutes(r)
+
+    r.Run(":8080")
+}
+'''
+
+# Agent generated file: routes/health.go
+routes_health_go = r'''package routes
+
+import "github.com/gin-gonic/gin"
+
+func RegisterHealthRoutes(r *gin.Engine) {
+    r.GET("/health", func(c *gin.Context) {
+        c.JSON(200, gin.H{
+            "status": "ok",
+            "from": "official-sdk-multi-file",
+        })
+    })
+}
+'''
+
+# Agent generated file: routes/user.go
+routes_user_go = r'''package routes
+
+import (
+    "gin-multi-file-demo/handlers"
+
+    "github.com/gin-gonic/gin"
+)
+
+func RegisterUserRoutes(r *gin.Engine) {
+    r.GET("/users/:id", handlers.GetUser)
+    r.POST("/users", handlers.CreateUser)
+}
+'''
+
+# Agent generated file: handlers/user_handler.go
+handlers_user_handler_go = r'''package handlers
+
+import (
+    "gin-multi-file-demo/models"
+
+    "github.com/gin-gonic/gin"
+)
+
+func GetUser(c *gin.Context) {
+    id := c.Param("id")
+
+    c.JSON(200, gin.H{
+        "id": id,
+        "name": "demo-user",
+    })
+}
+
+func CreateUser(c *gin.Context) {
+    var req models.CreateUserRequest
+
+    if err := c.ShouldBindJSON(&req); err != nil {
+        c.JSON(400, gin.H{
+            "error": err.Error(),
+        })
+        return
+    }
+
+    c.JSON(200, gin.H{
+        "message": "user created",
+        "name": req.Name,
+        "age": req.Age,
+    })
+}
+'''
+
+# Agent generated file: models/user.go
+models_user_go = r'''package models
+
+type CreateUserRequest struct {
+    Name string `json:"name"`
+    Age  int    `json:"age"`
+}
+'''
+
+def main() -> None:
+    template_id = require_env("CUBE_TEMPLATE_ID")
+
+    with Sandbox.create(template=template_id) as sandbox:
+        print("== sandbox info ==")
+        print(sandbox.get_info())
+
+        print("\n== go version ==")
+        result = sandbox.commands.run("go version", timeout=30)
+        print("exit_code:", result.exit_code)
+        print(result.stdout)
+        print(result.stderr)
+
+        print("\n== clean workspace ==")
+        result = sandbox.commands.run("rm -rf /workspace/app/*", timeout=30)
+        print("exit_code:", result.exit_code)
+        print(result.stdout)
+        print(result.stderr)
+
+        print("\n== create project directories ==")
+        result = sandbox.commands.run(
+            "mkdir -p /workspace/app/routes /workspace/app/handlers /workspace/app/models",
+            timeout=30,
+        )
+        print("exit_code:", result.exit_code)
+        print(result.stdout)
+        print(result.stderr)
+
+        print("\n== write agent generated files ==")
+        write_file_checked(sandbox, "/workspace/app/go.mod", go_mod)
+        write_file_checked(sandbox, "/workspace/app/main.go", main_go)
+        write_file_checked(sandbox, "/workspace/app/routes/health.go", routes_health_go)
+        write_file_checked(sandbox, "/workspace/app/routes/user.go", routes_user_go)
+        write_file_checked(sandbox, "/workspace/app/handlers/user_handler.go", handlers_user_handler_go)
+        write_file_checked(sandbox, "/workspace/app/models/user.go", models_user_go)
+
+        result = sandbox.commands.run(
+            "find /workspace/app -type f | sort",
+            timeout=30,
+        )
+        print(result.stdout)
+
+        print("\n== go mod tidy ==")
+        result = sandbox.commands.run(
+            "cd /workspace/app && GOPROXY=https://goproxy.cn,direct GOSUMDB=sum.golang.google.cn go mod tidy",
+            timeout=180,
+        )
+        print("exit_code:", result.exit_code)
+        print(result.stdout)
+        print(result.stderr)
+
+        print("\n== go build ==")
+        result = sandbox.commands.run(
+            "cd /workspace/app && GOPROXY=https://goproxy.cn,direct GOSUMDB=sum.golang.google.cn go build -o /tmp/gin-app .",
+            timeout=180,
+        )
+        print("exit_code:", result.exit_code)
+        print(result.stdout)
+        print(result.stderr)
+
+        start_gin_server(sandbox)
+
+        run_http_check(
+            sandbox,
+            "GET /health",
+            "curl -fsS http://127.0.0.1:8080/health",
+            {"status": "ok"},
+        )
+
+        run_http_check(
+            sandbox,
+            "GET /users/1001",
+            "curl -fsS http://127.0.0.1:8080/users/1001",
+            {"id": "1001", "name": "demo-user"},
+        )
+
+        run_http_check(
+            sandbox,
+            "POST /users",
+            "curl -fsS -X POST http://127.0.0.1:8080/users "
+            "-H 'Content-Type: application/json' "
+            "-d '{\"name\":\"demo-user\",\"age\":20}'",
+            {"message": "user created", "name": "demo-user", "age": 20},
+        )
+
+        print("\n== gin log ==")
+        print(sandbox.files.read("/tmp/gin.log"))
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/gin-api-sandbox/requirements.txt
+++ b/examples/gin-api-sandbox/requirements.txt
@@ -1,0 +1,2 @@
+e2b-code-interpreter==2.8.1
+python-dotenv==1.1.0


### PR DESCRIPTION
This PR adds a Gin API sandbox example.

It includes:
- Dockerfile for building a Go/Gin runtime template
- E2B-compatible SDK example for creating a sandbox from the template
- Multi-file Gin project written into /workspace/app
- Build and start flow with go mod tidy and go build
- HTTP endpoint tests for /health, /users/:id, and POST /users
- README with use cases, resource recommendations, known limitations, and deployment notes

Verified locally with CubeSandbox deployment.

Related to #682