### PR TITLE
fix(cube-egress): derive transparent proxy IP from sandbox CIDR

### DIFF
--- a/CubeEgress/scripts/cube-proxy-iptables-init.sh
+++ b/CubeEgress/scripts/cube-proxy-iptables-init.sh
@@ -22,20 +22,51 @@
 # Required before this runs:
 #   - cube-dev interface exists (host-side gateway iface for sandbox VMs)
 #   - the cube-egress container is reachable on TPROXY_ON_IP:TPROXY_PORT_*
-#     (it shares the host network namespace, so `--on-ip 192.168.0.1`
-#     hits OpenResty's `listen 192.168.0.1:8080;` / `listen 192.168.0.1:8443 ssl;`).
+#     (it shares the host network namespace, so `--on-ip <cube-dev gateway>`
+#     hits OpenResty's matching transparent listeners).
 set -euo pipefail
 
+log()   { printf '[iptables-init] %s\n' "$*" >&2; }
+fatal() { log "FATAL: $*"; exit 1; }
+
+sandbox_gateway_ip_from_cidr() {
+    local cidr="$1"
+    local ip="${cidr%/*}"
+    local mask="${cidr#*/}"
+    local a b c d ip_int host_bits mask_int network_int
+
+    [[ "${cidr}" == */* && "${ip}" != "${cidr}" && "${mask}" =~ ^[0-9]+$ ]] \
+        || fatal "invalid CUBE_SANDBOX_NETWORK_CIDR: ${cidr}"
+    [[ "${ip}" =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$ ]] \
+        || fatal "invalid CUBE_SANDBOX_NETWORK_CIDR address: ${cidr}"
+    IFS=. read -r a b c d <<< "${ip}"
+    local octet
+    for octet in "${a}" "${b}" "${c}" "${d}"; do
+        [[ "${octet}" =~ ^[0-9]{1,3}$ ]] || fatal "invalid CUBE_SANDBOX_NETWORK_CIDR address: ${cidr}"
+        (( 10#${octet} >= 0 && 10#${octet} <= 255 )) || fatal "invalid CUBE_SANDBOX_NETWORK_CIDR address: ${cidr}"
+    done
+
+    host_bits=$(( 32 - 10#${mask} ))
+    (( host_bits >= 1 && host_bits <= 31 )) || fatal "invalid CUBE_SANDBOX_NETWORK_CIDR mask: ${cidr}"
+    ip_int=$(( (10#${a} << 24) + (10#${b} << 16) + (10#${c} << 8) + 10#${d} ))
+    mask_int=$(( (0xFFFFFFFF << host_bits) & 0xFFFFFFFF ))
+    network_int=$(( ip_int & mask_int ))
+
+    printf '%s.%s.%s.%s\n' \
+        "$(( ((network_int + 1) >> 24) & 255 ))" \
+        "$(( ((network_int + 1) >> 16) & 255 ))" \
+        "$(( ((network_int + 1) >> 8) & 255 ))" \
+        "$(( (network_int + 1) & 255 ))"
+}
+
 # -------- Tunables (must match nginx.conf) --------
-TPROXY_ON_IP="${CUBE_TPROXY_ON_IP:-192.168.0.1}"  # cube-dev IP
+SANDBOX_NETWORK_CIDR="${CUBE_SANDBOX_NETWORK_CIDR:-192.168.0.0/18}"
+TPROXY_ON_IP="$(sandbox_gateway_ip_from_cidr "${SANDBOX_NETWORK_CIDR}")"  # cube-dev IP
 TPROXY_PORT_HTTP=8080
 TPROXY_PORT_HTTPS=8443
 ROUTE_TABLE=100
 INGRESS_IFACE="${CUBE_INGRESS_IFACE:-cube-dev}"
 CHAIN="TRANSPROXY"
-
-log()   { printf '[iptables-init] %s\n' "$*" >&2; }
-fatal() { log "FATAL: $*"; exit 1; }
 
 require_root()  { [[ "$(id -u)" -eq 0 ]] || fatal "must run as root"; }
 require_iface() { ip link show "${INGRESS_IFACE}" &>/dev/null \

--- a/CubeEgress/start.sh
+++ b/CubeEgress/start.sh
@@ -18,9 +18,66 @@ PLACEHOLDER_CERT="${CA_DIR}/placeholder.crt"
 PLACEHOLDER_KEY="${CA_DIR}/placeholder.key"
 AUDIT_DIR="/data/log/cube-egress"
 NGINX_BIN="/usr/local/openresty/nginx/sbin/nginx"
+NGINX_CONF="/usr/local/openresty/nginx/conf/nginx.conf"
 
 log()   { printf '[entrypoint] %s\n' "$*" >&2; }
 fatal() { log "FATAL: $*"; exit 1; }
+
+validate_ipv4_literal() {
+    local value="$1"
+    local name="${2:-IPv4 address}"
+    local a b c d octet
+
+    [[ "${value}" =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$ ]] \
+        || fatal "invalid ${name}: ${value}"
+    IFS=. read -r a b c d <<< "${value}"
+    for octet in "${a}" "${b}" "${c}" "${d}"; do
+        [[ "${octet}" =~ ^[0-9]{1,3}$ ]] || fatal "invalid ${name}: ${value}"
+        (( 10#${octet} >= 0 && 10#${octet} <= 255 )) || fatal "invalid ${name}: ${value}"
+    done
+}
+
+sandbox_gateway_ip_from_cidr() {
+    local cidr="$1"
+    local ip="${cidr%/*}"
+    local mask="${cidr#*/}"
+    local a b c d ip_int host_bits mask_int network_int
+
+    [[ "${cidr}" == */* && "${ip}" != "${cidr}" && "${mask}" =~ ^[0-9]+$ ]] \
+        || fatal "invalid CUBE_SANDBOX_NETWORK_CIDR: ${cidr}"
+    validate_ipv4_literal "${ip}" "CUBE_SANDBOX_NETWORK_CIDR address"
+    IFS=. read -r a b c d <<< "${ip}"
+
+    host_bits=$(( 32 - 10#${mask} ))
+    (( host_bits >= 1 && host_bits <= 31 )) || fatal "invalid CUBE_SANDBOX_NETWORK_CIDR mask: ${cidr}"
+    ip_int=$(( (10#${a} << 24) + (10#${b} << 16) + (10#${c} << 8) + 10#${d} ))
+    mask_int=$(( (0xFFFFFFFF << host_bits) & 0xFFFFFFFF ))
+    network_int=$(( ip_int & mask_int ))
+
+    printf '%s.%s.%s.%s\n' \
+        "$(( ((network_int + 1) >> 24) & 255 ))" \
+        "$(( ((network_int + 1) >> 16) & 255 ))" \
+        "$(( ((network_int + 1) >> 8) & 255 ))" \
+        "$(( (network_int + 1) & 255 ))"
+}
+
+configure_listen_ip() {
+    local sandbox_network_cidr="${CUBE_SANDBOX_NETWORK_CIDR:-192.168.0.0/18}"
+    local listen_ip
+    listen_ip="$(sandbox_gateway_ip_from_cidr "${sandbox_network_cidr}")"
+    validate_ipv4_literal "${listen_ip}" "CubeEgress listen IP"
+
+    [[ -f "${NGINX_CONF}" ]] || fatal "nginx config missing: ${NGINX_CONF}"
+    sed -i -E \
+        -e "s/listen [0-9]+\.[0-9]+\.[0-9]+\.[0-9]+:8080 transparent reuseport;/listen ${listen_ip}:8080 transparent reuseport;/" \
+        -e "s/listen [0-9]+\.[0-9]+\.[0-9]+\.[0-9]+:8443 ssl transparent reuseport;/listen ${listen_ip}:8443 ssl transparent reuseport;/" \
+        "${NGINX_CONF}"
+    grep -Fq "listen ${listen_ip}:8080 transparent reuseport;" "${NGINX_CONF}" \
+        || fatal "failed to render HTTP listen IP in ${NGINX_CONF}"
+    grep -Fq "listen ${listen_ip}:8443 ssl transparent reuseport;" "${NGINX_CONF}" \
+        || fatal "failed to render HTTPS listen IP in ${NGINX_CONF}"
+    log "nginx transparent listen IP: ${listen_ip}"
+}
 
 # -------- 0. Must run as root --------
 # Several downstream steps require uid 0:
@@ -108,7 +165,8 @@ if (( (owner_bits & 3) != 3 )); then
     fatal "audit dir mode ${audit_mode} lacks owner rwx bits: ${AUDIT_DIR}"
 fi
 
-# -------- 5. nginx config validity --------
+# -------- 5. Render listener IP and validate nginx config --------
+configure_listen_ip
 log "Running nginx -t"
 "${NGINX_BIN}" -t
 

--- a/deploy/one-click/scripts/systemd/cube-egress-start.sh
+++ b/deploy/one-click/scripts/systemd/cube-egress-start.sh
@@ -5,7 +5,7 @@
 # Launch the cube-egress container in foreground (Type=simple unit).
 #
 # Network model is host (mandatory): nginx.conf binds explicitly to
-# 192.168.0.1:8080/8443 with IP_TRANSPARENT, which only works in the
+# the cube-dev gateway IP with IP_TRANSPARENT, which only works in the
 # host network namespace where the cube-dev iface lives.
 #
 # CA + audit dir come from cube-egress-prepare.sh (run as a oneshot
@@ -48,6 +48,7 @@ AUDIT_DIR="${CUBE_EGRESS_AUDIT_DIR:-/data/log/cube-egress}"
 # this URL is reachable from inside the container without any port
 # forwarding.
 BOOTSTRAP_URL="${CUBE_EGRESS_BOOTSTRAP_URL:-http://127.0.0.1:19090/v1/policies/dump}"
+SANDBOX_NETWORK_CIDR="${CUBE_SANDBOX_NETWORK_CIDR:-192.168.0.0/18}"
 
 ensure_dir "${CA_DIR}"
 ensure_dir "${AUDIT_DIR}"
@@ -97,6 +98,7 @@ docker create \
   --cap-add=SETGID \
   --cap-add=DAC_READ_SEARCH \
   -e "CUBE_EGRESS_BOOTSTRAP_URL=${BOOTSTRAP_URL}" \
+  -e "CUBE_SANDBOX_NETWORK_CIDR=${SANDBOX_NETWORK_CIDR}" \
   "${CUBE_EGRESS_IMAGE}" >/dev/null
 
 # `docker start -a` keeps the foreground attached to the container


### PR DESCRIPTION
CubeEgress previously assumed that the sandbox gateway address was always 192.168.0.1. This worked for the default 192.168.0.0/18 sandbox network, but failed when one-click installations used a custom CUBE_SANDBOX_NETWORK_CIDR: the cube-dev gateway moved to the custom subnet while CubeEgress still rendered OpenResty listeners and TPROXY rules against the default address.

Derive the cube-dev gateway address from CUBE_SANDBOX_NETWORK_CIDR by using the first usable IP in the configured network. Render OpenResty's HTTP and HTTPS transparent listeners to that address during CubeEgress startup before running nginx -t, and use the same derived address as the TPROXY --on-ip target.

Pass CUBE_SANDBOX_NETWORK_CIDR from the one-click systemd launcher into the cube-egress container, falling back to the historical 192.168.0.0/18 default when it is not set. This keeps the default deployment behavior unchanged while allowing custom sandbox CIDRs to route through CubeEgress correctly.