### PR TITLE
fix(deploy): anchor cubelet config patching

### DIFF
--- a/deploy/one-click/lib/common.sh
+++ b/deploy/one-click/lib/common.sh
@@ -697,8 +697,8 @@ patch_cubelet_config_template() {
   if [[ -n "${eth_name}" ]]; then
     validate_interface_name "${eth_name}" "CUBE_SANDBOX_ETH_NAME"
     if grep -Eq '^[[:space:]]*eth_name = "' "${cubelet_config}"; then
-      sed -i "s/eth_name = \"[^\"]*\"/eth_name = \"${eth_name}\"/" "${cubelet_config}"
-      if ! grep -Fq "eth_name = \"${eth_name}\"" "${cubelet_config}"; then
+      sed -i -E "s|^([[:space:]]*)eth_name = \"[^\"]*\"|\1eth_name = \"${eth_name}\"|" "${cubelet_config}"
+      if ! grep -Eq "^[[:space:]]*eth_name = \"${eth_name}\"\$" "${cubelet_config}"; then
         log "WARNING: failed to patch eth_name in Cubelet config (${cubelet_config})"
       fi
     else
@@ -708,8 +708,8 @@ patch_cubelet_config_template() {
 
   if [[ -n "${network_cidr}" ]]; then
     if grep -Eq '^[[:space:]]*cidr = "' "${cubelet_config}"; then
-      sed -i "s|cidr = \"[^\"]*\"|cidr = \"${network_cidr}\"|" "${cubelet_config}"
-      if ! grep -Fq "cidr = \"${network_cidr}\"" "${cubelet_config}"; then
+      sed -i -E "s|^([[:space:]]*)cidr = \"[^\"]*\"|\1cidr = \"${network_cidr}\"|" "${cubelet_config}"
+      if ! grep -Eq "^[[:space:]]*cidr = \"${network_cidr}\"\$" "${cubelet_config}"; then
         log "WARNING: failed to patch cidr in Cubelet config (${cubelet_config})"
       fi
       log "patched cubevs CIDR: ${network_cidr}"
@@ -725,8 +725,8 @@ patch_cubelet_config_template() {
       cube_router_enable_toml="true"
     fi
     if grep -Eq '^[[:space:]]*cube_router_enable = ' "${cubelet_config}"; then
-      sed -i "s|cube_router_enable = .*|cube_router_enable = ${cube_router_enable_toml}|" "${cubelet_config}"
-      if ! grep -Fq "cube_router_enable = ${cube_router_enable_toml}" "${cubelet_config}"; then
+      sed -i -E "s|^([[:space:]]*)cube_router_enable = .*|\1cube_router_enable = ${cube_router_enable_toml}|" "${cubelet_config}"
+      if ! grep -Eq "^[[:space:]]*cube_router_enable = ${cube_router_enable_toml}\$" "${cubelet_config}"; then
         log "WARNING: failed to patch cube_router_enable in Cubelet config (${cubelet_config})"
       fi
       log "patched cube-router enable: ${cube_router_enable_toml}"
@@ -737,8 +737,8 @@ patch_cubelet_config_template() {
 
   if [[ -n "${cube_router_cidr}" ]]; then
     if grep -Eq '^[[:space:]]*cube_router_cidr = "' "${cubelet_config}"; then
-      sed -i "s|cube_router_cidr = \"[^\"]*\"|cube_router_cidr = \"${cube_router_cidr}\"|" "${cubelet_config}"
-      if ! grep -Fq "cube_router_cidr = \"${cube_router_cidr}\"" "${cubelet_config}"; then
+      sed -i -E "s|^([[:space:]]*)cube_router_cidr = \"[^\"]*\"|\1cube_router_cidr = \"${cube_router_cidr}\"|" "${cubelet_config}"
+      if ! grep -Eq "^[[:space:]]*cube_router_cidr = \"${cube_router_cidr}\"\$" "${cubelet_config}"; then
         log "WARNING: failed to patch cube_router_cidr in Cubelet config (${cubelet_config})"
       fi
       log "patched cube-router CIDR: ${cube_router_cidr}"

--- a/deploy/one-click/tests/test_install_mode.sh
+++ b/deploy/one-click/tests/test_install_mode.sh
@@ -332,6 +332,21 @@ EOF
   grep -Fq 'cube_router_enable = true' "${cfg}" || fail "patch should update cube_router_enable"
   grep -Fq 'cube_router_cidr = "172.20.0.0/16"' "${cfg}" || fail "patch should update cube_router_cidr"
 
+  local default_router_cidr_cfg="${TMP_DIR}/cubelet-default-router-cidr.toml"
+  cat > "${default_router_cidr_cfg}" <<'EOF'
+    eth_name = "eth0"
+    cidr = "192.168.0.0/18"
+    cube_router_enable = false
+    cube_router_cidr = ""
+EOF
+  patch_cubelet_config_template "${default_router_cidr_cfg}" "" "172.16.128.0/20" "1" "" >/dev/null 2>&1
+  grep -Fq 'cidr = "172.16.128.0/20"' "${default_router_cidr_cfg}" \
+    || fail "patch should update only the top-level cidr key"
+  grep -Fq 'cube_router_enable = true' "${default_router_cidr_cfg}" \
+    || fail "patch should update cube_router_enable when cube-router is enabled"
+  grep -Fq 'cube_router_cidr = ""' "${default_router_cidr_cfg}" \
+    || fail "patching cidr must not modify cube_router_cidr when cube-router CIDR is empty"
+
   local target="${TMP_DIR}/symlink-target.toml" link="${TMP_DIR}/symlink-config.toml"
   cat > "${target}" <<'EOF'
 eth_name = "eth0"


### PR DESCRIPTION
Patch Cubelet TOML keys by anchoring sed replacements at the start of the line. This prevents updating CUBE_SANDBOX_NETWORK_CIDR from accidentally rewriting cube_router_cidr when the cube-router CIDR is left empty.

Add a one-click install-mode regression test for the route-aware egress case where cube-router is enabled, sandbox CIDR is customized, and cube_router_cidr should remain empty for default derivation.

### What changed

This patch fixes an accidental broad TOML replacement in the one-click installer when patching Cubelet network settings.

Before this change, the installer used an unanchored `sed` pattern:

```bash
sed -i "s|cidr = \"[^\"]*\"|cidr = \"${network_cidr}\"|" "${cubelet_config}"
```

Because the pattern was not anchored to the beginning of the line, it matched both:
```bash
cidr = "192.168.0.0/18"
cube_router_cidr = "10.254.0.0/24"
```

The second line contains the substring cidr = "...", so cube_router_cidr could be accidentally rewritten when only the sandbox CIDR was supposed to be patched.
After this change, the replacement is anchored to the TOML key at line start:
```bash
sed -i -E "s|^([[:space:]]*)cidr = \"[^\"]*\"|\1cidr = \"${network_cidr}\"|" "${cubelet_config}"
```

Now only the top-level cidr key is patched, while similarly named keys such as cube_router_cidr are left untouched.
The same anchoring style is also applied to eth_name for consistency and to avoid future substring matches if another key name contains eth_name.