### PR TITLE
feat(node): add node isolation via scheduling-disabled label

### DIFF
--- a/CubeMaster/cmd/cubemastercli/commands/cubebox/node.go
+++ b/CubeMaster/cmd/cubemastercli/commands/cubebox/node.go
@@ -5,12 +5,14 @@
 package cubebox
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"log"
 	"math/rand"
 	"net"
 	"net/http"
+	"net/url"
 	"os"
 	"sort"
 	"text/tabwriter"
@@ -19,6 +21,7 @@ import (
 	"github.com/google/uuid"
 	commands "github.com/tencentcloud/CubeSandbox/CubeMaster/cmd/cubemastercli/commands"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/node"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/nodemeta"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/service/sandbox/types"
 	"github.com/urfave/cli"
 )
@@ -28,12 +31,26 @@ type nodeResponse struct {
 	Data []*node.Node `json:"data,omitempty"`
 }
 
+type nodeMetaResponse struct {
+	Ret  *types.Ret             `json:"ret,omitempty"`
+	Data *nodemeta.NodeSnapshot `json:"data,omitempty"`
+}
+
+var nodeIsolationFlags = []cli.Flag{
+	cli.BoolFlag{
+		Name:  "json",
+		Usage: "print raw json response",
+	},
+}
+
 var NodeCommand = cli.Command{
 	Name:    "node",
 	Aliases: []string{"nodes"},
-	Usage:   "list cubemaster nodes and status",
+	Usage:   "list / isolate / unisolate cubemaster nodes",
 	Subcommands: cli.Commands{
 		NodeListCommand,
+		NodeIsolateCommand,
+		NodeUnisolateCommand,
 	},
 }
 
@@ -97,6 +114,90 @@ var NodeListCommand = cli.Command{
 	},
 }
 
+var NodeIsolateCommand = cli.Command{
+	Name:      "isolate",
+	Usage:     "cordon node(s) (block new sandbox scheduling; existing sandboxes unaffected)",
+	ArgsUsage: "<node-id> [node-id ...]",
+	Flags:     nodeIsolationFlags,
+	Action: func(c *cli.Context) error {
+		return doNodeIsolation(c, http.MethodPut)
+	},
+}
+
+var NodeUnisolateCommand = cli.Command{
+	Name:      "unisolate",
+	Usage:     "remove cordon so the node(s) can receive new sandboxes",
+	ArgsUsage: "<node-id> [node-id ...]",
+	Flags:     nodeIsolationFlags,
+	Action: func(c *cli.Context) error {
+		return doNodeIsolation(c, http.MethodDelete)
+	},
+}
+
+func doNodeIsolation(c *cli.Context, method string) error {
+	if c.NArg() == 0 {
+		cmd := "unisolate"
+		if method == http.MethodPut {
+			cmd = "isolate"
+		}
+		_ = cli.ShowCommandHelp(c, cmd)
+		return errors.New("node id is required")
+	}
+	serverList = getServerAddrs(c)
+	if len(serverList) == 0 {
+		return errors.New("no server addr")
+	}
+	port = c.GlobalString("port")
+
+	var opErr error
+	for _, nodeID := range c.Args() {
+		if err := isolateOneNode(c, method, nodeID); err != nil {
+			log.Printf("%s failed: %s %s\n", isolationAction(method), nodeID, err.Error())
+			opErr = errors.Join(opErr, fmt.Errorf("%s: %w", nodeID, err))
+			continue
+		}
+	}
+	return opErr
+}
+
+func isolationAction(method string) string {
+	if method == http.MethodPut {
+		return "isolated"
+	}
+	return "unisolated"
+}
+
+func isolateOneNode(c *cli.Context, method, nodeID string) error {
+	requestID := uuid.New().String()
+	host := serverList[rand.Int()%len(serverList)]
+	u := &url.URL{
+		Scheme: "http",
+		Host:   net.JoinHostPort(host, port),
+		Path:   "/internal/meta/nodes/" + url.PathEscape(nodeID) + "/isolation",
+	}
+	rsp := &nodeMetaResponse{}
+	if err := doHttpReq(c, u.String(), method, requestID, bytes.NewReader(nil), rsp); err != nil {
+		return err
+	}
+	if rsp.Ret == nil {
+		return errors.New("empty response")
+	}
+	if rsp.Ret.RetCode != 200 {
+		return errors.New(rsp.Ret.RetMsg)
+	}
+	if c.Bool("json") {
+		commands.PrintAsJSON(rsp)
+		return nil
+	}
+	disabled := false
+	if rsp.Data != nil {
+		disabled = rsp.Data.SchedulingDisabled
+		nodeID = rsp.Data.NodeID
+	}
+	fmt.Printf("node %s %s: scheduling_disabled=%t\n", nodeID, isolationAction(method), disabled)
+	return nil
+}
+
 func printNodeSummary(nodes []*node.Node, scoreOnly bool) {
 	w := tabwriter.NewWriter(os.Stdout, 4, 8, 4, ' ', 0)
 	if scoreOnly {
@@ -111,10 +212,11 @@ func printNodeSummary(nodes []*node.Node, scoreOnly bool) {
 		_ = w.Flush()
 		return
 	}
-	fmt.Fprintln(w, "NODE_ID\tNODE_IP\tINSTANCE_TYPE\tZONE\tCPU_TYPE\tHEALTHY\tHOST_STATUS")
+	fmt.Fprintln(w, "NODE_ID\tNODE_IP\tINSTANCE_TYPE\tZONE\tCPU_TYPE\tHEALTHY\tSCHEDULING_DISABLED\tHOST_STATUS")
 	for _, item := range nodes {
-		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%t\t%s\n",
-			item.ID(), item.HostIP(), item.InstanceType, item.Zone, item.CPUType, item.Healthy, item.HostStatus,
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%t\t%t\t%s\n",
+			item.ID(), item.HostIP(), item.InstanceType, item.Zone, item.CPUType, item.Healthy,
+			item.SchedulingDisabled(), item.HostStatus,
 		)
 	}
 	_ = w.Flush()

--- a/CubeMaster/pkg/base/constants/constants.go
+++ b/CubeMaster/pkg/base/constants/constants.go
@@ -246,6 +246,15 @@ const (
 	AffinityKeyMemorySize          = "kubernetes.io/memory-size"
 	AffinityKeyCPUCores            = "kubernetes.io/cpu-cores"
 	AffinityKeyInstanceType        = "kubernetes.io/instance-type"
+
+	// LabelSchedulingDisabled is the control-plane reserved label that marks a
+	// node as cordoned: new sandboxes must not be scheduled onto it. The only
+	// legal persisted representations are key-absent (enabled) or value "true"
+	// (disabled). Owned exclusively by the isolation API; Cubelet register and
+	// the generic label API must never create, overwrite, or delete it.
+	LabelSchedulingDisabled = "cube.cloud.tencentcloud.com/scheduling-disabled"
+	// LabelSchedulingDisabledValue is the only legal value for LabelSchedulingDisabled.
+	LabelSchedulingDisabledValue = "true"
 )
 
 const (

--- a/CubeMaster/pkg/base/node/node.go
+++ b/CubeMaster/pkg/base/node/node.go
@@ -6,6 +6,7 @@
 package node
 
 import (
+	"encoding/json"
 	"fmt"
 	"sort"
 	"sync"
@@ -90,7 +91,69 @@ type Node struct {
 
 	NodeLabels map[string]string `json:"NodeLabels,omitempty"`
 
+	// schedulingDisabled is the cordon flag (true → block new sandboxes).
+	// Exposed via SchedulingDisabled() / JSON as "SchedulingDisabled".
+	schedulingDisabled atomic.Bool
+
 	labelsCache *nodeLabelsCacheStore
+}
+
+// DecodeSchedulingDisabled reports whether labels cordon the node.
+// Key absent → false; key present (canonical "true" or any other value) → true
+// so corrupt/non-canonical values fail closed.
+func DecodeSchedulingDisabled(labels map[string]string) bool {
+	if labels == nil {
+		return false
+	}
+	_, ok := labels[constants.LabelSchedulingDisabled]
+	return ok
+}
+
+// SetSchedulingDisabled stores the concurrent-safe cordon flag.
+func (n *Node) SetSchedulingDisabled(disabled bool) {
+	if n == nil {
+		return
+	}
+	n.schedulingDisabled.Store(disabled)
+}
+
+// SchedulingDisabled reports whether this node is cordoned.
+func (n *Node) SchedulingDisabled() bool {
+	return n != nil && n.schedulingDisabled.Load()
+}
+
+// SchedulingAllowed reports whether this node may receive new sandboxes based
+// solely on cordon state (health / metrics are orthogonal).
+func (n *Node) SchedulingAllowed() bool {
+	return n != nil && !n.schedulingDisabled.Load()
+}
+
+// MarshalJSON emits SchedulingDisabled from the atomic cordon flag.
+func (n *Node) MarshalJSON() ([]byte, error) {
+	type Alias Node
+	return json.Marshal(&struct {
+		*Alias
+		SchedulingDisabled bool `json:"SchedulingDisabled"`
+	}{
+		Alias:              (*Alias)(n),
+		SchedulingDisabled: n.SchedulingDisabled(),
+	})
+}
+
+// UnmarshalJSON loads SchedulingDisabled into the atomic cordon flag.
+func (n *Node) UnmarshalJSON(data []byte) error {
+	type Alias Node
+	aux := &struct {
+		*Alias
+		SchedulingDisabled bool `json:"SchedulingDisabled"`
+	}{
+		Alias: (*Alias)(n),
+	}
+	if err := json.Unmarshal(data, aux); err != nil {
+		return err
+	}
+	n.SetSchedulingDisabled(aux.SchedulingDisabled)
+	return nil
 }
 
 type nodeLabelsCache struct {
@@ -108,11 +171,15 @@ func (n *Node) Clone() *Node {
 		return nil
 	}
 	// Clone provides a best-effort read-side snapshot. Mutable counters such
-	// as LocalCreateNum are refreshed via atomic loads after the structural
-	// copy so cloned read models stay aligned with the write path.
+	// as LocalCreateNum and schedulingDisabled are refreshed via atomic loads
+	// after the structural copy so cloned read models stay aligned with the
+	// write path under concurrent updates.
 	localCreateNum := atomic.LoadInt64(&n.LocalCreateNum)
+	schedulingDisabled := n.SchedulingDisabled()
 	cloned := *n
 	cloned.LocalCreateNum = localCreateNum
+	cloned.schedulingDisabled = atomic.Bool{}
+	cloned.SetSchedulingDisabled(schedulingDisabled)
 	cloned.labelsCache = nil
 	if n.VirtualNodeQuotaArray != nil {
 		cloned.VirtualNodeQuotaArray = append([]int64(nil), n.VirtualNodeQuotaArray...)

--- a/CubeMaster/pkg/base/node/node_scheduling_test.go
+++ b/CubeMaster/pkg/base/node/node_scheduling_test.go
@@ -1,0 +1,61 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package node
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/constants"
+)
+
+func TestDecodeSchedulingDisabled(t *testing.T) {
+	assert.False(t, DecodeSchedulingDisabled(nil))
+	assert.False(t, DecodeSchedulingDisabled(map[string]string{}))
+	assert.False(t, DecodeSchedulingDisabled(map[string]string{"env": "prod"}))
+	assert.True(t, DecodeSchedulingDisabled(map[string]string{
+		constants.LabelSchedulingDisabled: constants.LabelSchedulingDisabledValue,
+	}))
+	assert.True(t, DecodeSchedulingDisabled(map[string]string{
+		constants.LabelSchedulingDisabled: "false",
+	}))
+}
+
+func TestNodeSchedulingDisabledZeroValue(t *testing.T) {
+	n := &Node{}
+	assert.True(t, n.SchedulingAllowed())
+	assert.False(t, n.SchedulingDisabled())
+}
+
+func TestNodeSetSchedulingDisabledAndClone(t *testing.T) {
+	n := &Node{InsID: "n1"}
+	n.SetSchedulingDisabled(true)
+	assert.False(t, n.SchedulingAllowed())
+	assert.True(t, n.SchedulingDisabled())
+
+	cloned := n.Clone()
+	assert.False(t, cloned.SchedulingAllowed())
+	assert.True(t, cloned.SchedulingDisabled())
+
+	cloned.SetSchedulingDisabled(false)
+	assert.False(t, n.SchedulingAllowed())
+	assert.True(t, cloned.SchedulingAllowed())
+}
+
+func TestNodeSchedulingDisabledJSONRoundTrip(t *testing.T) {
+	n := &Node{InsID: "n1", IP: "10.0.0.1", Healthy: true}
+	n.SetSchedulingDisabled(true)
+
+	raw, err := json.Marshal(n)
+	assert.NoError(t, err)
+	assert.Contains(t, string(raw), `"SchedulingDisabled":true`)
+
+	var got Node
+	assert.NoError(t, json.Unmarshal(raw, &got))
+	assert.True(t, got.SchedulingDisabled())
+	assert.False(t, got.SchedulingAllowed())
+	assert.Equal(t, "n1", got.InsID)
+}

--- a/CubeMaster/pkg/localcache/export.go
+++ b/CubeMaster/pkg/localcache/export.go
@@ -105,6 +105,48 @@ func GetNodes(n int) node.NodeList {
 }
 
 func GetHealthyNodes(n int) node.NodeList {
+	return collectCacheNodes(n, false)
+}
+
+func GetHealthyNodesByInstanceType(n int, product string) node.NodeList {
+	return collectClusterNodes(n, product, false)
+}
+
+// GetSchedulableNodesByInstanceType returns healthy nodes that may receive new
+// sandboxes. Cordon filtering happens before limit n so isolated nodes do not
+// consume PreSelectNum. Healthy-but-isolated nodes remain in GetHealthyNodes*.
+//
+//go:noinline
+func GetSchedulableNodesByInstanceType(n int, product string) node.NodeList {
+	return collectClusterNodes(n, product, true)
+}
+
+func collectClusterNodes(n int, product string, requireSchedulable bool) node.NodeList {
+	l.lockSortedNodes.RLock()
+	clusterNodes, exists := l.sortedNodesByClusters[product]
+	l.lockSortedNodes.RUnlock()
+	if !exists {
+		return collectCacheNodes(n, requireSchedulable)
+	}
+
+	nodes := node.NodeList{}
+	now := time.Now()
+	for _, v := range clusterNodes {
+		if n >= 0 && nodes.Len() >= n {
+			break
+		}
+		if requireSchedulable && !v.SchedulingAllowed() {
+			continue
+		}
+		current := cloneNodeWithCurrentHealth(v, now)
+		if current.Healthy {
+			nodes.Append(current)
+		}
+	}
+	return nodes
+}
+
+func collectCacheNodes(n int, requireSchedulable bool) node.NodeList {
 	nodes := node.NodeList{}
 	elems := l.cache.Items()
 	now := time.Now()
@@ -113,42 +155,17 @@ func GetHealthyNodes(n int) node.NodeList {
 			break
 		}
 		h, ok := v.Object.(*node.Node)
-		if ok {
-			current := cloneNodeWithCurrentHealth(h, now)
-			if current.Healthy {
-				nodes.Append(current)
-			}
+		if !ok {
+			continue
 		}
-
-	}
-	return nodes
-}
-
-func GetHealthyNodesByInstanceType(n int, product string) node.NodeList {
-
-	l.lockSortedNodes.RLock()
-	clusterNodes, exists := l.sortedNodesByClusters[product]
-	l.lockSortedNodes.RUnlock()
-	if !exists {
-
-		return GetHealthyNodes(n)
-	}
-
-	nodes := node.NodeList{}
-	now := time.Now()
-
-	for _, v := range clusterNodes {
-
-		if n >= 0 && nodes.Len() >= n {
-			break
+		if requireSchedulable && !h.SchedulingAllowed() {
+			continue
 		}
-
-		current := cloneNodeWithCurrentHealth(v, now)
+		current := cloneNodeWithCurrentHealth(h, now)
 		if current.Healthy {
 			nodes.Append(current)
 		}
 	}
-
 	return nodes
 }
 

--- a/CubeMaster/pkg/localcache/export.go
+++ b/CubeMaster/pkg/localcache/export.go
@@ -115,8 +115,6 @@ func GetHealthyNodesByInstanceType(n int, product string) node.NodeList {
 // GetSchedulableNodesByInstanceType returns healthy nodes that may receive new
 // sandboxes. Cordon filtering happens before limit n so isolated nodes do not
 // consume PreSelectNum. Healthy-but-isolated nodes remain in GetHealthyNodes*.
-//
-//go:noinline
 func GetSchedulableNodesByInstanceType(n int, product string) node.NodeList {
 	return collectClusterNodes(n, product, true)
 }

--- a/CubeMaster/pkg/localcache/export_schedulable_test.go
+++ b/CubeMaster/pkg/localcache/export_schedulable_test.go
@@ -1,0 +1,69 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package localcache
+
+import (
+	"testing"
+	"time"
+
+	"github.com/patrickmn/go-cache"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/node"
+)
+
+func TestGetSchedulableNodesByInstanceTypeFiltersBeforeLimit(t *testing.T) {
+	origNodesByClusters := l.sortedNodesByClusters
+	origCache := l.cache
+	defer func() {
+		l.sortedNodesByClusters = origNodesByClusters
+		l.cache = origCache
+	}()
+
+	now := time.Now()
+	mk := func(id, ip string, disabled bool) *node.Node {
+		n := &node.Node{InsID: id, IP: ip, ReportedReady: true, Healthy: true, MetaDataUpdateAt: now}
+		n.SetSchedulingDisabled(disabled)
+		return n
+	}
+	ok := mk("ok-1", "10.0.0.3", false)
+	l.sortedNodesByClusters = map[string]node.NodeList{
+		"valid": {mk("iso-1", "10.0.0.1", true), mk("iso-2", "10.0.0.2", true), ok},
+	}
+	l.cache = cache.New(0, 0)
+
+	got := GetSchedulableNodesByInstanceType(1, "valid")
+	if got.Len() != 1 || got[0].ID() != "ok-1" {
+		t.Fatalf("schedulable limit: got %+v", got)
+	}
+	if GetHealthyNodesByInstanceType(-1, "valid").Len() != 3 {
+		t.Fatal("healthy should include isolated")
+	}
+	if GetSchedulableNodesByInstanceType(-1, "valid").Len() != 1 {
+		t.Fatal("schedulable should exclude isolated")
+	}
+}
+
+func TestUpdateNodeFromMetaDataPropagatesSchedulingDisabled(t *testing.T) {
+	origCache := l.cache
+	origSorted := l.sortedNodesByClusters
+	defer func() {
+		l.cache = origCache
+		l.sortedNodesByClusters = origSorted
+	}()
+	l.cache = cache.New(0, 0)
+	l.sortedNodesByClusters = map[string]node.NodeList{}
+
+	existing := &node.Node{InsID: "n1", IP: "10.0.0.1", Healthy: true, InstanceType: "valid"}
+	l.cache.SetDefault("n1", existing)
+
+	incoming := &node.Node{InsID: "n1", IP: "10.0.0.1", Healthy: true, InstanceType: "valid"}
+	incoming.SetSchedulingDisabled(true)
+	if err := l.updateNodeFromMetaData(incoming); err != nil {
+		t.Fatalf("updateNodeFromMetaData: %v", err)
+	}
+	got, ok := GetNode("n1")
+	if !ok || got.SchedulingAllowed() || !got.SchedulingDisabled() {
+		t.Fatalf("got allowed=%v disabled=%v", got.SchedulingAllowed(), got.SchedulingDisabled())
+	}
+}

--- a/CubeMaster/pkg/localcache/node_cache.go
+++ b/CubeMaster/pkg/localcache/node_cache.go
@@ -320,6 +320,7 @@ func (l *local) updateNodeFromMetaData(n *node.Node) error {
 		}
 		old.NodeLabels = labels
 		old.InvalidateLabelsCache()
+		old.SetSchedulingDisabled(!n.SchedulingAllowed())
 		l.lockMetaData.Unlock()
 
 		l.updateSortedNodes(old)

--- a/CubeMaster/pkg/localcache/node_cache.go
+++ b/CubeMaster/pkg/localcache/node_cache.go
@@ -320,7 +320,7 @@ func (l *local) updateNodeFromMetaData(n *node.Node) error {
 		}
 		old.NodeLabels = labels
 		old.InvalidateLabelsCache()
-		old.SetSchedulingDisabled(!n.SchedulingAllowed())
+		old.SetSchedulingDisabled(n.SchedulingDisabled())
 		l.lockMetaData.Unlock()
 
 		l.updateSortedNodes(old)

--- a/CubeMaster/pkg/nodemeta/isolation.go
+++ b/CubeMaster/pkg/nodemeta/isolation.go
@@ -1,0 +1,121 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package nodemeta
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/constants"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/log"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/node"
+	"gorm.io/gorm"
+)
+
+var (
+	// ErrLabelsJSONCorrupt: isolation must not overwrite corrupt labels_json.
+	ErrLabelsJSONCorrupt = errors.New("node labels_json is corrupt")
+	// ErrSchedulingLabelRejected: cubelet must not set the control-plane cordon key.
+	ErrSchedulingLabelRejected = errors.New("cubelet must not set scheduling-disabled label")
+)
+
+func (s *service) lockNodeLabels(nodeID string) func() {
+	v, _ := s.labelWriteLocks.LoadOrStore(nodeID, &sync.Mutex{})
+	mu := v.(*sync.Mutex)
+	mu.Lock()
+	return mu.Unlock
+}
+
+// countUserLabels excludes the control-plane cordon key from the per-node quota.
+func countUserLabels(labels map[string]string) int {
+	n := len(labels)
+	if _, ok := labels[constants.LabelSchedulingDisabled]; ok {
+		n--
+	}
+	return n
+}
+
+// SetNodeSchedulingDisabled cordons (disabled=true) or uncordons a node.
+// Idempotent; always republishes localcache so a stale local view is repaired.
+func SetNodeSchedulingDisabled(ctx context.Context, nodeID string, disabled bool) (*NodeSnapshot, error) {
+	if nodeID == "" {
+		return nil, fmt.Errorf("node_id is required")
+	}
+	unlock := global.lockNodeLabels(nodeID)
+	defer unlock()
+
+	var nodeLabels map[string]string
+	var changed bool
+	if err := global.db.Transaction(func(tx *gorm.DB) error {
+		existing, err := readLabelsJSONForUpdate(tx, nodeID)
+		if err != nil {
+			return err
+		}
+		_, has := existing[constants.LabelSchedulingDisabled]
+		switch {
+		case disabled && (!has || existing[constants.LabelSchedulingDisabled] != constants.LabelSchedulingDisabledValue):
+			existing[constants.LabelSchedulingDisabled] = constants.LabelSchedulingDisabledValue
+			changed = true
+		case !disabled && has:
+			delete(existing, constants.LabelSchedulingDisabled)
+			changed = true
+		}
+		if changed {
+			if err := tx.Table(constants.NodeMetaRegistrationTable).
+				Where("node_id = ?", nodeID).
+				Updates(map[string]interface{}{
+					"labels_json": mustJSON(existing),
+					"updated_at":  time.Now(),
+				}).Error; err != nil {
+				return err
+			}
+		}
+		nodeLabels = existing
+		return nil
+	}); err != nil {
+		log.G(ctx).Warnf("node isolation write failed node_id=%s disabled=%v err=%v", nodeID, disabled, err)
+		return nil, err
+	}
+
+	snap := global.ensureNode(nodeID)
+	global.mu.Lock()
+	snap.Labels = cloneStringMap(nodeLabels)
+	snap.labelsJSONCorrupt = false
+	global.mu.Unlock()
+	syncLocalcache(snap)
+
+	out := cloneSnapshotWithCurrentHealth(snap, time.Now())
+	log.G(ctx).Infof("node isolation write node_id=%s disabled=%v changed=%v scheduling_disabled=%v",
+		nodeID, disabled, changed, out.SchedulingDisabled)
+	return out, nil
+}
+
+// stripAndPreserveSchedulingLabel merges cubelet labels while keeping the
+// control-plane cordon key from DB (cubelet cannot create/overwrite/delete it).
+func stripAndPreserveSchedulingLabel(existing, cubeletLabels map[string]string) map[string]string {
+	ctrlVal, hasCtrl := existing[constants.LabelSchedulingDisabled]
+	for k, v := range cubeletLabels {
+		if k == constants.LabelSchedulingDisabled {
+			continue
+		}
+		existing[k] = v
+	}
+	if hasCtrl {
+		existing[constants.LabelSchedulingDisabled] = ctrlVal
+	} else {
+		delete(existing, constants.LabelSchedulingDisabled)
+	}
+	return existing
+}
+
+func snapshotSchedulingDisabled(snap *NodeSnapshot) bool {
+	if snap == nil || snap.labelsJSONCorrupt {
+		return true
+	}
+	return node.DecodeSchedulingDisabled(snap.Labels)
+}

--- a/CubeMaster/pkg/nodemeta/isolation_test.go
+++ b/CubeMaster/pkg/nodemeta/isolation_test.go
@@ -1,0 +1,77 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package nodemeta
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/constants"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/node"
+)
+
+func TestCountUserLabelsExcludesControlPlaneKey(t *testing.T) {
+	assert.Equal(t, 0, countUserLabels(nil))
+	assert.Equal(t, 1, countUserLabels(map[string]string{"env": "prod"}))
+	assert.Equal(t, 1, countUserLabels(map[string]string{
+		"env":                             "prod",
+		constants.LabelSchedulingDisabled: constants.LabelSchedulingDisabledValue,
+	}))
+}
+
+func TestStripAndPreserveSchedulingLabel(t *testing.T) {
+	existing := map[string]string{
+		"env":                             "old",
+		constants.LabelSchedulingDisabled: constants.LabelSchedulingDisabledValue,
+	}
+	got := stripAndPreserveSchedulingLabel(existing, map[string]string{
+		"env":                             "new",
+		constants.LabelSchedulingDisabled: "false",
+	})
+	assert.Equal(t, "new", got["env"])
+	assert.Equal(t, constants.LabelSchedulingDisabledValue, got[constants.LabelSchedulingDisabled])
+}
+
+func TestCloneSnapshotAndToSchedulerNodeCordon(t *testing.T) {
+	snap := &NodeSnapshot{
+		NodeID: "n1",
+		HostIP: "10.0.0.1",
+		Labels: map[string]string{
+			constants.LabelSchedulingDisabled: constants.LabelSchedulingDisabledValue,
+		},
+		Healthy: true,
+	}
+	out := cloneSnapshot(snap)
+	assert.True(t, out.SchedulingDisabled)
+
+	n := toSchedulerNode(snap)
+	assert.False(t, n.SchedulingAllowed())
+	assert.True(t, n.SchedulingDisabled())
+}
+
+func TestSnapshotSchedulingDisabledCorrupt(t *testing.T) {
+	assert.True(t, snapshotSchedulingDisabled(&NodeSnapshot{labelsJSONCorrupt: true}))
+	assert.False(t, snapshotSchedulingDisabled(&NodeSnapshot{Labels: map[string]string{"env": "prod"}}))
+}
+
+func TestApplyReloadResultAppliesRemoteIsolation(t *testing.T) {
+	s := newTestService(&NodeSnapshot{
+		NodeID: "node-a",
+		Labels: map[string]string{"env": "prod"},
+	})
+	s.applyReloadResult(map[string]*NodeSnapshot{
+		"node-a": {
+			NodeID: "node-a",
+			Labels: map[string]string{
+				"env":                             "prod",
+				constants.LabelSchedulingDisabled: constants.LabelSchedulingDisabledValue,
+			},
+		},
+	})
+	s.mu.RLock()
+	snap := s.nodes["node-a"]
+	s.mu.RUnlock()
+	assert.True(t, node.DecodeSchedulingDisabled(snap.Labels))
+}

--- a/CubeMaster/pkg/nodemeta/service.go
+++ b/CubeMaster/pkg/nodemeta/service.go
@@ -135,9 +135,16 @@ type NodeSnapshot struct {
 	ReportedReady       bool                   `json:"-"`
 	Healthy             bool                   `json:"healthy"`
 	UnhealthyReason     string                 `json:"unhealthy_reason,omitempty"`
+	// SchedulingDisabled is the API-facing cordon view derived from the
+	// reserved label (or labels_json corruption). Not omitempty so enabled
+	// (false) remains distinguishable from older servers.
+	SchedulingDisabled bool `json:"scheduling_disabled"`
 	// versionsHash is the content hash of Versions, used to skip redundant DB
 	// writes on every heartbeat. Not serialised to JSON.
 	versionsHash string
+	// labelsJSONCorrupt marks that labels_json failed to parse; scheduling is
+	// fail-closed. Not serialised.
+	labelsJSONCorrupt bool
 }
 
 type service struct {
@@ -156,6 +163,11 @@ type service struct {
 	// node so concurrent heartbeats cannot race each other and issue redundant
 	// version writes or overwrite a newer in-memory hash with an older one.
 	versionWriteLocks sync.Map
+
+	// labelWriteLocks serialises label read-modify-write (register merge,
+	// admin labels, isolation) per node so DB commit and in-memory/localcache
+	// publication stay ordered.
+	labelWriteLocks sync.Map
 }
 
 var global = &service{
@@ -199,6 +211,10 @@ func RegisterNode(ctx context.Context, req *RegisterNodeRequest) (*NodeSnapshot,
 	if req.HostIP == "" {
 		req.HostIP = req.NodeID
 	}
+	if _, ok := req.Labels[constants.LabelSchedulingDisabled]; ok {
+		log.G(ctx).Warnf("cubelet attempted to set scheduling-disabled label node_id=%s", req.NodeID)
+		return nil, ErrSchedulingLabelRejected
+	}
 	reg := &models.NodeRegistration{
 		NodeID:              req.NodeID,
 		HostIP:              req.HostIP,
@@ -212,9 +228,13 @@ func RegisterNode(ctx context.Context, req *RegisterNodeRequest) (*NodeSnapshot,
 		CreateConcurrentNum: req.CreateConcurrentNum,
 		MaxMvmNum:           req.MaxMvmNum,
 	}
-	// Read existing labels from DB, merge cubelet labels (cubelet wins on conflict),
-	// then write back the merged result. Use SELECT ... FOR UPDATE inside a
-	// transaction to prevent concurrent admin label writes from being lost.
+	// Read existing labels from DB, merge cubelet labels (cubelet wins on
+	// conflict for user keys), preserve the control-plane scheduling-disabled
+	// key, then write back. Use SELECT ... FOR UPDATE inside a transaction
+	// under the per-node label write lock.
+	unlock := global.lockNodeLabels(req.NodeID)
+	defer unlock()
+
 	var mergedLabels map[string]string
 	if err := global.db.Transaction(func(tx *gorm.DB) error {
 		if err := tx.Clauses(clause.OnConflict{
@@ -231,11 +251,9 @@ func RegisterNode(ctx context.Context, req *RegisterNodeRequest) (*NodeSnapshot,
 		if err != nil {
 			return err
 		}
-		for k, v := range req.Labels {
-			existing[k] = v
-		}
-		if len(existing) > maxLabelsPerNode {
-			return fmt.Errorf("a node cannot have more than %d labels, got %d after merge", maxLabelsPerNode, len(existing))
+		existing = stripAndPreserveSchedulingLabel(existing, req.Labels)
+		if countUserLabels(existing) > maxLabelsPerNode {
+			return fmt.Errorf("a node cannot have more than %d labels, got %d after merge", maxLabelsPerNode, countUserLabels(existing))
 		}
 		if err := tx.Table(constants.NodeMetaRegistrationTable).
 			Where("node_id = ?", req.NodeID).
@@ -254,6 +272,7 @@ func RegisterNode(ctx context.Context, req *RegisterNodeRequest) (*NodeSnapshot,
 	snap.HostIP = req.HostIP
 	snap.GRPCPort = req.GRPCPort
 	snap.Labels = cloneStringMap(mergedLabels)
+	snap.labelsJSONCorrupt = false
 	snap.Capacity = req.Capacity
 	snap.Allocatable = req.Allocatable
 	snap.InstanceType = req.InstanceType
@@ -561,6 +580,9 @@ func UpdateNodeLabels(ctx context.Context, nodeID string, labels map[string]stri
 	if err := validateNodeLabels(labels); err != nil {
 		return err
 	}
+	unlock := global.lockNodeLabels(nodeID)
+	defer unlock()
+
 	var nodeLabels map[string]string
 	if err := global.db.Transaction(func(tx *gorm.DB) error {
 		existing, err := readLabelsJSONForUpdate(tx, nodeID)
@@ -570,8 +592,8 @@ func UpdateNodeLabels(ctx context.Context, nodeID string, labels map[string]stri
 		for k, v := range labels {
 			existing[k] = v
 		}
-		if len(existing) > maxLabelsPerNode {
-			return fmt.Errorf("a node cannot have more than %d labels, got %d after merge", maxLabelsPerNode, len(existing))
+		if countUserLabels(existing) > maxLabelsPerNode {
+			return fmt.Errorf("a node cannot have more than %d labels, got %d after merge", maxLabelsPerNode, countUserLabels(existing))
 		}
 		if err := tx.Table(constants.NodeMetaRegistrationTable).
 			Where("node_id = ?", nodeID).
@@ -590,6 +612,7 @@ func UpdateNodeLabels(ctx context.Context, nodeID string, labels map[string]stri
 	snap := global.ensureNode(nodeID)
 	global.mu.Lock()
 	snap.Labels = cloneStringMap(nodeLabels)
+	snap.labelsJSONCorrupt = false
 	global.mu.Unlock()
 	syncLocalcache(snap)
 	return nil
@@ -602,6 +625,9 @@ func DeleteNodeLabel(ctx context.Context, nodeID, key string) error {
 	if err := validateNodeLabelKey(key); err != nil {
 		return err
 	}
+	unlock := global.lockNodeLabels(nodeID)
+	defer unlock()
+
 	var nodeLabels map[string]string
 	if err := global.db.Transaction(func(tx *gorm.DB) error {
 		existing, err := readLabelsJSONForUpdate(tx, nodeID)
@@ -625,14 +651,14 @@ func DeleteNodeLabel(ctx context.Context, nodeID, key string) error {
 	snap := global.ensureNode(nodeID)
 	global.mu.Lock()
 	snap.Labels = cloneStringMap(nodeLabels)
+	snap.labelsJSONCorrupt = false
 	global.mu.Unlock()
 	syncLocalcache(snap)
 	return nil
 }
 
-// readLabelsJSONForUpdate reads the labels_json column with a row-level lock
-// (SELECT ... FOR UPDATE) inside an ongoing transaction, preventing concurrent
-// read-modify-write races on the same node's labels.
+// readLabelsJSONForUpdate reads labels_json with SELECT ... FOR UPDATE.
+// Corrupt JSON returns ErrLabelsJSONCorrupt (fail-closed for isolation writes).
 func readLabelsJSONForUpdate(tx *gorm.DB, nodeID string) (map[string]string, error) {
 	var reg models.NodeRegistration
 	if err := tx.Clauses(clause.Locking{Strength: "UPDATE"}).
@@ -641,7 +667,11 @@ func readLabelsJSONForUpdate(tx *gorm.DB, nodeID string) (map[string]string, err
 		Take(&reg).Error; err != nil {
 		return nil, err
 	}
-	return parseLabelsJSON(reg.LabelsJSON)
+	labels, err := parseLabelsJSON(reg.LabelsJSON)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrLabelsJSONCorrupt, err)
+	}
+	return labels, nil
 }
 
 func parseLabelsJSON(raw string) (map[string]string, error) {
@@ -805,7 +835,14 @@ func (s *service) reload() error {
 			CreateConcurrentNum: reg.CreateConcurrentNum,
 			MaxMvmNum:           reg.MaxMvmNum,
 		}
-		_ = json.Unmarshal([]byte(reg.LabelsJSON), &snap.Labels)
+		labels, err := parseLabelsJSON(reg.LabelsJSON)
+		if err != nil {
+			log.G(context.Background()).Warnf("node labels_json corrupt node_id=%s err=%v; scheduling fail-closed", reg.NodeID, err)
+			snap.Labels = map[string]string{}
+			snap.labelsJSONCorrupt = true
+		} else {
+			snap.Labels = labels
+		}
 		_ = json.Unmarshal([]byte(reg.CapacityJSON), &snap.Capacity)
 		_ = json.Unmarshal([]byte(reg.AllocatableJSON), &snap.Allocatable)
 		next[reg.NodeID] = snap
@@ -849,21 +886,19 @@ func (s *service) reload() error {
 }
 
 // applyReloadResult merges a DB snapshot (next) into the live in-memory map.
-// Registration fields and versions always take the DB value; status/heartbeat
-// fields keep the in-memory value when it is fresher than the DB snapshot.
+// Registration fields take the DB value (same eventual-consistency trade-off as
+// other labels). Status/heartbeat keep in-memory when fresher. After unlocking,
+// nodes whose cordon state changed are synced to localcache.
 func (s *service) applyReloadResult(next map[string]*NodeSnapshot) {
+	toSync := make([]*NodeSnapshot, 0)
+
 	s.mu.Lock()
-	defer s.mu.Unlock()
 	for nodeID, newSnap := range next {
 		if existing, ok := s.nodes[nodeID]; ok {
-			// Registration fields: take from DB.  A theoretical race exists
-			// where the reload() DB scan captures a row before a concurrent
-			// RegisterNode write commits, causing applyReloadResult to
-			// overwrite a fresher in-memory value with a stale DB snapshot.
-			// This is an accepted trade-off: registration field changes are
-			// rare, and any inconsistency self-corrects on the next reload
-			// cycle (≤ SyncMetaDataInterval).
+			prevDisabled := snapshotSchedulingDisabled(existing)
+
 			existing.Labels = cloneStringMap(newSnap.Labels)
+			existing.labelsJSONCorrupt = newSnap.labelsJSONCorrupt
 			existing.Capacity = newSnap.Capacity
 			existing.Allocatable = newSnap.Allocatable
 			existing.InstanceType = newSnap.InstanceType
@@ -876,8 +911,6 @@ func (s *service) applyReloadResult(next map[string]*NodeSnapshot) {
 			existing.GRPCPort = newSnap.GRPCPort
 			existing.Versions = append([]ComponentVersion(nil), newSnap.Versions...)
 			existing.versionsHash = newSnap.versionsHash
-			// Status fields: keep in-memory version if fresher to avoid
-			// regressing heartbeat state that arrived during the DB scan.
 			if newSnap.HeartbeatTime.After(existing.HeartbeatTime) {
 				existing.Conditions = newSnap.Conditions
 				existing.Images = newSnap.Images
@@ -886,10 +919,21 @@ func (s *service) applyReloadResult(next map[string]*NodeSnapshot) {
 				existing.ReportedReady = newSnap.ReportedReady
 			}
 			applyCurrentHealth(existing, time.Now())
+
+			if prevDisabled != snapshotSchedulingDisabled(existing) {
+				toSync = append(toSync, cloneSnapshot(existing))
+			}
 		} else {
-			// New node discovered from DB (registered on another replica).
 			s.nodes[nodeID] = newSnap
 		}
+	}
+	s.mu.Unlock()
+
+	if !s.ready {
+		return
+	}
+	for _, snap := range toSync {
+		syncLocalcache(snap)
 	}
 }
 
@@ -941,6 +985,7 @@ func applyCurrentHealth(snap *NodeSnapshot, now time.Time) {
 	snap.UnhealthyReason = status.UnhealthyReason
 }
 
+
 func toSchedulerNode(snap *NodeSnapshot) *node.Node {
 	if snap == nil {
 		return nil
@@ -961,7 +1006,7 @@ func toSchedulerNode(snap *NodeSnapshot) *node.Node {
 	if instanceType == "" {
 		instanceType = constants.DefaultInstanceTypeName
 	}
-	return &node.Node{
+	n := &node.Node{
 		InsID:               snap.NodeID,
 		UUID:                snap.NodeID,
 		IP:                  hostIP,
@@ -988,6 +1033,8 @@ func toSchedulerNode(snap *NodeSnapshot) *node.Node {
 		// correctly be excluded by the timeout filter until cubelet
 		// reports usage.
 	}
+	n.SetSchedulingDisabled(snapshotSchedulingDisabled(snap))
+	return n
 }
 
 func syncLocalcache(snap *NodeSnapshot) {
@@ -1019,6 +1066,7 @@ func cloneSnapshot(in *NodeSnapshot) *NodeSnapshot {
 	out.Images = append([]ContainerImage(nil), in.Images...)
 	out.LocalTemplates = append([]LocalTemplate(nil), in.LocalTemplates...)
 	out.Versions = append([]ComponentVersion(nil), in.Versions...)
+	out.SchedulingDisabled = snapshotSchedulingDisabled(in)
 	return &out
 }
 

--- a/CubeMaster/pkg/nodemeta/service.go
+++ b/CubeMaster/pkg/nodemeta/service.go
@@ -658,7 +658,8 @@ func DeleteNodeLabel(ctx context.Context, nodeID, key string) error {
 }
 
 // readLabelsJSONForUpdate reads labels_json with SELECT ... FOR UPDATE.
-// Corrupt JSON returns ErrLabelsJSONCorrupt (fail-closed for isolation writes).
+// Corrupt JSON returns ErrLabelsJSONCorrupt (fail-closed for all label writers:
+// register merge, admin labels, and isolation).
 func readLabelsJSONForUpdate(tx *gorm.DB, nodeID string) (map[string]string, error) {
 	var reg models.NodeRegistration
 	if err := tx.Clauses(clause.Locking{Strength: "UPDATE"}).

--- a/CubeMaster/pkg/nodemeta/service.go
+++ b/CubeMaster/pkg/nodemeta/service.go
@@ -985,7 +985,6 @@ func applyCurrentHealth(snap *NodeSnapshot, now time.Time) {
 	snap.UnhealthyReason = status.UnhealthyReason
 }
 
-
 func toSchedulerNode(snap *NodeSnapshot) *node.Node {
 	if snap == nil {
 		return nil

--- a/CubeMaster/pkg/selector/backofffilter/backofffilter.go
+++ b/CubeMaster/pkg/selector/backofffilter/backofffilter.go
@@ -45,9 +45,9 @@ func (l *backofffilter) Select(selCtx *selctx.SelectorCtx) (node.NodeList, error
 			return node.NodeList{}, nil
 		}
 	}
-	nodes := localcache.GetHealthyNodesByInstanceType(-1, selCtx.InstanceType)
+	nodes := localcache.GetSchedulableNodesByInstanceType(-1, selCtx.InstanceType)
 	if log.IsDebug() {
-		log.G(selCtx.Ctx).Debugf("GetNodes:%+v,size:%d", nodes.String(), nodes.Len())
+		log.G(selCtx.Ctx).Debugf("GetSchedulableNodes:%+v,size:%d", nodes.String(), nodes.Len())
 	}
 	newNodes := make(node.NodeList, 0, nodes.Len())
 	for i := range nodes {

--- a/CubeMaster/pkg/selector/prefilter/prefilter.go
+++ b/CubeMaster/pkg/selector/prefilter/prefilter.go
@@ -36,10 +36,10 @@ func (l *prefilter) Select(selCtx *selctx.SelectorCtx) (node.NodeList, error) {
 		return nil, ret.Errorf(errorcode.ErrorCode_MasterInternalError, "scheduler config is nil")
 	}
 
-	nodes := localcache.GetHealthyNodesByInstanceType(sconf.PreSelectNum, selCtx.InstanceType)
+	nodes := localcache.GetSchedulableNodesByInstanceType(sconf.PreSelectNum, selCtx.InstanceType)
 
 	if log.IsDebug() {
-		log.G(selCtx.Ctx).Debugf("GetHealthyNodesByInstanceType:%+v,size:%d", nodes.String(), nodes.Len())
+		log.G(selCtx.Ctx).Debugf("GetSchedulableNodesByInstanceType:%+v,size:%d", nodes.String(), nodes.Len())
 	}
 	newNodes := make(node.NodeList, 0, nodes.Len())
 	for i := range nodes {

--- a/CubeMaster/pkg/selector/prefilter/prefilter_test.go
+++ b/CubeMaster/pkg/selector/prefilter/prefilter_test.go
@@ -62,8 +62,8 @@ func TestPreFilterExcludesMetricTimeoutNode(t *testing.T) {
 	}
 	staleMetric := &node.Node{
 		InsID: "node-stale-metric", IP: "10.0.0.2", Healthy: true,
-		MetaDataUpdateAt: now,
-		MetricUpdate:     now.Add(-(timeout + time.Second)),
+		MetaDataUpdateAt:    now,
+		MetricUpdate:        now.Add(-(timeout + time.Second)),
 		MetricLocalUpdateAt: now.Add(-(timeout + time.Second)),
 	}
 

--- a/CubeMaster/pkg/selector/prefilter/prefilter_test.go
+++ b/CubeMaster/pkg/selector/prefilter/prefilter_test.go
@@ -30,41 +30,26 @@ func init() {
 func TestPreFilterExcludesUnhealthyNode(t *testing.T) {
 	now := time.Now()
 	fresh := &node.Node{
-		InsID:               "node-fresh",
-		IP:                  "10.0.0.1",
-		Healthy:             true,
-		MetaDataUpdateAt:    now,
-		MetricUpdate:        now,
-		MetricLocalUpdateAt: now,
+		InsID: "node-fresh", IP: "10.0.0.1", Healthy: true,
+		MetaDataUpdateAt: now, MetricUpdate: now, MetricLocalUpdateAt: now,
 	}
 	stale := &node.Node{
-		InsID:               "node-stale",
-		IP:                  "10.0.0.2",
-		Healthy:             false,
-		UnhealthyReason:     "HeartbeatExpired",
-		MetaDataUpdateAt:    now,
-		MetricUpdate:        now,
-		MetricLocalUpdateAt: now,
+		InsID: "node-stale", IP: "10.0.0.2", Healthy: false, UnhealthyReason: "HeartbeatExpired",
+		MetaDataUpdateAt: now, MetricUpdate: now, MetricLocalUpdateAt: now,
 	}
 
 	patches := gomonkey.NewPatches()
 	defer patches.Reset()
-	patches.ApplyFunc(localcache.GetHealthyNodesByInstanceType, func(n int, product string) node.NodeList {
+	patches.ApplyFunc(localcache.GetSchedulableNodesByInstanceType, func(n int, product string) node.NodeList {
 		return node.NodeList{fresh, stale}
 	})
 
-	got, err := NewPreFilter().Select(&selctx.SelectorCtx{
-		Ctx:          context.Background(),
-		InstanceType: "valid",
-	})
+	got, err := NewPreFilter().Select(&selctx.SelectorCtx{Ctx: context.Background(), InstanceType: "valid"})
 	if err != nil {
 		t.Fatalf("Select returned error: %v", err)
 	}
-	if got.Len() != 1 {
-		t.Fatalf("got %d nodes want 1", got.Len())
-	}
-	if got[0].ID() != fresh.ID() {
-		t.Fatalf("got node %s want %s", got[0].ID(), fresh.ID())
+	if got.Len() != 1 || got[0].ID() != fresh.ID() {
+		t.Fatalf("got %+v", got)
 	}
 }
 
@@ -72,39 +57,27 @@ func TestPreFilterExcludesMetricTimeoutNode(t *testing.T) {
 	now := time.Now()
 	timeout := config.GetConfig().Scheduler.MetricUpdateTimeout
 	fresh := &node.Node{
-		InsID:               "node-fresh",
-		IP:                  "10.0.0.1",
-		Healthy:             true,
-		MetaDataUpdateAt:    now,
-		MetricUpdate:        now,
-		MetricLocalUpdateAt: now,
+		InsID: "node-fresh", IP: "10.0.0.1", Healthy: true,
+		MetaDataUpdateAt: now, MetricUpdate: now, MetricLocalUpdateAt: now,
 	}
 	staleMetric := &node.Node{
-		InsID:               "node-stale-metric",
-		IP:                  "10.0.0.2",
-		Healthy:             true,
-		MetaDataUpdateAt:    now,
-		MetricUpdate:        now.Add(-(timeout + time.Second)),
+		InsID: "node-stale-metric", IP: "10.0.0.2", Healthy: true,
+		MetaDataUpdateAt: now,
+		MetricUpdate:     now.Add(-(timeout + time.Second)),
 		MetricLocalUpdateAt: now.Add(-(timeout + time.Second)),
 	}
 
 	patches := gomonkey.NewPatches()
 	defer patches.Reset()
-	patches.ApplyFunc(localcache.GetHealthyNodesByInstanceType, func(n int, product string) node.NodeList {
+	patches.ApplyFunc(localcache.GetSchedulableNodesByInstanceType, func(n int, product string) node.NodeList {
 		return node.NodeList{fresh, staleMetric}
 	})
 
-	got, err := NewPreFilter().Select(&selctx.SelectorCtx{
-		Ctx:          context.Background(),
-		InstanceType: "valid",
-	})
+	got, err := NewPreFilter().Select(&selctx.SelectorCtx{Ctx: context.Background(), InstanceType: "valid"})
 	if err != nil {
 		t.Fatalf("Select returned error: %v", err)
 	}
-	if got.Len() != 1 {
-		t.Fatalf("got %d nodes want 1", got.Len())
-	}
-	if got[0].ID() != fresh.ID() {
-		t.Fatalf("got node %s want %s", got[0].ID(), fresh.ID())
+	if got.Len() != 1 || got[0].ID() != fresh.ID() {
+		t.Fatalf("got %+v", got)
 	}
 }

--- a/CubeMaster/pkg/server/server.go
+++ b/CubeMaster/pkg/server/server.go
@@ -124,6 +124,8 @@ func (s *internalHttp) registerHandlers() {
 	metaGroup.HandleFunc(metahttp.NodeStatusAction(), metahttp.UpdateNodeStatusHandler).Methods(http.MethodPost)
 	metaGroup.HandleFunc(metahttp.NodeLabelsAction(), metahttp.UpdateNodeLabelsHandler).Methods(http.MethodPost)
 	metaGroup.HandleFunc(metahttp.NodeLabelsAction(), metahttp.DeleteNodeLabelHandler).Methods(http.MethodDelete)
+	metaGroup.HandleFunc(metahttp.NodeIsolationAction(), metahttp.IsolateNodeHandler).Methods(http.MethodPut)
+	metaGroup.HandleFunc(metahttp.NodeIsolationAction(), metahttp.UnisolateNodeHandler).Methods(http.MethodDelete)
 }
 
 func (s *internalHttp) Start() error {

--- a/CubeMaster/pkg/service/httpservice/meta/meta.go
+++ b/CubeMaster/pkg/service/httpservice/meta/meta.go
@@ -17,15 +17,15 @@ import (
 )
 
 const (
-	metaURI               = "/internal/meta"
-	readyzAction          = "/readyz"
-	registerNodeAction    = "/nodes/register"
-	nodesAction           = "/nodes"
-	nodeAction            = "/nodes/{node_id}"
-	nodeStatusAction      = "/nodes/{node_id}/status"
-	nodeLabelsAction      = "/nodes/{node_id}/labels"
-	nodeIsolationAction   = "/nodes/{node_id}/isolation"
-	versionMatrixAction   = "/version-matrix"
+	metaURI             = "/internal/meta"
+	readyzAction        = "/readyz"
+	registerNodeAction  = "/nodes/register"
+	nodesAction         = "/nodes"
+	nodeAction          = "/nodes/{node_id}"
+	nodeStatusAction    = "/nodes/{node_id}/status"
+	nodeLabelsAction    = "/nodes/{node_id}/labels"
+	nodeIsolationAction = "/nodes/{node_id}/isolation"
+	versionMatrixAction = "/version-matrix"
 )
 
 type nodesResponse struct {

--- a/CubeMaster/pkg/service/httpservice/meta/meta.go
+++ b/CubeMaster/pkg/service/httpservice/meta/meta.go
@@ -5,6 +5,7 @@
 package meta
 
 import (
+	"errors"
 	"net/http"
 
 	"github.com/gorilla/mux"
@@ -16,14 +17,15 @@ import (
 )
 
 const (
-	metaURI             = "/internal/meta"
-	readyzAction        = "/readyz"
-	registerNodeAction  = "/nodes/register"
-	nodesAction         = "/nodes"
-	nodeAction          = "/nodes/{node_id}"
-	nodeStatusAction    = "/nodes/{node_id}/status"
-	nodeLabelsAction    = "/nodes/{node_id}/labels"
-	versionMatrixAction = "/version-matrix"
+	metaURI               = "/internal/meta"
+	readyzAction          = "/readyz"
+	registerNodeAction    = "/nodes/register"
+	nodesAction           = "/nodes"
+	nodeAction            = "/nodes/{node_id}"
+	nodeStatusAction      = "/nodes/{node_id}/status"
+	nodeLabelsAction      = "/nodes/{node_id}/labels"
+	nodeIsolationAction   = "/nodes/{node_id}/isolation"
+	versionMatrixAction   = "/version-matrix"
 )
 
 type nodesResponse struct {
@@ -74,6 +76,10 @@ func VersionMatrixAction() string {
 
 func NodeLabelsAction() string {
 	return nodeLabelsAction
+}
+
+func NodeIsolationAction() string {
+	return nodeIsolationAction
 }
 
 func ReadyzHandler(w http.ResponseWriter, r *http.Request) {
@@ -193,6 +199,25 @@ func DeleteNodeLabelHandler(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
+// IsolateNodeHandler cordons a node (PUT). Idempotent; no request body.
+func IsolateNodeHandler(w http.ResponseWriter, r *http.Request) {
+	writeIsolation(w, r, true)
+}
+
+// UnisolateNodeHandler removes the cordon (DELETE). Idempotent.
+func UnisolateNodeHandler(w http.ResponseWriter, r *http.Request) {
+	writeIsolation(w, r, false)
+}
+
+func writeIsolation(w http.ResponseWriter, r *http.Request, disabled bool) {
+	data, err := nodemeta.SetNodeSchedulingDisabled(r.Context(), mux.Vars(r)["node_id"], disabled)
+	if err != nil {
+		writeErr(w, http.StatusOK, err)
+		return
+	}
+	common.WriteResponse(w, http.StatusOK, &nodeResponse{Ret: successRet(), Data: data})
+}
+
 func successRet() *sandboxtypes.Ret {
 	return &sandboxtypes.Ret{
 		RetCode: int(errorcode.ErrorCode_Success),
@@ -202,8 +227,11 @@ func successRet() *sandboxtypes.Ret {
 
 func writeErr(w http.ResponseWriter, status int, err error) {
 	retCode := int(errorcode.ErrorCode_MasterInternalError)
-	if err == gorm.ErrRecordNotFound {
+	switch {
+	case errors.Is(err, gorm.ErrRecordNotFound):
 		retCode = int(errorcode.ErrorCode_NotFound)
+	case errors.Is(err, nodemeta.ErrLabelsJSONCorrupt), errors.Is(err, nodemeta.ErrSchedulingLabelRejected):
+		retCode = int(errorcode.ErrorCode_MasterParamsError)
 	}
 	common.WriteResponse(w, status, &sandboxtypes.Res{
 		Ret: &sandboxtypes.Ret{

--- a/CubeMaster/pkg/service/sandbox/sandbox_admit_test.go
+++ b/CubeMaster/pkg/service/sandbox/sandbox_admit_test.go
@@ -1,0 +1,79 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package sandbox
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/node"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/ret"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/errorcode"
+)
+
+func TestAdmitSelectedHost(t *testing.T) {
+	mk := func(id string, disabled bool) *node.Node {
+		n := &node.Node{InsID: id, IP: "10.0.0.1"}
+		n.SetSchedulingDisabled(disabled)
+		return n
+	}
+	cacheOf := func(nodes ...*node.Node) func(string) (*node.Node, bool) {
+		m := make(map[string]*node.Node, len(nodes))
+		for _, n := range nodes {
+			m[n.ID()] = n
+		}
+		return func(id string) (*node.Node, bool) {
+			n, ok := m[id]
+			return n, ok
+		}
+	}
+
+	t.Run("nil host", func(t *testing.T) {
+		got, err := admitSelectedHost(nil, cacheOf())
+		assert.Nil(t, got)
+		assertAdmitFailed(t, err, "no selected host")
+	})
+
+	t.Run("cache miss", func(t *testing.T) {
+		got, err := admitSelectedHost(mk("missing", false), cacheOf())
+		assert.Nil(t, got)
+		assertAdmitFailed(t, err, "missing from cache")
+	})
+
+	t.Run("cordoned", func(t *testing.T) {
+		host := mk("n1", true)
+		got, err := admitSelectedHost(mk("n1", false), cacheOf(host))
+		assert.Nil(t, got)
+		assertAdmitFailed(t, err, "scheduling-disabled")
+	})
+
+	t.Run("schedulable refreshes host", func(t *testing.T) {
+		fresh := mk("n1", false)
+		fresh.IP = "10.0.0.9"
+		selected := mk("n1", false)
+		selected.IP = "10.0.0.1"
+
+		got, err := admitSelectedHost(selected, cacheOf(fresh))
+		assert.NoError(t, err)
+		assert.Same(t, fresh, got)
+		assert.Equal(t, "10.0.0.9", got.HostIP())
+	})
+}
+
+func TestRefreshAndAdmitHostUsesLocalcache(t *testing.T) {
+	c := &createSandboxContext{}
+	err := c.refreshAndAdmitHost()
+	assertAdmitFailed(t, err, "no selected host")
+}
+
+func assertAdmitFailed(t *testing.T, err error, msgSubstr string) {
+	t.Helper()
+	assert.Error(t, err)
+	status, ok := ret.FromError(err)
+	assert.True(t, ok)
+	assert.Equal(t, errorcode.ErrorCode_SelectNodesFailed, status.Code())
+	assert.True(t, strings.Contains(status.Message(), msgSubstr), "msg=%q want substr %q", status.Message(), msgSubstr)
+}

--- a/CubeMaster/pkg/service/sandbox/sandbox_run.go
+++ b/CubeMaster/pkg/service/sandbox/sandbox_run.go
@@ -214,6 +214,20 @@ func (c *createSandboxContext) handleCubelet() {
 			return
 		}
 
+		// Final cordon gate on this replica before Cubelet Create.
+		if err := c.refreshAndAdmitHost(); err != nil {
+			if c.directHost {
+				status, _ := ret.FromError(err)
+				c.setMasterRsp(int(status.Code()), status.Message())
+				return
+			}
+			c.selctx.AddLastBadNode(c.selectHost)
+			c.reschedule = true
+			log.G(c.ctx).Warnf("selected host blocked by scheduling admission, reschedule host=%s err=%v",
+				c.selectHost.ID(), err)
+			continue
+		}
+
 		if c.callCubelet() {
 			c.retryCost += c.cubeletEndTime.Sub(c.cubeletStartTime)
 			c.retryTimes++
@@ -228,6 +242,22 @@ func (c *createSandboxContext) handleCubelet() {
 		c.dealSuccResult()
 		return
 	}
+}
+
+func (c *createSandboxContext) refreshAndAdmitHost() error {
+	if c.selectHost == nil {
+		return ret.Err(errorcode.ErrorCode_SelectNodesFailed, "no selected host")
+	}
+	current, ok := localcache.GetNode(c.selectHost.ID())
+	if !ok {
+		return ret.Errorf(errorcode.ErrorCode_SelectNodesFailed, "selected host missing from cache: %s", c.selectHost.ID())
+	}
+	c.selectHost = current
+	if !current.SchedulingAllowed() {
+		return ret.Errorf(errorcode.ErrorCode_SelectNodesFailed,
+			"node %s is scheduling-disabled (cordon); new sandboxes are not admitted", current.ID())
+	}
+	return nil
 }
 
 func (c *createSandboxContext) callCubelet() bool {

--- a/CubeMaster/pkg/service/sandbox/sandbox_run.go
+++ b/CubeMaster/pkg/service/sandbox/sandbox_run.go
@@ -245,19 +245,30 @@ func (c *createSandboxContext) handleCubelet() {
 }
 
 func (c *createSandboxContext) refreshAndAdmitHost() error {
-	if c.selectHost == nil {
-		return ret.Err(errorcode.ErrorCode_SelectNodesFailed, "no selected host")
-	}
-	current, ok := localcache.GetNode(c.selectHost.ID())
-	if !ok {
-		return ret.Errorf(errorcode.ErrorCode_SelectNodesFailed, "selected host missing from cache: %s", c.selectHost.ID())
+	current, err := admitSelectedHost(c.selectHost, localcache.GetNode)
+	if err != nil {
+		return err
 	}
 	c.selectHost = current
+	return nil
+}
+
+// admitSelectedHost re-reads the selected host from cache and rejects cordoned
+// nodes. getNode is injected so unit tests cover all admission paths without a
+// live localcache.
+func admitSelectedHost(selected *node.Node, getNode func(string) (*node.Node, bool)) (*node.Node, error) {
+	if selected == nil {
+		return nil, ret.Err(errorcode.ErrorCode_SelectNodesFailed, "no selected host")
+	}
+	current, ok := getNode(selected.ID())
+	if !ok {
+		return nil, ret.Errorf(errorcode.ErrorCode_SelectNodesFailed, "selected host missing from cache: %s", selected.ID())
+	}
 	if !current.SchedulingAllowed() {
-		return ret.Errorf(errorcode.ErrorCode_SelectNodesFailed,
+		return nil, ret.Errorf(errorcode.ErrorCode_SelectNodesFailed,
 			"node %s is scheduling-disabled (cordon); new sandboxes are not admitted", current.ID())
 	}
-	return nil
+	return current, nil
 }
 
 func (c *createSandboxContext) callCubelet() bool {


### PR DESCRIPTION
## Summary

Add cordon/uncordon (node isolation) support to CubeMaster, allowing operators to mark a node as scheduling-disabled so new sandboxes are **not** assigned to it while existing sandboxes continue to run unaffected.

## Motivation

Operations teams need the ability to temporarily take a node out of the scheduling pool—for planned maintenance, draining before upgrades, or fencing a degraded node—without killing running workloads. This PR introduces a lightweight, label-based cordon mechanism that is:

- **Control-plane owned**: only the isolation API can set/clear the cordon label; Cubelet register and the generic label API are explicitly blocked from touching it.
- **Database-backed**: labels persist in `node_meta_registration.labels_json`, surviving CubeMaster restarts and replicas.
- **Fail-safe**: corrupt `labels_json` causes scheduling to fail **closed** (node treated as cordoned).
- **Concurrent-safe**: per-node mutex serialises label read-modify-write operations (register, admin labels, isolation) to prevent lost updates.

## Changes

### New CLI (`cubemastercli`)

```bash
# Cordon one or more nodes
cubemastercli node isolate <node-id> [node-id ...]

# Remove cordon
cubemastercli node unisolate <node-id> [node-id ...]

# List nodes (shows SCHEDULING_DISABLED column)
cubemastercli node list
```

### HTTP API (`/internal/meta`)

| Method | Path | Handler |
|--------|------|---------|
| `PUT` | `/internal/meta/nodes/{node_id}/isolation` | Cordon node |
| `DELETE` | `/internal/meta/nodes/{node_id}/isolation` | Remove cordon |

### Core Logic (`pkg/nodemeta/`)

- **`isolation.go`** (new) — `SetNodeSchedulingDisabled()` with per-node mutex, DB transaction, and localcache sync. `stripAndPreserveSchedulingLabel()` ensures Cubelet cannot overwrite/delete control-plane labels.
- **`service.go`** — Label read-modify-write operations (register, admin labels) are now serialised under `labelWriteLocks`. `reload()` / `applyReloadResult()` synchronises cordon state across replicas. `toSchedulerNode()` sets `schedulingDisabled` on scheduler-facing `Node` objects. `readLabelsJSONForUpdate()` returns `ErrLabelsJSONCorrupt` for corrupt JSON (fail-closed).

### Scheduler (`pkg/base/node/`, selector filters)

- **`node.go`** — `SchedulingDisabled()` / `SchedulingAllowed()` backed by `atomic.Bool`; custom `MarshalJSON`/`UnmarshalJSON` serialise the field. `Clone()` correctly snapshots the atomic flag.
- **`prefilter.go` / `backofffilter.go`** — Use `GetSchedulableNodesByInstanceType()` instead of `GetHealthyNodesByInstanceType()`, excluding cordoned nodes from the scheduling pool.
- **`sandbox_run.go`** — Final admission gate: before dispatching to Cubelet, `refreshAndAdmitHost()` re-reads the node from localcache and rejects if it is now cordoned (handles race between selector selection and Cubelet dispatch).

### Localcache (`pkg/localcache/`)

- **`export.go`** — New `GetSchedulableNodesByInstanceType()`; refactors `GetHealthyNodes*` to share `collectCacheNodes`/`collectClusterNodes` helpers with a `requireSchedulable` flag.
- **`node_cache.go`** — `updateNodeFromMetaData()` sets `SchedulingDisabled` on the cached node.

### Constants (`pkg/base/constants/`)

- `LabelSchedulingDisabled = "cube.cloud.tencentcloud.com/scheduling-disabled"` — reserved label key, owned by control plane.
- `LabelSchedulingDisabledValue = "true"` — canonical value.

### Tests

| File | Coverage |
|------|----------|
| `pkg/nodemeta/isolation_test.go` (new) | Cord/uncordon unit tests, label strip/preserve, clone/export, reload sync |
| `pkg/base/node/node_scheduling_test.go` (new) | SchedulingDisabled/SchedulingAllowed decode + MarshalJSON round-trip |
| `pkg/localcache/export_schedulable_test.go` (new) | Schedulable node collection with cordon filtering |

## Verification

Manually verified on a single-node staging cluster:

1. Created a code-interpreter template (`sandbox-code:latest`) ✅
2. Ran Python code execution (E2B SDK) ✅
3. `cubemastercli node isolate <id>` → `SCHEDULING_DISABLED: true` ✅
4. Sandbox creation blocked → `no more resource` ✅
5. `cubemastercli node unisolate <id>` → `SCHEDULING_DISABLED: false` ✅
6. Sandbox creation restored ✅