### PR TITLE
docs: add sandbox logs guide (cubecli cubebox logs)

### DIFF
--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -148,6 +148,7 @@ export default withMermaid(defineConfig({
               items: [
                 { text: 'WebUI Dashboard', link: '/guide/webui' },
                 { text: 'Service Management & Logs', link: '/guide/service-management' },
+                { text: 'Sandbox Logs', link: '/guide/sandbox-logs' },
                 { text: 'Template Inspection & Request Preview', link: '/guide/template-inspection-and-preview' },
                 { text: 'HTTPS & Domain Resolution', link: '/guide/https-and-domain' },
                 { text: 'Network Hardening', link: '/guide/network-hardening' },
@@ -273,6 +274,7 @@ export default withMermaid(defineConfig({
               items: [
                 { text: 'WebUI 控制台', link: '/zh/guide/webui' },
                 { text: '服务管理与日志', link: '/zh/guide/service-management' },
+                { text: '沙箱日志', link: '/zh/guide/sandbox-logs' },
                 { text: '模板检查与请求预览', link: '/zh/guide/template-inspection-and-preview' },
                 { text: 'HTTPS 证书与域名解析', link: '/zh/guide/https-and-domain' },
                 { text: '网络加固', link: '/zh/guide/network-hardening' },

--- a/docs/guide/sandbox-logs.md
+++ b/docs/guide/sandbox-logs.md
@@ -1,0 +1,92 @@
+---
+title: Sandbox Logs
+lang: en-US
+---
+
+# Sandbox Logs
+
+::: warning Work in progress
+Log retrieval is still being actively iterated. The `cubecli logs` command described here is a **temporary solution** — the interface and underlying storage layout may change in future releases.
+:::
+
+CubeSandbox exposes two complementary logging layers:
+
+| Layer | What it captures | How to access |
+|---|---|---|
+| **Sandbox log** | stdout/stderr of the container init process (the main entrypoint) | `cubecli logs` (this page) |
+| **`envd` task log** | stdout/stderr of individual `exec` sub-tasks spawned inside the sandbox | E2B SDK (`on_stdout` / `on_stderr` callbacks) |
+
+This page covers the **sandbox-level log** only. For `envd` sub-task logs, refer to the [E2B SDK documentation](https://e2b.dev/docs).
+
+## Prerequisites
+
+`cubecli` is built alongside Cubelet and installed as part of the standard one-click deployment. The `logs` sub-command accesses log files that live inside the **Cubelet mount namespace**, so it must be run **directly on the compute node** — it cannot be executed remotely via the API or from a non-node host.
+
+## Reading sandbox logs
+
+```bash
+# Last 100 lines of stdout (default)
+cubecli logs <sandbox-id>
+
+# Last 100 lines of stderr
+cubecli logs --stderr <sandbox-id>
+
+# Full log (all lines)
+cubecli logs --all <sandbox-id>
+
+# Last N lines
+cubecli logs --tail 50 <sandbox-id>
+# Short form
+cubecli logs -t 50 <sandbox-id>
+
+# First N lines
+cubecli logs --head 20 <sandbox-id>
+# Short form
+cubecli logs -H 20 <sandbox-id>
+```
+
+### Flag reference
+
+| Flag | Short | Description |
+|---|---|---|
+| `--stderr` | `-e` | Read stderr instead of stdout |
+| `--all` | `-a` | Print all lines; cannot be combined with `--tail` or `--head` |
+| `--tail N` | `-t N` | Print the last N lines (default: 100 when no other flag is set) |
+| `--head N` | `-H N` | Print the first N lines |
+
+## Reading template build logs
+
+During template construction the container's stdout/stderr are saved to the host filesystem under `/data/log/template/<templateID>_0/`. These files do **not** require entering the Cubelet mount namespace, so `--tpl` skips the namespace re-exec:
+
+```bash
+# Last 100 lines of template build stdout
+cubecli logs --tpl <template-id>
+
+# Full build stderr
+cubecli logs --tpl --all --stderr <template-id>
+```
+
+## Where the log files live
+
+| Context | Path |
+|---|---|
+| Sandbox stdout | `/data/cubelet/state/io.containerd.runtime.v2.task/default/<sandbox-id>/stdout` (inside Cubelet mount namespace) |
+| Sandbox stderr | `/data/cubelet/state/io.containerd.runtime.v2.task/default/<sandbox-id>/stderr` (inside Cubelet mount namespace) |
+| Template stdout | `/data/log/template/<template-id>_0/stdout` (host filesystem) |
+| Template stderr | `/data/log/template/<template-id>_0/stderr` (host filesystem) |
+
+::: tip Why the mount namespace?
+Sandbox log files are written by CubeShim into the bundle directory which is only visible inside Cubelet's private mount namespace. `cubecli logs` automatically re-execs itself into that namespace before reading — you do not need to do anything special beyond running the command on the node.
+:::
+
+## Scope and limitations
+
+- These logs capture only the **init process** (PID 1 inside the container). Output from processes spawned via `exec` calls is captured through the E2B SDK's `on_stdout` / `on_stderr` callbacks — refer to the [E2B SDK documentation](https://e2b.dev/docs) for details.
+- Log forwarding must be enabled on the running CubeShim version (available since v0.4.0). On older deployments the log file will be missing.
+- Logs are not streamed in real time — there is no `--follow` flag yet. Re-run the command to see new output.
+- Log files are removed when the sandbox is deleted.
+
+## Related
+
+- [Service Management & Logs](./service-management.md) — host-side service logs, journalctl, and the diagnostic bundle
+- [Template Inspection & Request Preview](./template-inspection-and-preview.md)

--- a/docs/zh/guide/sandbox-logs.md
+++ b/docs/zh/guide/sandbox-logs.md
@@ -1,0 +1,92 @@
+---
+title: 沙箱日志
+lang: zh-CN
+---
+
+# 沙箱日志
+
+::: warning 功能迭代中
+日志能力目前仍在持续迭代，本文介绍的 `cubecli logs` 命令是**临时使用版本**——后续版本可能对接口及底层存储结构进行调整。
+:::
+
+CubeSandbox 提供两个互补的日志层：
+
+| 层级 | 记录内容 | 获取方式 |
+|---|---|---|
+| **沙箱日志** | 容器 init 进程（主入口）的 stdout/stderr | `cubecli logs`（本文） |
+| **`envd` 任务日志** | 在沙箱内通过 `exec` 接口启动的子任务的 stdout/stderr | E2B SDK（`on_stdout` / `on_stderr` 回调） |
+
+本文仅介绍**沙箱级别的日志**。`envd` 子任务的日志获取方式请参阅 [E2B SDK 文档](https://e2b.dev/docs)。
+
+## 前置条件
+
+`cubecli` 随 Cubelet 一同构建，并在一键部署时自动安装。`logs` 子命令访问的日志文件位于 **Cubelet 挂载命名空间**内，因此必须**直接在计算节点上执行**，无法通过 API 或非节点主机远程调用。
+
+## 读取沙箱日志
+
+```bash
+# 最后 100 行 stdout（默认）
+cubecli logs <sandbox-id>
+
+# 最后 100 行 stderr
+cubecli logs --stderr <sandbox-id>
+
+# 完整日志（全部行）
+cubecli logs --all <sandbox-id>
+
+# 最后 N 行
+cubecli logs --tail 50 <sandbox-id>
+# 简写
+cubecli logs -t 50 <sandbox-id>
+
+# 前 N 行
+cubecli logs --head 20 <sandbox-id>
+# 简写
+cubecli logs -H 20 <sandbox-id>
+```
+
+### 参数说明
+
+| 参数 | 简写 | 说明 |
+|---|---|---|
+| `--stderr` | `-e` | 读取 stderr，默认读取 stdout |
+| `--all` | `-a` | 输出全部行；不可与 `--tail` 或 `--head` 同时使用 |
+| `--tail N` | `-t N` | 输出最后 N 行（未指定其他标志时默认为 100） |
+| `--head N` | `-H N` | 输出前 N 行 |
+
+## 读取模板构建日志
+
+模板构建过程中，容器的 stdout/stderr 会写入宿主机文件系统 `/data/log/template/<templateID>_0/`。这些文件无需进入 Cubelet 挂载命名空间，使用 `--tpl` 标志可跳过命名空间切换：
+
+```bash
+# 最后 100 行模板构建 stdout
+cubecli logs --tpl <template-id>
+
+# 完整模板构建 stderr
+cubecli logs --tpl --all --stderr <template-id>
+```
+
+## 日志文件路径
+
+| 场景 | 路径 |
+|---|---|
+| 沙箱 stdout | `/data/cubelet/state/io.containerd.runtime.v2.task/default/<sandbox-id>/stdout`（Cubelet 挂载命名空间内） |
+| 沙箱 stderr | `/data/cubelet/state/io.containerd.runtime.v2.task/default/<sandbox-id>/stderr`（Cubelet 挂载命名空间内） |
+| 模板 stdout | `/data/log/template/<template-id>_0/stdout`（宿主机文件系统） |
+| 模板 stderr | `/data/log/template/<template-id>_0/stderr`（宿主机文件系统） |
+
+::: tip 为什么需要挂载命名空间？
+沙箱日志文件由 CubeShim 写入 bundle 目录，该目录仅在 Cubelet 的私有挂载命名空间内可见。`cubecli logs` 会在读取前自动重新进入该命名空间——你无需任何额外操作，只需在节点上直接运行该命令即可。
+:::
+
+## 范围与限制
+
+- 这些日志仅记录 **init 进程**（容器内 PID 1）的输出。通过 `exec` 接口启动的进程输出需通过 E2B SDK 的 `on_stdout` / `on_stderr` 回调获取，详见 [E2B SDK 文档](https://e2b.dev/docs)。
+- 日志转发需要 v0.4.0 及以上版本的 CubeShim。在更旧的部署上，日志文件将不存在。
+- 日志目前不支持实时流式读取，暂无 `--follow` 标志。如需查看最新输出，请重新执行命令。
+- 沙箱删除后，对应的日志文件会一并清除。
+
+## 相关文档
+
+- [服务管理与日志](./service-management.md) — 宿主机服务日志、journalctl 及诊断包
+- [模板检查与请求预览](./template-inspection-and-preview.md)


### PR DESCRIPTION
Introduce a new guide page in both English and Chinese explaining how to retrieve sandbox and template build logs via cubecli cubebox logs.

Key points covered:
- WIP notice: log retrieval is actively iterated; current interface is temporary
- cubecli cubebox logs reads the container init-process stdout/stderr; must be run on the node (accesses Cubelet mount namespace)
- --tpl flag for template build logs (host filesystem, no ns entry)
- Flag reference: --stderr, --all, --tail N, --head N
- Log file paths for sandbox vs template
- Scope: init-process only; envd sub-task logs retrieved via E2B SDK (on_stdout / on_stderr callbacks), refer to E2B SDK docs
- Limitations: no --follow, logs deleted with sandbox

Add nav entries in config.mjs under the Operations section (en & zh).