### PR TITLE
docs(sdk/go): translate Extra payload merge comment to English

### DIFF
--- a/sdk/go/template.go
+++ b/sdk/go/template.go
@@ -62,7 +62,8 @@ type BuildTemplateOptions struct {
 	DNS                  []string
 	AllowOut             []string
 	DenyOut              []string
-	// Extra 在命名字段之后合并进请求体, 同名键会覆盖上方字段, 与 Python kwargs 行为一致.
+	// Extra is merged into the request payload after the named fields above,
+	// so duplicate keys override those fields to match Python kwargs behavior.
 	Extra                map[string]any
 }
 


### PR DESCRIPTION
## Motivation

`sdk/go/template.go` had one Chinese inline comment on `BuildTemplateOptions.Extra`, while the surrounding Go SDK comments are in English.

The comment explains non-obvious merge behavior, so this PR translates it instead of removing it.

## What Changed

* Translate the `BuildTemplateOptions.Extra` comment to English while keeping
  the documented merge-order semantics explicit.

## Scope

This PR only updates that comment in `sdk/go/template.go`.

## Validation

```bash
go test -vet=off . -run 'TestBuildTemplateForwardsCreateFromImageOptions|TestBuildTemplateRequiresImage|TestGetTemplateParsesNetworkFields' -count=1
```
