### PR TITLE
feat: sandbox timeout refactor — server-side default + three-value timeout semantics

### DIFF
--- a/CubeAPI/src/handlers/agenthub.rs
+++ b/CubeAPI/src/handlers/agenthub.rs
@@ -464,7 +464,7 @@ pub async fn create_agent_instance(
         .sandboxes
         .create_sandbox(NewSandbox {
             template_id: template_id.clone(),
-            timeout,
+            timeout: Some(timeout),
             lifecycle: None,
             secure: None,
             allow_internet_access: Some(true),
@@ -2226,7 +2226,7 @@ pub async fn clone_agent_instance(
         .sandboxes
         .create_sandbox(NewSandbox {
             template_id: snapshot_id.clone(),
-            timeout,
+            timeout: Some(timeout),
             lifecycle: None,
             secure: None,
             allow_internet_access: Some(true),
@@ -2932,7 +2932,7 @@ pub async fn resume_agent_openclaw(
     state
         .services
         .sandboxes
-        .connect_sandbox(&record.sandbox_id, timeout)
+        .connect_sandbox(&record.sandbox_id, Some(timeout))
         .await?;
     let store = state.agenthub_store.as_ref().ok_or_else(|| {
         AppError::BadRequest("AgentHub database persistence is not configured".to_string())

--- a/CubeAPI/src/handlers/sandboxes.rs
+++ b/CubeAPI/src/handlers/sandboxes.rs
@@ -8,9 +8,10 @@ use axum::{
     response::IntoResponse,
     Json,
 };
+use validator::Validate;
 
 use crate::{
-    error::AppResult,
+    error::{AppError, AppResult},
     logging::{LogEvent, LogLevel},
     models::{
         ApiError, ConnectSandbox, ListSandboxesQuery, ListSandboxesV2Query, NewSandbox,
@@ -421,6 +422,9 @@ pub async fn set_sandbox_timeout(
     Path(sandbox_id): Path<String>,
     Json(body): Json<SetTimeoutRequest>,
 ) -> AppResult<impl IntoResponse> {
+    body.validate()
+        .map_err(|e| AppError::BadRequest(e.to_string()))?;
+
     state
         .logger
         .log(

--- a/CubeAPI/src/models/mod.rs
+++ b/CubeAPI/src/models/mod.rs
@@ -171,9 +171,9 @@ pub struct NewSandbox {
     #[serde(rename = "templateID")]
     pub template_id: String,
 
-    #[validate(range(min = 0))]
-    #[serde(default = "default_timeout")]
-    pub timeout: i32,
+    /// Optional idle TTL in seconds. See docs/guide/lifecycle.md.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub timeout: Option<i32>,
 
     /// Sandbox lifecycle configuration. Maps to e2b's `lifecycle` object so
     /// callers that already speak e2b can pass through unchanged. Absent
@@ -213,10 +213,6 @@ pub struct NewSandbox {
 
     #[serde(rename = "volumeMounts", skip_serializing_if = "Option::is_none")]
     pub volume_mounts: Option<Vec<SandboxVolumeMount>>,
-}
-
-fn default_timeout() -> i32 {
-    15
 }
 
 // ─── Sandbox — create / connect response ──────────────────────────────────
@@ -265,8 +261,10 @@ pub struct ListedSandbox {
     pub client_id: String,
     #[serde(rename = "startedAt")]
     pub started_at: DateTime<Utc>,
-    #[serde(rename = "endAt")]
-    pub end_at: DateTime<Utc>,
+    /// Projected next-timeout instant. Omitted for never-timeout sandboxes
+    /// (no deadline) rather than being misreported as equal to startedAt.
+    #[serde(rename = "endAt", skip_serializing_if = "Option::is_none")]
+    pub end_at: Option<DateTime<Utc>>,
     #[serde(rename = "cpuCount")]
     pub cpu_count: i32,
     #[serde(rename = "memoryMB")]
@@ -295,8 +293,10 @@ pub struct SandboxDetail {
     pub client_id: String,
     #[serde(rename = "startedAt")]
     pub started_at: DateTime<Utc>,
-    #[serde(rename = "endAt")]
-    pub end_at: DateTime<Utc>,
+    /// Projected next-timeout instant. Omitted for never-timeout sandboxes
+    /// (no deadline) rather than being misreported as equal to startedAt.
+    #[serde(rename = "endAt", skip_serializing_if = "Option::is_none")]
+    pub end_at: Option<DateTime<Utc>>,
     #[serde(rename = "envdVersion")]
     pub envd_version: String,
     #[serde(rename = "envdAccessToken", skip_serializing_if = "Option::is_none")]
@@ -322,8 +322,9 @@ pub struct SandboxDetail {
 #[derive(Debug, Deserialize, ToSchema)]
 #[allow(dead_code)]
 pub struct ResumedSandbox {
-    #[serde(default = "default_timeout")]
-    pub timeout: i32,
+    /// Idle timeout in seconds; None when the client did not send one.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub timeout: Option<i32>,
     #[serde(rename = "autoPause", default)]
     pub auto_pause: bool,
 }
@@ -331,8 +332,9 @@ pub struct ResumedSandbox {
 /// Request body for POST /sandboxes/{id}/connect.
 #[derive(Debug, Deserialize, Validate, ToSchema)]
 pub struct ConnectSandbox {
-    #[validate(range(min = 0))]
-    pub timeout: i32,
+    /// Idle timeout in seconds; None when the client did not send one.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub timeout: Option<i32>,
 }
 
 /// Request body for POST /sandboxes/{id}/snapshots.
@@ -516,7 +518,26 @@ fn default_page_limit() -> i32 {
 
 #[cfg(test)]
 mod tests {
-    use super::{NewSandbox, SandboxNetworkConfig};
+    use super::{NewSandbox, SandboxNetworkConfig, SetTimeoutRequest};
+    use validator::Validate;
+
+    #[test]
+    fn set_timeout_request_rejects_negative_values() {
+        let req = SetTimeoutRequest { timeout: -1 };
+        assert!(
+            req.validate().is_err(),
+            "negative timeout should be rejected"
+        );
+    }
+
+    #[test]
+    fn set_timeout_request_accepts_zero_and_positive() {
+        for timeout in [0, 60, 3600] {
+            let req = SetTimeoutRequest { timeout };
+            req.validate()
+                .unwrap_or_else(|e| panic!("timeout={timeout} should be valid: {e}"));
+        }
+    }
 
     #[test]
     fn sandbox_network_config_accepts_snake_case_policy_fields() {

--- a/CubeAPI/src/services/sandboxes.rs
+++ b/CubeAPI/src/services/sandboxes.rs
@@ -117,11 +117,13 @@ impl SandboxService {
             .and_then(|s| s.started_at.as_ref().cloned())
             .or(d.started_at)
             .unwrap_or_else(chrono::Utc::now);
+        // Leave end_at as None for never-timeout sandboxes (CubeMaster returns
+        // no end instant) instead of collapsing it onto started_at, which
+        // would read as "already expired".
         let end_at = summary
             .as_ref()
             .and_then(|s| s.end_at.as_ref().cloned())
-            .or(d.end_at)
-            .unwrap_or(started_at);
+            .or(d.end_at);
 
         let envd_version = envd_version_from_annotations(&d.annotations);
         Ok(SandboxDetail {
@@ -196,7 +198,10 @@ impl SandboxService {
         let req = CreateSandboxRequest {
             request_id: new_request_id(),
             instance_type: self.instance_type.clone(),
-            timeout: Some(timeout),
+            // Pass the client's timeout through as-is: None → field omitted so
+            // CubeMaster applies its server default; Some(0) → immediate
+            // timeout; Some(n) → explicit TTL. No SDK/API-side default fill.
+            timeout,
             annotations,
             labels,
             create_time_env_vars: env_vars,
@@ -266,10 +271,14 @@ impl SandboxService {
         )
     }
 
-    pub async fn resume_sandbox(&self, sandbox_id: &str, timeout: i32) -> AppResult<Sandbox> {
+    pub async fn resume_sandbox(
+        &self,
+        sandbox_id: &str,
+        timeout: Option<i32>,
+    ) -> AppResult<Sandbox> {
         let resp = self
             .cubemaster
-            .update_sandbox(&self.build_update_request(sandbox_id, "resume", Some(timeout)))
+            .update_sandbox(&self.build_update_request(sandbox_id, "resume", timeout))
             .await
             .map_err(|e| map_update_cubemaster_err(e, sandbox_id))?;
 
@@ -295,13 +304,17 @@ impl SandboxService {
         ))
     }
 
-    pub async fn connect_sandbox(&self, sandbox_id: &str, timeout: i32) -> AppResult<Sandbox> {
+    pub async fn connect_sandbox(
+        &self,
+        sandbox_id: &str,
+        timeout: Option<i32>,
+    ) -> AppResult<Sandbox> {
         let mut d = self.fetch_sandbox_detail(sandbox_id).await?;
 
         if d.status == SandboxStatus::Paused {
             let resp = self
                 .cubemaster
-                .update_sandbox(&self.build_update_request(sandbox_id, "resume", Some(timeout)))
+                .update_sandbox(&self.build_update_request(sandbox_id, "resume", timeout))
                 .await
                 .map_err(|e| map_update_cubemaster_err(e, sandbox_id))?;
 
@@ -714,7 +727,7 @@ pub(crate) fn from_cubemaster_info(s: SandboxInfo) -> crate::models::ListedSandb
         sandbox_id: s.sandbox_id,
         client_id: s.host_id,
         started_at,
-        end_at: s.end_at.unwrap_or(now),
+        end_at: s.end_at,
         cpu_count: s.cpu_count,
         memory_mb: s.memory_mb,
         disk_size_mb: Some(0),
@@ -877,6 +890,7 @@ mod tests {
     };
     use crate::cubemaster::{
         CreateSandboxRequest, CubeMasterClient, ListSandboxResponse, SandboxInfo,
+        SandboxUpdateRequest,
     };
     use crate::models::{
         EgressRule, EgressRuleAction, EgressRuleInject, EgressRuleMatch, NewSandbox,
@@ -1162,6 +1176,88 @@ mod tests {
         );
     }
 
+    fn empty_create_request() -> CreateSandboxRequest {
+        CreateSandboxRequest {
+            request_id: "req-1".to_string(),
+            instance_type: "cubebox".to_string(),
+            timeout: None,
+            annotations: HashMap::new(),
+            labels: None,
+            create_time_env_vars: None,
+            distribution_scope: None,
+            volumes: None,
+            containers: vec![],
+            exposed_ports: vec![],
+            network_type: None,
+            cube_network_config: None,
+            auto_pause: false,
+            auto_resume: false,
+        }
+    }
+
+    /// CubeMaster applies its server default only when the timeout key is
+    /// absent. Lock down the three-value wire shape (omit / 0 / negative / positive).
+    #[test]
+    fn create_sandbox_request_timeout_wire_shape() {
+        let mut req = empty_create_request();
+        let json = serde_json::to_value(&req).unwrap();
+        assert!(
+            json.get("timeout").is_none(),
+            "timeout=None should be omitted, got: {json}"
+        );
+
+        for (value, label) in [(0, "zero"), (-1, "never"), (45, "positive")] {
+            req.timeout = Some(value);
+            let json = serde_json::to_value(&req).unwrap();
+            assert_eq!(
+                json.get("timeout"),
+                Some(&serde_json::Value::from(value)),
+                "timeout={label} should be forwarded as-is, got: {json}"
+            );
+        }
+    }
+
+    #[test]
+    fn new_sandbox_timeout_defaults_to_none_when_omitted() {
+        let req: NewSandbox = serde_json::from_value(serde_json::json!({
+            "templateID": "tpl",
+        }))
+        .unwrap();
+        assert_eq!(req.timeout, None);
+    }
+
+    #[test]
+    fn sandbox_update_request_timeout_wire_shape() {
+        let req = SandboxUpdateRequest {
+            request_id: "req-1".to_string(),
+            sandbox_id: "sb-1".to_string(),
+            instance_type: "cubebox".to_string(),
+            action: "resume".to_string(),
+            timeout: None,
+        };
+        let json = serde_json::to_value(&req).unwrap();
+        assert!(
+            json.get("timeout").is_none(),
+            "resume/connect with timeout=None should omit field, got: {json}"
+        );
+
+        for (value, label) in [(0, "zero"), (-1, "never"), (120, "positive")] {
+            let req = SandboxUpdateRequest {
+                request_id: "req-1".to_string(),
+                sandbox_id: "sb-1".to_string(),
+                instance_type: "cubebox".to_string(),
+                action: "resume".to_string(),
+                timeout: Some(value),
+            };
+            let json = serde_json::to_value(&req).unwrap();
+            assert_eq!(
+                json.get("timeout"),
+                Some(&serde_json::Value::from(value)),
+                "update timeout={label} should be forwarded as-is, got: {json}"
+            );
+        }
+    }
+
     /// The inbound API mirrors the e2b `lifecycle` object (camelCase nested
     /// struct). CubeAPI then translates it to the two CubeMaster-side bools
     /// when constructing the create-sandbox RPC. Verify the translation
@@ -1287,7 +1383,7 @@ mod tests {
         let sandbox = service
             .create_sandbox(NewSandbox {
                 template_id: "tpl-1".to_string(),
-                timeout: 15,
+                timeout: Some(15),
                 lifecycle: None,
                 secure: None,
                 allow_internet_access: None,
@@ -1362,7 +1458,7 @@ mod tests {
         let sandbox = service
             .create_sandbox(NewSandbox {
                 template_id: "tpl-1".to_string(),
-                timeout: 15,
+                timeout: Some(15),
                 lifecycle: None,
                 secure: None,
                 allow_internet_access: None,

--- a/CubeMaster/conf.yaml
+++ b/CubeMaster/conf.yaml
@@ -21,6 +21,10 @@ cubelet_conf:
     grpc_port: 9999
   common_timeout_insec: 30
   create_image_timeout_insec: 300
+  # See docs/guide/lifecycle.md — Timeout semantics (canonical).
+  default_timeout_insec: -1
+  # Create-path RPC/scheduling deadline (seconds).
+  create_timeout_insec: 300
   create_concurrent_limit: 100
   destroy_concurent_limit: 100
   enable_exposed_port: true

--- a/CubeMaster/integration/cubebox_helpers_test.go
+++ b/CubeMaster/integration/cubebox_helpers_test.go
@@ -24,7 +24,7 @@ func testGetCreateCubeSandboxReq() *types.CreateCubeSandboxReq {
 		Request: &types.Request{
 			RequestID: uuid.New().String(),
 		},
-		Timeout:      30,
+		Timeout:      types.TimeoutPtr(30),
 		InstanceType: "cubebox",
 		Volumes: []*types.Volume{
 			{
@@ -88,7 +88,12 @@ func testCreateSandboxByReq(reqC *types.CreateCubeSandboxReq) (rsp *types.Create
 			RetMsg:  errorcode.ErrorCode_Success.String(),
 		},
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(reqC.Timeout+3)*time.Second)
+	// Idle TTL is not a valid HTTP deadline; use a fixed test timeout instead.
+	timeoutSec := 30
+	if reqC.Timeout != nil && *reqC.Timeout > 0 {
+		timeoutSec = *reqC.Timeout + 3
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(timeoutSec)*time.Second)
 	defer cancel()
 
 	reqC.RequestID = uuid.New().String()

--- a/CubeMaster/pkg/base/config/config.go
+++ b/CubeMaster/pkg/base/config/config.go
@@ -545,26 +545,30 @@ type TemplateScore struct {
 }
 
 type CubeletConf struct {
-	Grpc                    *GrpcConf            `yaml:"grpc"`
-	CommonTimeoutInsec      int                  `yaml:"common_timeout_insec"`
-	CreateImageTimeoutInSec int                  `yaml:"create_image_timeout_insec"`
-	AsyncFlows              map[string]asyncFlow `yaml:"async_flows"`
-	RetryCode               []string             `yaml:"retry_code"`
-	LoopRetryCode           []string             `yaml:"loop_retry_code"`
-	ReuseRetryCode          []string             `yaml:"reuse_retry_code"`
-	CircuitBreakCode        []string             `yaml:"circuit_break_code"`
-	ExcludeLoopRetryCode    []string             `yaml:"exclude_loop_retry_code"`
-	BackoffRetryCode        []string             `yaml:"backoff_retry_code"`
-	MaxRetries              int64                `yaml:"max_retries"`
-	LoopMaxRetries          int64                `yaml:"loop_max_retries"`
-	BufferQueueMinJob       int64                `yaml:"buffer_queue_min_job"`
-	CreateConcurrentLimit   int64                `yaml:"create_concurrent_limit"`
-	DestroyConcurentLimit   int64                `yaml:"destroy_concurent_limit"`
-	ExposedPortList         []string             `yaml:"exposed_port_list"`
-	EnableExposedPort       bool                 `yaml:"enable_exposed_port"`
-	DisableRedisProxyPort   bool                 `yaml:"disable_redis_proxy_port"`
-	MaxDelayInSecond        int64                `yaml:"max_delay_in_second"`
-	BackoffRetryDelay       time.Duration        `yaml:"backoff_retry_delay"`
+	Grpc                    *GrpcConf `yaml:"grpc"`
+	CommonTimeoutInsec      int       `yaml:"common_timeout_insec"`
+	CreateImageTimeoutInSec int       `yaml:"create_image_timeout_insec"`
+	// Server default idle TTL when the client omits timeout. See docs/guide/lifecycle.md.
+	DefaultTimeoutInsec int `yaml:"default_timeout_insec"`
+	// Create RPC / scheduling deadline; decoupled from idle TTL.
+	CreateTimeoutInsec    int                  `yaml:"create_timeout_insec"`
+	AsyncFlows            map[string]asyncFlow `yaml:"async_flows"`
+	RetryCode             []string             `yaml:"retry_code"`
+	LoopRetryCode         []string             `yaml:"loop_retry_code"`
+	ReuseRetryCode        []string             `yaml:"reuse_retry_code"`
+	CircuitBreakCode      []string             `yaml:"circuit_break_code"`
+	ExcludeLoopRetryCode  []string             `yaml:"exclude_loop_retry_code"`
+	BackoffRetryCode      []string             `yaml:"backoff_retry_code"`
+	MaxRetries            int64                `yaml:"max_retries"`
+	LoopMaxRetries        int64                `yaml:"loop_max_retries"`
+	BufferQueueMinJob     int64                `yaml:"buffer_queue_min_job"`
+	CreateConcurrentLimit int64                `yaml:"create_concurrent_limit"`
+	DestroyConcurentLimit int64                `yaml:"destroy_concurent_limit"`
+	ExposedPortList       []string             `yaml:"exposed_port_list"`
+	EnableExposedPort     bool                 `yaml:"enable_exposed_port"`
+	DisableRedisProxyPort bool                 `yaml:"disable_redis_proxy_port"`
+	MaxDelayInSecond      int64                `yaml:"max_delay_in_second"`
+	BackoffRetryDelay     time.Duration        `yaml:"backoff_retry_delay"`
 }
 
 type GrpcConf struct {
@@ -891,6 +895,10 @@ func preHandleCubeletConf(config *Config) error {
 
 	if config.CubeletConf.CommonTimeoutInsec == 0 {
 		config.CubeletConf.CommonTimeoutInsec = 30
+	}
+	// DefaultTimeoutInsec is left untouched — see docs/guide/lifecycle.md.
+	if config.CubeletConf.CreateTimeoutInsec <= 0 {
+		config.CubeletConf.CreateTimeoutInsec = 300
 	}
 	if config.CubeletConf.MaxRetries == 0 {
 		config.CubeletConf.MaxRetries = 5

--- a/CubeMaster/pkg/lifecycle/init.go
+++ b/CubeMaster/pkg/lifecycle/init.go
@@ -73,11 +73,20 @@ func (p *storeTimeoutProvider) RefreshTimeout(ctx context.Context, sandboxID str
 	}
 
 	now := time.Now().UnixMilli()
-	meta.TimeoutSeconds = timeoutSeconds
+	ts := timeoutSeconds
+	meta.TimeoutSeconds = &ts
 	meta.CreatedAt = now
-	meta.EndAt = now + int64(timeoutSeconds)*1000
+	meta.EndAt = projectedEndAt(now, timeoutSeconds)
 	p.store.PublishUpdate(ctx, meta)
 	return meta.EndAt, nil
+}
+
+// projectedEndAt maps idle TTL to EndAt (unix ms). See docs/guide/lifecycle.md.
+func projectedEndAt(nowMs int64, timeoutSeconds int) int64 {
+	if timeoutSeconds < 0 {
+		return 0
+	}
+	return nowMs + int64(timeoutSeconds)*1000
 }
 
 // LookupEndAt reads the latest meta.EndAt straight from the lifecycle snapshot in Redis.
@@ -95,8 +104,8 @@ func (p *storeTimeoutProvider) LookupEndAt(ctx context.Context, sandboxID string
 	if meta.EndAt > 0 {
 		return meta.EndAt, nil
 	}
-	if meta.CreatedAt > 0 && meta.TimeoutSeconds > 0 {
-		return meta.CreatedAt + int64(meta.TimeoutSeconds)*1000, nil
+	if meta.CreatedAt > 0 && meta.TimeoutSeconds != nil && *meta.TimeoutSeconds > 0 {
+		return meta.CreatedAt + int64(*meta.TimeoutSeconds)*1000, nil
 	}
 	return 0, nil
 }
@@ -114,16 +123,22 @@ func onAfterCreate(ctx context.Context, sandboxID, hostID, hostIP string, req *s
 		return nil
 	}
 	now := time.Now().UnixMilli()
+	// ConstructCubeletReq normalizes req.Timeout before create; guard nil defensively.
+	timeoutSeconds := sandboxtypes.NeverTimeout
+	if req.Timeout != nil {
+		timeoutSeconds = *req.Timeout
+	}
+	ts := timeoutSeconds
 	meta := &SandboxLifecycleMeta{
 		SandboxID:      sandboxID,
 		HostID:         hostID,
 		HostIP:         hostIP,
 		InstanceType:   req.InstanceType,
-		TimeoutSeconds: req.Timeout,
+		TimeoutSeconds: &ts,
 		AutoPause:      req.AutoPause,
 		AutoResume:     req.AutoResume,
 		CreatedAt:      now,
-		EndAt:          now + int64(req.Timeout)*1000,
+		EndAt:          projectedEndAt(now, timeoutSeconds),
 	}
 	if req.Annotations != nil {
 		// Template ID is conventionally carried via annotations from CubeAPI;

--- a/CubeMaster/pkg/lifecycle/schema.go
+++ b/CubeMaster/pkg/lifecycle/schema.go
@@ -60,14 +60,15 @@ const (
 // also the payload field of OpCreate stream entries. OpDelete entries omit
 // the payload field — the sandbox ID is enough to drop a registry entry.
 type SandboxLifecycleMeta struct {
-	SandboxID      string `json:"sandbox_id"`
-	TemplateID     string `json:"template_id,omitempty"`
-	HostID         string `json:"host_id,omitempty"`
-	HostIP         string `json:"host_ip,omitempty"`
-	InstanceType   string `json:"instance_type,omitempty"`
-	TimeoutSeconds int    `json:"timeout_seconds,omitempty"`
-	AutoPause      bool   `json:"auto_pause,omitempty"`
-	AutoResume     bool   `json:"auto_resume,omitempty"`
+	SandboxID    string `json:"sandbox_id"`
+	TemplateID   string `json:"template_id,omitempty"`
+	HostID       string `json:"host_id,omitempty"`
+	HostIP       string `json:"host_ip,omitempty"`
+	InstanceType string `json:"instance_type,omitempty"`
+	// *int so nil (legacy absent) ≠ explicit 0. See docs/guide/lifecycle.md.
+	TimeoutSeconds *int `json:"timeout_seconds,omitempty"`
+	AutoPause      bool `json:"auto_pause,omitempty"`
+	AutoResume     bool `json:"auto_resume,omitempty"`
 	// CreatedAt is unix milliseconds. Sidecars use it as the initial
 	// "last active" baseline before they ever observe a real request.
 	CreatedAt int64 `json:"created_at,omitempty"`

--- a/CubeMaster/pkg/lifecycle/store_test.go
+++ b/CubeMaster/pkg/lifecycle/store_test.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"reflect"
 	"sync"
 	"testing"
 )
@@ -57,13 +58,14 @@ func (f *fakeRedis) snapshot() []recordedCall {
 }
 
 func TestSandboxLifecycleMeta_JSONRoundTrip(t *testing.T) {
+	timeout := 60
 	in := SandboxLifecycleMeta{
 		SandboxID:      "sbx-1",
 		TemplateID:     "tpl-1",
 		HostID:         "host-1",
 		HostIP:         "10.0.0.1",
 		InstanceType:   "cubebox",
-		TimeoutSeconds: 60,
+		TimeoutSeconds: &timeout,
 		AutoPause:      true,
 		AutoResume:     true,
 		CreatedAt:      1700000000000,
@@ -76,7 +78,9 @@ func TestSandboxLifecycleMeta_JSONRoundTrip(t *testing.T) {
 	if err := json.Unmarshal(b, &out); err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}
-	if out != in {
+	// TimeoutSeconds is a pointer now, so compare by value (DeepEqual) rather
+	// than == which would compare pointer identity.
+	if !reflect.DeepEqual(out, in) {
 		t.Fatalf("round trip mismatch: got %+v want %+v", out, in)
 	}
 }
@@ -85,9 +89,10 @@ func TestStore_PublishCreate_HappyPath(t *testing.T) {
 	r := &fakeRedis{}
 	s := NewStore(r)
 
+	timeout := 60
 	meta := &SandboxLifecycleMeta{
 		SandboxID:      "sbx-42",
-		TimeoutSeconds: 60,
+		TimeoutSeconds: &timeout,
 		AutoPause:      true,
 	}
 	s.PublishCreate(context.Background(), meta)
@@ -118,7 +123,7 @@ func TestStore_PublishCreate_HappyPath(t *testing.T) {
 	if err := json.Unmarshal(payloadBytes, &got); err != nil {
 		t.Fatalf("payload json: %v", err)
 	}
-	if got.SandboxID != "sbx-42" || !got.AutoPause || got.TimeoutSeconds != 60 {
+	if got.SandboxID != "sbx-42" || !got.AutoPause || got.TimeoutSeconds == nil || *got.TimeoutSeconds != 60 {
 		t.Fatalf("payload wrong: %+v", got)
 	}
 }

--- a/CubeMaster/pkg/sandboxspec/store.go
+++ b/CubeMaster/pkg/sandboxspec/store.go
@@ -232,7 +232,7 @@ func CanonicalizeRequest(req *sandboxtypes.CreateCubeSandboxReq) (*sandboxtypes.
 	if out.Labels == nil {
 		out.Labels = map[string]string{}
 	}
-	out.Timeout = 0
+	out.Timeout = nil
 	out.InsId = ""
 	out.InsIp = ""
 	out.Request = nil

--- a/CubeMaster/pkg/sandboxspec/store_test.go
+++ b/CubeMaster/pkg/sandboxspec/store_test.go
@@ -30,7 +30,7 @@ func TestCanonicalizeRequestStripsTransientSnapshotAnnotations(t *testing.T) {
 			"unrelated-annotation":                            "preserve",
 		},
 		Labels:  map[string]string{"keep": "me"},
-		Timeout: 30,
+		Timeout: sandboxtypes.TimeoutPtr(30),
 	}
 
 	out, err := CanonicalizeRequest(req)

--- a/CubeMaster/pkg/service/sandbox/sandbox_run.go
+++ b/CubeMaster/pkg/service/sandbox/sandbox_run.go
@@ -589,7 +589,9 @@ func (c *createSandboxContext) newContext(ctx context.Context, req *types.Create
 	}
 	c.selctx.ReqRes = reqResource
 
-	c.ctx, c.cancel = context.WithTimeout(ctx, time.Duration(req.Timeout)*time.Second)
+	// Create RPC deadline uses create_timeout_insec, not idle TTL.
+	createDeadline := time.Duration(config.GetConfig().CubeletConf.CreateTimeoutInsec) * time.Second
+	c.ctx, c.cancel = context.WithTimeout(ctx, createDeadline)
 	c.selctx.Ctx = c.ctx
 
 	switch {

--- a/CubeMaster/pkg/service/sandbox/timeout_resolve_test.go
+++ b/CubeMaster/pkg/service/sandbox/timeout_resolve_test.go
@@ -1,0 +1,84 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package sandbox
+
+import (
+	"testing"
+
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/service/sandbox/types"
+)
+
+func TestResolveTimeoutSeconds(t *testing.T) {
+	ptr := func(v int) *int { return &v }
+
+	cases := []struct {
+		name          string
+		clientTimeout *int
+		serverDefault int
+		want          int
+		wantErr       bool
+	}{
+		{
+			name:          "nil with positive server default fills default",
+			clientTimeout: nil,
+			serverDefault: 300,
+			want:          300,
+		},
+		{
+			name:          "nil with zero server default means never timeout",
+			clientTimeout: nil,
+			serverDefault: 0,
+			want:          types.NeverTimeout,
+		},
+		{
+			name:          "nil with negative server default means never timeout",
+			clientTimeout: nil,
+			serverDefault: -5,
+			want:          types.NeverTimeout,
+		},
+		{
+			name:          "explicit zero is preserved (immediate timeout)",
+			clientTimeout: ptr(0),
+			serverDefault: 300,
+			want:          0,
+		},
+		{
+			name:          "explicit positive passes through",
+			clientTimeout: ptr(45),
+			serverDefault: 300,
+			want:          45,
+		},
+		{
+			name:          "explicit -1 means never timeout",
+			clientTimeout: ptr(-1),
+			serverDefault: 300,
+			want:          types.NeverTimeout,
+		},
+		{
+			name:          "any negative is normalized to never timeout",
+			clientTimeout: ptr(-42),
+			serverDefault: 300,
+			want:          types.NeverTimeout,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got, err := resolveTimeoutSeconds(c.clientTimeout, c.serverDefault)
+			if c.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil (value=%d)", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != c.want {
+				t.Fatalf("resolveTimeoutSeconds = %d, want %d", got, c.want)
+			}
+		})
+	}
+}

--- a/CubeMaster/pkg/service/sandbox/types/types.go
+++ b/CubeMaster/pkg/service/sandbox/types/types.go
@@ -12,6 +12,16 @@ import (
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/node"
 )
 
+// NeverTimeout is the never-timeout idle TTL sentinel (-1).
+// See docs/guide/lifecycle.md — Timeout semantics (canonical).
+const NeverTimeout = -1
+
+// TimeoutPtr is a convenience constructor for the pointer-typed
+// CreateCubeSandboxReq.Timeout field.
+func TimeoutPtr(v int) *int {
+	return &v
+}
+
 type Request struct {
 	RequestID string `json:"requestID" p:"requestID"  v:"required"`
 }
@@ -35,7 +45,9 @@ type HostChangeEvent struct {
 type CreateCubeSandboxReq struct {
 	*Request
 
-	Timeout           int                `json:"timeout,omitempty" d:"60"`
+	// Optional idle TTL in seconds; nil = client omitted the field.
+	// See docs/guide/lifecycle.md — Timeout semantics (canonical).
+	Timeout           *int               `json:"timeout,omitempty"`
 	SnapshotDir       string             `json:"snapshot_dir,omitempty"`
 	InsId             string             `json:"ins_id,omitempty"`
 	InsIp             string             `json:"ins_ip,omitempty"`

--- a/CubeMaster/pkg/service/sandbox/util.go
+++ b/CubeMaster/pkg/service/sandbox/util.go
@@ -120,6 +120,22 @@ func getReqResource(req *types.CreateCubeSandboxReq) (cpu, mem resource.Quantity
 	return cpu, mem, err
 }
 
+// resolveTimeoutSeconds normalizes client timeout + server default.
+// See docs/guide/lifecycle.md — Timeout semantics (canonical).
+func resolveTimeoutSeconds(clientTimeout *int, serverDefault int) (int, error) {
+	switch {
+	case clientTimeout == nil:
+		if serverDefault > 0 {
+			return serverDefault, nil
+		}
+		return types.NeverTimeout, nil
+	case *clientTimeout < 0:
+		return types.NeverTimeout, nil
+	default:
+		return *clientTimeout, nil
+	}
+}
+
 func ConstructCubeletReq(ctx context.Context, req *types.CreateCubeSandboxReq) (*cubebox.RunCubeSandboxRequest, error) {
 	if err := checkParam(req); err != nil {
 		return nil, err
@@ -127,9 +143,12 @@ func ConstructCubeletReq(ctx context.Context, req *types.CreateCubeSandboxReq) (
 	log.G(ctx).Infof("[hostdir] ConstructCubeletReq: annotations=%v volumes_before_inject=%d",
 		req.Annotations, len(req.Volumes))
 
-	if req.Timeout <= 0 {
-		req.Timeout = config.GetConfig().CubeletConf.CommonTimeoutInsec
+	// Normalize the sandbox idle timeout into a concrete value.
+	timeoutSeconds, err := resolveTimeoutSeconds(req.Timeout, config.GetConfig().CubeletConf.DefaultTimeoutInsec)
+	if err != nil {
+		return nil, err
 	}
+	req.Timeout = &timeoutSeconds
 
 	out := &cubebox.RunCubeSandboxRequest{
 		RequestID:         req.RequestID,
@@ -148,7 +167,7 @@ func ConstructCubeletReq(ctx context.Context, req *types.CreateCubeSandboxReq) (
 		formatConstructCubeNetworkConfig(out.CubeNetworkConfig),
 	)
 
-	err := checkAndGetAnnotation(req, out)
+	err = checkAndGetAnnotation(req, out)
 	if err != nil {
 		return nil, ret.Err(errorcode.ErrorCode_MasterParamsError, err.Error())
 	}

--- a/CubeMaster/pkg/templatecenter/store.go
+++ b/CubeMaster/pkg/templatecenter/store.go
@@ -380,7 +380,7 @@ func normalizeStoredTemplateRequest(req *sandboxtypes.CreateCubeSandboxReq) (*sa
 	}
 	delete(cloned.Annotations, constants.CubeAnnotationsAppSnapshotCreate)
 	cloned.SnapshotDir = ""
-	cloned.Timeout = 0
+	cloned.Timeout = nil
 	cloned.InsId = ""
 	cloned.InsIp = ""
 	cloned.Request = nil

--- a/CubeMaster/pkg/templatecenter/store_test.go
+++ b/CubeMaster/pkg/templatecenter/store_test.go
@@ -37,7 +37,7 @@ func TestNormalizeStoredTemplateRequestStripsPhysicalAnnotations(t *testing.T) {
 	req := &sandboxtypes.CreateCubeSandboxReq{
 		InstanceType: "cubebox",
 		SnapshotDir:  "/snapshots/should-be-cleared",
-		Timeout:      1,
+		Timeout:      sandboxtypes.TimeoutPtr(1),
 		Annotations: map[string]string{
 			constants.CubeAnnotationsAppSnapshotCreate:        "true",
 			constants.CubeAnnotationRuntimeSnapshotID:         "snap-stale",

--- a/configs/single-node/cubemaster.yaml
+++ b/configs/single-node/cubemaster.yaml
@@ -24,6 +24,11 @@ cubelet_conf:
     grpc_port: 9999
   common_timeout_insec: 30
   create_image_timeout_insec: 300
+  # Sandbox idle TTL when the client omits timeout; unset or <=0 = no cluster default (never idle-timeout).
+  # Shipped default: no cluster-wide idle timeout. Set e.g. 300 in production if needed.
+  default_timeout_insec: -1
+  # Create/scheduling RPC deadline only (not sandbox idle TTL).
+  create_timeout_insec: 300
   create_concurrent_limit: 100
   destroy_concurent_limit: 100
   enable_exposed_port: true

--- a/cube-lifecycle-manager/cmd/cube-lifecycle-manager/main.go
+++ b/cube-lifecycle-manager/cmd/cube-lifecycle-manager/main.go
@@ -317,7 +317,7 @@ func handleEvent(ctx context.Context, ev redisstream.Event, push *proxypush.Clie
 			zap.String("sandbox_id", ev.SandboxID),
 			zap.Bool("auto_pause", ev.Meta.AutoPause),
 			zap.Bool("auto_resume", ev.Meta.AutoResume),
-			zap.Int("timeout_seconds", ev.Meta.TimeoutSeconds),
+			zap.Intp("timeout_seconds", ev.Meta.TimeoutSeconds),
 			zap.Int("registry_size", reg.Len()))
 		if err := push.UpsertMeta(ctx, *ev.Meta); err != nil {
 			log.Warn("create event push failed",
@@ -344,7 +344,7 @@ func handleEvent(ctx context.Context, ev redisstream.Event, push *proxypush.Clie
 			zap.String("sandbox_id", ev.SandboxID),
 			zap.Bool("auto_pause", ev.Meta.AutoPause),
 			zap.Bool("auto_resume", ev.Meta.AutoResume),
-			zap.Int("timeout_seconds", ev.Meta.TimeoutSeconds),
+			zap.Intp("timeout_seconds", ev.Meta.TimeoutSeconds),
 			zap.Int64("created_at_ms", ev.Meta.CreatedAt),
 			zap.Int64("end_at_ms", ev.Meta.EndAt))
 		if err := push.UpsertMeta(ctx, *ev.Meta); err != nil {

--- a/cube-lifecycle-manager/internal/lifecycle/schema.go
+++ b/cube-lifecycle-manager/internal/lifecycle/schema.go
@@ -54,14 +54,21 @@ const (
 
 // SandboxLifecycleMeta mirrors CubeMaster/pkg/lifecycle.SandboxLifecycleMeta.
 type SandboxLifecycleMeta struct {
-	SandboxID      string `json:"sandbox_id"`
-	TemplateID     string `json:"template_id,omitempty"`
-	HostID         string `json:"host_id,omitempty"`
-	HostIP         string `json:"host_ip,omitempty"`
-	InstanceType   string `json:"instance_type,omitempty"`
-	TimeoutSeconds int    `json:"timeout_seconds,omitempty"`
-	AutoPause      bool   `json:"auto_pause,omitempty"`
-	AutoResume     bool   `json:"auto_resume,omitempty"`
-	CreatedAt      int64  `json:"created_at,omitempty"`
-	EndAt          int64  `json:"end_at,omitempty"`
+	SandboxID    string `json:"sandbox_id"`
+	TemplateID   string `json:"template_id,omitempty"`
+	HostID       string `json:"host_id,omitempty"`
+	HostIP       string `json:"host_ip,omitempty"`
+	InstanceType string `json:"instance_type,omitempty"`
+	// *int so nil (legacy absent) ≠ explicit 0. See docs/guide/lifecycle.md.
+	TimeoutSeconds *int  `json:"timeout_seconds,omitempty"`
+	AutoPause      bool  `json:"auto_pause,omitempty"`
+	AutoResume     bool  `json:"auto_resume,omitempty"`
+	CreatedAt      int64 `json:"created_at,omitempty"`
+	EndAt          int64 `json:"end_at,omitempty"`
+}
+
+// TimeoutSecondsPtr is a convenience constructor for the TimeoutSeconds
+// pointer field. Prefer it over inline &v so intent reads clearly.
+func TimeoutSecondsPtr(v int) *int {
+	return &v
 }

--- a/cube-lifecycle-manager/internal/proxypush/client_test.go
+++ b/cube-lifecycle-manager/internal/proxypush/client_test.go
@@ -136,7 +136,7 @@ func TestUpsertMeta_RoundTrip(t *testing.T) {
 
 	c := New([]string{srv.URL}, "", time.Second, zap.NewNop())
 	meta := lifecycle.SandboxLifecycleMeta{
-		SandboxID: "sbx-1", AutoPause: true, TimeoutSeconds: 60,
+		SandboxID: "sbx-1", AutoPause: true, TimeoutSeconds: lifecycle.TimeoutSecondsPtr(60),
 	}
 	if err := c.UpsertMeta(context.Background(), meta); err != nil {
 		t.Fatalf("UpsertMeta failed: %v", err)

--- a/cube-lifecycle-manager/internal/sweeper/sweeper.go
+++ b/cube-lifecycle-manager/internal/sweeper/sweeper.go
@@ -130,9 +130,14 @@ func (s *Sweeper) sweepOnce(ctx context.Context) {
 			baseline = e.FirstSeenAt.UnixMilli()
 		}
 
-		timeout := time.Duration(e.Meta.TimeoutSeconds) * time.Second
-		if timeout <= 0 {
+		// Idle-timeout decision. See docs/guide/lifecycle.md.
+		var timeout time.Duration
+		if e.Meta.TimeoutSeconds == nil {
 			timeout = s.o.DefaultIdleTimeout
+		} else if ts := *e.Meta.TimeoutSeconds; ts < 0 {
+			continue
+		} else {
+			timeout = time.Duration(ts) * time.Second
 		}
 
 		idleFor := time.Duration(nowMs-baseline) * time.Millisecond
@@ -165,7 +170,7 @@ func (s *Sweeper) sweepOnce(ctx context.Context) {
 			s.o.Log.Info("idle threshold exceeded; pausing",
 				zap.String("sandbox_id", e.Meta.SandboxID),
 				zap.Duration("idle_for", idleFor),
-				zap.Int("timeout_seconds", e.Meta.TimeoutSeconds))
+				zap.Intp("timeout_seconds", e.Meta.TimeoutSeconds))
 
 			if err := s.tryPause(ctx, e); err != nil {
 				s.pauseFailed.Add(1)
@@ -178,7 +183,7 @@ func (s *Sweeper) sweepOnce(ctx context.Context) {
 			s.o.Log.Info("idle threshold exceeded; killing",
 				zap.String("sandbox_id", e.Meta.SandboxID),
 				zap.Duration("idle_for", idleFor),
-				zap.Int("timeout_seconds", e.Meta.TimeoutSeconds),
+				zap.Intp("timeout_seconds", e.Meta.TimeoutSeconds),
 				zap.String("kill_reason", cubemasterclient.KillReasonTimeout))
 
 			if err := s.tryKill(ctx, e); err != nil {
@@ -272,7 +277,7 @@ func (s *Sweeper) tryPause(ctx context.Context, e registry.Entry) error {
 	s.pauseTriggered.Add(1)
 	s.o.Log.Info("auto-paused sandbox",
 		zap.String("sandbox_id", sid),
-		zap.Int("timeout_seconds", e.Meta.TimeoutSeconds))
+		zap.Intp("timeout_seconds", e.Meta.TimeoutSeconds))
 	return nil
 }
 
@@ -344,7 +349,7 @@ func (s *Sweeper) tryKill(ctx context.Context, e registry.Entry) error {
 	s.killTriggered.Add(1)
 	s.o.Log.Info("timeout-killed sandbox",
 		zap.String("sandbox_id", sid),
-		zap.Int("timeout_seconds", e.Meta.TimeoutSeconds),
+		zap.Intp("timeout_seconds", e.Meta.TimeoutSeconds),
 		zap.String("kill_reason", cubemasterclient.KillReasonTimeout))
 	return nil
 }

--- a/cube-lifecycle-manager/internal/sweeper/sweeper_test.go
+++ b/cube-lifecycle-manager/internal/sweeper/sweeper_test.go
@@ -197,7 +197,7 @@ func TestSweeper_PausesIdleSandbox(t *testing.T) {
 	now := time.Now()
 	seedEntry(t, reg, lifecycle.SandboxLifecycleMeta{
 		SandboxID: "sbx-1", InstanceType: "cubebox",
-		AutoPause: true, TimeoutSeconds: 300,
+		AutoPause: true, TimeoutSeconds: lifecycle.TimeoutSecondsPtr(300),
 	}, now.Add(-10*time.Minute).UnixMilli())
 
 	s := newTestSweeper(reg, store, master, push, now)
@@ -228,7 +228,7 @@ func TestSweeper_SkipsSandboxWithoutAutoPause(t *testing.T) {
 
 	seedEntry(t, reg, lifecycle.SandboxLifecycleMeta{
 		SandboxID: "sbx-2", InstanceType: "cubebox",
-		AutoPause: false, TimeoutSeconds: 60,
+		AutoPause: false, TimeoutSeconds: lifecycle.TimeoutSecondsPtr(60),
 	}, now.Add(-1*time.Hour).UnixMilli())
 
 	s := newTestSweeper(reg, store, master, push, now)
@@ -271,7 +271,7 @@ func TestSweeper_KillRollsBackOnFailure(t *testing.T) {
 	now := time.Now()
 	seedEntry(t, reg, lifecycle.SandboxLifecycleMeta{
 		SandboxID: "sbx-killfail", InstanceType: "cubebox",
-		AutoPause: false, TimeoutSeconds: 60,
+		AutoPause: false, TimeoutSeconds: lifecycle.TimeoutSecondsPtr(60),
 	}, now.Add(-10*time.Minute).UnixMilli())
 
 	s := newTestSweeper(reg, store, master, push, now)
@@ -308,7 +308,7 @@ func TestSweeper_KillNotFoundEvictsRegistry(t *testing.T) {
 	now := time.Now()
 	seedEntry(t, reg, lifecycle.SandboxLifecycleMeta{
 		SandboxID: "sbx-killgone", InstanceType: "cubebox",
-		AutoPause: false, TimeoutSeconds: 60,
+		AutoPause: false, TimeoutSeconds: lifecycle.TimeoutSecondsPtr(60),
 	}, now.Add(-10*time.Minute).UnixMilli())
 
 	s := newTestSweeper(reg, store, master, push, now)
@@ -337,7 +337,7 @@ func TestSweeper_KillSkipsAlreadyKillingSandbox(t *testing.T) {
 	now := time.Now()
 	seedEntry(t, reg, lifecycle.SandboxLifecycleMeta{
 		SandboxID: "sbx-killmid", InstanceType: "cubebox",
-		AutoPause: false, TimeoutSeconds: 60,
+		AutoPause: false, TimeoutSeconds: lifecycle.TimeoutSecondsPtr(60),
 	}, now.Add(-1*time.Hour).UnixMilli())
 
 	s := newTestSweeper(reg, store, master, push, now)
@@ -362,7 +362,7 @@ func TestSweeper_BootstrapWarmupSkipsBootstrapEntries(t *testing.T) {
 	startedAt := time.Now()
 	reg.Upsert(lifecycle.SandboxLifecycleMeta{
 		SandboxID: "sbx-bootstrap", InstanceType: "cubebox",
-		AutoPause: true, TimeoutSeconds: 60,
+		AutoPause: true, TimeoutSeconds: lifecycle.TimeoutSecondsPtr(60),
 		CreatedAt: startedAt.Add(-1 * time.Hour).UnixMilli(), // ancient
 	})
 	// Pin FirstSeenAt to startedAt — that's exactly what main.go's
@@ -407,7 +407,7 @@ func TestSweeper_RollsBackOnPauseFailure(t *testing.T) {
 	now := time.Now()
 	seedEntry(t, reg, lifecycle.SandboxLifecycleMeta{
 		SandboxID: "sbx-4", InstanceType: "cubebox",
-		AutoPause: true, TimeoutSeconds: 60,
+		AutoPause: true, TimeoutSeconds: lifecycle.TimeoutSecondsPtr(60),
 	}, now.Add(-10*time.Minute).UnixMilli())
 
 	s := newTestSweeper(reg, store, master, push, now)
@@ -438,7 +438,7 @@ func TestSweeper_SkipsWhenLockHeldElsewhere(t *testing.T) {
 	now := time.Now()
 	seedEntry(t, reg, lifecycle.SandboxLifecycleMeta{
 		SandboxID: "sbx-5", InstanceType: "cubebox",
-		AutoPause: true, TimeoutSeconds: 1,
+		AutoPause: true, TimeoutSeconds: lifecycle.TimeoutSecondsPtr(1),
 	}, now.Add(-1*time.Hour).UnixMilli())
 
 	s := newTestSweeper(reg, store, master, push, now)
@@ -464,7 +464,7 @@ func TestSweeper_FallsBackToCreatedAtWhenNoActivityRecorded(t *testing.T) {
 	// the sandbox should NOT be paused.
 	reg.Upsert(lifecycle.SandboxLifecycleMeta{
 		SandboxID: "sbx-recent", InstanceType: "cubebox",
-		AutoPause: true, TimeoutSeconds: 300,
+		AutoPause: true, TimeoutSeconds: lifecycle.TimeoutSecondsPtr(300),
 		CreatedAt: now.Add(-1 * time.Minute).UnixMilli(),
 	})
 	// Pretend the entry was added long enough ago to clear the grace window.
@@ -480,7 +480,7 @@ func TestSweeper_FallsBackToCreatedAtWhenNoActivityRecorded(t *testing.T) {
 	// Now CreatedAt is 10 minutes old → past timeout → expect pause.
 	reg.Upsert(lifecycle.SandboxLifecycleMeta{
 		SandboxID: "sbx-old", InstanceType: "cubebox",
-		AutoPause: true, TimeoutSeconds: 300,
+		AutoPause: true, TimeoutSeconds: lifecycle.TimeoutSecondsPtr(300),
 		CreatedAt: now.Add(-10 * time.Minute).UnixMilli(),
 	})
 	at2 := now.Add(2 * time.Minute)
@@ -511,7 +511,7 @@ func TestSweeper_NotFoundEvictsRegistryEntry(t *testing.T) {
 	now := time.Now()
 	seedEntry(t, reg, lifecycle.SandboxLifecycleMeta{
 		SandboxID: "sbx-gone", InstanceType: "cubebox",
-		AutoPause: true, TimeoutSeconds: 60,
+		AutoPause: true, TimeoutSeconds: lifecycle.TimeoutSecondsPtr(60),
 	}, now.Add(-10*time.Minute).UnixMilli())
 
 	s := newTestSweeper(reg, store, master, push, now)
@@ -549,7 +549,7 @@ func TestSweeper_SkipsAlreadyPausedSandbox(t *testing.T) {
 	now := time.Now()
 	seedEntry(t, reg, lifecycle.SandboxLifecycleMeta{
 		SandboxID: "sbx-zzz", InstanceType: "cubebox",
-		AutoPause: true, TimeoutSeconds: 60,
+		AutoPause: true, TimeoutSeconds: lifecycle.TimeoutSecondsPtr(60),
 	}, now.Add(-1*time.Hour).UnixMilli())
 
 	s := newTestSweeper(reg, store, master, push, now)
@@ -576,7 +576,7 @@ func TestSweeper_SkipsPausingSandbox(t *testing.T) {
 	now := time.Now()
 	seedEntry(t, reg, lifecycle.SandboxLifecycleMeta{
 		SandboxID: "sbx-mid", InstanceType: "cubebox",
-		AutoPause: true, TimeoutSeconds: 60,
+		AutoPause: true, TimeoutSeconds: lifecycle.TimeoutSecondsPtr(60),
 	}, now.Add(-1*time.Hour).UnixMilli())
 
 	s := newTestSweeper(reg, store, master, push, now)
@@ -584,6 +584,86 @@ func TestSweeper_SkipsPausingSandbox(t *testing.T) {
 
 	if len(master.calls) != 0 {
 		t.Fatalf("sweeper must NOT call Pause when peer is mid-flight: %v", master.calls)
+	}
+}
+
+func TestSweeper_NeverTimeoutIsSkipped(t *testing.T) {
+	// Never-timeout entries must not be reclaimed. See docs/guide/lifecycle.md.
+	reg := registry.New()
+	store := newFakeStore()
+	master := &fakeMaster{}
+	push := newFakePush()
+
+	now := time.Now()
+	seedEntry(t, reg, lifecycle.SandboxLifecycleMeta{
+		SandboxID: "sbx-never", InstanceType: "cubebox",
+		AutoPause: false, TimeoutSeconds: lifecycle.TimeoutSecondsPtr(-1),
+	}, now.Add(-24*time.Hour).UnixMilli())
+
+	s := newTestSweeper(reg, store, master, push, now)
+	s.sweepOnce(context.Background())
+
+	if len(master.calls) != 0 || len(master.killCalls) != 0 {
+		t.Fatalf("never-timeout sandbox must not be paused/killed: pause=%v kill=%v",
+			master.calls, master.killCalls)
+	}
+	if reg.Get("sbx-never") == nil {
+		t.Fatal("never-timeout entry must remain in the registry")
+	}
+}
+
+func TestSweeper_ZeroTimeoutReclaimsImmediately(t *testing.T) {
+	// Zero timeout reclaims on the first sweep. See docs/guide/lifecycle.md.
+	reg := registry.New()
+	store := newFakeStore()
+	master := &fakeMaster{}
+	push := newFakePush()
+
+	now := time.Now()
+	// Freshly created (CreatedAt = now) and never active — with timeout 0 the
+	// idle check trips immediately.
+	reg.Upsert(lifecycle.SandboxLifecycleMeta{
+		SandboxID: "sbx-immediate", InstanceType: "cubebox",
+		AutoPause: false, TimeoutSeconds: lifecycle.TimeoutSecondsPtr(0),
+		CreatedAt: now.UnixMilli(),
+	})
+
+	s := newTestSweeper(reg, store, master, push, now)
+	s.sweepOnce(context.Background())
+
+	if len(master.killCalls) != 1 || master.killCalls[0] != "sbx-immediate" {
+		t.Fatalf("zero-timeout sandbox must be killed immediately: %v", master.killCalls)
+	}
+}
+
+func TestSweeper_NilTimeoutFallsBackToDefaultIdle(t *testing.T) {
+	// Nil timeout falls back to DefaultIdleTimeout. See docs/guide/lifecycle.md.
+	reg := registry.New()
+	store := newFakeStore()
+	master := &fakeMaster{}
+	push := newFakePush()
+
+	now := time.Now()
+
+	// Idle for 1 minute (< 5m default) → must survive.
+	reg.Upsert(lifecycle.SandboxLifecycleMeta{
+		SandboxID: "sbx-legacy-recent", InstanceType: "cubebox",
+		AutoPause: false, TimeoutSeconds: nil,
+		CreatedAt: now.Add(-1 * time.Minute).UnixMilli(),
+	})
+	// Idle for 10 minutes (> 5m default) → must be reclaimed.
+	reg.Upsert(lifecycle.SandboxLifecycleMeta{
+		SandboxID: "sbx-legacy-old", InstanceType: "cubebox",
+		AutoPause: false, TimeoutSeconds: nil,
+		CreatedAt: now.Add(-10 * time.Minute).UnixMilli(),
+	})
+
+	s := newTestSweeper(reg, store, master, push, now)
+	s.sweepOnce(context.Background())
+
+	if len(master.killCalls) != 1 || master.killCalls[0] != "sbx-legacy-old" {
+		t.Fatalf("nil timeout must use DefaultIdleTimeout: expected only sbx-legacy-old killed, got %v",
+			master.killCalls)
 	}
 }
 
@@ -607,7 +687,7 @@ func TestSweeper_AlreadyPausedReconcilesAsSuccess(t *testing.T) {
 	now := time.Now()
 	seedEntry(t, reg, lifecycle.SandboxLifecycleMeta{
 		SandboxID: "sbx-already", InstanceType: "cubebox",
-		AutoPause: true, TimeoutSeconds: 60,
+		AutoPause: true, TimeoutSeconds: lifecycle.TimeoutSecondsPtr(60),
 	}, now.Add(-10*time.Minute).UnixMilli())
 
 	s := newTestSweeper(reg, store, master, push, now)

--- a/deploy/one-click/README.md
+++ b/deploy/one-click/README.md
@@ -131,6 +131,7 @@ the existing installation.
 One-click does not create an extra global `configs/` layer on the target machine; instead, files are placed directly into each component's native configuration paths:
 
 - `configs/single-node/cubemaster.yaml` → `CubeMaster/conf.yaml`
+  - `cubelet_conf.default_timeout_insec`: cluster default sandbox idle TTL when the client omits `timeout`; unset or `<= 0` means **no cluster-wide idle timeout** (shipped default `-1`). See [lifecycle — Operational Notes](../../docs/guide/lifecycle.md#cluster-default-idle-timeout-default_timeout_insec).
 - `Cubelet/config/` → `Cubelet/config/`
 - `Cubelet/dynamicconf/` → `Cubelet/dynamicconf/`
 - `configs/single-node/network-agent.yaml` → `network-agent/network-agent.yaml`

--- a/deploy/one-click/README_zh.md
+++ b/deploy/one-click/README_zh.md
@@ -120,6 +120,7 @@ deploy/one-click/dist/cube-sandbox-one-click-<version>.tar.gz
 one-click 不会在目标机额外创建一层全局 `configs/`，而是直接落到各组件原生配置入口：
 
 - `configs/single-node/cubemaster.yaml` -> `CubeMaster/conf.yaml`
+  - `cubelet_conf.default_timeout_insec`: cluster default sandbox idle TTL when the client omits `timeout`; unset or `<= 0` means **no cluster-wide idle timeout** (shipped default `-1`). See [lifecycle — 设计与运维要点](../../docs/zh/guide/lifecycle.md#集群默认空闲超时default_timeout_insec)。
 - `Cubelet/config/` -> `Cubelet/config/`
 - `Cubelet/dynamicconf/` -> `Cubelet/dynamicconf/`
 - `configs/single-node/network-agent.yaml` -> `network-agent/network-agent.yaml`

--- a/docs/guide/lifecycle.md
+++ b/docs/guide/lifecycle.md
@@ -18,8 +18,19 @@ A sandbox is always in exactly one of these states:
 
 Two settings drive transitions:
 
-- **`timeout`**: how many seconds of inactivity trigger "timeout" (defaults to a fixed value in SDK Config, e.g. 300s).
-- **`on_timeout`**: what happens at timeout — `"kill"` (default; destroy) or `"pause"` (snapshot for later).
+- **`timeout`** (optional): seconds of **idle** time before a timeout fires (e2b uses milliseconds via `timeoutMs`; Cube uses seconds). When omitted, the server decides — the SDK no longer injects a hard-coded default.
+- **`on_timeout`**: what happens at timeout — `"kill"` (default; destroy) or `"pause"` (snapshot for later resume).
+
+`timeout` values (e2b-aligned):
+
+| Value | Behavior |
+|-------|----------|
+| omitted | Server default idle TTL; if the server has no positive default, the sandbox **never** times out |
+| `NEVER_TIMEOUT` (`-1`) | **Never** time out — no idle reclamation |
+| `0` | **Immediate** timeout — reclaimed on the first idle sweep |
+| positive integer `N` | Timeout after **N** seconds of idle time |
+
+Go: `cubesandbox.NeverTimeout`; Python: `from cubesandbox import NEVER_TIMEOUT`.
 
 ```
                        ┌──────────────────────────────────────┐
@@ -57,13 +68,13 @@ Key parameters of `Sandbox.create()`:
 | Parameter               | Description                                                                                  |
 |-------------------------|----------------------------------------------------------------------------------------------|
 | `template`              | Template ID used to boot the sandbox; defaults to env var `CUBE_TEMPLATE_ID`.                |
-| `timeout`               | Idle timeout in **seconds**. (Note: e2b's `timeoutMs` is milliseconds; Cube uses seconds.)   |
+| `timeout`               | Optional idle timeout in seconds; see the table above |
 | `lifecycle`             | Lifecycle policy — see [Platform-managed auto-pause / auto-resume](#platform-managed-auto-pause-auto-resume) below. |
 | `metadata`              | Arbitrary key/value pairs stored on the sandbox; readable from the list / detail endpoints. |
 | `env_vars`              | Environment variables injected into the sandbox process.                                     |
 | `allow_internet_access` | Whether outbound internet is allowed; `network` provides finer-grained egress control.       |
 
-> Cube doesn't impose hard wall-clock ceilings (24h Pro / 1h Base) the way hosted e2b does. The idle `timeout` is still required — it prevents stranded sandboxes from holding resources indefinitely.
+> Cube doesn't impose hard wall-clock ceilings (24h Pro / 1h Base) the way hosted e2b does. When you omit `timeout`, the effective idle TTL is set by your cluster operator — see [Operational Notes](#operational-notes) below.
 
 ## Inspect a Running Sandbox
 
@@ -80,7 +91,7 @@ print(info)
 # }
 ```
 
-`endAt` is the projected next-timeout instant given the current `timeout`. It is refreshed every time the sandbox receives a request (or when you call `set_timeout`, when available).
+`endAt` is the projected next-timeout instant given the current `timeout`. It is refreshed every time the sandbox receives a request (or when you call `set_timeout`, when available). For **never-timeout** sandboxes there is no deadline, so `endAt` is **omitted** from the response rather than reported as equal to `startedAt`.
 
 ## List Running Sandboxes
 
@@ -142,7 +153,7 @@ Any of these resets the idle clock:
 - SDK calls: `sandbox.run_code(...)`, `sandbox.commands.run(...)`, `sandbox.files.read(...)` / `write(...)`.
 - Direct HTTP traffic to a service inside the sandbox (e.g. via the URL returned by `getHost()`).
 
-Sandboxes that don't opt in (no `lifecycle` argument) default to `on_timeout="kill"`: once they sit idle for `timeout` seconds the platform destroys them. This matches e2b's `lifecycle.on_timeout="kill"` semantic. If you want a sandbox that never gets reaped automatically, set `timeout` high enough or have the client send periodic activity to reset the idle clock.
+Sandboxes that don't opt in (no `lifecycle` argument) default to `on_timeout="kill"`: once they sit idle for the effective `timeout` the platform destroys them. This matches e2b's `lifecycle.on_timeout="kill"` semantic. To avoid automatic reclamation, pass `timeout=NEVER_TIMEOUT`, omit `timeout` (with no positive server default), set a high `timeout`, or send periodic activity to reset the idle clock.
 
 ### End-to-end examples
 
@@ -162,6 +173,19 @@ python examples/code-sandbox-quickstart/auto-kill.py
 ```
 
 ## Operational Notes
+
+### Cluster default idle timeout (`default_timeout_insec`)
+
+When the client omits `timeout`, CubeMaster applies `cubelet_conf.default_timeout_insec` in `CubeMaster/conf.yaml` (one-click installs: `/usr/local/services/cubetoolbox/CubeMaster/conf.yaml`).
+
+| Config value | Effect when the client omits `timeout` |
+|--------------|----------------------------------------|
+| unset or `<= 0` | **No cluster-wide idle TTL** — sandboxes never time out from idle |
+| positive `N` | Default idle TTL of **N** seconds |
+
+The repository ships with **no cluster-wide idle timeout** (`default_timeout_insec: -1`). Set a positive value (for example `300`) if you want the cluster to reclaim sandboxes that never pass an explicit `timeout`. Restart `cube-sandbox-cubemaster.service` after edits.
+
+`create_timeout_insec` in the same section is unrelated: it only bounds the create/scheduling RPC deadline, not sandbox idle TTL. See [Service management — CubeMaster settings](service-management.md#cubemaster-settings).
 
 - **Pause fidelity**: CPU registers, process memory, TCP state (with no external peer), and filesystem mutations all survive the snapshot. Outbound sockets the sandbox itself opened are dropped on pause and must be reopened by the application after resume.
 - **Cluster coordination**: auto-pause is driven by the `cube-lifecycle-manager` service that runs on the control node. It consumes lifecycle events CubeMaster publishes via Redis stream, discovers every live CubeProxy replica through a Redis-backed registration table, and broadcasts state to each of them. Cross-replica races are resolved by Redis `SETNX` state locks so the same sandbox is never paused or resumed twice concurrently.

--- a/docs/guide/service-management.md
+++ b/docs/guide/service-management.md
@@ -126,6 +126,20 @@ sudo systemctl restart cube-sandbox-<service>.service
 If you only edited the helper script (`/usr/local/services/cubetoolbox/scripts/systemd/*.sh`), `daemon-reload` is **not** needed — the next `restart` re-invokes the script.
 :::
 
+## CubeMaster settings {#cubemaster-settings}
+
+Path: `/usr/local/services/cubetoolbox/CubeMaster/conf.yaml` (from `configs/single-node/cubemaster.yaml` in one-click bundles).
+
+Under `cubelet_conf`:
+
+| Key | Purpose |
+|-----|---------|
+| `default_timeout_insec` | Server default **sandbox idle TTL** (seconds) when the client omits `timeout`. **Unset or `<= 0` means no cluster-wide idle timeout** (sandboxes never time out from idle unless the client sets `timeout`). The repository ships `-1` for this “no default” behavior. Set a positive value (e.g. `300`) in production if you want automatic reclamation of sandboxes created without an explicit TTL. |
+| `create_timeout_insec` | Create/scheduling RPC deadline only — **not** sandbox idle TTL. Defaults to `300` when unset. |
+| `common_timeout_insec` | Generic CubeMaster→Cubelet RPC timeout for non-create paths. |
+
+After changing `default_timeout_insec`, restart CubeMaster and read [Sandbox lifecycle — Operational Notes](lifecycle.md#cluster-default-idle-timeout-default_timeout_insec) for client-visible behavior.
+
 ### Scenario B: a service is failing or restart-looping
 
 Every service has `Restart=on-failure`, so a single crash is auto-recovered. If the unit is restart-looping, find the root cause first.

--- a/docs/zh/guide/lifecycle.md
+++ b/docs/zh/guide/lifecycle.md
@@ -16,10 +16,21 @@
 | `resuming`  | 平台正在从快照恢复沙箱，瞬时态                                       |
 | `terminated`| 沙箱被显式销毁（`kill`）或因 `on_timeout="kill"` 超时被回收，无法恢复 |
 
-状态转换主要由两个变量驱动：
+状态转换主要由两个参数驱动：
 
-- **`timeout`**：空闲多久后触发"超时"（默认在 SDK Config 里给一个固定值，比如 300 秒）。
-- **`on_timeout`**：超时之后做什么 —— `"kill"`（默认，直接销毁）或 `"pause"`（暂停以备恢复）。
+- **`timeout`**（可选）：沙箱**空闲**多久后触发超时，单位为**秒**（e2b 的 `timeoutMs` 是毫秒）。不传时由服务端决定；SDK 不再自带 300 秒之类的默认值。
+- **`on_timeout`**：超时后怎么办——`"kill"`（默认，销毁）或 `"pause"`（暂停，可之后恢复）。
+
+`timeout` 取值（语义对齐 e2b）：
+
+| 取值 | 行为 |
+|------|------|
+| 不传 | 使用服务端配置的默认空闲超时；服务端未配置或设为 ≤ 0 时，**永不超时** |
+| `NEVER_TIMEOUT`（`-1`） | **永不超时**——不会因空闲被自动回收 |
+| `0` | **立刻超时**——空闲后首次扫描即回收 |
+| 正整数 `N` | 空闲 **N 秒**后触发超时 |
+
+Go：`cubesandbox.NeverTimeout`；Python：`from cubesandbox import NEVER_TIMEOUT`。
 
 ```
                        ┌──────────────────────────────────────┐
@@ -56,13 +67,13 @@ print(sandbox.sandbox_id)
 | 参数                    | 说明                                                                       |
 |-------------------------|----------------------------------------------------------------------------|
 | `template`              | 模板 ID，沙箱基于它启动；缺省读环境变量 `CUBE_TEMPLATE_ID`                  |
-| `timeout`               | 空闲超时，**秒**（注意：e2b 的 `timeoutMs` 是毫秒，Cube 是秒）              |
+| `timeout`               | 可选，空闲超时（秒），见上文取值说明 |
 | `lifecycle`             | 生命周期策略，详见下文 "[平台自动暂停 / 自动恢复](#平台自动暂停-自动恢复)" |
 | `metadata`              | 任意键值对，写入沙箱元数据，可在列表 / 详情接口中读出                      |
 | `env_vars`              | 注入沙箱进程的环境变量                                                     |
 | `allow_internet_access` | 是否允许出公网；`network` 提供更细粒度的出站策略                           |
 
-> Cube 的最大单次运行时长不像托管 e2b 那样有严格的 24h/1h 平台上限——但 idle `timeout` 仍然是必需的，它防止意外遗漏的沙箱长期占用资源。
+> Cube 不像托管 e2b 那样有严格的 24h/1h 单次运行上限。省略 `timeout` 时，实际空闲 TTL 由集群运维在服务端配置（见下文[设计与运维要点](#设计与运维要点)）。
 
 ## 查询沙箱信息
 
@@ -79,7 +90,7 @@ print(info)
 # }
 ```
 
-`endAt` 表示按当前 `timeout` 估算的下一次超时时间。每次接收到新请求或调用 `set_timeout`（若有），`endAt` 会被刷新。
+`endAt` 表示按当前 `timeout` 估算的下一次超时时间。每次接收到新请求或调用 `set_timeout`（若有），`endAt` 会被刷新。对于**永不超时**的沙箱没有截止时间，因此响应中会**省略** `endAt`，而不是把它渲染成等于 `startedAt`。
 
 ## 列出运行中的沙箱
 
@@ -141,7 +152,7 @@ sandbox = Sandbox.create(
 - 通过 SDK 调用：`sandbox.run_code(...)`、`sandbox.commands.run(...)`、`sandbox.files.read(...)` / `write(...)`。
 - 通过 HTTP 直连沙箱内的服务（例如 `getHost()` 返回的 URL）。
 
-未配置 `auto_pause` / 不传 `lifecycle` 的沙箱默认行为是 `on_timeout="kill"`：空闲超过 `timeout` 秒后，平台会主动销毁该沙箱。这与 e2b `lifecycle.on_timeout="kill"` 语义一致。如果完全不希望被自动回收，请在创建时把 `timeout` 设得足够大、或主动在客户端发心跳调用刷新 idle 计时。
+未配置 `auto_pause` / 不传 `lifecycle` 的沙箱默认行为是 `on_timeout="kill"`：空闲超过 `timeout` 秒后，平台会主动销毁该沙箱。这与 e2b `lifecycle.on_timeout="kill"` 语义一致。若不希望被自动回收，可传 `timeout=NEVER_TIMEOUT`、省略 `timeout`（且服务端未设正数默认）、把 `timeout` 设得足够大，或通过定期活动刷新空闲计时。
 
 ### 端到端示例
 
@@ -161,6 +172,19 @@ python examples/code-sandbox-quickstart/auto-kill.py
 ```
 
 ## 设计与运维要点
+
+### 集群默认空闲超时（`default_timeout_insec`）
+
+客户端不传 `timeout` 时，由 CubeMaster 读取 `CubeMaster/conf.yaml` 中的 `cubelet_conf.default_timeout_insec`（one-click 安装路径：`/usr/local/services/cubetoolbox/CubeMaster/conf.yaml`）。
+
+| 配置值 | 客户端省略 `timeout` 时的效果 |
+|--------|------------------------------|
+| 未配置或 `<= 0` | **不设集群级空闲 TTL** —— 沙箱不会因空闲被自动回收 |
+| 正整数 `N` | 默认空闲 **N 秒**后触发超时 |
+
+仓库默认**不配置集群级空闲超时**（`default_timeout_insec: -1`）。若希望集群自动回收未显式传 `timeout` 的沙箱，可改为正数（例如 `300`）。修改后需重启 `cube-sandbox-cubemaster.service`。
+
+同一段里的 `create_timeout_insec` 与空闲 TTL 无关，仅限制创建/调度 RPC 的截止时间。更多 CubeMaster 配置项见[服务管理 — CubeMaster 配置项](service-management.md#cubemaster-settings)。
 
 - **暂停的状态保真度**：CPU 寄存器、进程内存、TCP 连接（无外部对端）、文件系统改动都会随快照保留；面向外部的连接（如 sandbox 主动建立的 outbound socket）会在暂停时断开，恢复后由应用层自行重连。
 - **集群一致性**：自动暂停由部署在 control 节点上的 `cube-lifecycle-manager` 服务统一协调；它消费 CubeMaster 通过 Redis stream 发布的生命周期事件，通过 Redis 注册表实时发现所有在线的 CubeProxy 副本并广播状态。多副本环境下用 Redis SETNX 互斥锁确保同一沙箱不会被并发暂停或恢复。

--- a/docs/zh/guide/service-management.md
+++ b/docs/zh/guide/service-management.md
@@ -126,6 +126,20 @@ sudo systemctl restart cube-sandbox-<service>.service
 但如果你只是改了 helper 脚本（`/usr/local/services/cubetoolbox/scripts/systemd/*.sh`），不需要 `daemon-reload`，下一次 `restart` 就会重新拉起脚本生效。
 :::
 
+## CubeMaster 配置项 {#cubemaster-settings}
+
+路径：`/usr/local/services/cubetoolbox/CubeMaster/conf.yaml`（one-click 包内来自 `configs/single-node/cubemaster.yaml`）。
+
+`cubelet_conf` 段中与沙箱空闲超时相关的字段：
+
+| 配置项 | 说明 |
+|--------|------|
+| `default_timeout_insec` | 客户端**不传** `timeout` 时，集群默认的**沙箱空闲 TTL**（秒）。**未配置或 `<= 0` 表示不设集群级空闲超时**（沙箱不会因空闲被自动回收，除非客户端显式传 `timeout`）。仓库默认为 `-1`，即“无集群默认”。生产环境若需自动回收未带 TTL 的沙箱，可改为正数（如 `300`）。 |
+| `create_timeout_insec` | 仅限制创建/调度 RPC 的截止时间，**不是**沙箱空闲 TTL。未配置时默认 `300`。 |
+| `common_timeout_insec` | CubeMaster 访问 Cubelet 的通用 RPC 超时（非 create 专用）。 |
+
+修改 `default_timeout_insec` 后需重启 CubeMaster；客户端可见语义见[沙箱生命周期 — 设计与运维要点](lifecycle.md#集群默认空闲超时default_timeout_insec)。
+
 ### 场景 B：服务挂了 / 反复重启
 
 每个 service 都配了 `Restart=on-failure`，进程崩一次会自动重启。但如果反复 fail，需要先看清楚原因再重启。

--- a/sdk/go/client.go
+++ b/sdk/go/client.go
@@ -78,7 +78,9 @@ func (c *Client) Create(ctx context.Context, opts CreateOptions) (*Sandbox, erro
 }
 
 func (c *Client) Connect(ctx context.Context, sandboxID string) (*Sandbox, error) {
-	payload := map[string]any{"timeout": durationSeconds(c.config.Timeout)}
+	// Do not fabricate a timeout on connect: with no caller-provided value we
+	// omit the field entirely and let the server keep its own timeout policy.
+	payload := map[string]any{}
 	var sandbox Sandbox
 	if err := c.doJSON(ctx, http.MethodPost, "/sandboxes/"+url.PathEscape(sandboxID)+"/connect", payload, &sandbox, http.StatusOK); err != nil {
 		return nil, err
@@ -120,13 +122,12 @@ func (c *Client) createPayload(opts CreateOptions) (map[string]any, error) {
 		return nil, fmt.Errorf("template is required. Set CUBE_TEMPLATE_ID or pass TemplateID")
 	}
 
-	timeout := opts.Timeout
-	if timeout <= 0 {
-		timeout = c.config.Timeout
-	}
 	payload := map[string]any{
 		"templateID": templateID,
-		"timeout":    durationSeconds(timeout),
+	}
+	// Omitted when nil; see docs/guide/lifecycle.md.
+	if opts.Timeout != nil {
+		payload["timeout"] = timeoutPayloadSeconds(*opts.Timeout)
 	}
 	if len(opts.EnvVars) > 0 {
 		payload["envVars"] = opts.EnvVars

--- a/sdk/go/config.go
+++ b/sdk/go/config.go
@@ -130,3 +130,11 @@ func durationSeconds(d time.Duration) int {
 	}
 	return seconds
 }
+
+// timeoutPayloadSeconds maps a duration to wire seconds. See docs/guide/lifecycle.md.
+func timeoutPayloadSeconds(d time.Duration) int {
+	if d < 0 {
+		return -1
+	}
+	return durationSeconds(d)
+}

--- a/sdk/go/coverage_test.go
+++ b/sdk/go/coverage_test.go
@@ -152,7 +152,7 @@ func TestSandboxRequiresAttachedClient(t *testing.T) {
 	if err := (&Sandbox{}).Pause(ctx, PauseOptions{}); err == nil {
 		t.Fatal("Pause without client returned nil error")
 	}
-	if err := (&Sandbox{}).Resume(ctx, 0); err == nil {
+	if err := (&Sandbox{}).Resume(ctx, nil); err == nil {
 		t.Fatal("Resume without client returned nil error")
 	}
 	if err := (&Sandbox{}).Kill(ctx); err == nil {
@@ -289,7 +289,8 @@ func TestResumeDefaultTimeoutAndErrors(t *testing.T) {
 		client:    NewClient(Config{APIURL: server.URL, Timeout: 123 * time.Second}),
 		SandboxID: "sb-resume",
 	}
-	if err := sb.Resume(context.Background(), 0); err != nil {
+	// Resume now sends exactly the timeout it is given; nil omits the field.
+	if err := sb.Resume(context.Background(), DurationPtr(123*time.Second)); err != nil {
 		t.Fatalf("Resume returned error: %v", err)
 	}
 	if !strings.Contains(gotBody, `"timeout":123`) {
@@ -297,7 +298,7 @@ func TestResumeDefaultTimeoutAndErrors(t *testing.T) {
 	}
 
 	sb.client.config.APIURL = "http://%"
-	if err := sb.Resume(context.Background(), time.Second); err == nil {
+	if err := sb.Resume(context.Background(), DurationPtr(time.Second)); err == nil {
 		t.Fatal("Resume with malformed URL returned nil error")
 	}
 }

--- a/sdk/go/integration_test.go
+++ b/sdk/go/integration_test.go
@@ -60,7 +60,7 @@ func TestIntegrationSandboxExecutionCommandsFilesAndErrors(t *testing.T) {
 	defer cancel()
 
 	sb := createIntegrationSandbox(t, ctx, client, CreateOptions{
-		Timeout: 2 * time.Minute,
+		Timeout: DurationPtr(2 * time.Minute),
 		EnvVars: map[string]string{
 			"CUBE_GO_SDK_CREATE_ENV": "create-env-ok",
 		},
@@ -187,7 +187,7 @@ func TestIntegrationPauseConnectAndResumeExecution(t *testing.T) {
 	defer cancel()
 
 	sb := createIntegrationSandbox(t, ctx, client, CreateOptions{
-		Timeout: 3 * time.Minute,
+		Timeout: DurationPtr(3 * time.Minute),
 		Metadata: map[string]string{
 			"sdk":      "go",
 			"scenario": "integration-pause-connect",

--- a/sdk/go/models.go
+++ b/sdk/go/models.go
@@ -26,7 +26,7 @@ type SandboxInfo struct {
 	SandboxID    string            `json:"sandboxID"`
 	ClientID     string            `json:"clientID"`
 	StartedAt    time.Time         `json:"startedAt"`
-	EndAt        time.Time         `json:"endAt"`
+	EndAt        *time.Time        `json:"endAt,omitempty"`
 	EnvdVersion  string            `json:"envdVersion"`
 	Domain       string            `json:"domain,omitempty"`
 	CPUCount     int               `json:"cpuCount"`
@@ -53,14 +53,25 @@ type NetworkOptions struct {
 }
 
 type CreateOptions struct {
-	TemplateID          string
-	Timeout             time.Duration
+	TemplateID string
+	// Optional idle TTL; nil omits the field. See docs/guide/lifecycle.md.
+	Timeout             *time.Duration
 	EnvVars             map[string]string
 	Metadata            map[string]string
 	AllowInternetAccess *bool
 	Network             NetworkOptions
 	Extra               map[string]any
 }
+
+// DurationPtr returns a pointer to d. It is a convenience for optional
+// duration fields such as CreateOptions.Timeout and Sandbox.Resume, where nil
+// means "not provided; let the server decide".
+func DurationPtr(d time.Duration) *time.Duration {
+	return &d
+}
+
+// NeverTimeout requests a sandbox that never idle-times-out. See docs/guide/lifecycle.md.
+const NeverTimeout time.Duration = -1
 
 type PauseOptions struct {
 	Wait     *bool

--- a/sdk/go/sandbox.go
+++ b/sdk/go/sandbox.go
@@ -89,16 +89,17 @@ func (s *Sandbox) Pause(ctx context.Context, opts PauseOptions) error {
 //
 // Deprecated: use Client.Connect instead, which auto-resumes paused sandboxes
 // and returns a fresh Sandbox instance.
-func (s *Sandbox) Resume(ctx context.Context, timeout time.Duration) error {
+// The timeout is optional; nil omits it. See docs/guide/lifecycle.md.
+func (s *Sandbox) Resume(ctx context.Context, timeout *time.Duration) error {
 	if err := s.ensureClient(); err != nil {
 		return err
 	}
-	if timeout <= 0 {
-		timeout = s.client.config.Timeout
-	}
 
 	path := "/sandboxes/" + url.PathEscape(s.SandboxID) + "/resume"
-	payload := map[string]any{"timeout": durationSeconds(timeout)}
+	payload := map[string]any{}
+	if timeout != nil {
+		payload["timeout"] = timeoutPayloadSeconds(*timeout)
+	}
 	return s.client.doJSON(ctx, http.MethodPost, path, payload, nil, http.StatusOK, http.StatusCreated, http.StatusNoContent)
 }
 

--- a/sdk/go/sdk_test.go
+++ b/sdk/go/sdk_test.go
@@ -103,7 +103,7 @@ func TestCreateSendsPythonCompatiblePayload(t *testing.T) {
 	})
 
 	sb, err := client.Create(context.Background(), CreateOptions{
-		Timeout:             600 * time.Second,
+		Timeout:             DurationPtr(600 * time.Second),
 		EnvVars:             map[string]string{"FOO": "bar"},
 		Metadata:            map[string]string{"network-policy": "custom"},
 		AllowInternetAccess: &disallowInternet,
@@ -171,6 +171,43 @@ func TestCreateOmitsOptionalFieldsAndRequiresTemplate(t *testing.T) {
 	}
 }
 
+func TestCreateTimeoutWireValues(t *testing.T) {
+	var got map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got = nil
+		if err := json.NewDecoder(r.Body).Decode(&got); err != nil {
+			t.Fatalf("decode body: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		fmt.Fprint(w, sandboxJSON(testSandboxID, "tpl-t"))
+	}))
+	defer server.Close()
+
+	client := NewClient(Config{APIURL: server.URL, TemplateID: "tpl-t"})
+	ctx := context.Background()
+
+	// Omitted → field absent (server decides).
+	if _, err := client.Create(ctx, CreateOptions{}); err != nil {
+		t.Fatalf("Create(omit): %v", err)
+	}
+	if _, ok := got["timeout"]; ok {
+		t.Fatalf("timeout must be omitted when unset: %#v", got)
+	}
+
+	// Explicit zero is sent as 0.
+	if _, err := client.Create(ctx, CreateOptions{Timeout: DurationPtr(0)}); err != nil {
+		t.Fatalf("Create(0): %v", err)
+	}
+	assertNumber(t, got, "timeout", 0)
+
+	// NeverTimeout is sent as -1.
+	if _, err := client.Create(ctx, CreateOptions{Timeout: DurationPtr(NeverTimeout)}); err != nil {
+		t.Fatalf("Create(never): %v", err)
+	}
+	assertNumber(t, got, "timeout", -1)
+}
+
 func TestLifecycleEndpoints(t *testing.T) {
 	var calls []string
 	var connectTimeout, resumeTimeout int
@@ -220,8 +257,10 @@ func TestLifecycleEndpoints(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Connect: %v", err)
 	}
-	if connectTimeout != 600 {
-		t.Fatalf("connect timeout=%d", connectTimeout)
+	// Connect no longer fabricates a timeout: the field is omitted so the
+	// server keeps its own timeout policy (decoded default int is 0).
+	if connectTimeout != 0 {
+		t.Fatalf("connect must omit timeout, got=%d", connectTimeout)
 	}
 
 	list, err := client.List(ctx)
@@ -244,7 +283,7 @@ func TestLifecycleEndpoints(t *testing.T) {
 	if err := sb.Pause(ctx, PauseOptions{Wait: &wait}); err != nil {
 		t.Fatalf("Pause: %v", err)
 	}
-	if err := sb.Resume(ctx, 120*time.Second); err != nil {
+	if err := sb.Resume(ctx, DurationPtr(120*time.Second)); err != nil {
 		t.Fatalf("Resume: %v", err)
 	}
 	if resumeTimeout != 120 {
@@ -793,6 +832,34 @@ func sandboxJSON(sandboxID, templateID string) string {
 
 func sandboxInfoJSON(sandboxID, state string) string {
 	return fmt.Sprintf(`{"sandboxID":%q,"templateID":"tpl-test","clientID":"client-1","startedAt":"2026-05-14T00:00:00Z","endAt":"2026-05-14T01:00:00Z","envdVersion":"0.0.1","domain":"cube.app","cpuCount":2,"memoryMB":512,"state":%q}`, sandboxID, state)
+}
+
+func TestSandboxInfoEndAtOmitted(t *testing.T) {
+	const payload = `{"sandboxID":"sb-1","templateID":"tpl-1","clientID":"c-1","startedAt":"2026-05-14T00:00:00Z","envdVersion":"0.0.1","cpuCount":2,"memoryMB":512,"state":"running"}`
+
+	var info SandboxInfo
+	if err := json.Unmarshal([]byte(payload), &info); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if info.EndAt != nil {
+		t.Fatalf("EndAt=%#v, want nil when API omits endAt", info.EndAt)
+	}
+}
+
+func TestSandboxInfoEndAtPresent(t *testing.T) {
+	const payload = `{"sandboxID":"sb-1","templateID":"tpl-1","clientID":"c-1","startedAt":"2026-05-14T00:00:00Z","endAt":"2026-05-14T01:00:00Z","envdVersion":"0.0.1","cpuCount":2,"memoryMB":512,"state":"running"}`
+
+	var info SandboxInfo
+	if err := json.Unmarshal([]byte(payload), &info); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if info.EndAt == nil {
+		t.Fatal("EndAt=nil, want non-nil when API includes endAt")
+	}
+	want := time.Date(2026, 5, 14, 1, 0, 0, 0, time.UTC)
+	if !info.EndAt.Equal(want) {
+		t.Fatalf("EndAt=%v want %v", info.EndAt, want)
+	}
 }
 
 func serverHostPort(t *testing.T, rawURL string) (string, int) {

--- a/sdk/python/cubesandbox/__init__.py
+++ b/sdk/python/cubesandbox/__init__.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2026 Tencent Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-from .sandbox import Sandbox
+from .sandbox import Sandbox, NEVER_TIMEOUT
 from ._config import Config
 from ._models import Execution, Result, Logs, ExecutionError, OutputMessage, SnapshotInfo
 from ._exceptions import CubeSandboxError, SandboxNotFoundError, ApiError, TemplateNotFoundError, FilesystemNotFoundError, PartialWriteError
@@ -12,6 +12,7 @@ from ._policy import Rule, Match, Action, Inject
 
 __all__ = [
     "Sandbox",
+    "NEVER_TIMEOUT",
     "Config",
     "Execution",
     "Result",

--- a/sdk/python/cubesandbox/sandbox.py
+++ b/sdk/python/cubesandbox/sandbox.py
@@ -25,6 +25,9 @@ from ._transport import build_client
 
 JUPYTER_PORT = 49999
 
+#: Never-timeout sentinel. See docs/guide/lifecycle.md.
+NEVER_TIMEOUT = -1
+
 
 def _check_response(resp: requests.Response) -> None:
     if resp.ok:
@@ -156,7 +159,8 @@ class Sandbox:
 
         Args:
             template: Template ID. Falls back to ``CUBE_TEMPLATE_ID`` env var.
-            timeout: Sandbox TTL in seconds. Defaults to ``Config.timeout`` (300).
+            timeout: Sandbox idle timeout in seconds (``None`` omits the field).
+                See ``docs/guide/lifecycle.md``.
             env_vars: Environment variables injected into the sandbox.
             metadata: Arbitrary key-value metadata (e.g. network-policy, host-mount).
             allow_internet_access: When ``False``, the sandbox is blocked from
@@ -200,7 +204,10 @@ class Sandbox:
         if not tpl:
             raise ValueError("template is required. Set CUBE_TEMPLATE_ID or pass template=")
 
-        payload: dict = {"templateID": tpl, "timeout": timeout or cfg.timeout}
+        # Omitted when None; see docs/guide/lifecycle.md.
+        payload: dict = {"templateID": tpl}
+        if timeout is not None:
+            payload["timeout"] = timeout
         if env_vars:
             payload["envVars"] = env_vars
         if metadata:
@@ -262,8 +269,9 @@ class Sandbox:
         """
         cfg = config or Config()
         s = requests.Session()
+        # Connect omits timeout; see docs/guide/lifecycle.md.
         resp = s.post(f"{cfg.api_url}/sandboxes/{sandbox_id}/connect",
-                      json={"timeout": cfg.timeout},
+                      json={},
                       headers={"Content-Type": "application/json"})
         _check_response(resp)
         return cls(resp.json(), config=cfg)
@@ -421,7 +429,7 @@ class Sandbox:
                 f"Sandbox {self.sandbox_id!r} did not reach 'paused' state within {timeout}s"
             )
 
-    def resume(self, timeout: int = 300) -> None:
+    def resume(self, timeout: int | None = None) -> None:
         """POST /sandboxes/:sandboxID/resume - Resume a paused sandbox.
 
         .. deprecated::
@@ -429,16 +437,20 @@ class Sandbox:
             and returns a fresh :class:`Sandbox` instance.
 
         Args:
-            timeout: Sandbox TTL in seconds after resume (default: 300).
+            timeout: Sandbox TTL in seconds after resume (``None`` omits the field).
+                See ``docs/guide/lifecycle.md``.
 
         Raises:
             SandboxNotFoundError: If the sandbox does not exist (HTTP 404).
             ApiError: If the sandbox is already running (HTTP 409) or on
                 unexpected backend error (HTTP 500).
         """
+        body: dict = {}
+        if timeout is not None:
+            body["timeout"] = timeout
         resp = self._session.post(
             f"{self._config.api_url}/sandboxes/{self.sandbox_id}/resume",
-            json={"timeout": timeout},
+            json=body,
         )
         _check_response(resp)
 

--- a/sdk/python/tests/test_sandbox.py
+++ b/sdk/python/tests/test_sandbox.py
@@ -104,6 +104,30 @@ class TestCreate:
         assert body["templateID"] == "tpl-foo"
         assert body["timeout"] == 600
 
+    def test_create_omits_timeout_when_absent(self):
+        # No timeout argument → the field is omitted so CubeMaster applies its
+        # server-side default (no implicit client fill).
+        with patch("requests.Session.post", return_value=mock_response(SANDBOX_DATA, status=201)) as m:
+            Sandbox.create(template="tpl-foo", config=make_config())
+        body = m.call_args.kwargs["json"]
+        assert "timeout" not in body
+
+    def test_create_sends_explicit_zero_timeout(self):
+        # An explicit 0 must be forwarded as-is (not dropped as falsy).
+        with patch("requests.Session.post", return_value=mock_response(SANDBOX_DATA, status=201)) as m:
+            Sandbox.create(template="tpl-foo", timeout=0, config=make_config())
+        body = m.call_args.kwargs["json"]
+        assert body["timeout"] == 0
+
+    def test_create_sends_never_timeout(self):
+        # NEVER_TIMEOUT must be forwarded as -1.
+        from cubesandbox import NEVER_TIMEOUT
+
+        with patch("requests.Session.post", return_value=mock_response(SANDBOX_DATA, status=201)) as m:
+            Sandbox.create(template="tpl-foo", timeout=NEVER_TIMEOUT, config=make_config())
+        body = m.call_args.kwargs["json"]
+        assert body["timeout"] == -1
+
     def test_create_sends_env_vars(self):
         with patch("requests.Session.post", return_value=mock_response(SANDBOX_DATA, status=201)) as m:
             Sandbox.create(env_vars={"FOO": "bar"}, config=make_config())
@@ -621,13 +645,15 @@ class TestConnect:
             with pytest.raises(SandboxNotFoundError):
                 Sandbox.connect(SANDBOX_ID, config=make_config())
 
-    def test_connect_sends_timeout(self):
+    def test_connect_omits_timeout(self):
+        # connect no longer fabricates a timeout: the field must be absent so
+        # the server keeps its own timeout policy.
         cfg = make_config()
         cfg.timeout = 600
         with patch("requests.Session.post", return_value=mock_response(SANDBOX_DATA)) as m:
             Sandbox.connect(SANDBOX_ID, config=cfg)
         body = m.call_args.kwargs["json"]
-        assert body["timeout"] == 600
+        assert "timeout" not in body
 
 
 # ── GET /sandboxes ────────────────────────────────────────────────────────────
@@ -785,13 +811,35 @@ class TestResume:
         body = m.call_args.kwargs["json"]
         assert body["timeout"] == 120
 
-    def test_resume_default_timeout(self):
+    def test_resume_omits_timeout_by_default(self):
+        # resume() with no argument must omit the timeout field so the server
+        # keeps its own timeout policy.
         sb = make_sandbox()
         with patch.object(sb._session, "post",
                           return_value=mock_response(SANDBOX_DATA, status=201)) as m:
             sb.resume()
         body = m.call_args.kwargs["json"]
-        assert body["timeout"] == 300
+        assert "timeout" not in body
+
+    def test_resume_explicit_zero_is_sent(self):
+        # An explicit 0 must be forwarded as-is (not dropped as falsy).
+        sb = make_sandbox()
+        with patch.object(sb._session, "post",
+                          return_value=mock_response(SANDBOX_DATA, status=201)) as m:
+            sb.resume(timeout=0)
+        body = m.call_args.kwargs["json"]
+        assert body["timeout"] == 0
+
+    def test_resume_sends_never_timeout(self):
+        # NEVER_TIMEOUT must be forwarded as -1.
+        from cubesandbox import NEVER_TIMEOUT
+
+        sb = make_sandbox()
+        with patch.object(sb._session, "post",
+                          return_value=mock_response(SANDBOX_DATA, status=201)) as m:
+            sb.resume(timeout=NEVER_TIMEOUT)
+        body = m.call_args.kwargs["json"]
+        assert body["timeout"] == -1
 
     def test_resume_not_found(self):
         sb = make_sandbox()


### PR DESCRIPTION
## Summary

Implement three-value sandbox timeout semantics (`>0`=TTL, `0`=immediate expiry, `<0`=never timeout), moving the default-timeout decision from SDK/CubeAPI to CubeMaster so "not set" is preserved end-to-end.

## Motivation

Currently every layer in the call chain applies its own default timeout (SDK: 300s → CubeAPI: 15s → CubeMaster: 30s → CLM: 5min), making it impossible to express "never timeout" or to let the server decide the default. This refactor makes the server the single authority for timeout defaults.

## Key Changes

### SDK (Go/Python)
- `CreateOptions.Timeout` changed to pointer/optional — `nil`/`None` means "not set" (do not send the field)
- `Create`/`Connect`/`Resume` no longer auto-fill a default timeout
- Expose `NeverTimeout`/`NEVER_TIMEOUT` sentinel (`-1`) for explicit never-timeout requests

### CubeAPI (Rust)
- `NewSandbox`/`ConnectSandbox`/`ResumedSandbox` timeout fields: `i32` → `Option<i32>`
- Remove `serde default_timeout()` fallback; pure passthrough

### CubeMaster (Go)
- `CreateCubeSandboxReq.Timeout`: `int` → `*int` to distinguish "not set" from explicit `0`
- Three-value resolution: not-set→server default, explicit negative→normalize to `-1` (never), explicit `≥0`→passthrough
- Add `default_timeout_insec` (server-side default) and `create_timeout_insec` (RPC deadline) config options
- Decouple create RPC context deadline from sandbox idle TTL
- Lifecycle meta `TimeoutSeconds`: `int` → `*int` for old-data compatibility

### cube-lifecycle-manager
- Sweeper: `<0` → skip recycling; `==0` → immediate recycling; `nil` → fallback to `DefaultIdleTimeout`
- Schema `TimeoutSeconds` updated to `*int` (no `omitempty`)

### Docs
- Update lifecycle docs (en+zh) with the new timeout behavior matrix

## Deployment Order (Important)

1. Upgrade CLM first (sweeper `<0` skip support)
2. Then CubeMaster (sentinel `-1` + config + deadline decouple)
3. Then SDK/CubeAPI ("not set" passthrough)
Rollback in reverse order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)