### PR TITLE
perf(ci): use crane pull+push split mode for TCR CN sync to avoid rwnd stalls

### DIFF
--- a/.github/workflows/release-docker-images.yml
+++ b/.github/workflows/release-docker-images.yml
@@ -310,13 +310,14 @@ jobs:
             done
           done
 
-  # Copy per-arch and multi-arch images from TCR int to TCR cn on a China-side
-  # self-hosted runner. TCR int already receives the release images during the
-  # build, and using it here avoids pulling large layers from GHCR into China.
+  # Sync per-arch and multi-arch images from TCR int to TCR cn on a China-side
+  # self-hosted runner (crane pull then push; avoids streaming copy stalls).
+  # TCR int already receives the release images during the build, and using it
+  # here avoids pulling large layers from GHCR into China.
   # This ARC runner set requires a job container.
   sync_cn:
     name: ${{ matrix.component }} sync to TCR CN
-    runs-on: arc-runner-set-8c16g-containerd-guangzhou
+    runs-on: arc-2c4g-ctd-gz
     container:
       image: ubuntu:24.04
     needs: [publish_manifests, prepare]
@@ -382,29 +383,39 @@ jobs:
           fi
           echo "list=${tags}" >> "${GITHUB_OUTPUT}"
 
-      - name: Copy images to TCR CN
+      - name: Sync images to TCR CN
         env:
           IMAGE_TAG: ${{ inputs.image_tag }}
           IMAGE_NAME: ${{ matrix.image }}
           MANIFEST_TAGS: ${{ steps.tags.outputs.list }}
-          CRANE_COPY_ATTEMPTS: "3"
-          CRANE_COPY_TIMEOUT: 20m
+          CRANE_SYNC_ATTEMPTS: "3"
+          # Split pull/push instead of `crane copy` streaming: concurrent
+          # pull+push was getting rwnd-limited / unexpected EOF against TCR CN.
+          CRANE_PULL_TIMEOUT: 20m
+          CRANE_PUSH_TIMEOUT: 20m
         run: |
           set -euo pipefail
           src="cube-sandbox-int.tencentcloudcr.com/cube-sandbox/${IMAGE_NAME}"
           dst="cube-sandbox-cn.tencentcloudcr.com/cube-sandbox/${IMAGE_NAME}"
+          work_dir="${RUNNER_TEMP:-/tmp}/crane-sync"
+          mkdir -p "${work_dir}"
 
-          copy_image() {
+          sync_image() {
             local from="$1"
             local to="$2"
             local attempt
-            for attempt in $(seq 1 "${CRANE_COPY_ATTEMPTS}"); do
-              echo "Copying ${from} -> ${to} (attempt ${attempt}/${CRANE_COPY_ATTEMPTS})"
-              if timeout "${CRANE_COPY_TIMEOUT}" crane copy "${from}" "${to}"; then
+            local tarball="${work_dir}/image.tar"
+            for attempt in $(seq 1 "${CRANE_SYNC_ATTEMPTS}"); do
+              echo "Syncing ${from} -> ${to} (attempt ${attempt}/${CRANE_SYNC_ATTEMPTS})"
+              rm -f "${tarball}"
+              if timeout "${CRANE_PULL_TIMEOUT}" crane pull "${from}" "${tarball}" \
+                && timeout "${CRANE_PUSH_TIMEOUT}" crane push "${tarball}" "${to}"; then
+                rm -f "${tarball}"
                 return 0
               fi
-              if [[ "${attempt}" == "${CRANE_COPY_ATTEMPTS}" ]]; then
-                echo "Failed to copy ${from} -> ${to}" >&2
+              rm -f "${tarball}"
+              if [[ "${attempt}" == "${CRANE_SYNC_ATTEMPTS}" ]]; then
+                echo "Failed to sync ${from} -> ${to}" >&2
                 return 1
               fi
               sleep "$((attempt * 10))"
@@ -412,8 +423,8 @@ jobs:
           }
 
           for arch in amd64 arm64; do
-            copy_image "${src}:${IMAGE_TAG}-${arch}" "${dst}:${IMAGE_TAG}-${arch}"
+            sync_image "${src}:${IMAGE_TAG}-${arch}" "${dst}:${IMAGE_TAG}-${arch}"
           done
           for tag in ${MANIFEST_TAGS}; do
-            copy_image "${src}:${tag}" "${dst}:${tag}"
+            sync_image "${src}:${tag}" "${dst}:${tag}"
           done


### PR DESCRIPTION
## Summary

Switch TCR CN image sync from streaming `crane copy` to split `crane pull` then `crane push` to avoid rwnd-limited / unexpected EOF errors against TCR CN.

## Changes

- **Sync method**: Replace `crane copy` (streaming) with `crane pull` + `crane push` (split), writing to a temporary tarball. This resolves concurrent pull+push rwnd-limited / unexpected EOF stalls.
- **Runner**: Switch from `arc-runner-set-8c16g-containerd-guangzhou` to the lighter `arc-2c4g-ctd-gz`.
- **Naming**: Rename env vars from `CRANE_COPY_*` to `CRANE_SYNC_*`, function from `copy_image` to `sync_image`, and step/job descriptions accordingly.
- **Cleanup**: Ensure temporary tarballs are removed on both success and failure paths.

## Verification

- CI dry-run logic and tag preparation unchanged; only the copy mechanism is modified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)