### PR TITLE
fix(cubelet): fail fast on hung hostdir mounts

### DIFF
--- a/Cubelet/storage/hostdir.go
+++ b/Cubelet/storage/hostdir.go
@@ -5,11 +5,15 @@
 package storage
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"syscall"
+	"time"
 
 	cubebox "github.com/tencentcloud/CubeSandbox/Cubelet/api/services/cubebox/v1"
 	"github.com/tencentcloud/CubeSandbox/Cubelet/pkg/log"
@@ -20,6 +24,12 @@ import (
 
 var hostDirBasePath = "/data/cubelet/hostdir"
 
+const hostDirMountTimeout = 3 * time.Second
+
+const hostDirMountBinary = "/usr/bin/mount"
+
+var runHostDirCommand = defaultRunHostDirCommand
+
 type HostDirBackendInfo struct {
 	VolumeName string `json:"volume_name"`
 
@@ -28,6 +38,72 @@ type HostDirBackendInfo struct {
 	BindPath string `json:"bind_path"`
 
 	ReadOnly bool `json:"read_only"`
+}
+
+func defaultRunHostDirCommand(ctx context.Context, name string, args ...string) error {
+	cmd := exec.Command(name, args...)
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("start %s %v: %w", name, args, err)
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		done <- cmd.Wait()
+	}()
+
+	select {
+	case err := <-done:
+		if err == nil {
+			return nil
+		}
+		if stderr.Len() > 0 {
+			return fmt.Errorf("%w: %s", err, stderr.String())
+		}
+		return err
+	case <-ctx.Done():
+		if cmd.Process != nil {
+			_ = syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+		}
+		return ctx.Err()
+	}
+}
+
+func bindHostDir(ctx context.Context, srcPath, bindDest string, readOnly bool) error {
+	mountCtx, cancel := context.WithTimeout(ctx, hostDirMountTimeout)
+	defer cancel()
+
+	if err := runHostDirCommand(mountCtx, hostDirMountBinary, "--rbind", srcPath, bindDest); err != nil {
+		if errors.Is(err, context.DeadlineExceeded) {
+			return fmt.Errorf("bind mount %s -> %s timed out after %s: %w", srcPath, bindDest, hostDirMountTimeout, err)
+		}
+		if errors.Is(err, context.Canceled) {
+			return fmt.Errorf("bind mount %s -> %s canceled: %w", srcPath, bindDest, err)
+		}
+		return fmt.Errorf("bind mount %s -> %s: %w", srcPath, bindDest, err)
+	}
+
+	if !readOnly {
+		return nil
+	}
+
+	remountCtx, remountCancel := context.WithTimeout(ctx, hostDirMountTimeout)
+	defer remountCancel()
+
+	if err := runHostDirCommand(remountCtx, hostDirMountBinary, "-o", "remount,bind,ro", bindDest); err != nil {
+		if errors.Is(err, context.DeadlineExceeded) {
+			return fmt.Errorf("remount ro %s timed out after %s: %w", bindDest, hostDirMountTimeout, err)
+		}
+		if errors.Is(err, context.Canceled) {
+			return fmt.Errorf("remount ro %s canceled: %w", bindDest, err)
+		}
+		return fmt.Errorf("remount ro %s: %w", bindDest, err)
+	}
+	return nil
 }
 
 func (l *local) prepareHostDirVolume(ctx context.Context, opts *workflow.CreateContext,
@@ -71,18 +147,6 @@ func (l *local) prepareHostDirVolume(ctx context.Context, opts *workflow.CreateC
 			return fmt.Errorf("prepareHostDirVolume: mkdir %s: %w", bindDest, err)
 		}
 
-		flags := uintptr(unix.MS_BIND | unix.MS_REC)
-		if err := unix.Mount(src.GetHostPath(), bindDest, "", flags, ""); err != nil {
-			return fmt.Errorf("prepareHostDirVolume: bind mount %s -> %s: %w",
-				src.GetHostPath(), bindDest, err)
-		}
-		if readOnly {
-			roFlags := uintptr(unix.MS_BIND | unix.MS_REMOUNT | unix.MS_RDONLY)
-			if err := unix.Mount("", bindDest, "", roFlags, ""); err != nil {
-				return fmt.Errorf("prepareHostDirVolume: remount ro %s: %w", bindDest, err)
-			}
-		}
-
 		key := v.GetName() + "/" + src.GetName()
 		result.HostDirBackendInfos[key] = &HostDirBackendInfo{
 			VolumeName: v.GetName(),
@@ -90,6 +154,12 @@ func (l *local) prepareHostDirVolume(ctx context.Context, opts *workflow.CreateC
 			BindPath:   bindDest,
 			ReadOnly:   readOnly,
 		}
+
+		log.G(ctx).Infof("[hostdir] binding %s -> %s (ro=%v)", src.GetHostPath(), bindDest, readOnly)
+		if err := bindHostDir(ctx, src.GetHostPath(), bindDest, readOnly); err != nil {
+			return fmt.Errorf("prepareHostDirVolume: %w", err)
+		}
+
 		log.G(ctx).Infof("[hostdir] bound %s -> %s (ro=%v, shareDir=%s)",
 			src.GetHostPath(), bindDest, readOnly, shareDir)
 	}

--- a/Cubelet/storage/hostdir_test.go
+++ b/Cubelet/storage/hostdir_test.go
@@ -1,0 +1,217 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package storage
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
+
+func TestBindHostDirRW(t *testing.T) {
+	orig := runHostDirCommand
+	t.Cleanup(func() {
+		runHostDirCommand = orig
+	})
+
+	var calls [][]string
+	runHostDirCommand = func(ctx context.Context, name string, args ...string) error {
+		row := append([]string{name}, args...)
+		calls = append(calls, row)
+		return nil
+	}
+
+	if err := bindHostDir(context.Background(), "/host/path", "/bind/dest", false); err != nil {
+		t.Fatalf("bindHostDir returned error: %v", err)
+	}
+
+	if len(calls) != 1 {
+		t.Fatalf("expected 1 command, got %d", len(calls))
+	}
+	got := strings.Join(calls[0], " ")
+	want := "/usr/bin/mount --rbind /host/path /bind/dest"
+	if got != want {
+		t.Fatalf("unexpected command: got %q want %q", got, want)
+	}
+}
+
+func TestBindHostDirReadOnlyAddsRemount(t *testing.T) {
+	orig := runHostDirCommand
+	t.Cleanup(func() {
+		runHostDirCommand = orig
+	})
+
+	var calls [][]string
+	runHostDirCommand = func(ctx context.Context, name string, args ...string) error {
+		row := append([]string{name}, args...)
+		calls = append(calls, row)
+		return nil
+	}
+
+	if err := bindHostDir(context.Background(), "/host/path", "/bind/dest", true); err != nil {
+		t.Fatalf("bindHostDir returned error: %v", err)
+	}
+
+	if len(calls) != 2 {
+		t.Fatalf("expected 2 commands, got %d", len(calls))
+	}
+
+	gotBind := strings.Join(calls[0], " ")
+	wantBind := "/usr/bin/mount --rbind /host/path /bind/dest"
+	if gotBind != wantBind {
+		t.Fatalf("unexpected bind command: got %q want %q", gotBind, wantBind)
+	}
+
+	gotRemount := strings.Join(calls[1], " ")
+	wantRemount := "/usr/bin/mount -o remount,bind,ro /bind/dest"
+	if gotRemount != wantRemount {
+		t.Fatalf("unexpected remount command: got %q want %q", gotRemount, wantRemount)
+	}
+}
+
+func TestBindHostDirTimeout(t *testing.T) {
+	orig := runHostDirCommand
+	t.Cleanup(func() {
+		runHostDirCommand = orig
+	})
+
+	runHostDirCommand = func(ctx context.Context, name string, args ...string) error {
+		return context.DeadlineExceeded
+	}
+
+	err := bindHostDir(context.Background(), "/host/path", "/bind/dest", false)
+	if err == nil {
+		t.Fatal("expected timeout error, got nil")
+	}
+	if !strings.Contains(err.Error(), "timed out") {
+		t.Fatalf("expected timeout message, got %v", err)
+	}
+}
+
+func TestBindHostDirCanceled(t *testing.T) {
+	orig := runHostDirCommand
+	t.Cleanup(func() {
+		runHostDirCommand = orig
+	})
+
+	runHostDirCommand = func(ctx context.Context, name string, args ...string) error {
+		return context.Canceled
+	}
+
+	err := bindHostDir(context.Background(), "/host/path", "/bind/dest", false)
+	if err == nil {
+		t.Fatal("expected canceled error, got nil")
+	}
+	if !strings.Contains(err.Error(), "canceled") {
+		t.Fatalf("expected canceled message, got %v", err)
+	}
+	if strings.Contains(err.Error(), "timed out") {
+		t.Fatalf("did not expect timeout message, got %v", err)
+	}
+}
+
+func TestBindHostDirMountError(t *testing.T) {
+	orig := runHostDirCommand
+	t.Cleanup(func() {
+		runHostDirCommand = orig
+	})
+
+	runHostDirCommand = func(ctx context.Context, name string, args ...string) error {
+		return errors.New("mount failed")
+	}
+
+	err := bindHostDir(context.Background(), "/host/path", "/bind/dest", false)
+	if err == nil {
+		t.Fatal("expected mount error, got nil")
+	}
+	if !strings.Contains(err.Error(), "mount failed") {
+		t.Fatalf("expected wrapped mount error, got %v", err)
+	}
+}
+
+func TestBindHostDirReadOnlyRemountCanceled(t *testing.T) {
+	orig := runHostDirCommand
+	t.Cleanup(func() {
+		runHostDirCommand = orig
+	})
+
+	callCount := 0
+	runHostDirCommand = func(ctx context.Context, name string, args ...string) error {
+		callCount++
+		if callCount == 1 {
+			return nil
+		}
+		return context.Canceled
+	}
+
+	err := bindHostDir(context.Background(), "/host/path", "/bind/dest", true)
+	if err == nil {
+		t.Fatal("expected canceled remount error, got nil")
+	}
+	if !strings.Contains(err.Error(), "remount ro /bind/dest canceled") {
+		t.Fatalf("expected remount canceled message, got %v", err)
+	}
+	if strings.Contains(err.Error(), "timed out") {
+		t.Fatalf("did not expect timeout message, got %v", err)
+	}
+}
+
+func TestDefaultRunHostDirCommandTimeoutKillsProcessGroup(t *testing.T) {
+	shell, err := exec.LookPath("sh")
+	if err != nil {
+		t.Skipf("sh not available: %v", err)
+	}
+
+	pidFile := filepath.Join(t.TempDir(), "sleep.pid")
+	script := fmt.Sprintf("sleep 10 & child=$!; printf '%%s' \"$child\" > %q; wait \"$child\"", pidFile)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	err = defaultRunHostDirCommand(ctx, shell, "-c", script)
+	elapsed := time.Since(start)
+
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("expected context deadline exceeded, got %v", err)
+	}
+	if elapsed > time.Second {
+		t.Fatalf("expected timeout to return promptly, took %s", elapsed)
+	}
+
+	rawPID, err := os.ReadFile(pidFile)
+	if err != nil {
+		t.Fatalf("read child pid file: %v", err)
+	}
+
+	pid, err := strconv.Atoi(strings.TrimSpace(string(rawPID)))
+	if err != nil {
+		t.Fatalf("parse child pid %q: %v", strings.TrimSpace(string(rawPID)), err)
+	}
+
+	deadline := time.Now().Add(500 * time.Millisecond)
+	for {
+		killErr := syscall.Kill(pid, 0)
+		if killErr != nil {
+			if errors.Is(killErr, syscall.ESRCH) {
+				return
+			}
+			t.Fatalf("probe child pid %d: %v", pid, killErr)
+		}
+
+		if time.Now().After(deadline) {
+			t.Fatalf("child process %d still alive after timeout", pid)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}


### PR DESCRIPTION
## Motivation

An unhealthy host mount, such as a geesefs path with revoked remote access, can block the Cubelet hostdir bind step indefinitely. When that happens, sandbox creation hangs until an upstream API timeout even though the real failure is already at the hostdir mount boundary.

Cubelet should fail fast when a hostdir bind cannot complete, instead of leaving the create path blocked by a hung mount operation.

## What Changed

This PR makes Cubelet hostdir mounts fail fast by moving the bind operation out of the create goroutine and into a bounded helper subprocess.

Implementation highlights:

* `Cubelet/storage/hostdir.go` replaces the in-process `unix.Mount(...)` hostdir bind with `mount --rbind` executed through a helper subprocess
* each hostdir mount step is bounded to 3s
* read-only hostdir mounts keep the follow-up `remount,bind,ro` step under the same bounded helper path
* hostdir backend metadata is recorded before the bind attempt so cleanup still knows the sandbox-scoped hostdir paths after a failed create
* the top-level error category stays `CreateStorageFailed`, while the returned message now makes the hostdir timeout explicit
* `Cubelet/storage/hostdir_test.go` adds focused coverage for command shape, timeout/error handling, and real subprocess timeout cleanup

The timeout is per mount step rather than a flat per-request cap:

* read-write hostdir: up to about 3s per volume
* read-only hostdir: up to about 6s per volume, because bind and remount are bounded separately

## Testing

Focused unit tests:

```bash
go test ./storage -run HostDir -count=1
```

Covered cases:

* read-write hostdir helper command shape
* read-only hostdir bind + remount helper command shape
* timeout handling
* generic mount-error handling
* real subprocess timeout behavior, including prompt return and child process-group cleanup

Real-cluster healthy-path validation:

* with a healthy host mount, sandbox creation still succeeded in about `0.108s`

Real-cluster failure-path validation:

* reproduced an unhealthy geesefs-backed host mount where `ls` on the host path blocked indefinitely
* before this fix, sandbox creation hung until the upstream API timeout
* after this fix, CubeAPI returned `500 Internal Server Error` in about `3010ms`
* Cubelet returned `CreateStorageFailed` with a hostdir-specific timeout message, for example:

```text
prepareHostDirVolume: bind mount /mnt/aime-oss/test -> /data/cubelet/hostdir/<sandbox-id>/rw/hostdir-0 timed out after 3s: context deadline exceeded
```

* CubeMaster propagated the same `CreateStorageFailed` message in `CreateSandbox_rsp fail`
* post-failure checks showed no surviving sandbox in `cubecli cubebox list`
* post-failure checks showed no leftover sandbox hostdir root under `/data/cubelet/hostdir/<sandbox-id>`

Behavioral clarification:

* failure logs may still show a `sandboxID`, `sandboxIP`, and `port_mappings`
* this is expected because `createid` runs before storage, and storage/network run before the final `cubebox` step
* in the reproduced failure, the actual cubebox VM was not created

## Scope

This PR only changes Cubelet hostdir mount failure handling.
