### PR TITLE
cubeproxy: use atomic Lua CAS for lifecycle transitions

### DIFF
--- a/CubeProxy/sidecar/internal/config/config.go
+++ b/CubeProxy/sidecar/internal/config/config.go
@@ -40,8 +40,8 @@ type Config struct {
 	DefaultIdleTimeout time.Duration
 
 	// Loop intervals.
-	StreamReadBlock  time.Duration // XREADGROUP BLOCK arg
-	LastActivePoll   time.Duration // GET /admin/last_active cadence
+	StreamReadBlock   time.Duration // XREADGROUP BLOCK arg
+	LastActivePoll    time.Duration // GET /admin/last_active cadence
 	IdleSweepInterval time.Duration // sweeper cadence
 	// BootstrapWarmup: after sidecar restart, wait this long before pausing
 	// any sandbox that was loaded via HGETALL bootstrap. Lets the
@@ -49,7 +49,7 @@ type Config struct {
 	// that arrive AFTER startup are not affected by this delay.
 	BootstrapWarmup time.Duration
 
-	// Pause/resume locks (SETNX TTL). Long enough to outlive a slow
+	// Pause/resume locks (CAS TTL). Long enough to outlive a slow
 	// CubeMaster RPC, short enough that a crashed sidecar releases the lock.
 	StateLockTTL time.Duration
 
@@ -199,6 +199,9 @@ func (c *Config) Validate() error {
 	}
 	if c.LastActivePoll <= 0 {
 		return errors.New("last active poll must be > 0")
+	}
+	if c.StateLockTTL <= 0 {
+		return errors.New("state lock ttl must be > 0")
 	}
 	return nil
 }

--- a/CubeProxy/sidecar/internal/httpapi/server_test.go
+++ b/CubeProxy/sidecar/internal/httpapi/server_test.go
@@ -29,12 +29,18 @@ type fakeStore struct {
 }
 
 func newFakeStore() *fakeStore { return &fakeStore{states: map[string]string{}} }
-func (f *fakeStore) AcquireState(_ context.Context, sid, state string, _ time.Duration) (bool, error) {
-	if _, ok := f.states[sid]; ok {
-		return false, nil
+func (f *fakeStore) TryTransitionState(_ context.Context, sid, newState string, _ time.Duration, allowedCurrentStates ...string) (swapped bool, observedState string, err error) {
+	if len(allowedCurrentStates) == 0 {
+		return false, "", errors.New("TryTransitionState requires at least one expected state")
 	}
-	f.states[sid] = state
-	return true, nil
+	cur := f.states[sid]
+	for _, e := range allowedCurrentStates {
+		if cur == e {
+			f.states[sid] = newState
+			return true, cur, nil
+		}
+	}
+	return false, cur, nil
 }
 func (f *fakeStore) SetState(_ context.Context, sid, state string, _ time.Duration) error {
 	f.states[sid] = state

--- a/CubeProxy/sidecar/internal/lifecycle/schema.go
+++ b/CubeProxy/sidecar/internal/lifecycle/schema.go
@@ -31,8 +31,9 @@ const (
 )
 
 // StateKey returns the per-sandbox pause/resume coordination key. Values are
-// "running" | "pausing" | "paused" | "resuming". The sidecar uses SETNX with
-// TTL to coordinate concurrent pause/resume across replicas.
+// "running" | "pausing" | "paused" | "resuming" | "killing" | "killed". The
+// sidecar uses CAS with a TTL to coordinate concurrent lifecycle transitions
+// across replicas.
 func StateKey(sandboxID string) string {
 	return "cube:v1:shared:sandbox:lifecycle:state:" + sandboxID
 }

--- a/CubeProxy/sidecar/internal/lifecycle/state.go
+++ b/CubeProxy/sidecar/internal/lifecycle/state.go
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package lifecycle
+
+import "time"
+
+// TerminalStateTTL is the Redis TTL for terminal states (0 means no expiration).
+const TerminalStateTTL time.Duration = 0
+
+// TTLForRestoredState returns the correct Redis TTL when restoring an observed state.
+// Terminal states use TerminalStateTTL; transient states use the provided transitionTTL.
+func TTLForRestoredState(state string, transitionTTL time.Duration) time.Duration {
+	switch state {
+	case "running", "paused", "killed":
+		return TerminalStateTTL
+	default:
+		return transitionTTL
+	}
+}

--- a/CubeProxy/sidecar/internal/lifecycle/state_test.go
+++ b/CubeProxy/sidecar/internal/lifecycle/state_test.go
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package lifecycle
+
+import (
+	"testing"
+	"time"
+)
+
+func TestTTLForRestoredState(t *testing.T) {
+	transitionTTL := 30 * time.Second
+	tests := []struct {
+		state string
+		want  time.Duration
+	}{
+		{state: "running", want: TerminalStateTTL},
+		{state: "paused", want: TerminalStateTTL},
+		{state: "killed", want: TerminalStateTTL},
+		{state: "pausing", want: transitionTTL},
+		{state: "resuming", want: transitionTTL},
+		{state: "killing", want: transitionTTL},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.state, func(t *testing.T) {
+			if got := TTLForRestoredState(tt.state, transitionTTL); got != tt.want {
+				t.Fatalf("TTLForRestoredState(%q) = %s, want %s", tt.state, got, tt.want)
+			}
+		})
+	}
+}

--- a/CubeProxy/sidecar/internal/redisstream/stream.go
+++ b/CubeProxy/sidecar/internal/redisstream/stream.go
@@ -124,17 +124,98 @@ func (c *Client) Ack(ctx context.Context, group, id string) error {
 	return c.rdb.XAck(ctx, lifecycle.EventStreamKey, group, id).Err()
 }
 
-// AcquireState performs a SET NX EX on the per-sandbox lifecycle state key with
-// the supplied desired state. Returns true on success. Used to coordinate
-// concurrent pause/resume across sidecars: whoever wins the SETNX owns the
-// transition.
-func (c *Client) AcquireState(ctx context.Context, sandboxID, state string, ttl time.Duration) (bool, error) {
-	key := lifecycle.StateKey(sandboxID)
-	ok, err := c.rdb.SetNX(ctx, key, state, ttl).Result()
-	if err != nil {
-		return false, fmt.Errorf("setnx %s: %w", key, err)
+var casScript = redis.NewScript(`
+local curr = redis.call("GET", KEYS[1]) or ""
+
+local allowed = false
+for i = 3, #ARGV do
+	if curr == ARGV[i] then
+		allowed = true
+		break
+	end
+end
+
+if not allowed then
+	return {0, curr}
+end
+
+redis.call("SET", KEYS[1], ARGV[1], "PX", ARGV[2])
+return {1, curr}
+`)
+
+// TryTransitionState atomically changes sandboxID's lifecycle state to newState
+// when the current Redis state is one of allowedCurrentStates.
+// It returns whether the swap happened and the state observed before the
+// decision. An empty observedState means the state key was missing.
+func (c *Client) TryTransitionState(ctx context.Context, sandboxID, newState string, newStateTTL time.Duration, allowedCurrentStates ...string) (swapped bool, observedState string, err error) {
+	if len(allowedCurrentStates) == 0 {
+		return false, "", errors.New("TryTransitionState requires at least one expected state")
 	}
-	return ok, nil
+	ttlMs, err := casTTLMillis(newStateTTL)
+	if err != nil {
+		return false, "", err
+	}
+	key := lifecycle.StateKey(sandboxID)
+	args := make([]any, 0, 2+len(allowedCurrentStates))
+	args = append(args, newState, ttlMs)
+	for _, e := range allowedCurrentStates {
+		args = append(args, e)
+	}
+
+	res, err := casScript.Run(ctx, c.rdb, []string{key}, args...).Result()
+	if err != nil {
+		return false, "", fmt.Errorf("cas state %s: %w", key, err)
+	}
+
+	acquired, state, err := parseCASResult(res)
+	if err != nil {
+		return false, "", fmt.Errorf("cas state %s: %w", key, err)
+	}
+	return acquired, state, nil
+}
+
+func casTTLMillis(ttl time.Duration) (int64, error) {
+	if ttl <= 0 {
+		return 0, errors.New("TryTransitionState requires a positive ttl")
+	}
+	if ttl < time.Millisecond {
+		return 1, nil
+	}
+	return ttl.Milliseconds(), nil
+}
+
+func parseCASResult(res any) (bool, string, error) {
+	arr, ok := res.([]any)
+	if !ok {
+		return false, "", fmt.Errorf("unexpected script return type %T", res)
+	}
+	if len(arr) != 2 {
+		return false, "", fmt.Errorf("unexpected script return length %d", len(arr))
+	}
+
+	var code int64
+	switch v := arr[0].(type) {
+	case int64:
+		code = v
+	case int:
+		code = int64(v)
+	default:
+		return false, "", fmt.Errorf("unexpected script status type %T", arr[0])
+	}
+
+	state, ok := arr[1].(string)
+	if !ok {
+		return false, "", fmt.Errorf("unexpected script state type %T", arr[1])
+	}
+
+	switch code {
+	case 0:
+		return false, state, nil
+	case 1:
+		return true, state, nil
+	default:
+		return false, "", fmt.Errorf("unexpected script status %d", code)
+	}
 }
 
 // SetState forces the state value (overwriting any existing). Used to

--- a/CubeProxy/sidecar/internal/redisstream/stream_test.go
+++ b/CubeProxy/sidecar/internal/redisstream/stream_test.go
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package redisstream
+
+import (
+	"testing"
+	"time"
+)
+
+func TestParseCASResult(t *testing.T) {
+	tests := []struct {
+		name      string
+		raw       any
+		wantOK    bool
+		wantState string
+		wantErr   bool
+	}{
+		{
+			name:      "acquired returns previous state",
+			raw:       []any{int64(1), "running"},
+			wantOK:    true,
+			wantState: "running",
+		},
+		{
+			name:      "not acquired",
+			raw:       []any{int64(0), "resuming"},
+			wantOK:    false,
+			wantState: "resuming",
+		},
+		{
+			name:      "missing current state",
+			raw:       []any{int64(0), ""},
+			wantOK:    false,
+			wantState: "",
+		},
+		{
+			name:    "bad status",
+			raw:     []any{int64(2), "running"},
+			wantErr: true,
+		},
+		{
+			name:    "bad shape",
+			raw:     "OK",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotOK, gotState, err := parseCASResult(tt.raw)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parseCASResult returned error: %v", err)
+			}
+			if gotOK != tt.wantOK || gotState != tt.wantState {
+				t.Fatalf("parseCASResult = (%v, %q), want (%v, %q)",
+					gotOK, gotState, tt.wantOK, tt.wantState)
+			}
+		})
+	}
+}
+
+func TestCASTTLMillis(t *testing.T) {
+	tests := []struct {
+		name    string
+		ttl     time.Duration
+		want    int64
+		wantErr bool
+	}{
+		{name: "zero", ttl: 0, wantErr: true},
+		{name: "negative", ttl: -time.Second, wantErr: true},
+		{name: "sub millisecond rounds up", ttl: time.Microsecond, want: 1},
+		{name: "millisecond", ttl: time.Millisecond, want: 1},
+		{name: "second", ttl: time.Second, want: 1000},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := casTTLMillis(tt.ttl)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("casTTLMillis returned error: %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("casTTLMillis = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}

--- a/CubeProxy/sidecar/internal/resumer/iface.go
+++ b/CubeProxy/sidecar/internal/resumer/iface.go
@@ -9,10 +9,14 @@ import (
 	"time"
 )
 
-// stateStore is the subset of redisstream.Client we use. Tests substitute an
-// in-memory fake so we don't depend on a live Redis.
+// stateStore is the data store interface we use for lifecycle state management.
+// Tests substitute an in-memory fake so we don't depend on an external database.
 type stateStore interface {
-	AcquireState(ctx context.Context, sandboxID, state string, ttl time.Duration) (bool, error)
+	// TryTransitionState atomically changes sandboxID's lifecycle state to newState
+	// when the current underlying state is one of allowedCurrentStates.
+	// It returns whether the swap happened and the state observed before the
+	// decision. An empty observedState means the state was missing.
+	TryTransitionState(ctx context.Context, sandboxID, newState string, newStateTTL time.Duration, allowedCurrentStates ...string) (swapped bool, observedState string, err error)
 	SetState(ctx context.Context, sandboxID, state string, ttl time.Duration) error
 	ClearState(ctx context.Context, sandboxID string) error
 	GetState(ctx context.Context, sandboxID string) (string, bool, error)

--- a/CubeProxy/sidecar/internal/resumer/resumer.go
+++ b/CubeProxy/sidecar/internal/resumer/resumer.go
@@ -11,12 +11,14 @@ package resumer
 import (
 	"context"
 	"errors"
+	"fmt"
 	"sync"
 	"time"
 
 	"go.uber.org/zap"
 
 	"github.com/tencentcloud/CubeSandbox/CubeProxy/sidecar/internal/cubemasterclient"
+	"github.com/tencentcloud/CubeSandbox/CubeProxy/sidecar/internal/lifecycle"
 	"github.com/tencentcloud/CubeSandbox/CubeProxy/sidecar/internal/registry"
 )
 
@@ -92,6 +94,7 @@ func (r *Resumer) Resume(ctx context.Context, sandboxID string) error {
 }
 
 func (r *Resumer) doResume(ctx context.Context, sandboxID string) error {
+	start := time.Now()
 	entry := r.o.Registry.Get(sandboxID)
 	if entry == nil {
 		return errors.New("sandbox not in registry")
@@ -102,13 +105,17 @@ func (r *Resumer) doResume(ctx context.Context, sandboxID string) error {
 
 	// cube:v1:shared:sandbox:lifecycle:state:<id> is dual-purpose: terminal
 	// markers (paused / running) AND in-flight transition locks (pausing /
-	// resuming) live in the same key. SETNX alone can't distinguish "I'm
+	// resuming) live in the same key. The CAS below distinguishes "I'm
 	// resuming this" from "this sandbox is parked at terminal-paused waiting
-	// for someone to resume it" — we need to peek first.
-	switch ownErr := r.acquireResumeOwnership(ctx, sandboxID); {
+	// for someone to resume it".
+	origState, ownErr := r.acquireResumeOwnership(ctx, sandboxID)
+	switch {
 	case ownErr == nil:
 		// We own the resume; call CubeMaster.
 		if err := r.callCubeMasterResume(ctx, sandboxID, entry.Meta.InstanceType); err != nil {
+			if r.o.Registry.Get(sandboxID) != nil {
+				r.restoreState(ctx, sandboxID, origState)
+			}
 			return err
 		}
 	case errors.Is(ownErr, errAlreadyRunning):
@@ -129,13 +136,11 @@ func (r *Resumer) doResume(ctx context.Context, sandboxID string) error {
 	//  3. In-memory registry LastActiveMs → now. Without (3) the sweeper
 	//     sees a stale baseline (LastActiveMs=0, CreatedAt from minutes
 	//     ago) and immediately on the next 5s tick logs "idle threshold
-	//     exceeded; pausing" for the sandbox we *just* woke up. The log
-	//     is mostly cosmetic — tryPause will SETNX-fail against
-	//     state=running and silently return — but the noise is
-	//     misleading. The proxy's log_phase will eventually overwrite
-	//     this via the periodic last_active poll, but we want the right
-	//     answer immediately, not 5–10 seconds later.
-	if err := r.o.Redis.SetState(ctx, sandboxID, "running", r.o.StateLockTTL); err != nil {
+	//     exceeded; pausing" for the sandbox we *just* woke up. The proxy's
+	//     log_phase will eventually overwrite this via the periodic
+	//     last_active poll, but we want the right answer immediately, not
+	//     5–10 seconds later.
+	if err := r.o.Redis.SetState(ctx, sandboxID, "running", lifecycle.TerminalStateTTL); err != nil {
 		r.o.Log.Warn("write running state failed",
 			zap.String("sandbox_id", sandboxID), zap.Error(err))
 	}
@@ -147,7 +152,9 @@ func (r *Resumer) doResume(ctx context.Context, sandboxID string) error {
 	}
 	r.o.Registry.MergeLastActive(sandboxID, time.Now().UnixMilli())
 
-	r.o.Log.Info("auto-resumed sandbox", zap.String("sandbox_id", sandboxID))
+	r.o.Log.Info("auto-resumed sandbox",
+		zap.String("sandbox_id", sandboxID),
+		zap.Duration("duration", time.Since(start)))
 	return nil
 }
 
@@ -184,77 +191,76 @@ func (r *Resumer) callCubeMasterResume(ctx context.Context, sandboxID, instanceT
 			zap.Int("ret_code", apiErr.RetCode))
 		return nil
 	default:
-		// Real failure: clear the resuming key so a future request can
-		// retry, and surface the error.
-		_ = r.o.Redis.ClearState(ctx, sandboxID)
-		return errors.New("cubemaster resume: " + resumeErr.Error())
+		// Real failure: let the caller restore the state observed before
+		// CAS, then surface the error.
+		return fmt.Errorf("cubemaster resume: %w", resumeErr)
 	}
 }
 
 // acquireResumeOwnership decides whether the current call should drive
 // the resume RPC, wait for a peer to finish, or return immediately. It
-// returns nil when the caller owns the resume (i.e. has the lock written
-// as "resuming"); a non-nil error when the caller should NOT proceed
-// (peer in flight resolved, sandbox already running, or real failure).
+// returns the pre-CAS state and nil when the caller owns the resume (i.e. has
+// the lock written as "resuming"); a non-nil error when the caller should NOT
+// proceed (peer in flight resolved, sandbox already running, or real failure).
 //
-// The state-key conflict (terminal markers vs. transition locks share
-// the key) is resolved by GET-ing the current value:
+// The transition is driven by atomic CAS.
 //
-//   - "paused" or expired:        we own the resume — write "resuming"
+//   - "paused" or expired:        we own the resume — atomically write "resuming"
 //   - "running":                   nothing to do, return nil-and-success
-//                                  via a sentinel (the caller's success
-//                                  bookkeeping then runs and re-asserts
-//                                  state, which is the right behaviour
-//                                  for race-recovery).
+//     via a sentinel (the caller's success
+//     bookkeeping then runs and re-asserts
+//     state, which is the right behaviour
+//     for race-recovery).
 //   - "pausing" or "resuming":    a peer is in flight → waitForRunning
-//
-// This is intentionally racy: between GET and SET another sidecar could
-// claim the key. That's fine because the worst case is two resumers both
-// calling CubeMaster.Resume — which CubeMaster handles idempotently
-// (returns "already running" the second time, which we already map to
-// success in the caller).
-func (r *Resumer) acquireResumeOwnership(ctx context.Context, sandboxID string) error {
-	cur, ok, err := r.o.Redis.GetState(ctx, sandboxID)
+//   - "killing" or "killed":      terminal delete path is in progress
+func (r *Resumer) acquireResumeOwnership(ctx context.Context, sandboxID string) (string, error) {
+	acquired, cur, err := r.o.Redis.TryTransitionState(ctx, sandboxID, "resuming", r.o.StateLockTTL, "", "paused")
 	if err != nil {
-		return err
+		return "", err
 	}
 
-	switch {
-	case !ok, cur == "paused":
-		// Either no lock at all (most common after sweeper's TTL expired)
-		// or terminal "paused" left by a successful sweep. Either way we
-		// claim ownership by SET-ing "resuming".
-		if err := r.o.Redis.SetState(ctx, sandboxID, "resuming", r.o.StateLockTTL); err != nil {
-			return err
-		}
-		return nil
-	case cur == "running":
+	if acquired {
+		return cur, nil
+	}
+
+	switch cur {
+	case "running":
 		// Sandbox is already running on Redis's view. No-op resume; the
 		// caller's success path will re-push running to the proxy in case
 		// the local dict drifted.
 		r.o.Log.Info("resume requested but sandbox already running; reconciling",
 			zap.String("sandbox_id", sandboxID))
-		return errAlreadyRunning
-	case cur == "pausing" || cur == "resuming":
+		return "", errAlreadyRunning
+	case "pausing", "resuming":
 		// Active transition by a peer → wait it out. waitForRunning
 		// returning nil means the peer transitioned to "running"; treat
 		// that as a no-op resume from our perspective so we DON'T issue
 		// our own duplicate RPC. Any other return value (peer-paused,
 		// lock expired, ctx done) propagates as an error.
-		if err := r.waitForRunning(ctx, sandboxID); err != nil {
-			return err
+		if err := r.waitForRunning(ctx, sandboxID, cur); err != nil {
+			return "", err
 		}
-		return errAlreadyRunning
+		return "", errAlreadyRunning
+	case "killing", "killed":
+		return "", errors.New("sandbox is being killed")
 	default:
 		// Unknown state — fall back to wait, same translation rule.
 		r.o.Log.Warn("unknown state during resume ownership probe",
 			zap.String("sandbox_id", sandboxID),
 			zap.String("state", cur))
-		if err := r.waitForRunning(ctx, sandboxID); err != nil {
-			return err
+		if err := r.waitForRunning(ctx, sandboxID, cur); err != nil {
+			return "", err
 		}
-		return errAlreadyRunning
+		return "", errAlreadyRunning
 	}
+}
+
+func (r *Resumer) restoreState(ctx context.Context, sandboxID, state string) {
+	if state == "" {
+		_ = r.o.Redis.ClearState(ctx, sandboxID)
+		return
+	}
+	_ = r.o.Redis.SetState(ctx, sandboxID, state, lifecycle.TTLForRestoredState(state, r.o.StateLockTTL))
 }
 
 // errAlreadyRunning is returned by acquireResumeOwnership when GetState
@@ -262,28 +268,28 @@ func (r *Resumer) acquireResumeOwnership(ctx context.Context, sandboxID string) 
 // as a successful no-op (state will be re-asserted into the proxy dict).
 var errAlreadyRunning = errors.New("sandbox already running")
 
-// waitForRunning is invoked when AcquireState lost the SETNX race — i.e.
-// some other key/holder occupies cube:v1:shared:sandbox:lifecycle:state:<id>.
-// We poll that key for one of three terminal outcomes:
+// waitForRunning is invoked when CAS observes an in-flight peer transition.
+// Some other holder occupies cube:v1:shared:sandbox:lifecycle:state:<id>.
+// It starts from the state already returned by CAS, then polls that key for
+// one of three terminal outcomes:
 //
 //   - state == "running"    → peer succeeded, request can proceed.
 //   - state == "paused"     → peer gave up; bail with an error so
-//                              CubeProxy returns 503 and the next request
-//                              gets a fresh resume attempt.
+//     CubeProxy returns 503 and the next request
+//     gets a fresh resume attempt.
+//   - state == "killing" or "killed" → fail fast because the sandbox is
+//     being deleted and must not be resumed.
 //   - key expired (!ok)     → peer crashed mid-flight; do NOT treat this
-//                              as success — return a clear error so the
-//                              caller can retry. Without this guard we
-//                              would silently let through a request to a
-//                              still-paused sandbox.
-func (r *Resumer) waitForRunning(ctx context.Context, sandboxID string) error {
+//     as success — return a clear error so the
+//     caller can retry. Without this guard we
+//     would silently let through a request to a
+//     still-paused sandbox.
+func (r *Resumer) waitForRunning(ctx context.Context, sandboxID, initialState string) error {
 	const pollEvery = 200 * time.Millisecond
 	t := time.NewTicker(pollEvery)
 	defer t.Stop()
+	state, ok := initialState, true
 	for {
-		state, ok, err := r.o.Redis.GetState(ctx, sandboxID)
-		if err != nil {
-			return err
-		}
 		switch {
 		case !ok:
 			// Peer's lock expired without writing a terminal state. Don't
@@ -295,12 +301,20 @@ func (r *Resumer) waitForRunning(ctx context.Context, sandboxID string) error {
 			return nil
 		case state == "paused":
 			return errors.New("peer resume left sandbox paused")
-		// pausing / resuming → keep polling
+		case state == "killing" || state == "killed":
+			return errors.New("peer transition is killing sandbox")
+		default:
+			// pausing / resuming → keep polling
 		}
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
 		case <-t.C:
+		}
+		var err error
+		state, ok, err = r.o.Redis.GetState(ctx, sandboxID)
+		if err != nil {
+			return err
 		}
 	}
 }

--- a/CubeProxy/sidecar/internal/resumer/resumer_test.go
+++ b/CubeProxy/sidecar/internal/resumer/resumer_test.go
@@ -22,34 +22,48 @@ import (
 type fakeStore struct {
 	mu     sync.Mutex
 	states map[string]string
-	// allowAcquire controls whether AcquireState succeeds. When the second
-	// element is non-empty, AcquireState seeds that state value into the
+	ttls   map[string]time.Duration
+	// allowAcquire controls whether TryTransitionState succeeds. When the second
+	// element is non-empty, TryTransitionState seeds that state value into the
 	// map (simulating a peer holding the lock) and returns false.
 	preLocked map[string]string
 }
 
 func newFakeStore() *fakeStore {
-	return &fakeStore{states: make(map[string]string), preLocked: make(map[string]string)}
+	return &fakeStore{
+		states:    make(map[string]string),
+		ttls:      make(map[string]time.Duration),
+		preLocked: make(map[string]string),
+	}
 }
 
-func (f *fakeStore) AcquireState(_ context.Context, sid, state string, _ time.Duration) (bool, error) {
+func (f *fakeStore) TryTransitionState(_ context.Context, sid, newState string, _ time.Duration, allowedCurrentStates ...string) (swapped bool, observedState string, err error) {
+	if len(allowedCurrentStates) == 0 {
+		return false, "", errors.New("TryTransitionState requires at least one expected state")
+	}
 	f.mu.Lock()
 	defer f.mu.Unlock()
+	cur := f.states[sid]
 	if v, ok := f.preLocked[sid]; ok {
-		f.states[sid] = v
-		return false, nil
+		if cur == "" {
+			f.states[sid] = v
+			cur = v
+		}
 	}
-	if _, ok := f.states[sid]; ok {
-		return false, nil
+	for _, e := range allowedCurrentStates {
+		if cur == e {
+			f.states[sid] = newState
+			return true, cur, nil
+		}
 	}
-	f.states[sid] = state
-	return true, nil
+	return false, cur, nil
 }
 
-func (f *fakeStore) SetState(_ context.Context, sid, state string, _ time.Duration) error {
+func (f *fakeStore) SetState(_ context.Context, sid, state string, ttl time.Duration) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.states[sid] = state
+	f.ttls[sid] = ttl
 	return nil
 }
 
@@ -71,6 +85,12 @@ func (f *fakeStore) state(sid string) string {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	return f.states[sid]
+}
+
+func (f *fakeStore) ttl(sid string) time.Duration {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.ttls[sid]
 }
 
 // fakeMaster captures Resume calls; supports artificial latency to exercise
@@ -153,6 +173,9 @@ func TestResumer_HappyPath(t *testing.T) {
 	if got := store.state("sbx"); got != "running" {
 		t.Fatalf("expected redis state=running, got %q", got)
 	}
+	if got := store.ttl("sbx"); got != 0 {
+		t.Fatalf("running terminal state must not expire, ttl=%s", got)
+	}
 	// Regression: a successful resume must reset the registry's
 	// LastActiveMs to "now" — otherwise the sweeper, on its next 5s
 	// tick, computes idle = now - CreatedAt (hours ago) and noisily
@@ -221,20 +244,46 @@ func TestResumer_DedupesConcurrentResumes(t *testing.T) {
 }
 
 func TestResumer_RollsBackOnRPCFailure(t *testing.T) {
-	reg := registry.New()
-	reg.Upsert(lifecycle.SandboxLifecycleMeta{
-		SandboxID: "sbx", InstanceType: "cubebox", AutoResume: true,
-	})
-	store := newFakeStore()
-	master := &fakeMaster{failNext: true, failError: errors.New("master 500")}
-	push := &fakePush{}
-	r := newTestResumer(reg, store, master, push)
-
-	if err := r.Resume(context.Background(), "sbx"); err == nil {
-		t.Fatal("expected error from RPC failure")
+	tests := []struct {
+		name      string
+		orig      string
+		wantState string
+		wantTTL   time.Duration
+	}{
+		{
+			name: "missing",
+		},
+		{
+			name:      "paused",
+			orig:      "paused",
+			wantState: "paused",
+		},
 	}
-	if got := store.state("sbx"); got != "" {
-		t.Fatalf("state must be cleared on rollback, got %q", got)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reg := registry.New()
+			reg.Upsert(lifecycle.SandboxLifecycleMeta{
+				SandboxID: "sbx", InstanceType: "cubebox", AutoResume: true,
+			})
+			store := newFakeStore()
+			if tt.orig != "" {
+				store.states["sbx"] = tt.orig
+			}
+			master := &fakeMaster{failNext: true, failError: errors.New("master 500")}
+			push := &fakePush{}
+			r := newTestResumer(reg, store, master, push)
+
+			if err := r.Resume(context.Background(), "sbx"); err == nil {
+				t.Fatal("expected error from RPC failure")
+			}
+			if got := store.state("sbx"); got != tt.wantState {
+				t.Fatalf("state must roll back to %q, got %q", tt.wantState, got)
+			}
+			if got := store.ttl("sbx"); got != tt.wantTTL {
+				t.Fatalf("ttl must roll back to %s, got %s", tt.wantTTL, got)
+			}
+		})
 	}
 }
 
@@ -267,6 +316,31 @@ func TestResumer_WaitsWhenPeerHoldsLock(t *testing.T) {
 	}
 	if got := atomic.LoadInt32(&master.calls); got != 0 {
 		t.Fatalf("waiter must not call master.Resume, got %d", got)
+	}
+}
+
+func TestResumer_FailsFastWhenSandboxIsBeingKilled(t *testing.T) {
+	for _, state := range []string{"killing", "killed"} {
+		t.Run(state, func(t *testing.T) {
+			reg := registry.New()
+			reg.Upsert(lifecycle.SandboxLifecycleMeta{
+				SandboxID: "sbx", InstanceType: "cubebox", AutoResume: true,
+			})
+			store := newFakeStore()
+			store.states["sbx"] = state
+			master := &fakeMaster{}
+			push := &fakePush{}
+			r := newTestResumer(reg, store, master, push)
+
+			ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+			defer cancel()
+			if err := r.Resume(ctx, "sbx"); err == nil {
+				t.Fatal("expected killing state to fail resume")
+			}
+			if got := atomic.LoadInt32(&master.calls); got != 0 {
+				t.Fatalf("must not call master.Resume for %q state, got %d", state, got)
+			}
+		})
 	}
 }
 
@@ -317,5 +391,8 @@ func TestResumer_NoOpWhenStateIsAlreadyRunning(t *testing.T) {
 	}
 	if got := atomic.LoadInt32(&master.calls); got != 0 {
 		t.Fatalf("master.Resume must NOT be called when state=running, got %d", got)
+	}
+	if got := store.ttl("sbx-run"); got != 0 {
+		t.Fatalf("reconciled running state must not expire, ttl=%s", got)
 	}
 }

--- a/CubeProxy/sidecar/internal/sweeper/iface.go
+++ b/CubeProxy/sidecar/internal/sweeper/iface.go
@@ -9,12 +9,16 @@ import (
 	"time"
 )
 
-// stateStore is the subset of redisstream.Client that the sweeper needs.
+// stateStore is the data store interface the sweeper needs for lifecycle management.
 // Defining it as an interface here lets tests substitute an in-memory fake
-// without spinning up a real Redis. The concrete *redisstream.Client
+// without spinning up an external database. The concrete *redisstream.Client
 // satisfies this interface implicitly.
 type stateStore interface {
-	AcquireState(ctx context.Context, sandboxID, state string, ttl time.Duration) (bool, error)
+	// TryTransitionState atomically changes sandboxID's lifecycle state to newState
+	// when the current underlying state is one of allowedCurrentStates.
+	// It returns whether the swap happened and the state observed before the
+	// decision. An empty observedState means the state was missing.
+	TryTransitionState(ctx context.Context, sandboxID, newState string, newStateTTL time.Duration, allowedCurrentStates ...string) (swapped bool, observedState string, err error)
 	SetState(ctx context.Context, sandboxID, state string, ttl time.Duration) error
 	ClearState(ctx context.Context, sandboxID string) error
 	GetState(ctx context.Context, sandboxID string) (string, bool, error)

--- a/CubeProxy/sidecar/internal/sweeper/sweeper.go
+++ b/CubeProxy/sidecar/internal/sweeper/sweeper.go
@@ -10,12 +10,14 @@ package sweeper
 import (
 	"context"
 	"errors"
+	"fmt"
 	"sync/atomic"
 	"time"
 
 	"go.uber.org/zap"
 
 	"github.com/tencentcloud/CubeSandbox/CubeProxy/sidecar/internal/cubemasterclient"
+	"github.com/tencentcloud/CubeSandbox/CubeProxy/sidecar/internal/lifecycle"
 	"github.com/tencentcloud/CubeSandbox/CubeProxy/sidecar/internal/registry"
 )
 
@@ -144,10 +146,8 @@ func (s *Sweeper) sweepOnce(ctx context.Context) {
 		// at "paused", "pausing", "killing", or "killed", there is nothing
 		// for us to do — either the dataplane will resume it on demand
 		// (paused) or the sandbox is on its way out (killing/killed).
-		// Without this guard the sweeper logs "idle threshold exceeded"
-		// every Interval and the state-key TTL (StateLockTTL=60s) expires
-		// periodically, causing a pointless RPC churn against CubeMaster
-		// every minute.
+		// Without this guard the sweeper would log "idle threshold exceeded"
+		// every Interval and issue pointless RPC churn against CubeMaster.
 		curState, _, stateErr := s.o.Redis.GetState(ctx, e.Meta.SandboxID)
 		if stateErr != nil {
 			s.o.Log.Warn("get state failed; will attempt action anyway",
@@ -193,8 +193,8 @@ func (s *Sweeper) sweepOnce(ctx context.Context) {
 }
 
 // tryPause acquires the state lock, calls CubeMaster, and pushes the new
-// state out to CubeProxy. It is idempotent — a lost SETNX race is treated as
-// success (someone else is pausing the same sandbox).
+// state out to CubeProxy. It is idempotent — a lost CAS race is treated as
+// success because someone else is already transitioning the same sandbox.
 //
 // Two CubeMaster ret_codes are not real failures and are mapped to
 // terminal-success behaviour:
@@ -208,7 +208,7 @@ func (s *Sweeper) sweepOnce(ctx context.Context) {
 //     attempt). Treat exactly like a fresh successful pause.
 func (s *Sweeper) tryPause(ctx context.Context, e registry.Entry) error {
 	sid := e.Meta.SandboxID
-	got, err := s.o.Redis.AcquireState(ctx, sid, "pausing", s.o.StateLockTTL)
+	got, origState, err := s.o.Redis.TryTransitionState(ctx, sid, "pausing", s.o.StateLockTTL, "", "running")
 	if err != nil {
 		return err
 	}
@@ -246,21 +246,19 @@ func (s *Sweeper) tryPause(ctx context.Context, e registry.Entry) error {
 			// Redis + push it to CubeProxy (in case a peer sidecar paused
 			// it but didn't push, or our previous attempt failed only on
 			// the post-RPC bookkeeping).
+			// No return — proceed to success bookkeeping below.
 			s.o.Log.Info("sandbox already paused on cubemaster; reconciling state",
 				zap.String("sandbox_id", sid),
 				zap.Int("ret_code", apiErr.RetCode))
-			// no return — proceed to success bookkeeping below
 		default:
-			// Real failure. Roll back: clear the pausing state so a future
-			// sweep can retry, and tell CubeProxy the sandbox is back to
-			// running (it never actually paused).
-			_ = s.o.Redis.ClearState(ctx, sid)
-			_ = s.o.ProxyPush.SetState(ctx, sid, "running")
-			return errors.New("cubemaster pause: " + pauseErr.Error())
+			// Real failure. Roll back to the state CAS observed before it
+			// moved the sandbox into "pausing".
+			s.restoreState(ctx, sid, origState)
+			return fmt.Errorf("cubemaster pause: %w", pauseErr)
 		}
 	}
 
-	if err := s.o.Redis.SetState(ctx, sid, "paused", s.o.StateLockTTL); err != nil {
+	if err := s.o.Redis.SetState(ctx, sid, "paused", lifecycle.TerminalStateTTL); err != nil {
 		s.o.Log.Warn("write paused state failed",
 			zap.String("sandbox_id", sid), zap.Error(err))
 	}
@@ -288,15 +286,13 @@ func (s *Sweeper) KillStats() (triggered, failed int64) {
 	return s.killTriggered.Load(), s.killFailed.Load()
 }
 
-// tryKill is the kill-path counterpart of tryPause. Same coordination
-// pattern (SETNX → notify proxy → RPC → finalise), but the terminal state is
-// non-recoverable: on success we evict the registry entry and tell every
-// CubeProxy replica to forget the sandbox. The Lua gate maps `killing` /
-// `killed` to 410 Gone so any in-flight client request fails fast instead of
-// hanging on a doomed retry.
+// tryKill is the kill-path counterpart of tryPause. It uses the same Redis CAS
+// ownership pattern, but the terminal state is non-recoverable: on success we
+// evict the registry entry and tell every CubeProxy replica to forget the
+// sandbox.
 func (s *Sweeper) tryKill(ctx context.Context, e registry.Entry) error {
 	sid := e.Meta.SandboxID
-	got, err := s.o.Redis.AcquireState(ctx, sid, "killing", s.o.StateLockTTL)
+	got, origState, err := s.o.Redis.TryTransitionState(ctx, sid, "killing", s.o.StateLockTTL, "", "running")
 	if err != nil {
 		return err
 	}
@@ -304,11 +300,6 @@ func (s *Sweeper) tryKill(ctx context.Context, e registry.Entry) error {
 		// A peer sidecar (or our own resume / pause path) holds the state.
 		// Skip — the holder will drive the transition.
 		return nil
-	}
-
-	if err := s.o.ProxyPush.SetState(ctx, sid, "killing"); err != nil {
-		s.o.Log.Warn("push killing state failed",
-			zap.String("sandbox_id", sid), zap.Error(err))
 	}
 
 	killErr := s.o.CubeMaster.Kill(ctx, sid, e.Meta.InstanceType, cubemasterclient.KillReasonTimeout)
@@ -325,13 +316,12 @@ func (s *Sweeper) tryKill(ctx context.Context, e registry.Entry) error {
 				zap.String("sandbox_id", sid),
 				zap.Int("ret_code", apiErr.RetCode))
 		default:
-			_ = s.o.Redis.ClearState(ctx, sid)
-			_ = s.o.ProxyPush.SetState(ctx, sid, "running")
-			return errors.New("cubemaster kill: " + killErr.Error())
+			s.restoreState(ctx, sid, origState)
+			return fmt.Errorf("cubemaster kill: %w", killErr)
 		}
 	}
 
-	if err := s.o.Redis.SetState(ctx, sid, "killed", s.o.StateLockTTL); err != nil {
+	if err := s.o.Redis.SetState(ctx, sid, "killed", lifecycle.TerminalStateTTL); err != nil {
 		s.o.Log.Warn("write killed state failed",
 			zap.String("sandbox_id", sid), zap.Error(err))
 	}
@@ -347,4 +337,14 @@ func (s *Sweeper) tryKill(ctx context.Context, e registry.Entry) error {
 		zap.Int("timeout_seconds", e.Meta.TimeoutSeconds),
 		zap.String("kill_reason", cubemasterclient.KillReasonTimeout))
 	return nil
+}
+
+func (s *Sweeper) restoreState(ctx context.Context, sid, state string) {
+	if state == "" {
+		_ = s.o.Redis.ClearState(ctx, sid)
+		_ = s.o.ProxyPush.SetState(ctx, sid, "running")
+		return
+	}
+	_ = s.o.Redis.SetState(ctx, sid, state, lifecycle.TTLForRestoredState(state, s.o.StateLockTTL))
+	_ = s.o.ProxyPush.SetState(ctx, sid, state)
 }

--- a/CubeProxy/sidecar/internal/sweeper/sweeper_test.go
+++ b/CubeProxy/sidecar/internal/sweeper/sweeper_test.go
@@ -23,35 +23,46 @@ import (
 type fakeStore struct {
 	mu     sync.Mutex
 	states map[string]string
+	ttls   map[string]time.Duration
 
 	failAcquire bool
-	acquireBy   func(sid, state string) bool // when set, controls AcquireState success
+	acquireBy   func(sid, state string) bool // when set, controls TryTransitionState success
 }
 
 func newFakeStore() *fakeStore {
-	return &fakeStore{states: make(map[string]string)}
+	return &fakeStore{
+		states: make(map[string]string),
+		ttls:   make(map[string]time.Duration),
+	}
 }
 
-func (f *fakeStore) AcquireState(_ context.Context, sid, state string, _ time.Duration) (bool, error) {
+func (f *fakeStore) TryTransitionState(_ context.Context, sid, newState string, _ time.Duration, allowedCurrentStates ...string) (swapped bool, observedState string, err error) {
+	if len(allowedCurrentStates) == 0 {
+		return false, "", errors.New("TryTransitionState requires at least one expected state")
+	}
 	if f.failAcquire {
-		return false, errors.New("redis down")
+		return false, "", errors.New("redis down")
 	}
 	f.mu.Lock()
 	defer f.mu.Unlock()
-	if f.acquireBy != nil && !f.acquireBy(sid, state) {
-		return false, nil
+	cur := f.states[sid]
+	if f.acquireBy != nil && !f.acquireBy(sid, cur) {
+		return false, cur, nil
 	}
-	if _, ok := f.states[sid]; ok {
-		return false, nil // already held
+	for _, e := range allowedCurrentStates {
+		if cur == e {
+			f.states[sid] = newState
+			return true, cur, nil
+		}
 	}
-	f.states[sid] = state
-	return true, nil
+	return false, cur, nil
 }
 
-func (f *fakeStore) SetState(_ context.Context, sid, state string, _ time.Duration) error {
+func (f *fakeStore) SetState(_ context.Context, sid, state string, ttl time.Duration) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.states[sid] = state
+	f.ttls[sid] = ttl
 	return nil
 }
 
@@ -73,6 +84,12 @@ func (f *fakeStore) state(sid string) string {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	return f.states[sid]
+}
+
+func (f *fakeStore) ttl(sid string) time.Duration {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.ttls[sid]
 }
 
 // fakeMaster captures every Pause / Kill call and lets tests inject errors.
@@ -209,6 +226,9 @@ func TestSweeper_PausesIdleSandbox(t *testing.T) {
 	if got := store.state("sbx-1"); got != "paused" {
 		t.Fatalf("expected redis state=paused, got %q", got)
 	}
+	if got := store.ttl("sbx-1"); got != 0 {
+		t.Fatalf("paused terminal state must not expire, ttl=%s", got)
+	}
 	pushed := push.states("sbx-1")
 	if len(pushed) < 2 || pushed[0] != "pausing" || pushed[len(pushed)-1] != "paused" {
 		t.Fatalf("expected push pausing→paused, got %v", pushed)
@@ -252,9 +272,11 @@ func TestSweeper_SkipsSandboxWithoutAutoPause(t *testing.T) {
 	if got := store.state("sbx-2"); got != "killed" {
 		t.Fatalf("expected redis state=killed, got %q", got)
 	}
-	pushed := push.states("sbx-2")
-	if len(pushed) == 0 || pushed[0] != "killing" {
-		t.Fatalf("expected first push state=killing, got %v", pushed)
+	if got := store.ttl("sbx-2"); got != 0 {
+		t.Fatalf("killed terminal state must not expire, ttl=%s", got)
+	}
+	if pushed := push.states("sbx-2"); len(pushed) != 0 {
+		t.Fatalf("kill path should delete metadata without pushing transient state, got %v", pushed)
 	}
 	triggered, failed := s.KillStats()
 	if triggered != 1 || failed != 0 {
@@ -262,34 +284,99 @@ func TestSweeper_SkipsSandboxWithoutAutoPause(t *testing.T) {
 	}
 }
 
-func TestSweeper_KillRollsBackOnFailure(t *testing.T) {
+func TestSweeper_KillRollbackRestoresOriginalState(t *testing.T) {
+	tests := []struct {
+		name      string
+		sid       string
+		orig      string
+		wantRedis string
+		wantProxy string
+		viaSweep  bool
+	}{
+		{
+			name:      "missing",
+			sid:       "sbx-killfail",
+			wantRedis: "",
+			wantProxy: "running",
+			viaSweep:  true,
+		},
+		{
+			name:      "running",
+			sid:       "sbx-killrunning",
+			orig:      "running",
+			wantRedis: "running",
+			wantProxy: "running",
+			viaSweep:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reg := registry.New()
+			store := newFakeStore()
+			if tt.orig != "" {
+				store.states[tt.sid] = tt.orig
+			}
+			master := &fakeMaster{failNextKill: true, failKillErr: errors.New("master 500")}
+			push := newFakePush()
+
+			now := time.Now()
+			meta := lifecycle.SandboxLifecycleMeta{
+				SandboxID: tt.sid, InstanceType: "cubebox",
+				AutoPause: false, TimeoutSeconds: 60,
+			}
+			s := newTestSweeper(reg, store, master, push, now)
+			if tt.viaSweep {
+				seedEntry(t, reg, meta, now.Add(-10*time.Minute).UnixMilli())
+				s.sweepOnce(context.Background())
+			} else if err := s.tryKill(context.Background(), registry.Entry{Meta: meta}); err == nil {
+				t.Fatal("expected kill failure")
+			}
+
+			if got := store.state(tt.sid); got != tt.wantRedis {
+				t.Fatalf("redis state should be restored to %q, got %q", tt.wantRedis, got)
+			}
+			pushed := push.states(tt.sid)
+			if len(pushed) == 0 || pushed[len(pushed)-1] != tt.wantProxy {
+				t.Fatalf("rollback should restore proxy to %q, got %v", tt.wantProxy, pushed)
+			}
+			if tt.viaSweep {
+				if reg.Get(tt.sid) == nil {
+					t.Fatal("registry entry should NOT be evicted on kill failure")
+				}
+				_, failed := s.KillStats()
+				if failed != 1 {
+					t.Fatalf("expected kill failed=1, got %d", failed)
+				}
+			}
+		})
+	}
+}
+
+func TestSweeper_KillSkipsPausedSandbox(t *testing.T) {
 	reg := registry.New()
 	store := newFakeStore()
-	master := &fakeMaster{failNextKill: true, failKillErr: errors.New("master 500")}
+	store.states["sbx-paused-kill"] = "paused"
+	master := &fakeMaster{}
 	push := newFakePush()
 
 	now := time.Now()
 	seedEntry(t, reg, lifecycle.SandboxLifecycleMeta{
-		SandboxID: "sbx-killfail", InstanceType: "cubebox",
+		SandboxID: "sbx-paused-kill", InstanceType: "cubebox",
 		AutoPause: false, TimeoutSeconds: 60,
 	}, now.Add(-10*time.Minute).UnixMilli())
 
 	s := newTestSweeper(reg, store, master, push, now)
 	s.sweepOnce(context.Background())
 
-	if got := store.state("sbx-killfail"); got != "" {
-		t.Fatalf("redis state should be cleared after rollback, got %q", got)
+	if len(master.killCalls) != 0 {
+		t.Fatalf("paused sandbox must not be timeout-killed: %v", master.killCalls)
 	}
-	pushed := push.states("sbx-killfail")
-	if len(pushed) == 0 || pushed[len(pushed)-1] != "running" {
-		t.Fatalf("rollback should leave proxy at running, got %v", pushed)
+	if got := store.state("sbx-paused-kill"); got != "paused" {
+		t.Fatalf("paused state should be preserved, got %q", got)
 	}
-	if reg.Get("sbx-killfail") == nil {
-		t.Fatal("registry entry should NOT be evicted on kill failure")
-	}
-	_, failed := s.KillStats()
-	if failed != 1 {
-		t.Fatalf("expected kill failed=1, got %d", failed)
+	if got := push.deletedIDs(); len(got) != 0 {
+		t.Fatalf("paused sandbox metadata should not be deleted: %v", got)
 	}
 }
 
@@ -398,38 +485,67 @@ func TestSweeper_BootstrapWarmupSkipsBootstrapEntries(t *testing.T) {
 	}
 }
 
-func TestSweeper_RollsBackOnPauseFailure(t *testing.T) {
-	reg := registry.New()
-	store := newFakeStore()
-	master := &fakeMaster{failNext: true, failError: errors.New("master 500")}
-	push := newFakePush()
-
-	now := time.Now()
-	seedEntry(t, reg, lifecycle.SandboxLifecycleMeta{
-		SandboxID: "sbx-4", InstanceType: "cubebox",
-		AutoPause: true, TimeoutSeconds: 60,
-	}, now.Add(-10*time.Minute).UnixMilli())
-
-	s := newTestSweeper(reg, store, master, push, now)
-	s.sweepOnce(context.Background())
-
-	if got := store.state("sbx-4"); got != "" {
-		t.Fatalf("redis state should be cleared after rollback, got %q", got)
+func TestSweeper_PauseRollbackRestoresOriginalState(t *testing.T) {
+	tests := []struct {
+		name      string
+		sid       string
+		orig      string
+		wantRedis string
+		wantProxy string
+	}{
+		{
+			name:      "missing",
+			sid:       "sbx-4",
+			wantRedis: "",
+			wantProxy: "running",
+		},
+		{
+			name:      "running",
+			sid:       "sbx-running",
+			orig:      "running",
+			wantRedis: "running",
+			wantProxy: "running",
+		},
 	}
-	pushed := push.states("sbx-4")
-	if len(pushed) == 0 || pushed[len(pushed)-1] != "running" {
-		t.Fatalf("rollback should leave proxy at running, got %v", pushed)
-	}
-	_, failed := s.Stats()
-	if failed != 1 {
-		t.Fatalf("expected failed=1, got %d", failed)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reg := registry.New()
+			store := newFakeStore()
+			if tt.orig != "" {
+				store.states[tt.sid] = tt.orig
+			}
+			master := &fakeMaster{failNext: true, failError: errors.New("master 500")}
+			push := newFakePush()
+
+			now := time.Now()
+			seedEntry(t, reg, lifecycle.SandboxLifecycleMeta{
+				SandboxID: tt.sid, InstanceType: "cubebox",
+				AutoPause: true, TimeoutSeconds: 60,
+			}, now.Add(-10*time.Minute).UnixMilli())
+
+			s := newTestSweeper(reg, store, master, push, now)
+			s.sweepOnce(context.Background())
+
+			if got := store.state(tt.sid); got != tt.wantRedis {
+				t.Fatalf("redis state should be restored to %q, got %q", tt.wantRedis, got)
+			}
+			pushed := push.states(tt.sid)
+			if len(pushed) == 0 || pushed[len(pushed)-1] != tt.wantProxy {
+				t.Fatalf("rollback should restore proxy to %q, got %v", tt.wantProxy, pushed)
+			}
+			_, failed := s.Stats()
+			if failed != 1 {
+				t.Fatalf("expected failed=1, got %d", failed)
+			}
+		})
 	}
 }
 
 func TestSweeper_SkipsWhenLockHeldElsewhere(t *testing.T) {
 	reg := registry.New()
 	store := newFakeStore()
-	// Pre-seed the state map → AcquireState returns false (someone else owns).
+	// Pre-seed the state map → TryTransitionState returns false (someone else owns).
 	store.states["sbx-5"] = "pausing"
 
 	master := &fakeMaster{}
@@ -537,7 +653,7 @@ func TestSweeper_SkipsAlreadyPausedSandbox(t *testing.T) {
 	// Redis carries `state:<id>="paused"`. Subsequent sweeps must NOT
 	// re-attempt — the sandbox is already at the desired terminal state
 	// and there is no resource to reclaim. Without this guard the sweeper
-	// hammers SETNX every Interval and issues a pointless RPC against
+	// hammers the state key every Interval and issues pointless churn against
 	// CubeMaster every StateLockTTL seconds.
 	reg := registry.New()
 	store := newFakeStore()
@@ -615,6 +731,9 @@ func TestSweeper_AlreadyPausedReconcilesAsSuccess(t *testing.T) {
 
 	if got := store.state("sbx-already"); got != "paused" {
 		t.Fatalf("expected redis state=paused (reconciliation), got %q", got)
+	}
+	if got := store.ttl("sbx-already"); got != 0 {
+		t.Fatalf("reconciled paused state must not expire, ttl=%s", got)
 	}
 	pushed := push.states("sbx-already")
 	if len(pushed) == 0 || pushed[len(pushed)-1] != "paused" {


### PR DESCRIPTION
## Background
Currently, acquiring the lifecycle state lock relies on `SETNX`, which presents three significant issues in highly concurrent and complex state transitions:
1. **Get-and-Set Race Conditions**: Evaluating state before an update using separate operations is inherently racy. Between a `GET` to read the state and a `SET`/`SETNX` to write the new state, another sidecar instance could claim the key, leading to inconsistent state machine transitions.
2. **Wait Latency on State Override**: Existing states (e.g., `running`, `paused`) share the same state key. Under pure `SETNX`, transitioning from `running` to `pausing` is blocked by the current `running` state's TTL. In some scenarios, this causes an idle pause latency of up to one `StateLockTTL` period.
3. **Imprecise Rollback on Failure**: When a CubeMaster RPC (e.g., Pause or Kill) fails, the system struggles to precisely rollback the state to its exact original form because it cannot perceive the original state while acquiring the lock.

## What Changed
This commit atomically refactors CubeProxy's lifecycle state transitions:

1. **Lua CAS Atomic Operation**
   * Deprecates `SETNX` and introduces the `TryTransitionState` Lua script in Redis to perform a Check-And-Swap (CAS).
   * Supports conditional state updates (e.g., allowing a transition to `pausing` only if the state is `missing` or `running`), ensuring atomic transitions and eliminating both the Get-and-Set race condition and override wait times.
2. **Precise Failure Rollback Mechanism**
   * Upon successfully acquiring the lock, the CAS operation now returns the pre-transition original state (`origState`).
   * In the error handling logic within `resumer.go` and `sweeper.go`, if a Pause/Kill/Resume request fails, `origState` is utilized to accurately restore both Redis and Proxy states.
3. **Steady-state TTL Optimization**
   * For long-term stable states like `running`, `paused`, and `killed`, the short anti-deadlock TTL is replaced with a TTL of `0` (persistent). This reduces unnecessary Redis writes and redundant CubeMaster calls.
4. **Resumer Fail-fast Strategy**
   * Introduces a fail-fast mechanism in the Resume flow: if the sandbox is already detected as `killing` or `killed`, the operation is immediately aborted, avoiding futile polling.

PTAL @chenhengqi 