### PR TITLE
fix(ci): restrict pvm-guest build trigger to version tags only

### DIFF
--- a/.github/workflows/build-pvm-guest-vmlinux.yml
+++ b/.github/workflows/build-pvm-guest-vmlinux.yml
@@ -8,7 +8,7 @@ on:
       - 'deploy/pvm/configs/pvm_guest'
       - '.github/workflows/build-pvm-guest-vmlinux.yml'
     tags:
-      - '*'
+      - 'v*'
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
Change tag trigger pattern from `'*'` to `'v*'` in the PVM guest vmlinux build workflow.

This prevents unnecessary CI builds on non-version tags (e.g., arbitrary manual tags) while still triggering on release version tags like `v1.0.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)