### PR TITLE
fix(nodemeta): re-sync node health to localcache on periodic reload

### DIFF
--- a/CubeMaster/pkg/nodemeta/service.go
+++ b/CubeMaster/pkg/nodemeta/service.go
@@ -941,18 +941,52 @@ func (s *service) reload() error {
 	return nil
 }
 
-// applyReloadResult merges a DB snapshot (next) into the live in-memory map.
-// Registration fields take the DB value (same eventual-consistency trade-off as
-// other labels). Status/heartbeat keep in-memory when fresher. After unlocking,
-// nodes whose cordon state changed are synced to localcache.
+// applyReloadResult merges a DB snapshot (next) into the live in-memory map and
+// then re-syncs node health into localcache for every node the reload touched.
+//
+// Registration fields and versions always take the DB value; status/heartbeat
+// fields keep the in-memory value when it is fresher than the DB snapshot.
+//
+// The re-sync pushes ONLY the scheduler node cache (health, capacity, cordon
+// state); see syncLocalcacheNodeHealth. Template locality is deliberately left
+// to templatecenter, the authoritative owner of the imageCache (startup
+// warmReadyTemplateLocality + on-demand EnsureTemplateLocalityReady DB fallback).
+//
+// Why node health must be re-synced here: a replica that only learned a node via
+// DB reload (it registered/heartbeated on another replica) otherwise kept an
+// empty healthy-node set for it. EnsureTemplateLocalityReady matches a DB-Ready
+// template replica against localcache's healthy nodes, so with the node absent
+// it could not match and sandbox creation failed with "template has no ready
+// replica" (130400). Pushing node health here lets that DB fallback match and
+// self-heal template locality on demand.
 func (s *service) applyReloadResult(next map[string]*NodeSnapshot) {
-	toSync := make([]*NodeSnapshot, 0)
+	syncSnaps := s.mergeReloadResult(next)
 
+	// s.ready is set true at the end of Init, after the initial reload and
+	// before localcache.Init. The very first reload therefore skips the sync
+	// (localcache caches do not exist yet); localcache.Init then loads all nodes
+	// from the DB itself. Periodic loopReload runs long after both packages are
+	// initialised.
+	if !s.ready {
+		return
+	}
+	// Sync outside s.mu (localcache has its own locks).
+	for _, snap := range syncSnaps {
+		syncNodeHealthFn(snap)
+	}
+}
+
+// mergeReloadResult merges the DB reload snapshot into the in-memory node map
+// under s.mu and returns a clone of every touched node for the caller to sync
+// into localcache outside the lock. The critical section uses
+// defer s.mu.Unlock() so a panic in the merge loop cannot leak the lock and
+// silently deadlock subsequent register/heartbeat handlers.
+func (s *service) mergeReloadResult(next map[string]*NodeSnapshot) []*NodeSnapshot {
 	s.mu.Lock()
+	defer s.mu.Unlock()
+	syncSnaps := make([]*NodeSnapshot, 0, len(next))
 	for nodeID, newSnap := range next {
 		if existing, ok := s.nodes[nodeID]; ok {
-			prevDisabled := snapshotSchedulingDisabled(existing)
-
 			existing.Labels = cloneStringMap(newSnap.Labels)
 			existing.labelsJSONCorrupt = newSnap.labelsJSONCorrupt
 			existing.Capacity = newSnap.Capacity
@@ -975,22 +1009,13 @@ func (s *service) applyReloadResult(next map[string]*NodeSnapshot) {
 				existing.ReportedReady = newSnap.ReportedReady
 			}
 			applyCurrentHealth(existing, time.Now())
-
-			if prevDisabled != snapshotSchedulingDisabled(existing) {
-				toSync = append(toSync, cloneSnapshot(existing))
-			}
+			syncSnaps = append(syncSnaps, cloneSnapshot(existing))
 		} else {
 			s.nodes[nodeID] = newSnap
+			syncSnaps = append(syncSnaps, cloneSnapshot(newSnap))
 		}
 	}
-	s.mu.Unlock()
-
-	if !s.ready {
-		return
-	}
-	for _, snap := range toSync {
-		syncLocalcache(snap)
-	}
+	return syncSnaps
 }
 
 func (s *service) loopReload(ctx context.Context) {
@@ -1095,6 +1120,24 @@ func toSchedulerNode(snap *NodeSnapshot) *node.Node {
 func syncLocalcache(snap *NodeSnapshot) {
 	localcache.UpsertNode(toSchedulerNode(snap))
 	localcache.SyncNodeTemplates(snap.NodeID, templateIDsFromLocalTemplates(snap.LocalTemplates))
+}
+
+// syncNodeHealthFn is the reload -> localcache sync hook invoked by
+// applyReloadResult for every touched node. It is a package var (not a direct
+// call to syncLocalcacheNodeHealth) so unit tests can observe the sync path
+// without initialising the global localcache singleton.
+var syncNodeHealthFn = syncLocalcacheNodeHealth
+
+// syncLocalcacheNodeHealth pushes only the scheduler node cache (health,
+// capacity, cordon state) into localcache. Unlike syncLocalcache it deliberately
+// does NOT call SyncNodeTemplates: template locality lives in the imageCache,
+// which templatecenter owns authoritatively (warmReadyTemplateLocality at
+// startup + EnsureTemplateLocalityReady's DB fallback on demand). The periodic
+// reload only needs the node itself to be present/healthy so that DB fallback
+// can match a ready template replica to it; having reload also write the
+// imageCache would race that authoritative owner.
+func syncLocalcacheNodeHealth(snap *NodeSnapshot) {
+	localcache.UpsertNode(toSchedulerNode(snap))
 }
 
 func templateIDsFromLocalTemplates(localTemplates []LocalTemplate) []string {

--- a/CubeMaster/pkg/nodemeta/service_reload_test.go
+++ b/CubeMaster/pkg/nodemeta/service_reload_test.go
@@ -1,10 +1,13 @@
 package nodemeta
 
 import (
+	"sort"
 	"testing"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
+
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/constants"
 )
 
 // newTestService returns a service with a pre-populated in-memory node map,
@@ -207,5 +210,117 @@ func TestApplyReloadResultAddsNewNodeFromDB(t *testing.T) {
 	}
 	if snap.Labels["region"] != "us-east" {
 		t.Fatalf("Labels = %v, want region=us-east", snap.Labels)
+	}
+}
+
+// TestMergeReloadResultReturnsAllTouchedNodes locks in the Option B contract:
+// the periodic reload re-syncs EVERY touched node into localcache (node health),
+// not only nodes whose cordon state changed. mergeReloadResult must therefore
+// return a clone for both an updated existing node and a node newly discovered
+// from the DB. The clones must be decoupled from the in-memory map, and must
+// carry the derived cordon state so syncLocalcacheNodeHealth conveys it.
+func TestMergeReloadResultReturnsAllTouchedNodes(t *testing.T) {
+	s := newTestService(&NodeSnapshot{
+		NodeID: "node-existing",
+		Labels: map[string]string{"zone": "old"},
+	})
+
+	next := map[string]*NodeSnapshot{
+		"node-existing": {
+			NodeID: "node-existing",
+			Labels: map[string]string{
+				"zone":                            "new",
+				constants.LabelSchedulingDisabled: constants.LabelSchedulingDisabledValue,
+			},
+		},
+		"node-new": {
+			NodeID: "node-new",
+			HostIP: "3.3.3.3",
+			Labels: map[string]string{"region": "us-east"},
+		},
+	}
+
+	syncSnaps := s.mergeReloadResult(next)
+
+	if len(syncSnaps) != 2 {
+		t.Fatalf("mergeReloadResult returned %d snaps, want 2 (every touched node)", len(syncSnaps))
+	}
+
+	byID := make(map[string]*NodeSnapshot, len(syncSnaps))
+	for _, snap := range syncSnaps {
+		byID[snap.NodeID] = snap
+	}
+	existing, ok := byID["node-existing"]
+	if !ok {
+		t.Fatal("updated existing node missing from sync set")
+	}
+	if _, ok := byID["node-new"]; !ok {
+		t.Fatal("new-from-DB node missing from sync set")
+	}
+
+	// Clone reflects the merged (new) value and carries derived cordon state.
+	if existing.Labels["zone"] != "new" {
+		t.Fatalf("returned clone not merged: zone=%s want new", existing.Labels["zone"])
+	}
+	if !existing.SchedulingDisabled {
+		t.Fatal("returned clone must carry SchedulingDisabled derived from labels")
+	}
+
+	// Clone is decoupled from the in-memory map.
+	existing.Labels["zone"] = "mutated"
+	s.mu.RLock()
+	stored := s.nodes["node-existing"].Labels["zone"]
+	s.mu.RUnlock()
+	if stored != "new" {
+		t.Fatalf("mutating returned clone leaked into in-memory map: stored zone=%s", stored)
+	}
+}
+
+// TestApplyReloadResultSyncsNodeHealthWhenReady covers the core behavioral fix:
+// once s.ready is true, applyReloadResult must push EVERY touched node (updated
+// existing + newly discovered from DB) into localcache via the node-health sync
+// hook. The hook is swapped for a spy so the assertion needs no localcache
+// singleton. This is the path that lets a non-owner replica's DB fallback match
+// a ready template replica and avoid the 130400 failure.
+func TestApplyReloadResultSyncsNodeHealthWhenReady(t *testing.T) {
+	var synced []string
+	orig := syncNodeHealthFn
+	syncNodeHealthFn = func(snap *NodeSnapshot) { synced = append(synced, snap.NodeID) }
+	defer func() { syncNodeHealthFn = orig }()
+
+	s := newTestService(&NodeSnapshot{
+		NodeID: "node-existing",
+		Labels: map[string]string{"zone": "old"},
+	})
+	s.ready = true
+
+	next := map[string]*NodeSnapshot{
+		"node-existing": {NodeID: "node-existing", Labels: map[string]string{"zone": "new"}},
+		"node-new":      {NodeID: "node-new", HostIP: "3.3.3.3"},
+	}
+	s.applyReloadResult(next)
+
+	sort.Strings(synced)
+	if len(synced) != 2 || synced[0] != "node-existing" || synced[1] != "node-new" {
+		t.Fatalf("node-health sync not invoked for every touched node: got %v want [node-existing node-new]", synced)
+	}
+}
+
+// TestApplyReloadResultSkipsSyncBeforeReady locks in the Init-ordering safety:
+// the very first reload runs before s.ready is set and before localcache.Init,
+// so it must NOT touch localcache (the caches do not exist yet).
+func TestApplyReloadResultSkipsSyncBeforeReady(t *testing.T) {
+	called := false
+	orig := syncNodeHealthFn
+	syncNodeHealthFn = func(*NodeSnapshot) { called = true }
+	defer func() { syncNodeHealthFn = orig }()
+
+	s := newTestService(&NodeSnapshot{NodeID: "node-a"})
+	// s.ready defaults to false (mirrors the pre-Init initial reload).
+
+	s.applyReloadResult(map[string]*NodeSnapshot{"node-a": {NodeID: "node-a"}})
+
+	if called {
+		t.Fatal("node-health sync must be skipped before s.ready is set")
 	}
 }


### PR DESCRIPTION
## Summary

In a multi-replica CubeMaster deployment the periodic DB reload never refreshes
localcache's scheduler node cache, so a replica that learns a node only from the
DB keeps an empty healthy-node set for it. templatecenter's on-demand template
locality fallback then cannot match a ready replica to that node, and sandbox
creation intermittently fails with `template has no ready replica` (error 130400)
depending on which replica serves the request.

## Component

CubeMaster (`pkg/nodemeta`)

## Environment

- CubeSandbox version / commit: `master`
- Deployment mode: **cluster**, multi-replica CubeMaster (>= 2 replicas)
- KVM / kernel: not relevant — control-plane scheduler-cache consistency bug.

## Steps to Reproduce

1. Deploy CubeMaster with >= 2 replicas behind a LoadBalancer/VIP (each cubelet
   reports to a single replica).
2. Register/import a template so its ready replicas are learned by whichever
   CubeMaster replica the cubelet reports to.
3. Repeatedly create sandboxes from that template through the API (round-robins
   across CubeMaster replicas).

## Expected Behavior

Sandbox creation succeeds regardless of which replica serves the request.

## Actual Behavior

Only the replica that received the node's direct register/heartbeat has the node
in its localcache healthy-node set. On any other replica,
`EnsureTemplateLocalityReady` (templatecenter's DB fallback) cannot match a
DB-Ready template replica against localcache's healthy nodes, and creation fails
with `template has no ready replica` (error 130400). In a 2-replica setup,
creation succeeded roughly 50/50 depending on which replica the request hit.

## Root Cause

The periodic node-metadata reload (`loopReload` / `applyReloadResult`, added in
#542) rebuilds only the `nodemeta` in-memory node map. It does **not** refresh
`localcache`'s scheduler node cache, which is otherwise populated solely from the
register/heartbeat paths. A replica that learns a node only via the DB reload
therefore keeps an empty healthy-node set for it.

Template locality is not owned by `nodemeta` — it lives in the `imageCache`,
which `templatecenter` owns authoritatively (`warmReadyTemplateLocality` at
startup + `EnsureTemplateLocalityReady` on demand). That on-demand fallback
matches a DB-Ready template replica against localcache's **healthy nodes**; with
the node missing from that set it cannot match, surfacing as 130400.

## Fix

`applyReloadResult` now re-syncs every reloaded node's **node health** into
`localcache` via `syncLocalcacheNodeHealth` (`UpsertNode` only) after releasing
`s.mu`. This makes the node present/healthy on every replica, so
templatecenter's DB fallback can match a ready template replica and self-heal
locality on demand.

It deliberately does **not** call `SyncNodeTemplates`: writing the `imageCache`
from the reload path would race `templatecenter`, the authoritative owner, and
a stale full reconcile could erase freshly-registered replicas. Leaving template
locality to templatecenter keeps a single writer and a clear precedence.

The merge is extracted into `mergeReloadResult` with `defer s.mu.Unlock()` so a
panic in the merge loop cannot leak the lock. The sync reuses the existing
`s.ready` gate (set at the end of `Init`, after the initial reload and before
`localcache.Init`), so the first reload safely skips the sync while
`localcache.Init` loads all nodes from the DB itself.

## Testing

- `TestMergeReloadResultReturnsAllTouchedNodes`: reload returns a decoupled clone
  for every touched node (updated-existing + new-from-DB), carrying derived
  cordon state.
- `TestApplyReloadResultSyncsNodeHealthWhenReady`: with `s.ready = true`, the
  node-health sync is invoked for every touched node.
- `TestApplyReloadResultSkipsSyncBeforeReady`: before `s.ready`, the sync is
  skipped (Init-ordering safety).
- `go test -race ./CubeMaster/pkg/nodemeta/...` passes.
- Verified on a 2-replica staging deployment: a 20x sandbox-create loop that
  previously failed ~50% (130400) now succeeds 20/20.

## Related

- Follow-up to #542, which fixed the same cross-replica gap for node
  heartbeat/health but not for the scheduler node cache used by template-locality
  matching.
