### PR TITLE
fix(cubeapi): return 404 when deleting missing sandbox

### DIFF
--- a/CubeAPI/src/services/sandboxes.rs
+++ b/CubeAPI/src/services/sandboxes.rs
@@ -242,7 +242,7 @@ impl SandboxService {
             .cubemaster
             .delete_sandbox(&req)
             .await
-            .map_err(internal_error)?;
+            .map_err(|e| sandbox_not_found_or_internal(e, sandbox_id))?;
 
         resp.ret
             .into_result()
@@ -874,6 +874,7 @@ mod tests {
 
     use super::{
         build_cube_network_config, filter_by_metadata, from_cubemaster_info, SandboxService,
+        RET_CODE_NOT_FOUND,
     };
     use crate::cubemaster::{
         CreateSandboxRequest, CubeMasterClient, ListSandboxResponse, SandboxInfo,
@@ -882,7 +883,11 @@ mod tests {
         EgressRule, EgressRuleAction, EgressRuleInject, EgressRuleMatch, NewSandbox,
         SandboxNetworkConfig, SandboxState,
     };
-    use axum::{extract::State, routing::post, Json, Router};
+    use axum::{
+        extract::State,
+        routing::{delete, post},
+        Json, Router,
+    };
     use serde_json::Value;
     use tokio::sync::Mutex;
 
@@ -1377,6 +1382,48 @@ mod tests {
             create_body.get("create_time_env_vars").is_none(),
             "create_time_env_vars should be omitted when caller did not provide envs"
         );
+    }
+
+    #[tokio::test]
+    async fn kill_sandbox_maps_cubemaster_not_found_to_app_not_found() {
+        async fn delete_handler() -> Json<Value> {
+            Json(serde_json::json!({
+                "requestID": "req-delete",
+                "ret": { "ret_code": RET_CODE_NOT_FOUND, "ret_msg": "no such sandbox" },
+                "sandbox_id": "sandbox-missing"
+            }))
+        }
+
+        async fn spawn_server(app: Router) -> String {
+            let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+                .await
+                .expect("listener should bind");
+            let addr = listener.local_addr().expect("listener addr");
+            tokio::spawn(async move {
+                axum::serve(listener, app).await.expect("server should run");
+            });
+            format!("http://{}", addr)
+        }
+
+        let cubemaster_url =
+            spawn_server(Router::new().route("/cube/sandbox", delete(delete_handler))).await;
+        let service = SandboxService::new(
+            CubeMasterClient::new(cubemaster_url, reqwest::Client::new()),
+            "cubebox".to_string(),
+            "cube.app".to_string(),
+        );
+
+        let err = service
+            .kill_sandbox("sandbox-missing")
+            .await
+            .expect_err("missing sandbox delete should return not found");
+
+        match err {
+            crate::error::AppError::NotFound(msg) => {
+                assert_eq!(msg, "sandbox sandbox-missing not found");
+            }
+            other => panic!("expected not found error, got {other:?}"),
+        }
     }
 
     #[test]

--- a/CubeMaster/pkg/service/sandbox/sandbox_remove.go
+++ b/CubeMaster/pkg/service/sandbox/sandbox_remove.go
@@ -94,6 +94,7 @@ func DestroySandbox(ctx context.Context, req *types.DeleteCubeSandboxReq) (rsp *
 	switch req.InstanceType {
 	case cubebox.InstanceType_cubebox.String():
 		if !dealScfSandbox(ctx, req, t) {
+			rsp.Ret.RetCode = int(errorcode.ErrorCode_NotFound)
 			rsp.Ret.RetMsg = "no such sandbox"
 			return
 		}

--- a/CubeMaster/pkg/service/sandbox/sandbox_remove_test.go
+++ b/CubeMaster/pkg/service/sandbox/sandbox_remove_test.go
@@ -1,0 +1,32 @@
+package sandbox
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/api/services/cubebox/v1"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/errorcode"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/service/sandbox/types"
+)
+
+func TestDestroySandboxMissingSandboxReturnsNotFound(t *testing.T) {
+	ResetAfterDestroySandboxSuccessHooks()
+	defer ResetAfterDestroySandboxSuccessHooks()
+
+	hookCalled := false
+	RegisterAfterDestroySandboxSuccessHook(func(_ context.Context, _ string) error {
+		hookCalled = true
+		return nil
+	})
+
+	got := DestroySandbox(context.Background(), &types.DeleteCubeSandboxReq{
+		RequestID:    "req-missing-delete",
+		SandboxID:    "sandbox-does-not-exist",
+		InstanceType: cubebox.InstanceType_cubebox.String(),
+	})
+
+	assert.Equal(t, int(errorcode.ErrorCode_NotFound), got.Ret.RetCode)
+	assert.Equal(t, "no such sandbox", got.Ret.RetMsg)
+	assert.False(t, hookCalled, "after-destroy success hook should not run for missing sandbox")
+}


### PR DESCRIPTION
## Summary

Fixes #231.

This PR changes sandbox deletion behavior so deleting a nonexistent sandbox returns `404 Not Found` instead of `204 No Content`.

Previously, CubeMaster returned `"no such sandbox"` without setting a non-success ret code, so CubeAPI treated the delete operation as successful. CubeMaster now returns `ErrorCode_NotFound`, and CubeAPI maps that CubeMaster not-found response to `AppError::NotFound`.

## Changes

- Return `ErrorCode_NotFound` from CubeMaster when deleting a missing sandbox.
- Map CubeMaster delete not-found errors to CubeAPI `404 Not Found`.
- Add focused tests for CubeMaster and CubeAPI delete-missing behavior.

## Validation

```bash
gofmt -l CubeMaster/pkg/service/sandbox/sandbox_remove.go CubeMaster/pkg/service/sandbox/sandbox_remove_test.go
```

```bash
cargo fmt --manifest-path CubeAPI/Cargo.toml -- --check
```

```bash
git diff --check
```

```bash
CUBE_MASTER_CONFIG_PATH=/home/han/project/CubeSandbox/CubeMaster/conf.yaml GOCACHE=/tmp/cubesandbox-go-cache GOMODCACHE=/tmp/cubesandbox-go-mod-cache go test ./pkg/service/sandbox
```

```bash
CARGO_HOME=/tmp/cubesandbox-cargo-home CARGO_TARGET_DIR=/tmp/cubesandbox-cubeapi-target cargo test --manifest-path CubeAPI/Cargo.toml services::sandboxes::tests::kill_sandbox_maps_cubemaster_not_found_to_app_not_found
```

## Screenshots

Not applicable. This is an API behavior fix.
