### PR TITLE
fix(cube-egress): sync listener IP with sandbox CIDR

### DIFF
--- a/CubeEgress/scripts/cube-proxy-iptables-init.sh
+++ b/CubeEgress/scripts/cube-proxy-iptables-init.sh
@@ -22,12 +22,12 @@
 # Required before this runs:
 #   - cube-dev interface exists (host-side gateway iface for sandbox VMs)
 #   - the cube-egress container is reachable on TPROXY_ON_IP:TPROXY_PORT_*
-#     (it shares the host network namespace, so `--on-ip 192.168.0.1`
-#     hits OpenResty's `listen 192.168.0.1:8080;` / `listen 192.168.0.1:8443 ssl;`).
+#     (it shares the host network namespace, so `--on-ip ${cube-dev-gw}`
+#     hits OpenResty's matching HTTP/HTTPS listeners).
 set -euo pipefail
 
 # -------- Tunables (must match nginx.conf) --------
-TPROXY_ON_IP="${CUBE_TPROXY_ON_IP:-192.168.0.1}"  # cube-dev IP
+TPROXY_ON_IP="${CUBE_TPROXY_ON_IP:-192.168.0.1}"  # cube-dev gateway IP
 TPROXY_PORT_HTTP=8080
 TPROXY_PORT_HTTPS=8443
 ROUTE_TABLE=100

--- a/CubeEgress/start.sh
+++ b/CubeEgress/start.sh
@@ -18,6 +18,7 @@ PLACEHOLDER_CERT="${CA_DIR}/placeholder.crt"
 PLACEHOLDER_KEY="${CA_DIR}/placeholder.key"
 AUDIT_DIR="/data/log/cube-egress"
 NGINX_BIN="/usr/local/openresty/nginx/sbin/nginx"
+NGINX_CONF="/usr/local/openresty/nginx/conf/nginx.conf"
 
 log()   { printf '[entrypoint] %s\n' "$*" >&2; }
 fatal() { log "FATAL: $*"; exit 1; }
@@ -108,7 +109,23 @@ if (( (owner_bits & 3) != 3 )); then
     fatal "audit dir mode ${audit_mode} lacks owner rwx bits: ${AUDIT_DIR}"
 fi
 
-# -------- 5. nginx config validity --------
+# -------- 5. Render nginx listener IP and validate config --------
+TPROXY_ON_IP="${CUBE_TPROXY_ON_IP:-192.168.0.1}"
+if ! [[ "${TPROXY_ON_IP}" =~ ^([0-9]{1,3}\.){3}[0-9]{1,3}$ ]]; then
+    fatal "CUBE_TPROXY_ON_IP must be an IPv4 address, got: ${TPROXY_ON_IP}"
+fi
+IFS=. read -r ip_a ip_b ip_c ip_d <<< "${TPROXY_ON_IP}"
+for octet in "${ip_a}" "${ip_b}" "${ip_c}" "${ip_d}"; do
+    if (( 10#${octet} < 0 || 10#${octet} > 255 )); then
+        fatal "CUBE_TPROXY_ON_IP has an invalid octet: ${TPROXY_ON_IP}"
+    fi
+done
+log "Rendering nginx listen IP: ${TPROXY_ON_IP}"
+sed -i -E \
+    -e "s/listen[[:space:]]+[0-9.]+:8080[[:space:]]+transparent/listen ${TPROXY_ON_IP}:8080 transparent/" \
+    -e "s/listen[[:space:]]+[0-9.]+:8443[[:space:]]+ssl[[:space:]]+transparent/listen ${TPROXY_ON_IP}:8443 ssl transparent/" \
+    "${NGINX_CONF}"
+
 log "Running nginx -t"
 "${NGINX_BIN}" -t
 

--- a/deploy/one-click/scripts/systemd/common.sh
+++ b/deploy/one-click/scripts/systemd/common.sh
@@ -108,6 +108,29 @@ load_runtime_env() {
   fi
 }
 
+# Derive the cube-dev gateway address used by CubeEgress TPROXY listeners.
+# Cubelet/network-agent define the gateway as the sandbox CIDR network address + 1.
+derive_cube_tproxy_on_ip() {
+  if [[ -n "${CUBE_TPROXY_ON_IP:-}" ]]; then
+    validate_ipv4_literal "${CUBE_TPROXY_ON_IP}" "CUBE_TPROXY_ON_IP"
+    printf '%s\n' "${CUBE_TPROXY_ON_IP}"
+    return 0
+  fi
+
+  local cidr="${CUBE_SANDBOX_NETWORK_CIDR:-}"
+  if [[ -z "${cidr}" && -f "${TOOLBOX_ROOT}/Cubelet/config/config.toml" ]]; then
+    cidr="$(sed -nE '/^[[:space:]]*cidr[[:space:]]*=[[:space:]]*"/{s/.*"([^"]+)".*/\1/p;q;}' "${TOOLBOX_ROOT}/Cubelet/config/config.toml" 2>/dev/null || true)"
+  fi
+  cidr="${cidr:-192.168.0.0/18}"
+
+  require_cmd python3
+  python3 -c 'import ipaddress, sys
+net = ipaddress.ip_network(sys.argv[1], strict=True)
+if net.version != 4:
+    raise SystemExit(f"invalid sandbox CIDR {sys.argv[1]!r}: expected IPv4")
+print(net.network_address + 1)' "${cidr}"
+}
+
 one_click_deploy_role() {
   local role="${ONE_CLICK_DEPLOY_ROLE:-control}"
   case "${role}" in

--- a/deploy/one-click/scripts/systemd/cube-egress-net-start.sh
+++ b/deploy/one-click/scripts/systemd/cube-egress-net-start.sh
@@ -20,6 +20,8 @@ require_root
 
 INIT_SCRIPT="${CUBE_EGRESS_NET_INIT:-${TOOLBOX_ROOT}/scripts/cube-egress/cube-proxy-iptables-init.sh}"
 ensure_executable "${INIT_SCRIPT}"
+export CUBE_TPROXY_ON_IP="$(derive_cube_tproxy_on_ip)"
+log "cube-egress TPROXY rules IP: ${CUBE_TPROXY_ON_IP}"
 
 # cube-dev is created lazily by network-agent at first-sandbox time,
 # so on a fresh boot it isn't there yet. We give it a short window to

--- a/deploy/one-click/scripts/systemd/cube-egress-start.sh
+++ b/deploy/one-click/scripts/systemd/cube-egress-start.sh
@@ -4,9 +4,9 @@
 #
 # Launch the cube-egress container in foreground (Type=simple unit).
 #
-# Network model is host (mandatory): nginx.conf binds explicitly to
-# 192.168.0.1:8080/8443 with IP_TRANSPARENT, which only works in the
-# host network namespace where the cube-dev iface lives.
+# Network model is host (mandatory): nginx.conf binds explicitly to the
+# cube-dev gateway IP with IP_TRANSPARENT, which only works in the host
+# network namespace where the cube-dev iface lives.
 #
 # CA + audit dir come from cube-egress-prepare.sh (run as a oneshot
 # ExecStartPre or independently by the operator).
@@ -48,6 +48,8 @@ AUDIT_DIR="${CUBE_EGRESS_AUDIT_DIR:-/data/log/cube-egress}"
 # this URL is reachable from inside the container without any port
 # forwarding.
 BOOTSTRAP_URL="${CUBE_EGRESS_BOOTSTRAP_URL:-http://127.0.0.1:19090/v1/policies/dump}"
+TPROXY_ON_IP="$(derive_cube_tproxy_on_ip)"
+log "cube-egress TPROXY listen IP: ${TPROXY_ON_IP}"
 
 ensure_dir "${CA_DIR}"
 ensure_dir "${AUDIT_DIR}"
@@ -97,6 +99,7 @@ docker create \
   --cap-add=SETGID \
   --cap-add=DAC_READ_SEARCH \
   -e "CUBE_EGRESS_BOOTSTRAP_URL=${BOOTSTRAP_URL}" \
+  -e "CUBE_TPROXY_ON_IP=${TPROXY_ON_IP}" \
   "${CUBE_EGRESS_IMAGE}" >/dev/null
 
 # `docker start -a` keeps the foreground attached to the container


### PR DESCRIPTION
Motivation
Avoid a mismatch between host TPROXY rules and CubeEgress nginx listeners when operators customize CUBE_SANDBOX_NETWORK_CIDR, which could leave TPROXY redirecting traffic to an IP the container is not listening on.
This change fixes the user-reported issue tracked as https://github.com/TencentCloud/CubeSandbox/issues/832 by deriving the correct cube-dev gateway and ensuring both host rules and the container use the same IP.
Description
Add derive_cube_tproxy_on_ip() to deploy/one-click/scripts/systemd/common.sh to compute the cube-dev gateway as network_address + 1, honoring explicit CUBE_TPROXY_ON_IP overrides and falling back to packaged defaults.
Pass the derived CUBE_TPROXY_ON_IP into the cube-egress container from deploy/one-click/scripts/systemd/cube-egress-start.sh and export it for the net-init wrapper in deploy/one-click/scripts/systemd/cube-egress-net-start.sh.
Make the CubeEgress entrypoint (CubeEgress/start.sh) validate the supplied TPROXY IP and rewrite the nginx listen directives in the container's nginx.conf so listeners match the host TPROXY_ON_IP.
Update CubeEgress/scripts/cube-proxy-iptables-init.sh comments and variable name to clarify it expects the cube-dev gateway IP rather than a hard-coded 192.168.0.1.

Testing
Performed a shell syntax check with bash -n across the modified scripts which completed successfully.
Verified derive_cube_tproxy_on_ip returns the expected gateway for CUBE_SANDBOX_NETWORK_CIDR=10.100.0.0/18 by sourcing deploy/one-click/scripts/systemd/common.sh, which returned 10.100.0.1.
Verified explicit override behavior by exporting CUBE_TPROXY_ON_IP=10.200.0.1 and sourcing derive_cube_tproxy_on_ip, which returned 10.200.0.1 as expected.