### PR TITLE
fix(sdk/go): align allowOut domain guard with CubeAPI

### DIFF
--- a/sdk/go/aligned_test.go
+++ b/sdk/go/aligned_test.go
@@ -30,7 +30,7 @@ func TestCreateSerializesPolicyAndPublicTraffic(t *testing.T) {
 	_, err := client.Create(context.Background(), CreateOptions{
 		Network: NetworkOptions{
 			AllowPublicTraffic: &allowPublic,
-			AllowOut:           []string{"api.github.com"},
+			AllowOut:           []string{"172.67.0.0/16"},
 			Rules: []Rule{{
 				Name:   "gh",
 				Match:  Match{Host: "api.github.com", Scheme: "https"},
@@ -81,6 +81,63 @@ func TestCreateRejectsAllowOutDomainWithoutDenyAll(t *testing.T) {
 	if called {
 		t.Fatal("request should not be sent when validation fails")
 	}
+}
+
+func TestCreateRejectsAllowOutDomainWhenOnlyAllowPublicTrafficDisabled(t *testing.T) {
+	called := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusCreated)
+		fmt.Fprint(w, sandboxJSON(testSandboxID, "tpl-env"))
+	}))
+	defer server.Close()
+
+	allowPublic := false
+	client := NewClient(Config{APIURL: server.URL, TemplateID: "tpl-env"})
+	_, err := client.Create(context.Background(), CreateOptions{
+		Network: NetworkOptions{
+			AllowPublicTraffic: &allowPublic,
+			AllowOut:           []string{"api.example.com"},
+		},
+	})
+	if err == nil || !strings.Contains(err.Error(), "deny_out") {
+		t.Fatalf("err=%v, want allow_out domain guard", err)
+	}
+	if called {
+		t.Fatal("request should not be sent when validation fails")
+	}
+}
+
+func TestCreateAcceptsAllowOutDomainWhenInternetAccessDisabled(t *testing.T) {
+	var got map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&got); err != nil {
+			t.Fatalf("decode body: %v", err)
+		}
+		w.WriteHeader(http.StatusCreated)
+		fmt.Fprint(w, sandboxJSON(testSandboxID, "tpl-env"))
+	}))
+	defer server.Close()
+
+	disableInternet := false
+	client := NewClient(Config{APIURL: server.URL, TemplateID: "tpl-env"})
+	_, err := client.Create(context.Background(), CreateOptions{
+		AllowInternetAccess: &disableInternet,
+		Network: NetworkOptions{
+			AllowOut: []string{"api.example.com"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if got["allowInternetAccess"] != false {
+		t.Fatalf("allowInternetAccess=%#v, want false", got["allowInternetAccess"])
+	}
+	network, ok := got["network"].(map[string]any)
+	if !ok {
+		t.Fatalf("network=%#v", got["network"])
+	}
+	assertStringSlice(t, network["allowOut"], []string{"api.example.com"})
 }
 
 func TestInjectRender(t *testing.T) {

--- a/sdk/go/client.go
+++ b/sdk/go/client.go
@@ -134,15 +134,14 @@ func (c *Client) createPayload(opts CreateOptions) (map[string]any, error) {
 	if len(opts.Metadata) > 0 {
 		payload["metadata"] = opts.Metadata
 	}
-	if opts.AllowInternetAccess != nil && !*opts.AllowInternetAccess {
+	internetAccessDisabled := opts.AllowInternetAccess != nil && !*opts.AllowInternetAccess
+	if internetAccessDisabled {
 		payload["allowInternetAccess"] = false
 	}
 
-	// Allowing specific domains is only enforceable when all other egress is
-	// denied (public traffic off, or 0.0.0.0/0 in denyOut).
-	defaultDenyAll := (opts.AllowInternetAccess != nil && !*opts.AllowInternetAccess) ||
-		(opts.Network.AllowPublicTraffic != nil && !*opts.Network.AllowPublicTraffic)
-	if err := validateAllowOutDomainsRequireDenyAll(opts.Network.AllowOut, opts.Network.DenyOut, defaultDenyAll); err != nil {
+	// Mirror the server-side contract: domain allowOut requires either
+	// allowInternetAccess=false or an explicit deny-all CIDR in denyOut.
+	if err := validateAllowOutDomainsRequireDenyAll(opts.Network.AllowOut, opts.Network.DenyOut, internetAccessDisabled); err != nil {
 		return nil, err
 	}
 

--- a/sdk/go/policy.go
+++ b/sdk/go/policy.go
@@ -63,10 +63,10 @@ const (
 		"outbound traffic or include '0.0.0.0/0' in deny_out to block all other traffic."
 )
 
-// validateAllowOutDomainsRequireDenyAll mirrors the Python guard: allowing
-// specific domains is meaningful only when all other egress is denied, either
-// by disabling public traffic (defaultDenyAll) or by listing 0.0.0.0/0 in
-// denyOut. Returns nil when allowOut carries no domain target.
+// validateAllowOutDomainsRequireDenyAll mirrors the current server contract:
+// allowing specific domains is meaningful only when all other egress is denied,
+// either by allowInternetAccess=false (defaultDenyAll) or by listing
+// 0.0.0.0/0 in denyOut. Returns nil when allowOut carries no domain target.
 func validateAllowOutDomainsRequireDenyAll(allowOut, denyOut []string, defaultDenyAll bool) error {
 	hasDomain := false
 	for _, target := range allowOut {


### PR DESCRIPTION
## Motivation

The Go SDK currently treats `network.allowPublicTraffic = false` as satisfying the domain `allowOut` guard during sandbox creation.

That does not match the CubeAPI contract. Server-side validation only treats `network.allowInternetAccess = false` or an explicit `network.denyOut: ["0.0.0.0/0"]` as deny-all for domain-based `allowOut` validation.

This was observed on a real deployment when using the Go SDK with `AllowPublicTraffic=false`, `AllowOut=["api.example.com"]`, and default `AllowInternetAccess`. The SDK accepted the request and sent it to CubeAPI, which then rejected it with HTTP 400:

```text
When specifying allowed domains in allow_out, you must disable public outbound traffic or include '0.0.0.0/0' in deny_out to block all other traffic.
```

This PR aligns the SDK's local validation with CubeAPI, so this invalid parameter combination is rejected before the request is sent.

## What Changed

* Stop treating `AllowPublicTraffic = false` as deny-all in Go SDK sandbox-create validation.
* Add focused coverage for the case where domain `allowOut` is used while only `AllowPublicTraffic` is disabled.

## Scope

This PR only updates Go SDK sandbox-create validation and its tests.

It does not change template-build validation or broader network-policy behavior.

## Validation

In `sdk/go`:

```bash
go test -vet=off . -run 'TestCreateSerializesPolicyAndPublicTraffic|TestCreateRejectsAllowOutDomainWithoutDenyAll|TestCreateRejectsAllowOutDomainWhenOnlyAllowPublicTrafficDisabled|TestCreateSendsPythonCompatiblePayload|TestBuildTemplateForwardsCreateFromImageOptions|TestBuildTemplateRequiresImage|TestGetTemplateParsesNetworkFields' -count=1
```