### PR TITLE
feat(lifecycle): deliver sandbox lifecycle events to webhook endpoints from CLM

### DIFF
--- a/cube-lifecycle-manager/README.md
+++ b/cube-lifecycle-manager/README.md
@@ -42,3 +42,54 @@ Overrides:
 
 All configuration is via environment variables (prefix `CUBE_LCM_`); see
 `internal/config/config.go` for the authoritative list.
+
+## Webhook event notifications
+
+CLM can deliver `sandbox.created`, `sandbox.deleted`, `sandbox.paused`, and
+`sandbox.resumed` events to external HTTP endpoints. Set
+`CUBE_LCM_WEBHOOK_ENDPOINTS` to a JSON array before starting:
+
+```bash
+export CUBE_LCM_WEBHOOK_ENDPOINTS='[
+  {
+    "url": "https://ops.example.com/webhooks/cube",
+    "events": ["sandbox.created", "sandbox.deleted", "sandbox.paused", "sandbox.resumed"],
+    "secret": "replace-with-a-random-shared-secret"
+  }
+]'
+```
+
+- `events` is a filter; omit it (or pass `[]`) to subscribe to every event.
+- `secret` is optional. When set (minimum 16 bytes), every request carries
+  `X-Cube-Signature-256: sha256=<hex HMAC>` over the exact request body.
+
+Each endpoint owns an independent Redis consumer group
+(`webhook:<hash>`) on the lifecycle events stream, so a slow or unreachable
+receiver never delays other subscriptions or the auto-pause/resume loop.
+Delivery is at-least-once: an event is acknowledged only after it reaches a
+terminal state (delivered, permanently rejected, or retries exhausted), and a
+restarted replica redelivers whatever its consumer left pending. A single
+replica delivers events in stream order; with several replicas the group is
+split across consumers, so cross-replica ordering is not guaranteed. Entries
+left pending by a permanently dead replica stay observable via `XPENDING`
+and can be reassigned with `XAUTOCLAIM`.
+
+Delivery retries `5xx`, `408`, and `429` responses with exponential backoff
+and jitter (base `CUBE_LCM_WEBHOOK_RETRY_BASE`, default 250ms; up to
+`CUBE_LCM_WEBHOOK_MAX_RETRIES` retries, default 3; per-attempt timeout
+`CUBE_LCM_WEBHOOK_TIMEOUT`, default 5s). The whole delivery is capped at 30
+seconds. Other `4xx` responses are permanent and are not retried. Automatic
+redirects are disabled so a configured endpoint cannot bounce delivery to an
+internal service.
+
+The JSON body always carries `version`, `event`, `timestamp` (RFC 3339), and
+`sandbox_id`; `sandbox.created` adds `template_id` when known, and
+`sandbox.paused` / `sandbox.resumed` add `state`. Every request sets
+`X-Cube-Event` and `X-Cube-Timestamp` headers mirroring the body fields.
+
+See [`../examples/webhook-receiver/`](../examples/webhook-receiver/) for a
+dependency-free receiver with signature verification and replay protection.
+
+Webhook endpoints are trusted operator configuration and may intentionally
+target private or loopback services. Do not expose
+`CUBE_LCM_WEBHOOK_ENDPOINTS` to untrusted users.

--- a/cube-lifecycle-manager/README.md
+++ b/cube-lifecycle-manager/README.md
@@ -60,6 +60,8 @@ export CUBE_LCM_WEBHOOK_ENDPOINTS='[
 ```
 
 - `events` is a filter; omit it (or pass `[]`) to subscribe to every event.
+  Names are validated at startup against the four known events, so a typo
+  fails fast instead of leaving a silently dead subscription.
 - `secret` is optional. When set (minimum 16 bytes), every request carries
   `X-Cube-Signature-256: sha256=<hex HMAC>` over the exact request body.
 

--- a/cube-lifecycle-manager/cmd/cube-lifecycle-manager/main.go
+++ b/cube-lifecycle-manager/cmd/cube-lifecycle-manager/main.go
@@ -29,6 +29,7 @@ import (
 	"github.com/tencentcloud/CubeSandbox/cube-lifecycle-manager/internal/resumer"
 	"github.com/tencentcloud/CubeSandbox/cube-lifecycle-manager/internal/statesync"
 	"github.com/tencentcloud/CubeSandbox/cube-lifecycle-manager/internal/sweeper"
+	"github.com/tencentcloud/CubeSandbox/cube-lifecycle-manager/internal/webhook"
 )
 
 func main() {
@@ -182,6 +183,25 @@ func run() error {
 		Log:       logger.Named("statesync"),
 	}
 
+	// Outbound Webhook workers: one per configured endpoint, each with its
+	// own Redis consumer group so subscriptions are fully isolated from one
+	// another and from the auto-pause/resume loop above.
+	var webhookWorkers []*webhook.Worker
+	if len(cfg.WebhookEndpoints) > 0 {
+		delivery := webhook.DefaultDeliveryConfig()
+		delivery.MaxRetries = cfg.WebhookMaxRetries
+		delivery.Timeout = cfg.WebhookTimeout
+		delivery.RetryBase = cfg.WebhookRetryBase
+		deliverer := webhook.NewDeliverer(delivery, logger.Named("webhook"))
+		for _, ep := range cfg.WebhookEndpoints {
+			webhookWorkers = append(webhookWorkers,
+				webhook.NewWorker(ep, stream, deliverer, cfg.ConsumerName, cfg.StreamReadBlock, logger.Named("webhook")))
+		}
+		loopCount += len(webhookWorkers)
+		logger.Info("webhook delivery enabled",
+			zap.Int("endpoints", len(webhookWorkers)))
+	}
+
 	errs := make(chan error, loopCount)
 	go func() {
 		errs <- consumeStream(rootCtx, stream, pushClient, reg, cfg, stateSyncDeps, logger.Named("stream"))
@@ -191,6 +211,9 @@ func run() error {
 	go func() { errs <- apiSrv.Run(rootCtx) }()
 	if discSvc != nil {
 		go func() { errs <- discSvc.Run(rootCtx) }()
+	}
+	for _, w := range webhookWorkers {
+		go func() { errs <- w.Run(rootCtx) }()
 	}
 
 	// First loop to return wins; we cancel siblings via context and drain.

--- a/cube-lifecycle-manager/internal/config/config.go
+++ b/cube-lifecycle-manager/internal/config/config.go
@@ -11,6 +11,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/tencentcloud/CubeSandbox/cube-lifecycle-manager/internal/webhook"
 )
 
 // Config holds the cube-lifecycle-manager's runtime parameters. The shape is
@@ -76,6 +78,18 @@ type Config struct {
 	HeartbeatTTL time.Duration
 	// DiscoveryRefresh: cadence of the Redis heartbeat scan.
 	DiscoveryRefresh time.Duration
+
+	// Webhook endpoints receive outbound lifecycle event notifications
+	// (sandbox.created/deleted/paused/resumed). Empty disables the feature.
+	// Each endpoint gets its own Redis consumer group, so delivery is
+	// isolated per subscription and at-least-once across restarts.
+	WebhookEndpoints []webhook.Endpoint
+	// WebhookMaxRetries: retries after the initial delivery attempt.
+	WebhookMaxRetries int
+	// WebhookTimeout: per-attempt HTTP timeout for webhook delivery.
+	WebhookTimeout time.Duration
+	// WebhookRetryBase: initial exponential-backoff delay between attempts.
+	WebhookRetryBase time.Duration
 }
 
 // Default returns a config populated with safe defaults; callers then override
@@ -103,6 +117,11 @@ func Default() *Config {
 		UseStaticFleet:   false,
 		HeartbeatTTL:     15 * time.Second,
 		DiscoveryRefresh: 3 * time.Second,
+		// Webhook delivery defaults match the values the CubeAPI-side
+		// implementation used, so behaviour is familiar to operators.
+		WebhookMaxRetries: 3,
+		WebhookTimeout:    5 * time.Second,
+		WebhookRetryBase:  250 * time.Millisecond,
 	}
 }
 
@@ -204,6 +223,38 @@ func Load() (*Config, error) {
 			c.DiscoveryRefresh = d
 		}
 	}
+	if v := os.Getenv("CUBE_LCM_WEBHOOK_ENDPOINTS"); v != "" {
+		endpoints, err := webhook.ParseEndpoints(v)
+		if err != nil {
+			addErr("CUBE_LCM_WEBHOOK_ENDPOINTS", err)
+		} else {
+			c.WebhookEndpoints = endpoints
+		}
+	}
+	if v := os.Getenv("CUBE_LCM_WEBHOOK_MAX_RETRIES"); v != "" {
+		n, err := strconv.Atoi(v)
+		if err != nil {
+			addErr("CUBE_LCM_WEBHOOK_MAX_RETRIES", err)
+		} else if n < 0 {
+			addErr("CUBE_LCM_WEBHOOK_MAX_RETRIES", errors.New("must be >= 0"))
+		} else {
+			c.WebhookMaxRetries = n
+		}
+	}
+	if v := os.Getenv("CUBE_LCM_WEBHOOK_TIMEOUT"); v != "" {
+		if d, err := time.ParseDuration(v); err != nil {
+			addErr("CUBE_LCM_WEBHOOK_TIMEOUT", err)
+		} else {
+			c.WebhookTimeout = d
+		}
+	}
+	if v := os.Getenv("CUBE_LCM_WEBHOOK_RETRY_BASE"); v != "" {
+		if d, err := time.ParseDuration(v); err != nil {
+			addErr("CUBE_LCM_WEBHOOK_RETRY_BASE", err)
+		} else {
+			c.WebhookRetryBase = d
+		}
+	}
 
 	if c.ConsumerName == "" {
 		host, err := os.Hostname()
@@ -243,6 +294,14 @@ func (c *Config) Validate() error {
 	}
 	if c.LastActivePoll <= 0 {
 		return errors.New("last active poll must be > 0")
+	}
+	if len(c.WebhookEndpoints) > 0 {
+		if c.WebhookTimeout <= 0 {
+			return errors.New("webhook timeout must be > 0")
+		}
+		if c.WebhookRetryBase < 0 {
+			return errors.New("webhook retry base must be >= 0")
+		}
 	}
 	return nil
 }

--- a/cube-lifecycle-manager/internal/redisstream/stream.go
+++ b/cube-lifecycle-manager/internal/redisstream/stream.go
@@ -106,7 +106,34 @@ func (c *Client) ReadGroup(ctx context.Context, group, consumer string, block ti
 		}
 		return nil, fmt.Errorf("xreadgroup: %w", err)
 	}
+	return c.decodeMessages(ctx, group, res), nil
+}
 
+// ReadPending returns up to `count` entries that were already delivered to
+// this consumer but never acknowledged (its pending-entries list). Unlike
+// ReadGroup it never blocks: an empty result means the list is drained.
+// Consumers use it on startup to redeliver events a previous run failed to
+// finish, which is what makes delivery at-least-once across restarts.
+func (c *Client) ReadPending(ctx context.Context, group, consumer string, count int) ([]Event, error) {
+	res, err := c.rdb.XReadGroup(ctx, &redis.XReadGroupArgs{
+		Group:    group,
+		Consumer: consumer,
+		Streams:  []string{lifecycle.EventStreamKey, "0"},
+		Count:    int64(count),
+	}).Result()
+
+	if errors.Is(err, redis.Nil) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("xreadgroup pending: %w", err)
+	}
+	return c.decodeMessages(ctx, group, res), nil
+}
+
+// decodeMessages decodes raw XREADGROUP results, acking (and dropping) any
+// entry that cannot be parsed so a poisoned entry cannot stall the group.
+func (c *Client) decodeMessages(ctx context.Context, group string, res []redis.XStream) []Event {
 	var out []Event
 	for _, stream := range res {
 		for _, msg := range stream.Messages {
@@ -121,7 +148,7 @@ func (c *Client) ReadGroup(ctx context.Context, group, consumer string, block ti
 			}
 		}
 	}
-	return out, nil
+	return out
 }
 
 // Ack marks the event as processed so it leaves the consumer's pending list.

--- a/cube-lifecycle-manager/internal/webhook/config.go
+++ b/cube-lifecycle-manager/internal/webhook/config.go
@@ -70,10 +70,26 @@ func (e Endpoint) validate() error {
 	if u.User != nil {
 		return fmt.Errorf("URL must not contain userinfo credentials: %q", e.URL)
 	}
+	// A misspelled event name can never match a stream entry, so accepting
+	// it would leave a silently dead subscription. Fail fast instead.
+	for _, ev := range e.Events {
+		if !validEvents[ev] {
+			return fmt.Errorf("unknown event %q (valid: %s, %s, %s, %s)",
+				ev, EventCreated, EventDeleted, EventPaused, EventResumed)
+		}
+	}
 	if e.Secret != "" && len(e.Secret) < 16 {
 		return fmt.Errorf("secret must be at least 16 bytes")
 	}
 	return nil
+}
+
+// validEvents is the set of event names a subscription filter may use.
+var validEvents = map[string]bool{
+	EventCreated: true,
+	EventDeleted: true,
+	EventPaused:  true,
+	EventResumed: true,
 }
 
 // Subscribes reports whether the endpoint wants the named event. An empty
@@ -112,7 +128,9 @@ func (e Endpoint) Group() string {
 }
 
 // Label returns the endpoint URL sanitized for logs: credentials, query, and
-// fragment are stripped so tokens inside the URL never reach log output.
+// fragment are stripped so tokens inside the URL never reach log output. The
+// path is preserved by design so operators can tell endpoints apart in log
+// lines — do not embed secrets in the path; use the Secret field instead.
 func (e Endpoint) Label() string {
 	u, err := url.Parse(e.URL)
 	if err != nil {

--- a/cube-lifecycle-manager/internal/webhook/config.go
+++ b/cube-lifecycle-manager/internal/webhook/config.go
@@ -1,0 +1,125 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+// Package webhook delivers sandbox lifecycle events (created / deleted /
+// paused / resumed) to external, operator-configured HTTP endpoints.
+//
+// Each endpoint owns an independent Redis consumer group on the lifecycle
+// events stream, so a slow or unreachable receiver never delays other
+// subscriptions or the CLM's own auto-pause/resume loop. Delivery is
+// at-least-once: an event is XACKed only after it reaches a terminal state
+// (delivered, permanently rejected, or retries exhausted), so a crashed
+// replica redelivers its pending events after restart.
+package webhook
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"sort"
+	"strings"
+)
+
+// Endpoint is one outbound Webhook subscription. It mirrors the endpoint
+// shape used by the CubeAPI-side Webhook configuration so operators can move
+// between the two without reformatting.
+type Endpoint struct {
+	// URL is the HTTP(S) receiver address. Userinfo credentials are
+	// rejected: use Secret for authentication instead.
+	URL string `json:"url"`
+	// Events lists the subscribed event names (e.g. "sandbox.created").
+	// Empty subscribes to every lifecycle event.
+	Events []string `json:"events,omitempty"`
+	// Secret, when non-empty, enables HMAC-SHA256 signing of the exact
+	// request body in the X-Cube-Signature-256 header. Must be at least
+	// 16 bytes; empty means unsigned.
+	Secret string `json:"secret,omitempty"`
+}
+
+// ParseEndpoints decodes the JSON array carried by CUBE_LCM_WEBHOOK_ENDPOINTS
+// and validates every entry. An empty input yields no endpoints (feature
+// disabled); a malformed entry fails the whole parse so a typo never
+// silently drops a subscription.
+func ParseEndpoints(raw string) ([]Endpoint, error) {
+	if strings.TrimSpace(raw) == "" {
+		return nil, nil
+	}
+	var endpoints []Endpoint
+	if err := json.Unmarshal([]byte(raw), &endpoints); err != nil {
+		return nil, fmt.Errorf("webhook endpoints: invalid JSON: %w", err)
+	}
+	for i, ep := range endpoints {
+		if err := ep.validate(); err != nil {
+			return nil, fmt.Errorf("webhook endpoints[%d]: %w", i, err)
+		}
+	}
+	return endpoints, nil
+}
+
+func (e Endpoint) validate() error {
+	u, err := url.Parse(e.URL)
+	if err != nil || u.Host == "" {
+		return fmt.Errorf("invalid URL %q", e.URL)
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return fmt.Errorf("URL must use http or https: %q", e.URL)
+	}
+	if u.User != nil {
+		return fmt.Errorf("URL must not contain userinfo credentials: %q", e.URL)
+	}
+	if e.Secret != "" && len(e.Secret) < 16 {
+		return fmt.Errorf("secret must be at least 16 bytes")
+	}
+	return nil
+}
+
+// Subscribes reports whether the endpoint wants the named event. An empty
+// Events list is the wildcard subscription.
+func (e Endpoint) Subscribes(event string) bool {
+	if len(e.Events) == 0 {
+		return true
+	}
+	for _, item := range e.Events {
+		if item == event {
+			return true
+		}
+	}
+	return false
+}
+
+// Group returns the endpoint's Redis consumer group name on the lifecycle
+// events stream. The name is derived from the URL and the (sorted) event
+// filter so that:
+//   - every CLM replica derives the same group for the same subscription
+//     (replicas share the group and split the work via consumer names);
+//   - two subscriptions with different filters never share a group, which
+//     would split the stream between them and break the filters;
+//   - the group is disjoint from the CLM's own "cube-proxy-sidecar" group,
+//     so webhook delivery cannot disturb auto-pause/resume.
+func (e Endpoint) Group() string {
+	h := sha256.New()
+	h.Write([]byte(e.URL))
+	events := append([]string(nil), e.Events...)
+	sort.Strings(events)
+	for _, ev := range events {
+		h.Write([]byte{0})
+		h.Write([]byte(ev))
+	}
+	return "webhook:" + hex.EncodeToString(h.Sum(nil))[:12]
+}
+
+// Label returns the endpoint URL sanitized for logs: credentials, query, and
+// fragment are stripped so tokens inside the URL never reach log output.
+func (e Endpoint) Label() string {
+	u, err := url.Parse(e.URL)
+	if err != nil {
+		return "<invalid webhook URL>"
+	}
+	u.User = nil
+	u.RawQuery = ""
+	u.Fragment = ""
+	return u.String()
+}

--- a/cube-lifecycle-manager/internal/webhook/config_test.go
+++ b/cube-lifecycle-manager/internal/webhook/config_test.go
@@ -1,0 +1,119 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package webhook
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseEndpoints_Valid(t *testing.T) {
+	raw := `[
+		{"url": "https://ops.example.com/hook", "events": ["sandbox.created"], "secret": "0123456789abcdef"},
+		{"url": "http://127.0.0.1:9010/webhooks/cube"}
+	]`
+	endpoints, err := ParseEndpoints(raw)
+	if err != nil {
+		t.Fatalf("ParseEndpoints: %v", err)
+	}
+	if len(endpoints) != 2 {
+		t.Fatalf("got %d endpoints, want 2", len(endpoints))
+	}
+	if endpoints[0].Secret != "0123456789abcdef" {
+		t.Fatalf("secret not parsed: %q", endpoints[0].Secret)
+	}
+	if endpoints[1].Events != nil {
+		t.Fatalf("events must default to nil (wildcard): %v", endpoints[1].Events)
+	}
+}
+
+func TestParseEndpoints_EmptyDisablesFeature(t *testing.T) {
+	for _, raw := range []string{"", "   "} {
+		endpoints, err := ParseEndpoints(raw)
+		if err != nil || endpoints != nil {
+			t.Fatalf("raw %q: got (%v, %v), want (nil, nil)", raw, endpoints, err)
+		}
+	}
+}
+
+func TestParseEndpoints_RejectsBadEntries(t *testing.T) {
+	cases := map[string]string{
+		"not json":       `not-json`,
+		"bad scheme":     `[{"url": "ftp://example.com/hook"}]`,
+		"missing host":   `[{"url": "https:///path"}]`,
+		"userinfo":       `[{"url": "https://user:pw@example.com/hook"}]`,
+		"short secret":   `[{"url": "https://example.com/hook", "secret": "short"}]`,
+		"trailing entry": `[{"url": "https://ok.example.com"}, {"url": "::bad::"}]`,
+	}
+	for name, raw := range cases {
+		if _, err := ParseEndpoints(raw); err == nil {
+			t.Fatalf("%s: expected error, got nil", name)
+		}
+	}
+	// A failure anywhere must not yield a partial list.
+	if endpoints, _ := ParseEndpoints(cases["trailing entry"]); endpoints != nil {
+		t.Fatal("partial endpoint list returned on error")
+	}
+}
+
+func TestEndpointSubscribes(t *testing.T) {
+	selected := Endpoint{URL: "http://x", Events: []string{EventCreated}}
+	if !selected.Subscribes(EventCreated) || selected.Subscribes(EventDeleted) {
+		t.Fatal("filtered subscription mismatch")
+	}
+	wildcard := Endpoint{URL: "http://x"}
+	if !wildcard.Subscribes(EventDeleted) {
+		t.Fatal("empty events must subscribe to everything")
+	}
+}
+
+func TestEndpointGroup(t *testing.T) {
+	a := Endpoint{URL: "http://x/hook", Events: []string{EventCreated, EventDeleted}}
+	// Filter order must not change the group.
+	b := Endpoint{URL: "http://x/hook", Events: []string{EventDeleted, EventCreated}}
+	if a.Group() != b.Group() {
+		t.Fatalf("group must be filter-order independent: %q vs %q", a.Group(), b.Group())
+	}
+	if !strings.HasPrefix(a.Group(), "webhook:") {
+		t.Fatalf("group name must be namespaced: %q", a.Group())
+	}
+	// A different filter (or URL) must yield a different group, otherwise the
+	// stream would be split between subscribers with different filters.
+	c := Endpoint{URL: "http://x/hook", Events: []string{EventCreated}}
+	if a.Group() == c.Group() {
+		t.Fatal("different filters must not share a consumer group")
+	}
+	d := Endpoint{URL: "http://y/hook", Events: []string{EventCreated, EventDeleted}}
+	if a.Group() == d.Group() {
+		t.Fatal("different URLs must not share a consumer group")
+	}
+	// The secret never enters the group name: it must not leak into Redis
+	// keyspace metadata, and re-keying must not re-read history.
+	e := a
+	e.Secret = "0123456789abcdef"
+	if a.Group() != e.Group() {
+		t.Fatal("secret must not affect the consumer group")
+	}
+}
+
+func TestEndpointLabel(t *testing.T) {
+	ep := Endpoint{URL: "https://user:secret@example.com/hook?token=secret#fragment"}
+	if got := ep.Label(); got != "https://example.com/hook" {
+		t.Fatalf("label = %q", got)
+	}
+	bad := Endpoint{URL: "::not-a-url::"}
+	if got := bad.Label(); got != "<invalid webhook URL>" {
+		t.Fatalf("bad label = %q", got)
+	}
+}
+
+func TestSign(t *testing.T) {
+	// Same vector as the CubeAPI-side implementation: wire compatibility.
+	got := sign("secret", []byte("payload"))
+	want := "sha256=b82fcb791acec57859b989b430a826488ce2e479fdf92326bd0a2e8375a42ba4"
+	if got != want {
+		t.Fatalf("sign = %q, want %q", got, want)
+	}
+}

--- a/cube-lifecycle-manager/internal/webhook/config_test.go
+++ b/cube-lifecycle-manager/internal/webhook/config_test.go
@@ -46,6 +46,8 @@ func TestParseEndpoints_RejectsBadEntries(t *testing.T) {
 		"userinfo":       `[{"url": "https://user:pw@example.com/hook"}]`,
 		"short secret":   `[{"url": "https://example.com/hook", "secret": "short"}]`,
 		"trailing entry": `[{"url": "https://ok.example.com"}, {"url": "::bad::"}]`,
+		// A misspelled event name would silently never match; reject it.
+		"unknown event": `[{"url": "https://example.com/hook", "events": ["sandbox.creaetd"]}]`,
 	}
 	for name, raw := range cases {
 		if _, err := ParseEndpoints(raw); err == nil {
@@ -55,6 +57,15 @@ func TestParseEndpoints_RejectsBadEntries(t *testing.T) {
 	// A failure anywhere must not yield a partial list.
 	if endpoints, _ := ParseEndpoints(cases["trailing entry"]); endpoints != nil {
 		t.Fatal("partial endpoint list returned on error")
+	}
+}
+
+func TestParseEndpoints_AcceptsAllKnownEvents(t *testing.T) {
+	raw := `[{"url": "https://example.com/hook", "events": [
+		"sandbox.created", "sandbox.deleted", "sandbox.paused", "sandbox.resumed"
+	]}]`
+	if _, err := ParseEndpoints(raw); err != nil {
+		t.Fatalf("all known events must parse: %v", err)
 	}
 }
 

--- a/cube-lifecycle-manager/internal/webhook/deliver.go
+++ b/cube-lifecycle-manager/internal/webhook/deliver.go
@@ -1,0 +1,193 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package webhook
+
+import (
+	"bytes"
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"math/rand/v2"
+	"net/http"
+	"time"
+
+	"go.uber.org/zap"
+)
+
+// DeliveryConfig tunes the retry behaviour of a single event delivery.
+type DeliveryConfig struct {
+	// MaxRetries is the number of retries after the initial HTTP request.
+	MaxRetries int
+	// Timeout bounds each individual HTTP attempt.
+	Timeout time.Duration
+	// RetryBase is the initial exponential-backoff delay.
+	RetryBase time.Duration
+	// MaxDuration caps the whole delivery including retries and backoff.
+	MaxDuration time.Duration
+}
+
+// DefaultDeliveryConfig matches the values the CubeAPI-side Webhook
+// implementation shipped with, keeping behaviour consistent for operators.
+func DefaultDeliveryConfig() DeliveryConfig {
+	return DeliveryConfig{
+		MaxRetries:  3,
+		Timeout:     5 * time.Second,
+		RetryBase:   250 * time.Millisecond,
+		MaxDuration: 30 * time.Second,
+	}
+}
+
+// Deliverer POSTs prepared event bodies to endpoints with bounded retries.
+// It is safe for concurrent use by all endpoint workers.
+type Deliverer struct {
+	cfg   DeliveryConfig
+	httpc *http.Client
+	log   *zap.Logger
+}
+
+// NewDeliverer builds a Deliverer. Redirects are disabled so a configured
+// public endpoint cannot bounce delivery to an internal service (SSRF).
+func NewDeliverer(cfg DeliveryConfig, log *zap.Logger) *Deliverer {
+	return &Deliverer{
+		cfg: cfg,
+		httpc: &http.Client{
+			Timeout: cfg.Timeout,
+			CheckRedirect: func(*http.Request, []*http.Request) error {
+				return http.ErrUseLastResponse
+			},
+		},
+		log: log,
+	}
+}
+
+// Deliver posts body to the endpoint until it succeeds, is permanently
+// rejected, or the retry budget runs out. A nil return means the receiver
+// acknowledged the event with a 2xx. Any non-nil return is terminal for this
+// delivery attempt — the caller decides whether the stream entry is ACKed
+// (terminal failure) or kept pending (shutdown interrupted the delivery).
+func (d *Deliverer) Deliver(ctx context.Context, ep Endpoint, body []byte, event, timestamp string) error {
+	ctx, cancel := context.WithTimeout(ctx, d.cfg.MaxDuration)
+	defer cancel()
+
+	// The body is immutable across attempts, so the signature is computed
+	// once up front.
+	var signature string
+	if ep.Secret != "" {
+		signature = sign(ep.Secret, body)
+	}
+	label := ep.Label()
+
+	for attempt := 0; ; attempt++ {
+		err := d.post(ctx, ep.URL, body, event, timestamp, signature)
+		if err == nil {
+			return nil
+		}
+		if ctx.Err() != nil {
+			// Total deadline hit or the process is shutting down; the
+			// caller tells the two apart via its own context.
+			return fmt.Errorf("webhook delivery of %s to %s interrupted: %w", event, label, ctx.Err())
+		}
+		var rejected *rejectedError
+		if errors.As(err, &rejected) {
+			d.log.Warn("webhook delivery rejected without retry",
+				zap.String("url", label),
+				zap.String("event", event),
+				zap.Int("status", rejected.status))
+			return err
+		}
+		d.log.Warn("webhook delivery failed",
+			zap.String("url", label),
+			zap.String("event", event),
+			zap.Int("attempt", attempt),
+			zap.Error(err))
+		if attempt >= d.cfg.MaxRetries {
+			d.log.Error("webhook delivery exhausted retries",
+				zap.String("url", label),
+				zap.String("event", event),
+				zap.Int("attempts", attempt+1))
+			return fmt.Errorf("webhook delivery of %s to %s exhausted %d retries: %w",
+				event, label, d.cfg.MaxRetries, err)
+		}
+		timer := time.NewTimer(retryDelay(d.cfg.RetryBase, attempt))
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+		case <-timer.C:
+		}
+	}
+}
+
+// rejectedError marks a non-retryable HTTP response (4xx other than 408/429,
+// or a 3xx left unfollowed because redirects are disabled).
+type rejectedError struct {
+	status int
+	body   string
+}
+
+func (e *rejectedError) Error() string {
+	return fmt.Sprintf("status=%d body=%q", e.status, e.body)
+}
+
+// post performs one HTTP attempt. A nil error means 2xx.
+func (d *Deliverer) post(ctx context.Context, url string, body []byte, event, timestamp, signature string) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		// The URL was validated at config load; this is unreachable in
+		// practice, but treat it as permanent rather than retrying forever.
+		return &rejectedError{status: 0, body: err.Error()}
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Cube-Event", event)
+	req.Header.Set("X-Cube-Timestamp", timestamp)
+	if signature != "" {
+		req.Header.Set("X-Cube-Signature-256", signature)
+	}
+
+	resp, err := d.httpc.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode/100 == 2 {
+		// Drain so the connection can be reused.
+		_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 1<<20))
+		return nil
+	}
+	respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+	if !shouldRetryStatus(resp.StatusCode) {
+		return &rejectedError{status: resp.StatusCode, body: string(respBody)}
+	}
+	return fmt.Errorf("status=%d body=%q", resp.StatusCode, respBody)
+}
+
+// shouldRetryStatus classifies transient receiver failures: server errors,
+// request timeout, and rate limiting. Every other status is permanent.
+func shouldRetryStatus(status int) bool {
+	return status/100 == 5 || status == http.StatusRequestTimeout || status == http.StatusTooManyRequests
+}
+
+// retryDelay returns base * 2^attempt plus up to 50% jitter, mirroring the
+// CubeAPI-side implementation so retry cadence is identical for operators.
+func retryDelay(base time.Duration, attempt int) time.Duration {
+	shift := min(attempt, 16)
+	exponential := base << shift
+	maxJitter := int64(exponential / 2)
+	if maxJitter <= 0 {
+		return exponential
+	}
+	return exponential + time.Duration(rand.Int64N(maxJitter+1))
+}
+
+// sign returns the X-Cube-Signature-256 value for the exact request body.
+func sign(secret string, body []byte) string {
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write(body)
+	return "sha256=" + hex.EncodeToString(mac.Sum(nil))
+}

--- a/cube-lifecycle-manager/internal/webhook/deliver_test.go
+++ b/cube-lifecycle-manager/internal/webhook/deliver_test.go
@@ -1,0 +1,256 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package webhook
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"go.uber.org/zap"
+)
+
+type capturedRequest struct {
+	header http.Header
+	body   []byte
+}
+
+// receiver collects requests and answers with the queued status codes
+// (defaulting to 204 once the queue runs dry).
+type receiver struct {
+	mu       sync.Mutex
+	statuses []int
+	requests []capturedRequest
+	// block, when non-nil, makes every handler call wait on it — used to
+	// force client-side timeouts.
+	block <-chan struct{}
+}
+
+func (r *receiver) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	body, _ := io.ReadAll(req.Body)
+	r.mu.Lock()
+	r.requests = append(r.requests, capturedRequest{header: req.Header.Clone(), body: body})
+	status := http.StatusNoContent
+	if len(r.statuses) > 0 {
+		status = r.statuses[0]
+		r.statuses = r.statuses[1:]
+	}
+	block := r.block
+	r.mu.Unlock()
+	if block != nil {
+		<-block
+	}
+	if status/100 == 3 {
+		w.Header().Set("Location", "http://127.0.0.1:1/elsewhere")
+	}
+	w.WriteHeader(status)
+}
+
+func (r *receiver) count() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return len(r.requests)
+}
+
+func (r *receiver) got(i int) capturedRequest {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.requests[i]
+}
+
+func testConfig() DeliveryConfig {
+	return DeliveryConfig{
+		MaxRetries:  3,
+		Timeout:     5 * time.Second,
+		RetryBase:   0, // keep tests fast; backoff math is covered separately
+		MaxDuration: 30 * time.Second,
+	}
+}
+
+func newTestDeliverer(cfg DeliveryConfig) *Deliverer {
+	return NewDeliverer(cfg, zap.NewNop())
+}
+
+func TestDeliver_SuccessWithExactHeadersAndSignature(t *testing.T) {
+	r := &receiver{}
+	srv := httptest.NewServer(r)
+	defer srv.Close()
+
+	ep := Endpoint{URL: srv.URL, Secret: "0123456789abcdef"}
+	body := []byte(`{"version":"1","event":"sandbox.created"}`)
+	d := newTestDeliverer(testConfig())
+	if err := d.Deliver(context.Background(), ep, body, EventCreated, "2026-07-29T08:00:00Z"); err != nil {
+		t.Fatalf("Deliver: %v", err)
+	}
+	if r.count() != 1 {
+		t.Fatalf("requests = %d, want 1", r.count())
+	}
+	req := r.got(0)
+	if got := req.header.Get("Content-Type"); got != "application/json" {
+		t.Fatalf("content-type = %q", got)
+	}
+	if got := req.header.Get("X-Cube-Event"); got != EventCreated {
+		t.Fatalf("x-cube-event = %q", got)
+	}
+	if got := req.header.Get("X-Cube-Timestamp"); got != "2026-07-29T08:00:00Z" {
+		t.Fatalf("x-cube-timestamp = %q", got)
+	}
+	// The signature must cover the exact bytes received, not a re-serialization.
+	if got, want := req.header.Get("X-Cube-Signature-256"), sign(ep.Secret, req.body); got != want {
+		t.Fatalf("signature = %q, want %q", got, want)
+	}
+}
+
+func TestDeliver_OmitsSignatureWithoutSecret(t *testing.T) {
+	r := &receiver{}
+	srv := httptest.NewServer(r)
+	defer srv.Close()
+
+	d := newTestDeliverer(testConfig())
+	if err := d.Deliver(context.Background(), Endpoint{URL: srv.URL}, []byte(`{}`), EventDeleted, "ts"); err != nil {
+		t.Fatalf("Deliver: %v", err)
+	}
+	if got := r.got(0).header.Get("X-Cube-Signature-256"); got != "" {
+		t.Fatalf("unexpected signature header %q", got)
+	}
+}
+
+func TestDeliver_RetriesTransientStatusesUntilSuccess(t *testing.T) {
+	r := &receiver{statuses: []int{
+		http.StatusInternalServerError,
+		http.StatusRequestTimeout,
+		http.StatusTooManyRequests,
+		http.StatusNoContent,
+	}}
+	srv := httptest.NewServer(r)
+	defer srv.Close()
+
+	d := newTestDeliverer(testConfig())
+	if err := d.Deliver(context.Background(), Endpoint{URL: srv.URL}, []byte(`{}`), EventCreated, "ts"); err != nil {
+		t.Fatalf("Deliver: %v", err)
+	}
+	if r.count() != 4 {
+		t.Fatalf("requests = %d, want 4", r.count())
+	}
+}
+
+func TestDeliver_DoesNotRetryPermanentClientError(t *testing.T) {
+	r := &receiver{statuses: []int{http.StatusBadRequest}}
+	srv := httptest.NewServer(r)
+	defer srv.Close()
+
+	d := newTestDeliverer(testConfig())
+	err := d.Deliver(context.Background(), Endpoint{URL: srv.URL}, []byte(`{}`), EventCreated, "ts")
+	if err == nil {
+		t.Fatal("expected error on 400")
+	}
+	if r.count() != 1 {
+		t.Fatalf("requests = %d, want 1 (no retry on 4xx)", r.count())
+	}
+}
+
+func TestDeliver_StopsAfterConfiguredRetryLimit(t *testing.T) {
+	r := &receiver{statuses: []int{500, 500, 500, 500}}
+	srv := httptest.NewServer(r)
+	defer srv.Close()
+
+	cfg := testConfig()
+	cfg.MaxRetries = 2
+	d := newTestDeliverer(cfg)
+	if err := d.Deliver(context.Background(), Endpoint{URL: srv.URL}, []byte(`{}`), EventCreated, "ts"); err == nil {
+		t.Fatal("expected exhausted-retries error")
+	}
+	if r.count() != 3 {
+		t.Fatalf("requests = %d, want 3 (1 + 2 retries)", r.count())
+	}
+}
+
+func TestDeliver_RetriesTimedOutRequests(t *testing.T) {
+	gate := make(chan struct{})
+	r := &receiver{block: gate}
+	srv := httptest.NewServer(r)
+	defer srv.Close()
+	defer close(gate)
+
+	cfg := testConfig()
+	cfg.MaxRetries = 1
+	cfg.Timeout = 100 * time.Millisecond
+	d := newTestDeliverer(cfg)
+	if err := d.Deliver(context.Background(), Endpoint{URL: srv.URL}, []byte(`{}`), EventCreated, "ts"); err == nil {
+		t.Fatal("expected timeout error")
+	}
+	if r.count() != 2 {
+		t.Fatalf("requests = %d, want 2", r.count())
+	}
+}
+
+func TestDeliver_CapsTotalDeliveryDuration(t *testing.T) {
+	gate := make(chan struct{})
+	r := &receiver{block: gate}
+	srv := httptest.NewServer(r)
+	defer srv.Close()
+	defer close(gate)
+
+	cfg := testConfig()
+	cfg.MaxRetries = 1000                   // effectively unbounded retries...
+	cfg.MaxDuration = 50 * time.Millisecond // ...but the total cap wins
+	d := newTestDeliverer(cfg)
+	start := time.Now()
+	if err := d.Deliver(context.Background(), Endpoint{URL: srv.URL}, []byte(`{}`), EventCreated, "ts"); err == nil {
+		t.Fatal("expected deadline error")
+	}
+	if elapsed := time.Since(start); elapsed > 2*time.Second {
+		t.Fatalf("delivery ran %v, want it capped near 50ms", elapsed)
+	}
+	if r.count() != 1 {
+		t.Fatalf("requests = %d, want 1", r.count())
+	}
+}
+
+func TestDeliver_DoesNotFollowRedirects(t *testing.T) {
+	r := &receiver{statuses: []int{http.StatusFound}}
+	srv := httptest.NewServer(r)
+	defer srv.Close()
+
+	d := newTestDeliverer(testConfig())
+	err := d.Deliver(context.Background(), Endpoint{URL: srv.URL}, []byte(`{}`), EventCreated, "ts")
+	if err == nil {
+		t.Fatal("expected terminal rejection on 302")
+	}
+	if r.count() != 1 {
+		t.Fatalf("requests = %d, want 1 (redirect neither followed nor retried)", r.count())
+	}
+}
+
+func TestShouldRetryStatus(t *testing.T) {
+	cases := map[int]bool{
+		500: true, 502: true, 503: true,
+		http.StatusRequestTimeout:  true,
+		http.StatusTooManyRequests: true,
+		200:                        false, 302: false, 400: false, 401: false, 404: false,
+	}
+	for status, want := range cases {
+		if got := shouldRetryStatus(status); got != want {
+			t.Fatalf("shouldRetryStatus(%d) = %v, want %v", status, got, want)
+		}
+	}
+}
+
+func TestRetryDelay(t *testing.T) {
+	if got := retryDelay(0, 4); got != 0 {
+		t.Fatalf("zero base must stay zero, got %v", got)
+	}
+	base := 100 * time.Millisecond
+	for i := 0; i < 50; i++ {
+		got := retryDelay(base, 2)
+		if got < 400*time.Millisecond || got > 600*time.Millisecond {
+			t.Fatalf("delay %v outside [400ms, 600ms]", got)
+		}
+	}
+}

--- a/cube-lifecycle-manager/internal/webhook/payload.go
+++ b/cube-lifecycle-manager/internal/webhook/payload.go
@@ -1,0 +1,91 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package webhook
+
+import (
+	"time"
+
+	"github.com/tencentcloud/CubeSandbox/cube-lifecycle-manager/internal/lifecycle"
+	"github.com/tencentcloud/CubeSandbox/cube-lifecycle-manager/internal/redisstream"
+)
+
+// Event names delivered to Webhook endpoints.
+const (
+	EventCreated = "sandbox.created"
+	EventDeleted = "sandbox.deleted"
+	EventPaused  = "sandbox.paused"
+	EventResumed = "sandbox.resumed"
+)
+
+// PayloadVersion identifies the payload schema so receivers can evolve
+// parsing logic when a future version adds or renames fields.
+const PayloadVersion = "1"
+
+// Payload is the JSON body POSTed to a Webhook endpoint. The exact serialized
+// bytes are what the HMAC signature covers, so fields are ordered and
+// omitted deterministically via struct tags.
+type Payload struct {
+	Version   string `json:"version"`
+	Event     string `json:"event"`
+	Timestamp string `json:"timestamp"` // RFC 3339, mirrors X-Cube-Timestamp
+	SandboxID string `json:"sandbox_id"`
+	// TemplateID is set for sandbox.created when the stream event carries
+	// lifecycle metadata.
+	TemplateID string `json:"template_id,omitempty"`
+	// State is the terminal runtime state for sandbox.paused ("paused") and
+	// sandbox.resumed ("running").
+	State string `json:"state,omitempty"`
+}
+
+// MapEvent converts a lifecycle stream event into its Webhook payload.
+// It returns nil for events that are not external lifecycle transitions
+// (metadata updates, transition markers, unknown ops, or state events with
+// no usable payload), which the caller simply ACKs and skips.
+//
+// The payload timestamp prefers the stream entry's own timestamp (written by
+// CubeMaster when the transition happened) over the consumption time, so
+// redelivered events keep their original event time.
+func MapEvent(ev redisstream.Event, now func() time.Time) *Payload {
+	if now == nil {
+		now = time.Now
+	}
+	ts := now()
+	if ev.Timestamp > 0 {
+		ts = time.UnixMilli(ev.Timestamp)
+	}
+	p := &Payload{
+		Version:   PayloadVersion,
+		Timestamp: ts.UTC().Format(time.RFC3339),
+		SandboxID: ev.SandboxID,
+	}
+	switch ev.Op {
+	case lifecycle.OpCreate:
+		p.Event = EventCreated
+		if ev.Meta != nil {
+			p.TemplateID = ev.Meta.TemplateID
+		}
+	case lifecycle.OpDelete:
+		p.Event = EventDeleted
+	case lifecycle.OpState:
+		if ev.State == nil {
+			return nil
+		}
+		switch ev.State.State {
+		case lifecycle.StatePaused:
+			p.Event = EventPaused
+			p.State = lifecycle.StatePaused
+		case lifecycle.StateRunning:
+			p.Event = EventResumed
+			p.State = lifecycle.StateRunning
+		default:
+			// Transition markers ("pausing" / "resuming") are private to
+			// CLM coordination and must never leave the cluster.
+			return nil
+		}
+	default:
+		return nil
+	}
+	return p
+}

--- a/cube-lifecycle-manager/internal/webhook/payload_test.go
+++ b/cube-lifecycle-manager/internal/webhook/payload_test.go
@@ -1,0 +1,119 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package webhook
+
+import (
+	"testing"
+	"time"
+
+	"github.com/tencentcloud/CubeSandbox/cube-lifecycle-manager/internal/lifecycle"
+	"github.com/tencentcloud/CubeSandbox/cube-lifecycle-manager/internal/redisstream"
+)
+
+func TestMapEvent_Create(t *testing.T) {
+	ev := redisstream.Event{
+		StreamID:  "1-0",
+		Op:        lifecycle.OpCreate,
+		SandboxID: "sbx-1",
+		Meta: &lifecycle.SandboxLifecycleMeta{
+			SandboxID:  "sbx-1",
+			TemplateID: "tpl-9",
+		},
+		Timestamp: 1700000000000,
+	}
+	p := MapEvent(ev, nil)
+	if p == nil {
+		t.Fatal("MapEvent returned nil for create")
+	}
+	if p.Event != EventCreated || p.SandboxID != "sbx-1" || p.TemplateID != "tpl-9" {
+		t.Fatalf("wrong payload: %+v", p)
+	}
+	if p.Version != PayloadVersion {
+		t.Fatalf("version = %q", p.Version)
+	}
+	want := time.UnixMilli(1700000000000).UTC().Format(time.RFC3339)
+	if p.Timestamp != want {
+		t.Fatalf("timestamp = %q, want %q", p.Timestamp, want)
+	}
+	if p.State != "" {
+		t.Fatalf("create must not carry state: %+v", p)
+	}
+}
+
+func TestMapEvent_CreateWithoutMeta(t *testing.T) {
+	ev := redisstream.Event{Op: lifecycle.OpCreate, SandboxID: "sbx-1", Timestamp: 1}
+	p := MapEvent(ev, nil)
+	if p == nil || p.Event != EventCreated {
+		t.Fatalf("create without meta must still map: %+v", p)
+	}
+	if p.TemplateID != "" {
+		t.Fatalf("template id must be empty: %+v", p)
+	}
+}
+
+func TestMapEvent_Delete(t *testing.T) {
+	ev := redisstream.Event{Op: lifecycle.OpDelete, SandboxID: "sbx-1", Timestamp: 1}
+	p := MapEvent(ev, nil)
+	if p == nil || p.Event != EventDeleted || p.SandboxID != "sbx-1" {
+		t.Fatalf("wrong delete payload: %+v", p)
+	}
+}
+
+func TestMapEvent_State(t *testing.T) {
+	cases := []struct {
+		state string
+		event string
+	}{
+		{lifecycle.StatePaused, EventPaused},
+		{lifecycle.StateRunning, EventResumed},
+	}
+	for _, tc := range cases {
+		ev := redisstream.Event{
+			Op:        lifecycle.OpState,
+			SandboxID: "sbx-1",
+			State:     &lifecycle.StatePayload{State: tc.state},
+			Timestamp: 1,
+		}
+		p := MapEvent(ev, nil)
+		if p == nil {
+			t.Fatalf("state %q: MapEvent returned nil", tc.state)
+		}
+		if p.Event != tc.event || p.State != tc.state {
+			t.Fatalf("state %q: wrong payload %+v", tc.state, p)
+		}
+	}
+}
+
+func TestMapEvent_SkipsNonTransitions(t *testing.T) {
+	cases := map[string]redisstream.Event{
+		"metadata update":       {Op: lifecycle.OpUpdate, SandboxID: "sbx-1", Timestamp: 1},
+		"unknown op":            {Op: "future-op", SandboxID: "sbx-1", Timestamp: 1},
+		"state without payload": {Op: lifecycle.OpState, SandboxID: "sbx-1", Timestamp: 1},
+		"transition marker": {
+			Op:        lifecycle.OpState,
+			SandboxID: "sbx-1",
+			State:     &lifecycle.StatePayload{State: "pausing"},
+			Timestamp: 1,
+		},
+	}
+	for name, ev := range cases {
+		if p := MapEvent(ev, nil); p != nil {
+			t.Fatalf("%s: expected nil, got %+v", name, p)
+		}
+	}
+}
+
+func TestMapEvent_FallbackTimestamp(t *testing.T) {
+	fixed := time.Date(2026, 7, 29, 8, 0, 0, 0, time.UTC)
+	now := func() time.Time { return fixed }
+	ev := redisstream.Event{Op: lifecycle.OpDelete, SandboxID: "sbx-1"} // no ts
+	p := MapEvent(ev, now)
+	if p == nil {
+		t.Fatal("MapEvent returned nil")
+	}
+	if p.Timestamp != fixed.Format(time.RFC3339) {
+		t.Fatalf("timestamp = %q, want fallback %q", p.Timestamp, fixed.Format(time.RFC3339))
+	}
+}

--- a/cube-lifecycle-manager/internal/webhook/worker.go
+++ b/cube-lifecycle-manager/internal/webhook/worker.go
@@ -1,0 +1,169 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package webhook
+
+import (
+	"context"
+	"encoding/json"
+	"time"
+
+	"go.uber.org/zap"
+
+	"github.com/tencentcloud/CubeSandbox/cube-lifecycle-manager/internal/redisstream"
+)
+
+// Stream is the subset of redisstream.Client a Worker needs. Declared as an
+// interface so tests can drive the worker with a fake.
+type Stream interface {
+	EnsureGroup(ctx context.Context, group string) error
+	ReadGroup(ctx context.Context, group, consumer string, block time.Duration, count int) ([]redisstream.Event, error)
+	ReadPending(ctx context.Context, group, consumer string, count int) ([]redisstream.Event, error)
+	Ack(ctx context.Context, group, id string) error
+}
+
+// Worker consumes the lifecycle events stream for exactly one endpoint and
+// delivers matching events to it. Workers share no state, so a slow or
+// unreachable endpoint can only back up its own consumer group.
+type Worker struct {
+	endpoint  Endpoint
+	stream    Stream
+	deliverer *Deliverer
+	consumer  string
+	readBlock time.Duration
+	log       *zap.Logger
+	// now supplies the fallback event time when a stream entry carries no
+	// timestamp. Injectable for tests.
+	now func() time.Time
+}
+
+// NewWorker builds the worker for one endpoint. consumer is this replica's
+// consumer name inside the endpoint's group — reusing the CLM's hostname
+// means every replica gets an independent pending-entries list and the
+// group's entries are split across replicas.
+func NewWorker(endpoint Endpoint, stream Stream, deliverer *Deliverer, consumer string, readBlock time.Duration, log *zap.Logger) *Worker {
+	return &Worker{
+		endpoint:  endpoint,
+		stream:    stream,
+		deliverer: deliverer,
+		consumer:  consumer,
+		readBlock: readBlock,
+		log:       log.With(zap.String("endpoint", endpoint.Label()), zap.String("group", endpoint.Group())),
+		now:       time.Now,
+	}
+}
+
+// Run ensures the endpoint's consumer group exists, redelivers anything this
+// consumer left pending from a previous run, then consumes new events until
+// the context is cancelled. Transient Redis errors are retried with a short
+// backoff, mirroring the CLM's own stream consumer.
+func (w *Worker) Run(ctx context.Context) error {
+	group := w.endpoint.Group()
+	if err := w.stream.EnsureGroup(ctx, group); err != nil {
+		return err
+	}
+	w.log.Info("webhook worker started")
+
+	// Crash recovery: entries this consumer read but never ACKed are still
+	// on its pending-entries list; drain them before following new ones so
+	// an interrupted delivery is retried rather than lost.
+	var first string
+	for {
+		events, err := w.stream.ReadPending(ctx, group, w.consumer, 100)
+		if err != nil {
+			// Proceed to the main loop: pending entries stay on the list
+			// and are retried on the next restart (or via XAUTOCLAIM).
+			w.log.Warn("read pending failed; skipping crash recovery", zap.Error(err))
+			break
+		}
+		if len(events) == 0 {
+			break
+		}
+		if first == events[0].StreamID {
+			// The previous batch's ACKs did not land (Redis is flapping):
+			// re-reading would return the same entries forever. Leave them
+			// pending and proceed; the next restart retries them.
+			w.log.Warn("pending drain made no progress; leaving entries pending",
+				zap.String("id", first))
+			break
+		}
+		first = events[0].StreamID
+		w.log.Info("redelivering pending events", zap.Int("count", len(events)))
+		if err := w.deliverBatch(ctx, group, events); err != nil {
+			return err
+		}
+	}
+
+	for {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		events, err := w.stream.ReadGroup(ctx, group, w.consumer, w.readBlock, 100)
+		if err != nil {
+			w.log.Warn("xreadgroup failed; backing off", zap.Error(err))
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-time.After(time.Second):
+			}
+			continue
+		}
+		if err := w.deliverBatch(ctx, group, events); err != nil {
+			return err
+		}
+	}
+}
+
+// deliverBatch delivers events in stream order, ACKing each one as it reaches
+// a terminal state. It returns only when the context is cancelled mid-batch;
+// the interrupted entry is left pending for the next run.
+func (w *Worker) deliverBatch(ctx context.Context, group string, events []redisstream.Event) error {
+	for _, ev := range events {
+		if w.handleEvent(ctx, ev) {
+			if err := w.stream.Ack(ctx, group, ev.StreamID); err != nil {
+				w.log.Warn("ack failed", zap.String("id", ev.StreamID), zap.Error(err))
+			}
+			continue
+		}
+		return ctx.Err()
+	}
+	return nil
+}
+
+// handleEvent maps, filters, and delivers one stream event. The boolean
+// reports whether the event reached a terminal state and may be ACKed:
+//
+//   - not a lifecycle transition, or not subscribed → true (skip)
+//   - delivered, permanently rejected, or retries exhausted → true
+//   - delivery interrupted by shutdown → false (stays pending, is
+//     redelivered after restart)
+func (w *Worker) handleEvent(ctx context.Context, ev redisstream.Event) bool {
+	payload := MapEvent(ev, w.now)
+	if payload == nil || !w.endpoint.Subscribes(payload.Event) {
+		return true
+	}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		// Payload is a flat struct of strings; a marshal failure here is a
+		// bug, not a transient condition, so do not retry it.
+		w.log.Error("webhook payload serialization failed",
+			zap.String("event", payload.Event), zap.Error(err))
+		return true
+	}
+	if err := w.deliverer.Deliver(ctx, w.endpoint, body, payload.Event, payload.Timestamp); err != nil {
+		if ctx.Err() != nil {
+			w.log.Warn("delivery interrupted by shutdown; event stays pending",
+				zap.String("id", ev.StreamID), zap.String("event", payload.Event))
+			return false
+		}
+		// Terminal delivery failure (permanent rejection or exhausted
+		// retries) is already logged by the Deliverer; ACK so one dead
+		// endpoint cannot stall its group forever.
+		return true
+	}
+	w.log.Info("webhook event delivered",
+		zap.String("event", payload.Event),
+		zap.String("sandbox_id", payload.SandboxID))
+	return true
+}

--- a/cube-lifecycle-manager/internal/webhook/worker_test.go
+++ b/cube-lifecycle-manager/internal/webhook/worker_test.go
@@ -1,0 +1,215 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package webhook
+
+import (
+	"context"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"go.uber.org/zap"
+
+	"github.com/tencentcloud/CubeSandbox/cube-lifecycle-manager/internal/lifecycle"
+	"github.com/tencentcloud/CubeSandbox/cube-lifecycle-manager/internal/redisstream"
+)
+
+// fakeStream implements Stream with scripted pending/live batches and records
+// ACKed stream IDs in order.
+type fakeStream struct {
+	mu      sync.Mutex
+	pending [][]redisstream.Event
+	live    [][]redisstream.Event
+	acks    []string
+}
+
+func (f *fakeStream) EnsureGroup(context.Context, string) error { return nil }
+
+func (f *fakeStream) ReadGroup(ctx context.Context, _, _ string, _ time.Duration, _ int) ([]redisstream.Event, error) {
+	f.mu.Lock()
+	if len(f.live) > 0 {
+		batch := f.live[0]
+		f.live = f.live[1:]
+		f.mu.Unlock()
+		return batch, nil
+	}
+	f.mu.Unlock()
+	// No scripted events: behave like an idle blocking read.
+	<-ctx.Done()
+	return nil, ctx.Err()
+}
+
+func (f *fakeStream) ReadPending(_ context.Context, _, _ string, _ int) ([]redisstream.Event, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if len(f.pending) == 0 {
+		return nil, nil
+	}
+	batch := f.pending[0]
+	f.pending = f.pending[1:]
+	return batch, nil
+}
+
+func (f *fakeStream) Ack(_ context.Context, _, id string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.acks = append(f.acks, id)
+	return nil
+}
+
+func (f *fakeStream) acked() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]string(nil), f.acks...)
+}
+
+func createEvent(id, sid string) redisstream.Event {
+	return redisstream.Event{
+		StreamID:  id,
+		Op:        lifecycle.OpCreate,
+		SandboxID: sid,
+		Meta:      &lifecycle.SandboxLifecycleMeta{SandboxID: sid, TemplateID: "tpl-1"},
+		Timestamp: 1700000000000,
+	}
+}
+
+func deleteEvent(id, sid string) redisstream.Event {
+	return redisstream.Event{
+		StreamID:  id,
+		Op:        lifecycle.OpDelete,
+		SandboxID: sid,
+		Timestamp: 1700000001000,
+	}
+}
+
+func newTestWorker(ep Endpoint, stream Stream, d *Deliverer) *Worker {
+	return NewWorker(ep, stream, d, "consumer-1", time.Second, zap.NewNop())
+}
+
+func TestWorker_RedeliversPendingOnStartup(t *testing.T) {
+	r := &receiver{}
+	srv := httptest.NewServer(r)
+	defer srv.Close()
+
+	stream := &fakeStream{
+		pending: [][]redisstream.Event{{createEvent("1-0", "sbx-1")}},
+		// no live events; Run blocks on ReadGroup until cancelled
+	}
+	w := newTestWorker(Endpoint{URL: srv.URL}, stream, newTestDeliverer(testConfig()))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- w.Run(ctx) }()
+
+	// Wait for the ACK, not just the HTTP request: the request being seen by
+	// the receiver does not mean delivery has completed yet.
+	deadline := time.After(2 * time.Second)
+	for len(stream.acked()) == 0 {
+		select {
+		case <-deadline:
+			t.Fatal("pending event was not redelivered")
+		case <-time.After(time.Millisecond):
+		}
+	}
+	cancel()
+	if err := <-done; err != context.Canceled {
+		t.Fatalf("Run returned %v, want context.Canceled", err)
+	}
+	if r.count() != 1 {
+		t.Fatalf("requests = %d, want 1", r.count())
+	}
+	if acks := stream.acked(); len(acks) != 1 || acks[0] != "1-0" {
+		t.Fatalf("acks = %v, want [1-0]", acks)
+	}
+}
+
+func TestWorker_DeliversInStreamOrder(t *testing.T) {
+	r := &receiver{}
+	srv := httptest.NewServer(r)
+	defer srv.Close()
+
+	stream := &fakeStream{}
+	w := newTestWorker(Endpoint{URL: srv.URL}, stream, newTestDeliverer(testConfig()))
+
+	batch := []redisstream.Event{createEvent("1-0", "sbx-1"), deleteEvent("2-0", "sbx-1")}
+	if err := w.deliverBatch(context.Background(), w.endpoint.Group(), batch); err != nil {
+		t.Fatalf("deliverBatch: %v", err)
+	}
+	if r.count() != 2 {
+		t.Fatalf("requests = %d, want 2", r.count())
+	}
+	if got := r.got(0).header.Get("X-Cube-Event"); got != EventCreated {
+		t.Fatalf("first event = %q, want %q", got, EventCreated)
+	}
+	if got := r.got(1).header.Get("X-Cube-Event"); got != EventDeleted {
+		t.Fatalf("second event = %q, want %q", got, EventDeleted)
+	}
+	acks := stream.acked()
+	if len(acks) != 2 || acks[0] != "1-0" || acks[1] != "2-0" {
+		t.Fatalf("acks = %v, want [1-0 2-0]", acks)
+	}
+}
+
+func TestWorker_SkipsUnsubscribedAndNonTransitionEvents(t *testing.T) {
+	r := &receiver{}
+	srv := httptest.NewServer(r)
+	defer srv.Close()
+
+	stream := &fakeStream{}
+	ep := Endpoint{URL: srv.URL, Events: []string{EventCreated}}
+	w := newTestWorker(ep, stream, newTestDeliverer(testConfig()))
+
+	// Deleted is not subscribed; update is not an external transition.
+	batch := []redisstream.Event{
+		deleteEvent("1-0", "sbx-1"),
+		{StreamID: "2-0", Op: lifecycle.OpUpdate, SandboxID: "sbx-1", Timestamp: 1},
+		createEvent("3-0", "sbx-1"),
+	}
+	if err := w.deliverBatch(context.Background(), ep.Group(), batch); err != nil {
+		t.Fatalf("deliverBatch: %v", err)
+	}
+	if r.count() != 1 {
+		t.Fatalf("requests = %d, want 1 (only sandbox.created)", r.count())
+	}
+	if got := r.got(0).header.Get("X-Cube-Event"); got != EventCreated {
+		t.Fatalf("event = %q", got)
+	}
+	if acks := stream.acked(); len(acks) != 3 {
+		t.Fatalf("acks = %v, want all 3 acked", acks)
+	}
+}
+
+func TestWorker_AcksTerminalDeliveryFailure(t *testing.T) {
+	// 400 is permanent: the event must be ACKed (after logging) so a single
+	// rejecting endpoint cannot stall its consumer group forever.
+	r := &receiver{statuses: []int{400}}
+	srv := httptest.NewServer(r)
+	defer srv.Close()
+
+	stream := &fakeStream{}
+	w := newTestWorker(Endpoint{URL: srv.URL}, stream, newTestDeliverer(testConfig()))
+	if ack := w.handleEvent(context.Background(), createEvent("1-0", "sbx-1")); !ack {
+		t.Fatal("terminal rejection must be ACKed")
+	}
+}
+
+func TestWorker_KeepsEventPendingOnShutdown(t *testing.T) {
+	r := &receiver{}
+	srv := httptest.NewServer(r)
+	defer srv.Close()
+
+	stream := &fakeStream{}
+	w := newTestWorker(Endpoint{URL: srv.URL}, stream, newTestDeliverer(testConfig()))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // delivery is interrupted before it starts
+	if ack := w.handleEvent(ctx, createEvent("1-0", "sbx-1")); ack {
+		t.Fatal("interrupted delivery must stay pending (no ACK)")
+	}
+	if acks := stream.acked(); len(acks) != 0 {
+		t.Fatalf("acks = %v, want none", acks)
+	}
+}

--- a/cube-lifecycle-manager/scripts/verify-webhook-lifecycle.sh
+++ b/cube-lifecycle-manager/scripts/verify-webhook-lifecycle.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+# End-to-end verification of CLM webhook delivery against a live deployment.
+#
+# It starts the example receiver and a cube-lifecycle-manager configured with
+# CUBE_LCM_WEBHOOK_ENDPOINTS, drives a sandbox through create → pause → resume
+# → delete via the CubeAPI HTTP API, and asserts the receiver logs all four
+# events with the expected payload fields.
+#
+# Required environment:
+#   CLM_BINARY         path to the cube-lifecycle-manager binary to test
+#   CLM_ENV            env file with the CLM baseline configuration for the
+#                      deployment (CUBE_LCM_REDIS_ADDR, CUBE_LCM_CUBEMASTER_URL,
+#                      CUBE_LCM_PROXY_ADMIN_URLS, CUBE_LCM_USE_STATIC_FLEET, ...)
+#   CUBE_API_URL       base URL of a running CubeAPI (e.g. http://127.0.0.1:3000)
+#   WEBHOOK_RECEIVER   path to examples/webhook-receiver/receiver.py
+#
+# Optional:
+#   WEBHOOK_TEST_DIR   scratch dir for logs      (default /tmp/clm-webhook-test)
+#   WEBHOOK_TEST_TEMPLATE_ID                     (default wecom-ds-openclaw)
+#   PYTHON             python interpreter        (default python3)
+set -euo pipefail
+
+: "${CLM_BINARY:?set CLM_BINARY to the cube-lifecycle-manager binary}"
+: "${CLM_ENV:?set CLM_ENV to the CLM environment file}"
+: "${CUBE_API_URL:?set CUBE_API_URL to a running CubeAPI base URL}"
+: "${WEBHOOK_RECEIVER:?set WEBHOOK_RECEIVER to receiver.py}"
+
+TEST_DIR="${WEBHOOK_TEST_DIR:-/tmp/clm-webhook-test}"
+TEMPLATE_ID="${WEBHOOK_TEST_TEMPLATE_ID:-wecom-ds-openclaw}"
+PYTHON="${PYTHON:-python3}"
+CLM_PID=""
+RECEIVER_PID=""
+
+cleanup() {
+  [[ -n "${CLM_PID}" ]] && kill "${CLM_PID}" 2>/dev/null || true
+  [[ -n "${RECEIVER_PID}" ]] && kill "${RECEIVER_PID}" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+rm -rf "${TEST_DIR}"
+mkdir -p "${TEST_DIR}"
+
+# 1. Receiver with HMAC verification + replay protection enabled.
+export CUBE_WEBHOOK_SECRET="cube-webhook-integration-test"
+export PORT=9010
+PYTHONUNBUFFERED=1 "${PYTHON}" "${WEBHOOK_RECEIVER}" >"${TEST_DIR}/receiver.log" 2>&1 &
+RECEIVER_PID=$!
+
+# 2. CLM with the webhook subscription overlaid on the deployment config.
+set -a
+source "${CLM_ENV}"
+set +a
+export CUBE_LCM_LISTEN_ADDR="127.0.0.1:8083"
+export CUBE_LCM_WEBHOOK_ENDPOINTS='[{"url":"http://127.0.0.1:9010/webhooks/cube","events":["sandbox.created","sandbox.deleted","sandbox.paused","sandbox.resumed"],"secret":"cube-webhook-integration-test"}]'
+"${CLM_BINARY}" >"${TEST_DIR}/clm.log" 2>&1 &
+CLM_PID=$!
+
+for _ in $(seq 1 30); do
+  curl -fsS http://127.0.0.1:8083/readyz >/dev/null 2>&1 && break
+  sleep 1
+done
+curl -fsS http://127.0.0.1:8083/readyz >/dev/null
+
+# 3. Drive one sandbox through its full lifecycle.
+create_body=$(printf '{"templateID":"%s","timeout":300,"allow_internet_access":true}' "${TEMPLATE_ID}")
+create_response=$(curl -fsS -X POST "${CUBE_API_URL}/sandboxes" -H 'content-type: application/json' --data "${create_body}")
+printf '%s\n' "${create_response}" >"${TEST_DIR}/create-response.json"
+sandbox_id=$(printf '%s' "${create_response}" | "${PYTHON}" -c 'import json,sys; print(json.load(sys.stdin)["sandboxID"])')
+
+curl -fsS -o /dev/null -w '%{http_code}' -X POST "${CUBE_API_URL}/sandboxes/${sandbox_id}/pause" | grep -qx '204'
+curl -fsS -o /dev/null -w '%{http_code}' -X POST "${CUBE_API_URL}/sandboxes/${sandbox_id}/resume" -H 'content-type: application/json' --data '{}' | grep -qx '201'
+curl -fsS -o /dev/null -w '%{http_code}' -X DELETE "${CUBE_API_URL}/sandboxes/${sandbox_id}" | grep -qx '204'
+
+# 4. The events flow CubeMaster -> Redis stream -> CLM -> receiver, so allow
+#    for propagation time before giving up.
+for _ in $(seq 1 30); do
+  if "${PYTHON}" - "${TEST_DIR}/receiver.log" "${sandbox_id}" "${TEMPLATE_ID}" <<'PY'
+from datetime import datetime
+import json
+import sys
+
+path, sandbox_id, template_id = sys.argv[1:]
+expected = {"sandbox.created", "sandbox.paused", "sandbox.resumed", "sandbox.deleted"}
+received = {}
+for line in open(path, encoding="utf-8"):
+    try:
+        event = json.loads(line)
+    except json.JSONDecodeError:
+        continue
+    if event.get("sandbox_id") == sandbox_id:
+        received[event.get("event")] = event
+missing = expected - received.keys()
+if missing:
+    raise SystemExit("missing events: " + ", ".join(sorted(missing)))
+for name in expected:
+    event = received[name]
+    if event.get("version") != "1":
+        raise SystemExit(f"{name}: expected version='1', got {event.get('version')!r}")
+    timestamp = event.get("timestamp")
+    if not isinstance(timestamp, str):
+        raise SystemExit(f"{name}: missing timestamp")
+    try:
+        datetime.fromisoformat(timestamp.replace("Z", "+00:00"))
+    except ValueError as error:
+        raise SystemExit(f"{name}: invalid timestamp {timestamp!r}: {error}")
+created = received["sandbox.created"]
+if created.get("template_id") != template_id:
+    raise SystemExit(
+        f"sandbox.created: expected template_id={template_id!r}, "
+        f"got {created.get('template_id')!r}"
+    )
+for name, state in (("sandbox.paused", "paused"), ("sandbox.resumed", "running")):
+    if received[name].get("state") != state:
+        raise SystemExit(
+            f"{name}: expected state={state!r}, got {received[name].get('state')!r}"
+        )
+PY
+  then
+    echo "Webhook lifecycle verification passed for ${sandbox_id}"
+    exit 0
+  fi
+  sleep 1
+done
+
+echo "Webhook event verification timed out; inspect ${TEST_DIR}" >&2
+exit 1

--- a/examples/webhook-receiver/README.md
+++ b/examples/webhook-receiver/README.md
@@ -1,0 +1,38 @@
+# CubeSandbox Webhook receiver
+
+This dependency-free Python receiver prints every verified CubeSandbox lifecycle event as JSON.
+
+```bash
+export CUBE_WEBHOOK_SECRET='replace-with-a-random-shared-secret'
+# Optional replay window; defaults to 300 seconds.
+export CUBE_WEBHOOK_MAX_AGE_SECONDS=300
+# Optional listen port; defaults to 9010.
+export PORT=9010
+python3 receiver.py
+```
+
+Configure cube-lifecycle-manager with the same value:
+
+```bash
+export CUBE_LCM_WEBHOOK_ENDPOINTS='[{"url":"http://127.0.0.1:9010/webhooks/cube","events":["sandbox.created","sandbox.deleted","sandbox.paused","sandbox.resumed"],"secret":"replace-with-a-random-shared-secret"}]'
+```
+
+Restart cube-lifecycle-manager, then create, pause, resume, or delete a sandbox. The receiver prints a payload similar to:
+
+```json
+{
+  "version": "1",
+  "event": "sandbox.created",
+  "timestamp": "2026-07-11T08:15:30Z",
+  "sandbox_id": "sbx-123",
+  "template_id": "tpl-456"
+}
+```
+
+`X-Cube-Signature-256` is `sha256=` followed by the lowercase hex HMAC-SHA256 of the raw request body. Receivers that do not support this verification header can omit `secret`.
+
+After verifying the signature, receivers that trigger operational actions should reject replayed events. The signed body is authoritative: this example requires `X-Cube-Event` and `X-Cube-Timestamp` to match the body fields, and accepts events for five minutes, with 30 seconds of future clock skew. Keep receiver clocks synchronized and adjust `CUBE_WEBHOOK_MAX_AGE_SECONDS` only when delivery retries require a larger window.
+
+The example limits request bodies to 1 MiB and aborts socket reads after 30 seconds.
+
+Generic alerting products may require a product-specific payload rather than the CubeSandbox event schema. For example, a WeCom bot expects a `msgtype` message and cannot be used as an endpoint directly. Put an adapter such as this receiver in front of those products and translate the verified event into their required payload.

--- a/examples/webhook-receiver/receiver.py
+++ b/examples/webhook-receiver/receiver.py
@@ -25,6 +25,10 @@ class Receiver(BaseHTTPRequestHandler):
         if self.path != "/webhooks/cube":
             self.send_error(404, "not found")
             return
+        content_type = self.headers.get("Content-Type", "")
+        if content_type.split(";", 1)[0].strip().lower() != "application/json":
+            self.send_error(415, "unsupported content type")
+            return
         try:
             size = int(self.headers.get("Content-Length", ""))
         except ValueError:

--- a/examples/webhook-receiver/receiver.py
+++ b/examples/webhook-receiver/receiver.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Minimal CubeSandbox Webhook receiver with optional HMAC verification."""
+
+import hashlib
+import hmac
+import json
+import os
+from datetime import datetime, timezone
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+
+SECRET = os.environ.get("CUBE_WEBHOOK_SECRET", "")
+MAX_AGE_SECONDS = int(os.environ.get("CUBE_WEBHOOK_MAX_AGE_SECONDS", "300"))
+MAX_FUTURE_SKEW_SECONDS = 30
+MAX_BODY_BYTES = 1_048_576
+READ_TIMEOUT_SECONDS = 30
+
+
+class Receiver(BaseHTTPRequestHandler):
+    def setup(self):
+        super().setup()
+        self.request.settimeout(READ_TIMEOUT_SECONDS)
+
+    def do_POST(self):
+        if self.path != "/webhooks/cube":
+            self.send_error(404, "not found")
+            return
+        try:
+            size = int(self.headers.get("Content-Length", ""))
+        except ValueError:
+            self.send_error(400, "invalid Content-Length")
+            return
+        if size < 0:
+            self.send_error(400, "invalid Content-Length")
+            return
+        if size > MAX_BODY_BYTES:
+            self.send_error(413, "payload too large")
+            return
+        try:
+            body = self.rfile.read(size)
+        except TimeoutError:
+            self.send_error(408, "request body timeout")
+            return
+        if len(body) != size:
+            self.send_error(400, "incomplete request body")
+            return
+        received = self.headers.get("X-Cube-Signature-256", "")
+        if SECRET:
+            expected = "sha256=" + hmac.new(SECRET.encode(), body, hashlib.sha256).hexdigest()
+            if not hmac.compare_digest(received, expected):
+                self.send_error(401, "invalid webhook signature")
+                return
+        try:
+            event = json.loads(body)
+        except json.JSONDecodeError:
+            self.send_error(400, "invalid JSON")
+            return
+        if not isinstance(event, dict):
+            self.send_error(400, "invalid event JSON")
+            return
+        timestamp = event.get("timestamp")
+        event_name = event.get("event")
+        header_timestamp = self.headers.get("X-Cube-Timestamp", "")
+        header_event = self.headers.get("X-Cube-Event", "")
+        if not isinstance(event_name, str) or header_event != event_name:
+            self.send_error(401, "webhook event mismatch")
+            return
+        if not isinstance(timestamp, str):
+            self.send_error(401, "invalid webhook timestamp")
+            return
+        try:
+            observed = datetime.fromisoformat(timestamp.replace("Z", "+00:00"))
+            header_observed = datetime.fromisoformat(
+                header_timestamp.replace("Z", "+00:00")
+            )
+            if observed.tzinfo is None or header_observed.tzinfo is None:
+                raise ValueError("timestamp must include a timezone")
+        except (TypeError, ValueError):
+            self.send_error(401, "invalid webhook timestamp")
+            return
+        if header_observed != observed:
+            self.send_error(401, "webhook timestamp mismatch")
+            return
+        age = (datetime.now(timezone.utc) - observed).total_seconds()
+        if age > MAX_AGE_SECONDS or age < -MAX_FUTURE_SKEW_SECONDS:
+            self.send_error(401, "stale webhook timestamp")
+            return
+        print(json.dumps(event, ensure_ascii=False))
+        self.send_response(204)
+        self.end_headers()
+
+    def log_message(self, format, *args):
+        return
+
+
+if __name__ == "__main__":
+    port = int(os.environ.get("PORT", "9010"))
+    print(f"listening on http://127.0.0.1:{port}/webhooks/cube")
+    ThreadingHTTPServer(("127.0.0.1", port), Receiver).serve_forever()


### PR DESCRIPTION
## Problem

CubeSandbox records lifecycle events internally, but external orchestration and operations systems must poll the sandbox API to detect create, pause, resume, and delete transitions. Polling adds latency and unnecessary load.

Closes #642.

## Solution

Deliver lifecycle events to external HTTP endpoints from **cube-lifecycle-manager (CLM)**, which already consumes the durable lifecycle events stream (`cube:v1:shared:sandbox:lifecycle:events`). CubeAPI stays stateless and CubeMaster needs no changes: `create`, `delete`, and `state` (paused/running) transitions are already published to the stream.

Each endpoint owns an independent Redis consumer group (`webhook:<hash>`), so a slow or unavailable receiver cannot block other subscriptions or the auto-pause/resume loop. Delivery is at-least-once: an event is acknowledged only after it reaches a terminal state (delivered, permanently rejected, or retries exhausted), and a restarted replica redelivers whatever its consumer left pending. Multiple replicas share a group and split deliveries via consumer names, matching CLM's existing HA model.

**Durability:** there is no in-memory event queue. Redis Streams is the only buffer — each endpoint's worker reads the durable stream via `XREADGROUP` and ACKs an entry only after it reaches a terminal state, so a CLM restart (including `kill -9`) redelivers whatever its consumer left pending, with the original event timestamp preserved.

## Changes

- Configure endpoints with `CUBE_LCM_WEBHOOK_ENDPOINTS` (JSON array: `url`, optional `events` filter, optional `secret`), plus `CUBE_LCM_WEBHOOK_MAX_RETRIES`, `CUBE_LCM_WEBHOOK_TIMEOUT`, `CUBE_LCM_WEBHOOK_RETRY_BASE`. URLs must be http(s) without userinfo; secrets must be at least 16 bytes; event names are validated against the four known events so a typo fails fast instead of leaving a silently dead subscription.
- Emit `sandbox.created`, `sandbox.deleted`, `sandbox.paused`, and `sandbox.resumed`; metadata `update` ops and transition markers (`pausing`/`resuming`) are never delivered.
- Payload carries `version`, `event`, `timestamp` (taken from the stream entry, so redeliveries keep the original event time), and `sandbox_id`; `sandbox.created` adds `template_id` when known, and `sandbox.paused`/`sandbox.resumed` add `state`.
- Sign the exact JSON request body with HMAC-SHA256 in `X-Cube-Signature-256` when a secret is configured.
- Retry `5xx`, `408`, and `429` responses with exponential backoff and jitter; other `4xx` responses are permanent and not retried. The whole delivery is capped at 30 seconds, and automatic redirects are disabled so a configured endpoint cannot bounce delivery to an internal service. Log lines use a sanitized endpoint label (credentials, query, and fragment stripped).
- Add a dependency-free receiver example with signature verification, replay protection, and content-type validation, plus a verification script for deployed environments.
- Document configuration, delivery semantics, and operations (`XPENDING`/`XAUTOCLAIM`) in the CLM README.

## Scope

- Subscriptions are static configuration; this PR does not add the optional REST management API discussed in #642.
- Delivery is at-least-once, so receivers must be idempotent. Entries pending on a permanently dead replica stay observable via `XPENDING` and can be reassigned with `XAUTOCLAIM`.
- At-least-once is bounded by the retry budget: once retries are exhausted the event is ACKed and dropped, so a receiver that is unavailable for longer than the budget (~2s connection-refused / ~22s hanging, at the defaults) permanently loses those transitions. A keep-pending / dead-letter mode is under discussion in review.
- Generic alerting products that require a product-specific payload (e.g. a WeCom bot expecting `msgtype`) still need an adapter in front; the receiver example shows how.

## Verification

Unit tests (Go, `httptest` + pure functions, no new dependencies):

```text
go test ./...   # cube-lifecycle-manager: all 12 packages ok
go vet ./...    # clean
```

Live end-to-end on a deployed server (Redis 7.2 + CLM + the example receiver):

- `sandbox.created` / `paused` / `resumed` / `deleted` delivered in stream order with correct payloads (`version`, `template_id`, `state`) and receiver-verified HMAC signatures; `update` ops and `pausing` markers correctly filtered out.
- Consumer-group isolation confirmed: `webhook:<hash>` is disjoint from `cube-proxy-sidecar`, and an endpoint whose receiver is down backs up only its own group.
- Crash recovery: `kill -9` mid-retry leaves the event pending; after restart CLM logs `redelivering pending events`, redelivers with the original event timestamp, and the pending list drains to zero.
- Receiver content-type handling: `application/json` accepted (parameters tolerated), others rejected with 415.

## Review

Auto-review findings addressed in-place:

- M1 (unknown event names silently accepted) — now rejected at config load, with tests.
- L1 (URL path preserved in log labels) — documented as intentional in `Label()`; secrets belong in the `secret` field, never the path.
- L2 (no content-type check in the example receiver) — returns 415 for non-JSON bodies.
- L3 (retry-delay test is a range check) — left as-is; a property-based distribution check adds little over the existing bounds test.

Assisted-by: Kimi Code CLI:K2

<details>
<summary>Implementation history</summary>

A previous iteration of this PR implemented delivery inside CubeAPI, using a bounded per-endpoint in-memory `mpsc` queue that dropped events under backpressure. It was reworked following review feedback on the issue's other PRs: CubeAPI must stay stateless, and event delivery belongs in an independent service rather than an in-process worker with in-memory queues. The current implementation is Go, under `cube-lifecycle-manager/internal/webhook/`, and buffers nothing in process.

</details>
