### PR TITLE
fix(egress): prevent DNS TTL expiry from killing long-lived TCP connections

### DIFF
--- a/CubeEgress/nginx.conf
+++ b/CubeEgress/nginx.conf
@@ -123,8 +123,8 @@ http {
 
             proxy_pass http://$server_addr:$server_port;
             proxy_connect_timeout 10s;
-            proxy_send_timeout 60s;
-            proxy_read_timeout 60s;
+            proxy_send_timeout 600s;
+            proxy_read_timeout 600s;
 
             header_filter_by_lua_block {
                 require("debug_dump").dump_response_headers()
@@ -192,8 +192,8 @@ http {
             proxy_ssl_name $cube_original_sni;
             proxy_pass https://$server_addr:$server_port;
             proxy_connect_timeout 10s;
-            proxy_send_timeout 60s;
-            proxy_read_timeout 60s;
+            proxy_send_timeout 600s;
+            proxy_read_timeout 600s;
 
             header_filter_by_lua_block {
                 require("debug_dump").dump_response_headers()

--- a/CubeNet/src/cubevs.h
+++ b/CubeNet/src/cubevs.h
@@ -38,6 +38,11 @@
 #define NET_POLICY_FLAG_L7_REQUIRED	1
 #define NSEC_PER_SEC			1000000000ULL
 #define DNS_QUERY_TRACK_TTL_NS		(10ULL * NSEC_PER_SEC)
+/* Duration to extend DNS-learned allow_out_v2 entries when non-SYN TCP
+ * traffic hits them.  Keeps long-lived connections alive across DNS TTL
+ * rotation while still letting the reaper reclaim truly idle entries.
+ */
+#define DNS_LEARNED_REFRESH_NS		(600ULL * NSEC_PER_SEC)
 
 /* https://en.wikipedia.org/wiki/IPv4#Header
  *

--- a/CubeNet/src/mvmtap.bpf.c
+++ b/CubeNet/src/mvmtap.bpf.c
@@ -121,11 +121,13 @@ static __always_inline bool should_do_nat(const struct iphdr *l3)
  * matches, policy_value receives the matched flags for later L7 routing.
  */
 static __always_inline bool check_net_policy(__u32 ifindex, __u32 daddr,
-					     struct net_policy_value_v2 *policy_value)
+					     struct net_policy_value_v2 *policy_value,
+					     bool refresh_ttl)
 {
 	struct lpm_key key = { .prefixlen = 32, .ip = daddr };
 	struct net_policy_value_v2 *value;
 	void *inner_map;
+	__u64 now;
 
 	policy_value->expires_at_ns = 0;
 	policy_value->flags = 0;
@@ -136,13 +138,22 @@ static __always_inline bool check_net_policy(__u32 ifindex, __u32 daddr,
 	if (daddr == mvm_gateway_ip)
 		return true;
 
+	now = bpf_ktime_get_ns();
+
 	/* allow_out_v2 takes precedence. */
 	inner_map = bpf_map_lookup_elem(&allow_out_v2, &ifindex);
 	if (inner_map) {
 		value = bpf_map_lookup_elem(inner_map, &key);
 		if (value && (value->expires_at_ns == 0 ||
-			      value->expires_at_ns > bpf_ktime_get_ns())) {
+			      value->expires_at_ns > now)) {
 			*policy_value = *value;
+			/* Rate-limited refresh: only write when remaining
+			 * TTL drops below half, so a 10-min window yields
+			 * at most one write per ~5 minutes per destination.
+			 */
+			if (refresh_ttl && value->expires_at_ns != 0 &&
+			    value->expires_at_ns - now < DNS_LEARNED_REFRESH_NS / 2)
+				value->expires_at_ns = now + DNS_LEARNED_REFRESH_NS;
 			return true;
 		}
 		/* allow_out_v2 map exists but daddr not in it or entry expired,
@@ -1014,11 +1025,20 @@ int from_cube(struct __sk_buff *skb)
 		}
 	}
 
-	/* Enforce egress network policy before NAT. */
-	if (!check_net_policy(ifindex, daddr, &policy_value)) {
-		if (proto == IPPROTO_TCP)
-			return tcp_reply_reset(skb, ifindex);
-		return TC_ACT_SHOT;
+	/* Enforce egress network policy before NAT.  For non-SYN TCP,
+	 * also refresh DNS-learned entry TTL so long-lived connections
+	 * survive DNS TTL rotation.  l4 was parsed above for TCP.
+	 */
+	{
+		bool refresh = proto == IPPROTO_TCP &&
+			       !(l4->syn && !l4->ack) &&
+			       !l4->fin && !l4->rst;
+		if (!check_net_policy(ifindex, daddr, &policy_value,
+				      refresh)) {
+			if (proto == IPPROTO_TCP)
+				return tcp_reply_reset(skb, ifindex);
+			return TC_ACT_SHOT;
+		}
 	}
 
 	ret = pull_headers(skb, &l2, &l3);


### PR DESCRIPTION
## Summary

DNS-learned `allow_out_v2` entries expire after DNS TTL, causing the eBPF datapath to RST established TCP connections — even though the L7 policy still allows the domain.

### Root Cause

1. `dns_learn_response_ip()` sets `expires_at_ns = now + DNS_TTL` for each learned IP
2. When TTL expires, `check_net_policy()` rejects subsequent packets
3. For TCP, this triggers `tcp_reply_reset()` — the sandbox sees an abrupt connection termination

### Fix

**Activity-based TTL refresh (rate-limited)** — DNS-learned entries retain their original TTL. `check_net_policy()` now accepts a `refresh_ttl` flag: when a non-SYN TCP packet matches a dynamic entry whose remaining TTL has dropped below half of `DNS_LEARNED_REFRESH_NS` (5 min), the expiration is extended by 10 min. The refresh reuses the existing LPM lookup pointer — zero extra map traversals.

| Property | Behavior |
|----------|----------|
| Active connections | Kept alive — non-SYN data packets trigger rate-limited TTL refresh |
| Idle/stale entries | Naturally expire and are cleaned up by `reapDNSLearnedPolicies` |
| Static CIDR rules | Untouched (`expires_at_ns == 0`) |
| SYN packets | No refresh — new connections validated against current DNS state |
| Extra LPM lookups per packet | **0** (reuses existing lookup pointer) |
| Write frequency | At most **once per ~5 min** per destination IP |
| Max idle timeout | **600s** (eBPF + Nginx aligned) |

CubeEgress `proxy_read_timeout` / `proxy_send_timeout` increased from 60s to 600s, aligned with the eBPF refresh window, to support long-lived HTTP streams while limiting resource holding on upstream hangs.

### Changed Files

| File | Change |
|------|--------|
| `CubeNet/src/cubevs.h` | Add `DNS_LEARNED_REFRESH_NS` constant (600s) |
| `CubeNet/src/mvmtap.bpf.c` | Add rate-limited TTL refresh inside `check_net_policy()` for non-SYN TCP on dynamic entries |
| `CubeEgress/nginx.conf` | Increase proxy timeouts from 60s to 600s |

## Test Plan

- [ ] Verify non-SYN TCP packets refresh entry expiration only when remaining TTL < 5 min
- [ ] Verify SYN packets do **not** refresh the entry
- [ ] Verify long-lived TCP connection (e.g. gRPC stream) survives multiple DNS TTL cycles
- [ ] Verify idle DNS-learned entries expire and get reaped after 10 min without traffic
- [ ] Verify static AllowOut CIDR entries (`expires_at_ns == 0`) are never modified by refresh
- [ ] Verify CubeEgress proxy timeout supports 10-min idle HTTP streams without reset
- [ ] Verify no measurable performance regression under high-pps TCP workload