### PR TITLE
[Feature](tests): add SDK compatibility e2e suite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,11 @@ docs/image.png
 __pycache__
 /design
 /plan
-/tests
+/tests/*
+!/tests/e2e/
+/tests/e2e/*
+!/tests/e2e/sdk_compat/
+!/tests/e2e/sdk_compat/**
+/tests/e2e/sdk_compat/.pytest_cache/
 
 web/tsconfig.tsbuildinfo

--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,8 @@ docs/dev-log.md
 docs/image-1.png
 docs/image.png
 
+# Keep the SDK compatibility E2E suite tracked while ignoring other test
+# directories and its generated local pytest cache.
 __pycache__
 /design
 /plan

--- a/tests/e2e/sdk_compat/.gitignore
+++ b/tests/e2e/sdk_compat/.gitignore
@@ -1,0 +1,7 @@
+.pytest_cache/
+.venv/
+.env
+*.env.local
+**/__pycache__/
+reports/*
+!reports/.gitignore

--- a/tests/e2e/sdk_compat/README.md
+++ b/tests/e2e/sdk_compat/README.md
@@ -158,7 +158,7 @@ Run dual backend after installing E2B:
 
 ```bash
 pip install e2b-code-interpreter
-export E2B_API_KEY=e2b_000000
+export E2B_API_KEY=<your-e2b-api-key>
 export SSL_CERT_FILE=/root/.local/share/mkcert/rootCA.pem
 export SDK_E2E_BACKENDS=e2b,cubesandbox
 pytest --run-e2e
@@ -328,6 +328,7 @@ Priority markers:
 - `p1`: daily compatibility regression.
 - `p2`: weekly or broader feature coverage.
 - `p3`: release qualification and long-running scenarios.
+- `slow`: tests that exceed the normal PR time budget.
 
 Capability markers:
 
@@ -336,7 +337,7 @@ Capability markers:
 - `@pytest.mark.requires_cubeproxy`: platform lifecycle cases that depend on cube-proxy and lifecycle-manager coordination. Skipped unless `SDK_E2E_PLATFORM_LIFECYCLE=true`.
 - Common capabilities include `lifecycle`, `commands`, `filesystem`, and `run_code`.
 - Shared optional capabilities include `pause_resume`, `network_allow_deny`, and `network_public_access`.
-- CubeSandbox-specific extended capabilities currently include `network_l7_rules` and `proxy_url`.
+- `platform_lifecycle` is available only to CubeSandbox platform-managed lifecycle cases.
 
 ## Cleanup
 

--- a/tests/e2e/sdk_compat/README.md
+++ b/tests/e2e/sdk_compat/README.md
@@ -1,0 +1,347 @@
+# SDK Compatibility E2E Tests
+
+This directory contains live end-to-end tests for Python SDK compatibility. The
+same backend-neutral cases run against:
+
+- `cubesandbox`: the CubeSandbox Python SDK from `sdk/python`.
+- `e2b`: the E2B Python SDK (`e2b-code-interpreter` or `e2b`) against a CubeSandbox-compatible backend.
+
+The suite is opt-in. Without `--run-e2e`, pytest collection is safe and all cases
+are skipped. Live runs default to the `cubesandbox` backend so PR-gate runs stay
+small and stable. Use `SDK_E2E_BACKENDS=e2b,cubesandbox` for dual-SDK
+compatibility runs.
+
+Documentation:
+
+- [Framework design](docs/framework-design.md)
+- [Case authoring guide](docs/case-authoring.md)
+- [中文 README](README_zh.md)
+- [中文框架设计](docs/framework-design.zh-CN.md)
+- [中文用例编写指南](docs/zh/case-authoring.md)
+
+## Backend Environment Variables
+
+`cubesandbox` backend:
+
+- `CUBE_API_URL`: CubeAPI endpoint. Defaults to `http://127.0.0.1:3000`.
+- `CUBE_TEMPLATE_ID`: ready template ID used for sandbox creation.
+- `CUBE_API_KEY`: API key if the target CubeAPI requires one.
+- `CUBE_PROXY_NODE_IP`: optional CubeProxy node IP, useful when wildcard sandbox
+  DNS is unavailable from the runner.
+
+`e2b` backend:
+
+- `SDK_E2E_BACKENDS=e2b` or `SDK_E2E_BACKENDS=e2b,cubesandbox`: enables the
+  E2B backend.
+- `CUBE_API_URL`: E2B-compatible CubeSandbox control-plane endpoint. The
+  adapter passes this value to the E2B SDK explicitly.
+- `E2B_API_KEY`: API key used by the E2B SDK. For a self-hosted CubeSandbox
+  endpoint, use the key accepted by that endpoint.
+- `CUBE_TEMPLATE_ID`: ready CubeSandbox template ID used for sandbox creation.
+- `SSL_CERT_FILE`: local CA bundle for self-hosted HTTPS sandbox endpoints.
+
+Shared timeout, reporting, tracing, and lifecycle variables are listed in the
+[Environment](#environment) section.
+
+## Prepare Template
+
+Create a Code Interpreter capable template before running live E2E tests. The
+template must expose envd (`49983`) and Jupyter/Code Interpreter (`49999`):
+
+```bash
+cubemastercli tpl create-from-image \
+  --image cube-sandbox-cn.tencentcloudcr.com/cube-sandbox/sandbox-code:latest \
+  --writable-layer-size 1G \
+  --expose-port 49999 \
+  --expose-port 49983 \
+  --probe 49999
+```
+
+Use the generated template ID as `CUBE_TEMPLATE_ID` in the commands below.
+
+## Quick Start
+
+```bash
+cd tests/e2e/sdk_compat
+python3 -m venv .venv
+. .venv/bin/activate
+pip install -r requirements.txt
+
+export CUBE_API_URL=http://127.0.0.1:3000
+export CUBE_TEMPLATE_ID=tpl-xxxxxxxxxxxxxxxxxxxxxxxx
+export CUBE_PROXY_NODE_IP=127.0.0.1
+
+pytest --run-e2e
+```
+
+The default command above runs only the `cubesandbox` backend. Equivalent explicit
+form:
+
+```bash
+pytest --run-e2e --sdk-e2e-backends=cubesandbox
+```
+
+## Execution Scope
+
+Recommended scopes:
+
+```bash
+# Fast environment smoke
+pytest --run-e2e -m smoke
+
+# PR gate: stable CubeSandbox backend coverage
+pytest --run-e2e -m "smoke or p0" --sdk-e2e-backends=cubesandbox
+
+# Daily dual-SDK compatibility
+SDK_E2E_BACKENDS=e2b,cubesandbox pytest --run-e2e -m "p0 or p1"
+
+# Platform lifecycle regression (cube-proxy + lifecycle manager)
+SDK_E2E_PLATFORM_LIFECYCLE=true pytest --run-e2e -k lifecycle -m "p1 and slow"
+
+# Broader regression
+SDK_E2E_BACKENDS=e2b,cubesandbox pytest --run-e2e -m "p0 or p1 or p2"
+```
+
+Run one test suite, file, or test case:
+
+```bash
+# One test suite by marker
+pytest --run-e2e -m lifecycle
+
+# One lifecycle test file
+pytest --run-e2e cases/lifecycle/test_pause_resume.py
+
+# One test function
+pytest --run-e2e cases/lifecycle/test_pause_resume.py::test_pause_sets_state_paused
+
+# One parametrized backend explicitly
+pytest --run-e2e \
+  --sdk-e2e-backends=cubesandbox \
+  cases/lifecycle/test_pause_resume.py::test_pause_sets_state_paused[cubesandbox]
+
+# Select tests by keyword
+pytest --run-e2e -k "pause and resume"
+```
+
+Use `--collect-only -q` to inspect the exact node IDs before running a
+parameterized test:
+
+```bash
+pytest --collect-only -q cases/lifecycle/test_pause_resume.py
+```
+
+Run platform-managed lifecycle cases (`auto-pause`, `auto-resume`, and
+`auto-kill`):
+
+```bash
+# Required opt-in for the four slow cases in test_auto_lifecycle.py.
+export SDK_E2E_PLATFORM_LIFECYCLE=true
+
+# Recommended so preflight can probe CubeProxy admin heartbeat.
+export CUBE_PROXY_NODE_IP=<cube-proxy-node-ip>
+
+pytest --run-e2e --sdk-e2e-trace \
+  cases/lifecycle/test_auto_lifecycle.py
+```
+
+These cases are skipped unless `SDK_E2E_PLATFORM_LIFECYCLE=true` is set because
+they depend on the full platform chain: CubeProxy, Redis, cube-lifecycle-manager,
+CubeMaster, and Cubelet. They also require a `READY` template on all target
+compute nodes. To run only one case:
+
+```bash
+pytest --run-e2e --sdk-e2e-trace \
+  cases/lifecycle/test_auto_lifecycle.py::test_lifecycle_auto_resume_preserves_state
+```
+
+Run dual backend after installing E2B:
+
+```bash
+pip install e2b-code-interpreter
+export E2B_API_KEY=e2b_000000
+export SSL_CERT_FILE=/root/.local/share/mkcert/rootCA.pem
+export SDK_E2E_BACKENDS=e2b,cubesandbox
+pytest --run-e2e
+```
+
+## Environment
+
+The suite automatically loads `tests/e2e/sdk_compat/.env` if the file exists.
+Values already exported in the shell take precedence over `.env` values. Copy
+`env.example` to `.env` for local runs:
+
+```bash
+cp env.example .env
+```
+
+The built-in `.env` loader is intentionally small: it supports one `KEY=VALUE`
+entry per line and simple single/double quoted values. It does not support
+multiline quoted values. Export multiline secrets, private keys, or complex
+values in the shell instead of placing them in `.env`.
+
+Required:
+
+- `CUBE_API_URL`: CubeAPI endpoint.
+- `CUBE_TEMPLATE_ID`: ready template ID used for sandbox creation.
+
+Optional:
+
+- `SDK_E2E_BACKENDS`: comma-separated backend list. Defaults to `cubesandbox`.
+- `CUBE_API_KEY`: API key if the target environment requires one.
+- `E2B_API_KEY`: required when running the `e2b` backend. For a self-hosted
+  CubeSandbox endpoint, use the API key accepted by that endpoint. The adapter
+  falls back to `CUBE_API_KEY` when `E2B_API_KEY` is not set, but setting it
+  explicitly is recommended.
+- `CUBE_PROXY_NODE_IP`: useful when wildcard sandbox DNS is unavailable from the runner.
+- `CUBE_PROXY_PORT_HTTP`: defaults to `80`.
+- `CUBE_SANDBOX_DOMAIN`: defaults to `cube.app`.
+- `SDK_E2E_DEFAULT_TIMEOUT`: default timeout for operations such as explicit
+  connect and cleanup resume. Defaults to `120`.
+- `SDK_E2E_API_TIMEOUT`: CubeAPI control-plane request timeout in seconds for
+  preflight, diagnostics, and cleanup. Defaults to `5`.
+- `SDK_E2E_CREATE_TIMEOUT`: sandbox create timeout in seconds. Defaults to `120`.
+- `SDK_E2E_COMMAND_TIMEOUT`: command timeout in seconds. Defaults to `30`.
+- `SDK_E2E_RUN_CODE_TIMEOUT`: code execution timeout in seconds. Defaults to `60`.
+- `SDK_E2E_NETWORK_PROBE_TIMEOUT`: TCP probe socket timeout in seconds for
+  network policy cases. Defaults to `5`.
+- `SDK_E2E_KEEP_SANDBOX_ON_FAILURE`: preserve only sandboxes whose test setup
+  or call phase failed. Passed and skipped tests are still cleaned up. Defaults
+  to `false`.
+- `SDK_E2E_TRACE`: print every SDK adapter operation and include traces for
+  passed tests in JSONL. Equivalent to `--sdk-e2e-trace`. Defaults to `false`.
+- `SDK_E2E_SKIP_INTERNET_TESTS`: skip tests marked `requires_internet` when
+  the runner or environment has no stable public egress. Defaults to `false`.
+- `SDK_E2E_REPORT_DIR`: JSONL report directory. Defaults to `reports/sdk-dual`.
+- `CUBE_PYTHON_SDK_PATH`: override local CubeSandbox Python SDK path.
+- `SDK_E2E_PLATFORM_LIFECYCLE`: enable platform-managed lifecycle cases
+  (`auto-pause`, `auto-resume`, `auto-kill`). Defaults to `false`.
+- `SDK_E2E_PLATFORM_LIFECYCLE_IDLE_TIMEOUT`: idle timeout in seconds for
+  platform lifecycle cases. Defaults to `30`.
+- `SDK_E2E_PLATFORM_LIFECYCLE_WAIT_MARGIN`: extra seconds to wait after the
+  idle timeout for the lifecycle sweeper. Defaults to `20`.
+- `SDK_E2E_PLATFORM_LIFECYCLE_POLL_TIMEOUT`: extra polling window after the
+  initial wait. Defaults to `45`.
+- `CUBE_PROXY_ADMIN_PORT`: CubeProxy admin port used by the lifecycle probe.
+  Defaults to `8082`.
+
+For self-hosted HTTPS sandbox endpoints, trust the local CA:
+
+```bash
+export SSL_CERT_FILE=/root/.local/share/mkcert/rootCA.pem
+```
+
+The E2B backend does not disable TLS verification. Self-hosted environments must
+provide a trusted CA via `SSL_CERT_FILE` or the system trust store.
+
+## Preflight
+
+When `--run-e2e` is enabled, a session preflight runs once before per-test
+sandbox creation. It checks:
+
+- `CUBE_TEMPLATE_ID` or `--cube-template-id` is present.
+- `GET /health` on `CUBE_API_URL` is reachable.
+- `GET /templates/{template_id}` returns the selected template.
+- If the template response exposes `status` or `state`, it is ready-like:
+  `ready`, `active`, or `available`.
+
+Preflight failures are recorded as `preflight_failed` and stop the run early with
+a single diagnostic message. When `SDK_E2E_PLATFORM_LIFECYCLE=true`, preflight also
+probes CubeProxy admin health (`heartbeat_last_pushed_ms`) when
+`CUBE_PROXY_NODE_IP` is set.
+
+## Reporting
+
+The suite writes JSONL events to `SDK_E2E_REPORT_DIR/events.jsonl`.
+
+To generate a standard HTML report, pass pytest-html options explicitly:
+
+```bash
+pytest --run-e2e -m lifecycle \
+  --html=reports/sdk-dual/report.html \
+  --self-contained-html
+```
+
+To generate a JUnit XML report for CI systems:
+
+```bash
+pytest --run-e2e -m lifecycle \
+  --junit-xml=reports/sdk-dual/junit.xml
+```
+
+Event types:
+
+- `preflight_passed` / `preflight_failed`: live environment readiness.
+- `sandbox_created`: backend, sandbox ID, and pytest node ID.
+- `sandbox_cleanup` / `sandbox_kept`: teardown outcome.
+- `test_result`: pytest phase, outcome, duration, backend, sandbox ID, and failure diagnostics.
+
+Failed `test_result` events include `error` and best-effort `sandbox_info` when
+available. They also include a bounded SDK operation trace with create/connect,
+command, code, file, lifecycle, and cleanup calls. Sensitive keys and environment
+values are redacted, large strings and collections are truncated, and file
+contents are represented by length rather than plaintext.
+
+Failed tests automatically print the most recent SDK operations to the terminal.
+For live input/output tracing of every operation, use:
+
+```bash
+pytest --run-e2e --sdk-e2e-trace \
+  cases/lifecycle/test_pause_resume.py::test_pause_sets_state_paused
+
+# Equivalent environment form
+SDK_E2E_TRACE=true pytest --run-e2e -m lifecycle
+```
+
+Trace mode may expose non-secret command/code output in the terminal. JSONL
+redaction remains enabled in both normal and trace modes.
+
+## Layout
+
+```text
+tests/e2e/sdk_compat/
+  adapters/      # SDK-specific shims over a shared adapter interface
+  framework/     # config, preflight, capability flags, cleanup, reporting
+  cases/         # backend-neutral cases split by capability domain
+  reports/       # local JSONL events, ignored except reports/.gitignore
+```
+
+Current capability domains:
+
+- `cases/lifecycle/`: create/info smoke, connect, create options, pause/resume,
+  kill, and platform-managed auto-pause/auto-resume/auto-kill coverage.
+- `cases/commands/`: stdout, stderr, exit code, env, special characters, multiline output, missing command.
+- `cases/filesystem/`: read/write, overwrite, multiline content, file API and shell interoperability.
+- `cases/run_code/`: expression text, stdout, kernel state, Python error reporting.
+- `cases/network/`: create-time network policy for allow/deny and public egress access.
+
+Keep new cases backend-neutral. Add backend-specific behavior through capability
+markers instead of branching inside test bodies. Future domains can be added next
+to the existing directories, for example `network/`, `proxy/`, `metadata/`,
+`errors/`, and `concurrency/`.
+
+## Markers And Capabilities
+
+Priority markers:
+
+- `smoke`: minimum live-environment checks.
+- `p0`: PR-gate compatibility coverage.
+- `p1`: daily compatibility regression.
+- `p2`: weekly or broader feature coverage.
+- `p3`: release qualification and long-running scenarios.
+
+Capability markers:
+
+- `@pytest.mark.requires_capability("<name>")`: skip or deselect unsupported backends.
+- `@pytest.mark.sandbox_create_options(...)`: pass SDK create-time options such as `network`, `env_vars`, or `lifecycle`.
+- `@pytest.mark.requires_cubeproxy`: platform lifecycle cases that depend on cube-proxy and lifecycle-manager coordination. Skipped unless `SDK_E2E_PLATFORM_LIFECYCLE=true`.
+- Common capabilities include `lifecycle`, `commands`, `filesystem`, and `run_code`.
+- Shared optional capabilities include `pause_resume`, `network_allow_deny`, and `network_public_access`.
+- CubeSandbox-specific extended capabilities currently include `network_l7_rules` and `proxy_url`.
+
+## Cleanup
+
+Each test creates its own sandbox and destroys it in teardown. If SDK teardown
+fails, the suite falls back to `DELETE /sandboxes/{sandboxID}` against
+`CUBE_API_URL`.
+
+Set `SDK_E2E_KEEP_SANDBOX_ON_FAILURE=true` to preserve sandboxes while debugging.

--- a/tests/e2e/sdk_compat/README.md
+++ b/tests/e2e/sdk_compat/README.md
@@ -189,9 +189,10 @@ Optional:
 - `SDK_E2E_BACKENDS`: comma-separated backend list. Defaults to `cubesandbox`.
 - `CUBE_API_KEY`: API key if the target environment requires one.
 - `E2B_API_KEY`: required when running the `e2b` backend. For a self-hosted
-  CubeSandbox endpoint, use the API key accepted by that endpoint. The adapter
-  falls back to `CUBE_API_KEY` when `E2B_API_KEY` is not set, but setting it
-  explicitly is recommended.
+  CubeSandbox endpoint, use the API key accepted by that endpoint.
+- `SDK_E2E_E2B_VALIDATE_API_KEY`: enable the E2B SDK's client-side `e2b_*`
+  API key format check. Defaults to `false` for self-hosted deployments that
+  issue keys in another format. Server-side authentication remains enabled.
 - `CUBE_PROXY_NODE_IP`: useful when wildcard sandbox DNS is unavailable from the runner.
 - `CUBE_PROXY_PORT_HTTP`: defaults to `80`.
 - `CUBE_SANDBOX_DOMAIN`: defaults to `cube.app`.
@@ -204,6 +205,11 @@ Optional:
 - `SDK_E2E_RUN_CODE_TIMEOUT`: code execution timeout in seconds. Defaults to `60`.
 - `SDK_E2E_NETWORK_PROBE_TIMEOUT`: TCP probe socket timeout in seconds for
   network policy cases. Defaults to `5`.
+- `SDK_E2E_TCP_TARGET_IP`: primary public TCP probe address. Defaults to
+  `8.8.8.8`.
+- `SDK_E2E_TCP_TARGET_PORT`: public TCP probe port. Defaults to `53`.
+- `SDK_E2E_ALTERNATE_TCP_TARGET_IP`: alternate public TCP probe address.
+  Defaults to `1.1.1.1`.
 - `SDK_E2E_KEEP_SANDBOX_ON_FAILURE`: preserve only sandboxes whose test setup
   or call phase failed. Passed and skipped tests are still cleaned up. Defaults
   to `false`.
@@ -313,11 +319,11 @@ Current capability domains:
 - `cases/filesystem/`: read/write, overwrite, multiline content, file API and shell interoperability.
 - `cases/run_code/`: expression text, stdout, kernel state, Python error reporting.
 - `cases/network/`: create-time network policy for allow/deny and public egress access.
+- `cases/concurrency/`: simultaneous multi-sandbox isolation.
 
 Keep new cases backend-neutral. Add backend-specific behavior through capability
 markers instead of branching inside test bodies. Future domains can be added next
-to the existing directories, for example `network/`, `proxy/`, `metadata/`,
-`errors/`, and `concurrency/`.
+to the existing directories, for example `proxy/`, `metadata/`, and `errors/`.
 
 ## Markers And Capabilities
 

--- a/tests/e2e/sdk_compat/README_zh.md
+++ b/tests/e2e/sdk_compat/README_zh.md
@@ -33,7 +33,7 @@
 
 - `SDK_E2E_BACKENDS=e2b` 或 `SDK_E2E_BACKENDS=e2b,cubesandbox`：启用 E2B
   后端；
-- `E2B_API_KEY`：E2B SDK 使用的 API key；也可以使用 `CUBE_API_KEY`；
+- `E2B_API_KEY`：E2B SDK 使用的 API key，必须显式设置；
 - `CUBE_API_URL`：兼容 E2B 的 CubeSandbox 控制面地址，adapter 会显式传给
   E2B SDK；
 - `SSL_CERT_FILE`：自托管 HTTPS sandbox endpoint 使用的本地 CA 文件。
@@ -173,6 +173,8 @@ cp env.example .env
 - `SDK_E2E_BACKENDS`：后端列表，默认 `cubesandbox`；
 - `CUBE_API_KEY`：目标环境需要 API key 时使用；
 - `E2B_API_KEY`：运行 E2B 后端时需要；
+- `SDK_E2E_E2B_VALIDATE_API_KEY`：启用 E2B SDK 的客户端 `e2b_*` key
+  格式检查；自托管环境默认 `false`，服务端鉴权不受影响；
 - `CUBE_PROXY_NODE_IP`：无法解析 wildcard sandbox DNS 时使用；
 - `CUBE_PROXY_PORT_HTTP`：默认 `80`；
 - `CUBE_SANDBOX_DOMAIN`：默认 `cube.app`；
@@ -185,6 +187,10 @@ cp env.example .env
 - `SDK_E2E_RUN_CODE_TIMEOUT`：代码执行超时，默认 `60` 秒；
 - `SDK_E2E_NETWORK_PROBE_TIMEOUT`：network policy 用例中的 TCP socket
   探测超时，默认 `5` 秒；
+- `SDK_E2E_TCP_TARGET_IP`：公网 TCP 探测地址，默认 `8.8.8.8`；
+- `SDK_E2E_TCP_TARGET_PORT`：公网 TCP 探测端口，默认 `53`；
+- `SDK_E2E_ALTERNATE_TCP_TARGET_IP`：备用公网 TCP 探测地址，默认
+  `1.1.1.1`；
 - `SDK_E2E_KEEP_SANDBOX_ON_FAILURE`：仅保留 setup/call 失败的 sandbox；
 - `SDK_E2E_TRACE`：输出每次 SDK adapter 操作；
 - `SDK_E2E_SKIP_INTERNET_TESTS`：当 runner 或环境没有稳定公网出站时，
@@ -284,7 +290,8 @@ tests/e2e/sdk_compat/
   输出和缺失命令；
 - `cases/filesystem/`：读写、覆盖、多行内容、文件 API 与 shell 互操作；
 - `cases/run_code/`：表达式结果、stdout、kernel 状态和 Python 错误；
-- `cases/network/`：创建时的 allow/deny 和公网出站策略。
+- `cases/network/`：创建时的 allow/deny 和公网出站策略；
+- `cases/concurrency/`：同时运行多个 sandbox 时的数据隔离。
 
 新增测试应保持后端无关，通过 capability marker 表达后端差异。
 

--- a/tests/e2e/sdk_compat/README_zh.md
+++ b/tests/e2e/sdk_compat/README_zh.md
@@ -19,6 +19,28 @@
 - [English case authoring guide](docs/case-authoring.md)
 - [中文用例编写指南](docs/zh/case-authoring.md)
 
+## Backend 环境变量
+
+`cubesandbox` 后端：
+
+- `CUBE_API_URL`：CubeAPI 控制面地址，默认
+  `http://127.0.0.1:3000`；
+- `CUBE_TEMPLATE_ID`：用于创建 sandbox 的 READY 模板 ID；
+- `CUBE_API_KEY`：目标 CubeAPI 需要认证时使用；
+- `CUBE_PROXY_NODE_IP`：runner 无法解析 sandbox wildcard DNS 时使用。
+
+`e2b` 后端：
+
+- `SDK_E2E_BACKENDS=e2b` 或 `SDK_E2E_BACKENDS=e2b,cubesandbox`：启用 E2B
+  后端；
+- `E2B_API_KEY`：E2B SDK 使用的 API key；也可以使用 `CUBE_API_KEY`；
+- `CUBE_API_URL`：兼容 E2B 的 CubeSandbox 控制面地址，adapter 会显式传给
+  E2B SDK；
+- `SSL_CERT_FILE`：自托管 HTTPS sandbox endpoint 使用的本地 CA 文件。
+
+E2B 后端不会关闭 TLS 证书校验。自托管 HTTPS 环境必须配置
+`SSL_CERT_FILE` 或系统 trust store。
+
 ## 准备模板
 
 执行在线 E2E 前，需要准备支持 Code Interpreter 的模板，并暴露 envd
@@ -211,6 +233,21 @@ SDK_E2E_REPORT_DIR/events.jsonl
 - `sandbox_cleanup` / `sandbox_kept`；
 - `test_result`。
 
+生成 HTML 报告：
+
+```bash
+pytest --run-e2e -m lifecycle \
+  --html=reports/sdk-dual/report.html \
+  --self-contained-html
+```
+
+生成 CI 使用的 JUnit XML 报告：
+
+```bash
+pytest --run-e2e -m lifecycle \
+  --junit-xml=reports/sdk-dual/junit.xml
+```
+
 失败结果会包含错误、sandbox 信息和最近的 SDK 操作 trace。trace 会对
 API key、环境变量等敏感值脱敏，并截断过大的字符串和集合。文件内容只
 记录长度，不记录明文或内容 hash。
@@ -272,8 +309,8 @@ Capability marker：
 
 常用 capability 有 `lifecycle`、`commands`、`filesystem`、`run_code`。
 可选共享 capability 包括 `pause_resume`、`network_allow_deny`、
-`network_public_access`；CubeSandbox 专属扩展 capability 包括
-`network_l7_rules` 和 `proxy_url`。
+`network_public_access`。
+`platform_lifecycle` 仅由 CubeSandbox 的平台托管生命周期用例提供。
 
 ## 清理
 

--- a/tests/e2e/sdk_compat/README_zh.md
+++ b/tests/e2e/sdk_compat/README_zh.md
@@ -1,0 +1,289 @@
+# SDK 兼容性 E2E 测试
+
+本目录包含 Python SDK 兼容性在线端到端测试。相同的后端无关测试用例可
+分别通过以下 SDK 执行：
+
+- `cubesandbox`：`sdk/python` 中的 CubeSandbox Python SDK；
+- `e2b`：`e2b-code-interpreter` 或 `e2b` Python SDK，连接兼容 CubeSandbox
+  的后端。
+
+测试套件默认不执行在线测试。未指定 `--run-e2e` 时，pytest 只进行安全的
+收集。默认后端是 `cubesandbox`；使用
+`SDK_E2E_BACKENDS=e2b,cubesandbox` 执行双后端兼容性测试。
+
+相关文档：
+
+- [English README](README.md)
+- [English framework design](docs/framework-design.md)
+- [中文框架设计](docs/framework-design.zh-CN.md)
+- [English case authoring guide](docs/case-authoring.md)
+- [中文用例编写指南](docs/zh/case-authoring.md)
+
+## 准备模板
+
+执行在线 E2E 前，需要准备支持 Code Interpreter 的模板，并暴露 envd
+(`49983`) 和 Jupyter/Code Interpreter (`49999`)：
+
+```bash
+cubemastercli tpl create-from-image \
+  --image cube-sandbox-cn.tencentcloudcr.com/cube-sandbox/sandbox-code:latest \
+  --writable-layer-size 1G \
+  --expose-port 49999 \
+  --expose-port 49983 \
+  --probe 49999
+```
+
+将生成的 template ID 设置为 `CUBE_TEMPLATE_ID`。
+
+## 快速开始
+
+```bash
+cd tests/e2e/sdk_compat
+python3 -m venv .venv
+. .venv/bin/activate
+pip install -r requirements.txt
+
+export CUBE_API_URL=http://10.0.1.5:3000
+export CUBE_TEMPLATE_ID=tpl-xxxxxxxxxxxxxxxxxxxxxxxx
+export CUBE_PROXY_NODE_IP=10.0.1.2
+
+pytest --run-e2e
+```
+
+显式指定 CubeSandbox 后端：
+
+```bash
+pytest --run-e2e --sdk-e2e-backends=cubesandbox
+```
+
+## 执行范围
+
+```bash
+# 快速环境 smoke
+pytest --run-e2e -m smoke
+
+# PR gate：稳定的 CubeSandbox 后端测试
+pytest --run-e2e -m "smoke or p0" --sdk-e2e-backends=cubesandbox
+
+# 每日双 SDK 兼容性回归
+SDK_E2E_BACKENDS=e2b,cubesandbox pytest --run-e2e -m "p0 or p1"
+
+# 更广泛的回归
+SDK_E2E_BACKENDS=e2b,cubesandbox \
+pytest --run-e2e -m "p0 or p1 or p2"
+```
+
+运行单个测试文件、测试函数或参数化后端：
+
+```bash
+# lifecycle 文件
+pytest --run-e2e cases/lifecycle/test_pause_resume.py
+
+# 单个测试函数
+pytest --run-e2e \
+  cases/lifecycle/test_pause_resume.py::test_pause_sets_state_paused
+
+# 指定后端
+pytest --run-e2e \
+  --sdk-e2e-backends=cubesandbox \
+  cases/lifecycle/test_pause_resume.py::test_pause_sets_state_paused[cubesandbox]
+
+# 按关键字选择
+pytest --run-e2e -k "pause and resume"
+
+# 查看参数化测试的 node ID
+pytest --collect-only -q cases/lifecycle/test_pause_resume.py
+```
+
+### 平台生命周期测试
+
+自动 pause、auto-resume 和 auto-kill 依赖 CubeProxy、Redis、
+cube-lifecycle-manager、CubeMaster 和 Cubelet：
+
+```bash
+export SDK_E2E_PLATFORM_LIFECYCLE=true
+export CUBE_PROXY_NODE_IP=<cube-proxy-node-ip>
+
+pytest --run-e2e --sdk-e2e-trace \
+  cases/lifecycle/test_auto_lifecycle.py
+```
+
+如果没有设置 `SDK_E2E_PLATFORM_LIFECYCLE=true`，这些测试会被跳过。目标
+计算节点上还需要使用 `READY` 模板。
+
+运行单个生命周期测试：
+
+```bash
+pytest --run-e2e --sdk-e2e-trace \
+  cases/lifecycle/test_auto_lifecycle.py::test_lifecycle_auto_resume_preserves_state
+```
+
+### E2B 双后端
+
+```bash
+pip install e2b-code-interpreter
+export E2B_API_KEY=<e2b-api-key>
+export SSL_CERT_FILE=/root/.local/share/mkcert/rootCA.pem
+export SDK_E2E_BACKENDS=e2b,cubesandbox
+pytest --run-e2e
+```
+
+## 环境变量
+
+测试会自动加载 `tests/e2e/sdk_compat/.env`。已经在 shell 中导出的变量
+优先级高于 `.env`：
+
+```bash
+cp env.example .env
+```
+
+内置 `.env` loader 比较轻量：只支持每行一个 `KEY=VALUE`，以及简单的
+单引号/双引号值；不支持多行 quoted value。多行 secret、private key 或
+复杂配置建议直接在 shell 中 export，不要写入 `.env`。
+
+必需变量：
+
+- `CUBE_API_URL`：CubeAPI 地址；
+- `CUBE_TEMPLATE_ID`：用于创建 sandbox 的 READY 模板 ID。
+
+常用可选变量：
+
+- `SDK_E2E_BACKENDS`：后端列表，默认 `cubesandbox`；
+- `CUBE_API_KEY`：目标环境需要 API key 时使用；
+- `E2B_API_KEY`：运行 E2B 后端时需要；
+- `CUBE_PROXY_NODE_IP`：无法解析 wildcard sandbox DNS 时使用；
+- `CUBE_PROXY_PORT_HTTP`：默认 `80`；
+- `CUBE_SANDBOX_DOMAIN`：默认 `cube.app`；
+- `SDK_E2E_DEFAULT_TIMEOUT`：显式 connect、cleanup resume 等操作的默认
+  超时，默认 `120` 秒；
+- `SDK_E2E_API_TIMEOUT`：CubeAPI 控制面请求超时，用于 preflight、诊断
+  和清理，默认 `5` 秒；
+- `SDK_E2E_CREATE_TIMEOUT`：创建超时，默认 `120` 秒；
+- `SDK_E2E_COMMAND_TIMEOUT`：命令超时，默认 `30` 秒；
+- `SDK_E2E_RUN_CODE_TIMEOUT`：代码执行超时，默认 `60` 秒；
+- `SDK_E2E_NETWORK_PROBE_TIMEOUT`：network policy 用例中的 TCP socket
+  探测超时，默认 `5` 秒；
+- `SDK_E2E_KEEP_SANDBOX_ON_FAILURE`：仅保留 setup/call 失败的 sandbox；
+- `SDK_E2E_TRACE`：输出每次 SDK adapter 操作；
+- `SDK_E2E_SKIP_INTERNET_TESTS`：当 runner 或环境没有稳定公网出站时，
+  跳过 `requires_internet` 测试，默认 `false`；
+- `SDK_E2E_REPORT_DIR`：JSONL 报告目录；
+- `CUBE_PYTHON_SDK_PATH`：覆盖本地 CubeSandbox Python SDK 路径；
+- `SDK_E2E_PLATFORM_LIFECYCLE`：启用平台生命周期测试；
+- `SDK_E2E_PLATFORM_LIFECYCLE_IDLE_TIMEOUT`：平台空闲超时，默认 `30` 秒；
+- `SDK_E2E_PLATFORM_LIFECYCLE_WAIT_MARGIN`：额外等待时间，默认 `20` 秒；
+- `SDK_E2E_PLATFORM_LIFECYCLE_POLL_TIMEOUT`：轮询窗口，默认 `45` 秒；
+- `CUBE_PROXY_ADMIN_PORT`：CubeProxy admin 端口，默认 `8082`。
+
+自托管 HTTPS 环境优先使用本地 CA：
+
+```bash
+export SSL_CERT_FILE=/root/.local/share/mkcert/rootCA.pem
+```
+
+E2B 后端不会关闭 TLS 证书校验。自托管环境需要通过 `SSL_CERT_FILE` 或
+系统 trust store 信任本地 CA。
+
+## Preflight
+
+启用 `--run-e2e` 后，session 级 preflight 会检查：
+
+- `CUBE_TEMPLATE_ID` 或 `--cube-template-id` 是否存在；
+- CubeAPI `/health` 是否可访问；
+- 目标模板是否存在；
+- 模板状态是否为 ready-like：`ready`、`active` 或 `available`。
+
+启用平台生命周期时，如果设置了 `CUBE_PROXY_NODE_IP`，还会检查
+CubeProxy admin heartbeat。
+
+## 报告和 Trace
+
+JSONL 报告写入：
+
+```text
+SDK_E2E_REPORT_DIR/events.jsonl
+```
+
+主要事件包括：
+
+- `preflight_passed` / `preflight_failed`；
+- `sandbox_created`；
+- `sandbox_cleanup` / `sandbox_kept`；
+- `test_result`。
+
+失败结果会包含错误、sandbox 信息和最近的 SDK 操作 trace。trace 会对
+API key、环境变量等敏感值脱敏，并截断过大的字符串和集合。文件内容只
+记录长度，不记录明文或内容 hash。
+
+启用实时 trace：
+
+```bash
+pytest --run-e2e --sdk-e2e-trace \
+  cases/lifecycle/test_pause_resume.py::test_pause_sets_state_paused
+
+SDK_E2E_TRACE=true pytest --run-e2e -m lifecycle
+```
+
+Trace 模式可能在 terminal 中输出非敏感的命令或代码结果；JSONL 报告仍会
+执行脱敏。
+
+## 目录结构
+
+```text
+tests/e2e/sdk_compat/
+  adapters/       SDK adapter 和 tracing proxy
+  framework/      配置、preflight、capability、清理、报告
+  cases/          按 capability domain 划分的后端无关用例
+  reports/        本地 JSONL 报告
+  README.md
+  README_zh.md
+```
+
+当前测试域：
+
+- `cases/lifecycle/`：创建、info、connect、create options、pause/resume、
+  kill、auto-pause、auto-resume、auto-kill；
+- `cases/commands/`：stdout、stderr、退出码、环境变量、特殊字符、多行
+  输出和缺失命令；
+- `cases/filesystem/`：读写、覆盖、多行内容、文件 API 与 shell 互操作；
+- `cases/run_code/`：表达式结果、stdout、kernel 状态和 Python 错误；
+- `cases/network/`：创建时的 allow/deny 和公网出站策略。
+
+新增测试应保持后端无关，通过 capability marker 表达后端差异。
+
+## Marker 和 Capability
+
+优先级 marker：
+
+- `smoke`：最小在线环境检查；
+- `p0`：稳定 PR gate 覆盖；
+- `p1`：每日兼容性回归；
+- `p2`：更广或更慢的每周覆盖；
+- `p3`：发布准入与长时间运行覆盖；
+- `slow`：超过普通 PR 时间预算的用例。
+
+Capability marker：
+
+- `@pytest.mark.requires_capability("<name>")`：当前后端不支持时跳过；
+- `@pytest.mark.sandbox_create_options(...)`：传入 `network`、`env_vars`、
+  `lifecycle` 等 sandbox 创建参数；
+- `@pytest.mark.requires_cubeproxy`：依赖 CubeProxy/lifecycle-manager
+  协调，未设置 `SDK_E2E_PLATFORM_LIFECYCLE=true` 时跳过。
+
+常用 capability 有 `lifecycle`、`commands`、`filesystem`、`run_code`。
+可选共享 capability 包括 `pause_resume`、`network_allow_deny`、
+`network_public_access`；CubeSandbox 专属扩展 capability 包括
+`network_l7_rules` 和 `proxy_url`。
+
+## 清理
+
+每个测试独立创建 sandbox，并在 teardown 中清理。SDK 清理失败时，框架会
+回退到针对 `CUBE_API_URL` 的 `DELETE /sandboxes/{sandboxID}`。
+
+调试失败实例时可以设置：
+
+```bash
+export SDK_E2E_KEEP_SANDBOX_ON_FAILURE=true
+```
+
+通过和跳过的测试仍会清理 sandbox。

--- a/tests/e2e/sdk_compat/adapters/__init__.py
+++ b/tests/e2e/sdk_compat/adapters/__init__.py
@@ -1,0 +1,107 @@
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from adapters.base import SandboxAdapter
+from adapters.cubesandbox_adapter import CubeSandboxAdapter
+from adapters.e2b_adapter import E2BAdapter
+from adapters.tracing_adapter import wrap_adapter
+from framework.config import SdkE2EConfig
+from framework.trace import get_current_trace, summarize_create_options
+
+_ADAPTERS = {
+    "cubesandbox": CubeSandboxAdapter,
+    "e2b": E2BAdapter,
+}
+
+
+def create_adapter(
+    backend: str,
+    config: SdkE2EConfig,
+    *,
+    metadata: dict[str, str] | None = None,
+    create_options: dict | None = None,
+) -> SandboxAdapter:
+    trace = get_current_trace()
+
+    def _create() -> SandboxAdapter:
+        return _adapter_for(backend).create(
+            config,
+            metadata=metadata,
+            create_options=create_options,
+        )
+
+    if trace is None:
+        return _create()
+    adapter = trace.capture(
+        "create",
+        {
+            "backend": backend,
+            "template_id": config.cube_template_id,
+            "metadata_keys": sorted((metadata or {}).keys()),
+            "create_options": summarize_create_options(create_options),
+        },
+        _create,
+        output=lambda result: {"sandbox_id": result.sandbox_id},
+    )
+    return wrap_adapter(adapter, trace)
+
+
+def connect_adapter(backend: str, sandbox_id: str, config: SdkE2EConfig) -> SandboxAdapter:
+    trace = get_current_trace()
+
+    def _connect() -> SandboxAdapter:
+        return _adapter_for(backend).connect(sandbox_id, config)
+
+    if trace is None:
+        return _connect()
+    adapter = trace.capture(
+        "connect",
+        {"backend": backend, "sandbox_id": sandbox_id},
+        _connect,
+        output=lambda result: {"sandbox_id": result.sandbox_id},
+    )
+    return wrap_adapter(adapter, trace)
+
+
+def list_sandboxes(backend: str, config: SdkE2EConfig) -> list[dict]:
+    trace = get_current_trace()
+
+    def _list() -> list[dict]:
+        return _adapter_for(backend).list_sandboxes(config)
+
+    if trace is None:
+        return _list()
+    return trace.capture(
+        "list_sandboxes",
+        {"backend": backend},
+        _list,
+        output=lambda entries: {
+            "count": len(entries),
+            "sandboxes": [
+                {
+                    "sandbox_id": _entry_id(entry),
+                    "state": entry.get("state"),
+                }
+                for entry in entries
+                if isinstance(entry, dict)
+            ],
+        },
+    )
+
+
+def _adapter_for(backend: str):
+    try:
+        return _ADAPTERS[backend]
+    except KeyError as exc:
+        raise ValueError(f"unknown SDK E2E backend: {backend}") from exc
+
+
+def _entry_id(entry: dict):
+    if "sandboxID" in entry:
+        return entry["sandboxID"]
+    return entry.get("sandbox_id")
+
+
+__all__ = ["SandboxAdapter", "connect_adapter", "create_adapter", "list_sandboxes"]

--- a/tests/e2e/sdk_compat/adapters/api_adapter.py
+++ b/tests/e2e/sdk_compat/adapters/api_adapter.py
@@ -1,0 +1,69 @@
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import os
+
+import requests
+
+from framework.config import SdkE2EConfig
+
+
+class ApiClient:
+    """Small REST client used for cleanup and diagnostics, not as a primary user path."""
+
+    def __init__(self, config: SdkE2EConfig) -> None:
+        self._config = config
+        self._session = requests.Session()
+        api_key = os.environ.get("CUBE_API_KEY")
+        if api_key:
+            self._session.headers.update({"Authorization": f"Bearer {api_key}"})
+
+    def health(self) -> dict:
+        resp = self._session.get(
+            f"{self._config.cube_api_url}/health",
+            timeout=self._config.api_timeout,
+        )
+        resp.raise_for_status()
+        return resp.json()
+
+    def get_template(self, template_id: str) -> dict:
+        resp = self._session.get(
+            f"{self._config.cube_api_url}/templates/{template_id}",
+            timeout=self._config.api_timeout,
+        )
+        if resp.status_code == 404:
+            return {}
+        resp.raise_for_status()
+        return resp.json()
+
+    def delete_sandbox(self, sandbox_id: str) -> None:
+        resp = self._session.delete(
+            f"{self._config.cube_api_url}/sandboxes/{sandbox_id}",
+            timeout=self._config.api_timeout,
+        )
+        if resp.status_code not in (200, 202, 204, 404):
+            raise RuntimeError(f"failed to delete sandbox {sandbox_id}: HTTP {resp.status_code} {resp.text}")
+
+    def get_sandbox(self, sandbox_id: str) -> dict:
+        resp = self._session.get(
+            f"{self._config.cube_api_url}/sandboxes/{sandbox_id}",
+            timeout=self._config.api_timeout,
+        )
+        if resp.status_code == 404:
+            return {}
+        resp.raise_for_status()
+        return resp.json()
+
+    def list_sandboxes(self) -> list[dict]:
+        resp = self._session.get(
+            f"{self._config.cube_api_url}/sandboxes",
+            timeout=self._config.api_timeout,
+        )
+        resp.raise_for_status()
+        payload = resp.json()
+        return payload if isinstance(payload, list) else []
+
+    def close(self) -> None:
+        self._session.close()

--- a/tests/e2e/sdk_compat/adapters/base.py
+++ b/tests/e2e/sdk_compat/adapters/base.py
@@ -64,3 +64,20 @@ class SandboxAdapter(ABC):
         close = getattr(self.raw_sandbox, "close", None)
         if callable(close):
             close()
+
+
+def cleanup_raw_sandbox(sandbox: Any) -> None:
+    for name in ("kill", "delete"):
+        method = getattr(sandbox, name, None)
+        if callable(method):
+            try:
+                method()
+            except Exception:
+                pass
+            break
+    close = getattr(sandbox, "close", None)
+    if callable(close):
+        try:
+            close()
+        except Exception:
+            pass

--- a/tests/e2e/sdk_compat/adapters/base.py
+++ b/tests/e2e/sdk_compat/adapters/base.py
@@ -1,0 +1,66 @@
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Any
+
+from framework.exceptions import UnsupportedCapability
+from framework.models import CodeResult, CommandResult, SandboxInfo
+
+
+class SandboxAdapter(ABC):
+    backend: str
+    capabilities: frozenset[str]
+
+    def __init__(self, sandbox: Any) -> None:
+        self._sandbox = sandbox
+
+    @property
+    def raw_sandbox(self) -> Any:
+        return self._sandbox
+
+    @property
+    @abstractmethod
+    def sandbox_id(self) -> str:
+        raise NotImplementedError
+
+    def require(self, capability: str) -> None:
+        if capability not in self.capabilities:
+            raise UnsupportedCapability(self.backend, capability)
+
+    @abstractmethod
+    def info(self) -> SandboxInfo:
+        raise NotImplementedError
+
+    @abstractmethod
+    def run_command(self, command: str, *, user: str = "root", timeout: int = 30) -> CommandResult:
+        raise NotImplementedError
+
+    @abstractmethod
+    def write_file(self, path: str, content: str, *, user: str = "root") -> None:
+        raise NotImplementedError
+
+    @abstractmethod
+    def read_file(self, path: str, *, user: str = "root") -> str:
+        raise NotImplementedError
+
+    @abstractmethod
+    def run_code(self, code: str, *, timeout: int = 60) -> CodeResult:
+        raise NotImplementedError
+
+    def pause(self, *, timeout: int = 60) -> None:
+        raise UnsupportedCapability(self.backend, "pause_resume")
+
+    def resume_or_connect(self, *, timeout: int = 60) -> "SandboxAdapter":
+        raise UnsupportedCapability(self.backend, "pause_resume")
+
+    @abstractmethod
+    def kill(self) -> None:
+        raise NotImplementedError
+
+    def close(self) -> None:
+        close = getattr(self.raw_sandbox, "close", None)
+        if callable(close):
+            close()

--- a/tests/e2e/sdk_compat/adapters/cubesandbox_adapter.py
+++ b/tests/e2e/sdk_compat/adapters/cubesandbox_adapter.py
@@ -1,0 +1,149 @@
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from typing import Any
+
+from adapters.base import SandboxAdapter
+from framework.capabilities import CUBESANDBOX_CAPABILITIES
+from framework.config import SdkE2EConfig
+from framework.models import CodeResult, CommandResult, SandboxInfo, state_from_raw
+
+
+class CubeSandboxAdapter(SandboxAdapter):
+    backend = "cubesandbox"
+    capabilities = CUBESANDBOX_CAPABILITIES
+
+    @classmethod
+    def create(
+        cls,
+        config: SdkE2EConfig,
+        *,
+        metadata: dict[str, str] | None = None,
+        create_options: dict[str, Any] | None = None,
+    ) -> "CubeSandboxAdapter":
+        from cubesandbox import Config, Sandbox
+
+        sdk_config = cls._sdk_config(config)
+        opts = dict(create_options or {})
+        merged_metadata = dict(metadata or {})
+        extra_metadata = opts.pop("metadata", None)
+        if isinstance(extra_metadata, dict):
+            merged_metadata.update(extra_metadata)
+        timeout = opts.pop("timeout", config.create_timeout)
+        sandbox = None
+        try:
+            sandbox = Sandbox.create(
+                timeout=timeout,
+                metadata=merged_metadata or None,
+                config=sdk_config,
+                **opts,
+            )
+            return cls(sandbox, sdk_config=sdk_config, e2e_config=config)
+        except BaseException:
+            if sandbox is not None:
+                _cleanup_raw_sandbox(sandbox)
+            raise
+
+    @classmethod
+    def connect(
+        cls,
+        sandbox_id: str,
+        config: SdkE2EConfig,
+    ) -> "CubeSandboxAdapter":
+        from cubesandbox import Sandbox
+
+        sdk_config = cls._sdk_config(config)
+        return cls(Sandbox.connect(sandbox_id, config=sdk_config), sdk_config=sdk_config, e2e_config=config)
+
+    @classmethod
+    def list_sandboxes(cls, config: SdkE2EConfig) -> list[dict[str, Any]]:
+        from cubesandbox import Sandbox
+
+        return Sandbox.list(config=cls._sdk_config(config))
+
+    @staticmethod
+    def _sdk_config(config: SdkE2EConfig):
+        from cubesandbox import Config
+
+        return Config(
+            api_url=config.cube_api_url,
+            template_id=config.cube_template_id,
+            proxy_node_ip=config.cube_proxy_node_ip,
+            proxy_port=config.cube_proxy_port_http,
+            sandbox_domain=config.cube_sandbox_domain,
+        )
+
+    def __init__(self, sandbox: Any, *, sdk_config: Any, e2e_config: SdkE2EConfig | None = None) -> None:
+        super().__init__(sandbox)
+        self._sdk_config = sdk_config
+        self._e2e_config = e2e_config
+
+    @property
+    def sandbox_id(self) -> str:
+        return self._sandbox.sandbox_id
+
+    def info(self) -> SandboxInfo:
+        raw = self._sandbox.get_info()
+        sandbox_id = raw["sandboxID"] if "sandboxID" in raw else self.sandbox_id
+        return SandboxInfo(
+            sandbox_id=sandbox_id,
+            state=state_from_raw(raw),
+            raw=raw,
+        )
+
+    def run_command(self, command: str, *, user: str = "root", timeout: int = 30) -> CommandResult:
+        result = self._sandbox.commands.run(command, user=user, timeout=timeout)
+        return CommandResult(
+            stdout=result.stdout,
+            stderr=result.stderr,
+            exit_code=result.exit_code,
+        )
+
+    def write_file(self, path: str, content: str, *, user: str = "root") -> None:
+        self._sandbox.files.write(path, content, user=user)
+
+    def read_file(self, path: str, *, user: str = "root") -> str:
+        return self._sandbox.files.read(path, user=user)
+
+    def run_code(self, code: str, *, timeout: int = 60) -> CodeResult:
+        execution = self._sandbox.run_code(code, timeout=timeout)
+        stdout = _normalize_log_lines(execution.logs.stdout) if execution.logs else []
+        stderr = _normalize_log_lines(execution.logs.stderr) if execution.logs else []
+        return CodeResult(
+            text=execution.text,
+            stdout=stdout,
+            stderr=stderr,
+            error=execution.error,
+        )
+
+    def pause(self, *, timeout: int = 60) -> None:
+        self._sandbox.pause(timeout=timeout)
+
+    def resume_or_connect(self, *, timeout: int = 60) -> "CubeSandboxAdapter":
+        return type(self).connect(self.sandbox_id, self._e2e_config or SdkE2EConfig.from_env())
+
+    def kill(self) -> None:
+        self._sandbox.kill()
+
+
+def _normalize_log_lines(items: Any) -> list[str]:
+    return [str(getattr(item, "line", item)) for item in items or []]
+
+
+def _cleanup_raw_sandbox(sandbox: Any) -> None:
+    for name in ("kill", "delete"):
+        method = getattr(sandbox, name, None)
+        if callable(method):
+            try:
+                method()
+            except Exception:
+                pass
+            break
+    close = getattr(sandbox, "close", None)
+    if callable(close):
+        try:
+            close()
+        except Exception:
+            pass

--- a/tests/e2e/sdk_compat/adapters/cubesandbox_adapter.py
+++ b/tests/e2e/sdk_compat/adapters/cubesandbox_adapter.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from adapters.base import SandboxAdapter
+from adapters.base import SandboxAdapter, cleanup_raw_sandbox
 from framework.capabilities import CUBESANDBOX_CAPABILITIES
 from framework.config import SdkE2EConfig
 from framework.models import CodeResult, CommandResult, SandboxInfo, state_from_raw
@@ -41,9 +41,9 @@ class CubeSandboxAdapter(SandboxAdapter):
                 **opts,
             )
             return cls(sandbox, sdk_config=sdk_config, e2e_config=config)
-        except BaseException:
+        except Exception:
             if sandbox is not None:
-                _cleanup_raw_sandbox(sandbox)
+                cleanup_raw_sandbox(sandbox)
             raise
 
     @classmethod
@@ -130,20 +130,3 @@ class CubeSandboxAdapter(SandboxAdapter):
 
 def _normalize_log_lines(items: Any) -> list[str]:
     return [str(getattr(item, "line", item)) for item in items or []]
-
-
-def _cleanup_raw_sandbox(sandbox: Any) -> None:
-    for name in ("kill", "delete"):
-        method = getattr(sandbox, name, None)
-        if callable(method):
-            try:
-                method()
-            except Exception:
-                pass
-            break
-    close = getattr(sandbox, "close", None)
-    if callable(close):
-        try:
-            close()
-        except Exception:
-            pass

--- a/tests/e2e/sdk_compat/adapters/e2b_adapter.py
+++ b/tests/e2e/sdk_compat/adapters/e2b_adapter.py
@@ -20,6 +20,9 @@ from framework.models import (
     state_from_raw,
 )
 
+MAX_LIST_PAGES = 100
+
+
 def _import_e2b_sandbox():
     try:
         from e2b_code_interpreter import Sandbox  # type: ignore
@@ -126,6 +129,39 @@ def _sandbox_info_to_raw(info: Any) -> dict[str, Any]:
             normalized[alias] = normalized[source]
 
     return normalized
+
+
+def _sandbox_entry_to_dict(entry: Any) -> dict[str, Any]:
+    if isinstance(entry, dict):
+        data = dict(entry)
+    elif is_dataclass(entry) and not isinstance(entry, type):
+        data = asdict(entry)
+    else:
+        data = {
+            name: getattr(entry, name)
+            for name in ("sandbox_id", "sandboxID", "id", "state", "metadata", "template_id")
+            if hasattr(entry, name)
+        }
+
+    sandbox_id = first_present(data, "sandbox_id", "sandboxID", "id")
+    if sandbox_id is not None:
+        data.setdefault("sandbox_id", sandbox_id)
+        data.setdefault("sandboxID", sandbox_id)
+    state = data.get("state")
+    if state is not None:
+        data["state"] = str(getattr(state, "value", state))
+    return data
+
+
+def _list_sandboxes_via_cubeapi(config: SdkE2EConfig) -> list[dict[str, Any]]:
+    from adapters.api_adapter import ApiClient
+
+    api = ApiClient(config)
+    try:
+        entries = api.list_sandboxes()
+    finally:
+        api.close()
+    return [_sandbox_entry_to_dict(entry) for entry in entries]
 
 
 class E2BAdapter(SandboxAdapter):
@@ -294,8 +330,14 @@ class E2BAdapter(SandboxAdapter):
             entries = list_method(**_e2b_api_params(config))
             if hasattr(entries, "next_items"):
                 items: list[Any] = []
+                page_count = 0
                 while getattr(entries, "has_next", False):
+                    if page_count >= MAX_LIST_PAGES:
+                        raise RuntimeError(
+                            f"E2B sandbox listing exceeded {MAX_LIST_PAGES} pages"
+                        )
                     items.extend(entries.next_items())
+                    page_count += 1
                 entries = items
             return [_sandbox_entry_to_dict(entry) for entry in entries or []]
         except Exception:
@@ -306,16 +348,13 @@ class E2BAdapter(SandboxAdapter):
 
 
 def _e2b_api_params(config: SdkE2EConfig) -> dict[str, Any]:
-    api_key = os.environ.get("E2B_API_KEY") or os.environ.get("CUBE_API_KEY")
+    api_key = os.environ.get("E2B_API_KEY")
     if not api_key:
-        raise RuntimeError(
-            "E2B backend requires E2B_API_KEY or CUBE_API_KEY; "
-            "refusing to use a default API key"
-        )
+        raise RuntimeError("E2B backend requires E2B_API_KEY")
     params = {
         "api_url": config.cube_api_url,
         "api_key": api_key,
-        "validate_api_key": False,
+        "validate_api_key": config.e2b_validate_api_key,
     }
     return {
         key: value
@@ -330,37 +369,6 @@ def _connection_config_accepts_keyword(name: str) -> bool:
     except ImportError:
         return True
     return _accepts_keyword(ConnectionConfig, name)
-
-
-def _sandbox_entry_to_dict(entry: Any) -> dict[str, Any]:
-    if isinstance(entry, dict):
-        data = dict(entry)
-    elif is_dataclass(entry) and not isinstance(entry, type):
-        data = asdict(entry)
-    else:
-        data = {
-            name: getattr(entry, name)
-            for name in ("sandbox_id", "sandboxID", "id", "state", "metadata", "template_id")
-            if hasattr(entry, name)
-        }
-
-    sandbox_id = first_present(data, "sandbox_id", "sandboxID", "id")
-    if sandbox_id is not None:
-        data.setdefault("sandbox_id", sandbox_id)
-        data.setdefault("sandboxID", sandbox_id)
-    state = data.get("state")
-    if state is not None:
-        data["state"] = str(getattr(state, "value", state))
-    return data
-def _list_sandboxes_via_cubeapi(config: SdkE2EConfig) -> list[dict[str, Any]]:
-    from adapters.api_adapter import ApiClient
-
-    api = ApiClient(config)
-    try:
-        entries = api.list_sandboxes()
-    finally:
-        api.close()
-    return [_sandbox_entry_to_dict(entry) for entry in entries]
 
 
 def _accepts_keyword(callable_obj: Any, name: str) -> bool:

--- a/tests/e2e/sdk_compat/adapters/e2b_adapter.py
+++ b/tests/e2e/sdk_compat/adapters/e2b_adapter.py
@@ -1,0 +1,390 @@
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import inspect
+import os
+from dataclasses import asdict, is_dataclass
+from enum import Enum
+from typing import Any
+
+from adapters.base import SandboxAdapter
+from framework.capabilities import E2B_CAPABILITIES
+from framework.config import SdkE2EConfig
+from framework.models import CodeResult, CommandResult, SandboxInfo, state_from_raw
+
+def _import_e2b_sandbox():
+    try:
+        from e2b_code_interpreter import Sandbox  # type: ignore
+
+        return Sandbox
+    except ImportError:
+        pass
+    try:
+        from e2b import Sandbox  # type: ignore
+
+        return Sandbox
+    except ImportError as exc:
+        raise ImportError(
+            "E2B backend requires e2b-code-interpreter or e2b. "
+            "Install tests/e2e/sdk_compat/requirements.txt."
+        ) from exc
+
+
+def _import_e2b_command_exit_exception():
+    try:
+        from e2b.sandbox.commands.command_handle import CommandExitException  # type: ignore
+
+        return CommandExitException
+    except ImportError:
+        return None
+
+
+def _get_sandbox_id(sandbox: Any) -> str:
+    for name in ("sandbox_id", "sandboxID", "id"):
+        value = getattr(sandbox, name, None)
+        if value:
+            return str(value)
+    data = getattr(sandbox, "_data", None)
+    if isinstance(data, dict):
+        value = _first_present_value(data, "sandboxID", "sandbox_id", "id")
+        if value is not None:
+            return str(value)
+    raise RuntimeError("could not determine E2B sandbox id")
+
+
+def _normalize_info_value(value: Any) -> Any:
+    if isinstance(value, Enum):
+        return value.value
+    if hasattr(value, "isoformat"):
+        return value.isoformat()
+    if is_dataclass(value):
+        return _sandbox_info_to_raw(value)
+    if isinstance(value, dict):
+        return {key: _normalize_info_value(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_normalize_info_value(item) for item in value]
+    return value
+
+
+def _sandbox_info_to_raw(info: Any) -> dict[str, Any]:
+    """Normalize E2B SandboxInfo objects and older dict responses."""
+    if info is None:
+        return {}
+    if isinstance(info, dict):
+        raw = dict(info)
+    elif is_dataclass(info):
+        raw = asdict(info)
+    else:
+        raw = {}
+        for key in (
+            "sandbox_id",
+            "sandboxID",
+            "template_id",
+            "templateID",
+            "sandbox_domain",
+            "domain",
+            "metadata",
+            "started_at",
+            "startedAt",
+            "end_at",
+            "endAt",
+            "state",
+            "status",
+            "cpu_count",
+            "cpuCount",
+            "memory_mb",
+            "memoryMB",
+            "envd_version",
+            "envdVersion",
+        ):
+            if hasattr(info, key):
+                raw[key] = getattr(info, key)
+
+    normalized = {key: _normalize_info_value(value) for key, value in raw.items()}
+
+    # Keep both E2B snake_case and CubeAPI camel/acronym-style aliases available.
+    aliases = {
+        "sandbox_id": "sandboxID",
+        "template_id": "templateID",
+        "sandbox_domain": "domain",
+        "started_at": "startedAt",
+        "end_at": "endAt",
+        "cpu_count": "cpuCount",
+        "memory_mb": "memoryMB",
+        "envd_version": "envdVersion",
+    }
+    for source, alias in aliases.items():
+        if source in normalized and alias not in normalized:
+            normalized[alias] = normalized[source]
+
+    return normalized
+
+
+class E2BAdapter(SandboxAdapter):
+    backend = "e2b"
+    capabilities = E2B_CAPABILITIES
+
+    @classmethod
+    def create(
+        cls,
+        config: SdkE2EConfig,
+        *,
+        metadata: dict[str, str] | None = None,
+        create_options: dict[str, Any] | None = None,
+    ) -> "E2BAdapter":
+        Sandbox = _import_e2b_sandbox()
+
+        opts = dict(create_options or {})
+        # The backend-neutral tests use the CubeSandbox SDK create option name,
+        # while E2B's Python SDK calls the same concept `envs`.
+        if "env_vars" in opts:
+            opts.setdefault("envs", opts.pop("env_vars"))
+        merged_metadata = dict(metadata or {})
+        extra_metadata = opts.pop("metadata", None)
+        if isinstance(extra_metadata, dict):
+            merged_metadata.update(extra_metadata)
+
+        kwargs: dict[str, Any] = {
+            "template": config.cube_template_id,
+            "timeout": config.create_timeout,
+            "metadata": merged_metadata or None,
+            **_e2b_api_params(config),
+        }
+        kwargs.update(opts)
+        kwargs = {key: value for key, value in kwargs.items() if value is not None}
+        sandbox = None
+        try:
+            create_method = getattr(Sandbox, "create", None)
+            if callable(create_method):
+                sandbox = create_method(**kwargs)
+            else:
+                sandbox = Sandbox(**kwargs)
+            return cls(sandbox, e2e_config=config)
+        except BaseException:
+            if sandbox is not None:
+                _cleanup_raw_sandbox(sandbox)
+            raise
+
+    @classmethod
+    def connect(cls, sandbox_id: str, config: SdkE2EConfig, *, timeout: int | None = None) -> "E2BAdapter":
+        Sandbox = _import_e2b_sandbox()
+        connect_method = getattr(Sandbox, "connect", None)
+        if callable(connect_method):
+            kwargs = dict(_e2b_api_params(config))
+            if _accepts_keyword(connect_method, "timeout"):
+                kwargs["timeout"] = timeout
+            sandbox = connect_method(sandbox_id, **kwargs)
+        else:
+            sandbox = Sandbox(sandbox_id=sandbox_id, **_e2b_api_params(config))
+        return cls(sandbox, e2e_config=config)
+
+    def __init__(self, sandbox: Any, *, e2e_config: SdkE2EConfig | None = None) -> None:
+        super().__init__(sandbox)
+        self._e2e_config = e2e_config
+
+    @property
+    def sandbox_id(self) -> str:
+        return _get_sandbox_id(self._sandbox)
+
+    def info(self) -> SandboxInfo:
+        raw: dict[str, Any] = {}
+        for name in ("get_info", "get_info_sync"):
+            method = getattr(self._sandbox, name, None)
+            if callable(method):
+                raw = _sandbox_info_to_raw(method())
+                break
+        raw_sandbox_id = _first_present_value(raw, "sandboxID", "sandbox_id")
+        return SandboxInfo(
+            sandbox_id=str(raw_sandbox_id if raw_sandbox_id is not None else self.sandbox_id),
+            state=state_from_raw(raw),
+            raw=raw,
+        )
+
+    def run_command(self, command: str, *, user: str = "root", timeout: int = 30) -> CommandResult:
+        commands = getattr(self._sandbox, "commands", None)
+        if commands is None:
+            raise RuntimeError("E2B sandbox object does not expose commands")
+        command_exit_exception = _import_e2b_command_exit_exception()
+        try:
+            if _accepts_keyword(commands.run, "user"):
+                result = commands.run(command, timeout=timeout, user=user)
+            else:
+                result = commands.run(command, timeout=timeout)
+        except Exception as exc:  # E2B raises on non-zero command exits.
+            if command_exit_exception is None or not isinstance(exc, command_exit_exception):
+                raise
+            return CommandResult(
+                stdout=str(getattr(exc, "stdout", "") or ""),
+                stderr=str(getattr(exc, "stderr", "") or ""),
+                exit_code=int(getattr(exc, "exit_code")),
+            )
+        return CommandResult(
+            stdout=str(getattr(result, "stdout", "") or ""),
+            stderr=str(getattr(result, "stderr", "") or ""),
+            exit_code=int(getattr(result, "exit_code", getattr(result, "exitCode", 0))),
+        )
+
+    def write_file(self, path: str, content: str, *, user: str = "root") -> None:
+        files = getattr(self._sandbox, "files", None)
+        if files is None:
+            raise RuntimeError("E2B sandbox object does not expose files")
+        writer = getattr(files, "write", None) or getattr(files, "write_file", None)
+        if not callable(writer):
+            raise RuntimeError("E2B files object does not expose write/write_file")
+        writer(path, content)
+
+    def read_file(self, path: str, *, user: str = "root") -> str:
+        files = getattr(self._sandbox, "files", None)
+        if files is None:
+            raise RuntimeError("E2B sandbox object does not expose files")
+        reader = getattr(files, "read", None) or getattr(files, "read_file", None)
+        if not callable(reader):
+            raise RuntimeError("E2B files object does not expose read/read_file")
+        return str(reader(path))
+
+    def run_code(self, code: str, *, timeout: int = 60) -> CodeResult:
+        result = self._sandbox.run_code(code, timeout=timeout)
+        logs = getattr(result, "logs", None)
+        stdout = list(getattr(logs, "stdout", []) or [])
+        stderr = list(getattr(logs, "stderr", []) or [])
+        return CodeResult(
+            text=str(getattr(result, "text", "") or ""),
+            stdout=[str(item) for item in stdout],
+            stderr=[str(item) for item in stderr],
+            error=getattr(result, "error", None),
+        )
+
+    def pause(self, *, timeout: int = 60) -> None:
+        pause = getattr(self._sandbox, "pause", None)
+        if not callable(pause):
+            raise RuntimeError("E2B sandbox object does not expose pause()")
+        kwargs = {"request_timeout": timeout} if _accepts_keyword(pause, "request_timeout") else {}
+        pause(**kwargs)
+
+    def resume_or_connect(self, *, timeout: int = 60) -> "E2BAdapter":
+        return type(self).connect(
+            self.sandbox_id,
+            self._e2e_config or SdkE2EConfig.from_env(),
+            timeout=timeout,
+        )
+
+    def kill(self) -> None:
+        for name in ("kill", "delete", "close"):
+            method = getattr(self._sandbox, name, None)
+            if callable(method):
+                method()
+                return
+        raise RuntimeError("E2B sandbox object does not expose kill/delete/close")
+
+    @classmethod
+    def list_sandboxes(cls, config: SdkE2EConfig) -> list[dict[str, Any]]:
+        Sandbox = _import_e2b_sandbox()
+        list_method = getattr(Sandbox, "list", None)
+        if not callable(list_method):
+            raise RuntimeError("E2B sandbox SDK does not expose Sandbox.list()")
+        try:
+            entries = list_method(**_e2b_api_params(config))
+            if hasattr(entries, "next_items"):
+                items: list[Any] = []
+                while getattr(entries, "has_next", False):
+                    items.extend(entries.next_items())
+                entries = items
+            return [_sandbox_entry_to_dict(entry) for entry in entries or []]
+        except Exception:
+            # Some CubeSandbox-compatible deployments expose a list response that
+            # the E2B SDK model parser cannot deserialize. Use CubeAPI directly
+            # for diagnostics and cleanup assertions.
+            return _list_sandboxes_via_cubeapi(config)
+
+
+def _e2b_api_params(config: SdkE2EConfig) -> dict[str, Any]:
+    params = {
+        "api_url": config.cube_api_url,
+        "api_key": os.environ.get("E2B_API_KEY")
+        or os.environ.get("CUBE_API_KEY")
+        or "e2b_000000",
+        "validate_api_key": False,
+    }
+    return {
+        key: value
+        for key, value in params.items()
+        if _connection_config_accepts_keyword(key)
+    }
+
+
+def _connection_config_accepts_keyword(name: str) -> bool:
+    try:
+        from e2b.connection_config import ConnectionConfig  # type: ignore
+    except ImportError:
+        return True
+    return _accepts_keyword(ConnectionConfig, name)
+
+
+def _sandbox_entry_to_dict(entry: Any) -> dict[str, Any]:
+    if isinstance(entry, dict):
+        data = dict(entry)
+    elif is_dataclass(entry) and not isinstance(entry, type):
+        data = asdict(entry)
+    else:
+        data = {
+            name: getattr(entry, name)
+            for name in ("sandbox_id", "sandboxID", "id", "state", "metadata", "template_id")
+            if hasattr(entry, name)
+        }
+
+    sandbox_id = _first_present_value(data, "sandbox_id", "sandboxID", "id")
+    if sandbox_id is not None:
+        data.setdefault("sandbox_id", sandbox_id)
+        data.setdefault("sandboxID", sandbox_id)
+    state = data.get("state")
+    if state is not None:
+        data["state"] = str(getattr(state, "value", state))
+    return data
+
+
+def _first_present_value(data: dict[str, Any], *keys: str) -> Any | None:
+    for key in keys:
+        if key in data:
+            return data[key]
+    return None
+
+
+def _list_sandboxes_via_cubeapi(config: SdkE2EConfig) -> list[dict[str, Any]]:
+    from adapters.api_adapter import ApiClient
+
+    api = ApiClient(config)
+    try:
+        entries = api.list_sandboxes()
+    finally:
+        api.close()
+    return [_sandbox_entry_to_dict(entry) for entry in entries]
+
+
+def _cleanup_raw_sandbox(sandbox: Any) -> None:
+    for name in ("kill", "delete"):
+        method = getattr(sandbox, name, None)
+        if callable(method):
+            try:
+                method()
+            except Exception:
+                pass
+            break
+    close = getattr(sandbox, "close", None)
+    if callable(close):
+        try:
+            close()
+        except Exception:
+            pass
+
+
+def _accepts_keyword(callable_obj: Any, name: str) -> bool:
+    try:
+        signature = inspect.signature(callable_obj)
+    except (TypeError, ValueError):
+        return True
+    return name in signature.parameters or any(
+        parameter.kind is inspect.Parameter.VAR_KEYWORD
+        for parameter in signature.parameters.values()
+    )

--- a/tests/e2e/sdk_compat/adapters/e2b_adapter.py
+++ b/tests/e2e/sdk_compat/adapters/e2b_adapter.py
@@ -9,10 +9,16 @@ from dataclasses import asdict, is_dataclass
 from enum import Enum
 from typing import Any
 
-from adapters.base import SandboxAdapter
+from adapters.base import SandboxAdapter, cleanup_raw_sandbox
 from framework.capabilities import E2B_CAPABILITIES
 from framework.config import SdkE2EConfig
-from framework.models import CodeResult, CommandResult, SandboxInfo, state_from_raw
+from framework.models import (
+    CodeResult,
+    CommandResult,
+    SandboxInfo,
+    first_present,
+    state_from_raw,
+)
 
 def _import_e2b_sandbox():
     try:
@@ -48,7 +54,7 @@ def _get_sandbox_id(sandbox: Any) -> str:
             return str(value)
     data = getattr(sandbox, "_data", None)
     if isinstance(data, dict):
-        value = _first_present_value(data, "sandboxID", "sandbox_id", "id")
+        value = first_present(data, "sandboxID", "sandbox_id", "id")
         if value is not None:
             return str(value)
     raise RuntimeError("could not determine E2B sandbox id")
@@ -162,9 +168,9 @@ class E2BAdapter(SandboxAdapter):
             else:
                 sandbox = Sandbox(**kwargs)
             return cls(sandbox, e2e_config=config)
-        except BaseException:
+        except Exception:
             if sandbox is not None:
-                _cleanup_raw_sandbox(sandbox)
+                cleanup_raw_sandbox(sandbox)
             raise
 
     @classmethod
@@ -195,7 +201,7 @@ class E2BAdapter(SandboxAdapter):
             if callable(method):
                 raw = _sandbox_info_to_raw(method())
                 break
-        raw_sandbox_id = _first_present_value(raw, "sandboxID", "sandbox_id")
+        raw_sandbox_id = first_present(raw, "sandboxID", "sandbox_id")
         return SandboxInfo(
             sandbox_id=str(raw_sandbox_id if raw_sandbox_id is not None else self.sandbox_id),
             state=state_from_raw(raw),
@@ -300,11 +306,15 @@ class E2BAdapter(SandboxAdapter):
 
 
 def _e2b_api_params(config: SdkE2EConfig) -> dict[str, Any]:
+    api_key = os.environ.get("E2B_API_KEY") or os.environ.get("CUBE_API_KEY")
+    if not api_key:
+        raise RuntimeError(
+            "E2B backend requires E2B_API_KEY or CUBE_API_KEY; "
+            "refusing to use a default API key"
+        )
     params = {
         "api_url": config.cube_api_url,
-        "api_key": os.environ.get("E2B_API_KEY")
-        or os.environ.get("CUBE_API_KEY")
-        or "e2b_000000",
+        "api_key": api_key,
         "validate_api_key": False,
     }
     return {
@@ -334,7 +344,7 @@ def _sandbox_entry_to_dict(entry: Any) -> dict[str, Any]:
             if hasattr(entry, name)
         }
 
-    sandbox_id = _first_present_value(data, "sandbox_id", "sandboxID", "id")
+    sandbox_id = first_present(data, "sandbox_id", "sandboxID", "id")
     if sandbox_id is not None:
         data.setdefault("sandbox_id", sandbox_id)
         data.setdefault("sandboxID", sandbox_id)
@@ -342,15 +352,6 @@ def _sandbox_entry_to_dict(entry: Any) -> dict[str, Any]:
     if state is not None:
         data["state"] = str(getattr(state, "value", state))
     return data
-
-
-def _first_present_value(data: dict[str, Any], *keys: str) -> Any | None:
-    for key in keys:
-        if key in data:
-            return data[key]
-    return None
-
-
 def _list_sandboxes_via_cubeapi(config: SdkE2EConfig) -> list[dict[str, Any]]:
     from adapters.api_adapter import ApiClient
 
@@ -360,23 +361,6 @@ def _list_sandboxes_via_cubeapi(config: SdkE2EConfig) -> list[dict[str, Any]]:
     finally:
         api.close()
     return [_sandbox_entry_to_dict(entry) for entry in entries]
-
-
-def _cleanup_raw_sandbox(sandbox: Any) -> None:
-    for name in ("kill", "delete"):
-        method = getattr(sandbox, name, None)
-        if callable(method):
-            try:
-                method()
-            except Exception:
-                pass
-            break
-    close = getattr(sandbox, "close", None)
-    if callable(close):
-        try:
-            close()
-        except Exception:
-            pass
 
 
 def _accepts_keyword(callable_obj: Any, name: str) -> bool:

--- a/tests/e2e/sdk_compat/adapters/tracing_adapter.py
+++ b/tests/e2e/sdk_compat/adapters/tracing_adapter.py
@@ -1,0 +1,147 @@
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from typing import Any
+
+from adapters.base import SandboxAdapter
+from framework.models import CodeResult, CommandResult, SandboxInfo
+from framework.trace import TraceCollector
+
+
+class TracingSandboxAdapter(SandboxAdapter):
+    def __init__(self, wrapped: SandboxAdapter, trace: TraceCollector) -> None:
+        super().__init__(wrapped.raw_sandbox)
+        self._wrapped = wrapped
+        self._trace = trace
+        self.backend = wrapped.backend
+        self.capabilities = wrapped.capabilities
+
+    @property
+    def sandbox_id(self) -> str:
+        return self._wrapped.sandbox_id
+
+    def info(self) -> SandboxInfo:
+        return self._trace.capture(
+            "info",
+            {"backend": self.backend, "sandbox_id": self.sandbox_id},
+            self._wrapped.info,
+            output=lambda result: {
+                "sandbox_id": result.sandbox_id,
+                "state": result.state,
+                "raw": result.raw,
+            },
+        )
+
+    def run_command(
+        self,
+        command: str,
+        *,
+        user: str = "root",
+        timeout: int = 30,
+    ) -> CommandResult:
+        return self._trace.capture(
+            "run_command",
+            {
+                "backend": self.backend,
+                "sandbox_id": self.sandbox_id,
+                "command": command,
+                "user": user,
+                "timeout": timeout,
+            },
+            lambda: self._wrapped.run_command(command, user=user, timeout=timeout),
+        )
+
+    def write_file(self, path: str, content: str, *, user: str = "root") -> None:
+        return self._trace.capture(
+            "write_file",
+            {
+                "backend": self.backend,
+                "sandbox_id": self.sandbox_id,
+                "path": path,
+                "user": user,
+                **_content_summary(content),
+            },
+            lambda: self._wrapped.write_file(path, content, user=user),
+            output=lambda _: {"written": True},
+        )
+
+    def read_file(self, path: str, *, user: str = "root") -> str:
+        return self._trace.capture(
+            "read_file",
+            {
+                "backend": self.backend,
+                "sandbox_id": self.sandbox_id,
+                "path": path,
+                "user": user,
+            },
+            lambda: self._wrapped.read_file(path, user=user),
+            output=_content_summary,
+        )
+
+    def run_code(self, code: str, *, timeout: int = 60) -> CodeResult:
+        return self._trace.capture(
+            "run_code",
+            {
+                "backend": self.backend,
+                "sandbox_id": self.sandbox_id,
+                "code": code,
+                "timeout": timeout,
+            },
+            lambda: self._wrapped.run_code(code, timeout=timeout),
+        )
+
+    def pause(self, *, timeout: int = 60) -> None:
+        return self._trace.capture(
+            "pause",
+            {
+                "backend": self.backend,
+                "sandbox_id": self.sandbox_id,
+                "timeout": timeout,
+            },
+            lambda: self._wrapped.pause(timeout=timeout),
+            output=lambda _: {"paused": True},
+        )
+
+    def resume_or_connect(self, *, timeout: int = 60) -> SandboxAdapter:
+        resumed = self._trace.capture(
+            "resume_or_connect",
+            {
+                "backend": self.backend,
+                "sandbox_id": self.sandbox_id,
+                "timeout": timeout,
+            },
+            lambda: self._wrapped.resume_or_connect(timeout=timeout),
+            output=lambda result: {"sandbox_id": result.sandbox_id},
+        )
+        return wrap_adapter(resumed, self._trace)
+
+    def kill(self) -> None:
+        return self._trace.capture(
+            "kill",
+            {"backend": self.backend, "sandbox_id": self.sandbox_id},
+            self._wrapped.kill,
+            output=lambda _: {"killed": True},
+        )
+
+    def close(self) -> None:
+        return self._trace.capture(
+            "close",
+            {"backend": self.backend, "sandbox_id": self.sandbox_id},
+            self._wrapped.close,
+            output=lambda _: {"closed": True},
+        )
+
+
+def wrap_adapter(adapter: SandboxAdapter, trace: TraceCollector | None) -> SandboxAdapter:
+    if trace is None or isinstance(adapter, TracingSandboxAdapter):
+        return adapter
+    return TracingSandboxAdapter(adapter, trace)
+
+
+def _content_summary(content: Any) -> dict[str, Any]:
+    text = str(content)
+    return {
+        "content_length": len(text),
+    }

--- a/tests/e2e/sdk_compat/cases/__init__.py
+++ b/tests/e2e/sdk_compat/cases/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0

--- a/tests/e2e/sdk_compat/cases/commands/test_run.py
+++ b/tests/e2e/sdk_compat/cases/commands/test_run.py
@@ -1,0 +1,78 @@
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import pytest
+
+from framework.assertions import assert_command_ok
+from framework.capabilities import COMMANDS
+
+pytestmark = [
+    pytest.mark.e2e,
+    pytest.mark.sdk_compat,
+    pytest.mark.commands,
+    pytest.mark.p0,
+    pytest.mark.requires_capability(COMMANDS),
+]
+
+
+def test_command_stdout_stderr_and_exit_code(sdk_sandbox, sdk_e2e_config):
+    result = sdk_sandbox.run_command(
+        "printf 'hello-out'; printf 'hello-err' >&2; exit 7",
+        timeout=sdk_e2e_config.command_timeout,
+    )
+
+    assert result.exit_code == 7
+    assert "hello-out" in result.stdout
+    assert "hello-err" in result.stderr
+
+
+def test_command_environment_is_available(sdk_sandbox, sdk_e2e_config):
+    result = sdk_sandbox.run_command(
+        "SDK_COMPAT_VALUE=ok python3 - <<'PY'\n"
+        "import os\n"
+        "print(os.environ['SDK_COMPAT_VALUE'])\n"
+        "PY",
+        timeout=sdk_e2e_config.command_timeout,
+    )
+
+    assert_command_ok(result)
+    assert result.stdout.strip() == "ok"
+
+
+def test_command_handles_special_characters(sdk_sandbox, sdk_e2e_config):
+    text = "!@#$%^&*()_+"
+    result = sdk_sandbox.run_command(
+        f"printf '%s' '{text}'",
+        timeout=sdk_e2e_config.command_timeout,
+    )
+
+    assert_command_ok(result)
+    assert result.stdout == text
+
+
+def test_command_handles_multiline_output(sdk_sandbox, sdk_e2e_config):
+    result = sdk_sandbox.run_command(
+        "printf 'line1\\nline2\\nline3\\n'",
+        timeout=sdk_e2e_config.command_timeout,
+    )
+
+    assert_command_ok(result)
+    assert result.stdout.splitlines() == ["line1", "line2", "line3"]
+
+
+@pytest.mark.p1
+def test_missing_command_returns_127(sdk_sandbox, sdk_e2e_config):
+    result = sdk_sandbox.run_command(
+        "cube_sdk_compat_missing_binary --version",
+        timeout=sdk_e2e_config.command_timeout,
+    )
+
+    assert result.exit_code == 127
+
+
+@pytest.mark.p1
+def test_command_timeout_is_enforced(sdk_sandbox):
+    with pytest.raises(Exception):  # noqa: B017 - SDKs expose timeout as backend-specific errors
+        sdk_sandbox.run_command("sleep 5", timeout=1)

--- a/tests/e2e/sdk_compat/cases/commands/test_run.py
+++ b/tests/e2e/sdk_compat/cases/commands/test_run.py
@@ -74,5 +74,8 @@ def test_missing_command_returns_127(sdk_sandbox, sdk_e2e_config):
 
 @pytest.mark.p1
 def test_command_timeout_is_enforced(sdk_sandbox):
-    with pytest.raises(Exception):  # noqa: B017 - SDKs expose timeout as backend-specific errors
+    with pytest.raises(
+        Exception,
+        match=r"(?i)timeout|timed out|deadline",
+    ):  # noqa: B017 - SDKs expose backend-specific timeout errors
         sdk_sandbox.run_command("sleep 5", timeout=1)

--- a/tests/e2e/sdk_compat/cases/concurrency/test_isolation.py
+++ b/tests/e2e/sdk_compat/cases/concurrency/test_isolation.py
@@ -1,0 +1,38 @@
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import pytest
+
+from framework.capabilities import FILESYSTEM
+from framework.lifecycle import managed_control_sandbox
+
+pytestmark = [
+    pytest.mark.e2e,
+    pytest.mark.sdk_compat,
+    pytest.mark.concurrency,
+    pytest.mark.p2,
+    pytest.mark.requires_capability(FILESYSTEM),
+]
+
+_SHARED_PATH = "/tmp/sdk-compat-sandbox-isolation.txt"
+
+
+def test_two_sandboxes_keep_files_isolated(
+    sdk_sandbox,
+    sdk_backend,
+    sdk_e2e_config,
+):
+    with managed_control_sandbox(
+        sdk_backend,
+        sdk_e2e_config,
+        metadata={"test_role": "isolation_peer"},
+    ) as peer:
+        assert peer.sandbox_id != sdk_sandbox.sandbox_id
+
+        sdk_sandbox.write_file(_SHARED_PATH, "primary")
+        peer.write_file(_SHARED_PATH, "peer")
+
+        assert sdk_sandbox.read_file(_SHARED_PATH) == "primary"
+        assert peer.read_file(_SHARED_PATH) == "peer"

--- a/tests/e2e/sdk_compat/cases/filesystem/test_read_write.py
+++ b/tests/e2e/sdk_compat/cases/filesystem/test_read_write.py
@@ -91,5 +91,8 @@ def test_command_created_file_is_visible_to_files_api(sdk_sandbox, sdk_e2e_confi
 
 
 def test_reading_missing_file_raises(sdk_sandbox):
-    with pytest.raises(Exception):  # noqa: B017 - SDKs expose backend-specific errors
+    with pytest.raises(
+        Exception,
+        match=r"(?i)not found|does not exist|no such file|404",
+    ):  # noqa: B017 - SDKs expose backend-specific file errors
         sdk_sandbox.read_file("/tmp/sdk-compat-does-not-exist.txt")

--- a/tests/e2e/sdk_compat/cases/filesystem/test_read_write.py
+++ b/tests/e2e/sdk_compat/cases/filesystem/test_read_write.py
@@ -1,0 +1,95 @@
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import pytest
+
+from framework.assertions import assert_command_ok
+from framework.capabilities import FILESYSTEM
+
+pytestmark = [
+    pytest.mark.e2e,
+    pytest.mark.sdk_compat,
+    pytest.mark.filesystem,
+    pytest.mark.p0,
+    pytest.mark.requires_capability(FILESYSTEM),
+]
+
+
+def test_file_write_read_roundtrip(sdk_sandbox):
+    path = "/tmp/sdk-compat-file.txt"
+
+    sdk_sandbox.write_file(path, "hello file")
+
+    assert sdk_sandbox.read_file(path) == "hello file"
+
+
+def test_written_file_is_visible_to_commands(sdk_sandbox, sdk_e2e_config):
+    path = "/tmp/sdk-compat-command-visible.txt"
+
+    sdk_sandbox.write_file(path, "from-files-api")
+    result = sdk_sandbox.run_command(
+        f"cat {path}",
+        timeout=sdk_e2e_config.command_timeout,
+    )
+
+    assert_command_ok(result)
+    assert result.stdout == "from-files-api"
+
+
+def test_file_overwrite_replaces_previous_content(sdk_sandbox):
+    path = "/tmp/sdk-compat-overwrite.txt"
+
+    sdk_sandbox.write_file(path, "old")
+    sdk_sandbox.write_file(path, "new")
+
+    assert sdk_sandbox.read_file(path) == "new"
+
+
+def test_multiline_file_roundtrip(sdk_sandbox):
+    path = "/tmp/sdk-compat-multiline.txt"
+    content = "alpha\nbeta\ngamma\n"
+
+    sdk_sandbox.write_file(path, content)
+
+    assert sdk_sandbox.read_file(path) == content
+
+
+def test_deep_path_file_roundtrip(sdk_sandbox, sdk_e2e_config):
+    directory = "/tmp/sdk-compat/deep/path"
+    path = f"{directory}/file.txt"
+    result = sdk_sandbox.run_command(
+        f"mkdir -p {directory}",
+        timeout=sdk_e2e_config.command_timeout,
+    )
+    assert_command_ok(result)
+
+    sdk_sandbox.write_file(path, "deep-content")
+
+    assert sdk_sandbox.read_file(path) == "deep-content"
+
+
+def test_large_text_file_roundtrip(sdk_sandbox):
+    path = "/tmp/sdk-compat-large.txt"
+    content = "sdk-compat-large-line\n" * 4096
+
+    sdk_sandbox.write_file(path, content)
+
+    assert sdk_sandbox.read_file(path) == content
+
+
+def test_command_created_file_is_visible_to_files_api(sdk_sandbox, sdk_e2e_config):
+    path = "/tmp/sdk-compat-command-created.txt"
+    result = sdk_sandbox.run_command(
+        f"printf command-created > {path}",
+        timeout=sdk_e2e_config.command_timeout,
+    )
+
+    assert_command_ok(result)
+    assert sdk_sandbox.read_file(path) == "command-created"
+
+
+def test_reading_missing_file_raises(sdk_sandbox):
+    with pytest.raises(Exception):  # noqa: B017 - SDKs expose backend-specific errors
+        sdk_sandbox.read_file("/tmp/sdk-compat-does-not-exist.txt")

--- a/tests/e2e/sdk_compat/cases/lifecycle/test_auto_lifecycle.py
+++ b/tests/e2e/sdk_compat/cases/lifecycle/test_auto_lifecycle.py
@@ -8,7 +8,7 @@ import time
 import pytest
 
 from framework.assertions import assert_code_ok, assert_command_ok
-from framework.capabilities import LIFECYCLE, RUN_CODE
+from framework.capabilities import LIFECYCLE, PLATFORM_LIFECYCLE, RUN_CODE
 from framework.lifecycle import (
     PLATFORM_LIFECYCLE_SKIP_REASON,
     fetch_state,
@@ -61,6 +61,7 @@ def _wait_for_command_ready(adapter, config) -> None:
 
 
 @pytest.mark.requires_capability(RUN_CODE)
+@pytest.mark.requires_capability(PLATFORM_LIFECYCLE)
 @pytest.mark.requires_code_interpreter
 @pytest.mark.sandbox_create_options(lifecycle={"on_timeout": "pause", "auto_resume": True})
 def test_lifecycle_auto_resume_preserves_state(sdk_sandbox, sdk_e2e_config):
@@ -84,6 +85,7 @@ def test_lifecycle_auto_resume_preserves_state(sdk_sandbox, sdk_e2e_config):
 
 
 @pytest.mark.requires_capability(RUN_CODE)
+@pytest.mark.requires_capability(PLATFORM_LIFECYCLE)
 @pytest.mark.requires_code_interpreter
 @pytest.mark.sandbox_create_options(
     lifecycle={"on_timeout": "pause", "auto_resume": False},
@@ -129,6 +131,7 @@ def test_lifecycle_auto_pause_manual_connect_allows_command_and_run_code(
 
 
 @pytest.mark.requires_capability(RUN_CODE)
+@pytest.mark.requires_capability(PLATFORM_LIFECYCLE)
 @pytest.mark.requires_code_interpreter
 @pytest.mark.sandbox_create_options(
     lifecycle={"on_timeout": "pause", "auto_resume": True}
@@ -164,6 +167,7 @@ def test_lifecycle_auto_pause_auto_resume_allows_command_and_run_code(
 
 
 @pytest.mark.requires_capability(RUN_CODE)
+@pytest.mark.requires_capability(PLATFORM_LIFECYCLE)
 @pytest.mark.requires_code_interpreter
 @pytest.mark.sandbox_create_options(
     lifecycle={"on_timeout": "pause", "auto_resume": True}

--- a/tests/e2e/sdk_compat/cases/lifecycle/test_auto_lifecycle.py
+++ b/tests/e2e/sdk_compat/cases/lifecycle/test_auto_lifecycle.py
@@ -1,0 +1,236 @@
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from framework.assertions import assert_code_ok, assert_command_ok
+from framework.capabilities import LIFECYCLE, RUN_CODE
+from framework.lifecycle import (
+    PLATFORM_LIFECYCLE_SKIP_REASON,
+    fetch_state,
+    managed_control_sandbox,
+    wait_for_platform_destroy,
+    wait_for_platform_pause,
+    wait_until_running,
+)
+
+pytestmark = [
+    pytest.mark.e2e,
+    pytest.mark.sdk_compat,
+    pytest.mark.lifecycle,
+    pytest.mark.p1,
+    pytest.mark.slow,
+    pytest.mark.requires_cubeproxy,
+    pytest.mark.requires_capability(LIFECYCLE),
+]
+
+_SEED_CODE = """\
+hash_val = "sdk-compat-auto-lifecycle"
+pi_approx = 3.1415926535
+print(f"hash_val={hash_val}")
+print(f"pi_approx={pi_approx:.10f}")
+"""
+_RESUME_CODE = """\
+print(f"hash_val={hash_val}")
+print(f"pi_approx={pi_approx:.10f}")
+"""
+_CHECKPOINT = "/tmp/sdk-compat-auto-lifecycle.txt"
+
+
+def _wait_for_command_ready(adapter, config) -> None:
+    deadline = time.monotonic() + config.default_timeout
+    last_error = None
+    while time.monotonic() < deadline:
+        try:
+            result = adapter.run_command(
+                "true",
+                timeout=min(config.command_timeout, 5),
+            )
+            assert_command_ok(result)
+            return
+        except Exception as exc:  # noqa: BLE001 - readiness may fail transiently
+            last_error = exc
+            time.sleep(1)
+    raise AssertionError(
+        f"sandbox did not accept commands within {config.default_timeout}s: {last_error}"
+    )
+
+
+@pytest.mark.requires_capability(RUN_CODE)
+@pytest.mark.requires_code_interpreter
+@pytest.mark.sandbox_create_options(lifecycle={"on_timeout": "pause", "auto_resume": True})
+def test_lifecycle_auto_resume_preserves_state(sdk_sandbox, sdk_e2e_config):
+    seed = sdk_sandbox.run_code(_SEED_CODE, timeout=sdk_e2e_config.run_code_timeout)
+    assert_code_ok(seed)
+    assert any("hash_val=" in line for line in seed.stdout)
+
+    sdk_sandbox.write_file(_CHECKPOINT, "checkpoint-before-idle")
+    before_file = sdk_sandbox.read_file(_CHECKPOINT)
+
+    if not wait_for_platform_pause(sdk_sandbox, sdk_e2e_config):
+        pytest.skip(PLATFORM_LIFECYCLE_SKIP_REASON)
+
+    resumed = sdk_sandbox.run_code(_RESUME_CODE, timeout=sdk_e2e_config.run_code_timeout)
+    assert_code_ok(resumed)
+    assert any("hash_val=sdk-compat-auto-lifecycle" in line for line in resumed.stdout)
+    assert any("pi_approx=3.1415926535" in line for line in resumed.stdout)
+
+    after_file = sdk_sandbox.read_file(_CHECKPOINT)
+    assert after_file == before_file == "checkpoint-before-idle"
+
+
+@pytest.mark.requires_capability(RUN_CODE)
+@pytest.mark.requires_code_interpreter
+@pytest.mark.sandbox_create_options(
+    lifecycle={"on_timeout": "pause", "auto_resume": False},
+)
+def test_lifecycle_auto_pause_manual_connect_allows_command_and_run_code(
+    sdk_sandbox,
+    sdk_e2e_config,
+):
+    seed = sdk_sandbox.run_code(
+        "manual_connect_value = 41",
+        timeout=sdk_e2e_config.run_code_timeout,
+    )
+    assert_code_ok(seed)
+
+    sdk_sandbox.write_file(_CHECKPOINT, "checkpoint-before-manual-connect")
+    if not wait_for_platform_pause(sdk_sandbox, sdk_e2e_config):
+        pytest.skip(PLATFORM_LIFECYCLE_SKIP_REASON)
+
+    resumed = sdk_sandbox.resume_or_connect(timeout=sdk_e2e_config.default_timeout)
+    try:
+        assert wait_until_running(
+            resumed,
+            timeout=sdk_e2e_config.default_timeout,
+        ) == "running"
+        _wait_for_command_ready(resumed, sdk_e2e_config)
+
+        command = resumed.run_command(
+            "printf manual-connect",
+            timeout=sdk_e2e_config.command_timeout,
+        )
+        assert_command_ok(command)
+        assert command.stdout == "manual-connect"
+
+        code = resumed.run_code(
+            "manual_connect_value + 1",
+            timeout=sdk_e2e_config.run_code_timeout,
+        )
+        assert_code_ok(code)
+        assert code.text == "42"
+        assert resumed.read_file(_CHECKPOINT) == "checkpoint-before-manual-connect"
+    finally:
+        resumed.close()
+
+
+@pytest.mark.requires_capability(RUN_CODE)
+@pytest.mark.requires_code_interpreter
+@pytest.mark.sandbox_create_options(
+    lifecycle={"on_timeout": "pause", "auto_resume": True}
+)
+def test_lifecycle_auto_pause_auto_resume_allows_command_and_run_code(
+    sdk_sandbox,
+    sdk_e2e_config,
+):
+    seed = sdk_sandbox.run_code(
+        "auto_resume_value = 41",
+        timeout=sdk_e2e_config.run_code_timeout,
+    )
+    assert_code_ok(seed)
+
+    sdk_sandbox.write_file(_CHECKPOINT, "checkpoint-before-auto-resume")
+    if not wait_for_platform_pause(sdk_sandbox, sdk_e2e_config):
+        pytest.skip(PLATFORM_LIFECYCLE_SKIP_REASON)
+
+    command = sdk_sandbox.run_command(
+        "printf auto-resumed",
+        timeout=sdk_e2e_config.command_timeout,
+    )
+    assert_command_ok(command)
+    assert command.stdout == "auto-resumed"
+
+    code = sdk_sandbox.run_code(
+        "auto_resume_value + 1",
+        timeout=sdk_e2e_config.run_code_timeout,
+    )
+    assert_code_ok(code)
+    assert code.text == "42"
+    assert sdk_sandbox.read_file(_CHECKPOINT) == "checkpoint-before-auto-resume"
+
+
+@pytest.mark.requires_capability(RUN_CODE)
+@pytest.mark.requires_code_interpreter
+@pytest.mark.sandbox_create_options(
+    lifecycle={"on_timeout": "pause", "auto_resume": True}
+)
+def test_lifecycle_auto_resume_is_reentrant(sdk_sandbox, sdk_e2e_config):
+    seed = sdk_sandbox.run_code(
+        "reentrant_value = 7",
+        timeout=sdk_e2e_config.run_code_timeout,
+    )
+    assert_code_ok(seed)
+
+    for expected_value, request in (
+        ("reentrant-1", lambda: sdk_sandbox.run_command(
+            "printf reentrant-1",
+            timeout=sdk_e2e_config.command_timeout,
+        )),
+        ("8", lambda: sdk_sandbox.run_code(
+            "reentrant_value + 1",
+            timeout=sdk_e2e_config.run_code_timeout,
+        )),
+    ):
+        if not wait_for_platform_pause(sdk_sandbox, sdk_e2e_config):
+            pytest.skip(PLATFORM_LIFECYCLE_SKIP_REASON)
+
+        result = request()
+        if expected_value.startswith("reentrant-"):
+            assert_command_ok(result)
+            assert result.stdout == expected_value
+        else:
+            assert_code_ok(result)
+            assert result.text == expected_value
+
+
+@pytest.mark.sandbox_create_options(lifecycle={"on_timeout": "kill"})
+def test_lifecycle_auto_kill_makes_sandbox_unusable(
+    sdk_sandbox,
+    sdk_backend,
+    sdk_e2e_config,
+):
+    sandbox_id = sdk_sandbox.sandbox_id
+    control_state = "unknown"
+
+    result = sdk_sandbox.run_command(
+        "printf auto-kill-seed",
+        timeout=sdk_e2e_config.command_timeout,
+    )
+    assert_command_ok(result)
+
+    destroyed, details = wait_for_platform_destroy(
+        sdk_sandbox,
+        sandbox_id,
+        sdk_backend,
+        sdk_e2e_config,
+    )
+
+    with managed_control_sandbox(sdk_backend, sdk_e2e_config) as control:
+        control_state = fetch_state(control)
+        control_result = control.run_command(
+            "printf control-ok",
+            timeout=sdk_e2e_config.command_timeout,
+        )
+        assert_command_ok(control_result)
+
+    if not destroyed:
+        pytest.skip(
+            f"{PLATFORM_LIFECYCLE_SKIP_REASON}; last_observed={details!r}, "
+            f"control_state={control_state!r}"
+        )
+
+    assert control_state == "running"

--- a/tests/e2e/sdk_compat/cases/lifecycle/test_connect.py
+++ b/tests/e2e/sdk_compat/cases/lifecycle/test_connect.py
@@ -1,0 +1,45 @@
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import pytest
+
+from adapters import connect_adapter
+from framework.assertions import assert_command_ok
+from framework.capabilities import LIFECYCLE
+
+pytestmark = [
+    pytest.mark.e2e,
+    pytest.mark.sdk_compat,
+    pytest.mark.lifecycle,
+    pytest.mark.p1,
+    pytest.mark.requires_capability(LIFECYCLE),
+]
+
+
+def test_connect_existing_sandbox_preserves_id(sdk_sandbox, sdk_backend, sdk_e2e_config):
+    sandbox_id = sdk_sandbox.sandbox_id
+    sdk_sandbox.write_file("/tmp/sdk-compat-connect.txt", "connect-marker")
+
+    connected = connect_adapter(sdk_backend, sandbox_id, sdk_e2e_config)
+    try:
+        assert connected.sandbox_id == sandbox_id
+        assert connected.read_file("/tmp/sdk-compat-connect.txt") == "connect-marker"
+    finally:
+        connected.close()
+
+
+def test_connect_existing_sandbox_allows_commands(sdk_sandbox, sdk_backend, sdk_e2e_config):
+    sandbox_id = sdk_sandbox.sandbox_id
+
+    connected = connect_adapter(sdk_backend, sandbox_id, sdk_e2e_config)
+    try:
+        result = connected.run_command(
+            "printf connected",
+            timeout=sdk_e2e_config.command_timeout,
+        )
+        assert_command_ok(result)
+        assert result.stdout == "connected"
+    finally:
+        connected.close()

--- a/tests/e2e/sdk_compat/cases/lifecycle/test_create.py
+++ b/tests/e2e/sdk_compat/cases/lifecycle/test_create.py
@@ -1,0 +1,40 @@
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import pytest
+
+from framework.assertions import assert_command_ok
+
+pytestmark = [
+    pytest.mark.e2e,
+    pytest.mark.sdk_compat,
+    pytest.mark.lifecycle,
+    pytest.mark.p0,
+]
+
+
+@pytest.mark.smoke
+def test_create_returns_usable_sandbox(sdk_sandbox, sdk_e2e_config):
+    info = sdk_sandbox.info()
+
+    assert sdk_sandbox.sandbox_id
+    assert info.sandbox_id == sdk_sandbox.sandbox_id
+
+    result = sdk_sandbox.run_command(
+        "uname -s",
+        timeout=sdk_e2e_config.command_timeout,
+    )
+    assert_command_ok(result)
+    assert result.stdout.strip().lower() == "linux", (
+        f"expected Linux sandbox, got stdout={result.stdout!r} stderr={result.stderr!r}"
+    )
+
+
+def test_info_is_stable_for_created_sandbox(sdk_sandbox):
+    first = sdk_sandbox.info()
+    second = sdk_sandbox.info()
+
+    assert first.sandbox_id == sdk_sandbox.sandbox_id
+    assert second.sandbox_id == sdk_sandbox.sandbox_id

--- a/tests/e2e/sdk_compat/cases/lifecycle/test_create_options.py
+++ b/tests/e2e/sdk_compat/cases/lifecycle/test_create_options.py
@@ -1,0 +1,90 @@
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from framework.assertions import assert_command_ok, assert_stdout_contains
+from framework.capabilities import LIFECYCLE
+from framework.lifecycle import metadata_from_info
+
+pytestmark = [
+    pytest.mark.e2e,
+    pytest.mark.sdk_compat,
+    pytest.mark.lifecycle,
+    pytest.mark.p1,
+    pytest.mark.requires_capability(LIFECYCLE),
+]
+
+
+def test_create_metadata_visible_in_info(sdk_sandbox):
+    metadata = metadata_from_info(sdk_sandbox.info().raw)
+
+    assert metadata.get("test_suite") == "sdk_compat"
+    assert metadata.get("test_backend")
+
+
+@pytest.mark.sandbox_create_options(metadata={"sdk_compat_custom": "lifecycle-metadata"})
+def test_create_custom_metadata_visible_in_info(sdk_sandbox):
+    metadata = metadata_from_info(sdk_sandbox.info().raw)
+
+    assert metadata.get("sdk_compat_custom") == "lifecycle-metadata"
+    assert metadata.get("test_suite") == "sdk_compat"
+
+
+@pytest.mark.sandbox_create_options(env_vars={"SDK_COMPAT_E2E_VAR": "lifecycle-env"})
+def test_create_env_vars_visible_to_command(sdk_sandbox, sdk_e2e_config):
+    result = sdk_sandbox.run_command(
+        'printf "%s" "$SDK_COMPAT_E2E_VAR"',
+        timeout=sdk_e2e_config.command_timeout,
+    )
+    assert_command_ok(result)
+    assert result.stdout == "lifecycle-env"
+
+
+@pytest.mark.sandbox_create_options(timeout=120)
+def test_create_timeout_visible_in_info(sdk_sandbox):
+    requested_timeout = 120
+    observed_at = datetime.now(timezone.utc)
+    raw = sdk_sandbox.info().raw
+
+    returned_timeout = raw.get("timeout")
+    end_at = raw.get("endAt")
+
+    if returned_timeout is not None:
+        assert int(returned_timeout) == requested_timeout
+
+    assert end_at or returned_timeout is not None, (
+        "sandbox info must expose either timeout or endAt to verify the "
+        f"requested idle timeout; raw={raw!r}"
+    )
+
+    if end_at:
+        try:
+            deadline = datetime.fromisoformat(str(end_at).replace("Z", "+00:00"))
+        except ValueError as exc:
+            raise AssertionError(f"invalid endAt returned by sandbox info: {end_at!r}") from exc
+
+        if deadline.tzinfo is None:
+            deadline = deadline.replace(tzinfo=timezone.utc)
+
+        expected_deadline = observed_at + timedelta(seconds=requested_timeout)
+        drift_seconds = abs((deadline - expected_deadline).total_seconds())
+        allowed_drift_seconds = max(15, requested_timeout * 0.3)
+        assert drift_seconds <= allowed_drift_seconds, (
+            f"endAt is not consistent with timeout={requested_timeout}s: "
+            f"expected around {expected_deadline.isoformat()}, got {deadline.isoformat()}, "
+            f"drift={drift_seconds:.1f}s, allowed={allowed_drift_seconds:.1f}s"
+        )
+
+
+def test_create_command_smoke_after_options(sdk_sandbox, sdk_e2e_config):
+    result = sdk_sandbox.run_command(
+        "printf lifecycle-options",
+        timeout=sdk_e2e_config.command_timeout,
+    )
+    assert_command_ok(result)
+    assert_stdout_contains(result, "lifecycle-options")

--- a/tests/e2e/sdk_compat/cases/lifecycle/test_kill.py
+++ b/tests/e2e/sdk_compat/cases/lifecycle/test_kill.py
@@ -1,0 +1,64 @@
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import pytest
+
+from adapters.api_adapter import ApiClient
+from framework.capabilities import LIFECYCLE
+from framework.lifecycle import assert_connect_fails, is_terminal_failure, sandbox_listed
+
+pytestmark = [
+    pytest.mark.e2e,
+    pytest.mark.sdk_compat,
+    pytest.mark.lifecycle,
+    pytest.mark.p1,
+    pytest.mark.requires_capability(LIFECYCLE),
+]
+
+
+def test_kill_prevents_reconnect(sdk_sandbox, sdk_backend, sdk_e2e_config):
+    sandbox_id = sdk_sandbox.sandbox_id
+
+    sdk_sandbox.kill()
+
+    failure = assert_connect_fails(sandbox_id, sdk_backend, sdk_e2e_config)
+    assert failure
+
+    api = ApiClient(sdk_e2e_config)
+    try:
+        assert api.get_sandbox(sandbox_id) == {}
+    finally:
+        api.close()
+
+
+def test_kill_removes_sandbox_from_listing(sdk_sandbox, sdk_backend, sdk_e2e_config):
+    sandbox_id = sdk_sandbox.sandbox_id
+
+    sdk_sandbox.kill()
+
+    listed = sandbox_listed(sandbox_id, sdk_backend, sdk_e2e_config)
+    if listed is None:
+        pytest.skip(f"backend {sdk_backend!r} does not expose a reliable sandbox list API")
+    assert listed is False
+
+
+def test_kill_is_idempotent_or_reports_terminal_state(
+    sdk_sandbox,
+    sdk_backend,
+    sdk_e2e_config,
+):
+    sandbox_id = sdk_sandbox.sandbox_id
+    sdk_sandbox.kill()
+
+    try:
+        sdk_sandbox.kill()
+    except Exception as exc:  # noqa: BLE001 - backend-specific terminal response
+        assert is_terminal_failure(exc), (
+            "second kill must expose a terminal-state response, "
+            f"got {type(exc).__name__}: {exc}"
+        )
+
+    failure = assert_connect_fails(sandbox_id, sdk_backend, sdk_e2e_config)
+    assert failure

--- a/tests/e2e/sdk_compat/cases/lifecycle/test_pause_resume.py
+++ b/tests/e2e/sdk_compat/cases/lifecycle/test_pause_resume.py
@@ -1,0 +1,87 @@
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import pytest
+
+from framework.assertions import assert_code_ok, assert_command_ok
+from framework.capabilities import PAUSE_RESUME, RUN_CODE
+from framework.lifecycle import wait_until_paused
+
+pytestmark = [
+    pytest.mark.e2e,
+    pytest.mark.sdk_compat,
+    pytest.mark.lifecycle,
+    pytest.mark.p1,
+    pytest.mark.requires_capability(PAUSE_RESUME),
+]
+
+
+def test_pause_sets_state_paused(sdk_sandbox, sdk_e2e_config):
+    sdk_sandbox.pause(timeout=sdk_e2e_config.default_timeout)
+    state = wait_until_paused(sdk_sandbox, timeout=sdk_e2e_config.default_timeout)
+    assert state == "paused"
+
+
+def test_pause_and_connect_resume_preserves_files(sdk_sandbox, sdk_e2e_config):
+    sdk_sandbox.write_file("/tmp/sdk-compat-pause.txt", "before-pause")
+
+    sdk_sandbox.pause(timeout=sdk_e2e_config.default_timeout)
+    resumed = sdk_sandbox.resume_or_connect(timeout=sdk_e2e_config.default_timeout)
+    try:
+        assert resumed.sandbox_id == sdk_sandbox.sandbox_id
+        assert resumed.read_file("/tmp/sdk-compat-pause.txt") == "before-pause"
+    finally:
+        resumed.close()
+
+
+def test_pause_and_connect_resume_allows_commands(sdk_sandbox, sdk_e2e_config):
+    sdk_sandbox.pause(timeout=sdk_e2e_config.default_timeout)
+    resumed = sdk_sandbox.resume_or_connect(timeout=sdk_e2e_config.default_timeout)
+    try:
+        result = resumed.run_command(
+            "printf resumed",
+            timeout=sdk_e2e_config.command_timeout,
+        )
+        assert_command_ok(result)
+        assert result.stdout == "resumed"
+    finally:
+        resumed.close()
+
+
+@pytest.mark.sandbox_create_options(env_vars={"SDK_COMPAT_PAUSE_ENV": "pause-env"})
+def test_pause_and_connect_resume_preserves_env_vars(sdk_sandbox, sdk_e2e_config):
+    sdk_sandbox.pause(timeout=sdk_e2e_config.default_timeout)
+    resumed = sdk_sandbox.resume_or_connect(timeout=sdk_e2e_config.default_timeout)
+    try:
+        result = resumed.run_command(
+            'printf "%s" "$SDK_COMPAT_PAUSE_ENV"',
+            timeout=sdk_e2e_config.command_timeout,
+        )
+        assert_command_ok(result)
+        assert result.stdout == "pause-env"
+    finally:
+        resumed.close()
+
+
+@pytest.mark.requires_capability(RUN_CODE)
+@pytest.mark.requires_code_interpreter
+def test_pause_and_connect_resume_preserves_run_code_state(sdk_sandbox, sdk_e2e_config):
+    first = sdk_sandbox.run_code(
+        "sdk_compat_pause_value = 84",
+        timeout=sdk_e2e_config.run_code_timeout,
+    )
+    assert_code_ok(first)
+
+    sdk_sandbox.pause(timeout=sdk_e2e_config.default_timeout)
+    resumed = sdk_sandbox.resume_or_connect(timeout=sdk_e2e_config.default_timeout)
+    try:
+        second = resumed.run_code(
+            "sdk_compat_pause_value + 1",
+            timeout=sdk_e2e_config.run_code_timeout,
+        )
+        assert_code_ok(second)
+        assert second.text == "85"
+    finally:
+        resumed.close()

--- a/tests/e2e/sdk_compat/cases/network/test_policy.py
+++ b/tests/e2e/sdk_compat/cases/network/test_policy.py
@@ -1,0 +1,173 @@
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from framework.assertions import assert_command_ok
+from framework.capabilities import NETWORK_ALLOW_DENY, NETWORK_PUBLIC_ACCESS
+
+TCP_TARGET_IP = os.environ.get("SDK_E2E_TCP_TARGET_IP", "8.8.8.8")
+TCP_TARGET_PORT = int(os.environ.get("SDK_E2E_TCP_TARGET_PORT", "53"))
+ALTERNATE_TCP_TARGET_IP = os.environ.get(
+    "SDK_E2E_ALTERNATE_TCP_TARGET_IP",
+    "1.1.1.1",
+)
+
+pytestmark = [
+    pytest.mark.e2e,
+    pytest.mark.sdk_compat,
+    pytest.mark.network,
+    pytest.mark.p1,
+    pytest.mark.requires_internet,
+]
+
+
+def _tcp_probe_command(
+    host: str = TCP_TARGET_IP,
+    port: int = TCP_TARGET_PORT,
+    timeout: int = 5,
+) -> str:
+    return (
+        "python3 - <<'PY'\n"
+        "import socket\n"
+        "try:\n"
+        "    s = socket.socket()\n"
+        f"    s.settimeout({timeout!r})\n"
+        f"    rc = s.connect_ex(({host!r}, {port}))\n"
+        "    print('OK' if rc == 0 else f'FAIL:{rc}')\n"
+        "except Exception as exc:\n"
+        "    print(f'ERROR:{type(exc).__name__}:{exc}')\n"
+        "finally:\n"
+        "    try:\n"
+        "        s.close()\n"
+        "    except Exception:\n"
+        "        pass\n"
+        "PY"
+    )
+
+
+def _assert_tcp_reachable(result, target: str) -> None:
+    assert_command_ok(result)
+    assert result.stdout.strip() == "OK", (
+        f"TCP target {target}:{TCP_TARGET_PORT} should be reachable; "
+        f"stdout={result.stdout!r} stderr={result.stderr!r}"
+    )
+
+
+def _assert_tcp_blocked(result, target: str) -> None:
+    assert_command_ok(result)
+    output = result.stdout.strip()
+    assert output.startswith("FAIL:"), (
+        f"TCP target {target}:{TCP_TARGET_PORT} should be blocked; "
+        f"stdout={result.stdout!r} stderr={result.stderr!r}"
+    )
+
+
+@pytest.mark.requires_capability(NETWORK_ALLOW_DENY)
+@pytest.mark.sandbox_create_options(
+    network={
+        "allow_out": [TCP_TARGET_IP],
+        "deny_out": ["0.0.0.0/0"],
+    },
+)
+def test_allow_out_can_punch_through_deny_all(sdk_sandbox, sdk_e2e_config):
+    result = sdk_sandbox.run_command(
+        _tcp_probe_command(timeout=sdk_e2e_config.network_probe_timeout),
+        timeout=sdk_e2e_config.command_timeout,
+    )
+
+    assert_command_ok(result)
+    assert result.stdout.strip() == "OK", (
+        f"allow_out did not permit {TCP_TARGET_IP}:{TCP_TARGET_PORT}; "
+        f"stdout={result.stdout!r} stderr={result.stderr!r}"
+    )
+
+
+@pytest.mark.requires_capability(NETWORK_ALLOW_DENY)
+@pytest.mark.sandbox_create_options(
+    network={
+        "deny_out": ["0.0.0.0/0"],
+    },
+)
+def test_deny_out_blocks_public_tcp(sdk_sandbox, sdk_e2e_config):
+    result = sdk_sandbox.run_command(
+        _tcp_probe_command(timeout=sdk_e2e_config.network_probe_timeout),
+        timeout=sdk_e2e_config.command_timeout,
+    )
+
+    _assert_tcp_blocked(result, TCP_TARGET_IP)
+
+
+@pytest.mark.requires_capability(NETWORK_PUBLIC_ACCESS)
+@pytest.mark.sandbox_create_options(allow_internet_access=False)
+def test_allow_internet_access_false_blocks_public_tcp(sdk_sandbox, sdk_e2e_config):
+    result = sdk_sandbox.run_command(
+        _tcp_probe_command(timeout=sdk_e2e_config.network_probe_timeout),
+        timeout=sdk_e2e_config.command_timeout,
+    )
+
+    _assert_tcp_blocked(result, TCP_TARGET_IP)
+
+
+@pytest.mark.requires_capability(NETWORK_ALLOW_DENY)
+@pytest.mark.requires_capability(NETWORK_PUBLIC_ACCESS)
+@pytest.mark.sandbox_create_options(
+    allow_internet_access=False,
+    network={"allow_out": [TCP_TARGET_IP]},
+)
+def test_allow_out_works_when_public_access_is_disabled(sdk_sandbox, sdk_e2e_config):
+    allowed = sdk_sandbox.run_command(
+        _tcp_probe_command(TCP_TARGET_IP, timeout=sdk_e2e_config.network_probe_timeout),
+        timeout=sdk_e2e_config.command_timeout,
+    )
+    _assert_tcp_reachable(allowed, TCP_TARGET_IP)
+
+    blocked = sdk_sandbox.run_command(
+        _tcp_probe_command(
+            ALTERNATE_TCP_TARGET_IP,
+            timeout=sdk_e2e_config.network_probe_timeout,
+        ),
+        timeout=sdk_e2e_config.command_timeout,
+    )
+    _assert_tcp_blocked(blocked, ALTERNATE_TCP_TARGET_IP)
+
+
+@pytest.mark.requires_capability(NETWORK_ALLOW_DENY)
+@pytest.mark.requires_capability(NETWORK_PUBLIC_ACCESS)
+@pytest.mark.sandbox_create_options(
+    allow_internet_access=True,
+    network={"deny_out": [TCP_TARGET_IP]},
+)
+def test_deny_out_blocks_selected_target_but_preserves_public_access(
+    sdk_sandbox,
+    sdk_e2e_config,
+):
+    blocked = sdk_sandbox.run_command(
+        _tcp_probe_command(TCP_TARGET_IP, timeout=sdk_e2e_config.network_probe_timeout),
+        timeout=sdk_e2e_config.command_timeout,
+    )
+    _assert_tcp_blocked(blocked, TCP_TARGET_IP)
+
+    allowed = sdk_sandbox.run_command(
+        _tcp_probe_command(
+            ALTERNATE_TCP_TARGET_IP,
+            timeout=sdk_e2e_config.network_probe_timeout,
+        ),
+        timeout=sdk_e2e_config.command_timeout,
+    )
+    _assert_tcp_reachable(allowed, ALTERNATE_TCP_TARGET_IP)
+
+
+@pytest.mark.requires_capability(NETWORK_PUBLIC_ACCESS)
+@pytest.mark.sandbox_create_options(allow_internet_access=False)
+def test_no_internet_still_allows_internal_commands(sdk_sandbox, sdk_e2e_config):
+    result = sdk_sandbox.run_command(
+        "printf isolated-execution-ok",
+        timeout=sdk_e2e_config.command_timeout,
+    )
+    assert_command_ok(result)
+    assert result.stdout == "isolated-execution-ok"

--- a/tests/e2e/sdk_compat/cases/run_code/test_python.py
+++ b/tests/e2e/sdk_compat/cases/run_code/test_python.py
@@ -1,0 +1,81 @@
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import pytest
+
+from framework.assertions import assert_code_ok
+from framework.capabilities import RUN_CODE
+
+pytestmark = [
+    pytest.mark.e2e,
+    pytest.mark.sdk_compat,
+    pytest.mark.run_code,
+    pytest.mark.p0,
+    pytest.mark.requires_capability(RUN_CODE),
+    pytest.mark.requires_code_interpreter,
+]
+
+
+def test_run_code_returns_expression_text(sdk_sandbox, sdk_e2e_config):
+    result = sdk_sandbox.run_code("1 + 2", timeout=sdk_e2e_config.run_code_timeout)
+
+    assert_code_ok(result)
+    assert result.text == "3"
+
+
+def test_run_code_captures_stdout(sdk_sandbox, sdk_e2e_config):
+    result = sdk_sandbox.run_code(
+        "print('hello from python')",
+        timeout=sdk_e2e_config.run_code_timeout,
+    )
+
+    assert_code_ok(result)
+    assert any(line.strip() == "hello from python" for line in result.stdout)
+
+
+def test_run_code_captures_stderr(sdk_sandbox, sdk_e2e_config):
+    result = sdk_sandbox.run_code(
+        "import sys\nprint('hello stderr', file=sys.stderr)",
+        timeout=sdk_e2e_config.run_code_timeout,
+    )
+
+    assert_code_ok(result)
+    assert any(line.strip() == "hello stderr" for line in result.stderr)
+
+
+@pytest.mark.p1
+def test_run_code_preserves_kernel_state(sdk_sandbox, sdk_e2e_config):
+    first = sdk_sandbox.run_code(
+        "sdk_compat_value = 41",
+        timeout=sdk_e2e_config.run_code_timeout,
+    )
+    second = sdk_sandbox.run_code(
+        "sdk_compat_value + 1",
+        timeout=sdk_e2e_config.run_code_timeout,
+    )
+
+    assert_code_ok(first)
+    assert_code_ok(second)
+    assert second.text == "42"
+
+
+@pytest.mark.p1
+def test_run_code_reports_python_errors(sdk_sandbox, sdk_e2e_config):
+    result = sdk_sandbox.run_code(
+        "raise ValueError('sdk compat boom')",
+        timeout=sdk_e2e_config.run_code_timeout,
+    )
+
+    assert result.error is not None
+
+
+@pytest.mark.p1
+def test_run_code_reports_syntax_errors(sdk_sandbox, sdk_e2e_config):
+    result = sdk_sandbox.run_code(
+        "def broken(:\n    pass",
+        timeout=sdk_e2e_config.run_code_timeout,
+    )
+
+    assert result.error is not None

--- a/tests/e2e/sdk_compat/conftest.py
+++ b/tests/e2e/sdk_compat/conftest.py
@@ -1,0 +1,431 @@
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import os
+import sys
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[3]
+SDK_COMPAT_ROOT = Path(__file__).resolve().parent
+sys.path.insert(0, str(SDK_COMPAT_ROOT))
+
+from adapters import create_adapter  # noqa: E402
+from framework.cleanup import safe_kill  # noqa: E402
+from framework.capabilities import CODE_INTERPRETER, CUBESANDBOX_CAPABILITIES, E2B_CAPABILITIES  # noqa: E402
+from framework.config import SdkE2EConfig  # noqa: E402
+from framework.preflight import run_preflight  # noqa: E402
+from framework.reporting import JsonlReporter  # noqa: E402
+from framework.trace import TraceCollector, reset_current_trace, set_current_trace  # noqa: E402
+
+
+def _load_dotenv(path: Path) -> None:
+    if not path.exists():
+        return
+    for raw_line in path.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        if line.startswith("export "):
+            line = line[len("export ") :].strip()
+        key, value = line.split("=", 1)
+        key = key.strip()
+        value = _strip_env_value(value.strip())
+        if key:
+            os.environ.setdefault(key, value)
+
+
+def _strip_env_value(value: str) -> str:
+    if len(value) >= 2 and value[0] == value[-1] and value[0] in {"'", '"'}:
+        return value[1:-1]
+    return value
+
+
+_load_dotenv(SDK_COMPAT_ROOT / ".env")
+
+
+def pytest_addoption(parser: pytest.Parser) -> None:
+    group = parser.getgroup("sdk compat e2e")
+    group.addoption(
+        "--run-e2e",
+        action="store_true",
+        default=False,
+        help="run tests that hit a live CubeAPI/CubeProxy environment",
+    )
+    group.addoption(
+        "--sdk-e2e-backends",
+        default=None,
+        help="comma-separated backends to run; defaults to cubesandbox",
+    )
+    group.addoption(
+        "--cube-api-url",
+        default=None,
+        help="CubeAPI URL; defaults to CUBE_API_URL or http://127.0.0.1:3000",
+    )
+    group.addoption(
+        "--cube-template-id",
+        default=None,
+        help="template ID for SDK E2E; defaults to CUBE_TEMPLATE_ID",
+    )
+    group.addoption(
+        "--sdk-e2e-trace",
+        action="store_true",
+        default=False,
+        help="print every SDK adapter operation and include traces for passed tests",
+    )
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    for marker in (
+        "sdk_compat: SDK compatibility E2E tests",
+        "requires_capability(name): current SDK backend must support this capability",
+        "sandbox_create_options(**kwargs): SDK sandbox create options for this test",
+        "requires_code_interpreter: test requires a stateful Code Interpreter kernel",
+        "requires_internet: test requires public internet access from the sandbox",
+        "requires_cubeproxy: test requires CubeProxy routing to the sandbox",
+    ):
+        config.addinivalue_line("markers", marker)
+
+
+def pytest_generate_tests(metafunc: pytest.Metafunc) -> None:
+    if "sdk_backend" not in metafunc.fixturenames:
+        return
+    cfg = _config_from_pytest(metafunc.config)
+    metafunc.parametrize("sdk_backend", cfg.backends, ids=list(cfg.backends))
+
+
+def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item]) -> None:
+    if config.getoption("--run-e2e"):
+        return
+    skip = pytest.mark.skip(reason="live SDK E2E disabled; pass --run-e2e to run")
+    for item in items:
+        item.add_marker(skip)
+
+
+@pytest.hookimpl(hookwrapper=True)
+def pytest_runtest_makereport(item: pytest.Item, call: pytest.CallInfo):
+    outcome = yield
+    report = outcome.get_result()
+    setattr(item, f"rep_{report.when}", report)
+    if report.when not in {"setup", "call", "teardown"}:
+        return
+    if report.when == "setup" and report.passed:
+        return
+
+    reporter = item.funcargs.get("sdk_e2e_reporter")
+    if reporter is None:
+        return
+
+    adapter = item.funcargs.get("sdk_sandbox")
+    trace = item.funcargs.get("sdk_e2e_trace")
+    sandbox_id = getattr(adapter, "sandbox_id", None)
+    backend = item.funcargs.get("sdk_backend") or getattr(adapter, "backend", None)
+    payload = {
+        "nodeid": item.nodeid,
+        "backend": backend,
+        "sandbox_id": sandbox_id,
+        "phase": report.when,
+        "outcome": report.outcome,
+        "duration": report.duration,
+    }
+    if report.failed:
+        payload["error"] = report.longreprtext
+        if trace is not None:
+            payload["trace"] = trace.snapshot()
+            if not getattr(item, "_sdk_e2e_trace_dumped", False):
+                terminal = item.config.pluginmanager.get_plugin("terminalreporter")
+                if terminal is not None:
+                    terminal.write_sep("=", "SDK E2E trace")
+                    terminal.write_line(trace.format_failure())
+                item._sdk_e2e_trace_dumped = True
+        if adapter is not None:
+            try:
+                payload["sandbox_info"] = adapter.info().raw
+            except Exception as exc:  # noqa: BLE001 - diagnostics must not hide the failure
+                payload["sandbox_info_error"] = str(exc)
+    elif report.skipped:
+        payload["reason"] = str(report.longrepr)
+    elif report.when == "call" and trace is not None and trace.verbose:
+        payload["trace"] = trace.snapshot()
+
+    reporter.record_test_result(**payload)
+
+
+def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> None:
+    reporter = getattr(session.config, "_sdk_e2e_reporter", None)
+    if reporter is not None:
+        reporter.close()
+
+
+@pytest.fixture(scope="session")
+def sdk_e2e_config(pytestconfig: pytest.Config) -> SdkE2EConfig:
+    cfg = _config_from_pytest(pytestconfig)
+    if cfg.cube_python_sdk_path:
+        sys.path.insert(0, cfg.cube_python_sdk_path)
+    else:
+        sys.path.insert(0, str(ROOT / "sdk" / "python"))
+    for key, value in cfg.env().items():
+        os.environ.setdefault(key, value)
+    if pytestconfig.getoption("--run-e2e"):
+        _log_effective_environment(cfg)
+    return cfg
+
+
+@pytest.fixture(scope="session")
+def sdk_e2e_reporter(
+    sdk_e2e_config: SdkE2EConfig,
+    pytestconfig: pytest.Config,
+) -> JsonlReporter:
+    reporter = JsonlReporter(sdk_e2e_config.report_dir)
+    pytestconfig._sdk_e2e_reporter = reporter
+    return reporter
+
+
+@pytest.fixture()
+def sdk_e2e_trace(request: pytest.FixtureRequest, pytestconfig: pytest.Config) -> TraceCollector:
+    verbose = pytestconfig.getoption("--sdk-e2e-trace") or _env_true("SDK_E2E_TRACE")
+    terminal = pytestconfig.pluginmanager.get_plugin("terminalreporter")
+
+    def _emit(message: str) -> None:
+        if terminal is not None:
+            terminal.write_line(message)
+
+    return TraceCollector(
+        request.node.nodeid,
+        verbose=verbose,
+        emit=_emit,
+    )
+
+
+@pytest.fixture(scope="session", autouse=True)
+def sdk_e2e_preflight(pytestconfig: pytest.Config, sdk_e2e_config: SdkE2EConfig, sdk_e2e_reporter: JsonlReporter):
+    if not pytestconfig.getoption("--run-e2e"):
+        return
+    try:
+        run_preflight(sdk_e2e_config, sdk_e2e_reporter)
+    except RuntimeError as exc:
+        pytest.exit(str(exc), returncode=2)
+
+
+@pytest.fixture()
+def sdk_sandbox(
+    request: pytest.FixtureRequest,
+    sdk_backend: str,
+    sdk_e2e_config: SdkE2EConfig,
+    sdk_e2e_reporter: JsonlReporter,
+    sdk_e2e_trace: TraceCollector,
+):
+    for marker in request.node.iter_markers("requires_capability"):
+        capability = marker.args[0]
+        if capability not in _capabilities_for_backend(sdk_backend):
+            pytest.skip(f"backend {sdk_backend!r} does not support capability {capability!r}")
+
+    if request.node.get_closest_marker("requires_code_interpreter"):
+        if CODE_INTERPRETER not in _capabilities_for_backend(sdk_backend):
+            pytest.skip(
+                f"backend {sdk_backend!r} does not support stateful Code Interpreter"
+            )
+
+    if request.node.get_closest_marker("requires_internet") and _env_true(
+        "SDK_E2E_SKIP_INTERNET_TESTS"
+    ):
+        pytest.skip("internet-dependent SDK E2E tests disabled by SDK_E2E_SKIP_INTERNET_TESTS")
+
+    if request.node.get_closest_marker("requires_cubeproxy") and not sdk_e2e_config.platform_lifecycle_enabled:
+        pytest.skip(
+            "platform lifecycle tests require SDK_E2E_PLATFORM_LIFECYCLE=true "
+            "(cube-proxy + lifecycle manager coordination)"
+        )
+
+    if not sdk_e2e_config.cube_template_id:
+        pytest.skip("CUBE_TEMPLATE_ID or --cube-template-id is required for SDK E2E")
+
+    create_options = _create_options_for_node(request.node)
+    if sdk_backend == "e2b" and _is_auto_pause_case(create_options):
+        pytest.skip("e2b backend does not cover CubeSandbox platform-managed auto-pause cases")
+
+    metadata = {
+        "test_suite": "sdk_compat",
+        "test_backend": sdk_backend,
+        "test_nodeid": request.node.nodeid,
+        "test_run_id": uuid.uuid4().hex,
+    }
+    if request.node.get_closest_marker("requires_cubeproxy"):
+        create_options.setdefault("timeout", sdk_e2e_config.platform_lifecycle_idle_timeout)
+    request.node._sdk_e2e_backend = sdk_backend
+    trace_token = set_current_trace(sdk_e2e_trace)
+    adapter = None
+    try:
+        try:
+            _setup_log(
+                f"creating sandbox backend={sdk_backend} "
+                f"nodeid={request.node.nodeid}"
+            )
+            adapter = create_adapter(
+                sdk_backend,
+                sdk_e2e_config,
+                metadata=metadata,
+                create_options=create_options,
+            )
+        except ImportError as exc:
+            pytest.skip(str(exc))
+        try:
+            request.node._sdk_e2e_sandbox_id = adapter.sandbox_id
+            _setup_log(
+                f"sandbox created backend={sdk_backend} "
+                f"sandbox_id={adapter.sandbox_id}"
+            )
+
+            sdk_e2e_reporter.record(
+                "sandbox_created",
+                backend=sdk_backend,
+                sandbox_id=adapter.sandbox_id,
+                nodeid=request.node.nodeid,
+            )
+            yield adapter
+        finally:
+            _cleanup_sdk_sandbox(
+                adapter,
+                request,
+                sdk_backend,
+                sdk_e2e_config,
+                sdk_e2e_reporter,
+            )
+    finally:
+        reset_current_trace(trace_token)
+
+
+def _config_from_pytest(config: pytest.Config) -> SdkE2EConfig:
+    return SdkE2EConfig.from_env(
+        backends=config.getoption("--sdk-e2e-backends"),
+        cube_api_url=config.getoption("--cube-api-url"),
+        cube_template_id=config.getoption("--cube-template-id"),
+    )
+
+
+def _capabilities_for_backend(backend: str) -> frozenset[str]:
+    if backend == "cubesandbox":
+        return CUBESANDBOX_CAPABILITIES
+    if backend == "e2b":
+        return E2B_CAPABILITIES
+    return frozenset()
+
+
+def _create_options_for_node(node: pytest.Item) -> dict:
+    create_options: dict = {}
+    for marker in node.iter_markers("sandbox_create_options"):
+        create_options.update(marker.kwargs)
+        if marker.args:
+            if len(marker.args) != 1 or not isinstance(marker.args[0], dict):
+                raise ValueError("sandbox_create_options accepts keyword arguments or one dict argument")
+            create_options.update(marker.args[0])
+    return create_options
+
+
+def _cleanup_sdk_sandbox(
+    adapter,
+    request: pytest.FixtureRequest,
+    sdk_backend: str,
+    sdk_e2e_config: SdkE2EConfig,
+    sdk_e2e_reporter: JsonlReporter,
+) -> None:
+    failed = _test_failed(request.node)
+    if sdk_e2e_config.keep_sandbox_on_failure and failed:
+        errors: list[str] = []
+        try:
+            adapter.close()
+        except Exception as exc:  # noqa: BLE001 - keep remote sandbox, close local handles best-effort
+            errors.append(f"{adapter.backend}.close failed for {adapter.sandbox_id}: {exc}")
+        sdk_e2e_reporter.record(
+            "sandbox_kept",
+            backend=sdk_backend,
+            sandbox_id=adapter.sandbox_id,
+            nodeid=request.node.nodeid,
+            reason="test_failed",
+            errors=errors,
+        )
+        return
+
+    errors = safe_kill(adapter, sdk_e2e_config)
+    sdk_e2e_reporter.record(
+        "sandbox_cleanup",
+        backend=sdk_backend,
+        sandbox_id=adapter.sandbox_id,
+        nodeid=request.node.nodeid,
+        errors=errors,
+    )
+
+
+def _is_auto_pause_case(create_options: dict) -> bool:
+    lifecycle = create_options.get("lifecycle")
+    if not isinstance(lifecycle, dict):
+        return False
+    on_timeout = lifecycle.get("on_timeout")
+    if isinstance(on_timeout, dict):
+        return on_timeout.get("action") == "pause"
+    return on_timeout == "pause"
+
+
+def _test_failed(node: pytest.Item) -> bool:
+    return any(
+        getattr(report, "failed", False)
+        for report in (
+            getattr(node, "rep_setup", None),
+            getattr(node, "rep_call", None),
+        )
+    )
+
+
+def _env_true(name: str) -> bool:
+    return os.environ.get(name, "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _log_effective_environment(cfg: SdkE2EConfig) -> None:
+    fields = {
+        "SDK_E2E_BACKENDS": ",".join(cfg.backends),
+        "CUBE_API_URL": cfg.cube_api_url,
+        "CUBE_TEMPLATE_ID": cfg.cube_template_id,
+        "CUBE_API_KEY": _presence("CUBE_API_KEY"),
+        "CUBE_PROXY_NODE_IP": cfg.cube_proxy_node_ip,
+        "CUBE_PROXY_PORT_HTTP": str(cfg.cube_proxy_port_http),
+        "CUBE_SANDBOX_DOMAIN": cfg.cube_sandbox_domain,
+        "SDK_E2E_PLATFORM_LIFECYCLE": str(cfg.platform_lifecycle_enabled).lower(),
+    }
+    if "e2b" in cfg.backends:
+        fields.update(
+            {
+                "E2B_EFFECTIVE_API_URL": cfg.cube_api_url,
+                "E2B_API_KEY": _e2b_api_key_source(),
+                "SSL_CERT_FILE": os.environ.get("SSL_CERT_FILE"),
+            }
+        )
+    summary = " ".join(
+        f"{key}={_display_env_value(value)}" for key, value in fields.items()
+    )
+    _setup_log(f"effective env {summary}")
+
+
+def _display_env_value(value: str | None) -> str:
+    return value if value else "<unset>"
+
+
+def _presence(name: str) -> str:
+    return "<set>" if os.environ.get(name) else "<unset>"
+
+
+def _e2b_api_key_source() -> str:
+    if os.environ.get("E2B_API_KEY"):
+        return "<set from E2B_API_KEY>"
+    if os.environ.get("CUBE_API_KEY"):
+        return "<set from CUBE_API_KEY>"
+    return "<using e2b_000000 local key>"
+
+
+def _setup_log(message: str) -> None:
+    timestamp = datetime.now(timezone.utc).isoformat(timespec="milliseconds")
+    print(f"[sdk-e2e][{timestamp}] {message}", flush=True)

--- a/tests/e2e/sdk_compat/conftest.py
+++ b/tests/e2e/sdk_compat/conftest.py
@@ -391,6 +391,7 @@ def _log_effective_environment(cfg: SdkE2EConfig) -> None:
             {
                 "E2B_EFFECTIVE_API_URL": cfg.cube_api_url,
                 "E2B_API_KEY": _e2b_api_key_source(),
+                "SDK_E2E_E2B_VALIDATE_API_KEY": str(cfg.e2b_validate_api_key).lower(),
                 "SSL_CERT_FILE": os.environ.get("SSL_CERT_FILE"),
             }
         )
@@ -411,9 +412,7 @@ def _presence(name: str) -> str:
 def _e2b_api_key_source() -> str:
     if os.environ.get("E2B_API_KEY"):
         return "<set from E2B_API_KEY>"
-    if os.environ.get("CUBE_API_KEY"):
-        return "<set from CUBE_API_KEY>"
-    return "<missing E2B_API_KEY/CUBE_API_KEY>"
+    return "<missing E2B_API_KEY>"
 
 
 def _setup_log(message: str) -> None:

--- a/tests/e2e/sdk_compat/conftest.py
+++ b/tests/e2e/sdk_compat/conftest.py
@@ -246,8 +246,6 @@ def sdk_sandbox(
         pytest.skip("CUBE_TEMPLATE_ID or --cube-template-id is required for SDK E2E")
 
     create_options = _create_options_for_node(request.node)
-    if sdk_backend == "e2b" and _is_auto_pause_case(create_options):
-        pytest.skip("e2b backend does not cover CubeSandbox platform-managed auto-pause cases")
 
     metadata = {
         "test_suite": "sdk_compat",
@@ -334,6 +332,8 @@ def _cleanup_sdk_sandbox(
     sdk_e2e_config: SdkE2EConfig,
     sdk_e2e_reporter: JsonlReporter,
 ) -> None:
+    if adapter is None:
+        return
     failed = _test_failed(request.node)
     if sdk_e2e_config.keep_sandbox_on_failure and failed:
         errors: list[str] = []
@@ -359,16 +359,6 @@ def _cleanup_sdk_sandbox(
         nodeid=request.node.nodeid,
         errors=errors,
     )
-
-
-def _is_auto_pause_case(create_options: dict) -> bool:
-    lifecycle = create_options.get("lifecycle")
-    if not isinstance(lifecycle, dict):
-        return False
-    on_timeout = lifecycle.get("on_timeout")
-    if isinstance(on_timeout, dict):
-        return on_timeout.get("action") == "pause"
-    return on_timeout == "pause"
 
 
 def _test_failed(node: pytest.Item) -> bool:
@@ -423,7 +413,7 @@ def _e2b_api_key_source() -> str:
         return "<set from E2B_API_KEY>"
     if os.environ.get("CUBE_API_KEY"):
         return "<set from CUBE_API_KEY>"
-    return "<using e2b_000000 local key>"
+    return "<missing E2B_API_KEY/CUBE_API_KEY>"
 
 
 def _setup_log(message: str) -> None:

--- a/tests/e2e/sdk_compat/docs/case-authoring.md
+++ b/tests/e2e/sdk_compat/docs/case-authoring.md
@@ -1,0 +1,134 @@
+# SDK Compatibility E2E Case Authoring Guide
+
+## Select a domain
+
+Use an existing domain whenever possible:
+
+```text
+commands/      command output and exit behavior
+filesystem/    file API and shell interoperability
+lifecycle/     create, pause, resume, connect, and kill
+network/       create-time egress policy
+run_code/      interpreter output and kernel state
+```
+
+Create a new domain only when the behavior has a distinct API, capability
+boundary, or execution scope.
+
+## Use the shared adapter
+
+Do not import a concrete SDK in a shared case:
+
+```python
+def test_command_output(sdk_sandbox, sdk_e2e_config):
+    result = sdk_sandbox.run_command(
+        "printf hello",
+        timeout=sdk_e2e_config.command_timeout,
+    )
+    assert_command_ok(result)
+    assert result.stdout == "hello"
+```
+
+Put backend-specific behavior in `adapters/` and expose unsupported behavior
+with `requires_capability`.
+
+## Configure and mark the case
+
+Typical module markers:
+
+```python
+pytestmark = [
+    pytest.mark.e2e,
+    pytest.mark.sdk_compat,
+    pytest.mark.p1,
+]
+```
+
+Pass create-time options through the marker:
+
+```python
+@pytest.mark.requires_capability(NETWORK_ALLOW_DENY)
+@pytest.mark.requires_internet
+@pytest.mark.sandbox_create_options(
+    network={
+        "allow_out": ["8.8.8.8/32"],
+        "deny_out": ["0.0.0.0/0"],
+    }
+)
+```
+
+Do not hard-code a template ID in a shared case. Use `CUBE_TEMPLATE_ID` or
+`--cube-template-id`.
+
+## Assertions and state
+
+Assert observable results and include useful output:
+
+```python
+assert_command_ok(result)
+assert result.stdout == "expected", (
+    f"stdout={result.stdout!r} stderr={result.stderr!r}"
+)
+```
+
+For lifecycle or kernel cases, seed state before the transition and verify it
+afterward:
+
+```python
+seed = sdk_sandbox.run_code("value = 41")
+assert_code_ok(seed)
+sdk_sandbox.write_file("/tmp/checkpoint", "before")
+
+# pause/resume or connect
+
+result = resumed.run_code("value + 1")
+assert_code_ok(result)
+assert result.text == "42"
+assert resumed.read_file("/tmp/checkpoint") == "before"
+```
+
+`state == "running"` is a control-plane result, not a data-plane readiness
+guarantee. Use `wait_until_running` and record the first data-plane operation
+separately when investigating a readiness race.
+
+## Network cases
+
+Use the protocol under test:
+
+- TCP: `socket.connect_ex`;
+- UDP/DNS: send a DNS query and wait for a matching response;
+- HTTP/HTTPS: assert status code and response output;
+- L7: verify host, path, method, SNI, rule order, and injection.
+
+For a strict domain allowlist, combine `allow_out` with
+`allow_internet_access=False` or `deny_out=["0.0.0.0/0"]`. A successful TCP
+connection alone does not prove an HTTP or L7 policy.
+
+## Lifecycle and cleanup
+
+Platform lifecycle cases normally use `slow` and `requires_cubeproxy`:
+
+```bash
+SDK_E2E_PLATFORM_LIFECYCLE=true \
+pytest --run-e2e --sdk-e2e-trace cases/lifecycle/test_auto_lifecycle.py
+```
+
+Prefer lifecycle helpers over fixed sleeps. Let the fixture clean up the
+sandbox. If a test creates a resumed adapter, close it in `finally`:
+
+```python
+resumed = sdk_sandbox.resume_or_connect()
+try:
+    ...
+finally:
+    resumed.close()
+```
+
+## Review checklist
+
+- shared adapter and required capability markers are used;
+- assertions are deterministic and include failure context;
+- no fixed sandbox ID or cross-test dependency exists;
+- setup, call, skip, and cleanup paths are safe;
+- the intended backend combinations are collected;
+- `pytest --collect-only -q` and the narrowest live scope have been run.

--- a/tests/e2e/sdk_compat/docs/framework-design.md
+++ b/tests/e2e/sdk_compat/docs/framework-design.md
@@ -46,8 +46,8 @@ Use `requires_capability` for backend support boundaries:
 ```
 
 Available capability domains include `lifecycle`, `commands`, `filesystem`,
-`run_code`, `pause_resume`, `network_allow_deny`, `network_public_access`,
-`network_l7_rules`, and `proxy_url`.
+`run_code`, `pause_resume`, `network_allow_deny`, `network_public_access`, and
+`platform_lifecycle`.
 
 Use `smoke`, `p0`, `p1`, `p2`, `p3`, and `slow` to describe execution priority.
 Use `requires_cubeproxy` only for cases that require CubeProxy/lifecycle-manager

--- a/tests/e2e/sdk_compat/docs/framework-design.md
+++ b/tests/e2e/sdk_compat/docs/framework-design.md
@@ -1,0 +1,81 @@
+# SDK Compatibility E2E Framework Design
+
+## Purpose
+
+The suite runs backend-neutral pytest cases against the CubeSandbox and E2B
+Python SDKs. It is opt-in, isolates every test in its own sandbox, and records
+sanitized operation traces for failure diagnosis.
+
+## Architecture
+
+```text
+pytest cases
+    -> SandboxAdapter
+       -> CubeSandboxAdapter -> CubeSandbox SDK
+       -> E2BAdapter         -> E2B SDK
+       -> TracingSandboxAdapter -> TraceCollector
+                                  -> terminal / JSONL
+```
+
+Cases use only the shared adapter methods: `info`, `run_command`, `run_code`,
+`write_file`, `read_file`, `pause`, `resume_or_connect`, `kill`, and `close`.
+SDK-specific translation belongs in `adapters/`.
+
+## Fixture lifecycle
+
+`sdk_sandbox`:
+
+1. loads pytest, environment, and `.env` configuration;
+2. runs session preflight when `--run-e2e` is set;
+3. checks capabilities and platform markers;
+4. merges `sandbox_create_options`;
+5. creates one sandbox and attaches a `TraceCollector`;
+6. yields the adapter;
+7. preserves only setup/call failures when
+   `SDK_E2E_KEEP_SANDBOX_ON_FAILURE=true`;
+8. otherwise performs best-effort cleanup.
+
+Tests must not depend on a fixed sandbox ID or another test's sandbox.
+
+## Capabilities and markers
+
+Use `requires_capability` for backend support boundaries:
+
+```python
+@pytest.mark.requires_capability(NETWORK_ALLOW_DENY)
+```
+
+Available capability domains include `lifecycle`, `commands`, `filesystem`,
+`run_code`, `pause_resume`, `network_allow_deny`, `network_public_access`,
+`network_l7_rules`, and `proxy_url`.
+
+Use `smoke`, `p0`, `p1`, `p2`, `p3`, and `slow` to describe execution priority.
+Use `requires_cubeproxy` only for cases that require CubeProxy/lifecycle-manager
+coordination.
+
+## Preflight and reporting
+
+Preflight validates CubeAPI health and template readiness. Platform lifecycle
+preflight can also probe the CubeProxy admin heartbeat.
+
+`TraceCollector` records timestamp, operation, sanitized input/output,
+duration, and success. Secrets are redacted, large values are truncated, and
+file contents are represented by length only. JSONL events are written
+to `SDK_E2E_REPORT_DIR/events.jsonl`.
+
+Use `--sdk-e2e-trace` for live operation output:
+
+```bash
+pytest --run-e2e --sdk-e2e-trace cases/lifecycle/test_pause_resume.py
+```
+
+## Lifecycle readiness
+
+Control-plane `state == "running"` does not guarantee that CubeShim, envd, or
+the code interpreter is ready. Lifecycle tests should seed kernel/filesystem
+state, wait for `paused`, perform the intended resume path, wait for `running`,
+then execute and verify a data-plane operation.
+
+Prefer `wait_for_platform_pause`, `wait_for_platform_destroy`, and
+`wait_until_running` to fixed sleeps. A temporary sleep is acceptable for race
+diagnosis but must be justified before merge.

--- a/tests/e2e/sdk_compat/docs/framework-design.zh-CN.md
+++ b/tests/e2e/sdk_compat/docs/framework-design.zh-CN.md
@@ -45,8 +45,8 @@ pytest 用例
 ```
 
 当前 capability 包括 `lifecycle`、`commands`、`filesystem`、`run_code`、
-`pause_resume`、`network_allow_deny`、`network_public_access`、
-`network_l7_rules` 和 `proxy_url`。
+`pause_resume`、`network_allow_deny`、`network_public_access` 和
+`platform_lifecycle`。
 
 使用 `smoke`、`p0`、`p1`、`p2`、`p3` 和 `slow` 表达执行优先级。只有依赖
 CubeProxy/lifecycle-manager 协调的用例才使用 `requires_cubeproxy`。

--- a/tests/e2e/sdk_compat/docs/framework-design.zh-CN.md
+++ b/tests/e2e/sdk_compat/docs/framework-design.zh-CN.md
@@ -1,0 +1,77 @@
+# SDK 兼容性 E2E 测试框架设计
+
+## 目标
+
+测试套件通过 CubeSandbox 和 E2B Python SDK 执行同一组后端无关的 pytest
+用例。套件默认不执行在线测试，每个用例独立创建 sandbox，并输出脱敏的
+SDK 操作 trace 以便定位失败。
+
+## 架构
+
+```text
+pytest 用例
+    -> SandboxAdapter
+       -> CubeSandboxAdapter -> CubeSandbox SDK
+       -> E2BAdapter         -> E2B SDK
+       -> TracingSandboxAdapter -> TraceCollector
+                                  -> terminal / JSONL
+```
+
+用例只使用统一 adapter 方法：`info`、`run_command`、`run_code`、
+`write_file`、`read_file`、`pause`、`resume_or_connect`、`kill` 和
+`close`。SDK 差异应封装在 `adapters/` 中。
+
+## Fixture 生命周期
+
+`sdk_sandbox` 的流程是：
+
+1. 加载 pytest、环境变量和 `.env` 配置；
+2. 指定 `--run-e2e` 时执行 session preflight；
+3. 检查 capability 和平台 marker；
+4. 合并 `sandbox_create_options`；
+5. 创建独立 sandbox 并绑定 `TraceCollector`；
+6. 将 adapter 交给测试；
+7. `SDK_E2E_KEEP_SANDBOX_ON_FAILURE=true` 时只保留 setup/call 失败实例；
+8. 其他情况执行尽力清理。
+
+测试不能依赖固定 sandbox ID，也不能依赖其他测试创建的实例。
+
+## Capability 和 Marker
+
+使用 `requires_capability` 表达后端支持边界：
+
+```python
+@pytest.mark.requires_capability(NETWORK_ALLOW_DENY)
+```
+
+当前 capability 包括 `lifecycle`、`commands`、`filesystem`、`run_code`、
+`pause_resume`、`network_allow_deny`、`network_public_access`、
+`network_l7_rules` 和 `proxy_url`。
+
+使用 `smoke`、`p0`、`p1`、`p2`、`p3` 和 `slow` 表达执行优先级。只有依赖
+CubeProxy/lifecycle-manager 协调的用例才使用 `requires_cubeproxy`。
+
+## Preflight 和报告
+
+Preflight 检查 CubeAPI 健康状态和模板 readiness。平台生命周期模式下，
+还可以检查 CubeProxy admin heartbeat。
+
+`TraceCollector` 记录时间戳、操作、脱敏后的输入输出、耗时和成功状态。
+敏感信息会被脱敏，大对象会被截断，文件内容只记录长度。
+JSONL 事件写入 `SDK_E2E_REPORT_DIR/events.jsonl`。
+
+实时查看操作：
+
+```bash
+pytest --run-e2e --sdk-e2e-trace cases/lifecycle/test_pause_resume.py
+```
+
+## 生命周期 readiness
+
+控制面 `state == "running"` 不代表 CubeShim、envd 或代码解释器已经 ready。
+生命周期用例应先写入 kernel/文件状态，等待 `paused`，执行目标恢复路径，
+等待 `running`，再执行并验证数据面操作。
+
+优先使用 `wait_for_platform_pause`、`wait_for_platform_destroy` 和
+`wait_until_running`，不要用固定 sleep 代替状态判断。临时 sleep 可以用于
+定位竞态，但合入前必须说明原因。

--- a/tests/e2e/sdk_compat/docs/zh/case-authoring.md
+++ b/tests/e2e/sdk_compat/docs/zh/case-authoring.md
@@ -1,0 +1,130 @@
+# SDK 兼容性 E2E 用例编写指南
+
+## 选择测试域
+
+优先使用已有测试域：
+
+```text
+commands/      命令输出和退出行为
+filesystem/    文件 API 和 shell 互操作
+lifecycle/     创建、暂停、恢复、连接和销毁
+network/       创建时的出站网络策略
+run_code/      解释器输出和 kernel 状态
+```
+
+只有在行为具有独立 API、capability 边界或执行范围时，才新增测试域。
+
+## 使用统一 adapter
+
+共享用例不能直接导入具体 SDK：
+
+```python
+def test_command_output(sdk_sandbox, sdk_e2e_config):
+    result = sdk_sandbox.run_command(
+        "printf hello",
+        timeout=sdk_e2e_config.command_timeout,
+    )
+    assert_command_ok(result)
+    assert result.stdout == "hello"
+```
+
+后端差异放到 `adapters/`，不支持的行为使用 `requires_capability` 表达。
+
+## 配置和标记
+
+模块通常使用：
+
+```python
+pytestmark = [
+    pytest.mark.e2e,
+    pytest.mark.sdk_compat,
+    pytest.mark.p1,
+]
+```
+
+通过 marker 传递创建参数：
+
+```python
+@pytest.mark.requires_capability(NETWORK_ALLOW_DENY)
+@pytest.mark.requires_internet
+@pytest.mark.sandbox_create_options(
+    network={
+        "allow_out": ["8.8.8.8/32"],
+        "deny_out": ["0.0.0.0/0"],
+    }
+)
+```
+
+共享用例不要硬编码 template ID，应使用 `CUBE_TEMPLATE_ID` 或
+`--cube-template-id`。
+
+## 断言和状态验证
+
+断言用户可观察的结果，并保留失败上下文：
+
+```python
+assert_command_ok(result)
+assert result.stdout == "expected", (
+    f"stdout={result.stdout!r} stderr={result.stderr!r}"
+)
+```
+
+生命周期或 kernel 用例应在状态转换前写入状态，之后验证：
+
+```python
+seed = sdk_sandbox.run_code("value = 41")
+assert_code_ok(seed)
+sdk_sandbox.write_file("/tmp/checkpoint", "before")
+
+# pause/resume 或 connect
+
+result = resumed.run_code("value + 1")
+assert_code_ok(result)
+assert result.text == "42"
+assert resumed.read_file("/tmp/checkpoint") == "before"
+```
+
+`state == "running"` 只是控制面结果，不能保证数据面已经 ready。应使用
+`wait_until_running`，并在排查 readiness 竞态时单独记录第一次数据面操作。
+
+## 网络用例
+
+使用与目标行为匹配的协议：
+
+- TCP：`socket.connect_ex`；
+- UDP/DNS：发送 DNS query 并等待匹配响应；
+- HTTP/HTTPS：断言状态码和响应输出；
+- L7：验证 host、path、method、SNI、规则顺序和 header 注入。
+
+严格域名白名单需要将 `allow_out` 与
+`allow_internet_access=False` 或 `deny_out=["0.0.0.0/0"]` 一起配置。TCP
+连接成功本身不能证明 HTTP 或 L7 策略正确。
+
+## 生命周期和清理
+
+平台生命周期用例通常使用 `slow` 和 `requires_cubeproxy`：
+
+```bash
+SDK_E2E_PLATFORM_LIFECYCLE=true \
+pytest --run-e2e --sdk-e2e-trace cases/lifecycle/test_auto_lifecycle.py
+```
+
+优先使用生命周期 helper，而不是固定 sleep。由 fixture 负责清理 sandbox。
+如果用例创建了恢复后的 adapter，应在 `finally` 中关闭：
+
+```python
+resumed = sdk_sandbox.resume_or_connect()
+try:
+    ...
+finally:
+    resumed.close()
+```
+
+## 评审清单
+
+- 使用统一 adapter 和必要的 capability marker；
+- 断言确定且包含失败上下文；
+- 没有固定 sandbox ID 或跨测试依赖；
+- setup、call、skip 和 cleanup 路径安全；
+- 已按预期后端组合收集；
+- 已运行 `pytest --collect-only -q` 和最小在线范围测试。

--- a/tests/e2e/sdk_compat/env.example
+++ b/tests/e2e/sdk_compat/env.example
@@ -1,0 +1,56 @@
+# Copy this file to .env before running live E2E tests.
+# pytest automatically loads tests/e2e/sdk_compat/.env when it exists.
+# Exported shell variables take precedence over values in .env.
+# The lightweight loader supports one KEY=VALUE entry per line only; multiline
+# quoted values are not supported. Export complex secrets in the shell instead.
+
+# Select one or more backends. The cubesandbox backend uses the local SDK source
+# by default; e2b requires installing e2b-code-interpreter or e2b.
+SDK_E2E_BACKENDS=cubesandbox
+# Required when SDK_E2E_BACKENDS includes e2b.
+# E2B_API_KEY=your-e2b-api-key
+
+# Live CubeSandbox deployment.
+CUBE_API_URL=http://127.0.0.1:3000
+CUBE_TEMPLATE_ID=tpl-xxxxxxxxxxxxxxxxxxxxxxxx
+
+# CubeProxy routing. Set CUBE_PROXY_NODE_IP when DNS for *.cube.app is not
+# available from the test runner.
+# CUBE_PROXY_NODE_IP=10.0.1.2
+CUBE_PROXY_PORT_HTTP=80
+CUBE_SANDBOX_DOMAIN=cube.app
+
+# Timeouts.
+SDK_E2E_DEFAULT_TIMEOUT=120
+SDK_E2E_API_TIMEOUT=5
+SDK_E2E_CREATE_TIMEOUT=120
+SDK_E2E_COMMAND_TIMEOUT=30
+SDK_E2E_RUN_CODE_TIMEOUT=60
+SDK_E2E_NETWORK_PROBE_TIMEOUT=5
+
+# E2B SDK compatibility against local/self-hosted CubeSandbox deployments routes
+# sandbox command/files/run_code traffic through HTTPS endpoints. Trust the local
+# CA instead of disabling TLS verification.
+# SSL_CERT_FILE=/root/.local/share/mkcert/rootCA.pem
+
+# Keep failed sandboxes for debugging. Teardown still kills them by default.
+SDK_E2E_KEEP_SANDBOX_ON_FAILURE=false
+# Print every SDK adapter operation. Failed tests always print their recent
+# trace even when this is false.
+# SDK_E2E_TRACE=true
+# Skip tests marked requires_internet when the runner/environment has no stable
+# public egress route.
+# SDK_E2E_SKIP_INTERNET_TESTS=false
+SDK_E2E_REPORT_DIR=reports/sdk-dual
+
+# Platform-managed lifecycle (auto-pause / auto-resume / auto-kill) requires
+# cube-proxy plus cube-lifecycle-manager coordination. Keep disabled for PR
+# smoke; enable for daily lifecycle regression.
+# SDK_E2E_PLATFORM_LIFECYCLE=true
+# SDK_E2E_PLATFORM_LIFECYCLE_IDLE_TIMEOUT=30
+# SDK_E2E_PLATFORM_LIFECYCLE_WAIT_MARGIN=20
+# SDK_E2E_PLATFORM_LIFECYCLE_POLL_TIMEOUT=45
+# CUBE_PROXY_ADMIN_PORT=8082
+
+# Override local CubeSandbox Python SDK path if needed.
+# CUBE_PYTHON_SDK_PATH=/path/to/CubeSandbox/sdk/python

--- a/tests/e2e/sdk_compat/env.example
+++ b/tests/e2e/sdk_compat/env.example
@@ -9,10 +9,14 @@
 SDK_E2E_BACKENDS=cubesandbox
 # Required when SDK_E2E_BACKENDS includes e2b.
 # E2B_API_KEY=your-e2b-api-key
+# Enable E2B's client-side e2b_* API key format check. Keep false for
+# self-hosted deployments that issue keys in a different format.
+SDK_E2E_E2B_VALIDATE_API_KEY=false
 
 # Live CubeSandbox deployment.
 CUBE_API_URL=http://127.0.0.1:3000
 CUBE_TEMPLATE_ID=tpl-xxxxxxxxxxxxxxxxxxxxxxxx
+# CUBE_API_KEY=your-cube-api-key
 
 # CubeProxy routing. Set CUBE_PROXY_NODE_IP when DNS for *.cube.app is not
 # available from the test runner.
@@ -27,6 +31,10 @@ SDK_E2E_CREATE_TIMEOUT=120
 SDK_E2E_COMMAND_TIMEOUT=30
 SDK_E2E_RUN_CODE_TIMEOUT=60
 SDK_E2E_NETWORK_PROBE_TIMEOUT=5
+# Public TCP endpoints used by network policy tests.
+SDK_E2E_TCP_TARGET_IP=8.8.8.8
+SDK_E2E_TCP_TARGET_PORT=53
+SDK_E2E_ALTERNATE_TCP_TARGET_IP=1.1.1.1
 
 # E2B SDK compatibility against local/self-hosted CubeSandbox deployments routes
 # sandbox command/files/run_code traffic through HTTPS endpoints. Trust the local

--- a/tests/e2e/sdk_compat/framework/__init__.py
+++ b/tests/e2e/sdk_compat/framework/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0

--- a/tests/e2e/sdk_compat/framework/assertions.py
+++ b/tests/e2e/sdk_compat/framework/assertions.py
@@ -1,0 +1,26 @@
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from framework.models import CodeResult, CommandResult
+
+
+def assert_command_ok(result: CommandResult) -> None:
+    assert result.exit_code == 0, (
+        f"expected command exit 0, got {result.exit_code}; "
+        f"stdout={result.stdout!r} stderr={result.stderr!r}"
+    )
+
+
+def assert_code_ok(result: CodeResult) -> None:
+    assert result.error is None, (
+        f"expected successful code execution, got error={result.error!r}; "
+        f"text={result.text!r} stdout={result.stdout!r} stderr={result.stderr!r}"
+    )
+
+
+def assert_stdout_contains(result: CommandResult, expected: str) -> None:
+    assert expected in result.stdout, (
+        f"expected stdout to contain {expected!r}, got stdout={result.stdout!r} stderr={result.stderr!r}"
+    )

--- a/tests/e2e/sdk_compat/framework/capabilities.py
+++ b/tests/e2e/sdk_compat/framework/capabilities.py
@@ -11,6 +11,7 @@ CODE_INTERPRETER = "code_interpreter"
 PAUSE_RESUME = "pause_resume"
 NETWORK_ALLOW_DENY = "network_allow_deny"
 NETWORK_PUBLIC_ACCESS = "network_public_access"
+PLATFORM_LIFECYCLE = "platform_lifecycle"
 
 COMMON_CAPABILITIES = frozenset({LIFECYCLE, COMMANDS, FILESYSTEM, RUN_CODE})
 
@@ -31,5 +32,6 @@ CUBESANDBOX_CAPABILITIES = frozenset(
         PAUSE_RESUME,
         NETWORK_ALLOW_DENY,
         NETWORK_PUBLIC_ACCESS,
+        PLATFORM_LIFECYCLE,
     }
 )

--- a/tests/e2e/sdk_compat/framework/capabilities.py
+++ b/tests/e2e/sdk_compat/framework/capabilities.py
@@ -1,0 +1,35 @@
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+LIFECYCLE = "lifecycle"
+COMMANDS = "commands"
+FILESYSTEM = "filesystem"
+RUN_CODE = "run_code"
+CODE_INTERPRETER = "code_interpreter"
+PAUSE_RESUME = "pause_resume"
+NETWORK_ALLOW_DENY = "network_allow_deny"
+NETWORK_PUBLIC_ACCESS = "network_public_access"
+
+COMMON_CAPABILITIES = frozenset({LIFECYCLE, COMMANDS, FILESYSTEM, RUN_CODE})
+
+E2B_CAPABILITIES = frozenset(
+    {
+        *COMMON_CAPABILITIES,
+        CODE_INTERPRETER,
+        PAUSE_RESUME,
+        NETWORK_ALLOW_DENY,
+        NETWORK_PUBLIC_ACCESS,
+    }
+)
+
+CUBESANDBOX_CAPABILITIES = frozenset(
+    {
+        *COMMON_CAPABILITIES,
+        CODE_INTERPRETER,
+        PAUSE_RESUME,
+        NETWORK_ALLOW_DENY,
+        NETWORK_PUBLIC_ACCESS,
+    }
+)

--- a/tests/e2e/sdk_compat/framework/cleanup.py
+++ b/tests/e2e/sdk_compat/framework/cleanup.py
@@ -1,0 +1,77 @@
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from adapters.api_adapter import ApiClient
+from adapters.base import SandboxAdapter
+from framework.config import SdkE2EConfig
+
+
+def safe_kill(adapter: SandboxAdapter, config: SdkE2EConfig) -> list[str]:
+    """Best-effort sandbox cleanup.
+
+    Returns diagnostic messages instead of raising, so teardown never hides the
+    original test failure.
+    """
+
+    errors: list[str] = []
+    kill_adapter = adapter
+    kill_completed = False
+    interrupt: BaseException | None = None
+    try:
+        try:
+            state = adapter.info().state
+        except Exception as exc:  # noqa: BLE001 - cleanup must continue
+            state = None
+            errors.append(f"{adapter.backend}.info failed for {adapter.sandbox_id}: {exc}")
+
+        normalized_state = str(state).lower() if state is not None else None
+        if normalized_state == "paused":
+            try:
+                kill_adapter = adapter.resume_or_connect(timeout=config.default_timeout)
+            except Exception as exc:  # noqa: BLE001 - fallback delete handles this
+                errors.append(
+                    f"{adapter.backend}.resume before kill failed for "
+                    f"{adapter.sandbox_id}: {exc}"
+                )
+
+        kill_adapter.kill()
+        kill_completed = True
+        if normalized_state is None:
+            _rest_delete(adapter, config, errors)
+    except KeyboardInterrupt as exc:
+        interrupt = exc
+        errors.append(f"{kill_adapter.backend}.kill interrupted for {adapter.sandbox_id}: {exc}")
+    except Exception as exc:  # noqa: BLE001 - teardown must be best-effort
+        errors.append(f"{kill_adapter.backend}.kill failed for {adapter.sandbox_id}: {exc}")
+        _rest_delete(adapter, config, errors)
+    finally:
+        if not kill_completed and interrupt is not None:
+            _rest_delete(adapter, config, errors)
+        try:
+            if kill_adapter is not adapter:
+                kill_adapter.close()
+        except Exception as exc:  # noqa: BLE001
+            errors.append(
+                f"{kill_adapter.backend}.close failed for {adapter.sandbox_id}: {exc}"
+            )
+        try:
+            adapter.close()
+        except Exception as exc:  # noqa: BLE001
+            errors.append(f"{adapter.backend}.close failed for {adapter.sandbox_id}: {exc}")
+    if interrupt is not None:
+        raise interrupt
+    return errors
+
+
+def _rest_delete(adapter: SandboxAdapter, config: SdkE2EConfig, errors: list[str]) -> None:
+    api = None
+    try:
+        api = ApiClient(config)
+        api.delete_sandbox(adapter.sandbox_id)
+    except Exception as api_exc:  # noqa: BLE001
+        errors.append(f"REST delete failed for {adapter.sandbox_id}: {api_exc}")
+    finally:
+        if api is not None:
+            api.close()

--- a/tests/e2e/sdk_compat/framework/config.py
+++ b/tests/e2e/sdk_compat/framework/config.py
@@ -1,0 +1,98 @@
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from pathlib import Path
+
+
+def _csv(value: str) -> list[str]:
+    return [item.strip() for item in value.split(",") if item.strip()]
+
+
+def _bool_env(name: str, default: bool = False) -> bool:
+    value = os.environ.get(name)
+    if value is None:
+        return default
+    return value.strip().lower() in {"1", "true", "yes", "on"}
+
+
+@dataclass(frozen=True)
+class SdkE2EConfig:
+    backends: tuple[str, ...]
+    cube_api_url: str
+    cube_template_id: str | None
+    cube_proxy_node_ip: str | None
+    cube_proxy_port_http: int
+    cube_sandbox_domain: str
+    default_timeout: int
+    api_timeout: float
+    create_timeout: int
+    command_timeout: int
+    run_code_timeout: int
+    network_probe_timeout: int
+    keep_sandbox_on_failure: bool
+    report_dir: Path
+    cube_python_sdk_path: str | None
+    platform_lifecycle_enabled: bool
+    platform_lifecycle_idle_timeout: int
+    platform_lifecycle_wait_margin: int
+    platform_lifecycle_poll_timeout: int
+    cube_proxy_admin_port: int
+
+    @classmethod
+    def from_env(
+        cls,
+        *,
+        backends: str | None = None,
+        cube_api_url: str | None = None,
+        cube_template_id: str | None = None,
+    ) -> "SdkE2EConfig":
+        selected_backends = tuple(
+            _csv(backends or os.environ.get("SDK_E2E_BACKENDS", "cubesandbox"))
+        )
+        resolved_cube_api_url = (
+            cube_api_url or os.environ.get("CUBE_API_URL") or "http://127.0.0.1:3000"
+        ).rstrip("/")
+        return cls(
+            backends=selected_backends,
+            cube_api_url=resolved_cube_api_url,
+            cube_template_id=cube_template_id or os.environ.get("CUBE_TEMPLATE_ID"),
+            cube_proxy_node_ip=os.environ.get("CUBE_PROXY_NODE_IP") or None,
+            cube_proxy_port_http=int(os.environ.get("CUBE_PROXY_PORT_HTTP", "80")),
+            cube_sandbox_domain=os.environ.get("CUBE_SANDBOX_DOMAIN", "cube.app"),
+            default_timeout=int(os.environ.get("SDK_E2E_DEFAULT_TIMEOUT", "120")),
+            api_timeout=float(os.environ.get("SDK_E2E_API_TIMEOUT", "5")),
+            create_timeout=int(os.environ.get("SDK_E2E_CREATE_TIMEOUT", "120")),
+            command_timeout=int(os.environ.get("SDK_E2E_COMMAND_TIMEOUT", "30")),
+            run_code_timeout=int(os.environ.get("SDK_E2E_RUN_CODE_TIMEOUT", "60")),
+            network_probe_timeout=int(os.environ.get("SDK_E2E_NETWORK_PROBE_TIMEOUT", "5")),
+            keep_sandbox_on_failure=_bool_env("SDK_E2E_KEEP_SANDBOX_ON_FAILURE"),
+            report_dir=Path(os.environ.get("SDK_E2E_REPORT_DIR", "reports/sdk-dual")),
+            cube_python_sdk_path=os.environ.get("CUBE_PYTHON_SDK_PATH") or None,
+            platform_lifecycle_enabled=_bool_env("SDK_E2E_PLATFORM_LIFECYCLE"),
+            platform_lifecycle_idle_timeout=int(
+                os.environ.get("SDK_E2E_PLATFORM_LIFECYCLE_IDLE_TIMEOUT", "30")
+            ),
+            platform_lifecycle_wait_margin=int(
+                os.environ.get("SDK_E2E_PLATFORM_LIFECYCLE_WAIT_MARGIN", "20")
+            ),
+            platform_lifecycle_poll_timeout=int(
+                os.environ.get("SDK_E2E_PLATFORM_LIFECYCLE_POLL_TIMEOUT", "45")
+            ),
+            cube_proxy_admin_port=int(os.environ.get("CUBE_PROXY_ADMIN_PORT", "8082")),
+        )
+
+    def env(self) -> dict[str, str]:
+        values = {
+            "CUBE_API_URL": self.cube_api_url,
+            "CUBE_PROXY_PORT_HTTP": str(self.cube_proxy_port_http),
+            "CUBE_SANDBOX_DOMAIN": self.cube_sandbox_domain,
+        }
+        if self.cube_template_id:
+            values["CUBE_TEMPLATE_ID"] = self.cube_template_id
+        if self.cube_proxy_node_ip:
+            values["CUBE_PROXY_NODE_IP"] = self.cube_proxy_node_ip
+        return values

--- a/tests/e2e/sdk_compat/framework/config.py
+++ b/tests/e2e/sdk_compat/framework/config.py
@@ -33,6 +33,7 @@ class SdkE2EConfig:
     command_timeout: int
     run_code_timeout: int
     network_probe_timeout: int
+    e2b_validate_api_key: bool
     keep_sandbox_on_failure: bool
     report_dir: Path
     cube_python_sdk_path: str | None
@@ -69,6 +70,7 @@ class SdkE2EConfig:
             command_timeout=int(os.environ.get("SDK_E2E_COMMAND_TIMEOUT", "30")),
             run_code_timeout=int(os.environ.get("SDK_E2E_RUN_CODE_TIMEOUT", "60")),
             network_probe_timeout=int(os.environ.get("SDK_E2E_NETWORK_PROBE_TIMEOUT", "5")),
+            e2b_validate_api_key=_bool_env("SDK_E2E_E2B_VALIDATE_API_KEY"),
             keep_sandbox_on_failure=_bool_env("SDK_E2E_KEEP_SANDBOX_ON_FAILURE"),
             report_dir=Path(os.environ.get("SDK_E2E_REPORT_DIR", "reports/sdk-dual")),
             cube_python_sdk_path=os.environ.get("CUBE_PYTHON_SDK_PATH") or None,

--- a/tests/e2e/sdk_compat/framework/exceptions.py
+++ b/tests/e2e/sdk_compat/framework/exceptions.py
@@ -1,0 +1,17 @@
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+
+class SdkCompatError(Exception):
+    """Base exception for SDK compatibility E2E helpers."""
+
+
+class UnsupportedCapability(SdkCompatError):
+    """Raised when a backend cannot express a requested capability."""
+
+    def __init__(self, backend: str, capability: str) -> None:
+        super().__init__(f"backend {backend!r} does not support capability {capability!r}")
+        self.backend = backend
+        self.capability = capability

--- a/tests/e2e/sdk_compat/framework/lifecycle.py
+++ b/tests/e2e/sdk_compat/framework/lifecycle.py
@@ -1,0 +1,213 @@
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import time
+from collections.abc import Callable
+from contextlib import contextmanager
+from typing import Any
+
+from adapters import connect_adapter, create_adapter, list_sandboxes
+from adapters.base import SandboxAdapter
+from framework.cleanup import safe_kill
+from framework.config import SdkE2EConfig
+
+PAUSED_STATES = frozenset({"paused"})
+RUNNING_STATES = frozenset({"running"})
+TERMINAL_STATES = frozenset({"terminated", "killed", "killing", "stopped"})
+DEFAULT_IDLE_TIMEOUT = 30
+IDLE_WAIT_MARGIN = 20
+PLATFORM_LIFECYCLE_SKIP_REASON = (
+    "platform lifecycle coordinator did not act within the configured window; "
+    "ensure cube-lifecycle-manager is running, cube-proxy heartbeats are healthy, "
+    "and CUBE_PROXY_NODE_IP can reach the proxy admin port "
+    "(see docs/guide/lifecycle.md)"
+)
+
+
+from framework.models import state_from_raw
+
+
+def wait_until(
+    predicate: Callable[[], bool],
+    *,
+    timeout: float = 90,
+    interval: float = 1,
+    description: str = "condition",
+) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return
+        time.sleep(interval)
+    raise AssertionError(f"timed out waiting for {description} within {timeout}s")
+
+
+def wait_until_state(
+    adapter: SandboxAdapter,
+    states: frozenset[str],
+    *,
+    timeout: float = 90,
+    interval: float = 1,
+) -> str:
+    observed = "unknown"
+
+    def _matches() -> bool:
+        nonlocal observed
+        observed = fetch_state(adapter)
+        return observed in states
+
+    wait_until(
+        _matches,
+        timeout=timeout,
+        interval=interval,
+        description=f"state in {sorted(states)} (last={observed!r})",
+    )
+    return observed
+
+
+def wait_until_paused(adapter: SandboxAdapter, *, timeout: float = 90) -> str:
+    return wait_until_state(adapter, PAUSED_STATES, timeout=timeout)
+
+
+def wait_until_running(adapter: SandboxAdapter, *, timeout: float = 90) -> str:
+    return wait_until_state(adapter, RUNNING_STATES, timeout=timeout)
+
+
+def idle_past_timeout(idle_timeout: int, *, margin: int = IDLE_WAIT_MARGIN) -> None:
+    time.sleep(idle_timeout + margin)
+
+
+def wait_for_platform_pause(
+    adapter: SandboxAdapter,
+    config: SdkE2EConfig,
+) -> bool:
+    deadline = time.monotonic() + _platform_wait_timeout(config)
+    while time.monotonic() < deadline:
+        if fetch_state(adapter) in PAUSED_STATES:
+            return True
+        time.sleep(2)
+    return False
+
+
+def wait_for_platform_destroy(
+    adapter: SandboxAdapter,
+    sandbox_id: str,
+    backend: str,
+    config: SdkE2EConfig,
+) -> tuple[bool, dict[str, Any]]:
+    details: dict[str, Any] = {}
+    deadline = time.monotonic() + _platform_wait_timeout(config)
+    while time.monotonic() < deadline:
+        details["state"] = fetch_state(adapter)
+        details["listed"] = sandbox_listed(sandbox_id, backend, config)
+        if details["state"].startswith("unreachable") or details["state"] in TERMINAL_STATES:
+            return True, details
+        if details["listed"] is False:
+            return True, details
+        time.sleep(2)
+    return False, details
+
+
+def sandbox_listed(sandbox_id: str, backend: str, config: SdkE2EConfig) -> bool | None:
+    try:
+        entries = list_sandboxes(backend, config)
+    except Exception:
+        return None
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        entry_id = entry.get("sandboxID")
+        if entry_id is None:
+            entry_id = entry.get("sandbox_id")
+        if entry_id == sandbox_id:
+            return True
+    return False
+
+
+def fetch_state(adapter: SandboxAdapter) -> str:
+    try:
+        info = adapter.info()
+        state = state_from_raw(info.raw) or info.state
+        return str(state or "unknown")
+    except Exception as exc:
+        return f"unreachable ({type(exc).__name__})"
+
+
+def assert_connect_fails(
+    sandbox_id: str,
+    backend: str,
+    config: SdkE2EConfig,
+) -> str:
+    try:
+        connected = connect_adapter(backend, sandbox_id, config)
+    except Exception as exc:
+        return f"{type(exc).__name__}: {exc}"
+    try:
+        try:
+            connected.run_command("true", timeout=config.command_timeout)
+        except Exception as exc:
+            return f"{type(exc).__name__}: {exc}"
+        raise AssertionError("expected connect or command to fail for killed sandbox")
+    finally:
+        connected.close()
+
+
+def is_terminal_failure(exc: Exception) -> bool:
+    message = str(exc).lower()
+    terminal_markers = (
+        "404",
+        "not found",
+        "terminated",
+        "terminal",
+        "killed",
+        "stopped",
+        "does not exist",
+        "already",
+    )
+    return any(marker in message for marker in terminal_markers)
+
+
+def create_control_sandbox(
+    backend: str,
+    config: SdkE2EConfig,
+    *,
+    metadata: dict[str, str] | None = None,
+) -> SandboxAdapter:
+    return create_adapter(
+        backend,
+        config,
+        metadata={
+            "test_suite": "sdk_compat",
+            "test_role": "lifecycle_control",
+            **(metadata or {}),
+        },
+    )
+
+
+@contextmanager
+def managed_control_sandbox(
+    backend: str,
+    config: SdkE2EConfig,
+    *,
+    metadata: dict[str, str] | None = None,
+):
+    control = create_control_sandbox(backend, config, metadata=metadata)
+    try:
+        yield control
+    finally:
+        safe_kill(control, config)
+
+
+def metadata_from_info(raw: dict[str, Any]) -> dict[str, Any]:
+    metadata = raw.get("metadata")
+    return metadata if isinstance(metadata, dict) else {}
+
+
+def _platform_wait_timeout(config: SdkE2EConfig) -> int:
+    return (
+        config.platform_lifecycle_idle_timeout
+        + config.platform_lifecycle_wait_margin
+        + config.platform_lifecycle_poll_timeout
+    )

--- a/tests/e2e/sdk_compat/framework/lifecycle.py
+++ b/tests/e2e/sdk_compat/framework/lifecycle.py
@@ -84,10 +84,12 @@ def wait_for_platform_pause(
     config: SdkE2EConfig,
 ) -> bool:
     deadline = time.monotonic() + _platform_wait_timeout(config)
+    interval = 1.0
     while time.monotonic() < deadline:
         if fetch_state(adapter) in PAUSED_STATES:
             return True
-        time.sleep(2)
+        time.sleep(interval)
+        interval = min(interval * 2, 8.0)
     return False
 
 
@@ -99,6 +101,7 @@ def wait_for_platform_destroy(
 ) -> tuple[bool, dict[str, Any]]:
     details: dict[str, Any] = {}
     deadline = time.monotonic() + _platform_wait_timeout(config)
+    interval = 1.0
     while time.monotonic() < deadline:
         details["state"] = fetch_state(adapter)
         details["listed"] = sandbox_listed(sandbox_id, backend, config)
@@ -106,7 +109,8 @@ def wait_for_platform_destroy(
             return True, details
         if details["listed"] is False:
             return True, details
-        time.sleep(2)
+        time.sleep(interval)
+        interval = min(interval * 2, 8.0)
     return False, details
 
 

--- a/tests/e2e/sdk_compat/framework/models.py
+++ b/tests/e2e/sdk_compat/framework/models.py
@@ -1,0 +1,37 @@
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass(frozen=True)
+class CommandResult:
+    stdout: str
+    stderr: str
+    exit_code: int
+
+
+@dataclass(frozen=True)
+class CodeResult:
+    text: str
+    stdout: list[str] = field(default_factory=list)
+    stderr: list[str] = field(default_factory=list)
+    error: Any | None = None
+
+
+@dataclass(frozen=True)
+class SandboxInfo:
+    sandbox_id: str
+    state: str | None = None
+    raw: dict[str, Any] = field(default_factory=dict)
+
+
+def state_from_raw(raw: dict[str, Any]) -> str | None:
+    for key in ("state", "State", "status", "Status"):
+        value = raw.get(key)
+        if value:
+            return str(value)
+    return None

--- a/tests/e2e/sdk_compat/framework/models.py
+++ b/tests/e2e/sdk_compat/framework/models.py
@@ -29,6 +29,13 @@ class SandboxInfo:
     raw: dict[str, Any] = field(default_factory=dict)
 
 
+def first_present(data: dict[str, Any], *keys: str) -> Any | None:
+    for key in keys:
+        if key in data:
+            return data[key]
+    return None
+
+
 def state_from_raw(raw: dict[str, Any]) -> str | None:
     for key in ("state", "State", "status", "Status"):
         value = raw.get(key)

--- a/tests/e2e/sdk_compat/framework/platform_lifecycle.py
+++ b/tests/e2e/sdk_compat/framework/platform_lifecycle.py
@@ -1,0 +1,69 @@
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import time
+from typing import Any
+
+import requests
+
+from framework.config import SdkE2EConfig
+
+
+def probe_platform_lifecycle(config: SdkE2EConfig) -> tuple[bool, str, dict[str, Any]]:
+    """Best-effort readiness probe for platform-managed lifecycle.
+
+    Returns ``(ready, reason, details)``. When the proxy admin endpoint is not
+    reachable from the test runner, ``ready`` stays ``True`` and the caller
+    should rely on per-test skip-on-timeout behavior.
+    """
+
+    details: dict[str, Any] = {}
+    if not config.platform_lifecycle_enabled:
+        return False, "SDK_E2E_PLATFORM_LIFECYCLE is disabled", details
+
+    if not config.cube_proxy_node_ip:
+        return (
+            True,
+            "CUBE_PROXY_NODE_IP is unset; platform lifecycle readiness cannot be probed",
+            details,
+        )
+
+    url = (
+        f"http://{config.cube_proxy_node_ip}:{config.cube_proxy_admin_port}"
+        "/admin/healthz"
+    )
+    details["admin_healthz_url"] = url
+    try:
+        response = requests.get(url, timeout=5)
+        details["status_code"] = response.status_code
+        response.raise_for_status()
+        payload = response.json()
+        details["payload"] = payload
+    except Exception as exc:  # noqa: BLE001 - probe should stay best-effort
+        return (
+            True,
+            f"platform lifecycle admin probe unreachable ({exc}); tests may skip on timeout",
+            details,
+        )
+
+    heartbeat_ms = payload.get("heartbeat_last_pushed_ms")
+    details["heartbeat_last_pushed_ms"] = heartbeat_ms
+    if heartbeat_ms is None:
+        return (
+            False,
+            "cube-proxy admin healthz did not report heartbeat_last_pushed_ms",
+            details,
+        )
+
+    age_ms = int(time.time() * 1000) - int(heartbeat_ms)
+    details["heartbeat_age_ms"] = age_ms
+    if age_ms > 120_000:
+        return (
+            False,
+            f"stale cube-proxy heartbeat ({age_ms}ms old); lifecycle manager may be offline",
+            details,
+        )
+
+    return True, "platform lifecycle probe passed", details

--- a/tests/e2e/sdk_compat/framework/preflight.py
+++ b/tests/e2e/sdk_compat/framework/preflight.py
@@ -72,8 +72,8 @@ def _check_backend_dependencies(backends: tuple[str, ...], errors: list[str]) ->
 
     if "e2b" in backends:
         if _can_import("e2b_code_interpreter") or _can_import("e2b"):
-            if not (os.environ.get("E2B_API_KEY") or os.environ.get("CUBE_API_KEY")):
-                errors.append("e2b backend requires E2B_API_KEY or CUBE_API_KEY")
+            if not os.environ.get("E2B_API_KEY"):
+                errors.append("e2b backend requires E2B_API_KEY")
         else:
             errors.append(
                 "e2b backend requires e2b-code-interpreter or e2b. "

--- a/tests/e2e/sdk_compat/framework/preflight.py
+++ b/tests/e2e/sdk_compat/framework/preflight.py
@@ -4,10 +4,12 @@
 from __future__ import annotations
 
 import importlib
+import os
 from typing import Any
 
 from adapters.api_adapter import ApiClient
 from framework.config import SdkE2EConfig
+from framework.models import first_present
 from framework.platform_lifecycle import probe_platform_lifecycle
 from framework.reporting import JsonlReporter
 
@@ -70,11 +72,13 @@ def _check_backend_dependencies(backends: tuple[str, ...], errors: list[str]) ->
 
     if "e2b" in backends:
         if _can_import("e2b_code_interpreter") or _can_import("e2b"):
-            return
-        errors.append(
-            "e2b backend requires e2b-code-interpreter or e2b. "
-            "Install tests/e2e/sdk_compat/requirements.txt."
-        )
+            if not (os.environ.get("E2B_API_KEY") or os.environ.get("CUBE_API_KEY")):
+                errors.append("e2b backend requires E2B_API_KEY or CUBE_API_KEY")
+        else:
+            errors.append(
+                "e2b backend requires e2b-code-interpreter or e2b. "
+                "Install tests/e2e/sdk_compat/requirements.txt."
+            )
 
 
 def _can_import(module: str) -> bool:
@@ -86,7 +90,7 @@ def _can_import(module: str) -> bool:
 
 
 def _check_template_ready(template_id: str, template: dict[str, Any], errors: list[str]) -> None:
-    status = _first_present(
+    status = first_present(
         template,
         "status",
         "state",
@@ -97,20 +101,11 @@ def _check_template_ready(template_id: str, template: dict[str, Any], errors: li
         return
     if str(status).lower() not in {"ready", "active", "available"}:
         errors.append(f"template {template_id!r} is not ready: status={status!r}")
-
-
-def _first_present(data: dict[str, Any], *keys: str) -> Any | None:
-    for key in keys:
-        if key in data:
-            return data[key]
-    return None
-
-
 def _template_summary(template_id: str, template: dict[str, Any]) -> dict[str, Any]:
     return {
         "template_id": template_id,
-        "name": _first_present(template, "name", "templateName", "template_name"),
-        "status": _first_present(
+        "name": first_present(template, "name", "templateName", "template_name"),
+        "status": first_present(
             template,
             "status",
             "state",

--- a/tests/e2e/sdk_compat/framework/preflight.py
+++ b/tests/e2e/sdk_compat/framework/preflight.py
@@ -1,0 +1,121 @@
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import importlib
+from typing import Any
+
+from adapters.api_adapter import ApiClient
+from framework.config import SdkE2EConfig
+from framework.platform_lifecycle import probe_platform_lifecycle
+from framework.reporting import JsonlReporter
+
+
+def run_preflight(config: SdkE2EConfig, reporter: JsonlReporter) -> None:
+    errors: list[str] = []
+    details: dict[str, Any] = {"backends": config.backends}
+
+    if not config.cube_template_id:
+        errors.append("CUBE_TEMPLATE_ID or --cube-template-id is required")
+
+    _check_backend_dependencies(config.backends, errors)
+
+    api = ApiClient(config)
+    try:
+        try:
+            health = api.health()
+            details["health"] = health
+            if health.get("status") not in ("ok", "healthy"):
+                errors.append(f"CubeAPI health returned unexpected status: {health!r}")
+        except Exception as exc:  # noqa: BLE001 - preflight should aggregate diagnostics
+            errors.append(f"CubeAPI {config.cube_api_url}/health is not reachable: {exc}")
+
+        if config.cube_template_id:
+            try:
+                template = api.get_template(config.cube_template_id)
+                details["template"] = _template_summary(config.cube_template_id, template)
+                if not template:
+                    errors.append(f"template {config.cube_template_id!r} was not found")
+                else:
+                    _check_template_ready(config.cube_template_id, template, errors)
+            except Exception as exc:  # noqa: BLE001
+                errors.append(f"failed to read template {config.cube_template_id!r}: {exc}")
+    finally:
+        api.close()
+
+    if config.platform_lifecycle_enabled:
+        ready, reason, probe_details = probe_platform_lifecycle(config)
+        details["platform_lifecycle_probe"] = {
+            "ready": ready,
+            "reason": reason,
+            **probe_details,
+        }
+        if not ready:
+            details["platform_lifecycle_warning"] = reason
+
+    if errors:
+        reporter.record("preflight_failed", errors=errors, **details)
+        raise RuntimeError("SDK E2E preflight failed:\n- " + "\n- ".join(errors))
+
+    reporter.record("preflight_passed", **details)
+
+
+def _check_backend_dependencies(backends: tuple[str, ...], errors: list[str]) -> None:
+    if "cubesandbox" in backends:
+        try:
+            importlib.import_module("cubesandbox")
+        except ImportError as exc:
+            errors.append(f"cubesandbox backend requires the CubeSandbox Python SDK: {exc}")
+
+    if "e2b" in backends:
+        if _can_import("e2b_code_interpreter") or _can_import("e2b"):
+            return
+        errors.append(
+            "e2b backend requires e2b-code-interpreter or e2b. "
+            "Install tests/e2e/sdk_compat/requirements.txt."
+        )
+
+
+def _can_import(module: str) -> bool:
+    try:
+        importlib.import_module(module)
+    except ImportError:
+        return False
+    return True
+
+
+def _check_template_ready(template_id: str, template: dict[str, Any], errors: list[str]) -> None:
+    status = _first_present(
+        template,
+        "status",
+        "state",
+        "template_status",
+        "templateStatus",
+    )
+    if status is None:
+        return
+    if str(status).lower() not in {"ready", "active", "available"}:
+        errors.append(f"template {template_id!r} is not ready: status={status!r}")
+
+
+def _first_present(data: dict[str, Any], *keys: str) -> Any | None:
+    for key in keys:
+        if key in data:
+            return data[key]
+    return None
+
+
+def _template_summary(template_id: str, template: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "template_id": template_id,
+        "name": _first_present(template, "name", "templateName", "template_name"),
+        "status": _first_present(
+            template,
+            "status",
+            "state",
+            "template_status",
+            "templateStatus",
+        ),
+        "response_keys": sorted(template),
+    }

--- a/tests/e2e/sdk_compat/framework/reporting.py
+++ b/tests/e2e/sdk_compat/framework/reporting.py
@@ -1,0 +1,37 @@
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+from typing import Any
+
+from framework.trace import sanitize
+
+
+class JsonlReporter:
+    def __init__(self, report_dir: Path) -> None:
+        self._report_dir = report_dir
+        self._path = report_dir / "events.jsonl"
+        self._report_dir.mkdir(parents=True, exist_ok=True)
+        self._file = self._path.open("a", encoding="utf-8")
+
+    def record(self, event: str, **fields: Any) -> None:
+        if self._file.closed:
+            return
+        payload = sanitize({"ts": time.time(), "event": event, **fields})
+        try:
+            self._file.write(json.dumps(payload, ensure_ascii=False, sort_keys=True) + "\n")
+            self._file.flush()
+        except ValueError as exc:
+            if "closed file" not in str(exc):
+                raise
+
+    def record_test_result(self, **fields: Any) -> None:
+        self.record("test_result", **fields)
+
+    def close(self) -> None:
+        if not self._file.closed:
+            self._file.close()

--- a/tests/e2e/sdk_compat/framework/reporting.py
+++ b/tests/e2e/sdk_compat/framework/reporting.py
@@ -21,6 +21,8 @@ class JsonlReporter:
     def record(self, event: str, **fields: Any) -> None:
         if self._file.closed:
             return
+        # Keep the reporter as an independent redaction boundary. Trace events
+        # are sanitized when captured, but callers may pass other raw fields.
         payload = sanitize({"ts": time.time(), "event": event, **fields})
         try:
             self._file.write(json.dumps(payload, ensure_ascii=False, sort_keys=True) + "\n")

--- a/tests/e2e/sdk_compat/framework/trace.py
+++ b/tests/e2e/sdk_compat/framework/trace.py
@@ -5,9 +5,11 @@ from __future__ import annotations
 
 import re
 import time
+from collections import deque
 from contextvars import ContextVar, Token
 from dataclasses import asdict, is_dataclass
 from datetime import datetime, timezone
+from itertools import islice
 from typing import Any, Callable, TypeVar
 
 MAX_STRING_LENGTH = 2048
@@ -39,12 +41,15 @@ _SECRET_ASSIGNMENT_RE = re.compile(
     r"\b("
     r"api[_-]?key|"
     r"access[_-]?key|"
+    r"api[_-]?token|"
+    r"access[_-]?token|"
     r"auth[_-]?token|"
+    r"bearer[_-]?token|"
     r"jwt|"
     r"password|"
     r"private[_-]?key|"
     r"secret|"
-    r"token"
+    r"private[_-]?token"
     r")\b"
     r"(\s*[:=]\s*)"
     r"([^\r\n]*)"
@@ -142,7 +147,7 @@ class TraceCollector:
         self.nodeid = nodeid
         self.verbose = verbose
         self._emit = emit
-        self._events: list[dict[str, Any]] = []
+        self._events: deque[dict[str, Any]] = deque(maxlen=MAX_TRACE_EVENTS)
         self._dropped_events = 0
 
     def capture(
@@ -195,10 +200,9 @@ class TraceCollector:
                 "error": error,
             }
         )
-        self._events.append(event)
-        if len(self._events) > MAX_TRACE_EVENTS:
-            self._events.pop(0)
+        if len(self._events) == MAX_TRACE_EVENTS:
             self._dropped_events += 1
+        self._events.append(event)
         if self.verbose and self._emit:
             try:
                 self._emit(self.format_event(event))
@@ -215,7 +219,8 @@ class TraceCollector:
         lines = ["SDK trace (most recent operations):"]
         if self._dropped_events:
             lines.append(f"SDK trace: {self._dropped_events} older operations were dropped")
-        for event in self._events[-10:]:
+        start = max(0, len(self._events) - 10)
+        for event in islice(self._events, start, None):
             lines.append(self.format_event(event))
         return "\n".join(lines)
 

--- a/tests/e2e/sdk_compat/framework/trace.py
+++ b/tests/e2e/sdk_compat/framework/trace.py
@@ -1,0 +1,247 @@
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import re
+import time
+from contextvars import ContextVar, Token
+from dataclasses import asdict, is_dataclass
+from datetime import datetime, timezone
+from typing import Any, Callable, TypeVar
+
+MAX_STRING_LENGTH = 2048
+MAX_COLLECTION_ITEMS = 50
+MAX_TRACE_EVENTS = 100
+
+_SENSITIVE_KEY_PARTS = (
+    "access_key",
+    "access-key",
+    "api_key",
+    "api-key",
+    "apikey",
+    "auth_token",
+    "auth-token",
+    "authorization",
+    "bearer",
+    "credential",
+    "jwt",
+    "password",
+    "private_key",
+    "private-key",
+    "secret",
+    "token",
+)
+_ENV_CONTAINER_KEYS = {"env", "envs", "environment", "env_vars", "envvars"}
+_BEARER_RE = re.compile(r"(?i)(authorization\s*:\s*bearer\s+)\S+")
+_SECRET_ASSIGNMENT_RE = re.compile(
+    r"(?im)"
+    r"\b("
+    r"api[_-]?key|"
+    r"access[_-]?key|"
+    r"auth[_-]?token|"
+    r"jwt|"
+    r"password|"
+    r"private[_-]?key|"
+    r"secret|"
+    r"token"
+    r")\b"
+    r"(\s*[:=]\s*)"
+    r"([^\r\n]*)"
+)
+_current_trace: ContextVar[TraceCollector | None] = ContextVar(
+    "sdk_e2e_current_trace",
+    default=None,
+)
+T = TypeVar("T")
+
+
+def sanitize(value: Any, *, key: str | None = None, depth: int = 0) -> Any:
+    if key and any(part in key.lower() for part in _SENSITIVE_KEY_PARTS):
+        return "***"
+    if depth >= 8:
+        return "<max-depth>"
+    if is_dataclass(value):
+        return sanitize(asdict(value), depth=depth + 1)
+    if isinstance(value, dict):
+        items = list(value.items())
+        env_container = bool(key and key.lower() in _ENV_CONTAINER_KEYS)
+        named_env_item = env_container and any(
+            str(item_key).lower() == "name" for item_key, _ in items
+        )
+        result = {
+            str(item_key): (
+                "***"
+                if env_container
+                and (
+                    not named_env_item
+                    or str(item_key).lower() in {"value", "valuefrom", "value_from"}
+                )
+                else sanitize(item_value, key=str(item_key), depth=depth + 1)
+            )
+            for item_key, item_value in items[:MAX_COLLECTION_ITEMS]
+        }
+        if len(items) > MAX_COLLECTION_ITEMS:
+            result["_truncated_items"] = len(items) - MAX_COLLECTION_ITEMS
+        return result
+    if isinstance(value, (list, tuple, set, frozenset)):
+        items = list(value)
+        result = [
+            sanitize(item, key=key, depth=depth + 1)
+            for item in items[:MAX_COLLECTION_ITEMS]
+        ]
+        if len(items) > MAX_COLLECTION_ITEMS:
+            result.append(f"<{len(items) - MAX_COLLECTION_ITEMS} more items>")
+        return result
+    if isinstance(value, bytes):
+        return f"<bytes length={len(value)}>"
+    if isinstance(value, str):
+        display_value = value
+        truncated_chars = 0
+        if len(value) > MAX_STRING_LENGTH:
+            truncated_chars = len(value) - MAX_STRING_LENGTH
+            display_value = (
+                value[:MAX_STRING_LENGTH]
+                + f"... <truncated {truncated_chars} chars>"
+            )
+        return _redact_text(display_value)
+    if value is None or isinstance(value, (bool, int, float)):
+        return value
+    return sanitize(str(value), depth=depth + 1)
+
+
+def summarize_create_options(options: dict[str, Any] | None) -> dict[str, Any]:
+    options = options or {}
+    summary: dict[str, Any] = {"keys": sorted(options)}
+    for key in ("timeout", "lifecycle", "allow_internet_access"):
+        if key in options:
+            summary[key] = sanitize(options[key], key=key)
+    for key in ("env_vars", "metadata"):
+        value = options.get(key)
+        if isinstance(value, dict):
+            summary[f"{key}_keys"] = sorted(str(item) for item in value)
+    network = options.get("network")
+    if isinstance(network, dict):
+        summary["network_keys"] = sorted(str(item) for item in network)
+    return summary
+
+
+def _redact_text(value: str) -> str:
+    value = _BEARER_RE.sub(r"\1***", value)
+    return _SECRET_ASSIGNMENT_RE.sub(r"\1\2***", value)
+
+
+class TraceCollector:
+    def __init__(
+        self,
+        nodeid: str,
+        *,
+        verbose: bool = False,
+        emit: Callable[[str], None] | None = None,
+    ) -> None:
+        self.nodeid = nodeid
+        self.verbose = verbose
+        self._emit = emit
+        self._events: list[dict[str, Any]] = []
+        self._dropped_events = 0
+
+    def capture(
+        self,
+        operation: str,
+        inputs: dict[str, Any],
+        call: Callable[[], T],
+        *,
+        output: Callable[[T], Any] | None = None,
+    ) -> T:
+        started = time.monotonic()
+        try:
+            result = call()
+        except Exception as exc:
+            self.record(
+                operation,
+                inputs=inputs,
+                duration_ms=(time.monotonic() - started) * 1000,
+                success=False,
+                error=f"{type(exc).__name__}: {exc}",
+            )
+            raise
+        self.record(
+            operation,
+            inputs=inputs,
+            duration_ms=(time.monotonic() - started) * 1000,
+            success=True,
+            output=output(result) if output else result,
+        )
+        return result
+
+    def record(
+        self,
+        operation: str,
+        *,
+        inputs: Any = None,
+        output: Any = None,
+        duration_ms: float | None = None,
+        success: bool = True,
+        error: str | None = None,
+    ) -> None:
+        event = sanitize(
+            {
+                "ts": time.time(),
+                "operation": operation,
+                "success": success,
+                "duration_ms": round(duration_ms, 2) if duration_ms is not None else None,
+                "input": inputs,
+                "output": output,
+                "error": error,
+            }
+        )
+        self._events.append(event)
+        if len(self._events) > MAX_TRACE_EVENTS:
+            self._events.pop(0)
+            self._dropped_events += 1
+        if self.verbose and self._emit:
+            try:
+                self._emit(self.format_event(event))
+            except ValueError as exc:
+                if "closed file" not in str(exc):
+                    raise
+
+    def snapshot(self) -> list[dict[str, Any]]:
+        return list(self._events)
+
+    def format_failure(self) -> str:
+        if not self._events:
+            return "SDK trace: no adapter operations were recorded"
+        lines = ["SDK trace (most recent operations):"]
+        if self._dropped_events:
+            lines.append(f"SDK trace: {self._dropped_events} older operations were dropped")
+        for event in self._events[-10:]:
+            lines.append(self.format_event(event))
+        return "\n".join(lines)
+
+    @staticmethod
+    def format_event(event: dict[str, Any]) -> str:
+        status = "ok" if event.get("success") else "failed"
+        duration = event.get("duration_ms")
+        detail = event.get("error") or event.get("output")
+        timestamp = event.get("ts")
+        if isinstance(timestamp, (int, float)):
+            timestamp = datetime.fromtimestamp(timestamp, timezone.utc).isoformat(
+                timespec="milliseconds"
+            )
+        return (
+            f"[sdk-e2e][{timestamp}] {event.get('operation')} {status} "
+            f"duration_ms={duration} input={event.get('input')!r} output={detail!r}"
+        )
+
+
+def get_current_trace() -> TraceCollector | None:
+    return _current_trace.get()
+
+
+def set_current_trace(trace: TraceCollector) -> Token:
+    return _current_trace.set(trace)
+
+
+def reset_current_trace(token: Token) -> None:
+    _current_trace.reset(token)

--- a/tests/e2e/sdk_compat/pytest.ini
+++ b/tests/e2e/sdk_compat/pytest.ini
@@ -1,0 +1,23 @@
+[pytest]
+testpaths = cases
+addopts = -ra --tb=short
+markers =
+    smoke: smoke tests that validate the minimum live environment
+    p0: P0 tests that should run on every SDK compatibility gate
+    p1: P1 tests for daily SDK compatibility regression
+    p2: P2 tests for weekly, slower, or broader compatibility coverage
+    p3: P3 tests for release qualification and long-running scenarios
+    slow: tests that take longer than the normal PR budget
+    e2e: tests that hit a live CubeAPI/CubeProxy environment
+    sdk_compat: cross-SDK compatibility tests
+    lifecycle: sandbox lifecycle compatibility tests
+    commands: sandbox command execution compatibility tests
+    filesystem: sandbox filesystem compatibility tests
+    network: sandbox network policy compatibility tests
+    run_code: sandbox code interpreter compatibility tests
+    requires_capability(name): current backend must support the named capability
+    sandbox_create_options(**kwargs): SDK sandbox create options for this test
+    requires_code_interpreter: test requires a template exposing Code Interpreter / Jupyter
+    requires_internet: test requires public internet from the sandbox
+    requires_cubeproxy: test requires CubeProxy routing to the sandbox
+    known_bug: regression coverage for a known backend or SDK bug

--- a/tests/e2e/sdk_compat/pytest.ini
+++ b/tests/e2e/sdk_compat/pytest.ini
@@ -13,6 +13,7 @@ markers =
     lifecycle: sandbox lifecycle compatibility tests
     commands: sandbox command execution compatibility tests
     filesystem: sandbox filesystem compatibility tests
+    concurrency: multi-sandbox isolation and concurrency compatibility tests
     network: sandbox network policy compatibility tests
     run_code: sandbox code interpreter compatibility tests
     requires_capability(name): current backend must support the named capability
@@ -20,4 +21,3 @@ markers =
     requires_code_interpreter: test requires a template exposing Code Interpreter / Jupyter
     requires_internet: test requires public internet from the sandbox
     requires_cubeproxy: test requires CubeProxy routing to the sandbox
-    known_bug: regression coverage for a known backend or SDK bug

--- a/tests/e2e/sdk_compat/reports/.gitignore
+++ b/tests/e2e/sdk_compat/reports/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/tests/e2e/sdk_compat/requirements.txt
+++ b/tests/e2e/sdk_compat/requirements.txt
@@ -1,0 +1,9 @@
+pytest>=7.0
+httpx>=0.27
+requests>=2
+
+# Optional backends:
+# - cubesandbox is loaded from ../../../../sdk/python by default.
+# - Install e2b-code-interpreter or e2b when running the e2b backend.
+# e2b-code-interpreter
+# e2b


### PR DESCRIPTION
## Summary
- Add a backend-neutral pytest E2E suite for CubeSandbox and E2B Python SDK compatibility.
- Cover lifecycle, commands, filesystem, and code execution flows with backend capability markers and capability-domain test directories.
- Default live PR-gate runs to the CubeSandbox backend, with optional dual SDK compatibility via `SDK_E2E_BACKENDS=e2b,cubesandbox`.
- Add preflight checks and per-test JSONL result reporting for better live-environment diagnostics.
- Document live environment setup, local CA trust via `SSL_CERT_FILE`, and E2B TLS fallback behavior.

## Test plan
- `python3 -m pytest --collect-only -q` collected 18 default CubeSandbox backend cases.
- `SDK_E2E_BACKENDS=e2b,cubesandbox python3 -m pytest --collect-only -q` collected 36 dual-backend cases.
- `python3 -m pytest -q` skipped all 18 default cases without `--run-e2e`.