### PR TITLE
fix(sandbox): return volume mounts in sandbox info and list APIs

### DIFF
--- a/CubeAPI/src/cubemaster/mod.rs
+++ b/CubeAPI/src/cubemaster/mod.rs
@@ -892,6 +892,17 @@ pub struct EnvVar {
     pub value: String,
 }
 
+/// Volume mount entry as returned by CubeMaster sandbox info/list APIs.
+#[derive(Debug, Deserialize, Clone)]
+pub struct CubeVolumeMount {
+    #[serde(default)]
+    pub name: String,
+    #[serde(default, alias = "containerPath")]
+    pub container_path: String,
+    #[serde(default)]
+    pub readonly: bool,
+}
+
 #[derive(Debug, Serialize, Clone)]
 pub struct VolumeMount {
     pub name: String,
@@ -1101,6 +1112,8 @@ pub struct SandboxInfo {
     pub annotations: HashMap<String, String>,
     #[serde(default)]
     pub labels: HashMap<String, String>,
+    #[serde(default)]
+    pub volume_mounts: Vec<CubeVolumeMount>,
 }
 
 // ─── Get single sandbox ────────────────────────────────────────────────────
@@ -1137,6 +1150,8 @@ pub struct GetSandboxDataItem {
     pub namespace: String,
     #[serde(default, deserialize_with = "deserialize_optional_datetime")]
     pub end_at: Option<DateTime<Utc>>,
+    #[serde(default)]
+    pub volume_mounts: Vec<CubeVolumeMount>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -1178,6 +1193,7 @@ pub struct SandboxDetail {
     pub disk_size_mb: i32,
     pub annotations: HashMap<String, String>,
     pub labels: HashMap<String, String>,
+    pub volume_mounts: Vec<CubeVolumeMount>,
 }
 
 fn parse_cpu_millicores(s: &str) -> i32 {
@@ -1356,6 +1372,7 @@ impl GetSandboxResponse {
             disk_size_mb: 0,
             annotations: item.annotations,
             labels: item.labels,
+            volume_mounts: item.volume_mounts,
         })
     }
 }

--- a/CubeAPI/src/services/sandboxes.rs
+++ b/CubeAPI/src/services/sandboxes.rs
@@ -146,7 +146,7 @@ impl SandboxService {
             disk_size_mb: Some(d.disk_size_mb),
             metadata: optional_metadata(d.labels),
             state: sandbox_state_from_status(d.status),
-            volume_mounts: None,
+            volume_mounts: map_volume_mounts(&d.volume_mounts),
         })
     }
 
@@ -853,7 +853,30 @@ pub(crate) fn from_cubemaster_info(s: SandboxInfo) -> crate::models::ListedSandb
         metadata: optional_metadata(s.labels),
         state: sandbox_state_from_str(&s.status),
         envd_version,
-        volume_mounts: None,
+        volume_mounts: map_volume_mounts(&s.volume_mounts),
+    }
+}
+
+pub(crate) fn map_volume_mounts(
+    mounts: &[crate::cubemaster::CubeVolumeMount],
+) -> Option<Vec<crate::models::SandboxVolumeMount>> {
+    if mounts.is_empty() {
+        return None;
+    }
+    let mapped: Vec<_> = mounts
+        .iter()
+        // Drop entries that have neither a logical name nor a container path.
+        .filter(|mount| !mount.name.is_empty() || !mount.container_path.is_empty())
+        .map(|mount| crate::models::SandboxVolumeMount {
+            name: mount.name.clone(),
+            path: mount.container_path.clone(),
+            read_only: mount.readonly,
+        })
+        .collect();
+    if mapped.is_empty() {
+        None
+    } else {
+        Some(mapped)
     }
 }
 
@@ -1067,12 +1090,13 @@ mod tests {
 
     use super::{
         build_cube_network_config, filter_by_metadata, from_cubemaster_info,
-        map_delete_cubemaster_err, validate_mask_request_host, SandboxService, RET_CODE_CONFLICT,
-        RET_CODE_NOT_FOUND, RET_CODE_TASK_RESUME_FAILED, RET_CODE_TASK_STATE_INVALID,
+        map_delete_cubemaster_err, map_volume_mounts, validate_mask_request_host, SandboxService,
+        RET_CODE_CONFLICT, RET_CODE_NOT_FOUND, RET_CODE_TASK_RESUME_FAILED,
+        RET_CODE_TASK_STATE_INVALID,
     };
     use crate::cubemaster::{
-        CreateSandboxRequest, CubeMasterClient, CubeMasterError, ListSandboxResponse, SandboxInfo,
-        SandboxUpdateRequest,
+        CreateSandboxRequest, CubeMasterClient, CubeMasterError, CubeVolumeMount,
+        ListSandboxResponse, SandboxInfo, SandboxUpdateRequest,
     };
     use crate::error::AppError;
     use crate::models::{
@@ -1088,6 +1112,36 @@ mod tests {
     };
     use serde_json::Value;
     use tokio::sync::Mutex;
+
+    #[test]
+    fn map_volume_mounts_returns_none_for_empty_input() {
+        assert!(map_volume_mounts(&[]).is_none());
+    }
+
+    #[test]
+    fn map_volume_mounts_skips_all_empty_entries() {
+        assert!(map_volume_mounts(&[CubeVolumeMount {
+            name: String::new(),
+            container_path: String::new(),
+            readonly: false,
+        }])
+        .is_none());
+    }
+
+    #[test]
+    fn map_volume_mounts_exposes_public_mount_fields() {
+        let mapped = map_volume_mounts(&[CubeVolumeMount {
+            name: "hostdir-0".to_string(),
+            container_path: "/mnt/data".to_string(),
+            readonly: true,
+        }])
+        .expect("mounts should map");
+
+        assert_eq!(mapped.len(), 1);
+        assert_eq!(mapped[0].name, "hostdir-0");
+        assert_eq!(mapped[0].path, "/mnt/data");
+        assert!(mapped[0].read_only);
+    }
 
     #[test]
     fn metadata_filter_matches_all_pairs() {
@@ -1346,6 +1400,7 @@ mod tests {
             template_id: "tpl-1".to_string(),
             annotations: HashMap::new(),
             labels: HashMap::new(),
+            volume_mounts: vec![],
         });
 
         assert_eq!(listed.cpu_count, 2);
@@ -2153,6 +2208,7 @@ mod tests {
                      name,
                      path,
                      read_only,
+                     ..
                  }| {
                     (
                         VolumeSpec {

--- a/CubeMaster/api/services/cubebox/v1/cubebox.pb.go
+++ b/CubeMaster/api/services/cubebox/v1/cubebox.pb.go
@@ -3626,9 +3626,11 @@ type Container struct {
 	// Creation time of the container in nanoseconds.
 	CreatedAt int64 `protobuf:"varint,6,opt,name=created_at,json=createdAt,proto3" json:"created_at,omitempty"`
 	// exit time of the container in nanoseconds.
-	FinishedAt    int64             `protobuf:"varint,7,opt,name=finished_at,json=finishedAt,proto3" json:"finished_at,omitempty"`
-	Labels        map[string]string `protobuf:"bytes,8,rep,name=labels,proto3" json:"labels,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
-	PausedAt      int64             `protobuf:"varint,9,opt,name=paused_at,json=pausedAt,proto3" json:"paused_at,omitempty"`
+	FinishedAt int64             `protobuf:"varint,7,opt,name=finished_at,json=finishedAt,proto3" json:"finished_at,omitempty"`
+	Labels     map[string]string `protobuf:"bytes,8,rep,name=labels,proto3" json:"labels,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	PausedAt   int64             `protobuf:"varint,9,opt,name=paused_at,json=pausedAt,proto3" json:"paused_at,omitempty"`
+	// Mounts declared on the container spec (including host-dir mounts).
+	VolumeMounts  []*VolumeMounts `protobuf:"bytes,10,rep,name=volume_mounts,json=volumeMounts,proto3" json:"volume_mounts,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -3724,6 +3726,13 @@ func (x *Container) GetPausedAt() int64 {
 		return x.PausedAt
 	}
 	return 0
+}
+
+func (x *Container) GetVolumeMounts() []*VolumeMounts {
+	if x != nil {
+		return x.VolumeMounts
+	}
+	return nil
 }
 
 // ContainerStateValue is the wrapper of ContainerState.
@@ -6798,7 +6807,7 @@ const file_api_services_cubebox_v1_cubebox_proto_rawDesc = "" +
 	"\x1cprivate_cubebox_storage_data\x18\t \x01(\fR\x19privateCubeboxStorageData\x1a9\n" +
 	"\vLabelsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\xb1\x03\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\x81\x04\n" +
 	"\tContainer\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x14\n" +
 	"\x05image\x18\x02 \x01(\tR\x05image\x12\x12\n" +
@@ -6810,7 +6819,9 @@ const file_api_services_cubebox_v1_cubebox_proto_rawDesc = "" +
 	"\vfinished_at\x18\a \x01(\x03R\n" +
 	"finishedAt\x12J\n" +
 	"\x06labels\x18\b \x03(\v22.cubelet.services.cubebox.v1.Container.LabelsEntryR\x06labels\x12\x1b\n" +
-	"\tpaused_at\x18\t \x01(\x03R\bpausedAt\x1a9\n" +
+	"\tpaused_at\x18\t \x01(\x03R\bpausedAt\x12N\n" +
+	"\rvolume_mounts\x18\n" +
+	" \x03(\v2).cubelet.services.cubebox.v1.VolumeMountsR\fvolumeMounts\x1a9\n" +
 	"\vLabelsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"X\n" +
@@ -7303,70 +7314,71 @@ var file_api_services_cubebox_v1_cubebox_proto_depIdxs = []int32{
 	32,  // 62: cubelet.services.cubebox.v1.Container.resources:type_name -> cubelet.services.cubebox.v1.Resource
 	5,   // 63: cubelet.services.cubebox.v1.Container.state:type_name -> cubelet.services.cubebox.v1.ContainerState
 	97,  // 64: cubelet.services.cubebox.v1.Container.labels:type_name -> cubelet.services.cubebox.v1.Container.LabelsEntry
-	5,   // 65: cubelet.services.cubebox.v1.ContainerStateValue.state:type_name -> cubelet.services.cubebox.v1.ContainerState
-	52,  // 66: cubelet.services.cubebox.v1.CubeSandboxFilter.state:type_name -> cubelet.services.cubebox.v1.ContainerStateValue
-	98,  // 67: cubelet.services.cubebox.v1.CubeSandboxFilter.label_selector:type_name -> cubelet.services.cubebox.v1.CubeSandboxFilter.LabelSelectorEntry
-	53,  // 68: cubelet.services.cubebox.v1.ListCubeSandboxRequest.filter:type_name -> cubelet.services.cubebox.v1.CubeSandboxFilter
-	59,  // 69: cubelet.services.cubebox.v1.ListCubeSandboxRequest.option:type_name -> cubelet.services.cubebox.v1.ListCubeSandboxOption
-	50,  // 70: cubelet.services.cubebox.v1.ListCubeSandboxResponse.items:type_name -> cubelet.services.cubebox.v1.CubeSandbox
-	99,  // 71: cubelet.services.cubebox.v1.UpdateCubeSandboxRequest.annotations:type_name -> cubelet.services.cubebox.v1.UpdateCubeSandboxRequest.AnnotationsEntry
-	103, // 72: cubelet.services.cubebox.v1.UpdateCubeSandboxResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
-	103, // 73: cubelet.services.cubebox.v1.ExecCubeSandboxResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
-	40,  // 74: cubelet.services.cubebox.v1.AppSnapshotRequest.create_request:type_name -> cubelet.services.cubebox.v1.RunCubeSandboxRequest
-	103, // 75: cubelet.services.cubebox.v1.AppSnapshotResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
-	103, // 76: cubelet.services.cubebox.v1.CommitSandboxResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
-	103, // 77: cubelet.services.cubebox.v1.RollbackSandboxResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
-	68,  // 78: cubelet.services.cubebox.v1.CleanupTemplateRequest.objects:type_name -> cubelet.services.cubebox.v1.CowObjectRef
-	103, // 79: cubelet.services.cubebox.v1.CleanupTemplateResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
-	68,  // 80: cubelet.services.cubebox.v1.ListSandboxSnapshotsRequest.objects:type_name -> cubelet.services.cubebox.v1.CowObjectRef
-	103, // 81: cubelet.services.cubebox.v1.ListSandboxSnapshotsResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
-	72,  // 82: cubelet.services.cubebox.v1.ListSandboxSnapshotsResponse.objects:type_name -> cubelet.services.cubebox.v1.CowObjectStatus
-	103, // 83: cubelet.services.cubebox.v1.ListLocalSnapshotsResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
-	75,  // 84: cubelet.services.cubebox.v1.ListLocalSnapshotsResponse.snapshots:type_name -> cubelet.services.cubebox.v1.LocalSnapshotInfo
-	103, // 85: cubelet.services.cubebox.v1.GetLocalSnapshotResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
-	75,  // 86: cubelet.services.cubebox.v1.GetLocalSnapshotResponse.snapshot:type_name -> cubelet.services.cubebox.v1.LocalSnapshotInfo
-	103, // 87: cubelet.services.cubebox.v1.GetStorageMetricsResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
-	100, // 88: cubelet.services.cubebox.v1.GetStorageMetricsResponse.metrics:type_name -> cubelet.services.cubebox.v1.GetStorageMetricsResponse.MetricsEntry
-	81,  // 89: cubelet.services.cubebox.v1.SandboxStorageInfo.volumes:type_name -> cubelet.services.cubebox.v1.StorageVolumeInfo
-	103, // 90: cubelet.services.cubebox.v1.InspectStorageVolumesResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
-	82,  // 91: cubelet.services.cubebox.v1.InspectStorageVolumesResponse.sandboxes:type_name -> cubelet.services.cubebox.v1.SandboxStorageInfo
-	103, // 92: cubelet.services.cubebox.v1.CleanupOrphanStorageFilesResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
-	86,  // 93: cubelet.services.cubebox.v1.CleanupOrphanStorageFilesResponse.orphans:type_name -> cubelet.services.cubebox.v1.StorageOrphanEntry
-	40,  // 94: cubelet.services.cubebox.v1.CubeboxMgr.Create:input_type -> cubelet.services.cubebox.v1.RunCubeSandboxRequest
-	48,  // 95: cubelet.services.cubebox.v1.CubeboxMgr.Destroy:input_type -> cubelet.services.cubebox.v1.DestroyCubeSandboxRequest
-	54,  // 96: cubelet.services.cubebox.v1.CubeboxMgr.List:input_type -> cubelet.services.cubebox.v1.ListCubeSandboxRequest
-	56,  // 97: cubelet.services.cubebox.v1.CubeboxMgr.Update:input_type -> cubelet.services.cubebox.v1.UpdateCubeSandboxRequest
-	60,  // 98: cubelet.services.cubebox.v1.CubeboxMgr.Exec:input_type -> cubelet.services.cubebox.v1.ExecCubeSandboxRequest
-	62,  // 99: cubelet.services.cubebox.v1.CubeboxMgr.AppSnapshot:input_type -> cubelet.services.cubebox.v1.AppSnapshotRequest
-	64,  // 100: cubelet.services.cubebox.v1.CubeboxMgr.CommitSandbox:input_type -> cubelet.services.cubebox.v1.CommitSandboxRequest
-	66,  // 101: cubelet.services.cubebox.v1.CubeboxMgr.RollbackSandbox:input_type -> cubelet.services.cubebox.v1.RollbackSandboxRequest
-	69,  // 102: cubelet.services.cubebox.v1.CubeboxMgr.CleanupTemplate:input_type -> cubelet.services.cubebox.v1.CleanupTemplateRequest
-	71,  // 103: cubelet.services.cubebox.v1.CubeboxMgr.ListSandboxSnapshots:input_type -> cubelet.services.cubebox.v1.ListSandboxSnapshotsRequest
-	74,  // 104: cubelet.services.cubebox.v1.CubeboxMgr.ListLocalSnapshots:input_type -> cubelet.services.cubebox.v1.ListLocalSnapshotsRequest
-	77,  // 105: cubelet.services.cubebox.v1.CubeboxMgr.GetLocalSnapshot:input_type -> cubelet.services.cubebox.v1.GetLocalSnapshotRequest
-	79,  // 106: cubelet.services.cubebox.v1.CubeboxMgr.GetStorageMetrics:input_type -> cubelet.services.cubebox.v1.GetStorageMetricsRequest
-	83,  // 107: cubelet.services.cubebox.v1.CubeboxMgr.InspectStorageVolumes:input_type -> cubelet.services.cubebox.v1.InspectStorageVolumesRequest
-	85,  // 108: cubelet.services.cubebox.v1.CubeboxMgr.CleanupOrphanStorageFiles:input_type -> cubelet.services.cubebox.v1.CleanupOrphanStorageFilesRequest
-	41,  // 109: cubelet.services.cubebox.v1.CubeboxMgr.Create:output_type -> cubelet.services.cubebox.v1.RunCubeSandboxResponse
-	49,  // 110: cubelet.services.cubebox.v1.CubeboxMgr.Destroy:output_type -> cubelet.services.cubebox.v1.DestroyCubeSandboxResponse
-	55,  // 111: cubelet.services.cubebox.v1.CubeboxMgr.List:output_type -> cubelet.services.cubebox.v1.ListCubeSandboxResponse
-	57,  // 112: cubelet.services.cubebox.v1.CubeboxMgr.Update:output_type -> cubelet.services.cubebox.v1.UpdateCubeSandboxResponse
-	61,  // 113: cubelet.services.cubebox.v1.CubeboxMgr.Exec:output_type -> cubelet.services.cubebox.v1.ExecCubeSandboxResponse
-	63,  // 114: cubelet.services.cubebox.v1.CubeboxMgr.AppSnapshot:output_type -> cubelet.services.cubebox.v1.AppSnapshotResponse
-	65,  // 115: cubelet.services.cubebox.v1.CubeboxMgr.CommitSandbox:output_type -> cubelet.services.cubebox.v1.CommitSandboxResponse
-	67,  // 116: cubelet.services.cubebox.v1.CubeboxMgr.RollbackSandbox:output_type -> cubelet.services.cubebox.v1.RollbackSandboxResponse
-	70,  // 117: cubelet.services.cubebox.v1.CubeboxMgr.CleanupTemplate:output_type -> cubelet.services.cubebox.v1.CleanupTemplateResponse
-	73,  // 118: cubelet.services.cubebox.v1.CubeboxMgr.ListSandboxSnapshots:output_type -> cubelet.services.cubebox.v1.ListSandboxSnapshotsResponse
-	76,  // 119: cubelet.services.cubebox.v1.CubeboxMgr.ListLocalSnapshots:output_type -> cubelet.services.cubebox.v1.ListLocalSnapshotsResponse
-	78,  // 120: cubelet.services.cubebox.v1.CubeboxMgr.GetLocalSnapshot:output_type -> cubelet.services.cubebox.v1.GetLocalSnapshotResponse
-	80,  // 121: cubelet.services.cubebox.v1.CubeboxMgr.GetStorageMetrics:output_type -> cubelet.services.cubebox.v1.GetStorageMetricsResponse
-	84,  // 122: cubelet.services.cubebox.v1.CubeboxMgr.InspectStorageVolumes:output_type -> cubelet.services.cubebox.v1.InspectStorageVolumesResponse
-	87,  // 123: cubelet.services.cubebox.v1.CubeboxMgr.CleanupOrphanStorageFiles:output_type -> cubelet.services.cubebox.v1.CleanupOrphanStorageFilesResponse
-	109, // [109:124] is the sub-list for method output_type
-	94,  // [94:109] is the sub-list for method input_type
-	94,  // [94:94] is the sub-list for extension type_name
-	94,  // [94:94] is the sub-list for extension extendee
-	0,   // [0:94] is the sub-list for field type_name
+	12,  // 65: cubelet.services.cubebox.v1.Container.volume_mounts:type_name -> cubelet.services.cubebox.v1.VolumeMounts
+	5,   // 66: cubelet.services.cubebox.v1.ContainerStateValue.state:type_name -> cubelet.services.cubebox.v1.ContainerState
+	52,  // 67: cubelet.services.cubebox.v1.CubeSandboxFilter.state:type_name -> cubelet.services.cubebox.v1.ContainerStateValue
+	98,  // 68: cubelet.services.cubebox.v1.CubeSandboxFilter.label_selector:type_name -> cubelet.services.cubebox.v1.CubeSandboxFilter.LabelSelectorEntry
+	53,  // 69: cubelet.services.cubebox.v1.ListCubeSandboxRequest.filter:type_name -> cubelet.services.cubebox.v1.CubeSandboxFilter
+	59,  // 70: cubelet.services.cubebox.v1.ListCubeSandboxRequest.option:type_name -> cubelet.services.cubebox.v1.ListCubeSandboxOption
+	50,  // 71: cubelet.services.cubebox.v1.ListCubeSandboxResponse.items:type_name -> cubelet.services.cubebox.v1.CubeSandbox
+	99,  // 72: cubelet.services.cubebox.v1.UpdateCubeSandboxRequest.annotations:type_name -> cubelet.services.cubebox.v1.UpdateCubeSandboxRequest.AnnotationsEntry
+	103, // 73: cubelet.services.cubebox.v1.UpdateCubeSandboxResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
+	103, // 74: cubelet.services.cubebox.v1.ExecCubeSandboxResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
+	40,  // 75: cubelet.services.cubebox.v1.AppSnapshotRequest.create_request:type_name -> cubelet.services.cubebox.v1.RunCubeSandboxRequest
+	103, // 76: cubelet.services.cubebox.v1.AppSnapshotResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
+	103, // 77: cubelet.services.cubebox.v1.CommitSandboxResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
+	103, // 78: cubelet.services.cubebox.v1.RollbackSandboxResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
+	68,  // 79: cubelet.services.cubebox.v1.CleanupTemplateRequest.objects:type_name -> cubelet.services.cubebox.v1.CowObjectRef
+	103, // 80: cubelet.services.cubebox.v1.CleanupTemplateResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
+	68,  // 81: cubelet.services.cubebox.v1.ListSandboxSnapshotsRequest.objects:type_name -> cubelet.services.cubebox.v1.CowObjectRef
+	103, // 82: cubelet.services.cubebox.v1.ListSandboxSnapshotsResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
+	72,  // 83: cubelet.services.cubebox.v1.ListSandboxSnapshotsResponse.objects:type_name -> cubelet.services.cubebox.v1.CowObjectStatus
+	103, // 84: cubelet.services.cubebox.v1.ListLocalSnapshotsResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
+	75,  // 85: cubelet.services.cubebox.v1.ListLocalSnapshotsResponse.snapshots:type_name -> cubelet.services.cubebox.v1.LocalSnapshotInfo
+	103, // 86: cubelet.services.cubebox.v1.GetLocalSnapshotResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
+	75,  // 87: cubelet.services.cubebox.v1.GetLocalSnapshotResponse.snapshot:type_name -> cubelet.services.cubebox.v1.LocalSnapshotInfo
+	103, // 88: cubelet.services.cubebox.v1.GetStorageMetricsResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
+	100, // 89: cubelet.services.cubebox.v1.GetStorageMetricsResponse.metrics:type_name -> cubelet.services.cubebox.v1.GetStorageMetricsResponse.MetricsEntry
+	81,  // 90: cubelet.services.cubebox.v1.SandboxStorageInfo.volumes:type_name -> cubelet.services.cubebox.v1.StorageVolumeInfo
+	103, // 91: cubelet.services.cubebox.v1.InspectStorageVolumesResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
+	82,  // 92: cubelet.services.cubebox.v1.InspectStorageVolumesResponse.sandboxes:type_name -> cubelet.services.cubebox.v1.SandboxStorageInfo
+	103, // 93: cubelet.services.cubebox.v1.CleanupOrphanStorageFilesResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
+	86,  // 94: cubelet.services.cubebox.v1.CleanupOrphanStorageFilesResponse.orphans:type_name -> cubelet.services.cubebox.v1.StorageOrphanEntry
+	40,  // 95: cubelet.services.cubebox.v1.CubeboxMgr.Create:input_type -> cubelet.services.cubebox.v1.RunCubeSandboxRequest
+	48,  // 96: cubelet.services.cubebox.v1.CubeboxMgr.Destroy:input_type -> cubelet.services.cubebox.v1.DestroyCubeSandboxRequest
+	54,  // 97: cubelet.services.cubebox.v1.CubeboxMgr.List:input_type -> cubelet.services.cubebox.v1.ListCubeSandboxRequest
+	56,  // 98: cubelet.services.cubebox.v1.CubeboxMgr.Update:input_type -> cubelet.services.cubebox.v1.UpdateCubeSandboxRequest
+	60,  // 99: cubelet.services.cubebox.v1.CubeboxMgr.Exec:input_type -> cubelet.services.cubebox.v1.ExecCubeSandboxRequest
+	62,  // 100: cubelet.services.cubebox.v1.CubeboxMgr.AppSnapshot:input_type -> cubelet.services.cubebox.v1.AppSnapshotRequest
+	64,  // 101: cubelet.services.cubebox.v1.CubeboxMgr.CommitSandbox:input_type -> cubelet.services.cubebox.v1.CommitSandboxRequest
+	66,  // 102: cubelet.services.cubebox.v1.CubeboxMgr.RollbackSandbox:input_type -> cubelet.services.cubebox.v1.RollbackSandboxRequest
+	69,  // 103: cubelet.services.cubebox.v1.CubeboxMgr.CleanupTemplate:input_type -> cubelet.services.cubebox.v1.CleanupTemplateRequest
+	71,  // 104: cubelet.services.cubebox.v1.CubeboxMgr.ListSandboxSnapshots:input_type -> cubelet.services.cubebox.v1.ListSandboxSnapshotsRequest
+	74,  // 105: cubelet.services.cubebox.v1.CubeboxMgr.ListLocalSnapshots:input_type -> cubelet.services.cubebox.v1.ListLocalSnapshotsRequest
+	77,  // 106: cubelet.services.cubebox.v1.CubeboxMgr.GetLocalSnapshot:input_type -> cubelet.services.cubebox.v1.GetLocalSnapshotRequest
+	79,  // 107: cubelet.services.cubebox.v1.CubeboxMgr.GetStorageMetrics:input_type -> cubelet.services.cubebox.v1.GetStorageMetricsRequest
+	83,  // 108: cubelet.services.cubebox.v1.CubeboxMgr.InspectStorageVolumes:input_type -> cubelet.services.cubebox.v1.InspectStorageVolumesRequest
+	85,  // 109: cubelet.services.cubebox.v1.CubeboxMgr.CleanupOrphanStorageFiles:input_type -> cubelet.services.cubebox.v1.CleanupOrphanStorageFilesRequest
+	41,  // 110: cubelet.services.cubebox.v1.CubeboxMgr.Create:output_type -> cubelet.services.cubebox.v1.RunCubeSandboxResponse
+	49,  // 111: cubelet.services.cubebox.v1.CubeboxMgr.Destroy:output_type -> cubelet.services.cubebox.v1.DestroyCubeSandboxResponse
+	55,  // 112: cubelet.services.cubebox.v1.CubeboxMgr.List:output_type -> cubelet.services.cubebox.v1.ListCubeSandboxResponse
+	57,  // 113: cubelet.services.cubebox.v1.CubeboxMgr.Update:output_type -> cubelet.services.cubebox.v1.UpdateCubeSandboxResponse
+	61,  // 114: cubelet.services.cubebox.v1.CubeboxMgr.Exec:output_type -> cubelet.services.cubebox.v1.ExecCubeSandboxResponse
+	63,  // 115: cubelet.services.cubebox.v1.CubeboxMgr.AppSnapshot:output_type -> cubelet.services.cubebox.v1.AppSnapshotResponse
+	65,  // 116: cubelet.services.cubebox.v1.CubeboxMgr.CommitSandbox:output_type -> cubelet.services.cubebox.v1.CommitSandboxResponse
+	67,  // 117: cubelet.services.cubebox.v1.CubeboxMgr.RollbackSandbox:output_type -> cubelet.services.cubebox.v1.RollbackSandboxResponse
+	70,  // 118: cubelet.services.cubebox.v1.CubeboxMgr.CleanupTemplate:output_type -> cubelet.services.cubebox.v1.CleanupTemplateResponse
+	73,  // 119: cubelet.services.cubebox.v1.CubeboxMgr.ListSandboxSnapshots:output_type -> cubelet.services.cubebox.v1.ListSandboxSnapshotsResponse
+	76,  // 120: cubelet.services.cubebox.v1.CubeboxMgr.ListLocalSnapshots:output_type -> cubelet.services.cubebox.v1.ListLocalSnapshotsResponse
+	78,  // 121: cubelet.services.cubebox.v1.CubeboxMgr.GetLocalSnapshot:output_type -> cubelet.services.cubebox.v1.GetLocalSnapshotResponse
+	80,  // 122: cubelet.services.cubebox.v1.CubeboxMgr.GetStorageMetrics:output_type -> cubelet.services.cubebox.v1.GetStorageMetricsResponse
+	84,  // 123: cubelet.services.cubebox.v1.CubeboxMgr.InspectStorageVolumes:output_type -> cubelet.services.cubebox.v1.InspectStorageVolumesResponse
+	87,  // 124: cubelet.services.cubebox.v1.CubeboxMgr.CleanupOrphanStorageFiles:output_type -> cubelet.services.cubebox.v1.CleanupOrphanStorageFilesResponse
+	110, // [110:125] is the sub-list for method output_type
+	95,  // [95:110] is the sub-list for method input_type
+	95,  // [95:95] is the sub-list for extension type_name
+	95,  // [95:95] is the sub-list for extension extendee
+	0,   // [0:95] is the sub-list for field type_name
 }
 
 func init() { file_api_services_cubebox_v1_cubebox_proto_init() }

--- a/CubeMaster/api/services/cubebox/v1/cubebox.proto
+++ b/CubeMaster/api/services/cubebox/v1/cubebox.proto
@@ -697,6 +697,8 @@ message Container {
   int64 finished_at = 7;
   map<string, string> labels = 8;
   int64 paused_at = 9;
+  // Mounts declared on the container spec (including host-dir mounts).
+  repeated VolumeMounts volume_mounts = 10;
 }
 
 // ContainerState represents the lifecycle state of a container.

--- a/CubeMaster/cmd/cubemastercli/commands/cubebox/info.go
+++ b/CubeMaster/cmd/cubemastercli/commands/cubebox/info.go
@@ -124,6 +124,17 @@ func printSandboxInfoBlock(w *tabwriter.Writer, sb *types.SandboxData) {
 	fmt.Fprintf(w, "NAMESPACE\t%s\n", displayValue(sb.NameSpace))
 	fmt.Fprintf(w, "ANNOTATIONS\t%s\n", displayValue(utils.InterfaceToString(sb.Annotations)))
 	fmt.Fprintf(w, "LABELS\t%s\n", displayValue(utils.InterfaceToString(sb.Labels)))
+	if len(sb.VolumeMounts) > 0 {
+		fmt.Fprintln(w, "VOLUME_MOUNTS")
+		fmt.Fprintln(w, "NAME\tCONTAINER_PATH\tREAD_ONLY")
+		for _, mount := range sb.VolumeMounts {
+			fmt.Fprintf(w, "%s\t%s\t%t\n",
+				displayValue(mount.Name),
+				displayValue(mount.ContainerPath),
+				mount.Readonly,
+			)
+		}
+	}
 	if sb.ExposedPortEndpoint != "" {
 		fmt.Fprintf(w, "EXPOSED_PORT_MODE\t%s\n", displayValue(sb.ExposedPortMode))
 		fmt.Fprintf(w, "EXPOSED_ENDPOINT\t%s\n", displayValue(sb.ExposedPortEndpoint))

--- a/CubeMaster/cmd/cubemastercli/commands/cubebox/list_info_test.go
+++ b/CubeMaster/cmd/cubemastercli/commands/cubebox/list_info_test.go
@@ -138,6 +138,32 @@ func TestParseListFiltersSkipsInvalidEntries(t *testing.T) {
 	}
 }
 
+func TestPrintSandboxInfoBlockIncludesVolumeMounts(t *testing.T) {
+	var buf bytes.Buffer
+	w := tabwriter.NewWriter(&buf, 4, 8, 4, ' ', 0)
+	printSandboxInfoBlock(w, &types.SandboxData{
+		SandboxID: "sb-1",
+		VolumeMounts: []*types.VolumeMountInfo{{
+			Name:          "hostdir-0",
+			ContainerPath: "/mnt/data",
+			Readonly:      true,
+		}},
+	})
+	if err := w.Flush(); err != nil {
+		t.Fatalf("flush writer error=%v", err)
+	}
+
+	output := buf.String()
+	for _, want := range []string{"VOLUME_MOUNTS", "hostdir-0", "/mnt/data", "true"} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("output=%q, missing %q", output, want)
+		}
+	}
+	if strings.Contains(output, "HOST_PATH") || strings.Contains(output, "/tmp/data") {
+		t.Fatalf("output=%q unexpectedly includes hostPath", output)
+	}
+}
+
 func TestPrintSandboxInfoBlockIncludesMetadata(t *testing.T) {
 	var buf bytes.Buffer
 	w := tabwriter.NewWriter(&buf, 4, 8, 4, ' ', 0)

--- a/CubeMaster/pkg/service/sandbox/hostdir_mount.go
+++ b/CubeMaster/pkg/service/sandbox/hostdir_mount.go
@@ -97,6 +97,7 @@ func injectHostDirMounts(ctx context.Context, req *types.CreateCubeSandboxReq) e
 		vm = append(vm, &cubeboxv1.VolumeMounts{
 			Name:          name,
 			ContainerPath: o.MountPath,
+			HostPath:      o.HostPath,
 			Readonly:      o.ReadOnly,
 		})
 		log.G(ctx).Infof("[hostdir] injected VolumeMount %q containerPath=%s readOnly=%v", name, o.MountPath, o.ReadOnly)

--- a/CubeMaster/pkg/service/sandbox/hostdir_mount_test.go
+++ b/CubeMaster/pkg/service/sandbox/hostdir_mount_test.go
@@ -210,3 +210,26 @@ func TestValidateHostPath(t *testing.T) {
 		})
 	}
 }
+
+func TestInjectHostDirMountsSetsHostPathOnVolumeMount(t *testing.T) {
+	req := &types.CreateCubeSandboxReq{
+		Annotations: map[string]string{
+			AnnotationHostDirMount: `[{"hostPath":"/data/shared/data","mountPath":"/mnt/data","readOnly":true}]`,
+		},
+		Containers: []*types.Container{{Name: "work"}},
+	}
+
+	if err := injectHostDirMounts(context.Background(), req); err != nil {
+		t.Fatalf("injectHostDirMounts() error=%v", err)
+	}
+	if len(req.Containers[0].VolumeMounts) != 1 {
+		t.Fatalf("volume mount count=%d want 1", len(req.Containers[0].VolumeMounts))
+	}
+	mount := req.Containers[0].VolumeMounts[0]
+	if mount.GetHostPath() != "/data/shared/data" {
+		t.Fatalf("HostPath=%q want /data/shared/data", mount.GetHostPath())
+	}
+	if mount.GetContainerPath() != "/mnt/data" || !mount.GetReadonly() {
+		t.Fatalf("unexpected mount: %+v", mount)
+	}
+}

--- a/CubeMaster/pkg/service/sandbox/sandbox_info.go
+++ b/CubeMaster/pkg/service/sandbox/sandbox_info.go
@@ -179,6 +179,7 @@ func doget(ctx context.Context, calleep string, cubeletReq *cubebox.ListCubeSand
 		one.Annotations = buildAnnotationsFromLabels(sandboxLabels)
 		one.Labels = sandboxLabels
 		one.EndAt = LookupSandboxEndAt(ctx, sandbox.GetId())
+		one.VolumeMounts = volumeMountsToContainerInfo(collectVolumeMountsFromContainers(sandbox.GetContainers()))
 		rsp.Data = append(rsp.Data, one)
 	}
 	return nil

--- a/CubeMaster/pkg/service/sandbox/sandbox_list.go
+++ b/CubeMaster/pkg/service/sandbox/sandbox_list.go
@@ -203,6 +203,8 @@ func doOneList(ctx context.Context, req *types.ListCubeSandboxReq, tmpNode *node
 					CreateAt:    sandbox.GetCreatedAt(),
 					PauseAt:     container.GetPausedAt(),
 					EndAt:       LookupSandboxEndAt(ctx, sandbox.GetId()),
+					VolumeMounts: volumeMountsToContainerInfo(
+						collectVolumeMountsFromContainers(sandbox.GetContainers())),
 				}:
 				}
 				break

--- a/CubeMaster/pkg/service/sandbox/types/types.go
+++ b/CubeMaster/pkg/service/sandbox/types/types.go
@@ -539,19 +539,20 @@ type ListCubeSandboxRes struct {
 }
 
 type SandboxBriefData struct {
-	SandboxID   string            `json:"sandbox_id,omitempty"`
-	Status      int32             `json:"status,omitempty"`
-	HostID      string            `json:"host_id,omitempty"`
-	HostIP      string            `json:"host_ip,omitempty"`
-	TemplateID  string            `json:"template_id,omitempty"`
-	CpuCount    int32             `json:"cpu_count,omitempty"`
-	MemoryMB    int32             `json:"memory_mb,omitempty"`
-	Annotations map[string]string `json:"annotations,omitempty"`
-	Labels      map[string]string `json:"labels,omitempty"`
-	NameSpace   string            `json:"namespace,omitempty"`
-	CreateAt    int64             `json:"create_at,omitempty"`
-	PauseAt     int64             `json:"pause_at,omitempty"`
-	EndAt       int64             `json:"end_at,omitempty"`
+	SandboxID    string             `json:"sandbox_id,omitempty"`
+	Status       int32              `json:"status,omitempty"`
+	HostID       string             `json:"host_id,omitempty"`
+	HostIP       string             `json:"host_ip,omitempty"`
+	TemplateID   string             `json:"template_id,omitempty"`
+	CpuCount     int32              `json:"cpu_count,omitempty"`
+	MemoryMB     int32              `json:"memory_mb,omitempty"`
+	Annotations  map[string]string  `json:"annotations,omitempty"`
+	Labels       map[string]string  `json:"labels,omitempty"`
+	NameSpace    string             `json:"namespace,omitempty"`
+	CreateAt     int64              `json:"create_at,omitempty"`
+	PauseAt      int64              `json:"pause_at,omitempty"`
+	EndAt        int64              `json:"end_at,omitempty"`
+	VolumeMounts []*VolumeMountInfo `json:"volume_mounts,omitempty"`
 }
 
 type GetCubeSandboxReq struct {
@@ -569,20 +570,28 @@ type GetCubeSandboxRes struct {
 }
 
 type SandboxData struct {
-	SandboxID              string            `json:"sandbox_id,omitempty"`
-	Status                 int32             `json:"status,omitempty"`
-	HostID                 string            `json:"host_id,omitempty"`
-	HostIP                 string            `json:"host_ip,omitempty"`
-	SandboxIP              string            `json:"sandbox_ip,omitempty"`
-	TemplateID             string            `json:"template_id,omitempty"`
-	Annotations            map[string]string `json:"annotations,omitempty"`
-	Labels                 map[string]string `json:"labels,omitempty"`
-	Containers             []*ContainerInfo  `json:"containers,omitempty"`
-	NameSpace              string            `json:"namespace,omitempty"`
-	ExposedPortEndpoint    string            `json:"exposed_port_endpoint,omitempty"`
-	ExposedPortMode        string            `json:"exposed_port_mode,omitempty"`
-	RequestedContainerPort int32             `json:"requested_container_port,omitempty"`
-	EndAt                  int64             `json:"end_at,omitempty"`
+	SandboxID              string             `json:"sandbox_id,omitempty"`
+	Status                 int32              `json:"status,omitempty"`
+	HostID                 string             `json:"host_id,omitempty"`
+	HostIP                 string             `json:"host_ip,omitempty"`
+	SandboxIP              string             `json:"sandbox_ip,omitempty"`
+	TemplateID             string             `json:"template_id,omitempty"`
+	Annotations            map[string]string  `json:"annotations,omitempty"`
+	Labels                 map[string]string  `json:"labels,omitempty"`
+	Containers             []*ContainerInfo   `json:"containers,omitempty"`
+	NameSpace              string             `json:"namespace,omitempty"`
+	ExposedPortEndpoint    string             `json:"exposed_port_endpoint,omitempty"`
+	ExposedPortMode        string             `json:"exposed_port_mode,omitempty"`
+	RequestedContainerPort int32              `json:"requested_container_port,omitempty"`
+	EndAt                  int64              `json:"end_at,omitempty"`
+	VolumeMounts           []*VolumeMountInfo `json:"volume_mounts,omitempty"`
+}
+
+// VolumeMountInfo is one container volume mount exposed in sandbox info/list APIs.
+type VolumeMountInfo struct {
+	Name          string `json:"name,omitempty"`
+	ContainerPath string `json:"container_path,omitempty"`
+	Readonly      bool   `json:"readonly,omitempty"`
 }
 
 type ContainerInfo struct {

--- a/CubeMaster/pkg/service/sandbox/volume_mounts.go
+++ b/CubeMaster/pkg/service/sandbox/volume_mounts.go
@@ -1,0 +1,87 @@
+// Copyright (c) 2024 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package sandbox
+
+import (
+	"strconv"
+	"strings"
+
+	cubeboxv1 "github.com/tencentcloud/CubeSandbox/CubeMaster/api/services/cubebox/v1"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/service/sandbox/types"
+)
+
+// collectVolumeMountsFromContainers gathers mounts from every reported
+// container. Template sandboxes often only have a type=sandbox container, and
+// hostdir mounts are injected onto that container as well.
+func collectVolumeMountsFromContainers(containers []*cubeboxv1.Container) []*cubeboxv1.VolumeMounts {
+	if len(containers) == 0 {
+		return nil
+	}
+	out := make([]*cubeboxv1.VolumeMounts, 0)
+	for _, container := range containers {
+		if container == nil {
+			continue
+		}
+		for _, mount := range container.GetVolumeMounts() {
+			if mount == nil {
+				continue
+			}
+			out = append(out, mount)
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// isInternalRootfsMount reports mounts that are Cube runtime plumbing
+// (writable rootfs at "/") and must not appear on public info/list.
+func isInternalRootfsMount(mount *cubeboxv1.VolumeMounts) bool {
+	if mount == nil {
+		return false
+	}
+	if mount.GetContainerPath() == "/" {
+		return true
+	}
+	return strings.HasPrefix(mount.GetName(), "cube_rootfs_")
+}
+
+// volumeMountsToContainerInfo converts cubelet mounts into API-facing JSON structs.
+// HostPath is intentionally omitted: node-local paths are not part of the public
+// sandbox info/list contract.
+func volumeMountsToContainerInfo(mounts []*cubeboxv1.VolumeMounts) []*types.VolumeMountInfo {
+	if len(mounts) == 0 {
+		return nil
+	}
+	out := make([]*types.VolumeMountInfo, 0, len(mounts))
+	// Hostdir mounts can be injected into multiple containers; dedupe by the
+	// public mount identity so info/list does not repeat the same entry.
+	// Caveat: this key is intentional for hostdir (identical copies across
+	// containers). Other mount types that share name/path/readonly but differ
+	// elsewhere would also collapse — keep hostdir-oriented.
+	seen := make(map[string]struct{}, len(mounts))
+	for _, mount := range mounts {
+		if mount == nil || isInternalRootfsMount(mount) {
+			continue
+		}
+		key := mount.GetName() + "\x1f" +
+			mount.GetContainerPath() + "\x1f" +
+			strconv.FormatBool(mount.GetReadonly())
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, &types.VolumeMountInfo{
+			Name:          mount.GetName(),
+			ContainerPath: mount.GetContainerPath(),
+			Readonly:      mount.GetReadonly(),
+		})
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}

--- a/CubeMaster/pkg/service/sandbox/volume_mounts_test.go
+++ b/CubeMaster/pkg/service/sandbox/volume_mounts_test.go
@@ -1,0 +1,115 @@
+// Copyright (c) 2024 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package sandbox
+
+import (
+	"testing"
+
+	cubeboxv1 "github.com/tencentcloud/CubeSandbox/CubeMaster/api/services/cubebox/v1"
+)
+
+func TestCollectVolumeMountsFromContainersIncludesSandboxOnly(t *testing.T) {
+	containers := []*cubeboxv1.Container{
+		{
+			Type: "sandbox",
+			VolumeMounts: []*cubeboxv1.VolumeMounts{{
+				Name:          "hostdir-0",
+				ContainerPath: "/mnt/data",
+				HostPath:      "/tmp/data",
+				Readonly:      true,
+			}},
+		},
+	}
+
+	got := collectVolumeMountsFromContainers(containers)
+	if len(got) != 1 {
+		t.Fatalf("collectVolumeMountsFromContainers() len=%d want 1", len(got))
+	}
+	if got[0].GetName() != "hostdir-0" || got[0].GetContainerPath() != "/mnt/data" {
+		t.Fatalf("unexpected mount: %+v", got[0])
+	}
+}
+
+func TestCollectVolumeMountsFromContainersDedupsAcrossTypes(t *testing.T) {
+	mount := &cubeboxv1.VolumeMounts{
+		Name:          "hostdir-0",
+		ContainerPath: "/mnt/data",
+		HostPath:      "/tmp/data",
+		Readonly:      true,
+	}
+	containers := []*cubeboxv1.Container{
+		{Type: "sandbox", VolumeMounts: []*cubeboxv1.VolumeMounts{mount}},
+		{Type: "container", VolumeMounts: []*cubeboxv1.VolumeMounts{mount}},
+	}
+
+	got := volumeMountsToContainerInfo(collectVolumeMountsFromContainers(containers))
+	if len(got) != 1 {
+		t.Fatalf("deduped mounts len=%d want 1", len(got))
+	}
+	if !got[0].Readonly || got[0].ContainerPath != "/mnt/data" || got[0].Name != "hostdir-0" {
+		t.Fatalf("unexpected mount info: %+v", got[0])
+	}
+}
+
+func TestCollectVolumeMountsFromContainersSkipsNilContainer(t *testing.T) {
+	containers := []*cubeboxv1.Container{
+		nil,
+		{
+			Type: "container",
+			VolumeMounts: []*cubeboxv1.VolumeMounts{{
+				Name:          "hostdir-0",
+				ContainerPath: "/mnt/data",
+			}},
+		},
+	}
+
+	got := collectVolumeMountsFromContainers(containers)
+	if len(got) != 1 || got[0].GetName() != "hostdir-0" {
+		t.Fatalf("collectVolumeMountsFromContainers()=%#v", got)
+	}
+}
+
+func TestVolumeMountsToContainerInfoOmitsEmpty(t *testing.T) {
+	if got := volumeMountsToContainerInfo(nil); got != nil {
+		t.Fatalf("volumeMountsToContainerInfo(nil)=%v want nil", got)
+	}
+	if got := volumeMountsToContainerInfo([]*cubeboxv1.VolumeMounts{nil}); got != nil {
+		t.Fatalf("volumeMountsToContainerInfo([nil])=%v want nil", got)
+	}
+}
+
+func TestVolumeMountsToContainerInfoFiltersInternalRootfs(t *testing.T) {
+	got := volumeMountsToContainerInfo([]*cubeboxv1.VolumeMounts{
+		{
+			Name:          "cube_rootfs_rw",
+			ContainerPath: "/",
+		},
+		{
+			Name:          "hostdir-0",
+			ContainerPath: "/mnt/rw",
+		},
+		{
+			Name:          "hostdir-1",
+			ContainerPath: "/mnt/ro",
+			Readonly:      true,
+		},
+	})
+	if len(got) != 2 {
+		t.Fatalf("len=%d want 2 (rootfs filtered): %+v", len(got), got)
+	}
+	if got[0].Name != "hostdir-0" || got[1].Name != "hostdir-1" {
+		t.Fatalf("unexpected mounts: %+v", got)
+	}
+}
+
+func TestVolumeMountsToContainerInfoFiltersRootPathEvenWithoutRootfsName(t *testing.T) {
+	got := volumeMountsToContainerInfo([]*cubeboxv1.VolumeMounts{
+		{Name: "other", ContainerPath: "/"},
+		{Name: "hostdir-0", ContainerPath: "/mnt/data"},
+	})
+	if len(got) != 1 || got[0].ContainerPath != "/mnt/data" {
+		t.Fatalf("got=%+v want only /mnt/data", got)
+	}
+}

--- a/Cubelet/api/services/cubebox/v1/cubebox.pb.go
+++ b/Cubelet/api/services/cubebox/v1/cubebox.pb.go
@@ -3569,9 +3569,11 @@ type Container struct {
 	// Creation time of the container in nanoseconds.
 	CreatedAt int64 `protobuf:"varint,6,opt,name=created_at,json=createdAt,proto3" json:"created_at,omitempty"`
 	// exit time of the container in nanoseconds.
-	FinishedAt    int64             `protobuf:"varint,7,opt,name=finished_at,json=finishedAt,proto3" json:"finished_at,omitempty"`
-	Labels        map[string]string `protobuf:"bytes,8,rep,name=labels,proto3" json:"labels,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
-	PausedAt      int64             `protobuf:"varint,9,opt,name=paused_at,json=pausedAt,proto3" json:"paused_at,omitempty"`
+	FinishedAt int64             `protobuf:"varint,7,opt,name=finished_at,json=finishedAt,proto3" json:"finished_at,omitempty"`
+	Labels     map[string]string `protobuf:"bytes,8,rep,name=labels,proto3" json:"labels,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	PausedAt   int64             `protobuf:"varint,9,opt,name=paused_at,json=pausedAt,proto3" json:"paused_at,omitempty"`
+	// Mounts declared on the container spec (including host-dir mounts).
+	VolumeMounts  []*VolumeMounts `protobuf:"bytes,10,rep,name=volume_mounts,json=volumeMounts,proto3" json:"volume_mounts,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -3667,6 +3669,13 @@ func (x *Container) GetPausedAt() int64 {
 		return x.PausedAt
 	}
 	return 0
+}
+
+func (x *Container) GetVolumeMounts() []*VolumeMounts {
+	if x != nil {
+		return x.VolumeMounts
+	}
+	return nil
 }
 
 // ContainerStateValue is the wrapper of ContainerState.
@@ -6763,7 +6772,7 @@ const file_api_services_cubebox_v1_cubebox_proto_rawDesc = "" +
 	"\x1cprivate_cubebox_storage_data\x18\t \x01(\fR\x19privateCubeboxStorageData\x1a9\n" +
 	"\vLabelsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\xb1\x03\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\x81\x04\n" +
 	"\tContainer\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x14\n" +
 	"\x05image\x18\x02 \x01(\tR\x05image\x12\x12\n" +
@@ -6775,7 +6784,9 @@ const file_api_services_cubebox_v1_cubebox_proto_rawDesc = "" +
 	"\vfinished_at\x18\a \x01(\x03R\n" +
 	"finishedAt\x12J\n" +
 	"\x06labels\x18\b \x03(\v22.cubelet.services.cubebox.v1.Container.LabelsEntryR\x06labels\x12\x1b\n" +
-	"\tpaused_at\x18\t \x01(\x03R\bpausedAt\x1a9\n" +
+	"\tpaused_at\x18\t \x01(\x03R\bpausedAt\x12N\n" +
+	"\rvolume_mounts\x18\n" +
+	" \x03(\v2).cubelet.services.cubebox.v1.VolumeMountsR\fvolumeMounts\x1a9\n" +
 	"\vLabelsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"X\n" +
@@ -7266,70 +7277,71 @@ var file_api_services_cubebox_v1_cubebox_proto_depIdxs = []int32{
 	32,  // 61: cubelet.services.cubebox.v1.Container.resources:type_name -> cubelet.services.cubebox.v1.Resource
 	5,   // 62: cubelet.services.cubebox.v1.Container.state:type_name -> cubelet.services.cubebox.v1.ContainerState
 	95,  // 63: cubelet.services.cubebox.v1.Container.labels:type_name -> cubelet.services.cubebox.v1.Container.LabelsEntry
-	5,   // 64: cubelet.services.cubebox.v1.ContainerStateValue.state:type_name -> cubelet.services.cubebox.v1.ContainerState
-	51,  // 65: cubelet.services.cubebox.v1.CubeSandboxFilter.state:type_name -> cubelet.services.cubebox.v1.ContainerStateValue
-	96,  // 66: cubelet.services.cubebox.v1.CubeSandboxFilter.label_selector:type_name -> cubelet.services.cubebox.v1.CubeSandboxFilter.LabelSelectorEntry
-	52,  // 67: cubelet.services.cubebox.v1.ListCubeSandboxRequest.filter:type_name -> cubelet.services.cubebox.v1.CubeSandboxFilter
-	58,  // 68: cubelet.services.cubebox.v1.ListCubeSandboxRequest.option:type_name -> cubelet.services.cubebox.v1.ListCubeSandboxOption
-	49,  // 69: cubelet.services.cubebox.v1.ListCubeSandboxResponse.items:type_name -> cubelet.services.cubebox.v1.CubeSandbox
-	97,  // 70: cubelet.services.cubebox.v1.UpdateCubeSandboxRequest.annotations:type_name -> cubelet.services.cubebox.v1.UpdateCubeSandboxRequest.AnnotationsEntry
-	102, // 71: cubelet.services.cubebox.v1.UpdateCubeSandboxResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
-	102, // 72: cubelet.services.cubebox.v1.ExecCubeSandboxResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
-	39,  // 73: cubelet.services.cubebox.v1.AppSnapshotRequest.create_request:type_name -> cubelet.services.cubebox.v1.RunCubeSandboxRequest
-	102, // 74: cubelet.services.cubebox.v1.AppSnapshotResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
-	102, // 75: cubelet.services.cubebox.v1.CommitSandboxResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
-	102, // 76: cubelet.services.cubebox.v1.RollbackSandboxResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
-	67,  // 77: cubelet.services.cubebox.v1.CleanupTemplateRequest.objects:type_name -> cubelet.services.cubebox.v1.CowObjectRef
-	102, // 78: cubelet.services.cubebox.v1.CleanupTemplateResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
-	67,  // 79: cubelet.services.cubebox.v1.ListSandboxSnapshotsRequest.objects:type_name -> cubelet.services.cubebox.v1.CowObjectRef
-	102, // 80: cubelet.services.cubebox.v1.ListSandboxSnapshotsResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
-	71,  // 81: cubelet.services.cubebox.v1.ListSandboxSnapshotsResponse.objects:type_name -> cubelet.services.cubebox.v1.CowObjectStatus
-	102, // 82: cubelet.services.cubebox.v1.ListLocalSnapshotsResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
-	74,  // 83: cubelet.services.cubebox.v1.ListLocalSnapshotsResponse.snapshots:type_name -> cubelet.services.cubebox.v1.LocalSnapshotInfo
-	102, // 84: cubelet.services.cubebox.v1.GetLocalSnapshotResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
-	74,  // 85: cubelet.services.cubebox.v1.GetLocalSnapshotResponse.snapshot:type_name -> cubelet.services.cubebox.v1.LocalSnapshotInfo
-	102, // 86: cubelet.services.cubebox.v1.GetStorageMetricsResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
-	98,  // 87: cubelet.services.cubebox.v1.GetStorageMetricsResponse.metrics:type_name -> cubelet.services.cubebox.v1.GetStorageMetricsResponse.MetricsEntry
-	80,  // 88: cubelet.services.cubebox.v1.SandboxStorageInfo.volumes:type_name -> cubelet.services.cubebox.v1.StorageVolumeInfo
-	102, // 89: cubelet.services.cubebox.v1.InspectStorageVolumesResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
-	81,  // 90: cubelet.services.cubebox.v1.InspectStorageVolumesResponse.sandboxes:type_name -> cubelet.services.cubebox.v1.SandboxStorageInfo
-	102, // 91: cubelet.services.cubebox.v1.CleanupOrphanStorageFilesResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
-	85,  // 92: cubelet.services.cubebox.v1.CleanupOrphanStorageFilesResponse.orphans:type_name -> cubelet.services.cubebox.v1.StorageOrphanEntry
-	39,  // 93: cubelet.services.cubebox.v1.CubeboxMgr.Create:input_type -> cubelet.services.cubebox.v1.RunCubeSandboxRequest
-	47,  // 94: cubelet.services.cubebox.v1.CubeboxMgr.Destroy:input_type -> cubelet.services.cubebox.v1.DestroyCubeSandboxRequest
-	53,  // 95: cubelet.services.cubebox.v1.CubeboxMgr.List:input_type -> cubelet.services.cubebox.v1.ListCubeSandboxRequest
-	55,  // 96: cubelet.services.cubebox.v1.CubeboxMgr.Update:input_type -> cubelet.services.cubebox.v1.UpdateCubeSandboxRequest
-	59,  // 97: cubelet.services.cubebox.v1.CubeboxMgr.Exec:input_type -> cubelet.services.cubebox.v1.ExecCubeSandboxRequest
-	61,  // 98: cubelet.services.cubebox.v1.CubeboxMgr.AppSnapshot:input_type -> cubelet.services.cubebox.v1.AppSnapshotRequest
-	63,  // 99: cubelet.services.cubebox.v1.CubeboxMgr.CommitSandbox:input_type -> cubelet.services.cubebox.v1.CommitSandboxRequest
-	65,  // 100: cubelet.services.cubebox.v1.CubeboxMgr.RollbackSandbox:input_type -> cubelet.services.cubebox.v1.RollbackSandboxRequest
-	68,  // 101: cubelet.services.cubebox.v1.CubeboxMgr.CleanupTemplate:input_type -> cubelet.services.cubebox.v1.CleanupTemplateRequest
-	70,  // 102: cubelet.services.cubebox.v1.CubeboxMgr.ListSandboxSnapshots:input_type -> cubelet.services.cubebox.v1.ListSandboxSnapshotsRequest
-	73,  // 103: cubelet.services.cubebox.v1.CubeboxMgr.ListLocalSnapshots:input_type -> cubelet.services.cubebox.v1.ListLocalSnapshotsRequest
-	76,  // 104: cubelet.services.cubebox.v1.CubeboxMgr.GetLocalSnapshot:input_type -> cubelet.services.cubebox.v1.GetLocalSnapshotRequest
-	78,  // 105: cubelet.services.cubebox.v1.CubeboxMgr.GetStorageMetrics:input_type -> cubelet.services.cubebox.v1.GetStorageMetricsRequest
-	82,  // 106: cubelet.services.cubebox.v1.CubeboxMgr.InspectStorageVolumes:input_type -> cubelet.services.cubebox.v1.InspectStorageVolumesRequest
-	84,  // 107: cubelet.services.cubebox.v1.CubeboxMgr.CleanupOrphanStorageFiles:input_type -> cubelet.services.cubebox.v1.CleanupOrphanStorageFilesRequest
-	40,  // 108: cubelet.services.cubebox.v1.CubeboxMgr.Create:output_type -> cubelet.services.cubebox.v1.RunCubeSandboxResponse
-	48,  // 109: cubelet.services.cubebox.v1.CubeboxMgr.Destroy:output_type -> cubelet.services.cubebox.v1.DestroyCubeSandboxResponse
-	54,  // 110: cubelet.services.cubebox.v1.CubeboxMgr.List:output_type -> cubelet.services.cubebox.v1.ListCubeSandboxResponse
-	56,  // 111: cubelet.services.cubebox.v1.CubeboxMgr.Update:output_type -> cubelet.services.cubebox.v1.UpdateCubeSandboxResponse
-	60,  // 112: cubelet.services.cubebox.v1.CubeboxMgr.Exec:output_type -> cubelet.services.cubebox.v1.ExecCubeSandboxResponse
-	62,  // 113: cubelet.services.cubebox.v1.CubeboxMgr.AppSnapshot:output_type -> cubelet.services.cubebox.v1.AppSnapshotResponse
-	64,  // 114: cubelet.services.cubebox.v1.CubeboxMgr.CommitSandbox:output_type -> cubelet.services.cubebox.v1.CommitSandboxResponse
-	66,  // 115: cubelet.services.cubebox.v1.CubeboxMgr.RollbackSandbox:output_type -> cubelet.services.cubebox.v1.RollbackSandboxResponse
-	69,  // 116: cubelet.services.cubebox.v1.CubeboxMgr.CleanupTemplate:output_type -> cubelet.services.cubebox.v1.CleanupTemplateResponse
-	72,  // 117: cubelet.services.cubebox.v1.CubeboxMgr.ListSandboxSnapshots:output_type -> cubelet.services.cubebox.v1.ListSandboxSnapshotsResponse
-	75,  // 118: cubelet.services.cubebox.v1.CubeboxMgr.ListLocalSnapshots:output_type -> cubelet.services.cubebox.v1.ListLocalSnapshotsResponse
-	77,  // 119: cubelet.services.cubebox.v1.CubeboxMgr.GetLocalSnapshot:output_type -> cubelet.services.cubebox.v1.GetLocalSnapshotResponse
-	79,  // 120: cubelet.services.cubebox.v1.CubeboxMgr.GetStorageMetrics:output_type -> cubelet.services.cubebox.v1.GetStorageMetricsResponse
-	83,  // 121: cubelet.services.cubebox.v1.CubeboxMgr.InspectStorageVolumes:output_type -> cubelet.services.cubebox.v1.InspectStorageVolumesResponse
-	86,  // 122: cubelet.services.cubebox.v1.CubeboxMgr.CleanupOrphanStorageFiles:output_type -> cubelet.services.cubebox.v1.CleanupOrphanStorageFilesResponse
-	108, // [108:123] is the sub-list for method output_type
-	93,  // [93:108] is the sub-list for method input_type
-	93,  // [93:93] is the sub-list for extension type_name
-	93,  // [93:93] is the sub-list for extension extendee
-	0,   // [0:93] is the sub-list for field type_name
+	12,  // 64: cubelet.services.cubebox.v1.Container.volume_mounts:type_name -> cubelet.services.cubebox.v1.VolumeMounts
+	5,   // 65: cubelet.services.cubebox.v1.ContainerStateValue.state:type_name -> cubelet.services.cubebox.v1.ContainerState
+	51,  // 66: cubelet.services.cubebox.v1.CubeSandboxFilter.state:type_name -> cubelet.services.cubebox.v1.ContainerStateValue
+	96,  // 67: cubelet.services.cubebox.v1.CubeSandboxFilter.label_selector:type_name -> cubelet.services.cubebox.v1.CubeSandboxFilter.LabelSelectorEntry
+	52,  // 68: cubelet.services.cubebox.v1.ListCubeSandboxRequest.filter:type_name -> cubelet.services.cubebox.v1.CubeSandboxFilter
+	58,  // 69: cubelet.services.cubebox.v1.ListCubeSandboxRequest.option:type_name -> cubelet.services.cubebox.v1.ListCubeSandboxOption
+	49,  // 70: cubelet.services.cubebox.v1.ListCubeSandboxResponse.items:type_name -> cubelet.services.cubebox.v1.CubeSandbox
+	97,  // 71: cubelet.services.cubebox.v1.UpdateCubeSandboxRequest.annotations:type_name -> cubelet.services.cubebox.v1.UpdateCubeSandboxRequest.AnnotationsEntry
+	102, // 72: cubelet.services.cubebox.v1.UpdateCubeSandboxResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
+	102, // 73: cubelet.services.cubebox.v1.ExecCubeSandboxResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
+	39,  // 74: cubelet.services.cubebox.v1.AppSnapshotRequest.create_request:type_name -> cubelet.services.cubebox.v1.RunCubeSandboxRequest
+	102, // 75: cubelet.services.cubebox.v1.AppSnapshotResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
+	102, // 76: cubelet.services.cubebox.v1.CommitSandboxResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
+	102, // 77: cubelet.services.cubebox.v1.RollbackSandboxResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
+	67,  // 78: cubelet.services.cubebox.v1.CleanupTemplateRequest.objects:type_name -> cubelet.services.cubebox.v1.CowObjectRef
+	102, // 79: cubelet.services.cubebox.v1.CleanupTemplateResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
+	67,  // 80: cubelet.services.cubebox.v1.ListSandboxSnapshotsRequest.objects:type_name -> cubelet.services.cubebox.v1.CowObjectRef
+	102, // 81: cubelet.services.cubebox.v1.ListSandboxSnapshotsResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
+	71,  // 82: cubelet.services.cubebox.v1.ListSandboxSnapshotsResponse.objects:type_name -> cubelet.services.cubebox.v1.CowObjectStatus
+	102, // 83: cubelet.services.cubebox.v1.ListLocalSnapshotsResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
+	74,  // 84: cubelet.services.cubebox.v1.ListLocalSnapshotsResponse.snapshots:type_name -> cubelet.services.cubebox.v1.LocalSnapshotInfo
+	102, // 85: cubelet.services.cubebox.v1.GetLocalSnapshotResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
+	74,  // 86: cubelet.services.cubebox.v1.GetLocalSnapshotResponse.snapshot:type_name -> cubelet.services.cubebox.v1.LocalSnapshotInfo
+	102, // 87: cubelet.services.cubebox.v1.GetStorageMetricsResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
+	98,  // 88: cubelet.services.cubebox.v1.GetStorageMetricsResponse.metrics:type_name -> cubelet.services.cubebox.v1.GetStorageMetricsResponse.MetricsEntry
+	80,  // 89: cubelet.services.cubebox.v1.SandboxStorageInfo.volumes:type_name -> cubelet.services.cubebox.v1.StorageVolumeInfo
+	102, // 90: cubelet.services.cubebox.v1.InspectStorageVolumesResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
+	81,  // 91: cubelet.services.cubebox.v1.InspectStorageVolumesResponse.sandboxes:type_name -> cubelet.services.cubebox.v1.SandboxStorageInfo
+	102, // 92: cubelet.services.cubebox.v1.CleanupOrphanStorageFilesResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
+	85,  // 93: cubelet.services.cubebox.v1.CleanupOrphanStorageFilesResponse.orphans:type_name -> cubelet.services.cubebox.v1.StorageOrphanEntry
+	39,  // 94: cubelet.services.cubebox.v1.CubeboxMgr.Create:input_type -> cubelet.services.cubebox.v1.RunCubeSandboxRequest
+	47,  // 95: cubelet.services.cubebox.v1.CubeboxMgr.Destroy:input_type -> cubelet.services.cubebox.v1.DestroyCubeSandboxRequest
+	53,  // 96: cubelet.services.cubebox.v1.CubeboxMgr.List:input_type -> cubelet.services.cubebox.v1.ListCubeSandboxRequest
+	55,  // 97: cubelet.services.cubebox.v1.CubeboxMgr.Update:input_type -> cubelet.services.cubebox.v1.UpdateCubeSandboxRequest
+	59,  // 98: cubelet.services.cubebox.v1.CubeboxMgr.Exec:input_type -> cubelet.services.cubebox.v1.ExecCubeSandboxRequest
+	61,  // 99: cubelet.services.cubebox.v1.CubeboxMgr.AppSnapshot:input_type -> cubelet.services.cubebox.v1.AppSnapshotRequest
+	63,  // 100: cubelet.services.cubebox.v1.CubeboxMgr.CommitSandbox:input_type -> cubelet.services.cubebox.v1.CommitSandboxRequest
+	65,  // 101: cubelet.services.cubebox.v1.CubeboxMgr.RollbackSandbox:input_type -> cubelet.services.cubebox.v1.RollbackSandboxRequest
+	68,  // 102: cubelet.services.cubebox.v1.CubeboxMgr.CleanupTemplate:input_type -> cubelet.services.cubebox.v1.CleanupTemplateRequest
+	70,  // 103: cubelet.services.cubebox.v1.CubeboxMgr.ListSandboxSnapshots:input_type -> cubelet.services.cubebox.v1.ListSandboxSnapshotsRequest
+	73,  // 104: cubelet.services.cubebox.v1.CubeboxMgr.ListLocalSnapshots:input_type -> cubelet.services.cubebox.v1.ListLocalSnapshotsRequest
+	76,  // 105: cubelet.services.cubebox.v1.CubeboxMgr.GetLocalSnapshot:input_type -> cubelet.services.cubebox.v1.GetLocalSnapshotRequest
+	78,  // 106: cubelet.services.cubebox.v1.CubeboxMgr.GetStorageMetrics:input_type -> cubelet.services.cubebox.v1.GetStorageMetricsRequest
+	82,  // 107: cubelet.services.cubebox.v1.CubeboxMgr.InspectStorageVolumes:input_type -> cubelet.services.cubebox.v1.InspectStorageVolumesRequest
+	84,  // 108: cubelet.services.cubebox.v1.CubeboxMgr.CleanupOrphanStorageFiles:input_type -> cubelet.services.cubebox.v1.CleanupOrphanStorageFilesRequest
+	40,  // 109: cubelet.services.cubebox.v1.CubeboxMgr.Create:output_type -> cubelet.services.cubebox.v1.RunCubeSandboxResponse
+	48,  // 110: cubelet.services.cubebox.v1.CubeboxMgr.Destroy:output_type -> cubelet.services.cubebox.v1.DestroyCubeSandboxResponse
+	54,  // 111: cubelet.services.cubebox.v1.CubeboxMgr.List:output_type -> cubelet.services.cubebox.v1.ListCubeSandboxResponse
+	56,  // 112: cubelet.services.cubebox.v1.CubeboxMgr.Update:output_type -> cubelet.services.cubebox.v1.UpdateCubeSandboxResponse
+	60,  // 113: cubelet.services.cubebox.v1.CubeboxMgr.Exec:output_type -> cubelet.services.cubebox.v1.ExecCubeSandboxResponse
+	62,  // 114: cubelet.services.cubebox.v1.CubeboxMgr.AppSnapshot:output_type -> cubelet.services.cubebox.v1.AppSnapshotResponse
+	64,  // 115: cubelet.services.cubebox.v1.CubeboxMgr.CommitSandbox:output_type -> cubelet.services.cubebox.v1.CommitSandboxResponse
+	66,  // 116: cubelet.services.cubebox.v1.CubeboxMgr.RollbackSandbox:output_type -> cubelet.services.cubebox.v1.RollbackSandboxResponse
+	69,  // 117: cubelet.services.cubebox.v1.CubeboxMgr.CleanupTemplate:output_type -> cubelet.services.cubebox.v1.CleanupTemplateResponse
+	72,  // 118: cubelet.services.cubebox.v1.CubeboxMgr.ListSandboxSnapshots:output_type -> cubelet.services.cubebox.v1.ListSandboxSnapshotsResponse
+	75,  // 119: cubelet.services.cubebox.v1.CubeboxMgr.ListLocalSnapshots:output_type -> cubelet.services.cubebox.v1.ListLocalSnapshotsResponse
+	77,  // 120: cubelet.services.cubebox.v1.CubeboxMgr.GetLocalSnapshot:output_type -> cubelet.services.cubebox.v1.GetLocalSnapshotResponse
+	79,  // 121: cubelet.services.cubebox.v1.CubeboxMgr.GetStorageMetrics:output_type -> cubelet.services.cubebox.v1.GetStorageMetricsResponse
+	83,  // 122: cubelet.services.cubebox.v1.CubeboxMgr.InspectStorageVolumes:output_type -> cubelet.services.cubebox.v1.InspectStorageVolumesResponse
+	86,  // 123: cubelet.services.cubebox.v1.CubeboxMgr.CleanupOrphanStorageFiles:output_type -> cubelet.services.cubebox.v1.CleanupOrphanStorageFilesResponse
+	109, // [109:124] is the sub-list for method output_type
+	94,  // [94:109] is the sub-list for method input_type
+	94,  // [94:94] is the sub-list for extension type_name
+	94,  // [94:94] is the sub-list for extension extendee
+	0,   // [0:94] is the sub-list for field type_name
 }
 
 func init() { file_api_services_cubebox_v1_cubebox_proto_init() }

--- a/Cubelet/api/services/cubebox/v1/cubebox.proto
+++ b/Cubelet/api/services/cubebox/v1/cubebox.proto
@@ -687,6 +687,8 @@ message Container {
   int64 finished_at = 7;
   map<string, string> labels = 8;
   int64 paused_at = 9;
+  // Mounts declared on the container spec (including host-dir mounts).
+  repeated VolumeMounts volume_mounts = 10;
 }
 
 // ContainerState represents the lifecycle state of a container.

--- a/Cubelet/services/cubebox/service.go
+++ b/Cubelet/services/cubebox/service.go
@@ -809,6 +809,10 @@ func toGRPCContainer(c *cubeboxstore.Container) *cubebox.Container {
 		cc.PausedAt = c.Status.Status.PausedAt
 	}
 
+	if mounts := c.Config.GetVolumeMounts(); len(mounts) > 0 {
+		cc.VolumeMounts = append(cc.VolumeMounts, mounts...)
+	}
+
 	if cc.Labels == nil {
 		cc.Labels = make(map[string]string)
 	}

--- a/Cubelet/services/cubebox/service_test.go
+++ b/Cubelet/services/cubebox/service_test.go
@@ -16,9 +16,40 @@ import (
 	"github.com/stretchr/testify/require"
 	cubeboxv1 "github.com/tencentcloud/CubeSandbox/Cubelet/api/services/cubebox/v1"
 	"github.com/tencentcloud/CubeSandbox/Cubelet/api/services/errorcode/v1"
+	imagesv1 "github.com/tencentcloud/CubeSandbox/Cubelet/api/services/images/v1"
 	"github.com/tencentcloud/CubeSandbox/Cubelet/pkg/constants"
 	cubeboxstore "github.com/tencentcloud/CubeSandbox/Cubelet/pkg/store/cubebox"
 )
+
+func TestToGRPCContainerIncludesVolumeMounts(t *testing.T) {
+	container := &cubeboxstore.Container{
+		Metadata: cubeboxstore.Metadata{
+			ID:     "ctr-1",
+			Labels: map[string]string{},
+			Config: &cubeboxv1.ContainerConfig{
+				Image: &imagesv1.ImageSpec{Image: "img"},
+				Resources: &cubeboxv1.Resource{
+					Cpu: "100m",
+					Mem: "128Mi",
+				},
+				VolumeMounts: []*cubeboxv1.VolumeMounts{{
+					Name:          "hostdir-0",
+					ContainerPath: "/mnt/data",
+					HostPath:      "/tmp/data",
+					Readonly:      true,
+				}},
+			},
+		},
+		Status: cubeboxstore.StoreStatus(cubeboxstore.Status{StartedAt: time.Now().UnixNano()}),
+	}
+
+	got := toGRPCContainer(container)
+	require.Len(t, got.GetVolumeMounts(), 1)
+	assert.Equal(t, "hostdir-0", got.GetVolumeMounts()[0].GetName())
+	assert.Equal(t, "/mnt/data", got.GetVolumeMounts()[0].GetContainerPath())
+	assert.Equal(t, "/tmp/data", got.GetVolumeMounts()[0].GetHostPath())
+	assert.True(t, got.GetVolumeMounts()[0].GetReadonly())
+}
 
 func TestDeadline(t *testing.T) {
 	expected := time.Duration(10) * time.Second

--- a/sdk/go/models.go
+++ b/sdk/go/models.go
@@ -41,6 +41,8 @@ type SandboxInfo struct {
 type VolumeMount struct {
 	Name string `json:"name"`
 	Path string `json:"path"`
+	// ReadOnly is false when the API omits the field (CubeAPI skips serializing false).
+	ReadOnly bool `json:"readOnly,omitempty"`
 }
 
 type NetworkOptions struct {

--- a/sdk/go/sdk_test.go
+++ b/sdk/go/sdk_test.go
@@ -937,6 +937,56 @@ func TestSandboxInfoEndAtPresent(t *testing.T) {
 	}
 }
 
+func TestGetInfoDecodesVolumeMounts(t *testing.T) {
+	const sandboxID = "sb-mount-1"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/sandboxes/"+sandboxID {
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
+		}
+		fmt.Fprint(w, `{"sandboxID":"sb-mount-1","templateID":"tpl-test","clientID":"client-1","startedAt":"2026-05-14T00:00:00Z","endAt":"2026-05-14T01:00:00Z","envdVersion":"0.0.1","domain":"cube.app","cpuCount":2,"memoryMB":512,"state":"running","volumeMounts":[{"name":"hostdir-0","path":"/mnt/data","readOnly":true}]}`)
+	}))
+	defer server.Close()
+
+	client := NewClient(Config{APIURL: server.URL, TemplateID: "tpl-test"})
+	sb := &Sandbox{client: client, SandboxID: sandboxID}
+	info, err := sb.GetInfo(context.Background())
+	if err != nil {
+		t.Fatalf("GetInfo: %v", err)
+	}
+	if len(info.VolumeMounts) != 1 {
+		t.Fatalf("VolumeMounts=%#v want len 1", info.VolumeMounts)
+	}
+	mount := info.VolumeMounts[0]
+	if mount.Name != "hostdir-0" || mount.Path != "/mnt/data" {
+		t.Fatalf("mount=%#v", mount)
+	}
+	if !mount.ReadOnly {
+		t.Fatalf("ReadOnly=%v want true", mount.ReadOnly)
+	}
+}
+
+func TestListDecodesVolumeMounts(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/sandboxes" {
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
+		}
+		fmt.Fprint(w, `[{"sandboxID":"sb-mount-1","templateID":"tpl-test","clientID":"client-1","startedAt":"2026-05-14T00:00:00Z","endAt":"2026-05-14T01:00:00Z","envdVersion":"0.0.1","domain":"cube.app","cpuCount":2,"memoryMB":512,"state":"running","volumeMounts":[{"name":"hostdir-0","path":"/mnt/data","readOnly":true}]}]`)
+	}))
+	defer server.Close()
+
+	client := NewClient(Config{APIURL: server.URL, TemplateID: "tpl-test"})
+	list, err := client.List(context.Background())
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(list) != 1 || len(list[0].VolumeMounts) != 1 {
+		t.Fatalf("List=%#v", list)
+	}
+	if list[0].VolumeMounts[0].Path != "/mnt/data" {
+		t.Fatalf("mount=%#v", list[0].VolumeMounts[0])
+	}
+}
+
 func serverHostPort(t *testing.T, rawURL string) (string, int) {
 	t.Helper()
 	parsed, err := url.Parse(rawURL)

--- a/sdk/python/tests/test_sandbox.py
+++ b/sdk/python/tests/test_sandbox.py
@@ -701,6 +701,22 @@ class TestListSandboxesV1:
             result = Sandbox.list(config=make_config())
         assert result == data
 
+    def test_list_includes_volume_mounts(self):
+        data = [{
+            **SANDBOX_DATA,
+            "volumeMounts": [{
+                "name": "hostdir-0",
+                "path": "/mnt/data",
+                "readOnly": True,
+            }],
+        }]
+        with patch("requests.Session.get", return_value=mock_response(data)):
+            result = Sandbox.list(config=make_config())
+
+        assert len(result) == 1
+        assert result[0]["volumeMounts"][0]["path"] == "/mnt/data"
+        assert result[0]["volumeMounts"][0]["readOnly"] is True
+
     def test_list_empty(self):
         with patch("requests.Session.get", return_value=mock_response([])):
             result = Sandbox.list(config=make_config())
@@ -726,6 +742,23 @@ class TestListSandboxesV2:
         with patch("requests.Session.get", return_value=mock_response(data)):
             result = Sandbox.list_v2(config=make_config())
         assert result == data
+
+    def test_list_v2_includes_volume_mounts(self):
+        data = [{
+            **SANDBOX_DATA,
+            "volumeMounts": [{
+                "name": "hostdir-0",
+                "path": "/mnt/ro",
+                "readOnly": True,
+            }],
+        }]
+        with patch("requests.Session.get", return_value=mock_response(data)):
+            result = Sandbox.list_v2(config=make_config())
+
+        mount = result[0]["volumeMounts"][0]
+        assert mount["path"] == "/mnt/ro"
+        assert mount["readOnly"] is True
+        assert "hostPath" not in mount
 
     def test_list_v2_calls_correct_endpoint(self):
         with patch("requests.Session.get", return_value=mock_response([])) as m:
@@ -892,6 +925,26 @@ class TestGetInfo:
         assert info.cpu_count is None
         assert info.metadata == {}
         assert info.state is None
+
+    def test_get_info_includes_volume_mounts(self):
+        sb = make_sandbox()
+        info = {
+            **SANDBOX_DATA,
+            "volumeMounts": [{
+                "name": "hostdir-0",
+                "path": "/mnt/data",
+                "readOnly": True,
+            }],
+        }
+        with patch.object(sb._session, "get", return_value=mock_response(info)):
+            result = sb.get_info()
+
+        mounts = result["volumeMounts"]
+        assert len(mounts) == 1
+        assert mounts[0]["name"] == "hostdir-0"
+        assert mounts[0]["path"] == "/mnt/data"
+        assert mounts[0]["readOnly"] is True
+        assert "hostPath" not in mounts[0]
 
     def test_get_info_not_found(self):
         sb = make_sandbox()

--- a/tests/e2e/sdk_compat/cases/host-mount/test_create_with_mount.py
+++ b/tests/e2e/sdk_compat/cases/host-mount/test_create_with_mount.py
@@ -8,6 +8,10 @@ read-write and a read-only host directory mounted, verify both are visible
 inside the VM, that the read-only mount rejects writes, and that a hostPath
 outside the allowed prefix is rejected at create time (README section 1).
 
+Also asserts that sandbox info and list APIs expose the mounts as
+``volumeMounts`` (``name`` / ``path`` / ``readOnly``) after create.
+``hostPath`` is intentionally not part of the public contract.
+
 A host-mount ``hostPath`` must already exist on the Cubelet node: Cubelet
 bind-mounts it directly and does not create it. Only the allowed-prefix root is
 guaranteed to exist, so the ``_provision_host_dirs`` autouse fixture creates the
@@ -136,3 +140,69 @@ def test_disallowed_hostpath_rejected_at_create(sdk_backend, sdk_e2e_config):
     assert "is not within an allowed mount prefix" in message.lower(), (
         f"expected an allowed-prefix rejection message, got {message!r}"
     )
+
+
+def _mounts_by_path(raw: dict) -> dict[str, dict]:
+    mounts = raw.get("volumeMounts") or []
+    assert isinstance(mounts, list), f"volumeMounts should be a list, got {mounts!r}"
+    return {str(m.get("path")): m for m in mounts if isinstance(m, dict)}
+
+
+@pytest.mark.sandbox_create_options(metadata=_RW_RO_METADATA)
+def test_get_info_returns_volume_mounts(sdk_sandbox):
+    """GET /sandboxes/:id exposes host mounts as public volumeMounts fields."""
+    raw = sdk_sandbox.info().raw
+    by_path = _mounts_by_path(raw)
+
+    rw = by_path.get(_RW_MOUNT)
+    ro = by_path.get(_RO_MOUNT)
+    assert rw is not None and ro is not None, (
+        f"expected mounts for {_RW_MOUNT} and {_RO_MOUNT}, got volumeMounts={raw.get('volumeMounts')!r}"
+    )
+    assert "hostPath" not in rw and "hostPath" not in ro, (
+        f"hostPath must not be exposed publicly; rw={rw!r} ro={ro!r}"
+    )
+    # CubeAPI omits readOnly when false; treat missing as false.
+    assert bool(rw.get("readOnly")) is False, f"rw mount={rw!r}"
+    assert ro.get("readOnly") is True, f"ro mount={ro!r}"
+    assert rw.get("name") and ro.get("name"), f"rw={rw!r} ro={ro!r}"
+    assert "/" not in by_path and not any(
+        str(m.get("name", "")).startswith("cube_rootfs_") for m in (raw.get("volumeMounts") or [])
+    ), f"internal rootfs must not leak into volumeMounts={raw.get('volumeMounts')!r}"
+
+
+@pytest.mark.sandbox_create_options(metadata=_RW_RO_METADATA)
+def test_list_returns_volume_mounts(sdk_sandbox, sdk_backend, sdk_e2e_config):
+    """GET /sandboxes list includes the same volumeMounts as get_info."""
+    from adapters import list_sandboxes
+
+    listed = list_sandboxes(sdk_backend, sdk_e2e_config)
+    entry = next(
+        (
+            item
+            for item in listed
+            if isinstance(item, dict)
+            and item.get("sandboxID", item.get("sandbox_id")) == sdk_sandbox.sandbox_id
+        ),
+        None,
+    )
+    assert entry is not None, (
+        f"sandbox {sdk_sandbox.sandbox_id!r} missing from list ({len(listed)} entries)"
+    )
+
+    by_path = _mounts_by_path(entry)
+    rw = by_path.get(_RW_MOUNT)
+    ro = by_path.get(_RO_MOUNT)
+    assert rw is not None and ro is not None, (
+        f"expected mounts for {_RW_MOUNT} and {_RO_MOUNT}, got volumeMounts={entry.get('volumeMounts')!r}"
+    )
+    assert "hostPath" not in rw and "hostPath" not in ro, (
+        f"hostPath must not be exposed publicly; rw={rw!r} ro={ro!r}"
+    )
+    assert bool(rw.get("readOnly")) is False, f"rw mount={rw!r}"
+    assert ro.get("readOnly") is True, f"ro mount={ro!r}"
+    assert rw.get("name") and ro.get("name"), f"rw={rw!r} ro={ro!r}"
+    assert "/" not in by_path and not any(
+        str(m.get("name", "")).startswith("cube_rootfs_")
+        for m in (entry.get("volumeMounts") or [])
+    ), f"internal rootfs must not leak into volumeMounts={entry.get('volumeMounts')!r}"

--- a/web/src/api/generated/schema.ts
+++ b/web/src/api/generated/schema.ts
@@ -475,6 +475,8 @@ export interface components {
         SandboxVolumeMount: {
             name: string;
             path: string;
+            /** CubeSandbox extension: mount this volume read-only for this sandbox attachment. Defaults to false when omitted. */
+            readOnly?: boolean;
         };
         TemplateAliasLookupResponse: {
             public: boolean;


### PR DESCRIPTION
## Summary

- Expose `volume_mounts` on Cubelet list `Container` responses and thread them through CubeMaster sandbox info/list into CubeAPI `GET /sandboxes` and list payloads.
- Populate `hostPath` when injecting host-dir mounts so clients can see bind-mount source paths after create.
- Extend `SandboxVolumeMount` with optional `hostPath` and `readOnly`; regenerate `openapi.yml` and web TypeScript schema; update SDK models and `cubemastercli info` output.

## Problem

Host mounts are applied at create time via `metadata["host-mount"]`, but sandbox detail/list APIs always returned `volumeMounts: null`. Web, CLI, and SDK callers could not inspect mounts on a running sandbox.

## Test plan

- [x] `go test ./services/cubebox -run TestToGRPCContainerIncludesVolumeMounts` (Cubelet)
- [x] `go test ./pkg/service/sandbox -run 'TestInjectHostDirMounts|TestCollectVolumeMounts'` (CubeMaster)
- [x] `go test ./cmd/cubemastercli/commands/cubebox -run TestPrintSandboxInfoBlockIncludesVolumeMounts` (CLI)
- [x] `cargo test map_volume_mounts` (CubeAPI)