### PR TITLE
Set cubelet reporting interval default to 1s

### DIFF
--- a/Cubelet/config/config.toml
+++ b/Cubelet/config/config.toml
@@ -38,7 +38,7 @@ dynamic_config_path = "/usr/local/services/cubetoolbox/Cubelet/dynamicconf/conf.
   [plugins."io.cubelet.controller.config.v1.cubelet"]
     # Static-only cadence for node status and resource reporting.
     # Do not configure this in dynamicconf/conf.yaml.
-    node_status_update_frequency = "10s"
+    node_status_update_frequency = "1s"
 
   [plugins."io.cubelet.internal.v1.volume"]
   [plugins."io.cubelet.internal.v1.shimlog"]

--- a/deploy/one-click/terraform/tencentcloud/create.sh
+++ b/deploy/one-click/terraform/tencentcloud/create.sh
@@ -754,7 +754,7 @@ setup_env() {
 	CUBE_DB="${TENCENTCLOUD_CUBE_DB:-cube_mvp}"
 	CUBE_USER="${TENCENTCLOUD_CUBE_USER:-cube}"
 	CUBE_PASSWORD="${TENCENTCLOUD_CUBE_PASSWORD:-cube_pass}"
-	CUBELET_NODE_STATUS_UPDATE_FREQUENCY="${TENCENTCLOUD_CUBELET_NODE_STATUS_UPDATE_FREQUENCY:-10s}"
+	CUBELET_NODE_STATUS_UPDATE_FREQUENCY="${TENCENTCLOUD_CUBELET_NODE_STATUS_UPDATE_FREQUENCY:-1s}"
 	# Wire the cube DB name/user/password into Terraform so the MySQL account +
 	# database (main.tf), the cube-master conf Secret (tke-addons.tf) and the health
 	# checks below all use the SAME values. Without this the control plane would
@@ -3833,10 +3833,10 @@ echo '[local-bundle] Done'"
 
 		if [ "${install_rc:-1}" -eq 0 ]; then
 			echo -e "  ${GREEN}✓ compute installation complete${NC}"
-			echo -e "  ${CYAN}Configuring cubelet node status update frequency: ${CUBELET_NODE_STATUS_UPDATE_FREQUENCY:-10s}${NC}"
-			if ssh "${ssh_opts[@]}" root@"${compute_private_ip}" "CUBELET_NODE_STATUS_UPDATE_FREQUENCY='${CUBELET_NODE_STATUS_UPDATE_FREQUENCY:-10s}' bash -s" <<'REMOTE_CUBELET_FREQ'
+			echo -e "  ${CYAN}Configuring cubelet node status update frequency: ${CUBELET_NODE_STATUS_UPDATE_FREQUENCY:-1s}${NC}"
+			if ssh "${ssh_opts[@]}" root@"${compute_private_ip}" "CUBELET_NODE_STATUS_UPDATE_FREQUENCY='${CUBELET_NODE_STATUS_UPDATE_FREQUENCY:-1s}' bash -s" <<'REMOTE_CUBELET_FREQ'
 set -euo pipefail
-freq="${CUBELET_NODE_STATUS_UPDATE_FREQUENCY:-10s}"
+freq="${CUBELET_NODE_STATUS_UPDATE_FREQUENCY:-1s}"
 cfg="/usr/local/services/cubetoolbox/Cubelet/config/config.toml"
 if [ ! -f "$cfg" ]; then
   echo "cubelet config not found: $cfg" >&2
@@ -4097,7 +4097,7 @@ TENCENTCLOUD_REDIS_PASSWORD='${TENCENTCLOUD_REDIS_PASSWORD:-}'
 TENCENTCLOUD_CUBE_DB='${TENCENTCLOUD_CUBE_DB:-cube_mvp}'
 TENCENTCLOUD_CUBE_USER='${TENCENTCLOUD_CUBE_USER:-cube}'
 TENCENTCLOUD_CUBE_PASSWORD='${TENCENTCLOUD_CUBE_PASSWORD:-}'
-TENCENTCLOUD_CUBELET_NODE_STATUS_UPDATE_FREQUENCY='${CUBELET_NODE_STATUS_UPDATE_FREQUENCY:-${TENCENTCLOUD_CUBELET_NODE_STATUS_UPDATE_FREQUENCY:-10s}}'
+TENCENTCLOUD_CUBELET_NODE_STATUS_UPDATE_FREQUENCY='${CUBELET_NODE_STATUS_UPDATE_FREQUENCY:-${TENCENTCLOUD_CUBELET_NODE_STATUS_UPDATE_FREQUENCY:-1s}}'
 TENCENTCLOUD_CUBE_IMAGE_TAG='${TENCENTCLOUD_CUBE_IMAGE_TAG:-v0.5.0}'
 TENCENTCLOUD_TKE_CLUSTER_VERSION='${TKE_CLUSTER_VERSION:-1.34.1}'
 TENCENTCLOUD_TKE_NODE_COUNT='${TKE_NODE_COUNT:-2}'
@@ -4289,7 +4289,7 @@ write_resolved_tfvars_file() {
 		--arg cube_password "${TF_VAR_cube_password:-${CUBE_PASSWORD:-${TENCENTCLOUD_CUBE_PASSWORD:-cube_pass}}}" \
 		--arg cube_db "${TF_VAR_cube_db:-${CUBE_DB:-${TENCENTCLOUD_CUBE_DB:-cube_mvp}}}" \
 		--arg cube_user "${TF_VAR_cube_user:-${CUBE_USER:-${TENCENTCLOUD_CUBE_USER:-cube}}}" \
-		--arg cubelet_node_status_update_frequency "${TF_VAR_cubelet_node_status_update_frequency:-${CUBELET_NODE_STATUS_UPDATE_FREQUENCY:-${TENCENTCLOUD_CUBELET_NODE_STATUS_UPDATE_FREQUENCY:-10s}}}" \
+		--arg cubelet_node_status_update_frequency "${TF_VAR_cubelet_node_status_update_frequency:-${CUBELET_NODE_STATUS_UPDATE_FREQUENCY:-${TENCENTCLOUD_CUBELET_NODE_STATUS_UPDATE_FREQUENCY:-1s}}}" \
 		--arg tke_cluster_name "${TF_VAR_tke_cluster_name:-cubesandbox-terraform-tke}" \
 		--arg tke_cluster_version "${TF_VAR_tke_cluster_version:-${TKE_CLUSTER_VERSION:-${TENCENTCLOUD_TKE_CLUSTER_VERSION:-1.34.1}}}" \
 		--argjson tke_node_count "$tke_count" \

--- a/deploy/one-click/terraform/tencentcloud/destroy.sh
+++ b/deploy/one-click/terraform/tencentcloud/destroy.sh
@@ -68,7 +68,7 @@ export TF_VAR_ssh_private_key_path="$SSH_PRI_KEY"
 # the desired topology matches the state.
 [ -n "${TENCENTCLOUD_COMPUTE_NODE_COUNT:-}" ] && export TF_VAR_compute_node_count="$TENCENTCLOUD_COMPUTE_NODE_COUNT"
 export TF_VAR_compute_node_count="${TF_VAR_compute_node_count:-${TENCENTCLOUD_COMPUTE_NODE_COUNT:-2}}"
-export TF_VAR_cubelet_node_status_update_frequency="${TF_VAR_cubelet_node_status_update_frequency:-${TENCENTCLOUD_CUBELET_NODE_STATUS_UPDATE_FREQUENCY:-10s}}"
+export TF_VAR_cubelet_node_status_update_frequency="${TF_VAR_cubelet_node_status_update_frequency:-${TENCENTCLOUD_CUBELET_NODE_STATUS_UPDATE_FREQUENCY:-1s}}"
 export TF_VAR_tke_node_count="${TF_VAR_tke_node_count:-${TENCENTCLOUD_TKE_NODE_COUNT:-2}}"
 
 mkdir -p "$SCRIPT_DIR/.kube"

--- a/deploy/one-click/terraform/tencentcloud/env.example
+++ b/deploy/one-click/terraform/tencentcloud/env.example
@@ -30,7 +30,7 @@ TENCENTCLOUD_COMPUTE_NODE_COUNT='2'
 # formatted as XFS and mounted at /data/cubelet on first boot.
 # TENCENTCLOUD_COMPUTE_DATA_DISK_SIZE='200'
 # Cubelet node status/resource reporting interval to CubeMaster.
-TENCENTCLOUD_CUBELET_NODE_STATUS_UPDATE_FREQUENCY='10s'
+TENCENTCLOUD_CUBELET_NODE_STATUS_UPDATE_FREQUENCY='1s'
 
 # --- Passwords (CHANGE THESE for any non-throwaway deployment)
 TENCENTCLOUD_MYSQL_PASSWORD='CHANGEME_MYSQL_PASSWORD'

--- a/deploy/one-click/terraform/tencentcloud/variables.tf
+++ b/deploy/one-click/terraform/tencentcloud/variables.tf
@@ -96,7 +96,7 @@ variable "compute_data_disk_size" {
 variable "cubelet_node_status_update_frequency" {
   description = "Cubelet node status and resource reporting interval. create.sh patches Cubelet/config/config.toml on each compute node."
   type        = string
-  default     = "10s"
+  default     = "1s"
 
   validation {
     condition     = can(regex("^[0-9]+(ns|us|µs|ms|s|m|h)$", var.cubelet_node_status_update_frequency))

--- a/docs/guide/tencentcloud-terraform-deploy.md
+++ b/docs/guide/tencentcloud-terraform-deploy.md
@@ -282,7 +282,7 @@ export TENCENTCLOUD_REGION=ap-guangzhou
 export TENCENTCLOUD_AVAILABILITY_ZONE=ap-guangzhou-6
 export TENCENTCLOUD_COMPUTE_NODE_COUNT=2              # CVM PVM compute nodes
 export TENCENTCLOUD_COMPUTE_DATA_DISK_SIZE=200        # CBS data disk per compute node (GB)
-export TENCENTCLOUD_CUBELET_NODE_STATUS_UPDATE_FREQUENCY=10s
+export TENCENTCLOUD_CUBELET_NODE_STATUS_UPDATE_FREQUENCY=1s
 export TENCENTCLOUD_TKE_NODE_COUNT=2                 # TKE worker nodes (control-plane Pods)
 export TENCENTCLOUD_COMPUTE_INSTANCE_TYPE=SA9.MEDIUM8
 export TENCENTCLOUD_USE_TCR=false                    # default: public pre-built images
@@ -304,7 +304,7 @@ export TENCENTCLOUD_CUBE_IMAGE_TAG=v0.5.0
 | `TENCENTCLOUD_TKE_WORKER_INSTANCE_TYPE` | `SA9.LARGE8` | TKE worker instance type (4C8G) |
 | `TENCENTCLOUD_COMPUTE_NODE_COUNT` | `2` | **PVM compute nodes** (run Cubelet / sandboxes) |
 | `TENCENTCLOUD_COMPUTE_DATA_DISK_SIZE` | `200` | CBS data disk size per compute node (GB, XFS, mounted at `/data/cubelet`). Sandbox image templates, snapshots and runtime data on the compute node all live under this directory — size it to your actual needs |
-| `TENCENTCLOUD_CUBELET_NODE_STATUS_UPDATE_FREQUENCY` | `10s` | Cubelet node status/resource reporting interval to CubeMaster. `create.sh` patches `Cubelet/config/config.toml` on each compute node |
+| `TENCENTCLOUD_CUBELET_NODE_STATUS_UPDATE_FREQUENCY` | `1s` | Cubelet node status/resource reporting interval to CubeMaster. `create.sh` patches `Cubelet/config/config.toml` on each compute node |
 | `TENCENTCLOUD_TKE_NODE_COUNT` | `2` | **TKE workers** (run control-plane Pods; maps to `worker_config.count`) |
 | `TENCENTCLOUD_USE_TCR` | `false` | When `true`, create TCR and build/push images on the jumpserver; when `false`, use public pre-built images |
 | `TENCENTCLOUD_USE_CFS` | `false` | When `true` and cubemaster has multiple replicas, create CFS NFS shared storage |

--- a/docs/zh/guide/tencentcloud-terraform-deploy.md
+++ b/docs/zh/guide/tencentcloud-terraform-deploy.md
@@ -281,7 +281,7 @@ export TENCENTCLOUD_REGION=ap-guangzhou
 export TENCENTCLOUD_AVAILABILITY_ZONE=ap-guangzhou-6
 export TENCENTCLOUD_COMPUTE_NODE_COUNT=2              # CVM PVM 计算节点数
 export TENCENTCLOUD_COMPUTE_DATA_DISK_SIZE=200        # 每个计算节点的 CBS 数据盘大小（GB）
-export TENCENTCLOUD_CUBELET_NODE_STATUS_UPDATE_FREQUENCY=10s
+export TENCENTCLOUD_CUBELET_NODE_STATUS_UPDATE_FREQUENCY=1s
 export TENCENTCLOUD_TKE_NODE_COUNT=2                 # TKE worker 节点数（运行控制面 Pod）
 export TENCENTCLOUD_COMPUTE_INSTANCE_TYPE=SA9.MEDIUM8
 export TENCENTCLOUD_USE_TCR=false                    # 默认：公网预置镜像
@@ -303,7 +303,7 @@ export TENCENTCLOUD_CUBE_IMAGE_TAG=v0.5.0
 | `TENCENTCLOUD_TKE_WORKER_INSTANCE_TYPE` | `SA9.LARGE8` | TKE worker 节点机型（4C8G） |
 | `TENCENTCLOUD_COMPUTE_NODE_COUNT` | `2` | **PVM 计算节点**数（运行 Cubelet / sandbox） |
 | `TENCENTCLOUD_COMPUTE_DATA_DISK_SIZE` | `200` | 每个计算节点的 CBS 数据盘大小（GB，XFS，挂载于 `/data/cubelet`）。计算节点的沙箱镜像模板、快照及运行时数据均存放于此目录，请按实际需求调整 |
-| `TENCENTCLOUD_CUBELET_NODE_STATUS_UPDATE_FREQUENCY` | `10s` | Cubelet 向 CubeMaster 上报节点状态/资源的间隔。`create.sh` 会在每台计算节点上写入 `Cubelet/config/config.toml` |
+| `TENCENTCLOUD_CUBELET_NODE_STATUS_UPDATE_FREQUENCY` | `1s` | Cubelet 向 CubeMaster 上报节点状态/资源的间隔。`create.sh` 会在每台计算节点上写入 `Cubelet/config/config.toml` |
 | `TENCENTCLOUD_TKE_NODE_COUNT` | `2` | **TKE worker** 数（运行控制面 Pod；对应 `worker_config.count`） |
 | `TENCENTCLOUD_USE_TCR` | `false` | `true` 时创建 TCR 并在跳板机构建/推送镜像；`false` 时使用公网预置镜像 |
 | `TENCENTCLOUD_USE_CFS` | `false` | `true` 且 cubemaster 多副本时创建 CFS NFS 共享存储 |


### PR DESCRIPTION
## Summary
- Change the default Cubelet `node_status_update_frequency` from `10s` to `1s`.
- Align TencentCloud Terraform defaults, env template, destroy mapping, and docs with the new `1s` interval.

## Test plan
- `bash -n deploy/one-click/terraform/tencentcloud/create.sh`
- `bash -n deploy/one-click/terraform/tencentcloud/destroy.sh`
- `terraform fmt -check deploy/one-click/terraform/tencentcloud/variables.tf`

