### PR TITLE
cubemaster(cli): support positional template-id in tpl info/delete/redo

### DIFF
--- a/CubeMaster/cmd/cubemastercli/commands/cubebox/template.go
+++ b/CubeMaster/cmd/cubemastercli/commands/cubebox/template.go
@@ -449,9 +449,23 @@ var TemplateCreateCommand = cli.Command{
 	},
 }
 
+// resolveTemplateID returns the template ID from the --template-id flag,
+// falling back to the first positional argument to match docker/kubectl
+// conventions (e.g. `cubemastercli tpl info <template-id>`).
+func resolveTemplateID(c *cli.Context) string {
+	if id := c.String("template-id"); id != "" {
+		return id
+	}
+	if c.NArg() > 0 {
+		return c.Args().First()
+	}
+	return ""
+}
+
 var TemplateInfoCommand = cli.Command{
-	Name:  "info",
-	Usage: "show template metadata and node replicas",
+	Name:      "info",
+	Usage:     "show template metadata and node replicas",
+	ArgsUsage: "<template-id>",
 	Flags: []cli.Flag{
 		cli.StringFlag{
 			Name:  "template-id",
@@ -467,7 +481,7 @@ var TemplateInfoCommand = cli.Command{
 		},
 	},
 	Action: func(c *cli.Context) error {
-		templateID := c.String("template-id")
+		templateID := resolveTemplateID(c)
 		if templateID == "" {
 			return errors.New("template-id is required")
 		}
@@ -590,8 +604,9 @@ var TemplateRenderCommand = cli.Command{
 }
 
 var TemplateDeleteCommand = cli.Command{
-	Name:  "delete",
-	Usage: "delete template metadata and node replicas",
+	Name:      "delete",
+	Usage:     "delete template metadata and node replicas",
+	ArgsUsage: "<template-id>",
 	Flags: []cli.Flag{
 		cli.StringFlag{
 			Name:  "template-id",
@@ -599,7 +614,7 @@ var TemplateDeleteCommand = cli.Command{
 		},
 	},
 	Action: func(c *cli.Context) error {
-		templateID := c.String("template-id")
+		templateID := resolveTemplateID(c)
 		if templateID == "" {
 			return errors.New("template-id is required")
 		}
@@ -849,8 +864,9 @@ var TemplateCreateFromImageCommand = cli.Command{
 }
 
 var TemplateRedoCommand = cli.Command{
-	Name:  "redo",
-	Usage: "redo a template on all, specific, or failed nodes",
+	Name:      "redo",
+	Usage:     "redo a template on all, specific, or failed nodes",
+	ArgsUsage: "<template-id>",
 	Flags: []cli.Flag{
 		cli.StringFlag{Name: "template-id", Usage: "template id to redo"},
 		cli.StringSliceFlag{Name: "node", Usage: "redo only the specified node id or host ip; repeat to specify multiple nodes"},
@@ -861,7 +877,7 @@ var TemplateRedoCommand = cli.Command{
 		cli.BoolFlag{Name: "json", Usage: "print raw json response"},
 	},
 	Action: func(c *cli.Context) error {
-		templateID := c.String("template-id")
+		templateID := resolveTemplateID(c)
 		if templateID == "" {
 			return errors.New("template-id is required")
 		}

--- a/CubeMaster/cmd/cubemastercli/commands/cubebox/template_test.go
+++ b/CubeMaster/cmd/cubemastercli/commands/cubebox/template_test.go
@@ -460,3 +460,74 @@ func TestResolveTemplateIDEmpty(t *testing.T) {
 		t.Fatalf("got %q, want empty", got)
 	}
 }
+
+// newCmdContext builds a *cli.Context from a command definition and args,
+// used to verify resolveTemplateID works correctly with each command's
+// specific flag set (info, delete, redo).
+func newCmdContext(t *testing.T, cmd cli.Command, args []string) *cli.Context {
+	t.Helper()
+	set := flag.NewFlagSet(cmd.Name, flag.ContinueOnError)
+	for _, cliFlag := range cmd.Flags {
+		cliFlag.Apply(set)
+	}
+	if err := set.Parse(args); err != nil {
+		t.Fatalf("parse args %v: %v", args, err)
+	}
+	ctx := cli.NewContext(nil, set, nil)
+	ctx.Command = cmd
+	return ctx
+}
+
+func TestResolveTemplateIDFromAllTemplateCommands(t *testing.T) {
+	tests := []struct {
+		name string
+		cmd  cli.Command
+		args []string
+		want string
+	}{
+		{
+			name: "info via positional arg",
+			cmd:  TemplateInfoCommand,
+			args: []string{"tpl-info-1"},
+			want: "tpl-info-1",
+		},
+		{
+			name: "delete via positional arg",
+			cmd:  TemplateDeleteCommand,
+			args: []string{"tpl-delete-1"},
+			want: "tpl-delete-1",
+		},
+		{
+			name: "redo via positional arg",
+			cmd:  TemplateRedoCommand,
+			args: []string{"tpl-redo-1"},
+			want: "tpl-redo-1",
+		},
+		{
+			name: "info flag overrides positional",
+			cmd:  TemplateInfoCommand,
+			args: []string{"--template-id", "flag-id", "positional-id"},
+			want: "flag-id",
+		},
+		{
+			name: "delete flag overrides positional",
+			cmd:  TemplateDeleteCommand,
+			args: []string{"--template-id", "flag-id", "positional-id"},
+			want: "flag-id",
+		},
+		{
+			name: "redo flag overrides positional",
+			cmd:  TemplateRedoCommand,
+			args: []string{"--template-id", "flag-id", "positional-id"},
+			want: "flag-id",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := newCmdContext(t, tt.cmd, tt.args)
+			if got := resolveTemplateID(ctx); got != tt.want {
+				t.Fatalf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/CubeMaster/cmd/cubemastercli/commands/cubebox/template_test.go
+++ b/CubeMaster/cmd/cubemastercli/commands/cubebox/template_test.go
@@ -432,3 +432,31 @@ func TestPrintTemplateSummaryIncludesOptionalMetadata(t *testing.T) {
 		t.Fatalf("stdout=%q, missing replica table header", stdout)
 	}
 }
+
+func TestResolveTemplateIDFromFlag(t *testing.T) {
+	ctx := newRedoContext(t, []string{"--template-id", "tpl-1"})
+	if got := resolveTemplateID(ctx); got != "tpl-1" {
+		t.Fatalf("got %q, want tpl-1", got)
+	}
+}
+
+func TestResolveTemplateIDFromPositional(t *testing.T) {
+	ctx := newRedoContext(t, []string{"tpl-1"})
+	if got := resolveTemplateID(ctx); got != "tpl-1" {
+		t.Fatalf("got %q, want tpl-1", got)
+	}
+}
+
+func TestResolveTemplateIDFlagOverridesPositional(t *testing.T) {
+	ctx := newRedoContext(t, []string{"--template-id", "flag-id", "positional-id"})
+	if got := resolveTemplateID(ctx); got != "flag-id" {
+		t.Fatalf("got %q, want flag-id", got)
+	}
+}
+
+func TestResolveTemplateIDEmpty(t *testing.T) {
+	ctx := newRedoContext(t, nil)
+	if got := resolveTemplateID(ctx); got != "" {
+		t.Fatalf("got %q, want empty", got)
+	}
+}

--- a/docs/guide/template-inspection-and-preview.md
+++ b/docs/guide/template-inspection-and-preview.md
@@ -27,19 +27,21 @@ In practice:
 Basic metadata:
 
 ```bash
-cubemastercli tpl info --template-id <template-id>
+cubemastercli tpl info <template-id>
 ```
+
+The template ID can be passed as a positional argument (docker/kubectl style) or with `--template-id`; both forms are equivalent.
 
 Raw JSON output:
 
 ```bash
-cubemastercli tpl info --template-id <template-id> --json
+cubemastercli tpl info <template-id> --json
 ```
 
 Include the stored request body:
 
 ```bash
-cubemastercli tpl info --template-id <template-id> --json --include-request
+cubemastercli tpl info <template-id> --json --include-request
 ```
 
 Typical response shape:
@@ -142,13 +144,13 @@ When you only have a `template_id` and want to understand what sandbox creation 
 1. Check template status and replicas.
 
 ```bash
-cubemastercli tpl info --template-id <template-id>
+cubemastercli tpl info <template-id>
 ```
 
 2. If you need to know what the template itself stores, inspect `create_request`.
 
 ```bash
-cubemastercli tpl info --template-id <template-id> --json --include-request
+cubemastercli tpl info <template-id> --json --include-request
 ```
 
 3. Preview the effective request that would be used right now.

--- a/docs/guide/tutorials/template-from-image.md
+++ b/docs/guide/tutorials/template-from-image.md
@@ -193,19 +193,21 @@ cubemastercli tpl list --json | jq '.data[].template_id'
 ### Inspect a single template
 
 ```bash
-cubemastercli tpl info --template-id tpl-748094d2f2374b0a8a37e6ec
+cubemastercli tpl info tpl-748094d2f2374b0a8a37e6ec
 ```
+
+The template ID can be passed as a positional argument (docker/kubectl style) or with `--template-id`; both forms are equivalent.
 
 Add `--json` for machine-readable output:
 
 ```bash
-cubemastercli tpl info --template-id tpl-748094d2f2374b0a8a37e6ec --json
+cubemastercli tpl info tpl-748094d2f2374b0a8a37e6ec --json
 ```
 
 Add `--include-request` when you want to inspect the stored template request body:
 
 ```bash
-cubemastercli tpl info --template-id tpl-748094d2f2374b0a8a37e6ec --json --include-request
+cubemastercli tpl info tpl-748094d2f2374b0a8a37e6ec --json --include-request
 ```
 
 If you want to preview the effective sandbox payload after template resolution, use:
@@ -221,7 +223,7 @@ For a user-oriented walkthrough of what each output means and how to preview the
 ## Deleting a Template
 
 ```bash
-cubemastercli tpl delete --template-id tpl-748094d2f2374b0a8a37e6ec
+cubemastercli tpl delete tpl-748094d2f2374b0a8a37e6ec
 ```
 
 On success:

--- a/docs/zh/guide/template-inspection-and-preview.md
+++ b/docs/zh/guide/template-inspection-and-preview.md
@@ -27,19 +27,21 @@
 查看基础信息：
 
 ```bash
-cubemastercli tpl info --template-id <template-id>
+cubemastercli tpl info <template-id>
 ```
+
+模板 ID 既可以用位置参数传入（与 docker/kubectl 风格一致），也可以继续使用 `--template-id`，两种写法等价。
 
 查看原始 JSON：
 
 ```bash
-cubemastercli tpl info --template-id <template-id> --json
+cubemastercli tpl info <template-id> --json
 ```
 
 把模板里保存的请求体一并带出来：
 
 ```bash
-cubemastercli tpl info --template-id <template-id> --json --include-request
+cubemastercli tpl info <template-id> --json --include-request
 ```
 
 典型返回结构如下：
@@ -142,13 +144,13 @@ cubemastercli tpl render -f req.json --template-id <template-id> --json
 1. 先看模板状态和副本。
 
 ```bash
-cubemastercli tpl info --template-id <template-id>
+cubemastercli tpl info <template-id>
 ```
 
 2. 如果你想确认模板本身存了什么，再看 `create_request`。
 
 ```bash
-cubemastercli tpl info --template-id <template-id> --json --include-request
+cubemastercli tpl info <template-id> --json --include-request
 ```
 
 3. 再看当前真正会生效的请求预览。

--- a/docs/zh/guide/tutorials/template-build-practice.md
+++ b/docs/zh/guide/tutorials/template-build-practice.md
@@ -608,11 +608,11 @@ print(os.environ['RUNTIME_VAR'])
 cubemastercli tpl list
 cubemastercli tpl list -o wide
 
-# 查看模板详情
-cubemastercli tpl info --template-id <template_id>
+# 查看模板详情（模板 ID 用位置参数传入，等价于 --template-id）
+cubemastercli tpl info <template_id>
 
 # 删除模板
-cubemastercli tpl delete --template-id <template_id>
+cubemastercli tpl delete <template_id>
 
 # 必要环境变量（使用 SDK 时）
 export CUBE_TEMPLATE_ID=<template_id>

--- a/docs/zh/guide/tutorials/template-from-image.md
+++ b/docs/zh/guide/tutorials/template-from-image.md
@@ -175,19 +175,21 @@ cubemastercli tpl list --json | jq '.data[].template_id'
 ### 查看单个模板详情
 
 ```bash
-cubemastercli tpl info --template-id tpl-748094d2f2374b0a8a37e6ec
+cubemastercli tpl info tpl-748094d2f2374b0a8a37e6ec
 ```
+
+模板 ID 既可以用位置参数传入（与 docker/kubectl 风格一致），也可以继续使用 `--template-id`，两种写法等价。
 
 需要机器可读输出时，加上 `--json`：
 
 ```bash
-cubemastercli tpl info --template-id tpl-748094d2f2374b0a8a37e6ec --json
+cubemastercli tpl info tpl-748094d2f2374b0a8a37e6ec --json
 ```
 
 如果想查看模板里保存的创建请求体，可再加 `--include-request`：
 
 ```bash
-cubemastercli tpl info --template-id tpl-748094d2f2374b0a8a37e6ec --json --include-request
+cubemastercli tpl info tpl-748094d2f2374b0a8a37e6ec --json --include-request
 ```
 
 如果想预览创建沙箱时最终生效的请求，可使用：
@@ -203,7 +205,7 @@ cubemastercli tpl render --template-id tpl-748094d2f2374b0a8a37e6ec --json
 ## 删除模板
 
 ```bash
-cubemastercli tpl delete --template-id tpl-748094d2f2374b0a8a37e6ec
+cubemastercli tpl delete tpl-748094d2f2374b0a8a37e6ec
 ```
 
 成功后输出：


### PR DESCRIPTION
## Motivation

The `cubemastercli tpl` subcommands required `--template-id <id>` as a flag for every invocation. This contradicts the docker/kubectl convention where resource identifiers are positional arguments:

```bash
# What users instinctively type (docker/kubectl style):
cubemastercli tpl info tpl-abc123        # ← was rejected with "template-id is required"
cubemastercli tpl delete tpl-abc123
cubemastercli tpl redo tpl-abc123

# What they had to type instead:
cubemastercli tpl info --template-id tpl-abc123
```

This friction is a usability papercut — the codebase already had the correct pattern in `destroy` (positional `<sandbox-id>`) and `create`/`commit` (flag-fallback-to-positional), but the template commands did not follow it.

## Changes

### Code (`cubemaster:`)
- **New `resolveTemplateID(c)` helper** — checks `--template-id` flag first, falls back to the first positional arg (`c.Args().First()`), returns empty if neither is present.
- **`tpl info`** — accepts positional `<template-id>`, added `ArgsUsage`.
- **`tpl delete`** — accepts positional `<template-id>`, added `ArgsUsage`.
- **`tpl redo`** — accepts positional `<template-id>`, added `ArgsUsage`.
- **`tpl render`** — intentionally untouched. Its positional slot is already the file path, so `--template-id` is the correct interface there.

Backward compatibility: `--template-id` flag still works exactly as before and takes priority over the positional arg.

### Docs (`docs:`)
Updated all `tpl info` / `tpl delete` examples in EN + ZH to positional syntax, with backward-compat notes. `tpl render` examples left unchanged.

### Tests
4 unit tests for `resolveTemplateID`: flag-only, positional-only, flag-overrides-positional, empty.

## Verification

**Unit tests:** `go test -run TestResolveTemplateID ./cmd/cubemastercli/commands/cubebox/` → 4/4 PASS. Full package tests pass with no regressions.

**E2E on live PVM cluster** (cubemaster on `0.0.0.0:8089`, real templates):

| Test | Result |
|---|---|
| `tpl info tpl-b394e8e5...` (positional) | ✅ Full metadata + replica table |
| `tpl info --template-id tpl-b394e8e5...` (flag) | ✅ Byte-identical to positional (except ephemeral requestID) |
| `tpl info tpl-b394e8e5... --json --include-request` | ✅ Includes `create_request` |
| `tpl info` (no args) | ✅ `template-id is required` |
| `tpl info tpl-doesnotexist` | ✅ `template not found` |
| `tpl redo tpl-b394e8e5... --detach` (positional) | ✅ Server accepted redo job, returned `job_id` |
| `tpl delete` / `tpl redo` (no args) | ✅ `template-id is required` |
| Help output for all three | ✅ Shows `<template-id>` in USAGE |

Assisted-by: Oh My Pi:zai/glm-5.2