### PR TITLE
docs: add Gemini CLI integration guide and example

### DIFF
--- a/docs/guide/integrations/gemini-cli.md
+++ b/docs/guide/integrations/gemini-cli.md
@@ -1,0 +1,107 @@
+---
+title: Gemini CLI Integration Guide
+author: initiallyqq
+date: 2026-07-10
+tags:
+  - integration
+  - gemini-cli
+  - coding-agent
+  - agent
+lang: en-US
+---
+
+# Gemini CLI Integration Guide
+
+This guide runs Gemini CLI in a CubeSandbox MicroVM so an agent can inspect and modify a workspace without receiving host access. The companion example is in [`examples/gemini-cli-integration`](../../../examples/gemini-cli-integration/).
+
+## What the integration provides
+
+- A template Dockerfile based on `ghcr.io/tencentcloud/cubesandbox-base` with Node.js and `@google/gemini-cli`.
+- A one-shot coding-agent runner using the E2B-compatible Python SDK.
+- A pause/resume runner that verifies workspace state survives a CubeSandbox snapshot.
+- A default-deny egress example that uses CubeEgress to inject `x-goog-api-key` on the allowed Google API request.
+
+## Prerequisites
+
+- A running CubeSandbox deployment with a `READY` template.
+- Python 3.10+ and the packages in `requirements.txt` on the host that runs the example.
+- A Google AI Studio API key for Gemini API-key mode.
+- A registry reachable by CubeSandbox nodes when publishing a custom template.
+
+## Build the template
+
+```bash
+cd examples/gemini-cli-integration
+chmod +x build-template.sh
+IMAGE=registry.example.com/cube/gemini-cli:2026-07-10 ./build-template.sh
+```
+
+The script builds the image, pushes it, and registers it with a readiness probe on the inherited `envd` port `49983`. Pin `GEMINI_CLI_VERSION` after validating upgrades instead of relying on `latest` in production.
+
+## Configure the host-side runner
+
+```bash
+cp .env.example .env
+python3 -m pip install -r requirements.txt
+```
+
+Set `E2B_API_URL`, `E2B_API_KEY`, `CUBE_TEMPLATE_ID`, and `GEMINI_API_KEY` in `.env`. Keep `.env` on the trusted runner host; it is excluded from Git.
+
+## Run a coding task
+
+```bash
+python3 run_gemini.py --approve-all
+```
+
+The runner creates a sandbox, seeds a small Python project, and invokes `gemini --prompt ...`. `--approve-all` maps to Gemini CLI `--yolo`; use it only for an explicitly scoped sandbox because it lets the agent perform tool actions without per-action confirmation.
+
+## Preserve work across turns
+
+```bash
+python3 resume_gemini.py --approve-all
+```
+
+The first turn writes `/workspace/plan.md`, then `sandbox.pause()` creates a snapshot. The runner reconnects with `Sandbox.connect(...)`, verifies `plan.md`, and runs a second turn. Do not use a `with Sandbox.create(...)` context manager for this workflow: leaving the context kills the sandbox and defeats pause/resume.
+
+## Secure egress and secret injection
+
+The simple runner passes `GEMINI_API_KEY` in the per-command environment and is useful for development only. For shared clusters, run:
+
+```bash
+python3 network_policy.py --approve-all
+```
+
+This creates the sandbox with `allow_internet_access=False` and a single CubeEgress rule for `generativelanguage.googleapis.com`. The rule injects the real `x-goog-api-key` header after the host/SNI match. Gemini receives a placeholder `GEMINI_API_KEY`; the actual key is not present in the VM environment, filesystem, or command line.
+
+For HTTPS interception, build templates with the CubeEgress CA available. The example sets `NODE_EXTRA_CA_CERTS=/etc/ssl/certs/ca-certificates.crt` so Node can trust the interception chain. See [Security Proxy](../security-proxy.md) for the rule grammar and audit behavior.
+
+## Recommended operating model
+
+- Use a dedicated template with fixed Gemini CLI and Node versions.
+- Keep `--yolo` disabled unless the sandbox workload and file scope are intentionally constrained.
+- Give each user/session a separate sandbox; pause idle sessions and enforce lifecycle timeouts.
+- Use default-deny egress with a narrow Google API host rule in production.
+- Store only non-sensitive workspace state in snapshots. A snapshot preserves writable filesystem and process state.
+- Review CubeEgress metadata audit logs for the rule name, destination, status, and latency; secrets are redacted.
+
+## Troubleshooting
+
+| Symptom | Cause and resolution |
+| --- | --- |
+| `gemini: command not found` | Rebuild the template and inspect `gemini --version` inside the image. |
+| Authentication fails | Verify the key is valid for API-key mode. For the vault path, ensure the CubeEgress rule uses the correct host and injects `x-goog-api-key`. |
+| TLS self-signed or connection error | The template may not trust the CubeEgress CA. Rebuild with the standard base image/CA path and set `NODE_EXTRA_CA_CERTS` as shown. |
+| Egress request is denied | Default-deny is expected. Add only the required API host as an explicit rule; do not enable unrestricted internet access as a workaround. |
+| Files disappear after the first turn | Confirm the workflow calls `pause()` and reconnects to the same sandbox ID, rather than creating a new sandbox or exiting a context manager. |
+| Agent waits for approval | Add `--approve-all` only when autonomous writes are intended, or keep approval-gated behavior for safer runs. |
+
+## Validation
+
+```bash
+python3 -m unittest examples/gemini-cli-integration/test_common.py
+python3 -m py_compile examples/gemini-cli-integration/*.py
+bash -n examples/gemini-cli-integration/build-template.sh
+docker build -t gemini-cli-cube:local examples/gemini-cli-integration
+```
+
+A live run additionally needs a registered CubeSandbox template and credentials. Test `run_gemini.py`, `resume_gemini.py`, and `network_policy.py` against a non-production project before enabling autonomous actions.

--- a/docs/guide/integrations/index.md
+++ b/docs/guide/integrations/index.md
@@ -48,3 +48,4 @@ lang: en-US
 | Title | Author | Date | Tags |
 | --- | --- | --- | --- |
 | [Pi Agent Integration Guide](./pi-agent.md) | chaojixinren | 2026-07-01 | integration, pi-agent, coding-agent, agent |
+| [Gemini CLI Integration Guide](./gemini-cli.md) | initiallyqq | 2026-07-10 | integration, gemini-cli, coding-agent, agent |

--- a/docs/zh/guide/integrations/gemini-cli.md
+++ b/docs/zh/guide/integrations/gemini-cli.md
@@ -1,0 +1,107 @@
+---
+title: Gemini CLI 集成指南
+author: initiallyqq
+date: 2026-07-10
+tags:
+  - integration
+  - gemini-cli
+  - coding-agent
+  - agent
+lang: zh-CN
+---
+
+# Gemini CLI 集成指南
+
+本指南将 Gemini CLI 运行在 CubeSandbox MicroVM 中，让 Agent 在不获得宿主机权限的前提下检查和修改工作区。配套示例位于 [`examples/gemini-cli-integration`](../../../examples/gemini-cli-integration/)。
+
+## 集成能力
+
+- 基于 `ghcr.io/tencentcloud/cubesandbox-base` 的模板 Dockerfile，内置 Node.js 和 `@google/gemini-cli`。
+- 通过 E2B 兼容 Python SDK 运行的一次性编码 Agent。
+- 用于验证 CubeSandbox 快照后工作区状态仍可恢复的暂停/恢复示例。
+- 使用 CubeEgress 在已允许的 Google API 请求上注入 `x-goog-api-key` 的默认拒绝出口示例。
+
+## 前置条件
+
+- 已部署 CubeSandbox，且存在一个 `READY` 模板。
+- 运行示例的可信宿主机上安装 Python 3.10+ 与 `requirements.txt` 中的依赖。
+- Gemini API Key（Google AI Studio API-key 模式）。
+- 发布自定义模板时，CubeSandbox 节点可访问的镜像仓库。
+
+## 构建模板
+
+```bash
+cd examples/gemini-cli-integration
+chmod +x build-template.sh
+IMAGE=registry.example.com/cube/gemini-cli:2026-07-10 ./build-template.sh
+```
+
+脚本会构建并推送镜像，然后使用继承的 `envd` `49983` 端口注册健康检查。生产环境应在升级验证后固定 `GEMINI_CLI_VERSION`，不要长期依赖 `latest`。
+
+## 配置宿主机运行器
+
+```bash
+cp .env.example .env
+python3 -m pip install -r requirements.txt
+```
+
+在 `.env` 中设置 `E2B_API_URL`、`E2B_API_KEY`、`CUBE_TEMPLATE_ID` 和 `GEMINI_API_KEY`。`.env` 必须仅保存在可信运行器宿主机上，且已被 Git 忽略。
+
+## 运行编码任务
+
+```bash
+python3 run_gemini.py --approve-all
+```
+
+运行器会创建 sandbox、写入一个小型 Python 项目，并调用 `gemini --prompt ...`。`--approve-all` 映射到 Gemini CLI 的 `--yolo`；仅在已明确限定 sandbox 与文件范围时使用，因为它会跳过每次工具调用的确认。
+
+## 跨轮次保留工作状态
+
+```bash
+python3 resume_gemini.py --approve-all
+```
+
+第一轮会写入 `/workspace/plan.md`，随后 `sandbox.pause()` 创建快照。运行器通过 `Sandbox.connect(...)` 重连、验证 `plan.md`，再运行第二轮。不要对该工作流使用 `with Sandbox.create(...)`：退出上下文会销毁 sandbox，使暂停/恢复失效。
+
+## 安全出口与密钥注入
+
+简单运行器通过命令环境变量传入 `GEMINI_API_KEY`，仅适合开发调试。共享集群请运行：
+
+```bash
+python3 network_policy.py --approve-all
+```
+
+该脚本以 `allow_internet_access=False` 创建 sandbox，并仅为 `generativelanguage.googleapis.com` 设置一条 CubeEgress 规则。规则会在 Host/SNI 匹配后注入真实 `x-goog-api-key` 请求头。Gemini 只能看到占位 `GEMINI_API_KEY`，真实密钥不会出现在 VM 环境、文件系统或命令行中。
+
+HTTPS 拦截需要模板信任 CubeEgress CA。示例设置 `NODE_EXTRA_CA_CERTS=/etc/ssl/certs/ca-certificates.crt`，使 Node 信任拦截证书链。规则语法和审计行为请参阅[安全代理](../security-proxy.md)。
+
+## 生产建议
+
+- 使用固定 Gemini CLI 和 Node 版本的专用模板。
+- 除非已明确约束工作负载与文件范围，否则保持关闭 `--yolo`。
+- 每个用户或会话使用独立 sandbox；对闲置会话暂停并设置生命周期超时。
+- 生产环境采用默认拒绝出口，只放行精确的 Google API 主机。
+- 快照中仅保留不敏感工作区状态。快照会保留可写文件系统和进程状态。
+- 审查 CubeEgress 元数据审计日志中的规则名、目标、状态和延迟；密钥会被脱敏。
+
+## 常见问题
+
+| 现象 | 原因与处理 |
+| --- | --- |
+| `gemini: command not found` | 重新构建模板，并在镜像中检查 `gemini --version`。 |
+| 鉴权失败 | 检查 API-key 模式的 Key 是否有效。凭据保险库路径还需确认 CubeEgress 使用了正确主机并注入 `x-goog-api-key`。 |
+| TLS 自签名或连接错误 | 模板可能不信任 CubeEgress CA。请使用标准基础镜像/CA 路径重建，并按示例设置 `NODE_EXTRA_CA_CERTS`。 |
+| 出口请求被拒绝 | 默认拒绝是预期行为。只添加必要 API 主机的显式规则，不要以开启全部网络作为替代方案。 |
+| 第一轮后的文件丢失 | 确认调用了 `pause()` 并连接同一个 sandbox ID，而不是创建新 sandbox 或退出上下文管理器。 |
+| Agent 等待确认 | 仅在需要自主写入时添加 `--approve-all`，否则保留审批模式。 |
+
+## 验证
+
+```bash
+python3 -m unittest examples/gemini-cli-integration/test_common.py
+python3 -m py_compile examples/gemini-cli-integration/*.py
+bash -n examples/gemini-cli-integration/build-template.sh
+docker build -t gemini-cli-cube:local examples/gemini-cli-integration
+```
+
+在线运行还需要已注册的 CubeSandbox 模板和凭据。在启用自主操作前，请先在非生产项目中运行 `run_gemini.py`、`resume_gemini.py` 与 `network_policy.py`。

--- a/docs/zh/guide/integrations/index.md
+++ b/docs/zh/guide/integrations/index.md
@@ -48,3 +48,4 @@ lang: zh-CN
 | 标题 | 作者 | 日期 | 标签 |
 | --- | --- | --- | --- |
 | [Pi Agent 集成指南](./pi-agent.md) | chaojixinren | 2026-07-01 | integration, pi-agent, coding-agent, agent |
+| [Gemini CLI 集成指南](./gemini-cli.md) | initiallyqq | 2026-07-10 | integration, gemini-cli, coding-agent, agent |

--- a/examples/gemini-cli-integration/.env.example
+++ b/examples/gemini-cli-integration/.env.example
@@ -1,0 +1,17 @@
+# CubeSandbox E2B-compatible endpoint and API key.
+E2B_API_URL=http://<cube-api-host>:3000
+E2B_API_KEY=<cube-api-key>
+CUBE_TEMPLATE_ID=tpl-<gemini-cli-template>
+
+# Google AI Studio API key. Keep this only on the host running the example.
+GEMINI_API_KEY=<your-google-ai-studio-key>
+
+# Optional defaults.
+GEMINI_MODEL=gemini-2.5-flash
+GEMINI_WORKSPACE=/workspace
+GEMINI_SANDBOX_TIMEOUT=1800
+GEMINI_EXEC_TIMEOUT=900
+
+# Set to 1 only when the agent should be allowed to modify files without
+# interactive approval. This enables Gemini CLI's --yolo mode.
+GEMINI_APPROVE_ALL=0

--- a/examples/gemini-cli-integration/.gitignore
+++ b/examples/gemini-cli-integration/.gitignore
@@ -1,0 +1,3 @@
+.env
+__pycache__/
+*.py[cod]

--- a/examples/gemini-cli-integration/Dockerfile
+++ b/examples/gemini-cli-integration/Dockerfile
@@ -1,0 +1,40 @@
+# syntax=docker/dockerfile:1.7
+# Gemini CLI image for a CubeSandbox template.
+# The base image already contains cube-entrypoint and envd on :49983.
+
+ARG CUBE_BASE_IMAGE=ghcr.io/tencentcloud/cubesandbox-base:2026.16
+FROM ${CUBE_BASE_IMAGE}
+
+ARG DEBIAN_FRONTEND=noninteractive
+ARG NODE_MAJOR=22
+ARG GEMINI_CLI_VERSION=latest
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        bash \
+        ca-certificates \
+        curl \
+        git \
+        gnupg \
+        jq \
+        python3 \
+        python3-pip \
+        ripgrep \
+    && curl -fsSL "https://deb.nodesource.com/setup_${NODE_MAJOR}.x" | bash - \
+    && apt-get install -y --no-install-recommends nodejs \
+    && rm -rf /var/lib/apt/lists/*
+
+# Pin GEMINI_CLI_VERSION in production builds after validating an upgrade.
+RUN npm install -g --ignore-scripts "@google/gemini-cli@${GEMINI_CLI_VERSION}" \
+    && gemini --version \
+    && npm cache clean --force \
+    && rm -rf /root/.npm
+
+ENV GEMINI_CLI_HOME=/root/.gemini \
+    GEMINI_CLI_TELEMETRY_ENABLED=false \
+    NPM_CONFIG_UPDATE_NOTIFIER=false
+
+RUN mkdir -p /workspace "${GEMINI_CLI_HOME}"
+
+WORKDIR /workspace
+EXPOSE 49983

--- a/examples/gemini-cli-integration/README.md
+++ b/examples/gemini-cli-integration/README.md
@@ -1,0 +1,58 @@
+# Gemini CLI + CubeSandbox
+
+This example runs [Gemini CLI](https://github.com/google-gemini/gemini-cli) inside a hardware-isolated CubeSandbox MicroVM.
+
+- `run_gemini.py`: one-shot coding task with host-side environment injection.
+- `resume_gemini.py`: pause/resume workflow that proves `/workspace` survives the snapshot.
+- `network_policy.py`: default-deny egress plus CubeEgress `x-goog-api-key` injection; the real key never enters the VM.
+
+## 1. Build and register the template
+
+```bash
+cd examples/gemini-cli-integration
+chmod +x build-template.sh
+IMAGE=registry.example.com/cube/gemini-cli:2026-07-10 ./build-template.sh
+```
+
+Set the template ID printed by `cubemastercli` in `.env`:
+
+```bash
+cp .env.example .env
+# Edit E2B_API_URL, E2B_API_KEY, CUBE_TEMPLATE_ID, GEMINI_API_KEY
+python3 -m pip install -r requirements.txt
+```
+
+## 2. Run a one-shot task
+
+```bash
+python3 run_gemini.py --approve-all
+```
+
+`--approve-all` explicitly enables Gemini CLI's `--yolo` mode. Leave it off for read-only or approval-gated workloads.
+
+## 3. Verify pause/resume persistence
+
+```bash
+python3 resume_gemini.py --approve-all
+```
+
+The script has Gemini create `plan.md`, pauses the sandbox, reconnects to the same sandbox, verifies the file, then asks Gemini to create `progress.md`.
+
+## 4. Use the credential-vault path
+
+```bash
+python3 network_policy.py --approve-all
+```
+
+This path creates the sandbox with `allow_internet_access=False` and permits only `generativelanguage.googleapis.com`. CubeEgress injects the real `x-goog-api-key` header on the allowed request. The in-VM process receives only a placeholder key.
+
+## Validation
+
+```bash
+python3 -m unittest test_common.py
+python3 -m py_compile common.py run_gemini.py resume_gemini.py network_policy.py
+bash -n build-template.sh
+docker build -t gemini-cli-cube:local .
+```
+
+A live end-to-end run additionally requires a CubeSandbox cluster, a registered template, and a Google AI Studio API key. Do not commit `.env` or place API keys in the Docker image.

--- a/examples/gemini-cli-integration/README_zh.md
+++ b/examples/gemini-cli-integration/README_zh.md
@@ -1,0 +1,58 @@
+# Gemini CLI + CubeSandbox
+
+本示例在 CubeSandbox 的硬件隔离 MicroVM 中运行 [Gemini CLI](https://github.com/google-gemini/gemini-cli)。
+
+- `run_gemini.py`：通过宿主机环境变量注入密钥的一次性编码任务。
+- `resume_gemini.py`：暂停/恢复流程，验证 `/workspace` 会随快照持久化。
+- `network_policy.py`：默认拒绝出口策略和 CubeEgress `x-goog-api-key` 密钥注入，真实密钥不会进入虚拟机。
+
+## 1. 构建并注册模板
+
+```bash
+cd examples/gemini-cli-integration
+chmod +x build-template.sh
+IMAGE=registry.example.com/cube/gemini-cli:2026-07-10 ./build-template.sh
+```
+
+将 `cubemastercli` 输出的模板 ID 写入 `.env`：
+
+```bash
+cp .env.example .env
+# 编辑 E2B_API_URL、E2B_API_KEY、CUBE_TEMPLATE_ID、GEMINI_API_KEY
+python3 -m pip install -r requirements.txt
+```
+
+## 2. 运行一次性任务
+
+```bash
+python3 run_gemini.py --approve-all
+```
+
+`--approve-all` 会显式启用 Gemini CLI 的 `--yolo` 模式。只读或需要人工确认的工作负载应省略该参数。
+
+## 3. 验证暂停/恢复持久化
+
+```bash
+python3 resume_gemini.py --approve-all
+```
+
+脚本先让 Gemini 创建 `plan.md`，暂停 sandbox，再连接同一个 sandbox 验证文件存在，最后让 Gemini 创建 `progress.md`。
+
+## 4. 使用凭据保险库路径
+
+```bash
+python3 network_policy.py --approve-all
+```
+
+该路径通过 `allow_internet_access=False` 创建 sandbox，只允许访问 `generativelanguage.googleapis.com`。CubeEgress 会在已允许请求上注入真实 `x-goog-api-key` 请求头，虚拟机内进程仅能获得占位密钥。
+
+## 验证命令
+
+```bash
+python3 -m unittest test_common.py
+python3 -m py_compile common.py run_gemini.py resume_gemini.py network_policy.py
+bash -n build-template.sh
+docker build -t gemini-cli-cube:local .
+```
+
+端到端运行还需要可用的 CubeSandbox 集群、已注册模板及 Google AI Studio API Key。不要提交 `.env`，也不要把 API Key 写入 Docker 镜像。

--- a/examples/gemini-cli-integration/build-template.sh
+++ b/examples/gemini-cli-integration/build-template.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Build a Gemini CLI image and register it as a CubeSandbox template.
+# Example:
+#   IMAGE=registry.example.com/cube/gemini-cli:2026-07-10 ./build-template.sh
+
+: "${IMAGE:?Set IMAGE to a registry image name, for example registry.example.com/cube/gemini-cli:tag}"
+: "${CUBE_TEMPLATE_NAME:=gemini-cli}"
+: "${GEMINI_CLI_VERSION:=latest}"
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+
+docker build \
+  --build-arg "GEMINI_CLI_VERSION=${GEMINI_CLI_VERSION}" \
+  -t "${IMAGE}" \
+  "${SCRIPT_DIR}"
+docker push "${IMAGE}"
+
+cubemastercli tpl create-from-image \
+  --image "${IMAGE}" \
+  --name "${CUBE_TEMPLATE_NAME}" \
+  --writable-layer-size 4G \
+  --expose-port 49983 \
+  --probe 49983 \
+  --probe-path /health

--- a/examples/gemini-cli-integration/common.py
+++ b/examples/gemini-cli-integration/common.py
@@ -1,0 +1,79 @@
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Small, dependency-free helpers shared by the Gemini CLI examples."""
+
+from __future__ import annotations
+
+import os
+import shlex
+from pathlib import Path
+from typing import Any
+
+
+def load_dotenv(path: str = ".env") -> None:
+    """Load simple KEY=VALUE lines without overriding exported variables."""
+    dotenv = Path(path)
+    if not dotenv.is_file():
+        return
+    for line in dotenv.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        key = key.strip()
+        value = value.strip().strip('"').strip("'")
+        if key:
+            os.environ.setdefault(key, value)
+
+
+def required(name: str) -> str:
+    value = os.environ.get(name, "").strip()
+    if not value:
+        raise SystemExit(f"Missing required environment variable: {name}")
+    return value
+
+
+def int_env(name: str, default: int) -> int:
+    value = os.environ.get(name, "").strip()
+    return int(value) if value else default
+
+
+def shell_join(*commands: str) -> str:
+    return " && ".join(command for command in commands if command)
+
+
+def gemini_command(prompt: str, *, model: str | None, approve_all: bool) -> str:
+    """Build a non-interactive Gemini CLI command with safely quoted values."""
+    command = ["gemini", "--prompt", prompt]
+    if model:
+        command.extend(["--model", model])
+    if approve_all:
+        command.append("--yolo")
+    return " ".join(shlex.quote(item) for item in command)
+
+
+def run_command(sandbox: Any, command: str, **kwargs: Any) -> Any:
+    """Run a command while accommodating SDKs that call env vars env or envs."""
+    try:
+        return sandbox.commands.run(command, **kwargs)
+    except TypeError as exc:
+        if "envs" not in kwargs or "envs" not in str(exc):
+            raise
+        retry = dict(kwargs)
+        retry["env"] = retry.pop("envs")
+        return sandbox.commands.run(command, **retry)
+
+
+def ensure_success(result: Any, action: str) -> None:
+    exit_code = getattr(result, "exit_code", None)
+    if exit_code not in (None, 0):
+        raise SystemExit(
+            f"Failed to {action} (exit {exit_code}).\n"
+            f"STDOUT:\n{getattr(result, 'stdout', '')}\n"
+            f"STDERR:\n{getattr(result, 'stderr', '')}"
+        )
+
+
+def sandbox_id(sandbox: Any) -> str:
+    return str(getattr(sandbox, "sandbox_id", getattr(sandbox, "id", "unknown")))

--- a/examples/gemini-cli-integration/network_policy.py
+++ b/examples/gemini-cli-integration/network_policy.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Run Gemini CLI with default-deny egress and CubeEgress key injection."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import shlex
+import sys
+
+from cubesandbox import Action, Inject, Match, Rule, Sandbox
+
+from common import (
+    ensure_success,
+    gemini_command,
+    int_env,
+    load_dotenv,
+    required,
+    run_command,
+    sandbox_id,
+    shell_join,
+)
+
+DEFAULT_HOST = "generativelanguage.googleapis.com"
+PLACEHOLDER_KEY = "cube-egress-managed-placeholder"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--template", default=os.environ.get("CUBE_TEMPLATE_ID"))
+    parser.add_argument("--model", default=os.environ.get("GEMINI_MODEL"))
+    parser.add_argument("--host", default=os.environ.get("GEMINI_API_HOST", DEFAULT_HOST))
+    parser.add_argument("--workspace", default=os.environ.get("GEMINI_WORKSPACE", "/workspace"))
+    parser.add_argument("--approve-all", action="store_true")
+    parser.add_argument("--sandbox-timeout", type=int, default=int_env("GEMINI_SANDBOX_TIMEOUT", 1800))
+    parser.add_argument("--exec-timeout", type=int, default=int_env("GEMINI_EXEC_TIMEOUT", 900))
+    return parser.parse_args()
+
+
+def main() -> int:
+    load_dotenv()
+    args = parse_args()
+    template = args.template or required("CUBE_TEMPLATE_ID")
+    required("E2B_API_URL")
+    required("E2B_API_KEY")
+    secret = required("GEMINI_API_KEY")
+    args.approve_all = args.approve_all or os.environ.get("GEMINI_APPROVE_ALL") == "1"
+
+    # API-key mode sends x-goog-api-key to the public Generative Language API.
+    # Lock both SNI and Host. Unmatched egress remains unavailable.
+    rules = [
+        Rule(
+            name="allow_google_gemini_api",
+            match=Match(scheme="https", sni=args.host, host=args.host),
+            action=Action(
+                allow=True,
+                audit="metadata",
+                inject=[Inject(header="x-goog-api-key", secret=secret)],
+            ),
+        )
+    ]
+    sandbox = Sandbox.create(
+        template=template,
+        allow_internet_access=False,
+        network={"rules": rules},
+        timeout=args.sandbox_timeout,
+    )
+    current_id = sandbox_id(sandbox)
+    try:
+        print(f"Sandbox ready: {current_id}; only {args.host} is allowed.")
+        no_secret = run_command(sandbox, "printenv GEMINI_API_KEY || true", timeout=30, user="root")
+        ensure_success(no_secret, "inspect in-VM key")
+        value = getattr(no_secret, "stdout", "").strip() or "<unset>"
+        print(f"In-VM GEMINI_API_KEY before command: {value}")
+
+        command = shell_join(
+            f"mkdir -p {shlex.quote(args.workspace)}",
+            f"cd {shlex.quote(args.workspace)}",
+            gemini_command(
+                "Reply with one sentence confirming the secure egress route is available.",
+                model=args.model,
+                approve_all=args.approve_all,
+            ),
+        )
+        # Gemini CLI receives a placeholder. CubeEgress replaces it only on the
+        # allowed outbound request, so the true key never reaches the VM.
+        result = run_command(
+            sandbox,
+            command,
+            cwd=args.workspace,
+            envs={
+                "GEMINI_API_KEY": PLACEHOLDER_KEY,
+                "NODE_EXTRA_CA_CERTS": "/etc/ssl/certs/ca-certificates.crt",
+            },
+            timeout=args.exec_timeout,
+            user="root",
+        )
+        ensure_success(result, "run Gemini CLI through CubeEgress")
+        print(getattr(result, "stdout", ""))
+        return 0
+    finally:
+        try:
+            sandbox.kill()
+            print(f"Sandbox {current_id} killed.")
+        except Exception as exc:  # noqa: BLE001
+            print(f"Warning: failed to kill sandbox {current_id}: {exc}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/examples/gemini-cli-integration/requirements.txt
+++ b/examples/gemini-cli-integration/requirements.txt
@@ -1,0 +1,2 @@
+e2b>=1.0.0
+cubesandbox>=0.3.0

--- a/examples/gemini-cli-integration/resume_gemini.py
+++ b/examples/gemini-cli-integration/resume_gemini.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Verify Gemini CLI workspace persistence across CubeSandbox pause/resume."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import shlex
+import sys
+
+from e2b import Sandbox
+
+from common import (
+    ensure_success,
+    gemini_command,
+    int_env,
+    load_dotenv,
+    required,
+    run_command,
+    sandbox_id,
+    shell_join,
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--template", default=os.environ.get("CUBE_TEMPLATE_ID"))
+    parser.add_argument("--model", default=os.environ.get("GEMINI_MODEL"))
+    parser.add_argument("--workspace", default=os.environ.get("GEMINI_WORKSPACE", "/workspace"))
+    parser.add_argument("--approve-all", action="store_true")
+    parser.add_argument(
+        "--sandbox-timeout", type=int, default=int_env("GEMINI_SANDBOX_TIMEOUT", 1800)
+    )
+    parser.add_argument("--exec-timeout", type=int, default=int_env("GEMINI_EXEC_TIMEOUT", 900))
+    return parser.parse_args()
+
+
+def run_turn(sandbox: Sandbox, prompt: str, args: argparse.Namespace, envs: dict[str, str]):
+    command = shell_join(
+        f"cd {shlex.quote(args.workspace)}",
+        gemini_command(prompt, model=args.model, approve_all=args.approve_all),
+    )
+    return run_command(
+        sandbox,
+        command,
+        cwd=args.workspace,
+        envs=envs,
+        timeout=args.exec_timeout,
+        user="root",
+    )
+
+
+def main() -> int:
+    load_dotenv()
+    args = parse_args()
+    template = args.template or required("CUBE_TEMPLATE_ID")
+    required("E2B_API_URL")
+    required("E2B_API_KEY")
+    envs = {"GEMINI_API_KEY": required("GEMINI_API_KEY")}
+    args.approve_all = args.approve_all or os.environ.get("GEMINI_APPROVE_ALL") == "1"
+
+    sandbox = Sandbox.create(template=template, timeout=args.sandbox_timeout)
+    current_id = sandbox_id(sandbox)
+    try:
+        setup = run_command(
+            sandbox,
+            f"mkdir -p {shlex.quote(args.workspace)}",
+            timeout=60,
+            user="root",
+        )
+        ensure_success(setup, "create workspace")
+
+        first = run_turn(
+            sandbox,
+            f"Create {args.workspace}/plan.md with a numbered three-step plan for a small Python CLI. Only create plan.md.",
+            args,
+            envs,
+        )
+        ensure_success(first, "run Gemini CLI turn 1")
+
+        print(f"Pausing {current_id}; CubeSandbox snapshots the VM and writable filesystem.")
+        resume_handle = sandbox.pause()
+        if isinstance(resume_handle, str) and resume_handle:
+            current_id = resume_handle
+        sandbox = Sandbox.connect(sandbox_id=current_id)
+
+        persisted = run_command(
+            sandbox,
+            f"test -f {shlex.quote(args.workspace)}/plan.md && cat {shlex.quote(args.workspace)}/plan.md",
+            timeout=60,
+            user="root",
+        )
+        ensure_success(persisted, "verify plan.md survived pause/resume")
+        print("\n--- persisted plan.md ---\n" + getattr(persisted, "stdout", ""))
+
+        second = run_turn(
+            sandbox,
+            f"Read {args.workspace}/plan.md and create {args.workspace}/progress.md describing completion of step 1. Do not delete plan.md.",
+            args,
+            envs,
+        )
+        ensure_success(second, "run Gemini CLI turn 2")
+        return 0
+    finally:
+        try:
+            sandbox.kill()
+            print(f"Sandbox {current_id} killed.")
+        except Exception as exc:  # noqa: BLE001
+            print(f"Warning: failed to kill sandbox {current_id}: {exc}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/examples/gemini-cli-integration/run_gemini.py
+++ b/examples/gemini-cli-integration/run_gemini.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Run a Gemini CLI coding task inside a CubeSandbox MicroVM.
+
+The default mode demonstrates host-side secret injection through the E2B-
+compatible SDK. For production, use network_policy.py so CubeEgress injects the
+key on the wire and the real secret never enters the sandbox.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import shlex
+import sys
+
+from e2b import Sandbox
+
+from common import (
+    ensure_success,
+    gemini_command,
+    int_env,
+    load_dotenv,
+    required,
+    run_command,
+    sandbox_id,
+    shell_join,
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--template", default=os.environ.get("CUBE_TEMPLATE_ID"))
+    parser.add_argument("--model", default=os.environ.get("GEMINI_MODEL"))
+    parser.add_argument("--workspace", default=os.environ.get("GEMINI_WORKSPACE", "/workspace"))
+    parser.add_argument(
+        "--prompt",
+        default=(
+            "Inspect the project, run python3 app.py, and write a concise summary "
+            "of the result to /workspace/result.md."
+        ),
+    )
+    parser.add_argument("--approve-all", action="store_true", help="Pass --yolo to Gemini CLI.")
+    parser.add_argument(
+        "--sandbox-timeout", type=int, default=int_env("GEMINI_SANDBOX_TIMEOUT", 1800)
+    )
+    parser.add_argument("--exec-timeout", type=int, default=int_env("GEMINI_EXEC_TIMEOUT", 900))
+    parser.add_argument("--no-seed", action="store_true")
+    return parser.parse_args()
+
+
+def seed_workspace(sandbox: Sandbox, workspace: str) -> None:
+    quoted = shlex.quote(workspace)
+    command = f"""mkdir -p {quoted}
+cat > {quoted}/app.py <<'EOF'
+def main() -> None:
+    print("hello from CubeSandbox + Gemini CLI")
+
+
+if __name__ == "__main__":
+    main()
+EOF
+cat > {quoted}/README.md <<'EOF'
+# Gemini CLI CubeSandbox smoke project
+EOF
+"""
+    ensure_success(run_command(sandbox, command, timeout=60, user="root"), "seed workspace")
+
+
+def main() -> int:
+    load_dotenv()
+    args = parse_args()
+    template = args.template or required("CUBE_TEMPLATE_ID")
+    required("E2B_API_URL")
+    required("E2B_API_KEY")
+    api_key = required("GEMINI_API_KEY")
+    approve_all = args.approve_all or os.environ.get("GEMINI_APPROVE_ALL") == "1"
+
+    # This local-development path puts the key in the command environment.
+    # network_policy.py instead keeps the real key outside the VM.
+    command = shell_join(
+        f"cd {shlex.quote(args.workspace)}",
+        gemini_command(args.prompt, model=args.model, approve_all=approve_all),
+    )
+
+    sandbox = Sandbox.create(template=template, timeout=args.sandbox_timeout)
+    current_id = sandbox_id(sandbox)
+    try:
+        print(f"Sandbox ready: {current_id}")
+        version = run_command(sandbox, "gemini --version", timeout=60, user="root")
+        ensure_success(version, "check Gemini CLI version")
+        print(f"Gemini CLI: {getattr(version, 'stdout', '').strip()}")
+
+        if not args.no_seed:
+            seed_workspace(sandbox, args.workspace)
+
+        result = run_command(
+            sandbox,
+            command,
+            cwd=args.workspace,
+            envs={"GEMINI_API_KEY": api_key},
+            timeout=args.exec_timeout,
+            user="root",
+        )
+        ensure_success(result, "run Gemini CLI")
+        if getattr(result, "stdout", ""):
+            print(result.stdout)
+
+        inspect = run_command(
+            sandbox,
+            f"test ! -f {shlex.quote(args.workspace)}/result.md || cat {shlex.quote(args.workspace)}/result.md",
+            timeout=60,
+            user="root",
+        )
+        ensure_success(inspect, "read generated result")
+        if getattr(inspect, "stdout", ""):
+            print("\n--- result.md ---\n" + inspect.stdout)
+        return 0
+    finally:
+        try:
+            sandbox.kill()
+            print(f"Sandbox {current_id} killed.")
+        except Exception as exc:  # noqa: BLE001
+            print(f"Warning: failed to kill sandbox {current_id}: {exc}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/examples/gemini-cli-integration/test_common.py
+++ b/examples/gemini-cli-integration/test_common.py
@@ -1,0 +1,31 @@
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from common import gemini_command, shell_join
+
+
+class GeminiCommandTests(unittest.TestCase):
+    def test_command_quotes_prompt_and_model(self):
+        command = gemini_command("write 'result.md'", model="gemini-2.5-flash", approve_all=False)
+        self.assertIn("--prompt", command)
+        self.assertIn("gemini-2.5-flash", command)
+        self.assertNotIn("--yolo", command)
+
+    def test_command_requires_explicit_approval_for_yolo(self):
+        command = gemini_command("write a file", model=None, approve_all=True)
+        self.assertTrue(command.endswith("--yolo"))
+
+    def test_shell_join_omits_empty_commands(self):
+        self.assertEqual(
+            shell_join("cd /workspace", "", "gemini --version"),
+            "cd /workspace && gemini --version",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a runnable Gemini CLI CubeSandbox template and host runners
- document direct-key, pause/resume, and default-deny CubeEgress secret-injection workflows
- add mirrored English and Chinese integration guides

## Validation
- `python3 -m unittest examples/gemini-cli-integration/test_common.py`
- `python3 -m py_compile examples/gemini-cli-integration/*.py`
- `bash -n examples/gemini-cli-integration/build-template.sh`
- `git diff --check`
- verified Gemini CLI 0.50.0 supports `--prompt`, `--model`, and `--yolo`
- `npm run docs:build` is blocked by an existing missing asset in `docs/zh/blog/posts/2026-06-25-cubesandbox-snapshot-clone-rollback-deep-dive.md`

## Notes
- Related to #644 (Gemini CLI subdirection).
- Live Docker, CubeSandbox, and Gemini API tests require cluster, registry, and API credentials and were not run.
- Per `CONTRIBUTING.md`, this AI-assisted commit intentionally has no `Signed-off-by` line; the human submitter must review and add their own DCO sign-off before merge.

Autonomously-by: Codex:GPT-5