### PR TITLE
feat(cubelet): support cgroup v2 in guest VM via kernel cmdline annotation

### DIFF
--- a/CubeMaster/cmd/cubemastercli/commands/cubebox/template.go
+++ b/CubeMaster/cmd/cubemastercli/commands/cubebox/template.go
@@ -776,6 +776,7 @@ var TemplateCreateFromImageCommand = cli.Command{
 		cli.BoolFlag{Name: "detach, no-wait", Usage: "submit and exit immediately instead of watching the job to completion"},
 		cli.DurationFlag{Name: "interval", Value: defaultWatchInterval, Usage: "poll interval while watching the job"},
 		cli.BoolFlag{Name: "json", Usage: "print raw json response"},
+		cli.StringSliceFlag{Name: "annotation", Usage: "set template annotation, KEY=VALUE format; repeat for multiple annotations"},
 	},
 	Action: func(c *cli.Context) error {
 		if c.String("image") == "" {
@@ -819,6 +820,26 @@ var TemplateCreateFromImageCommand = cli.Command{
 		req.CubeNetworkConfig, err = mergeCreateFromImageCubeNetworkConfigFlags(c, req.CubeNetworkConfig)
 		if err != nil {
 			return err
+		}
+
+		// Parse custom annotations provided via --annotation flags.
+		if rawAnnotations := c.StringSlice("annotation"); len(rawAnnotations) > 0 {
+			req.Annotations = make(map[string]string, len(rawAnnotations))
+			for _, kv := range rawAnnotations {
+				idx := strings.IndexByte(kv, '=')
+				if idx < 0 {
+					return fmt.Errorf("invalid annotation %q: expected KEY=VALUE format", kv)
+				}
+				key := strings.TrimSpace(kv[:idx])
+				val := strings.TrimSpace(kv[idx+1:])
+				if key == "" {
+					return fmt.Errorf("invalid annotation %q: key must not be empty after trimming", kv)
+				}
+				if val == "" {
+					return fmt.Errorf("invalid annotation %q: value must not be empty after trimming", kv)
+				}
+				req.Annotations[key] = val
+			}
 		}
 		body, err := jsoniter.Marshal(req)
 		if err != nil {

--- a/CubeMaster/pkg/service/sandbox/types/types.go
+++ b/CubeMaster/pkg/service/sandbox/types/types.go
@@ -553,6 +553,10 @@ type CreateTemplateFromImageReq struct {
 	//   false → skip the bake entirely
 	// See design/cube-egress-ca-bake.md.
 	WithCubeCA *bool `json:"with_cube_ca,omitempty"`
+
+	// Annotations carries custom annotations merged into the template's
+	// CreateRequest. Template-owned keys take precedence.
+	Annotations map[string]string `json:"annotations,omitempty"`
 }
 
 type RedoTemplateFromImageReq struct {

--- a/CubeMaster/pkg/templatecenter/template_request.go
+++ b/CubeMaster/pkg/templatecenter/template_request.go
@@ -37,6 +37,13 @@ func generateTemplateCreateRequest(req *types.CreateTemplateFromImageReq, artifa
 	if len(req.ExposedPorts) > 0 {
 		annotations[constants.AnnotationsExposedPort] = formatExposedPortsAnnotation(req.ExposedPorts)
 	}
+	if len(req.Annotations) > 0 {
+		for k, v := range req.Annotations {
+			if _, ok := annotations[k]; !ok {
+				annotations[k] = v
+			}
+		}
+	}
 	rootVolume := &types.Volume{
 		Name: rootfsWritableVolumeName,
 		VolumeSource: &types.VolumeSource{

--- a/CubeShim/shim/src/sandbox/config.rs
+++ b/CubeShim/shim/src/sandbox/config.rs
@@ -24,6 +24,13 @@ pub const ANNO_SNAPSHOT_NOTIFY: &str = "cube.snapshot.healthcheck";
 pub const ANNO_VM_KERNEL: &str = "cube.vm.kernel.path";
 /// Annotation key used to append extra kernel cmdline parameters.
 pub const ANNO_VM_KERNEL_CMDLINE_APPEND: &str = "cube.vm.kernel.cmdline.append";
+/// Annotation key that enables cgroup v2 (unified hierarchy) in the guest VM.
+/// When set to "true", CGROUP_V2_KERNEL_PARAM is appended to kernel cmdline.
+pub const ANNO_VM_CGROUP_V2_ENABLE: &str = "cube.vm.cgroup_v2.enable";
+
+/// Kernel cmdline parameter appended when ANNO_VM_CGROUP_V2_ENABLE is "true",
+/// instructing the guest agent to mount the unified cgroup v2 hierarchy.
+pub const CGROUP_V2_KERNEL_PARAM: &str = "agent.unified_cgroup_hierarchy=true";
 pub const ANNO_SNAPSHOT_BASE: &str = "cube.vm.snapshot.base.path";
 pub const ANNO_SNAPSHOT_MEMORY_VOL_URL: &str = "cube.vm.snapshot.memory_vol_url";
 pub const ANNO_APP_SNAPSHOT_CREATE: &str = "cube.appsnapshot.create";
@@ -173,7 +180,8 @@ impl Config {
         if let Some(anno) = anno.get(ANNO_VIRTIOFS) {
             virtiofs = Utils::anno_to_obj::<Vec<VirtioFs>>(anno)?;
         }
-        let extra_kernel_params = if let Some(params) = anno.get(ANNO_VM_KERNEL_CMDLINE_APPEND) {
+        let mut extra_kernel_params = if let Some(params) = anno.get(ANNO_VM_KERNEL_CMDLINE_APPEND)
+        {
             let params_vec = Utils::anno_to_obj::<Vec<String>>(params)?;
             params_vec
                 .into_iter()
@@ -189,6 +197,15 @@ impl Config {
         } else {
             Vec::new()
         };
+
+        if anno.get(ANNO_VM_CGROUP_V2_ENABLE).map(|v| v.as_str()) == Some("true") {
+            if !extra_kernel_params
+                .iter()
+                .any(|p| p == CGROUP_V2_KERNEL_PARAM)
+            {
+                extra_kernel_params.push(CGROUP_V2_KERNEL_PARAM.to_string());
+            }
+        }
 
         let c = Config {
             net,
@@ -253,9 +270,11 @@ mod tests {
     use crate::sandbox::config::Config;
     use crate::sandbox::config::ANNO_SNAPSHOT_BASE;
     use crate::sandbox::config::ANNO_SNAPSHOT_MEMORY_VOL_URL;
+    use crate::sandbox::config::ANNO_VM_CGROUP_V2_ENABLE;
     use crate::sandbox::config::ANNO_VM_KERNEL;
     use crate::sandbox::config::ANNO_VM_KERNEL_CMDLINE_APPEND;
     use crate::sandbox::config::ANNO_VM_RES;
+    use crate::sandbox::config::CGROUP_V2_KERNEL_PARAM;
     use crate::sandbox::config::KERNEL_SCF;
 
     #[test]
@@ -425,5 +444,44 @@ mod tests {
         assert!(ret.is_ok());
         let config = ret.unwrap();
         assert_eq!(config.extra_kernel_params, vec!["single=param".to_string()]);
+
+        // Test 9: cgroup v2 annotation enabled - should append unified_cgroup_hierarchy
+        annotations.insert(ANNO_VM_CGROUP_V2_ENABLE.to_string(), "true".to_string());
+        let ret = Config::new(&Some(annotations.clone()));
+        assert!(ret.is_ok());
+        let config = ret.unwrap();
+        assert_eq!(
+            config.extra_kernel_params,
+            vec![
+                "single=param".to_string(),
+                CGROUP_V2_KERNEL_PARAM.to_string()
+            ]
+        );
+
+        // Test 10: cgroup v2 annotation with false value - should not append
+        annotations.insert(ANNO_VM_CGROUP_V2_ENABLE.to_string(), "false".to_string());
+        let ret = Config::new(&Some(annotations.clone()));
+        assert!(ret.is_ok());
+        let config = ret.unwrap();
+        assert_eq!(config.extra_kernel_params, vec!["single=param".to_string()]);
+
+        // Test 11: cgroup v2 annotation with empty string - should not append
+        annotations.insert(ANNO_VM_CGROUP_V2_ENABLE.to_string(), "".to_string());
+        let ret = Config::new(&Some(annotations.clone()));
+        assert!(ret.is_ok());
+        let config = ret.unwrap();
+        assert_eq!(config.extra_kernel_params, vec!["single=param".to_string()]);
+
+        // Test 12: cgroup v2 enabled, no other cmdline params
+        let mut fresh = HashMap::<String, String>::new();
+        fresh.insert(ANNO_VM_RES.to_string(), res.to_string());
+        fresh.insert(ANNO_VM_CGROUP_V2_ENABLE.to_string(), "true".to_string());
+        let ret = Config::new(&Some(fresh));
+        assert!(ret.is_ok());
+        let config = ret.unwrap();
+        assert_eq!(
+            config.extra_kernel_params,
+            vec![CGROUP_V2_KERNEL_PARAM.to_string()]
+        );
     }
 }

--- a/Cubelet/pkg/constants/const.go
+++ b/Cubelet/pkg/constants/const.go
@@ -254,6 +254,18 @@ const (
 	AnnotationVMKernelCmdlineAppend = "cube.vm.kernel.cmdline.append"
 	AnnotationVirtiofs              = "cube.virtiofs"
 
+	// AnnotationVMCgroupV2Enable is the VM-level OCI spec annotation that enables cgroup v2
+	// (unified hierarchy) in the guest VM. It is set by the CBRI plugin when the request carries
+	// MasterAnnotationVMCgroupV2Enable=true. The cube shim reads this annotation and appends
+	// agent.unified_cgroup_hierarchy=true to the kernel cmdline.
+	AnnotationVMCgroupV2Enable = "cube.vm.cgroup_v2.enable"
+
+	// MasterAnnotationVMCgroupV2Enable is the cube.master-prefixed request annotation that users
+	// set to enable cgroup v2 in the guest VM. User-provided annotations are forwarded verbatim
+	// to the CBRI plugin (no annotation filtering in CubeMaster); each consumer is responsible
+	// for validating the annotations it cares about.
+	MasterAnnotationVMCgroupV2Enable = "cube.master.vm.cgroup_v2.enable"
+
 	AnnotationPropagationMounts          = "cube.propagation.mounts"
 	AnnotationPropagationContainerMounts = "cube.propagation.container.mounts"
 	AnnotationPropagationExecMounts      = "cube.propagation.exec.mounts"

--- a/Cubelet/plugins/cbri/cubeboxcbri/cubebox.go
+++ b/Cubelet/plugins/cbri/cubeboxcbri/cubebox.go
@@ -164,6 +164,11 @@ func (e *cubeboxInstancePlugin) CreateSandbox(ctx context.Context, flowOpts *wor
 	annotations[constants.AnnotationsVMKernelPath] = kernelPath
 	annotations[constants.AnnotationsProduct] = e.config.instanceType
 
+	if reqAnnotations := realReq.GetAnnotations(); reqAnnotations != nil && reqAnnotations[constants.MasterAnnotationVMCgroupV2Enable] == "true" {
+		annotations[constants.AnnotationVMCgroupV2Enable] = "true"
+		logEntry.WithField("cgroup_v2", "enabled").Info("cgroup v2 annotation set on OCI spec")
+	}
+
 	if flowOpts.IsCreateSnapshot() {
 		annotations[constants.AnnotationAppSnapshotCreate] = "true"
 


### PR DESCRIPTION
## Summary

Support cgroup v2 (unified hierarchy) in guest VMs via a `cube.master`-prefixed annotation that flows through the full stack: CLI → CubeMaster → Cubelet CBRI plugin → CubeShim → VM kernel cmdline.

## How it works

```
User sets cube.master.vm.cgroup_v2.enable=true
  → passes CubeMaster annotation filter (cube.master prefix)
  → CBRI plugin reads it, sets cube.vm.cgroup_v2.enable=true on OCI spec
  → Cube shim reads OCI spec annotation, appends agent.unified_cgroup_hierarchy=true to VM kernel cmdline
  → guest agent reads cmdline, mounts cgroup v2
```

## Changes

### Cubelet — annotation constants and CBRI plugin

- `Cubelet/pkg/constants/const.go`: Add `AnnotationsVMCgroupV2Enable` (`cube.vm.cgroup_v2.enable`, VM-level OCI spec annotation consumed by shim) and `MasterAnnotationVMCgroupV2Enable` (`cube.master.vm.cgroup_v2.enable`, user-facing request annotation that passes CubeMaster's prefix filter).
- `Cubelet/plugins/cbri/cubeboxcbri/cubebox.go`: In `CreateSandbox`, read `cube.master.vm.cgroup_v2.enable` from request annotations; if `"true"`, set `cube.vm.cgroup_v2.enable=true` on the OCI spec annotations. Placed alongside existing `AnnotationsVMKernelPath` / `AnnotationsProduct` assignments before the three-way branch, covering snapshot create, snapshot restore, and cold start paths.

### CubeShim — kernel cmdline injection

- `CubeShim/shim/src/sandbox/config.rs`: Add `ANNO_VM_CGROUP_V2_ENABLE` constant. When the annotation is `"true"`, append `agent.unified_cgroup_hierarchy=true` to `extra_kernel_params`. Includes 4 unit tests (enabled, disabled with `"false"`, disabled with empty string, standalone).

### CubeMaster — template CLI annotation support

- `CubeMaster/pkg/service/sandbox/types/types.go`: Add `Annotations` field to `CreateTemplateFromImageReq`.
- `CubeMaster/pkg/templatecenter/template_request.go`: Merge user-provided annotations into the template's `CreateRequest` (template-owned keys take precedence).
- `CubeMaster/cmd/cubemastercli/commands/cubebox/template.go`: Add `--annotation` flag (`KEY=VALUE`, repeatable) to `template create-from-image`.

## Usage

### Create a template with cgroup v2 enabled

```bash
cubemastercli --address <addr> --port <port> template create-from-image \
    --image <oci-image-ref> \
    --writable-layer-size 2G \
    --annotation cube.master.vm.cgroup_v2.enable=true
```

### Create a sandbox from the template

Sandboxes created from the template automatically inherit the annotation:

```python
import cubesandbox
sandbox = cubesandbox.Sandbox.create(template="<template-id>")
```

## Verification

Check the VMM log or `/proc/cmdline` inside the guest — the kernel cmdline will include `agent.unified_cgroup_hierarchy=true`.