### PR TITLE
fix: unify Docker build context and fix ARG scoping

### DIFF
--- a/CubeMaster/Dockerfile
+++ b/CubeMaster/Dockerfile
@@ -18,9 +18,11 @@ ARG CUBE_BUILD_TIME=unknown
 WORKDIR /src
 
 COPY CubeMaster/go.mod CubeMaster/go.sum ./
+COPY cubelog/go.mod cubelog/go.sum /cubelog/
 RUN go mod download
 
 COPY CubeMaster/ ./
+COPY cubelog/ /cubelog/
 
 ENV CGO_ENABLED=0
 RUN set -eux; \
@@ -34,7 +36,7 @@ RUN set -eux; \
         -X 'github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/version.Version=${CUBE_VERSION}' \
         -X 'github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/version.Commit=${CUBE_COMMIT}' \
         -X 'github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/version.BuildTime=${CUBE_BUILD_TIME}'" \
-      ./cmd/cubemaster/...
+      ./cmd/cubemaster
 
 # ── Runtime stage ──────────────────────────────────────────────────────────────
 FROM ubuntu:24.04

--- a/CubeMaster/Dockerfile.dockerignore
+++ b/CubeMaster/Dockerfile.dockerignore
@@ -3,7 +3,10 @@
 #
 # Build-context filter for CubeMaster/Dockerfile (context = repository root).
 # The repo-root .dockerignore is tailored to docker/Dockerfile.builder and would
-# exclude CubeMaster/ without these overrides.
+# exclude CubeMaster/ without these overrides. CubeMaster's go.mod replaces the
+# local cubelog module via ../cubelog, so the image build must include it too.
 **
 !CubeMaster
 !CubeMaster/**
+!cubelog
+!cubelog/**

--- a/deploy/one-click/webui/Dockerfile
+++ b/deploy/one-click/webui/Dockerfile
@@ -21,6 +21,10 @@
 # To override the CubeAPI upstream at runtime, mount a custom nginx.conf:
 #   docker run -p 80:80 -v ./my-nginx.conf:/usr/local/openresty/nginx/conf/nginx.conf:ro cube-webui:v1.0
 
+# Base image ARGs used in FROM must be declared before the first FROM so Docker
+# treats them as global build args available to later stages.
+ARG OPENRESTY_BASE_IMAGE=cube-sandbox-image.tencentcloudcr.com/opensource/openresty:1.21.4.1-6-alpine-fat
+
 # ── Build stage ────────────────────────────────────────────────────────────────
 FROM node:22-alpine AS builder
 
@@ -45,7 +49,6 @@ ENV CUBE_VERSION=${CUBE_VERSION}
 RUN npm run build
 
 # ── Runtime stage ──────────────────────────────────────────────────────────────
-ARG OPENRESTY_BASE_IMAGE=cube-sandbox-image.tencentcloudcr.com/opensource/openresty:1.21.4.1-6-alpine-fat
 FROM ${OPENRESTY_BASE_IMAGE}
 
 RUN sed -i 's#https\?://dl-cdn.alpinelinux.org#http://mirrors.tencent.com#g' /etc/apk/repositories \


### PR DESCRIPTION
## Summary

Three Dockerfile fixes to improve build consistency across the project.

### Changes

- **CubeMaster/Dockerfile**: Include `cubelog` module in build context since CubeMaster go.mod replaces the local cubelog module via relative path (`../cubelog`). Also narrow the go build target from `./cmd/cubemaster/...` to `./cmd/cubemaster`.

- **CubeMaster/Dockerfile.dockerignore**: Whitelist the `cubelog` directory so it is included in the Docker build context, matching the new Dockerfile requirement.

- **deploy/one-click/webui/Dockerfile**: Move `OPENRESTY_BASE_IMAGE` ARG declaration before the first `FROM` instruction so Docker treats it as a global build arg available to all stages.

### Verification
- All changes are Dockerfile/build-config only, no runtime logic affected.