### PR TITLE
fix(cubeproxy): configure resolver for Redis hostnames

### DIFF
--- a/.github/workflows/unit-test-check.yml
+++ b/.github/workflows/unit-test-check.yml
@@ -7,6 +7,7 @@ on:
       - 'CubeAPI/**'
       - 'CubeOps/**'
       - 'CubeDB/**'
+      - 'CubeProxy/**'
       - 'CubeShim/**'
       - 'CubeNet/**'
       - 'network-agent/**'
@@ -19,6 +20,7 @@ on:
       - 'CubeAPI/**'
       - 'CubeOps/**'
       - 'CubeDB/**'
+      - 'CubeProxy/**'
       - 'CubeShim/**'
       - 'CubeNet/**'
       - 'network-agent/**'
@@ -36,6 +38,7 @@ on:
         options:
           - all
           - cubeapi
+          - cubeproxy
           - cubeshim
           - network-agent
 
@@ -84,6 +87,7 @@ jobs:
           add_all_components() {
             add_component "CubeAPI"
             add_component "CubeOps"
+            add_component "CubeProxy"
             add_component "CubeShim"
             add_component "network-agent"
           }
@@ -94,6 +98,7 @@ jobs:
               all) add_all_components ;;
               cubeapi) add_component "CubeAPI" ;;
               cubeops) add_component "CubeOps" ;;
+              cubeproxy) add_component "CubeProxy" ;;
               cubeshim) add_component "CubeShim" ;;
               network-agent) add_component "network-agent" ;;
               *)
@@ -130,6 +135,9 @@ jobs:
                 CubeOps/*|CubeDB/*)
                   add_component "CubeOps"
                   ;;
+                CubeProxy/*)
+                  add_component "CubeProxy"
+                  ;;
                 CubeShim/*)
                   add_component "CubeShim"
                   ;;
@@ -154,6 +162,7 @@ jobs:
                   display_name: (
                     if . == "CubeAPI" then "CubeAPI"
                     elif . == "CubeOps" then "CubeOps"
+                    elif . == "CubeProxy" then "CubeProxy"
                     elif . == "CubeShim" then "CubeShim"
                     elif . == "network-agent" then "Network Agent"
                     else error("unsupported component: " + .)
@@ -162,11 +171,13 @@ jobs:
                   make_target: (
                     if . == "CubeAPI" then "cube-api-test"
                     elif . == "CubeOps" then "cubeops-test"
+                    elif . == "CubeProxy" then "cube-proxy-test"
                     elif . == "CubeShim" then "shim-test"
                     elif . == "network-agent" then "network-agent-test"
                     else error("unsupported component: " + .)
                     end
-                  )
+                  ),
+                  requires_builder: (. != "CubeProxy")
                 })
             '
           )"
@@ -193,6 +204,7 @@ jobs:
 
       - name: Detect builder changes
         id: builder_changes
+        if: matrix.requires_builder
         shell: bash
         run: |
           set -euo pipefail
@@ -225,7 +237,7 @@ jobs:
 
       - name: Log in to GitHub Container Registry
         id: ghcr_login
-        if: steps.builder_changes.outputs.changed != 'true'
+        if: matrix.requires_builder && steps.builder_changes.outputs.changed != 'true'
         continue-on-error: true
         uses: docker/login-action@v3
         with:
@@ -234,12 +246,13 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Warn about GHCR login failure
-        if: steps.ghcr_login.outcome == 'failure'
+        if: matrix.requires_builder && steps.ghcr_login.outcome == 'failure'
         shell: bash
         run: echo "::warning::GHCR login failed - will attempt pull as anonymous or build locally"
 
       - name: Resolve builder image
         id: builder_image
+        if: matrix.requires_builder
         shell: bash
         run: |
           set -euo pipefail
@@ -274,11 +287,15 @@ jobs:
         shell: bash
         env:
           MAKE_TARGET: ${{ matrix.make_target }}
+          REQUIRES_BUILDER: ${{ matrix.requires_builder }}
+          BUILDER_IMAGE: ${{ steps.builder_image.outputs.image }}
         run: |
           set -euo pipefail
 
           echo "Component: ${{ matrix.component }}"
-          echo "Builder image: ${{ steps.builder_image.outputs.image }}"
-
-          make "${MAKE_TARGET}" \
-            BUILDER_IMAGE="${{ steps.builder_image.outputs.image }}"
+          if [[ "${REQUIRES_BUILDER}" == "true" ]]; then
+            echo "Builder image: ${BUILDER_IMAGE}"
+            make "${MAKE_TARGET}" BUILDER_IMAGE="${BUILDER_IMAGE}"
+          else
+            make "${MAKE_TARGET}"
+          fi

--- a/CubeProxy/Makefile
+++ b/CubeProxy/Makefile
@@ -42,6 +42,10 @@ build:
 		-t $(IMAGE_LOCAL):$(IMAGE_TAG)-$(ARCH) \
 		.
 
+.PHONY: test
+test:
+	bash tests/test_start.sh
+
 # Push the architecture-specific image to all registries.
 # Run `make push` on an amd64 host, then again on an arm64 host, then
 # `make manifest` on either host to combine them.

--- a/CubeProxy/conf/includes/resolver.inc
+++ b/CubeProxy/conf/includes/resolver.inc
@@ -1,0 +1,2 @@
+# Always regenerated at container startup by CubeProxy/start.sh.
+# Intentionally empty in the source tree.

--- a/CubeProxy/nginx.conf
+++ b/CubeProxy/nginx.conf
@@ -29,6 +29,8 @@ events {
 }
 
 http {
+    # Keep resolver configuration at http scope so every Lua cosocket path inherits it.
+    include /usr/local/openresty/nginx/conf/includes/resolver.inc;
     include mime.types;
     lua_package_path "/usr/local/openresty/nginx/lua/?.lua;;";
     default_type application/octet-stream;

--- a/CubeProxy/start.sh
+++ b/CubeProxy/start.sh
@@ -7,5 +7,233 @@
 
 set -u
 
-/usr/sbin/crond
-exec /usr/local/openresty/nginx/sbin/nginx
+GLOBAL_CONF_PATH="${CUBE_PROXY_GLOBAL_CONF_PATH:-/usr/local/openresty/nginx/conf/global/global.conf}"
+RESOLVER_INCLUDE_PATH="${CUBE_PROXY_RESOLVER_INCLUDE_PATH:-/usr/local/openresty/nginx/conf/includes/resolver.inc}"
+
+die() {
+  echo "$(date -Iseconds) FATAL: $*" >&2
+  return 1
+}
+
+ipv4_literal_is_valid() {
+  local value="${1:-}"
+  local a b c d octet
+  [[ "${value}" =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$ ]] || return 1
+  IFS=. read -r a b c d <<< "${value}"
+  for octet in "${a}" "${b}" "${c}" "${d}"; do
+    [[ "${octet}" =~ ^[0-9]{1,3}$ ]] || return 1
+    (( 10#${octet} >= 0 && 10#${octet} <= 255 )) || return 1
+  done
+  return 0
+}
+
+ipv6_literal_is_valid() {
+  local value="${1:-}"
+  [[ -n "${value}" ]] || return 1
+  value="${value#\[}"
+  value="${value%\]}"
+  [[ "${value}" == *:* ]] || return 1
+  [[ "${value}" =~ ^[0-9A-Fa-f:.]+$ ]] || return 1
+  [[ "${value}" != *:::* ]] || return 1
+  [[ "${value}" != :* || "${value}" == ::* ]] || return 1
+  [[ "${value}" != *: || "${value}" == *:: ]] || return 1
+
+  local compressed=0
+  if [[ "${value}" == *::* ]]; then
+    compressed=1
+    [[ "${value#*::}" != *::* ]] || return 1
+  fi
+
+  local -a parts=()
+  IFS=: read -r -a parts <<< "${value}"
+  local groups=0 index part
+  for index in "${!parts[@]}"; do
+    part="${parts[${index}]}"
+    [[ -n "${part}" ]] || continue
+    if [[ "${part}" == *.* ]]; then
+      [[ "${index}" -eq $((${#parts[@]} - 1)) ]] || return 1
+      ipv4_literal_is_valid "${part}" || return 1
+      groups=$((groups + 2))
+      continue
+    fi
+    [[ "${part}" =~ ^[0-9A-Fa-f]{1,4}$ ]] || return 1
+    groups=$((groups + 1))
+  done
+
+  if [[ "${compressed}" == "1" ]]; then
+    (( groups < 8 ))
+  else
+    (( groups == 8 ))
+  fi
+}
+
+is_ip_literal() {
+  local value="${1:-}"
+  ipv4_literal_is_valid "${value}" || ipv6_literal_is_valid "${value}"
+}
+
+normalize_resolver_address() {
+  local value="${1:-}"
+  if ipv4_literal_is_valid "${value}"; then
+    printf '%s\n' "${value}"
+    return 0
+  fi
+  if ipv6_literal_is_valid "${value}"; then
+    value="${value#\[}"
+    value="${value%\]}"
+    [[ "${value}" != "::" ]] || return 1
+    printf '[%s]\n' "${value}"
+    return 0
+  fi
+
+  [[ "${value}" =~ ^(.+):([0-9]+)$ ]] || return 1
+  local host="${BASH_REMATCH[1]}"
+  local port="${BASH_REMATCH[2]}"
+  (( 10#${port} >= 1 && 10#${port} <= 65535 )) || return 1
+  if ipv4_literal_is_valid "${host}"; then
+    printf '%s:%s\n' "${host}" "${port}"
+    return 0
+  fi
+  if [[ "${host}" == \[*\] ]] && ipv6_literal_is_valid "${host}"; then
+    host="${host#\[}"
+    host="${host%\]}"
+    [[ "${host}" != "::" ]] || return 1
+    printf '[%s]:%s\n' "${host}" "${port}"
+    return 0
+  fi
+  return 1
+}
+
+discover_resolver_addresses() {
+  local path="${1:-${CUBE_PROXY_RESOLV_CONF:-/etc/resolv.conf}}"
+  [[ -f "${path}" ]] || return 0
+
+  local line keyword nameserver resolver_address
+  declare -A seen_addresses=()
+  while IFS= read -r line || [[ -n "${line}" ]]; do
+    read -r keyword nameserver _ <<< "${line}"
+    [[ "${keyword:-}" == "nameserver" ]] || continue
+    [[ -n "${nameserver}" ]] || continue
+    resolver_address="$(normalize_resolver_address "${nameserver}")" || continue
+    [[ -n "${seen_addresses[${resolver_address}]:-}" ]] && continue
+    seen_addresses["${resolver_address}"]=1
+    printf '%s\n' "${resolver_address}"
+  done < "${path}"
+}
+
+read_redis_host_from_global_conf() {
+  local path="${1:-${GLOBAL_CONF_PATH}}"
+  [[ -f "${path}" ]] || return 0
+
+  local line redis_line=""
+  while IFS= read -r line || [[ -n "${line}" ]]; do
+    [[ "${line}" =~ ^[[:space:]]*set[[:space:]]+\$redis_ip[[:space:]]+ ]] || continue
+    # nginx executes rewrite-module set directives in order, so the last assignment wins.
+    redis_line="${line}"
+  done < "${path}"
+
+  [[ -n "${redis_line}" ]] || return 0
+  if [[ "${redis_line}" =~ ^[[:space:]]*set[[:space:]]+\$redis_ip[[:space:]]+\"([^\"]*)\"[[:space:]]*\;[[:space:]]*(#.*)?$ ]]; then
+    printf '%s\n' "${BASH_REMATCH[1]}"
+    return 0
+  fi
+
+  die "unable to parse global.conf: \$redis_ip from ${path}; expected a quoted static value"
+  return 1
+}
+
+build_cube_proxy_resolver_include() {
+  local resolver_list="${1:-}"
+  if [[ -z "${resolver_list}" ]]; then
+    printf '%s\n' "# no usable nginx resolver discovered"
+    return 0
+  fi
+
+  local valid="${CUBE_PROXY_RESOLVER_VALID:-30s}"
+  local timeout="${CUBE_PROXY_RESOLVER_TIMEOUT:-5s}"
+  local ipv6="${CUBE_PROXY_RESOLVER_IPV6:-off}"
+  [[ "${valid}" =~ ^[0-9]+(ms|s|m|h|d|w|M|y)?$ ]] \
+    || { die "invalid CUBE_PROXY_RESOLVER_VALID: ${valid}"; return 1; }
+  [[ "${timeout}" =~ ^[0-9]+(ms|s|m|h|d|w|M|y)?$ ]] \
+    || { die "invalid CUBE_PROXY_RESOLVER_TIMEOUT: ${timeout}"; return 1; }
+  [[ "${ipv6}" == "on" || "${ipv6}" == "off" ]] \
+    || { die "invalid CUBE_PROXY_RESOLVER_IPV6: ${ipv6} (expected on or off)"; return 1; }
+
+  printf 'resolver %s ipv6=%s valid=%s;\nresolver_timeout %s;\n' \
+    "${resolver_list}" "${ipv6}" "${valid}" "${timeout}"
+}
+
+ensure_hostname_target_has_resolver() {
+  local target="${1:-}"
+  local resolver_list="${2:-}"
+  local target_var="${3:-target}"
+
+  if ! is_ip_literal "${target}" && [[ -z "${resolver_list}" ]]; then
+    die "${target_var} '${target}' is not an IP literal, but no nginx resolver nameserver could be discovered from ${CUBE_PROXY_RESOLV_CONF:-/etc/resolv.conf}. Ensure the container resolv.conf has at least one valid IPv4 or IPv6 nameserver."
+    return 1
+  fi
+}
+
+render_resolver_include() {
+  local resolver_list="${1:-}"
+  local tmp="${RESOLVER_INCLUDE_PATH}.tmp"
+
+  mkdir -p "$(dirname "${RESOLVER_INCLUDE_PATH}")"
+  if ! build_cube_proxy_resolver_include "${resolver_list}" > "${tmp}"; then
+    rm -f "${tmp}"
+    die "failed to render resolver include: ${RESOLVER_INCLUDE_PATH}" || return 1
+  fi
+  mv -f "${tmp}" "${RESOLVER_INCLUDE_PATH}"
+}
+
+prepare_resolver_include() {
+  local resolver_list=""
+  local -a resolver_addresses=()
+  if [[ -n "${CUBE_PROXY_RESOLVER_ADDRS:-}" ]]; then
+    local -a configured_addresses=()
+    read -r -a configured_addresses <<< "${CUBE_PROXY_RESOLVER_ADDRS}"
+    local configured_address resolver_address
+    for configured_address in "${configured_addresses[@]}"; do
+      resolver_address="$(normalize_resolver_address "${configured_address}")" \
+        || { die "invalid nameserver in CUBE_PROXY_RESOLVER_ADDRS: ${configured_address}"; return 1; }
+      resolver_addresses+=("${resolver_address}")
+    done
+  else
+    local discovered_addresses=""
+    discovered_addresses="$(discover_resolver_addresses)" || return 1
+    if [[ -n "${discovered_addresses}" ]]; then
+      mapfile -t resolver_addresses <<< "${discovered_addresses}"
+    fi
+  fi
+  if [[ "${#resolver_addresses[@]}" -gt 0 ]]; then
+    resolver_list="${resolver_addresses[*]}"
+  fi
+
+  if [[ -z "${resolver_list}" ]]; then
+    local redis_host=""
+    redis_host="$(read_redis_host_from_global_conf)" || return 1
+    if [[ -n "${redis_host}" ]]; then
+      ensure_hostname_target_has_resolver \
+        "${redis_host}" "${resolver_list}" 'global.conf: $redis_ip' || return 1
+    fi
+
+    if [[ "${CUBE_PROXY_REGISTRY_ENABLE:-}" == "1" && -n "${CUBE_PROXY_REGISTRY_REDIS_HOST:-}" ]]; then
+      ensure_hostname_target_has_resolver \
+        "${CUBE_PROXY_REGISTRY_REDIS_HOST}" "${resolver_list}" \
+        "CUBE_PROXY_REGISTRY_REDIS_HOST" || return 1
+    fi
+  fi
+
+  render_resolver_include "${resolver_list}" || return 1
+}
+
+main() {
+  prepare_resolver_include || exit 1
+
+  /usr/sbin/crond
+  exec /usr/local/openresty/nginx/sbin/nginx
+}
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+  main "$@"
+fi

--- a/CubeProxy/tests/test_start.sh
+++ b/CubeProxy/tests/test_start.sh
@@ -1,0 +1,544 @@
+#!/usr/bin/env bash
+# CubeProxy resolver entrypoint regression tests.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CUBE_PROXY_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+CUBE_PROXY_START_SH="${CUBE_PROXY_DIR}/start.sh"
+
+TMP_DIR="$(mktemp -d)"
+cleanup() {
+  rm -rf "${TMP_DIR}"
+}
+trap cleanup EXIT
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+assert_contains() {
+  grep -Fq -- "$2" "$1" || fail "expected $1 to contain: $2"
+}
+
+run_prepare_resolver() {
+  env \
+    CUBE_PROXY_START_SH="${CUBE_PROXY_START_SH}" \
+    "$@" \
+    bash -c '
+      set -euo pipefail
+      source "${CUBE_PROXY_START_SH}"
+      prepare_resolver_include
+    '
+}
+
+test_cube_proxy_start_discover_resolver_addresses() {
+  local resolv_conf="${TMP_DIR}/cube-proxy-resolver.conf"
+  local output=""
+
+  cat > "${resolv_conf}" <<'EOF'
+nameserver 127.0.0.53
+nameserver 100.100.2.136
+nameserver 100.100.2.136
+nameserver 999.999.999.999
+nameserver 0377.0377.0377.0377
+nameserver 169.254.254.53
+nameserver 2001:db8::1
+nameserver 2001:db8::1
+nameserver 2001:db8::zz
+EOF
+
+  output="$(
+    CUBE_PROXY_RESOLV_CONF="${resolv_conf}" \
+      bash -c '
+        set -euo pipefail
+        source "'"${CUBE_PROXY_START_SH}"'"
+        discover_resolver_addresses
+      '
+  )"
+
+  grep -Fxq "127.0.0.53" <<<"${output}" \
+    || fail "discover_resolver_addresses should keep container-local loopback resolvers"
+  grep -Fxq "100.100.2.136" <<<"${output}" \
+    || fail "discover_resolver_addresses should include upstream nameservers"
+  grep -Fxq "169.254.254.53" <<<"${output}" \
+    || fail "discover_resolver_addresses should include link-local IPv4 nameservers"
+  if grep -Fxq "999.999.999.999" <<<"${output}" || grep -Fxq "0377.0377.0377.0377" <<<"${output}"; then
+    fail "discover_resolver_addresses should skip invalid IPv4 nameservers"
+  fi
+  grep -Fxq "[2001:db8::1]" <<<"${output}" \
+    || fail "discover_resolver_addresses should include IPv6 nameservers"
+  if grep -Fxq "2001:db8::zz" <<<"${output}"; then
+    fail "discover_resolver_addresses should skip invalid IPv6 nameservers"
+  fi
+  if [[ "$(grep -Fxc "100.100.2.136" <<<"${output}")" != "1" ]]; then
+    fail "discover_resolver_addresses should dedupe identical nameservers"
+  fi
+}
+
+test_cube_proxy_start_build_resolver_include() {
+  local output=""
+
+  output="$(
+    bash -c '
+      set -euo pipefail
+      source "'"${CUBE_PROXY_START_SH}"'"
+      build_cube_proxy_resolver_include "169.254.254.53 100.100.2.136"
+    '
+  )"
+  [[ "${output}" == $'resolver 169.254.254.53 100.100.2.136 ipv6=off valid=30s;\nresolver_timeout 5s;' ]] \
+    || fail "build_cube_proxy_resolver_include should render the exact nginx include body (got: ${output})"
+
+  output="$(
+    bash -c '
+      set -euo pipefail
+      source "'"${CUBE_PROXY_START_SH}"'"
+      build_cube_proxy_resolver_include ""
+    '
+  )"
+  [[ "${output}" == "# no usable nginx resolver discovered" ]] \
+    || fail "build_cube_proxy_resolver_include should render an explicit no-op marker for empty resolver lists"
+
+  output="$(
+    CUBE_PROXY_RESOLVER_VALID=300s \
+    CUBE_PROXY_RESOLVER_TIMEOUT=10s \
+    CUBE_PROXY_RESOLVER_IPV6=on \
+      bash -c '
+        set -euo pipefail
+        source "'"${CUBE_PROXY_START_SH}"'"
+        build_cube_proxy_resolver_include "169.254.254.53"
+      '
+  )"
+  [[ "${output}" == $'resolver 169.254.254.53 ipv6=on valid=300s;\nresolver_timeout 10s;' ]] \
+    || fail "build_cube_proxy_resolver_include should honor existing resolver tuning env vars"
+
+  if CUBE_PROXY_RESOLVER_VALID='bad;' bash -c '
+    set -euo pipefail
+    source "'"${CUBE_PROXY_START_SH}"'"
+    build_cube_proxy_resolver_include "169.254.254.53"
+  ' >/dev/null 2>&1; then
+    fail "build_cube_proxy_resolver_include should reject invalid resolver tuning"
+  fi
+}
+
+test_cube_proxy_start_prepare_resolver_include_for_hostname() {
+  local resolv_conf="${TMP_DIR}/cube-proxy-hostname-resolv.conf"
+  local global_conf="${TMP_DIR}/cube-proxy-global.conf"
+  local resolver_inc="${TMP_DIR}/resolver.inc"
+
+  cat > "${resolv_conf}" <<'EOF'
+nameserver 169.254.254.53
+nameserver 100.100.2.136
+EOF
+
+  cat > "${global_conf}" <<'EOF'
+set $redis_ip "redis.example.com";
+EOF
+
+  if ! run_prepare_resolver \
+    CUBE_PROXY_RESOLV_CONF="${resolv_conf}" \
+    CUBE_PROXY_GLOBAL_CONF_PATH="${global_conf}" \
+    CUBE_PROXY_RESOLVER_INCLUDE_PATH="${resolver_inc}" >/dev/null 2>&1; then
+    fail "prepare_resolver_include should succeed for hostname Redis targets when resolvers are available"
+  fi
+
+  assert_contains "${resolver_inc}" "resolver 169.254.254.53 100.100.2.136 ipv6=off valid=30s;"
+  assert_contains "${resolver_inc}" "resolver_timeout 5s;"
+}
+
+test_cube_proxy_start_prepare_resolver_include_for_hostname_with_space_before_semicolon() {
+  local resolv_conf="${TMP_DIR}/cube-proxy-hostname-space-resolv.conf"
+  local global_conf="${TMP_DIR}/cube-proxy-global-space.conf"
+  local resolver_inc="${TMP_DIR}/resolver-space.inc"
+
+  cat > "${resolv_conf}" <<'EOF'
+nameserver 169.254.254.53
+EOF
+
+  cat > "${global_conf}" <<'EOF'
+set $redis_ip "redis.example.com" ;
+EOF
+
+  if ! run_prepare_resolver \
+    CUBE_PROXY_RESOLV_CONF="${resolv_conf}" \
+    CUBE_PROXY_GLOBAL_CONF_PATH="${global_conf}" \
+    CUBE_PROXY_RESOLVER_INCLUDE_PATH="${resolver_inc}" >/dev/null 2>&1; then
+    fail "prepare_resolver_include should accept global.conf redis_ip entries with whitespace before the semicolon"
+  fi
+
+  assert_contains "${resolver_inc}" "resolver 169.254.254.53 ipv6=off valid=30s;"
+  assert_contains "${resolver_inc}" "resolver_timeout 5s;"
+}
+
+test_cube_proxy_start_always_writes_discovered_resolver() {
+  local resolv_conf="${TMP_DIR}/cube-proxy-always-resolver.conf"
+  local global_conf="${TMP_DIR}/cube-proxy-global-ip.conf"
+  local resolver_inc="${TMP_DIR}/resolver-ip.inc"
+
+  cat > "${resolv_conf}" <<'EOF'
+nameserver 169.254.254.53
+EOF
+
+  cat > "${global_conf}" <<'EOF'
+set $redis_ip "127.0.0.1";
+EOF
+
+  if ! run_prepare_resolver \
+    CUBE_PROXY_RESOLV_CONF="${resolv_conf}" \
+    CUBE_PROXY_GLOBAL_CONF_PATH="${global_conf}" \
+    CUBE_PROXY_RESOLVER_INCLUDE_PATH="${resolver_inc}" >/dev/null 2>&1; then
+    fail "prepare_resolver_include should succeed when a resolver is available"
+  fi
+
+  assert_contains "${resolver_inc}" "resolver 169.254.254.53 ipv6=off valid=30s;"
+}
+
+test_cube_proxy_start_registry_hostname_fails_without_resolver() {
+  local resolv_conf="${TMP_DIR}/cube-proxy-registry-no-resolver.conf"
+  local global_conf="${TMP_DIR}/cube-proxy-registry-global.conf"
+  local resolver_inc="${TMP_DIR}/resolver-registry-none.inc"
+  local err="${TMP_DIR}/cube-proxy-registry-no-resolver.err"
+
+  : > "${resolv_conf}"
+  cat > "${global_conf}" <<'EOF'
+set $redis_ip "127.0.0.1";
+EOF
+
+  if run_prepare_resolver \
+    CUBE_PROXY_RESOLV_CONF="${resolv_conf}" \
+    CUBE_PROXY_GLOBAL_CONF_PATH="${global_conf}" \
+    CUBE_PROXY_RESOLVER_INCLUDE_PATH="${resolver_inc}" \
+    CUBE_PROXY_REGISTRY_ENABLE=1 \
+    CUBE_PROXY_REGISTRY_REDIS_HOST=registry.redis.example.com >/dev/null 2>"${err}"; then
+    fail "prepare_resolver_include should fail when registry Redis needs DNS but no resolver is available"
+  fi
+
+  assert_contains "${err}" "CUBE_PROXY_REGISTRY_REDIS_HOST 'registry.redis.example.com' is not an IP literal"
+}
+
+test_cube_proxy_start_registry_hostname_uses_explicit_resolver_override() {
+  local resolv_conf="${TMP_DIR}/cube-proxy-registry-explicit-resolver.conf"
+  local global_conf="${TMP_DIR}/cube-proxy-registry-explicit-global.conf"
+  local resolver_inc="${TMP_DIR}/resolver-registry-explicit.inc"
+
+  : > "${resolv_conf}"
+  cat > "${global_conf}" <<'EOF'
+set $redis_ip "127.0.0.1";
+EOF
+
+  if ! run_prepare_resolver \
+    CUBE_PROXY_RESOLV_CONF="${resolv_conf}" \
+    CUBE_PROXY_GLOBAL_CONF_PATH="${global_conf}" \
+    CUBE_PROXY_RESOLVER_INCLUDE_PATH="${resolver_inc}" \
+    CUBE_PROXY_RESOLVER_ADDRS="172.18.0.10:5353 [2001:db8::53]:5353" \
+    CUBE_PROXY_RESOLVER_VALID=300s \
+    CUBE_PROXY_RESOLVER_TIMEOUT=10s \
+    CUBE_PROXY_REGISTRY_ENABLE=1 \
+    CUBE_PROXY_REGISTRY_REDIS_HOST=registry.redis.example.com >/dev/null 2>&1; then
+    fail "prepare_resolver_include should honor the Helm resolver override for registry Redis"
+  fi
+
+  assert_contains "${resolver_inc}" "resolver 172.18.0.10:5353 [2001:db8::53]:5353 ipv6=off valid=300s;"
+  assert_contains "${resolver_inc}" "resolver_timeout 10s;"
+}
+
+test_cube_proxy_start_hostname_uses_ipv6_resolver() {
+  local resolv_conf="${TMP_DIR}/cube-proxy-ipv6-resolver.conf"
+  local global_conf="${TMP_DIR}/cube-proxy-ipv6-global.conf"
+  local resolver_inc="${TMP_DIR}/resolver-ipv6.inc"
+
+  cat > "${resolv_conf}" <<'EOF'
+nameserver 2001:db8::53
+EOF
+  cat > "${global_conf}" <<'EOF'
+set $redis_ip "redis.example.com";
+EOF
+
+  if ! run_prepare_resolver \
+    CUBE_PROXY_RESOLV_CONF="${resolv_conf}" \
+    CUBE_PROXY_GLOBAL_CONF_PATH="${global_conf}" \
+    CUBE_PROXY_RESOLVER_INCLUDE_PATH="${resolver_inc}" >/dev/null 2>&1; then
+    fail "prepare_resolver_include should support an IPv6-only resolver"
+  fi
+
+  assert_contains "${resolver_inc}" "resolver [2001:db8::53] ipv6=off valid=30s;"
+}
+
+test_cube_proxy_start_trailing_comment_hostname_fails_without_resolver() {
+  local resolv_conf="${TMP_DIR}/cube-proxy-comment-no-resolver.conf"
+  local global_conf="${TMP_DIR}/cube-proxy-comment-global.conf"
+  local resolver_inc="${TMP_DIR}/resolver-comment-none.inc"
+  local err="${TMP_DIR}/cube-proxy-comment-no-resolver.err"
+
+  : > "${resolv_conf}"
+  cat > "${global_conf}" <<'EOF'
+set $redis_ip "redis.example.com"; # primary redis
+EOF
+
+  if run_prepare_resolver \
+    CUBE_PROXY_RESOLV_CONF="${resolv_conf}" \
+    CUBE_PROXY_GLOBAL_CONF_PATH="${global_conf}" \
+    CUBE_PROXY_RESOLVER_INCLUDE_PATH="${resolver_inc}" >/dev/null 2>"${err}"; then
+    fail "prepare_resolver_include should not ignore a hostname followed by a trailing comment"
+  fi
+
+  assert_contains "${err}" "global.conf: \$redis_ip 'redis.example.com' is not an IP literal"
+}
+
+test_cube_proxy_start_uses_global_conf_over_unconsumed_env() {
+  local resolv_conf="${TMP_DIR}/cube-proxy-env-mismatch-no-resolver.conf"
+  local global_conf="${TMP_DIR}/cube-proxy-env-mismatch-global.conf"
+  local resolver_inc="${TMP_DIR}/resolver-env-mismatch-none.inc"
+  local err="${TMP_DIR}/cube-proxy-env-mismatch-no-resolver.err"
+
+  : > "${resolv_conf}"
+  cat > "${global_conf}" <<'EOF'
+set $redis_ip "redis.example.com";
+EOF
+
+  if run_prepare_resolver \
+    CUBE_PROXY_RESOLV_CONF="${resolv_conf}" \
+    CUBE_PROXY_GLOBAL_CONF_PATH="${global_conf}" \
+    CUBE_PROXY_RESOLVER_INCLUDE_PATH="${resolver_inc}" \
+    CUBE_PROXY_REDIS_IP=127.0.0.1 >/dev/null 2>"${err}"; then
+    fail "prepare_resolver_include should use the Redis host nginx reads from global.conf"
+  fi
+
+  assert_contains "${err}" "global.conf: \$redis_ip 'redis.example.com' is not an IP literal"
+}
+
+test_cube_proxy_start_ip_targets_succeed_without_resolver() {
+  local resolv_conf="${TMP_DIR}/cube-proxy-ip-targets-no-resolver.conf"
+  local global_conf="${TMP_DIR}/cube-proxy-ip-targets-global.conf"
+  local resolver_inc="${TMP_DIR}/resolver-ip-targets-none.inc"
+
+  : > "${resolv_conf}"
+  cat > "${global_conf}" <<'EOF'
+set $redis_ip "127.0.0.1";
+EOF
+
+  if ! run_prepare_resolver \
+    CUBE_PROXY_RESOLV_CONF="${resolv_conf}" \
+    CUBE_PROXY_GLOBAL_CONF_PATH="${global_conf}" \
+    CUBE_PROXY_RESOLVER_INCLUDE_PATH="${resolver_inc}" \
+    CUBE_PROXY_REGISTRY_ENABLE=1 \
+    CUBE_PROXY_REGISTRY_REDIS_HOST=10.0.0.12 >/dev/null 2>&1; then
+    fail "prepare_resolver_include should allow IP-only Redis targets without a resolver"
+  fi
+
+  assert_contains "${resolver_inc}" "# no usable nginx resolver discovered"
+}
+
+test_cube_proxy_start_unparseable_redis_host_fails_without_resolver() {
+  local resolv_conf="${TMP_DIR}/cube-proxy-unparseable-no-resolver.conf"
+  local global_conf="${TMP_DIR}/cube-proxy-unparseable-global.conf"
+  local resolver_inc="${TMP_DIR}/resolver-unparseable-none.inc"
+  local err="${TMP_DIR}/cube-proxy-unparseable-no-resolver.err"
+
+  : > "${resolv_conf}"
+  cat > "${global_conf}" <<'EOF'
+set $redis_ip redis.example.com;
+EOF
+
+  if run_prepare_resolver \
+    CUBE_PROXY_RESOLV_CONF="${resolv_conf}" \
+    CUBE_PROXY_GLOBAL_CONF_PATH="${global_conf}" \
+    CUBE_PROXY_RESOLVER_INCLUDE_PATH="${resolver_inc}" >/dev/null 2>"${err}"; then
+    fail "prepare_resolver_include should fail when it cannot classify the configured Redis target"
+  fi
+
+  assert_contains "${err}" "unable to parse global.conf: \$redis_ip"
+}
+
+test_cube_proxy_start_prepare_resolver_include_fails_without_resolver() {
+  local resolv_conf="${TMP_DIR}/cube-proxy-no-resolver.conf"
+  local global_conf="${TMP_DIR}/cube-proxy-global-no-resolver.conf"
+  local resolver_inc="${TMP_DIR}/resolver-none.inc"
+  local err="${TMP_DIR}/cube-proxy-no-resolver.err"
+
+  cat > "${resolv_conf}" <<'EOF'
+nameserver 2001:db8::zz
+nameserver 999.999.999.999
+EOF
+
+  cat > "${global_conf}" <<'EOF'
+set $redis_ip "redis.example.com";
+EOF
+
+  if run_prepare_resolver \
+    CUBE_PROXY_RESOLV_CONF="${resolv_conf}" \
+    CUBE_PROXY_GLOBAL_CONF_PATH="${global_conf}" \
+    CUBE_PROXY_RESOLVER_INCLUDE_PATH="${resolver_inc}" >/dev/null 2>"${err}"; then
+    fail "prepare_resolver_include should fail fast when Redis is a hostname and no valid resolver is available"
+  fi
+
+  assert_contains "${err}" "global.conf: \$redis_ip 'redis.example.com' is not an IP literal"
+  assert_contains "${err}" "Ensure the container resolv.conf has at least one valid IPv4 or IPv6 nameserver."
+}
+
+test_cube_proxy_start_rejects_unspecified_ipv6_resolver() {
+  local global_conf="${TMP_DIR}/cube-proxy-unspecified-ipv6-global.conf"
+  local resolver_inc="${TMP_DIR}/resolver-unspecified-ipv6.inc"
+  local err="${TMP_DIR}/cube-proxy-unspecified-ipv6.err"
+
+  cat > "${global_conf}" <<'EOF'
+set $redis_ip "127.0.0.1";
+EOF
+
+  if run_prepare_resolver \
+    CUBE_PROXY_GLOBAL_CONF_PATH="${global_conf}" \
+    CUBE_PROXY_RESOLVER_INCLUDE_PATH="${resolver_inc}" \
+    CUBE_PROXY_RESOLVER_ADDRS="::" >/dev/null 2>"${err}"; then
+    fail "prepare_resolver_include should reject the unspecified IPv6 resolver address"
+  fi
+
+  assert_contains "${err}" "invalid nameserver in CUBE_PROXY_RESOLVER_ADDRS: ::"
+}
+
+test_cube_proxy_start_uses_last_global_conf_redis_host() {
+  local resolv_conf="${TMP_DIR}/cube-proxy-multiple-redis-no-resolver.conf"
+  local global_conf="${TMP_DIR}/cube-proxy-multiple-redis-global.conf"
+  local resolver_inc="${TMP_DIR}/resolver-multiple-redis.inc"
+  local err="${TMP_DIR}/cube-proxy-multiple-redis.err"
+
+  : > "${resolv_conf}"
+  cat > "${global_conf}" <<'EOF'
+set $redis_ip "127.0.0.1";
+set $redis_ip "redis.example.com";
+EOF
+
+  if run_prepare_resolver \
+    CUBE_PROXY_RESOLV_CONF="${resolv_conf}" \
+    CUBE_PROXY_GLOBAL_CONF_PATH="${global_conf}" \
+    CUBE_PROXY_RESOLVER_INCLUDE_PATH="${resolver_inc}" >/dev/null 2>"${err}"; then
+    fail "prepare_resolver_include should classify the last global.conf redis_ip value"
+  fi
+
+  assert_contains "${err}" "global.conf: \$redis_ip 'redis.example.com' is not an IP literal"
+}
+
+test_cube_proxy_start_ignores_overridden_unparseable_redis_host() {
+  local resolv_conf="${TMP_DIR}/cube-proxy-overridden-redis-no-resolver.conf"
+  local global_conf="${TMP_DIR}/cube-proxy-overridden-redis-global.conf"
+  local resolver_inc="${TMP_DIR}/resolver-overridden-redis.inc"
+
+  : > "${resolv_conf}"
+  cat > "${global_conf}" <<'EOF'
+set $redis_ip redis.ignored.example.com;
+set $redis_ip "127.0.0.1";
+EOF
+
+  if ! run_prepare_resolver \
+    CUBE_PROXY_RESOLV_CONF="${resolv_conf}" \
+    CUBE_PROXY_GLOBAL_CONF_PATH="${global_conf}" \
+    CUBE_PROXY_RESOLVER_INCLUDE_PATH="${resolver_inc}" >/dev/null 2>&1; then
+    fail "prepare_resolver_include should classify only the last global.conf redis_ip declaration"
+  fi
+
+  assert_contains "${resolver_inc}" "# no usable nginx resolver discovered"
+}
+
+test_cube_proxy_start_main_exits_when_resolver_preparation_fails() {
+  local resolv_conf="${TMP_DIR}/cube-proxy-main-no-resolver.conf"
+  local global_conf="${TMP_DIR}/cube-proxy-main-global.conf"
+  local resolver_inc="${TMP_DIR}/resolver-main-none.inc"
+  local err="${TMP_DIR}/cube-proxy-main-no-resolver.err"
+
+  : > "${resolv_conf}"
+  cat > "${global_conf}" <<'EOF'
+set $redis_ip "redis.example.com";
+EOF
+
+  if env \
+    CUBE_PROXY_START_SH="${CUBE_PROXY_START_SH}" \
+    CUBE_PROXY_RESOLV_CONF="${resolv_conf}" \
+    CUBE_PROXY_GLOBAL_CONF_PATH="${global_conf}" \
+    CUBE_PROXY_RESOLVER_INCLUDE_PATH="${resolver_inc}" \
+    bash -c '
+      set -euo pipefail
+      source "${CUBE_PROXY_START_SH}"
+      main
+    ' >/dev/null 2>"${err}"; then
+    fail "main should exit non-zero when resolver preparation fails"
+  fi
+
+  assert_contains "${err}" "global.conf: \$redis_ip 'redis.example.com' is not an IP literal"
+  [[ ! -e "${resolver_inc}" ]] \
+    || fail "main should not render a resolver include after preparation fails"
+}
+
+test_cube_proxy_start_discover_resolver_addresses_empty_and_missing() {
+  local empty_resolv_conf="${TMP_DIR}/cube-proxy-empty-resolv.conf"
+  local missing_resolv_conf="${TMP_DIR}/cube-proxy-missing-resolv.conf"
+  local output=""
+
+  : > "${empty_resolv_conf}"
+  output="$(
+    CUBE_PROXY_RESOLV_CONF="${empty_resolv_conf}" \
+      bash -c '
+        set -euo pipefail
+        source "'"${CUBE_PROXY_START_SH}"'"
+        discover_resolver_addresses
+      '
+  )"
+  [[ -z "${output}" ]] \
+    || fail "discover_resolver_addresses should return no addresses for an empty resolv.conf"
+
+  output="$(
+    CUBE_PROXY_RESOLV_CONF="${missing_resolv_conf}" \
+      bash -c '
+        set -euo pipefail
+        source "'"${CUBE_PROXY_START_SH}"'"
+        discover_resolver_addresses
+      '
+  )"
+  [[ -z "${output}" ]] \
+    || fail "discover_resolver_addresses should return no addresses for a missing resolv.conf"
+}
+
+test_cube_proxy_start_propagates_resolver_discovery_failure() {
+  local resolver_inc="${TMP_DIR}/resolver-discovery-failure.inc"
+  local err="${TMP_DIR}/resolver-discovery-failure.err"
+
+  if env \
+    CUBE_PROXY_START_SH="${CUBE_PROXY_START_SH}" \
+    CUBE_PROXY_RESOLVER_INCLUDE_PATH="${resolver_inc}" \
+    bash -c '
+      set -euo pipefail
+      source "${CUBE_PROXY_START_SH}"
+      discover_resolver_addresses() {
+        echo "simulated resolver discovery failure" >&2
+        return 42
+      }
+      prepare_resolver_include
+    ' >/dev/null 2>"${err}"; then
+    fail "prepare_resolver_include should propagate resolver discovery failures"
+  fi
+
+  assert_contains "${err}" "simulated resolver discovery failure"
+  [[ ! -e "${resolver_inc}" ]] \
+    || fail "prepare_resolver_include should not render an include after resolver discovery fails"
+}
+
+test_cube_proxy_start_discover_resolver_addresses
+test_cube_proxy_start_build_resolver_include
+test_cube_proxy_start_prepare_resolver_include_for_hostname
+test_cube_proxy_start_prepare_resolver_include_for_hostname_with_space_before_semicolon
+test_cube_proxy_start_always_writes_discovered_resolver
+test_cube_proxy_start_registry_hostname_fails_without_resolver
+test_cube_proxy_start_registry_hostname_uses_explicit_resolver_override
+test_cube_proxy_start_hostname_uses_ipv6_resolver
+test_cube_proxy_start_trailing_comment_hostname_fails_without_resolver
+test_cube_proxy_start_uses_global_conf_over_unconsumed_env
+test_cube_proxy_start_ip_targets_succeed_without_resolver
+test_cube_proxy_start_unparseable_redis_host_fails_without_resolver
+test_cube_proxy_start_prepare_resolver_include_fails_without_resolver
+test_cube_proxy_start_rejects_unspecified_ipv6_resolver
+test_cube_proxy_start_uses_last_global_conf_redis_host
+test_cube_proxy_start_ignores_overridden_unparseable_redis_host
+test_cube_proxy_start_main_exits_when_resolver_preparation_fails
+test_cube_proxy_start_discover_resolver_addresses_empty_and_missing
+test_cube_proxy_start_propagates_resolver_discovery_failure
+
+echo "CubeProxy resolver tests OK"

--- a/Makefile
+++ b/Makefile
@@ -113,6 +113,7 @@ help:
 	@printf "  shim          Build containerd-shim-cube-rs and cube-runtime in Docker\n"
 	@printf "  cubemaster-test Run CubeMaster unit tests in Docker\n"
 	@printf "  cubelet-test  Run Cubelet unit tests in Docker\n"
+	@printf "  cube-proxy-test Run CubeProxy unit tests locally\n"
 	@printf "  cube-api-test Run CubeAPI unit tests in Docker\n"
 	@printf "  cubeops-test  Run CubeOps unit tests in Docker\n"
 	@printf "  shim-test     Run CubeShim unit tests in Docker\n"
@@ -292,6 +293,10 @@ cubelet-test: builder-image
 .PHONY: network-agent-test
 network-agent-test: builder-image
 	$(MAKE) builder-run BUILDER_CMD='cd /workspace/network-agent && go mod download && make test'
+
+.PHONY: cube-proxy-test
+cube-proxy-test:
+	$(MAKE) -C CubeProxy test
 
 .PHONY: cube-api-test
 cube-api-test: builder-image


### PR DESCRIPTION
## Motivation

When CubeProxy connects to Redis by hostname, OpenResty Lua can fail with:

```text
no resolver defined to resolve "<redis-hostname>"
```

NGINX/OpenResty requires an explicit `resolver` directive for Lua cosocket hostname resolution. Reading `/etc/resolv.conf` is not enough by itself, because nginx expects concrete resolver addresses in `nginx.conf`.

CubeProxy has two independent Redis connections: the request path reads `$redis_ip` from `global.conf`, while the heartbeat and registration path reads `CUBE_PROXY_REGISTRY_REDIS_HOST`. Following the review feedback, this PR keeps the fix focused on the shared resolver path so both connections use the same container-side nginx resolver configuration.

## What Changed

This PR makes CubeProxy prepare only the resolver include at container startup:

* adds a dedicated `conf/includes/resolver.inc` include hook at the nginx `http` level
* updates `CubeProxy/start.sh` to:
  * reuse the existing Helm `CUBE_PROXY_RESOLVER_ADDRS` override when configured, or discover resolver addresses from the container's `/etc/resolv.conf`
  * validate and normalize IPv4 and IPv6 resolver addresses, including optional ports
  * always render available resolver addresses instead of trying to predict which Lua path will need DNS
  * read the business Redis target from the mounted `global.conf`, matching the source nginx actually uses
  * check `CUBE_PROXY_REGISTRY_REDIS_HOST` when proxy registration is enabled
  * accept trailing comments on the `$redis_ip` declaration and fail clearly when the declaration cannot be classified
  * honor the existing resolver `valid`, `timeout`, and IPv6 settings used by the Helm chart
  * fail fast only when an enabled Redis target is a hostname and no valid resolver is available
  * keep IP-only deployments working when no resolver is available
* adds focused resolver regression coverage in `CubeProxy/tests/test_start.sh` and exposes it through `make -C CubeProxy test`

The final change is limited to the CubeProxy component. It does not rework the broader one-click or Helm rendering flows.

## Validation

* Ran the focused CubeProxy shell tests with `make -C CubeProxy test`.
* Verified the CubeProxy startup helper across the relevant resolver branches:
  * available resolver addresses are always written, including for IP-only Redis targets
  * the business and registry Redis paths both fail fast when a hostname requires DNS but no resolver is available
  * `global.conf` entries with trailing comments are parsed correctly
  * `CUBE_PROXY_REDIS_IP` does not override the `global.conf` value nginx actually consumes
  * IPv4 and IPv6 resolver addresses, optional ports, and resolver tuning values are validated
* Built the CubeProxy image successfully in a Linux environment.
* Verified the container-side startup path in a temporary container: `start.sh` rendered `conf/includes/resolver.inc` with `[2001:db8::53]:5353` and `172.18.0.10:5353`, and the target OpenResty `nginx -t` succeeded.
* Verified `bash -n CubeProxy/start.sh CubeProxy/tests/test_start.sh` and `git diff --check origin/master...HEAD`.

## Scope

This PR fixes Redis hostname resolution through CubeProxy's nginx/OpenResty resolver configuration.

It intentionally does not change:

* CubeProxy's Lua Redis access logic
* non-resolver CubeProxy routing behavior
* the wider one-click nginx rendering flow
* the existing Helm chart rendering flow
