### PR TITLE
perf(cubevs): reduce net policy apply overhead

### DIFF
--- a/CubeNet/cubevs/dnspolicy.go
+++ b/CubeNet/cubevs/dnspolicy.go
@@ -83,52 +83,79 @@ func makeDNSAllowRule(domain string, flags uint8) (dnsAllowKey, dnsAllowValue, e
 	return key, value, nil
 }
 
-// populateDNSAllowInnerMap replaces all DNS allow entries for a sandbox.
-func populateDNSAllowInnerMap(outerMap *ebpf.Map, ifindex uint32, domains, l7Domains []string) error {
-	if count, err := countUniqueDNSAllowEntries(domains, l7Domains); err != nil {
-		return err
-	} else if err := validateNetPolicyEntryCount("network.dns_allow", count, maxDNSAllowDomains); err != nil {
-		return err
-	}
+type dnsAllowRule struct {
+	key    dnsAllowKey
+	value  dnsAllowValue
+	domain string
+}
 
-	inner, err := lookupInnerMap(outerMap, ifindex)
-	if err != nil {
-		return err
-	}
-	defer inner.Close()
+func buildDNSAllowRules(domains, l7Domains []string) ([]dnsAllowRule, error) {
+	rules := make([]dnsAllowRule, 0, len(domains)+len(l7Domains))
+	indexByKey := make(map[dnsAllowKey]int, len(domains)+len(l7Domains))
 
-	if err := flushDNSAllowInnerMap(inner); err != nil {
-		return err
-	}
-
-	for _, domain := range domains {
-		if err := updateDNSAllowRule(inner, domain, 0); err != nil {
-			return err
+	add := func(domains []string, flags uint8) error {
+		for _, domain := range domains {
+			key, value, err := makeDNSAllowRule(domain, flags)
+			if err != nil {
+				return err
+			}
+			if idx, ok := indexByKey[key]; ok {
+				rules[idx].value.Flags |= flags
+				continue
+			}
+			indexByKey[key] = len(rules)
+			rules = append(rules, dnsAllowRule{
+				key:    key,
+				value:  value,
+				domain: domain,
+			})
 		}
+		return nil
 	}
-	for _, domain := range l7Domains {
-		if err := updateDNSAllowRule(inner, domain, uint8(netPolicyFlagL7Required)); err != nil {
+
+	if err := add(domains, 0); err != nil {
+		return nil, err
+	}
+	if err := add(l7Domains, uint8(netPolicyFlagL7Required)); err != nil {
+		return nil, err
+	}
+	return rules, nil
+}
+
+// populateDNSAllowInnerMap installs DNS allow entries for a sandbox.
+func populateDNSAllowInnerMap(inner *ebpf.Map, rules []dnsAllowRule) error {
+	for _, rule := range rules {
+		if err := updateDNSAllowRule(inner, rule); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func updateDNSAllowRule(inner *ebpf.Map, domain string, flags uint8) error {
-	key, value, err := makeDNSAllowRule(domain, flags)
+func flushDNSAllowForIfindex(outerMap *ebpf.Map, ifindex uint32) error {
+	inner, err := lookupInnerMap(outerMap, ifindex)
+	if errors.Is(err, ebpf.ErrKeyNotExist) {
+		return nil
+	}
 	if err != nil {
 		return err
 	}
+	defer inner.Close()
 
+	return flushDNSAllowInnerMap(inner)
+}
+
+func updateDNSAllowRule(inner *ebpf.Map, rule dnsAllowRule) error {
+	value := rule.value
 	var oldValue dnsAllowValue
-	if err := inner.Lookup(&key, &oldValue); err == nil {
+	if err := inner.Lookup(&rule.key, &oldValue); err == nil {
 		value.Flags |= oldValue.Flags
 	} else if !errors.Is(err, ebpf.ErrKeyNotExist) {
-		return fmt.Errorf("dns allow lookup failed: %w, domain: %s", err, domain)
+		return fmt.Errorf("dns allow lookup failed: %w, domain: %s", err, rule.domain)
 	}
 
-	if err := inner.Update(&key, &value, ebpf.UpdateAny); err != nil {
-		return fmt.Errorf("dns allow update failed: %w, domain: %s", err, domain)
+	if err := inner.Update(&rule.key, &value, ebpf.UpdateAny); err != nil {
+		return fmt.Errorf("dns allow update failed: %w, domain: %s", err, rule.domain)
 	}
 	return nil
 }
@@ -167,15 +194,34 @@ func cleanupDNSAllow(ifindex uint32) error {
 }
 
 // applyDNSAllow installs DNS allow rules parsed from MVMOptions.
-func applyDNSAllow(ifindex uint32, domains, l7Domains []string) error {
+func applyDNSAllow(ifindex uint32, rules []dnsAllowRule, replace bool) error {
+	if len(rules) == 0 && !replace {
+		return nil
+	}
+
 	dnsAllow, err := loadPinnedMap(MapNameDNSAllow)
 	if err != nil {
 		return err
 	}
 	defer dnsAllow.Close()
 
+	if len(rules) == 0 {
+		return flushDNSAllowForIfindex(dnsAllow, ifindex)
+	}
 	if err := ensureDNSAllowInnerMap(dnsAllow, ifindex); err != nil {
 		return err
 	}
-	return populateDNSAllowInnerMap(dnsAllow, ifindex, domains, l7Domains)
+
+	inner, err := lookupInnerMap(dnsAllow, ifindex)
+	if err != nil {
+		return err
+	}
+	defer inner.Close()
+
+	if replace {
+		if err := flushDNSAllowInnerMap(inner); err != nil {
+			return err
+		}
+	}
+	return populateDNSAllowInnerMap(inner, rules)
 }

--- a/CubeNet/cubevs/netpolicy.go
+++ b/CubeNet/cubevs/netpolicy.go
@@ -22,6 +22,26 @@ var alwaysDeniedSandboxCIDRs = []string{
 	"192.168.0.0/16",
 }
 
+var alwaysDeniedSandboxEntries = mustBuildDenyOutPolicyEntries(alwaysDeniedSandboxCIDRs)
+
+type allowOutPolicyEntry struct {
+	key    lpmKey
+	flags  uint8
+	source string
+}
+
+type denyOutPolicyEntry struct {
+	key    lpmKey
+	source string
+}
+
+type netPolicyPlan struct {
+	allowOutEntries []allowOutPolicyEntry
+	dnsAllowRules   []dnsAllowRule
+	denyOutEntries  []denyOutPolicyEntry
+	dnsPolicyFlags  uint8
+}
+
 // newInnerLPMMap creates a new LPM trie map with uint32 values for deny_out.
 func newInnerLPMMap() (*ebpf.Map, error) {
 	return newInnerLPMMapWithValueSize(uint32(unsafe.Sizeof(uint32(0))), btfTypeLPMKey, btfTypeU32)
@@ -203,6 +223,151 @@ func parseCIDR(s string) (lpmKey, error) {
 	return lpmKey{Prefixlen: uint32(ones), IP: ipToUint32(ipNet.IP)}, nil
 }
 
+func mustBuildDenyOutPolicyEntries(cidrs []string) []denyOutPolicyEntry {
+	entries, err := buildDenyOutPolicyEntries(cidrs)
+	if err != nil {
+		panic(err)
+	}
+	return entries
+}
+
+func buildAllowOutPolicyEntries(allowOutCIDRs, l7AllowOutCIDRs []string) ([]allowOutPolicyEntry, error) {
+	entries := make([]allowOutPolicyEntry, 0, len(allowOutCIDRs)+len(l7AllowOutCIDRs))
+	indexByKey := make(map[lpmKey]int, len(allowOutCIDRs)+len(l7AllowOutCIDRs))
+
+	add := func(cidrs []string, flags uint8) error {
+		for _, cidr := range cidrs {
+			key, err := parseCIDR(cidr)
+			if err != nil {
+				return err
+			}
+			if idx, ok := indexByKey[key]; ok {
+				entries[idx].flags |= flags
+				continue
+			}
+			indexByKey[key] = len(entries)
+			entries = append(entries, allowOutPolicyEntry{
+				key:    key,
+				flags:  flags,
+				source: cidr,
+			})
+		}
+		return nil
+	}
+
+	if err := add(allowOutCIDRs, 0); err != nil {
+		return nil, err
+	}
+	if err := add(l7AllowOutCIDRs, uint8(netPolicyFlagL7Required)); err != nil {
+		return nil, err
+	}
+	return entries, nil
+}
+
+func buildDenyOutPolicyEntries(cidrs []string) ([]denyOutPolicyEntry, error) {
+	entries := make([]denyOutPolicyEntry, 0, len(cidrs))
+	seen := make(map[lpmKey]struct{}, len(cidrs))
+	for _, cidr := range cidrs {
+		key, err := parseCIDR(cidr)
+		if err != nil {
+			return nil, err
+		}
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		entries = append(entries, denyOutPolicyEntry{
+			key:    key,
+			source: cidr,
+		})
+	}
+	return entries, nil
+}
+
+func buildNetPolicyPlan(opts MVMOptions) (*netPolicyPlan, error) {
+	var allowOut []string
+	if opts.AllowOut != nil {
+		allowOut = *opts.AllowOut
+	}
+	allowOutCIDRs, dnsAllowDomains, err := splitAllowOutTargets(allowOut)
+	if err != nil {
+		return nil, err
+	}
+
+	var l7AllowOut []string
+	if opts.L7AllowOut != nil {
+		l7AllowOut = *opts.L7AllowOut
+	}
+	l7AllowOutCIDRs, l7DNSAllowDomains, err := splitAllowOutTargets(l7AllowOut)
+	if err != nil {
+		return nil, err
+	}
+
+	allowOutEntries, err := buildAllowOutPolicyEntries(allowOutCIDRs, l7AllowOutCIDRs)
+	if err != nil {
+		return nil, err
+	}
+	dnsAllowRules, err := buildDNSAllowRules(dnsAllowDomains, l7DNSAllowDomains)
+	if err != nil {
+		return nil, err
+	}
+
+	var denyOutEntries []denyOutPolicyEntry
+	if opts.AllowInternetAccess != nil && !*opts.AllowInternetAccess {
+		denyOutEntries, err = buildDenyOutPolicyEntries([]string{"0.0.0.0/0"})
+	} else {
+		if opts.DenyOut != nil {
+			denyOutEntries, err = buildDenyOutPolicyEntries(*opts.DenyOut)
+			if err != nil {
+				return nil, err
+			}
+		}
+		denyOutEntries = appendDenyOutPolicyEntries(denyOutEntries, alwaysDeniedSandboxEntries)
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	plan := &netPolicyPlan{
+		allowOutEntries: allowOutEntries,
+		dnsAllowRules:   dnsAllowRules,
+		denyOutEntries:  denyOutEntries,
+		dnsPolicyFlags:  dnsPolicyFlagsForDomains(dnsAllowDomains, l7DNSAllowDomains),
+	}
+	if err := validateNetPolicyPlan(plan); err != nil {
+		return nil, err
+	}
+	return plan, nil
+}
+
+func appendDenyOutPolicyEntries(dst, src []denyOutPolicyEntry) []denyOutPolicyEntry {
+	if len(src) == 0 {
+		return dst
+	}
+	seen := make(map[lpmKey]struct{}, len(dst)+len(src))
+	for _, entry := range dst {
+		seen[entry.key] = struct{}{}
+	}
+	for _, entry := range src {
+		if _, ok := seen[entry.key]; ok {
+			continue
+		}
+		seen[entry.key] = struct{}{}
+		dst = append(dst, entry)
+	}
+	return dst
+}
+
+func validateNetPolicyPlan(plan *netPolicyPlan) error {
+	if err := validateNetPolicyEntryCount("network.allow_out_v2", len(plan.allowOutEntries), maxNetPolicyEntries); err != nil {
+		return err
+	}
+	if err := validateNetPolicyEntryCount("network.dns_allow", len(plan.dnsAllowRules), maxDNSAllowDomains); err != nil {
+		return err
+	}
+	return validateNetPolicyEntryCount("network.deny_out", len(plan.denyOutEntries), maxNetPolicyEntries)
+}
+
 func validateNetPolicyEntryCounts(allowOutCIDRs, l7AllowOutCIDRs, dnsAllowDomains, l7DNSAllowDomains, denyOut []string) error {
 	if count, err := countUniqueLPMEntries(allowOutCIDRs, l7AllowOutCIDRs); err != nil {
 		return err
@@ -379,9 +544,9 @@ func isValidDNSDomainName(domain string) bool {
 	return true
 }
 
-// populateInnerMap parses the given CIDR list and inserts each entry
-// into the inner LPM trie map for the specified ifindex.
-func populateInnerMap(outerMap *ebpf.Map, ifindex uint32, cidrs []string) error {
+// populateInnerMap inserts pre-parsed deny_out entries into the inner LPM trie
+// map for the specified ifindex.
+func populateInnerMap(outerMap *ebpf.Map, ifindex uint32, entries []denyOutPolicyEntry) error {
 	var innerMapID uint32
 	err := outerMap.Lookup(&ifindex, &innerMapID)
 	if err != nil {
@@ -395,21 +560,17 @@ func populateInnerMap(outerMap *ebpf.Map, ifindex uint32, cidrs []string) error 
 	defer inner.Close()
 
 	val := uint32(netPolicyValueStatic)
-	for _, cidr := range cidrs {
-		key, err := parseCIDR(cidr)
+	for _, entry := range entries {
+		err = inner.Update(&entry.key, &val, ebpf.UpdateAny)
 		if err != nil {
-			return err
-		}
-		err = inner.Update(&key, &val, ebpf.UpdateAny)
-		if err != nil {
-			return fmt.Errorf("inner map update failed: %w, cidr: %s", err, cidr)
+			return fmt.Errorf("inner map update failed: %w, cidr: %s", err, entry.source)
 		}
 	}
 	return nil
 }
 
-// populateAllowOutInnerMap parses the given CIDR list and inserts static allow entries.
-func populateAllowOutInnerMap(outerMap *ebpf.Map, ifindex uint32, cidrs []string, flags uint8) error {
+// populateAllowOutInnerMap inserts pre-parsed static allow_out_v2 entries.
+func populateAllowOutInnerMap(outerMap *ebpf.Map, ifindex uint32, entries []allowOutPolicyEntry) error {
 	var innerMapID uint32
 	err := outerMap.Lookup(&ifindex, &innerMapID)
 	if err != nil {
@@ -422,24 +583,19 @@ func populateAllowOutInnerMap(outerMap *ebpf.Map, ifindex uint32, cidrs []string
 	}
 	defer inner.Close()
 
-	for _, cidr := range cidrs {
-		key, err := parseCIDR(cidr)
-		if err != nil {
-			return err
-		}
-
-		val := netPolicyValueV2{Flags: flags}
+	for _, entry := range entries {
+		val := netPolicyValueV2{Flags: entry.flags}
 		var oldVal netPolicyValueV2
-		if err := inner.Lookup(&key, &oldVal); err == nil {
+		if err := inner.Lookup(&entry.key, &oldVal); err == nil {
 			// Static allow entries never expire, but they must preserve existing flags.
 			val.Flags |= oldVal.Flags
 		} else if !errors.Is(err, ebpf.ErrKeyNotExist) {
-			return fmt.Errorf("inner map lookup failed: %w, cidr: %s", err, cidr)
+			return fmt.Errorf("inner map lookup failed: %w, cidr: %s", err, entry.source)
 		}
 
-		err = inner.Update(&key, &val, ebpf.UpdateAny)
+		err = inner.Update(&entry.key, &val, ebpf.UpdateAny)
 		if err != nil {
-			return fmt.Errorf("inner map update failed: %w, cidr: %s", err, cidr)
+			return fmt.Errorf("inner map update failed: %w, cidr: %s", err, entry.source)
 		}
 	}
 	return nil
@@ -473,45 +629,12 @@ func replaceNetPolicy(ifindex uint32, opts MVMOptions) error {
 }
 
 func applyNetPolicyWithMode(ifindex uint32, opts MVMOptions, replace bool) error {
-	// Process allowOut.
-	var allowOut []string
-	if opts.AllowOut != nil {
-		allowOut = *opts.AllowOut
-	}
-	allowOutCIDRs, dnsAllowDomains, err := splitAllowOutTargets(allowOut)
+	plan, err := buildNetPolicyPlan(opts)
 	if err != nil {
 		return err
 	}
 
-	var l7AllowOut []string
-	if opts.L7AllowOut != nil {
-		l7AllowOut = *opts.L7AllowOut
-	}
-	l7AllowOutCIDRs, l7DNSAllowDomains, err := splitAllowOutTargets(l7AllowOut)
-	if err != nil {
-		return err
-	}
-
-	// Process denyOut: always append alwaysDeniedSandboxCIDRs.
-	// If AllowInternetAccess is false, deny all outbound traffic.
-	var denyOut []string
-	if opts.AllowInternetAccess != nil && !*opts.AllowInternetAccess {
-		denyOut = []string{"0.0.0.0/0"}
-	} else {
-		if opts.DenyOut != nil {
-			denyOut = append(*opts.DenyOut, alwaysDeniedSandboxCIDRs...)
-		} else {
-			denyOut = append(denyOut, alwaysDeniedSandboxCIDRs...)
-		}
-	}
-
-	if err := validateNetPolicyEntryCounts(allowOutCIDRs, l7AllowOutCIDRs, dnsAllowDomains, l7DNSAllowDomains, denyOut); err != nil {
-		return err
-	}
-
-	dnsPolicyModeFlags := dnsPolicyFlagsForDomains(dnsAllowDomains, l7DNSAllowDomains)
-
-	if replace || len(allowOutCIDRs)+len(l7AllowOutCIDRs) > 0 {
+	if replace || len(plan.allowOutEntries) > 0 {
 		allowOutMap, err := loadPinnedMap(MapNameAllowOutV2)
 		if err != nil {
 			return err
@@ -526,20 +649,16 @@ func applyNetPolicyWithMode(ifindex uint32, opts MVMOptions, replace bool) error
 				return fmt.Errorf("flush %s failed: %w", MapNameAllowOutV2, err)
 			}
 		}
-		err = populateAllowOutInnerMap(allowOutMap, ifindex, allowOutCIDRs, 0)
-		if err != nil {
-			return fmt.Errorf("populate %s failed: %w", MapNameAllowOutV2, err)
-		}
-		err = populateAllowOutInnerMap(allowOutMap, ifindex, l7AllowOutCIDRs, uint8(netPolicyFlagL7Required))
+		err = populateAllowOutInnerMap(allowOutMap, ifindex, plan.allowOutEntries)
 		if err != nil {
 			return fmt.Errorf("populate %s failed: %w", MapNameAllowOutV2, err)
 		}
 	}
-	if err := applyDNSAllow(ifindex, dnsAllowDomains, l7DNSAllowDomains); err != nil {
+	if err := applyDNSAllow(ifindex, plan.dnsAllowRules, replace); err != nil {
 		return fmt.Errorf("populate %s failed: %w", MapNameDNSAllow, err)
 	}
 
-	if replace || len(denyOut) > 0 {
+	if replace || len(plan.denyOutEntries) > 0 {
 		denyOutMap, err := loadPinnedMap(MapNameDenyOut)
 		if err != nil {
 			return err
@@ -554,11 +673,14 @@ func applyNetPolicyWithMode(ifindex uint32, opts MVMOptions, replace bool) error
 				return fmt.Errorf("flush %s failed: %w", MapNameDenyOut, err)
 			}
 		}
-		err = populateInnerMap(denyOutMap, ifindex, denyOut)
+		err = populateInnerMap(denyOutMap, ifindex, plan.denyOutEntries)
 		if err != nil {
 			return fmt.Errorf("populate %s failed: %w", MapNameDenyOut, err)
 		}
 	}
 
-	return setDNSPolicyFlags(ifindex, dnsPolicyModeFlags)
+	if !replace && plan.dnsPolicyFlags == 0 {
+		return nil
+	}
+	return setDNSPolicyFlags(ifindex, plan.dnsPolicyFlags)
 }

--- a/CubeNet/cubevs/tap.go
+++ b/CubeNet/cubevs/tap.go
@@ -44,7 +44,14 @@ func ListTAPDevices() ([]TAPDevice, error) {
 
 // AddTAPDevice adds a new device to CubeVS.
 func AddTAPDevice(ifindex uint32, ip net.IP, id string, version uint32, opts MVMOptions) error {
-	return UpsertTAPDevice(ifindex, ip, id, version, opts)
+	if err := UpsertTAPDeviceMeta(ifindex, ip, id, version); err != nil {
+		return err
+	}
+	if err := applyNetPolicy(ifindex, opts); err != nil {
+		_ = DelTAPDevice(ifindex, ip)
+		return err
+	}
+	return nil
 }
 
 // UpsertTAPDeviceMeta registers or refreshes TAP metadata without touching


### PR DESCRIPTION
Precompute network policy entries before touching pinned maps so create-time policy application avoids repeated parsing and duplicate map walks.

Skip no-op DNS allow map work for new sandboxes without domain allow rules, while preserving replace-path cleanup semantics for recovered or updated sandboxes.

Use the TAP metadata upsert path for new sandbox registration and apply policy separately, rolling back the TAP registration if policy application fails.