### PR TITLE
deploy: tolerate missing 'resolvectl default-route' on older systemd

### DIFF
--- a/deploy/one-click/scripts/one-click/up-dns.sh
+++ b/deploy/one-click/scripts/one-click/up-dns.sh
@@ -193,7 +193,11 @@ configure_with_resolved() {
 
   resolvectl dns "${RESOLVED_LINK_NAME}" "${COREDNS_BIND_ADDR}" >/dev/null
   resolvectl domain "${RESOLVED_LINK_NAME}" '~cube.app' >/dev/null
-  resolvectl default-route "${RESOLVED_LINK_NAME}" no >/dev/null
+
+  # default-route needs systemd v240+; tolerate any failure on older releases.
+  if ! default_route_err="$(resolvectl default-route "${RESOLVED_LINK_NAME}" no 2>&1 >/dev/null)"; then
+    log "resolvectl default-route failed (unsupported on systemd <v240, or other error); continuing — ~cube.app routing already applies: ${default_route_err}"
+  fi
 
   printf 'systemd-resolved\n' > "${DNS_MODE_FILE}"
   printf '%s\n' "${RESOLVED_LINK_NAME}" > "${DNS_IFACE_FILE}"

--- a/deploy/one-click/scripts/systemd/dns-host-route-up.sh
+++ b/deploy/one-click/scripts/systemd/dns-host-route-up.sh
@@ -162,7 +162,10 @@ configure_with_resolved() {
   resolvectl revert "${RESOLVED_LINK_NAME}" >/dev/null 2>&1 || true
   resolvectl dns "${RESOLVED_LINK_NAME}" "${COREDNS_BIND_ADDR}" >/dev/null
   resolvectl domain "${RESOLVED_LINK_NAME}" '~cube.app' >/dev/null
-  resolvectl default-route "${RESOLVED_LINK_NAME}" no >/dev/null
+  # default-route needs systemd v240+; tolerate any failure on older releases.
+  if ! default_route_err="$(resolvectl default-route "${RESOLVED_LINK_NAME}" no 2>&1 >/dev/null)"; then
+    log "resolvectl default-route failed (unsupported on systemd <v240, or other error); continuing — ~cube.app routing already applies: ${default_route_err}"
+  fi
   printf 'systemd-resolved\n' > "${DNS_MODE_FILE}"
   printf '%s\n' "${RESOLVED_LINK_NAME}" > "${DNS_IFACE_FILE}"
 }


### PR DESCRIPTION
`configure_with_resolved()` in the one-click DNS setup called `resolvectl default-route <link> no` unconditionally. That subcommand was added in systemd v240, so on older releases (e.g. RHEL 8.3, which ships systemd 239) resolvectl exists but rejects the call. Under `set -euo pipefail` this aborts the entire one-click install.

Make only that call best-effort and log a note when it is unsupported. The `~cube.app` routing domain configured just above already scopes queries to the dummy link, so skipping the explicit default-route flag is harmless; behavior on systemd >= v240 is unchanged. Applied to both the one-click and bundled systemd copies of the script.

Closes #401