### PR TITLE
Configure TencentCloud cubelet reporting and scheduler scoring

### DIFF
--- a/deploy/one-click/terraform/tencentcloud/create.sh
+++ b/deploy/one-click/terraform/tencentcloud/create.sh
@@ -754,6 +754,7 @@ setup_env() {
 	CUBE_DB="${TENCENTCLOUD_CUBE_DB:-cube_mvp}"
 	CUBE_USER="${TENCENTCLOUD_CUBE_USER:-cube}"
 	CUBE_PASSWORD="${TENCENTCLOUD_CUBE_PASSWORD:-cube_pass}"
+	CUBELET_NODE_STATUS_UPDATE_FREQUENCY="${TENCENTCLOUD_CUBELET_NODE_STATUS_UPDATE_FREQUENCY:-10s}"
 	# Wire the cube DB name/user/password into Terraform so the MySQL account +
 	# database (main.tf), the cube-master conf Secret (tke-addons.tf) and the health
 	# checks below all use the SAME values. Without this the control plane would
@@ -762,6 +763,7 @@ setup_env() {
 	export TF_VAR_cube_db="$CUBE_DB"
 	export TF_VAR_cube_user="$CUBE_USER"
 	export TF_VAR_cube_password="$CUBE_PASSWORD"
+	export TF_VAR_cubelet_node_status_update_frequency="$CUBELET_NODE_STATUS_UPDATE_FREQUENCY"
 	# Resolve the deployment bundle: explicit TENCENTCLOUD_LOCAL_BUNDLE wins,
 	# otherwise the user is asked interactively (local file path or web URL), with
 	# auto-detection inside an extracted release bundle as the default. An empty
@@ -3831,6 +3833,52 @@ echo '[local-bundle] Done'"
 
 		if [ "${install_rc:-1}" -eq 0 ]; then
 			echo -e "  ${GREEN}✓ compute installation complete${NC}"
+			echo -e "  ${CYAN}Configuring cubelet node status update frequency: ${CUBELET_NODE_STATUS_UPDATE_FREQUENCY:-10s}${NC}"
+			if ssh "${ssh_opts[@]}" root@"${compute_private_ip}" "CUBELET_NODE_STATUS_UPDATE_FREQUENCY='${CUBELET_NODE_STATUS_UPDATE_FREQUENCY:-10s}' bash -s" <<'REMOTE_CUBELET_FREQ'
+set -euo pipefail
+freq="${CUBELET_NODE_STATUS_UPDATE_FREQUENCY:-10s}"
+cfg="/usr/local/services/cubetoolbox/Cubelet/config/config.toml"
+if [ ! -f "$cfg" ]; then
+  echo "cubelet config not found: $cfg" >&2
+  exit 1
+fi
+if command -v python3 >/dev/null 2>&1; then
+  python3 - "$cfg" "$freq" <<'PY'
+import re
+import sys
+
+path, freq = sys.argv[1], sys.argv[2]
+with open(path, "r", encoding="utf-8") as f:
+    text = f.read()
+
+section_re = re.compile(r'(\[plugins\."io\.cubelet\.controller\.config\.v1\.cubelet"\]\n)(.*?)(?=\n\s*\[|$)', re.S)
+match = section_re.search(text)
+if not match:
+    raise SystemExit("cubelet controller config section not found")
+
+body = match.group(2)
+line_re = re.compile(r'(^\s*node_status_update_frequency\s*=\s*)".*?"', re.M)
+if line_re.search(body):
+    body = line_re.sub(rf'\1"{freq}"', body, count=1)
+else:
+    body = body.rstrip() + f'\n    node_status_update_frequency = "{freq}"\n'
+
+text = text[:match.start(2)] + body + text[match.end(2):]
+with open(path, "w", encoding="utf-8") as f:
+    f.write(text)
+PY
+else
+  sed -i -E "s#^([[:space:]]*node_status_update_frequency[[:space:]]*=[[:space:]]*)\"[^\"]*\"#\1\"${freq}\"#" "$cfg"
+fi
+grep -q "node_status_update_frequency = \"${freq}\"" "$cfg"
+systemctl restart cube-sandbox-cubelet.service
+REMOTE_CUBELET_FREQ
+			then
+				echo -e "  ${GREEN}✓ cubelet node status update frequency configured${NC}"
+			else
+				echo -e "  ${RED}✗ failed to configure cubelet node status update frequency on node ${node_num}${NC}"
+				failed_nodes+=("${compute_private_ip} (cubelet config)")
+			fi
 		else
 			echo -e "  ${RED}✗ compute installation failed on node ${node_num} (${compute_private_ip}, exit ${install_rc})${NC}"
 			failed_nodes+=("${compute_private_ip} (install)")
@@ -4049,6 +4097,7 @@ TENCENTCLOUD_REDIS_PASSWORD='${TENCENTCLOUD_REDIS_PASSWORD:-}'
 TENCENTCLOUD_CUBE_DB='${TENCENTCLOUD_CUBE_DB:-cube_mvp}'
 TENCENTCLOUD_CUBE_USER='${TENCENTCLOUD_CUBE_USER:-cube}'
 TENCENTCLOUD_CUBE_PASSWORD='${TENCENTCLOUD_CUBE_PASSWORD:-}'
+TENCENTCLOUD_CUBELET_NODE_STATUS_UPDATE_FREQUENCY='${CUBELET_NODE_STATUS_UPDATE_FREQUENCY:-${TENCENTCLOUD_CUBELET_NODE_STATUS_UPDATE_FREQUENCY:-10s}}'
 TENCENTCLOUD_CUBE_IMAGE_TAG='${TENCENTCLOUD_CUBE_IMAGE_TAG:-v0.5.0}'
 TENCENTCLOUD_TKE_CLUSTER_VERSION='${TKE_CLUSTER_VERSION:-1.34.1}'
 TENCENTCLOUD_TKE_NODE_COUNT='${TKE_NODE_COUNT:-2}'
@@ -4240,6 +4289,7 @@ write_resolved_tfvars_file() {
 		--arg cube_password "${TF_VAR_cube_password:-${CUBE_PASSWORD:-${TENCENTCLOUD_CUBE_PASSWORD:-cube_pass}}}" \
 		--arg cube_db "${TF_VAR_cube_db:-${CUBE_DB:-${TENCENTCLOUD_CUBE_DB:-cube_mvp}}}" \
 		--arg cube_user "${TF_VAR_cube_user:-${CUBE_USER:-${TENCENTCLOUD_CUBE_USER:-cube}}}" \
+		--arg cubelet_node_status_update_frequency "${TF_VAR_cubelet_node_status_update_frequency:-${CUBELET_NODE_STATUS_UPDATE_FREQUENCY:-${TENCENTCLOUD_CUBELET_NODE_STATUS_UPDATE_FREQUENCY:-10s}}}" \
 		--arg tke_cluster_name "${TF_VAR_tke_cluster_name:-cubesandbox-terraform-tke}" \
 		--arg tke_cluster_version "${TF_VAR_tke_cluster_version:-${TKE_CLUSTER_VERSION:-${TENCENTCLOUD_TKE_CLUSTER_VERSION:-1.34.1}}}" \
 		--argjson tke_node_count "$tke_count" \
@@ -4281,6 +4331,7 @@ write_resolved_tfvars_file() {
 			cube_password: $cube_password,
 			cube_db: $cube_db,
 			cube_user: $cube_user,
+			cubelet_node_status_update_frequency: $cubelet_node_status_update_frequency,
 			tke_cluster_name: $tke_cluster_name,
 			tke_cluster_version: $tke_cluster_version,
 			tke_node_count: $tke_node_count,

--- a/deploy/one-click/terraform/tencentcloud/destroy.sh
+++ b/deploy/one-click/terraform/tencentcloud/destroy.sh
@@ -68,6 +68,7 @@ export TF_VAR_ssh_private_key_path="$SSH_PRI_KEY"
 # the desired topology matches the state.
 [ -n "${TENCENTCLOUD_COMPUTE_NODE_COUNT:-}" ] && export TF_VAR_compute_node_count="$TENCENTCLOUD_COMPUTE_NODE_COUNT"
 export TF_VAR_compute_node_count="${TF_VAR_compute_node_count:-${TENCENTCLOUD_COMPUTE_NODE_COUNT:-2}}"
+export TF_VAR_cubelet_node_status_update_frequency="${TF_VAR_cubelet_node_status_update_frequency:-${TENCENTCLOUD_CUBELET_NODE_STATUS_UPDATE_FREQUENCY:-10s}}"
 export TF_VAR_tke_node_count="${TF_VAR_tke_node_count:-${TENCENTCLOUD_TKE_NODE_COUNT:-2}}"
 
 mkdir -p "$SCRIPT_DIR/.kube"

--- a/deploy/one-click/terraform/tencentcloud/env.example
+++ b/deploy/one-click/terraform/tencentcloud/env.example
@@ -29,6 +29,8 @@ TENCENTCLOUD_COMPUTE_NODE_COUNT='2'
 # Optional: per compute-node CBS data disk size in GB (default 200). The disk is
 # formatted as XFS and mounted at /data/cubelet on first boot.
 # TENCENTCLOUD_COMPUTE_DATA_DISK_SIZE='200'
+# Cubelet node status/resource reporting interval to CubeMaster.
+TENCENTCLOUD_CUBELET_NODE_STATUS_UPDATE_FREQUENCY='10s'
 
 # --- Passwords (CHANGE THESE for any non-throwaway deployment)
 TENCENTCLOUD_MYSQL_PASSWORD='CHANGEME_MYSQL_PASSWORD'

--- a/deploy/one-click/terraform/tencentcloud/tke-addons.tf
+++ b/deploy/one-click/terraform/tencentcloud/tke-addons.tf
@@ -36,6 +36,10 @@ locals {
   # var.cubemaster_replicas docs in variables.tf for why under-reporting the
   # master count oversubscribes the compute nodes.
   cubemaster_replicas = var.cubemaster_replicas
+  # Multi-node scheduling: pick randomly from the top scored compute nodes.
+  # The multi-node guide recommends 3 as a small-cluster starting point; cap at
+  # the actual compute-node count so the default 2-node POC uses 2.
+  cubemaster_priority_select_num = max(1, min(var.compute_node_count, 3))
 
   # All files under the certificate directory
   cert_files = fileset("${path.module}/cubeproxy-certs", "*")
@@ -258,11 +262,32 @@ resource "kubernetes_secret" "cubemaster_conf" {
         max_retry    = 2
       }
       scheduler = {
-        priority_select_num         = 1
+        priority_select_num         = local.cubemaster_priority_select_num
         metric_update_timeout       = "300s"
         local_metric_update_timeout = "300s"
         filter = {
           enable_filters = ["cpu", "mem", "template_locality", "realtime_create_num"]
+        }
+        score = {
+          enable_scorers = ["real_time_weighted_average"]
+          resource_weights = {
+            mvm_num          = 2
+            local_create_num = 3
+            cpu_usage        = 1
+            quota_mem_usage  = 1
+          }
+          plugin_conf = {
+            real_time_weighted_average = {
+              weight = 1.0
+              enable_weight_factors = [
+                "mvm_num",
+                "local_create_num",
+                "cpu_usage",
+                "quota_mem_usage",
+              ]
+              time_decay_seconds = 300
+            }
+          }
         }
       }
     })

--- a/deploy/one-click/terraform/tencentcloud/variables.tf
+++ b/deploy/one-click/terraform/tencentcloud/variables.tf
@@ -93,6 +93,17 @@ variable "compute_data_disk_size" {
   }
 }
 
+variable "cubelet_node_status_update_frequency" {
+  description = "Cubelet node status and resource reporting interval. create.sh patches Cubelet/config/config.toml on each compute node."
+  type        = string
+  default     = "10s"
+
+  validation {
+    condition     = can(regex("^[0-9]+(ns|us|µs|ms|s|m|h)$", var.cubelet_node_status_update_frequency))
+    error_message = "cubelet_node_status_update_frequency must be a Go duration such as 10s, 500ms, 1m, or 1h."
+  }
+}
+
 # WARNING: these defaults are weak, well-known demo credentials kept only so a
 # zero-config `create.sh` / `terraform apply` succeeds. Always override them for
 # any non-throwaway deployment via TENCENTCLOUD_MYSQL_PASSWORD /

--- a/docs/guide/tencentcloud-terraform-deploy.md
+++ b/docs/guide/tencentcloud-terraform-deploy.md
@@ -282,6 +282,7 @@ export TENCENTCLOUD_REGION=ap-guangzhou
 export TENCENTCLOUD_AVAILABILITY_ZONE=ap-guangzhou-6
 export TENCENTCLOUD_COMPUTE_NODE_COUNT=2              # CVM PVM compute nodes
 export TENCENTCLOUD_COMPUTE_DATA_DISK_SIZE=200        # CBS data disk per compute node (GB)
+export TENCENTCLOUD_CUBELET_NODE_STATUS_UPDATE_FREQUENCY=10s
 export TENCENTCLOUD_TKE_NODE_COUNT=2                 # TKE worker nodes (control-plane Pods)
 export TENCENTCLOUD_COMPUTE_INSTANCE_TYPE=SA9.MEDIUM8
 export TENCENTCLOUD_USE_TCR=false                    # default: public pre-built images
@@ -303,6 +304,7 @@ export TENCENTCLOUD_CUBE_IMAGE_TAG=v0.5.0
 | `TENCENTCLOUD_TKE_WORKER_INSTANCE_TYPE` | `SA9.LARGE8` | TKE worker instance type (4C8G) |
 | `TENCENTCLOUD_COMPUTE_NODE_COUNT` | `2` | **PVM compute nodes** (run Cubelet / sandboxes) |
 | `TENCENTCLOUD_COMPUTE_DATA_DISK_SIZE` | `200` | CBS data disk size per compute node (GB, XFS, mounted at `/data/cubelet`). Sandbox image templates, snapshots and runtime data on the compute node all live under this directory — size it to your actual needs |
+| `TENCENTCLOUD_CUBELET_NODE_STATUS_UPDATE_FREQUENCY` | `10s` | Cubelet node status/resource reporting interval to CubeMaster. `create.sh` patches `Cubelet/config/config.toml` on each compute node |
 | `TENCENTCLOUD_TKE_NODE_COUNT` | `2` | **TKE workers** (run control-plane Pods; maps to `worker_config.count`) |
 | `TENCENTCLOUD_USE_TCR` | `false` | When `true`, create TCR and build/push images on the jumpserver; when `false`, use public pre-built images |
 | `TENCENTCLOUD_USE_CFS` | `false` | When `true` and cubemaster has multiple replicas, create CFS NFS shared storage |

--- a/docs/zh/guide/tencentcloud-terraform-deploy.md
+++ b/docs/zh/guide/tencentcloud-terraform-deploy.md
@@ -281,6 +281,7 @@ export TENCENTCLOUD_REGION=ap-guangzhou
 export TENCENTCLOUD_AVAILABILITY_ZONE=ap-guangzhou-6
 export TENCENTCLOUD_COMPUTE_NODE_COUNT=2              # CVM PVM 计算节点数
 export TENCENTCLOUD_COMPUTE_DATA_DISK_SIZE=200        # 每个计算节点的 CBS 数据盘大小（GB）
+export TENCENTCLOUD_CUBELET_NODE_STATUS_UPDATE_FREQUENCY=10s
 export TENCENTCLOUD_TKE_NODE_COUNT=2                 # TKE worker 节点数（运行控制面 Pod）
 export TENCENTCLOUD_COMPUTE_INSTANCE_TYPE=SA9.MEDIUM8
 export TENCENTCLOUD_USE_TCR=false                    # 默认：公网预置镜像
@@ -302,6 +303,7 @@ export TENCENTCLOUD_CUBE_IMAGE_TAG=v0.5.0
 | `TENCENTCLOUD_TKE_WORKER_INSTANCE_TYPE` | `SA9.LARGE8` | TKE worker 节点机型（4C8G） |
 | `TENCENTCLOUD_COMPUTE_NODE_COUNT` | `2` | **PVM 计算节点**数（运行 Cubelet / sandbox） |
 | `TENCENTCLOUD_COMPUTE_DATA_DISK_SIZE` | `200` | 每个计算节点的 CBS 数据盘大小（GB，XFS，挂载于 `/data/cubelet`）。计算节点的沙箱镜像模板、快照及运行时数据均存放于此目录，请按实际需求调整 |
+| `TENCENTCLOUD_CUBELET_NODE_STATUS_UPDATE_FREQUENCY` | `10s` | Cubelet 向 CubeMaster 上报节点状态/资源的间隔。`create.sh` 会在每台计算节点上写入 `Cubelet/config/config.toml` |
 | `TENCENTCLOUD_TKE_NODE_COUNT` | `2` | **TKE worker** 数（运行控制面 Pod；对应 `worker_config.count`） |
 | `TENCENTCLOUD_USE_TCR` | `false` | `true` 时创建 TCR 并在跳板机构建/推送镜像；`false` 时使用公网预置镜像 |
 | `TENCENTCLOUD_USE_CFS` | `false` | `true` 且 cubemaster 多副本时创建 CFS NFS 共享存储 |


### PR DESCRIPTION
## Summary
- Add `TENCENTCLOUD_CUBELET_NODE_STATUS_UPDATE_FREQUENCY` / `cubelet_node_status_update_frequency` and persist it for reruns.
- Patch compute-node `Cubelet/config/config.toml` after install so `node_status_update_frequency` is configurable.
- Make cubemaster scheduler select from top scored compute nodes and enable the `real_time_weighted_average` scorer for multi-node deployments.

## Test plan
- `bash -n deploy/one-click/terraform/tencentcloud/create.sh`
- `bash -n deploy/one-click/terraform/tencentcloud/destroy.sh`
- `terraform fmt -check deploy/one-click/terraform/tencentcloud/variables.tf deploy/one-click/terraform/tencentcloud/tke-addons.tf`
