### PR TITLE
build: add multi-arch CI support for builder images, vmlinux, and one-click release

### DIFF
--- a/.github/workflows/build-builder-image.yml
+++ b/.github/workflows/build-builder-image.yml
@@ -12,12 +12,27 @@ on:
       - '.github/workflows/build-builder-image.yml'
   workflow_dispatch:
 
+concurrency:
+  group: build-builder-image-${{ github.ref }}
+  cancel-in-progress: false
+
 env:
   IMAGE_NAME: ghcr.io/tencentcloud/cubesandbox-builder
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    name: Build ${{ matrix.arch }} builder image
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            platform: linux/amd64
+            runner: ubuntu-latest
+          - arch: arm64
+            platform: linux/arm64
+            runner: ubuntu-24.04-arm
     permissions:
       contents: read
       packages: write
@@ -42,22 +57,73 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.IMAGE_NAME }}
-          tags: |
-            type=raw,value=latest,enable=${{ github.repository == 'TencentCloud/CubeSandbox' && github.ref == 'refs/heads/master' }}
-            type=raw,value=ubuntu2004,enable=${{ github.repository == 'TencentCloud/CubeSandbox' && github.ref == 'refs/heads/master' }}
-            type=sha,prefix=sha-,format=short
+
+      - name: Prepare image tags
+        id: image_tags
+        env:
+          ARCH: ${{ matrix.arch }}
+          IS_RELEASE_PUSH: ${{ github.repository == 'TencentCloud/CubeSandbox' && github.ref == 'refs/heads/master' }}
+        run: |
+          short_sha="${GITHUB_SHA::7}"
+          {
+            echo "short_sha=${short_sha}"
+            echo "tags<<EOF"
+            echo "${IMAGE_NAME}:sha-${short_sha}-${ARCH}"
+            if [[ "${IS_RELEASE_PUSH}" == "true" ]]; then
+              echo "${IMAGE_NAME}:latest-${ARCH}"
+              echo "${IMAGE_NAME}:ubuntu2004-${ARCH}"
+            fi
+            echo "EOF"
+          } >> "${GITHUB_OUTPUT}"
 
       - name: Build and push
         uses: docker/build-push-action@v6
         with:
           context: .
           file: docker/Dockerfile.builder
+          platforms: ${{ matrix.platform }}
           push: ${{ github.repository == 'TencentCloud/CubeSandbox' && github.ref == 'refs/heads/master' }}
-          tags: ${{ steps.meta.outputs.tags }}
+          tags: ${{ steps.image_tags.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             GITHUB_ACTIONS=true
             RUSTUP_DIST_SERVER=https://static.rust-lang.org
             RUSTUP_UPDATE_ROOT=https://static.rust-lang.org/rustup
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=builder-${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=builder-${{ matrix.arch }}
+
+  publish_manifest:
+    name: Publish multi-arch builder manifests
+    if: github.repository == 'TencentCloud/CubeSandbox' && github.ref == 'refs/heads/master'
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create multi-arch manifests
+        run: |
+          short_sha="${GITHUB_SHA::7}"
+          docker buildx imagetools create \
+            -t "${IMAGE_NAME}:latest" \
+            "${IMAGE_NAME}:sha-${short_sha}-amd64" \
+            "${IMAGE_NAME}:sha-${short_sha}-arm64"
+          docker buildx imagetools create \
+            -t "${IMAGE_NAME}:ubuntu2004" \
+            "${IMAGE_NAME}:sha-${short_sha}-amd64" \
+            "${IMAGE_NAME}:sha-${short_sha}-arm64"
+          docker buildx imagetools create \
+            -t "${IMAGE_NAME}:sha-${short_sha}" \
+            "${IMAGE_NAME}:sha-${short_sha}-amd64" \
+            "${IMAGE_NAME}:sha-${short_sha}-arm64"

--- a/.github/workflows/build-vmlinux.yml
+++ b/.github/workflows/build-vmlinux.yml
@@ -1,4 +1,5 @@
 name: Build vmlinux
+run-name: Build vmlinux ${{ inputs.kernel_arch || 'all' }}
 
 on:
   push:
@@ -7,11 +8,19 @@ on:
       - 'configs/kernel-oc9.x86_64.config'
       - '.github/workflows/build-vmlinux.yml'
   workflow_dispatch:
+    inputs:
+      kernel_arch:
+        description: Kernel architecture to build
+        required: true
+        default: x86_64
+        type: choice
+        options:
+          - x86_64
+          - aarch64
 
 env:
   KERNEL_TAG: 6.6.119-49.6
   KERNEL_ARCHIVE_URL: https://cnb.cool/CubeSandbox/OpenCloudOS-Kernel/-/git/archive/6.6.119-49.6.zip
-  VMLINUX_CACHE_PATH: kernel-cache/vmlinux
 
 defaults:
   run:
@@ -19,11 +28,20 @@ defaults:
 
 jobs:
   build:
-    runs-on: arc-runner-set-16c32g-containerd
+    name: Build vmlinux (${{ matrix.kernel_arch }})
+    runs-on: ${{ matrix.runner }}
     container:
       image: ubuntu:24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJSON(github.event_name == 'workflow_dispatch' && inputs.kernel_arch == 'x86_64' && '[{"kernel_arch":"x86_64","kbuild_arch":"x86","runner":"arc-runner-set-16c32g-containerd"}]' || github.event_name == 'workflow_dispatch' && inputs.kernel_arch == 'aarch64' && '[{"kernel_arch":"aarch64","kbuild_arch":"arm64","runner":"ubuntu-24.04-arm"}]' || '[{"kernel_arch":"x86_64","kbuild_arch":"x86","runner":"arc-runner-set-16c32g-containerd"},{"kernel_arch":"aarch64","kbuild_arch":"arm64","runner":"ubuntu-24.04-arm"}]') }}
     permissions:
       contents: read
+    env:
+      KERNEL_ARCH: ${{ matrix.kernel_arch }}
+      KBUILD_ARCH: ${{ matrix.kbuild_arch }}
+      VMLINUX_CACHE_PATH: kernel-cache/${{ matrix.kernel_arch }}/vmlinux
 
     steps:
       - name: Checkout
@@ -32,10 +50,10 @@ jobs:
       - name: Compute vmlinux cache metadata
         id: vmlinux_metadata
         run: |
-          config_hash="$(sha256sum configs/kernel-oc9.$(uname -m).config | awk '{print $1}')"
+          config_hash="$(sha256sum "configs/kernel-oc9.${KERNEL_ARCH}.config" | awk '{print $1}')"
           echo "config_hash=${config_hash}" >> "${GITHUB_OUTPUT}"
-          echo "cache_key=vmlinux-opencloudos-${KERNEL_TAG}-${config_hash}-ubuntu-latest" >> "${GITHUB_OUTPUT}"
-          echo "artifact_name=vmlinux-opencloudos-${KERNEL_TAG}-${config_hash}" >> "${GITHUB_OUTPUT}"
+          echo "cache_key=vmlinux-opencloudos-${KERNEL_TAG}-${KERNEL_ARCH}-${config_hash}-ubuntu-latest" >> "${GITHUB_OUTPUT}"
+          echo "artifact_name=vmlinux-opencloudos-${KERNEL_TAG}-${KERNEL_ARCH}-${config_hash}" >> "${GITHUB_OUTPUT}"
 
       - name: Install kernel build dependencies
         run: |
@@ -80,15 +98,20 @@ jobs:
       - name: Configure kernel
         if: steps.restore_vmlinux.outputs.cache-hit != 'true'
         run: |
-          cp configs/kernel-oc9.$(uname -m).config "${KERNEL_SRC}/.config"
-          make -C "${KERNEL_SRC}" olddefconfig
+          cp "configs/kernel-oc9.${KERNEL_ARCH}.config" "${KERNEL_SRC}/.config"
+          make -C "${KERNEL_SRC}" ARCH="${KBUILD_ARCH}" olddefconfig
 
       - name: Build vmlinux
         if: steps.restore_vmlinux.outputs.cache-hit != 'true'
         run: |
           (
             cd "${KERNEL_SRC}"
-            KCFLAGS="-Wa,-mx86-used-note=no" make -j "$(nproc)" vmlinux
+            if [[ "${KERNEL_ARCH}" == "x86_64" ]]; then
+              KCFLAGS="-Wa,-mx86-used-note=no" make ARCH="${KBUILD_ARCH}" -j "$(nproc)" vmlinux
+            else
+              make ARCH="${KBUILD_ARCH}" -j "$(nproc)" Image
+              cp arch/arm64/boot/Image vmlinux
+            fi
           )
           install -D -m 0644 "${KERNEL_SRC}/vmlinux" "${VMLINUX_CACHE_PATH}"
 

--- a/.github/workflows/release-one-click.yml
+++ b/.github/workflows/release-one-click.yml
@@ -25,7 +25,7 @@ env:
 
 jobs:
   build_pvm_guest_vmlinux:
-    name: Build PVM guest vmlinux for release
+    name: Build PVM guest vmlinux for release (x86_64)
     runs-on: arc-runner-set-16c32g-containerd
     container:
       image: ubuntu:24.04
@@ -64,8 +64,8 @@ jobs:
               | awk '{print $1}'
           )"
           echo "source_hash=${source_hash}" >> "${GITHUB_OUTPUT}"
-          echo "cache_key=vmlinux-pvm-${PVM_KERNEL_TAG}-${source_hash}-ubuntu-latest" >> "${GITHUB_OUTPUT}"
-          echo "artifact_name=vmlinux-pvm-${PVM_KERNEL_TAG}-${source_hash}" >> "${GITHUB_OUTPUT}"
+          echo "cache_key=vmlinux-pvm-${PVM_KERNEL_TAG}-x86_64-${source_hash}-ubuntu-latest" >> "${GITHUB_OUTPUT}"
+          echo "artifact_name=vmlinux-pvm-${PVM_KERNEL_TAG}-x86_64-${source_hash}" >> "${GITHUB_OUTPUT}"
 
       - name: Restore cached PVM vmlinux
         id: restore_pvm_vmlinux
@@ -109,9 +109,33 @@ jobs:
           if-no-files-found: error
           retention-days: 14
 
-  release:
+  ensure_release:
+    name: Ensure GitHub Release exists
     runs-on: ubuntu-latest
-    needs: build_pvm_guest_vmlinux
+
+    steps:
+      - name: Ensure GitHub Release exists
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release view "${GITHUB_REF_NAME}" >/dev/null 2>&1 || \
+            gh release create "${GITHUB_REF_NAME}" \
+              --title "${GITHUB_REF_NAME}" \
+              --notes "Automated one-click release bundle."
+
+  release_amd64:
+    name: Release one-click bundle (amd64)
+    runs-on: ubuntu-latest
+    needs:
+      - ensure_release
+      - build_pvm_guest_vmlinux
+    env:
+      KERNEL_ARCH: x86_64
+      BUNDLE_ARCH: amd64
+      VMLINUX_CACHE_PATH: kernel-cache/x86_64/vmlinux
+      VMLINUX_RELEASE_PATH: deploy/one-click/assets/kernel-artifacts/vmlinux
+      PVM_VMLINUX_CACHE_PATH: kernel-cache/x86_64/vmlinux-pvm
+      PVM_VMLINUX_RELEASE_PATH: deploy/one-click/assets/kernel-artifacts/vmlinux-pvm
 
     steps:
       - name: Checkout
@@ -133,10 +157,10 @@ jobs:
       - name: Compute vmlinux cache metadata
         id: vmlinux_metadata
         run: |
-          config_hash="$(sha256sum configs/kernel-oc9.$(uname -m).config | awk '{print $1}')"
+          config_hash="$(sha256sum "configs/kernel-oc9.${KERNEL_ARCH}.config" | awk '{print $1}')"
           echo "config_hash=${config_hash}" >> "${GITHUB_OUTPUT}"
-          echo "cache_key=vmlinux-opencloudos-${KERNEL_TAG}-${config_hash}-ubuntu-latest" >> "${GITHUB_OUTPUT}"
-          echo "artifact_name=vmlinux-opencloudos-${KERNEL_TAG}-${config_hash}" >> "${GITHUB_OUTPUT}"
+          echo "cache_key=vmlinux-opencloudos-${KERNEL_TAG}-${KERNEL_ARCH}-${config_hash}-ubuntu-latest" >> "${GITHUB_OUTPUT}"
+          echo "artifact_name=vmlinux-opencloudos-${KERNEL_TAG}-${KERNEL_ARCH}-${config_hash}" >> "${GITHUB_OUTPUT}"
 
       - name: Prepare vmlinux directories
         run: |
@@ -170,13 +194,14 @@ jobs:
           if [[ -z "${artifact_url}" ]]; then
             echo "vmlinux cache miss and no unexpired artifact found, triggering build-vmlinux workflow..." >&2
             trigger_epoch="$(date -u +%s)"
-            gh workflow run build-vmlinux.yml --ref "${GITHUB_REF_NAME}"
+            expected_title="Build vmlinux ${KERNEL_ARCH}"
+            gh workflow run build-vmlinux.yml --ref "${GITHUB_REF_NAME}" -f kernel_arch="${KERNEL_ARCH}"
 
             run_id=""
             for attempt in {1..30}; do
               runs_json="$(gh api "/repos/${GITHUB_REPOSITORY}/actions/workflows/build-vmlinux.yml/runs?event=workflow_dispatch&per_page=20")"
               run_id="$(
-                python3 -c 'import json, sys; from datetime import datetime, timezone; head_sha = sys.argv[1]; trigger_epoch = int(sys.argv[2]); data = json.load(sys.stdin); runs = []; [runs.append(run) for run in data.get("workflow_runs", []) if run.get("head_sha") == head_sha and run.get("created_at") and int(datetime.strptime(run["created_at"], "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=timezone.utc).timestamp()) >= trigger_epoch]; runs.sort(key=lambda run: run.get("created_at", ""), reverse=True); print(runs[0].get("id", "") if runs else "")' "${GITHUB_SHA}" "${trigger_epoch}" <<<"${runs_json}"
+                python3 -c 'import json, sys; from datetime import datetime, timezone; head_sha = sys.argv[1]; trigger_epoch = int(sys.argv[2]); expected_title = sys.argv[3]; data = json.load(sys.stdin); runs = []; [runs.append(run) for run in data.get("workflow_runs", []) if run.get("head_sha") == head_sha and run.get("display_title") == expected_title and run.get("created_at") and int(datetime.strptime(run["created_at"], "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=timezone.utc).timestamp()) >= trigger_epoch]; runs.sort(key=lambda run: run.get("created_at", ""), reverse=True); print(runs[0].get("id", "") if runs else "")' "${GITHUB_SHA}" "${trigger_epoch}" "${expected_title}" <<<"${runs_json}"
               )"
               if [[ -n "${run_id}" ]]; then
                 break
@@ -185,7 +210,7 @@ jobs:
             done
 
             if [[ -z "${run_id}" ]]; then
-              echo "failed to locate the dispatched build-vmlinux workflow run" >&2
+              echo "failed to locate the dispatched build-vmlinux workflow run for ${KERNEL_ARCH}" >&2
               exit 1
             fi
 
@@ -245,8 +270,8 @@ jobs:
               | awk '{print $1}'
           )"
           echo "source_hash=${source_hash}" >> "${GITHUB_OUTPUT}"
-          echo "cache_key=vmlinux-pvm-${PVM_KERNEL_TAG}-${source_hash}-ubuntu-latest" >> "${GITHUB_OUTPUT}"
-          echo "artifact_name=vmlinux-pvm-${PVM_KERNEL_TAG}-${source_hash}" >> "${GITHUB_OUTPUT}"
+          echo "cache_key=vmlinux-pvm-${PVM_KERNEL_TAG}-x86_64-${source_hash}-ubuntu-latest" >> "${GITHUB_OUTPUT}"
+          echo "artifact_name=vmlinux-pvm-${PVM_KERNEL_TAG}-x86_64-${source_hash}" >> "${GITHUB_OUTPUT}"
 
       - name: Download PVM vmlinux artifact
         uses: actions/download-artifact@v4
@@ -277,33 +302,192 @@ jobs:
           # Propagates to Go ldflags, Rust build.rs, web build, and guest-image version.
           CUBE_VERSION: ${{ github.ref_name }}
           CUBE_COMMIT: ${{ github.sha }}
-          ONE_CLICK_DIST_VERSION: ${{ github.ref_name }}
+          ONE_CLICK_DIST_VERSION: ${{ github.ref_name }}-amd64
         run: CUBE_BUILD_TIME="$(date -u +'%Y-%m-%dT%H:%M:%SZ')" ./deploy/one-click/build-release-bundle-builder.sh
 
       - name: Resolve bundle path
         id: bundle
         run: |
-          bundle_path="deploy/one-click/dist/cube-sandbox-one-click-${{ github.ref_name }}.tar.gz"
+          bundle_path="deploy/one-click/dist/cube-sandbox-one-click-${{ github.ref_name }}-amd64.tar.gz"
           test -f "${bundle_path}"
           echo "path=${bundle_path}" >> "${GITHUB_OUTPUT}"
 
       - name: Upload one-click bundle artifact
         uses: actions/upload-artifact@v4
         with:
-          name: one-click-bundle-${{ github.ref_name }}
+          name: one-click-bundle-${{ github.ref_name }}-amd64
           path: ${{ steps.bundle.outputs.path }}
           if-no-files-found: error
           retention-days: 14
 
-      - name: Ensure GitHub Release exists
+      - name: Upload one-click bundle to Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release upload "${GITHUB_REF_NAME}" "${{ steps.bundle.outputs.path }}" --clobber
+
+  release_arm64:
+    name: Release one-click bundle (arm64)
+    runs-on: ubuntu-24.04-arm
+    needs: ensure_release
+    env:
+      KERNEL_ARCH: aarch64
+      BUNDLE_ARCH: arm64
+      VMLINUX_CACHE_PATH: kernel-cache/aarch64/vmlinux
+      VMLINUX_RELEASE_PATH: deploy/one-click/assets/kernel-artifacts/vmlinux
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Free disk space
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: false
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          docker-images: false
+          swap-storage: true
+
+      - name: Compute vmlinux cache metadata
+        id: vmlinux_metadata
+        run: |
+          config_hash="$(sha256sum "configs/kernel-oc9.${KERNEL_ARCH}.config" | awk '{print $1}')"
+          echo "config_hash=${config_hash}" >> "${GITHUB_OUTPUT}"
+          echo "cache_key=vmlinux-opencloudos-${KERNEL_TAG}-${KERNEL_ARCH}-${config_hash}-ubuntu-latest" >> "${GITHUB_OUTPUT}"
+          echo "artifact_name=vmlinux-opencloudos-${KERNEL_TAG}-${KERNEL_ARCH}-${config_hash}" >> "${GITHUB_OUTPUT}"
+
+      - name: Prepare vmlinux directories
+        run: |
+          mkdir -p "$(dirname "${VMLINUX_CACHE_PATH}")"
+          mkdir -p "$(dirname "${VMLINUX_RELEASE_PATH}")"
+
+      - name: Restore cached vmlinux
+        id: restore_vmlinux
+        uses: actions/cache/restore@v4
+        with:
+          path: ${{ env.VMLINUX_CACHE_PATH }}
+          key: ${{ steps.vmlinux_metadata.outputs.cache_key }}
+
+      - name: Stage cached vmlinux
+        if: steps.restore_vmlinux.outputs.cache-hit == 'true'
+        run: install -D -m 0644 "${VMLINUX_CACHE_PATH}" "${VMLINUX_RELEASE_PATH}"
+
+      - name: Resolve vmlinux artifact fallback
+        id: resolve_vmlinux_artifact
+        if: steps.restore_vmlinux.outputs.cache-hit != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VMLINUX_ARTIFACT_NAME: ${{ steps.vmlinux_metadata.outputs.artifact_name }}
+        run: |
+          get_latest_artifact_url() {
+            gh api --paginate --slurp "/repos/${GITHUB_REPOSITORY}/actions/artifacts?per_page=100" | \
+              python3 -c 'import json, sys; artifact_name = sys.argv[1]; artifacts = [artifact for page in json.load(sys.stdin) for artifact in page.get("artifacts", []) if artifact.get("name") == artifact_name and not artifact.get("expired", False)]; artifacts.sort(key=lambda artifact: artifact.get("created_at", ""), reverse=True); print(artifacts[0].get("archive_download_url", "") if artifacts else "")' "${VMLINUX_ARTIFACT_NAME}"
+          }
+
+          artifact_url="$(get_latest_artifact_url)"
+          if [[ -z "${artifact_url}" ]]; then
+            echo "vmlinux cache miss and no unexpired artifact found, triggering build-vmlinux workflow..." >&2
+            trigger_epoch="$(date -u +%s)"
+            expected_title="Build vmlinux ${KERNEL_ARCH}"
+            gh workflow run build-vmlinux.yml --ref "${GITHUB_REF_NAME}" -f kernel_arch="${KERNEL_ARCH}"
+
+            run_id=""
+            for attempt in {1..30}; do
+              runs_json="$(gh api "/repos/${GITHUB_REPOSITORY}/actions/workflows/build-vmlinux.yml/runs?event=workflow_dispatch&per_page=20")"
+              run_id="$(
+                python3 -c 'import json, sys; from datetime import datetime, timezone; head_sha = sys.argv[1]; trigger_epoch = int(sys.argv[2]); expected_title = sys.argv[3]; data = json.load(sys.stdin); runs = []; [runs.append(run) for run in data.get("workflow_runs", []) if run.get("head_sha") == head_sha and run.get("display_title") == expected_title and run.get("created_at") and int(datetime.strptime(run["created_at"], "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=timezone.utc).timestamp()) >= trigger_epoch]; runs.sort(key=lambda run: run.get("created_at", ""), reverse=True); print(runs[0].get("id", "") if runs else "")' "${GITHUB_SHA}" "${trigger_epoch}" "${expected_title}" <<<"${runs_json}"
+              )"
+              if [[ -n "${run_id}" ]]; then
+                break
+              fi
+              sleep 10
+            done
+
+            if [[ -z "${run_id}" ]]; then
+              echo "failed to locate the dispatched build-vmlinux workflow run for ${KERNEL_ARCH}" >&2
+              exit 1
+            fi
+
+            gh run watch "${run_id}" --interval 20 --exit-status
+            artifact_url="$(get_latest_artifact_url)"
+          fi
+
+          if [[ -z "${artifact_url}" ]]; then
+            echo "vmlinux artifact is still unavailable after build-vmlinux completed" >&2
+            exit 1
+          fi
+
+          echo "artifact_url=${artifact_url}" >> "${GITHUB_OUTPUT}"
+
+      - name: Download vmlinux artifact fallback
+        if: steps.restore_vmlinux.outputs.cache-hit != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          if ! gh release view "${GITHUB_REF_NAME}" >/dev/null 2>&1; then
-            gh release create "${GITHUB_REF_NAME}" \
-              --title "${GITHUB_REF_NAME}" \
-              --notes "Automated one-click release bundle."
-          fi
+          rm -rf downloaded-vmlinux
+          mkdir -p downloaded-vmlinux/extracted
+          curl -fsSL \
+            -H "Authorization: Bearer ${GH_TOKEN}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "${{ steps.resolve_vmlinux_artifact.outputs.artifact_url }}" \
+            -o downloaded-vmlinux/artifact.zip
+          unzip -q downloaded-vmlinux/artifact.zip -d downloaded-vmlinux/extracted
+          install -D -m 0644 \
+            downloaded-vmlinux/extracted/vmlinux \
+            "${VMLINUX_CACHE_PATH}"
+          install -D -m 0644 \
+            "${VMLINUX_CACHE_PATH}" \
+            "${VMLINUX_RELEASE_PATH}"
+
+      - name: Refresh vmlinux cache from artifact
+        if: steps.restore_vmlinux.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: ${{ env.VMLINUX_CACHE_PATH }}
+          key: ${{ steps.vmlinux_metadata.outputs.cache_key }}
+
+      - name: Verify vmlinux
+        run: |
+          test -f "${VMLINUX_CACHE_PATH}"
+          test -f "${VMLINUX_RELEASE_PATH}"
+          file "${VMLINUX_RELEASE_PATH}"
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Pull builder image
+        run: docker pull "${BUILDER_IMAGE}"
+
+      - name: Build one-click release bundle
+        env:
+          # Propagates to Go ldflags, Rust build.rs, web build, and guest-image version.
+          CUBE_VERSION: ${{ github.ref_name }}
+          CUBE_COMMIT: ${{ github.sha }}
+          ONE_CLICK_DIST_VERSION: ${{ github.ref_name }}-arm64
+        run: CUBE_BUILD_TIME="$(date -u +'%Y-%m-%dT%H:%M:%SZ')" ./deploy/one-click/build-release-bundle-builder.sh
+
+      - name: Resolve bundle path
+        id: bundle
+        run: |
+          bundle_path="deploy/one-click/dist/cube-sandbox-one-click-${{ github.ref_name }}-arm64.tar.gz"
+          test -f "${bundle_path}"
+          echo "path=${bundle_path}" >> "${GITHUB_OUTPUT}"
+
+      - name: Upload one-click bundle artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: one-click-bundle-${{ github.ref_name }}-arm64
+          path: ${{ steps.bundle.outputs.path }}
+          if-no-files-found: error
+          retention-days: 14
 
       - name: Upload one-click bundle to Release
         env:

--- a/CubeProxy/Makefile
+++ b/CubeProxy/Makefile
@@ -11,11 +11,6 @@ IMAGE_LOCAL     := cube-proxy
 SIDECAR_SRC     := $(CURDIR)/sidecar
 SIDECAR_OUT_DIR := $(CURDIR)/bin
 SIDECAR_OUT     := $(SIDECAR_OUT_DIR)/cube-proxy-sidecar
-# Target architecture for the sidecar binary. Defaults to the host's Go arch
-# (so an arm64 build box produces an arm64 binary and an amd64 box produces
-# amd64). Override with `make SIDECAR_GOARCH=arm64 ...` for cross-builds. The
-# arch MUST match the openresty base image the sidecar is COPY-ed into.
-SIDECAR_GOARCH  ?= $(shell go env GOARCH)
 
 ifeq ($(V),1)
 	Q =
@@ -44,7 +39,7 @@ build: prebuild-sidecar
 		-t $(IMAGE_LOCAL):$(IMAGE_TAG)		\
 		.
 
-# prebuild-sidecar produces a static linux/$(SIDECAR_GOARCH) binary at
+# prebuild-sidecar produces a static binary for the current build host at
 # bin/cube-proxy-sidecar so the Dockerfile can simply COPY it into the
 # musl-based openresty:alpine-fat image. The binary MUST be statically
 # linked — CGO_ENABLED=0 plus the netgo/osusergo build tags forces the
@@ -73,7 +68,7 @@ prebuild-sidecar:
 	fi
 	$(call msg,BUILD,cube-proxy-sidecar)
 	$(Q)cd "$(SIDECAR_SRC)" && \
-		CGO_ENABLED=0 GOOS=linux GOARCH=$(SIDECAR_GOARCH) \
+		CGO_ENABLED=0 GOOS=linux \
 			go build -trimpath -tags 'netgo osusergo' -ldflags '-s -w' \
 				-o "$(SIDECAR_OUT)" ./cmd/sidecar
 

--- a/deploy/one-click/build-release-bundle.sh
+++ b/deploy/one-click/build-release-bundle.sh
@@ -28,16 +28,7 @@ CUBE_PROXY_SOURCE_DIR="${ONE_CLICK_CUBE_PROXY_SOURCE_DIR:-${ROOT_DIR}/CubeProxy}
 CUBE_EGRESS_SOURCE_DIR="${ONE_CLICK_CUBE_EGRESS_SOURCE_DIR:-${ROOT_DIR}/CubeEgress}"
 WEB_SOURCE_DIR="${ONE_CLICK_WEB_SOURCE_DIR:-${ROOT_DIR}/web}"
 WEB_DIST_OVERRIDE="${ONE_CLICK_WEB_DIST_DIR:-}"
-# Arch (Go/GOARCH naming: amd64|arm64) of the arch-flag-selected release assets:
-# the pre-built cube-proxy-sidecar binary and the bundled mkcert binary. Defaults
-# to the build host's arch (arm64 build box -> arm64, amd64 -> amd64). NOTE: the
-# rest of the bundle is built host-native (cube-api via host cargo, the Go
-# binaries via the default GOARCH), so this is NOT a full cross-build switch —
-# build the bundle on the same arch as the deploy target and leave this at the
-# default. ONE_CLICK_TARGET_ARCH is only an escape hatch and must match the build
-# host arch to produce a self-consistent bundle.
-TARGET_GOARCH="${ONE_CLICK_TARGET_ARCH:-$(uname -m | sed -e 's/x86_64/amd64/' -e 's/aarch64/arm64/')}"
-MKCERT_BIN_ASSET="${ONE_CLICK_MKCERT_BIN:-${SCRIPT_DIR}/assets/bin/mkcert-v1.4.4-linux-${TARGET_GOARCH}}"
+MKCERT_BIN_ASSET="${ONE_CLICK_MKCERT_BIN:-${SCRIPT_DIR}/assets/bin/mkcert-v1.4.4-linux-$(uname -m | sed -e 's/x86_64/amd64/' -e 's/aarch64/arm64/')}"
 CUBE_KERNEL_VMLINUX="${ONE_CLICK_CUBE_KERNEL_VMLINUX:-${RAW_ARTIFACTS_DIR}/vmlinux}"
 KERNEL_ARTIFACT_ZIP="${WORK_ROOT}/cube-kernel-scf.zip"
 
@@ -513,7 +504,7 @@ else
       require_cmd go
       (cd "${ROOT_DIR}/CubeProxy/sidecar" && \
         go mod download && \
-        CGO_ENABLED=0 GOOS=linux GOARCH="${TARGET_GOARCH}" \
+        CGO_ENABLED=0 GOOS=linux \
           go build -trimpath -tags 'netgo osusergo' -ldflags '-s -w' \
             -o "${CORE_BIN_DIR}/cube-proxy-sidecar" ./cmd/sidecar) >&2
       ;;

--- a/deploy/one-click/env.example
+++ b/deploy/one-click/env.example
@@ -16,13 +16,6 @@ ONE_CLICK_CUBE_API_BUILD_MODE=local
 ONE_CLICK_NETWORK_AGENT_BUILD_MODE=local
 ONE_CLICK_CUBE_AGENT_BUILD_MODE=local
 ONE_CLICK_CUBE_SHIM_BUILD_MODE=local
-# Arch (amd64|arm64) of the arch-flag-selected release assets: the
-# cube-proxy-sidecar binary and the bundled mkcert binary. Defaults to the build
-# host's arch. NOTE: the one-click bundle is built host-native (cube-api and the
-# Go binaries follow the build host), so this is NOT a full cross-build switch —
-# build the bundle on the same arch as the deploy target and leave this unset.
-# Set it only as an escape hatch, and only to match the build host's arch.
-# ONE_CLICK_TARGET_ARCH=arm64
 
 # Optional overrides for prebuilt binaries or fixed artifacts.
 # ONE_CLICK_CUBEMASTER_BIN=/abs/path/to/cubemaster


### PR DESCRIPTION
## Summary

Add full multi-architecture (amd64 + arm64) support across CI workflows, enabling the project to build and release artifacts for both architectures.

## Changes

### 1. Builder Image Workflow (`build-builder-image.yml`)
- Convert from single-arch to matrix build supporting `amd64` and `arm64`
- Tag images with architecture suffix (e.g., `sha-<hash>-amd64`, `sha-<hash>-arm64`)
- Add `publish_manifest` job to create multi-arch Docker manifests for `latest`, `ubuntu2004`, and `sha-<hash>` tags
- Scope build cache by architecture to avoid cache conflicts

### 2. Vmlinux Build Workflow (`build-vmlinux.yml`)
- Add `workflow_dispatch` input to select `x86_64` or `aarch64` kernel architecture
- Matrix build strategy: push triggers build both arches; manual dispatch builds the selected arch
- Use architecture-specific kernel config files, cache keys, and artifact names
- aarch64 builds produce `Image` (copied as `vmlinux`) via native arm64 runner

### 3. One-Click Release Workflow (`release-one-click.yml`)
- Split monolithic release job into `release_amd64` and `release_arm64` parallel jobs
- Extract `ensure_release` as a separate prerequisite job
- Each arch job: resolves its own vmlinux (with artifact fallback + auto-trigger of build-vmlinux), builds the bundle with architecture suffix, uploads to release
- Bundle artifact names and dist versions include architecture suffix

### 4. Build Script Cleanup (`CubeProxy/Makefile`, `build-release-bundle.sh`)
- Remove explicit `GOARCH` / `SIDECAR_GOARCH` / `TARGET_GOARCH` overrides
- Rely on host-native builds — the CI matrix already ensures the correct runner per architecture
- mkcert binary selection uses `uname -m` directly

### 5. Environment Config Cleanup (`env.example`)
- Remove `ONE_CLICK_TARGET_ARCH` documentation (no longer applicable)

## Why

Previous CI only built for x86_64. With arm64 runners available (e.g., `ubuntu-24.04-arm`), we can produce native arm64 images, kernels, and one-click bundles without emulation overhead. Host-native builds on the correct runner are simpler and more reliable than cross-compilation.