### PR TITLE
docs: add OpenCode integration guide and runnable examples (#644)

### DIFF
--- a/docs/guide/integrations/index.md
+++ b/docs/guide/integrations/index.md
@@ -48,3 +48,4 @@ lang: en-US
 | Title | Author | Date | Tags |
 | --- | --- | --- | --- |
 | [Pi Agent Integration Guide](./pi-agent.md) | chaojixinren | 2026-07-01 | integration, pi-agent, coding-agent, agent |
+| [OpenCode Integration Guide](./opencode.md) | chaojixinren | 2026-07-10 | integration, opencode, coding-agent, agent |

--- a/docs/guide/integrations/opencode.md
+++ b/docs/guide/integrations/opencode.md
@@ -1,0 +1,315 @@
+---
+title: OpenCode Integration Guide
+author: chaojixinren
+date: 2026-07-10
+tags:
+  - integration
+  - opencode
+  - coding-agent
+  - agent
+lang: en-US
+---
+
+# OpenCode Integration Guide
+
+[中文文档](../../zh/guide/integrations/opencode.md)
+
+Run [OpenCode](https://www.npmjs.com/package/opencode-ai) — a terminal-native AI
+coding agent — inside CubeSandbox MicroVMs. This guide covers image build, key
+injection, egress control, and snapshot-based session persistence, and pairs with
+the runnable
+[`examples/opencode-integration`](https://github.com/TencentCloud/CubeSandbox/tree/master/examples/opencode-integration)
+project.
+
+## Integration Target and Version
+
+| Component | Version |
+|---|---|
+| OpenCode CLI | `opencode-ai@1.17.18` (pinned via `ARG OPENCODE_VERSION`) |
+| Node.js | 24 (installed via NodeSource) |
+| CubeSandbox base image | `ghcr.io/tencentcloud/cubesandbox-base:2026.16` |
+| CubeSandbox SDK (host driver) | `cubesandbox==0.3.0` |
+| CubeSandbox platform | `>= 0.3.0` (pause/resume) / `>= 0.4.0` (CubeEgress credential vault) |
+
+## Prerequisites
+
+- A running CubeSandbox deployment; CubeAPI reachable at `http://<node>:3000`.
+- `cubemastercli` on `$PATH`, connected to the cluster.
+- Docker on the build workstation, plus a registry the Cube nodes can pull from.
+- An LLM provider API key. Supported providers: `anthropic`, `openai`, `deepseek`,
+  and `openrouter`.
+- Python 3.10+ for the host driver scripts.
+
+## Why Run OpenCode Inside a Sandbox
+
+OpenCode is a terminal agent that edits files, runs commands, and installs
+packages. Running it directly on a workstation blends the agent's blast radius
+with your dev environment. Running it inside CubeSandbox gives you:
+
+| Concern | CubeSandbox provides |
+|---|---|
+| **Isolation** | KVM MicroVM per session, dedicated guest kernel |
+| **Reproducibility** | Every session boots from the same template snapshot |
+| **Fast spin-up** | Sub-60 ms cold start, so N-parallel agents are cheap |
+| **Long tasks** | `sandbox.pause()` snapshots VM + rootfs; resume later |
+| **Key hygiene** | CubeEgress injects the auth header on the wire — the VM never sees the real key |
+| **Egress audit** | Every request to the LLM API is recorded in the egress audit log |
+
+## Integration Steps
+
+### 1. Build the template image
+
+The image stacks Node.js 24 and the OpenCode CLI on top of `cubesandbox-base`, so
+envd is already listening on `:49983`.
+
+```dockerfile
+# examples/opencode-integration/Dockerfile (excerpt)
+ARG CUBE_BASE_IMAGE=ghcr.io/tencentcloud/cubesandbox-base:2026.16
+FROM ${CUBE_BASE_IMAGE}
+
+ARG NODE_MAJOR=24
+ARG OPENCODE_VERSION=1.17.18
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        bash ca-certificates curl git gnupg jq less procps \
+        python3 python3-pip ripgrep \
+    && curl -fsSL "https://deb.nodesource.com/setup_${NODE_MAJOR}.x" | bash - \
+    && apt-get install -y --no-install-recommends nodejs \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN npm install -g "opencode-ai@${OPENCODE_VERSION}" \
+    && opencode --version \
+    && npm cache clean --force \
+    && rm -rf /root/.npm
+
+WORKDIR /workspace
+EXPOSE 49983
+```
+
+Build and push:
+
+```bash
+docker build --platform linux/amd64 \
+  -t <your-registry>/opencode-cube:latest \
+  examples/opencode-integration
+docker push <your-registry>/opencode-cube:latest
+```
+
+### 2. Register as a Cube template
+
+```bash
+cubemastercli tpl create-from-image \
+  --image <your-registry>/opencode-cube:latest \
+  --writable-layer-size 4G \
+  --expose-port 49983 \
+  --probe       49983 \
+  --probe-path  /health
+
+cubemastercli tpl watch --job-id <job_id>
+```
+
+Once the job reaches `READY`, note the `template_id` — you pass it to every
+`Sandbox.create()` call. `4G` writable layer suits medium tasks; bump to `8G+`
+if the agent installs large toolchains.
+
+### 3. Wire up the host driver
+
+```bash
+cd examples/opencode-integration
+cp .env.example .env
+# fill in CUBE_API_URL, CUBE_TEMPLATE_ID, and your provider key
+pip install -r requirements.txt
+```
+
+| Variable | Where it flows | Notes |
+|---|---|---|
+| `CUBE_API_URL` | Local process | CubeAPI address (`http://<node>:3000`) |
+| `CUBE_TEMPLATE_ID` | `Sandbox.create(template=...)` | From step 2 |
+| `OPENCODE_PROVIDER` | Provider selection | `anthropic`, `openai`, `deepseek`, or `openrouter` |
+| `OPENCODE_MODEL` | OpenCode `--model` flag | Must use `provider/model` form |
+| `ANTHROPIC_API_KEY` (or provider key) | `envs=...` (direct) or CubeEgress inject (vault) | Provider key |
+| `OPENCODE_LLM_HOST` | `network_policy.py` | Override LLM host for CubeEgress rules |
+| `OPENCODE_WORKSPACE` | `--dir` flag | Workspace inside the sandbox |
+| `OPENCODE_SANDBOX_TIMEOUT` | `Sandbox.create(timeout=...)` | Sandbox lifetime in seconds |
+| `OPENCODE_EXEC_TIMEOUT` | `commands.run(timeout=...)` | Per-command timeout |
+| `OPENCODE_NODE_CA_BUNDLE` | `NODE_EXTRA_CA_CERTS` | CA bundle for CubeEgress TLS (vault) |
+
+### 4. Runtime Configuration and API Key Injection
+
+OpenCode is invoked non-interactively with `opencode run --model <model>
+--dir <workspace> --auto --format json <prompt>`. The `--auto` flag approves
+tool calls without user confirmation, `--format json` emits machine-readable
+JSON events, and the prompt is the trailing positional argument. Two key-flow
+flavors share the same template:
+
+**Direct flavor** — forward the key per command. The `cubesandbox` SDK's
+`commands.run(envs=...)` puts the environment into the exec envelope, not into
+a persistent file inside the VM, so the key lives only for the lifetime of that
+command:
+
+```python
+result = sandbox.commands.run(
+    "opencode run --model anthropic/claude-sonnet-4-6 "
+    "--dir /workspace --auto --format json 'do something'",
+    envs={"ANTHROPIC_API_KEY": key},
+    user="root",
+    timeout=900,
+)
+```
+
+**Vault flavor** — keep the key out of the VM entirely (see step 6).
+
+The example scripts parse the JSON event stream and print a concise transcript
+by default; the raw output is available through `result.stdout`.
+
+### 5. Session Persistence (pause / resume)
+
+```bash
+python snapshot_restore.py
+```
+
+This mirrors the [snapshot / clone / rollback](../snapshot-rollback-clone.md)
+engine at the SDK layer:
+
+- `sandbox.pause()` snapshots the running VM (memory + rootfs) and frees compute.
+- `Sandbox.connect(sandbox_id)` resumes with `/workspace`, OpenCode's state
+  directories (`/root/.config/opencode`, `/root/.local/share/opencode`), and
+  every other file intact.
+
+> **Lifecycle caveat:** manage the sandbox lifecycle with `try/finally`, not a
+> `with Sandbox.create(...)` context manager. On `__exit__` the context manager
+> kills the sandbox, which would undo the pause. The example creates the sandbox
+> explicitly and only calls `sandbox.kill()` in `finally`.
+
+```python
+sandbox = Sandbox.create(template=template_id, timeout=1800)
+try:
+    run_turn(sandbox, prompt_1)          # writes /workspace/plan.md
+    sandbox_id = sandbox.pause() or sandbox.sandbox_id
+    sandbox = Sandbox.connect(sandbox_id)
+    assert_state_survived(sandbox)       # /workspace + OpenCode state intact
+    run_turn(sandbox, prompt_2, continue_last=True)  # continues the work
+finally:
+    sandbox.kill()
+```
+
+The resumed turn passes `--continue` so OpenCode picks up the previous session
+context rather than starting a new one.
+
+### 6. Network and Egress Policy (credential vault)
+
+`network_policy.py` demonstrates the recommended pattern for shared clusters:
+default-deny egress plus on-the-wire key injection.
+
+```python
+# Credential injection uses the native cubesandbox SDK (see security-proxy.md).
+from cubesandbox import Sandbox, Rule, Match, Action, Inject
+
+host = "api.anthropic.com"
+rules = [
+    Rule(
+        name="allow_anthropic_llm",
+        match=Match(scheme="https", sni=host, host=host),
+        action=Action(allow=True, audit="metadata", inject=[
+            Inject(header="x-api-key", secret=ANTHROPIC_API_KEY, format="${SECRET}"),
+        ]),
+    ),
+]
+
+sandbox = Sandbox.create(
+    template=CUBE_TEMPLATE_ID,
+    allow_internet_access=False,   # default-deny; the rule's host is auto-allowed
+    network={"rules": rules},
+)
+```
+
+Effect:
+
+- `printenv ANTHROPIC_API_KEY` inside the sandbox shows only a placeholder.
+- Every request to the LLM host gets the auth header attached on the wire.
+- Anything else is dropped by CubeVS at L3/L4 (`allow_internet_access=False`) and
+  never leaves the sandbox.
+- Every allow / deny decision lands in the egress audit log.
+
+For non-Anthropic providers the example injects an `Authorization: Bearer` header
+instead. If a provider does not accept a header-injected key, fall back to the
+direct flavor (`envs=...`) — but never write the key into a persistent file
+inside the sandbox.
+
+## Use Cases and Best Practices
+
+- **Isolated development.** Run the coding agent inside the sandbox so its file
+  edits and shell commands cannot touch the host.
+- **Execute agent-generated code and collect results.** Have the agent write to
+  `/workspace`, then read artifacts back via `sandbox.files` or `commands.run`.
+- **Checkpoint / resume long tasks.** Use `pause()` + `connect()` to snapshot a
+  long refactor and resume later, or fork multiple task variants off one snapshot.
+- **Preinstall heavy dependencies** into the template rather than fetching them
+  at runtime, especially under a default-deny egress policy.
+
+## Key Code Snippets
+
+### Headless OpenCode invocation
+
+```python
+cmd = (
+    "opencode run --model anthropic/claude-sonnet-4-6 "
+    "--dir /workspace --auto --format json "
+    "'Inspect the project, run app.py, and summarize the result.'"
+)
+result = sandbox.commands.run(cmd, envs=opencode_env, user="root", timeout=900)
+```
+
+### Preflight version check
+
+```python
+version = sandbox.commands.run("opencode --version", timeout=60)
+```
+
+## Caveats
+
+- **Node.js version.** OpenCode needs a recent Node runtime; the base image
+  ships an older apt Node, so always install via NodeSource (the Dockerfile does).
+- **OpenCode state directories.** `/root/.config/opencode` and
+  `/root/.local/share/opencode` hold OpenCode's configuration and session data.
+  Keep them empty in the image to avoid leaking sessions across tenants; they are
+  created at build time but not populated with any credentials.
+- **Direct-flavor key persistence.** With the direct flavor (`envs=`) the key is
+  scoped to the exec call, but OpenCode may cache provider credentials under its
+  state directories, which survive `pause()` / `resume()`. For strict isolation
+  prefer the vault flavor (`network_policy.py`), where the key never enters the
+  VM.
+- **CubeEgress CA (Node).** For the vault flavor the sandbox must trust the
+  CubeEgress root CA, which the base image installs into the system bundle.
+  OpenCode runs on Node.js, which ignores the system store, so
+  `network_policy.py` also sets `NODE_EXTRA_CA_CERTS` (override via
+  `OPENCODE_NODE_CA_BUNDLE`) — without it the vault path fails with
+  `Connection error`.
+- **Egress side-effects.** Tasks that `npm install` or fetch MCP tools need those
+  hosts allowed or preinstalled into the template.
+- **Interactive TTY features.** The OpenCode TUI is not available over the
+  CubeSandbox protocol. Use headless `opencode run --format json` and drive
+  multi-turn conversations from the host script.
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| `opencode: command not found` in preflight | Template not rebuilt after CLI change | Rebuild the image, re-register the template |
+| Provider auth failure | Key not forwarded (direct) or missing inject rule (vault) | Pass `envs={...}` or fix the rule's `sni`/`host` |
+| `403 Forbidden - CubeEgress` | Default-deny with no matching allow rule | Add the LLM host (and any extra hosts) to the rules |
+| `Connection error` / TLS failure from OpenCode (vault) | OpenCode's Node runtime ignores the system CA store, so it won't trust the CubeEgress CA | The example sets `NODE_EXTRA_CA_CERTS`; override with `OPENCODE_NODE_CA_BUNDLE` if the CA lives elsewhere |
+| Template creation stuck in `PULLING` | Registry unreachable from Cube nodes | Push to a registry the cluster can reach; supply auth if needed |
+| Readiness probe timeout | Base image without envd | Ensure `FROM ghcr.io/tencentcloud/cubesandbox-base:2026.16` |
+| `pause()` / `connect()` errors | Platform too old for snapshots | Upgrade the CubeSandbox platform |
+| `OPENCODE_MODEL` validation error | Model string missing `provider/model` form | Use the format `anthropic/claude-sonnet-4-6` |
+
+## References
+
+- Runnable example: [`examples/opencode-integration`](https://github.com/TencentCloud/CubeSandbox/tree/master/examples/opencode-integration)
+- Bring Your Own Image: [`docs/guide/tutorials/bring-your-own-image.md`](../tutorials/bring-your-own-image.md)
+- Template from image: [`docs/guide/tutorials/template-from-image.md`](../tutorials/template-from-image.md)
+- Snapshot / Clone / Rollback: [`docs/guide/snapshot-rollback-clone.md`](../snapshot-rollback-clone.md)
+- Credential vault + egress control: [`docs/guide/security-proxy.md`](../security-proxy.md)
+- OpenCode CLI: <https://www.npmjs.com/package/opencode-ai>

--- a/docs/zh/guide/integrations/index.md
+++ b/docs/zh/guide/integrations/index.md
@@ -48,3 +48,4 @@ lang: zh-CN
 | 标题 | 作者 | 日期 | 标签 |
 | --- | --- | --- | --- |
 | [Pi Agent 集成指南](./pi-agent.md) | chaojixinren | 2026-07-01 | integration, pi-agent, coding-agent, agent |
+| [OpenCode 集成指南](./opencode.md) | chaojixinren | 2026-07-10 | integration, opencode, coding-agent, agent |

--- a/docs/zh/guide/integrations/opencode.md
+++ b/docs/zh/guide/integrations/opencode.md
@@ -1,0 +1,272 @@
+---
+title: OpenCode 集成指南
+author: chaojixinren
+date: 2026-07-10
+tags:
+  - integration
+  - opencode
+  - coding-agent
+  - agent
+lang: zh-CN
+---
+
+# OpenCode 集成指南
+
+[English](../../../guide/integrations/opencode.md)
+
+在 CubeSandbox MicroVM 内运行 [OpenCode](https://www.npmjs.com/package/opencode-ai)
+（面向终端的 AI 编码 Agent）。本文覆盖镜像构建、密钥注入、出网管控，以及基于快照的会话持久化，配套的可运行示例位于
+[`examples/opencode-integration`](https://github.com/TencentCloud/CubeSandbox/tree/master/examples/opencode-integration)。
+
+## 集成对象与版本
+
+| 组件 | 版本 |
+|---|---|
+| OpenCode CLI | `opencode-ai@1.17.18`（通过 `ARG OPENCODE_VERSION` 固定） |
+| Node.js | 24（通过 NodeSource 安装） |
+| CubeSandbox 基础镜像 | `ghcr.io/tencentcloud/cubesandbox-base:2026.16` |
+| CubeSandbox SDK（宿主端驱动） | `cubesandbox==0.3.0` |
+| CubeSandbox 平台 | `>= 0.3.0`（pause/resume）/ `>= 0.4.0`（CubeEgress 密钥保险柜） |
+
+## 前置条件
+
+- 已部署 CubeSandbox，CubeAPI 可访问（`http://<node>:3000`）。
+- `cubemastercli` 已在 `$PATH` 且已连通集群。
+- 构建机装有 Docker，且 registry 能被 Cube 集群拉取。
+- 一个 LLM provider 的 API Key。支持的 provider：`anthropic`、`openai`、`deepseek` 和 `openrouter`。
+- Python 3.10+（宿主端驱动脚本）。
+
+## 为什么要把 OpenCode 放进沙箱
+
+OpenCode 是一个会编辑文件、执行命令、安装依赖的终端 Agent。直接跑在开发机上，Agent 的"爆炸半径"就等于你的开发环境。放进 CubeSandbox 你能拿到：
+
+| 关注点 | CubeSandbox 提供 |
+|---|---|
+| **隔离** | 每个会话一个 KVM MicroVM，独立 guest kernel |
+| **可复现** | 每次会话都从同一个 template 快照启动 |
+| **秒起** | 冷启动 <60ms，N 路并行代价极小 |
+| **长任务** | `sandbox.pause()` 对 VM + rootfs 打快照，稍后恢复 |
+| **密钥卫生** | CubeEgress 在链路上注入鉴权头，VM 看不到真实密钥 |
+| **出网审计** | 每次访问 LLM API 都会记入出网审计日志 |
+
+## 集成步骤
+
+### 1. 构建模板镜像
+
+镜像在 `cubesandbox-base` 上叠加 Node.js 24 与 OpenCode CLI，envd 已监听 `:49983`。
+
+```dockerfile
+# examples/opencode-integration/Dockerfile（节选）
+ARG CUBE_BASE_IMAGE=ghcr.io/tencentcloud/cubesandbox-base:2026.16
+FROM ${CUBE_BASE_IMAGE}
+
+ARG NODE_MAJOR=24
+ARG OPENCODE_VERSION=1.17.18
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        bash ca-certificates curl git gnupg jq less procps \
+        python3 python3-pip ripgrep \
+    && curl -fsSL "https://deb.nodesource.com/setup_${NODE_MAJOR}.x" | bash - \
+    && apt-get install -y --no-install-recommends nodejs \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN npm install -g "opencode-ai@${OPENCODE_VERSION}" \
+    && opencode --version \
+    && npm cache clean --force \
+    && rm -rf /root/.npm
+
+WORKDIR /workspace
+EXPOSE 49983
+```
+
+构建并推送：
+
+```bash
+docker build --platform linux/amd64 \
+  -t <your-registry>/opencode-cube:latest \
+  examples/opencode-integration
+docker push <your-registry>/opencode-cube:latest
+```
+
+### 2. 注册为 Cube 模板
+
+```bash
+cubemastercli tpl create-from-image \
+  --image <your-registry>/opencode-cube:latest \
+  --writable-layer-size 4G \
+  --expose-port 49983 \
+  --probe       49983 \
+  --probe-path  /health
+
+cubemastercli tpl watch --job-id <job_id>
+```
+
+任务变为 `READY` 后记下 `template_id`，后续每次 `Sandbox.create()` 都要用它。`4G` 可写层适合中等任务；若
+Agent 会安装大型工具链，提升到 `8G+`。
+
+### 3. 配置宿主端驱动
+
+```bash
+cd examples/opencode-integration
+cp .env.example .env
+# 填写 CUBE_API_URL、CUBE_TEMPLATE_ID 以及你的 provider key
+pip install -r requirements.txt
+```
+
+| 变量 | 作用位置 | 说明 |
+|---|---|---|
+| `CUBE_API_URL` | 本地进程 | CubeAPI 地址（`http://<node>:3000`） |
+| `CUBE_TEMPLATE_ID` | `Sandbox.create(template=...)` | 来自第 2 步 |
+| `OPENCODE_PROVIDER` | provider 选择 | `anthropic`、`openai`、`deepseek` 或 `openrouter` |
+| `OPENCODE_MODEL` | OpenCode `--model` 参数 | 必须使用 `provider/model` 格式 |
+| `ANTHROPIC_API_KEY`（或对应 provider key） | `envs=...`（直连）或 CubeEgress 注入（保险柜） | provider 密钥 |
+| `OPENCODE_LLM_HOST` | `network_policy.py` | 覆盖 LLM host，用于 CubeEgress 规则 |
+| `OPENCODE_WORKSPACE` | `--dir` 参数 | 沙箱内工作区 |
+| `OPENCODE_SANDBOX_TIMEOUT` | `Sandbox.create(timeout=...)` | 沙箱生命周期（秒） |
+| `OPENCODE_EXEC_TIMEOUT` | `commands.run(timeout=...)` | 单命令超时 |
+| `OPENCODE_NODE_CA_BUNDLE` | `NODE_EXTRA_CA_CERTS` | CubeEgress TLS CA 包（保险柜方式） |
+
+### 4. 运行时配置与 API Key 注入
+
+OpenCode 以非交互方式调用：`opencode run --model <model> --dir <workspace> --auto --format json <prompt>`。`--auto` 表示自动批准工具调用，`--format json` 输出机器可读的 JSON 事件流，prompt 作为末尾的位置参数传入。两种密钥流转方式共用同一个模板：
+
+**直连方式** —— 逐命令传入密钥。`cubesandbox` SDK 的 `commands.run(envs=...)` 把环境放进 exec 信封，而非 VM 内的持久文件，因此密钥只在该命令执行期间存在：
+
+```python
+result = sandbox.commands.run(
+    "opencode run --model anthropic/claude-sonnet-4-6 "
+    "--dir /workspace --auto --format json 'do something'",
+    envs={"ANTHROPIC_API_KEY": key},
+    user="root",
+    timeout=900,
+)
+```
+
+**保险柜方式** —— 让密钥完全不进入 VM（见第 6 步）。
+
+示例脚本会解析 JSON 事件流，默认打印精简转写；原始输出可通过 `result.stdout` 获取。
+
+### 5. 会话持久化（pause / resume）
+
+```bash
+python snapshot_restore.py
+```
+
+它在 SDK 层复用了[快照 / 克隆 / 回滚](../snapshot-rollback-clone.md)引擎：
+
+- `sandbox.pause()` 对运行中的 VM（内存 + rootfs）打快照并释放算力。
+- `Sandbox.connect(sandbox_id)` 恢复时，`/workspace`、OpenCode 状态目录（`/root/.config/opencode`、`/root/.local/share/opencode`）及其他文件都完好无损。
+
+> **生命周期注意：** 用 `try/finally` 手动管理沙箱，不要用 `with Sandbox.create(...)` context manager。
+> context manager 在 `__exit__` 时会 kill 沙箱，这会让 pause 失效。示例显式创建沙箱，只在 `finally` 里调用
+> `sandbox.kill()`。
+
+```python
+sandbox = Sandbox.create(template=template_id, timeout=1800)
+try:
+    run_turn(sandbox, prompt_1)          # 写入 /workspace/plan.md
+    sandbox_id = sandbox.pause() or sandbox.sandbox_id
+    sandbox = Sandbox.connect(sandbox_id)
+    assert_state_survived(sandbox)       # /workspace + OpenCode 状态仍在
+    run_turn(sandbox, prompt_2, continue_last=True)  # 继续工作
+finally:
+    sandbox.kill()
+```
+
+恢复轮次传入 `--continue`，使 OpenCode 接续上一个会话上下文，而非开启新会话。
+
+### 6. 网络与出网策略（密钥保险柜）
+
+`network_policy.py` 展示了推荐用于共享集群的模式：默认拒绝出网 + 链路上注入密钥。
+
+```python
+# 凭证注入使用原生 cubesandbox SDK（见 security-proxy.md）。
+from cubesandbox import Sandbox, Rule, Match, Action, Inject
+
+host = "api.anthropic.com"
+rules = [
+    Rule(
+        name="allow_anthropic_llm",
+        match=Match(scheme="https", sni=host, host=host),
+        action=Action(allow=True, audit="metadata", inject=[
+            Inject(header="x-api-key", secret=ANTHROPIC_API_KEY, format="${SECRET}"),
+        ]),
+    ),
+]
+
+sandbox = Sandbox.create(
+    template=CUBE_TEMPLATE_ID,
+    allow_internet_access=False,   # 默认拒绝；规则里的 host 会被自动放行
+    network={"rules": rules},
+)
+```
+
+效果：
+
+- 沙箱内 `printenv ANTHROPIC_API_KEY` 只显示占位值。
+- 每次访问 LLM host 都会在链路上被附加鉴权头。
+- 其他任何目的地都会被 CubeVS 在 L3/L4 层丢弃（`allow_internet_access=False`），根本无法离开沙箱。
+- 每条 allow / deny 决策都会记入出网审计日志。
+
+非 Anthropic provider 时，示例会改注入 `Authorization: Bearer` 头。若某 provider 不接受 header 注入的密钥，可回退到直连方式（`envs=...`）—— 但绝不要把密钥写进沙箱内的持久文件。
+
+## 使用场景与最佳实践
+
+- **隔离开发。** 把编码 Agent 跑在沙箱内，其文件编辑与 shell 命令无法触及宿主。
+- **执行 Agent 生成的代码并回收结果。** 让 Agent 写入 `/workspace`，再通过 `sandbox.files` 或
+  `commands.run` 读回产物。
+- **长任务断点续跑。** 用 `pause()` + `connect()` 给长时间重构打快照并稍后恢复，或从一个快照分叉多个任务变体。
+- **把重依赖预装进模板**，而不是运行时拉取，尤其在默认拒绝出网的策略下。
+
+## 关键代码片段
+
+### 无交互调用 OpenCode
+
+```python
+cmd = (
+    "opencode run --model anthropic/claude-sonnet-4-6 "
+    "--dir /workspace --auto --format json "
+    "'Inspect the project, run app.py, and summarize the result.'"
+)
+result = sandbox.commands.run(cmd, envs=opencode_env, user="root", timeout=900)
+```
+
+### preflight 版本检查
+
+```python
+version = sandbox.commands.run("opencode --version", timeout=60)
+```
+
+## 注意事项
+
+- **Node.js 版本。** OpenCode 需要较新的 Node 运行时；基础镜像自带的 apt Node 偏旧，务必通过 NodeSource 安装（Dockerfile 已如此）。
+- **OpenCode 状态目录。** `/root/.config/opencode` 和 `/root/.local/share/opencode` 保存 OpenCode 的配置与会话数据。镜像里保持它们为空，避免跨租户泄露会话；它们在构建时创建但不写入任何凭证。
+- **直连方式的密钥留存。** 直连方式（`envs=`）下密钥仅作用于该 exec 调用，但 OpenCode 可能把 provider 凭证缓存到其状态目录，会在 `pause()` / `resume()` 后仍留在盘上。对隔离要求高时优先用保险柜方式（`network_policy.py`），密钥完全不进入 VM。
+- **CubeEgress CA（Node）。** 保险柜方式要求沙箱信任 CubeEgress 根 CA，基础镜像已把它装入系统 CA 包。
+  但 OpenCode 基于 Node.js、忽略系统 CA 库，因此 `network_policy.py` 还会设置 `NODE_EXTRA_CA_CERTS`
+  （可用 `OPENCODE_NODE_CA_BUNDLE` 覆盖）——否则保险柜路径会以 `Connection error` 失败。
+- **出网副作用。** 需要 `npm install` 或拉取 MCP 工具的任务，要放行相应 host 或预装进模板。
+- **交互式 TTY 功能。** OpenCode TUI 在 CubeSandbox 协议下不可用。请用无交互 `opencode run --format json`，多轮对话由宿主脚本驱动。
+
+## 排错
+
+| 现象 | 可能原因 | 处理 |
+|---|---|---|
+| preflight 报 `opencode: command not found` | CLI 变更后未重建模板 | 重建镜像并重新注册模板 |
+| provider 鉴权失败 | 密钥未传入（直连）或缺少 inject 规则（保险柜） | 传 `envs={...}` 或修正规则的 `sni`/`host` |
+| `403 Forbidden - CubeEgress` | 默认拒绝且无匹配放行规则 | 把 LLM host（及所需其他 host）加入规则 |
+| 保险柜下 OpenCode 报 `Connection error` / TLS 失败 | OpenCode 的 Node 运行时忽略系统 CA 库，不信任 CubeEgress CA | 示例已设 `NODE_EXTRA_CA_CERTS`；若 CA 在别处用 `OPENCODE_NODE_CA_BUNDLE` 覆盖 |
+| 模板创建卡在 `PULLING` | Cube 节点无法访问 registry | 推送到集群可访问的 registry，必要时提供鉴权 |
+| 就绪探针超时 | 基础镜像缺少 envd | 确认 `FROM ghcr.io/tencentcloud/cubesandbox-base:2026.16` |
+| `pause()` / `connect()` 报错 | 平台版本过低不支持快照 | 升级 CubeSandbox 平台 |
+| `OPENCODE_MODEL` 校验失败 | 模型字符串缺少 `provider/model` 格式 | 使用 `anthropic/claude-sonnet-4-6` 格式 |
+
+## 参考
+
+- 可运行示例：[`examples/opencode-integration`](https://github.com/TencentCloud/CubeSandbox/tree/master/examples/opencode-integration)
+- 自带镜像：[`docs/guide/tutorials/bring-your-own-image.md`](../tutorials/bring-your-own-image.md)
+- 从镜像构建模板：[`docs/guide/tutorials/template-from-image.md`](../tutorials/template-from-image.md)
+- 快照 / 克隆 / 回滚：[`docs/guide/snapshot-rollback-clone.md`](../snapshot-rollback-clone.md)
+- 密钥保险柜 + 出网管控：[`docs/guide/security-proxy.md`](../security-proxy.md)
+- OpenCode CLI：<https://www.npmjs.com/package/opencode-ai>

--- a/examples/opencode-integration/.env.example
+++ b/examples/opencode-integration/.env.example
@@ -1,0 +1,49 @@
+# --- CubeSandbox connection ---
+
+# Required: CubeAPI address. Use CubeAPI, not CubeProxy.
+CUBE_API_URL="http://<cube-host>:3000"
+
+# Required: template created from this example's Dockerfile.
+CUBE_TEMPLATE_ID="<template-id>"
+
+# Optional: direct node routing for the native SDK file/command data path.
+# CUBE_PROXY_NODE_IP="<cube-proxy-node-ip>"
+# CUBE_PROXY_PORT_HTTP="80"
+# CUBE_SANDBOX_DOMAIN="cube.app"
+
+# --- OpenCode provider ---
+
+# Required: currently supported values are anthropic, openai, deepseek, and
+# openrouter. OPENCODE_MODEL must use OpenCode's provider/model form.
+OPENCODE_PROVIDER="anthropic"
+OPENCODE_MODEL="anthropic/claude-sonnet-4-6"
+
+# Required: configure only the key for the selected provider. The one-shot
+# example can pass it directly to the command. The restricted-egress example
+# keeps the real value on the host and places only a placeholder in the VM.
+ANTHROPIC_API_KEY="<your-anthropic-api-key>"
+# OPENAI_API_KEY="<your-openai-api-key>"
+# DEEPSEEK_API_KEY="<your-deepseek-api-key>"
+# OPENROUTER_API_KEY="<your-openrouter-api-key>"
+
+# Optional: override the provider's standard API hostname. A URL is accepted;
+# only its hostname is used when constructing CubeEgress rules.
+# OPENCODE_LLM_HOST="api.anthropic.com"
+
+# Optional: inline OpenCode JSON configuration, for example when using a custom
+# OpenAI-compatible base URL. Keep credentials out of this value.
+# OPENCODE_CONFIG_CONTENT='{"$schema":"https://opencode.ai/config.json"}'
+
+# --- Runtime behavior ---
+
+OPENCODE_WORKSPACE="/workspace"
+OPENCODE_SANDBOX_TIMEOUT="1800"
+OPENCODE_EXEC_TIMEOUT="900"
+
+# CubeEgress terminates TLS to inject credentials. Node.js needs an explicit CA
+# bundle containing the CubeEgress root CA.
+OPENCODE_NODE_CA_BUNDLE="/etc/ssl/certs/ca-certificates.crt"
+
+# The restricted-egress runner exposes this value inside the VM so OpenCode
+# emits its normal auth header; CubeEgress replaces it on the wire.
+OPENCODE_PLACEHOLDER_KEY="cube-egress-managed-placeholder"

--- a/examples/opencode-integration/Dockerfile
+++ b/examples/opencode-integration/Dockerfile
@@ -1,0 +1,55 @@
+# syntax=docker/dockerfile:1.7
+#
+# OpenCode inside a CubeSandbox template.
+#
+# The inherited cube-entrypoint keeps envd listening on :49983. Do not replace
+# the base image ENTRYPOINT or CMD: CubeSandbox uses envd for command, file, and
+# readiness APIs.
+
+ARG CUBE_BASE_IMAGE=ghcr.io/tencentcloud/cubesandbox-base:2026.16
+FROM ${CUBE_BASE_IMAGE}
+
+ARG DEBIAN_FRONTEND=noninteractive
+ARG NODE_MAJOR=24
+ARG OPENCODE_VERSION=1.17.18
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        bash \
+        ca-certificates \
+        curl \
+        git \
+        gnupg \
+        jq \
+        less \
+        procps \
+        python3 \
+        python3-pip \
+        ripgrep \
+    && curl -fsSL "https://deb.nodesource.com/setup_${NODE_MAJOR}.x" | bash - \
+    && apt-get install -y --no-install-recommends nodejs \
+    && rm -rf /var/lib/apt/lists/*
+
+# opencode-ai's postinstall script installs the platform-specific binary, so
+# npm lifecycle scripts must remain enabled. Pinning the version makes template
+# rebuilds deterministic and prevents an upstream CLI change from silently
+# changing the documented command contract.
+RUN npm install -g "opencode-ai@${OPENCODE_VERSION}" \
+    && opencode --version \
+    && npm cache clean --force \
+    && rm -rf /root/.npm
+
+ENV OPENCODE_AUTO_SHARE=false \
+    OPENCODE_DISABLE_AUTOUPDATE=true \
+    OPENCODE_DISABLE_PRUNE=true \
+    OPENCODE_DISABLE_TERMINAL_TITLE=true \
+    NPM_CONFIG_UPDATE_NOTIFIER=false
+
+RUN mkdir -p \
+        /workspace \
+        /root/.config/opencode \
+        /root/.local/share/opencode
+
+WORKDIR /workspace
+
+EXPOSE 49983

--- a/examples/opencode-integration/README.md
+++ b/examples/opencode-integration/README.md
@@ -1,0 +1,140 @@
+# OpenCode × CubeSandbox Integration
+
+Run [OpenCode](https://www.npmjs.com/package/opencode-ai) — a terminal-native AI
+coding agent — inside CubeSandbox MicroVMs with hardware-level isolation,
+snapshot-based session persistence, and optional default-deny egress with
+on-the-wire credential injection.
+
+> Full integration guide: [`docs/guide/integrations/opencode.md`](../../docs/guide/integrations/opencode.md)
+
+## Prerequisites
+
+| Requirement | Notes |
+|---|---|
+| CubeSandbox deployment | CubeAPI reachable at `http://<node>:3000` |
+| `cubemastercli` | On `$PATH`, connected to the cluster |
+| Python | 3.9+ |
+| Docker | Build workstation + registry the Cube nodes can pull from |
+| LLM provider API key | `anthropic`, `openai`, `deepseek`, or `openrouter` |
+
+## Quick Start
+
+### 1. Build and register the template
+
+```bash
+# All environment variables are optional; defaults shown
+# REGISTRY=ghcr.io/tencentcloud  IMAGE_NAME=opencode-cube  IMAGE_TAG=latest
+./build-template.sh
+```
+
+The script builds the Docker image, pushes it, registers it with
+`cubemastercli tpl create-from-image`, watches the build job, and prints
+the final `template_id` once it reaches `READY`.
+
+### 2. Configure `.env`
+
+```bash
+cp .env.example .env
+# fill in CUBE_API_URL, CUBE_TEMPLATE_ID, and your provider key
+pip install -r requirements.txt
+```
+
+### 3. Run the one-shot example
+
+```bash
+python run_opencode.py
+```
+
+This creates a MicroVM, seeds a deterministic calculator project, runs an
+OpenCode coding task, verifies the result contains the expected marker, and
+tears the sandbox down.
+
+## Files
+
+| File | Description |
+|---|---|
+| `build-template.sh` | Build, push, and register the template image |
+| `Dockerfile` | Stacks Node.js 24 + OpenCode CLI on `cubesandbox-base` |
+| `run_opencode.py` | One-shot example: seed → run → verify |
+| `snapshot_restore.py` | Pause/resume: run turn 1 → pause → reconnect → run turn 2 |
+| `network_policy.py` | Default-deny egress with CubeEgress credential vault |
+| `env_utils.py` | Configuration, provider specs, secret redaction helpers |
+| `_opencode_common.py` | Shared command builder, result parser, session ID extraction |
+| `test_commands.py` | Unit tests for `_opencode_common.py` |
+| `test_env_utils.py` | Unit tests for `env_utils.py` |
+| `.env.example` | Template for required environment variables |
+| `requirements.txt` | Python dependencies (`cubesandbox`, `python-dotenv`) |
+
+## Environment Variables
+
+See `.env.example` for the full template. Key variables:
+
+| Variable | Required | Default | Description |
+|---|---|---|---|
+| `CUBE_API_URL` | Yes | — | CubeAPI address (`http://<node>:3000`) |
+| `CUBE_TEMPLATE_ID` | Yes | — | Template ID from `build-template.sh` |
+| `OPENCODE_PROVIDER` | Yes | `anthropic` | LLM provider: `anthropic`, `openai`, `deepseek`, `openrouter` |
+| `OPENCODE_MODEL` | Yes | — | Must use `provider/model` form (e.g. `anthropic/claude-sonnet-4-6`) |
+| `ANTHROPIC_API_KEY` | Provider | — | Provider key (only the selected provider's key is needed) |
+| `OPENAI_API_KEY` | Provider | — | — |
+| `DEEPSEEK_API_KEY` | Provider | — | — |
+| `OPENROUTER_API_KEY` | Provider | — | — |
+| `OPENCODE_LLM_HOST` | No | Provider default | Override LLM API hostname for CubeEgress rules |
+| `OPENCODE_WORKSPACE` | No | `/workspace` | Workspace path inside the sandbox |
+| `OPENCODE_SANDBOX_TIMEOUT` | No | `1800` | Sandbox lifetime in seconds |
+| `OPENCODE_EXEC_TIMEOUT` | No | `900` | Per-command timeout in seconds |
+| `OPENCODE_NODE_CA_BUNDLE` | No | `/etc/ssl/certs/ca-certificates.crt` | CA bundle for CubeEgress TLS (vault flavor) |
+| `OPENCODE_PLACEHOLDER_KEY` | No | `cube-egress-managed-placeholder` | Placeholder key value inside the VM (vault flavor) |
+| `CUBE_PROXY_NODE_IP` | No | — | Direct node routing for SDK data path |
+
+## Snapshot and Restore
+
+```bash
+python snapshot_restore.py
+```
+
+Runs a two-turn workflow:
+
+1. **Turn 1** — OpenCode creates `plan.md` describing the intended work.
+2. **Pause** — `sandbox.pause()` snapshots the running VM (memory + rootfs).
+3. **Reconnect** — `Sandbox.connect(sandbox_id)` restores with `/workspace`
+   and OpenCode's state directories intact.
+4. **Turn 2** — OpenCode continues with `--continue`, implementing the plan
+   and running tests.
+
+> Use `try/finally` — not a `with` context manager — to manage the sandbox
+> lifecycle. A context manager kills the sandbox on `__exit__`, undoing the
+> pause.
+
+## Default-Deny Egress and Credential Vault
+
+```bash
+python network_policy.py
+```
+
+Creates a sandbox with `allow_internet_access=False` and a single allow rule
+for the configured LLM host. The real provider key stays on the host; only a
+placeholder is placed inside the VM. CubeEgress injects the real auth header
+on the wire when OpenCode calls the LLM API.
+
+- `printenv ANTHROPIC_API_KEY` inside the sandbox shows only the placeholder.
+- Every request to the allowed LLM host gets the auth header attached.
+- All other destinations are dropped at L3/L4 by CubeVS.
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| `opencode: command not found` | Template not rebuilt after CLI change | Rebuild the image and re-register the template |
+| Provider auth failure | Key not forwarded (direct) or missing inject rule (vault) | Pass `envs={...}` or fix the rule's `sni`/`host` |
+| `403 Forbidden - CubeEgress` | Default-deny with no matching allow rule | Add the LLM host to the network rules |
+| `Connection error` / TLS failure (vault) | Node.js ignores system CA store | Example sets `NODE_EXTRA_CA_CERTS`; override with `OPENCODE_NODE_CA_BUNDLE` |
+| Template stuck in `PULLING` | Registry unreachable from Cube nodes | Push to an accessible registry; supply auth if needed |
+| Readiness probe timeout | Base image missing envd | Use `FROM ghcr.io/tencentcloud/cubesandbox-base:2026.16` |
+| `Missing required environment variable` | `.env` not configured | Copy `.env.example` and fill in the required values |
+| `OPENCODE_MODEL` validation error | Model missing `provider/model` form | Use e.g. `anthropic/claude-sonnet-4-6` |
+
+## Full Guide
+
+For deeper coverage of architecture, best practices, and caveats, see the
+[OpenCode Integration Guide](../../docs/guide/integrations/opencode.md).

--- a/examples/opencode-integration/README_zh.md
+++ b/examples/opencode-integration/README_zh.md
@@ -1,0 +1,126 @@
+# OpenCode × CubeSandbox 集成
+
+在 CubeSandbox MicroVM 内运行 [OpenCode](https://www.npmjs.com/package/opencode-ai)（面向终端的 AI 编码 Agent），具备硬件级隔离、基于快照的会话持久化，以及可选的默认拒绝出网 + 链路上凭证注入。
+
+> 完整集成指南：[`docs/zh/guide/integrations/opencode.md`](../../docs/zh/guide/integrations/opencode.md)
+
+## 前置条件
+
+| 要求 | 说明 |
+|---|---|
+| CubeSandbox 部署 | CubeAPI 可访问（`http://<node>:3000`） |
+| `cubemastercli` | 已在 `$PATH` 且已连通集群 |
+| Python | 3.10+ |
+| Docker | 构建机 + Cube 集群可拉取的 registry |
+| LLM provider API key | `anthropic`、`openai`、`deepseek` 或 `openrouter` |
+
+## 快速开始
+
+### 1. 构建并注册模板
+
+```bash
+# 以下环境变量均为可选；默认值如注释所示
+# REGISTRY=ghcr.io/tencentcloud  IMAGE_NAME=opencode-cube  IMAGE_TAG=latest
+./build-template.sh
+```
+
+脚本会构建 Docker 镜像、推送、通过 `cubemastercli tpl create-from-image` 注册，监控构建任务，并在到达 `READY` 后打印最终的 `template_id`。
+
+### 2. 配置 `.env`
+
+```bash
+cp .env.example .env
+# 填写 CUBE_API_URL、CUBE_TEMPLATE_ID 以及你的 provider key
+pip install -r requirements.txt
+```
+
+### 3. 运行一次性示例
+
+```bash
+python run_opencode.py
+```
+
+脚本会创建 MicroVM，植入确定性的计算器项目，执行 OpenCode 编码任务，验证结果中包含预期标记，最后销毁沙箱。
+
+## 文件说明
+
+| 文件 | 描述 |
+|---|---|
+| `build-template.sh` | 构建、推送并注册模板镜像 |
+| `Dockerfile` | 在 `cubesandbox-base` 上叠加 Node.js 24 + OpenCode CLI |
+| `run_opencode.py` | 一次性示例：植入 → 运行 → 验证 |
+| `snapshot_restore.py` | 暂停/恢复：第一轮 → pause → 重连 → 第二轮 |
+| `network_policy.py` | 默认拒绝出网 + CubeEgress 凭证保险柜 |
+| `env_utils.py` | 配置、provider 规格、密钥脱敏工具 |
+| `_opencode_common.py` | 共享命令构造、结果解析、session ID 提取 |
+| `test_commands.py` | `_opencode_common.py` 单元测试 |
+| `test_env_utils.py` | `env_utils.py` 单元测试 |
+| `.env.example` | 环境变量模板 |
+| `requirements.txt` | Python 依赖（`cubesandbox`、`python-dotenv`） |
+
+## 环境变量
+
+完整模板见 `.env.example`。主要变量：
+
+| 变量 | 必填 | 默认值 | 说明 |
+|---|---|---|---|
+| `CUBE_API_URL` | 是 | — | CubeAPI 地址（`http://<node>:3000`） |
+| `CUBE_TEMPLATE_ID` | 是 | — | 来自 `build-template.sh` 的模板 ID |
+| `OPENCODE_PROVIDER` | 是 | `anthropic` | LLM provider：`anthropic`、`openai`、`deepseek`、`openrouter` |
+| `OPENCODE_MODEL` | 是 | — | 必须使用 `provider/model` 格式（如 `anthropic/claude-sonnet-4-6`） |
+| `ANTHROPIC_API_KEY` | 按 provider | — | provider 密钥（只需填写所选 provider 的 key） |
+| `OPENAI_API_KEY` | 按 provider | — | — |
+| `DEEPSEEK_API_KEY` | 按 provider | — | — |
+| `OPENROUTER_API_KEY` | 按 provider | — | — |
+| `OPENCODE_LLM_HOST` | 否 | provider 默认值 | 覆盖 LLM API 主机名，用于 CubeEgress 规则 |
+| `OPENCODE_WORKSPACE` | 否 | `/workspace` | 沙箱内工作区路径 |
+| `OPENCODE_SANDBOX_TIMEOUT` | 否 | `1800` | 沙箱生命周期（秒） |
+| `OPENCODE_EXEC_TIMEOUT` | 否 | `900` | 单命令超时（秒） |
+| `OPENCODE_NODE_CA_BUNDLE` | 否 | `/etc/ssl/certs/ca-certificates.crt` | CubeEgress TLS CA 包（保险柜方式） |
+| `OPENCODE_PLACEHOLDER_KEY` | 否 | `cube-egress-managed-placeholder` | VM 内的占位 key 值（保险柜方式） |
+| `CUBE_PROXY_NODE_IP` | 否 | — | SDK 数据路径的直接节点路由 |
+
+## 快照与恢复
+
+```bash
+python snapshot_restore.py
+```
+
+运行两轮工作流：
+
+1. **第一轮** — OpenCode 创建 `plan.md` 描述计划内容。
+2. **暂停** — `sandbox.pause()` 对运行中的 VM（内存 + rootfs）打快照。
+3. **重连** — `Sandbox.connect(sandbox_id)` 恢复，`/workspace` 与 OpenCode 状态目录完好无损。
+4. **第二轮** — OpenCode 带 `--continue` 继续，执行计划并跑测试。
+
+> 用 `try/finally`（而非 `with` context manager）管理沙箱生命周期。context manager 在 `__exit__` 时会 kill 沙箱，导致 pause 失效。
+
+## 默认拒绝出网与凭证保险柜
+
+```bash
+python network_policy.py
+```
+
+创建 `allow_internet_access=False` 的沙箱，仅放行一条针对已配置 LLM host 的规则。真实 provider key 留在宿主；VM 内只有占位值。当 OpenCode 调用 LLM API 时，CubeEgress 在链路上注入真实鉴权头。
+
+- 沙箱内 `printenv ANTHROPIC_API_KEY` 只显示占位值。
+- 每次访问放行的 LLM host 都会在链路上被附加鉴权头。
+- 其他所有目的地都被 CubeVS 在 L3/L4 层丢弃。
+
+## 排错
+
+| 现象 | 可能原因 | 处理 |
+|---|---|---|
+| `opencode: command not found` | CLI 变更后未重建模板 | 重建镜像并重新注册模板 |
+| provider 鉴权失败 | 密钥未传入（直连）或缺少 inject 规则（保险柜） | 传 `envs={...}` 或修正规则的 `sni`/`host` |
+| `403 Forbidden - CubeEgress` | 默认拒绝且无匹配放行规则 | 把 LLM host 加入网络规则 |
+| `Connection error` / TLS 失败（保险柜） | Node.js 忽略系统 CA 库 | 示例已设 `NODE_EXTRA_CA_CERTS`；用 `OPENCODE_NODE_CA_BUNDLE` 覆盖 |
+| 模板卡在 `PULLING` | Cube 节点无法访问 registry | 推送到可访问的 registry，必要时提供鉴权 |
+| 就绪探针超时 | 基础镜像缺少 envd | 使用 `FROM ghcr.io/tencentcloud/cubesandbox-base:2026.16` |
+| `Missing required environment variable` | `.env` 未配置 | 复制 `.env.example` 并填写必填项 |
+| `OPENCODE_MODEL` 校验失败 | 模型缺少 `provider/model` 格式 | 使用如 `anthropic/claude-sonnet-4-6` |
+
+## 完整指南
+
+如需了解架构、最佳实践和注意事项的更深入说明，请参阅
+[OpenCode 集成指南](../../docs/zh/guide/integrations/opencode.md)。

--- a/examples/opencode-integration/_opencode_common.py
+++ b/examples/opencode-integration/_opencode_common.py
@@ -1,0 +1,190 @@
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared OpenCode command, result, session, and cleanup helpers."""
+
+from __future__ import annotations
+
+import json
+import shlex
+import sys
+from collections.abc import Collection, Iterator
+from typing import Any
+
+from env_utils import redact_secrets
+
+
+class CommandExecutionError(RuntimeError):
+    """Raised when a command inside the sandbox exits unsuccessfully."""
+
+
+def opencode_command(
+    prompt: str,
+    *,
+    model: str,
+    workspace: str = "/workspace",
+    title: str | None = None,
+    session_id: str | None = None,
+    continue_last: bool = False,
+    auto: bool = True,
+    json_format: bool = True,
+) -> str:
+    """Build a quoted, non-interactive ``opencode run`` invocation."""
+    if session_id and continue_last:
+        raise ValueError("session_id and continue_last are mutually exclusive")
+    if not prompt.strip():
+        raise ValueError("prompt must not be empty")
+    if not model.strip() or "/" not in model:
+        raise ValueError("model must use OpenCode's provider/model form")
+
+    args = ["opencode", "run", "--model", model, "--dir", workspace]
+    if title:
+        args.extend(["--title", title])
+    if session_id:
+        args.extend(["--session", session_id])
+    elif continue_last:
+        args.append("--continue")
+    if auto:
+        args.append("--auto")
+    if json_format:
+        args.extend(["--format", "json"])
+    args.append(prompt)
+    return shlex.join(args)
+
+
+def run_command(
+    sandbox: Any,
+    command: str,
+    *,
+    cwd: str | None = None,
+    envs: dict[str, str] | None = None,
+    timeout: int | float | None = None,
+    user: str = "root",
+):
+    """Execute through the SDK while supporting its ``envs``/``env`` aliases."""
+    kwargs: dict[str, object] = {"user": user}
+    if cwd is not None:
+        kwargs["cwd"] = cwd
+    if timeout is not None:
+        kwargs["timeout"] = timeout
+    if envs:
+        kwargs["envs"] = envs
+
+    try:
+        return sandbox.commands.run(command, **kwargs)
+    except TypeError as exc:
+        if "envs" not in kwargs or "envs" not in str(exc):
+            raise
+        kwargs["env"] = kwargs.pop("envs")
+        return sandbox.commands.run(command, **kwargs)
+
+
+def redacted_result_output(
+    result: object,
+    *,
+    secrets: Collection[str] | None = None,
+) -> tuple[str, str]:
+    stdout = redact_secrets(getattr(result, "stdout", ""), secrets)
+    stderr = redact_secrets(getattr(result, "stderr", ""), secrets)
+    return stdout, stderr
+
+
+def ensure_success(
+    result: object,
+    action: str,
+    *,
+    secrets: Collection[str] | None = None,
+) -> None:
+    exit_code = getattr(result, "exit_code", None)
+    if exit_code in (None, 0):
+        return
+    stdout, stderr = redacted_result_output(result, secrets=secrets)
+    raise CommandExecutionError(
+        f"Failed to {action} (exit {exit_code}).\n"
+        f"STDOUT:\n{stdout}\nSTDERR:\n{stderr}"
+    )
+
+
+def extract_session_id(output: str, *, title: str | None = None) -> str:
+    """Extract a session ID from OpenCode JSON events or ``session list`` JSON.
+
+    The pinned CLI is contract-tested by this example's tests. Matching a
+    unique title is preferred for session-list output so an older session is
+    never resumed accidentally.
+    """
+    candidates: list[tuple[str, str | None]] = []
+    for document in _json_documents(output):
+        candidates.extend(_session_candidates(document))
+
+    if title is not None:
+        for session_id, candidate_title in candidates:
+            if candidate_title == title:
+                return session_id
+        raise ValueError(f"No OpenCode session found with title {title!r}")
+
+    if candidates:
+        return candidates[0][0]
+    raise ValueError("OpenCode output did not contain a session ID")
+
+
+def _json_documents(output: str) -> Iterator[object]:
+    stripped = output.strip()
+    if not stripped:
+        return
+    try:
+        yield json.loads(stripped)
+        return
+    except (TypeError, ValueError):
+        pass
+
+    for line in output.splitlines():
+        if not line.strip():
+            continue
+        try:
+            yield json.loads(line)
+        except (TypeError, ValueError):
+            continue
+
+
+def _session_candidates(value: object) -> list[tuple[str, str | None]]:
+    found: list[tuple[str, str | None]] = []
+    if isinstance(value, dict):
+        title_value = value.get("title")
+        title = title_value if isinstance(title_value, str) else None
+        for key in ("sessionID", "sessionId", "session_id"):
+            session_id = value.get(key)
+            if isinstance(session_id, str) and session_id:
+                found.append((session_id, title))
+        generic_id = value.get("id")
+        value_type = value.get("type")
+        if (
+            isinstance(generic_id, str)
+            and generic_id
+            and (title is not None or value_type == "session")
+        ):
+            found.append((generic_id, title))
+        for nested in value.values():
+            found.extend(_session_candidates(nested))
+    elif isinstance(value, list):
+        for item in value:
+            found.extend(_session_candidates(item))
+    return found
+
+
+def sandbox_identifier(sandbox: Any) -> str:
+    return str(getattr(sandbox, "sandbox_id", getattr(sandbox, "id", "unknown")))
+
+
+def safe_kill(sandbox: Any, *, label: str = "sandbox") -> Exception | None:
+    """Best-effort cleanup that reports, rather than masks, an earlier error."""
+    if sandbox is None:
+        return None
+    try:
+        sandbox.kill()
+    except Exception as exc:  # noqa: BLE001 - cleanup must preserve root cause
+        print(
+            f"Warning: failed to kill {label} {sandbox_identifier(sandbox)}: {exc}",
+            file=sys.stderr,
+        )
+        return exc
+    return None

--- a/examples/opencode-integration/build-template.sh
+++ b/examples/opencode-integration/build-template.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+#
+# Build and register the OpenCode CubeSandbox template.
+#
+# Usage:
+#   ./build-template.sh
+#
+# Environment variables (all optional):
+#   REGISTRY   - container registry prefix  (default: ghcr.io/tencentcloud)
+#   IMAGE_NAME - image repository / name    (default: opencode-cube)
+#   IMAGE_TAG  - image tag                  (default: latest)
+#   WRITABLE_LAYER_SIZE - rootfs writable layer size (default: 4G)
+#
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Configurable defaults
+# ---------------------------------------------------------------------------
+REGISTRY="${REGISTRY:-ghcr.io/tencentcloud}"
+IMAGE_NAME="${IMAGE_NAME:-opencode-cube}"
+IMAGE_TAG="${IMAGE_TAG:-latest}"
+WRITABLE_LAYER_SIZE="${WRITABLE_LAYER_SIZE:-4G}"
+
+FULL_IMAGE="${REGISTRY}/${IMAGE_NAME}:${IMAGE_TAG}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# ---------------------------------------------------------------------------
+# Step 1 — Build the Docker image
+# ---------------------------------------------------------------------------
+echo "==> Building image: ${FULL_IMAGE}"
+docker build \
+    -t "${FULL_IMAGE}" \
+    -f "${SCRIPT_DIR}/Dockerfile" \
+    "${SCRIPT_DIR}"
+
+# ---------------------------------------------------------------------------
+# Step 2 — Push the image
+# ---------------------------------------------------------------------------
+echo "==> Pushing image: ${FULL_IMAGE}"
+docker push "${FULL_IMAGE}"
+
+# ---------------------------------------------------------------------------
+# Step 3 — Register as a Cube template
+# ---------------------------------------------------------------------------
+echo "==> Creating template from image"
+CREATE_OUTPUT="$(cubemastercli tpl create-from-image \
+    --image "${FULL_IMAGE}" \
+    --writable-layer-size "${WRITABLE_LAYER_SIZE}" \
+    --expose-port 49983 \
+    --probe 49983 \
+    --probe-path /health)"
+
+echo "${CREATE_OUTPUT}"
+
+JOB_ID="$(echo "${CREATE_OUTPUT}" | grep -E '^job_id:' | awk '{print $2}')"
+TEMPLATE_ID="$(echo "${CREATE_OUTPUT}" | grep -E '^template_id:' | awk '{print $2}')"
+
+if [[ -z "${JOB_ID}" ]]; then
+    echo "ERROR: failed to parse job_id from create-from-image output" >&2
+    exit 1
+fi
+if [[ -z "${TEMPLATE_ID}" ]]; then
+    echo "ERROR: failed to parse template_id from create-from-image output" >&2
+    exit 1
+fi
+
+echo "==> job_id=${JOB_ID}  template_id=${TEMPLATE_ID}"
+
+# ---------------------------------------------------------------------------
+# Step 4 — Watch the build job until it reaches a terminal state
+# ---------------------------------------------------------------------------
+echo "==> Watching build job (this may take a while)..."
+WATCH_OUTPUT="$(cubemastercli tpl watch --job-id "${JOB_ID}")"
+echo "${WATCH_OUTPUT}"
+
+# ---------------------------------------------------------------------------
+# Step 5 — Verify the template reached READY
+# ---------------------------------------------------------------------------
+FINAL_STATUS="$(echo "${WATCH_OUTPUT}" | grep -E '^status:' | tail -1 | awk '{print $2}')"
+
+if [[ "${FINAL_STATUS}" != "READY" ]]; then
+    echo "ERROR: template build did not reach READY (status=${FINAL_STATUS:-UNKNOWN})" >&2
+    exit 1
+fi
+
+echo ""
+echo "========================================="
+echo " Template READY"
+echo " template_id: ${TEMPLATE_ID}"
+echo "========================================="

--- a/examples/opencode-integration/env_utils.py
+++ b/examples/opencode-integration/env_utils.py
@@ -1,0 +1,274 @@
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Configuration and secret-handling helpers for the OpenCode example."""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Collection
+from dataclasses import dataclass, field
+from pathlib import Path
+from urllib.parse import urlparse
+
+from dotenv import load_dotenv
+
+
+DEFAULT_WORKSPACE = "/workspace"
+DEFAULT_NODE_CA_BUNDLE = "/etc/ssl/certs/ca-certificates.crt"
+DEFAULT_PLACEHOLDER_KEY = "cube-egress-managed-placeholder"
+
+
+@dataclass(frozen=True)
+class ProviderSpec:
+    name: str
+    key_env: str
+    default_host: str
+    auth_header: str
+    auth_format: str
+
+
+@dataclass(frozen=True)
+class ProviderConfig:
+    name: str
+    model: str
+    host: str
+    key_env: str
+    auth_header: str
+    auth_format: str
+    secret: str = field(repr=False)
+
+
+@dataclass(frozen=True)
+class RunConfig:
+    api_url: str
+    template_id: str
+    workspace: str
+    sandbox_timeout: int
+    exec_timeout: int
+    node_ca_bundle: str
+    provider: ProviderConfig
+
+
+PROVIDERS: dict[str, ProviderSpec] = {
+    "anthropic": ProviderSpec(
+        name="anthropic",
+        key_env="ANTHROPIC_API_KEY",
+        default_host="api.anthropic.com",
+        auth_header="x-api-key",
+        auth_format="${SECRET}",
+    ),
+    "openai": ProviderSpec(
+        name="openai",
+        key_env="OPENAI_API_KEY",
+        default_host="api.openai.com",
+        auth_header="Authorization",
+        auth_format="Bearer ${SECRET}",
+    ),
+    "deepseek": ProviderSpec(
+        name="deepseek",
+        key_env="DEEPSEEK_API_KEY",
+        default_host="api.deepseek.com",
+        auth_header="Authorization",
+        auth_format="Bearer ${SECRET}",
+    ),
+    "openrouter": ProviderSpec(
+        name="openrouter",
+        key_env="OPENROUTER_API_KEY",
+        default_host="openrouter.ai",
+        auth_header="Authorization",
+        auth_format="Bearer ${SECRET}",
+    ),
+}
+
+OPENCODE_PASSTHROUGH_ENV = (
+    "OPENCODE_CONFIG",
+    "OPENCODE_CONFIG_DIR",
+    "OPENCODE_CONFIG_CONTENT",
+)
+
+
+def load_local_dotenv() -> None:
+    """Load the nearest example .env without overriding process variables."""
+    candidates = (Path(__file__).with_name(".env"), Path.cwd() / ".env")
+    seen: set[Path] = set()
+    for candidate in candidates:
+        resolved = candidate.resolve()
+        if resolved in seen:
+            continue
+        seen.add(resolved)
+        if candidate.is_file():
+            load_dotenv(dotenv_path=candidate, override=False)
+            return
+
+
+def required(name: str) -> str:
+    value = os.environ.get(name)
+    if value is None or not value.strip():
+        raise SystemExit(f"Missing required environment variable: {name}")
+    return value
+
+
+def optional(name: str, default: str = "") -> str:
+    return os.environ.get(name) or default
+
+
+def int_env(name: str, default: int, *, minimum: int = 1) -> int:
+    raw = os.environ.get(name)
+    if not raw:
+        return default
+    try:
+        value = int(raw)
+    except ValueError as exc:
+        raise SystemExit(f"{name} must be an integer, got {raw!r}") from exc
+    if value < minimum:
+        raise SystemExit(f"{name} must be at least {minimum}, got {value}")
+    return value
+
+
+def provider_name() -> str:
+    return optional("OPENCODE_PROVIDER", "anthropic").strip().lower()
+
+
+def provider_config(*, require_secret: bool = True) -> ProviderConfig:
+    name = provider_name()
+    try:
+        spec = PROVIDERS[name]
+    except KeyError as exc:
+        supported = ", ".join(sorted(PROVIDERS))
+        raise SystemExit(
+            f"Unsupported OPENCODE_PROVIDER {name!r}; choose one of: {supported}"
+        ) from exc
+
+    model = required("OPENCODE_MODEL").strip()
+    if "/" not in model:
+        raise SystemExit(
+            "OPENCODE_MODEL must use OpenCode's provider/model form, "
+            f"got {model!r}"
+        )
+    model_provider = model.split("/", 1)[0].strip().lower()
+    if model_provider != name:
+        raise SystemExit(
+            f"OPENCODE_MODEL provider {model_provider!r} does not match "
+            f"OPENCODE_PROVIDER {name!r}"
+        )
+
+    secret = os.environ.get(spec.key_env, "")
+    if require_secret and not secret.strip():
+        raise SystemExit(f"Missing required environment variable: {spec.key_env}")
+
+    explicit_host = optional("OPENCODE_LLM_HOST")
+    host = _host_from_url(explicit_host) if explicit_host else spec.default_host
+    if not host:
+        raise SystemExit("Could not determine the LLM API host")
+
+    return ProviderConfig(
+        name=spec.name,
+        model=model,
+        host=host,
+        key_env=spec.key_env,
+        auth_header=spec.auth_header,
+        auth_format=spec.auth_format,
+        secret=secret,
+    )
+
+
+def run_config(*, require_secret: bool = True) -> RunConfig:
+    api_url = required("CUBE_API_URL").strip().rstrip("/")
+    workspace = optional("OPENCODE_WORKSPACE", DEFAULT_WORKSPACE).strip()
+    if not workspace:
+        raise SystemExit("OPENCODE_WORKSPACE must not be empty")
+    return RunConfig(
+        api_url=api_url,
+        template_id=required("CUBE_TEMPLATE_ID").strip(),
+        workspace=workspace,
+        sandbox_timeout=int_env("OPENCODE_SANDBOX_TIMEOUT", 1800),
+        exec_timeout=int_env("OPENCODE_EXEC_TIMEOUT", 900),
+        node_ca_bundle=optional(
+            "OPENCODE_NODE_CA_BUNDLE", DEFAULT_NODE_CA_BUNDLE
+        ).strip(),
+        provider=provider_config(require_secret=require_secret),
+    )
+
+
+def build_opencode_env(
+    provider: ProviderConfig | None = None,
+    *,
+    include_secret: bool = True,
+) -> dict[str, str]:
+    """Build the minimal environment passed to OpenCode inside the VM.
+
+    With ``include_secret=False`` the VM receives only a placeholder. The real
+    key is expected to be injected into the outbound request by CubeEgress.
+    """
+    config = provider or provider_config(require_secret=include_secret)
+    env = {
+        "OPENCODE_AUTO_SHARE": optional("OPENCODE_AUTO_SHARE", "false"),
+        "OPENCODE_DISABLE_AUTOUPDATE": optional(
+            "OPENCODE_DISABLE_AUTOUPDATE", "true"
+        ),
+        "OPENCODE_DISABLE_PRUNE": optional("OPENCODE_DISABLE_PRUNE", "true"),
+        "OPENCODE_DISABLE_TERMINAL_TITLE": optional(
+            "OPENCODE_DISABLE_TERMINAL_TITLE", "true"
+        ),
+    }
+    for name in OPENCODE_PASSTHROUGH_ENV:
+        value = os.environ.get(name)
+        if value:
+            env[name] = value
+
+    if include_secret:
+        if not config.secret:
+            raise SystemExit(f"Missing required environment variable: {config.key_env}")
+        env[config.key_env] = config.secret
+    else:
+        env[config.key_env] = optional(
+            "OPENCODE_PLACEHOLDER_KEY", DEFAULT_PLACEHOLDER_KEY
+        )
+        env["NODE_EXTRA_CA_CERTS"] = optional(
+            "OPENCODE_NODE_CA_BUNDLE", DEFAULT_NODE_CA_BUNDLE
+        )
+    return env
+
+
+def provider_inject(provider: ProviderConfig) -> list[dict[str, str]]:
+    """Return CubeEgress Inject constructor arguments for this provider."""
+    if not provider.secret:
+        raise SystemExit(f"Missing required environment variable: {provider.key_env}")
+    return [
+        {
+            "header": provider.auth_header,
+            "secret": provider.secret,
+            "format": provider.auth_format,
+        }
+    ]
+
+
+def known_secret_values() -> tuple[str, ...]:
+    values = {
+        value
+        for spec in PROVIDERS.values()
+        if (value := os.environ.get(spec.key_env)) and value.strip()
+    }
+    return tuple(sorted(values, key=len, reverse=True))
+
+
+def redact_secrets(
+    text: object,
+    secrets: Collection[str] | None = None,
+) -> str:
+    redacted = "" if text is None else str(text)
+    values = secrets if secrets is not None else known_secret_values()
+    for secret in sorted({value for value in values if value}, key=len, reverse=True):
+        redacted = redacted.replace(secret, "<redacted>")
+    return redacted
+
+
+def _host_from_url(value: str) -> str:
+    candidate = value.strip()
+    if not candidate:
+        return ""
+    if "://" not in candidate:
+        candidate = f"https://{candidate}"
+    parsed = urlparse(candidate)
+    return (parsed.hostname or "").lower()

--- a/examples/opencode-integration/network_policy.py
+++ b/examples/opencode-integration/network_policy.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Run OpenCode with default-deny egress and on-the-wire credentials."""
+
+from __future__ import annotations
+
+import shlex
+import sys
+
+from cubesandbox import Action, Inject, Match, Rule, Sandbox
+
+from _opencode_common import (
+    ensure_success,
+    opencode_command,
+    redacted_result_output,
+    run_command,
+    safe_kill,
+    sandbox_identifier,
+)
+import env_utils
+
+
+RESULT_FILE = "egress_check.md"
+PROMPT = (
+    "Work only in {workspace}. Read README.md, then write {result_file} "
+    "containing one sentence confirming that this OpenCode task completed."
+)
+SEED_README = (
+    "# CubeEgress OpenCode example\n\n"
+    "This task must use injected egress.\n"
+)
+
+
+def build_rules(config: env_utils.RunConfig) -> list[Rule]:
+    """Allow only the configured LLM host and inject its auth header."""
+    provider = config.provider
+    return [
+        Rule(
+            name=f"allow_{provider.name}_llm",
+            match=Match(
+                scheme="https",
+                sni=provider.host,
+                host=provider.host,
+            ),
+            action=Action(
+                allow=True,
+                audit="metadata",
+                inject=[
+                    Inject(**spec)
+                    for spec in env_utils.provider_inject(provider)
+                ],
+            ),
+        )
+    ]
+
+
+def seed_project(
+    sandbox: Sandbox,
+    workspace: str,
+    config: env_utils.RunConfig,
+) -> None:
+    """Create a non-secret project for the restricted OpenCode task."""
+    result = run_command(
+        sandbox,
+        f"mkdir -p {shlex.quote(workspace)}",
+        timeout=60,
+    )
+    ensure_success(
+        result,
+        "create the workspace",
+        secrets=(config.provider.secret,),
+    )
+    sandbox.files.write(
+        f"{workspace.rstrip('/')}/README.md",
+        SEED_README,
+        user="root",
+    )
+
+
+def print_redacted_result(
+    result: object,
+    config: env_utils.RunConfig,
+) -> None:
+    """Print OpenCode output without exposing the provider credential."""
+    stdout, stderr = redacted_result_output(
+        result,
+        secrets=(config.provider.secret,),
+    )
+    if stdout:
+        print(stdout, end="" if stdout.endswith("\n") else "\n")
+    if stderr:
+        print(
+            stderr,
+            file=sys.stderr,
+            end="" if stderr.endswith("\n") else "\n",
+        )
+
+
+def verify_result(
+    sandbox: Sandbox,
+    workspace: str,
+    config: env_utils.RunConfig,
+) -> None:
+    """Confirm the restricted OpenCode task wrote its expected artifact."""
+    result = run_command(
+        sandbox,
+        f"test -s {shlex.quote(RESULT_FILE)}",
+        cwd=workspace,
+        timeout=60,
+    )
+    ensure_success(
+        result,
+        "verify the OpenCode egress-check artifact",
+        secrets=(config.provider.secret,),
+    )
+
+
+def main() -> int:
+    """Create a default-deny sandbox and run OpenCode through CubeEgress."""
+    env_utils.load_local_dotenv()
+    config = env_utils.run_config()
+    workspace = config.workspace
+    rules = build_rules(config)
+    command_env = env_utils.build_opencode_env(
+        config.provider,
+        include_secret=False,
+    )
+    command_env["NODE_EXTRA_CA_CERTS"] = config.node_ca_bundle
+
+    sandbox: Sandbox | None = None
+    try:
+        print(f"Allowed LLM host: {config.provider.host}")
+        print("Creating default-deny sandbox with credential injection.")
+        sandbox = Sandbox.create(
+            template=config.template_id,
+            allow_internet_access=False,
+            network={"rules": rules},
+            timeout=config.sandbox_timeout,
+        )
+        print(f"Sandbox ready: {sandbox_identifier(sandbox)}")
+
+        seed_project(sandbox, workspace, config)
+        command = opencode_command(
+            PROMPT.format(workspace=workspace, result_file=RESULT_FILE),
+            model=config.provider.model,
+            workspace=workspace,
+            title="cube-opencode-egress",
+        )
+        result = run_command(
+            sandbox,
+            command,
+            cwd=workspace,
+            envs=command_env,
+            timeout=config.exec_timeout,
+        )
+        ensure_success(
+            result,
+            "run OpenCode through the restricted egress policy",
+            secrets=(config.provider.secret,),
+        )
+        print_redacted_result(result, config)
+        verify_result(sandbox, workspace, config)
+        print(
+            f"Verified {RESULT_FILE}; the provider key stayed outside the VM."
+        )
+        return 0
+    finally:
+        safe_kill(sandbox)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/examples/opencode-integration/requirements.txt
+++ b/examples/opencode-integration/requirements.txt
@@ -1,0 +1,2 @@
+cubesandbox>=0.5.0
+python-dotenv==1.2.2

--- a/examples/opencode-integration/run_opencode.py
+++ b/examples/opencode-integration/run_opencode.py
@@ -1,0 +1,234 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Run one deterministic OpenCode task inside a CubeSandbox MicroVM."""
+
+from __future__ import annotations
+
+import argparse
+import shlex
+import sys
+
+from cubesandbox import Sandbox
+
+from _opencode_common import (
+    ensure_success,
+    extract_session_id,
+    opencode_command,
+    redacted_result_output,
+    run_command,
+    safe_kill,
+    sandbox_identifier,
+)
+from env_utils import (
+    RunConfig,
+    build_opencode_env,
+    load_local_dotenv,
+    run_config,
+)
+
+
+SUCCESS_MARKER = "OPENCODE_CUBE_OK"
+DEFAULT_TITLE = "cube-opencode-one-shot"
+DEFAULT_PROMPT = (
+    "Inspect the Python project in {workspace}. Implement multiply(a, b) in "
+    "calculator.py, add a unittest asserting multiply(4, 5) == 20, run "
+    "`python3 -m unittest discover -v`, and write result.md containing the "
+    f"exact marker {SUCCESS_MARKER}."
+)
+
+SEED_FILES = {
+    "README.md": """# CubeSandbox OpenCode Smoke Project
+
+This deterministic project verifies that OpenCode can edit files and run tests
+inside an isolated CubeSandbox MicroVM.
+""",
+    "calculator.py": """def add(a: int, b: int) -> int:
+    return a + b
+""",
+    "test_calculator.py": """import unittest
+
+from calculator import add
+
+
+class CalculatorTest(unittest.TestCase):
+    def test_adds_two_numbers(self) -> None:
+        self.assertEqual(add(2, 3), 5)
+
+
+if __name__ == "__main__":
+    unittest.main()
+""",
+}
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Run a one-shot OpenCode task inside CubeSandbox."
+    )
+    parser.add_argument(
+        "--prompt",
+        help="Prompt passed to OpenCode. Defaults to the deterministic smoke task.",
+    )
+    parser.add_argument(
+        "--workspace",
+        help="Workspace inside the sandbox. Defaults to OPENCODE_WORKSPACE.",
+    )
+    parser.add_argument(
+        "--title",
+        help="OpenCode session title. Defaults to a sandbox-specific title.",
+    )
+    parser.add_argument(
+        "--no-seed",
+        action="store_true",
+        help="Do not create the deterministic calculator project.",
+    )
+    return parser.parse_args()
+
+
+def seed_project(sandbox: Sandbox, workspace: str, config: RunConfig) -> None:
+    mkdir = run_command(
+        sandbox,
+        f"mkdir -p {shlex.quote(workspace)}",
+        timeout=60,
+    )
+    ensure_success(mkdir, "create the workspace", secrets=(config.provider.secret,))
+
+    for filename, content in SEED_FILES.items():
+        path = f"{workspace.rstrip('/')}/{filename}"
+        sandbox.files.write(path, content, user="root")
+
+
+def verify_result(sandbox: Sandbox, workspace: str, config: RunConfig) -> None:
+    marker = shlex.quote(SUCCESS_MARKER)
+    command = (
+        "python3 -m unittest discover -v "
+        "&& grep -q 'def multiply' calculator.py "
+        "&& test -f result.md "
+        f"&& grep -q {marker} result.md"
+    )
+    result = run_command(
+        sandbox,
+        command,
+        cwd=workspace,
+        timeout=120,
+    )
+    ensure_success(
+        result,
+        "verify OpenCode's workspace changes",
+        secrets=(config.provider.secret,),
+    )
+
+
+def resolve_session_id(
+    sandbox: Sandbox,
+    output: str,
+    title: str,
+    workspace: str,
+    command_env: dict[str, str],
+    config: RunConfig,
+) -> str:
+    try:
+        return extract_session_id(output)
+    except ValueError:
+        listing = run_command(
+            sandbox,
+            "opencode session list --format json",
+            cwd=workspace,
+            envs=command_env,
+            timeout=60,
+        )
+        ensure_success(
+            listing,
+            "list OpenCode sessions",
+            secrets=(config.provider.secret,),
+        )
+        return extract_session_id(listing.stdout, title=title)
+
+
+def print_redacted_result(result: object, config: RunConfig) -> None:
+    stdout, stderr = redacted_result_output(
+        result,
+        secrets=(config.provider.secret,),
+    )
+    if stdout:
+        print(stdout, end="" if stdout.endswith("\n") else "\n")
+    if stderr:
+        print(stderr, file=sys.stderr, end="" if stderr.endswith("\n") else "\n")
+
+
+def main() -> int:
+    load_local_dotenv()
+    args = parse_args()
+    config = run_config()
+    workspace = args.workspace or config.workspace
+    command_env = build_opencode_env(config.provider, include_secret=True)
+
+    sandbox: Sandbox | None = None
+    try:
+        print(f"Creating sandbox from template: {config.template_id}")
+        print(
+            "Security note: this one-shot example passes the provider key into "
+            "the VM. Use network_policy.py for shared or production clusters.",
+            file=sys.stderr,
+        )
+        sandbox = Sandbox.create(
+            template=config.template_id,
+            timeout=config.sandbox_timeout,
+        )
+        sandbox_id = sandbox_identifier(sandbox)
+        title = args.title or f"{DEFAULT_TITLE}-{sandbox_id}"
+        print(f"Sandbox ready: {sandbox_id}")
+
+        version = run_command(sandbox, "opencode --version", timeout=60)
+        ensure_success(
+            version,
+            "check the OpenCode version",
+            secrets=(config.provider.secret,),
+        )
+        print(f"OpenCode version: {version.stdout.strip()}")
+
+        if not args.no_seed:
+            seed_project(sandbox, workspace, config)
+            print(f"Seeded deterministic project in {workspace}")
+
+        prompt = args.prompt or DEFAULT_PROMPT.format(workspace=workspace)
+        command = opencode_command(
+            prompt,
+            model=config.provider.model,
+            workspace=workspace,
+            title=title,
+        )
+        print("\nRunning OpenCode task...\n")
+        result = run_command(
+            sandbox,
+            command,
+            cwd=workspace,
+            envs=command_env,
+            timeout=config.exec_timeout,
+        )
+        ensure_success(
+            result,
+            "run the OpenCode task",
+            secrets=(config.provider.secret,),
+        )
+        print_redacted_result(result, config)
+
+        verify_result(sandbox, workspace, config)
+        session_id = resolve_session_id(
+            sandbox,
+            result.stdout,
+            title,
+            workspace,
+            command_env,
+            config,
+        )
+        print(f"\nVerified marker {SUCCESS_MARKER}; session: {session_id}")
+        return 0
+    finally:
+        safe_kill(sandbox)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/examples/opencode-integration/snapshot_restore.py
+++ b/examples/opencode-integration/snapshot_restore.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Pause and resume an OpenCode task in a CubeSandbox MicroVM."""
+
+from __future__ import annotations
+
+import shlex
+import sys
+
+from cubesandbox import Sandbox
+
+from _opencode_common import (
+    ensure_success,
+    opencode_command,
+    redacted_result_output,
+    run_command,
+    safe_kill,
+    sandbox_identifier,
+)
+from env_utils import (
+    RunConfig,
+    build_opencode_env,
+    load_local_dotenv,
+    run_config,
+)
+
+
+TITLE_PREFIX = "cube-opencode-pause-resume"
+SEED_FILES = {
+    "README.md": "# OpenCode pause/resume example\n",
+    "calculator.py": """def add(a: int, b: int) -> int:
+    return a + b
+""",
+    "test_calculator.py": """import unittest
+
+from calculator import add
+
+
+class CalculatorTest(unittest.TestCase):
+    def test_add(self) -> None:
+        self.assertEqual(add(2, 3), 5)
+""",
+}
+TURN_1_PROMPT = """Work only in {workspace}. Inspect the seeded Python project.
+Create plan.md that says you will add multiply(a, b), test it, and record the
+test result. Do not modify calculator.py or test_calculator.py yet."""
+TURN_2_PROMPT = """Continue the task from plan.md. Implement multiply(a, b) in
+calculator.py, add a unittest asserting multiply(4, 5) == 20, run
+`python3 -m unittest discover -v`, and write result.md with the test result."""
+
+
+def seed_project(sandbox: Sandbox, workspace: str, config: RunConfig) -> None:
+    """Create the small project without persisting provider credentials."""
+    result = run_command(
+        sandbox,
+        f"mkdir -p {shlex.quote(workspace)}",
+        timeout=60,
+    )
+    ensure_success(
+        result,
+        "create the workspace",
+        secrets=(config.provider.secret,),
+    )
+    for filename, content in SEED_FILES.items():
+        path = f"{workspace.rstrip('/')}/{filename}"
+        sandbox.files.write(path, content, user="root")
+
+
+def print_result(result: object, config: RunConfig) -> None:
+    """Print command output after removing any provider secret."""
+    stdout, stderr = redacted_result_output(
+        result,
+        secrets=(config.provider.secret,),
+    )
+    if stdout:
+        print(stdout, end="" if stdout.endswith("\n") else "\n")
+    if stderr:
+        print(stderr, file=sys.stderr, end="" if stderr.endswith("\n") else "\n")
+
+
+def verify_workspace(sandbox: Sandbox, workspace: str, config: RunConfig) -> None:
+    """Verify files from both turns are present after reconnecting."""
+    command = (
+        "test -f README.md && test -f plan.md && test -f calculator.py "
+        "&& test -f test_calculator.py && test -f result.md "
+        "&& grep -q 'def multiply' calculator.py "
+        "&& python3 -m unittest discover -v"
+    )
+    result = run_command(sandbox, command, cwd=workspace, timeout=120)
+    ensure_success(
+        result,
+        "verify workspace files survived pause/resume",
+        secrets=(config.provider.secret,),
+    )
+    print_result(result, config)
+
+
+def main() -> int:
+    """Run an OpenCode turn, snapshot it, then resume and continue it."""
+    load_local_dotenv()
+    config = run_config()
+    workspace = config.workspace
+    command_env = build_opencode_env(config.provider, include_secret=True)
+    sandbox: Sandbox | None = None
+
+    try:
+        sandbox = Sandbox.create(
+            template=config.template_id,
+            timeout=config.sandbox_timeout,
+        )
+        sandbox_id = sandbox_identifier(sandbox)
+        title = f"{TITLE_PREFIX}-{sandbox_id}"
+        print(f"Sandbox ready: {sandbox_id}")
+
+        seed_project(sandbox, workspace, config)
+        print(f"Seeded project in {workspace}")
+
+        first_command = opencode_command(
+            TURN_1_PROMPT.format(workspace=workspace),
+            model=config.provider.model,
+            workspace=workspace,
+            title=title,
+        )
+        first_result = run_command(
+            sandbox,
+            first_command,
+            cwd=workspace,
+            envs=command_env,
+            timeout=config.exec_timeout,
+        )
+        ensure_success(
+            first_result,
+            "run the first OpenCode turn",
+            secrets=(config.provider.secret,),
+        )
+        print_result(first_result, config)
+
+        saved_sandbox_id = sandbox_id
+        pause_result = sandbox.pause()
+        if isinstance(pause_result, str) and pause_result:
+            sandbox_id = pause_result
+        else:
+            sandbox_id = saved_sandbox_id
+        print(f"Paused sandbox; resume handle: {sandbox_id}")
+
+        sandbox = Sandbox.connect(sandbox_id)
+        print(f"Reconnected to sandbox: {sandbox_identifier(sandbox)}")
+
+        second_command = opencode_command(
+            TURN_2_PROMPT,
+            model=config.provider.model,
+            workspace=workspace,
+            continue_last=True,
+        )
+        second_result = run_command(
+            sandbox,
+            second_command,
+            cwd=workspace,
+            envs=command_env,
+            timeout=config.exec_timeout,
+        )
+        ensure_success(
+            second_result,
+            "run the resumed OpenCode turn",
+            secrets=(config.provider.secret,),
+        )
+        print_result(second_result, config)
+
+        verify_workspace(sandbox, workspace, config)
+        print("Verified workspace persistence and completed OpenCode task.")
+        return 0
+    finally:
+        safe_kill(sandbox)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/examples/opencode-integration/test_commands.py
+++ b/examples/opencode-integration/test_commands.py
@@ -1,0 +1,200 @@
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import io
+import shlex
+import unittest
+from contextlib import redirect_stderr
+from types import SimpleNamespace
+
+from _opencode_common import (
+    CommandExecutionError,
+    ensure_success,
+    extract_session_id,
+    opencode_command,
+    run_command,
+    safe_kill,
+    sandbox_identifier,
+)
+
+
+class RecordingCommands:
+    def __init__(self, result: object | None = None) -> None:
+        self.result = result or SimpleNamespace(stdout="", stderr="", exit_code=0)
+        self.calls: list[tuple[str, dict[str, object]]] = []
+
+    def run(self, command: str, **kwargs: object) -> object:
+        self.calls.append((command, kwargs))
+        return self.result
+
+
+class EnvAliasCommands(RecordingCommands):
+    def run(self, command: str, **kwargs: object) -> object:
+        self.calls.append((command, kwargs.copy()))
+        if "envs" in kwargs:
+            raise TypeError("unexpected keyword argument 'envs'")
+        return self.result
+
+
+class FakeSandbox:
+    def __init__(self, commands: RecordingCommands | None = None) -> None:
+        self.commands = commands or RecordingCommands()
+        self.sandbox_id = "sb-test"
+        self.kill_calls = 0
+
+    def kill(self) -> None:
+        self.kill_calls += 1
+
+
+class FailingKillSandbox(FakeSandbox):
+    def kill(self) -> None:
+        raise RuntimeError("cleanup failed")
+
+
+class CommandHelpersTest(unittest.TestCase):
+    def test_opencode_command_quotes_every_dynamic_argument(self) -> None:
+        command = opencode_command(
+            "fix user's file; echo unsafe",
+            model="anthropic/test-model",
+            workspace="/work dir",
+            title="quoted title",
+            session_id="ses_123",
+        )
+
+        self.assertEqual(
+            shlex.split(command),
+            [
+                "opencode",
+                "run",
+                "--model",
+                "anthropic/test-model",
+                "--dir",
+                "/work dir",
+                "--title",
+                "quoted title",
+                "--session",
+                "ses_123",
+                "--auto",
+                "--format",
+                "json",
+                "fix user's file; echo unsafe",
+            ],
+        )
+
+    def test_opencode_command_supports_continue_and_optional_flags(self) -> None:
+        command = opencode_command(
+            "continue",
+            model="openai/model",
+            continue_last=True,
+            auto=False,
+            json_format=False,
+        )
+
+        args = shlex.split(command)
+        self.assertIn("--continue", args)
+        self.assertNotIn("--auto", args)
+        self.assertNotIn("--format", args)
+
+    def test_opencode_command_rejects_invalid_combinations(self) -> None:
+        with self.assertRaisesRegex(ValueError, "mutually exclusive"):
+            opencode_command(
+                "prompt",
+                model="openai/model",
+                session_id="ses_1",
+                continue_last=True,
+            )
+        with self.assertRaisesRegex(ValueError, "prompt must not be empty"):
+            opencode_command(" ", model="openai/model")
+        with self.assertRaisesRegex(ValueError, "provider/model"):
+            opencode_command("prompt", model="invalid")
+
+    def test_run_command_forwards_sdk_arguments(self) -> None:
+        commands = RecordingCommands()
+        sandbox = FakeSandbox(commands)
+
+        result = run_command(
+            sandbox,
+            "echo ok",
+            cwd="/workspace",
+            envs={"A": "B"},
+            timeout=12.5,
+        )
+
+        self.assertIs(result, commands.result)
+        self.assertEqual(
+            commands.calls,
+            [
+                (
+                    "echo ok",
+                    {
+                        "user": "root",
+                        "cwd": "/workspace",
+                        "timeout": 12.5,
+                        "envs": {"A": "B"},
+                    },
+                )
+            ],
+        )
+
+    def test_run_command_retries_only_the_env_alias(self) -> None:
+        commands = EnvAliasCommands()
+
+        run_command(FakeSandbox(commands), "echo ok", envs={"A": "B"})
+
+        self.assertEqual(len(commands.calls), 2)
+        self.assertIn("envs", commands.calls[0][1])
+        self.assertEqual(commands.calls[1][1]["env"], {"A": "B"})
+
+    def test_ensure_success_accepts_zero_and_redacts_failures(self) -> None:
+        ensure_success(SimpleNamespace(stdout="ok", stderr="", exit_code=0), "run")
+
+        result = SimpleNamespace(
+            stdout="response secret-value",
+            stderr="error secret-value",
+            exit_code=7,
+        )
+        with self.assertRaises(CommandExecutionError) as raised:
+            ensure_success(result, "run OpenCode", secrets=("secret-value",))
+
+        self.assertNotIn("secret-value", str(raised.exception))
+        self.assertIn("<redacted>", str(raised.exception))
+        self.assertIn("exit 7", str(raised.exception))
+
+    def test_extract_session_id_handles_events_lists_and_titles(self) -> None:
+        jsonl = 'not-json\n{"type":"message","sessionID":"ses_event"}\n'
+        listing = '[{"id":"ses_old","title":"old"},{"id":"ses_new","title":"wanted"}]'
+
+        self.assertEqual(extract_session_id(jsonl), "ses_event")
+        self.assertEqual(
+            extract_session_id(listing, title="wanted"),
+            "ses_new",
+        )
+
+    def test_extract_session_id_rejects_missing_or_wrong_title(self) -> None:
+        with self.assertRaisesRegex(ValueError, "did not contain"):
+            extract_session_id("no json here")
+        with self.assertRaisesRegex(ValueError, "No OpenCode session"):
+            extract_session_id('[{"id":"ses_1","title":"other"}]', title="wanted")
+
+    def test_safe_kill_reports_cleanup_failure_without_raising(self) -> None:
+        healthy = FakeSandbox()
+        self.assertIsNone(safe_kill(healthy))
+        self.assertEqual(healthy.kill_calls, 1)
+
+        stderr = io.StringIO()
+        with redirect_stderr(stderr):
+            error = safe_kill(FailingKillSandbox(), label="source")
+
+        self.assertIsInstance(error, RuntimeError)
+        self.assertIn("cleanup failed", stderr.getvalue())
+        self.assertIn("source sb-test", stderr.getvalue())
+
+    def test_sandbox_identifier_supports_both_sdk_attribute_names(self) -> None:
+        self.assertEqual(sandbox_identifier(SimpleNamespace(sandbox_id="native")), "native")
+        self.assertEqual(sandbox_identifier(SimpleNamespace(id="e2b")), "e2b")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/examples/opencode-integration/test_env_utils.py
+++ b/examples/opencode-integration/test_env_utils.py
@@ -1,0 +1,145 @@
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import os
+import unittest
+from unittest.mock import patch
+
+import env_utils
+
+
+BASE_ENV = {
+    "CUBE_API_URL": "http://cube.test:3000/",
+    "CUBE_TEMPLATE_ID": "tpl-test",
+    "OPENCODE_PROVIDER": "anthropic",
+    "OPENCODE_MODEL": "anthropic/test-model",
+    "ANTHROPIC_API_KEY": "anthropic-secret",
+}
+
+
+class EnvUtilsTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.env = patch.dict(os.environ, BASE_ENV, clear=True)
+        self.env.start()
+        self.addCleanup(self.env.stop)
+
+    def test_provider_config_uses_expected_anthropic_defaults(self) -> None:
+        config = env_utils.provider_config()
+
+        self.assertEqual(config.name, "anthropic")
+        self.assertEqual(config.model, "anthropic/test-model")
+        self.assertEqual(config.host, "api.anthropic.com")
+        self.assertEqual(config.key_env, "ANTHROPIC_API_KEY")
+        self.assertEqual(config.auth_header, "x-api-key")
+        self.assertNotIn("anthropic-secret", repr(config))
+
+    def test_provider_host_accepts_a_full_url(self) -> None:
+        os.environ["OPENCODE_LLM_HOST"] = "https://Gateway.Example.com/v1/messages"
+
+        self.assertEqual(env_utils.provider_config().host, "gateway.example.com")
+
+    def test_provider_rejects_unknown_provider(self) -> None:
+        os.environ["OPENCODE_PROVIDER"] = "unknown"
+        os.environ["OPENCODE_MODEL"] = "unknown/model"
+
+        with self.assertRaisesRegex(SystemExit, "Unsupported OPENCODE_PROVIDER"):
+            env_utils.provider_config()
+
+    def test_provider_rejects_invalid_or_mismatched_model(self) -> None:
+        for model, message in (
+            ("missing-prefix", "provider/model"),
+            ("openai/test-model", "does not match"),
+        ):
+            with self.subTest(model=model):
+                os.environ["OPENCODE_MODEL"] = model
+                with self.assertRaisesRegex(SystemExit, message):
+                    env_utils.provider_config()
+
+    def test_provider_can_be_loaded_without_secret_for_validation(self) -> None:
+        del os.environ["ANTHROPIC_API_KEY"]
+
+        config = env_utils.provider_config(require_secret=False)
+
+        self.assertEqual(config.secret, "")
+
+    def test_direct_environment_contains_only_the_active_provider_secret(self) -> None:
+        os.environ["OPENAI_API_KEY"] = "must-not-leak"
+
+        command_env = env_utils.build_opencode_env(env_utils.provider_config())
+
+        self.assertEqual(command_env["ANTHROPIC_API_KEY"], "anthropic-secret")
+        self.assertNotIn("OPENAI_API_KEY", command_env)
+        self.assertEqual(command_env["OPENCODE_DISABLE_AUTOUPDATE"], "true")
+
+    def test_vault_environment_uses_placeholder_and_node_ca(self) -> None:
+        os.environ["OPENCODE_PLACEHOLDER_KEY"] = "placeholder"
+        os.environ["OPENCODE_NODE_CA_BUNDLE"] = "/custom/ca.pem"
+
+        command_env = env_utils.build_opencode_env(
+            env_utils.provider_config(), include_secret=False
+        )
+
+        self.assertEqual(command_env["ANTHROPIC_API_KEY"], "placeholder")
+        self.assertEqual(command_env["NODE_EXTRA_CA_CERTS"], "/custom/ca.pem")
+        self.assertNotIn("anthropic-secret", command_env.values())
+
+    def test_inline_config_is_forwarded_without_unrelated_host_variables(self) -> None:
+        os.environ["OPENCODE_CONFIG_CONTENT"] = '{"model":"anthropic/test-model"}'
+        os.environ["UNRELATED_TOKEN"] = "do-not-forward"
+
+        command_env = env_utils.build_opencode_env(env_utils.provider_config())
+
+        self.assertIn("OPENCODE_CONFIG_CONTENT", command_env)
+        self.assertNotIn("UNRELATED_TOKEN", command_env)
+
+    def test_run_config_normalizes_url_and_reads_timeouts(self) -> None:
+        os.environ["OPENCODE_WORKSPACE"] = "/work"
+        os.environ["OPENCODE_SANDBOX_TIMEOUT"] = "1200"
+        os.environ["OPENCODE_EXEC_TIMEOUT"] = "300"
+
+        config = env_utils.run_config()
+
+        self.assertEqual(config.api_url, "http://cube.test:3000")
+        self.assertEqual(config.workspace, "/work")
+        self.assertEqual(config.sandbox_timeout, 1200)
+        self.assertEqual(config.exec_timeout, 300)
+
+    def test_int_env_rejects_non_integer_and_non_positive_values(self) -> None:
+        for value, message in (("abc", "must be an integer"), ("0", "at least 1")):
+            with self.subTest(value=value):
+                os.environ["OPENCODE_EXEC_TIMEOUT"] = value
+                with self.assertRaisesRegex(SystemExit, message):
+                    env_utils.run_config()
+
+    def test_provider_inject_uses_raw_anthropic_and_bearer_openai_headers(self) -> None:
+        anthropic = env_utils.provider_inject(env_utils.provider_config())
+        self.assertEqual(anthropic[0]["header"], "x-api-key")
+        self.assertEqual(anthropic[0]["format"], "${SECRET}")
+
+        os.environ.update(
+            {
+                "OPENCODE_PROVIDER": "openai",
+                "OPENCODE_MODEL": "openai/test-model",
+                "OPENAI_API_KEY": "openai-secret",
+            }
+        )
+        openai = env_utils.provider_inject(env_utils.provider_config())
+        self.assertEqual(openai[0]["header"], "Authorization")
+        self.assertEqual(openai[0]["format"], "Bearer ${SECRET}")
+
+    def test_redact_secrets_handles_known_and_explicit_values(self) -> None:
+        os.environ["OPENAI_API_KEY"] = "a-longer-openai-secret"
+
+        text = env_utils.redact_secrets(
+            "anthropic-secret and a-longer-openai-secret"
+        )
+        explicit = env_utils.redact_secrets("custom-secret", ("custom-secret",))
+
+        self.assertEqual(text, "<redacted> and <redacted>")
+        self.assertEqual(explicit, "<redacted>")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Add end-to-end OpenCode integration for CubeSandbox, covering template build, API key injection (direct and CubeEgress vault), default-deny egress policy, and snapshot-based pause/resume workflow.

Closes https://github.com/TencentCloud/CubeSandbox/issues/644

## Changes

### Examples (`examples/opencode-integration/`)

| File | Description |
|------|-------------|
| `run_opencode.py` | One-shot: seed project → run OpenCode task → verify result |
| `snapshot_restore.py` | Turn 1 → pause → reconnect → Turn 2 (breakpoint resume) |
| `network_policy.py` | Default-deny egress + CubeEgress credential vault |
| `env_utils.py` | Configuration, provider specs, secret redaction |
| `_opencode_common.py` | Command builder, result parser, session ID extraction |
| `test_env_utils.py` / `test_commands.py` | 22 unit tests (all passing) |
| `Dockerfile` | Node.js 24 + OpenCode CLI on cubesandbox-base |
| `build-template.sh` | One-click build → push → register template |
| `README.md` / `README_zh.md` | Bilingual usage guide |
| `requirements.txt` | `cubesandbox>=0.5.0`, `python-dotenv` |
| `.env.example` | Environment variable template |

### Documentation (`docs/guide/integrations/`)

- `opencode.md` — Full integration guide (6 steps: template build, env config, API key injection, snapshot/restore, network policy, caveats)
- `zh/guide/integrations/opencode.md` — Chinese translation (aligned structure)
- Both index pages updated with OpenCode entry

## Testing
pytest test_env_utils.py test_commands.py -v
22 passed, 4 subtests passed in 0.19s (Python 3.11.13)

## Compatibility

- Python 3.9+ (all files use `from __future__ import annotations`)
- SDK `cubesandbox>=0.5.0` (Rule, Match, Action, Inject confirmed in `__all__`)

related to: https://github.com/TencentCloud/CubeSandbox/issues/644