### PR TITLE
feat(sdk): add set_timeout/SetTimeout for sandbox idle TTL refresh

### DIFF
--- a/sdk/go/coverage_test.go
+++ b/sdk/go/coverage_test.go
@@ -155,6 +155,9 @@ func TestSandboxRequiresAttachedClient(t *testing.T) {
 	if err := (&Sandbox{}).Resume(ctx, nil); err == nil {
 		t.Fatal("Resume without client returned nil error")
 	}
+	if err := (&Sandbox{}).SetTimeout(ctx, time.Minute); err == nil {
+		t.Fatal("SetTimeout without client returned nil error")
+	}
 	if err := (&Sandbox{}).Kill(ctx); err == nil {
 		t.Fatal("Kill without client returned nil error")
 	}

--- a/sdk/go/sandbox.go
+++ b/sdk/go/sandbox.go
@@ -85,6 +85,23 @@ func (s *Sandbox) Pause(ctx context.Context, opts PauseOptions) error {
 	}
 }
 
+// SetTimeout sets the sandbox idle TTL from now.
+//
+// Semantics align with e2b's set_timeout; see docs/guide/lifecycle.md.
+// NeverTimeout is not supported on this endpoint.
+func (s *Sandbox) SetTimeout(ctx context.Context, timeout time.Duration) error {
+	if err := s.ensureClient(); err != nil {
+		return err
+	}
+	secs := durationSeconds(timeout)
+	if secs <= 0 {
+		return fmt.Errorf("timeout must be a positive duration")
+	}
+	path := "/sandboxes/" + url.PathEscape(s.SandboxID) + "/timeout"
+	payload := map[string]any{"timeout": secs}
+	return s.client.doJSON(ctx, http.MethodPost, path, payload, nil, http.StatusOK, http.StatusNoContent)
+}
+
 // Resume resumes a paused sandbox.
 //
 // Deprecated: use Client.Connect instead, which auto-resumes paused sandboxes

--- a/sdk/go/sdk_test.go
+++ b/sdk/go/sdk_test.go
@@ -308,6 +308,56 @@ func TestLifecycleEndpoints(t *testing.T) {
 	}
 }
 
+func TestSetTimeout(t *testing.T) {
+	var timeoutBody map[string]int
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/sandboxes/"+testSandboxID+"/timeout":
+			if err := json.NewDecoder(r.Body).Decode(&timeoutBody); err != nil {
+				t.Fatalf("decode timeout: %v", err)
+			}
+			w.WriteHeader(http.StatusNoContent)
+		case r.Method == http.MethodPost && r.URL.Path == "/sandboxes/"+testSandboxID+"/connect":
+			fmt.Fprint(w, sandboxJSON(testSandboxID, "tpl-test"))
+		default:
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	client := NewClient(Config{APIURL: server.URL, TemplateID: "tpl-test"})
+	ctx := context.Background()
+	sb, err := client.Connect(ctx, testSandboxID)
+	if err != nil {
+		t.Fatalf("Connect: %v", err)
+	}
+
+	if err := sb.SetTimeout(ctx, 5*time.Minute); err != nil {
+		t.Fatalf("SetTimeout: %v", err)
+	}
+	if timeoutBody["timeout"] != 300 {
+		t.Fatalf("timeout body=%v, want 300", timeoutBody)
+	}
+
+	if err := sb.SetTimeout(ctx, 0); err == nil {
+		t.Fatal("SetTimeout(0) returned nil error")
+	}
+}
+
+func TestSetTimeoutNotFound(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, `{"message":"sandbox not found"}`, http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	sb := &Sandbox{client: NewClient(Config{APIURL: server.URL}), SandboxID: testSandboxID}
+	if err := sb.SetTimeout(context.Background(), time.Minute); !errors.Is(err, ErrSandboxNotFound) {
+		t.Fatalf("SetTimeout error=%v, want ErrSandboxNotFound", err)
+	}
+}
+
 func TestAPIErrorMapping(t *testing.T) {
 	tests := []struct {
 		name       string

--- a/sdk/python/cubesandbox/sandbox.py
+++ b/sdk/python/cubesandbox/sandbox.py
@@ -429,6 +429,30 @@ class Sandbox:
                 f"Sandbox {self.sandbox_id!r} did not reach 'paused' state within {timeout}s"
             )
 
+    def set_timeout(self, timeout: int) -> None:
+        """POST /sandboxes/:sandboxID/timeout - Set sandbox idle timeout.
+
+        Resets the idle clock from now. Semantics align with e2b's
+        ``set_timeout``; see ``docs/guide/lifecycle.md``.
+
+        Args:
+            timeout: New idle TTL in seconds. Must be a positive integer.
+                ``NEVER_TIMEOUT`` (-1) is not supported on this endpoint
+                (use :meth:`create` or :meth:`resume` instead).
+
+        Raises:
+            ValueError: If ``timeout`` is not positive.
+            SandboxNotFoundError: If the sandbox does not exist (HTTP 404).
+            ApiError: On unexpected backend error (HTTP 500).
+        """
+        if timeout <= 0:
+            raise ValueError("timeout must be a positive integer (seconds)")
+        resp = self._session.post(
+            f"{self._config.api_url}/sandboxes/{self.sandbox_id}/timeout",
+            json={"timeout": timeout},
+        )
+        _check_response(resp)
+
     def resume(self, timeout: int | None = None) -> None:
         """POST /sandboxes/:sandboxID/resume - Resume a paused sandbox.
 

--- a/sdk/python/tests/test_sandbox.py
+++ b/sdk/python/tests/test_sandbox.py
@@ -849,6 +849,32 @@ class TestResume:
                 sb.resume()
 
 
+# ── POST /sandboxes/:id/timeout ───────────────────────────────────────────────
+
+class TestSetTimeout:
+    def test_set_timeout_success(self):
+        sb = make_sandbox()
+        with patch.object(sb._session, "post", return_value=mock_response(status=204)) as m:
+            sb.set_timeout(300)
+        url = m.call_args.args[0]
+        assert url.endswith(f"/sandboxes/{SANDBOX_ID}/timeout")
+        assert m.call_args.kwargs["json"] == {"timeout": 300}
+
+    def test_set_timeout_rejects_non_positive(self):
+        sb = make_sandbox()
+        with pytest.raises(ValueError, match="positive"):
+            sb.set_timeout(0)
+        with pytest.raises(ValueError, match="positive"):
+            sb.set_timeout(-1)
+
+    def test_set_timeout_not_found(self):
+        sb = make_sandbox()
+        with patch.object(sb._session, "post",
+                          return_value=mock_response({"message": "not found"}, status=404)):
+            with pytest.raises(SandboxNotFoundError):
+                sb.set_timeout(60)
+
+
 # ── properties / get_host ─────────────────────────────────────────────────────
 
 class TestProperties:


### PR DESCRIPTION
## Summary

Add `set_timeout()` (Python) / `SetTimeout()` (Go) instance methods that reset the sandbox idle clock from now and set a new TTL, aligning with e2b's `set_timeout` semantics.

## Changes

### Python SDK
- `Sandbox.set_timeout(timeout: int)` — client-side validation rejects non-positive values with `ValueError`
- Unit tests: success, non-positive rejection, 404 error mapping

### Go SDK
- `Sandbox.SetTimeout(ctx, timeout time.Duration)` — client-side validation, returns `ErrSandboxNotFound` on missing sandbox
- Unit tests: success payload assertion, zero-duration rejection, 404 error mapping
- Coverage test for detached-client code path

🤖 Generated with [Claude Code](https://claude.com/claude-code)