### PR TITLE
feat(sdk/go): add SetTimeout() to Go SDK

### DIFF
--- a/sdk/go/coverage_test.go
+++ b/sdk/go/coverage_test.go
@@ -161,6 +161,12 @@ func TestSandboxRequiresAttachedClient(t *testing.T) {
 	if _, err := (&Sandbox{}).RunCode(ctx, "1", RunCodeOptions{}); err == nil {
 		t.Fatal("RunCode without client returned nil error")
 	}
+	if err := (&Sandbox{}).SetTimeout(ctx, time.Second); err == nil {
+		t.Fatal("SetTimeout without client returned nil error")
+	}
+	if err := (*Sandbox)(nil).SetTimeout(ctx, time.Second); err == nil {
+		t.Fatal("SetTimeout on nil sandbox returned nil error")
+	}
 }
 
 func TestSandboxPauseBranches(t *testing.T) {

--- a/sdk/go/sandbox.go
+++ b/sdk/go/sandbox.go
@@ -111,6 +111,30 @@ func (s *Sandbox) Resume(ctx context.Context, timeout *time.Duration) error {
 	return s.client.doJSON(ctx, http.MethodPost, path, payload, nil, http.StatusOK, http.StatusCreated, http.StatusNoContent)
 }
 
+// SetTimeout updates the sandbox idle timeout (POST /sandboxes/:id/timeout).
+//
+// Positive values set a new TTL in seconds. Zero requests immediate expiry.
+// NeverTimeout (-1) disables idle timeout entirely. Sub-second durations are
+// rounded up because the wire protocol uses integer seconds. Values other
+// than NeverTimeout that are < 0 are rejected with a descriptive error.
+//
+// Errors wrap ErrSandboxNotFound (404) or an *APIError for other HTTP errors.
+//
+// See docs/guide/lifecycle.md for timeout semantics.
+func (s *Sandbox) SetTimeout(ctx context.Context, timeout time.Duration) error {
+	if err := s.ensureClient(); err != nil {
+		return err
+	}
+	if timeout < 0 && timeout != NeverTimeout {
+		return fmt.Errorf("cubesandbox: timeout must be >= 0 or NeverTimeout (-1), got %v", timeout)
+	}
+
+	seconds := timeoutPayloadSeconds(timeout)
+	path := "/sandboxes/" + url.PathEscape(s.SandboxID) + "/timeout"
+	payload := map[string]any{"timeout": seconds}
+	return s.client.doJSON(ctx, http.MethodPost, path, payload, nil, http.StatusNoContent)
+}
+
 func (s *Sandbox) Kill(ctx context.Context) error {
 	if err := s.ensureClient(); err != nil {
 		return err

--- a/sdk/go/sdk_test.go
+++ b/sdk/go/sdk_test.go
@@ -1390,3 +1390,122 @@ func TestGetTemplateParsesNetworkFields(t *testing.T) {
 		t.Fatalf("AllowInternetAccess=%#v, want false", info.AllowInternetAccess)
 	}
 }
+
+// ── SetTimeout ─────────────────────────────────────────────────────────────
+
+func TestSetTimeoutWireValues(t *testing.T) {
+	tests := []struct {
+		name    string
+		timeout time.Duration
+		want    int
+	}{
+		{"positive", 120 * time.Second, 120},
+		{"zero", 0, 0},
+		{"never_timeout", NeverTimeout, -1},
+		{"sub_second_rounds_up", 500 * time.Millisecond, 1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var got map[string]any
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != http.MethodPost {
+					t.Errorf("method=%s, want POST", r.Method)
+				}
+				expectedPath := "/sandboxes/" + testSandboxID + "/timeout"
+				if r.URL.Path != expectedPath {
+					t.Errorf("path=%s, want %s", r.URL.Path, expectedPath)
+				}
+				json.NewDecoder(r.Body).Decode(&got)
+				w.WriteHeader(http.StatusNoContent)
+			}))
+			defer server.Close()
+
+			client := NewClient(Config{APIURL: server.URL})
+			sb := &Sandbox{client: client, SandboxID: testSandboxID}
+			ctx := context.Background()
+
+			if err := sb.SetTimeout(ctx, tt.timeout); err != nil {
+				t.Fatalf("SetTimeout: %v", err)
+			}
+			assertNumber(t, got, "timeout", float64(tt.want))
+		})
+	}
+}
+
+func TestSetTimeoutRejectsInvalidNegative(t *testing.T) {
+	client := NewClient(Config{APIURL: "http://unreachable"})
+	sb := &Sandbox{client: client, SandboxID: testSandboxID}
+
+	err := sb.SetTimeout(context.Background(), -5*time.Second)
+	if err == nil {
+		t.Fatal("SetTimeout(-5s) should return an error")
+	}
+	if !strings.Contains(err.Error(), "NeverTimeout") && !strings.Contains(err.Error(), "-1") {
+		t.Fatalf("error should mention NeverTimeout/-1, got: %v", err)
+	}
+}
+
+func TestSetTimeoutContextCancelled(t *testing.T) {
+	client := NewClient(Config{APIURL: "http://unreachable"})
+	sb := &Sandbox{client: client, SandboxID: testSandboxID}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	err := sb.SetTimeout(ctx, 60*time.Second)
+	if err == nil {
+		t.Fatal("SetTimeout with cancelled context returned nil error")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("err=%v, want context.Canceled", err)
+	}
+}
+
+func TestSetTimeoutNotFound(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		fmt.Fprint(w, `{"message":"sandbox not found"}`)
+	}))
+	defer server.Close()
+
+	client := NewClient(Config{APIURL: server.URL})
+	sb := &Sandbox{client: client, SandboxID: "sb-nonexistent"}
+	ctx := context.Background()
+
+	err := sb.SetTimeout(ctx, 60*time.Second)
+	if err == nil {
+		t.Fatal("SetTimeout for missing sandbox returned nil error")
+	}
+	if !errors.Is(err, ErrSandboxNotFound) {
+		t.Fatalf("err=%v, want ErrSandboxNotFound", err)
+	}
+	var apiErr *APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("err=%v, want *APIError", err)
+	}
+}
+
+func TestSetTimeoutServerError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusInternalServerError)
+		fmt.Fprint(w, `{"message":"internal error"}`)
+	}))
+	defer server.Close()
+
+	client := NewClient(Config{APIURL: server.URL})
+	sb := &Sandbox{client: client, SandboxID: testSandboxID}
+
+	err := sb.SetTimeout(context.Background(), 60*time.Second)
+	if err == nil {
+		t.Fatal("SetTimeout for 500 returned nil error")
+	}
+	var apiErr *APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("err=%v, want *APIError", err)
+	}
+	if apiErr.StatusCode != http.StatusInternalServerError {
+		t.Fatalf("StatusCode=%d, want 500", apiErr.StatusCode)
+	}
+}


### PR DESCRIPTION
## Summary

Add `SetTimeout()` to the CubeSandbox Go SDK, mirroring the Python SDK `set_timeout()` (added in #743).

## API

```go
func (s *Sandbox) SetTimeout(ctx context.Context, timeout time.Duration) error
```

Supports the full three-value timeout semantics:
- `timeout > 0` → new TTL in seconds
- `timeout == 0` → expire immediately
- `NeverTimeout` (-1) → disable idle timeout entirely

## Design Decisions

1. **`time.Duration` parameter** — consistent with existing Go SDK conventions (`CreateOptions.Timeout`, `Resume`)
2. **`*Sandbox` receiver** — matches Python `sb.set_timeout()` and other Go lifecycle methods (`Pause`, `Resume`, `Kill`)
3. **Client-side validation** — rejects negative values other than `NeverTimeout` with a descriptive error, failing fast at the call site
4. **`http.StatusNoContent` only** — CubeAPI always returns 204 on success
5. **Sub-second rounding** — durations like 500ms round _up_ to 1 second (wire protocol uses integer seconds)

## Test Coverage (10 tests)

| Test | What it verifies |
|------|-----------------|
| `TestSetTimeoutWireValues/positive` | 120s → wire `120` |
| `TestSetTimeoutWireValues/zero` | 0 → wire `0` |
| `TestSetTimeoutWireValues/never_timeout` | `NeverTimeout` → wire `-1` |
| `TestSetTimeoutWireValues/sub_second_rounds_up` | 500ms → wire `1` |
| `TestSetTimeoutRejectsInvalidNegative` | `-5s` → descriptive error mentioning `-1` |
| `TestSetTimeoutContextCancelled` | cancelled ctx → `context.Canceled` |
| `TestSetTimeoutNotFound` | 404 → `errors.Is(ErrSandboxNotFound)` + `*APIError` |
| `TestSetTimeoutServerError` | 500 → `*APIError{StatusCode:500}` |
| detached sandbox (coverage) | no client → non-nil error |
| nil sandbox (coverage) | nil receiver → non-nil error |

## Not in Scope

- `Refresh` API (`POST /sandboxes/:id/refreshes`) — the server supports it but neither SDK exposes it yet. Will be added to both SDKs in a follow-up PR.