### PR TITLE
docs: quote pip extras install examples

### DIFF
--- a/examples/mini-rl-training/mini-swe-agent-patch/README.md
+++ b/examples/mini-rl-training/mini-swe-agent-patch/README.md
@@ -15,7 +15,7 @@
 安装 mini-swe-agent 后，运行 patch 脚本将改动文件覆盖到 site-packages：
 
 ```bash
-pip install mini-swe-agent[extra]
+pip install 'mini-swe-agent[extra]'
 bash install.sh
 ```
 


### PR DESCRIPTION
## Summary
- Quote `pip install` examples that include extras.

## Why
- Shells such as zsh can expand unquoted bracket expressions before `pip` receives them.

## Scope
- Files changed:
- `examples/mini-rl-training/mini-swe-agent-patch/README.md`
- This does not change dependencies or runtime behavior.

## Testing
- `git diff --check`

## Maintainer Fit
- Small install-command correctness fix.
- Duplicate PR search terms checked: `quote pip extras`, `quote optional dependency`, `zsh pip install extras`, `pip extras install examples`