### PR TITLE
fix(sdk): route Go SDK envd RPCs to the envd port (49983)

### DIFF
--- a/sdk/go/README.md
+++ b/sdk/go/README.md
@@ -198,10 +198,14 @@ sb, err := client.Create(ctx, cubesandbox.CreateOptions{
 When `CUBE_PROXY_NODE_IP` is set, data-plane requests connect directly to that IP and port while preserving the virtual sandbox host:
 
 ```text
-URL:  <CUBE_PROXY_SCHEME>://49999-<sandboxID>.<CUBE_SANDBOX_DOMAIN>/<envd-endpoint>
+URL:  <CUBE_PROXY_SCHEME>://49983-<sandboxID>.<CUBE_SANDBOX_DOMAIN>/<envd-endpoint>
 TCP:  <CUBE_PROXY_NODE_IP>:<CUBE_PROXY_PORT_HTTP>
-Host: 49999-<sandboxID>.<CUBE_SANDBOX_DOMAIN>
+Host: 49983-<sandboxID>.<CUBE_SANDBOX_DOMAIN>
 ```
+
+The host prefix is the sandbox's internal service port: `49983` (envd) for
+commands/filesystem/files/PTY, and `49999` (Jupyter) for the code interpreter
+(`RunCode` / `/execute`).
 
 You can also set it directly:
 

--- a/sdk/go/envd.go
+++ b/sdk/go/envd.go
@@ -225,7 +225,7 @@ func multipartFileBody(path string, data []byte) (io.Reader, string, error) {
 func (s *Sandbox) newEnvdRequest(ctx context.Context, method, path string, query url.Values, body io.Reader) (*http.Request, error) {
 	target := url.URL{
 		Scheme:   s.client.config.ProxyScheme,
-		Host:     s.GetHost(JupyterPort),
+		Host:     s.GetHost(EnvdPort),
 		Path:     path,
 		RawQuery: query.Encode(),
 	}

--- a/sdk/go/sandbox.go
+++ b/sdk/go/sandbox.go
@@ -13,7 +13,15 @@ import (
 	"time"
 )
 
-const JupyterPort = 49999
+const (
+	// JupyterPort is the code-interpreter (Jupyter) port, used only by the
+	// /execute endpoint (RunCode).
+	JupyterPort = 49999
+	// EnvdPort is the envd daemon port. All envd data-plane RPCs — commands,
+	// filesystem, files, and PTY — route here, matching the Python/Node SDKs
+	// (ENVD_PORT = 49983). Sending these to JupyterPort yields 404s.
+	EnvdPort = 49983
+)
 
 func (s *Sandbox) GetHost(port int) string {
 	domain := s.Domain

--- a/sdk/go/sdk_test.go
+++ b/sdk/go/sdk_test.go
@@ -655,7 +655,7 @@ func TestCommandsRunUsesEnvdProcessStart(t *testing.T) {
 		t.Fatalf("Run: %v", err)
 	}
 
-	if gotHost != "49999-sb-proc.cube.test" {
+	if gotHost != "49983-sb-proc.cube.test" {
 		t.Fatalf("Host=%q", gotHost)
 	}
 	if gotHeaders.Get("Content-Type") != connectContentType || gotHeaders.Get("Connect-Protocol-Version") != connectProtocolVersion {
@@ -721,7 +721,7 @@ func TestFilesReadUsesEnvdHTTPFileAPI(t *testing.T) {
 	if content != "file content" {
 		t.Fatalf("content=%q", content)
 	}
-	if gotHost != "49999-sb-files.cube.test" || gotPath != "/tmp/foo bar.txt" || gotToken != "envd-token" {
+	if gotHost != "49983-sb-files.cube.test" || gotPath != "/tmp/foo bar.txt" || gotToken != "envd-token" {
 		t.Fatalf("host/path/token=%q/%q/%q", gotHost, gotPath, gotToken)
 	}
 }
@@ -944,7 +944,7 @@ func TestFilesListUsesEnvdFilesystemRPC(t *testing.T) {
 	if len(entries) != 1 || entries[0].Name != "a.txt" || entries[0].Size != 10 || entries[0].IsDir() {
 		t.Fatalf("entries=%#v", entries)
 	}
-	if gotHost != "49999-sb-fs.cube.test" || gotPath != "/filesystem.Filesystem/ListDir" || gotCT != "application/json" {
+	if gotHost != "49983-sb-fs.cube.test" || gotPath != "/filesystem.Filesystem/ListDir" || gotCT != "application/json" {
 		t.Fatalf("host/path/ct=%q/%q/%q", gotHost, gotPath, gotCT)
 	}
 }


### PR DESCRIPTION

## Summary

Fixes #816. Every envd data-plane RPC in the Go SDK was routed to the sandbox's **Jupyter** port (`49999`) instead of the **envd** port (`49983`), so `Commands.Run`, `Files.*`, `Filesystem.*`, and the `Pty` from #815 all failed against real deployments (non-2xx — `404` or `502` depending on the template's Jupyter upstream). Only `RunCode` (`/execute`) worked, since `/execute` genuinely lives on the Jupyter port.

## Root cause

`newEnvdRequest` — the shared request builder for **all** envd RPCs — hardcoded `s.GetHost(JupyterPort)`. CubeProxy routes by the `<port>-<sandboxID>.<domain>` host prefix, so these requests reached the Jupyter kernel gateway, which does not serve `/process.Process/*`, `/files`, or `/filesystem.Filesystem/*`.

## Changes

- Add a dedicated `EnvdPort = 49983` constant (`sandbox.go`).
- Use `s.GetHost(EnvdPort)` in `newEnvdRequest` (`envd.go`); `RunCode`'s `/execute` stays on `JupyterPort`.
- Update the affected unit-test host assertions (`sdk_test.go`) and the README proxy example.

This matches the Python (`ENVD_PORT`) and Node SDKs, which keep the two ports separate. It's effectively a one-line routing fix — every `newEnvdRequest`-based API (including the PTY in #815) recovers automatically.

## Testing

- `gofmt` / `go vet ./...` clean; `go test -race ./...` green.
- **Live E2E** against a real CubeSandbox (`api=127.0.0.1:13000`, `proxy=127.0.0.1:11080`, `domain=cube.app`): `/files` read/write and `/filesystem.Filesystem/*` (mkdir/list/stat) now succeed on `49983`. Same-sandbox A/B confirms the routing: identical `GET /files` returns non-2xx on `49999` but `200` on `49983` — the port prefix is the only difference.

## Scope

Routing fix only. A separate, independent framing bug on the streaming `/process.Process/Start` request (its body isn't Connect-enveloped in `startProcess`, unlike Python and the Go PTY) is tracked separately and will be its own PR; it does not affect `/files` or `/filesystem.Filesystem/*`.
