### PR TITLE
fix(cubemaster): rebuild stale rootfs artifacts

### DIFF
--- a/CubeMaster/pkg/templatecenter/artifact_build.go
+++ b/CubeMaster/pkg/templatecenter/artifact_build.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
 	"strings"
 	"sync"
 	"time"
@@ -16,6 +17,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/constants"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/db/models"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/log"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/service/sandbox/types"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/templatecenter/cube_egress_ca"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/templatecenter/image"
@@ -72,9 +74,13 @@ func ensureRootfsArtifact(ctx context.Context, req *types.CreateTemplateFromImag
 		record.DeletedAt = gorm.DeletedAt{}
 	}
 	if err == nil && record.Status == ArtifactStatusReady && record.GeneratedRequestJSON != "" {
-		generatedReq, err = generateTemplateCreateRequest(req, record, source.Config, downloadBaseURL)
-		if err == nil {
-			return record, generatedReq, false, nil
+		if validationErr := validateReusableRootfsArtifactFile(record); validationErr != nil {
+			log.G(ctx).Warnf("rootfs artifact %s is not reusable: %v; rebuilding", record.ArtifactID, validationErr)
+		} else {
+			generatedReq, err = generateTemplateCreateRequest(req, record, source.Config, downloadBaseURL)
+			if err == nil {
+				return record, generatedReq, false, nil
+			}
 		}
 	}
 	if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
@@ -106,9 +112,13 @@ func ensureRootfsArtifact(ctx context.Context, req *types.CreateTemplateFromImag
 				record.DeletedAt = gorm.DeletedAt{}
 			}
 			if record.Status == ArtifactStatusReady && record.GeneratedRequestJSON != "" {
-				generatedReq, err = generateTemplateCreateRequest(req, record, source.Config, downloadBaseURL)
-				if err == nil {
-					return record, generatedReq, false, nil
+				if validationErr := validateReusableRootfsArtifactFile(record); validationErr != nil {
+					log.G(ctx).Warnf("rootfs artifact %s is not reusable: %v; rebuilding", record.ArtifactID, validationErr)
+				} else {
+					generatedReq, err = generateTemplateCreateRequest(req, record, source.Config, downloadBaseURL)
+					if err == nil {
+						return record, generatedReq, false, nil
+					}
 				}
 			}
 		}
@@ -236,6 +246,32 @@ func validateReusableRootfsArtifact(record *models.RootfsArtifact, fingerprint, 
 		return nil, fmt.Errorf("rootfs artifact %s fingerprint mismatch: want %s got %s", artifactID, fingerprint, record.TemplateSpecFingerprint)
 	}
 	return record, nil
+}
+
+func validateReusableRootfsArtifactFile(record *models.RootfsArtifact) error {
+	if record == nil {
+		return gorm.ErrRecordNotFound
+	}
+	if strings.TrimSpace(record.Ext4Path) == "" {
+		return fmt.Errorf("rootfs artifact %s ext4 path is empty", record.ArtifactID)
+	}
+	if record.Ext4SizeBytes <= 0 {
+		return fmt.Errorf("rootfs artifact %s ext4 size is invalid: %d", record.ArtifactID, record.Ext4SizeBytes)
+	}
+	info, err := os.Stat(record.Ext4Path) // NOCC:Path Traversal()
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("rootfs artifact %s ext4 file %q is missing: %w", record.ArtifactID, record.Ext4Path, err)
+		}
+		return fmt.Errorf("stat rootfs artifact %s ext4 file %q: %w", record.ArtifactID, record.Ext4Path, err)
+	}
+	if !info.Mode().IsRegular() {
+		return fmt.Errorf("rootfs artifact %s ext4 path %q is not a regular file", record.ArtifactID, record.Ext4Path)
+	}
+	if info.Size() != record.Ext4SizeBytes {
+		return fmt.Errorf("rootfs artifact %s ext4 size mismatch: got %d want %d", record.ArtifactID, info.Size(), record.Ext4SizeBytes)
+	}
+	return nil
 }
 
 func rootfsArtifactSoftDeleted(record *models.RootfsArtifact) bool {

--- a/CubeMaster/pkg/templatecenter/redo.go
+++ b/CubeMaster/pkg/templatecenter/redo.go
@@ -9,13 +9,16 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
+	"sync"
+
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/constants"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/db/models"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/log"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/node"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/service/sandbox/types"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/templatecenter/image"
-	"strings"
+	"gorm.io/gorm"
 )
 
 func normalizeRedoTemplateImageRequest(req *types.RedoTemplateFromImageReq) (*types.RedoTemplateFromImageReq, error) {
@@ -184,6 +187,39 @@ func failRedoTemplateImageJob(ctx context.Context, jobID, phase, message string)
 	})
 }
 
+// prepareRootfsArtifactForRedoBuild removes leftovers from an interrupted
+// BUILDING_EXT4 attempt while holding the same process-local lock used by
+// ensureRootfsArtifact. If another caller completed a reusable artifact before
+// this redo acquired the lock, keep that fresh artifact instead of deleting it.
+func prepareRootfsArtifactForRedoBuild(ctx context.Context, artifactID string) (*models.RootfsArtifact, bool) {
+	artifactID = strings.TrimSpace(artifactID)
+	if artifactID == "" {
+		return nil, false
+	}
+	muV, _ := artifactBuildLocks.LoadOrStore(artifactID, &sync.Mutex{})
+	mu := muV.(*sync.Mutex)
+	mu.Lock()
+	defer mu.Unlock()
+
+	previousArtifact, err := getRootfsArtifactByID(ctx, artifactID)
+	if err != nil {
+		return nil, false
+	}
+	if previousArtifact.Status == ArtifactStatusReady && previousArtifact.GeneratedRequestJSON != "" {
+		if validationErr := validateReusableRootfsArtifactFile(previousArtifact); validationErr == nil {
+			return previousArtifact, true
+		}
+	}
+	if previousArtifact.Ext4Path != "" {
+		_ = cleanupLocalRootfsArtifact(previousArtifact.ArtifactID, previousArtifact.Ext4Path)
+	}
+	_ = updateRootfsArtifact(ctx, previousArtifact.ArtifactID, map[string]any{
+		"status":     ArtifactStatusFailed,
+		"last_error": "redo requested after artifact build failure",
+	})
+	return nil, false
+}
+
 func runRedoTemplateImageJob(ctx context.Context, jobID string, req *types.RedoTemplateFromImageReq, downloadBaseURL string) {
 	logger := log.G(ctx).WithFields(map[string]any{
 		"job_id":      jobID,
@@ -224,25 +260,81 @@ func runRedoTemplateImageJob(ctx context.Context, jobID string, req *types.RedoT
 	if resumePhase == "" {
 		resumePhase = JobPhaseSnapshotting
 	}
-	if resumePhase == JobPhaseBuildingExt4 {
+	needsBuild := resumePhase == JobPhaseBuildingExt4
+	cleanupPreviousBuild := needsBuild
+	if !needsBuild {
+		artifact, err = getRootfsArtifactByID(ctx, jobRecord.ArtifactID)
+		if err != nil {
+			failRedoTemplateImageJob(ctx, jobID, resumePhase, err.Error())
+			return
+		}
+		muV, _ := artifactBuildLocks.LoadOrStore(artifact.ArtifactID, &sync.Mutex{})
+		mu := muV.(*sync.Mutex)
+		validationErr, reloadErr := func() (error, error) {
+			mu.Lock()
+			defer mu.Unlock()
+
+			// The artifact may have been rebuilt while this redo waited for the
+			// per-artifact lock. Reload the authoritative row so validation and
+			// subsequent distribution use the current token, SHA, and metadata.
+			refreshedArtifact, err := getRootfsArtifactByID(ctx, jobRecord.ArtifactID)
+			if err != nil {
+				if errors.Is(err, gorm.ErrRecordNotFound) {
+					return err, nil
+				}
+				return nil, err
+			}
+			artifact = refreshedArtifact
+			switch {
+			case artifact.Status != ArtifactStatusReady:
+				return fmt.Errorf("rootfs artifact %s status is %q, want %q", artifact.ArtifactID, artifact.Status, ArtifactStatusReady), nil
+			case strings.TrimSpace(artifact.GeneratedRequestJSON) == "":
+				return fmt.Errorf("rootfs artifact %s generated request is empty", artifact.ArtifactID), nil
+			default:
+				return validateReusableRootfsArtifactFile(artifact), nil
+			}
+		}()
+		if reloadErr != nil {
+			failRedoTemplateImageJob(ctx, jobID, resumePhase, fmt.Sprintf("reload rootfs artifact %s after acquiring build lock: %v", jobRecord.ArtifactID, reloadErr))
+			return
+		}
+		if validationErr != nil {
+			logger.Warnf("redo rootfs artifact %s is not reusable: %v; rebuilding", artifact.ArtifactID, validationErr)
+			needsBuild = true
+			resumePhase = JobPhaseBuildingExt4
+			// ensureRootfsArtifact revalidates and claims the row under the same
+			// artifact lock. Do not separately clean the invalid file here: a
+			// concurrent create may replace it with a fresh artifact meanwhile.
+			cleanupPreviousBuild = false
+		}
+	}
+	if needsBuild {
 		if ShouldInjectEnvdIntoTemplate(&workingReq) {
 			failRedoTemplateImageJob(ctx, jobID, JobPhaseBuildingExt4, "redo cannot rebuild envd-enabled template rootfs because the original envd payload is not persisted")
 			return
 		}
+		if cleanupPreviousBuild {
+			if reusableArtifact, reusable := prepareRootfsArtifactForRedoBuild(ctx, jobRecord.ArtifactID); reusable {
+				artifact = reusableArtifact
+				needsBuild = false
+				resumePhase = JobPhaseDistributing
+				if err := updateTemplateImageJob(ctx, jobID, map[string]any{
+					"artifact_id":               artifact.ArtifactID,
+					"template_spec_fingerprint": artifact.TemplateSpecFingerprint,
+					"source_image_digest":       artifact.SourceImageDigest,
+					"artifact_status":           artifact.Status,
+					"phase":                     JobPhaseDistributing,
+					"progress":                  60,
+				}); err != nil {
+					logger.Errorf("update redo reusable artifact fail: %v", err)
+				}
+			}
+		}
+	}
+	if needsBuild {
 		if err := image.EnsureArtifactBuildPreflight(ctx); err != nil {
 			failRedoTemplateImageJob(ctx, jobID, JobPhaseBuildingExt4, err.Error())
 			return
-		}
-		if jobRecord.ArtifactID != "" {
-			if previousArtifact, lookupErr := getRootfsArtifactByID(ctx, jobRecord.ArtifactID); lookupErr == nil {
-				if previousArtifact.Ext4Path != "" {
-					_ = cleanupLocalRootfsArtifact(previousArtifact.ArtifactID, previousArtifact.Ext4Path)
-				}
-				_ = updateRootfsArtifact(ctx, previousArtifact.ArtifactID, map[string]any{
-					"status":     ArtifactStatusFailed,
-					"last_error": "redo requested after artifact build failure",
-				})
-			}
 		}
 		source, prepErr := image.PrepareLocalSource(ctx, image.SourceSpec{ImageRef: workingReq.SourceImageRef, RegistryUsername: workingReq.RegistryUsername, RegistryPassword: workingReq.RegistryPassword, DownloadBaseURL: downloadBaseURL})
 		if prepErr != nil {
@@ -276,12 +368,6 @@ func runRedoTemplateImageJob(ctx context.Context, jobID string, req *types.RedoT
 			logger.Errorf("update redo rebuilt artifact fail: %v", err)
 		}
 		resumePhase = JobPhaseDistributing
-	} else {
-		artifact, err = getRootfsArtifactByID(ctx, jobRecord.ArtifactID)
-		if err != nil {
-			failRedoTemplateImageJob(ctx, jobID, resumePhase, err.Error())
-			return
-		}
 	}
 
 	var imageCfg image.DockerImageConfig

--- a/CubeMaster/pkg/templatecenter/template_image_test.go
+++ b/CubeMaster/pkg/templatecenter/template_image_test.go
@@ -6,12 +6,16 @@ package templatecenter
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"reflect"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -1036,6 +1040,125 @@ func TestValidateReusableRootfsArtifactHandlesMissingRecord(t *testing.T) {
 	}
 }
 
+func TestValidateReusableRootfsArtifactFileAcceptsMatchingStat(t *testing.T) {
+	data := []byte("artifact-data")
+	path, _ := writeRootfsArtifactTestFile(t, data)
+
+	err := validateReusableRootfsArtifactFile(&models.RootfsArtifact{
+		ArtifactID:    "rfs-1",
+		Ext4Path:      path,
+		Ext4SHA256:    strings.Repeat("b", 64),
+		Ext4SizeBytes: int64(len(data)),
+	})
+	if err != nil {
+		t.Fatalf("validateReusableRootfsArtifactFile failed: %v", err)
+	}
+}
+
+func TestValidateReusableRootfsArtifactFileRejectsMissingFile(t *testing.T) {
+	err := validateReusableRootfsArtifactFile(&models.RootfsArtifact{
+		ArtifactID:    "rfs-1",
+		Ext4Path:      filepath.Join(t.TempDir(), "missing.ext4"),
+		Ext4SHA256:    strings.Repeat("a", 64),
+		Ext4SizeBytes: 1024,
+	})
+	if err == nil || !strings.Contains(err.Error(), "missing") {
+		t.Fatalf("expected missing file error, got %v", err)
+	}
+}
+
+func TestValidateReusableRootfsArtifactFileRejectsSizeMismatch(t *testing.T) {
+	path, _ := writeRootfsArtifactTestFile(t, []byte("artifact-data"))
+
+	err := validateReusableRootfsArtifactFile(&models.RootfsArtifact{
+		ArtifactID:    "rfs-1",
+		Ext4Path:      path,
+		Ext4SizeBytes: 1,
+	})
+	if err == nil || !strings.Contains(err.Error(), "size mismatch") {
+		t.Fatalf("expected size mismatch error, got %v", err)
+	}
+}
+
+func TestValidateReusableRootfsArtifactFileRejectsNonRegularFile(t *testing.T) {
+	err := validateReusableRootfsArtifactFile(&models.RootfsArtifact{
+		ArtifactID:    "rfs-1",
+		Ext4Path:      t.TempDir(),
+		Ext4SizeBytes: 1,
+	})
+	if err == nil || !strings.Contains(err.Error(), "not a regular file") {
+		t.Fatalf("expected non-regular file error, got %v", err)
+	}
+}
+
+func TestEnsureRootfsArtifactRebuildsMissingReadyArtifact(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	withCubeCA := false
+	source := &image.PreparedSource{
+		Digest:     "sha256:digest",
+		ConfigJSON: `{}`,
+	}
+	req := &types.CreateTemplateFromImageReq{
+		Request:           &types.Request{RequestID: "req-1"},
+		TemplateID:        "tpl-1",
+		SourceImageRef:    "docker.io/library/nginx:latest",
+		WritableLayerSize: "20Gi",
+		InstanceType:      cubeboxv1.InstanceType_cubebox.String(),
+		WithCubeCA:        &withCubeCA,
+	}
+	fingerprint := buildTemplateSpecFingerprintWithEnvdSHA(req, source.Digest, "", "")
+	artifactID := buildArtifactID(fingerprint)
+	stale := &models.RootfsArtifact{
+		ArtifactID:              artifactID,
+		TemplateSpecFingerprint: fingerprint,
+		Status:                  ArtifactStatusReady,
+		GeneratedRequestJSON:    `{"annotations":{"cube.master.template.id":"tpl-old"}}`,
+		Ext4Path:                filepath.Join(t.TempDir(), "missing.ext4"),
+		Ext4SHA256:              strings.Repeat("a", 64),
+		Ext4SizeBytes:           1024,
+	}
+	rebuiltReq := &types.CreateCubeSandboxReq{
+		Annotations: map[string]string{constants.CubeAnnotationAppSnapshotTemplateID: "tpl-1"},
+	}
+
+	patches.ApplyFunc(findReusableRootfsArtifact, func(ctx context.Context, fingerprint, artifactID string) (*models.RootfsArtifact, bool, error) {
+		return stale, false, nil
+	})
+	patches.ApplyFunc(claimRootfsArtifactForBuild, func(ctx context.Context, artifactID, fingerprint string, req *types.CreateTemplateFromImageReq, sourceDigest string) (*models.RootfsArtifact, error) {
+		if artifactID != stale.ArtifactID {
+			t.Fatalf("artifactID=%q, want %q", artifactID, stale.ArtifactID)
+		}
+		claimed := *stale
+		claimed.Status = ArtifactStatusBuilding
+		return &claimed, nil
+	})
+
+	buildCalled := false
+	patches.ApplyFunc(buildRootfsArtifact, func(ctx context.Context, record *models.RootfsArtifact, req *types.CreateTemplateFromImageReq, source *image.PreparedSource, downloadBaseURL string, caPEM []byte, caFingerprint string, envdPayload *EnvdInjectionPayload) (*models.RootfsArtifact, *types.CreateCubeSandboxReq, error) {
+		buildCalled = true
+		rebuilt := *record
+		rebuilt.Status = ArtifactStatusReady
+		rebuilt.Ext4Path = "/data/CubeMaster/storage/rfs-stale/rfs-stale.ext4"
+		return &rebuilt, rebuiltReq, nil
+	})
+
+	gotArtifact, gotReq, builtFresh, err := ensureRootfsArtifact(context.Background(), req, source, "http://master.example", nil)
+	if err != nil {
+		t.Fatalf("ensureRootfsArtifact failed: %v", err)
+	}
+	if !buildCalled || !builtFresh {
+		t.Fatalf("expected missing reusable artifact to trigger rebuild, buildCalled=%v builtFresh=%v", buildCalled, builtFresh)
+	}
+	if gotArtifact == nil || gotArtifact.Ext4Path == stale.Ext4Path {
+		t.Fatalf("expected rebuilt artifact, got %#v", gotArtifact)
+	}
+	if gotReq != rebuiltReq {
+		t.Fatalf("expected rebuilt request, got %#v", gotReq)
+	}
+}
+
 func TestRootfsArtifactSoftDeleted(t *testing.T) {
 	if rootfsArtifactSoftDeleted(nil) {
 		t.Fatal("nil record should not be treated as deleted")
@@ -1048,6 +1171,16 @@ func TestRootfsArtifactSoftDeleted(t *testing.T) {
 	if !rootfsArtifactSoftDeleted(record) {
 		t.Fatal("soft-deleted record should be detected")
 	}
+}
+
+func writeRootfsArtifactTestFile(t *testing.T, data []byte) (string, string) {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "artifact.ext4")
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		t.Fatalf("WriteFile failed: %v", err)
+	}
+	sum := sha256.Sum256(data)
+	return path, hex.EncodeToString(sum[:])
 }
 
 func TestManagedArtifactDirRecognizesWorkAndStoreRoots(t *testing.T) {
@@ -1348,6 +1481,8 @@ func TestRunRedoTemplateImageJobStopsOnArtifactCleanupFailure(t *testing.T) {
 	patches := gomonkey.NewPatches()
 	defer patches.Reset()
 
+	artifactData := []byte("artifact-data")
+	artifactPath, artifactSHA := writeRootfsArtifactTestFile(t, artifactData)
 	targets := []*node.Node{{InsID: "node-a", IP: "10.0.0.1", Healthy: true}}
 	generatedReqPayload, _ := json.Marshal(&types.CreateCubeSandboxReq{
 		InstanceType: cubeboxv1.InstanceType_cubebox.String(),
@@ -1388,6 +1523,12 @@ func TestRunRedoTemplateImageJobStopsOnArtifactCleanupFailure(t *testing.T) {
 	patches.ApplyFunc(getRootfsArtifactByID, func(ctx context.Context, artifactID string) (*models.RootfsArtifact, error) {
 		return &models.RootfsArtifact{
 			ArtifactID:           artifactID,
+			Ext4Path:             artifactPath,
+			Ext4SHA256:           artifactSHA,
+			Ext4SizeBytes:        int64(len(artifactData)),
+			DownloadToken:        "token-1",
+			MasterNodeIP:         "http://master.example",
+			Status:               ArtifactStatusReady,
 			GeneratedRequestJSON: string(generatedReqPayload),
 		}, nil
 	})
@@ -1415,10 +1556,436 @@ func TestRunRedoTemplateImageJobStopsOnArtifactCleanupFailure(t *testing.T) {
 	}
 }
 
+func TestRunRedoTemplateImageJobReloadsArtifactAfterBuildLock(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	const (
+		artifactID = "artifact-lock-refresh"
+		staleToken = "token-a"
+		freshToken = "token-b"
+	)
+	artifactData := []byte("artifact-data")
+	artifactPath, artifactSHA := writeRootfsArtifactTestFile(t, artifactData)
+	targets := []*node.Node{{InsID: "node-a", IP: "10.0.0.1", Healthy: true}}
+	staleArtifact := &models.RootfsArtifact{
+		ArtifactID:              artifactID,
+		TemplateSpecFingerprint: "fingerprint-1",
+		Ext4Path:                artifactPath,
+		Ext4SHA256:              artifactSHA,
+		Ext4SizeBytes:           int64(len(artifactData)),
+		DownloadToken:           staleToken,
+		Status:                  ArtifactStatusReady,
+		GeneratedRequestJSON:    `{}`,
+		ImageConfigJSON:         `{}`,
+		SourceImageDigest:       "sha256:digest",
+	}
+	freshArtifact := *staleArtifact
+	freshArtifact.DownloadToken = freshToken
+	freshArtifact.Ext4SHA256 = strings.Repeat("b", 64)
+
+	buildLock := &sync.Mutex{}
+	buildLock.Lock()
+	lockHeld := true
+	artifactBuildLocks.Delete(artifactID)
+	artifactBuildLocks.Store(artifactID, buildLock)
+	defer func() {
+		if lockHeld {
+			buildLock.Unlock()
+		}
+		artifactBuildLocks.Delete(artifactID)
+	}()
+
+	initialRead := make(chan struct{})
+	lockedReload := make(chan struct{})
+	lookupCalls := 0
+	distributedToken := ""
+	distributedSHA := ""
+	generatedToken := ""
+	generatedSHA := ""
+
+	patches.ApplyFunc(getTemplateImageJobRecordByID, func(ctx context.Context, jobID string) (*models.TemplateImageJob, error) {
+		return &models.TemplateImageJob{
+			JobID:       jobID,
+			TemplateID:  "tpl-1",
+			ResumePhase: JobPhaseDistributing,
+			ArtifactID:  artifactID,
+		}, nil
+	})
+	patches.ApplyFunc(updateTemplateImageJob, func(ctx context.Context, jobID string, values map[string]any) error {
+		return nil
+	})
+	patches.ApplyFunc(unmarshalTemplateImageJobRequest, func(payload string) (*types.CreateTemplateFromImageReq, error) {
+		return &types.CreateTemplateFromImageReq{
+			Request:           &types.Request{RequestID: "req-1"},
+			TemplateID:        "tpl-1",
+			InstanceType:      cubeboxv1.InstanceType_cubebox.String(),
+			WritableLayerSize: "20Gi",
+			SourceImageRef:    "docker.io/library/nginx:latest",
+		}, nil
+	})
+	patches.ApplyFunc(ListReplicas, func(ctx context.Context, templateID string) ([]models.TemplateReplica, error) {
+		return []models.TemplateReplica{{NodeID: "node-a", Status: ReplicaStatusFailed}}, nil
+	})
+	patches.ApplyFunc(resolveRedoTargets, func(instanceType string, req *types.RedoTemplateFromImageReq, replicas []models.TemplateReplica) ([]*node.Node, error) {
+		return targets, nil
+	})
+	patches.ApplyFunc(getRootfsArtifactByID, func(ctx context.Context, gotArtifactID string) (*models.RootfsArtifact, error) {
+		lookupCalls++
+		switch lookupCalls {
+		case 1:
+			close(initialRead)
+			copy := *staleArtifact
+			return &copy, nil
+		case 2:
+			close(lockedReload)
+			copy := freshArtifact
+			return &copy, nil
+		default:
+			return nil, fmt.Errorf("unexpected artifact lookup %d", lookupCalls)
+		}
+	})
+	patches.ApplyFunc(cleanupArtifactOnNodes, func(ctx context.Context, gotArtifactID, instanceType string, targets []*node.Node) error {
+		return nil
+	})
+	patches.ApplyFunc(distributeRootfsArtifact, func(ctx context.Context, req *types.CreateTemplateFromImageReq, generatedReq *types.CreateCubeSandboxReq, artifact *models.RootfsArtifact, templateID, jobID string) ([]*node.Node, int32, int32, int32, error) {
+		distributedToken = artifact.DownloadToken
+		distributedSHA = artifact.Ext4SHA256
+		if generatedReq != nil && len(generatedReq.Containers) > 0 && generatedReq.Containers[0].Image != nil {
+			generatedToken = generatedReq.Containers[0].Image.Annotations[constants.CubeAnnotationRootfsArtifactToken]
+			generatedSHA = generatedReq.Containers[0].Image.Annotations[constants.CubeAnnotationRootfsArtifactSHA256]
+		}
+		return targets, 1, 1, 0, nil
+	})
+	patches.ApplyFunc(cleanupTemplateReplicasOnNodes, func(ctx context.Context, templateID string, replicas []models.TemplateReplica, targets []*node.Node) error {
+		return nil
+	})
+	patches.ApplyFunc(ensureTemplateDefinitionWithOptions, func(ctx context.Context, templateID string, storedReq *types.CreateCubeSandboxReq, instanceType, version string, opts definitionCreateOptions) (bool, error) {
+		return true, nil
+	})
+	patches.ApplyFunc(createTemplateReplicasOnNodes, func(ctx context.Context, templateID string, req *types.CreateCubeSandboxReq, targets []*node.Node, opts replicaRunOptions) ([]ReplicaStatus, error) {
+		return []ReplicaStatus{{NodeID: "node-a", Status: ReplicaStatusReady}}, nil
+	})
+	patches.ApplyFunc(refreshTemplateReplicaSummary, func(ctx context.Context, templateID, alias string) (string, error) {
+		return "", nil
+	})
+	patches.ApplyFunc(GetTemplateInfo, func(ctx context.Context, templateID string) (*TemplateInfo, error) {
+		return &TemplateInfo{TemplateID: templateID, Status: StatusReady}, nil
+	})
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		runRedoTemplateImageJob(context.Background(), "job-lock-refresh", &types.RedoTemplateFromImageReq{
+			Request:    &types.Request{RequestID: "req-redo"},
+			TemplateID: "tpl-1",
+		}, "http://master.example")
+	}()
+
+	select {
+	case <-initialRead:
+	case <-time.After(5 * time.Second):
+		t.Fatal("redo did not read the stale artifact")
+	}
+	select {
+	case <-lockedReload:
+		t.Fatal("redo reloaded the artifact before acquiring the build lock")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	// Simulate the concurrent rebuild committing token B before releasing the
+	// build lock. Redo must reload this version after it acquires the lock.
+	buildLock.Unlock()
+	lockHeld = false
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("redo did not finish after the build lock was released")
+	}
+	if lookupCalls != 2 {
+		t.Fatalf("artifact lookups = %d, want initial read plus locked reload", lookupCalls)
+	}
+	if distributedToken != freshToken || generatedToken != freshToken {
+		t.Fatalf("distributed token=%q generated token=%q, want refreshed %q", distributedToken, generatedToken, freshToken)
+	}
+	if distributedSHA != freshArtifact.Ext4SHA256 || generatedSHA != freshArtifact.Ext4SHA256 {
+		t.Fatalf("distributed sha=%q generated sha=%q, want refreshed %q", distributedSHA, generatedSHA, freshArtifact.Ext4SHA256)
+	}
+}
+
+func TestRunRedoTemplateImageJobFailsOnArtifactReloadError(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	const artifactID = "artifact-reload-error"
+	reloadErr := errors.New("database connection reset")
+	targets := []*node.Node{{InsID: "node-a", IP: "10.0.0.1", Healthy: true}}
+	lookupCalls := 0
+	var lastUpdate map[string]any
+
+	patches.ApplyFunc(getTemplateImageJobRecordByID, func(ctx context.Context, jobID string) (*models.TemplateImageJob, error) {
+		return &models.TemplateImageJob{
+			JobID:       jobID,
+			TemplateID:  "tpl-1",
+			ResumePhase: JobPhaseDistributing,
+			ArtifactID:  artifactID,
+		}, nil
+	})
+	patches.ApplyFunc(updateTemplateImageJob, func(ctx context.Context, jobID string, values map[string]any) error {
+		lastUpdate = values
+		return nil
+	})
+	patches.ApplyFunc(unmarshalTemplateImageJobRequest, func(payload string) (*types.CreateTemplateFromImageReq, error) {
+		return &types.CreateTemplateFromImageReq{
+			Request:           &types.Request{RequestID: "req-1"},
+			TemplateID:        "tpl-1",
+			InstanceType:      cubeboxv1.InstanceType_cubebox.String(),
+			WritableLayerSize: "20Gi",
+			SourceImageRef:    "docker.io/library/nginx:latest",
+		}, nil
+	})
+	patches.ApplyFunc(ListReplicas, func(ctx context.Context, templateID string) ([]models.TemplateReplica, error) {
+		return []models.TemplateReplica{{NodeID: "node-a", Status: ReplicaStatusFailed}}, nil
+	})
+	patches.ApplyFunc(resolveRedoTargets, func(instanceType string, req *types.RedoTemplateFromImageReq, replicas []models.TemplateReplica) ([]*node.Node, error) {
+		return targets, nil
+	})
+	patches.ApplyFunc(getRootfsArtifactByID, func(ctx context.Context, gotArtifactID string) (*models.RootfsArtifact, error) {
+		lookupCalls++
+		if gotArtifactID != artifactID {
+			return nil, fmt.Errorf("artifact id = %q, want %q", gotArtifactID, artifactID)
+		}
+		if lookupCalls == 1 {
+			return &models.RootfsArtifact{ArtifactID: artifactID}, nil
+		}
+		return nil, reloadErr
+	})
+	patches.ApplyFunc(image.EnsureArtifactBuildPreflight, func(ctx context.Context) error {
+		t.Fatal("artifact reload errors must not trigger a rebuild")
+		return nil
+	})
+
+	runRedoTemplateImageJob(context.Background(), "job-reload-error", &types.RedoTemplateFromImageReq{
+		Request:    &types.Request{RequestID: "req-redo"},
+		TemplateID: "tpl-1",
+	}, "http://master.example")
+
+	if lookupCalls != 2 {
+		t.Fatalf("artifact lookups = %d, want initial read plus locked reload", lookupCalls)
+	}
+	if lastUpdate == nil || lastUpdate["status"] != JobStatusFailed || lastUpdate["phase"] != JobPhaseDistributing {
+		t.Fatalf("unexpected redo failure update: %+v", lastUpdate)
+	}
+	if got, _ := lastUpdate["error_message"].(string); !strings.Contains(got, reloadErr.Error()) || !strings.Contains(got, "after acquiring build lock") {
+		t.Fatalf("unexpected reload failure message: %q", got)
+	}
+}
+
+func TestRunRedoTemplateImageJobEntersRebuildPathWhenArtifactPreparationFails(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	artifactData := []byte("artifact-data")
+	artifactPath, artifactSHA := writeRootfsArtifactTestFile(t, artifactData)
+	targets := []*node.Node{{InsID: "node-a", IP: "10.0.0.1", Healthy: true}}
+	var lastUpdate map[string]any
+	prepareCalled := false
+	patches.ApplyFunc(getTemplateImageJobRecordByID, func(ctx context.Context, jobID string) (*models.TemplateImageJob, error) {
+		return &models.TemplateImageJob{
+			JobID:       jobID,
+			TemplateID:  "tpl-1",
+			ResumePhase: JobPhaseDistributing,
+			ArtifactID:  "artifact-1",
+		}, nil
+	})
+	patches.ApplyFunc(updateTemplateImageJob, func(ctx context.Context, jobID string, values map[string]any) error {
+		lastUpdate = values
+		return nil
+	})
+	patches.ApplyFunc(unmarshalTemplateImageJobRequest, func(payload string) (*types.CreateTemplateFromImageReq, error) {
+		return &types.CreateTemplateFromImageReq{
+			Request:           &types.Request{RequestID: "req-1"},
+			TemplateID:        "tpl-1",
+			InstanceType:      cubeboxv1.InstanceType_cubebox.String(),
+			WritableLayerSize: "20Gi",
+			SourceImageRef:    "docker.io/library/nginx:latest",
+		}, nil
+	})
+	patches.ApplyFunc(ListReplicas, func(ctx context.Context, templateID string) ([]models.TemplateReplica, error) {
+		return []models.TemplateReplica{{NodeID: "node-a", Status: ReplicaStatusFailed}}, nil
+	})
+	patches.ApplyFunc(resolveRedoTargets, func(instanceType string, req *types.RedoTemplateFromImageReq, replicas []models.TemplateReplica) ([]*node.Node, error) {
+		return targets, nil
+	})
+	patches.ApplyFunc(getRootfsArtifactByID, func(ctx context.Context, artifactID string) (*models.RootfsArtifact, error) {
+		return &models.RootfsArtifact{
+			ArtifactID:              artifactID,
+			Ext4Path:                artifactPath,
+			Ext4SHA256:              artifactSHA,
+			Ext4SizeBytes:           int64(len(artifactData)),
+			DownloadToken:           "token-1",
+			MasterNodeIP:            "http://master.example",
+			Status:                  ArtifactStatusFailed,
+			GeneratedRequestJSON:    `{}`,
+			ImageConfigJSON:         `{}`,
+			TemplateSpecFingerprint: "fingerprint-1",
+		}, nil
+	})
+	patches.ApplyFunc(cleanupLocalRootfsArtifact, func(artifactID, ext4Path string) error {
+		return nil
+	})
+	patches.ApplyFunc(updateRootfsArtifact, func(ctx context.Context, artifactID string, values map[string]any) error {
+		return nil
+	})
+	patches.ApplyFunc(image.EnsureArtifactBuildPreflight, func(ctx context.Context) error {
+		return nil
+	})
+	patches.ApplyFunc(image.PrepareLocalSource, func(ctx context.Context, spec image.SourceSpec) (*image.PreparedSource, error) {
+		prepareCalled = true
+		return nil, errors.New("redo rebuild requested for missing artifact")
+	})
+
+	runRedoTemplateImageJob(context.Background(), "job-redo-missing", &types.RedoTemplateFromImageReq{
+		Request:    &types.Request{RequestID: "req-redo"},
+		TemplateID: "tpl-1",
+	}, "http://master.example")
+
+	if !prepareCalled {
+		t.Fatal("expected missing redo artifact to enter the rebuild path")
+	}
+	if lastUpdate == nil || lastUpdate["status"] != JobStatusFailed || lastUpdate["phase"] != JobPhaseBuildingExt4 {
+		t.Fatalf("unexpected redo failure update: %+v", lastUpdate)
+	}
+	if got, _ := lastUpdate["error_message"].(string); !strings.Contains(got, "redo rebuild requested") {
+		t.Fatalf("unexpected redo failure message: %q", got)
+	}
+}
+
+func TestRunRedoTemplateImageJobRebuildsMissingArtifactBeforeRedistribution(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	targets := []*node.Node{{InsID: "node-a", IP: "10.0.0.1", Healthy: true}}
+	rebuiltArtifact := &models.RootfsArtifact{
+		ArtifactID:              "artifact-1",
+		TemplateSpecFingerprint: "fingerprint-1",
+		Ext4Path:                filepath.Join(t.TempDir(), "artifact-1.ext4"),
+		Ext4SHA256:              strings.Repeat("b", 64),
+		Ext4SizeBytes:           2048,
+		DownloadToken:           "rebuilt-token",
+		MasterNodeIP:            "http://master.example",
+		Status:                  ArtifactStatusReady,
+		ImageConfigJSON:         `{}`,
+	}
+	var lastUpdate map[string]any
+	prepareCalled := false
+	rebuildCalled := false
+	redistributeCalled := false
+	patches.ApplyFunc(getTemplateImageJobRecordByID, func(ctx context.Context, jobID string) (*models.TemplateImageJob, error) {
+		return &models.TemplateImageJob{
+			JobID:       jobID,
+			TemplateID:  "tpl-1",
+			ResumePhase: JobPhaseDistributing,
+			ArtifactID:  "artifact-1",
+		}, nil
+	})
+	patches.ApplyFunc(updateTemplateImageJob, func(ctx context.Context, jobID string, values map[string]any) error {
+		lastUpdate = values
+		return nil
+	})
+	patches.ApplyFunc(unmarshalTemplateImageJobRequest, func(payload string) (*types.CreateTemplateFromImageReq, error) {
+		return &types.CreateTemplateFromImageReq{
+			Request:           &types.Request{RequestID: "req-1"},
+			TemplateID:        "tpl-1",
+			InstanceType:      cubeboxv1.InstanceType_cubebox.String(),
+			WritableLayerSize: "20Gi",
+			SourceImageRef:    "docker.io/library/nginx:latest",
+		}, nil
+	})
+	patches.ApplyFunc(ListReplicas, func(ctx context.Context, templateID string) ([]models.TemplateReplica, error) {
+		return []models.TemplateReplica{{NodeID: "node-a", Status: ReplicaStatusFailed}}, nil
+	})
+	patches.ApplyFunc(resolveRedoTargets, func(instanceType string, req *types.RedoTemplateFromImageReq, replicas []models.TemplateReplica) ([]*node.Node, error) {
+		return targets, nil
+	})
+	patches.ApplyFunc(getRootfsArtifactByID, func(ctx context.Context, artifactID string) (*models.RootfsArtifact, error) {
+		return &models.RootfsArtifact{
+			ArtifactID:      artifactID,
+			Ext4Path:        filepath.Join(t.TempDir(), "missing.ext4"),
+			Ext4SHA256:      strings.Repeat("a", 64),
+			Ext4SizeBytes:   1024,
+			DownloadToken:   "stale-token",
+			MasterNodeIP:    "http://master.example",
+			Status:          ArtifactStatusReady,
+			ImageConfigJSON: `{}`,
+		}, nil
+	})
+	patches.ApplyFunc(cleanupLocalRootfsArtifact, func(artifactID, ext4Path string) error {
+		t.Fatal("validation-triggered redo rebuild must not separately clean the artifact")
+		return nil
+	})
+	patches.ApplyFunc(updateRootfsArtifact, func(ctx context.Context, artifactID string, values map[string]any) error {
+		t.Fatal("validation-triggered redo rebuild must let ensureRootfsArtifact claim the row")
+		return nil
+	})
+	patches.ApplyFunc(image.EnsureArtifactBuildPreflight, func(ctx context.Context) error {
+		return nil
+	})
+	patches.ApplyFunc(image.PrepareLocalSource, func(ctx context.Context, spec image.SourceSpec) (*image.PreparedSource, error) {
+		prepareCalled = true
+		return &image.PreparedSource{
+			Digest:       "sha256:rebuilt",
+			ConfigJSON:   `{}`,
+			MasterNodeIP: "http://master.example",
+		}, nil
+	})
+	patches.ApplyFunc(ensureRootfsArtifact, func(ctx context.Context, req *types.CreateTemplateFromImageReq, source *image.PreparedSource, downloadBaseURL string, envdPayload *EnvdInjectionPayload) (*models.RootfsArtifact, *types.CreateCubeSandboxReq, bool, error) {
+		rebuildCalled = true
+		return rebuiltArtifact, nil, true, nil
+	})
+	patches.ApplyFunc(cleanupArtifactOnNodes, func(ctx context.Context, artifactID, instanceType string, targets []*node.Node) error {
+		return nil
+	})
+	patches.ApplyFunc(distributeRootfsArtifact, func(ctx context.Context, req *types.CreateTemplateFromImageReq, generatedReq *types.CreateCubeSandboxReq, artifact *models.RootfsArtifact, templateID, jobID string) ([]*node.Node, int32, int32, int32, error) {
+		redistributeCalled = true
+		return targets, 1, 1, 0, nil
+	})
+	patches.ApplyFunc(cleanupTemplateReplicasOnNodes, func(ctx context.Context, templateID string, replicas []models.TemplateReplica, targets []*node.Node) error {
+		return nil
+	})
+	patches.ApplyFunc(ensureTemplateDefinitionWithOptions, func(ctx context.Context, templateID string, storedReq *types.CreateCubeSandboxReq, instanceType, version string, opts definitionCreateOptions) (bool, error) {
+		return true, nil
+	})
+	patches.ApplyFunc(createTemplateReplicasOnNodes, func(ctx context.Context, templateID string, req *types.CreateCubeSandboxReq, targets []*node.Node, opts replicaRunOptions) ([]ReplicaStatus, error) {
+		return []ReplicaStatus{{NodeID: "node-a", Status: ReplicaStatusReady}}, nil
+	})
+	patches.ApplyFunc(refreshTemplateReplicaSummary, func(ctx context.Context, templateID, alias string) (string, error) {
+		return "", nil
+	})
+	patches.ApplyFunc(GetTemplateInfo, func(ctx context.Context, templateID string) (*TemplateInfo, error) {
+		return &TemplateInfo{TemplateID: templateID, Status: StatusReady}, nil
+	})
+
+	runRedoTemplateImageJob(context.Background(), "job-redo-missing-success", &types.RedoTemplateFromImageReq{
+		Request:    &types.Request{RequestID: "req-redo"},
+		TemplateID: "tpl-1",
+	}, "http://master.example")
+
+	if !prepareCalled || !rebuildCalled || !redistributeCalled {
+		t.Fatalf("expected prepare, rebuild, and redistribution, got prepare=%t rebuild=%t redistribute=%t", prepareCalled, rebuildCalled, redistributeCalled)
+	}
+	if lastUpdate == nil || lastUpdate["status"] != JobStatusReady || lastUpdate["phase"] != JobPhaseReady {
+		t.Fatalf("unexpected final redo update: %+v", lastUpdate)
+	}
+}
+
 func TestRunRedoTemplateImageJobRegeneratesRequestForRedoTemplateID(t *testing.T) {
 	patches := gomonkey.NewPatches()
 	defer patches.Reset()
 
+	artifactData := []byte("artifact-data")
+	artifactPath, artifactSHA := writeRootfsArtifactTestFile(t, artifactData)
 	const redoTemplateID = "tpl-redo"
 	const staleTemplateID = "tpl-stale"
 	targets := []*node.Node{{InsID: "node-a", IP: "10.0.0.1", Healthy: true}}
@@ -1465,8 +2032,9 @@ func TestRunRedoTemplateImageJobRegeneratesRequestForRedoTemplateID(t *testing.T
 		return &models.RootfsArtifact{
 			ArtifactID:              artifactID,
 			TemplateSpecFingerprint: "fingerprint-1",
-			Ext4SHA256:              "sha256",
-			Ext4SizeBytes:           1024,
+			Ext4Path:                artifactPath,
+			Ext4SHA256:              artifactSHA,
+			Ext4SizeBytes:           int64(len(artifactData)),
 			DownloadToken:           "token-1",
 			GeneratedRequestJSON:    string(staleReqPayload),
 			ImageConfigJSON:         string(imageConfigPayload),


### PR DESCRIPTION
## Summary

Fixes #852.

This change prevents CubeMaster from reusing a READY rootfs artifact record when the master-local ext4 file is stale or missing. Before reuse, CubeMaster performs a lightweight `stat` validation: the recorded path must exist, be a regular file, and match the stored size. If validation fails, the existing build path claims the artifact row and rebuilds it instead of distributing stale metadata to Cubelet.

The reuse path intentionally does not re-hash the ext4 file. SHA256 is still calculated when the artifact is built and retained in its metadata, while reuse validation avoids multi-gigabyte disk reads and request latency in persistent-storage deployments.

The same readiness and lightweight file validation applies to redo jobs resuming at the distribution or snapshot phase. After acquiring the per-artifact build lock, redo reloads the authoritative artifact row and uses that refreshed row for status, generated-request, and local-file validation as well as later generation and distribution. This prevents a redo waiting behind a concurrent rebuild from distributing a stale token or SHA. If the row disappears while redo waits for the lock, redo falls back to rebuild; other errors from the locked reload fail redo with their original cause instead of triggering an expensive rebuild.

Redo cleanup also uses the per-artifact build lock and rechecks the row so it cannot delete an artifact that a concurrent create has just rebuilt.

## Why

After a CubeMaster Pod restart with ephemeral local storage, the database can still contain READY artifact metadata while `/data/CubeMaster/storage/.../*.ext4` no longer exists. Reusing that stale metadata causes compute nodes to download invalid content and fail with a SHA256 mismatch. A lightweight local-file check detects the missing-file scenario from #852 without adding full-file hashing overhead to every deployment mode.

## Validation

- Squashed to one commit as requested; current signed head is `6135bf8deec043e20f2cd922172e1d7c9bb853d7`
- GitHub reports the PR mergeable against current `master` (`3c1c399b3bcc5dc1953e44025762eca4ca24c335`)
- Added a lock-ordering regression test that returns token A before the wait, commits token B while redo is blocked, then verifies both generated annotations and distribution use token B/SHA B
- Added a reload-error regression test that verifies transient database errors fail redo with their original cause and never enter artifact build preflight
- `gofmt` on the changed Go files
- `git diff --check`
- Linux/amd64 compilation of the full `./pkg/templatecenter` test package with Go 1.25.7
- Linux/arm64 compilation of the full `./pkg/templatecenter` test package with Go 1.25.7