### PR TITLE
Revert "fix(cubelet): avoid FATAL crash when ControllerPlugin does not implement CubeMetaController"

### DIFF
--- a/Cubelet/pkg/constants/const.go
+++ b/Cubelet/pkg/constants/const.go
@@ -90,7 +90,6 @@ const (
 	ControllerConfigPlugin  plugin.Type = "io.cubelet.controller.config.v1"
 	ControllerCubeletPlugin plugin.Type = "io.cubelet.controller.cubelet.v1"
 	ControllerPlugin        plugin.Type = "io.cubelet.controller.v1"
-	ResourceManagerPlugin   plugin.Type = "io.cubelet.resource-manager.v1"
 
 	PluginCubelet                       string   = "cubelet"
 	PluginRunTemplateManager            PluginId = "run-template-manager"

--- a/Cubelet/plugins/controller/cubelet_plugin.go
+++ b/Cubelet/plugins/controller/cubelet_plugin.go
@@ -51,7 +51,6 @@ func registerCubelet() {
 			plugins.CRIServicePlugin,
 			constants.ControllerPlugin,
 			constants.ControllerConfigPlugin,
-			constants.ResourceManagerPlugin,
 		},
 		InitFn: func(ic *plugin.InitContext) (interface{}, error) {
 			obj, err := ic.GetByID(constants.ControllerConfigPlugin, constants.PluginCubelet)
@@ -92,11 +91,11 @@ func registerCubelet() {
 				if ok {
 					controllerMap[name] = c
 				} else {
-					log.G(ic.Context).Warnf("controller %s is not a valid CubeMetaController", name)
+					log.G(ic.Context).Fatalf("controller %s is not a valid CubeMetaController", name)
 				}
 			}
 
-			obj, err = ic.GetByID(constants.ResourceManagerPlugin, constants.PluginRunTemplateManager.ID())
+			obj, err = ic.GetByID(constants.ControllerPlugin, constants.PluginRunTemplateManager.ID())
 			if err != nil {
 				return nil, fmt.Errorf("failed to get run template manager: %w", err)
 			}

--- a/Cubelet/plugins/controller/resource_manager_plugins.go
+++ b/Cubelet/plugins/controller/resource_manager_plugins.go
@@ -20,7 +20,7 @@ func init() {
 
 func registerCubeRunTemplateResourceManager() {
 	registry.Register(&plugin.Registration{
-		Type: constants.ResourceManagerPlugin,
+		Type: constants.ControllerPlugin,
 		ID:   constants.PluginRunTemplateManager.ID(),
 		Requires: []plugin.Type{
 			constants.CubeMetaStorePlugin,

--- a/Cubelet/plugins/cube/internals/appsnapshot/appsnapshot_plugin.go
+++ b/Cubelet/plugins/cube/internals/appsnapshot/appsnapshot_plugin.go
@@ -23,10 +23,10 @@ func init() {
 		Type: constants.InternalPlugin,
 		ID:   constants.APPSnapshotID.ID(),
 		Requires: []plugin.Type{
-			constants.ResourceManagerPlugin,
+			constants.ControllerPlugin,
 		},
 		InitFn: func(ic *plugin.InitContext) (interface{}, error) {
-			obj, err := ic.GetByID(constants.ResourceManagerPlugin, constants.PluginRunTemplateManager.ID())
+			obj, err := ic.GetByID(constants.ControllerPlugin, constants.PluginRunTemplateManager.ID())
 			if err != nil {
 				return nil, fmt.Errorf("failed to get run template manager: %w", err)
 			}


### PR DESCRIPTION
Reverts TencentCloud/CubeSandbox#751 because it makes cubelet failed to register to cubematser


<img width="1190" height="478" alt="image" src="https://github.com/user-attachments/assets/3a065fa1-be3e-44c6-bbbc-6d8455350d97" />

and, the `Fatalf` in CubeLog do not make cubelet crash, the origin issue #750 's "cubelet crash every 5 minutes" is false positive