### PR TITLE
perf(ci): sync TCR CN images via self-hosted runner with crane

### DIFF
--- a/.github/workflows/release-docker-images.yml
+++ b/.github/workflows/release-docker-images.yml
@@ -2,8 +2,8 @@ name: Release Docker Images
 
 # Reusable pipeline for building and pushing release component images.
 # GitHub-hosted runners build amd64 + arm64 and publish multi-arch manifests to
-# GHCR and TCR int. The TCR int instance auto-syncs to TCR cn on Tencent Cloud,
-# so no separate CN push job is needed. Add a component by extending the prepare
+# GHCR and TCR int. A self-hosted job then copies per-arch and multi-arch images
+# to TCR cn (avoids slow US→CN pushes). Add a component by extending the prepare
 # job's component table and publish_manifests matrix below.
 on:
   workflow_dispatch:
@@ -308,4 +308,88 @@ jobs:
                 "${image}:${IMAGE_TAG}-amd64" \
                 "${image}:${IMAGE_TAG}-arm64"
             done
+          done
+
+  # Copy per-arch and multi-arch images to TCR cn from a China-side self-hosted
+  # runner so we do not push large layers from GitHub-hosted (US) runners to CN.
+  # This ARC runner set requires a job container.
+  sync_cn:
+    name: ${{ matrix.component }} sync to TCR CN
+    runs-on: arc-runner-set-16c32g-containerd
+    container:
+      image: ubuntu:24.04
+    needs: [publish_manifests, prepare]
+    if: >-
+      always() &&
+      needs.publish_manifests.result == 'success' &&
+      github.repository == 'TencentCloud/CubeSandbox'
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.prepare.outputs.publish) }}
+    steps:
+      - name: Install dependencies
+        run: |
+          set -euo pipefail
+          apt-get update
+          apt-get install -y --no-install-recommends curl ca-certificates
+          rm -rf /var/lib/apt/lists/*
+
+      - name: Install crane
+        env:
+          CRANE_VERSION: v0.20.3
+        run: |
+          set -euo pipefail
+          arch="$(uname -m)"
+          case "${arch}" in
+            x86_64|amd64) crane_arch=x86_64 ;;
+            aarch64|arm64) crane_arch=arm64 ;;
+            *) echo "unsupported arch: ${arch}" >&2; exit 1 ;;
+          esac
+          bin_dir="${RUNNER_TEMP}/crane-bin"
+          mkdir -p "${bin_dir}"
+          curl -fsSL \
+            "https://github.com/google/go-containerregistry/releases/download/${CRANE_VERSION}/go-containerregistry_Linux_${crane_arch}.tar.gz" \
+            | tar -xz -C "${bin_dir}" crane
+          echo "${bin_dir}" >> "${GITHUB_PATH}"
+          "${bin_dir}/crane" version
+
+      - name: Log in to registries
+        env:
+          GHCR_USER: ${{ github.actor }}
+          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TCR_CN_USERNAME: ${{ secrets.TCR_CN_USERNAME }}
+          TCR_CN_PASSWORD: ${{ secrets.TCR_CN_PASSWORD }}
+        run: |
+          set -euo pipefail
+          echo "${GHCR_TOKEN}" | crane auth login ghcr.io -u "${GHCR_USER}" --password-stdin
+          echo "${TCR_CN_PASSWORD}" | crane auth login cube-sandbox-cn.tencentcloudcr.com \
+            -u "${TCR_CN_USERNAME}" --password-stdin
+
+      - name: Resolve manifest tags
+        id: tags
+        env:
+          IMAGE_TAG: ${{ inputs.image_tag }}
+        run: |
+          tags="${IMAGE_TAG}"
+          if [[ "${IMAGE_TAG}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            tags="${tags} latest"
+          fi
+          echo "list=${tags}" >> "${GITHUB_OUTPUT}"
+
+      - name: Copy images to TCR CN
+        env:
+          IMAGE_TAG: ${{ inputs.image_tag }}
+          IMAGE_NAME: ${{ matrix.image }}
+          MANIFEST_TAGS: ${{ steps.tags.outputs.list }}
+        run: |
+          set -euo pipefail
+          src="ghcr.io/tencentcloud/${IMAGE_NAME}"
+          dst="cube-sandbox-cn.tencentcloudcr.com/cube-sandbox/${IMAGE_NAME}"
+          for arch in amd64 arm64; do
+            echo "Copying ${src}:${IMAGE_TAG}-${arch} -> ${dst}:${IMAGE_TAG}-${arch}"
+            crane copy "${src}:${IMAGE_TAG}-${arch}" "${dst}:${IMAGE_TAG}-${arch}"
+          done
+          for tag in ${MANIFEST_TAGS}; do
+            echo "Copying ${src}:${tag} -> ${dst}:${tag}"
+            crane copy "${src}:${tag}" "${dst}:${tag}"
           done


### PR DESCRIPTION
## Summary

Replace the previous push-from-GitHub approach for syncing images to TCR CN with a dedicated `sync_cn` job that:
- Runs on an ARC self-hosted runner (China-side) to avoid slow cross-region pushes
- Uses `crane copy` to replicate per-arch (amd64/arm64) and multi-arch manifest images from GHCR to TCR CN
- Resolves version tags, automatically adding `latest` for stable releases (e.g., `v0.5.0`)

## Changes

- Added `sync_cn` job to `.github/workflows/release-docker-images.yml`
- Runs after `publish_manifests` succeeds and only for the `TencentCloud/CubeSandbox` repository
- Installs `crane` v0.20.3 and logs into both GHCR and TCR CN registries via secrets
- Copies all component images (per-arch + manifest tags) using `crane copy`

## Why

Pushing large container layers from GitHub-hosted US runners directly to a CN registry is slow and unreliable. Running the sync from a China-side self-hosted runner via `crane copy` (registry-to-registry) is significantly faster and more reliable.