### PR TITLE
fix(actions): guard claude-response on explicit /cubebot trigger

### DIFF
--- a/.github/workflows/claude-response.yml
+++ b/.github/workflows/claude-response.yml
@@ -11,6 +11,24 @@ on:
 
 jobs:
   claude-response:
+    if: |
+      (
+        github.event_name == 'issue_comment' &&
+        contains(github.event.comment.body || '', '/cubebot') &&
+        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
+      ) || (
+        github.event_name == 'pull_request_review_comment' &&
+        contains(github.event.comment.body || '', '/cubebot') &&
+        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
+      ) || (
+        github.event_name == 'pull_request_review' &&
+        contains(github.event.review.body || '', '/cubebot') &&
+        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.review.author_association)
+      ) || (
+        github.event_name == 'issues' &&
+        contains(github.event.issue.body || '', '/cubebot') &&
+        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.issue.author_association)
+      )
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Motivation

The `AI Assistant / claude-response` workflow currently starts on ordinary PR comments and reviews even when CubeBot was not explicitly requested.

In those cases, `anthropics/claude-code-action` reports that no trigger phrase was found and can still fail during actor permission checks, creating false red checks on PRs.

## What Changed

* Add a job-level guard so `claude-response` only runs when the event body contains `/cubebot`.
* Limit the guarded execution path to trusted GitHub `author_association` values.
* Keep the guard aligned with the action's existing `/cubebot` `trigger_phrase`, so the workflow does not start for comments the action would later reject as non-triggers.
* Preserve the existing `/cubebot` trigger contract instead of broadening trigger handling.

## Scope

This PR only updates `.github/workflows/claude-response.yml`.

It does not change the existing `/cubebot` trigger phrase, and it does not add broader aliases such as `@cubebot`.

## Related

Fixes #844.
