### PR TITLE
fix(CubeMaster): stably sort sandbox list to stop reordering on refresh

### DIFF
--- a/CubeMaster/pkg/service/sandbox/sandbox_list.go
+++ b/CubeMaster/pkg/service/sandbox/sandbox_list.go
@@ -7,6 +7,7 @@ package sandbox
 import (
 	"context"
 	"runtime/debug"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -100,6 +101,17 @@ func ListSandbox(ctx context.Context, req *types.ListCubeSandboxReq) (rsp *types
 	wg.Wait()
 	close(resChan)
 	<-done
+
+	// Results arrive over resChan in goroutine-completion order, which varies
+	// between calls and across nodes, so rsp.Data would otherwise be reshuffled
+	// on every list request. Sort by creation time descending (newest first),
+	// falling back to SandboxID for a deterministic, stable order.
+	sort.Slice(rsp.Data, func(i, j int) bool {
+		if rsp.Data[i].CreateAt != rsp.Data[j].CreateAt {
+			return rsp.Data[i].CreateAt > rsp.Data[j].CreateAt
+		}
+		return rsp.Data[i].SandboxID < rsp.Data[j].SandboxID
+	})
 	return
 }
 


### PR DESCRIPTION
Fixes #742.
  
### Problem
The Sandboxes list (`:12088/sandboxes`) reorders on every ~auto-refresh. `ListSandbox` fans out to per-node goroutines and appends results to `rsp.Data` in goroutine-completion order, which varies between calls, so the WebUI/SDK receive a reshuffled list each poll. No layer (CubeMaster, CubeAPI, frontend) imposed a stable order.

### Root cause
The request path is:
WebUI → CubeAPI `GET /v2/sandboxes` → CubeMaster `ListSandbox` (gRPC) → per-node Cubelet.
In `CubeMaster/pkg/service/sandbox/sandbox_list.go`, `ListSandbox` fans out to one goroutine per node and aggregates the results through a  channel:

```go
for res := range resChan {
    rsp.Data = append(rsp.Data, res)
}   
```
Results are appended in goroutine-completion order, which is non-deterministic and varies between calls and across nodes. No layer (CubeMaster, CubeAPI, or the frontend) applied any sort, so each refresh returned the same set of sandboxes in a different order.
  
### Fix
Add a stable sort after aggregation in ListSandbox, before returning:

- primary key: CreateAt descending (newest first)
- tie-breaker: SandboxID ascending (deterministic)

This is consistent with the existing cubecli list command, which already sorts by CreatedAt descending. The fix is contained to the CubeMaster aggregation layer, so all consumers (WebUI and SDK) get a stable order without frontend changes.
```
sort.Slice(rsp.Data, func(i, j int) bool {
  if rsp.Data[i].CreateAt != rsp.Data[j].CreateAt {
       return rsp.Data[i].CreateAt > rsp.Data[j].CreateAt
  }
  return rsp.Data[i].SandboxID < rsp.Data[j].SandboxID
})
```