### PR TITLE
fix(agent): show friendly error message when container creation fails

### DIFF
--- a/agent/cube/src/rootfs.rs
+++ b/agent/cube/src/rootfs.rs
@@ -75,7 +75,7 @@ pub struct PropagationContainerUmount {
 }
 
 pub fn exit_proc_failed(msg: String) {
-    println!("{}", msg);
+    eprintln!("{}", msg);
     std::process::exit(1);
 }
 

--- a/agent/rustjail/src/container.rs
+++ b/agent/rustjail/src/container.rs
@@ -1675,7 +1675,10 @@ pub async fn start_exec_process(
     println!("exec a child process");
     let exec_path = std::env::current_exe().map_err(|e| format!("get exe path failed:{}", e))?;
     let mut cmd = std::process::Command::new(exec_path);
-    cmd.arg("exec").env(ENV_CONTAINER_PID, format!("{}", pid));
+    cmd.arg("exec")
+        .env(ENV_CONTAINER_PID, format!("{}", pid))
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped());
     if let Some(mnt) = exec_mnts {
         cmd.env(ANNO_PROPAGATION_EXEC_MNTS, format!("{}", mnt));
     }
@@ -1685,22 +1688,45 @@ pub async fn start_exec_process(
     }
     let _lock = WAIT_PID_LOCKER.lock().await;
 
-    let mut child = cmd
+    let child = cmd
         .spawn()
         .map_err(|e| format!("spawn child process failed:{}", e))?;
-
-    let status = child
-        .wait()
+    let output = child
+        .wait_with_output()
         .map_err(|e| format!("wait child failed:{}", e))?;
-    match status.code() {
+    match output.status.code() {
         Some(code) => {
             if code != 0 {
-                return Err(format!("exec process exit code:{}", code));
+                // Surface the child's real failure reason (e.g.
+                // "the source dir X not exists") instead of a bare
+                // exit code. exit_proc_failed writes to stderr.
+                let detail = String::from_utf8_lossy(&output.stderr);
+                let detail = if detail.trim().is_empty() {
+                    String::from_utf8_lossy(&output.stdout)
+                } else {
+                    detail
+                };
+                let detail = detail.trim();
+                if detail.is_empty() {
+                    return Err(format!("exec process exit code:{}", code));
+                }
+                return Err(detail.to_string());
             }
         }
         None => {
             return Err("exec process terminated by signal".to_string());
         }
+    }
+
+    // On success, log child stdout for observability (was previously
+    // inherited to the agent's stdout before piping was added).
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    if !stdout.trim().is_empty() {
+        debug!(
+            slog_scope::logger(),
+            "exec mount child output: {}",
+            stdout.trim()
+        );
     }
 
     Ok(())


### PR DESCRIPTION
## Problem

When a user creates a template from a custom image that is missing required files (e.g. envd), container creation fails during mount propagation. The error message returned to the user is unhelpful — a bare exit code with no indication of what actually went wrong:

```
500: CubeMaster returned error code -1: failed to run container <id>:
  failed to create shim task: Others("...Exec mount failed:exec process
  exit code:1\n\nStack backtrace:...")
```

## Root Cause

`start_exec_process` in the agent spawns a child process (the agent binary re-executed with the `exec` subcommand) to perform mount propagation. When the child fails, it calls `exit_proc_failed()` which prints the real error reason (e.g. `"the source dir X not exists"`) and exits with code 1.

However, the parent process (`start_exec_process`) never captured the childs stdout/stderr — it only called `child.wait()` and checked the exit code. The real error message was printed to inherited stdout and lost; the parent returned only `"exec process exit code:1"`.

## Fix (2 files, +34/-8)

**`agent/rustjail/src/container.rs`** — `start_exec_process`:
- Add `.stdout(Stdio::piped()).stderr(Stdio::piped())` to the child Command
- Replace `child.wait()` with `child.wait_with_output()` which atomically waits and drains both pipes (also eliminates a potential pipe-buffer deadlock when the child output exceeds 64 KB)
- On failure (exit code ≠ 0), surface the childs stderr (preferred) or stdout as the error message instead of a bare exit code
- On success, log captured stdout via `slog::debug` to preserve observability

**`agent/cube/src/rootfs.rs`** — `exit_proc_failed`:
- Change `println!` to `eprintln!` so error messages go to stderr, cleanly separated from informational stdout output

## Test Results

### Environment
- CubeSandbox cluster deployed via PVM (single node)
- Fixed agent binary built with `cargo build --release` and injected into the guest image (`/sbin/init`)
- `busybox:latest` (from Tencent Cloud mirror) used as a minimal image that lacks envd and required mount sources

### Test 1: Regression check — normal sandbox creation
Created a sandbox from an existing READY template (`sandbox-code:latest`).

**Result: ✅ SUCCESS** — the fixed agent does not break normal operation.

### Test 2: Error scenario — sandbox from minimal image
1. Created a template from `busybox:latest` → **READY** (template `tpl-36d23022af304330bb7b6d74`)
2. Created a sandbox from the busybox template → triggers snapshot restore path → `start_exec_process` → mount propagation failure

**Error message comparison:**

| | Error Message |
|---|---|
| **Before fix** | `Exec mount failed:exec process exit code:1` |
| **After fix** | `Exec mount failed:open /proc/73/ns/mnt failed:No such file or directory (os error 2)` |

The user now sees the **specific failure reason** instead of a meaningless exit code.

### Test 3: Component-level test — direct agent binary test
Ran the fixed agent binary directly with the `exec` subcommand in three failure scenarios:

| Scenario | Captured Error (stderr) |
|---|---|
| Source dir not exists | `the source dir /nonexistent/snapshot/rootfs not exists` |
| Invalid PID | `open /proc/999999/ns/mnt failed:No such file or directory (os error 2)` |
| Missing env var | `Not found env: container.pid` |

All three cases produce clean, specific error messages on stderr, which `wait_with_output()` captures and returns to the caller.

### Compilation
```
cargo check -p cube-agent -p rustjail -p cube → all pass
cargo test -p rustjail -p cube → 57 passed, 1 pre-existing failure (unrelated)
```

Assisted-by: Oh My Pi:zai/glm-5.2