### PR TITLE
chore: bump Python SDK version to 0.5.0

### DIFF
--- a/sdk/python/cubesandbox/__init__.py
+++ b/sdk/python/cubesandbox/__init__.py
@@ -39,4 +39,4 @@ __all__ = [
     "Inject",
 ]
 
-__version__ = "0.3.0"
+__version__ = "0.5.0"

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "cubesandbox"
-version = "0.3.0"
+version = "0.5.0"
 description = "Python SDK for CubeSandbox"
 license = { text = "Apache-2.0" }
 requires-python = ">=3.9"


### PR DESCRIPTION
Bump Python SDK version from 0.3.0 to 0.5.0

Changes:
- `sdk/python/pyproject.toml`: version 0.3.0 → 0.5.0
- `sdk/python/cubesandbox/__init__.py`: __version__ 0.3.0 → 0.5.0

After this PR is merged, create a tag `python-sdk-v0.5.0` to trigger the publish workflow.