### PR TITLE
fix(cubeapi): accept snake_case lifecycle fields

### DIFF
--- a/CubeAPI/src/models/mod.rs
+++ b/CubeAPI/src/models/mod.rs
@@ -127,12 +127,12 @@ pub struct EgressRuleInject {
 #[derive(Debug, Clone, Default, Serialize, Deserialize, ToSchema)]
 pub struct SandboxLifecycleConfig {
     /// "kill" (default) | "pause".
-    #[serde(rename = "onTimeout", default)]
+    #[serde(rename = "onTimeout", alias = "on_timeout", default)]
     pub on_timeout: SandboxOnTimeout,
 
     /// Auto-resume on activity. Defaults to false. Only meaningful when
     /// `on_timeout` is set to "pause".
-    #[serde(rename = "autoResume", default)]
+    #[serde(rename = "autoResume", alias = "auto_resume", default)]
     pub auto_resume: bool,
 }
 

--- a/CubeAPI/src/services/sandboxes.rs
+++ b/CubeAPI/src/services/sandboxes.rs
@@ -1209,6 +1209,16 @@ mod tests {
         .unwrap();
         assert_eq!(translate(&pause_with_resume), (true, true));
 
+        // Some Python SDK versions and direct callers may send the Pythonic
+        // snake_case shape. Keep accepting it so lifecycle does not silently
+        // fall back to the default kill/no-resume behaviour.
+        let snake_case_pause_with_resume: NewSandbox = serde_json::from_value(serde_json::json!({
+            "templateID": "tpl",
+            "lifecycle": {"on_timeout": "pause", "auto_resume": true},
+        }))
+        .unwrap();
+        assert_eq!(translate(&snake_case_pause_with_resume), (true, true));
+
         // Pause without auto_resume — caller must call connect() manually.
         let pause_only: NewSandbox = serde_json::from_value(serde_json::json!({
             "templateID": "tpl",


### PR DESCRIPTION
## Summary

Fix CubeAPI lifecycle decoding so both supported request shapes work:

- canonical E2B-style `lifecycle.onTimeout` / `lifecycle.autoResume`
- Python-style `lifecycle.on_timeout` / `lifecycle.auto_resume`

This adds serde aliases for the snake_case lifecycle fields and covers the regression with a focused unit test.

## Background

This bug was discovered while testing lifecycle behavior with:

- `cubesandbox` Python SDK `0.3.0`
- `e2b` Python SDK `2.29.1`

When creating a sandbox with:

```python
sandbox = Sandbox.create(
    template=os.environ.get("CUBE_TEMPLATE_ID"),
    timeout=15,
    lifecycle={
        "on_timeout": "pause",
        "auto_resume": True,
    },
)
```

the CubeProxy sidecar log at `/data/log/cube-proxy/sidecar.log` always showed:

```json
{
    "level": "info",
    "ts": 1783305204.332911,
    "logger": "stream",
    "caller": "sidecar/main.go:216",
    "msg": "create event applied",
    "sandbox_id": "a25ba6ed2828480b9dee733f6cb4057e",
    "auto_pause": false,
    "auto_resume": false,
    "timeout_seconds": 15,
    "registry_size": 1
}
```

This did not match the caller's lifecycle input, which led to this fix.

## Root Cause

CubeAPI only accepted the camelCase lifecycle keys. When a caller sent snake_case fields, serde treated them as unknown, applied the default lifecycle values, and CubeAPI forwarded `auto_pause=false` and `auto_resume=false` to CubeMaster.

## Impact

Python SDK users and direct HTTP callers that send snake_case lifecycle fields now get the expected behavior:

- `on_timeout="pause"` maps to `auto_pause=true`
- `auto_resume=true` maps to `auto_resume=true`

Existing camelCase clients remain unchanged.

## Testing

- `cargo +1.85.1 test -q lifecycle`
- `cargo +1.85.1 fmt --check`
- `git --no-pager diff --no-ext-diff --check`

Signed-off-by: chenyaojie <chenyaojiexxx@gmail.com>