### PR TITLE
docs(blog): add Cube Sandbox Arm support announcement blog posts

### DIFF
--- a/docs/blog/posts/2026-07-08-cubesandbox-arm-support.md
+++ b/docs/blog/posts/2026-07-08-cubesandbox-arm-support.md
@@ -1,0 +1,155 @@
+---
+title: "Cube Sandbox Officially Supports Arm: Tencent Cloud and Arm Team Up to Unlock Multi-Architecture Compute for Agents"
+date: 2026-07-08
+author: InfoQ
+description: "On July 3, Tencent Cloud open-sourced the AI Agent secure sandbox Cube Sandbox v0.5.0. Native Arm support — one of the headline features — has been merged upstream with substantial investment from the Arm engineering team. Developers can now build, deploy, launch, and run typical sandbox workloads end-to-end on AArch64 servers."
+featured: false
+---
+
+# Cube Sandbox Officially Supports Arm: Tencent Cloud and Arm Team Up to Unlock Multi-Architecture Compute for Agents
+
+
+On July 3, Tencent Cloud released **Cube Sandbox v0.5.0**, the open-source AI Agent secure sandbox. Built as a hardware-isolated runtime foundation purpose-designed for LLM applications, v0.5.0 lands a set of production-critical upgrades under the banner of "stable, efficient, broad." Among them, **native Arm support** — one of the headline features — has been merged upstream with substantial investment from the Arm engineering team. (See the v0.5.0 deep dive: [Cube v0.5.0 Released: Auto-Pause, ARM Support, One-Click Cluster Deploy — Taking Sandboxes to Production](https://mp.weixin.qq.com/s?__biz=MzYzNDkyMDU3MQ==&mid=2247483839&idx=1&sn=bd0f059a3e3be0654f1c1ca89e4e8107&scene=21#wechat_redirect))
+
+Developers can now carry out the full pipeline on **AArch64** servers — native build, deploy, launch, and run typical sandbox workloads.
+
+To clear the critical path from low-level build through runtime, Tencent Cloud's IaaS frontier tech team and the Arm engineering team ran a months-long joint R&D effort, focused squarely on **AArch64 builds, the Guest Kernel, the runtime environment, and the deployment chain**.
+
+As compute supply accelerates into an "x86 + Arm" multi-architecture era, the industry urgently needs an Agent runtime foundation that breaks past traditional architecture boundaries. v0.5.0 extends Cube's core isolation capabilities into the Arm ecosystem — not only as a step up in production-grade delivery, but as a reliable, flexible execution substrate for Agents operating across the cloud, edge, and endpoint in heterogeneous scenarios.
+
+## 1. When the Compute Platform Goes Heterogeneous
+
+If "putting AI Agents into production at scale" is a stress test of the underlying infrastructure, two variables are visibly shifting at once:
+
+**First, the workload side.** Today's Agents are no longer one-shot scripts — they evolve into dozens or hundreds of serial or parallel tool calls. Each call implies a sandbox start, a period of isolated execution, and a result collection.
+
+This workload pattern places extreme demands on the underlying infrastructure: it must deliver both **very high compute density** and **extremely fast elastic response**.
+
+**Second, the infrastructure side.** AI-era compute supply is rapidly moving from a single architecture to an "x86 + Arm" dual-track. Driven by the energy efficiency and performance advantages of the Arm Neoverse platform in cloud AI workloads, Arm architecture is seeing broad industry adoption. With Arm compute platforms like Amazon Graviton, Google Cloud Axion, and Microsoft Azure Cobalt continuing to scale, alongside a wave of domestic Arm processors being rapidly deployed, the Arm ecosystem is accelerating. **"AI runs on Arm"** has shifted from a curiosity to a **real line item in the budget**.
+
+Stack these two variables together and the conclusion is clear: Agent sandboxes can't be locked to x86. They have to ship deployment capabilities across multi-architecture server environments. Going further, it isn't enough to simply "run" on Arm — they need to deliver **performance on par with — or better than — x86** on that platform.
+
+That is the starting point for the joint R&D between the Cube team and the Arm engineering team.
+
+## 2. From "Runs" to "Native"
+
+From the moment the Arm engineering team first engaged, to the code being formally merged upstream, this joint R&D effort spanned several months. What truly moved the project from "runs" to "usable" was the intense polish of the final stretch — the mainline merge alone went through more than twenty commits.
+
+The core of this delivery is: Cube Sandbox now has the **end-to-end capability to deploy natively, compile, launch, and run typical sandbox workloads on AArch64**, and the project has formally entered the Enablement stage. Specifically, this update goes deep on four key layers:
+
+**First, native compilation and build.**
+
+The team cleared out the x86/amd64 default assumptions scattered across build scripts, Dockerfiles, and components, so the system correctly builds and emits output for the target architecture. To lower the bar for developers, the team also reworked the build chain: the Guest kernel build is now configured as a standalone target that supports cross-architecture cross-compilation. In other words, developers can produce an Arm kernel image from an x86 machine — no need to have Arm hardware on hand to get started.
+
+**Second, native ecosystem deployment.**
+
+To fit diverse compute environments, the team connected the full chain from deployment-package generation all the way to sandbox bring-up. By reworking the build toolchain, developers now need only a single `docker buildx` command to produce multi-architecture images that target both x86 and Arm — letting Cube Sandbox slot into existing CI/CD pipelines seamlessly.
+
+**Third, smooth startup.**
+
+To address the underlying architectural differences between Arm and x86, the team refactored the boot path and I/O logic. By introducing **UEFI firmware** to replace the legacy SeaBIOS, and through deep adaptation of the Hypervisor layer, the team made sure that sandboxes boot as quickly and as stably on Arm servers as they do on x86.
+
+**Fourth, efficient runtime at a native level.**
+
+The two teams stepped out of the traditional CPU-benchmark mindset and instead focused on the metrics that Agent production environments actually care about: **cold start, snapshot creation and rollback, high-concurrency creation, and per-host deployment density** — making sure Cube Sandbox doesn't just "run" on Arm, but runs *fast* and runs *steady*.
+
+If "runs" is the floor, "usable" is the ticket handed to developers. Crossing this line means developers can now weave Cube Sandbox into real production workflows.
+
+## 3. How Cross-Architecture Was Made Real
+
+This path was so challenging because what Cube Sandbox had to port wasn't a normal application — it was an entire sandbox runtime system designed for AI Agents. It spans the external build and image artifacts, but also the Guest Kernel and Guest Agent inside the sandbox, and underneath that the virtualization and security-isolation layers.
+
+To deliver the best possible results on "Agent-native metrics," the two teams focused on the following key technical problems:
+
+**First, eliminate x86 dependencies and hardcoded assumptions.**
+
+A lot of infrastructure projects, over years of evolution, end up treating x86 as the default environment. The first step in Cube Sandbox's port was to dismantle the hardcoded `x86_64` / `amd64` settings in build scripts, Dockerfiles, and components. That includes making Go components auto-track the host architecture as their build target, and filling in the **AArch64**-specific compile headers for the bytecode generation logic in the network module — so the project truly has cross-architecture build and multi-architecture output capability.
+
+**Second, bridge the hypervisor's underlying-architecture gap.**
+
+This was the most complex piece of the adaptation — touching the I/O system, the boot path, and the security mechanism, all in one go:
+
+- **I/O system architectural transition:** The Guest-to-Host control-notification channel was rewritten from legacy PIO (Programmed I/O) to **MMIO (Memory-Mapped I/O)**, to match Arm architecture characteristics.
+- **Boot path reconstruction:** x86 machines boot through lightweight SeaBIOS; for Arm, the team reworked the boot logic so UEFI firmware can be used normally.
+- **Seccomp sandbox alignment:** Filter rules were rewritten to account for the syscall-number differences between x86 and **AArch64**, so the security-isolation mechanism stays effective across multi-architecture environments.
+
+**Finally, re-validate the virtualization and security chain.**
+
+Cube Sandbox's core value is hardware-level isolation for Agents, and that leans on KVM, the hypervisor, and other low-level capabilities. Just compiling cleanly isn't enough — this round of changes spans the virtualization layer, the network module, and the build toolchain, across multiple subsystems.
+
+During the multiple rounds of cross-review between the two teams, a subtle bug was caught and fixed that would have broken the base-library path. This kind of repeated calibration on low-level details is what guarantees stable operation in multi-architecture environments.
+
+This is also why the Arm engineering team went deep on the engagement. They didn't stop at the code merge — they focused on establishing a **bootable, communicative, verifiable compatibility chain on AArch64**, so that Cube delivers the same determinism and stability on heterogeneous platforms as it does on native ones.
+
+## 4. Running Your First Arm Sandbox on Cube
+
+**Environment requirements:**
+
+- **Hardware:** AArch64 Linux server (a physical machine with virtualization extensions enabled)
+- **OS:** OpenCloudOS 9 (kernel 6.6) recommended
+- **Must run as root + Docker daemon running**
+
+> ⚠️ **Note:** PVM nested virtualization is not yet supported on Arm. Please use a physical machine / bare-metal with native KVM (cloud VMs must have Arm nested virt enabled).
+
+### Step 1: Download and install
+
+```bash
+# 1. Download the ARM64 one-click bundle
+wget https://github.com/TencentCloud/CubeSandbox/releases/download/v0.5.0/cube-sandbox-one-click-v0.5.0-arm64.tar.gz
+# Users in China can use the mirror:
+wget https://cnb.cool/CubeSandbox/CubeSandbox/-/releases/download/v0.5.0/cube-sandbox-one-click-v0.5.0-arm64.tar.gz
+
+# 2. Extract and enter the directory
+tar -xzf cube-sandbox-one-click-v0.5.0-arm64.tar.gz
+cd cube-sandbox-one-click-v0.5.0-arm64
+
+# 3. Generate the config file (defaults work for most scenarios)
+cp env.example .env
+#    If eth0 is not your primary NIC, edit .env to set the IP explicitly:
+#      CUBE_SANDBOX_NODE_IP=<your-node-ip>
+#    If the default CIDR 192.168.0.0/18 conflicts with your host network, change it too:
+#      CUBE_SANDBOX_NETWORK_CIDR=<your-available-cidr>
+
+# 4. One-click install
+sudo ./install.sh
+```
+
+### Step 2: Deployment verification & environment variables
+
+```bash
+# Health check
+sudo ./smoke.sh
+
+# Set 4 environment variables on the client (for local testing you can run everything on the same box)
+export CUBE_TEMPLATE_ID=<your-template-id>
+export E2B_API_URL=http://<target-machine-ip>:3000
+export E2B_API_KEY=e2b_000000                 # any local string is fine
+export SSL_CERT_FILE=/root/.local/share/mkcert/rootCA.pem
+```
+
+### Step 3: Spin up your first sandbox
+
+```python
+# Use the e2b-code-interpreter SDK to spin up your first ARM sandbox
+import os
+
+from e2b_code_interpreter import Sandbox
+
+with Sandbox.create(template=os.environ["CUBE_TEMPLATE_ID"]) as sbx:
+    print(sbx.run_code("import platform; print(platform.machine())"))
+    # Expected output: aarch64
+```
+
+For the full set of configuration options, the deployment flow, and detailed instructions, see the official docs → [https://cubesandbox.com/guide/self-build-deploy.html](https://cubesandbox.com/guide/self-build-deploy.html)
+
+## 5. Closing
+
+Back to the engineering itself, the key thing about Cube Sandbox v0.5.0 isn't just "supports Arm" — it's that it has systematically crossed the threshold barriers that an Agent sandbox must clear in an **AArch64** environment, so that Arm is no longer merely a compatibility target for Cube Sandbox, and is starting to become a real, buildable, bootable, verifiable runtime option for Agent secure execution.
+
+For teams building AI Agent workflows, Agentic RL training platforms, or code-execution services on Arm servers, the current version already provides a viable starting point. As cold start, snapshot rollback, concurrent creation, and deployment density continue to improve, Cube Sandbox's production value in heterogeneous compute scenarios will only grow.
+
+The project is open source on GitHub — feel free to read the code, file an Issue, or contribute via PR.
+
+- **GitHub repo:** [https://github.com/TencentCloud/CubeSandbox](https://github.com/TencentCloud/CubeSandbox)
+
+If you like what you see, a Star 🌟 would mean a lot.

--- a/docs/zh/blog/posts/2026-07-08-cubesandbox-arm-support.md
+++ b/docs/zh/blog/posts/2026-07-08-cubesandbox-arm-support.md
@@ -1,0 +1,156 @@
+---
+title: "Cube Sandbox正式支持Arm架构！腾讯云与Arm联手解锁Agent多架构算力"
+date: 2026-07-08
+author: InfoQ
+description: "7月3日，由腾讯云开源的 AI Agent 安全沙箱 Cube Sandbox v0.5.0 正式发布。Arm 架构原生支持作为核心特性之一，已在 Arm 工程团队的重点投入下合入开源主线。开发者现在可以在 AArch64 服务器上，实现从原生构建、部署、启动到运行典型沙箱负载的完整流程。"
+featured: false
+---
+
+# Cube Sandbox正式支持Arm架构！腾讯云与Arm联手解锁Agent多架构算力
+
+<!-- 图片 -->
+
+7月3日，由腾讯云开源的 AI Agent 安全沙箱 **Cube Sandbox v0.5.0** 正式发布。作为专为 LLM 应用设计的硬件级隔离运行底座，v0.5.0 此次面向生产环境进行了关键升级，围绕"稳、省、广"补齐了多项能力；其中，**Arm 架构原生支持**作为核心特性之一，已在 Arm 工程团队的重点投入下合入开源主线。（[V0.5.0 详情可见：Cube v0.5.0发布：自动暂停 · Arm支持· 一键集群部署，把沙箱送进生产](https://mp.weixin.qq.com/s?__biz=MzYzNDkyMDU3MQ==&mid=2247483839&idx=1&sn=bd0f059a3e3be0654f1c1ca89e4e8107&scene=21#wechat_redirect)）
+
+开发者现在可以在 **AArch64** 服务器上，实现从原生构建、部署、启动到运行典型沙箱负载的完整流程。
+
+为打通从底层构建到运行时的关键路径，腾讯云 IaaS 前沿技术团队与 Arm 工程团队开展了为期数月的深度联合研发，重点攻克 **AArch64 构建、Guest Kernel、运行环境及部署链路**等关键目标。
+
+随着算力供给加速迈向"x86 + Arm"多架构并存，行业亟需 Agent 运行底座突破传统架构边界。v0.5.0 将沙箱的核心隔离能力扩展至 Arm 生态，不仅是生产级交付能力的提升，更为横跨云、边、端多元异构场景下的 Agent 提供了可靠、灵活的运行支撑。
+
+## 一、当算力平台走向异构
+
+如果将"AI Agent 大规模上生产"视为对底层基建能力的一次大考，你会发现有两个变量正以肉眼可见的速度发生演变：
+
+**首先是负载侧。** 当前的 Agent 已不再是简单的一次性脚本，而是演变为数十、数百次串行或并发的工具调用。每一次调用都意味着一次沙箱的启停、一段隔离的运行以及一次结果的回收。
+
+这种负载模式对底层基础设施提出了极致需求：既要有**极高的算力密度**，又要有**极快的弹性响应**。
+
+**其次是基础设施侧。** AI 时代的算力供给正快速从单一架构走向"x86 + Arm"双轨并行。凭借 Arm Neoverse 平台在云端 AI 工作负载方面的能效和性能优势，Arm 架构正在获得行业的广泛采用。随着 Amazon Graviton、Google Cloud Axion、Microsoft Azure Cobalt 等 Arm 计算平台持续扩展，以及诸多国产 Arm 处理器快速落地部署，Arm 生态正加速发展。**"AI 跑在 Arm 上"**已从尝鲜话题转变为**真实的预算投入**。
+
+把这两个变量叠加在一起看，结论是清晰的：Agent 沙箱不能局限于 x86，它必须在多架构服务器环境中补齐部署能力。更进一步，它不应止步于在 Arm 上"跑通"，更要在这一平台上跑出**与 x86 同等量级甚至更优**的性能表现。
+
+这正是 Cube 团队与 Arm 工程团队联合研发的起点。
+
+## 二、从"能跑"到"原生"
+
+从 Arm 工程团队最初介入，到代码正式合入主仓库，这场联合研发历时数月。真正推动项目从"能跑"迈向"能用"的，是最后阶段的高强度打磨——仅本轮合入主线的改动，便历经二十余次提交。
+
+这一版的交付核心在于：Cube Sandbox 已具备在 **AArch64** 平台上**原生部署、编译、启动和运行典型沙箱工作负载**的全链路能力，项目正式进入落地阶段。具体而言，此次更新深入到了四个关键层面：
+
+**一是原生编译与构建。**
+
+团队清理了散落在构建脚本、Dockerfile 及组件中的 x86/amd64 默认假设，让系统能根据目标架构正确构建与输出。为降低开发门槛，团队还特别优化了构建链路，将 Guest 内核构建配置为支持跨架构交叉编译的独立目标。也就是说，开发者在 x86 机器上就能产出 Arm 内核镜像，无需依赖 Arm 架构设备也能轻松上手。
+
+**二是原生生态的部署。**
+
+为了适配多元算力环境，团队打通了从部署包生成到沙箱拉起的完整链路。通过优化构建工具链，开发者现在仅需一条 `docker buildx` 命令，即可同时产出兼容 x86 与 Arm 的多架构镜像，让 Cube Sandbox 能够无缝融入现有的 CI/CD 流程。
+
+**三是平滑启动。**
+
+针对 Arm 与 x86 在底层架构上的差异，团队重构了引导路径与 I/O 逻辑。通过引入 **UEFI 固件**替代传统的 SeaBIOS，以及对 Hypervisor 层进行深度适配，确保了沙箱在 Arm 服务器上能够像在 x86 上一样快速、稳定地启动。
+
+**四是原生程度的高效运行。**
+
+双方团队跳出了传统 CPU benchmark 的视角，转而聚焦 Agent 生产环境真正关心的指标：包括优化**冷启动、Snapshot 创建与回滚、高并发创建以及单机部署密度**等关键能力，确保 Cube Sandbox 在 Arm 架构下不仅能"跑起来"，更能"跑得快"、"跑得稳"。
+
+如果说"能跑"是门槛，那么"能用"才是交付给开发者的入场券。这一步的跨越，意味着开发者已能将 Cube Sandbox 真正融入生产工作流。
+
+## 三、如何实现跨架构
+
+这条链路之所以极具挑战，在于 Cube Sandbox 要迁移的并非一个普通应用，而是一套面向 AI Agent 的沙箱运行体系。它既涉及外部构建和镜像产物，也涉及沙箱内部的 Guest Kernel、Guest Agent，以及更底层的虚拟化和安全隔离能力。
+
+为了在"Agent 原生指标"上拿到极致的结果，双方团队重点解决了以下关键的技术难题：
+
+**首先，消除对 x86 架构的依赖与硬编码假设。**
+
+很多基建项目在长期演进中，都会把 x86 当成默认环境。Cube Sandbox 迁移的第一步，就是拆解构建脚本、Dockerfile 及组件中硬编码的 `x86_64` / `amd64` 设定。这不仅包括让 Go 组件的编译目标自动跟随宿主架构，还包括为网络模块的字节码生成逻辑补齐 **AArch64** 专属编译头文件，让项目真正具备跨架构构建与多架构输出的能力。
+
+**其次，跨越 Hypervisor 的底层架构鸿沟。**
+
+这是本次适配中最复杂的部分，涉及 I/O 系统、引导路径和安全机制的全面重构：
+
+- **I/O 系统的架构跨越：** 将 Guest 对 Host 的控制通知通道从原来的 PIO（Programmed I/O）改写为了 MMIO（Memory Mapped I/O），以适配 Arm 架构特性；
+- **引导路径重构：** x86 机器依靠轻量化 SeaBIOS 启动，而针对 Arm 架构，团队改造了启动逻辑，现在可以正常使用 UEFI 固件开机；
+- **Seccomp 沙盒对齐：** 针对 x86 与 **AArch64** 的系统调用号差异，重写了过滤规则，确保安全隔离机制在多架构环境下依然有效。
+
+**最后，重新验证虚拟化与安全链路。**
+
+Cube Sandbox 的核心价值是为 Agent 提供硬件级隔离，这背后依赖 KVM、Hypervisor 等底层能力。单纯的编译通过并不够，本轮改动横跨虚拟化层、网络模块与构建工具链等多个子系统。
+
+在双方团队的多轮交叉审查过程中，还发现并修正了一处导致基础库路径失效的隐蔽 Bug。这种对底层细节的反复校准，为系统在多架构环境下的稳定运行提供了保障。
+
+这也是 Arm 工程团队深度介入的原因。它并未止步于代码合入，而是聚焦在 **AArch64** 环境中建立一条可启动、可通信、可验证的兼容性链路，确保 Cube 在异构平台上也能获得与原生环境一致的确定性与稳定性。
+
+## 四、如何在 Cube 上运行你的第一台 Arm 沙箱
+
+**环境要求：**
+
+- **环境：** AArch64 架构的 Linux 服务器（支持虚拟化特性的物理机）
+- **操作系统：** 推荐 OpenCloudOS 9（内核 6.6）
+- **需在 root 用户下运行 + Docker 已运行**
+
+> ⚠️ **注意：** Arm 上暂不支持 PVM 嵌套虚拟化，请使用原生 KVM 的物理机 / 裸金属（云 VM 需已开启 Arm Nested Virt）。
+
+### Step 1：下载并安装
+
+```bash
+# 1. 下载 ARM64 one-click 包
+wget https://github.com/TencentCloud/CubeSandbox/releases/download/v0.5.0/cube-sandbox-one-click-v0.5.0-arm64.tar.gz
+# 国内用户可使用如下地址：
+wget https://cnb.cool/CubeSandbox/CubeSandbox/-/releases/download/v0.5.0/cube-sandbox-one-click-v0.5.0-arm64.tar.gz
+
+# 2. 解压并安装
+tar -xzf cube-sandbox-one-click-v0.5.0-arm64.tar.gz
+cd cube-sandbox-one-click-v0.5.0-arm64
+
+# 3. 生成配置文件（大多数场景用默认值即可）
+cp env.example .env
+#    如果 eth0 不是主网卡，编辑 .env 显式指定 IP：
+#      CUBE_SANDBOX_NODE_IP=<你的节点IP>
+#    如果默认 CIDR 192.168.0.0/18 与本机网络冲突，同步改：
+#      CUBE_SANDBOX_NETWORK_CIDR=<你的可用CIDR>
+
+# 4. 一键安装
+sudo ./install.sh
+```
+
+### Step 2：部署验证 & 环境变量设置
+
+```bash
+# 健康检查
+sudo ./smoke.sh
+
+# 在客户端设置 4 个环境变量（本机测试可全跑在同一台上）
+export CUBE_TEMPLATE_ID=<你的模板ID>
+export E2B_API_URL=http://<目标机IP>:3000
+export E2B_API_KEY=e2b_000000                 # 本地任意字符串即可
+export SSL_CERT_FILE=/root/.local/share/mkcert/rootCA.pem
+```
+
+### Step 3：拉起第一个沙箱
+
+```python
+# 用 e2b-code-interpreter SDK 拉起第一个 ARM 沙箱
+import os
+
+from e2b_code_interpreter import Sandbox
+
+with Sandbox.create(template=os.environ["CUBE_TEMPLATE_ID"]) as sbx:
+    print(sbx.run_code("import platform; print(platform.machine())"))
+    # 预期输出：aarch64
+```
+
+更完整的配置项、部署流程和详细说明，参考官方文档 → [https://cubesandbox.com/zh/guide/self-build-deploy.html](https://cubesandbox.com/zh/guide/self-build-deploy.html)
+
+## 五、结语
+
+回到工程本身，Cube Sandbox v0.5.0 的关键并不只是"支持 Arm"，而是把 Agent 沙箱在 **AArch64** 环境中必须跨过的几道门槛逐一补齐，让 Arm 架构不再只是 Cube Sandbox 的一个兼容目标，而开始成为 Agent 安全执行环境中可构建、可启动、可验证的真实运行选项。
+
+对于正在 Arm 服务器上构建 AI Agent 工作流、Agentic RL 训练平台或代码执行服务的团队来说，当前版本已经提供了一个可用起点。后续，随着冷启动、快照回滚、并发创建和部署密度等指标继续优化，Cube Sandbox 在异构算力场景中的生产价值也会进一步释放。
+
+项目代码已在 GitHub 开源，欢迎查看代码、提交 Issue 或通过 PR 参与共建。
+
+- **GitHub 仓库：** [https://github.com/TencentCloud/CubeSandbox](https://github.com/TencentCloud/CubeSandbox)
+
+如果觉得 Cube 还不错，欢迎点个 Star 🌟 关注一下哦～


### PR DESCRIPTION
## Summary

Add English and Chinese blog posts announcing Cube Sandbox v0.5.0 native Arm architecture support.

## Changes

- `docs/blog/posts/2026-07-08-cubesandbox-arm-support.md` — English version
- `docs/zh/blog/posts/2026-07-08-cubesandbox-arm-support.md` — Chinese version

## Context

These blog posts cover the joint effort between Tencent Cloud and Arm engineering teams to bring native AArch64 support to Cube Sandbox v0.5.0.