### PR TITLE
fix(cubelet): avoid FATAL crash when ControllerPlugin does not implement CubeMetaController

### DIFF
--- a/Cubelet/pkg/constants/const.go
+++ b/Cubelet/pkg/constants/const.go
@@ -90,6 +90,7 @@ const (
 	ControllerConfigPlugin  plugin.Type = "io.cubelet.controller.config.v1"
 	ControllerCubeletPlugin plugin.Type = "io.cubelet.controller.cubelet.v1"
 	ControllerPlugin        plugin.Type = "io.cubelet.controller.v1"
+	ResourceManagerPlugin   plugin.Type = "io.cubelet.resource-manager.v1"
 
 	PluginCubelet                       string   = "cubelet"
 	PluginRunTemplateManager            PluginId = "run-template-manager"

--- a/Cubelet/plugins/controller/cubelet_plugin.go
+++ b/Cubelet/plugins/controller/cubelet_plugin.go
@@ -51,6 +51,7 @@ func registerCubelet() {
 			plugins.CRIServicePlugin,
 			constants.ControllerPlugin,
 			constants.ControllerConfigPlugin,
+			constants.ResourceManagerPlugin,
 		},
 		InitFn: func(ic *plugin.InitContext) (interface{}, error) {
 			obj, err := ic.GetByID(constants.ControllerConfigPlugin, constants.PluginCubelet)
@@ -91,11 +92,11 @@ func registerCubelet() {
 				if ok {
 					controllerMap[name] = c
 				} else {
-					log.G(ic.Context).Fatalf("controller %s is not a valid CubeMetaController", name)
+					log.G(ic.Context).Warnf("controller %s is not a valid CubeMetaController", name)
 				}
 			}
 
-			obj, err = ic.GetByID(constants.ControllerPlugin, constants.PluginRunTemplateManager.ID())
+			obj, err = ic.GetByID(constants.ResourceManagerPlugin, constants.PluginRunTemplateManager.ID())
 			if err != nil {
 				return nil, fmt.Errorf("failed to get run template manager: %w", err)
 			}

--- a/Cubelet/plugins/controller/resource_manager_plugins.go
+++ b/Cubelet/plugins/controller/resource_manager_plugins.go
@@ -20,7 +20,7 @@ func init() {
 
 func registerCubeRunTemplateResourceManager() {
 	registry.Register(&plugin.Registration{
-		Type: constants.ControllerPlugin,
+		Type: constants.ResourceManagerPlugin,
 		ID:   constants.PluginRunTemplateManager.ID(),
 		Requires: []plugin.Type{
 			constants.CubeMetaStorePlugin,

--- a/Cubelet/plugins/cube/internals/appsnapshot/appsnapshot_plugin.go
+++ b/Cubelet/plugins/cube/internals/appsnapshot/appsnapshot_plugin.go
@@ -23,10 +23,10 @@ func init() {
 		Type: constants.InternalPlugin,
 		ID:   constants.APPSnapshotID.ID(),
 		Requires: []plugin.Type{
-			constants.ControllerPlugin,
+			constants.ResourceManagerPlugin,
 		},
 		InitFn: func(ic *plugin.InitContext) (interface{}, error) {
-			obj, err := ic.GetByID(constants.ControllerPlugin, constants.PluginRunTemplateManager.ID())
+			obj, err := ic.GetByID(constants.ResourceManagerPlugin, constants.PluginRunTemplateManager.ID())
 			if err != nil {
 				return nil, fmt.Errorf("failed to get run template manager: %w", err)
 			}


### PR DESCRIPTION
## Summary

- Introduce a dedicated `ResourceManagerPlugin` type (`io.cubelet.resource-manager.v1`) and move `run-template-manager` from `ControllerPlugin` to it
- Downgrade `Fatalf` to `Warnf` in the controller init loop so unexpected interface mismatches degrade gracefully instead of crashing

## Root Cause

The `run-template-manager` was registered as `ControllerPlugin` type but only implements `RunTemplateManager` — it has no `Run(stopCh <-chan struct{}) error` method required by `CubeMetaController`. The controller initialization loop in `cubelet_plugin.go` iterates all `ControllerPlugin` plugins and called `Fatalf` when the type assertion failed, causing Cubelet to crash on every startup (~5 minute restart cycle).

This bug has existed since the initial open-source release (commit 37cb5c6, 2026-04-16).

## Fix

1. Add `ResourceManagerPlugin` plugin type to cleanly separate resource managers (service providers) from controllers (that implement `Run`)
2. Register `run-template-manager` under `ResourceManagerPlugin` instead of `ControllerPlugin`
3. Update `cubelet_plugin.go` and `appsnapshot_plugin.go` to depend on and retrieve from the new type
4. Downgrade `Fatalf` to `Warnf` as a defense-in-depth measure

## Test Plan

- [ ] Verify Cubelet starts without FATAL crash on bare-metal deployment
- [ ] Verify `run-template-manager` is correctly initialized and functional (template listing/ensuring works)
- [ ] Verify `appsnapshot` plugin can still retrieve the template manager
- [ ] Confirm no regression in sandbox creation with snapshot templates

Fixes #750

Signed-off-by: Feng Jin <ronyjin@tencent.com>
Assisted-by: Cursor:claude-opus-4-8-thinking-high