### PR TITLE
CubeVS: Skip network policy check for established connections

### DIFF
--- a/CubeNet/src/cubevs.h
+++ b/CubeNet/src/cubevs.h
@@ -70,6 +70,9 @@
 #define ICMP_CSUM_OFF(LEN)		(sizeof(struct ethhdr) + LEN + offsetof(struct icmphdr, checksum))
 #define ICMP_ECHO_ID_OFF(LEN)		(sizeof(struct ethhdr) + LEN + offsetof(struct icmphdr, un.echo.id))
 
+/* Current network namespace */
+#define BPF_F_CURRENT_NETNS		(-1L)
+
 /* IP and MAC address inside MVMs */
 const volatile __u32 mvm_inner_ip       = 0x0644fea9;	/* 169.254.68.6, network byte order */
 const volatile __u32 mvm_macaddr_p1     = 0xfc6f9020;	/* 20:90:6f:fc:fc:fc */

--- a/CubeNet/src/cubevs.h
+++ b/CubeNet/src/cubevs.h
@@ -242,6 +242,26 @@ struct snat_ip {
 	__u16 reserved;
 };
 
+/* skb->cb[0] is reserved as a per-invocation NAT status word used by
+ * create_nat_session() to communicate the failure reason back to callers
+ * in from_cube(). skb->cb[] is 5 * u32 scratch that survives across
+ * bpf-to-bpf calls within a single program invocation, so this works even
+ * when the session helpers are compiled as subprogs.
+ */
+#define NAT_CB_STATUS_INDEX		0
+#define NAT_CB_OK			0
+#define NAT_CB_DENIED_BY_POLICY		1
+
+static __always_inline void nat_cb_set(struct __sk_buff *skb, __u32 status)
+{
+	skb->cb[NAT_CB_STATUS_INDEX] = status;
+}
+
+static __always_inline __u32 nat_cb_get(const struct __sk_buff *skb)
+{
+	return skb->cb[NAT_CB_STATUS_INDEX];
+}
+
 /* static assert, make sure size of structs are expected
  */
 static __always_inline int _()

--- a/CubeNet/src/dns_response.h
+++ b/CubeNet/src/dns_response.h
@@ -160,6 +160,7 @@ static __always_inline bool dns_process_response_answer(struct __sk_buff *skb,
 		if (bpf_skb_load_bytes(skb, *cursor, &ip, sizeof(ip)))
 			return false;
 		ttl = bpf_ntohl(rr.ttl);
+		if (ttl < 300) ttl = 300;
 		dns_learn_response_ip(ifindex, ip, ttl, flags);
 	}
 

--- a/CubeNet/src/icmp.h
+++ b/CubeNet/src/icmp.h
@@ -34,11 +34,12 @@ static __always_inline void update_icmp_session(enum ip_conntrack_dir dir,
 	session_mark_replied(dir, sess, ICMP_CT_UNREPLIED, ICMP_CT_REPLIED);
 }
 
-static __always_inline bool create_icmp_sessions(struct session_key *ekey,
+static __always_inline bool create_icmp_sessions(struct __sk_buff *skb,
+						 struct session_key *ekey,
 						 __u64 now_ns, __u32 vm_ifindex,
 						 struct snat_ip *snat_ip, __u16 snat_id)
 {
-	return create_nat_session(ekey, now_ns, vm_ifindex, snat_ip, snat_id,
+	return create_nat_session(skb, ekey, now_ns, vm_ifindex, snat_ip, snat_id,
 				  ICMP_CT_UNREPLIED);
 }
 

--- a/CubeNet/src/mvmtap.bpf.c
+++ b/CubeNet/src/mvmtap.bpf.c
@@ -929,8 +929,10 @@ int from_cube(struct __sk_buff *skb)
 	__u32 daddr, ifindex, dst_ifindex;
 	__u64 tcp_ret;
 	struct net_policy_value_v2 policy_value = {};
+	struct bpf_sock_tuple tuple = {};
 	struct mvm_port mvm_port = {};
 	struct mvm_meta *mvm_meta;
+	struct bpf_sock *sk;
 	struct ethhdr *l2;
 	struct iphdr *l3;
 	struct tcphdr *l4;
@@ -1011,6 +1013,23 @@ int from_cube(struct __sk_buff *skb)
 				return TC_ACT_SHOT;
 
 			return bpf_redirect(nodenic_ifindex, 0);
+		}
+	}
+
+	if (proto == IPPROTO_TCP &&
+	    __pull_headers(skb, &l2, &l3, &l4) &&
+	    (l4->dest == bpf_htons(80) || l4->dest == bpf_htons(443))) {
+		tuple.ipv4.saddr = mvm_meta->ip;
+		tuple.ipv4.daddr = daddr;
+		tuple.ipv4.sport = l4->source;
+		tuple.ipv4.dport = l4->dest;
+		sk = bpf_skc_lookup_tcp(skb, &tuple, sizeof(tuple.ipv4), BPF_F_CURRENT_NETNS, 0);
+		if (sk) {
+			__u32 state = sk->state;
+
+			bpf_sk_release(sk);
+			if (state == BPF_TCP_ESTABLISHED)
+				return bpf_redirect(cubegw0_ifindex, BPF_F_INGRESS);
 		}
 	}
 

--- a/CubeNet/src/mvmtap.bpf.c
+++ b/CubeNet/src/mvmtap.bpf.c
@@ -107,67 +107,35 @@ static __always_inline bool should_do_nat(const struct iphdr *l3)
 }
 
 /*
- * Check egress network policy for a packet.
+ * Check whether a TCP flow should be redirected to the L7 proxy.
  *
- * Priority: allow_out_v2 > deny_out > default allow
- *
- *   1. If allow_out_v2 has an inner map for this ifindex and daddr matches,
- *      the packet is explicitly allowed (even if deny_out would match).
- *   2. If deny_out has an inner map for this ifindex and daddr matches,
- *      the packet is denied.
- *   3. Otherwise the packet is allowed.
- *
- * Returns true if the packet is allowed, false if denied. When allow_out_v2
- * matches, policy_value receives the matched flags for later L7 routing.
+ * Looks up allow_out_v2 for the given ifindex/daddr and returns true iff
+ * the entry carries NET_POLICY_FLAG_L7_REQUIRED and the destination port
+ * is 80 or 443. This is a fast, self-contained lookup — the general
+ * egress policy check (allow / deny) is enforced later inside
+ * create_nat_session().
  */
-static __always_inline bool check_net_policy(__u32 ifindex, __u32 daddr,
-					     struct net_policy_value_v2 *policy_value)
+static __always_inline bool should_redirect_to_l7_proxy(__u32 ifindex, __u32 daddr,
+							const struct tcphdr *l4)
 {
 	struct lpm_key key = { .prefixlen = 32, .ip = daddr };
 	struct net_policy_value_v2 *value;
 	void *inner_map;
 
-	policy_value->expires_at_ns = 0;
-	policy_value->flags = 0;
-
-	/* Traffic to mvm_gateway_ip is internal (destined for cube-dev),
-	 * skip network policy enforcement.
-	 */
-	if (daddr == mvm_gateway_ip)
-		return true;
-
-	/* allow_out_v2 takes precedence. */
-	inner_map = bpf_map_lookup_elem(&allow_out_v2, &ifindex);
-	if (inner_map) {
-		value = bpf_map_lookup_elem(inner_map, &key);
-		if (value && (value->expires_at_ns == 0 ||
-			      value->expires_at_ns > bpf_ktime_get_ns())) {
-			*policy_value = *value;
-			return true;
-		}
-		/* allow_out_v2 map exists but daddr not in it or entry expired,
-		 * fall through to deny_out check.
-		 */
-	}
-
-	/* check deny_out */
-	inner_map = bpf_map_lookup_elem(&deny_out, &ifindex);
-	if (inner_map) {
-		if (bpf_map_lookup_elem(inner_map, &key))
-			return false;
-	}
-
-	/* default: allow */
-	return true;
-}
-
-static __always_inline bool should_redirect_to_l7_proxy(const struct net_policy_value_v2 *policy_value,
-							const struct tcphdr *l4)
-{
-	if (!(policy_value->flags & NET_POLICY_FLAG_L7_REQUIRED))
+	if (l4->dest != bpf_htons(80) && l4->dest != bpf_htons(443))
 		return false;
 
-	return l4->dest == bpf_htons(80) || l4->dest == bpf_htons(443);
+	inner_map = bpf_map_lookup_elem(&allow_out_v2, &ifindex);
+	if (!inner_map)
+		return false;
+
+	value = bpf_map_lookup_elem(inner_map, &key);
+	if (!value)
+		return false;
+	if (value->expires_at_ns != 0 && value->expires_at_ns <= bpf_ktime_get_ns())
+		return false;
+
+	return value->flags & NET_POLICY_FLAG_L7_REQUIRED;
 }
 
 enum tcp_nat_result {
@@ -505,7 +473,7 @@ static __always_inline __u32 do_icmp_nat(struct __sk_buff *skb, struct mvm_meta 
 	snat_ip = pick_snat_ip_port(mvm_meta->ip, &key, &snat_id);
 	if (!snat_ip || !snat_ip->ip || !snat_id)
 		return 0;
-	ok = create_icmp_sessions(&key, now, skb->ingress_ifindex, snat_ip, snat_id);
+	ok = create_icmp_sessions(skb, &key, now, skb->ingress_ifindex, snat_ip, snat_id);
 	if (!ok)
 		return 0;
 	sess = bpf_map_lookup_elem(&egress_sessions, &key);
@@ -603,7 +571,7 @@ static __always_inline __u32 do_udp_nat_inline(struct __sk_buff *skb,
 	snat_ip = pick_snat_ip_port(mvm_meta->ip, &key, &snat_port);
 	if (!snat_ip || !snat_ip->ip || !snat_port)
 		return 0;
-	ok = create_udp_sessions(&key, now, skb->ingress_ifindex, snat_ip, snat_port);
+	ok = create_udp_sessions(skb, &key, now, skb->ingress_ifindex, snat_ip, snat_port);
 	if (!ok)
 		return 0;
 	sess = bpf_map_lookup_elem(&egress_sessions, &key);
@@ -755,9 +723,15 @@ do_create:
 		snat_ip = pick_snat_ip_port(mvm_meta->ip, &key, &snat_port);
 		if (!snat_ip || !snat_ip->ip || !snat_port)
 			return TCP_NAT_DROP;
-		ok = create_new_sessions(&key, now, skb->ingress_ifindex, snat_ip, snat_port);
-		if (!ok)
+		ok = create_new_sessions(skb, &key, now, skb->ingress_ifindex, snat_ip, snat_port);
+		if (!ok) {
+			/* Preserve RST-on-deny: create_nat_session stamps
+			 * skb->cb when the failure is due to net policy.
+			 */
+			if (nat_cb_get(skb) == NAT_CB_DENIED_BY_POLICY)
+				return TCP_NAT_PACK(0, TCP_NAT_RESET);
 			return TCP_NAT_DROP;
+		}
 		sess = bpf_map_lookup_elem(&egress_sessions, &key);
 		if (!sess)
 			return TCP_NAT_DROP;
@@ -928,7 +902,6 @@ int from_cube(struct __sk_buff *skb)
 {
 	__u32 daddr, ifindex, dst_ifindex;
 	__u64 tcp_ret;
-	struct net_policy_value_v2 policy_value = {};
 	struct bpf_sock_tuple tuple = {};
 	struct mvm_port mvm_port = {};
 	struct mvm_meta *mvm_meta;
@@ -1033,13 +1006,6 @@ int from_cube(struct __sk_buff *skb)
 		}
 	}
 
-	/* Enforce egress network policy before NAT. */
-	if (!check_net_policy(ifindex, daddr, &policy_value)) {
-		if (proto == IPPROTO_TCP)
-			return tcp_reply_reset(skb, ifindex);
-		return TC_ACT_SHOT;
-	}
-
 	ret = pull_headers(skb, &l2, &l3);
 	if (ret != TC_ACT_OK)
 		return ret;
@@ -1047,13 +1013,24 @@ int from_cube(struct __sk_buff *skb)
 	if (!should_do_nat(l3))
 		return TC_ACT_SHOT;
 
-	if (l3->daddr == nodenic_ip)
+	if (l3->daddr == nodenic_ip) {
+		/* This branch bypasses do_*_nat() and therefore the policy
+		 * check inside create_nat_session(). Enforce policy inline.
+		 * TCP callers get an RST to match the guest-visible behavior
+		 * of the do_tcp_nat() path; UDP/ICMP silently drop.
+		 */
+		if (!session_policy_allowed(ifindex, daddr)) {
+			if (proto == IPPROTO_TCP)
+				return tcp_reply_reset(skb, ifindex);
+			return TC_ACT_SHOT;
+		}
 		return bpf_redirect(cubegw0_ifindex, BPF_F_INGRESS);
+	}
 
 	if (proto == IPPROTO_TCP) {
 		if (!__pull_headers(skb, &l2, &l3, &l4))
 			return TC_ACT_SHOT;
-		if (should_redirect_to_l7_proxy(&policy_value, l4))
+		if (should_redirect_to_l7_proxy(ifindex, daddr, l4))
 			return bpf_redirect(cubegw0_ifindex, BPF_F_INGRESS);
 		tcp_ret = do_tcp_nat(skb, mvm_meta);
 		if (TCP_NAT_STATUS(tcp_ret) == TCP_NAT_OK)

--- a/CubeNet/src/session.h
+++ b/CubeNet/src/session.h
@@ -38,7 +38,48 @@ static __always_inline void session_mark_replied(enum ip_conntrack_dir dir,
 }
 
 /**
+ * session_policy_allowed - check egress network policy for a candidate flow
+ * @vm_ifindex: TAP ifindex of the originating MVM (policy key)
+ * @daddr:      destination IP address in network byte order
+ *
+ * Priority: allow_out_v2 > deny_out > default allow.
+ *
+ *   1. If allow_out_v2 has an inner map for this ifindex and daddr matches
+ *      a non-expired entry, the flow is explicitly allowed.
+ *   2. If deny_out has an inner map for this ifindex and daddr matches,
+ *      the flow is denied.
+ *   3. Otherwise the flow is allowed.
+ *
+ * Traffic to mvm_gateway_ip is internal (destined for cube-dev) and always
+ * allowed regardless of policy.
+ */
+static __always_inline bool session_policy_allowed(__u32 vm_ifindex, __u32 daddr)
+{
+	struct lpm_key key = { .prefixlen = 32, .ip = daddr };
+	struct net_policy_value_v2 *value;
+	void *inner_map;
+
+	if (daddr == mvm_gateway_ip)
+		return true;
+
+	inner_map = bpf_map_lookup_elem(&allow_out_v2, &vm_ifindex);
+	if (inner_map) {
+		value = bpf_map_lookup_elem(inner_map, &key);
+		if (value && (value->expires_at_ns == 0 ||
+			      value->expires_at_ns > bpf_ktime_get_ns()))
+			return true;
+	}
+
+	inner_map = bpf_map_lookup_elem(&deny_out, &vm_ifindex);
+	if (inner_map && bpf_map_lookup_elem(inner_map, &key))
+		return false;
+
+	return true;
+}
+
+/**
  * create_nat_session - create egress session with rollback on failure
+ * @skb:           packet skb, used to signal deny reason via skb->cb[]
  * @ekey:          egress session key
  * @now_ns:        current monotonic time
  * @vm_ifindex:    TAP ifindex of the originating MVM
@@ -46,9 +87,15 @@ static __always_inline void session_mark_replied(enum ip_conntrack_dir dir,
  * @snat_port:     selected SNAT port/identifier in network byte order
  * @initial_state: protocol-specific initial conntrack state
  *
+ * Enforces egress network policy before creating the session. On policy
+ * deny, stamps skb->cb with NAT_CB_DENIED_BY_POLICY so the caller can
+ * distinguish "deny" from "resource exhaustion" (e.g. TCP callers use it
+ * to trigger tcp_reply_reset).
+ *
  * Returns true on success, false otherwise (ingress session cleaned up).
  */
-static __always_inline bool create_nat_session(struct session_key *ekey,
+static __always_inline bool create_nat_session(struct __sk_buff *skb,
+					       struct session_key *ekey,
 					       __u64 now_ns, __u32 vm_ifindex,
 					       struct snat_ip *snat_ip, __u16 snat_port,
 					       __u8 initial_state)
@@ -56,6 +103,26 @@ static __always_inline bool create_nat_session(struct session_key *ekey,
 	struct nat_session sess = {};
 	struct session_key ikey = {};
 	long err;
+
+	ikey.src_ip = ekey->dst_ip;
+	ikey.dst_ip = snat_ip->ip;
+	ikey.src_port = ekey->dst_port;
+	ikey.dst_port = snat_port;
+	ikey.version = 0;
+	ikey.protocol = ekey->protocol;
+
+	/* Clear the status word so callers only see a fresh value written by
+	 * this invocation. skb->cb[] can carry state from earlier tc filters
+	 * in the chain, so we cannot assume it starts at zero.
+	 */
+	nat_cb_set(skb, NAT_CB_OK);
+
+	if (!session_policy_allowed(vm_ifindex, ekey->dst_ip)) {
+		nat_cb_set(skb, NAT_CB_DENIED_BY_POLICY);
+		/* release the ingress slot reserved in pick_snat_ip_port */
+		bpf_map_delete_elem(&ingress_sessions, &ikey);
+		return false;
+	}
 
 	sess.access_time = now_ns;
 	sess.node_ifindex = snat_ip->ifindex;
@@ -68,12 +135,6 @@ static __always_inline bool create_nat_session(struct session_key *ekey,
 	err = bpf_map_update_elem(&egress_sessions, ekey, &sess, BPF_NOEXIST);
 	if (err) {
 		/* on failure, clean up the ingress slot we reserved earlier */
-		ikey.src_ip = ekey->dst_ip;
-		ikey.dst_ip = snat_ip->ip;
-		ikey.src_port = ekey->dst_port;
-		ikey.dst_port = snat_port;
-		ikey.version = 0;
-		ikey.protocol = ekey->protocol;
 		bpf_map_delete_elem(&ingress_sessions, &ikey);
 		return false;
 	}

--- a/CubeNet/src/tcp.h
+++ b/CubeNet/src/tcp.h
@@ -295,11 +295,12 @@ static __always_inline void update_session(enum ip_conntrack_dir dir, struct nat
 		sess->state = new_state;
 }
 
-static __always_inline bool create_new_sessions(struct session_key *ekey,
+static __always_inline bool create_new_sessions(struct __sk_buff *skb,
+						struct session_key *ekey,
 						__u64 now_ns, __u32 vm_ifindex,
 						struct snat_ip *snat_ip, __u16 snat_port)
 {
-	return create_nat_session(ekey, now_ns, vm_ifindex, snat_ip, snat_port,
+	return create_nat_session(skb, ekey, now_ns, vm_ifindex, snat_ip, snat_port,
 				  TCP_CONNTRACK_SYN_SENT);
 }
 

--- a/CubeNet/src/udp.h
+++ b/CubeNet/src/udp.h
@@ -18,11 +18,12 @@ static __always_inline void update_udp_session(enum ip_conntrack_dir dir,
 	session_mark_replied(dir, sess, UDP_CT_UNREPLIED, UDP_CT_REPLIED);
 }
 
-static __always_inline bool create_udp_sessions(struct session_key *ekey,
+static __always_inline bool create_udp_sessions(struct __sk_buff *skb,
+						struct session_key *ekey,
 						__u64 now_ns, __u32 vm_ifindex,
 						struct snat_ip *snat_ip, __u16 snat_port)
 {
-	return create_nat_session(ekey, now_ns, vm_ifindex, snat_ip, snat_port,
+	return create_nat_session(skb, ekey, now_ns, vm_ifindex, snat_ip, snat_port,
 				  UDP_CT_UNREPLIED);
 }
 


### PR DESCRIPTION
This PR fixes connections broken by DNS TTL expiry.

# CubeEgress sessions

DNS response TTL is recorded in allow_out_v2 map, and the userspace DNS reaper periodically removes stale entries. CubeVS relies on these records to enforce egress network policies.

If a DNS record expires (removed by the reaper) while a connection is still open, subsequent packets will be rejected by the policy check, even though the TCP session already exists. This causes active connections to break when the DNS TTL elapses.

Fix this by checking whether a TCP socket already exists for the connection (bpf_skc_lookup_tcp) before enforcing the egress network policy. If a socket is found, the traffic is from an already-established session, so the policy check is skipped and the packet is redirected directly to CubeEgress.

# NAT sessions

Move the egress network policy gate off the sandbox egress fast path and into the shared create_nat_session() helper so TCP, UDP and ICMP all funnel through a single enforcement point at session creation time.

Previously, from_cube() called check_net_policy() on every packet before NAT. That call site is now removed; the check runs once per new NAT session and its result is cached in the session record's lifetime. Packets that hit an existing session are not re-evaluated so that an established connection survived even when DNS record expired.

To preserve the TCP "RST on policy deny" behavior, create_nat_session() receives the skb and communicates the deny reason back to callers via skb->cb[0]. do_tcp_nat() translates NAT_CB_DENIED_BY_POLICY into TCP_NAT_RESET, which the caller already dispatches to tcp_reply_reset(). UDP and ICMP drops stay silent, matching their previous behavior.

should_redirect_to_l7_proxy() no longer takes a plumbed policy_value. It performs its own allow_out_v2 lookup — cheap since the branch only fires for TCP dports 80/443.

