### PR TITLE
Docs/pi agent integration

### DIFF
--- a/docs/guide/integrations/index.md
+++ b/docs/guide/integrations/index.md
@@ -47,4 +47,4 @@ lang: en-US
 
 | Title | Author | Date | Tags |
 | --- | --- | --- | --- |
-| _Add your article here_ | - | - | - |
+| [Pi Agent Integration Guide](./pi-agent.md) | chaojixinren | 2026-07-01 | integration, pi-agent, coding-agent, agent |

--- a/docs/guide/integrations/pi-agent.md
+++ b/docs/guide/integrations/pi-agent.md
@@ -142,7 +142,7 @@ the VM, so the key lives only for the lifetime of that command:
 ```python
 result = sandbox.commands.run(
     "cd /workspace && pi --mode json --provider anthropic "
-    "--model claude-sonnet-4-20250514 --approve 'do something'",
+    "--model claude-sonnet-4-6 --approve 'do something'",
     envs={"ANTHROPIC_API_KEY": key},
     user="root",
     timeout=900,
@@ -239,7 +239,7 @@ inside the sandbox.
 ```python
 cmd = (
     "cd /workspace && pi --mode json "
-    "--provider anthropic --model claude-sonnet-4-20250514 "
+    "--provider anthropic --model claude-sonnet-4-6 "
     "--approve 'Inspect the project, run app.py, and summarize the result.'"
 )
 result = sandbox.commands.run(cmd, envs=pi_env, user="root", timeout=900)

--- a/docs/guide/integrations/pi-agent.md
+++ b/docs/guide/integrations/pi-agent.md
@@ -198,7 +198,7 @@ rules = [
             "audit": "metadata",
             "inject": [
                 {"header": "x-api-key", "secret": ANTHROPIC_API_KEY, "format": "${SECRET}"},
-                {"header": "anthropic-version", "secret": "2023-06-01"},
+                {"header": "anthropic-version", "secret": "2023-06-01", "format": "${SECRET}"},
             ],
         },
     },
@@ -206,7 +206,7 @@ rules = [
 
 sandbox = Sandbox.create(
     template=CUBE_TEMPLATE_ID,
-    allow_internet_access=True,
+    allow_internet_access=False,  # default-deny at L3/L4; the rule's host is auto-allowed
     network={"rules": rules},
 )
 ```
@@ -215,7 +215,7 @@ Effect:
 
 - `printenv ANTHROPIC_API_KEY` inside the sandbox shows only a placeholder.
 - Every request to the LLM host gets the auth header attached on the wire.
-- Anything else is default-denied and returned as `403 Forbidden - CubeEgress`.
+- Anything else is dropped by CubeVS at L3/L4 (`allow_internet_access=False`) and never leaves the sandbox.
 - Every allow / deny decision lands in the egress audit log.
 
 For non-Anthropic providers the example injects `Authorization: Bearer ${SECRET}`

--- a/docs/guide/integrations/pi-agent.md
+++ b/docs/guide/integrations/pi-agent.md
@@ -131,9 +131,11 @@ pip install -r requirements.txt
 
 ### 4. Runtime Configuration and API Key Injection
 
-The Pi command is built headlessly (no TUI) with an explicit provider/model and
-`--mode json` so the host can capture a machine-readable result. Two key-flow
-flavors share the same template:
+The Pi command is built headlessly with `--print` (process the prompt and exit,
+no TUI), an explicit provider/model, and `--mode json` so the host can capture a
+machine-readable JSONL event stream. `--approve` trusts the project-local files
+in the sandbox for this run, and the prompt is the trailing positional argument.
+Two key-flow flavors share the same template:
 
 **Direct flavor** — forward the key per command. `e2b`'s `commands.run(envs=...)`
 puts the environment into the exec envelope, not into a persistent file inside
@@ -141,7 +143,7 @@ the VM, so the key lives only for the lifetime of that command:
 
 ```python
 result = sandbox.commands.run(
-    "cd /workspace && pi --mode json --provider anthropic "
+    "cd /workspace && pi --print --mode json --provider anthropic "
     "--model claude-sonnet-4-6 --approve 'do something'",
     envs={"ANTHROPIC_API_KEY": key},
     user="root",
@@ -238,7 +240,7 @@ inside the sandbox.
 
 ```python
 cmd = (
-    "cd /workspace && pi --mode json "
+    "cd /workspace && pi --print --mode json "
     "--provider anthropic --model claude-sonnet-4-6 "
     "--approve 'Inspect the project, run app.py, and summarize the result.'"
 )
@@ -264,8 +266,8 @@ version = sandbox.commands.run("pi --version", timeout=60)
 - **Egress side-effects.** Tasks that `npm install` or fetch MCP tools need those
   hosts allowed or preinstalled into the template.
 - **Interactive TTY features.** The Pi TUI is not available over the E2B
-  protocol. Use headless `--mode json` and drive multi-turn conversations from
-  the host script.
+  protocol. Use headless `--print --mode json` and drive multi-turn
+  conversations from the host script.
 
 ## Troubleshooting
 

--- a/docs/guide/integrations/pi-agent.md
+++ b/docs/guide/integrations/pi-agent.md
@@ -269,9 +269,11 @@ version = sandbox.commands.run("pi --version", timeout=60)
   dir (`/root/.pi/agent/`), which survives `pause()` / `resume()`. For strict
   isolation prefer the vault flavor (`network_policy.py`), where the key never
   enters the VM.
-- **CubeEgress CA.** For the vault flavor to work, the sandbox must trust the
-  CubeEgress root CA. This is on by default for templates built via
-  `cubemastercli tpl create-from-image`.
+- **CubeEgress CA (Node).** For the vault flavor the sandbox must trust the
+  CubeEgress root CA, which the base image installs into the system bundle. Pi
+  runs on Node.js, which ignores the system store, so `network_policy.py` also
+  sets `NODE_EXTRA_CA_CERTS` (override via `PI_NODE_EXTRA_CA_CERTS`) — without
+  it the vault path fails with `Connection error`.
 - **Egress side-effects.** Tasks that `npm install` or fetch MCP tools need those
   hosts allowed or preinstalled into the template.
 - **Interactive TTY features.** The Pi TUI is not available over the E2B
@@ -285,7 +287,7 @@ version = sandbox.commands.run("pi --version", timeout=60)
 | `pi: command not found` in preflight | Template not rebuilt after CLI change | Rebuild the image, re-register the template |
 | Provider auth failure | Key not forwarded (direct) or missing inject rule (vault) | Pass `envs={...}` or fix the rule's `sni`/`host` |
 | `403 Forbidden - CubeEgress` | Default-deny with no matching allow rule | Add the LLM host (and any extra hosts) to the rules |
-| SSL handshake failure to the LLM host | Sandbox doesn't trust the CubeEgress CA | Rebuild with the Cube CA enabled, or set `SSL_CERT_FILE` |
+| `Connection error` / TLS failure from Pi (vault) | Pi's Node runtime ignores the system CA store, so it won't trust the CubeEgress CA | The example sets `NODE_EXTRA_CA_CERTS`; override with `PI_NODE_EXTRA_CA_CERTS` if the CA lives elsewhere |
 | Template creation stuck in `PULLING` | Registry unreachable from Cube nodes | Push to a registry the cluster can reach; supply auth if needed |
 | Readiness probe timeout | Base image without envd | Ensure `FROM ghcr.io/tencentcloud/cubesandbox-base:2026.16` |
 | `pause()` / `connect()` errors | Platform too old for snapshots | Upgrade the CubeSandbox platform |

--- a/docs/guide/integrations/pi-agent.md
+++ b/docs/guide/integrations/pi-agent.md
@@ -153,6 +153,10 @@ result = sandbox.commands.run(
 
 **Vault flavor** — keep the key out of the VM entirely (see step 6).
 
+The example scripts parse this JSONL and print a concise transcript by default
+(assistant text, tool calls, and any failures); pass `--raw` (or set
+`PI_STREAM_RAW=1`) to see the raw event stream.
+
 ### 5. Session Persistence (pause / resume)
 
 ```bash

--- a/docs/guide/integrations/pi-agent.md
+++ b/docs/guide/integrations/pi-agent.md
@@ -260,6 +260,11 @@ version = sandbox.commands.run("pi --version", timeout=60)
 - **Agent state directory.** `/root/.pi/agent` holds Pi's session cache. Keep it
   empty in the image to avoid leaking sessions across tenants; it is created at
   build time but not populated with any credentials.
+- **Direct-flavor key persistence.** With the direct flavor (`envs=`) the key is
+  scoped to the exec call, but Pi may cache provider credentials under its state
+  dir (`/root/.pi/agent/`), which survives `pause()` / `resume()`. For strict
+  isolation prefer the vault flavor (`network_policy.py`), where the key never
+  enters the VM.
 - **CubeEgress CA.** For the vault flavor to work, the sandbox must trust the
   CubeEgress root CA. This is on by default for templates built via
   `cubemastercli tpl create-from-image`.

--- a/docs/guide/integrations/pi-agent.md
+++ b/docs/guide/integrations/pi-agent.md
@@ -189,24 +189,24 @@ finally:
 default-deny egress plus on-the-wire key injection.
 
 ```python
+# Credential injection uses the native cubesandbox SDK (see security-proxy.md).
+from cubesandbox import Sandbox, Rule, Match, Action, Inject
+
+host = "api.anthropic.com"
 rules = [
-    {
-        "name": "allow_anthropic_llm",
-        "match": {"scheme": "https", "sni": "api.anthropic.com", "host": "api.anthropic.com"},
-        "action": {
-            "allow": True,
-            "audit": "metadata",
-            "inject": [
-                {"header": "x-api-key", "secret": ANTHROPIC_API_KEY, "format": "${SECRET}"},
-                {"header": "anthropic-version", "secret": "2023-06-01", "format": "${SECRET}"},
-            ],
-        },
-    },
+    Rule(
+        name="allow_anthropic_llm",
+        match=Match(scheme="https", sni=host, host=host),
+        action=Action(allow=True, audit="metadata", inject=[
+            Inject(header="x-api-key", secret=ANTHROPIC_API_KEY, format="${SECRET}"),
+            Inject(header="anthropic-version", secret="2023-06-01", format="${SECRET}"),
+        ]),
+    ),
 ]
 
 sandbox = Sandbox.create(
     template=CUBE_TEMPLATE_ID,
-    allow_internet_access=False,  # default-deny at L3/L4; the rule's host is auto-allowed
+    allow_internet_access=False,   # default-deny; the rule's host is auto-allowed
     network={"rules": rules},
 )
 ```
@@ -218,7 +218,7 @@ Effect:
 - Anything else is dropped by CubeVS at L3/L4 (`allow_internet_access=False`) and never leaves the sandbox.
 - Every allow / deny decision lands in the egress audit log.
 
-For non-Anthropic providers the example injects `Authorization: Bearer ${SECRET}`
+For non-Anthropic providers the example injects an `Authorization: Bearer` header
 instead. If a provider does not accept a header-injected key, fall back to the
 direct flavor (`envs=...`) — but never write the key into a persistent file
 inside the sandbox.

--- a/docs/guide/integrations/pi-agent.md
+++ b/docs/guide/integrations/pi-agent.md
@@ -1,0 +1,289 @@
+---
+title: Pi Agent Integration Guide
+author: chaojixinren
+date: 2026-07-01
+tags:
+  - integration
+  - pi-agent
+  - coding-agent
+  - agent
+lang: en-US
+---
+
+# Pi Agent Integration Guide
+
+[中文文档](../../zh/guide/integrations/pi-agent.md)
+
+Run the [Pi coding agent](https://www.npmjs.com/package/@earendil-works/pi-coding-agent)
+— a terminal-native AI coding agent — inside CubeSandbox MicroVMs. This guide
+covers image build, key injection, egress control, and snapshot-based session
+persistence, and pairs with the runnable
+[`examples/pi-agent-integration`](https://github.com/TencentCloud/CubeSandbox/tree/master/examples/pi-agent-integration)
+project.
+
+## Integration Target and Version
+
+| Component | Version |
+|---|---|
+| Pi coding agent | `@earendil-works/pi-coding-agent` (pinned via `--build-arg PI_VERSION=x.y.z`) |
+| Node.js | 24 (installed via NodeSource) |
+| CubeSandbox base image | `ghcr.io/tencentcloud/cubesandbox-base:2026.16` |
+| E2B SDK (host driver) | `e2b` (latest) |
+| CubeSandbox platform | `>= 0.3.0` (pause/resume) / `>= 0.4.0` (CubeEgress credential vault) |
+
+## Prerequisites
+
+- A running CubeSandbox deployment; CubeAPI reachable at `http://<node>:3000`.
+- `cubemastercli` on `$PATH`, connected to the cluster.
+- Docker on the build workstation, plus a registry the Cube nodes can pull from.
+- An LLM provider API key. Anthropic is the default; any Anthropic-compatible or
+  OpenAI-compatible endpoint works via `ANTHROPIC_BASE_URL` / provider env.
+- Python 3.10+ for the host driver scripts.
+
+## Why Run Pi Inside a Sandbox
+
+Pi is a terminal agent that edits files, runs commands, and installs packages.
+Running it directly on a workstation blends the agent's blast radius with your
+dev environment. Running it inside CubeSandbox gives you:
+
+| Concern | CubeSandbox provides |
+|---|---|
+| **Isolation** | KVM MicroVM per session, dedicated guest kernel |
+| **Reproducibility** | Every session boots from the same template snapshot |
+| **Fast spin-up** | Sub-60 ms cold start, so N-parallel agents are cheap |
+| **Long tasks** | `sandbox.pause()` snapshots VM + rootfs; resume later |
+| **Key hygiene** | CubeEgress injects the auth header on the wire — the VM never sees the real key |
+| **Egress audit** | Every request to the LLM API is recorded in the egress audit log |
+
+## Integration Steps
+
+### 1. Build the template image
+
+The image stacks Node.js 24 and the Pi CLI on top of `cubesandbox-base`, so
+envd is already listening on `:49983`.
+
+```dockerfile
+# examples/pi-agent-integration/Dockerfile (excerpt)
+ARG CUBE_BASE_IMAGE=ghcr.io/tencentcloud/cubesandbox-base:2026.16
+FROM ${CUBE_BASE_IMAGE}
+
+ARG NODE_MAJOR=24
+ARG PI_VERSION=0.80.3
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        ca-certificates curl git gnupg jq less procps python3 python3-pip ripgrep \
+    && curl -fsSL "https://deb.nodesource.com/setup_${NODE_MAJOR}.x" | bash - \
+    && apt-get install -y --no-install-recommends nodejs \
+    && npm install -g --ignore-scripts "@earendil-works/pi-coding-agent@${PI_VERSION}" \
+    && pi --version \
+    && npm cache clean --force \
+    && rm -rf /root/.npm /var/lib/apt/lists/*
+
+WORKDIR /workspace
+EXPOSE 49983
+```
+
+Build and push:
+
+```bash
+docker build --platform linux/amd64 \
+  -t <your-registry>/pi-agent-cube:latest \
+  examples/pi-agent-integration
+docker push <your-registry>/pi-agent-cube:latest
+```
+
+### 2. Register as a Cube template
+
+```bash
+cubemastercli tpl create-from-image \
+  --image <your-registry>/pi-agent-cube:latest \
+  --writable-layer-size 4G \
+  --expose-port 49983 \
+  --probe       49983 \
+  --probe-path  /health
+
+cubemastercli tpl watch --job-id <job_id>
+```
+
+Once the job reaches `READY`, note the `template_id` — you pass it to every
+`Sandbox.create()` call. `4G` writable layer suits medium tasks; bump to `8G+`
+if the agent installs large toolchains.
+
+### 3. Wire up the host driver
+
+```bash
+cd examples/pi-agent-integration
+cp .env.example .env
+# fill in E2B_API_URL, CUBE_TEMPLATE_ID, and your provider key
+pip install -r requirements.txt
+```
+
+| Variable | Where it flows | Notes |
+|---|---|---|
+| `E2B_API_URL` | Local process | CubeAPI address (`http://<node>:3000`) |
+| `E2B_API_KEY` | Local process | Any non-empty string in local dev |
+| `CUBE_TEMPLATE_ID` | `Sandbox.create(template=...)` | From step 2 |
+| `PI_PROVIDER` / `PI_MODEL` | Pi CLI flags | Provider and model selection |
+| `ANTHROPIC_API_KEY` | `envs=...` (direct) or CubeEgress inject (vault) | Provider key |
+| `ANTHROPIC_BASE_URL` | Passed into the exec env | Anthropic-compatible gateways (e.g. DeepSeek) |
+| `PI_LLM_HOST` | `network_policy.py` | LLM host allowed under default-deny egress |
+
+### 4. Runtime Configuration and API Key Injection
+
+The Pi command is built headlessly (no TUI) with an explicit provider/model and
+`--mode json` so the host can capture a machine-readable result. Two key-flow
+flavors share the same template:
+
+**Direct flavor** — forward the key per command. `e2b`'s `commands.run(envs=...)`
+puts the environment into the exec envelope, not into a persistent file inside
+the VM, so the key lives only for the lifetime of that command:
+
+```python
+result = sandbox.commands.run(
+    "cd /workspace && pi --mode json --provider anthropic "
+    "--model claude-sonnet-4-20250514 --approve 'do something'",
+    envs={"ANTHROPIC_API_KEY": key},
+    user="root",
+    timeout=900,
+)
+```
+
+**Vault flavor** — keep the key out of the VM entirely (see step 6).
+
+### 5. Session Persistence (pause / resume)
+
+```bash
+python resume_pi_agent.py
+```
+
+This mirrors the [snapshot / clone / rollback](../snapshot-rollback-clone.md)
+engine at the SDK layer:
+
+- `sandbox.pause()` snapshots the running VM (memory + rootfs) and frees compute.
+- `Sandbox.connect(sandbox_id)` resumes with `/workspace`, Pi's state directory
+  (`/root/.pi/agent`), and every other file intact.
+
+> **Lifecycle caveat:** manage the sandbox lifecycle with `try/finally`, not a
+> `with Sandbox.create(...)` context manager. On `__exit__` the context manager
+> kills the sandbox, which would undo the pause. The example creates the sandbox
+> explicitly and only calls `sandbox.kill()` in `finally`.
+
+```python
+sandbox = Sandbox.create(template=template_id, timeout=1800)
+try:
+    run_turn(sandbox, prompt_1)          # writes /workspace/plan.md
+    sandbox_id = sandbox.pause() or sandbox.sandbox_id
+    sandbox = Sandbox.connect(sandbox_id)
+    assert_state_survived(sandbox)       # /workspace + /root/.pi/agent intact
+    run_turn(sandbox, prompt_2)          # continues the work
+finally:
+    sandbox.kill()
+```
+
+### 6. Network and Egress Policy (credential vault)
+
+`network_policy.py` demonstrates the recommended pattern for shared clusters:
+default-deny egress plus on-the-wire key injection.
+
+```python
+rules = [
+    {
+        "name": "allow_anthropic_llm",
+        "match": {"scheme": "https", "sni": "api.anthropic.com", "host": "api.anthropic.com"},
+        "action": {
+            "allow": True,
+            "audit": "metadata",
+            "inject": [
+                {"header": "x-api-key", "secret": ANTHROPIC_API_KEY, "format": "${SECRET}"},
+                {"header": "anthropic-version", "secret": "2023-06-01"},
+            ],
+        },
+    },
+]
+
+sandbox = Sandbox.create(
+    template=CUBE_TEMPLATE_ID,
+    allow_internet_access=True,
+    network={"rules": rules},
+)
+```
+
+Effect:
+
+- `printenv ANTHROPIC_API_KEY` inside the sandbox shows only a placeholder.
+- Every request to the LLM host gets the auth header attached on the wire.
+- Anything else is default-denied and returned as `403 Forbidden - CubeEgress`.
+- Every allow / deny decision lands in the egress audit log.
+
+For non-Anthropic providers the example injects `Authorization: Bearer ${SECRET}`
+instead. If a provider does not accept a header-injected key, fall back to the
+direct flavor (`envs=...`) — but never write the key into a persistent file
+inside the sandbox.
+
+## Use Cases and Best Practices
+
+- **Isolated development.** Run the coding agent inside the sandbox so its file
+  edits and shell commands cannot touch the host.
+- **Execute agent-generated code and collect results.** Have the agent write to
+  `/workspace`, then read artifacts back via `sandbox.files` or `commands.run`.
+- **Checkpoint / resume long tasks.** Use `pause()` + `connect()` to snapshot a
+  long refactor and resume later, or fork multiple task variants off one snapshot.
+- **Preinstall heavy dependencies** into the template rather than fetching them
+  at runtime, especially under a default-deny egress policy.
+
+## Key Code Snippets
+
+### Headless Pi invocation
+
+```python
+cmd = (
+    "cd /workspace && pi --mode json "
+    "--provider anthropic --model claude-sonnet-4-20250514 "
+    "--approve 'Inspect the project, run app.py, and summarize the result.'"
+)
+result = sandbox.commands.run(cmd, envs=pi_env, user="root", timeout=900)
+```
+
+### Preflight version check
+
+```python
+version = sandbox.commands.run("pi --version", timeout=60)
+```
+
+## Caveats
+
+- **Node.js version.** Pi needs a recent Node runtime; the base image ships an
+  older apt Node, so always install via NodeSource (the Dockerfile does).
+- **Agent state directory.** `/root/.pi/agent` holds Pi's session cache. Keep it
+  empty in the image to avoid leaking sessions across tenants; it is created at
+  build time but not populated with any credentials.
+- **CubeEgress CA.** For the vault flavor to work, the sandbox must trust the
+  CubeEgress root CA. This is on by default for templates built via
+  `cubemastercli tpl create-from-image`.
+- **Egress side-effects.** Tasks that `npm install` or fetch MCP tools need those
+  hosts allowed or preinstalled into the template.
+- **Interactive TTY features.** The Pi TUI is not available over the E2B
+  protocol. Use headless `--mode json` and drive multi-turn conversations from
+  the host script.
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| `pi: command not found` in preflight | Template not rebuilt after CLI change | Rebuild the image, re-register the template |
+| Provider auth failure | Key not forwarded (direct) or missing inject rule (vault) | Pass `envs={...}` or fix the rule's `sni`/`host` |
+| `403 Forbidden - CubeEgress` | Default-deny with no matching allow rule | Add the LLM host (and any extra hosts) to the rules |
+| SSL handshake failure to the LLM host | Sandbox doesn't trust the CubeEgress CA | Rebuild with the Cube CA enabled, or set `SSL_CERT_FILE` |
+| Template creation stuck in `PULLING` | Registry unreachable from Cube nodes | Push to a registry the cluster can reach; supply auth if needed |
+| Readiness probe timeout | Base image without envd | Ensure `FROM ghcr.io/tencentcloud/cubesandbox-base:2026.16` |
+| `pause()` / `connect()` errors | Platform too old for snapshots | Upgrade the CubeSandbox platform |
+
+## References
+
+- Runnable example: [`examples/pi-agent-integration`](https://github.com/TencentCloud/CubeSandbox/tree/master/examples/pi-agent-integration)
+- Bring Your Own Image: [`docs/guide/tutorials/bring-your-own-image.md`](../tutorials/bring-your-own-image.md)
+- Template from image: [`docs/guide/tutorials/template-from-image.md`](../tutorials/template-from-image.md)
+- Snapshot / Clone / Rollback: [`docs/guide/snapshot-rollback-clone.md`](../snapshot-rollback-clone.md)
+- Credential vault + egress control: [`docs/guide/security-proxy.md`](../security-proxy.md)
+- Pi coding agent: <https://www.npmjs.com/package/@earendil-works/pi-coding-agent>

--- a/docs/zh/guide/integrations/index.md
+++ b/docs/zh/guide/integrations/index.md
@@ -47,4 +47,4 @@ lang: zh-CN
 
 | 标题 | 作者 | 日期 | 标签 |
 | --- | --- | --- | --- |
-| _在这里补充你的文章_ | - | - | - |
+| [Pi Agent 集成指南](./pi-agent.md) | chaojixinren | 2026-07-01 | integration, pi-agent, coding-agent, agent |

--- a/docs/zh/guide/integrations/pi-agent.md
+++ b/docs/zh/guide/integrations/pi-agent.md
@@ -181,7 +181,7 @@ rules = [
             "audit": "metadata",
             "inject": [
                 {"header": "x-api-key", "secret": ANTHROPIC_API_KEY, "format": "${SECRET}"},
-                {"header": "anthropic-version", "secret": "2023-06-01"},
+                {"header": "anthropic-version", "secret": "2023-06-01", "format": "${SECRET}"},
             ],
         },
     },
@@ -189,7 +189,7 @@ rules = [
 
 sandbox = Sandbox.create(
     template=CUBE_TEMPLATE_ID,
-    allow_internet_access=True,
+    allow_internet_access=False,  # L3/L4 默认拒绝；规则里的 host 会被自动放行
     network={"rules": rules},
 )
 ```
@@ -198,7 +198,7 @@ sandbox = Sandbox.create(
 
 - 沙箱内 `printenv ANTHROPIC_API_KEY` 只显示占位值。
 - 每次访问 LLM host 都会在链路上被附加鉴权头。
-- 其他任何目的地都被默认拒绝，返回 `403 Forbidden - CubeEgress`。
+- 其他任何目的地都会被 CubeVS 在 L3/L4 层丢弃（`allow_internet_access=False`），根本无法离开沙箱。
 - 每条 allow / deny 决策都会记入出网审计日志。
 
 非 Anthropic provider 时，示例会改注入 `Authorization: Bearer ${SECRET}`。若某 provider 不接受 header 注入的密钥，可回退到直连方式（`envs=...`）—— 但绝不要把密钥写进沙箱内的持久文件。

--- a/docs/zh/guide/integrations/pi-agent.md
+++ b/docs/zh/guide/integrations/pi-agent.md
@@ -131,7 +131,7 @@ Pi 命令以无交互（无 TUI）方式构造，显式指定 provider/model 并
 ```python
 result = sandbox.commands.run(
     "cd /workspace && pi --mode json --provider anthropic "
-    "--model claude-sonnet-4-20250514 --approve 'do something'",
+    "--model claude-sonnet-4-6 --approve 'do something'",
     envs={"ANTHROPIC_API_KEY": key},
     user="root",
     timeout=900,
@@ -218,7 +218,7 @@ sandbox = Sandbox.create(
 ```python
 cmd = (
     "cd /workspace && pi --mode json "
-    "--provider anthropic --model claude-sonnet-4-20250514 "
+    "--provider anthropic --model claude-sonnet-4-6 "
     "--approve 'Inspect the project, run app.py, and summarize the result.'"
 )
 result = sandbox.commands.run(cmd, envs=pi_env, user="root", timeout=900)

--- a/docs/zh/guide/integrations/pi-agent.md
+++ b/docs/zh/guide/integrations/pi-agent.md
@@ -124,13 +124,13 @@ pip install -r requirements.txt
 
 ### 4. 运行时配置与 API Key 注入
 
-Pi 命令以无交互（无 TUI）方式构造，显式指定 provider/model 并使用 `--mode json`，便于宿主端捕获机器可读结果。两种密钥流转方式共用同一个模板：
+Pi 命令以无交互方式构造：`--print` 表示处理完 prompt 即退出（不启动 TUI，否则会在 E2B exec 通道上挂死），配合显式 provider/model 与 `--mode json` 输出机器可读的 JSONL 事件流；`--approve` 是布尔开关，表示本次运行信任沙箱内的项目本地文件，prompt 作为末尾的位置参数传入。两种密钥流转方式共用同一个模板：
 
 **直连方式** —— 逐命令传入密钥。`e2b` 的 `commands.run(envs=...)` 把环境放进 exec 信封，而非 VM 内的持久文件，因此密钥只在该命令执行期间存在：
 
 ```python
 result = sandbox.commands.run(
-    "cd /workspace && pi --mode json --provider anthropic "
+    "cd /workspace && pi --print --mode json --provider anthropic "
     "--model claude-sonnet-4-6 --approve 'do something'",
     envs={"ANTHROPIC_API_KEY": key},
     user="root",
@@ -217,7 +217,7 @@ sandbox = Sandbox.create(
 
 ```python
 cmd = (
-    "cd /workspace && pi --mode json "
+    "cd /workspace && pi --print --mode json "
     "--provider anthropic --model claude-sonnet-4-6 "
     "--approve 'Inspect the project, run app.py, and summarize the result.'"
 )
@@ -237,7 +237,7 @@ version = sandbox.commands.run("pi --version", timeout=60)
 - **CubeEgress CA。** 保险柜方式要求沙箱信任 CubeEgress 根 CA。通过
   `cubemastercli tpl create-from-image` 构建的模板默认已开启。
 - **出网副作用。** 需要 `npm install` 或拉取 MCP 工具的任务，要放行相应 host 或预装进模板。
-- **交互式 TTY 功能。** Pi TUI 在 E2B 协议下不可用。请用无交互 `--mode json`，多轮对话由宿主脚本驱动。
+- **交互式 TTY 功能。** Pi TUI 在 E2B 协议下不可用。请用无交互 `--print --mode json`，多轮对话由宿主脚本驱动。
 
 ## 排错
 

--- a/docs/zh/guide/integrations/pi-agent.md
+++ b/docs/zh/guide/integrations/pi-agent.md
@@ -140,6 +140,8 @@ result = sandbox.commands.run(
 
 **保险柜方式** —— 让密钥完全不进入 VM（见第 6 步）。
 
+示例脚本会解析这份 JSONL，默认打印精简转写（助手文本、工具调用、失败项）；加 `--raw`（或设 `PI_STREAM_RAW=1`）可查看原始事件流。
+
 ### 5. 会话持久化（pause / resume）
 
 ```bash

--- a/docs/zh/guide/integrations/pi-agent.md
+++ b/docs/zh/guide/integrations/pi-agent.md
@@ -172,24 +172,24 @@ finally:
 `network_policy.py` 展示了推荐用于共享集群的模式：默认拒绝出网 + 链路上注入密钥。
 
 ```python
+# 凭证注入使用原生 cubesandbox SDK(见 security-proxy.md)。
+from cubesandbox import Sandbox, Rule, Match, Action, Inject
+
+host = "api.anthropic.com"
 rules = [
-    {
-        "name": "allow_anthropic_llm",
-        "match": {"scheme": "https", "sni": "api.anthropic.com", "host": "api.anthropic.com"},
-        "action": {
-            "allow": True,
-            "audit": "metadata",
-            "inject": [
-                {"header": "x-api-key", "secret": ANTHROPIC_API_KEY, "format": "${SECRET}"},
-                {"header": "anthropic-version", "secret": "2023-06-01", "format": "${SECRET}"},
-            ],
-        },
-    },
+    Rule(
+        name="allow_anthropic_llm",
+        match=Match(scheme="https", sni=host, host=host),
+        action=Action(allow=True, audit="metadata", inject=[
+            Inject(header="x-api-key", secret=ANTHROPIC_API_KEY, format="${SECRET}"),
+            Inject(header="anthropic-version", secret="2023-06-01", format="${SECRET}"),
+        ]),
+    ),
 ]
 
 sandbox = Sandbox.create(
     template=CUBE_TEMPLATE_ID,
-    allow_internet_access=False,  # L3/L4 默认拒绝；规则里的 host 会被自动放行
+    allow_internet_access=False,   # 默认拒绝；规则里的 host 会被自动放行
     network={"rules": rules},
 )
 ```
@@ -201,7 +201,7 @@ sandbox = Sandbox.create(
 - 其他任何目的地都会被 CubeVS 在 L3/L4 层丢弃（`allow_internet_access=False`），根本无法离开沙箱。
 - 每条 allow / deny 决策都会记入出网审计日志。
 
-非 Anthropic provider 时，示例会改注入 `Authorization: Bearer ${SECRET}`。若某 provider 不接受 header 注入的密钥，可回退到直连方式（`envs=...`）—— 但绝不要把密钥写进沙箱内的持久文件。
+非 Anthropic provider 时，示例会改注入 `Authorization: Bearer` 头。若某 provider 不接受 header 注入的密钥，可回退到直连方式（`envs=...`）—— 但绝不要把密钥写进沙箱内的持久文件。
 
 ## 使用场景与最佳实践
 

--- a/docs/zh/guide/integrations/pi-agent.md
+++ b/docs/zh/guide/integrations/pi-agent.md
@@ -237,8 +237,9 @@ version = sandbox.commands.run("pi --version", timeout=60)
 - **Node.js 版本。** Pi 需要较新的 Node 运行时；基础镜像自带的 apt Node 偏旧，务必通过 NodeSource 安装（Dockerfile 已如此）。
 - **Agent 状态目录。** `/root/.pi/agent` 保存 Pi 的会话缓存。镜像里保持它为空，避免跨租户泄露会话；它在构建时创建但不写入任何凭证。
 - **直连方式的密钥留存。** 直连方式（`envs=`）下密钥仅作用于该 exec 调用，但 Pi 可能把 provider 凭证缓存到其状态目录（`/root/.pi/agent/`），会在 `pause()` / `resume()` 后仍留在盘上。对隔离要求高时优先用保险柜方式（`network_policy.py`），密钥完全不进入 VM。
-- **CubeEgress CA。** 保险柜方式要求沙箱信任 CubeEgress 根 CA。通过
-  `cubemastercli tpl create-from-image` 构建的模板默认已开启。
+- **CubeEgress CA（Node）。** 保险柜方式要求沙箱信任 CubeEgress 根 CA，基础镜像已把它装入系统 CA 包。
+  但 Pi 基于 Node.js、忽略系统 CA 库，因此 `network_policy.py` 还会设置 `NODE_EXTRA_CA_CERTS`
+  （可用 `PI_NODE_EXTRA_CA_CERTS` 覆盖）——否则 vault 路径会以 `Connection error` 失败。
 - **出网副作用。** 需要 `npm install` 或拉取 MCP 工具的任务，要放行相应 host 或预装进模板。
 - **交互式 TTY 功能。** Pi TUI 在 E2B 协议下不可用。请用无交互 `--print --mode json`，多轮对话由宿主脚本驱动。
 
@@ -249,7 +250,7 @@ version = sandbox.commands.run("pi --version", timeout=60)
 | preflight 报 `pi: command not found` | CLI 变更后未重建模板 | 重建镜像并重新注册模板 |
 | provider 鉴权失败 | 密钥未传入（直连）或缺少 inject 规则（vault） | 传 `envs={...}` 或修正规则的 `sni`/`host` |
 | `403 Forbidden - CubeEgress` | 默认拒绝且无匹配放行规则 | 把 LLM host（及所需其他 host）加入规则 |
-| 到 LLM host 的 SSL 握手失败 | 沙箱不信任 CubeEgress CA | 重建模板启用 Cube CA，或设置 `SSL_CERT_FILE` |
+| vault 下 Pi 报 `Connection error` / TLS 失败 | Pi 的 Node 运行时忽略系统 CA 库，不信任 CubeEgress CA | 示例已设 `NODE_EXTRA_CA_CERTS`；若 CA 在别处用 `PI_NODE_EXTRA_CA_CERTS` 覆盖 |
 | 模板创建卡在 `PULLING` | Cube 节点无法访问 registry | 推送到集群可访问的 registry，必要时提供鉴权 |
 | 就绪探针超时 | 基础镜像缺少 envd | 确认 `FROM ghcr.io/tencentcloud/cubesandbox-base:2026.16` |
 | `pause()` / `connect()` 报错 | 平台版本过低不支持快照 | 升级 CubeSandbox 平台 |

--- a/docs/zh/guide/integrations/pi-agent.md
+++ b/docs/zh/guide/integrations/pi-agent.md
@@ -1,0 +1,261 @@
+---
+title: Pi Agent 集成指南
+author: chaojixinren
+date: 2026-07-01
+tags:
+  - integration
+  - pi-agent
+  - coding-agent
+  - agent
+lang: zh-CN
+---
+
+# Pi Agent 集成指南
+
+[English](../../../guide/integrations/pi-agent.md)
+
+在 CubeSandbox MicroVM 内运行 [Pi coding agent](https://www.npmjs.com/package/@earendil-works/pi-coding-agent)
+（面向终端的 AI 编码 Agent）。本文覆盖镜像构建、密钥注入、出网管控，以及基于快照的会话持久化，配套的可运行示例位于
+[`examples/pi-agent-integration`](https://github.com/TencentCloud/CubeSandbox/tree/master/examples/pi-agent-integration)。
+
+## 集成对象与版本
+
+| 组件 | 版本 |
+|---|---|
+| Pi coding agent | `@earendil-works/pi-coding-agent`（通过 `--build-arg PI_VERSION=x.y.z` 固定） |
+| Node.js | 24（通过 NodeSource 安装） |
+| CubeSandbox 基础镜像 | `ghcr.io/tencentcloud/cubesandbox-base:2026.16` |
+| E2B SDK（宿主端驱动） | `e2b`（最新） |
+| CubeSandbox 平台 | `>= 0.3.0`（pause/resume）/ `>= 0.4.0`（CubeEgress 密钥保险柜） |
+
+## 前置条件
+
+- 已部署 CubeSandbox，CubeAPI 可访问（`http://<node>:3000`）。
+- `cubemastercli` 已在 `$PATH` 且已连通集群。
+- 构建机装有 Docker，且 registry 能被 Cube 集群拉取。
+- 一个 LLM provider 的 API Key。默认 Anthropic；任何 Anthropic 兼容或 OpenAI 兼容端点均可（通过
+  `ANTHROPIC_BASE_URL` / provider 环境变量）。
+- Python 3.10+（宿主端驱动脚本）。
+
+## 为什么要把 Pi 放进沙箱
+
+Pi 是一个会编辑文件、执行命令、安装依赖的终端 Agent。直接跑在开发机上，Agent 的"爆炸半径"就等于你的开发环境。放进 CubeSandbox 你能拿到：
+
+| 关注点 | CubeSandbox 提供 |
+|---|---|
+| **隔离** | 每个会话一个 KVM MicroVM，独立 guest kernel |
+| **可复现** | 每次会话都从同一个 template 快照启动 |
+| **秒起** | 冷启动 <60ms，N 路并行代价极小 |
+| **长任务** | `sandbox.pause()` 对 VM + rootfs 打快照，稍后恢复 |
+| **密钥卫生** | CubeEgress 在链路上注入鉴权头，VM 看不到真实密钥 |
+| **出网审计** | 每次访问 LLM API 都会记入出网审计日志 |
+
+## 集成步骤
+
+### 1. 构建模板镜像
+
+镜像在 `cubesandbox-base` 上叠加 Node.js 24 与 Pi CLI，envd 已监听 `:49983`。
+
+```dockerfile
+# examples/pi-agent-integration/Dockerfile（节选）
+ARG CUBE_BASE_IMAGE=ghcr.io/tencentcloud/cubesandbox-base:2026.16
+FROM ${CUBE_BASE_IMAGE}
+
+ARG NODE_MAJOR=24
+ARG PI_VERSION=0.80.3
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        ca-certificates curl git gnupg jq less procps python3 python3-pip ripgrep \
+    && curl -fsSL "https://deb.nodesource.com/setup_${NODE_MAJOR}.x" | bash - \
+    && apt-get install -y --no-install-recommends nodejs \
+    && npm install -g --ignore-scripts "@earendil-works/pi-coding-agent@${PI_VERSION}" \
+    && pi --version \
+    && npm cache clean --force \
+    && rm -rf /root/.npm /var/lib/apt/lists/*
+
+WORKDIR /workspace
+EXPOSE 49983
+```
+
+构建并推送：
+
+```bash
+docker build --platform linux/amd64 \
+  -t <your-registry>/pi-agent-cube:latest \
+  examples/pi-agent-integration
+docker push <your-registry>/pi-agent-cube:latest
+```
+
+### 2. 注册为 Cube 模板
+
+```bash
+cubemastercli tpl create-from-image \
+  --image <your-registry>/pi-agent-cube:latest \
+  --writable-layer-size 4G \
+  --expose-port 49983 \
+  --probe       49983 \
+  --probe-path  /health
+
+cubemastercli tpl watch --job-id <job_id>
+```
+
+任务变为 `READY` 后记下 `template_id`，后续每次 `Sandbox.create()` 都要用它。`4G` 可写层适合中等任务；若
+Agent 会安装大型工具链，提升到 `8G+`。
+
+### 3. 配置宿主端驱动
+
+```bash
+cd examples/pi-agent-integration
+cp .env.example .env
+# 填写 E2B_API_URL、CUBE_TEMPLATE_ID 以及你的 provider key
+pip install -r requirements.txt
+```
+
+| 变量 | 作用位置 | 说明 |
+|---|---|---|
+| `E2B_API_URL` | 本地进程 | CubeAPI 地址（`http://<node>:3000`） |
+| `E2B_API_KEY` | 本地进程 | 本地开发填任意非空字符串 |
+| `CUBE_TEMPLATE_ID` | `Sandbox.create(template=...)` | 来自第 2 步 |
+| `PI_PROVIDER` / `PI_MODEL` | Pi CLI 参数 | 选择 provider 与模型 |
+| `ANTHROPIC_API_KEY` | `envs=...`（直连）或 CubeEgress 注入（vault） | provider 密钥 |
+| `ANTHROPIC_BASE_URL` | 传入 exec 环境 | Anthropic 兼容网关（如 DeepSeek） |
+| `PI_LLM_HOST` | `network_policy.py` | 默认拒绝出网下放行的 LLM host |
+
+### 4. 运行时配置与 API Key 注入
+
+Pi 命令以无交互（无 TUI）方式构造，显式指定 provider/model 并使用 `--mode json`，便于宿主端捕获机器可读结果。两种密钥流转方式共用同一个模板：
+
+**直连方式** —— 逐命令传入密钥。`e2b` 的 `commands.run(envs=...)` 把环境放进 exec 信封，而非 VM 内的持久文件，因此密钥只在该命令执行期间存在：
+
+```python
+result = sandbox.commands.run(
+    "cd /workspace && pi --mode json --provider anthropic "
+    "--model claude-sonnet-4-20250514 --approve 'do something'",
+    envs={"ANTHROPIC_API_KEY": key},
+    user="root",
+    timeout=900,
+)
+```
+
+**保险柜方式** —— 让密钥完全不进入 VM（见第 6 步）。
+
+### 5. 会话持久化（pause / resume）
+
+```bash
+python resume_pi_agent.py
+```
+
+它在 SDK 层复用了[快照 / 克隆 / 回滚](../snapshot-rollback-clone.md)引擎：
+
+- `sandbox.pause()` 对运行中的 VM（内存 + rootfs）打快照并释放算力。
+- `Sandbox.connect(sandbox_id)` 恢复时，`/workspace`、Pi 状态目录（`/root/.pi/agent`）及其他文件都完好无损。
+
+> **生命周期注意：** 用 `try/finally` 手动管理沙箱，不要用 `with Sandbox.create(...)` context manager。
+> context manager 在 `__exit__` 时会 kill 沙箱，这会让 pause 失效。示例显式创建沙箱，只在 `finally` 里调用
+> `sandbox.kill()`。
+
+```python
+sandbox = Sandbox.create(template=template_id, timeout=1800)
+try:
+    run_turn(sandbox, prompt_1)          # 写入 /workspace/plan.md
+    sandbox_id = sandbox.pause() or sandbox.sandbox_id
+    sandbox = Sandbox.connect(sandbox_id)
+    assert_state_survived(sandbox)       # /workspace + /root/.pi/agent 仍在
+    run_turn(sandbox, prompt_2)          # 继续工作
+finally:
+    sandbox.kill()
+```
+
+### 6. 网络与出网策略（密钥保险柜）
+
+`network_policy.py` 展示了推荐用于共享集群的模式：默认拒绝出网 + 链路上注入密钥。
+
+```python
+rules = [
+    {
+        "name": "allow_anthropic_llm",
+        "match": {"scheme": "https", "sni": "api.anthropic.com", "host": "api.anthropic.com"},
+        "action": {
+            "allow": True,
+            "audit": "metadata",
+            "inject": [
+                {"header": "x-api-key", "secret": ANTHROPIC_API_KEY, "format": "${SECRET}"},
+                {"header": "anthropic-version", "secret": "2023-06-01"},
+            ],
+        },
+    },
+]
+
+sandbox = Sandbox.create(
+    template=CUBE_TEMPLATE_ID,
+    allow_internet_access=True,
+    network={"rules": rules},
+)
+```
+
+效果：
+
+- 沙箱内 `printenv ANTHROPIC_API_KEY` 只显示占位值。
+- 每次访问 LLM host 都会在链路上被附加鉴权头。
+- 其他任何目的地都被默认拒绝，返回 `403 Forbidden - CubeEgress`。
+- 每条 allow / deny 决策都会记入出网审计日志。
+
+非 Anthropic provider 时，示例会改注入 `Authorization: Bearer ${SECRET}`。若某 provider 不接受 header 注入的密钥，可回退到直连方式（`envs=...`）—— 但绝不要把密钥写进沙箱内的持久文件。
+
+## 使用场景与最佳实践
+
+- **隔离开发。** 把编码 Agent 跑在沙箱内，其文件编辑与 shell 命令无法触及宿主。
+- **执行 Agent 生成的代码并回收结果。** 让 Agent 写入 `/workspace`，再通过 `sandbox.files` 或
+  `commands.run` 读回产物。
+- **长任务断点续跑。** 用 `pause()` + `connect()` 给长时间重构打快照并稍后恢复，或从一个快照分叉多个任务变体。
+- **把重依赖预装进模板**，而不是运行时拉取，尤其在默认拒绝出网的策略下。
+
+## 关键代码片段
+
+### 无交互调用 Pi
+
+```python
+cmd = (
+    "cd /workspace && pi --mode json "
+    "--provider anthropic --model claude-sonnet-4-20250514 "
+    "--approve 'Inspect the project, run app.py, and summarize the result.'"
+)
+result = sandbox.commands.run(cmd, envs=pi_env, user="root", timeout=900)
+```
+
+### preflight 版本检查
+
+```python
+version = sandbox.commands.run("pi --version", timeout=60)
+```
+
+## 注意事项
+
+- **Node.js 版本。** Pi 需要较新的 Node 运行时；基础镜像自带的 apt Node 偏旧，务必通过 NodeSource 安装（Dockerfile 已如此）。
+- **Agent 状态目录。** `/root/.pi/agent` 保存 Pi 的会话缓存。镜像里保持它为空，避免跨租户泄露会话；它在构建时创建但不写入任何凭证。
+- **CubeEgress CA。** 保险柜方式要求沙箱信任 CubeEgress 根 CA。通过
+  `cubemastercli tpl create-from-image` 构建的模板默认已开启。
+- **出网副作用。** 需要 `npm install` 或拉取 MCP 工具的任务，要放行相应 host 或预装进模板。
+- **交互式 TTY 功能。** Pi TUI 在 E2B 协议下不可用。请用无交互 `--mode json`，多轮对话由宿主脚本驱动。
+
+## 排错
+
+| 现象 | 可能原因 | 处理 |
+|---|---|---|
+| preflight 报 `pi: command not found` | CLI 变更后未重建模板 | 重建镜像并重新注册模板 |
+| provider 鉴权失败 | 密钥未传入（直连）或缺少 inject 规则（vault） | 传 `envs={...}` 或修正规则的 `sni`/`host` |
+| `403 Forbidden - CubeEgress` | 默认拒绝且无匹配放行规则 | 把 LLM host（及所需其他 host）加入规则 |
+| 到 LLM host 的 SSL 握手失败 | 沙箱不信任 CubeEgress CA | 重建模板启用 Cube CA，或设置 `SSL_CERT_FILE` |
+| 模板创建卡在 `PULLING` | Cube 节点无法访问 registry | 推送到集群可访问的 registry，必要时提供鉴权 |
+| 就绪探针超时 | 基础镜像缺少 envd | 确认 `FROM ghcr.io/tencentcloud/cubesandbox-base:2026.16` |
+| `pause()` / `connect()` 报错 | 平台版本过低不支持快照 | 升级 CubeSandbox 平台 |
+
+## 参考
+
+- 可运行示例：[`examples/pi-agent-integration`](https://github.com/TencentCloud/CubeSandbox/tree/master/examples/pi-agent-integration)
+- 自带镜像：[`docs/guide/tutorials/bring-your-own-image.md`](../tutorials/bring-your-own-image.md)
+- 从镜像构建模板：[`docs/guide/tutorials/template-from-image.md`](../tutorials/template-from-image.md)
+- 快照 / 克隆 / 回滚：[`docs/guide/snapshot-rollback-clone.md`](../snapshot-rollback-clone.md)
+- 密钥保险柜 + 出网管控：[`docs/guide/security-proxy.md`](../security-proxy.md)
+- Pi coding agent：<https://www.npmjs.com/package/@earendil-works/pi-coding-agent>

--- a/docs/zh/guide/integrations/pi-agent.md
+++ b/docs/zh/guide/integrations/pi-agent.md
@@ -234,6 +234,7 @@ version = sandbox.commands.run("pi --version", timeout=60)
 
 - **Node.js 版本。** Pi 需要较新的 Node 运行时；基础镜像自带的 apt Node 偏旧，务必通过 NodeSource 安装（Dockerfile 已如此）。
 - **Agent 状态目录。** `/root/.pi/agent` 保存 Pi 的会话缓存。镜像里保持它为空，避免跨租户泄露会话；它在构建时创建但不写入任何凭证。
+- **直连方式的密钥留存。** 直连方式（`envs=`）下密钥仅作用于该 exec 调用，但 Pi 可能把 provider 凭证缓存到其状态目录（`/root/.pi/agent/`），会在 `pause()` / `resume()` 后仍留在盘上。对隔离要求高时优先用保险柜方式（`network_policy.py`），密钥完全不进入 VM。
 - **CubeEgress CA。** 保险柜方式要求沙箱信任 CubeEgress 根 CA。通过
   `cubemastercli tpl create-from-image` 构建的模板默认已开启。
 - **出网副作用。** 需要 `npm install` 或拉取 MCP 工具的任务，要放行相应 host 或预装进模板。

--- a/examples/pi-agent-integration/.env.example
+++ b/examples/pi-agent-integration/.env.example
@@ -1,0 +1,40 @@
+# --- CubeSandbox connection ---
+
+# Required: CubeAPI address (use CubeAPI, not CubeProxy).
+E2B_API_URL="http://<cube-host>:3000"
+
+# Required: any non-empty value in local dev; a real key when auth is enabled.
+E2B_API_KEY="e2b_000000"
+
+# Required: template built from this example's Dockerfile.
+CUBE_TEMPLATE_ID="<template-id>"
+
+# Optional: only when talking to CubeProxy over HTTPS with Cube's mkcert cert.
+# SSL_CERT_FILE="/root/.local/share/mkcert/rootCA.pem"
+
+# --- Pi agent ---
+
+# Required: provider and model Pi runs against.
+PI_PROVIDER="anthropic"
+PI_MODEL="claude-sonnet-4-20250514"
+
+# Required: the provider API key (only the one matching PI_PROVIDER).
+ANTHROPIC_API_KEY="<your-anthropic-api-key>"
+# Other providers (uncomment the one you use):
+# OPENAI_API_KEY="<your-openai-api-key>"
+# GEMINI_API_KEY="<your-gemini-api-key>"
+# DEEPSEEK_API_KEY="<your-deepseek-api-key>"
+# OPENROUTER_API_KEY="<your-openrouter-api-key>"
+
+# Anthropic-compatible endpoint (e.g. DeepSeek): keep the models aligned.
+# ANTHROPIC_BASE_URL="https://api.deepseek.com/anthropic"
+# ANTHROPIC_AUTH_TOKEN="<your-deepseek-api-key>"
+# ANTHROPIC_MODEL="deepseek-v4-pro"
+
+# Optional (network_policy.py): LLM host to allow under default-deny egress.
+# Defaults to the provider host (or the ANTHROPIC_BASE_URL host); override only
+# for a custom endpoint.
+# PI_LLM_HOST="api.anthropic.com"
+
+# Advanced Pi tunables (PI_WORKSPACE, PI_THINKING, PI_AGENT_EXEC_TIMEOUT,
+# PI_CODING_AGENT_DIR, ...) have sane defaults; see env_utils.py to override.

--- a/examples/pi-agent-integration/.env.example
+++ b/examples/pi-agent-integration/.env.example
@@ -16,7 +16,7 @@ CUBE_TEMPLATE_ID="<template-id>"
 
 # Required: provider and model Pi runs against.
 PI_PROVIDER="anthropic"
-PI_MODEL="claude-sonnet-4-20250514"
+PI_MODEL="claude-sonnet-4-6"
 
 # Required: the provider API key (only the one matching PI_PROVIDER).
 ANTHROPIC_API_KEY="<your-anthropic-api-key>"

--- a/examples/pi-agent-integration/.gitignore
+++ b/examples/pi-agent-integration/.gitignore
@@ -1,0 +1,9 @@
+.env
+.env.*
+!.env.example
+__pycache__/
+*.pyc
+*.log
+output/
+workspace-seed/
+

--- a/examples/pi-agent-integration/Dockerfile
+++ b/examples/pi-agent-integration/Dockerfile
@@ -1,0 +1,63 @@
+# syntax=docker/dockerfile:1.7
+#
+# Pi coding agent inside a CubeSandbox template.
+#
+# The image installs Node.js 24 and the Pi coding-agent CLI on top of the
+# official CubeSandbox base image. The inherited cube-entrypoint keeps envd
+# running on :49983 so Cube can use the standard readiness probe.
+#
+# Build:
+#   docker build -t pi-agent-cube:latest examples/pi-agent-integration
+#
+# Register as a Cube template:
+#   cubemastercli tpl create-from-image \
+#     --image <your-registry>/pi-agent-cube:latest \
+#     --writable-layer-size 4G \
+#     --expose-port 49983 \
+#     --probe       49983 \
+#     --probe-path  /health
+
+ARG CUBE_BASE_IMAGE=ghcr.io/tencentcloud/cubesandbox-base:2026.16
+FROM ${CUBE_BASE_IMAGE}
+
+ARG DEBIAN_FRONTEND=noninteractive
+ARG NODE_MAJOR=24
+ARG PI_VERSION=0.80.3
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        bash \
+        ca-certificates \
+        curl \
+        git \
+        gnupg \
+        jq \
+        less \
+        procps \
+        python3 \
+        python3-pip \
+        ripgrep \
+    && curl -fsSL "https://deb.nodesource.com/setup_${NODE_MAJOR}.x" | bash - \
+    && apt-get install -y --no-install-recommends nodejs \
+    && npm install -g --ignore-scripts "@earendil-works/pi-coding-agent@${PI_VERSION}" \
+    && pi --version \
+    && npm cache clean --force \
+    && rm -rf /root/.npm /var/lib/apt/lists/*
+
+ENV PI_CODING_AGENT_DIR=/root/.pi/agent \
+    PI_CODING_AGENT_SESSION_DIR=/root/.pi/agent/sessions \
+    PI_SKIP_VERSION_CHECK=1 \
+    PI_TELEMETRY=0 \
+    NPM_CONFIG_UPDATE_NOTIFIER=false
+
+RUN mkdir -p /workspace "${PI_CODING_AGENT_SESSION_DIR}" \
+    && printf '%s\n' \
+        '{' \
+        '  "quietStartup": true,' \
+        '  "enableInstallTelemetry": false' \
+        '}' \
+        > "${PI_CODING_AGENT_DIR}/settings.json"
+
+WORKDIR /workspace
+
+EXPOSE 49983

--- a/examples/pi-agent-integration/Dockerfile
+++ b/examples/pi-agent-integration/Dockerfile
@@ -39,10 +39,14 @@ RUN apt-get update \
         ripgrep \
     && curl -fsSL "https://deb.nodesource.com/setup_${NODE_MAJOR}.x" | bash - \
     && apt-get install -y --no-install-recommends nodejs \
-    && npm install -g --ignore-scripts "@earendil-works/pi-coding-agent@${PI_VERSION}" \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Pi in its own layer so bumping PI_VERSION does not invalidate the slow
+# OS + Node.js layer above (only this short layer rebuilds on a version bump).
+RUN npm install -g --ignore-scripts "@earendil-works/pi-coding-agent@${PI_VERSION}" \
     && pi --version \
     && npm cache clean --force \
-    && rm -rf /root/.npm /var/lib/apt/lists/*
+    && rm -rf /root/.npm
 
 ENV PI_CODING_AGENT_DIR=/root/.pi/agent \
     PI_CODING_AGENT_SESSION_DIR=/root/.pi/agent/sessions \

--- a/examples/pi-agent-integration/README.md
+++ b/examples/pi-agent-integration/README.md
@@ -101,6 +101,10 @@ The key is forwarded per-command via `sandbox.commands.run(..., envs=...)`, so i
 lives only for the lifetime of that exec call — never written to a persistent
 file inside the VM.
 
+> **Security:** this direct flavor leaves egress open, so a compromised agent
+> could exfiltrate the injected key. For shared clusters use the vault flavor
+> (step 6): default-deny egress + on-the-wire key injection.
+
 All three scripts run Pi with `--mode json` and render a concise transcript by
 default (assistant text, tool calls, and any failures). Pass `--raw` (or set
 `PI_STREAM_RAW=1`) to stream Pi's raw JSONL events instead.

--- a/examples/pi-agent-integration/README.md
+++ b/examples/pi-agent-integration/README.md
@@ -129,6 +129,10 @@ python network_policy.py
   (`x-api-key` for Anthropic, `Authorization: Bearer` otherwise), so
   `printenv` inside the sandbox never shows the real key — it only sees a
   placeholder.
+- Because Pi runs on Node.js (which ignores the system CA store), the script
+  sets `NODE_EXTRA_CA_CERTS` so Pi trusts the CubeEgress interception CA;
+  without it the vault path fails with `Connection error`. Override the bundle
+  path via `PI_NODE_EXTRA_CA_CERTS` if your image keeps the CA elsewhere.
 - Any other destination returns `403 Forbidden - CubeEgress`.
 
 If the agent needs extra hosts (package registries, MCP servers), add matching
@@ -141,7 +145,7 @@ allow rules or preinstall those dependencies into the template.
 | `pi: command not found` in preflight | Template not rebuilt after CLI change | Rebuild the image, re-register the template |
 | Auth error from the provider | Key not forwarded (direct) or missing inject rule (vault) | Pass `envs={...}` or fix the rule's `sni`/`host` |
 | `403 Forbidden - CubeEgress` | Default-deny with no matching allow rule | Add the LLM host (and any extra hosts) to the rules |
-| SSL handshake failure to the LLM host | Sandbox doesn't trust the CubeEgress CA | Rebuild the template with the Cube CA enabled, or set `SSL_CERT_FILE` |
+| `Connection error` / TLS failure from Pi on the vault path | Pi runs on Node, which ignores the system CA store and won't trust the CubeEgress interception CA | The script sets `NODE_EXTRA_CA_CERTS` to the system bundle; override with `PI_NODE_EXTRA_CA_CERTS` if your CA lives elsewhere |
 | Readiness probe timeout | Image without envd | Ensure `FROM ghcr.io/tencentcloud/cubesandbox-base:...` |
 | `pause()`/`connect()` errors | Platform too old for snapshots | Upgrade the CubeSandbox platform |
 

--- a/examples/pi-agent-integration/README.md
+++ b/examples/pi-agent-integration/README.md
@@ -1,0 +1,148 @@
+# Pi Agent + CubeSandbox Example
+
+[中文文档](README_zh.md)
+
+Run the [Pi coding agent](https://www.npmjs.com/package/@earendil-works/pi-coding-agent)
+— a terminal-native AI coding agent — inside a CubeSandbox MicroVM. The agent
+edits files, runs commands, and reaches an LLM API entirely within an isolated,
+reproducible sandbox.
+
+This example ships:
+
+- A `Dockerfile` that stacks Node.js + the Pi CLI on top of the CubeSandbox base
+  image (envd already listens on `:49983`).
+- `run_pi_agent.py` — a headless one-shot run inside `/workspace`.
+- `resume_pi_agent.py` — pause/resume across two turns, proving `/workspace` and
+  Pi's state directory survive the snapshot.
+- `network_policy.py` — a default-deny egress policy where CubeEgress injects the
+  API key on the wire, so the key never enters the VM.
+- `env_utils.py`, `.env.example`, `requirements.txt`.
+
+## Directory layout
+
+```
+pi-agent-integration/
+├── Dockerfile            # CubeSandbox template image (Node.js + Pi CLI)
+├── .env.example          # Copy to .env and fill in
+├── .gitignore
+├── requirements.txt      # Host driver deps (e2b, python-dotenv, rich)
+├── env_utils.py          # .env loading, provider keys, Pi command builder
+├── run_pi_agent.py       # One-shot Pi task
+├── resume_pi_agent.py    # Pause / resume session persistence
+├── network_policy.py     # Default-deny egress + on-the-wire key injection
+├── README.md             # English docs (this file)
+└── README_zh.md          # Chinese docs
+```
+
+## Prerequisites
+
+- A running CubeSandbox deployment; CubeAPI reachable at `http://<node>:3000`.
+- `cubemastercli` on `$PATH`, connected to the cluster.
+- Docker on the build workstation, plus a registry the Cube nodes can pull from.
+- An LLM provider API key (Anthropic by default; any Anthropic-compatible or
+  OpenAI-compatible endpoint works).
+- Python 3.10+ for the host driver scripts.
+
+## 1. Build the template image
+
+```bash
+docker build --platform linux/amd64 \
+  -t <your-registry>/pi-agent-cube:latest \
+  examples/pi-agent-integration
+docker push <your-registry>/pi-agent-cube:latest
+```
+
+The image installs `@earendil-works/pi-coding-agent`, plus `git`, `python3`,
+`ripgrep`, `jq`, and cleans apt/npm caches. The Pi version is pinned via
+`--build-arg PI_VERSION=x.y.z`.
+
+## 2. Register as a Cube template
+
+```bash
+cubemastercli tpl create-from-image \
+  --image <your-registry>/pi-agent-cube:latest \
+  --writable-layer-size 4G \
+  --expose-port 49983 \
+  --probe       49983 \
+  --probe-path  /health
+
+cubemastercli tpl watch --job-id <job_id>
+```
+
+Note the `template_id` once the job reaches `READY`.
+
+## 3. Configure the host driver
+
+```bash
+cd examples/pi-agent-integration
+cp .env.example .env
+# fill in E2B_API_URL, CUBE_TEMPLATE_ID, and your provider key
+pip install -r requirements.txt
+```
+
+| Variable | Where it flows | Notes |
+|---|---|---|
+| `E2B_API_URL` | Local process | CubeAPI address (`http://<node>:3000`) |
+| `E2B_API_KEY` | Local process | Any non-empty string in local dev |
+| `CUBE_TEMPLATE_ID` | `Sandbox.create(template=...)` | From step 2 |
+| `PI_PROVIDER` | Pi CLI | `anthropic` (default), `openai`, `deepseek`, ... |
+| `PI_MODEL` | Pi CLI | Model id for the provider |
+| `ANTHROPIC_API_KEY` | `envs=...` (direct) or CubeEgress inject (vault) | Provider key |
+| `PI_LLM_HOST` | `network_policy.py` | LLM API host to allow; keep aligned with the provider |
+
+## 4. One-shot run (direct key flavor)
+
+```bash
+python run_pi_agent.py --prompt "Create hello.py that prints 'Hello from CubeSandbox' and run it."
+```
+
+The key is forwarded per-command via `sandbox.commands.run(..., envs=...)`, so it
+lives only for the lifetime of that exec call — never written to a persistent
+file inside the VM.
+
+## 5. Pause / resume (session persistence)
+
+```bash
+python resume_pi_agent.py
+```
+
+Turn 1 asks Pi to write `/workspace/plan.md`, then `sandbox.pause()` snapshots
+the VM. The script reconnects with `Sandbox.connect(sandbox_id)`, verifies
+`/workspace/plan.md` and Pi's state directory (`/root/.pi/agent`) survived, then
+runs turn 2 to continue the work. The sandbox lifecycle is managed manually with
+`try/finally` (not a context manager), so the pause is not undone by an early
+`kill`.
+
+## 6. Restricted egress + key vault (recommended for shared clusters)
+
+```bash
+python network_policy.py
+```
+
+- Egress is default-deny — only the LLM host (`PI_LLM_HOST`) is reachable.
+- CubeEgress attaches the provider key as an HTTP header on the wire
+  (`x-api-key` for Anthropic, `Authorization: Bearer` otherwise), so
+  `printenv` inside the sandbox never shows the real key — it only sees a
+  placeholder.
+- Any other destination returns `403 Forbidden - CubeEgress`.
+
+If the agent needs extra hosts (package registries, MCP servers), add matching
+allow rules or preinstall those dependencies into the template.
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| `pi: command not found` in preflight | Template not rebuilt after CLI change | Rebuild the image, re-register the template |
+| Auth error from the provider | Key not forwarded (direct) or missing inject rule (vault) | Pass `envs={...}` or fix the rule's `sni`/`host` |
+| `403 Forbidden - CubeEgress` | Default-deny with no matching allow rule | Add the LLM host (and any extra hosts) to the rules |
+| SSL handshake failure to the LLM host | Sandbox doesn't trust the CubeEgress CA | Rebuild the template with the Cube CA enabled, or set `SSL_CERT_FILE` |
+| Readiness probe timeout | Image without envd | Ensure `FROM ghcr.io/tencentcloud/cubesandbox-base:...` |
+| `pause()`/`connect()` errors | Platform too old for snapshots | Upgrade the CubeSandbox platform |
+
+## References
+
+- Integration guide: [`docs/guide/integrations/pi-agent.md`](../../docs/guide/integrations/pi-agent.md)
+- Snapshot / Clone / Rollback: [`docs/guide/snapshot-rollback-clone.md`](../../docs/guide/snapshot-rollback-clone.md)
+- Network / egress policy examples: [`examples/network-policy`](../network-policy)
+- Pi coding agent: <https://www.npmjs.com/package/@earendil-works/pi-coding-agent>

--- a/examples/pi-agent-integration/README.md
+++ b/examples/pi-agent-integration/README.md
@@ -101,6 +101,10 @@ The key is forwarded per-command via `sandbox.commands.run(..., envs=...)`, so i
 lives only for the lifetime of that exec call — never written to a persistent
 file inside the VM.
 
+All three scripts run Pi with `--mode json` and render a concise transcript by
+default (assistant text, tool calls, and any failures). Pass `--raw` (or set
+`PI_STREAM_RAW=1`) to stream Pi's raw JSONL events instead.
+
 ## 5. Pause / resume (session persistence)
 
 ```bash

--- a/examples/pi-agent-integration/README.md
+++ b/examples/pi-agent-integration/README.md
@@ -25,8 +25,9 @@ pi-agent-integration/
 ├── Dockerfile            # CubeSandbox template image (Node.js + Pi CLI)
 ├── .env.example          # Copy to .env and fill in
 ├── .gitignore
-├── requirements.txt      # Host driver deps (e2b, python-dotenv, rich)
+├── requirements.txt      # Host driver deps (e2b, cubesandbox, python-dotenv)
 ├── env_utils.py          # .env loading, provider keys, Pi command builder
+├── _pi_common.py         # Shared sandbox command helpers (run/ensure/id)
 ├── run_pi_agent.py       # One-shot Pi task
 ├── resume_pi_agent.py    # Pause / resume session persistence
 ├── network_policy.py     # Default-deny egress + on-the-wire key injection

--- a/examples/pi-agent-integration/README_zh.md
+++ b/examples/pi-agent-integration/README_zh.md
@@ -92,6 +92,8 @@ python run_pi_agent.py --prompt "创建 hello.py 打印 'Hello from CubeSandbox'
 
 密钥通过 `sandbox.commands.run(..., envs=...)` 逐命令传入，只在该命令执行期间存在，不会写入 VM 内的持久文件。
 
+三个脚本都以 `--mode json` 运行 Pi，默认输出精简转写（助手文本、工具调用、失败项）。加 `--raw`（或设置 `PI_STREAM_RAW=1`）可改为打印 Pi 的原始 JSONL 事件流。
+
 ## 5. pause / resume（会话持久化）
 
 ```bash

--- a/examples/pi-agent-integration/README_zh.md
+++ b/examples/pi-agent-integration/README_zh.md
@@ -114,6 +114,9 @@ python network_policy.py
 - 出网默认拒绝，仅放行 LLM host（`PI_LLM_HOST`）。
 - CubeEgress 在链路上把 provider 密钥作为 HTTP 头注入（Anthropic 用 `x-api-key`，其他用
   `Authorization: Bearer`），因此沙箱内 `printenv` 看不到真实密钥，只有占位值。
+- Pi 基于 Node.js（忽略系统 CA 库），脚本会设置 `NODE_EXTRA_CA_CERTS` 让 Pi 信任 CubeEgress 的
+  拦截 CA；否则 vault 路径会以 `Connection error` 失败。若镜像里 CA 路径不同，可用
+  `PI_NODE_EXTRA_CA_CERTS` 覆盖。
 - 任何其他目的地都会返回 `403 Forbidden - CubeEgress`。
 
 若 Agent 需要访问额外主机（包镜像源、MCP 服务器等），请增加对应的放行规则，或把这些依赖预装进模板。
@@ -125,7 +128,7 @@ python network_policy.py
 | preflight 报 `pi: command not found` | CLI 变更后未重建模板 | 重建镜像并重新注册模板 |
 | provider 鉴权失败 | 密钥未传入（直连）或缺少 inject 规则（vault） | 传 `envs={...}` 或修正规则的 `sni`/`host` |
 | `403 Forbidden - CubeEgress` | 默认拒绝且无匹配放行规则 | 把 LLM host（及所需其他 host）加入规则 |
-| 到 LLM host 的 SSL 握手失败 | 沙箱不信任 CubeEgress CA | 重建模板启用 Cube CA，或设置 `SSL_CERT_FILE` |
+| vault 路径下 Pi 报 `Connection error` / TLS 失败 | Pi 基于 Node，忽略系统 CA 库，不信任 CubeEgress 拦截 CA | 脚本已把 `NODE_EXTRA_CA_CERTS` 指向系统 CA 包；若 CA 在别处，用 `PI_NODE_EXTRA_CA_CERTS` 覆盖 |
 | 就绪探针超时 | 镜像缺少 envd | 确认 `FROM ghcr.io/tencentcloud/cubesandbox-base:...` |
 | `pause()`/`connect()` 报错 | 平台版本过低不支持快照 | 升级 CubeSandbox 平台 |
 

--- a/examples/pi-agent-integration/README_zh.md
+++ b/examples/pi-agent-integration/README_zh.md
@@ -20,8 +20,9 @@ pi-agent-integration/
 ├── Dockerfile            # CubeSandbox 模板镜像（Node.js + Pi CLI）
 ├── .env.example          # 复制为 .env 并填写
 ├── .gitignore
-├── requirements.txt      # 宿主端驱动依赖（e2b、python-dotenv、rich）
+├── requirements.txt      # 宿主端驱动依赖（e2b、cubesandbox、python-dotenv）
 ├── env_utils.py          # .env 加载、provider key、Pi 命令构造
+├── _pi_common.py         # 共享的沙箱命令辅助（run/ensure/id）
 ├── run_pi_agent.py       # 一次性 Pi 任务
 ├── resume_pi_agent.py    # pause / resume 会话持久化
 ├── network_policy.py     # 默认拒绝出网 + 链路上注入密钥

--- a/examples/pi-agent-integration/README_zh.md
+++ b/examples/pi-agent-integration/README_zh.md
@@ -92,6 +92,8 @@ python run_pi_agent.py --prompt "创建 hello.py 打印 'Hello from CubeSandbox'
 
 密钥通过 `sandbox.commands.run(..., envs=...)` 逐命令传入，只在该命令执行期间存在，不会写入 VM 内的持久文件。
 
+> **安全：** 直连方式出网是放开的，Agent 被攻破可能外泄注入的密钥。共享集群请用保险柜方式（第 6 步）：默认拒绝出网 + 链路上注入密钥。
+
 三个脚本都以 `--mode json` 运行 Pi，默认输出精简转写（助手文本、工具调用、失败项）。加 `--raw`（或设置 `PI_STREAM_RAW=1`）可改为打印 Pi 的原始 JSONL 事件流。
 
 ## 5. pause / resume（会话持久化）

--- a/examples/pi-agent-integration/README_zh.md
+++ b/examples/pi-agent-integration/README_zh.md
@@ -1,0 +1,134 @@
+# Pi Agent + CubeSandbox 示例
+
+[English](README.md)
+
+在 CubeSandbox MicroVM 内运行 [Pi coding agent](https://www.npmjs.com/package/@earendil-works/pi-coding-agent)
+（面向终端的 AI 编码 Agent）。Agent 在一个隔离、可复现的沙箱内编辑文件、执行命令并访问 LLM API。
+
+本示例包含：
+
+- 一个 `Dockerfile`：在 CubeSandbox 基础镜像上叠加 Node.js 与 Pi CLI（envd 已监听 `:49983`）。
+- `run_pi_agent.py`：在 `/workspace` 内的一次性无交互运行。
+- `resume_pi_agent.py`：跨两轮的 pause/resume，证明 `/workspace` 与 Pi 状态目录在快照后仍存在。
+- `network_policy.py`：默认拒绝出网的策略，由 CubeEgress 在链路上注入 API Key，密钥不进入 VM。
+- `env_utils.py`、`.env.example`、`requirements.txt`。
+
+## 目录结构
+
+```
+pi-agent-integration/
+├── Dockerfile            # CubeSandbox 模板镜像（Node.js + Pi CLI）
+├── .env.example          # 复制为 .env 并填写
+├── .gitignore
+├── requirements.txt      # 宿主端驱动依赖（e2b、python-dotenv、rich）
+├── env_utils.py          # .env 加载、provider key、Pi 命令构造
+├── run_pi_agent.py       # 一次性 Pi 任务
+├── resume_pi_agent.py    # pause / resume 会话持久化
+├── network_policy.py     # 默认拒绝出网 + 链路上注入密钥
+├── README.md             # 英文文档
+└── README_zh.md          # 中文文档（本文件）
+```
+
+## 前置条件
+
+- 已部署 CubeSandbox，CubeAPI 可访问（`http://<node>:3000`）。
+- `cubemastercli` 已在 `$PATH` 且已连通集群。
+- 构建机装有 Docker，且 registry 能被 Cube 集群拉取。
+- 一个 LLM provider 的 API Key（默认 Anthropic；任何 Anthropic 兼容或 OpenAI 兼容端点均可）。
+- Python 3.10+（宿主端驱动脚本）。
+
+## 1. 构建模板镜像
+
+```bash
+docker build --platform linux/amd64 \
+  -t <your-registry>/pi-agent-cube:latest \
+  examples/pi-agent-integration
+docker push <your-registry>/pi-agent-cube:latest
+```
+
+镜像会安装 `@earendil-works/pi-coding-agent`，以及 `git`、`python3`、`ripgrep`、`jq`，并清理
+apt/npm 缓存。Pi 版本通过 `--build-arg PI_VERSION=x.y.z` 固定。
+
+## 2. 注册为 Cube 模板
+
+```bash
+cubemastercli tpl create-from-image \
+  --image <your-registry>/pi-agent-cube:latest \
+  --writable-layer-size 4G \
+  --expose-port 49983 \
+  --probe       49983 \
+  --probe-path  /health
+
+cubemastercli tpl watch --job-id <job_id>
+```
+
+任务变为 `READY` 后记下 `template_id`。
+
+## 3. 配置宿主端驱动
+
+```bash
+cd examples/pi-agent-integration
+cp .env.example .env
+# 填写 E2B_API_URL、CUBE_TEMPLATE_ID 以及你的 provider key
+pip install -r requirements.txt
+```
+
+| 变量 | 作用位置 | 说明 |
+|---|---|---|
+| `E2B_API_URL` | 本地进程 | CubeAPI 地址（`http://<node>:3000`） |
+| `E2B_API_KEY` | 本地进程 | 本地开发填任意非空字符串 |
+| `CUBE_TEMPLATE_ID` | `Sandbox.create(template=...)` | 来自第 2 步 |
+| `PI_PROVIDER` | Pi CLI | `anthropic`（默认）、`openai`、`deepseek` 等 |
+| `PI_MODEL` | Pi CLI | 对应 provider 的模型 id |
+| `ANTHROPIC_API_KEY` | `envs=...`（直连）或 CubeEgress 注入（vault） | provider 密钥 |
+| `PI_LLM_HOST` | `network_policy.py` | 放行的 LLM API host，需与 provider 对齐 |
+
+## 4. 一次性运行（直连注入密钥）
+
+```bash
+python run_pi_agent.py --prompt "创建 hello.py 打印 'Hello from CubeSandbox' 并运行它。"
+```
+
+密钥通过 `sandbox.commands.run(..., envs=...)` 逐命令传入，只在该命令执行期间存在，不会写入 VM 内的持久文件。
+
+## 5. pause / resume（会话持久化）
+
+```bash
+python resume_pi_agent.py
+```
+
+第一轮让 Pi 写 `/workspace/plan.md`，随后 `sandbox.pause()` 对 VM 打快照。脚本用
+`Sandbox.connect(sandbox_id)` 恢复，校验 `/workspace/plan.md` 与 Pi 状态目录
+（`/root/.pi/agent`）仍在，再执行第二轮续写。沙箱生命周期用 `try/finally` 手动管理（不用
+context manager），避免 pause 后被过早 `kill` 掉。
+
+## 6. 受限出网 + 密钥保险柜（推荐用于共享集群）
+
+```bash
+python network_policy.py
+```
+
+- 出网默认拒绝，仅放行 LLM host（`PI_LLM_HOST`）。
+- CubeEgress 在链路上把 provider 密钥作为 HTTP 头注入（Anthropic 用 `x-api-key`，其他用
+  `Authorization: Bearer`），因此沙箱内 `printenv` 看不到真实密钥，只有占位值。
+- 任何其他目的地都会返回 `403 Forbidden - CubeEgress`。
+
+若 Agent 需要访问额外主机（包镜像源、MCP 服务器等），请增加对应的放行规则，或把这些依赖预装进模板。
+
+## 排错
+
+| 现象 | 可能原因 | 处理 |
+|---|---|---|
+| preflight 报 `pi: command not found` | CLI 变更后未重建模板 | 重建镜像并重新注册模板 |
+| provider 鉴权失败 | 密钥未传入（直连）或缺少 inject 规则（vault） | 传 `envs={...}` 或修正规则的 `sni`/`host` |
+| `403 Forbidden - CubeEgress` | 默认拒绝且无匹配放行规则 | 把 LLM host（及所需其他 host）加入规则 |
+| 到 LLM host 的 SSL 握手失败 | 沙箱不信任 CubeEgress CA | 重建模板启用 Cube CA，或设置 `SSL_CERT_FILE` |
+| 就绪探针超时 | 镜像缺少 envd | 确认 `FROM ghcr.io/tencentcloud/cubesandbox-base:...` |
+| `pause()`/`connect()` 报错 | 平台版本过低不支持快照 | 升级 CubeSandbox 平台 |
+
+## 参考
+
+- 集成指南：[`docs/guide/integrations/pi-agent.md`](../../docs/zh/guide/integrations/pi-agent.md)
+- 快照 / 克隆 / 回滚：[`docs/guide/snapshot-rollback-clone.md`](../../docs/zh/guide/snapshot-rollback-clone.md)
+- 网络 / 出网策略示例：[`examples/network-policy`](../network-policy)
+- Pi coding agent：<https://www.npmjs.com/package/@earendil-works/pi-coding-agent>

--- a/examples/pi-agent-integration/_pi_common.py
+++ b/examples/pi-agent-integration/_pi_common.py
@@ -11,6 +11,8 @@ used by ``network_policy.py``.
 
 from __future__ import annotations
 
+import json
+import os
 import sys
 from collections.abc import Callable
 from typing import Any
@@ -21,6 +23,86 @@ def stream_writer(stream) -> Callable[[object], None]:
         text = getattr(chunk, "line", chunk)
         stream.write(str(text))
         stream.flush()
+
+    return write
+
+
+def _tool_brief(arguments: dict) -> str:
+    for key in ("command", "path", "pattern", "query", "url"):
+        value = arguments.get(key)
+        if value:
+            return str(value).replace("\n", " ")[:120]
+    return ""
+
+
+def _render_message(message: object) -> None:
+    if not isinstance(message, dict):
+        return
+    role = message.get("role")
+    content = message.get("content")
+    if role == "assistant":
+        if isinstance(content, str) and content.strip():
+            print(content.strip())
+        elif isinstance(content, list):
+            for item in content:
+                if not isinstance(item, dict):
+                    continue
+                itype = item.get("type")
+                if itype == "text":
+                    text = str(item.get("text", "")).strip()
+                    if text:
+                        print(text)
+                elif itype == "toolCall":
+                    name = item.get("name") or "tool"
+                    arguments = (
+                        item.get("arguments")
+                        if isinstance(item.get("arguments"), dict)
+                        else {}
+                    )
+                    brief = _tool_brief(arguments)
+                    print(f"  \u2192 [tool] {name}{': ' + brief if brief else ''}")
+        if message.get("stopReason") == "error":
+            print(f"  [error] {str(message.get('errorMessage', ''))[:300]}")
+    elif role == "toolResult" and message.get("isError"):
+        print(f"  \u2717 [tool] {message.get('toolName', 'tool')} failed")
+
+
+def _render_jsonl_line(line: str) -> None:
+    """Render one Pi ``--mode json`` event as concise, human-readable output.
+
+    Pi streams a lot of envelopes (per-token deltas, thinking traces, duplicate
+    message snapshots). We ignore all of those and render only the authoritative
+    ``agent_end`` transcript: assistant text, tool calls, and any failures, in
+    order. Non-JSON lines are printed verbatim. Set PI_STREAM_RAW=1 (or pass
+    ``--raw``) to see the raw JSONL stream instead.
+    """
+    line = line.rstrip("\r\n")
+    if not line.strip():
+        return
+    try:
+        event = json.loads(line)
+    except (ValueError, TypeError):
+        print(line)
+        return
+    if not isinstance(event, dict) or event.get("type") != "agent_end":
+        return
+    for message in event.get("messages") or []:
+        _render_message(message)
+
+
+def jsonl_render_writer() -> Callable[[object], None]:
+    # e2b delivers stdout as arbitrary chunks (often several JSONL events, or a
+    # partial line, per callback), not one event per call. Buffer and split on
+    # newlines so each event is rendered exactly once. Pi newline-terminates
+    # every event, so nothing important is left dangling in the buffer.
+    buffer = {"text": ""}
+
+    def write(chunk: object) -> None:
+        text = getattr(chunk, "line", chunk)
+        buffer["text"] += text if isinstance(text, str) else str(text)
+        while "\n" in buffer["text"]:
+            line, buffer["text"] = buffer["text"].split("\n", 1)
+            _render_jsonl_line(line)
 
     return write
 
@@ -42,7 +124,10 @@ def run_command(
     if envs:
         kwargs["envs"] = envs
     if stream:
-        kwargs["on_stdout"] = stream_writer(sys.stdout)
+        # Default to a concise transcript (assistant text + tool calls + errors).
+        # Set PI_STREAM_RAW=1 (or pass --raw) to dump Pi's raw JSONL instead.
+        raw = os.environ.get("PI_STREAM_RAW", "").strip().lower() in ("1", "true", "yes")
+        kwargs["on_stdout"] = stream_writer(sys.stdout) if raw else jsonl_render_writer()
         kwargs["on_stderr"] = stream_writer(sys.stderr)
 
     try:

--- a/examples/pi-agent-integration/_pi_common.py
+++ b/examples/pi-agent-integration/_pi_common.py
@@ -1,0 +1,71 @@
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared sandbox command helpers for the Pi example scripts.
+
+Kept SDK-agnostic (duck-typed on ``sandbox.commands.run`` and the result's
+attributes) so the same helpers work with both the e2b-compatible SDK used by
+``run_pi_agent.py`` / ``resume_pi_agent.py`` and the native ``cubesandbox`` SDK
+used by ``network_policy.py``.
+"""
+
+from __future__ import annotations
+
+import sys
+from collections.abc import Callable
+from typing import Any
+
+
+def stream_writer(stream) -> Callable[[object], None]:
+    def write(chunk: object) -> None:
+        text = getattr(chunk, "line", chunk)
+        stream.write(str(text))
+        stream.flush()
+
+    return write
+
+
+def run_command(
+    sandbox: Any,
+    command: str,
+    *,
+    cwd: str | None = None,
+    envs: dict[str, str] | None = None,
+    timeout: int | float | None = None,
+    stream: bool = False,
+    user: str = "root",
+):
+    # Run as root: /workspace and Pi's state dir (/root/.pi/agent) are root-owned,
+    # and the default e2b exec user ("user") cannot write to them.
+    kwargs = {"cwd": cwd, "timeout": timeout, "user": user}
+    kwargs = {key: value for key, value in kwargs.items() if value is not None}
+    if envs:
+        kwargs["envs"] = envs
+    if stream:
+        kwargs["on_stdout"] = stream_writer(sys.stdout)
+        kwargs["on_stderr"] = stream_writer(sys.stderr)
+
+    try:
+        return sandbox.commands.run(command, **kwargs)
+    except TypeError as exc:
+        # Older SDKs name the parameter ``env`` instead of ``envs``. Only retry
+        # for that specific signature mismatch; re-raise any other TypeError so
+        # real bugs (e.g. a wrong-type command or timeout) are not masked.
+        if "envs" not in kwargs or "envs" not in str(exc):
+            raise
+        kwargs["env"] = kwargs.pop("envs")
+        return sandbox.commands.run(command, **kwargs)
+
+
+def ensure_success(result, action: str) -> None:
+    exit_code = getattr(result, "exit_code", None)
+    if exit_code not in (None, 0):
+        stdout = getattr(result, "stdout", "")
+        stderr = getattr(result, "stderr", "")
+        raise SystemExit(
+            f"Failed to {action} (exit {exit_code}).\nSTDOUT:\n{stdout}\nSTDERR:\n{stderr}"
+        )
+
+
+def sandbox_identifier(sandbox: Any) -> str:
+    return getattr(sandbox, "sandbox_id", getattr(sandbox, "id", "unknown"))

--- a/examples/pi-agent-integration/env_utils.py
+++ b/examples/pi-agent-integration/env_utils.py
@@ -210,13 +210,17 @@ def provider_inject(provider: str, secret: str) -> list[dict[str, str]]:
     return [{"header": "Authorization", "secret": secret, "format": "Bearer ${SECRET}"}]
 
 
-def pi_command(prompt: str, *, mode: str = "json", name: str | None = None) -> str:
+def pi_command(
+    prompt: str, *, mode: str = "json", name: str | None = None, approve: bool = True
+) -> str:
     """Build a headless (non-interactive) Pi invocation.
 
     ``--print`` makes Pi process the prompt and exit instead of launching the
     interactive TUI (which would hang over the E2B exec channel). ``--mode json``
-    streams machine-readable JSONL events. ``--approve`` is a boolean flag that
-    trusts project-local files (AGENTS.md/CLAUDE.md) for this run; the prompt is
+    streams machine-readable JSONL events. ``approve`` toggles ``--approve``,
+    which trusts project-local files (AGENTS.md/CLAUDE.md) for this run — handy
+    in an isolated sandbox, but pass ``approve=False`` in high-security workflows
+    where those files could be attacker-controlled between turns. The prompt is
     passed as the trailing positional message.
     """
     args = ["pi", "--print"]
@@ -233,7 +237,8 @@ def pi_command(prompt: str, *, mode: str = "json", name: str | None = None) -> s
         args.extend(["--thinking", thinking])
     if name:
         args.extend(["--name", name])
-    args.append("--approve")
+    if approve:
+        args.append("--approve")
     args.append(prompt)
     return " ".join(shlex.quote(arg) for arg in args)
 

--- a/examples/pi-agent-integration/env_utils.py
+++ b/examples/pi-agent-integration/env_utils.py
@@ -34,14 +34,12 @@ PROVIDER_DEFAULT_HOST = {
     "openrouter": "openrouter.ai",
 }
 
-SECRET_ENV_NAMES = (
-    "ANTHROPIC_API_KEY",
-    "ANTHROPIC_AUTH_TOKEN",
-    "OPENAI_API_KEY",
-    "GEMINI_API_KEY",
-    "DEEPSEEK_API_KEY",
-    "OPENROUTER_API_KEY",
-)
+# Only Anthropic ships a default model; other providers must set PI_MODEL
+# explicitly (model IDs are provider-specific and change often), so we fail
+# loudly instead of sending a Claude model name to, say, OpenAI.
+PROVIDER_DEFAULT_MODEL = {
+    "anthropic": "claude-sonnet-4-6",
+}
 
 PASSTHROUGH_ENV_NAMES = (
     "ANTHROPIC_BASE_URL",
@@ -94,17 +92,26 @@ def int_env(name: str, default: int) -> int:
 
 
 def pi_provider() -> str:
-    return optional("PI_PROVIDER", "anthropic")
+    # Normalize case so every downstream comparison and dict lookup
+    # (provider_inject, PROVIDER_DEFAULT_HOST, key candidates, ...) is
+    # case-insensitive; "Anthropic" and "anthropic" must behave the same.
+    return optional("PI_PROVIDER", "anthropic").strip().lower()
 
 
 def pi_model() -> str:
-    if pi_provider() == "anthropic":
-        return (
-            os.environ.get("PI_MODEL")
-            or os.environ.get("ANTHROPIC_MODEL")
-            or "claude-sonnet-4-6"
-        )
-    return optional("PI_MODEL", "claude-sonnet-4-6")
+    provider = pi_provider()
+    explicit = os.environ.get("PI_MODEL")
+    if not explicit and provider == "anthropic":
+        explicit = os.environ.get("ANTHROPIC_MODEL")
+    if explicit:
+        return explicit
+    default = PROVIDER_DEFAULT_MODEL.get(provider)
+    if default:
+        return default
+    raise SystemExit(
+        f"No default model for provider {provider!r}. Set PI_MODEL in your .env "
+        "(model IDs are provider-specific; there is no safe cross-provider default)."
+    )
 
 
 def pi_workspace() -> str:
@@ -133,6 +140,7 @@ def require_provider_key(provider: str | None = None) -> str:
 
 
 def provider_key_candidates(provider: str) -> tuple[str, ...]:
+    provider = provider.strip().lower()
     default_name = PROVIDER_KEY_ENV.get(provider, f"{provider.upper()}_API_KEY")
     return (default_name, *PROVIDER_KEY_ALIASES.get(provider, ()))
 
@@ -157,7 +165,10 @@ def build_pi_env(include_secrets: bool = True) -> dict[str, str]:
         if value:
             env[name] = value
     if include_secrets:
-        for name in SECRET_ENV_NAMES:
+        # Forward ONLY the active provider's key(s), never every known secret —
+        # a host with several provider keys (e.g. a CI matrix) must not leak all
+        # of them into the sandbox.
+        for name in provider_key_candidates(pi_provider()):
             value = os.environ.get(name)
             if value:
                 env[name] = value
@@ -170,7 +181,7 @@ def pi_llm_host(provider: str | None = None) -> str:
     Precedence: explicit ``PI_LLM_HOST`` > host parsed from ``ANTHROPIC_BASE_URL``
     (for Anthropic-compatible endpoints) > the provider default.
     """
-    provider_name = provider or pi_provider()
+    provider_name = (provider or pi_provider()).strip().lower()
     explicit = os.environ.get("PI_LLM_HOST")
     if explicit:
         return _host_from_url(explicit)
@@ -202,7 +213,7 @@ def provider_inject(provider: str, secret: str) -> list[dict[str, str]]:
     ``Bearer ${SECRET}``. Anthropic uses ``x-api-key`` plus the required
     API-version header; every other provider uses ``Authorization: Bearer``.
     """
-    if provider == "anthropic":
+    if provider.strip().lower() == "anthropic":
         return [
             {"header": "x-api-key", "secret": secret, "format": "${SECRET}"},
             {"header": "anthropic-version", "secret": "2023-06-01", "format": "${SECRET}"},

--- a/examples/pi-agent-integration/env_utils.py
+++ b/examples/pi-agent-integration/env_utils.py
@@ -203,7 +203,7 @@ def provider_inject(provider: str, secret: str) -> list[dict[str, str]]:
     if provider == "anthropic":
         return [
             {"header": "x-api-key", "secret": secret, "format": "${SECRET}"},
-            {"header": "anthropic-version", "secret": "2023-06-01"},
+            {"header": "anthropic-version", "secret": "2023-06-01", "format": "${SECRET}"},
         ]
     return [{"header": "Authorization", "secret": secret, "format": "Bearer ${SECRET}"}]
 

--- a/examples/pi-agent-integration/env_utils.py
+++ b/examples/pi-agent-integration/env_utils.py
@@ -1,0 +1,231 @@
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import os
+import shlex
+from pathlib import Path
+from urllib.parse import urlparse
+
+from dotenv import load_dotenv
+
+DEFAULT_PI_DIR = "/root/.pi/agent"
+DEFAULT_SESSION_DIR = f"{DEFAULT_PI_DIR}/sessions"
+DEFAULT_WORKSPACE = "/workspace"
+
+PROVIDER_KEY_ENV = {
+    "anthropic": "ANTHROPIC_API_KEY",
+    "openai": "OPENAI_API_KEY",
+    "google": "GEMINI_API_KEY",
+    "deepseek": "DEEPSEEK_API_KEY",
+    "openrouter": "OPENROUTER_API_KEY",
+}
+
+PROVIDER_KEY_ALIASES = {
+    "anthropic": ("ANTHROPIC_AUTH_TOKEN",),
+}
+
+PROVIDER_DEFAULT_HOST = {
+    "anthropic": "api.anthropic.com",
+    "openai": "api.openai.com",
+    "google": "generativelanguage.googleapis.com",
+    "deepseek": "api.deepseek.com",
+    "openrouter": "openrouter.ai",
+}
+
+SECRET_ENV_NAMES = (
+    "ANTHROPIC_API_KEY",
+    "ANTHROPIC_AUTH_TOKEN",
+    "OPENAI_API_KEY",
+    "GEMINI_API_KEY",
+    "DEEPSEEK_API_KEY",
+    "OPENROUTER_API_KEY",
+)
+
+PASSTHROUGH_ENV_NAMES = (
+    "ANTHROPIC_BASE_URL",
+    "ANTHROPIC_MODEL",
+    "PI_CACHE_RETENTION",
+    "HTTP_PROXY",
+    "HTTPS_PROXY",
+    "NO_PROXY",
+)
+
+
+def load_local_dotenv() -> None:
+    """Best-effort load of a nearby .env file without overriding real env vars."""
+    candidate_paths = [
+        Path(__file__).with_name(".env"),
+        Path.cwd() / ".env",
+    ]
+
+    seen_paths: set[Path] = set()
+    for path in candidate_paths:
+        resolved_path = path.resolve()
+        if resolved_path in seen_paths:
+            continue
+        seen_paths.add(resolved_path)
+
+        if path.is_file():
+            load_dotenv(dotenv_path=path, override=False)
+            return
+
+
+def required(name: str) -> str:
+    value = os.environ.get(name)
+    if not value:
+        raise SystemExit(f"Missing required environment variable: {name}")
+    return value
+
+
+def optional(name: str, default: str = "") -> str:
+    return os.environ.get(name) or default
+
+
+def int_env(name: str, default: int) -> int:
+    raw = os.environ.get(name)
+    if not raw:
+        return default
+    try:
+        return int(raw)
+    except ValueError as exc:
+        raise SystemExit(f"{name} must be an integer, got {raw!r}") from exc
+
+
+def pi_provider() -> str:
+    return optional("PI_PROVIDER", "anthropic")
+
+
+def pi_model() -> str:
+    if pi_provider() == "anthropic":
+        return (
+            os.environ.get("PI_MODEL")
+            or os.environ.get("ANTHROPIC_MODEL")
+            or "claude-sonnet-4-20250514"
+        )
+    return optional("PI_MODEL", "claude-sonnet-4-20250514")
+
+
+def pi_workspace() -> str:
+    return optional("PI_WORKSPACE", DEFAULT_WORKSPACE)
+
+
+def provider_key_name(provider: str | None = None) -> str:
+    provider_name = provider or pi_provider()
+    names = provider_key_candidates(provider_name)
+    for name in names:
+        if os.environ.get(name):
+            return name
+    return names[0]
+
+
+def require_provider_key(provider: str | None = None) -> str:
+    provider_name = provider or pi_provider()
+    names = provider_key_candidates(provider_name)
+    for name in names:
+        value = os.environ.get(name)
+        if value:
+            return value
+    raise SystemExit(
+        "Missing required environment variable: one of " + ", ".join(names)
+    )
+
+
+def provider_key_candidates(provider: str) -> tuple[str, ...]:
+    default_name = PROVIDER_KEY_ENV.get(provider, f"{provider.upper()}_API_KEY")
+    return (default_name, *PROVIDER_KEY_ALIASES.get(provider, ()))
+
+
+def build_pi_env(include_secrets: bool = True) -> dict[str, str]:
+    """Build the env map passed to the Pi command inside the sandbox.
+
+    Set ``include_secrets=False`` for the CubeEgress vault flavor: the real
+    provider key rides the wire via egress injection, so it must never enter
+    the sandbox environment.
+    """
+    env = {
+        "PI_CODING_AGENT_DIR": optional("PI_CODING_AGENT_DIR", DEFAULT_PI_DIR),
+        "PI_CODING_AGENT_SESSION_DIR": optional(
+            "PI_CODING_AGENT_SESSION_DIR", DEFAULT_SESSION_DIR
+        ),
+        "PI_SKIP_VERSION_CHECK": optional("PI_SKIP_VERSION_CHECK", "1"),
+        "PI_TELEMETRY": optional("PI_TELEMETRY", "0"),
+    }
+    for name in PASSTHROUGH_ENV_NAMES:
+        value = os.environ.get(name)
+        if value:
+            env[name] = value
+    if include_secrets:
+        for name in SECRET_ENV_NAMES:
+            value = os.environ.get(name)
+            if value:
+                env[name] = value
+    return env
+
+
+def pi_llm_host(provider: str | None = None) -> str:
+    """Resolve the LLM API host that Pi must reach.
+
+    Precedence: explicit ``PI_LLM_HOST`` > host parsed from ``ANTHROPIC_BASE_URL``
+    (for Anthropic-compatible endpoints) > the provider default.
+    """
+    provider_name = provider or pi_provider()
+    explicit = os.environ.get("PI_LLM_HOST")
+    if explicit:
+        return _host_from_url(explicit)
+    if provider_name == "anthropic":
+        base_url = os.environ.get("ANTHROPIC_BASE_URL")
+        if base_url:
+            host = _host_from_url(base_url)
+            if host:
+                return host
+    return PROVIDER_DEFAULT_HOST.get(provider_name, "")
+
+
+def _host_from_url(value: str) -> str:
+    candidate = value.strip()
+    if not candidate:
+        return ""
+    if "://" not in candidate:
+        candidate = f"https://{candidate}"
+    return urlparse(candidate).hostname or ""
+
+
+def provider_inject(provider: str, secret: str) -> list[dict[str, str]]:
+    """Build CubeEgress credential-injection headers for a provider.
+
+    Anthropic uses ``x-api-key`` plus a required API version header; everything
+    else uses an ``Authorization: Bearer`` header. Static values are carried as
+    ``secret`` with the default ``${SECRET}`` format so they satisfy CubeEgress
+    validation (which requires a non-empty ``secret`` on every inject entry).
+    """
+    if provider == "anthropic":
+        return [
+            {"header": "x-api-key", "secret": secret, "format": "${SECRET}"},
+            {"header": "anthropic-version", "secret": "2023-06-01"},
+        ]
+    return [{"header": "Authorization", "secret": secret, "format": "Bearer ${SECRET}"}]
+
+
+def pi_command(prompt: str, *, mode: str = "json", name: str | None = None) -> str:
+    args = ["pi"]
+    if mode:
+        args.extend(["--mode", mode])
+    provider = pi_provider()
+    model = pi_model()
+    thinking = optional("PI_THINKING")
+    if provider:
+        args.extend(["--provider", provider])
+    if model:
+        args.extend(["--model", model])
+    if thinking:
+        args.extend(["--thinking", thinking])
+    if name:
+        args.extend(["--name", name])
+    args.extend(["--approve", prompt])
+    return " ".join(shlex.quote(arg) for arg in args)
+
+
+def shell_join(*parts: str) -> str:
+    return " && ".join(part for part in parts if part)

--- a/examples/pi-agent-integration/env_utils.py
+++ b/examples/pi-agent-integration/env_utils.py
@@ -209,7 +209,15 @@ def provider_inject(provider: str, secret: str) -> list[dict[str, str]]:
 
 
 def pi_command(prompt: str, *, mode: str = "json", name: str | None = None) -> str:
-    args = ["pi"]
+    """Build a headless (non-interactive) Pi invocation.
+
+    ``--print`` makes Pi process the prompt and exit instead of launching the
+    interactive TUI (which would hang over the E2B exec channel). ``--mode json``
+    streams machine-readable JSONL events. ``--approve`` is a boolean flag that
+    trusts project-local files (AGENTS.md/CLAUDE.md) for this run; the prompt is
+    passed as the trailing positional message.
+    """
+    args = ["pi", "--print"]
     if mode:
         args.extend(["--mode", mode])
     provider = pi_provider()
@@ -223,7 +231,8 @@ def pi_command(prompt: str, *, mode: str = "json", name: str | None = None) -> s
         args.extend(["--thinking", thinking])
     if name:
         args.extend(["--name", name])
-    args.extend(["--approve", prompt])
+    args.append("--approve")
+    args.append(prompt)
     return " ".join(shlex.quote(arg) for arg in args)
 
 

--- a/examples/pi-agent-integration/env_utils.py
+++ b/examples/pi-agent-integration/env_utils.py
@@ -102,9 +102,9 @@ def pi_model() -> str:
         return (
             os.environ.get("PI_MODEL")
             or os.environ.get("ANTHROPIC_MODEL")
-            or "claude-sonnet-4-20250514"
+            or "claude-sonnet-4-6"
         )
-    return optional("PI_MODEL", "claude-sonnet-4-20250514")
+    return optional("PI_MODEL", "claude-sonnet-4-6")
 
 
 def pi_workspace() -> str:

--- a/examples/pi-agent-integration/env_utils.py
+++ b/examples/pi-agent-integration/env_utils.py
@@ -193,12 +193,14 @@ def _host_from_url(value: str) -> str:
 
 
 def provider_inject(provider: str, secret: str) -> list[dict[str, str]]:
-    """Build CubeEgress credential-injection headers for a provider.
+    """CubeEgress credential-injection specs for a provider's auth header(s).
 
-    Anthropic uses ``x-api-key`` plus a required API version header; everything
-    else uses an ``Authorization: Bearer`` header. Static values are carried as
-    ``secret`` with the default ``${SECRET}`` format so they satisfy CubeEgress
-    validation (which requires a non-empty ``secret`` on every inject entry).
+    Each dict maps directly to a ``cubesandbox.Inject(header=..., secret=...,
+    format=...)``. CubeEgress attaches these headers to matched outbound
+    requests, so the real key rides the wire and never enters the sandbox VM.
+    ``format`` defaults to ``${SECRET}`` (raw secret); bearer schemes use
+    ``Bearer ${SECRET}``. Anthropic uses ``x-api-key`` plus the required
+    API-version header; every other provider uses ``Authorization: Bearer``.
     """
     if provider == "anthropic":
         return [

--- a/examples/pi-agent-integration/network_policy.py
+++ b/examples/pi-agent-integration/network_policy.py
@@ -41,7 +41,7 @@ from env_utils import (
     required,
     shell_join,
 )
-from run_pi_agent import ensure_success, run_command
+from _pi_common import ensure_success, run_command, sandbox_identifier
 
 PLACEHOLDER_KEY = "cube-egress-managed-placeholder"
 
@@ -131,10 +131,6 @@ def create_sandbox(template_id: str, rules: list[Rule], timeout: int) -> Sandbox
         network={"rules": rules},
         timeout=timeout,
     )
-
-
-def sandbox_identifier(sandbox: Sandbox) -> str:
-    return getattr(sandbox, "sandbox_id", getattr(sandbox, "id", "unknown"))
 
 
 def show_key_not_in_vm(sandbox: Sandbox, key_name: str) -> None:

--- a/examples/pi-agent-integration/network_policy.py
+++ b/examples/pi-agent-integration/network_policy.py
@@ -1,0 +1,224 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Restrict Pi's egress to the LLM API and inject the key on the wire.
+
+This is the recommended production ("credential vault") pattern:
+
+* Default-deny egress — only the LLM API host is reachable. Everything else is
+  rejected by CubeEgress with ``403 Forbidden`` before leaving the sandbox.
+* The provider API key is attached by CubeEgress as an HTTP header on the
+  matched outbound requests, so the real key never enters the sandbox VM. The
+  agent inside only sees a placeholder value.
+
+Run:
+    python network_policy.py
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import shlex
+import sys
+
+from e2b import Sandbox
+
+from env_utils import (
+    build_pi_env,
+    int_env,
+    load_local_dotenv,
+    pi_command,
+    pi_llm_host,
+    pi_provider,
+    pi_workspace,
+    provider_inject,
+    provider_key_name,
+    require_provider_key,
+    required,
+    shell_join,
+)
+from run_pi_agent import ensure_success, run_command
+
+PLACEHOLDER_KEY = "cube-egress-managed-placeholder"
+
+DEFAULT_PROMPT = (
+    "Reply with a single short sentence confirming you can reach the LLM API, "
+    "then write that sentence to {workspace}/egress_check.md."
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Run Pi under a default-deny egress policy with on-the-wire key injection."
+    )
+    parser.add_argument(
+        "--template",
+        default=os.environ.get("CUBE_TEMPLATE_ID"),
+        help="CubeSandbox template ID. Defaults to CUBE_TEMPLATE_ID.",
+    )
+    parser.add_argument(
+        "--host",
+        default=None,
+        help="LLM API host to allow. Defaults to PI_LLM_HOST or the provider default.",
+    )
+    parser.add_argument(
+        "--workspace",
+        default=pi_workspace(),
+        help="Working directory inside the sandbox. Defaults to PI_WORKSPACE.",
+    )
+    parser.add_argument(
+        "--prompt",
+        default=None,
+        help="Prompt passed to Pi. Defaults to a small egress reachability check.",
+    )
+    parser.add_argument(
+        "--name",
+        default="cube-pi-agent-egress",
+        help="Pi session name for the egress demo run.",
+    )
+    parser.add_argument(
+        "--sandbox-timeout",
+        type=int,
+        default=int_env("PI_SANDBOX_TIMEOUT", 1800),
+        help="Sandbox lifetime in seconds. Defaults to PI_SANDBOX_TIMEOUT or 1800.",
+    )
+    parser.add_argument(
+        "--exec-timeout",
+        type=int,
+        default=int_env("PI_AGENT_EXEC_TIMEOUT", 900),
+        help="Pi command timeout in seconds. Defaults to PI_AGENT_EXEC_TIMEOUT or 900.",
+    )
+    parser.add_argument(
+        "--skip-agent",
+        action="store_true",
+        help="Only show the egress checks; skip the actual Pi run.",
+    )
+    args = parser.parse_args()
+    if args.prompt is None:
+        args.prompt = DEFAULT_PROMPT.format(workspace=args.workspace)
+    return args
+
+
+def build_llm_rule(provider: str, host: str, secret: str) -> dict:
+    return {
+        "name": f"allow_{provider}_llm",
+        "match": {"scheme": "https", "sni": host, "host": host},
+        "action": {
+            "allow": True,
+            "audit": "metadata",
+            "inject": provider_inject(provider, secret),
+        },
+    }
+
+
+def create_sandbox(template_id: str, rules: list[dict], timeout: int) -> Sandbox:
+    kwargs = {
+        "template": template_id,
+        "allow_internet_access": True,
+        "network": {"rules": rules},
+        "timeout": timeout,
+    }
+    try:
+        return Sandbox.create(**kwargs)
+    except TypeError:
+        kwargs.pop("allow_internet_access", None)
+        return Sandbox.create(**kwargs)
+
+
+def sandbox_identifier(sandbox: Sandbox) -> str:
+    return getattr(sandbox, "sandbox_id", getattr(sandbox, "id", "unknown"))
+
+
+def show_key_not_in_vm(sandbox: Sandbox, key_name: str) -> None:
+    command = f"printenv {shlex.quote(key_name)} || echo '<unset>'"
+    result = run_command(sandbox, command, timeout=30)
+    ensure_success(result, "read provider key inside sandbox")
+    value = getattr(result, "stdout", "").strip()
+    print(f"In-VM {key_name}: {value!r} (real secret stays in CubeEgress)")
+
+
+def show_non_llm_blocked(sandbox: Sandbox) -> None:
+    command = (
+        "curl -s -o /dev/null -w '%{http_code}' --max-time 8 https://example.com "
+        "|| echo blocked"
+    )
+    result = run_command(sandbox, command, timeout=30)
+    status = getattr(result, "stdout", "").strip()
+    print(f"Non-LLM host (example.com) response: {status or 'blocked'} "
+          "(expected 403/blocked under default-deny)")
+
+
+def run_agent(sandbox: Sandbox, args: argparse.Namespace, envs: dict[str, str]):
+    command = shell_join(
+        f"cd {shlex.quote(args.workspace)}",
+        pi_command(args.prompt, mode="json", name=args.name),
+    )
+    return run_command(
+        sandbox,
+        command,
+        cwd=args.workspace,
+        envs=envs,
+        timeout=args.exec_timeout,
+        stream=True,
+    )
+
+
+def main() -> int:
+    load_local_dotenv()
+    args = parse_args()
+
+    template_id = args.template or required("CUBE_TEMPLATE_ID")
+    required("E2B_API_URL")
+    required("E2B_API_KEY")
+
+    provider = pi_provider()
+    secret = require_provider_key(provider)
+    host = args.host or pi_llm_host(provider)
+    if not host:
+        raise SystemExit(
+            "Could not resolve the LLM host. Set PI_LLM_HOST in your .env or pass --host."
+        )
+
+    rules = [build_llm_rule(provider, host, secret)]
+
+    sandbox_env = build_pi_env(include_secrets=False)
+    key_name = provider_key_name(provider)
+    sandbox_env[key_name] = PLACEHOLDER_KEY
+
+    print(f"Provider: {provider}")
+    print(f"Allowed LLM host (default-deny for everything else): {host}")
+    print(f"Creating sandbox from template: {template_id}")
+
+    sandbox = create_sandbox(template_id, rules, args.sandbox_timeout)
+    sandbox_id = sandbox_identifier(sandbox)
+    result = None
+    try:
+        print(f"Sandbox ready: {sandbox_id}\n")
+
+        show_key_not_in_vm(sandbox, key_name)
+        show_non_llm_blocked(sandbox)
+
+        if args.skip_agent:
+            print("\n--skip-agent set: not invoking Pi.")
+            return 0
+
+        print("\nRunning Pi through the injected egress path...\n")
+        result = run_agent(sandbox, args, sandbox_env)
+        exit_code = getattr(result, "exit_code", None)
+        print(f"\nPi exit code: {exit_code}")
+        return 0 if exit_code is None else int(exit_code)
+    finally:
+        try:
+            sandbox.kill()
+            print(f"\nSandbox {sandbox_id} killed.")
+        except Exception as exc:  # noqa: BLE001 - cleanup must not mask real errors
+            print(
+                f"Warning: failed to kill sandbox {sandbox_id}: {exc}",
+                file=sys.stderr,
+            )
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/examples/pi-agent-integration/network_policy.py
+++ b/examples/pi-agent-integration/network_policy.py
@@ -45,6 +45,13 @@ from _pi_common import ensure_success, run_command, sandbox_identifier
 
 PLACEHOLDER_KEY = "cube-egress-managed-placeholder"
 
+# Pi runs on Node.js, which uses its own bundled CA store and ignores the system
+# trust store. On the vault path CubeEgress terminates TLS to inject the
+# credential, so Node must trust the CubeEgress root CA or every LLM call fails
+# with "Connection error". Point NODE_EXTRA_CA_CERTS at a bundle that includes
+# it; the CubeSandbox base image installs the CA into the system bundle below.
+DEFAULT_NODE_CA_BUNDLE = "/etc/ssl/certs/ca-certificates.crt"
+
 DEFAULT_PROMPT = (
     "Reply with a single short sentence confirming you can reach the LLM API, "
     "then write that sentence to {workspace}/egress_check.md."
@@ -195,6 +202,11 @@ def main() -> int:
     sandbox_env = build_pi_env(include_secrets=False)
     key_name = provider_key_name(provider)
     sandbox_env[key_name] = PLACEHOLDER_KEY
+    # Let the Node-based Pi CLI trust the CubeEgress interception CA (see note
+    # on DEFAULT_NODE_CA_BUNDLE); without this the vault path fails TLS.
+    sandbox_env["NODE_EXTRA_CA_CERTS"] = os.environ.get(
+        "PI_NODE_EXTRA_CA_CERTS", DEFAULT_NODE_CA_BUNDLE
+    )
 
     print(f"Provider: {provider}")
     print(f"Allowed LLM host (default-deny for everything else): {host}")

--- a/examples/pi-agent-integration/network_policy.py
+++ b/examples/pi-agent-integration/network_policy.py
@@ -6,12 +6,13 @@
 
 This is the recommended production ("credential vault") pattern:
 
-* Default-deny egress — the sandbox is created with ``allow_internet_access=False``,
-  so CubeVS drops all outbound traffic at L3/L4 except the LLM API host, which is
-  auto-allowed because it is extracted from the L7 ``rules`` below.
-* The provider API key is attached by CubeEgress as an HTTP header on the
-  matched outbound requests, so the real key never enters the sandbox VM. The
-  agent inside only sees a placeholder value.
+* Default-deny egress — the sandbox is created with ``allow_internet_access=False``
+  and an ``allow_out`` list containing only the LLM API host, so every other
+  destination is dropped before it can leave the sandbox.
+* The provider auth header is attached by CubeEgress via ``inject`` rules
+  (native ``cubesandbox`` SDK; see docs/guide/security-proxy.md), so the real
+  key rides the wire and never enters the sandbox VM. The agent inside only
+  sees a placeholder value.
 
 Run:
     python network_policy.py
@@ -24,7 +25,7 @@ import os
 import shlex
 import sys
 
-from e2b import Sandbox
+from cubesandbox import Sandbox, Rule, Match, Action, Inject
 
 from env_utils import (
     build_pi_env,
@@ -102,23 +103,28 @@ def parse_args() -> argparse.Namespace:
     return args
 
 
-def build_llm_rule(provider: str, host: str, secret: str) -> dict:
-    return {
-        "name": f"allow_{provider}_llm",
-        "match": {"scheme": "https", "sni": host, "host": host},
-        "action": {
-            "allow": True,
-            "audit": "metadata",
-            "inject": provider_inject(provider, secret),
-        },
-    }
+def build_rules(provider: str, host: str, secret: str) -> list[Rule]:
+    # Canonical CubeEgress rule (see docs/guide/security-proxy.md): allow the LLM
+    # host and attach the provider auth header(s) on the wire via ``inject`` so
+    # the real key never enters the sandbox VM. Anything matching no rule under
+    # default-deny is rejected by CubeEgress with 403.
+    return [
+        Rule(
+            name=f"allow_{provider}_llm",
+            match=Match(scheme="https", sni=host, host=host),
+            action=Action(
+                allow=True,
+                audit="metadata",
+                inject=[Inject(**spec) for spec in provider_inject(provider, secret)],
+            ),
+        )
+    ]
 
 
-def create_sandbox(template_id: str, rules: list[dict], timeout: int) -> Sandbox:
-    # allow_internet_access=False is what makes egress default-deny at L3/L4:
-    # CubeVS drops everything except the hosts extracted from the L7 rules (the
-    # LLM API), which it auto-adds as allow targets. This flag must never be
-    # silently dropped on error, or full internet egress would be re-enabled.
+def create_sandbox(template_id: str, rules: list[Rule], timeout: int) -> Sandbox:
+    # allow_internet_access=False makes egress default-deny at L3/L4; the LLM host
+    # named in the rules is auto-allowed and its requests are injected at L7 by
+    # CubeEgress. Never silently drop this flag, or full egress is re-enabled.
     return Sandbox.create(
         template=template_id,
         allow_internet_access=False,
@@ -181,7 +187,7 @@ def main() -> int:
             "Could not resolve the LLM host. Set PI_LLM_HOST in your .env or pass --host."
         )
 
-    rules = [build_llm_rule(provider, host, secret)]
+    rules = build_rules(provider, host, secret)
 
     sandbox_env = build_pi_env(include_secrets=False)
     key_name = provider_key_name(provider)

--- a/examples/pi-agent-integration/network_policy.py
+++ b/examples/pi-agent-integration/network_policy.py
@@ -6,8 +6,9 @@
 
 This is the recommended production ("credential vault") pattern:
 
-* Default-deny egress — only the LLM API host is reachable. Everything else is
-  rejected by CubeEgress with ``403 Forbidden`` before leaving the sandbox.
+* Default-deny egress — the sandbox is created with ``allow_internet_access=False``,
+  so CubeVS drops all outbound traffic at L3/L4 except the LLM API host, which is
+  auto-allowed because it is extracted from the L7 ``rules`` below.
 * The provider API key is attached by CubeEgress as an HTTP header on the
   matched outbound requests, so the real key never enters the sandbox VM. The
   agent inside only sees a placeholder value.
@@ -114,17 +115,16 @@ def build_llm_rule(provider: str, host: str, secret: str) -> dict:
 
 
 def create_sandbox(template_id: str, rules: list[dict], timeout: int) -> Sandbox:
-    kwargs = {
-        "template": template_id,
-        "allow_internet_access": True,
-        "network": {"rules": rules},
-        "timeout": timeout,
-    }
-    try:
-        return Sandbox.create(**kwargs)
-    except TypeError:
-        kwargs.pop("allow_internet_access", None)
-        return Sandbox.create(**kwargs)
+    # allow_internet_access=False is what makes egress default-deny at L3/L4:
+    # CubeVS drops everything except the hosts extracted from the L7 rules (the
+    # LLM API), which it auto-adds as allow targets. This flag must never be
+    # silently dropped on error, or full internet egress would be re-enabled.
+    return Sandbox.create(
+        template=template_id,
+        allow_internet_access=False,
+        network={"rules": rules},
+        timeout=timeout,
+    )
 
 
 def sandbox_identifier(sandbox: Sandbox) -> str:

--- a/examples/pi-agent-integration/network_policy.py
+++ b/examples/pi-agent-integration/network_policy.py
@@ -97,6 +97,11 @@ def parse_args() -> argparse.Namespace:
         action="store_true",
         help="Only show the egress checks; skip the actual Pi run.",
     )
+    parser.add_argument(
+        "--raw",
+        action="store_true",
+        help="Stream Pi's raw JSONL instead of the concise transcript.",
+    )
     args = parser.parse_args()
     if args.prompt is None:
         args.prompt = DEFAULT_PROMPT.format(workspace=args.workspace)
@@ -170,6 +175,8 @@ def run_agent(sandbox: Sandbox, args: argparse.Namespace, envs: dict[str, str]):
 def main() -> int:
     load_local_dotenv()
     args = parse_args()
+    if args.raw:
+        os.environ["PI_STREAM_RAW"] = "1"
 
     template_id = args.template or required("CUBE_TEMPLATE_ID")
     required("E2B_API_URL")

--- a/examples/pi-agent-integration/requirements.txt
+++ b/examples/pi-agent-integration/requirements.txt
@@ -1,0 +1,3 @@
+e2b>=2.4.1
+python-dotenv>=1.0.0
+rich>=13.0

--- a/examples/pi-agent-integration/requirements.txt
+++ b/examples/pi-agent-integration/requirements.txt
@@ -1,4 +1,3 @@
 e2b>=2.4.1
 cubesandbox>=0.3.0
 python-dotenv>=1.0.0
-rich>=13.0

--- a/examples/pi-agent-integration/requirements.txt
+++ b/examples/pi-agent-integration/requirements.txt
@@ -1,3 +1,4 @@
 e2b>=2.4.1
+cubesandbox>=0.3.0
 python-dotenv>=1.0.0
 rich>=13.0

--- a/examples/pi-agent-integration/resume_pi_agent.py
+++ b/examples/pi-agent-integration/resume_pi_agent.py
@@ -174,7 +174,10 @@ def main() -> int:
 
         print(f"\nPausing sandbox {sandbox_id} (snapshotting VM + rootfs)...")
         paused_id = sandbox.pause()
-        if paused_id:
+        # The sandbox_id is stable across pause. Some SDK versions return the
+        # resume handle as a string; others return a bool (success). Only adopt
+        # a string handle, otherwise keep the original id for connect().
+        if isinstance(paused_id, str) and paused_id:
             sandbox_id = paused_id
         print(f"Paused. Resume handle: {sandbox_id}")
 

--- a/examples/pi-agent-integration/resume_pi_agent.py
+++ b/examples/pi-agent-integration/resume_pi_agent.py
@@ -34,7 +34,7 @@ from env_utils import (
     required,
     shell_join,
 )
-from run_pi_agent import ensure_success, run_command
+from _pi_common import ensure_success, run_command, sandbox_identifier
 
 DEFAULT_PI_STATE_DIR = "/root/.pi/agent"
 
@@ -86,10 +86,6 @@ def parse_args() -> argparse.Namespace:
         help="Pi command timeout in seconds. Defaults to PI_AGENT_EXEC_TIMEOUT or 900.",
     )
     return parser.parse_args()
-
-
-def sandbox_identifier(sandbox: Sandbox) -> str:
-    return getattr(sandbox, "sandbox_id", getattr(sandbox, "id", "unknown"))
 
 
 def run_turn(

--- a/examples/pi-agent-integration/resume_pi_agent.py
+++ b/examples/pi-agent-integration/resume_pi_agent.py
@@ -85,6 +85,11 @@ def parse_args() -> argparse.Namespace:
         default=int_env("PI_AGENT_EXEC_TIMEOUT", 900),
         help="Pi command timeout in seconds. Defaults to PI_AGENT_EXEC_TIMEOUT or 900.",
     )
+    parser.add_argument(
+        "--raw",
+        action="store_true",
+        help="Stream Pi's raw JSONL instead of the concise transcript.",
+    )
     return parser.parse_args()
 
 
@@ -141,6 +146,8 @@ def show_final_workspace(sandbox: Sandbox, workspace: str) -> None:
 def main() -> int:
     load_local_dotenv()
     args = parse_args()
+    if args.raw:
+        os.environ["PI_STREAM_RAW"] = "1"
 
     template_id = args.template or required("CUBE_TEMPLATE_ID")
     required("E2B_API_URL")

--- a/examples/pi-agent-integration/resume_pi_agent.py
+++ b/examples/pi-agent-integration/resume_pi_agent.py
@@ -1,0 +1,211 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Demonstrate Pi coding-agent session persistence across a CubeSandbox pause/resume.
+
+Turn 1 asks Pi to write ``/workspace/plan.md``, then the sandbox is paused.
+Turn 2 reconnects to the same sandbox, verifies both ``/workspace`` and the Pi
+state directory survived the snapshot, and asks Pi to continue the work.
+
+Lifecycle note: this script deliberately avoids ``with Sandbox.create(...)``.
+A context manager kills the sandbox on ``__exit__``, which would defeat the
+pause. The lifecycle is managed manually with try/finally so the sandbox stays
+alive between turns and is only killed at the very end.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import shlex
+import sys
+
+from e2b import Sandbox
+
+from env_utils import (
+    build_pi_env,
+    int_env,
+    load_local_dotenv,
+    pi_command,
+    pi_provider,
+    pi_workspace,
+    require_provider_key,
+    required,
+    shell_join,
+)
+from run_pi_agent import ensure_success, run_command
+
+DEFAULT_PI_STATE_DIR = "/root/.pi/agent"
+
+TURN_1_PROMPT = (
+    "Create {workspace}/plan.md containing a numbered 3-step plan for building a "
+    "small Python CLI that prints the current time. Only write the plan file."
+)
+TURN_2_PROMPT = (
+    "Read {workspace}/plan.md and implement step 1 by creating "
+    "{workspace}/progress.md that records which step you completed and why. "
+    "Do not delete plan.md."
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Demonstrate Pi session persistence across a CubeSandbox pause/resume."
+    )
+    parser.add_argument(
+        "--template",
+        default=os.environ.get("CUBE_TEMPLATE_ID"),
+        help="CubeSandbox template ID. Defaults to CUBE_TEMPLATE_ID.",
+    )
+    parser.add_argument(
+        "--workspace",
+        default=pi_workspace(),
+        help="Working directory inside the sandbox. Defaults to PI_WORKSPACE.",
+    )
+    parser.add_argument(
+        "--name",
+        default="cube-pi-agent-resume",
+        help="Pi session name reused across both turns to keep the conversation.",
+    )
+    parser.add_argument(
+        "--pi-state-dir",
+        default=os.environ.get("PI_CODING_AGENT_DIR", DEFAULT_PI_STATE_DIR),
+        help="Pi state directory checked for survival after resume.",
+    )
+    parser.add_argument(
+        "--sandbox-timeout",
+        type=int,
+        default=int_env("PI_SANDBOX_TIMEOUT", 1800),
+        help="Sandbox lifetime in seconds. Defaults to PI_SANDBOX_TIMEOUT or 1800.",
+    )
+    parser.add_argument(
+        "--exec-timeout",
+        type=int,
+        default=int_env("PI_AGENT_EXEC_TIMEOUT", 900),
+        help="Pi command timeout in seconds. Defaults to PI_AGENT_EXEC_TIMEOUT or 900.",
+    )
+    return parser.parse_args()
+
+
+def sandbox_identifier(sandbox: Sandbox) -> str:
+    return getattr(sandbox, "sandbox_id", getattr(sandbox, "id", "unknown"))
+
+
+def run_turn(
+    sandbox: Sandbox,
+    workspace: str,
+    prompt: str,
+    name: str,
+    exec_timeout: int,
+    envs: dict[str, str],
+):
+    command = shell_join(
+        f"cd {shlex.quote(workspace)}",
+        pi_command(prompt, mode="json", name=name),
+    )
+    return run_command(
+        sandbox,
+        command,
+        cwd=workspace,
+        envs=envs,
+        timeout=exec_timeout,
+        stream=True,
+    )
+
+
+def assert_state_survived(sandbox: Sandbox, workspace: str, state_dir: str) -> None:
+    quoted_workspace = shlex.quote(workspace)
+    quoted_state = shlex.quote(state_dir)
+    command = shell_join(
+        f"test -f {quoted_workspace}/plan.md",
+        f"test -d {quoted_state}",
+        "printf '\\n--- plan.md (survived pause/resume) ---\\n'",
+        f"cat {quoted_workspace}/plan.md",
+    )
+    result = run_command(sandbox, command, timeout=60)
+    ensure_success(result, "verify /workspace and Pi state survived pause/resume")
+    if getattr(result, "stdout", ""):
+        print(result.stdout)
+
+
+def show_final_workspace(sandbox: Sandbox, workspace: str) -> None:
+    quoted_workspace = shlex.quote(workspace)
+    command = shell_join(
+        f"ls -la {quoted_workspace}",
+        f"test ! -f {quoted_workspace}/progress.md || "
+        f"(printf '\\n--- progress.md ---\\n' && cat {quoted_workspace}/progress.md)",
+    )
+    result = run_command(sandbox, command, timeout=60)
+    ensure_success(result, "inspect final workspace")
+    if getattr(result, "stdout", ""):
+        print(result.stdout)
+
+
+def main() -> int:
+    load_local_dotenv()
+    args = parse_args()
+
+    template_id = args.template or required("CUBE_TEMPLATE_ID")
+    required("E2B_API_URL")
+    required("E2B_API_KEY")
+    require_provider_key(pi_provider())
+
+    pi_env = build_pi_env()
+    turn_1_prompt = TURN_1_PROMPT.format(workspace=args.workspace)
+    turn_2_prompt = TURN_2_PROMPT.format(workspace=args.workspace)
+
+    print(f"Creating sandbox from template: {template_id}")
+    sandbox = Sandbox.create(template=template_id, timeout=args.sandbox_timeout)
+    sandbox_id = sandbox_identifier(sandbox)
+
+    try:
+        print(f"Sandbox ready: {sandbox_id}")
+
+        version_result = run_command(sandbox, "pi --version", timeout=60)
+        ensure_success(version_result, "check Pi version")
+        print(f"Pi version: {getattr(version_result, 'stdout', '').strip()}")
+
+        print("\n=== Turn 1: create plan.md ===\n")
+        result_1 = run_turn(
+            sandbox, args.workspace, turn_1_prompt, args.name, args.exec_timeout, pi_env
+        )
+        ensure_success(result_1, "run Pi turn 1")
+
+        print(f"\nPausing sandbox {sandbox_id} (snapshotting VM + rootfs)...")
+        paused_id = sandbox.pause()
+        if paused_id:
+            sandbox_id = paused_id
+        print(f"Paused. Resume handle: {sandbox_id}")
+
+        print(f"\nReconnecting to {sandbox_id}...")
+        sandbox = Sandbox.connect(sandbox_id=sandbox_id)
+        print("Reconnected after resume.")
+
+        print("\n=== Verifying persistence after resume ===\n")
+        assert_state_survived(sandbox, args.workspace, args.pi_state_dir)
+
+        print("\n=== Turn 2: continue the work ===\n")
+        result_2 = run_turn(
+            sandbox, args.workspace, turn_2_prompt, args.name, args.exec_timeout, pi_env
+        )
+        ensure_success(result_2, "run Pi turn 2")
+
+        show_final_workspace(sandbox, args.workspace)
+
+        exit_code = getattr(result_2, "exit_code", 0)
+        return 0 if exit_code is None else int(exit_code)
+    finally:
+        if sandbox is not None:
+            try:
+                sandbox.kill()
+                print(f"\nSandbox {sandbox_id} killed.")
+            except Exception as exc:  # noqa: BLE001 - cleanup must not mask real errors
+                print(
+                    f"Warning: failed to kill sandbox {sandbox_id}: {exc}",
+                    file=sys.stderr,
+                )
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/examples/pi-agent-integration/resume_pi_agent.py
+++ b/examples/pi-agent-integration/resume_pi_agent.py
@@ -159,6 +159,10 @@ def main() -> int:
     turn_2_prompt = TURN_2_PROMPT.format(workspace=args.workspace)
 
     print(f"Creating sandbox from template: {template_id}")
+    # SECURITY: like run_pi_agent.py this demo keeps egress open and injects the
+    # key per command. The pause() snapshot also captures the in-VM env and any
+    # credentials Pi caches under /root/.pi/agent, widening exposure — for shared
+    # clusters prefer the default-deny + vault pattern in network_policy.py.
     sandbox = Sandbox.create(template=template_id, timeout=args.sandbox_timeout)
     sandbox_id = sandbox_identifier(sandbox)
 

--- a/examples/pi-agent-integration/run_pi_agent.py
+++ b/examples/pi-agent-integration/run_pi_agent.py
@@ -8,10 +8,10 @@ import argparse
 import os
 import shlex
 import sys
-from collections.abc import Callable
 
 from e2b import Sandbox
 
+from _pi_common import ensure_success, run_command, sandbox_identifier
 from env_utils import (
     build_pi_env,
     int_env,
@@ -81,47 +81,6 @@ def parse_args() -> argparse.Namespace:
     return args
 
 
-def stream_writer(stream) -> Callable[[object], None]:
-    def write(chunk: object) -> None:
-        text = getattr(chunk, "line", chunk)
-        stream.write(str(text))
-        stream.flush()
-
-    return write
-
-
-def run_command(
-    sandbox: Sandbox,
-    command: str,
-    *,
-    cwd: str | None = None,
-    envs: dict[str, str] | None = None,
-    timeout: int | float | None = None,
-    stream: bool = False,
-    user: str = "root",
-):
-    # Run as root: /workspace and Pi's state dir (/root/.pi/agent) are root-owned,
-    # and the default e2b exec user ("user") cannot write to them.
-    kwargs = {"cwd": cwd, "timeout": timeout, "user": user}
-    kwargs = {key: value for key, value in kwargs.items() if value is not None}
-    if envs:
-        kwargs["envs"] = envs
-    if stream:
-        kwargs["on_stdout"] = stream_writer(sys.stdout)
-        kwargs["on_stderr"] = stream_writer(sys.stderr)
-
-    try:
-        return sandbox.commands.run(command, **kwargs)
-    except TypeError as exc:
-        # Older SDKs name the parameter ``env`` instead of ``envs``. Only retry
-        # for that specific signature mismatch; re-raise any other TypeError so
-        # real bugs (e.g. a wrong-type command or timeout) are not masked.
-        if "envs" not in kwargs or "envs" not in str(exc):
-            raise
-        kwargs["env"] = kwargs.pop("envs")
-        return sandbox.commands.run(command, **kwargs)
-
-
 def seed_project(sandbox: Sandbox, workspace: str, timeout: int) -> None:
     quoted_workspace = shlex.quote(workspace)
     command = f"""mkdir -p {quoted_workspace}
@@ -141,16 +100,6 @@ EOF
 """
     result = run_command(sandbox, command, timeout=timeout)
     ensure_success(result, "seed workspace")
-
-
-def ensure_success(result, action: str) -> None:
-    exit_code = getattr(result, "exit_code", None)
-    if exit_code not in (None, 0):
-        stdout = getattr(result, "stdout", "")
-        stderr = getattr(result, "stderr", "")
-        raise SystemExit(
-            f"Failed to {action} (exit {exit_code}).\nSTDOUT:\n{stdout}\nSTDERR:\n{stderr}"
-        )
 
 
 def print_result_summary(result) -> None:
@@ -194,7 +143,7 @@ def main() -> int:
     print(f"Creating sandbox from template: {template_id}")
     result = None
     with Sandbox.create(template=template_id, timeout=args.sandbox_timeout) as sandbox:
-        sandbox_id = getattr(sandbox, "sandbox_id", getattr(sandbox, "id", "unknown"))
+        sandbox_id = sandbox_identifier(sandbox)
         print(f"Sandbox ready: {sandbox_id}")
 
         version_result = run_command(sandbox, "pi --version", timeout=60)

--- a/examples/pi-agent-integration/run_pi_agent.py
+++ b/examples/pi-agent-integration/run_pi_agent.py
@@ -109,8 +109,11 @@ def run_command(
 
     try:
         return sandbox.commands.run(command, **kwargs)
-    except TypeError:
-        if "envs" not in kwargs:
+    except TypeError as exc:
+        # Older SDKs name the parameter ``env`` instead of ``envs``. Only retry
+        # for that specific signature mismatch; re-raise any other TypeError so
+        # real bugs (e.g. a wrong-type command or timeout) are not masked.
+        if "envs" not in kwargs or "envs" not in str(exc):
             raise
         kwargs["env"] = kwargs.pop("envs")
         return sandbox.commands.run(command, **kwargs)

--- a/examples/pi-agent-integration/run_pi_agent.py
+++ b/examples/pi-agent-integration/run_pi_agent.py
@@ -1,0 +1,220 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import argparse
+import os
+import shlex
+import sys
+from collections.abc import Callable
+
+from e2b import Sandbox
+
+from env_utils import (
+    build_pi_env,
+    int_env,
+    load_local_dotenv,
+    pi_command,
+    pi_provider,
+    pi_workspace,
+    require_provider_key,
+    required,
+    shell_join,
+)
+
+DEFAULT_PROMPT_TEMPLATE = (
+    "Inspect the project in {workspace}, run python3 app.py, and write a "
+    "concise summary of the result to {workspace}/result.md."
+)
+
+
+def default_prompt(workspace: str) -> str:
+    return DEFAULT_PROMPT_TEMPLATE.format(workspace=workspace)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Run a one-shot Pi coding-agent task inside CubeSandbox."
+    )
+    parser.add_argument(
+        "--template",
+        default=os.environ.get("CUBE_TEMPLATE_ID"),
+        help="CubeSandbox template ID. Defaults to CUBE_TEMPLATE_ID.",
+    )
+    parser.add_argument(
+        "--prompt",
+        default=None,
+        help="Prompt passed to Pi. Defaults to a small workspace smoke task.",
+    )
+    parser.add_argument(
+        "--workspace",
+        default=pi_workspace(),
+        help="Working directory inside the sandbox. Defaults to PI_WORKSPACE.",
+    )
+    parser.add_argument(
+        "--name",
+        default="cube-pi-agent-demo",
+        help="Pi session name for the one-shot run.",
+    )
+    parser.add_argument(
+        "--sandbox-timeout",
+        type=int,
+        default=int_env("PI_SANDBOX_TIMEOUT", 1800),
+        help="Sandbox lifetime in seconds. Defaults to PI_SANDBOX_TIMEOUT or 1800.",
+    )
+    parser.add_argument(
+        "--exec-timeout",
+        type=int,
+        default=int_env("PI_AGENT_EXEC_TIMEOUT", 900),
+        help="Pi command timeout in seconds. Defaults to PI_AGENT_EXEC_TIMEOUT or 900.",
+    )
+    parser.add_argument(
+        "--no-seed",
+        action="store_true",
+        help="Skip writing the demo files into the sandbox workspace.",
+    )
+    args = parser.parse_args()
+    if args.prompt is None:
+        args.prompt = default_prompt(args.workspace)
+    return args
+
+
+def stream_writer(stream) -> Callable[[object], None]:
+    def write(chunk: object) -> None:
+        text = getattr(chunk, "line", chunk)
+        stream.write(str(text))
+        stream.flush()
+
+    return write
+
+
+def run_command(
+    sandbox: Sandbox,
+    command: str,
+    *,
+    cwd: str | None = None,
+    envs: dict[str, str] | None = None,
+    timeout: int | float | None = None,
+    stream: bool = False,
+):
+    kwargs = {"cwd": cwd, "timeout": timeout}
+    kwargs = {key: value for key, value in kwargs.items() if value is not None}
+    if envs:
+        kwargs["envs"] = envs
+    if stream:
+        kwargs["on_stdout"] = stream_writer(sys.stdout)
+        kwargs["on_stderr"] = stream_writer(sys.stderr)
+
+    try:
+        return sandbox.commands.run(command, **kwargs)
+    except TypeError:
+        if "envs" not in kwargs:
+            raise
+        kwargs["env"] = kwargs.pop("envs")
+        return sandbox.commands.run(command, **kwargs)
+
+
+def seed_project(sandbox: Sandbox, workspace: str, timeout: int) -> None:
+    quoted_workspace = shlex.quote(workspace)
+    command = f"""mkdir -p {quoted_workspace}
+cat > {quoted_workspace}/README.md <<'EOF'
+# CubeSandbox Pi Agent Smoke Project
+
+This tiny project exists so the Pi coding agent has a deterministic task to run.
+EOF
+cat > {quoted_workspace}/app.py <<'EOF'
+def main() -> None:
+    print("hello from CubeSandbox + Pi")
+
+
+if __name__ == "__main__":
+    main()
+EOF
+"""
+    result = run_command(sandbox, command, timeout=timeout)
+    ensure_success(result, "seed workspace")
+
+
+def ensure_success(result, action: str) -> None:
+    exit_code = getattr(result, "exit_code", None)
+    if exit_code not in (None, 0):
+        stdout = getattr(result, "stdout", "")
+        stderr = getattr(result, "stderr", "")
+        raise SystemExit(
+            f"Failed to {action} (exit {exit_code}).\nSTDOUT:\n{stdout}\nSTDERR:\n{stderr}"
+        )
+
+
+def print_result_summary(result) -> None:
+    exit_code = getattr(result, "exit_code", None)
+    stderr = getattr(result, "stderr", "")
+
+    print(f"\nPi exit code: {exit_code}")
+    if stderr:
+        print("\nCaptured stderr:", file=sys.stderr)
+        print(stderr, file=sys.stderr)
+
+
+def show_workspace_result(sandbox: Sandbox, workspace: str, timeout: int) -> None:
+    quoted_workspace = shlex.quote(workspace)
+    command = shell_join(
+        f"ls -la {quoted_workspace}",
+        f"test ! -f {quoted_workspace}/result.md || "
+        f"(printf '\\n--- result.md ---\\n' && cat {quoted_workspace}/result.md)",
+    )
+    result = run_command(sandbox, command, timeout=timeout)
+    ensure_success(result, "inspect workspace")
+    if getattr(result, "stdout", ""):
+        print(result.stdout)
+
+
+def main() -> int:
+    load_local_dotenv()
+    args = parse_args()
+
+    template_id = args.template or required("CUBE_TEMPLATE_ID")
+    required("E2B_API_URL")
+    required("E2B_API_KEY")
+    require_provider_key(pi_provider())
+
+    pi_env = build_pi_env()
+    command = shell_join(
+        f"cd {shlex.quote(args.workspace)}",
+        pi_command(args.prompt, mode="json", name=args.name),
+    )
+
+    print(f"Creating sandbox from template: {template_id}")
+    result = None
+    with Sandbox.create(template=template_id, timeout=args.sandbox_timeout) as sandbox:
+        sandbox_id = getattr(sandbox, "sandbox_id", getattr(sandbox, "id", "unknown"))
+        print(f"Sandbox ready: {sandbox_id}")
+
+        version_result = run_command(sandbox, "pi --version", timeout=60)
+        ensure_success(version_result, "check Pi version")
+        print(f"Pi version: {getattr(version_result, 'stdout', '').strip()}")
+
+        if not args.no_seed:
+            seed_project(sandbox, args.workspace, timeout=60)
+            print(f"Seeded demo project in {args.workspace}")
+
+        print("\nRunning Pi task...\n")
+        result = run_command(
+            sandbox,
+            command,
+            cwd=args.workspace,
+            envs=pi_env,
+            timeout=args.exec_timeout,
+            stream=True,
+        )
+
+        print_result_summary(result)
+        show_workspace_result(sandbox, args.workspace, timeout=60)
+
+    exit_code = getattr(result, "exit_code", 1)
+    return 0 if exit_code is None else int(exit_code)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/examples/pi-agent-integration/run_pi_agent.py
+++ b/examples/pi-agent-integration/run_pi_agent.py
@@ -149,6 +149,11 @@ def main() -> int:
 
     print(f"Creating sandbox from template: {template_id}")
     result = None
+    # SECURITY: this direct-key demo keeps egress open (allow_internet_access
+    # defaults to True) for simplicity, and injects the provider key per command
+    # via envs=. A compromised agent with open egress could exfiltrate that key.
+    # For shared/production use prefer network_policy.py, which pairs default-deny
+    # egress with the CubeEgress credential vault (the key never enters the VM).
     with Sandbox.create(template=template_id, timeout=args.sandbox_timeout) as sandbox:
         sandbox_id = sandbox_identifier(sandbox)
         print(f"Sandbox ready: {sandbox_id}")

--- a/examples/pi-agent-integration/run_pi_agent.py
+++ b/examples/pi-agent-integration/run_pi_agent.py
@@ -75,6 +75,11 @@ def parse_args() -> argparse.Namespace:
         action="store_true",
         help="Skip writing the demo files into the sandbox workspace.",
     )
+    parser.add_argument(
+        "--raw",
+        action="store_true",
+        help="Stream Pi's raw JSONL instead of the concise transcript.",
+    )
     args = parser.parse_args()
     if args.prompt is None:
         args.prompt = default_prompt(args.workspace)
@@ -128,6 +133,8 @@ def show_workspace_result(sandbox: Sandbox, workspace: str, timeout: int) -> Non
 def main() -> int:
     load_local_dotenv()
     args = parse_args()
+    if args.raw:
+        os.environ["PI_STREAM_RAW"] = "1"
 
     template_id = args.template or required("CUBE_TEMPLATE_ID")
     required("E2B_API_URL")

--- a/examples/pi-agent-integration/run_pi_agent.py
+++ b/examples/pi-agent-integration/run_pi_agent.py
@@ -98,8 +98,11 @@ def run_command(
     envs: dict[str, str] | None = None,
     timeout: int | float | None = None,
     stream: bool = False,
+    user: str = "root",
 ):
-    kwargs = {"cwd": cwd, "timeout": timeout}
+    # Run as root: /workspace and Pi's state dir (/root/.pi/agent) are root-owned,
+    # and the default e2b exec user ("user") cannot write to them.
+    kwargs = {"cwd": cwd, "timeout": timeout, "user": user}
     kwargs = {key: value for key, value in kwargs.items() if value is not None}
     if envs:
         kwargs["envs"] = envs


### PR DESCRIPTION
## Summary

Adds an end-to-end **Pi Agent** integration for #698: a bilingual guide plus a
runnable example project, following the layout and quality bar of the existing
integration examples.

## What Changed

- **Runnable example** at `examples/pi-agent-integration/`:
  - `Dockerfile` — Node.js 24 + `@earendil-works/pi-coding-agent` on top of
    `ghcr.io/tencentcloud/cubesandbox-base:2026.16`; envd already listens on `:49983`.
   - `run_pi_agent.py` — headless one-shot run (`pi --version` preflight → seed
    project → `pi --print --mode json` → stream stdout, key injected per-command via `envs=`).
  - `resume_pi_agent.py` — pause/resume across two turns; verifies `/workspace`
    and Pi's state dir (`/root/.pi/agent`) survive the snapshot. Manual
    `try/finally` lifecycle (no context manager) so the pause is not undone.
  - `network_policy.py` — default-deny egress + CubeEgress `inject` so the
    provider key rides the wire and never enters the VM.
  - `env_utils.py`, bilingual `README.md` / `README_zh.md`, `.env.example`,
    `.gitignore`, `requirements.txt`.
- **Integration guide** in both languages, on the `_template.md` frontmatter,
  linked from both index tables:
  - `docs/guide/integrations/pi-agent.md`
  - `docs/zh/guide/integrations/pi-agent.md`

## Acceptance Criteria (#698)

1. End-to-end guide — template build, deps, API key injection, network/egress
   policy, snapshot-based session persistence. ✅
2. Runnable example under `examples/` with template definition + reproducible
   flow + bilingual README. ✅
3. Use cases & best practices (isolated dev, run agent-generated code, snapshot
   checkpoint/resume). ✅
4. FAQ / troubleshooting aligned with existing egress / auth / template mechanics. ✅
5. Docs placed under `docs/guide/integrations` following the existing template. ✅

## Test Plan

- [x] `python3 -m py_compile examples/pi-agent-integration/*.py`
- [x] env_utils helper checks (LLM host resolution, credential inject shape, vault env excludes secrets)
- [x] `run/resume/network_policy --help` parse cleanly
- [x] `cd docs && npm run docs:build`
- [x] `git diff --check` clean
- [x] `docker build --platform linux/amd64` succeeds (~76s; image 551 MB)
- [x] envd `/health` returns 204 (probe passes); envd 0.5.13; pi 0.80.3; node 24.18; git/python3/rg/jq present

### Live CubeSandbox cluster run

Ran against a live single-node CubeSandbox cluster (a registered `pi-agent-cube`
template, pi 0.80.3). The LLM provider was an Anthropic-compatible gateway
registered as a **custom** Pi provider (model `glm-5.2`), because no native
Anthropic key was available in the test environment.

- [x] `run_pi_agent.py` — sandbox created, `pi --version` preflight, seeded
  project, one-shot task drove `bash`/`write` tool calls and wrote
  `/workspace/result.md`; exit 0. The runner's parsed transcript (assistant
  text + tool calls) renders cleanly; `--raw` still dumps the JSONL stream.
- [x] `resume_pi_agent.py` — turn 1 wrote `/workspace/plan.md`; `sandbox.pause()`
  then `Sandbox.connect()` resumed; `/workspace/plan.md` and Pi's state dir
  (`/root/.pi/agent`) survived the snapshot; turn 2 read the plan and continued
  (wrote `current_time.py` + `progress.md`, `plan.md` left intact); exit 0.
- [x] `network_policy.py` — default-deny egress verified on-cluster: a non-LLM
  host (`example.com`) is blocked, and `printenv` inside the sandbox shows the
  provider key unset/placeholder (the real key never enters the VM).
- [x] `network_policy.py` full LLM call via CubeEgress `inject` — verified end-to-end
  on-cluster. A bare request (no auth header) is authenticated by the injected
  key and the LLM returns HTTP 200, while the VM only ever holds a placeholder.
  Pi (Node) additionally needs `NODE_EXTRA_CA_CERTS` to trust the CubeEgress
  interception CA (now set by the script).

<img width="852" height="991" alt="截屏2026-07-02 16 43 10" src="https://github.com/user-attachments/assets/7ae9e0c8-292c-4fd9-8e2d-a62fdcb7af63" />
<img width="1122" height="967" alt="截屏2026-07-02 16 43 33" src="https://github.com/user-attachments/assets/c8568c8c-e677-47bb-b74b-969e4af82fd8" />
<img width="1074" height="61" alt="截屏2026-07-02 16 43 51" src="https://github.com/user-attachments/assets/5de17996-94de-4e01-97ff-c386248d85ff" />

Closes #698