### PR TITLE
fix(agenthub): force OpenClaw gateway bind to "lan" mode

### DIFF
--- a/CubeAPI/src/handlers/agenthub.rs
+++ b/CubeAPI/src/handlers/agenthub.rs
@@ -3242,8 +3242,10 @@ enum OpenClawApplyMode {
     /// without bundled state.
     FullInit,
     /// Only merge the LLM-related blocks into existing config, preserving the
-    /// gateway (and its token). Used when the sandbox already carries OpenClaw
-    /// state (published template fast path / clone from snapshot).
+    /// gateway (and its token). Gateway `bind` is forced to `"lan"` regardless
+    /// of existing state to ensure cube-proxy can reach the sandbox tap IP.
+    /// Used when the sandbox already carries OpenClaw state (published template
+    /// fast path / clone from snapshot).
     MergeLlm,
 }
 
@@ -3687,7 +3689,7 @@ if mode == "full_init":
             token = existing
         if not token:
             token = secrets.token_hex(16)
-        gateway["bind"] = os.environ.get("OPENCLAW_BIND", "auto")
+        gateway["bind"] = "lan"
         gateway["port"] = int(os.environ.get("OPENCLAW_PORT", "18789"))
         gateway["mode"] = "local"
         gateway["tailscale"] = {"mode": "off", "resetOnExit": False}
@@ -3737,6 +3739,10 @@ if mode == "full_init":
             "secret": os.environ["OPENCLAW_BOT_SECRET"],
             "enabled": True,
         }, ensure_ascii=False, indent=2) + "\n")
+
+# Cube-proxy dials the sandbox tap IP, so merge_llm / template fast paths must
+# still expose the gateway on non-loopback interfaces ("lan", not loopback/auto).
+data.setdefault("gateway", {})["bind"] = "lan"
 
 tmp = config_path.with_suffix(".json.tmp")
 tmp.write_text(json.dumps(data, ensure_ascii=False, indent=2) + "\n")


### PR DESCRIPTION
## Summary

Cube-proxy connects to the OpenClaw gateway via the sandbox tap IP, which requires the gateway to listen on non-loopback interfaces. Previously the bind mode defaulted to `"auto"`, which could resolve to loopback and break connectivity.

## Changes

1. **Template init**: Hardcode `gateway["bind"] = "lan"` instead of reading the `OPENCLAW_BIND` env var (which defaults to `"auto"`).
2. **Post-init merge fast path**: Force `gateway.bind = "lan"` in the LLM config merge step, so the setting persists across config re-merges.

## Affected

- `CubeAPI/src/handlers/agenthub.rs` — AgentHub handler, OpenClaw config generation logic.