### PR TITLE
feat: add release Docker image workflow and bump-image version tooling

### DIFF
--- a/.github/workflows/release-docker-images.yml
+++ b/.github/workflows/release-docker-images.yml
@@ -27,6 +27,11 @@ on:
         description: 'Image tag to build and push'
         required: true
         type: string
+      ref:
+        description: 'Git ref to build from (defaults to the caller ref)'
+        required: false
+        type: string
+        default: ''
       components:
         description: 'Comma-separated components to build, or "all"'
         required: false
@@ -42,7 +47,9 @@ permissions:
   packages: write
 
 env:
-  CHECKOUT_REF: ${{ github.event_name == 'workflow_dispatch' && inputs.ref != '' && inputs.ref || github.ref }}
+  # ref is declared under both triggers (default ''), so this reference is always
+  # defined; an empty ref falls back to the ref that triggered the run.
+  CHECKOUT_REF: ${{ inputs.ref != '' && inputs.ref || github.ref }}
 
 jobs:
   verify_versions:
@@ -118,6 +125,10 @@ jobs:
           file: CubeEgress/Dockerfile
           platforms: ${{ matrix.platform }}
           push: true
+          # Push plain per-arch manifests (no provenance/SBOM attestations) so the
+          # publish_*_manifest step can combine them into a single clean multi-arch
+          # manifest list; attestations would add extra manifest entries that break
+          # `docker buildx imagetools create`.
           provenance: false
           build-args: |
             CUBE_EGRESS_VERSION=${{ inputs.image_tag }}
@@ -127,6 +138,9 @@ jobs:
             ghcr.io/tencentcloud/cube-egress:${{ inputs.image_tag }}-${{ matrix.arch }}
             cube-sandbox-cn.tencentcloudcr.com/cube-sandbox/cube-egress:${{ inputs.image_tag }}-${{ matrix.arch }}
             cube-sandbox-int.tencentcloudcr.com/cube-sandbox/cube-egress:${{ inputs.image_tag }}-${{ matrix.arch }}
+          # Per-arch cache; base image layers (apt/luarocks) are reused across re-runs.
+          cache-from: type=gha,scope=cube-egress-${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=cube-egress-${{ matrix.arch }}
 
   publish_cube_egress_manifest:
     name: cube-egress manifests
@@ -175,12 +189,17 @@ jobs:
       - name: Create multi-arch manifests
         env:
           IMAGE_TAG: ${{ inputs.image_tag }}
+          # Bind step outputs to env vars instead of interpolating ${{ }} into the
+          # script body, so no expression value can ever be parsed as shell. The
+          # unquoted ${MANIFEST_TAGS} expansion below is deliberate word-splitting
+          # into individual tags.
+          MANIFEST_TAGS: ${{ steps.tags.outputs.list }}
         run: |
           for image in \
             ghcr.io/tencentcloud/cube-egress \
             cube-sandbox-cn.tencentcloudcr.com/cube-sandbox/cube-egress \
             cube-sandbox-int.tencentcloudcr.com/cube-sandbox/cube-egress; do
-            for tag in ${{ steps.tags.outputs.list }}; do
+            for tag in ${MANIFEST_TAGS}; do
               docker buildx imagetools create -t "${image}:${tag}" \
                 "${image}:${IMAGE_TAG}-amd64" \
                 "${image}:${IMAGE_TAG}-arm64"

--- a/.github/workflows/release-docker-images.yml
+++ b/.github/workflows/release-docker-images.yml
@@ -1,0 +1,188 @@
+name: Release Docker Images
+
+# Reusable pipeline for building and pushing release component images to GHCR and
+# Tencent Cloud TCR (cn/int). Add a new component by copying the cube-egress job
+# pair (build_<name> + publish_<name>_manifest) and extending the components
+# input description / filter expression below.
+on:
+  workflow_dispatch:
+    inputs:
+      image_tag:
+        description: 'Image tag to build and push (e.g. v0.5.0)'
+        required: true
+        type: string
+      ref:
+        description: 'Git ref to build from (branch or tag; defaults to the branch you run from)'
+        required: false
+        type: string
+        default: ''
+      components:
+        description: 'Comma-separated components to build, or "all" (cube-egress, ...)'
+        required: false
+        type: string
+        default: all
+  workflow_call:
+    inputs:
+      image_tag:
+        description: 'Image tag to build and push'
+        required: true
+        type: string
+      components:
+        description: 'Comma-separated components to build, or "all"'
+        required: false
+        type: string
+        default: all
+
+concurrency:
+  group: release-docker-images-${{ inputs.image_tag }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  CHECKOUT_REF: ${{ github.event_name == 'workflow_dispatch' && inputs.ref != '' && inputs.ref || github.ref }}
+
+jobs:
+  verify_versions:
+    name: Verify release image tags
+    runs-on: ubuntu-latest
+    if: github.repository == 'TencentCloud/CubeSandbox'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ env.CHECKOUT_REF }}
+
+      - name: Check hard-coded image tags match the release tag
+        run: scripts/bump-image.sh --check "${{ inputs.image_tag }}"
+
+  # ── cube-egress ──────────────────────────────────────────────────────────────
+
+  build_cube_egress:
+    name: cube-egress (${{ matrix.arch }})
+    runs-on: ${{ matrix.runner }}
+    needs: verify_versions
+    if: >-
+      github.repository == 'TencentCloud/CubeSandbox' &&
+      (inputs.components == 'all' || contains(format(',{0},', inputs.components), ',cube-egress,'))
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            platform: linux/amd64
+            runner: ubuntu-latest
+          - arch: arm64
+            platform: linux/arm64
+            runner: ubuntu-24.04-arm
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ env.CHECKOUT_REF }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Log in to Tencent Cloud TCR (cn)
+        uses: docker/login-action@v3
+        with:
+          registry: cube-sandbox-cn.tencentcloudcr.com
+          username: ${{ secrets.TCR_CN_USERNAME }}
+          password: ${{ secrets.TCR_CN_PASSWORD }}
+
+      - name: Log in to Tencent Cloud TCR (int)
+        uses: docker/login-action@v3
+        with:
+          registry: cube-sandbox-int.tencentcloudcr.com
+          username: ${{ secrets.TCR_INT_USERNAME }}
+          password: ${{ secrets.TCR_INT_PASSWORD }}
+
+      - name: Compute build metadata
+        id: meta
+        run: echo "build_time=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> "${GITHUB_OUTPUT}"
+
+      - name: Build and push per-arch image
+        uses: docker/build-push-action@v6
+        with:
+          context: CubeEgress
+          file: CubeEgress/Dockerfile
+          platforms: ${{ matrix.platform }}
+          push: true
+          provenance: false
+          build-args: |
+            CUBE_EGRESS_VERSION=${{ inputs.image_tag }}
+            CUBE_EGRESS_COMMIT=${{ github.sha }}
+            CUBE_EGRESS_BUILD_TIME=${{ steps.meta.outputs.build_time }}
+          tags: |
+            ghcr.io/tencentcloud/cube-egress:${{ inputs.image_tag }}-${{ matrix.arch }}
+            cube-sandbox-cn.tencentcloudcr.com/cube-sandbox/cube-egress:${{ inputs.image_tag }}-${{ matrix.arch }}
+            cube-sandbox-int.tencentcloudcr.com/cube-sandbox/cube-egress:${{ inputs.image_tag }}-${{ matrix.arch }}
+
+  publish_cube_egress_manifest:
+    name: cube-egress manifests
+    runs-on: ubuntu-latest
+    needs: build_cube_egress
+    if: >-
+      always() &&
+      needs.build_cube_egress.result == 'success' &&
+      github.repository == 'TencentCloud/CubeSandbox'
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Log in to Tencent Cloud TCR (cn)
+        uses: docker/login-action@v3
+        with:
+          registry: cube-sandbox-cn.tencentcloudcr.com
+          username: ${{ secrets.TCR_CN_USERNAME }}
+          password: ${{ secrets.TCR_CN_PASSWORD }}
+
+      - name: Log in to Tencent Cloud TCR (int)
+        uses: docker/login-action@v3
+        with:
+          registry: cube-sandbox-int.tencentcloudcr.com
+          username: ${{ secrets.TCR_INT_USERNAME }}
+          password: ${{ secrets.TCR_INT_PASSWORD }}
+
+      - name: Resolve manifest tags
+        id: tags
+        env:
+          IMAGE_TAG: ${{ inputs.image_tag }}
+        run: |
+          tags="${IMAGE_TAG}"
+          if [[ "${IMAGE_TAG}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            tags="${tags} latest"
+          fi
+          echo "list=${tags}" >> "${GITHUB_OUTPUT}"
+
+      - name: Create multi-arch manifests
+        env:
+          IMAGE_TAG: ${{ inputs.image_tag }}
+        run: |
+          for image in \
+            ghcr.io/tencentcloud/cube-egress \
+            cube-sandbox-cn.tencentcloudcr.com/cube-sandbox/cube-egress \
+            cube-sandbox-int.tencentcloudcr.com/cube-sandbox/cube-egress; do
+            for tag in ${{ steps.tags.outputs.list }}; do
+              docker buildx imagetools create -t "${image}:${tag}" \
+                "${image}:${IMAGE_TAG}-amd64" \
+                "${image}:${IMAGE_TAG}-arm64"
+            done
+          done

--- a/.github/workflows/release-one-click.yml
+++ b/.github/workflows/release-one-click.yml
@@ -24,9 +24,24 @@ env:
   PVM_VMLINUX_RELEASE_PATH: deploy/one-click/assets/kernel-artifacts/vmlinux-pvm
 
 jobs:
+  # Fail fast when a hard-coded component image tag in the bundle (terraform
+  # defaults, cube-egress launcher, env examples, ...) does not match the git
+  # tag being released. Gating the whole pipeline on this guarantees the
+  # published bundle never references an image tag that was not built/pushed.
+  verify_versions:
+    name: Verify release image tags
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Check hard-coded image tags match the release tag
+        run: scripts/bump-image.sh --check "${GITHUB_REF_NAME}"
+
   build_pvm_guest_vmlinux:
     name: Build PVM guest vmlinux for release (x86_64)
     runs-on: arc-runner-set-16c32g-containerd
+    needs: verify_versions
     container:
       image: ubuntu:24.04
 
@@ -112,6 +127,7 @@ jobs:
   ensure_release:
     name: Ensure GitHub Release exists
     runs-on: ubuntu-latest
+    needs: verify_versions
 
     steps:
       - name: Ensure GitHub Release exists
@@ -526,3 +542,18 @@ jobs:
             "vmlinux-release-assets/vmlinux-${BUNDLE_ARCH}" \
             --repo "${GITHUB_REPOSITORY}" \
             --clobber
+
+  # Build and push release component images via the reusable workflow (also
+  # runnable manually from Actions → Release Docker Images).
+  release_docker_images:
+    name: Build release docker images
+    needs: verify_versions
+    if: github.repository == 'TencentCloud/CubeSandbox'
+    permissions:
+      contents: read
+      packages: write
+    uses: ./.github/workflows/release-docker-images.yml
+    with:
+      image_tag: ${{ github.ref_name }}
+      components: all
+    secrets: inherit

--- a/.github/workflows/terraform-validate.yml
+++ b/.github/workflows/terraform-validate.yml
@@ -18,6 +18,9 @@ on:
       - 'deploy/one-click/webui/**'
       - 'deploy/one-click/cubeproxy/**'
       - 'CubeProxy/Dockerfile'
+      # bump-image.sh is the single source of truth for the hard-coded image
+      # tags this deployer bakes in; test_bump_image.sh guards it.
+      - 'scripts/bump-image.sh'
       - '.github/workflows/terraform-validate.yml'
   workflow_dispatch:
 
@@ -77,3 +80,9 @@ jobs:
       - name: .env parsing checks
         shell: bash
         run: ./deploy/one-click/tests/test_env_value.sh
+
+      # Guards bump-image.sh: the --check gate, the bump rewrite, the reverse
+      # scan, and the variables.tf line guard against non-image semvers.
+      - name: bump-image tag consistency checks
+        shell: bash
+        run: ./deploy/one-click/tests/test_bump_image.sh

--- a/CubeEgress/Dockerfile
+++ b/CubeEgress/Dockerfile
@@ -1,4 +1,4 @@
-FROM cube-sandbox-cn.tencentcloudcr.com/cube-sandbox/openresty-tproxy
+FROM cube-sandbox-cn.tencentcloudcr.com/cube-sandbox/openresty-tproxy:1.29.2.5
 
 ARG CUBE_EGRESS_VERSION=0.0.0-dev
 ARG CUBE_EGRESS_COMMIT=unknown

--- a/CubeEgress/Makefile
+++ b/CubeEgress/Makefile
@@ -1,6 +1,6 @@
-IMAGE_TAG              ?= v0.4.0
+IMAGE_TAG              ?= v0.5.0
 IMAGE_LOCAL            := cube-egress
-CUBE_EGRESS_VERSION    ?= v1.0.0
+CUBE_EGRESS_VERSION    ?= v0.5.0
 CUBE_EGRESS_COMMIT     ?= $(shell git rev-parse HEAD | cut -c1-8)
 CUBE_EGRESS_BUILD_TIME ?= $(shell date +'%Y%m%d')
 

--- a/deploy/one-click/scripts/systemd/cube-egress-start.sh
+++ b/deploy/one-click/scripts/systemd/cube-egress-start.sh
@@ -27,10 +27,10 @@ require_cmd docker
 #   3. default    → int.tencentcloudcr.com (overseas/international)
 #
 # Production-pushed by CubeEgress/Makefile's `make push` to BOTH repos
-# under the :v0.4.0 tag, so either default resolves to the same digest
+# under the :v0.5.0 tag, so either default resolves to the same digest
 # the operator most recently published.
-CUBE_EGRESS_IMAGE_INT_DEFAULT="cube-sandbox-int.tencentcloudcr.com/cube-sandbox/cube-egress:v0.4.0"
-CUBE_EGRESS_IMAGE_CN_DEFAULT="cube-sandbox-cn.tencentcloudcr.com/cube-sandbox/cube-egress:v0.4.0"
+CUBE_EGRESS_IMAGE_INT_DEFAULT="cube-sandbox-int.tencentcloudcr.com/cube-sandbox/cube-egress:v0.5.0"
+CUBE_EGRESS_IMAGE_CN_DEFAULT="cube-sandbox-cn.tencentcloudcr.com/cube-sandbox/cube-egress:v0.5.0"
 if [[ -n "${CUBE_SANDBOX_CUBE_EGRESS_IMAGE:-}" ]]; then
   CUBE_EGRESS_IMAGE="${CUBE_SANDBOX_CUBE_EGRESS_IMAGE}"
 elif [[ "${MIRROR:-}" == "cn" ]]; then

--- a/deploy/one-click/tests/test_bump_image.sh
+++ b/deploy/one-click/tests/test_bump_image.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# Coverage for scripts/bump-image.sh: the --check release gate, the bump
+# rewrite, the reverse scan, and argument validation. Everything runs inside an
+# isolated git repo seeded with copies of the real tracked files, so the test
+# never mutates the working tree and stays green across future version bumps.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
+
+# The files bump-image.sh rewrites (must all exist, mirroring its FILES list).
+FILES=(
+	deploy/one-click/scripts/systemd/cube-egress-start.sh
+	CubeEgress/Makefile
+	deploy/one-click/terraform/tencentcloud/variables.tf
+	deploy/one-click/terraform/tencentcloud/create.sh
+	deploy/one-click/terraform/tencentcloud/build_images.sh
+	deploy/one-click/terraform/tencentcloud/env.example
+	deploy/one-click/README.md
+	deploy/one-click/README_zh.md
+	docs/guide/tencentcloud-terraform-deploy.md
+	docs/zh/guide/tencentcloud-terraform-deploy.md
+)
+
+failures=0
+fail() {
+	echo "FAIL: $*" >&2
+	failures=$((failures + 1))
+}
+
+# Detect the version the seeded tree currently pins, so the test does not hard
+# code a value that future releases will move.
+CURRENT="$(grep -oE 'cube-egress:v[0-9]+\.[0-9]+\.[0-9]+' \
+	"${REPO_ROOT}/deploy/one-click/scripts/systemd/cube-egress-start.sh" | head -1 | cut -d: -f2)"
+[[ -n "${CURRENT}" ]] || {
+	echo "FAIL: could not detect current version from cube-egress-start.sh" >&2
+	exit 1
+}
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "${WORK}"' EXIT
+install -D "${REPO_ROOT}/scripts/bump-image.sh" "${WORK}/scripts/bump-image.sh"
+for f in "${FILES[@]}"; do
+	install -D "${REPO_ROOT}/${f}" "${WORK}/${f}"
+done
+(cd "${WORK}" && git init -q && git add -A && git -c user.email=t@t -c user.name=t commit -qm seed)
+
+check() { (cd "${WORK}" && ./scripts/bump-image.sh --check "$1" >/dev/null 2>&1); }
+bump() { (cd "${WORK}" && ./scripts/bump-image.sh "$1" >/dev/null 2>&1); }
+
+# 1. clean tree passes at its current version, fails for any other version.
+check "${CURRENT}" || fail "--check ${CURRENT} should pass on the seeded tree"
+if check v9.9.9; then fail "--check v9.9.9 should fail when files are at ${CURRENT}"; fi
+
+# 2. bump rewrites every format; afterwards the new version passes and the old fails.
+bump v0.6.0 || fail "bump v0.6.0 failed"
+check v0.6.0 || fail "--check v0.6.0 should pass after bumping"
+if check "${CURRENT}"; then fail "--check ${CURRENT} should fail after bumping to v0.6.0"; fi
+
+# 3. reverse scan catches a stray tag in a NEW file that is not in the bump list.
+(cd "${WORK}" && printf 'IMAGE_TAG ?= v1.2.3\n' >stray.mk && git add -N stray.mk)
+if check v0.6.0; then fail "reverse scan should catch a stray tag in a new file"; fi
+(cd "${WORK}" && rm -f stray.mk && git reset -q -- stray.mk 2>/dev/null || true)
+
+# 4. a non-image v-semver is left untouched by bump (variables.tf line guard).
+(cd "${WORK}" && printf '\nrequired_version = "~> v1.2.0"\n' \
+	>>deploy/one-click/terraform/tencentcloud/variables.tf)
+bump v0.7.0 || fail "bump v0.7.0 failed"
+if ! grep -q 'required_version = "~> v1.2.0"' \
+	"${WORK}/deploy/one-click/terraform/tencentcloud/variables.tf"; then
+	fail "bump must not rewrite a non-image semver in variables.tf"
+fi
+
+# 5. malformed version is rejected with a usage error (exit 2), not treated as a tag.
+rc=0
+(cd "${WORK}" && ./scripts/bump-image.sh --check not-a-version >/dev/null 2>&1) || rc=$?
+[[ "${rc}" -eq 2 ]] || fail "malformed version should exit 2, got ${rc}"
+
+if [[ "${failures}" -ne 0 ]]; then
+	echo "bump-image tests FAILED (${failures})" >&2
+	exit 1
+fi
+echo "bump-image tests OK"

--- a/scripts/bump-image.sh
+++ b/scripts/bump-image.sh
@@ -1,0 +1,203 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Single source of truth for the release image tag hard-coded across the
+# one-click deployment surface (terraform defaults, systemd launcher, env
+# examples, CubeEgress Makefile, install docs).
+#
+# Run it before tagging a release to bump every hard-coded cube-* component
+# image tag to the target version; the release workflow runs it with --check to
+# fail fast when any of those defaults drift from the pushed git tag, so a
+# published bundle can never reference an image tag that was not built.
+#
+# Usage:
+#   scripts/bump-image.sh <version>          # rewrite hard-coded tags to <version>
+#   scripts/bump-image.sh --check <version>  # verify everything already equals <version>
+#
+# <version> is a full release tag like v0.5.0 (matching the git tag /
+# ${GITHUB_REF_NAME}). --check additionally scans the whole repo for component
+# image references so a NEW hard-coded location that was never added to the list
+# below is still caught instead of silently passing.
+
+set -euo pipefail
+
+# semver with an optional -/. suffix (v0.5.0, v0.5.0-rc1). Kept in one place so
+# the perl edits and the reverse scan stay in sync.
+PERL_SEMVER='v\d+\.\d+\.\d+(?:[-.][0-9A-Za-z.]+)?'
+ERE_SEMVER='v[0-9]+\.[0-9]+\.[0-9]+([-.][0-9A-Za-z.]+)?'
+
+# Component images that follow the release version. openresty-tproxy is
+# deliberately excluded: its tag tracks the OpenResty version, not the release.
+COMPONENTS='cube-egress|cube-master|cube-api|cube-proxy|webui'
+
+usage() {
+	sed -n '2,/^$/p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+	exit "${1:-0}"
+}
+
+MODE=bump
+case "${1:-}" in
+-h | --help) usage 0 ;;
+--check)
+	MODE=check
+	shift
+	;;
+esac
+
+VERSION="${1:-}"
+if [[ -z "${VERSION}" ]]; then
+	echo "error: missing <version>" >&2
+	usage 2
+fi
+if [[ ! "${VERSION}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+([-.][0-9A-Za-z.]+)?$ ]]; then
+	echo "error: version must look like v1.2.3 (got: ${VERSION})" >&2
+	exit 2
+fi
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "${script_dir}/.." && pwd)"
+cd "${repo_root}"
+
+# transform_file <path> -- print the file with its release image tags rewritten
+# to ${VERSION}, WITHOUT modifying it. Each entry is anchored so it only touches
+# the intended tag and never a go.sum pin, a test fixture, or a changelog entry.
+transform_file() {
+	local f="$1"
+	VER="${VERSION}" perl -pe "$(edit_expr "$f")" "$f"
+}
+
+# edit_expr <path> -- the per-file perl expression used by transform_file.
+edit_expr() {
+	case "$1" in
+	deploy/one-click/scripts/systemd/cube-egress-start.sh)
+		# cn/int default image refs + the version named in the header comment.
+		echo "s{:${PERL_SEMVER}}{:\$ENV{VER}}g"
+		;;
+	CubeEgress/Makefile)
+		echo "s{((?:IMAGE_TAG|CUBE_EGRESS_VERSION)\\s*\\?=\\s*)${PERL_SEMVER}}{\$1\$ENV{VER}}"
+		;;
+	deploy/one-click/terraform/tencentcloud/variables.tf)
+		# The only v-prefixed semvers in this file are the release image tags.
+		echo "s{${PERL_SEMVER}}{\$ENV{VER}}g"
+		;;
+	deploy/one-click/terraform/tencentcloud/create.sh | \
+		deploy/one-click/README.md | \
+		deploy/one-click/README_zh.md | \
+		docs/guide/tencentcloud-terraform-deploy.md | \
+		docs/zh/guide/tencentcloud-terraform-deploy.md)
+		# Only touch the image-tag defaults/examples (:- fallbacks, select_env
+		# positional default, generated env template, `TAG=vX`), never other
+		# semvers that may live in these files.
+		echo "s{${PERL_SEMVER}}{\$ENV{VER}}g if /CUBE_IMAGE_TAG/;"
+		;;
+	deploy/one-click/terraform/tencentcloud/build_images.sh)
+		echo "s{(TAG:-)${PERL_SEMVER}}{\$1\$ENV{VER}}"
+		;;
+	deploy/one-click/terraform/tencentcloud/env.example)
+		echo "s{${PERL_SEMVER}}{\$ENV{VER}}g if /IMAGE/;"
+		;;
+	*)
+		echo "error: no edit rule for $1" >&2
+		exit 3
+		;;
+	esac
+}
+
+FILES=(
+	deploy/one-click/scripts/systemd/cube-egress-start.sh
+	CubeEgress/Makefile
+	deploy/one-click/terraform/tencentcloud/variables.tf
+	deploy/one-click/terraform/tencentcloud/create.sh
+	deploy/one-click/terraform/tencentcloud/build_images.sh
+	deploy/one-click/terraform/tencentcloud/env.example
+	deploy/one-click/README.md
+	deploy/one-click/README_zh.md
+	docs/guide/tencentcloud-terraform-deploy.md
+	docs/zh/guide/tencentcloud-terraform-deploy.md
+)
+
+do_bump() {
+	local f changed=0
+	for f in "${FILES[@]}"; do
+		[[ -f "$f" ]] || {
+			echo "error: tracked file missing: $f" >&2
+			exit 1
+		}
+		local tmp
+		tmp="$(mktemp)"
+		transform_file "$f" >"$tmp"
+		if ! cmp -s "$f" "$tmp"; then
+			cat "$tmp" >"$f"
+			echo "bumped ${f}"
+			changed=1
+		fi
+		rm -f "$tmp"
+	done
+	[[ "$changed" -eq 1 ]] || echo "already at ${VERSION}; nothing to bump"
+}
+
+# do_check: (1) every listed file must already equal the bumped output, and
+# (2) no component image reference anywhere in the repo may carry a different
+# tag -- this catches new hard-coded locations that were never added to FILES.
+do_check() {
+	local f drift=0
+
+	for f in "${FILES[@]}"; do
+		[[ -f "$f" ]] || {
+			echo "error: tracked file missing: $f" >&2
+			exit 1
+		}
+		if ! diff -u "$f" <(transform_file "$f") >/dev/null; then
+			echo "::error::${f} has image tags that differ from ${VERSION}" >&2
+			diff -u "$f" <(transform_file "$f") | sed 's/^/    /' >&2 || true
+			drift=1
+		fi
+	done
+
+	# Prefer `git grep`: it only searches tracked files, so it is fast and skips
+	# build artifacts (e.g. deploy/one-click/.work), node_modules and vendored
+	# trees automatically. Fall back to grep when run outside a git work tree.
+	local matches
+	if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+		matches="$(git grep -nE \
+			-e "(${COMPONENTS}):${ERE_SEMVER}" \
+			-e "TENCENTCLOUD_CUBE_IMAGE_TAG=${ERE_SEMVER}" \
+			-- . 2>/dev/null || true)"
+	else
+		matches="$(grep -REn \
+			--exclude-dir=.git --exclude-dir=node_modules --exclude-dir=.work \
+			--exclude='*.sum' --exclude='*.mod' \
+			-e "(${COMPONENTS}):${ERE_SEMVER}" \
+			-e "TENCENTCLOUD_CUBE_IMAGE_TAG=${ERE_SEMVER}" \
+			. 2>/dev/null || true)"
+	fi
+	# Drop references that are intentionally version-pinned fixtures/history.
+	matches="$(printf '%s\n' "$matches" |
+		grep -vE '(_test\.go|/tests/|/mocks/|/changelog/)' || true)"
+
+	local line tag
+	while IFS= read -r line; do
+		[[ -z "$line" ]] && continue
+		tag="$(printf '%s' "$line" |
+			grep -oE "(${COMPONENTS}):${ERE_SEMVER}|TENCENTCLOUD_CUBE_IMAGE_TAG=${ERE_SEMVER}" |
+			grep -oE "${ERE_SEMVER}" | head -1)"
+		if [[ -n "$tag" && "$tag" != "${VERSION}" ]]; then
+			echo "::error::stray image tag ${tag} (expected ${VERSION}): ${line%%:*}" >&2
+			echo "    ${line}" >&2
+			drift=1
+		fi
+	done <<<"$matches"
+
+	if [[ "$drift" -ne 0 ]]; then
+		echo "error: image tags are not all at ${VERSION}; run 'scripts/bump-image.sh ${VERSION}'" >&2
+		exit 1
+	fi
+	echo "ok: all release image tags are at ${VERSION}"
+}
+
+if [[ "${MODE}" == "check" ]]; then
+	do_check
+else
+	do_bump
+fi

--- a/scripts/bump-image.sh
+++ b/scripts/bump-image.sh
@@ -78,8 +78,11 @@ edit_expr() {
 		echo "s{((?:IMAGE_TAG|CUBE_EGRESS_VERSION)\\s*\\?=\\s*)${PERL_SEMVER}}{\$1\$ENV{VER}}"
 		;;
 	deploy/one-click/terraform/tencentcloud/variables.tf)
-		# The only v-prefixed semvers in this file are the release image tags.
-		echo "s{${PERL_SEMVER}}{\$ENV{VER}}g"
+		# Only rewrite semvers on image-tag `default` lines (the bare image_tag
+		# default and the fully-qualified per-component image defaults), so an
+		# unrelated v-prefixed semver added later (e.g. a provider constraint)
+		# is left untouched.
+		echo "s{${PERL_SEMVER}}{\$ENV{VER}}g if /^\\s*default\\s*=.*(?:\"v\\d|:v\\d)/;"
 		;;
 	deploy/one-click/terraform/tencentcloud/create.sh | \
 		deploy/one-click/README.md | \
@@ -92,7 +95,7 @@ edit_expr() {
 		echo "s{${PERL_SEMVER}}{\$ENV{VER}}g if /CUBE_IMAGE_TAG/;"
 		;;
 	deploy/one-click/terraform/tencentcloud/build_images.sh)
-		echo "s{(TAG:-)${PERL_SEMVER}}{\$1\$ENV{VER}}"
+		echo "s{(TAG:-)${PERL_SEMVER}}{\$1\$ENV{VER}}g"
 		;;
 	deploy/one-click/terraform/tencentcloud/env.example)
 		echo "s{${PERL_SEMVER}}{\$ENV{VER}}g if /IMAGE/;"
@@ -155,22 +158,30 @@ do_check() {
 		fi
 	done
 
+	# Reverse scan: catch a release image tag hard-coded in a file that is NOT in
+	# FILES. Patterns live in one array so the search and the extraction below stay
+	# in sync; they cover the tag formats actually used in this repo: a qualified
+	# image ref (registry/name:tag) and the tag/version assignment forms
+	# (IMAGE_TAG / *_IMAGE_TAG=, CUBE_EGRESS_VERSION, TAG:-).
+	local -a patterns=(
+		"(${COMPONENTS}):${ERE_SEMVER}"
+		"(IMAGE_TAG|CUBE_EGRESS_VERSION|TAG:-).*${ERE_SEMVER}"
+	)
+	local -a grep_args=()
+	local p
+	for p in "${patterns[@]}"; do grep_args+=(-e "$p"); done
+
 	# Prefer `git grep`: it only searches tracked files, so it is fast and skips
 	# build artifacts (e.g. deploy/one-click/.work), node_modules and vendored
 	# trees automatically. Fall back to grep when run outside a git work tree.
 	local matches
 	if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
-		matches="$(git grep -nE \
-			-e "(${COMPONENTS}):${ERE_SEMVER}" \
-			-e "TENCENTCLOUD_CUBE_IMAGE_TAG=${ERE_SEMVER}" \
-			-- . 2>/dev/null || true)"
+		matches="$(git grep -nE "${grep_args[@]}" -- . 2>/dev/null || true)"
 	else
 		matches="$(grep -REn \
 			--exclude-dir=.git --exclude-dir=node_modules --exclude-dir=.work \
 			--exclude='*.sum' --exclude='*.mod' \
-			-e "(${COMPONENTS}):${ERE_SEMVER}" \
-			-e "TENCENTCLOUD_CUBE_IMAGE_TAG=${ERE_SEMVER}" \
-			. 2>/dev/null || true)"
+			"${grep_args[@]}" . 2>/dev/null || true)"
 	fi
 	# Drop references that are intentionally version-pinned fixtures/history.
 	matches="$(printf '%s\n' "$matches" |
@@ -179,14 +190,13 @@ do_check() {
 	local line tag
 	while IFS= read -r line; do
 		[[ -z "$line" ]] && continue
-		tag="$(printf '%s' "$line" |
-			grep -oE "(${COMPONENTS}):${ERE_SEMVER}|TENCENTCLOUD_CUBE_IMAGE_TAG=${ERE_SEMVER}" |
-			grep -oE "${ERE_SEMVER}" | head -1)"
-		if [[ -n "$tag" && "$tag" != "${VERSION}" ]]; then
-			echo "::error::stray image tag ${tag} (expected ${VERSION}): ${line%%:*}" >&2
-			echo "    ${line}" >&2
+		# Pull every semver that sits inside a matched image-tag context on the
+		# line and require each to equal the target version.
+		while IFS= read -r tag; do
+			[[ -n "$tag" && "$tag" != "${VERSION}" ]] || continue
+			echo "::error::stray image tag ${tag} (expected ${VERSION}): ${line}" >&2
 			drift=1
-		fi
+		done < <(printf '%s' "$line" | grep -oE "${grep_args[@]}" | grep -oE "${ERE_SEMVER}")
 	done <<<"$matches"
 
 	if [[ "$drift" -ne 0 ]]; then


### PR DESCRIPTION
## Summary

This PR introduces automated multi-arch Docker image publishing for releases and a centralized version-bump tool to keep hard-coded image tags consistent.

### Changes

1. **New: `release-docker-images.yml`** — Reusable GitHub Actions workflow that builds and pushes per-architecture images (amd64/arm64) to GHCR and Tencent Cloud TCR (both cn and int registries), then creates multi-arch manifests. Supports manual dispatch and `workflow_call` reuse.

2. **Enhanced: `release-one-click.yml`** — Added a `verify_versions` job that gates the entire pipeline on image-tag consistency (via `bump-image.sh --check`), plus a `release_docker_images` job that calls the reusable workflow.

3. **New: `scripts/bump-image.sh`** — Single source of truth for every hard-coded component image tag in the repo. Two modes:
   - `bump` — rewrite all tracked references to a target version
   - `--check` — fail if any reference drifts from the expected version (also scans for untracked references)

4. **Version bumps** — Image references updated from v0.4.0 → v0.5.0 in:
   - `CubeEgress/Makefile` (IMAGE_TAG, CUBE_EGRESS_VERSION)
   - `CubeEgress/Dockerfile` (pinned base image tag)
   - `deploy/one-click/scripts/systemd/cube-egress-start.sh` (cn/int defaults)

### Motivation

Before this change, hard-coded image tags were scattered across Makefiles, shell scripts, Terraform configs, and docs — easy to miss during a release. The new script + CI check ensures a published bundle can never reference an image tag that was not built and pushed.