### PR TITLE
feat: add Python SDK set_timeout() with NEVER_TIMEOUT (-1) support

### DIFF
--- a/CubeAPI/src/models/mod.rs
+++ b/CubeAPI/src/models/mod.rs
@@ -479,8 +479,25 @@ fn default_log_limit() -> i32 {
 /// Request body for POST /sandboxes/{id}/timeout
 #[derive(Debug, Deserialize, Validate, ToSchema)]
 pub struct SetTimeoutRequest {
-    #[validate(range(min = 0))]
+    #[validate(custom(function = "validate_timeout_value"))]
     pub timeout: i32,
+}
+
+/// Validates the timeout value for SetTimeoutRequest.
+///
+/// Accepts:
+/// - `>= 0`: normal TTL in seconds (0 = immediate expire)
+/// - `-1`:  never-timeout sentinel (see `NEVER_TIMEOUT` in SDK)
+///
+/// Rejects all other negative values.
+fn validate_timeout_value(timeout: i32) -> Result<(), validator::ValidationError> {
+    if timeout >= 0 || timeout == -1 {
+        Ok(())
+    } else {
+        Err(validator::ValidationError::new(
+            "timeout_must_be_non_negative_or_never",
+        ))
+    }
 }
 
 /// Request body for POST /sandboxes/{id}/refreshes
@@ -522,12 +539,22 @@ mod tests {
     use validator::Validate;
 
     #[test]
-    fn set_timeout_request_rejects_negative_values() {
+    fn set_timeout_request_rejects_invalid_negative_values() {
+        // Only -1 (NEVER_TIMEOUT) is accepted as a valid negative value.
+        for timeout in [-2, -100, -999] {
+            let req = SetTimeoutRequest { timeout };
+            assert!(
+                req.validate().is_err(),
+                "timeout={timeout} should be rejected (only -1 is valid negative)"
+            );
+        }
+    }
+
+    #[test]
+    fn set_timeout_request_accepts_never_timeout() {
         let req = SetTimeoutRequest { timeout: -1 };
-        assert!(
-            req.validate().is_err(),
-            "negative timeout should be rejected"
-        );
+        req.validate()
+            .unwrap_or_else(|e| panic!("NEVER_TIMEOUT (-1) should be valid: {e}"));
     }
 
     #[test]

--- a/CubeMaster/pkg/service/sandbox/sandbox_timeout.go
+++ b/CubeMaster/pkg/service/sandbox/sandbox_timeout.go
@@ -42,9 +42,9 @@ func SetTimeout(ctx context.Context, req *types.SetTimeoutRequest) (rsp *types.S
 		rsp.Ret.RetMsg = "should provide sandboxID"
 		return
 	}
-	if req.Timeout < 0 {
+	if req.Timeout < -1 {
 		rsp.Ret.RetCode = int(errorcode.ErrorCode_MasterParamsError)
-		rsp.Ret.RetMsg = "timeout must be non-negative (seconds)"
+		rsp.Ret.RetMsg = "timeout must be >= -1 (use -1 for never timeout)"
 		return
 	}
 

--- a/CubeMaster/pkg/service/sandbox/sandbox_timeout.go
+++ b/CubeMaster/pkg/service/sandbox/sandbox_timeout.go
@@ -42,9 +42,9 @@ func SetTimeout(ctx context.Context, req *types.SetTimeoutRequest) (rsp *types.S
 		rsp.Ret.RetMsg = "should provide sandboxID"
 		return
 	}
-	if req.Timeout <= 0 {
+	if req.Timeout < 0 {
 		rsp.Ret.RetCode = int(errorcode.ErrorCode_MasterParamsError)
-		rsp.Ret.RetMsg = "timeout must be positive (seconds)"
+		rsp.Ret.RetMsg = "timeout must be non-negative (seconds)"
 		return
 	}
 

--- a/CubeMaster/pkg/service/sandbox/sandbox_timeout_test.go
+++ b/CubeMaster/pkg/service/sandbox/sandbox_timeout_test.go
@@ -36,13 +36,33 @@ func TestSetTimeoutValidationAllowsZero(t *testing.T) {
 }
 
 func TestSetTimeoutValidationRejectsNegative(t *testing.T) {
+	// Only -1 (NeverTimeout) is accepted as a valid negative value.
 	rsp := SetTimeout(context.Background(), &types.SetTimeoutRequest{
 		RequestID: "req-negative",
 		SandboxID: "sb-timeout-negative-validation",
-		Timeout:   -1,
+		Timeout:   -2,
 	})
 
 	if rsp.Ret.RetCode != int(errorcode.ErrorCode_MasterParamsError) {
-		t.Fatalf("timeout<0 should be rejected as params error, got ret=%+v", rsp.Ret)
+		t.Fatalf("timeout<-1 should be rejected as params error, got ret=%+v", rsp.Ret)
+	}
+}
+
+func TestSetTimeoutValidationAllowsNeverTimeout(t *testing.T) {
+	const sandboxID = "sb-timeout-never-validation"
+	localcache.SetSandboxCache(sandboxID, &localcache.SandboxCache{
+		SandboxID: sandboxID,
+		HostIP:    "127.0.0.1",
+	})
+	defer localcache.DeleteSandboxCache(sandboxID)
+
+	rsp := SetTimeout(context.Background(), &types.SetTimeoutRequest{
+		RequestID: "req-never",
+		SandboxID: sandboxID,
+		Timeout:   types.NeverTimeout,
+	})
+
+	if rsp.Ret.RetCode != int(errorcode.ErrorCode_Success) {
+		t.Fatalf("timeout=-1 (NeverTimeout) should be accepted, got ret=%+v", rsp.Ret)
 	}
 }

--- a/CubeMaster/pkg/service/sandbox/sandbox_timeout_test.go
+++ b/CubeMaster/pkg/service/sandbox/sandbox_timeout_test.go
@@ -1,0 +1,48 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package sandbox
+
+import (
+	"context"
+	"testing"
+
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/errorcode"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/localcache"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/service/sandbox/types"
+)
+
+func TestSetTimeoutValidationAllowsZero(t *testing.T) {
+	const sandboxID = "sb-timeout-zero-validation"
+	localcache.SetSandboxCache(sandboxID, &localcache.SandboxCache{
+		SandboxID: sandboxID,
+		HostIP:    "127.0.0.1",
+	})
+	defer localcache.DeleteSandboxCache(sandboxID)
+
+	rsp := SetTimeout(context.Background(), &types.SetTimeoutRequest{
+		RequestID: "req-zero",
+		SandboxID: sandboxID,
+		Timeout:   0,
+	})
+
+	if rsp.Ret.RetCode != int(errorcode.ErrorCode_Success) {
+		t.Fatalf("timeout=0 should be accepted, got ret=%+v", rsp.Ret)
+	}
+	if rsp.EndAt <= 0 {
+		t.Fatalf("timeout=0 should return an immediate endAt, got %d", rsp.EndAt)
+	}
+}
+
+func TestSetTimeoutValidationRejectsNegative(t *testing.T) {
+	rsp := SetTimeout(context.Background(), &types.SetTimeoutRequest{
+		RequestID: "req-negative",
+		SandboxID: "sb-timeout-negative-validation",
+		Timeout:   -1,
+	})
+
+	if rsp.Ret.RetCode != int(errorcode.ErrorCode_MasterParamsError) {
+		t.Fatalf("timeout<0 should be rejected as params error, got ret=%+v", rsp.Ret)
+	}
+}

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -279,6 +279,7 @@ with Sandbox.create(config=cfg) as sb:
 | `sb.get_info()` | `GET /sandboxes/:id` — get sandbox state and metadata |
 | `sb.pause(*, wait, timeout, interval)` | `POST /sandboxes/:id/pause` — pause sandbox |
 | `sb.resume(timeout)` | `POST /sandboxes/:id/resume` — resume (deprecated, use `connect`) |
+| `sb.set_timeout(timeout)` | `POST /sandboxes/:id/timeout` — set sandbox idle timeout |
 | `sb.kill()` | `DELETE /sandboxes/:id` — destroy sandbox |
 | `sb.get_host(port)` | Return virtual hostname `{port}-{id}.{domain}` |
 

--- a/sdk/python/cubesandbox/sandbox.py
+++ b/sdk/python/cubesandbox/sandbox.py
@@ -459,7 +459,8 @@ class Sandbox:
 
         Args:
             timeout: New idle timeout in seconds. ``0`` requests immediate
-                timeout; positive values set a normal TTL.
+                timeout; positive values set a normal TTL; ``NEVER_TIMEOUT``
+                (-1) disables idle timeout entirely.
 
         Raises:
             SandboxNotFoundError: If the sandbox does not exist (HTTP 404).

--- a/sdk/python/cubesandbox/sandbox.py
+++ b/sdk/python/cubesandbox/sandbox.py
@@ -454,6 +454,23 @@ class Sandbox:
         )
         _check_response(resp)
 
+    def set_timeout(self, timeout: int) -> None:
+        """POST /sandboxes/:sandboxID/timeout - Set sandbox idle timeout.
+
+        Args:
+            timeout: New idle timeout in seconds. ``0`` requests immediate
+                timeout; positive values set a normal TTL.
+
+        Raises:
+            SandboxNotFoundError: If the sandbox does not exist (HTTP 404).
+            ApiError: If the timeout is invalid or on unexpected backend error.
+        """
+        resp = self._session.post(
+            f"{self._config.api_url}/sandboxes/{self.sandbox_id}/timeout",
+            json={"timeout": timeout},
+        )
+        _check_response(resp)
+
     def kill(self) -> None:
         """DELETE /sandboxes/:sandboxID - Destroy a sandbox.
 

--- a/sdk/python/tests/test_sandbox.py
+++ b/sdk/python/tests/test_sandbox.py
@@ -865,6 +865,13 @@ class TestSetTimeout:
             sb.set_timeout(0)
         assert m.call_args.kwargs["json"] == {"timeout": 0}
 
+    def test_set_timeout_sends_never_timeout(self):
+        from cubesandbox import NEVER_TIMEOUT
+        sb = make_sandbox()
+        with patch.object(sb._session, "post", return_value=mock_response(status=204)) as m:
+            sb.set_timeout(NEVER_TIMEOUT)
+        assert m.call_args.kwargs["json"] == {"timeout": -1}
+
     def test_set_timeout_not_found(self):
         sb = make_sandbox()
         with patch.object(sb._session, "post",

--- a/sdk/python/tests/test_sandbox.py
+++ b/sdk/python/tests/test_sandbox.py
@@ -849,6 +849,30 @@ class TestResume:
                 sb.resume()
 
 
+# ── POST /sandboxes/:id/timeout ───────────────────────────────────────────────
+
+class TestSetTimeout:
+    def test_set_timeout_success(self):
+        sb = make_sandbox()
+        with patch.object(sb._session, "post", return_value=mock_response(status=204)) as m:
+            sb.set_timeout(120)
+        assert m.call_args.args[0] == f"{sb._config.api_url}/sandboxes/{SANDBOX_ID}/timeout"
+        assert m.call_args.kwargs["json"] == {"timeout": 120}
+
+    def test_set_timeout_sends_explicit_zero(self):
+        sb = make_sandbox()
+        with patch.object(sb._session, "post", return_value=mock_response(status=204)) as m:
+            sb.set_timeout(0)
+        assert m.call_args.kwargs["json"] == {"timeout": 0}
+
+    def test_set_timeout_not_found(self):
+        sb = make_sandbox()
+        with patch.object(sb._session, "post",
+                          return_value=mock_response({"message": "not found"}, status=404)):
+            with pytest.raises(SandboxNotFoundError):
+                sb.set_timeout(120)
+
+
 # ── properties / get_host ─────────────────────────────────────────────────────
 
 class TestProperties:


### PR DESCRIPTION
## Summary

This PR adds `set_timeout()` to the CubeSandbox Python SDK, making it
API-compatible with the E2B SDK.  It also extends the endpoint to
accept `NEVER_TIMEOUT (-1)` as a valid sentinel, completing the
three-value timeout semantics introduced in #810.

## Changes

### Python SDK
- Add `Sandbox.set_timeout(timeout)` → `POST /sandboxes/{id}/timeout`
- Export `NEVER_TIMEOUT = -1` sentinel for never-timeout requests
- Document the new method in `sdk/python/README.md`

### CubeAPI (Rust)
- Replace `#[validate(range(min = 0))]` with a custom validator that
  accepts `>= 0` or `== -1`.  Reject all other negative values.

### CubeMaster (Go)
- Relax `SetTimeout` validation from `timeout < 0` to `timeout < -1`
  so that `-1` (NeverTimeout) is forwarded to the lifecycle provider.

### Tests
- Rust: `set_timeout_request_accepts_never_timeout`
- Go: `TestSetTimeoutValidationAllowsZero`,
  `TestSetTimeoutValidationRejectsNegative`,
  `TestSetTimeoutValidationAllowsNeverTimeout`
- Python: happy path, explicit zero, NEVER_TIMEOUT, 404

## Timeout semantics (after #810)

| `timeout` value | Meaning |
|-----------------|---------|
| `> 0` | Normal TTL in seconds |
| `0` | Immediate expiry |
| `-1` (`NEVER_TIMEOUT`) | Never expire |
| `<-1` | Rejected (invalid) |

## Verification

```bash
# Rust
cargo check --manifest-path CubeAPI/Cargo.toml
cargo test -p cubeapi -- models::mod::tests

# Go
go test ./pkg/service/sandbox -run 'TestSetTimeoutValidation' -count=1

# Python
uv run --project sdk/python --extra dev pytest sdk/python/tests/test_sandbox.py -q
```

## Dependencies

- [x] #810 (merged) — three-value timeout semantics + server-side default

🤖 Generated with [Claude Code](https://claude.com/claude-code)