### PR TITLE
feat(examples)  add Go sandbox templates（(#645)）

### DIFF
--- a/docs/guide/tutorials/examples.md
+++ b/docs/guide/tutorials/examples.md
@@ -5,6 +5,7 @@ Hands-on examples demonstrating various Cube Sandbox use cases. Each example is 
 | Example | Description |
 |---------|-------------|
 | [Code Sandbox Quickstart](https://github.com/tencentcloud/CubeSandbox/tree/master/examples/code-sandbox-quickstart) | The most basic usage: create a sandbox, run Python code, execute shell commands, manage network policies, and more — all via the E2B SDK. |
+| [Go Sandbox](https://github.com/tencentcloud/CubeSandbox/tree/master/examples/go-sandbox) | A ready-to-use Go runtime template: compile and unit-test Go programs via `go test` through the E2B SDK, including a restricted-egress (air-gapped / allowlist) differentiated scenario. |
 | [Browser Sandbox (Playwright)](https://github.com/tencentcloud/CubeSandbox/tree/master/examples/browser-sandbox) | Run a headless Chromium inside a MicroVM and control it remotely with Playwright via CDP. |
 | [OpenClaw Integration](https://github.com/tencentcloud/CubeSandbox/tree/master/examples/openclaw-integration) | Deploy Cube Sandbox and configure the OpenClaw skill so AI agents can execute code in isolated VM environments. |
 | [SWE-bench with mini-swe-agent](https://github.com/tencentcloud/CubeSandbox/tree/master/examples/mini-rl-training) | Automate SWE-bench coding tasks in isolated sandboxes using cube-sandbox + mini-swe-agent, with multi-model support and RL training vision. |

--- a/docs/zh/guide/tutorials/examples.md
+++ b/docs/zh/guide/tutorials/examples.md
@@ -5,6 +5,7 @@
 | 示例 | 说明 |
 |------|------|
 | [代码沙箱快速入门](https://github.com/tencentcloud/CubeSandbox/tree/master/examples/code-sandbox-quickstart) | 最基础的用法：创建沙箱、执行 Python 代码、运行 Shell 命令、管理网络策略等，全部通过 E2B SDK 完成。 |
+| [Go 运行时沙箱](https://github.com/tencentcloud/CubeSandbox/tree/master/examples/go-sandbox) | 开箱即用的 Go 运行时模板：通过 E2B SDK 运行 `go test` 编译并单测 Go 程序，并包含出口受限（断网 / 白名单）差异化场景。 |
 | [浏览器沙箱（Playwright）](https://github.com/tencentcloud/CubeSandbox/tree/master/examples/browser-sandbox) | 在 MicroVM 中运行无头 Chromium，通过 CDP 协议使用 Playwright 远程控制浏览器。 |
 | [OpenClaw 集成](https://github.com/tencentcloud/CubeSandbox/tree/master/examples/openclaw-integration) | 部署 Cube Sandbox 并配置 OpenClaw Skill，让 AI Agent 能够在隔离的虚拟机环境中执行代码。 |
 | [SWE-bench + mini-swe-agent](https://github.com/tencentcloud/CubeSandbox/tree/master/examples/mini-rl-training) | 使用 cube-sandbox + mini-swe-agent 在隔离沙箱中自动化 SWE-bench 编码任务，支持多模型切换和 RL 训练愿景。 |

--- a/examples/go-sandbox/.env.example
+++ b/examples/go-sandbox/.env.example
@@ -1,0 +1,17 @@
+# Required: Cube API server address
+export E2B_API_URL="http://<your-node-ip>:3000"
+
+# Required: any non-empty value satisfies the SDK check
+export E2B_API_KEY="e2b_000000"
+
+# Required: template ID obtained from create-from-image
+export CUBE_TEMPLATE_ID="<your-template-id>"
+
+# Optional: only needed when using Cube's built-in mkcert certificate
+export SSL_CERT_FILE="/root/.local/share/mkcert/rootCA.pem"
+
+# Optional: only for the allowlist scenario in go_egress_restricted.py ([C]).
+# Comma-separated CIDRs (e.g. your private GOPROXY + DNS) permitted while all
+# other egress stays blocked. Leave unset to skip that scenario.
+# export CUBE_GOPROXY_CIDRS="10.0.1.5/32,10.0.0.53/32"
+# export CUBE_GOPROXY_URL="http://10.0.1.5:8080"

--- a/examples/go-sandbox/Dockerfile
+++ b/examples/go-sandbox/Dockerfile
@@ -1,0 +1,48 @@
+# syntax=docker/dockerfile:1.7
+
+# Go runtime template for Cube Sandbox.
+# Adds the official Go toolchain onto cubesandbox-base; envd stays on :49983.
+# No foreground service: Go programs run on demand via the E2B SDK.
+
+# Build:
+#   docker build -t cubesandbox-go:latest examples/go-sandbox
+# Register (replace <your-registry>):
+#   docker tag  cubesandbox-go:latest <your-registry>/cubesandbox-go:latest
+#   docker push <your-registry>/cubesandbox-go:latest
+#   cubemastercli tpl create-from-image \
+#     --image <your-registry>/cubesandbox-go:latest \
+#     --writable-layer-size 4G \
+#     --expose-port 49983 --probe 49983 --probe-path /health
+# ARM64 nodes: add --platform linux/arm64 to the build above.
+
+ARG GOLANG_VERSION=1.23.4
+ARG CUBE_BASE_IMAGE=ghcr.io/tencentcloud/cubesandbox-base:2026.16
+
+FROM golang:${GOLANG_VERSION}-bookworm AS gobuild
+
+FROM ${CUBE_BASE_IMAGE}
+
+# cubesandbox-base (Ubuntu 22.04) already ships bash/curl/ca-certificates.
+# git/procps omitted on purpose: examples use GOPROXY=proxy.golang.org
+# (zip downloads, no VCS) and setsid/nohup (already present).
+
+COPY --from=gobuild /usr/local/go /usr/local/go
+
+# PATH: make `go` callable. GOPATH/GOCACHE under /workspace (writable layer,
+# persist across runs). GOFLAGS=-mod=mod so examples skip `go mod tidy`.
+ENV PATH=/usr/local/go/bin:$PATH \
+    GOPATH=/workspace/go \
+    GOCACHE=/workspace/.cache/go-build \
+    GOFLAGS=-mod=mod \
+    GO111MODULE=on \
+    GOTOOLCHAIN=local
+
+WORKDIR /workspace
+
+# 49983 = envd readiness/probe port (required). No other port is opened.
+EXPOSE 49983
+
+# The base image's cube-entrypoint.sh launches envd on ${ENVD_PORT:-49983} in
+# the background and then execs the foreground CMD, so envd stays up on :49983
+# and the standard readiness probe (/health -> 204) passes. We rely on that
+# inherited entrypoint; no extra ports or services are started at boot.

--- a/examples/go-sandbox/README.md
+++ b/examples/go-sandbox/README.md
@@ -1,0 +1,198 @@
+# Go Sandbox
+
+A ready-to-use **Go runtime template** for Cube Sandbox, with a minimal example
+that drives it through the E2B-compatible Python SDK. Use it to compile and unit
+test Go programs inside an isolated KVM MicroVM.
+
+[中文文档](README_zh.md)
+
+## 1. What's inside
+
+| File | What it shows |
+|------|---------------|
+| `Dockerfile` | Builds the Go runtime image from `cubesandbox-base` (preinstalled `go` toolchain, envd kept on `:49983`). |
+| `env_utils.py` | Shared `.env` loader — mirrors the `env_utils` helper used by other examples. |
+| `go_test.py` | Write a Go module + unit test, run `go test -v`, assert pass. |
+| `go_egress_restricted.py` | Run Go under a restricted egress policy: air-gapped zero-dependency build/test, proof that egress is enforced, allowlist recipe for module downloads. |
+
+## 2. Prerequisites
+
+- A running Cube Sandbox deployment (`cubemastercli` on `$PATH`, `CUBEMASTER_ADDR` set).
+- Docker (to build/push the template image).
+- Python 3.8+.
+
+```bash
+pip install -r requirements.txt
+```
+
+The script uses `python-dotenv` to best-effort load a `.env` file from this
+directory or your current working directory (without overriding already-set
+environment variables). Copy the template and fill it in:
+
+```bash
+cp .env.example .env
+# edit .env: set E2B_API_URL and CUBE_TEMPLATE_ID
+```
+
+
+## 3. Build, push, and register the template
+
+### Step 1 — Build the image
+
+```bash
+docker build -t cubesandbox-go:latest examples/go-sandbox
+```
+
+> **Cross-arch:** if your CubeMaster nodes are ARM64, add
+> `--platform linux/arm64` to the `docker build` command above (the Go
+> toolchain is copied from `golang:1.23.4-bookworm`, which is `amd64` by
+> default).
+
+### Step 2 — Push to a reachable registry
+
+CubeMaster pulls the image from a registry the **cluster nodes** can reach. Use
+your own Tencent Cloud Registry (TCR) namespace (or any registry your nodes can
+pull from):
+
+```bash
+docker tag  cubesandbox-go:latest <your-registry>/cubesandbox-go:latest
+docker push <your-registry>/cubesandbox-go:latest
+```
+
+### Step 3 — Register as a Cube template
+
+```bash
+cubemastercli tpl create-from-image \
+  --image <your-registry>/cubesandbox-go:latest \
+  --writable-layer-size 4G \
+  --expose-port 49983 \
+  --probe       49983 \
+  --probe-path  /health
+```
+
+- `49983` is envd's readiness/probe port — **required** for the template to
+  reach `READY`. Exposing it is what makes the probe (`GET /health` → 204) pass.
+- `4G` writable layer: Go module + build caches are heavy; size it for your
+  module graph.
+
+Track the build:
+
+```bash
+cubemastercli tpl watch --job-id <job_id>   # exits when READY or FAILED
+```
+
+Note the `template_id` from the output.
+
+### Step 4 — Configure environment variables
+
+```bash
+export E2B_API_KEY=e2b_000000
+export E2B_API_URL=http://<your-node-ip>:3000
+export CUBE_TEMPLATE_ID=<template-id>
+```
+
+## 4. Run the example
+
+```bash
+python go_test.py            # compile + unit test
+```
+
+The script reads `CUBE_TEMPLATE_ID` from the environment (or your `.env`),
+connects via `E2B_API_URL` / `E2B_API_KEY`, and boots a sandbox from the Go
+template.
+
+
+The script prints a short `✓` line on success and a non-zero exit code on
+failure.
+
+## 5. Resource recommendations
+
+| Setting | Suggested | Why |
+|---------|-----------|-----|
+| `writable-layer-size` | `4G` (more for big module graphs) | module cache (`GOPATH=/workspace/go`) + build cache (`GOCACHE=/workspace/.cache/go-build`) live in the writable layer. |
+| Instance CPU/Mem | 1 vCPU / 1–2 GB minimum | `go build` is CPU-bound; tests parallelize with `GOMAXPROCS`. |
+
+## 6. Known limitations
+
+- **No pre-warmed official Go image.** Unlike `sandbox-code`, the Go image is
+  built from this repo's `Dockerfile` (based on `cubesandbox-base`). Pin
+  `GOLANG_VERSION` and the base tag for reproducibility.
+- **Architecture.** The toolchain is copied from `golang:<ver>-bookworm` on the
+  build host's arch. Match `--platform` to your node arch or the template boot
+  may fail.
+- **`go mod` needs egress.** Pure `go test`/`go build` of dependency-free code
+  runs fully offline, but fetching modules requires either general internet or
+  an egress allowlist.
+- **`git` is not preinstalled.** To keep the image build independent of Ubuntu
+  package mirrors, the `Dockerfile` does not install `git`. The example pins
+  `GOPROXY=proxy.golang.org`, so modules are fetched as zips from the proxy (no
+  VCS access needed). If you need `GOPROXY=direct` or private-repo VCS fetching,
+  `apt-get install git` in a derived image.
+- **`GOPROXY` default.** The template leaves the upstream default
+  (`proxy.golang.org,direct`). For regulated environments, set `GOPROXY` to your
+  private proxy and restrict egress accordingly.
+
+## 7. Security alignment
+
+- The template inherits the `cubesandbox-base` security baseline (envd
+  auth, isolated kernel/network). No extra ports or services are opened at boot.
+- No secrets are baked into the image; runtime config is passed via
+  `env_vars`/`network` at `Sandbox.create` time.
+- `GOTOOLCHAIN=local` is pinned in the image so the toolchain is never
+  auto-downloaded from the network — a supply-chain safeguard that also makes
+  air-gapped builds deterministic.
+
+## 8. Running under restricted egress (differentiated scenario)
+
+Go's standout property for regulated environments is that a **module with no
+external dependencies compiles and unit-tests fully offline**. Cube Sandbox
+enforces outbound policy at the Cubelet tap layer (kernel level), so it cannot
+be bypassed from inside the VM. `go_egress_restricted.py` demonstrates this:
+
+```bash
+python go_egress_restricted.py
+```
+
+It runs three checks:
+
+1. **Air-gapped zero-dependency build/test** — creates the sandbox with
+   `allow_internet_access=False`, writes a stdlib-only module, and runs
+   `go test -v`. Passes completely offline because `GOTOOLCHAIN=local` +
+   `-mod=readonly` prevent any network touch.
+2. **Egress is really cut** — the same air-gapped sandbox cannot
+   `go mod download` an external module (`rsc.io/quote`); the command fails,
+   proving the policy is enforced, not cosmetic.
+3. **Allowlist recipe for deps** (opt-in) — set `CUBE_GOPROXY_CIDRS` to permit
+   only your private module proxy (+ DNS) CIDR while keeping everything else
+   blocked:
+
+   ```bash
+   export CUBE_GOPROXY_CIDRS="10.0.1.5/32,10.0.0.53/32"   # proxy + DNS
+   export CUBE_GOPROXY_URL="http://10.0.1.5:8080"          # reachable proxy
+   python go_egress_restricted.py
+   ```
+
+   With the allowlist, `go mod download` reaches only the proxy; public internet
+   stays blocked. This is the regulated-environment pattern: keep `go mod` working
+   via an internal proxy instead of opening general egress.
+
+| Mode | `Sandbox.create` args | Effect |
+|------|----------------------|--------|
+| Air-gapped | `allow_internet_access=False` | Zero-dep Go builds/tests run; all egress blocked |
+| Allowlist | `allow_internet_access=False`, `network={"allow_out":[...]}` | Only listed CIDRs (e.g. proxy+DNS) reachable |
+
+## 9. Directory structure
+
+```
+go-sandbox/
+├── Dockerfile                 # Go runtime image (cubesandbox-base + go toolchain)
+├── README.md                  # This file
+├── README_zh.md               # Chinese documentation
+├── requirements.txt           # Python dependencies
+├── env_utils.py               # shared .env loader (matches other examples)
+├── .env.example               # Environment variable template
+├── go_test.py                 # go test demo
+└── go_egress_restricted.py    # air-gapped / allowlist egress demo
+```
+
+

--- a/examples/go-sandbox/README_zh.md
+++ b/examples/go-sandbox/README_zh.md
@@ -1,0 +1,179 @@
+# Go 运行时沙箱
+
+一个开箱即用的 **Go 运行时模板**，配合通过 E2B 兼容 Python SDK 驱动的最小示例。
+可在隔离的 KVM MicroVM 中编译并单元测试 Go 程序。
+
+[English](README.md)
+
+## 1. 目录内容
+
+| 文件 | 说明 |
+|------|------|
+| `Dockerfile` | 基于 `cubesandbox-base` 构建 Go 运行时镜像（预装 `go` 工具链，envd 保留在 `:49983`）。 |
+| `env_utils.py` | 共享的 `.env` 加载器——与其它示例使用的 `env_utils` 辅助模块一致。 |
+| `go_test.py` | 写入 Go 模块与单元测试，运行 `go test -v` 并断言通过。 |
+| `go_egress_restricted.py` | 在受限出口策略下运行 Go：离线零依赖构建/测试、验证出口确被管控、依赖下载的白名单方案。 |
+
+## 2. 前置条件
+
+- 已部署并运行中的 Cube Sandbox（`cubemastercli` 在 `$PATH`，已设置 `CUBEMASTER_ADDR`）。
+- Docker（用于构建/推送模板镜像）。
+- Python 3.8+。
+
+```bash
+pip install -r requirements.txt
+```
+
+脚本通过 `python-dotenv` 尽力加载当前目录或工作目录下的 `.env`
+（不覆盖已设置的环境变量）。复制模板并填写即可：
+
+```bash
+cp .env.example .env
+# 编辑 .env：填入 E2B_API_URL 与 CUBE_TEMPLATE_ID
+```
+
+
+## 3. 构建、推送并注册模板
+
+### 第一步 —— 构建镜像
+
+```bash
+docker build -t cubesandbox-go:latest examples/go-sandbox
+```
+
+> **跨架构说明：** 若你的 CubeMaster 节点为 ARM64，请在上面的 `docker build`
+> 命令加上 `--platform linux/arm64`（Go 工具链默认从 `golang:1.23.4-bookworm`
+> 复制，其为 `amd64`）。
+
+### 第二步 —— 推送到可达的镜像仓库
+
+CubeMaster 会从**集群节点可访问**的镜像仓库拉取镜像。请使用你自己的腾讯云
+镜像仓库（TCR）命名空间（或任何节点可拉取的仓库）：
+
+```bash
+docker tag  cubesandbox-go:latest <your-registry>/cubesandbox-go:latest
+docker push <your-registry>/cubesandbox-go:latest
+```
+
+### 第三步 —— 注册为 Cube 模板
+
+```bash
+cubemastercli tpl create-from-image \
+  --image <your-registry>/cubesandbox-go:latest \
+  --writable-layer-size 4G \
+  --expose-port 49983 \
+  --probe       49983 \
+  --probe-path  /health
+```
+
+- `49983` 是 envd 的就绪/探针端口——模板达到 `READY` **必须**暴露它；探针
+  `GET /health` 返回 204 即视为就绪。
+- `4G` 可写层：Go 模块与构建缓存体积较大，请按你的依赖规模调整。
+
+跟踪构建进度：
+
+```bash
+cubemastercli tpl watch --job-id <job_id>   # READY 或 FAILED 时退出
+```
+
+记下输出中的 `template_id`。
+
+### 第四步 —— 配置环境变量
+
+```bash
+export E2B_API_KEY=e2b_000000
+export E2B_API_URL=http://<your-node-ip>:3000
+export CUBE_TEMPLATE_ID=<template-id>
+```
+
+## 4. 运行示例
+
+```bash
+python go_test.py            # 编译 + 单元测试
+```
+
+脚本从环境变量（或 `.env`）读取 `CUBE_TEMPLATE_ID`，通过 `E2B_API_URL` /
+`E2B_API_KEY` 连接，并基于 Go 模板拉起沙箱。脚本成功时打印 `✓`，失败时返回非零退出码。
+
+
+## 5. 资源建议
+
+| 配置项 | 建议 | 原因 |
+|--------|------|------|
+| `writable-layer-size` | `4G`（依赖多时更大） | 模块缓存（`GOPATH=/workspace/go`）与构建缓存（`GOCACHE=/workspace/.cache/go-build`）均在可写层中。 |
+| 实例 CPU/内存 | 至少 1 vCPU / 1–2 GB | `go build` 偏 CPU；测试按 `GOMAXPROCS` 并行。 |
+
+## 6. 已知限制
+
+- **无官方预构建 Go 镜像。** 与 `sandbox-code` 不同，Go 镜像由本仓库
+  `Dockerfile`（基于 `cubesandbox-base`）构建。请固定 `GOLANG_VERSION` 与
+  base 标签以保证可复现。
+- **架构。** 工具链从 `golang:<ver>-bookworm` 按构建机架构复制。请用
+  `--platform` 与节点架构对齐，否则模板启动可能失败。
+- **`go mod` 需要出口。** 无依赖的纯 `go test`/`go build` 可完全离线运行；
+  但拉取模块需要公网或出口白名单。
+- **未预装 `git`。** 为使镜像构建不依赖 Ubuntu 软件源，`Dockerfile` 未安装
+  `git`；示例将 `GOPROXY` 固定为 `proxy.golang.org`，模块以 zip 从代理下载，
+  无需 VCS 访问。如需 `GOPROXY=direct` 或私有仓库的 VCS 拉取，请在派生镜像中
+  自行 `apt-get install git`。
+- **`GOPROXY` 默认值。** 模板保留上游默认（`proxy.golang.org,direct`）。在受
+  监管环境请将 `GOPROXY` 指向私有代理并相应收紧出口。
+
+## 7. 安全对齐
+
+- 模板继承 `cubesandbox-base` 安全基线（envd 鉴权、隔离内核/网络），启动时
+  不开放额外端口或服务。
+- 镜像不内置任何密钥；运行期配置通过 `Sandbox.create` 的 `env_vars`/`network`
+  传入。
+- 镜像固定 `GOTOOLCHAIN=local`，工具链绝不自动从网络下载——既是供应链安全
+  防护，也保证离线构建可复现。
+
+## 8. 出口受限场景（差异化能力）
+
+Go 在受监管环境中最大的优势是：**没有任何外部依赖的模块可以完全离线编译并
+单元测试**。Cube Sandbox 在 Cubelet 的 tap 网络层（内核级）执行出口策略，
+因此沙箱内部无法绕过。`go_egress_restricted.py` 演示这一能力：
+
+```bash
+python go_egress_restricted.py
+```
+
+它依次执行三项检查：
+
+1. **离线零依赖构建/测试** —— 以 `allow_internet_access=False` 创建沙箱，写入
+   仅依赖标准库的模块并运行 `go test -v`。因 `GOTOOLCHAIN=local` + `-mod=readonly`
+   杜绝一切网络访问，完全离线通过。
+2. **出口确被管控（非摆设）** —— 同一离线沙箱无法 `go mod download` 外部模块
+   （`rsc.io/quote`），命令失败，证明策略真实生效。
+3. **依赖白名单方案（可选）** —— 设置 `CUBE_GOPROXY_CIDRS`，仅放行你的私有模块
+   代理（+ DNS）CIDR，其余一律阻断：
+
+   ```bash
+   export CUBE_GOPROXY_CIDRS="10.0.1.5/32,10.0.0.53/32"   # 代理 + DNS
+   export CUBE_GOPROXY_URL="http://10.0.1.5:8080"          # 可达的代理
+   python go_egress_restricted.py
+   ```
+
+   白名单模式下 `go mod download` 仅能到达该代理，公网仍然不可达。这正是受监管
+   环境的推荐做法：通过内部代理让 `go mod` 可用，而不是放开通用出口。
+
+| 模式 | `Sandbox.create` 参数 | 效果 |
+|------|----------------------|------|
+| 离线 | `allow_internet_access=False` | 零依赖 Go 构建/测试可跑；全部出口被阻断 |
+| 白名单 | `allow_internet_access=False`，`network={"allow_out":[...]}` | 仅列出的 CIDR（如代理+DNS）可达 |
+
+## 9. 目录结构
+
+```
+go-sandbox/
+├── Dockerfile                 # Go 运行时镜像（cubesandbox-base + go 工具链）
+├── README.md                  # 英文文档
+├── README_zh.md               # 本文件
+├── requirements.txt           # Python 依赖
+├── env_utils.py               # 共享 .env 加载器（与其它示例一致）
+├── .env.example               # 环境变量模板
+├── go_test.py                 # go test 示例
+└── go_egress_restricted.py    # 离线 / 白名单出口示例
+```
+
+

--- a/examples/go-sandbox/env_utils.py
+++ b/examples/go-sandbox/env_utils.py
@@ -1,0 +1,22 @@
+from pathlib import Path
+
+from dotenv import load_dotenv
+
+
+def load_local_dotenv() -> None:
+    """Best-effort load of a nearby .env file without overriding real env vars."""
+    candidate_paths = [
+        Path(__file__).with_name(".env"),
+        Path.cwd() / ".env",
+    ]
+
+    seen_paths = set()
+    for path in candidate_paths:
+        resolved_path = path.resolve()
+        if resolved_path in seen_paths:
+            continue
+        seen_paths.add(resolved_path)
+
+        if path.is_file():
+            load_dotenv(dotenv_path=path, override=False)
+            return

--- a/examples/go-sandbox/go_egress_restricted.py
+++ b/examples/go-sandbox/go_egress_restricted.py
@@ -1,0 +1,190 @@
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Run Go under a restricted egress network policy in a Cube Sandbox.
+
+Differentiated scenario (requirement 3: "出口网络策略受限下的运行").
+Cube Sandbox enforces outbound policy at the Cubelet tap network layer (kernel
+level), so it cannot be bypassed from inside the VM. This script shows:
+
+  A. Air-gapped, zero-dependency build/test
+     A Go module that only imports the standard library compiles and unit-tests
+     fully OFFLINE. This is Go's key strength for regulated / egress-restricted
+     environments: no network == no supply-chain exposure.
+
+  B. Egress is really cut (not cosmetic)
+     Under the same air-gap, `go mod download` of an external module fails --
+     evidence the policy is enforced. Dependencies require either a reachable
+     private proxy (allowlist) or general internet.
+
+  C. Allowlist mode for dependencies (opt-in)
+     Switch to allowlist mode and permit ONLY your module proxy (+ DNS) CIDR so
+     `go mod download` works while everything else stays blocked. Enable by
+     exporting CUBE_GOPROXY_CIDRS (e.g. "10.0.1.5/32,10.0.0.53/32"). The
+     sandbox GOPROXY must point at that reachable proxy (CUBE_GOPROXY_URL).
+
+Prereqs: a Go template (see README), `pip install -r requirements.txt`,
+and `CUBE_TEMPLATE_ID` set in the environment.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+from e2b_code_interpreter import Sandbox
+
+from env_utils import load_local_dotenv
+
+load_local_dotenv()
+
+template_id = os.environ["CUBE_TEMPLATE_ID"]
+
+# GOTOOLCHAIN=local: never auto-download a toolchain; GOFLAGS=-mod=readonly:
+# never touch the network for module graph resolution. Together these make a
+# stdlib-only build run fully offline even if GOPROXY is reachable.
+OFFLINE_ENV = "GOTOOLCHAIN=local GOFLAGS=-mod=readonly"
+
+GOMOD = "module hellogo\n\ngo 1.23\n"
+
+MAIN_GO = """package main
+
+import (
+\t"fmt"
+\t"strings"
+)
+
+// JoinTags uppercases and joins tags with a comma. Pure stdlib, no deps.
+func JoinTags(tags ...string) string {
+\tfor i, t := range tags {
+\t\ttags[i] = strings.ToUpper(t)
+\t}
+\treturn strings.Join(tags, ",")
+}
+
+func main() {
+\tfmt.Println(JoinTags("go", "sandbox"))
+}
+"""
+
+MAIN_TEST_GO = """package main
+
+import "testing"
+
+func TestJoinTags(t *testing.T) {
+\tif got := JoinTags("go", "sandbox"); got != "GO,SANDBOX" {
+\t\tt.Fatalf("JoinTags = %q; want GO,SANDBOX", got)
+\t}
+}
+"""
+
+# A module requiring an external dependency -- used to prove egress is cut.
+DEP_GOMOD = "module needsdep\n\ngo 1.23\n\nrequire rsc.io/quote v1.5.2\n"
+DEP_MAIN_GO = """package main
+
+import (
+\t"fmt"
+\t"rsc.io/quote"
+)
+
+func main() { fmt.Println(quote.Hello()) }
+"""
+
+
+def run_air_gapped(sandbox: Sandbox) -> int:
+    print("== [A] Air-gapped zero-dependency build/test ==")
+    sandbox.files.make_dir("/workspace/hellogo")
+    sandbox.files.write("/workspace/hellogo/go.mod", GOMOD)
+    sandbox.files.write("/workspace/hellogo/main.go", MAIN_GO)
+    sandbox.files.write("/workspace/hellogo/main_test.go", MAIN_TEST_GO)
+
+    res = sandbox.commands.run(
+        f"{OFFLINE_ENV} go test -v ./...", cwd="/workspace/hellogo"
+    )
+    print(res.stdout)
+    if res.stderr:
+        print(res.stderr, file=sys.stderr)
+    if res.exit_code != 0:
+        print("FAILED: air-gapped go test", file=sys.stderr)
+        return 1
+    print("air-gapped go test passed \u2713")
+
+    # Prove egress is actually cut at the tap layer.
+    res = sandbox.commands.run(
+        "curl -s --max-time 3 https://proxy.golang.org -o /dev/null "
+        "-w '%{http_code}' || echo blocked"
+    )
+    blocked = res.stdout.strip() == "blocked" or res.exit_code != 0
+    print("public egress blocked:", blocked)
+    if not blocked:
+        print("FAILED: egress was NOT restricted", file=sys.stderr)
+        return 1
+    return 0
+
+
+def run_dep_blocked(sandbox: Sandbox) -> int:
+    print("\n== [B] External dependency is blocked under air-gap ==")
+    sandbox.files.make_dir("/workspace/needsdep")
+    sandbox.files.write("/workspace/needsdep/go.mod", DEP_GOMOD)
+    sandbox.files.write("/workspace/needsdep/main.go", DEP_MAIN_GO)
+    res = sandbox.commands.run("go mod download", cwd="/workspace/needsdep")
+    blocked = res.exit_code != 0
+    print((res.stderr or res.stdout).strip())
+    print("external go mod download blocked:", blocked)
+    if not blocked:
+        print("FAILED: dependency download succeeded despite air-gap", file=sys.stderr)
+        return 1
+    return 0
+
+
+def run_with_proxy_allowlist() -> int:
+    """Allowlist mode: permit ONLY a module proxy (+ DNS), block the rest.
+
+    Enable by exporting CUBE_GOPROXY_CIDRS (comma-separated CIDRs), e.g. the
+    resolved CIDR(s) of your private GOPROXY and your DNS server. The sandbox
+    GOPROXY must point at that reachable proxy (CUBE_GOPROXY_URL).
+    """
+    raw = os.environ.get("CUBE_GOPROXY_CIDRS", "").strip()
+    if not raw:
+        print("\n== [C] Allowlist for deps: SKIPPED ==")
+        print(
+            "Set CUBE_GOPROXY_CIDRS to enable (e.g. '10.0.1.5/32,10.0.0.53/32')."
+        )
+        return 0
+
+    allow_out = [c.strip() for c in raw.split(",") if c.strip()]
+    proxy_url = os.environ.get("CUBE_GOPROXY_URL", "direct")
+    print(f"\n== [C] Allowlist for deps: allow_out={allow_out} GOPROXY={proxy_url} ==")
+    with Sandbox.create(
+        template=template_id,
+        allow_internet_access=False,
+        network={"allow_out": allow_out},
+    ) as sandbox:
+        sandbox.files.make_dir("/workspace/needsdep")
+        sandbox.files.write("/workspace/needsdep/go.mod", DEP_GOMOD)
+        sandbox.files.write("/workspace/needsdep/main.go", DEP_MAIN_GO)
+        res = sandbox.commands.run(
+            f"GOPROXY={proxy_url} GOFLAGS=-mod=mod go mod download",
+            cwd="/workspace/needsdep",
+        )
+        print(res.stdout)
+        if res.stderr:
+            print(res.stderr, file=sys.stderr)
+        if res.exit_code != 0:
+            print("FAILED: allowlist go mod download", file=sys.stderr)
+            return 1
+        print("allowlist go mod download passed \u2713")
+    return 0
+
+
+def main() -> int:
+    rc = 0
+    with Sandbox.create(template=template_id, allow_internet_access=False) as sandbox:
+        rc |= run_air_gapped(sandbox)
+        rc |= run_dep_blocked(sandbox)
+    rc |= run_with_proxy_allowlist()
+    return rc
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/go-sandbox/go_test.py
+++ b/examples/go-sandbox/go_test.py
@@ -1,0 +1,81 @@
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Run a Go unit test inside a Cube Sandbox.
+
+Writes a small Go module + test into the sandbox, runs `go test -v ./...`,
+and asserts it passes via the E2B SDK's `commands.run`.
+
+Prereqs: a Go template (see README), `pip install -r requirements.txt`,
+and `CUBE_TEMPLATE_ID` set in the environment.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+from e2b_code_interpreter import Sandbox
+
+from env_utils import load_local_dotenv
+
+load_local_dotenv()
+
+template_id = os.environ["CUBE_TEMPLATE_ID"]
+
+GOMOD = "module hellogo\n\ngo 1.23\n"
+
+MAIN_GO = """package main
+
+import "fmt"
+
+// Add returns the sum of two integers.
+func Add(a, b int) int { return a + b }
+
+func main() {
+\tfmt.Println("hello from go", Add(2, 3))
+}
+"""
+
+MAIN_TEST_GO = """package main
+
+import "testing"
+
+func TestAdd(t *testing.T) {
+\tif got := Add(2, 3); got != 5 {
+\t\tt.Fatalf("Add(2,3) = %d; want 5", got)
+\t}
+}
+"""
+
+
+def main() -> int:
+    with Sandbox.create(template=template_id) as sandbox:
+        print("== go version ==")
+        res = sandbox.commands.run("go version")
+        print(res.stdout.strip())
+        if res.exit_code != 0:
+            print("FAILED: `go` not found in template", file=sys.stderr)
+            print(res.stderr, file=sys.stderr)
+            return 1
+
+        sandbox.files.make_dir("/workspace/hellogo")
+        sandbox.files.write("/workspace/hellogo/go.mod", GOMOD)
+        sandbox.files.write("/workspace/hellogo/main.go", MAIN_GO)
+        sandbox.files.write("/workspace/hellogo/main_test.go", MAIN_TEST_GO)
+
+        print("\n== go test -v ./... ==")
+        res = sandbox.commands.run("go test -v ./...", cwd="/workspace/hellogo")
+        print(res.stdout)
+        if res.stderr:
+            print(res.stderr, file=sys.stderr)
+        if res.exit_code != 0:
+            print(f"FAILED: go test exited with {res.exit_code}", file=sys.stderr)
+            return 1
+
+        print("go test passed \u2713")
+        return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/go-sandbox/requirements.txt
+++ b/examples/go-sandbox/requirements.txt
@@ -1,0 +1,2 @@
+e2b-code-interpreter>=2.4.1
+python-dotenv


### PR DESCRIPTION
### What changed
What changed
Add a ready-to-use Go runtime sandbox template (examples/go-sandbox/) for Cube Sandbox, demonstrating how to compile and unit-test Go programs inside an isolated KVM MicroVM through the E2B-compatible Python SDK.

### Added
examples/go-sandbox/Dockerfile — builds the Go runtime image on top of cubesandbox-base (official Go toolchain copied in, envd kept on :49983); inherits the base cube-entrypoint.sh so envd stays up for the readiness probe.
examples/go-sandbox/go_test.py — minimal runnable flow: writes a Go module + unit test into the sandbox and asserts go test -v passes.
examples/go-sandbox/go_egress_restricted.py — differentiated scenario for restricted egress: [A] air-gapped zero-dependency build/test, [B] proof that egress is actually enforced (external go mod download fails), [C] opt-in allowlist recipe (only a private GOPROXY + DNS CIDR reachable).
examples/go-sandbox/env_utils.py — shared .env loader, matching the env_utils helper used by network-policy / code-sandbox-quickstart.
examples/go-sandbox/README.md & README_zh.md — scenario, resource recommendations, known limitations, security alignment, and the restricted-egress walkthrough.
examples/go-sandbox/requirements.txt, .env.example — dependencies and env var template.
Registered the example in docs/guide/tutorials/examples.md (EN) and docs/zh/guide/tutorials/examples.md (ZH), with the differentiated egress scenario noted for discoverability.

### Alignment / safety
Follows platform conventions: env_utils.py and the egress params (allow_internet_access=False, network={"allow_out":[...]}) match network-policy exactly.
Inherits the cubesandbox-base security baseline (envd auth, isolated kernel/network); no extra ports/services opened; no secrets baked into the image.
GOTOOLCHAIN=local pinned to prevent toolchain auto-download (supply-chain safeguard, deterministic air-gapped builds).

### Verification
Python files pass python -m py_compile.
Egress params verified against the platform data path (CubeNet eBPF session_policy_allowed): the policy is enforced at the kernel tap layer and cannot be bypassed from inside the VM.
Spinning up the sandbox on a real cluster requires a Cube Sandbox deployment (not available in this environment); steps are documented in README §3.

### Below are the smoke test script of shell commands and results showing that the template image can be built, can run Go, and can reach the READY state.

### Cluster-free smoke checks. Pure stdout (no file written). Run with:
### docker run --rm -v <dir>:/out cubesandbox-go:local sh -c 'sh /out/_inner.sh'

`!/bin/sh
set -e

echo "CubeSandbox Go Template - Cluster-free Smoke Test"
echo "  image : cubesandbox-go:local"
echo "  base  : ghcr.io/tencentcloud/cubesandbox-base:2026.16"
echo "  go    : $(go version | awk '{print $3" "$4}')"
echo "  scope : runs with 'docker run' only, no CubeSandbox cluster required"
echo

echo "Step 1/3  Go toolchain + go test"
echo "  What it checks: the bundled Go toolchain can compile and run a Go"
echo "  program, and 'go test' reports a passing unit test inside the image."
printf '  go version : %s\n' "$(go version | awk '{print $3" "$4}')"
rm -rf /tmp/demo && mkdir -p /tmp/demo/src && cd /tmp/demo
printf "module demo\n\ngo 1.23\n" > go.mod
printf "package main\nimport \"fmt\"\nfunc main(){ fmt.Println(\"hello cubesandbox\") }\n" > src/main.go
printf "package main\nimport \"testing\"\nfunc TestMath(t *testing.T){ if 1+1 != 2 { t.Fatal(\"math broke\") } }\n" > src/main_test.go
runout=$(go run src/main.go 2>&1)
echo "  build+run  : compiled and executed src/main.go"
echo "               -> output: $runout"
if go test ./... >/dev/null 2>&1; then testres=PASS; else testres=FAIL; fi
echo "  unit test  : TestMath"
echo "               -> $testres"
echo "Result: $testres"

echo
echo "Step 2/3  Build cache (GOCACHE) reuse"
echo "  What it checks: GOCACHE is writable and reused. A cold build compiles"
echo "  every package; an identical warm build must compile 0 (cache hit)."
rm -rf /tmp/demo && mkdir -p /tmp/demo/src && cd /tmp/demo
printf "module demo\n\ngo 1.23\n" > go.mod
printf "package main\nimport \"fmt\"\nfunc main(){ fmt.Println(\"ok\") }\n" > src/main.go
go clean -cache
cold=$(go build -x -o /tmp/app ./... 2>&1 | grep -c compile || true)
warm=$(go build -x -o /tmp/app ./... 2>&1 | grep -c compile || true)
echo "  cold compiles : $cold"
echo "  warm compiles : $warm"
if [ "$cold" -gt 0 ] && [ "$warm" -eq 0 ]; then
  echo "Result: PASS  (warm build served entirely from cache)"
else
  echo "Result: FAIL  (cold=$cold warm=$warm)"
  exit 1
fi

echo
echo "Step 3/3  envd /health probe"
echo "  What it checks: envd (the sandbox sidecar started by the image"
echo "  entrypoint) is alive and answers its health endpoint with HTTP 204."
code=$(curl -s -o /dev/null -w '%{http_code}' http://localhost:49983/health || true)
printf '  GET /health : %s\n' "$code"
if [ "$code" = "204" ]; then
  echo "Result: PASS"
else
  printf 'Result: FAIL  (expected 204, got %s)\n' "$code"
  exit 1
fi

echo
echo "Summary"
echo "  Step 1/3  Go toolchain + go test      PASS"
echo "  Step 2/3  Build cache reuse           PASS"
echo "  Step 3/3  envd /health probe          PASS"
echo "All 3 cluster-free checks passed."
echo "SDK-driven examples (go_http_server / pause_resume_go / go_mod_allowlist)"
echo "need a running CubeSandbox cluster and are verified separately."
`

<img width="1296" height="911" alt="屏幕截图 2026-07-11 194531" src="https://github.com/user-attachments/assets/c863a9c5-6f9a-4f1c-88bf-0988eb7ac748" />
