### PR TITLE
feat: add interactive web terminal for sandboxes

### DIFF
--- a/CubeAPI/Cargo.lock
+++ b/CubeAPI/Cargo.lock
@@ -670,6 +670,7 @@ dependencies = [
  "axum-test",
  "base64 0.22.1",
  "bcrypt",
+ "bytes",
  "chrono",
  "clap",
  "config",
@@ -684,10 +685,12 @@ dependencies = [
  "sqlx",
  "thiserror 1.0.69",
  "tokio",
+ "tokio-util",
  "tower 0.4.13",
  "tower-http 0.5.2",
  "tracing",
  "tracing-subscriber",
+ "url",
  "utoipa",
  "uuid",
  "validator",
@@ -2279,6 +2282,7 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "futures-core",
+ "futures-util",
  "http 1.4.0",
  "http-body",
  "http-body-util",
@@ -2298,12 +2302,14 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
+ "tokio-util",
  "tower 0.5.3",
  "tower-http 0.6.11",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
  "webpki-roots 1.0.7",
 ]
@@ -3607,6 +3613,19 @@ dependencies = [
  "indexmap 2.13.0",
  "wasm-encoder",
  "wasmparser",
+]
+
+[[package]]
+name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]

--- a/CubeAPI/Cargo.toml
+++ b/CubeAPI/Cargo.toml
@@ -30,6 +30,10 @@ tower-http = { version = "0.5", features = [
 tokio = { version = "1", features = ["full"] }
 # select!, join!, channel helpers
 futures = "0.3"
+# Byte buffer utilities for streaming protocols
+bytes = "1"
+# CancellationToken and other sync utilities
+tokio-util = "0.7"
 
 # ── Serialization ─────────────────────────────────────────────────────────
 serde = { version = "1", features = ["derive"] }
@@ -69,10 +73,13 @@ governor = { version = "0.6", features = ["dashmap"] }
 
 # ── HTTP client (orchestrator / backend calls) ────────────────────────────
 # connection pool built-in, rustls for TLS
-reqwest = { version = "0.12", features = ["json", "rustls-tls"], default-features = false }
+reqwest = { version = "0.12", features = ["json", "rustls-tls", "stream"], default-features = false }
 
 # ── Validation ────────────────────────────────────────────────────────────
 validator = { version = "0.16", features = ["derive"] }
+
+# ── URL parsing / query string decoding ───────────────────────────────────
+url = "2"
 
 # ── Async trait support ───────────────────────────────────────────────────
 async-trait = "0.1"

--- a/CubeAPI/src/config/mod.rs
+++ b/CubeAPI/src/config/mod.rs
@@ -53,6 +53,9 @@ pub struct ServerConfig {
     ///   - `X-Request-Method: <HTTP method>` (e.g. GET, POST, DELETE, PATCH)
     ///
     /// An HTTP 200 response grants access; any other status code returns 401 to the client.
+    /// On success, the callback may optionally return identity headers for audit logs:
+    ///   - `X-User-ID: <user identifier>`
+    ///   - `X-User-Name: <display name>`
     ///
     /// **Security note**: Multiple HTTP methods (e.g. GET/POST/DELETE/PATCH) are mounted
     /// on the same path (e.g. `/templates/:id`). Callbacks that only whitelist by path
@@ -71,6 +74,30 @@ pub struct ServerConfig {
     /// Example: mysql://cube:cube_pass@127.0.0.1:3306/cube_mvp
     #[serde(default = "default_database_url")]
     pub database_url: Option<String>,
+
+    /// Username used for envd Basic authentication (default: "root").
+    ///
+    /// Env var: `ENVD_AUTH_USERNAME`
+    #[serde(default = "default_envd_auth_username")]
+    pub envd_auth_username: String,
+
+    /// Password used for envd Basic authentication (default: empty).
+    ///
+    /// Env var: `ENVD_AUTH_PASSWORD`
+    #[serde(default)]
+    pub envd_auth_password: Option<String>,
+
+    /// Idle timeout for terminal WebSocket sessions in seconds; 0 disables (default: 300).
+    ///
+    /// Env var: `TERMINAL_IDLE_TIMEOUT_SECONDS`
+    #[serde(default = "default_terminal_idle_timeout_seconds")]
+    pub terminal_idle_timeout_seconds: u64,
+
+    /// WebSocket keepalive interval in seconds; 0 disables (default: 30).
+    ///
+    /// Env var: `TERMINAL_KEEPALIVE_INTERVAL_SECONDS`
+    #[serde(default = "default_terminal_keepalive_interval_seconds")]
+    pub terminal_keepalive_interval_seconds: u64,
 }
 
 fn default_bind() -> String {
@@ -123,6 +150,24 @@ fn default_cube_sandbox_mysql_url() -> Option<String> {
     ))
 }
 
+fn default_envd_auth_username() -> String {
+    std::env::var("ENVD_AUTH_USERNAME").unwrap_or_else(|_| "root".to_string())
+}
+
+fn default_terminal_idle_timeout_seconds() -> u64 {
+    std::env::var("TERMINAL_IDLE_TIMEOUT_SECONDS")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(300)
+}
+
+fn default_terminal_keepalive_interval_seconds() -> u64 {
+    std::env::var("TERMINAL_KEEPALIVE_INTERVAL_SECONDS")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(30)
+}
+
 impl ServerConfig {
     pub fn from_env() -> anyhow::Result<Self> {
         let _ = dotenvy::dotenv();
@@ -148,6 +193,10 @@ impl Default for ServerConfig {
             log_prefix: default_log_prefix(),
             auth_callback_url: None,
             database_url: default_database_url(),
+            envd_auth_username: default_envd_auth_username(),
+            envd_auth_password: None,
+            terminal_idle_timeout_seconds: default_terminal_idle_timeout_seconds(),
+            terminal_keepalive_interval_seconds: default_terminal_keepalive_interval_seconds(),
         }
     }
 }

--- a/CubeAPI/src/cubemaster/mod.rs
+++ b/CubeAPI/src/cubemaster/mod.rs
@@ -1037,7 +1037,7 @@ pub struct GetSandboxDataItem {
     pub end_at: Option<DateTime<Utc>>,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Clone)]
 #[allow(dead_code)]
 pub struct GetSandboxContainerItem {
     #[serde(default)]
@@ -1076,14 +1076,15 @@ pub struct SandboxDetail {
     pub disk_size_mb: i32,
     pub annotations: HashMap<String, String>,
     pub labels: HashMap<String, String>,
+    pub containers: Vec<GetSandboxContainerItem>,
 }
 
-fn parse_cpu_millicores(s: &str) -> i32 {
+pub(crate) fn parse_cpu_millicores(s: &str) -> i32 {
     let s = s.trim().trim_end_matches('m');
     s.parse::<i32>().unwrap_or(0) / 1000
 }
 
-fn parse_mem_mb(s: &str) -> i32 {
+pub(crate) fn parse_mem_mb(s: &str) -> i32 {
     let s = s
         .trim()
         .trim_end_matches("Mi")
@@ -1254,6 +1255,7 @@ impl GetSandboxResponse {
             disk_size_mb: 0,
             annotations: item.annotations,
             labels: item.labels,
+            containers: item.containers,
         })
     }
 }

--- a/CubeAPI/src/envd.rs
+++ b/CubeAPI/src/envd.rs
@@ -1,0 +1,67 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+//! Shared helpers for talking to the in-guest envd daemon over the Connect-JSON
+//! protocol.  This module is used by both the agenthub command proxy and the
+//! Web Terminal bridge so that both features share the same wire-format
+//! implementation and do not drift apart.
+
+use base64::{engine::general_purpose::STANDARD as BASE64, Engine as _};
+
+/// Default envd port inside the sandbox.
+pub const ENVD_PORT: u16 = 49983;
+
+/// Content-Type for Connect-JSON streaming RPCs.
+pub const CONNECT_JSON: &str = "application/connect+json";
+
+/// Connect-Protocol-Version header value.
+pub const CONNECT_PROTOCOL_VERSION: &str = "1";
+
+/// Connect end-of-stream flag (bit 1 of the frame flags byte).
+pub const CONNECT_END_STREAM_FLAG: u8 = 0b10;
+
+/// Connect compressed payload flag (bit 0 of the frame flags byte).  envd may
+/// set this on trailer frames but never on data frames; we reject it if seen.
+pub const CONNECT_COMPRESSED_FLAG: u8 = 0b01;
+
+/// Wrap a JSON payload in the 5-byte Connect envelope:
+///   [1 byte flags][4 bytes big-endian length][payload]
+pub fn connect_envelope(payload: &[u8]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(payload.len() + 5);
+    out.push(0);
+    out.extend_from_slice(&(payload.len() as u32).to_be_bytes());
+    out.extend_from_slice(payload);
+    out
+}
+
+/// envd-facing Host header value used to route the request into the sandbox.
+/// Format: `{port}-{sandbox_id}.{domain}`.
+pub fn envd_host(port: u16, sandbox_id: &str, domain: &str) -> String {
+    format!("{}-{}.{}", port, sandbox_id, domain)
+}
+
+/// Base URL of the sidecar/proxy that forwards requests into the sandbox.
+/// Defaults to `http://127.0.0.1` and can be overridden with the
+/// `AGENTHUB_SANDBOX_PROXY_URL` environment variable.
+pub fn envd_proxy_url() -> String {
+    std::env::var("AGENTHUB_SANDBOX_PROXY_URL")
+        .unwrap_or_else(|_| "http://127.0.0.1".to_string())
+        .trim_end_matches('/')
+        .to_string()
+}
+
+/// Full URL for a `process.Process/{method}` RPC against the envd proxy.
+pub fn envd_process_url(method: &str) -> String {
+    format!("{}/process.Process/{}", envd_proxy_url(), method)
+}
+
+/// Build the `Authorization: Basic ...` header value used by envd.
+///
+/// An empty or missing password is treated as no password, matching the
+/// default envd configuration and the Go/Python SDKs.
+pub fn basic_auth_header(username: &str, password: Option<&str>) -> String {
+    let password = password.unwrap_or("");
+    let creds = BASE64.encode(format!("{}:{}", username, password));
+    format!("Basic {}", creds)
+}

--- a/CubeAPI/src/handlers/agenthub.rs
+++ b/CubeAPI/src/handlers/agenthub.rs
@@ -9,6 +9,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 use crate::{
+    envd,
     error::{AppError, AppResult},
     models::{
         EgressRule, EgressRuleAction, EgressRuleInject, EgressRuleMatch, NewSandbox,
@@ -25,10 +26,8 @@ const DEEPSEEK_V4_FLASH_MODEL_LABEL: &str = "DeepSeek V4 Flash";
 const DEFAULT_OPENCLAW_MODEL: &str = DEEPSEEK_V4_FLASH_MODEL;
 const DEEPSEEK_V4_PRO_MODEL: &str = "deepseek/deepseek-v4-pro";
 const DEEPSEEK_V4_PRO_MODEL_LABEL: &str = "DeepSeek V4 Pro";
-const ENVD_PORT: u16 = 49983;
 const LOGIN_ENV_PORT: u16 = 8080;
 const OPENCLAW_UI_PORT: u16 = 18789;
-const CONNECT_JSON: &str = "application/connect+json";
 const SETTING_DEEPSEEK_API_KEY: &str = "deepseek_api_key";
 const SETTING_LLM_PROVIDER: &str = "llm_provider";
 const SETTING_LLM_BASE_URL: &str = "llm_base_url";
@@ -3798,18 +3797,22 @@ async fn run_envd_command(
     domain: &str,
     req: Value,
 ) -> AppResult<CommandOutput> {
-    let host = format!("{}-{}.{}", ENVD_PORT, sandbox_id, domain);
-    let url = std::env::var("AGENTHUB_SANDBOX_PROXY_URL")
-        .unwrap_or_else(|_| "http://127.0.0.1".to_string());
-    let url = format!("{}/process.Process/Start", url.trim_end_matches('/'));
+    let host = envd::envd_host(envd::ENVD_PORT, sandbox_id, domain);
+    let url = envd::envd_process_url("Start");
 
-    let body = connect_envelope(&serde_json::to_vec(&req).map_err(anyhow::Error::from)?);
+    let body = envd::connect_envelope(&serde_json::to_vec(&req).map_err(anyhow::Error::from)?);
     let resp = state
         .http_client
         .post(url)
         .header("Host", host)
-        .header("Content-Type", CONNECT_JSON)
-        .header("Authorization", "Basic cm9vdDo=")
+        .header("Content-Type", envd::CONNECT_JSON)
+        .header(
+            "Authorization",
+            envd::basic_auth_header(
+                &state.config.envd_auth_username,
+                state.config.envd_auth_password.as_deref(),
+            ),
+        )
         .body(body)
         .send()
         .await
@@ -3826,14 +3829,6 @@ async fn run_envd_command(
         AppError::Internal(anyhow::anyhow!("failed reading envd command stream: {}", e))
     })?;
     parse_connect_stream(&bytes)
-}
-
-fn connect_envelope(payload: &[u8]) -> Vec<u8> {
-    let mut out = Vec::with_capacity(payload.len() + 5);
-    out.push(0);
-    out.extend_from_slice(&(payload.len() as u32).to_be_bytes());
-    out.extend_from_slice(payload);
-    out
 }
 
 fn parse_connect_stream(bytes: &[u8]) -> AppResult<CommandOutput> {

--- a/CubeAPI/src/handlers/mod.rs
+++ b/CubeAPI/src/handlers/mod.rs
@@ -11,3 +11,4 @@ pub mod sandboxes;
 pub mod snapshots;
 pub mod store;
 pub mod templates;
+pub mod terminal;

--- a/CubeAPI/src/handlers/terminal.rs
+++ b/CubeAPI/src/handlers/terminal.rs
@@ -413,9 +413,14 @@ async fn envd_reader(
                 .await;
                 return reason.unwrap_or_else(|| "cancelled".to_string());
             },
-            _ = ping_rx.recv() => {
-                if let Err(e) = ws_tx.send(Message::Ping(vec![])).await {
-                    tracing::debug!(error = %e, "failed to send WebSocket ping");
+            ping = ping_rx.recv() => {
+                match ping {
+                    Some(()) => {
+                        if let Err(e) = ws_tx.send(Message::Ping(vec![])).await {
+                            tracing::debug!(error = %e, "failed to send WebSocket ping");
+                        }
+                    }
+                    None => return "keepalive_stopped".to_string(),
                 }
                 continue;
             },

--- a/CubeAPI/src/handlers/terminal.rs
+++ b/CubeAPI/src/handlers/terminal.rs
@@ -1,0 +1,846 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+use axum::{
+    extract::{
+        ws::{Message, WebSocket, WebSocketUpgrade},
+        ConnectInfo, Extension, Path, Query, State,
+    },
+    http::HeaderMap,
+    response::IntoResponse,
+};
+use base64::{engine::general_purpose::STANDARD as BASE64, Engine as _};
+use bytes::BytesMut;
+use futures::{SinkExt, StreamExt};
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+use tokio::sync::{mpsc, oneshot, RwLock};
+use tokio_util::sync::CancellationToken;
+
+use crate::{
+    envd,
+    error::{AppError, AppResult},
+    middleware::auth::{AuthContext, SharedAuthContext},
+    middleware::terminal_audit::{extract_remote_ip, log_terminal_event},
+    models::{SandboxContainer, SandboxContainerState, SandboxState},
+    state::AppState,
+};
+use std::time::{Duration, Instant, SystemTime};
+use std::{
+    net::SocketAddr,
+    sync::{
+        atomic::{AtomicBool, AtomicU16, AtomicU64, Ordering},
+        Arc,
+    },
+};
+
+pub(crate) const DEFAULT_COLS: u16 = 80;
+pub(crate) const DEFAULT_ROWS: u16 = 24;
+const SIGNAL_SIGKILL: &str = "SIGNAL_SIGKILL";
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct TerminalQuery {
+    #[serde(default = "default_cols")]
+    pub(crate) cols: u16,
+    #[serde(default = "default_rows")]
+    pub(crate) rows: u16,
+    #[serde(default)]
+    pub(crate) container: Option<String>,
+}
+
+fn default_cols() -> u16 {
+    DEFAULT_COLS
+}
+
+fn default_rows() -> u16 {
+    DEFAULT_ROWS
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+enum ClientMessage {
+    Input { data: String },
+    Resize { cols: u16, rows: u16 },
+}
+
+#[derive(Debug, Serialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+enum ServerMessage {
+    Output {
+        data: String,
+    },
+    Error {
+        message: String,
+    },
+    Close {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        reason: Option<String>,
+    },
+}
+
+#[derive(Debug)]
+enum TerminalAction {
+    Input(Vec<u8>),
+    Resize { cols: u16, rows: u16 },
+}
+
+/// Locate a running container by container ID.  The WebUI sends container IDs
+/// from the sandbox detail response, so avoid name fallback that can shadow an
+/// actual ID when containers have colliding names.
+fn select_running_container<'a>(
+    containers: &'a [SandboxContainer],
+    container_id: &str,
+) -> AppResult<&'a SandboxContainer> {
+    let container = containers
+        .iter()
+        .find(|c| c.container_id == container_id)
+        .ok_or_else(|| {
+            AppError::BadRequest(format!("container '{}' not found in sandbox", container_id))
+        })?;
+    if container.state != SandboxContainerState::Running {
+        return Err(AppError::Conflict(format!(
+            "container {} is not running",
+            container_id
+        )));
+    }
+    Ok(container)
+}
+
+/// WebSocket entry point for the sandbox terminal.
+pub async fn terminal_ws(
+    ws: WebSocketUpgrade,
+    State(state): State<AppState>,
+    Path(sandbox_id): Path<String>,
+    Query(query): Query<TerminalQuery>,
+    Extension(auth_ctx_ext): Extension<SharedAuthContext>,
+    headers: HeaderMap,
+    connect_info: Option<ConnectInfo<SocketAddr>>,
+) -> AppResult<impl IntoResponse> {
+    let detail = state.services.sandboxes.get_sandbox(&sandbox_id).await?;
+
+    if detail.state != SandboxState::Running {
+        return Err(AppError::Conflict(format!(
+            "sandbox {} is not running",
+            sandbox_id
+        )));
+    }
+
+    let selected_container_id = query
+        .container
+        .as_deref()
+        .map(|container_id| {
+            select_running_container(&detail.containers, container_id)
+                .map(|c| c.container_id.clone())
+        })
+        .transpose()?;
+
+    let domain = detail
+        .domain
+        .filter(|d| !d.trim().is_empty())
+        .unwrap_or_else(|| state.config.sandbox_domain.clone());
+    if domain.trim().is_empty() {
+        return Err(AppError::Internal(anyhow::anyhow!(
+            "sandbox domain is not configured"
+        )));
+    }
+
+    let remote_ip = extract_remote_ip(&headers, connect_info.map(|ci| ci.0));
+    let auth_ctx = auth_ctx_ext.read().await.clone();
+
+    Ok(ws.on_upgrade(move |socket| {
+        handle_terminal_socket(
+            socket,
+            state,
+            sandbox_id,
+            domain,
+            PtySize {
+                cols: query.cols,
+                rows: query.rows,
+            },
+            selected_container_id,
+            remote_ip,
+            auth_ctx,
+        )
+    }))
+}
+
+#[derive(Debug, Clone, Copy)]
+struct PtySize {
+    cols: u16,
+    rows: u16,
+}
+
+async fn handle_terminal_socket(
+    socket: WebSocket,
+    state: AppState,
+    sandbox_id: String,
+    domain: String,
+    initial_size: PtySize,
+    selected_container_id: Option<String>,
+    remote_ip: String,
+    auth_ctx: AuthContext,
+) {
+    let start = Instant::now();
+    let connected = Arc::new(AtomicBool::new(false));
+    let current_size = Arc::new((
+        AtomicU16::new(initial_size.cols),
+        AtomicU16::new(initial_size.rows),
+    ));
+    let last_activity = Arc::new(AtomicU64::new(unix_now_secs()));
+    let shutdown_reason: Arc<RwLock<Option<String>>> = Arc::new(RwLock::new(None));
+
+    let (ws_tx, ws_rx) = socket.split();
+    let cancel = CancellationToken::new();
+    let (pid_tx, pid_rx) = oneshot::channel::<i64>();
+    let (action_tx, action_rx) = mpsc::channel::<TerminalAction>(64);
+    let (ping_tx, ping_rx) = mpsc::channel::<()>(2);
+
+    let mut set = tokio::task::JoinSet::<String>::new();
+    set.spawn(envd_reader(
+        state.clone(),
+        sandbox_id.clone(),
+        domain.clone(),
+        initial_size,
+        selected_container_id.clone(),
+        remote_ip.clone(),
+        auth_ctx.clone(),
+        connected.clone(),
+        Some(pid_tx),
+        ws_tx,
+        shutdown_reason.clone(),
+        ping_rx,
+        cancel.child_token(),
+    ));
+    set.spawn(envd_writer(
+        state.clone(),
+        sandbox_id.clone(),
+        domain,
+        pid_rx,
+        action_rx,
+        current_size.clone(),
+        cancel.child_token(),
+    ));
+    set.spawn(ws_reader_task(
+        action_tx,
+        ws_rx,
+        last_activity.clone(),
+        shutdown_reason.clone(),
+        cancel.child_token(),
+    ));
+
+    let idle_timeout = Duration::from_secs(state.config.terminal_idle_timeout_seconds);
+    if idle_timeout > Duration::ZERO {
+        set.spawn(idle_watcher(
+            last_activity.clone(),
+            shutdown_reason.clone(),
+            idle_timeout,
+            cancel.clone(),
+        ));
+    }
+
+    let keepalive_interval = Duration::from_secs(state.config.terminal_keepalive_interval_seconds);
+    if keepalive_interval > Duration::ZERO {
+        set.spawn(keepalive_task(
+            ping_tx,
+            keepalive_interval,
+            cancel.child_token(),
+        ));
+    }
+
+    // Wait for any task to finish, then signal the others to shut down.
+    let disconnect_reason = match set.join_next().await {
+        Some(Ok(reason)) => reason,
+        Some(Err(e)) => {
+            tracing::error!(error = %e, "terminal task panicked");
+            "task_panicked".to_string()
+        }
+        None => "unknown".to_string(),
+    };
+    cancel.cancel();
+
+    // Give the remaining tasks a short grace period to clean up (the writer
+    // needs to SIGKILL the PTY).  Abort anything still stuck afterwards.
+    while !set.is_empty() {
+        match tokio::time::timeout(Duration::from_secs(5), set.join_next()).await {
+            Ok(Some(_)) => {}
+            _ => {
+                set.abort_all();
+                break;
+            }
+        }
+    }
+
+    if connected.load(Ordering::Relaxed) {
+        let cols = current_size.0.load(Ordering::Relaxed);
+        let rows = current_size.1.load(Ordering::Relaxed);
+        let mut extra = vec![
+            ("duration_ms", (start.elapsed().as_millis() as u64).into()),
+            ("disconnect_reason", disconnect_reason.clone().into()),
+        ];
+        if let Some(ref container_id) = selected_container_id {
+            extra.push(("container", container_id.clone().into()));
+        }
+        log_terminal_event(
+            &state.logger,
+            "terminal.disconnect",
+            &sandbox_id,
+            &remote_ip,
+            &auth_ctx,
+            cols,
+            rows,
+            extra,
+        )
+        .await;
+    }
+}
+
+/// Reads the envd `process.Process/Start` stream and forwards PTY output to
+/// the browser.  Signals the writer task once the `start` event is received.
+/// Returns a short human-readable reason string used for audit logs.
+fn build_start_payload(size: PtySize, selected_container_id: Option<&str>) -> serde_json::Value {
+    let mut payload = json!({
+        "process": {
+            "cmd": "/bin/bash",
+            "args": ["-i", "-l"],
+            "envs": {
+                "TERM": "xterm-256color",
+                "LANG": "C.UTF-8",
+                "LC_ALL": "C.UTF-8"
+            }
+        },
+        "pty": {
+            "size": {
+                "rows": size.rows,
+                "cols": size.cols
+            }
+        }
+    });
+
+    if let Some(container_id) = selected_container_id {
+        payload["process"]["container_id"] = json!(container_id);
+    }
+
+    payload
+}
+
+async fn envd_reader(
+    state: AppState,
+    sandbox_id: String,
+    domain: String,
+    size: PtySize,
+    selected_container_id: Option<String>,
+    remote_ip: String,
+    auth_ctx: AuthContext,
+    connected: Arc<AtomicBool>,
+    mut pid_tx: Option<oneshot::Sender<i64>>,
+    mut ws_tx: futures::stream::SplitSink<WebSocket, Message>,
+    shutdown_reason: Arc<RwLock<Option<String>>>,
+    mut ping_rx: mpsc::Receiver<()>,
+    cancel: CancellationToken,
+) -> String {
+    let start_process = build_start_payload(size, selected_container_id.as_deref());
+
+    let body = match serde_json::to_vec(&start_process) {
+        Ok(bytes) => envd::connect_envelope(&bytes),
+        Err(e) => {
+            let _ = send_error(
+                &mut ws_tx,
+                &format!("failed to serialize start request: {}", e),
+            )
+            .await;
+            tracing::error!(error = %e, "failed to serialize terminal start request");
+            return "start_serialize_error".to_string();
+        }
+    };
+
+    let host = envd::envd_host(envd::ENVD_PORT, &sandbox_id, &domain);
+    let auth_header = envd::basic_auth_header(
+        &state.config.envd_auth_username,
+        state.config.envd_auth_password.as_deref(),
+    );
+    let req = state
+        .http_client
+        .post(envd::envd_process_url("Start"))
+        .header("Host", host)
+        .header("Content-Type", envd::CONNECT_JSON)
+        .header("Connect-Protocol-Version", envd::CONNECT_PROTOCOL_VERSION)
+        .header("Connect-Content-Encoding", "identity")
+        .header("Authorization", auth_header)
+        .body(body);
+
+    let resp = match req.send().await {
+        Ok(r) => r,
+        Err(e) => {
+            let _ = send_error(
+                &mut ws_tx,
+                &format!("failed to connect to sandbox terminal: {}", e),
+            )
+            .await;
+            tracing::error!(error = %e, "failed to connect to sandbox terminal");
+            return "envd_start_request_error".to_string();
+        }
+    };
+
+    if !resp.status().is_success() {
+        let status = resp.status();
+        let body_text = resp.text().await.unwrap_or_default();
+        let _ = send_error(
+            &mut ws_tx,
+            &format!(
+                "envd terminal start failed: HTTP {} - {}",
+                status, body_text
+            ),
+        )
+        .await;
+        tracing::error!(status = %status, "envd terminal start returned HTTP error");
+        return "envd_start_http_error".to_string();
+    }
+
+    let mut stream = resp.bytes_stream();
+    let mut buffer = BytesMut::new();
+    let mut finish_reason = "envd_stream_closed".to_string();
+
+    loop {
+        let chunk = tokio::select! {
+            _ = cancel.cancelled() => {
+                let reason = shutdown_reason.read().await.clone();
+                let close_reason = reason.clone();
+                let _ = send_msg(
+                    &mut ws_tx,
+                    &ServerMessage::Close { reason: close_reason },
+                )
+                .await;
+                return reason.unwrap_or_else(|| "cancelled".to_string());
+            },
+            _ = ping_rx.recv() => {
+                if let Err(e) = ws_tx.send(Message::Ping(vec![])).await {
+                    tracing::debug!(error = %e, "failed to send WebSocket ping");
+                }
+                continue;
+            },
+            item = stream.next() => item,
+        };
+
+        match chunk {
+            Some(Ok(bytes)) => buffer.extend_from_slice(&bytes),
+            Some(Err(e)) => {
+                let _ =
+                    send_error(&mut ws_tx, &format!("error reading terminal stream: {}", e)).await;
+                tracing::debug!(error = %e, "error reading terminal stream");
+                finish_reason = "envd_stream_error".to_string();
+                break;
+            }
+            None => break,
+        }
+
+        while buffer.len() >= 5 {
+            let flags = buffer[0];
+            let len = u32::from_be_bytes([buffer[1], buffer[2], buffer[3], buffer[4]]) as usize;
+            if len > 8 * 1024 * 1024 {
+                let _ = send_error(&mut ws_tx, "terminal stream frame exceeds maximum size").await;
+                return "envd_frame_too_large".to_string();
+            }
+            if buffer.len() < 5 + len {
+                break;
+            }
+
+            let payload = buffer.split_to(5 + len).split_off(5).freeze();
+
+            if flags & envd::CONNECT_COMPRESSED_FLAG != 0 {
+                let _ = send_error(
+                    &mut ws_tx,
+                    "compressed terminal stream frames are not supported",
+                )
+                .await;
+                return "envd_compressed_frame".to_string();
+            }
+
+            if flags & envd::CONNECT_END_STREAM_FLAG != 0 {
+                // Trailer frame.  If it carries an error, surface it.
+                if let Ok(v) = serde_json::from_slice::<serde_json::Value>(&payload) {
+                    if let Some(err) = v.get("error").and_then(|e| e.as_str()) {
+                        let _ =
+                            send_error(&mut ws_tx, &format!("envd terminal error: {}", err)).await;
+                    }
+                }
+                break;
+            }
+
+            let event: serde_json::Value = match serde_json::from_slice(&payload) {
+                Ok(v) => v,
+                Err(e) => {
+                    tracing::warn!(error = %e, "invalid envd terminal event JSON");
+                    continue;
+                }
+            };
+
+            if let Some(start) = event.get("event").and_then(|e| e.get("start")) {
+                if let Some(pid) = start.get("pid").and_then(|p| p.as_i64()) {
+                    if let Some(tx) = pid_tx.take() {
+                        let _ = tx.send(pid);
+                        if !connected.swap(true, Ordering::Relaxed) {
+                            let mut extra = vec![];
+                            if let Some(ref container_id) = selected_container_id {
+                                extra.push(("container", container_id.clone().into()));
+                            }
+                            log_terminal_event(
+                                &state.logger,
+                                "terminal.connect",
+                                &sandbox_id,
+                                &remote_ip,
+                                &auth_ctx,
+                                size.cols,
+                                size.rows,
+                                extra,
+                            )
+                            .await;
+                        }
+                    }
+                }
+            }
+
+            if let Some(data) = event.get("event").and_then(|e| e.get("data")) {
+                if let Some(pty) = data.get("pty").and_then(|p| p.as_str()) {
+                    let _ = send_msg(
+                        &mut ws_tx,
+                        &ServerMessage::Output {
+                            data: pty.to_string(),
+                        },
+                    )
+                    .await;
+                }
+            }
+
+            if event.get("event").and_then(|e| e.get("end")).is_some() {
+                let _ = send_msg(&mut ws_tx, &ServerMessage::Close { reason: None }).await;
+                return "envd_end".to_string();
+            }
+        }
+    }
+
+    let _ = send_msg(&mut ws_tx, &ServerMessage::Close { reason: None }).await;
+    finish_reason
+}
+
+/// Receives input/resize actions from the browser and forwards them to envd
+/// via the unary `SendInput` and `Update` RPCs.  Cleans up the PTY when the
+/// channel closes or cancellation is requested.  Returns a short reason string
+/// for audit logs.
+async fn envd_writer(
+    state: AppState,
+    sandbox_id: String,
+    domain: String,
+    pid_rx: oneshot::Receiver<i64>,
+    mut action_rx: mpsc::Receiver<TerminalAction>,
+    current_size: Arc<(AtomicU16, AtomicU16)>,
+    cancel: CancellationToken,
+) -> String {
+    let pid = match pid_rx.await {
+        Ok(p) => p,
+        Err(_) => {
+            tracing::debug!("envd_writer: pid sender dropped before start event");
+            return "pid_sender_dropped".to_string();
+        }
+    };
+
+    let mut finish_reason = "writer_finished".to_string();
+    loop {
+        let action = tokio::select! {
+            _ = cancel.cancelled() => {
+                finish_reason = "cancelled".to_string();
+                break;
+            },
+            item = action_rx.recv() => match item {
+                Some(a) => a,
+                None => break,
+            },
+        };
+
+        match action {
+            TerminalAction::Input(bytes) => {
+                let payload = json!({
+                    "process": { "pid": pid },
+                    "input": { "pty": BASE64.encode(&bytes) }
+                });
+                if let Err(e) =
+                    send_envd_unary(&state, &sandbox_id, &domain, "SendInput", payload).await
+                {
+                    tracing::error!(error = %e, pid, "terminal SendInput to envd failed");
+                    cancel.cancel();
+                    finish_reason = "envd_action_error".to_string();
+                    break;
+                }
+            }
+            TerminalAction::Resize { cols, rows } => {
+                current_size.0.store(cols, Ordering::Relaxed);
+                current_size.1.store(rows, Ordering::Relaxed);
+                let payload = json!({
+                    "process": { "pid": pid },
+                    "pty": { "size": { "rows": rows, "cols": cols } }
+                });
+                if let Err(e) =
+                    send_envd_unary(&state, &sandbox_id, &domain, "Update", payload).await
+                {
+                    tracing::error!(error = %e, pid, "terminal Update to envd failed");
+                    cancel.cancel();
+                    finish_reason = "envd_action_error".to_string();
+                    break;
+                }
+            }
+        }
+    }
+
+    // Best-effort cleanup: kill the shell so we do not leak PTYs.
+    let kill_payload = json!({
+        "process": { "pid": pid },
+        "signal": SIGNAL_SIGKILL
+    });
+    if let Err(e) = send_envd_unary(&state, &sandbox_id, &domain, "SendSignal", kill_payload).await
+    {
+        tracing::debug!(error = %e, pid, "failed to SIGKILL terminal process (may already be gone)");
+    }
+
+    finish_reason
+}
+
+/// Reads JSON messages from the browser and forwards them to the envd writer.
+/// Returns a short reason string for audit logs.
+async fn ws_reader_task(
+    action_tx: mpsc::Sender<TerminalAction>,
+    mut ws_rx: futures::stream::SplitStream<WebSocket>,
+    last_activity: Arc<AtomicU64>,
+    shutdown_reason: Arc<RwLock<Option<String>>>,
+    cancel: CancellationToken,
+) -> String {
+    loop {
+        let msg = tokio::select! {
+            _ = cancel.cancelled() => {
+                let reason = shutdown_reason.read().await.clone();
+                return reason.unwrap_or_else(|| "cancelled".to_string());
+            },
+            item = ws_rx.next() => item,
+        };
+
+        match msg {
+            Some(Ok(Message::Text(text))) => {
+                let client_msg: ClientMessage = match serde_json::from_str(&text) {
+                    Ok(m) => m,
+                    Err(e) => {
+                        tracing::debug!(error = %e, "ignoring invalid terminal client message");
+                        continue;
+                    }
+                };
+
+                let action = match client_msg {
+                    ClientMessage::Input { data } => match BASE64.decode(data) {
+                        Ok(bytes) => TerminalAction::Input(bytes),
+                        Err(e) => {
+                            tracing::debug!(error = %e, "ignoring invalid base64 terminal input");
+                            continue;
+                        }
+                    },
+                    ClientMessage::Resize { cols, rows } => TerminalAction::Resize { cols, rows },
+                };
+
+                last_activity.store(unix_now_secs(), Ordering::Relaxed);
+
+                if action_tx.send(action).await.is_err() {
+                    return "action_channel_closed".to_string();
+                }
+            }
+            Some(Ok(Message::Close(_))) | None => return "client_closed".to_string(),
+            Some(Ok(_)) => {}
+            Some(Err(e)) => {
+                tracing::debug!(error = %e, "WebSocket receive error");
+                return "client_error".to_string();
+            }
+        }
+    }
+}
+
+async fn idle_watcher(
+    last_activity: Arc<AtomicU64>,
+    shutdown_reason: Arc<RwLock<Option<String>>>,
+    timeout: Duration,
+    cancel: CancellationToken,
+) -> String {
+    let check_interval = timeout / 4;
+    let check_interval = check_interval.max(Duration::from_secs(1));
+
+    loop {
+        tokio::select! {
+            _ = cancel.cancelled() => return "cancelled".to_string(),
+            _ = tokio::time::sleep(check_interval) => {}
+        }
+
+        let elapsed = Duration::from_secs(unix_now_secs() - last_activity.load(Ordering::Relaxed));
+        if elapsed >= timeout {
+            let mut reason = shutdown_reason.write().await;
+            *reason = Some("idle_timeout".to_string());
+            cancel.cancel();
+            return "idle_timeout".to_string();
+        }
+    }
+}
+
+async fn keepalive_task(
+    ping_tx: mpsc::Sender<()>,
+    interval: Duration,
+    cancel: CancellationToken,
+) -> String {
+    loop {
+        tokio::select! {
+            _ = cancel.cancelled() => return "cancelled".to_string(),
+            _ = tokio::time::sleep(interval) => {}
+        }
+
+        if ping_tx.send(()).await.is_err() {
+            return "ping_channel_closed".to_string();
+        }
+    }
+}
+
+async fn send_envd_unary(
+    state: &AppState,
+    sandbox_id: &str,
+    domain: &str,
+    method: &str,
+    payload: serde_json::Value,
+) -> AppResult<()> {
+    let host = envd::envd_host(envd::ENVD_PORT, sandbox_id, domain);
+    let auth_header = envd::basic_auth_header(
+        &state.config.envd_auth_username,
+        state.config.envd_auth_password.as_deref(),
+    );
+    let resp = state
+        .http_client
+        .post(envd::envd_process_url(method))
+        .header("Host", host)
+        .header("Content-Type", "application/json")
+        .header("Connect-Protocol-Version", envd::CONNECT_PROTOCOL_VERSION)
+        .header("Authorization", auth_header)
+        .json(&payload)
+        .send()
+        .await
+        .map_err(|e| {
+            AppError::Internal(anyhow::anyhow!("envd {} request failed: {}", method, e))
+        })?;
+
+    if !resp.status().is_success() {
+        let status = resp.status();
+        return Err(AppError::Internal(anyhow::anyhow!(
+            "envd {} returned HTTP {}",
+            method,
+            status,
+        )));
+    }
+
+    Ok(())
+}
+
+async fn send_msg(ws_tx: &mut futures::stream::SplitSink<WebSocket, Message>, msg: &ServerMessage) {
+    let text = match serde_json::to_string(msg) {
+        Ok(t) => t,
+        Err(e) => {
+            tracing::error!(error = %e, "failed to serialize terminal server message");
+            return;
+        }
+    };
+    if let Err(e) = ws_tx.send(Message::Text(text)).await {
+        tracing::debug!(error = %e, "failed to send terminal message to browser");
+    }
+}
+
+async fn send_error(ws_tx: &mut futures::stream::SplitSink<WebSocket, Message>, message: &str) {
+    send_msg(
+        ws_tx,
+        &ServerMessage::Error {
+            message: message.to_string(),
+        },
+    )
+    .await;
+}
+
+fn unix_now_secs() -> u64 {
+    SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models::{SandboxContainer, SandboxContainerState};
+
+    #[test]
+    fn basic_auth_header_default_root_no_password() {
+        let header = envd::basic_auth_header("root", None);
+        assert_eq!(header, "Basic cm9vdDo=");
+    }
+
+    #[test]
+    fn basic_auth_header_with_password() {
+        let header = envd::basic_auth_header("root", Some("secret"));
+        assert_eq!(header, "Basic cm9vdDpzZWNyZXQ=");
+    }
+
+    #[test]
+    fn select_running_container_matches_by_id_only() {
+        let containers = vec![SandboxContainer {
+            container_id: "cid-1".to_string(),
+            name: "app".to_string(),
+            state: SandboxContainerState::Running,
+            image: "img".to_string(),
+            cpu_count: 1,
+            memory_mb: 256,
+            started_at: None,
+            kind: None,
+        }];
+
+        assert!(select_running_container(&containers, "cid-1").is_ok());
+        assert!(select_running_container(&containers, "app").is_err());
+    }
+
+    #[test]
+    fn select_running_container_rejects_missing_or_not_running() {
+        let containers = vec![
+            SandboxContainer {
+                container_id: "cid-1".to_string(),
+                name: "app".to_string(),
+                state: SandboxContainerState::Running,
+                image: "img".to_string(),
+                cpu_count: 1,
+                memory_mb: 256,
+                started_at: None,
+                kind: None,
+            },
+            SandboxContainer {
+                container_id: "cid-2".to_string(),
+                name: "sidecar".to_string(),
+                state: SandboxContainerState::Paused,
+                image: "img".to_string(),
+                cpu_count: 1,
+                memory_mb: 256,
+                started_at: None,
+                kind: None,
+            },
+        ];
+
+        assert!(select_running_container(&containers, "missing").is_err());
+        assert!(select_running_container(&containers, "sidecar").is_err());
+    }
+
+    #[test]
+    fn build_start_payload_includes_container_id_when_selected() {
+        let payload = build_start_payload(PtySize { cols: 80, rows: 24 }, Some("cid-1"));
+        assert_eq!(payload["process"]["container_id"].as_str(), Some("cid-1"));
+    }
+
+    #[test]
+    fn build_start_payload_omits_container_id_when_not_selected() {
+        let payload = build_start_payload(PtySize { cols: 80, rows: 24 }, None);
+        assert!(payload["process"]["container_id"].is_null());
+    }
+}

--- a/CubeAPI/src/main.rs
+++ b/CubeAPI/src/main.rs
@@ -7,6 +7,7 @@ mod constants;
 mod crypto;
 mod cubemaster;
 mod db;
+mod envd;
 mod error;
 mod handlers;
 mod logging;
@@ -117,6 +118,30 @@ struct Cli {
     #[arg(long, value_name = "DOMAIN")]
     sandbox_domain: Option<String>,
 
+    /// Username used for envd Basic authentication (default: "root").
+    ///
+    /// Overrides the ENVD_AUTH_USERNAME environment variable.
+    #[arg(long, value_name = "USER")]
+    envd_auth_username: Option<String>,
+
+    /// Password used for envd Basic authentication (default: empty).
+    ///
+    /// Overrides the ENVD_AUTH_PASSWORD environment variable.
+    #[arg(long, value_name = "PASSWORD")]
+    envd_auth_password: Option<String>,
+
+    /// Idle timeout for terminal WebSocket sessions in seconds (default: 300, 0 disables).
+    ///
+    /// Overrides the TERMINAL_IDLE_TIMEOUT_SECONDS environment variable.
+    #[arg(long, value_name = "SECONDS")]
+    terminal_idle_timeout_seconds: Option<u64>,
+
+    /// WebSocket keepalive interval in seconds (default: 30, 0 disables).
+    ///
+    /// Overrides the TERMINAL_KEEPALIVE_INTERVAL_SECONDS environment variable.
+    #[arg(long, value_name = "SECONDS")]
+    terminal_keepalive_interval_seconds: Option<u64>,
+
     /// Export the current OpenAPI spec to a YAML file and exit.
     #[arg(long, value_name = "PATH")]
     export_openapi: Option<String>,
@@ -168,6 +193,18 @@ fn main() -> anyhow::Result<()> {
     }
     if let Some(v) = cli.sandbox_domain {
         cfg.sandbox_domain = v;
+    }
+    if let Some(v) = cli.envd_auth_username {
+        cfg.envd_auth_username = v;
+    }
+    if let Some(v) = cli.envd_auth_password {
+        cfg.envd_auth_password = Some(v);
+    }
+    if let Some(v) = cli.terminal_idle_timeout_seconds {
+        cfg.terminal_idle_timeout_seconds = v;
+    }
+    if let Some(v) = cli.terminal_keepalive_interval_seconds {
+        cfg.terminal_keepalive_interval_seconds = v;
     }
 
     // ── Tracing (stdout) ───────────────────────────────────────────────────
@@ -238,9 +275,12 @@ async fn async_main(cfg: config::ServerConfig, debug: bool) -> anyhow::Result<()
     tracing::info!("cube-api listening on {}", cfg.bind);
 
     // ── Graceful shutdown ──────────────────────────────────────────────────
-    axum::serve(listener, app)
-        .with_graceful_shutdown(shutdown_signal())
-        .await?;
+    axum::serve(
+        listener,
+        app.into_make_service_with_connect_info::<std::net::SocketAddr>(),
+    )
+    .with_graceful_shutdown(shutdown_signal())
+    .await?;
 
     logging::Logger::flush(&*logger).await;
     tracing::info!("cube-api shut down gracefully");

--- a/CubeAPI/src/middleware/auth.rs
+++ b/CubeAPI/src/middleware/auth.rs
@@ -5,21 +5,47 @@
 use crate::{error::AppError, state::AppState};
 use axum::{
     extract::{Request, State},
+    http::header::{HeaderValue, AUTHORIZATION},
     middleware::Next,
     response::Response,
 };
+use std::sync::Arc;
+use tokio::sync::RwLock;
 
 /// Auth credential extracted from the request headers.
 #[derive(Debug)]
-enum AuthCredential {
+pub(crate) enum AuthCredential {
     /// `Authorization: Bearer <token>`
     Bearer(String),
     /// `X-API-Key: <key>`
     ApiKey(String),
 }
 
+/// Propagated auth identity.  Populated by the callback middleware and read by
+/// audit / terminal handlers.  When no callback is configured the terminal may
+/// fall back to AgentHub session validation.
+#[derive(Debug, Clone, Default)]
+pub(crate) struct AuthContext {
+    /// "bearer" | "api_key" | "session" | "none"
+    pub auth_type: String,
+    pub user_id: Option<String>,
+    pub user_name: Option<String>,
+}
+
+pub(crate) type SharedAuthContext = Arc<RwLock<AuthContext>>;
+
+/// Return the existing auth context or create a default one and insert it.
+pub(crate) fn get_or_init_auth_context(request: &mut Request) -> SharedAuthContext {
+    if let Some(ctx) = request.extensions().get::<SharedAuthContext>().cloned() {
+        return ctx;
+    }
+    let ctx = Arc::new(RwLock::new(AuthContext::default()));
+    request.extensions_mut().insert(ctx.clone());
+    ctx
+}
+
 /// Extract the auth credential from request headers (Bearer takes priority over X-API-Key).
-fn extract_credential(request: &Request) -> Option<AuthCredential> {
+pub(crate) fn extract_credential(request: &Request) -> Option<AuthCredential> {
     let headers = request.headers();
 
     // Prefer Authorization: Bearer
@@ -63,15 +89,24 @@ fn extract_credential(request: &Request) -> Option<AuthCredential> {
 /// The two credential headers are mutually exclusive; the callback receives whichever
 /// one the client sent. No extra type discriminator is needed.
 ///
+/// On a successful callback, the response headers `X-User-ID` and `X-User-Name` are
+/// captured and propagated to downstream handlers / audit logs.  The callback may omit
+/// them if it has no identity to return.
+///
 /// # Security note
 ///
 /// Multiple HTTP methods (e.g. GET/POST/DELETE/PATCH) are mounted on the same path
 /// (e.g. `/templates/:id`). A callback that only whitelists by path cannot distinguish
 /// a read from a write or delete operation. Forwarding `X-Request-Method` allows the
 /// callback to enforce fine-grained (path + method) authorization.
+///
+/// For the terminal WebSocket route (`/sandboxes/:sandboxID/terminal/ws`), the
+/// callback receives the concrete sandbox ID in `X-Request-Path` and can therefore
+/// enforce per-sandbox access control.  This is the recommended authorization model
+/// when sandbox ownership data is not otherwise available in CubeAPI.
 pub async fn unified_auth(
     State(state): State<AppState>,
-    request: Request,
+    mut request: Request,
     next: Next,
 ) -> Result<Response, AppError> {
     // No callback configured — pass through immediately.
@@ -91,6 +126,16 @@ pub async fn unified_auth(
                 .to_string(),
         )
     })?;
+
+    // Record the credential type for downstream audit logs.
+    {
+        let auth_type = match &credential {
+            AuthCredential::Bearer(_) => "bearer",
+            AuthCredential::ApiKey(_) => "api_key",
+        };
+        let ctx = get_or_init_auth_context(&mut request);
+        ctx.write().await.auth_type = auth_type.to_string();
+    }
 
     // Build the callback POST, forwarding the credential headers, request path, and HTTP method.
     // X-Request-Method is required for correct authz: the same path (e.g. /templates/:id)
@@ -119,6 +164,27 @@ pub async fn unified_auth(
     };
 
     if callback_resp.status().as_u16() == 200 {
+        // Capture user identity returned by the callback, if any.
+        let user_id = callback_resp
+            .headers()
+            .get("X-User-ID")
+            .and_then(|v| v.to_str().ok())
+            .map(|v| v.trim().to_string())
+            .filter(|v| !v.is_empty());
+        let user_name = callback_resp
+            .headers()
+            .get("X-User-Name")
+            .and_then(|v| v.to_str().ok())
+            .map(|v| v.trim().to_string())
+            .filter(|v| !v.is_empty());
+
+        {
+            let ctx = get_or_init_auth_context(&mut request);
+            let mut guard = ctx.write().await;
+            guard.user_id = user_id;
+            guard.user_name = user_name;
+        }
+
         tracing::debug!(
             path = %request_path,
             method = %request_method,
@@ -138,6 +204,120 @@ pub async fn unified_auth(
             "Authentication rejected by callback".to_string(),
         ))
     }
+}
+
+/// Rewrite WebSocket auth query parameters into HTTP headers before the
+/// unified auth middleware runs.  Browsers cannot set custom headers on a
+/// `WebSocket` connection, so the frontend sends credentials as query params:
+///   - `?api_key=...`      -> `X-API-Key: ...`
+///   - `?access_token=...` -> `Authorization: Bearer ...`
+///
+/// Existing headers are never overwritten, so clients that can set headers
+/// directly continue to work unchanged.
+///
+/// Also initializes the shared `AuthContext` so that downstream middleware can
+/// update it with the authenticated identity.
+pub async fn websocket_auth(mut request: Request, next: Next) -> Result<Response, AppError> {
+    let query = request.uri().query().unwrap_or("").to_string();
+
+    // Initialise auth context from query params so audit logs know which
+    // credential type the browser sent even if auth later fails.
+    let mut initial_auth_type = "none";
+    for (key, _) in url::form_urlencoded::parse(query.as_bytes()) {
+        match key.as_ref() {
+            "api_key" => initial_auth_type = "api_key",
+            "access_token" if initial_auth_type == "none" => {
+                initial_auth_type = "bearer";
+            }
+            _ => {}
+        }
+    }
+    {
+        let ctx = get_or_init_auth_context(&mut request);
+        ctx.write().await.auth_type = initial_auth_type.to_string();
+    }
+
+    let headers = request.headers_mut();
+
+    for (key, value) in url::form_urlencoded::parse(query.as_bytes()) {
+        match key.as_ref() {
+            "api_key" if !headers.contains_key("X-API-Key") => {
+                let hv = HeaderValue::from_str(&value).map_err(|_| {
+                    AppError::BadRequest("invalid api_key query parameter".to_string())
+                })?;
+                headers.insert("X-API-Key", hv);
+            }
+            "access_token" if !headers.contains_key(AUTHORIZATION) => {
+                let bearer = format!("Bearer {}", value);
+                let hv = HeaderValue::from_str(&bearer).map_err(|_| {
+                    AppError::BadRequest("invalid access_token query parameter".to_string())
+                })?;
+                headers.insert(AUTHORIZATION, hv);
+            }
+            _ => {}
+        }
+    }
+
+    Ok(next.run(request).await)
+}
+
+/// Terminal-only fallback: when no `auth_callback_url` is configured but an
+/// AgentHub database is available, treat `?access_token=<session_token>` as a
+/// WebUI session token and validate it.  This lets default WebUI deployments
+/// carry a user identity in terminal audit logs without requiring a separate
+/// auth callback.
+///
+/// When a callback is configured this middleware is a no-op (the callback is
+/// the authoritative source).  When no token is provided the request is allowed
+/// through anonymously, preserving backward compatibility for open deployments.
+pub async fn terminal_session_auth(
+    State(state): State<AppState>,
+    mut request: Request,
+    next: Next,
+) -> Result<Response, AppError> {
+    // Callback mode takes precedence.
+    if state
+        .config
+        .auth_callback_url
+        .as_deref()
+        .is_some_and(|u| !u.is_empty())
+    {
+        return Ok(next.run(request).await);
+    }
+
+    // If unified_auth already ran and produced an identity, do not override.
+    {
+        let ctx = get_or_init_auth_context(&mut request);
+        if ctx.read().await.user_id.is_some() {
+            return Ok(next.run(request).await);
+        }
+    }
+
+    if let Some(AuthCredential::Bearer(token)) = extract_credential(&request) {
+        if let Some(store) = &state.agenthub_store {
+            let ctx = get_or_init_auth_context(&mut request);
+            ctx.write().await.auth_type = "session".to_string();
+
+            match store.validate_session(&token).await {
+                Ok(Some(username)) => {
+                    ctx.write().await.user_id = Some(username);
+                }
+                Ok(None) => {
+                    return Err(AppError::Unauthorized(
+                        "invalid or expired session".to_string(),
+                    ));
+                }
+                Err(e) => {
+                    return Err(AppError::Internal(anyhow::anyhow!(
+                        "session validation failed: {}",
+                        e
+                    )));
+                }
+            }
+        }
+    }
+
+    Ok(next.run(request).await)
 }
 
 #[cfg(test)]

--- a/CubeAPI/src/middleware/auth.rs
+++ b/CubeAPI/src/middleware/auth.rs
@@ -5,7 +5,11 @@
 use crate::{error::AppError, state::AppState};
 use axum::{
     extract::{Request, State},
-    http::header::{HeaderValue, AUTHORIZATION},
+    http::{
+        header::{HeaderValue, AUTHORIZATION},
+        uri::PathAndQuery,
+        Uri,
+    },
     middleware::Next,
     response::Response,
 };
@@ -258,7 +262,50 @@ pub async fn websocket_auth(mut request: Request, next: Next) -> Result<Response
         }
     }
 
+    strip_websocket_auth_query_params(&mut request)?;
+
     Ok(next.run(request).await)
+}
+
+fn strip_websocket_auth_query_params(request: &mut Request) -> Result<(), AppError> {
+    let Some(query) = request.uri().query() else {
+        return Ok(());
+    };
+
+    let mut removed_secret = false;
+    let mut serializer = url::form_urlencoded::Serializer::new(String::new());
+
+    for (key, value) in url::form_urlencoded::parse(query.as_bytes()) {
+        match key.as_ref() {
+            "api_key" | "access_token" => removed_secret = true,
+            _ => {
+                serializer.append_pair(&key, &value);
+            }
+        }
+    }
+
+    if !removed_secret {
+        return Ok(());
+    }
+
+    let sanitized_query = serializer.finish();
+    let path = request.uri().path();
+    let path_and_query = if sanitized_query.is_empty() {
+        path.to_string()
+    } else {
+        format!("{}?{}", path, sanitized_query)
+    };
+
+    let mut parts = request.uri().clone().into_parts();
+    parts.path_and_query = Some(
+        path_and_query
+            .parse::<PathAndQuery>()
+            .map_err(|_| AppError::BadRequest("invalid WebSocket query parameters".to_string()))?,
+    );
+    *request.uri_mut() = Uri::from_parts(parts)
+        .map_err(|_| AppError::BadRequest("invalid WebSocket URI".to_string()))?;
+
+    Ok(())
 }
 
 /// Terminal-only fallback: when no `auth_callback_url` is configured but an
@@ -524,5 +571,22 @@ mod tests {
             .collect();
         assert!(methods.contains(&"POST"), "should see POST");
         assert!(methods.contains(&"PATCH"), "should see PATCH");
+    }
+
+    #[tokio::test]
+    async fn websocket_auth_strips_credentials_from_request_uri() {
+        let mut request = axum::http::Request::builder()
+            .uri(
+                "/sandboxes/sb-1/terminal/ws?access_token=tok%201&cols=100&api_key=key%202&rows=40&container=web",
+            )
+            .body(Body::empty())
+            .unwrap();
+
+        strip_websocket_auth_query_params(&mut request).unwrap();
+
+        assert_eq!(
+            request.uri().to_string(),
+            "/sandboxes/sb-1/terminal/ws?cols=100&rows=40&container=web"
+        );
     }
 }

--- a/CubeAPI/src/middleware/mod.rs
+++ b/CubeAPI/src/middleware/mod.rs
@@ -4,3 +4,4 @@
 
 pub mod auth;
 pub mod rate_limit;
+pub mod terminal_audit;

--- a/CubeAPI/src/middleware/terminal_audit.rs
+++ b/CubeAPI/src/middleware/terminal_audit.rs
@@ -1,0 +1,182 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+use crate::{
+    handlers::terminal::{DEFAULT_COLS, DEFAULT_ROWS},
+    logging::{ArcLogger, LogEvent, LogLevel},
+    middleware::auth::{get_or_init_auth_context, AuthContext},
+    state::AppState,
+};
+use axum::{
+    extract::{ConnectInfo, Path, Request, State},
+    http::{HeaderMap, StatusCode},
+    middleware::Next,
+    response::Response,
+};
+use std::{net::SocketAddr, time::Instant};
+
+/// Terminal WebSocket access audit middleware.
+///
+/// Runs as the outermost layer on the terminal route so it can observe every
+/// rejection (auth, rate limit, state validation, backend error) as well as the
+/// successful 101 upgrade.  Successful upgrades do not emit an event here;
+/// `handlers::terminal` emits `terminal.connect` once the envd PTY is actually
+/// established, and `terminal.disconnect` when the socket closes.
+pub async fn terminal_audit(
+    State(state): State<AppState>,
+    Path(sandbox_id): Path<String>,
+    connect_info: Option<ConnectInfo<SocketAddr>>,
+    mut request: Request,
+    next: Next,
+) -> Result<Response, crate::error::AppError> {
+    let remote_ip = extract_remote_ip(request.headers(), connect_info.map(|c| c.0));
+    let (cols, rows) = terminal_query_dimensions(request.uri().query());
+    let container = terminal_query_container(request.uri().query());
+
+    // Initialise a shared auth context before handing the request down; inner
+    // middleware will update it with the credential type and, on success, user
+    // identity.  We keep a clone so we can read the final state after the
+    // response has been produced.
+    let auth_ctx = get_or_init_auth_context(&mut request);
+
+    let start = Instant::now();
+    let response = next.run(request).await;
+    let elapsed = start.elapsed();
+
+    let final_ctx = auth_ctx.read().await.clone();
+
+    let status = response.status();
+    if status != StatusCode::SWITCHING_PROTOCOLS {
+        let reason = connect_denied_reason(status);
+        let mut extra = vec![
+            ("http_status", (status.as_u16() as u64).into()),
+            ("reason", reason.into()),
+            ("duration_ms", (elapsed.as_millis() as u64).into()),
+        ];
+        if let Some(container_id) = container {
+            extra.push(("container", container_id.into()));
+        }
+        log_terminal_event(
+            &state.logger,
+            "terminal.connect_denied",
+            &sandbox_id,
+            &remote_ip,
+            &final_ctx,
+            cols,
+            rows,
+            extra,
+        )
+        .await;
+    }
+
+    Ok(response)
+}
+
+fn terminal_query_dimensions(query: Option<&str>) -> (u16, u16) {
+    let mut cols = DEFAULT_COLS;
+    let mut rows = DEFAULT_ROWS;
+
+    if let Some(query) = query {
+        for (key, value) in url::form_urlencoded::parse(query.as_bytes()) {
+            match key.as_ref() {
+                "cols" => {
+                    if let Ok(parsed) = value.parse::<u16>() {
+                        cols = parsed;
+                    }
+                }
+                "rows" => {
+                    if let Ok(parsed) = value.parse::<u16>() {
+                        rows = parsed;
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+
+    (cols, rows)
+}
+
+fn terminal_query_container(query: Option<&str>) -> Option<String> {
+    query.and_then(|q| {
+        url::form_urlencoded::parse(q.as_bytes())
+            .find(|(key, _)| key == "container")
+            .map(|(_, value)| value.to_string())
+            .filter(|v| !v.is_empty())
+    })
+}
+
+fn connect_denied_reason(status: StatusCode) -> &'static str {
+    match status {
+        StatusCode::UNAUTHORIZED => "auth_required",
+        StatusCode::FORBIDDEN => "forbidden",
+        StatusCode::NOT_FOUND => "not_found",
+        StatusCode::CONFLICT => "not_running",
+        StatusCode::TOO_MANY_REQUESTS => "rate_limited",
+        StatusCode::INTERNAL_SERVER_ERROR => "server_error",
+        StatusCode::BAD_GATEWAY | StatusCode::SERVICE_UNAVAILABLE | StatusCode::GATEWAY_TIMEOUT => {
+            "backend_unavailable"
+        }
+        _ => "unknown",
+    }
+}
+
+/// Compute the best-effort remote client IP.
+///
+/// Honours `X-Forwarded-For` / `X-Real-IP` first so that deployments behind a
+/// reverse proxy log the original client.  Falls back to the TCP peer address
+/// from `ConnectInfo`, and finally `"unknown"`.
+pub(crate) fn extract_remote_ip(headers: &HeaderMap, connect_addr: Option<SocketAddr>) -> String {
+    if let Some(v) = headers.get("X-Forwarded-For").and_then(|h| h.to_str().ok()) {
+        if let Some(ip) = v.split(',').next().map(str::trim).filter(|s| !s.is_empty()) {
+            return ip.to_string();
+        }
+    }
+    if let Some(v) = headers
+        .get("X-Real-IP")
+        .and_then(|h| h.to_str().ok())
+        .map(str::trim)
+    {
+        if !v.is_empty() {
+            return v.to_string();
+        }
+    }
+    connect_addr
+        .map(|a| a.ip().to_string())
+        .unwrap_or_else(|| "unknown".to_string())
+}
+
+/// Emit a structured terminal audit event.
+pub(crate) async fn log_terminal_event(
+    logger: &ArcLogger,
+    event: &str,
+    sandbox_id: &str,
+    remote_ip: &str,
+    auth_ctx: &AuthContext,
+    cols: u16,
+    rows: u16,
+    extra: Vec<(&str, serde_json::Value)>,
+) {
+    let mut ev = LogEvent::new(LogLevel::Info, event)
+        .field("sandbox_id", sandbox_id)
+        .field("remote_ip", remote_ip)
+        .field("auth_type", &auth_ctx.auth_type)
+        .field("cols", cols.to_string())
+        .field("rows", rows.to_string());
+
+    if let Some(user_id) = &auth_ctx.user_id {
+        ev = ev.field("user_id", user_id);
+    }
+    if let Some(user_name) = &auth_ctx.user_name {
+        ev = ev.field("user_name", user_name);
+    }
+
+    for (k, v) in extra {
+        if let Ok(serialised) = serde_json::to_value(v) {
+            ev.fields.insert(k.to_string(), serialised);
+        }
+    }
+
+    logger.log(ev).await;
+}

--- a/CubeAPI/src/models/mod.rs
+++ b/CubeAPI/src/models/mod.rs
@@ -156,6 +156,37 @@ pub struct SandboxVolumeMount {
     pub path: String,
 }
 
+// ─── Sandbox — container state ─────────────────────────────────────────────
+
+/// Lifecycle state of an individual container inside a sandbox.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "lowercase")]
+pub enum SandboxContainerState {
+    Running,
+    Paused,
+    Pausing,
+    Stopped,
+    Unknown,
+}
+
+/// A single container running inside a sandbox.
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct SandboxContainer {
+    #[serde(rename = "containerID")]
+    pub container_id: String,
+    pub name: String,
+    pub state: SandboxContainerState,
+    pub image: String,
+    #[serde(rename = "cpuCount")]
+    pub cpu_count: i32,
+    #[serde(rename = "memoryMB")]
+    pub memory_mb: i32,
+    #[serde(rename = "startedAt", skip_serializing_if = "Option::is_none")]
+    pub started_at: Option<DateTime<Utc>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub kind: Option<String>,
+}
+
 // ─── Sandbox — create request ──────────────────────────────────────────────
 
 /// Request body for POST /sandboxes
@@ -314,6 +345,8 @@ pub struct SandboxDetail {
     pub state: SandboxState,
     #[serde(rename = "volumeMounts", skip_serializing_if = "Option::is_none")]
     pub volume_mounts: Option<Vec<SandboxVolumeMount>>,
+    #[serde(rename = "containers", default, skip_serializing_if = "Vec::is_empty")]
+    pub containers: Vec<SandboxContainer>,
 }
 
 // ─── Sandbox — pause/resume/connect/snapshot ──────────────────────────────

--- a/CubeAPI/src/routes.rs
+++ b/CubeAPI/src/routes.rs
@@ -18,8 +18,14 @@ use tower_http::{
 };
 
 use crate::{
-    handlers::{agenthub, auth, cluster, config, health, sandboxes, snapshots, store, templates},
-    middleware::{auth::unified_auth, rate_limit::rate_limit},
+    handlers::{
+        agenthub, auth, cluster, config, health, sandboxes, snapshots, store, templates, terminal,
+    },
+    middleware::{
+        auth::{terminal_session_auth, unified_auth, websocket_auth},
+        rate_limit::rate_limit,
+        terminal_audit::terminal_audit,
+    },
     state::AppState,
 };
 
@@ -150,7 +156,14 @@ fn build_sandbox_routes(state: &AppState, auth_configured: bool) -> Router<AppSt
         )
         .route("/snapshots", get(snapshots::list_snapshots));
 
-    with_auth_and_rate_limit(routes, state, auth_configured)
+    let terminal_routes = Router::new().route(
+        "/sandboxes/:sandboxID/terminal/ws",
+        get(terminal::terminal_ws),
+    );
+
+    with_auth_and_rate_limit(routes, state, auth_configured).merge(
+        with_terminal_auth_and_rate_limit(terminal_routes, state, auth_configured),
+    )
 }
 
 /// Sandbox-rooted routes that must run on the long (240 s) budget.  Snapshot
@@ -348,6 +361,56 @@ fn with_auth_and_rate_limit(
             .layer(middleware::from_fn_with_state(state.clone(), unified_auth))
     } else {
         routes
+    }
+}
+
+/// Same as `with_auth_and_rate_limit`, but additionally rewrites WebSocket
+/// auth query parameters (`api_key`, `access_token`) into HTTP headers before
+/// the unified auth middleware runs.  Used only for the terminal WebSocket
+/// route because browsers cannot set custom headers on a WebSocket handshake.
+///
+/// Layer order (outer -> inner):
+///   terminal_audit -> websocket_auth -> terminal_session_auth -> unified_auth -> rate_limit -> handler
+///
+/// `terminal_audit` is outermost so it can log every rejection (auth, rate
+/// limit, state validation, backend error) as well as the 101 upgrade.
+///
+/// Authorization policy: per-sandbox access control is expected to be enforced
+/// by the configured `auth_callback_url`, which receives the concrete sandbox
+/// ID in `X-Request-Path`.  CubeAPI does not currently have sandbox ownership
+/// metadata, so no additional resource-level check is performed here.
+///
+/// Note: layers are applied in reverse order; `terminal_audit` is added last
+/// so it wraps all the others.
+fn with_terminal_auth_and_rate_limit(
+    routes: Router<AppState>,
+    state: &AppState,
+    auth_configured: bool,
+) -> Router<AppState> {
+    if auth_configured {
+        routes
+            .layer(middleware::from_fn_with_state(state.clone(), rate_limit))
+            .layer(middleware::from_fn_with_state(state.clone(), unified_auth))
+            .layer(middleware::from_fn_with_state(
+                state.clone(),
+                terminal_session_auth,
+            ))
+            .layer(middleware::from_fn(websocket_auth))
+            .layer(middleware::from_fn_with_state(
+                state.clone(),
+                terminal_audit,
+            ))
+    } else {
+        routes
+            .layer(middleware::from_fn_with_state(
+                state.clone(),
+                terminal_session_auth,
+            ))
+            .layer(middleware::from_fn(websocket_auth))
+            .layer(middleware::from_fn_with_state(
+                state.clone(),
+                terminal_audit,
+            ))
     }
 }
 

--- a/CubeAPI/src/services/sandboxes.rs
+++ b/CubeAPI/src/services/sandboxes.rs
@@ -9,16 +9,18 @@ use super::validate_allow_out_domains_require_deny_all;
 use crate::{
     constants::{ENVD_VERSION_ANNOTATION, ENVD_VERSION_FALLBACK},
     cubemaster::{
-        datetime_from_unix_nanos, extract_template_id, CreateSandboxRequest, CubeEgressRule,
-        CubeEgressRuleAction, CubeEgressRuleInject, CubeEgressRuleMatch, CubeMasterClient,
-        CubeMasterError, CubeNetworkConfig, DeleteSandboxRequest, ListSandboxRequest, SandboxInfo,
+        datetime_from_unix_nanos, extract_template_id, parse_cpu_millicores, parse_mem_mb,
+        CreateSandboxRequest, CubeEgressRule, CubeEgressRuleAction, CubeEgressRuleInject,
+        CubeEgressRuleMatch, CubeMasterClient, CubeMasterError, CubeNetworkConfig,
+        DeleteSandboxRequest, GetSandboxContainerItem, ListSandboxRequest, SandboxInfo,
         SandboxLogsRequest, SandboxRefreshRequest, SandboxStatus, SandboxTimeoutRequest,
         SandboxUpdateRequest,
     },
     error::{AppError, AppResult},
     models::{
-        EgressRule, LogLevel as ModelLogLevel, NewSandbox, Sandbox, SandboxDetail, SandboxLog,
-        SandboxLogEntry, SandboxLogs, SandboxLogsV2Response, SandboxNetworkConfig, SandboxState,
+        EgressRule, LogLevel as ModelLogLevel, NewSandbox, Sandbox, SandboxContainer,
+        SandboxContainerState, SandboxDetail, SandboxLog, SandboxLogEntry, SandboxLogs,
+        SandboxLogsV2Response, SandboxNetworkConfig, SandboxState,
     },
 };
 
@@ -142,6 +144,7 @@ impl SandboxService {
             metadata: optional_metadata(d.labels),
             state: sandbox_state_from_status(d.status),
             volume_mounts: None,
+            containers: map_containers(&d.containers),
         })
     }
 
@@ -793,6 +796,33 @@ fn optional_metadata(metadata: HashMap<String, String>) -> Option<HashMap<String
         None
     } else {
         Some(metadata)
+    }
+}
+
+fn map_containers(items: &[GetSandboxContainerItem]) -> Vec<SandboxContainer> {
+    items.iter().map(map_container).collect()
+}
+
+fn map_container(item: &GetSandboxContainerItem) -> SandboxContainer {
+    SandboxContainer {
+        container_id: item.container_id.clone(),
+        name: item.name.clone(),
+        state: container_state_from_status(item.status),
+        image: item.image.clone(),
+        cpu_count: parse_cpu_millicores(&item.cpu),
+        memory_mb: parse_mem_mb(&item.mem),
+        started_at: datetime_from_unix_nanos(item.create_at),
+        kind: Some(item.kind.clone()).filter(|k| !k.is_empty()),
+    }
+}
+
+fn container_state_from_status(status: i32) -> SandboxContainerState {
+    match status {
+        1 => SandboxContainerState::Running,
+        4 => SandboxContainerState::Pausing,
+        5 => SandboxContainerState::Paused,
+        2 => SandboxContainerState::Stopped,
+        _ => SandboxContainerState::Unknown,
     }
 }
 

--- a/docs/guide/webui.md
+++ b/docs/guide/webui.md
@@ -67,7 +67,25 @@ If any number is red, click into **Nodes** to see which host is unhappy.
 
 To stop a sandbox, go to **Sandboxes**, find the row, and click the pause / kill button on the right.
 
-### 3.3 Configure the API key (only if auth is enabled)
+### 3.3 Open a terminal inside a running sandbox
+
+For **running** sandboxes, both the sandbox list and the sandbox detail page show an **Open Terminal** button.
+
+1. Click **Open Terminal**.
+2. A popup with an `xterm.js` shell appears.
+3. If the sandbox has more than one container, use the **Container** dropdown in the popup header to choose which container to log in to. Only containers in the `running` state can be selected.
+4. Type commands as you would in a normal shell. The terminal supports:
+   - ANSI colors and cursor control
+   - Window resize (the shell receives the new dimensions automatically)
+   - Copy / paste
+   - Scrollback
+   - Full screen (`F11` or `Ctrl/Cmd + Shift + F`)
+   - Font size adjustment
+   - Reconnect if the connection drops
+
+> **Note:** Multi-container targeting depends on the in-guest `envd` daemon accepting a `container_id` field in the `process.Process/Start` request. The WebUI passes the selected container ID; verify that your `envd` version supports this field.
+
+### 3.4 Configure the API key (only if auth is enabled)
 
 If your deployment has authentication turned on, the Dashboard needs an API key before any request will succeed.
 

--- a/openapi.yml
+++ b/openapi.yml
@@ -1,8 +1,3 @@
----
-# Copyright (c) 2026 Tencent Inc.
-# SPDX-License-Identifier: Apache-2.0
-#
-
 openapi: 3.1.0
 info:
   title: CubeAPI
@@ -602,7 +597,6 @@ components:
       - sandboxID
       - clientID
       - startedAt
-      - endAt
       - cpuCount
       - memoryMB
       - state
@@ -623,8 +617,13 @@ components:
           - 'null'
           format: int32
         endAt:
-          type: string
+          type:
+          - string
+          - 'null'
           format: date-time
+          description: |-
+            Projected next-timeout instant. Omitted for never-timeout sandboxes
+            (no deadline) rather than being misreported as equal to startedAt.
         envdVersion:
           type: string
         memoryMB:
@@ -792,8 +791,11 @@ components:
         autoPause:
           type: boolean
         timeout:
-          type: integer
+          type:
+          - integer
+          - 'null'
           format: int32
+          description: Idle timeout in seconds; None when the client did not send one.
     Sandbox:
       type: object
       description: |-
@@ -829,6 +831,49 @@ components:
           type:
           - string
           - 'null'
+    SandboxContainer:
+      type: object
+      description: A single container running inside a sandbox.
+      required:
+      - containerID
+      - name
+      - state
+      - image
+      - cpuCount
+      - memoryMB
+      properties:
+        containerID:
+          type: string
+        cpuCount:
+          type: integer
+          format: int32
+        image:
+          type: string
+        kind:
+          type:
+          - string
+          - 'null'
+        memoryMB:
+          type: integer
+          format: int32
+        name:
+          type: string
+        startedAt:
+          type:
+          - string
+          - 'null'
+          format: date-time
+        state:
+          $ref: '#/components/schemas/SandboxContainerState'
+    SandboxContainerState:
+      type: string
+      description: Lifecycle state of an individual container inside a sandbox.
+      enum:
+      - running
+      - paused
+      - pausing
+      - stopped
+      - unknown
     SandboxDetail:
       type: object
       description: Detailed sandbox info returned by GET /sandboxes/{sandboxID}.
@@ -837,7 +882,6 @@ components:
       - sandboxID
       - clientID
       - startedAt
-      - endAt
       - envdVersion
       - cpuCount
       - memoryMB
@@ -849,6 +893,10 @@ components:
           - 'null'
         clientID:
           type: string
+        containers:
+          type: array
+          items:
+            $ref: '#/components/schemas/SandboxContainer'
         cpuCount:
           type: integer
           format: int32
@@ -862,8 +910,13 @@ components:
           - string
           - 'null'
         endAt:
-          type: string
+          type:
+          - string
+          - 'null'
           format: date-time
+          description: |-
+            Projected next-timeout instant. Omitted for never-timeout sandboxes
+            (no deadline) rather than being misreported as equal to startedAt.
         envdAccessToken:
           type:
           - string
@@ -1019,15 +1072,15 @@ components:
           - 'null'
           description: Whether public internet access is allowed for sandboxes from this template.
         createRequest: {}
+        instanceType:
+          type:
+          - string
+          - 'null'
         jobID:
           type:
           - string
           - 'null'
           description: Latest create/rebuild job id for the template.
-        instanceType:
-          type:
-          - string
-          - 'null'
         lastError:
           type:
           - string
@@ -1105,6 +1158,11 @@ components:
           type:
           - string
           - 'null'
+        jobID:
+          type:
+          - string
+          - 'null'
+          description: Latest create/rebuild job id for the template.
         lastError:
           type:
           - string
@@ -1117,11 +1175,6 @@ components:
           type:
           - string
           - 'null'
-        jobID:
-          type:
-          - string
-          - 'null'
-          description: Latest create/rebuild job id for the template.
     VersionMatrixView:
       type: object
       description: Full node x component version matrix.

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -22,6 +22,8 @@
         "@radix-ui/react-toast": "^1.2.2",
         "@radix-ui/react-tooltip": "^1.1.3",
         "@tanstack/react-query": "^5.59.0",
+        "@xterm/addon-fit": "^0.11.0",
+        "@xterm/xterm": "^6.0.0",
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.1.1",
         "cmdk": "^1.0.0",
@@ -2978,6 +2980,21 @@
       "peerDependencies": {
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
+    },
+    "node_modules/@xterm/addon-fit": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@xterm/addon-fit/-/addon-fit-0.11.0.tgz",
+      "integrity": "sha512-jYcgT6xtVYhnhgxh3QgYDnnNMYTcf8ElbxxFzX0IZo+vabQqSPAjC3c1wJrKB5E19VwQei89QCiZZP86DCPF7g==",
+      "license": "MIT"
+    },
+    "node_modules/@xterm/xterm": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@xterm/xterm/-/xterm-6.0.0.tgz",
+      "integrity": "sha512-TQwDdQGtwwDt+2cgKDLn0IRaSxYu1tSUjgKarSDkUM0ZNiSRXFpjxEsvc/Zgc5kq5omJ+V0a8/kIM2WD3sMOYg==",
+      "license": "MIT",
+      "workspaces": [
+        "addons/*"
+      ]
     },
     "node_modules/agent-base": {
       "version": "7.1.4",

--- a/web/package.json
+++ b/web/package.json
@@ -27,6 +27,8 @@
     "@radix-ui/react-toast": "^1.2.2",
     "@radix-ui/react-tooltip": "^1.1.3",
     "@tanstack/react-query": "^5.59.0",
+    "@xterm/addon-fit": "^0.11.0",
+    "@xterm/xterm": "^6.0.0",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",
     "cmdk": "^1.0.0",

--- a/web/src/api/generated/schema.ts
+++ b/web/src/api/generated/schema.ts
@@ -309,8 +309,12 @@ export interface components {
             cpuCount: number;
             /** Format: int32 */
             diskSizeMB?: number | null;
-            /** Format: date-time */
-            endAt: string;
+            /**
+             * Format: date-time
+             * @description Projected next-timeout instant. Omitted for never-timeout sandboxes
+             *     (no deadline) rather than being misreported as equal to startedAt.
+             */
+            endAt?: string | null;
             envdVersion: string;
             /** Format: int32 */
             memoryMB: number;
@@ -396,8 +400,11 @@ export interface components {
         /** @description Request body for POST /sandboxes/{id}/resume (deprecated). */
         ResumedSandbox: {
             autoPause?: boolean;
-            /** Format: int32 */
-            timeout?: number;
+            /**
+             * Format: int32
+             * @description Idle timeout in seconds; None when the client did not send one.
+             */
+            timeout?: number | null;
         };
         /**
          * @description Response for POST /sandboxes and POST /sandboxes/{id}/connect.
@@ -413,17 +420,41 @@ export interface components {
             templateID: string;
             trafficAccessToken?: string | null;
         };
+        /** @description A single container running inside a sandbox. */
+        SandboxContainer: {
+            containerID: string;
+            /** Format: int32 */
+            cpuCount: number;
+            image: string;
+            kind?: string | null;
+            /** Format: int32 */
+            memoryMB: number;
+            name: string;
+            /** Format: date-time */
+            startedAt?: string | null;
+            state: components["schemas"]["SandboxContainerState"];
+        };
+        /**
+         * @description Lifecycle state of an individual container inside a sandbox.
+         * @enum {string}
+         */
+        SandboxContainerState: "running" | "paused" | "pausing" | "stopped" | "unknown";
         /** @description Detailed sandbox info returned by GET /sandboxes/{sandboxID}. */
         SandboxDetail: {
             alias?: string | null;
             clientID: string;
+            containers?: components["schemas"]["SandboxContainer"][];
             /** Format: int32 */
             cpuCount: number;
             /** Format: int32 */
             diskSizeMB?: number | null;
             domain?: string | null;
-            /** Format: date-time */
-            endAt: string;
+            /**
+             * Format: date-time
+             * @description Projected next-timeout instant. Omitted for never-timeout sandboxes
+             *     (no deadline) rather than being misreported as equal to startedAt.
+             */
+            endAt?: string | null;
             envdAccessToken?: string | null;
             envdVersion: string;
             /** Format: int32 */
@@ -491,9 +522,9 @@ export interface components {
             /** @description Whether public internet access is allowed for sandboxes from this template. */
             allowInternetAccess?: boolean | null;
             createRequest?: unknown;
+            instanceType?: string | null;
             /** @description Latest create/rebuild job id for the template. */
             jobID?: string | null;
-            instanceType?: string | null;
             lastError?: string | null;
             /** @description Network type used when the template was created, e.g. "tap". */
             networkType?: string | null;
@@ -518,12 +549,12 @@ export interface components {
             createdAt?: string | null;
             imageInfo?: string | null;
             instanceType?: string | null;
+            /** @description Latest create/rebuild job id for the template. */
+            jobID?: string | null;
             lastError?: string | null;
             status: string;
             templateID: string;
             version?: string | null;
-            /** @description Latest create/rebuild job id for the template. */
-            jobID?: string | null;
         };
         /** @description Full node x component version matrix. */
         VersionMatrixView: {

--- a/web/src/components/SandboxTerminal.tsx
+++ b/web/src/components/SandboxTerminal.tsx
@@ -1,0 +1,302 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2026 Tencent. All rights reserved.
+
+import { useRef, useEffect, useState, useMemo } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { useTranslation } from 'react-i18next';
+import * as DropdownMenu from '@radix-ui/react-dropdown-menu';
+import { CardTitle, CardDescription } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { Skeleton } from '@/components/ui/skeleton';
+import { X, RefreshCw, Maximize2, Minimize2, ZoomIn, ZoomOut, ChevronDown, Check } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { useTerminal, getTerminalTheme } from '@/hooks/useTerminal';
+import { useThemeStore, resolveEffective } from '@/store/theme';
+import { closeReasonMessage } from '@/lib/terminalSocket';
+import { sandboxApi } from '@/api/client';
+import type { SandboxDetail } from '@/api/client';
+import '@/styles/xterm.css';
+
+interface SandboxTerminalProps {
+  sandboxID: string;
+  onClose: () => void;
+}
+
+type Container = NonNullable<SandboxDetail['containers']>[number];
+
+function defaultContainerID(containers?: Container[]): string | undefined {
+  if (!containers || containers.length === 0) return undefined;
+  const running = containers.find((c) => c.state === 'running');
+  return running?.containerID;
+}
+
+export default function SandboxTerminal({ sandboxID, onClose }: SandboxTerminalProps) {
+  const { t } = useTranslation('sandboxDetail');
+  const containerRef = useRef<HTMLDivElement>(null);
+  const reconnectTimerRef = useRef<number | null>(null);
+  const mode = useThemeStore((s) => s.mode);
+  const effective = resolveEffective(mode);
+
+  const { data: detail, isLoading } = useQuery({
+    queryKey: ['sandbox', sandboxID],
+    queryFn: () => sandboxApi.get(sandboxID),
+    enabled: !!sandboxID,
+    refetchInterval: 5_000,
+  });
+
+  const containers = useMemo(() => detail?.containers ?? [], [detail?.containers]);
+  const [selectedContainerID, setSelectedContainerID] = useState<string | undefined>(() =>
+    defaultContainerID(containers),
+  );
+
+  useEffect(() => {
+    if (containers.length === 0) {
+      if (selectedContainerID) {
+        setSelectedContainerID(undefined);
+      }
+      return;
+    }
+
+    const selectedStillRunning = containers.some(
+      (container) =>
+        container.containerID === selectedContainerID && container.state === 'running',
+    );
+    if (!selectedStillRunning) {
+      setSelectedContainerID(defaultContainerID(containers));
+    }
+  }, [containers, selectedContainerID]);
+
+  const selectedContainer = useMemo(
+    () => containers.find((c) => c.containerID === selectedContainerID),
+    [containers, selectedContainerID],
+  );
+  const hasRunningContainer = containers.some((container) => container.state === 'running');
+  const noRunningContainer = !isLoading && containers.length > 0 && !hasRunningContainer;
+  const terminalEnabled = !isLoading && (containers.length === 0 || !!selectedContainerID);
+
+  const {
+    status,
+    fit,
+    reconnect,
+    fontSize,
+    increaseFontSize,
+    decreaseFontSize,
+    isFullscreen,
+    toggleFullscreen,
+    disconnectReason,
+  } = useTerminal(containerRef, {
+    sandboxID,
+    containerID: selectedContainerID,
+    enabled: terminalEnabled,
+  });
+
+  // Close on Escape; F11 or Ctrl/Cmd+Shift+F toggles fullscreen.
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        onClose();
+      } else if (e.key === 'F11' || (e.ctrlKey && e.shiftKey && e.key.toLowerCase() === 'f')) {
+        e.preventDefault();
+        toggleFullscreen();
+      }
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [onClose, toggleFullscreen]);
+
+  // Refit the terminal after the popup mounts or fullscreen toggles, in case
+  // the container size is still settling.
+  useEffect(() => {
+    const timer = window.setTimeout(() => fit(), 50);
+    return () => window.clearTimeout(timer);
+  }, [fit, isFullscreen]);
+
+  useEffect(() => {
+    return () => {
+      if (reconnectTimerRef.current != null) {
+        window.clearTimeout(reconnectTimerRef.current);
+      }
+    };
+  }, []);
+
+  const statusConfig = {
+    connecting: { label: t('terminal.connecting'), tone: 'info' as const },
+    connected: { label: t('terminal.connected'), tone: 'ok' as const },
+    disconnected: { label: t('terminal.disconnected'), tone: 'err' as const },
+  };
+  const displayStatus = !terminalEnabled && !noRunningContainer ? 'connecting' : status;
+  const { label, tone } = statusConfig[displayStatus];
+
+  const disconnectMessage = disconnectReason
+    ? closeReasonMessage(undefined, disconnectReason)
+    : undefined;
+
+  const showContainerSelector = containers.length > 1;
+
+  return (
+    <div
+      className={cn(
+        'fixed z-50 flex items-center justify-center',
+        isFullscreen ? 'inset-0' : 'inset-0 p-4',
+      )}
+      onClick={onClose}
+      role="dialog"
+      aria-modal="true"
+      aria-label={t('terminal.title')}
+    >
+      {/* Backdrop */}
+      <div
+        className={cn('absolute inset-0 bg-black/60 backdrop-blur-sm', isFullscreen && 'bg-black/80')}
+        aria-hidden="true"
+      />
+
+      {/* Terminal panel */}
+      <div
+        className={cn(
+          'relative flex flex-col overflow-hidden rounded-xl border border-border/60 bg-card shadow-2xl',
+          isFullscreen ? 'h-screen w-screen' : 'w-[92vw] max-w-6xl',
+        )}
+        style={isFullscreen ? undefined : { height: 'min(85vh, 900px)' }}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <header className="flex flex-row items-center justify-between border-b border-border/60 px-4 py-3">
+          <div className="flex items-center gap-3">
+            <div>
+              <CardTitle className="text-sm font-medium">{t('terminal.title')}</CardTitle>
+              <CardDescription className="text-xs">
+                {sandboxID}
+              </CardDescription>
+            </div>
+            <Badge
+              tone={tone as any}
+              className={cn(
+                'h-5 px-1.5 text-[10px] uppercase tracking-wider',
+                displayStatus === 'connecting' && 'animate-pulse',
+              )}
+            >
+              {label}
+            </Badge>
+            {showContainerSelector && (
+              <DropdownMenu.Root>
+                <DropdownMenu.Trigger asChild>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    className="h-7 gap-1 px-2 text-xs"
+                    disabled={isLoading || !hasRunningContainer}
+                  >
+                    {isLoading ? (
+                      <Skeleton className="h-3 w-16" />
+                    ) : (
+                      <>
+                        <span className="max-w-[140px] truncate">
+                          {selectedContainer?.name ?? t('terminal.container')}
+                        </span>
+                        <ChevronDown size={12} />
+                      </>
+                    )}
+                  </Button>
+                </DropdownMenu.Trigger>
+                <DropdownMenu.Portal>
+                  <DropdownMenu.Content
+                    align="start"
+                    sideOffset={6}
+                    className="z-50 min-w-[180px] rounded-lg border border-border/60 bg-popover p-1 shadow-lg"
+                  >
+                    {containers.map((container) => {
+                      const isRunning = container.state === 'running';
+                      const isSelected = container.containerID === selectedContainerID;
+                      return (
+                        <DropdownMenu.Item
+                          key={container.containerID}
+                          disabled={!isRunning}
+                          onSelect={() => setSelectedContainerID(container.containerID)}
+                          className={cn(
+                            'flex items-center justify-between rounded-md px-2 py-1.5 text-xs outline-none',
+                            'focus:bg-accent focus:text-accent-foreground',
+                            'data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
+                          )}
+                        >
+                          <span className="flex flex-col">
+                            <span className="font-medium">{container.name}</span>
+                            <span className="text-[10px] text-muted-foreground">
+                              {container.state}
+                            </span>
+                          </span>
+                          {isSelected && <Check size={13} className="text-primary" />}
+                        </DropdownMenu.Item>
+                      );
+                    })}
+                  </DropdownMenu.Content>
+                </DropdownMenu.Portal>
+              </DropdownMenu.Root>
+            )}
+          </div>
+          <div className="flex items-center gap-1">
+            <Button
+              variant="ghost"
+              size="icon"
+              title={t(isFullscreen ? 'terminal.exitFullscreen' : 'terminal.fullscreen')}
+              onClick={toggleFullscreen}
+            >
+              {isFullscreen ? <Minimize2 size={14} /> : <Maximize2 size={14} />}
+            </Button>
+            <Button
+              variant="ghost"
+              size="icon"
+              title={t('terminal.fontSizeDecrease')}
+              onClick={decreaseFontSize}
+              disabled={fontSize <= 8}
+            >
+              <ZoomOut size={14} />
+            </Button>
+            <Button
+              variant="ghost"
+              size="icon"
+              title={t('terminal.fontSizeIncrease')}
+              onClick={increaseFontSize}
+              disabled={fontSize >= 32}
+            >
+              <ZoomIn size={14} />
+            </Button>
+            {status === 'disconnected' && terminalEnabled && (
+              <Button
+                variant="ghost"
+                size="icon"
+                title={t('terminal.reconnect')}
+                onClick={() => {
+                  reconnect();
+                  reconnectTimerRef.current = window.setTimeout(() => fit(), 0);
+                }}
+              >
+                <RefreshCw size={14} />
+              </Button>
+            )}
+            <Button variant="ghost" size="icon" title={t('terminal.close')} onClick={onClose}>
+              <X size={14} />
+            </Button>
+          </div>
+        </header>
+
+        {noRunningContainer && (
+          <div className="border-b border-border/60 bg-cube-warn/10 px-4 py-2 text-xs text-cube-warn">
+            {t('terminal.errors.noRunningContainers')}
+          </div>
+        )}
+
+        {status === 'disconnected' && disconnectMessage && (
+          <div className="border-b border-border/60 bg-cube-err/10 px-4 py-2 text-xs text-cube-err">
+            {t('terminal.errors.disconnected', { reason: disconnectMessage })}
+          </div>
+        )}
+
+        <div
+          ref={containerRef}
+          className="min-h-0 flex-1 overflow-hidden"
+          style={{ backgroundColor: getTerminalTheme(effective).background }}
+        />
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/SandboxTerminal.tsx
+++ b/web/src/components/SandboxTerminal.tsx
@@ -96,7 +96,10 @@ export default function SandboxTerminal({ sandboxID, onClose }: SandboxTerminalP
     const onKey = (e: KeyboardEvent) => {
       if (e.key === 'Escape') {
         onClose();
-      } else if (e.key === 'F11' || (e.ctrlKey && e.shiftKey && e.key.toLowerCase() === 'f')) {
+      } else if (
+        e.key === 'F11' ||
+        ((e.ctrlKey || e.metaKey) && e.shiftKey && e.key.toLowerCase() === 'f')
+      ) {
         e.preventDefault();
         toggleFullscreen();
       }
@@ -169,7 +172,7 @@ export default function SandboxTerminal({ sandboxID, onClose }: SandboxTerminalP
               </CardDescription>
             </div>
             <Badge
-              tone={tone as any}
+              tone={tone}
               className={cn(
                 'h-5 px-1.5 text-[10px] uppercase tracking-wider',
                 displayStatus === 'connecting' && 'animate-pulse',

--- a/web/src/hooks/useTerminal.ts
+++ b/web/src/hooks/useTerminal.ts
@@ -1,0 +1,278 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2026 Tencent. All rights reserved.
+
+import { useEffect, useRef, useState } from 'react';
+import { Terminal } from '@xterm/xterm';
+import { FitAddon } from '@xterm/addon-fit';
+import { createTerminalSocket, base64ToUtf8, type TerminalMessage } from '@/lib/terminalSocket';
+import { useThemeStore, resolveEffective } from '@/store/theme';
+
+export type TerminalStatus = 'connecting' | 'connected' | 'disconnected';
+
+const MIN_FONT_SIZE = 8;
+const MAX_FONT_SIZE = 32;
+
+interface UseTerminalOptions {
+  sandboxID: string;
+  containerID?: string;
+  enabled?: boolean;
+  initialFontSize?: number;
+}
+
+export function getTerminalTheme(effective: 'light' | 'dark') {
+  if (effective === 'light') {
+    return {
+      background: '#faf9f7',
+      foreground: '#2b2622',
+      cursor: '#2b2622',
+      cursorAccent: '#faf9f7',
+      selectionBackground: '#d4cfc7',
+      black: '#2b2622',
+      red: '#a83838',
+      green: '#2e7a4f',
+      yellow: '#8a6a1f',
+      blue: '#2b5f8c',
+      magenta: '#6b3d81',
+      cyan: '#2b6e6e',
+      white: '#e8e4de',
+      brightBlack: '#5c534a',
+      brightRed: '#c44747',
+      brightGreen: '#3a9a66',
+      brightYellow: '#b0862a',
+      brightBlue: '#3a7ab8',
+      brightMagenta: '#8b55a6',
+      brightCyan: '#3a8e8e',
+      brightWhite: '#ffffff',
+    };
+  }
+  return {
+    background: '#0b0f14',
+    foreground: '#e2e8f0',
+    cursor: '#e2e8f0',
+    cursorAccent: '#0b0f14',
+    selectionBackground: '#1e293b',
+    black: '#0b0f14',
+    red: '#f87171',
+    green: '#34d399',
+    yellow: '#fbbf24',
+    blue: '#60a5fa',
+    magenta: '#c084fc',
+    cyan: '#22d3ee',
+    white: '#cbd5e1',
+    brightBlack: '#475569',
+    brightRed: '#fca5a5',
+    brightGreen: '#6ee7b7',
+    brightYellow: '#fde68a',
+    brightBlue: '#93c5fd',
+    brightMagenta: '#d8b4fe',
+    brightCyan: '#67e8f9',
+    brightWhite: '#ffffff',
+  };
+}
+
+export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>, options: UseTerminalOptions) {
+  const { sandboxID, containerID, enabled = true, initialFontSize = 13 } = options;
+  const [status, setStatus] = useState<TerminalStatus>('connecting');
+  const [fontSize, setFontSizeState] = useState(initialFontSize);
+  const [isFullscreen, setIsFullscreen] = useState(false);
+  const [disconnectReason, setDisconnectReason] = useState<string | undefined>();
+
+  const terminalRef = useRef<Terminal | null>(null);
+  const fitRef = useRef<FitAddon | null>(null);
+  const socketRef = useRef<ReturnType<typeof createTerminalSocket> | null>(null);
+  const connectRef = useRef<() => void>(() => {});
+  const resizeObserverRef = useRef<ResizeObserver | null>(null);
+  const rafRef = useRef<number | null>(null);
+  const mode = useThemeStore((s) => s.mode);
+  const effective = resolveEffective(mode);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+    if (!enabled) {
+      setStatus('disconnected');
+      setDisconnectReason(undefined);
+      return;
+    }
+
+    const term = new Terminal({
+      fontFamily: '"JetBrains Mono Variable", "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, Consolas, monospace',
+      fontSize,
+      lineHeight: 1.25,
+      cursorBlink: true,
+      cursorStyle: 'block',
+      scrollback: 5000,
+      allowProposedApi: false,
+      theme: getTerminalTheme(effective),
+    });
+
+    const fitAddon = new FitAddon();
+    term.loadAddon(fitAddon);
+    term.open(container);
+
+    terminalRef.current = term;
+    fitRef.current = fitAddon;
+
+    const fitTimer = window.setTimeout(() => {
+      try {
+        fitAddon.fit();
+      } catch {
+        // Container may be hidden; ignore.
+      }
+    }, 0);
+
+    const disposables = [
+      // Forward to the current socket so a reconnect swaps underneath us.
+      term.onData((data) => socketRef.current?.sendInput(data)),
+      term.onResize(({ cols, rows }) => socketRef.current?.sendResize(cols, rows)),
+    ];
+
+    const ro = new ResizeObserver(() => {
+      if (rafRef.current != null) {
+        window.cancelAnimationFrame(rafRef.current);
+      }
+      rafRef.current = window.requestAnimationFrame(() => {
+        rafRef.current = null;
+        try {
+          fitAddon.fit();
+        } catch {
+          // ignore
+        }
+      });
+    });
+    ro.observe(container);
+    resizeObserverRef.current = ro;
+
+    const connect = () => {
+      setStatus('connecting');
+      setDisconnectReason(undefined);
+      const socket = createTerminalSocket(sandboxID, containerID);
+      socketRef.current = socket;
+
+      socket.onopen = () => {
+        setStatus('connected');
+        try {
+          fitAddon.fit();
+        } catch {
+          // ignore
+        }
+      };
+
+      socket.onmessage = (message: TerminalMessage) => {
+        if (message.type === 'output') {
+          term.write(base64ToUtf8(message.data));
+        } else if (message.type === 'error') {
+          term.writeln(`\r\n\x1b[31m${message.message}\x1b[0m`);
+        } else if (message.type === 'close') {
+          setStatus('disconnected');
+          if (message.reason) {
+            setDisconnectReason(message.reason);
+          }
+        }
+      };
+
+      socket.onclose = (event) => {
+        setStatus('disconnected');
+        setDisconnectReason(event?.reason);
+      };
+
+      socket.onerror = (event) => {
+        setStatus('disconnected');
+        setDisconnectReason(event.message);
+        term.writeln(`\r\n\x1b[31m${event.message}\x1b[0m`);
+      };
+    };
+
+    connectRef.current = connect;
+    connect();
+
+    return () => {
+      window.clearTimeout(fitTimer);
+      if (rafRef.current != null) {
+        window.cancelAnimationFrame(rafRef.current);
+        rafRef.current = null;
+      }
+      ro.disconnect();
+      disposables.forEach((d) => d.dispose());
+      const socket = socketRef.current;
+      if (socket) {
+        socket.onopen = null;
+        socket.onmessage = null;
+        socket.onclose = null;
+        socket.onerror = null;
+        socket.close();
+      }
+      term.dispose();
+      terminalRef.current = null;
+      fitRef.current = null;
+      socketRef.current = null;
+      resizeObserverRef.current = null;
+      connectRef.current = () => {};
+    };
+  }, [sandboxID, containerID, enabled, containerRef]);
+
+  useEffect(() => {
+    if (terminalRef.current) {
+      terminalRef.current.options.theme = getTerminalTheme(effective);
+    }
+  }, [effective]);
+
+  useEffect(() => {
+    const term = terminalRef.current;
+    if (!term) return;
+    term.options.fontSize = fontSize;
+    try {
+      fitRef.current?.fit();
+    } catch {
+      // ignore
+    }
+  }, [fontSize]);
+
+  const reconnect = () => {
+    const old = socketRef.current;
+    if (old) {
+      // Detach handlers so the old socket doesn't flip status after we close it.
+      old.onopen = null;
+      old.onmessage = null;
+      old.onclose = null;
+      old.onerror = null;
+      old.close();
+    }
+    connectRef.current();
+  };
+
+  const fit = () => {
+    try {
+      fitRef.current?.fit();
+    } catch {
+      // ignore
+    }
+  };
+
+  const setFontSize = (size: number) => {
+    setFontSizeState(Math.max(MIN_FONT_SIZE, Math.min(MAX_FONT_SIZE, size)));
+  };
+
+  const increaseFontSize = () => setFontSize(fontSize + 1);
+  const decreaseFontSize = () => setFontSize(fontSize - 1);
+
+  const toggleFullscreen = () => {
+    setIsFullscreen((prev) => !prev);
+    // Give the layout a tick to settle before refitting.
+    window.setTimeout(() => fit(), 0);
+  };
+
+  return {
+    status,
+    fit,
+    reconnect,
+    terminal: terminalRef.current,
+    fontSize,
+    setFontSize,
+    increaseFontSize,
+    decreaseFontSize,
+    isFullscreen,
+    toggleFullscreen,
+    disconnectReason,
+  };
+}

--- a/web/src/lib/terminalSocket.ts
+++ b/web/src/lib/terminalSocket.ts
@@ -1,0 +1,315 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2026 Tencent. All rights reserved.
+
+import { isMockEnabled } from './mockFlag';
+
+export type TerminalMessage =
+  | { type: 'input'; data: string }
+  | { type: 'output'; data: string }
+  | { type: 'resize'; cols: number; rows: number }
+  | { type: 'error'; message: string }
+  | { type: 'close'; reason?: string };
+
+export interface TerminalSocket {
+  readonly readyState: number;
+  onopen: (() => void) | null;
+  onmessage: ((message: TerminalMessage) => void) | null;
+  onclose: ((event?: { code?: number; reason?: string }) => void) | null;
+  onerror: ((event: { message: string }) => void) | null;
+  sendInput(data: string): void;
+  sendResize(cols: number, rows: number): void;
+  close(): void;
+}
+
+const READY_STATE_CONNECTING = 0;
+const READY_STATE_OPEN = 1;
+const READY_STATE_CLOSING = 2;
+const READY_STATE_CLOSED = 3;
+
+function utf8ToBase64(s: string): string {
+  const bytes = new TextEncoder().encode(s);
+  let binary = '';
+  for (let i = 0; i < bytes.byteLength; i++) {
+    binary += String.fromCharCode(bytes[i]);
+  }
+  return btoa(binary);
+}
+
+export { utf8ToBase64 };
+
+export function base64ToUtf8(b64: string): string {
+  const binary = atob(b64);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return new TextDecoder().decode(bytes);
+}
+
+export function closeReasonMessage(code?: number, reason?: string): string {
+  if (reason) return reason;
+  switch (code) {
+    case 1000:
+      return 'normal closure';
+    case 1001:
+      return 'endpoint going away';
+    case 1006:
+      return 'connection lost';
+    case 1008:
+      return 'policy violation';
+    case 1011:
+      return 'server error';
+    default:
+      return code ? `closed (${code})` : 'connection closed';
+  }
+}
+
+/**
+ * Create a WebSocket connection to the sandbox terminal endpoint.
+ * In mock mode this returns a local fake shell so the UI can be exercised
+ * without the backend bridge implemented in step 3.
+ */
+export function createTerminalSocket(sandboxID: string, containerID?: string): TerminalSocket {
+  if (isMockEnabled()) {
+    return new MockTerminalSocket(sandboxID);
+  }
+  return new NativeTerminalSocket(sandboxID, containerID);
+}
+
+class NativeTerminalSocket implements TerminalSocket {
+  private ws: WebSocket;
+  private inputQueue: string[] = [];
+  private pendingResize: { cols: number; rows: number } | null = null;
+
+  onopen: (() => void) | null = null;
+  onmessage: ((message: TerminalMessage) => void) | null = null;
+  onclose: ((event?: { code?: number; reason?: string }) => void) | null = null;
+  onerror: ((event: { message: string }) => void) | null = null;
+
+  constructor(sandboxID: string, containerID?: string) {
+    const apiKey = localStorage.getItem('cube.apiKey') ?? '';
+    const accessToken = localStorage.getItem('cube.session') ?? '';
+    const params = new URLSearchParams();
+    if (apiKey) params.set('api_key', apiKey);
+    if (accessToken) params.set('access_token', accessToken);
+    if (containerID) params.set('container', containerID);
+
+    const query = params.toString();
+    const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
+    const url = `${protocol}//${window.location.host}/cubeapi/v1/sandboxes/${encodeURIComponent(sandboxID)}/terminal/ws${query ? `?${query}` : ''}`;
+
+    this.ws = new WebSocket(url);
+    this.ws.onopen = () => {
+      this.flushQueue();
+      this.onopen?.();
+    };
+    this.ws.onmessage = (event) => {
+      try {
+        const message = JSON.parse(event.data as string) as TerminalMessage;
+        this.onmessage?.(message);
+      } catch {
+        this.onmessage?.({ type: 'output', data: utf8ToBase64(String(event.data)) });
+      }
+    };
+    this.ws.onclose = (event) => this.onclose?.({ code: event.code, reason: event.reason });
+    this.ws.onerror = () => this.onerror?.({ message: 'WebSocket error' });
+  }
+
+  get readyState(): number {
+    return this.ws.readyState;
+  }
+
+  sendInput(data: string): void {
+    if (this.ws.readyState === WebSocket.OPEN) {
+      this.ws.send(JSON.stringify({ type: 'input', data: utf8ToBase64(data) }));
+    } else if (this.ws.readyState === WebSocket.CONNECTING) {
+      this.inputQueue.push(data);
+    }
+  }
+
+  sendResize(cols: number, rows: number): void {
+    if (this.ws.readyState === WebSocket.OPEN) {
+      this.ws.send(JSON.stringify({ type: 'resize', cols, rows }));
+    } else if (this.ws.readyState === WebSocket.CONNECTING) {
+      this.pendingResize = { cols, rows };
+    }
+  }
+
+  close(): void {
+    this.inputQueue = [];
+    this.pendingResize = null;
+    this.ws.close();
+  }
+
+  private flushQueue(): void {
+    while (this.inputQueue.length > 0) {
+      const data = this.inputQueue.shift()!;
+      this.sendInput(data);
+    }
+    if (this.pendingResize) {
+      this.sendResize(this.pendingResize.cols, this.pendingResize.rows);
+      this.pendingResize = null;
+    }
+  }
+}
+
+/**
+ * In-memory mock terminal for local development. It echoes typed characters and
+ * evaluates a tiny set of fake shell commands so the xterm cursor, resize and
+ * scrollback behavior can be verified before the real backend exists.
+ */
+class MockTerminalSocket implements TerminalSocket {
+  readyState = READY_STATE_CONNECTING;
+
+  onopen: (() => void) | null = null;
+  onmessage: ((message: TerminalMessage) => void) | null = null;
+  onclose: ((event?: { code?: number; reason?: string }) => void) | null = null;
+  onerror: ((event: { message: string }) => void) | null = null;
+
+  private sandboxID: string;
+  private line = '';
+  private timer: number | null = null;
+  private closed = false;
+
+  constructor(sandboxID: string) {
+    this.sandboxID = sandboxID;
+    this.timer = window.setTimeout(() => {
+      if (this.closed) return;
+      this.readyState = READY_STATE_OPEN;
+      this.onopen?.();
+      this.emitOutput(
+        '\x1b[1;36mCubeSandbox mock terminal\x1b[0m\r\n' +
+          '\x1b[90msandbox:\x1b[0m \x1b[33m' +
+          sandboxID +
+          '\x1b[0m\r\n' +
+          '\x1b[90mTry: help, ls, colors, dmesg, clear, exit\x1b[0m\r\n\r\n' +
+          this.prompt(),
+      );
+    }, 400);
+  }
+
+  private prompt(): string {
+    return '\x1b[32m$\x1b[0m ';
+  }
+
+  sendInput(data: string): void {
+    if (this.readyState !== READY_STATE_OPEN || this.closed) return;
+
+    for (const ch of data) {
+      const code = ch.charCodeAt(0);
+      if (ch === '\r') {
+        this.emitOutput('\r\n');
+        this.runCommand(this.line.trim());
+        this.line = '';
+        this.emitOutput(this.prompt());
+      } else if (ch === '\x7f' || ch === '\b') {
+        if (this.line.length > 0) {
+          this.line = this.line.slice(0, -1);
+          this.emitOutput('\b \b');
+        }
+      } else if (code === 3) {
+        // Ctrl+C
+        this.line = '';
+        this.emitOutput('^C\r\n' + this.prompt());
+      } else if (code === 4) {
+        // Ctrl+D
+        this.emitOutput('\x1b[33mexit\x1b[0m\r\n');
+        this.close();
+        return;
+      } else if (code === 9) {
+        // Tab — no completion in mock mode
+      } else if (code >= 32 && code < 127) {
+        this.line += ch;
+        this.emitOutput(ch);
+      }
+    }
+  }
+
+  sendResize(_cols: number, _rows: number): void {
+    // Mock shell ignores resizes.
+  }
+
+  close(): void {
+    if (this.closed) return;
+    this.closed = true;
+    this.readyState = READY_STATE_CLOSED;
+    if (this.timer) {
+      window.clearTimeout(this.timer);
+      this.timer = null;
+    }
+    this.onmessage?.({ type: 'close' });
+    this.onclose?.({ code: 1000, reason: 'closed by client' });
+  }
+
+  private emitOutput(text: string): void {
+    this.onmessage?.({ type: 'output', data: utf8ToBase64(text) });
+  }
+
+  private runCommand(cmd: string): void {
+    if (!cmd) return;
+    const [name, ...args] = cmd.split(/\s+/);
+    switch (name) {
+      case 'help':
+        this.emitOutput(
+          '\x1b[1mAvailable commands:\x1b[0m\r\n' +
+            '  \x1b[32mhelp\x1b[0m      show this help\r\n' +
+            '  \x1b[32mls\x1b[0m       list files\r\n' +
+            '  \x1b[32mpwd\x1b[0m      print working directory\r\n' +
+            '  \x1b[32muname\x1b[0m    print system info\r\n' +
+            '  \x1b[32mecho\x1b[0m     echo arguments\r\n' +
+            '  \x1b[32mdate\x1b[0m     print current time\r\n' +
+            '  \x1b[32mwhoami\x1b[0m    print current user\r\n' +
+            '  \x1b[32mcolors\x1b[0m    ANSI color test\r\n' +
+            '  \x1b[32mdmesg\x1b[0m    long colored output (scrollback demo)\r\n' +
+            '  \x1b[32mclear\x1b[0m    clear the screen\r\n' +
+            '  \x1b[32mexit\x1b[0m     close the terminal\r\n',
+        );
+        break;
+      case 'ls':
+        this.emitOutput(
+          '\x1b[34mdocs\x1b[0m/      \x1b[34mworkspace\x1b[0m/  \x1b[32mrun.sh\x1b[0m*   \x1b[0mREADME.md\x1b[0m   \x1b[35mconfig.yaml\x1b[0m\r\n',
+        );
+        break;
+      case 'pwd':
+        this.emitOutput('/home/sandbox\r\n');
+        break;
+      case 'uname':
+        this.emitOutput('CubeSandbox mock kernel 0.5.0 x86_64\r\n');
+        break;
+      case 'echo':
+        this.emitOutput(`${args.join(' ')}\r\n`);
+        break;
+      case 'date':
+        this.emitOutput(`\x1b[33m${new Date().toISOString()}\x1b[0m\r\n`);
+        break;
+      case 'whoami':
+        this.emitOutput('\x1b[32mmock\x1b[0m\r\n');
+        break;
+      case 'colors':
+        this.emitOutput(
+          '\x1b[31mred\x1b[0m  \x1b[32mgreen\x1b[0m  \x1b[33myellow\x1b[0m  ' +
+            '\x1b[34mblue\x1b[0m  \x1b[35mmagenta\x1b[0m  \x1b[36mcyan\x1b[0m  \x1b[90mgray\x1b[0m\r\n' +
+            '\x1b[1;31mred\x1b[0m  \x1b[1;32mgreen\x1b[0m  \x1b[1;33myellow\x1b[0m  ' +
+            '\x1b[1;34mblue\x1b[0m  \x1b[1;35mmagenta\x1b[0m  \x1b[1;36mcyan\x1b[0m\r\n',
+        );
+        break;
+      case 'dmesg':
+        for (let i = 1; i <= 40; i++) {
+          const color = i % 2 === 0 ? '\x1b[32m' : '\x1b[36m';
+          this.emitOutput(
+            `\x1b[90m[${String(i).padStart(3, '0')}.000000]\x1b[0m ${color}mock kernel: event ${i} logged\x1b[0m\r\n`,
+          );
+        }
+        break;
+      case 'clear':
+        this.onmessage?.({ type: 'output', data: utf8ToBase64('\x1b[2J\x1b[H') });
+        break;
+      case 'exit':
+        this.emitOutput('\x1b[33mlogout\x1b[0m\r\n');
+        this.close();
+        break;
+      default:
+        this.emitOutput(`\x1b[31m${name}: command not found\x1b[0m\r\n`);
+    }
+  }
+}

--- a/web/src/locales/en/sandboxDetail.json
+++ b/web/src/locales/en/sandboxDetail.json
@@ -25,7 +25,26 @@
   "actions": {
     "resume": "Resume",
     "pause": "Pause",
-    "kill": "Kill"
+    "kill": "Kill",
+    "terminal": "Open Terminal",
+    "terminalDisabledTooltip": "Terminal is only available while the sandbox is running"
+  },
+  "terminal": {
+    "title": "Terminal",
+    "connecting": "Connecting…",
+    "connected": "Connected",
+    "disconnected": "Disconnected",
+    "close": "Close Terminal",
+    "reconnect": "Reconnect",
+    "fullscreen": "Full screen",
+    "exitFullscreen": "Exit full screen",
+    "fontSizeIncrease": "Increase font size",
+    "fontSizeDecrease": "Decrease font size",
+    "container": "Container",
+    "errors": {
+      "disconnected": "Disconnected: {{reason}}",
+      "noRunningContainers": "No running containers are available for terminal login."
+    }
   },
   "errors": {
     "unknown": "Unknown error",

--- a/web/src/locales/en/sandboxes.json
+++ b/web/src/locales/en/sandboxes.json
@@ -25,7 +25,9 @@
   "actions": {
     "resume": "Resume",
     "pause": "Pause",
-    "kill": "Kill"
+    "kill": "Kill",
+    "terminal": "Open Terminal",
+    "terminalDisabledTooltip": "Terminal is only available while the sandbox is running"
   },
   "errors": {
     "unknown": "Unknown error",

--- a/web/src/locales/zh/sandboxDetail.json
+++ b/web/src/locales/zh/sandboxDetail.json
@@ -25,7 +25,26 @@
   "actions": {
     "resume": "恢复",
     "pause": "暂停",
-    "kill": "终止"
+    "kill": "终止",
+    "terminal": "打开终端",
+    "terminalDisabledTooltip": "仅当沙箱处于运行状态时可打开终端"
+  },
+  "terminal": {
+    "title": "终端",
+    "connecting": "连接中…",
+    "connected": "已连接",
+    "disconnected": "已断开",
+    "close": "关闭终端",
+    "reconnect": "重新连接",
+    "fullscreen": "全屏",
+    "exitFullscreen": "退出全屏",
+    "fontSizeIncrease": "放大字号",
+    "fontSizeDecrease": "缩小字号",
+    "container": "容器",
+    "errors": {
+      "disconnected": "已断开：{{reason}}",
+      "noRunningContainers": "没有可登录的运行中容器。"
+    }
   },
   "errors": {
     "unknown": "未知错误",

--- a/web/src/locales/zh/sandboxes.json
+++ b/web/src/locales/zh/sandboxes.json
@@ -25,7 +25,9 @@
   "actions": {
     "resume": "恢复",
     "pause": "暂停",
-    "kill": "终止"
+    "kill": "终止",
+    "terminal": "打开终端",
+    "terminalDisabledTooltip": "仅当沙箱处于运行状态时可打开终端"
   },
   "errors": {
     "unknown": "未知错误",

--- a/web/src/mocks/handlers/index.ts
+++ b/web/src/mocks/handlers/index.ts
@@ -32,6 +32,13 @@ export const handlers = [
     return HttpResponse.json({ status: 'ok', sandboxes: listSandboxes().length });
   }),
 
+  http.get('/cubeapi/v1/auth/session', async () => {
+    await mockDelay();
+    // In mock mode authentication is not required, so AuthGuard lets the
+    // user straight into the dashboard without showing the login page.
+    return HttpResponse.json({ authRequired: false, authenticated: false, username: 'mock' });
+  }),
+
   http.get('/cubeapi/v1/cluster/overview', async () => {
     await mockDelay();
     return HttpResponse.json(getClusterOverview());

--- a/web/src/pages/SandboxDetail.tsx
+++ b/web/src/pages/SandboxDetail.tsx
@@ -3,7 +3,7 @@
 
 import { useEffect, useRef, useState } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { useNavigate, useParams, Link } from 'react-router-dom';
+import { useNavigate, useParams, Link, useSearchParams } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { sandboxApi } from '@/api/client';
 import { Card, CardTitle, CardDescription, CardHeader } from '@/components/ui/card';
@@ -11,10 +11,11 @@ import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 
 import { Skeleton } from '@/components/ui/skeleton';
-import { ArrowLeft, Pause, Play, Trash2, RefreshCw } from 'lucide-react';
+import { ArrowLeft, Pause, Play, Trash2, RefreshCw, Terminal } from 'lucide-react';
 import { cn, formatBytes, formatRelative } from '@/lib/utils';
 import { formatSandboxActionError } from '@/lib/sandboxActionError';
 import { SandboxActionErrorBanner } from '@/components/SandboxActionErrorBanner';
+import SandboxTerminal from '@/components/SandboxTerminal';
 
 // ── Log level colors ────────────────────────────────────────────────────────
 const LEVEL_CLASS: Record<string, string> = {
@@ -34,8 +35,10 @@ function formatLogTime(ts: string): string {
 export default function SandboxDetailPage() {
   const { sandboxID = '' } = useParams();
   const nav = useNavigate();
+  const [searchParams, setSearchParams] = useSearchParams();
   const qc = useQueryClient();
   const { t } = useTranslation('sandboxDetail');
+  const showTerminal = searchParams.get('terminal') === '1';
 
   // ── Sandbox detail ──────────────────────────────────────────────────────
   const { data, isLoading } = useQuery({
@@ -98,6 +101,13 @@ export default function SandboxDetailPage() {
   const tone = state === 'paused' || state === 'pausing' ? 'warn' : state === 'running' ? 'ok' : 'mute';
   const entries = logs.data?.logs ?? [];
 
+  // Close the terminal automatically if the sandbox stops running.
+  useEffect(() => {
+    if (showTerminal && state !== 'running') {
+      setSearchParams({}, { replace: true });
+    }
+  }, [showTerminal, state, setSearchParams]);
+
   return (
     <div className="animate-fade-in space-y-5">
       {/* ── Header ── */}
@@ -117,6 +127,14 @@ export default function SandboxDetailPage() {
           </p>
         </div>
         <div className="flex gap-2">
+          <Button
+            variant="outline"
+            onClick={() => setSearchParams({ terminal: '1' }, { replace: true })}
+            title={state === 'running' ? t('actions.terminal') : t('actions.terminalDisabledTooltip')}
+            disabled={state !== 'running'}
+          >
+            <Terminal size={14} /> {t('actions.terminal')}
+          </Button>
           {state === 'paused' ? (
             <Button variant="outline" onClick={() => resume.mutate()} disabled={resume.isPending}>
               <Play size={14} /> {t('actions.resume')}
@@ -248,6 +266,10 @@ export default function SandboxDetailPage() {
           )}
         </pre>
       </Card>
+
+      {showTerminal && (
+        <SandboxTerminal sandboxID={sandboxID} onClose={() => setSearchParams({}, { replace: true })} />
+      )}
     </div>
   );
 }

--- a/web/src/pages/Sandboxes.tsx
+++ b/web/src/pages/Sandboxes.tsx
@@ -3,7 +3,7 @@
 
 import { useMemo, useState } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { Link } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { sandboxApi, type RunningSandbox } from '@/api/client';
 import { Card } from '@/components/ui/card';
@@ -11,7 +11,7 @@ import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { Skeleton } from '@/components/ui/skeleton';
-import { Pause, Play, Trash2, Search, Plus } from 'lucide-react';
+import { Pause, Play, Trash2, Search, Plus, Terminal } from 'lucide-react';
 import { formatBytes, formatRelative, short } from '@/lib/utils';
 import { cn } from '@/lib/utils';
 import { formatSandboxActionError } from '@/lib/sandboxActionError';
@@ -22,6 +22,7 @@ type StateFilter = 'all' | 'running' | 'paused';
 export default function SandboxesPage() {
   const [q, setQ] = useState('');
   const [stateFilter, setStateFilter] = useState<StateFilter>('all');
+  const nav = useNavigate();
   const qc = useQueryClient();
   const { t } = useTranslation('sandboxes');
 
@@ -162,6 +163,7 @@ export default function SandboxesPage() {
             onKill={() => killMut.mutate(sb.sandboxID)}
             onPause={() => pauseMut.mutate(sb.sandboxID)}
             onResume={() => resumeMut.mutate(sb.sandboxID)}
+            onOpenTerminal={() => nav(`/sandboxes/${sb.sandboxID}?terminal=1`)}
             busy={pendingId === sb.sandboxID}
           />
         ))}
@@ -178,12 +180,14 @@ function Row({
   onKill,
   onPause,
   onResume,
+  onOpenTerminal,
   busy,
 }: {
   sb: RunningSandbox;
   onKill: () => void;
   onPause: () => void;
   onResume: () => void;
+  onOpenTerminal: () => void;
   busy: boolean;
 }) {
   const { t } = useTranslation('sandboxes');
@@ -213,6 +217,15 @@ function Row({
       <div className="text-xs text-muted-foreground/80 text-num">{sb.clientID || '—'}</div>
       <div className="text-xs text-muted-foreground">{formatRelative(sb.startedAt)}</div>
       <div className="flex justify-end gap-1">
+        <Button
+          size="icon"
+          variant="ghost"
+          title={state === 'running' ? t('actions.terminal') : t('actions.terminalDisabledTooltip')}
+          onClick={onOpenTerminal}
+          disabled={busy || state !== 'running'}
+        >
+          <Terminal size={14} />
+        </Button>
         {state === 'paused' ? (
           <Button size="icon" variant="ghost" title={t('actions.resume')} onClick={onResume} disabled={busy}>
             <Play size={14} />

--- a/web/src/styles/xterm.css
+++ b/web/src/styles/xterm.css
@@ -1,0 +1,45 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* Copyright (C) 2026 Tencent. All rights reserved. */
+
+/* xterm.js integration tweaks. The theme itself is set via Terminal.options
+ * in useTerminal.ts so it stays in sync with the app light/dark mode. */
+
+.xterm {
+  height: 100%;
+  padding: 0;
+}
+
+.xterm-screen {
+  height: 100%;
+}
+
+.xterm-viewport {
+  border-radius: 0 0 calc(var(--radius) - 2px) calc(var(--radius) - 2px);
+}
+
+.xterm-viewport::-webkit-scrollbar {
+  width: 8px;
+  height: 8px;
+}
+
+.xterm-viewport::-webkit-scrollbar-thumb {
+  background: hsl(var(--border));
+  border-radius: 8px;
+  border: 2px solid transparent;
+  background-clip: content-box;
+}
+
+.xterm-viewport::-webkit-scrollbar-thumb:hover {
+  background: hsl(var(--muted-foreground) / 0.5);
+}
+
+/* xterm leaves some internal measurement helpers in the DOM. Hide them so they
+ * don't show up as a stray row of characters above the rendered terminal. */
+.xterm-width-cache-measure-container,
+.xterm-char-measure-element {
+  position: absolute !important;
+  left: -9999px !important;
+  top: 0 !important;
+  opacity: 0 !important;
+  pointer-events: none !important;
+}

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -9,6 +9,7 @@ import react from '@vitejs/plugin-react';
 import { defineConfig } from 'vite';
 
 const pkg = JSON.parse(readFileSync(path.resolve(__dirname, './package.json'), 'utf-8'));
+const cubeApiProxyTarget = process.env.CUBE_API_PROXY_TARGET ?? 'http://127.0.0.1:3000';
 
 // Displayed app version, aligned with the release tag. Release builds inject the
 // tag via CUBE_VERSION (release-one-click.yml passes github.ref_name); otherwise
@@ -42,7 +43,11 @@ export default defineConfig({
   server: {
     port: 5173,
     proxy: {
-      '/cubeapi': 'http://127.0.0.1:3000',
+      '/cubeapi': {
+        target: cubeApiProxyTarget,
+        changeOrigin: true,
+        ws: true,
+      },
     },
   },
 });


### PR DESCRIPTION
Related to #643

## Summary

This PR adds interactive Web Terminal support for running sandboxes in CubeSandbox WebUI.

Users can open a terminal from the sandbox list or detail page, connect through CubeAPI WebSocket, and interact with a real TTY shell from the browser.

## Frontend

- Add "Open Terminal" entry in sandbox list and sandbox detail page.
- Disable terminal entry when the sandbox is not running.
- Add xterm.js terminal dialog.
- Support command input/output, ANSI colors, resize, fullscreen, reconnect, and font size controls.
- Add container selector for sandbox container login.
- Add EN/ZH i18n strings.

### Frontend Evidence

Sandbox list: running terminal enabled, paused terminal disabled.

<img width="1440" height="960" alt="01-list-running-enabled-paused-disabled" src="https://github.com/user-attachments/assets/131ca0ca-837e-4032-ad8f-4ba1101ce386" />

Running sandbox detail page with Open Terminal entry.

<img width="1440" height="989" alt="02-detail-running-open-terminal-entry" src="https://github.com/user-attachments/assets/886fa2a5-a64b-49e9-ae94-459ceec9f018" />


Paused sandbox detail page with terminal disabled.

<img width="1440" height="989" alt="03-detail-paused-terminal-disabled" src="https://github.com/user-attachments/assets/1b00e29b-4519-4053-9435-0047aee6b159" />

Real backend terminal connected.

<img width="1440" height="989" alt="04-terminal-connected-real-backend" src="https://github.com/user-attachments/assets/d887794f-9903-4b78-9441-be7aefa77985" />

Command output, ANSI color, and terminal resize.

<img width="1440" height="989" alt="05-terminal-command-ansi-resize-output" src="https://github.com/user-attachments/assets/ce27032e-e6e6-4fd1-a6e7-8d10547d55c4" />


Disconnected state with reconnect action.

<img width="1440" height="989" alt="07-terminal-disconnected-reconnect" src="https://github.com/user-attachments/assets/e0d2c65c-0b5a-4665-9b3a-b4523c254b6d" />

Alice and Bob independent terminal sessions.

<img width="1440" height="989" alt="08-multiuser-alice-real-terminal" src="https://github.com/user-attachments/assets/ba766f61-d6fe-4505-9157-ef75436d72ad" />
<img width="1440" height="989" alt="09-multiuser-bob-real-terminal" src="https://github.com/user-attachments/assets/3ea8d72d-79d9-482e-a8ad-4f759370c5f2" />

## Backend

- Add terminal WebSocket endpoint for sandbox shell sessions.
- Bridge browser terminal I/O to envd TTY process APIs.
- Support input, output, resize, close, keepalive, and idle timeout.
- Reuse existing auth for WebSocket terminal access.
- Reject unauthorized terminal connections.
- Reject terminal login when sandbox is not running.
- Add audit logs for terminal connect, disconnect, and denied events.
- Add sandbox container metadata for terminal container selection.

### Backend Evidence

Terminal audit logs record connect, disconnect, and denied events:

```json
{"timestamp":"2026-07-11T08:20:15.263764294Z","level":"info","event":"terminal.connect","rows":"33","user_id":"alice","cols":"120","user_name":"Alice","remote_ip":"127.0.0.1","sandbox_id":"4fe07d237a4047cfa64a4b4c576bd02f","auth_type":"bearer"}
{"timestamp":"2026-07-11T08:20:15.284415617Z","level":"info","event":"terminal.disconnect","user_id":"alice","disconnect_reason":"client_closed","duration_ms":26,"auth_type":"bearer","cols":"120","sandbox_id":"4fe07d237a4047cfa64a4b4c576bd02f","remote_ip":"127.0.0.1","rows":"33","user_name":"Alice"}
{"timestamp":"2026-07-11T08:20:15.284846238Z","level":"info","event":"terminal.connect_denied","auth_type":"bearer","sandbox_id":"4fe07d237a4047cfa64a4b4c576bd02f","remote_ip":"127.0.0.1","cols":"100","reason":"auth_required","rows":"40","http_status":401,"duration_ms":0}
{"timestamp":"2026-07-11T08:20:15.287112299Z","level":"info","event":"terminal.connect_denied","cols":"100","auth_type":"bearer","reason":"not_running","duration_ms":1,"rows":"40","sandbox_id":"253ef63ffc434ca493467c0707a21fb5","remote_ip":"127.0.0.1","user_name":"Alice","http_status":409,"user_id":"alice"}
{"timestamp":"2026-07-11T08:20:15.296670480Z","level":"info","event":"terminal.connect","rows":"22","user_id":"alice","user_name":"Alice","auth_type":"bearer","remote_ip":"127.0.0.1","cols":"111","sandbox_id":"4fe07d237a4047cfa64a4b4c576bd02f"}
{"timestamp":"2026-07-11T08:20:15.296741082Z","level":"info","event":"terminal.connect","cols":"122","rows":"33","auth_type":"bearer","sandbox_id":"4fe07d237a4047cfa64a4b4c576bd02f","remote_ip":"127.0.0.1","user_id":"bob","user_name":"Bob"}
{"timestamp":"2026-07-11T08:20:17.836807198Z","level":"info","event":"terminal.disconnect","cols":"111","remote_ip":"127.0.0.1","auth_type":"bearer","user_id":"alice","user_name":"Alice","sandbox_id":"4fe07d237a4047cfa64a4b4c576bd02f","rows":"22","duration_ms":2546,"disconnect_reason":"envd_end"}
{"timestamp":"2026-07-11T08:20:17.836878139Z","level":"info","event":"terminal.disconnect","user_name":"Bob","rows":"33","user_id":"bob","duration_ms":2546,"cols":"122","sandbox_id":"4fe07d237a4047cfa64a4b4c576bd02f","disconnect_reason":"envd_end","auth_type":"bearer","remote_ip":"127.0.0.1"}
```

Invalid token WebSocket handshake returns 401:

```http
HTTP/1.1 401 Unauthorized

{"code":401,"message":"Authentication rejected by callback"}
```

Paused sandbox WebSocket handshake returns 409:

```http
HTTP/1.1 409 Conflict

{"code":409,"message":"sandbox 253ef63ffc434ca493467c0707a21fb5 is not running"}
```

Idle terminal session closes with `idle_timeout`:

```json
{
  "status": "HTTP/1.1 101 Switching Protocols",
  "close_reason": "idle_timeout",
  "messages": [
    {"type": "output"},
    {"type": "output"},
    {"type": "close", "reason": "idle_timeout"}
  ]
}
```

Alice/Bob concurrent sessions are isolated:

```json
{
  "alice": {"ok": true, "status": "HTTP/1.1 101 Switching Protocols"},
  "bob": {"ok": true, "status": "HTTP/1.1 101 Switching Protocols"}
}
```

Audit logs do not contain terminal input/output payload:

```text
PASS: no terminal input/output markers found in audit logs
```

## Verification

- `cargo fmt --manifest-path CubeAPI/Cargo.toml -- --check`
- `git diff --check upstream/master..HEAD`
- `cargo test --manifest-path CubeAPI/Cargo.toml`
- `npm run build`


