### PR TITLE
build: complete aarch64 support across image and bundle builds

### DIFF
--- a/CubeAPI/Dockerfile
+++ b/CubeAPI/Dockerfile
@@ -8,14 +8,30 @@
 #   docker run -e CUBE_MASTER_ADDR=http://cubemaster:8089 -p 3000:3000 cube-api:v1.0
 
 # ── Build stage ────────────────────────────────────────────────────────────────
+# TARGETARCH is auto-populated by BuildKit/buildx (amd64 | arm64). Falls back to
+# the host arch for a plain `docker build` without buildx.
 FROM rust:1.85-alpine AS builder
+ARG TARGETARCH
 
 # musl-dev provides the musl C runtime/headers needed to link the static binary
-# against the x86_64-unknown-linux-musl target (rust:alpine already ships gcc).
+# against the <arch>-unknown-linux-musl target (rust:alpine already ships gcc).
 # We add the target explicitly so the installed musl headers are actually used.
 # TLS is pure-rustls, so no OpenSSL is required.
-RUN apk add --no-cache musl-dev \
-    && rustup target add x86_64-unknown-linux-musl
+#
+# The target triple is derived from TARGETARCH so the image builds natively on
+# both amd64 and arm64. It is written to /etc/rust-target so the later
+# dependency- and application-build steps in this stage reuse the same triple
+# without re-deriving it.
+RUN set -eux; \
+    arch="${TARGETARCH:-$(apk --print-arch)}"; \
+    case "${arch}" in \
+      amd64|x86_64)  rust_target=x86_64-unknown-linux-musl;; \
+      arm64|aarch64) rust_target=aarch64-unknown-linux-musl;; \
+      *) echo "unsupported TARGETARCH: ${arch}" >&2; exit 1;; \
+    esac; \
+    echo "${rust_target}" > /etc/rust-target; \
+    apk add --no-cache musl-dev; \
+    rustup target add "${rust_target}"
 
 WORKDIR /app
 
@@ -28,13 +44,17 @@ COPY build.rs ./
 # source change doesn't invalidate the whole dependency cache.
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     mkdir src && echo "fn main() {}" > src/main.rs \
-    && cargo build --release --locked --target x86_64-unknown-linux-musl --bin cube-api 2>/dev/null || true \
+    && cargo build --release --locked --target "$(cat /etc/rust-target)" --bin cube-api 2>/dev/null || true \
     && rm -rf src
 
 # Phase 2: copy the real source — only application code recompiles from here on.
+# The built binary is staged at a fixed, arch-independent path so the runtime
+# stage's COPY --from doesn't need to know the target triple.
 COPY src/ src/
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
-    cargo build --release --locked --target x86_64-unknown-linux-musl --bin cube-api
+    rust_target="$(cat /etc/rust-target)" \
+    && cargo build --release --locked --target "${rust_target}" --bin cube-api \
+    && install -Dm0755 "target/${rust_target}/release/cube-api" /out/cube-api
 
 # ── Runtime stage ──────────────────────────────────────────────────────────────
 FROM alpine:3.21
@@ -52,7 +72,7 @@ RUN addgroup -S cube && adduser -S -G cube cube \
     && chown -R cube:cube /var/log/cube-api
 ENV LOG_DIR=/var/log/cube-api
 
-COPY --from=builder /app/target/x86_64-unknown-linux-musl/release/cube-api /usr/local/bin/cube-api
+COPY --from=builder /out/cube-api /usr/local/bin/cube-api
 
 USER cube
 

--- a/CubeProxy/Makefile
+++ b/CubeProxy/Makefile
@@ -11,6 +11,11 @@ IMAGE_LOCAL     := cube-proxy
 SIDECAR_SRC     := $(CURDIR)/sidecar
 SIDECAR_OUT_DIR := $(CURDIR)/bin
 SIDECAR_OUT     := $(SIDECAR_OUT_DIR)/cube-proxy-sidecar
+# Target architecture for the sidecar binary. Defaults to the host's Go arch
+# (so an arm64 build box produces an arm64 binary and an amd64 box produces
+# amd64). Override with `make SIDECAR_GOARCH=arm64 ...` for cross-builds. The
+# arch MUST match the openresty base image the sidecar is COPY-ed into.
+SIDECAR_GOARCH  ?= $(shell go env GOARCH)
 
 ifeq ($(V),1)
 	Q =
@@ -39,7 +44,7 @@ build: prebuild-sidecar
 		-t $(IMAGE_LOCAL):$(IMAGE_TAG)		\
 		.
 
-# prebuild-sidecar produces a static linux/amd64 binary at
+# prebuild-sidecar produces a static linux/$(SIDECAR_GOARCH) binary at
 # bin/cube-proxy-sidecar so the Dockerfile can simply COPY it into the
 # musl-based openresty:alpine-fat image. The binary MUST be statically
 # linked — CGO_ENABLED=0 plus the netgo/osusergo build tags forces the
@@ -68,7 +73,7 @@ prebuild-sidecar:
 	fi
 	$(call msg,BUILD,cube-proxy-sidecar)
 	$(Q)cd "$(SIDECAR_SRC)" && \
-		CGO_ENABLED=0 GOOS=linux GOARCH=amd64 \
+		CGO_ENABLED=0 GOOS=linux GOARCH=$(SIDECAR_GOARCH) \
 			go build -trimpath -tags 'netgo osusergo' -ldflags '-s -w' \
 				-o "$(SIDECAR_OUT)" ./cmd/sidecar
 

--- a/Cubelet/config/config.toml
+++ b/Cubelet/config/config.toml
@@ -178,7 +178,9 @@ dynamic_config_path = "/usr/local/services/cubetoolbox/Cubelet/dynamicconf/conf.
   [plugins."io.containerd.monitor.v1.cgroups"]
     no_prometheus = false
   [plugins."io.containerd.runtime.v2.task"]
-    platforms = ["linux/amd64"]
+    # Declare both platforms so the same config runs on amd64 and arm64 hosts;
+    # containerd matches image manifests against the host's native platform.
+    platforms = ["linux/amd64", "linux/arm64"]
     sched_core = false
   [plugins."io.cubelet.chi.v1.vsocket-manager"]
     proxyPort = 1032

--- a/deploy/one-click/build-release-bundle.sh
+++ b/deploy/one-click/build-release-bundle.sh
@@ -28,7 +28,16 @@ CUBE_PROXY_SOURCE_DIR="${ONE_CLICK_CUBE_PROXY_SOURCE_DIR:-${ROOT_DIR}/CubeProxy}
 CUBE_EGRESS_SOURCE_DIR="${ONE_CLICK_CUBE_EGRESS_SOURCE_DIR:-${ROOT_DIR}/CubeEgress}"
 WEB_SOURCE_DIR="${ONE_CLICK_WEB_SOURCE_DIR:-${ROOT_DIR}/web}"
 WEB_DIST_OVERRIDE="${ONE_CLICK_WEB_DIST_DIR:-}"
-MKCERT_BIN_ASSET="${ONE_CLICK_MKCERT_BIN:-${SCRIPT_DIR}/assets/bin/mkcert-v1.4.4-linux-$(uname -m | sed -e 's/x86_64/amd64/' -e 's/aarch64/arm64/')}"
+# Arch (Go/GOARCH naming: amd64|arm64) of the arch-flag-selected release assets:
+# the pre-built cube-proxy-sidecar binary and the bundled mkcert binary. Defaults
+# to the build host's arch (arm64 build box -> arm64, amd64 -> amd64). NOTE: the
+# rest of the bundle is built host-native (cube-api via host cargo, the Go
+# binaries via the default GOARCH), so this is NOT a full cross-build switch —
+# build the bundle on the same arch as the deploy target and leave this at the
+# default. ONE_CLICK_TARGET_ARCH is only an escape hatch and must match the build
+# host arch to produce a self-consistent bundle.
+TARGET_GOARCH="${ONE_CLICK_TARGET_ARCH:-$(uname -m | sed -e 's/x86_64/amd64/' -e 's/aarch64/arm64/')}"
+MKCERT_BIN_ASSET="${ONE_CLICK_MKCERT_BIN:-${SCRIPT_DIR}/assets/bin/mkcert-v1.4.4-linux-${TARGET_GOARCH}}"
 CUBE_KERNEL_VMLINUX="${ONE_CLICK_CUBE_KERNEL_VMLINUX:-${RAW_ARTIFACTS_DIR}/vmlinux}"
 KERNEL_ARTIFACT_ZIP="${WORK_ROOT}/cube-kernel-scf.zip"
 
@@ -504,7 +513,7 @@ else
       require_cmd go
       (cd "${ROOT_DIR}/CubeProxy/sidecar" && \
         go mod download && \
-        CGO_ENABLED=0 GOOS=linux GOARCH=amd64 \
+        CGO_ENABLED=0 GOOS=linux GOARCH="${TARGET_GOARCH}" \
           go build -trimpath -tags 'netgo osusergo' -ldflags '-s -w' \
             -o "${CORE_BIN_DIR}/cube-proxy-sidecar" ./cmd/sidecar) >&2
       ;;

--- a/deploy/one-click/env.example
+++ b/deploy/one-click/env.example
@@ -16,6 +16,13 @@ ONE_CLICK_CUBE_API_BUILD_MODE=local
 ONE_CLICK_NETWORK_AGENT_BUILD_MODE=local
 ONE_CLICK_CUBE_AGENT_BUILD_MODE=local
 ONE_CLICK_CUBE_SHIM_BUILD_MODE=local
+# Arch (amd64|arm64) of the arch-flag-selected release assets: the
+# cube-proxy-sidecar binary and the bundled mkcert binary. Defaults to the build
+# host's arch. NOTE: the one-click bundle is built host-native (cube-api and the
+# Go binaries follow the build host), so this is NOT a full cross-build switch —
+# build the bundle on the same arch as the deploy target and leave this unset.
+# Set it only as an escape hatch, and only to match the build host's arch.
+# ONE_CLICK_TARGET_ARCH=arm64
 
 # Optional overrides for prebuilt binaries or fixed artifacts.
 # ONE_CLICK_CUBEMASTER_BIN=/abs/path/to/cubemaster


### PR DESCRIPTION
Several build and deploy paths still assumed an amd64/x86_64 host, which prevented CubeSandbox from being built and run natively on aarch64. These were the last residual hardcodings left after the earlier aarch64 series: the cube-api container image build, the cube-proxy sidecar build (both the in-tree Makefile flow and the one-click release bundle), and the containerd runtime platform declaration.

Derive the target architecture from the build context so each path builds natively on both amd64 and arm64, and declare both platforms for the runtime so the same config works on either host. The amd64 behavior is preserved unchanged, so existing x86_64 quickstart and install-package deployments are unaffected.

Assisted-by: Cursor:claude-opus-4.8