### PR TITLE
fix(one-click): extend network-agent postcheck timeout

### DIFF
--- a/deploy/one-click/scripts/systemd/network-agent-postcheck.sh
+++ b/deploy/one-click/scripts/systemd/network-agent-postcheck.sh
@@ -33,7 +33,7 @@ network_agent_tap_init_num() {
 network_agent_postcheck_timeout() {
   local tap_init_num="$1"
   local base_taps="${NETWORK_AGENT_POSTCHECK_BASE_TAPS:-500}"
-  local base_timeout="${NETWORK_AGENT_POSTCHECK_BASE_TIMEOUT:-60}"
+  local base_timeout="${NETWORK_AGENT_POSTCHECK_BASE_TIMEOUT:-300}"
   local min_timeout="${NETWORK_AGENT_POSTCHECK_MIN_TIMEOUT:-30}"
   local timeout
 


### PR DESCRIPTION
Increase the default network-agent postcheck base timeout from 60s to 300s. This gives cold starts with the default 500 TAP initialization count a larger readiness window, avoiding install-time false negatives on slower environments.

The timeout remains dynamically calculated from tap_init_num, and can still be overridden through NETWORK_AGENT_POSTCHECK_TIMEOUT or NETWORK_AGENT_POSTCHECK_BASE_TIMEOUT.