### PR TITLE
fix(network-agent): retain taps until cleanup and pool prep complete

### DIFF
--- a/CubeNet/cubevs/dnspolicy.go
+++ b/CubeNet/cubevs/dnspolicy.go
@@ -165,7 +165,9 @@ func flushDNSAllowInnerMap(inner *ebpf.Map) error {
 	var oldValue dnsAllowValue
 	iter := inner.Iterate()
 	for iter.Next(&oldKey, &oldValue) {
-		_ = inner.Delete(&oldKey)
+		if err := inner.Delete(&oldKey); err != nil && !errors.Is(err, ebpf.ErrKeyNotExist) {
+			return fmt.Errorf("dns allow delete failed: %w", err)
+		}
 	}
 	if err := iter.Err(); err != nil {
 		return fmt.Errorf("dns allow iterate failed: %w", err)

--- a/CubeNet/cubevs/netpolicy.go
+++ b/CubeNet/cubevs/netpolicy.go
@@ -209,10 +209,18 @@ func cleanupNetPolicy(ifindex uint32) error {
 	return flushInnerMap(denyOut, ifindex)
 }
 
-// PrepareTAPDevicePolicy installs policy entries that are invariant for a TAP
-// while it sits in the free pool. Per-sandbox policy application can then skip
-// rewriting these default private/link-local deny ranges on every create.
+// PrepareTAPDevicePolicy clears per-sandbox policy residue, then installs
+// policy entries that are invariant for a TAP while it sits in the free pool.
+// Per-sandbox policy application can then skip rewriting these default
+// private/link-local deny ranges on every create.
 func PrepareTAPDevicePolicy(ifindex uint32) error {
+	if err := cleanupNetPolicy(ifindex); err != nil {
+		return err
+	}
+	if err := cleanupDNSAllow(ifindex); err != nil {
+		return err
+	}
+
 	denyOut, err := loadPinnedMap(MapNameDenyOut)
 	if err != nil {
 		return err

--- a/CubeNet/cubevs/netpolicy.go
+++ b/CubeNet/cubevs/netpolicy.go
@@ -36,11 +36,10 @@ type denyOutPolicyEntry struct {
 }
 
 type netPolicyPlan struct {
-	allowOutEntries       []allowOutPolicyEntry
-	dnsAllowRules         []dnsAllowRule
-	denyOutEntries        []denyOutPolicyEntry
-	includeDefaultDenyOut bool
-	dnsPolicyFlags        uint8
+	allowOutEntries []allowOutPolicyEntry
+	dnsAllowRules   []dnsAllowRule
+	denyOutEntries  []denyOutPolicyEntry
+	dnsPolicyFlags  uint8
 }
 
 // newInnerLPMMap creates a new LPM trie map with uint32 values for deny_out.
@@ -335,9 +334,7 @@ func buildNetPolicyPlan(opts MVMOptions) (*netPolicyPlan, error) {
 	}
 
 	var denyOutEntries []denyOutPolicyEntry
-	includeDefaultDenyOut := true
 	if opts.AllowInternetAccess != nil && !*opts.AllowInternetAccess {
-		includeDefaultDenyOut = false
 		denyOutEntries, err = buildDenyOutPolicyEntries([]string{"0.0.0.0/0"})
 	} else {
 		if opts.DenyOut != nil {
@@ -352,11 +349,10 @@ func buildNetPolicyPlan(opts MVMOptions) (*netPolicyPlan, error) {
 	}
 
 	plan := &netPolicyPlan{
-		allowOutEntries:       allowOutEntries,
-		dnsAllowRules:         dnsAllowRules,
-		denyOutEntries:        denyOutEntries,
-		includeDefaultDenyOut: includeDefaultDenyOut,
-		dnsPolicyFlags:        dnsPolicyFlagsForDomains(dnsAllowDomains, l7DNSAllowDomains),
+		allowOutEntries: allowOutEntries,
+		dnsAllowRules:   dnsAllowRules,
+		denyOutEntries:  denyOutEntries,
+		dnsPolicyFlags:  dnsPolicyFlagsForDomains(dnsAllowDomains, l7DNSAllowDomains),
 	}
 	if err := validateNetPolicyPlan(plan); err != nil {
 		return nil, err
@@ -385,9 +381,6 @@ func appendDenyOutPolicyEntries(dst, src []denyOutPolicyEntry) []denyOutPolicyEn
 func effectiveDenyOutEntriesForReplace(plan *netPolicyPlan) []denyOutPolicyEntry {
 	if plan == nil {
 		return nil
-	}
-	if !plan.includeDefaultDenyOut {
-		return plan.denyOutEntries
 	}
 	entries := make([]denyOutPolicyEntry, len(plan.denyOutEntries), len(plan.denyOutEntries)+len(alwaysDeniedSandboxEntries))
 	copy(entries, plan.denyOutEntries)

--- a/CubeNet/cubevs/netpolicy.go
+++ b/CubeNet/cubevs/netpolicy.go
@@ -36,10 +36,11 @@ type denyOutPolicyEntry struct {
 }
 
 type netPolicyPlan struct {
-	allowOutEntries []allowOutPolicyEntry
-	dnsAllowRules   []dnsAllowRule
-	denyOutEntries  []denyOutPolicyEntry
-	dnsPolicyFlags  uint8
+	allowOutEntries       []allowOutPolicyEntry
+	dnsAllowRules         []dnsAllowRule
+	denyOutEntries        []denyOutPolicyEntry
+	includeDefaultDenyOut bool
+	dnsPolicyFlags        uint8
 }
 
 // newInnerLPMMap creates a new LPM trie map with uint32 values for deny_out.
@@ -161,7 +162,9 @@ func flushInnerMapWithValue(outerMap *ebpf.Map, ifindex uint32, value any) error
 	var key lpmKey
 	iter := inner.Iterate()
 	for iter.Next(&key, value) {
-		_ = inner.Delete(&key)
+		if err := inner.Delete(&key); err != nil && !errors.Is(err, ebpf.ErrKeyNotExist) {
+			return fmt.Errorf("inner map delete failed: %w", err)
+		}
 	}
 	if err := iter.Err(); err != nil {
 		return fmt.Errorf("inner map iterate failed: %w", err)
@@ -205,6 +208,25 @@ func cleanupNetPolicy(ifindex uint32) error {
 	defer denyOut.Close()
 
 	return flushInnerMap(denyOut, ifindex)
+}
+
+// PrepareTAPDevicePolicy installs policy entries that are invariant for a TAP
+// while it sits in the free pool. Per-sandbox policy application can then skip
+// rewriting these default private/link-local deny ranges on every create.
+func PrepareTAPDevicePolicy(ifindex uint32) error {
+	denyOut, err := loadPinnedMap(MapNameDenyOut)
+	if err != nil {
+		return err
+	}
+	defer denyOut.Close()
+
+	if err := ensureDenyOutInnerMap(denyOut, ifindex); err != nil {
+		return err
+	}
+	if err := populateInnerMap(denyOut, ifindex, alwaysDeniedSandboxEntries); err != nil {
+		return fmt.Errorf("populate default %s failed: %w", MapNameDenyOut, err)
+	}
+	return nil
 }
 
 // parseCIDR parses a CIDR string (e.g. "10.0.0.0/8") or a plain IP
@@ -313,7 +335,9 @@ func buildNetPolicyPlan(opts MVMOptions) (*netPolicyPlan, error) {
 	}
 
 	var denyOutEntries []denyOutPolicyEntry
+	includeDefaultDenyOut := true
 	if opts.AllowInternetAccess != nil && !*opts.AllowInternetAccess {
+		includeDefaultDenyOut = false
 		denyOutEntries, err = buildDenyOutPolicyEntries([]string{"0.0.0.0/0"})
 	} else {
 		if opts.DenyOut != nil {
@@ -322,17 +346,17 @@ func buildNetPolicyPlan(opts MVMOptions) (*netPolicyPlan, error) {
 				return nil, err
 			}
 		}
-		denyOutEntries = appendDenyOutPolicyEntries(denyOutEntries, alwaysDeniedSandboxEntries)
 	}
 	if err != nil {
 		return nil, err
 	}
 
 	plan := &netPolicyPlan{
-		allowOutEntries: allowOutEntries,
-		dnsAllowRules:   dnsAllowRules,
-		denyOutEntries:  denyOutEntries,
-		dnsPolicyFlags:  dnsPolicyFlagsForDomains(dnsAllowDomains, l7DNSAllowDomains),
+		allowOutEntries:       allowOutEntries,
+		dnsAllowRules:         dnsAllowRules,
+		denyOutEntries:        denyOutEntries,
+		includeDefaultDenyOut: includeDefaultDenyOut,
+		dnsPolicyFlags:        dnsPolicyFlagsForDomains(dnsAllowDomains, l7DNSAllowDomains),
 	}
 	if err := validateNetPolicyPlan(plan); err != nil {
 		return nil, err
@@ -358,6 +382,18 @@ func appendDenyOutPolicyEntries(dst, src []denyOutPolicyEntry) []denyOutPolicyEn
 	return dst
 }
 
+func effectiveDenyOutEntriesForReplace(plan *netPolicyPlan) []denyOutPolicyEntry {
+	if plan == nil {
+		return nil
+	}
+	if !plan.includeDefaultDenyOut {
+		return plan.denyOutEntries
+	}
+	entries := make([]denyOutPolicyEntry, len(plan.denyOutEntries), len(plan.denyOutEntries)+len(alwaysDeniedSandboxEntries))
+	copy(entries, plan.denyOutEntries)
+	return appendDenyOutPolicyEntries(entries, alwaysDeniedSandboxEntries)
+}
+
 func validateNetPolicyPlan(plan *netPolicyPlan) error {
 	if err := validateNetPolicyEntryCount("network.allow_out_v2", len(plan.allowOutEntries), maxNetPolicyEntries); err != nil {
 		return err
@@ -365,7 +401,7 @@ func validateNetPolicyPlan(plan *netPolicyPlan) error {
 	if err := validateNetPolicyEntryCount("network.dns_allow", len(plan.dnsAllowRules), maxDNSAllowDomains); err != nil {
 		return err
 	}
-	return validateNetPolicyEntryCount("network.deny_out", len(plan.denyOutEntries), maxNetPolicyEntries)
+	return validateNetPolicyEntryCount("network.deny_out", len(effectiveDenyOutEntriesForReplace(plan)), maxNetPolicyEntries)
 }
 
 func validateNetPolicyEntryCounts(allowOutCIDRs, l7AllowOutCIDRs, dnsAllowDomains, l7DNSAllowDomains, denyOut []string) error {
@@ -615,7 +651,8 @@ func netPolicyValueV2Expired(value netPolicyValueV2, now uint64) bool {
 //   - L7AllowOut IP/CIDR targets are inserted into allow_out_v2 with the L7 flag.
 //   - AllowOut domain targets are inserted into dns_allow inner map.
 //   - L7AllowOut domain targets are inserted into dns_allow with the L7 flag.
-//   - DenyOut always includes alwaysDeniedSandboxCIDRs.
+//   - Default private/link-local DenyOut ranges are preloaded when a TAP enters
+//     the free pool. Replace paths replay them after flushing policy maps.
 //   - AllowInternetAccess=false: DenyOut is set to "0.0.0.0/0" (deny all).
 func applyNetPolicy(ifindex uint32, opts MVMOptions) error {
 	return applyNetPolicyWithMode(ifindex, opts, false)
@@ -658,7 +695,11 @@ func applyNetPolicyWithMode(ifindex uint32, opts MVMOptions, replace bool) error
 		return fmt.Errorf("populate %s failed: %w", MapNameDNSAllow, err)
 	}
 
-	if replace || len(plan.denyOutEntries) > 0 {
+	denyOutEntries := plan.denyOutEntries
+	if replace {
+		denyOutEntries = effectiveDenyOutEntriesForReplace(plan)
+	}
+	if replace || len(denyOutEntries) > 0 {
 		denyOutMap, err := loadPinnedMap(MapNameDenyOut)
 		if err != nil {
 			return err
@@ -673,7 +714,7 @@ func applyNetPolicyWithMode(ifindex uint32, opts MVMOptions, replace bool) error
 				return fmt.Errorf("flush %s failed: %w", MapNameDenyOut, err)
 			}
 		}
-		err = populateInnerMap(denyOutMap, ifindex, plan.denyOutEntries)
+		err = populateInnerMap(denyOutMap, ifindex, denyOutEntries)
 		if err != nil {
 			return fmt.Errorf("populate %s failed: %w", MapNameDenyOut, err)
 		}

--- a/CubeNet/cubevs/netpolicy_test.go
+++ b/CubeNet/cubevs/netpolicy_test.go
@@ -104,6 +104,217 @@ func TestValidateNetPolicyEntryCountsDeduplicatesByMapKey(t *testing.T) {
 	}
 }
 
+func TestBuildDNSAllowRulesDeduplicatesAndMergesFlags(t *testing.T) {
+	rules, err := buildDNSAllowRules(
+		[]string{"api.example.com", "*.github.com"},
+		[]string{"API.Example.COM.", "*.GitHub.com."},
+	)
+	if err != nil {
+		t.Fatalf("buildDNSAllowRules returned error: %v", err)
+	}
+	if got, want := len(rules), 2; got != want {
+		t.Fatalf("len(rules)=%d, want %d", got, want)
+	}
+
+	byKey := make(map[dnsAllowKey]dnsAllowRule, len(rules))
+	for _, rule := range rules {
+		byKey[rule.key] = rule
+	}
+	for _, domain := range []string{"api.example.com", "*.github.com"} {
+		key, _, err := makeDNSAllowRule(domain, 0)
+		if err != nil {
+			t.Fatalf("makeDNSAllowRule(%q) returned error: %v", domain, err)
+		}
+		rule, ok := byKey[key]
+		if !ok {
+			t.Fatalf("missing DNS allow rule for %q", domain)
+		}
+		if rule.value.Flags != uint8(netPolicyFlagL7Required) {
+			t.Fatalf("rule %q flags=%d, want %d", domain, rule.value.Flags, netPolicyFlagL7Required)
+		}
+	}
+}
+
+func TestBuildAllowOutPolicyEntriesDeduplicatesAndMergesFlags(t *testing.T) {
+	entries, err := buildAllowOutPolicyEntries(
+		[]string{"198.51.100.1", "203.0.113.0/24"},
+		[]string{"198.51.100.1/32", "203.0.113.0/24"},
+	)
+	if err != nil {
+		t.Fatalf("buildAllowOutPolicyEntries returned error: %v", err)
+	}
+	if got, want := len(entries), 2; got != want {
+		t.Fatalf("len(entries)=%d, want %d", got, want)
+	}
+
+	for _, entry := range entries {
+		if entry.flags != uint8(netPolicyFlagL7Required) {
+			t.Fatalf("entry %q flags=%d, want %d", entry.source, entry.flags, netPolicyFlagL7Required)
+		}
+	}
+	if entries[0].source != "198.51.100.1" {
+		t.Fatalf("first duplicate source=%q, want first source", entries[0].source)
+	}
+	if entries[1].source != "203.0.113.0/24" {
+		t.Fatalf("second duplicate source=%q, want first source", entries[1].source)
+	}
+}
+
+func TestBuildDenyOutPolicyEntriesDeduplicates(t *testing.T) {
+	entries, err := buildDenyOutPolicyEntries([]string{
+		"192.0.2.1",
+		"192.0.2.1/32",
+		"198.51.100.0/24",
+	})
+	if err != nil {
+		t.Fatalf("buildDenyOutPolicyEntries returned error: %v", err)
+	}
+	if got, want := len(entries), 2; got != want {
+		t.Fatalf("len(entries)=%d, want %d", got, want)
+	}
+	if entries[0].source != "192.0.2.1" {
+		t.Fatalf("duplicate source=%q, want first source", entries[0].source)
+	}
+}
+
+func TestAppendDenyOutPolicyEntriesDeduplicatesExisting(t *testing.T) {
+	dst, err := buildDenyOutPolicyEntries([]string{"192.168.0.0/16"})
+	if err != nil {
+		t.Fatalf("buildDenyOutPolicyEntries(dst) returned error: %v", err)
+	}
+	src, err := buildDenyOutPolicyEntries([]string{"192.168.0.0/16", "10.0.0.0/8"})
+	if err != nil {
+		t.Fatalf("buildDenyOutPolicyEntries(src) returned error: %v", err)
+	}
+
+	got := appendDenyOutPolicyEntries(dst, src)
+	if len(got) != 2 {
+		t.Fatalf("len(got)=%d, want 2", len(got))
+	}
+	if got[0].source != "192.168.0.0/16" {
+		t.Fatalf("duplicate source=%q, want existing dst source", got[0].source)
+	}
+	if got[1].source != "10.0.0.0/8" {
+		t.Fatalf("appended source=%q, want src-only entry", got[1].source)
+	}
+}
+
+func TestBuildNetPolicyPlanDeduplicatesAndMergesFlags(t *testing.T) {
+	allowOut := []string{"api.example.com", "198.51.100.1"}
+	l7AllowOut := []string{"API.Example.COM.", "198.51.100.1/32"}
+	denyOut := []string{"192.168.0.0/16", "203.0.113.0/24"}
+
+	plan, err := buildNetPolicyPlan(MVMOptions{
+		AllowOut:   &allowOut,
+		L7AllowOut: &l7AllowOut,
+		DenyOut:    &denyOut,
+	})
+	if err != nil {
+		t.Fatalf("buildNetPolicyPlan returned error: %v", err)
+	}
+
+	if got, want := len(plan.allowOutEntries), 1; got != want {
+		t.Fatalf("len(plan.allowOutEntries)=%d, want %d", got, want)
+	}
+	if got, want := plan.allowOutEntries[0].flags, uint8(netPolicyFlagL7Required); got != want {
+		t.Fatalf("allow out flags=%d, want %d", got, want)
+	}
+	if got, want := len(plan.dnsAllowRules), 1; got != want {
+		t.Fatalf("len(plan.dnsAllowRules)=%d, want %d", got, want)
+	}
+	if got, want := plan.dnsAllowRules[0].value.Flags, uint8(netPolicyFlagL7Required); got != want {
+		t.Fatalf("dns allow flags=%d, want %d", got, want)
+	}
+	if got, want := plan.dnsPolicyFlags, uint8(dnsPolicyFlagLearningEnabled); got != want {
+		t.Fatalf("dnsPolicyFlags=%d, want %d", got, want)
+	}
+	if got, want := len(plan.denyOutEntries), 2; got != want {
+		t.Fatalf("len(plan.denyOutEntries)=%d, want %d", got, want)
+	}
+	if !plan.includeDefaultDenyOut {
+		t.Fatal("includeDefaultDenyOut=false, want true")
+	}
+	if got, want := len(effectiveDenyOutEntriesForReplace(plan)), len(alwaysDeniedSandboxEntries)+1; got != want {
+		t.Fatalf("len(effectiveDenyOutEntriesForReplace(plan))=%d, want %d", got, want)
+	}
+}
+
+func TestBuildNetPolicyPlanBlockAllDoesNotIncludeDefaultDenyOut(t *testing.T) {
+	allowInternetAccess := false
+	plan, err := buildNetPolicyPlan(MVMOptions{AllowInternetAccess: &allowInternetAccess})
+	if err != nil {
+		t.Fatalf("buildNetPolicyPlan returned error: %v", err)
+	}
+	if plan.includeDefaultDenyOut {
+		t.Fatal("includeDefaultDenyOut=true, want false for deny-all policy")
+	}
+	if got, want := len(plan.denyOutEntries), 1; got != want {
+		t.Fatalf("len(plan.denyOutEntries)=%d, want %d", got, want)
+	}
+	if got := len(effectiveDenyOutEntriesForReplace(plan)); got != 1 {
+		t.Fatalf("len(effectiveDenyOutEntriesForReplace(plan))=%d, want 1", got)
+	}
+}
+
+func TestPolicyEntryBuildersRejectBlankCIDR(t *testing.T) {
+	tests := []struct {
+		name string
+		fn   func() error
+	}{
+		{
+			name: "allow out builder",
+			fn: func() error {
+				_, err := buildAllowOutPolicyEntries([]string{"   "}, nil)
+				return err
+			},
+		},
+		{
+			name: "deny out builder",
+			fn: func() error {
+				_, err := buildDenyOutPolicyEntries([]string{"   "})
+				return err
+			},
+		},
+		{
+			name: "net policy plan allow out",
+			fn: func() error {
+				allowOut := []string{"   "}
+				_, err := buildNetPolicyPlan(MVMOptions{AllowOut: &allowOut})
+				return err
+			},
+		},
+		{
+			name: "net policy plan deny out",
+			fn: func() error {
+				denyOut := []string{"   "}
+				_, err := buildNetPolicyPlan(MVMOptions{DenyOut: &denyOut})
+				return err
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := tt.fn(); err == nil {
+				t.Fatalf("returned nil error")
+			}
+		})
+	}
+}
+
+func TestAlwaysDeniedSandboxEntriesInitializes(t *testing.T) {
+	entries, err := buildDenyOutPolicyEntries(alwaysDeniedSandboxCIDRs)
+	if err != nil {
+		t.Fatalf("buildDenyOutPolicyEntries(alwaysDeniedSandboxCIDRs) returned error: %v", err)
+	}
+	if len(entries) == 0 {
+		t.Fatalf("alwaysDeniedSandboxCIDRs produced no entries")
+	}
+	if got, want := len(alwaysDeniedSandboxEntries), len(entries); got != want {
+		t.Fatalf("len(alwaysDeniedSandboxEntries)=%d, want %d", got, want)
+	}
+}
+
 func repeatedCIDRs(count int) []string {
 	entries := make([]string, count)
 	for i := range entries {

--- a/CubeNet/cubevs/netpolicy_test.go
+++ b/CubeNet/cubevs/netpolicy_test.go
@@ -231,28 +231,22 @@ func TestBuildNetPolicyPlanDeduplicatesAndMergesFlags(t *testing.T) {
 	if got, want := len(plan.denyOutEntries), 2; got != want {
 		t.Fatalf("len(plan.denyOutEntries)=%d, want %d", got, want)
 	}
-	if !plan.includeDefaultDenyOut {
-		t.Fatal("includeDefaultDenyOut=false, want true")
-	}
 	if got, want := len(effectiveDenyOutEntriesForReplace(plan)), len(alwaysDeniedSandboxEntries)+1; got != want {
 		t.Fatalf("len(effectiveDenyOutEntriesForReplace(plan))=%d, want %d", got, want)
 	}
 }
 
-func TestBuildNetPolicyPlanBlockAllDoesNotIncludeDefaultDenyOut(t *testing.T) {
+func TestBuildNetPolicyPlanBlockAllKeepsDefaultDenyOutOnReplace(t *testing.T) {
 	allowInternetAccess := false
 	plan, err := buildNetPolicyPlan(MVMOptions{AllowInternetAccess: &allowInternetAccess})
 	if err != nil {
 		t.Fatalf("buildNetPolicyPlan returned error: %v", err)
 	}
-	if plan.includeDefaultDenyOut {
-		t.Fatal("includeDefaultDenyOut=true, want false for deny-all policy")
-	}
 	if got, want := len(plan.denyOutEntries), 1; got != want {
 		t.Fatalf("len(plan.denyOutEntries)=%d, want %d", got, want)
 	}
-	if got := len(effectiveDenyOutEntriesForReplace(plan)); got != 1 {
-		t.Fatalf("len(effectiveDenyOutEntriesForReplace(plan))=%d, want 1", got)
+	if got, want := len(effectiveDenyOutEntriesForReplace(plan)), len(alwaysDeniedSandboxEntries)+1; got != want {
+		t.Fatalf("len(effectiveDenyOutEntriesForReplace(plan))=%d, want %d", got, want)
 	}
 }
 

--- a/network-agent/internal/service/local_service.go
+++ b/network-agent/internal/service/local_service.go
@@ -535,6 +535,9 @@ func (s *localService) prepareTapForPool(tap *tapDevice) error {
 }
 
 func (s *localService) prepareAndStageTapForPool(ctx context.Context, tap *tapDevice, reason string) error {
+	if err := s.clearPortMappings(tap); err != nil {
+		return markTapCleanupError(err)
+	}
 	if err := s.prepareTapForPool(tap); err != nil {
 		return err
 	}
@@ -544,21 +547,12 @@ func (s *localService) prepareAndStageTapForPool(ctx context.Context, tap *tapDe
 	return nil
 }
 
-func (s *localService) enqueueTapForAsyncPrepare(ctx context.Context, tap *tapDevice, reason string) {
+func (s *localService) enqueuePrepareFailedTap(ctx context.Context, tap *tapDevice, err error) {
 	if tap == nil {
 		return
 	}
-	CubeLog.WithContext(ctx).Infof(
-		"network-agent tap cleanup complete; async pool preparation queued: name=%s ifindex=%d ip=%s reason=%s",
-		tap.Name, tap.Index, tap.IP, reason,
-	)
-	s.mu.Lock()
-	s.enqueuePreparePoolLocked(tap, reason)
-	s.mu.Unlock()
-}
-
-func (s *localService) enqueuePrepareFailedTap(ctx context.Context, tap *tapDevice, err error) {
-	if tap == nil {
+	if isTapCleanupError(err) {
+		s.enqueueCleanupFailedTap(ctx, tap, err)
 		return
 	}
 	CubeLog.WithContext(ctx).Warnf(
@@ -693,11 +687,13 @@ func (s *localService) releaseState(ctx context.Context, state *managedState) er
 	if err := s.store.Delete(state.SandboxID); err != nil {
 		return err
 	}
-	s.enqueueTapForAsyncPrepare(ctx, state.tap, "recycle")
-	// Best-effort: drop the L7 policy from CubeEgress so a future
-	// sandbox that lands on the same IP sees a clean slate. Failures
-	// here are logged at WARN, never propagated — see deleteEgressForState.
+	// Best-effort: drop the L7 policy from CubeEgress before the TAP becomes
+	// reusable, so a future sandbox that lands on the same IP sees a clean slate.
+	// Failures here are logged at WARN, never propagated — see deleteEgressForState.
 	s.deleteEgressForState(ctx, state.SandboxID, state.SandboxIP)
+	if err := s.prepareAndStageTapForPool(ctx, state.tap, "recycle"); err != nil {
+		s.enqueuePrepareFailedTap(ctx, state.tap, err)
+	}
 	return nil
 }
 

--- a/network-agent/internal/service/local_service.go
+++ b/network-agent/internal/service/local_service.go
@@ -28,6 +28,7 @@ var (
 	cubevsUpsertTAPDevice     = cubevs.UpsertTAPDevice
 	cubevsUpsertTAPDeviceMeta = cubevs.UpsertTAPDeviceMeta
 	cubevsDelTAPDevice        = cubevs.DelTAPDevice
+	cubevsPrepareTAPPolicy    = cubevs.PrepareTAPDevicePolicy
 	cubevsAddPortMap          = cubevs.AddPortMapping
 	cubevsDelPortMap          = cubevs.DelPortMapping
 	listCubeTapsFunc          = listCubeTaps
@@ -406,11 +407,22 @@ func (s *localService) createState(ctx context.Context, req *EnsureNetworkReques
 	}
 	actualMappings, err := s.configurePortMappings(tap, requestedMappings)
 	if err != nil {
-		s.releaseAcquiredTap(tap, fromPool)
+		if isTapCleanupError(err) {
+			s.enqueueCleanupFailedTap(ctx, tap, err)
+		} else {
+			s.releaseAcquiredTap(tap, fromPool)
+		}
 		return nil, err
 	}
 	if err := s.registerCubeVSTap(tap.Index, tap.IP, req.SandboxID, req.CubeNetworkConfig); err != nil {
-		s.clearPortMappings(tap)
+		cleanupErr := errors.Join(
+			s.clearPortMappings(tap),
+			s.cleanupCubeVSTap(tap.Index, tap.IP.To4()),
+		)
+		if cleanupErr != nil {
+			s.enqueueCleanupFailedTap(ctx, tap, cleanupErr)
+			return nil, errors.Join(err, markTapCleanupError(cleanupErr))
+		}
 		s.releaseAcquiredTap(tap, fromPool)
 		return nil, err
 	}
@@ -432,13 +444,18 @@ func (s *localService) createState(ctx context.Context, req *EnsureNetworkReques
 		policyKnown: true,
 	}
 	if err := s.store.Save(&state.persistedState); err != nil {
-		if delErr := cubevsDelTAPDevice(uint32(tap.Index), tap.IP.To4()); delErr != nil {
+		cleanupErr := errors.Join(
+			s.clearPortMappings(tap),
+			s.cleanupCubeVSTap(tap.Index, tap.IP.To4()),
+		)
+		if cleanupErr != nil {
 			CubeLog.WithContext(ctx).Warnf(
-				"network-agent createState rollback: cubevs del tap failed (stale eBPF entries may leak): sandbox_id=%s ifindex=%d ip=%s err=%v",
-				req.SandboxID, tap.Index, tap.IP.String(), delErr,
+				"network-agent createState rollback cleanup failed; tap will not be reused until cleanup succeeds: sandbox_id=%s ifindex=%d ip=%s err=%v",
+				req.SandboxID, tap.Index, tap.IP.String(), cleanupErr,
 			)
+			s.enqueueCleanupFailedTap(ctx, tap, cleanupErr)
+			return nil, errors.Join(err, markTapCleanupError(cleanupErr))
 		}
-		s.clearPortMappings(tap)
 		s.releaseAcquiredTap(tap, fromPool)
 		return nil, err
 	}
@@ -478,24 +495,92 @@ func (s *localService) acquireTap() (*tapDevice, bool, error) {
 		s.allocator.Release(ip)
 		return nil, false, err
 	}
+	if err := s.prepareTapForPool(tap); err != nil {
+		closeTapFile(tap.File)
+		_ = destroyTapFunc(tap.Index)
+		s.allocator.Release(ip)
+		return nil, false, err
+	}
 	return tap, false, nil
 }
 
-// releaseAcquiredTap rolls back a tap obtained via acquireTap when a later
-// creation step fails. Pool taps are recycled back into the pool (their IP stays
-// allocated for reuse); freshly created taps are destroyed and their IP freed.
-// Callers must perform stage-specific compensation (clearPortMappings,
-// cubevsDelTAPDevice) before calling this.
+// releaseAcquiredTap rolls back a tap obtained via acquireTap after all
+// stage-specific cleanup has succeeded. Pool taps are recycled back into the
+// pool (their IP stays allocated for reuse); freshly created taps are destroyed
+// and their IP freed.
 func (s *localService) releaseAcquiredTap(tap *tapDevice, fromPool bool) {
 	if fromPool {
-		s.mu.Lock()
-		s.recycleTapLocked(tap)
-		s.mu.Unlock()
+		if err := s.prepareAndStageTapForPool(context.Background(), tap, "recycle"); err != nil {
+			s.enqueuePrepareFailedTap(context.Background(), tap, err)
+		}
 		return
 	}
 	closeTapFile(tap.File)
 	_ = destroyTapFunc(tap.Index)
 	s.allocator.Release(tap.IP)
+}
+
+func (s *localService) cleanupCubeVSTap(ifindex int, ip net.IP) error {
+	if err := cubevsDelTAPDevice(uint32(ifindex), ip); err != nil && !errors.Is(err, ebpf.ErrKeyNotExist) {
+		return err
+	}
+	return nil
+}
+
+func (s *localService) prepareTapForPool(tap *tapDevice) error {
+	if tap == nil {
+		return nil
+	}
+	return cubevsPrepareTAPPolicy(uint32(tap.Index))
+}
+
+func (s *localService) prepareAndStageTapForPool(ctx context.Context, tap *tapDevice, reason string) error {
+	if err := s.prepareTapForPool(tap); err != nil {
+		return err
+	}
+	s.mu.Lock()
+	s.stageTapForPoolLocked(tap, reason)
+	s.mu.Unlock()
+	return nil
+}
+
+func (s *localService) enqueueTapForAsyncPrepare(ctx context.Context, tap *tapDevice, reason string) {
+	if tap == nil {
+		return
+	}
+	CubeLog.WithContext(ctx).Infof(
+		"network-agent tap cleanup complete; async pool preparation queued: name=%s ifindex=%d ip=%s reason=%s",
+		tap.Name, tap.Index, tap.IP, reason,
+	)
+	s.mu.Lock()
+	s.enqueuePreparePoolLocked(tap, reason)
+	s.mu.Unlock()
+}
+
+func (s *localService) enqueuePrepareFailedTap(ctx context.Context, tap *tapDevice, err error) {
+	if tap == nil {
+		return
+	}
+	CubeLog.WithContext(ctx).Warnf(
+		"network-agent tap pool preparation failed; withholding tap from reuse: name=%s ifindex=%d ip=%s err=%v",
+		tap.Name, tap.Index, tap.IP, err,
+	)
+	s.mu.Lock()
+	s.requeuePreparePoolFailureLocked(tap, err)
+	s.mu.Unlock()
+}
+
+func (s *localService) enqueueCleanupFailedTap(ctx context.Context, tap *tapDevice, err error) {
+	if tap == nil {
+		return
+	}
+	CubeLog.WithContext(ctx).Errorf(
+		"network-agent tap cleanup failed; withholding tap from reuse: name=%s ifindex=%d ip=%s err=%v",
+		tap.Name, tap.Index, tap.IP, err,
+	)
+	s.mu.Lock()
+	s.enqueueAbnormalLocked(tap, abnormalStageRecoverCleanup, err)
+	s.mu.Unlock()
 }
 
 func (s *localService) reconcileState(ctx context.Context, state *managedState) error {
@@ -599,16 +684,16 @@ func (s *localService) releaseState(ctx context.Context, state *managedState) er
 	} else {
 		state.tap.PortMappings = append([]PortMapping(nil), state.PortMappings...)
 	}
-	s.clearPortMappings(state.tap)
-	if err := cubevsDelTAPDevice(uint32(state.TapIfIndex), net.ParseIP(state.SandboxIP).To4()); err != nil && !errors.Is(err, ebpf.ErrKeyNotExist) {
+	if err := s.clearPortMappings(state.tap); err != nil {
 		return err
 	}
-	s.mu.Lock()
-	s.recycleTapLocked(state.tap)
-	s.mu.Unlock()
+	if err := s.cleanupCubeVSTap(state.TapIfIndex, net.ParseIP(state.SandboxIP).To4()); err != nil {
+		return err
+	}
 	if err := s.store.Delete(state.SandboxID); err != nil {
 		return err
 	}
+	s.enqueueTapForAsyncPrepare(ctx, state.tap, "recycle")
 	// Best-effort: drop the L7 policy from CubeEgress so a future
 	// sandbox that lands on the same IP sees a clean slate. Failures
 	// here are logged at WARN, never propagated — see deleteEgressForState.
@@ -693,13 +778,21 @@ func (s *localService) recover() error {
 			continue
 		}
 		if inCubeVS {
-			s.clearPortMappings(restoredTap)
-			if err := cubevsDelTAPDevice(uint32(restoredTap.Index), restoredTap.IP.To4()); err != nil && !errors.Is(err, ebpf.ErrKeyNotExist) {
-				s.enqueueAbnormalLocked(restoredTap, abnormalStageRecoverCleanup, err)
+			cleanupErr := errors.Join(
+				s.clearPortMappings(restoredTap),
+				s.cleanupCubeVSTap(restoredTap.Index, restoredTap.IP.To4()),
+			)
+			if cleanupErr != nil {
+				s.enqueueAbnormalLocked(restoredTap, abnormalStageRecoverCleanup, cleanupErr)
 				continue
 			}
 		}
-		s.stageTapForPoolLocked(restoredTap, "recover")
+		if err := s.prepareAndStageTapForPool(context.Background(), restoredTap, "recover"); err != nil {
+			s.mu.Lock()
+			s.requeuePreparePoolFailureLocked(restoredTap, err)
+			s.mu.Unlock()
+			continue
+		}
 	}
 	for _, state := range states {
 		if _, ok := recovered[state.SandboxID]; ok {
@@ -716,9 +809,12 @@ func (s *localService) recover() error {
 				staleTap.PortMappings = append([]PortMapping(nil), state.PortMappings...)
 			}
 			CubeLog.WithContext(context.Background()).Warnf("network-agent recover dropping stale state for sandbox %s: tap %s missing on host, cleaning persisted state and cubevs entries", state.SandboxID, state.TapName)
-			s.clearPortMappings(staleTap)
-			if err := cubevsDelTAPDevice(uint32(device.Ifindex), staleTap.IP); err != nil && !errors.Is(err, ebpf.ErrKeyNotExist) {
-				return err
+			cleanupErr := errors.Join(
+				s.clearPortMappings(staleTap),
+				s.cleanupCubeVSTap(device.Ifindex, staleTap.IP),
+			)
+			if cleanupErr != nil {
+				return cleanupErr
 			}
 		}
 		if err := s.store.Delete(state.SandboxID); err != nil {

--- a/network-agent/internal/service/local_service_concurrency_test.go
+++ b/network-agent/internal/service/local_service_concurrency_test.go
@@ -29,6 +29,7 @@ func installEnsureMocks(t *testing.T) {
 	oldRestore := restoreTapFunc
 	oldAddTap := cubevsAddTAPDevice
 	oldDelTap := cubevsDelTAPDevice
+	oldPrepareTap := cubevsPrepareTAPPolicy
 	oldAddPort := cubevsAddPortMap
 	oldDelPort := cubevsDelPortMap
 	oldList := listCubeTapsFunc
@@ -41,6 +42,7 @@ func installEnsureMocks(t *testing.T) {
 		restoreTapFunc = oldRestore
 		cubevsAddTAPDevice = oldAddTap
 		cubevsDelTAPDevice = oldDelTap
+		cubevsPrepareTAPPolicy = oldPrepareTap
 		cubevsAddPortMap = oldAddPort
 		cubevsDelPortMap = oldDelPort
 		listCubeTapsFunc = oldList
@@ -61,6 +63,7 @@ func installEnsureMocks(t *testing.T) {
 	}
 	cubevsAddTAPDevice = func(uint32, net.IP, string, uint32, cubevs.MVMOptions) error { return nil }
 	cubevsDelTAPDevice = func(uint32, net.IP) error { return nil }
+	cubevsPrepareTAPPolicy = func(uint32) error { return nil }
 	cubevsAddPortMap = func(uint32, uint16, uint16) error { return nil }
 	cubevsDelPortMap = func(uint32, uint16, uint16) error { return nil }
 	listCubeTapsFunc = func() (map[string]*tapDevice, error) { return map[string]*tapDevice{}, nil }
@@ -305,6 +308,92 @@ func TestCreateStateRollbackRecyclesPoolTap(t *testing.T) {
 	}
 }
 
+func TestCreateStateRollbackWithholdsPoolTapWhenCleanupFails(t *testing.T) {
+	installEnsureMocks(t)
+	cubevsAddTAPDevice = func(uint32, net.IP, string, uint32, cubevs.MVMOptions) error {
+		return errors.New("register boom")
+	}
+	cubevsDelTAPDevice = func(uint32, net.IP) error {
+		return errors.New("cleanup boom")
+	}
+
+	svc := newConcurrencyTestService(t)
+	pooled := &tapDevice{Name: tapName("192.168.0.50"), Index: 70, IP: net.ParseIP("192.168.0.50").To4()}
+	svc.allocator.Assign(pooled.IP)
+	svc.mu.Lock()
+	svc.enqueueTapLocked(pooled)
+	svc.mu.Unlock()
+
+	_, err := svc.EnsureNetwork(context.Background(), &EnsureNetworkRequest{
+		SandboxID:    "sb",
+		PortMappings: []PortMapping{{ContainerPort: 80}},
+	})
+	if err == nil {
+		t.Fatal("EnsureNetwork: expected register failure")
+	}
+	if !isTapCleanupError(err) {
+		t.Fatalf("EnsureNetwork error=%v, want tap cleanup error", err)
+	}
+
+	svc.mu.Lock()
+	poolLen := len(svc.tapPool)
+	abnormalLen := len(svc.abnormalTapPool)
+	statesLen := len(svc.states)
+	svc.mu.Unlock()
+	if poolLen != 0 {
+		t.Fatalf("tapPool len=%d, want 0 (cleanup failed tap must not be reused)", poolLen)
+	}
+	if abnormalLen != 1 {
+		t.Fatalf("abnormalTapPool len=%d, want 1", abnormalLen)
+	}
+	if statesLen != 0 {
+		t.Fatalf("states len=%d, want 0", statesLen)
+	}
+}
+
+func TestCreateStateRollbackQueuesPoolTapWhenPrepareFails(t *testing.T) {
+	installEnsureMocks(t)
+	cubevsAddTAPDevice = func(uint32, net.IP, string, uint32, cubevs.MVMOptions) error {
+		return errors.New("register boom")
+	}
+	cubevsPrepareTAPPolicy = func(uint32) error {
+		return errors.New("prepare boom")
+	}
+
+	svc := newConcurrencyTestService(t)
+	pooled := &tapDevice{Name: tapName("192.168.0.51"), Index: 71, IP: net.ParseIP("192.168.0.51").To4()}
+	svc.allocator.Assign(pooled.IP)
+	svc.mu.Lock()
+	svc.enqueueTapLocked(pooled)
+	svc.mu.Unlock()
+
+	_, err := svc.EnsureNetwork(context.Background(), &EnsureNetworkRequest{
+		SandboxID:    "sb",
+		PortMappings: []PortMapping{{ContainerPort: 80}},
+	})
+	if err == nil {
+		t.Fatal("EnsureNetwork: expected register failure")
+	}
+
+	svc.mu.Lock()
+	poolLen := len(svc.tapPool)
+	pendingLen := len(svc.abnormalTapPool)
+	pendingStage := ""
+	if pendingLen > 0 {
+		pendingStage = svc.abnormalTapPool[0].LastStage
+	}
+	svc.mu.Unlock()
+	if poolLen != 0 {
+		t.Fatalf("tapPool len=%d, want 0 before pool preparation succeeds", poolLen)
+	}
+	if pendingLen != 1 {
+		t.Fatalf("abnormalTapPool len=%d, want 1 pending preparation", pendingLen)
+	}
+	if pendingStage != abnormalStagePreparePool {
+		t.Fatalf("pending stage=%q, want %q", pendingStage, abnormalStagePreparePool)
+	}
+}
+
 // TestCreateStateRollbackDestroysNonPoolTapOnSaveFailure asserts that a freshly
 // created (non-pool) tap is destroyed, its IP released, and cubevs metadata
 // cleaned up when state persistence fails.
@@ -349,6 +438,95 @@ func TestCreateStateRollbackDestroysNonPoolTapOnSaveFailure(t *testing.T) {
 	svc.mu.Unlock()
 	if statesLen != 0 || poolLen != 0 {
 		t.Fatalf("residue after rollback: states=%d pool=%d", statesLen, poolLen)
+	}
+}
+
+func TestReleaseNetworkDoesNotRecycleTapWhenCubeVSCleanupFails(t *testing.T) {
+	installEnsureMocks(t)
+	cubevsDelTAPDevice = func(uint32, net.IP) error {
+		return errors.New("cleanup boom")
+	}
+
+	svc := newConcurrencyTestService(t)
+	ip := net.ParseIP("192.168.0.60").To4()
+	tap := &tapDevice{Name: tapName(ip.String()), Index: 80, IP: ip, File: newTestTapFile(t)}
+	state := &managedState{
+		persistedState: persistedState{
+			SandboxID:     "sb",
+			NetworkHandle: "sb",
+			TapName:       tap.Name,
+			TapIfIndex:    tap.Index,
+			SandboxIP:     ip.String(),
+		},
+		tap: tap,
+	}
+	svc.states["sb"] = state
+	if err := svc.store.Save(&state.persistedState); err != nil {
+		t.Fatalf("store.Save error=%v", err)
+	}
+
+	_, err := svc.ReleaseNetwork(context.Background(), &ReleaseNetworkRequest{SandboxID: "sb", NetworkHandle: "sb"})
+	if err == nil {
+		t.Fatal("ReleaseNetwork: expected cleanup failure")
+	}
+
+	svc.mu.Lock()
+	_, stillActive := svc.states["sb"]
+	poolLen := len(svc.tapPool)
+	svc.mu.Unlock()
+	if !stillActive {
+		t.Fatal("state was removed despite cleanup failure")
+	}
+	if poolLen != 0 {
+		t.Fatalf("tapPool len=%d, want 0 (cleanup failed tap must not be reused)", poolLen)
+	}
+}
+
+func TestReleaseNetworkQueuesTapWhenAsyncPrepareFails(t *testing.T) {
+	installEnsureMocks(t)
+	cubevsPrepareTAPPolicy = func(uint32) error {
+		return errors.New("prepare boom")
+	}
+
+	svc := newConcurrencyTestService(t)
+	ip := net.ParseIP("192.168.0.61").To4()
+	tap := &tapDevice{Name: tapName(ip.String()), Index: 81, IP: ip, File: newTestTapFile(t)}
+	state := &managedState{
+		persistedState: persistedState{
+			SandboxID:     "sb",
+			NetworkHandle: "sb",
+			TapName:       tap.Name,
+			TapIfIndex:    tap.Index,
+			SandboxIP:     ip.String(),
+		},
+		tap: tap,
+	}
+	svc.states["sb"] = state
+	if err := svc.store.Save(&state.persistedState); err != nil {
+		t.Fatalf("store.Save error=%v", err)
+	}
+
+	resp, err := svc.ReleaseNetwork(context.Background(), &ReleaseNetworkRequest{SandboxID: "sb", NetworkHandle: "sb"})
+	if err != nil {
+		t.Fatalf("ReleaseNetwork error=%v", err)
+	}
+	if resp == nil || !resp.Released {
+		t.Fatalf("ReleaseNetwork resp=%+v, want Released=true", resp)
+	}
+
+	svc.mu.Lock()
+	_, stillActive := svc.states["sb"]
+	poolLen := len(svc.tapPool)
+	pendingLen := len(svc.abnormalTapPool)
+	svc.mu.Unlock()
+	if stillActive {
+		t.Fatal("state remained active after successful cleanup")
+	}
+	if poolLen != 0 {
+		t.Fatalf("tapPool len=%d, want 0 before async preparation succeeds", poolLen)
+	}
+	if pendingLen != 1 {
+		t.Fatalf("abnormalTapPool len=%d, want 1 pending async preparation", pendingLen)
 	}
 }
 

--- a/network-agent/internal/service/local_service_concurrency_test.go
+++ b/network-agent/internal/service/local_service_concurrency_test.go
@@ -482,7 +482,7 @@ func TestReleaseNetworkDoesNotRecycleTapWhenCubeVSCleanupFails(t *testing.T) {
 	}
 }
 
-func TestReleaseNetworkQueuesTapWhenAsyncPrepareFails(t *testing.T) {
+func TestReleaseNetworkQueuesTapWhenPoolPrepareFails(t *testing.T) {
 	installEnsureMocks(t)
 	cubevsPrepareTAPPolicy = func(uint32) error {
 		return errors.New("prepare boom")
@@ -523,10 +523,10 @@ func TestReleaseNetworkQueuesTapWhenAsyncPrepareFails(t *testing.T) {
 		t.Fatal("state remained active after successful cleanup")
 	}
 	if poolLen != 0 {
-		t.Fatalf("tapPool len=%d, want 0 before async preparation succeeds", poolLen)
+		t.Fatalf("tapPool len=%d, want 0 before pool preparation succeeds", poolLen)
 	}
 	if pendingLen != 1 {
-		t.Fatalf("abnormalTapPool len=%d, want 1 pending async preparation", pendingLen)
+		t.Fatalf("abnormalTapPool len=%d, want 1 pending pool preparation", pendingLen)
 	}
 }
 

--- a/network-agent/internal/service/local_service_test.go
+++ b/network-agent/internal/service/local_service_test.go
@@ -238,11 +238,13 @@ func TestRefreshCubeVSTapForRecoverPropagatesAttachFilterError(t *testing.T) {
 func TestRecoverCleansOrphanTapsWithoutPersistedState(t *testing.T) {
 	oldList := listCubeTapsFunc
 	oldRestore := restoreTapFunc
+	oldPrepareTap := cubevsPrepareTAPPolicy
 	oldListCubeVSTaps := cubevsListTAPDevices
 	oldListPortMappings := cubevsListPortMappings
 	t.Cleanup(func() {
 		listCubeTapsFunc = oldList
 		restoreTapFunc = oldRestore
+		cubevsPrepareTAPPolicy = oldPrepareTap
 		cubevsListTAPDevices = oldListCubeVSTaps
 		cubevsListPortMappings = oldListPortMappings
 	})
@@ -266,6 +268,7 @@ func TestRecoverCleansOrphanTapsWithoutPersistedState(t *testing.T) {
 	}
 	cubevsListTAPDevices = func() ([]cubevs.TAPDevice, error) { return nil, nil }
 	cubevsListPortMappings = func() (map[uint16]cubevs.MVMPort, error) { return map[uint16]cubevs.MVMPort{}, nil }
+	cubevsPrepareTAPPolicy = func(uint32) error { return nil }
 
 	store, err := newStateStore(t.TempDir())
 	if err != nil {
@@ -303,6 +306,7 @@ func TestRecoverKeepsPersistedTapAndRemovesOnlyOrphans(t *testing.T) {
 	oldAdd := cubevsAddTAPDevice
 	oldUpsert := cubevsUpsertTAPDevice
 	oldUpsertMeta := cubevsUpsertTAPDeviceMeta
+	oldPrepareTap := cubevsPrepareTAPPolicy
 	oldListCubeVSTaps := cubevsListTAPDevices
 	oldListPortMappings := cubevsListPortMappings
 	oldARP := addARPEntryFunc
@@ -316,6 +320,7 @@ func TestRecoverKeepsPersistedTapAndRemovesOnlyOrphans(t *testing.T) {
 		cubevsAddTAPDevice = oldAdd
 		cubevsUpsertTAPDevice = oldUpsert
 		cubevsUpsertTAPDeviceMeta = oldUpsertMeta
+		cubevsPrepareTAPPolicy = oldPrepareTap
 		cubevsListTAPDevices = oldListCubeVSTaps
 		cubevsListPortMappings = oldListPortMappings
 		addARPEntryFunc = oldARP
@@ -372,6 +377,7 @@ func TestRecoverKeepsPersistedTapAndRemovesOnlyOrphans(t *testing.T) {
 		return nil
 	}
 	cubevsUpsertTAPDeviceMeta = func(uint32, net.IP, string, uint32) error { return nil }
+	cubevsPrepareTAPPolicy = func(uint32) error { return nil }
 	cubevsListTAPDevices = func() ([]cubevs.TAPDevice, error) { return nil, nil }
 	cubevsListPortMappings = func() (map[uint16]cubevs.MVMPort, error) { return map[uint16]cubevs.MVMPort{}, nil }
 	addARPEntryFunc = func(net.IP, string, int) error { return nil }
@@ -505,6 +511,7 @@ func TestEnsureReleaseEnsureReusesTapFromPool(t *testing.T) {
 	oldRestore := restoreTapFunc
 	oldAddTap := cubevsAddTAPDevice
 	oldDelTap := cubevsDelTAPDevice
+	oldPrepareTap := cubevsPrepareTAPPolicy
 	oldAddPort := cubevsAddPortMap
 	oldDelPort := cubevsDelPortMap
 	oldRouteList := netlinkRouteListFiltered
@@ -514,6 +521,7 @@ func TestEnsureReleaseEnsureReusesTapFromPool(t *testing.T) {
 		restoreTapFunc = oldRestore
 		cubevsAddTAPDevice = oldAddTap
 		cubevsDelTAPDevice = oldDelTap
+		cubevsPrepareTAPPolicy = oldPrepareTap
 		cubevsAddPortMap = oldAddPort
 		cubevsDelPortMap = oldDelPort
 		netlinkRouteListFiltered = oldRouteList
@@ -540,6 +548,7 @@ func TestEnsureReleaseEnsureReusesTapFromPool(t *testing.T) {
 		return nil
 	}
 	cubevsDelTAPDevice = func(uint32, net.IP) error { return nil }
+	cubevsPrepareTAPPolicy = func(uint32) error { return nil }
 	cubevsAddPortMap = func(uint32, uint16, uint16) error { return nil }
 	cubevsDelPortMap = func(uint32, uint16, uint16) error { return nil }
 	netlinkRouteListFiltered = func(_ int, _ *netlink.Route, _ uint64) ([]netlink.Route, error) {
@@ -575,6 +584,13 @@ func TestEnsureReleaseEnsureReusesTapFromPool(t *testing.T) {
 	if _, err := svc.ReleaseNetwork(t.Context(), &ReleaseNetworkRequest{SandboxID: "sandbox-1"}); err != nil {
 		t.Fatalf("ReleaseNetwork error=%v", err)
 	}
+	if len(svc.tapPool) != 0 {
+		t.Fatalf("tapPool len=%d, want 0 before async preparation", len(svc.tapPool))
+	}
+	if len(svc.abnormalTapPool) != 1 {
+		t.Fatalf("abnormalTapPool len=%d, want 1 pending async preparation", len(svc.abnormalTapPool))
+	}
+	svc.handleAbnormalTaps()
 	if len(svc.tapPool) != 1 {
 		t.Fatalf("tapPool len=%d, want 1", len(svc.tapPool))
 	}
@@ -600,6 +616,7 @@ func TestGetTapFileRestoresMissingFD(t *testing.T) {
 	oldGetTap := cubevsGetTAPDevice
 	oldAddTap := cubevsAddTAPDevice
 	oldUpsert := cubevsUpsertTAPDevice
+	oldPrepareTap := cubevsPrepareTAPPolicy
 	oldARP := addARPEntryFunc
 	oldRouteList := netlinkRouteListFiltered
 	oldRouteReplace := netlinkRouteReplace
@@ -613,6 +630,7 @@ func TestGetTapFileRestoresMissingFD(t *testing.T) {
 		cubevsGetTAPDevice = oldGetTap
 		cubevsAddTAPDevice = oldAddTap
 		cubevsUpsertTAPDevice = oldUpsert
+		cubevsPrepareTAPPolicy = oldPrepareTap
 		addARPEntryFunc = oldARP
 		netlinkRouteListFiltered = oldRouteList
 		netlinkRouteReplace = oldRouteReplace
@@ -659,6 +677,7 @@ func TestGetTapFileRestoresMissingFD(t *testing.T) {
 	cubevsGetTAPDevice = func(uint32) (*cubevs.TAPDevice, error) { return &cubevs.TAPDevice{}, nil }
 	cubevsAddTAPDevice = func(uint32, net.IP, string, uint32, cubevs.MVMOptions) error { return nil }
 	cubevsUpsertTAPDevice = func(uint32, net.IP, string, uint32, cubevs.MVMOptions) error { return nil }
+	cubevsPrepareTAPPolicy = func(uint32) error { return nil }
 	addARPEntryFunc = func(net.IP, string, int) error { return nil }
 	netlinkRouteListFiltered = func(_ int, _ *netlink.Route, _ uint64) ([]netlink.Route, error) { return nil, nil }
 	netlinkRouteReplace = func(_ *netlink.Route) error { return nil }
@@ -715,6 +734,7 @@ func TestGetTapFileHotPathOpenFailureSelfHeals(t *testing.T) {
 	oldGetTap := cubevsGetTAPDevice
 	oldAddTap := cubevsAddTAPDevice
 	oldUpsert := cubevsUpsertTAPDevice
+	oldPrepareTap := cubevsPrepareTAPPolicy
 	oldARP := addARPEntryFunc
 	oldRouteList := netlinkRouteListFiltered
 	oldRouteReplace := netlinkRouteReplace
@@ -728,6 +748,7 @@ func TestGetTapFileHotPathOpenFailureSelfHeals(t *testing.T) {
 		cubevsGetTAPDevice = oldGetTap
 		cubevsAddTAPDevice = oldAddTap
 		cubevsUpsertTAPDevice = oldUpsert
+		cubevsPrepareTAPPolicy = oldPrepareTap
 		addARPEntryFunc = oldARP
 		netlinkRouteListFiltered = oldRouteList
 		netlinkRouteReplace = oldRouteReplace
@@ -774,6 +795,7 @@ func TestGetTapFileHotPathOpenFailureSelfHeals(t *testing.T) {
 	cubevsGetTAPDevice = func(uint32) (*cubevs.TAPDevice, error) { return &cubevs.TAPDevice{}, nil }
 	cubevsAddTAPDevice = func(uint32, net.IP, string, uint32, cubevs.MVMOptions) error { return nil }
 	cubevsUpsertTAPDevice = func(uint32, net.IP, string, uint32, cubevs.MVMOptions) error { return nil }
+	cubevsPrepareTAPPolicy = func(uint32) error { return nil }
 	addARPEntryFunc = func(net.IP, string, int) error { return nil }
 	netlinkRouteListFiltered = func(_ int, _ *netlink.Route, _ uint64) ([]netlink.Route, error) { return nil, nil }
 	netlinkRouteReplace = func(_ *netlink.Route) error { return nil }

--- a/network-agent/internal/service/tap_lifecycle.go
+++ b/network-agent/internal/service/tap_lifecycle.go
@@ -6,6 +6,7 @@ package service
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"time"
@@ -27,11 +28,36 @@ const maxAbnormalRecoveryAttempts = 3
 
 const (
 	abnormalStageRecycle         = "recycle"
+	abnormalStagePreparePool     = "prepare_pool"
 	abnormalStageRecoverRestore  = "recover_restore"
 	abnormalStageRecoverCleanup  = "recover_cleanup"
 	abnormalStageRetryRestore    = "retry_restore"
 	abnormalStageLegacyDestroyed = "legacy_destroy_queue"
 )
+
+type tapCleanupError struct {
+	err error
+}
+
+func (e tapCleanupError) Error() string {
+	return e.err.Error()
+}
+
+func (e tapCleanupError) Unwrap() error {
+	return e.err
+}
+
+func markTapCleanupError(err error) error {
+	if err == nil {
+		return nil
+	}
+	return tapCleanupError{err: err}
+}
+
+func isTapCleanupError(err error) bool {
+	var cleanupErr tapCleanupError
+	return errors.As(err, &cleanupErr)
+}
 
 func (s *localService) enqueueTapLocked(tap *tapDevice) {
 	if tap == nil {
@@ -83,6 +109,55 @@ func (s *localService) enqueueAbnormalLocked(tap *tapDevice, stage string, err e
 	)
 }
 
+func (s *localService) enqueuePreparePoolLocked(tap *tapDevice, reason string) {
+	if tap == nil {
+		return
+	}
+	closeTapFile(tap.File)
+	tap.File = nil
+	tap.InUse = false
+	tap.FailureCount = 0
+	tap.LastStage = abnormalStagePreparePool
+	tap.LastError = ""
+	tap.PortMappings = nil
+	s.abnormalTapPool = append(s.abnormalTapPool, tap)
+	CubeLog.WithContext(context.Background()).Infof(
+		"network-agent tap queued for async pool preparation: name=%s ifindex=%d reason=%s pool=%d pending=%d quarantined=%d",
+		tap.Name, tap.Index, reason, len(s.tapPool), len(s.abnormalTapPool), len(s.quarantinedTaps),
+	)
+}
+
+func (s *localService) requeuePreparePoolFailureLocked(tap *tapDevice, err error) {
+	if tap == nil {
+		return
+	}
+	closeTapFile(tap.File)
+	tap.File = nil
+	tap.InUse = false
+	tap.PortMappings = nil
+	tap.FailureCount++
+	tap.LastStage = abnormalStagePreparePool
+	if err != nil {
+		tap.LastError = err.Error()
+	}
+	if tap.FailureCount >= maxAbnormalRecoveryAttempts {
+		if s.quarantinedTaps == nil {
+			s.quarantinedTaps = make(map[string]*tapDevice)
+		}
+		s.quarantinedTaps[tap.Name] = tap
+		CubeLog.WithContext(context.Background()).Errorf(
+			"network-agent quarantined tap after repeated pool preparation failures: name=%s ifindex=%d failures=%d err=%v quarantined=%d",
+			tap.Name, tap.Index, tap.FailureCount, err, len(s.quarantinedTaps),
+		)
+		return
+	}
+	s.abnormalTapPool = append(s.abnormalTapPool, tap)
+	CubeLog.WithContext(context.Background()).Warnf(
+		"network-agent tap pool preparation failed, will retry: name=%s ifindex=%d failures=%d err=%v pending=%d",
+		tap.Name, tap.Index, tap.FailureCount, err, len(s.abnormalTapPool),
+	)
+}
+
 func (s *localService) dequeueAbnormalLocked() *tapDevice {
 	for len(s.abnormalTapPool) > 0 {
 		tap := s.abnormalTapPool[0]
@@ -101,7 +176,9 @@ func (s *localService) configurePortMappings(tap *tapDevice, requestedMappings [
 		if hostPort == 0 {
 			allocatedPort, err := s.ports.Allocate()
 			if err != nil {
-				s.clearPortMappings(tap)
+				if cleanupErr := s.clearPortMappings(tap); cleanupErr != nil {
+					return nil, errors.Join(err, markTapCleanupError(cleanupErr))
+				}
 				return nil, err
 			}
 			hostPort = int32(allocatedPort)
@@ -109,10 +186,10 @@ func (s *localService) configurePortMappings(tap *tapDevice, requestedMappings [
 			s.ports.Assign(uint16(hostPort))
 		}
 		if err := cubevsAddPortMap(uint32(tap.Index), uint16(mapping.ContainerPort), uint16(hostPort)); err != nil {
-			if mapping.HostPort == 0 {
-				s.ports.Release(uint16(hostPort))
+			s.ports.Release(uint16(hostPort))
+			if cleanupErr := s.clearPortMappings(tap); cleanupErr != nil {
+				return nil, errors.Join(err, markTapCleanupError(cleanupErr))
 			}
-			s.clearPortMappings(tap)
 			return nil, err
 		}
 		actualMappings = append(actualMappings, PortMapping{
@@ -121,20 +198,32 @@ func (s *localService) configurePortMappings(tap *tapDevice, requestedMappings [
 			HostPort:      int32(hostPort),
 			ContainerPort: mapping.ContainerPort,
 		})
+		tap.PortMappings = append([]PortMapping(nil), actualMappings...)
 	}
-	tap.PortMappings = append([]PortMapping(nil), actualMappings...)
 	return actualMappings, nil
 }
 
-func (s *localService) clearPortMappings(tap *tapDevice) {
+func (s *localService) clearPortMappings(tap *tapDevice) error {
 	if tap == nil {
-		return
+		return nil
 	}
+	remaining := tap.PortMappings[:0]
+	var cleanupErr error
 	for _, mapping := range tap.PortMappings {
-		_ = cubevsDelPortMap(uint32(tap.Index), uint16(mapping.ContainerPort), uint16(mapping.HostPort))
+		if err := cubevsDelPortMap(uint32(tap.Index), uint16(mapping.ContainerPort), uint16(mapping.HostPort)); err != nil {
+			cleanupErr = errors.Join(cleanupErr, fmt.Errorf("delete port mapping %d->%d for tap %s(%d): %w",
+				mapping.ContainerPort, mapping.HostPort, tap.Name, tap.Index, err))
+			remaining = append(remaining, mapping)
+			continue
+		}
 		s.ports.Release(uint16(mapping.HostPort))
 	}
+	if cleanupErr != nil {
+		tap.PortMappings = remaining
+		return cleanupErr
+	}
 	tap.PortMappings = nil
+	return nil
 }
 
 func (s *localService) recycleTapLocked(tap *tapDevice) {
@@ -155,9 +244,12 @@ func (s *localService) createPoolTap() error {
 		s.allocator.Release(ip)
 		return err
 	}
-	s.mu.Lock()
-	s.stageTapForPoolLocked(tap, "create_pool")
-	s.mu.Unlock()
+	if err := s.prepareAndStageTapForPool(context.Background(), tap, "create_pool"); err != nil {
+		closeTapFile(tap.File)
+		_ = destroyTapFunc(tap.Index)
+		s.allocator.Release(ip)
+		return err
+	}
 	return nil
 }
 
@@ -247,6 +339,14 @@ func (s *localService) handleAbnormalTaps() {
 		if tap == nil {
 			break
 		}
+		if tap.LastStage == abnormalStagePreparePool {
+			if err := s.prepareAndStageTapForPool(context.Background(), tap, "async_prepare"); err != nil {
+				s.mu.Lock()
+				s.requeuePreparePoolFailureLocked(tap, err)
+				s.mu.Unlock()
+			}
+			continue
+		}
 		restored, err := s.tryRecoverAbnormalTap(tap)
 		if err != nil {
 			s.mu.Lock()
@@ -268,9 +368,12 @@ func (s *localService) handleAbnormalTaps() {
 			s.mu.Unlock()
 			continue
 		}
-		s.mu.Lock()
-		s.stageTapForPoolLocked(restored, "abnormal_recovered")
-		s.mu.Unlock()
+		if err := s.prepareAndStageTapForPool(context.Background(), restored, "abnormal_recovered"); err != nil {
+			s.mu.Lock()
+			s.requeuePreparePoolFailureLocked(restored, err)
+			s.mu.Unlock()
+			continue
+		}
 	}
 
 	if missingReleased {
@@ -306,8 +409,11 @@ func (s *localService) tryRecoverAbnormalTap(tap *tapDevice) (*tapDevice, error)
 		return nil, err
 	}
 	if tap.LastStage == abnormalStageRecoverCleanup {
-		s.clearPortMappings(restored)
-		if err := cubevsDelTAPDevice(uint32(restored.Index), restored.IP.To4()); err != nil {
+		if err := s.clearPortMappings(restored); err != nil {
+			tap.LastError = err.Error()
+			return nil, err
+		}
+		if err := s.cleanupCubeVSTap(restored.Index, restored.IP.To4()); err != nil {
 			tap.LastError = err.Error()
 			return nil, err
 		}

--- a/network-agent/internal/service/tap_lifecycle.go
+++ b/network-agent/internal/service/tap_lifecycle.go
@@ -109,24 +109,6 @@ func (s *localService) enqueueAbnormalLocked(tap *tapDevice, stage string, err e
 	)
 }
 
-func (s *localService) enqueuePreparePoolLocked(tap *tapDevice, reason string) {
-	if tap == nil {
-		return
-	}
-	closeTapFile(tap.File)
-	tap.File = nil
-	tap.InUse = false
-	tap.FailureCount = 0
-	tap.LastStage = abnormalStagePreparePool
-	tap.LastError = ""
-	tap.PortMappings = nil
-	s.abnormalTapPool = append(s.abnormalTapPool, tap)
-	CubeLog.WithContext(context.Background()).Infof(
-		"network-agent tap queued for async pool preparation: name=%s ifindex=%d reason=%s pool=%d pending=%d quarantined=%d",
-		tap.Name, tap.Index, reason, len(s.tapPool), len(s.abnormalTapPool), len(s.quarantinedTaps),
-	)
-}
-
 func (s *localService) requeuePreparePoolFailureLocked(tap *tapDevice, err error) {
 	if tap == nil {
 		return
@@ -186,7 +168,9 @@ func (s *localService) configurePortMappings(tap *tapDevice, requestedMappings [
 			s.ports.Assign(uint16(hostPort))
 		}
 		if err := cubevsAddPortMap(uint32(tap.Index), uint16(mapping.ContainerPort), uint16(hostPort)); err != nil {
-			s.ports.Release(uint16(hostPort))
+			if mapping.HostPort == 0 {
+				s.ports.Release(uint16(hostPort))
+			}
 			if cleanupErr := s.clearPortMappings(tap); cleanupErr != nil {
 				return nil, errors.Join(err, markTapCleanupError(cleanupErr))
 			}
@@ -351,7 +335,11 @@ func (s *localService) handleAbnormalTaps() {
 		if err != nil {
 			s.mu.Lock()
 			tap.FailureCount++
-			tap.LastStage = abnormalStageRetryRestore
+			retryStage := abnormalStageRetryRestore
+			if tap.LastStage == abnormalStageRecoverCleanup {
+				retryStage = abnormalStageRecoverCleanup
+			}
+			tap.LastStage = retryStage
 			tap.LastError = err.Error()
 			if isTapMissingError(err) {
 				logger.Warnf("network-agent abnormal tap missing on host, releasing ip: name=%s ifindex=%d ip=%s err=%v",
@@ -363,7 +351,7 @@ func (s *localService) handleAbnormalTaps() {
 				logger.Errorf("network-agent quarantined tap after repeated recovery failures: name=%s ifindex=%d failures=%d last_stage=%s err=%s quarantined=%d",
 					tap.Name, tap.Index, tap.FailureCount, tap.LastStage, tap.LastError, len(s.quarantinedTaps))
 			} else {
-				s.enqueueAbnormalLocked(tap, abnormalStageRetryRestore, err)
+				s.enqueueAbnormalLocked(tap, retryStage, err)
 			}
 			s.mu.Unlock()
 			continue

--- a/network-agent/internal/service/tap_lifecycle_test.go
+++ b/network-agent/internal/service/tap_lifecycle_test.go
@@ -46,9 +46,11 @@ func TestRecycleTapLockedStagesTapWithoutRestore(t *testing.T) {
 func TestCreatePoolTapLockedStagesNewTapWithoutRestore(t *testing.T) {
 	oldNewTap := newTapFunc
 	oldRestore := restoreTapFunc
+	oldPrepareTap := cubevsPrepareTAPPolicy
 	t.Cleanup(func() {
 		newTapFunc = oldNewTap
 		restoreTapFunc = oldRestore
+		cubevsPrepareTAPPolicy = oldPrepareTap
 	})
 
 	restoreCalls := 0
@@ -65,6 +67,7 @@ func TestCreatePoolTapLockedStagesNewTapWithoutRestore(t *testing.T) {
 			InUse: true,
 		}, nil
 	}
+	cubevsPrepareTAPPolicy = func(uint32) error { return nil }
 
 	svc := newLifecycleTestService(t)
 	if err := svc.createPoolTap(); err != nil {
@@ -82,16 +85,61 @@ func TestCreatePoolTapLockedStagesNewTapWithoutRestore(t *testing.T) {
 	}
 }
 
+func TestCreatePoolTapDoesNotPoolWhenPrepareFails(t *testing.T) {
+	oldNewTap := newTapFunc
+	oldPrepareTap := cubevsPrepareTAPPolicy
+	oldDestroy := destroyTapFunc
+	t.Cleanup(func() {
+		newTapFunc = oldNewTap
+		cubevsPrepareTAPPolicy = oldPrepareTap
+		destroyTapFunc = oldDestroy
+	})
+
+	newTapFunc = func(ip net.IP, _ string, _ int, _ int) (*tapDevice, error) {
+		return &tapDevice{
+			Name:  tapName(ip.String()),
+			Index: 31,
+			IP:    ip,
+			File:  newTestTapFile(t),
+			InUse: true,
+		}, nil
+	}
+	cubevsPrepareTAPPolicy = func(uint32) error { return errors.New("prepare boom") }
+	destroyCalls := 0
+	destroyTapFunc = func(int) error {
+		destroyCalls++
+		return nil
+	}
+
+	svc := newLifecycleTestService(t)
+	usedBefore := svc.allocator.usedIPNum
+	if err := svc.createPoolTap(); err == nil {
+		t.Fatal("createPoolTap returned nil error")
+	}
+	if len(svc.tapPool) != 0 {
+		t.Fatalf("tapPool len=%d, want 0", len(svc.tapPool))
+	}
+	if destroyCalls != 1 {
+		t.Fatalf("destroyCalls=%d, want 1", destroyCalls)
+	}
+	if svc.allocator.usedIPNum != usedBefore {
+		t.Fatalf("usedIPNum=%d, want %d", svc.allocator.usedIPNum, usedBefore)
+	}
+}
+
 func TestHandleAbnormalTapsRecoversTapBackToPool(t *testing.T) {
 	oldRestore := restoreTapFunc
+	oldPrepareTap := cubevsPrepareTAPPolicy
 	t.Cleanup(func() {
 		restoreTapFunc = oldRestore
+		cubevsPrepareTAPPolicy = oldPrepareTap
 	})
 
 	restoreTapFunc = func(tap *tapDevice, _ int, _ string, _ int) (*tapDevice, error) {
 		tap.File = newTestTapFile(t)
 		return tap, nil
 	}
+	cubevsPrepareTAPPolicy = func(uint32) error { return nil }
 
 	svc := newLifecycleTestService(t)
 	tap := &tapDevice{


### PR DESCRIPTION
Keep TAP devices out of the reusable pool when sandbox cleanup fails. Port mappings and CubeVS policy metadata must be cleaned successfully before a TAP can be recycled, so stale allow/deny state cannot leak into a later sandbox that reuses the same ifindex.

Move the default private/link-local deny ranges out of the sandbox creation hot path. TAPs now receive those invariant deny_out entries when they are initialized or asynchronously prepared for the pool, while replace/recover paths still replay them after flushing policy maps.