### PR TITLE
cubemaster, cubelet: resolve short sandbox ID prefixes

### DIFF
--- a/CubeMaster/cmd/cubemastercli/commands/cubebox/list.go
+++ b/CubeMaster/cmd/cubemastercli/commands/cubebox/list.go
@@ -21,6 +21,7 @@ import (
 	"github.com/google/uuid"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/utils"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/sandboxid"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/service/sandbox/types"
 	"github.com/urfave/cli"
 )
@@ -147,9 +148,21 @@ var ListCommand = cli.Command{
 		}
 
 		if quiet {
+			var resolvedSandboxID string
+			if sandboxID != "" {
+				candidates := make([]string, 0, len(rsp.Data))
+				for _, sandbox := range rsp.Data {
+					candidates = append(candidates, sandbox.SandboxID)
+				}
+				var err error
+				resolvedSandboxID, err = sandboxid.Resolve(sandboxID, candidates)
+				if err != nil {
+					return err
+				}
+			}
 			for _, sandbox := range rsp.Data {
 				if delete {
-					if sandboxID != "" && sandbox.SandboxID != sandboxID {
+					if resolvedSandboxID != "" && sandbox.SandboxID != resolvedSandboxID {
 						continue
 					}
 					err = doInnerDestroySandbox(c, sandbox.SandboxID, sandbox.Labels, c.String("type"))

--- a/CubeMaster/pkg/localcache/list_cache.go
+++ b/CubeMaster/pkg/localcache/list_cache.go
@@ -43,6 +43,17 @@ func SetSandboxCache(sandboxID string, cache *SandboxCache) {
 	listCache.Store(sandboxID, cache)
 }
 
+func ListKnownSandboxIDs() []string {
+	ids := make([]string, 0)
+	listCache.Range(func(key, _ any) bool {
+		if sandboxID, ok := key.(string); ok && sandboxID != "" {
+			ids = append(ids, sandboxID)
+		}
+		return true
+	})
+	return ids
+}
+
 func (l *local) cleanSandboxCache(ctx context.Context) {
 	ticker := time.NewTicker(time.Second)
 	defer ticker.Stop()

--- a/CubeMaster/pkg/sandboxid/resolve.go
+++ b/CubeMaster/pkg/sandboxid/resolve.go
@@ -1,0 +1,61 @@
+// Copyright (c) 2024 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package sandboxid
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+var (
+	ErrNotFound  = errors.New("sandbox id not found")
+	ErrAmbiguous = errors.New("ambiguous sandbox id prefix")
+
+	fullIDPattern = regexp.MustCompile(`^[0-9a-fA-F]{32}$`)
+)
+
+// NormalizeInput trims leading and trailing whitespace from a sandbox ID input.
+func NormalizeInput(input string) string {
+	return strings.TrimSpace(input)
+}
+
+// IsFullID reports whether id is a 32-character hexadecimal sandbox ID.
+func IsFullID(id string) bool {
+	return fullIDPattern.MatchString(id)
+}
+
+// Resolve maps a short or full sandbox ID to the unique full ID among candidates.
+func Resolve(input string, candidates []string) (string, error) {
+	input = NormalizeInput(input)
+	if input == "" {
+		return "", ErrNotFound
+	}
+
+	inputLower := strings.ToLower(input)
+	var matches []string
+	for _, candidate := range candidates {
+		if candidate == "" {
+			continue
+		}
+		candidateLower := strings.ToLower(candidate)
+		if candidateLower == inputLower {
+			return candidate, nil
+		}
+		if strings.HasPrefix(candidateLower, inputLower) {
+			matches = append(matches, candidate)
+		}
+	}
+
+	switch len(matches) {
+	case 0:
+		return "", fmt.Errorf("%w: %q", ErrNotFound, input)
+	case 1:
+		return matches[0], nil
+	default:
+		return "", fmt.Errorf("%w: %q matches %d sandboxes", ErrAmbiguous, input, len(matches))
+	}
+}

--- a/CubeMaster/pkg/sandboxid/resolve_test.go
+++ b/CubeMaster/pkg/sandboxid/resolve_test.go
@@ -1,0 +1,93 @@
+// Copyright (c) 2024 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package sandboxid
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestResolveExactMatch(t *testing.T) {
+	candidates := []string{
+		"aabbccddeeff00112233445566778899",
+		"112233445566778899aabbccddeeff00",
+	}
+	got, err := Resolve("aabbccddeeff00112233445566778899", candidates)
+	if err != nil {
+		t.Fatalf("Resolve() err=%v", err)
+	}
+	if got != candidates[0] {
+		t.Fatalf("Resolve()=%q, want %q", got, candidates[0])
+	}
+}
+
+func TestResolveUniquePrefix(t *testing.T) {
+	candidates := []string{
+		"aabbccddeeff00112233445566778899",
+		"112233445566778899aabbccddeeff00",
+	}
+	got, err := Resolve("aabbccdd", candidates)
+	if err != nil {
+		t.Fatalf("Resolve() err=%v", err)
+	}
+	if got != candidates[0] {
+		t.Fatalf("Resolve()=%q, want %q", got, candidates[0])
+	}
+}
+
+func TestResolveAmbiguousPrefix(t *testing.T) {
+	candidates := []string{
+		"aabbccddeeff00112233445566778899",
+		"aabbccddeeff00112233445566778898",
+	}
+	_, err := Resolve("aabbccdd", candidates)
+	if !errors.Is(err, ErrAmbiguous) {
+		t.Fatalf("Resolve() err=%v, want ErrAmbiguous", err)
+	}
+}
+
+func TestResolveNotFound(t *testing.T) {
+	_, err := Resolve("deadbeef", []string{"aabbccddeeff00112233445566778899"})
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("Resolve() err=%v, want ErrNotFound", err)
+	}
+}
+
+func TestResolveFullIDRequiresCandidate(t *testing.T) {
+	fullID := "AABBCCDDEEFF00112233445566778899"
+	_, err := Resolve(fullID, nil)
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("Resolve() err=%v, want ErrNotFound", err)
+	}
+
+	got, err := Resolve(fullID, []string{"aabbccddeeff00112233445566778899"})
+	if err != nil {
+		t.Fatalf("Resolve() err=%v", err)
+	}
+	if got != "aabbccddeeff00112233445566778899" {
+		t.Fatalf("Resolve()=%q, want exact candidate", got)
+	}
+}
+
+func TestIsFullID(t *testing.T) {
+	if !IsFullID("aabbccddeeff00112233445566778899") {
+		t.Fatal("IsFullID(full lowercase)=false, want true")
+	}
+	if !IsFullID("AABBCCDDEEFF00112233445566778899") {
+		t.Fatal("IsFullID(full uppercase)=false, want true")
+	}
+	if IsFullID("aabbccdd") {
+		t.Fatal("IsFullID(short)=true, want false")
+	}
+	if IsFullID("aabbccddeeff0011223344556677889g") {
+		t.Fatal("IsFullID(non-hex)=true, want false")
+	}
+}
+
+func TestNormalizeInput(t *testing.T) {
+	if got := NormalizeInput("  abc  "); got != "abc" {
+		t.Fatalf("NormalizeInput()=%q, want %q", got, "abc")
+	}
+}

--- a/CubeMaster/pkg/service/httpservice/cube/sandbox_logs.go
+++ b/CubeMaster/pkg/service/httpservice/cube/sandbox_logs.go
@@ -15,6 +15,7 @@ import (
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/utils"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/errorcode"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/service/httpservice/common"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/service/sandbox"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/service/sandbox/types"
 	CubeLog "github.com/tencentcloud/CubeSandbox/cubelog"
 )
@@ -97,6 +98,13 @@ func handleSandboxLogsAction(c *gin.Context) {
 			},
 		})
 		return
+	}
+	if resolved, ret := sandbox.NormalizeSandboxIDParam(c.Request.Context(), req.SandboxID); ret != nil {
+		rt.RetCode = int64(ret.RetCode)
+		common.WriteAPI(c, &SandboxLogsRes{Res: &types.Res{Ret: ret}})
+		return
+	} else {
+		req.SandboxID = resolved
 	}
 
 	limit := req.Limit

--- a/CubeMaster/pkg/service/httpservice/cube/snapshot.go
+++ b/CubeMaster/pkg/service/httpservice/cube/snapshot.go
@@ -182,15 +182,6 @@ func handleSandboxRollbackAction(c *gin.Context) {
 	if req.SandboxID == "" {
 		req.SandboxID = pathSandboxID
 	}
-	if pathSandboxID != "" && strings.TrimSpace(req.SandboxID) != pathSandboxID {
-		common.WriteAPI(c, &operationResponse{
-			Res: &types.Res{Ret: &types.Ret{
-				RetCode: int(errorcode.ErrorCode_MasterParamsError),
-				RetMsg:  "sandbox_id in path does not match request body",
-			}},
-		})
-		return
-	}
 	if requestID == "" || strings.TrimSpace(req.SandboxID) == "" || strings.TrimSpace(req.SnapshotID) == "" {
 		common.WriteAPI(c, &operationResponse{
 			Res: &types.Res{Ret: &types.Ret{
@@ -199,6 +190,30 @@ func handleSandboxRollbackAction(c *gin.Context) {
 			}},
 		})
 		return
+	}
+	// Resolve short/full IDs before comparing path vs body so a short prefix
+	// and the matching full ID are not treated as a mismatch.
+	if resolved, ret := sandbox.NormalizeSandboxIDParam(c.Request.Context(), req.SandboxID); ret != nil {
+		common.WriteAPI(c, &operationResponse{Res: &types.Res{Ret: ret}})
+		return
+	} else {
+		req.SandboxID = resolved
+	}
+	if pathSandboxID != "" {
+		resolvedPath, pathRet := sandbox.NormalizeSandboxIDParam(c.Request.Context(), pathSandboxID)
+		if pathRet != nil {
+			common.WriteAPI(c, &operationResponse{Res: &types.Res{Ret: pathRet}})
+			return
+		}
+		if resolvedPath != req.SandboxID {
+			common.WriteAPI(c, &operationResponse{
+				Res: &types.Res{Ret: &types.Ret{
+					RetCode: int(errorcode.ErrorCode_MasterParamsError),
+					RetMsg:  "sandbox_id in path does not match request body",
+				}},
+			})
+			return
+		}
 	}
 	ctx, cancel := snapshotExecutionContext(c.Request.Context(), map[string]any{
 		"RequestId":  requestID,
@@ -289,6 +304,11 @@ func createSnapshot(r *http.Request, rt *CubeLog.RequestTrace) interface{} {
 				RetMsg:  "sandbox_id is required",
 			}},
 		}
+	}
+	if resolved, ret := sandbox.NormalizeSandboxIDParam(r.Context(), req.SandboxID); ret != nil {
+		return &snapshotResponse{Res: &types.Res{Ret: ret}}
+	} else {
+		req.SandboxID = resolved
 	}
 	requestID := firstNonEmptyTrimmed(req.RequestID, req.LegacyRequestID)
 	if requestID == "" {

--- a/CubeMaster/pkg/service/httpservice/cube/template_commit.go
+++ b/CubeMaster/pkg/service/httpservice/cube/template_commit.go
@@ -62,6 +62,12 @@ func handleSandboxCommitAction(c *gin.Context) {
 		})
 		return
 	}
+	if resolved, ret := sandbox.NormalizeSandboxIDParam(c.Request.Context(), req.SandboxID); ret != nil {
+		common.WriteAPI(c, &commitTemplateResponse{Res: &types.Res{Ret: ret}})
+		return
+	} else {
+		req.SandboxID = resolved
+	}
 	// Auto-generate the template ID before any later response can reference it.
 	// Users are not allowed to set custom template IDs because the snapshot
 	// system depends on the tpl- / snap- prefix convention.

--- a/CubeMaster/pkg/service/sandbox/id_resolve.go
+++ b/CubeMaster/pkg/service/sandbox/id_resolve.go
@@ -1,0 +1,143 @@
+// Copyright (c) 2024 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package sandbox
+
+import (
+	"context"
+	"errors"
+	"sync"
+
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/api/services/cubebox/v1"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/log"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/cubelet"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/localcache"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/sandboxid"
+)
+
+// Bound fan-out when listing sandboxes from healthy cubelets. Matches the
+// ListSandbox-style concurrency cap so a large cluster cannot open unbounded
+// concurrent gRPC calls on the request path.
+const clusterSandboxCollectConcurrency = 32
+
+type clusterSandboxEntry struct {
+	SandboxID string
+	HostIP    string
+}
+
+// ResolveSandboxID accepts a short or full sandbox ID and returns the canonical full ID.
+func ResolveSandboxID(ctx context.Context, input string) (string, error) {
+	input = sandboxid.NormalizeInput(input)
+	if input == "" {
+		return "", sandboxid.ErrNotFound
+	}
+
+	candidates := localcache.ListKnownSandboxIDs()
+	resolved, err := sandboxid.Resolve(input, candidates)
+	if err == nil {
+		return resolved, nil
+	}
+	// Local cache may be stale or partial: fall through to a cluster scan for
+	// both missing and ambiguous prefixes so a unique live match can win.
+	if !cacheResolveNeedsClusterFallback(err) {
+		return "", err
+	}
+
+	entries := collectClusterSandboxIDs(ctx)
+	cacheCollectedSandboxEntries(entries)
+	clusterIDs := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		clusterIDs = append(clusterIDs, entry.SandboxID)
+	}
+	merged := mergeSandboxIDs(candidates, clusterIDs)
+	return sandboxid.Resolve(input, merged)
+}
+
+func cacheResolveNeedsClusterFallback(err error) bool {
+	return errors.Is(err, sandboxid.ErrNotFound) || errors.Is(err, sandboxid.ErrAmbiguous)
+}
+
+func mergeSandboxIDs(base, extra []string) []string {
+	seen := make(map[string]struct{}, len(base)+len(extra))
+	merged := make([]string, 0, len(base)+len(extra))
+	for _, id := range append(base, extra...) {
+		if id == "" {
+			continue
+		}
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		seen[id] = struct{}{}
+		merged = append(merged, id)
+	}
+	return merged
+}
+
+func cacheCollectedSandboxEntries(entries []clusterSandboxEntry) {
+	for _, entry := range entries {
+		localcache.SetSandboxCache(entry.SandboxID, &localcache.SandboxCache{
+			SandboxID: entry.SandboxID,
+			HostIP:    entry.HostIP,
+		})
+	}
+}
+
+func collectClusterSandboxIDs(ctx context.Context) []clusterSandboxEntry {
+	nodes := localcache.GetHealthyNodes(-1)
+	if len(nodes) == 0 {
+		return nil
+	}
+
+	var (
+		mu      sync.Mutex
+		entries []clusterSandboxEntry
+		wg      sync.WaitGroup
+		sem     = make(chan struct{}, clusterSandboxCollectConcurrency)
+	)
+	for _, nodeItem := range nodes {
+		if ctx.Err() != nil {
+			break
+		}
+		nodeItem := nodeItem
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			select {
+			case sem <- struct{}{}:
+				defer func() { <-sem }()
+			case <-ctx.Done():
+				return
+			}
+			if ctx.Err() != nil {
+				return
+			}
+
+			hostIP := nodeItem.HostIP()
+			cubeletReq := &cubebox.ListCubeSandboxRequest{
+				Filter: &cubebox.CubeSandboxFilter{
+					LabelSelector: map[string]string{"io.kubernetes.cri.container-type": "sandbox"},
+				},
+			}
+			cubeRsp, err := cubelet.List(ctx, cubelet.GetCubeletAddr(hostIP), cubeletReq)
+			if err != nil {
+				log.G(ctx).Warnf("collect sandbox ids from %s failed: %v", hostIP, err)
+				return
+			}
+			for _, sandbox := range cubeRsp.GetItems() {
+				sandboxID := sandbox.GetId()
+				if sandboxID == "" {
+					continue
+				}
+				mu.Lock()
+				entries = append(entries, clusterSandboxEntry{
+					SandboxID: sandboxID,
+					HostIP:    hostIP,
+				})
+				mu.Unlock()
+			}
+		}()
+	}
+	wg.Wait()
+	return entries
+}

--- a/CubeMaster/pkg/service/sandbox/id_resolve_helpers.go
+++ b/CubeMaster/pkg/service/sandbox/id_resolve_helpers.go
@@ -1,0 +1,51 @@
+// Copyright (c) 2024 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package sandbox
+
+import (
+	"context"
+	"errors"
+
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/errorcode"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/sandboxid"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/service/sandbox/types"
+)
+
+// NormalizeSandboxIDParam resolves a short or full sandbox ID for HTTP handlers.
+func NormalizeSandboxIDParam(ctx context.Context, sandboxID string) (string, *types.Ret) {
+	return resolveSandboxIDOrError(ctx, sandboxID)
+}
+
+func resolveSandboxIDOrError(ctx context.Context, sandboxID string) (string, *types.Ret) {
+	resolved, err := ResolveSandboxID(ctx, sandboxID)
+	if err == nil {
+		return resolved, nil
+	}
+	ret := &types.Ret{}
+	switch {
+	case errors.Is(err, sandboxid.ErrAmbiguous):
+		ret.RetCode = int(errorcode.ErrorCode_MasterParamsError)
+		ret.RetMsg = err.Error()
+	case errors.Is(err, sandboxid.ErrNotFound):
+		ret.RetCode = int(errorcode.ErrorCode_NotFound)
+		ret.RetMsg = err.Error()
+	default:
+		ret.RetCode = int(errorcode.ErrorCode_MasterParamsError)
+		ret.RetMsg = err.Error()
+	}
+	return "", ret
+}
+
+func normalizeSandboxIDInReq(ctx context.Context, sandboxID *string) *types.Ret {
+	if sandboxID == nil || *sandboxID == "" {
+		return nil
+	}
+	resolved, ret := resolveSandboxIDOrError(ctx, *sandboxID)
+	if ret != nil {
+		return ret
+	}
+	*sandboxID = resolved
+	return nil
+}

--- a/CubeMaster/pkg/service/sandbox/id_resolve_test.go
+++ b/CubeMaster/pkg/service/sandbox/id_resolve_test.go
@@ -1,0 +1,51 @@
+// Copyright (c) 2024 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package sandbox
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/sandboxid"
+)
+
+func TestCacheResolveNeedsClusterFallback(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "nil", err: nil, want: false},
+		{name: "not found", err: sandboxid.ErrNotFound, want: true},
+		{name: "ambiguous", err: sandboxid.ErrAmbiguous, want: true},
+		{name: "wrapped not found", err: fmt.Errorf("%w: %q", sandboxid.ErrNotFound, "ab"), want: true},
+		{name: "wrapped ambiguous", err: fmt.Errorf("%w: %q matches %d sandboxes", sandboxid.ErrAmbiguous, "ab", 2), want: true},
+		{name: "other", err: errors.New("boom"), want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := cacheResolveNeedsClusterFallback(tt.err); got != tt.want {
+				t.Fatalf("cacheResolveNeedsClusterFallback()=%v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMergeSandboxIDs(t *testing.T) {
+	got := mergeSandboxIDs(
+		[]string{"aaa", "", "bbb"},
+		[]string{"bbb", "ccc", ""},
+	)
+	want := []string{"aaa", "bbb", "ccc"}
+	if len(got) != len(want) {
+		t.Fatalf("mergeSandboxIDs()=%v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("mergeSandboxIDs()=%v, want %v", got, want)
+		}
+	}
+}

--- a/CubeMaster/pkg/service/sandbox/sandbox_exec.go
+++ b/CubeMaster/pkg/service/sandbox/sandbox_exec.go
@@ -39,6 +39,10 @@ func Exec(ctx context.Context, req *types.ExecRequest) (rsp *types.Res) {
 		rsp.Ret.RetMsg = "should provide sandbox id and container id"
 		return
 	}
+	if ret := normalizeSandboxIDInReq(ctx, &req.SandboxID); ret != nil {
+		rsp.Ret = ret
+		return
+	}
 
 	if len(req.Args) == 0 {
 		rsp.Ret.RetCode = int(errorcode.ErrorCode_MasterParamsError)

--- a/CubeMaster/pkg/service/sandbox/sandbox_info.go
+++ b/CubeMaster/pkg/service/sandbox/sandbox_info.go
@@ -33,6 +33,12 @@ func SandboxInfo(ctx context.Context, req *types.GetCubeSandboxReq) (rsp *types.
 		},
 	}
 	log.G(ctx).Infof("GetSandboxInfo:%+v", utils.InterfaceToString(req))
+	if req.SandboxID != "" {
+		if ret := normalizeSandboxIDInReq(ctx, &req.SandboxID); ret != nil {
+			rsp.Ret = ret
+			return
+		}
+	}
 	defer func() {
 		if log.IsDebug() {
 			log.G(ctx).Debugf("GetSandboxInfo_rsp:%+v", utils.InterfaceToString(rsp))

--- a/CubeMaster/pkg/service/sandbox/sandbox_remove.go
+++ b/CubeMaster/pkg/service/sandbox/sandbox_remove.go
@@ -34,6 +34,18 @@ func DestroySandbox(ctx context.Context, req *types.DeleteCubeSandboxReq) (rsp *
 			RetMsg:  errorcode.ErrorCode_Success.String(),
 		},
 	}
+	if req.SandboxID == "" {
+		rsp.Ret.RetCode = int(errorcode.ErrorCode_MasterParamsError)
+		rsp.Ret.RetMsg = "should provide sandbox id"
+		return
+	}
+	// Resolve before config-dependent work so invalid / ambiguous IDs fail fast.
+	if ret := normalizeSandboxIDInReq(ctx, &req.SandboxID); ret != nil {
+		rsp.Ret = ret
+		return
+	}
+	rsp.SandboxID = req.SandboxID
+
 	destroyReq := &cubebox.DestroyCubeSandboxRequest{
 		RequestID:   req.RequestID,
 		SandboxID:   req.SandboxID,
@@ -83,11 +95,6 @@ func DestroySandbox(ctx context.Context, req *types.DeleteCubeSandboxReq) (rsp *
 		}
 	}()
 	if config.GetConfig().Common.MockCreateDirect {
-		return
-	}
-	if req.SandboxID == "" {
-		rsp.Ret.RetCode = int(errorcode.ErrorCode_MasterParamsError)
-		rsp.Ret.RetMsg = "should provide sandbox id"
 		return
 	}
 

--- a/CubeMaster/pkg/service/sandbox/sandbox_remove_test.go
+++ b/CubeMaster/pkg/service/sandbox/sandbox_remove_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/api/services/cubebox/v1"
 	cubeleterrorcode "github.com/tencentcloud/CubeSandbox/CubeMaster/api/services/errorcode/v1"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/config"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/ret"
 	basetypes "github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/types"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/errorcode"
@@ -27,6 +28,13 @@ func TestDestroySandboxMissingSandboxReturnsNotFound(t *testing.T) {
 	})
 	patches := gomonkey.NewPatches()
 	defer patches.Reset()
+	patches.ApplyFunc(config.GetConfig, func() *config.Config {
+		return &config.Config{Common: &config.CommonConf{}}
+	})
+	// Keep ID as-is so the missing-sandbox path is exercised after resolve.
+	patches.ApplyFunc(ResolveSandboxID, func(_ context.Context, input string) (string, error) {
+		return input, nil
+	})
 	patches.ApplyFunc(localcache.GetSandboxCache, func(string) *localcache.SandboxCache {
 		return nil
 	})

--- a/CubeMaster/pkg/service/sandbox/sandbox_timeout.go
+++ b/CubeMaster/pkg/service/sandbox/sandbox_timeout.go
@@ -42,6 +42,10 @@ func SetTimeout(ctx context.Context, req *types.SetTimeoutRequest) (rsp *types.S
 		rsp.Ret.RetMsg = "should provide sandboxID"
 		return
 	}
+	if ret := normalizeSandboxIDInReq(ctx, &req.SandboxID); ret != nil {
+		rsp.Ret = ret
+		return
+	}
 	if req.Timeout < -1 {
 		rsp.Ret.RetCode = int(errorcode.ErrorCode_MasterParamsError)
 		rsp.Ret.RetMsg = "timeout must be >= -1 (use -1 for never timeout)"
@@ -84,6 +88,10 @@ func Refresh(ctx context.Context, req *types.RefreshSandboxRequest) (rsp *types.
 	if req.SandboxID == "" {
 		rsp.Ret.RetCode = int(errorcode.ErrorCode_MasterParamsError)
 		rsp.Ret.RetMsg = "should provide sandboxID"
+		return
+	}
+	if ret := normalizeSandboxIDInReq(ctx, &req.SandboxID); ret != nil {
+		rsp.Ret = ret
 		return
 	}
 	if req.Duration <= 0 {

--- a/CubeMaster/pkg/service/sandbox/sandbox_update.go
+++ b/CubeMaster/pkg/service/sandbox/sandbox_update.go
@@ -46,6 +46,10 @@ func Update(ctx context.Context, req *types.UpdateRequest) (rsp *types.Res) {
 		rsp.Ret.RetMsg = "action should be pause or resume"
 		return
 	}
+	if ret := normalizeSandboxIDInReq(ctx, &req.SandboxID); ret != nil {
+		rsp.Ret = ret
+		return
+	}
 
 	var hostIP string
 	if v := localcache.GetSandboxCache(req.SandboxID); v != nil {

--- a/Cubelet/cmd/cubecli/commands/cubebox/destroy.go
+++ b/Cubelet/cmd/cubecli/commands/cubebox/destroy.go
@@ -70,10 +70,21 @@ var Destroy = &cli.Command{
 			ids = append(ids, context.String("name"))
 		}
 		if context.Bool("force") {
+			ctx, cancel := commands.AppContext(context)
+			defer cancel()
+			req := &cubebox.ListCubeSandboxRequest{}
+			resp, err := client.List(ctx, req)
+			if err != nil {
+				return err
+			}
 			for _, id := range ids {
+				resolved, err := resolveSandboxIDFromList(resp.Items, strings.TrimSpace(id))
+				if err != nil {
+					return err
+				}
 				if err = destroy(context, &cubebox.DestroyCubeSandboxRequest{
 					RequestID: uuid.New().String(),
-					SandboxID: strings.TrimSpace(id),
+					SandboxID: resolved,
 				}, client); err != nil {
 					return err
 				}
@@ -105,24 +116,17 @@ var Destroy = &cli.Command{
 			return nil
 		}
 
-		for _, item := range resp.Items {
-			for _, id := range ids {
-				id := strings.TrimSpace(id)
-				if len(item.GetContainers()) == 0 {
-					log.Printf("Warning sandbox:%s has no container", item.GetId())
-					continue
-				}
-
-				if strings.HasPrefix(item.GetId(), id) || strings.HasPrefix(item.GetContainers()[0].GetId(), id) {
-					if err = destroy(context, &cubebox.DestroyCubeSandboxRequest{
-						RequestID:   uuid.New().String(),
-						SandboxID:   item.GetId(),
-						Annotations: tmpAnnation,
-					}, client); err == nil {
-						break
-					}
-
-				}
+		for _, id := range ids {
+			resolved, err := resolveSandboxIDFromList(resp.Items, strings.TrimSpace(id))
+			if err != nil {
+				return err
+			}
+			if err = destroy(context, &cubebox.DestroyCubeSandboxRequest{
+				RequestID:   uuid.New().String(),
+				SandboxID:   resolved,
+				Annotations: tmpAnnation,
+			}, client); err != nil {
+				return err
 			}
 		}
 		return nil

--- a/Cubelet/cmd/cubecli/commands/cubebox/metadata.go
+++ b/Cubelet/cmd/cubecli/commands/cubebox/metadata.go
@@ -6,7 +6,6 @@ package cubebox
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/urfave/cli/v2"
 
@@ -43,17 +42,11 @@ var inspecMetaData = cli.Command{
 			return err
 		}
 		for _, id := range ids {
-			found := false
-			for _, item := range resp.Items {
-				if strings.HasPrefix(item.GetId(), id) {
-					boxIDs = append(boxIDs, item.GetId())
-					found = true
-					break
-				}
+			resolved, err := resolveSandboxIDFromList(resp.Items, id)
+			if err != nil {
+				return err
 			}
-			if !found {
-				return fmt.Errorf("cubebox %s not found", id)
-			}
+			boxIDs = append(boxIDs, resolved)
 		}
 
 		for _, id := range boxIDs {

--- a/Cubelet/cmd/cubecli/commands/cubebox/resolve.go
+++ b/Cubelet/cmd/cubecli/commands/cubebox/resolve.go
@@ -1,0 +1,71 @@
+// Copyright (c) 2024 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package cubebox
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/tencentcloud/CubeSandbox/Cubelet/api/services/cubebox/v1"
+	"github.com/tencentcloud/CubeSandbox/Cubelet/pkg/sandboxid"
+)
+
+func resolveSandboxIDFromList(items []*cubebox.CubeSandbox, input string) (string, error) {
+	candidates := make([]string, 0, len(items))
+	for _, item := range items {
+		candidates = append(candidates, item.GetId())
+	}
+	resolved, err := sandboxid.Resolve(input, candidates)
+	if err == nil || !errors.Is(err, sandboxid.ErrNotFound) {
+		return resolved, err
+	}
+
+	// Preserve historical cubecli behavior: also accept a unique container ID
+	// (or prefix) and map it back to the owning sandbox ID.
+	return resolveSandboxIDByContainer(items, input)
+}
+
+func resolveSandboxIDByContainer(items []*cubebox.CubeSandbox, input string) (string, error) {
+	input = sandboxid.NormalizeInput(input)
+	if input == "" {
+		return "", sandboxid.ErrNotFound
+	}
+	inputLower := strings.ToLower(input)
+
+	var matches []string
+	seen := make(map[string]struct{})
+	for _, item := range items {
+		sandboxID := item.GetId()
+		if sandboxID == "" {
+			continue
+		}
+		for _, container := range item.GetContainers() {
+			containerID := container.GetId()
+			if containerID == "" {
+				continue
+			}
+			containerLower := strings.ToLower(containerID)
+			if containerLower != inputLower && !strings.HasPrefix(containerLower, inputLower) {
+				continue
+			}
+			if _, ok := seen[sandboxID]; ok {
+				continue
+			}
+			seen[sandboxID] = struct{}{}
+			matches = append(matches, sandboxID)
+			break
+		}
+	}
+
+	switch len(matches) {
+	case 0:
+		return "", fmt.Errorf("%w: %q", sandboxid.ErrNotFound, input)
+	case 1:
+		return matches[0], nil
+	default:
+		return "", fmt.Errorf("%w: %q matches %d sandboxes", sandboxid.ErrAmbiguous, input, len(matches))
+	}
+}

--- a/Cubelet/cmd/cubecli/commands/cubebox/resolve_test.go
+++ b/Cubelet/cmd/cubecli/commands/cubebox/resolve_test.go
@@ -1,0 +1,68 @@
+// Copyright (c) 2024 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package cubebox
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/tencentcloud/CubeSandbox/Cubelet/api/services/cubebox/v1"
+	"github.com/tencentcloud/CubeSandbox/Cubelet/pkg/sandboxid"
+)
+
+func TestResolveSandboxIDFromListBySandboxPrefix(t *testing.T) {
+	items := []*cubebox.CubeSandbox{
+		{Id: "aabbccddeeff00112233445566778899"},
+		{Id: "112233445566778899aabbccddeeff00"},
+	}
+	got, err := resolveSandboxIDFromList(items, "aabbccdd")
+	if err != nil {
+		t.Fatalf("err=%v", err)
+	}
+	if got != items[0].Id {
+		t.Fatalf("got=%q want=%q", got, items[0].Id)
+	}
+}
+
+func TestResolveSandboxIDFromListByContainerPrefix(t *testing.T) {
+	items := []*cubebox.CubeSandbox{
+		{
+			Id: "aabbccddeeff00112233445566778899",
+			Containers: []*cubebox.Container{
+				{Id: "contaabb00112233445566778899aabb"},
+			},
+		},
+		{
+			Id: "112233445566778899aabbccddeeff00",
+			Containers: []*cubebox.Container{
+				{Id: "cont112233445566778899aabbccddee"},
+			},
+		},
+	}
+	got, err := resolveSandboxIDFromList(items, "contaabb")
+	if err != nil {
+		t.Fatalf("err=%v", err)
+	}
+	if got != items[0].Id {
+		t.Fatalf("got=%q want sandbox id %q", got, items[0].Id)
+	}
+}
+
+func TestResolveSandboxIDFromListContainerAmbiguous(t *testing.T) {
+	items := []*cubebox.CubeSandbox{
+		{
+			Id:         "aabbccddeeff00112233445566778899",
+			Containers: []*cubebox.Container{{Id: "contshared00112233445566778899aa"}},
+		},
+		{
+			Id:         "112233445566778899aabbccddeeff00",
+			Containers: []*cubebox.Container{{Id: "contshared00112233445566778899bb"}},
+		},
+	}
+	_, err := resolveSandboxIDFromList(items, "contshared")
+	if !errors.Is(err, sandboxid.ErrAmbiguous) {
+		t.Fatalf("err=%v want ErrAmbiguous", err)
+	}
+}

--- a/Cubelet/pkg/sandboxid/resolve.go
+++ b/Cubelet/pkg/sandboxid/resolve.go
@@ -1,0 +1,61 @@
+// Copyright (c) 2024 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package sandboxid
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+var (
+	ErrNotFound  = errors.New("sandbox id not found")
+	ErrAmbiguous = errors.New("ambiguous sandbox id prefix")
+
+	fullIDPattern = regexp.MustCompile(`^[0-9a-fA-F]{32}$`)
+)
+
+// NormalizeInput trims leading and trailing whitespace from a sandbox ID input.
+func NormalizeInput(input string) string {
+	return strings.TrimSpace(input)
+}
+
+// IsFullID reports whether id is a 32-character hexadecimal sandbox ID.
+func IsFullID(id string) bool {
+	return fullIDPattern.MatchString(id)
+}
+
+// Resolve maps a short or full sandbox ID to the unique full ID among candidates.
+func Resolve(input string, candidates []string) (string, error) {
+	input = NormalizeInput(input)
+	if input == "" {
+		return "", ErrNotFound
+	}
+
+	inputLower := strings.ToLower(input)
+	var matches []string
+	for _, candidate := range candidates {
+		if candidate == "" {
+			continue
+		}
+		candidateLower := strings.ToLower(candidate)
+		if candidateLower == inputLower {
+			return candidate, nil
+		}
+		if strings.HasPrefix(candidateLower, inputLower) {
+			matches = append(matches, candidate)
+		}
+	}
+
+	switch len(matches) {
+	case 0:
+		return "", fmt.Errorf("%w: %q", ErrNotFound, input)
+	case 1:
+		return matches[0], nil
+	default:
+		return "", fmt.Errorf("%w: %q matches %d sandboxes", ErrAmbiguous, input, len(matches))
+	}
+}

--- a/Cubelet/pkg/sandboxid/resolve_test.go
+++ b/Cubelet/pkg/sandboxid/resolve_test.go
@@ -1,0 +1,93 @@
+// Copyright (c) 2024 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package sandboxid
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestResolveExactMatch(t *testing.T) {
+	candidates := []string{
+		"aabbccddeeff00112233445566778899",
+		"112233445566778899aabbccddeeff00",
+	}
+	got, err := Resolve("aabbccddeeff00112233445566778899", candidates)
+	if err != nil {
+		t.Fatalf("Resolve() err=%v", err)
+	}
+	if got != candidates[0] {
+		t.Fatalf("Resolve()=%q, want %q", got, candidates[0])
+	}
+}
+
+func TestResolveUniquePrefix(t *testing.T) {
+	candidates := []string{
+		"aabbccddeeff00112233445566778899",
+		"112233445566778899aabbccddeeff00",
+	}
+	got, err := Resolve("aabbccdd", candidates)
+	if err != nil {
+		t.Fatalf("Resolve() err=%v", err)
+	}
+	if got != candidates[0] {
+		t.Fatalf("Resolve()=%q, want %q", got, candidates[0])
+	}
+}
+
+func TestResolveAmbiguousPrefix(t *testing.T) {
+	candidates := []string{
+		"aabbccddeeff00112233445566778899",
+		"aabbccddeeff00112233445566778898",
+	}
+	_, err := Resolve("aabbccdd", candidates)
+	if !errors.Is(err, ErrAmbiguous) {
+		t.Fatalf("Resolve() err=%v, want ErrAmbiguous", err)
+	}
+}
+
+func TestResolveNotFound(t *testing.T) {
+	_, err := Resolve("deadbeef", []string{"aabbccddeeff00112233445566778899"})
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("Resolve() err=%v, want ErrNotFound", err)
+	}
+}
+
+func TestResolveFullIDRequiresCandidate(t *testing.T) {
+	fullID := "AABBCCDDEEFF00112233445566778899"
+	_, err := Resolve(fullID, nil)
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("Resolve() err=%v, want ErrNotFound", err)
+	}
+
+	got, err := Resolve(fullID, []string{"aabbccddeeff00112233445566778899"})
+	if err != nil {
+		t.Fatalf("Resolve() err=%v", err)
+	}
+	if got != "aabbccddeeff00112233445566778899" {
+		t.Fatalf("Resolve()=%q, want exact candidate", got)
+	}
+}
+
+func TestIsFullID(t *testing.T) {
+	if !IsFullID("aabbccddeeff00112233445566778899") {
+		t.Fatal("IsFullID(full lowercase)=false, want true")
+	}
+	if !IsFullID("AABBCCDDEEFF00112233445566778899") {
+		t.Fatal("IsFullID(full uppercase)=false, want true")
+	}
+	if IsFullID("aabbccdd") {
+		t.Fatal("IsFullID(short)=true, want false")
+	}
+	if IsFullID("aabbccddeeff0011223344556677889g") {
+		t.Fatal("IsFullID(non-hex)=true, want false")
+	}
+}
+
+func TestNormalizeInput(t *testing.T) {
+	if got := NormalizeInput("  abc  "); got != "abc" {
+		t.Fatalf("NormalizeInput()=%q, want %q", got, "abc")
+	}
+}

--- a/Cubelet/pkg/store/cubebox/store.go
+++ b/Cubelet/pkg/store/cubebox/store.go
@@ -6,11 +6,13 @@ package cubebox
 
 import (
 	"errors"
+	"strings"
 
 	jsoniter "github.com/json-iterator/go"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/tools/cache"
 
+	"github.com/tencentcloud/CubeSandbox/Cubelet/pkg/sandboxid"
 	"github.com/tencentcloud/CubeSandbox/Cubelet/pkg/utils"
 	"github.com/tencentcloud/CubeSandbox/Cubelet/plugins/cube/multimeta"
 )
@@ -114,7 +116,23 @@ func (s *Store) Add(box *CubeBox) {
 }
 
 func (s *Store) Get(id string) (*CubeBox, error) {
-	obj, exist, err := s.indexer.GetByKey(id)
+	id = sandboxid.NormalizeInput(id)
+	if sandboxid.IsFullID(id) {
+		return s.getByKey(strings.ToLower(id))
+	}
+
+	resolved, err := s.resolveID(id)
+	if err != nil {
+		if errors.Is(err, sandboxid.ErrNotFound) {
+			return nil, utils.ErrorKeyNotFound
+		}
+		return nil, err
+	}
+	return s.getByKey(resolved)
+}
+
+func (s *Store) getByKey(key string) (*CubeBox, error) {
+	obj, exist, err := s.indexer.GetByKey(key)
 	if err != nil {
 		return nil, err
 	}
@@ -126,6 +144,15 @@ func (s *Store) Get(id string) (*CubeBox, error) {
 		return nil, errors.New("obj is not a cubebox")
 	}
 	return cb, nil
+}
+
+func (s *Store) resolveID(input string) (string, error) {
+	boxes := s.List()
+	candidates := make([]string, 0, len(boxes))
+	for _, cb := range boxes {
+		candidates = append(candidates, cb.ID)
+	}
+	return sandboxid.Resolve(input, candidates)
 }
 
 func (s *Store) GetContainer(id string) (*Container, error) {


### PR DESCRIPTION
## Summary

Sandbox IDs are 32-character lowercase hex strings (UUID without dashes). `cubecli ls` truncates them to 12 characters for display, but several APIs and CLIs previously required the full ID or used naive `strings.HasPrefix` matching without ambiguity checks.

This PR adds a shared sandbox ID resolver and wires it through CubeMaster, Cubelet, and CLI entry points so that:

- **Display** can stay short (12-char truncation unchanged; `--no-trunc` still shows the full ID)
- **Input** accepts either a full 32-char ID or a **unique** short prefix
- **Ambiguous** prefixes return a clear error instead of silently matching the wrong sandbox
- **Missing** IDs return a not-found error

### Core resolver (`sandboxid.Resolve`)

| Case | Behavior |
|------|----------|
| Exact match (case-insensitive hex) | Return canonical full ID |
| Unique prefix among candidates | Return the matching full ID |
| Multiple prefix matches | `ambiguous sandbox id prefix` |
| No match (full or short) | `sandbox id not found` |

Unmatched full 32-char IDs are **not** passthrough; they must appear in the candidate set (local cache and/or cluster scan).

### Changes by component

**CubeMaster**
- New `pkg/sandboxid/` with table-driven unit tests
- `ResolveSandboxID()` falls through from local cache to a bounded cluster scan on both `ErrNotFound` and `ErrAmbiguous` (stale/partial cache)
- Wired into sandbox service paths (`SandboxInfo`, `DestroySandbox`, `Exec`, `Update`, `SetTimeout`, `Refresh`) with early normalize on destroy
- HTTP handlers: snapshot create/rollback, template commit, sandbox logs
- `cubemastercli list --sandboxid` filter uses prefix resolution

**Cubelet**
- New `pkg/sandboxid/` (same logic, separate module)
- `Store.Get()` keeps an O(1) full-ID fast path; prefix resolution only for short inputs
- `cubecli destroy` / `inspect` resolve unique sandbox or container ID prefixes

## Test plan

- [x] `go test ./pkg/sandboxid/ ./pkg/service/sandbox/ -run 'TestResolve|TestIsFullID|TestNormalizeInput|TestCacheResolve|TestMergeSandbox|TestDestroySandboxMissing'`
- [x] `go test ./cmd/cubecli/commands/cubebox/ -run TestResolveSandbox` (Cubelet)
- [ ] Manual: short unique prefix destroy/info succeeds; ambiguous prefix errors; unmatched full ID returns not-found
