### PR TITLE
fix(examples): align host-mount example paths with default allowed prefix

### DIFF
--- a/examples/host-mount/README.md
+++ b/examples/host-mount/README.md
@@ -13,8 +13,8 @@ the standard E2B API: they are requested through the `metadata` field of
 ```
 Cubelet host node
 ┌──────────────────────────────────────────────────────┐
-│  /tmp/rw  ───────────────────► /mnt/rw  (read-write) │
-│  /tmp/ro  ───────────────────► /mnt/ro  (read-only)  │
+│  /data/shared/rw  ───────────► /mnt/rw  (read-write) │
+│  /data/shared/ro  ───────────► /mnt/ro  (read-only)  │
 │                                                       │
 │              KVM MicroVM (sandbox)                    │
 └──────────────────────────────────────────────────────┘
@@ -104,13 +104,16 @@ Content-Type: application/json
 
 - A running Cube Sandbox deployment
 - Python 3.8+
-- The host directories (`/tmp/rw` and `/tmp/ro` in the example) must exist on
+- The host directories (`/data/shared/rw` and `/data/shared/ro` in the example) must exist on
   the Cubelet node before creating the sandbox
+- If you want to use a different host path prefix, see `docs/guide/persistent-storage.md`
+  for the `allowed_host_mount_prefixes` configuration and update the example
+  paths accordingly
 
 ```bash
 # On the Cubelet node (or wherever your sandbox VM runs):
-mkdir -p /tmp/rw /tmp/ro
-echo "hello from host" > /tmp/ro/greeting.txt
+mkdir -p /data/shared/rw /data/shared/ro
+echo "hello from host" > /data/shared/ro/greeting.txt
 ```
 
 Install dependencies:
@@ -174,8 +177,8 @@ with Sandbox.create(
     template=template_id,
     metadata={
         "host-mount": json.dumps([
-            {"hostPath": "/tmp/rw", "mountPath": "/mnt/rw", "readOnly": False},
-            {"hostPath": "/tmp/ro", "mountPath": "/mnt/ro", "readOnly": True},
+            {"hostPath": "/data/shared/rw", "mountPath": "/mnt/rw", "readOnly": False},
+            {"hostPath": "/data/shared/ro", "mountPath": "/mnt/ro", "readOnly": True},
         ])
     },
 ) as sandbox:
@@ -193,9 +196,9 @@ with Sandbox.create(
 
 | Symptom | Likely Cause | Fix |
 |---------|-------------|-----|
-| `hostPath "..." is not within an allowed mount prefix` | `hostPath` is outside the allowed prefixes | Move data under `/data/shared/` or add the path to `allowed_host_mount_prefixes` in CubeMaster config |
+| `hostPath "..." is not within an allowed mount prefix` | `hostPath` is outside the configured allowed prefixes | Move data under `/data/shared/`, or update `allowed_host_mount_prefixes` as described in `docs/guide/persistent-storage.md` |
 | `No such file or directory` inside sandbox | `hostPath` does not exist on the Cubelet node | Create the directory on the node before running |
-| `Read-only file system` on write | Mounted with `readOnly: true` | Use `readOnly: false` or switch to `/mnt/rw` |
+| `Read-only file system` when writing to `/mnt/ro/...` | Mounted with `readOnly: true` | Set that mount to `readOnly: false`, or write to the read-write sandbox path `/mnt/rw/...` instead |
 | `Template not found` | Wrong template ID | Run `cubemastercli tpl list` |
 | `Connection refused` | CubeAPI not reachable | Check `E2B_API_URL` and that port 3000 is open |
 

--- a/examples/host-mount/create_with_mount.py
+++ b/examples/host-mount/create_with_mount.py
@@ -36,12 +36,12 @@ with Sandbox.create(
         # path inside the sandbox VM.
         "host-mount": json.dumps([
             {
-                "hostPath":  "/tmp/rw",   # host directory (must exist on the Cubelet node)
+                "hostPath":  "/data/shared/rw",  # host directory under the default allowed prefix (must exist on the Cubelet node)
                 "mountPath": "/mnt/rw",   # where it appears inside the sandbox
                 "readOnly":  False,       # read-write mount
             },
             {
-                "hostPath":  "/tmp/ro",   # host directory (must exist on the Cubelet node)
+                "hostPath":  "/data/shared/ro",  # host directory under the default allowed prefix (must exist on the Cubelet node)
                 "mountPath": "/mnt/ro",   # where it appears inside the sandbox
                 "readOnly":  True,        # read-only mount
             },


### PR DESCRIPTION
## Motivation

After #756, the default host-mount validation only allows host paths under `/data/shared/`.

The dedicated runnable host-mount example still used the old `/tmp/...` paths, so it could fail on a fresh default deployment even though users were following the example as written.

## What Changed

* Update `examples/host-mount/create_with_mount.py` to use `/data/shared/rw` and `/data/shared/ro`.
* Update `examples/host-mount/README.md` so the runnable example, prerequisite commands, and diagram all use the same default prefix.
* Clarify troubleshooting guidance for disallowed hostPath prefixes, read-only sandbox mount paths, and host-directory permission mismatches.

## Scope

This PR only updates the dedicated host-mount example.

## Validation

* Verified the worktree only changes:

  * `examples/host-mount/create_with_mount.py`
  * `examples/host-mount/README.md`
* Verified the updated host-mount example no longer uses `/tmp/rw` or `/tmp/ro`.
* No code tests were run because this PR only updates example and documentation content.
