### PR TITLE
feat(examples): add secure OpenCode checkpoint and fork workflow

### DIFF
--- a/docs/guide/integrations/index.md
+++ b/docs/guide/integrations/index.md
@@ -47,4 +47,5 @@ lang: en-US
 
 | Title | Author | Date | Tags |
 | --- | --- | --- | --- |
+| [OpenCode Integration Guide](./opencode.md) | Sam-Hui-dot | 2026-07-05 | integration, opencode, coding-agent, agent |
 | [Pi Agent Integration Guide](./pi-agent.md) | chaojixinren | 2026-07-01 | integration, pi-agent, coding-agent, agent |

--- a/docs/guide/integrations/opencode.md
+++ b/docs/guide/integrations/opencode.md
@@ -1,0 +1,227 @@
+---
+title: OpenCode Integration Guide
+author: Sam-Hui-dot
+date: 2026-07-05
+tags:
+  - integration
+  - opencode
+  - coding-agent
+  - agent
+lang: en-US
+---
+
+# OpenCode Integration Guide
+
+[中文文档](../../zh/guide/integrations/opencode.md)
+
+Run [OpenCode](https://opencode.ai/), an open-source terminal coding agent,
+inside CubeSandbox MicroVMs. This guide pairs with the runnable
+[`examples/opencode-integration`](https://github.com/TencentCloud/CubeSandbox/tree/master/examples/opencode-integration)
+project.
+
+## Integration Target and Version
+
+| Component | Version |
+|---|---|
+| OpenCode CLI | `opencode-ai` pinned by `OPENCODE_VERSION` build arg |
+| Node.js | 22, installed through NodeSource |
+| CubeSandbox base image | `ghcr.io/tencentcloud/cubesandbox-base:2026.16` |
+| Host SDKs | `e2b>=2.4.1`, `cubesandbox>=0.3.0` |
+| CubeSandbox platform | `>=0.3.0` for pause/resume; CubeEgress required for header injection |
+
+OpenCode's documented non-interactive mode is `opencode run [message..]`. The
+example uses:
+
+```bash
+opencode run --model <provider/model> --dir /workspace --auto --format json "<prompt>"
+```
+
+## Why Run OpenCode Inside CubeSandbox
+
+OpenCode can edit files, execute commands, install packages, and call LLM APIs.
+Running it in CubeSandbox gives each coding task a disposable MicroVM boundary:
+
+| Concern | CubeSandbox pattern |
+|---|---|
+| Isolation | One MicroVM per task or session |
+| Reproducibility | Boot from a pinned template image |
+| Fast reuse | Pause/resume preserves `/workspace` and OpenCode state |
+| Network control | Default-deny egress with explicit LLM host allow rules |
+| Secret handling | CubeEgress can inject API keys on the wire |
+| Reviewability | Host scripts verify generated files and test results |
+
+## Prerequisites
+
+- A running CubeSandbox deployment; CubeAPI reachable at `http://<node>:3000`.
+- `cubemastercli` on `$PATH`.
+- Docker plus a registry reachable from Cube nodes.
+- Python 3.10+ for host-side driver scripts.
+- An LLM provider API key supported by OpenCode.
+
+## Integration Steps
+
+### 1. Build the template image
+
+```bash
+cd examples/opencode-integration
+docker build --platform linux/amd64 \
+  -t <registry>/opencode-cube:latest .
+docker push <registry>/opencode-cube:latest
+```
+
+The image installs Node.js, OpenCode, `git`, `ripgrep`, Python, and small
+inspection tools on top of the CubeSandbox base image.
+
+### 2. Register the Cube template
+
+```bash
+cubemastercli tpl create-from-image \
+  --image <registry>/opencode-cube:latest \
+  --writable-layer-size 4G \
+  --expose-port 49983 \
+  --probe 49983 \
+  --probe-path /health
+```
+
+The inherited CubeSandbox base entrypoint keeps envd on port `49983` and serves
+the standard `/health` endpoint.
+
+### 3. Configure the host driver
+
+```bash
+cp .env.example .env
+pip install -r requirements.txt
+```
+
+Set:
+
+```bash
+E2B_API_URL=http://<node>:3000
+E2B_API_KEY=e2b_000000
+CUBE_TEMPLATE_ID=<template-id>
+OPENCODE_MODEL=openai/gpt-4.1-mini
+OPENAI_API_KEY=<provider-key>
+```
+
+For custom endpoints, set `OPENCODE_BASE_URL`; the scripts write an
+`opencode.json` in the sandbox workspace with `provider.<id>.options.baseURL`.
+
+When validating against the repository's `dev-env/` VM, set
+`CUBE_DEV_SIDECAR=1` so the host-side SDK routes sandbox traffic through
+`examples/e2b-dev-sidecar`.
+
+`network_policy.py` uses the native `cubesandbox` SDK. When running that script
+against `dev-env/`, also set:
+
+```bash
+CUBE_API_URL=http://127.0.0.1:13000
+CUBE_PROXY_NODE_IP=127.0.0.1
+CUBE_PROXY_PORT_HTTP=11080
+```
+
+### 4. Run the one-shot coding task
+
+```bash
+python run_opencode.py --dry-run
+python run_opencode.py
+```
+
+The script seeds a small Python project, runs OpenCode, then verifies:
+
+- `calculator.add` was implemented.
+- `python3 -m unittest discover -v` passes.
+- `result.md` contains the marker `OPENCODE_CUBE_OK`.
+
+### 5. Demonstrate session persistence
+
+```bash
+python resume_opencode.py
+```
+
+The first turn writes `plan.md`, pauses the sandbox, reconnects to the same
+sandbox, verifies `/workspace` and OpenCode's state directory survived, then
+continues the task and checks `OPENCODE_RESUME_OK`.
+
+### 6. Restrict egress and inject credentials
+
+```bash
+python network_policy.py
+```
+
+The strict path uses the native `cubesandbox` SDK:
+
+- `allow_internet_access=False` makes egress default-deny.
+- A CubeEgress rule allows only the configured LLM host.
+- `Inject` attaches the real provider credential as an HTTP header.
+- The sandbox process receives only a placeholder key.
+
+Use `--skip-agent` to verify policy behavior without spending LLM tokens.
+
+## Key Code Snippets
+
+Headless OpenCode command construction:
+
+```python
+opencode_command(
+    prompt,
+    workspace="/workspace",
+    model="openai/gpt-4.1-mini",
+    title="cube-opencode-demo",
+)
+```
+
+Restricted egress rule:
+
+```python
+Rule(
+    name="allow_openai_llm",
+    match=Match(scheme="https", sni="api.openai.com", host="api.openai.com"),
+    action=Action(
+        allow=True,
+        audit="metadata",
+        inject=[Inject(
+            header="Authorization",
+            secret=secret,
+            format="Bearer ${SECRET}",
+        )],
+    ),
+)
+```
+
+## Caveats
+
+- OpenCode still needs a real LLM provider key for live runs.
+- `--auto` lets OpenCode perform edits and commands without interactive approval;
+  use it only inside the isolated sandbox boundary.
+- Direct env injection in `run_opencode.py` is convenient for local validation,
+  but shared clusters should prefer `network_policy.py`.
+- Custom provider support depends on OpenCode's provider configuration and the
+  target endpoint's compatibility with the selected model.
+
+## Validation
+
+From `examples/opencode-integration`:
+
+```bash
+python3 -m py_compile env_utils.py _opencode_common.py run_opencode.py resume_opencode.py network_policy.py
+python3 -m unittest discover . -p 'test_*.py'
+bash -n build-template.sh
+docker build --platform linux/amd64 -t opencode-cube:verify .
+docker run --rm opencode-cube:verify opencode --version
+```
+
+Live CubeSandbox validation:
+
+```bash
+python run_opencode.py
+python resume_opencode.py
+python network_policy.py --skip-agent
+python network_policy.py
+```
+
+## References
+
+- [OpenCode CLI documentation](https://opencode.ai/docs/cli/)
+- [OpenCode provider documentation](https://opencode.ai/docs/providers/)
+- [CubeSandbox OpenCode example](https://github.com/TencentCloud/CubeSandbox/tree/master/examples/opencode-integration)
+- [CubeSandbox Security Proxy](../security-proxy.md)

--- a/docs/guide/integrations/opencode.md
+++ b/docs/guide/integrations/opencode.md
@@ -157,6 +157,14 @@ The strict path uses the native `cubesandbox` SDK:
 - `Inject` attaches the real provider credential as an HTTP header.
 - The sandbox process receives only a placeholder key.
 
+Set `OPENCODE_LLM_HOST` when the LLM API host differs from the provider
+default, especially when using `OPENCODE_BASE_URL` or a provider-specific
+`<PROVIDER>_BASE_URL`:
+
+```bash
+OPENCODE_LLM_HOST=api.openai.com python3 network_policy.py
+```
+
 Use `--skip-agent` to verify policy behavior without spending LLM tokens:
 
 ```bash

--- a/docs/guide/integrations/opencode.md
+++ b/docs/guide/integrations/opencode.md
@@ -103,8 +103,10 @@ OPENCODE_MODEL=openai/gpt-4.1-mini
 OPENAI_API_KEY=<provider-key>
 ```
 
-For custom endpoints, set `OPENCODE_BASE_URL`; the scripts write an
-`opencode.json` in the sandbox workspace with `provider.<id>.options.baseURL`.
+For custom endpoints, set `OPENCODE_BASE_URL`. If it is not set, the scripts
+also accept provider-specific variables such as `OPENAI_BASE_URL`. The scripts
+write an `opencode.json` in the sandbox workspace with
+`provider.<provider_prefix>.options.baseURL`.
 
 When validating against the repository's `dev-env/` VM, set
 `CUBE_DEV_SIDECAR=1` so the host-side SDK routes sandbox traffic through
@@ -122,8 +124,8 @@ CUBE_PROXY_PORT_HTTP=11080
 ### 4. Run the one-shot coding task
 
 ```bash
-python run_opencode.py --dry-run
-python run_opencode.py
+python3 run_opencode.py --dry-run
+python3 run_opencode.py
 ```
 
 The script seeds a small Python project, runs OpenCode, then verifies:
@@ -135,7 +137,7 @@ The script seeds a small Python project, runs OpenCode, then verifies:
 ### 5. Demonstrate session persistence
 
 ```bash
-python resume_opencode.py
+python3 resume_opencode.py
 ```
 
 The first turn writes `plan.md`, pauses the sandbox, reconnects to the same
@@ -145,7 +147,7 @@ continues the task and checks `OPENCODE_RESUME_OK`.
 ### 6. Restrict egress and inject credentials
 
 ```bash
-python network_policy.py
+python3 network_policy.py
 ```
 
 The strict path uses the native `cubesandbox` SDK:
@@ -155,7 +157,11 @@ The strict path uses the native `cubesandbox` SDK:
 - `Inject` attaches the real provider credential as an HTTP header.
 - The sandbox process receives only a placeholder key.
 
-Use `--skip-agent` to verify policy behavior without spending LLM tokens.
+Use `--skip-agent` to verify policy behavior without spending LLM tokens:
+
+```bash
+python3 network_policy.py --skip-agent
+```
 
 ## Key Code Snippets
 
@@ -193,10 +199,14 @@ Rule(
 - OpenCode still needs a real LLM provider key for live runs.
 - `--auto` lets OpenCode perform edits and commands without interactive approval;
   use it only inside the isolated sandbox boundary.
-- Direct env injection in `run_opencode.py` is convenient for local validation,
-  but shared clusters should prefer `network_policy.py`.
+- Direct env injection in `run_opencode.py` is convenient for local validation
+  and known secret values are redacted from failure output, but shared clusters
+  should prefer `network_policy.py`.
 - Custom provider support depends on OpenCode's provider configuration and the
   target endpoint's compatibility with the selected model.
+- The example Dockerfile uses the NodeSource setup script for readability.
+  Production images should pin and verify Node.js package sources or mirror the
+  artifacts internally.
 
 ## Validation
 
@@ -213,10 +223,10 @@ docker run --rm opencode-cube:verify opencode --version
 Live CubeSandbox validation:
 
 ```bash
-python run_opencode.py
-python resume_opencode.py
-python network_policy.py --skip-agent
-python network_policy.py
+python3 run_opencode.py
+python3 resume_opencode.py
+python3 network_policy.py --skip-agent
+python3 network_policy.py
 ```
 
 ## References

--- a/docs/guide/integrations/opencode.md
+++ b/docs/guide/integrations/opencode.md
@@ -23,10 +23,10 @@ project.
 
 | Component | Version |
 |---|---|
-| OpenCode CLI | `opencode-ai` pinned by `OPENCODE_VERSION` build arg |
-| Node.js | 22, installed through NodeSource |
+| OpenCode CLI | `opencode-ai` 1.17.13, pinned by `OPENCODE_VERSION` |
+| Node.js | 22.23.1 official archive, verified with SHA-256 |
 | CubeSandbox base image | `ghcr.io/tencentcloud/cubesandbox-base:2026.16` |
-| Host SDKs | `e2b>=2.4.1`, `cubesandbox>=0.3.0` |
+| Host SDKs | `e2b==2.7.0`, `cubesandbox==0.3.0` |
 | CubeSandbox platform | `>=0.3.0` for pause/resume; CubeEgress required for header injection |
 
 OpenCode's documented non-interactive mode is `opencode run [message..]`. The
@@ -140,11 +140,26 @@ The script seeds a small Python project, runs OpenCode, then verifies:
 python3 resume_opencode.py
 ```
 
-The first turn writes `plan.md`, pauses the sandbox, reconnects to the same
-sandbox, verifies `/workspace` and OpenCode's state directory survived, then
-continues the task and checks `OPENCODE_RESUME_OK`.
+The first turn writes `plan.md`. `sandbox.pause()` snapshots the VM and root
+filesystem; the script reconnects to the same sandbox, verifies `/workspace`
+and OpenCode's state directory survived, then continues the task and checks
+`OPENCODE_RESUME_OK`.
 
-### 6. Restrict egress and inject credentials
+### 6. Create a checkpoint, fork, and continue
+
+```bash
+python3 checkpoint_fork_opencode.py
+```
+
+This workflow runs OpenCode in a source sandbox, creates an explicit snapshot
+after turn 1, starts a new sandbox with `template=snapshot_id`, and continues
+the same OpenCode session in the fork. It proves the workspace and OpenCode
+state were inherited while the source and fork remain independent, then deletes
+the temporary snapshot. This checkpoint/fork demo uses the same direct provider
+environment style as the basic run/resume demos; use `network_policy.py` for
+the default-deny CubeEgress credential-injection path.
+
+### 7. Restrict egress and inject credentials
 
 ```bash
 python3 network_policy.py
@@ -155,7 +170,10 @@ The strict path uses the native `cubesandbox` SDK:
 - `allow_internet_access=False` makes egress default-deny.
 - A CubeEgress rule allows only the configured LLM host.
 - `Inject` attaches the real provider credential as an HTTP header.
-- The sandbox process receives only a placeholder key.
+- The VM's global environment contains no provider key.
+- The OpenCode command receives only a placeholder key.
+- The script fails if either secret invariant is violated or an unrelated host
+  is reachable.
 
 Set `OPENCODE_LLM_HOST` when the LLM API host differs from the provider
 default, especially when using `OPENCODE_BASE_URL` or a provider-specific
@@ -207,21 +225,22 @@ Rule(
 - OpenCode still needs a real LLM provider key for live runs.
 - `--auto` lets OpenCode perform edits and commands without interactive approval;
   use it only inside the isolated sandbox boundary.
-- Direct env injection in `run_opencode.py` is convenient for local validation
-  and known secret values are redacted from failure output, but shared clusters
-  should prefer `network_policy.py`.
+- Direct env injection in `run_opencode.py` is convenient for local validation;
+  only the active provider key is forwarded and known secret values are
+  redacted from failure output. Shared clusters should prefer
+  `network_policy.py` or `checkpoint_fork_opencode.py`.
 - Custom provider support depends on OpenCode's provider configuration and the
   target endpoint's compatibility with the selected model.
-- The example Dockerfile uses the NodeSource setup script for readability.
-  Production images should pin and verify Node.js package sources or mirror the
-  artifacts internally.
+- The example pins the Node.js archive and verifies its official SHA-256 before
+  extraction. Update `NODE_VERSION` and `NODE_SHA256` together after checking
+  Node.js `SHASUMS256.txt`.
 
 ## Validation
 
 From `examples/opencode-integration`:
 
 ```bash
-python3 -m py_compile env_utils.py _opencode_common.py run_opencode.py resume_opencode.py network_policy.py
+python3 -m py_compile env_utils.py _opencode_common.py run_opencode.py resume_opencode.py checkpoint_fork_opencode.py network_policy.py
 python3 -m unittest discover . -p 'test_*.py'
 bash -n build-template.sh
 docker build --platform linux/amd64 -t opencode-cube:verify .
@@ -233,6 +252,7 @@ Live CubeSandbox validation:
 ```bash
 python3 run_opencode.py
 python3 resume_opencode.py
+python3 checkpoint_fork_opencode.py
 python3 network_policy.py --skip-agent
 python3 network_policy.py
 ```

--- a/docs/guide/integrations/opencode.md
+++ b/docs/guide/integrations/opencode.md
@@ -25,7 +25,7 @@ project.
 |---|---|
 | OpenCode CLI | `opencode-ai` 1.17.13, pinned by `OPENCODE_VERSION` |
 | Node.js | 22.23.1 official archive, verified with SHA-256 |
-| CubeSandbox base image | `ghcr.io/tencentcloud/cubesandbox-base:2026.16` |
+| CubeSandbox base image | `ghcr.io/tencentcloud/cubesandbox-base:2026.16`, pinned by digest |
 | Host SDKs | `e2b==2.7.0`, `cubesandbox==0.3.0` |
 | CubeSandbox platform | `>=0.3.0` for pause/resume; CubeEgress required for header injection |
 
@@ -112,8 +112,8 @@ When validating against the repository's `dev-env/` VM, set
 `CUBE_DEV_SIDECAR=1` so the host-side SDK routes sandbox traffic through
 `examples/e2b-dev-sidecar`.
 
-`network_policy.py` uses the native `cubesandbox` SDK. When running that script
-against `dev-env/`, also set:
+`network_policy.py` and `checkpoint_fork_opencode.py` use the native
+`cubesandbox` SDK. When running either script against `dev-env/`, also set:
 
 ```bash
 CUBE_API_URL=http://127.0.0.1:13000
@@ -155,9 +155,10 @@ This workflow runs OpenCode in a source sandbox, creates an explicit snapshot
 after turn 1, starts a new sandbox with `template=snapshot_id`, and continues
 the same OpenCode session in the fork. It proves the workspace and OpenCode
 state were inherited while the source and fork remain independent, then deletes
-the temporary snapshot. This checkpoint/fork demo uses the same direct provider
-environment style as the basic run/resume demos; use `network_policy.py` for
-the default-deny CubeEgress credential-injection path.
+the temporary snapshot. Both sandboxes use default-deny egress and the same
+LLM-host allow rule. CubeEgress injects the real provider credential on the
+wire, and the workflow verifies that both OpenCode commands receive only a
+placeholder key while unrelated hosts remain blocked.
 
 ### 7. Restrict egress and inject credentials
 
@@ -240,7 +241,7 @@ Rule(
 From `examples/opencode-integration`:
 
 ```bash
-python3 -m py_compile env_utils.py _opencode_common.py run_opencode.py resume_opencode.py checkpoint_fork_opencode.py network_policy.py
+python3 -m py_compile env_utils.py _opencode_common.py egress_policy.py run_opencode.py resume_opencode.py checkpoint_fork_opencode.py network_policy.py
 python3 -m unittest discover . -p 'test_*.py'
 bash -n build-template.sh
 docker build --platform linux/amd64 -t opencode-cube:verify .

--- a/docs/zh/guide/integrations/index.md
+++ b/docs/zh/guide/integrations/index.md
@@ -47,4 +47,5 @@ lang: zh-CN
 
 | 标题 | 作者 | 日期 | 标签 |
 | --- | --- | --- | --- |
+| [OpenCode 集成指南](./opencode.md) | Sam-Hui-dot | 2026-07-05 | integration, opencode, coding-agent, agent |
 | [Pi Agent 集成指南](./pi-agent.md) | chaojixinren | 2026-07-01 | integration, pi-agent, coding-agent, agent |

--- a/docs/zh/guide/integrations/opencode.md
+++ b/docs/zh/guide/integrations/opencode.md
@@ -150,6 +150,13 @@ python3 network_policy.py
 - `Inject` 在 HTTP header 中注入真实 provider 凭证。
 - 沙箱进程只能看到占位 key。
 
+当 LLM API host 与 provider 默认值不一致时（尤其使用 `OPENCODE_BASE_URL`
+或 provider-specific `<PROVIDER>_BASE_URL` 时），请设置 `OPENCODE_LLM_HOST`：
+
+```bash
+OPENCODE_LLM_HOST=api.openai.com python3 network_policy.py
+```
+
 可用 `--skip-agent` 只验证策略，不消耗 LLM token：
 
 ```bash

--- a/docs/zh/guide/integrations/opencode.md
+++ b/docs/zh/guide/integrations/opencode.md
@@ -100,8 +100,9 @@ OPENCODE_MODEL=openai/gpt-4.1-mini
 OPENAI_API_KEY=<provider-key>
 ```
 
-自定义端点可设置 `OPENCODE_BASE_URL`；脚本会在沙箱工作目录写入
-`opencode.json`，配置 `provider.<id>.options.baseURL`。
+自定义端点可设置 `OPENCODE_BASE_URL`；如果未设置，脚本也接受 provider-specific
+变量，例如 `OPENAI_BASE_URL`。脚本会在沙箱工作目录写入 `opencode.json`，
+配置 `provider.<provider_prefix>.options.baseURL`。
 
 如果使用本仓库的 `dev-env/` VM 验证，设置 `CUBE_DEV_SIDECAR=1`，让宿主端 SDK
 通过 `examples/e2b-dev-sidecar` 转发 sandbox 流量。
@@ -117,8 +118,8 @@ CUBE_PROXY_PORT_HTTP=11080
 ### 4. 运行一次性编码任务
 
 ```bash
-python run_opencode.py --dry-run
-python run_opencode.py
+python3 run_opencode.py --dry-run
+python3 run_opencode.py
 ```
 
 脚本会放入一个小型 Python 项目，运行 OpenCode，并验证：
@@ -130,7 +131,7 @@ python run_opencode.py
 ### 5. 演示会话保持
 
 ```bash
-python resume_opencode.py
+python3 resume_opencode.py
 ```
 
 第一轮写入 `plan.md`，暂停沙箱，再连接同一个 sandbox；脚本验证 `/workspace`
@@ -139,7 +140,7 @@ python resume_opencode.py
 ### 6. 限制出网并注入凭证
 
 ```bash
-python network_policy.py
+python3 network_policy.py
 ```
 
 严格模式使用原生 `cubesandbox` SDK：
@@ -149,7 +150,11 @@ python network_policy.py
 - `Inject` 在 HTTP header 中注入真实 provider 凭证。
 - 沙箱进程只能看到占位 key。
 
-可用 `--skip-agent` 只验证策略，不消耗 LLM token。
+可用 `--skip-agent` 只验证策略，不消耗 LLM token：
+
+```bash
+python3 network_policy.py --skip-agent
+```
 
 ## 关键代码片段
 
@@ -186,9 +191,11 @@ Rule(
 
 - live 运行仍需要真实 LLM provider key。
 - `--auto` 会让 OpenCode 无需交互确认即可编辑和执行命令，应放在隔离沙箱内使用。
-- `run_opencode.py` 的直接 env 注入适合本地验证；共享集群建议使用
-  `network_policy.py`。
+- `run_opencode.py` 的直接 env 注入适合本地验证，并会在失败输出中脱敏已知
+  secret；共享集群建议使用 `network_policy.py`。
 - 自定义 provider 取决于 OpenCode provider 配置以及目标端点对所选模型的兼容性。
+- 示例 Dockerfile 为了可读性使用 NodeSource setup script；生产镜像建议 pin
+  并校验 Node.js 包来源，或使用内部镜像源。
 
 ## 验证
 
@@ -205,10 +212,10 @@ docker run --rm opencode-cube:verify opencode --version
 live CubeSandbox 验证：
 
 ```bash
-python run_opencode.py
-python resume_opencode.py
-python network_policy.py --skip-agent
-python network_policy.py
+python3 run_opencode.py
+python3 resume_opencode.py
+python3 network_policy.py --skip-agent
+python3 network_policy.py
 ```
 
 ## 参考

--- a/docs/zh/guide/integrations/opencode.md
+++ b/docs/zh/guide/integrations/opencode.md
@@ -22,10 +22,10 @@ lang: zh-CN
 
 | 组件 | 版本 |
 |---|---|
-| OpenCode CLI | 通过 `OPENCODE_VERSION` build arg 固定的 `opencode-ai` |
-| Node.js | 22，通过 NodeSource 安装 |
+| OpenCode CLI | 通过 `OPENCODE_VERSION` 固定的 `opencode-ai` 1.17.13 |
+| Node.js | Node.js 官方 22.23.1 归档，经过 SHA-256 校验 |
 | CubeSandbox 基础镜像 | `ghcr.io/tencentcloud/cubesandbox-base:2026.16` |
-| 宿主端 SDK | `e2b>=2.4.1`、`cubesandbox>=0.3.0` |
+| 宿主端 SDK | `e2b==2.7.0`、`cubesandbox==0.3.0` |
 | CubeSandbox 平台 | pause/resume 需要 `>=0.3.0`；header 注入需要 CubeEgress |
 
 OpenCode 官方的非交互模式是 `opencode run [message..]`。本示例使用：
@@ -134,10 +134,23 @@ python3 run_opencode.py
 python3 resume_opencode.py
 ```
 
-第一轮写入 `plan.md`，暂停沙箱，再连接同一个 sandbox；脚本验证 `/workspace`
-和 OpenCode 状态目录仍存在，然后继续任务并检查 `OPENCODE_RESUME_OK`。
+第一轮写入 `plan.md`；`sandbox.pause()` 会保存 VM 和根文件系统快照。脚本再连接
+同一个 sandbox，验证 `/workspace` 和 OpenCode 状态目录仍存在，然后继续任务并
+检查 `OPENCODE_RESUME_OK`。
 
-### 6. 限制出网并注入凭证
+### 6. 创建 checkpoint、fork 并继续任务
+
+```bash
+python3 checkpoint_fork_opencode.py
+```
+
+该流程在 source sandbox 中运行 OpenCode，在第一轮后创建显式 snapshot，使用
+`template=snapshot_id` 启动新 sandbox，并在 fork 中继续同一个 OpenCode 会话。
+它证明 workspace 和 OpenCode 状态已继承、source 与 fork 相互独立，最后删除临时
+snapshot。该 checkpoint/fork demo 使用与基础 run/resume demo 相同的直接 provider
+环境变量方式；默认拒绝出网与 CubeEgress 凭证注入路径由 `network_policy.py` 验证。
+
+### 7. 限制出网并注入凭证
 
 ```bash
 python3 network_policy.py
@@ -148,7 +161,9 @@ python3 network_policy.py
 - `allow_internet_access=False` 将出网设为默认拒绝。
 - CubeEgress rule 只允许配置的 LLM host。
 - `Inject` 在 HTTP header 中注入真实 provider 凭证。
-- 沙箱进程只能看到占位 key。
+- VM 全局环境中没有 provider key。
+- OpenCode 命令环境中只能看到占位 key。
+- 如果任一 secret 条件不满足，或无关 host 可以访问，脚本会直接失败。
 
 当 LLM API host 与 provider 默认值不一致时（尤其使用 `OPENCODE_BASE_URL`
 或 provider-specific `<PROVIDER>_BASE_URL` 时），请设置 `OPENCODE_LLM_HOST`：
@@ -198,18 +213,19 @@ Rule(
 
 - live 运行仍需要真实 LLM provider key。
 - `--auto` 会让 OpenCode 无需交互确认即可编辑和执行命令，应放在隔离沙箱内使用。
-- `run_opencode.py` 的直接 env 注入适合本地验证，并会在失败输出中脱敏已知
-  secret；共享集群建议使用 `network_policy.py`。
+- `run_opencode.py` 的直接 env 注入适合本地验证；它只传递当前 provider 的 key，
+  并会在失败输出中脱敏已知 secret。共享集群建议使用 `network_policy.py` 或
+  `checkpoint_fork_opencode.py`。
 - 自定义 provider 取决于 OpenCode provider 配置以及目标端点对所选模型的兼容性。
-- 示例 Dockerfile 为了可读性使用 NodeSource setup script；生产镜像建议 pin
-  并校验 Node.js 包来源，或使用内部镜像源。
+- 示例固定 Node.js 官方归档并在解压前校验 SHA-256。更新时应对照 Node.js
+  `SHASUMS256.txt` 同时修改 `NODE_VERSION` 和 `NODE_SHA256`。
 
 ## 验证
 
 在 `examples/opencode-integration` 下执行：
 
 ```bash
-python3 -m py_compile env_utils.py _opencode_common.py run_opencode.py resume_opencode.py network_policy.py
+python3 -m py_compile env_utils.py _opencode_common.py run_opencode.py resume_opencode.py checkpoint_fork_opencode.py network_policy.py
 python3 -m unittest discover . -p 'test_*.py'
 bash -n build-template.sh
 docker build --platform linux/amd64 -t opencode-cube:verify .
@@ -221,6 +237,7 @@ live CubeSandbox 验证：
 ```bash
 python3 run_opencode.py
 python3 resume_opencode.py
+python3 checkpoint_fork_opencode.py
 python3 network_policy.py --skip-agent
 python3 network_policy.py
 ```

--- a/docs/zh/guide/integrations/opencode.md
+++ b/docs/zh/guide/integrations/opencode.md
@@ -1,0 +1,219 @@
+---
+title: OpenCode 集成指南
+author: Sam-Hui-dot
+date: 2026-07-05
+tags:
+  - integration
+  - opencode
+  - coding-agent
+  - agent
+lang: zh-CN
+---
+
+# OpenCode 集成指南
+
+[English](../../../guide/integrations/opencode.md)
+
+本指南介绍如何在 CubeSandbox MicroVM 中运行
+[OpenCode](https://opencode.ai/) 这类开源终端编码 Agent。可运行示例位于
+[`examples/opencode-integration`](https://github.com/TencentCloud/CubeSandbox/tree/master/examples/opencode-integration)。
+
+## 集成目标与版本
+
+| 组件 | 版本 |
+|---|---|
+| OpenCode CLI | 通过 `OPENCODE_VERSION` build arg 固定的 `opencode-ai` |
+| Node.js | 22，通过 NodeSource 安装 |
+| CubeSandbox 基础镜像 | `ghcr.io/tencentcloud/cubesandbox-base:2026.16` |
+| 宿主端 SDK | `e2b>=2.4.1`、`cubesandbox>=0.3.0` |
+| CubeSandbox 平台 | pause/resume 需要 `>=0.3.0`；header 注入需要 CubeEgress |
+
+OpenCode 官方的非交互模式是 `opencode run [message..]`。本示例使用：
+
+```bash
+opencode run --model <provider/model> --dir /workspace --auto --format json "<prompt>"
+```
+
+## 为什么放进 CubeSandbox
+
+OpenCode 可以编辑文件、执行命令、安装依赖并访问 LLM API。放入 CubeSandbox 后，
+每次编码任务都拥有独立 MicroVM 边界：
+
+| 关注点 | CubeSandbox 模式 |
+|---|---|
+| 隔离性 | 每个任务或会话一个 MicroVM |
+| 可复现 | 从固定模板镜像启动 |
+| 快速复用 | pause/resume 保留 `/workspace` 和 OpenCode 状态 |
+| 网络控制 | 默认拒绝出网，只放行 LLM host |
+| 密钥处理 | CubeEgress 在链路上注入 API key |
+| 可审查 | 宿主端脚本验证生成文件和测试结果 |
+
+## 前置条件
+
+- 已部署 CubeSandbox，CubeAPI 可通过 `http://<node>:3000` 访问。
+- `cubemastercli` 已在 `$PATH` 中。
+- Docker 和 Cube 节点可拉取的镜像仓库。
+- 宿主端 Python 3.10+。
+- 一个 OpenCode 支持的 LLM provider API key。
+
+## 集成步骤
+
+### 1. 构建模板镜像
+
+```bash
+cd examples/opencode-integration
+docker build --platform linux/amd64 \
+  -t <registry>/opencode-cube:latest .
+docker push <registry>/opencode-cube:latest
+```
+
+镜像基于 CubeSandbox base，安装 Node.js、OpenCode、`git`、`ripgrep`、Python
+以及少量排查工具。
+
+### 2. 注册 Cube 模板
+
+```bash
+cubemastercli tpl create-from-image \
+  --image <registry>/opencode-cube:latest \
+  --writable-layer-size 4G \
+  --expose-port 49983 \
+  --probe 49983 \
+  --probe-path /health
+```
+
+基础镜像入口会保持 envd 监听 `49983`，并提供标准 `/health` endpoint。
+
+### 3. 配置宿主端脚本
+
+```bash
+cp .env.example .env
+pip install -r requirements.txt
+```
+
+填写：
+
+```bash
+E2B_API_URL=http://<node>:3000
+E2B_API_KEY=e2b_000000
+CUBE_TEMPLATE_ID=<template-id>
+OPENCODE_MODEL=openai/gpt-4.1-mini
+OPENAI_API_KEY=<provider-key>
+```
+
+自定义端点可设置 `OPENCODE_BASE_URL`；脚本会在沙箱工作目录写入
+`opencode.json`，配置 `provider.<id>.options.baseURL`。
+
+如果使用本仓库的 `dev-env/` VM 验证，设置 `CUBE_DEV_SIDECAR=1`，让宿主端 SDK
+通过 `examples/e2b-dev-sidecar` 转发 sandbox 流量。
+
+`network_policy.py` 使用原生 `cubesandbox` SDK。用 `dev-env/` 跑这个脚本时，还需要设置：
+
+```bash
+CUBE_API_URL=http://127.0.0.1:13000
+CUBE_PROXY_NODE_IP=127.0.0.1
+CUBE_PROXY_PORT_HTTP=11080
+```
+
+### 4. 运行一次性编码任务
+
+```bash
+python run_opencode.py --dry-run
+python run_opencode.py
+```
+
+脚本会放入一个小型 Python 项目，运行 OpenCode，并验证：
+
+- `calculator.add` 已实现。
+- `python3 -m unittest discover -v` 通过。
+- `result.md` 包含 `OPENCODE_CUBE_OK`。
+
+### 5. 演示会话保持
+
+```bash
+python resume_opencode.py
+```
+
+第一轮写入 `plan.md`，暂停沙箱，再连接同一个 sandbox；脚本验证 `/workspace`
+和 OpenCode 状态目录仍存在，然后继续任务并检查 `OPENCODE_RESUME_OK`。
+
+### 6. 限制出网并注入凭证
+
+```bash
+python network_policy.py
+```
+
+严格模式使用原生 `cubesandbox` SDK：
+
+- `allow_internet_access=False` 将出网设为默认拒绝。
+- CubeEgress rule 只允许配置的 LLM host。
+- `Inject` 在 HTTP header 中注入真实 provider 凭证。
+- 沙箱进程只能看到占位 key。
+
+可用 `--skip-agent` 只验证策略，不消耗 LLM token。
+
+## 关键代码片段
+
+构造非交互 OpenCode 命令：
+
+```python
+opencode_command(
+    prompt,
+    workspace="/workspace",
+    model="openai/gpt-4.1-mini",
+    title="cube-opencode-demo",
+)
+```
+
+受限出网规则：
+
+```python
+Rule(
+    name="allow_openai_llm",
+    match=Match(scheme="https", sni="api.openai.com", host="api.openai.com"),
+    action=Action(
+        allow=True,
+        audit="metadata",
+        inject=[Inject(
+            header="Authorization",
+            secret=secret,
+            format="Bearer ${SECRET}",
+        )],
+    ),
+)
+```
+
+## 注意事项
+
+- live 运行仍需要真实 LLM provider key。
+- `--auto` 会让 OpenCode 无需交互确认即可编辑和执行命令，应放在隔离沙箱内使用。
+- `run_opencode.py` 的直接 env 注入适合本地验证；共享集群建议使用
+  `network_policy.py`。
+- 自定义 provider 取决于 OpenCode provider 配置以及目标端点对所选模型的兼容性。
+
+## 验证
+
+在 `examples/opencode-integration` 下执行：
+
+```bash
+python3 -m py_compile env_utils.py _opencode_common.py run_opencode.py resume_opencode.py network_policy.py
+python3 -m unittest discover . -p 'test_*.py'
+bash -n build-template.sh
+docker build --platform linux/amd64 -t opencode-cube:verify .
+docker run --rm opencode-cube:verify opencode --version
+```
+
+live CubeSandbox 验证：
+
+```bash
+python run_opencode.py
+python resume_opencode.py
+python network_policy.py --skip-agent
+python network_policy.py
+```
+
+## 参考
+
+- [OpenCode CLI 文档](https://opencode.ai/docs/cli/)
+- [OpenCode provider 文档](https://opencode.ai/docs/providers/)
+- [CubeSandbox OpenCode 示例](https://github.com/TencentCloud/CubeSandbox/tree/master/examples/opencode-integration)
+- [CubeSandbox Security Proxy](../../../guide/security-proxy.md)

--- a/docs/zh/guide/integrations/opencode.md
+++ b/docs/zh/guide/integrations/opencode.md
@@ -24,7 +24,7 @@ lang: zh-CN
 |---|---|
 | OpenCode CLI | 通过 `OPENCODE_VERSION` 固定的 `opencode-ai` 1.17.13 |
 | Node.js | Node.js 官方 22.23.1 归档，经过 SHA-256 校验 |
-| CubeSandbox 基础镜像 | `ghcr.io/tencentcloud/cubesandbox-base:2026.16` |
+| CubeSandbox 基础镜像 | `ghcr.io/tencentcloud/cubesandbox-base:2026.16`，通过 digest 固定 |
 | 宿主端 SDK | `e2b==2.7.0`、`cubesandbox==0.3.0` |
 | CubeSandbox 平台 | pause/resume 需要 `>=0.3.0`；header 注入需要 CubeEgress |
 
@@ -107,7 +107,8 @@ OPENAI_API_KEY=<provider-key>
 如果使用本仓库的 `dev-env/` VM 验证，设置 `CUBE_DEV_SIDECAR=1`，让宿主端 SDK
 通过 `examples/e2b-dev-sidecar` 转发 sandbox 流量。
 
-`network_policy.py` 使用原生 `cubesandbox` SDK。用 `dev-env/` 跑这个脚本时，还需要设置：
+`network_policy.py` 和 `checkpoint_fork_opencode.py` 使用原生 `cubesandbox` SDK。
+用 `dev-env/` 跑任一脚本时，还需要设置：
 
 ```bash
 CUBE_API_URL=http://127.0.0.1:13000
@@ -147,8 +148,9 @@ python3 checkpoint_fork_opencode.py
 该流程在 source sandbox 中运行 OpenCode，在第一轮后创建显式 snapshot，使用
 `template=snapshot_id` 启动新 sandbox，并在 fork 中继续同一个 OpenCode 会话。
 它证明 workspace 和 OpenCode 状态已继承、source 与 fork 相互独立，最后删除临时
-snapshot。该 checkpoint/fork demo 使用与基础 run/resume demo 相同的直接 provider
-环境变量方式；默认拒绝出网与 CubeEgress 凭证注入路径由 `network_policy.py` 验证。
+snapshot。两个 sandbox 都使用默认拒绝出网与同一条 LLM host 放行规则；真实 provider
+凭证由 CubeEgress 在链路上注入。脚本会验证两次 OpenCode 命令环境中都只有占位 key，
+且无关 host 始终被阻断。
 
 ### 7. 限制出网并注入凭证
 
@@ -225,7 +227,7 @@ Rule(
 在 `examples/opencode-integration` 下执行：
 
 ```bash
-python3 -m py_compile env_utils.py _opencode_common.py run_opencode.py resume_opencode.py checkpoint_fork_opencode.py network_policy.py
+python3 -m py_compile env_utils.py _opencode_common.py egress_policy.py run_opencode.py resume_opencode.py checkpoint_fork_opencode.py network_policy.py
 python3 -m unittest discover . -p 'test_*.py'
 bash -n build-template.sh
 docker build --platform linux/amd64 -t opencode-cube:verify .

--- a/examples/opencode-integration/.dockerignore
+++ b/examples/opencode-integration/.dockerignore
@@ -1,0 +1,3 @@
+*
+!Dockerfile
+!.dockerignore

--- a/examples/opencode-integration/.env.example
+++ b/examples/opencode-integration/.env.example
@@ -44,14 +44,16 @@ OPENAI_API_KEY="<your-openai-api-key>"
 # OPENCODE_WORKSPACE="/workspace"
 # OPENCODE_SANDBOX_TIMEOUT="1800"
 # OPENCODE_EXEC_TIMEOUT="900"
+# OPENCODE_DISABLE_AUTOUPDATE="1"
 
 # Optional: only for this repository's dev-env VM. It patches the E2B SDK to
 # route sandbox traffic through examples/e2b-dev-sidecar.
 # CUBE_DEV_SIDECAR="1"
 
-# Required for network_policy.py: it uses the native cubesandbox SDK rather
-# than the E2B SDK. Set CubeAPI plus the CubeProxy address used for envd command
-# streams. For this repository's dev-env VM, use the forwarded values below.
+# Required for network_policy.py and checkpoint_fork_opencode.py: they use the
+# native cubesandbox SDK rather than the E2B SDK. Set CubeAPI plus the CubeProxy
+# address used for envd command streams. For this repository's dev-env VM, use
+# the forwarded values below.
 # CUBE_API_URL="http://127.0.0.1:13000"
 # CUBE_PROXY_NODE_IP="127.0.0.1"
 # CUBE_PROXY_PORT_HTTP="11080"

--- a/examples/opencode-integration/.env.example
+++ b/examples/opencode-integration/.env.example
@@ -49,9 +49,9 @@ OPENAI_API_KEY="<your-openai-api-key>"
 # route sandbox traffic through examples/e2b-dev-sidecar.
 # CUBE_DEV_SIDECAR="1"
 
-# Optional: only for network_policy.py against this repository's dev-env VM.
-# The native cubesandbox SDK needs the CubeAPI URL plus the local CubeProxy
-# HTTP forward when it opens envd command streams.
+# Required for network_policy.py: it uses the native cubesandbox SDK rather
+# than the E2B SDK. Set CubeAPI plus the CubeProxy address used for envd command
+# streams. For this repository's dev-env VM, use the forwarded values below.
 # CUBE_API_URL="http://127.0.0.1:13000"
 # CUBE_PROXY_NODE_IP="127.0.0.1"
 # CUBE_PROXY_PORT_HTTP="11080"

--- a/examples/opencode-integration/.env.example
+++ b/examples/opencode-integration/.env.example
@@ -29,9 +29,12 @@ OPENAI_API_KEY="<your-openai-api-key>"
 # DEEPSEEK_API_KEY="<your-deepseek-api-key>"
 # OPENROUTER_API_KEY="<your-openrouter-api-key>"
 
-# Optional: override the provider base URL. The example writes opencode.json
-# with provider.<prefix>.options.baseURL when this is set.
+# Optional: override the provider base URL. OPENCODE_BASE_URL wins; if it is
+# unset, the scripts also accept <PROVIDER>_BASE_URL, for example
+# OPENAI_BASE_URL. The example writes opencode.json with
+# provider.<provider_prefix>.options.baseURL when either value is set.
 # OPENCODE_BASE_URL="https://api.openai.com/v1"
+# OPENAI_BASE_URL="https://api.openai.com/v1"
 
 # Optional (network_policy.py): LLM host allowed under default-deny egress.
 # Defaults to OPENCODE_BASE_URL host or the provider's known default host.

--- a/examples/opencode-integration/.env.example
+++ b/examples/opencode-integration/.env.example
@@ -1,0 +1,54 @@
+# --- CubeSandbox connection ---
+
+# Required: CubeAPI address (use CubeAPI, not CubeProxy).
+E2B_API_URL="http://<cube-host>:3000"
+
+# Required: any non-empty value in local dev; a real key when auth is enabled.
+E2B_API_KEY="e2b_000000"
+
+# Required: template built from this example's Dockerfile.
+CUBE_TEMPLATE_ID="<template-id>"
+
+# Optional: only when talking to CubeProxy over HTTPS with Cube's mkcert cert.
+# SSL_CERT_FILE="/root/.local/share/mkcert/rootCA.pem"
+
+# --- OpenCode agent ---
+
+# Required: OpenCode model in provider/model form.
+# Examples:
+#   openai/gpt-4.1-mini
+#   anthropic/claude-sonnet-4-6
+#   deepseek/deepseek-chat
+#   openrouter/anthropic/claude-sonnet-4
+OPENCODE_MODEL="openai/gpt-4.1-mini"
+
+# Required: API key for the provider prefix in OPENCODE_MODEL.
+OPENAI_API_KEY="<your-openai-api-key>"
+# Other common providers:
+# ANTHROPIC_API_KEY="<your-anthropic-api-key>"
+# DEEPSEEK_API_KEY="<your-deepseek-api-key>"
+# OPENROUTER_API_KEY="<your-openrouter-api-key>"
+
+# Optional: override the provider base URL. The example writes opencode.json
+# with provider.<prefix>.options.baseURL when this is set.
+# OPENCODE_BASE_URL="https://api.openai.com/v1"
+
+# Optional (network_policy.py): LLM host allowed under default-deny egress.
+# Defaults to OPENCODE_BASE_URL host or the provider's known default host.
+# OPENCODE_LLM_HOST="api.openai.com"
+
+# Optional: tune execution.
+# OPENCODE_WORKSPACE="/workspace"
+# OPENCODE_SANDBOX_TIMEOUT="1800"
+# OPENCODE_EXEC_TIMEOUT="900"
+
+# Optional: only for this repository's dev-env VM. It patches the E2B SDK to
+# route sandbox traffic through examples/e2b-dev-sidecar.
+# CUBE_DEV_SIDECAR="1"
+
+# Optional: only for network_policy.py against this repository's dev-env VM.
+# The native cubesandbox SDK needs the CubeAPI URL plus the local CubeProxy
+# HTTP forward when it opens envd command streams.
+# CUBE_API_URL="http://127.0.0.1:13000"
+# CUBE_PROXY_NODE_IP="127.0.0.1"
+# CUBE_PROXY_PORT_HTTP="11080"

--- a/examples/opencode-integration/.env.example
+++ b/examples/opencode-integration/.env.example
@@ -36,7 +36,8 @@ OPENAI_API_KEY="<your-openai-api-key>"
 # OPENCODE_BASE_URL="https://api.openai.com/v1"
 # OPENAI_BASE_URL="https://api.openai.com/v1"
 
-# Optional (network_policy.py): LLM host allowed under default-deny egress.
+# Optional (network_policy.py and checkpoint_fork_opencode.py): LLM host
+# allowed under default-deny egress.
 # Defaults to OPENCODE_BASE_URL host or the provider's known default host.
 # OPENCODE_LLM_HOST="api.openai.com"
 

--- a/examples/opencode-integration/Dockerfile
+++ b/examples/opencode-integration/Dockerfile
@@ -9,7 +9,8 @@ ARG CUBE_BASE_IMAGE=ghcr.io/tencentcloud/cubesandbox-base:2026.16
 FROM ${CUBE_BASE_IMAGE}
 
 ARG DEBIAN_FRONTEND=noninteractive
-ARG NODE_MAJOR=22
+ARG NODE_VERSION=22.23.1
+ARG NODE_SHA256=7a8cb04b4a1df4eaf432125324b81b29a088e73570a23259a8de1c65d07fc129
 ARG OPENCODE_VERSION=1.17.13
 
 RUN apt-get update \
@@ -18,23 +19,30 @@ RUN apt-get update \
         ca-certificates \
         curl \
         git \
-        gnupg \
         jq \
         less \
         procps \
         python3 \
         python3-pip \
         ripgrep \
-    && curl -fsSL "https://deb.nodesource.com/setup_${NODE_MAJOR}.x" | bash - \
-    && apt-get install -y --no-install-recommends nodejs \
     && rm -rf /var/lib/apt/lists/*
+
+RUN curl -fsSLo /tmp/node.tar.gz \
+        "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-x64.tar.gz" \
+    && echo "${NODE_SHA256}  /tmp/node.tar.gz" | sha256sum --check --strict \
+    && tar -xzf /tmp/node.tar.gz -C /usr/local --strip-components=1 --no-same-owner \
+    && rm -f /tmp/node.tar.gz \
+    && node --version \
+    && npm --version
 
 RUN npm install -g "opencode-ai@${OPENCODE_VERSION}" \
     && opencode --version \
     && npm cache clean --force \
     && rm -rf /root/.npm
 
-ENV OPENCODE_DISABLE_AUTO_UPDATE=1 \
+ENV OPENCODE_DISABLE_AUTOUPDATE=1 \
+    OPENCODE_DISABLE_PRUNE=1 \
+    OPENCODE_DISABLE_TERMINAL_TITLE=1 \
     NPM_CONFIG_UPDATE_NOTIFIER=false
 
 RUN mkdir -p /workspace /root/.local/share/opencode /root/.config/opencode

--- a/examples/opencode-integration/Dockerfile
+++ b/examples/opencode-integration/Dockerfile
@@ -1,0 +1,44 @@
+# syntax=docker/dockerfile:1.7
+#
+# OpenCode inside a CubeSandbox template.
+#
+# The inherited cube-entrypoint keeps envd running on :49983 and serves
+# /health, so Cube can use the standard readiness probe.
+
+ARG CUBE_BASE_IMAGE=ghcr.io/tencentcloud/cubesandbox-base:2026.16
+FROM ${CUBE_BASE_IMAGE}
+
+ARG DEBIAN_FRONTEND=noninteractive
+ARG NODE_MAJOR=22
+ARG OPENCODE_VERSION=1.17.13
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        bash \
+        ca-certificates \
+        curl \
+        git \
+        gnupg \
+        jq \
+        less \
+        procps \
+        python3 \
+        python3-pip \
+        ripgrep \
+    && curl -fsSL "https://deb.nodesource.com/setup_${NODE_MAJOR}.x" | bash - \
+    && apt-get install -y --no-install-recommends nodejs \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN npm install -g "opencode-ai@${OPENCODE_VERSION}" \
+    && opencode --version \
+    && npm cache clean --force \
+    && rm -rf /root/.npm
+
+ENV OPENCODE_DISABLE_AUTO_UPDATE=1 \
+    NPM_CONFIG_UPDATE_NOTIFIER=false
+
+RUN mkdir -p /workspace /root/.local/share/opencode /root/.config/opencode
+
+WORKDIR /workspace
+
+EXPOSE 49983

--- a/examples/opencode-integration/Dockerfile
+++ b/examples/opencode-integration/Dockerfile
@@ -5,7 +5,7 @@
 # The inherited cube-entrypoint keeps envd running on :49983 and serves
 # /health, so Cube can use the standard readiness probe.
 
-ARG CUBE_BASE_IMAGE=ghcr.io/tencentcloud/cubesandbox-base:2026.16
+ARG CUBE_BASE_IMAGE=ghcr.io/tencentcloud/cubesandbox-base:2026.16@sha256:34ea312a63a5534e66ab17005c23d7fbaf33c38bccd5411ee402d901e63a3193
 FROM ${CUBE_BASE_IMAGE}
 
 ARG DEBIAN_FRONTEND=noninteractive

--- a/examples/opencode-integration/README.md
+++ b/examples/opencode-integration/README.md
@@ -18,9 +18,13 @@ opencode-integration/
 |-- _opencode_common.py     # Sandbox command helpers
 |-- run_opencode.py         # One-shot coding-agent demo
 |-- resume_opencode.py      # pause/resume session persistence demo
+|-- checkpoint_fork_opencode.py # checkpoint, fork, and continue demo
 |-- network_policy.py       # Default-deny egress + CubeEgress injection demo
 |-- test_env_utils.py       # Unit tests for config handling
 |-- test_commands.py        # Unit tests for command construction
+|-- test_network_policy.py  # Security-policy assertion tests
+|-- test_opencode_common.py # Sandbox helper tests
+|-- test_workflows.py       # Mocked end-to-end orchestration tests
 `-- requirements.txt        # Host-side Python dependencies
 ```
 
@@ -40,8 +44,8 @@ docker build --platform linux/amd64 -t <registry>/opencode-cube:latest .
 docker push <registry>/opencode-cube:latest
 ```
 
-The image installs Node.js 22 and `opencode-ai` on top of
-`ghcr.io/tencentcloud/cubesandbox-base:2026.16`.
+The image installs checksum-verified Node.js 22.23.1 and OpenCode 1.17.13 on top
+of `ghcr.io/tencentcloud/cubesandbox-base:2026.16`.
 
 ## 2. Register a CubeSandbox template
 
@@ -118,11 +122,26 @@ that `result.md` contains `OPENCODE_CUBE_OK`.
 python3 resume_opencode.py
 ```
 
-The first turn asks OpenCode to write `plan.md`, pauses the sandbox, reconnects
-to the same sandbox ID, verifies `/workspace` and OpenCode state survived, then
-continues the task and checks for `OPENCODE_RESUME_OK`.
+The first turn asks OpenCode to write `plan.md`. `sandbox.pause()` snapshots the
+VM and root filesystem; the script reconnects to the same sandbox ID, verifies
+`/workspace` and OpenCode state survived, then continues the task and checks for
+`OPENCODE_RESUME_OK`.
 
-## 6. Run with restricted egress
+## 6. Create a reusable checkpoint and fork the task
+
+```bash
+python3 checkpoint_fork_opencode.py
+```
+
+This workflow runs OpenCode in a source sandbox, creates an explicit checkpoint,
+starts a new sandbox from that checkpoint, and continues the same OpenCode
+session in the fork. It verifies inherited workspace and OpenCode state,
+independent sandbox IDs, passing tests, and `OPENCODE_FORK_OK`, then deletes
+both sandboxes and the temporary checkpoint. It uses the same direct provider
+environment style as `run_opencode.py` and `resume_opencode.py`; use
+`network_policy.py` for the default-deny CubeEgress credential-injection path.
+
+## 7. Run with restricted egress
 
 ```bash
 python3 network_policy.py
@@ -130,8 +149,10 @@ python3 network_policy.py
 
 This path uses the native `cubesandbox` SDK to create the sandbox with
 default-deny egress and an allow rule for only the configured LLM host. The
-provider key is injected by CubeEgress as an HTTP header, while the sandbox sees
-only a placeholder environment value.
+provider key is injected by CubeEgress as an HTTP header. The global VM
+environment must not contain the key, and the OpenCode command receives only a
+placeholder. The script fails if either invariant is violated or if
+`example.com` is reachable.
 
 Set `OPENCODE_LLM_HOST` when using a custom endpoint:
 
@@ -148,7 +169,7 @@ python3 network_policy.py --skip-agent
 ## Validation
 
 ```bash
-python3 -m py_compile env_utils.py _opencode_common.py run_opencode.py resume_opencode.py network_policy.py
+python3 -m py_compile env_utils.py _opencode_common.py run_opencode.py resume_opencode.py checkpoint_fork_opencode.py network_policy.py
 python3 -m unittest discover . -p 'test_*.py'
 bash -n build-template.sh
 ```
@@ -171,14 +192,14 @@ docker run --rm opencode-cube:verify python3 --version
 | OpenCode cannot authenticate | Wrong provider key name | Match the prefix: `openai/*` needs `OPENAI_API_KEY` |
 | Template probe fails | The envd port is not reachable | Use `--probe 49983 --probe-path /health` with the CubeSandbox base entrypoint |
 | `403 Forbidden - CubeEgress` | Strict egress blocked a host | Set `OPENCODE_LLM_HOST` to the real provider host |
-| Supply-chain hardening required | The example Dockerfile uses the NodeSource setup script for readability | Pin and verify Node.js packages or mirror the artifacts in production pipelines |
+| Node.js download checksum fails | The upstream archive changed or the download is corrupt | Verify `NODE_VERSION` against Node.js `SHASUMS256.txt` before updating `NODE_SHA256` |
 
 ## Security notes
 
 - The Docker image never contains provider secrets.
-- `run_opencode.py` and `resume_opencode.py` inject the provider key only for
-  the command and redact known secret values from failure output. This is
-  convenient for local validation but leaves egress open.
-- `network_policy.py` is the recommended shared-cluster pattern: default-deny
-  egress plus CubeEgress header injection.
+- `run_opencode.py` and `resume_opencode.py` inject only the active provider's
+  key for the command and redact known secret values from failure output. This
+  is convenient for local validation but leaves egress open.
+- `network_policy.py` and `checkpoint_fork_opencode.py` are the recommended
+  shared-cluster patterns: default-deny egress plus CubeEgress header injection.
 - Do not commit `.env`.

--- a/examples/opencode-integration/README.md
+++ b/examples/opencode-integration/README.md
@@ -1,0 +1,176 @@
+# OpenCode + CubeSandbox Example
+
+[中文](README_zh.md)
+
+Run [OpenCode](https://opencode.ai/) inside a CubeSandbox MicroVM. The host
+driver creates an isolated sandbox, asks OpenCode to edit a tiny Python project,
+checks the generated artifacts, and demonstrates pause/resume plus restricted
+LLM egress.
+
+## What is included
+
+```text
+opencode-integration/
+|-- Dockerfile              # CubeSandbox template image with Node.js + OpenCode
+|-- .env.example            # Copy to .env and fill in local values
+|-- build-template.sh       # Prints docker/cubemastercli commands
+|-- env_utils.py            # Provider, model, env, and command helpers
+|-- _opencode_common.py     # Sandbox command helpers
+|-- run_opencode.py         # One-shot coding-agent demo
+|-- resume_opencode.py      # pause/resume session persistence demo
+|-- network_policy.py       # Default-deny egress + CubeEgress injection demo
+|-- test_env_utils.py       # Unit tests for config handling
+|-- test_commands.py        # Unit tests for command construction
+`-- requirements.txt        # Host-side Python dependencies
+```
+
+## Prerequisites
+
+- A running CubeSandbox deployment with CubeAPI reachable at `http://<node>:3000`.
+- `cubemastercli` connected to the cluster.
+- Docker and a registry reachable by Cube nodes.
+- Python 3.10+ on the host.
+- An LLM provider key supported by OpenCode.
+
+## 1. Build the image
+
+```bash
+cd examples/opencode-integration
+docker build --platform linux/amd64 -t <registry>/opencode-cube:latest .
+docker push <registry>/opencode-cube:latest
+```
+
+The image installs Node.js 22 and `opencode-ai` on top of
+`ghcr.io/tencentcloud/cubesandbox-base:2026.16`.
+
+## 2. Register a CubeSandbox template
+
+```bash
+cubemastercli tpl create-from-image \
+  --image <registry>/opencode-cube:latest \
+  --writable-layer-size 4G \
+  --expose-port 49983 \
+  --probe 49983 \
+  --probe-path /health
+```
+
+Wait for the template job to become `READY`, then copy the returned
+`template_id` into `.env`.
+
+## 3. Configure the host driver
+
+```bash
+cp .env.example .env
+pip install -r requirements.txt
+```
+
+Required values:
+
+| Variable | Description |
+|---|---|
+| `E2B_API_URL` | CubeAPI URL, for example `http://<node>:3000` |
+| `E2B_API_KEY` | Any non-empty value for local dev, or the real key when auth is enabled |
+| `CUBE_TEMPLATE_ID` | Template ID created in step 2 |
+| `OPENCODE_MODEL` | OpenCode model in `provider/model` form |
+| `<PROVIDER>_API_KEY` | API key matching the provider prefix |
+
+Use `OPENCODE_BASE_URL` for OpenAI-compatible custom endpoints. The scripts
+write an `opencode.json` into the sandbox workspace when this is set.
+
+When running against this repository's `dev-env/` VM, also set:
+
+```bash
+CUBE_DEV_SIDECAR=1
+```
+
+The sidecar patches the E2B SDK so sandbox traffic is routed through the
+dev-env CubeProxy port forwards.
+
+`network_policy.py` uses the native `cubesandbox` SDK. When running that script
+against `dev-env/`, also set the native SDK's API and proxy variables:
+
+```bash
+CUBE_API_URL=http://127.0.0.1:13000
+CUBE_PROXY_NODE_IP=127.0.0.1
+CUBE_PROXY_PORT_HTTP=11080
+```
+
+## 4. Run the one-shot coding task
+
+```bash
+python run_opencode.py --dry-run
+python run_opencode.py
+```
+
+The demo seeds `/workspace` with a tiny Python project, asks OpenCode to
+implement `calculator.add`, runs `python3 -m unittest discover -v`, and verifies
+that `result.md` contains `OPENCODE_CUBE_OK`.
+
+## 5. Verify pause/resume persistence
+
+```bash
+python resume_opencode.py
+```
+
+The first turn asks OpenCode to write `plan.md`, pauses the sandbox, reconnects
+to the same sandbox ID, verifies `/workspace` and OpenCode state survived, then
+continues the task and checks for `OPENCODE_RESUME_OK`.
+
+## 6. Run with restricted egress
+
+```bash
+python network_policy.py
+```
+
+This path uses the native `cubesandbox` SDK to create the sandbox with
+default-deny egress and an allow rule for only the configured LLM host. The
+provider key is injected by CubeEgress as an HTTP header, while the sandbox sees
+only a placeholder environment value.
+
+Set `OPENCODE_LLM_HOST` when using a custom endpoint:
+
+```bash
+OPENCODE_LLM_HOST=api.openai.com python network_policy.py
+```
+
+For quick policy checks without spending LLM tokens:
+
+```bash
+python network_policy.py --skip-agent
+```
+
+## Validation
+
+```bash
+python3 -m py_compile env_utils.py _opencode_common.py run_opencode.py resume_opencode.py network_policy.py
+python3 -m unittest discover . -p 'test_*.py'
+bash -n build-template.sh
+```
+
+Optional image checks:
+
+```bash
+docker build --platform linux/amd64 -t opencode-cube:verify .
+docker run --rm opencode-cube:verify opencode --version
+docker run --rm opencode-cube:verify node --version
+docker run --rm opencode-cube:verify python3 --version
+```
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| `Missing required environment variable` | `.env` is incomplete | Fill every required field in `.env` |
+| `OPENCODE_MODEL must be in provider/model form` | Model lacks provider prefix | Use values like `openai/gpt-4.1-mini` |
+| OpenCode cannot authenticate | Wrong provider key name | Match the prefix: `openai/*` needs `OPENAI_API_KEY` |
+| Template probe fails | The envd port is not reachable | Use `--probe 49983 --probe-path /health` with the CubeSandbox base entrypoint |
+| `403 Forbidden - CubeEgress` | Strict egress blocked a host | Set `OPENCODE_LLM_HOST` to the real provider host |
+
+## Security notes
+
+- The Docker image never contains provider secrets.
+- `run_opencode.py` and `resume_opencode.py` inject the provider key only for
+  the command. This is convenient for local validation but leaves egress open.
+- `network_policy.py` is the recommended shared-cluster pattern: default-deny
+  egress plus CubeEgress header injection.
+- Do not commit `.env`.

--- a/examples/opencode-integration/README.md
+++ b/examples/opencode-integration/README.md
@@ -74,8 +74,11 @@ Required values:
 | `OPENCODE_MODEL` | OpenCode model in `provider/model` form |
 | `<PROVIDER>_API_KEY` | API key matching the provider prefix |
 
-Use `OPENCODE_BASE_URL` for OpenAI-compatible custom endpoints. The scripts
-write an `opencode.json` into the sandbox workspace when this is set.
+Use `OPENCODE_BASE_URL` for OpenAI-compatible custom endpoints. If it is not
+set, the scripts also accept provider-specific variables such as
+`OPENAI_BASE_URL`. The scripts write an `opencode.json` into the sandbox
+workspace with `provider.<provider_prefix>.options.baseURL` when either value
+is set.
 
 When running against this repository's `dev-env/` VM, also set:
 
@@ -98,8 +101,8 @@ CUBE_PROXY_PORT_HTTP=11080
 ## 4. Run the one-shot coding task
 
 ```bash
-python run_opencode.py --dry-run
-python run_opencode.py
+python3 run_opencode.py --dry-run
+python3 run_opencode.py
 ```
 
 The demo seeds `/workspace` with a tiny Python project, asks OpenCode to
@@ -109,7 +112,7 @@ that `result.md` contains `OPENCODE_CUBE_OK`.
 ## 5. Verify pause/resume persistence
 
 ```bash
-python resume_opencode.py
+python3 resume_opencode.py
 ```
 
 The first turn asks OpenCode to write `plan.md`, pauses the sandbox, reconnects
@@ -119,7 +122,7 @@ continues the task and checks for `OPENCODE_RESUME_OK`.
 ## 6. Run with restricted egress
 
 ```bash
-python network_policy.py
+python3 network_policy.py
 ```
 
 This path uses the native `cubesandbox` SDK to create the sandbox with
@@ -130,13 +133,13 @@ only a placeholder environment value.
 Set `OPENCODE_LLM_HOST` when using a custom endpoint:
 
 ```bash
-OPENCODE_LLM_HOST=api.openai.com python network_policy.py
+OPENCODE_LLM_HOST=api.openai.com python3 network_policy.py
 ```
 
 For quick policy checks without spending LLM tokens:
 
 ```bash
-python network_policy.py --skip-agent
+python3 network_policy.py --skip-agent
 ```
 
 ## Validation
@@ -165,12 +168,14 @@ docker run --rm opencode-cube:verify python3 --version
 | OpenCode cannot authenticate | Wrong provider key name | Match the prefix: `openai/*` needs `OPENAI_API_KEY` |
 | Template probe fails | The envd port is not reachable | Use `--probe 49983 --probe-path /health` with the CubeSandbox base entrypoint |
 | `403 Forbidden - CubeEgress` | Strict egress blocked a host | Set `OPENCODE_LLM_HOST` to the real provider host |
+| Supply-chain hardening required | The example Dockerfile uses the NodeSource setup script for readability | Pin and verify Node.js packages or mirror the artifacts in production pipelines |
 
 ## Security notes
 
 - The Docker image never contains provider secrets.
 - `run_opencode.py` and `resume_opencode.py` inject the provider key only for
-  the command. This is convenient for local validation but leaves egress open.
+  the command and redact known secret values from failure output. This is
+  convenient for local validation but leaves egress open.
 - `network_policy.py` is the recommended shared-cluster pattern: default-deny
   egress plus CubeEgress header injection.
 - Do not commit `.env`.

--- a/examples/opencode-integration/README.md
+++ b/examples/opencode-integration/README.md
@@ -73,6 +73,8 @@ Required values:
 | `CUBE_TEMPLATE_ID` | Template ID created in step 2 |
 | `OPENCODE_MODEL` | OpenCode model in `provider/model` form |
 | `<PROVIDER>_API_KEY` | API key matching the provider prefix |
+| `CUBE_API_URL` | Required for `network_policy.py`; native CubeSandbox SDK CubeAPI URL |
+| `CUBE_PROXY_NODE_IP` | Required for `network_policy.py`; CubeProxy IP used for command streams |
 
 Use `OPENCODE_BASE_URL` for OpenAI-compatible custom endpoints. If it is not
 set, the scripts also accept provider-specific variables such as
@@ -89,8 +91,9 @@ CUBE_DEV_SIDECAR=1
 The sidecar patches the E2B SDK so sandbox traffic is routed through the
 dev-env CubeProxy port forwards.
 
-`network_policy.py` uses the native `cubesandbox` SDK. When running that script
-against `dev-env/`, also set the native SDK's API and proxy variables:
+`network_policy.py` uses the native `cubesandbox` SDK instead of the E2B SDK, so
+it reads `CUBE_API_URL` and `CUBE_PROXY_NODE_IP`. When running that script
+against `dev-env/`, use the forwarded native SDK API and proxy variables:
 
 ```bash
 CUBE_API_URL=http://127.0.0.1:13000

--- a/examples/opencode-integration/README.md
+++ b/examples/opencode-integration/README.md
@@ -16,6 +16,7 @@ opencode-integration/
 |-- build-template.sh       # Prints docker/cubemastercli commands
 |-- env_utils.py            # Provider, model, env, and command helpers
 |-- _opencode_common.py     # Sandbox command helpers
+|-- egress_policy.py        # Shared default-deny CubeEgress helpers
 |-- run_opencode.py         # One-shot coding-agent demo
 |-- resume_opencode.py      # pause/resume session persistence demo
 |-- checkpoint_fork_opencode.py # checkpoint, fork, and continue demo
@@ -45,7 +46,7 @@ docker push <registry>/opencode-cube:latest
 ```
 
 The image installs checksum-verified Node.js 22.23.1 and OpenCode 1.17.13 on top
-of `ghcr.io/tencentcloud/cubesandbox-base:2026.16`.
+of a digest-pinned `ghcr.io/tencentcloud/cubesandbox-base:2026.16`.
 
 ## 2. Register a CubeSandbox template
 
@@ -77,8 +78,8 @@ Required values:
 | `CUBE_TEMPLATE_ID` | Template ID created in step 2 |
 | `OPENCODE_MODEL` | OpenCode model in `provider/model` form |
 | `<PROVIDER>_API_KEY` | API key matching the provider prefix |
-| `CUBE_API_URL` | Required for `network_policy.py`; native CubeSandbox SDK CubeAPI URL |
-| `CUBE_PROXY_NODE_IP` | Required for `network_policy.py`; CubeProxy IP used for command streams |
+| `CUBE_API_URL` | Required for the restricted-egress and checkpoint/fork workflows; native CubeSandbox SDK CubeAPI URL |
+| `CUBE_PROXY_NODE_IP` | Required for the restricted-egress and checkpoint/fork workflows; CubeProxy IP used for command streams |
 
 Use `OPENCODE_BASE_URL` for OpenAI-compatible custom endpoints. If it is not
 set, the scripts also accept provider-specific variables such as
@@ -95,9 +96,10 @@ CUBE_DEV_SIDECAR=1
 The sidecar patches the E2B SDK so sandbox traffic is routed through the
 dev-env CubeProxy port forwards.
 
-`network_policy.py` uses the native `cubesandbox` SDK instead of the E2B SDK, so
-it reads `CUBE_API_URL` and `CUBE_PROXY_NODE_IP`. When running that script
-against `dev-env/`, use the forwarded native SDK API and proxy variables:
+`network_policy.py` and `checkpoint_fork_opencode.py` use the native
+`cubesandbox` SDK instead of the E2B SDK, so they read `CUBE_API_URL` and
+`CUBE_PROXY_NODE_IP`. When running either script against `dev-env/`, use the
+forwarded native SDK API and proxy variables:
 
 ```bash
 CUBE_API_URL=http://127.0.0.1:13000
@@ -137,9 +139,11 @@ This workflow runs OpenCode in a source sandbox, creates an explicit checkpoint,
 starts a new sandbox from that checkpoint, and continues the same OpenCode
 session in the fork. It verifies inherited workspace and OpenCode state,
 independent sandbox IDs, passing tests, and `OPENCODE_FORK_OK`, then deletes
-both sandboxes and the temporary checkpoint. It uses the same direct provider
-environment style as `run_opencode.py` and `resume_opencode.py`; use
-`network_policy.py` for the default-deny CubeEgress credential-injection path.
+both sandboxes and the temporary checkpoint. Both source and fork use
+default-deny egress with the same LLM-host allow rule. CubeEgress injects the
+real provider credential on the wire while each OpenCode command sees only a
+placeholder. The workflow verifies the secret and network invariants before
+running OpenCode in both sandboxes.
 
 ## 7. Run with restricted egress
 
@@ -169,7 +173,7 @@ python3 network_policy.py --skip-agent
 ## Validation
 
 ```bash
-python3 -m py_compile env_utils.py _opencode_common.py run_opencode.py resume_opencode.py checkpoint_fork_opencode.py network_policy.py
+python3 -m py_compile env_utils.py _opencode_common.py egress_policy.py run_opencode.py resume_opencode.py checkpoint_fork_opencode.py network_policy.py
 python3 -m unittest discover . -p 'test_*.py'
 bash -n build-template.sh
 ```

--- a/examples/opencode-integration/README_zh.md
+++ b/examples/opencode-integration/README_zh.md
@@ -1,0 +1,169 @@
+# OpenCode + CubeSandbox 示例
+
+[English](README.md)
+
+本示例演示如何在 CubeSandbox MicroVM 中运行
+[OpenCode](https://opencode.ai/)。宿主端脚本创建隔离沙箱，让 OpenCode 修改一个
+很小的 Python 项目，并验证生成产物；同时覆盖 pause/resume 会话保持和受限 LLM
+出网。
+
+## 包含内容
+
+```text
+opencode-integration/
+|-- Dockerfile              # Node.js + OpenCode 的 CubeSandbox 模板镜像
+|-- .env.example            # 复制为 .env 后填写本地配置
+|-- build-template.sh       # 打印 docker/cubemastercli 命令
+|-- env_utils.py            # provider、model、env、命令构造 helper
+|-- _opencode_common.py     # 沙箱命令 helper
+|-- run_opencode.py         # 一次性编码任务 demo
+|-- resume_opencode.py      # pause/resume 会话保持 demo
+|-- network_policy.py       # 默认拒绝出网 + CubeEgress 注入 demo
+|-- test_env_utils.py       # 配置处理单测
+|-- test_commands.py        # 命令构造单测
+`-- requirements.txt        # 宿主端 Python 依赖
+```
+
+## 前置条件
+
+- 已部署 CubeSandbox，CubeAPI 可通过 `http://<node>:3000` 访问。
+- `cubemastercli` 已连接集群。
+- 构建机有 Docker，并能推送到 Cube 节点可拉取的镜像仓库。
+- 宿主端 Python 3.10+。
+- 一个 OpenCode 支持的 LLM provider API key。
+
+## 1. 构建镜像
+
+```bash
+cd examples/opencode-integration
+docker build --platform linux/amd64 -t <registry>/opencode-cube:latest .
+docker push <registry>/opencode-cube:latest
+```
+
+镜像基于 `ghcr.io/tencentcloud/cubesandbox-base:2026.16`，安装 Node.js 22
+和 `opencode-ai`。
+
+## 2. 注册 CubeSandbox 模板
+
+```bash
+cubemastercli tpl create-from-image \
+  --image <registry>/opencode-cube:latest \
+  --writable-layer-size 4G \
+  --expose-port 49983 \
+  --probe 49983 \
+  --probe-path /health
+```
+
+等待模板任务进入 `READY` 后，把返回的 `template_id` 写入 `.env`。
+
+## 3. 配置宿主端脚本
+
+```bash
+cp .env.example .env
+pip install -r requirements.txt
+```
+
+必填变量：
+
+| 变量 | 说明 |
+|---|---|
+| `E2B_API_URL` | CubeAPI 地址，例如 `http://<node>:3000` |
+| `E2B_API_KEY` | 本地开发可填任意非空值；启用鉴权时填写真实 key |
+| `CUBE_TEMPLATE_ID` | 第 2 步创建的模板 ID |
+| `OPENCODE_MODEL` | `provider/model` 形式的 OpenCode 模型 |
+| `<PROVIDER>_API_KEY` | 与 provider 前缀匹配的 API key |
+
+如需使用 OpenAI-compatible 自定义端点，设置 `OPENCODE_BASE_URL`。脚本会在沙箱
+工作目录写入 `opencode.json`。
+
+如果连接的是本仓库的 `dev-env/` VM，还需要设置：
+
+```bash
+CUBE_DEV_SIDECAR=1
+```
+
+sidecar 会 patch E2B SDK，让 sandbox 流量走 dev-env 的 CubeProxy 端口转发。
+
+`network_policy.py` 使用原生 `cubesandbox` SDK。用 `dev-env/` 跑这个脚本时，还需要设置原生 SDK 的 API 和代理变量：
+
+```bash
+CUBE_API_URL=http://127.0.0.1:13000
+CUBE_PROXY_NODE_IP=127.0.0.1
+CUBE_PROXY_PORT_HTTP=11080
+```
+
+## 4. 运行一次性编码任务
+
+```bash
+python run_opencode.py --dry-run
+python run_opencode.py
+```
+
+脚本会在 `/workspace` 放入一个小型 Python 项目，让 OpenCode 实现
+`calculator.add`，运行 `python3 -m unittest discover -v`，并验证 `result.md`
+包含 `OPENCODE_CUBE_OK`。
+
+## 5. 验证 pause/resume 会话保持
+
+```bash
+python resume_opencode.py
+```
+
+第一轮让 OpenCode 写入 `plan.md`，随后暂停沙箱；脚本再连接同一个 sandbox ID，
+验证 `/workspace` 和 OpenCode 状态目录仍存在，然后继续任务并检查
+`OPENCODE_RESUME_OK`。
+
+## 6. 受限出网模式
+
+```bash
+python network_policy.py
+```
+
+该路径使用原生 `cubesandbox` SDK 创建沙箱：默认拒绝出网，只允许配置的 LLM host。
+真实 provider key 由 CubeEgress 在链路上注入 HTTP header，沙箱里只能看到占位值。
+
+自定义端点请设置：
+
+```bash
+OPENCODE_LLM_HOST=api.openai.com python network_policy.py
+```
+
+只检查策略、不实际调用 LLM：
+
+```bash
+python network_policy.py --skip-agent
+```
+
+## 验证
+
+```bash
+python3 -m py_compile env_utils.py _opencode_common.py run_opencode.py resume_opencode.py network_policy.py
+python3 -m unittest discover . -p 'test_*.py'
+bash -n build-template.sh
+```
+
+可选镜像检查：
+
+```bash
+docker build --platform linux/amd64 -t opencode-cube:verify .
+docker run --rm opencode-cube:verify opencode --version
+docker run --rm opencode-cube:verify node --version
+docker run --rm opencode-cube:verify python3 --version
+```
+
+## 排错
+
+| 现象 | 可能原因 | 处理方式 |
+|---|---|---|
+| `Missing required environment variable` | `.env` 未填完整 | 补齐 `.env` 必填项 |
+| `OPENCODE_MODEL must be in provider/model form` | 模型缺少 provider 前缀 | 使用 `openai/gpt-4.1-mini` 这类格式 |
+| OpenCode 鉴权失败 | provider key 名称不匹配 | `openai/*` 对应 `OPENAI_API_KEY` |
+| 模板 probe 失败 | envd 端口不可达 | 使用 CubeSandbox base entrypoint 时配置 `--probe 49983 --probe-path /health` |
+| `403 Forbidden - CubeEgress` | 严格出网模式阻断了目标 host | 设置真实的 `OPENCODE_LLM_HOST` |
+
+## 安全说明
+
+- Docker 镜像不包含任何 provider secret。
+- `run_opencode.py` 和 `resume_opencode.py` 只在单次命令环境中注入 key，适合本地验证。
+- `network_policy.py` 是共享集群推荐路径：默认拒绝出网 + CubeEgress header 注入。
+- 不要提交 `.env`。

--- a/examples/opencode-integration/README_zh.md
+++ b/examples/opencode-integration/README_zh.md
@@ -18,9 +18,13 @@ opencode-integration/
 |-- _opencode_common.py     # 沙箱命令 helper
 |-- run_opencode.py         # 一次性编码任务 demo
 |-- resume_opencode.py      # pause/resume 会话保持 demo
+|-- checkpoint_fork_opencode.py # checkpoint、fork、继续任务 demo
 |-- network_policy.py       # 默认拒绝出网 + CubeEgress 注入 demo
 |-- test_env_utils.py       # 配置处理单测
 |-- test_commands.py        # 命令构造单测
+|-- test_network_policy.py  # 安全策略断言测试
+|-- test_opencode_common.py # 沙箱 helper 测试
+|-- test_workflows.py       # 完整编排流程 mock 测试
 `-- requirements.txt        # 宿主端 Python 依赖
 ```
 
@@ -40,8 +44,8 @@ docker build --platform linux/amd64 -t <registry>/opencode-cube:latest .
 docker push <registry>/opencode-cube:latest
 ```
 
-镜像基于 `ghcr.io/tencentcloud/cubesandbox-base:2026.16`，安装 Node.js 22
-和 `opencode-ai`。
+镜像基于 `ghcr.io/tencentcloud/cubesandbox-base:2026.16`，安装经过 SHA-256
+校验的 Node.js 22.23.1 和 OpenCode 1.17.13。
 
 ## 2. 注册 CubeSandbox 模板
 
@@ -114,18 +118,33 @@ python3 run_opencode.py
 python3 resume_opencode.py
 ```
 
-第一轮让 OpenCode 写入 `plan.md`，随后暂停沙箱；脚本再连接同一个 sandbox ID，
-验证 `/workspace` 和 OpenCode 状态目录仍存在，然后继续任务并检查
-`OPENCODE_RESUME_OK`。
+第一轮让 OpenCode 写入 `plan.md`；`sandbox.pause()` 会保存 VM 和根文件系统快照。
+脚本再连接同一个 sandbox ID，验证 `/workspace` 和 OpenCode 状态目录仍存在，
+然后继续任务并检查 `OPENCODE_RESUME_OK`。
 
-## 6. 受限出网模式
+## 6. 创建可复用 checkpoint 并 fork 任务
+
+```bash
+python3 checkpoint_fork_opencode.py
+```
+
+该流程在 source sandbox 中运行 OpenCode，创建显式 checkpoint，再从该 checkpoint
+启动一个新 sandbox，并在 fork 中继续同一个 OpenCode 会话。脚本验证 workspace 和
+OpenCode 状态已继承、sandbox ID 相互独立、测试通过且结果包含 `OPENCODE_FORK_OK`，
+最后清理两个 sandbox 和临时 checkpoint。它使用与 `run_opencode.py`、
+`resume_opencode.py` 相同的直接 provider 环境变量方式；默认拒绝出网与 CubeEgress
+凭证注入路径由 `network_policy.py` 验证。
+
+## 7. 受限出网模式
 
 ```bash
 python3 network_policy.py
 ```
 
 该路径使用原生 `cubesandbox` SDK 创建沙箱：默认拒绝出网，只允许配置的 LLM host。
-真实 provider key 由 CubeEgress 在链路上注入 HTTP header，沙箱里只能看到占位值。
+真实 provider key 由 CubeEgress 在链路上注入 HTTP header；VM 全局环境中必须没有
+该 key，OpenCode 命令环境中只能有占位值。如果任一条件不满足，或
+`example.com` 可以访问，脚本都会失败。
 
 自定义端点请设置：
 
@@ -142,7 +161,7 @@ python3 network_policy.py --skip-agent
 ## 验证
 
 ```bash
-python3 -m py_compile env_utils.py _opencode_common.py run_opencode.py resume_opencode.py network_policy.py
+python3 -m py_compile env_utils.py _opencode_common.py run_opencode.py resume_opencode.py checkpoint_fork_opencode.py network_policy.py
 python3 -m unittest discover . -p 'test_*.py'
 bash -n build-template.sh
 ```
@@ -165,11 +184,11 @@ docker run --rm opencode-cube:verify python3 --version
 | OpenCode 鉴权失败 | provider key 名称不匹配 | `openai/*` 对应 `OPENAI_API_KEY` |
 | 模板 probe 失败 | envd 端口不可达 | 使用 CubeSandbox base entrypoint 时配置 `--probe 49983 --probe-path /health` |
 | `403 Forbidden - CubeEgress` | 严格出网模式阻断了目标 host | 设置真实的 `OPENCODE_LLM_HOST` |
-| 需要生产级供应链加固 | 示例 Dockerfile 为了可读性使用 NodeSource setup script | 生产镜像建议 pin 并校验 Node.js 包来源，或使用内部镜像源 |
+| Node.js 下载校验失败 | 上游归档发生变化或下载内容损坏 | 更新 `NODE_SHA256` 前先对照 Node.js `SHASUMS256.txt` 验证 `NODE_VERSION` |
 
 ## 安全说明
 
 - Docker 镜像不包含任何 provider secret。
-- `run_opencode.py` 和 `resume_opencode.py` 只在单次命令环境中注入 key，并会在失败输出中脱敏已知 secret，适合本地验证。
-- `network_policy.py` 是共享集群推荐路径：默认拒绝出网 + CubeEgress header 注入。
+- `run_opencode.py` 和 `resume_opencode.py` 只在单次命令环境中注入当前 provider 的 key，并会在失败输出中脱敏已知 secret，适合本地验证。
+- `network_policy.py` 和 `checkpoint_fork_opencode.py` 是共享集群推荐路径：默认拒绝出网 + CubeEgress header 注入。
 - 不要提交 `.env`。

--- a/examples/opencode-integration/README_zh.md
+++ b/examples/opencode-integration/README_zh.md
@@ -72,6 +72,8 @@ pip install -r requirements.txt
 | `CUBE_TEMPLATE_ID` | 第 2 步创建的模板 ID |
 | `OPENCODE_MODEL` | `provider/model` 形式的 OpenCode 模型 |
 | `<PROVIDER>_API_KEY` | 与 provider 前缀匹配的 API key |
+| `CUBE_API_URL` | `network_policy.py` 必填；原生 CubeSandbox SDK 的 CubeAPI 地址 |
+| `CUBE_PROXY_NODE_IP` | `network_policy.py` 必填；命令流使用的 CubeProxy IP |
 
 如需使用 OpenAI-compatible 自定义端点，设置 `OPENCODE_BASE_URL`。如果未设置，
 脚本也接受 provider-specific 变量，例如 `OPENAI_BASE_URL`。脚本会在沙箱
@@ -85,7 +87,9 @@ CUBE_DEV_SIDECAR=1
 
 sidecar 会 patch E2B SDK，让 sandbox 流量走 dev-env 的 CubeProxy 端口转发。
 
-`network_policy.py` 使用原生 `cubesandbox` SDK。用 `dev-env/` 跑这个脚本时，还需要设置原生 SDK 的 API 和代理变量：
+`network_policy.py` 使用原生 `cubesandbox` SDK，而不是 E2B SDK，所以会读取
+`CUBE_API_URL` 和 `CUBE_PROXY_NODE_IP`。用 `dev-env/` 跑这个脚本时，使用下面的
+原生 SDK API 和代理端口转发变量：
 
 ```bash
 CUBE_API_URL=http://127.0.0.1:13000

--- a/examples/opencode-integration/README_zh.md
+++ b/examples/opencode-integration/README_zh.md
@@ -73,8 +73,9 @@ pip install -r requirements.txt
 | `OPENCODE_MODEL` | `provider/model` 形式的 OpenCode 模型 |
 | `<PROVIDER>_API_KEY` | 与 provider 前缀匹配的 API key |
 
-如需使用 OpenAI-compatible 自定义端点，设置 `OPENCODE_BASE_URL`。脚本会在沙箱
-工作目录写入 `opencode.json`。
+如需使用 OpenAI-compatible 自定义端点，设置 `OPENCODE_BASE_URL`。如果未设置，
+脚本也接受 provider-specific 变量，例如 `OPENAI_BASE_URL`。脚本会在沙箱
+工作目录写入 `opencode.json`，配置 `provider.<provider_prefix>.options.baseURL`。
 
 如果连接的是本仓库的 `dev-env/` VM，还需要设置：
 
@@ -95,8 +96,8 @@ CUBE_PROXY_PORT_HTTP=11080
 ## 4. 运行一次性编码任务
 
 ```bash
-python run_opencode.py --dry-run
-python run_opencode.py
+python3 run_opencode.py --dry-run
+python3 run_opencode.py
 ```
 
 脚本会在 `/workspace` 放入一个小型 Python 项目，让 OpenCode 实现
@@ -106,7 +107,7 @@ python run_opencode.py
 ## 5. 验证 pause/resume 会话保持
 
 ```bash
-python resume_opencode.py
+python3 resume_opencode.py
 ```
 
 第一轮让 OpenCode 写入 `plan.md`，随后暂停沙箱；脚本再连接同一个 sandbox ID，
@@ -116,7 +117,7 @@ python resume_opencode.py
 ## 6. 受限出网模式
 
 ```bash
-python network_policy.py
+python3 network_policy.py
 ```
 
 该路径使用原生 `cubesandbox` SDK 创建沙箱：默认拒绝出网，只允许配置的 LLM host。
@@ -125,13 +126,13 @@ python network_policy.py
 自定义端点请设置：
 
 ```bash
-OPENCODE_LLM_HOST=api.openai.com python network_policy.py
+OPENCODE_LLM_HOST=api.openai.com python3 network_policy.py
 ```
 
 只检查策略、不实际调用 LLM：
 
 ```bash
-python network_policy.py --skip-agent
+python3 network_policy.py --skip-agent
 ```
 
 ## 验证
@@ -160,10 +161,11 @@ docker run --rm opencode-cube:verify python3 --version
 | OpenCode 鉴权失败 | provider key 名称不匹配 | `openai/*` 对应 `OPENAI_API_KEY` |
 | 模板 probe 失败 | envd 端口不可达 | 使用 CubeSandbox base entrypoint 时配置 `--probe 49983 --probe-path /health` |
 | `403 Forbidden - CubeEgress` | 严格出网模式阻断了目标 host | 设置真实的 `OPENCODE_LLM_HOST` |
+| 需要生产级供应链加固 | 示例 Dockerfile 为了可读性使用 NodeSource setup script | 生产镜像建议 pin 并校验 Node.js 包来源，或使用内部镜像源 |
 
 ## 安全说明
 
 - Docker 镜像不包含任何 provider secret。
-- `run_opencode.py` 和 `resume_opencode.py` 只在单次命令环境中注入 key，适合本地验证。
+- `run_opencode.py` 和 `resume_opencode.py` 只在单次命令环境中注入 key，并会在失败输出中脱敏已知 secret，适合本地验证。
 - `network_policy.py` 是共享集群推荐路径：默认拒绝出网 + CubeEgress header 注入。
 - 不要提交 `.env`。

--- a/examples/opencode-integration/README_zh.md
+++ b/examples/opencode-integration/README_zh.md
@@ -16,6 +16,7 @@ opencode-integration/
 |-- build-template.sh       # 打印 docker/cubemastercli 命令
 |-- env_utils.py            # provider、model、env、命令构造 helper
 |-- _opencode_common.py     # 沙箱命令 helper
+|-- egress_policy.py        # 共享的默认拒绝出网与 CubeEgress helper
 |-- run_opencode.py         # 一次性编码任务 demo
 |-- resume_opencode.py      # pause/resume 会话保持 demo
 |-- checkpoint_fork_opencode.py # checkpoint、fork、继续任务 demo
@@ -44,7 +45,7 @@ docker build --platform linux/amd64 -t <registry>/opencode-cube:latest .
 docker push <registry>/opencode-cube:latest
 ```
 
-镜像基于 `ghcr.io/tencentcloud/cubesandbox-base:2026.16`，安装经过 SHA-256
+镜像基于 digest 固定的 `ghcr.io/tencentcloud/cubesandbox-base:2026.16`，安装经过 SHA-256
 校验的 Node.js 22.23.1 和 OpenCode 1.17.13。
 
 ## 2. 注册 CubeSandbox 模板
@@ -76,8 +77,8 @@ pip install -r requirements.txt
 | `CUBE_TEMPLATE_ID` | 第 2 步创建的模板 ID |
 | `OPENCODE_MODEL` | `provider/model` 形式的 OpenCode 模型 |
 | `<PROVIDER>_API_KEY` | 与 provider 前缀匹配的 API key |
-| `CUBE_API_URL` | `network_policy.py` 必填；原生 CubeSandbox SDK 的 CubeAPI 地址 |
-| `CUBE_PROXY_NODE_IP` | `network_policy.py` 必填；命令流使用的 CubeProxy IP |
+| `CUBE_API_URL` | 受限出网和 checkpoint/fork 流程必填；原生 CubeSandbox SDK 的 CubeAPI 地址 |
+| `CUBE_PROXY_NODE_IP` | 受限出网和 checkpoint/fork 流程必填；命令流使用的 CubeProxy IP |
 
 如需使用 OpenAI-compatible 自定义端点，设置 `OPENCODE_BASE_URL`。如果未设置，
 脚本也接受 provider-specific 变量，例如 `OPENAI_BASE_URL`。脚本会在沙箱
@@ -91,9 +92,9 @@ CUBE_DEV_SIDECAR=1
 
 sidecar 会 patch E2B SDK，让 sandbox 流量走 dev-env 的 CubeProxy 端口转发。
 
-`network_policy.py` 使用原生 `cubesandbox` SDK，而不是 E2B SDK，所以会读取
-`CUBE_API_URL` 和 `CUBE_PROXY_NODE_IP`。用 `dev-env/` 跑这个脚本时，使用下面的
-原生 SDK API 和代理端口转发变量：
+`network_policy.py` 和 `checkpoint_fork_opencode.py` 使用原生 `cubesandbox`
+SDK，而不是 E2B SDK，所以会读取 `CUBE_API_URL` 和 `CUBE_PROXY_NODE_IP`。
+用 `dev-env/` 跑任一脚本时，使用下面的原生 SDK API 和代理端口转发变量：
 
 ```bash
 CUBE_API_URL=http://127.0.0.1:13000
@@ -131,9 +132,9 @@ python3 checkpoint_fork_opencode.py
 该流程在 source sandbox 中运行 OpenCode，创建显式 checkpoint，再从该 checkpoint
 启动一个新 sandbox，并在 fork 中继续同一个 OpenCode 会话。脚本验证 workspace 和
 OpenCode 状态已继承、sandbox ID 相互独立、测试通过且结果包含 `OPENCODE_FORK_OK`，
-最后清理两个 sandbox 和临时 checkpoint。它使用与 `run_opencode.py`、
-`resume_opencode.py` 相同的直接 provider 环境变量方式；默认拒绝出网与 CubeEgress
-凭证注入路径由 `network_policy.py` 验证。
+最后清理两个 sandbox 和临时 checkpoint。source 与 fork 都使用默认拒绝出网和同一条
+LLM host 放行规则；真实 provider key 由 CubeEgress 在链路上注入，OpenCode 命令环境
+中只有占位值。脚本会在两个 sandbox 中分别验证 secret 与网络策略不变量。
 
 ## 7. 受限出网模式
 
@@ -161,7 +162,7 @@ python3 network_policy.py --skip-agent
 ## 验证
 
 ```bash
-python3 -m py_compile env_utils.py _opencode_common.py run_opencode.py resume_opencode.py checkpoint_fork_opencode.py network_policy.py
+python3 -m py_compile env_utils.py _opencode_common.py egress_policy.py run_opencode.py resume_opencode.py checkpoint_fork_opencode.py network_policy.py
 python3 -m unittest discover . -p 'test_*.py'
 bash -n build-template.sh
 ```

--- a/examples/opencode-integration/_opencode_common.py
+++ b/examples/opencode-integration/_opencode_common.py
@@ -94,7 +94,11 @@ def _command_env_kwarg(commands_type: type) -> str:
         return "envs"
     if "env" in params:
         return "env"
-    return "envs"
+    supported = ", ".join(params) or "<none>"
+    raise TypeError(
+        "sandbox.commands.run does not expose an env or envs parameter; "
+        f"supported parameters: {supported}"
+    )
 
 
 @lru_cache(maxsize=None)

--- a/examples/opencode-integration/_opencode_common.py
+++ b/examples/opencode-integration/_opencode_common.py
@@ -13,13 +13,14 @@ from functools import lru_cache
 from typing import Any
 
 
-SECRET_ENV_MARKERS = ("API_KEY", "TOKEN", "SECRET")
+SECRET_ENV_SUFFIXES = ("API_KEY", "_KEY", "_TOKEN", "_SECRET")
+SECRET_ENV_NAMES = {"KEY", "TOKEN", "SECRET", "API_KEY"}
 
 
 def stream_writer(stream) -> Callable[[object], None]:
     def write(chunk: object) -> None:
         text = getattr(chunk, "line", chunk)
-        stream.write(str(text))
+        stream.write(redact_secrets(str(text)))
         stream.flush()
 
     return write
@@ -61,6 +62,17 @@ def sandbox_identifier(sandbox: Any) -> str:
     return getattr(sandbox, "sandbox_id", getattr(sandbox, "id", "unknown"))
 
 
+def warn_direct_secret_env(key_name: str) -> None:
+    if _secret_is_present(os.environ.get(key_name)):
+        print(
+            f"Warning: {key_name} will be passed into the sandbox process "
+            "environment for this local convenience demo. Use network_policy.py "
+            "for shared clusters so CubeEgress can inject credentials without "
+            "exposing the real key inside the sandbox.",
+            file=sys.stderr,
+        )
+
+
 @lru_cache(maxsize=None)
 def _command_env_kwarg(commands_type: type) -> str:
     params = _command_run_parameters(commands_type)
@@ -91,7 +103,8 @@ def _filter_supported_kwargs(commands_type: type, kwargs: dict[str, Any]) -> dic
 
 
 def _is_secret_env(name: str) -> bool:
-    return any(marker in name.upper() for marker in SECRET_ENV_MARKERS)
+    normalized = name.upper()
+    return normalized in SECRET_ENV_NAMES or normalized.endswith(SECRET_ENV_SUFFIXES)
 
 
 def _secret_is_present(value: str | None) -> bool:
@@ -100,7 +113,11 @@ def _secret_is_present(value: str | None) -> bool:
 
 def redact_secrets(text: str) -> str:
     redacted = text
-    for name, value in os.environ.items():
-        if _is_secret_env(name) and _secret_is_present(value):
-            redacted = redacted.replace(value, "<redacted>")
+    values = {
+        value
+        for name, value in os.environ.items()
+        if _is_secret_env(name) and _secret_is_present(value)
+    }
+    for value in sorted(values, key=len, reverse=True):
+        redacted = redacted.replace(value, "<redacted>")
     return redacted

--- a/examples/opencode-integration/_opencode_common.py
+++ b/examples/opencode-integration/_opencode_common.py
@@ -62,6 +62,18 @@ def sandbox_identifier(sandbox: Any) -> str:
     return getattr(sandbox, "sandbox_id", getattr(sandbox, "id", "unknown"))
 
 
+def pause_sandbox(sandbox: Any) -> str:
+    pause = getattr(sandbox, "pause", None)
+    if callable(pause):
+        paused_id = pause()
+    else:
+        beta_pause = getattr(sandbox, "beta_pause", None)
+        if not callable(beta_pause):
+            raise AttributeError("Sandbox object does not support pause or beta_pause")
+        paused_id = beta_pause()
+    return paused_id if isinstance(paused_id, str) and paused_id else sandbox_identifier(sandbox)
+
+
 def warn_direct_secret_env(key_name: str) -> None:
     if _secret_is_present(os.environ.get(key_name)):
         print(

--- a/examples/opencode-integration/_opencode_common.py
+++ b/examples/opencode-integration/_opencode_common.py
@@ -1,0 +1,75 @@
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared sandbox command helpers for the OpenCode integration examples."""
+
+from __future__ import annotations
+
+import os
+import sys
+from collections.abc import Callable
+from typing import Any
+
+
+def stream_writer(stream) -> Callable[[object], None]:
+    def write(chunk: object) -> None:
+        text = getattr(chunk, "line", chunk)
+        stream.write(str(text))
+        stream.flush()
+
+    return write
+
+
+def run_command(
+    sandbox: Any,
+    command: str,
+    *,
+    cwd: str | None = None,
+    envs: dict[str, str] | None = None,
+    timeout: int | float | None = None,
+    stream: bool = False,
+    user: str = "root",
+):
+    kwargs = {"cwd": cwd, "timeout": timeout, "user": user}
+    kwargs = {key: value for key, value in kwargs.items() if value is not None}
+    if envs:
+        kwargs["envs"] = envs
+    if stream:
+        kwargs["on_stdout"] = stream_writer(sys.stdout)
+        kwargs["on_stderr"] = stream_writer(sys.stderr)
+
+    try:
+        return sandbox.commands.run(command, **kwargs)
+    except TypeError as exc:
+        if "envs" not in kwargs or "envs" not in str(exc):
+            raise
+        kwargs["env"] = kwargs.pop("envs")
+        return sandbox.commands.run(command, **kwargs)
+
+
+def ensure_success(result, action: str) -> None:
+    exit_code = getattr(result, "exit_code", None)
+    if exit_code not in (None, 0):
+        stdout = getattr(result, "stdout", "")
+        stderr = getattr(result, "stderr", "")
+        raise SystemExit(
+            f"Failed to {action} (exit {exit_code}).\nSTDOUT:\n{stdout}\nSTDERR:\n{stderr}"
+        )
+
+
+def sandbox_identifier(sandbox: Any) -> str:
+    return getattr(sandbox, "sandbox_id", getattr(sandbox, "id", "unknown"))
+
+
+def secret_is_present(value: str | None) -> bool:
+    return bool(value and value.strip() and not value.strip().startswith("<"))
+
+
+def redact_env(envs: dict[str, str]) -> dict[str, str]:
+    redacted: dict[str, str] = {}
+    for key, value in envs.items():
+        if "KEY" in key or "TOKEN" in key or "SECRET" in key:
+            redacted[key] = "<redacted>" if value else ""
+        else:
+            redacted[key] = value
+    return redacted

--- a/examples/opencode-integration/_opencode_common.py
+++ b/examples/opencode-integration/_opencode_common.py
@@ -5,10 +5,15 @@
 
 from __future__ import annotations
 
+import inspect
 import os
 import sys
 from collections.abc import Callable
+from functools import lru_cache
 from typing import Any
+
+
+SECRET_ENV_MARKERS = ("API_KEY", "TOKEN", "SECRET")
 
 
 def stream_writer(stream) -> Callable[[object], None]:
@@ -33,25 +38,20 @@ def run_command(
     kwargs = {"cwd": cwd, "timeout": timeout, "user": user}
     kwargs = {key: value for key, value in kwargs.items() if value is not None}
     if envs:
-        kwargs["envs"] = envs
+        kwargs[_command_env_kwarg(type(sandbox.commands))] = envs
     if stream:
         kwargs["on_stdout"] = stream_writer(sys.stdout)
         kwargs["on_stderr"] = stream_writer(sys.stderr)
+    kwargs = _filter_supported_kwargs(type(sandbox.commands), kwargs)
 
-    try:
-        return sandbox.commands.run(command, **kwargs)
-    except TypeError as exc:
-        if "envs" not in kwargs or "envs" not in str(exc):
-            raise
-        kwargs["env"] = kwargs.pop("envs")
-        return sandbox.commands.run(command, **kwargs)
+    return sandbox.commands.run(command, **kwargs)
 
 
 def ensure_success(result, action: str) -> None:
     exit_code = getattr(result, "exit_code", None)
     if exit_code not in (None, 0):
-        stdout = getattr(result, "stdout", "")
-        stderr = getattr(result, "stderr", "")
+        stdout = redact_secrets(getattr(result, "stdout", ""))
+        stderr = redact_secrets(getattr(result, "stderr", ""))
         raise SystemExit(
             f"Failed to {action} (exit {exit_code}).\nSTDOUT:\n{stdout}\nSTDERR:\n{stderr}"
         )
@@ -61,15 +61,46 @@ def sandbox_identifier(sandbox: Any) -> str:
     return getattr(sandbox, "sandbox_id", getattr(sandbox, "id", "unknown"))
 
 
-def secret_is_present(value: str | None) -> bool:
+@lru_cache(maxsize=None)
+def _command_env_kwarg(commands_type: type) -> str:
+    params = _command_run_parameters(commands_type)
+    if params is None:
+        return "envs"
+    if "envs" in params:
+        return "envs"
+    if "env" in params:
+        return "env"
+    return "envs"
+
+
+@lru_cache(maxsize=None)
+def _command_run_parameters(commands_type: type) -> dict[str, inspect.Parameter] | None:
+    try:
+        return dict(inspect.signature(commands_type.run).parameters)
+    except (TypeError, ValueError):
+        return None
+
+
+def _filter_supported_kwargs(commands_type: type, kwargs: dict[str, Any]) -> dict[str, Any]:
+    params = _command_run_parameters(commands_type)
+    if params is None:
+        return kwargs
+    if any(param.kind == inspect.Parameter.VAR_KEYWORD for param in params.values()):
+        return kwargs
+    return {key: value for key, value in kwargs.items() if key in params}
+
+
+def _is_secret_env(name: str) -> bool:
+    return any(marker in name.upper() for marker in SECRET_ENV_MARKERS)
+
+
+def _secret_is_present(value: str | None) -> bool:
     return bool(value and value.strip() and not value.strip().startswith("<"))
 
 
-def redact_env(envs: dict[str, str]) -> dict[str, str]:
-    redacted: dict[str, str] = {}
-    for key, value in envs.items():
-        if "KEY" in key or "TOKEN" in key or "SECRET" in key:
-            redacted[key] = "<redacted>" if value else ""
-        else:
-            redacted[key] = value
+def redact_secrets(text: str) -> str:
+    redacted = text
+    for name, value in os.environ.items():
+        if _is_secret_env(name) and _secret_is_present(value):
+            redacted = redacted.replace(value, "<redacted>")
     return redacted

--- a/examples/opencode-integration/build-template.sh
+++ b/examples/opencode-integration/build-template.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+IMAGE="${IMAGE:-opencode-cube:latest}"
+WRITABLE_LAYER_SIZE="${WRITABLE_LAYER_SIZE:-4G}"
+EXPOSE_PORT="${EXPOSE_PORT:-49983}"
+PROBE_PORT="${PROBE_PORT:-49983}"
+PROBE_PATH="${PROBE_PATH:-/health}"
+
+cat <<EOF
+Build and push the image:
+
+  docker build --platform linux/amd64 -t ${IMAGE} .
+  docker push ${IMAGE}
+
+Register the CubeSandbox template:
+
+  cubemastercli tpl create-from-image \\
+    --image ${IMAGE} \\
+    --writable-layer-size ${WRITABLE_LAYER_SIZE} \\
+    --expose-port ${EXPOSE_PORT} \\
+    --probe ${PROBE_PORT} \\
+    --probe-path ${PROBE_PATH}
+
+After the job reaches READY, copy the returned template_id into CUBE_TEMPLATE_ID.
+EOF

--- a/examples/opencode-integration/checkpoint_fork_opencode.py
+++ b/examples/opencode-integration/checkpoint_fork_opencode.py
@@ -1,0 +1,239 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Continue one OpenCode task in a new sandbox forked from a checkpoint."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import shlex
+import sys
+
+from cubesandbox import Sandbox
+
+from _opencode_common import (
+    ensure_success,
+    run_command,
+    sandbox_identifier,
+    warn_direct_secret_env,
+)
+from env_utils import (
+    build_opencode_env,
+    int_env,
+    load_local_dotenv,
+    opencode_command,
+    opencode_config_json,
+    opencode_model,
+    opencode_provider,
+    opencode_workspace,
+    provider_key_name,
+    require_provider_key,
+    required,
+    shell_join,
+)
+
+TURN_1_PROMPT = (
+    "Create {workspace}/checkpoint_plan.md containing exactly this single line: "
+    "OPENCODE_CHECKPOINT_READY. Do not read or print environment variables."
+)
+
+TURN_2_PROMPT = (
+    "Continue the previous task. Read checkpoint_plan.md, then create "
+    "fork_result.md containing exactly two lines: OPENCODE_CHECKPOINT_READY and "
+    "OPENCODE_FORK_OK. Do not read or print environment variables."
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Run OpenCode, create a CubeSandbox checkpoint, fork a new sandbox, "
+            "and continue the same task in the fork."
+        )
+    )
+    parser.add_argument("--template", default=os.environ.get("CUBE_TEMPLATE_ID"))
+    parser.add_argument("--workspace", default=opencode_workspace())
+    parser.add_argument("--title", default="cube-opencode-checkpoint-fork")
+    parser.add_argument(
+        "--sandbox-timeout",
+        type=int,
+        default=int_env("OPENCODE_SANDBOX_TIMEOUT", 1800),
+    )
+    parser.add_argument(
+        "--exec-timeout",
+        type=int,
+        default=int_env("OPENCODE_EXEC_TIMEOUT", 900),
+    )
+    return parser.parse_args()
+
+
+def create_sandbox(template_id: str, timeout: int) -> Sandbox:
+    return Sandbox.create(template=template_id, timeout=timeout)
+
+
+def seed_project(sandbox: Sandbox, workspace: str) -> None:
+    quoted_workspace = shlex.quote(workspace)
+    command = f"""mkdir -p {quoted_workspace}
+cat > {quoted_workspace}/opencode.json <<'EOF'
+{opencode_config_json()}
+EOF
+cat > {quoted_workspace}/calculator.py <<'EOF'
+def add(a: int, b: int) -> int:
+    return a + b
+EOF
+cat > {quoted_workspace}/test_calculator.py <<'EOF'
+import unittest
+
+from calculator import add
+
+
+class CalculatorTest(unittest.TestCase):
+    def test_adds_two_numbers(self) -> None:
+        self.assertEqual(add(2, 3), 5)
+
+
+if __name__ == "__main__":
+    unittest.main()
+EOF
+"""
+    result = run_command(sandbox, command, timeout=60)
+    ensure_success(result, "seed checkpoint/fork workspace")
+
+
+def run_turn(
+    sandbox: Sandbox,
+    workspace: str,
+    prompt: str,
+    model: str,
+    envs: dict[str, str],
+    timeout: int,
+    *,
+    title: str | None = None,
+    continue_last: bool = False,
+):
+    command = opencode_command(
+        prompt,
+        workspace=workspace,
+        model=model,
+        title=title,
+        continue_last=continue_last,
+    )
+    return run_command(
+        sandbox,
+        command,
+        cwd=workspace,
+        envs=envs,
+        timeout=timeout,
+        stream=True,
+    )
+
+
+def verify_checkpoint_state(sandbox: Sandbox, workspace: str) -> None:
+    quoted_workspace = shlex.quote(workspace)
+    command = shell_join(
+        f"cd {quoted_workspace}",
+        "test -f checkpoint_plan.md",
+        "grep -q OPENCODE_CHECKPOINT_READY checkpoint_plan.md",
+        "test -d /root/.local/share/opencode",
+        "cat checkpoint_plan.md",
+    )
+    result = run_command(sandbox, command, timeout=60)
+    ensure_success(result, "verify checkpoint state in forked sandbox")
+    if getattr(result, "stdout", ""):
+        print(result.stdout)
+
+
+def verify_fork_result(sandbox: Sandbox, workspace: str) -> None:
+    quoted_workspace = shlex.quote(workspace)
+    command = shell_join(
+        f"cd {quoted_workspace}",
+        "python3 -m unittest discover -v",
+        "test -f fork_result.md",
+        "grep -q OPENCODE_CHECKPOINT_READY fork_result.md",
+        "grep -q OPENCODE_FORK_OK fork_result.md",
+        "cat fork_result.md",
+    )
+    result = run_command(sandbox, command, timeout=120)
+    ensure_success(result, "verify continued task in forked sandbox")
+    if getattr(result, "stdout", ""):
+        print(result.stdout)
+
+
+def main() -> int:
+    load_local_dotenv()
+    args = parse_args()
+
+    template_id = args.template or required("CUBE_TEMPLATE_ID")
+    model = opencode_model()
+    provider = opencode_provider(model)
+    require_provider_key(provider)
+    key_name = provider_key_name(provider)
+    warn_direct_secret_env(key_name)
+    envs = build_opencode_env(include_secrets=True)
+
+    source = None
+    forked = None
+    snapshot_id = None
+    try:
+        print(f"Creating source sandbox from template: {template_id}")
+        source = create_sandbox(template_id, args.sandbox_timeout)
+        print(f"Source sandbox ready: {sandbox_identifier(source)}")
+
+        seed_project(source, args.workspace)
+
+        print("\n=== Turn 1: prepare checkpoint state ===\n")
+        result_1 = run_turn(
+            source,
+            args.workspace,
+            TURN_1_PROMPT.format(workspace=args.workspace),
+            model,
+            envs,
+            args.exec_timeout,
+            title=args.title,
+        )
+        ensure_success(result_1, "run OpenCode before checkpoint")
+        verify_checkpoint_state(source, args.workspace)
+
+        snapshot = source.create_snapshot(name="opencode-checkpoint-fork")
+        snapshot_id = snapshot.snapshot_id
+        print(f"Checkpoint created: {snapshot_id}")
+
+        forked = create_sandbox(snapshot_id, args.sandbox_timeout)
+        print(f"Forked sandbox ready: {sandbox_identifier(forked)}")
+        verify_checkpoint_state(forked, args.workspace)
+
+        print("\n=== Turn 2: continue inside the fork ===\n")
+        result_2 = run_turn(
+            forked,
+            args.workspace,
+            TURN_2_PROMPT,
+            model,
+            envs,
+            args.exec_timeout,
+            continue_last=True,
+        )
+        ensure_success(result_2, "continue OpenCode in forked sandbox")
+        verify_fork_result(forked, args.workspace)
+        print("\nCheckpoint/fork workflow passed.")
+        return 0
+    finally:
+        for label, sandbox in (("forked", forked), ("source", source)):
+            if sandbox is None:
+                continue
+            try:
+                sandbox.kill()
+                print(f"{label.capitalize()} sandbox killed.")
+            except Exception as exc:  # noqa: BLE001
+                print(f"Warning: failed to kill {label} sandbox: {exc}", file=sys.stderr)
+        if snapshot_id is not None:
+            try:
+                Sandbox.delete_snapshot(snapshot_id)
+                print(f"Checkpoint deleted: {snapshot_id}")
+            except Exception as exc:  # noqa: BLE001
+                print(f"Warning: failed to delete checkpoint {snapshot_id}: {exc}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/examples/opencode-integration/checkpoint_fork_opencode.py
+++ b/examples/opencode-integration/checkpoint_fork_opencode.py
@@ -11,18 +11,27 @@ import os
 import shlex
 import sys
 
-from cubesandbox import Sandbox
+from cubesandbox import Rule, Sandbox
 
 from _opencode_common import (
     ensure_success,
     run_command,
     sandbox_identifier,
-    warn_direct_secret_env,
+)
+from egress_policy import (
+    PLACEHOLDER_KEY,
+    build_rules,
+    create_sandbox as create_restricted_sandbox,
+    require_native_sdk_env,
+    verify_key_not_in_vm,
+    verify_non_llm_blocked,
+    verify_placeholder_env,
 )
 from env_utils import (
     build_opencode_env,
     int_env,
     load_local_dotenv,
+    opencode_llm_host,
     opencode_command,
     opencode_config_json,
     opencode_model,
@@ -69,8 +78,16 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
-def create_sandbox(template_id: str, timeout: int) -> Sandbox:
-    return Sandbox.create(template=template_id, timeout=timeout)
+def create_sandbox(template_id: str, rules: list[Rule], timeout: int) -> Sandbox:
+    return create_restricted_sandbox(template_id, rules, timeout)
+
+
+def verify_restricted_environment(
+    sandbox: Sandbox, key_name: str, envs: dict[str, str]
+) -> None:
+    verify_key_not_in_vm(sandbox, key_name)
+    verify_placeholder_env(sandbox, key_name, envs)
+    verify_non_llm_blocked(sandbox)
 
 
 def seed_project(sandbox: Sandbox, workspace: str) -> None:
@@ -166,20 +183,29 @@ def main() -> int:
     args = parse_args()
 
     template_id = args.template or required("CUBE_TEMPLATE_ID")
+    require_native_sdk_env()
     model = opencode_model()
     provider = opencode_provider(model)
-    require_provider_key(provider)
+    secret = require_provider_key(provider)
+    host = opencode_llm_host(provider)
+    if not host:
+        raise SystemExit("Set OPENCODE_LLM_HOST or OPENCODE_BASE_URL for this provider.")
+
     key_name = provider_key_name(provider)
-    warn_direct_secret_env(key_name)
-    envs = build_opencode_env(include_secrets=True)
+    envs = build_opencode_env(include_secrets=False)
+    envs[key_name] = PLACEHOLDER_KEY
+    rules = build_rules(provider, host, secret)
 
     source = None
     forked = None
     snapshot_id = None
+    source_id = None
     try:
         print(f"Creating source sandbox from template: {template_id}")
-        source = create_sandbox(template_id, args.sandbox_timeout)
-        print(f"Source sandbox ready: {sandbox_identifier(source)}")
+        source = create_sandbox(template_id, rules, args.sandbox_timeout)
+        source_id = sandbox_identifier(source)
+        print(f"Source sandbox ready: {source_id}")
+        verify_restricted_environment(source, key_name, envs)
 
         seed_project(source, args.workspace)
 
@@ -200,8 +226,12 @@ def main() -> int:
         snapshot_id = snapshot.snapshot_id
         print(f"Checkpoint created: {snapshot_id}")
 
-        forked = create_sandbox(snapshot_id, args.sandbox_timeout)
-        print(f"Forked sandbox ready: {sandbox_identifier(forked)}")
+        forked = create_sandbox(snapshot_id, rules, args.sandbox_timeout)
+        forked_id = sandbox_identifier(forked)
+        if forked_id == source_id:
+            raise RuntimeError("Forked sandbox unexpectedly reused the source sandbox ID")
+        print(f"Forked sandbox ready: {forked_id}")
+        verify_restricted_environment(forked, key_name, envs)
         verify_checkpoint_state(forked, args.workspace)
 
         print("\n=== Turn 2: continue inside the fork ===\n")

--- a/examples/opencode-integration/egress_policy.py
+++ b/examples/opencode-integration/egress_policy.py
@@ -1,0 +1,86 @@
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared default-deny CubeEgress helpers for OpenCode workflows."""
+
+from __future__ import annotations
+
+import shlex
+
+from cubesandbox import Action, Inject, Match, Rule, Sandbox
+
+from _opencode_common import ensure_success, run_command
+from env_utils import provider_inject, required
+
+
+PLACEHOLDER_KEY = "cube-egress-managed-placeholder"
+
+
+def require_native_sdk_env() -> None:
+    required("CUBE_API_URL")
+    required("CUBE_PROXY_NODE_IP")
+
+
+def build_rules(provider: str, host: str, secret: str) -> list[Rule]:
+    return [
+        Rule(
+            name=f"allow_{provider}_llm",
+            match=Match(scheme="https", sni=host, host=host),
+            action=Action(
+                allow=True,
+                audit="metadata",
+                inject=[Inject(**spec) for spec in provider_inject(provider, secret)],
+            ),
+        )
+    ]
+
+
+def create_sandbox(template_id: str, rules: list[Rule], timeout: int) -> Sandbox:
+    return Sandbox.create(
+        template=template_id,
+        allow_internet_access=False,
+        network={"rules": rules},
+        timeout=timeout,
+    )
+
+
+def verify_key_not_in_vm(sandbox: Sandbox, key_name: str) -> None:
+    command = f"printenv {shlex.quote(key_name)} || echo '<unset>'"
+    result = run_command(sandbox, command, timeout=30)
+    ensure_success(result, "read provider key inside sandbox")
+    value = getattr(result, "stdout", "").strip()
+    if value != "<unset>":
+        raise SystemExit(
+            f"Security check failed: {key_name} exists in the sandbox's global environment."
+        )
+    print(f"In-VM global {key_name}: '<unset>' (real secret stays in CubeEgress)")
+
+
+def verify_placeholder_env(
+    sandbox: Sandbox, key_name: str, envs: dict[str, str]
+) -> None:
+    command = f"printenv {shlex.quote(key_name)}"
+    result = run_command(sandbox, command, envs=envs, timeout=30)
+    ensure_success(result, "verify provider placeholder inside the agent command")
+    value = getattr(result, "stdout", "").strip()
+    if value != PLACEHOLDER_KEY:
+        raise SystemExit(
+            f"Security check failed: {key_name} was not replaced by the CubeEgress placeholder."
+        )
+    print(f"Agent command {key_name}: '<placeholder>'")
+
+
+def verify_non_llm_blocked(sandbox: Sandbox) -> None:
+    command = (
+        "curl -s -o /dev/null -w '%{http_code}' --max-time 8 https://example.com "
+        "|| echo blocked"
+    )
+    result = run_command(sandbox, command, timeout=30)
+    status = getattr(result, "stdout", "").strip()
+    blocked = status == "403" or status.endswith("blocked")
+    if not blocked:
+        raise SystemExit(
+            "Security check failed: non-LLM host example.com was reachable "
+            f"(curl status {status or '<empty>'})."
+        )
+    print(f"Non-LLM host example.com: {status or 'blocked'} (blocked as expected)")

--- a/examples/opencode-integration/env_utils.py
+++ b/examples/opencode-integration/env_utils.py
@@ -42,14 +42,21 @@ PASSTHROUGH_ENV_NAMES = (
 def load_local_dotenv() -> None:
     candidate_paths = [Path(__file__).with_name(".env"), Path.cwd() / ".env"]
     seen_paths: set[Path] = set()
+    checked_paths: list[str] = []
     for path in candidate_paths:
         resolved = path.resolve()
         if resolved in seen_paths:
             continue
         seen_paths.add(resolved)
+        checked_paths.append(str(path))
         if path.is_file():
             load_dotenv(dotenv_path=path, override=False)
             return
+    print(
+        "Warning: no .env file found; continuing with existing environment. "
+        f"Checked: {', '.join(checked_paths)}",
+        file=sys.stderr,
+    )
 
 
 def required(name: str) -> str:

--- a/examples/opencode-integration/env_utils.py
+++ b/examples/opencode-integration/env_utils.py
@@ -60,7 +60,8 @@ def required(name: str) -> str:
 
 
 def optional(name: str, default: str = "") -> str:
-    return os.environ.get(name) or default
+    value = os.environ.get(name)
+    return default if value is None else value
 
 
 def int_env(name: str, default: int) -> int:

--- a/examples/opencode-integration/env_utils.py
+++ b/examples/opencode-integration/env_utils.py
@@ -29,10 +29,6 @@ PROVIDER_DEFAULT_HOST = {
 }
 
 PASSTHROUGH_ENV_NAMES = (
-    "ANTHROPIC_API_KEY",
-    "DEEPSEEK_API_KEY",
-    "OPENAI_API_KEY",
-    "OPENROUTER_API_KEY",
     "HTTP_PROXY",
     "HTTPS_PROXY",
     "NO_PROXY",
@@ -134,15 +130,17 @@ def opencode_llm_host(provider: str | None = None) -> str:
 def build_opencode_env(include_secrets: bool = True) -> dict[str, str]:
     provider = opencode_provider()
     env = {
-        "OPENCODE_DISABLE_AUTO_UPDATE": optional("OPENCODE_DISABLE_AUTO_UPDATE", "1"),
+        "OPENCODE_DISABLE_AUTOUPDATE": optional("OPENCODE_DISABLE_AUTOUPDATE", "1"),
     }
     for name in PASSTHROUGH_ENV_NAMES:
         value = os.environ.get(name)
-        if not value:
-            continue
-        if name.endswith("_API_KEY") and not include_secrets:
-            continue
-        env[name] = value
+        if value:
+            env[name] = value
+    if include_secrets:
+        key_name = provider_key_name(provider)
+        key_value = os.environ.get(key_name)
+        if key_value:
+            env[key_name] = key_value
     return env
 
 

--- a/examples/opencode-integration/env_utils.py
+++ b/examples/opencode-integration/env_utils.py
@@ -1,0 +1,226 @@
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import json
+import os
+import shlex
+import sys
+from pathlib import Path
+from urllib.parse import urlparse
+
+from dotenv import load_dotenv
+
+DEFAULT_WORKSPACE = "/workspace"
+
+PROVIDER_KEY_ENV = {
+    "anthropic": "ANTHROPIC_API_KEY",
+    "deepseek": "DEEPSEEK_API_KEY",
+    "openai": "OPENAI_API_KEY",
+    "openrouter": "OPENROUTER_API_KEY",
+}
+
+PROVIDER_DEFAULT_HOST = {
+    "anthropic": "api.anthropic.com",
+    "deepseek": "api.deepseek.com",
+    "openai": "api.openai.com",
+    "openrouter": "openrouter.ai",
+}
+
+PASSTHROUGH_ENV_NAMES = (
+    "ANTHROPIC_API_KEY",
+    "DEEPSEEK_API_KEY",
+    "OPENAI_API_KEY",
+    "OPENROUTER_API_KEY",
+    "HTTP_PROXY",
+    "HTTPS_PROXY",
+    "NO_PROXY",
+)
+
+
+def load_local_dotenv() -> None:
+    candidate_paths = [Path(__file__).with_name(".env"), Path.cwd() / ".env"]
+    seen_paths: set[Path] = set()
+    for path in candidate_paths:
+        resolved = path.resolve()
+        if resolved in seen_paths:
+            continue
+        seen_paths.add(resolved)
+        if path.is_file():
+            load_dotenv(dotenv_path=path, override=False)
+            return
+
+
+def required(name: str) -> str:
+    value = os.environ.get(name)
+    if not value:
+        raise SystemExit(f"Missing required environment variable: {name}")
+    return value
+
+
+def optional(name: str, default: str = "") -> str:
+    return os.environ.get(name) or default
+
+
+def int_env(name: str, default: int) -> int:
+    raw = os.environ.get(name)
+    if not raw:
+        return default
+    try:
+        return int(raw)
+    except ValueError as exc:
+        raise SystemExit(f"{name} must be an integer, got {raw!r}") from exc
+
+
+def opencode_workspace() -> str:
+    return optional("OPENCODE_WORKSPACE", DEFAULT_WORKSPACE)
+
+
+def opencode_model() -> str:
+    model = required("OPENCODE_MODEL").strip()
+    if "/" not in model:
+        raise SystemExit(
+            "OPENCODE_MODEL must be in provider/model form, for example openai/gpt-4.1-mini"
+        )
+    return model
+
+
+def opencode_provider(model: str | None = None) -> str:
+    selected = model or opencode_model()
+    return selected.split("/", 1)[0].strip().lower()
+
+
+def provider_key_name(provider: str | None = None) -> str:
+    provider_name = provider or opencode_provider()
+    return PROVIDER_KEY_ENV.get(provider_name, f"{provider_name.upper()}_API_KEY")
+
+
+def require_provider_key(provider: str | None = None) -> str:
+    key_name = provider_key_name(provider)
+    value = os.environ.get(key_name)
+    if not value:
+        raise SystemExit(f"Missing required environment variable: {key_name}")
+    return value
+
+
+def opencode_base_url(provider: str | None = None) -> str:
+    provider_name = provider or opencode_provider()
+    explicit = os.environ.get("OPENCODE_BASE_URL")
+    if explicit:
+        return explicit
+    provider_specific = os.environ.get(f"{provider_name.upper()}_BASE_URL")
+    return provider_specific or ""
+
+
+def opencode_llm_host(provider: str | None = None) -> str:
+    explicit = os.environ.get("OPENCODE_LLM_HOST")
+    if explicit:
+        return _host_from_url(explicit)
+    base_url = opencode_base_url(provider)
+    if base_url:
+        return _host_from_url(base_url)
+    return PROVIDER_DEFAULT_HOST.get(provider or opencode_provider(), "")
+
+
+def build_opencode_env(include_secrets: bool = True) -> dict[str, str]:
+    provider = opencode_provider()
+    env = {
+        "OPENCODE_DISABLE_AUTO_UPDATE": optional("OPENCODE_DISABLE_AUTO_UPDATE", "1"),
+    }
+    for name in PASSTHROUGH_ENV_NAMES:
+        value = os.environ.get(name)
+        if not value:
+            continue
+        if name.endswith("_API_KEY") and not include_secrets:
+            continue
+        env[name] = value
+    return env
+
+
+def opencode_config_json(provider: str | None = None) -> str:
+    provider_name = provider or opencode_provider()
+    base_url = opencode_base_url(provider_name)
+    config: dict[str, object] = {"$schema": "https://opencode.ai/config.json"}
+    if base_url:
+        config["provider"] = {
+            provider_name: {
+                "options": {
+                    "baseURL": base_url,
+                }
+            }
+        }
+    return json.dumps(config, indent=2, sort_keys=True)
+
+
+def opencode_command(
+    prompt: str,
+    *,
+    workspace: str | None = None,
+    model: str | None = None,
+    title: str | None = None,
+    session: str | None = None,
+    continue_last: bool = False,
+    auto: bool = True,
+    json_format: bool = True,
+) -> str:
+    args = ["opencode", "run"]
+    if model:
+        args.extend(["--model", model])
+    if workspace:
+        args.extend(["--dir", workspace])
+    if title:
+        args.extend(["--title", title])
+    if session:
+        args.extend(["--session", session])
+    elif continue_last:
+        args.append("--continue")
+    if auto:
+        args.append("--auto")
+    if json_format:
+        args.extend(["--format", "json"])
+    args.append(prompt)
+    return " ".join(shlex.quote(arg) for arg in args)
+
+
+def shell_join(*parts: str) -> str:
+    return " && ".join(part for part in parts if part)
+
+
+def setup_dev_sidecar_if_requested() -> None:
+    value = os.environ.get("CUBE_DEV_SIDECAR", "").strip().lower()
+    if value not in ("1", "true", "yes", "on"):
+        return
+    sidecar_dir = Path(__file__).resolve().parents[1] / "e2b-dev-sidecar"
+    if not sidecar_dir.is_dir():
+        raise SystemExit(
+            "CUBE_DEV_SIDECAR=1 was set, but examples/e2b-dev-sidecar was not found."
+        )
+    if str(sidecar_dir) not in sys.path:
+        sys.path.insert(0, str(sidecar_dir))
+    from dev_sidecar import setup_dev_sidecar
+
+    setup_dev_sidecar()
+
+
+def _host_from_url(value: str) -> str:
+    candidate = value.strip()
+    if not candidate:
+        return ""
+    if "://" not in candidate:
+        candidate = f"https://{candidate}"
+    return urlparse(candidate).hostname or ""
+
+
+def provider_inject(provider: str, secret: str) -> list[dict[str, str]]:
+    provider_name = provider.strip().lower()
+    if provider_name == "anthropic":
+        return [
+            {"header": "x-api-key", "secret": secret, "format": "${SECRET}"},
+            {
+                "header": "anthropic-version",
+                "secret": "2023-06-01",
+                "format": "${SECRET}",
+            },
+        ]
+    return [{"header": "Authorization", "secret": secret, "format": "Bearer ${SECRET}"}]

--- a/examples/opencode-integration/network_policy.py
+++ b/examples/opencode-integration/network_policy.py
@@ -98,22 +98,46 @@ def create_sandbox(template_id: str, rules: list[Rule], timeout: int) -> Sandbox
     )
 
 
-def show_key_not_in_vm(sandbox: Sandbox, key_name: str) -> None:
+def verify_key_not_in_vm(sandbox: Sandbox, key_name: str) -> None:
     command = f"printenv {shlex.quote(key_name)} || echo '<unset>'"
     result = run_command(sandbox, command, timeout=30)
     ensure_success(result, "read provider key inside sandbox")
     value = getattr(result, "stdout", "").strip()
-    print(f"In-VM {key_name}: {value!r} (expected placeholder, not the real key)")
+    if value != "<unset>":
+        raise SystemExit(
+            f"Security check failed: {key_name} exists in the sandbox's global environment."
+        )
+    print(f"In-VM global {key_name}: '<unset>' (real secret stays in CubeEgress)")
 
 
-def show_non_llm_blocked(sandbox: Sandbox) -> None:
+def verify_placeholder_env(
+    sandbox: Sandbox, key_name: str, envs: dict[str, str]
+) -> None:
+    command = f"printenv {shlex.quote(key_name)}"
+    result = run_command(sandbox, command, envs=envs, timeout=30)
+    ensure_success(result, "verify provider placeholder inside the agent command")
+    value = getattr(result, "stdout", "").strip()
+    if value != PLACEHOLDER_KEY:
+        raise SystemExit(
+            f"Security check failed: {key_name} was not replaced by the CubeEgress placeholder."
+        )
+    print(f"Agent command {key_name}: '<placeholder>'")
+
+
+def verify_non_llm_blocked(sandbox: Sandbox) -> None:
     command = (
         "curl -s -o /dev/null -w '%{http_code}' --max-time 8 https://example.com "
         "|| echo blocked"
     )
     result = run_command(sandbox, command, timeout=30)
     status = getattr(result, "stdout", "").strip()
-    print(f"Non-LLM host example.com: {status or 'blocked'}")
+    blocked = status == "403" or status.endswith("blocked")
+    if not blocked:
+        raise SystemExit(
+            "Security check failed: non-LLM host example.com was reachable "
+            f"(curl status {status or '<empty>'})."
+        )
+    print(f"Non-LLM host example.com: {status or 'blocked'} (blocked as expected)")
 
 
 def verify_agent_output(sandbox: Sandbox, workspace: str) -> None:
@@ -171,8 +195,9 @@ def main() -> int:
         sandbox_id = sandbox_identifier(sandbox)
         print(f"Sandbox ready: {sandbox_id}\n")
 
-        show_key_not_in_vm(sandbox, key_name)
-        show_non_llm_blocked(sandbox)
+        verify_key_not_in_vm(sandbox, key_name)
+        verify_placeholder_env(sandbox, key_name, envs)
+        verify_non_llm_blocked(sandbox)
         seed_workspace(sandbox, args.workspace)
 
         if args.skip_agent:

--- a/examples/opencode-integration/network_policy.py
+++ b/examples/opencode-integration/network_policy.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Run OpenCode with default-deny egress and CubeEgress credential injection."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import shlex
+import sys
+
+from cubesandbox import Action, Inject, Match, Rule, Sandbox
+
+from _opencode_common import ensure_success, run_command, sandbox_identifier
+from env_utils import (
+    build_opencode_env,
+    int_env,
+    load_local_dotenv,
+    opencode_command,
+    opencode_config_json,
+    opencode_llm_host,
+    opencode_model,
+    opencode_provider,
+    opencode_workspace,
+    provider_inject,
+    provider_key_name,
+    require_provider_key,
+    required,
+    shell_join,
+)
+
+PLACEHOLDER_KEY = "cube-egress-managed-placeholder"
+DEFAULT_PROMPT = (
+    "Create {workspace}/egress_check.md containing exactly OPENCODE_EGRESS_OK. "
+    "Use the write tool or shell redirection, then stop only after the file exists."
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Run OpenCode under a restricted CubeEgress policy."
+    )
+    parser.add_argument("--template", default=os.environ.get("CUBE_TEMPLATE_ID"))
+    parser.add_argument("--host", default=None)
+    parser.add_argument("--workspace", default=opencode_workspace())
+    parser.add_argument("--prompt", default=None)
+    parser.add_argument("--title", default="cube-opencode-egress")
+    parser.add_argument(
+        "--sandbox-timeout",
+        type=int,
+        default=int_env("OPENCODE_SANDBOX_TIMEOUT", 1800),
+    )
+    parser.add_argument(
+        "--exec-timeout",
+        type=int,
+        default=int_env("OPENCODE_EXEC_TIMEOUT", 900),
+    )
+    parser.add_argument("--skip-agent", action="store_true")
+    args = parser.parse_args()
+    if args.prompt is None:
+        args.prompt = DEFAULT_PROMPT.format(workspace=args.workspace)
+    return args
+
+
+def build_rules(provider: str, host: str, secret: str) -> list[Rule]:
+    return [
+        Rule(
+            name=f"allow_{provider}_llm",
+            match=Match(scheme="https", sni=host, host=host),
+            action=Action(
+                allow=True,
+                audit="metadata",
+                inject=[Inject(**spec) for spec in provider_inject(provider, secret)],
+            ),
+        )
+    ]
+
+
+def seed_workspace(sandbox: Sandbox, workspace: str) -> None:
+    quoted_workspace = shlex.quote(workspace)
+    command = f"""mkdir -p {quoted_workspace}
+cat > {quoted_workspace}/opencode.json <<'EOF'
+{opencode_config_json()}
+EOF
+"""
+    result = run_command(sandbox, command, timeout=60)
+    ensure_success(result, "seed egress workspace")
+
+
+def create_sandbox(template_id: str, rules: list[Rule], timeout: int) -> Sandbox:
+    return Sandbox.create(
+        template=template_id,
+        allow_internet_access=False,
+        network={"rules": rules},
+        timeout=timeout,
+    )
+
+
+def show_key_not_in_vm(sandbox: Sandbox, key_name: str) -> None:
+    command = f"printenv {shlex.quote(key_name)} || echo '<unset>'"
+    result = run_command(sandbox, command, timeout=30)
+    ensure_success(result, "read provider key inside sandbox")
+    value = getattr(result, "stdout", "").strip()
+    print(f"In-VM {key_name}: {value!r} (expected placeholder, not the real key)")
+
+
+def show_non_llm_blocked(sandbox: Sandbox) -> None:
+    command = (
+        "curl -s -o /dev/null -w '%{http_code}' --max-time 8 https://example.com "
+        "|| echo blocked"
+    )
+    result = run_command(sandbox, command, timeout=30)
+    status = getattr(result, "stdout", "").strip()
+    print(f"Non-LLM host example.com: {status or 'blocked'}")
+
+
+def verify_agent_output(sandbox: Sandbox, workspace: str) -> None:
+    quoted_workspace = shlex.quote(workspace)
+    command = shell_join(
+        f"test -f {quoted_workspace}/egress_check.md",
+        f"grep -q OPENCODE_EGRESS_OK {quoted_workspace}/egress_check.md",
+        f"cat {quoted_workspace}/egress_check.md",
+    )
+    result = run_command(sandbox, command, timeout=60)
+    ensure_success(result, "verify egress demo output")
+    if getattr(result, "stdout", ""):
+        print(result.stdout)
+
+
+def print_command_output(result) -> None:
+    stdout = getattr(result, "stdout", "")
+    stderr = getattr(result, "stderr", "")
+    if stdout:
+        print(stdout)
+    if stderr:
+        print(stderr, file=sys.stderr)
+
+
+def main() -> int:
+    load_local_dotenv()
+    args = parse_args()
+
+    template_id = args.template or required("CUBE_TEMPLATE_ID")
+    required("E2B_API_URL")
+    required("E2B_API_KEY")
+    model = opencode_model()
+    provider = opencode_provider(model)
+    secret = require_provider_key(provider)
+    host = args.host or opencode_llm_host(provider)
+    if not host:
+        raise SystemExit("Set OPENCODE_LLM_HOST or OPENCODE_BASE_URL for this provider.")
+
+    key_name = provider_key_name(provider)
+    envs = build_opencode_env(include_secrets=False)
+    envs[key_name] = PLACEHOLDER_KEY
+
+    rules = build_rules(provider, host, secret)
+    sandbox = None
+    sandbox_id = "unknown"
+    try:
+        print(f"Provider: {provider}")
+        print(f"Allowed LLM host: {host}")
+        print(f"Creating sandbox from template: {template_id}")
+        sandbox = create_sandbox(template_id, rules, args.sandbox_timeout)
+        sandbox_id = sandbox_identifier(sandbox)
+        print(f"Sandbox ready: {sandbox_id}\n")
+
+        show_key_not_in_vm(sandbox, key_name)
+        show_non_llm_blocked(sandbox)
+        seed_workspace(sandbox, args.workspace)
+
+        if args.skip_agent:
+            print("\n--skip-agent set: not invoking OpenCode.")
+            return 0
+
+        command = opencode_command(
+            args.prompt,
+            workspace=args.workspace,
+            model=model,
+            title=args.title,
+        )
+        print("\nRunning OpenCode through CubeEgress injection...\n")
+        result = run_command(
+            sandbox,
+            command,
+            cwd=args.workspace,
+            envs=envs,
+            timeout=args.exec_timeout,
+            stream=True,
+        )
+        ensure_success(result, "run OpenCode with restricted egress")
+        print_command_output(result)
+        verify_agent_output(sandbox, args.workspace)
+        return 0
+    finally:
+        if sandbox is not None:
+            try:
+                sandbox.kill()
+                print(f"\nSandbox {sandbox_id} killed.")
+            except Exception as exc:  # noqa: BLE001
+                print(
+                    f"Warning: failed to kill sandbox {sandbox_id}: {exc}",
+                    file=sys.stderr,
+                )
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/examples/opencode-integration/network_policy.py
+++ b/examples/opencode-integration/network_policy.py
@@ -138,13 +138,17 @@ def print_command_output(result) -> None:
         print(stderr, file=sys.stderr)
 
 
+def require_native_sdk_env() -> None:
+    required("CUBE_API_URL")
+    required("CUBE_PROXY_NODE_IP")
+
+
 def main() -> int:
     load_local_dotenv()
     args = parse_args()
 
     template_id = args.template or required("CUBE_TEMPLATE_ID")
-    required("E2B_API_URL")
-    required("E2B_API_KEY")
+    require_native_sdk_env()
     model = opencode_model()
     provider = opencode_provider(model)
     secret = require_provider_key(provider)

--- a/examples/opencode-integration/network_policy.py
+++ b/examples/opencode-integration/network_policy.py
@@ -11,9 +11,18 @@ import os
 import shlex
 import sys
 
-from cubesandbox import Action, Inject, Match, Rule, Sandbox
+from cubesandbox import Sandbox
 
 from _opencode_common import ensure_success, run_command, sandbox_identifier
+from egress_policy import (
+    PLACEHOLDER_KEY,
+    build_rules,
+    create_sandbox,
+    require_native_sdk_env,
+    verify_key_not_in_vm,
+    verify_non_llm_blocked,
+    verify_placeholder_env,
+)
 from env_utils import (
     build_opencode_env,
     int_env,
@@ -24,14 +33,12 @@ from env_utils import (
     opencode_model,
     opencode_provider,
     opencode_workspace,
-    provider_inject,
     provider_key_name,
     require_provider_key,
     required,
     shell_join,
 )
 
-PLACEHOLDER_KEY = "cube-egress-managed-placeholder"
 DEFAULT_PROMPT = (
     "Create {workspace}/egress_check.md containing exactly OPENCODE_EGRESS_OK. "
     "Use the write tool or shell redirection, then stop only after the file exists."
@@ -64,20 +71,6 @@ def parse_args() -> argparse.Namespace:
     return args
 
 
-def build_rules(provider: str, host: str, secret: str) -> list[Rule]:
-    return [
-        Rule(
-            name=f"allow_{provider}_llm",
-            match=Match(scheme="https", sni=host, host=host),
-            action=Action(
-                allow=True,
-                audit="metadata",
-                inject=[Inject(**spec) for spec in provider_inject(provider, secret)],
-            ),
-        )
-    ]
-
-
 def seed_workspace(sandbox: Sandbox, workspace: str) -> None:
     quoted_workspace = shlex.quote(workspace)
     command = f"""mkdir -p {quoted_workspace}
@@ -87,57 +80,6 @@ EOF
 """
     result = run_command(sandbox, command, timeout=60)
     ensure_success(result, "seed egress workspace")
-
-
-def create_sandbox(template_id: str, rules: list[Rule], timeout: int) -> Sandbox:
-    return Sandbox.create(
-        template=template_id,
-        allow_internet_access=False,
-        network={"rules": rules},
-        timeout=timeout,
-    )
-
-
-def verify_key_not_in_vm(sandbox: Sandbox, key_name: str) -> None:
-    command = f"printenv {shlex.quote(key_name)} || echo '<unset>'"
-    result = run_command(sandbox, command, timeout=30)
-    ensure_success(result, "read provider key inside sandbox")
-    value = getattr(result, "stdout", "").strip()
-    if value != "<unset>":
-        raise SystemExit(
-            f"Security check failed: {key_name} exists in the sandbox's global environment."
-        )
-    print(f"In-VM global {key_name}: '<unset>' (real secret stays in CubeEgress)")
-
-
-def verify_placeholder_env(
-    sandbox: Sandbox, key_name: str, envs: dict[str, str]
-) -> None:
-    command = f"printenv {shlex.quote(key_name)}"
-    result = run_command(sandbox, command, envs=envs, timeout=30)
-    ensure_success(result, "verify provider placeholder inside the agent command")
-    value = getattr(result, "stdout", "").strip()
-    if value != PLACEHOLDER_KEY:
-        raise SystemExit(
-            f"Security check failed: {key_name} was not replaced by the CubeEgress placeholder."
-        )
-    print(f"Agent command {key_name}: '<placeholder>'")
-
-
-def verify_non_llm_blocked(sandbox: Sandbox) -> None:
-    command = (
-        "curl -s -o /dev/null -w '%{http_code}' --max-time 8 https://example.com "
-        "|| echo blocked"
-    )
-    result = run_command(sandbox, command, timeout=30)
-    status = getattr(result, "stdout", "").strip()
-    blocked = status == "403" or status.endswith("blocked")
-    if not blocked:
-        raise SystemExit(
-            "Security check failed: non-LLM host example.com was reachable "
-            f"(curl status {status or '<empty>'})."
-        )
-    print(f"Non-LLM host example.com: {status or 'blocked'} (blocked as expected)")
 
 
 def verify_agent_output(sandbox: Sandbox, workspace: str) -> None:
@@ -160,11 +102,6 @@ def print_command_output(result) -> None:
         print(stdout)
     if stderr:
         print(stderr, file=sys.stderr)
-
-
-def require_native_sdk_env() -> None:
-    required("CUBE_API_URL")
-    required("CUBE_PROXY_NODE_IP")
 
 
 def main() -> int:

--- a/examples/opencode-integration/requirements.txt
+++ b/examples/opencode-integration/requirements.txt
@@ -1,0 +1,3 @@
+e2b>=2.4.1
+cubesandbox>=0.3.0
+python-dotenv>=1.0.0

--- a/examples/opencode-integration/requirements.txt
+++ b/examples/opencode-integration/requirements.txt
@@ -1,3 +1,3 @@
-e2b>=2.4.1
-cubesandbox>=0.3.0
-python-dotenv>=1.0.0
+e2b==2.7.0
+cubesandbox==0.3.0
+python-dotenv==1.0.1

--- a/examples/opencode-integration/resume_opencode.py
+++ b/examples/opencode-integration/resume_opencode.py
@@ -13,7 +13,12 @@ import sys
 
 from e2b import Sandbox
 
-from _opencode_common import ensure_success, run_command, sandbox_identifier
+from _opencode_common import (
+    ensure_success,
+    run_command,
+    sandbox_identifier,
+    warn_direct_secret_env,
+)
 from env_utils import (
     build_opencode_env,
     int_env,
@@ -23,6 +28,7 @@ from env_utils import (
     opencode_model,
     opencode_provider,
     opencode_workspace,
+    provider_key_name,
     require_provider_key,
     required,
     setup_dev_sidecar_if_requested,
@@ -162,9 +168,11 @@ def main() -> int:
     model = opencode_model()
     provider = opencode_provider(model)
     require_provider_key(provider)
+    key_name = provider_key_name(provider)
     envs = build_opencode_env(include_secrets=True)
 
     setup_dev_sidecar_if_requested()
+    warn_direct_secret_env(key_name)
 
     sandbox = None
     sandbox_id = "unknown"

--- a/examples/opencode-integration/resume_opencode.py
+++ b/examples/opencode-integration/resume_opencode.py
@@ -15,6 +15,7 @@ from e2b import Sandbox
 
 from _opencode_common import (
     ensure_success,
+    pause_sandbox,
     run_command,
     sandbox_identifier,
     warn_direct_secret_env,
@@ -197,9 +198,7 @@ def main() -> int:
         ensure_success(result_1, "run OpenCode turn 1")
 
         print(f"\nPausing sandbox {sandbox_id}...")
-        paused_id = sandbox.pause()
-        if isinstance(paused_id, str) and paused_id:
-            sandbox_id = paused_id
+        sandbox_id = pause_sandbox(sandbox)
         print(f"Paused. Resume handle: {sandbox_id}")
 
         print(f"\nReconnecting to {sandbox_id}...")

--- a/examples/opencode-integration/resume_opencode.py
+++ b/examples/opencode-integration/resume_opencode.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Demonstrate OpenCode state persistence across CubeSandbox pause/resume."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import shlex
+import sys
+
+from e2b import Sandbox
+
+from _opencode_common import ensure_success, run_command, sandbox_identifier
+from env_utils import (
+    build_opencode_env,
+    int_env,
+    load_local_dotenv,
+    opencode_command,
+    opencode_config_json,
+    opencode_model,
+    opencode_provider,
+    opencode_workspace,
+    require_provider_key,
+    required,
+    setup_dev_sidecar_if_requested,
+    shell_join,
+)
+
+TURN_1_PROMPT = (
+    "In {workspace}, create plan.md with a numbered two-step plan for adding a "
+    "multiply function to calculator.py. Only write plan.md."
+)
+
+TURN_2_PROMPT = (
+    "Continue from the previous session. Read plan.md, add multiply(a, b) to "
+    "calculator.py, add a unittest for multiply(4, 5) == 20, run "
+    "`python3 -m unittest discover -v`, and write progress.md with the exact "
+    "marker OPENCODE_RESUME_OK."
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Run OpenCode before and after CubeSandbox pause/resume."
+    )
+    parser.add_argument("--template", default=os.environ.get("CUBE_TEMPLATE_ID"))
+    parser.add_argument("--workspace", default=opencode_workspace())
+    parser.add_argument("--title", default="cube-opencode-resume")
+    parser.add_argument(
+        "--sandbox-timeout",
+        type=int,
+        default=int_env("OPENCODE_SANDBOX_TIMEOUT", 1800),
+    )
+    parser.add_argument(
+        "--exec-timeout",
+        type=int,
+        default=int_env("OPENCODE_EXEC_TIMEOUT", 900),
+    )
+    return parser.parse_args()
+
+
+def seed_project(sandbox: Sandbox, workspace: str, timeout: int) -> None:
+    quoted_workspace = shlex.quote(workspace)
+    command = f"""mkdir -p {quoted_workspace}
+cat > {quoted_workspace}/opencode.json <<'EOF'
+{opencode_config_json()}
+EOF
+cat > {quoted_workspace}/calculator.py <<'EOF'
+def add(a: int, b: int) -> int:
+    return a + b
+EOF
+cat > {quoted_workspace}/test_calculator.py <<'EOF'
+import unittest
+
+from calculator import add
+
+
+class CalculatorTest(unittest.TestCase):
+    def test_adds_two_numbers(self) -> None:
+        self.assertEqual(add(2, 3), 5)
+
+
+if __name__ == "__main__":
+    unittest.main()
+EOF
+"""
+    result = run_command(sandbox, command, timeout=timeout)
+    ensure_success(result, "seed resume workspace")
+
+
+def run_turn(
+    sandbox: Sandbox,
+    workspace: str,
+    prompt: str,
+    title: str,
+    model: str,
+    envs: dict[str, str],
+    timeout: int,
+    *,
+    continue_last: bool = False,
+):
+    command = opencode_command(
+        prompt,
+        workspace=workspace,
+        model=model,
+        title=title,
+        continue_last=continue_last,
+    )
+    return run_command(
+        sandbox,
+        command,
+        cwd=workspace,
+        envs=envs,
+        timeout=timeout,
+        stream=True,
+    )
+
+
+def verify_after_resume(sandbox: Sandbox, workspace: str) -> None:
+    quoted_workspace = shlex.quote(workspace)
+    command = shell_join(
+        f"cd {quoted_workspace}",
+        "test -f plan.md",
+        "test -f calculator.py",
+        "test -d /root/.local/share/opencode",
+        "printf '\\n--- plan.md survived pause/resume ---\\n'",
+        "cat plan.md",
+    )
+    result = run_command(sandbox, command, timeout=60)
+    ensure_success(result, "verify OpenCode state survived pause/resume")
+    if getattr(result, "stdout", ""):
+        print(result.stdout)
+
+
+def verify_final(sandbox: Sandbox, workspace: str) -> None:
+    quoted_workspace = shlex.quote(workspace)
+    command = shell_join(
+        f"cd {quoted_workspace}",
+        "python3 -m unittest discover -v",
+        "grep -q 'def multiply' calculator.py",
+        "test -f progress.md",
+        "grep -q OPENCODE_RESUME_OK progress.md",
+        "printf '\\n--- progress.md ---\\n'",
+        "cat progress.md",
+    )
+    result = run_command(sandbox, command, timeout=120)
+    ensure_success(result, "verify final resumed output")
+    if getattr(result, "stdout", ""):
+        print(result.stdout)
+
+
+def main() -> int:
+    load_local_dotenv()
+    args = parse_args()
+
+    template_id = args.template or required("CUBE_TEMPLATE_ID")
+    required("E2B_API_URL")
+    required("E2B_API_KEY")
+    model = opencode_model()
+    provider = opencode_provider(model)
+    require_provider_key(provider)
+    envs = build_opencode_env(include_secrets=True)
+
+    setup_dev_sidecar_if_requested()
+
+    sandbox = None
+    sandbox_id = "unknown"
+    try:
+        print(f"Creating sandbox from template: {template_id}")
+        sandbox = Sandbox.create(template=template_id, timeout=args.sandbox_timeout)
+        sandbox_id = sandbox_identifier(sandbox)
+        print(f"Sandbox ready: {sandbox_id}")
+
+        seed_project(sandbox, args.workspace, timeout=60)
+
+        print("\n=== Turn 1: create plan.md ===\n")
+        result_1 = run_turn(
+            sandbox,
+            args.workspace,
+            TURN_1_PROMPT.format(workspace=args.workspace),
+            args.title,
+            model,
+            envs,
+            args.exec_timeout,
+        )
+        ensure_success(result_1, "run OpenCode turn 1")
+
+        print(f"\nPausing sandbox {sandbox_id}...")
+        paused_id = sandbox.pause()
+        if isinstance(paused_id, str) and paused_id:
+            sandbox_id = paused_id
+        print(f"Paused. Resume handle: {sandbox_id}")
+
+        print(f"\nReconnecting to {sandbox_id}...")
+        sandbox = Sandbox.connect(sandbox_id=sandbox_id)
+        print("Reconnected after resume.")
+
+        verify_after_resume(sandbox, args.workspace)
+
+        print("\n=== Turn 2: continue after resume ===\n")
+        result_2 = run_turn(
+            sandbox,
+            args.workspace,
+            TURN_2_PROMPT,
+            args.title,
+            model,
+            envs,
+            args.exec_timeout,
+            continue_last=True,
+        )
+        ensure_success(result_2, "run OpenCode turn 2")
+
+        verify_final(sandbox, args.workspace)
+        return 0
+    finally:
+        if sandbox is not None:
+            try:
+                sandbox.kill()
+                print(f"\nSandbox {sandbox_id} killed.")
+            except Exception as exc:  # noqa: BLE001
+                print(
+                    f"Warning: failed to kill sandbox {sandbox_id}: {exc}",
+                    file=sys.stderr,
+                )
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/examples/opencode-integration/run_opencode.py
+++ b/examples/opencode-integration/run_opencode.py
@@ -9,7 +9,12 @@ import os
 import shlex
 import sys
 
-from _opencode_common import ensure_success, run_command, sandbox_identifier
+from _opencode_common import (
+    ensure_success,
+    run_command,
+    sandbox_identifier,
+    warn_direct_secret_env,
+)
 from env_utils import (
     build_opencode_env,
     int_env,
@@ -19,6 +24,7 @@ from env_utils import (
     opencode_model,
     opencode_provider,
     opencode_workspace,
+    provider_key_name,
     require_provider_key,
     required,
     setup_dev_sidecar_if_requested,
@@ -57,6 +63,7 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument("--dry-run", action="store_true")
     parser.add_argument("--keep-alive", action="store_true")
+    parser.add_argument("--verbose", action="store_true")
     parser.add_argument("--raw", action="store_true", help="Reserved for symmetry.")
     args = parser.parse_args()
     if args.prompt is None:
@@ -129,6 +136,7 @@ def main() -> int:
     model = opencode_model()
     provider = opencode_provider(model)
     require_provider_key(provider)
+    key_name = provider_key_name(provider)
 
     command = opencode_command(
         args.prompt,
@@ -148,6 +156,7 @@ def main() -> int:
         return 0
 
     setup_dev_sidecar_if_requested()
+    warn_direct_secret_env(key_name)
     from e2b import Sandbox
 
     print(f"Creating sandbox from template: {template_id}")
@@ -158,9 +167,10 @@ def main() -> int:
         sandbox_id = sandbox_identifier(sandbox)
         print(f"Sandbox ready: {sandbox_id}")
 
-        version_result = run_command(sandbox, "opencode --version", timeout=60)
-        ensure_success(version_result, "check OpenCode version")
-        print(f"OpenCode version: {getattr(version_result, 'stdout', '').strip()}")
+        if args.verbose:
+            version_result = run_command(sandbox, "opencode --version", timeout=60)
+            ensure_success(version_result, "check OpenCode version")
+            print(f"OpenCode version: {getattr(version_result, 'stdout', '').strip()}")
 
         seed_project(sandbox, args.workspace, timeout=60)
         print(f"Seeded deterministic project in {args.workspace}")

--- a/examples/opencode-integration/run_opencode.py
+++ b/examples/opencode-integration/run_opencode.py
@@ -1,0 +1,194 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import argparse
+import os
+import shlex
+import sys
+
+from _opencode_common import ensure_success, run_command, sandbox_identifier
+from env_utils import (
+    build_opencode_env,
+    int_env,
+    load_local_dotenv,
+    opencode_command,
+    opencode_config_json,
+    opencode_model,
+    opencode_provider,
+    opencode_workspace,
+    require_provider_key,
+    required,
+    setup_dev_sidecar_if_requested,
+    shell_join,
+)
+
+DEFAULT_PROMPT_TEMPLATE = (
+    "You are in {workspace}. Implement the missing add(a, b) function in "
+    "calculator.py, run `python3 -m unittest discover -v`, and write "
+    "{workspace}/result.md containing the exact marker OPENCODE_CUBE_OK plus "
+    "one short sentence about the test result."
+)
+
+
+def default_prompt(workspace: str) -> str:
+    return DEFAULT_PROMPT_TEMPLATE.format(workspace=workspace)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Run a one-shot OpenCode coding-agent task inside CubeSandbox."
+    )
+    parser.add_argument("--template", default=os.environ.get("CUBE_TEMPLATE_ID"))
+    parser.add_argument("--prompt", default=None)
+    parser.add_argument("--workspace", default=opencode_workspace())
+    parser.add_argument("--title", default="cube-opencode-demo")
+    parser.add_argument(
+        "--sandbox-timeout",
+        type=int,
+        default=int_env("OPENCODE_SANDBOX_TIMEOUT", 1800),
+    )
+    parser.add_argument(
+        "--exec-timeout",
+        type=int,
+        default=int_env("OPENCODE_EXEC_TIMEOUT", 900),
+    )
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--keep-alive", action="store_true")
+    parser.add_argument("--raw", action="store_true", help="Reserved for symmetry.")
+    args = parser.parse_args()
+    if args.prompt is None:
+        args.prompt = default_prompt(args.workspace)
+    return args
+
+
+def seed_project(sandbox, workspace: str, timeout: int) -> None:
+    quoted_workspace = shlex.quote(workspace)
+    config_json = opencode_config_json()
+    command = f"""mkdir -p {quoted_workspace}
+cat > {quoted_workspace}/opencode.json <<'EOF'
+{config_json}
+EOF
+cat > {quoted_workspace}/calculator.py <<'EOF'
+def add(a: int, b: int) -> int:
+    raise NotImplementedError("OpenCode should implement this")
+
+
+if __name__ == "__main__":
+    print(add(2, 3))
+EOF
+cat > {quoted_workspace}/test_calculator.py <<'EOF'
+import unittest
+
+from calculator import add
+
+
+class CalculatorTest(unittest.TestCase):
+    def test_adds_two_numbers(self) -> None:
+        self.assertEqual(add(2, 3), 5)
+
+
+if __name__ == "__main__":
+    unittest.main()
+EOF
+cat > {quoted_workspace}/README.md <<'EOF'
+# CubeSandbox OpenCode Smoke Project
+
+Implement calculator.add, run the test, and summarize the result.
+EOF
+"""
+    result = run_command(sandbox, command, timeout=timeout)
+    ensure_success(result, "seed OpenCode workspace")
+
+
+def verify_workspace(sandbox, workspace: str, timeout: int) -> None:
+    quoted_workspace = shlex.quote(workspace)
+    command = shell_join(
+        f"cd {quoted_workspace}",
+        "python3 -m unittest discover -v",
+        "test -f result.md",
+        "grep -q OPENCODE_CUBE_OK result.md",
+        "printf '\\n--- result.md ---\\n'",
+        "cat result.md",
+    )
+    result = run_command(sandbox, command, timeout=timeout)
+    ensure_success(result, "verify OpenCode output")
+    if getattr(result, "stdout", ""):
+        print(result.stdout)
+
+
+def main() -> int:
+    load_local_dotenv()
+    args = parse_args()
+
+    template_id = args.template or required("CUBE_TEMPLATE_ID")
+    required("E2B_API_URL")
+    required("E2B_API_KEY")
+    model = opencode_model()
+    provider = opencode_provider(model)
+    require_provider_key(provider)
+
+    command = opencode_command(
+        args.prompt,
+        workspace=args.workspace,
+        model=model,
+        title=args.title,
+    )
+    envs = build_opencode_env(include_secrets=True)
+
+    if args.dry_run:
+        print(f"Template: {template_id}")
+        print(f"Provider: {provider}")
+        print(f"Model: {model}")
+        print(f"Workspace: {args.workspace}")
+        print(f"Command: {command}")
+        print("Secrets: redacted")
+        return 0
+
+    setup_dev_sidecar_if_requested()
+    from e2b import Sandbox
+
+    print(f"Creating sandbox from template: {template_id}")
+    sandbox = None
+    result = None
+    try:
+        sandbox = Sandbox.create(template=template_id, timeout=args.sandbox_timeout)
+        sandbox_id = sandbox_identifier(sandbox)
+        print(f"Sandbox ready: {sandbox_id}")
+
+        version_result = run_command(sandbox, "opencode --version", timeout=60)
+        ensure_success(version_result, "check OpenCode version")
+        print(f"OpenCode version: {getattr(version_result, 'stdout', '').strip()}")
+
+        seed_project(sandbox, args.workspace, timeout=60)
+        print(f"Seeded deterministic project in {args.workspace}")
+
+        print("\nRunning OpenCode task...\n")
+        result = run_command(
+            sandbox,
+            command,
+            cwd=args.workspace,
+            envs=envs,
+            timeout=args.exec_timeout,
+            stream=True,
+        )
+        ensure_success(result, "run OpenCode")
+
+        print("\nVerifying generated project state...")
+        verify_workspace(sandbox, args.workspace, timeout=120)
+        return 0
+    finally:
+        if sandbox is not None and not args.keep_alive:
+            try:
+                sandbox.kill()
+                print("\nSandbox killed.")
+            except Exception as exc:  # noqa: BLE001
+                print(f"Warning: failed to kill sandbox: {exc}", file=sys.stderr)
+        elif sandbox is not None:
+            print(f"\nSandbox kept alive: {sandbox_identifier(sandbox)}")
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/examples/opencode-integration/test_commands.py
+++ b/examples/opencode-integration/test_commands.py
@@ -1,0 +1,47 @@
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import unittest
+
+from env_utils import opencode_command
+
+
+class CommandTest(unittest.TestCase):
+    def test_opencode_command_uses_headless_run_mode(self) -> None:
+        command = opencode_command(
+            "fix tests",
+            workspace="/workspace",
+            model="openai/gpt-4.1-mini",
+            title="cube-demo",
+        )
+        self.assertIn("opencode run", command)
+        self.assertIn("--model openai/gpt-4.1-mini", command)
+        self.assertIn("--dir /workspace", command)
+        self.assertIn("--auto", command)
+        self.assertIn("--format json", command)
+
+    def test_prompt_is_shell_quoted(self) -> None:
+        prompt = 'write file"; touch /tmp/pwned; echo "'
+        command = opencode_command(
+            prompt,
+            workspace="/workspace",
+            model="openai/gpt-4.1-mini",
+        )
+        self.assertIn("'write file", command)
+        self.assertIn("touch /tmp/pwned", command)
+        self.assertTrue(command.endswith("'"))
+
+    def test_continue_last_switch(self) -> None:
+        command = opencode_command(
+            "continue",
+            workspace="/workspace",
+            model="openai/gpt-4.1-mini",
+            continue_last=True,
+        )
+        self.assertIn("--continue", command)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/examples/opencode-integration/test_commands.py
+++ b/examples/opencode-integration/test_commands.py
@@ -3,7 +3,11 @@
 
 from __future__ import annotations
 
+import sys
 import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
 
 from env_utils import opencode_command
 

--- a/examples/opencode-integration/test_env_utils.py
+++ b/examples/opencode-integration/test_env_utils.py
@@ -1,0 +1,60 @@
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import os
+import unittest
+from unittest.mock import patch
+
+import env_utils
+
+
+class EnvUtilsTest(unittest.TestCase):
+    def test_model_must_include_provider_prefix(self) -> None:
+        with patch.dict(os.environ, {"OPENCODE_MODEL": "gpt-4.1-mini"}, clear=True):
+            with self.assertRaises(SystemExit):
+                env_utils.opencode_model()
+
+    def test_provider_is_model_prefix(self) -> None:
+        with patch.dict(os.environ, {"OPENCODE_MODEL": "openai/gpt-4.1-mini"}, clear=True):
+            self.assertEqual(env_utils.opencode_provider(), "openai")
+
+    def test_provider_key_name_defaults_from_prefix(self) -> None:
+        self.assertEqual(env_utils.provider_key_name("openai"), "OPENAI_API_KEY")
+        self.assertEqual(env_utils.provider_key_name("deepseek"), "DEEPSEEK_API_KEY")
+        self.assertEqual(env_utils.provider_key_name("custom"), "CUSTOM_API_KEY")
+
+    def test_build_env_omits_all_api_keys_for_vault_mode(self) -> None:
+        env = {
+            "OPENCODE_MODEL": "openai/gpt-4.1-mini",
+            "OPENAI_API_KEY": "sk-openai",
+            "ANTHROPIC_API_KEY": "sk-anthropic",
+            "HTTPS_PROXY": "http://proxy.local:8080",
+        }
+        with patch.dict(os.environ, env, clear=True):
+            result = env_utils.build_opencode_env(include_secrets=False)
+        self.assertNotIn("OPENAI_API_KEY", result)
+        self.assertNotIn("ANTHROPIC_API_KEY", result)
+        self.assertEqual(result["HTTPS_PROXY"], "http://proxy.local:8080")
+
+    def test_llm_host_prefers_base_url(self) -> None:
+        env = {
+            "OPENCODE_MODEL": "openai/gpt-4.1-mini",
+            "OPENCODE_BASE_URL": "https://llm.example.test/v1",
+        }
+        with patch.dict(os.environ, env, clear=True):
+            self.assertEqual(env_utils.opencode_llm_host("openai"), "llm.example.test")
+
+    def test_config_json_contains_base_url_only_when_set(self) -> None:
+        env = {
+            "OPENCODE_MODEL": "openai/gpt-4.1-mini",
+            "OPENCODE_BASE_URL": "https://llm.example.test/v1",
+        }
+        with patch.dict(os.environ, env, clear=True):
+            config = env_utils.opencode_config_json("openai")
+        self.assertIn('"baseURL": "https://llm.example.test/v1"', config)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/examples/opencode-integration/test_env_utils.py
+++ b/examples/opencode-integration/test_env_utils.py
@@ -4,8 +4,12 @@
 from __future__ import annotations
 
 import os
+import sys
 import unittest
+from pathlib import Path
 from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
 
 import env_utils
 
@@ -38,6 +42,19 @@ class EnvUtilsTest(unittest.TestCase):
         self.assertNotIn("ANTHROPIC_API_KEY", result)
         self.assertEqual(result["HTTPS_PROXY"], "http://proxy.local:8080")
 
+    def test_build_env_includes_provider_keys_by_default(self) -> None:
+        env = {
+            "OPENCODE_MODEL": "openai/gpt-4.1-mini",
+            "OPENAI_API_KEY": "sk-openai",
+        }
+        with patch.dict(os.environ, env, clear=True):
+            result = env_utils.build_opencode_env()
+        self.assertEqual(result["OPENAI_API_KEY"], "sk-openai")
+
+    def test_optional_preserves_empty_string(self) -> None:
+        with patch.dict(os.environ, {"OPENCODE_DISABLE_AUTO_UPDATE": ""}, clear=True):
+            self.assertEqual(env_utils.optional("OPENCODE_DISABLE_AUTO_UPDATE", "1"), "")
+
     def test_llm_host_prefers_base_url(self) -> None:
         env = {
             "OPENCODE_MODEL": "openai/gpt-4.1-mini",
@@ -45,6 +62,17 @@ class EnvUtilsTest(unittest.TestCase):
         }
         with patch.dict(os.environ, env, clear=True):
             self.assertEqual(env_utils.opencode_llm_host("openai"), "llm.example.test")
+
+    def test_base_url_uses_provider_specific_fallback(self) -> None:
+        env = {
+            "OPENCODE_MODEL": "openai/gpt-4.1-mini",
+            "OPENAI_BASE_URL": "https://openai-compatible.example/v1",
+        }
+        with patch.dict(os.environ, env, clear=True):
+            self.assertEqual(
+                env_utils.opencode_base_url("openai"),
+                "https://openai-compatible.example/v1",
+            )
 
     def test_config_json_contains_base_url_only_when_set(self) -> None:
         env = {
@@ -54,6 +82,25 @@ class EnvUtilsTest(unittest.TestCase):
         with patch.dict(os.environ, env, clear=True):
             config = env_utils.opencode_config_json("openai")
         self.assertIn('"baseURL": "https://llm.example.test/v1"', config)
+
+    def test_provider_inject_uses_bearer_header_for_openai_style_providers(self) -> None:
+        self.assertEqual(
+            env_utils.provider_inject("deepseek", "sk-test"),
+            [{"header": "Authorization", "secret": "sk-test", "format": "Bearer ${SECRET}"}],
+        )
+
+    def test_provider_inject_uses_anthropic_headers(self) -> None:
+        self.assertEqual(
+            env_utils.provider_inject("anthropic", "sk-ant"),
+            [
+                {"header": "x-api-key", "secret": "sk-ant", "format": "${SECRET}"},
+                {
+                    "header": "anthropic-version",
+                    "secret": "2023-06-01",
+                    "format": "${SECRET}",
+                },
+            ],
+        )
 
 
 if __name__ == "__main__":

--- a/examples/opencode-integration/test_env_utils.py
+++ b/examples/opencode-integration/test_env_utils.py
@@ -53,18 +53,30 @@ class EnvUtilsTest(unittest.TestCase):
         self.assertNotIn("ANTHROPIC_API_KEY", result)
         self.assertEqual(result["HTTPS_PROXY"], "http://proxy.local:8080")
 
-    def test_build_env_includes_provider_keys_by_default(self) -> None:
+    def test_build_env_includes_only_active_provider_key_by_default(self) -> None:
+        env = {
+            "OPENCODE_MODEL": "openai/gpt-4.1-mini",
+            "OPENAI_API_KEY": "sk-openai",
+            "ANTHROPIC_API_KEY": "sk-anthropic-must-not-leak",
+        }
+        with patch.dict(os.environ, env, clear=True):
+            result = env_utils.build_opencode_env()
+        self.assertEqual(result["OPENAI_API_KEY"], "sk-openai")
+        self.assertNotIn("ANTHROPIC_API_KEY", result)
+
+    def test_optional_preserves_empty_string(self) -> None:
+        with patch.dict(os.environ, {"OPENCODE_DISABLE_AUTOUPDATE": ""}, clear=True):
+            self.assertEqual(env_utils.optional("OPENCODE_DISABLE_AUTOUPDATE", "1"), "")
+
+    def test_build_env_uses_official_autoupdate_variable_name(self) -> None:
         env = {
             "OPENCODE_MODEL": "openai/gpt-4.1-mini",
             "OPENAI_API_KEY": "sk-openai",
         }
         with patch.dict(os.environ, env, clear=True):
             result = env_utils.build_opencode_env()
-        self.assertEqual(result["OPENAI_API_KEY"], "sk-openai")
-
-    def test_optional_preserves_empty_string(self) -> None:
-        with patch.dict(os.environ, {"OPENCODE_DISABLE_AUTO_UPDATE": ""}, clear=True):
-            self.assertEqual(env_utils.optional("OPENCODE_DISABLE_AUTO_UPDATE", "1"), "")
+        self.assertEqual(result["OPENCODE_DISABLE_AUTOUPDATE"], "1")
+        self.assertNotIn("OPENCODE_DISABLE_AUTO_UPDATE", result)
 
     def test_llm_host_prefers_base_url(self) -> None:
         env = {

--- a/examples/opencode-integration/test_env_utils.py
+++ b/examples/opencode-integration/test_env_utils.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import os
 import sys
 import unittest
+from io import StringIO
 from pathlib import Path
 from unittest.mock import patch
 
@@ -28,6 +29,16 @@ class EnvUtilsTest(unittest.TestCase):
         self.assertEqual(env_utils.provider_key_name("openai"), "OPENAI_API_KEY")
         self.assertEqual(env_utils.provider_key_name("deepseek"), "DEEPSEEK_API_KEY")
         self.assertEqual(env_utils.provider_key_name("custom"), "CUSTOM_API_KEY")
+
+    def test_require_provider_key_fails_when_missing(self) -> None:
+        with patch.dict(os.environ, {}, clear=True):
+            with self.assertRaises(SystemExit):
+                env_utils.require_provider_key("openai")
+
+    def test_int_env_rejects_non_integer_values(self) -> None:
+        with patch.dict(os.environ, {"OPENCODE_EXEC_TIMEOUT": "slow"}, clear=True):
+            with self.assertRaises(SystemExit):
+                env_utils.int_env("OPENCODE_EXEC_TIMEOUT", 900)
 
     def test_build_env_omits_all_api_keys_for_vault_mode(self) -> None:
         env = {
@@ -82,6 +93,28 @@ class EnvUtilsTest(unittest.TestCase):
         with patch.dict(os.environ, env, clear=True):
             config = env_utils.opencode_config_json("openai")
         self.assertIn('"baseURL": "https://llm.example.test/v1"', config)
+
+    def test_config_json_omits_provider_without_base_url(self) -> None:
+        with patch.dict(os.environ, {"OPENCODE_MODEL": "openai/gpt-4.1-mini"}, clear=True):
+            config = env_utils.opencode_config_json("openai")
+        self.assertNotIn('"provider"', config)
+
+    def test_host_from_url_handles_empty_and_scheme_less_values(self) -> None:
+        self.assertEqual(env_utils._host_from_url(""), "")
+        self.assertEqual(env_utils._host_from_url("api.deepseek.com"), "api.deepseek.com")
+        self.assertEqual(
+            env_utils._host_from_url("https://api.example.test/v1"),
+            "api.example.test",
+        )
+
+    def test_load_local_dotenv_warns_when_no_file_exists(self) -> None:
+        stderr = StringIO()
+        missing_dir = Path("/tmp/cube-opencode-missing-env-test")
+        with patch.object(env_utils, "__file__", str(missing_dir / "env_utils.py")):
+            with patch("pathlib.Path.cwd", return_value=missing_dir):
+                with patch("sys.stderr", stderr):
+                    env_utils.load_local_dotenv()
+        self.assertIn("Warning: no .env file found", stderr.getvalue())
 
     def test_provider_inject_uses_bearer_header_for_openai_style_providers(self) -> None:
         self.assertEqual(

--- a/examples/opencode-integration/test_network_policy.py
+++ b/examples/opencode-integration/test_network_policy.py
@@ -6,12 +6,20 @@ from __future__ import annotations
 import os
 import sys
 import unittest
+from dataclasses import dataclass
 from pathlib import Path
 from unittest.mock import patch
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
 import network_policy
+
+
+@dataclass
+class FakeResult:
+    stdout: str = ""
+    stderr: str = ""
+    exit_code: int = 0
 
 
 class NetworkPolicyTest(unittest.TestCase):
@@ -31,6 +39,63 @@ class NetworkPolicyTest(unittest.TestCase):
         }
         with patch.dict(os.environ, env, clear=True):
             network_policy.require_native_sdk_env()
+
+    def test_key_must_be_absent_from_global_vm_environment(self) -> None:
+        with patch.object(
+            network_policy, "run_command", return_value=FakeResult(stdout="<unset>\n")
+        ):
+            network_policy.verify_key_not_in_vm(object(), "OPENAI_API_KEY")
+
+        with patch.object(
+            network_policy, "run_command", return_value=FakeResult(stdout="unexpected\n")
+        ):
+            with self.assertRaisesRegex(SystemExit, "global environment"):
+                network_policy.verify_key_not_in_vm(object(), "OPENAI_API_KEY")
+
+    def test_agent_command_must_receive_only_placeholder(self) -> None:
+        envs = {"OPENAI_API_KEY": network_policy.PLACEHOLDER_KEY}
+        with patch.object(
+            network_policy,
+            "run_command",
+            return_value=FakeResult(stdout=f"{network_policy.PLACEHOLDER_KEY}\n"),
+        ) as run:
+            network_policy.verify_placeholder_env(object(), "OPENAI_API_KEY", envs)
+        self.assertEqual(run.call_args.kwargs["envs"], envs)
+
+        with patch.object(
+            network_policy, "run_command", return_value=FakeResult(stdout="wrong\n")
+        ):
+            with self.assertRaisesRegex(SystemExit, "placeholder"):
+                network_policy.verify_placeholder_env(
+                    object(), "OPENAI_API_KEY", envs
+                )
+
+    def test_non_llm_check_accepts_block_and_rejects_reachability(self) -> None:
+        for status in ("403\n", "000blocked\n"):
+            with self.subTest(status=status):
+                with patch.object(
+                    network_policy,
+                    "run_command",
+                    return_value=FakeResult(stdout=status),
+                ):
+                    network_policy.verify_non_llm_blocked(object())
+
+        with patch.object(
+            network_policy, "run_command", return_value=FakeResult(stdout="200")
+        ):
+            with self.assertRaisesRegex(SystemExit, "was reachable"):
+                network_policy.verify_non_llm_blocked(object())
+
+    def test_create_sandbox_keeps_default_deny_enabled(self) -> None:
+        with patch.object(network_policy.Sandbox, "create", return_value="sandbox") as create:
+            result = network_policy.create_sandbox("tpl-test", ["rule"], 1800)
+        self.assertEqual(result, "sandbox")
+        create.assert_called_once_with(
+            template="tpl-test",
+            allow_internet_access=False,
+            network={"rules": ["rule"]},
+            timeout=1800,
+        )
 
 
 if __name__ == "__main__":

--- a/examples/opencode-integration/test_network_policy.py
+++ b/examples/opencode-integration/test_network_policy.py
@@ -1,0 +1,37 @@
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import network_policy
+
+
+class NetworkPolicyTest(unittest.TestCase):
+    def test_requires_native_cubesandbox_sdk_env(self) -> None:
+        env = {
+            "E2B_API_URL": "http://127.0.0.1:3000",
+            "E2B_API_KEY": "e2b_000000",
+        }
+        with patch.dict(os.environ, env, clear=True):
+            with self.assertRaisesRegex(SystemExit, "CUBE_API_URL"):
+                network_policy.require_native_sdk_env()
+
+    def test_accepts_native_cubesandbox_sdk_env(self) -> None:
+        env = {
+            "CUBE_API_URL": "http://127.0.0.1:3000",
+            "CUBE_PROXY_NODE_IP": "127.0.0.1",
+        }
+        with patch.dict(os.environ, env, clear=True):
+            network_policy.require_native_sdk_env()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/examples/opencode-integration/test_network_policy.py
+++ b/examples/opencode-integration/test_network_policy.py
@@ -12,7 +12,7 @@ from unittest.mock import patch
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
-import network_policy
+import egress_policy
 
 
 @dataclass
@@ -30,7 +30,7 @@ class NetworkPolicyTest(unittest.TestCase):
         }
         with patch.dict(os.environ, env, clear=True):
             with self.assertRaisesRegex(SystemExit, "CUBE_API_URL"):
-                network_policy.require_native_sdk_env()
+                egress_policy.require_native_sdk_env()
 
     def test_accepts_native_cubesandbox_sdk_env(self) -> None:
         env = {
@@ -38,35 +38,35 @@ class NetworkPolicyTest(unittest.TestCase):
             "CUBE_PROXY_NODE_IP": "127.0.0.1",
         }
         with patch.dict(os.environ, env, clear=True):
-            network_policy.require_native_sdk_env()
+            egress_policy.require_native_sdk_env()
 
     def test_key_must_be_absent_from_global_vm_environment(self) -> None:
         with patch.object(
-            network_policy, "run_command", return_value=FakeResult(stdout="<unset>\n")
+            egress_policy, "run_command", return_value=FakeResult(stdout="<unset>\n")
         ):
-            network_policy.verify_key_not_in_vm(object(), "OPENAI_API_KEY")
+            egress_policy.verify_key_not_in_vm(object(), "OPENAI_API_KEY")
 
         with patch.object(
-            network_policy, "run_command", return_value=FakeResult(stdout="unexpected\n")
+            egress_policy, "run_command", return_value=FakeResult(stdout="unexpected\n")
         ):
             with self.assertRaisesRegex(SystemExit, "global environment"):
-                network_policy.verify_key_not_in_vm(object(), "OPENAI_API_KEY")
+                egress_policy.verify_key_not_in_vm(object(), "OPENAI_API_KEY")
 
     def test_agent_command_must_receive_only_placeholder(self) -> None:
-        envs = {"OPENAI_API_KEY": network_policy.PLACEHOLDER_KEY}
+        envs = {"OPENAI_API_KEY": egress_policy.PLACEHOLDER_KEY}
         with patch.object(
-            network_policy,
+            egress_policy,
             "run_command",
-            return_value=FakeResult(stdout=f"{network_policy.PLACEHOLDER_KEY}\n"),
+            return_value=FakeResult(stdout=f"{egress_policy.PLACEHOLDER_KEY}\n"),
         ) as run:
-            network_policy.verify_placeholder_env(object(), "OPENAI_API_KEY", envs)
+            egress_policy.verify_placeholder_env(object(), "OPENAI_API_KEY", envs)
         self.assertEqual(run.call_args.kwargs["envs"], envs)
 
         with patch.object(
-            network_policy, "run_command", return_value=FakeResult(stdout="wrong\n")
+            egress_policy, "run_command", return_value=FakeResult(stdout="wrong\n")
         ):
             with self.assertRaisesRegex(SystemExit, "placeholder"):
-                network_policy.verify_placeholder_env(
+                egress_policy.verify_placeholder_env(
                     object(), "OPENAI_API_KEY", envs
                 )
 
@@ -74,21 +74,21 @@ class NetworkPolicyTest(unittest.TestCase):
         for status in ("403\n", "000blocked\n"):
             with self.subTest(status=status):
                 with patch.object(
-                    network_policy,
+                    egress_policy,
                     "run_command",
                     return_value=FakeResult(stdout=status),
                 ):
-                    network_policy.verify_non_llm_blocked(object())
+                    egress_policy.verify_non_llm_blocked(object())
 
         with patch.object(
-            network_policy, "run_command", return_value=FakeResult(stdout="200")
+            egress_policy, "run_command", return_value=FakeResult(stdout="200")
         ):
             with self.assertRaisesRegex(SystemExit, "was reachable"):
-                network_policy.verify_non_llm_blocked(object())
+                egress_policy.verify_non_llm_blocked(object())
 
     def test_create_sandbox_keeps_default_deny_enabled(self) -> None:
-        with patch.object(network_policy.Sandbox, "create", return_value="sandbox") as create:
-            result = network_policy.create_sandbox("tpl-test", ["rule"], 1800)
+        with patch.object(egress_policy.Sandbox, "create", return_value="sandbox") as create:
+            result = egress_policy.create_sandbox("tpl-test", ["rule"], 1800)
         self.assertEqual(result, "sandbox")
         create.assert_called_once_with(
             template="tpl-test",

--- a/examples/opencode-integration/test_opencode_common.py
+++ b/examples/opencode-integration/test_opencode_common.py
@@ -7,12 +7,13 @@ import os
 import sys
 import unittest
 from dataclasses import dataclass
+from io import StringIO
 from pathlib import Path
 from unittest.mock import patch
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
-from _opencode_common import ensure_success, redact_secrets, run_command
+from _opencode_common import ensure_success, redact_secrets, run_command, stream_writer
 
 
 @dataclass
@@ -51,6 +52,31 @@ class CommonHelperTest(unittest.TestCase):
             self.assertEqual(
                 redact_secrets("provider key is sk-secret-value"),
                 "provider key is <redacted>",
+            )
+
+    def test_stream_writer_redacts_known_env_values(self) -> None:
+        stream = StringIO()
+        with patch.dict(os.environ, {"OPENAI_API_KEY": "sk-stream-secret"}, clear=True):
+            stream_writer(stream)("stdout sk-stream-secret\n")
+        self.assertEqual(stream.getvalue(), "stdout <redacted>\n")
+
+    def test_redact_secrets_replaces_longest_values_first(self) -> None:
+        env = {
+            "A_API_KEY": "sk-foo",
+            "B_API_KEY": "sk-foobar",
+        }
+        with patch.dict(os.environ, env, clear=True):
+            self.assertEqual(redact_secrets("value sk-foobar"), "value <redacted>")
+
+    def test_redact_secrets_uses_secret_name_suffixes(self) -> None:
+        env = {
+            "CSRF_TOKEN_EXPIRY_SECONDS": "3600",
+            "SESSION_TOKEN": "secret-token",
+        }
+        with patch.dict(os.environ, env, clear=True):
+            self.assertEqual(
+                redact_secrets("ttl 3600 token secret-token"),
+                "ttl 3600 token <redacted>",
             )
 
     def test_ensure_success_redacts_stdout_and_stderr(self) -> None:

--- a/examples/opencode-integration/test_opencode_common.py
+++ b/examples/opencode-integration/test_opencode_common.py
@@ -1,0 +1,71 @@
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+from dataclasses import dataclass
+from pathlib import Path
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from _opencode_common import ensure_success, redact_secrets, run_command
+
+
+@dataclass
+class FakeResult:
+    stdout: str = ""
+    stderr: str = ""
+    exit_code: int = 0
+
+
+class EnvOnlyCommands:
+    def __init__(self) -> None:
+        self.kwargs = {}
+
+    def run(self, command: str, *, env: dict[str, str] | None = None):
+        self.kwargs = {"command": command, "env": env}
+        return FakeResult()
+
+
+class FakeSandbox:
+    def __init__(self) -> None:
+        self.commands = EnvOnlyCommands()
+
+
+class CommonHelperTest(unittest.TestCase):
+    def test_run_command_uses_env_keyword_when_envs_is_not_supported(self) -> None:
+        sandbox = FakeSandbox()
+        result = run_command(sandbox, "true", envs={"OPENAI_API_KEY": "placeholder"})
+        self.assertEqual(result.exit_code, 0)
+        self.assertEqual(
+            sandbox.commands.kwargs,
+            {"command": "true", "env": {"OPENAI_API_KEY": "placeholder"}},
+        )
+
+    def test_redact_secrets_hides_known_env_values(self) -> None:
+        with patch.dict(os.environ, {"OPENAI_API_KEY": "sk-secret-value"}, clear=True):
+            self.assertEqual(
+                redact_secrets("provider key is sk-secret-value"),
+                "provider key is <redacted>",
+            )
+
+    def test_ensure_success_redacts_stdout_and_stderr(self) -> None:
+        result = FakeResult(
+            stdout="stdout sk-secret-value",
+            stderr="stderr sk-secret-value",
+            exit_code=1,
+        )
+        with patch.dict(os.environ, {"OPENAI_API_KEY": "sk-secret-value"}, clear=True):
+            with self.assertRaises(SystemExit) as raised:
+                ensure_success(result, "run command")
+        message = str(raised.exception)
+        self.assertIn("<redacted>", message)
+        self.assertNotIn("sk-secret-value", message)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/examples/opencode-integration/test_opencode_common.py
+++ b/examples/opencode-integration/test_opencode_common.py
@@ -13,7 +13,13 @@ from unittest.mock import patch
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
-from _opencode_common import ensure_success, redact_secrets, run_command, stream_writer
+from _opencode_common import (
+    ensure_success,
+    pause_sandbox,
+    redact_secrets,
+    run_command,
+    stream_writer,
+)
 
 
 @dataclass
@@ -37,6 +43,20 @@ class FakeSandbox:
         self.commands = EnvOnlyCommands()
 
 
+class PauseSandbox:
+    sandbox_id = "sandbox-id"
+
+    def pause(self) -> str:
+        return "paused-id"
+
+
+class BetaPauseSandbox:
+    sandbox_id = "beta-sandbox-id"
+
+    def beta_pause(self) -> None:
+        return None
+
+
 class CommonHelperTest(unittest.TestCase):
     def test_run_command_uses_env_keyword_when_envs_is_not_supported(self) -> None:
         sandbox = FakeSandbox()
@@ -46,6 +66,12 @@ class CommonHelperTest(unittest.TestCase):
             sandbox.commands.kwargs,
             {"command": "true", "env": {"OPENAI_API_KEY": "placeholder"}},
         )
+
+    def test_pause_sandbox_uses_pause_when_available(self) -> None:
+        self.assertEqual(pause_sandbox(PauseSandbox()), "paused-id")
+
+    def test_pause_sandbox_falls_back_to_beta_pause(self) -> None:
+        self.assertEqual(pause_sandbox(BetaPauseSandbox()), "beta-sandbox-id")
 
     def test_redact_secrets_hides_known_env_values(self) -> None:
         with patch.dict(os.environ, {"OPENAI_API_KEY": "sk-secret-value"}, clear=True):

--- a/examples/opencode-integration/test_opencode_common.py
+++ b/examples/opencode-integration/test_opencode_common.py
@@ -38,9 +38,19 @@ class EnvOnlyCommands:
         return FakeResult()
 
 
+class NoEnvCommands:
+    def run(self, command: str):
+        return FakeResult(stdout=command)
+
+
 class FakeSandbox:
     def __init__(self) -> None:
         self.commands = EnvOnlyCommands()
+
+
+class NoEnvSandbox:
+    def __init__(self) -> None:
+        self.commands = NoEnvCommands()
 
 
 class PauseSandbox:
@@ -66,6 +76,10 @@ class CommonHelperTest(unittest.TestCase):
             sandbox.commands.kwargs,
             {"command": "true", "env": {"OPENAI_API_KEY": "placeholder"}},
         )
+
+    def test_run_command_fails_when_env_kwarg_is_not_supported(self) -> None:
+        with self.assertRaisesRegex(TypeError, "env or envs parameter"):
+            run_command(NoEnvSandbox(), "true", envs={"OPENAI_API_KEY": "placeholder"})
 
     def test_pause_sandbox_uses_pause_when_available(self) -> None:
         self.assertEqual(pause_sandbox(PauseSandbox()), "paused-id")

--- a/examples/opencode-integration/test_workflows.py
+++ b/examples/opencode-integration/test_workflows.py
@@ -1,0 +1,428 @@
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+from contextlib import ExitStack
+from dataclasses import dataclass
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import call, patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import checkpoint_fork_opencode
+import e2b
+import network_policy
+import resume_opencode
+import run_opencode
+
+
+@dataclass
+class FakeResult:
+    stdout: str = ""
+    stderr: str = ""
+    exit_code: int = 0
+
+
+class FakeCommands:
+    def __init__(self, *results: FakeResult) -> None:
+        self.results = list(results)
+        self.calls: list[tuple[str, dict[str, object]]] = []
+
+    def run(
+        self,
+        command: str,
+        *,
+        cwd: str | None = None,
+        envs: dict[str, str] | None = None,
+        timeout: int | float | None = None,
+        on_stdout=None,
+        on_stderr=None,
+        user: str = "root",
+    ) -> FakeResult:
+        self.calls.append(
+            (
+                command,
+                {
+                    "cwd": cwd,
+                    "envs": envs,
+                    "timeout": timeout,
+                    "on_stdout": on_stdout,
+                    "on_stderr": on_stderr,
+                    "user": user,
+                },
+            )
+        )
+        return self.results.pop(0) if self.results else FakeResult()
+
+
+class FakeSnapshot:
+    snapshot_id = "snap-test"
+
+
+class FakeSandbox:
+    def __init__(self, sandbox_id: str, *results: FakeResult) -> None:
+        self.sandbox_id = sandbox_id
+        self.commands = FakeCommands(*results)
+        self.kill_calls = 0
+        self.pause_calls = 0
+        self.snapshot_calls = 0
+
+    def kill(self) -> None:
+        self.kill_calls += 1
+
+    def pause(self) -> str:
+        self.pause_calls += 1
+        return self.sandbox_id
+
+    def create_snapshot(self, name: str | None = None) -> FakeSnapshot:
+        self.snapshot_calls += 1
+        self.snapshot_name = name
+        return FakeSnapshot()
+
+
+def run_args(**overrides):
+    values = {
+        "template": "tpl-test",
+        "prompt": "fix the project",
+        "workspace": "/workspace",
+        "title": "test-title",
+        "sandbox_timeout": 1800,
+        "exec_timeout": 900,
+        "dry_run": False,
+        "keep_alive": False,
+        "verbose": False,
+        "raw": False,
+    }
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+def resume_args():
+    return SimpleNamespace(
+        template="tpl-test",
+        workspace="/workspace",
+        title="resume-title",
+        sandbox_timeout=1800,
+        exec_timeout=900,
+    )
+
+
+def network_args(**overrides):
+    values = {
+        "template": "tpl-test",
+        "host": None,
+        "workspace": "/workspace",
+        "prompt": "write marker",
+        "title": "egress-title",
+        "sandbox_timeout": 1800,
+        "exec_timeout": 900,
+        "skip_agent": False,
+    }
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+def checkpoint_args():
+    return SimpleNamespace(
+        template="tpl-test",
+        host=None,
+        workspace="/workspace",
+        title="checkpoint-title",
+        sandbox_timeout=1800,
+        exec_timeout=900,
+    )
+
+
+def enter_patches(stack: ExitStack, patches):
+    return [stack.enter_context(item) for item in patches]
+
+
+class WorkflowTestCase(unittest.TestCase):
+    def setUp(self) -> None:
+        env = patch.dict(
+            os.environ,
+            {
+                "OPENCODE_MODEL": "deepseek/deepseek-chat",
+                "DEEPSEEK_API_KEY": "test-secret",
+            },
+            clear=False,
+        )
+        env.start()
+        self.addCleanup(env.stop)
+
+
+class RunWorkflowTest(WorkflowTestCase):
+    def common_patches(self, sandbox: FakeSandbox):
+        return (
+            patch.object(run_opencode, "load_local_dotenv"),
+            patch.object(run_opencode, "parse_args", return_value=run_args()),
+            patch.object(run_opencode, "required", return_value="configured"),
+            patch.object(run_opencode, "opencode_model", return_value="deepseek/deepseek-chat"),
+            patch.object(run_opencode, "opencode_provider", return_value="deepseek"),
+            patch.object(run_opencode, "require_provider_key", return_value="secret"),
+            patch.object(run_opencode, "provider_key_name", return_value="DEEPSEEK_API_KEY"),
+            patch.object(
+                run_opencode,
+                "build_opencode_env",
+                return_value={"DEEPSEEK_API_KEY": "secret"},
+            ),
+            patch.object(run_opencode, "setup_dev_sidecar_if_requested"),
+            patch.object(run_opencode, "warn_direct_secret_env"),
+            patch.object(e2b.Sandbox, "create", return_value=sandbox),
+        )
+
+    def test_success_runs_agent_verifies_and_kills(self) -> None:
+        sandbox = FakeSandbox("run-sb", FakeResult(), FakeResult(), FakeResult(stdout="OK"))
+        patches = self.common_patches(sandbox)
+        with ExitStack() as stack:
+            entered = enter_patches(stack, patches)
+            self.assertEqual(run_opencode.main(), 0)
+        create = entered[-1]
+        create.assert_called_once_with(template="tpl-test", timeout=1800)
+        self.assertEqual(sandbox.kill_calls, 1)
+        self.assertEqual(len(sandbox.commands.calls), 3)
+        self.assertEqual(
+            sandbox.commands.calls[1][1]["envs"],
+            {"DEEPSEEK_API_KEY": "secret"},
+        )
+
+    def test_agent_failure_still_kills(self) -> None:
+        sandbox = FakeSandbox("run-sb", FakeResult(), FakeResult(stderr="failed", exit_code=7))
+        patches = self.common_patches(sandbox)
+        with ExitStack() as stack:
+            enter_patches(stack, patches)
+            with self.assertRaisesRegex(SystemExit, "run OpenCode"):
+                run_opencode.main()
+        self.assertEqual(sandbox.kill_calls, 1)
+
+    def test_create_failure_is_reported_without_cleanup_masking(self) -> None:
+        sandbox = FakeSandbox("unused")
+        patches = self.common_patches(sandbox)
+        patches = patches[:-1] + (
+            patch.object(
+                e2b.Sandbox,
+                "create",
+                side_effect=RuntimeError("create failed"),
+            ),
+        )
+        with ExitStack() as stack:
+            enter_patches(stack, patches)
+            with self.assertRaisesRegex(RuntimeError, "create failed"):
+                run_opencode.main()
+        self.assertEqual(sandbox.kill_calls, 0)
+
+
+class ResumeWorkflowTest(WorkflowTestCase):
+    def common_patches(self, source: FakeSandbox, resumed: FakeSandbox):
+        return (
+            patch.object(resume_opencode, "load_local_dotenv"),
+            patch.object(resume_opencode, "parse_args", return_value=resume_args()),
+            patch.object(resume_opencode, "required", return_value="configured"),
+            patch.object(resume_opencode, "opencode_model", return_value="deepseek/deepseek-chat"),
+            patch.object(resume_opencode, "opencode_provider", return_value="deepseek"),
+            patch.object(resume_opencode, "require_provider_key", return_value="secret"),
+            patch.object(resume_opencode, "provider_key_name", return_value="DEEPSEEK_API_KEY"),
+            patch.object(
+                resume_opencode,
+                "build_opencode_env",
+                return_value={"DEEPSEEK_API_KEY": "secret"},
+            ),
+            patch.object(resume_opencode, "setup_dev_sidecar_if_requested"),
+            patch.object(resume_opencode, "warn_direct_secret_env"),
+            patch.object(resume_opencode.Sandbox, "create", return_value=source),
+            patch.object(resume_opencode.Sandbox, "connect", return_value=resumed),
+        )
+
+    def test_pause_connect_continue_and_cleanup(self) -> None:
+        source = FakeSandbox("resume-sb", FakeResult(), FakeResult())
+        resumed = FakeSandbox("resume-sb", FakeResult(stdout="plan"), FakeResult(), FakeResult())
+        patches = self.common_patches(source, resumed)
+        with ExitStack() as stack:
+            entered = enter_patches(stack, patches)
+            self.assertEqual(resume_opencode.main(), 0)
+        connect = entered[-1]
+        self.assertEqual(source.pause_calls, 1)
+        connect.assert_called_once_with(sandbox_id="resume-sb")
+        self.assertEqual(resumed.kill_calls, 1)
+
+    def test_connect_failure_cleans_paused_handle(self) -> None:
+        source = FakeSandbox("resume-sb", FakeResult(), FakeResult())
+        resumed = FakeSandbox("unused")
+        patches = self.common_patches(source, resumed)
+        patches = patches[:-1] + (
+            patch.object(
+                resume_opencode.Sandbox,
+                "connect",
+                side_effect=RuntimeError("connect failed"),
+            ),
+        )
+        with ExitStack() as stack:
+            enter_patches(stack, patches)
+            with self.assertRaisesRegex(RuntimeError, "connect failed"):
+                resume_opencode.main()
+        self.assertEqual(source.kill_calls, 1)
+
+    def test_second_turn_failure_cleans_resumed_sandbox(self) -> None:
+        source = FakeSandbox("resume-sb", FakeResult(), FakeResult())
+        resumed = FakeSandbox(
+            "resume-sb",
+            FakeResult(stdout="plan"),
+            FakeResult(stderr="agent failed", exit_code=8),
+        )
+        patches = self.common_patches(source, resumed)
+        with ExitStack() as stack:
+            enter_patches(stack, patches)
+            with self.assertRaisesRegex(SystemExit, "turn 2"):
+                resume_opencode.main()
+        self.assertEqual(resumed.kill_calls, 1)
+
+
+class NetworkWorkflowTest(WorkflowTestCase):
+    def common_patches(self, sandbox: FakeSandbox, args=None):
+        return (
+            patch.object(network_policy, "load_local_dotenv"),
+            patch.object(network_policy, "parse_args", return_value=args or network_args()),
+            patch.object(network_policy, "required", return_value="configured"),
+            patch.object(network_policy, "opencode_model", return_value="deepseek/deepseek-chat"),
+            patch.object(network_policy, "opencode_provider", return_value="deepseek"),
+            patch.object(network_policy, "require_provider_key", return_value="real-secret"),
+            patch.object(network_policy, "opencode_llm_host", return_value="api.deepseek.com"),
+            patch.object(network_policy, "provider_key_name", return_value="DEEPSEEK_API_KEY"),
+            patch.object(network_policy, "build_opencode_env", return_value={}),
+            patch.object(network_policy, "build_rules", return_value=["rule"]),
+            patch.object(network_policy, "create_sandbox", return_value=sandbox),
+        )
+
+    def test_security_checks_agent_and_cleanup(self) -> None:
+        sandbox = FakeSandbox(
+            "network-sb",
+            FakeResult(stdout="<unset>\n"),
+            FakeResult(stdout=f"{network_policy.PLACEHOLDER_KEY}\n"),
+            FakeResult(stdout="403"),
+            FakeResult(),
+            FakeResult(),
+            FakeResult(stdout="OPENCODE_EGRESS_OK"),
+        )
+        patches = self.common_patches(sandbox)
+        with ExitStack() as stack:
+            entered = enter_patches(stack, patches)
+            self.assertEqual(network_policy.main(), 0)
+        create = entered[-1]
+        create.assert_called_once_with("tpl-test", ["rule"], 1800)
+        self.assertEqual(sandbox.kill_calls, 1)
+
+    def test_reachable_non_llm_host_fails_and_cleans_up(self) -> None:
+        sandbox = FakeSandbox(
+            "network-sb",
+            FakeResult(stdout="<unset>\n"),
+            FakeResult(stdout=f"{network_policy.PLACEHOLDER_KEY}\n"),
+            FakeResult(stdout="200"),
+        )
+        patches = self.common_patches(sandbox)
+        with ExitStack() as stack:
+            enter_patches(stack, patches)
+            with self.assertRaisesRegex(SystemExit, "was reachable"):
+                network_policy.main()
+        self.assertEqual(sandbox.kill_calls, 1)
+
+    def test_agent_failure_still_cleans_restricted_sandbox(self) -> None:
+        sandbox = FakeSandbox(
+            "network-sb",
+            FakeResult(stdout="<unset>\n"),
+            FakeResult(stdout=f"{network_policy.PLACEHOLDER_KEY}\n"),
+            FakeResult(stdout="403"),
+            FakeResult(),
+            FakeResult(stderr="agent failed", exit_code=9),
+        )
+        patches = self.common_patches(sandbox)
+        with ExitStack() as stack:
+            enter_patches(stack, patches)
+            with self.assertRaisesRegex(SystemExit, "restricted egress"):
+                network_policy.main()
+        self.assertEqual(sandbox.kill_calls, 1)
+
+
+class CheckpointForkWorkflowTest(WorkflowTestCase):
+    def common_patches(self, source: FakeSandbox, forked: FakeSandbox):
+        return (
+            patch.object(checkpoint_fork_opencode, "load_local_dotenv"),
+            patch.object(checkpoint_fork_opencode, "parse_args", return_value=checkpoint_args()),
+            patch.object(checkpoint_fork_opencode, "required", return_value="configured"),
+            patch.object(
+                checkpoint_fork_opencode,
+                "opencode_model",
+                return_value="deepseek/deepseek-chat",
+            ),
+            patch.object(checkpoint_fork_opencode, "opencode_provider", return_value="deepseek"),
+            patch.object(
+                checkpoint_fork_opencode,
+                "require_provider_key",
+                return_value="real-secret",
+            ),
+            patch.object(
+                checkpoint_fork_opencode,
+                "provider_key_name",
+                return_value="DEEPSEEK_API_KEY",
+            ),
+            patch.object(
+                checkpoint_fork_opencode,
+                "build_opencode_env",
+                return_value={"DEEPSEEK_API_KEY": "real-secret"},
+            ),
+            patch.object(checkpoint_fork_opencode, "warn_direct_secret_env"),
+            patch.object(
+                checkpoint_fork_opencode,
+                "create_sandbox",
+                side_effect=[source, forked],
+            ),
+            patch.object(checkpoint_fork_opencode.Sandbox, "delete_snapshot"),
+        )
+
+    def test_snapshot_fork_continue_and_cleanup(self) -> None:
+        source = FakeSandbox(
+            "source-sb",
+            FakeResult(),
+            FakeResult(),
+            FakeResult(stdout="OPENCODE_CHECKPOINT_READY"),
+        )
+        forked = FakeSandbox("forked-sb", FakeResult(stdout="plan"), FakeResult(), FakeResult())
+        patches = self.common_patches(source, forked)
+        with ExitStack() as stack:
+            entered = enter_patches(stack, patches)
+            self.assertEqual(checkpoint_fork_opencode.main(), 0)
+        create = entered[9]
+        delete = entered[10]
+        self.assertEqual(source.snapshot_calls, 1)
+        self.assertEqual(
+            create.call_args_list,
+            [call("tpl-test", 1800), call("snap-test", 1800)],
+        )
+        self.assertEqual(source.kill_calls, 1)
+        self.assertEqual(forked.kill_calls, 1)
+        delete.assert_called_once_with("snap-test")
+
+    def test_fork_creation_failure_cleans_source_and_checkpoint(self) -> None:
+        source = FakeSandbox(
+            "source-sb",
+            FakeResult(),
+            FakeResult(),
+            FakeResult(stdout="OPENCODE_CHECKPOINT_READY"),
+        )
+        fork_error = RuntimeError("fork create failed")
+        patches = self.common_patches(source, fork_error)
+        with ExitStack() as stack:
+            entered = enter_patches(stack, patches)
+            with self.assertRaisesRegex(RuntimeError, "fork create failed"):
+                checkpoint_fork_opencode.main()
+        delete = entered[10]
+        self.assertEqual(source.kill_calls, 1)
+        delete.assert_called_once_with("snap-test")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/examples/opencode-integration/test_workflows.py
+++ b/examples/opencode-integration/test_workflows.py
@@ -288,6 +288,7 @@ class NetworkWorkflowTest(WorkflowTestCase):
             patch.object(network_policy, "load_local_dotenv"),
             patch.object(network_policy, "parse_args", return_value=args or network_args()),
             patch.object(network_policy, "required", return_value="configured"),
+            patch.object(network_policy, "require_native_sdk_env"),
             patch.object(network_policy, "opencode_model", return_value="deepseek/deepseek-chat"),
             patch.object(network_policy, "opencode_provider", return_value="deepseek"),
             patch.object(network_policy, "require_provider_key", return_value="real-secret"),
@@ -353,6 +354,7 @@ class CheckpointForkWorkflowTest(WorkflowTestCase):
             patch.object(checkpoint_fork_opencode, "load_local_dotenv"),
             patch.object(checkpoint_fork_opencode, "parse_args", return_value=checkpoint_args()),
             patch.object(checkpoint_fork_opencode, "required", return_value="configured"),
+            patch.object(checkpoint_fork_opencode, "require_native_sdk_env"),
             patch.object(
                 checkpoint_fork_opencode,
                 "opencode_model",
@@ -366,15 +368,23 @@ class CheckpointForkWorkflowTest(WorkflowTestCase):
             ),
             patch.object(
                 checkpoint_fork_opencode,
+                "opencode_llm_host",
+                return_value="api.deepseek.com",
+            ),
+            patch.object(
+                checkpoint_fork_opencode,
                 "provider_key_name",
                 return_value="DEEPSEEK_API_KEY",
             ),
             patch.object(
                 checkpoint_fork_opencode,
                 "build_opencode_env",
-                return_value={"DEEPSEEK_API_KEY": "real-secret"},
+                return_value={},
             ),
-            patch.object(checkpoint_fork_opencode, "warn_direct_secret_env"),
+            patch.object(checkpoint_fork_opencode, "build_rules", return_value=["rule"]),
+            patch.object(checkpoint_fork_opencode, "verify_key_not_in_vm"),
+            patch.object(checkpoint_fork_opencode, "verify_placeholder_env"),
+            patch.object(checkpoint_fork_opencode, "verify_non_llm_blocked"),
             patch.object(
                 checkpoint_fork_opencode,
                 "create_sandbox",
@@ -395,12 +405,37 @@ class CheckpointForkWorkflowTest(WorkflowTestCase):
         with ExitStack() as stack:
             entered = enter_patches(stack, patches)
             self.assertEqual(checkpoint_fork_opencode.main(), 0)
-        create = entered[9]
-        delete = entered[10]
+        create = entered[14]
+        delete = entered[15]
         self.assertEqual(source.snapshot_calls, 1)
         self.assertEqual(
             create.call_args_list,
-            [call("tpl-test", 1800), call("snap-test", 1800)],
+            [
+                call("tpl-test", ["rule"], 1800),
+                call("snap-test", ["rule"], 1800),
+            ],
+        )
+        entered[9].assert_called_once_with(include_secrets=False)
+        secure_env = {
+            "DEEPSEEK_API_KEY": checkpoint_fork_opencode.PLACEHOLDER_KEY
+        }
+        self.assertEqual(
+            entered[11].call_args_list,
+            [
+                call(source, "DEEPSEEK_API_KEY"),
+                call(forked, "DEEPSEEK_API_KEY"),
+            ],
+        )
+        self.assertEqual(
+            entered[12].call_args_list,
+            [
+                call(source, "DEEPSEEK_API_KEY", secure_env),
+                call(forked, "DEEPSEEK_API_KEY", secure_env),
+            ],
+        )
+        self.assertEqual(
+            entered[13].call_args_list,
+            [call(source), call(forked)],
         )
         self.assertEqual(source.kill_calls, 1)
         self.assertEqual(forked.kill_calls, 1)
@@ -419,9 +454,28 @@ class CheckpointForkWorkflowTest(WorkflowTestCase):
             entered = enter_patches(stack, patches)
             with self.assertRaisesRegex(RuntimeError, "fork create failed"):
                 checkpoint_fork_opencode.main()
-        delete = entered[10]
+        delete = entered[15]
         self.assertEqual(source.kill_calls, 1)
         delete.assert_called_once_with("snap-test")
+
+    def test_reused_source_id_rejects_fork_and_cleans_everything(self) -> None:
+        source = FakeSandbox(
+            "same-sb",
+            FakeResult(),
+            FakeResult(),
+            FakeResult(stdout="OPENCODE_CHECKPOINT_READY"),
+        )
+        forked = FakeSandbox("same-sb")
+        patches = self.common_patches(source, forked)
+
+        with ExitStack() as stack:
+            entered = enter_patches(stack, patches)
+            with self.assertRaisesRegex(RuntimeError, "reused the source sandbox ID"):
+                checkpoint_fork_opencode.main()
+
+        self.assertEqual(source.kill_calls, 1)
+        self.assertEqual(forked.kill_calls, 1)
+        entered[15].assert_called_once_with("snap-test")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Refs #644

## Summary

This PR adds a production-oriented OpenCode integration example under
`examples/opencode-integration`.

Its main differentiators are:

- **Credentials stay outside the VM:** the guest receives only a placeholder
  value while CubeEgress injects the real provider credential on the wire.
- **Egress is default-deny:** the sandbox allows only the configured LLM host
  and verifies that unrelated outbound traffic is blocked.
- **Checkpoint/fork continues real agent state:** the example checkpoints a
  source sandbox, starts a distinct fork, continues the same OpenCode task in
  that fork, proves inherited workspace/session state, and cleans up both
  sandboxes plus the temporary checkpoint.

The example also includes one-shot coding and pause/resume workflows,
deterministic result checks, bilingual documentation, pinned build inputs, and
workflow-level failure/cleanup tests.

## Workflows

- **One-shot coding:** seeds a Python project, asks OpenCode to implement
  `calculator.add`, runs unit tests, and verifies `OPENCODE_CUBE_OK`.
- **Pause/resume:** preserves the workspace and OpenCode state across sandbox
  pause/resume, continues the task, and verifies `OPENCODE_RESUME_OK`.
- **Checkpoint/fork:** creates an explicit snapshot, starts a new sandbox from
  it, continues the prior OpenCode task, verifies inherited state plus
  source/fork independence, and cleans up all temporary resources.
- **Restricted egress:** starts with `allow_internet_access=False`, permits only
  the selected LLM host, injects credentials through CubeEgress, and verifies
  `OPENCODE_EGRESS_OK` without exposing the real key in the guest.

Provider configuration covers OpenAI, Anthropic, DeepSeek, and
OpenRouter-style model names.

## Security Properties

- The real provider key is never placed in the sandbox-global environment.
- Restricted workflows fail closed if the placeholder or CubeEgress
  requirements are not met.
- Non-LLM traffic is actively tested and must remain blocked.
- The CubeEgress CA is baked into the example image when the secure proxy path
  is used.
- Snapshot/fork cleanup is exercised on success and failure paths.

## Validation

Static and workflow tests:

```bash
cd examples/opencode-integration
python3 -m py_compile env_utils.py _opencode_common.py egress_policy.py run_opencode.py resume_opencode.py checkpoint_fork_opencode.py network_policy.py
python3 -m unittest discover -v
bash -n ./build-template.sh
git diff --check -- examples/opencode-integration docs/guide/integrations docs/zh/guide/integrations
```

Image checks:

```bash
docker build --platform linux/amd64 -t opencode-cube:verify .
docker run --rm opencode-cube:verify opencode --version
docker run --rm opencode-cube:verify node --version
docker run --rm opencode-cube:verify python3 --version
```

Real local CubeSandbox validation:

```bash
python3 run_opencode.py
python3 resume_opencode.py
python3 network_policy.py --skip-agent
python3 network_policy.py
```

Observed results:

- Template image built and registered successfully.
- A real OpenCode task completed with DeepSeek and passed the in-sandbox tests.
- Pause/resume preserved workspace and OpenCode state.
- Default-deny egress blocked non-LLM traffic.
- The real provider key was not visible inside the VM.
- CubeEgress injected the provider credential and the live OpenCode request
  completed successfully.
- Workflow tests cover checkpoint/fork continuation, distinct sandbox identity,
  and cleanup failure paths.
- English and Chinese docs builds passed.

## Notes

- This PR focuses on the OpenCode sub-direction of #644.
- `Refs #644` is intentional because #644 is a multi-part participation issue.
- Runtime outputs and local planning artifacts are excluded from the commit.

Assisted-by: Codex:GPT-5
