### PR TITLE
fix(ci): add --repo flag to gh release commands in one-click workflow

### DIFF
--- a/.github/workflows/release-one-click.yml
+++ b/.github/workflows/release-one-click.yml
@@ -118,8 +118,9 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh release view "${GITHUB_REF_NAME}" >/dev/null 2>&1 || \
+          gh release view "${GITHUB_REF_NAME}" --repo "${GITHUB_REPOSITORY}" >/dev/null 2>&1 || \
             gh release create "${GITHUB_REF_NAME}" \
+              --repo "${GITHUB_REPOSITORY}" \
               --title "${GITHUB_REF_NAME}" \
               --notes "Automated one-click release bundle."
 
@@ -323,7 +324,7 @@ jobs:
       - name: Upload one-click bundle to Release
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh release upload "${GITHUB_REF_NAME}" "${{ steps.bundle.outputs.path }}" --clobber
+        run: gh release upload "${GITHUB_REF_NAME}" "${{ steps.bundle.outputs.path }}" --repo "${GITHUB_REPOSITORY}" --clobber
 
   release_arm64:
     name: Release one-click bundle (arm64)
@@ -492,4 +493,4 @@ jobs:
       - name: Upload one-click bundle to Release
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh release upload "${GITHUB_REF_NAME}" "${{ steps.bundle.outputs.path }}" --clobber
+        run: gh release upload "${GITHUB_REF_NAME}" "${{ steps.bundle.outputs.path }}" --repo "${GITHUB_REPOSITORY}" --clobber


### PR DESCRIPTION
## Summary

Add explicit `--repo "${GITHUB_REPOSITORY}"` flag to `gh release view`, `gh release create`, and `gh release upload` commands in the one-click release workflow.

## Changes

- `gh release view`: added `--repo` flag
- `gh release create`: added `--repo` flag  
- `gh release upload` (amd64 & arm64): added `--repo` flag

## Reason

Explicitly specifying the repository ensures the GitHub CLI targets the correct repository in all CI environments, avoiding potential issues with default repository detection.