### PR TITLE
examples: add CMake C++ sandbox template

### DIFF
--- a/docs/guide/tutorials/examples.md
+++ b/docs/guide/tutorials/examples.md
@@ -5,6 +5,7 @@ Hands-on examples demonstrating various Cube Sandbox use cases. Each example is 
 | Example | Description |
 |---------|-------------|
 | [Code Sandbox Quickstart](https://github.com/tencentcloud/CubeSandbox/tree/master/examples/code-sandbox-quickstart) | The most basic usage: create a sandbox, run Python code, execute shell commands, manage network policies, and more — all via the E2B SDK. |
+| [C/C++ CMake Sandbox](https://github.com/tencentcloud/CubeSandbox/tree/master/examples/cpp-cmake-sandbox) | Build isolated C/C++ projects with GCC, CMake, Ninja, and ccache; pause and resume the sandbox to retain its build directory and compiler cache. |
 | [Browser Sandbox (Playwright)](https://github.com/tencentcloud/CubeSandbox/tree/master/examples/browser-sandbox) | Run a headless Chromium inside a MicroVM and control it remotely with Playwright via CDP. |
 | [OpenClaw Integration](https://github.com/tencentcloud/CubeSandbox/tree/master/examples/openclaw-integration) | Deploy Cube Sandbox and configure the OpenClaw skill so AI agents can execute code in isolated VM environments. |
 | [SWE-bench with mini-swe-agent](https://github.com/tencentcloud/CubeSandbox/tree/master/examples/mini-rl-training) | Automate SWE-bench coding tasks in isolated sandboxes using cube-sandbox + mini-swe-agent, with multi-model support and RL training vision. |

--- a/docs/zh/guide/tutorials/examples.md
+++ b/docs/zh/guide/tutorials/examples.md
@@ -5,6 +5,7 @@
 | 示例 | 说明 |
 |------|------|
 | [代码沙箱快速入门](https://github.com/tencentcloud/CubeSandbox/tree/master/examples/code-sandbox-quickstart) | 最基础的用法：创建沙箱、执行 Python 代码、运行 Shell 命令、管理网络策略等，全部通过 E2B SDK 完成。 |
+| [C/C++ CMake 沙箱](https://github.com/tencentcloud/CubeSandbox/tree/master/examples/cpp-cmake-sandbox) | 使用 GCC、CMake、Ninja 和 ccache 隔离构建 C/C++ 项目；暂停和恢复沙箱后继续复用构建目录与编译缓存。 |
 | [浏览器沙箱（Playwright）](https://github.com/tencentcloud/CubeSandbox/tree/master/examples/browser-sandbox) | 在 MicroVM 中运行无头 Chromium，通过 CDP 协议使用 Playwright 远程控制浏览器。 |
 | [OpenClaw 集成](https://github.com/tencentcloud/CubeSandbox/tree/master/examples/openclaw-integration) | 部署 Cube Sandbox 并配置 OpenClaw Skill，让 AI Agent 能够在隔离的虚拟机环境中执行代码。 |
 | [SWE-bench + mini-swe-agent](https://github.com/tencentcloud/CubeSandbox/tree/master/examples/mini-rl-training) | 使用 cube-sandbox + mini-swe-agent 在隔离沙箱中自动化 SWE-bench 编码任务，支持多模型切换和 RL 训练愿景。 |

--- a/examples/cpp-cmake-sandbox/.env.example
+++ b/examples/cpp-cmake-sandbox/.env.example
@@ -1,0 +1,11 @@
+# Required: Cube API server address
+export E2B_API_URL="http://<your-node-ip>:3000"
+
+# Required: any non-empty value satisfies the SDK check in local deployments
+export E2B_API_KEY="e2b_000000"
+
+# Required: template ID created from this image
+export CUBE_TEMPLATE_ID="<your-template-id>"
+
+# Optional: use this when Cube's HTTPS certificate is not publicly trusted
+# export SSL_CERT_FILE="/path/to/cube-ca.pem"

--- a/examples/cpp-cmake-sandbox/.gitignore
+++ b/examples/cpp-cmake-sandbox/.gitignore
@@ -1,0 +1,5 @@
+.env
+.env.*
+!.env.example
+__pycache__/
+*.pyc

--- a/examples/cpp-cmake-sandbox/Dockerfile
+++ b/examples/cpp-cmake-sandbox/Dockerfile
@@ -1,0 +1,31 @@
+# syntax=docker/dockerfile:1.7
+#
+# A Cube-ready C/C++ development image. The inherited entrypoint keeps envd
+# listening on :49983 while CMake/Ninja builds are launched through the SDK.
+#
+# Build:
+#   docker build -t cubesandbox-cpp-cmake:local examples/cpp-cmake-sandbox
+
+ARG CUBE_BASE_IMAGE=ghcr.io/tencentcloud/cubesandbox-base:2026.16
+FROM ${CUBE_BASE_IMAGE}
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        build-essential \
+        ccache \
+        cmake \
+        ninja-build \
+    && rm -rf /var/lib/apt/lists/*
+
+ENV CCACHE_DIR=/home/user/.cache/ccache \
+    CCACHE_COMPILERCHECK=content
+
+COPY sample /opt/cpp-cmake-sandbox/sample
+
+RUN install -d -o user -g user /workspace "${CCACHE_DIR}" \
+    && chown -R user:user /opt/cpp-cmake-sandbox
+
+WORKDIR /workspace
+EXPOSE 49983

--- a/examples/cpp-cmake-sandbox/README.md
+++ b/examples/cpp-cmake-sandbox/README.md
@@ -1,0 +1,111 @@
+# C/C++ CMake Sandbox
+
+[Chinese README](README_zh.md)
+
+A CubeSandbox template for isolated C/C++ builds. It extends
+`cubesandbox-base` with GCC, CMake, Ninja, and ccache, then demonstrates that
+both the CMake build directory and compiler cache survive a pause/resume cycle.
+
+## Included
+
+```text
+cpp-cmake-sandbox/
+|-- Dockerfile            # Cube-ready build image
+|-- sample/               # Minimal CMake project and CTest target
+|-- build_and_resume.py   # SDK build, snapshot, resume, and rebuild demo
+|-- env_utils.py          # Local .env loading and validation
+|-- .env.example          # Cube connection settings
+`-- requirements.txt      # Host-side SDK dependencies
+```
+
+## Prerequisites
+
+- A CubeSandbox deployment and `cubemastercli`.
+- Docker on a build workstation and a registry reachable from Cube nodes.
+- Python 3.9+ on the machine that runs the host-side script.
+
+## Build the template
+
+```bash
+docker build --platform linux/amd64 \
+  -t <your-registry>/cubesandbox-cpp-cmake:latest \
+  examples/cpp-cmake-sandbox
+docker push <your-registry>/cubesandbox-cpp-cmake:latest
+```
+
+The image uses the pinned `ghcr.io/tencentcloud/cubesandbox-base:2026.16`
+base, so `envd` already handles Cube SDK commands on port `49983`.
+
+## Register it in CubeSandbox
+
+```bash
+cubemastercli tpl create-from-image \
+  --image <your-registry>/cubesandbox-cpp-cmake:latest \
+  --writable-layer-size 2G \
+  --expose-port 49983 \
+  --probe 49983 \
+  --probe-path /health
+
+cubemastercli tpl watch --job-id <job-id>
+```
+
+Record the `template_id` after the job reaches `READY`.
+
+## Run the snapshot cache demo
+
+```bash
+cd examples/cpp-cmake-sandbox
+cp .env.example .env
+# Set E2B_API_URL, E2B_API_KEY, and CUBE_TEMPLATE_ID.
+pip install -r requirements.txt
+python build_and_resume.py
+```
+
+The script performs these steps:
+
+1. Copies `sample/` into the sandbox workspace and builds it with
+   `cmake -G Ninja` and `ccache`.
+2. Runs CTest and the resulting binary.
+3. Calls `sandbox.pause()` to save the MicroVM state and release compute.
+4. Reconnects with `Sandbox.connect(sandbox_id)`, touches one source file, and
+   rebuilds. The persisted CMake tree and `~/.cache/ccache` are displayed by
+   `ccache --show-stats`.
+
+The script removes its sandbox in a `finally` block, including when a build
+fails. It does not create a durable snapshot; use the
+[`snapshot-rollback-clone`](../snapshot-rollback-clone) examples when you want
+to retain or fan out snapshots.
+
+## Local image smoke test
+
+This check validates the toolchain without requiring a Cube cluster:
+
+```bash
+docker build -t cubesandbox-cpp-cmake:local .
+docker run --rm cubesandbox-cpp-cmake:local sh -lc \
+  'cp -a /opt/cpp-cmake-sandbox/sample /tmp/demo && \
+   cmake -S /tmp/demo -B /tmp/demo/build -G Ninja \
+     -DCMAKE_CXX_COMPILER_LAUNCHER=ccache && \
+   cmake --build /tmp/demo/build && \
+   ctest --test-dir /tmp/demo/build --output-on-failure'
+```
+
+## Resource and security notes
+
+- Start with a `2G` writable layer; increase it for larger source trees or
+  generated build artifacts.
+- The bundled toolchain needs no outbound network access. Keep
+  `allow_internet_access=False` for untrusted builds that do not download
+  dependencies.
+- `ccache` only speeds repeated compilations when source and compiler inputs
+  are compatible. A base-image, compiler, or build-flag change can legitimately
+  cause misses.
+- The demo is intentionally small. For package managers such as Conan or
+  vcpkg, preinstall dependencies in a derived image or allow only the required
+  registry hosts through CubeEgress.
+
+## References
+
+- [Bring Your Own Image](../../docs/guide/tutorials/bring-your-own-image.md)
+- [Snapshot, Rollback, and Clone](../snapshot-rollback-clone)
+- [Code Sandbox Quickstart](../code-sandbox-quickstart)

--- a/examples/cpp-cmake-sandbox/README_zh.md
+++ b/examples/cpp-cmake-sandbox/README_zh.md
@@ -1,0 +1,105 @@
+# C/C++ CMake 沙箱
+
+[English README](README.md)
+
+这是一个面向隔离 C/C++ 构建的 CubeSandbox 模板。它在
+`cubesandbox-base` 上安装 GCC、CMake、Ninja 和 ccache，并演示暂停和恢复
+后 CMake 构建目录及编译缓存仍然可用。
+
+## 包含内容
+
+```text
+cpp-cmake-sandbox/
+├── Dockerfile            # 可用于 Cube 的构建镜像
+├── sample/               # 最小 CMake 工程和 CTest 用例
+├── build_and_resume.py   # SDK 构建、快照、恢复和重新构建示例
+├── env_utils.py          # 本地 .env 加载和校验
+├── .env.example          # Cube 连接配置
+└── requirements.txt      # 主机侧 SDK 依赖
+```
+
+## 前置条件
+
+- 已部署的 CubeSandbox 和 `cubemastercli`。
+- 构建机上的 Docker，以及 Cube 节点可拉取的镜像仓库。
+- 运行主机侧脚本的机器安装 Python 3.9+。
+
+## 构建模板
+
+```bash
+docker build --platform linux/amd64 \
+  -t <your-registry>/cubesandbox-cpp-cmake:latest \
+  examples/cpp-cmake-sandbox
+docker push <your-registry>/cubesandbox-cpp-cmake:latest
+```
+
+镜像固定使用 `ghcr.io/tencentcloud/cubesandbox-base:2026.16`，因此 `envd`
+已经在 `49983` 端口提供 Cube SDK 所需的命令服务。
+
+## 在 CubeSandbox 中注册
+
+```bash
+cubemastercli tpl create-from-image \
+  --image <your-registry>/cubesandbox-cpp-cmake:latest \
+  --writable-layer-size 2G \
+  --expose-port 49983 \
+  --probe 49983 \
+  --probe-path /health
+
+cubemastercli tpl watch --job-id <job-id>
+```
+
+任务状态变为 `READY` 后，记录输出中的 `template_id`。
+
+## 运行快照缓存示例
+
+```bash
+cd examples/cpp-cmake-sandbox
+cp .env.example .env
+# 设置 E2B_API_URL、E2B_API_KEY 和 CUBE_TEMPLATE_ID。
+pip install -r requirements.txt
+python build_and_resume.py
+```
+
+脚本依次会：
+
+1. 将 `sample/` 复制到沙箱工作区，使用 `cmake -G Ninja` 和 `ccache` 构建。
+2. 执行 CTest 和生成的二进制文件。
+3. 调用 `sandbox.pause()` 保存 MicroVM 状态并释放计算资源。
+4. 使用 `Sandbox.connect(sandbox_id)` 重连，修改一个源文件的时间戳并重新
+   构建。`ccache --show-stats` 会展示保留下来的 CMake 树和
+   `~/.cache/ccache` 编译缓存。
+
+脚本通过 `finally` 清理沙箱，即使构建失败也不会遗留运行中的实例。它不会
+创建持久快照；如需长期保留或从快照批量创建实例，请参考
+[`snapshot-rollback-clone`](../snapshot-rollback-clone) 示例。
+
+## 本地镜像冒烟测试
+
+以下检查不依赖 Cube 集群，只验证镜像中的工具链：
+
+```bash
+docker build -t cubesandbox-cpp-cmake:local .
+docker run --rm cubesandbox-cpp-cmake:local sh -lc \
+  'cp -a /opt/cpp-cmake-sandbox/sample /tmp/demo && \
+   cmake -S /tmp/demo -B /tmp/demo/build -G Ninja \
+     -DCMAKE_CXX_COMPILER_LAUNCHER=ccache && \
+   cmake --build /tmp/demo/build && \
+   ctest --test-dir /tmp/demo/build --output-on-failure'
+```
+
+## 资源和安全说明
+
+- 建议从 `2G` 可写层开始；大型代码库或生成较多构建产物时应提高该数值。
+- 自带工具链无需访问外网。构建不可信代码且无需下载依赖时，应保持
+  `allow_internet_access=False`。
+- 只有源文件和编译器输入兼容时，ccache 才会加速重复编译。基础镜像、编译器
+  或构建参数发生变化时出现缓存未命中是正常现象。
+- 示例保持最小化。使用 Conan 或 vcpkg 时，可在派生镜像中预装依赖，或仅通过
+  CubeEgress 放行必要的仓库主机。
+
+## 参考
+
+- [自带镜像接入](../../docs/zh/guide/tutorials/bring-your-own-image.md)
+- [快照、回滚与克隆](../snapshot-rollback-clone)
+- [代码沙箱快速入门](../code-sandbox-quickstart)

--- a/examples/cpp-cmake-sandbox/build_and_resume.py
+++ b/examples/cpp-cmake-sandbox/build_and_resume.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Build a CMake project, pause it, then resume with ccache preserved."""
+
+from __future__ import annotations
+
+import os
+import sys
+
+from e2b import Sandbox
+
+from env_utils import load_local_dotenv, required
+
+WORKSPACE = "/workspace/cpp-cmake-demo"
+
+FIRST_BUILD = f"""\
+set -eu
+rm -rf {WORKSPACE}
+mkdir -p {WORKSPACE}
+cp -a /opt/cpp-cmake-sandbox/sample/. {WORKSPACE}/
+cd {WORKSPACE}
+ccache --zero-stats || true
+cmake -S . -B build -G Ninja -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+cmake --build build
+ctest --test-dir build --output-on-failure
+./build/cpp-cmake-demo CubeSandbox
+printf 'first build completed\\n' > .snapshot-marker
+printf '\\n--- ccache after first build ---\\n'
+ccache --show-stats
+"""
+
+RESUMED_BUILD = f"""\
+set -eu
+cd {WORKSPACE}
+test -f .snapshot-marker
+touch src/greeting.cpp
+cmake --build build
+ctest --test-dir build --output-on-failure
+./build/cpp-cmake-demo resumed
+printf '\\n--- ccache after resumed build ---\\n'
+ccache --show-stats
+"""
+
+
+def run_checked(sandbox: Sandbox, command: str, label: str) -> str:
+    result = sandbox.commands.run(command, timeout=300)
+    stdout = getattr(result, "stdout", "")
+    stderr = getattr(result, "stderr", "")
+    if stdout:
+        print(stdout, end="" if stdout.endswith("\n") else "\n")
+    if getattr(result, "exit_code", 0) != 0:
+        raise RuntimeError(f"{label} failed (exit {result.exit_code}): {stderr}")
+    return stdout
+
+
+def main() -> int:
+    load_local_dotenv()
+    required("E2B_API_URL")
+    required("E2B_API_KEY")
+    template_id = os.environ.get("CUBE_TEMPLATE_ID") or required("CUBE_TEMPLATE_ID")
+
+    sandbox = Sandbox.create(template=template_id, timeout=1800)
+    sandbox_id = sandbox.sandbox_id
+    try:
+        print(f"Sandbox ready: {sandbox_id}")
+        print("\n=== First build ===")
+        first_output = run_checked(sandbox, FIRST_BUILD, "first build")
+        if "Hello, CubeSandbox!" not in first_output:
+            raise RuntimeError("the first build did not run the expected binary")
+
+        print("\n=== Pause sandbox (snapshot VM state) ===")
+        sandbox.pause()
+
+        print("\n=== Resume sandbox and rebuild ===")
+        sandbox = Sandbox.connect(sandbox_id)
+        resumed_output = run_checked(sandbox, RESUMED_BUILD, "resumed build")
+        if "Hello, resumed!" not in resumed_output:
+            raise RuntimeError("the resumed build did not run the expected binary")
+
+        print("\nSuccess: CMake build directory and ccache survived pause/resume.")
+        return 0
+    finally:
+        sandbox.kill()
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except Exception as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        raise SystemExit(1)

--- a/examples/cpp-cmake-sandbox/env_utils.py
+++ b/examples/cpp-cmake-sandbox/env_utils.py
@@ -1,0 +1,23 @@
+"""Small environment helpers shared by the host-side example scripts."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from dotenv import load_dotenv
+
+
+def load_local_dotenv() -> None:
+    """Load a nearby .env without replacing explicitly exported variables."""
+    for candidate in (Path(__file__).with_name(".env"), Path.cwd() / ".env"):
+        if candidate.is_file():
+            load_dotenv(candidate, override=False)
+            return
+
+
+def required(name: str) -> str:
+    value = os.environ.get(name, "").strip()
+    if not value:
+        raise SystemExit(f"Missing required environment variable: {name}")
+    return value

--- a/examples/cpp-cmake-sandbox/requirements.txt
+++ b/examples/cpp-cmake-sandbox/requirements.txt
@@ -1,0 +1,2 @@
+e2b>=2.4.1
+python-dotenv>=1.0.0

--- a/examples/cpp-cmake-sandbox/sample/CMakeLists.txt
+++ b/examples/cpp-cmake-sandbox/sample/CMakeLists.txt
@@ -1,0 +1,16 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(cpp_cmake_sandbox VERSION 0.1.0 LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+add_library(greeting src/greeting.cpp)
+target_include_directories(greeting PUBLIC include)
+
+add_executable(cpp-cmake-demo src/main.cpp)
+target_link_libraries(cpp-cmake-demo PRIVATE greeting)
+
+enable_testing()
+add_test(NAME greeting COMMAND cpp-cmake-demo CubeSandbox)

--- a/examples/cpp-cmake-sandbox/sample/include/greeting.h
+++ b/examples/cpp-cmake-sandbox/sample/include/greeting.h
@@ -1,0 +1,5 @@
+#pragma once
+
+#include <string>
+
+std::string greeting_for(const std::string& name);

--- a/examples/cpp-cmake-sandbox/sample/src/greeting.cpp
+++ b/examples/cpp-cmake-sandbox/sample/src/greeting.cpp
@@ -1,0 +1,5 @@
+#include "greeting.h"
+
+std::string greeting_for(const std::string& name) {
+    return "Hello, " + name + "!";
+}

--- a/examples/cpp-cmake-sandbox/sample/src/main.cpp
+++ b/examples/cpp-cmake-sandbox/sample/src/main.cpp
@@ -1,0 +1,10 @@
+#include <iostream>
+#include <string>
+
+#include "greeting.h"
+
+int main(int argc, char* argv[]) {
+    const std::string name = argc > 1 ? argv[1] : "world";
+    std::cout << greeting_for(name) << '\n';
+    return 0;
+}


### PR DESCRIPTION
## Summary
- Add a C/C++ sandbox image template with CMake, Ninja, and ccache.
- Include a C++20 CMake/CTest sample plus a pause/resume ccache demonstration script.
- Add English and Chinese READMEs and tutorial index links.

## Validation
- `python -m py_compile build_and_resume.py env_utils.py`
- Docker image build, CMake build, CTest, sample execution, and ccache-hit rebuild all passed locally.
- Live `Sandbox.create`/pause/connect validation requires a configured CubeSandbox environment.

Refs #645

Autonomously-by: Codex:GPT-5