### PR TITLE
docs: add End User Program / 核心用户计划 links to navigation bar

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@
   <a href="./docs/guide/quickstart.md"><strong>Quick Start</strong></a> ·
   <a href="./docs/index.md"><strong>Documentation</strong></a> ·
   <a href="./docs/changelog/index.md"><strong>Changelog</strong></a> ·
-  <a href="https://x.com/CubeSandbox_AI"><strong>X(Twitter)</strong></a>
+  <a href="https://x.com/CubeSandbox_AI"><strong>X(Twitter)</strong></a> ·
+  <a href="https://github.com/TencentCloud/CubeSandbox/issues/158"><strong>End User Program</strong></a>
 </p>
 
 ---


### PR DESCRIPTION
## Summary

Add navigation links for both English and Chinese README:

- **English (README.md)**: Added `End User Program` link → https://github.com/TencentCloud/CubeSandbox/issues/158
- **中文 (README_zh.md)**: Added `核心用户计划` link → https://wj.qq.com/s2/26753159/ss16/

Both links are placed after the existing X(Twitter) link in the navigation bar, following the same style.

Closes #158