### PR TITLE
feat(cube-proxy): migrate from local build to pre-published multi-arch images

### DIFF
--- a/CubeProxy/Dockerfile
+++ b/CubeProxy/Dockerfile
@@ -1,7 +1,7 @@
 # Base image is overridable at build time (e.g. to point at a private registry
-# mirror or a pinned @sha256 digest). The one-click deploy passes this build
-# arg from CUBE_PROXY_BASE_IMAGE in .one-click.env via the compose build.args;
-# the default below keeps `docker build CubeProxy/` working standalone.
+# mirror or a pinned @sha256 digest). CubeProxy/Makefile and the release
+# workflow pass CUBE_PROXY_BASE_IMAGE; the default below keeps
+# `docker build CubeProxy/` working standalone.
 ARG CUBE_PROXY_BASE_IMAGE=cube-sandbox-image.tencentcloudcr.com/opensource/openresty:1.21.4.1-6-alpine-fat
 FROM ${CUBE_PROXY_BASE_IMAGE}
 

--- a/CubeProxy/Makefile
+++ b/CubeProxy/Makefile
@@ -1,9 +1,20 @@
-VERSION     := test
-DATE        := $(shell date +'%Y%m%d')
-COMMIT      := $(shell git rev-parse HEAD | cut -c1-8)
-IMAGE_TAG   := $(VERSION)-$(DATE)-$(COMMIT)
+IMAGE_TAG           ?= v0.5.1-rc3
+IMAGE_LOCAL         := cube-proxy
+CUBE_VERSION        ?= $(IMAGE_TAG)
+CUBE_COMMIT         ?= $(shell git rev-parse HEAD | cut -c1-8)
+CUBE_BUILD_TIME     ?= $(shell date +'%Y%m%d')
 
-IMAGE_LOCAL     := cube-proxy
+# Base OpenResty image; overridable for private mirrors / pinned digests.
+CUBE_PROXY_BASE_IMAGE ?= cube-sandbox-image.tencentcloudcr.com/opensource/openresty:1.21.4.1-6-alpine-fat
+
+# Target architecture; defaults to the host architecture.
+# Override with: make build ARCH=amd64  or  make build ARCH=arm64
+ARCH ?= $(shell uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')
+
+IMAGES := \
+	cube-sandbox-cn.tencentcloudcr.com/cube-sandbox/cube-proxy \
+	cube-sandbox-int.tencentcloudcr.com/cube-sandbox/cube-proxy \
+	#
 
 ifeq ($(V),1)
 	Q =
@@ -19,15 +30,44 @@ else
 	MAKEFLAGS += --no-print-directory
 endif
 
-.PHONY: test
-test: build
-
-.PHONY: release
-release: build
-
 .PHONY: build
 build:
-	$(call msg,BUILD IMAGE $(IMAGE_LOCAL):$(IMAGE_TAG))
-	$(Q)docker build --rm $(QUIET)			\
-		-t $(IMAGE_LOCAL):$(IMAGE_TAG)		\
+	$(call msg,BUILD IMAGE $(IMAGE_LOCAL):$(IMAGE_TAG)-$(ARCH))
+	$(Q)docker build --rm $(QUIET) \
+		--platform linux/$(ARCH) \
+		--build-arg CUBE_PROXY_BASE_IMAGE=$(CUBE_PROXY_BASE_IMAGE) \
+		--build-arg CUBE_VERSION=$(CUBE_VERSION) \
+		--build-arg CUBE_COMMIT=$(CUBE_COMMIT) \
+		--build-arg CUBE_BUILD_TIME=$(CUBE_BUILD_TIME) \
+		-t $(IMAGE_LOCAL):$(IMAGE_TAG)-$(ARCH) \
 		.
+
+# Push the architecture-specific image to all registries.
+# Run `make push` on an amd64 host, then again on an arm64 host, then
+# `make manifest` on either host to combine them.
+.PHONY: push
+push: $(IMAGES)
+
+$(IMAGES):
+	$(call msg,TAG and PUSH $@:$(IMAGE_TAG)-$(ARCH))
+	$(Q)docker tag $(IMAGE_LOCAL):$(IMAGE_TAG)-$(ARCH) $@:$(IMAGE_TAG)-$(ARCH)
+	$(Q)docker push $(QUIET) $@:$(IMAGE_TAG)-$(ARCH)
+
+# Create and push multi-arch manifest lists for $(IMAGE_TAG) and `latest`.
+# Requires both amd64 and arm64 images to have been pushed to all registries
+# first (via `make push` on each architecture).
+.PHONY: manifest
+manifest:
+	$(Q)for image in $(IMAGES); do \
+		for tag in $(IMAGE_TAG) latest; do \
+			docker manifest create $$image:$$tag \
+				$$image:$(IMAGE_TAG)-amd64 \
+				$$image:$(IMAGE_TAG)-arm64; \
+			docker manifest push $$image:$$tag; \
+			docker manifest rm $$image:$$tag; \
+		done; \
+	done
+
+.PHONY: clean
+clean:
+	$(Q)rm -rf bin/

--- a/deploy/one-click/README_zh.md
+++ b/deploy/one-click/README_zh.md
@@ -109,7 +109,7 @@ deploy/one-click/dist/cube-sandbox-one-click-<version>.tar.gz
 - `CubeAPI/bin/cube-api`
 - `containerd-shim-cube-rs`、`cube-runtime`
 - 本地构建得到的 `cube-image/cube-guest-image-cpu.img`
-- `cubeproxy/` 目录及其 `build-context`
+- `cubeproxy/` 目录（运行时拉取预构建镜像；`build-context` 仅供私有 TCR 重建）
 - `support/` 目录及其 compose 模板
 - `webui/` 目录、compose 模板、nginx 配置和已构建的 `web/dist` 静态资源
 - 基于 `vmlinux` 现场打包得到的 `cube-kernel-scf.zip`

--- a/deploy/one-click/build-release-bundle.sh
+++ b/deploy/one-click/build-release-bundle.sh
@@ -550,6 +550,10 @@ copy_dir_contents "${CUBE_PROXY_TEMPLATE_DIR}" "${PACKAGE_ROOT}/cubeproxy"
 copy_dir_contents "${CUBE_COREDNS_TEMPLATE_DIR}" "${PACKAGE_ROOT}/coredns"
 copy_dir_contents "${CUBE_WEBUI_TEMPLATE_DIR}" "${PACKAGE_ROOT}/webui"
 copy_dir_contents "${CUBE_SYSTEMD_TEMPLATE_DIR}" "${PACKAGE_ROOT}/systemd"
+# cube-proxy runtime pulls a pre-published image (CubeProxy/Makefile `make
+# push` → cube-sandbox-{int,cn}.tencentcloudcr.com). build-context is still
+# shipped so terraform/tencentcloud/build_images.sh can rebuild into a private
+# TCR when TENCENTCLOUD_USE_TCR=true.
 copy_dir_contents "${CUBE_PROXY_SOURCE_DIR}" "${PACKAGE_ROOT}/cubeproxy/build-context"
 rm -f "${PACKAGE_ROOT}/cubeproxy/build-context/Makefile"
 generate_cube_proxy_nginx_template \

--- a/deploy/one-click/cubeproxy/docker-compose.yaml.template
+++ b/deploy/one-click/cubeproxy/docker-compose.yaml.template
@@ -3,11 +3,6 @@ services:
   cube-proxy:
     image: __CUBE_PROXY_IMAGE__
     container_name: __CUBE_PROXY_CONTAINER_NAME__
-    build:
-      context: __CUBE_PROXY_BUILD_CONTEXT__
-      dockerfile: Dockerfile
-      args:
-        CUBE_PROXY_BASE_IMAGE: "__CUBE_PROXY_BASE_IMAGE__"
     restart: unless-stopped
     network_mode: host
     environment:

--- a/deploy/one-click/env.example
+++ b/deploy/one-click/env.example
@@ -77,9 +77,6 @@ CUBE_SANDBOX_SYSTEMD_RUNTIME_DIR=/run/cube-sandbox-systemd
 # Canonical override names for the upstream container images used by the
 # bundled dependency services. These are consumed by deploy/one-click/scripts:
 #   CUBE_PROXY_COREDNS_IMAGE  -> scripts/one-click/up-dns.sh + scripts/systemd/coredns-start.sh
-#   CUBE_PROXY_BASE_IMAGE -> scripts/one-click/up-cube-proxy.sh (FROM base image
-#                            that CubeProxy/Dockerfile is built on; passed as the
-#                            CUBE_PROXY_BASE_IMAGE docker build arg)
 #   CUBE_SANDBOX_MYSQL_IMAGE    -> scripts/one-click/up-support.sh
 #   CUBE_SANDBOX_REDIS_IMAGE    -> scripts/one-click/up-support.sh
 #   WEB_UI_IMAGE   -> scripts/one-click/up-webui.sh
@@ -88,8 +85,12 @@ CUBE_SANDBOX_SYSTEMD_RUNTIME_DIR=/run/cube-sandbox-systemd
 # a pull-through mirror, or pinned @sha256 digests for air-gapped installs.
 # These values participate in the three-way env merge, so a customized image
 # is preserved across upgrades.
+#
+# Pre-published CubeSandbox component images (cube-proxy / cube-lifecycle-
+# manager / cube-egress) are selected by MIRROR=cn|int below, or overridden
+# with CUBE_SANDBOX_CUBE_PROXY_IMAGE / CUBE_SANDBOX_CUBE_LCM_IMAGE /
+# CUBE_SANDBOX_CUBE_EGRESS_IMAGE.
 CUBE_PROXY_COREDNS_IMAGE=cube-sandbox-image.tencentcloudcr.com/opensource/coredns/coredns:1.14.2
-CUBE_PROXY_BASE_IMAGE=cube-sandbox-image.tencentcloudcr.com/opensource/openresty:1.21.4.1-6-alpine-fat
 CUBE_SANDBOX_MYSQL_IMAGE=cube-sandbox-image.tencentcloudcr.com/opensource/mysql:8.0
 CUBE_SANDBOX_REDIS_IMAGE=cube-sandbox-image.tencentcloudcr.com/opensource/redis:7-alpine
 WEB_UI_IMAGE=cube-sandbox-image.tencentcloudcr.com/opensource/openresty:1.21.4.1-6-alpine-fat
@@ -145,7 +146,8 @@ CUBE_SANDBOX_CUBE_ROUTER_ENABLE=0
 
 # Cube proxy options.
 CUBE_PROXY_ENABLE=1
-CUBE_PROXY_IMAGE_TAG=cube-proxy:one-click
+# Optional full image override (otherwise selected by MIRROR=cn|int):
+# CUBE_SANDBOX_CUBE_PROXY_IMAGE=<registry>/cube-sandbox/cube-proxy:<tag>
 CUBE_PROXY_CONTAINER_NAME=cube-proxy
 CUBE_PROXY_HTTPS_PORT=443
 # The systemd post-start TCP listener check follows this HTTP proxy port.
@@ -213,7 +215,7 @@ DATABASE_URL=mysql://cube:cube_pass@127.0.0.1:3306/cube_mvp
 
 # Container image registry region selector.
 # Controls which regional registry is used for pulling CubeSandbox component
-# images (currently affects cube-egress).
+# images (cube-proxy / cube-lifecycle-manager / cube-egress).
 #   <empty> (default) → international registry (cube-sandbox-int.tencentcloudcr.com)
 #   cn                → China-region registry (cube-sandbox-cn.tencentcloudcr.com)
 # Other images (coredns, mysql, redis, webui) use the unified global registry

--- a/deploy/one-click/lib/common.sh
+++ b/deploy/one-click/lib/common.sh
@@ -992,6 +992,10 @@ DEPRECATED_KEYS = {
     "AGENTHUB_LLM_CREDENTIAL_MODE",
     "AGENTHUB_SECRET_KEY",
     "CUBE_API_DATABASE_URL",
+    # cube-proxy now pulls a pre-published image (MIRROR / CUBE_SANDBOX_CUBE_PROXY_IMAGE);
+    # the old local-build knobs must not linger as kept-extra after upgrade.
+    "CUBE_PROXY_IMAGE_TAG",
+    "CUBE_PROXY_BASE_IMAGE",
 }
 
 LEGACY_CUBE_PROXY_CERT_DIR_DEFAULTS = {
@@ -999,6 +1003,12 @@ LEGACY_CUBE_PROXY_CERT_DIR_DEFAULTS = {
     "'${ONE_CLICK_INSTALL_PREFIX}/cubeproxy/certs'",
     "${ONE_CLICK_INSTALL_PREFIX}/cubeproxy/certs",
 }
+
+# Old one-click default for the locally-built cube-proxy image. Upgrades that
+# still carry this exact value drop it (via DEPRECATED_KEYS) and adopt the
+# pre-published TCR image selected by MIRROR; only non-default custom tags are
+# migrated to CUBE_SANDBOX_CUBE_PROXY_IMAGE.
+LEGACY_CUBE_PROXY_IMAGE_TAG_DEFAULT = "cube-proxy:one-click"
 
 
 def normalize_legacy_value(key, val, tmpl_val):
@@ -1057,6 +1067,20 @@ for line in template:
     else:
         added.append((key, tmpl_val))
     out_lines.append("%s=%s" % (key, chosen))
+
+# Migrate a customized CUBE_PROXY_IMAGE_TAG into CUBE_SANDBOX_CUBE_PROXY_IMAGE
+# before the obsolete key is dropped. The old default cube-proxy:one-click is
+# NOT migrated: upgrades adopt the pre-published TCR image selected by MIRROR.
+legacy_proxy_image_tag = old_values.get("CUBE_PROXY_IMAGE_TAG", "").strip()
+if (legacy_proxy_image_tag
+        and legacy_proxy_image_tag != LEGACY_CUBE_PROXY_IMAGE_TAG_DEFAULT
+        and "CUBE_SANDBOX_CUBE_PROXY_IMAGE" not in old_values):
+    old_values["CUBE_SANDBOX_CUBE_PROXY_IMAGE"] = legacy_proxy_image_tag
+    migrated_legacy.append((
+        "CUBE_PROXY_IMAGE_TAG",
+        legacy_proxy_image_tag,
+        "CUBE_SANDBOX_CUBE_PROXY_IMAGE=%s" % legacy_proxy_image_tag,
+    ))
 
 # Old-only keys (present in old runtime, absent from the new template) are
 # host/user specific (NODE_IP, ROLE, control-plane addr, custom vars). Never

--- a/deploy/one-click/scripts/cube-diag/collect-logs.sh
+++ b/deploy/one-click/scripts/cube-diag/collect-logs.sh
@@ -258,8 +258,8 @@ collect_cube_proxy() {
   mkdir -p "${dest}"
 
   # cube-proxy runs inside a Docker container; its logs are not on the host
-  # filesystem. Find the running container by image name (cube-proxy:one-click
-  # as shipped by the one-click installer) and extract via docker exec.
+  # filesystem. Find the running container by name (or image path containing
+  # /cube-proxy:) and extract via docker exec.
   if ! command -v docker >/dev/null 2>&1; then
     _warn "docker not found — cannot collect cube-proxy container logs"
     return
@@ -273,10 +273,10 @@ collect_cube_proxy() {
            --format '{{.Names}}\t{{.ID}}' 2>/dev/null \
          | awk '$1=="cube-proxy" {print $2}' | head -1)"
   if [[ -z "${cid}" ]]; then
-    # Fall back: match by image name pattern cube-proxy:*
+    # Fall back: match by image name (local cube-proxy:* or registry .../cube-proxy:*)
     cid="$(docker ps --filter 'status=running' \
              --format '{{.Image}}\t{{.ID}}' 2>/dev/null \
-           | awk '$1~/^cube-proxy:/ {print $2}' | head -1)"
+           | awk '$1~/(^|\/)cube-proxy:/ {print $2}' | head -1)"
   fi
   if [[ -z "${cid}" ]]; then
     _warn "cube-proxy container not running — cannot collect its logs"

--- a/deploy/one-click/scripts/one-click/common.sh
+++ b/deploy/one-click/scripts/one-click/common.sh
@@ -368,6 +368,11 @@ docker_rm_if_exists() {
   docker rm "${name}" >/dev/null 2>&1 || true
 }
 
+docker_image_exists() {
+  local image_ref="$1"
+  docker image inspect "${image_ref}" >/dev/null 2>&1
+}
+
 wait_for_http() {
   local url="$1"
   local retries="${2:-30}"

--- a/deploy/one-click/scripts/one-click/up-cube-lifecycle-manager.sh
+++ b/deploy/one-click/scripts/one-click/up-cube-lifecycle-manager.sh
@@ -113,13 +113,18 @@ if command_output_contains_fixed_string "LISTEN" ss -lnt "( sport = :${CUBE_LCM_
   die "port ${CUBE_LCM_LISTEN_PORT} is already in use; cube-lifecycle-manager uses host networking and requires it to be free"
 fi
 
-# Pull explicitly so a stale image cached in the local docker store doesn't
-# silently mask a new release. On failure fall through to `compose up` — that
-# path may still succeed if the image is already present locally (airgap
-# scenario with CUBE_SANDBOX_CUBE_LCM_IMAGE pointing at a preloaded tag).
+# Pull explicitly so the failure mode (registry unreachable / not logged in /
+# image not pushed yet) surfaces here instead of midway through `compose up`.
+# If the image already exists locally and the registry is unreachable, fall
+# back to the cached copy (airgap / CUBE_SANDBOX_CUBE_LCM_IMAGE preload).
 log "pulling ${CUBE_LCM_IMAGE}"
-docker pull "${CUBE_LCM_IMAGE}" >/dev/null 2>&1 \
-  || log "docker pull failed; assuming ${CUBE_LCM_IMAGE} is available locally"
+if ! docker pull "${CUBE_LCM_IMAGE}" >/dev/null; then
+  if docker_image_exists "${CUBE_LCM_IMAGE}"; then
+    log "WARN: pull failed but local image exists; using cached copy"
+  else
+    die "pull failed for ${CUBE_LCM_IMAGE} and no local copy is cached; check registry reachability and credentials (or set MIRROR=cn / CUBE_SANDBOX_CUBE_LCM_IMAGE)"
+  fi
+fi
 
 if [[ "${COMPOSE_DETACH}" == "0" ]]; then
   cube_lcm_compose_run up cube-lifecycle-manager

--- a/deploy/one-click/scripts/one-click/up-cube-proxy.sh
+++ b/deploy/one-click/scripts/one-click/up-cube-proxy.sh
@@ -1,4 +1,9 @@
 #!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (C) 2026 Tencent. All rights reserved.
+#
+# Bring up cube-proxy on the control node from a pre-published image
+# (mirrors up-cube-lifecycle-manager.sh / cube-egress).
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -16,7 +21,6 @@ CUBE_PROXY_ENABLE="${CUBE_PROXY_ENABLE:-1}"
 [[ "${CUBE_PROXY_ENABLE}" == "1" ]] || die "CUBE_PROXY_ENABLE must be 1; cube proxy is required in one-click deployment"
 
 PROXY_DIR="${TOOLBOX_ROOT}/cubeproxy"
-BUILD_CONTEXT_DIR="${PROXY_DIR}/build-context"
 CUBE_PROXY_CERT_DIR="${CUBE_PROXY_CERT_DIR:-${PROXY_DIR}/certs}"
 CERT_DIR="${CUBE_PROXY_CERT_DIR}"
 GLOBAL_TEMPLATE="${PROXY_DIR}/global.conf.template"
@@ -24,8 +28,35 @@ GLOBAL_CONF="${PROXY_DIR}/global.conf"
 COMPOSE_TEMPLATE="${PROXY_DIR}/docker-compose.yaml.template"
 COMPOSE_FILE="${PROXY_DIR}/docker-compose.yaml"
 
-CUBE_PROXY_IMAGE_TAG="${CUBE_PROXY_IMAGE_TAG:-cube-proxy:one-click}"
-CUBE_PROXY_BASE_IMAGE="${CUBE_PROXY_BASE_IMAGE:-cube-sandbox-image.tencentcloudcr.com/opensource/openresty:1.21.4.1-6-alpine-fat}"
+# Image resolution priority mirrors up-cube-lifecycle-manager.sh:
+#   1. CUBE_SANDBOX_CUBE_PROXY_IMAGE (explicit operator override)
+#   2. MIRROR=cn  → cn.tencentcloudcr.com (China-region pull-through)
+#   3. default    → int.tencentcloudcr.com (overseas/international)
+#
+# The image is published by CubeProxy/Makefile's `make push` to both
+# registries under the same :v0.5.1-rc3 tag; either default resolves
+# to whatever the operator most recently published.
+#
+# Compatibility: CUBE_PROXY_IMAGE_TAG is deprecated (local compose build era).
+# A non-default leftover value is honored once with a warning; the old default
+# cube-proxy:one-click is ignored so upgrades adopt the pre-published image.
+CUBE_PROXY_IMAGE_INT_DEFAULT="cube-sandbox-int.tencentcloudcr.com/cube-sandbox/cube-proxy:v0.5.1-rc3"
+CUBE_PROXY_IMAGE_CN_DEFAULT="cube-sandbox-cn.tencentcloudcr.com/cube-sandbox/cube-proxy:v0.5.1-rc3"
+if [[ -z "${CUBE_SANDBOX_CUBE_PROXY_IMAGE:-}" && -n "${CUBE_PROXY_IMAGE_TAG:-}" ]]; then
+  if [[ "${CUBE_PROXY_IMAGE_TAG}" == "cube-proxy:one-click" ]]; then
+    log "CUBE_PROXY_IMAGE_TAG=cube-proxy:one-click is deprecated and ignored; set CUBE_SANDBOX_CUBE_PROXY_IMAGE or MIRROR to select the pre-published cube-proxy image"
+  else
+    log "CUBE_PROXY_IMAGE_TAG is deprecated; using ${CUBE_PROXY_IMAGE_TAG}. Set CUBE_SANDBOX_CUBE_PROXY_IMAGE instead"
+    CUBE_SANDBOX_CUBE_PROXY_IMAGE="${CUBE_PROXY_IMAGE_TAG}"
+  fi
+fi
+if [[ -n "${CUBE_SANDBOX_CUBE_PROXY_IMAGE:-}" ]]; then
+  CUBE_PROXY_IMAGE="${CUBE_SANDBOX_CUBE_PROXY_IMAGE}"
+elif [[ "${MIRROR:-}" == "cn" ]]; then
+  CUBE_PROXY_IMAGE="${CUBE_PROXY_IMAGE_CN_DEFAULT}"
+else
+  CUBE_PROXY_IMAGE="${CUBE_PROXY_IMAGE_INT_DEFAULT}"
+fi
 CUBE_PROXY_CONTAINER_NAME="${CUBE_PROXY_CONTAINER_NAME:-cube-proxy}"
 CUBE_SANDBOX_NODE_IP="${CUBE_SANDBOX_NODE_IP:-}"
 CUBE_PROXY_REDIS_IP="${CUBE_PROXY_REDIS_IP:-127.0.0.1}"
@@ -75,9 +106,7 @@ MKCERT_BUNDLED_BIN="${TOOLBOX_ROOT}/support/bin/mkcert"
 PREPARE_ONLY="${ONE_CLICK_PREPARE_ONLY:-0}"
 
 ensure_dir "${PROXY_DIR}"
-ensure_dir "${BUILD_CONTEXT_DIR}"
 mkdir -p "${CERT_DIR}"
-ensure_file "${BUILD_CONTEXT_DIR}/Dockerfile"
 ensure_file "${GLOBAL_TEMPLATE}"
 ensure_file "${COMPOSE_TEMPLATE}"
 [[ -n "${CUBE_SANDBOX_NODE_IP}" ]] || die "CUBE_SANDBOX_NODE_IP is required for cube proxy"
@@ -149,10 +178,8 @@ render_template_atomic \
 render_template_atomic \
   "${COMPOSE_TEMPLATE}" \
   "${COMPOSE_FILE}" \
-  -e "s#__CUBE_PROXY_IMAGE__#$(escape_sed "${CUBE_PROXY_IMAGE_TAG}" '#')#g" \
-  -e "s#__CUBE_PROXY_BASE_IMAGE__#$(escape_sed "${CUBE_PROXY_BASE_IMAGE}" '#')#g" \
+  -e "s#__CUBE_PROXY_IMAGE__#$(escape_sed "${CUBE_PROXY_IMAGE}" '#')#g" \
   -e "s#__CUBE_PROXY_CONTAINER_NAME__#$(escape_sed "${CUBE_PROXY_CONTAINER_NAME}" '#')#g" \
-  -e "s#__CUBE_PROXY_BUILD_CONTEXT__#$(escape_sed "${BUILD_CONTEXT_DIR}" '#')#g" \
   -e "s#__CUBE_PROXY_CERT_DIR__#$(escape_sed "${CERT_DIR}" '#')#g" \
   -e "s#__CUBE_PROXY_GLOBAL_CONF__#$(escape_sed "${GLOBAL_CONF}" '#')#g" \
   -e "s#__CUBE_PROXY_NGINX_CONF__#$(escape_sed "${NGINX_CONF}" '#')#g" \
@@ -185,7 +212,19 @@ for port in "${CUBE_PROXY_HTTP_PORT}" "${CUBE_PROXY_HTTPS_PORT}"; do
   fi
 done
 
-compose_run build cube-proxy
+# Pull explicitly so the failure mode (registry unreachable / not logged in /
+# image not pushed yet) surfaces here instead of midway through `compose up`.
+# If the image already exists locally and the registry is unreachable, fall
+# back to the cached copy (airgap / CUBE_SANDBOX_CUBE_PROXY_IMAGE preload).
+log "pulling ${CUBE_PROXY_IMAGE}"
+if ! docker pull "${CUBE_PROXY_IMAGE}" >/dev/null; then
+  if docker_image_exists "${CUBE_PROXY_IMAGE}"; then
+    log "WARN: pull failed but local image exists; using cached copy"
+  else
+    die "pull failed for ${CUBE_PROXY_IMAGE} and no local copy is cached; check registry reachability and credentials (or set MIRROR=cn / CUBE_SANDBOX_CUBE_PROXY_IMAGE)"
+  fi
+fi
+
 if [[ "${COMPOSE_DETACH}" == "0" ]]; then
   compose_run up cube-proxy
   exit $?

--- a/deploy/one-click/tests/test_bump_image.sh
+++ b/deploy/one-click/tests/test_bump_image.sh
@@ -15,6 +15,8 @@ FILES=(
 	cube-lifecycle-manager/Makefile
 	cube-lifecycle-manager/README.md
 	deploy/one-click/scripts/one-click/up-cube-lifecycle-manager.sh
+	CubeProxy/Makefile
+	deploy/one-click/scripts/one-click/up-cube-proxy.sh
 	deploy/one-click/terraform/tencentcloud/variables.tf
 	deploy/one-click/terraform/tencentcloud/create.sh
 	deploy/one-click/terraform/tencentcloud/build_images.sh

--- a/deploy/one-click/tests/test_env_merge.sh
+++ b/deploy/one-click/tests/test_env_merge.sh
@@ -439,6 +439,73 @@ EOF
   assert_value "${out}" MY_CUSTOM_KEEP stays
 }
 
+test_migrates_custom_cube_proxy_image_tag() {
+  local new="${TMP_DIR}/new_proxy_img.example" old="${TMP_DIR}/old_proxy_img.env"
+  local out="${TMP_DIR}/out_proxy_img.env" diff="${TMP_DIR}/diff_proxy_img.txt"
+  write_new_example "${new}"
+  cat > "${old}" <<'EOF'
+CUBE_PROXY_IMAGE_TAG=my.reg/cube-proxy:custom
+CUBE_PROXY_BASE_IMAGE=cube-sandbox-image.tencentcloudcr.com/opensource/openresty:1.21.4.1-6-alpine-fat
+CUBE_SANDBOX_MYSQL_PORT=3306
+EOF
+
+  merge_env_three_way "${new}" "${old}" "" "" "${out}" "${diff}" 2>/dev/null
+
+  assert_value "${out}" CUBE_SANDBOX_CUBE_PROXY_IMAGE "my.reg/cube-proxy:custom"
+  if grep -q "^CUBE_PROXY_IMAGE_TAG=" "${out}"; then
+    fail "CUBE_PROXY_IMAGE_TAG should have been dropped after migration"
+  fi
+  if grep -q "^CUBE_PROXY_BASE_IMAGE=" "${out}"; then
+    fail "CUBE_PROXY_BASE_IMAGE should have been dropped on upgrade"
+  fi
+  assert_contains "${diff}" "[migrated-legacy]"
+  assert_contains "${diff}" "CUBE_PROXY_IMAGE_TAG: my.reg/cube-proxy:custom -> CUBE_SANDBOX_CUBE_PROXY_IMAGE=my.reg/cube-proxy:custom"
+  assert_contains "${diff}" "[dropped]"
+}
+
+test_drops_default_cube_proxy_image_tag_without_migration() {
+  local new="${TMP_DIR}/new_proxy_def.example" old="${TMP_DIR}/old_proxy_def.env"
+  local out="${TMP_DIR}/out_proxy_def.env" diff="${TMP_DIR}/diff_proxy_def.txt"
+  write_new_example "${new}"
+  cat > "${old}" <<'EOF'
+CUBE_PROXY_IMAGE_TAG=cube-proxy:one-click
+CUBE_PROXY_BASE_IMAGE=cube-sandbox-image.tencentcloudcr.com/opensource/openresty:1.21.4.1-6-alpine-fat
+CUBE_SANDBOX_MYSQL_PORT=3306
+EOF
+
+  merge_env_three_way "${new}" "${old}" "" "" "${out}" "${diff}" 2>/dev/null
+
+  if grep -q "^CUBE_PROXY_IMAGE_TAG=" "${out}"; then
+    fail "default CUBE_PROXY_IMAGE_TAG should have been dropped"
+  fi
+  if grep -q "^CUBE_PROXY_BASE_IMAGE=" "${out}"; then
+    fail "CUBE_PROXY_BASE_IMAGE should have been dropped"
+  fi
+  if grep -q "^CUBE_SANDBOX_CUBE_PROXY_IMAGE=" "${out}"; then
+    fail "default cube-proxy:one-click must not migrate to CUBE_SANDBOX_CUBE_PROXY_IMAGE"
+  fi
+  assert_contains "${diff}" "[dropped]"
+}
+
+test_keeps_existing_cube_sandbox_cube_proxy_image_over_legacy_tag() {
+  local new="${TMP_DIR}/new_proxy_keep.example" old="${TMP_DIR}/old_proxy_keep.env"
+  local out="${TMP_DIR}/out_proxy_keep.env" diff="${TMP_DIR}/diff_proxy_keep.txt"
+  write_new_example "${new}"
+  cat > "${old}" <<'EOF'
+CUBE_PROXY_IMAGE_TAG=my.reg/cube-proxy:stale
+CUBE_SANDBOX_CUBE_PROXY_IMAGE=my.reg/cube-proxy:already-set
+EOF
+
+  merge_env_three_way "${new}" "${old}" "" "" "${out}" "${diff}" 2>/dev/null
+
+  assert_value "${out}" CUBE_SANDBOX_CUBE_PROXY_IMAGE "my.reg/cube-proxy:already-set"
+  if grep -q "^CUBE_PROXY_IMAGE_TAG=" "${out}"; then
+    fail "CUBE_PROXY_IMAGE_TAG should have been dropped"
+  fi
+  # Must not rewrite an already-present override from the stale IMAGE_TAG.
+  assert_not_contains "${diff}" "CUBE_PROXY_IMAGE_TAG: my.reg/cube-proxy:stale ->"
+}
+
 test_non_utf8_env_fails_cleanly() {
   local new="${TMP_DIR}/new_bad_utf8.example" old="${TMP_DIR}/old_bad_utf8.env"
   local out="${TMP_DIR}/out_bad_utf8.env" diff="${TMP_DIR}/diff_bad_utf8.txt" err="${TMP_DIR}/bad_utf8.err"
@@ -539,6 +606,9 @@ test_new_dotenv_overrides_take_priority
 test_version_lt
 test_diff_report_redacts_secrets
 test_drops_obsolete_agenthub_keys
+test_migrates_custom_cube_proxy_image_tag
+test_drops_default_cube_proxy_image_tag_without_migration
+test_keeps_existing_cube_sandbox_cube_proxy_image_over_legacy_tag
 test_non_utf8_env_fails_cleanly
 test_read_helpers_reject_invalid_key
 test_read_helpers

--- a/scripts/bump-image.sh
+++ b/scripts/bump-image.sh
@@ -77,13 +77,15 @@ edit_expr() {
 	CubeEgress/Makefile)
 		echo "s{((?:IMAGE_TAG|CUBE_VERSION)\\s*\\?=\\s*)${PERL_SEMVER}}{\$1\$ENV{VER}}"
 		;;
-	cube-lifecycle-manager/Makefile)
+	cube-lifecycle-manager/Makefile | \
+		CubeProxy/Makefile)
 		echo "s{((?:IMAGE_TAG|CUBE_VERSION)\\s*\\?=\\s*)${PERL_SEMVER}}{\$1\$ENV{VER}}"
 		;;
 	cube-lifecycle-manager/README.md)
 		echo "s{${PERL_SEMVER}}{\$ENV{VER}}g if /cube-lifecycle-manager:|IMAGE_TAG/;"
 		;;
-	deploy/one-click/scripts/one-click/up-cube-lifecycle-manager.sh)
+	deploy/one-click/scripts/one-click/up-cube-lifecycle-manager.sh | \
+		deploy/one-click/scripts/one-click/up-cube-proxy.sh)
 		echo "s{:${PERL_SEMVER}}{:\$ENV{VER}}g"
 		;;
 	deploy/one-click/terraform/tencentcloud/variables.tf)
@@ -122,6 +124,8 @@ FILES=(
 	cube-lifecycle-manager/Makefile
 	cube-lifecycle-manager/README.md
 	deploy/one-click/scripts/one-click/up-cube-lifecycle-manager.sh
+	CubeProxy/Makefile
+	deploy/one-click/scripts/one-click/up-cube-proxy.sh
 	deploy/one-click/terraform/tencentcloud/variables.tf
 	deploy/one-click/terraform/tencentcloud/create.sh
 	deploy/one-click/terraform/tencentcloud/build_images.sh


### PR DESCRIPTION
## Summary

Replace the on-host Docker build of cube-proxy with pre-published, multi-arch images pulled from TCR registries, mirroring the pattern already used by cube-lifecycle-manager and cube-egress.

### Changes

**CubeProxy/Makefile:**
- Support multi-arch builds (`ARCH=amd64|arm64`) with platform flag
- Add `make push` to tag and push architecture-specific images to both registries
- Add `make manifest` to create and push multi-arch manifest lists

**One-click deploy:**
- Drop compose build block; pull cube-proxy from TCR by default
- Resolve image via `MIRROR=cn|int` (same as other components)
- Honor `CUBE_SANDBOX_CUBE_PROXY_IMAGE` override for airgap/preload scenarios
- Deprecate `CUBE_PROXY_IMAGE_TAG` and `CUBE_PROXY_BASE_IMAGE`; migrate non-default values automatically on upgrade
- Gracefully fall back to cached local image when registry is unreachable

**Diagnostics & tests:**
- Update collect-logs.sh to match registry-pulled image names
- Add env-merge tests for legacy migration and deprecation paths
- Update bump-image.sh to cover CubeProxy version references