### PR TITLE
fix(cubemaster): isolate missing sandbox delete test

### DIFF
--- a/CubeMaster/pkg/service/sandbox/sandbox_remove_test.go
+++ b/CubeMaster/pkg/service/sandbox/sandbox_remove_test.go
@@ -4,9 +4,12 @@ import (
 	"context"
 	"testing"
 
+	"github.com/agiledragon/gomonkey/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/api/services/cubebox/v1"
+	basetypes "github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/types"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/errorcode"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/localcache"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/service/sandbox/types"
 )
 
@@ -19,11 +22,22 @@ func TestDestroySandboxMissingSandboxReturnsNotFound(t *testing.T) {
 		hookCalled = true
 		return nil
 	})
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+	patches.ApplyFunc(localcache.GetSandboxCache, func(string) *localcache.SandboxCache {
+		return nil
+	})
+	patches.ApplyFunc(localcache.GetSandboxProxyMap, func(context.Context, string) (*basetypes.SandboxProxyMap, bool) {
+		return nil, false
+	})
 
 	got := DestroySandbox(context.Background(), &types.DeleteCubeSandboxReq{
 		RequestID:    "req-missing-delete",
 		SandboxID:    "sandbox-does-not-exist",
 		InstanceType: cubebox.InstanceType_cubebox.String(),
+		Filter: &types.CubeSandboxFilter{
+			LabelSelector: map[string]string{},
+		},
 	})
 
 	assert.Equal(t, int(errorcode.ErrorCode_NotFound), got.Ret.RetCode)


### PR DESCRIPTION
## Summary

This PR isolates the CubeMaster missing-sandbox delete unit test from
process-local cache state left by other tests.

`TestDestroySandboxMissingSandboxReturnsNotFound` now mocks the sandbox cache
and proxy map lookups so it consistently exercises the missing-sandbox path.

## Changes

- Mock `localcache.GetSandboxCache` in the missing-sandbox delete test.
- Mock `localcache.GetSandboxProxyMap` in the same test.
- Keep the existing not-found assertion and success-hook assertion unchanged.

## Validation

Unit test - CubeMaster missing sandbox delete test:

```bash
CUBE_MASTER_CONFIG_PATH=<test-configs>/cubesandbox-cubemaster-conf.yaml \
GOCACHE=<go-build-cache> \
GOMODCACHE=<go-mod-cache> \
go test ./pkg/service/sandbox \
  -run TestDestroySandboxMissingSandboxReturnsNotFound \
  -count=1 \
  -v
```

```text
=== RUN   TestDestroySandboxMissingSandboxReturnsNotFound
{"Version":"","Callee":"","InstanceType":"","Module":"","CalleeEndpoint":"","FunctionType":"","AppId":0,"CallerIp":"","LogContent":"async DestroySandbox:{\"requestID\":\"req-missing-delete\",\"sandbox_id\":\"sandbox-does-not-exist\",\"filter\":{},\"instance_type\":\"cubebox\"}","Action":"","Caller":"","RetCode":0,"ContainerId":"","CodeLine":"","LogLevel":"WARN","CostTime":0,"RequestId":"","LocalIp":"172.28.162.54","@timestamp":"2026-07-10T09:42:45.573104998+08:00","Namespace":"","CalleeAction":"","InstanceId":""}
{"LocalIp":"172.28.162.54","Module":"","LogLevel":"ERROR","Callee":"","InstanceId":"","FunctionType":"","CodeLine":"","AppId":0,"Version":"","CalleeAction":"","CalleeEndpoint":"","ContainerId":"","Caller":"","CostTime":0,"@timestamp":"2026-07-10T09:42:45.573804794+08:00","Namespace":"","InstanceType":"","Action":"","RequestId":"","RetCode":130404,"LogContent":"async DestroySandbox_rsp fail:{\"requestID\":\"req-missing-delete\",\"ret\":{\"ret_code\":130404,\"ret_msg\":\"no such sandbox\"},\"sandbox_id\":\"sandbox-does-not-exist\"}","CallerIp":""}
--- PASS: TestDestroySandboxMissingSandboxReturnsNotFound (0.00s)
PASS
ok  	github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/service/sandbox	0.011s
```

Diff check:

```bash
git diff --check
```

```text
<no output>
```

## Screenshots

Not applicable. This is a unit test isolation fix.
