### PR TITLE
feat(sdk): add official Node.js / TypeScript SDK

### DIFF
--- a/sdk/node/.gitignore
+++ b/sdk/node/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+dist/
+*.log
+.DS_Store
+coverage/

--- a/sdk/node/README.md
+++ b/sdk/node/README.md
@@ -1,0 +1,488 @@
+<p align="center">
+  <strong>@cubesandbox/sdk</strong> — Node.js / TypeScript SDK for CubeSandbox
+</p>
+
+<p align="center">
+  <a href="https://github.com/TencentCloud/CubeSandbox"><img src="https://img.shields.io/badge/CubeSandbox-GitHub-blue" alt="CubeSandbox" /></a>
+  <a href="../../LICENSE"><img src="https://img.shields.io/badge/License-Apache_2.0-green" alt="Apache 2.0" /></a>
+  <img src="https://img.shields.io/badge/Node.js-18%2B-blue" alt="Node.js 18+" />
+  <img src="https://img.shields.io/badge/version-0.3.0-orange" alt="v0.3.0" />
+</p>
+
+---
+
+`@cubesandbox/sdk` is the official Node.js / TypeScript SDK for
+[CubeSandbox](https://github.com/TencentCloud/CubeSandbox). It provides a
+Promise-based interface to create sandboxes, execute code, run shell commands,
+manage files, and control the full sandbox lifecycle — including pause/resume
+with memory snapshot. It matches the Python SDK's surface with idiomatic
+JavaScript naming (camelCase, `async`/`await`).
+
+## Installation
+
+```bash
+npm install @cubesandbox/sdk
+```
+
+Requires Node.js 18 or newer (uses the built-in fetch/FormData/Blob and the
+`undici` HTTP dispatcher). Ships dual ESM + CommonJS builds with TypeScript
+type definitions.
+
+## Quick Start
+
+Set the required environment variables:
+
+```bash
+export CUBE_API_URL=http://<your-cubeapi-host>:3000
+export CUBE_TEMPLATE_ID=<your-template-id>
+
+# Required for remote access (bypasses DNS for *.cube.app)
+export CUBE_PROXY_NODE_IP=<your-cubeproxy-node-ip>
+```
+
+Run your first sandbox:
+
+```ts
+import { Sandbox } from "@cubesandbox/sdk";
+
+const sb = await Sandbox.create();
+try {
+  const result = await sb.runCode("1 + 1");
+  console.log(result.text); // "2"
+} finally {
+  await sb.kill();
+}
+```
+
+With TypeScript 5.2+ / Node 20+ you can use explicit resource management so the
+sandbox is destroyed automatically:
+
+```ts
+await using sb = await Sandbox.create();
+const result = await sb.runCode("1 + 1");
+console.log(result.text); // "2"
+```
+
+## Features
+
+### Execute code
+
+```ts
+import { Sandbox } from "@cubesandbox/sdk";
+
+const sb = await Sandbox.create();
+
+// Simple expression
+let result = await sb.runCode("x = 42\nx * 2");
+console.log(result.text); // "84"
+
+// Capture stdout
+result = await sb.runCode('print("hello")');
+console.log(result.logs.stdout); // ["hello\n"]
+
+// Stream output in real time
+await sb.runCode("for i in range(3): print(i)", {
+  onStdout: (msg) => console.log("out:", msg.text),
+});
+
+await sb.kill();
+```
+
+`runCode` and `commands.run` both accept a `timeoutMs` (with `timeout` as a
+millisecond alias for E2B parity; `timeoutMs` wins when both are given). Omit it
+for no timeout. **The two APIs interpret it differently:**
+
+- **`runCode`** — a pure **idle / read** timeout: the timer resets on every
+  chunk received, so a long-running task that keeps producing output is never
+  cut off; only a stream that goes silent for longer than `timeoutMs` aborts.
+- **`commands.run`** — the same client-side idle reset **plus** the value is
+  sent to envd as `Connect-Timeout-Ms`, which envd enforces as a **hard
+  wall-clock deadline** for the whole command. So a command is aborted once it
+  either goes silent for longer than `timeoutMs` **or** runs longer than
+  `timeoutMs` in total — whichever comes first (this matches the Python SDK).
+  Use a larger `timeoutMs` (or none) for genuinely long-running commands.
+
+```ts
+// runCode: aborts only if the sandbox produces no output for 30s straight.
+await sb.runCode("long_running_job()", { timeoutMs: 30_000 });
+
+// commands.run: aborts after 30s of silence OR 30s total wall-clock.
+await sb.commands.run("./build.sh", { timeoutMs: 30_000 });
+```
+
+### Run shell commands
+
+```ts
+const result = await sb.commands.run("echo hello cube");
+console.log(result.stdout); // "hello cube\n"
+console.log(result.exitCode); // 0
+```
+
+When `user` is omitted the SDK sends requests as `root` for compatibility with
+envd versions that reject process/file requests without an explicit user.
+
+### Persistent variables within a sandbox
+
+Variables assigned in one `runCode` call persist for the lifetime of the
+sandbox — no separate context object needed:
+
+```ts
+await sb.runCode("x = 100");
+const result = await sb.runCode("x + 1");
+console.log(result.text); // "101"
+```
+
+### Pause & resume
+
+```ts
+const sb = await Sandbox.create();
+
+// Pause — preserves memory snapshot, polls until state=paused
+await sb.pause(); // wait=true, timeoutMs=30000 by default
+await sb.pause({ wait: false }); // fire-and-forget
+await sb.pause({ timeoutMs: 60000, intervalMs: 500 }); // custom poll params
+
+// Resume by connecting — auto-resumes a paused sandbox
+const sb2 = await Sandbox.connect(sb.sandboxId);
+```
+
+### Network policy
+
+Two layers can be combined inside `network`:
+
+- **L3/L4** — `allowOut` / `denyOut` lists of CIDRs or hostnames.
+- **L7** — `rules` for host / path / SNI matching, audit, and credential
+  injection using the typed `Rule` / `Match` / `Action` / `Inject` shapes.
+
+```ts
+import { Sandbox, type Rule } from "@cubesandbox/sdk";
+
+const rules: Rule[] = [
+  {
+    name: "deepseek_api",
+    match: {
+      scheme: "https",
+      host: "api.deepseek.com",
+      method: ["POST"],
+      path: "/v1/chat",
+      sni: "api.deepseek.com",
+    },
+    action: {
+      allow: true,
+      audit: "metadata",
+      inject: [
+        { header: "Authorization", format: "Bearer ${SECRET}", secret: "sk_xxxxxxxx" },
+      ],
+    },
+  },
+];
+
+const sb = await Sandbox.create({
+  network: { allowOut: ["172.67.0.0/16"], rules },
+});
+await sb.runCode("import requests; requests.post('https://api.deepseek.com/v1/chat')");
+```
+
+Rules are evaluated **first-match-wins** in list order. Credential injection
+only runs on HTTPS requests where SNI and Host match (server-enforced).
+
+#### E2B per-host request transforms (compat shape)
+
+For drop-in compatibility with E2B's per-host request transforms,
+`network.rules` also accepts a host-keyed mapping. Each `transform.headers`
+entry is converted into a CubeEgress L7 rule that injects the same headers on
+outbound HTTPS requests to that host:
+
+```ts
+const sb = await Sandbox.create({
+  network: {
+    // The host must still be referenced via allowOut — registering a rule
+    // alone does not grant egress.
+    allowOut: ["api.example.com"],
+    denyOut: ["0.0.0.0/0"],
+    rules: {
+      "api.example.com": [{ transform: { headers: { "X-Header": "Content" } } }],
+    },
+  },
+});
+```
+
+Pass either a list of `Rule` (typed) **or** a host-keyed mapping (E2B-shaped)
+on a single `create` call — not both.
+
+### Filesystem
+
+```ts
+// Read & write
+await sb.files.write("/tmp/hello.txt", "Hello, world!");
+console.log(await sb.files.read("/tmp/hello.txt")); // "Hello, world!"
+
+// Batch write
+await sb.files.writeFiles([
+  { path: "/tmp/a.txt", data: "aaa" },
+  { path: "/tmp/b.txt", data: new Uint8Array([98, 98, 98]) }, // bytes also accepted
+]);
+
+// Directory operations
+await sb.files.makeDir("/tmp/mydir");
+const entries = await sb.files.list("/tmp");
+const info = await sb.files.stat("/tmp/hello.txt");
+console.log(await sb.files.exists("/tmp/hello.txt")); // true
+await sb.files.rename("/tmp/hello.txt", "/tmp/renamed.txt");
+await sb.files.remove("/tmp/renamed.txt");
+
+// Watch for changes
+const watcher = await sb.files.watchDir("/tmp");
+for await (const event of watcher) {
+  console.log(event.name, event.type); // e.g. "a.txt" "EVENT_TYPE_CREATE"
+  break;
+}
+watcher.close();
+```
+
+### PTY (interactive terminal)
+
+Start an interactive login shell over a pseudo-terminal, stream its raw output,
+and drive it with keystrokes / resizes — mirrors the Python SDK's `sandbox.pty`.
+
+```ts
+// Start a PTY (defaults to `/bin/bash -i -l`, TERM=xterm-256color)
+const handle = await sb.pty.create({ rows: 24, cols: 80 });
+console.log("pty pid:", handle.pid);
+
+// Feed it input (string or bytes)
+await handle.sendStdin("echo hello\n");
+await handle.resize({ rows: 40, cols: 120 });
+
+// Stream raw output as it arrives (each chunk is a Uint8Array)
+const decoder = new TextDecoder();
+for await (const chunk of handle) {
+  process.stdout.write(decoder.decode(chunk));
+  if (/* your exit condition */ false) break;
+}
+
+// …or drain to completion with a callback and get the exit code
+const exitCode = await handle.wait((chunk) => process.stdout.write(chunk));
+
+// Detach without killing (reattach later with sb.pty.connect(pid))
+handle.disconnect();
+const reattached = await sb.pty.connect(handle.pid);
+
+// Ad-hoc control by pid without holding a handle
+await sb.pty.sendStdin(handle.pid, "exit\n");
+await sb.pty.resize(handle.pid, { rows: 50, cols: 132 });
+await sb.pty.kill(handle.pid); // → boolean (false if it no longer exists)
+```
+
+### Snapshots, clone, rollback
+
+```ts
+const snap = await sb.createSnapshot(); // POST /sandboxes/:id/snapshots
+
+const { snapshots, nextToken } = await Sandbox.listSnapshots({
+  sandboxId: sb.sandboxId,
+  limit: 100,
+});
+
+await Sandbox.deleteSnapshot(snap.snapshotId); // DELETE /templates/:id
+
+await sb.rollback(snap.snapshotId); // POST /sandboxes/:id/rollback
+
+const clones = await sb.clone(3, { concurrency: 3 });
+```
+
+`clone` snapshots the sandbox, creates `n` sandboxes from it (capped by
+`concurrency`), then deletes the ephemeral snapshot. If any create fails, all
+successful siblings are killed and the first error is re-thrown.
+
+### List & health check
+
+```ts
+console.log(await Sandbox.health()); // { status: "ok", sandboxes: 4 }
+console.log(await Sandbox.list()); // list of running sandboxes
+console.log(await Sandbox.listV2()); // v2 API (supports filtering)
+```
+
+### Templates
+
+```ts
+import { Template } from "@cubesandbox/sdk";
+
+const templates = await Template.list();
+const build = await Template.build({ image: "python:3.11-slim" });
+const detail = await Template.get("tpl-xxxxxxxxxxxxxxxxxxxxxxxx");
+await Template.delete("tpl-xxx");
+```
+
+## Configuration
+
+| Environment Variable | Required | Default | Description |
+|---|:---:|---|---|
+| `CUBE_API_URL` | | `http://127.0.0.1:3000` | CubeAPI management plane address (defaults to localhost) |
+| `CUBE_API_KEY` | remote | — | Management-plane API key → `Authorization: Bearer` (falls back to `E2B_API_KEY`; omitted when unset) |
+| `CUBE_TEMPLATE_ID` | ✅ | — | Template ID for sandbox creation |
+| `CUBE_PROXY_NODE_IP` | remote | — | CubeProxy node IP, bypasses DNS for `*.cube.app` |
+| `CUBE_PROXY_PORT_HTTP` | | `80` | CubeProxy HTTP port |
+| `CUBE_PROXY_SCHEME` | | `http` | Data-plane scheme; normalized to `http` / `https` (unknown values → `https` when port is 443, else `http`) |
+| `CUBE_SANDBOX_DOMAIN` | | `cube.app` | Sandbox domain suffix |
+
+You can also pass a `Config` (or plain options object) directly:
+
+```ts
+import { Config, Sandbox } from "@cubesandbox/sdk";
+
+const config = new Config({
+  apiUrl: "http://10.0.0.1:3000",
+  templateId: "tpl-xxxxxxxxxxxxxxxxxxxxxxxx",
+  proxyNodeIp: "10.0.0.1",
+});
+const sb = await Sandbox.create({ config });
+console.log((await sb.runCode("2 ** 10")).text); // "1024"
+```
+
+Or, for convenience, pass the connection settings inline on `create` (handy
+when talking to different CubeAPIs from the same process):
+
+```ts
+const sb = await Sandbox.create({
+  apiUrl: process.env.CUBE_API_URL,
+  templateId: process.env.CUBE_TEMPLATE_ID, // alias for `template`
+  proxyNodeIp: process.env.CUBE_PROXY_NODE_IP,
+});
+```
+
+Precedence for these settings is: **inline field > `config` > `CUBE_*` env
+var**. Inline fields accepted by `create`: `apiUrl`, `proxyNodeIp`,
+`proxyPort`, `proxyScheme`, `sandboxDomain`, `requestTimeoutMs`, and
+`templateId` (alias for `template`).
+
+## API Reference
+
+### `Sandbox` — static methods
+
+| Method | Description |
+|---|---|
+| `Sandbox.create(options?)` | `POST /sandboxes` — create a new sandbox |
+| `Sandbox.connect(sandboxId, options?)` | `POST /sandboxes/:id/connect` — connect (auto-resumes if paused) |
+| `Sandbox.list(config?)` | `GET /sandboxes` — list running sandboxes (v1) |
+| `Sandbox.listV2(config?)` | `GET /v2/sandboxes` — list sandboxes (v2) |
+| `Sandbox.health(config?)` | `GET /health` — service health check |
+| `Sandbox.listSnapshots(options?)` | `GET /snapshots` — list snapshots (paginated) |
+| `Sandbox.deleteSnapshot(snapshotId, options?)` | `DELETE /templates/:id` — delete a snapshot |
+
+### `Sandbox` — instance methods
+
+| Method | Description |
+|---|---|
+| `sb.runCode(code, options?)` | `POST /execute` — execute code, returns `Execution` |
+| `sb.getInfo()` | `GET /sandboxes/:id` — get sandbox state and metadata |
+| `sb.pause(options?)` | `POST /sandboxes/:id/pause` — pause sandbox |
+| `sb.resume(timeout?)` | `POST /sandboxes/:id/resume` — resume (deprecated, use `connect`) |
+| `sb.kill()` | `DELETE /sandboxes/:id` — destroy sandbox |
+| `sb.createSnapshot(name?)` | `POST /sandboxes/:id/snapshots` — create a snapshot |
+| `sb.rollback(snapshotId)` | `POST /sandboxes/:id/rollback` — roll back to a snapshot |
+| `sb.clone(n?, options?)` | Snapshot + create ×n + cleanup |
+| `sb.getHost(port)` | Return virtual hostname `{port}-{id}.{domain}` |
+| `sb.commands` / `sb.files` / `sb.pty` | Shell / filesystem / PTY namespaces (see below) |
+
+### `sb.files` — Filesystem
+
+| Method | Description |
+|---|---|
+| `read(path, options?)` | Download file content via `GET /files` |
+| `write(path, data, options?)` | Upload via `POST /files` (octet-stream, multipart fallback) |
+| `writeFiles(files, options?)` | Batch write, stops on first error, returns count |
+| `list(path)` | List directory entries |
+| `stat(path)` | File/directory metadata |
+| `exists(path)` | `true` if path exists (stat + 404 check) |
+| `makeDir(path)` | Create directory |
+| `rename(old, new)` | Move/rename |
+| `remove(path)` | Delete file or directory |
+| `watchDir(path)` | Stream filesystem events → async-iterable `Watcher` |
+
+### `sb.commands` — Shell commands
+
+| Method | Description |
+|---|---|
+| `commands.run(cmd, options?)` | Run a shell command over envd's Connect process API; returns `{ stdout, stderr, exitCode }`. Options: `user`, `cwd`, `envs`, `timeoutMs`/`timeout` (see [timeout semantics](#execute-code)) |
+
+### `sb.pty` — Pseudo-terminals
+
+| Method | Description |
+|---|---|
+| `pty.create(size, options?)` | Start a PTY (`/bin/bash -i -l`) → `PtyHandle`. Options: `user`, `cwd`, `envs`, `timeoutMs` (envd deadline + client idle abort, default 60000) |
+| `pty.connect(pid, options?)` | Reattach to a running PTY → `PtyHandle` |
+| `pty.kill(pid, requestTimeoutMs?)` | `SIGKILL` a PTY → `boolean` (`false` if not found) |
+| `pty.sendStdin(pid, data, requestTimeoutMs?)` | Write input (string or bytes) to a PTY |
+| `pty.resize(pid, size, requestTimeoutMs?)` | Resize a running PTY |
+
+`PtyHandle` is an async-iterable of `Uint8Array` output chunks with: `pid`,
+`exitCode`, `error`, `wait(onData?)` → exit code, `disconnect()` (detach without
+killing), and per-handle `kill()` / `sendStdin(data)` / `resize(size)`.
+
+### `Template` — static methods
+
+| Method | Description |
+|---|---|
+| `Template.list(options?)` | `GET /templates` — list all templates |
+| `Template.get(templateId, options?)` | `GET /templates/:id` — template detail + build history |
+| `Template.build(options)` | `POST /templates` — build a new template from a container image |
+| `Template.rebuild(templateId, options?)` | `POST /templates/:id` — rebuild an existing template |
+| `Template.getBuildStatus(templateId, buildId, options?)` | `GET /templates/:id/builds/:buildId/status` — poll build status |
+| `Template.getBuildLogs(templateId, buildId, options?)` | `GET /templates/:id/builds/:buildId/logs` — fetch build logs |
+| `Template.delete(templateId, options?)` | `DELETE /templates/:id` — delete a template permanently |
+
+### `Execution` object
+
+| Property | Type | Description |
+|---|---|---|
+| `.text` | `string \| undefined` | Final expression value (main result) |
+| `.logs.stdout` | `string[]` | All stdout lines |
+| `.logs.stderr` | `string[]` | All stderr lines |
+| `.error` | `ExecutionError \| null` | Exception info if execution failed |
+| `.results` | `Result[]` | All result events |
+
+## DNS bypass (remote access)
+
+When running outside the CubeSandbox node, `*.cube.app` cannot be resolved by
+the OS DNS. Set `CUBE_PROXY_NODE_IP` to route all data-plane connections
+directly to that IP while preserving the virtual `Host` header for CubeProxy
+routing — the Node equivalent of `curl --resolve host:port:ip`, implemented
+with a custom `undici` dispatcher.
+
+```
+Without CUBE_PROXY_NODE_IP:
+  SDK → OS DNS (*.cube.app) → CubeProxy
+
+With CUBE_PROXY_NODE_IP:
+  SDK → TCP direct to CUBE_PROXY_NODE_IP:80
+        Host: 49999-{sandboxID}.cube.app (preserved for routing)
+```
+
+When `CUBE_PROXY_SCHEME=https`, the TLS SNI / certificate name is also pinned
+to the virtual `*.cube.app` host (not the proxy IP), so CubeProxy's TLS routing
+and certificate validation keep working through the IP override.
+
+## Development
+
+```bash
+npm install
+npm run build       # tsup → dist (ESM + CJS + .d.ts)
+npm run typecheck   # tsc --noEmit
+npm test            # vitest (unit tests, no live service required)
+```
+
+Live integration tests are gated behind `CUBE_RUN_INTEGRATION=1` and require a
+running CubeAPI:
+
+```bash
+export CUBE_RUN_INTEGRATION=1
+export CUBE_API_URL=http://<your-cubeapi-host>:3000
+export CUBE_TEMPLATE_ID=<your-template-id>
+export CUBE_PROXY_NODE_IP=<your-cubeproxy-node-ip>
+npm test
+```
+
+## License
+
+Apache-2.0 © 2026 Tencent Inc.

--- a/sdk/node/package-lock.json
+++ b/sdk/node/package-lock.json
@@ -1,0 +1,2451 @@
+{
+  "name": "@cubesandbox/sdk",
+  "version": "0.3.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@cubesandbox/sdk",
+      "version": "0.3.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "undici": "^6.19.8"
+      },
+      "devDependencies": {
+        "@types/node": "^20.14.0",
+        "tsup": "^8.2.4",
+        "typescript": "^5.5.4",
+        "vitest": "^2.0.5"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.2.tgz",
+      "integrity": "sha512-6o7ZLZK+BeenkZCFNDXqpbjw9bD6nuWonvS/lwQJp7NoVVxm6p3qE7qQ5jGuBjiFsgvqjD8mZAU5oWxTmbOeOg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.2.tgz",
+      "integrity": "sha512-BaH7BllCACHoH1LguOU56UItGfUWjujlO65kS9LAodViaN4bwIKd7oeW/ZHJ/4ljr/7MIiENnNy3HJ0zXv8Zkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.2.tgz",
+      "integrity": "sha512-v39RCCvj4He82I9sFmk+M1VZ0PLM9sfsLVikjfx2hYBNALhrrOR2D3JjQA6AhlaSOgcR+RzrKY7e1+bT6SUO/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.2.tgz",
+      "integrity": "sha512-yl0y2vq3S3lHeuXhEdss6TWfKW8vkujImO12tn4ZkG/4oghr09LvdYm2RElVjokTQiUvDUGXLGsYeLqUMCKpGA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.2.tgz",
+      "integrity": "sha512-tT4pvt4qXD+vEoezupCWi+a1F0vvDiksiHc+PxRlYTOH1I6/X4id9jPxTP+Fg+545euaFT1jJVs4CEdHZAU1vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.2.tgz",
+      "integrity": "sha512-6nU5F2wCW+qvCBhTn1pdIU3bzsIoF7EUwsCDRxilWGprQR6yd508YnH9+OKFCwpfS8pjZqDUmnCAr7exax0XCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.2.tgz",
+      "integrity": "sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.2.tgz",
+      "integrity": "sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.2.tgz",
+      "integrity": "sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.2.tgz",
+      "integrity": "sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.2.tgz",
+      "integrity": "sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.2.tgz",
+      "integrity": "sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.2.tgz",
+      "integrity": "sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.2.tgz",
+      "integrity": "sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.2.tgz",
+      "integrity": "sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.2.tgz",
+      "integrity": "sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.2.tgz",
+      "integrity": "sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.2.tgz",
+      "integrity": "sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.2.tgz",
+      "integrity": "sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.2.tgz",
+      "integrity": "sha512-8hOJnxgbyObnCm5AlRA3A931xX19xq80RjVTKgJOvEKWqJruP/Uf12IbAOaDjjEXYRewwHLfmF0YRIdK3OwKWA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.2.tgz",
+      "integrity": "sha512-mmF4AY1i0hG/bLWUctUq59gtmgaSIRa3cu/A3JFRp/sCNEme2bgDEiDS22P9FbnJB8NJNF4jPJiSP5RHQpUTDg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.2.tgz",
+      "integrity": "sha512-DZgkknc6jhHrk46V25vbAM0zZkyP0nSDkJB8/dRkLTxv470dOmWDqGoEJl/9A0dFfS7yE3REOwNDxpHwSLSt0Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-T6xr6ucWSFto+VGajA8YH26LdpHRuP4YLHEKAtCWvJDOlnmWcDZVCI2Jmjr+IFHDlt2zRaTAKE4tfjTaWLgJBg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.2.tgz",
+      "integrity": "sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.43",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
+      "integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
+      "integrity": "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.9.tgz",
+      "integrity": "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.12"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
+      "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.9.tgz",
+      "integrity": "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "2.1.9",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner/node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.9.tgz",
+      "integrity": "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot/node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitest/spy": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.9.tgz",
+      "integrity": "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^3.0.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz",
+      "integrity": "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "loupe": "^3.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
+      "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/any-promise": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+      "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/bundle-require": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/bundle-require/-/bundle-require-5.1.0.tgz",
+      "integrity": "sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "load-tsconfig": "^0.2.3"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "esbuild": ">=0.18"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/commander": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+      "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/confbox": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
+      "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/consola": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/consola/-/consola-3.4.2.tgz",
+      "integrity": "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.18.0 || >=16.10.0"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fix-dts-default-cjs-exports": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/fix-dts-default-cjs-exports/-/fix-dts-default-cjs-exports-1.0.1.tgz",
+      "integrity": "sha512-pVIECanWFC61Hzl2+oOCtoJ3F17kglZC/6N94eRWycFgBH35hHx0Li604ZIzhseh97mf2p0cv7vVrOZGoqhlEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "magic-string": "^0.30.17",
+        "mlly": "^1.7.4",
+        "rollup": "^4.34.8"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/joycon": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/joycon/-/joycon-3.1.1.tgz",
+      "integrity": "sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/lilconfig": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
+      "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antonk52"
+      }
+    },
+    "node_modules/lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/load-tsconfig": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/load-tsconfig/-/load-tsconfig-0.2.5.tgz",
+      "integrity": "sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/mlly": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.2.tgz",
+      "integrity": "sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.16.0",
+        "pathe": "^2.0.3",
+        "pkg-types": "^1.3.1",
+        "ufo": "^1.6.3"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mz": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
+      "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "thenify-all": "^1.0.0"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.15",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
+      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pirates": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
+      "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/pkg-types": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
+      "integrity": "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "confbox": "^0.1.8",
+        "mlly": "^1.7.4",
+        "pathe": "^2.0.1"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.16",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
+      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postcss-load-config": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-6.0.1.tgz",
+      "integrity": "sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "lilconfig": "^3.1.1"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "jiti": ">=1.21.0",
+        "postcss": ">=8.0.9",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        },
+        "postcss": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.18.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.2.tgz",
+      "integrity": "sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.62.2",
+        "@rollup/rollup-android-arm64": "4.62.2",
+        "@rollup/rollup-darwin-arm64": "4.62.2",
+        "@rollup/rollup-darwin-x64": "4.62.2",
+        "@rollup/rollup-freebsd-arm64": "4.62.2",
+        "@rollup/rollup-freebsd-x64": "4.62.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.62.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.62.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.62.2",
+        "@rollup/rollup-linux-arm64-musl": "4.62.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.62.2",
+        "@rollup/rollup-linux-loong64-musl": "4.62.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.62.2",
+        "@rollup/rollup-linux-ppc64-musl": "4.62.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.62.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.62.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-musl": "4.62.2",
+        "@rollup/rollup-openbsd-x64": "4.62.2",
+        "@rollup/rollup-openharmony-arm64": "4.62.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.62.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.62.2",
+        "@rollup/rollup-win32-x64-gnu": "4.62.2",
+        "@rollup/rollup-win32-x64-msvc": "4.62.2",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map": {
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
+      "integrity": "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/sucrase": {
+      "version": "3.35.1",
+      "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.1.tgz",
+      "integrity": "sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.2",
+        "commander": "^4.0.0",
+        "lines-and-columns": "^1.1.6",
+        "mz": "^2.7.0",
+        "pirates": "^4.0.1",
+        "tinyglobby": "^0.2.11",
+        "ts-interface-checker": "^0.1.9"
+      },
+      "bin": {
+        "sucrase": "bin/sucrase",
+        "sucrase-node": "bin/sucrase-node"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/thenify": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
+      "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0"
+      }
+    },
+    "node_modules/thenify-all": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
+      "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "thenify": ">= 3.1.0 < 4"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
+      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tree-kill": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "tree-kill": "cli.js"
+      }
+    },
+    "node_modules/ts-interface-checker": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
+      "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/tsup": {
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/tsup/-/tsup-8.5.1.tgz",
+      "integrity": "sha512-xtgkqwdhpKWr3tKPmCkvYmS9xnQK3m3XgxZHwSUjvfTjp7YfXe5tT3GgWi0F2N+ZSMsOeWeZFh7ZZFg5iPhing==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bundle-require": "^5.1.0",
+        "cac": "^6.7.14",
+        "chokidar": "^4.0.3",
+        "consola": "^3.4.0",
+        "debug": "^4.4.0",
+        "esbuild": "^0.27.0",
+        "fix-dts-default-cjs-exports": "^1.0.0",
+        "joycon": "^3.1.1",
+        "picocolors": "^1.1.1",
+        "postcss-load-config": "^6.0.1",
+        "resolve-from": "^5.0.0",
+        "rollup": "^4.34.8",
+        "source-map": "^0.7.6",
+        "sucrase": "^3.35.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.11",
+        "tree-kill": "^1.2.2"
+      },
+      "bin": {
+        "tsup": "dist/cli-default.js",
+        "tsup-node": "dist/cli-node.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@microsoft/api-extractor": "^7.36.0",
+        "@swc/core": "^1",
+        "postcss": "^8.4.12",
+        "typescript": ">=4.5.0"
+      },
+      "peerDependenciesMeta": {
+        "@microsoft/api-extractor": {
+          "optional": true
+        },
+        "@swc/core": {
+          "optional": true
+        },
+        "postcss": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/ufo": {
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.4.tgz",
+      "integrity": "sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/undici": {
+      "version": "6.27.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
+      "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.9.tgz",
+      "integrity": "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.7",
+        "es-module-lexer": "^1.5.4",
+        "pathe": "^1.1.2",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vite-node/node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vite/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.9.tgz",
+      "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "2.1.9",
+        "@vitest/mocker": "2.1.9",
+        "@vitest/pretty-format": "^2.1.9",
+        "@vitest/runner": "2.1.9",
+        "@vitest/snapshot": "2.1.9",
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "debug": "^4.3.7",
+        "expect-type": "^1.1.0",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2",
+        "std-env": "^3.8.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.1",
+        "tinypool": "^1.0.1",
+        "tinyrainbow": "^1.2.0",
+        "vite": "^5.0.0",
+        "vite-node": "2.1.9",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "2.1.9",
+        "@vitest/ui": "2.1.9",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    }
+  }
+}

--- a/sdk/node/package.json
+++ b/sdk/node/package.json
@@ -1,0 +1,59 @@
+{
+  "name": "@cubesandbox/sdk",
+  "version": "0.3.0",
+  "description": "Node.js / TypeScript SDK for CubeSandbox",
+  "license": "Apache-2.0",
+  "author": "Tencent Inc.",
+  "homepage": "https://github.com/TencentCloud/CubeSandbox",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/TencentCloud/CubeSandbox.git",
+    "directory": "sdk/node"
+  },
+  "keywords": [
+    "cubesandbox",
+    "sandbox",
+    "e2b",
+    "ai-agent",
+    "code-interpreter"
+  ],
+  "type": "module",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
+    }
+  },
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "engines": {
+    "node": ">=18"
+  },
+  "scripts": {
+    "build": "tsup",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "prepublishOnly": "npm run build"
+  },
+  "dependencies": {
+    "undici": "^6.19.8"
+  },
+  "devDependencies": {
+    "@types/node": "^20.14.0",
+    "tsup": "^8.2.4",
+    "typescript": "^5.5.4",
+    "vitest": "^2.0.5"
+  }
+}

--- a/sdk/node/src/commands.ts
+++ b/sdk/node/src/commands.ts
@@ -1,0 +1,349 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { fetch } from "undici";
+
+import type { Sandbox } from "./sandbox.js";
+import { createIdleTimeout } from "./stream.js";
+
+export const ENVD_PORT = 49983;
+export const CONNECT_PROTOCOL_VERSION = "1";
+export const CONNECT_CONTENT_TYPE = "application/connect+json";
+export const CONNECT_END_STREAM_FLAG = 0x02;
+export const CONNECT_COMPRESSED_FLAG = 0x01;
+export const MAX_CONNECT_ENVELOPE_SIZE = 64 * 1024 * 1024;
+export const DEFAULT_ENVD_USER = "root";
+
+/** Result of running a shell command inside the sandbox. */
+export interface CommandResult {
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+}
+
+/** Options for {@link Commands.run}. */
+export interface CommandOptions {
+  /**
+   * Timeout in milliseconds. Applied two ways, matching the Python SDK:
+   *  - a client-side idle (read) abort that resets on every chunk received, and
+   *  - sent to envd as ``Connect-Timeout-Ms``, which envd enforces as a hard
+   *    wall-clock deadline for the whole command.
+   *
+   * A command is therefore aborted once it either goes silent for longer than
+   * this OR runs longer than this in total — whichever comes first. So a
+   * long-running command is not kept alive just because it keeps producing
+   * output; use a larger timeout (or none) for genuinely long jobs.
+   * Default: no timeout.
+   */
+  timeoutMs?: number;
+  /**
+   * Alias for {@link CommandOptions.timeoutMs} (also milliseconds), matching
+   * the Issue #760 / E2B shape. {@link CommandOptions.timeoutMs} wins when both
+   * are set.
+   */
+  timeout?: number;
+  cwd?: string;
+  envs?: Record<string, string>;
+  /** Alias for ``envs``, matching the E2B SDK command API. */
+  env?: Record<string, string>;
+  /** Sandbox user for envd process auth. Defaults to ``"root"``. */
+  user?: string;
+}
+
+/** Encode a single Connect envelope: ``[flags:1][len:4 BE][payload]``. */
+export function encodeConnectEnvelope(data: Buffer, flags = 0): Buffer {
+  const header = Buffer.alloc(5);
+  header.writeUInt8(flags, 0);
+  header.writeUInt32BE(data.length, 1);
+  return Buffer.concat([header, data]);
+}
+
+/** ``Authorization: Basic base64(user:)`` header for envd. */
+export function basicAuthUser(user: string): string {
+  const token = Buffer.from(`${user}:`).toString("base64");
+  return `Basic ${token}`;
+}
+
+export function userHeaders(user: string | undefined): Record<string, string> {
+  return user ? { Authorization: basicAuthUser(user) } : {};
+}
+
+/**
+ * Consume a web ``ReadableStream`` of Connect-framed bytes, yielding each
+ * complete frame as ``{ flags, payload }``. Mirrors the Python/Go SDKs.
+ *
+ * Incoming chunks are held in a list and only copied out once a full frame is
+ * available, so each received byte is copied at most once. This avoids the
+ * quadratic ``Buffer.concat`` cost when a single large frame arrives split
+ * across many chunks.
+ */
+export async function* readConnectFrames(
+  body: ReadableStream<Uint8Array>,
+): AsyncGenerator<{ flags: number; payload: Buffer }> {
+  const reader = body.getReader();
+  const chunks: Buffer[] = [];
+  let buffered = 0;
+
+  // Peek the 5-byte header without consuming it. Requires ``buffered >= 5``.
+  const peekHeader = (): { flags: number; size: number } => {
+    const first = chunks[0];
+    if (first.length >= 5) {
+      return { flags: first.readUInt8(0), size: first.readUInt32BE(1) };
+    }
+    const head = Buffer.allocUnsafe(5);
+    let filled = 0;
+    for (const chunk of chunks) {
+      const copyLen = Math.min(chunk.length, 5 - filled);
+      chunk.copy(head, filled, 0, copyLen);
+      filled += copyLen;
+      if (filled === 5) {
+        break;
+      }
+    }
+    return { flags: head.readUInt8(0), size: head.readUInt32BE(1) };
+  };
+
+  // Remove and return the first ``n`` bytes. Requires ``buffered >= n``.
+  const take = (n: number): Buffer => {
+    const first = chunks[0];
+    if (first.length >= n) {
+      buffered -= n;
+      if (first.length === n) {
+        chunks.shift();
+        return first;
+      }
+      chunks[0] = first.subarray(n);
+      return first.subarray(0, n);
+    }
+    const out = Buffer.allocUnsafe(n);
+    let filled = 0;
+    while (filled < n) {
+      const chunk = chunks[0];
+      const need = n - filled;
+      if (chunk.length <= need) {
+        chunk.copy(out, filled);
+        filled += chunk.length;
+        chunks.shift();
+      } else {
+        chunk.copy(out, filled, 0, need);
+        chunks[0] = chunk.subarray(need);
+        filled = n;
+      }
+    }
+    buffered -= n;
+    return out;
+  };
+
+  try {
+    for (;;) {
+      while (buffered >= 5) {
+        const { flags, size } = peekHeader();
+        if (size > MAX_CONNECT_ENVELOPE_SIZE) {
+          throw new Error(`Connect stream message too large: ${size} bytes`);
+        }
+        if (buffered < 5 + size) {
+          break;
+        }
+        const frame = take(5 + size);
+        yield { flags, payload: frame.subarray(5, 5 + size) };
+      }
+      const { done, value } = await reader.read();
+      if (done) {
+        break;
+      }
+      if (value && value.length > 0) {
+        const chunk = Buffer.from(value);
+        chunks.push(chunk);
+        buffered += chunk.length;
+      }
+    }
+  } finally {
+    reader.releaseLock();
+  }
+  if (buffered > 0) {
+    throw new Error("Connect stream ended with a partial message");
+  }
+}
+
+export function raiseConnectEndStream(payload: Buffer): void {
+  if (payload.length === 0) {
+    return;
+  }
+  let data: Record<string, any>;
+  try {
+    data = JSON.parse(payload.toString("utf-8"));
+  } catch {
+    return;
+  }
+  const error = data?.error;
+  if (!error) {
+    return;
+  }
+  const message = String(error.message || "Connect stream error").trim();
+  if (error.code) {
+    throw new Error(`${error.code}: ${message}`);
+  }
+  throw new Error(message);
+}
+
+export function exitCodeFromStatus(status: unknown): number | null {
+  if (typeof status !== "string") {
+    return null;
+  }
+  const exitMatch = status.match(/(?:exit status|exited with code)\s+(-?\d+)/);
+  if (exitMatch) {
+    return parseInt(exitMatch[1], 10);
+  }
+  const signalMatch = status.match(/(?:signal|terminated by signal)\s+(\d+)/);
+  if (signalMatch) {
+    return 128 + parseInt(signalMatch[1], 10);
+  }
+  if (status === "exited") {
+    return 0;
+  }
+  return null;
+}
+
+export class Commands {
+  private readonly sandbox: Sandbox;
+
+  constructor(sandbox: Sandbox) {
+    this.sandbox = sandbox;
+  }
+
+  /**
+   * Run a shell command inside the sandbox through envd's process API.
+   * Starts ``/bin/bash -l -c <cmd>`` and returns the collected stdout/stderr
+   * plus the process exit code.
+   */
+  async run(cmd: string, options: CommandOptions = {}): Promise<CommandResult> {
+    const envs = options.envs ?? options.env ?? {};
+    const user = options.user || DEFAULT_ENVD_USER;
+    const idleMs = options.timeoutMs ?? options.timeout;
+
+    const process: Record<string, unknown> = {
+      cmd: "/bin/bash",
+      args: ["-l", "-c", cmd],
+      envs,
+    };
+    if (options.cwd) {
+      process.cwd = options.cwd;
+    }
+    const payload = { process, stdin: false };
+
+    const headers: Record<string, string> = {
+      "Content-Type": CONNECT_CONTENT_TYPE,
+      "Connect-Protocol-Version": CONNECT_PROTOCOL_VERSION,
+      "Connect-Content-Encoding": "identity",
+      ...this.sandbox.trafficTokenHeaders(),
+      ...userHeaders(user),
+    };
+    if (idleMs !== undefined) {
+      headers["Connect-Timeout-Ms"] = String(Math.trunc(idleMs));
+    }
+    const accessToken = this.sandbox.envdAccessToken;
+    if (accessToken) {
+      headers["X-Access-Token"] = accessToken;
+    }
+
+    const url = this.sandbox.dataUrl(ENVD_PORT, "/process.Process/Start");
+    const encoded = encodeConnectEnvelope(Buffer.from(JSON.stringify(payload), "utf-8"));
+
+    const idle = createIdleTimeout(idleMs);
+    let resp: Awaited<ReturnType<typeof fetch>>;
+    try {
+      resp = await fetch(url, {
+        method: "POST",
+        headers,
+        body: encoded,
+        dispatcher: this.sandbox.dataDispatcher,
+        signal: idle.signal,
+      });
+    } catch (err) {
+      idle.clear();
+      if (idle.firedRef.current) {
+        throw new Error(`command timed out after ${idleMs}ms of inactivity`);
+      }
+      throw err;
+    }
+
+    if (resp.status >= 400) {
+      idle.clear();
+      const detail = (await resp.text().catch(() => "")).trim();
+      const suffix = detail ? `: ${detail}` : "";
+      throw new Error(`command failed: HTTP ${resp.status}${suffix}`);
+    }
+    if (!resp.body) {
+      idle.clear();
+      throw new Error("process stream ended without EndEvent");
+    }
+
+    try {
+      return await this.collectProcessStream(
+        resp.body as ReadableStream<Uint8Array>,
+        idle.reset,
+      );
+    } catch (err) {
+      if (idle.firedRef.current) {
+        throw new Error(`command timed out after ${idleMs}ms of inactivity`);
+      }
+      throw err;
+    } finally {
+      idle.clear();
+    }
+  }
+
+  private async collectProcessStream(
+    body: ReadableStream<Uint8Array>,
+    onActivity?: () => void,
+  ): Promise<CommandResult> {
+    const stdout: string[] = [];
+    const stderr: string[] = [];
+    let exitCode: number | null = null;
+
+    for await (const { flags, payload } of readConnectFrames(body)) {
+      onActivity?.();
+      if (flags & CONNECT_COMPRESSED_FLAG) {
+        throw new Error("unsupported compressed Connect stream message");
+      }
+      if (flags & CONNECT_END_STREAM_FLAG) {
+        // End-of-stream trailer: throws if it carries an error, otherwise the
+        // stream is finished — stop reading rather than processing any further
+        // (a well-behaved envd sends nothing after EOS; a misbehaving one must
+        // not be able to inject post-EOS frames).
+        raiseConnectEndStream(payload);
+        break;
+      }
+
+      const event = JSON.parse(payload.toString("utf-8")).event ?? {};
+      const data = event.data ?? {};
+      if (data.stdout) {
+        stdout.push(Buffer.from(data.stdout, "base64").toString("utf-8"));
+      }
+      if (data.stderr) {
+        stderr.push(Buffer.from(data.stderr, "base64").toString("utf-8"));
+      }
+      const end = event.end;
+      if (end !== undefined && end !== null) {
+        if (end.exitCode !== undefined) {
+          exitCode = Number(end.exitCode);
+        } else if (end.exit_code !== undefined) {
+          exitCode = Number(end.exit_code);
+        } else if (exitCodeFromStatus(end.status) !== null) {
+          exitCode = exitCodeFromStatus(end.status);
+        } else if (end.error) {
+          throw new Error(`process failed: ${end.error}`);
+        } else if (end.exited) {
+          exitCode = 0;
+        } else {
+          throw new Error("process EndEvent missing exit code");
+        }
+      }
+    }
+
+    if (exitCode === null) {
+      throw new Error("process stream ended without EndEvent");
+    }
+    return { stdout: stdout.join(""), stderr: stderr.join(""), exitCode };
+  }
+}

--- a/sdk/node/src/config.ts
+++ b/sdk/node/src/config.ts
@@ -1,0 +1,109 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * SDK configuration. All fields can be sourced from environment variables.
+ *
+ * Mirrors the Python SDK's ``Config`` dataclass. Pass a partial object to
+ * override individual fields; anything omitted falls back to the matching
+ * ``CUBE_*`` environment variable (evaluated at construction time).
+ */
+export interface ConfigOptions {
+  /** CubeAPI management-plane address. Env: ``CUBE_API_URL``. */
+  apiUrl?: string;
+  /**
+   * API key for management-plane authentication, sent as
+   * ``Authorization: Bearer <key>`` on every control-plane request. Env:
+   * ``CUBE_API_KEY`` (falling back to ``E2B_API_KEY``). When unset no
+   * ``Authorization`` header is sent — matching an unauthenticated localhost
+   * deployment.
+   */
+  apiKey?: string | null;
+  /** Template ID for sandbox creation. Env: ``CUBE_TEMPLATE_ID``. */
+  templateId?: string | null;
+  /** CubeProxy node IP; bypasses DNS for ``*.cube.app``. Env: ``CUBE_PROXY_NODE_IP``. */
+  proxyNodeIp?: string | null;
+  /** CubeProxy HTTP port. Env: ``CUBE_PROXY_PORT_HTTP`` (default 80). */
+  proxyPort?: number;
+  /** Data-plane scheme (``http`` / ``https``). Env: ``CUBE_PROXY_SCHEME`` (default http). */
+  proxyScheme?: string;
+  /** Sandbox domain suffix. Env: ``CUBE_SANDBOX_DOMAIN`` (default cube.app). */
+  sandboxDomain?: string;
+  /** Default sandbox TTL in seconds (default 300). */
+  timeout?: number;
+  /** Per-request connect timeout in milliseconds (default 30000). */
+  requestTimeoutMs?: number;
+}
+
+/**
+ * Parse a port from an env var, falling back to ``fallback`` when the value is
+ * unset, non-numeric (``NaN``), or outside the valid TCP port range
+ * (1–65535). Mirrors the Go SDK's ``parseIntEnv`` graceful-fallback behavior
+ * (``parseInt`` returns ``NaN`` — not ``null`` — so ``??`` alone would let it
+ * slip through), with an added upper bound so an out-of-range value doesn't
+ * surface later as an opaque connection failure.
+ */
+function parsePort(value: string | undefined, fallback: number): number {
+  if (value === undefined) {
+    return fallback;
+  }
+  const parsed = parseInt(value, 10);
+  return Number.isInteger(parsed) && parsed > 0 && parsed <= 65535 ? parsed : fallback;
+}
+
+/**
+ * Restrict a data-plane scheme to ``http`` / ``https``. Mirrors the Go SDK's
+ * ``normalizeProxyScheme``: an unknown/empty value falls back to ``https`` when
+ * the proxy port is 443, otherwise ``http`` — so a typo can't slip an invalid
+ * scheme into the data-plane URL and surface as an opaque connection error.
+ */
+function normalizeProxyScheme(scheme: string | undefined, port: number): string {
+  const normalized = (scheme ?? "").trim().toLowerCase();
+  if (normalized === "http" || normalized === "https") {
+    return normalized;
+  }
+  return port === 443 ? "https" : "http";
+}
+
+/** Default sandbox TTL in seconds, shared by {@link Config} and ``resume``. */
+export const DEFAULT_SANDBOX_TIMEOUT_S = 300;
+
+export class Config {
+  apiUrl: string;
+  apiKey: string | null;
+  templateId: string | null;
+  proxyNodeIp: string | null;
+  proxyPort: number;
+  proxyScheme: string;
+  sandboxDomain: string;
+  timeout: number;
+  requestTimeoutMs: number;
+
+  constructor(options: ConfigOptions = {}) {
+    const env = process.env;
+    this.apiUrl = (options.apiUrl ?? env.CUBE_API_URL ?? "http://127.0.0.1:3000").replace(
+      /\/+$/,
+      "",
+    );
+    const rawKey = options.apiKey ?? env.CUBE_API_KEY ?? env.E2B_API_KEY ?? null;
+    this.apiKey = rawKey && rawKey.trim() ? rawKey.trim() : null;
+    this.templateId = options.templateId ?? env.CUBE_TEMPLATE_ID ?? null;
+    this.proxyNodeIp = options.proxyNodeIp ?? env.CUBE_PROXY_NODE_IP ?? null;
+    this.proxyPort = options.proxyPort ?? parsePort(env.CUBE_PROXY_PORT_HTTP, 80);
+    this.proxyScheme = normalizeProxyScheme(
+      options.proxyScheme ?? env.CUBE_PROXY_SCHEME,
+      this.proxyPort,
+    );
+    this.sandboxDomain = options.sandboxDomain ?? env.CUBE_SANDBOX_DOMAIN ?? "cube.app";
+    this.timeout = options.timeout ?? DEFAULT_SANDBOX_TIMEOUT_S;
+    this.requestTimeoutMs = options.requestTimeoutMs ?? 30000;
+  }
+}
+
+/** Coerce an optional ``Config | ConfigOptions`` into a concrete ``Config``. */
+export function resolveConfig(config?: Config | ConfigOptions): Config {
+  if (config instanceof Config) {
+    return config;
+  }
+  return new Config(config);
+}

--- a/sdk/node/src/exceptions.ts
+++ b/sdk/node/src/exceptions.ts
@@ -1,0 +1,43 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/** Base class for all CubeSandbox SDK errors. */
+export class CubeSandboxError extends Error {
+  readonly statusCode?: number;
+
+  constructor(message: string, statusCode?: number) {
+    super(message);
+    this.name = new.target.name;
+    this.statusCode = statusCode;
+    Object.setPrototypeOf(this, new.target.prototype);
+  }
+}
+
+/** Raised when a sandbox is not found (HTTP 404). */
+export class SandboxNotFoundError extends CubeSandboxError {}
+
+/** Raised when a template is not found (HTTP 404). */
+export class TemplateNotFoundError extends CubeSandboxError {}
+
+/** Raised on authentication/authorization failure (HTTP 401/403). */
+export class AuthenticationError extends CubeSandboxError {}
+
+/** Raised on an unexpected backend error (HTTP 4xx/5xx). */
+export class ApiError extends CubeSandboxError {}
+
+/** Raised when a filesystem path is not found. */
+export class FilesystemNotFoundError extends CubeSandboxError {}
+
+/**
+ * Raised when {@link Filesystem.writeFiles} fails partway through.
+ *
+ * ``written`` is the number of files successfully written before the failure.
+ */
+export class PartialWriteError extends CubeSandboxError {
+  readonly written: number;
+
+  constructor(message: string, written: number) {
+    super(message);
+    this.written = written;
+  }
+}

--- a/sdk/node/src/filesystem.ts
+++ b/sdk/node/src/filesystem.ts
@@ -1,0 +1,300 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { fetch } from "undici";
+
+import {
+  CONNECT_CONTENT_TYPE,
+  CONNECT_END_STREAM_FLAG,
+  CONNECT_PROTOCOL_VERSION,
+  DEFAULT_ENVD_USER,
+  ENVD_PORT,
+  encodeConnectEnvelope,
+  readConnectFrames,
+} from "./commands.js";
+import { FilesystemNotFoundError, PartialWriteError } from "./exceptions.js";
+import type { Sandbox } from "./sandbox.js";
+
+/** A file or directory entry returned by list/stat/makeDir/rename. */
+export type FileEntry = Record<string, any>;
+
+/** A single file to write via {@link Filesystem.writeFiles}. */
+export interface WriteEntry {
+  path: string;
+  data: string | Uint8Array;
+}
+
+/** A filesystem change event delivered by {@link Watcher}. */
+export interface WatchEvent {
+  name: string;
+  type: string;
+}
+
+function toBuffer(data: string | Uint8Array): Buffer {
+  return typeof data === "string" ? Buffer.from(data, "utf-8") : Buffer.from(data);
+}
+
+export class Filesystem {
+  private readonly sandbox: Sandbox;
+
+  constructor(sandbox: Sandbox) {
+    this.sandbox = sandbox;
+  }
+
+  private baseHeaders(): Record<string, string> {
+    const headers: Record<string, string> = { ...this.sandbox.trafficTokenHeaders() };
+    const token = this.sandbox.envdAccessToken;
+    if (token) {
+      headers["X-Access-Token"] = token;
+    }
+    return headers;
+  }
+
+  private async rpc(method: string, payload: Record<string, unknown>): Promise<Record<string, any>> {
+    const headers: Record<string, string> = {
+      ...this.baseHeaders(),
+      "Content-Type": "application/json",
+      "Connect-Protocol-Version": CONNECT_PROTOCOL_VERSION,
+    };
+    const resp = await fetch(this.sandbox.dataUrl(ENVD_PORT, `/filesystem.Filesystem/${method}`), {
+      method: "POST",
+      headers,
+      body: JSON.stringify(payload),
+      dispatcher: this.sandbox.dataDispatcher,
+    });
+
+    const text = await resp.text();
+    if (resp.status >= 400) {
+      let body: Record<string, any> = {};
+      try {
+        body = text ? JSON.parse(text) : {};
+      } catch {
+        body = {};
+      }
+      const code = body.code ?? "";
+      let message = body.message || body.detail || text || `HTTP ${resp.status}`;
+      if (code) {
+        message = `${code}: ${message}`;
+      }
+      if (resp.status === 404 || code === "not_found") {
+        throw new FilesystemNotFoundError(
+          `Filesystem ${method} failed: ${message}`,
+          resp.status,
+        );
+      }
+      throw new Error(`Filesystem ${method} failed: ${message}`);
+    }
+    if (!text) {
+      return {};
+    }
+    return JSON.parse(text);
+  }
+
+  /** Read a file's contents through envd's HTTP file API. */
+  async read(path: string, options: { user?: string } = {}): Promise<string> {
+    const user = options.user || DEFAULT_ENVD_USER;
+    const params = new URLSearchParams({ path, username: user });
+    const resp = await fetch(this.sandbox.dataUrl(ENVD_PORT, `/files?${params.toString()}`), {
+      method: "GET",
+      headers: this.baseHeaders(),
+      dispatcher: this.sandbox.dataDispatcher,
+    });
+    const text = await resp.text();
+    if (resp.status !== 200) {
+      let message = text || `HTTP ${resp.status}`;
+      try {
+        const body = JSON.parse(text);
+        message = body.message || body.detail || message;
+      } catch {
+        // raw text
+      }
+      throw new Error(`Failed to read ${path}: ${message}`);
+    }
+    return text;
+  }
+
+  /** Write a file through envd's HTTP file API (octet-stream, multipart fallback). */
+  async write(
+    path: string,
+    data: string | Uint8Array,
+    options: { user?: string } = {},
+  ): Promise<void> {
+    const user = options.user || DEFAULT_ENVD_USER;
+    const params = new URLSearchParams({ path, username: user });
+    const url = this.sandbox.dataUrl(ENVD_PORT, `/files?${params.toString()}`);
+    const body = toBuffer(data);
+
+    let resp = await fetch(url, {
+      method: "POST",
+      headers: { ...this.baseHeaders(), "Content-Type": "application/octet-stream" },
+      body,
+      dispatcher: this.sandbox.dataDispatcher,
+    });
+
+    if (resp.status >= 400) {
+      const form = new FormData();
+      form.append("file", new Blob([body]), path);
+      resp = await fetch(url, {
+        method: "POST",
+        headers: this.baseHeaders(),
+        body: form,
+        dispatcher: this.sandbox.dataDispatcher,
+      });
+    }
+
+    if (resp.status >= 400) {
+      const text = await resp.text().catch(() => "");
+      let message = text || `HTTP ${resp.status}`;
+      try {
+        const payload = JSON.parse(text);
+        message = payload.message || payload.detail || message;
+      } catch {
+        // raw text
+      }
+      throw new Error(`Failed to write ${path}: ${message}`);
+    }
+  }
+
+  /** Write multiple files. Returns the count; throws {@link PartialWriteError} on first failure. */
+  async writeFiles(files: WriteEntry[], options: { user?: string } = {}): Promise<number> {
+    for (let i = 0; i < files.length; i++) {
+      const { path, data } = files[i];
+      try {
+        await this.write(path, data, options);
+      } catch (err) {
+        throw new PartialWriteError(
+          `writeFiles failed at ${path} (${i + 1}/${files.length}): ${
+            err instanceof Error ? err.message : String(err)
+          }`,
+          i,
+        );
+      }
+    }
+    return files.length;
+  }
+
+  /** List entries in a directory. */
+  async list(path: string): Promise<FileEntry[]> {
+    const result = await this.rpc("ListDir", { path });
+    return result.entries ?? [];
+  }
+
+  /** Return metadata for a file or directory. */
+  async stat(path: string): Promise<FileEntry> {
+    const result = await this.rpc("Stat", { path });
+    return result.entry ?? {};
+  }
+
+  /** Return true if the path exists inside the sandbox. */
+  async exists(path: string): Promise<boolean> {
+    try {
+      await this.stat(path);
+      return true;
+    } catch (err) {
+      if (err instanceof FilesystemNotFoundError) {
+        return false;
+      }
+      throw err;
+    }
+  }
+
+  /** Delete a file or directory inside the sandbox. */
+  async remove(path: string): Promise<void> {
+    await this.rpc("Remove", { path });
+  }
+
+  /** Move or rename a file or directory. */
+  async rename(oldPath: string, newPath: string): Promise<FileEntry> {
+    const result = await this.rpc("Move", { source: oldPath, destination: newPath });
+    return result.entry ?? {};
+  }
+
+  /** Create a directory inside the sandbox. */
+  async makeDir(path: string): Promise<FileEntry> {
+    const result = await this.rpc("MakeDir", { path });
+    return result.entry ?? {};
+  }
+
+  /** Watch a directory for filesystem changes. */
+  async watchDir(path: string): Promise<Watcher> {
+    const controller = new AbortController();
+    const headers: Record<string, string> = {
+      ...this.baseHeaders(),
+      "Content-Type": CONNECT_CONTENT_TYPE,
+      "Connect-Protocol-Version": CONNECT_PROTOCOL_VERSION,
+    };
+    const envelope = encodeConnectEnvelope(Buffer.from(JSON.stringify({ path }), "utf-8"));
+    const resp = await fetch(
+      this.sandbox.dataUrl(ENVD_PORT, "/filesystem.Filesystem/WatchDir"),
+      {
+        method: "POST",
+        headers,
+        body: envelope,
+        dispatcher: this.sandbox.dataDispatcher,
+        signal: controller.signal,
+      },
+    );
+    if (resp.status >= 400) {
+      controller.abort();
+      throw new Error(`WatchDir failed: HTTP ${resp.status}`);
+    }
+    if (!resp.body) {
+      controller.abort();
+      throw new Error("WatchDir failed: empty response body");
+    }
+    return new Watcher(resp.body as ReadableStream<Uint8Array>, controller);
+  }
+}
+
+/**
+ * Iterates over filesystem change events from a streaming ``WatchDir``
+ * response. Use it as an async iterator and call {@link Watcher.close} when
+ * done:
+ * ```ts
+ * const watcher = await sb.files.watchDir("/tmp");
+ * for await (const ev of watcher) {
+ *   console.log(ev.name, ev.type);
+ * }
+ * ```
+ */
+export class Watcher {
+  private readonly body: ReadableStream<Uint8Array>;
+  private readonly controller: AbortController;
+  private closed = false;
+
+  constructor(body: ReadableStream<Uint8Array>, controller: AbortController) {
+    this.body = body;
+    this.controller = controller;
+  }
+
+  /** Terminate the watch stream and release resources. */
+  close(): void {
+    if (!this.closed) {
+      this.closed = true;
+      this.controller.abort();
+    }
+  }
+
+  async *[Symbol.asyncIterator](): AsyncIterator<WatchEvent> {
+    try {
+      for await (const { flags, payload } of readConnectFrames(this.body)) {
+        if (flags & CONNECT_END_STREAM_FLAG) {
+          const data = payload.length ? JSON.parse(payload.toString("utf-8")) : {};
+          if (data?.error) {
+            throw new Error(data.error.message || "watch stream error");
+          }
+          return;
+        }
+        const data = JSON.parse(payload.toString("utf-8"));
+        if (data.filesystem) {
+          yield { name: data.filesystem.name ?? "", type: data.filesystem.type ?? "" };
+        }
+      }
+    } catch (err) {
+      if (this.closed || (err as Error)?.name === "AbortError") {
+        return;
+      }
+      throw err;
+    }
+  }
+}

--- a/sdk/node/src/index.ts
+++ b/sdk/node/src/index.ts
@@ -1,0 +1,83 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+export const VERSION = "0.3.0";
+
+export {
+  Sandbox,
+  JUPYTER_PORT,
+  type CreateOptions,
+  type RunCodeOptions,
+  type PauseOptions,
+  type ListSnapshotsOptions,
+  type NetworkOptions,
+  type LifecycleOptions,
+} from "./sandbox.js";
+
+export { Config, resolveConfig, type ConfigOptions } from "./config.js";
+
+export {
+  Execution,
+  Result,
+  Logs,
+  ExecutionError,
+  OutputMessage,
+  SnapshotInfo,
+} from "./models.js";
+
+export {
+  CubeSandboxError,
+  SandboxNotFoundError,
+  TemplateNotFoundError,
+  AuthenticationError,
+  ApiError,
+  FilesystemNotFoundError,
+  PartialWriteError,
+} from "./exceptions.js";
+
+export {
+  Commands,
+  ENVD_PORT,
+  DEFAULT_ENVD_USER,
+  type CommandResult,
+  type CommandOptions,
+} from "./commands.js";
+
+export {
+  Filesystem,
+  Watcher,
+  type FileEntry,
+  type WriteEntry,
+  type WatchEvent,
+} from "./filesystem.js";
+
+export {
+  Pty,
+  PtyHandle,
+  type PtySize,
+  type PtyOutput,
+  type PtyCreateOptions,
+  type PtyConnectOptions,
+} from "./pty.js";
+
+export {
+  Template,
+  TemplateInfo,
+  TemplateBuild,
+  type TemplateBuildOptions,
+} from "./template.js";
+
+export {
+  type Rule,
+  type Match,
+  type Action,
+  type Inject,
+  type Scheme,
+  type Method,
+  type AuditLevel,
+  type NetworkRules,
+  type E2BPerHostRules,
+  type E2BTransformEntry,
+} from "./policy.js";
+
+export { type RunCodeCallbacks } from "./stream.js";

--- a/sdk/node/src/models.ts
+++ b/sdk/node/src/models.ts
@@ -1,0 +1,177 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/** Collected stdout / stderr lines from a code execution. */
+export class Logs {
+  stdout: string[] = [];
+  stderr: string[] = [];
+
+  toJSON(): { stdout: string[]; stderr: string[] } {
+    return { stdout: this.stdout, stderr: this.stderr };
+  }
+}
+
+/** Exception information captured when an execution fails. */
+export class ExecutionError {
+  name: string;
+  value: string;
+  traceback: string;
+
+  constructor(name: string, value: string, traceback: string | string[] = "") {
+    this.name = name;
+    this.value = value;
+    this.traceback = Array.isArray(traceback) ? traceback.join("\n") : traceback || "";
+  }
+
+  toJSON(): { name: string; value: string; traceback: string } {
+    return { name: this.name, value: this.value, traceback: this.traceback };
+  }
+}
+
+const RESULT_FORMAT_KEYS = [
+  "text",
+  "html",
+  "markdown",
+  "svg",
+  "png",
+  "jpeg",
+  "pdf",
+  "latex",
+  "json",
+  "javascript",
+  "data",
+  "chart",
+] as const;
+
+/**
+ * A single result event from an execution (e.g. the value of the final
+ * expression, or a rich display output such as an image or chart).
+ */
+export class Result {
+  text?: string;
+  html?: string;
+  markdown?: string;
+  svg?: string;
+  png?: string;
+  jpeg?: string;
+  pdf?: string;
+  latex?: string;
+  json?: Record<string, unknown>;
+  javascript?: string;
+  data?: Record<string, unknown>;
+  chart?: unknown;
+  isMainResult = false;
+  extra?: Record<string, unknown>;
+
+  constructor(raw: Record<string, any> = {}) {
+    this.text = raw.text;
+    this.html = raw.html;
+    this.markdown = raw.markdown;
+    this.svg = raw.svg;
+    this.png = raw.png;
+    this.jpeg = raw.jpeg;
+    this.pdf = raw.pdf;
+    this.latex = raw.latex;
+    this.json = raw.json ?? raw.json_data;
+    this.javascript = raw.javascript;
+    this.data = raw.data;
+    this.chart = raw.chart;
+    this.isMainResult = Boolean(raw.is_main_result ?? raw.isMainResult ?? false);
+    this.extra = raw.extra;
+  }
+
+  /** Backward-compatible alias for E2B's ``json`` field. */
+  get jsonData(): Record<string, unknown> | undefined {
+    return this.json;
+  }
+
+  /** Names of the formats present on this result. */
+  formats(): string[] {
+    const formats: string[] = [];
+    for (const key of RESULT_FORMAT_KEYS) {
+      if ((this as Record<string, unknown>)[key]) {
+        formats.push(key);
+      }
+    }
+    if (this.extra) {
+      formats.push(...Object.keys(this.extra));
+    }
+    return formats;
+  }
+}
+
+/** The full outcome of a {@link Sandbox.runCode} call. */
+export class Execution {
+  results: Result[] = [];
+  logs: Logs = new Logs();
+  error: ExecutionError | null = null;
+  executionCount: number | null = null;
+
+  /** Text of the main result (the last expression value), if any. */
+  get text(): string | undefined {
+    for (const r of this.results) {
+      if (r.isMainResult) {
+        return r.text;
+      }
+    }
+    return undefined;
+  }
+
+  toJSON(): Record<string, unknown> {
+    return {
+      results: this.results.map((r) => {
+        const item: Record<string, unknown> = {};
+        const record = r as unknown as Record<string, unknown>;
+        for (const key of r.formats()) {
+          item[key] = record[key] ?? r.extra?.[key];
+        }
+        item.text = r.text;
+        return item;
+      }),
+      logs: this.logs.toJSON(),
+      error: this.error ? this.error.toJSON() : null,
+    };
+  }
+}
+
+/** A single stdout / stderr line delivered to a streaming callback. */
+export class OutputMessage {
+  line: string;
+  timestamp: string | number;
+  error: boolean;
+
+  constructor(line = "", timestamp: string | number = "", error = false) {
+    this.line = line;
+    this.timestamp = timestamp;
+    this.error = error;
+  }
+
+  /** Backward-compatible alias for E2B's ``line`` field. */
+  get text(): string {
+    return this.line;
+  }
+
+  /** Backward-compatible alias for E2B's ``error`` field. */
+  get isStderr(): boolean {
+    return this.error;
+  }
+
+  toString(): string {
+    return this.line;
+  }
+}
+
+/** Metadata returned by snapshot-related APIs. */
+export class SnapshotInfo {
+  snapshotId: string;
+  names: string[];
+
+  constructor(snapshotId: string, names: string[] = []) {
+    this.snapshotId = snapshotId;
+    this.names = names;
+  }
+
+  static fromDict(data: Record<string, any>): SnapshotInfo {
+    return new SnapshotInfo(data.snapshotID ?? "", data.names ?? []);
+  }
+}

--- a/sdk/node/src/policy.ts
+++ b/sdk/node/src/policy.ts
@@ -1,0 +1,294 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * L7 egress policy types — host/path/SNI matching, audit, credential
+ * injection.
+ *
+ * These are pure data holders on the SDK side; matching and evaluation happen
+ * server-side. {@link serializeRule} emits the camelCase JSON shape that nests
+ * under ``network.rules`` in the ``POST /sandboxes`` payload.
+ */
+
+import { ApiError } from "./exceptions.js";
+
+export type Scheme = "http" | "https";
+
+export type Method =
+  | "GET"
+  | "HEAD"
+  | "POST"
+  | "PUT"
+  | "PATCH"
+  | "DELETE"
+  | "OPTIONS"
+  | "CONNECT"
+  | "TRACE";
+
+export type AuditLevel = "full" | "metadata" | "none";
+
+/**
+ * Rule match conditions. All fields optional; an empty match matches any
+ * request. Semantics: AND across fields, OR within ``method``. Comparisons on
+ * sni/host/scheme are case-insensitive (server-enforced).
+ */
+export interface Match {
+  sni?: string;
+  host?: string;
+  method?: Method[];
+  path?: string;
+  scheme?: Scheme;
+}
+
+/**
+ * Credential injection. Only honored when ``Action.allow`` is true and the
+ * request is HTTPS with matching SNI/Host (server enforces).
+ */
+export interface Inject {
+  header: string;
+  secret: string;
+  format?: string;
+}
+
+/**
+ * Rule action.
+ *
+ * - ``allow: true`` — pass the request through; optional credential injection.
+ * - ``allow: false`` — reject (HTTP 403); ``inject`` is ignored if set.
+ * - ``audit`` defaults to ``"metadata"`` server-side when omitted.
+ */
+export interface Action {
+  allow: boolean;
+  inject?: Inject[];
+  audit?: AuditLevel;
+}
+
+/** Egress rule. ``name`` is a human-readable label used for audit logging. */
+export interface Rule {
+  name: string;
+  match: Match;
+  action: Action;
+}
+
+/** E2B per-host request transform entry. */
+export interface E2BTransformEntry {
+  transform: { headers: Record<string, string> };
+}
+
+/** E2B per-host request transforms (host -> list of transform entries). */
+export type E2BPerHostRules = Record<string, E2BTransformEntry[]>;
+
+/** Accepted shapes for ``network.rules``. */
+export type NetworkRules = Rule[] | E2BPerHostRules;
+
+/** Render the final injected header value (preview helper). */
+export function renderInject(inject: Inject): string {
+  const fmt = inject.format ?? "${SECRET}";
+  return fmt.replace("${SECRET}", inject.secret);
+}
+
+function serializeMatch(match: Match): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  if (match.sni !== undefined) out.sni = match.sni;
+  if (match.host !== undefined) out.host = match.host;
+  if (match.method !== undefined) out.method = [...match.method];
+  if (match.path !== undefined) out.path = match.path;
+  if (match.scheme !== undefined) out.scheme = match.scheme;
+  return out;
+}
+
+function serializeInject(inject: Inject): Record<string, unknown> {
+  const out: Record<string, unknown> = { header: inject.header, secret: inject.secret };
+  if (inject.format !== undefined) out.format = inject.format;
+  return out;
+}
+
+function serializeAction(action: Action): Record<string, unknown> {
+  const out: Record<string, unknown> = { allow: action.allow };
+  if (action.audit !== undefined) out.audit = action.audit;
+  if (action.inject !== undefined) out.inject = action.inject.map(serializeInject);
+  return out;
+}
+
+/** Serialize a {@link Rule} to the wire JSON shape used by CubeEgress. */
+export function serializeRule(rule: Rule): Record<string, unknown> {
+  return {
+    name: rule.name,
+    match: serializeMatch(rule.match),
+    action: serializeAction(rule.action),
+  };
+}
+
+function isE2BPerHostRules(rules: NetworkRules): rules is E2BPerHostRules {
+  return !Array.isArray(rules) && typeof rules === "object" && rules !== null;
+}
+
+function convertE2BTransformToInject(transform: {
+  headers?: Record<string, string>;
+}): Inject[] {
+  if (typeof transform !== "object" || transform === null) {
+    throw new Error("network.rules transform must be an object");
+  }
+  const headers = transform.headers;
+  if (headers === undefined) {
+    throw new Error("network.rules transform requires a 'headers' field");
+  }
+  if (typeof headers !== "object" || headers === null) {
+    throw new Error("network.rules transform.headers must be an object");
+  }
+  const unknown = Object.keys(transform).filter((k) => k !== "headers");
+  if (unknown.length > 0) {
+    throw new Error(
+      `network.rules transform has unsupported keys: ${JSON.stringify(unknown)}; ` +
+        "only 'headers' is supported by the CubeEgress compatibility layer",
+    );
+  }
+  const injects: Inject[] = [];
+  for (const [name, value] of Object.entries(headers)) {
+    if (!name) {
+      throw new Error("network.rules transform.headers keys must be non-empty strings");
+    }
+    if (typeof value !== "string") {
+      throw new Error(`network.rules transform.headers[${name}] must be a string`);
+    }
+    injects.push({ header: name, secret: value });
+  }
+  return injects;
+}
+
+/**
+ * Convert E2B's per-host transform mapping into CubeEgress rules. Each
+ * ``host -> [entry, ...]`` pair fans out into one rule per entry, preserving
+ * list order. Generated rule names use the ``e2b-transform-<host>[-<index>]``
+ * convention so compat-layer output is identifiable in audit logs.
+ */
+export function convertE2BPerHostRules(rules: E2BPerHostRules): Rule[] {
+  const converted: Rule[] = [];
+  for (const [host, entries] of Object.entries(rules)) {
+    if (!host) {
+      throw new Error("network.rules host keys must be non-empty strings");
+    }
+    if (!Array.isArray(entries)) {
+      throw new Error(`network.rules[${host}] must be a list of transform entries`);
+    }
+    entries.forEach((entry, index) => {
+      if (typeof entry !== "object" || entry === null) {
+        throw new Error(`network.rules[${host}][${index}] must be an object`);
+      }
+      const transform = (entry as E2BTransformEntry).transform;
+      if (transform === undefined) {
+        throw new Error(
+          `network.rules[${host}][${index}] is missing the 'transform' field`,
+        );
+      }
+      const unknown = Object.keys(entry).filter((k) => k !== "transform");
+      if (unknown.length > 0) {
+        throw new Error(
+          `network.rules[${host}][${index}] has unsupported keys: ` +
+            `${JSON.stringify(unknown)}; only 'transform' is supported`,
+        );
+      }
+      const injects = convertE2BTransformToInject(transform);
+      const suffix = entries.length === 1 ? "" : `-${index}`;
+      converted.push({
+        name: `e2b-transform-${host}${suffix}`,
+        match: { host },
+        action: { allow: true, inject: injects },
+      });
+    });
+  }
+  return converted;
+}
+
+/**
+ * Normalize the ``network.rules`` argument to a list of {@link Rule} suitable
+ * for {@link serializeRule}. Accepts either a CubeEgress rule array or an E2B
+ * per-host transform mapping.
+ */
+export function normalizeRulesArg(rules?: NetworkRules): Rule[] {
+  if (!rules) {
+    return [];
+  }
+  if (isE2BPerHostRules(rules)) {
+    return convertE2BPerHostRules(rules);
+  }
+  return rules;
+}
+
+const DENY_ALL_IPV4_CIDR = "0.0.0.0/0";
+const ALLOW_OUT_DOMAIN_REQUIRES_DENY_ALL =
+  "When specifying allowed domains in allow_out, you must disable public " +
+  "outbound traffic or include '0.0.0.0/0' in deny_out to block all other traffic.";
+
+function isIpAddress(target: string): boolean {
+  // IPv4 dotted-decimal.
+  if (/^\d{1,3}(\.\d{1,3}){3}$/.test(target)) {
+    return target.split(".").every((p) => Number(p) <= 255);
+  }
+  // IPv6 (loose check — anything with a colon).
+  return target.includes(":");
+}
+
+function isDottedDecimalLike(target: string): boolean {
+  const parts = target.replace(/\.+$/, "").split(".");
+  return parts.length === 4 && parts.every((p) => p.length > 0 && /^\d+$/.test(p));
+}
+
+function isValidDnsDomainName(domain: string): boolean {
+  if (!domain || domain.length >= 255) {
+    return false;
+  }
+  return domain.split(".").every(
+    (label) =>
+      label.length > 0 &&
+      label.length <= 63 &&
+      !label.startsWith("-") &&
+      !label.endsWith("-") &&
+      /^[a-zA-Z0-9-]+$/.test(label),
+  );
+}
+
+function isDomainAllowOutTarget(target: unknown): boolean {
+  if (typeof target !== "string") {
+    return false;
+  }
+  const trimmed = target.trim();
+  if (!trimmed || trimmed.includes("/")) {
+    return false;
+  }
+  if (isIpAddress(trimmed)) {
+    return false;
+  }
+  if (isDottedDecimalLike(trimmed)) {
+    return false;
+  }
+  let domain = trimmed.replace(/\.+$/, "").toLowerCase();
+  if (domain.startsWith("*.")) {
+    domain = domain.slice(2);
+  } else if (domain.includes("*")) {
+    return false;
+  }
+  return isValidDnsDomainName(domain);
+}
+
+/**
+ * Enforce that allowing specific domains in ``allowOut`` is only permitted
+ * when all other egress is denied (public traffic off, or ``0.0.0.0/0`` in
+ * ``denyOut``). Throws {@link ApiError} otherwise. Mirrors the Python SDK.
+ */
+export function validateAllowOutDomainsRequireDenyAll(
+  allowOut?: string[],
+  denyOut?: string[],
+  defaultDenyAll = false,
+): void {
+  if (!(allowOut ?? []).some(isDomainAllowOutTarget)) {
+    return;
+  }
+  if (
+    defaultDenyAll ||
+    (denyOut ?? []).some((target) => String(target).trim() === DENY_ALL_IPV4_CIDR)
+  ) {
+    return;
+  }
+  throw new ApiError(ALLOW_OUT_DOMAIN_REQUIRES_DENY_ALL, 400);
+}

--- a/sdk/node/src/pty.ts
+++ b/sdk/node/src/pty.ts
@@ -1,0 +1,582 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Pseudo-terminal (PTY) interface for CubeSandbox.
+ *
+ * Ports the Python SDK's ``sandbox.pty`` API (``cubesandbox._pty``) to Node.
+ * It speaks envd's Connect-JSON RPC directly: streaming calls (``Start`` /
+ * ``Connect``) use the framed ``application/connect+json`` wire format shared
+ * with {@link Commands}, while selector calls (``SendSignal`` / ``SendInput`` /
+ * ``Update``) use plain unary ``application/json`` POSTs. protobuf ``bytes``
+ * fields are base64 strings on the JSON side.
+ */
+
+import { fetch } from "undici";
+
+import {
+  CONNECT_COMPRESSED_FLAG,
+  CONNECT_CONTENT_TYPE,
+  CONNECT_END_STREAM_FLAG,
+  CONNECT_PROTOCOL_VERSION,
+  DEFAULT_ENVD_USER,
+  ENVD_PORT,
+  encodeConnectEnvelope,
+  exitCodeFromStatus,
+  raiseConnectEndStream,
+  readConnectFrames,
+  userHeaders,
+} from "./commands.js";
+import { ApiError, CubeSandboxError } from "./exceptions.js";
+import type { Sandbox } from "./sandbox.js";
+
+/** Raw bytes streamed from the PTY master side. */
+export type PtyOutput = Uint8Array;
+
+/** Pseudo-terminal size. */
+export interface PtySize {
+  /** Number of rows. */
+  rows: number;
+  /** Number of columns. */
+  cols: number;
+}
+
+/** Options for {@link Pty.create}. */
+export interface PtyCreateOptions {
+  /** Sandbox user for envd process auth. Defaults to ``"root"``. */
+  user?: string;
+  /** Working directory for the shell. */
+  cwd?: string;
+  /**
+   * Extra environment variables. ``TERM``/``LANG``/``LC_ALL`` are seeded with
+   * sensible defaults unless overridden here.
+   */
+  envs?: Record<string, string>;
+  /**
+   * Timeout in milliseconds, applied two ways to match the Python SDK:
+   *  - sent to envd as ``Connect-Timeout-Ms`` (a hard wall-clock deadline), and
+   *  - a client-side idle abort that resets on every chunk received.
+   *
+   * Default: 60000. Pass ``0`` to disable both.
+   */
+  timeoutMs?: number;
+}
+
+/** Options for {@link Pty.connect}. */
+export interface PtyConnectOptions {
+  /** See {@link PtyCreateOptions.timeoutMs}. Default: 60000. */
+  timeoutMs?: number;
+}
+
+const SIGNAL_SIGKILL = "SIGNAL_SIGKILL";
+const DEFAULT_PTY_TIMEOUT_MS = 60000;
+
+/** Drives the client-side idle timeout and manual disconnect for a stream. */
+interface StreamControl {
+  /** Reset the idle timer (call on every received frame). */
+  reset(): void;
+  /** Cancel the idle timer without aborting the request. */
+  clearIdle(): void;
+  /** Abort the request; marks the stream as intentionally disconnected. */
+  disconnect(): void;
+  readonly signal: AbortSignal;
+  readonly idleFired: boolean;
+  readonly disconnected: boolean;
+  readonly timeoutMs: number;
+}
+
+function createStreamControl(timeoutMs: number): StreamControl {
+  const controller = new AbortController();
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  let idleFired = false;
+  let disconnected = false;
+
+  const arm = (): void => {
+    if (timeoutMs <= 0) {
+      return;
+    }
+    timer = setTimeout(() => {
+      idleFired = true;
+      controller.abort();
+    }, timeoutMs);
+    // Don't let a pending idle timer keep the event loop alive on its own,
+    // matching ``createIdleTimeout`` in stream.ts.
+    (timer as { unref?: () => void }).unref?.();
+  };
+  const clearTimer = (): void => {
+    if (timer !== undefined) {
+      clearTimeout(timer);
+      timer = undefined;
+    }
+  };
+
+  arm();
+
+  return {
+    reset(): void {
+      clearTimer();
+      arm();
+    },
+    clearIdle(): void {
+      clearTimer();
+    },
+    disconnect(): void {
+      disconnected = true;
+      clearTimer();
+      if (!controller.signal.aborted) {
+        controller.abort();
+      }
+    },
+    signal: controller.signal,
+    get idleFired() {
+      return idleFired;
+    },
+    get disconnected() {
+      return disconnected;
+    },
+    timeoutMs,
+  };
+}
+
+/**
+ * Handle to a running PTY.
+ *
+ * The handle is an async iterable that yields {@link PtyOutput} chunks until
+ * the PTY process exits or {@link PtyHandle.disconnect} is called. Use
+ * {@link PtyHandle.wait} to drain the stream with an optional callback, or read
+ * chunks directly via ``for await`` when integrating with a UI / event loop.
+ */
+export class PtyHandle {
+  private readonly _pid: number;
+  private readonly _events: AsyncGenerator<Record<string, any>>;
+  private readonly _control: StreamControl;
+  private readonly _handleKill: () => Promise<boolean>;
+  private readonly _handleSendStdin: (
+    data: string | Uint8Array,
+    requestTimeoutMs?: number,
+  ) => Promise<void>;
+  private readonly _handleResize: (
+    size: PtySize,
+    requestTimeoutMs?: number,
+  ) => Promise<void>;
+
+  private _exitCode: number | null = null;
+  private _error: string | null = null;
+  private _exited = false;
+
+  constructor(params: {
+    pid: number;
+    events: AsyncGenerator<Record<string, any>>;
+    control: StreamControl;
+    handleKill: () => Promise<boolean>;
+    handleSendStdin: (data: string | Uint8Array, requestTimeoutMs?: number) => Promise<void>;
+    handleResize: (size: PtySize, requestTimeoutMs?: number) => Promise<void>;
+  }) {
+    this._pid = params.pid;
+    this._events = params.events;
+    this._control = params.control;
+    this._handleKill = params.handleKill;
+    this._handleSendStdin = params.handleSendStdin;
+    this._handleResize = params.handleResize;
+  }
+
+  /** PTY process ID. */
+  get pid(): number {
+    return this._pid;
+  }
+
+  /** Exit code once the PTY process has finished, otherwise ``null``. */
+  get exitCode(): number | null {
+    return this._exitCode;
+  }
+
+  /** Error message reported by envd for the PTY, if any. */
+  get error(): string | null {
+    return this._error;
+  }
+
+  async *[Symbol.asyncIterator](): AsyncGenerator<PtyOutput> {
+    try {
+      for await (const event of this._events) {
+        const data = event.data ?? {};
+        if (data.pty) {
+          yield Buffer.from(data.pty, "base64");
+        }
+        const end = event.end;
+        if (end !== undefined && end !== null) {
+          this._exitCode = extractExitCode(end);
+          this._error = end.error || null;
+          this._exited = true;
+        }
+      }
+    } catch (err) {
+      if (this._control.disconnected) {
+        return;
+      }
+      if (this._control.idleFired) {
+        throw new CubeSandboxError(
+          `PTY stream timed out after ${this._control.timeoutMs}ms of inactivity`,
+        );
+      }
+      throw err;
+    } finally {
+      this._control.clearIdle();
+      try {
+        await this._events.return(undefined);
+      } catch {
+        // best-effort cleanup
+      }
+    }
+  }
+
+  /**
+   * Block until the PTY exits and return its exit code.
+   *
+   * @param onData Callback invoked with each PTY output chunk.
+   * @throws {CubeSandboxError} If the stream ends without an end event or envd
+   *   reports an error.
+   */
+  async wait(onData?: (chunk: PtyOutput) => void): Promise<number> {
+    for await (const chunk of this) {
+      onData?.(chunk);
+    }
+    if (!this._exited) {
+      throw new CubeSandboxError("PTY stream ended without an end event");
+    }
+    if (this._error) {
+      throw new CubeSandboxError(`PTY exited with error: ${this._error}`);
+    }
+    return this._exitCode ?? 0;
+  }
+
+  /**
+   * Stop receiving events without killing the PTY. The process keeps running
+   * inside the sandbox; reattach later via {@link Pty.connect}.
+   */
+  disconnect(): void {
+    this._control.disconnect();
+    void this._events.return(undefined).catch(() => {});
+  }
+
+  /**
+   * Send ``SIGKILL`` to the PTY process.
+   *
+   * @returns ``true`` if killed, ``false`` if it could not be found.
+   */
+  kill(): Promise<boolean> {
+    return this._handleKill();
+  }
+
+  /** Send input (bytes or a UTF-8 string) to the PTY master side. */
+  sendStdin(data: string | Uint8Array, requestTimeoutMs?: number): Promise<void> {
+    return this._handleSendStdin(data, requestTimeoutMs);
+  }
+
+  /** Resize the PTY window. */
+  resize(size: PtySize, requestTimeoutMs?: number): Promise<void> {
+    return this._handleResize(size, requestTimeoutMs);
+  }
+}
+
+/**
+ * Module for interacting with PTYs (pseudo-terminals) in the sandbox.
+ *
+ * Mirrors the Python/E2B ``sandbox.pty`` namespace: {@link Pty.create} starts a
+ * new interactive shell, {@link Pty.connect} reattaches to an existing one, and
+ * {@link Pty.kill}/{@link Pty.sendStdin}/{@link Pty.resize} give ad-hoc control
+ * by PID without holding a {@link PtyHandle}.
+ */
+export class Pty {
+  private readonly sandbox: Sandbox;
+
+  constructor(sandbox: Sandbox) {
+    this.sandbox = sandbox;
+  }
+
+  private url(method: string): string {
+    return this.sandbox.dataUrl(ENVD_PORT, `/process.Process/${method}`);
+  }
+
+  private buildHeaders(options: {
+    streaming: boolean;
+    user?: string;
+    timeoutMs?: number;
+  }): Record<string, string> {
+    const headers: Record<string, string> = options.streaming
+      ? {
+          "Content-Type": CONNECT_CONTENT_TYPE,
+          "Connect-Protocol-Version": CONNECT_PROTOCOL_VERSION,
+          "Connect-Content-Encoding": "identity",
+        }
+      : {
+          "Content-Type": "application/json",
+          "Connect-Protocol-Version": CONNECT_PROTOCOL_VERSION,
+        };
+    if (options.timeoutMs !== undefined && options.timeoutMs > 0) {
+      headers["Connect-Timeout-Ms"] = String(Math.trunc(options.timeoutMs));
+    }
+    const accessToken = this.sandbox.envdAccessToken;
+    if (accessToken) {
+      headers["X-Access-Token"] = accessToken;
+    }
+    Object.assign(headers, this.sandbox.trafficTokenHeaders());
+    Object.assign(headers, userHeaders(options.user));
+    return headers;
+  }
+
+  // ── Selector RPCs (unary application/json) ────────────────────────────────
+
+  /**
+   * Send ``SIGKILL`` to a PTY process.
+   *
+   * @returns ``true`` if killed, ``false`` if not found (e.g. already exited).
+   */
+  async kill(pid: number, requestTimeoutMs?: number): Promise<boolean> {
+    const result = await this.unary(
+      "SendSignal",
+      { process: { pid }, signal: SIGNAL_SIGKILL },
+      { requestTimeoutMs, allowNotFound: true },
+    );
+    return result !== null;
+  }
+
+  /** Send input (bytes or a UTF-8 string) to a PTY identified by *pid*. */
+  async sendStdin(
+    pid: number,
+    data: string | Uint8Array,
+    requestTimeoutMs?: number,
+  ): Promise<void> {
+    const bytes = typeof data === "string" ? Buffer.from(data, "utf-8") : Buffer.from(data);
+    await this.unary(
+      "SendInput",
+      { process: { pid }, input: { pty: bytes.toString("base64") } },
+      { requestTimeoutMs },
+    );
+  }
+
+  /** Resize a running PTY. */
+  async resize(pid: number, size: PtySize, requestTimeoutMs?: number): Promise<void> {
+    await this.unary(
+      "Update",
+      { process: { pid }, pty: { size: { rows: size.rows, cols: size.cols } } },
+      { requestTimeoutMs },
+    );
+  }
+
+  private async unary(
+    method: string,
+    payload: Record<string, unknown>,
+    options: { requestTimeoutMs?: number; allowNotFound?: boolean } = {},
+  ): Promise<Record<string, any> | null> {
+    const timeoutMs = options.requestTimeoutMs ?? this.sandbox.config.requestTimeoutMs;
+    const headers = this.buildHeaders({ streaming: false, timeoutMs });
+
+    let resp: Awaited<ReturnType<typeof fetch>>;
+    try {
+      resp = await fetch(this.url(method), {
+        method: "POST",
+        headers,
+        body: JSON.stringify(payload),
+        dispatcher: this.sandbox.dataDispatcher,
+        signal: AbortSignal.timeout(timeoutMs),
+      });
+    } catch (err) {
+      throw new CubeSandboxError(`${method} failed: ${(err as Error).message}`);
+    }
+
+    if (resp.status >= 400) {
+      const body = await resp.text().catch(() => "");
+      if (options.allowNotFound && isNotFound(resp.status, body)) {
+        return null;
+      }
+      const detail = body.trim();
+      const suffix = detail ? `: ${detail}` : "";
+      throw new ApiError(`${method} failed: HTTP ${resp.status}${suffix}`, resp.status);
+    }
+
+    const raw = await resp.text();
+    if (!raw) {
+      return {};
+    }
+    try {
+      return JSON.parse(raw);
+    } catch (err) {
+      throw new CubeSandboxError(`${method}: invalid JSON response: ${(err as Error).message}`);
+    }
+  }
+
+  // ── Streaming RPCs (framed application/connect+json) ───────────────────────
+
+  /** Start a new PTY running an interactive login bash shell. */
+  create(size: PtySize, options: PtyCreateOptions = {}): Promise<PtyHandle> {
+    const envs: Record<string, string> = {
+      TERM: "xterm-256color",
+      LANG: "C.UTF-8",
+      LC_ALL: "C.UTF-8",
+      ...(options.envs ?? {}),
+    };
+    const process: Record<string, unknown> = {
+      cmd: "/bin/bash",
+      args: ["-i", "-l"],
+      envs,
+    };
+    if (options.cwd) {
+      process.cwd = options.cwd;
+    }
+    const payload = { process, pty: { size: { rows: size.rows, cols: size.cols } } };
+
+    return this.openStream("Start", payload, {
+      user: options.user || DEFAULT_ENVD_USER,
+      timeoutMs: options.timeoutMs ?? DEFAULT_PTY_TIMEOUT_MS,
+    });
+  }
+
+  /** Reattach to an already-running PTY. */
+  connect(pid: number, options: PtyConnectOptions = {}): Promise<PtyHandle> {
+    return this.openStream(
+      "Connect",
+      { process: { pid } },
+      { timeoutMs: options.timeoutMs ?? DEFAULT_PTY_TIMEOUT_MS },
+    );
+  }
+
+  private async openStream(
+    method: string,
+    payload: Record<string, unknown>,
+    options: { user?: string; timeoutMs: number },
+  ): Promise<PtyHandle> {
+    const control = createStreamControl(options.timeoutMs);
+    const headers = this.buildHeaders({
+      streaming: true,
+      user: options.user,
+      timeoutMs: options.timeoutMs,
+    });
+    const body = encodeConnectEnvelope(Buffer.from(JSON.stringify(payload), "utf-8"));
+
+    let resp: Awaited<ReturnType<typeof fetch>>;
+    try {
+      resp = await fetch(this.url(method), {
+        method: "POST",
+        headers,
+        body,
+        dispatcher: this.sandbox.dataDispatcher,
+        signal: control.signal,
+      });
+    } catch (err) {
+      control.clearIdle();
+      if (control.idleFired) {
+        throw new CubeSandboxError(`${method} timed out after ${options.timeoutMs}ms`);
+      }
+      throw new CubeSandboxError(`${method} failed: ${(err as Error).message}`);
+    }
+
+    if (resp.status >= 400) {
+      control.clearIdle();
+      const detail = (await resp.text().catch(() => "")).trim();
+      const suffix = detail ? `: ${detail}` : "";
+      throw new ApiError(`${method} failed: HTTP ${resp.status}${suffix}`, resp.status);
+    }
+    if (!resp.body) {
+      control.clearIdle();
+      throw new CubeSandboxError(`${method}: stream closed before start event`);
+    }
+
+    const events = iterConnectEvents(resp.body as ReadableStream<Uint8Array>, control);
+
+    let pid: number;
+    try {
+      const first = await events.next();
+      if (first.done) {
+        throw new CubeSandboxError(`${method}: stream closed before start event`);
+      }
+      const start = first.value?.start;
+      if (!start || start.pid === undefined || start.pid === null) {
+        throw new CubeSandboxError(
+          `${method}: expected start event, got ${JSON.stringify(first.value)}`,
+        );
+      }
+      pid = Number(start.pid);
+    } catch (err) {
+      control.disconnect();
+      try {
+        await events.return(undefined);
+      } catch {
+        // best-effort cleanup
+      }
+      if (control.idleFired) {
+        throw new CubeSandboxError(`${method} timed out after ${options.timeoutMs}ms`);
+      }
+      throw err;
+    }
+
+    return new PtyHandle({
+      pid,
+      events,
+      control,
+      handleKill: () => this.kill(pid),
+      handleSendStdin: (data, rt) => this.sendStdin(pid, data, rt),
+      handleResize: (size, rt) => this.resize(pid, size, rt),
+    });
+  }
+}
+
+/**
+ * Yield the ``event`` field of each ProcessEvent JSON message from a
+ * Connect-framed stream. Resets ``control``'s idle timer on every frame and
+ * stops (raising on error) at the end-of-stream trailer.
+ */
+async function* iterConnectEvents(
+  body: ReadableStream<Uint8Array>,
+  control: StreamControl,
+): AsyncGenerator<Record<string, any>> {
+  for await (const { flags, payload } of readConnectFrames(body)) {
+    control.reset();
+    if (flags & CONNECT_COMPRESSED_FLAG) {
+      throw new CubeSandboxError("unsupported compressed Connect stream message");
+    }
+    if (flags & CONNECT_END_STREAM_FLAG) {
+      raiseConnectEndStream(payload);
+      return;
+    }
+    const message = JSON.parse(payload.toString("utf-8"));
+    const event = message.event;
+    if (event !== undefined && event !== null) {
+      yield event as Record<string, any>;
+    }
+  }
+}
+
+/** Best-effort exit-code extraction from an end event. */
+function extractExitCode(end: Record<string, any>): number | null {
+  if (end.exitCode !== undefined && end.exitCode !== null) {
+    return Number(end.exitCode);
+  }
+  if (end.exit_code !== undefined && end.exit_code !== null) {
+    return Number(end.exit_code);
+  }
+  const parsed = exitCodeFromStatus(end.status);
+  if (parsed !== null) {
+    return parsed;
+  }
+  if (end.exited) {
+    return 0;
+  }
+  return null;
+}
+
+/** Detect Connect's ``not_found`` on a unary error response (HTTP 404 or body code). */
+function isNotFound(status: number, body: string): boolean {
+  if (status === 404) {
+    return true;
+  }
+  if (!body) {
+    return false;
+  }
+  try {
+    const parsed = JSON.parse(body);
+    const code = parsed?.code;
+    return typeof code === "string" && code.toLowerCase() === "not_found";
+  } catch {
+    return false;
+  }
+}

--- a/sdk/node/src/sandbox.ts
+++ b/sdk/node/src/sandbox.ts
@@ -1,0 +1,677 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { fetch, type Dispatcher } from "undici";
+
+import { Commands } from "./commands.js";
+import { Config, DEFAULT_SANDBOX_TIMEOUT_S, resolveConfig, type ConfigOptions } from "./config.js";
+import {
+  ApiError,
+  AuthenticationError,
+  CubeSandboxError,
+  SandboxNotFoundError,
+  TemplateNotFoundError,
+} from "./exceptions.js";
+import { Filesystem } from "./filesystem.js";
+import { Execution, SnapshotInfo } from "./models.js";
+import {
+  normalizeRulesArg,
+  serializeRule,
+  validateAllowOutDomainsRequireDenyAll,
+  type NetworkRules,
+} from "./policy.js";
+import { Pty } from "./pty.js";
+import { createIdleTimeout, parseNdjsonStream, type RunCodeCallbacks } from "./stream.js";
+import { buildDataDispatcher, controlFetch, dataScheme } from "./transport.js";
+
+export const JUPYTER_PORT = 49999;
+
+/** Egress network policy passed to {@link Sandbox.create}. */
+export interface NetworkOptions {
+  allowOut?: string[];
+  denyOut?: string[];
+  allowPublicTraffic?: boolean;
+  rules?: NetworkRules;
+}
+
+/** Sandbox auto-resume lifecycle, mirroring the e2b SDK's ``lifecycle``. */
+export interface LifecycleOptions {
+  onTimeout?: "kill" | "pause";
+  autoResume?: boolean;
+}
+
+/** Options for {@link Sandbox.create}. */
+export interface CreateOptions {
+  template?: string;
+  /** Alias for {@link CreateOptions.template}, matching the Issue #760 / E2B shape. */
+  templateId?: string;
+  timeout?: number;
+  envVars?: Record<string, string>;
+  metadata?: Record<string, string>;
+  allowInternetAccess?: boolean;
+  network?: NetworkOptions;
+  lifecycle?: LifecycleOptions;
+  config?: Config | ConfigOptions;
+  /** Extra fields forwarded verbatim into the create request body. */
+  extra?: Record<string, unknown>;
+
+  // ── Inline config overrides ───────────────────────────────────────────────
+  // Convenience fields so callers can pass connection settings directly on
+  // `create` (as shown in Issue #760) instead of nesting them under `config`.
+  // Precedence: these flat fields > `config` > `CUBE_*` env vars.
+  /** CubeAPI management-plane address. Overrides ``config``/``CUBE_API_URL``. */
+  apiUrl?: string;
+  /** CubeProxy node IP; bypasses DNS for ``*.cube.app``. Overrides ``config``/``CUBE_PROXY_NODE_IP``. */
+  proxyNodeIp?: string | null;
+  /** CubeProxy HTTP port. Overrides ``config``/``CUBE_PROXY_PORT_HTTP``. */
+  proxyPort?: number;
+  /** Data-plane scheme (``http`` / ``https``). Overrides ``config``/``CUBE_PROXY_SCHEME``. */
+  proxyScheme?: string;
+  /** Sandbox domain suffix. Overrides ``config``/``CUBE_SANDBOX_DOMAIN``. */
+  sandboxDomain?: string;
+  /** Per-request connect timeout in milliseconds. Overrides ``config``. */
+  requestTimeoutMs?: number;
+}
+
+/** Options for {@link Sandbox.runCode}. */
+export interface RunCodeOptions extends RunCodeCallbacks {
+  language?: string;
+  envs?: Record<string, string>;
+  /**
+   * Idle (read) timeout in milliseconds. The timer resets on every chunk
+   * received, so long-running executions that keep producing output are not
+   * aborted — only a stream that goes silent for longer than this is. Mirrors
+   * the Python SDK's read timeout. Default: no timeout.
+   */
+  timeoutMs?: number;
+  /**
+   * Alias for {@link RunCodeOptions.timeoutMs} (also milliseconds), matching
+   * the Issue #760 / E2B shape. {@link RunCodeOptions.timeoutMs} wins when both
+   * are set.
+   */
+  timeout?: number;
+}
+
+/** Options for {@link Sandbox.pause}. */
+export interface PauseOptions {
+  wait?: boolean;
+  timeoutMs?: number;
+  intervalMs?: number;
+}
+
+/** Options for {@link Sandbox.listSnapshots}. */
+export interface ListSnapshotsOptions {
+  sandboxId?: string;
+  limit?: number;
+  nextToken?: string;
+  config?: Config | ConfigOptions;
+}
+
+const VALID_ON_TIMEOUT = ["kill", "pause"] as const;
+
+function serializeLifecycle(lifecycle: LifecycleOptions): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  if (lifecycle.onTimeout !== undefined) {
+    if (!VALID_ON_TIMEOUT.includes(lifecycle.onTimeout)) {
+      throw new Error(
+        `lifecycle.onTimeout must be one of ${JSON.stringify(VALID_ON_TIMEOUT)}, ` +
+          `got ${JSON.stringify(lifecycle.onTimeout)}`,
+      );
+    }
+    out.onTimeout = lifecycle.onTimeout;
+  }
+  if (lifecycle.autoResume !== undefined) {
+    out.autoResume = Boolean(lifecycle.autoResume);
+  }
+  return out;
+}
+
+async function errorMessageFromResponse(resp: {
+  status: number;
+  text: () => Promise<string>;
+}): Promise<string> {
+  let text = "";
+  try {
+    text = await resp.text();
+  } catch {
+    text = "";
+  }
+  if (text) {
+    try {
+      const body = JSON.parse(text);
+      const msg = body?.message ?? body?.detail;
+      if (typeof msg === "string" && msg) {
+        return msg;
+      }
+    } catch {
+      // not JSON — fall through to raw (truncated) text
+    }
+    // Cap non-JSON bodies (HTML error pages, stack traces, internal IPs) so an
+    // opaque upstream response can't bloat or leak into the thrown message.
+    const trimmed = text.trim();
+    const capped = trimmed.length > 500 ? `${trimmed.slice(0, 500)}… (truncated)` : trimmed;
+    return capped ? `HTTP ${resp.status}: ${capped}` : `HTTP ${resp.status}`;
+  }
+  return `HTTP ${resp.status}`;
+}
+
+async function checkControlResponse(resp: {
+  ok: boolean;
+  status: number;
+  text: () => Promise<string>;
+}): Promise<void> {
+  if (resp.ok) {
+    return;
+  }
+  const msg = await errorMessageFromResponse(resp);
+  const code = resp.status;
+  if (code === 401 || code === 403) {
+    throw new AuthenticationError(msg, code);
+  }
+  if (code === 404) {
+    if (msg.toLowerCase().includes("template")) {
+      throw new TemplateNotFoundError(msg, code);
+    }
+    throw new SandboxNotFoundError(msg, code);
+  }
+  throw new ApiError(msg, code);
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Resolve the effective {@link Config} for {@link Sandbox.create}, merging the
+ * inline config overrides on {@link CreateOptions} over ``options.config`` over
+ * the ``CUBE_*`` environment defaults. Flat fields win when defined.
+ */
+function resolveCreateConfig(options: CreateOptions): Config {
+  const base: ConfigOptions =
+    options.config instanceof Config
+      ? {
+          apiUrl: options.config.apiUrl,
+          templateId: options.config.templateId,
+          proxyNodeIp: options.config.proxyNodeIp,
+          proxyPort: options.config.proxyPort,
+          proxyScheme: options.config.proxyScheme,
+          sandboxDomain: options.config.sandboxDomain,
+          timeout: options.config.timeout,
+          requestTimeoutMs: options.config.requestTimeoutMs,
+        }
+      : { ...(options.config ?? {}) };
+
+  if (options.apiUrl !== undefined) base.apiUrl = options.apiUrl;
+  if (options.proxyNodeIp !== undefined) base.proxyNodeIp = options.proxyNodeIp;
+  if (options.proxyPort !== undefined) base.proxyPort = options.proxyPort;
+  if (options.proxyScheme !== undefined) base.proxyScheme = options.proxyScheme;
+  if (options.sandboxDomain !== undefined) base.sandboxDomain = options.sandboxDomain;
+  if (options.requestTimeoutMs !== undefined) base.requestTimeoutMs = options.requestTimeoutMs;
+
+  return new Config(base);
+}
+
+/**
+ * A CubeSandbox code-execution environment.
+ *
+ * Example:
+ * ```ts
+ * const sb = await Sandbox.create();
+ * await sb.runCode("x = 1");
+ * const result = await sb.runCode("x + 1");
+ * console.log(result.text); // "2"
+ * await sb.kill();
+ * ```
+ */
+export class Sandbox {
+  /** Raw create/connect response payload (backend wire shape). */
+  private readonly _data: Record<string, any>;
+  readonly config: Config;
+
+  private _dataDispatcher: Dispatcher | undefined;
+  private _dataDispatcherBuilt = false;
+  private readonly _commands: Commands;
+  private readonly _files: Filesystem;
+  private readonly _pty: Pty;
+
+  constructor(data: Record<string, any>, config: Config) {
+    this._data = data;
+    this.config = config;
+    this._commands = new Commands(this);
+    this._files = new Filesystem(this);
+    this._pty = new Pty(this);
+  }
+
+  get sandboxId(): string {
+    return this._data.sandboxID;
+  }
+
+  get templateId(): string {
+    return this._data.templateID;
+  }
+
+  get domain(): string {
+    return this._data.domain || this.config.sandboxDomain;
+  }
+
+  /**
+   * Per-sandbox token returned when ``network.allowPublicTraffic=false``. Sent
+   * as both the ``e2b-traffic-access-token`` and ``cube-traffic-access-token``
+   * headers on every request to the sandbox's public URL (CubeProxy accepts
+   * either). ``null`` for publicly reachable sandboxes.
+   */
+  get trafficAccessToken(): string | null {
+    return this._data.trafficAccessToken || null;
+  }
+
+  get envdAccessToken(): string | undefined {
+    return this._data.envdAccessToken;
+  }
+
+  get commands(): Commands {
+    return this._commands;
+  }
+
+  get files(): Filesystem {
+    return this._files;
+  }
+
+  /** PTY (pseudo-terminal) namespace: ``create``/``connect``/``kill``/… */
+  get pty(): Pty {
+    return this._pty;
+  }
+
+  /** Return the virtual hostname for a sandbox port, e.g. ``49999-<id>.cube.app``. */
+  getHost(port: number): string {
+    return `${port}-${this.sandboxId}.${this.domain}`;
+  }
+
+  /** Data-plane URL for an envd/jupyter port and path. */
+  dataUrl(port: number, path: string): string {
+    return `${dataScheme(this.config)}://${this.getHost(port)}${path}`;
+  }
+
+  /** Lazily-built undici dispatcher for data-plane (CubeProxy) requests. */
+  get dataDispatcher(): Dispatcher | undefined {
+    if (!this._dataDispatcherBuilt) {
+      this._dataDispatcher = buildDataDispatcher(this.config);
+      this._dataDispatcherBuilt = true;
+    }
+    return this._dataDispatcher;
+  }
+
+  /** Headers required on every CubeProxy data-plane request. */
+  trafficTokenHeaders(): Record<string, string> {
+    const token = this.trafficAccessToken;
+    return token
+      ? { "e2b-traffic-access-token": token, "cube-traffic-access-token": token }
+      : {};
+  }
+
+  // ── Class methods ─────────────────────────────────────────────────────────
+
+  /** POST /sandboxes — create a new sandbox. */
+  static async create(options: CreateOptions = {}): Promise<Sandbox> {
+    const cfg = resolveCreateConfig(options);
+    const tpl = options.template || options.templateId || cfg.templateId;
+    if (!tpl) {
+      throw new Error(
+        "template is required. Set CUBE_TEMPLATE_ID or pass template/templateId",
+      );
+    }
+
+    const payload: Record<string, unknown> = {
+      templateID: tpl,
+      timeout: options.timeout ?? cfg.timeout,
+    };
+    if (options.envVars) {
+      payload.envVars = options.envVars;
+    }
+    if (options.metadata) {
+      payload.metadata = options.metadata;
+    }
+    if (options.allowInternetAccess === false) {
+      payload.allow_internet_access = false;
+    }
+    if (options.network) {
+      const net = options.network;
+      validateAllowOutDomainsRequireDenyAll(
+        net.allowOut,
+        net.denyOut,
+        options.allowInternetAccess === false,
+      );
+      const wire: Record<string, unknown> = {};
+      if (net.allowOut !== undefined) wire.allowOut = net.allowOut;
+      if (net.denyOut !== undefined) wire.denyOut = net.denyOut;
+      if (net.allowPublicTraffic !== undefined) {
+        wire.allowPublicTraffic = net.allowPublicTraffic;
+      }
+      if (net.rules) {
+        const normalized = normalizeRulesArg(net.rules);
+        if (normalized.length > 0) {
+          wire.rules = normalized.map(serializeRule);
+        }
+      }
+      if (Object.keys(wire).length > 0) {
+        payload.network = wire;
+      }
+    }
+    if (options.lifecycle) {
+      payload.lifecycle = serializeLifecycle(options.lifecycle);
+    }
+    if (options.extra) {
+      Object.assign(payload, options.extra);
+    }
+
+    const resp = await controlFetch(cfg, `${cfg.apiUrl}/sandboxes`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+    });
+    await checkControlResponse(resp);
+    return new Sandbox((await resp.json()) as Record<string, any>, cfg);
+  }
+
+  /** POST /sandboxes/:id/connect — connect (auto-resumes if paused). */
+  static async connect(
+    sandboxId: string,
+    options: { config?: Config | ConfigOptions } = {},
+  ): Promise<Sandbox> {
+    const cfg = resolveConfig(options.config);
+    const resp = await controlFetch(cfg, `${cfg.apiUrl}/sandboxes/${sandboxId}/connect`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ timeout: cfg.timeout }),
+    });
+    await checkControlResponse(resp);
+    return new Sandbox((await resp.json()) as Record<string, any>, cfg);
+  }
+
+  /** GET /sandboxes — list all running sandboxes (v1). */
+  static async list(config?: Config | ConfigOptions): Promise<Record<string, any>[]> {
+    const cfg = resolveConfig(config);
+    const resp = await controlFetch(cfg, `${cfg.apiUrl}/sandboxes`);
+    await checkControlResponse(resp);
+    return (await resp.json()) as Record<string, any>[];
+  }
+
+  /** GET /v2/sandboxes — list all running sandboxes (v2). */
+  static async listV2(config?: Config | ConfigOptions): Promise<Record<string, any>[]> {
+    const cfg = resolveConfig(config);
+    const resp = await controlFetch(cfg, `${cfg.apiUrl}/v2/sandboxes`);
+    await checkControlResponse(resp);
+    return (await resp.json()) as Record<string, any>[];
+  }
+
+  /** GET /health — check the health of the CubeAPI service. */
+  static async health(config?: Config | ConfigOptions): Promise<Record<string, any>> {
+    const cfg = resolveConfig(config);
+    const resp = await controlFetch(cfg, `${cfg.apiUrl}/health`);
+    await checkControlResponse(resp);
+    return (await resp.json()) as Record<string, any>;
+  }
+
+  /** GET /snapshots — list snapshots with pagination. */
+  static async listSnapshots(
+    options: ListSnapshotsOptions = {},
+  ): Promise<{ snapshots: SnapshotInfo[]; nextToken: string | null }> {
+    const cfg = resolveConfig(options.config);
+    const params = new URLSearchParams();
+    if (options.sandboxId !== undefined) params.set("sandboxID", options.sandboxId);
+    if (options.limit !== undefined) params.set("limit", String(options.limit));
+    if (options.nextToken !== undefined) params.set("nextToken", options.nextToken);
+    const query = params.toString();
+    const resp = await controlFetch(cfg, `${cfg.apiUrl}/snapshots${query ? `?${query}` : ""}`);
+    await checkControlResponse(resp);
+    const items = ((await resp.json()) as Record<string, any>[]) || [];
+    const snapshots = items.map((d) => SnapshotInfo.fromDict(d));
+    const nextToken = resp.headers.get("x-next-token") || null;
+    return { snapshots, nextToken };
+  }
+
+  /** DELETE /templates/:id — delete a snapshot (stored as a template). */
+  static async deleteSnapshot(
+    snapshotId: string,
+    options: { config?: Config | ConfigOptions } = {},
+  ): Promise<void> {
+    const cfg = resolveConfig(options.config);
+    const resp = await controlFetch(cfg, `${cfg.apiUrl}/templates/${snapshotId}`, {
+      method: "DELETE",
+    });
+    await checkControlResponse(resp);
+  }
+
+  // ── Instance methods ────────────────────────────────────────────────────────
+
+  /** POST /execute — execute code inside the sandbox (streams ndjson). */
+  async runCode(code: string, options: RunCodeOptions = {}): Promise<Execution> {
+    const url = this.dataUrl(JUPYTER_PORT, "/execute");
+    const payload = {
+      code,
+      language: options.language ?? null,
+      env_vars: options.envs ?? null,
+    };
+    const execution = new Execution();
+
+    const idleMs = options.timeoutMs ?? options.timeout;
+    const idle = createIdleTimeout(idleMs);
+    let resp: Awaited<ReturnType<typeof fetch>>;
+    try {
+      resp = await fetch(url, {
+        method: "POST",
+        headers: { "Content-Type": "application/json", ...this.trafficTokenHeaders() },
+        body: JSON.stringify(payload),
+        dispatcher: this.dataDispatcher,
+        signal: idle.signal,
+      });
+    } catch (err) {
+      idle.clear();
+      if (idle.firedRef.current) {
+        throw new ApiError(`runCode timed out after ${idleMs}ms of inactivity`);
+      }
+      throw err;
+    }
+    if (resp.status >= 400) {
+      idle.clear();
+      void resp.body?.cancel().catch(() => undefined);
+      throw new ApiError(`execute failed: HTTP ${resp.status}`, resp.status);
+    }
+    try {
+      if (resp.body) {
+        await parseNdjsonStream(
+          resp.body as ReadableStream<Uint8Array>,
+          execution,
+          options,
+          idle.reset,
+        );
+      }
+    } catch (err) {
+      if (idle.firedRef.current) {
+        throw new ApiError(`runCode timed out after ${idleMs}ms of inactivity`);
+      }
+      throw err;
+    } finally {
+      idle.clear();
+    }
+    return execution;
+  }
+
+  /** GET /sandboxes/:id — get sandbox detail. */
+  async getInfo(): Promise<Record<string, any>> {
+    const resp = await controlFetch(this.config, `${this.config.apiUrl}/sandboxes/${this.sandboxId}`);
+    await checkControlResponse(resp);
+    return (await resp.json()) as Record<string, any>;
+  }
+
+  /** POST /sandboxes/:id/pause — pause a sandbox (preserves memory snapshot). */
+  async pause(options: PauseOptions = {}): Promise<void> {
+    const wait = options.wait ?? true;
+    const timeoutMs = options.timeoutMs ?? 30000;
+    const intervalMs = options.intervalMs ?? 1000;
+
+    const resp = await controlFetch(this.config, `${this.config.apiUrl}/sandboxes/${this.sandboxId}/pause`, {
+      method: "POST",
+    });
+    await checkControlResponse(resp);
+
+    if (!wait) {
+      return;
+    }
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+      const info = await this.getInfo();
+      if (info.state === "paused") {
+        return;
+      }
+      await sleep(intervalMs);
+    }
+    throw new Error(
+      `Sandbox ${this.sandboxId} did not reach 'paused' state within ${timeoutMs}ms`,
+    );
+  }
+
+  /**
+   * POST /sandboxes/:id/resume — resume a paused sandbox.
+   * @deprecated Use {@link Sandbox.connect} which auto-resumes and returns a
+   * fresh instance.
+   */
+  async resume(timeout = DEFAULT_SANDBOX_TIMEOUT_S): Promise<void> {
+    const resp = await controlFetch(this.config, `${this.config.apiUrl}/sandboxes/${this.sandboxId}/resume`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ timeout }),
+    });
+    await checkControlResponse(resp);
+  }
+
+  /** DELETE /sandboxes/:id — destroy a sandbox. */
+  async kill(): Promise<void> {
+    const resp = await controlFetch(this.config, `${this.config.apiUrl}/sandboxes/${this.sandboxId}`, {
+      method: "DELETE",
+    });
+    await checkControlResponse(resp);
+  }
+
+  /** POST /sandboxes/:id/snapshots — create a snapshot. */
+  async createSnapshot(name?: string): Promise<SnapshotInfo> {
+    const payload: Record<string, unknown> = {};
+    if (name !== undefined) {
+      payload.name = name;
+    }
+    const resp = await controlFetch(this.config, `${this.config.apiUrl}/sandboxes/${this.sandboxId}/snapshots`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+    });
+    await checkControlResponse(resp);
+    return SnapshotInfo.fromDict((await resp.json()) as Record<string, any>);
+  }
+
+  /** POST /sandboxes/:id/rollback — roll back a sandbox to a snapshot. */
+  async rollback(snapshotId: string): Promise<Record<string, any>> {
+    const resp = await controlFetch(this.config, `${this.config.apiUrl}/sandboxes/${this.sandboxId}/rollback`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ snapshotID: snapshotId }),
+    });
+    await checkControlResponse(resp);
+    const result = (await resp.json()) as Record<string, any>;
+    // Rollback restarts the sandbox process — drop the pooled data-plane
+    // dispatcher so the next call reconnects.
+    this._resetConnections();
+    return result;
+  }
+
+  /**
+   * Clone this sandbox ``n`` times: snapshot -> create ×n -> delete snapshot.
+   *
+   * ``concurrency`` caps how many ``Sandbox.create`` calls run in parallel at
+   * ``min(n, concurrency)`` (default 1 = sequential), mirroring the Python
+   * (``ThreadPoolExecutor``) and Go (semaphore) SDKs. If any create fails, all
+   * successful siblings are killed and the first error is re-thrown.
+   */
+  async clone(n = 1, options: { concurrency?: number } = {}): Promise<Sandbox[]> {
+    const concurrency = options.concurrency ?? 1;
+    const snapshot = await this.createSnapshot();
+    const snapId = snapshot.snapshotId;
+    const cfg = this.config;
+
+    const createOne = (): Promise<Sandbox> => Sandbox.create({ template: snapId, config: cfg });
+
+    const sandboxes: Sandbox[] = [];
+    let firstError: unknown = null;
+
+    try {
+      if (concurrency <= 1 || n <= 1) {
+        for (let i = 0; i < n; i++) {
+          try {
+            sandboxes.push(await createOne());
+          } catch (err) {
+            firstError = err;
+            break;
+          }
+        }
+      } else {
+        // Bounded fan-out: at most min(n, concurrency) create calls are in
+        // flight at once (workers pull from a shared cursor), matching the
+        // Python (ThreadPoolExecutor) and Go (semaphore) SDKs. Every task is
+        // drained so a mid-fan-out failure never leaks a created sibling.
+        const limit = Math.min(n, concurrency);
+        let next = 0;
+        const worker = async (): Promise<void> => {
+          for (;;) {
+            const index = next++;
+            if (index >= n) {
+              return;
+            }
+            try {
+              sandboxes.push(await createOne());
+            } catch (err) {
+              if (firstError === null) {
+                firstError = err;
+              }
+            }
+          }
+        };
+        await Promise.all(Array.from({ length: limit }, () => worker()));
+      }
+    } finally {
+      try {
+        await Sandbox.deleteSnapshot(snapId, { config: cfg });
+      } catch {
+        // best-effort cleanup
+      }
+    }
+
+    if (firstError !== null) {
+      await Promise.allSettled(sandboxes.map((sb) => sb.kill()));
+      throw firstError;
+    }
+    return sandboxes;
+  }
+
+  /** Close pooled HTTP connections without destroying the sandbox. */
+  close(): void {
+    this._resetConnections();
+  }
+
+  private _resetConnections(): void {
+    if (this._dataDispatcher) {
+      void this._dataDispatcher.close().catch(() => undefined);
+    }
+    this._dataDispatcher = undefined;
+    this._dataDispatcherBuilt = false;
+  }
+
+  async [Symbol.asyncDispose](): Promise<void> {
+    try {
+      await this.kill();
+    } catch (err) {
+      if (!(err instanceof CubeSandboxError)) {
+        throw err;
+      }
+    } finally {
+      this.close();
+    }
+  }
+}

--- a/sdk/node/src/stream.ts
+++ b/sdk/node/src/stream.ts
@@ -1,0 +1,191 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { Execution, ExecutionError, OutputMessage, Result } from "./models.js";
+
+/** Streaming callbacks for {@link Sandbox.runCode}. */
+export interface RunCodeCallbacks {
+  onStdout?: (msg: OutputMessage) => void;
+  onStderr?: (msg: OutputMessage) => void;
+  onResult?: (result: Result) => void;
+  onError?: (error: ExecutionError) => void;
+}
+
+/**
+ * An idle (inactivity) timeout backed by an {@link AbortController}. The timer
+ * is *reset* every time {@link IdleTimeout.reset} is called (i.e. on each chunk
+ * received), so a long-running-but-active stream is never aborted — only a
+ * stream that goes quiet for longer than ``timeoutMs`` is.
+ *
+ * This mirrors the Python SDK's httpx *read* timeout (as opposed to a hard
+ * deadline over the whole request).
+ */
+export interface IdleTimeout {
+  readonly signal: AbortSignal;
+  /** Restart the inactivity timer (call whenever fresh bytes arrive). */
+  reset(): void;
+  /** Stop the timer for good (call when the stream is fully consumed). */
+  clear(): void;
+  /** True once the timer fired and aborted the signal. */
+  readonly firedRef: { current: boolean };
+}
+
+/**
+ * Create an {@link IdleTimeout}. When ``timeoutMs`` is falsy or non-positive the
+ * returned handle is inert (never aborts) so callers can pass it unconditionally.
+ */
+export function createIdleTimeout(timeoutMs?: number): IdleTimeout {
+  const controller = new AbortController();
+  const firedRef = { current: false };
+
+  if (!timeoutMs || timeoutMs <= 0) {
+    return { signal: controller.signal, reset() {}, clear() {}, firedRef };
+  }
+
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const arm = (): void => {
+    timer = setTimeout(() => {
+      firedRef.current = true;
+      controller.abort();
+    }, timeoutMs);
+    // Don't let a pending idle timer keep the event loop alive on its own.
+    (timer as { unref?: () => void }).unref?.();
+  };
+  arm();
+
+  return {
+    signal: controller.signal,
+    reset(): void {
+      if (timer !== undefined) {
+        clearTimeout(timer);
+      }
+      arm();
+    },
+    clear(): void {
+      if (timer !== undefined) {
+        clearTimeout(timer);
+        timer = undefined;
+      }
+    },
+    firedRef,
+  };
+}
+
+/**
+ * Parse a single ndjson line emitted by the sandbox's envd process, mutating
+ * ``execution`` in place and invoking the matching callback. Malformed lines
+ * and unknown event types are silently skipped (mirrors the Python SDK).
+ */
+export function parseLine(
+  execution: Execution,
+  line: string,
+  callbacks: RunCodeCallbacks = {},
+): void {
+  if (!line) {
+    return;
+  }
+
+  let data: Record<string, any>;
+  try {
+    data = JSON.parse(line);
+  } catch {
+    return;
+  }
+
+  const eventType = data.type;
+
+  switch (eventType) {
+    case "result": {
+      const result = new Result(data);
+      execution.results.push(result);
+      callbacks.onResult?.(result);
+      break;
+    }
+    case "stdout": {
+      const text = data.text ?? "";
+      execution.logs.stdout.push(text);
+      callbacks.onStdout?.(new OutputMessage(text, data.timestamp ?? ""));
+      break;
+    }
+    case "stderr": {
+      const text = data.text ?? "";
+      execution.logs.stderr.push(text);
+      callbacks.onStderr?.(new OutputMessage(text, data.timestamp ?? "", true));
+      break;
+    }
+    case "error": {
+      execution.error = new ExecutionError(
+        data.name ?? "",
+        data.value ?? "",
+        data.traceback ?? [],
+      );
+      callbacks.onError?.(execution.error);
+      break;
+    }
+    case "number_of_executions": {
+      execution.executionCount = data.execution_count ?? null;
+      break;
+    }
+    default:
+      break;
+  }
+}
+
+/**
+ * Consume a web ``ReadableStream`` of ndjson bytes, feeding each complete line
+ * to {@link parseLine}. Handles UTF-8 decoding and partial-line buffering.
+ */
+export async function parseNdjsonStream(
+  body: ReadableStream<Uint8Array>,
+  execution: Execution,
+  callbacks: RunCodeCallbacks = {},
+  onActivity?: () => void,
+): Promise<void> {
+  const reader = body.getReader();
+  const decoder = new TextDecoder();
+  // Accumulate decoded fragments without repeatedly reallocating a growing
+  // string. We only join (and scan for newlines) when a fragment actually
+  // contains one, so a large line split across many chunks costs O(n) total
+  // instead of the O(n²) of `buffer += chunk` on every read.
+  let pending: string[] = [];
+
+  const flushCompleteLines = (): void => {
+    let buf = pending.join("");
+    let newlineIndex: number;
+    while ((newlineIndex = buf.indexOf("\n")) >= 0) {
+      const line = buf.slice(0, newlineIndex).replace(/\r$/, "");
+      buf = buf.slice(newlineIndex + 1);
+      parseLine(execution, line, callbacks);
+    }
+    pending = buf ? [buf] : [];
+  };
+
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) {
+        break;
+      }
+      onActivity?.();
+      const text = decoder.decode(value, { stream: true });
+      if (text.length === 0) {
+        continue;
+      }
+      pending.push(text);
+      if (text.indexOf("\n") >= 0) {
+        flushCompleteLines();
+      }
+    }
+  } finally {
+    reader.releaseLock();
+  }
+
+  const flushed = decoder.decode();
+  if (flushed) {
+    pending.push(flushed);
+  }
+  const tail = pending.join("").replace(/\r$/, "");
+  if (tail) {
+    parseLine(execution, tail, callbacks);
+  }
+}

--- a/sdk/node/src/template.ts
+++ b/sdk/node/src/template.ts
@@ -1,0 +1,327 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { Config, resolveConfig, type ConfigOptions } from "./config.js";
+import { ApiError, AuthenticationError, TemplateNotFoundError } from "./exceptions.js";
+import { validateAllowOutDomainsRequireDenyAll } from "./policy.js";
+import { controlFetch } from "./transport.js";
+
+async function checkTemplateResponse(resp: {
+  ok: boolean;
+  status: number;
+  text: () => Promise<string>;
+}): Promise<void> {
+  if (resp.ok) {
+    return;
+  }
+  let text = "";
+  try {
+    text = await resp.text();
+  } catch {
+    text = "";
+  }
+  let msg = text || `HTTP ${resp.status}`;
+  try {
+    const body = JSON.parse(text);
+    msg = body?.message || body?.detail || msg;
+  } catch {
+    // raw text
+  }
+  const code = resp.status;
+  if (code === 401 || code === 403) {
+    throw new AuthenticationError(msg, code);
+  }
+  if (code === 404) {
+    throw new TemplateNotFoundError(msg, code);
+  }
+  throw new ApiError(msg, code);
+}
+
+/** A template create/rebuild job or build status record. */
+export class TemplateBuild {
+  buildId: string;
+  templateId: string;
+  status: string;
+  phase: string;
+  progress: number;
+  errorMessage: string;
+  message: string;
+  createdAt: string;
+  finishedAt: string;
+  logs: string[];
+
+  constructor(fields: Partial<TemplateBuild> = {}) {
+    this.buildId = fields.buildId ?? "";
+    this.templateId = fields.templateId ?? "";
+    this.status = fields.status ?? "";
+    this.phase = fields.phase ?? "";
+    this.progress = fields.progress ?? 0;
+    this.errorMessage = fields.errorMessage ?? "";
+    this.message = fields.message ?? "";
+    this.createdAt = fields.createdAt ?? "";
+    this.finishedAt = fields.finishedAt ?? "";
+    this.logs = fields.logs ?? [];
+  }
+
+  /** Alias for create/rebuild responses that use ``jobID``. */
+  get jobId(): string {
+    return this.buildId;
+  }
+
+  static fromDict(data: Record<string, any>): TemplateBuild {
+    return new TemplateBuild({
+      buildId: data.buildID ?? data.jobID ?? data.build_id ?? "",
+      templateId: data.templateID ?? data.template_id ?? "",
+      status: data.status ?? "",
+      phase: data.phase ?? "",
+      progress: data.progress ?? 0,
+      errorMessage: data.errorMessage ?? data.error_message ?? "",
+      message: data.message ?? "",
+      createdAt: data.createdAt ?? data.created_at ?? "",
+      finishedAt: data.finishedAt ?? data.finished_at ?? "",
+      logs: data.logs ?? [],
+    });
+  }
+}
+
+/** Metadata for a CubeSandbox template. */
+export class TemplateInfo {
+  templateId: string;
+  name: string;
+  instanceType: string;
+  version: string;
+  status: string;
+  lastError: string;
+  createdAt: string;
+  imageInfo: string;
+  jobId: string;
+  public: boolean;
+  cpuCount: number;
+  memoryMb: number;
+  replicas: Record<string, any>[];
+  createRequest: Record<string, any> | null;
+  networkType: string | null;
+  allowInternetAccess: boolean | null;
+  builds: TemplateBuild[];
+
+  constructor(fields: Partial<TemplateInfo> = {}) {
+    this.templateId = fields.templateId ?? "";
+    this.name = fields.name ?? "";
+    this.instanceType = fields.instanceType ?? "";
+    this.version = fields.version ?? "";
+    this.status = fields.status ?? "";
+    this.lastError = fields.lastError ?? "";
+    this.createdAt = fields.createdAt ?? "";
+    this.imageInfo = fields.imageInfo ?? "";
+    this.jobId = fields.jobId ?? "";
+    this.public = fields.public ?? false;
+    this.cpuCount = fields.cpuCount ?? 0;
+    this.memoryMb = fields.memoryMb ?? 0;
+    this.replicas = fields.replicas ?? [];
+    this.createRequest = fields.createRequest ?? null;
+    this.networkType = fields.networkType ?? null;
+    this.allowInternetAccess = fields.allowInternetAccess ?? null;
+    this.builds = fields.builds ?? [];
+  }
+
+  static fromDict(data: Record<string, any>): TemplateInfo {
+    const aliases: string[] = data.aliases ?? [];
+    return new TemplateInfo({
+      templateId: data.templateID ?? data.template_id ?? "",
+      name: data.name || (aliases.length ? aliases[0] : "") || "",
+      instanceType: data.instanceType ?? data.instance_type ?? "",
+      version: data.version ?? "",
+      status: data.status ?? "",
+      lastError: data.lastError ?? data.last_error ?? "",
+      createdAt: data.createdAt ?? data.created_at ?? "",
+      imageInfo: data.imageInfo ?? data.image_info ?? "",
+      jobId: data.jobID ?? data.job_id ?? "",
+      public: Boolean(data.public ?? false),
+      cpuCount: data.cpuCount ?? data.cpu_count ?? 0,
+      memoryMb: data.memoryMB ?? data.memory_mb ?? 0,
+      replicas: data.replicas ?? [],
+      createRequest: data.createRequest ?? data.create_request ?? null,
+      networkType: data.networkType ?? data.network_type ?? null,
+      allowInternetAccess:
+        "allowInternetAccess" in data
+          ? data.allowInternetAccess
+          : (data.allow_internet_access ?? null),
+      builds: (data.builds ?? []).map((b: Record<string, any>) => TemplateBuild.fromDict(b)),
+    });
+  }
+}
+
+/** Options for {@link Template.build}. */
+export interface TemplateBuildOptions {
+  image?: string;
+  dockerfile?: string;
+  startCmd?: string;
+  instanceType?: string;
+  writableLayerSize?: string;
+  exposedPorts?: number[];
+  probePort?: number;
+  probePath?: string;
+  cpuCount?: number;
+  memoryMb?: number;
+  envs?: Record<string, string>;
+  allowInternetAccess?: boolean;
+  networkType?: string;
+  nodes?: string[];
+  registryUsername?: string;
+  registryPassword?: string;
+  command?: string[];
+  args?: string[];
+  dns?: string[];
+  allowOut?: string[];
+  denyOut?: string[];
+  config?: Config | ConfigOptions;
+  extra?: Record<string, unknown>;
+}
+
+/** Class-level helper for Cube template management. All methods are static. */
+export class Template {
+  /** GET /templates — list all templates. */
+  static async list(options: { config?: Config | ConfigOptions } = {}): Promise<TemplateInfo[]> {
+    const cfg = resolveConfig(options.config);
+    const resp = await controlFetch(cfg, `${cfg.apiUrl}/templates`);
+    await checkTemplateResponse(resp);
+    let data = (await resp.json()) as any;
+    if (data && !Array.isArray(data)) {
+      data = data.templates ?? data.items ?? [];
+    }
+    return ((data as Record<string, any>[]) || []).map((d) => TemplateInfo.fromDict(d));
+  }
+
+  /** GET /templates/:id — get a template and its build history. */
+  static async get(
+    templateId: string,
+    options: { limit?: number; nextToken?: string; config?: Config | ConfigOptions } = {},
+  ): Promise<TemplateInfo> {
+    const cfg = resolveConfig(options.config);
+    const params = new URLSearchParams();
+    if (options.limit !== undefined) params.set("limit", String(options.limit));
+    if (options.nextToken !== undefined) params.set("nextToken", options.nextToken);
+    const query = params.toString();
+    const resp = await controlFetch(
+      cfg,
+      `${cfg.apiUrl}/templates/${templateId}${query ? `?${query}` : ""}`,
+    );
+    await checkTemplateResponse(resp);
+    return TemplateInfo.fromDict((await resp.json()) as Record<string, any>);
+  }
+
+  /** POST /templates — build (create) a new template from a container image. */
+  static async build(options: TemplateBuildOptions): Promise<TemplateBuild> {
+    if (options.dockerfile !== undefined) {
+      throw new Error("dockerfile builds are not supported by CubeAPI /templates");
+    }
+    if (options.startCmd !== undefined) {
+      throw new Error("startCmd is not supported by CubeAPI /templates");
+    }
+    if (!options.image || !options.image.trim()) {
+      throw new Error("image is required");
+    }
+    validateAllowOutDomainsRequireDenyAll(
+      options.allowOut,
+      options.denyOut,
+      options.allowInternetAccess === false,
+    );
+
+    const cfg = resolveConfig(options.config);
+    const payload: Record<string, unknown> = { image: options.image.trim() };
+    if (options.instanceType !== undefined) payload.instanceType = options.instanceType;
+    if (options.writableLayerSize !== undefined) {
+      payload.writableLayerSize = options.writableLayerSize;
+    }
+    if (options.exposedPorts !== undefined) payload.exposedPorts = options.exposedPorts;
+    if (options.probePort !== undefined) payload.probePort = options.probePort;
+    if (options.probePath !== undefined) payload.probePath = options.probePath;
+    if (options.cpuCount !== undefined) payload.cpu = options.cpuCount;
+    if (options.memoryMb !== undefined) payload.memory = options.memoryMb;
+    if (options.envs !== undefined) {
+      payload.env = Object.entries(options.envs).map(([k, v]) => `${k}=${v}`);
+    }
+    if (options.allowInternetAccess !== undefined) {
+      payload.allowInternetAccess = options.allowInternetAccess;
+    }
+    if (options.networkType !== undefined) payload.networkType = options.networkType;
+    if (options.nodes !== undefined) payload.nodes = options.nodes;
+    if (options.registryUsername !== undefined) {
+      payload.registryUsername = options.registryUsername;
+    }
+    if (options.registryPassword !== undefined) {
+      payload.registryPassword = options.registryPassword;
+    }
+    if (options.command !== undefined) payload.command = options.command;
+    if (options.args !== undefined) payload.args = options.args;
+    if (options.dns !== undefined) payload.dns = options.dns;
+    if (options.allowOut !== undefined) payload.allowOut = options.allowOut;
+    if (options.denyOut !== undefined) payload.denyOut = options.denyOut;
+    if (options.extra) Object.assign(payload, options.extra);
+
+    const resp = await controlFetch(cfg, `${cfg.apiUrl}/templates`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+    });
+    await checkTemplateResponse(resp);
+    return TemplateBuild.fromDict((await resp.json()) as Record<string, any>);
+  }
+
+  /** POST /templates/:id — rebuild an existing template. */
+  static async rebuild(
+    templateId: string,
+    options: { config?: Config | ConfigOptions; extra?: Record<string, unknown> } = {},
+  ): Promise<TemplateBuild> {
+    const cfg = resolveConfig(options.config);
+    const resp = await controlFetch(cfg, `${cfg.apiUrl}/templates/${templateId}`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(options.extra ?? {}),
+    });
+    await checkTemplateResponse(resp);
+    return TemplateBuild.fromDict((await resp.json()) as Record<string, any>);
+  }
+
+  /** GET /templates/:id/builds/:buildId/status. */
+  static async getBuildStatus(
+    templateId: string,
+    buildId: string,
+    options: { config?: Config | ConfigOptions } = {},
+  ): Promise<TemplateBuild> {
+    const cfg = resolveConfig(options.config);
+    const resp = await controlFetch(
+      cfg,
+      `${cfg.apiUrl}/templates/${templateId}/builds/${buildId}/status`,
+    );
+    await checkTemplateResponse(resp);
+    return TemplateBuild.fromDict((await resp.json()) as Record<string, any>);
+  }
+
+  /** GET /templates/:id/builds/:buildId/logs. */
+  static async getBuildLogs(
+    templateId: string,
+    buildId: string,
+    options: { config?: Config | ConfigOptions } = {},
+  ): Promise<Record<string, any>> {
+    const cfg = resolveConfig(options.config);
+    const resp = await controlFetch(
+      cfg,
+      `${cfg.apiUrl}/templates/${templateId}/builds/${buildId}/logs`,
+    );
+    await checkTemplateResponse(resp);
+    return (await resp.json()) as Record<string, any>;
+  }
+
+  /** DELETE /templates/:id — delete a template permanently. */
+  static async delete(
+    templateId: string,
+    options: { config?: Config | ConfigOptions } = {},
+  ): Promise<void> {
+    const cfg = resolveConfig(options.config);
+    const resp = await controlFetch(cfg, `${cfg.apiUrl}/templates/${templateId}`, {
+      method: "DELETE",
+    });
+    await checkTemplateResponse(resp);
+  }
+}

--- a/sdk/node/src/transport.ts
+++ b/sdk/node/src/transport.ts
@@ -1,0 +1,79 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { Agent, buildConnector, fetch, type Dispatcher } from "undici";
+
+import type { Config } from "./config.js";
+
+/**
+ * Build an undici {@link Dispatcher} for sandbox data-plane requests.
+ *
+ * When ``config.proxyNodeIp`` is set, every TCP connection is routed directly
+ * to that IP:port while the request URL retains the virtual ``*.cube.app``
+ * hostname, so the ``Host`` header is preserved for CubeProxy routing. This is
+ * the Node equivalent of the Python SDK's ``IPOverrideTransport`` and the Go
+ * SDK's ``DialContext`` override (``curl --resolve host:port:ip``).
+ *
+ * Returns ``undefined`` when no proxy override is configured, in which case
+ * callers fall back to the default global dispatcher (normal DNS resolution).
+ */
+export function buildDataDispatcher(config: Config): Dispatcher | undefined {
+  if (!config.proxyNodeIp) {
+    return undefined;
+  }
+
+  const proxyIp = config.proxyNodeIp;
+  const proxyPort = config.proxyPort;
+  const baseConnect = buildConnector({ timeout: config.requestTimeoutMs });
+
+  return new Agent({
+    connect(opts, callback) {
+      // Ignore the virtual hostname/port from the URL and dial the proxy node
+      // instead. The Host header (derived from the URL) is left untouched.
+      //
+      // For TLS (``https`` data plane) we must keep the SNI / cert-verification
+      // servername pinned to the *virtual* sandbox host, not the proxy IP —
+      // otherwise the handshake fails or is validated against the wrong name.
+      // This mirrors ``curl --resolve host:port:ip`` (dial ip, present host).
+      const virtualServername =
+        (opts as { servername?: string }).servername ??
+        (typeof opts.hostname === "string" ? opts.hostname : undefined);
+      baseConnect(
+        { ...opts, hostname: proxyIp, port: String(proxyPort), servername: virtualServername },
+        callback,
+      );
+    },
+  });
+}
+
+/** Scheme used for data-plane (CubeProxy-routed) URLs. */
+export function dataScheme(config: Config): string {
+  return config.proxyScheme || "http";
+}
+
+/**
+ * Perform a management-plane (CubeAPI) request with an overall timeout derived
+ * from ``config.requestTimeoutMs`` (default 30s). Mirrors the Go SDK's
+ * control-plane ``http.Client{Timeout: RequestTimeout}`` so a hung or slow
+ * management call fails fast instead of blocking the caller indefinitely.
+ *
+ * Data-plane calls (``runCode`` / ``commands`` / filesystem) do NOT go through
+ * here — they carry their own idle/connect timeouts and data dispatcher. A
+ * caller-supplied ``signal`` takes precedence and disables the default timeout.
+ *
+ * When ``config.apiKey`` is set, an ``Authorization: Bearer`` header is injected
+ * (unless the caller already provided one), matching the Go SDK's control-plane
+ * auth. With no key the request is sent unauthenticated (localhost default).
+ */
+export function controlFetch(
+  config: Config,
+  url: string,
+  init: Parameters<typeof fetch>[1] = {},
+): ReturnType<typeof fetch> {
+  const signal = init?.signal ?? AbortSignal.timeout(config.requestTimeoutMs);
+  const headers: Record<string, string> = { ...(init?.headers as Record<string, string>) };
+  if (config.apiKey && headers.Authorization === undefined) {
+    headers.Authorization = `Bearer ${config.apiKey}`;
+  }
+  return fetch(url, { ...init, headers, signal });
+}

--- a/sdk/node/test/_env.ts
+++ b/sdk/node/test/_env.ts
@@ -1,0 +1,43 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { afterEach, beforeEach } from "vitest";
+
+const CUBE_ENV_KEYS = [
+  "CUBE_API_URL",
+  "CUBE_API_KEY",
+  "E2B_API_KEY",
+  "CUBE_TEMPLATE_ID",
+  "CUBE_PROXY_NODE_IP",
+  "CUBE_PROXY_PORT_HTTP",
+  "CUBE_PROXY_SCHEME",
+  "CUBE_SANDBOX_DOMAIN",
+] as const;
+
+/**
+ * Isolate a test suite from any ambient ``CUBE_*`` configuration so unit tests
+ * stay hermetic even when the shell or CI has them set — e.g. when running the
+ * gated live integration test in the same `npm test` invocation. Registers
+ * `beforeEach`/`afterEach` hooks that clear the vars before each test and
+ * restore the originals afterwards.
+ */
+export function stubCubeEnv(): void {
+  let saved: Record<string, string | undefined> = {};
+  beforeEach(() => {
+    saved = {};
+    for (const key of CUBE_ENV_KEYS) {
+      saved[key] = process.env[key];
+      delete process.env[key];
+    }
+  });
+  afterEach(() => {
+    for (const key of CUBE_ENV_KEYS) {
+      const value = saved[key];
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+  });
+}

--- a/sdk/node/test/commands.test.ts
+++ b/sdk/node/test/commands.test.ts
@@ -1,0 +1,193 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { createServer, type IncomingHttpHeaders, type Server } from "node:http";
+import type { AddressInfo } from "node:net";
+
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+
+import { Config } from "../src/config.js";
+import { Sandbox } from "../src/index.js";
+
+const SANDBOX_ID = "sb-test-001";
+const DOMAIN = "cube.app";
+const SANDBOX_DATA = {
+  sandboxID: SANDBOX_ID,
+  templateID: "tpl-test",
+  domain: DOMAIN,
+  state: "running",
+};
+
+interface RecordedRequest {
+  method: string;
+  pathname: string;
+  headers: IncomingHttpHeaders;
+  body: Buffer;
+}
+
+interface MockResponse {
+  status?: number;
+  json?: unknown;
+  buffer?: Buffer;
+  headers?: Record<string, string>;
+}
+
+type Handler = (req: RecordedRequest) => MockResponse;
+
+let server: Server;
+let port: number;
+let requests: RecordedRequest[] = [];
+let handler: Handler = () => ({ status: 201, json: SANDBOX_DATA });
+
+/** Build a single Connect protocol envelope: [flags:1][len:4 BE][payload]. */
+function connectFrame(flags: number, payload: string): Buffer {
+  const raw = Buffer.from(payload, "utf-8");
+  const header = Buffer.alloc(5);
+  header.writeUInt8(flags, 0);
+  header.writeUInt32BE(raw.length, 1);
+  return Buffer.concat([header, raw]);
+}
+
+/** Decode the JSON payload out of a data (flags=0) Connect envelope. */
+function decodeConnectPayload(raw: Buffer): Record<string, unknown> {
+  expect(raw.length).toBeGreaterThanOrEqual(5);
+  const flags = raw.readUInt8(0);
+  const size = raw.readUInt32BE(1);
+  expect(flags).toBe(0);
+  expect(raw.length).toBe(5 + size);
+  return JSON.parse(raw.slice(5, 5 + size).toString("utf-8"));
+}
+
+function makeConfig(): Config {
+  return new Config({
+    apiUrl: `http://127.0.0.1:${port}`,
+    templateId: "tpl-test",
+    proxyNodeIp: "127.0.0.1",
+    proxyPort: port,
+    sandboxDomain: DOMAIN,
+  });
+}
+
+async function createSandbox(): Promise<Sandbox> {
+  handler = () => ({ status: 201, json: SANDBOX_DATA });
+  const sb = await Sandbox.create({ config: makeConfig() });
+  requests = [];
+  return sb;
+}
+
+beforeAll(async () => {
+  server = createServer((req, res) => {
+    const chunks: Buffer[] = [];
+    req.on("data", (c: Buffer) => chunks.push(c));
+    req.on("end", () => {
+      const url = new URL(req.url ?? "/", "http://localhost");
+      const record: RecordedRequest = {
+        method: req.method ?? "",
+        pathname: url.pathname,
+        headers: req.headers,
+        body: Buffer.concat(chunks),
+      };
+      requests.push(record);
+      const out = handler(record);
+      const headers: Record<string, string> = { ...(out.headers ?? {}) };
+      let payload: string | Buffer = "";
+      if (out.buffer !== undefined) {
+        payload = out.buffer;
+      } else if (out.json !== undefined) {
+        payload = JSON.stringify(out.json);
+        headers["content-type"] ??= "application/json";
+      }
+      res.writeHead(out.status ?? 200, headers);
+      res.end(payload);
+    });
+  });
+  await new Promise<void>((resolve) => server.listen(0, resolve));
+  port = (server.address() as AddressInfo).port;
+});
+
+afterAll(() => {
+  server.close();
+});
+
+afterEach(() => {
+  requests = [];
+});
+
+describe("Commands.run", () => {
+  it("decodes base64 stdout and reports a zero exit code", async () => {
+    const sb = await createSandbox();
+    const stdout = Buffer.from("hello\nworld\n").toString("base64");
+    handler = (req) => {
+      expect(req.method).toBe("POST");
+      expect(req.pathname).toBe("/process.Process/Start");
+      expect(req.headers.host).toBe(`49983-${SANDBOX_ID}.${DOMAIN}`);
+      expect(req.headers.authorization).toBe("Basic cm9vdDo=");
+      const payload = decodeConnectPayload(req.body) as {
+        process: { cmd: string; args: string[]; envs: Record<string, string>; cwd?: string };
+      };
+      expect(payload.process.cmd).toBe("/bin/bash");
+      expect(payload.process.args).toEqual(["-l", "-c", "echo hello"]);
+      expect(payload.process.envs).toEqual({ A: "B" });
+      expect(payload.process.cwd).toBe("/work");
+      const body = Buffer.concat([
+        connectFrame(0, '{"event":{"start":{"pid":123}}}'),
+        connectFrame(0, JSON.stringify({ event: { data: { stdout } } })),
+        connectFrame(0, '{"event":{"end":{"exitCode":0,"exited":true}}}'),
+        connectFrame(0x02, "{}"),
+      ]);
+      return { status: 200, buffer: body };
+    };
+
+    const result = await sb.commands.run("echo hello", { cwd: "/work", envs: { A: "B" } });
+    expect(result.stdout).toBe("hello\nworld\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+    sb.close();
+  });
+
+  it("decodes base64 stderr", async () => {
+    const sb = await createSandbox();
+    const stderr = Buffer.from("warn\nerror\n").toString("base64");
+    handler = () => ({
+      status: 200,
+      buffer: Buffer.concat([
+        connectFrame(0, JSON.stringify({ event: { data: { stderr } } })),
+        connectFrame(0, '{"event":{"end":{"exitCode":0,"exited":true}}}'),
+        connectFrame(0x02, "{}"),
+      ]),
+    });
+
+    const result = await sb.commands.run("echo warn >&2");
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toBe("warn\nerror\n");
+    expect(result.exitCode).toBe(0);
+    sb.close();
+  });
+
+  it("reports a non-zero exit code", async () => {
+    const sb = await createSandbox();
+    handler = () => ({
+      status: 200,
+      buffer: Buffer.concat([
+        connectFrame(0, '{"event":{"end":{"exitCode":1,"exited":true}}}'),
+        connectFrame(0x02, "{}"),
+      ]),
+    });
+    const result = await sb.commands.run("false");
+    expect(result.exitCode).toBe(1);
+    sb.close();
+  });
+
+  it("propagates an error delivered on the end-of-stream frame", async () => {
+    const sb = await createSandbox();
+    handler = () => ({
+      status: 200,
+      buffer: connectFrame(
+        0x02,
+        '{"error":{"code":"internal","message":"boom"}}',
+      ),
+    });
+    await expect(sb.commands.run("boom")).rejects.toThrow(/boom/);
+    sb.close();
+  });
+});

--- a/sdk/node/test/config.test.ts
+++ b/sdk/node/test/config.test.ts
@@ -1,0 +1,128 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { Config } from "../src/config.js";
+
+const ENV_KEYS = [
+  "CUBE_API_URL",
+  "CUBE_API_KEY",
+  "E2B_API_KEY",
+  "CUBE_TEMPLATE_ID",
+  "CUBE_PROXY_NODE_IP",
+  "CUBE_PROXY_PORT_HTTP",
+  "CUBE_PROXY_SCHEME",
+  "CUBE_SANDBOX_DOMAIN",
+] as const;
+
+describe("Config", () => {
+  let saved: Record<string, string | undefined>;
+
+  beforeEach(() => {
+    saved = {};
+    for (const key of ENV_KEYS) {
+      saved[key] = process.env[key];
+      delete process.env[key];
+    }
+  });
+
+  afterEach(() => {
+    for (const key of ENV_KEYS) {
+      const value = saved[key];
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+  });
+
+  it("uses documented defaults when nothing is provided", () => {
+    const cfg = new Config();
+    expect(cfg.apiUrl).toBe("http://127.0.0.1:3000");
+    expect(cfg.apiKey).toBeNull();
+    expect(cfg.templateId).toBeNull();
+    expect(cfg.proxyNodeIp).toBeNull();
+    expect(cfg.proxyPort).toBe(80);
+    expect(cfg.proxyScheme).toBe("http");
+    expect(cfg.sandboxDomain).toBe("cube.app");
+    expect(cfg.timeout).toBe(300);
+    expect(cfg.requestTimeoutMs).toBe(30000);
+  });
+
+  it("reads the API key from CUBE_API_KEY, then E2B_API_KEY", () => {
+    process.env.E2B_API_KEY = "e2b-key";
+    expect(new Config().apiKey).toBe("e2b-key");
+    process.env.CUBE_API_KEY = "cube-key";
+    expect(new Config().apiKey).toBe("cube-key"); // CUBE_ wins
+    expect(new Config({ apiKey: "explicit" }).apiKey).toBe("explicit");
+  });
+
+  it("treats a blank API key as unset", () => {
+    process.env.CUBE_API_KEY = "   ";
+    expect(new Config().apiKey).toBeNull();
+  });
+
+  it("normalizes proxyScheme to http/https", () => {
+    expect(new Config({ proxyScheme: "HTTPS" }).proxyScheme).toBe("https");
+    expect(new Config({ proxyScheme: " http " }).proxyScheme).toBe("http");
+    // Unknown scheme falls back by port: 443 → https, otherwise http.
+    expect(new Config({ proxyScheme: "ftp" }).proxyScheme).toBe("http");
+    expect(new Config({ proxyScheme: "ftp", proxyPort: 443 }).proxyScheme).toBe("https");
+    expect(new Config({ proxyPort: 443 }).proxyScheme).toBe("https");
+  });
+
+  it("strips trailing slashes from apiUrl", () => {
+    expect(new Config({ apiUrl: "http://localhost:3000/" }).apiUrl).toBe(
+      "http://localhost:3000",
+    );
+    expect(new Config({ apiUrl: "http://localhost:3000///" }).apiUrl).toBe(
+      "http://localhost:3000",
+    );
+  });
+
+  it("reads CUBE_* environment variables", () => {
+    process.env.CUBE_API_URL = "http://1.2.3.4:3000";
+    process.env.CUBE_TEMPLATE_ID = "tpl-env";
+    process.env.CUBE_PROXY_NODE_IP = "1.2.3.4";
+    process.env.CUBE_PROXY_PORT_HTTP = "9090";
+    process.env.CUBE_SANDBOX_DOMAIN = "mybox.io";
+
+    const cfg = new Config();
+    expect(cfg.apiUrl).toBe("http://1.2.3.4:3000");
+    expect(cfg.templateId).toBe("tpl-env");
+    expect(cfg.proxyNodeIp).toBe("1.2.3.4");
+    expect(cfg.proxyPort).toBe(9090);
+    expect(cfg.sandboxDomain).toBe("mybox.io");
+  });
+
+  it("falls back to port 80 when CUBE_PROXY_PORT_HTTP is invalid or out of range", () => {
+    for (const bad of ["abc", "", "0", "-1", "65536", "99999"]) {
+      process.env.CUBE_PROXY_PORT_HTTP = bad;
+      const cfg = new Config();
+      expect(cfg.proxyPort).toBe(80);
+      expect(Number.isNaN(cfg.proxyPort)).toBe(false);
+    }
+  });
+
+  it("accepts the maximum valid port from CUBE_PROXY_PORT_HTTP", () => {
+    process.env.CUBE_PROXY_PORT_HTTP = "65535";
+    expect(new Config().proxyPort).toBe(65535);
+  });
+
+  it("lets explicit options override environment variables", () => {
+    process.env.CUBE_API_URL = "http://env-host:3000";
+    process.env.CUBE_TEMPLATE_ID = "tpl-env";
+    process.env.CUBE_PROXY_PORT_HTTP = "9090";
+
+    const cfg = new Config({
+      apiUrl: "http://explicit:4000",
+      templateId: "tpl-explicit",
+      proxyPort: 8080,
+    });
+    expect(cfg.apiUrl).toBe("http://explicit:4000");
+    expect(cfg.templateId).toBe("tpl-explicit");
+    expect(cfg.proxyPort).toBe(8080);
+  });
+});

--- a/sdk/node/test/connect-frames.test.ts
+++ b/sdk/node/test/connect-frames.test.ts
@@ -1,0 +1,99 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+
+import {
+  MAX_CONNECT_ENVELOPE_SIZE,
+  encodeConnectEnvelope,
+  readConnectFrames,
+} from "../src/commands.js";
+
+/** A ReadableStream that emits ``data`` in fixed-size slices. */
+function streamOf(data: Buffer, chunkSize: number): ReadableStream<Uint8Array> {
+  let offset = 0;
+  return new ReadableStream<Uint8Array>({
+    pull(controller) {
+      if (offset >= data.length) {
+        controller.close();
+        return;
+      }
+      const end = Math.min(offset + chunkSize, data.length);
+      controller.enqueue(new Uint8Array(data.subarray(offset, end)));
+      offset = end;
+    },
+  });
+}
+
+async function collect(
+  stream: ReadableStream<Uint8Array>,
+): Promise<{ flags: number; payload: Buffer }[]> {
+  const frames: { flags: number; payload: Buffer }[] = [];
+  for await (const frame of readConnectFrames(stream)) {
+    // Copy the payload out: it may be a view into an internal chunk.
+    frames.push({ flags: frame.flags, payload: Buffer.from(frame.payload) });
+  }
+  return frames;
+}
+
+describe("readConnectFrames", () => {
+  it("reassembles frames when headers and payloads are split across chunks", async () => {
+    const data = Buffer.concat([
+      encodeConnectEnvelope(Buffer.from("first"), 0),
+      encodeConnectEnvelope(Buffer.from("second"), 0),
+      encodeConnectEnvelope(Buffer.alloc(0), 0x02),
+    ]);
+
+    // One byte at a time forces every header/payload boundary to span chunks.
+    const frames = await collect(streamOf(data, 1));
+
+    expect(frames).toHaveLength(3);
+    expect(frames[0]).toEqual({ flags: 0, payload: Buffer.from("first") });
+    expect(frames[1]).toEqual({ flags: 0, payload: Buffer.from("second") });
+    expect(frames[2].flags).toBe(0x02);
+    expect(frames[2].payload).toHaveLength(0);
+  });
+
+  it("reassembles a single large frame delivered in many small chunks", async () => {
+    const big = Buffer.alloc(256 * 1024);
+    for (let i = 0; i < big.length; i++) {
+      big[i] = i % 251;
+    }
+    const data = encodeConnectEnvelope(big, 0);
+
+    const frames = await collect(streamOf(data, 1024));
+
+    expect(frames).toHaveLength(1);
+    expect(frames[0].flags).toBe(0);
+    expect(frames[0].payload.equals(big)).toBe(true);
+  });
+
+  it("handles multiple whole frames arriving in a single chunk", async () => {
+    const data = Buffer.concat([
+      encodeConnectEnvelope(Buffer.from("a"), 0),
+      encodeConnectEnvelope(Buffer.from("bb"), 0),
+      encodeConnectEnvelope(Buffer.from("ccc"), 0),
+    ]);
+
+    const frames = await collect(streamOf(data, data.length));
+
+    expect(frames.map((f) => f.payload.toString())).toEqual(["a", "bb", "ccc"]);
+  });
+
+  it("rejects a frame whose declared size exceeds the limit", async () => {
+    const header = Buffer.alloc(5);
+    header.writeUInt8(0, 0);
+    header.writeUInt32BE(MAX_CONNECT_ENVELOPE_SIZE + 1, 1);
+
+    await expect(collect(streamOf(header, 5))).rejects.toThrow(/too large/);
+  });
+
+  it("rejects a stream that ends mid-frame", async () => {
+    const header = Buffer.alloc(5);
+    header.writeUInt8(0, 0);
+    header.writeUInt32BE(10, 1); // claims 10 payload bytes...
+    const data = Buffer.concat([header, Buffer.from("abc")]); // ...but only 3 arrive
+
+    await expect(collect(streamOf(data, 2))).rejects.toThrow(/partial message/);
+  });
+});

--- a/sdk/node/test/exceptions.test.ts
+++ b/sdk/node/test/exceptions.test.ts
@@ -1,0 +1,58 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+
+import {
+  ApiError,
+  AuthenticationError,
+  CubeSandboxError,
+  FilesystemNotFoundError,
+  PartialWriteError,
+  SandboxNotFoundError,
+  TemplateNotFoundError,
+} from "../src/exceptions.js";
+
+describe("exception hierarchy", () => {
+  const cases: Array<[new (message: string, statusCode?: number) => CubeSandboxError, string]> = [
+    [SandboxNotFoundError, "SandboxNotFoundError"],
+    [TemplateNotFoundError, "TemplateNotFoundError"],
+    [AuthenticationError, "AuthenticationError"],
+    [ApiError, "ApiError"],
+    [FilesystemNotFoundError, "FilesystemNotFoundError"],
+  ];
+
+  for (const [Ctor, name] of cases) {
+    it(`${name} extends CubeSandboxError and Error`, () => {
+      const err = new Ctor("boom", 404);
+      expect(err).toBeInstanceOf(CubeSandboxError);
+      expect(err).toBeInstanceOf(Error);
+      expect(err).toBeInstanceOf(Ctor);
+      expect(err.name).toBe(name);
+      expect(err.message).toBe("boom");
+      expect(err.statusCode).toBe(404);
+    });
+  }
+
+  it("CubeSandboxError carries an optional statusCode", () => {
+    expect(new CubeSandboxError("x").statusCode).toBeUndefined();
+    expect(new CubeSandboxError("x", 500).statusCode).toBe(500);
+  });
+
+  it("distinguishes sibling error subclasses", () => {
+    const err = new AuthenticationError("nope", 401);
+    expect(err).not.toBeInstanceOf(ApiError);
+    expect(err).not.toBeInstanceOf(SandboxNotFoundError);
+  });
+});
+
+describe("PartialWriteError", () => {
+  it("records how many files were written before failure", () => {
+    const err = new PartialWriteError("failed at /tmp/b.txt", 2);
+    expect(err).toBeInstanceOf(CubeSandboxError);
+    expect(err).toBeInstanceOf(PartialWriteError);
+    expect(err.name).toBe("PartialWriteError");
+    expect(err.written).toBe(2);
+    expect(err.message).toContain("/tmp/b.txt");
+  });
+});

--- a/sdk/node/test/filesystem-watch.test.ts
+++ b/sdk/node/test/filesystem-watch.test.ts
@@ -1,0 +1,178 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { createServer, type IncomingHttpHeaders, type Server } from "node:http";
+import type { AddressInfo } from "node:net";
+
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+
+import { Config } from "../src/config.js";
+import type { WatchEvent } from "../src/filesystem.js";
+import { Sandbox } from "../src/index.js";
+import { stubCubeEnv } from "./_env.js";
+
+stubCubeEnv();
+
+const SANDBOX_ID = "sb-test-001";
+const DOMAIN = "cube.app";
+const SANDBOX_DATA = {
+  sandboxID: SANDBOX_ID,
+  templateID: "tpl-test",
+  domain: DOMAIN,
+  state: "running",
+};
+
+interface RecordedRequest {
+  method: string;
+  pathname: string;
+  headers: IncomingHttpHeaders;
+  body: Buffer;
+}
+
+interface MockResponse {
+  status?: number;
+  buffer?: Buffer;
+}
+
+type Handler = (req: RecordedRequest) => MockResponse;
+
+let server: Server;
+let port: number;
+let requests: RecordedRequest[] = [];
+let handler: Handler = () => ({ status: 201 });
+
+/** Build a single Connect protocol envelope: [flags:1][len:4 BE][payload]. */
+function connectFrame(flags: number, payload: string): Buffer {
+  const raw = Buffer.from(payload, "utf-8");
+  const header = Buffer.alloc(5);
+  header.writeUInt8(flags, 0);
+  header.writeUInt32BE(raw.length, 1);
+  return Buffer.concat([header, raw]);
+}
+
+function makeConfig(): Config {
+  return new Config({
+    apiUrl: `http://127.0.0.1:${port}`,
+    templateId: "tpl-test",
+    proxyNodeIp: "127.0.0.1",
+    proxyPort: port,
+    sandboxDomain: DOMAIN,
+  });
+}
+
+async function createSandbox(): Promise<Sandbox> {
+  handler = () => ({ status: 201, buffer: Buffer.from(JSON.stringify(SANDBOX_DATA)) });
+  const sb = await Sandbox.create({ config: makeConfig() });
+  requests = [];
+  return sb;
+}
+
+async function drain(watcher: AsyncIterable<WatchEvent>): Promise<WatchEvent[]> {
+  const events: WatchEvent[] = [];
+  for await (const ev of watcher) {
+    events.push(ev);
+  }
+  return events;
+}
+
+beforeAll(async () => {
+  server = createServer((req, res) => {
+    const chunks: Buffer[] = [];
+    req.on("data", (c: Buffer) => chunks.push(c));
+    req.on("end", () => {
+      const url = new URL(req.url ?? "/", "http://localhost");
+      requests.push({
+        method: req.method ?? "",
+        pathname: url.pathname,
+        headers: req.headers,
+        body: Buffer.concat(chunks),
+      });
+      const out = handler(requests[requests.length - 1]);
+      res.writeHead(out.status ?? 200);
+      res.end(out.buffer ?? "");
+    });
+  });
+  await new Promise<void>((resolve) => server.listen(0, resolve));
+  port = (server.address() as AddressInfo).port;
+});
+
+afterAll(() => {
+  server.close();
+});
+
+afterEach(() => {
+  requests = [];
+});
+
+describe("Filesystem.watchDir / Watcher", () => {
+  it("streams filesystem events until the end-of-stream frame", async () => {
+    const sb = await createSandbox();
+    handler = (req) => {
+      expect(req.method).toBe("POST");
+      expect(req.pathname).toBe("/filesystem.Filesystem/WatchDir");
+      // The requested path is carried inside a Connect envelope.
+      expect(req.body.subarray(5).toString()).toContain("/tmp");
+      return {
+        status: 200,
+        buffer: Buffer.concat([
+          connectFrame(0, JSON.stringify({ filesystem: { name: "a.txt", type: "create" } })),
+          connectFrame(0, JSON.stringify({ filesystem: { name: "b.txt", type: "write" } })),
+          connectFrame(0x02, "{}"),
+        ]),
+      };
+    };
+
+    const watcher = await sb.files.watchDir("/tmp");
+    const events = await drain(watcher);
+    expect(events).toEqual([
+      { name: "a.txt", type: "create" },
+      { name: "b.txt", type: "write" },
+    ]);
+    watcher.close();
+    sb.close();
+  });
+
+  it("ignores frames without a filesystem payload", async () => {
+    const sb = await createSandbox();
+    handler = () => ({
+      status: 200,
+      buffer: Buffer.concat([
+        connectFrame(0, JSON.stringify({ keepalive: true })),
+        connectFrame(0, JSON.stringify({ filesystem: { name: "only.txt", type: "remove" } })),
+        connectFrame(0x02, "{}"),
+      ]),
+    });
+    const events = await drain(await sb.files.watchDir("/tmp"));
+    expect(events).toEqual([{ name: "only.txt", type: "remove" }]);
+    sb.close();
+  });
+
+  it("throws when the end-of-stream frame carries an error", async () => {
+    const sb = await createSandbox();
+    handler = () => ({
+      status: 200,
+      buffer: connectFrame(0x02, JSON.stringify({ error: { message: "watch boom" } })),
+    });
+    const watcher = await sb.files.watchDir("/tmp");
+    await expect(drain(watcher)).rejects.toThrow(/watch boom/);
+    sb.close();
+  });
+
+  it("rejects when WatchDir returns an error status", async () => {
+    const sb = await createSandbox();
+    handler = () => ({ status: 500 });
+    await expect(sb.files.watchDir("/tmp")).rejects.toThrow(/WatchDir failed: HTTP 500/);
+    sb.close();
+  });
+
+  it("close() is idempotent and safe to call before iterating", async () => {
+    const sb = await createSandbox();
+    handler = () => ({ status: 200, buffer: connectFrame(0x02, "{}") });
+    const watcher = await sb.files.watchDir("/tmp");
+    expect(() => {
+      watcher.close();
+      watcher.close();
+    }).not.toThrow();
+    sb.close();
+  });
+});

--- a/sdk/node/test/filesystem.test.ts
+++ b/sdk/node/test/filesystem.test.ts
@@ -1,0 +1,292 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { createServer, type IncomingHttpHeaders, type Server } from "node:http";
+import type { AddressInfo } from "node:net";
+
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+
+import { Config } from "../src/config.js";
+import { FilesystemNotFoundError, PartialWriteError } from "../src/exceptions.js";
+import { Sandbox } from "../src/index.js";
+
+const SANDBOX_ID = "sb-test-001";
+const DOMAIN = "cube.app";
+const SANDBOX_DATA = {
+  sandboxID: SANDBOX_ID,
+  templateID: "tpl-test",
+  domain: DOMAIN,
+  state: "running",
+};
+
+interface RecordedRequest {
+  method: string;
+  pathname: string;
+  url: URL;
+  headers: IncomingHttpHeaders;
+  body: Buffer;
+}
+
+interface MockResponse {
+  status?: number;
+  json?: unknown;
+  text?: string;
+  headers?: Record<string, string>;
+}
+
+type Handler = (req: RecordedRequest) => MockResponse;
+
+let server: Server;
+let port: number;
+let requests: RecordedRequest[] = [];
+let handler: Handler = () => ({ status: 201, json: SANDBOX_DATA });
+
+function makeConfig(): Config {
+  return new Config({
+    apiUrl: `http://127.0.0.1:${port}`,
+    templateId: "tpl-test",
+    proxyNodeIp: "127.0.0.1",
+    proxyPort: port,
+    sandboxDomain: DOMAIN,
+  });
+}
+
+async function createSandbox(): Promise<Sandbox> {
+  handler = () => ({ status: 201, json: SANDBOX_DATA });
+  const sb = await Sandbox.create({ config: makeConfig() });
+  requests = [];
+  return sb;
+}
+
+beforeAll(async () => {
+  server = createServer((req, res) => {
+    const chunks: Buffer[] = [];
+    req.on("data", (c: Buffer) => chunks.push(c));
+    req.on("end", () => {
+      const url = new URL(req.url ?? "/", "http://localhost");
+      const record: RecordedRequest = {
+        method: req.method ?? "",
+        pathname: url.pathname,
+        url,
+        headers: req.headers,
+        body: Buffer.concat(chunks),
+      };
+      requests.push(record);
+      const out = handler(record);
+      const headers: Record<string, string> = { ...(out.headers ?? {}) };
+      let payload = "";
+      if (out.text !== undefined) {
+        payload = out.text;
+      } else if (out.json !== undefined) {
+        payload = JSON.stringify(out.json);
+        headers["content-type"] ??= "application/json";
+      }
+      res.writeHead(out.status ?? 200, headers);
+      res.end(payload);
+    });
+  });
+  await new Promise<void>((resolve) => server.listen(0, resolve));
+  port = (server.address() as AddressInfo).port;
+});
+
+afterAll(() => {
+  server.close();
+});
+
+afterEach(() => {
+  requests = [];
+});
+
+describe("Filesystem.read", () => {
+  it("GETs /files with path + username and returns the raw body", async () => {
+    const sb = await createSandbox();
+    handler = (req) => {
+      expect(req.method).toBe("GET");
+      expect(req.pathname).toBe("/files");
+      expect(req.headers.host).toBe(`49983-${SANDBOX_ID}.${DOMAIN}`);
+      expect(req.url.searchParams.get("path")).toBe("/tmp/foo.txt");
+      expect(req.url.searchParams.get("username")).toBe("root");
+      return { status: 200, text: "file content" };
+    };
+    expect(await sb.files.read("/tmp/foo.txt")).toBe("file content");
+    sb.close();
+  });
+});
+
+describe("Filesystem.write", () => {
+  it("writes as application/octet-stream on the first attempt", async () => {
+    const sb = await createSandbox();
+    handler = (req) => {
+      expect(req.method).toBe("POST");
+      expect(req.pathname).toBe("/files");
+      expect(req.headers["content-type"]).toBe("application/octet-stream");
+      expect(req.body.toString()).toBe("file content");
+      return { status: 200, json: [{ path: "/tmp/foo.txt" }] };
+    };
+    await sb.files.write("/tmp/foo.txt", "file content");
+    expect(requests).toHaveLength(1);
+    sb.close();
+  });
+
+  it("falls back to multipart form-data when octet-stream is rejected", async () => {
+    const sb = await createSandbox();
+    let calls = 0;
+    handler = (req) => {
+      calls += 1;
+      if (calls === 1) {
+        return { status: 415, text: "unsupported media type" };
+      }
+      expect(req.headers["content-type"]).toMatch(/multipart\/form-data/);
+      expect(req.body.toString()).toContain("file content");
+      return { status: 200, json: [{ path: "/tmp/foo.txt" }] };
+    };
+    await sb.files.write("/tmp/foo.txt", "file content");
+    expect(calls).toBe(2);
+    sb.close();
+  });
+});
+
+describe("Filesystem.writeFiles", () => {
+  it("returns the number of files written", async () => {
+    const sb = await createSandbox();
+    const paths: Array<string | null> = [];
+    handler = (req) => {
+      paths.push(req.url.searchParams.get("path"));
+      return { status: 200, json: [] };
+    };
+    const n = await sb.files.writeFiles([
+      { path: "/tmp/a.txt", data: "aaa" },
+      { path: "/tmp/b.txt", data: "bbb" },
+      { path: "/tmp/c.txt", data: "ccc" },
+    ]);
+    expect(n).toBe(3);
+    expect(paths).toEqual(["/tmp/a.txt", "/tmp/b.txt", "/tmp/c.txt"]);
+    sb.close();
+  });
+
+  it("throws PartialWriteError recording the successful count", async () => {
+    const sb = await createSandbox();
+    handler = (req) => {
+      if (req.url.searchParams.get("path") === "/tmp/b.txt") {
+        return { status: 500, json: { message: "disk full" } };
+      }
+      return { status: 200, json: [] };
+    };
+    let thrown: unknown;
+    try {
+      await sb.files.writeFiles([
+        { path: "/tmp/a.txt", data: "ok" },
+        { path: "/tmp/b.txt", data: "fail" },
+        { path: "/tmp/c.txt", data: "skip" },
+      ]);
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toBeInstanceOf(PartialWriteError);
+    expect((thrown as PartialWriteError).written).toBe(1);
+    sb.close();
+  });
+});
+
+describe("Filesystem RPCs", () => {
+  it("lists a directory via ListDir", async () => {
+    const sb = await createSandbox();
+    handler = (req) => {
+      expect(req.method).toBe("POST");
+      expect(req.pathname).toBe("/filesystem.Filesystem/ListDir");
+      expect(JSON.parse(req.body.toString())).toEqual({ path: "/tmp" });
+      return {
+        status: 200,
+        json: {
+          entries: [
+            { name: "a.txt", type: "FILE_TYPE_FILE", path: "/tmp/a.txt" },
+            { name: "sub", type: "FILE_TYPE_DIRECTORY", path: "/tmp/sub" },
+          ],
+        },
+      };
+    };
+    const entries = await sb.files.list("/tmp");
+    expect(entries).toHaveLength(2);
+    expect(entries[0].name).toBe("a.txt");
+    expect(entries[1].type).toBe("FILE_TYPE_DIRECTORY");
+    sb.close();
+  });
+
+  it("stats a path and returns the entry", async () => {
+    const sb = await createSandbox();
+    handler = (req) => {
+      expect(req.pathname).toBe("/filesystem.Filesystem/Stat");
+      expect(JSON.parse(req.body.toString())).toEqual({ path: "/tmp/hello.txt" });
+      return {
+        status: 200,
+        json: { entry: { name: "hello.txt", type: "FILE_TYPE_FILE", size: "30" } },
+      };
+    };
+    const entry = await sb.files.stat("/tmp/hello.txt");
+    expect(entry.name).toBe("hello.txt");
+    expect(entry.size).toBe("30");
+    sb.close();
+  });
+
+  it("maps a 404 stat to FilesystemNotFoundError", async () => {
+    const sb = await createSandbox();
+    handler = () => ({ status: 404, json: { code: "not_found", message: "file not found" } });
+    await expect(sb.files.stat("/tmp/missing.txt")).rejects.toBeInstanceOf(
+      FilesystemNotFoundError,
+    );
+    sb.close();
+  });
+
+  it("exists returns true when the path is present", async () => {
+    const sb = await createSandbox();
+    handler = () => ({ status: 200, json: { entry: { name: "f.txt" } } });
+    expect(await sb.files.exists("/tmp/f.txt")).toBe(true);
+    sb.close();
+  });
+
+  it("exists returns false on a 404", async () => {
+    const sb = await createSandbox();
+    handler = () => ({ status: 404, json: { code: "not_found", message: "missing" } });
+    expect(await sb.files.exists("/tmp/missing.txt")).toBe(false);
+    sb.close();
+  });
+
+  it("makes a directory via MakeDir", async () => {
+    const sb = await createSandbox();
+    handler = (req) => {
+      expect(req.pathname).toBe("/filesystem.Filesystem/MakeDir");
+      expect(JSON.parse(req.body.toString())).toEqual({ path: "/tmp/newdir" });
+      return { status: 200, json: { entry: { name: "newdir", type: "FILE_TYPE_DIRECTORY" } } };
+    };
+    const entry = await sb.files.makeDir("/tmp/newdir");
+    expect(entry.type).toBe("FILE_TYPE_DIRECTORY");
+    sb.close();
+  });
+
+  it("renames via Move with source/destination", async () => {
+    const sb = await createSandbox();
+    handler = (req) => {
+      expect(req.pathname).toBe("/filesystem.Filesystem/Move");
+      expect(JSON.parse(req.body.toString())).toEqual({
+        source: "/tmp/old.txt",
+        destination: "/tmp/new.txt",
+      });
+      return { status: 200, json: { entry: { name: "new.txt" } } };
+    };
+    const entry = await sb.files.rename("/tmp/old.txt", "/tmp/new.txt");
+    expect(entry.name).toBe("new.txt");
+    sb.close();
+  });
+
+  it("removes a path via Remove", async () => {
+    const sb = await createSandbox();
+    handler = (req) => {
+      expect(req.pathname).toBe("/filesystem.Filesystem/Remove");
+      expect(JSON.parse(req.body.toString())).toEqual({ path: "/tmp/old.txt" });
+      return { status: 200, json: {} };
+    };
+    await sb.files.remove("/tmp/old.txt");
+    expect(requests).toHaveLength(1);
+    sb.close();
+  });
+});

--- a/sdk/node/test/integration.test.ts
+++ b/sdk/node/test/integration.test.ts
@@ -1,0 +1,43 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// End-to-end tests against a live CubeAPI. Skipped unless CUBE_RUN_INTEGRATION="1".
+//
+// Required environment (read by Config):
+//   CUBE_API_URL, CUBE_TEMPLATE_ID, CUBE_PROXY_NODE_IP, CUBE_PROXY_PORT_HTTP,
+//   CUBE_SANDBOX_DOMAIN
+//
+// Run with, e.g.:
+//   CUBE_RUN_INTEGRATION=1 CUBE_API_URL=... CUBE_TEMPLATE_ID=... npm test
+
+import { describe, expect, it } from "vitest";
+
+import { Config } from "../src/config.js";
+import { Sandbox } from "../src/index.js";
+
+const RUN_INTEGRATION = process.env.CUBE_RUN_INTEGRATION === "1";
+
+describe.skipIf(!RUN_INTEGRATION)("integration (live CubeAPI)", () => {
+  it(
+    "creates a sandbox, runs code and commands, writes/reads a file, then kills it",
+    async () => {
+      const config = new Config();
+      const sb = await Sandbox.create({ config });
+      try {
+        const execution = await sb.runCode("1+1");
+        expect(execution.text).toBe("2");
+
+        const cmd = await sb.commands.run("echo hello");
+        expect(cmd.exitCode).toBe(0);
+        expect(cmd.stdout).toContain("hello");
+
+        await sb.files.write("/tmp/cube-sdk-e2e.txt", "cube");
+        expect(await sb.files.read("/tmp/cube-sdk-e2e.txt")).toBe("cube");
+      } finally {
+        await sb.kill();
+        sb.close();
+      }
+    },
+    60_000,
+  );
+});

--- a/sdk/node/test/models.test.ts
+++ b/sdk/node/test/models.test.ts
@@ -1,0 +1,123 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+
+import {
+  Execution,
+  ExecutionError,
+  Logs,
+  OutputMessage,
+  Result,
+  SnapshotInfo,
+} from "../src/models.js";
+
+describe("Result", () => {
+  it("defaults isMainResult to false", () => {
+    expect(new Result({ text: "x" }).isMainResult).toBe(false);
+  });
+
+  it("parses is_main_result from the wire payload", () => {
+    expect(new Result({ text: "42", is_main_result: true }).isMainResult).toBe(true);
+  });
+
+  it("exposes jsonData as an alias for json", () => {
+    const result = new Result({ json: { a: 1 }, data: { b: 2 }, chart: { type: "bar" } });
+    expect(result.json).toEqual({ a: 1 });
+    expect(result.jsonData).toEqual({ a: 1 });
+    expect(result.data).toEqual({ b: 2 });
+    expect(result.chart).toEqual({ type: "bar" });
+  });
+
+  it("accepts the legacy json_data constructor key", () => {
+    expect(new Result({ json_data: { a: 1 } }).json).toEqual({ a: 1 });
+  });
+
+  it("lists only the formats that are present", () => {
+    const result = new Result({ json: { a: 1 }, data: { b: 2 }, chart: { type: "bar" } });
+    expect(new Set(result.formats())).toEqual(new Set(["json", "data", "chart"]));
+  });
+
+  it("includes extra keys in formats()", () => {
+    const result = new Result({ text: "hi", extra: { custom: "value" } });
+    expect(result.formats()).toContain("text");
+    expect(result.formats()).toContain("custom");
+  });
+});
+
+describe("Execution", () => {
+  it("returns the text of the main result", () => {
+    const ex = new Execution();
+    ex.results.push(new Result({ text: "side", is_main_result: false }));
+    ex.results.push(new Result({ text: "42", is_main_result: true }));
+    expect(ex.text).toBe("42");
+  });
+
+  it("returns undefined when there are no results", () => {
+    expect(new Execution().text).toBeUndefined();
+  });
+
+  it("returns undefined when no result is the main result", () => {
+    const ex = new Execution();
+    ex.results.push(new Result({ text: "x", is_main_result: false }));
+    expect(ex.text).toBeUndefined();
+  });
+
+  it("starts with empty logs and no error", () => {
+    const ex = new Execution();
+    expect(ex.logs.stdout).toEqual([]);
+    expect(ex.logs.stderr).toEqual([]);
+    expect(ex.error).toBeNull();
+    expect(ex.executionCount).toBeNull();
+  });
+});
+
+describe("ExecutionError", () => {
+  it("joins a traceback array into a newline-separated string", () => {
+    const err = new ExecutionError("ValueError", "bad", ["line1", "line2"]);
+    expect(err.traceback).toBe("line1\nline2");
+  });
+
+  it("defaults the traceback to an empty string", () => {
+    expect(new ExecutionError("e", "v").traceback).toBe("");
+  });
+});
+
+describe("Logs", () => {
+  it("serializes stdout and stderr via toJSON", () => {
+    const logs = new Logs();
+    logs.stdout.push("a");
+    logs.stderr.push("b");
+    expect(logs.toJSON()).toEqual({ stdout: ["a"], stderr: ["b"] });
+  });
+});
+
+describe("OutputMessage", () => {
+  it("exposes text and isStderr aliases", () => {
+    const msg = new OutputMessage("hello\n", 123, true);
+    expect(msg.line).toBe("hello\n");
+    expect(msg.text).toBe("hello\n");
+    expect(msg.error).toBe(true);
+    expect(msg.isStderr).toBe(true);
+    expect(String(msg)).toBe("hello\n");
+  });
+
+  it("defaults to a non-error stdout message", () => {
+    const msg = new OutputMessage("out\n");
+    expect(msg.isStderr).toBe(false);
+  });
+});
+
+describe("SnapshotInfo", () => {
+  it("parses snapshotID and names from a wire dict", () => {
+    const info = SnapshotInfo.fromDict({ snapshotID: "snap-1", names: ["a", "b"] });
+    expect(info.snapshotId).toBe("snap-1");
+    expect(info.names).toEqual(["a", "b"]);
+  });
+
+  it("defaults names to an empty array", () => {
+    const info = SnapshotInfo.fromDict({ snapshotID: "snap-2" });
+    expect(info.snapshotId).toBe("snap-2");
+    expect(info.names).toEqual([]);
+  });
+});

--- a/sdk/node/test/policy.test.ts
+++ b/sdk/node/test/policy.test.ts
@@ -1,0 +1,192 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+
+import { ApiError } from "../src/exceptions.js";
+import {
+  convertE2BPerHostRules,
+  normalizeRulesArg,
+  renderInject,
+  serializeRule,
+  validateAllowOutDomainsRequireDenyAll,
+  type Rule,
+} from "../src/policy.js";
+
+describe("serializeRule", () => {
+  it("drops undefined match fields and always includes allow", () => {
+    const wire = serializeRule({
+      name: "r1",
+      match: { host: "example.com" },
+      action: { allow: false },
+    });
+    expect(wire).toEqual({
+      name: "r1",
+      match: { host: "example.com" },
+      action: { allow: false },
+    });
+    expect((wire.match as Record<string, unknown>).scheme).toBeUndefined();
+  });
+
+  it("serializes a fully populated match", () => {
+    const wire = serializeRule({
+      name: "deepseek_api",
+      match: {
+        scheme: "https",
+        host: "api.deepseek.com",
+        method: ["POST"],
+        path: "/v1/chat",
+        sni: "api.deepseek.com",
+      },
+      action: { allow: true, audit: "metadata" },
+    });
+    expect(wire).toEqual({
+      name: "deepseek_api",
+      match: {
+        scheme: "https",
+        host: "api.deepseek.com",
+        method: ["POST"],
+        path: "/v1/chat",
+        sni: "api.deepseek.com",
+      },
+      action: { allow: true, audit: "metadata" },
+    });
+  });
+
+  it("serializes injected credentials", () => {
+    const wire = serializeRule({
+      name: "r1",
+      match: { host: "api.example.com" },
+      action: {
+        allow: true,
+        inject: [{ header: "Authorization", format: "Bearer ${SECRET}", secret: "sk_xxx" }],
+      },
+    });
+    expect((wire.action as Record<string, unknown>).inject).toEqual([
+      { header: "Authorization", secret: "sk_xxx", format: "Bearer ${SECRET}" },
+    ]);
+  });
+});
+
+describe("renderInject", () => {
+  it("substitutes the secret into a custom format", () => {
+    expect(
+      renderInject({ header: "Authorization", format: "Bearer ${SECRET}", secret: "sk_xxx" }),
+    ).toBe("Bearer sk_xxx");
+  });
+
+  it("defaults to the bare secret when no format is provided", () => {
+    expect(renderInject({ header: "X-Token", secret: "abc" })).toBe("abc");
+  });
+});
+
+describe("convertE2BPerHostRules", () => {
+  it("maps a single host + single header to one rule", () => {
+    const rules = convertE2BPerHostRules({
+      "api.example.com": [{ transform: { headers: { "X-Header": "Content" } } }],
+    });
+    expect(rules).toEqual([
+      {
+        name: "e2b-transform-api.example.com",
+        match: { host: "api.example.com" },
+        action: { allow: true, inject: [{ header: "X-Header", secret: "Content" }] },
+      },
+    ]);
+  });
+
+  it("preserves header insertion order for a single entry", () => {
+    const rules = convertE2BPerHostRules({
+      "api.example.com": [
+        { transform: { headers: { Authorization: "Bearer sk_xxx", "X-Trace": "on" } } },
+      ],
+    });
+    expect(rules[0].action.inject).toEqual([
+      { header: "Authorization", secret: "Bearer sk_xxx" },
+      { header: "X-Trace", secret: "on" },
+    ]);
+  });
+
+  it("indexes rule names when a host has multiple entries", () => {
+    const rules = convertE2BPerHostRules({
+      "api.example.com": [
+        { transform: { headers: { "X-A": "1" } } },
+        { transform: { headers: { "X-B": "2" } } },
+      ],
+    });
+    expect(rules.map((r) => r.name)).toEqual([
+      "e2b-transform-api.example.com-0",
+      "e2b-transform-api.example.com-1",
+    ]);
+  });
+
+  it("fans out multiple hosts preserving order", () => {
+    const rules = convertE2BPerHostRules({
+      "api.example.com": [{ transform: { headers: { "X-A": "1" } } }],
+      "api.other.com": [{ transform: { headers: { "X-B": "2" } } }],
+    });
+    expect(rules.map((r) => r.match.host)).toEqual(["api.example.com", "api.other.com"]);
+  });
+});
+
+describe("normalizeRulesArg", () => {
+  it("returns an empty array for undefined input", () => {
+    expect(normalizeRulesArg(undefined)).toEqual([]);
+  });
+
+  it("passes a typed Rule array through unchanged", () => {
+    const rules: Rule[] = [
+      { name: "r1", match: { host: "x.com" }, action: { allow: true } },
+    ];
+    expect(normalizeRulesArg(rules)).toEqual(rules);
+  });
+
+  it("converts an E2B per-host mapping into rules", () => {
+    const rules = normalizeRulesArg({
+      "api.example.com": [{ transform: { headers: { "X-Header": "Content" } } }],
+    });
+    expect(rules).toEqual([
+      {
+        name: "e2b-transform-api.example.com",
+        match: { host: "api.example.com" },
+        action: { allow: true, inject: [{ header: "X-Header", secret: "Content" }] },
+      },
+    ]);
+  });
+});
+
+describe("validateAllowOutDomainsRequireDenyAll", () => {
+  it("throws ApiError(400) when a domain is allowed without deny-all", () => {
+    let thrown: unknown;
+    try {
+      validateAllowOutDomainsRequireDenyAll(["api.example.com"], ["203.0.113.0/24"]);
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toBeInstanceOf(ApiError);
+    expect((thrown as ApiError).statusCode).toBe(400);
+  });
+
+  it("passes when 0.0.0.0/0 is present in denyOut", () => {
+    expect(() =>
+      validateAllowOutDomainsRequireDenyAll(["api.example.com"], ["0.0.0.0/0"]),
+    ).not.toThrow();
+  });
+
+  it("passes when defaultDenyAll is true", () => {
+    expect(() =>
+      validateAllowOutDomainsRequireDenyAll(["api.example.com"], undefined, true),
+    ).not.toThrow();
+  });
+
+  it("ignores pure-IP / CIDR allowOut targets", () => {
+    expect(() => validateAllowOutDomainsRequireDenyAll(["8.8.8.8/32"])).not.toThrow();
+    expect(() => validateAllowOutDomainsRequireDenyAll(["8.8.8.8"])).not.toThrow();
+    expect(() => validateAllowOutDomainsRequireDenyAll([])).not.toThrow();
+  });
+
+  it("accepts wildcard domains when deny-all is present", () => {
+    expect(() =>
+      validateAllowOutDomainsRequireDenyAll(["*.example.com"], ["0.0.0.0/0"]),
+    ).not.toThrow();
+  });
+});

--- a/sdk/node/test/pty.test.ts
+++ b/sdk/node/test/pty.test.ts
@@ -1,0 +1,390 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+  createServer,
+  type IncomingHttpHeaders,
+  type Server,
+  type ServerResponse,
+} from "node:http";
+import type { AddressInfo } from "node:net";
+
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+
+import { Config } from "../src/config.js";
+import { Sandbox, type PtyOutput } from "../src/index.js";
+
+const SANDBOX_ID = "sb-pty-001";
+const DOMAIN = "cube.app";
+const SANDBOX_DATA = {
+  sandboxID: SANDBOX_ID,
+  templateID: "tpl-test",
+  domain: DOMAIN,
+  state: "running",
+};
+
+interface RecordedRequest {
+  method: string;
+  pathname: string;
+  headers: IncomingHttpHeaders;
+  body: Buffer;
+}
+
+interface MockResponse {
+  status?: number;
+  json?: unknown;
+  buffer?: Buffer;
+  headers?: Record<string, string>;
+}
+
+type Handler = (req: RecordedRequest) => MockResponse;
+
+let server: Server;
+let port: number;
+let requests: RecordedRequest[] = [];
+let handler: Handler = () => ({ status: 201, json: SANDBOX_DATA });
+
+/** Build a single Connect protocol envelope: [flags:1][len:4 BE][payload]. */
+function connectFrame(flags: number, payload: string): Buffer {
+  const raw = Buffer.from(payload, "utf-8");
+  const header = Buffer.alloc(5);
+  header.writeUInt8(flags, 0);
+  header.writeUInt32BE(raw.length, 1);
+  return Buffer.concat([header, raw]);
+}
+
+/** Decode the JSON payload out of a data (flags=0) Connect envelope. */
+function decodeConnectPayload(raw: Buffer): Record<string, any> {
+  const flags = raw.readUInt8(0);
+  const size = raw.readUInt32BE(1);
+  expect(flags).toBe(0);
+  expect(raw.length).toBe(5 + size);
+  return JSON.parse(raw.slice(5, 5 + size).toString("utf-8"));
+}
+
+function b64(text: string): string {
+  return Buffer.from(text, "utf-8").toString("base64");
+}
+
+function makeConfig(): Config {
+  return new Config({
+    apiUrl: `http://127.0.0.1:${port}`,
+    templateId: "tpl-test",
+    proxyNodeIp: "127.0.0.1",
+    proxyPort: port,
+    sandboxDomain: DOMAIN,
+  });
+}
+
+async function createSandbox(): Promise<Sandbox> {
+  handler = () => ({ status: 201, json: SANDBOX_DATA });
+  const sb = await Sandbox.create({ config: makeConfig() });
+  requests = [];
+  return sb;
+}
+
+beforeAll(async () => {
+  server = createServer((req, res) => {
+    const chunks: Buffer[] = [];
+    req.on("data", (c: Buffer) => chunks.push(c));
+    req.on("end", () => {
+      const url = new URL(req.url ?? "/", "http://localhost");
+      const record: RecordedRequest = {
+        method: req.method ?? "",
+        pathname: url.pathname,
+        headers: req.headers,
+        body: Buffer.concat(chunks),
+      };
+      requests.push(record);
+      const out = handler(record);
+      const headers: Record<string, string> = { ...(out.headers ?? {}) };
+      let payload: string | Buffer = "";
+      if (out.buffer !== undefined) {
+        payload = out.buffer;
+      } else if (out.json !== undefined) {
+        payload = JSON.stringify(out.json);
+        headers["content-type"] ??= "application/json";
+      }
+      res.writeHead(out.status ?? 200, headers);
+      res.end(payload);
+    });
+  });
+  await new Promise<void>((resolve) => server.listen(0, resolve));
+  port = (server.address() as AddressInfo).port;
+});
+
+afterAll(() => {
+  server.close();
+});
+
+afterEach(() => {
+  requests = [];
+});
+
+describe("Pty.create", () => {
+  it("streams output, resolves pid, and returns the exit code", async () => {
+    const sb = await createSandbox();
+    handler = (req) => {
+      expect(req.method).toBe("POST");
+      expect(req.pathname).toBe("/process.Process/Start");
+      expect(req.headers.host).toBe(`49983-${SANDBOX_ID}.${DOMAIN}`);
+      expect(req.headers["content-type"]).toBe("application/connect+json");
+      expect(req.headers["connect-timeout-ms"]).toBe("60000");
+      const payload = decodeConnectPayload(req.body);
+      expect(payload.process.cmd).toBe("/bin/bash");
+      expect(payload.process.args).toEqual(["-i", "-l"]);
+      expect(payload.process.envs).toMatchObject({
+        TERM: "xterm-256color",
+        LANG: "C.UTF-8",
+        LC_ALL: "C.UTF-8",
+      });
+      expect(payload.pty.size).toEqual({ rows: 24, cols: 80 });
+      return {
+        status: 200,
+        buffer: Buffer.concat([
+          connectFrame(0, '{"event":{"start":{"pid":4242}}}'),
+          connectFrame(0, JSON.stringify({ event: { data: { pty: b64("hi> ") } } })),
+          connectFrame(0, JSON.stringify({ event: { data: { pty: b64("done\n") } } })),
+          connectFrame(0, '{"event":{"end":{"exitCode":0,"exited":true}}}'),
+          connectFrame(0x02, "{}"),
+        ]),
+      };
+    };
+
+    const handle = await sb.pty.create({ rows: 24, cols: 80 });
+    expect(handle.pid).toBe(4242);
+
+    const collected: PtyOutput[] = [];
+    const code = await handle.wait((chunk) => collected.push(chunk));
+    expect(code).toBe(0);
+    expect(handle.exitCode).toBe(0);
+    expect(Buffer.concat(collected.map((c) => Buffer.from(c))).toString("utf-8")).toBe("hi> done\n");
+    sb.close();
+  });
+
+  it("merges caller envs/cwd and lets the caller override TERM", async () => {
+    const sb = await createSandbox();
+    let seen: Record<string, any> = {};
+    handler = (req) => {
+      seen = decodeConnectPayload(req.body);
+      return {
+        status: 200,
+        buffer: Buffer.concat([
+          connectFrame(0, '{"event":{"start":{"pid":7}}}'),
+          connectFrame(0, '{"event":{"end":{"exitCode":0,"exited":true}}}'),
+          connectFrame(0x02, "{}"),
+        ]),
+      };
+    };
+
+    const handle = await sb.pty.create(
+      { rows: 40, cols: 120 },
+      { cwd: "/work", envs: { TERM: "dumb", FOO: "bar" } },
+    );
+    await handle.wait();
+    expect(seen.process.cwd).toBe("/work");
+    expect(seen.process.envs).toMatchObject({ TERM: "dumb", FOO: "bar", LANG: "C.UTF-8" });
+    sb.close();
+  });
+
+  it("propagates an error delivered on the end-of-stream frame", async () => {
+    const sb = await createSandbox();
+    handler = () => ({
+      status: 200,
+      buffer: Buffer.concat([
+        connectFrame(0, '{"event":{"start":{"pid":9}}}'),
+        connectFrame(0x02, '{"error":{"code":"internal","message":"pty boom"}}'),
+      ]),
+    });
+    const handle = await sb.pty.create({ rows: 24, cols: 80 });
+    await expect(handle.wait()).rejects.toThrow(/pty boom/);
+    sb.close();
+  });
+
+  it("raises when the stream closes before a start event", async () => {
+    const sb = await createSandbox();
+    handler = () => ({ status: 200, buffer: connectFrame(0x02, "{}") });
+    await expect(sb.pty.create({ rows: 24, cols: 80 })).rejects.toThrow(
+      /stream closed before start event/,
+    );
+    sb.close();
+  });
+
+  it("maps an HTTP error to ApiError", async () => {
+    const sb = await createSandbox();
+    handler = () => ({ status: 503, json: { message: "unavailable" } });
+    await expect(sb.pty.create({ rows: 24, cols: 80 })).rejects.toThrow(/HTTP 503/);
+    sb.close();
+  });
+});
+
+describe("Pty.connect", () => {
+  it("reattaches to an existing PTY by pid", async () => {
+    const sb = await createSandbox();
+    handler = (req) => {
+      expect(req.pathname).toBe("/process.Process/Connect");
+      const payload = decodeConnectPayload(req.body);
+      expect(payload.process.pid).toBe(555);
+      return {
+        status: 200,
+        buffer: Buffer.concat([
+          connectFrame(0, '{"event":{"start":{"pid":555}}}'),
+          connectFrame(0, '{"event":{"end":{"exit_code":3,"exited":true}}}'),
+          connectFrame(0x02, "{}"),
+        ]),
+      };
+    };
+    const handle = await sb.pty.connect(555);
+    expect(handle.pid).toBe(555);
+    expect(await handle.wait()).toBe(3);
+    sb.close();
+  });
+});
+
+describe("Pty selector RPCs", () => {
+  it("kill sends SIGKILL via unary SendSignal and returns true", async () => {
+    const sb = await createSandbox();
+    handler = (req) => {
+      expect(req.pathname).toBe("/process.Process/SendSignal");
+      expect(req.headers["content-type"]).toBe("application/json");
+      expect(JSON.parse(req.body.toString("utf-8"))).toEqual({
+        process: { pid: 12 },
+        signal: "SIGNAL_SIGKILL",
+      });
+      return { status: 200, json: {} };
+    };
+    expect(await sb.pty.kill(12)).toBe(true);
+    sb.close();
+  });
+
+  it("kill returns false on HTTP 404", async () => {
+    const sb = await createSandbox();
+    handler = () => ({ status: 404, json: { code: "not_found" } });
+    expect(await sb.pty.kill(99)).toBe(false);
+    sb.close();
+  });
+
+  it("kill returns false on a Connect not_found body", async () => {
+    const sb = await createSandbox();
+    handler = () => ({ status: 400, json: { code: "not_found", message: "gone" } });
+    expect(await sb.pty.kill(99)).toBe(false);
+    sb.close();
+  });
+
+  it("sendStdin base64-encodes input via unary SendInput", async () => {
+    const sb = await createSandbox();
+    handler = (req) => {
+      expect(req.pathname).toBe("/process.Process/SendInput");
+      expect(JSON.parse(req.body.toString("utf-8"))).toEqual({
+        process: { pid: 5 },
+        input: { pty: b64("ls -la\n") },
+      });
+      return { status: 200, json: {} };
+    };
+    await sb.pty.sendStdin(5, "ls -la\n");
+    sb.close();
+  });
+
+  it("resize sends rows/cols via unary Update", async () => {
+    const sb = await createSandbox();
+    handler = (req) => {
+      expect(req.pathname).toBe("/process.Process/Update");
+      expect(JSON.parse(req.body.toString("utf-8"))).toEqual({
+        process: { pid: 8 },
+        pty: { size: { rows: 50, cols: 132 } },
+      });
+      return { status: 200, json: {} };
+    };
+    await sb.pty.resize(8, { rows: 50, cols: 132 });
+    sb.close();
+  });
+});
+
+describe("PtyHandle control delegates to the resolved pid", () => {
+  it("routes kill/sendStdin/resize to the started pid", async () => {
+    const sb = await createSandbox();
+    let phase: "start" | "control" = "start";
+    const controlPaths: string[] = [];
+    const controlPids: number[] = [];
+    handler = (req) => {
+      if (phase === "start") {
+        phase = "control";
+        return {
+          status: 200,
+          buffer: Buffer.concat([
+            connectFrame(0, '{"event":{"start":{"pid":314}}}'),
+            connectFrame(0, JSON.stringify({ event: { data: { pty: b64("x") } } })),
+            connectFrame(0, '{"event":{"end":{"exitCode":0,"exited":true}}}'),
+            connectFrame(0x02, "{}"),
+          ]),
+        };
+      }
+      controlPaths.push(req.pathname);
+      controlPids.push(JSON.parse(req.body.toString("utf-8")).process.pid);
+      return { status: 200, json: {} };
+    };
+
+    const handle = await sb.pty.create({ rows: 24, cols: 80 });
+    await handle.sendStdin(Buffer.from("echo\n"));
+    await handle.resize({ rows: 10, cols: 10 });
+    expect(await handle.kill()).toBe(true);
+
+    expect(controlPaths).toEqual([
+      "/process.Process/SendInput",
+      "/process.Process/Update",
+      "/process.Process/SendSignal",
+    ]);
+    expect(controlPids).toEqual([314, 314, 314]);
+    sb.close();
+  });
+});
+
+describe("PtyHandle.disconnect", () => {
+  it("stops iterating gracefully without an end event", async () => {
+    // A dedicated server that emits start + one data frame then holds the
+    // socket open, so we can exercise disconnect() mid-stream.
+    let heldRes: ServerResponse | undefined;
+    const streamServer = createServer((req, res) => {
+      req.on("data", () => {});
+      req.on("end", () => {
+        if (req.url === "/sandboxes") {
+          res.writeHead(201, { "content-type": "application/json" });
+          res.end(JSON.stringify(SANDBOX_DATA));
+          return;
+        }
+        res.writeHead(200);
+        res.write(connectFrame(0, '{"event":{"start":{"pid":21}}}'));
+        res.write(connectFrame(0, JSON.stringify({ event: { data: { pty: b64("prompt$ ") } } })));
+        heldRes = res; // never ended — held open until we disconnect
+      });
+    });
+    await new Promise<void>((resolve) => streamServer.listen(0, resolve));
+    const sp = (streamServer.address() as AddressInfo).port;
+
+    const sb = await Sandbox.create({
+      config: new Config({
+        apiUrl: `http://127.0.0.1:${sp}`,
+        templateId: "tpl-test",
+        proxyNodeIp: "127.0.0.1",
+        proxyPort: sp,
+        sandboxDomain: DOMAIN,
+      }),
+    });
+
+    try {
+      const handle = await sb.pty.create({ rows: 24, cols: 80 });
+      const it = handle[Symbol.asyncIterator]();
+      const first = await it.next();
+      expect(first.done).toBe(false);
+      expect(Buffer.from(first.value as PtyOutput).toString("utf-8")).toBe("prompt$ ");
+
+      handle.disconnect();
+      const next = await it.next();
+      expect(next.done).toBe(true);
+    } finally {
+      heldRes?.destroy();
+      sb.close();
+      await new Promise<void>((resolve) => streamServer.close(() => resolve()));
+    }
+  });
+});

--- a/sdk/node/test/sandbox.test.ts
+++ b/sdk/node/test/sandbox.test.ts
@@ -1,0 +1,535 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { createServer, type IncomingHttpHeaders, type Server } from "node:http";
+import type { AddressInfo } from "node:net";
+
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+
+import { Config } from "../src/config.js";
+import {
+  ApiError,
+  AuthenticationError,
+  SandboxNotFoundError,
+  TemplateNotFoundError,
+} from "../src/exceptions.js";
+import { Sandbox } from "../src/index.js";
+import { stubCubeEnv } from "./_env.js";
+
+stubCubeEnv();
+
+const SANDBOX_ID = "sb-test-001";
+const DOMAIN = "cube.app";
+const SANDBOX_DATA = {
+  sandboxID: SANDBOX_ID,
+  templateID: "tpl-test",
+  domain: DOMAIN,
+  state: "running",
+  cpuCount: 2,
+  memoryMB: 512,
+};
+
+interface RecordedRequest {
+  method: string;
+  pathname: string;
+  url: URL;
+  headers: IncomingHttpHeaders;
+  body: Buffer;
+}
+
+interface MockResponse {
+  status?: number;
+  json?: unknown;
+  text?: string;
+  ndjson?: string;
+  headers?: Record<string, string>;
+}
+
+type Handler = (req: RecordedRequest) => MockResponse | Promise<MockResponse>;
+
+let server: Server;
+let port: number;
+let requests: RecordedRequest[] = [];
+let handler: Handler = () => ({ status: 201, json: SANDBOX_DATA });
+
+function setHandler(h: Handler): void {
+  handler = h;
+}
+
+function makeConfig(): Config {
+  return new Config({
+    apiUrl: `http://127.0.0.1:${port}`,
+    templateId: "tpl-test",
+    proxyNodeIp: "127.0.0.1",
+    proxyPort: port,
+    sandboxDomain: DOMAIN,
+  });
+}
+
+beforeAll(async () => {
+  server = createServer((req, res) => {
+    const chunks: Buffer[] = [];
+    req.on("data", (c: Buffer) => chunks.push(c));
+    req.on("end", async () => {
+      const url = new URL(req.url ?? "/", "http://localhost");
+      const record: RecordedRequest = {
+        method: req.method ?? "",
+        pathname: url.pathname,
+        url,
+        headers: req.headers,
+        body: Buffer.concat(chunks),
+      };
+      requests.push(record);
+      let out: MockResponse;
+      try {
+        out = await handler(record);
+      } catch {
+        out = { status: 500, json: { message: "handler threw" } };
+      }
+      const headers: Record<string, string> = { ...(out.headers ?? {}) };
+      let payload = "";
+      if (out.ndjson !== undefined) {
+        payload = out.ndjson;
+      } else if (out.text !== undefined) {
+        payload = out.text;
+      } else if (out.json !== undefined) {
+        payload = JSON.stringify(out.json);
+        headers["content-type"] ??= "application/json";
+      }
+      res.writeHead(out.status ?? 200, headers);
+      res.end(payload);
+    });
+  });
+  await new Promise<void>((resolve) => server.listen(0, resolve));
+  port = (server.address() as AddressInfo).port;
+});
+
+afterAll(() => {
+  server.close();
+});
+
+afterEach(() => {
+  requests = [];
+});
+
+describe("Sandbox.create", () => {
+  it("returns a sandbox with fields parsed from the response", async () => {
+    setHandler(() => ({ status: 201, json: SANDBOX_DATA }));
+    const sb = await Sandbox.create({ config: makeConfig() });
+    expect(sb.sandboxId).toBe(SANDBOX_ID);
+    expect(sb.templateId).toBe("tpl-test");
+    expect(sb.domain).toBe(DOMAIN);
+    sb.close();
+  });
+
+  it("rejects when no template can be resolved", async () => {
+    const cfg = makeConfig();
+    cfg.templateId = null;
+    await expect(Sandbox.create({ config: cfg })).rejects.toThrow(/template is required/);
+  });
+
+  it("sends templateID and timeout on the wire", async () => {
+    setHandler(() => ({ status: 201, json: SANDBOX_DATA }));
+    const sb = await Sandbox.create({ template: "tpl-foo", timeout: 600, config: makeConfig() });
+    const body = JSON.parse(requests[0].body.toString());
+    expect(body.templateID).toBe("tpl-foo");
+    expect(body.timeout).toBe(600);
+    sb.close();
+  });
+
+  it("sends envVars and metadata", async () => {
+    setHandler(() => ({ status: 201, json: SANDBOX_DATA }));
+    const sb = await Sandbox.create({
+      envVars: { FOO: "bar" },
+      metadata: { "network-policy": "deny-all" },
+      config: makeConfig(),
+    });
+    const body = JSON.parse(requests[0].body.toString());
+    expect(body.envVars).toEqual({ FOO: "bar" });
+    expect(body.metadata).toEqual({ "network-policy": "deny-all" });
+    sb.close();
+  });
+
+  it("emits allow_internet_access only when false", async () => {
+    setHandler(() => ({ status: 201, json: SANDBOX_DATA }));
+    const sb1 = await Sandbox.create({ allowInternetAccess: false, config: makeConfig() });
+    expect(JSON.parse(requests[0].body.toString()).allow_internet_access).toBe(false);
+    sb1.close();
+
+    requests = [];
+    const sb2 = await Sandbox.create({ config: makeConfig() });
+    expect("allow_internet_access" in JSON.parse(requests[0].body.toString())).toBe(false);
+    sb2.close();
+  });
+
+  it("maps network allowOut / denyOut", async () => {
+    setHandler(() => ({ status: 201, json: SANDBOX_DATA }));
+    const sb = await Sandbox.create({
+      network: { allowOut: ["8.8.8.8/32"], denyOut: ["0.0.0.0/0"] },
+      config: makeConfig(),
+    });
+    const body = JSON.parse(requests[0].body.toString());
+    expect(body.network.allowOut).toEqual(["8.8.8.8/32"]);
+    expect(body.network.denyOut).toEqual(["0.0.0.0/0"]);
+    sb.close();
+  });
+
+  it("omits the network block for empty network options", async () => {
+    setHandler(() => ({ status: 201, json: SANDBOX_DATA }));
+    const sb = await Sandbox.create({ network: {}, config: makeConfig() });
+    expect("network" in JSON.parse(requests[0].body.toString())).toBe(false);
+    sb.close();
+  });
+
+  it("serializes typed L7 rules under network.rules", async () => {
+    setHandler(() => ({ status: 201, json: SANDBOX_DATA }));
+    const sb = await Sandbox.create({
+      network: {
+        rules: [
+          {
+            name: "github_api",
+            match: { host: "api.github.com", path: "/repos/*" },
+            action: { allow: true, audit: "metadata" },
+          },
+        ],
+      },
+      config: makeConfig(),
+    });
+    const body = JSON.parse(requests[0].body.toString());
+    expect(body.network.rules).toEqual([
+      {
+        name: "github_api",
+        match: { host: "api.github.com", path: "/repos/*" },
+        action: { allow: true, audit: "metadata" },
+      },
+    ]);
+    sb.close();
+  });
+
+  it("maps lifecycle to camelCase wire keys", async () => {
+    setHandler(() => ({ status: 201, json: SANDBOX_DATA }));
+    const sb1 = await Sandbox.create({
+      lifecycle: { onTimeout: "pause" },
+      config: makeConfig(),
+    });
+    expect(JSON.parse(requests[0].body.toString()).lifecycle).toEqual({ onTimeout: "pause" });
+    sb1.close();
+
+    requests = [];
+    const sb2 = await Sandbox.create({
+      lifecycle: { onTimeout: "pause", autoResume: true },
+      config: makeConfig(),
+    });
+    expect(JSON.parse(requests[0].body.toString()).lifecycle).toEqual({
+      onTimeout: "pause",
+      autoResume: true,
+    });
+    sb2.close();
+  });
+
+  it("omits lifecycle when not provided", async () => {
+    setHandler(() => ({ status: 201, json: SANDBOX_DATA }));
+    const sb = await Sandbox.create({ config: makeConfig() });
+    expect("lifecycle" in JSON.parse(requests[0].body.toString())).toBe(false);
+    sb.close();
+  });
+
+  it("accepts inline config fields (templateId + apiUrl) per Issue #760", async () => {
+    setHandler(() => ({ status: 201, json: SANDBOX_DATA }));
+    // No `config` and no `template` — only the flat Issue #760 shape.
+    const sb = await Sandbox.create({
+      apiUrl: `http://127.0.0.1:${port}`,
+      templateId: "tpl-inline",
+      proxyNodeIp: "127.0.0.1",
+      proxyPort: port,
+      sandboxDomain: DOMAIN,
+    });
+    expect(JSON.parse(requests[0].body.toString()).templateID).toBe("tpl-inline");
+    expect(sb.config.apiUrl).toBe(`http://127.0.0.1:${port}`);
+    expect(sb.config.proxyNodeIp).toBe("127.0.0.1");
+    sb.close();
+  });
+
+  it("lets inline fields override a passed config object", async () => {
+    setHandler(() => ({ status: 201, json: SANDBOX_DATA }));
+    const sb = await Sandbox.create({
+      config: makeConfig(),
+      apiUrl: `http://127.0.0.1:${port}`,
+      proxyScheme: "https",
+      sandboxDomain: "override.app",
+    });
+    // Flat fields win over the config object.
+    expect(sb.config.proxyScheme).toBe("https");
+    expect(sb.config.sandboxDomain).toBe("override.app");
+    sb.close();
+  });
+
+  it("prefers explicit template over templateId over config.templateId", async () => {
+    setHandler(() => ({ status: 201, json: SANDBOX_DATA }));
+    const cfg = makeConfig();
+    cfg.templateId = "tpl-from-config";
+    const sb = await Sandbox.create({
+      template: "tpl-explicit",
+      templateId: "tpl-alias",
+      config: cfg,
+    });
+    expect(JSON.parse(requests[0].body.toString()).templateID).toBe("tpl-explicit");
+    sb.close();
+  });
+
+  it("exposes the traffic access token when returned", async () => {
+    setHandler(() => ({
+      status: 201,
+      json: { ...SANDBOX_DATA, trafficAccessToken: "tok-123" },
+    }));
+    const sb = await Sandbox.create({ config: makeConfig() });
+    expect(sb.trafficAccessToken).toBe("tok-123");
+    sb.close();
+  });
+
+  it("returns a null traffic access token by default", async () => {
+    setHandler(() => ({ status: 201, json: SANDBOX_DATA }));
+    const sb = await Sandbox.create({ config: makeConfig() });
+    expect(sb.trafficAccessToken).toBeNull();
+    sb.close();
+  });
+});
+
+describe("Sandbox control-plane error mapping", () => {
+  it("maps 401 to AuthenticationError", async () => {
+    setHandler(() => ({ status: 401, json: { message: "unauthorized" } }));
+    await expect(Sandbox.create({ config: makeConfig() })).rejects.toBeInstanceOf(
+      AuthenticationError,
+    );
+  });
+
+  it("maps 404 with a template message to TemplateNotFoundError", async () => {
+    setHandler(() => ({ status: 404, json: { message: "template not found" } }));
+    await expect(Sandbox.create({ config: makeConfig() })).rejects.toBeInstanceOf(
+      TemplateNotFoundError,
+    );
+  });
+
+  it("maps 404 without a template message to SandboxNotFoundError", async () => {
+    setHandler(() => ({ status: 404, json: { message: "sandbox gone" } }));
+    await expect(Sandbox.connect(SANDBOX_ID, { config: makeConfig() })).rejects.toBeInstanceOf(
+      SandboxNotFoundError,
+    );
+  });
+
+  it("maps other non-2xx responses to ApiError with a status code", async () => {
+    setHandler(() => ({ status: 500, json: { message: "internal error" } }));
+    let thrown: unknown;
+    try {
+      await Sandbox.create({ config: makeConfig() });
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toBeInstanceOf(ApiError);
+    expect((thrown as ApiError).statusCode).toBe(500);
+  });
+});
+
+describe("Sandbox list / health", () => {
+  it("lists sandboxes (v1)", async () => {
+    setHandler((req) => {
+      expect(req.pathname).toBe("/sandboxes");
+      expect(req.method).toBe("GET");
+      return { status: 200, json: [SANDBOX_DATA] };
+    });
+    const result = await Sandbox.list(makeConfig());
+    expect(result).toHaveLength(1);
+    expect(result[0].sandboxID).toBe(SANDBOX_ID);
+  });
+
+  it("lists sandboxes (v2) from the /v2 endpoint", async () => {
+    setHandler((req) => {
+      expect(req.pathname).toBe("/v2/sandboxes");
+      return { status: 200, json: [] };
+    });
+    expect(await Sandbox.listV2(makeConfig())).toEqual([]);
+  });
+
+  it("reports health", async () => {
+    setHandler((req) => {
+      expect(req.pathname).toBe("/health");
+      return { status: 200, json: { status: "ok", sandboxes: 2 } };
+    });
+    const health = await Sandbox.health(makeConfig());
+    expect(health.status).toBe("ok");
+    expect(health.sandboxes).toBe(2);
+  });
+});
+
+describe("Sandbox instance operations", () => {
+  async function createSandbox(): Promise<Sandbox> {
+    setHandler(() => ({ status: 201, json: SANDBOX_DATA }));
+    const sb = await Sandbox.create({ config: makeConfig() });
+    requests = [];
+    return sb;
+  }
+
+  it("builds virtual hostnames from port + id + domain", async () => {
+    const sb = await createSandbox();
+    expect(sb.getHost(49999)).toBe(`49999-${SANDBOX_ID}.${DOMAIN}`);
+    expect(sb.getHost(8080)).toBe(`8080-${SANDBOX_ID}.${DOMAIN}`);
+    sb.close();
+  });
+
+  it("fetches info via GET /sandboxes/:id", async () => {
+    const sb = await createSandbox();
+    setHandler((req) => {
+      expect(req.pathname).toBe(`/sandboxes/${SANDBOX_ID}`);
+      expect(req.method).toBe("GET");
+      return { status: 200, json: { ...SANDBOX_DATA, state: "paused" } };
+    });
+    const info = await sb.getInfo();
+    expect(info.state).toBe("paused");
+    sb.close();
+  });
+
+  it("kills via DELETE /sandboxes/:id", async () => {
+    const sb = await createSandbox();
+    setHandler((req) => {
+      expect(req.method).toBe("DELETE");
+      expect(req.pathname).toBe(`/sandboxes/${SANDBOX_ID}`);
+      return { status: 204 };
+    });
+    await sb.kill();
+    expect(requests).toHaveLength(1);
+    sb.close();
+  });
+
+  it("pauses and polls getInfo until the sandbox is paused", async () => {
+    const sb = await createSandbox();
+    let getCalls = 0;
+    setHandler((req) => {
+      if (req.method === "POST" && req.pathname.endsWith("/pause")) {
+        return { status: 204 };
+      }
+      // GET /sandboxes/:id
+      getCalls += 1;
+      return {
+        status: 200,
+        json: { ...SANDBOX_DATA, state: getCalls >= 2 ? "paused" : "running" },
+      };
+    });
+    await sb.pause({ wait: true, intervalMs: 0 });
+    expect(getCalls).toBeGreaterThanOrEqual(2);
+    sb.close();
+  });
+
+  it("throws a paused-timeout error when the state never flips", async () => {
+    const sb = await createSandbox();
+    setHandler((req) => {
+      if (req.method === "POST" && req.pathname.endsWith("/pause")) {
+        return { status: 204 };
+      }
+      return { status: 200, json: { ...SANDBOX_DATA, state: "running" } };
+    });
+    await expect(sb.pause({ wait: true, timeoutMs: 20, intervalMs: 1 })).rejects.toThrow(
+      /paused/,
+    );
+    sb.close();
+  });
+});
+
+describe("Sandbox.runCode", () => {
+  async function createSandbox(): Promise<Sandbox> {
+    setHandler(() => ({ status: 201, json: SANDBOX_DATA }));
+    const sb = await Sandbox.create({ config: makeConfig() });
+    requests = [];
+    return sb;
+  }
+
+  it("streams ndjson into an Execution and fires callbacks", async () => {
+    const sb = await createSandbox();
+    const ndjson =
+      '{"type":"stdout","text":"hello\\n","timestamp":123}\n' +
+      '{"type":"result","text":"2","is_main_result":true}\n' +
+      '{"type":"number_of_executions","execution_count":1}\n';
+    setHandler((req) => {
+      expect(req.method).toBe("POST");
+      expect(req.pathname).toBe("/execute");
+      expect(req.headers.host).toBe(`49999-${SANDBOX_ID}.${DOMAIN}`);
+      const body = JSON.parse(req.body.toString());
+      expect(body.code).toBe("1+1");
+      return { status: 200, ndjson };
+    });
+
+    const stdout: string[] = [];
+    const results: Array<string | undefined> = [];
+    const execution = await sb.runCode("1+1", {
+      onStdout: (m) => stdout.push(m.text),
+      onResult: (r) => results.push(r.text),
+    });
+
+    expect(execution.text).toBe("2");
+    expect(execution.logs.stdout).toEqual(["hello\n"]);
+    expect(execution.executionCount).toBe(1);
+    expect(stdout).toEqual(["hello\n"]);
+    expect(results).toEqual(["2"]);
+    sb.close();
+  });
+
+  it("captures execution errors from the stream", async () => {
+    const sb = await createSandbox();
+    const ndjson =
+      '{"type":"error","name":"ValueError","value":"boom","traceback":["line1","line2"]}\n';
+    setHandler(() => ({ status: 200, ndjson }));
+
+    const errors: string[] = [];
+    const execution = await sb.runCode("raise ValueError('boom')", {
+      onError: (e) => errors.push(e.name),
+    });
+
+    expect(execution.error?.name).toBe("ValueError");
+    expect(execution.error?.traceback).toBe("line1\nline2");
+    expect(errors).toEqual(["ValueError"]);
+    sb.close();
+  });
+});
+
+describe("control-plane request timeout", () => {
+  it("aborts a management call that exceeds requestTimeoutMs", async () => {
+    setHandler(async () => {
+      await new Promise((r) => setTimeout(r, 300));
+      return { status: 200, json: [] };
+    });
+    const cfg = new Config({
+      apiUrl: `http://127.0.0.1:${port}`,
+      templateId: "tpl-test",
+      requestTimeoutMs: 60,
+    });
+    await expect(Sandbox.list(cfg)).rejects.toThrow();
+  });
+
+  it("completes when the response returns within requestTimeoutMs", async () => {
+    setHandler(() => ({ status: 200, json: [] }));
+    const cfg = new Config({
+      apiUrl: `http://127.0.0.1:${port}`,
+      templateId: "tpl-test",
+      requestTimeoutMs: 1000,
+    });
+    await expect(Sandbox.list(cfg)).resolves.toEqual([]);
+  });
+});
+
+describe("Sandbox.trafficTokenHeaders", () => {
+  it("sends both e2b- and cube- traffic tokens when the sandbox is restricted", async () => {
+    setHandler(() => ({ status: 201, json: { ...SANDBOX_DATA, trafficAccessToken: "tok-123" } }));
+    const sb = await Sandbox.create({ config: makeConfig() });
+    expect(sb.trafficTokenHeaders()).toEqual({
+      "e2b-traffic-access-token": "tok-123",
+      "cube-traffic-access-token": "tok-123",
+    });
+    sb.close();
+  });
+
+  it("sends no traffic-token headers for a public sandbox", async () => {
+    setHandler(() => ({ status: 201, json: SANDBOX_DATA }));
+    const sb = await Sandbox.create({ config: makeConfig() });
+    expect(sb.trafficTokenHeaders()).toEqual({});
+    sb.close();
+  });
+});

--- a/sdk/node/test/snapshots.test.ts
+++ b/sdk/node/test/snapshots.test.ts
@@ -1,0 +1,290 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { createServer, type IncomingHttpHeaders, type Server } from "node:http";
+import type { AddressInfo } from "node:net";
+
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+
+import { Config } from "../src/config.js";
+import { Sandbox } from "../src/index.js";
+import { stubCubeEnv } from "./_env.js";
+
+stubCubeEnv();
+
+const SANDBOX_ID = "sb-test-001";
+const DOMAIN = "cube.app";
+const SANDBOX_DATA = {
+  sandboxID: SANDBOX_ID,
+  templateID: "tpl-test",
+  domain: DOMAIN,
+  state: "running",
+};
+
+interface RecordedRequest {
+  method: string;
+  pathname: string;
+  url: URL;
+  headers: IncomingHttpHeaders;
+  body: Buffer;
+}
+
+interface MockResponse {
+  status?: number;
+  json?: unknown;
+  text?: string;
+  headers?: Record<string, string>;
+}
+
+type Handler = (req: RecordedRequest) => MockResponse | Promise<MockResponse>;
+
+let server: Server;
+let port: number;
+let requests: RecordedRequest[] = [];
+let handler: Handler = () => ({ status: 201, json: SANDBOX_DATA });
+
+function setHandler(h: Handler): void {
+  handler = h;
+}
+
+function makeConfig(): Config {
+  return new Config({
+    apiUrl: `http://127.0.0.1:${port}`,
+    templateId: "tpl-test",
+    proxyNodeIp: "127.0.0.1",
+    proxyPort: port,
+    sandboxDomain: DOMAIN,
+  });
+}
+
+beforeAll(async () => {
+  server = createServer((req, res) => {
+    const chunks: Buffer[] = [];
+    req.on("data", (c: Buffer) => chunks.push(c));
+    req.on("end", async () => {
+      const url = new URL(req.url ?? "/", "http://localhost");
+      const record: RecordedRequest = {
+        method: req.method ?? "",
+        pathname: url.pathname,
+        url,
+        headers: req.headers,
+        body: Buffer.concat(chunks),
+      };
+      requests.push(record);
+      let out: MockResponse;
+      try {
+        out = await handler(record);
+      } catch {
+        out = { status: 500, json: { message: "handler threw" } };
+      }
+      const headers: Record<string, string> = { ...(out.headers ?? {}) };
+      let payload = "";
+      if (out.text !== undefined) {
+        payload = out.text;
+      } else if (out.json !== undefined) {
+        payload = JSON.stringify(out.json);
+        headers["content-type"] ??= "application/json";
+      }
+      res.writeHead(out.status ?? 200, headers);
+      res.end(payload);
+    });
+  });
+  await new Promise<void>((resolve) => server.listen(0, resolve));
+  port = (server.address() as AddressInfo).port;
+});
+
+afterAll(() => {
+  server.close();
+});
+
+afterEach(() => {
+  requests = [];
+});
+
+async function createSandbox(): Promise<Sandbox> {
+  setHandler(() => ({ status: 201, json: SANDBOX_DATA }));
+  const sb = await Sandbox.create({ config: makeConfig() });
+  requests = [];
+  return sb;
+}
+
+describe("Sandbox.createSnapshot", () => {
+  it("POSTs a name and parses the SnapshotInfo response", async () => {
+    const sb = await createSandbox();
+    setHandler((req) => {
+      expect(req.method).toBe("POST");
+      expect(req.pathname).toBe(`/sandboxes/${SANDBOX_ID}/snapshots`);
+      expect(JSON.parse(req.body.toString())).toEqual({ name: "snap-1" });
+      return { status: 200, json: { snapshotID: "snap-abc", names: ["snap-1"] } };
+    });
+    const snap = await sb.createSnapshot("snap-1");
+    expect(snap.snapshotId).toBe("snap-abc");
+    expect(snap.names).toEqual(["snap-1"]);
+    sb.close();
+  });
+
+  it("sends an empty body when no name is given", async () => {
+    const sb = await createSandbox();
+    setHandler((req) => {
+      expect(JSON.parse(req.body.toString())).toEqual({});
+      return { status: 200, json: { snapshotID: "snap-noname" } };
+    });
+    const snap = await sb.createSnapshot();
+    expect(snap.snapshotId).toBe("snap-noname");
+    expect(snap.names).toEqual([]);
+    sb.close();
+  });
+});
+
+describe("Sandbox.listSnapshots", () => {
+  it("forwards query params and reads the next-token header", async () => {
+    setHandler((req) => {
+      expect(req.pathname).toBe("/snapshots");
+      expect(req.url.searchParams.get("sandboxID")).toBe(SANDBOX_ID);
+      expect(req.url.searchParams.get("limit")).toBe("10");
+      expect(req.url.searchParams.get("nextToken")).toBe("tok-in");
+      return {
+        status: 200,
+        json: [{ snapshotID: "s1" }, { snapshotID: "s2", names: ["b"] }],
+        headers: { "x-next-token": "tok-out" },
+      };
+    });
+    const { snapshots, nextToken } = await Sandbox.listSnapshots({
+      sandboxId: SANDBOX_ID,
+      limit: 10,
+      nextToken: "tok-in",
+      config: makeConfig(),
+    });
+    expect(snapshots.map((s) => s.snapshotId)).toEqual(["s1", "s2"]);
+    expect(snapshots[1].names).toEqual(["b"]);
+    expect(nextToken).toBe("tok-out");
+  });
+
+  it("returns a null next token when the header is absent", async () => {
+    setHandler(() => ({ status: 200, json: [] }));
+    const { snapshots, nextToken } = await Sandbox.listSnapshots({ config: makeConfig() });
+    expect(snapshots).toEqual([]);
+    expect(nextToken).toBeNull();
+  });
+});
+
+describe("Sandbox.deleteSnapshot", () => {
+  it("DELETEs the snapshot's template id", async () => {
+    setHandler((req) => {
+      expect(req.method).toBe("DELETE");
+      expect(req.pathname).toBe("/templates/snap-abc");
+      return { status: 204 };
+    });
+    await Sandbox.deleteSnapshot("snap-abc", { config: makeConfig() });
+    expect(requests).toHaveLength(1);
+  });
+});
+
+describe("Sandbox.rollback", () => {
+  it("POSTs the snapshot id and returns the result body", async () => {
+    const sb = await createSandbox();
+    setHandler((req) => {
+      expect(req.method).toBe("POST");
+      expect(req.pathname).toBe(`/sandboxes/${SANDBOX_ID}/rollback`);
+      expect(JSON.parse(req.body.toString())).toEqual({ snapshotID: "snap-abc" });
+      return { status: 200, json: { ok: true } };
+    });
+    const result = await sb.rollback("snap-abc");
+    expect(result.ok).toBe(true);
+    sb.close();
+  });
+});
+
+describe("Sandbox.clone", () => {
+  it("snapshots, creates n siblings, then deletes the snapshot", async () => {
+    const sb = await createSandbox();
+    const createdIds: string[] = [];
+    let snapshotDeleted = false;
+    setHandler((req) => {
+      if (req.method === "POST" && req.pathname.endsWith("/snapshots")) {
+        return { status: 200, json: { snapshotID: "snap-clone" } };
+      }
+      if (req.method === "POST" && req.pathname === "/sandboxes") {
+        expect(JSON.parse(req.body.toString()).templateID).toBe("snap-clone");
+        const id = `sb-clone-${createdIds.length}`;
+        createdIds.push(id);
+        return { status: 201, json: { ...SANDBOX_DATA, sandboxID: id } };
+      }
+      if (req.method === "DELETE" && req.pathname === "/templates/snap-clone") {
+        snapshotDeleted = true;
+        return { status: 204 };
+      }
+      return { status: 500, json: { message: "unexpected" } };
+    });
+
+    const clones = await sb.clone(2);
+    expect(clones.map((c) => c.sandboxId)).toEqual(["sb-clone-0", "sb-clone-1"]);
+    expect(snapshotDeleted).toBe(true);
+    clones.forEach((c) => c.close());
+    sb.close();
+  });
+
+  it("caps in-flight creates at `concurrency`", async () => {
+    const sb = await createSandbox();
+    let inFlight = 0;
+    let maxInFlight = 0;
+    let created = 0;
+    setHandler(async (req) => {
+      if (req.method === "POST" && req.pathname.endsWith("/snapshots")) {
+        return { status: 200, json: { snapshotID: "snap-clone" } };
+      }
+      if (req.method === "POST" && req.pathname === "/sandboxes") {
+        inFlight += 1;
+        maxInFlight = Math.max(maxInFlight, inFlight);
+        await new Promise((r) => setTimeout(r, 50));
+        inFlight -= 1;
+        return { status: 201, json: { ...SANDBOX_DATA, sandboxID: `sb-clone-${created++}` } };
+      }
+      if (req.method === "DELETE" && req.pathname === "/templates/snap-clone") {
+        return { status: 204 };
+      }
+      return { status: 500, json: { message: "unexpected" } };
+    });
+
+    const clones = await sb.clone(6, { concurrency: 2 });
+    expect(clones).toHaveLength(6);
+    // Never more than the requested concurrency in flight, but actually parallel.
+    expect(maxInFlight).toBeLessThanOrEqual(2);
+    expect(maxInFlight).toBeGreaterThan(1);
+    clones.forEach((c) => c.close());
+    sb.close();
+  });
+
+  it("kills successful siblings and rethrows when a create fails", async () => {
+    const sb = await createSandbox();
+    let createCount = 0;
+    const killed: string[] = [];
+    let snapshotDeleted = false;
+    setHandler((req) => {
+      if (req.method === "POST" && req.pathname.endsWith("/snapshots")) {
+        return { status: 200, json: { snapshotID: "snap-clone" } };
+      }
+      if (req.method === "POST" && req.pathname === "/sandboxes") {
+        createCount += 1;
+        if (createCount === 1) {
+          return { status: 201, json: { ...SANDBOX_DATA, sandboxID: "sb-clone-0" } };
+        }
+        return { status: 500, json: { message: "boom" } };
+      }
+      if (req.method === "DELETE" && req.pathname.startsWith("/sandboxes/")) {
+        killed.push(req.pathname);
+        return { status: 204 };
+      }
+      if (req.method === "DELETE" && req.pathname === "/templates/snap-clone") {
+        snapshotDeleted = true;
+        return { status: 204 };
+      }
+      return { status: 500, json: { message: "unexpected" } };
+    });
+
+    await expect(sb.clone(2)).rejects.toThrow(/boom/);
+    expect(killed).toContain("/sandboxes/sb-clone-0");
+    expect(snapshotDeleted).toBe(true);
+    sb.close();
+  });
+});

--- a/sdk/node/test/stream.test.ts
+++ b/sdk/node/test/stream.test.ts
@@ -1,0 +1,180 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+
+import { Execution } from "../src/models.js";
+import { parseLine, parseNdjsonStream } from "../src/stream.js";
+
+function streamFromChunks(chunks: string[]): ReadableStream<Uint8Array> {
+  const encoder = new TextEncoder();
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const chunk of chunks) {
+        controller.enqueue(encoder.encode(chunk));
+      }
+      controller.close();
+    },
+  });
+}
+
+describe("parseLine", () => {
+  it("parses a result event and captures the main result text", () => {
+    const ex = new Execution();
+    parseLine(ex, '{"type":"result","text":"2","is_main_result":true}');
+    expect(ex.text).toBe("2");
+    expect(ex.results).toHaveLength(1);
+  });
+
+  it("parses e2b-style rich result fields", () => {
+    const ex = new Execution();
+    parseLine(
+      ex,
+      '{"type":"result","json":{"a":1},"data":{"b":2},"chart":{"type":"bar"},"is_main_result":true}',
+    );
+    const result = ex.results[0];
+    expect(result.json).toEqual({ a: 1 });
+    expect(result.jsonData).toEqual({ a: 1 });
+    expect(result.data).toEqual({ b: 2 });
+    expect(result.chart).toEqual({ type: "bar" });
+  });
+
+  it("parses stdout events", () => {
+    const ex = new Execution();
+    parseLine(ex, '{"type":"stdout","text":"hello\\n","timestamp":"t1"}');
+    expect(ex.logs.stdout).toEqual(["hello\n"]);
+  });
+
+  it("parses stderr events", () => {
+    const ex = new Execution();
+    parseLine(ex, '{"type":"stderr","text":"warn\\n","timestamp":"t1"}');
+    expect(ex.logs.stderr).toEqual(["warn\n"]);
+  });
+
+  it("parses error events", () => {
+    const ex = new Execution();
+    parseLine(ex, '{"type":"error","name":"ValueError","value":"bad","traceback":["l1","l2"]}');
+    expect(ex.error?.name).toBe("ValueError");
+    expect(ex.error?.value).toBe("bad");
+    expect(ex.error?.traceback).toBe("l1\nl2");
+  });
+
+  it("parses the execution count", () => {
+    const ex = new Execution();
+    parseLine(ex, '{"type":"number_of_executions","execution_count":5}');
+    expect(ex.executionCount).toBe(5);
+  });
+
+  it("ignores malformed JSON", () => {
+    const ex = new Execution();
+    parseLine(ex, "not json at all");
+    expect(ex.results).toEqual([]);
+    expect(ex.error).toBeNull();
+  });
+
+  it("ignores empty lines", () => {
+    const ex = new Execution();
+    parseLine(ex, "");
+    expect(ex.results).toEqual([]);
+  });
+
+  it("ignores unknown event types", () => {
+    const ex = new Execution();
+    parseLine(ex, '{"type":"unknown_event","data":"x"}');
+    expect(ex.results).toEqual([]);
+  });
+
+  it("invokes the stdout callback", () => {
+    const ex = new Execution();
+    const seen: Array<[string, boolean]> = [];
+    parseLine(ex, '{"type":"stdout","text":"hi\\n"}', {
+      onStdout: (m) => seen.push([m.text, m.isStderr]),
+    });
+    expect(seen).toEqual([["hi\n", false]]);
+  });
+
+  it("invokes the stderr callback with isStderr=true", () => {
+    const ex = new Execution();
+    const seen: Array<[string, boolean]> = [];
+    parseLine(ex, '{"type":"stderr","text":"warn\\n"}', {
+      onStderr: (m) => seen.push([m.text, m.isStderr]),
+    });
+    expect(seen).toEqual([["warn\n", true]]);
+  });
+
+  it("invokes the result and error callbacks", () => {
+    const ex = new Execution();
+    const results: Array<string | undefined> = [];
+    const errors: string[] = [];
+    parseLine(ex, '{"type":"result","text":"42","is_main_result":true}', {
+      onResult: (r) => results.push(r.text),
+    });
+    parseLine(ex, '{"type":"error","name":"Err","value":"v","traceback":[]}', {
+      onError: (e) => errors.push(e.name),
+    });
+    expect(results).toEqual(["42"]);
+    expect(errors).toEqual(["Err"]);
+  });
+});
+
+describe("parseNdjsonStream", () => {
+  it("assembles events across chunk boundaries", async () => {
+    const ex = new Execution();
+    const chunks = [
+      '{"type":"stdout","text":"hel',
+      'lo\\n"}\n{"type":"resul',
+      't","text":"5","is_main_result":true}\n',
+    ];
+    await parseNdjsonStream(streamFromChunks(chunks), ex);
+    expect(ex.logs.stdout).toEqual(["hello\n"]);
+    expect(ex.text).toBe("5");
+  });
+
+  it("parses a trailing line that lacks a newline terminator", async () => {
+    const ex = new Execution();
+    await parseNdjsonStream(
+      streamFromChunks(['{"type":"result","text":"9","is_main_result":true}']),
+      ex,
+    );
+    expect(ex.text).toBe("9");
+  });
+
+  it("skips malformed lines but keeps valid ones", async () => {
+    const ex = new Execution();
+    const chunks = [
+      '{"type":"stdout","text":"a\\n"}\n',
+      "this is not json\n",
+      '{"type":"stdout","text":"b\\n"}\n',
+    ];
+    await parseNdjsonStream(streamFromChunks(chunks), ex);
+    expect(ex.logs.stdout).toEqual(["a\n", "b\n"]);
+  });
+
+  it("forwards callbacks while streaming", async () => {
+    const ex = new Execution();
+    const stdout: string[] = [];
+    await parseNdjsonStream(
+      streamFromChunks([
+        '{"type":"stdout","text":"one\\n"}\n{"type":"stdout","text":"two\\n"}\n',
+      ]),
+      ex,
+      { onStdout: (m) => stdout.push(m.text) },
+    );
+    expect(stdout).toEqual(["one\n", "two\n"]);
+  });
+
+  it("reassembles a single large line split across many chunks", async () => {
+    const ex = new Execution();
+    const big = "x".repeat(200_000);
+    const line = `{"type":"result","text":"${big}","is_main_result":true}`;
+    // Feed the line one byte-ish slice at a time, with the terminating newline
+    // only in the final chunk — exercises the no-newline fast path.
+    const chunks: string[] = [];
+    for (let i = 0; i < line.length; i += 4096) {
+      chunks.push(line.slice(i, i + 4096));
+    }
+    chunks.push("\n");
+    await parseNdjsonStream(streamFromChunks(chunks), ex);
+    expect(ex.text).toBe(big);
+  });
+});

--- a/sdk/node/test/template.test.ts
+++ b/sdk/node/test/template.test.ts
@@ -1,0 +1,213 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { createServer, type IncomingHttpHeaders, type Server } from "node:http";
+import type { AddressInfo } from "node:net";
+
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+
+import { Config } from "../src/config.js";
+import { TemplateNotFoundError } from "../src/exceptions.js";
+import { Template } from "../src/index.js";
+
+interface RecordedRequest {
+  method: string;
+  pathname: string;
+  headers: IncomingHttpHeaders;
+  body: Buffer;
+}
+
+interface MockResponse {
+  status?: number;
+  json?: unknown;
+  text?: string;
+}
+
+type Handler = (req: RecordedRequest) => MockResponse;
+
+let server: Server;
+let port: number;
+let requests: RecordedRequest[] = [];
+let handler: Handler = () => ({ status: 200, json: {} });
+
+function makeConfig(): Config {
+  return new Config({ apiUrl: `http://127.0.0.1:${port}` });
+}
+
+beforeAll(async () => {
+  server = createServer((req, res) => {
+    const chunks: Buffer[] = [];
+    req.on("data", (c: Buffer) => chunks.push(c));
+    req.on("end", () => {
+      const url = new URL(req.url ?? "/", "http://localhost");
+      const record: RecordedRequest = {
+        method: req.method ?? "",
+        pathname: url.pathname,
+        headers: req.headers,
+        body: Buffer.concat(chunks),
+      };
+      requests.push(record);
+      const out = handler(record);
+      const headers: Record<string, string> = {};
+      let payload = "";
+      if (out.text !== undefined) {
+        payload = out.text;
+      } else if (out.json !== undefined) {
+        payload = JSON.stringify(out.json);
+        headers["content-type"] = "application/json";
+      }
+      res.writeHead(out.status ?? 200, headers);
+      res.end(payload);
+    });
+  });
+  await new Promise<void>((resolve) => server.listen(0, resolve));
+  port = (server.address() as AddressInfo).port;
+});
+
+afterAll(() => {
+  server.close();
+});
+
+afterEach(() => {
+  requests = [];
+});
+
+describe("Template.list", () => {
+  it("returns parsed TemplateInfo objects", async () => {
+    handler = (req) => {
+      expect(req.method).toBe("GET");
+      expect(req.pathname).toBe("/templates");
+      return {
+        status: 200,
+        json: [{ templateID: "tpl-a", status: "READY", aliases: ["alpha"] }],
+      };
+    };
+    const templates = await Template.list({ config: makeConfig() });
+    expect(templates).toHaveLength(1);
+    expect(templates[0].templateId).toBe("tpl-a");
+    expect(templates[0].status).toBe("READY");
+  });
+});
+
+describe("Template.get", () => {
+  it("fetches a single template and parses network fields", async () => {
+    handler = (req) => {
+      expect(req.pathname).toBe("/templates/tpl-network");
+      return {
+        status: 200,
+        json: {
+          templateID: "tpl-network",
+          status: "READY",
+          networkType: "tap",
+          allowInternetAccess: false,
+        },
+      };
+    };
+    const info = await Template.get("tpl-network", { config: makeConfig() });
+    expect(info.templateId).toBe("tpl-network");
+    expect(info.networkType).toBe("tap");
+    expect(info.allowInternetAccess).toBe(false);
+  });
+});
+
+describe("Template.build", () => {
+  it("rejects when no image is provided", async () => {
+    await expect(Template.build({ config: makeConfig() })).rejects.toThrow(/image/);
+  });
+
+  it("POSTs to /templates with the image and returns a build", async () => {
+    handler = (req) => {
+      expect(req.method).toBe("POST");
+      expect(req.pathname).toBe("/templates");
+      const body = JSON.parse(req.body.toString());
+      expect(body.image).toBe("python:3.11-slim");
+      return {
+        status: 200,
+        json: {
+          jobID: "job-001",
+          templateID: "tpl-python",
+          status: "running",
+          phase: "Pulling",
+          progress: 10,
+        },
+      };
+    };
+    const build = await Template.build({ image: "python:3.11-slim", config: makeConfig() });
+    expect(build.buildId).toBe("job-001");
+    expect(build.jobId).toBe("job-001");
+    expect(build.templateId).toBe("tpl-python");
+    expect(build.status).toBe("running");
+  });
+});
+
+describe("Template.rebuild", () => {
+  it("POSTs an empty body to /templates/:id by default", async () => {
+    handler = (req) => {
+      expect(req.method).toBe("POST");
+      expect(req.pathname).toBe("/templates/tpl-python");
+      expect(JSON.parse(req.body.toString())).toEqual({});
+      return {
+        status: 200,
+        json: { jobID: "job-002", templateID: "tpl-python", status: "running" },
+      };
+    };
+    const build = await Template.rebuild("tpl-python", { config: makeConfig() });
+    expect(build.jobId).toBe("job-002");
+    expect(build.templateId).toBe("tpl-python");
+    expect(build.status).toBe("running");
+  });
+
+  it("forwards extra fields into the request body", async () => {
+    handler = (req) => {
+      expect(JSON.parse(req.body.toString())).toEqual({ force: true });
+      return { status: 200, json: { jobID: "job-003" } };
+    };
+    const build = await Template.rebuild("tpl-x", { extra: { force: true }, config: makeConfig() });
+    expect(build.jobId).toBe("job-003");
+  });
+
+  it("maps a 404 to TemplateNotFoundError", async () => {
+    handler = () => ({ status: 404, json: { message: "template not found" } });
+    await expect(Template.rebuild("tpl-missing", { config: makeConfig() })).rejects.toBeInstanceOf(
+      TemplateNotFoundError,
+    );
+  });
+});
+
+describe("Template.getBuildLogs", () => {
+  it("GETs the build logs endpoint and returns the payload", async () => {
+    handler = (req) => {
+      expect(req.method).toBe("GET");
+      expect(req.pathname).toBe("/templates/tpl-python/builds/job-001/logs");
+      return { status: 200, json: { logs: ["step 1", "step 2"] } };
+    };
+    const logs = await Template.getBuildLogs("tpl-python", "job-001", { config: makeConfig() });
+    expect(logs.logs).toEqual(["step 1", "step 2"]);
+  });
+});
+
+describe("Template.getBuildStatus", () => {
+  it("GETs the build status endpoint", async () => {
+    handler = (req) => {
+      expect(req.pathname).toBe("/templates/tpl-python/builds/job-001/status");
+      return { status: 200, json: { buildID: "job-001", status: "succeeded" } };
+    };
+    const build = await Template.getBuildStatus("tpl-python", "job-001", {
+      config: makeConfig(),
+    });
+    expect(build.buildId).toBe("job-001");
+    expect(build.status).toBe("succeeded");
+  });
+});
+
+describe("Template.delete", () => {
+  it("DELETEs the template", async () => {
+    handler = (req) => {
+      expect(req.method).toBe("DELETE");
+      expect(req.pathname).toBe("/templates/tpl-old");
+      return { status: 204 };
+    };
+    await Template.delete("tpl-old", { config: makeConfig() });
+    expect(requests).toHaveLength(1);
+  });
+});

--- a/sdk/node/test/timeout.test.ts
+++ b/sdk/node/test/timeout.test.ts
@@ -1,0 +1,169 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Idle- (read-) timeout behavior for runCode / commands.run: the timer resets
+// on every chunk, so a slow-but-active stream survives, while a stalled stream
+// aborts after `timeoutMs` of silence.
+
+import { createServer, type Server, type ServerResponse } from "node:http";
+import type { AddressInfo } from "node:net";
+
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+
+import { encodeConnectEnvelope } from "../src/commands.js";
+import { Config } from "../src/config.js";
+import { Sandbox } from "../src/index.js";
+
+const SANDBOX_ID = "sb-timeout";
+const DOMAIN = "cube.app";
+const SANDBOX_DATA = { sandboxID: SANDBOX_ID, templateID: "tpl-t", domain: DOMAIN };
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+interface StreamPlan {
+  chunks: string[];
+  gapMs: number;
+  stall: boolean;
+}
+
+let server: Server;
+let port: number;
+let plan: StreamPlan = { chunks: [], gapMs: 0, stall: false };
+const openResponses = new Set<ServerResponse>();
+
+function connectDataFrame(text: string): string {
+  const payload = JSON.stringify({
+    event: { data: { stdout: Buffer.from(text, "utf-8").toString("base64") } },
+  });
+  return encodeConnectEnvelope(Buffer.from(payload, "utf-8")).toString("binary");
+}
+
+function connectEndFrame(exitCode: number): string {
+  const payload = JSON.stringify({ event: { end: { exitCode } } });
+  return encodeConnectEnvelope(Buffer.from(payload, "utf-8")).toString("binary");
+}
+
+async function streamPlan(res: ServerResponse): Promise<void> {
+  openResponses.add(res);
+  res.writeHead(200);
+  for (const c of plan.chunks) {
+    if (res.writableEnded || res.destroyed) return;
+    res.write(Buffer.from(c, "binary"));
+    if (plan.gapMs > 0) await sleep(plan.gapMs);
+  }
+  if (!plan.stall && !res.destroyed) {
+    res.end();
+  }
+  // When stalling we intentionally leave the response open; the client's idle
+  // timeout should abort it. afterEach closes anything left dangling.
+}
+
+beforeAll(async () => {
+  server = createServer((req, res) => {
+    req.resume();
+    req.on("end", () => {
+      const path = (req.url ?? "").split("?")[0];
+      if (path === "/sandboxes") {
+        res.writeHead(201, { "content-type": "application/json" });
+        res.end(JSON.stringify(SANDBOX_DATA));
+        return;
+      }
+      // /execute (ndjson) and /process.Process/Start (connect frames) both
+      // just replay the configured stream plan.
+      void streamPlan(res);
+    });
+  });
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  port = (server.address() as AddressInfo).port;
+});
+
+afterEach(() => {
+  for (const res of openResponses) {
+    if (!res.writableEnded) res.destroy();
+  }
+  openResponses.clear();
+});
+
+afterAll(() => {
+  server.close();
+});
+
+function config(): Config {
+  return new Config({
+    apiUrl: `http://127.0.0.1:${port}`,
+    templateId: "tpl-t",
+    proxyNodeIp: "127.0.0.1",
+    proxyPort: port,
+    sandboxDomain: DOMAIN,
+  });
+}
+
+async function makeSandbox(): Promise<Sandbox> {
+  return Sandbox.create({ config: config() });
+}
+
+describe("runCode idle timeout", () => {
+  it("does NOT abort a slow stream whose total time exceeds timeoutMs", async () => {
+    const sb = await makeSandbox();
+    // 5 chunks, 40ms apart → ~200ms total, but each gap (40ms) < 100ms idle.
+    plan = {
+      chunks: [
+        '{"type":"stdout","text":"a\\n"}\n',
+        '{"type":"stdout","text":"b\\n"}\n',
+        '{"type":"stdout","text":"c\\n"}\n',
+        '{"type":"stdout","text":"d\\n"}\n',
+        '{"type":"result","text":"done","is_main_result":true}\n',
+      ],
+      gapMs: 40,
+      stall: false,
+    };
+    const execution = await sb.runCode("slow()", { timeoutMs: 100 });
+    expect(execution.text).toBe("done");
+    expect(execution.logs.stdout).toEqual(["a\n", "b\n", "c\n", "d\n"]);
+    sb.close();
+  });
+
+  it("aborts with an inactivity error when the stream stalls", async () => {
+    const sb = await makeSandbox();
+    plan = {
+      chunks: ['{"type":"stdout","text":"hi\\n"}\n'],
+      gapMs: 0,
+      stall: true, // never ends → idle timer fires
+    };
+    await expect(sb.runCode("hang()", { timeoutMs: 60 })).rejects.toThrow(/inactivity/);
+    sb.close();
+  });
+});
+
+describe("commands.run idle timeout", () => {
+  it("aborts with an inactivity error when the process stream stalls", async () => {
+    const sb = await makeSandbox();
+    plan = {
+      chunks: [connectDataFrame("partial output")],
+      gapMs: 0,
+      stall: true,
+    };
+    await expect(sb.commands.run("hang", { timeoutMs: 60 })).rejects.toThrow(/inactivity/);
+    sb.close();
+  });
+
+  it("completes a slow-but-active process stream past timeoutMs", async () => {
+    const sb = await makeSandbox();
+    plan = {
+      chunks: [
+        connectDataFrame("one\n"),
+        connectDataFrame("two\n"),
+        connectDataFrame("three\n"),
+        connectEndFrame(0),
+      ],
+      gapMs: 40, // < 100ms idle, but ~160ms total
+      stall: false,
+    };
+    const result = await sb.commands.run("slow", { timeoutMs: 100 });
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toBe("one\ntwo\nthree\n");
+    sb.close();
+  });
+});

--- a/sdk/node/test/transport.test.ts
+++ b/sdk/node/test/transport.test.ts
@@ -1,0 +1,169 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { execFileSync } from "node:child_process";
+import { createServer as createHttpServer, type Server } from "node:http";
+import { createServer as createHttpsServer, type Server as HttpsServer } from "node:https";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import type { AddressInfo } from "node:net";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { TLSSocket } from "node:tls";
+
+import { fetch } from "undici";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { Config } from "../src/config.js";
+import { buildDataDispatcher, controlFetch } from "../src/transport.js";
+import { stubCubeEnv } from "./_env.js";
+
+stubCubeEnv();
+
+describe("controlFetch auth", () => {
+  let server: Server;
+  let port: number;
+  let seenAuth: string | undefined;
+
+  beforeAll(async () => {
+    server = createHttpServer((req, res) => {
+      seenAuth = req.headers.authorization;
+      res.writeHead(200);
+      res.end("ok");
+    });
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    port = (server.address() as AddressInfo).port;
+  });
+
+  afterAll(() => server.close());
+
+  it("injects Authorization: Bearer when an API key is set", async () => {
+    const cfg = new Config({ apiKey: "secret-key" });
+    await controlFetch(cfg, `http://127.0.0.1:${port}/health`);
+    expect(seenAuth).toBe("Bearer secret-key");
+  });
+
+  it("sends no Authorization header when no API key is set", async () => {
+    seenAuth = undefined;
+    const cfg = new Config({ apiKey: null });
+    await controlFetch(cfg, `http://127.0.0.1:${port}/health`);
+    expect(seenAuth).toBeUndefined();
+  });
+
+  it("does not overwrite a caller-provided Authorization header", async () => {
+    const cfg = new Config({ apiKey: "secret-key" });
+    await controlFetch(cfg, `http://127.0.0.1:${port}/health`, {
+      headers: { Authorization: "Bearer caller" },
+    });
+    expect(seenAuth).toBe("Bearer caller");
+  });
+});
+
+describe("buildDataDispatcher", () => {
+  it("returns undefined when no proxy node IP is configured", () => {
+    const cfg = new Config({ proxyNodeIp: null });
+    expect(buildDataDispatcher(cfg)).toBeUndefined();
+  });
+
+  it("routes plain http connections to the proxy node while keeping the Host header", async () => {
+    let seenHost: string | undefined;
+    let seenPath: string | undefined;
+    const server: Server = createHttpServer((req, res) => {
+      seenHost = req.headers.host;
+      seenPath = req.url;
+      res.writeHead(200);
+      res.end("ok");
+    });
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const proxyPort = (server.address() as AddressInfo).port;
+
+    try {
+      const cfg = new Config({
+        proxyNodeIp: "127.0.0.1",
+        proxyPort,
+        proxyScheme: "http",
+        sandboxDomain: "cube.app",
+      });
+      const dispatcher = buildDataDispatcher(cfg);
+      const virtualHost = "49983-sb-http.cube.app";
+      const resp = await fetch(`http://${virtualHost}/files`, { dispatcher });
+      expect(resp.status).toBe(200);
+      // Dialed the proxy IP, but the virtual host is preserved for routing.
+      expect(seenHost).toBe(virtualHost);
+      expect(seenPath).toBe("/files");
+      await dispatcher?.close();
+    } finally {
+      server.close();
+    }
+  });
+});
+
+describe("buildDataDispatcher (https SNI preservation)", () => {
+  let tmp: string;
+  let server: HttpsServer;
+  let proxyPort: number;
+  let capturedServername: string | undefined;
+  const prevReject = process.env.NODE_TLS_REJECT_UNAUTHORIZED;
+
+  beforeAll(async () => {
+    tmp = mkdtempSync(join(tmpdir(), "cube-tls-"));
+    const keyPath = join(tmp, "key.pem");
+    const certPath = join(tmp, "cert.pem");
+    // Self-signed cert; SAN is set to the virtual host but not actually
+    // verified here (see NODE_TLS_REJECT_UNAUTHORIZED below) — the point of
+    // this test is purely that the SNI servername reaches the server.
+    execFileSync(
+      "openssl",
+      [
+        "req", "-x509", "-newkey", "rsa:2048", "-nodes",
+        "-keyout", keyPath, "-out", certPath, "-days", "1",
+        "-subj", "/CN=cube-test",
+        "-addext", "subjectAltName=DNS:49999-sb-tls.cube.app",
+      ],
+      { stdio: "ignore" },
+    );
+
+    // Self-signed cert would otherwise fail verification; we only assert on
+    // the presented SNI, so relax verification for this test process.
+    process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0";
+
+    server = createHttpsServer(
+      { key: readFileSync(keyPath), cert: readFileSync(certPath) },
+      (_req, res) => {
+        res.writeHead(200);
+        res.end("ok");
+      },
+    );
+    server.on("secureConnection", (socket: TLSSocket) => {
+      capturedServername = socket.servername || undefined;
+    });
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    proxyPort = (server.address() as AddressInfo).port;
+  });
+
+  afterAll(() => {
+    server.close();
+    if (prevReject === undefined) {
+      delete process.env.NODE_TLS_REJECT_UNAUTHORIZED;
+    } else {
+      process.env.NODE_TLS_REJECT_UNAUTHORIZED = prevReject;
+    }
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it("presents the virtual sandbox host as the TLS SNI, not the proxy IP", async () => {
+    const cfg = new Config({
+      proxyNodeIp: "127.0.0.1",
+      proxyPort,
+      proxyScheme: "https",
+      sandboxDomain: "cube.app",
+    });
+    const dispatcher = buildDataDispatcher(cfg);
+    const virtualHost = "49999-sb-tls.cube.app";
+    const resp = await fetch(`https://${virtualHost}/execute`, { dispatcher });
+    expect(resp.status).toBe(200);
+    // SNI must be the virtual host so CubeProxy TLS routing / cert checks work,
+    // even though the TCP socket landed on 127.0.0.1 (the proxy IP).
+    expect(capturedServername).toBe(virtualHost);
+    await dispatcher?.close();
+  });
+});

--- a/sdk/node/tsconfig.json
+++ b/sdk/node/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022", "ESNext.Disposable"],
+    "types": ["node", "vitest/globals"],
+    "declaration": true,
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noImplicitOverride": true,
+    "outDir": "dist"
+  },
+  "include": ["src", "test"]
+}

--- a/sdk/node/tsup.config.ts
+++ b/sdk/node/tsup.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["esm", "cjs"],
+  dts: true,
+  sourcemap: true,
+  clean: true,
+  target: "node18",
+  outExtension({ format }) {
+    return { js: format === "cjs" ? ".cjs" : ".js" };
+  },
+});

--- a/sdk/node/vitest.config.ts
+++ b/sdk/node/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    globals: true,
+    include: ["test/**/*.test.ts"],
+  },
+});


### PR DESCRIPTION
## Summary

Adds a first-party Node.js / TypeScript SDK under `sdk/node`, to be published
to npm as `@cubesandbox/sdk`. Node.js/TypeScript agent apps (Next.js,
LangChain.js, Vercel AI SDK, NestJS, serverless workers) can now use
CubeSandbox directly instead of hand-rolling REST calls or adapting the E2B JS
SDK.

The SDK mirrors the existing Python and Go SDK surface, with idiomatic
JavaScript conventions (camelCase, Promise-based `async`/`await`).

## What's included

- **Sandbox lifecycle** — `create` / `connect` / `pause` / `resume` / `kill`,
  plus `list` / `listV2` / `health` / `getInfo`.
- **Code execution** — `runCode` with streaming `onStdout` / `onStderr` /
  `onResult` / `onError` callbacks (ndjson stream parsing).
- **Commands** — `commands.run` over envd's Connect process API.
- **Filesystem** — `read` / `write` / `writeFiles` / `list` / `stat` /
  `exists` / `makeDir` / `rename` / `remove` / `watchDir`.
- **Snapshots** — `createSnapshot` / `listSnapshots` / `deleteSnapshot` /
  `rollback` / `clone`.
- **Templates** — `Template.list` / `get` / `build` / `rebuild` /
  build status & logs / `delete`.
- **Network policy** — L3/L4 (`allowOut` / `denyOut`) and typed L7 `rules`,
  including the E2B per-host transform compat shape.
- **DNS bypass** — custom `undici` dispatcher that routes data-plane
  connections to `CUBE_PROXY_NODE_IP` while preserving the virtual `Host`
  header (Node equivalent of the Python `IPOverrideTransport` / Go
  `DialContext` override), with correct TLS SNI pinning for `https`.

## Design notes

- API shape follows Issue #760: `Sandbox.create({ apiUrl, templateId,
  proxyNodeIp })`, `runCode(code, { language, timeout, onStdout, onStderr })`,
  `commands.run`, `files.read/write`, `kill`. `timeout` (ms) is accepted as an
  alias for `timeoutMs`.
- Wire payloads, headers (traffic / envd access tokens), and error mapping are
  kept compatible with the Python/Go SDKs.

## Review feedback addressed

- **`config`**: `CUBE_PROXY_PORT_HTTP` now parses via a helper that falls back
  to `80` on `NaN`/empty/non-positive/out-of-range (>65535) values.
- **Connect frame reader**: replaced per-chunk `Buffer.concat` with a chunk
  list so each received byte is copied at most once (removes O(n²) growth on
  large frames split across many reads).
- **Test isolation**: unit tests are now hermetic w.r.t. ambient `CUBE_*` env.
- **Coverage**: added mocked tests for the previously-uncovered
  `clone` / snapshot / `watchDir` / `Template.rebuild`+`getBuildLogs` paths.
- **Docs**: clarified that `commands.run`'s `timeout` is also sent to envd as
  `Connect-Timeout-Ms` (a hard wall-clock deadline), not a pure idle timeout.

## Test plan

### Automated unit tests
`npm run typecheck` / `npm test` / `npm run build` all pass locally
(144 unit tests; the live integration test also passes — see below).

- [x] `config` — env var resolution, precedence, URL trimming, port fallback (incl. out-of-range)
- [x] `exceptions` — error hierarchy & status codes
- [x] `models` — Execution/Result/Logs/OutputMessage/SnapshotInfo parsing & aliases
- [x] `stream` — ndjson line parsing, callbacks, partial-line buffering
- [x] `policy` — rule serialization, E2B per-host transform conversion, allowOut/denyOut validation
- [x] `commands` — Connect envelope encode/decode, exit-code extraction (mocked stream)
- [x] `connect-frames` — frame reassembly across split headers/payloads, large multi-chunk frames, oversize/truncated streams
- [x] `filesystem` — RPC shape, octet-stream + multipart fallback, 404 mapping (mocked)
- [x] `filesystem-watch` — `watchDir` / `Watcher` event stream, end-stream error, close idempotency (mocked)
- [x] `sandbox` — create/connect/list/pause/kill wire payloads & headers (mocked fetch)
- [x] `snapshots` — createSnapshot/listSnapshots/deleteSnapshot/rollback + `clone` success & failure-cleanup (mocked)
- [x] `template` — list/get/build/rebuild/status/logs/delete (mocked)
- [x] `transport` — undici IP-override dispatcher + TLS SNI pinning
- [x] `timeout` — idle-timeout reset semantics for runCode & commands.run
- [x] Build — dual ESM + CJS output with `.d.ts` / `.d.cts`

### End-to-end against a live CubeAPI
Run against a live deployment with `CUBE_RUN_INTEGRATION=1` (`CUBE_API_URL`,
`CUBE_TEMPLATE_ID`, `CUBE_PROXY_NODE_IP`, `CUBE_PROXY_PORT_HTTP`,
`CUBE_SANDBOX_DOMAIN`), using a `sandbox-code` template (code interpreter on
port 49999).

- [x] Existing integration test: create → runCode(`1+1`)→`"2"` → commands.run(`echo`) → files write/read → kill
- [x] `runCode` streaming stdout (`for i in range(3): print(i)` → `0\n1\n2\n`)
- [x] `pause` (wait=true) → `connect` auto-resume → state verified `running`
- [x] Snapshot lifecycle: createSnapshot → listSnapshots → rollback → deleteSnapshot (rollback restored the pre-snapshot filesystem state)
- [x] `clone(n)` fan-out (live `clone(1)`; sibling failure-cleanup covered by unit test)
- [x] `files.watchDir` streams create events (observed `EVENT_TYPE_CREATE`)
- [x] `Template.build` from image via the SDK → poll build status → create from it → `runCode(6*7)`→`"42"` → delete
- [x] Network policy `denyOut` enforced (control sandbox reached `1.1.1.1:443`; deny-all sandbox blocked). L7 `rules` serialization is unit-tested; live L7 enforcement not separately exercised.
- [x] DNS bypass via `CUBE_PROXY_NODE_IP` against real CubeProxy — all data-plane calls over `http`, plus `https` proxy scheme + TLS SNI over the TLS port (dev cert accepted via `NODE_TLS_REJECT_UNAUTHORIZED=0`; SNI routing verified)
- [x] Idle-timeout against real processes: `runCode` idle-abort fires on a hung execution; `commands.run` timeout fires via envd's `Connect-Timeout-Ms` hard deadline

### Consumption smoke check
- [x] `import { Sandbox } from "@cubesandbox/sdk"` works from an ESM app
- [x] `require("@cubesandbox/sdk")` works from a CJS app
- [x] Types resolve in a downstream `tsc` project (`moduleResolution: nodenext`, exports-map `types` conditions for both `.d.ts`/`.d.cts`)