### PR TITLE
fix(sdk): Connect-envelope process.Process/Start and parse exit-0 end…

### DIFF
--- a/sdk/go/envd.go
+++ b/sdk/go/envd.go
@@ -102,12 +102,13 @@ func (s *Sandbox) startProcess(ctx context.Context, payload processStartRequest,
 		return nil, err
 	}
 
-	req, err := s.newEnvdRequest(ctx, http.MethodPost, "/process.Process/Start", nil, bytes.NewReader(raw))
+	req, err := s.newEnvdRequest(ctx, http.MethodPost, "/process.Process/Start", nil, encodeConnectEnvelope(raw))
 	if err != nil {
 		return nil, err
 	}
 	req.Header.Set("Content-Type", connectContentType)
 	req.Header.Set("Connect-Protocol-Version", connectProtocolVersion)
+	req.Header.Set("Connect-Content-Encoding", "identity")
 	req.Header.Set("Authorization", basicAuthUser(opts.User))
 	setConnectTimeout(req, opts.Timeout)
 
@@ -347,6 +348,18 @@ func readConnectEnvelope(r io.Reader) (byte, []byte, error) {
 	return header[0], payload, nil
 }
 
+// encodeConnectEnvelope wraps payload in a Connect streaming message: a 5-byte
+// header (1 flag byte + big-endian uint32 length) followed by the payload. Both
+// request and response messages on a streaming Connect RPC use this framing.
+func encodeConnectEnvelope(payload []byte) io.Reader {
+	buf := bytes.NewBuffer(make([]byte, 0, 5+len(payload)))
+	var header [5]byte
+	binary.BigEndian.PutUint32(header[1:], uint32(len(payload)))
+	buf.Write(header[:])
+	buf.Write(payload)
+	return buf
+}
+
 func parseConnectEndStream(raw []byte) error {
 	if len(raw) == 0 {
 		return nil
@@ -539,15 +552,8 @@ func (s *Sandbox) watchDir(ctx context.Context, path string) (*Watcher, error) {
 		return nil, err
 	}
 
-	var envelope bytes.Buffer
-	var header [5]byte
-	header[0] = 0
-	binary.BigEndian.PutUint32(header[1:], uint32(len(payload)))
-	envelope.Write(header[:])
-	envelope.Write(payload)
-
 	streamCtx, cancel := context.WithCancel(ctx)
-	req, err := s.newEnvdRequest(streamCtx, http.MethodPost, "/filesystem.Filesystem/WatchDir", nil, &envelope)
+	req, err := s.newEnvdRequest(streamCtx, http.MethodPost, "/filesystem.Filesystem/WatchDir", nil, encodeConnectEnvelope(payload))
 	if err != nil {
 		cancel()
 		return nil, err
@@ -643,6 +649,19 @@ func (e *processEndEvent) exitCode() (int, bool) {
 	}
 	if e.ExitCodeSnake != nil {
 		return *e.ExitCodeSnake, true
+	}
+	// envd serializes the end event as proto3 JSON, which omits a zero-valued
+	// exitCode field entirely. A successful (exit 0) process therefore arrives
+	// with no exitCode key at all — only status="exit status 0" and
+	// exited=true. Recover the code from the status string, then fall back to
+	// the exited flag so exit-0 commands don't spuriously fail.
+	if s := strings.TrimSpace(e.Status); strings.HasPrefix(s, "exit status ") {
+		if code, err := strconv.Atoi(strings.TrimSpace(strings.TrimPrefix(s, "exit status "))); err == nil {
+			return code, true
+		}
+	}
+	if e.Exited {
+		return 0, true
 	}
 	return 0, false
 }

--- a/sdk/go/sdk_test.go
+++ b/sdk/go/sdk_test.go
@@ -10,6 +10,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -581,8 +582,18 @@ func TestCommandsRunUsesEnvdProcessStart(t *testing.T) {
 		}
 		gotHost = r.Host
 		gotHeaders = r.Header.Clone()
-		if err := json.NewDecoder(r.Body).Decode(&gotPayload); err != nil {
-			t.Fatalf("decode payload: %v", err)
+		body, _ := io.ReadAll(r.Body)
+		if len(body) < 5 {
+			t.Fatalf("request body too short for a Connect envelope: %d bytes", len(body))
+		}
+		if body[0] != 0 {
+			t.Fatalf("Connect envelope flags=%d, want 0", body[0])
+		}
+		if n := binary.BigEndian.Uint32(body[1:5]); int(n) != len(body)-5 {
+			t.Fatalf("Connect envelope length=%d, want %d", n, len(body)-5)
+		}
+		if err := json.Unmarshal(body[5:], &gotPayload); err != nil {
+			t.Fatalf("decode enveloped payload: %v", err)
 		}
 		w.Header().Set("Content-Type", connectContentType)
 		w.Write(connectEnvelope(0, `{"event":{"start":{"pid":123}}}`))
@@ -622,6 +633,9 @@ func TestCommandsRunUsesEnvdProcessStart(t *testing.T) {
 	if gotHeaders.Get("Content-Type") != connectContentType || gotHeaders.Get("Connect-Protocol-Version") != connectProtocolVersion {
 		t.Fatalf("connect headers=%#v", gotHeaders)
 	}
+	if gotHeaders.Get("Connect-Content-Encoding") != "identity" {
+		t.Fatalf("Connect-Content-Encoding=%q, want identity", gotHeaders.Get("Connect-Content-Encoding"))
+	}
 	if gotHeaders.Get("Connect-Timeout-Ms") != "1500" || gotHeaders.Get("X-Access-Token") != "envd-token" {
 		t.Fatalf("headers=%#v", gotHeaders)
 	}
@@ -641,6 +655,67 @@ func TestCommandsRunUsesEnvdProcessStart(t *testing.T) {
 		t.Fatalf("stdin=%#v", gotPayload["stdin"])
 	}
 	if result.Stdout != "cmd-out\n" || result.Stderr != "cmd-err\n" || result.ExitCode != 7 {
+		t.Fatalf("result=%#v", result)
+	}
+}
+
+func TestProcessEndEventExitCode(t *testing.T) {
+	i := func(v int) *int { return &v }
+	cases := []struct {
+		name string
+		end  processEndEvent
+		code int
+		ok   bool
+	}{
+		{"explicit camelCase", processEndEvent{ExitCode: i(3), Exited: true, Status: "exit status 3"}, 3, true},
+		{"explicit snake_case", processEndEvent{ExitCodeSnake: i(9), Exited: true}, 9, true},
+		{"explicit zero present", processEndEvent{ExitCode: i(0), Exited: true, Status: "exit status 0"}, 0, true},
+		// proto3 JSON omits a zero-valued exitCode: exit-0 arrives as status only.
+		{"exit-0 status only", processEndEvent{Exited: true, Status: "exit status 0"}, 0, true},
+		{"nonzero status only", processEndEvent{Exited: true, Status: "exit status 5"}, 5, true},
+		{"exited flag only", processEndEvent{Exited: true}, 0, true},
+		{"unparsable status but exited", processEndEvent{Exited: true, Status: "signal: killed"}, 0, true},
+		{"nothing", processEndEvent{}, 0, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := tc.end.exitCode()
+			if ok != tc.ok || got != tc.code {
+				t.Fatalf("exitCode()=(%d,%v), want (%d,%v)", got, ok, tc.code, tc.ok)
+			}
+		})
+	}
+}
+
+func TestCommandsRunExitZeroStatusOnly(t *testing.T) {
+	// Reproduces envd's real exit-0 end event: proto3 JSON drops the zero-valued
+	// exitCode, leaving only status/exited. Commands.Run must still succeed.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/process.Process/Start" {
+			t.Fatalf("request=%s %s", r.Method, r.URL.Path)
+		}
+		w.Header().Set("Content-Type", connectContentType)
+		w.Write(connectEnvelope(0, `{"event":{"start":{"pid":7}}}`))
+		w.Write(connectEnvelope(0, fmt.Sprintf(`{"event":{"data":{"stdout":%q}}}`, base64.StdEncoding.EncodeToString([]byte("ok\n")))))
+		w.Write(connectEnvelope(0, `{"event":{"end":{"exited":true,"status":"exit status 0"}}}`))
+		w.Write(connectEnvelope(connectEndStreamFlag, `{}`))
+	}))
+	defer server.Close()
+
+	host, port := serverHostPort(t, server.URL)
+	client := NewClient(Config{
+		ProxyNodeIP:    host,
+		ProxyPortHTTP:  port,
+		SandboxDomain:  "cube.test",
+		RequestTimeout: time.Second,
+	})
+	sb := &Sandbox{client: client, SandboxID: "sb-proc", TemplateID: "tpl-test", EnvdAccessToken: "t"}
+
+	result, err := sb.Commands().Run(context.Background(), "true", CommandOptions{Timeout: time.Second})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if result.ExitCode != 0 || result.Stdout != "ok\n" {
 		t.Fatalf("result=%#v", result)
 	}
 }


### PR DESCRIPTION
## Summary

Two fixes on the Go SDK's `Commands.Run` (`/process.Process/Start`) path, both
required to run a process end-to-end against a real deployment:

1. **Request framing (#825)** — `startProcess` sent the streaming request body as
   raw JSON while advertising `Content-Type: application/connect+json`. A
   server-streaming Connect RPC requires a 5-byte length-prefixed enveloped
   message, so envd read the leading JSON bytes (`{"pr…`) as a frame header,
   decoded a bogus length, and aborted. Now wrapped via a new
   `encodeConnectEnvelope` helper + `Connect-Content-Encoding: identity`,
   matching the Python SDK and the Go PTY path. `watchDir` reuses the same
   helper (previously inlined identical framing).

2. **Exit-0 end-event parsing** — the end event is proto3 JSON, which omits a
   zero-valued `exitCode` entirely, so a successful (exit 0) process arrives as
   only `{"exited":true,"status":"exit status 0"}` and `parseProcessStartStream`
   failed with `process EndEvent missing exit code`. Now recovers the code from
   the `status` string and falls back to the `exited` flag, so exit-0 commands
   (the common case) no longer spuriously fail.

## Changes

- `sdk/go/envd.go`
  - Add `encodeConnectEnvelope`; use it in `startProcess` + set
    `Connect-Content-Encoding: identity`; refactor `watchDir` to reuse it.
  - `processEndEvent.exitCode()`: fall back to parsing `status` (`exit status N`)
    then the `exited` flag when `exitCode`/`exit_code` are absent.
- `sdk/go/sdk_test.go`
  - `TestCommandsRunUsesEnvdProcessStart`: assert the request body is a valid
    Connect envelope and `Connect-Content-Encoding: identity`.
  - Add `TestProcessEndEventExitCode` (table-driven) and
    `TestCommandsRunExitZeroStatusOnly` (exit-0 stream reproduction).

## Root cause (framing) — live A/B, same endpoint/port, only body framing differs

```
[FRAME] raw JSON      -> {"error":{"code":"invalid_argument","message":"protocol error: promised 577794671 bytes in enveloped message, got 50 bytes"}}

[FRAME] Connect frame -> {"event":{"start":{"pid":11}}}
                         {"event":{"data":{"stdout":"aGkK"}}}
                         {"event":{"end":{"exited":true,"status":"exit status 0"}}}
```

Raw JSON → envd's protocol framing error. The 5-byte-enveloped request runs
cleanly (`pid=11`, `stdout=aGkK` = base64 of `hi\n`, `exit status 0`). The
envelope is the only variable.

## Testing

- `go vet ./...` clean; `go test ./...` green (unit tests, incl. the new
  envelope + exit-0 coverage).
- **Live E2E** against a real CubeSandbox (`api=127.0.0.1:13000`,
  `proxy=127.0.0.1:11080`, `domain=cube.app`), with the #816 envd-port fix
  applied so requests reach envd (`49983`):

Framing fix — `/process.Process/Start` streams cleanly:

```
=== RUN   TestIntegrationProcessConnectEnvelope
OK  /process.Process/Start streamed cleanly -> stdout="envd-ok\n" stderr="e\n" exit=3
--- PASS: TestIntegrationProcessConnectEnvelope
```

Exit-0 parsing fix — exit 0 and exit 3 both return correctly:

```
=== RUN   TestIntegrationCommandsExitCodes
OK  exit 0 -> stdout="line-1\nline-2\nline-3\n" exit=0
OK  exit 3 -> stdout="bye\n" exit=3
--- PASS: TestIntegrationCommandsExitCodes (0.76s)
PASS
```

## Notes

- Depends on #816 (envd-port routing) to be exercisable end-to-end; the two are
  distinct bugs on the same code path. Unit tests do not catch either
  (`httptest` mocks never validate request framing and always include a nonzero
  `exitCode`).
- Response parsing was already Connect-aware (`parseProcessStartStream` →
  `readConnectEnvelope`); only the request side and the exit-0 case were wrong.

Closes #825
