### PR TITLE
feat: add C/C++ CMake sandbox template

### DIFF
--- a/docs/guide/tutorials/examples.md
+++ b/docs/guide/tutorials/examples.md
@@ -11,6 +11,7 @@ Hands-on examples demonstrating various Cube Sandbox use cases. Each example is 
 | [OpenAI Agents SDK Integration](https://github.com/tencentcloud/CubeSandbox/tree/master/examples/openai-agents-example) | Wire OpenAI Agents SDK's `E2BSandboxClient` to Cube Sandbox. Ships a minimal Shell Agent with Pause/Resume and a full SWE-bench Django debugging agent with streaming + tracing. |
 | [OpenAI Agents + Code Interpreter](https://github.com/tencentcloud/CubeSandbox/tree/master/examples/openai-agents-code-interpreter) | Data-analysis Agent running pandas / matplotlib inside a Cube Sandbox. Provides two variants: generic E2B write+exec and Jupyter-kernel Code Interpreter with cross-turn state and auto image capture. |
 | [cube-bench](https://github.com/tencentcloud/CubeSandbox/tree/master/examples/cube-bench) | CLI benchmark tool written in Go that measures sandbox creation/deletion latency at configurable concurrency levels. Features a real-time TUI dashboard (Bubbletea/Lipgloss), percentile report (P50/P95/P99), and JSON export. |
+| [C/C++ CMake Sandbox](https://github.com/tencentcloud/CubeSandbox/tree/master/examples/cpp-cmake-sandbox) | Build a minimal C++ project with CMake + Ninja inside a MicroVM, and use snapshots to persist and restore the ccache compile cache for fast incremental builds. |
 
 ::: tip
 All examples share the same environment variable conventions (`E2B_API_URL`, `E2B_API_KEY`, `CUBE_TEMPLATE_ID`). See the [Quick Start](../quickstart.md) guide to set up your Cube Sandbox deployment first.

--- a/docs/zh/guide/tutorials/examples.md
+++ b/docs/zh/guide/tutorials/examples.md
@@ -11,6 +11,7 @@
 | [OpenAI Agents SDK 集成](https://github.com/tencentcloud/CubeSandbox/tree/master/examples/openai-agents-example) | 将 OpenAI Agents SDK 的 `E2BSandboxClient` 对接 Cube Sandbox。包含最小 Shell Agent（含 Pause/Resume 演示）以及完整的 SWE-bench Django 调试 Agent（流式输出 + 全链路追踪）。 |
 | [OpenAI Agents + Code Interpreter](https://github.com/tencentcloud/CubeSandbox/tree/master/examples/openai-agents-code-interpreter) | 在 Cube Sandbox 中运行使用 pandas / matplotlib 的数据分析 Agent，提供通用 E2B（write+exec）与 Jupyter kernel（状态跨轮保留、图像自动捕获）两种执行形态。 |
 | [cube-bench](https://github.com/tencentcloud/CubeSandbox/tree/master/examples/cube-bench) | Go 编写的 CLI 压测工具，可在可配置并发数下测量沙箱创建/删除延迟。具备实时 TUI 看板（Bubbletea/Lipgloss）、分位数报告（P50/P95/P99）和 JSON 导出功能。 |
+| [C/C++ CMake 沙箱](https://github.com/tencentcloud/CubeSandbox/tree/master/examples/cpp-cmake-sandbox) | 在 MicroVM 中用 CMake + Ninja 构建最小 C++ 项目，并借助快照持久化并恢复 ccache 编译缓存，实现秒级增量构建。 |
 
 ::: tip
 所有示例共享相同的环境变量约定（`E2B_API_URL`、`E2B_API_KEY`、`CUBE_TEMPLATE_ID`）。请先参考[快速开始](../quickstart.md)指南搭建 Cube Sandbox 环境。

--- a/examples/cpp-cmake-sandbox/.env.example
+++ b/examples/cpp-cmake-sandbox/.env.example
@@ -1,0 +1,26 @@
+# ---------------------------------------------------------------------------
+# 01_build_in_sandbox.py / 02_run_ctest.py — E2B-compatible SDK
+# ---------------------------------------------------------------------------
+
+# Required: Cube API server address
+export E2B_API_URL="http://<your-node-ip>:3000"
+
+# Required: any non-empty value satisfies the E2B SDK check
+export E2B_API_KEY="e2b_000000"
+
+# ---------------------------------------------------------------------------
+# 03_ccache_snapshot.py / 04_ccache_rollback.py — native cubesandbox SDK
+# ---------------------------------------------------------------------------
+
+# Required: Cube API server address (read by the native SDK Config)
+export CUBE_API_URL="http://<your-node-ip>:3000"
+
+# ---------------------------------------------------------------------------
+# Shared by all scripts
+# ---------------------------------------------------------------------------
+
+# Required: template ID obtained from `cubemastercli tpl create-from-image`
+export CUBE_TEMPLATE_ID="<your-template-id>"
+
+# Optional: only needed when using Cube's built-in cube.app mkcert certificate
+export SSL_CERT_FILE="/root/.local/share/mkcert/rootCA.pem"

--- a/examples/cpp-cmake-sandbox/.gitignore
+++ b/examples/cpp-cmake-sandbox/.gitignore
@@ -1,0 +1,8 @@
+.env
+.env.*
+!.env.example
+__pycache__/
+*.pyc
+*.log
+# local build output when trying the project outside a sandbox
+project/build/

--- a/examples/cpp-cmake-sandbox/01_build_in_sandbox.py
+++ b/examples/cpp-cmake-sandbox/01_build_in_sandbox.py
@@ -1,0 +1,39 @@
+# Copyright (c) 2024 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Demo 01 (E2B-compatible SDK): push the C++ project into a sandbox, build it
+# with CMake + Ninja, then run the resulting executable.
+
+import os
+
+from e2b_code_interpreter import Sandbox
+
+from env_utils import load_local_dotenv
+from seed import SANDBOX_PROJECT_DIR, push_project
+
+load_local_dotenv()
+
+template_id = os.environ["CUBE_TEMPLATE_ID"]
+
+BUILD_CMD = (
+    f"cd {SANDBOX_PROJECT_DIR} "
+    "&& cmake -G Ninja -B build -DCMAKE_BUILD_TYPE=Release "
+    "&& cmake --build build"
+)
+RUN_CMD = f"{SANDBOX_PROJECT_DIR}/build/app"
+
+with Sandbox.create(template=template_id) as sandbox:
+    written = push_project(sandbox)
+    print(f"pushed {written} project files -> {SANDBOX_PROJECT_DIR}\n")
+
+    print("=== cmake configure + build ===")
+    sandbox.commands.run(
+        BUILD_CMD,
+        timeout=300,
+        on_stdout=lambda line: print(line, end=""),
+        on_stderr=lambda line: print(line, end=""),
+    )
+
+    print("\n=== run ./app ===")
+    result = sandbox.commands.run(RUN_CMD, timeout=60)
+    print(result.stdout.strip())

--- a/examples/cpp-cmake-sandbox/02_run_ctest.py
+++ b/examples/cpp-cmake-sandbox/02_run_ctest.py
@@ -1,0 +1,43 @@
+# Copyright (c) 2024 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Demo 02 (E2B-compatible SDK): build the project and run its CTest suite
+# inside the sandbox. A non-zero ctest exit code surfaces as a failed command.
+
+import os
+
+from e2b_code_interpreter import Sandbox
+
+from env_utils import load_local_dotenv
+from seed import SANDBOX_PROJECT_DIR, push_project
+
+load_local_dotenv()
+
+template_id = os.environ["CUBE_TEMPLATE_ID"]
+
+BUILD_CMD = (
+    f"cd {SANDBOX_PROJECT_DIR} "
+    "&& cmake -G Ninja -B build -DCMAKE_BUILD_TYPE=Release "
+    "&& cmake --build build"
+)
+TEST_CMD = f"cd {SANDBOX_PROJECT_DIR}/build && ctest --output-on-failure"
+
+with Sandbox.create(template=template_id) as sandbox:
+    written = push_project(sandbox)
+    print(f"pushed {written} project files -> {SANDBOX_PROJECT_DIR}\n")
+
+    print("=== build ===")
+    sandbox.commands.run(
+        BUILD_CMD,
+        timeout=300,
+        on_stdout=lambda line: print(line, end=""),
+        on_stderr=lambda line: print(line, end=""),
+    )
+
+    print("\n=== ctest ===")
+    sandbox.commands.run(
+        TEST_CMD,
+        timeout=120,
+        on_stdout=lambda line: print(line, end=""),
+        on_stderr=lambda line: print(line, end=""),
+    )

--- a/examples/cpp-cmake-sandbox/03_ccache_snapshot.py
+++ b/examples/cpp-cmake-sandbox/03_ccache_snapshot.py
@@ -1,0 +1,91 @@
+# Copyright (c) 2024 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Demo 03 (native cubesandbox SDK): the differentiated capability.
+#
+#   1. First build from scratch — ccache is cold, everything compiles.
+#   2. create_snapshot() — captures the filesystem, INCLUDING the ccache
+#      directory at /workspace/.ccache.
+#   3. Spawn a fresh sandbox from that snapshot (template=snapshot_id).
+#      It inherits the warm ccache.
+#   4. Wipe the build dir and rebuild — ccache hits turn a cold recompile into
+#      a near-instant incremental build.
+#
+# The script prints both timings and the speedup factor so the win is obvious.
+
+import time
+
+from cubesandbox import Sandbox
+
+from env import TEMPLATE_ID
+from seed import SANDBOX_PROJECT_DIR, push_project
+
+BUILD_CMD = (
+    f"cd {SANDBOX_PROJECT_DIR} "
+    "&& cmake -G Ninja -B build -DCMAKE_BUILD_TYPE=Release "
+    "&& cmake --build build"
+)
+
+
+def run(sb, cmd, *, timeout=300):
+    """Run a command, echo its output, and raise on a non-zero exit code."""
+    result = sb.commands.run(cmd, timeout=timeout)
+    if result.stdout:
+        print(result.stdout, end="" if result.stdout.endswith("\n") else "\n")
+    if result.exit_code != 0:
+        print(result.stderr)
+        raise SystemExit(f"command failed (exit={result.exit_code}): {cmd}")
+    return result
+
+
+def timed_build(sb) -> float:
+    """Run a clean-config build and return wall-clock seconds."""
+    start = time.perf_counter()
+    run(sb, BUILD_CMD)
+    return time.perf_counter() - start
+
+
+snapshot_id = None
+clone = None
+
+sb = Sandbox.create(template=TEMPLATE_ID)
+try:
+    print(f"sandbox: {sb.sandbox_id}")
+    push_project(sb)
+
+    # 1) Cold build — populate the compile cache.
+    run(sb, "ccache --zero-stats")
+    first_build = timed_build(sb)
+    print(f"\n[cold]  first build: {first_build:.2f}s")
+    print(run(sb, "ccache --show-stats --verbose", timeout=60).stdout)
+
+    # 2) Snapshot — the ccache under /workspace/.ccache travels with it.
+    snapshot = sb.create_snapshot()
+    snapshot_id = snapshot.snapshot_id
+    print(f"snapshot created: {snapshot_id}")
+finally:
+    sb.kill()
+
+# 3) Fresh sandbox from the snapshot — inherits the warm ccache.
+clone = Sandbox.create(template=snapshot_id)
+try:
+    print(f"\nclone from snapshot: {clone.sandbox_id}")
+
+    # 4) Force a full recompile: drop build artifacts, keep the ccache.
+    run(clone, f"rm -rf {SANDBOX_PROJECT_DIR}/build")
+    run(clone, "ccache --zero-stats")
+    second_build = timed_build(clone)
+    print(f"\n[warm]  incremental build after snapshot: {second_build:.2f}s")
+    print(run(clone, "ccache --show-stats --verbose", timeout=60).stdout)
+
+    speedup = first_build / second_build if second_build > 0 else float("inf")
+    print("=" * 48)
+    print(f"first build (cold ccache):   {first_build:6.2f}s")
+    print(f"rebuild after snapshot:      {second_build:6.2f}s")
+    print(f"speedup:                     {speedup:6.1f}x")
+    print("=" * 48)
+finally:
+    clone.kill()
+    if snapshot_id:
+        Sandbox.delete_snapshot(snapshot_id)
+        print(f"snapshot deleted: {snapshot_id}")

--- a/examples/cpp-cmake-sandbox/04_ccache_rollback.py
+++ b/examples/cpp-cmake-sandbox/04_ccache_rollback.py
@@ -1,0 +1,73 @@
+# Copyright (c) 2024 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Demo 04 (native cubesandbox SDK): in-place rollback to a warm-cache snapshot.
+#
+# Unlike 03 (which clones a NEW sandbox from the snapshot), this rolls the SAME
+# sandbox back to the moment the compile cache was warm — then shows a rebuild
+# hitting the cache. Handy for "reset my workspace but keep my build cache"
+# and long-running / checkpoint-resume workflows.
+
+import time
+
+from cubesandbox import Sandbox
+
+from env import TEMPLATE_ID
+from seed import SANDBOX_PROJECT_DIR, push_project
+
+BUILD_CMD = (
+    f"cd {SANDBOX_PROJECT_DIR} "
+    "&& cmake -G Ninja -B build -DCMAKE_BUILD_TYPE=Release "
+    "&& cmake --build build"
+)
+
+
+def run(sb, cmd, *, timeout=300):
+    """Run a command, echo its output, and raise on a non-zero exit code."""
+    result = sb.commands.run(cmd, timeout=timeout)
+    if result.stdout:
+        print(result.stdout, end="" if result.stdout.endswith("\n") else "\n")
+    if result.exit_code != 0:
+        print(result.stderr)
+        raise SystemExit(f"command failed (exit={result.exit_code}): {cmd}")
+    return result
+
+
+snapshot_id = None
+
+sb = Sandbox.create(template=TEMPLATE_ID)
+try:
+    print(f"sandbox: {sb.sandbox_id}")
+    push_project(sb)
+
+    # Warm the cache with one full build, then snapshot this state.
+    run(sb, "ccache --zero-stats")
+    run(sb, BUILD_CMD)
+    snapshot = sb.create_snapshot()
+    snapshot_id = snapshot.snapshot_id
+    print(f"snapshot (warm cache) created: {snapshot_id}")
+
+    # Simulate a dirty / broken workspace after the snapshot.
+    run(sb, f"rm -rf {SANDBOX_PROJECT_DIR}/build")
+    run(sb, f"rm -rf {SANDBOX_PROJECT_DIR}/src")
+    print("workspace mutated (build/ and src/ removed)")
+
+    # Roll the SAME sandbox back to the warm-cache snapshot.
+    sb.rollback(snapshot_id)
+    print("rolled back to warm-cache snapshot")
+
+    # Rebuild after rollback: sources are back and ccache is warm -> cache hits.
+    run(sb, f"rm -rf {SANDBOX_PROJECT_DIR}/build")
+    run(sb, "ccache --zero-stats")
+    start = time.perf_counter()
+    run(sb, BUILD_CMD)
+    elapsed = time.perf_counter() - start
+    print(f"\nrebuild after rollback: {elapsed:.2f}s")
+
+    print("\n=== ccache stats (expect cache hits > 0) ===")
+    print(run(sb, "ccache --show-stats --verbose", timeout=60).stdout)
+finally:
+    sb.kill()
+    if snapshot_id:
+        Sandbox.delete_snapshot(snapshot_id)
+        print(f"snapshot deleted: {snapshot_id}")

--- a/examples/cpp-cmake-sandbox/Dockerfile
+++ b/examples/cpp-cmake-sandbox/Dockerfile
@@ -1,0 +1,64 @@
+# syntax=docker/dockerfile:1.7
+#
+# C/C++ development template for CubeSandbox.
+#
+# Installs a complete C/C++ toolchain (gcc/g++/clang, CMake, Ninja, ccache,
+# gdb) on top of the official CubeSandbox base image. The inherited
+# cube-entrypoint keeps envd running on :49983 so Cube can use the standard
+# readiness probe without any extra wiring.
+#
+# The compile cache (ccache) lives under /workspace/.ccache — a world-writable
+# path inside the sandbox filesystem — so it is captured by snapshots and can
+# be restored into a fresh sandbox for fast incremental builds.
+#
+# Build:
+#   docker build -t cubesandbox-cpp-cmake:latest examples/cpp-cmake-sandbox
+#
+# Register as a Cube template:
+#   cubemastercli tpl create-from-image \
+#     --image <your-registry>/cubesandbox-cpp-cmake:latest \
+#     --writable-layer-size 4G \
+#     --expose-port 49983 \
+#     --probe       49983 \
+#     --probe-path  /health
+
+ARG CUBE_BASE_IMAGE=ghcr.io/tencentcloud/cubesandbox-base:2026.16
+FROM ${CUBE_BASE_IMAGE}
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+# C/C++ toolchain: compilers + CMake + Ninja + ccache + debugger.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        build-essential \
+        gcc \
+        g++ \
+        clang \
+        cmake \
+        ninja-build \
+        ccache \
+        gdb \
+        make \
+        pkg-config \
+        git \
+        ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+# Route every CMake compile through ccache. CCACHE_DIR points at a path in the
+# sandbox filesystem (not root's home) so it survives snapshot/rollback and is
+# writable regardless of which envd user (root or uid=1000 "user") runs builds.
+ENV CCACHE_DIR=/workspace/.ccache \
+    CMAKE_GENERATOR=Ninja \
+    CMAKE_C_COMPILER_LAUNCHER=ccache \
+    CMAKE_CXX_COMPILER_LAUNCHER=ccache
+
+RUN mkdir -p /workspace/.ccache \
+    && chmod -R 777 /workspace \
+    && ccache --max-size=2G \
+    && cmake --version \
+    && ninja --version \
+    && ccache --version
+
+WORKDIR /workspace
+
+EXPOSE 49983

--- a/examples/cpp-cmake-sandbox/README.md
+++ b/examples/cpp-cmake-sandbox/README.md
@@ -1,0 +1,160 @@
+# C/C++ CMake Sandbox
+
+[中文文档](README_zh.md)
+
+A ready-to-use **C/C++ development template** for Cube Sandbox: build a minimal
+C++17 project with **CMake + Ninja** inside an isolated MicroVM, and use
+**snapshots to persist and restore the `ccache` compile cache** for fast
+incremental builds.
+
+This template is intentionally independent of the Node / Python / Go / Rust /
+Java templates and focuses on the C/C++ toolchain.
+
+## 1. What you get
+
+| File | Purpose |
+|------|---------|
+| `Dockerfile` | C/C++ dev image on `cubesandbox-base` (gcc/g++/clang, CMake, Ninja, ccache, gdb) |
+| `project/` | Minimal C++17 project: a `greeter` static lib, an `app` executable, and a CTest test — **zero third-party dependencies** |
+| `01_build_in_sandbox.py` | E2B SDK: push the project, build with CMake+Ninja, run `./app` |
+| `02_run_ctest.py` | E2B SDK: build and run the CTest suite |
+| `03_ccache_snapshot.py` | Native SDK: cold build → snapshot (with ccache) → clone → warm incremental build, with timings + speedup |
+| `04_ccache_rollback.py` | Native SDK: warm-cache snapshot → mutate workspace → `rollback()` → rebuild hits the cache |
+
+> **Two SDKs on purpose.** `01`/`02` use the E2B-compatible SDK
+> (`e2b_code_interpreter`) to mirror the [Code Sandbox Quickstart](../code-sandbox-quickstart).
+> `03`/`04` use the native `cubesandbox` SDK because its snapshot / rollback API
+> is more direct. See [Environment variables](#4-environment-variables).
+
+## 2. When to use this template
+
+- C/C++ CI: compile and test a project in a clean, isolated environment.
+- Incremental-build acceleration: warm a `ccache`, snapshot it, and fan out or
+  resume builds that hit the cache instead of recompiling from scratch.
+- Checkpoint / resume long builds via snapshot + rollback.
+
+**Resource suggestion:** `--writable-layer-size 4G` (C/C++ artifacts + ccache
+are larger than scripting-language templates), ccache capped at 2G.
+
+**Known limitations:** linux/amd64 only; no third-party package manager
+(vcpkg / Conan) is wired in — the sample project is dependency-free by design.
+
+## 3. Quick start
+
+### Step 1 — Build the image and register a template
+
+```bash
+# Build locally (run from the repository root)
+docker build -t cubesandbox-cpp-cmake:latest examples/cpp-cmake-sandbox
+
+# Optional local sanity check: envd readiness probe should return 204
+docker run --rm -d -p 49983:49983 --name cube-cpp cubesandbox-cpp-cmake:latest
+curl -s -o /dev/null -w "envd /health => %{http_code}\n" http://127.0.0.1:49983/health
+docker rm -f cube-cpp
+
+# Push to your registry, then register as a Cube template
+cubemastercli tpl create-from-image \
+    --image <your-registry>/cubesandbox-cpp-cmake:latest \
+    --writable-layer-size 4G \
+    --expose-port 49983 \
+    --probe       49983 \
+    --probe-path  /health
+```
+
+Note the `template_id` printed on success.
+
+### Step 2 — Install dependencies and configure the environment
+
+```bash
+pip install -r requirements.txt
+
+cp .env.example .env
+# edit .env and fill in the values below
+```
+
+### Step 3 — Run the demos
+
+```bash
+# E2B SDK: build + run
+python 01_build_in_sandbox.py
+
+# E2B SDK: build + ctest
+python 02_run_ctest.py
+
+# Native SDK: ccache persistence via snapshot + clone (the highlight)
+python 03_ccache_snapshot.py
+
+# Native SDK: in-place rollback to a warm-cache snapshot
+python 04_ccache_rollback.py
+```
+
+Expected highlights:
+
+- `01` prints `Hello, CubeSandbox!`
+- `02` prints `100% tests passed`
+- `03` prints a `first build` vs `rebuild after snapshot` comparison and a
+  `speedup: Nx` line
+- `04` prints `ccache` stats showing cache hits > 0 after rollback
+
+## 4. Environment variables
+
+| Variable | Used by | Meaning |
+|----------|---------|---------|
+| `E2B_API_URL` | `01`, `02` | Cube API address, e.g. `http://<node-ip>:3000` |
+| `E2B_API_KEY` | `01`, `02` | Any non-empty value satisfies the E2B SDK |
+| `CUBE_API_URL` | `03`, `04` | Cube API address (read by the native SDK `Config`) |
+| `CUBE_TEMPLATE_ID` | all | Template ID from `create-from-image` |
+| `SSL_CERT_FILE` | optional | Root CA path when CubeAPI is served over HTTPS |
+
+## 5. Try the project locally (optional)
+
+The `project/` tree is a normal CMake project, so you can verify it on any
+machine with a C++ toolchain before pushing it into a sandbox:
+
+```bash
+cd project
+cmake -G Ninja -B build -DCMAKE_BUILD_TYPE=Release
+cmake --build build
+./build/app                 # -> Hello, CubeSandbox!
+ctest --test-dir build --output-on-failure
+```
+
+## 6. Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---------|-------------|-----|
+| `SSL: CERTIFICATE_VERIFY_FAILED` | HTTPS without CA cert | Set `SSL_CERT_FILE=/root/.local/share/mkcert/rootCA.pem` |
+| `Template not found` | Wrong template ID | Re-run `cubemastercli tpl list` |
+| `Connection refused` | CubeAPI not reachable | Check `E2B_API_URL` / `CUBE_API_URL` and port 3000 |
+| Build times out | Default command timeout too low | The scripts already pass `timeout=300`; raise it if needed |
+| `speedup` close to `1x` | Cache not reused | Confirm `CCACHE_DIR=/workspace/.ccache` (set in the Dockerfile) is inside the snapshot |
+
+## 7. Directory structure
+
+```
+cpp-cmake-sandbox/
+├── README.md                 # English documentation (this file)
+├── README_zh.md              # Chinese documentation
+├── Dockerfile                # C/C++ dev image on cubesandbox-base
+├── requirements.txt          # Python dependencies (both SDKs)
+├── .env.example              # Environment variable template
+├── env_utils.py              # Shared .env loader (E2B scripts)
+├── env.py                    # TEMPLATE_ID helper (native scripts)
+├── seed.py                   # Pushes project/ into a sandbox
+├── project/                  # Minimal C++17 CMake project
+│   ├── CMakeLists.txt
+│   ├── include/greeter.hpp
+│   ├── src/greeter.cpp
+│   ├── src/main.cpp
+│   └── tests/test_greeter.cpp
+├── 01_build_in_sandbox.py    # E2B: build + run
+├── 02_run_ctest.py           # E2B: build + ctest
+├── 03_ccache_snapshot.py     # Native: snapshot-persisted ccache + clone
+└── 04_ccache_rollback.py     # Native: rollback to a warm-cache snapshot
+```
+
+## 8. See also
+
+- [Bring Your Own Image (envd)](../../docs/guide/tutorials/bring-your-own-image.md)
+- [Snapshot · Rollback · Clone](../snapshot-rollback-clone) — native SDK snapshot APIs
+- [Code Sandbox Quickstart](../code-sandbox-quickstart) — the basic E2B flow

--- a/examples/cpp-cmake-sandbox/README_zh.md
+++ b/examples/cpp-cmake-sandbox/README_zh.md
@@ -1,0 +1,156 @@
+# C/C++ CMake 沙箱
+
+[English](README.md)
+
+一个开箱即用的 Cube Sandbox **C/C++ 开发模板**：在隔离的 MicroVM 中用
+**CMake + Ninja** 构建一个最小 C++17 项目，并借助**快照持久化并恢复 `ccache`
+编译缓存**，实现秒级增量构建。
+
+本模板与 Node / Python / Go / Rust / Java 模板相互独立，专注 C/C++ 工具链。
+
+## 1. 内容一览
+
+| 文件 | 作用 |
+|------|------|
+| `Dockerfile` | 基于 `cubesandbox-base` 的 C/C++ 开发镜像（gcc/g++/clang、CMake、Ninja、ccache、gdb） |
+| `project/` | 最小 C++17 项目：`greeter` 静态库 + `app` 可执行文件 + 一个 CTest 用例，**零第三方依赖** |
+| `01_build_in_sandbox.py` | E2B SDK：推送项目 → CMake+Ninja 构建 → 运行 `./app` |
+| `02_run_ctest.py` | E2B SDK：构建并运行 CTest 测试 |
+| `03_ccache_snapshot.py` | 原生 SDK：冷构建 → 快照（含 ccache）→ 克隆 → 热增量构建，输出耗时与加速倍数 |
+| `04_ccache_rollback.py` | 原生 SDK：热缓存快照 → 破坏工作区 → `rollback()` → 重建命中缓存 |
+
+> **刻意使用两套 SDK。** `01`/`02` 使用 E2B 兼容 SDK（`e2b_code_interpreter`），
+> 与[代码沙箱快速入门](../code-sandbox-quickstart)保持一致；`03`/`04` 使用原生
+> `cubesandbox` SDK，因为其快照 / 回滚 API 更直接。见[环境变量](#4-环境变量)。
+
+## 2. 适用场景
+
+- C/C++ CI：在干净隔离的环境中编译并测试项目。
+- 增量构建加速：预热 `ccache` 后打快照，克隆或恢复出来的沙箱直接命中缓存，
+  无需从零重编。
+- 长时构建的断点续跑：通过快照 + 回滚实现 checkpoint / resume。
+
+**资源建议：** `--writable-layer-size 4G`（C/C++ 产物 + ccache 比脚本语言模板更大），
+ccache 上限设为 2G。
+
+**已知限制：** 仅支持 linux/amd64；未接入第三方包管理器（vcpkg / Conan）——
+示例项目刻意做到零依赖。
+
+## 3. 快速开始
+
+### 步骤 1 — 构建镜像并注册模板
+
+```bash
+# 本地构建（在仓库根目录执行）
+docker build -t cubesandbox-cpp-cmake:latest examples/cpp-cmake-sandbox
+
+# 可选的本地自检：envd 就绪探针应返回 204
+docker run --rm -d -p 49983:49983 --name cube-cpp cubesandbox-cpp-cmake:latest
+curl -s -o /dev/null -w "envd /health => %{http_code}\n" http://127.0.0.1:49983/health
+docker rm -f cube-cpp
+
+# 推送到你的镜像仓库，然后注册为 Cube 模板
+cubemastercli tpl create-from-image \
+    --image <your-registry>/cubesandbox-cpp-cmake:latest \
+    --writable-layer-size 4G \
+    --expose-port 49983 \
+    --probe       49983 \
+    --probe-path  /health
+```
+
+记下成功后打印的 `template_id`。
+
+### 步骤 2 — 安装依赖并配置环境
+
+```bash
+pip install -r requirements.txt
+
+cp .env.example .env
+# 编辑 .env，填入下方变量
+```
+
+### 步骤 3 — 运行示例
+
+```bash
+# E2B SDK：构建 + 运行
+python 01_build_in_sandbox.py
+
+# E2B SDK：构建 + ctest
+python 02_run_ctest.py
+
+# 原生 SDK：通过快照 + 克隆持久化 ccache（核心亮点）
+python 03_ccache_snapshot.py
+
+# 原生 SDK：原地回滚到热缓存快照
+python 04_ccache_rollback.py
+```
+
+预期亮点：
+
+- `01` 打印 `Hello, CubeSandbox!`
+- `02` 打印 `100% tests passed`
+- `03` 打印 `first build` 与 `rebuild after snapshot` 的耗时对比，以及一行
+  `speedup: Nx`
+- `04` 回滚后 `ccache` 统计显示缓存命中数 > 0
+
+## 4. 环境变量
+
+| 变量 | 使用脚本 | 含义 |
+|------|----------|------|
+| `E2B_API_URL` | `01`、`02` | Cube API 地址，如 `http://<node-ip>:3000` |
+| `E2B_API_KEY` | `01`、`02` | 任意非空值即可满足 E2B SDK 校验 |
+| `CUBE_API_URL` | `03`、`04` | Cube API 地址（由原生 SDK 的 `Config` 读取） |
+| `CUBE_TEMPLATE_ID` | 全部 | `create-from-image` 得到的模板 ID |
+| `SSL_CERT_FILE` | 可选 | CubeAPI 走 HTTPS 时的根证书路径 |
+
+## 5. 本地试跑项目（可选）
+
+`project/` 是标准 CMake 项目，推送进沙箱前可在任意带 C++ 工具链的机器上先验证：
+
+```bash
+cd project
+cmake -G Ninja -B build -DCMAKE_BUILD_TYPE=Release
+cmake --build build
+./build/app                 # -> Hello, CubeSandbox!
+ctest --test-dir build --output-on-failure
+```
+
+## 6. 故障排查
+
+| 现象 | 可能原因 | 解决方法 |
+|------|----------|----------|
+| `SSL: CERTIFICATE_VERIFY_FAILED` | HTTPS 缺少 CA 证书 | 设置 `SSL_CERT_FILE=/root/.local/share/mkcert/rootCA.pem` |
+| `Template not found` | 模板 ID 错误 | 重新执行 `cubemastercli tpl list` |
+| `Connection refused` | 无法连到 CubeAPI | 检查 `E2B_API_URL` / `CUBE_API_URL` 及 3000 端口 |
+| 构建超时 | 默认命令超时太短 | 脚本已传 `timeout=300`，需要时再调大 |
+| `speedup` 接近 `1x` | 缓存未复用 | 确认 Dockerfile 中的 `CCACHE_DIR=/workspace/.ccache` 已包含在快照内 |
+
+## 7. 目录结构
+
+```
+cpp-cmake-sandbox/
+├── README.md                 # 英文文档
+├── README_zh.md              # 中文文档（本文件）
+├── Dockerfile                # 基于 cubesandbox-base 的 C/C++ 开发镜像
+├── requirements.txt          # Python 依赖（两套 SDK）
+├── .env.example              # 环境变量模板
+├── env_utils.py              # 共享 .env 加载器（E2B 脚本）
+├── env.py                    # TEMPLATE_ID 辅助（原生脚本）
+├── seed.py                   # 将 project/ 推入沙箱
+├── project/                  # 最小 C++17 CMake 项目
+│   ├── CMakeLists.txt
+│   ├── include/greeter.hpp
+│   ├── src/greeter.cpp
+│   ├── src/main.cpp
+│   └── tests/test_greeter.cpp
+├── 01_build_in_sandbox.py    # E2B：构建 + 运行
+├── 02_run_ctest.py           # E2B：构建 + ctest
+├── 03_ccache_snapshot.py     # 原生：快照持久化 ccache + 克隆
+└── 04_ccache_rollback.py     # 原生：回滚到热缓存快照
+```
+
+## 8. 相关链接
+
+- [使用自定义镜像（envd）](../../docs/guide/tutorials/bring-your-own-image.md)
+- [快照 · 回滚 · 克隆](../snapshot-rollback-clone) —— 原生 SDK 快照 API
+- [代码沙箱快速入门](../code-sandbox-quickstart) —— 基础 E2B 流程

--- a/examples/cpp-cmake-sandbox/env.py
+++ b/examples/cpp-cmake-sandbox/env.py
@@ -1,0 +1,28 @@
+# Copyright (c) 2024 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Shared environment helper for the native `cubesandbox` SDK demos
+# (03_ccache_snapshot.py, 04_ccache_rollback.py).
+#
+# Required env vars:
+#   CUBE_API_URL       e.g. http://127.0.0.1:3000   (read by the SDK Config)
+#   CUBE_TEMPLATE_ID   e.g. tpl-aa14fc963b9c443aaff65b17
+#                      Look one up with `cubemastercli tpl list`.
+# Optional:
+#   SSL_CERT_FILE      path to your cluster's root CA when CubeAPI is HTTPS
+
+import os
+import sys
+
+from env_utils import load_local_dotenv
+
+load_local_dotenv()
+
+TEMPLATE_ID = os.environ.get("CUBE_TEMPLATE_ID")
+
+if not TEMPLATE_ID:
+    sys.stderr.write(
+        "ERROR: CUBE_TEMPLATE_ID is not set.\n"
+        "  Look one up with: cubemastercli tpl list | awk 'NR>1 && $1 ~ /^tpl-/{print $1; exit}'\n"
+    )
+    sys.exit(2)

--- a/examples/cpp-cmake-sandbox/env_utils.py
+++ b/examples/cpp-cmake-sandbox/env_utils.py
@@ -1,0 +1,25 @@
+# Copyright (c) 2024 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+from pathlib import Path
+
+from dotenv import load_dotenv
+
+
+def load_local_dotenv() -> None:
+    """Best-effort load of a nearby .env file without overriding real env vars."""
+    candidate_paths = [
+        Path(__file__).with_name(".env"),
+        Path.cwd() / ".env",
+    ]
+
+    seen_paths = set()
+    for path in candidate_paths:
+        resolved_path = path.resolve()
+        if resolved_path in seen_paths:
+            continue
+        seen_paths.add(resolved_path)
+
+        if path.is_file():
+            load_dotenv(dotenv_path=path, override=False)
+            return

--- a/examples/cpp-cmake-sandbox/project/CMakeLists.txt
+++ b/examples/cpp-cmake-sandbox/project/CMakeLists.txt
@@ -1,0 +1,25 @@
+cmake_minimum_required(VERSION 3.16)
+
+project(cube_greeter LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+if(NOT CMAKE_BUILD_TYPE)
+    set(CMAKE_BUILD_TYPE Release)
+endif()
+
+# Static library under test — zero third-party dependencies.
+add_library(greeter STATIC src/greeter.cpp)
+target_include_directories(greeter PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
+
+# Demo executable that prints a greeting.
+add_executable(app src/main.cpp)
+target_link_libraries(app PRIVATE greeter)
+
+# CTest wiring — a single self-contained assertion binary, no GoogleTest.
+enable_testing()
+add_executable(test_greeter tests/test_greeter.cpp)
+target_link_libraries(test_greeter PRIVATE greeter)
+add_test(NAME greeter_returns_expected_message COMMAND test_greeter)

--- a/examples/cpp-cmake-sandbox/project/include/greeter.hpp
+++ b/examples/cpp-cmake-sandbox/project/include/greeter.hpp
@@ -1,0 +1,16 @@
+// Copyright (c) 2024 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef CUBE_GREETER_HPP
+#define CUBE_GREETER_HPP
+
+#include <string>
+
+namespace cube {
+
+// Returns a greeting of the form "Hello, <name>!".
+std::string greet(const std::string& name);
+
+}  // namespace cube
+
+#endif  // CUBE_GREETER_HPP

--- a/examples/cpp-cmake-sandbox/project/src/greeter.cpp
+++ b/examples/cpp-cmake-sandbox/project/src/greeter.cpp
@@ -1,0 +1,12 @@
+// Copyright (c) 2024 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "greeter.hpp"
+
+namespace cube {
+
+std::string greet(const std::string& name) {
+    return "Hello, " + name + "!";
+}
+
+}  // namespace cube

--- a/examples/cpp-cmake-sandbox/project/src/main.cpp
+++ b/examples/cpp-cmake-sandbox/project/src/main.cpp
@@ -1,0 +1,11 @@
+// Copyright (c) 2024 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <iostream>
+
+#include "greeter.hpp"
+
+int main() {
+    std::cout << cube::greet("CubeSandbox") << std::endl;
+    return 0;
+}

--- a/examples/cpp-cmake-sandbox/project/tests/test_greeter.cpp
+++ b/examples/cpp-cmake-sandbox/project/tests/test_greeter.cpp
@@ -1,0 +1,34 @@
+// Copyright (c) 2024 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Minimal CTest test: no GoogleTest, just plain assertions. A non-zero exit
+// code marks the test as failed, so anyone can run `ctest` offline.
+
+#include <iostream>
+#include <string>
+
+#include "greeter.hpp"
+
+int main() {
+    int failures = 0;
+
+    const std::string actual = cube::greet("Cube");
+    const std::string expected = "Hello, Cube!";
+    if (actual != expected) {
+        std::cerr << "FAIL: greet(\"Cube\") == \"" << actual
+                  << "\", expected \"" << expected << "\"" << std::endl;
+        ++failures;
+    }
+
+    if (cube::greet("").empty()) {
+        std::cerr << "FAIL: greet(\"\") should not be empty" << std::endl;
+        ++failures;
+    }
+
+    if (failures == 0) {
+        std::cout << "OK: all greeter assertions passed" << std::endl;
+        return 0;
+    }
+    std::cerr << failures << " assertion(s) failed" << std::endl;
+    return 1;
+}

--- a/examples/cpp-cmake-sandbox/requirements.txt
+++ b/examples/cpp-cmake-sandbox/requirements.txt
@@ -1,0 +1,5 @@
+# 01_build_in_sandbox.py / 02_run_ctest.py use the E2B-compatible SDK
+e2b-code-interpreter>=2.4.1
+# 03_ccache_snapshot.py / 04_ccache_rollback.py use the native CubeSandbox SDK
+cubesandbox>=0.2.0
+python-dotenv

--- a/examples/cpp-cmake-sandbox/seed.py
+++ b/examples/cpp-cmake-sandbox/seed.py
@@ -1,0 +1,36 @@
+# Copyright (c) 2024 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Shared helper that pushes the local `project/` tree into a sandbox.
+#
+# Works with both the E2B-compatible SDK (e2b_code_interpreter.Sandbox) and the
+# native cubesandbox SDK, since both expose the same `sandbox.files.write(path,
+# data)` method.
+
+from pathlib import Path
+from typing import Iterator, Tuple
+
+PROJECT_DIR = Path(__file__).with_name("project")
+
+#: Destination directory for the project inside the sandbox.
+SANDBOX_PROJECT_DIR = "/workspace/project"
+
+
+def iter_project_files() -> Iterator[Tuple[str, str]]:
+    """Yield ``(relative_posix_path, text_content)`` for every project file."""
+    for path in sorted(PROJECT_DIR.rglob("*")):
+        if path.is_file():
+            rel = path.relative_to(PROJECT_DIR).as_posix()
+            yield rel, path.read_text(encoding="utf-8")
+
+
+def push_project(sandbox, dest: str = SANDBOX_PROJECT_DIR) -> int:
+    """Copy the whole project into ``dest`` inside the sandbox.
+
+    Returns the number of files written.
+    """
+    count = 0
+    for rel, content in iter_project_files():
+        sandbox.files.write(f"{dest}/{rel}", content)
+        count += 1
+    return count


### PR DESCRIPTION
## What
Added `examples/cpp-cmake-sandbox`: C/C++ development template based on cubesandbox-base (CMake + Ninja + ccache)
- Snapshot + ccache: Incremental compilation hits cache after clone/rollback
- Zero third-party dependencies, ctest runs offline

## Test
- [x] Local CMake build of project/ + ctest
- [x] All 4 scripts pass py_compile
- [x] Cluster environment validation for demos 01~04