### PR TITLE
hypervisor: make arm64 PMU exposure configurable

### DIFF
--- a/CubeShim/README.md
+++ b/CubeShim/README.md
@@ -31,6 +31,14 @@ When containerd needs to create a sandbox, it spawns `containerd-shim-cube-rs` a
 |-------|------|
 | Extended shim API (shimapi) | [`docs/shimapi/`](./docs/shimapi/README.md) |
 
+## Sandbox Annotations
+
+CubeShim reads pod sandbox annotations when constructing the VM configuration.
+
+| Key | Values | Default | Description |
+|-----|--------|---------|-------------|
+| `cube.vm.pmu` | `on`, `off` | `on` | Controls ARM PMUv3 exposure on AArch64 hosts. Set to `off` when the host provides KVM but does not support exposing a virtual PMU. |
+
 ## Sub-components
 
 | Directory | Binary | Description |

--- a/CubeShim/shim/src/hypervisor/config.rs
+++ b/CubeShim/shim/src/hypervisor/config.rs
@@ -17,8 +17,8 @@ use crate::sandbox::pmem::Pmem;
 
 use cube_hypervisor::config::{RateLimiterConfig, TokenBucketConfig};
 use cube_hypervisor::vm_config::{
-    ConsoleConfig, ConsoleOutputMode, CpuTopology, DiskConfig, FsConfig, MacAddr, NetConfig,
-    PayloadConfig, PmemConfig, RngConfig, VmConfig as VC, VsockConfig,
+    ConsoleConfig, ConsoleOutputMode, CpuPmuConfig, CpuTopology, DiskConfig, FsConfig, MacAddr,
+    NetConfig, PayloadConfig, PmemConfig, RngConfig, VmConfig as VC, VsockConfig,
 };
 use cube_hypervisor::vmm_config::VmmConfig;
 
@@ -66,6 +66,7 @@ pub struct VmConfig {
     pub vsock: Option<VsockConfig>,
     pub sys_ctrl: bool,
     pub rng: RngConfig,
+    pub pmu: CpuPmuConfig,
 }
 
 impl Default for VmConfig {
@@ -123,6 +124,7 @@ impl Default for VmConfig {
                 src: PathBuf::from("/dev/urandom"),
                 iommu: false,
             },
+            pmu: CpuPmuConfig::default(),
         }
     }
 }
@@ -133,6 +135,7 @@ impl VmConfig {
 
         vc.cpus.max_vcpus = self.vcpus as u8;
         vc.cpus.boot_vcpus = self.vcpus as u8;
+        vc.cpus.pmu = self.pmu;
         let topology = CpuTopology {
             threads_per_core: 1,
             cores_per_die: self.vcpus as u8,
@@ -235,6 +238,11 @@ impl VmConfig {
 
     pub fn set_kernel(&mut self, kernel: String) -> &mut Self {
         self.kernel = kernel;
+        self
+    }
+
+    pub fn set_pmu(&mut self, pmu: CpuPmuConfig) -> &mut Self {
+        self.pmu = pmu;
         self
     }
 
@@ -436,7 +444,7 @@ pub struct PciDeviceInfo {
 
 #[cfg(test)]
 mod tests {
-    use cube_hypervisor::vm_config::ConsoleOutputMode;
+    use cube_hypervisor::vm_config::{ConsoleOutputMode, CpuPmuConfig};
     use std::path::PathBuf;
 
     use crate::common::utils::Utils;
@@ -455,6 +463,7 @@ mod tests {
         assert_eq!(pmem[0].file, PathBuf::from(IMAGE_PATH));
         assert_eq!(config.console.mode, ConsoleOutputMode::Tty);
         assert_eq!(config.rng.src, PathBuf::from("/dev/urandom"));
+        assert_eq!(config.pmu, CpuPmuConfig::On);
 
         let mut params = vec![
             "root=/dev/pmem0".to_string(),
@@ -498,6 +507,9 @@ mod tests {
         config.set_memory(999, true);
         assert_eq!(config.memory_size, 999);
         assert!(config.dirty_log);
+
+        config.set_pmu(CpuPmuConfig::Off);
+        assert_eq!(config.to_vm_config().cpus.pmu, CpuPmuConfig::Off);
 
         //add_disk
         assert!(config.disks.is_some());

--- a/CubeShim/shim/src/sandbox/config.rs
+++ b/CubeShim/shim/src/sandbox/config.rs
@@ -9,6 +9,7 @@ use crate::sandbox::disk::{Disk, ANNO_DISK};
 use crate::sandbox::net::{Net, ANNO_NET};
 use crate::sandbox::pmem::{Pmem, ANNO_PMEM};
 use cube_hypervisor::config::{BackendFsConfig, RateLimiterConfig};
+use cube_hypervisor::vm_config::CpuPmuConfig;
 
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -22,6 +23,7 @@ pub const ANNO_CUBE_VIPS: &str = "cube.net.vips";
 pub const ANNO_SNAPSHOT_DISABLE: &str = "cube.snapshot.disable";
 pub const ANNO_SNAPSHOT_NOTIFY: &str = "cube.snapshot.healthcheck";
 pub const ANNO_VM_KERNEL: &str = "cube.vm.kernel.path";
+pub const ANNO_VM_PMU: &str = "cube.vm.pmu";
 /// Annotation key used to append extra kernel cmdline parameters.
 pub const ANNO_VM_KERNEL_CMDLINE_APPEND: &str = "cube.vm.kernel.cmdline.append";
 pub const ANNO_SNAPSHOT_BASE: &str = "cube.vm.snapshot.base.path";
@@ -60,6 +62,7 @@ pub struct Config {
     pub app_snapshot_restore: bool,
     /// Extra kernel cmdline parameters injected through annotations.
     pub extra_kernel_params: Vec<String>,
+    pub pmu: CpuPmuConfig,
 }
 
 impl Config {
@@ -189,6 +192,12 @@ impl Config {
         } else {
             Vec::new()
         };
+        let pmu = if let Some(pmu) = anno.get(ANNO_VM_PMU) {
+            pmu.parse::<CpuPmuConfig>()
+                .map_err(|_| format!("Invalid annotation:{}={}", ANNO_VM_PMU, pmu))?
+        } else {
+            CpuPmuConfig::default()
+        };
 
         let c = Config {
             net,
@@ -212,6 +221,7 @@ impl Config {
             app_snapshot_create,
             app_snapshot_restore,
             extra_kernel_params,
+            pmu,
         };
         Ok(c)
     }
@@ -248,6 +258,8 @@ pub struct VirtioFs {
 mod tests {
     use std::collections::HashMap;
 
+    use cube_hypervisor::vm_config::CpuPmuConfig;
+
     use crate::common::utils::Utils;
     use crate::common::PRODUCT_CUBEBOX;
     use crate::sandbox::config::Config;
@@ -255,6 +267,7 @@ mod tests {
     use crate::sandbox::config::ANNO_SNAPSHOT_MEMORY_VOL_URL;
     use crate::sandbox::config::ANNO_VM_KERNEL;
     use crate::sandbox::config::ANNO_VM_KERNEL_CMDLINE_APPEND;
+    use crate::sandbox::config::ANNO_VM_PMU;
     use crate::sandbox::config::ANNO_VM_RES;
     use crate::sandbox::config::KERNEL_SCF;
 
@@ -276,6 +289,7 @@ mod tests {
         assert_eq!(config.vm_res.memory, 2048);
         assert_eq!(config.vm_res.preserve_memory, 2048);
         assert_eq!(config.vm_res.snap_memory, 2048);
+        assert_eq!(config.pmu, CpuPmuConfig::On);
 
         // product,kernel,snapshot base dir (always CUBEBOX)
         assert_eq!(config.product, PRODUCT_CUBEBOX);
@@ -327,6 +341,16 @@ mod tests {
             config.extra_kernel_params,
             vec!["foo=bar".to_string(), "second=2".to_string()]
         );
+
+        annotations.insert(ANNO_VM_PMU.to_string(), "off".to_string());
+        let ret = Config::new(&Some(annotations.clone()));
+        assert!(ret.is_ok());
+        let config = ret.unwrap();
+        assert_eq!(config.pmu, CpuPmuConfig::Off);
+
+        annotations.insert(ANNO_VM_PMU.to_string(), "maybe".to_string());
+        let ret = Config::new(&Some(annotations.clone()));
+        assert!(ret.is_err());
     }
 
     #[test]

--- a/CubeShim/shim/src/sandbox/sb.rs
+++ b/CubeShim/shim/src/sandbox/sb.rs
@@ -716,6 +716,7 @@ impl SandBox {
         vc.set_kernel(self.conf.kernel.clone())
             .set_vcpus(self.conf.vm_res.cpu)
             .set_memory(self.conf.vm_res.memory, false)
+            .set_pmu(self.conf.pmu)
             .add_nets(&self.conf.net)?
             .add_disks(&self.conf.disk)
             .add_virtiofs(&self.conf.virtiofs)
@@ -1375,6 +1376,7 @@ fn normalize_dns_for_agent(entry: &str) -> CResult<String> {
 
 #[cfg(test)]
 mod tests {
+    use cube_hypervisor::vm_config::CpuPmuConfig;
     use protobuf::MessageDyn;
     use std::collections::HashSet;
     use tokio::sync::mpsc::channel;
@@ -1394,6 +1396,7 @@ mod tests {
         sb.conf.vm_res.cpu = 999;
         sb.conf.vm_res.memory = 999;
         sb.conf.product = PRODUCT_CUBEBOX.to_string();
+        sb.conf.pmu = CpuPmuConfig::Off;
         sb.conf.extra_kernel_params = vec![
             "custom.param=42".to_string(),
             "another.param=foo".to_string(),
@@ -1406,6 +1409,7 @@ mod tests {
         assert_eq!(vm_config.vcpus, 999);
         assert_eq!(vm_config.memory_size, 999);
         assert_eq!(vm_config.kernel, "ut_kernel".to_string());
+        assert_eq!(vm_config.pmu, CpuPmuConfig::Off);
         assert!(vm_config.cmdlines.contains(&"custom.param=42".to_string()));
         assert!(vm_config
             .cmdlines

--- a/hypervisor/docs/cpu.md
+++ b/hypervisor/docs/cpu.md
@@ -18,11 +18,12 @@ struct CpusConfig {
     max_phys_bits: u8,
     affinity: Option<Vec<CpuAffinity>>,
     features: CpuFeatures,
+    pmu: CpuPmuConfig,
 }
 ```
 
 ```
---cpus boot=<boot_vcpus>,max=<max_vcpus>,topology=<threads_per_core>:<cores_per_die>:<dies_per_package>:<packages>,kvm_hyperv=on|off,max_phys_bits=<maximum_number_of_physical_bits>,affinity=<list_of_vcpus_with_their_associated_cpuset>,features=<list_of_features_to_enable>
+--cpus boot=<boot_vcpus>,max=<max_vcpus>,topology=<threads_per_core>:<cores_per_die>:<dies_per_package>:<packages>,kvm_hyperv=on|off,max_phys_bits=<maximum_number_of_physical_bits>,affinity=<list_of_vcpus_with_their_associated_cpuset>,features=<list_of_features_to_enable>,pmu=on|off
 ```
 
 ### `boot`
@@ -115,6 +116,23 @@ _Example_
 
 ```
 --cpus kvm_hyperv=on
+```
+
+### `pmu`
+
+Enable ARM PMUv3 exposure to the guest.
+
+When turned off, the VMM does not request `KVM_ARM_VCPU_PMU_V3` during vCPU
+initialization and does not add a PMU node to the guest device tree. This is
+useful for deployments where KVM is available but the host hypervisor does not
+support exposing a virtual PMU.
+
+By default this option is turned on.
+
+_Example_
+
+```
+--cpus pmu=off
 ```
 
 ### `max_phys_bits`

--- a/hypervisor/src/main.rs
+++ b/hypervisor/src/main.rs
@@ -119,7 +119,8 @@ fn create_app(default_vcpus: String, default_memory: String, default_rng: String
                     topology=<threads_per_core>:<cores_per_die>:<dies_per_package>:<packages>,\
                     kvm_hyperv=on|off,max_phys_bits=<maximum_number_of_physical_bits>,\
                     affinity=<list_of_vcpus_with_their_associated_cpuset>,\
-                    features=<list_of_features_to_enable>,compatible=vendor|max|ignore",
+                    features=<list_of_features_to_enable>,compatible=vendor|max|ignore,\
+                    pmu=on|off",
                 )
                 .default_value(default_vcpus)
                 .group("vm-config"),
@@ -781,8 +782,8 @@ mod unit_tests {
     use std::path::PathBuf;
     use vmm::config::VmParams;
     use vmm::vm_config::{
-        CompatibleMode, ConsoleConfig, ConsoleOutputMode, CpuFeatures, CpusConfig, HotplugMethod,
-        MemoryConfig, PayloadConfig, RngConfig, VmConfig,
+        CompatibleMode, ConsoleConfig, ConsoleOutputMode, CpuFeatures, CpuPmuConfig, CpusConfig,
+        HotplugMethod, MemoryConfig, PayloadConfig, RngConfig, VmConfig,
     };
 
     fn get_vm_config_from_vec(args: &[&str]) -> VmConfig {
@@ -831,6 +832,7 @@ mod unit_tests {
                 affinity: None,
                 features: CpuFeatures::default(),
                 compatible: CompatibleMode::Vendor,
+                pmu: CpuPmuConfig::On,
             },
             memory: MemoryConfig {
                 size: 536_870_912,

--- a/hypervisor/vmm/src/api/openapi/cloud-hypervisor.yaml
+++ b/hypervisor/vmm/src/api/openapi/cloud-hypervisor.yaml
@@ -666,6 +666,10 @@ components:
             $ref: "#/components/schemas/CpuAffinity"
         features:
           $ref: "#/components/schemas/CpuFeatures"
+        pmu:
+          type: string
+          enum: [on, off]
+          default: on
 
     PlatformConfig:
       type: object

--- a/hypervisor/vmm/src/config.rs
+++ b/hypervisor/vmm/src/config.rs
@@ -591,6 +591,23 @@ impl FromStr for CompatibleMode {
     }
 }
 
+#[derive(Debug)]
+pub enum ParseCpuPmuConfigError {
+    InvalidValue(String),
+}
+
+impl FromStr for CpuPmuConfig {
+    type Err = ParseCpuPmuConfigError;
+
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        match s.to_lowercase().as_str() {
+            "on" => Ok(CpuPmuConfig::On),
+            "off" => Ok(CpuPmuConfig::Off),
+            _ => Err(ParseCpuPmuConfigError::InvalidValue(s.to_owned())),
+        }
+    }
+}
+
 impl CpusConfig {
     pub fn parse(cpus: &str) -> Result<Self> {
         let mut parser = OptionParser::new();
@@ -602,7 +619,8 @@ impl CpusConfig {
             .add("max_phys_bits")
             .add("affinity")
             .add("features")
-            .add("compatible");
+            .add("compatible")
+            .add("pmu");
         parser.parse(cpus).map_err(Error::ParseCpus)?;
 
         let boot_vcpus: u8 = parser
@@ -642,6 +660,10 @@ impl CpusConfig {
             .convert("compatible")
             .map_err(Error::ParseCpus)?
             .unwrap_or_default();
+        let pmu = parser
+            .convert("pmu")
+            .map_err(Error::ParseCpus)?
+            .unwrap_or_default();
 
         // Some ugliness here as the features being checked might be disabled
         // at compile time causing the below allow and the need to specify the
@@ -670,6 +692,7 @@ impl CpusConfig {
             affinity,
             features,
             compatible,
+            pmu,
         })
     }
 }
@@ -2892,6 +2915,16 @@ mod tests {
                 ..Default::default()
             }
         );
+        assert_eq!(
+            CpusConfig::parse("boot=1,pmu=off")?,
+            CpusConfig {
+                boot_vcpus: 1,
+                max_vcpus: 1,
+                pmu: CpuPmuConfig::Off,
+                ..Default::default()
+            }
+        );
+        assert!(CpusConfig::parse("pmu=maybe").is_err());
         assert_eq!(
             CpusConfig::parse("boot=2,affinity=[0@[0,2],1@[1,3]]")?,
             CpusConfig {

--- a/hypervisor/vmm/src/cpu.rs
+++ b/hypervisor/vmm/src/cpu.rs
@@ -26,6 +26,8 @@ use crate::seccomp_filters::{get_seccomp_filter, Thread};
 use crate::vm::physical_bits;
 #[cfg(target_arch = "x86_64")]
 use crate::vm_config::CompatibleMode;
+#[cfg(target_arch = "aarch64")]
+use crate::vm_config::CpuPmuConfig;
 use crate::vm_config::CpusConfig;
 use crate::GuestMemoryMmap;
 use crate::CPU_MANAGER_SNAPSHOT_ID;
@@ -345,13 +347,14 @@ impl Vcpu {
         &mut self,
         #[cfg(target_arch = "aarch64")] vm: &Arc<dyn hypervisor::Vm>,
         kernel_entry_point: Option<EntryPoint>,
+        #[cfg(target_arch = "aarch64")] pmu: CpuPmuConfig,
         #[cfg(target_arch = "x86_64")] vm_memory: &GuestMemoryAtomic<GuestMemoryMmap>,
         #[cfg(target_arch = "x86_64")] cpuid: Vec<CpuIdEntry>,
         #[cfg(target_arch = "x86_64")] kvm_hyperv: bool,
     ) -> Result<()> {
         #[cfg(target_arch = "aarch64")]
         {
-            self.init(vm)?;
+            self.init(vm, pmu)?;
             self.mpidr = arch::configure_vcpu(&self.vcpu, self.id, kernel_entry_point)
                 .map_err(Error::VcpuConfiguration)?;
         }
@@ -384,19 +387,22 @@ impl Vcpu {
 
     /// Initializes an aarch64 specific vcpu for booting Linux.
     #[cfg(target_arch = "aarch64")]
-    pub fn init(&self, vm: &Arc<dyn hypervisor::Vm>) -> Result<()> {
+    pub fn init(&self, vm: &Arc<dyn hypervisor::Vm>, pmu: CpuPmuConfig) -> Result<()> {
         let mut kvi: kvm_bindings::kvm_vcpu_init = kvm_bindings::kvm_vcpu_init::default();
 
         // This reads back the kernel's preferred target type.
         vm.get_preferred_target(&mut kvi)
             .map_err(Error::VcpuArmPreferredTarget)?;
-        // We already checked that the capability is supported.
+        // We already checked that PSCI 0.2 is supported.
         kvi.features[0] |= 1 << kvm_bindings::KVM_ARM_VCPU_PSCI_0_2;
-        kvi.features[0] |= 1 << kvm_bindings::KVM_ARM_VCPU_PMU_V3;
+        if pmu == CpuPmuConfig::On {
+            kvi.features[0] |= 1 << kvm_bindings::KVM_ARM_VCPU_PMU_V3;
+        }
         // Non-boot cpus are powered off initially.
         if self.id > 0 {
             kvi.features[0] |= 1 << kvm_bindings::KVM_ARM_VCPU_POWER_OFF;
         }
+
         self.vcpu.vcpu_init(&kvi).map_err(Error::VcpuArmInit)
     }
 
@@ -805,7 +811,7 @@ impl CpuManager {
         if let Some(snapshot) = snapshot {
             // AArch64 vCPUs should be initialized after created.
             #[cfg(target_arch = "aarch64")]
-            vcpu.init(&self.vm)?;
+            vcpu.init(&self.vm, self.config.pmu)?;
 
             vcpu.restore(snapshot).expect("Failed to restore vCPU");
         } else {
@@ -818,7 +824,7 @@ impl CpuManager {
             )?;
 
             #[cfg(target_arch = "aarch64")]
-            vcpu.configure(&self.vm, entry_point)?;
+            vcpu.configure(&self.vm, entry_point, self.config.pmu)?;
         }
 
         // Adding vCPU to the CpuManager's vCPU list.
@@ -852,18 +858,30 @@ impl CpuManager {
 
     #[cfg(target_arch = "aarch64")]
     pub fn init_pmu(&self, irq: u32) -> Result<bool> {
+        if self.config.pmu == CpuPmuConfig::Off {
+            debug!("PMUv3 is disabled by CPU configuration, skip PMU init!");
+            return Ok(false);
+        }
+
+        // The guest sees PMU as a single device-tree capability, so expose it
+        // only when every created vCPU supports the PMU control attributes.
+        // Both passes below must execute without concurrent vCPU modification;
+        // this is safe because init_pmu is called during VM setup before any
+        // vCPU threads are spawned.
         for cpu in self.vcpus.iter() {
             let cpu = cpu.lock().unwrap();
-            // Check if PMU attr is available, if not, log the information.
-            if cpu.vcpu.has_pmu_support() {
-                cpu.vcpu.init_pmu(irq).map_err(Error::InitPmu)?;
-            } else {
+            if !cpu.vcpu.has_pmu_support() {
                 debug!(
                     "PMU attribute is not supported in vCPU{}, skip PMU init!",
                     cpu.id
                 );
                 return Ok(false);
             }
+        }
+
+        for cpu in self.vcpus.iter() {
+            let cpu = cpu.lock().unwrap();
+            cpu.vcpu.init_pmu(irq).map_err(Error::InitPmu)?;
         }
 
         Ok(true)

--- a/hypervisor/vmm/src/lib.rs
+++ b/hypervisor/vmm/src/lib.rs
@@ -2200,7 +2200,7 @@ const DEVICE_MANAGER_SNAPSHOT_ID: &str = "device-manager";
 #[cfg(test)]
 mod unit_tests {
     use super::*;
-    use crate::vm_config::{CompatibleMode, CpuFeatures};
+    use crate::vm_config::{CompatibleMode, CpuFeatures, CpuPmuConfig};
     use vm_config::{
         ConsoleConfig, ConsoleOutputMode, CpusConfig, HotplugMethod, MemoryConfig, PayloadConfig,
         RngConfig, VmConfig,
@@ -2234,6 +2234,7 @@ mod unit_tests {
                 affinity: None,
                 features: CpuFeatures::default(),
                 compatible: CompatibleMode::Vendor,
+                pmu: CpuPmuConfig::On,
             },
             memory: MemoryConfig {
                 size: 536_870_912,

--- a/hypervisor/vmm/src/vm_config.rs
+++ b/hypervisor/vmm/src/vm_config.rs
@@ -30,6 +30,19 @@ pub struct CpuFeatures {
     pub amx: bool,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum CpuPmuConfig {
+    On,
+    Off,
+}
+
+impl Default for CpuPmuConfig {
+    fn default() -> Self {
+        CpuPmuConfig::On
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 pub struct CpuTopology {
     pub threads_per_core: u8,
@@ -63,6 +76,8 @@ pub struct CpusConfig {
     pub features: CpuFeatures,
     #[serde(default)]
     pub compatible: CompatibleMode,
+    #[serde(default)]
+    pub pmu: CpuPmuConfig,
 }
 
 pub const DEFAULT_VCPUS: u8 = 1;
@@ -78,6 +93,7 @@ impl Default for CpusConfig {
             affinity: None,
             features: CpuFeatures::default(),
             compatible: CompatibleMode::Vendor,
+            pmu: CpuPmuConfig::default(),
         }
     }
 }


### PR DESCRIPTION
## Summary
- Add a CPU PMU exposure knob: `cpus.pmu` in JSON/OpenAPI and `--cpus pmu=on|off` in the CLI.
- Keep the default as `pmu=on` to preserve existing behavior on hosts that support ARM PMUv3.
- Allow CubeShim deployments to set `cube.vm.pmu=off`, which avoids requesting `KVM_ARM_VCPU_PMU_V3` and omits the guest PMU device-tree node.
- Treat PMU exposure as a guest-wide capability: if any created vCPU lacks PMU control attributes, no PMU node is exposed to the guest.

## Validation
- `cargo fmt --all --check` in `hypervisor`
- `cargo fmt --all --check` in `CubeShim/shim`
- `git diff --check`
- `make builder-run BUILDER_CMD='cd /workspace/hypervisor && cargo test -p vmm --features kvm test_cpu_parsing'`
- `make builder-run BUILDER_CMD='cd /workspace/CubeShim/shim && cargo test config'`
- `make builder-run BUILDER_CMD='cd /workspace/CubeShim/shim && cargo test test_sandbox_prepare_resource'`
- `make shim`
