### PR TITLE
feat(terraform): add TencentCloud lifecycle manager deployment

### DIFF
--- a/deploy/one-click/build-release-bundle.sh
+++ b/deploy/one-click/build-release-bundle.sh
@@ -618,11 +618,14 @@ find "${PACKAGE_ROOT}/terraform/tencentcloud" -maxdepth 1 -type f \
 # not maintained separately but derived from the canonical webui/nginx.conf so
 # the two never drift.
 copy_file "${CUBE_WEBUI_TEMPLATE_DIR}/nginx.conf" "${PACKAGE_ROOT}/terraform/tencentcloud/webui-nginx.conf"
+# tke-addons.tf also mounts cube-proxy's nginx.conf so the admin listener can be
+# cluster-reachable by cube-lifecycle-manager in Kubernetes deployments.
+copy_file "${CUBE_PROXY_SOURCE_DIR}/nginx.conf" "${PACKAGE_ROOT}/terraform/tencentcloud/cubeproxy-nginx.conf"
 # Verify the terraform deployer actually shipped (mirrors the guarding done for
 # the other components), so a renamed/emptied source dir fails the build loudly
 # instead of producing a bundle with an absent/broken deployer.
 for _tf in create.sh destroy.sh build_images.sh lib-state-sync.sh lib-phases.sh \
-  main.tf variables.tf tke-addons.tf query_outputs.tf webui-nginx.conf; do
+  main.tf variables.tf tke-addons.tf query_outputs.tf webui-nginx.conf cubeproxy-nginx.conf; do
   ensure_file "${PACKAGE_ROOT}/terraform/tencentcloud/${_tf}"
 done
 
@@ -680,9 +683,11 @@ find "${DIST_ROOT}/terraform/tencentcloud" -maxdepth 1 -type f \
 # sandbox-package copy above) so create.sh can apply tke-addons.tf straight from
 # the extracted bundle without the source tree present.
 copy_file "${CUBE_WEBUI_TEMPLATE_DIR}/nginx.conf" "${DIST_ROOT}/terraform/tencentcloud/webui-nginx.conf"
+# Ship cube-proxy's canonical nginx.conf for the Terraform TKE deployment too.
+copy_file "${CUBE_PROXY_SOURCE_DIR}/nginx.conf" "${DIST_ROOT}/terraform/tencentcloud/cubeproxy-nginx.conf"
 # Verify the top-level terraform deployer copy shipped intact too.
 for _tf in create.sh destroy.sh build_images.sh lib-state-sync.sh lib-phases.sh \
-  main.tf variables.tf tke-addons.tf query_outputs.tf webui-nginx.conf; do
+  main.tf variables.tf tke-addons.tf query_outputs.tf webui-nginx.conf cubeproxy-nginx.conf; do
   ensure_file "${DIST_ROOT}/terraform/tencentcloud/${_tf}"
 done
 find "${DIST_ROOT}/terraform" -type f -name "*.sh" -exec chmod +x {} \;

--- a/deploy/one-click/build-release-bundle.sh
+++ b/deploy/one-click/build-release-bundle.sh
@@ -618,9 +618,12 @@ find "${PACKAGE_ROOT}/terraform/tencentcloud" -maxdepth 1 -type f \
 # not maintained separately but derived from the canonical webui/nginx.conf so
 # the two never drift.
 copy_file "${CUBE_WEBUI_TEMPLATE_DIR}/nginx.conf" "${PACKAGE_ROOT}/terraform/tencentcloud/webui-nginx.conf"
-# tke-addons.tf also mounts cube-proxy's nginx.conf so the admin listener can be
-# cluster-reachable by cube-lifecycle-manager in Kubernetes deployments.
-copy_file "${CUBE_PROXY_SOURCE_DIR}/nginx.conf" "${PACKAGE_ROOT}/terraform/tencentcloud/cubeproxy-nginx.conf"
+# tke-addons.tf also mounts cube-proxy's nginx.conf; render the Terraform copy
+# with placeholders so the Kubernetes deployment can bind the admin listener on
+# the Pod IP while preserving CubeProxy/nginx.conf as the canonical source.
+generate_cube_proxy_nginx_template \
+  "${CUBE_PROXY_SOURCE_DIR}/nginx.conf" \
+  "${PACKAGE_ROOT}/terraform/tencentcloud/cubeproxy-nginx.conf"
 # Verify the terraform deployer actually shipped (mirrors the guarding done for
 # the other components), so a renamed/emptied source dir fails the build loudly
 # instead of producing a bundle with an absent/broken deployer.
@@ -683,8 +686,10 @@ find "${DIST_ROOT}/terraform/tencentcloud" -maxdepth 1 -type f \
 # sandbox-package copy above) so create.sh can apply tke-addons.tf straight from
 # the extracted bundle without the source tree present.
 copy_file "${CUBE_WEBUI_TEMPLATE_DIR}/nginx.conf" "${DIST_ROOT}/terraform/tencentcloud/webui-nginx.conf"
-# Ship cube-proxy's canonical nginx.conf for the Terraform TKE deployment too.
-copy_file "${CUBE_PROXY_SOURCE_DIR}/nginx.conf" "${DIST_ROOT}/terraform/tencentcloud/cubeproxy-nginx.conf"
+# Ship the placeholder-rendered cube-proxy nginx config for Terraform too.
+generate_cube_proxy_nginx_template \
+  "${CUBE_PROXY_SOURCE_DIR}/nginx.conf" \
+  "${DIST_ROOT}/terraform/tencentcloud/cubeproxy-nginx.conf"
 # Verify the top-level terraform deployer copy shipped intact too.
 for _tf in create.sh destroy.sh build_images.sh lib-state-sync.sh lib-phases.sh \
   main.tf variables.tf tke-addons.tf query_outputs.tf webui-nginx.conf cubeproxy-nginx.conf; do

--- a/deploy/one-click/terraform/tencentcloud/build_images.sh
+++ b/deploy/one-click/terraform/tencentcloud/build_images.sh
@@ -15,14 +15,15 @@
 #   tar xzf assets/package/sandbox-package.tar.gz -C assets/package/
 #   assets/package/sandbox-package/terraform/tencentcloud/build_images.sh
 #
-# It builds four images straight from the package contents:
-#   cube-api    <- CubeAPI/Dockerfile          (prebuilt CubeAPI/bin/cube-api)
-#   cubemaster  <- CubeMaster/Dockerfile       (prebuilt CubeMaster/bin/cubemaster)
-#   cubeproxy   <- cubeproxy/build-context/Dockerfile
-#   cube-webui  <- webui/Dockerfile.package    (prebuilt webui/dist)
+# It builds five images straight from the package contents:
+#   cube-api                <- CubeAPI/Dockerfile          (prebuilt CubeAPI/bin/cube-api)
+#   cubemaster              <- CubeMaster/Dockerfile       (prebuilt CubeMaster/bin/cubemaster)
+#   cubeproxy               <- cubeproxy/build-context/Dockerfile
+#   cube-lifecycle-manager  <- cube-lifecycle-manager/build-context/Dockerfile
+#   cube-webui              <- webui/Dockerfile.package    (prebuilt webui/dist)
 #
 # Selecting images:
-#   build_images.sh                       # all four (default)
+#   build_images.sh                       # all five (default)
 #   build_images.sh cube-api webui        # only the listed ones
 #
 # Options / environment:
@@ -37,6 +38,7 @@
 #   CUBE_API_IMAGE=...         fully-qualified ref overrides (per component);
 #   CUBE_MASTER_IMAGE=...      default to ${REGISTRY}/${NAMESPACE}/<name>:${TAG},
 #   CUBE_PROXY_IMAGE=...       matching terraform/tencentcloud (var.image_tag) so
+#   CUBE_LCM_IMAGE=...
 #   CUBE_WEBUI_IMAGE=...       freshly built images work with the TKE deployment.
 #   WEB_UI_UPSTREAM=...        CubeAPI upstream baked into the webui image
 #                              (default http://host.docker.internal:3000)
@@ -72,6 +74,7 @@ TAG="${TAG:-v0.5.0}"
 CUBE_API_IMAGE="${CUBE_API_IMAGE:-${REGISTRY}/${NAMESPACE}/cube-api:${TAG}}"
 CUBE_MASTER_IMAGE="${CUBE_MASTER_IMAGE:-${REGISTRY}/${NAMESPACE}/cube-master:${TAG}}"
 CUBE_PROXY_IMAGE="${CUBE_PROXY_IMAGE:-${REGISTRY}/${NAMESPACE}/cube-proxy:${TAG}}"
+CUBE_LCM_IMAGE="${CUBE_LCM_IMAGE:-${REGISTRY}/${NAMESPACE}/cube-lifecycle-manager:${TAG}}"
 CUBE_WEBUI_IMAGE="${CUBE_WEBUI_IMAGE:-${REGISTRY}/${NAMESPACE}/webui:${TAG}}"
 
 WEB_UI_UPSTREAM="${WEB_UI_UPSTREAM:-http://host.docker.internal:3000}"
@@ -236,6 +239,12 @@ build_cube_proxy() {
 		"${PKG_ROOT}/cubeproxy/build-context"
 }
 
+build_cube_lifecycle_manager() {
+	docker_build "${CUBE_LCM_IMAGE}" \
+		"${PKG_ROOT}/cube-lifecycle-manager/build-context/Dockerfile" \
+		"${PKG_ROOT}/cube-lifecycle-manager/build-context"
+}
+
 build_cube_webui() {
 	docker_build "${CUBE_WEBUI_IMAGE}" \
 		"${PKG_ROOT}/webui/Dockerfile.package" "${PKG_ROOT}/webui" \
@@ -249,17 +258,18 @@ main() {
 		case "${arg}" in
 		-h | --help) usage 0 ;;
 		--push) PUSH=1 ;;
-		all) targets+=(cube-api cube-master cube-proxy webui) ;;
+		all) targets+=(cube-api cube-master cube-proxy cube-lifecycle-manager webui) ;;
 		cube-api | cubeapi) targets+=(cube-api) ;;
 		cube-master | cubemaster | master) targets+=(cube-master) ;;
 		cube-proxy | cubeproxy | proxy) targets+=(cube-proxy) ;;
+		cube-lifecycle-manager | lifecycle-manager | lcm) targets+=(cube-lifecycle-manager) ;;
 		webui | cube-webui) targets+=(webui) ;;
 		*) die "unknown argument: ${arg} (run with --help)" ;;
 		esac
 	done
 
 	if [[ "${#targets[@]}" -eq 0 ]]; then
-		targets=(cube-api cube-master cube-proxy webui)
+		targets=(cube-api cube-master cube-proxy cube-lifecycle-manager webui)
 	fi
 
 	command -v docker >/dev/null 2>&1 || die "docker is required but was not found in PATH"
@@ -271,6 +281,7 @@ main() {
 		cube-api) build_cube_api ;;
 		cube-master) build_cube_master ;;
 		cube-proxy) build_cube_proxy ;;
+		cube-lifecycle-manager) build_cube_lifecycle_manager ;;
 		webui) build_cube_webui ;;
 		esac
 	done

--- a/deploy/one-click/terraform/tencentcloud/create.sh
+++ b/deploy/one-click/terraform/tencentcloud/create.sh
@@ -613,11 +613,41 @@ prepare_cubeproxy_nginx_conf() {
 	[ -f "${dst}" ] && return 0
 
 	local src
+	src="${SCRIPT_DIR}/../../cubeproxy/nginx.conf.template"
+	if [ -f "${src}" ]; then
+		cp -f "${src}" "${dst}"
+		echo -e "  ${GREEN}✓ Generated cubeproxy-nginx.conf from ${src}${NC}"
+		return 0
+	fi
+
 	for src in \
-		"${SCRIPT_DIR}/../../../../CubeProxy/nginx.conf" \
-		"${SCRIPT_DIR}/../../cubeproxy/nginx.conf.template"; do
+		"${SCRIPT_DIR}/../../../../CubeProxy/nginx.conf"; do
 		if [ -f "${src}" ]; then
-			cp -f "${src}" "${dst}"
+			{
+				cat <<'EOF'
+# NOTE: This file is auto-generated from CubeProxy/nginx.conf.
+# DO NOT edit by hand; modify the upstream CubeProxy/nginx.conf instead.
+
+EOF
+				sed \
+					-e 's|^worker_processes [0-9]\+;|worker_processes auto;|' \
+					-e 's|^\(\s*listen \)8081\( reuseport;\)|\1__CUBE_PROXY_HTTP_PORT__\2|' \
+					-e 's|^\(\s*listen \)8080\( ssl reuseport;\)|\1__CUBE_PROXY_HTTPS_PORT__\2|' \
+					-e 's|^\(\s*set \$host_proxy_port \)8081;|\1__CUBE_PROXY_HTTP_PORT__;|' \
+					-e 's|^\(\s*set \$host_proxy_port \)8080;|\1__CUBE_PROXY_HTTPS_PORT__;|' \
+					-e 's|^\(\s*listen \)127\.0\.0\.1:8082;|\1__CUBE_PROXY_ADMIN_LISTEN__:8082;|' \
+					-e 's|/usr/local/openresty/nginx/certs/cube\.app+3\.pem|/usr/local/openresty/nginx/certs/__CUBE_PROXY_SSL_CERT__|' \
+					-e 's|/usr/local/openresty/nginx/certs/cube\.app+3-key\.pem|/usr/local/openresty/nginx/certs/__CUBE_PROXY_SSL_KEY__|' \
+					"${src}"
+			} >"${dst}"
+			local token
+			for token in __CUBE_PROXY_HTTP_PORT__ __CUBE_PROXY_HTTPS_PORT__ __CUBE_PROXY_ADMIN_LISTEN__ __CUBE_PROXY_SSL_CERT__ __CUBE_PROXY_SSL_KEY__; do
+				if ! grep -q -F "${token}" "${dst}"; then
+					rm -f "${dst}"
+					echo -e "  ${RED}✗ cube-proxy nginx template is missing ${token}; upstream CubeProxy/nginx.conf may have changed${NC}" >&2
+					return 1
+				fi
+			done
 			echo -e "  ${GREEN}✓ Generated cubeproxy-nginx.conf from ${src}${NC}"
 			return 0
 		fi
@@ -651,7 +681,7 @@ http {
   }
 }
 EOF
-	echo -e "  ${YELLOW}⚠ cube-proxy nginx source not found; generated a minimal cubeproxy-nginx.conf fallback${NC}"
+	echo -e "  ${YELLOW}⚠ cube-proxy nginx source not found; generated a minimal fallback that only satisfies probes and will not proxy sandbox traffic${NC}" >&2
 	return 0
 }
 

--- a/deploy/one-click/terraform/tencentcloud/create.sh
+++ b/deploy/one-click/terraform/tencentcloud/create.sh
@@ -620,38 +620,36 @@ prepare_cubeproxy_nginx_conf() {
 		return 0
 	fi
 
-	for src in \
-		"${SCRIPT_DIR}/../../../../CubeProxy/nginx.conf"; do
-		if [ -f "${src}" ]; then
-			{
-				cat <<'EOF'
+	src="${SCRIPT_DIR}/../../../../CubeProxy/nginx.conf"
+	if [ -f "${src}" ]; then
+		{
+			cat <<'EOF'
 # NOTE: This file is auto-generated from CubeProxy/nginx.conf.
 # DO NOT edit by hand; modify the upstream CubeProxy/nginx.conf instead.
 
 EOF
-				sed \
-					-e 's|^worker_processes [0-9]\+;|worker_processes auto;|' \
-					-e 's|^\(\s*listen \)8081\( reuseport;\)|\1__CUBE_PROXY_HTTP_PORT__\2|' \
-					-e 's|^\(\s*listen \)8080\( ssl reuseport;\)|\1__CUBE_PROXY_HTTPS_PORT__\2|' \
-					-e 's|^\(\s*set \$host_proxy_port \)8081;|\1__CUBE_PROXY_HTTP_PORT__;|' \
-					-e 's|^\(\s*set \$host_proxy_port \)8080;|\1__CUBE_PROXY_HTTPS_PORT__;|' \
-					-e 's|^\(\s*listen \)127\.0\.0\.1:8082;|\1__CUBE_PROXY_ADMIN_LISTEN__:8082;|' \
-					-e 's|/usr/local/openresty/nginx/certs/cube\.app+3\.pem|/usr/local/openresty/nginx/certs/__CUBE_PROXY_SSL_CERT__|' \
-					-e 's|/usr/local/openresty/nginx/certs/cube\.app+3-key\.pem|/usr/local/openresty/nginx/certs/__CUBE_PROXY_SSL_KEY__|' \
-					"${src}"
-			} >"${dst}"
-			local token
-			for token in __CUBE_PROXY_HTTP_PORT__ __CUBE_PROXY_HTTPS_PORT__ __CUBE_PROXY_ADMIN_LISTEN__ __CUBE_PROXY_SSL_CERT__ __CUBE_PROXY_SSL_KEY__; do
-				if ! grep -q -F "${token}" "${dst}"; then
-					rm -f "${dst}"
-					echo -e "  ${RED}✗ cube-proxy nginx template is missing ${token}; upstream CubeProxy/nginx.conf may have changed${NC}" >&2
-					return 1
-				fi
-			done
-			echo -e "  ${GREEN}✓ Generated cubeproxy-nginx.conf from ${src}${NC}"
-			return 0
-		fi
-	done
+			sed \
+				-e 's|^worker_processes [0-9]\+;|worker_processes auto;|' \
+				-e 's|^\(\s*listen \)8081\( reuseport;\)|\1__CUBE_PROXY_HTTP_PORT__\2|' \
+				-e 's|^\(\s*listen \)8080\( ssl reuseport;\)|\1__CUBE_PROXY_HTTPS_PORT__\2|' \
+				-e 's|^\(\s*set \$host_proxy_port \)8081;|\1__CUBE_PROXY_HTTP_PORT__;|' \
+				-e 's|^\(\s*set \$host_proxy_port \)8080;|\1__CUBE_PROXY_HTTPS_PORT__;|' \
+				-e 's|^\(\s*listen \)127\.0\.0\.1:8082;|\1__CUBE_PROXY_ADMIN_LISTEN__:8082;|' \
+				-e 's|/usr/local/openresty/nginx/certs/cube\.app+3\.pem|/usr/local/openresty/nginx/certs/__CUBE_PROXY_SSL_CERT__|' \
+				-e 's|/usr/local/openresty/nginx/certs/cube\.app+3-key\.pem|/usr/local/openresty/nginx/certs/__CUBE_PROXY_SSL_KEY__|' \
+				"${src}"
+		} >"${dst}"
+		local token
+		for token in __CUBE_PROXY_HTTP_PORT__ __CUBE_PROXY_HTTPS_PORT__ __CUBE_PROXY_ADMIN_LISTEN__ __CUBE_PROXY_SSL_CERT__ __CUBE_PROXY_SSL_KEY__; do
+			if ! grep -q -F "${token}" "${dst}"; then
+				rm -f "${dst}"
+				echo -e "  ${RED}✗ cube-proxy nginx template is missing ${token}; upstream CubeProxy/nginx.conf may have changed${NC}" >&2
+				return 1
+			fi
+		done
+		echo -e "  ${GREEN}✓ Generated cubeproxy-nginx.conf from ${src}${NC}"
+		return 0
+	fi
 
 	cat >"${dst}" <<'EOF'
 user root;

--- a/deploy/one-click/terraform/tencentcloud/create.sh
+++ b/deploy/one-click/terraform/tencentcloud/create.sh
@@ -584,7 +584,74 @@ prepare_webui_nginx_conf() {
 		echo -e "  ${GREEN}✓ Generated webui-nginx.conf from webui/nginx.conf${NC}"
 		return 0
 	fi
-	echo -e "${YELLOW}⚠ webui-nginx.conf not found and cannot be generated from webui/nginx.conf; cube-webui addon deployment may fail${NC}"
+
+	cat >"${dst}" <<'EOF'
+worker_processes auto;
+events { worker_connections 1024; }
+http {
+  server {
+    listen 80;
+    root /usr/share/nginx/html;
+    index index.html;
+    location ^~ /sandbox/ { proxy_pass __SANDBOX_PROXY_UPSTREAM__; }
+    location /cubeapi/ { proxy_pass __WEB_UI_UPSTREAM__/cubeapi/; }
+    location / { try_files $uri $uri/ /index.html; }
+  }
+}
+EOF
+	echo -e "  ${YELLOW}⚠ webui/nginx.conf source not found; generated a minimal webui-nginx.conf fallback${NC}"
+	return 0
+}
+
+# ---------------------------------------------------------------
+# prepare_cubeproxy_nginx_conf — ensure the cubeproxy-nginx.conf required by
+#   tke-addons.tf exists. The Kubernetes deployment mounts this file so the
+#   admin listener is reachable by cube-lifecycle-manager.
+# ---------------------------------------------------------------
+prepare_cubeproxy_nginx_conf() {
+	local dst="${SCRIPT_DIR}/cubeproxy-nginx.conf"
+	[ -f "${dst}" ] && return 0
+
+	local src
+	for src in \
+		"${SCRIPT_DIR}/../../../../CubeProxy/nginx.conf" \
+		"${SCRIPT_DIR}/../../cubeproxy/nginx.conf.template"; do
+		if [ -f "${src}" ]; then
+			cp -f "${src}" "${dst}"
+			echo -e "  ${GREEN}✓ Generated cubeproxy-nginx.conf from ${src}${NC}"
+			return 0
+		fi
+	done
+
+	cat >"${dst}" <<'EOF'
+user root;
+worker_processes auto;
+error_log /data/log/cube-proxy/error.log notice;
+daemon off;
+events { worker_connections 100000; }
+http {
+  include mime.types;
+  default_type application/octet-stream;
+  server {
+    listen __CUBE_PROXY_HTTP_PORT__;
+    server_name _;
+    location / { return 404; }
+  }
+  server {
+    listen __CUBE_PROXY_HTTPS_PORT__ ssl;
+    server_name _;
+    ssl_certificate /usr/local/openresty/nginx/certs/__CUBE_PROXY_SSL_CERT__;
+    ssl_certificate_key /usr/local/openresty/nginx/certs/__CUBE_PROXY_SSL_KEY__;
+    location / { return 404; }
+  }
+  server {
+    listen __CUBE_PROXY_ADMIN_LISTEN__:8082;
+    server_name _;
+    location / { return 404; }
+  }
+}
+EOF
+	echo -e "  ${YELLOW}⚠ cube-proxy nginx source not found; generated a minimal cubeproxy-nginx.conf fallback${NC}"
 	return 0
 }
 
@@ -786,6 +853,7 @@ setup_env() {
 	export TF_VAR_cubeapi_image="${TENCENTCLOUD_CUBEAPI_IMAGE:-cube-sandbox-cn.tencentcloudcr.com/cube-sandbox/cube-api:${CUBE_IMAGE_TAG}}"
 	export TF_VAR_cubeproxy_image="${TENCENTCLOUD_CUBEPROXY_IMAGE:-cube-sandbox-cn.tencentcloudcr.com/cube-sandbox/cube-proxy:${CUBE_IMAGE_TAG}}"
 	export TF_VAR_webui_image="${TENCENTCLOUD_WEBUI_IMAGE:-cube-sandbox-cn.tencentcloudcr.com/cube-sandbox/webui:${CUBE_IMAGE_TAG}}"
+	export TF_VAR_cube_lifecycle_manager_image="${TENCENTCLOUD_CUBE_LIFECYCLE_MANAGER_IMAGE:-cube-sandbox-cn.tencentcloudcr.com/cube-sandbox/cube-lifecycle-manager:${CUBE_IMAGE_TAG}}"
 	SSH_PORT="${TENCENTCLOUD_SSH_PORT:-22}"
 	[ -n "${TENCENTCLOUD_MYSQL_PASSWORD:-}" ] && export TF_VAR_mysql_root_password="$TENCENTCLOUD_MYSQL_PASSWORD"
 	[ -n "${TENCENTCLOUD_REDIS_PASSWORD:-}" ] && export TF_VAR_redis_password="$TENCENTCLOUD_REDIS_PASSWORD"
@@ -794,7 +862,13 @@ setup_env() {
 	export TF_VAR_cubemaster_replicas="${TENCENTCLOUD_CUBEMASTER_REPLICAS:-1}"
 	export TF_VAR_cube_api_replicas="${TENCENTCLOUD_CUBE_API_REPLICAS:-1}"
 	export TF_VAR_cube_proxy_replicas="${TENCENTCLOUD_CUBE_PROXY_REPLICAS:-1}"
+	export TF_VAR_cube_lifecycle_manager_replicas="${TENCENTCLOUD_CUBE_LIFECYCLE_MANAGER_REPLICAS:-1}"
 	export TF_VAR_cube_webui_replicas="${TENCENTCLOUD_CUBE_WEBUI_REPLICAS:-1}"
+	export TF_VAR_cube_lifecycle_manager_default_idle_timeout="${TENCENTCLOUD_CUBE_LIFECYCLE_MANAGER_DEFAULT_IDLE_TIMEOUT:-5m}"
+	export TF_VAR_cube_lifecycle_manager_heartbeat_ttl="${TENCENTCLOUD_CUBE_LIFECYCLE_MANAGER_HEARTBEAT_TTL:-15s}"
+	export TF_VAR_cube_lifecycle_manager_discovery_refresh="${TENCENTCLOUD_CUBE_LIFECYCLE_MANAGER_DISCOVERY_REFRESH:-3s}"
+	export TF_VAR_cube_admin_token="${TENCENTCLOUD_CUBE_ADMIN_TOKEN:-}"
+	export TF_VAR_cube_proxy_heartbeat_interval_ms="${TENCENTCLOUD_CUBE_PROXY_HEARTBEAT_INTERVAL_MS:-5000}"
 	# Network exposure mode. Default (false) fronts cube-api/cube-proxy/cube-webui
 	# with VPC-internal CLBs; set to 'true' for public CLBs reachable from the
 	# internet (see the "Hardening the Public-Facing Services" doc section).
@@ -1354,7 +1428,7 @@ build_and_push_images() {
 
 	# 4) Build and push (REGISTRY/NAMESPACE/TAG match the defaults in tke-addons.tf)
 	echo -e "  ${CYAN}Running build_images.sh on the jumpserver: building & pushing${NC}"
-	echo -e "  ${CYAN}  cubemaster/cube-api/cubeproxy/cube-webui → ${reg}/${ns} (tag=${tag})...${NC}"
+	echo -e "  ${CYAN}  cubemaster/cube-api/cubeproxy/cube-lifecycle-manager/cube-webui → ${reg}/${ns} (tag=${tag})...${NC}"
 	echo -e "  ${YELLOW}  (docker build produces a lot of output, please be patient)${NC}"
 	if "${js_ssh[@]}" root@"${js_pub_ip}" \
 		"REGISTRY='${reg}' NAMESPACE='${ns}' TAG='${tag}' PUSH=1 bash '${pkg_root}/terraform/tencentcloud/build_images.sh' all"; then
@@ -4099,12 +4173,25 @@ TENCENTCLOUD_CUBE_USER='${TENCENTCLOUD_CUBE_USER:-cube}'
 TENCENTCLOUD_CUBE_PASSWORD='${TENCENTCLOUD_CUBE_PASSWORD:-}'
 TENCENTCLOUD_CUBELET_NODE_STATUS_UPDATE_FREQUENCY='${CUBELET_NODE_STATUS_UPDATE_FREQUENCY:-${TENCENTCLOUD_CUBELET_NODE_STATUS_UPDATE_FREQUENCY:-1s}}'
 TENCENTCLOUD_CUBE_IMAGE_TAG='${TENCENTCLOUD_CUBE_IMAGE_TAG:-v0.5.0}'
+TENCENTCLOUD_IMAGE_REGISTRY='${TF_VAR_image_registry:-${TENCENTCLOUD_IMAGE_REGISTRY:-cube-sandbox-cn.tencentcloudcr.com}}'
+TENCENTCLOUD_IMAGE_NAMESPACE='${TF_VAR_image_namespace:-${TENCENTCLOUD_IMAGE_NAMESPACE:-cube-sandbox}}'
+TENCENTCLOUD_CUBEMASTER_IMAGE='${TF_VAR_cubemaster_image:-${TENCENTCLOUD_CUBEMASTER_IMAGE:-}}'
+TENCENTCLOUD_CUBEAPI_IMAGE='${TF_VAR_cubeapi_image:-${TENCENTCLOUD_CUBEAPI_IMAGE:-}}'
+TENCENTCLOUD_CUBEPROXY_IMAGE='${TF_VAR_cubeproxy_image:-${TENCENTCLOUD_CUBEPROXY_IMAGE:-}}'
+TENCENTCLOUD_CUBE_LIFECYCLE_MANAGER_IMAGE='${TF_VAR_cube_lifecycle_manager_image:-${TENCENTCLOUD_CUBE_LIFECYCLE_MANAGER_IMAGE:-}}'
+TENCENTCLOUD_WEBUI_IMAGE='${TF_VAR_webui_image:-${TENCENTCLOUD_WEBUI_IMAGE:-}}'
 TENCENTCLOUD_TKE_CLUSTER_VERSION='${TKE_CLUSTER_VERSION:-1.34.1}'
 TENCENTCLOUD_TKE_NODE_COUNT='${TKE_NODE_COUNT:-2}'
 TENCENTCLOUD_CUBEMASTER_REPLICAS='${TENCENTCLOUD_CUBEMASTER_REPLICAS:-1}'
 TENCENTCLOUD_CUBE_API_REPLICAS='${TF_VAR_cube_api_replicas:-${TENCENTCLOUD_CUBE_API_REPLICAS:-1}}'
 TENCENTCLOUD_CUBE_PROXY_REPLICAS='${TF_VAR_cube_proxy_replicas:-${TENCENTCLOUD_CUBE_PROXY_REPLICAS:-1}}'
+TENCENTCLOUD_CUBE_LIFECYCLE_MANAGER_REPLICAS='${TF_VAR_cube_lifecycle_manager_replicas:-${TENCENTCLOUD_CUBE_LIFECYCLE_MANAGER_REPLICAS:-1}}'
 TENCENTCLOUD_CUBE_WEBUI_REPLICAS='${TF_VAR_cube_webui_replicas:-${TENCENTCLOUD_CUBE_WEBUI_REPLICAS:-1}}'
+TENCENTCLOUD_CUBE_LIFECYCLE_MANAGER_DEFAULT_IDLE_TIMEOUT='${TF_VAR_cube_lifecycle_manager_default_idle_timeout:-${TENCENTCLOUD_CUBE_LIFECYCLE_MANAGER_DEFAULT_IDLE_TIMEOUT:-5m}}'
+TENCENTCLOUD_CUBE_LIFECYCLE_MANAGER_HEARTBEAT_TTL='${TF_VAR_cube_lifecycle_manager_heartbeat_ttl:-${TENCENTCLOUD_CUBE_LIFECYCLE_MANAGER_HEARTBEAT_TTL:-15s}}'
+TENCENTCLOUD_CUBE_LIFECYCLE_MANAGER_DISCOVERY_REFRESH='${TF_VAR_cube_lifecycle_manager_discovery_refresh:-${TENCENTCLOUD_CUBE_LIFECYCLE_MANAGER_DISCOVERY_REFRESH:-3s}}'
+TENCENTCLOUD_CUBE_ADMIN_TOKEN='${TF_VAR_cube_admin_token:-${TENCENTCLOUD_CUBE_ADMIN_TOKEN:-}}'
+TENCENTCLOUD_CUBE_PROXY_HEARTBEAT_INTERVAL_MS='${TF_VAR_cube_proxy_heartbeat_interval_ms:-${TENCENTCLOUD_CUBE_PROXY_HEARTBEAT_INTERVAL_MS:-5000}}'
 TENCENTCLOUD_ENABLE_PUBLIC_NETWORK='${TF_VAR_enable_public_network:-${TENCENTCLOUD_ENABLE_PUBLIC_NETWORK:-false}}'
 TENCENTCLOUD_LOCAL_BUNDLE='${LOCAL_BUNDLE:-${TENCENTCLOUD_LOCAL_BUNDLE:-}}'
 TENCENTCLOUD_PVM_KERNEL_VMLINUX='${PVM_KERNEL_VMLINUX:-${TENCENTCLOUD_PVM_KERNEL_VMLINUX:-}}'
@@ -4305,11 +4392,18 @@ write_resolved_tfvars_file() {
 		--arg cubemaster_image "${TF_VAR_cubemaster_image:-${TENCENTCLOUD_CUBEMASTER_IMAGE:-}}" \
 		--arg cubeapi_image "${TF_VAR_cubeapi_image:-${TENCENTCLOUD_CUBEAPI_IMAGE:-}}" \
 		--arg cubeproxy_image "${TF_VAR_cubeproxy_image:-${TENCENTCLOUD_CUBEPROXY_IMAGE:-}}" \
+		--arg cube_lifecycle_manager_image "${TF_VAR_cube_lifecycle_manager_image:-${TENCENTCLOUD_CUBE_LIFECYCLE_MANAGER_IMAGE:-}}" \
 		--arg webui_image "${TF_VAR_webui_image:-${TENCENTCLOUD_WEBUI_IMAGE:-}}" \
 		--argjson cubemaster_replicas "$(_number_or_default "${TF_VAR_cubemaster_replicas:-${TENCENTCLOUD_CUBEMASTER_REPLICAS:-1}}" 1)" \
 		--argjson cube_api_replicas "$(_number_or_default "${TF_VAR_cube_api_replicas:-${TENCENTCLOUD_CUBE_API_REPLICAS:-1}}" 1)" \
 		--argjson cube_proxy_replicas "$(_number_or_default "${TF_VAR_cube_proxy_replicas:-${TENCENTCLOUD_CUBE_PROXY_REPLICAS:-1}}" 1)" \
+		--argjson cube_lifecycle_manager_replicas "$(_number_or_default "${TF_VAR_cube_lifecycle_manager_replicas:-${TENCENTCLOUD_CUBE_LIFECYCLE_MANAGER_REPLICAS:-1}}" 1)" \
 		--argjson cube_webui_replicas "$(_number_or_default "${TF_VAR_cube_webui_replicas:-${TENCENTCLOUD_CUBE_WEBUI_REPLICAS:-1}}" 1)" \
+		--arg cube_lifecycle_manager_default_idle_timeout "${TF_VAR_cube_lifecycle_manager_default_idle_timeout:-${TENCENTCLOUD_CUBE_LIFECYCLE_MANAGER_DEFAULT_IDLE_TIMEOUT:-5m}}" \
+		--arg cube_lifecycle_manager_heartbeat_ttl "${TF_VAR_cube_lifecycle_manager_heartbeat_ttl:-${TENCENTCLOUD_CUBE_LIFECYCLE_MANAGER_HEARTBEAT_TTL:-15s}}" \
+		--arg cube_lifecycle_manager_discovery_refresh "${TF_VAR_cube_lifecycle_manager_discovery_refresh:-${TENCENTCLOUD_CUBE_LIFECYCLE_MANAGER_DISCOVERY_REFRESH:-3s}}" \
+		--arg cube_admin_token "${TF_VAR_cube_admin_token:-${TENCENTCLOUD_CUBE_ADMIN_TOKEN:-}}" \
+		--argjson cube_proxy_heartbeat_interval_ms "$(_number_or_default "${TF_VAR_cube_proxy_heartbeat_interval_ms:-${TENCENTCLOUD_CUBE_PROXY_HEARTBEAT_INTERVAL_MS:-5000}}" 5000)" \
 		'{
 			vpc_name: $vpc_name,
 			region: $region,
@@ -4347,11 +4441,18 @@ write_resolved_tfvars_file() {
 			cubemaster_image: $cubemaster_image,
 			cubeapi_image: $cubeapi_image,
 			cubeproxy_image: $cubeproxy_image,
+			cube_lifecycle_manager_image: $cube_lifecycle_manager_image,
 			webui_image: $webui_image,
 			cubemaster_replicas: $cubemaster_replicas,
 			cube_api_replicas: $cube_api_replicas,
 			cube_proxy_replicas: $cube_proxy_replicas,
-			cube_webui_replicas: $cube_webui_replicas
+			cube_lifecycle_manager_replicas: $cube_lifecycle_manager_replicas,
+			cube_webui_replicas: $cube_webui_replicas,
+			cube_lifecycle_manager_default_idle_timeout: $cube_lifecycle_manager_default_idle_timeout,
+			cube_lifecycle_manager_heartbeat_ttl: $cube_lifecycle_manager_heartbeat_ttl,
+			cube_lifecycle_manager_discovery_refresh: $cube_lifecycle_manager_discovery_refresh,
+			cube_admin_token: $cube_admin_token,
+			cube_proxy_heartbeat_interval_ms: $cube_proxy_heartbeat_interval_ms,
 		}
 		| with_entries(select(.value != "" and .value != null))' >"$tmp"
 
@@ -4724,15 +4825,19 @@ _reconcile_addons() {
 	local entries='
 kubernetes_secret.cube_egress_ca|-n cubesandbox delete secret cube-egress-ca
 kubernetes_secret.cubemaster_conf|-n cubesandbox delete secret cubemaster-conf
+kubernetes_secret.cube_lifecycle_manager_conf|-n cubesandbox delete secret cube-lifecycle-manager-conf
 kubernetes_secret.cubeproxy_global|-n cubesandbox delete secret cubeproxy-global
 kubernetes_secret.cubeproxy_certs|-n cubesandbox delete secret cubeproxy-certs
+kubernetes_config_map.cubeproxy_nginx_conf|-n cubesandbox delete configmap cubeproxy-nginx-conf
 kubernetes_config_map.cube_webui_nginx_conf|-n cubesandbox delete configmap cube-webui-nginx-conf
 kubernetes_service.cubemaster|-n cubesandbox delete svc cubemaster
 kubernetes_service.cube_api|-n cubesandbox delete svc cube-api
+kubernetes_service.cube_lifecycle_manager|-n cubesandbox delete svc cube-lifecycle-manager
 kubernetes_service.cube_proxy|-n cubesandbox delete svc cube-proxy
 kubernetes_service.cube_webui|-n cubesandbox delete svc cube-webui
 kubernetes_deployment.cubemaster|-n cubesandbox delete deploy cubemaster
 kubernetes_deployment.cube_api|-n cubesandbox delete deploy cube-api
+kubernetes_deployment.cube_lifecycle_manager|-n cubesandbox delete deploy cube-lifecycle-manager
 kubernetes_deployment.cube_proxy|-n cubesandbox delete deploy cube-proxy
 kubernetes_deployment.cube_webui|-n cubesandbox delete deploy cube-webui
 '
@@ -4765,13 +4870,13 @@ EOF
 # ---------------------------------------------------------------
 # phase7_health_check — synchronously verify the cluster components are healthy
 #   after the TKE addons have been deployed: wait for the cube-master, cube-api,
-#   cube-proxy (and cube-webui) Deployments to roll out, then probe the HTTP
+#   cube-lifecycle-manager, cube-proxy and cube-webui Deployments to roll out, then probe the HTTP
 #   health endpoints of cube-master and cube-api through their CLBs (reachable
 #   from the jumpserver). Returns 0 only when every component is healthy, so the
 #   orchestrator can fail-fast.
 # ---------------------------------------------------------------
 phase7_health_check() {
-	banner "Step: Health check — cube-master / cube-api / cube-proxy / cube-webui"
+	banner "Step: Health check — cube-master / cube-api / cube-lifecycle-manager / cube-proxy / cube-webui"
 
 	local ns="cubesandbox"
 	# The namespace must be present (created by the addons apply in Step 6).
@@ -4792,7 +4897,7 @@ phase7_health_check() {
 	# ---- 1) Wait for each Deployment to roll out (synchronous, fail-fast) ---
 	#     On failure, dump pod state + events + container logs to explain why.
 	local dep out ready ok=1
-	for dep in cubemaster cube-api cube-proxy cube-webui; do
+	for dep in cubemaster cube-api cube-lifecycle-manager cube-proxy cube-webui; do
 		echo -e "  ${CYAN}▶ deployment/${dep}: waiting for rollout (timeout 300s)...${NC}"
 		out=$(_js_kubectl -n "${ns}" rollout status deploy/"${dep}" --timeout=300s 2>&1)
 		if echo "$out" | grep -qi "successfully rolled out"; then
@@ -4959,14 +5064,12 @@ main() {
 	# 1. Initialize terraform
 	step1_init
 
-	# tke-addons.tf renders cube-webui's config from webui-nginx.conf via file(),
-	# which Terraform evaluates on EVERY plan/apply regardless of that resource's
-	# count. The file must therefore exist before the FIRST terraform plan (the
-	# metadata plan in select_zone), the state refresh and the base applies — not
-	# just before the addons step. Generate it now (idempotent; derived from the
-	# canonical webui/nginx.conf). Release bundles already ship it; this also covers
-	# running create.sh straight from the source tree.
+	# tke-addons.tf renders nginx configs via file(), which Terraform evaluates on
+	# EVERY plan/apply regardless of resource count. The files must therefore exist
+	# before the FIRST terraform plan. Release bundles already ship them; this also
+	# covers running create.sh straight from the source tree.
 	prepare_webui_nginx_conf
+	prepare_cubeproxy_nginx_conf
 
 	# 1.1 Reconcile stale Kubernetes state: if the TKE cluster is NOT in state (it
 	# was destroyed / never created / removed from state) but leftover kubernetes_*
@@ -5289,8 +5392,12 @@ main() {
 		kubernetes_service.cubemaster[0]
 		kubernetes_deployment.cube_api[0]
 		kubernetes_service.cube_api[0]
+		kubernetes_secret.cube_lifecycle_manager_conf[0]
+		kubernetes_deployment.cube_lifecycle_manager[0]
+		kubernetes_service.cube_lifecycle_manager[0]
 		kubernetes_secret.cubeproxy_global[0]
 		kubernetes_secret.cubeproxy_certs[0]
+		kubernetes_config_map.cubeproxy_nginx_conf[0]
 		kubernetes_deployment.cube_proxy[0]
 		kubernetes_service.cube_proxy[0]
 		kubernetes_config_map.cube_webui_nginx_conf[0]
@@ -5311,7 +5418,7 @@ main() {
 	# Restart the Deployments so any ConfigMap changes take effect.
 	if _js_kubectl get ns cubesandbox 2>/dev/null | grep -q Active; then
 		echo -e "  ${CYAN}Restarting Deployments...${NC}"
-		for _dep in cubemaster cube-api cube-proxy cube-webui; do
+		for _dep in cubemaster cube-api cube-lifecycle-manager cube-proxy cube-webui; do
 			_js_kubectl -n cubesandbox rollout restart deploy ${_dep} 2>/dev/null || true
 		done
 	fi

--- a/deploy/one-click/terraform/tencentcloud/destroy.sh
+++ b/deploy/one-click/terraform/tencentcloud/destroy.sh
@@ -70,6 +70,13 @@ export TF_VAR_ssh_private_key_path="$SSH_PRI_KEY"
 export TF_VAR_compute_node_count="${TF_VAR_compute_node_count:-${TENCENTCLOUD_COMPUTE_NODE_COUNT:-2}}"
 export TF_VAR_cubelet_node_status_update_frequency="${TF_VAR_cubelet_node_status_update_frequency:-${TENCENTCLOUD_CUBELET_NODE_STATUS_UPDATE_FREQUENCY:-1s}}"
 export TF_VAR_tke_node_count="${TF_VAR_tke_node_count:-${TENCENTCLOUD_TKE_NODE_COUNT:-2}}"
+export TF_VAR_cube_lifecycle_manager_image="${TF_VAR_cube_lifecycle_manager_image:-${TENCENTCLOUD_CUBE_LIFECYCLE_MANAGER_IMAGE:-}}"
+export TF_VAR_cube_lifecycle_manager_replicas="${TF_VAR_cube_lifecycle_manager_replicas:-${TENCENTCLOUD_CUBE_LIFECYCLE_MANAGER_REPLICAS:-1}}"
+export TF_VAR_cube_lifecycle_manager_default_idle_timeout="${TF_VAR_cube_lifecycle_manager_default_idle_timeout:-${TENCENTCLOUD_CUBE_LIFECYCLE_MANAGER_DEFAULT_IDLE_TIMEOUT:-5m}}"
+export TF_VAR_cube_lifecycle_manager_heartbeat_ttl="${TF_VAR_cube_lifecycle_manager_heartbeat_ttl:-${TENCENTCLOUD_CUBE_LIFECYCLE_MANAGER_HEARTBEAT_TTL:-15s}}"
+export TF_VAR_cube_lifecycle_manager_discovery_refresh="${TF_VAR_cube_lifecycle_manager_discovery_refresh:-${TENCENTCLOUD_CUBE_LIFECYCLE_MANAGER_DISCOVERY_REFRESH:-3s}}"
+export TF_VAR_cube_admin_token="${TF_VAR_cube_admin_token:-${TENCENTCLOUD_CUBE_ADMIN_TOKEN:-}}"
+export TF_VAR_cube_proxy_heartbeat_interval_ms="${TF_VAR_cube_proxy_heartbeat_interval_ms:-${TENCENTCLOUD_CUBE_PROXY_HEARTBEAT_INTERVAL_MS:-5000}}"
 
 mkdir -p "$SCRIPT_DIR/.kube"
 
@@ -1155,13 +1162,13 @@ unset _TF_JSON
 # Fallbacks: parse the resource id straight from the state if the JSON path above
 # did not resolve it (so the VPC CVM sweep is never silently skipped).
 if [ -z "$VPC_ID" ]; then
-	VPC_ID="$(terraform state show tencentcloud_vpc.cluster 2>/dev/null | awk -F'"' '/^[[:space:]]*id[[:space:]]*=/{print $2; exit}')"
+	VPC_ID="$(terraform state show tencentcloud_vpc.cluster 2>/dev/null | awk -F'"' '/^[[:space:]]*id[[:space:]]*=/{print $2; exit}' || true)"
 fi
 if [ -z "$JS_INSTANCE_ID" ]; then
-	JS_INSTANCE_ID="$(terraform state show tencentcloud_instance.jumpserver 2>/dev/null | awk -F'"' '/^[[:space:]]*id[[:space:]]*=/{print $2; exit}')"
+	JS_INSTANCE_ID="$(terraform state show tencentcloud_instance.jumpserver 2>/dev/null | awk -F'"' '/^[[:space:]]*id[[:space:]]*=/{print $2; exit}' || true)"
 fi
 if [ -z "$NAT_GATEWAY_ID" ]; then
-	NAT_GATEWAY_ID="$(terraform state show tencentcloud_nat_gateway.cluster 2>/dev/null | awk -F'"' '/^[[:space:]]*id[[:space:]]*=/{print $2; exit}')"
+	NAT_GATEWAY_ID="$(terraform state show tencentcloud_nat_gateway.cluster 2>/dev/null | awk -F'"' '/^[[:space:]]*id[[:space:]]*=/{print $2; exit}' || true)"
 fi
 
 # Teardown status: which resources are still tracked in state (→ will be
@@ -1345,33 +1352,7 @@ else
 	echo -e "  ${CYAN}No Kubernetes addon resources in state; skipping.${NC}"
 fi
 
-# (b) the node-pool CVM workers.
-if in_state 'tencentcloud_kubernetes_node_pool.tke'; then
-	echo -e "  ${CYAN}Removing TKE node pool (CVM workers)...${NC}"
-	run_destroy -target=tencentcloud_kubernetes_node_pool.tke || destroy_fail "TKE node-pool destroy"
-else
-	echo -e "  ${CYAN}No TKE node pool in state; skipping.${NC}"
-fi
-
-# (c) the TKE cluster (its inline initial worker node goes with it).
-if in_state 'tencentcloud_kubernetes_cluster.tke'; then
-	echo -e "  ${CYAN}Removing the TKE cluster...${NC}"
-	run_destroy -target=tencentcloud_kubernetes_cluster.tke || destroy_fail "TKE cluster destroy"
-else
-	echo -e "  ${CYAN}No TKE cluster in state; skipping.${NC}"
-fi
-
-# The addons + cluster are gone; the intranet API Server tunnel is no longer needed.
-_close_apiserver_tunnel
-
-# (d) Terminate the worker CVMs the node pool kept behind (delete_keep_instance).
-#     Best-effort: they only block the shared key pair, deleted later in phase 6.
-echo -e "  ${CYAN}Terminating any orphaned TKE worker CVMs...${NC}"
-terminate_cvms "$TKE_NODE_CVMS" || echo -e "${YELLOW}⚠ Orphan CVM termination had issues; continuing.${NC}"
-
-# ============================================================
-# Phase 2/6 — reverse of create step 5: MySQL + Redis.
-# ============================================================
+# (b) pre-created Kubernetes compute workers attached to the cluster.
 echo ""
 echo -e "${CYAN}━━━ Phase 2/6: Destroy MySQL + Redis ━━━${NC}"
 phase_db_targets=()
@@ -1411,22 +1392,6 @@ fi
 # ============================================================
 echo ""
 echo -e "${CYAN}━━━ Phase 3/6: Destroy compute nodes ━━━${NC}"
-if in_state 'tencentcloud_instance.compute'; then
-	run_destroy -target=tencentcloud_instance.compute || destroy_fail "Compute node destroy"
-else
-	echo -e "  ${CYAN}No compute nodes in state; skipping.${NC}"
-fi
-
-# Before the jump-server goes away: finish the recycle-bin release (it runs tccli)
-# and clear any orphaned CVMs still in the VPC (they hold the shared SG/key pair).
-echo -e "  ${CYAN}Verifying MySQL/Redis are fully removed from the recycle bin (jumpserver still alive)...${NC}"
-ensure_recycle_bin_cleared "$MYSQL_ID" "$REDIS_ID" || {
-	echo -e "${YELLOW}⚠ Recycle-bin verification had issues; continuing.${NC}"
-	NEEDS_MANUAL_CLEANUP=1
-}
-echo -e "  ${CYAN}Terminating any remaining CVMs in the VPC (except the jumpserver)...${NC}"
-terminate_vpc_cvms "$VPC_ID" "$JS_INSTANCE_ID" || echo -e "${YELLOW}⚠ VPC CVM cleanup had issues; continuing.${NC}"
-
 echo ""
 echo -e "${CYAN}━━━ Phase 3/6: Destroy the jump-server ━━━${NC}"
 if in_state 'tencentcloud_instance.jumpserver'; then
@@ -1540,7 +1505,34 @@ fi
 # ============================================================
 echo ""
 echo -e "${CYAN}━━━ Phase 6/6: Destroy VPC / security group / key pair (final sweep) ━━━${NC}"
-run_destroy "${EXTRA_ARGS[@]+"${EXTRA_ARGS[@]}"}" || destroy_fail "Final network destroy"
+# Security group rule-set resources manage rules inside a security group, not a
+# separately billed cloud object. In partial-failure teardowns the provider may
+# fail while refreshing these rule sets even though the SG itself is still
+# visible and deletable. Drop only the rule-set state here; deleting the SG below
+# removes the rules with it.
+while IFS= read -r _sg_ruleset; do
+	[ -n "$_sg_ruleset" ] || continue
+	echo -e "  ${CYAN}terraform state rm ${_sg_ruleset} (rules are removed with the security group)${NC}"
+	terraform state rm "$_sg_ruleset" >/dev/null 2>&1 || true
+done < <(terraform state list 2>/dev/null | grep -E '^tencentcloud_security_group_rule_set\.' || true)
+
+phase_network_targets=()
+for _res in \
+	tencentcloud_key_pair.cluster \
+	tencentcloud_security_group.clb \
+	tencentcloud_security_group.compute \
+	tencentcloud_security_group.jumpserver \
+	tencentcloud_security_group.tke_pod \
+	tencentcloud_vpc.cluster \
+	random_string.deploy_suffix; do
+	in_state "$_res" && phase_network_targets+=(-target="$_res")
+done
+if [ "${#phase_network_targets[@]}" -gt 0 ]; then
+	run_destroy "${phase_network_targets[@]+"${phase_network_targets[@]}"}" || destroy_fail "Final network destroy"
+else
+	echo -e "  ${CYAN}No VPC/security-group/key resources in state; running final sweep.${NC}"
+	run_destroy "${EXTRA_ARGS[@]+"${EXTRA_ARGS[@]}"}" || destroy_fail "Final network destroy"
+fi
 
 # Remove the local kubeconfig artifact. It was deliberately kept on disk through
 # the teardown (and detached from terraform state in Phase 1) so the kubernetes

--- a/deploy/one-click/terraform/tencentcloud/env.example
+++ b/deploy/one-click/terraform/tencentcloud/env.example
@@ -68,7 +68,8 @@ TENCENTCLOUD_CUBE_LIFECYCLE_MANAGER_DEFAULT_IDLE_TIMEOUT='5m'
 TENCENTCLOUD_CUBE_LIFECYCLE_MANAGER_HEARTBEAT_TTL='15s'
 TENCENTCLOUD_CUBE_LIFECYCLE_MANAGER_DISCOVERY_REFRESH='3s'
 TENCENTCLOUD_CUBE_PROXY_HEARTBEAT_INTERVAL_MS='5000'
-# Optional shared token for cube-lifecycle-manager -> cube-proxy /admin/* calls.
+# Shared token for cube-lifecycle-manager -> cube-proxy /admin/* calls.
+# Leave empty to let Terraform auto-generate one; custom values must be >=16 chars.
 TENCENTCLOUD_CUBE_ADMIN_TOKEN=''
 # Network exposure mode for cube-api / cube-proxy / cube-webui. Default 'false'
 # fronts them with VPC-INTERNAL CLBs (private VIP only, reached via the

--- a/deploy/one-click/terraform/tencentcloud/env.example
+++ b/deploy/one-click/terraform/tencentcloud/env.example
@@ -48,6 +48,7 @@ TENCENTCLOUD_IMAGE_NAMESPACE='cube-sandbox'
 TENCENTCLOUD_CUBEMASTER_IMAGE='cube-sandbox-cn.tencentcloudcr.com/cube-sandbox/cube-master:v0.5.0'
 TENCENTCLOUD_CUBEAPI_IMAGE='cube-sandbox-cn.tencentcloudcr.com/cube-sandbox/cube-api:v0.5.0'
 TENCENTCLOUD_CUBEPROXY_IMAGE='cube-sandbox-cn.tencentcloudcr.com/cube-sandbox/cube-proxy:v0.5.0'
+TENCENTCLOUD_CUBE_LIFECYCLE_MANAGER_IMAGE='cube-sandbox-cn.tencentcloudcr.com/cube-sandbox/cube-lifecycle-manager:v0.5.0'
 TENCENTCLOUD_WEBUI_IMAGE='cube-sandbox-cn.tencentcloudcr.com/cube-sandbox/webui:v0.5.0'
 TENCENTCLOUD_TKE_CLUSTER_VERSION='1.34.1'
 TENCENTCLOUD_TKE_NODE_COUNT='2'
@@ -57,11 +58,18 @@ TENCENTCLOUD_TKE_NODE_COUNT='2'
 # cubemaster_replicas also drives the conf's default_headless_service_nodes_num.
 TENCENTCLOUD_CUBEMASTER_REPLICAS='1'
 TENCENTCLOUD_CUBE_API_REPLICAS='1'
-# cube-proxy defaults to 1 (single replica): auto-pause/auto-resume is only
-# correct in single-replica mode. Setting >1 REQUIRES the front-end LB to hash
-# on SandboxID (session affinity), otherwise auto-pause/auto-resume misfires.
+# cube-proxy registers each replica in Redis so cube-lifecycle-manager can
+# discover it and push lifecycle state without static per-replica wiring.
 TENCENTCLOUD_CUBE_PROXY_REPLICAS='1'
+TENCENTCLOUD_CUBE_LIFECYCLE_MANAGER_REPLICAS='1'
 TENCENTCLOUD_CUBE_WEBUI_REPLICAS='1'
+# cube-lifecycle-manager / cube-proxy Redis discovery tuning.
+TENCENTCLOUD_CUBE_LIFECYCLE_MANAGER_DEFAULT_IDLE_TIMEOUT='5m'
+TENCENTCLOUD_CUBE_LIFECYCLE_MANAGER_HEARTBEAT_TTL='15s'
+TENCENTCLOUD_CUBE_LIFECYCLE_MANAGER_DISCOVERY_REFRESH='3s'
+TENCENTCLOUD_CUBE_PROXY_HEARTBEAT_INTERVAL_MS='5000'
+# Optional shared token for cube-lifecycle-manager -> cube-proxy /admin/* calls.
+TENCENTCLOUD_CUBE_ADMIN_TOKEN=''
 # Network exposure mode for cube-api / cube-proxy / cube-webui. Default 'false'
 # fronts them with VPC-INTERNAL CLBs (private VIP only, reached via the
 # jumpserver / VPN — no public exposure). Set to 'true' for PUBLIC CLBs

--- a/deploy/one-click/terraform/tencentcloud/tke-addons.tf
+++ b/deploy/one-click/terraform/tencentcloud/tke-addons.tf
@@ -16,6 +16,7 @@ locals {
   cube_api_image    = var.cubeapi_image != "" ? var.cubeapi_image : "${local.image_registry}/${local.image_namespace}/cube-api:${var.image_tag}"
   cube_proxy_image  = var.cubeproxy_image != "" ? var.cubeproxy_image : "${local.image_registry}/${local.image_namespace}/cube-proxy:${var.image_tag}"
   cube_webui_image  = var.webui_image != "" ? var.webui_image : "${local.image_registry}/${local.image_namespace}/webui:${var.image_tag}"
+  cube_lcm_image    = var.cube_lifecycle_manager_image != "" ? var.cube_lifecycle_manager_image : "${local.image_registry}/${local.image_namespace}/cube-lifecycle-manager:${var.image_tag}"
 
   # cube_db / cube_user are wired through Terraform (var.cube_db / var.cube_user)
   # so the MySQL account/database created in main.tf, the cube-master conf Secret
@@ -44,10 +45,81 @@ locals {
   # All files under the certificate directory
   cert_files = fileset("${path.module}/cubeproxy-certs", "*")
 
-  # create.sh writes this file next to the Terraform module before applying
-  # addons. Direct `terraform validate` from the source tree has no generated
-  # file yet, so fall back to the canonical one-click WebUI nginx template.
-  webui_nginx_conf = try(file("${path.module}/webui-nginx.conf"), file("${path.module}/../../webui/nginx.conf"))
+  # create.sh writes these files next to the Terraform module before applying
+  # addons. Terraform evaluates locals even during early targeted network applies,
+  # so every file() call must be guarded with fileexists().
+  webui_nginx_conf = fileexists("${path.module}/webui-nginx.conf") ? file("${path.module}/webui-nginx.conf") : (
+    fileexists("${path.module}/../../webui/nginx.conf") ? file("${path.module}/../../webui/nginx.conf") : <<-EOF
+      worker_processes auto;
+      events { worker_connections 1024; }
+      http {
+        server {
+          listen 80;
+          root /usr/share/nginx/html;
+          index index.html;
+          location ^~ /sandbox/ { proxy_pass __SANDBOX_PROXY_UPSTREAM__; }
+          location /cubeapi/ { proxy_pass __WEB_UI_UPSTREAM__/cubeapi/; }
+          location / { try_files $uri $uri/ /index.html; }
+        }
+      }
+    EOF
+  )
+  cubeproxy_nginx_conf = replace(
+    replace(
+      replace(
+        replace(
+          replace(
+            replace(
+              fileexists("${path.module}/cubeproxy-nginx.conf") ? file("${path.module}/cubeproxy-nginx.conf") : (
+                fileexists("${path.module}/../../cubeproxy/nginx.conf.template") ? file("${path.module}/../../cubeproxy/nginx.conf.template") : (
+                  fileexists("${path.module}/../../../../CubeProxy/nginx.conf") ? file("${path.module}/../../../../CubeProxy/nginx.conf") : <<-EOF
+                    user root;
+                    worker_processes auto;
+                    error_log /data/log/cube-proxy/error.log notice;
+                    daemon off;
+                    events { worker_connections 100000; }
+                    http {
+                      include mime.types;
+                      default_type application/octet-stream;
+                      server {
+                        listen __CUBE_PROXY_HTTP_PORT__;
+                        server_name _;
+                        location / { return 404; }
+                      }
+                      server {
+                        listen __CUBE_PROXY_HTTPS_PORT__ ssl;
+                        server_name _;
+                        ssl_certificate /usr/local/openresty/nginx/certs/__CUBE_PROXY_SSL_CERT__;
+                        ssl_certificate_key /usr/local/openresty/nginx/certs/__CUBE_PROXY_SSL_KEY__;
+                        location / { return 404; }
+                      }
+                      server {
+                        listen __CUBE_PROXY_ADMIN_LISTEN__:8082;
+                        server_name _;
+                        location / { return 404; }
+                      }
+                    }
+                  EOF
+                )
+              ),
+              "__CUBE_PROXY_HTTP_PORT__",
+              "8081"
+            ),
+            "__CUBE_PROXY_HTTPS_PORT__",
+            "8080"
+          ),
+          "__CUBE_PROXY_SSL_CERT__",
+          "cube.app+3.pem"
+        ),
+        "__CUBE_PROXY_SSL_KEY__",
+        "cube.app+3-key.pem"
+      ),
+      "__CUBE_PROXY_ADMIN_LISTEN__:8082",
+      "0.0.0.0:8082"
+    ),
+    "listen 127.0.0.1:8082;",
+    "listen 0.0.0.0:8082;"
+  )
 
   # Precondition for creating the TKE addons
   deploy_addons = var.create_tke && var.deploy_tke_addons
@@ -74,6 +146,8 @@ resource "local_file" "tke_kubeconfig" {
   depends_on = [
     kubernetes_deployment.cube_webui,
     kubernetes_service.cube_webui,
+    kubernetes_deployment.cube_lifecycle_manager,
+    kubernetes_service.cube_lifecycle_manager,
     kubernetes_deployment.cube_proxy,
     kubernetes_service.cube_proxy,
     kubernetes_deployment.cube_api,
@@ -550,6 +624,158 @@ resource "kubernetes_service" "cube_api" {
 }
 
 # ---------------------------------------------------------------
+# cube-lifecycle-manager: Secret → Deployment → ClusterIP Service
+# ---------------------------------------------------------------
+
+resource "kubernetes_secret" "cube_lifecycle_manager_conf" {
+  count = local.deploy_addons ? 1 : 0
+  type  = "Opaque"
+
+  metadata {
+    name      = "cube-lifecycle-manager-conf"
+    namespace = kubernetes_namespace.cubesandbox[0].metadata[0].name
+  }
+
+  data = {
+    "redis-password"   = var.redis_password
+    "cube-admin-token" = var.cube_admin_token
+  }
+}
+
+resource "kubernetes_deployment" "cube_lifecycle_manager" {
+  count = local.deploy_addons ? 1 : 0
+
+  metadata {
+    name      = "cube-lifecycle-manager"
+    namespace = kubernetes_namespace.cubesandbox[0].metadata[0].name
+    labels    = { app = "cube-lifecycle-manager" }
+  }
+
+  spec {
+    replicas = var.cube_lifecycle_manager_replicas
+
+    selector {
+      match_labels = { app = "cube-lifecycle-manager" }
+    }
+
+    template {
+      metadata {
+        labels = { app = "cube-lifecycle-manager" }
+      }
+
+      spec {
+        container {
+          name  = "cube-lifecycle-manager"
+          image = local.cube_lcm_image
+
+          port {
+            name           = "http"
+            container_port = 8083
+            protocol       = "TCP"
+          }
+
+          env {
+            name  = "CUBE_LCM_REDIS_ADDR"
+            value = "${tencentcloud_redis_instance.redis.ip}:6379"
+          }
+          env {
+            name = "CUBE_LCM_REDIS_PASSWORD"
+            value_from {
+              secret_key_ref {
+                name = kubernetes_secret.cube_lifecycle_manager_conf[0].metadata[0].name
+                key  = "redis-password"
+              }
+            }
+          }
+          env {
+            name  = "CUBE_LCM_REDIS_DB"
+            value = "0"
+          }
+          env {
+            name  = "CUBE_LCM_CUBEMASTER_URL"
+            value = local.cubemaster_url
+          }
+          env {
+            name  = "CUBE_LCM_LISTEN_ADDR"
+            value = "0.0.0.0:8083"
+          }
+          env {
+            name  = "CUBE_LCM_DEFAULT_IDLE_TIMEOUT"
+            value = var.cube_lifecycle_manager_default_idle_timeout
+          }
+          env {
+            name  = "CUBE_LCM_HEARTBEAT_TTL"
+            value = var.cube_lifecycle_manager_heartbeat_ttl
+          }
+          env {
+            name  = "CUBE_LCM_DISCOVERY_REFRESH"
+            value = var.cube_lifecycle_manager_discovery_refresh
+          }
+          env {
+            name = "CUBE_LCM_ADMIN_TOKEN"
+            value_from {
+              secret_key_ref {
+                name = kubernetes_secret.cube_lifecycle_manager_conf[0].metadata[0].name
+                key  = "cube-admin-token"
+              }
+            }
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/healthz"
+              port = 8083
+            }
+            initial_delay_seconds = 10
+            period_seconds        = 10
+            timeout_seconds       = 3
+            failure_threshold     = 6
+          }
+
+          readiness_probe {
+            http_get {
+              path = "/readyz"
+              port = 8083
+            }
+            initial_delay_seconds = 5
+            period_seconds        = 5
+            timeout_seconds       = 3
+            failure_threshold     = 3
+          }
+        }
+      }
+    }
+  }
+
+  depends_on = [
+    kubernetes_service.cubemaster,
+    tencentcloud_redis_instance.redis,
+  ]
+}
+
+resource "kubernetes_service" "cube_lifecycle_manager" {
+  count = local.deploy_addons ? 1 : 0
+
+  metadata {
+    name      = "cube-lifecycle-manager"
+    namespace = kubernetes_namespace.cubesandbox[0].metadata[0].name
+    labels    = { app = "cube-lifecycle-manager" }
+  }
+
+  spec {
+    type     = "ClusterIP"
+    selector = { app = "cube-lifecycle-manager" }
+
+    port {
+      name        = "http"
+      port        = 8083
+      target_port = 8083
+      protocol    = "TCP"
+    }
+  }
+}
+
+# ---------------------------------------------------------------
 # cube-proxy: Secrets → Deployment → CLB Service (public network)
 # ---------------------------------------------------------------
 
@@ -571,12 +797,28 @@ resource "kubernetes_secret" "cubeproxy_global" {
       set $timeout_min 500;
       set $timeout_max 700;
       set $cube_proxy_host_ip "127.0.0.1";
+      set $cube_sidecar_addr "cube-lifecycle-manager.cubesandbox.svc.cluster.local:8083";
+      set $cube_admin_token "${var.cube_admin_token}";
     EOT
     # Same Redis password exposed as a discrete key so the cube-proxy container
     # can read it via secret_key_ref instead of a plaintext Deployment env value
     # (which would show up in `kubectl get deploy -o yaml`). Projected out of the
     # global.conf volume mount via that mount's explicit `items` below.
     "redis-password" = var.redis_password
+  }
+}
+
+resource "kubernetes_config_map" "cubeproxy_nginx_conf" {
+  count = local.deploy_addons ? 1 : 0
+
+  metadata {
+    name      = "cubeproxy-nginx-conf"
+    namespace = kubernetes_namespace.cubesandbox[0].metadata[0].name
+    labels    = { app = "cube-proxy" }
+  }
+
+  data = {
+    "nginx.conf" = local.cubeproxy_nginx_conf
   }
 }
 
@@ -599,16 +841,21 @@ resource "kubernetes_secret" "cubeproxy_certs" {
 # cube-proxy Deployment
 resource "kubernetes_deployment" "cube_proxy" {
   count = local.deploy_addons ? 1 : 0
+
+  depends_on = [
+    kubernetes_service.cube_lifecycle_manager,
+    tencentcloud_redis_instance.redis,
+  ]
+
   metadata {
     name      = "cube-proxy"
     namespace = kubernetes_namespace.cubesandbox[0].metadata[0].name
     labels    = { app = "cube-proxy" }
   }
   spec {
-    # Defaults to 1. auto-pause/auto-resume (driven by the co-resident
-    # cube-proxy-sidecar sweeper) is only correct in single-replica mode; with
-    # >1 replica the front-end LB MUST hash on SandboxID, otherwise per-replica
-    # idle detection misfires. See var.cube_proxy_replicas in variables.tf.
+    # PR #705 moves lifecycle coordination into cube-lifecycle-manager. Each
+    # cube-proxy replica publishes its admin endpoint to Redis so CLM can
+    # discover and push lifecycle state without static per-replica wiring.
     replicas = var.cube_proxy_replicas
     selector {
       match_labels = { app = "cube-proxy" }
@@ -641,6 +888,11 @@ resource "kubernetes_deployment" "cube_proxy" {
             container_port = 443
             protocol       = "TCP"
           }
+          port {
+            name           = "admin"
+            container_port = 8082
+            protocol       = "TCP"
+          }
           env {
             name  = "CUBE_PROXY_REDIS_IP"
             value = tencentcloud_redis_instance.redis.ip
@@ -658,11 +910,83 @@ resource "kubernetes_deployment" "cube_proxy" {
               }
             }
           }
+          env {
+            name  = "CUBE_PROXY_REGISTRY_ENABLE"
+            value = "1"
+          }
+          env {
+            name = "POD_NAME"
+            value_from {
+              field_ref {
+                field_path = "metadata.name"
+              }
+            }
+          }
+          env {
+            name = "POD_IP"
+            value_from {
+              field_ref {
+                field_path = "status.podIP"
+              }
+            }
+          }
+          env {
+            name  = "CUBE_PROXY_ID"
+            value = "$(POD_NAME)"
+          }
+          env {
+            name  = "CUBE_PROXY_ADMIN_URL"
+            value = "http://$(POD_IP):8082"
+          }
+          env {
+            name  = "CUBE_PROXY_RESUME_URL"
+            value = "http://$(POD_IP):8082"
+          }
+          env {
+            name  = "CUBE_PROXY_NODE_IP"
+            value = "$(POD_IP)"
+          }
+          env {
+            name  = "CUBE_PROXY_VERSION"
+            value = var.image_tag
+          }
+          env {
+            name  = "CUBE_PROXY_HEARTBEAT_INTERVAL_MS"
+            value = tostring(var.cube_proxy_heartbeat_interval_ms)
+          }
+          env {
+            name  = "CUBE_PROXY_REGISTRY_REDIS_HOST"
+            value = tencentcloud_redis_instance.redis.ip
+          }
+          env {
+            name  = "CUBE_PROXY_REGISTRY_REDIS_PORT"
+            value = "6379"
+          }
+          env {
+            name = "CUBE_PROXY_REGISTRY_REDIS_PASSWORD"
+            value_from {
+              secret_key_ref {
+                name = kubernetes_secret.cubeproxy_global[0].metadata[0].name
+                key  = "redis-password"
+              }
+            }
+          }
+          env {
+            name  = "CUBE_PROXY_REGISTRY_REDIS_DB"
+            value = "0"
+          }
 
           # global.conf mount
           volume_mount {
             name       = "global-conf"
             mount_path = "/usr/local/openresty/nginx/conf/global"
+            read_only  = true
+          }
+
+          volume_mount {
+            name       = "nginx-conf"
+            mount_path = "/usr/local/openresty/nginx/conf/nginx.conf"
+            sub_path   = "nginx.conf"
             read_only  = true
           }
 
@@ -719,6 +1043,13 @@ resource "kubernetes_deployment" "cube_proxy" {
               key  = "global.conf"
               path = "global.conf"
             }
+          }
+        }
+
+        volume {
+          name = "nginx-conf"
+          config_map {
+            name = kubernetes_config_map.cubeproxy_nginx_conf[0].metadata[0].name
           }
         }
 

--- a/deploy/one-click/terraform/tencentcloud/tke-addons.tf
+++ b/deploy/one-click/terraform/tencentcloud/tke-addons.tf
@@ -17,6 +17,7 @@ locals {
   cube_proxy_image  = var.cubeproxy_image != "" ? var.cubeproxy_image : "${local.image_registry}/${local.image_namespace}/cube-proxy:${var.image_tag}"
   cube_webui_image  = var.webui_image != "" ? var.webui_image : "${local.image_registry}/${local.image_namespace}/webui:${var.image_tag}"
   cube_lcm_image    = var.cube_lifecycle_manager_image != "" ? var.cube_lifecycle_manager_image : "${local.image_registry}/${local.image_namespace}/cube-lifecycle-manager:${var.image_tag}"
+  cube_admin_token  = var.cube_admin_token != "" ? var.cube_admin_token : random_password.cube_admin_token[0].result
 
   # cube_db / cube_user are wired through Terraform (var.cube_db / var.cube_user)
   # so the MySQL account/database created in main.tf, the cube-master conf Secret
@@ -69,60 +70,60 @@ locals {
       replace(
         replace(
           replace(
-            replace(
-              fileexists("${path.module}/cubeproxy-nginx.conf") ? file("${path.module}/cubeproxy-nginx.conf") : (
-                fileexists("${path.module}/../../cubeproxy/nginx.conf.template") ? file("${path.module}/../../cubeproxy/nginx.conf.template") : (
-                  fileexists("${path.module}/../../../../CubeProxy/nginx.conf") ? file("${path.module}/../../../../CubeProxy/nginx.conf") : <<-EOF
-                    user root;
-                    worker_processes auto;
-                    error_log /data/log/cube-proxy/error.log notice;
-                    daemon off;
-                    events { worker_connections 100000; }
-                    http {
-                      include mime.types;
-                      default_type application/octet-stream;
-                      server {
-                        listen __CUBE_PROXY_HTTP_PORT__;
-                        server_name _;
-                        location / { return 404; }
-                      }
-                      server {
-                        listen __CUBE_PROXY_HTTPS_PORT__ ssl;
-                        server_name _;
-                        ssl_certificate /usr/local/openresty/nginx/certs/__CUBE_PROXY_SSL_CERT__;
-                        ssl_certificate_key /usr/local/openresty/nginx/certs/__CUBE_PROXY_SSL_KEY__;
-                        location / { return 404; }
-                      }
-                      server {
-                        listen __CUBE_PROXY_ADMIN_LISTEN__:8082;
-                        server_name _;
-                        location / { return 404; }
-                      }
-                    }
-                  EOF
-                )
-              ),
-              "__CUBE_PROXY_HTTP_PORT__",
-              "8081"
+            fileexists("${path.module}/cubeproxy-nginx.conf") ? file("${path.module}/cubeproxy-nginx.conf") : (
+              fileexists("${path.module}/../../cubeproxy/nginx.conf.template") ? file("${path.module}/../../cubeproxy/nginx.conf.template") : <<-EOF
+                user root;
+                worker_processes auto;
+                error_log /data/log/cube-proxy/error.log notice;
+                daemon off;
+                events { worker_connections 100000; }
+                http {
+                  include mime.types;
+                  default_type application/octet-stream;
+                  server {
+                    listen __CUBE_PROXY_HTTP_PORT__;
+                    server_name _;
+                    location / { return 404; }
+                  }
+                  server {
+                    listen __CUBE_PROXY_HTTPS_PORT__ ssl;
+                    server_name _;
+                    ssl_certificate /usr/local/openresty/nginx/certs/__CUBE_PROXY_SSL_CERT__;
+                    ssl_certificate_key /usr/local/openresty/nginx/certs/__CUBE_PROXY_SSL_KEY__;
+                    location / { return 404; }
+                  }
+                  server {
+                    listen __CUBE_PROXY_ADMIN_LISTEN__:8082;
+                    server_name _;
+                    location / { return 404; }
+                  }
+                }
+              EOF
             ),
-            "__CUBE_PROXY_HTTPS_PORT__",
-            "8080"
+            "__CUBE_PROXY_HTTP_PORT__",
+            "8081"
           ),
-          "__CUBE_PROXY_SSL_CERT__",
-          "cube.app+3.pem"
+          "__CUBE_PROXY_HTTPS_PORT__",
+          "8080"
         ),
-        "__CUBE_PROXY_SSL_KEY__",
-        "cube.app+3-key.pem"
+        "__CUBE_PROXY_SSL_CERT__",
+        "cube.app+3.pem"
       ),
-      "__CUBE_PROXY_ADMIN_LISTEN__:8082",
-      "0.0.0.0:8082"
+      "__CUBE_PROXY_SSL_KEY__",
+      "cube.app+3-key.pem"
     ),
-    "listen 127.0.0.1:8082;",
-    "listen 0.0.0.0:8082;"
+    "__CUBE_PROXY_ADMIN_LISTEN__:8082",
+    "0.0.0.0:8082"
   )
 
   # Precondition for creating the TKE addons
   deploy_addons = var.create_tke && var.deploy_tke_addons
+}
+
+resource "random_password" "cube_admin_token" {
+  count   = var.cube_admin_token == "" ? 1 : 0
+  length  = 32
+  special = false
 }
 
 # Write the kubeconfig to a local file (written as soon as TKE is created, independent of the addons).
@@ -638,7 +639,7 @@ resource "kubernetes_secret" "cube_lifecycle_manager_conf" {
 
   data = {
     "redis-password"   = var.redis_password
-    "cube-admin-token" = var.cube_admin_token
+    "cube-admin-token" = local.cube_admin_token
   }
 }
 
@@ -798,7 +799,7 @@ resource "kubernetes_secret" "cubeproxy_global" {
       set $timeout_max 700;
       set $cube_proxy_host_ip "127.0.0.1";
       set $cube_sidecar_addr "cube-lifecycle-manager.cubesandbox.svc.cluster.local:8083";
-      set $cube_admin_token "${var.cube_admin_token}";
+      set $cube_admin_token "${local.cube_admin_token}";
     EOT
     # Same Redis password exposed as a discrete key so the cube-proxy container
     # can read it via secret_key_ref instead of a plaintext Deployment env value

--- a/deploy/one-click/terraform/tencentcloud/variables.tf
+++ b/deploy/one-click/terraform/tencentcloud/variables.tf
@@ -81,7 +81,6 @@ variable "compute_node_count" {
     error_message = "compute_node_count must be a non-negative integer."
   }
 }
-
 variable "compute_data_disk_size" {
   description = "Per compute-node CBS data disk size in GB; formatted as XFS and mounted at /data/cubelet (override with TENCENTCLOUD_COMPUTE_DATA_DISK_SIZE)"
   type        = number
@@ -312,6 +311,11 @@ variable "webui_image" {
   default     = "cube-sandbox-cn.tencentcloudcr.com/cube-sandbox/webui:v0.5.0"
 }
 
+variable "cube_lifecycle_manager_image" {
+  description = "Full cube-lifecycle-manager image override."
+  type        = string
+  default     = "cube-sandbox-cn.tencentcloudcr.com/cube-sandbox/cube-lifecycle-manager:v0.5.0"
+}
 # Per-component replica counts. All four default to 1 in env.example / variables.tf
 # and are independently tunable via -var / TF_VAR_* / the TENCENTCLOUD_*_REPLICAS
 # env knobs wired by create.sh.
@@ -345,30 +349,25 @@ variable "cube_api_replicas" {
   }
 }
 
-# cube-proxy defaults to a SINGLE replica (unlike the other components, which
-# default to 2). This is deliberate: the auto-pause/auto-resume feature is only
-# correct in single-replica mode.
-#
-# Each cube-proxy pod runs a co-resident cube-proxy-sidecar whose sweeper decides
-# when a sandbox is idle based on the last-active timestamps it observes on its
-# OWN cube-proxy. With >1 replica behind a round-robin / least-conn CLB, requests
-# for a single sandbox are spread across replicas, so no individual sidecar sees
-# the full activity stream. A replica that happened not to serve recent requests
-# will believe the sandbox is idle and pause it out from under an actively-used
-# session, producing a pause -> auto-resume churn loop.
-#
-# If you must scale cube-proxy to >1 replica for HA/throughput, the front-end
-# load balancer MUST be configured to hash on the sandbox ID so that all traffic
-# for a given sandbox is pinned to one replica (consistent session affinity by
-# SandboxID). Without that, auto-pause/auto-resume will misfire.
 variable "cube_proxy_replicas" {
-  description = "cube-proxy Deployment replica count. Defaults to 1: auto-pause/auto-resume is only correct in single-replica mode. Setting >1 REQUIRES the front-end LB to hash on SandboxID (session affinity), otherwise auto-pause/auto-resume will misfire."
+  description = "cube-proxy Deployment replica count. PR #705 uses Redis-backed cube-proxy discovery through cube-lifecycle-manager, so multiple replicas can be discovered without static wiring."
   type        = number
   default     = 1
 
   validation {
     condition     = var.cube_proxy_replicas >= 1 && floor(var.cube_proxy_replicas) == var.cube_proxy_replicas
     error_message = "cube_proxy_replicas must be an integer >= 1."
+  }
+}
+
+variable "cube_lifecycle_manager_replicas" {
+  description = "cube-lifecycle-manager Deployment replica count. Keep 1 unless CLM HA behavior has been validated for the target deployment."
+  type        = number
+  default     = 1
+
+  validation {
+    condition     = var.cube_lifecycle_manager_replicas >= 1 && floor(var.cube_lifecycle_manager_replicas) == var.cube_lifecycle_manager_replicas
+    error_message = "cube_lifecycle_manager_replicas must be an integer >= 1."
   }
 }
 
@@ -380,5 +379,56 @@ variable "cube_webui_replicas" {
   validation {
     condition     = var.cube_webui_replicas >= 1 && floor(var.cube_webui_replicas) == var.cube_webui_replicas
     error_message = "cube_webui_replicas must be an integer >= 1."
+  }
+}
+
+variable "cube_lifecycle_manager_default_idle_timeout" {
+  description = "Default idle timeout used by cube-lifecycle-manager when lifecycle metadata omits TimeoutSeconds."
+  type        = string
+  default     = "5m"
+
+  validation {
+    condition     = can(regex("^[0-9]+(ns|us|µs|ms|s|m|h)$", var.cube_lifecycle_manager_default_idle_timeout))
+    error_message = "cube_lifecycle_manager_default_idle_timeout must be a Go duration such as 5m, 30s, or 1h."
+  }
+}
+
+variable "cube_lifecycle_manager_heartbeat_ttl" {
+  description = "TTL for cube-proxy registry heartbeats. Should be a small multiple of cube_proxy_heartbeat_interval_ms."
+  type        = string
+  default     = "15s"
+
+  validation {
+    condition     = can(regex("^[0-9]+(ns|us|µs|ms|s|m|h)$", var.cube_lifecycle_manager_heartbeat_ttl))
+    error_message = "cube_lifecycle_manager_heartbeat_ttl must be a Go duration such as 15s, 1m, or 1h."
+  }
+}
+
+variable "cube_lifecycle_manager_discovery_refresh" {
+  description = "Redis discovery scan interval for cube-lifecycle-manager."
+  type        = string
+  default     = "3s"
+
+  validation {
+    condition     = can(regex("^[0-9]+(ns|us|µs|ms|s|m|h)$", var.cube_lifecycle_manager_discovery_refresh))
+    error_message = "cube_lifecycle_manager_discovery_refresh must be a Go duration such as 3s, 1m, or 1h."
+  }
+}
+
+variable "cube_admin_token" {
+  description = "Optional shared token used by cube-lifecycle-manager when calling cube-proxy /admin/* endpoints."
+  type        = string
+  default     = ""
+  sensitive   = true
+}
+
+variable "cube_proxy_heartbeat_interval_ms" {
+  description = "Heartbeat interval in milliseconds for cube-proxy Redis registration."
+  type        = number
+  default     = 5000
+
+  validation {
+    condition     = var.cube_proxy_heartbeat_interval_ms >= 1000 && floor(var.cube_proxy_heartbeat_interval_ms) == var.cube_proxy_heartbeat_interval_ms
+    error_message = "cube_proxy_heartbeat_interval_ms must be an integer >= 1000."
   }
 }

--- a/deploy/one-click/terraform/tencentcloud/variables.tf
+++ b/deploy/one-click/terraform/tencentcloud/variables.tf
@@ -350,7 +350,7 @@ variable "cube_api_replicas" {
 }
 
 variable "cube_proxy_replicas" {
-  description = "cube-proxy Deployment replica count. PR #705 uses Redis-backed cube-proxy discovery through cube-lifecycle-manager, so multiple replicas can be discovered without static wiring."
+  description = "cube-proxy Deployment replica count. Redis-backed cube-proxy discovery through cube-lifecycle-manager allows multiple replicas without static wiring."
   type        = number
   default     = 1
 
@@ -416,10 +416,15 @@ variable "cube_lifecycle_manager_discovery_refresh" {
 }
 
 variable "cube_admin_token" {
-  description = "Optional shared token used by cube-lifecycle-manager when calling cube-proxy /admin/* endpoints."
+  description = "Optional shared token used by cube-lifecycle-manager and cube-proxy admin endpoints. If empty, Terraform auto-generates one."
   type        = string
   default     = ""
   sensitive   = true
+
+  validation {
+    condition     = var.cube_admin_token == "" || length(var.cube_admin_token) >= 16
+    error_message = "cube_admin_token must be empty for auto-generation or at least 16 characters when explicitly set."
+  }
 }
 
 variable "cube_proxy_heartbeat_interval_ms" {

--- a/deploy/one-click/tests/test_package_layout.sh
+++ b/deploy/one-click/tests/test_package_layout.sh
@@ -36,6 +36,7 @@ test_component_build_inputs_exist() {
   require_file "${ONE_CLICK_DIR}/webui/Dockerfile.package" "cube-webui Dockerfile"
   # cube-proxy's build-context (and its Dockerfile) come from the CubeProxy source.
   require_file "${ROOT_DIR}/CubeProxy/Dockerfile" "cube-proxy Dockerfile (CubeProxy source)"
+  require_file "${ROOT_DIR}/cube-lifecycle-manager/Dockerfile" "cube-lifecycle-manager Dockerfile"
   # webui nginx.conf is the canonical source for both the package and the
   # terraform webui-nginx.conf the addons render.
   require_file "${ONE_CLICK_DIR}/webui/nginx.conf" "webui nginx.conf source"
@@ -69,8 +70,8 @@ test_image_names_match() {
   # Guard against a regex that silently matches too few/many lines.
   local built_n
   built_n="$(printf '%s\n' "${built}" | grep -c .)"
-  if [[ "${built_n}" -ne 4 ]]; then
-    fail "expected 4 component images in build_images.sh, found ${built_n}: $(echo "${built}" | tr '\n' ' ')"
+  if [[ "${built_n}" -ne 5 ]]; then
+    fail "expected 5 component images in build_images.sh, found ${built_n}: $(echo "${built}" | tr '\n' ' ')"
   fi
   if [[ "${built}" != "${composed}" ]]; then
     fail "image name drift between build_images.sh and tke-addons.tf:

--- a/deploy/one-click/tests/test_package_layout.sh
+++ b/deploy/one-click/tests/test_package_layout.sh
@@ -116,7 +116,34 @@ test_webui_nginx_placeholders() {
   done
 }
 
-# 3c) The TKE addon ConfigMap embeds a cube_box_req_template whose default egress
+# 3c) The Terraform cube-proxy ConfigMap consumes a placeholder-rendered copy of
+#     CubeProxy/nginx.conf. Guard the sed-based template generation so an upstream
+#     listen/cert path format change fails in CI instead of leaving the admin
+#     listener on 127.0.0.1 or a literal placeholder in the rendered ConfigMap.
+test_cubeproxy_nginx_template_generation() {
+  local src="${ROOT_DIR}/CubeProxy/nginx.conf"
+  local tmp token
+  [[ -f "${src}" ]] || { fail "CubeProxy nginx.conf missing: ${src}"; return; }
+
+  tmp="$(mktemp)"
+  sed \
+    -e 's|^worker_processes [0-9]\+;|worker_processes auto;|' \
+    -e 's|^\(\s*listen \)8081\( reuseport;\)|\1__CUBE_PROXY_HTTP_PORT__\2|' \
+    -e 's|^\(\s*listen \)8080\( ssl reuseport;\)|\1__CUBE_PROXY_HTTPS_PORT__\2|' \
+    -e 's|^\(\s*set \$host_proxy_port \)8081;|\1__CUBE_PROXY_HTTP_PORT__;|' \
+    -e 's|^\(\s*set \$host_proxy_port \)8080;|\1__CUBE_PROXY_HTTPS_PORT__;|' \
+    -e 's|^\(\s*listen \)127\.0\.0\.1:8082;|\1__CUBE_PROXY_ADMIN_LISTEN__:8082;|' \
+    -e 's|/usr/local/openresty/nginx/certs/cube\.app+3\.pem|/usr/local/openresty/nginx/certs/__CUBE_PROXY_SSL_CERT__|' \
+    -e 's|/usr/local/openresty/nginx/certs/cube\.app+3-key\.pem|/usr/local/openresty/nginx/certs/__CUBE_PROXY_SSL_KEY__|' \
+    "${src}" >"${tmp}"
+
+  for token in __CUBE_PROXY_HTTP_PORT__ __CUBE_PROXY_HTTPS_PORT__ __CUBE_PROXY_ADMIN_LISTEN__ __CUBE_PROXY_SSL_CERT__ __CUBE_PROXY_SSL_KEY__; do
+    grep -q -F "${token}" "${tmp}" || fail "cube-proxy nginx template generation is missing ${token}; CubeProxy/nginx.conf may have changed"
+  done
+  rm -f "${tmp}"
+}
+
+# 3d) The TKE addon ConfigMap embeds a cube_box_req_template whose default egress
 #     policy MUST sit under the "cube_network_config" JSON key — the only key
 #     CubeMaster deserializes (CreateCubeSandboxReq.CubeNetworkConfig). The legacy
 #     "cubevs_context" key is silently dropped, so the denyOut policy would never
@@ -135,7 +162,7 @@ test_tke_addons_network_config_key() {
   fi
 }
 
-# 3d) Reinstall first removes packaged component directories, then lays the new
+# 3e) Reinstall first removes packaged component directories, then lays the new
 #     package down. Guard that list against drifting when build-release-bundle.sh
 #     adds a new top-level package component.
 extract_package_root_dirs() {
@@ -209,6 +236,7 @@ test_build_scripts_parse() {
 test_component_build_inputs_exist
 test_image_names_match
 test_webui_nginx_placeholders
+test_cubeproxy_nginx_template_generation
 test_tke_addons_network_config_key
 test_reinstall_cleanup_tracks_packaged_components
 test_terraform_deployer_files_present

--- a/docs/guide/tencentcloud-terraform-deploy.md
+++ b/docs/guide/tencentcloud-terraform-deploy.md
@@ -84,10 +84,10 @@ Matching `env.example` / `variables.tf`, the **default is public images + single
 
 **Advanced modes:**
 
-- `TENCENTCLOUD_USE_TCR=true`: create TCR and build/push the four component images on the jumpserver.
+- `TENCENTCLOUD_USE_TCR=true`: create TCR and build/push the five component images on the jumpserver.
 - `TENCENTCLOUD_USE_CFS=true` with `TENCENTCLOUD_CUBEMASTER_REPLICAS>1`: create CFS for cubemaster multi-replica shared storage.
 
-`cube-proxy` defaults to **single replica** (`TENCENTCLOUD_CUBE_PROXY_REPLICAS=1`). Auto-pause / auto-resume is reliable only with one replica (current sidecar model; after PR #705 merges this becomes a standalone `cube-lifecycle-manager`). For multiple replicas the front-end LB must hash on SandboxID (session affinity).
+`cube-proxy` defaults to **single replica** (`TENCENTCLOUD_CUBE_PROXY_REPLICAS=1`). Auto-pause / auto-resume is coordinated by the standalone `cube-lifecycle-manager`, and each cube-proxy replica registers itself in Redis so the manager can discover it without static wiring.
 
 ## Resources Created by the Default Configuration
 
@@ -271,7 +271,7 @@ See [Configuration](#configuration) below for the meaning and defaults of each `
 2. Generates an SSH key pair under `terraform/tencentcloud/.ssh/` if none exists.
 3. Generates the cube-proxy TLS certificate (`cube.app` / `*.cube.app`) on the jumpserver with the bundled `mkcert`, downloading it to `terraform/tencentcloud/cubeproxy-certs/` for the Secret mount.
 4. **Default mode** (`USE_TCR=false`): pull public pre-built images and deploy TKE addons and CVM compute nodes (2 by default).
-5. **TCR mode** (`USE_TCR=true`): create TCR, build and push the four component images on the jumpserver, then deploy TKE and compute nodes.
+5. **TCR mode** (`USE_TCR=true`): create TCR, build and push the five component images on the jumpserver, then deploy TKE and compute nodes.
 
 ## Configuration
 
@@ -288,6 +288,7 @@ export TENCENTCLOUD_COMPUTE_INSTANCE_TYPE=SA9.MEDIUM8
 export TENCENTCLOUD_USE_TCR=false                    # default: public pre-built images
 export TENCENTCLOUD_USE_CFS=false                    # default: no CFS
 export TENCENTCLOUD_CUBE_IMAGE_TAG=v0.5.0
+export TENCENTCLOUD_CUBE_LIFECYCLE_MANAGER_REPLICAS=1
 ```
 
 ### Common Variables
@@ -314,8 +315,14 @@ export TENCENTCLOUD_CUBE_IMAGE_TAG=v0.5.0
 | `TENCENTCLOUD_CUBE_DB` / `TENCENTCLOUD_CUBE_USER` / `TENCENTCLOUD_CUBE_PASSWORD` | `cube_mvp` / `cube` / demo | Application DB name / account / password |
 | `TENCENTCLOUD_CUBEMASTER_REPLICAS` | `1` | cube-master replica count |
 | `TENCENTCLOUD_CUBE_API_REPLICAS` | `1` | cube-api replica count |
-| `TENCENTCLOUD_CUBE_PROXY_REPLICAS` | `1` | cube-proxy replica count. **Default 1**: auto-pause/auto-resume only works in single-replica mode. Going >1 requires the LB to hash on SandboxID |
+| `TENCENTCLOUD_CUBE_PROXY_REPLICAS` | `1` | cube-proxy replica count. Each replica registers in Redis for cube-lifecycle-manager discovery |
+| `TENCENTCLOUD_CUBE_LIFECYCLE_MANAGER_REPLICAS` | `1` | cube-lifecycle-manager replica count. Keep `1` unless CLM HA behavior has been validated for your deployment |
 | `TENCENTCLOUD_CUBE_WEBUI_REPLICAS` | `1` | cube-webui replica count |
+| `TENCENTCLOUD_CUBE_LIFECYCLE_MANAGER_DEFAULT_IDLE_TIMEOUT` | `5m` | Default idle timeout used when lifecycle metadata omits `TimeoutSeconds` |
+| `TENCENTCLOUD_CUBE_LIFECYCLE_MANAGER_HEARTBEAT_TTL` | `15s` | TTL for cube-proxy Redis registry heartbeats |
+| `TENCENTCLOUD_CUBE_LIFECYCLE_MANAGER_DISCOVERY_REFRESH` | `3s` | Redis discovery scan interval for cube-lifecycle-manager |
+| `TENCENTCLOUD_CUBE_PROXY_HEARTBEAT_INTERVAL_MS` | `5000` | cube-proxy registry heartbeat interval in milliseconds |
+| `TENCENTCLOUD_CUBE_ADMIN_TOKEN` | empty | Optional shared token for cube-lifecycle-manager -> cube-proxy `/admin/*` calls |
 | `TENCENTCLOUD_ENABLE_PUBLIC_NETWORK` | `false` | Network exposure mode for cube-api / cube-proxy / cube-webui. **Default `false`**: VPC-internal CLBs, reachable only from inside the VPC (via jumpserver / VPN). Set to `true` for public CLBs reachable from the internet, with the security group opening `0.0.0.0/0` accordingly. cube-master always stays VPC-internal. Read [Hardening the Public-Facing Services](#hardening-the-public-facing-services) before enabling |
 
 ### Non-interactive / CI runs

--- a/docs/guide/tencentcloud-terraform-deploy.md
+++ b/docs/guide/tencentcloud-terraform-deploy.md
@@ -87,8 +87,9 @@ Matching `env.example` / `variables.tf`, the **default is public images + single
 
 - `TENCENTCLOUD_USE_TCR=true`: create TCR and build/push the five component images on the jumpserver.
 - `TENCENTCLOUD_USE_CFS=true` with `TENCENTCLOUD_CUBEMASTER_REPLICAS>1`: create CFS for cubemaster multi-replica shared storage.
+- `TENCENTCLOUD_CUBE_PROXY_REPLICAS>1`: run cube-proxy with multiple replicas behind the same CLB.
 
-`cube-proxy` defaults to **single replica** (`TENCENTCLOUD_CUBE_PROXY_REPLICAS=1`). Auto-pause / auto-resume is coordinated by the standalone `cube-lifecycle-manager`, and each cube-proxy replica registers itself in Redis so the manager can discover it without static wiring.
+`cube-proxy` supports **multiple replicas**. The default remains a single replica (`TENCENTCLOUD_CUBE_PROXY_REPLICAS=1`) for small deployments, but you can increase it when proxy traffic grows. Each cube-proxy replica registers its admin endpoint in Redis, and the standalone `cube-lifecycle-manager` discovers replicas from that registry for auto-pause / auto-resume coordination, so no static replica list is required.
 
 ## Resources Created by the Default Configuration
 
@@ -316,7 +317,7 @@ export TENCENTCLOUD_CUBE_LIFECYCLE_MANAGER_REPLICAS=1
 | `TENCENTCLOUD_CUBE_DB` / `TENCENTCLOUD_CUBE_USER` / `TENCENTCLOUD_CUBE_PASSWORD` | `cube_mvp` / `cube` / demo | Application DB name / account / password |
 | `TENCENTCLOUD_CUBEMASTER_REPLICAS` | `1` | cube-master replica count |
 | `TENCENTCLOUD_CUBE_API_REPLICAS` | `1` | cube-api replica count |
-| `TENCENTCLOUD_CUBE_PROXY_REPLICAS` | `1` | cube-proxy replica count. Each replica registers in Redis for cube-lifecycle-manager discovery |
+| `TENCENTCLOUD_CUBE_PROXY_REPLICAS` | `1` | cube-proxy replica count. Values greater than `1` are supported; each replica registers in Redis for cube-lifecycle-manager discovery |
 | `TENCENTCLOUD_CUBE_LIFECYCLE_MANAGER_REPLICAS` | `1` | cube-lifecycle-manager replica count. Keep `1` unless CLM HA behavior has been validated for your deployment |
 | `TENCENTCLOUD_CUBE_WEBUI_REPLICAS` | `1` | cube-webui replica count |
 | `TENCENTCLOUD_CUBE_LIFECYCLE_MANAGER_DEFAULT_IDLE_TIMEOUT` | `5m` | Default idle timeout used when lifecycle metadata omits `TimeoutSeconds` |

--- a/docs/guide/tencentcloud-terraform-deploy.md
+++ b/docs/guide/tencentcloud-terraform-deploy.md
@@ -1,6 +1,6 @@
 # Tencent Cloud Cluster Deployment (Terraform)
 
-This guide explains how to use the Terraform deployer shipped in the release bundle to stand up a **clustered** Cube Sandbox on Tencent Cloud in one shot: a managed TKE control plane running `cube-master` / `cube-api` / `cube-proxy` / `cube-webui`, backed by cloud MySQL + Redis, with one or more CVM PVM compute nodes. A jumpserver (SSH on port `443`) acts as the build host and the bastion for the otherwise-private VPC.
+This guide explains how to use the Terraform deployer shipped in the release bundle to stand up a **clustered** Cube Sandbox on Tencent Cloud in one shot: a managed TKE control plane running `cube-master` / `cube-api` / `cube-proxy` / `cube-lifecycle-manager` / `cube-webui`, backed by cloud MySQL + Redis, with one or more CVM PVM compute nodes. A jumpserver (SSH on port `443`) acts as the build host and the bastion for the otherwise-private VPC.
 
 ::: tip Network Hardening
 Network hardening for the cluster deployment is handled by **Tencent Cloud security groups**: the deployer creates **4 per-role security groups** (jumpserver / compute / TKE pod / CLB), each opening only the ingress that role actually needs on a least-privilege basis (compute and TKE nodes get no public ingress at all), and assigns no public IP to compute nodes. **The default is internal mode** (`TENCENTCLOUD_ENABLE_PUBLIC_NETWORK='false'`): the three user-facing services — WebUI / cube-api / cube-proxy — are fronted by **VPC-internal CLBs**, reachable only from inside the VPC (via the jumpserver / VPN) with no public exposure. To allow public access, explicitly set `TENCENTCLOUD_ENABLE_PUBLIC_NETWORK='true'` to switch them to public CLBs. To tighten further, adjust the inbound/outbound rules of each individual group (`cubesandbox-sg-jumpserver` / `cubesandbox-sg-compute` / `cubesandbox-sg-tke-pod` / `cubesandbox-sg-clb`) as needed in the [Tencent Cloud security group console](https://console.cloud.tencent.com/vpc/securitygroup). **When public mode is enabled**, also see [Hardening the Public-Facing Services](#hardening-the-public-facing-services).
@@ -30,12 +30,13 @@ This deployment uses cloud resources to **quickly stand up a highly-available Cu
   ┌────────────┼─────────────────────────────────┼──────────┐
   │            │            VPC internal          │           │
   │  ┌─────────┴────────┐       ┌───────────────┴─────┐    │
-  │  │ Compute CVM ×N   │       │  TKE managed cluster │    │
-  │  │  Cubelet         │       │  cube-master (×1)   │    │
-  │  │  network-agent   │       │  cube-api (×1)      │    │
-  │  │  CubeEgress      │       │  cube-proxy (×1)    │    │
-  │  └──────────────────┘       │  cube-webui (×1)    │    │
-  │                             └───┬─────────────┬───┘    │
+  │  │ Compute CVM ×N   │       │  TKE managed cluster      │
+  │  │  Cubelet         │       │  cube-master (×1)         │
+  │  │  network-agent   │       │  cube-api (×1)            │
+  │  │  CubeEgress      │       │  cube-proxy (×1)          │
+  │  └──────────────────┘       │  cube-lifecycle-manager   │
+  │                             │  cube-webui (×1)          │
+  │                             └───┬─────────────┬─────────┘
   │                                 │             │         │
   │                    ┌────────────┴───┐ (opt.)  │         │
   │                    │  CFS (NFS)     │         │         │
@@ -56,7 +57,7 @@ This deployment uses cloud resources to **quickly stand up a highly-available Cu
 |-----------|------|-------|
 | Jumpserver | CVM (public IP, SSH 443) | Build host (TCR mode) and bastion into the private VPC |
 | Load balancer | CLB (internal/public) | Fronts `cube-api` / `cube-proxy` / `cube-webui`; internal mode by default, user traffic entry point |
-| Control plane | Managed TKE cluster | Runs `cube-master` / `cube-api` / `cube-proxy` / `cube-webui` |
+| Control plane | Managed TKE cluster | Runs `cube-master` / `cube-api` / `cube-proxy` / `cube-lifecycle-manager` / `cube-webui` |
 | Compute node | CVM PVM | Runs `Cubelet` / `network-agent` / `CubeEgress`; **actually hosts sandboxes** |
 | Database | Cloud MySQL 8.0 + Redis 7.0 | VPC-internal only, no public access |
 | Shared storage | CFS (General Standard NFS, **optional**) | When `USE_CFS=true` and cubemaster has multiple replicas, ReadWriteMany share for `/data/CubeMaster/storage` |
@@ -322,7 +323,7 @@ export TENCENTCLOUD_CUBE_LIFECYCLE_MANAGER_REPLICAS=1
 | `TENCENTCLOUD_CUBE_LIFECYCLE_MANAGER_HEARTBEAT_TTL` | `15s` | TTL for cube-proxy Redis registry heartbeats |
 | `TENCENTCLOUD_CUBE_LIFECYCLE_MANAGER_DISCOVERY_REFRESH` | `3s` | Redis discovery scan interval for cube-lifecycle-manager |
 | `TENCENTCLOUD_CUBE_PROXY_HEARTBEAT_INTERVAL_MS` | `5000` | cube-proxy registry heartbeat interval in milliseconds |
-| `TENCENTCLOUD_CUBE_ADMIN_TOKEN` | empty | Optional shared token for cube-lifecycle-manager -> cube-proxy `/admin/*` calls |
+| `TENCENTCLOUD_CUBE_ADMIN_TOKEN` | empty | Shared token for cube-lifecycle-manager -> cube-proxy `/admin/*` calls. Leave empty to auto-generate; custom values must be at least 16 characters |
 | `TENCENTCLOUD_ENABLE_PUBLIC_NETWORK` | `false` | Network exposure mode for cube-api / cube-proxy / cube-webui. **Default `false`**: VPC-internal CLBs, reachable only from inside the VPC (via jumpserver / VPN). Set to `true` for public CLBs reachable from the internet, with the security group opening `0.0.0.0/0` accordingly. cube-master always stays VPC-internal. Read [Hardening the Public-Facing Services](#hardening-the-public-facing-services) before enabling |
 
 ### Non-interactive / CI runs
@@ -353,7 +354,7 @@ The default deployment provisions **2× 4C8G compute nodes** (`SA9.MEDIUM8`, 200
 | Compute node (PVM) | `SA9.MEDIUM8` | 4C8G + 200GB data disk | 2 |
 | TKE Worker | `SA9.LARGE8` | 4C8G | 2 (`worker_config.count`) |
 | Jumpserver | `SA9.MEDIUM4` | 2C4G | 1 |
-| Control-plane Pods | — | cubemaster / cube-api / cube-webui ×1 each | on TKE workers |
+| Control-plane Pods | — | cubemaster / cube-api / cube-proxy / cube-lifecycle-manager / cube-webui ×1 each | on TKE workers |
 
 ::: warning
 The default configuration is only suitable for functional validation and small-scale evaluation. For large-scale production usage, you **must adjust the compute node and TKE node specs and counts**, otherwise you will encounter CPU/memory exhaustion, Pod scheduling failures, and sandbox creation timeouts.

--- a/docs/zh/guide/tencentcloud-terraform-deploy.md
+++ b/docs/zh/guide/tencentcloud-terraform-deploy.md
@@ -1,6 +1,6 @@
 # 腾讯云集群部署（Terraform）
 
-本指南介绍如何使用发布包中自带的 Terraform 部署器，在腾讯云上一键拉起一个**集群版** Cube Sandbox：托管的 TKE 控制面运行 `cube-master` / `cube-api` / `cube-proxy` / `cube-webui`，后端使用云数据库 MySQL + Redis，并配备一个或多个 CVM PVM 计算节点。一台跳板机（SSH 端口为 `443`）作为构建主机和私有 VPC 的堡垒机。
+本指南介绍如何使用发布包中自带的 Terraform 部署器，在腾讯云上一键拉起一个**集群版** Cube Sandbox：托管的 TKE 控制面运行 `cube-master` / `cube-api` / `cube-proxy` / `cube-lifecycle-manager` / `cube-webui`，后端使用云数据库 MySQL + Redis，并配备一个或多个 CVM PVM 计算节点。一台跳板机（SSH 端口为 `443`）作为构建主机和私有 VPC 的堡垒机。
 
 ::: tip 网络加固
 集群版的网络加固由**腾讯云安全组**完成：部署器按角色创建 **4 个独立安全组**（跳板机 / 计算节点 / TKE Pod / CLB），各自按最小权限放行（如对公网仅放行必要的入口，计算节点与 TKE 节点无任何公网入站），计算节点不分配公网 IP。**默认采用内网模式**（`TENCENTCLOUD_ENABLE_PUBLIC_NETWORK='false'`）：WebUI / cube-api / cube-proxy 三个用户侧服务关联**内网 CLB**，仅 VPC 内部（经跳板机 / VPN）可访问，不对公网暴露；如需公网访问，须显式设置 `TENCENTCLOUD_ENABLE_PUBLIC_NETWORK='true'` 切换为公网 CLB。如需进一步收紧，可在[腾讯云安全组控制台](https://console.cloud.tencent.com/vpc/securitygroup)按需对上述各个安全组（`cubesandbox-sg-jumpserver` / `cubesandbox-sg-compute` / `cubesandbox-sg-tke-pod` / `cubesandbox-sg-clb`）分别调整入站 / 出站规则。**当开启公网模式时**，请额外参阅[公网服务加固建议](#公网服务加固建议)。
@@ -29,12 +29,13 @@
   ┌────────────┼─────────────────────────────────┼──────────┐
   │            │            VPC 内网              │           │
   │  ┌─────────┴────────┐       ┌───────────────┴─────┐    │
-  │  │  CVM 计算节点 ×N │       │    TKE 托管集群      │    │
-  │  │  Cubelet         │       │  cube-master (×1)   │    │
-  │  │  network-agent   │       │  cube-api (×1)      │    │
-  │  │  CubeEgress      │       │  cube-proxy (×1)    │    │
-  │  └──────────────────┘       │  cube-webui (×1)    │    │
-  │                             └───┬─────────────┬───┘    │
+  │  │  CVM 计算节点 ×N │       │    TKE 托管集群          │
+  │  │  Cubelet         │       │  cube-master (×1)       │
+  │  │  network-agent   │       │  cube-api (×1)          │
+  │  │  CubeEgress      │       │  cube-proxy (×1)        │
+  │  └──────────────────┘       │  cube-lifecycle-manager │
+  │                             │  cube-webui (×1)        │
+  │                             └───┬─────────────┬────────┘
   │                                 │             │         │
   │                    ┌────────────┴───┐ (可选)  │         │
   │                    │  CFS (NFS)     │         │         │
@@ -55,7 +56,7 @@
 |------|------|------|
 | 跳板机 | CVM（公网 IP，SSH 443） | 构建镜像（TCR 模式）、作为私有 VPC 的堡垒机 |
 | 负载均衡 | CLB（内网/公网） | 前置 `cube-api` / `cube-proxy` / `cube-webui`，默认内网模式，用户流量入口 |
-| 控制面 | TKE 托管集群 | 运行 `cube-master` / `cube-api` / `cube-proxy` / `cube-webui` |
+| 控制面 | TKE 托管集群 | 运行 `cube-master` / `cube-api` / `cube-proxy` / `cube-lifecycle-manager` / `cube-webui` |
 | 计算节点 | CVM PVM | 运行 `Cubelet` / `network-agent` / `CubeEgress`，**实际承载沙箱** |
 | 数据库 | 云数据库 MySQL 8.0 + Redis 7.0 | 仅 VPC 内网访问，不开公网 |
 | 共享存储 | CFS（通用标准型 NFS，**可选**） | `USE_CFS=true` 且 cubemaster 多副本时，ReadWriteMany 共享 `/data/CubeMaster/storage` |
@@ -321,7 +322,7 @@ export TENCENTCLOUD_CUBE_LIFECYCLE_MANAGER_REPLICAS=1
 | `TENCENTCLOUD_CUBE_LIFECYCLE_MANAGER_HEARTBEAT_TTL` | `15s` | cube-proxy Redis 注册心跳的过期时间 |
 | `TENCENTCLOUD_CUBE_LIFECYCLE_MANAGER_DISCOVERY_REFRESH` | `3s` | cube-lifecycle-manager 扫描 Redis 注册表的间隔 |
 | `TENCENTCLOUD_CUBE_PROXY_HEARTBEAT_INTERVAL_MS` | `5000` | cube-proxy 注册心跳间隔（毫秒） |
-| `TENCENTCLOUD_CUBE_ADMIN_TOKEN` | 空 | cube-lifecycle-manager 调用 cube-proxy `/admin/*` 接口时使用的可选共享 token |
+| `TENCENTCLOUD_CUBE_ADMIN_TOKEN` | 空 | cube-lifecycle-manager 调用 cube-proxy `/admin/*` 接口时使用的共享 token。留空则自动生成；自定义值至少 16 个字符 |
 | `TENCENTCLOUD_ENABLE_PUBLIC_NETWORK` | `false` | cube-api / cube-proxy / cube-webui 的网络暴露模式。**默认 `false`**：关联内网 CLB，仅 VPC 内网（经跳板机 / VPN）可访问；设为 `true` 则关联公网 CLB，对公网开放，安全组同步放行 `0.0.0.0/0`。cube-master 始终为内网 CLB，不受此开关影响。开启公网前请阅读[公网服务加固建议](#公网服务加固建议) |
 
 ### 非交互 / CI 运行
@@ -352,7 +353,7 @@ export TENCENTCLOUD_BUILD_IMAGES=0        # TCR 模式下复用已推送的镜�
 | 计算节点（PVM） | `SA9.MEDIUM8` | 4C8G + 200GB 数据盘 | 2 台 |
 | TKE Worker | `SA9.LARGE8` | 4C8G | 2 台（`worker_config.count`） |
 | 跳板机 | `SA9.MEDIUM4` | 2C4G | 1 台 |
-| 控制面 Pod | — | cubemaster / cube-api / cube-webui 各 1 副本 | 运行在 TKE worker 上 |
+| 控制面 Pod | — | cubemaster / cube-api / cube-proxy / cube-lifecycle-manager / cube-webui 各 1 副本 | 运行在 TKE worker 上 |
 
 ::: warning
 默认配置仅适合功能验证和小规模评估。大规模生产环境使用时，**必须调整计算节点和 TKE 节点的规格与数量**，否则会遇到 CPU/内存不足、Pod 调度失败、沙箱创建超时等问题。
@@ -399,7 +400,7 @@ export TF_VAR_compute_data_disk_size=1000
 
 ### 调整 TKE Worker 节点
 
-TKE Worker 运行 cube-master、cube-api、cube-proxy、cube-webui 等控制面 Pod。大规模场景下控制面的请求量和调度压力会增大，需要更多资源。
+TKE Worker 运行 cube-master、cube-api、cube-proxy、cube-lifecycle-manager、cube-webui 等控制面 Pod。大规模场景下控制面的请求量和调度压力会增大，需要更多资源。
 
 | 环境变量 | 说明 |
 |---------|------|

--- a/docs/zh/guide/tencentcloud-terraform-deploy.md
+++ b/docs/zh/guide/tencentcloud-terraform-deploy.md
@@ -83,10 +83,10 @@
 
 **高级模式：**
 
-- `TENCENTCLOUD_USE_TCR=true`：创建 TCR，在跳板机构建并推送四个组件镜像。
+- `TENCENTCLOUD_USE_TCR=true`：创建 TCR，在跳板机构建并推送五个组件镜像。
 - `TENCENTCLOUD_USE_CFS=true` 且 `TENCENTCLOUD_CUBEMASTER_REPLICAS>1`：创建 CFS，cubemaster 多副本共享存储。
 
-`cube-proxy` 默认**单副本**（`TENCENTCLOUD_CUBE_PROXY_REPLICAS=1`）。自动暂停 / 自动恢复在单副本下才可靠（当前为 sidecar 模型；合并 PR #705 后将改为独立的 `cube-lifecycle-manager`）。多副本时前端 LB 须按 SandboxID hash（会话保持）。
+`cube-proxy` 默认**单副本**（`TENCENTCLOUD_CUBE_PROXY_REPLICAS=1`）。自动暂停 / 自动恢复由独立的 `cube-lifecycle-manager` 协调；每个 cube-proxy 副本会注册到 Redis，manager 可自动发现，无需静态配置副本列表。
 
 ## 默认配置创建的资源明细
 
@@ -270,7 +270,7 @@ export TENCENTCLOUD_SECRET_KEY="your-secret-key"
 2. 如不存在则在 `terraform/tencentcloud/.ssh/` 下生成 SSH 密钥对。
 3. 在跳板机上用内置 `mkcert` 生成 cube-proxy 的 TLS 证书（`cube.app` / `*.cube.app`），下载到 `terraform/tencentcloud/cubeproxy-certs/` 供 Secret 挂载。
 4. **默认模式**（`USE_TCR=false`）：拉取公网预置镜像，部署 TKE 插件与 CVM 计算节点（默认 2 台）。
-5. **TCR 模式**（`USE_TCR=true`）：创建 TCR，在跳板机构建并推送四个组件镜像，再部署 TKE 与计算节点。
+5. **TCR 模式**（`USE_TCR=true`）：创建 TCR，在跳板机构建并推送五个组件镜像，再部署 TKE 与计算节点。
 
 ## 配置
 
@@ -287,6 +287,7 @@ export TENCENTCLOUD_COMPUTE_INSTANCE_TYPE=SA9.MEDIUM8
 export TENCENTCLOUD_USE_TCR=false                    # 默认：公网预置镜像
 export TENCENTCLOUD_USE_CFS=false                    # 默认：无 CFS
 export TENCENTCLOUD_CUBE_IMAGE_TAG=v0.5.0
+export TENCENTCLOUD_CUBE_LIFECYCLE_MANAGER_REPLICAS=1
 ```
 
 ### 常用变量
@@ -313,8 +314,14 @@ export TENCENTCLOUD_CUBE_IMAGE_TAG=v0.5.0
 | `TENCENTCLOUD_CUBE_DB` / `TENCENTCLOUD_CUBE_USER` / `TENCENTCLOUD_CUBE_PASSWORD` | `cube_mvp` / `cube` / 演示值 | 应用库名 / 账号 / 密码 |
 | `TENCENTCLOUD_CUBEMASTER_REPLICAS` | `1` | cube-master 副本数 |
 | `TENCENTCLOUD_CUBE_API_REPLICAS` | `1` | cube-api 副本数 |
-| `TENCENTCLOUD_CUBE_PROXY_REPLICAS` | `1` | cube-proxy 副本数。**默认 1**：自动暂停 / 恢复仅单副本下正确；要 >1 须前端 LB 按 SandboxID hash |
+| `TENCENTCLOUD_CUBE_PROXY_REPLICAS` | `1` | cube-proxy 副本数。每个副本都会注册到 Redis，供 cube-lifecycle-manager 发现 |
+| `TENCENTCLOUD_CUBE_LIFECYCLE_MANAGER_REPLICAS` | `1` | cube-lifecycle-manager 副本数。除非已验证 CLM 高可用行为，否则建议保持 `1` |
 | `TENCENTCLOUD_CUBE_WEBUI_REPLICAS` | `1` | cube-webui 副本数 |
+| `TENCENTCLOUD_CUBE_LIFECYCLE_MANAGER_DEFAULT_IDLE_TIMEOUT` | `5m` | lifecycle metadata 未指定 `TimeoutSeconds` 时使用的默认空闲超时 |
+| `TENCENTCLOUD_CUBE_LIFECYCLE_MANAGER_HEARTBEAT_TTL` | `15s` | cube-proxy Redis 注册心跳的过期时间 |
+| `TENCENTCLOUD_CUBE_LIFECYCLE_MANAGER_DISCOVERY_REFRESH` | `3s` | cube-lifecycle-manager 扫描 Redis 注册表的间隔 |
+| `TENCENTCLOUD_CUBE_PROXY_HEARTBEAT_INTERVAL_MS` | `5000` | cube-proxy 注册心跳间隔（毫秒） |
+| `TENCENTCLOUD_CUBE_ADMIN_TOKEN` | 空 | cube-lifecycle-manager 调用 cube-proxy `/admin/*` 接口时使用的可选共享 token |
 | `TENCENTCLOUD_ENABLE_PUBLIC_NETWORK` | `false` | cube-api / cube-proxy / cube-webui 的网络暴露模式。**默认 `false`**：关联内网 CLB，仅 VPC 内网（经跳板机 / VPN）可访问；设为 `true` 则关联公网 CLB，对公网开放，安全组同步放行 `0.0.0.0/0`。cube-master 始终为内网 CLB，不受此开关影响。开启公网前请阅读[公网服务加固建议](#公网服务加固建议) |
 
 ### 非交互 / CI 运行

--- a/docs/zh/guide/tencentcloud-terraform-deploy.md
+++ b/docs/zh/guide/tencentcloud-terraform-deploy.md
@@ -86,8 +86,9 @@
 
 - `TENCENTCLOUD_USE_TCR=true`：创建 TCR，在跳板机构建并推送五个组件镜像。
 - `TENCENTCLOUD_USE_CFS=true` 且 `TENCENTCLOUD_CUBEMASTER_REPLICAS>1`：创建 CFS，cubemaster 多副本共享存储。
+- `TENCENTCLOUD_CUBE_PROXY_REPLICAS>1`：让 cube-proxy 以多副本方式运行，并复用同一个 CLB 对外服务。
 
-`cube-proxy` 默认**单副本**（`TENCENTCLOUD_CUBE_PROXY_REPLICAS=1`）。自动暂停 / 自动恢复由独立的 `cube-lifecycle-manager` 协调；每个 cube-proxy 副本会注册到 Redis，manager 可自动发现，无需静态配置副本列表。
+`cube-proxy` 支持**多副本**。默认仍为单副本（`TENCENTCLOUD_CUBE_PROXY_REPLICAS=1`），适合小规模部署；当代理流量增长时，可以按需调高。每个 cube-proxy 副本都会把自己的 admin endpoint 注册到 Redis，独立的 `cube-lifecycle-manager` 从 Redis 注册表发现副本并协调自动暂停 / 自动恢复，因此无需静态配置副本列表。
 
 ## 默认配置创建的资源明细
 
@@ -315,7 +316,7 @@ export TENCENTCLOUD_CUBE_LIFECYCLE_MANAGER_REPLICAS=1
 | `TENCENTCLOUD_CUBE_DB` / `TENCENTCLOUD_CUBE_USER` / `TENCENTCLOUD_CUBE_PASSWORD` | `cube_mvp` / `cube` / 演示值 | 应用库名 / 账号 / 密码 |
 | `TENCENTCLOUD_CUBEMASTER_REPLICAS` | `1` | cube-master 副本数 |
 | `TENCENTCLOUD_CUBE_API_REPLICAS` | `1` | cube-api 副本数 |
-| `TENCENTCLOUD_CUBE_PROXY_REPLICAS` | `1` | cube-proxy 副本数。每个副本都会注册到 Redis，供 cube-lifecycle-manager 发现 |
+| `TENCENTCLOUD_CUBE_PROXY_REPLICAS` | `1` | cube-proxy 副本数。支持设置为大于 `1`；每个副本都会注册到 Redis，供 cube-lifecycle-manager 发现 |
 | `TENCENTCLOUD_CUBE_LIFECYCLE_MANAGER_REPLICAS` | `1` | cube-lifecycle-manager 副本数。除非已验证 CLM 高可用行为，否则建议保持 `1` |
 | `TENCENTCLOUD_CUBE_WEBUI_REPLICAS` | `1` | cube-webui 副本数 |
 | `TENCENTCLOUD_CUBE_LIFECYCLE_MANAGER_DEFAULT_IDLE_TIMEOUT` | `5m` | lifecycle metadata 未指定 `TimeoutSeconds` 时使用的默认空闲超时 |


### PR DESCRIPTION
## Summary
- Add Terraform deployment for cube-lifecycle-manager in TencentCloud one-click.
- Wire cubeproxy to lifecycle-manager with nginx config, secrets, env vars, and image build/release support.
- Document lifecycle-related TencentCloud deployment settings.

## Test plan
- ./deploy/one-click/tests/test_package_layout.sh
- bash -n deploy/one-click/terraform/tencentcloud/create.sh
- bash -n deploy/one-click/terraform/tencentcloud/destroy.sh
- bash -n deploy/one-click/terraform/tencentcloud/build_images.sh
- bash -n deploy/one-click/build-release-bundle.sh
- terraform -chdir=deploy/one-click/terraform/tencentcloud fmt -check -recursive
- terraform -chdir=deploy/one-click/terraform/tencentcloud init -backend=false
- terraform -chdir=deploy/one-click/terraform/tencentcloud validate