### PR TITLE
Allow platform-suffixed versions in version matrix checks

### DIFF
--- a/CubeMaster/pkg/nodemeta/versionmatrix.go
+++ b/CubeMaster/pkg/nodemeta/versionmatrix.go
@@ -307,10 +307,31 @@ func versionIsDeclared(component, actual string, primary map[string]string, sets
 		if _, ok := set[actual]; ok {
 			return true
 		}
+		for declared := range set {
+			if versionMatchesDeclared(declared, actual) {
+				return true
+			}
+		}
 		return false
 	}
 	exp := primary[component]
-	return exp != "" && exp != "unknown" && actual == exp
+	return exp != "" && exp != "unknown" && versionMatchesDeclared(exp, actual)
+}
+
+func versionMatchesDeclared(declared, actual string) bool {
+	if declared == actual {
+		return true
+	}
+	return stripPlatformVersionSuffix(actual) == declared
+}
+
+func stripPlatformVersionSuffix(value string) string {
+	for _, suffix := range []string{"-amd64", "-arm64", "-x86_64", "-aarch64"} {
+		if strings.HasSuffix(value, suffix) {
+			return strings.TrimSuffix(value, suffix)
+		}
+	}
+	return value
 }
 
 func sortedDeclaredVersions(component string, primary map[string]string, sets map[string]map[string]struct{}) []string {

--- a/CubeMaster/pkg/nodemeta/versionmatrix.go
+++ b/CubeMaster/pkg/nodemeta/versionmatrix.go
@@ -15,6 +15,8 @@ import (
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/version"
 )
 
+var platformVersionSuffixes = []string{"-amd64", "-arm64", "-x86_64", "-aarch64"}
+
 // defaultReleaseManifestPath is the on-disk location of the release manifest
 // installed by the one-click bundle. It can be overridden with the
 // CUBE_RELEASE_MANIFEST environment variable (mainly for tests / non-standard
@@ -318,6 +320,9 @@ func versionIsDeclared(component, actual string, primary map[string]string, sets
 	return exp != "" && exp != "unknown" && versionMatchesDeclared(exp, actual)
 }
 
+// versionMatchesDeclared reports whether actual matches declared. Declared
+// values from the release manifest stay canonical; only actual is normalized
+// by stripping known platform suffixes before comparison.
 func versionMatchesDeclared(declared, actual string) bool {
 	if declared == actual {
 		return true
@@ -326,9 +331,15 @@ func versionMatchesDeclared(declared, actual string) bool {
 }
 
 func stripPlatformVersionSuffix(value string) string {
-	for _, suffix := range []string{"-amd64", "-arm64", "-x86_64", "-aarch64"} {
-		if strings.HasSuffix(value, suffix) {
-			return strings.TrimSuffix(value, suffix)
+	changed := true
+	for changed {
+		changed = false
+		for _, suffix := range platformVersionSuffixes {
+			if strings.HasSuffix(value, suffix) {
+				value = strings.TrimSuffix(value, suffix)
+				changed = true
+				break
+			}
 		}
 	}
 	return value

--- a/CubeMaster/pkg/nodemeta/versionmatrix_test.go
+++ b/CubeMaster/pkg/nodemeta/versionmatrix_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/db/models"
 )
 
@@ -95,16 +96,38 @@ func TestVersionIsDeclaredIgnoresPlatformSuffix(t *testing.T) {
 		},
 	}
 
-	for _, actual := range []string{"v0.5.0", "v0.5.0-arm64", "v0.5.0-amd64", "v0.5.0-aarch64", "v0.5.0-x86_64"} {
-		if !versionIsDeclared("cube-egress", actual, primary, sets) {
-			t.Fatalf("expected platform-specific version %q to match declaration", actual)
-		}
+	for _, actual := range []string{"v0.5.0", "v0.5.0-arm64", "v0.5.0-amd64", "v0.5.0-aarch64", "v0.5.0-x86_64", "v0.5.0-arm64-amd64"} {
+		assert.True(t, versionIsDeclared("cube-egress", actual, primary, sets), "platform-specific version %q should match declaration", actual)
 	}
-	for _, actual := range []string{"v0.5.0-dev", "v0.5.0-rc1", "v0.5.1-arm64", "unknown", ""} {
-		if versionIsDeclared("cube-egress", actual, primary, sets) {
-			t.Fatalf("version %q must not match declaration v0.5.0", actual)
-		}
+	for _, actual := range []string{"v0.5.0-dev", "v0.5.0-rc1", "v0.5.1-arm64", "v0.5.0-arm64-fips", "unknown", ""} {
+		assert.False(t, versionIsDeclared("cube-egress", actual, primary, sets), "version %q must not match declaration v0.5.0", actual)
 	}
+}
+
+func TestVersionIsDeclaredPlatformSuffixCaseSensitive(t *testing.T) {
+	primary := map[string]string{"cube-egress": "v0.5.0"}
+	sets := map[string]map[string]struct{}{
+		"cube-egress": {"v0.5.0": {}},
+	}
+
+	assert.False(
+		t,
+		versionIsDeclared("cube-egress", "v0.5.0-ARM64", primary, sets),
+		"platform suffix matching is case-sensitive by design",
+	)
+}
+
+func TestVersionIsDeclaredUsesPrimaryWhenSetMissing(t *testing.T) {
+	primary := map[string]string{"cube-egress": "v0.5.0"}
+
+	assert.True(t, versionIsDeclared("cube-egress", "v0.5.0-arm64", primary, nil))
+	assert.False(t, versionIsDeclared("cube-egress", "v0.5.0-dev", primary, nil))
+}
+
+func TestStripPlatformVersionSuffix(t *testing.T) {
+	assert.Equal(t, "v0.5.0", stripPlatformVersionSuffix("v0.5.0-arm64-amd64"))
+	assert.Equal(t, "v0.5.0-arm64-fips", stripPlatformVersionSuffix("v0.5.0-arm64-fips"))
+	assert.Equal(t, "v0.5.0-ARM64", stripPlatformVersionSuffix("v0.5.0-ARM64"))
 }
 
 func TestBuildVersionMatrixUsesDeclaredDistribution(t *testing.T) {

--- a/CubeMaster/pkg/nodemeta/versionmatrix_test.go
+++ b/CubeMaster/pkg/nodemeta/versionmatrix_test.go
@@ -87,14 +87,38 @@ func TestVersionIsDeclaredForKernelVariants(t *testing.T) {
 	}
 }
 
+func TestVersionIsDeclaredIgnoresPlatformSuffix(t *testing.T) {
+	primary := map[string]string{"cube-egress": "v0.5.0"}
+	sets := map[string]map[string]struct{}{
+		"cube-egress": {
+			"v0.5.0": {},
+		},
+	}
+
+	for _, actual := range []string{"v0.5.0", "v0.5.0-arm64", "v0.5.0-amd64", "v0.5.0-aarch64", "v0.5.0-x86_64"} {
+		if !versionIsDeclared("cube-egress", actual, primary, sets) {
+			t.Fatalf("expected platform-specific version %q to match declaration", actual)
+		}
+	}
+	for _, actual := range []string{"v0.5.0-dev", "v0.5.0-rc1", "v0.5.1-arm64", "unknown", ""} {
+		if versionIsDeclared("cube-egress", actual, primary, sets) {
+			t.Fatalf("version %q must not match declaration v0.5.0", actual)
+		}
+	}
+}
+
 func TestBuildVersionMatrixUsesDeclaredDistribution(t *testing.T) {
 	declared := map[string]string{
-		"cubelet": "v1.0.0",
-		"kernel":  "kernel-v1@sha256:ordinary",
+		"cubelet":     "v1.0.0",
+		"cube-egress": "v0.5.0",
+		"kernel":      "kernel-v1@sha256:ordinary",
 	}
 	declaredSets := map[string]map[string]struct{}{
 		"cubelet": {
 			"v1.0.0": {},
+		},
+		"cube-egress": {
+			"v0.5.0": {},
 		},
 		"kernel": {
 			"kernel-v1@sha256:ordinary": {},
@@ -103,6 +127,7 @@ func TestBuildVersionMatrixUsesDeclaredDistribution(t *testing.T) {
 	}
 	rows := []*models.NodeComponentVersion{
 		{NodeID: "node-bm", Component: "cubelet", Version: "v1.0.0"},
+		{NodeID: "node-bm", Component: "cube-egress", Version: "v0.5.0-arm64"},
 		{NodeID: "node-bm", Component: "kernel", Version: "kernel-v1@sha256:ordinary"},
 		{NodeID: "node-pvm", Component: "cubelet", Version: "v1.1.0-test"},
 		{NodeID: "node-pvm", Component: "kernel", Version: "kernel-pvm-v1@sha256:pvm"},
@@ -126,6 +151,13 @@ func TestBuildVersionMatrixUsesDeclaredDistribution(t *testing.T) {
 	}
 	if !findNodeComponent(t, matrix, "node-pvm", "kernel").Declared {
 		t.Fatalf("PVM kernel identity should be declared")
+	}
+	egress := findNodeComponent(t, matrix, "node-bm", "cube-egress")
+	if !egress.Declared {
+		t.Fatalf("platform-specific cube-egress version should match the release declaration")
+	}
+	if egress.Version != "v0.5.0-arm64" {
+		t.Fatalf("cube-egress matrix should preserve the reported version, got %q", egress.Version)
 	}
 	if findNodeComponent(t, matrix, "node-pvm", "cubelet").Declared {
 		t.Fatalf("cubelet test build should be marked undeclared")

--- a/web/src/pages/Versions.tsx
+++ b/web/src/pages/Versions.tsx
@@ -42,7 +42,28 @@ function declaredVersionsFor(row: ComponentRow): string[] {
 
 function isVersionUndeclared(row: ComponentRow, version: string): boolean {
   const declared = declaredVersionsFor(row);
-  return declared.length > 0 && version !== '' && version !== 'unknown' && !declared.includes(version);
+  return (
+    declared.length > 0 &&
+    version !== '' &&
+    version !== 'unknown' &&
+    !declared.some((declaredVersion) => versionMatchesDeclared(declaredVersion, version))
+  );
+}
+
+function versionMatchesDeclared(declared: string, actual: string): boolean {
+  if (declared === actual) {
+    return true;
+  }
+  return stripPlatformVersionSuffix(actual) === declared;
+}
+
+function stripPlatformVersionSuffix(version: string): string {
+  for (const suffix of ['-amd64', '-arm64', '-x86_64', '-aarch64']) {
+    if (version.endsWith(suffix)) {
+      return version.slice(0, -suffix.length);
+    }
+  }
+  return version;
 }
 
 function rowHasUndeclaredVersion(row: ComponentRow): boolean {

--- a/web/src/pages/Versions.tsx
+++ b/web/src/pages/Versions.tsx
@@ -50,6 +50,9 @@ function isVersionUndeclared(row: ComponentRow, version: string): boolean {
   );
 }
 
+const platformVersionSuffixes = ['-amd64', '-arm64', '-x86_64', '-aarch64'] as const;
+
+// Declared manifest versions stay canonical; only actual is normalized.
 function versionMatchesDeclared(declared: string, actual: string): boolean {
   if (declared === actual) {
     return true;
@@ -58,12 +61,19 @@ function versionMatchesDeclared(declared: string, actual: string): boolean {
 }
 
 function stripPlatformVersionSuffix(version: string): string {
-  for (const suffix of ['-amd64', '-arm64', '-x86_64', '-aarch64']) {
-    if (version.endsWith(suffix)) {
-      return version.slice(0, -suffix.length);
+  let normalized = version;
+  let changed = true;
+  while (changed) {
+    changed = false;
+    for (const suffix of platformVersionSuffixes) {
+      if (normalized.endsWith(suffix)) {
+        normalized = normalized.slice(0, -suffix.length);
+        changed = true;
+        break;
+      }
     }
   }
-  return version;
+  return normalized;
 }
 
 function rowHasUndeclaredVersion(row: ComponentRow): boolean {


### PR DESCRIPTION
## Summary
- keep reported component versions unchanged in the Versions matrix
- treat platform-suffixed versions such as `v0.5.0-arm64` as declared when the release manifest declares `v0.5.0`
- apply the same comparison in the WebUI so component badges, filters, and KPI counts match the backend matrix result
- add regression coverage that preserves the displayed reported version while marking it declared

## Root cause
Architecture-specific one-click bundles can report installed component versions with platform suffixes, for example `v0.5.0-arm64`. The release manifest declares the release line as `v0.5.0`, so exact string comparisons marked those platform-specific reports as undeclared even though they belong to the declared release.

## Behavior
The matrix still displays the actual reported value, such as `v0.5.0-arm64`. Only the declared/undeclared comparison normalizes known platform suffixes (`amd64`, `arm64`, `x86_64`, `aarch64`). Pre-release or custom suffixes such as `-rc1` and `-dev` remain undeclared unless explicitly declared.

## Validation
- `go test ./pkg/nodemeta` from `CubeMaster`
- `npm run build` from `web`
- locally deployed CubeMaster and WebUI on the CentOS VM; verified `cube-egress` reports `v0.5.0-arm64`, remains displayed as `v0.5.0-arm64`, and is counted as declared / single-version in the dashboard

Note: this PR intentionally does not change one-click packaging or CubeEgress image defaults.
