### PR TITLE
fix(cubeapi): return conflict for paused sandbox delete

### DIFF
--- a/CubeAPI/src/services/sandboxes.rs
+++ b/CubeAPI/src/services/sandboxes.rs
@@ -26,6 +26,7 @@ const RET_CODE_OK: i32 = 0;
 const RET_CODE_HTTP_OK: i32 = 200;
 const RET_CODE_NOT_FOUND: i32 = 130404;
 const RET_CODE_CONFLICT: i32 = 130409;
+const RET_CODE_MASTER_INTERNAL: i32 = 130593;
 const HOSTDIR_MOUNT_KEY: &str = "host-mount";
 const ENV_VAR_NAME_MAX_LEN: usize = 256;
 const ENV_VAR_VALUE_MAX_LEN: usize = 4096;
@@ -243,11 +244,24 @@ impl SandboxService {
             annotations: None,
         };
 
-        let resp = self
-            .cubemaster
-            .delete_sandbox(&req)
-            .await
-            .map_err(|e| sandbox_not_found_or_internal(e, sandbox_id))?;
+        let resp = match self.cubemaster.delete_sandbox(&req).await {
+            Ok(resp) => resp,
+            Err(
+                e @ CubeMasterError::Api {
+                    ret_code: RET_CODE_MASTER_INTERNAL,
+                    ..
+                },
+            ) => match self.fetch_sandbox_detail(sandbox_id).await {
+                Ok(detail) if detail.status == SandboxStatus::Paused => {
+                    return Err(AppError::Conflict(format!(
+                        "sandbox {} is paused; resume it before deleting",
+                        sandbox_id
+                    )));
+                }
+                _ => return Err(internal_error(e)),
+            },
+            Err(e) => return Err(sandbox_not_found_or_internal(e, sandbox_id)),
+        };
 
         resp.ret
             .into_result()
@@ -899,7 +913,7 @@ mod tests {
     };
     use axum::{
         extract::State,
-        routing::{delete, post},
+        routing::{delete, get, post},
         Json, Router,
     };
     use serde_json::Value;
@@ -1530,6 +1544,65 @@ mod tests {
             }
             other => panic!("expected not found error, got {other:?}"),
         }
+    }
+
+    #[tokio::test]
+    async fn kill_sandbox_returns_conflict_for_paused_delete_state_error() {
+        async fn delete_handler() -> Json<Value> {
+            Json(serde_json::json!({
+                "requestID": "req-delete",
+                "sandbox_id": "sb-paused",
+                "ret": {
+                    "ret_code": super::RET_CODE_MASTER_INTERNAL,
+                    "ret_msg": "backend delete failed"
+                }
+            }))
+        }
+
+        async fn info_handler() -> Json<Value> {
+            Json(serde_json::json!({
+                "requestID": "req-info",
+                "ret": { "ret_code": 0, "ret_msg": "ok" },
+                "data": [{
+                    "sandbox_id": "sb-paused",
+                    "host_id": "host-1",
+                    "status": 5,
+                    "template_id": "tpl-1"
+                }]
+            }))
+        }
+
+        async fn spawn_server(app: Router) -> String {
+            let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+                .await
+                .expect("listener should bind");
+            let addr = listener.local_addr().expect("listener addr");
+            tokio::spawn(async move {
+                axum::serve(listener, app).await.expect("server should run");
+            });
+            format!("http://{}", addr)
+        }
+
+        let cubemaster_url = spawn_server(
+            Router::new()
+                .route("/cube/sandbox", delete(delete_handler))
+                .route("/cube/sandbox/info", get(info_handler)),
+        )
+        .await;
+
+        let service = SandboxService::new(
+            CubeMasterClient::new(cubemaster_url, reqwest::Client::new()),
+            "cubebox".to_string(),
+            "cube.app".to_string(),
+        );
+
+        let err = service
+            .kill_sandbox("sb-paused")
+            .await
+            .expect_err("paused-state delete should return a conflict");
+
+        assert!(matches!(err, crate::error::AppError::Conflict(_)));
+        assert!(err.to_string().contains("resume it before deleting"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes #219.

This PR changes CubeAPI sandbox deletion behavior so deleting a paused sandbox
returns `409 Conflict` instead of surfacing a CubeMaster internal error.

When CubeMaster reports the paused-delete backend error, CubeAPI now checks the
sandbox state. If the sandbox is paused, the API returns a client-actionable
conflict telling the caller to resume the sandbox before deleting it. Other
CubeMaster internal errors keep the existing internal-error behavior.

## Changes

- Map paused sandbox delete failures to `AppError::Conflict`.
- Preserve the existing not-found mapping for missing sandbox deletion.
- Add focused CubeAPI coverage for the paused-delete conflict path.

## Validation

Unit tests — CubeAPI sandbox delete path

```bash
cargo test --manifest-path CubeAPI/Cargo.toml kill_sandbox -- --nocapture
```

```text
    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.30s
     Running unittests src/main.rs (target/debug/deps/cube_api-580ae8bdea1a4d0b)

running 2 tests
test services::sandboxes::tests::kill_sandbox_returns_conflict_for_paused_delete_state_error ... ok
test services::sandboxes::tests::kill_sandbox_maps_cubemaster_not_found_to_app_not_found ... ok

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 80 filtered out; finished in 1.55s
```

Broader sandbox service regression tests:

```bash
cargo test --manifest-path CubeAPI/Cargo.toml services::sandboxes::tests -- --nocapture
```

```text
    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.14s
     Running unittests src/main.rs (target/debug/deps/cube_api-580ae8bdea1a4d0b)

running 23 tests
test services::sandboxes::tests::create_sandbox_accepts_valid_env_var_names ... ok
test services::sandboxes::tests::create_sandbox_request_serializes_lifecycle_flags ... ok
test services::sandboxes::tests::create_sandbox_rejects_invalid_env_var_value ... ok
test services::sandboxes::tests::create_sandbox_rejects_dangerous_env_var_names ... ok
test services::sandboxes::tests::create_sandbox_rejects_invalid_env_var_name_format ... ok
test services::sandboxes::tests::create_sandbox_request_timeout_wire_shape ... ok
test services::sandboxes::tests::create_sandbox_rejects_dangerous_env_var_names_case_insensitive ... ok
test services::sandboxes::tests::listed_sandbox_preserves_resources_from_cubemaster_list ... ok
test services::sandboxes::tests::lifecycle_object_translates_to_cubemaster_bools ... ok
test services::sandboxes::tests::network_context_accepts_allow_out_domain_when_internet_access_disabled ... ok
test services::sandboxes::tests::network_context_ignores_allow_public_traffic_for_outbound_access ... ok
test services::sandboxes::tests::metadata_filter_matches_all_pairs ... ok
test services::sandboxes::tests::listed_sandbox_maps_paused_container_state_from_cubemaster_list ... ok
test services::sandboxes::tests::network_context_rejects_allow_out_domain_without_deny_all ... ok
test services::sandboxes::tests::network_context_rejects_allow_out_domain_when_only_allow_public_traffic_disabled ... ok
test services::sandboxes::tests::network_context_forwards_egress_rules ... ok
test services::sandboxes::tests::network_rules_serialize_to_camel_case_wire ... ok
test services::sandboxes::tests::new_sandbox_timeout_defaults_to_none_when_omitted ... ok
test services::sandboxes::tests::sandbox_update_request_timeout_wire_shape ... ok
test services::sandboxes::tests::kill_sandbox_maps_cubemaster_not_found_to_app_not_found ... ok
test services::sandboxes::tests::kill_sandbox_returns_conflict_for_paused_delete_state_error ... ok
test services::sandboxes::tests::create_sandbox_forwards_create_time_env_vars_to_cubemaster ... ok
test services::sandboxes::tests::create_sandbox_omits_create_time_env_vars_when_absent ... ok

test result: ok. 23 passed; 0 failed; 0 ignored; 0 measured; 59 filtered out; finished in 1.49s
```

Formatting and diff checks:

```bash
cargo fmt --manifest-path CubeAPI/Cargo.toml -- --check
```

```text
<no output>
```

```bash
git diff --check
```

```text
<no output>
```

## Screenshots

Not applicable. This is an API behavior fix.