### PR TITLE
docs: refresh CODEOWNERS and PR/issue close policy

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,12 +1,50 @@
-* @fslongjin @ls-ggg @tinklone @up2wing @chenhengqi
+# Default owners for anything not covered by a more specific rule below.
+* @fslongjin @ls-ggg @chenhengqi
 
-/CubeEgress/ @chenhengqi
-/CubeNet/ @chenhengqi
-/CubeShim/ @ls-ggg @fslongjin
-/Cubelet/ @fslongjin
-/agent/ @ls-ggg @fslongjin
-/docs/ @tinklone
-/examples/ @tinklone
+# ---------------------------------------------------------------------------
+# Module ownership
+# CODEOWNERS applies last-match-wins, so more specific paths are listed below
+# the catch-all rule above.
+# ---------------------------------------------------------------------------
+
+# Network: network configuration, tap devices, connectivity
+/CubeNet/ @chenhengqi @zhouxianping
+/CubeEgress/ @chenhengqi @zhouxianping
+/network-agent/ @chenhengqi @zhouxianping
+
+# Cubelet / CubeMaster: overall system/orchestration flow
+/Cubelet/ @fslongjin @ls-ggg @chenhengqi
+/CubeMaster/ @fslongjin @ls-ggg @chenhengqi
+
+# Shim: containerd shim
+/CubeShim/ @ls-ggg
+
+# agent: in-guest runtime
+/agent/ @ls-ggg
+
+# Hypervisor (Cloud Hypervisor fork)
 /hypervisor/ @up2wing @lisongqian
-/network-agent/ @fslongjin
+
+# API / SDK: external interfaces, client SDKs
+/CubeAPI/ @ls-ggg @fslongjin
+/sdk/ @tinklone @wbzdssm
+
+# Docs: doc errors, sample code (primary owner; module-specific pages are
+# still covered by the owning module's rule above when paths overlap)
+/docs/ @fslongjin
+
+# ARM platform
+*aarch64* @lkml-likexu
+*arm64* @lkml-likexu
+
+# Deployment: one-click / k8s
+/deploy/one-click/ @fslongjin
+
+# Terraform deployment
+/deploy/one-click/terraform/ @lkml-likexu @tinklone
+
+# CI / test cases / examples
+/.github/workflows/ @tinklone
+/examples/ @tinklone
+
 /cubecow @lisongqian

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -133,6 +133,15 @@ Commits without a valid `Signed-off-by` line will not be accepted.
 - **Rust** — follow `rustfmt` and `clippy` recommendations.
 - **Documentation** — use clear, concise language. Both English and Chinese docs should be kept in sync.
 
+## Issue & PR Close Policy
+
+Issues and PRs are closed under the following conditions:
+
+- **Stale after a `need-info` request** — if a maintainer asks for more information or requested changes and the author does not respond **for more than 2 weeks**, the Issue/PR is closed as stale. It can be reopened once the requested information or changes are provided.
+- **Resolved or superseded** — the underlying bug is fixed, the feature is implemented, or the change has been superseded by another PR/approach.
+- **Out of scope / won't fix** — closed with a comment explaining why.
+- **Duplicate** — closed with a link to the original Issue/PR.
+
 ## Reporting Security Issues
 
 If you discover a security vulnerability, please report it responsibly via [GitHub Security Advisories](https://github.com/tencentcloud/CubeSandbox/security/advisories) rather than opening a public Issue.

--- a/CONTRIBUTING_zh.md
+++ b/CONTRIBUTING_zh.md
@@ -133,6 +133,15 @@ Signed-off-by: Your Name <your.email@example.com>
 - **Rust** — 遵循 `rustfmt` 和 `clippy` 的建议。
 - **文档** — 使用清晰简洁的语言，中英文文档应保持同步。
 
+## Issue / PR 关闭规则
+
+Issue 与 PR 会在以下条件下被关闭：
+
+- **`need-info` 超时未回复**：维护者要求补充信息或修改后，作者**超过两周未回应**，将被作为过期项关闭。待补充所需信息或完成修改后可重新打开。
+- **已解决或被取代**：问题已修复、功能已实现，或已被其他 PR/方案取代。
+- **不在项目范围内 / 不予处理**：关闭时会说明原因。
+- **重复提交**：关闭并附上原始 Issue/PR 链接。
+
 ## 报告安全问题
 
 如果你发现安全漏洞，请通过 [GitHub Security Advisories](https://github.com/tencentcloud/CubeSandbox/security/advisories) 进行负责任的披露，而不是在公开 Issue 中提交。


### PR DESCRIPTION
- Fill in module owners in .github/CODEOWNERS (network, cubelet/ cubemaster, shim/agent, hypervisor, API/SDK, docs, arm, terraform, one-click, ci/examples). Hypervisor stays owned by up2wing/ lisongqian; shim/agent stays owned by ls-ggg/fslongjin only.
- Add a concise Issue/PR close policy section to CONTRIBUTING.md and CONTRIBUTING_zh.md: need-info or unaddressed review feedback with no author response for more than 2 weeks gets closed as stale, reopenable once resolved.