### PR TITLE
docs: fix hypervisor documentation typos

### DIFF
--- a/hypervisor/docs/logging.md
+++ b/hypervisor/docs/logging.md
@@ -23,7 +23,7 @@ Users should react to this error by checking their initial VM configuration.
 
 ### `warn!()`
 
-A serious problem has occured but the execution of the VM can continue although some functionality might be impacted.
+A serious problem has occurred but the execution of the VM can continue although some functionality might be impacted.
 
 A typical example of where this level of message should be generated is during an API call request that cannot be fulfilled.
 

--- a/hypervisor/docs/windows.md
+++ b/hypervisor/docs/windows.md
@@ -135,7 +135,7 @@ This section illustrates the Windows specific aspects of the VM network configur
 
 ### Basic Networking
 
-As the simplest option, using `--net tap=` in the Cloud Hypervisor command line will create a `vmtapX` device on the host with the default IPv4 adress `192.168.249.1`. After SAC becomes available, the guest configuration can be set with
+As the simplest option, using `--net tap=` in the Cloud Hypervisor command line will create a `vmtapX` device on the host with the default IPv4 address `192.168.249.1`. After SAC becomes available, the guest configuration can be set with
 
 <pre>
 SAC>i 10 192.168.249.2 255.255.255.0 192.168.249.1

--- a/hypervisor/docs/windows.md
+++ b/hypervisor/docs/windows.md
@@ -209,7 +209,7 @@ In this excercise, [WinDbg](https://docs.microsoft.com/en-us/windows-hardware/dr
 
 #### WinDbg VM
 
-For simplicity, the debugger VM is supposed to be only running under QEMU. It will require VGA and doesn't neccessarily depend on UEFI. As an OS, it can carry any supported Windows OS where the debugger of choice can be installed. The simplest way is to follow the image preparation instructions from the previous chapter, but avoid using the OVMF firmware. It is also not required to use VirtIO drivers, whereby it might be useful in some case. Though, while creating the image file for the debugger VM, be sure to choose a sufficient disk size that counts in the need to save the corresponding debug symbols and sources.
+For simplicity, the debugger VM is supposed to be only running under QEMU. It will require VGA and doesn't necessarily depend on UEFI. As an OS, it can carry any supported Windows OS where the debugger of choice can be installed. The simplest way is to follow the image preparation instructions from the previous chapter, but avoid using the OVMF firmware. It is also not required to use VirtIO drivers, whereby it might be useful in some cases. Though, while creating the image file for the debugger VM, be sure to choose a sufficient disk size that counts in the need to save the corresponding debug symbols and sources.
 
 To create the debugger Windows VM, the following command can be used:
 


### PR DESCRIPTION
## Summary
- fix `occurred` typo in logging docs
- fix `address` typo in Windows networking docs
- fix `necessarily` and pluralize `cases` in Windows debugger VM section
- consolidate documentation fixes previously split across #829 and #830, per maintainer request

## Testing
- not run (documentation-only change)
