### PR TITLE
fix(image): strengthen image reference validation and prevent argument injection

### DIFF
--- a/CubeMaster/pkg/templatecenter/image/command.go
+++ b/CubeMaster/pkg/templatecenter/image/command.go
@@ -65,7 +65,7 @@ func (b *boundedBuffer) String() string {
 
 func dockerLogin(ctx context.Context, configDir, imageRef, username, password string) error {
 	registry := registryHostFromImageRef(imageRef)
-	cmd := exec.CommandContext(ctx, "docker", "--config", configDir, "login", registry, "-u", username, "--password-stdin")
+	cmd := exec.CommandContext(ctx, "docker", "--config", configDir, "login", "-u", username, "--password-stdin", "--", registry)
 	cmd.Stdin = strings.NewReader(password)
 	output, err := cmd.CombinedOutput()
 	if err != nil {

--- a/CubeMaster/pkg/templatecenter/image/disk.go
+++ b/CubeMaster/pkg/templatecenter/image/disk.go
@@ -104,7 +104,7 @@ func createExt4ImageStreaming(ctx context.Context, source *PreparedSource, workD
 		}
 		containerID := strings.TrimSpace(string(containerIDBytes))
 		defer func() {
-			_ = dockerRun(cleanupCtx, "", "rm", "-f", containerID)
+			_ = dockerRun(cleanupCtx, "", "rm", "-f", "--", containerID)
 		}()
 
 		if err := pipeExportToDir(ctx, containerID, mountPoint); err != nil {
@@ -141,7 +141,7 @@ func createExt4ImageStreaming(ctx context.Context, source *PreparedSource, workD
 // pipeExportToDir streams the docker export of a container directly into a target
 // directory via tar -xf -.
 func pipeExportToDir(ctx context.Context, containerID, destDir string) error {
-	exportCmd := exec.CommandContext(ctx, "docker", "export", containerID)
+	exportCmd := exec.CommandContext(ctx, "docker", "export", "--", containerID)
 	// --same-owner --numeric-owner preserves the image's original uid/gid.
 	// GNU tar restores ownership only with --same-owner (the default for root,
 	// set explicitly to be robust); --numeric-owner avoids name lookups

--- a/CubeMaster/pkg/templatecenter/image/export.go
+++ b/CubeMaster/pkg/templatecenter/image/export.go
@@ -18,7 +18,7 @@ func exportImageRootfs(ctx context.Context, source *PreparedSource, destRootfsDi
 		return errors.New("resolved source image is nil")
 	}
 	if source.ExportMode != ExportModeNative {
-		if err := validateImageRef(source.LocalRef); err != nil {
+		if err := ValidateImageRef(source.LocalRef); err != nil {
 			return err
 		}
 	}
@@ -135,7 +135,7 @@ func dockerExportImageRootfs(ctx context.Context, source *PreparedSource, destRo
 	// Use context.Background() so that cleanup runs even after request ctx is cancelled.
 	cleanupCtx := context.Background()
 	defer func() {
-		_ = dockerRun(cleanupCtx, "", "rm", "-f", containerID)
+		_ = dockerRun(cleanupCtx, "", "rm", "-f", "--", containerID)
 	}()
 
 	if err := os.RemoveAll(destRootfsDir); err != nil { // NOCC:Path Traversal()

--- a/CubeMaster/pkg/templatecenter/image/image_test.go
+++ b/CubeMaster/pkg/templatecenter/image/image_test.go
@@ -606,13 +606,14 @@ func TestValidateImageRef(t *testing.T) {
 	valid := []string{
 		"docker://registry.example.com/image:latest",
 		"registry.example.com:5000/ns/app:1.2.3",
+		"nginx",
 		"library/nginx",
 		"library/nginx@sha256:" + strings.Repeat("a", 64),
 		"reg.io/my_app.name/sub-component:tag_1.0",
 	}
 	for _, ref := range valid {
-		if err := validateImageRef(ref); err != nil {
-			t.Errorf("validateImageRef(%q) returned error, want nil: %v", ref, err)
+		if err := ValidateImageRef(ref); err != nil {
+			t.Errorf("ValidateImageRef(%q) returned error, want nil: %v", ref, err)
 		}
 	}
 
@@ -627,11 +628,81 @@ func TestValidateImageRef(t *testing.T) {
 		"image;rm -rf /",
 		"image$(whoami)",
 		"image`whoami`",
+		"library/nginx:",
+		"library/nginx@sha256:not-a-digest",
+		"docker://docker://library/nginx",
 	}
 	for _, ref := range invalid {
-		if err := validateImageRef(ref); err == nil {
-			t.Errorf("validateImageRef(%q) returned nil, want error", ref)
+		if err := ValidateImageRef(ref); err == nil {
+			t.Errorf("ValidateImageRef(%q) returned nil, want error", ref)
 		}
+	}
+}
+
+func TestPrepareDockerSourceRejectsInvalidImageRefBeforeEngineAccess(t *testing.T) {
+	original := newEngineClient
+	engineCalled := false
+	newEngineClient = func() (engineClient, error) {
+		engineCalled = true
+		return nil, errors.New("must not be called")
+	}
+	t.Cleanup(func() {
+		newEngineClient = original
+	})
+
+	_, err := prepareDockerSource(context.Background(), SourceSpec{ImageRef: "docker://--help"})
+	if err == nil || !strings.Contains(err.Error(), "invalid image reference") {
+		t.Fatalf("prepareDockerSource error=%v, want validation failure", err)
+	}
+	if engineCalled {
+		t.Fatal("engine client was accessed before image reference validation")
+	}
+}
+
+func TestDockerLoginTerminatesOptionsBeforeRegistry(t *testing.T) {
+	tmpDir := t.TempDir()
+	argsFile := filepath.Join(tmpDir, "args")
+	stdinFile := filepath.Join(tmpDir, "stdin")
+	t.Setenv("DOCKER_ARGS_FILE", argsFile)
+	t.Setenv("DOCKER_STDIN_FILE", stdinFile)
+	t.Setenv("PATH", tmpDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	installFakeCommand(t, tmpDir, "docker", `printf '%s\n' "$@" > "$DOCKER_ARGS_FILE"
+cat > "$DOCKER_STDIN_FILE"`)
+
+	err := dockerLogin(
+		context.Background(),
+		"/tmp/cubemaster-docker-config",
+		"registry.example.com/ns/app:latest",
+		"-v",
+		"s3cret",
+	)
+	if err != nil {
+		t.Fatalf("dockerLogin failed: %v", err)
+	}
+	args, err := os.ReadFile(argsFile)
+	if err != nil {
+		t.Fatalf("read docker args: %v", err)
+	}
+	wantArgs := strings.Join([]string{
+		"--config",
+		"/tmp/cubemaster-docker-config",
+		"login",
+		"-u",
+		"-v",
+		"--password-stdin",
+		"--",
+		"registry.example.com",
+		"",
+	}, "\n")
+	if string(args) != wantArgs {
+		t.Fatalf("docker args=%q, want %q", string(args), wantArgs)
+	}
+	stdin, err := os.ReadFile(stdinFile)
+	if err != nil {
+		t.Fatalf("read docker stdin: %v", err)
+	}
+	if string(stdin) != "s3cret" {
+		t.Fatalf("docker stdin=%q, want password only", string(stdin))
 	}
 }
 
@@ -1106,7 +1177,7 @@ func TestPrepareLocalSourceRejectsInvalidImageRef(t *testing.T) {
 			t.Errorf("PrepareLocalSource(%q) returned nil error, want validation failure", ref)
 			continue
 		}
-		// validateImageRef returns "empty image reference" for blank refs
+		// ValidateImageRef returns "empty image reference" for blank refs
 		// and "invalid image reference" for refs with forbidden characters.
 		if !strings.Contains(err.Error(), "invalid image reference") && !strings.Contains(err.Error(), "empty image reference") {
 			t.Errorf("PrepareLocalSource(%q) error=%v, want validation failure", ref, err)

--- a/CubeMaster/pkg/templatecenter/image/ref.go
+++ b/CubeMaster/pkg/templatecenter/image/ref.go
@@ -5,8 +5,40 @@
 package image
 
 import (
+	"errors"
+	"fmt"
+	"regexp"
 	"strings"
+
+	"github.com/google/go-containerregistry/pkg/name"
 )
+
+// imageRefAllowedPattern is the strict character whitelist for image
+// references. It permits exactly the characters that appear in legitimate
+// registry/repository[:tag][@algo:hexdigest] references.
+var imageRefAllowedPattern = regexp.MustCompile(`^[A-Za-z0-9._:/@-]+$`)
+
+// ValidateImageRef guards every external image consumer against argument
+// injection and rejects syntactically invalid Docker/OCI references.
+//
+// The optional docker:// transport is accepted for compatibility with skopeo,
+// but it is not passed to the semantic parser.
+func ValidateImageRef(imageRef string) error {
+	rawRef := strings.TrimPrefix(imageRef, "docker://")
+	if rawRef == "" {
+		return errors.New("empty image reference")
+	}
+	if strings.HasPrefix(rawRef, "docker://") {
+		return fmt.Errorf("invalid image reference: %s", imageRef)
+	}
+	if strings.HasPrefix(rawRef, "-") || !imageRefAllowedPattern.MatchString(rawRef) {
+		return fmt.Errorf("invalid image reference: %s", imageRef)
+	}
+	if _, err := name.ParseReference(rawRef); err != nil {
+		return fmt.Errorf("invalid image reference %q: %w", imageRef, err)
+	}
+	return nil
+}
 
 func skopeoDockerImageRef(imageRef string) string {
 	if strings.HasPrefix(imageRef, "docker://") {

--- a/CubeMaster/pkg/templatecenter/image/source.go
+++ b/CubeMaster/pkg/templatecenter/image/source.go
@@ -12,7 +12,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"regexp"
 	"strings"
 
 	"github.com/google/go-containerregistry/pkg/name"
@@ -24,7 +23,7 @@ func PrepareLocalSource(ctx context.Context, spec SourceSpec) (*PreparedSource, 
 	// Validate the reference up front so both the docker and dockerless branches
 	// enforce the same argument-injection guard before the ref is handed to
 	// external CLI subprocesses (docker / skopeo).
-	if err := validateImageRef(spec.ImageRef); err != nil {
+	if err := ValidateImageRef(spec.ImageRef); err != nil {
 		return nil, err
 	}
 	if nativeRootfsExportEnabled() {
@@ -73,7 +72,7 @@ func PrepareSource(ctx context.Context, spec SourceSpec) (*PreparedSource, error
 }
 
 func prepareNativeSource(ctx context.Context, spec SourceSpec) (*PreparedSource, error) {
-	if err := validateImageRef(spec.ImageRef); err != nil {
+	if err := ValidateImageRef(spec.ImageRef); err != nil {
 		return nil, err
 	}
 
@@ -157,7 +156,7 @@ func convertV1Config(cfg v1.Config) DockerImageConfig {
 }
 
 func prepareDockerlessSource(ctx context.Context, spec SourceSpec) (*PreparedSource, error) {
-	if err := validateImageRef(spec.ImageRef); err != nil {
+	if err := ValidateImageRef(spec.ImageRef); err != nil {
 		return nil, err
 	}
 	authFile, cleanup, err := createSkopeoAuthFile(spec.ImageRef, spec.RegistryUsername, spec.RegistryPassword)
@@ -211,7 +210,7 @@ func prepareDockerSource(ctx context.Context, spec SourceSpec) (*PreparedSource,
 	// Validate the reference up front so the docker prepare path enforces the
 	// same argument-injection guard as the dockerless path before the ref is
 	// handed to docker subprocesses.
-	if err := validateImageRef(spec.ImageRef); err != nil {
+	if err := ValidateImageRef(spec.ImageRef); err != nil {
 		return nil, err
 	}
 	if source, err := prepareDockerSourceWithEngine(ctx, spec); err == nil {
@@ -316,34 +315,6 @@ func dockerInspectToPreparedSource(spec SourceSpec, inspectInfo dockerInspectIma
 		},
 	}
 	return source, nil
-}
-
-// imageRefAllowedPattern is the strict character whitelist for image
-// references. It permits exactly the characters that appear in legitimate
-// registry/repository[:tag][@algo:hexdigest] references: alphanumerics and
-// `.`, `-`, `_`, `/`, `:`, `@`. Any other character (notably whitespace) is
-// rejected so the reference cannot be split into additional argv entries.
-var imageRefAllowedPattern = regexp.MustCompile(`^[A-Za-z0-9._:/@-]+$`)
-
-// validateImageRef guards against argument injection (CWE-88) when the image
-// reference is later passed as a positional argument to external CLIs
-// (skopeo/umoci/docker). Those tools accept flags interspersed with positional
-// arguments, so a ref such as `registry.example.com/image --authfile /etc/shadow`
-// would otherwise smuggle extra flags into the subprocess. To prevent this we
-// enforce a strict character whitelist (which excludes whitespace and other
-// argument delimiters) and reject any ref that begins with a dash.
-func validateImageRef(imageRef string) error {
-	trimmed := strings.TrimPrefix(imageRef, "docker://")
-	if trimmed == "" {
-		return errors.New("empty image reference")
-	}
-	if strings.HasPrefix(trimmed, "-") {
-		return fmt.Errorf("invalid image reference: %s", imageRef)
-	}
-	if !imageRefAllowedPattern.MatchString(trimmed) {
-		return fmt.Errorf("invalid image reference: %s", imageRef)
-	}
-	return nil
 }
 
 func createSkopeoAuthFile(imageRef, username, password string) (string, func(), error) {

--- a/CubeMaster/pkg/templatecenter/request_validation.go
+++ b/CubeMaster/pkg/templatecenter/request_validation.go
@@ -14,6 +14,7 @@ import (
 	cubeboxv1 "github.com/tencentcloud/CubeSandbox/CubeMaster/api/services/cubebox/v1"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/node"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/service/sandbox/types"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/templatecenter/image"
 )
 
 func resolveTemplateNodes(instanceType string, scope []string) ([]*node.Node, error) {
@@ -72,16 +73,18 @@ func normalizeTemplateImageRequest(req *types.CreateTemplateFromImageReq) (*type
 	if req.Request == nil || strings.TrimSpace(req.RequestID) == "" {
 		return nil, errors.New("requestID is required")
 	}
-	if strings.TrimSpace(req.SourceImageRef) == "" {
+	sourceImageRef := strings.TrimSpace(req.SourceImageRef)
+	if sourceImageRef == "" {
 		return nil, errors.New("source_image_ref is required")
 	}
-	if strings.HasPrefix(strings.TrimSpace(req.SourceImageRef), "-") {
-		return nil, errors.New("source_image_ref must not start with '-'")
+	if err := image.ValidateImageRef(sourceImageRef); err != nil {
+		return nil, fmt.Errorf("source_image_ref: %w", err)
 	}
 	if strings.TrimSpace(req.WritableLayerSize) == "" {
 		return nil, errors.New("writable_layer_size is required")
 	}
 	cloned := *req
+	cloned.SourceImageRef = sourceImageRef
 	exposedPorts, err := normalizeTemplateExposedPorts(req.ExposedPorts)
 	if err != nil {
 		return nil, err

--- a/CubeMaster/pkg/templatecenter/template_image_test.go
+++ b/CubeMaster/pkg/templatecenter/template_image_test.go
@@ -49,6 +49,46 @@ func TestNormalizeTemplateImageRequestDefaults(t *testing.T) {
 	}
 }
 
+func TestNormalizeTemplateImageRequestTrimsAndValidatesSourceImageRef(t *testing.T) {
+	req, err := normalizeTemplateImageRequest(&types.CreateTemplateFromImageReq{
+		Request:           &types.Request{RequestID: "req-1"},
+		SourceImageRef:    "  registry.example.com:5000/ns/app:1.2.3  ",
+		WritableLayerSize: "20Gi",
+	})
+	if err != nil {
+		t.Fatalf("normalizeTemplateImageRequest failed: %v", err)
+	}
+	if req.SourceImageRef != "registry.example.com:5000/ns/app:1.2.3" {
+		t.Fatalf("SourceImageRef=%q, want trimmed reference", req.SourceImageRef)
+	}
+}
+
+func TestNormalizeTemplateImageRequestRejectsInvalidSourceImageRef(t *testing.T) {
+	invalidRefs := []string{
+		"",
+		"--help",
+		"-v",
+		"docker://--help",
+		"registry.example.com/image --authfile /etc/shadow",
+		"registry.example.com/image\n--flag",
+		"image;rm",
+		"library/nginx:",
+		"library/nginx@sha256:not-a-digest",
+	}
+	for _, imageRef := range invalidRefs {
+		t.Run(imageRef, func(t *testing.T) {
+			_, err := normalizeTemplateImageRequest(&types.CreateTemplateFromImageReq{
+				Request:           &types.Request{RequestID: "req-1"},
+				SourceImageRef:    imageRef,
+				WritableLayerSize: "20Gi",
+			})
+			if err == nil || !strings.Contains(err.Error(), "source_image_ref") {
+				t.Fatalf("normalizeTemplateImageRequest(%q) error=%v, want source_image_ref validation error", imageRef, err)
+			}
+		})
+	}
+}
+
 func TestNormalizeTemplateImageRequestIgnoresProvidedTemplateID(t *testing.T) {
 
 	req, err := normalizeTemplateImageRequest(&types.CreateTemplateFromImageReq{


### PR DESCRIPTION
## Summary

Strengthens image reference validation and prevents argument injection in Docker CLI invocations.

## Changes

### Public validation function (`ValidateImageRef`)
- Extracted `validateImageRef` from `source.go` into a new exported function `ValidateImageRef` in `ref.go`
- Enhanced with semantic parsing via `go-containerregistry/pkg/name` in addition to character whitelist checking
- Additional validation: rejects empty tags (`image:tag:`), malformed digests, and double `docker://` prefixes

### Argument injection prevention
- Added `--` option terminator before positional arguments in `docker login`, `docker rm`, and `docker export` commands
- Prevents registry hostnames or container IDs from being interpreted as command flags

### API boundary validation
- `normalizeTemplateImageRequest` now calls `image.ValidateImageRef()` to validate `SourceImageRef` at the API layer
- Whitespace trimming applied before validation

### Tests
- `TestDockerLoginTerminatesOptionsBeforeRegistry`: verifies `--` is placed before the registry argument
- `TestPrepareDockerSourceRejectsInvalidImageRefBeforeEngineAccess`: ensures the engine client is never accessed for invalid refs
- `TestNormalizeTemplateImageRequestTrimsAndValidatesSourceImageRef` / `TestNormalizeTemplateImageRequestRejectsInvalidSourceImageRef`: API-level validation
- Extended `TestValidateImageRef` with additional valid and invalid cases

## Security context

These changes mitigate argument injection risks (CWE-88) when image references are passed to external CLI tools (docker, skopeo, umoci) as positional arguments.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)