### PR TITLE
docs: add Claude Code + CubeSandbox integration guide and example

### DIFF
--- a/docs/guide/integrations/claude-code.md
+++ b/docs/guide/integrations/claude-code.md
@@ -1,0 +1,320 @@
+---
+title: Claude Code Integration Guide
+author: LangQi99
+date: 2026-07-01
+tags:
+  - integration
+  - claude-code
+  - anthropic
+  - agent
+lang: en-US
+---
+
+# Claude Code Integration Guide
+
+[中文文档](../../zh/guide/integrations/claude-code.md)
+
+Run [Anthropic Claude Code](https://docs.anthropic.com/en/docs/claude-code) —
+the terminal-native AI coding agent — inside CubeSandbox MicroVMs. This guide
+covers everything from image build to production egress control, and pairs
+with the runnable [`examples/claude-code-integration`](https://github.com/TencentCloud/CubeSandbox/tree/master/examples/claude-code-integration)
+project.
+
+## Integration Target and Version
+
+| Component | Version |
+|---|---|
+| Claude Code CLI | `@anthropic-ai/claude-code` (latest at build time; pinned via `--build-arg CLAUDE_CODE_VERSION=x.y.z`) |
+| Node.js | 20 LTS |
+| CubeSandbox base image | `ghcr.io/tencentcloud/cubesandbox-base:2026.16` |
+| E2B SDK (host driver) | `e2b >= 2.4.1` |
+| CubeSandbox platform | `>= 0.3.0` (pause/resume) / `>= 0.4.0` (credential vault via CubeEgress) |
+
+## Prerequisites
+
+- CubeSandbox deployment reachable at CubeAPI (`http://<node>:3000`)
+- `cubemastercli` on `$PATH` and connected to the cluster
+- Docker on the workstation used to build the template image, plus a registry
+  the Cube nodes can pull from
+- Anthropic API key (`sk-ant-...`) — or a compatible gateway (Bedrock, Vertex,
+  in-house Anthropic proxy)
+- Python 3.10+ for the host driver scripts
+
+## Why Run Claude Code Inside a Sandbox
+
+Claude Code is a terminal agent that edits files, runs commands, and installs
+packages. Running it directly on your workstation blends the agent's blast
+radius with your dev environment. Running it inside CubeSandbox gives you:
+
+| Concern | CubeSandbox provides |
+|---|---|
+| **Isolation** | KVM MicroVM per session, dedicated guest kernel |
+| **Reproducibility** | Every session boots from the same template snapshot |
+| **Fast spin-up** | Sub-60 ms cold start, so N-parallel agents are cheap |
+| **Long tasks** | `sandbox.pause()` snapshots VM + rootfs; resume later |
+| **Key hygiene** | CubeEgress injects `x-api-key` on the wire — the VM never sees it |
+| **Egress audit** | Every request to `api.anthropic.com` lands in a JSONL audit log |
+
+## Architecture
+
+```
+┌────────────────────────┐        ┌───────────────────────┐
+│  Host driver script     │  E2B  │  CubeSandbox MicroVM  │
+│  (run_claude.py)        │       │                       │
+│                         │──────►│  envd (:49983)        │
+│  ANTHROPIC_API_KEY      │       │  claude CLI (Node 20) │
+│  optional               │       │  git / python / rg    │
+│                         │       │  /workspace           │
+└──────────┬──────────────┘       └───────────┬───────────┘
+           │                                  │ HTTPS
+           │                                  ▼
+           │                           ┌───────────────┐
+           └── inject rule ──────────► │  CubeEgress   │───► api.anthropic.com
+                                       └───────────────┘
+                                              │
+                                              ▼
+                                  /data/log/cube-egress/access.jsonl
+```
+
+Two integration flavors are supported and interchangeable at the SDK level:
+
+| Flavor | Key flow | Best for |
+|---|---|---|
+| **Direct** | `envs={"ANTHROPIC_API_KEY": key}` per exec call | Single-tenant dev machines, quick trials |
+| **Vault** | `Sandbox.create(network={"rules": [inject rule]})` | Shared clusters, hosted services, audit-heavy environments |
+
+Both flavors share the same template — the only difference is whether the key
+is forwarded into the sandbox or attached in-flight by CubeEgress.
+
+## Integration Steps
+
+### 1. Build the template image
+
+The image stacks Node.js 20 and Anthropic's official CLI on top of
+`cubesandbox-base`, so envd is already listening on `:49983`.
+
+```dockerfile
+# examples/claude-code-integration/Dockerfile
+FROM ghcr.io/tencentcloud/cubesandbox-base:2026.16
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      ca-certificates curl gnupg git jq ripgrep less \
+      python3 python3-pip build-essential \
+    && curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
+    && apt-get install -y --no-install-recommends nodejs \
+    && npm install -g @anthropic-ai/claude-code \
+    && claude --version
+
+ENV CLAUDE_CODE_HOME=/root/.claude
+WORKDIR /workspace
+EXPOSE 49983
+```
+
+Build and push:
+
+```bash
+docker build -t <your-registry>/claude-code-cube:latest \
+  examples/claude-code-integration
+docker push <your-registry>/claude-code-cube:latest
+```
+
+### 2. Register as a Cube template
+
+```bash
+cubemastercli tpl create-from-image \
+  --image <your-registry>/claude-code-cube:latest \
+  --writable-layer-size 4G \
+  --expose-port 49983 \
+  --probe       49983 \
+  --probe-path  /health
+
+cubemastercli tpl watch --job-id <job_id>
+```
+
+Once the job reaches `READY`, note the `template_id` — you'll pass it to every
+`Sandbox.create()` call. `4G` writable layer is enough for medium tasks; bump
+it to `8G+` if the agent is expected to install large toolchains.
+
+### 3. Wire up the host driver
+
+```bash
+cd examples/claude-code-integration
+cp env.example .env
+# fill in E2B_API_URL, CUBE_TEMPLATE_ID, ANTHROPIC_API_KEY
+pip install -r requirements.txt
+```
+
+Direct-flavor smoke test:
+
+```bash
+python run_claude.py --prompt "Create hello.py that prints 'Hello from CubeSandbox!' and run it."
+```
+
+### 4. Enable pause / resume for long tasks
+
+```bash
+python resume_claude.py
+```
+
+This mirrors the [snapshot / clone / rollback](../snapshot-rollback-clone.md)
+engine at the SDK layer:
+
+- `sandbox.pause()` snapshots the running VM (memory + rootfs) to disk and
+  frees compute resources.
+- `Sandbox.connect(sandbox_id)` resumes from the snapshot with `/workspace`,
+  `/root/.claude/`, and every other file intact.
+- Multiple resumes off the same snapshot let you fork task variants without
+  rerunning the setup.
+
+### 5. Vault-flavor: keep the key out of the VM
+
+`network_policy.py` demonstrates the recommended pattern for shared clusters:
+
+```python
+rules = [
+    {
+        "name": "allow_anthropic_api",
+        "match": {
+            "scheme": "https",
+            "sni": "api.anthropic.com",
+            "host": "api.anthropic.com",
+        },
+        "action": {
+            "allow": True,
+            "audit": "metadata",
+            "inject": [
+                {"header": "x-api-key",         "format": "${SECRET}",
+                 "secret": ANTHROPIC_API_KEY},
+                {"header": "anthropic-version", "format": "2023-06-01"},
+            ],
+        },
+    },
+]
+
+with Sandbox.create(
+    template=CUBE_TEMPLATE_ID,
+    allow_internet_access=True,
+    network={"rules": rules},
+) as sandbox:
+    ...
+```
+
+Effect:
+
+- `printenv | grep ANTHROPIC_API_KEY` inside the sandbox returns nothing.
+- Every request to `api.anthropic.com` gets `x-api-key` attached on the wire.
+- Anything else is default-denied and returned as `403 Forbidden - CubeEgress`
+  before touching the network.
+- Every allow / deny decision lands in `/data/log/cube-egress/access.jsonl`.
+
+## Key Code Snippets
+
+### Headless `claude` invocation
+
+Use `--print` (disables the interactive TUI) plus `--allowedTools` (skips the
+per-tool permission prompt for whitelisted commands):
+
+```python
+cmd = (
+    "cd /workspace && claude --print "
+    "--allowedTools 'Bash(npm:*),Bash(node:*),Bash(python3:*),Edit,Write,Read' "
+    f"-- {shlex.quote(prompt)}"
+)
+result = sandbox.commands.run(
+    cmd, envs={"ANTHROPIC_API_KEY": key}, user="root", timeout=300,
+    on_stdout=lambda m: sys.stdout.write(m),
+    on_stderr=lambda m: sys.stderr.write(m),
+)
+```
+
+Add `--verbose --output-format stream-json` when the caller wants a
+machine-readable event stream (one JSON object per turn).
+
+### Passing secrets via `envs` (direct flavor)
+
+`e2b`'s `commands.run(envs=...)` puts the environment into the exec envelope,
+not into a persistent env file inside the VM — the key lives only for the
+lifetime of that command:
+
+```python
+sandbox.commands.run(
+    "claude --print -- 'do something'",
+    envs={"ANTHROPIC_API_KEY": key, "ANTHROPIC_MODEL": "claude-sonnet-4-5"},
+    user="root",
+)
+```
+
+### Uploading a seed project
+
+```python
+sandbox.files.write(
+    f"{workspace}/{Path(seed).name}",
+    Path(seed).read_bytes(),
+    user="root",
+)
+```
+
+### Pause / resume around a task
+
+```python
+sandbox = Sandbox.create(template=template_id, timeout=1800)
+run_claude(sandbox, prompt_1)
+sandbox.pause()
+
+# ... hours later ...
+
+sandbox = Sandbox.connect(sandbox_id)
+run_claude(sandbox, prompt_2)  # /workspace + /root/.claude are intact
+```
+
+## Caveats
+
+- **Node.js version.** Claude Code needs Node ≥ 18. The base image ships
+  Ubuntu 22.04, whose apt Node is too old — always install via NodeSource.
+- **Agent state directory.** `/root/.claude/` holds Claude Code's local
+  session cache. Baking a stale directory into the image can leak previous
+  sessions across tenants; the Dockerfile deliberately keeps it empty.
+- **`--dangerously-skip-permissions`.** Skipping tool permissions is only
+  reasonable inside a sandbox you're OK to lose. Prefer explicit
+  `--allowedTools` whitelists.
+- **CubeEgress CA.** For the vault flavor to work, the sandbox must trust
+  CubeEgress's root CA. This is on by default for templates built via
+  `cubemastercli tpl create-from-image`. If you set `--with-cube-ca=false`,
+  set `SSL_CERT_FILE` inside the agent env to the correct bundle instead.
+- **Egress side-effects.** Some `claude` tasks want to `npm install` or fetch
+  MCP tools — either preinstall them into the template or add
+  `registry.npmjs.org` (and, for MCP servers, the specific hosts) to your
+  allow rules.
+- **Interactive TTY features.** The Claude Code TUI (multi-line editor,
+  `/` slash commands) is not available over the E2B protocol. Use `--print`
+  headless mode and drive multi-turn conversations from the host script.
+- **Network-agent auto-resume.** If you enable `on_timeout: pause,
+  auto_resume: True`, the platform pauses idle sandboxes for you and wakes
+  them up on the next request — see the [`auto-resume.py`](https://github.com/TencentCloud/CubeSandbox/blob/master/examples/code-sandbox-quickstart/auto-resume.py)
+  demo for the pattern.
+- **Template writable layer.** Node's `npm` cache alone can hit hundreds of
+  MB. `4G` writable layer is a safe default; long refactor sessions with
+  large dependencies may need `8G` or more.
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| `claude: command not found` in preflight | Template not rebuilt after CLI upgrade | Rebuild the image, re-register template |
+| `Invalid API key · Please run /login` | Key not forwarded (direct flavor) or missing inject rule (vault flavor) | Add `envs={"ANTHROPIC_API_KEY": ...}` or fix the rule's `sni` / `host` |
+| `403 Forbidden — CubeEgress` | Default-deny with no matching allow | Add `Match(sni="api.anthropic.com", scheme="https")` |
+| SSL handshake failure to `api.anthropic.com` | Sandbox doesn't trust CubeEgress CA | Rebuild template with `--with-cube-ca=true` (default), or wire `SSL_CERT_FILE` correctly |
+| Template creation stuck in `PULLING` | Registry unreachable from Cube nodes | Push to a registry the cluster can reach; supply auth if needed |
+| Readiness probe timeout | Base image without envd | Ensure `FROM ghcr.io/tencentcloud/cubesandbox-base:2026.16` |
+| Agent hangs waiting on Bash tool | No `--allowedTools`, no TTY | Always run headless with `--print --allowedTools '...'` |
+| `sandbox.pause()` errors on 0.2.x | Snapshot engine requires 0.3.0+ | Upgrade CubeSandbox platform |
+
+## References
+
+- Runnable example: [`examples/claude-code-integration`](https://github.com/TencentCloud/CubeSandbox/tree/master/examples/claude-code-integration)
+- Bring Your Own Image: [`docs/guide/tutorials/bring-your-own-image.md`](../tutorials/bring-your-own-image.md)
+- Template pipeline: [`docs/guide/tutorials/template-from-image.md`](../tutorials/template-from-image.md)
+- Snapshot / Clone / Rollback: [`docs/guide/snapshot-rollback-clone.md`](../snapshot-rollback-clone.md)
+- Credential vault + egress control: [`docs/guide/security-proxy.md`](../security-proxy.md)
+- Claude Code CLI reference: <https://docs.anthropic.com/en/docs/claude-code/cli-reference>
+- Claude Code SDK / headless mode: <https://docs.anthropic.com/en/docs/claude-code/sdk>

--- a/docs/guide/integrations/claude-code.md
+++ b/docs/guide/integrations/claude-code.md
@@ -144,6 +144,17 @@ cp env.example .env
 pip install -r requirements.txt
 ```
 
+| Variable | Where it flows | Notes |
+|---|---|---|
+| `E2B_API_URL` | Local process | Points at CubeAPI (`http://<node>:3000`) |
+| `E2B_API_KEY` | Local process | Any non-empty string |
+| `CUBE_TEMPLATE_ID` | `Sandbox.create(template=...)` | From step 2 |
+| `ANTHROPIC_API_KEY` | Forwarded per-command via `envs=...` | Or omit when using CubeEgress inject |
+| `ANTHROPIC_MODEL` | Optional, e.g. `claude-sonnet-4-5` | Passed straight to `claude` |
+| `ANTHROPIC_BASE_URL` | Optional custom Anthropic-compatible gateway | e.g. Bedrock proxy |
+| `CLAUDE_CODE_USE_BEDROCK` | Optional, `true` to route through AWS Bedrock | Requires AWS creds in sandbox exec env; **mutually exclusive with Vertex** |
+| `CLAUDE_CODE_USE_VERTEX` | Optional, `true` to route through Google Vertex AI | Requires `GOOGLE_APPLICATION_CREDENTIALS` in sandbox; **mutually exclusive with Bedrock** |
+
 Direct-flavor smoke test:
 
 ```bash
@@ -227,8 +238,8 @@ result = sandbox.commands.run(
 )
 ```
 
-Add `--verbose --output-format stream-json` when the caller wants a
-machine-readable event stream (one JSON object per turn).
+Add `--stream-json` when the caller wants a machine-readable event stream
+(implies `--verbose --output-format stream-json`; one JSON object per turn).
 
 ### Passing secrets via `envs` (direct flavor)
 

--- a/docs/guide/integrations/index.md
+++ b/docs/guide/integrations/index.md
@@ -47,4 +47,4 @@ lang: en-US
 
 | Title | Author | Date | Tags |
 | --- | --- | --- | --- |
-| _Add your article here_ | - | - | - |
+| [Claude Code Integration Guide](./claude-code.md) | LangQi99 | 2026-07-01 | integration, claude-code, anthropic, agent |

--- a/docs/zh/guide/integrations/claude-code.md
+++ b/docs/zh/guide/integrations/claude-code.md
@@ -136,6 +136,17 @@ cp env.example .env
 pip install -r requirements.txt
 ```
 
+| 变量 | 流向 | 说明 |
+|---|---|---|
+| `E2B_API_URL` | 本地进程 | CubeAPI（`http://<node>:3000`） |
+| `E2B_API_KEY` | 本地进程 | 任意非空字符串 |
+| `CUBE_TEMPLATE_ID` | `Sandbox.create(template=...)` | 步骤 2 获得 |
+| `ANTHROPIC_API_KEY` | 通过 `envs=...` 逐条命令注入 | 走 CubeEgress 注入时可省 |
+| `ANTHROPIC_MODEL` | 可选，例如 `claude-sonnet-4-5` | 透传给 `claude` |
+| `ANTHROPIC_BASE_URL` | 可选：Anthropic 兼容网关 | 例如 Bedrock 代理 |
+| `CLAUDE_CODE_USE_BEDROCK` | 可选，`true` 走 AWS Bedrock | 沙箱 exec env 需 AWS 凭证；**与 Vertex 互斥** |
+| `CLAUDE_CODE_USE_VERTEX` | 可选，`true` 走 Google Vertex AI | 沙箱内需 `GOOGLE_APPLICATION_CREDENTIALS`；**与 Bedrock 互斥** |
+
 直连模式冒烟测试：
 
 ```bash
@@ -213,7 +224,8 @@ result = sandbox.commands.run(
 )
 ```
 
-需要机读事件流时加 `--verbose --output-format stream-json`（每一步作为一个 JSON 对象输出）。
+需要机读事件流时加 `--stream-json`（脚本内部会展开为 `--verbose --output-format stream-json`，
+每一步作为一个 JSON 对象输出）。
 
 ### 通过 `envs` 传递密钥（直连模式）
 

--- a/docs/zh/guide/integrations/claude-code.md
+++ b/docs/zh/guide/integrations/claude-code.md
@@ -1,0 +1,295 @@
+---
+title: Claude Code 集成指南
+author: LangQi99
+date: 2026-07-01
+tags:
+  - integration
+  - claude-code
+  - anthropic
+  - agent
+lang: zh-CN
+---
+
+# Claude Code 集成指南
+
+[English](../../../guide/integrations/claude-code.md)
+
+在 CubeSandbox MicroVM 内运行 [Anthropic Claude Code](https://docs.anthropic.com/en/docs/claude-code)（面向终端的 AI 编码 Agent）。本文覆盖从镜像构建到生产级出口管控的完整链路，配套的可运行示例位于
+[`examples/claude-code-integration`](https://github.com/TencentCloud/CubeSandbox/tree/master/examples/claude-code-integration)。
+
+## 集成对象与版本
+
+| 组件 | 版本 |
+|---|---|
+| Claude Code CLI | `@anthropic-ai/claude-code`（构建时最新，可通过 `--build-arg CLAUDE_CODE_VERSION=x.y.z` 固定） |
+| Node.js | 20 LTS |
+| CubeSandbox 基础镜像 | `ghcr.io/tencentcloud/cubesandbox-base:2026.16` |
+| E2B SDK（宿主端驱动） | `e2b >= 2.4.1` |
+| CubeSandbox 平台 | `>= 0.3.0`（pause/resume）/ `>= 0.4.0`（CubeEgress 密钥保险柜） |
+
+## 前置条件
+
+- 已部署 CubeSandbox，CubeAPI 可访问（`http://<node>:3000`）
+- `cubemastercli` 已安装且已连通集群
+- 有 Docker 的构建机，且 registry 能被 Cube 集群拉取
+- Anthropic API Key（`sk-ant-...`）；或兼容网关（Bedrock、Vertex、自建 Anthropic 代理）
+- Python 3.10+（宿主端驱动脚本）
+
+## 为什么要把 Claude Code 放进沙箱
+
+Claude Code 是一个会编辑文件、执行命令、安装依赖包的终端 Agent。直接跑在开发机上，Agent 的
+"爆炸半径" 就等于你的开发环境。放进 CubeSandbox 你能拿到：
+
+| 关注点 | CubeSandbox 提供 |
+|---|---|
+| **隔离** | 每个会话一个 KVM MicroVM，独立 guest kernel |
+| **可复现** | 每次会话都从同一个 template 快照启动 |
+| **秒起** | 冷启动 <60ms，N 路并行代价极小 |
+| **长任务** | `sandbox.pause()` 快照 VM+rootfs，稍后可恢复 |
+| **密钥卫生** | CubeEgress 出口注入 `x-api-key`，VM 永远看不到明文 |
+| **出口审计** | 每一次访问 `api.anthropic.com` 都写入 JSONL 审计日志 |
+
+## 架构
+
+```
+┌────────────────────────┐        ┌───────────────────────┐
+│  宿主端驱动脚本         │  E2B  │  CubeSandbox MicroVM  │
+│  (run_claude.py)        │       │                       │
+│                         │──────►│  envd (:49983)        │
+│  ANTHROPIC_API_KEY      │       │  claude CLI (Node 20) │
+│  可选                   │       │  git / python / rg    │
+│                         │       │  /workspace           │
+└──────────┬──────────────┘       └───────────┬───────────┘
+           │                                  │ HTTPS
+           │                                  ▼
+           │                           ┌───────────────┐
+           └── 注入规则 ─────────────► │  CubeEgress   │───► api.anthropic.com
+                                       └───────────────┘
+                                              │
+                                              ▼
+                                  /data/log/cube-egress/access.jsonl
+```
+
+有两种可互换的集成模式：
+
+| 模式 | Key 走向 | 适用场景 |
+|---|---|---|
+| **直连** | 每条命令通过 `envs={"ANTHROPIC_API_KEY": key}` 下发 | 单人开发机、快速验证 |
+| **保险柜** | 通过 `Sandbox.create(network={"rules": [inject 规则]})` 在出口挂载 | 多租集群、托管服务、审计要求高的场景 |
+
+两种模式使用相同的 template；差别只是 Key 是进 VM，还是由 CubeEgress 在出口挂载。
+
+## 接入步骤
+
+### 1. 构建 template 镜像
+
+镜像在 `cubesandbox-base` 之上加装 Node.js 20 与 Anthropic 官方 CLI，envd 已经在
+`:49983` 监听。
+
+```dockerfile
+# examples/claude-code-integration/Dockerfile
+FROM ghcr.io/tencentcloud/cubesandbox-base:2026.16
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      ca-certificates curl gnupg git jq ripgrep less \
+      python3 python3-pip build-essential \
+    && curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
+    && apt-get install -y --no-install-recommends nodejs \
+    && npm install -g @anthropic-ai/claude-code \
+    && claude --version
+
+ENV CLAUDE_CODE_HOME=/root/.claude
+WORKDIR /workspace
+EXPOSE 49983
+```
+
+构建并推送：
+
+```bash
+docker build -t <your-registry>/claude-code-cube:latest \
+  examples/claude-code-integration
+docker push <your-registry>/claude-code-cube:latest
+```
+
+### 2. 注册为 Cube template
+
+```bash
+cubemastercli tpl create-from-image \
+  --image <your-registry>/claude-code-cube:latest \
+  --writable-layer-size 4G \
+  --expose-port 49983 \
+  --probe       49983 \
+  --probe-path  /health
+
+cubemastercli tpl watch --job-id <job_id>
+```
+
+`READY` 之后拿到 `template_id`，后续每次 `Sandbox.create()` 都会用到它。中等任务
+`4G` 可写层足够；如果 Agent 会安装大型工具链，请拉到 `8G` 或更大。
+
+### 3. 配置宿主端驱动
+
+```bash
+cd examples/claude-code-integration
+cp env.example .env
+# 填 E2B_API_URL、CUBE_TEMPLATE_ID、ANTHROPIC_API_KEY
+pip install -r requirements.txt
+```
+
+直连模式冒烟测试：
+
+```bash
+python run_claude.py --prompt "Create hello.py that prints 'Hello from CubeSandbox!' and run it."
+```
+
+### 4. 使用 pause / resume 支撑长任务
+
+```bash
+python resume_claude.py
+```
+
+这在 SDK 层直接映射到 [快照 · 克隆 · 回滚](../snapshot-rollback-clone.md) 引擎：
+
+- `sandbox.pause()` 把运行中 VM 的内存 + rootfs 快照落盘并释放算力；
+- `Sandbox.connect(sandbox_id)` 从快照恢复，`/workspace`、`/root/.claude/` 等所有文件保留；
+- 从同一个快照多次 `connect` 可派生多个变体分支，无需重跑初始化。
+
+### 5. 保险柜模式：Key 永远不进 VM
+
+`network_policy.py` 展示多租集群推荐做法：
+
+```python
+rules = [
+    {
+        "name": "allow_anthropic_api",
+        "match": {
+            "scheme": "https",
+            "sni": "api.anthropic.com",
+            "host": "api.anthropic.com",
+        },
+        "action": {
+            "allow": True,
+            "audit": "metadata",
+            "inject": [
+                {"header": "x-api-key",         "format": "${SECRET}",
+                 "secret": ANTHROPIC_API_KEY},
+                {"header": "anthropic-version", "format": "2023-06-01"},
+            ],
+        },
+    },
+]
+
+with Sandbox.create(
+    template=CUBE_TEMPLATE_ID,
+    allow_internet_access=True,
+    network={"rules": rules},
+) as sandbox:
+    ...
+```
+
+效果：
+
+- 沙箱内 `printenv | grep ANTHROPIC_API_KEY` 什么都看不到；
+- 每次访问 `api.anthropic.com` 都会在出口挂上 `x-api-key`；
+- 其他一切默认拒绝，直接返回 `403 Forbidden - CubeEgress`，请求根本不出网；
+- 每一次 allow / deny 都会写入 `/data/log/cube-egress/access.jsonl`。
+
+## 关键代码片段
+
+### 无头 `claude` 调用
+
+用 `--print`（关闭交互式 TUI）配 `--allowedTools`（跳过白名单命令的授权提示）：
+
+```python
+cmd = (
+    "cd /workspace && claude --print "
+    "--allowedTools 'Bash(npm:*),Bash(node:*),Bash(python3:*),Edit,Write,Read' "
+    f"-- {shlex.quote(prompt)}"
+)
+result = sandbox.commands.run(
+    cmd, envs={"ANTHROPIC_API_KEY": key}, user="root", timeout=300,
+    on_stdout=lambda m: sys.stdout.write(m),
+    on_stderr=lambda m: sys.stderr.write(m),
+)
+```
+
+需要机读事件流时加 `--verbose --output-format stream-json`（每一步作为一个 JSON 对象输出）。
+
+### 通过 `envs` 传递密钥（直连模式）
+
+`e2b` 的 `commands.run(envs=...)` 把环境变量放进 exec 信封，不会写入沙箱里的持久 env 文件；
+密钥只在这条命令的生命周期里存在：
+
+```python
+sandbox.commands.run(
+    "claude --print -- 'do something'",
+    envs={"ANTHROPIC_API_KEY": key, "ANTHROPIC_MODEL": "claude-sonnet-4-5"},
+    user="root",
+)
+```
+
+### 上传 seed 项目
+
+```python
+sandbox.files.write(
+    f"{workspace}/{Path(seed).name}",
+    Path(seed).read_bytes(),
+    user="root",
+)
+```
+
+### 在任务前后 pause / resume
+
+```python
+sandbox = Sandbox.create(template=template_id, timeout=1800)
+run_claude(sandbox, prompt_1)
+sandbox.pause()
+
+# ... 数小时后 ...
+
+sandbox = Sandbox.connect(sandbox_id)
+run_claude(sandbox, prompt_2)  # /workspace 与 /root/.claude 都保留
+```
+
+## 注意事项
+
+- **Node.js 版本**：Claude Code 需要 Node ≥ 18。基础镜像是 Ubuntu 22.04，apt 自带的 Node
+  过旧，务必走 NodeSource 安装。
+- **Agent 状态目录**：`/root/.claude/` 存的是 Claude Code 的本地会话缓存。把它烧进镜像可能
+  让上一租户的会话泄漏到下一租户；示例 Dockerfile 特意留空。
+- **`--dangerously-skip-permissions`**：仅在你完全接受沙箱风险时使用，优先用显式的
+  `--allowedTools` 白名单。
+- **CubeEgress CA**：保险柜模式要求沙箱信任 CubeEgress 根证书。使用
+  `cubemastercli tpl create-from-image` 时默认会烧进去；若你显式设了 `--with-cube-ca=false`，
+  需要在 Agent env 里设置 `SSL_CERT_FILE` 指向正确的 bundle。
+- **出口副作用**：某些任务会 `npm install` 或拉取 MCP 工具——要么把它们预装进 template，
+  要么把 `registry.npmjs.org`（以及具体 MCP host）加进 allow 规则。
+- **交互式 TTY 能力**：Claude Code 的 TUI（多行编辑器、`/` 命令）走 E2B 协议无法使用，
+  统一用 `--print` 无头模式，多轮对话由宿主脚本编排。
+- **network-agent 自动挂起**：设置 `on_timeout: pause, auto_resume: True` 后，平台会自动
+  挂起空闲沙箱并在下一次请求到达时唤醒——参见示例
+  [`auto-resume.py`](https://github.com/TencentCloud/CubeSandbox/blob/master/examples/code-sandbox-quickstart/auto-resume.py)。
+- **Template 可写层大小**：仅 npm 缓存就可能几百 MB。`4G` 是安全默认值；长时间大依赖重构可能需要 `8G` 以上。
+
+## 常见问题
+
+| 现象 | 可能原因 | 解决 |
+|---|---|---|
+| 预检 `claude: command not found` | CLI 升级后 template 未重建 | 重构镜像并重新注册 template |
+| `Invalid API key · Please run /login` | 直连模式没传 Key，或保险柜规则没生效 | 加 `envs={"ANTHROPIC_API_KEY": ...}`，或修正规则的 `sni` / `host` |
+| `403 Forbidden — CubeEgress` | 默认拒绝但没有 allow 规则 | 添加 `Match(sni="api.anthropic.com", scheme="https")` |
+| 访问 `api.anthropic.com` SSL 握手失败 | 沙箱不信任 CubeEgress 根证书 | 用 `--with-cube-ca=true`（默认）重建 template；或在沙箱内正确配置 `SSL_CERT_FILE` |
+| Template 创建卡在 `PULLING` | Cube 节点拉不到 registry | 换 registry 或提供 `--registry-username/--registry-password` |
+| 就绪探测超时 | 基础镜像没有 envd | 确保 `FROM ghcr.io/tencentcloud/cubesandbox-base:2026.16` |
+| Agent 卡在 Bash 工具确认 | 没配 `--allowedTools`，也没有 TTY | 一律用 `--print --allowedTools '...'` |
+| `sandbox.pause()` 在 0.2.x 报错 | 快照引擎需要 0.3.0+ | 升级 CubeSandbox 平台 |
+
+## 参考资料
+
+- 可运行示例：[`examples/claude-code-integration`](https://github.com/TencentCloud/CubeSandbox/tree/master/examples/claude-code-integration)
+- 自带镜像：[`docs/zh/guide/tutorials/bring-your-own-image.md`](../tutorials/bring-your-own-image.md)
+- Template 流水线：[`docs/zh/guide/tutorials/template-from-image.md`](../tutorials/template-from-image.md)
+- 快照 · 克隆 · 回滚：[`docs/zh/guide/snapshot-rollback-clone.md`](../snapshot-rollback-clone.md)
+- 密钥保险柜与出口管控：[`docs/zh/guide/security-proxy.md`](../security-proxy.md)
+- Claude Code CLI 参考：<https://docs.anthropic.com/en/docs/claude-code/cli-reference>
+- Claude Code SDK / 无头模式：<https://docs.anthropic.com/en/docs/claude-code/sdk>

--- a/docs/zh/guide/integrations/index.md
+++ b/docs/zh/guide/integrations/index.md
@@ -47,4 +47,4 @@ lang: zh-CN
 
 | 标题 | 作者 | 日期 | 标签 |
 | --- | --- | --- | --- |
-| _在这里补充你的文章_ | - | - | - |
+| [Claude Code 集成指南](./claude-code.md) | LangQi99 | 2026-07-01 | integration, claude-code, anthropic, agent |

--- a/examples/claude-code-integration/.gitignore
+++ b/examples/claude-code-integration/.gitignore
@@ -1,0 +1,3 @@
+.env
+__pycache__/
+*.pyc

--- a/examples/claude-code-integration/Dockerfile
+++ b/examples/claude-code-integration/Dockerfile
@@ -1,0 +1,51 @@
+# syntax=docker/dockerfile:1.7
+#
+# Claude Code inside a CubeSandbox template.
+#
+# The image stacks Node.js LTS + Anthropic's official `@anthropic-ai/claude-code`
+# CLI on top of `cubesandbox-base`, which already ships `envd` on `:49983`
+# so the resulting sandbox passes the readiness probe out of the box.
+#
+# Build:
+#   docker build -t claude-code-cube:latest examples/claude-code-integration
+#
+# Register as a Cube template (see README.md for details):
+#   cubemastercli tpl create-from-image \
+#     --image <your-registry>/claude-code-cube:latest \
+#     --writable-layer-size 4G \
+#     --expose-port 49983 \
+#     --probe       49983 \
+#     --probe-path  /health
+
+ARG CUBE_BASE_IMAGE=ghcr.io/tencentcloud/cubesandbox-base:2026.16
+FROM ${CUBE_BASE_IMAGE}
+
+ARG DEBIAN_FRONTEND=noninteractive
+ARG NODE_MAJOR=20
+ARG CLAUDE_CODE_VERSION=latest
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+         ca-certificates curl gnupg git jq ripgrep less \
+         python3 python3-pip build-essential \
+    && curl -fsSL "https://deb.nodesource.com/setup_${NODE_MAJOR}.x" | bash - \
+    && apt-get install -y --no-install-recommends nodejs \
+    && rm -rf /var/lib/apt/lists/* \
+    && npm install -g "@anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}" \
+    && claude --version
+
+ENV CLAUDE_CODE_HOME=/root/.claude \
+    ANTHROPIC_MODEL="" \
+    ANTHROPIC_BASE_URL=""
+
+RUN mkdir -p "${CLAUDE_CODE_HOME}" /workspace \
+    && printf '%s\n' \
+        '# Placeholder settings.' \
+        '# Runtime settings live under /root/.claude/settings.json and are' \
+        '# populated at sandbox creation time via envd env vars or session' \
+        '# writes so secrets never bake into the image.' \
+        > "${CLAUDE_CODE_HOME}/README.md"
+
+WORKDIR /workspace
+
+EXPOSE 49983

--- a/examples/claude-code-integration/Dockerfile
+++ b/examples/claude-code-integration/Dockerfile
@@ -32,7 +32,9 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends nodejs \
     && rm -rf /var/lib/apt/lists/* \
     && npm install -g "@anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}" \
-    && claude --version
+    && claude --version \
+    && npm cache clean --force \
+    && rm -rf /root/.npm
 
 ENV CLAUDE_CODE_HOME=/root/.claude \
     ANTHROPIC_MODEL="" \

--- a/examples/claude-code-integration/README.md
+++ b/examples/claude-code-integration/README.md
@@ -95,6 +95,8 @@ pip install -r requirements.txt
 | `ANTHROPIC_API_KEY` | Forwarded per-command via `envs=...` | Or omit when using CubeEgress inject |
 | `ANTHROPIC_MODEL` | Optional, e.g. `claude-sonnet-4-5` | Passed straight to `claude` |
 | `ANTHROPIC_BASE_URL` | Optional custom Anthropic-compatible gateway | e.g. Bedrock proxy |
+| `CLAUDE_CODE_USE_BEDROCK` | Optional, `true` to route through AWS Bedrock | Requires AWS creds in the sandbox exec env; **mutually exclusive with Vertex** |
+| `CLAUDE_CODE_USE_VERTEX` | Optional, `true` to route through Google Vertex AI | Requires `GOOGLE_APPLICATION_CREDENTIALS` in the sandbox; **mutually exclusive with Bedrock** |
 
 ## 3. One-shot run
 
@@ -111,7 +113,7 @@ Under the hood the script:
 4. Streams stdout/stderr back to the host in real time.
 5. Lists `/workspace` so you can see the files the agent produced.
 
-Add `--verbose` for `--output-format stream-json` (each turn emitted as a
+Add `--stream-json` for `--output-format stream-json` (each turn emitted as a
 JSON event — handy for orchestration systems that want to watch the tool
 calls). Add `--seed ./my_project.py` to upload a local file into the
 workspace before the agent runs.

--- a/examples/claude-code-integration/README.md
+++ b/examples/claude-code-integration/README.md
@@ -1,0 +1,204 @@
+# Claude Code + CubeSandbox
+
+[中文文档](README_zh.md)
+
+Run [Anthropic Claude Code](https://docs.anthropic.com/en/docs/claude-code) —
+a terminal-native AI coding agent — **inside a CubeSandbox MicroVM**. The agent
+gets a KVM-isolated rootfs with hardware-level isolation from the host and
+your other tenants; the operator gets an audited egress path where API keys
+never enter the VM.
+
+```
+┌───────────────────────┐          ┌───────────────────────┐
+│  Host driver script    │  E2B     │  CubeSandbox MicroVM  │
+│  (run_claude.py)       │  proto   │                       │
+│                        │ ────────►│  envd  (:49983)       │
+│  Anthropic key stays   │          │  claude CLI (Node 20) │
+│  on the host OR is     │          │  git / python3 / rg   │
+│  injected by CubeEgress│          │  /workspace           │
+└──────────┬─────────────┘          └───────────┬───────────┘
+           │                                    │ HTTPS
+           │                                    ▼
+           │                             ┌─────────────────┐
+           └─── (optional inject rule) ─►│  CubeEgress     │───► api.anthropic.com
+                                         └─────────────────┘
+```
+
+## What you get
+
+| Feature | How CubeSandbox provides it |
+|---|---|
+| Hardware-isolated rootfs for the agent | KVM MicroVM (Cloud Hypervisor) with a dedicated guest kernel |
+| Sub-second cold start of a fresh workspace | Boot from a template snapshot in <60 ms |
+| Long-running agent tasks with checkpoint / resume | `sandbox.pause()` + `Sandbox.connect(sandbox_id)` |
+| API key never touches the sandbox | CubeEgress `inject` rule attaches `x-api-key` on egress |
+| Egress control | Domain allowlist limited to `api.anthropic.com` (or your gateway) |
+| Full audit log of every LLM request | `/data/log/cube-egress/access.jsonl` per host |
+
+## Directory layout
+
+```
+claude-code-integration/
+├── README.md                # This file (English)
+├── README_zh.md             # Chinese version
+├── Dockerfile               # cubesandbox-base + Node 20 + @anthropic-ai/claude-code
+├── env.example              # Copy to .env and fill in
+├── env_utils.py             # dotenv + envs=... helper
+├── requirements.txt         # e2b>=2.4.1, python-dotenv
+├── run_claude.py            # Minimal one-shot demo
+├── resume_claude.py         # pause / resume across two turns
+└── network_policy.py        # CubeEgress inject rule (key-in-vault mode)
+```
+
+## 1. Build & register the template
+
+Any x86_64 host with Docker will do — the image only ships in a registry the
+Cube cluster can reach.
+
+```bash
+# 1) Build
+docker build -t claude-code-cube:latest examples/claude-code-integration
+
+# 2) Push to a registry your Cube nodes can pull from
+docker tag  claude-code-cube:latest <your-registry>/claude-code-cube:latest
+docker push                        <your-registry>/claude-code-cube:latest
+
+# 3) Register as a Cube template
+cubemastercli tpl create-from-image \
+  --image <your-registry>/claude-code-cube:latest \
+  --writable-layer-size 4G \
+  --expose-port 49983 \
+  --probe       49983 \
+  --probe-path  /health
+
+# 4) Wait for READY
+cubemastercli tpl watch --job-id <job_id>
+```
+
+The image inherits `cubesandbox-base`, so envd is already listening on
+`:49983`. Claude Code lands at `/usr/bin/claude` and its state directory at
+`/root/.claude/`; nothing user-specific is baked into the image.
+
+## 2. Configure the driver
+
+```bash
+cd examples/claude-code-integration
+cp env.example .env      # fill in E2B_API_URL, CUBE_TEMPLATE_ID, ANTHROPIC_API_KEY
+pip install -r requirements.txt
+```
+
+| Variable | Where it flows | Notes |
+|---|---|---|
+| `E2B_API_URL` | Local process | Points at CubeAPI (`http://<node>:3000`) |
+| `E2B_API_KEY` | Local process | Any non-empty string |
+| `CUBE_TEMPLATE_ID` | `Sandbox.create(template=...)` | From step 1 |
+| `ANTHROPIC_API_KEY` | Forwarded per-command via `envs=...` | Or omit when using CubeEgress inject |
+| `ANTHROPIC_MODEL` | Optional, e.g. `claude-sonnet-4-5` | Passed straight to `claude` |
+| `ANTHROPIC_BASE_URL` | Optional custom Anthropic-compatible gateway | e.g. Bedrock proxy |
+
+## 3. One-shot run
+
+```bash
+python run_claude.py --prompt "Create hello.py that prints 'Hello from CubeSandbox!' and run it."
+```
+
+Under the hood the script:
+
+1. Boots a sandbox from the Claude Code template.
+2. `claude --version` preflight to catch stale templates fast.
+3. Runs `claude --print --allowedTools 'Bash(npm:*),Bash(node:*),Bash(python3:*),Edit,Write,Read' -- <prompt>`
+   inside `/workspace` with the API key forwarded per-exec via `envs=...`.
+4. Streams stdout/stderr back to the host in real time.
+5. Lists `/workspace` so you can see the files the agent produced.
+
+Add `--verbose` for `--output-format stream-json` (each turn emitted as a
+JSON event — handy for orchestration systems that want to watch the tool
+calls). Add `--seed ./my_project.py` to upload a local file into the
+workspace before the agent runs.
+
+## 4. Long-running tasks with pause / resume
+
+```bash
+python resume_claude.py
+```
+
+The demo runs Claude Code, then calls `sandbox.pause()` — the VM is
+snapshotted to disk, resources are released, and a later
+`Sandbox.connect(sandbox_id)` brings it back with the rootfs, `/workspace`
+files, and Claude Code's on-disk state (`~/.claude/`) intact. This is
+particularly useful for:
+
+- multi-hour refactors where you want to walk away and check in later
+- interactive sessions that need to survive host maintenance
+- forking N variants from a common baseline (via `sandbox.pause()` + clone)
+
+The E2B protocol version of this call maps directly onto CubeSandbox's
+[Snapshot / Clone / Rollback engine](../../docs/guide/snapshot-rollback-clone.md).
+
+## 5. Credential vault mode (recommended for shared clusters)
+
+`network_policy.py` demonstrates the **API-key-never-in-VM** pattern. The
+sandbox is created with a CubeEgress rule set that:
+
+- default-denies every outbound request,
+- allows `https://api.anthropic.com`,
+- injects `x-api-key: sk-ant-...` and `anthropic-version: 2023-06-01`
+  headers on the wire.
+
+```bash
+python network_policy.py
+```
+
+Inside the sandbox, `printenv | grep ANTHROPIC_API_KEY` returns nothing —
+the CLI still authenticates because CubeEgress attaches the header after
+the sandbox emits the bare request. Every request lands in
+`/data/log/cube-egress/access.jsonl` on the host with the rule name, sandbox
+IP, method, path, latency, and TLS handshake outcome.
+
+For gateway deployments (Bedrock, Vertex, in-house Anthropic proxies) point
+`ANTHROPIC_BASE_URL` at the gateway and change the rule's `sni` / `host`
+accordingly. Full grammar: [Security proxy guide](../../docs/guide/security-proxy.md).
+
+## 6. Best practices
+
+**Egress**: keep the sandbox default-denied. Add exactly the domains
+Claude Code needs — usually only `api.anthropic.com`, plus `registry.npmjs.org`
+if the task installs new npm packages.
+
+**Tool whitelisting**: pass `--allowedTools` (or set `--dangerously-skip-permissions`
+only inside a sandbox you're OK to lose). The CLI still enforces user
+prompts by default, but a whitelist compresses one round-trip per call.
+
+**Snapshot as commit**: after the agent completes a self-contained step,
+`sandbox.pause()` yields a resumable checkpoint. If the next turn goes
+sideways you can `Sandbox.connect(sid)` on the previous one and try again.
+
+**Concurrent agents**: one sandbox per session. CubeSandbox's `<60 ms`
+cold start makes N-parallel workflows cheap; hardware isolation means one
+malfunctioning agent can't touch its neighbours.
+
+**Working directory**: mount only `/workspace` for user files. Everything
+under `/root/.claude/` is agent state — losing it just resets the agent's
+short-term memory, not the code you produced.
+
+## 7. Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| `claude: command not found` in preflight | Wrong template | Re-check `CUBE_TEMPLATE_ID`; rebuild image; template must have Node ≥ 18 |
+| `Invalid API key` from Claude Code | `ANTHROPIC_API_KEY` not forwarded (or CubeEgress rule missing) | See §5, or add the key to `envs=...` |
+| Egress blocked with `403 Forbidden — CubeEgress` | Default-deny with no matching allow rule | Add `Match(sni="api.anthropic.com")` (or your gateway) |
+| Template creation fails readiness probe | Base image without envd | Ensure `FROM ghcr.io/tencentcloud/cubesandbox-base:2026.16` |
+| `Cannot find /workspace` | Custom `WORKDIR` overridden | Pass `--workspace /some/dir` and `mkdir -p` before running |
+| Agent hangs on `Bash(...)` prompt | No `--allowedTools` supplied and TTY is missing | Use `--print` + `--allowedTools` (both scripts already do this) |
+| SSL handshake fails against `api.anthropic.com` | CubeEgress cert not trusted inside sandbox | Template must be built `--with-cube-ca=true` (default), or set `SSL_CERT_FILE` |
+
+## 8. Related docs
+
+- [Integration guide (English)](../../docs/guide/integrations/claude-code.md)
+- [集成指南（中文）](../../docs/zh/guide/integrations/claude-code.md)
+- [Bring Your Own Image (envd)](../../docs/guide/tutorials/bring-your-own-image.md)
+- [Create Templates from OCI Images](../../docs/guide/tutorials/template-from-image.md)
+- [Snapshot · Clone · Rollback](../../docs/guide/snapshot-rollback-clone.md)
+- [Security Proxy · Credential Vault](../../docs/guide/security-proxy.md)
+- [Claude Code CLI reference](https://docs.anthropic.com/en/docs/claude-code/cli-reference)

--- a/examples/claude-code-integration/README_zh.md
+++ b/examples/claude-code-integration/README_zh.md
@@ -1,0 +1,186 @@
+# Claude Code + CubeSandbox
+
+[English README](README.md)
+
+在 CubeSandbox MicroVM 内运行 [Anthropic Claude Code](https://docs.anthropic.com/en/docs/claude-code) —
+面向终端的 AI 编码 Agent。Agent 拿到一个 KVM 硬件级隔离的 rootfs，跟宿主机与其他租户完全隔开；
+运维侧则拿到一条可审计的出口链路，API Key 永远不进入 VM。
+
+```
+┌───────────────────────┐          ┌───────────────────────┐
+│  宿主端驱动脚本         │  E2B     │  CubeSandbox MicroVM  │
+│  (run_claude.py)       │ 协议     │                       │
+│                        │ ────────►│  envd  (:49983)       │
+│  Anthropic Key 保留在   │          │  claude CLI (Node 20) │
+│  宿主端；或由 CubeEgress│          │  git / python3 / rg   │
+│  在出口注入            │          │  /workspace           │
+└──────────┬─────────────┘          └───────────┬───────────┘
+           │                                    │ HTTPS
+           │                                    ▼
+           │                             ┌─────────────────┐
+           └─── (可选注入规则) ────────►│  CubeEgress     │───► api.anthropic.com
+                                         └─────────────────┘
+```
+
+## 你能得到什么
+
+| 能力 | CubeSandbox 如何提供 |
+|---|---|
+| 给 Agent 一个硬件级隔离的 rootfs | KVM MicroVM（Cloud Hypervisor），独立 guest kernel |
+| 亚秒级冷启动的干净工作区 | 从 template 快照启动，<60ms |
+| 长任务断点续跑 | `sandbox.pause()` + `Sandbox.connect(sandbox_id)` |
+| API Key 永远不进入沙箱 | 通过 CubeEgress `inject` 规则在出口挂载 `x-api-key` 头 |
+| 出口管控 | 域名白名单，只放行 `api.anthropic.com`（或你自己的网关） |
+| 全量 LLM 请求审计 | 每台宿主机 `/data/log/cube-egress/access.jsonl` |
+
+## 目录结构
+
+```
+claude-code-integration/
+├── README.md                # 英文说明
+├── README_zh.md             # 本文件
+├── Dockerfile               # cubesandbox-base + Node 20 + @anthropic-ai/claude-code
+├── env.example              # 复制为 .env 后填写
+├── env_utils.py             # dotenv + envs=... 工具函数
+├── requirements.txt         # e2b>=2.4.1, python-dotenv
+├── run_claude.py            # 最小一次性任务示例
+├── resume_claude.py         # 跨两轮的 pause/resume 示例
+└── network_policy.py        # CubeEgress 注入规则（Key 保留在保险柜）
+```
+
+## 1. 构建并注册 template
+
+任意支持 Docker 的 x86_64 主机都可以构建镜像；镜像本身只需要放到 Cube 集群能拉取的 registry。
+
+```bash
+# 1) 构建
+docker build -t claude-code-cube:latest examples/claude-code-integration
+
+# 2) 推到 Cube 集群可访问的 registry
+docker tag  claude-code-cube:latest <your-registry>/claude-code-cube:latest
+docker push                        <your-registry>/claude-code-cube:latest
+
+# 3) 注册为 Cube template
+cubemastercli tpl create-from-image \
+  --image <your-registry>/claude-code-cube:latest \
+  --writable-layer-size 4G \
+  --expose-port 49983 \
+  --probe       49983 \
+  --probe-path  /health
+
+# 4) 等待 READY
+cubemastercli tpl watch --job-id <job_id>
+```
+
+镜像继承 `cubesandbox-base`，所以 envd 已经在 `:49983` 监听。Claude Code 位于
+`/usr/bin/claude`，状态目录在 `/root/.claude/`；镜像里没有任何用户敏感信息。
+
+## 2. 配置驱动脚本
+
+```bash
+cd examples/claude-code-integration
+cp env.example .env      # 填 E2B_API_URL、CUBE_TEMPLATE_ID、ANTHROPIC_API_KEY
+pip install -r requirements.txt
+```
+
+| 变量 | 流向 | 说明 |
+|---|---|---|
+| `E2B_API_URL` | 本地进程 | CubeAPI 地址（`http://<node>:3000`） |
+| `E2B_API_KEY` | 本地进程 | 任意非空字符串即可 |
+| `CUBE_TEMPLATE_ID` | `Sandbox.create(template=...)` | 步骤 1 中获得 |
+| `ANTHROPIC_API_KEY` | 通过 `envs=...` 逐条命令注入 | 若走 CubeEgress 注入模式可省 |
+| `ANTHROPIC_MODEL` | 可选，例如 `claude-sonnet-4-5` | 直接透传给 `claude` |
+| `ANTHROPIC_BASE_URL` | 可选：Anthropic 兼容网关 | 例如 Bedrock 代理 |
+
+## 3. 单次任务
+
+```bash
+python run_claude.py --prompt "Create hello.py that prints 'Hello from CubeSandbox!' and run it."
+```
+
+脚本内部：
+
+1. 从 Claude Code template 拉起沙箱；
+2. `claude --version` 预检，快速识别 template 是否过期；
+3. 在 `/workspace` 里执行 `claude --print --allowedTools 'Bash(npm:*),Bash(node:*),Bash(python3:*),Edit,Write,Read' -- <prompt>`，
+   API Key 通过 `envs=...` 逐条命令下发；
+4. stdout / stderr 实时透传回宿主端；
+5. 打印 `/workspace` 的目录列表，便于验收 Agent 产出的文件。
+
+添加 `--verbose` 会启用 `--output-format stream-json`（Claude Code 每一步输出为 JSON 事件，
+便于外部编排）。用 `--seed ./my_project.py` 可以在 Agent 运行前把宿主端文件上传到工作区。
+
+## 4. 使用 pause/resume 支撑长任务
+
+```bash
+python resume_claude.py
+```
+
+Demo 会先运行一段 Claude Code，然后调用 `sandbox.pause()`：VM 快照落盘，资源释放；之后
+再 `Sandbox.connect(sandbox_id)` 恢复，rootfs、`/workspace` 里的文件、Claude Code 落盘状态
+（`~/.claude/`）都完好保留。适合以下场景：
+
+- 长时间重构任务，中途离场再回来继续；
+- 交互式会话希望在宿主机维护窗口内保留状态；
+- 从同一基线 fork 出 N 个变体。
+
+E2B 协议中的 `pause` 直接对应 CubeSandbox 的 [快照 / 克隆 / 回滚引擎](../../docs/zh/guide/snapshot-rollback-clone.md)。
+
+## 5. 密钥保险柜模式（多租集群推荐）
+
+`network_policy.py` 展示 **API Key 永远不进入 VM** 的最佳实践。沙箱创建时携带一组
+CubeEgress 规则：
+
+- 默认拒绝所有出口；
+- 放行 `https://api.anthropic.com`；
+- 在出口注入 `x-api-key: sk-ant-...` 与 `anthropic-version: 2023-06-01` 头。
+
+```bash
+python network_policy.py
+```
+
+沙箱内 `printenv | grep ANTHROPIC_API_KEY` 什么都看不到；CLI 依然能通过认证，因为
+CubeEgress 在沙箱发出裸请求之后才把 header 挂上去。所有请求都会写入宿主机
+`/data/log/cube-egress/access.jsonl`，包含规则名、沙箱 IP、method、path、耗时、TLS 结果。
+
+如果你使用 Bedrock、Vertex 或自建 Anthropic 网关：把 `ANTHROPIC_BASE_URL` 指向网关，规则里
+的 `sni` / `host` 也换成对应域名。完整语法参见 [安全代理指南](../../docs/zh/guide/security-proxy.md)。
+
+## 6. 最佳实践
+
+**出口策略**：默认拒绝，只按需放行 Claude Code 需要的域名。通常只需要
+`api.anthropic.com`；如果任务里会 `npm install`，再加上 `registry.npmjs.org`。
+
+**工具白名单**：明确传 `--allowedTools`；只有在你完全接受沙箱风险时才用
+`--dangerously-skip-permissions`。白名单可以省掉一次交互往返。
+
+**用快照当 commit**：Agent 完成一个自洽的小步骤后 `sandbox.pause()` 就是一个可回滚的
+checkpoint。下一步失败时可以 `Sandbox.connect(sid)` 回到上一个快照重试。
+
+**并发 Agent**：一个会话一个沙箱。CubeSandbox `<60ms` 冷启动让 N 路并行开销可忽略；硬件
+隔离保证一个 Agent 出错不会影响其他 Agent。
+
+**工作目录**：只把 `/workspace` 当用户产物目录。`/root/.claude/` 是 Agent 的短期状态，
+丢了也只是丢短期记忆，不影响你已经产出的代码。
+
+## 7. 常见问题
+
+| 现象 | 可能原因 | 解决 |
+|---|---|---|
+| 预检报 `claude: command not found` | Template 有问题 | 检查 `CUBE_TEMPLATE_ID`；重建镜像；镜像内 Node ≥ 18 |
+| Claude Code 报 `Invalid API key` | Key 没进沙箱，也没配 CubeEgress | 参考 §5，或把 Key 加到 `envs=...` |
+| 出口命中 `403 Forbidden — CubeEgress` | 默认拒绝但没有 allow 规则 | 增加 `Match(sni="api.anthropic.com")`（或你的网关） |
+| Template 就绪探测失败 | 基础镜像没有 envd | 确保 `FROM ghcr.io/tencentcloud/cubesandbox-base:2026.16` |
+| `Cannot find /workspace` | 上层镜像换了 `WORKDIR` | 传 `--workspace /some/dir` 并先 `mkdir -p` |
+| Agent 卡在 `Bash(...)` 提示 | 没配 `--allowedTools`，且没有 TTY | 使用 `--print` + `--allowedTools`（两个脚本都是这么做的） |
+| 访问 `api.anthropic.com` SSL 握手失败 | 沙箱不信任 CubeEgress 证书 | Template 需以 `--with-cube-ca=true`（默认）构建，或设置 `SSL_CERT_FILE` |
+
+## 8. 相关文档
+
+- [集成指南（中文）](../../docs/zh/guide/integrations/claude-code.md)
+- [Integration guide (English)](../../docs/guide/integrations/claude-code.md)
+- [自带镜像（envd）](../../docs/zh/guide/tutorials/bring-your-own-image.md)
+- [从 OCI 镜像创建 Template](../../docs/zh/guide/tutorials/template-from-image.md)
+- [快照 · 克隆 · 回滚](../../docs/zh/guide/snapshot-rollback-clone.md)
+- [安全代理 · 密钥保险柜](../../docs/zh/guide/security-proxy.md)
+- [Claude Code CLI 参考](https://docs.anthropic.com/en/docs/claude-code/cli-reference)

--- a/examples/claude-code-integration/README_zh.md
+++ b/examples/claude-code-integration/README_zh.md
@@ -91,6 +91,8 @@ pip install -r requirements.txt
 | `ANTHROPIC_API_KEY` | 通过 `envs=...` 逐条命令注入 | 若走 CubeEgress 注入模式可省 |
 | `ANTHROPIC_MODEL` | 可选，例如 `claude-sonnet-4-5` | 直接透传给 `claude` |
 | `ANTHROPIC_BASE_URL` | 可选：Anthropic 兼容网关 | 例如 Bedrock 代理 |
+| `CLAUDE_CODE_USE_BEDROCK` | 可选，`true` 走 AWS Bedrock | 需在沙箱 exec env 中提供 AWS 凭证；**与 Vertex 互斥** |
+| `CLAUDE_CODE_USE_VERTEX` | 可选，`true` 走 Google Vertex AI | 需在沙箱内提供 `GOOGLE_APPLICATION_CREDENTIALS`；**与 Bedrock 互斥** |
 
 ## 3. 单次任务
 
@@ -107,7 +109,7 @@ python run_claude.py --prompt "Create hello.py that prints 'Hello from CubeSandb
 4. stdout / stderr 实时透传回宿主端；
 5. 打印 `/workspace` 的目录列表，便于验收 Agent 产出的文件。
 
-添加 `--verbose` 会启用 `--output-format stream-json`（Claude Code 每一步输出为 JSON 事件，
+添加 `--stream-json` 会启用 `--output-format stream-json`（Claude Code 每一步输出为 JSON 事件，
 便于外部编排）。用 `--seed ./my_project.py` 可以在 Agent 运行前把宿主端文件上传到工作区。
 
 ## 4. 使用 pause/resume 支撑长任务

--- a/examples/claude-code-integration/env.example
+++ b/examples/claude-code-integration/env.example
@@ -1,0 +1,24 @@
+# Required: Cube API server address
+export E2B_API_URL="http://<your-node-ip>:3000"
+
+# Required: any non-empty value satisfies the SDK check
+export E2B_API_KEY="e2b_000000"
+
+# Required: template ID printed by `cubemastercli tpl create-from-image ...`
+export CUBE_TEMPLATE_ID="<your-template-id>"
+
+# Required for run_claude.py: forwarded to Claude Code inside the sandbox
+export ANTHROPIC_API_KEY="sk-ant-..."
+
+# Optional: pin the model, otherwise Claude Code picks its default
+# export ANTHROPIC_MODEL="claude-sonnet-4-5"
+
+# Optional: point Claude Code at a compatible gateway (e.g. Bedrock proxy).
+# Leave unset for the default https://api.anthropic.com endpoint.
+# export ANTHROPIC_BASE_URL="https://your-anthropic-gateway.example.com"
+
+# Optional: only needed when Cube ships a custom mkcert root CA
+# export SSL_CERT_FILE="/etc/pki/tls/cert.pem"
+
+# Optional: change the on-disk workspace inside the sandbox
+export CLAUDE_WORKSPACE="/workspace"

--- a/examples/claude-code-integration/env.example
+++ b/examples/claude-code-integration/env.example
@@ -17,6 +17,14 @@ export ANTHROPIC_API_KEY="sk-ant-..."
 # Leave unset for the default https://api.anthropic.com endpoint.
 # export ANTHROPIC_BASE_URL="https://your-anthropic-gateway.example.com"
 
+# Optional: enable AWS Bedrock backend. Requires AWS credentials in the
+# sandbox exec env (or an inject rule). Cannot be combined with Vertex.
+# export CLAUDE_CODE_USE_BEDROCK="true"
+
+# Optional: enable Google Vertex AI backend. Requires GOOGLE_APPLICATION_CREDENTIALS
+# or workload-identity in the sandbox exec env. Cannot be combined with Bedrock.
+# export CLAUDE_CODE_USE_VERTEX="true"
+
 # Optional: only needed when Cube ships a custom mkcert root CA
 # export SSL_CERT_FILE="/etc/pki/tls/cert.pem"
 

--- a/examples/claude-code-integration/env_utils.py
+++ b/examples/claude-code-integration/env_utils.py
@@ -1,0 +1,51 @@
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared helpers for the Claude Code + CubeSandbox demos."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from dotenv import load_dotenv
+
+
+def load_local_dotenv() -> None:
+    """Best-effort load of a nearby `.env` file without overriding real env."""
+    for path in (Path(__file__).with_name(".env"), Path.cwd() / ".env"):
+        if path.is_file():
+            load_dotenv(dotenv_path=path, override=False)
+            return
+
+
+def required(name: str) -> str:
+    value = os.environ.get(name, "").strip()
+    if not value:
+        raise SystemExit(
+            f"missing required env var {name}; copy env.example -> .env and fill it in"
+        )
+    return value
+
+
+def build_agent_env() -> dict[str, str]:
+    """Env vars that get forwarded into the sandbox for `claude` invocations.
+
+    The Anthropic API key stays on the operator side by default: it is passed
+    to `sandbox.commands.run(..., envs=...)` per-call so it lives in the envd
+    exec envelope, not in a persistent /etc/environment file inside the VM.
+    Combined with a CubeEgress inject rule (see README §5) you can drop the
+    key from this dict entirely and let CubeEgress attach it on the wire.
+    """
+    envs: dict[str, str] = {}
+    for name in (
+        "ANTHROPIC_API_KEY",
+        "ANTHROPIC_MODEL",
+        "ANTHROPIC_BASE_URL",
+        "CLAUDE_CODE_USE_BEDROCK",
+        "CLAUDE_CODE_USE_VERTEX",
+    ):
+        value = os.environ.get(name)
+        if value:
+            envs[name] = value
+    return envs

--- a/examples/claude-code-integration/network_policy.py
+++ b/examples/claude-code-integration/network_policy.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+network_policy.py — run Claude Code inside a sandbox where:
+
+  * The Anthropic API key is *never* forwarded into the sandbox env.
+  * Only api.anthropic.com is reachable; every other domain is default-denied.
+  * CubeEgress injects `x-api-key: sk-ant-...` on the wire, so the header
+    only lives in the operator's rule list.
+
+This is the recommended "credential vault" pattern for running third-party
+coding agents. The sandbox sees a bare API request; the secret never enters
+the VM's environment, filesystem, or process space.
+"""
+
+from __future__ import annotations
+
+import os
+import shlex
+import sys
+
+from e2b import Sandbox
+
+from env_utils import load_local_dotenv, required
+
+
+PROMPT = "Write a file called ok.txt containing 'ok'."
+
+
+def main() -> int:
+    load_local_dotenv()
+    template_id = required("CUBE_TEMPLATE_ID")
+    api_key = required("ANTHROPIC_API_KEY")
+
+    rules = [
+        {
+            "name": "allow_anthropic_api",
+            "match": {
+                "scheme": "https",
+                "sni": "api.anthropic.com",
+                "host": "api.anthropic.com",
+            },
+            "action": {
+                "allow": True,
+                "audit": "metadata",
+                "inject": [
+                    {
+                        "header": "x-api-key",
+                        "format": "${SECRET}",
+                        "secret": api_key,
+                    },
+                    {
+                        "header": "anthropic-version",
+                        "format": "2023-06-01",
+                    },
+                ],
+            },
+        },
+    ]
+
+    print("[cube] creating sandbox with default-deny egress + Anthropic inject rule")
+    with Sandbox.create(
+        template=template_id,
+        allow_internet_access=True,
+        network={"rules": rules},
+    ) as sandbox:
+        # Deliberately do NOT forward ANTHROPIC_API_KEY into the sandbox.
+        # The proxy will attach the auth header on the way out.
+        envs: dict[str, str] = {}
+        for name in ("ANTHROPIC_MODEL", "ANTHROPIC_BASE_URL"):
+            value = os.environ.get(name)
+            if value:
+                envs[name] = value
+
+        # Confirm the key is not present inside the sandbox.
+        leak_check = sandbox.commands.run(
+            "printenv | grep -c ANTHROPIC_API_KEY || true", user="root", timeout=10,
+        )
+        print(f"[verify] ANTHROPIC_API_KEY visible inside sandbox: {leak_check.stdout.strip()} times")
+
+        cmd = (
+            "cd /workspace && "
+            f"claude --print --allowedTools 'Edit,Write,Read' -- {shlex.quote(PROMPT)}"
+        )
+        result = sandbox.commands.run(
+            cmd, envs=envs, user="root", timeout=300,
+            on_stdout=lambda m: sys.stdout.write(m),
+            on_stderr=lambda m: sys.stderr.write(m),
+        )
+        print(f"\n[claude] exit_code={result.exit_code}")
+
+        listing = sandbox.commands.run("ls -la /workspace", user="root")
+        print(listing.stdout)
+
+        return 0 if result.exit_code == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/examples/claude-code-integration/requirements.txt
+++ b/examples/claude-code-integration/requirements.txt
@@ -1,0 +1,2 @@
+e2b>=2.4.1
+python-dotenv>=1.0

--- a/examples/claude-code-integration/resume_claude.py
+++ b/examples/claude-code-integration/resume_claude.py
@@ -46,7 +46,7 @@ def parse_args() -> argparse.Namespace:
     return p.parse_args()
 
 
-def run_claude(sandbox: Sandbox, prompt: str, workspace: str, envs: dict[str, str]) -> None:
+def run_claude(sandbox: Sandbox, prompt: str, workspace: str, envs: dict[str, str]) -> int:
     cmd = (
         f"cd {shlex.quote(workspace)} && "
         f"claude --print --allowedTools 'Edit,Write,Read,Bash(ls:*)' -- {shlex.quote(prompt)}"
@@ -57,6 +57,7 @@ def run_claude(sandbox: Sandbox, prompt: str, workspace: str, envs: dict[str, st
         on_stderr=lambda m: sys.stderr.write(m),
     )
     print(f"\n[claude] exit_code={result.exit_code}")
+    return result.exit_code or 0
 
 
 def main() -> int:
@@ -68,14 +69,17 @@ def main() -> int:
 
     print(f"[cube] creating sandbox from template={template_id}")
     sandbox = Sandbox.create(template=template_id, timeout=1800)
-    sid = sandbox.sandbox_id
-    print(f"[cube] sandbox_id={sid}")
 
+    sid: str | None = None
+    failures = 0
     try:
+        sid = sandbox.sandbox_id
+        print(f"[cube] sandbox_id={sid}")
+
         sandbox.commands.run(f"mkdir -p {shlex.quote(args.workspace)}", user="root", timeout=15)
 
         print("\n=== Step 1: initial task ===")
-        run_claude(sandbox, PROMPT_1, args.workspace, envs)
+        failures += 1 if run_claude(sandbox, PROMPT_1, args.workspace, envs) else 0
 
         listing1 = sandbox.commands.run(f"ls -la {shlex.quote(args.workspace)}", user="root")
         print(listing1.stdout)
@@ -89,7 +93,7 @@ def main() -> int:
 
         print("\n=== Step 3: resume + continue ===")
         sandbox = Sandbox.connect(sid)
-        run_claude(sandbox, PROMPT_2, args.workspace, envs)
+        failures += 1 if run_claude(sandbox, PROMPT_2, args.workspace, envs) else 0
 
         listing2 = sandbox.commands.run(f"ls -la {shlex.quote(args.workspace)}", user="root")
         print(listing2.stdout)
@@ -100,7 +104,7 @@ def main() -> int:
         print("\n=== rationale.md ===")
         print(rationale.stdout)
 
-        return 0
+        return 0 if failures == 0 else 1
     finally:
         try:
             sandbox.kill()

--- a/examples/claude-code-integration/resume_claude.py
+++ b/examples/claude-code-integration/resume_claude.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+resume_claude.py — long-running Claude Code sessions with pause/resume.
+
+Demonstrates:
+  1. Create sandbox from the Claude Code template.
+  2. Ask Claude to start a task; write a small note into /workspace so we can
+     later verify the pause/resume round-trip preserved the filesystem.
+  3. Pause the sandbox — resources released, VM snapshot on disk.
+  4. Resume; ask Claude to continue by inspecting the note. The rootfs, plus
+     any partial state under /root/.claude/, is intact.
+
+Usage:
+    python resume_claude.py
+"""
+
+from __future__ import annotations
+
+import argparse
+import shlex
+import sys
+import time
+
+from e2b import Sandbox
+
+from env_utils import build_agent_env, load_local_dotenv, required
+
+
+PROMPT_1 = (
+    "Write a file called plan.md that lists three ideas for improving a "
+    "Python CLI. Then say 'done'."
+)
+PROMPT_2 = (
+    "Read plan.md, pick the first idea, and write a one-paragraph rationale "
+    "into rationale.md."
+)
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--workspace", default="/workspace")
+    p.add_argument("--pause-seconds", type=int, default=5)
+    return p.parse_args()
+
+
+def run_claude(sandbox: Sandbox, prompt: str, workspace: str, envs: dict[str, str]) -> None:
+    cmd = (
+        f"cd {shlex.quote(workspace)} && "
+        f"claude --print --allowedTools 'Edit,Write,Read,Bash(ls:*)' -- {shlex.quote(prompt)}"
+    )
+    result = sandbox.commands.run(
+        cmd, envs=envs, user="root", timeout=300,
+        on_stdout=lambda m: sys.stdout.write(m),
+        on_stderr=lambda m: sys.stderr.write(m),
+    )
+    print(f"\n[claude] exit_code={result.exit_code}")
+
+
+def main() -> int:
+    args = parse_args()
+    load_local_dotenv()
+    template_id = required("CUBE_TEMPLATE_ID")
+    required("ANTHROPIC_API_KEY")
+    envs = build_agent_env()
+
+    print(f"[cube] creating sandbox from template={template_id}")
+    sandbox = Sandbox.create(template=template_id, timeout=1800)
+    sid = sandbox.sandbox_id
+    print(f"[cube] sandbox_id={sid}")
+
+    try:
+        sandbox.commands.run(f"mkdir -p {shlex.quote(args.workspace)}", user="root", timeout=15)
+
+        print("\n=== Step 1: initial task ===")
+        run_claude(sandbox, PROMPT_1, args.workspace, envs)
+
+        listing1 = sandbox.commands.run(f"ls -la {shlex.quote(args.workspace)}", user="root")
+        print(listing1.stdout)
+
+        print(f"\n=== Step 2: pausing sandbox for {args.pause_seconds}s ===")
+        sandbox.pause()
+        for _ in range(args.pause_seconds):
+            time.sleep(1)
+            print(".", end="", flush=True)
+        print()
+
+        print("\n=== Step 3: resume + continue ===")
+        sandbox = Sandbox.connect(sid)
+        run_claude(sandbox, PROMPT_2, args.workspace, envs)
+
+        listing2 = sandbox.commands.run(f"ls -la {shlex.quote(args.workspace)}", user="root")
+        print(listing2.stdout)
+
+        rationale = sandbox.commands.run(
+            f"cat {shlex.quote(args.workspace)}/rationale.md", user="root",
+        )
+        print("\n=== rationale.md ===")
+        print(rationale.stdout)
+
+        return 0
+    finally:
+        try:
+            sandbox.kill()
+        except Exception as exc:  # noqa: BLE001
+            print(f"[cleanup] sandbox.kill() raised {exc!r}")
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/examples/claude-code-integration/resume_claude.py
+++ b/examples/claude-code-integration/resume_claude.py
@@ -57,7 +57,11 @@ def run_claude(sandbox: Sandbox, prompt: str, workspace: str, envs: dict[str, st
         on_stderr=lambda m: sys.stderr.write(m),
     )
     print(f"\n[claude] exit_code={result.exit_code}")
-    return result.exit_code or 0
+    # Treat a missing exit_code (SDK returned None on error) as failure —
+    # `exit_code or 0` would mask this because `None or 0` == 0.
+    if result.exit_code is None:
+        return 1
+    return result.exit_code
 
 
 def main() -> int:
@@ -68,11 +72,11 @@ def main() -> int:
     envs = build_agent_env()
 
     print(f"[cube] creating sandbox from template={template_id}")
-    sandbox = Sandbox.create(template=template_id, timeout=1800)
-
+    sandbox: Sandbox | None = None
     sid: str | None = None
     failures = 0
     try:
+        sandbox = Sandbox.create(template=template_id, timeout=1800)
         sid = sandbox.sandbox_id
         print(f"[cube] sandbox_id={sid}")
 
@@ -106,10 +110,11 @@ def main() -> int:
 
         return 0 if failures == 0 else 1
     finally:
-        try:
-            sandbox.kill()
-        except Exception as exc:  # noqa: BLE001
-            print(f"[cleanup] sandbox.kill() raised {exc!r}")
+        if sandbox is not None:
+            try:
+                sandbox.kill()
+            except Exception as exc:  # noqa: BLE001
+                print(f"[cleanup] sandbox.kill() raised {exc!r}")
 
 
 if __name__ == "__main__":

--- a/examples/claude-code-integration/run_claude.py
+++ b/examples/claude-code-integration/run_claude.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+run_claude.py — spin up a CubeSandbox from the Claude Code template, feed it a
+prompt over the E2B protocol, and print the transcript.
+
+The sandbox is fully isolated: Claude Code runs *inside* the MicroVM, and every
+tool call it makes (bash, file edits, etc.) hits the sandbox rootfs, never the
+host. The Anthropic API key is forwarded per-command via `envs=...` so it
+never touches the sandbox filesystem or persistent env.
+
+Usage:
+    cp env.example .env  # fill in E2B_API_URL, CUBE_TEMPLATE_ID, ANTHROPIC_API_KEY
+    pip install -r requirements.txt
+    python run_claude.py --prompt "Write hello.py that prints Hello, Cube!"
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shlex
+import sys
+from pathlib import Path
+
+from e2b import Sandbox
+
+from env_utils import build_agent_env, load_local_dotenv, required
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument(
+        "--prompt",
+        default="Create hello.py that prints 'Hello from CubeSandbox!' and run it.",
+        help="Task the Claude Code agent should perform inside the sandbox.",
+    )
+    p.add_argument(
+        "--workspace",
+        default=os.environ.get("CLAUDE_WORKSPACE", "/workspace"),
+        help="Working directory inside the sandbox (default: /workspace).",
+    )
+    p.add_argument(
+        "--seed",
+        default=None,
+        help="Optional path to a local file uploaded into the workspace before "
+             "Claude Code runs (e.g. an existing project the agent should edit).",
+    )
+    p.add_argument(
+        "--timeout",
+        type=int,
+        default=600,
+        help="Sandbox lifetime in seconds (default: 600).",
+    )
+    p.add_argument(
+        "--exec-timeout",
+        type=int,
+        default=300,
+        help="Per-command exec timeout in seconds (default: 300).",
+    )
+    p.add_argument(
+        "--allowed-tools",
+        default="Bash(npm:*),Bash(node:*),Bash(python3:*),Edit,Write,Read",
+        help="Comma-separated whitelist passed to `claude --allowedTools`.",
+    )
+    p.add_argument(
+        "--pause",
+        action="store_true",
+        help="Pause the sandbox at the end (for later resume) instead of "
+             "destroying it. The sandbox_id is printed on exit.",
+    )
+    p.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Emit `--output-format stream-json` events; otherwise plain text.",
+    )
+    return p.parse_args()
+
+
+def preflight_agent(sandbox: Sandbox) -> None:
+    """Sanity-check that the template really has Claude Code installed."""
+    result = sandbox.commands.run("claude --version", user="root", timeout=30)
+    if result.exit_code != 0:
+        raise SystemExit(
+            "claude CLI is not installed in the template.\n"
+            "Rebuild the image from examples/claude-code-integration/Dockerfile "
+            "and re-register the template.\n"
+            f"stderr: {result.stderr}"
+        )
+    print(f"[preflight] {result.stdout.strip()}")
+
+
+def upload_seed(sandbox: Sandbox, workspace: str, seed: str) -> None:
+    """Copy a local file into the sandbox workspace so the agent can edit it."""
+    seed_path = Path(seed)
+    if not seed_path.is_file():
+        raise SystemExit(f"seed file not found: {seed_path}")
+    dst = f"{workspace.rstrip('/')}/{seed_path.name}"
+    sandbox.files.write(dst, seed_path.read_bytes(), user="root")
+    print(f"[seed] {seed_path} -> {dst}")
+
+
+def build_command(prompt: str, allowed_tools: str, verbose: bool) -> str:
+    """
+    Compose a headless `claude` invocation. `--print` disables the interactive
+    TUI so we can capture stdout linearly. `--output-format stream-json` is
+    optional but very useful when the agent takes many tool-call turns.
+    """
+    parts = [
+        "claude",
+        "--print",
+        "--allowedTools", allowed_tools,
+    ]
+    if verbose:
+        parts.extend(["--verbose", "--output-format", "stream-json"])
+    parts.append("--")
+    parts.append(prompt)
+    return " ".join(shlex.quote(p) for p in parts)
+
+
+def run(args: argparse.Namespace) -> int:
+    load_local_dotenv()
+    template_id = required("CUBE_TEMPLATE_ID")
+    required("ANTHROPIC_API_KEY")
+
+    envs = build_agent_env()
+    print(f"[cube] creating sandbox from template={template_id}")
+    with Sandbox.create(template=template_id, timeout=args.timeout) as sandbox:
+        print(f"[cube] sandbox_id={sandbox.sandbox_id}")
+        preflight_agent(sandbox)
+
+        sandbox.commands.run(
+            f"mkdir -p {shlex.quote(args.workspace)}", user="root", timeout=15,
+        )
+        if args.seed:
+            upload_seed(sandbox, args.workspace, args.seed)
+
+        cmd = build_command(args.prompt, args.allowed_tools, args.verbose)
+        wrapped = f"cd {shlex.quote(args.workspace)} && {cmd}"
+
+        print(f"[claude] $ {cmd}")
+        print("─" * 60)
+
+        result = sandbox.commands.run(
+            wrapped,
+            envs=envs,
+            user="root",
+            timeout=args.exec_timeout,
+            on_stdout=lambda m: sys.stdout.write(m),
+            on_stderr=lambda m: sys.stderr.write(m),
+        )
+
+        print("─" * 60)
+        print(
+            f"[claude] exit_code={result.exit_code} "
+            f"len(stdout)={len(result.stdout or '')} "
+            f"len(stderr)={len(result.stderr or '')}"
+        )
+
+        listing = sandbox.commands.run(
+            f"ls -la {shlex.quote(args.workspace)}", user="root", timeout=10,
+        )
+        print("[cube] workspace after run:")
+        print(listing.stdout)
+
+        if args.pause:
+            info = sandbox.pause()
+            print(json.dumps({"paused": True, "sandbox_id": sandbox.sandbox_id, "info": info}, default=str))
+
+        return 0 if result.exit_code == 0 else result.exit_code or 1
+
+
+if __name__ == "__main__":
+    sys.exit(run(parse_args()))

--- a/examples/claude-code-integration/run_claude.py
+++ b/examples/claude-code-integration/run_claude.py
@@ -47,7 +47,10 @@ def parse_args() -> argparse.Namespace:
         "--seed",
         default=None,
         help="Optional path to a local file uploaded into the workspace before "
-             "Claude Code runs (e.g. an existing project the agent should edit).",
+             "Claude Code runs (e.g. an existing project the agent should edit). "
+             "WARNING: this file will be readable by the agent inside the "
+             "sandbox — do not point it at credentials, SSH keys, or other "
+             "secrets.",
     )
     p.add_argument(
         "--timeout",
@@ -129,7 +132,13 @@ def run(args: argparse.Namespace) -> int:
 
     envs = build_agent_env()
     print(f"[cube] creating sandbox from template={template_id}")
-    with Sandbox.create(template=template_id, timeout=args.timeout) as sandbox:
+
+    # Do not use `with Sandbox.create(...) as sandbox:` when --pause is set —
+    # __exit__ destroys the sandbox on scope exit, defeating the pause. When
+    # --pause is off we still want deterministic cleanup, so a try/finally
+    # around a bare create() covers both cases uniformly.
+    sandbox = Sandbox.create(template=template_id, timeout=args.timeout)
+    try:
         print(f"[cube] sandbox_id={sandbox.sandbox_id}")
         preflight_agent(sandbox)
 
@@ -169,9 +178,19 @@ def run(args: argparse.Namespace) -> int:
 
         if args.pause:
             info = sandbox.pause()
-            print(json.dumps({"paused": True, "sandbox_id": sandbox.sandbox_id, "info": info}, default=str))
+            print(json.dumps(
+                {"paused": True, "sandbox_id": sandbox.sandbox_id, "info": info},
+                default=str,
+            ))
 
-        return 0 if result.exit_code == 0 else result.exit_code or 1
+        exit_code = result.exit_code
+        return 0 if exit_code == 0 else (exit_code if exit_code is not None else 1)
+    finally:
+        if not args.pause:
+            try:
+                sandbox.kill()
+            except Exception as exc:  # noqa: BLE001
+                print(f"[cleanup] sandbox.kill() raised {exc!r}")
 
 
 if __name__ == "__main__":

--- a/examples/claude-code-integration/run_claude.py
+++ b/examples/claude-code-integration/run_claude.py
@@ -73,9 +73,10 @@ def parse_args() -> argparse.Namespace:
              "destroying it. The sandbox_id is printed on exit.",
     )
     p.add_argument(
-        "--verbose",
+        "--stream-json",
         action="store_true",
-        help="Emit `--output-format stream-json` events; otherwise plain text.",
+        help="Emit `--output-format stream-json` events (machine-readable, "
+             "one JSON object per turn). Implies `claude --verbose`.",
     )
     return p.parse_args()
 
@@ -103,7 +104,7 @@ def upload_seed(sandbox: Sandbox, workspace: str, seed: str) -> None:
     print(f"[seed] {seed_path} -> {dst}")
 
 
-def build_command(prompt: str, allowed_tools: str, verbose: bool) -> str:
+def build_command(prompt: str, allowed_tools: str, stream_json: bool) -> str:
     """
     Compose a headless `claude` invocation. `--print` disables the interactive
     TUI so we can capture stdout linearly. `--output-format stream-json` is
@@ -114,7 +115,7 @@ def build_command(prompt: str, allowed_tools: str, verbose: bool) -> str:
         "--print",
         "--allowedTools", allowed_tools,
     ]
-    if verbose:
+    if stream_json:
         parts.extend(["--verbose", "--output-format", "stream-json"])
     parts.append("--")
     parts.append(prompt)
@@ -138,7 +139,7 @@ def run(args: argparse.Namespace) -> int:
         if args.seed:
             upload_seed(sandbox, args.workspace, args.seed)
 
-        cmd = build_command(args.prompt, args.allowed_tools, args.verbose)
+        cmd = build_command(args.prompt, args.allowed_tools, args.stream_json)
         wrapped = f"cd {shlex.quote(args.workspace)} && {cmd}"
 
         print(f"[claude] $ {cmd}")


### PR DESCRIPTION
## Summary

Addresses the **Claude Code** sub-direction of #644 with an end-to-end
integration guide plus a runnable example project.

- **Runnable example** at [`examples/claude-code-integration/`](../tree/master/examples/claude-code-integration):
  - `Dockerfile` — stacks Node.js 20 + Anthropic's official `@anthropic-ai/claude-code` on top of `ghcr.io/tencentcloud/cubesandbox-base:2026.16` so envd is already listening on `:49983`.
  - `run_claude.py` — headless one-shot Agent driver (upload optional seed → `claude --print --allowedTools ...` → stream stdout back).
  - `resume_claude.py` — pause/resume across two turns; verifies `/workspace` + `/root/.claude/` survive the snapshot.
  - `network_policy.py` — recommended **credential vault** pattern: default-deny egress, allow only `api.anthropic.com`, CubeEgress `inject` attaches `x-api-key` on the wire so the key never enters the VM.
  - Bilingual `README.md` / `README_zh.md`, `env.example`, `requirements.txt`, `env_utils.py`.
- **Integration guide** in both languages, following the `_template.md` frontmatter and referenced in the index tables:
  - [`docs/guide/integrations/claude-code.md`](../tree/master/docs/guide/integrations/claude-code.md)
  - [`docs/zh/guide/integrations/claude-code.md`](../tree/master/docs/zh/guide/integrations/claude-code.md)

Covers the acceptance criteria from #644:
1. end-to-end integration guide (template build, deps, key injection, egress policy, session persistence via snapshots),
2. runnable example project with build script and README,
3. typical use cases + best practices,
4. FAQ / troubleshooting section aligned with existing egress / auth / template mechanics,
5. article dropped into the `docs/guide/integrations` system on the existing template.

## Test plan

Verified locally without a live cluster (I don't have one on this laptop):

- [x] `docker build --platform linux/amd64` succeeds (~125 s).
- [x] `envd /health` inside the running image returns **204** (readiness probe will pass).
- [x] `claude --version` -> `2.1.197 (Claude Code)`; `envd -version` -> `0.5.13`; `node -v` -> `v20.20.2`.
- [x] `git`, `python3`, `rg`, `jq` all present.
- [x] `claude --help` confirms every flag used by the scripts (`--print`, `--allowedTools`, `--verbose`, `--output-format stream-json`, `--dangerously-skip-permissions`) is supported.
- [x] All four Python scripts pass `py_compile.compile(..., doraise=True)`.
- [ ] End-to-end run against a live CubeSandbox + Anthropic key (needs cluster access — please run `python run_claude.py`, `python resume_claude.py`, `python network_policy.py` before merge).

## Notes for the maintainers

- Doc filenames match kebab-case in both language dirs; frontmatter keys are identical between languages.
- Example directory follows the same layout convention as `openai-agents-example` / `openclaw-integration`.
- No changes to core code — docs + example only.

Closes part of #644 (Claude Code sub-direction). CodeBuddy / OpenCode remain open for other contributors.