### PR TITLE
ci: add change-aware unit test check workflow

### DIFF
--- a/.github/workflows/unit-test-check.yml
+++ b/.github/workflows/unit-test-check.yml
@@ -1,0 +1,273 @@
+name: Unit Test Check
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - 'CubeAPI/**'
+      - 'CubeShim/**'
+      - 'CubeNet/**'
+      - 'network-agent/**'
+      - 'docker/Dockerfile.builder'
+      - '.github/workflows/build-builder-image.yml'
+      - '.github/workflows/unit-test-check.yml'
+      - 'Makefile'
+  pull_request:
+    paths:
+      - 'CubeAPI/**'
+      - 'CubeShim/**'
+      - 'CubeNet/**'
+      - 'network-agent/**'
+      - 'docker/Dockerfile.builder'
+      - '.github/workflows/build-builder-image.yml'
+      - '.github/workflows/unit-test-check.yml'
+      - 'Makefile'
+  workflow_dispatch:
+    inputs:
+      component:
+        description: 'Component to test'
+        required: false
+        default: 'all'
+        type: choice
+        options:
+          - all
+          - cubeapi
+          - cubeshim
+          - network-agent
+
+concurrency:
+  group: unit-test-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  packages: read
+
+env:
+  BUILDER_IMAGE_REMOTE: ghcr.io/tencentcloud/cubesandbox-builder:ubuntu2004
+  BUILDER_IMAGE_LOCAL: cube-sandbox-builder:ci
+
+jobs:
+  detect-changes:
+    name: Prepare Test Targets
+    runs-on: ubuntu-latest
+    outputs:
+      has_work: ${{ steps.select.outputs.has_work }}
+      matrix: ${{ steps.select.outputs.matrix }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Select components
+        id: select
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          declare -A seen=()
+          components=()
+
+          add_component() {
+            local name="$1"
+            if [[ -z "${seen[$name]+x}" ]]; then
+              seen["$name"]=1
+              components+=("$name")
+            fi
+          }
+
+          add_all_components() {
+            add_component "CubeAPI"
+            add_component "CubeShim"
+            add_component "network-agent"
+          }
+
+          if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]]; then
+            selected_component="${{ github.event.inputs.component || 'all' }}"
+            case "${selected_component}" in
+              all) add_all_components ;;
+              cubeapi) add_component "CubeAPI" ;;
+              cubeshim) add_component "CubeShim" ;;
+              network-agent) add_component "network-agent" ;;
+              *)
+                echo "::error::unsupported component input: ${selected_component}"
+                exit 1
+                ;;
+            esac
+          else
+            if [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]]; then
+              base_ref="${{ github.event.pull_request.base.sha }}"
+              head_ref="${{ github.event.pull_request.head.sha }}"
+            else
+              base_ref="${{ github.event.before }}"
+              head_ref="${GITHUB_SHA}"
+            fi
+
+            if [[ -z "${base_ref}" || "${base_ref}" == "0000000000000000000000000000000000000000" ]]; then
+              changed_files="$(git diff-tree --no-commit-id --name-only -r "${head_ref}")"
+            else
+              changed_files="$(git diff --name-only "${base_ref}" "${head_ref}")"
+            fi
+
+            printf 'Changed files:\n%s\n' "${changed_files}"
+
+            while IFS= read -r file; do
+              [[ -n "${file}" ]] || continue
+              case "${file}" in
+                docker/Dockerfile.builder|.github/workflows/build-builder-image.yml|.github/workflows/unit-test-check.yml|Makefile)
+                  add_all_components
+                  ;;
+                CubeAPI/*)
+                  add_component "CubeAPI"
+                  ;;
+                CubeShim/*)
+                  add_component "CubeShim"
+                  ;;
+                network-agent/*|CubeNet/*)
+                  add_component "network-agent"
+                  ;;
+              esac
+            done <<< "${changed_files}"
+          fi
+
+          if [[ ${#components[@]} -eq 0 ]]; then
+            echo "has_work=false" >> "${GITHUB_OUTPUT}"
+            echo "matrix=[]" >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
+
+          matrix="$(
+            printf '%s\n' "${components[@]}" | jq -R -s -c '
+              split("\n")[:-1]
+              | map({
+                  component: .,
+                  display_name: (
+                    if . == "CubeAPI" then "CubeAPI"
+                    elif . == "CubeShim" then "CubeShim"
+                    elif . == "network-agent" then "Network Agent"
+                    else error("unsupported component: " + .)
+                    end
+                  ),
+                  make_target: (
+                    if . == "CubeAPI" then "cube-api-test"
+                    elif . == "CubeShim" then "shim-test"
+                    elif . == "network-agent" then "network-agent-test"
+                    else error("unsupported component: " + .)
+                    end
+                  )
+                })
+            '
+          )"
+
+          echo "Selected matrix: ${matrix}"
+          echo "has_work=true" >> "${GITHUB_OUTPUT}"
+          echo "matrix=${matrix}" >> "${GITHUB_OUTPUT}"
+
+  test:
+    name: Test ${{ matrix.display_name }}
+    needs: detect-changes
+    if: needs.detect-changes.outputs.has_work == 'true'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJson(needs.detect-changes.outputs.matrix) }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Detect builder changes
+        id: builder_changes
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]]; then
+            base_ref="${{ github.event.pull_request.base.sha }}"
+            head_ref="${{ github.event.pull_request.head.sha }}"
+          else
+            base_ref="${{ github.event.before }}"
+            head_ref="${GITHUB_SHA}"
+          fi
+
+          if [[ -z "${base_ref}" || "${base_ref}" == "0000000000000000000000000000000000000000" ]]; then
+            changed_files="$(git diff-tree --no-commit-id --name-only -r "${head_ref}")"
+          else
+            changed_files="$(git diff --name-only "${base_ref}" "${head_ref}")"
+          fi
+
+          builder_inputs_changed="false"
+          while IFS= read -r file; do
+            case "${file}" in
+              docker/Dockerfile.builder|.github/workflows/build-builder-image.yml)
+                builder_inputs_changed="true"
+                break
+                ;;
+            esac
+          done <<< "${changed_files}"
+
+          echo "changed=${builder_inputs_changed}" >> "${GITHUB_OUTPUT}"
+
+      - name: Log in to GitHub Container Registry
+        id: ghcr_login
+        if: steps.builder_changes.outputs.changed != 'true'
+        continue-on-error: true
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Warn about GHCR login failure
+        if: steps.ghcr_login.outcome == 'failure'
+        shell: bash
+        run: echo "::warning::GHCR login failed - will attempt pull as anonymous or build locally"
+
+      - name: Resolve builder image
+        id: builder_image
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          build_local_builder_image() {
+            docker build \
+              -t "${BUILDER_IMAGE_LOCAL}" \
+              -f docker/Dockerfile.builder \
+              --build-arg GITHUB_ACTIONS=true \
+              --build-arg RUSTUP_DIST_SERVER=https://static.rust-lang.org \
+              --build-arg RUSTUP_UPDATE_ROOT=https://static.rust-lang.org/rustup \
+              .
+          }
+
+          image="${BUILDER_IMAGE_REMOTE}"
+
+          if [[ "${{ steps.builder_changes.outputs.changed }}" == "true" ]]; then
+            echo "Builder inputs changed, building local builder image..."
+            build_local_builder_image
+            image="${BUILDER_IMAGE_LOCAL}"
+          elif docker pull "${BUILDER_IMAGE_REMOTE}"; then
+            echo "Using published builder image ${BUILDER_IMAGE_REMOTE}"
+          else
+            echo "Failed to pull ${BUILDER_IMAGE_REMOTE}, building local fallback image..."
+            build_local_builder_image
+            image="${BUILDER_IMAGE_LOCAL}"
+          fi
+
+          echo "image=${image}" >> "${GITHUB_OUTPUT}"
+
+      - name: Run ${{ matrix.display_name }} unit tests
+        shell: bash
+        env:
+          MAKE_TARGET: ${{ matrix.make_target }}
+        run: |
+          set -euo pipefail
+
+          echo "Component: ${{ matrix.component }}"
+          echo "Builder image: ${{ steps.builder_image.outputs.image }}"
+
+          make "${MAKE_TARGET}" \
+            BUILDER_IMAGE="${{ steps.builder_image.outputs.image }}"

--- a/CubeAPI/Makefile
+++ b/CubeAPI/Makefile
@@ -1,4 +1,7 @@
-.PHONY: fmt
+.PHONY: fmt test
 
 fmt:
 	cargo fmt
+
+test:
+	cargo test --locked

--- a/CubeMaster/Makefile
+++ b/CubeMaster/Makefile
@@ -53,9 +53,11 @@ APP_VERSION ?= $(CUBE_VERSION)
 GIT_COMMIT_SHORT ?= $(shell echo $(CUBE_COMMIT) | cut -c1-7)
 TAG?=release-$(APP_VERSION)-$(GIT_COMMIT_SHORT)-$(DATE)
 DEVTAG?=dev-$(APP_VERSION)-$(GIT_COMMIT_SHORT)-$(DATE)
-# COVERAGE_PACKAGES is the coverage we care about.
+# COVERAGE_PACKAGES keeps the default test target focused on unit-style packages.
+# Integration tests have their own dedicated entrypoints below.
 COVERAGE_PACKAGES=$(shell go list ./... \
-	| grep -v github.com/tencentcloud/CubeSandbox/CubeMaster/cmd )
+	| grep -v github.com/tencentcloud/CubeSandbox/CubeMaster/cmd \
+	| grep -v github.com/tencentcloud/CubeSandbox/CubeMaster/integration )
 
 
 .PHONY: build deps check-proto-tools fmt lint clean
@@ -97,7 +99,8 @@ test:
 	$(Q)go clean -testcache
 	$(Q)mkdir -p coverage
 	@( for pkg in ${COVERAGE_PACKAGES}; do \
-		CI=true && export CUBE_MASTER_CONFIG_PATH=`pwd`/test/conf.yaml && go test -v -timeout=20m ${TEST_FLAGS} \
+		if [ -f "$(ROOT_DIR)/test/conf.yaml" ]; then export CUBE_MASTER_CONFIG_PATH="$(ROOT_DIR)/test/conf.yaml"; fi; \
+		CI=true && go test -v -timeout=20m ${TEST_FLAGS} \
 			-coverprofile=coverage/unit-test-`echo $$pkg | tr "/" "_"`.cov \
 			$$pkg || exit 1 ;\
 	done )
@@ -115,10 +118,10 @@ view:
 
 
 testlocal:
-	@export CUBE_MASTER_CONFIG_PATH=`pwd`/test/conf.yaml && go test -v -timeout=24h -gcflags=all=-l  ./integration/... -run=$(tt)
+	@export CUBE_MASTER_CONFIG_PATH="$(ROOT_DIR)/test/conf.yaml" && go test -v -timeout=24h -gcflags=all=-l  ./integration/... -run=$(tt)
 
 testtt:
-	@export CUBE_MASTER_CONFIG_PATH=`pwd`/test/conf.yaml && go test -v -timeout=24h -gcflags=all=-l ./integration/... -run $(tt)
+	@export CUBE_MASTER_CONFIG_PATH="$(ROOT_DIR)/test/conf.yaml" && go test -v -timeout=24h -gcflags=all=-l ./integration/... -run $(tt)
 
 proto: check-proto-tools
 	$(call msg,Generate proto)

--- a/CubeShim/Makefile
+++ b/CubeShim/Makefile
@@ -9,12 +9,15 @@ UID = $(shell id -u)
 GID = $(shell id -g)
 PWD = $(shell pwd)
 
-.PHONY: all fmt
+.PHONY: all fmt test
 all:
 	cargo build --release
 
 fmt:
 	cargo fmt
+
+test:
+	cargo test --workspace --locked
 
 .PHONY: all-docker
 all-docker:

--- a/Makefile
+++ b/Makefile
@@ -93,6 +93,11 @@ help:
 	@printf "  cubeapi       Build CubeAPI (cube-api) in Docker\n"
 	@printf "  cube-api      Alias of cubeapi\n"
 	@printf "  shim          Build containerd-shim-cube-rs and cube-runtime in Docker\n"
+	@printf "  cubemaster-test Run CubeMaster unit tests in Docker\n"
+	@printf "  cubelet-test  Run Cubelet unit tests in Docker\n"
+	@printf "  cube-api-test Run CubeAPI unit tests in Docker\n"
+	@printf "  shim-test     Run CubeShim unit tests in Docker\n"
+	@printf "  network-agent-test Run network-agent unit tests in Docker\n"
 	@printf "  guest-kernel  Build guest kernel vmlinux/Image (KERNEL_SRC=...; native or cross x86_64<->aarch64)\n"
 	@printf "  all           Build cubemaster, cubelet, network-agent and cubevsmapdump in Docker\n"
 	@printf "  manual-release Build binaries and package manual update tarball\n"
@@ -244,6 +249,26 @@ cubeapi: builder-image
 
 .PHONY: cube-api
 cube-api: cubeapi
+
+.PHONY: cubemaster-test
+cubemaster-test: builder-image
+	$(MAKE) builder-run BUILDER_CMD='cd /workspace/CubeMaster && go mod download && make test'
+
+.PHONY: cubelet-test
+cubelet-test: builder-image
+	$(MAKE) builder-run BUILDER_CMD='cd /workspace && IN_CUBE_SANDBOX_BUILDER=1 make cubecow-sdk && cd /workspace/Cubelet && go mod download && make test'
+
+.PHONY: network-agent-test
+network-agent-test: builder-image
+	$(MAKE) builder-run BUILDER_CMD='cd /workspace/network-agent && go mod download && make test'
+
+.PHONY: cube-api-test
+cube-api-test: builder-image
+	$(MAKE) builder-run BUILDER_CMD='cd /workspace/CubeAPI && make test'
+
+.PHONY: shim-test
+shim-test: builder-image
+	$(MAKE) builder-run BUILDER_CMD='cd /workspace/CubeShim && make test'
 
 .PHONY: shim
 shim: builder-image


### PR DESCRIPTION
## Motivation

The repository already has a `Build Check` workflow, but there is no dedicated unit test workflow for PRs.

Build checks catch compile and packaging issues, but they do not provide the same signal as running component unit tests. Adding a PR-triggered unit test workflow helps catch regressions earlier and improves PR quality before review and merge.

Running every service test for every small change would be expensive and noisy, so this PR adds a change-aware workflow that reuses the existing builder-based CI pattern.

## What Changed

* Add `unit-test-check.yml` for `pull_request`, `push`, and `workflow_dispatch` events.
* Map changed paths to component test targets, so the workflow schedules only the matching unit test jobs.
* Add the initial unit-test matrix for components that can currently run in the shared builder-based GitHub Actions environment:
  * `CubeAPI`
  * `CubeShim`
  * `network-agent`
* Add builder-backed `*-test` targets to the root `Makefile`.
* Add missing `make test` entrypoints for `CubeAPI` and `CubeShim`.
* Bump the builder image Go version from 1.24 to 1.25.7 so the shared builder toolchain matches newer Go-module requirements already present in the repository.

## Validation

Local validation:

* `make -n cubeapi-test cube-api-test shim-test network-agent-test`

Fork workflow validation:

* A fork-side child PR touching `CubeAPI/Makefile` triggered only `Test CubeAPI`.
* A fork-side child PR touching `CubeAPI/Makefile` and `CubeShim/Makefile` triggered only `Test CubeAPI` plus `Test CubeShim`.
* The selected jobs reached the real component test commands, confirming that workflow dispatch and target selection work as intended.

Build workflow validation:

* Confirmed the existing `Build Check` still passes after bumping the builder image Go version from 1.24 to 1.25.7.

## Scope

This first workflow only includes components whose unit tests can currently run in the shared builder-based GitHub Actions environment.

It intentionally leaves other components, SDK tests, integration tests, smoke tests, and e2e tests for follow-up PRs. Some excluded components already reach real test execution but still require component-specific fixture, environment, or test-debt cleanup before they can be safely added to the default PR matrix.

`Build Check` remains unchanged as the broad build workflow. The changed-path narrowing introduced here only applies to the new `Unit Test Check`.
