### PR TITLE
chore(cubeapi): remove dead code to clear compiler warnings

### DIFF
--- a/CubeAPI/src/cubemaster/mod.rs
+++ b/CubeAPI/src/cubemaster/mod.rs
@@ -384,22 +384,6 @@ impl CubeMasterClient {
         parse_response(resp).await
     }
 
-    /// GET /cube/template/from-image?job_id=… — poll a create-from-image job.
-    pub async fn get_template_from_image_job(
-        &self,
-        job_id: &str,
-    ) -> Result<TemplateJobResponse, CubeMasterError> {
-        let url = format!("{}/cube/template/from-image", self.base_url);
-        let resp = self
-            .inner
-            .get(&url)
-            .query(&[("job_id", job_id)])
-            .send()
-            .await
-            .map_err(CubeMasterError::Http)?;
-        parse_response(resp).await
-    }
-
     /// POST /cube/template/redo — rebuild an existing template.
     pub async fn redo_template(
         &self,
@@ -1375,10 +1359,6 @@ pub struct SandboxLogsResponse {
     pub ret: RetCode,
     #[serde(default)]
     pub logs: Vec<SandboxLogLine>,
-    #[serde(rename = "nextCursor", default)]
-    pub next_cursor: Option<i64>,
-    #[serde(rename = "hasMore", default)]
-    pub has_more: bool,
 }
 
 #[derive(Debug, Deserialize)]
@@ -1924,7 +1904,7 @@ pub struct RedoTemplateReq {
     pub extra: serde_json::Map<String, serde_json::Value>,
 }
 
-/// Envelope for template-build jobs (from-image / redo / poll).
+/// Envelope for template-build jobs (from-image / redo).
 #[derive(Debug, Deserialize)]
 #[allow(dead_code)]
 pub struct TemplateJobResponse {

--- a/CubeAPI/src/db.rs
+++ b/CubeAPI/src/db.rs
@@ -377,32 +377,6 @@ WHERE agent_id = ? AND deleted_at IS NULL
         self.get_instance(agent_id).await
     }
 
-    pub async fn update_model(
-        &self,
-        agent_id: &str,
-        model: &str,
-        setup: &AgentSetupResult,
-    ) -> anyhow::Result<Option<AgentHubInstanceRecord>> {
-        let last_error = (!setup.stderr.trim().is_empty()).then(|| setup.stderr.clone());
-        sqlx::query(
-            r#"
-UPDATE t_agenthub_instance
-SET model = ?,
-    setup_exit_code = ?,
-    last_error = ?
-WHERE agent_id = ? AND deleted_at IS NULL
-"#,
-        )
-        .bind(model)
-        .bind(setup.exit_code)
-        .bind(last_error)
-        .bind(agent_id)
-        .execute(&self.pool)
-        .await?;
-
-        self.get_instance(agent_id).await
-    }
-
     pub async fn update_status(
         &self,
         agent_id: &str,

--- a/CubeAPI/src/handlers/agenthub.rs
+++ b/CubeAPI/src/handlers/agenthub.rs
@@ -724,8 +724,6 @@ fn openclaw_model_suffix(model: &str) -> &str {
 /// reason about prefixes, providers, or credential modes.
 #[derive(Debug, Clone)]
 struct LlmRuntimePlan {
-    /// Original model string as stored/displayed (e.g. `deepseek/deepseek-v4-flash`).
-    public_model: String,
     /// Bare model id sent upstream as the request body `model` field.
     upstream_model_id: String,
     /// Provider literal from settings (e.g. `deepseek`, `openai-compatible`).
@@ -762,7 +760,6 @@ impl LlmRuntimePlan {
             openclaw_primary,
             openclaw_api_key: llm.openclaw_api_key().to_string(),
             credential_mode: llm.credential_mode.clone(),
-            public_model,
         }
     }
 }
@@ -4041,7 +4038,6 @@ mod tests {
         );
         assert_eq!(plan.upstream_model_id, "deepseek-v4-flash");
         assert_eq!(plan.openclaw_primary, "openai-compatible/deepseek-v4-flash");
-        assert_eq!(plan.public_model, "deepseek/deepseek-v4-flash");
     }
 
     #[test]

--- a/CubeAPI/src/handlers/store.rs
+++ b/CubeAPI/src/handlers/store.rs
@@ -27,8 +27,6 @@ const STORE_IMAGES: &[&str] = &[
 
 #[derive(Deserialize)]
 struct InspectResult {
-    #[serde(rename = "Id")]
-    id: String,
     #[serde(rename = "Size")]
     size: u64,
     #[serde(rename = "RepoDigests")]

--- a/CubeAPI/src/services/cluster.rs
+++ b/CubeAPI/src/services/cluster.rs
@@ -98,10 +98,6 @@ fn map_err(e: CubeMasterError) -> AppError {
     }
 }
 
-pub(crate) fn build_overview(nodes: &[NodeSnapshot]) -> ClusterOverview {
-    build_overview_with_used(nodes, &HashMap::new())
-}
-
 fn build_overview_with_used(
     nodes: &[NodeSnapshot],
     used_map: &HashMap<String, (i64, i64)>,
@@ -208,11 +204,6 @@ pub(crate) fn to_view_with_used(
     }
 }
 
-/// Keep the old signature for tests (no sandbox data, pure CubeMaster values).
-pub(crate) fn to_view(s: NodeSnapshot) -> NodeView {
-    to_view_with_used(s, &HashMap::new())
-}
-
 fn to_version_matrix_view(m: crate::cubemaster::VersionMatrix) -> VersionMatrixView {
     VersionMatrixView {
         control_plane: ControlPlaneVersionView {
@@ -269,8 +260,9 @@ pub(crate) fn saturation_pct(total: i64, allocatable: i64) -> f32 {
 
 #[cfg(test)]
 mod tests {
-    use super::{build_overview, saturation_pct, to_view};
+    use super::{build_overview_with_used, saturation_pct, to_view_with_used};
     use crate::cubemaster::{LocalTemplate, NodeCondition, NodeResources, NodeSnapshot};
+    use std::collections::HashMap;
 
     #[test]
     fn saturation_is_clamped() {
@@ -311,13 +303,13 @@ mod tests {
             ..Default::default()
         };
 
-        let view = to_view(snapshot.clone());
+        let view = to_view_with_used(snapshot.clone(), &HashMap::new());
         assert_eq!(view.node_id, "node-a");
         assert_eq!(view.capacity.cpu_milli, 2200);
         assert_eq!(view.allocatable.cpu_milli, 1000);
         assert_eq!(view.local_templates, vec!["tmpl-1".to_string()]);
 
-        let overview = build_overview(&[snapshot]);
+        let overview = build_overview_with_used(&[snapshot], &HashMap::new());
         assert_eq!(overview.node_count, 1);
         assert_eq!(overview.healthy_nodes, 1);
         assert_eq!(overview.total_cpu_milli, 2200);


### PR DESCRIPTION
Drop unused client methods, struct fields, and test-only wrappers in CubeAPI that no longer have any callers. These leftovers only produced dead_code warnings and added noise to the build output:

```
warning: method `get_template_from_image_job` is never used
   --> src/cubemaster/mod.rs:388:18
    |
48  | impl CubeMasterClient {
    | --------------------- method in this implementation
...
388 |     pub async fn get_template_from_image_job(
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `#[warn(dead_code)]` on by default

warning: fields `next_cursor` and `has_more` are never read
    --> src/cubemaster/mod.rs:1379:9
     |
1374 | pub struct SandboxLogsResponse {
     |            ------------------- fields in this struct
...
1379 |     pub next_cursor: Option<i64>,
     |         ^^^^^^^^^^^
1380 |     #[serde(rename = "hasMore", default)]
1381 |     pub has_more: bool,
     |         ^^^^^^^^
     |
     = note: `SandboxLogsResponse` has a derived impl for the trait `Debug`, but this is intentionally ignored during dead code analysis

warning: method `update_model` is never used
   --> src/db.rs:380:18
    |
87  | impl AgentHubStore {
    | ------------------ method in this implementation
...
380 |     pub async fn update_model(
    |                  ^^^^^^^^^^^^

warning: field `public_model` is never read
   --> src/handlers/agenthub.rs:728:5
    |
726 | struct LlmRuntimePlan {
    |        -------------- field in this struct
727 |     /// Original model string as stored/displayed (e.g. `deepseek/deepseek-v4-flash`).
728 |     public_model: String,
    |     ^^^^^^^^^^^^
    |
    = note: `LlmRuntimePlan` has derived impls for the traits `Clone` and `Debug`, but these are intentionally ignored during dead code analysis

warning: field `id` is never read
  --> src/handlers/store.rs:31:5
   |
29 | struct InspectResult {
   |        ------------- field in this struct
30 |     #[serde(rename = "Id")]
31 |     id: String,
   |     ^^

warning: function `build_overview` is never used
   --> src/services/cluster.rs:101:15
    |
101 | pub(crate) fn build_overview(nodes: &[NodeSnapshot]) -> ClusterOverview {
    |               ^^^^^^^^^^^^^^

warning: function `to_view` is never used
   --> src/services/cluster.rs:212:15
    |
212 | pub(crate) fn to_view(s: NodeSnapshot) -> NodeView {
    |               ^^^^^^^

warning: `cube-api` (bin "cube-api") generated 7 warni
```

The removals are confined to unused CubeAPI internals: no public API, route, or wire format changes. SandboxLogsResponse does not use deny_unknown_fields, so dropping the unread pagination fields keeps deserialization compatible with the JSON CubeMaster still emits.

No behavioral change; build is warning-free and the full test suite passes.

Assisted-by: Claude:claude-opus-4-8