### PR TITLE
docs: add Claude Code, CodeBuddy, and OpenCode integrations

### DIFF
--- a/docs/guide/integrations/claude-code.md
+++ b/docs/guide/integrations/claude-code.md
@@ -75,9 +75,8 @@ RUN apt-get update \
         ca-certificates curl git gnupg jq less procps python3 python3-pip ripgrep \
     && curl -fsSL "https://deb.nodesource.com/setup_${NODE_MAJOR}.x" | bash - \
     && apt-get install -y --no-install-recommends nodejs \
-    && npm install -g --ignore-scripts "@anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}" \
+    && npm install -g "@anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}" \
     && claude --version \
-    && npm cache clean --force \
     && rm -rf /root/.npm /var/lib/apt/lists/*
 
 WORKDIR /workspace

--- a/docs/guide/integrations/claude-code.md
+++ b/docs/guide/integrations/claude-code.md
@@ -62,6 +62,10 @@ with your dev environment. Running it inside CubeSandbox gives you:
 The image stacks Node.js 24 and the Claude Code CLI on top of `cubesandbox-base`,
 so envd is already listening on `:49983`.
 
+The excerpt below highlights the main build steps. Use the checked-in
+`Dockerfile` as the canonical source for the exact package list, install flags,
+and environment settings.
+
 ```dockerfile
 # examples/claude-code-integration/Dockerfile (excerpt)
 ARG CUBE_BASE_IMAGE=ghcr.io/tencentcloud/cubesandbox-base:2026.16

--- a/docs/guide/integrations/claude-code.md
+++ b/docs/guide/integrations/claude-code.md
@@ -33,7 +33,8 @@ project.
 
 ## Prerequisites
 
-- A running CubeSandbox deployment; CubeAPI reachable at `http://<node>:3000`.
+- A running CubeSandbox deployment; CubeAPI reachable at `https://<node>:3000`.
+  Use plain HTTP only for isolated local development on loopback.
 - `cubemastercli` on `$PATH`, connected to the cluster.
 - Docker on the build workstation, plus a registry the Cube nodes can pull from.
 - An Anthropic API key (or an Anthropic-compatible endpoint via `ANTHROPIC_BASE_URL`).
@@ -120,7 +121,7 @@ pip install -r requirements.txt
 
 | Variable | Where it flows | Notes |
 |---|---|---|
-| `E2B_API_URL` | Local process | CubeAPI address (`http://<node>:3000`) |
+| `E2B_API_URL` | Local process | TLS-protected CubeAPI address (`https://<node>:3000`) |
 | `E2B_API_KEY` | Local process | Any non-empty string in local dev |
 | `CUBE_TEMPLATE_ID` | `Sandbox.create(template=...)` | From step 2 |
 | `ANTHROPIC_API_KEY` | `envs=...` (direct) or CubeEgress inject (vault) | Anthropic key |
@@ -257,7 +258,8 @@ version = sandbox.commands.run("claude --version", timeout=60)
 - **Node.js version.** Claude Code needs a recent Node runtime; the base image
   ships an older apt Node, so always install via NodeSource (the Dockerfile does).
 - **Node.js CA (CubeEgress).** For the vault flavor the sandbox must trust the
-  CubeEgress root CA, which the base image installs into the system bundle.
+  CubeEgress root CA, which CubeMaster bakes as the dedicated
+  `/usr/local/share/ca-certificates/cube-egress-root.crt` anchor.
   Claude Code runs on Node.js, which ignores the system store, so
   `network_policy.py` also sets `NODE_EXTRA_CA_CERTS` (override via
   `CLAUDE_CODE_NODE_EXTRA_CA_CERTS`) — without it the vault path fails with

--- a/docs/guide/integrations/claude-code.md
+++ b/docs/guide/integrations/claude-code.md
@@ -1,0 +1,294 @@
+---
+title: Claude Code Integration Guide
+author: zhangzherui
+date: 2026-07-11
+tags:
+  - integration
+  - claude-code
+  - coding-agent
+  - agent
+lang: en-US
+---
+
+# Claude Code Integration Guide
+
+[中文文档](../../zh/guide/integrations/claude-code.md)
+
+Run [Claude Code](https://docs.anthropic.com/en/docs/claude-code)
+— Anthropic's official CLI coding agent — inside CubeSandbox MicroVMs. This
+guide covers image build, key injection, egress control, and snapshot-based
+session persistence, and pairs with the runnable
+[`examples/claude-code-integration`](https://github.com/TencentCloud/CubeSandbox/tree/master/examples/claude-code-integration)
+project.
+
+## Integration Target and Version
+
+| Component | Version |
+|---|---|
+| Claude Code CLI | `@anthropic-ai/claude-code` (pinned via `--build-arg CLAUDE_CODE_VERSION=x.y.z`) |
+| Node.js | 24 (installed via NodeSource) |
+| CubeSandbox base image | `ghcr.io/tencentcloud/cubesandbox-base:2026.16` |
+| E2B SDK (host driver) | `e2b` (latest) |
+| CubeSandbox platform | `>= 0.3.0` (pause/resume) / `>= 0.4.0` (CubeEgress credential vault) |
+
+## Prerequisites
+
+- A running CubeSandbox deployment; CubeAPI reachable at `http://<node>:3000`.
+- `cubemastercli` on `$PATH`, connected to the cluster.
+- Docker on the build workstation, plus a registry the Cube nodes can pull from.
+- An Anthropic API key (or an Anthropic-compatible endpoint via `ANTHROPIC_BASE_URL`).
+- Python 3.10+ for the host driver scripts.
+
+## Why Run Claude Code Inside a Sandbox
+
+Claude Code is a terminal agent that edits files, runs commands, and installs
+packages. Running it directly on a workstation blends the agent's blast radius
+with your dev environment. Running it inside CubeSandbox gives you:
+
+| Concern | CubeSandbox provides |
+|---|---|
+| **Isolation** | KVM MicroVM per session, dedicated guest kernel |
+| **Reproducibility** | Every session boots from the same template snapshot |
+| **Fast spin-up** | Sub-60 ms cold start, so N-parallel agents are cheap |
+| **Long tasks** | `sandbox.pause()` snapshots VM + rootfs; resume later |
+| **Key hygiene** | CubeEgress injects the auth header on the wire — the VM never sees the real key |
+| **Egress audit** | Every request to the LLM API is recorded in the egress audit log |
+
+## Integration Steps
+
+### 1. Build the template image
+
+The image stacks Node.js 24 and the Claude Code CLI on top of `cubesandbox-base`,
+so envd is already listening on `:49983`.
+
+```dockerfile
+# examples/claude-code-integration/Dockerfile (excerpt)
+ARG CUBE_BASE_IMAGE=ghcr.io/tencentcloud/cubesandbox-base:2026.16
+FROM ${CUBE_BASE_IMAGE}
+
+ARG NODE_MAJOR=24
+ARG CLAUDE_CODE_VERSION=1.0.33
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        ca-certificates curl git gnupg jq less procps python3 python3-pip ripgrep \
+    && curl -fsSL "https://deb.nodesource.com/setup_${NODE_MAJOR}.x" | bash - \
+    && apt-get install -y --no-install-recommends nodejs \
+    && npm install -g --ignore-scripts "@anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}" \
+    && claude --version \
+    && npm cache clean --force \
+    && rm -rf /root/.npm /var/lib/apt/lists/*
+
+WORKDIR /workspace
+EXPOSE 49983
+```
+
+Build and push:
+
+```bash
+docker build --platform linux/amd64 \
+  -t <your-registry>/claude-code-cube:latest \
+  examples/claude-code-integration
+docker push <your-registry>/claude-code-cube:latest
+```
+
+### 2. Register as a Cube template
+
+```bash
+cubemastercli tpl create-from-image \
+  --image <your-registry>/claude-code-cube:latest \
+  --writable-layer-size 4G \
+  --expose-port 49983 \
+  --probe       49983 \
+  --probe-path  /health
+
+cubemastercli tpl watch --job-id <job_id>
+```
+
+Once the job reaches `READY`, note the `template_id` — you pass it to every
+`Sandbox.create()` call. `4G` writable layer suits medium tasks; bump to `8G+`
+if the agent installs large toolchains.
+
+### 3. Wire up the host driver
+
+```bash
+cd examples/claude-code-integration
+cp .env.example .env
+# fill in E2B_API_URL, CUBE_TEMPLATE_ID, and your Anthropic key
+pip install -r requirements.txt
+```
+
+| Variable | Where it flows | Notes |
+|---|---|---|
+| `E2B_API_URL` | Local process | CubeAPI address (`http://<node>:3000`) |
+| `E2B_API_KEY` | Local process | Any non-empty string in local dev |
+| `CUBE_TEMPLATE_ID` | `Sandbox.create(template=...)` | From step 2 |
+| `ANTHROPIC_API_KEY` | `envs=...` (direct) or CubeEgress inject (vault) | Anthropic key |
+| `ANTHROPIC_BASE_URL` | Passed into the exec env | Anthropic-compatible gateways (e.g. DeepSeek) |
+| `CLAUDE_CODE_MODEL` | Claude CLI `--model` flag | Defaults to `claude-sonnet-4-6` |
+| `CLAUDE_CODE_LLM_HOST` | `network_policy.py` | LLM host allowed under default-deny egress |
+
+### 4. Runtime Configuration and API Key Injection
+
+The Claude Code command is built headlessly with `-p` (the `--print` flag for
+non-interactive mode — process the prompt and exit, no TUI), an explicit model
+via `--model`, and `--output-format stream-json` so the host can capture a
+machine-readable JSONL event stream. `--accept-edits` auto-approves file edits
+in an isolated sandbox, and the prompt is the positional argument to `-p`.
+Two key-flow flavors share the same template:
+
+**Direct flavor** — forward the key per command. `e2b`'s `commands.run(envs=...)`
+puts the environment into the exec envelope, not into a persistent file inside
+the VM, so the key lives only for the lifetime of that command:
+
+```python
+result = sandbox.commands.run(
+    "cd /workspace && claude -p --output-format stream-json "
+    "--model claude-sonnet-4-6 --accept-edits 'do something'",
+    envs={"ANTHROPIC_API_KEY": key},
+    user="root",
+    timeout=900,
+)
+```
+
+**Vault flavor** — keep the key out of the VM entirely (see step 6).
+
+The example scripts parse this JSONL and print a concise transcript by default
+(assistant text, tool calls, and any failures); pass `--raw` (or set
+`CLAUDE_CODE_STREAM_RAW=1`) to see the raw event stream.
+
+### 5. Session Persistence (pause / resume)
+
+```bash
+python resume_claude_code.py
+```
+
+This mirrors the [snapshot / clone / rollback](../snapshot-rollback-clone.md)
+engine at the SDK layer:
+
+- `sandbox.pause()` snapshots the running VM (memory + rootfs) and frees compute.
+- `Sandbox.connect(sandbox_id)` resumes with `/workspace` and every other file
+  intact.
+
+> **Lifecycle caveat:** manage the sandbox lifecycle with `try/finally`, not a
+> `with Sandbox.create(...)` context manager. On `__exit__` the context manager
+> kills the sandbox, which would undo the pause. The example creates the sandbox
+> explicitly and only calls `sandbox.kill()` in `finally`.
+
+```python
+sandbox = Sandbox.create(template=template_id, timeout=1800)
+try:
+    run_turn(sandbox, prompt_1)          # writes /workspace/plan.md
+    sandbox_id = sandbox.pause() or sandbox.sandbox_id
+    sandbox = Sandbox.connect(sandbox_id)
+    assert_state_survived(sandbox)       # /workspace intact
+    run_turn(sandbox, prompt_2)          # continues the work
+finally:
+    sandbox.kill()
+```
+
+### 6. Network and Egress Policy (credential vault)
+
+`network_policy.py` demonstrates the recommended pattern for shared clusters:
+default-deny egress plus on-the-wire key injection.
+
+```python
+# Credential injection uses the native cubesandbox SDK (see security-proxy.md).
+from cubesandbox import Sandbox, Rule, Match, Action, Inject
+
+host = "api.anthropic.com"
+rules = [
+    Rule(
+        name="allow_anthropic_llm",
+        match=Match(scheme="https", sni=host, host=host),
+        action=Action(allow=True, audit="metadata", inject=[
+            Inject(header="x-api-key", secret=ANTHROPIC_API_KEY, format="${SECRET}"),
+            Inject(header="anthropic-version", secret="2023-06-01", format="${SECRET}"),
+        ]),
+    ),
+]
+
+sandbox = Sandbox.create(
+    template=CUBE_TEMPLATE_ID,
+    allow_internet_access=False,   # default-deny; the rule's host is auto-allowed
+    network={"rules": rules},
+)
+```
+
+Effect:
+
+- `printenv ANTHROPIC_API_KEY` inside the sandbox shows only a placeholder.
+- Every request to the LLM host gets the auth headers attached on the wire.
+- Anything else is dropped by CubeVS at L3/L4 (`allow_internet_access=False`) and never leaves the sandbox.
+- Every allow / deny decision lands in the egress audit log.
+
+## Use Cases and Best Practices
+
+- **Isolated development.** Run the coding agent inside the sandbox so its file
+  edits and shell commands cannot touch the host.
+- **Execute agent-generated code and collect results.** Have the agent write to
+  `/workspace`, then read artifacts back via `sandbox.files` or `commands.run`.
+- **Checkpoint / resume long tasks.** Use `pause()` + `connect()` to snapshot a
+  long refactor and resume later, or fork multiple task variants off one snapshot.
+- **Preinstall heavy dependencies** into the template rather than fetching them
+  at runtime, especially under a default-deny egress policy.
+
+## Key Code Snippets
+
+### Headless Claude Code invocation
+
+```python
+cmd = (
+    "cd /workspace && claude -p --output-format stream-json "
+    "--model claude-sonnet-4-6 "
+    "--accept-edits 'Inspect the project, run app.py, and summarize the result.'"
+)
+result = sandbox.commands.run(cmd, envs=claude_env, user="root", timeout=900)
+```
+
+### Preflight version check
+
+```python
+version = sandbox.commands.run("claude --version", timeout=60)
+```
+
+## Caveats
+
+- **Node.js version.** Claude Code needs a recent Node runtime; the base image
+  ships an older apt Node, so always install via NodeSource (the Dockerfile does).
+- **Node.js CA (CubeEgress).** For the vault flavor the sandbox must trust the
+  CubeEgress root CA, which the base image installs into the system bundle.
+  Claude Code runs on Node.js, which ignores the system store, so
+  `network_policy.py` also sets `NODE_EXTRA_CA_CERTS` (override via
+  `CLAUDE_CODE_NODE_EXTRA_CA_CERTS`) — without it the vault path fails with
+  `Connection error`.
+- **Key persistence.** With the direct flavor (`envs=`) the key is scoped to the
+  exec call, but it is visible in the process environment during the run. For
+  strict isolation prefer the vault flavor (`network_policy.py`), where the key
+  never enters the VM.
+- **Egress side-effects.** Tasks that `npm install` or fetch MCP tools need those
+  hosts allowed or preinstalled into the template.
+- **TTY limitation.** Claude Code's interactive TUI is not available over the E2B
+  protocol. Use headless `-p --output-format stream-json` and drive multi-turn
+  conversations from the host script.
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| `claude: command not found` in preflight | Template not rebuilt after CLI change | Rebuild the image, re-register the template |
+| Anthropic auth failure | Key not forwarded (direct) or missing inject rule (vault) | Pass `envs={...}` or fix the rule's `sni`/`host` |
+| `403 Forbidden - CubeEgress` | Default-deny with no matching allow rule | Add the LLM host (and any extra hosts) to the rules |
+| `Connection error` / TLS failure from Claude Code (vault) | Claude Code's Node runtime ignores the system CA store, so it won't trust the CubeEgress CA | The example sets `NODE_EXTRA_CA_CERTS`; override with `CLAUDE_CODE_NODE_EXTRA_CA_CERTS` if the CA lives elsewhere |
+| Template creation stuck in `PULLING` | Registry unreachable from Cube nodes | Push to a registry the cluster can reach; supply auth if needed |
+| Readiness probe timeout | Base image without envd | Ensure `FROM ghcr.io/tencentcloud/cubesandbox-base:2026.16` |
+| `pause()` / `connect()` errors | Platform too old for snapshots | Upgrade the CubeSandbox platform |
+
+## References
+
+- Runnable example: [`examples/claude-code-integration`](https://github.com/TencentCloud/CubeSandbox/tree/master/examples/claude-code-integration)
+- Bring Your Own Image: [`docs/guide/tutorials/bring-your-own-image.md`](../tutorials/bring-your-own-image.md)
+- Template from image: [`docs/guide/tutorials/template-from-image.md`](../tutorials/template-from-image.md)
+- Snapshot / Clone / Rollback: [`docs/guide/snapshot-rollback-clone.md`](../snapshot-rollback-clone.md)
+- Credential vault + egress control: [`docs/guide/security-proxy.md`](../security-proxy.md)
+- Claude Code: <https://docs.anthropic.com/en/docs/claude-code>

--- a/docs/guide/integrations/codebuddy.md
+++ b/docs/guide/integrations/codebuddy.md
@@ -33,7 +33,8 @@ project.
 
 ## Prerequisites
 
-- A running CubeSandbox deployment; CubeAPI reachable at `http://<node>:3000`.
+- A running CubeSandbox deployment; CubeAPI reachable at `https://<node>:3000`.
+  Use plain HTTP only for isolated local development on loopback.
 - `cubemastercli` on `$PATH`, connected to the cluster.
 - Docker on the build workstation, plus a registry the Cube nodes can pull from.
 - An LLM provider API key. Anthropic is the default; any Anthropic-compatible or
@@ -121,10 +122,11 @@ pip install -r requirements.txt
 
 | Variable | Where it flows | Notes |
 |---|---|---|
-| `E2B_API_URL` | Local process | CubeAPI address (`http://<node>:3000`) |
+| `E2B_API_URL` | Local process | TLS-protected CubeAPI address (`https://<node>:3000`) |
 | `E2B_API_KEY` | Local process | Any non-empty string in local dev |
 | `CUBE_TEMPLATE_ID` | `Sandbox.create(template=...)` | From step 2 |
 | `CODEBUDDY_MODEL` | CodeBuddy CLI `--model` flag | Model selection |
+| `CODEBUDDY_PROVIDER` | Local script | Provider name: `anthropic`, `openai`, `google`, `deepseek`, or `openrouter` |
 | `ANTHROPIC_API_KEY` | `envs=...` (direct) or CubeEgress inject (vault) | Provider key |
 | `ANTHROPIC_BASE_URL` | Passed into the exec env | Anthropic-compatible gateways (e.g. DeepSeek) |
 | `CODEBUDDY_LLM_HOST` | `network_policy.py` | LLM host allowed under default-deny egress |
@@ -272,7 +274,8 @@ version = sandbox.commands.run("codebuddy --version", timeout=60)
   strict isolation prefer the vault flavor (`network_policy.py`), where the key
   never enters the VM.
 - **CubeEgress CA (Node).** For the vault flavor the sandbox must trust the
-  CubeEgress root CA, which the base image installs into the system bundle.
+  CubeEgress root CA, which CubeMaster bakes as the dedicated
+  `/usr/local/share/ca-certificates/cube-egress-root.crt` anchor.
   CodeBuddy runs on Node.js, which ignores the system store, so
   `network_policy.py` also sets `NODE_EXTRA_CA_CERTS` (override via
   `CODEBUDDY_NODE_EXTRA_CA_CERTS`) — without it the vault path fails with

--- a/docs/guide/integrations/codebuddy.md
+++ b/docs/guide/integrations/codebuddy.md
@@ -63,6 +63,10 @@ with your dev environment. Running it inside CubeSandbox gives you:
 The image stacks Node.js 24 and the CodeBuddy CLI on top of `cubesandbox-base`,
 so envd is already listening on `:49983`.
 
+The excerpt below highlights the main build steps. Use the checked-in
+`Dockerfile` as the canonical source for the exact package list, install flags,
+and environment settings.
+
 ```dockerfile
 # examples/codebuddy-integration/Dockerfile (excerpt)
 ARG CUBE_BASE_IMAGE=ghcr.io/tencentcloud/cubesandbox-base:2026.16

--- a/docs/guide/integrations/codebuddy.md
+++ b/docs/guide/integrations/codebuddy.md
@@ -1,0 +1,309 @@
+---
+title: CodeBuddy Integration Guide
+author: zhangzherui
+date: 2026-07-11
+tags:
+  - integration
+  - codebuddy
+  - coding-agent
+  - agent
+lang: en-US
+---
+
+# CodeBuddy Integration Guide
+
+[中文文档](../../zh/guide/integrations/codebuddy.md)
+
+Run [CodeBuddy](https://www.npmjs.com/package/@tencent-ai/codebuddy-code) — an AI coding
+agent CLI — inside CubeSandbox MicroVMs. This guide covers image build, key
+injection, egress control, and snapshot-based session persistence, and pairs
+with the runnable
+[`examples/codebuddy-integration`](https://github.com/TencentCloud/CubeSandbox/tree/master/examples/codebuddy-integration)
+project.
+
+## Integration Target and Version
+
+| Component | Version |
+|---|---|
+| CodeBuddy CLI | `@tencent-ai/codebuddy-code` (pinned via `--build-arg CODEBUDDY_VERSION=x.y.z`) |
+| Node.js | 24 (installed via NodeSource) |
+| CubeSandbox base image | `ghcr.io/tencentcloud/cubesandbox-base:2026.16` |
+| E2B SDK (host driver) | `e2b` (latest) |
+| CubeSandbox platform | `>= 0.3.0` (pause/resume) / `>= 0.4.0` (CubeEgress credential vault) |
+
+## Prerequisites
+
+- A running CubeSandbox deployment; CubeAPI reachable at `http://<node>:3000`.
+- `cubemastercli` on `$PATH`, connected to the cluster.
+- Docker on the build workstation, plus a registry the Cube nodes can pull from.
+- An LLM provider API key. Anthropic is the default; any Anthropic-compatible or
+  OpenAI-compatible endpoint works via `ANTHROPIC_BASE_URL` / provider env.
+- Python 3.10+ for the host driver scripts.
+
+## Why Run CodeBuddy Inside a Sandbox
+
+CodeBuddy is a coding agent that edits files, runs commands, and installs
+packages. Running it directly on a workstation blends the agent's blast radius
+with your dev environment. Running it inside CubeSandbox gives you:
+
+| Concern | CubeSandbox provides |
+|---|---|
+| **Isolation** | KVM MicroVM per session, dedicated guest kernel |
+| **Reproducibility** | Every session boots from the same template snapshot |
+| **Fast spin-up** | Sub-60 ms cold start, so N-parallel agents are cheap |
+| **Long tasks** | `sandbox.pause()` snapshots VM + rootfs; resume later |
+| **Key hygiene** | CubeEgress injects the auth header on the wire — the VM never sees the real key |
+| **Egress audit** | Every request to the LLM API is recorded in the egress audit log |
+
+## Integration Steps
+
+### 1. Build the template image
+
+The image stacks Node.js 24 and the CodeBuddy CLI on top of `cubesandbox-base`,
+so envd is already listening on `:49983`.
+
+```dockerfile
+# examples/codebuddy-integration/Dockerfile (excerpt)
+ARG CUBE_BASE_IMAGE=ghcr.io/tencentcloud/cubesandbox-base:2026.16
+FROM ${CUBE_BASE_IMAGE}
+
+ARG NODE_MAJOR=24
+ARG CODEBUDDY_VERSION=2.119.2
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        ca-certificates curl git gnupg jq less procps python3 python3-pip ripgrep \
+    && curl -fsSL "https://deb.nodesource.com/setup_${NODE_MAJOR}.x" | bash - \
+    && apt-get install -y --no-install-recommends nodejs \
+    && npm install -g --ignore-scripts "@tencent-ai/codebuddy-code@${CODEBUDDY_VERSION}" \
+    && codebuddy --version \
+    && npm cache clean --force \
+    && rm -rf /root/.npm /var/lib/apt/lists/*
+
+WORKDIR /workspace
+EXPOSE 49983
+```
+
+Build and push:
+
+```bash
+docker build --platform linux/amd64 \
+  -t <your-registry>/codebuddy-cube:latest \
+  examples/codebuddy-integration
+docker push <your-registry>/codebuddy-cube:latest
+```
+
+### 2. Register as a Cube template
+
+```bash
+cubemastercli tpl create-from-image \
+  --image <your-registry>/codebuddy-cube:latest \
+  --writable-layer-size 4G \
+  --expose-port 49983 \
+  --probe       49983 \
+  --probe-path  /health
+
+cubemastercli tpl watch --job-id <job_id>
+```
+
+Once the job reaches `READY`, note the `template_id` — you pass it to every
+`Sandbox.create()` call. `4G` writable layer suits medium tasks; bump to `8G+`
+if the agent installs large toolchains.
+
+### 3. Wire up the host driver
+
+```bash
+cd examples/codebuddy-integration
+cp .env.example .env
+# fill in E2B_API_URL, CUBE_TEMPLATE_ID, and your provider key
+pip install -r requirements.txt
+```
+
+| Variable | Where it flows | Notes |
+|---|---|---|
+| `E2B_API_URL` | Local process | CubeAPI address (`http://<node>:3000`) |
+| `E2B_API_KEY` | Local process | Any non-empty string in local dev |
+| `CUBE_TEMPLATE_ID` | `Sandbox.create(template=...)` | From step 2 |
+| `CODEBUDDY_MODEL` | CodeBuddy CLI `--model` flag | Model selection |
+| `ANTHROPIC_API_KEY` | `envs=...` (direct) or CubeEgress inject (vault) | Provider key |
+| `ANTHROPIC_BASE_URL` | Passed into the exec env | Anthropic-compatible gateways (e.g. DeepSeek) |
+| `CODEBUDDY_LLM_HOST` | `network_policy.py` | LLM host allowed under default-deny egress |
+
+### 4. Runtime Configuration and API Key Injection
+
+The CodeBuddy command is built headlessly with `-p` (``--print`` — process the
+prompt and exit, no TUI), an explicit `--model`, `--output-format stream-json`
+so the host can capture a machine-readable JSONL event stream, and
+`--permission-mode acceptEdits` to allow file edits without prompting in an
+isolated sandbox. The prompt is the positional argument after `-p`. Two key-flow
+flavors share the same template:
+
+**Direct flavor** — forward the key per command. `e2b`'s `commands.run(envs=...)`
+puts the environment into the exec envelope, not into a persistent file inside
+the VM, so the key lives only for the lifetime of that command:
+
+```python
+result = sandbox.commands.run(
+    "cd /workspace && codebuddy -p --output-format stream-json "
+    "--model claude-sonnet-4-6 --permission-mode acceptEdits "
+    "'do something'",
+    envs={"ANTHROPIC_API_KEY": key},
+    user="root",
+    timeout=900,
+)
+```
+
+**Vault flavor** — keep the key out of the VM entirely (see step 6).
+
+The example scripts parse this JSONL and print a concise transcript by default
+(assistant text, tool calls, and any failures); pass `--raw` (or set
+`CODEBUDDY_STREAM_RAW=1`) to see the raw event stream.
+
+### 5. Session Persistence (pause / resume)
+
+```bash
+python resume_codebuddy.py
+```
+
+This mirrors the [snapshot / clone / rollback](../snapshot-rollback-clone.md)
+engine at the SDK layer:
+
+- `sandbox.pause()` snapshots the running VM (memory + rootfs) and frees compute.
+- `Sandbox.connect(sandbox_id)` resumes with `/workspace`, CodeBuddy's state
+  directory (`/root/.codebuddy`), and every other file intact.
+
+> **Lifecycle caveat:** manage the sandbox lifecycle with `try/finally`, not a
+> `with Sandbox.create(...)` context manager. On `__exit__` the context manager
+> kills the sandbox, which would undo the pause. The example creates the sandbox
+> explicitly and only calls `sandbox.kill()` in `finally`.
+
+```python
+sandbox = Sandbox.create(template=template_id, timeout=1800)
+try:
+    run_turn(sandbox, prompt_1)          # writes /workspace/plan.md
+    sandbox_id = sandbox.pause() or sandbox.sandbox_id
+    sandbox = Sandbox.connect(sandbox_id)
+    assert_state_survived(sandbox)       # /workspace + /root/.codebuddy intact
+    run_turn(sandbox, prompt_2)          # continues the work
+finally:
+    sandbox.kill()
+```
+
+### 6. Network and Egress Policy (credential vault)
+
+`network_policy.py` demonstrates the recommended pattern for shared clusters:
+default-deny egress plus on-the-wire key injection.
+
+```python
+# Credential injection uses the native cubesandbox SDK (see security-proxy.md).
+from cubesandbox import Sandbox, Rule, Match, Action, Inject
+
+host = "api.anthropic.com"
+rules = [
+    Rule(
+        name="allow_anthropic_llm",
+        match=Match(scheme="https", sni=host, host=host),
+        action=Action(allow=True, audit="metadata", inject=[
+            Inject(header="x-api-key", secret=ANTHROPIC_API_KEY, format="${SECRET}"),
+            Inject(header="anthropic-version", secret="2023-06-01", format="${SECRET}"),
+        ]),
+    ),
+]
+
+sandbox = Sandbox.create(
+    template=CUBE_TEMPLATE_ID,
+    allow_internet_access=False,   # default-deny; the rule's host is auto-allowed
+    network={"rules": rules},
+)
+```
+
+Effect:
+
+- `printenv ANTHROPIC_API_KEY` inside the sandbox shows only a placeholder.
+- Every request to the LLM host gets the auth header attached on the wire.
+- Anything else is dropped by CubeVS at L3/L4 (`allow_internet_access=False`) and never leaves the sandbox.
+- Every allow / deny decision lands in the egress audit log.
+
+For non-Anthropic providers the example injects an `Authorization: Bearer`
+header instead. If a provider does not accept a header-injected key, fall back
+to the direct flavor (`envs=...`) — but never write the key into a persistent
+file inside the sandbox.
+
+## Use Cases and Best Practices
+
+- **Isolated development.** Run the coding agent inside the sandbox so its file
+  edits and shell commands cannot touch the host.
+- **Execute agent-generated code and collect results.** Have the agent write to
+  `/workspace`, then read artifacts back via `sandbox.files` or `commands.run`.
+- **Checkpoint / resume long tasks.** Use `pause()` + `connect()` to snapshot a
+  long refactor and resume later, or fork multiple task variants off one snapshot.
+- **Preinstall heavy dependencies** into the template rather than fetching them
+  at runtime, especially under a default-deny egress policy.
+
+## Key Code Snippets
+
+### Headless CodeBuddy invocation
+
+```python
+cmd = (
+    "cd /workspace && codebuddy -p --output-format stream-json "
+    "--model claude-sonnet-4-6 --permission-mode acceptEdits "
+    "'Inspect the project, run app.py, and summarize the result.'"
+)
+result = sandbox.commands.run(cmd, envs=codebuddy_env, user="root", timeout=900)
+```
+
+### Preflight version check
+
+```python
+version = sandbox.commands.run("codebuddy --version", timeout=60)
+```
+
+## Caveats
+
+- **Node.js version.** CodeBuddy needs a recent Node runtime; the base image
+  ships an older apt Node, so always install via NodeSource (the Dockerfile does).
+- **Agent state directory.** `/root/.codebuddy` holds CodeBuddy's session cache.
+  Keep it empty in the image to avoid leaking sessions across tenants; it is
+  created at build time but not populated with any credentials.
+- **Direct-flavor key persistence.** With the direct flavor (`envs=`) the key is
+  scoped to the exec call, but CodeBuddy may cache provider credentials under its
+  state dir (`/root/.codebuddy/`), which survives `pause()` / `resume()`. For
+  strict isolation prefer the vault flavor (`network_policy.py`), where the key
+  never enters the VM.
+- **CubeEgress CA (Node).** For the vault flavor the sandbox must trust the
+  CubeEgress root CA, which the base image installs into the system bundle.
+  CodeBuddy runs on Node.js, which ignores the system store, so
+  `network_policy.py` also sets `NODE_EXTRA_CA_CERTS` (override via
+  `CODEBUDDY_NODE_EXTRA_CA_CERTS`) — without it the vault path fails with
+  `Connection error`.
+- **Egress side-effects.** Tasks that `npm install` or fetch MCP tools need
+  those hosts allowed or preinstalled into the template.
+- **Interactive TTY features.** CodeBuddy's interactive TUI is not available
+  over the E2B protocol. Use headless `-p --output-format stream-json` and drive
+  multi-turn conversations from the host script.
+- **Built-in `--sandbox` flag.** CodeBuddy has a native `--sandbox` flag that
+  connects to E2B/CubeSandbox directly, but this integration uses the Python host
+  driver approach for more control over egress policy, credential injection, and
+  session lifecycle.
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| `codebuddy: command not found` in preflight | Template not rebuilt after CLI change | Rebuild the image, re-register the template |
+| Provider auth failure | Key not forwarded (direct) or missing inject rule (vault) | Pass `envs={...}` or fix the rule's `sni`/`host` |
+| `403 Forbidden - CubeEgress` | Default-deny with no matching allow rule | Add the LLM host (and any extra hosts) to the rules |
+| `Connection error` / TLS failure from CodeBuddy (vault) | CodeBuddy's Node runtime ignores the system CA store, so it won't trust the CubeEgress CA | The example sets `NODE_EXTRA_CA_CERTS`; override with `CODEBUDDY_NODE_EXTRA_CA_CERTS` if the CA lives elsewhere |
+| Template creation stuck in `PULLING` | Registry unreachable from Cube nodes | Push to a registry the cluster can reach; supply auth if needed |
+| Readiness probe timeout | Base image without envd | Ensure `FROM ghcr.io/tencentcloud/cubesandbox-base:2026.16` |
+| `pause()` / `connect()` errors | Platform too old for snapshots | Upgrade the CubeSandbox platform |
+
+## References
+
+- Runnable example: [`examples/codebuddy-integration`](https://github.com/TencentCloud/CubeSandbox/tree/master/examples/codebuddy-integration)
+- Bring Your Own Image: [`docs/guide/tutorials/bring-your-own-image.md`](../tutorials/bring-your-own-image.md)
+- Template from image: [`docs/guide/tutorials/template-from-image.md`](../tutorials/template-from-image.md)
+- Snapshot / Clone / Rollback: [`docs/guide/snapshot-rollback-clone.md`](../snapshot-rollback-clone.md)
+- Credential vault + egress control: [`docs/guide/security-proxy.md`](../security-proxy.md)
+- CodeBuddy CLI: <https://www.npmjs.com/package/@tencent-ai/codebuddy-code>

--- a/docs/guide/integrations/codebuddy.md
+++ b/docs/guide/integrations/codebuddy.md
@@ -76,9 +76,8 @@ RUN apt-get update \
         ca-certificates curl git gnupg jq less procps python3 python3-pip ripgrep \
     && curl -fsSL "https://deb.nodesource.com/setup_${NODE_MAJOR}.x" | bash - \
     && apt-get install -y --no-install-recommends nodejs \
-    && npm install -g --ignore-scripts "@tencent-ai/codebuddy-code@${CODEBUDDY_VERSION}" \
+    && npm install -g "@tencent-ai/codebuddy-code@${CODEBUDDY_VERSION}" \
     && codebuddy --version \
-    && npm cache clean --force \
     && rm -rf /root/.npm /var/lib/apt/lists/*
 
 WORKDIR /workspace

--- a/docs/guide/integrations/index.md
+++ b/docs/guide/integrations/index.md
@@ -48,3 +48,6 @@ lang: en-US
 | Title | Author | Date | Tags |
 | --- | --- | --- | --- |
 | [Pi Agent Integration Guide](./pi-agent.md) | chaojixinren | 2026-07-01 | integration, pi-agent, coding-agent, agent |
+| [Claude Code Integration Guide](./claude-code.md) | zhangzherui | 2026-07-11 | integration, claude-code, coding-agent, agent |
+| [CodeBuddy Integration Guide](./codebuddy.md) | zhangzherui | 2026-07-11 | integration, codebuddy, coding-agent, agent |
+| [OpenCode Integration Guide](./opencode.md) | zhangzherui | 2026-07-11 | integration, opencode, coding-agent, agent |

--- a/docs/guide/integrations/opencode.md
+++ b/docs/guide/integrations/opencode.md
@@ -1,0 +1,337 @@
+---
+title: OpenCode Integration Guide
+author: zhangzherui
+date: 2026-07-11
+tags:
+  - integration
+  - opencode
+  - coding-agent
+  - agent
+lang: en-US
+---
+
+# OpenCode Integration Guide
+
+[中文文档](../../zh/guide/integrations/opencode.md)
+
+Run [OpenCode](https://www.npmjs.com/package/opencode-ai)
+— a terminal-native AI coding agent — inside CubeSandbox MicroVMs. This guide
+covers image build, key injection, egress control, snapshot-based session
+persistence, and both headless and server-mode integration, pairing with the
+runnable
+[`examples/opencode-integration`](https://github.com/TencentCloud/CubeSandbox/tree/master/examples/opencode-integration)
+project.
+
+## Integration Target and Version
+
+| Component | Version |
+|---|---|
+| OpenCode coding agent | `opencode-ai` (pinned via `--build-arg OPENCODE_VERSION=x.y.z`) |
+| Node.js | 24 (installed via NodeSource) |
+| CubeSandbox base image | `ghcr.io/tencentcloud/cubesandbox-base:2026.16` |
+| E2B SDK (host driver) | `e2b` (latest) |
+| CubeSandbox platform | `>= 0.3.0` (pause/resume) / `>= 0.4.0` (CubeEgress credential vault) |
+
+## Prerequisites
+
+- A running CubeSandbox deployment; CubeAPI reachable at `http://<node>:3000`.
+- `cubemastercli` on `$PATH`, connected to the cluster.
+- Docker on the build workstation, plus a registry the Cube nodes can pull from.
+- An LLM provider API key. Anthropic is the default; OpenAI and Google are
+  supported via `OPENCODE_PROVIDER` / `OPENCODE_MODEL`.
+- Python 3.10+ for the host driver scripts.
+
+## Why Run OpenCode Inside a Sandbox
+
+OpenCode is a terminal agent that edits files, runs commands, and installs
+packages. Running it directly on a workstation blends the agent's blast radius
+with your dev environment. Running it inside CubeSandbox gives you:
+
+| Concern | CubeSandbox provides |
+|---|---|
+| **Isolation** | KVM MicroVM per session, dedicated guest kernel |
+| **Reproducibility** | Every session boots from the same template snapshot |
+| **Fast spin-up** | Sub-60 ms cold start, so N-parallel agents are cheap |
+| **Long tasks** | `sandbox.pause()` snapshots VM + rootfs; resume later |
+| **Key hygiene** | CubeEgress injects the auth header on the wire — the VM never sees the real key |
+| **Egress audit** | Every request to the LLM API is recorded in the egress audit log |
+
+## Integration Steps
+
+### 1. Build the template image
+
+The image stacks Node.js 24 and the OpenCode CLI on top of `cubesandbox-base`,
+so envd is already listening on `:49983`.
+
+```dockerfile
+# examples/opencode-integration/Dockerfile (excerpt)
+ARG CUBE_BASE_IMAGE=ghcr.io/tencentcloud/cubesandbox-base:2026.16
+FROM ${CUBE_BASE_IMAGE}
+
+ARG NODE_MAJOR=24
+ARG OPENCODE_VERSION=0.5.0
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        ca-certificates curl git gnupg jq less procps python3 python3-pip ripgrep \
+    && curl -fsSL "https://deb.nodesource.com/setup_${NODE_MAJOR}.x" | bash - \
+    && apt-get install -y --no-install-recommends nodejs \
+    && npm install -g --ignore-scripts "opencode-ai@${OPENCODE_VERSION}" \
+    && opencode --version \
+    && npm cache clean --force \
+    && rm -rf /root/.npm /var/lib/apt/lists/*
+
+WORKDIR /workspace
+EXPOSE 49983
+```
+
+Build and push:
+
+```bash
+docker build --platform linux/amd64 \
+  -t <your-registry>/opencode-cube:latest \
+  examples/opencode-integration
+docker push <your-registry>/opencode-cube:latest
+```
+
+### 2. Register as a Cube template
+
+```bash
+cubemastercli tpl create-from-image \
+  --image <your-registry>/opencode-cube:latest \
+  --writable-layer-size 4G \
+  --expose-port 49983 \
+  --probe       49983 \
+  --probe-path  /health
+
+cubemastercli tpl watch --job-id <job_id>
+```
+
+Once the job reaches `READY`, note the `template_id` — you pass it to every
+`Sandbox.create()` call. `4G` writable layer suits medium tasks; bump to `8G+`
+if the agent installs large toolchains.
+
+### 3. Wire up the host driver
+
+```bash
+cd examples/opencode-integration
+cp .env.example .env
+# fill in E2B_API_URL, CUBE_TEMPLATE_ID, and your provider key
+pip install -r requirements.txt
+```
+
+| Variable | Where it flows | Notes |
+|---|---|---|
+| `E2B_API_URL` | Local process | CubeAPI address (`http://<node>:3000`) |
+| `E2B_API_KEY` | Local process | Any non-empty string in local dev |
+| `CUBE_TEMPLATE_ID` | `Sandbox.create(template=...)` | From step 2 |
+| `OPENCODE_PROVIDER` / `OPENCODE_MODEL` | OpenCode CLI flags | Provider and model selection |
+| `ANTHROPIC_API_KEY` | `envs=...` (direct) or CubeEgress inject (vault) | Provider key |
+| `OPENCODE_LLM_HOST` | `network_policy.py` | LLM host allowed under default-deny egress |
+
+### 4. Runtime Configuration and API Key Injection
+
+OpenCode supports two runtime modes inside the sandbox:
+
+**Headless mode** — `opencode run "prompt"` processes the prompt and exits,
+ideal for one-shot tasks. Two key-flow flavors share the same template:
+
+**Direct flavor** — forward the key per command. `e2b`'s `commands.run(envs=...)`
+puts the environment into the exec envelope, not into a persistent file inside
+the VM, so the key lives only for the lifetime of that command:
+
+```python
+result = sandbox.commands.run(
+    "cd /workspace && opencode run --provider anthropic "
+    "--model claude-sonnet-4-6 'do something'",
+    envs={"ANTHROPIC_API_KEY": key},
+    user="root",
+    timeout=900,
+)
+```
+
+**Vault flavor** — keep the key out of the VM entirely (see step 6).
+
+**Server mode** — `opencode serve --hostname 0.0.0.0 --port 4096` starts an
+HTTP server inside the sandbox. The host driver can then use the `@opencode-ai/sdk`
+package to create sessions, send prompts, and retrieve results programmatically.
+This mode is useful for multi-turn conversations or orchestrating several agents
+from one host process.
+
+```python
+# Start the server
+sandbox.commands.run(
+    "opencode serve --hostname 0.0.0.0 --port 4096 "
+    "--provider anthropic --model claude-sonnet-4-6",
+    envs={"ANTHROPIC_API_KEY": key},
+    user="root",
+    background=True,
+)
+
+# Then interact via @opencode-ai/sdk from the host (or curl the HTTP API)
+```
+
+### 5. Session Persistence (pause / resume)
+
+```bash
+python resume_opencode.py
+```
+
+This mirrors the [snapshot / clone / rollback](../snapshot-rollback-clone.md)
+engine at the SDK layer:
+
+- `sandbox.pause()` snapshots the running VM (memory + rootfs) and frees compute.
+- `Sandbox.connect(sandbox_id)` resumes with `/workspace`, OpenCode's state
+  directory (`/root/.opencode`), and every other file intact.
+
+> **Lifecycle caveat:** manage the sandbox lifecycle with `try/finally`, not a
+> `with Sandbox.create(...)` context manager. On `__exit__` the context manager
+> kills the sandbox, which would undo the pause. The example creates the sandbox
+> explicitly and only calls `sandbox.kill()` in `finally`.
+
+```python
+sandbox = Sandbox.create(template=template_id, timeout=1800)
+try:
+    run_turn(sandbox, prompt_1)          # writes /workspace/plan.md
+    sandbox_id = sandbox.pause() or sandbox.sandbox_id
+    sandbox = Sandbox.connect(sandbox_id)
+    assert_state_survived(sandbox)       # /workspace + /root/.opencode intact
+    run_turn(sandbox, prompt_2)          # continues the work
+finally:
+    sandbox.kill()
+```
+
+### 6. Network and Egress Policy (credential vault)
+
+`network_policy.py` demonstrates the recommended pattern for shared clusters:
+default-deny egress plus on-the-wire key injection.
+
+```python
+# Credential injection uses the native cubesandbox SDK (see security-proxy.md).
+from cubesandbox import Sandbox, Rule, Match, Action, Inject
+
+host = "api.anthropic.com"
+rules = [
+    Rule(
+        name="allow_anthropic_llm",
+        match=Match(scheme="https", sni=host, host=host),
+        action=Action(allow=True, audit="metadata", inject=[
+            Inject(header="x-api-key", secret=ANTHROPIC_API_KEY, format="${SECRET}"),
+            Inject(header="anthropic-version", secret="2023-06-01", format="${SECRET}"),
+        ]),
+    ),
+]
+
+sandbox = Sandbox.create(
+    template=CUBE_TEMPLATE_ID,
+    allow_internet_access=False,   # default-deny; the rule's host is auto-allowed
+    network={"rules": rules},
+)
+```
+
+Effect:
+
+- `printenv ANTHROPIC_API_KEY` inside the sandbox shows only a placeholder.
+- Every request to the LLM host gets the auth header attached on the wire.
+- Anything else is dropped by CubeVS at L3/L4 (`allow_internet_access=False`) and never leaves the sandbox.
+- Every allow / deny decision lands in the egress audit log.
+
+For non-Anthropic providers the example injects an `Authorization: Bearer`
+header instead. If a provider does not accept a header-injected key, fall back
+to the direct flavor (`envs=...`) — but never write the key into a persistent
+file inside the sandbox.
+
+## Use Cases and Best Practices
+
+- **Isolated development.** Run the coding agent inside the sandbox so its file
+  edits and shell commands cannot touch the host.
+- **Execute agent-generated code and collect results.** Have the agent write to
+  `/workspace`, then read artifacts back via `sandbox.files` or `commands.run`.
+- **Checkpoint / resume long tasks.** Use `pause()` + `connect()` to snapshot a
+  long refactor and resume later, or fork multiple task variants off one snapshot.
+- **Programmatic control with SDK.** Start OpenCode in server mode
+  (`opencode serve`) and use `@opencode-ai/sdk` for fine-grained multi-turn
+  orchestration.
+- **Preinstall heavy dependencies** into the template rather than fetching them
+  at runtime, especially under a default-deny egress policy.
+
+## Key Code Snippets
+
+### Headless OpenCode invocation
+
+```python
+cmd = (
+    "cd /workspace && opencode run --provider anthropic "
+    "--model claude-sonnet-4-6 "
+    "'Inspect the project, run app.py, and summarize the result.'"
+)
+result = sandbox.commands.run(cmd, envs=opencode_env, user="root", timeout=900)
+```
+
+### Server mode with SDK
+
+```python
+# Start OpenCode server inside the sandbox
+sandbox.commands.run(
+    "opencode serve --hostname 0.0.0.0 --port 4096 "
+    "--provider anthropic --model claude-sonnet-4-6",
+    envs=opencode_env,
+    user="root",
+    background=True,
+)
+# Interact via @opencode-ai/sdk from the host driver
+```
+
+### Preflight version check
+
+```python
+version = sandbox.commands.run("opencode --version", timeout=60)
+```
+
+## Caveats
+
+- **Node.js version.** OpenCode needs a recent Node runtime; the base image
+  ships an older apt Node, so always install via NodeSource (the Dockerfile
+  does).
+- **Agent state directory.** `/root/.opencode` holds OpenCode's session cache.
+  Keep it empty in the image to avoid leaking sessions across tenants; it is
+  created at build time but not populated with any credentials.
+- **Direct-flavor key persistence.** With the direct flavor (`envs=`) the key
+  is scoped to the exec call, but OpenCode may cache provider credentials under
+  its state dir (`/root/.opencode/`), which survives `pause()` / `resume()`.
+  For strict isolation prefer the vault flavor (`network_policy.py`), where the
+  key never enters the VM.
+- **CubeEgress CA (Node).** For the vault flavor the sandbox must trust the
+  CubeEgress root CA, which the base image installs into the system bundle.
+  OpenCode runs on Node.js, which ignores the system store, so
+  `network_policy.py` also sets `NODE_EXTRA_CA_CERTS` (override via
+  `OPENCODE_NODE_EXTRA_CA_CERTS`) — without it the vault path fails with
+  `Connection error`.
+- **Egress side-effects.** Tasks that `npm install` or fetch MCP tools need
+  those hosts allowed or preinstalled into the template.
+- **Interactive TTY features.** The OpenCode interactive session is not
+  available over the E2B protocol. Use headless `opencode run` or server mode
+  (`opencode serve`) and drive multi-turn conversations from the host script or
+  SDK.
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| `opencode: command not found` in preflight | Template not rebuilt after CLI change | Rebuild the image, re-register the template |
+| Provider auth failure | Key not forwarded (direct) or missing inject rule (vault) | Pass `envs={...}` or fix the rule's `sni`/`host` |
+| `403 Forbidden - CubeEgress` | Default-deny with no matching allow rule | Add the LLM host (and any extra hosts) to the rules |
+| `Connection error` / TLS failure from OpenCode (vault) | OpenCode's Node runtime ignores the system CA store, so it won't trust the CubeEgress CA | The example sets `NODE_EXTRA_CA_CERTS`; override with `OPENCODE_NODE_EXTRA_CA_CERTS` if the CA lives elsewhere |
+| Template creation stuck in `PULLING` | Registry unreachable from Cube nodes | Push to a registry the cluster can reach; supply auth if needed |
+| Readiness probe timeout | Base image without envd | Ensure `FROM ghcr.io/tencentcloud/cubesandbox-base:2026.16` |
+| `pause()` / `connect()` errors | Platform too old for snapshots | Upgrade the CubeSandbox platform |
+
+## References
+
+- Runnable example: [`examples/opencode-integration`](https://github.com/TencentCloud/CubeSandbox/tree/master/examples/opencode-integration)
+- Bring Your Own Image: [`docs/guide/tutorials/bring-your-own-image.md`](../tutorials/bring-your-own-image.md)
+- Template from image: [`docs/guide/tutorials/template-from-image.md`](../tutorials/template-from-image.md)
+- Snapshot / Clone / Rollback: [`docs/guide/snapshot-rollback-clone.md`](../snapshot-rollback-clone.md)
+- Credential vault + egress control: [`docs/guide/security-proxy.md`](../security-proxy.md)
+- OpenCode coding agent: <https://www.npmjs.com/package/opencode-ai>
+- OpenCode SDK: <https://www.npmjs.com/package/@opencode-ai/sdk>

--- a/docs/guide/integrations/opencode.md
+++ b/docs/guide/integrations/opencode.md
@@ -64,6 +64,10 @@ with your dev environment. Running it inside CubeSandbox gives you:
 The image stacks Node.js 24 and the OpenCode CLI on top of `cubesandbox-base`,
 so envd is already listening on `:49983`.
 
+The excerpt below highlights the main build steps. Use the checked-in
+`Dockerfile` as the canonical source for the exact package list, install flags,
+and environment settings.
+
 ```dockerfile
 # examples/opencode-integration/Dockerfile (excerpt)
 ARG CUBE_BASE_IMAGE=ghcr.io/tencentcloud/cubesandbox-base:2026.16

--- a/docs/guide/integrations/opencode.md
+++ b/docs/guide/integrations/opencode.md
@@ -77,9 +77,8 @@ RUN apt-get update \
         ca-certificates curl git gnupg jq less procps python3 python3-pip ripgrep \
     && curl -fsSL "https://deb.nodesource.com/setup_${NODE_MAJOR}.x" | bash - \
     && apt-get install -y --no-install-recommends nodejs \
-    && npm install -g --ignore-scripts "opencode-ai@${OPENCODE_VERSION}" \
+    && npm install -g "opencode-ai@${OPENCODE_VERSION}" \
     && opencode --version \
-    && npm cache clean --force \
     && rm -rf /root/.npm /var/lib/apt/lists/*
 
 WORKDIR /workspace
@@ -128,6 +127,7 @@ pip install -r requirements.txt
 | `CUBE_TEMPLATE_ID` | `Sandbox.create(template=...)` | From step 2 |
 | `OPENCODE_PROVIDER` / `OPENCODE_MODEL` | OpenCode CLI flags | Provider and model selection |
 | `ANTHROPIC_API_KEY` | `envs=...` (direct) or CubeEgress inject (vault) | Provider key |
+| `ANTHROPIC_BASE_URL` | Passed into the exec env | Anthropic-compatible gateways (e.g. DeepSeek) |
 | `OPENCODE_LLM_HOST` | `network_policy.py` | LLM host allowed under default-deny egress |
 
 ### 4. Runtime Configuration and API Key Injection

--- a/docs/guide/integrations/opencode.md
+++ b/docs/guide/integrations/opencode.md
@@ -34,7 +34,8 @@ project.
 
 ## Prerequisites
 
-- A running CubeSandbox deployment; CubeAPI reachable at `http://<node>:3000`.
+- A running CubeSandbox deployment; CubeAPI reachable at `https://<node>:3000`.
+  Use plain HTTP only for isolated local development on loopback.
 - `cubemastercli` on `$PATH`, connected to the cluster.
 - Docker on the build workstation, plus a registry the Cube nodes can pull from.
 - An LLM provider API key. Anthropic is the default; OpenAI and Google are
@@ -122,7 +123,7 @@ pip install -r requirements.txt
 
 | Variable | Where it flows | Notes |
 |---|---|---|
-| `E2B_API_URL` | Local process | CubeAPI address (`http://<node>:3000`) |
+| `E2B_API_URL` | Local process | TLS-protected CubeAPI address (`https://<node>:3000`) |
 | `E2B_API_KEY` | Local process | Any non-empty string in local dev |
 | `CUBE_TEMPLATE_ID` | `Sandbox.create(template=...)` | From step 2 |
 | `OPENCODE_PROVIDER` / `OPENCODE_MODEL` | OpenCode CLI flags | Provider and model selection |
@@ -302,7 +303,8 @@ version = sandbox.commands.run("opencode --version", timeout=60)
   For strict isolation prefer the vault flavor (`network_policy.py`), where the
   key never enters the VM.
 - **CubeEgress CA (Node).** For the vault flavor the sandbox must trust the
-  CubeEgress root CA, which the base image installs into the system bundle.
+  CubeEgress root CA, which CubeMaster bakes as the dedicated
+  `/usr/local/share/ca-certificates/cube-egress-root.crt` anchor.
   OpenCode runs on Node.js, which ignores the system store, so
   `network_policy.py` also sets `NODE_EXTRA_CA_CERTS` (override via
   `OPENCODE_NODE_EXTRA_CA_CERTS`) — without it the vault path fails with

--- a/docs/zh/guide/integrations/claude-code.md
+++ b/docs/zh/guide/integrations/claude-code.md
@@ -69,9 +69,8 @@ RUN apt-get update \
         ca-certificates curl git gnupg jq less procps python3 python3-pip ripgrep \
     && curl -fsSL "https://deb.nodesource.com/setup_${NODE_MAJOR}.x" | bash - \
     && apt-get install -y --no-install-recommends nodejs \
-    && npm install -g --ignore-scripts "@anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}" \
+    && npm install -g "@anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}" \
     && claude --version \
-    && npm cache clean --force \
     && rm -rf /root/.npm /var/lib/apt/lists/*
 
 WORKDIR /workspace

--- a/docs/zh/guide/integrations/claude-code.md
+++ b/docs/zh/guide/integrations/claude-code.md
@@ -56,6 +56,9 @@ Claude Code 是一个会编辑文件、执行命令、安装依赖的终端 Agen
 
 镜像在 `cubesandbox-base` 上叠加 Node.js 24 与 Claude Code CLI，envd 已监听 `:49983`。
 
+下方节选仅展示主要构建步骤。准确的软件包列表、安装参数和环境设置以仓库中的
+`Dockerfile` 为准。
+
 ```dockerfile
 # examples/claude-code-integration/Dockerfile（节选）
 ARG CUBE_BASE_IMAGE=ghcr.io/tencentcloud/cubesandbox-base:2026.16

--- a/docs/zh/guide/integrations/claude-code.md
+++ b/docs/zh/guide/integrations/claude-code.md
@@ -30,7 +30,8 @@ lang: zh-CN
 
 ## 前置条件
 
-- 已部署 CubeSandbox，CubeAPI 可访问（`http://<node>:3000`）。
+- 已部署 CubeSandbox，CubeAPI 可通过 TLS 访问（`https://<node>:3000`）。
+  明文 HTTP 只适用于隔离的本地回环开发环境。
 - `cubemastercli` 已在 `$PATH` 且已连通集群。
 - 构建机装有 Docker，且 registry 能被 Cube 集群拉取。
 - 一个 Anthropic API Key（或通过 `ANTHROPIC_BASE_URL` 使用 Anthropic 兼容端点）。
@@ -112,7 +113,7 @@ pip install -r requirements.txt
 
 | 变量 | 作用位置 | 说明 |
 |---|---|---|
-| `E2B_API_URL` | 本地进程 | CubeAPI 地址（`http://<node>:3000`） |
+| `E2B_API_URL` | 本地进程 | 启用 TLS 的 CubeAPI 地址（`https://<node>:3000`） |
 | `E2B_API_KEY` | 本地进程 | 本地开发填任意非空字符串 |
 | `CUBE_TEMPLATE_ID` | `Sandbox.create(template=...)` | 来自第 2 步 |
 | `ANTHROPIC_API_KEY` | `envs=...`（直连）或 CubeEgress 注入（vault） | Anthropic 密钥 |

--- a/docs/zh/guide/integrations/claude-code.md
+++ b/docs/zh/guide/integrations/claude-code.md
@@ -1,0 +1,258 @@
+---
+title: Claude Code 集成指南
+author: zhangzherui
+date: 2026-07-11
+tags:
+  - integration
+  - claude-code
+  - coding-agent
+  - agent
+lang: zh-CN
+---
+
+# Claude Code 集成指南
+
+[English](../../../guide/integrations/claude-code.md)
+
+在 CubeSandbox MicroVM 内运行 [Claude Code](https://docs.anthropic.com/en/docs/claude-code)
+（Anthropic 官方 CLI 编码 Agent）。本文覆盖镜像构建、密钥注入、出网管控，以及基于快照的会话持久化，配套的可运行示例位于
+[`examples/claude-code-integration`](https://github.com/TencentCloud/CubeSandbox/tree/master/examples/claude-code-integration)。
+
+## 集成对象与版本
+
+| 组件 | 版本 |
+|---|---|
+| Claude Code CLI | `@anthropic-ai/claude-code`（通过 `--build-arg CLAUDE_CODE_VERSION=x.y.z` 固定） |
+| Node.js | 24（通过 NodeSource 安装） |
+| CubeSandbox 基础镜像 | `ghcr.io/tencentcloud/cubesandbox-base:2026.16` |
+| E2B SDK（宿主端驱动） | `e2b`（最新） |
+| CubeSandbox 平台 | `>= 0.3.0`（pause/resume）/ `>= 0.4.0`（CubeEgress 密钥保险柜） |
+
+## 前置条件
+
+- 已部署 CubeSandbox，CubeAPI 可访问（`http://<node>:3000`）。
+- `cubemastercli` 已在 `$PATH` 且已连通集群。
+- 构建机装有 Docker，且 registry 能被 Cube 集群拉取。
+- 一个 Anthropic API Key（或通过 `ANTHROPIC_BASE_URL` 使用 Anthropic 兼容端点）。
+- Python 3.10+（宿主端驱动脚本）。
+
+## 为什么要把 Claude Code 放进沙箱
+
+Claude Code 是一个会编辑文件、执行命令、安装依赖的终端 Agent。直接跑在开发机上，Agent 的"爆炸半径"就等于你的开发环境。放进 CubeSandbox 你能拿到：
+
+| 关注点 | CubeSandbox 提供 |
+|---|---|
+| **隔离** | 每个会话一个 KVM MicroVM，独立 guest kernel |
+| **可复现** | 每次会话都从同一个 template 快照启动 |
+| **秒起** | 冷启动 <60ms，N 路并行代价极小 |
+| **长任务** | `sandbox.pause()` 对 VM + rootfs 打快照，稍后恢复 |
+| **密钥卫生** | CubeEgress 在链路上注入鉴权头，VM 看不到真实密钥 |
+| **出网审计** | 每次访问 LLM API 都会记入出网审计日志 |
+
+## 集成步骤
+
+### 1. 构建模板镜像
+
+镜像在 `cubesandbox-base` 上叠加 Node.js 24 与 Claude Code CLI，envd 已监听 `:49983`。
+
+```dockerfile
+# examples/claude-code-integration/Dockerfile（节选）
+ARG CUBE_BASE_IMAGE=ghcr.io/tencentcloud/cubesandbox-base:2026.16
+FROM ${CUBE_BASE_IMAGE}
+
+ARG NODE_MAJOR=24
+ARG CLAUDE_CODE_VERSION=1.0.33
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        ca-certificates curl git gnupg jq less procps python3 python3-pip ripgrep \
+    && curl -fsSL "https://deb.nodesource.com/setup_${NODE_MAJOR}.x" | bash - \
+    && apt-get install -y --no-install-recommends nodejs \
+    && npm install -g --ignore-scripts "@anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}" \
+    && claude --version \
+    && npm cache clean --force \
+    && rm -rf /root/.npm /var/lib/apt/lists/*
+
+WORKDIR /workspace
+EXPOSE 49983
+```
+
+构建并推送：
+
+```bash
+docker build --platform linux/amd64 \
+  -t <your-registry>/claude-code-cube:latest \
+  examples/claude-code-integration
+docker push <your-registry>/claude-code-cube:latest
+```
+
+### 2. 注册为 Cube 模板
+
+```bash
+cubemastercli tpl create-from-image \
+  --image <your-registry>/claude-code-cube:latest \
+  --writable-layer-size 4G \
+  --expose-port 49983 \
+  --probe       49983 \
+  --probe-path  /health
+
+cubemastercli tpl watch --job-id <job_id>
+```
+
+任务变为 `READY` 后记下 `template_id`，后续每次 `Sandbox.create()` 都要用它。`4G` 可写层适合中等任务；若 Agent 会安装大型工具链，提升到 `8G+`。
+
+### 3. 配置宿主端驱动
+
+```bash
+cd examples/claude-code-integration
+cp .env.example .env
+# 填写 E2B_API_URL、CUBE_TEMPLATE_ID 以及你的 Anthropic key
+pip install -r requirements.txt
+```
+
+| 变量 | 作用位置 | 说明 |
+|---|---|---|
+| `E2B_API_URL` | 本地进程 | CubeAPI 地址（`http://<node>:3000`） |
+| `E2B_API_KEY` | 本地进程 | 本地开发填任意非空字符串 |
+| `CUBE_TEMPLATE_ID` | `Sandbox.create(template=...)` | 来自第 2 步 |
+| `ANTHROPIC_API_KEY` | `envs=...`（直连）或 CubeEgress 注入（vault） | Anthropic 密钥 |
+| `ANTHROPIC_BASE_URL` | 传入 exec 环境 | Anthropic 兼容网关（如 DeepSeek） |
+| `CLAUDE_CODE_MODEL` | Claude CLI `--model` 参数 | 默认 `claude-sonnet-4-6` |
+| `CLAUDE_CODE_LLM_HOST` | `network_policy.py` | 默认拒绝出网下放行的 LLM host |
+
+### 4. 运行时配置与 API Key 注入
+
+Claude Code 命令以无交互方式构造：`-p`（`--print`）表示处理完 prompt 即退出（不启动 TUI，否则会在 E2B exec 通道上挂死），配合显式 model 与 `--output-format stream-json` 输出机器可读的 JSONL 事件流；`--accept-edits` 是布尔开关，表示本次运行自动批准沙箱内的文件编辑，prompt 作为 `-p` 的位置参数传入。两种密钥流转方式共用同一个模板：
+
+**直连方式** —— 逐命令传入密钥。`e2b` 的 `commands.run(envs=...)` 把环境放进 exec 信封，而非 VM 内的持久文件，因此密钥只在该命令执行期间存在：
+
+```python
+result = sandbox.commands.run(
+    "cd /workspace && claude -p --output-format stream-json "
+    "--model claude-sonnet-4-6 --accept-edits 'do something'",
+    envs={"ANTHROPIC_API_KEY": key},
+    user="root",
+    timeout=900,
+)
+```
+
+**保险柜方式** —— 让密钥完全不进入 VM（见第 6 步）。
+
+示例脚本会解析这份 JSONL，默认打印精简转写（助手文本、工具调用、失败项）；加 `--raw`（或设 `CLAUDE_CODE_STREAM_RAW=1`）可查看原始事件流。
+
+### 5. 会话持久化（pause / resume）
+
+```bash
+python resume_claude_code.py
+```
+
+它在 SDK 层复用了[快照 / 克隆 / 回滚](../snapshot-rollback-clone.md)引擎：
+
+- `sandbox.pause()` 对运行中的 VM（内存 + rootfs）打快照并释放算力。
+- `Sandbox.connect(sandbox_id)` 恢复时，`/workspace` 及其他文件都完好无损。
+
+> **生命周期注意：** 用 `try/finally` 手动管理沙箱，不要用 `with Sandbox.create(...)` context manager。
+> context manager 在 `__exit__` 时会 kill 沙箱，这会让 pause 失效。示例显式创建沙箱，只在 `finally` 里调用 `sandbox.kill()`。
+
+```python
+sandbox = Sandbox.create(template=template_id, timeout=1800)
+try:
+    run_turn(sandbox, prompt_1)          # 写入 /workspace/plan.md
+    sandbox_id = sandbox.pause() or sandbox.sandbox_id
+    sandbox = Sandbox.connect(sandbox_id)
+    assert_state_survived(sandbox)       # /workspace 仍在
+    run_turn(sandbox, prompt_2)          # 继续工作
+finally:
+    sandbox.kill()
+```
+
+### 6. 网络与出网策略（密钥保险柜）
+
+`network_policy.py` 展示了推荐用于共享集群的模式：默认拒绝出网 + 链路上注入密钥。
+
+```python
+# 凭证注入使用原生 cubesandbox SDK（见 security-proxy.md）。
+from cubesandbox import Sandbox, Rule, Match, Action, Inject
+
+host = "api.anthropic.com"
+rules = [
+    Rule(
+        name="allow_anthropic_llm",
+        match=Match(scheme="https", sni=host, host=host),
+        action=Action(allow=True, audit="metadata", inject=[
+            Inject(header="x-api-key", secret=ANTHROPIC_API_KEY, format="${SECRET}"),
+            Inject(header="anthropic-version", secret="2023-06-01", format="${SECRET}"),
+        ]),
+    ),
+]
+
+sandbox = Sandbox.create(
+    template=CUBE_TEMPLATE_ID,
+    allow_internet_access=False,   # 默认拒绝；规则里的 host 会被自动放行
+    network={"rules": rules},
+)
+```
+
+效果：
+
+- 沙箱内 `printenv ANTHROPIC_API_KEY` 只显示占位值。
+- 每次访问 LLM host 都会在链路上被附加鉴权头。
+- 其他任何目的地都会被 CubeVS 在 L3/L4 层丢弃（`allow_internet_access=False`），根本无法离开沙箱。
+- 每条 allow / deny 决策都会记入出网审计日志。
+
+## 使用场景与最佳实践
+
+- **隔离开发。** 把编码 Agent 跑在沙箱内，其文件编辑与 shell 命令无法触及宿主。
+- **执行 Agent 生成的代码并回收结果。** 让 Agent 写入 `/workspace`，再通过 `sandbox.files` 或 `commands.run` 读回产物。
+- **长任务断点续跑。** 用 `pause()` + `connect()` 给长时间重构打快照并稍后恢复，或从一个快照分叉多个任务变体。
+- **把重依赖预装进模板**，而不是运行时拉取，尤其在默认拒绝出网的策略下。
+
+## 关键代码片段
+
+### 无交互调用 Claude Code
+
+```python
+cmd = (
+    "cd /workspace && claude -p --output-format stream-json "
+    "--model claude-sonnet-4-6 "
+    "--accept-edits 'Inspect the project, run app.py, and summarize the result.'"
+)
+result = sandbox.commands.run(cmd, envs=claude_env, user="root", timeout=900)
+```
+
+### preflight 版本检查
+
+```python
+version = sandbox.commands.run("claude --version", timeout=60)
+```
+
+## 注意事项
+
+- **Node.js 版本。** Claude Code 需要较新的 Node 运行时；基础镜像自带的 apt Node 偏旧，务必通过 NodeSource 安装（Dockerfile 已如此）。
+- **Node.js CA（CubeEgress）。** 保险柜方式要求沙箱信任 CubeEgress 根 CA，基础镜像已把它装入系统 CA 包。
+  但 Claude Code 基于 Node.js、忽略系统 CA 库，因此 `network_policy.py` 还会设置 `NODE_EXTRA_CA_CERTS`
+  （可用 `CLAUDE_CODE_NODE_EXTRA_CA_CERTS` 覆盖）——否则 vault 路径会以 `Connection error` 失败。
+- **密钥留存。** 直连方式（`envs=`）下密钥仅作用于该 exec 调用，但密钥在进程环境中可见。对隔离要求高时优先用保险柜方式（`network_policy.py`），密钥完全不进入 VM。
+- **出网副作用。** 需要 `npm install` 或拉取 MCP 工具的任务，要放行相应 host 或预装进模板。
+- **交互式 TTY 功能。** Claude Code 的交互 TUI 在 E2B 协议下不可用。请用无交互 `-p --output-format stream-json`，多轮对话由宿主脚本驱动。
+
+## 排错
+
+| 现象 | 可能原因 | 处理 |
+|---|---|---|
+| preflight 报 `claude: command not found` | CLI 变更后未重建模板 | 重建镜像并重新注册模板 |
+| Anthropic 鉴权失败 | 密钥未传入（直连）或缺少 inject 规则（vault） | 传 `envs={...}` 或修正规则的 `sni`/`host` |
+| `403 Forbidden - CubeEgress` | 默认拒绝且无匹配放行规则 | 把 LLM host（及所需其他 host）加入规则 |
+| vault 下 Claude Code 报 `Connection error` / TLS 失败 | Claude Code 的 Node 运行时忽略系统 CA 库，不信任 CubeEgress CA | 示例已设 `NODE_EXTRA_CA_CERTS`；若 CA 在别处用 `CLAUDE_CODE_NODE_EXTRA_CA_CERTS` 覆盖 |
+| 模板创建卡在 `PULLING` | Cube 节点无法访问 registry | 推送到集群可访问的 registry，必要时提供鉴权 |
+| 就绪探针超时 | 基础镜像缺少 envd | 确认 `FROM ghcr.io/tencentcloud/cubesandbox-base:2026.16` |
+| `pause()` / `connect()` 报错 | 平台版本过低不支持快照 | 升级 CubeSandbox 平台 |
+
+## 参考
+
+- 可运行示例：[`examples/claude-code-integration`](https://github.com/TencentCloud/CubeSandbox/tree/master/examples/claude-code-integration)
+- 自带镜像：[`docs/zh/guide/tutorials/bring-your-own-image.md`](../tutorials/bring-your-own-image.md)
+- 从镜像构建模板：[`docs/zh/guide/tutorials/template-from-image.md`](../tutorials/template-from-image.md)
+- 快照 / 克隆 / 回滚：[`docs/zh/guide/snapshot-rollback-clone.md`](../snapshot-rollback-clone.md)
+- 密钥保险柜 + 出网管控：[`docs/zh/guide/security-proxy.md`](../security-proxy.md)
+- Claude Code：<https://docs.anthropic.com/en/docs/claude-code>

--- a/docs/zh/guide/integrations/codebuddy.md
+++ b/docs/zh/guide/integrations/codebuddy.md
@@ -1,0 +1,267 @@
+---
+title: CodeBuddy 集成指南
+author: zhangzherui
+date: 2026-07-11
+tags:
+  - integration
+  - codebuddy
+  - coding-agent
+  - agent
+lang: zh-CN
+---
+
+# CodeBuddy 集成指南
+
+[English](../../../guide/integrations/codebuddy.md)
+
+在 CubeSandbox MicroVM 内运行 [CodeBuddy](https://www.npmjs.com/package/@tencent-ai/codebuddy-code)
+（AI 编码 Agent CLI）。本文覆盖镜像构建、密钥注入、出网管控，以及基于快照的会话持久化，配套的可运行示例位于
+[`examples/codebuddy-integration`](https://github.com/TencentCloud/CubeSandbox/tree/master/examples/codebuddy-integration)。
+
+## 集成对象与版本
+
+| 组件 | 版本 |
+|---|---|
+| CodeBuddy CLI | `@tencent-ai/codebuddy-code`（通过 `--build-arg CODEBUDDY_VERSION=x.y.z` 固定） |
+| Node.js | 24（通过 NodeSource 安装） |
+| CubeSandbox 基础镜像 | `ghcr.io/tencentcloud/cubesandbox-base:2026.16` |
+| E2B SDK（宿主端驱动） | `e2b`（最新） |
+| CubeSandbox 平台 | `>= 0.3.0`（pause/resume）/ `>= 0.4.0`（CubeEgress 密钥保险柜） |
+
+## 前置条件
+
+- 已部署 CubeSandbox，CubeAPI 可访问（`http://<node>:3000`）。
+- `cubemastercli` 已在 `$PATH` 且已连通集群。
+- 构建机装有 Docker，且 registry 能被 Cube 集群拉取。
+- 一个 LLM provider 的 API Key。默认 Anthropic；任何 Anthropic 兼容或 OpenAI 兼容端点均可（通过
+  `ANTHROPIC_BASE_URL` / provider 环境变量）。
+- Python 3.10+（宿主端驱动脚本）。
+
+## 为什么要把 CodeBuddy 放进沙箱
+
+CodeBuddy 是一个会编辑文件、执行命令、安装依赖的编码 Agent。直接跑在开发机上，Agent 的"爆炸半径"就等于你的开发环境。放进 CubeSandbox 你能拿到：
+
+| 关注点 | CubeSandbox 提供 |
+|---|---|
+| **隔离** | 每个会话一个 KVM MicroVM，独立 guest kernel |
+| **可复现** | 每次会话都从同一个 template 快照启动 |
+| **秒起** | 冷启动 <60ms，N 路并行代价极小 |
+| **长任务** | `sandbox.pause()` 对 VM + rootfs 打快照，稍后恢复 |
+| **密钥卫生** | CubeEgress 在链路上注入鉴权头，VM 看不到真实密钥 |
+| **出网审计** | 每次访问 LLM API 都会记入出网审计日志 |
+
+## 集成步骤
+
+### 1. 构建模板镜像
+
+镜像在 `cubesandbox-base` 上叠加 Node.js 24 与 CodeBuddy CLI，envd 已监听 `:49983`。
+
+```dockerfile
+# examples/codebuddy-integration/Dockerfile（节选）
+ARG CUBE_BASE_IMAGE=ghcr.io/tencentcloud/cubesandbox-base:2026.16
+FROM ${CUBE_BASE_IMAGE}
+
+ARG NODE_MAJOR=24
+ARG CODEBUDDY_VERSION=2.119.2
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        ca-certificates curl git gnupg jq less procps python3 python3-pip ripgrep \
+    && curl -fsSL "https://deb.nodesource.com/setup_${NODE_MAJOR}.x" | bash - \
+    && apt-get install -y --no-install-recommends nodejs \
+    && npm install -g --ignore-scripts "@tencent-ai/codebuddy-code@${CODEBUDDY_VERSION}" \
+    && codebuddy --version \
+    && npm cache clean --force \
+    && rm -rf /root/.npm /var/lib/apt/lists/*
+
+WORKDIR /workspace
+EXPOSE 49983
+```
+
+构建并推送：
+
+```bash
+docker build --platform linux/amd64 \
+  -t <your-registry>/codebuddy-cube:latest \
+  examples/codebuddy-integration
+docker push <your-registry>/codebuddy-cube:latest
+```
+
+### 2. 注册为 Cube 模板
+
+```bash
+cubemastercli tpl create-from-image \
+  --image <your-registry>/codebuddy-cube:latest \
+  --writable-layer-size 4G \
+  --expose-port 49983 \
+  --probe       49983 \
+  --probe-path  /health
+
+cubemastercli tpl watch --job-id <job_id>
+```
+
+任务变为 `READY` 后记下 `template_id`，后续每次 `Sandbox.create()` 都要用它。`4G` 可写层适合中等任务；若
+Agent 会安装大型工具链，提升到 `8G+`。
+
+### 3. 配置宿主端驱动
+
+```bash
+cd examples/codebuddy-integration
+cp .env.example .env
+# 填写 E2B_API_URL、CUBE_TEMPLATE_ID 以及你的 provider key
+pip install -r requirements.txt
+```
+
+| 变量 | 作用位置 | 说明 |
+|---|---|---|
+| `E2B_API_URL` | 本地进程 | CubeAPI 地址（`http://<node>:3000`） |
+| `E2B_API_KEY` | 本地进程 | 本地开发填任意非空字符串 |
+| `CUBE_TEMPLATE_ID` | `Sandbox.create(template=...)` | 来自第 2 步 |
+| `CODEBUDDY_MODEL` | CodeBuddy CLI `--model` 参数 | 选择模型 |
+| `ANTHROPIC_API_KEY` | `envs=...`（直连）或 CubeEgress 注入（vault） | provider 密钥 |
+| `ANTHROPIC_BASE_URL` | 传入 exec 环境 | Anthropic 兼容网关（如 DeepSeek） |
+| `CODEBUDDY_LLM_HOST` | `network_policy.py` | 默认拒绝出网下放行的 LLM host |
+
+### 4. 运行时配置与 API Key 注入
+
+CodeBuddy 命令以无交互方式构造：`-p`（`--print`）表示处理完 prompt 即退出（不启动 TUI，否则会在 E2B exec 通道上挂死），配合 `--model` 与 `--output-format stream-json` 输出机器可读的 JSONL 事件流；`--permission-mode acceptEdits` 允许 Agent 在隔离沙箱内编辑文件而不弹确认，prompt 作为 `-p` 之后的位置参数传入。两种密钥流转方式共用同一个模板：
+
+**直连方式** —— 逐命令传入密钥。`e2b` 的 `commands.run(envs=...)` 把环境放进 exec 信封，而非 VM 内的持久文件，因此密钥只在该命令执行期间存在：
+
+```python
+result = sandbox.commands.run(
+    "cd /workspace && codebuddy -p --output-format stream-json "
+    "--model claude-sonnet-4-6 --permission-mode acceptEdits "
+    "'do something'",
+    envs={"ANTHROPIC_API_KEY": key},
+    user="root",
+    timeout=900,
+)
+```
+
+**保险柜方式** —— 让密钥完全不进入 VM（见第 6 步）。
+
+示例脚本会解析这份 JSONL，默认打印精简转写（助手文本、工具调用、失败项）；加 `--raw`（或设 `CODEBUDDY_STREAM_RAW=1`）可查看原始事件流。
+
+### 5. 会话持久化（pause / resume）
+
+```bash
+python resume_codebuddy.py
+```
+
+它在 SDK 层复用了[快照 / 克隆 / 回滚](../snapshot-rollback-clone.md)引擎：
+
+- `sandbox.pause()` 对运行中的 VM（内存 + rootfs）打快照并释放算力。
+- `Sandbox.connect(sandbox_id)` 恢复时，`/workspace`、CodeBuddy 状态目录（`/root/.codebuddy`）及其他文件都完好无损。
+
+> **生命周期注意：** 用 `try/finally` 手动管理沙箱，不要用 `with Sandbox.create(...)` context manager。
+> context manager 在 `__exit__` 时会 kill 沙箱，这会让 pause 失效。示例显式创建沙箱，只在 `finally` 里调用
+> `sandbox.kill()`。
+
+```python
+sandbox = Sandbox.create(template=template_id, timeout=1800)
+try:
+    run_turn(sandbox, prompt_1)          # 写入 /workspace/plan.md
+    sandbox_id = sandbox.pause() or sandbox.sandbox_id
+    sandbox = Sandbox.connect(sandbox_id)
+    assert_state_survived(sandbox)       # /workspace + /root/.codebuddy 仍在
+    run_turn(sandbox, prompt_2)          # 继续工作
+finally:
+    sandbox.kill()
+```
+
+### 6. 网络与出网策略（密钥保险柜）
+
+`network_policy.py` 展示了推荐用于共享集群的模式：默认拒绝出网 + 链路上注入密钥。
+
+```python
+# 凭证注入使用原生 cubesandbox SDK(见 security-proxy.md)。
+from cubesandbox import Sandbox, Rule, Match, Action, Inject
+
+host = "api.anthropic.com"
+rules = [
+    Rule(
+        name="allow_anthropic_llm",
+        match=Match(scheme="https", sni=host, host=host),
+        action=Action(allow=True, audit="metadata", inject=[
+            Inject(header="x-api-key", secret=ANTHROPIC_API_KEY, format="${SECRET}"),
+            Inject(header="anthropic-version", secret="2023-06-01", format="${SECRET}"),
+        ]),
+    ),
+]
+
+sandbox = Sandbox.create(
+    template=CUBE_TEMPLATE_ID,
+    allow_internet_access=False,   # 默认拒绝；规则里的 host 会被自动放行
+    network={"rules": rules},
+)
+```
+
+效果：
+
+- 沙箱内 `printenv ANTHROPIC_API_KEY` 只显示占位值。
+- 每次访问 LLM host 都会在链路上被附加鉴权头。
+- 其他任何目的地都会被 CubeVS 在 L3/L4 层丢弃（`allow_internet_access=False`），根本无法离开沙箱。
+- 每条 allow / deny 决策都会记入出网审计日志。
+
+非 Anthropic provider 时，示例会改注入 `Authorization: Bearer` 头。若某 provider 不接受 header 注入的密钥，可回退到直连方式（`envs=...`）—— 但绝不要把密钥写进沙箱内的持久文件。
+
+## 使用场景与最佳实践
+
+- **隔离开发。** 把编码 Agent 跑在沙箱内，其文件编辑与 shell 命令无法触及宿主。
+- **执行 Agent 生成的代码并回收结果。** 让 Agent 写入 `/workspace`，再通过 `sandbox.files` 或
+  `commands.run` 读回产物。
+- **长任务断点续跑。** 用 `pause()` + `connect()` 给长时间重构打快照并稍后恢复，或从一个快照分叉多个任务变体。
+- **把重依赖预装进模板**，而不是运行时拉取，尤其在默认拒绝出网的策略下。
+
+## 关键代码片段
+
+### 无交互调用 CodeBuddy
+
+```python
+cmd = (
+    "cd /workspace && codebuddy -p --output-format stream-json "
+    "--model claude-sonnet-4-6 --permission-mode acceptEdits "
+    "'Inspect the project, run app.py, and summarize the result.'"
+)
+result = sandbox.commands.run(cmd, envs=codebuddy_env, user="root", timeout=900)
+```
+
+### preflight 版本检查
+
+```python
+version = sandbox.commands.run("codebuddy --version", timeout=60)
+```
+
+## 注意事项
+
+- **Node.js 版本。** CodeBuddy 需要较新的 Node 运行时；基础镜像自带的 apt Node 偏旧，务必通过 NodeSource 安装（Dockerfile 已如此）。
+- **Agent 状态目录。** `/root/.codebuddy` 保存 CodeBuddy 的会话缓存。镜像里保持它为空，避免跨租户泄露会话；它在构建时创建但不写入任何凭证。
+- **直连方式的密钥留存。** 直连方式（`envs=`）下密钥仅作用于该 exec 调用，但 CodeBuddy 可能把 provider 凭证缓存到其状态目录（`/root/.codebuddy/`），会在 `pause()` / `resume()` 后仍留在盘上。对隔离要求高时优先用保险柜方式（`network_policy.py`），密钥完全不进入 VM。
+- **CubeEgress CA（Node）。** 保险柜方式要求沙箱信任 CubeEgress 根 CA，基础镜像已把它装入系统 CA 包。
+  但 CodeBuddy 基于 Node.js、忽略系统 CA 库，因此 `network_policy.py` 还会设置 `NODE_EXTRA_CA_CERTS`
+  （可用 `CODEBUDDY_NODE_EXTRA_CA_CERTS` 覆盖）——否则 vault 路径会以 `Connection error` 失败。
+- **出网副作用。** 需要 `npm install` 或拉取 MCP 工具的任务，要放行相应 host 或预装进模板。
+- **交互式 TTY 功能。** CodeBuddy 的交互式 TUI 在 E2B 协议下不可用。请用无交互 `-p --output-format stream-json`，多轮对话由宿主脚本驱动。
+- **内置 `--sandbox` 标志。** CodeBuddy 有原生 `--sandbox` 标志可直接连接 E2B/CubeSandbox，但本集成采用 Python 宿主端驱动方式，以便更好地控制出网策略、凭证注入和会话生命周期。
+
+## 排错
+
+| 现象 | 可能原因 | 处理 |
+|---|---|---|
+| preflight 报 `codebuddy: command not found` | CLI 变更后未重建模板 | 重建镜像并重新注册模板 |
+| provider 鉴权失败 | 密钥未传入（直连）或缺少 inject 规则（vault） | 传 `envs={...}` 或修正规则的 `sni`/`host` |
+| `403 Forbidden - CubeEgress` | 默认拒绝且无匹配放行规则 | 把 LLM host（及所需其他 host）加入规则 |
+| vault 下 CodeBuddy 报 `Connection error` / TLS 失败 | CodeBuddy 的 Node 运行时忽略系统 CA 库，不信任 CubeEgress CA | 示例已设 `NODE_EXTRA_CA_CERTS`；若 CA 在别处用 `CODEBUDDY_NODE_EXTRA_CA_CERTS` 覆盖 |
+| 模板创建卡在 `PULLING` | Cube 节点无法访问 registry | 推送到集群可访问的 registry，必要时提供鉴权 |
+| 就绪探针超时 | 基础镜像缺少 envd | 确认 `FROM ghcr.io/tencentcloud/cubesandbox-base:2026.16` |
+| `pause()` / `connect()` 报错 | 平台版本过低不支持快照 | 升级 CubeSandbox 平台 |
+
+## 参考
+
+- 可运行示例：[`examples/codebuddy-integration`](https://github.com/TencentCloud/CubeSandbox/tree/master/examples/codebuddy-integration)
+- 自带镜像：[`docs/guide/tutorials/bring-your-own-image.md`](../tutorials/bring-your-own-image.md)
+- 从镜像构建模板：[`docs/guide/tutorials/template-from-image.md`](../tutorials/template-from-image.md)
+- 快照 / 克隆 / 回滚：[`docs/guide/snapshot-rollback-clone.md`](../snapshot-rollback-clone.md)
+- 密钥保险柜 + 出网管控：[`docs/guide/security-proxy.md`](../security-proxy.md)
+- CodeBuddy CLI：<https://www.npmjs.com/package/@tencent-ai/codebuddy-code>

--- a/docs/zh/guide/integrations/codebuddy.md
+++ b/docs/zh/guide/integrations/codebuddy.md
@@ -30,7 +30,8 @@ lang: zh-CN
 
 ## 前置条件
 
-- 已部署 CubeSandbox，CubeAPI 可访问（`http://<node>:3000`）。
+- 已部署 CubeSandbox，CubeAPI 可通过 TLS 访问（`https://<node>:3000`）。
+  明文 HTTP 只适用于隔离的本地回环开发环境。
 - `cubemastercli` 已在 `$PATH` 且已连通集群。
 - 构建机装有 Docker，且 registry 能被 Cube 集群拉取。
 - 一个 LLM provider 的 API Key。默认 Anthropic；任何 Anthropic 兼容或 OpenAI 兼容端点均可（通过
@@ -114,10 +115,11 @@ pip install -r requirements.txt
 
 | 变量 | 作用位置 | 说明 |
 |---|---|---|
-| `E2B_API_URL` | 本地进程 | CubeAPI 地址（`http://<node>:3000`） |
+| `E2B_API_URL` | 本地进程 | 启用 TLS 的 CubeAPI 地址（`https://<node>:3000`） |
 | `E2B_API_KEY` | 本地进程 | 本地开发填任意非空字符串 |
 | `CUBE_TEMPLATE_ID` | `Sandbox.create(template=...)` | 来自第 2 步 |
 | `CODEBUDDY_MODEL` | CodeBuddy CLI `--model` 参数 | 选择模型 |
+| `CODEBUDDY_PROVIDER` | 本地脚本 | Provider 名称：`anthropic`、`openai`、`google`、`deepseek` 或 `openrouter` |
 | `ANTHROPIC_API_KEY` | `envs=...`（直连）或 CubeEgress 注入（vault） | provider 密钥 |
 | `ANTHROPIC_BASE_URL` | 传入 exec 环境 | Anthropic 兼容网关（如 DeepSeek） |
 | `CODEBUDDY_LLM_HOST` | `network_policy.py` | 默认拒绝出网下放行的 LLM host |
@@ -260,8 +262,8 @@ version = sandbox.commands.run("codebuddy --version", timeout=60)
 ## 参考
 
 - 可运行示例：[`examples/codebuddy-integration`](https://github.com/TencentCloud/CubeSandbox/tree/master/examples/codebuddy-integration)
-- 自带镜像：[`docs/guide/tutorials/bring-your-own-image.md`](../tutorials/bring-your-own-image.md)
-- 从镜像构建模板：[`docs/guide/tutorials/template-from-image.md`](../tutorials/template-from-image.md)
-- 快照 / 克隆 / 回滚：[`docs/guide/snapshot-rollback-clone.md`](../snapshot-rollback-clone.md)
-- 密钥保险柜 + 出网管控：[`docs/guide/security-proxy.md`](../security-proxy.md)
+- 自带镜像：[`docs/zh/guide/tutorials/bring-your-own-image.md`](../tutorials/bring-your-own-image.md)
+- 从镜像构建模板：[`docs/zh/guide/tutorials/template-from-image.md`](../tutorials/template-from-image.md)
+- 快照 / 克隆 / 回滚：[`docs/zh/guide/snapshot-rollback-clone.md`](../snapshot-rollback-clone.md)
+- 密钥保险柜 + 出网管控：[`docs/zh/guide/security-proxy.md`](../security-proxy.md)
 - CodeBuddy CLI：<https://www.npmjs.com/package/@tencent-ai/codebuddy-code>

--- a/docs/zh/guide/integrations/codebuddy.md
+++ b/docs/zh/guide/integrations/codebuddy.md
@@ -57,6 +57,9 @@ CodeBuddy 是一个会编辑文件、执行命令、安装依赖的编码 Agent�
 
 镜像在 `cubesandbox-base` 上叠加 Node.js 24 与 CodeBuddy CLI，envd 已监听 `:49983`。
 
+下方节选仅展示主要构建步骤。准确的软件包列表、安装参数和环境设置以仓库中的
+`Dockerfile` 为准。
+
 ```dockerfile
 # examples/codebuddy-integration/Dockerfile（节选）
 ARG CUBE_BASE_IMAGE=ghcr.io/tencentcloud/cubesandbox-base:2026.16

--- a/docs/zh/guide/integrations/codebuddy.md
+++ b/docs/zh/guide/integrations/codebuddy.md
@@ -70,9 +70,8 @@ RUN apt-get update \
         ca-certificates curl git gnupg jq less procps python3 python3-pip ripgrep \
     && curl -fsSL "https://deb.nodesource.com/setup_${NODE_MAJOR}.x" | bash - \
     && apt-get install -y --no-install-recommends nodejs \
-    && npm install -g --ignore-scripts "@tencent-ai/codebuddy-code@${CODEBUDDY_VERSION}" \
+    && npm install -g "@tencent-ai/codebuddy-code@${CODEBUDDY_VERSION}" \
     && codebuddy --version \
-    && npm cache clean --force \
     && rm -rf /root/.npm /var/lib/apt/lists/*
 
 WORKDIR /workspace

--- a/docs/zh/guide/integrations/index.md
+++ b/docs/zh/guide/integrations/index.md
@@ -48,3 +48,6 @@ lang: zh-CN
 | 标题 | 作者 | 日期 | 标签 |
 | --- | --- | --- | --- |
 | [Pi Agent 集成指南](./pi-agent.md) | chaojixinren | 2026-07-01 | integration, pi-agent, coding-agent, agent |
+| [Claude Code 集成指南](./claude-code.md) | zhangzherui | 2026-07-11 | integration, claude-code, coding-agent, agent |
+| [CodeBuddy 集成指南](./codebuddy.md) | zhangzherui | 2026-07-11 | integration, codebuddy, coding-agent, agent |
+| [OpenCode 集成指南](./opencode.md) | zhangzherui | 2026-07-11 | integration, opencode, coding-agent, agent |

--- a/docs/zh/guide/integrations/opencode.md
+++ b/docs/zh/guide/integrations/opencode.md
@@ -71,9 +71,8 @@ RUN apt-get update \
         ca-certificates curl git gnupg jq less procps python3 python3-pip ripgrep \
     && curl -fsSL "https://deb.nodesource.com/setup_${NODE_MAJOR}.x" | bash - \
     && apt-get install -y --no-install-recommends nodejs \
-    && npm install -g --ignore-scripts "opencode-ai@${OPENCODE_VERSION}" \
+    && npm install -g "opencode-ai@${OPENCODE_VERSION}" \
     && opencode --version \
-    && npm cache clean --force \
     && rm -rf /root/.npm /var/lib/apt/lists/*
 
 WORKDIR /workspace
@@ -121,6 +120,7 @@ pip install -r requirements.txt
 | `CUBE_TEMPLATE_ID` | `Sandbox.create(template=...)` | 来自第 2 步 |
 | `OPENCODE_PROVIDER` / `OPENCODE_MODEL` | OpenCode CLI 参数 | 选择 provider 与模型 |
 | `ANTHROPIC_API_KEY` | `envs=...`（直连）或 CubeEgress 注入（vault） | provider 密钥 |
+| `ANTHROPIC_BASE_URL` | 传入 exec 环境 | Anthropic 兼容网关（如 DeepSeek） |
 | `OPENCODE_LLM_HOST` | `network_policy.py` | 默认拒绝出网下放行的 LLM host |
 
 ### 4. 运行时配置与 API Key 注入

--- a/docs/zh/guide/integrations/opencode.md
+++ b/docs/zh/guide/integrations/opencode.md
@@ -58,6 +58,9 @@ OpenCode 是一个会编辑文件、执行命令、安装依赖的终端 Agent�
 
 镜像在 `cubesandbox-base` 上叠加 Node.js 24 与 OpenCode CLI，envd 已监听 `:49983`。
 
+下方节选仅展示主要构建步骤。准确的软件包列表、安装参数和环境设置以仓库中的
+`Dockerfile` 为准。
+
 ```dockerfile
 # examples/opencode-integration/Dockerfile（节选）
 ARG CUBE_BASE_IMAGE=ghcr.io/tencentcloud/cubesandbox-base:2026.16

--- a/docs/zh/guide/integrations/opencode.md
+++ b/docs/zh/guide/integrations/opencode.md
@@ -31,7 +31,8 @@ lang: zh-CN
 
 ## 前置条件
 
-- 已部署 CubeSandbox，CubeAPI 可访问（`http://<node>:3000`）。
+- 已部署 CubeSandbox，CubeAPI 可通过 TLS 访问（`https://<node>:3000`）。
+  明文 HTTP 只适用于隔离的本地回环开发环境。
 - `cubemastercli` 已在 `$PATH` 且已连通集群。
 - 构建机装有 Docker，且 registry 能被 Cube 集群拉取。
 - 一个 LLM provider 的 API Key。默认 Anthropic；OpenAI 和 Google 可通过
@@ -115,7 +116,7 @@ pip install -r requirements.txt
 
 | 变量 | 作用位置 | 说明 |
 |---|---|---|
-| `E2B_API_URL` | 本地进程 | CubeAPI 地址（`http://<node>:3000`） |
+| `E2B_API_URL` | 本地进程 | 启用 TLS 的 CubeAPI 地址（`https://<node>:3000`） |
 | `E2B_API_KEY` | 本地进程 | 本地开发填任意非空字符串 |
 | `CUBE_TEMPLATE_ID` | `Sandbox.create(template=...)` | 来自第 2 步 |
 | `OPENCODE_PROVIDER` / `OPENCODE_MODEL` | OpenCode CLI 参数 | 选择 provider 与模型 |
@@ -289,9 +290,9 @@ version = sandbox.commands.run("opencode --version", timeout=60)
 ## 参考
 
 - 可运行示例：[`examples/opencode-integration`](https://github.com/TencentCloud/CubeSandbox/tree/master/examples/opencode-integration)
-- 自带镜像：[`docs/guide/tutorials/bring-your-own-image.md`](../tutorials/bring-your-own-image.md)
-- 从镜像构建模板：[`docs/guide/tutorials/template-from-image.md`](../tutorials/template-from-image.md)
-- 快照 / 克隆 / 回滚：[`docs/guide/snapshot-rollback-clone.md`](../snapshot-rollback-clone.md)
-- 密钥保险柜 + 出网管控：[`docs/guide/security-proxy.md`](../security-proxy.md)
+- 自带镜像：[`docs/zh/guide/tutorials/bring-your-own-image.md`](../tutorials/bring-your-own-image.md)
+- 从镜像构建模板：[`docs/zh/guide/tutorials/template-from-image.md`](../tutorials/template-from-image.md)
+- 快照 / 克隆 / 回滚：[`docs/zh/guide/snapshot-rollback-clone.md`](../snapshot-rollback-clone.md)
+- 密钥保险柜 + 出网管控：[`docs/zh/guide/security-proxy.md`](../security-proxy.md)
 - OpenCode coding agent：<https://www.npmjs.com/package/opencode-ai>
 - OpenCode SDK：<https://www.npmjs.com/package/@opencode-ai/sdk>

--- a/docs/zh/guide/integrations/opencode.md
+++ b/docs/zh/guide/integrations/opencode.md
@@ -1,0 +1,297 @@
+---
+title: OpenCode 集成指南
+author: zhangzherui
+date: 2026-07-11
+tags:
+  - integration
+  - opencode
+  - coding-agent
+  - agent
+lang: zh-CN
+---
+
+# OpenCode 集成指南
+
+[English](../../../guide/integrations/opencode.md)
+
+在 CubeSandbox MicroVM 内运行 [OpenCode](https://www.npmjs.com/package/opencode-ai)
+（面向终端的 AI 编码 Agent）。本文覆盖镜像构建、密钥注入、出网管控、基于快照的会话持久化，
+以及无交互与服务器两种集成模式，配套的可运行示例位于
+[`examples/opencode-integration`](https://github.com/TencentCloud/CubeSandbox/tree/master/examples/opencode-integration)。
+
+## 集成对象与版本
+
+| 组件 | 版本 |
+|---|---|
+| OpenCode coding agent | `opencode-ai`（通过 `--build-arg OPENCODE_VERSION=x.y.z` 固定） |
+| Node.js | 24（通过 NodeSource 安装） |
+| CubeSandbox 基础镜像 | `ghcr.io/tencentcloud/cubesandbox-base:2026.16` |
+| E2B SDK（宿主端驱动） | `e2b`（最新） |
+| CubeSandbox 平台 | `>= 0.3.0`（pause/resume）/ `>= 0.4.0`（CubeEgress 密钥保险柜） |
+
+## 前置条件
+
+- 已部署 CubeSandbox，CubeAPI 可访问（`http://<node>:3000`）。
+- `cubemastercli` 已在 `$PATH` 且已连通集群。
+- 构建机装有 Docker，且 registry 能被 Cube 集群拉取。
+- 一个 LLM provider 的 API Key。默认 Anthropic；OpenAI 和 Google 可通过
+  `OPENCODE_PROVIDER` / `OPENCODE_MODEL` 配置。
+- Python 3.10+（宿主端驱动脚本）。
+
+## 为什么要把 OpenCode 放进沙箱
+
+OpenCode 是一个会编辑文件、执行命令、安装依赖的终端 Agent。直接跑在开发机上，Agent 的"爆炸半径"就等于你的开发环境。放进 CubeSandbox 你能拿到：
+
+| 关注点 | CubeSandbox 提供 |
+|---|---|
+| **隔离** | 每个会话一个 KVM MicroVM，独立 guest kernel |
+| **可复现** | 每次会话都从同一个 template 快照启动 |
+| **秒起** | 冷启动 <60ms，N 路并行代价极小 |
+| **长任务** | `sandbox.pause()` 对 VM + rootfs 打快照，稍后恢复 |
+| **密钥卫生** | CubeEgress 在链路上注入鉴权头，VM 看不到真实密钥 |
+| **出网审计** | 每次访问 LLM API 都会记入出网审计日志 |
+
+## 集成步骤
+
+### 1. 构建模板镜像
+
+镜像在 `cubesandbox-base` 上叠加 Node.js 24 与 OpenCode CLI，envd 已监听 `:49983`。
+
+```dockerfile
+# examples/opencode-integration/Dockerfile（节选）
+ARG CUBE_BASE_IMAGE=ghcr.io/tencentcloud/cubesandbox-base:2026.16
+FROM ${CUBE_BASE_IMAGE}
+
+ARG NODE_MAJOR=24
+ARG OPENCODE_VERSION=0.5.0
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        ca-certificates curl git gnupg jq less procps python3 python3-pip ripgrep \
+    && curl -fsSL "https://deb.nodesource.com/setup_${NODE_MAJOR}.x" | bash - \
+    && apt-get install -y --no-install-recommends nodejs \
+    && npm install -g --ignore-scripts "opencode-ai@${OPENCODE_VERSION}" \
+    && opencode --version \
+    && npm cache clean --force \
+    && rm -rf /root/.npm /var/lib/apt/lists/*
+
+WORKDIR /workspace
+EXPOSE 49983
+```
+
+构建并推送：
+
+```bash
+docker build --platform linux/amd64 \
+  -t <your-registry>/opencode-cube:latest \
+  examples/opencode-integration
+docker push <your-registry>/opencode-cube:latest
+```
+
+### 2. 注册为 Cube 模板
+
+```bash
+cubemastercli tpl create-from-image \
+  --image <your-registry>/opencode-cube:latest \
+  --writable-layer-size 4G \
+  --expose-port 49983 \
+  --probe       49983 \
+  --probe-path  /health
+
+cubemastercli tpl watch --job-id <job_id>
+```
+
+任务变为 `READY` 后记下 `template_id`，后续每次 `Sandbox.create()` 都要用它。`4G` 可写层适合中等任务；若
+Agent 会安装大型工具链，提升到 `8G+`。
+
+### 3. 配置宿主端驱动
+
+```bash
+cd examples/opencode-integration
+cp .env.example .env
+# 填写 E2B_API_URL、CUBE_TEMPLATE_ID 以及你的 provider key
+pip install -r requirements.txt
+```
+
+| 变量 | 作用位置 | 说明 |
+|---|---|---|
+| `E2B_API_URL` | 本地进程 | CubeAPI 地址（`http://<node>:3000`） |
+| `E2B_API_KEY` | 本地进程 | 本地开发填任意非空字符串 |
+| `CUBE_TEMPLATE_ID` | `Sandbox.create(template=...)` | 来自第 2 步 |
+| `OPENCODE_PROVIDER` / `OPENCODE_MODEL` | OpenCode CLI 参数 | 选择 provider 与模型 |
+| `ANTHROPIC_API_KEY` | `envs=...`（直连）或 CubeEgress 注入（vault） | provider 密钥 |
+| `OPENCODE_LLM_HOST` | `network_policy.py` | 默认拒绝出网下放行的 LLM host |
+
+### 4. 运行时配置与 API Key 注入
+
+OpenCode 在沙箱内支持两种运行模式：
+
+**无交互模式** — `opencode run "prompt"` 处理 prompt 后退出，适合一次性任务。两种密钥流转方式共用同一个模板：
+
+**直连方式** —— 逐命令传入密钥。`e2b` 的 `commands.run(envs=...)` 把环境放进 exec 信封，而非 VM 内的持久文件，因此密钥只在该命令执行期间存在：
+
+```python
+result = sandbox.commands.run(
+    "cd /workspace && opencode run --provider anthropic "
+    "--model claude-sonnet-4-6 'do something'",
+    envs={"ANTHROPIC_API_KEY": key},
+    user="root",
+    timeout=900,
+)
+```
+
+**保险柜方式** —— 让密钥完全不进入 VM（见第 6 步）。
+
+**服务器模式** — `opencode serve --hostname 0.0.0.0 --port 4096` 在沙箱内启动 HTTP 服务器。宿主端驱动可使用 `@opencode-ai/sdk` 包创建会话、发送 prompt、获取结果，适合多轮对话或从同一个宿主进程编排多个 Agent：
+
+```python
+# 启动服务器
+sandbox.commands.run(
+    "opencode serve --hostname 0.0.0.0 --port 4096 "
+    "--provider anthropic --model claude-sonnet-4-6",
+    envs={"ANTHROPIC_API_KEY": key},
+    user="root",
+    background=True,
+)
+
+# 然后从宿主端用 @opencode-ai/sdk 交互（或 curl HTTP API）
+```
+
+### 5. 会话持久化（pause / resume）
+
+```bash
+python resume_opencode.py
+```
+
+它在 SDK 层复用了[快照 / 克隆 / 回滚](../snapshot-rollback-clone.md)引擎：
+
+- `sandbox.pause()` 对运行中的 VM（内存 + rootfs）打快照并释放算力。
+- `Sandbox.connect(sandbox_id)` 恢复时，`/workspace`、OpenCode 状态目录（`/root/.opencode`）及其他文件都完好无损。
+
+> **生命周期注意：** 用 `try/finally` 手动管理沙箱，不要用 `with Sandbox.create(...)` context manager。
+> context manager 在 `__exit__` 时会 kill 沙箱，这会让 pause 失效。示例显式创建沙箱，只在 `finally` 里调用
+> `sandbox.kill()`。
+
+```python
+sandbox = Sandbox.create(template=template_id, timeout=1800)
+try:
+    run_turn(sandbox, prompt_1)          # 写入 /workspace/plan.md
+    sandbox_id = sandbox.pause() or sandbox.sandbox_id
+    sandbox = Sandbox.connect(sandbox_id)
+    assert_state_survived(sandbox)       # /workspace + /root/.opencode 仍在
+    run_turn(sandbox, prompt_2)          # 继续工作
+finally:
+    sandbox.kill()
+```
+
+### 6. 网络与出网策略（密钥保险柜）
+
+`network_policy.py` 展示了推荐用于共享集群的模式：默认拒绝出网 + 链路上注入密钥。
+
+```python
+# 凭证注入使用原生 cubesandbox SDK(见 security-proxy.md)。
+from cubesandbox import Sandbox, Rule, Match, Action, Inject
+
+host = "api.anthropic.com"
+rules = [
+    Rule(
+        name="allow_anthropic_llm",
+        match=Match(scheme="https", sni=host, host=host),
+        action=Action(allow=True, audit="metadata", inject=[
+            Inject(header="x-api-key", secret=ANTHROPIC_API_KEY, format="${SECRET}"),
+            Inject(header="anthropic-version", secret="2023-06-01", format="${SECRET}"),
+        ]),
+    ),
+]
+
+sandbox = Sandbox.create(
+    template=CUBE_TEMPLATE_ID,
+    allow_internet_access=False,   # 默认拒绝；规则里的 host 会被自动放行
+    network={"rules": rules},
+)
+```
+
+效果：
+
+- 沙箱内 `printenv ANTHROPIC_API_KEY` 只显示占位值。
+- 每次访问 LLM host 都会在链路上被附加鉴权头。
+- 其他任何目的地都会被 CubeVS 在 L3/L4 层丢弃（`allow_internet_access=False`），根本无法离开沙箱。
+- 每条 allow / deny 决策都会记入出网审计日志。
+
+非 Anthropic provider 时，示例会改注入 `Authorization: Bearer` 头。若某 provider 不接受 header 注入的密钥，可回退到直连方式（`envs=...`）—— 但绝不要把密钥写进沙箱内的持久文件。
+
+## 使用场景与最佳实践
+
+- **隔离开发。** 把编码 Agent 跑在沙箱内，其文件编辑与 shell 命令无法触及宿主。
+- **执行 Agent 生成的代码并回收结果。** 让 Agent 写入 `/workspace`，再通过 `sandbox.files` 或
+  `commands.run` 读回产物。
+- **长任务断点续跑。** 用 `pause()` + `connect()` 给长时间重构打快照并稍后恢复，或从一个快照分叉多个任务变体。
+- **SDK 编程控制。** 启动 OpenCode 服务器模式（`opencode serve`），用 `@opencode-ai/sdk` 进行细粒度的多轮编排。
+- **把重依赖预装进模板**，而不是运行时拉取，尤其在默认拒绝出网的策略下。
+
+## 关键代码片段
+
+### 无交互调用 OpenCode
+
+```python
+cmd = (
+    "cd /workspace && opencode run --provider anthropic "
+    "--model claude-sonnet-4-6 "
+    "'Inspect the project, run app.py, and summarize the result.'"
+)
+result = sandbox.commands.run(cmd, envs=opencode_env, user="root", timeout=900)
+```
+
+### 服务器模式 + SDK
+
+```python
+# 在沙箱内启动 OpenCode 服务器
+sandbox.commands.run(
+    "opencode serve --hostname 0.0.0.0 --port 4096 "
+    "--provider anthropic --model claude-sonnet-4-6",
+    envs=opencode_env,
+    user="root",
+    background=True,
+)
+# 从宿主端驱动用 @opencode-ai/sdk 交互
+```
+
+### preflight 版本检查
+
+```python
+version = sandbox.commands.run("opencode --version", timeout=60)
+```
+
+## 注意事项
+
+- **Node.js 版本。** OpenCode 需要较新的 Node 运行时；基础镜像自带的 apt Node 偏旧，务必通过 NodeSource 安装（Dockerfile 已如此）。
+- **Agent 状态目录。** `/root/.opencode` 保存 OpenCode 的会话缓存。镜像里保持它为空，避免跨租户泄露会话；它在构建时创建但不写入任何凭证。
+- **直连方式的密钥留存。** 直连方式（`envs=`）下密钥仅作用于该 exec 调用，但 OpenCode 可能把 provider 凭证缓存到其状态目录（`/root/.opencode/`），会在 `pause()` / `resume()` 后仍留在盘上。对隔离要求高时优先用保险柜方式（`network_policy.py`），密钥完全不进入 VM。
+- **CubeEgress CA（Node）。** 保险柜方式要求沙箱信任 CubeEgress 根 CA，基础镜像已把它装入系统 CA 包。
+  但 OpenCode 基于 Node.js、忽略系统 CA 库，因此 `network_policy.py` 还会设置 `NODE_EXTRA_CA_CERTS`
+  （可用 `OPENCODE_NODE_EXTRA_CA_CERTS` 覆盖）——否则 vault 路径会以 `Connection error` 失败。
+- **出网副作用。** 需要 `npm install` 或拉取 MCP 工具的任务，要放行相应 host 或预装进模板。
+- **交互式 TTY 功能。** OpenCode 交互式会话在 E2B 协议下不可用。请用无交互 `opencode run` 或服务器模式
+  （`opencode serve`），多轮对话由宿主脚本或 SDK 驱动。
+
+## 排错
+
+| 现象 | 可能原因 | 处理 |
+|---|---|---|
+| preflight 报 `opencode: command not found` | CLI 变更后未重建模板 | 重建镜像并重新注册模板 |
+| provider 鉴权失败 | 密钥未传入（直连）或缺少 inject 规则（vault） | 传 `envs={...}` 或修正规则的 `sni`/`host` |
+| `403 Forbidden - CubeEgress` | 默认拒绝且无匹配放行规则 | 把 LLM host（及所需其他 host）加入规则 |
+| vault 下 OpenCode 报 `Connection error` / TLS 失败 | OpenCode 的 Node 运行时忽略系统 CA 库，不信任 CubeEgress CA | 示例已设 `NODE_EXTRA_CA_CERTS`；若 CA 在别处用 `OPENCODE_NODE_EXTRA_CA_CERTS` 覆盖 |
+| 模板创建卡在 `PULLING` | Cube 节点无法访问 registry | 推送到集群可访问的 registry，必要时提供鉴权 |
+| 就绪探针超时 | 基础镜像缺少 envd | 确认 `FROM ghcr.io/tencentcloud/cubesandbox-base:2026.16` |
+| `pause()` / `connect()` 报错 | 平台版本过低不支持快照 | 升级 CubeSandbox 平台 |
+
+## 参考
+
+- 可运行示例：[`examples/opencode-integration`](https://github.com/TencentCloud/CubeSandbox/tree/master/examples/opencode-integration)
+- 自带镜像：[`docs/guide/tutorials/bring-your-own-image.md`](../tutorials/bring-your-own-image.md)
+- 从镜像构建模板：[`docs/guide/tutorials/template-from-image.md`](../tutorials/template-from-image.md)
+- 快照 / 克隆 / 回滚：[`docs/guide/snapshot-rollback-clone.md`](../snapshot-rollback-clone.md)
+- 密钥保险柜 + 出网管控：[`docs/guide/security-proxy.md`](../security-proxy.md)
+- OpenCode coding agent：<https://www.npmjs.com/package/opencode-ai>
+- OpenCode SDK：<https://www.npmjs.com/package/@opencode-ai/sdk>

--- a/examples/claude-code-integration/.env.example
+++ b/examples/claude-code-integration/.env.example
@@ -17,8 +17,6 @@ CUBE_TEMPLATE_ID="<template-id>"
 
 # Required: Anthropic API key.
 ANTHROPIC_API_KEY="<your-anthropic-api-key>"
-# Other providers (uncomment the one you use):
-# OPENAI_API_KEY="<your-openai-api-key>"
 
 # Optional: Anthropic-compatible endpoint (e.g. DeepSeek or AWS Bedrock).
 # ANTHROPIC_BASE_URL="https://api.deepseek.com/anthropic"

--- a/examples/claude-code-integration/.env.example
+++ b/examples/claude-code-integration/.env.example
@@ -1,0 +1,34 @@
+# --- CubeSandbox connection ---
+
+# Required: CubeAPI address (use CubeAPI, not CubeProxy).
+E2B_API_URL="http://<cube-host>:3000"
+
+# Required: any non-empty value in local dev; a real key when auth is enabled.
+E2B_API_KEY="e2b_000000"
+
+# Required: template built from this example's Dockerfile.
+CUBE_TEMPLATE_ID="<template-id>"
+
+# Optional: only when talking to CubeProxy over HTTPS with Cube's mkcert cert.
+# SSL_CERT_FILE="/root/.local/share/mkcert/rootCA.pem"
+
+# --- Claude Code agent ---
+
+# Required: Anthropic API key.
+ANTHROPIC_API_KEY="<your-anthropic-api-key>"
+# Other providers (uncomment the one you use):
+# OPENAI_API_KEY="<your-openai-api-key>"
+
+# Optional: Anthropic-compatible endpoint (e.g. DeepSeek or AWS Bedrock).
+# ANTHROPIC_BASE_URL="https://api.deepseek.com/anthropic"
+
+# Optional: default model (can also be set via --model flag).
+# CLAUDE_CODE_MODEL="claude-sonnet-4-6"
+
+# Optional (network_policy.py): LLM host to allow under default-deny egress.
+# Defaults to api.anthropic.com (or the ANTHROPIC_BASE_URL host); override only
+# for a custom endpoint.
+# CLAUDE_LLM_HOST="api.anthropic.com"
+
+# Advanced tunables (CLAUDE_CODE_MAX_TURNS, CLAUDE_CODE_EXEC_TIMEOUT, ...)
+# have sane defaults; see env_utils.py to override.

--- a/examples/claude-code-integration/.env.example
+++ b/examples/claude-code-integration/.env.example
@@ -1,7 +1,8 @@
 # --- CubeSandbox connection ---
 
-# Required: CubeAPI address (use CubeAPI, not CubeProxy).
-E2B_API_URL="http://<cube-host>:3000"
+# Required: TLS-protected CubeAPI address (use CubeAPI, not CubeProxy).
+# Plain HTTP is suitable only for isolated local development on loopback.
+E2B_API_URL="https://<cube-host>:3000"
 
 # Required: any non-empty value in local dev; a real key when auth is enabled.
 E2B_API_KEY="e2b_000000"

--- a/examples/claude-code-integration/.env.example
+++ b/examples/claude-code-integration/.env.example
@@ -28,7 +28,7 @@ ANTHROPIC_API_KEY="<your-anthropic-api-key>"
 # Optional (network_policy.py): LLM host to allow under default-deny egress.
 # Defaults to api.anthropic.com (or the ANTHROPIC_BASE_URL host); override only
 # for a custom endpoint.
-# CLAUDE_LLM_HOST="api.anthropic.com"
+# CLAUDE_CODE_LLM_HOST="api.anthropic.com"
 
 # Advanced tunables (CLAUDE_CODE_MAX_TURNS, CLAUDE_CODE_EXEC_TIMEOUT, ...)
 # have sane defaults; see env_utils.py to override.

--- a/examples/claude-code-integration/.gitignore
+++ b/examples/claude-code-integration/.gitignore
@@ -1,0 +1,8 @@
+.env
+.env.*
+!.env.example
+__pycache__/
+*.pyc
+*.log
+output/
+workspace-seed/

--- a/examples/claude-code-integration/Dockerfile
+++ b/examples/claude-code-integration/Dockerfile
@@ -1,0 +1,59 @@
+# syntax=docker/dockerfile:1.7
+#
+# Claude Code inside a CubeSandbox template.
+#
+# The image installs Node.js 24 and the @anthropic-ai/claude-code npm package on
+# top of the official CubeSandbox base image. The inherited cube-entrypoint keeps
+# envd running on :49983 so Cube can use the standard readiness probe.
+#
+# Build:
+#   docker build -t claude-code-cube:latest examples/claude-code-integration
+#
+# Register as a Cube template:
+#   cubemastercli tpl create-from-image \
+#     --image <your-registry>/claude-code-cube:latest \
+#     --writable-layer-size 4G \
+#     --expose-port 49983 \
+#     --probe       49983 \
+#     --probe-path  /health
+
+ARG CUBE_BASE_IMAGE=ghcr.io/tencentcloud/cubesandbox-base:2026.16
+FROM ${CUBE_BASE_IMAGE}
+
+ARG DEBIAN_FRONTEND=noninteractive
+ARG NODE_MAJOR=24
+ARG CLAUDE_CODE_VERSION=1.0.33
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        bash \
+        ca-certificates \
+        curl \
+        git \
+        gnupg \
+        jq \
+        less \
+        procps \
+        python3 \
+        python3-pip \
+        ripgrep \
+    && curl -fsSL "https://deb.nodesource.com/setup_${NODE_MAJOR}.x" | bash - \
+    && apt-get install -y --no-install-recommends nodejs \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Claude Code in its own layer so bumping CLAUDE_CODE_VERSION does not
+# invalidate the slow OS + Node.js layer above (only this short layer rebuilds
+# on a version bump).
+RUN npm install -g --ignore-scripts "@anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}" \
+    && claude --version \
+    && npm cache clean --force \
+    && rm -rf /root/.npm
+
+ENV CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1 \
+    NPM_CONFIG_UPDATE_NOTIFIER=false
+
+RUN mkdir -p /workspace
+
+WORKDIR /workspace
+
+EXPOSE 49983

--- a/examples/claude-code-integration/Dockerfile
+++ b/examples/claude-code-integration/Dockerfile
@@ -24,6 +24,9 @@ ARG DEBIAN_FRONTEND=noninteractive
 ARG NODE_MAJOR=24
 ARG CLAUDE_CODE_VERSION=1.0.33
 
+ENV CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1 \
+    NPM_CONFIG_UPDATE_NOTIFIER=false
+
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         bash \
@@ -44,13 +47,10 @@ RUN apt-get update \
 # Install Claude Code in its own layer so bumping CLAUDE_CODE_VERSION does not
 # invalidate the slow OS + Node.js layer above (only this short layer rebuilds
 # on a version bump).
-RUN npm install -g --ignore-scripts "@anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}" \
+RUN npm install -g --ignore-scripts --no-audit --no-fund "@anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}" \
     && claude --version \
     && npm cache clean --force \
     && rm -rf /root/.npm
-
-ENV CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1 \
-    NPM_CONFIG_UPDATE_NOTIFIER=false
 
 RUN mkdir -p /workspace
 

--- a/examples/claude-code-integration/Dockerfile
+++ b/examples/claude-code-integration/Dockerfile
@@ -33,7 +33,6 @@ RUN apt-get update \
         ca-certificates \
         curl \
         git \
-        gnupg \
         jq \
         less \
         procps \

--- a/examples/claude-code-integration/Dockerfile
+++ b/examples/claude-code-integration/Dockerfile
@@ -47,9 +47,8 @@ RUN apt-get update \
 # Install Claude Code in its own layer so bumping CLAUDE_CODE_VERSION does not
 # invalidate the slow OS + Node.js layer above (only this short layer rebuilds
 # on a version bump).
-RUN npm install -g --ignore-scripts --no-audit --no-fund "@anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}" \
+RUN npm install -g --no-audit --no-fund "@anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}" \
     && claude --version \
-    && npm cache clean --force \
     && rm -rf /root/.npm
 
 RUN mkdir -p /workspace

--- a/examples/claude-code-integration/README.md
+++ b/examples/claude-code-integration/README.md
@@ -37,7 +37,8 @@ claude-code-integration/
 
 ## Prerequisites
 
-- A running CubeSandbox deployment; CubeAPI reachable at `http://<node>:3000`.
+- A running CubeSandbox deployment; CubeAPI reachable at `https://<node>:3000`.
+  Use plain HTTP only for isolated local development on loopback.
 - `cubemastercli` on `$PATH`, connected to the cluster.
 - Docker on the build workstation, plus a registry the Cube nodes can pull from.
 - An Anthropic API key (or an Anthropic-compatible endpoint via `ANTHROPIC_BASE_URL`).
@@ -82,7 +83,7 @@ pip install -r requirements.txt
 
 | Variable | Where it flows | Notes |
 |---|---|---|
-| `E2B_API_URL` | Local process | CubeAPI address (`http://<node>:3000`) |
+| `E2B_API_URL` | Local process | TLS-protected CubeAPI address (`https://<node>:3000`) |
 | `E2B_API_KEY` | Local process | Any non-empty string in local dev |
 | `CUBE_TEMPLATE_ID` | `Sandbox.create(template=...)` | From step 2 |
 | `ANTHROPIC_API_KEY` | `envs=...` (direct) or CubeEgress inject (vault) | Anthropic key |
@@ -149,7 +150,7 @@ allow rules or preinstall those dependencies into the template.
 | `claude: command not found` in preflight | Template not rebuilt after CLI change | Rebuild the image, re-register the template |
 | Auth error from Anthropic | Key not forwarded (direct) or missing inject rule (vault) | Pass `envs={...}` or fix the rule's `sni`/`host` |
 | `403 Forbidden - CubeEgress` | Default-deny with no matching allow rule | Add the LLM host (and any extra hosts) to the rules |
-| `Connection error` / TLS failure on the vault path | Claude Code runs on Node, which ignores the system CA store and won't trust the CubeEgress interception CA | The script sets `NODE_EXTRA_CA_CERTS` to the system bundle; override with `CLAUDE_CODE_NODE_EXTRA_CA_CERTS` if your CA lives elsewhere |
+| `Connection error` / TLS failure on the vault path | Claude Code runs on Node, which ignores the system CA store and won't trust the CubeEgress interception CA | The script points `NODE_EXTRA_CA_CERTS` at the dedicated CubeEgress anchor; override with `CLAUDE_CODE_NODE_EXTRA_CA_CERTS` if your CA lives elsewhere |
 | Readiness probe timeout | Image without envd | Ensure `FROM ghcr.io/tencentcloud/cubesandbox-base:...` |
 | `pause()`/`connect()` errors | Platform too old for snapshots | Upgrade the CubeSandbox platform |
 

--- a/examples/claude-code-integration/README.md
+++ b/examples/claude-code-integration/README.md
@@ -1,0 +1,161 @@
+# Claude Code + CubeSandbox Example
+
+[中文文档](README_zh.md)
+
+Run [Claude Code](https://docs.anthropic.com/en/docs/claude-code)
+— Anthropic's official CLI coding agent — inside a CubeSandbox MicroVM. The
+agent edits files, runs commands, and reaches the Anthropic LLM API entirely
+within an isolated, reproducible sandbox.
+
+This example ships:
+
+- A `Dockerfile` that stacks Node.js 24 + the Claude Code CLI on top of the
+  CubeSandbox base image (envd already listens on `:49983`).
+- `run_claude_code.py` — a headless one-shot run inside `/workspace`.
+- `resume_claude_code.py` — pause/resume across two turns, proving `/workspace`
+  survived the snapshot.
+- `network_policy.py` — a default-deny egress policy where CubeEgress injects
+  the API key on the wire, so the key never enters the VM.
+- `env_utils.py`, `.env.example`, `requirements.txt`.
+
+## Directory layout
+
+```
+claude-code-integration/
+├── Dockerfile            # CubeSandbox template image (Node.js + Claude Code CLI)
+├── .env.example          # Copy to .env and fill in
+├── .gitignore
+├── requirements.txt      # Host driver deps (e2b, cubesandbox, python-dotenv)
+├── env_utils.py          # .env loading, Anthropic key, Claude Code command builder
+├── _common.py            # Shared sandbox command helpers (run/ensure/id)
+├── run_claude_code.py    # One-shot Claude Code task
+├── resume_claude_code.py # Pause / resume session persistence
+├── network_policy.py     # Default-deny egress + on-the-wire key injection
+├── README.md             # English docs (this file)
+└── README_zh.md          # Chinese docs
+```
+
+## Prerequisites
+
+- A running CubeSandbox deployment; CubeAPI reachable at `http://<node>:3000`.
+- `cubemastercli` on `$PATH`, connected to the cluster.
+- Docker on the build workstation, plus a registry the Cube nodes can pull from.
+- An Anthropic API key (or an Anthropic-compatible endpoint via `ANTHROPIC_BASE_URL`).
+- Python 3.10+ for the host driver scripts.
+
+## 1. Build the template image
+
+```bash
+docker build --platform linux/amd64 \
+  -t <your-registry>/claude-code-cube:latest \
+  examples/claude-code-integration
+docker push <your-registry>/claude-code-cube:latest
+```
+
+The image installs `@anthropic-ai/claude-code`, plus `git`, `python3`,
+`ripgrep`, `jq`, and cleans apt/npm caches. The Claude Code version is pinned
+via `--build-arg CLAUDE_CODE_VERSION=x.y.z`.
+
+## 2. Register as a Cube template
+
+```bash
+cubemastercli tpl create-from-image \
+  --image <your-registry>/claude-code-cube:latest \
+  --writable-layer-size 4G \
+  --expose-port 49983 \
+  --probe       49983 \
+  --probe-path  /health
+
+cubemastercli tpl watch --job-id <job_id>
+```
+
+Note the `template_id` once the job reaches `READY`.
+
+## 3. Configure the host driver
+
+```bash
+cd examples/claude-code-integration
+cp .env.example .env
+# fill in E2B_API_URL, CUBE_TEMPLATE_ID, and your Anthropic key
+pip install -r requirements.txt
+```
+
+| Variable | Where it flows | Notes |
+|---|---|---|
+| `E2B_API_URL` | Local process | CubeAPI address (`http://<node>:3000`) |
+| `E2B_API_KEY` | Local process | Any non-empty string in local dev |
+| `CUBE_TEMPLATE_ID` | `Sandbox.create(template=...)` | From step 2 |
+| `ANTHROPIC_API_KEY` | `envs=...` (direct) or CubeEgress inject (vault) | Anthropic key |
+| `ANTHROPIC_BASE_URL` | Passed into the exec env | Anthropic-compatible gateways (e.g. DeepSeek) |
+| `CLAUDE_CODE_MODEL` | Claude CLI `--model` flag | Defaults to `claude-sonnet-4-6` |
+| `CLAUDE_CODE_LLM_HOST` | `network_policy.py` | LLM host allowed under default-deny egress |
+
+## 4. One-shot run (direct key flavor)
+
+```bash
+python run_claude_code.py --prompt "Create hello.py that prints 'Hello from CubeSandbox' and run it."
+```
+
+The key is forwarded per-command via `sandbox.commands.run(..., envs=...)`, so
+it lives only for the lifetime of that exec call — never written to a
+persistent file inside the VM.
+
+> **Security:** this direct flavor leaves egress open, so a compromised agent
+> could exfiltrate the injected key. For shared clusters use the vault flavor
+> (step 6): default-deny egress + on-the-wire key injection.
+
+All three scripts run Claude Code with `--output-format stream-json` and render
+a concise transcript by default (assistant text, tool calls, and any failures).
+Pass `--raw` (or set `CLAUDE_CODE_STREAM_RAW=1`) to stream Claude Code's raw
+JSONL events instead.
+
+## 5. Pause / resume (session persistence)
+
+```bash
+python resume_claude_code.py
+```
+
+Turn 1 asks Claude Code to write `/workspace/plan.md`, then
+`sandbox.pause()` snapshots the VM. The script reconnects with
+`Sandbox.connect(sandbox_id)`, verifies `/workspace/plan.md` survived, then
+runs turn 2 to continue the work. The sandbox lifecycle is managed manually
+with `try/finally` (not a context manager), so the pause is not undone by an
+early `kill`.
+
+## 6. Restricted egress + key vault (recommended for shared clusters)
+
+```bash
+python network_policy.py
+```
+
+- Egress is default-deny — only the Anthropic LLM host is reachable.
+- CubeEgress attaches the Anthropic key as HTTP headers on the wire (`x-api-key`
+  and `anthropic-version`), so `printenv` inside the sandbox never shows the
+  real key — it only sees a placeholder.
+- Because Claude Code runs on Node.js (which ignores the system CA store), the
+  script sets `NODE_EXTRA_CA_CERTS` so Claude Code trusts the CubeEgress
+  interception CA; without it the vault path fails with `Connection error`.
+  Override the bundle path via `CLAUDE_CODE_NODE_EXTRA_CA_CERTS` if your image
+  keeps the CA elsewhere.
+- Any other destination returns `403 Forbidden - CubeEgress`.
+
+If the agent needs extra hosts (package registries, MCP servers), add matching
+allow rules or preinstall those dependencies into the template.
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| `claude: command not found` in preflight | Template not rebuilt after CLI change | Rebuild the image, re-register the template |
+| Auth error from Anthropic | Key not forwarded (direct) or missing inject rule (vault) | Pass `envs={...}` or fix the rule's `sni`/`host` |
+| `403 Forbidden - CubeEgress` | Default-deny with no matching allow rule | Add the LLM host (and any extra hosts) to the rules |
+| `Connection error` / TLS failure on the vault path | Claude Code runs on Node, which ignores the system CA store and won't trust the CubeEgress interception CA | The script sets `NODE_EXTRA_CA_CERTS` to the system bundle; override with `CLAUDE_CODE_NODE_EXTRA_CA_CERTS` if your CA lives elsewhere |
+| Readiness probe timeout | Image without envd | Ensure `FROM ghcr.io/tencentcloud/cubesandbox-base:...` |
+| `pause()`/`connect()` errors | Platform too old for snapshots | Upgrade the CubeSandbox platform |
+
+## References
+
+- Integration guide: [`docs/guide/integrations/claude-code.md`](../../docs/guide/integrations/claude-code.md)
+- Snapshot / Clone / Rollback: [`docs/guide/snapshot-rollback-clone.md`](../../docs/guide/snapshot-rollback-clone.md)
+- Network / egress policy examples: [`examples/network-policy`](../network-policy)
+- Claude Code: <https://docs.anthropic.com/en/docs/claude-code>

--- a/examples/claude-code-integration/README_zh.md
+++ b/examples/claude-code-integration/README_zh.md
@@ -32,7 +32,8 @@ claude-code-integration/
 
 ## 前置条件
 
-- 已部署 CubeSandbox，CubeAPI 可访问（`http://<node>:3000`）。
+- 已部署 CubeSandbox，CubeAPI 可通过 TLS 访问（`https://<node>:3000`）。
+  明文 HTTP 只适用于隔离的本地回环开发环境。
 - `cubemastercli` 已在 `$PATH` 且已连通集群。
 - 构建机装有 Docker，且 registry 能被 Cube 集群拉取。
 - 一个 Anthropic API Key（或通过 `ANTHROPIC_BASE_URL` 使用 Anthropic 兼容端点）。
@@ -76,7 +77,7 @@ pip install -r requirements.txt
 
 | 变量 | 作用位置 | 说明 |
 |---|---|---|
-| `E2B_API_URL` | 本地进程 | CubeAPI 地址（`http://<node>:3000`） |
+| `E2B_API_URL` | 本地进程 | 启用 TLS 的 CubeAPI 地址（`https://<node>:3000`） |
 | `E2B_API_KEY` | 本地进程 | 本地开发填任意非空字符串 |
 | `CUBE_TEMPLATE_ID` | `Sandbox.create(template=...)` | 来自第 2 步 |
 | `ANTHROPIC_API_KEY` | `envs=...`（直连）或 CubeEgress 注入（vault） | Anthropic 密钥 |
@@ -125,7 +126,7 @@ python network_policy.py
 | preflight 报 `claude: command not found` | CLI 变更后未重建模板 | 重建镜像并重新注册模板 |
 | Anthropic 鉴权失败 | 密钥未传入（直连）或缺少 inject 规则（vault） | 传 `envs={...}` 或修正规则的 `sni`/`host` |
 | `403 Forbidden - CubeEgress` | 默认拒绝且无匹配放行规则 | 把 LLM host（及所需其他 host）加入规则 |
-| vault 路径下 Claude Code 报 `Connection error` / TLS 失败 | Claude Code 基于 Node，忽略系统 CA 库，不信任 CubeEgress 拦截 CA | 脚本已把 `NODE_EXTRA_CA_CERTS` 指向系统 CA 包；若 CA 在别处，用 `CLAUDE_CODE_NODE_EXTRA_CA_CERTS` 覆盖 |
+| vault 路径下 Claude Code 报 `Connection error` / TLS 失败 | Claude Code 基于 Node，忽略系统 CA 库，不信任 CubeEgress 拦截 CA | 脚本已把 `NODE_EXTRA_CA_CERTS` 指向专用 CubeEgress CA；若 CA 在别处，用 `CLAUDE_CODE_NODE_EXTRA_CA_CERTS` 覆盖 |
 | 就绪探针超时 | 镜像缺少 envd | 确认 `FROM ghcr.io/tencentcloud/cubesandbox-base:...` |
 | `pause()`/`connect()` 报错 | 平台版本过低不支持快照 | 升级 CubeSandbox 平台 |
 

--- a/examples/claude-code-integration/README_zh.md
+++ b/examples/claude-code-integration/README_zh.md
@@ -1,0 +1,137 @@
+# Claude Code + CubeSandbox 示例
+
+[English](README.md)
+
+在 CubeSandbox MicroVM 内运行 [Claude Code](https://docs.anthropic.com/en/docs/claude-code)
+（Anthropic 官方 CLI 编码 Agent）。Agent 在一个隔离、可复现的沙箱内编辑文件、执行命令并访问 Anthropic LLM API。
+
+本示例包含：
+
+- 一个 `Dockerfile`：在 CubeSandbox 基础镜像上叠加 Node.js 与 Claude Code CLI（envd 已监听 `:49983`）。
+- `run_claude_code.py`：在 `/workspace` 内的一次性无交互运行。
+- `resume_claude_code.py`：跨两轮的 pause/resume，证明 `/workspace` 在快照后仍存在。
+- `network_policy.py`：默认拒绝出网的策略，由 CubeEgress 在链路上注入 API Key，密钥不进入 VM。
+- `env_utils.py`、`.env.example`、`requirements.txt`。
+
+## 目录结构
+
+```
+claude-code-integration/
+├── Dockerfile            # CubeSandbox 模板镜像（Node.js + Claude Code CLI）
+├── .env.example          # 复制为 .env 并填写
+├── .gitignore
+├── requirements.txt      # 宿主端驱动依赖（e2b、cubesandbox、python-dotenv）
+├── env_utils.py          # .env 加载、Anthropic key、Claude Code 命令构造
+├── _common.py            # 共享的沙箱命令辅助（run/ensure/id）
+├── run_claude_code.py    # 一次性 Claude Code 任务
+├── resume_claude_code.py # pause / resume 会话持久化
+├── network_policy.py     # 默认拒绝出网 + 链路上注入密钥
+├── README.md             # 英文文档
+└── README_zh.md          # 中文文档（本文件）
+```
+
+## 前置条件
+
+- 已部署 CubeSandbox，CubeAPI 可访问（`http://<node>:3000`）。
+- `cubemastercli` 已在 `$PATH` 且已连通集群。
+- 构建机装有 Docker，且 registry 能被 Cube 集群拉取。
+- 一个 Anthropic API Key（或通过 `ANTHROPIC_BASE_URL` 使用 Anthropic 兼容端点）。
+- Python 3.10+（宿主端驱动脚本）。
+
+## 1. 构建模板镜像
+
+```bash
+docker build --platform linux/amd64 \
+  -t <your-registry>/claude-code-cube:latest \
+  examples/claude-code-integration
+docker push <your-registry>/claude-code-cube:latest
+```
+
+镜像会安装 `@anthropic-ai/claude-code`，以及 `git`、`python3`、`ripgrep`、`jq`，并清理
+apt/npm 缓存。Claude Code 版本通过 `--build-arg CLAUDE_CODE_VERSION=x.y.z` 固定。
+
+## 2. 注册为 Cube 模板
+
+```bash
+cubemastercli tpl create-from-image \
+  --image <your-registry>/claude-code-cube:latest \
+  --writable-layer-size 4G \
+  --expose-port 49983 \
+  --probe       49983 \
+  --probe-path  /health
+
+cubemastercli tpl watch --job-id <job_id>
+```
+
+任务变为 `READY` 后记下 `template_id`。
+
+## 3. 配置宿主端驱动
+
+```bash
+cd examples/claude-code-integration
+cp .env.example .env
+# 填写 E2B_API_URL、CUBE_TEMPLATE_ID 以及你的 Anthropic key
+pip install -r requirements.txt
+```
+
+| 变量 | 作用位置 | 说明 |
+|---|---|---|
+| `E2B_API_URL` | 本地进程 | CubeAPI 地址（`http://<node>:3000`） |
+| `E2B_API_KEY` | 本地进程 | 本地开发填任意非空字符串 |
+| `CUBE_TEMPLATE_ID` | `Sandbox.create(template=...)` | 来自第 2 步 |
+| `ANTHROPIC_API_KEY` | `envs=...`（直连）或 CubeEgress 注入（vault） | Anthropic 密钥 |
+| `ANTHROPIC_BASE_URL` | 传入 exec 环境 | Anthropic 兼容网关（如 DeepSeek） |
+| `CLAUDE_CODE_MODEL` | Claude CLI `--model` 参数 | 默认 `claude-sonnet-4-6` |
+| `CLAUDE_CODE_LLM_HOST` | `network_policy.py` | 放行的 LLM API host |
+
+## 4. 一次性运行（直连注入密钥）
+
+```bash
+python run_claude_code.py --prompt "创建 hello.py 打印 'Hello from CubeSandbox' 并运行它。"
+```
+
+密钥通过 `sandbox.commands.run(..., envs=...)` 逐命令传入，只在该命令执行期间存在，不会写入 VM 内的持久文件。
+
+> **安全：** 直连方式出网是放开的，Agent 被攻破可能外泄注入的密钥。共享集群请用保险柜方式（第 6 步）：默认拒绝出网 + 链路上注入密钥。
+
+三个脚本都以 `--output-format stream-json` 运行 Claude Code，默认输出精简转写（助手文本、工具调用、失败项）。加 `--raw`（或设置 `CLAUDE_CODE_STREAM_RAW=1`）可改为打印原始 JSONL 事件流。
+
+## 5. pause / resume（会话持久化）
+
+```bash
+python resume_claude_code.py
+```
+
+第一轮让 Claude Code 写 `/workspace/plan.md`，随后 `sandbox.pause()` 对 VM 打快照。脚本用
+`Sandbox.connect(sandbox_id)` 恢复，校验 `/workspace/plan.md` 仍在，再执行第二轮续写。沙箱生命周期用 `try/finally` 手动管理（不用 context manager），避免 pause 后被过早 `kill` 掉。
+
+## 6. 受限出网 + 密钥保险柜（推荐用于共享集群）
+
+```bash
+python network_policy.py
+```
+
+- 出网默认拒绝，仅放行 Anthropic LLM host。
+- CubeEgress 在链路上把 Anthropic 密钥作为 HTTP 头注入（`x-api-key` 和 `anthropic-version`），因此沙箱内 `printenv` 看不到真实密钥，只有占位值。
+- Claude Code 基于 Node.js（忽略系统 CA 库），脚本会设置 `NODE_EXTRA_CA_CERTS` 让 Claude Code 信任 CubeEgress 的拦截 CA；否则 vault 路径会以 `Connection error` 失败。若镜像里 CA 路径不同，可用 `CLAUDE_CODE_NODE_EXTRA_CA_CERTS` 覆盖。
+- 任何其他目的地都会返回 `403 Forbidden - CubeEgress`。
+
+若 Agent 需要访问额外主机（包镜像源、MCP 服务器等），请增加对应的放行规则，或把这些依赖预装进模板。
+
+## 排错
+
+| 现象 | 可能原因 | 处理 |
+|---|---|---|
+| preflight 报 `claude: command not found` | CLI 变更后未重建模板 | 重建镜像并重新注册模板 |
+| Anthropic 鉴权失败 | 密钥未传入（直连）或缺少 inject 规则（vault） | 传 `envs={...}` 或修正规则的 `sni`/`host` |
+| `403 Forbidden - CubeEgress` | 默认拒绝且无匹配放行规则 | 把 LLM host（及所需其他 host）加入规则 |
+| vault 路径下 Claude Code 报 `Connection error` / TLS 失败 | Claude Code 基于 Node，忽略系统 CA 库，不信任 CubeEgress 拦截 CA | 脚本已把 `NODE_EXTRA_CA_CERTS` 指向系统 CA 包；若 CA 在别处，用 `CLAUDE_CODE_NODE_EXTRA_CA_CERTS` 覆盖 |
+| 就绪探针超时 | 镜像缺少 envd | 确认 `FROM ghcr.io/tencentcloud/cubesandbox-base:...` |
+| `pause()`/`connect()` 报错 | 平台版本过低不支持快照 | 升级 CubeSandbox 平台 |
+
+## 参考
+
+- 集成指南：[`docs/zh/guide/integrations/claude-code.md`](../../docs/zh/guide/integrations/claude-code.md)
+- 快照 / 克隆 / 回滚：[`docs/zh/guide/snapshot-rollback-clone.md`](../../docs/zh/guide/snapshot-rollback-clone.md)
+- 网络 / 出网策略示例：[`examples/network-policy`](../network-policy)
+- Claude Code：<https://docs.anthropic.com/en/docs/claude-code>

--- a/examples/claude-code-integration/_common.py
+++ b/examples/claude-code-integration/_common.py
@@ -163,7 +163,13 @@ def run_command(
 
 def ensure_success(result, action: str) -> None:
     exit_code = getattr(result, "exit_code", None)
-    if exit_code is not None and int(exit_code) != 0:
+    if exit_code is None:
+        return
+    try:
+        code = int(exit_code)
+    except (TypeError, ValueError) as exc:
+        raise SystemExit(f"Cannot parse exit code {exit_code!r} for: {action}") from exc
+    if code != 0:
         stdout = getattr(result, "stdout", "")
         stderr = getattr(result, "stderr", "")
         raise SystemExit(

--- a/examples/claude-code-integration/_common.py
+++ b/examples/claude-code-integration/_common.py
@@ -104,14 +104,19 @@ def stream_json_render_writer() -> Callable[[object], None]:
     # partial line, per callback), not one event per call. Buffer and split on
     # newlines so each event is rendered exactly once. Claude Code newline-
     # terminates every event, so nothing important is left dangling in the buffer.
-    buffer = {"text": ""}
+    buffer = {"parts": []}
 
     def write(chunk: object) -> None:
         text = getattr(chunk, "line", chunk)
-        buffer["text"] += text if isinstance(text, str) else str(text)
-        while "\n" in buffer["text"]:
-            line, buffer["text"] = buffer["text"].split("\n", 1)
+        text = text if isinstance(text, str) else str(text)
+        lines = text.split("\n")
+        if len(lines) == 1:
+            buffer["parts"].append(text)
+            return
+        _render_stream_json_line("".join(buffer["parts"]) + lines[0])
+        for line in lines[1:-1]:
             _render_stream_json_line(line)
+        buffer["parts"] = [lines[-1]]
 
     return write
 
@@ -124,6 +129,7 @@ def run_command(
     envs: dict[str, str] | None = None,
     timeout: int | float | None = None,
     stream: bool = False,
+    raw: bool | None = None,
     user: str = "root",
 ):
     # Run as root: /workspace is root-owned, and the default e2b exec user
@@ -136,9 +142,10 @@ def run_command(
         # Default to a concise transcript (assistant text + tool calls + errors).
         # Set CLAUDE_CODE_STREAM_RAW=1 (or pass --raw) to dump Claude Code's
         # raw stream-json instead.
-        raw = os.environ.get("CLAUDE_CODE_STREAM_RAW", "").strip().lower() in (
-            "1", "true", "yes",
-        )
+        if raw is None:
+            raw = os.environ.get("CLAUDE_CODE_STREAM_RAW", "").strip().lower() in (
+                "1", "true", "yes",
+            )
         kwargs["on_stdout"] = stream_writer(sys.stdout) if raw else stream_json_render_writer()
         kwargs["on_stderr"] = stream_writer(sys.stderr)
 
@@ -156,7 +163,7 @@ def run_command(
 
 def ensure_success(result, action: str) -> None:
     exit_code = getattr(result, "exit_code", None)
-    if exit_code not in (None, 0):
+    if exit_code is not None and int(exit_code) != 0:
         stdout = getattr(result, "stdout", "")
         stderr = getattr(result, "stderr", "")
         raise SystemExit(

--- a/examples/claude-code-integration/_common.py
+++ b/examples/claude-code-integration/_common.py
@@ -1,0 +1,168 @@
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared sandbox command helpers for the Claude Code example scripts.
+
+Kept SDK-agnostic (duck-typed on ``sandbox.commands.run`` and the result's
+attributes) so the same helpers work with both the e2b-compatible SDK used by
+``run_claude_code.py`` / ``resume_claude_code.py`` and the native
+``cubesandbox`` SDK used by ``network_policy.py``.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from collections.abc import Callable
+from typing import Any
+
+
+def stream_writer(stream) -> Callable[[object], None]:
+    def write(chunk: object) -> None:
+        text = getattr(chunk, "line", chunk)
+        stream.write(str(text))
+        stream.flush()
+
+    return write
+
+
+def _render_stream_json_line(line: str) -> None:
+    """Render one Claude Code ``--output-format stream-json`` event as concise,
+    human-readable output.
+
+    Claude Code stream-json events include assistant text, tool use, and
+    result messages. We extract the key content for a concise transcript.
+    Non-JSON lines are printed verbatim. Set CLAUDE_CODE_STREAM_RAW=1 (or pass
+    ``--raw``) to see the raw JSONL stream instead.
+    """
+    line = line.rstrip("\r\n")
+    if not line.strip():
+        return
+    try:
+        event = json.loads(line)
+    except (ValueError, TypeError):
+        print(line)
+        return
+    if not isinstance(event, dict):
+        print(line)
+        return
+
+    # Claude Code stream-json has different event types; render the key ones.
+    event_type = event.get("type")
+
+    if event_type == "assistant":
+        # Assistant text content
+        message = event.get("message", event)
+        content = message.get("content", [])
+        if isinstance(content, str) and content.strip():
+            print(content.strip())
+        elif isinstance(content, list):
+            for item in content:
+                if not isinstance(item, dict):
+                    continue
+                itype = item.get("type")
+                if itype == "text":
+                    text = str(item.get("text", "")).strip()
+                    if text:
+                        print(text)
+                elif itype == "tool_use":
+                    name = item.get("name") or "tool"
+                    input_data = item.get("input", {})
+                    brief = _tool_brief(input_data)
+                    print(f"  -> [tool] {name}{': ' + brief if brief else ''}")
+
+    elif event_type == "result":
+        # Final result message
+        result_text = event.get("result", "")
+        if isinstance(result_text, str) and result_text.strip():
+            print(result_text.strip())
+
+    elif event_type == "error":
+        error_msg = event.get("error", event.get("message", ""))
+        print(f"  [error] {str(error_msg)[:300]}")
+
+    elif event_type == "tool_result":
+        # Tool execution result — only show errors
+        content = event.get("content", "")
+        is_error = event.get("is_error", False)
+        if is_error:
+            tool_name = event.get("tool_use_id", "tool")
+            print(f"  x [tool] {tool_name} failed")
+
+
+def _tool_brief(arguments: dict) -> str:
+    for key in ("command", "path", "pattern", "query", "url", "file_path"):
+        value = arguments.get(key)
+        if value:
+            return str(value).replace("\n", " ")[:120]
+    return ""
+
+
+def stream_json_render_writer() -> Callable[[object], None]:
+    # e2b delivers stdout as arbitrary chunks (often several JSONL events, or a
+    # partial line, per callback), not one event per call. Buffer and split on
+    # newlines so each event is rendered exactly once. Claude Code newline-
+    # terminates every event, so nothing important is left dangling in the buffer.
+    buffer = {"text": ""}
+
+    def write(chunk: object) -> None:
+        text = getattr(chunk, "line", chunk)
+        buffer["text"] += text if isinstance(text, str) else str(text)
+        while "\n" in buffer["text"]:
+            line, buffer["text"] = buffer["text"].split("\n", 1)
+            _render_stream_json_line(line)
+
+    return write
+
+
+def run_command(
+    sandbox: Any,
+    command: str,
+    *,
+    cwd: str | None = None,
+    envs: dict[str, str] | None = None,
+    timeout: int | float | None = None,
+    stream: bool = False,
+    user: str = "root",
+):
+    # Run as root: /workspace is root-owned, and the default e2b exec user
+    # ("user") cannot write to it.
+    kwargs = {"cwd": cwd, "timeout": timeout, "user": user}
+    kwargs = {key: value for key, value in kwargs.items() if value is not None}
+    if envs:
+        kwargs["envs"] = envs
+    if stream:
+        # Default to a concise transcript (assistant text + tool calls + errors).
+        # Set CLAUDE_CODE_STREAM_RAW=1 (or pass --raw) to dump Claude Code's
+        # raw stream-json instead.
+        raw = os.environ.get("CLAUDE_CODE_STREAM_RAW", "").strip().lower() in (
+            "1", "true", "yes",
+        )
+        kwargs["on_stdout"] = stream_writer(sys.stdout) if raw else stream_json_render_writer()
+        kwargs["on_stderr"] = stream_writer(sys.stderr)
+
+    try:
+        return sandbox.commands.run(command, **kwargs)
+    except TypeError as exc:
+        # Older SDKs name the parameter ``env`` instead of ``envs``. Only retry
+        # for that specific signature mismatch; re-raise any other TypeError so
+        # real bugs (e.g. a wrong-type command or timeout) are not masked.
+        if "envs" not in kwargs or "envs" not in str(exc):
+            raise
+        kwargs["env"] = kwargs.pop("envs")
+        return sandbox.commands.run(command, **kwargs)
+
+
+def ensure_success(result, action: str) -> None:
+    exit_code = getattr(result, "exit_code", None)
+    if exit_code not in (None, 0):
+        stdout = getattr(result, "stdout", "")
+        stderr = getattr(result, "stderr", "")
+        raise SystemExit(
+            f"Failed to {action} (exit {exit_code}).\nSTDOUT:\n{stdout}\nSTDERR:\n{stderr}"
+        )
+
+
+def sandbox_identifier(sandbox: Any) -> str:
+    return getattr(sandbox, "sandbox_id", getattr(sandbox, "id", "unknown"))

--- a/examples/claude-code-integration/_common.py
+++ b/examples/claude-code-integration/_common.py
@@ -99,26 +99,34 @@ def _tool_brief(arguments: dict) -> str:
     return ""
 
 
+class _BufferedJSONWriter:
+    def __init__(self) -> None:
+        self.parts: list[str] = []
+
+    def __call__(self, chunk: object) -> None:
+        text = getattr(chunk, "line", chunk)
+        text = text if isinstance(text, str) else str(text)
+        lines = text.split("\n")
+        if len(lines) == 1:
+            self.parts.append(text)
+            return
+        _render_stream_json_line("".join(self.parts) + lines[0])
+        for line in lines[1:-1]:
+            _render_stream_json_line(line)
+        self.parts = [lines[-1]]
+
+    def flush(self) -> None:
+        if self.parts:
+            _render_stream_json_line("".join(self.parts))
+            self.parts.clear()
+
+
 def stream_json_render_writer() -> Callable[[object], None]:
     # e2b delivers stdout as arbitrary chunks (often several JSONL events, or a
     # partial line, per callback), not one event per call. Buffer and split on
     # newlines so each event is rendered exactly once. Claude Code newline-
     # terminates every event, so nothing important is left dangling in the buffer.
-    buffer = {"parts": []}
-
-    def write(chunk: object) -> None:
-        text = getattr(chunk, "line", chunk)
-        text = text if isinstance(text, str) else str(text)
-        lines = text.split("\n")
-        if len(lines) == 1:
-            buffer["parts"].append(text)
-            return
-        _render_stream_json_line("".join(buffer["parts"]) + lines[0])
-        for line in lines[1:-1]:
-            _render_stream_json_line(line)
-        buffer["parts"] = [lines[-1]]
-
-    return write
+    return _BufferedJSONWriter()
 
 
 def run_command(
@@ -138,6 +146,7 @@ def run_command(
     kwargs = {key: value for key, value in kwargs.items() if value is not None}
     if envs:
         kwargs["envs"] = envs
+    stdout_writer = None
     if stream:
         # Default to a concise transcript (assistant text + tool calls + errors).
         # Set CLAUDE_CODE_STREAM_RAW=1 (or pass --raw) to dump Claude Code's
@@ -146,25 +155,31 @@ def run_command(
             raw = os.environ.get("CLAUDE_CODE_STREAM_RAW", "").strip().lower() in (
                 "1", "true", "yes",
             )
-        kwargs["on_stdout"] = stream_writer(sys.stdout) if raw else stream_json_render_writer()
+        stdout_writer = stream_writer(sys.stdout) if raw else stream_json_render_writer()
+        kwargs["on_stdout"] = stdout_writer
         kwargs["on_stderr"] = stream_writer(sys.stderr)
 
     try:
-        return sandbox.commands.run(command, **kwargs)
-    except TypeError as exc:
-        # Older SDKs name the parameter ``env`` instead of ``envs``. Only retry
-        # for that specific signature mismatch; re-raise any other TypeError so
-        # real bugs (e.g. a wrong-type command or timeout) are not masked.
-        if "envs" not in kwargs or "envs" not in str(exc):
-            raise
-        kwargs["env"] = kwargs.pop("envs")
-        return sandbox.commands.run(command, **kwargs)
+        try:
+            return sandbox.commands.run(command, **kwargs)
+        except TypeError as exc:
+            # Older SDKs name the parameter ``env`` instead of ``envs``. Only retry
+            # for that specific signature mismatch; re-raise any other TypeError so
+            # real bugs (e.g. a wrong-type command or timeout) are not masked.
+            if "envs" not in kwargs or "envs" not in str(exc):
+                raise
+            kwargs["env"] = kwargs.pop("envs")
+            return sandbox.commands.run(command, **kwargs)
+    finally:
+        flush = getattr(stdout_writer, "flush", None)
+        if flush:
+            flush()
 
 
 def ensure_success(result, action: str) -> None:
     exit_code = getattr(result, "exit_code", None)
     if exit_code is None:
-        return
+        raise SystemExit(f"Failed to {action}: command returned no exit code")
     try:
         code = int(exit_code)
     except (TypeError, ValueError) as exc:

--- a/examples/claude-code-integration/env_utils.py
+++ b/examples/claude-code-integration/env_utils.py
@@ -15,6 +15,7 @@ DEFAULT_WORKSPACE = "/workspace"
 
 PASSTHROUGH_ENV_NAMES = (
     "ANTHROPIC_BASE_URL",
+    "ANTHROPIC_MODEL",
     "HTTP_PROXY",
     "HTTPS_PROXY",
     "NO_PROXY",
@@ -61,11 +62,14 @@ def int_env(name: str, default: int) -> int:
 def claude_code_model() -> str:
     """Resolve the model Claude Code should use.
 
-    Precedence: explicit ``CLAUDE_CODE_MODEL`` > default ``claude-sonnet-4-6``.
+    Precedence: ``CLAUDE_CODE_MODEL`` > ``ANTHROPIC_MODEL`` > default.
     """
     explicit = os.environ.get("CLAUDE_CODE_MODEL")
     if explicit:
         return explicit
+    anthropic_model = os.environ.get("ANTHROPIC_MODEL")
+    if anthropic_model:
+        return anthropic_model
     return "claude-sonnet-4-6"
 
 

--- a/examples/claude-code-integration/env_utils.py
+++ b/examples/claude-code-integration/env_utils.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import os
 import shlex
+import warnings
 from pathlib import Path
 from urllib.parse import urlparse
 
@@ -87,6 +88,12 @@ def build_claude_code_env(include_secrets: bool = True) -> dict[str, str]:
     Anthropic key rides the wire via egress injection, so it must never enter
     the sandbox environment.
     """
+    if include_secrets and any(os.environ.get(name) for name in ("HTTP_PROXY", "HTTPS_PROXY")):
+        warnings.warn(
+            "Direct-key mode forwards proxy settings; the proxy can observe LLM traffic and credentials.",
+            RuntimeWarning,
+            stacklevel=2,
+        )
     env: dict[str, str] = {}
     for name in PASSTHROUGH_ENV_NAMES:
         value = os.environ.get(name)

--- a/examples/claude-code-integration/env_utils.py
+++ b/examples/claude-code-integration/env_utils.py
@@ -20,6 +20,7 @@ PASSTHROUGH_ENV_NAMES = (
     "HTTPS_PROXY",
     "NO_PROXY",
 )
+PROXY_ENV_NAMES = ("HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY")
 
 
 def load_local_dotenv() -> None:
@@ -46,6 +47,7 @@ def required(name: str) -> str:
 
 
 def optional(name: str, default: str = "") -> str:
+    """Return the configured non-empty value, otherwise ``default``."""
     return os.environ.get(name) or default
 
 
@@ -100,6 +102,8 @@ def build_claude_code_env(include_secrets: bool = True) -> dict[str, str]:
         )
     env: dict[str, str] = {}
     for name in PASSTHROUGH_ENV_NAMES:
+        if not include_secrets and name in PROXY_ENV_NAMES:
+            continue
         value = os.environ.get(name)
         if value:
             env[name] = value

--- a/examples/claude-code-integration/env_utils.py
+++ b/examples/claude-code-integration/env_utils.py
@@ -22,10 +22,7 @@ PASSTHROUGH_ENV_NAMES = (
 
 def load_local_dotenv() -> None:
     """Best-effort load of a nearby .env file without overriding real env vars."""
-    candidate_paths = [
-        Path(__file__).with_name(".env"),
-        Path.cwd() / ".env",
-    ]
+    candidate_paths = [Path(__file__).with_name(".env")]
 
     seen_paths: set[Path] = set()
     for path in candidate_paths:

--- a/examples/claude-code-integration/env_utils.py
+++ b/examples/claude-code-integration/env_utils.py
@@ -1,0 +1,178 @@
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import os
+import shlex
+from pathlib import Path
+from urllib.parse import urlparse
+
+from dotenv import load_dotenv
+
+DEFAULT_WORKSPACE = "/workspace"
+
+PASSTHROUGH_ENV_NAMES = (
+    "ANTHROPIC_BASE_URL",
+    "HTTP_PROXY",
+    "HTTPS_PROXY",
+    "NO_PROXY",
+)
+
+
+def load_local_dotenv() -> None:
+    """Best-effort load of a nearby .env file without overriding real env vars."""
+    candidate_paths = [
+        Path(__file__).with_name(".env"),
+        Path.cwd() / ".env",
+    ]
+
+    seen_paths: set[Path] = set()
+    for path in candidate_paths:
+        resolved_path = path.resolve()
+        if resolved_path in seen_paths:
+            continue
+        seen_paths.add(resolved_path)
+
+        if path.is_file():
+            load_dotenv(dotenv_path=path, override=False)
+            return
+
+
+def required(name: str) -> str:
+    value = os.environ.get(name)
+    if not value:
+        raise SystemExit(f"Missing required environment variable: {name}")
+    return value
+
+
+def optional(name: str, default: str = "") -> str:
+    return os.environ.get(name) or default
+
+
+def int_env(name: str, default: int) -> int:
+    raw = os.environ.get(name)
+    if not raw:
+        return default
+    try:
+        return int(raw)
+    except ValueError as exc:
+        raise SystemExit(f"{name} must be an integer, got {raw!r}") from exc
+
+
+def claude_code_model() -> str:
+    """Resolve the model Claude Code should use.
+
+    Precedence: explicit ``CLAUDE_CODE_MODEL`` > default ``claude-sonnet-4-6``.
+    """
+    explicit = os.environ.get("CLAUDE_CODE_MODEL")
+    if explicit:
+        return explicit
+    return "claude-sonnet-4-6"
+
+
+def claude_code_workspace() -> str:
+    return optional("CLAUDE_CODE_WORKSPACE", DEFAULT_WORKSPACE)
+
+
+def require_anthropic_key() -> str:
+    """Return the Anthropic API key, failing if absent."""
+    value = os.environ.get("ANTHROPIC_API_KEY")
+    if not value:
+        raise SystemExit("Missing required environment variable: ANTHROPIC_API_KEY")
+    return value
+
+
+def build_claude_code_env(include_secrets: bool = True) -> dict[str, str]:
+    """Build the env map passed to the Claude Code command inside the sandbox.
+
+    Set ``include_secrets=False`` for the CubeEgress vault flavor: the real
+    Anthropic key rides the wire via egress injection, so it must never enter
+    the sandbox environment.
+    """
+    env: dict[str, str] = {}
+    for name in PASSTHROUGH_ENV_NAMES:
+        value = os.environ.get(name)
+        if value:
+            env[name] = value
+    if include_secrets:
+        # Forward the Anthropic key so Claude Code can authenticate with the
+        # LLM backend. Under the vault flavor the key is a placeholder — the
+        # real one is injected on the wire by CubeEgress.
+        anthropic_key = os.environ.get("ANTHROPIC_API_KEY")
+        if anthropic_key:
+            env["ANTHROPIC_API_KEY"] = anthropic_key
+    return env
+
+
+def claude_code_llm_host() -> str:
+    """Resolve the LLM API host that Claude Code must reach.
+
+    Precedence: explicit ``CLAUDE_CODE_LLM_HOST`` > host parsed from
+    ``ANTHROPIC_BASE_URL`` > default ``api.anthropic.com``.
+    """
+    explicit = os.environ.get("CLAUDE_CODE_LLM_HOST")
+    if explicit:
+        return _host_from_url(explicit)
+    base_url = os.environ.get("ANTHROPIC_BASE_URL")
+    if base_url:
+        host = _host_from_url(base_url)
+        if host:
+            return host
+    return "api.anthropic.com"
+
+
+def anthropic_inject(secret: str) -> list[dict[str, str]]:
+    """CubeEgress credential-injection specs for Anthropic's auth headers.
+
+    Each dict maps directly to a ``cubesandbox.Inject(header=..., secret=...,
+    format=...)``. CubeEgress attaches these headers to matched outbound
+    requests, so the real key rides the wire and never enters the sandbox VM.
+    Anthropic uses ``x-api-key`` plus the required API-version header.
+    """
+    return [
+        {"header": "x-api-key", "secret": secret, "format": "${SECRET}"},
+        {"header": "anthropic-version", "secret": "2023-06-01", "format": "${SECRET}"},
+    ]
+
+
+def claude_command(
+    prompt: str,
+    *,
+    output_format: str = "stream-json",
+    model: str | None = None,
+    accept_edits: bool = True,
+) -> str:
+    """Build a headless (non-interactive) Claude Code invocation.
+
+    ``-p`` (``--print``) makes Claude Code process the prompt and exit instead
+    of launching the interactive TUI (which would hang over the E2B exec
+    channel). ``--output-format stream-json`` streams machine-readable JSONL
+    events. ``accept_edits`` toggles ``--accept-edits``, which auto-approves
+    file edits in an isolated sandbox — pass ``accept_edits=False`` in
+    high-security workflows. The prompt is passed as the positional argument
+    to ``-p``.
+    """
+    args = ["claude", "-p"]
+    if output_format:
+        args.extend(["--output-format", output_format])
+    resolved_model = model or claude_code_model()
+    if resolved_model:
+        args.extend(["--model", resolved_model])
+    if accept_edits:
+        args.append("--accept-edits")
+    args.append(prompt)
+    return " ".join(shlex.quote(arg) for arg in args)
+
+
+def shell_join(*parts: str) -> str:
+    return " && ".join(part for part in parts if part)
+
+
+def _host_from_url(value: str) -> str:
+    candidate = value.strip()
+    if not candidate:
+        return ""
+    if "://" not in candidate:
+        candidate = f"https://{candidate}"
+    return urlparse(candidate).hostname or ""

--- a/examples/claude-code-integration/network_policy.py
+++ b/examples/claude-code-integration/network_policy.py
@@ -48,8 +48,8 @@ PLACEHOLDER_KEY = "cube-egress-managed-placeholder"
 # the system trust store. On the vault path CubeEgress terminates TLS to inject
 # the credential, so Node must trust the CubeEgress root CA or every LLM call
 # fails with "Connection error". Point NODE_EXTRA_CA_CERTS at a bundle that
-# includes it; the CubeSandbox base image installs the CA into the system bundle.
-DEFAULT_NODE_CA_BUNDLE = "/etc/ssl/certs/ca-certificates.crt"
+# includes it; CubeMaster bakes a dedicated CubeEgress anchor into the image.
+DEFAULT_NODE_CA_BUNDLE = "/usr/local/share/ca-certificates/cube-egress-root.crt"
 
 DEFAULT_PROMPT = (
     "Reply with a single short sentence confirming you can reach the LLM API, "
@@ -171,15 +171,13 @@ def run_agent(sandbox: Sandbox, args: argparse.Namespace, envs: dict[str, str]):
         envs=envs,
         timeout=args.exec_timeout,
         stream=True,
+        raw=args.raw,
     )
 
 
 def main() -> int:
     load_local_dotenv()
     args = parse_args()
-    if args.raw:
-        os.environ["CLAUDE_CODE_STREAM_RAW"] = "1"
-
     template_id = args.template or required("CUBE_TEMPLATE_ID")
     required("E2B_API_URL")
     required("E2B_API_KEY")

--- a/examples/claude-code-integration/network_policy.py
+++ b/examples/claude-code-integration/network_policy.py
@@ -1,0 +1,237 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Restrict Claude Code's egress to the LLM API and inject the key on the wire.
+
+This is the recommended production ("credential vault") pattern:
+
+* Default-deny egress — the sandbox is created with ``allow_internet_access=False``
+  and an ``allow_out`` list containing only the LLM API host, so every other
+  destination is dropped before it can leave the sandbox.
+* The Anthropic auth headers are attached by CubeEgress via ``inject`` rules
+  (native ``cubesandbox`` SDK; see docs/guide/security-proxy.md), so the real
+  key rides the wire and never enters the sandbox VM. The agent inside only
+  sees a placeholder value.
+
+Run:
+    python network_policy.py
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import shlex
+import sys
+
+from cubesandbox import Sandbox, Rule, Match, Action, Inject
+
+from env_utils import (
+    anthropic_inject,
+    build_claude_code_env,
+    claude_command,
+    claude_code_llm_host,
+    claude_code_model,
+    claude_code_workspace,
+    int_env,
+    load_local_dotenv,
+    require_anthropic_key,
+    required,
+    shell_join,
+)
+from _common import ensure_success, run_command, sandbox_identifier
+
+PLACEHOLDER_KEY = "cube-egress-managed-placeholder"
+
+# Claude Code runs on Node.js, which uses its own bundled CA store and ignores
+# the system trust store. On the vault path CubeEgress terminates TLS to inject
+# the credential, so Node must trust the CubeEgress root CA or every LLM call
+# fails with "Connection error". Point NODE_EXTRA_CA_CERTS at a bundle that
+# includes it; the CubeSandbox base image installs the CA into the system bundle.
+DEFAULT_NODE_CA_BUNDLE = "/etc/ssl/certs/ca-certificates.crt"
+
+DEFAULT_PROMPT = (
+    "Reply with a single short sentence confirming you can reach the LLM API, "
+    "then write that sentence to {workspace}/egress_check.md."
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Run Claude Code under a default-deny egress policy with on-the-wire key injection."
+    )
+    parser.add_argument(
+        "--template",
+        default=os.environ.get("CUBE_TEMPLATE_ID"),
+        help="CubeSandbox template ID. Defaults to CUBE_TEMPLATE_ID.",
+    )
+    parser.add_argument(
+        "--host",
+        default=None,
+        help="LLM API host to allow. Defaults to CLAUDE_CODE_LLM_HOST or api.anthropic.com.",
+    )
+    parser.add_argument(
+        "--workspace",
+        default=claude_code_workspace(),
+        help="Working directory inside the sandbox. Defaults to CLAUDE_CODE_WORKSPACE.",
+    )
+    parser.add_argument(
+        "--prompt",
+        default=None,
+        help="Prompt passed to Claude Code. Defaults to a small egress reachability check.",
+    )
+    parser.add_argument(
+        "--sandbox-timeout",
+        type=int,
+        default=int_env("CLAUDE_CODE_SANDBOX_TIMEOUT", 1800),
+        help="Sandbox lifetime in seconds. Defaults to CLAUDE_CODE_SANDBOX_TIMEOUT or 1800.",
+    )
+    parser.add_argument(
+        "--exec-timeout",
+        type=int,
+        default=int_env("CLAUDE_CODE_EXEC_TIMEOUT", 900),
+        help="Claude Code command timeout in seconds. Defaults to CLAUDE_CODE_EXEC_TIMEOUT or 900.",
+    )
+    parser.add_argument(
+        "--skip-agent",
+        action="store_true",
+        help="Only show the egress checks; skip the actual Claude Code run.",
+    )
+    parser.add_argument(
+        "--raw",
+        action="store_true",
+        help="Stream Claude Code's raw stream-json instead of the concise transcript.",
+    )
+    args = parser.parse_args()
+    if args.prompt is None:
+        args.prompt = DEFAULT_PROMPT.format(workspace=args.workspace)
+    return args
+
+
+def build_rules(host: str, secret: str) -> list[Rule]:
+    # Canonical CubeEgress rule (see docs/guide/security-proxy.md): allow the LLM
+    # host and attach the Anthropic auth headers on the wire via ``inject`` so
+    # the real key never enters the sandbox VM. Anything matching no rule under
+    # default-deny is rejected by CubeEgress with 403.
+    inject_specs = anthropic_inject(secret)
+    return [
+        Rule(
+            name="allow_anthropic_llm",
+            match=Match(scheme="https", sni=host, host=host),
+            action=Action(
+                allow=True,
+                audit="metadata",
+                inject=[Inject(**spec) for spec in inject_specs],
+            ),
+        )
+    ]
+
+
+def create_sandbox(template_id: str, rules: list[Rule], timeout: int) -> Sandbox:
+    # allow_internet_access=False makes egress default-deny at L3/L4; the LLM host
+    # named in the rules is auto-allowed and its requests are injected at L7 by
+    # CubeEgress. Never silently drop this flag, or full egress is re-enabled.
+    return Sandbox.create(
+        template=template_id,
+        allow_internet_access=False,
+        network={"rules": rules},
+        timeout=timeout,
+    )
+
+
+def show_key_not_in_vm(sandbox: Sandbox, key_name: str) -> None:
+    command = f"printenv {shlex.quote(key_name)} || echo '<unset>'"
+    result = run_command(sandbox, command, timeout=30)
+    ensure_success(result, "read Anthropic key inside sandbox")
+    value = getattr(result, "stdout", "").strip()
+    print(f"In-VM {key_name}: {value!r} (real secret stays in CubeEgress)")
+
+
+def show_non_llm_blocked(sandbox: Sandbox) -> None:
+    command = (
+        "curl -s -o /dev/null -w '%{http_code}' --max-time 8 https://example.com "
+        "|| echo blocked"
+    )
+    result = run_command(sandbox, command, timeout=30)
+    status = getattr(result, "stdout", "").strip()
+    print(f"Non-LLM host (example.com) response: {status or 'blocked'} "
+          "(expected 403/blocked under default-deny)")
+
+
+def run_agent(sandbox: Sandbox, args: argparse.Namespace, envs: dict[str, str]):
+    command = shell_join(
+        f"cd {shlex.quote(args.workspace)}",
+        claude_command(args.prompt, output_format="stream-json", model=claude_code_model()),
+    )
+    return run_command(
+        sandbox,
+        command,
+        cwd=args.workspace,
+        envs=envs,
+        timeout=args.exec_timeout,
+        stream=True,
+    )
+
+
+def main() -> int:
+    load_local_dotenv()
+    args = parse_args()
+    if args.raw:
+        os.environ["CLAUDE_CODE_STREAM_RAW"] = "1"
+
+    template_id = args.template or required("CUBE_TEMPLATE_ID")
+    required("E2B_API_URL")
+    required("E2B_API_KEY")
+
+    secret = require_anthropic_key()
+    host = args.host or claude_code_llm_host()
+    if not host:
+        raise SystemExit(
+            "Could not resolve the LLM host. Set CLAUDE_CODE_LLM_HOST in your .env or pass --host."
+        )
+
+    rules = build_rules(host, secret)
+
+    sandbox_env = build_claude_code_env(include_secrets=False)
+    sandbox_env["ANTHROPIC_API_KEY"] = PLACEHOLDER_KEY
+    # Let the Node-based Claude Code CLI trust the CubeEgress interception CA
+    # (see note on DEFAULT_NODE_CA_BUNDLE); without this the vault path fails TLS.
+    sandbox_env["NODE_EXTRA_CA_CERTS"] = os.environ.get(
+        "CLAUDE_CODE_NODE_EXTRA_CA_CERTS", DEFAULT_NODE_CA_BUNDLE
+    )
+
+    print(f"Allowed LLM host (default-deny for everything else): {host}")
+    print(f"Creating sandbox from template: {template_id}")
+
+    sandbox = create_sandbox(template_id, rules, args.sandbox_timeout)
+    sandbox_id = sandbox_identifier(sandbox)
+    result = None
+    try:
+        print(f"Sandbox ready: {sandbox_id}\n")
+
+        show_key_not_in_vm(sandbox, "ANTHROPIC_API_KEY")
+        show_non_llm_blocked(sandbox)
+
+        if args.skip_agent:
+            print("\n--skip-agent set: not invoking Claude Code.")
+            return 0
+
+        print("\nRunning Claude Code through the injected egress path...\n")
+        result = run_agent(sandbox, args, sandbox_env)
+        exit_code = getattr(result, "exit_code", None)
+        print(f"\nClaude Code exit code: {exit_code}")
+        return 0 if exit_code is None else int(exit_code)
+    finally:
+        try:
+            sandbox.kill()
+            print(f"\nSandbox {sandbox_id} killed.")
+        except Exception as exc:  # noqa: BLE001 - cleanup must not mask real errors
+            print(
+                f"Warning: failed to kill sandbox {sandbox_id}: {exc}",
+                file=sys.stderr,
+            )
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/examples/claude-code-integration/requirements.txt
+++ b/examples/claude-code-integration/requirements.txt
@@ -1,0 +1,3 @@
+e2b>=2.4.1
+cubesandbox>=0.3.0
+python-dotenv>=1.0.0

--- a/examples/claude-code-integration/requirements.txt
+++ b/examples/claude-code-integration/requirements.txt
@@ -1,3 +1,3 @@
-e2b>=2.4.1
-cubesandbox>=0.3.0
-python-dotenv>=1.0.0
+e2b==2.4.1
+cubesandbox==0.3.0
+python-dotenv==1.0.0

--- a/examples/claude-code-integration/resume_claude_code.py
+++ b/examples/claude-code-integration/resume_claude_code.py
@@ -149,10 +149,11 @@ def main() -> int:
     # the key per command. The pause() snapshot also captures the in-VM env and
     # any credentials that might persist, widening exposure — for shared
     # clusters prefer the default-deny + vault pattern in network_policy.py.
-    sandbox = Sandbox.create(template=template_id, timeout=args.sandbox_timeout)
-    sandbox_id = sandbox_identifier(sandbox)
-
+    sandbox = None
+    sandbox_id = "uncreated"
     try:
+        sandbox = Sandbox.create(template=template_id, timeout=args.sandbox_timeout)
+        sandbox_id = sandbox_identifier(sandbox)
         print(f"Sandbox ready: {sandbox_id}")
 
         version_result = run_command(sandbox, "claude --version", timeout=60)
@@ -175,7 +176,7 @@ def main() -> int:
         print(f"Paused. Resume handle: {sandbox_id}")
 
         print(f"\nReconnecting to {sandbox_id}...")
-        sandbox = Sandbox.connect(sandbox_id=sandbox_id)
+        sandbox = Sandbox.connect(sandbox_id=sandbox_id, timeout=args.sandbox_timeout)
         print("Reconnected after resume.")
 
         print("\n=== Verifying persistence after resume ===\n")

--- a/examples/claude-code-integration/resume_claude_code.py
+++ b/examples/claude-code-integration/resume_claude_code.py
@@ -1,0 +1,208 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Demonstrate Claude Code session persistence across a CubeSandbox pause/resume.
+
+Turn 1 asks Claude Code to write ``/workspace/plan.md``, then the sandbox is
+paused. Turn 2 reconnects to the same sandbox, verifies ``/workspace`` survived
+the snapshot, and asks Claude Code to continue the work.
+
+Lifecycle note: this script deliberately avoids ``with Sandbox.create(...)``.
+A context manager kills the sandbox on ``__exit__``, which would defeat the
+pause. The lifecycle is managed manually with try/finally so the sandbox stays
+alive between turns and is only killed at the very end.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import shlex
+import sys
+
+from e2b import Sandbox
+
+from env_utils import (
+    build_claude_code_env,
+    claude_command,
+    claude_code_model,
+    claude_code_workspace,
+    int_env,
+    load_local_dotenv,
+    require_anthropic_key,
+    required,
+    shell_join,
+)
+from _common import ensure_success, run_command, sandbox_identifier
+
+DEFAULT_WORKSPACE = "/workspace"
+
+TURN_1_PROMPT = (
+    "Create {workspace}/plan.md containing a numbered 3-step plan for building a "
+    "small Python CLI that prints the current time. Only write the plan file."
+)
+TURN_2_PROMPT = (
+    "Read {workspace}/plan.md and implement step 1 by creating "
+    "{workspace}/progress.md that records which step you completed and why. "
+    "Do not delete plan.md."
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Demonstrate Claude Code session persistence across a CubeSandbox pause/resume."
+    )
+    parser.add_argument(
+        "--template",
+        default=os.environ.get("CUBE_TEMPLATE_ID"),
+        help="CubeSandbox template ID. Defaults to CUBE_TEMPLATE_ID.",
+    )
+    parser.add_argument(
+        "--workspace",
+        default=claude_code_workspace(),
+        help="Working directory inside the sandbox. Defaults to CLAUDE_CODE_WORKSPACE.",
+    )
+    parser.add_argument(
+        "--sandbox-timeout",
+        type=int,
+        default=int_env("CLAUDE_CODE_SANDBOX_TIMEOUT", 1800),
+        help="Sandbox lifetime in seconds. Defaults to CLAUDE_CODE_SANDBOX_TIMEOUT or 1800.",
+    )
+    parser.add_argument(
+        "--exec-timeout",
+        type=int,
+        default=int_env("CLAUDE_CODE_EXEC_TIMEOUT", 900),
+        help="Claude Code command timeout in seconds. Defaults to CLAUDE_CODE_EXEC_TIMEOUT or 900.",
+    )
+    parser.add_argument(
+        "--raw",
+        action="store_true",
+        help="Stream Claude Code's raw stream-json instead of the concise transcript.",
+    )
+    return parser.parse_args()
+
+
+def run_turn(
+    sandbox: Sandbox,
+    workspace: str,
+    prompt: str,
+    exec_timeout: int,
+    envs: dict[str, str],
+):
+    command = shell_join(
+        f"cd {shlex.quote(workspace)}",
+        claude_command(prompt, output_format="stream-json", model=claude_code_model()),
+    )
+    return run_command(
+        sandbox,
+        command,
+        cwd=workspace,
+        envs=envs,
+        timeout=exec_timeout,
+        stream=True,
+    )
+
+
+def assert_state_survived(sandbox: Sandbox, workspace: str) -> None:
+    quoted_workspace = shlex.quote(workspace)
+    command = shell_join(
+        f"test -f {quoted_workspace}/plan.md",
+        "printf '\\n--- plan.md (survived pause/resume) ---\\n'",
+        f"cat {quoted_workspace}/plan.md",
+    )
+    result = run_command(sandbox, command, timeout=60)
+    ensure_success(result, "verify /workspace survived pause/resume")
+    if getattr(result, "stdout", ""):
+        print(result.stdout)
+
+
+def show_final_workspace(sandbox: Sandbox, workspace: str) -> None:
+    quoted_workspace = shlex.quote(workspace)
+    command = shell_join(
+        f"ls -la {quoted_workspace}",
+        f"test ! -f {quoted_workspace}/progress.md || "
+        f"(printf '\\n--- progress.md ---\\n' && cat {quoted_workspace}/progress.md)",
+    )
+    result = run_command(sandbox, command, timeout=60)
+    ensure_success(result, "inspect final workspace")
+    if getattr(result, "stdout", ""):
+        print(result.stdout)
+
+
+def main() -> int:
+    load_local_dotenv()
+    args = parse_args()
+    if args.raw:
+        os.environ["CLAUDE_CODE_STREAM_RAW"] = "1"
+
+    template_id = args.template or required("CUBE_TEMPLATE_ID")
+    required("E2B_API_URL")
+    required("E2B_API_KEY")
+    require_anthropic_key()
+
+    claude_env = build_claude_code_env()
+    turn_1_prompt = TURN_1_PROMPT.format(workspace=args.workspace)
+    turn_2_prompt = TURN_2_PROMPT.format(workspace=args.workspace)
+
+    print(f"Creating sandbox from template: {template_id}")
+    # SECURITY: like run_claude_code.py this demo keeps egress open and injects
+    # the key per command. The pause() snapshot also captures the in-VM env and
+    # any credentials that might persist, widening exposure — for shared
+    # clusters prefer the default-deny + vault pattern in network_policy.py.
+    sandbox = Sandbox.create(template=template_id, timeout=args.sandbox_timeout)
+    sandbox_id = sandbox_identifier(sandbox)
+
+    try:
+        print(f"Sandbox ready: {sandbox_id}")
+
+        version_result = run_command(sandbox, "claude --version", timeout=60)
+        ensure_success(version_result, "check Claude Code version")
+        print(f"Claude Code version: {getattr(version_result, 'stdout', '').strip()}")
+
+        print("\n=== Turn 1: create plan.md ===\n")
+        result_1 = run_turn(
+            sandbox, args.workspace, turn_1_prompt, args.exec_timeout, claude_env
+        )
+        ensure_success(result_1, "run Claude Code turn 1")
+
+        print(f"\nPausing sandbox {sandbox_id} (snapshotting VM + rootfs)...")
+        paused_id = sandbox.pause()
+        # The sandbox_id is stable across pause. Some SDK versions return the
+        # resume handle as a string; others return a bool (success). Only adopt
+        # a string handle, otherwise keep the original id for connect().
+        if isinstance(paused_id, str) and paused_id:
+            sandbox_id = paused_id
+        print(f"Paused. Resume handle: {sandbox_id}")
+
+        print(f"\nReconnecting to {sandbox_id}...")
+        sandbox = Sandbox.connect(sandbox_id=sandbox_id)
+        print("Reconnected after resume.")
+
+        print("\n=== Verifying persistence after resume ===\n")
+        assert_state_survived(sandbox, args.workspace)
+
+        print("\n=== Turn 2: continue the work ===\n")
+        result_2 = run_turn(
+            sandbox, args.workspace, turn_2_prompt, args.exec_timeout, claude_env
+        )
+        ensure_success(result_2, "run Claude Code turn 2")
+
+        show_final_workspace(sandbox, args.workspace)
+
+        exit_code = getattr(result_2, "exit_code", 0)
+        return 0 if exit_code is None else int(exit_code)
+    finally:
+        if sandbox is not None:
+            try:
+                sandbox.kill()
+                print(f"\nSandbox {sandbox_id} killed.")
+            except Exception as exc:  # noqa: BLE001 - cleanup must not mask real errors
+                print(
+                    f"Warning: failed to kill sandbox {sandbox_id}: {exc}",
+                    file=sys.stderr,
+                )
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/examples/claude-code-integration/resume_claude_code.py
+++ b/examples/claude-code-integration/resume_claude_code.py
@@ -168,10 +168,12 @@ def main() -> int:
 
         print(f"\nPausing sandbox {sandbox_id} (snapshotting VM + rootfs)...")
         paused_id = sandbox.pause()
+        if not paused_id:
+            raise SystemExit("Failed to pause sandbox: no snapshot ID returned")
         # The sandbox_id is stable across pause. Some SDK versions return the
         # resume handle as a string; others return a bool (success). Only adopt
         # a string handle, otherwise keep the original id for connect().
-        if isinstance(paused_id, str) and paused_id:
+        if isinstance(paused_id, str):
             sandbox_id = paused_id
         print(f"Paused. Resume handle: {sandbox_id}")
 

--- a/examples/claude-code-integration/resume_claude_code.py
+++ b/examples/claude-code-integration/resume_claude_code.py
@@ -89,6 +89,7 @@ def run_turn(
     prompt: str,
     exec_timeout: int,
     envs: dict[str, str],
+    raw: bool = False,
 ):
     command = shell_join(
         f"cd {shlex.quote(workspace)}",
@@ -101,6 +102,7 @@ def run_turn(
         envs=envs,
         timeout=exec_timeout,
         stream=True,
+        raw=raw,
     )
 
 
@@ -133,9 +135,6 @@ def show_final_workspace(sandbox: Sandbox, workspace: str) -> None:
 def main() -> int:
     load_local_dotenv()
     args = parse_args()
-    if args.raw:
-        os.environ["CLAUDE_CODE_STREAM_RAW"] = "1"
-
     template_id = args.template or required("CUBE_TEMPLATE_ID")
     required("E2B_API_URL")
     required("E2B_API_KEY")
@@ -162,7 +161,7 @@ def main() -> int:
 
         print("\n=== Turn 1: create plan.md ===\n")
         result_1 = run_turn(
-            sandbox, args.workspace, turn_1_prompt, args.exec_timeout, claude_env
+            sandbox, args.workspace, turn_1_prompt, args.exec_timeout, claude_env, args.raw
         )
         ensure_success(result_1, "run Claude Code turn 1")
 
@@ -184,7 +183,7 @@ def main() -> int:
 
         print("\n=== Turn 2: continue the work ===\n")
         result_2 = run_turn(
-            sandbox, args.workspace, turn_2_prompt, args.exec_timeout, claude_env
+            sandbox, args.workspace, turn_2_prompt, args.exec_timeout, claude_env, args.raw
         )
         ensure_success(result_2, "run Claude Code turn 2")
 

--- a/examples/claude-code-integration/run_claude_code.py
+++ b/examples/claude-code-integration/run_claude_code.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import argparse
+import os
+import shlex
+import sys
+
+from e2b import Sandbox
+
+from _common import ensure_success, run_command, sandbox_identifier
+from env_utils import (
+    build_claude_code_env,
+    claude_command,
+    claude_code_model,
+    claude_code_workspace,
+    int_env,
+    load_local_dotenv,
+    require_anthropic_key,
+    required,
+    shell_join,
+)
+
+DEFAULT_PROMPT_TEMPLATE = (
+    "Inspect the project in {workspace}, run python3 app.py, and write a "
+    "concise summary of the result to {workspace}/result.md."
+)
+
+
+def default_prompt(workspace: str) -> str:
+    return DEFAULT_PROMPT_TEMPLATE.format(workspace=workspace)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Run a one-shot Claude Code task inside CubeSandbox."
+    )
+    parser.add_argument(
+        "--template",
+        default=os.environ.get("CUBE_TEMPLATE_ID"),
+        help="CubeSandbox template ID. Defaults to CUBE_TEMPLATE_ID.",
+    )
+    parser.add_argument(
+        "--prompt",
+        default=None,
+        help="Prompt passed to Claude Code. Defaults to a small workspace smoke task.",
+    )
+    parser.add_argument(
+        "--workspace",
+        default=claude_code_workspace(),
+        help="Working directory inside the sandbox. Defaults to CLAUDE_CODE_WORKSPACE.",
+    )
+    parser.add_argument(
+        "--sandbox-timeout",
+        type=int,
+        default=int_env("CLAUDE_CODE_SANDBOX_TIMEOUT", 1800),
+        help="Sandbox lifetime in seconds. Defaults to CLAUDE_CODE_SANDBOX_TIMEOUT or 1800.",
+    )
+    parser.add_argument(
+        "--exec-timeout",
+        type=int,
+        default=int_env("CLAUDE_CODE_EXEC_TIMEOUT", 900),
+        help="Claude Code command timeout in seconds. Defaults to CLAUDE_CODE_EXEC_TIMEOUT or 900.",
+    )
+    parser.add_argument(
+        "--no-seed",
+        action="store_true",
+        help="Skip writing the demo files into the sandbox workspace.",
+    )
+    parser.add_argument(
+        "--raw",
+        action="store_true",
+        help="Stream Claude Code's raw stream-json instead of the concise transcript.",
+    )
+    args = parser.parse_args()
+    if args.prompt is None:
+        args.prompt = default_prompt(args.workspace)
+    return args
+
+
+def seed_project(sandbox: Sandbox, workspace: str, timeout: int) -> None:
+    quoted_workspace = shlex.quote(workspace)
+    command = f"""mkdir -p {quoted_workspace}
+cat > {quoted_workspace}/README.md <<'EOF'
+# CubeSandbox Claude Code Smoke Project
+
+This tiny project exists so the Claude Code agent has a deterministic task to run.
+EOF
+cat > {quoted_workspace}/app.py <<'EOF'
+def main() -> None:
+    print("hello from CubeSandbox + Claude Code")
+
+
+if __name__ == "__main__":
+    main()
+EOF
+"""
+    result = run_command(sandbox, command, timeout=timeout)
+    ensure_success(result, "seed workspace")
+
+
+def print_result_summary(result) -> None:
+    exit_code = getattr(result, "exit_code", None)
+    stderr = getattr(result, "stderr", "")
+
+    print(f"\nClaude Code exit code: {exit_code}")
+    if stderr:
+        print("\nCaptured stderr:", file=sys.stderr)
+        print(stderr, file=sys.stderr)
+
+
+def show_workspace_result(sandbox: Sandbox, workspace: str, timeout: int) -> None:
+    quoted_workspace = shlex.quote(workspace)
+    command = shell_join(
+        f"ls -la {quoted_workspace}",
+        f"test ! -f {quoted_workspace}/result.md || "
+        f"(printf '\\n--- result.md ---\\n' && cat {quoted_workspace}/result.md)",
+    )
+    result = run_command(sandbox, command, timeout=timeout)
+    ensure_success(result, "inspect workspace")
+    if getattr(result, "stdout", ""):
+        print(result.stdout)
+
+
+def main() -> int:
+    load_local_dotenv()
+    args = parse_args()
+    if args.raw:
+        os.environ["CLAUDE_CODE_STREAM_RAW"] = "1"
+
+    template_id = args.template or required("CUBE_TEMPLATE_ID")
+    required("E2B_API_URL")
+    required("E2B_API_KEY")
+    require_anthropic_key()
+
+    claude_env = build_claude_code_env()
+    command = shell_join(
+        f"cd {shlex.quote(args.workspace)}",
+        claude_command(args.prompt, output_format="stream-json", model=claude_code_model()),
+    )
+
+    print(f"Creating sandbox from template: {template_id}")
+    result = None
+    # SECURITY: this direct-key demo keeps egress open (allow_internet_access
+    # defaults to True) for simplicity, and injects the Anthropic key per command
+    # via envs=. A compromised agent with open egress could exfiltrate that key.
+    # For shared/production use prefer network_policy.py, which pairs default-deny
+    # egress with the CubeEgress credential vault (the key never enters the VM).
+    with Sandbox.create(template=template_id, timeout=args.sandbox_timeout) as sandbox:
+        sandbox_id = sandbox_identifier(sandbox)
+        print(f"Sandbox ready: {sandbox_id}")
+
+        version_result = run_command(sandbox, "claude --version", timeout=60)
+        ensure_success(version_result, "check Claude Code version")
+        print(f"Claude Code version: {getattr(version_result, 'stdout', '').strip()}")
+
+        if not args.no_seed:
+            seed_project(sandbox, args.workspace, timeout=60)
+            print(f"Seeded demo project in {args.workspace}")
+
+        print("\nRunning Claude Code task...\n")
+        result = run_command(
+            sandbox,
+            command,
+            cwd=args.workspace,
+            envs=claude_env,
+            timeout=args.exec_timeout,
+            stream=True,
+        )
+
+        print_result_summary(result)
+        show_workspace_result(sandbox, args.workspace, timeout=60)
+
+    exit_code = getattr(result, "exit_code", 1)
+    return 0 if exit_code is None else int(exit_code)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/examples/claude-code-integration/run_claude_code.py
+++ b/examples/claude-code-integration/run_claude_code.py
@@ -128,9 +128,6 @@ def show_workspace_result(sandbox: Sandbox, workspace: str, timeout: int) -> Non
 def main() -> int:
     load_local_dotenv()
     args = parse_args()
-    if args.raw:
-        os.environ["CLAUDE_CODE_STREAM_RAW"] = "1"
-
     template_id = args.template or required("CUBE_TEMPLATE_ID")
     required("E2B_API_URL")
     required("E2B_API_KEY")
@@ -169,6 +166,7 @@ def main() -> int:
             envs=claude_env,
             timeout=args.exec_timeout,
             stream=True,
+            raw=args.raw,
         )
 
         print_result_summary(result)

--- a/examples/claude-code-integration/test_helpers.py
+++ b/examples/claude-code-integration/test_helpers.py
@@ -13,6 +13,21 @@ class HelperTests(unittest.TestCase):
     def test_string_zero_exit_code_is_success(self):
         _common.ensure_success(type("Result", (), {"exit_code": "0"})(), "test")
 
+    def test_missing_exit_code_is_failure(self):
+        with self.assertRaisesRegex(SystemExit, "no exit code"):
+            _common.ensure_success(type("Result", (), {"exit_code": None})(), "test")
+
+    def test_vault_env_drops_proxy_settings(self):
+        with patch.dict(os.environ, {"HTTPS_PROXY": "http://proxy.example"}, clear=True):
+            self.assertNotIn("HTTPS_PROXY", env_utils.build_claude_code_env(False))
+
+    def test_renderer_flushes_partial_line(self):
+        writer = _common.stream_json_render_writer()
+        with patch.object(_common, "_render_stream_json_line") as render:
+            writer("partial")
+            writer.flush()
+            render.assert_called_once_with("partial")
+
     def test_anthropic_base_url_selects_llm_host(self):
         with patch.dict(os.environ, {"ANTHROPIC_BASE_URL": "https://llm.example/v1"}, clear=True):
             self.assertEqual(env_utils.claude_code_llm_host(), "llm.example")

--- a/examples/claude-code-integration/test_helpers.py
+++ b/examples/claude-code-integration/test_helpers.py
@@ -1,0 +1,22 @@
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+import unittest
+from unittest.mock import patch
+
+import _common
+import env_utils
+
+
+class HelperTests(unittest.TestCase):
+    def test_string_zero_exit_code_is_success(self):
+        _common.ensure_success(type("Result", (), {"exit_code": "0"})(), "test")
+
+    def test_anthropic_base_url_selects_llm_host(self):
+        with patch.dict(os.environ, {"ANTHROPIC_BASE_URL": "https://llm.example/v1"}, clear=True):
+            self.assertEqual(env_utils.claude_code_llm_host(), "llm.example")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/examples/codebuddy-integration/.env.example
+++ b/examples/codebuddy-integration/.env.example
@@ -1,0 +1,36 @@
+# --- CubeSandbox connection ---
+
+# Required: CubeAPI address (use CubeAPI, not CubeProxy).
+E2B_API_URL="http://<cube-host>:3000"
+
+# Required: any non-empty value in local dev; a real key when auth is enabled.
+E2B_API_KEY="e2b_000000"
+
+# Required: template built from this example's Dockerfile.
+CUBE_TEMPLATE_ID="<template-id>"
+
+# Optional: only when talking to CubeProxy over HTTPS with Cube's mkcert cert.
+# SSL_CERT_FILE="/root/.local/share/mkcert/rootCA.pem"
+
+# --- CodeBuddy agent ---
+
+# Required: provider and model CodeBuddy runs against.
+CODEBUDDY_PROVIDER="anthropic"
+CODEBUDDY_MODEL="claude-sonnet-4-6"
+
+# Required: the provider API key (only the one matching CODEBUDDY_PROVIDER).
+ANTHROPIC_API_KEY="<your-anthropic-api-key>"
+# Other providers (uncomment the one you use):
+# OPENAI_API_KEY="<your-openai-api-key>"
+# GEMINI_API_KEY="<your-gemini-api-key>"
+# DEEPSEEK_API_KEY="<your-deepseek-api-key>"
+
+# Optional: Anthropic-compatible endpoint (e.g. DeepSeek or AWS Bedrock).
+# ANTHROPIC_BASE_URL="https://api.deepseek.com/anthropic"
+
+# Optional (network_policy.py): LLM host to allow under default-deny egress.
+# Defaults to the provider host; override only for a custom endpoint.
+# CODEBUDDY_LLM_HOST="api.anthropic.com"
+
+# Advanced tunables (CODEBUDDY_MAX_TURNS, CODEBUDDY_EXEC_TIMEOUT, ...)
+# have sane defaults; see env_utils.py to override.

--- a/examples/codebuddy-integration/.env.example
+++ b/examples/codebuddy-integration/.env.example
@@ -1,7 +1,8 @@
 # --- CubeSandbox connection ---
 
-# Required: CubeAPI address (use CubeAPI, not CubeProxy).
-E2B_API_URL="http://<cube-host>:3000"
+# Required: TLS-protected CubeAPI address (use CubeAPI, not CubeProxy).
+# Plain HTTP is suitable only for isolated local development on loopback.
+E2B_API_URL="https://<cube-host>:3000"
 
 # Required: any non-empty value in local dev; a real key when auth is enabled.
 E2B_API_KEY="e2b_000000"

--- a/examples/codebuddy-integration/.gitignore
+++ b/examples/codebuddy-integration/.gitignore
@@ -1,0 +1,8 @@
+.env
+.env.*
+!.env.example
+__pycache__/
+*.pyc
+*.log
+output/
+workspace-seed/

--- a/examples/codebuddy-integration/Dockerfile
+++ b/examples/codebuddy-integration/Dockerfile
@@ -1,0 +1,66 @@
+# syntax=docker/dockerfile:1.7
+#
+# CodeBuddy coding agent inside a CubeSandbox template.
+#
+# The image installs Node.js 24 and the CodeBuddy CLI npm package on top of the
+# official CubeSandbox base image. The inherited cube-entrypoint keeps envd
+# running on :49983 so Cube can use the standard readiness probe.
+#
+# Build:
+#   docker build -t codebuddy-cube:latest examples/codebuddy-integration
+#
+# Register as a Cube template:
+#   cubemastercli tpl create-from-image \
+#     --image <your-registry>/codebuddy-cube:latest \
+#     --writable-layer-size 4G \
+#     --expose-port 49983 \
+#     --probe       49983 \
+#     --probe-path  /health
+
+ARG CUBE_BASE_IMAGE=ghcr.io/tencentcloud/cubesandbox-base:2026.16
+FROM ${CUBE_BASE_IMAGE}
+
+ARG DEBIAN_FRONTEND=noninteractive
+ARG NODE_MAJOR=24
+ARG CODEBUDDY_VERSION=2.119.2
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        bash \
+        ca-certificates \
+        curl \
+        git \
+        gnupg \
+        jq \
+        less \
+        procps \
+        python3 \
+        python3-pip \
+        ripgrep \
+    && curl -fsSL "https://deb.nodesource.com/setup_${NODE_MAJOR}.x" | bash - \
+    && apt-get install -y --no-install-recommends nodejs \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install CodeBuddy CLI in its own layer so bumping CODEBUDDY_VERSION does not
+# invalidate the slow OS + Node.js layer above (only this short layer rebuilds
+# on a version bump).
+RUN npm install -g --ignore-scripts "@tencent-ai/codebuddy-code@${CODEBUDDY_VERSION}" \
+    && codebuddy --version \
+    && npm cache clean --force \
+    && rm -rf /root/.npm
+
+ENV CODEBUDDY_HOME=/root/.codebuddy \
+    CODEBUDDY_TELEMETRY=0 \
+    NPM_CONFIG_UPDATE_NOTIFIER=false
+
+RUN mkdir -p /workspace "${CODEBUDDY_HOME}" \
+    && printf '%s\n' \
+        '{' \
+        '  "telemetry": false,' \
+        '  "quietStartup": true' \
+        '}' \
+        > "${CODEBUDDY_HOME}/settings.json"
+
+WORKDIR /workspace
+
+EXPOSE 49983

--- a/examples/codebuddy-integration/Dockerfile
+++ b/examples/codebuddy-integration/Dockerfile
@@ -48,9 +48,8 @@ RUN apt-get update \
 # Install CodeBuddy CLI in its own layer so bumping CODEBUDDY_VERSION does not
 # invalidate the slow OS + Node.js layer above (only this short layer rebuilds
 # on a version bump).
-RUN npm install -g --ignore-scripts --no-audit --no-fund "@tencent-ai/codebuddy-code@${CODEBUDDY_VERSION}" \
+RUN npm install -g --no-audit --no-fund "@tencent-ai/codebuddy-code@${CODEBUDDY_VERSION}" \
     && codebuddy --version \
-    && npm cache clean --force \
     && rm -rf /root/.npm
 
 RUN mkdir -p /workspace "${CODEBUDDY_HOME}" \

--- a/examples/codebuddy-integration/Dockerfile
+++ b/examples/codebuddy-integration/Dockerfile
@@ -34,7 +34,6 @@ RUN apt-get update \
         ca-certificates \
         curl \
         git \
-        gnupg \
         jq \
         less \
         procps \

--- a/examples/codebuddy-integration/Dockerfile
+++ b/examples/codebuddy-integration/Dockerfile
@@ -24,6 +24,10 @@ ARG DEBIAN_FRONTEND=noninteractive
 ARG NODE_MAJOR=24
 ARG CODEBUDDY_VERSION=2.119.2
 
+ENV CODEBUDDY_HOME=/root/.codebuddy \
+    CODEBUDDY_TELEMETRY=0 \
+    NPM_CONFIG_UPDATE_NOTIFIER=false
+
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         bash \
@@ -44,14 +48,10 @@ RUN apt-get update \
 # Install CodeBuddy CLI in its own layer so bumping CODEBUDDY_VERSION does not
 # invalidate the slow OS + Node.js layer above (only this short layer rebuilds
 # on a version bump).
-RUN npm install -g --ignore-scripts "@tencent-ai/codebuddy-code@${CODEBUDDY_VERSION}" \
+RUN npm install -g --ignore-scripts --no-audit --no-fund "@tencent-ai/codebuddy-code@${CODEBUDDY_VERSION}" \
     && codebuddy --version \
     && npm cache clean --force \
     && rm -rf /root/.npm
-
-ENV CODEBUDDY_HOME=/root/.codebuddy \
-    CODEBUDDY_TELEMETRY=0 \
-    NPM_CONFIG_UPDATE_NOTIFIER=false
 
 RUN mkdir -p /workspace "${CODEBUDDY_HOME}" \
     && printf '%s\n' \

--- a/examples/codebuddy-integration/README.md
+++ b/examples/codebuddy-integration/README.md
@@ -36,7 +36,8 @@ codebuddy-integration/
 
 ## Prerequisites
 
-- A running CubeSandbox deployment; CubeAPI reachable at `http://<node>:3000`.
+- A running CubeSandbox deployment; CubeAPI reachable at `https://<node>:3000`.
+  Use plain HTTP only for isolated local development on loopback.
 - `cubemastercli` on `$PATH`, connected to the cluster.
 - Docker on the build workstation, plus a registry the Cube nodes can pull from.
 - An LLM provider API key (Anthropic by default; any Anthropic-compatible or
@@ -82,10 +83,11 @@ pip install -r requirements.txt
 
 | Variable | Where it flows | Notes |
 |---|---|---|
-| `E2B_API_URL` | Local process | CubeAPI address (`http://<node>:3000`) |
+| `E2B_API_URL` | Local process | TLS-protected CubeAPI address (`https://<node>:3000`) |
 | `E2B_API_KEY` | Local process | Any non-empty string in local dev |
 | `CUBE_TEMPLATE_ID` | `Sandbox.create(template=...)` | From step 2 |
 | `CODEBUDDY_MODEL` | CodeBuddy CLI `--model` flag | Model id for the provider |
+| `CODEBUDDY_PROVIDER` | Local script | Provider name: `anthropic`, `openai`, `google`, `deepseek`, or `openrouter` |
 | `ANTHROPIC_API_KEY` | `envs=...` (direct) or CubeEgress inject (vault) | Provider key |
 | `CODEBUDDY_LLM_HOST` | `network_policy.py` | LLM API host to allow; keep aligned with the provider |
 
@@ -150,7 +152,7 @@ allow rules or preinstall those dependencies into the template.
 | `codebuddy: command not found` in preflight | Template not rebuilt after CLI change | Rebuild the image, re-register the template |
 | Auth error from the provider | Key not forwarded (direct) or missing inject rule (vault) | Pass `envs={...}` or fix the rule's `sni`/`host` |
 | `403 Forbidden - CubeEgress` | Default-deny with no matching allow rule | Add the LLM host (and any extra hosts) to the rules |
-| `Connection error` / TLS failure from CodeBuddy on the vault path | CodeBuddy runs on Node, which ignores the system CA store and won't trust the CubeEgress interception CA | The script sets `NODE_EXTRA_CA_CERTS` to the system bundle; override with `CODEBUDDY_NODE_EXTRA_CA_CERTS` if your CA lives elsewhere |
+| `Connection error` / TLS failure from CodeBuddy on the vault path | CodeBuddy runs on Node, which ignores the system CA store and won't trust the CubeEgress interception CA | The script points `NODE_EXTRA_CA_CERTS` at the dedicated CubeEgress anchor; override with `CODEBUDDY_NODE_EXTRA_CA_CERTS` if your CA lives elsewhere |
 | Readiness probe timeout | Image without envd | Ensure `FROM ghcr.io/tencentcloud/cubesandbox-base:...` |
 | `pause()`/`connect()` errors | Platform too old for snapshots | Upgrade the CubeSandbox platform |
 

--- a/examples/codebuddy-integration/README.md
+++ b/examples/codebuddy-integration/README.md
@@ -1,0 +1,162 @@
+# CodeBuddy + CubeSandbox Example
+
+[中文文档](README_zh.md)
+
+Run [CodeBuddy](https://www.npmjs.com/package/@tencent-ai/codebuddy-code) — an AI coding
+agent CLI — inside a CubeSandbox MicroVM. The agent edits files, runs commands,
+and reaches an LLM API entirely within an isolated, reproducible sandbox.
+
+This example ships:
+
+- A `Dockerfile` that stacks Node.js 24 + the CodeBuddy CLI on top of the
+  CubeSandbox base image (envd already listens on `:49983`).
+- `run_codebuddy.py` — a headless one-shot run inside `/workspace`.
+- `resume_codebuddy.py` — pause/resume across two turns, proving `/workspace`
+  and CodeBuddy's state directory survive the snapshot.
+- `network_policy.py` — a default-deny egress policy where CubeEgress injects
+  the API key on the wire, so the key never enters the VM.
+- `env_utils.py`, `.env.example`, `requirements.txt`.
+
+## Directory layout
+
+```
+codebuddy-integration/
+├── Dockerfile            # CubeSandbox template image (Node.js + CodeBuddy CLI)
+├── .env.example          # Copy to .env and fill in
+├── .gitignore
+├── requirements.txt      # Host driver deps (e2b, cubesandbox, python-dotenv)
+├── env_utils.py          # .env loading, provider keys, CodeBuddy command builder
+├── _common.py            # Shared sandbox command helpers (run/ensure/id)
+├── run_codebuddy.py      # One-shot CodeBuddy task
+├── resume_codebuddy.py   # Pause / resume session persistence
+├── network_policy.py     # Default-deny egress + on-the-wire key injection
+├── README.md             # English docs (this file)
+└── README_zh.md          # Chinese docs
+```
+
+## Prerequisites
+
+- A running CubeSandbox deployment; CubeAPI reachable at `http://<node>:3000`.
+- `cubemastercli` on `$PATH`, connected to the cluster.
+- Docker on the build workstation, plus a registry the Cube nodes can pull from.
+- An LLM provider API key (Anthropic by default; any Anthropic-compatible or
+  OpenAI-compatible endpoint works).
+- Python 3.10+ for the host driver scripts.
+
+## 1. Build the template image
+
+```bash
+docker build --platform linux/amd64 \
+  -t <your-registry>/codebuddy-cube:latest \
+  examples/codebuddy-integration
+docker push <your-registry>/codebuddy-cube:latest
+```
+
+The image installs `@tencent-ai/codebuddy-code`, plus `git`, `python3`, `ripgrep`, `jq`, and
+cleans apt/npm caches. The CodeBuddy version is pinned via
+`--build-arg CODEBUDDY_VERSION=x.y.z`.
+
+## 2. Register as a Cube template
+
+```bash
+cubemastercli tpl create-from-image \
+  --image <your-registry>/codebuddy-cube:latest \
+  --writable-layer-size 4G \
+  --expose-port 49983 \
+  --probe       49983 \
+  --probe-path  /health
+
+cubemastercli tpl watch --job-id <job_id>
+```
+
+Note the `template_id` once the job reaches `READY`.
+
+## 3. Configure the host driver
+
+```bash
+cd examples/codebuddy-integration
+cp .env.example .env
+# fill in E2B_API_URL, CUBE_TEMPLATE_ID, and your provider key
+pip install -r requirements.txt
+```
+
+| Variable | Where it flows | Notes |
+|---|---|---|
+| `E2B_API_URL` | Local process | CubeAPI address (`http://<node>:3000`) |
+| `E2B_API_KEY` | Local process | Any non-empty string in local dev |
+| `CUBE_TEMPLATE_ID` | `Sandbox.create(template=...)` | From step 2 |
+| `CODEBUDDY_MODEL` | CodeBuddy CLI `--model` flag | Model id for the provider |
+| `ANTHROPIC_API_KEY` | `envs=...` (direct) or CubeEgress inject (vault) | Provider key |
+| `CODEBUDDY_LLM_HOST` | `network_policy.py` | LLM API host to allow; keep aligned with the provider |
+
+## 4. One-shot run (direct key flavor)
+
+```bash
+python run_codebuddy.py --prompt "Create hello.py that prints 'Hello from CubeSandbox' and run it."
+```
+
+The key is forwarded per-command via `sandbox.commands.run(..., envs=...)`, so it
+lives only for the lifetime of that exec call — never written to a persistent
+file inside the VM.
+
+> **Security:** this direct flavor leaves egress open, so a compromised agent
+> could exfiltrate the injected key. For shared clusters use the vault flavor
+> (step 6): default-deny egress + on-the-wire key injection.
+
+All three scripts run CodeBuddy with `--output-format stream-json` and render a
+concise transcript by default (assistant text, tool calls, and any failures).
+Pass `--raw` (or set `CODEBUDDY_STREAM_RAW=1`) to stream CodeBuddy's raw JSONL
+events instead.
+
+## 5. Pause / resume (session persistence)
+
+```bash
+python resume_codebuddy.py
+```
+
+Turn 1 asks CodeBuddy to write `/workspace/plan.md`, then `sandbox.pause()`
+snapshots the VM. The script reconnects with `Sandbox.connect(sandbox_id)`,
+verifies `/workspace/plan.md` and CodeBuddy's state directory
+(`/root/.codebuddy`) survived, then runs turn 2 to continue the work. The
+sandbox lifecycle is managed manually with `try/finally` (not a context
+manager), so the pause is not undone by an early `kill`.
+
+## 6. Restricted egress + key vault (recommended for shared clusters)
+
+```bash
+python network_policy.py
+```
+
+- Egress is default-deny — only the LLM host (`CODEBUDDY_LLM_HOST`) is
+  reachable.
+- CubeEgress attaches the provider key as an HTTP header on the wire
+  (`x-api-key` for Anthropic, `Authorization: Bearer` otherwise), so
+  `printenv` inside the sandbox never shows the real key — it only sees a
+  placeholder.
+- Because CodeBuddy runs on Node.js (which ignores the system CA store), the
+  script sets `NODE_EXTRA_CA_CERTS` so CodeBuddy trusts the CubeEgress
+  interception CA; without it the vault path fails with `Connection error`.
+  Override the bundle path via `CODEBUDDY_NODE_EXTRA_CA_CERTS` if your image
+  keeps the CA elsewhere.
+- Any other destination returns `403 Forbidden - CubeEgress`.
+
+If the agent needs extra hosts (package registries, MCP servers), add matching
+allow rules or preinstall those dependencies into the template.
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| `codebuddy: command not found` in preflight | Template not rebuilt after CLI change | Rebuild the image, re-register the template |
+| Auth error from the provider | Key not forwarded (direct) or missing inject rule (vault) | Pass `envs={...}` or fix the rule's `sni`/`host` |
+| `403 Forbidden - CubeEgress` | Default-deny with no matching allow rule | Add the LLM host (and any extra hosts) to the rules |
+| `Connection error` / TLS failure from CodeBuddy on the vault path | CodeBuddy runs on Node, which ignores the system CA store and won't trust the CubeEgress interception CA | The script sets `NODE_EXTRA_CA_CERTS` to the system bundle; override with `CODEBUDDY_NODE_EXTRA_CA_CERTS` if your CA lives elsewhere |
+| Readiness probe timeout | Image without envd | Ensure `FROM ghcr.io/tencentcloud/cubesandbox-base:...` |
+| `pause()`/`connect()` errors | Platform too old for snapshots | Upgrade the CubeSandbox platform |
+
+## References
+
+- Integration guide: [`docs/guide/integrations/codebuddy.md`](../../docs/guide/integrations/codebuddy.md)
+- Snapshot / Clone / Rollback: [`docs/guide/snapshot-rollback-clone.md`](../../docs/guide/snapshot-rollback-clone.md)
+- Network / egress policy examples: [`examples/network-policy`](../network-policy)
+- CodeBuddy CLI: <https://www.npmjs.com/package/@tencent-ai/codebuddy-code>

--- a/examples/codebuddy-integration/README_zh.md
+++ b/examples/codebuddy-integration/README_zh.md
@@ -1,0 +1,141 @@
+# CodeBuddy + CubeSandbox 示例
+
+[English](README.md)
+
+在 CubeSandbox MicroVM 内运行 [CodeBuddy](https://www.npmjs.com/package/@tencent-ai/codebuddy-code)
+（AI 编码 Agent CLI）。Agent 在一个隔离、可复现的沙箱内编辑文件、执行命令并访问 LLM API。
+
+本示例包含：
+
+- 一个 `Dockerfile`：在 CubeSandbox 基础镜像上叠加 Node.js 与 CodeBuddy CLI（envd 已监听 `:49983`）。
+- `run_codebuddy.py`：在 `/workspace` 内的一次性无交互运行。
+- `resume_codebuddy.py`：跨两轮的 pause/resume，证明 `/workspace` 与 CodeBuddy 状态目录在快照后仍存在。
+- `network_policy.py`：默认拒绝出网的策略，由 CubeEgress 在链路上注入 API Key，密钥不进入 VM。
+- `env_utils.py`、`.env.example`、`requirements.txt`。
+
+## 目录结构
+
+```
+codebuddy-integration/
+├── Dockerfile            # CubeSandbox 模板镜像（Node.js + CodeBuddy CLI）
+├── .env.example          # 复制为 .env 并填写
+├── .gitignore
+├── requirements.txt      # 宿主端驱动依赖（e2b、cubesandbox、python-dotenv）
+├── env_utils.py          # .env 加载、provider key、CodeBuddy 命令构造
+├── _common.py            # 共享的沙箱命令辅助（run/ensure/id）
+├── run_codebuddy.py      # 一次性 CodeBuddy 任务
+├── resume_codebuddy.py   # pause / resume 会话持久化
+├── network_policy.py     # 默认拒绝出网 + 链路上注入密钥
+├── README.md             # 英文文档
+└── README_zh.md          # 中文文档（本文件）
+```
+
+## 前置条件
+
+- 已部署 CubeSandbox，CubeAPI 可访问（`http://<node>:3000`）。
+- `cubemastercli` 已在 `$PATH` 且已连通集群。
+- 构建机装有 Docker，且 registry 能被 Cube 集群拉取。
+- 一个 LLM provider 的 API Key（默认 Anthropic；任何 Anthropic 兼容或 OpenAI 兼容端点均可）。
+- Python 3.10+（宿主端驱动脚本）。
+
+## 1. 构建模板镜像
+
+```bash
+docker build --platform linux/amd64 \
+  -t <your-registry>/codebuddy-cube:latest \
+  examples/codebuddy-integration
+docker push <your-registry>/codebuddy-cube:latest
+```
+
+镜像会安装 `@tencent-ai/codebuddy-code`，以及 `git`、`python3`、`ripgrep`、`jq`，并清理
+apt/npm 缓存。CodeBuddy 版本通过 `--build-arg CODEBUDDY_VERSION=x.y.z` 固定。
+
+## 2. 注册为 Cube 模板
+
+```bash
+cubemastercli tpl create-from-image \
+  --image <your-registry>/codebuddy-cube:latest \
+  --writable-layer-size 4G \
+  --expose-port 49983 \
+  --probe       49983 \
+  --probe-path  /health
+
+cubemastercli tpl watch --job-id <job_id>
+```
+
+任务变为 `READY` 后记下 `template_id`。
+
+## 3. 配置宿主端驱动
+
+```bash
+cd examples/codebuddy-integration
+cp .env.example .env
+# 填写 E2B_API_URL、CUBE_TEMPLATE_ID 以及你的 provider key
+pip install -r requirements.txt
+```
+
+| 变量 | 作用位置 | 说明 |
+|---|---|---|
+| `E2B_API_URL` | 本地进程 | CubeAPI 地址（`http://<node>:3000`） |
+| `E2B_API_KEY` | 本地进程 | 本地开发填任意非空字符串 |
+| `CUBE_TEMPLATE_ID` | `Sandbox.create(template=...)` | 来自第 2 步 |
+| `CODEBUDDY_MODEL` | CodeBuddy CLI `--model` 参数 | 对应 provider 的模型 id |
+| `ANTHROPIC_API_KEY` | `envs=...`（直连）或 CubeEgress 注入（vault） | provider 密钥 |
+| `CODEBUDDY_LLM_HOST` | `network_policy.py` | 放行的 LLM API host，需与 provider 对齐 |
+
+## 4. 一次性运行（直连注入密钥）
+
+```bash
+python run_codebuddy.py --prompt "创建 hello.py 打印 'Hello from CubeSandbox' 并运行它。"
+```
+
+密钥通过 `sandbox.commands.run(..., envs=...)` 逐命令传入，只在该命令执行期间存在，不会写入 VM 内的持久文件。
+
+> **安全：** 直连方式出网是放开的，Agent 被攻破可能外泄注入的密钥。共享集群请用保险柜方式（第 6 步）：默认拒绝出网 + 链路上注入密钥。
+
+三个脚本都以 `--output-format stream-json` 运行 CodeBuddy，默认输出精简转写（助手文本、工具调用、失败项）。加 `--raw`（或设置 `CODEBUDDY_STREAM_RAW=1`）可改为打印 CodeBuddy 的原始 JSONL 事件流。
+
+## 5. pause / resume（会话持久化）
+
+```bash
+python resume_codebuddy.py
+```
+
+第一轮让 CodeBuddy 写 `/workspace/plan.md`，随后 `sandbox.pause()` 对 VM 打快照。脚本用
+`Sandbox.connect(sandbox_id)` 恢复，校验 `/workspace/plan.md` 与 CodeBuddy 状态目录
+（`/root/.codebuddy`）仍在，再执行第二轮续写。沙箱生命周期用 `try/finally` 手动管理（不用
+context manager），避免 pause 后被过早 `kill` 掉。
+
+## 6. 受限出网 + 密钥保险柜（推荐用于共享集群）
+
+```bash
+python network_policy.py
+```
+
+- 出网默认拒绝，仅放行 LLM host（`CODEBUDDY_LLM_HOST`）。
+- CubeEgress 在链路上把 provider 密钥作为 HTTP 头注入（Anthropic 用 `x-api-key`，其他用
+  `Authorization: Bearer`），因此沙箱内 `printenv` 看不到真实密钥，只有占位值。
+- CodeBuddy 基于 Node.js（忽略系统 CA 库），脚本会设置 `NODE_EXTRA_CA_CERTS` 让 CodeBuddy 信任 CubeEgress 的
+  拦截 CA；否则 vault 路径会以 `Connection error` 失败。若镜像里 CA 路径不同，可用
+  `CODEBUDDY_NODE_EXTRA_CA_CERTS` 覆盖。
+- 任何其他目的地都会返回 `403 Forbidden - CubeEgress`。
+
+若 Agent 需要访问额外主机（包镜像源、MCP 服务器等），请增加对应的放行规则，或把这些依赖预装进模板。
+
+## 排错
+
+| 现象 | 可能原因 | 处理 |
+|---|---|---|
+| preflight 报 `codebuddy: command not found` | CLI 变更后未重建模板 | 重建镜像并重新注册模板 |
+| provider 鉴权失败 | 密钥未传入（直连）或缺少 inject 规则（vault） | 传 `envs={...}` 或修正规则的 `sni`/`host` |
+| `403 Forbidden - CubeEgress` | 默认拒绝且无匹配放行规则 | 把 LLM host（及所需其他 host）加入规则 |
+| vault 路径下 CodeBuddy 报 `Connection error` / TLS 失败 | CodeBuddy 基于 Node，忽略系统 CA 库，不信任 CubeEgress 拦截 CA | 脚本已把 `NODE_EXTRA_CA_CERTS` 指向系统 CA 包；若 CA 在别处，用 `CODEBUDDY_NODE_EXTRA_CA_CERTS` 覆盖 |
+| 就绪探针超时 | 镜像缺少 envd | 确认 `FROM ghcr.io/tencentcloud/cubesandbox-base:...` |
+| `pause()`/`connect()` 报错 | 平台版本过低不支持快照 | 升级 CubeSandbox 平台 |
+
+## 参考
+
+- 集成指南：[`docs/zh/guide/integrations/codebuddy.md`](../../docs/zh/guide/integrations/codebuddy.md)
+- 快照 / 克隆 / 回滚：[`docs/guide/snapshot-rollback-clone.md`](../../docs/guide/snapshot-rollback-clone.md)
+- 网络 / 出网策略示例：[`examples/network-policy`](../network-policy)
+- CodeBuddy CLI：<https://www.npmjs.com/package/@tencent-ai/codebuddy-code>

--- a/examples/codebuddy-integration/README_zh.md
+++ b/examples/codebuddy-integration/README_zh.md
@@ -32,7 +32,8 @@ codebuddy-integration/
 
 ## 前置条件
 
-- 已部署 CubeSandbox，CubeAPI 可访问（`http://<node>:3000`）。
+- 已部署 CubeSandbox，CubeAPI 可通过 TLS 访问（`https://<node>:3000`）。
+  明文 HTTP 只适用于隔离的本地回环开发环境。
 - `cubemastercli` 已在 `$PATH` 且已连通集群。
 - 构建机装有 Docker，且 registry 能被 Cube 集群拉取。
 - 一个 LLM provider 的 API Key（默认 Anthropic；任何 Anthropic 兼容或 OpenAI 兼容端点均可）。
@@ -76,10 +77,11 @@ pip install -r requirements.txt
 
 | 变量 | 作用位置 | 说明 |
 |---|---|---|
-| `E2B_API_URL` | 本地进程 | CubeAPI 地址（`http://<node>:3000`） |
+| `E2B_API_URL` | 本地进程 | 启用 TLS 的 CubeAPI 地址（`https://<node>:3000`） |
 | `E2B_API_KEY` | 本地进程 | 本地开发填任意非空字符串 |
 | `CUBE_TEMPLATE_ID` | `Sandbox.create(template=...)` | 来自第 2 步 |
 | `CODEBUDDY_MODEL` | CodeBuddy CLI `--model` 参数 | 对应 provider 的模型 id |
+| `CODEBUDDY_PROVIDER` | 本地脚本 | Provider 名称：`anthropic`、`openai`、`google`、`deepseek` 或 `openrouter` |
 | `ANTHROPIC_API_KEY` | `envs=...`（直连）或 CubeEgress 注入（vault） | provider 密钥 |
 | `CODEBUDDY_LLM_HOST` | `network_policy.py` | 放行的 LLM API host，需与 provider 对齐 |
 
@@ -129,7 +131,7 @@ python network_policy.py
 | preflight 报 `codebuddy: command not found` | CLI 变更后未重建模板 | 重建镜像并重新注册模板 |
 | provider 鉴权失败 | 密钥未传入（直连）或缺少 inject 规则（vault） | 传 `envs={...}` 或修正规则的 `sni`/`host` |
 | `403 Forbidden - CubeEgress` | 默认拒绝且无匹配放行规则 | 把 LLM host（及所需其他 host）加入规则 |
-| vault 路径下 CodeBuddy 报 `Connection error` / TLS 失败 | CodeBuddy 基于 Node，忽略系统 CA 库，不信任 CubeEgress 拦截 CA | 脚本已把 `NODE_EXTRA_CA_CERTS` 指向系统 CA 包；若 CA 在别处，用 `CODEBUDDY_NODE_EXTRA_CA_CERTS` 覆盖 |
+| vault 路径下 CodeBuddy 报 `Connection error` / TLS 失败 | CodeBuddy 基于 Node，忽略系统 CA 库，不信任 CubeEgress 拦截 CA | 脚本已把 `NODE_EXTRA_CA_CERTS` 指向专用 CubeEgress CA；若 CA 在别处，用 `CODEBUDDY_NODE_EXTRA_CA_CERTS` 覆盖 |
 | 就绪探针超时 | 镜像缺少 envd | 确认 `FROM ghcr.io/tencentcloud/cubesandbox-base:...` |
 | `pause()`/`connect()` 报错 | 平台版本过低不支持快照 | 升级 CubeSandbox 平台 |
 

--- a/examples/codebuddy-integration/README_zh.md
+++ b/examples/codebuddy-integration/README_zh.md
@@ -138,6 +138,6 @@ python network_policy.py
 ## 参考
 
 - 集成指南：[`docs/zh/guide/integrations/codebuddy.md`](../../docs/zh/guide/integrations/codebuddy.md)
-- 快照 / 克隆 / 回滚：[`docs/guide/snapshot-rollback-clone.md`](../../docs/guide/snapshot-rollback-clone.md)
+- 快照 / 克隆 / 回滚：[`docs/zh/guide/snapshot-rollback-clone.md`](../../docs/zh/guide/snapshot-rollback-clone.md)
 - 网络 / 出网策略示例：[`examples/network-policy`](../network-policy)
 - CodeBuddy CLI：<https://www.npmjs.com/package/@tencent-ai/codebuddy-code>

--- a/examples/codebuddy-integration/_common.py
+++ b/examples/codebuddy-integration/_common.py
@@ -96,26 +96,34 @@ def _render_jsonl_line(line: str) -> None:
             _render_message(message)
 
 
+class _BufferedJSONWriter:
+    def __init__(self) -> None:
+        self.parts: list[str] = []
+
+    def __call__(self, chunk: object) -> None:
+        text = getattr(chunk, "line", chunk)
+        text = text if isinstance(text, str) else str(text)
+        lines = text.split("\n")
+        if len(lines) == 1:
+            self.parts.append(text)
+            return
+        _render_jsonl_line("".join(self.parts) + lines[0])
+        for line in lines[1:-1]:
+            _render_jsonl_line(line)
+        self.parts = [lines[-1]]
+
+    def flush(self) -> None:
+        if self.parts:
+            _render_jsonl_line("".join(self.parts))
+            self.parts.clear()
+
+
 def jsonl_render_writer() -> Callable[[object], None]:
     # e2b delivers stdout as arbitrary chunks (often several JSONL events, or a
     # partial line, per callback), not one event per call. Buffer and split on
     # newlines so each event is rendered exactly once. CodeBuddy newline-terminates
     # every event, so nothing important is left dangling in the buffer.
-    buffer = {"parts": []}
-
-    def write(chunk: object) -> None:
-        text = getattr(chunk, "line", chunk)
-        text = text if isinstance(text, str) else str(text)
-        lines = text.split("\n")
-        if len(lines) == 1:
-            buffer["parts"].append(text)
-            return
-        _render_jsonl_line("".join(buffer["parts"]) + lines[0])
-        for line in lines[1:-1]:
-            _render_jsonl_line(line)
-        buffer["parts"] = [lines[-1]]
-
-    return write
+    return _BufferedJSONWriter()
 
 
 def run_command(
@@ -135,6 +143,7 @@ def run_command(
     kwargs = {key: value for key, value in kwargs.items() if value is not None}
     if envs:
         kwargs["envs"] = envs
+    stdout_writer = None
     if stream:
         # Default to a concise transcript (assistant text + tool calls + errors).
         # Set CODEBUDDY_STREAM_RAW=1 (or pass --raw) to dump CodeBuddy's raw
@@ -143,25 +152,31 @@ def run_command(
             raw = os.environ.get("CODEBUDDY_STREAM_RAW", "").strip().lower() in (
                 "1", "true", "yes",
             )
-        kwargs["on_stdout"] = stream_writer(sys.stdout) if raw else jsonl_render_writer()
+        stdout_writer = stream_writer(sys.stdout) if raw else jsonl_render_writer()
+        kwargs["on_stdout"] = stdout_writer
         kwargs["on_stderr"] = stream_writer(sys.stderr)
 
     try:
-        return sandbox.commands.run(command, **kwargs)
-    except TypeError as exc:
-        # Older SDKs name the parameter ``env`` instead of ``envs``. Only retry
-        # for that specific signature mismatch; re-raise any other TypeError so
-        # real bugs (e.g. a wrong-type command or timeout) are not masked.
-        if "envs" not in kwargs or "envs" not in str(exc):
-            raise
-        kwargs["env"] = kwargs.pop("envs")
-        return sandbox.commands.run(command, **kwargs)
+        try:
+            return sandbox.commands.run(command, **kwargs)
+        except TypeError as exc:
+            # Older SDKs name the parameter ``env`` instead of ``envs``. Only retry
+            # for that specific signature mismatch; re-raise any other TypeError so
+            # real bugs (e.g. a wrong-type command or timeout) are not masked.
+            if "envs" not in kwargs or "envs" not in str(exc):
+                raise
+            kwargs["env"] = kwargs.pop("envs")
+            return sandbox.commands.run(command, **kwargs)
+    finally:
+        flush = getattr(stdout_writer, "flush", None)
+        if flush:
+            flush()
 
 
 def ensure_success(result, action: str) -> None:
     exit_code = getattr(result, "exit_code", None)
     if exit_code is None:
-        return
+        raise SystemExit(f"Failed to {action}: command returned no exit code")
     try:
         code = int(exit_code)
     except (TypeError, ValueError) as exc:

--- a/examples/codebuddy-integration/_common.py
+++ b/examples/codebuddy-integration/_common.py
@@ -28,7 +28,7 @@ def stream_writer(stream) -> Callable[[object], None]:
 
 
 def _tool_brief(arguments: dict) -> str:
-    for key in ("command", "path", "pattern", "query", "url"):
+    for key in ("command", "path", "pattern", "query", "url", "file_path"):
         value = arguments.get(key)
         if value:
             return str(value).replace("\n", " ")[:120]

--- a/examples/codebuddy-integration/_common.py
+++ b/examples/codebuddy-integration/_common.py
@@ -101,14 +101,19 @@ def jsonl_render_writer() -> Callable[[object], None]:
     # partial line, per callback), not one event per call. Buffer and split on
     # newlines so each event is rendered exactly once. CodeBuddy newline-terminates
     # every event, so nothing important is left dangling in the buffer.
-    buffer = {"text": ""}
+    buffer = {"parts": []}
 
     def write(chunk: object) -> None:
         text = getattr(chunk, "line", chunk)
-        buffer["text"] += text if isinstance(text, str) else str(text)
-        while "\n" in buffer["text"]:
-            line, buffer["text"] = buffer["text"].split("\n", 1)
+        text = text if isinstance(text, str) else str(text)
+        lines = text.split("\n")
+        if len(lines) == 1:
+            buffer["parts"].append(text)
+            return
+        _render_jsonl_line("".join(buffer["parts"]) + lines[0])
+        for line in lines[1:-1]:
             _render_jsonl_line(line)
+        buffer["parts"] = [lines[-1]]
 
     return write
 
@@ -121,6 +126,7 @@ def run_command(
     envs: dict[str, str] | None = None,
     timeout: int | float | None = None,
     stream: bool = False,
+    raw: bool | None = None,
     user: str = "root",
 ):
     # Run as root: /workspace and CodeBuddy's state dir (/root/.codebuddy) are
@@ -133,9 +139,10 @@ def run_command(
         # Default to a concise transcript (assistant text + tool calls + errors).
         # Set CODEBUDDY_STREAM_RAW=1 (or pass --raw) to dump CodeBuddy's raw
         # JSONL instead.
-        raw = os.environ.get("CODEBUDDY_STREAM_RAW", "").strip().lower() in (
-            "1", "true", "yes"
-        )
+        if raw is None:
+            raw = os.environ.get("CODEBUDDY_STREAM_RAW", "").strip().lower() in (
+                "1", "true", "yes",
+            )
         kwargs["on_stdout"] = stream_writer(sys.stdout) if raw else jsonl_render_writer()
         kwargs["on_stderr"] = stream_writer(sys.stderr)
 
@@ -153,7 +160,7 @@ def run_command(
 
 def ensure_success(result, action: str) -> None:
     exit_code = getattr(result, "exit_code", None)
-    if exit_code not in (None, 0):
+    if exit_code is not None and int(exit_code) != 0:
         stdout = getattr(result, "stdout", "")
         stderr = getattr(result, "stderr", "")
         raise SystemExit(

--- a/examples/codebuddy-integration/_common.py
+++ b/examples/codebuddy-integration/_common.py
@@ -1,0 +1,165 @@
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared sandbox command helpers for the CodeBuddy example scripts.
+
+Kept SDK-agnostic (duck-typed on ``sandbox.commands.run`` and the result's
+attributes) so the same helpers work with both the e2b-compatible SDK used by
+``run_codebuddy.py`` / ``resume_codebuddy.py`` and the native ``cubesandbox``
+SDK used by ``network_policy.py``.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from collections.abc import Callable
+from typing import Any
+
+
+def stream_writer(stream) -> Callable[[object], None]:
+    def write(chunk: object) -> None:
+        text = getattr(chunk, "line", chunk)
+        stream.write(str(text))
+        stream.flush()
+
+    return write
+
+
+def _tool_brief(arguments: dict) -> str:
+    for key in ("command", "path", "pattern", "query", "url"):
+        value = arguments.get(key)
+        if value:
+            return str(value).replace("\n", " ")[:120]
+    return ""
+
+
+def _render_message(message: object) -> None:
+    if not isinstance(message, dict):
+        return
+    role = message.get("role")
+    content = message.get("content")
+    if role == "assistant":
+        if isinstance(content, str) and content.strip():
+            print(content.strip())
+        elif isinstance(content, list):
+            for item in content:
+                if not isinstance(item, dict):
+                    continue
+                itype = item.get("type")
+                if itype == "text":
+                    text = str(item.get("text", "")).strip()
+                    if text:
+                        print(text)
+                elif itype == "toolCall":
+                    name = item.get("name") or "tool"
+                    arguments = (
+                        item.get("arguments")
+                        if isinstance(item.get("arguments"), dict)
+                        else {}
+                    )
+                    brief = _tool_brief(arguments)
+                    print(f"  \u2192 [tool] {name}{': ' + brief if brief else ''}")
+        if message.get("stopReason") == "error":
+            print(f"  [error] {str(message.get('errorMessage', ''))[:300]}")
+    elif role == "toolResult" and message.get("isError"):
+        print(f"  \u2717 [tool] {message.get('toolName', 'tool')} failed")
+
+
+def _render_jsonl_line(line: str) -> None:
+    """Render one CodeBuddy ``--output-format stream-json`` event as concise,
+    human-readable output.
+
+    CodeBuddy streams a lot of envelopes (per-token deltas, thinking traces,
+    duplicate message snapshots). We ignore all of those and render only the
+    authoritative transcript: assistant text, tool calls, and any failures, in
+    order. Non-JSON lines are printed verbatim. Set CODEBUDDY_STREAM_RAW=1 (or
+    pass ``--raw``) to see the raw JSONL stream instead.
+    """
+    line = line.rstrip("\r\n")
+    if not line.strip():
+        return
+    try:
+        event = json.loads(line)
+    except (ValueError, TypeError):
+        print(line)
+        return
+    if not isinstance(event, dict):
+        return
+    # CodeBuddy stream-json events have a "type" field; we render the
+    # final transcript event (type "result" or "end") and skip incremental
+    # deltas. For other event types, only render if CODEBUDDY_STREAM_RAW is set.
+    event_type = event.get("type")
+    if event_type in ("result", "end"):
+        for message in event.get("messages") or []:
+            _render_message(message)
+
+
+def jsonl_render_writer() -> Callable[[object], None]:
+    # e2b delivers stdout as arbitrary chunks (often several JSONL events, or a
+    # partial line, per callback), not one event per call. Buffer and split on
+    # newlines so each event is rendered exactly once. CodeBuddy newline-terminates
+    # every event, so nothing important is left dangling in the buffer.
+    buffer = {"text": ""}
+
+    def write(chunk: object) -> None:
+        text = getattr(chunk, "line", chunk)
+        buffer["text"] += text if isinstance(text, str) else str(text)
+        while "\n" in buffer["text"]:
+            line, buffer["text"] = buffer["text"].split("\n", 1)
+            _render_jsonl_line(line)
+
+    return write
+
+
+def run_command(
+    sandbox: Any,
+    command: str,
+    *,
+    cwd: str | None = None,
+    envs: dict[str, str] | None = None,
+    timeout: int | float | None = None,
+    stream: bool = False,
+    user: str = "root",
+):
+    # Run as root: /workspace and CodeBuddy's state dir (/root/.codebuddy) are
+    # root-owned, and the default e2b exec user ("user") cannot write to them.
+    kwargs = {"cwd": cwd, "timeout": timeout, "user": user}
+    kwargs = {key: value for key, value in kwargs.items() if value is not None}
+    if envs:
+        kwargs["envs"] = envs
+    if stream:
+        # Default to a concise transcript (assistant text + tool calls + errors).
+        # Set CODEBUDDY_STREAM_RAW=1 (or pass --raw) to dump CodeBuddy's raw
+        # JSONL instead.
+        raw = os.environ.get("CODEBUDDY_STREAM_RAW", "").strip().lower() in (
+            "1", "true", "yes"
+        )
+        kwargs["on_stdout"] = stream_writer(sys.stdout) if raw else jsonl_render_writer()
+        kwargs["on_stderr"] = stream_writer(sys.stderr)
+
+    try:
+        return sandbox.commands.run(command, **kwargs)
+    except TypeError as exc:
+        # Older SDKs name the parameter ``env`` instead of ``envs``. Only retry
+        # for that specific signature mismatch; re-raise any other TypeError so
+        # real bugs (e.g. a wrong-type command or timeout) are not masked.
+        if "envs" not in kwargs or "envs" not in str(exc):
+            raise
+        kwargs["env"] = kwargs.pop("envs")
+        return sandbox.commands.run(command, **kwargs)
+
+
+def ensure_success(result, action: str) -> None:
+    exit_code = getattr(result, "exit_code", None)
+    if exit_code not in (None, 0):
+        stdout = getattr(result, "stdout", "")
+        stderr = getattr(result, "stderr", "")
+        raise SystemExit(
+            f"Failed to {action} (exit {exit_code}).\nSTDOUT:\n{stdout}\nSTDERR:\n{stderr}"
+        )
+
+
+def sandbox_identifier(sandbox: Any) -> str:
+    return getattr(sandbox, "sandbox_id", getattr(sandbox, "id", "unknown"))

--- a/examples/codebuddy-integration/_common.py
+++ b/examples/codebuddy-integration/_common.py
@@ -160,7 +160,13 @@ def run_command(
 
 def ensure_success(result, action: str) -> None:
     exit_code = getattr(result, "exit_code", None)
-    if exit_code is not None and int(exit_code) != 0:
+    if exit_code is None:
+        return
+    try:
+        code = int(exit_code)
+    except (TypeError, ValueError) as exc:
+        raise SystemExit(f"Cannot parse exit code {exit_code!r} for: {action}") from exc
+    if code != 0:
         stdout = getattr(result, "stdout", "")
         stderr = getattr(result, "stderr", "")
         raise SystemExit(

--- a/examples/codebuddy-integration/env_utils.py
+++ b/examples/codebuddy-integration/env_utils.py
@@ -51,10 +51,7 @@ PASSTHROUGH_ENV_NAMES = (
 
 def load_local_dotenv() -> None:
     """Best-effort load of a nearby .env file without overriding real env vars."""
-    candidate_paths = [
-        Path(__file__).with_name(".env"),
-        Path.cwd() / ".env",
-    ]
+    candidate_paths = [Path(__file__).with_name(".env")]
 
     seen_paths: set[Path] = set()
     for path in candidate_paths:

--- a/examples/codebuddy-integration/env_utils.py
+++ b/examples/codebuddy-integration/env_utils.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import os
 import shlex
+import warnings
 from pathlib import Path
 from urllib.parse import urlparse
 
@@ -151,6 +152,12 @@ def build_codebuddy_env(include_secrets: bool = True) -> dict[str, str]:
     provider key rides the wire via egress injection, so it must never enter
     the sandbox environment.
     """
+    if include_secrets and any(os.environ.get(name) for name in ("HTTP_PROXY", "HTTPS_PROXY")):
+        warnings.warn(
+            "Direct-key mode forwards proxy settings; the proxy can observe LLM traffic and credentials.",
+            RuntimeWarning,
+            stacklevel=2,
+        )
     env = {
         "CODEBUDDY_HOME": optional("CODEBUDDY_HOME", DEFAULT_CODEBUDDY_HOME),
         "CODEBUDDY_TELEMETRY": optional("CODEBUDDY_TELEMETRY", "0"),

--- a/examples/codebuddy-integration/env_utils.py
+++ b/examples/codebuddy-integration/env_utils.py
@@ -1,0 +1,250 @@
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import os
+import shlex
+from pathlib import Path
+from urllib.parse import urlparse
+
+from dotenv import load_dotenv
+
+DEFAULT_CODEBUDDY_HOME = "/root/.codebuddy"
+DEFAULT_WORKSPACE = "/workspace"
+
+PROVIDER_KEY_ENV = {
+    "anthropic": "ANTHROPIC_API_KEY",
+    "openai": "OPENAI_API_KEY",
+    "google": "GEMINI_API_KEY",
+    "deepseek": "DEEPSEEK_API_KEY",
+    "openrouter": "OPENROUTER_API_KEY",
+}
+
+PROVIDER_KEY_ALIASES = {
+    "anthropic": ("ANTHROPIC_AUTH_TOKEN",),
+}
+
+PROVIDER_DEFAULT_HOST = {
+    "anthropic": "api.anthropic.com",
+    "openai": "api.openai.com",
+    "google": "generativelanguage.googleapis.com",
+    "deepseek": "api.deepseek.com",
+    "openrouter": "openrouter.ai",
+}
+
+# Only Anthropic ships a default model; other providers must set CODEBUDDY_MODEL
+# explicitly (model IDs are provider-specific and change often), so we fail
+# loudly instead of sending a Claude model name to, say, OpenAI.
+PROVIDER_DEFAULT_MODEL = {
+    "anthropic": "claude-sonnet-4-6",
+}
+
+PASSTHROUGH_ENV_NAMES = (
+    "ANTHROPIC_BASE_URL",
+    "ANTHROPIC_MODEL",
+    "HTTP_PROXY",
+    "HTTPS_PROXY",
+    "NO_PROXY",
+)
+
+
+def load_local_dotenv() -> None:
+    """Best-effort load of a nearby .env file without overriding real env vars."""
+    candidate_paths = [
+        Path(__file__).with_name(".env"),
+        Path.cwd() / ".env",
+    ]
+
+    seen_paths: set[Path] = set()
+    for path in candidate_paths:
+        resolved_path = path.resolve()
+        if resolved_path in seen_paths:
+            continue
+        seen_paths.add(resolved_path)
+
+        if path.is_file():
+            load_dotenv(dotenv_path=path, override=False)
+            return
+
+
+def required(name: str) -> str:
+    value = os.environ.get(name)
+    if not value:
+        raise SystemExit(f"Missing required environment variable: {name}")
+    return value
+
+
+def optional(name: str, default: str = "") -> str:
+    return os.environ.get(name) or default
+
+
+def int_env(name: str, default: int) -> int:
+    raw = os.environ.get(name)
+    if not raw:
+        return default
+    try:
+        return int(raw)
+    except ValueError as exc:
+        raise SystemExit(f"{name} must be an integer, got {raw!r}") from exc
+
+
+def codebuddy_provider() -> str:
+    # Normalize case so every downstream comparison and dict lookup
+    # (provider_inject, PROVIDER_DEFAULT_HOST, key candidates, ...) is
+    # case-insensitive; "Anthropic" and "anthropic" must behave the same.
+    return optional("CODEBUDDY_PROVIDER", "anthropic").strip().lower()
+
+
+def codebuddy_model() -> str:
+    provider = codebuddy_provider()
+    explicit = os.environ.get("CODEBUDDY_MODEL")
+    if not explicit and provider == "anthropic":
+        explicit = os.environ.get("ANTHROPIC_MODEL")
+    if explicit:
+        return explicit
+    default = PROVIDER_DEFAULT_MODEL.get(provider)
+    if default:
+        return default
+    raise SystemExit(
+        f"No default model for provider {provider!r}. Set CODEBUDDY_MODEL in your .env "
+        "(model IDs are provider-specific; there is no safe cross-provider default)."
+    )
+
+
+def codebuddy_workspace() -> str:
+    return optional("CODEBUDDY_WORKSPACE", DEFAULT_WORKSPACE)
+
+
+def codebuddy_permission_mode() -> str:
+    return optional("CODEBUDDY_PERMISSION_MODE", "acceptEdits")
+
+
+def provider_key_name(provider: str | None = None) -> str:
+    provider_name = provider or codebuddy_provider()
+    names = provider_key_candidates(provider_name)
+    for name in names:
+        if os.environ.get(name):
+            return name
+    return names[0]
+
+
+def require_provider_key(provider: str | None = None) -> str:
+    provider_name = provider or codebuddy_provider()
+    names = provider_key_candidates(provider_name)
+    for name in names:
+        value = os.environ.get(name)
+        if value:
+            return value
+    raise SystemExit(
+        "Missing required environment variable: one of " + ", ".join(names)
+    )
+
+
+def provider_key_candidates(provider: str) -> tuple[str, ...]:
+    provider = provider.strip().lower()
+    default_name = PROVIDER_KEY_ENV.get(provider, f"{provider.upper()}_API_KEY")
+    return (default_name, *PROVIDER_KEY_ALIASES.get(provider, ()))
+
+
+def build_codebuddy_env(include_secrets: bool = True) -> dict[str, str]:
+    """Build the env map passed to the CodeBuddy command inside the sandbox.
+
+    Set ``include_secrets=False`` for the CubeEgress vault flavor: the real
+    provider key rides the wire via egress injection, so it must never enter
+    the sandbox environment.
+    """
+    env = {
+        "CODEBUDDY_HOME": optional("CODEBUDDY_HOME", DEFAULT_CODEBUDDY_HOME),
+        "CODEBUDDY_TELEMETRY": optional("CODEBUDDY_TELEMETRY", "0"),
+    }
+    for name in PASSTHROUGH_ENV_NAMES:
+        value = os.environ.get(name)
+        if value:
+            env[name] = value
+    if include_secrets:
+        # Forward ONLY the active provider's key(s), never every known secret —
+        # a host with several provider keys (e.g. a CI matrix) must not leak all
+        # of them into the sandbox.
+        for name in provider_key_candidates(codebuddy_provider()):
+            value = os.environ.get(name)
+            if value:
+                env[name] = value
+    return env
+
+
+def codebuddy_llm_host(provider: str | None = None) -> str:
+    """Resolve the LLM API host that CodeBuddy must reach.
+
+    Precedence: explicit ``CODEBUDDY_LLM_HOST`` > host parsed from ``ANTHROPIC_BASE_URL``
+    (for Anthropic-compatible endpoints) > the provider default.
+    """
+    provider_name = (provider or codebuddy_provider()).strip().lower()
+    explicit = os.environ.get("CODEBUDDY_LLM_HOST")
+    if explicit:
+        return _host_from_url(explicit)
+    if provider_name == "anthropic":
+        base_url = os.environ.get("ANTHROPIC_BASE_URL")
+        if base_url:
+            host = _host_from_url(base_url)
+            if host:
+                return host
+    return PROVIDER_DEFAULT_HOST.get(provider_name, "")
+
+
+def _host_from_url(value: str) -> str:
+    candidate = value.strip()
+    if not candidate:
+        return ""
+    if "://" not in candidate:
+        candidate = f"https://{candidate}"
+    return urlparse(candidate).hostname or ""
+
+
+def provider_inject(provider: str, secret: str) -> list[dict[str, str]]:
+    """CubeEgress credential-injection specs for a provider's auth header(s).
+
+    Each dict maps directly to a ``cubesandbox.Inject(header=..., secret=...,
+    format=...)``. CubeEgress attaches these headers to matched outbound
+    requests, so the real key rides the wire and never enters the sandbox VM.
+    ``format`` defaults to ``${SECRET}`` (raw secret); bearer schemes use
+    ``Bearer ${SECRET}``. Anthropic uses ``x-api-key`` plus the required
+    API-version header; every other provider uses ``Authorization: Bearer``.
+    """
+    if provider.strip().lower() == "anthropic":
+        return [
+            {"header": "x-api-key", "secret": secret, "format": "${SECRET}"},
+            {"header": "anthropic-version", "secret": "2023-06-01", "format": "${SECRET}"},
+        ]
+    return [{"header": "Authorization", "secret": secret, "format": "Bearer ${SECRET}"}]
+
+
+def codebuddy_command(
+    prompt: str, *, output_format: str = "stream-json", name: str | None = None
+) -> str:
+    """Build a headless (non-interactive) CodeBuddy invocation.
+
+    ``-p`` (``--print``) makes CodeBuddy process the prompt and exit instead of
+    launching the interactive TUI (which would hang over the E2B exec channel).
+    ``--output-format stream-json`` streams machine-readable JSONL events.
+    ``--permission-mode acceptEdits`` allows CodeBuddy to edit files without
+    prompting — handy in an isolated sandbox. The prompt is passed as the
+    positional argument after ``-p``.
+    """
+    args = ["codebuddy", "-p"]
+    if output_format:
+        args.extend(["--output-format", output_format])
+    model = codebuddy_model()
+    if model:
+        args.extend(["--model", model])
+    perm_mode = codebuddy_permission_mode()
+    if perm_mode:
+        args.extend(["--permission-mode", perm_mode])
+    if name:
+        args.extend(["--name", name])
+    args.append(prompt)
+    return " ".join(shlex.quote(arg) for arg in args)
+
+
+def shell_join(*parts: str) -> str:
+    return " && ".join(part for part in parts if part)

--- a/examples/codebuddy-integration/env_utils.py
+++ b/examples/codebuddy-integration/env_utils.py
@@ -48,6 +48,7 @@ PASSTHROUGH_ENV_NAMES = (
     "HTTPS_PROXY",
     "NO_PROXY",
 )
+PROXY_ENV_NAMES = ("HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY")
 
 
 def load_local_dotenv() -> None:
@@ -74,6 +75,7 @@ def required(name: str) -> str:
 
 
 def optional(name: str, default: str = "") -> str:
+    """Return the configured non-empty value, otherwise ``default``."""
     return os.environ.get(name) or default
 
 
@@ -163,6 +165,8 @@ def build_codebuddy_env(include_secrets: bool = True) -> dict[str, str]:
         "CODEBUDDY_TELEMETRY": optional("CODEBUDDY_TELEMETRY", "0"),
     }
     for name in PASSTHROUGH_ENV_NAMES:
+        if not include_secrets and name in PROXY_ENV_NAMES:
+            continue
         value = os.environ.get(name)
         if value:
             env[name] = value

--- a/examples/codebuddy-integration/network_policy.py
+++ b/examples/codebuddy-integration/network_policy.py
@@ -49,8 +49,8 @@ PLACEHOLDER_KEY = "cube-egress-managed-placeholder"
 # trust store. On the vault path CubeEgress terminates TLS to inject the credential,
 # so Node must trust the CubeEgress root CA or every LLM call fails with
 # "Connection error". Point NODE_EXTRA_CA_CERTS at a bundle that includes it; the
-# CubeSandbox base image installs the CA into the system bundle below.
-DEFAULT_NODE_CA_BUNDLE = "/etc/ssl/certs/ca-certificates.crt"
+# CubeMaster bakes a dedicated CubeEgress anchor into the image.
+DEFAULT_NODE_CA_BUNDLE = "/usr/local/share/ca-certificates/cube-egress-root.crt"
 
 DEFAULT_PROMPT = (
     "Reply with a single short sentence confirming you can reach the LLM API, "
@@ -176,15 +176,13 @@ def run_agent(sandbox: Sandbox, args: argparse.Namespace, envs: dict[str, str]):
         envs=envs,
         timeout=args.exec_timeout,
         stream=True,
+        raw=args.raw,
     )
 
 
 def main() -> int:
     load_local_dotenv()
     args = parse_args()
-    if args.raw:
-        os.environ["CODEBUDDY_STREAM_RAW"] = "1"
-
     template_id = args.template or required("CUBE_TEMPLATE_ID")
     required("E2B_API_URL")
     required("E2B_API_KEY")

--- a/examples/codebuddy-integration/network_policy.py
+++ b/examples/codebuddy-integration/network_policy.py
@@ -1,0 +1,245 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Restrict CodeBuddy's egress to the LLM API and inject the key on the wire.
+
+This is the recommended production ("credential vault") pattern:
+
+* Default-deny egress — the sandbox is created with ``allow_internet_access=False``
+  and an ``allow_out`` list containing only the LLM API host, so every other
+  destination is dropped before it can leave the sandbox.
+* The provider auth header is attached by CubeEgress via ``inject`` rules
+  (native ``cubesandbox`` SDK; see docs/guide/security-proxy.md), so the real
+  key rides the wire and never enters the sandbox VM. The agent inside only
+  sees a placeholder value.
+
+Run:
+    python network_policy.py
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import shlex
+import sys
+
+from cubesandbox import Sandbox, Rule, Match, Action, Inject
+
+from env_utils import (
+    build_codebuddy_env,
+    codebuddy_command,
+    codebuddy_llm_host,
+    codebuddy_provider,
+    codebuddy_workspace,
+    int_env,
+    load_local_dotenv,
+    provider_inject,
+    provider_key_name,
+    require_provider_key,
+    required,
+    shell_join,
+)
+from _common import ensure_success, run_command, sandbox_identifier
+
+PLACEHOLDER_KEY = "cube-egress-managed-placeholder"
+
+# CodeBuddy runs on Node.js, which uses its own bundled CA store and ignores the system
+# trust store. On the vault path CubeEgress terminates TLS to inject the credential,
+# so Node must trust the CubeEgress root CA or every LLM call fails with
+# "Connection error". Point NODE_EXTRA_CA_CERTS at a bundle that includes it; the
+# CubeSandbox base image installs the CA into the system bundle below.
+DEFAULT_NODE_CA_BUNDLE = "/etc/ssl/certs/ca-certificates.crt"
+
+DEFAULT_PROMPT = (
+    "Reply with a single short sentence confirming you can reach the LLM API, "
+    "then write that sentence to {workspace}/egress_check.md."
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Run CodeBuddy under a default-deny egress policy with on-the-wire key injection."
+    )
+    parser.add_argument(
+        "--template",
+        default=os.environ.get("CUBE_TEMPLATE_ID"),
+        help="CubeSandbox template ID. Defaults to CUBE_TEMPLATE_ID.",
+    )
+    parser.add_argument(
+        "--host",
+        default=None,
+        help="LLM API host to allow. Defaults to CODEBUDDY_LLM_HOST or the provider default.",
+    )
+    parser.add_argument(
+        "--workspace",
+        default=codebuddy_workspace(),
+        help="Working directory inside the sandbox. Defaults to CODEBUDDY_WORKSPACE.",
+    )
+    parser.add_argument(
+        "--prompt",
+        default=None,
+        help="Prompt passed to CodeBuddy. Defaults to a small egress reachability check.",
+    )
+    parser.add_argument(
+        "--name",
+        default="cube-codebuddy-egress",
+        help="CodeBuddy session name for the egress demo run.",
+    )
+    parser.add_argument(
+        "--sandbox-timeout",
+        type=int,
+        default=int_env("CODEBUDDY_SANDBOX_TIMEOUT", 1800),
+        help="Sandbox lifetime in seconds. Defaults to CODEBUDDY_SANDBOX_TIMEOUT or 1800.",
+    )
+    parser.add_argument(
+        "--exec-timeout",
+        type=int,
+        default=int_env("CODEBUDDY_EXEC_TIMEOUT", 900),
+        help="CodeBuddy command timeout in seconds. Defaults to CODEBUDDY_EXEC_TIMEOUT or 900.",
+    )
+    parser.add_argument(
+        "--skip-agent",
+        action="store_true",
+        help="Only show the egress checks; skip the actual CodeBuddy run.",
+    )
+    parser.add_argument(
+        "--raw",
+        action="store_true",
+        help="Stream CodeBuddy's raw JSONL instead of the concise transcript.",
+    )
+    args = parser.parse_args()
+    if args.prompt is None:
+        args.prompt = DEFAULT_PROMPT.format(workspace=args.workspace)
+    return args
+
+
+def build_rules(provider: str, host: str, secret: str) -> list[Rule]:
+    # Canonical CubeEgress rule (see docs/guide/security-proxy.md): allow the LLM
+    # host and attach the provider auth header(s) on the wire via ``inject`` so
+    # the real key never enters the sandbox VM. Anything matching no rule under
+    # default-deny is rejected by CubeEgress with 403.
+    return [
+        Rule(
+            name=f"allow_{provider}_llm",
+            match=Match(scheme="https", sni=host, host=host),
+            action=Action(
+                allow=True,
+                audit="metadata",
+                inject=[Inject(**spec) for spec in provider_inject(provider, secret)],
+            ),
+        )
+    ]
+
+
+def create_sandbox(template_id: str, rules: list[Rule], timeout: int) -> Sandbox:
+    # allow_internet_access=False makes egress default-deny at L3/L4; the LLM host
+    # named in the rules is auto-allowed and its requests are injected at L7 by
+    # CubeEgress. Never silently drop this flag, or full egress is re-enabled.
+    return Sandbox.create(
+        template=template_id,
+        allow_internet_access=False,
+        network={"rules": rules},
+        timeout=timeout,
+    )
+
+
+def show_key_not_in_vm(sandbox: Sandbox, key_name: str) -> None:
+    command = f"printenv {shlex.quote(key_name)} || echo '<unset>'"
+    result = run_command(sandbox, command, timeout=30)
+    ensure_success(result, "read provider key inside sandbox")
+    value = getattr(result, "stdout", "").strip()
+    print(f"In-VM {key_name}: {value!r} (real secret stays in CubeEgress)")
+
+
+def show_non_llm_blocked(sandbox: Sandbox) -> None:
+    command = (
+        "curl -s -o /dev/null -w '%{http_code}' --max-time 8 https://example.com "
+        "|| echo blocked"
+    )
+    result = run_command(sandbox, command, timeout=30)
+    status = getattr(result, "stdout", "").strip()
+    print(f"Non-LLM host (example.com) response: {status or 'blocked'} "
+          "(expected 403/blocked under default-deny)")
+
+
+def run_agent(sandbox: Sandbox, args: argparse.Namespace, envs: dict[str, str]):
+    command = shell_join(
+        f"cd {shlex.quote(args.workspace)}",
+        codebuddy_command(args.prompt, output_format="stream-json", name=args.name),
+    )
+    return run_command(
+        sandbox,
+        command,
+        cwd=args.workspace,
+        envs=envs,
+        timeout=args.exec_timeout,
+        stream=True,
+    )
+
+
+def main() -> int:
+    load_local_dotenv()
+    args = parse_args()
+    if args.raw:
+        os.environ["CODEBUDDY_STREAM_RAW"] = "1"
+
+    template_id = args.template or required("CUBE_TEMPLATE_ID")
+    required("E2B_API_URL")
+    required("E2B_API_KEY")
+
+    provider = codebuddy_provider()
+    secret = require_provider_key(provider)
+    host = args.host or codebuddy_llm_host(provider)
+    if not host:
+        raise SystemExit(
+            "Could not resolve the LLM host. Set CODEBUDDY_LLM_HOST in your .env or pass --host."
+        )
+
+    rules = build_rules(provider, host, secret)
+
+    sandbox_env = build_codebuddy_env(include_secrets=False)
+    key_name = provider_key_name(provider)
+    sandbox_env[key_name] = PLACEHOLDER_KEY
+    # Let the Node-based CodeBuddy CLI trust the CubeEgress interception CA (see note
+    # on DEFAULT_NODE_CA_BUNDLE); without this the vault path fails TLS.
+    sandbox_env["NODE_EXTRA_CA_CERTS"] = os.environ.get(
+        "CODEBUDDY_NODE_EXTRA_CA_CERTS", DEFAULT_NODE_CA_BUNDLE
+    )
+
+    print(f"Provider: {provider}")
+    print(f"Allowed LLM host (default-deny for everything else): {host}")
+    print(f"Creating sandbox from template: {template_id}")
+
+    sandbox = create_sandbox(template_id, rules, args.sandbox_timeout)
+    sandbox_id = sandbox_identifier(sandbox)
+    result = None
+    try:
+        print(f"Sandbox ready: {sandbox_id}\n")
+
+        show_key_not_in_vm(sandbox, key_name)
+        show_non_llm_blocked(sandbox)
+
+        if args.skip_agent:
+            print("\n--skip-agent set: not invoking CodeBuddy.")
+            return 0
+
+        print("\nRunning CodeBuddy through the injected egress path...\n")
+        result = run_agent(sandbox, args, sandbox_env)
+        exit_code = getattr(result, "exit_code", None)
+        print(f"\nCodeBuddy exit code: {exit_code}")
+        return 0 if exit_code is None else int(exit_code)
+    finally:
+        try:
+            sandbox.kill()
+            print(f"\nSandbox {sandbox_id} killed.")
+        except Exception as exc:  # noqa: BLE001 - cleanup must not mask real errors
+            print(
+                f"Warning: failed to kill sandbox {sandbox_id}: {exc}",
+                file=sys.stderr,
+            )
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/examples/codebuddy-integration/requirements.txt
+++ b/examples/codebuddy-integration/requirements.txt
@@ -1,0 +1,3 @@
+e2b>=2.4.1
+cubesandbox>=0.3.0
+python-dotenv>=1.0.0

--- a/examples/codebuddy-integration/requirements.txt
+++ b/examples/codebuddy-integration/requirements.txt
@@ -1,3 +1,3 @@
-e2b>=2.4.1
-cubesandbox>=0.3.0
-python-dotenv>=1.0.0
+e2b==2.4.1
+cubesandbox==0.3.0
+python-dotenv==1.0.0

--- a/examples/codebuddy-integration/resume_codebuddy.py
+++ b/examples/codebuddy-integration/resume_codebuddy.py
@@ -187,10 +187,12 @@ def main() -> int:
 
         print(f"\nPausing sandbox {sandbox_id} (snapshotting VM + rootfs)...")
         paused_id = sandbox.pause()
+        if not paused_id:
+            raise SystemExit("Failed to pause sandbox: no snapshot ID returned")
         # The sandbox_id is stable across pause. Some SDK versions return the
         # resume handle as a string; others return a bool (success). Only adopt
         # a string handle, otherwise keep the original id for connect().
-        if isinstance(paused_id, str) and paused_id:
+        if isinstance(paused_id, str):
             sandbox_id = paused_id
         print(f"Paused. Resume handle: {sandbox_id}")
 

--- a/examples/codebuddy-integration/resume_codebuddy.py
+++ b/examples/codebuddy-integration/resume_codebuddy.py
@@ -162,10 +162,11 @@ def main() -> int:
     # key per command. The pause() snapshot also captures the in-VM env and any
     # credentials CodeBuddy caches under /root/.codebuddy, widening exposure — for
     # shared clusters prefer the default-deny + vault pattern in network_policy.py.
-    sandbox = Sandbox.create(template=template_id, timeout=args.sandbox_timeout)
-    sandbox_id = sandbox_identifier(sandbox)
-
+    sandbox = None
+    sandbox_id = "uncreated"
     try:
+        sandbox = Sandbox.create(template=template_id, timeout=args.sandbox_timeout)
+        sandbox_id = sandbox_identifier(sandbox)
         print(f"Sandbox ready: {sandbox_id}")
 
         version_result = run_command(sandbox, "codebuddy --version", timeout=60)
@@ -194,7 +195,7 @@ def main() -> int:
         print(f"Paused. Resume handle: {sandbox_id}")
 
         print(f"\nReconnecting to {sandbox_id}...")
-        sandbox = Sandbox.connect(sandbox_id=sandbox_id)
+        sandbox = Sandbox.connect(sandbox_id=sandbox_id, timeout=args.sandbox_timeout)
         print("Reconnected after resume.")
 
         print("\n=== Verifying persistence after resume ===\n")

--- a/examples/codebuddy-integration/resume_codebuddy.py
+++ b/examples/codebuddy-integration/resume_codebuddy.py
@@ -100,6 +100,7 @@ def run_turn(
     name: str,
     exec_timeout: int,
     envs: dict[str, str],
+    raw: bool = False,
 ):
     command = shell_join(
         f"cd {shlex.quote(workspace)}",
@@ -112,6 +113,7 @@ def run_turn(
         envs=envs,
         timeout=exec_timeout,
         stream=True,
+        raw=raw,
     )
 
 
@@ -146,9 +148,6 @@ def show_final_workspace(sandbox: Sandbox, workspace: str) -> None:
 def main() -> int:
     load_local_dotenv()
     args = parse_args()
-    if args.raw:
-        os.environ["CODEBUDDY_STREAM_RAW"] = "1"
-
     template_id = args.template or required("CUBE_TEMPLATE_ID")
     required("E2B_API_URL")
     required("E2B_API_KEY")
@@ -175,7 +174,13 @@ def main() -> int:
 
         print("\n=== Turn 1: create plan.md ===\n")
         result_1 = run_turn(
-            sandbox, args.workspace, turn_1_prompt, args.name, args.exec_timeout, codebuddy_env
+            sandbox,
+            args.workspace,
+            turn_1_prompt,
+            args.name,
+            args.exec_timeout,
+            codebuddy_env,
+            args.raw,
         )
         ensure_success(result_1, "run CodeBuddy turn 1")
 
@@ -197,7 +202,13 @@ def main() -> int:
 
         print("\n=== Turn 2: continue the work ===\n")
         result_2 = run_turn(
-            sandbox, args.workspace, turn_2_prompt, args.name, args.exec_timeout, codebuddy_env
+            sandbox,
+            args.workspace,
+            turn_2_prompt,
+            args.name,
+            args.exec_timeout,
+            codebuddy_env,
+            args.raw,
         )
         ensure_success(result_2, "run CodeBuddy turn 2")
 

--- a/examples/codebuddy-integration/resume_codebuddy.py
+++ b/examples/codebuddy-integration/resume_codebuddy.py
@@ -1,0 +1,221 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Demonstrate CodeBuddy coding-agent session persistence across a CubeSandbox pause/resume.
+
+Turn 1 asks CodeBuddy to write ``/workspace/plan.md``, then the sandbox is paused.
+Turn 2 reconnects to the same sandbox, verifies both ``/workspace`` and the
+CodeBuddy state directory survived the snapshot, and asks CodeBuddy to continue the work.
+
+Lifecycle note: this script deliberately avoids ``with Sandbox.create(...)``.
+A context manager kills the sandbox on ``__exit__``, which would defeat the
+pause. The lifecycle is managed manually with try/finally so the sandbox stays
+alive between turns and is only killed at the very end.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import shlex
+import sys
+
+from e2b import Sandbox
+
+from env_utils import (
+    build_codebuddy_env,
+    codebuddy_command,
+    codebuddy_provider,
+    codebuddy_workspace,
+    int_env,
+    load_local_dotenv,
+    require_provider_key,
+    required,
+    shell_join,
+)
+from _common import ensure_success, run_command, sandbox_identifier
+
+DEFAULT_CODEBUDDY_STATE_DIR = "/root/.codebuddy"
+
+TURN_1_PROMPT = (
+    "Create {workspace}/plan.md containing a numbered 3-step plan for building a "
+    "small Python CLI that prints the current time. Only write the plan file."
+)
+TURN_2_PROMPT = (
+    "Read {workspace}/plan.md and implement step 1 by creating "
+    "{workspace}/progress.md that records which step you completed and why. "
+    "Do not delete plan.md."
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Demonstrate CodeBuddy session persistence across a CubeSandbox pause/resume."
+    )
+    parser.add_argument(
+        "--template",
+        default=os.environ.get("CUBE_TEMPLATE_ID"),
+        help="CubeSandbox template ID. Defaults to CUBE_TEMPLATE_ID.",
+    )
+    parser.add_argument(
+        "--workspace",
+        default=codebuddy_workspace(),
+        help="Working directory inside the sandbox. Defaults to CODEBUDDY_WORKSPACE.",
+    )
+    parser.add_argument(
+        "--name",
+        default="cube-codebuddy-resume",
+        help="CodeBuddy session name reused across both turns to keep the conversation.",
+    )
+    parser.add_argument(
+        "--codebuddy-state-dir",
+        default=os.environ.get("CODEBUDDY_HOME", DEFAULT_CODEBUDDY_STATE_DIR),
+        help="CodeBuddy state directory checked for survival after resume.",
+    )
+    parser.add_argument(
+        "--sandbox-timeout",
+        type=int,
+        default=int_env("CODEBUDDY_SANDBOX_TIMEOUT", 1800),
+        help="Sandbox lifetime in seconds. Defaults to CODEBUDDY_SANDBOX_TIMEOUT or 1800.",
+    )
+    parser.add_argument(
+        "--exec-timeout",
+        type=int,
+        default=int_env("CODEBUDDY_EXEC_TIMEOUT", 900),
+        help="CodeBuddy command timeout in seconds. Defaults to CODEBUDDY_EXEC_TIMEOUT or 900.",
+    )
+    parser.add_argument(
+        "--raw",
+        action="store_true",
+        help="Stream CodeBuddy's raw JSONL instead of the concise transcript.",
+    )
+    return parser.parse_args()
+
+
+def run_turn(
+    sandbox: Sandbox,
+    workspace: str,
+    prompt: str,
+    name: str,
+    exec_timeout: int,
+    envs: dict[str, str],
+):
+    command = shell_join(
+        f"cd {shlex.quote(workspace)}",
+        codebuddy_command(prompt, output_format="stream-json", name=name),
+    )
+    return run_command(
+        sandbox,
+        command,
+        cwd=workspace,
+        envs=envs,
+        timeout=exec_timeout,
+        stream=True,
+    )
+
+
+def assert_state_survived(sandbox: Sandbox, workspace: str, state_dir: str) -> None:
+    quoted_workspace = shlex.quote(workspace)
+    quoted_state = shlex.quote(state_dir)
+    command = shell_join(
+        f"test -f {quoted_workspace}/plan.md",
+        f"test -d {quoted_state}",
+        "printf '\\n--- plan.md (survived pause/resume) ---\\n'",
+        f"cat {quoted_workspace}/plan.md",
+    )
+    result = run_command(sandbox, command, timeout=60)
+    ensure_success(result, "verify /workspace and CodeBuddy state survived pause/resume")
+    if getattr(result, "stdout", ""):
+        print(result.stdout)
+
+
+def show_final_workspace(sandbox: Sandbox, workspace: str) -> None:
+    quoted_workspace = shlex.quote(workspace)
+    command = shell_join(
+        f"ls -la {quoted_workspace}",
+        f"test ! -f {quoted_workspace}/progress.md || "
+        f"(printf '\\n--- progress.md ---\\n' && cat {quoted_workspace}/progress.md)",
+    )
+    result = run_command(sandbox, command, timeout=60)
+    ensure_success(result, "inspect final workspace")
+    if getattr(result, "stdout", ""):
+        print(result.stdout)
+
+
+def main() -> int:
+    load_local_dotenv()
+    args = parse_args()
+    if args.raw:
+        os.environ["CODEBUDDY_STREAM_RAW"] = "1"
+
+    template_id = args.template or required("CUBE_TEMPLATE_ID")
+    required("E2B_API_URL")
+    required("E2B_API_KEY")
+    require_provider_key(codebuddy_provider())
+
+    codebuddy_env = build_codebuddy_env()
+    turn_1_prompt = TURN_1_PROMPT.format(workspace=args.workspace)
+    turn_2_prompt = TURN_2_PROMPT.format(workspace=args.workspace)
+
+    print(f"Creating sandbox from template: {template_id}")
+    # SECURITY: like run_codebuddy.py this demo keeps egress open and injects the
+    # key per command. The pause() snapshot also captures the in-VM env and any
+    # credentials CodeBuddy caches under /root/.codebuddy, widening exposure — for
+    # shared clusters prefer the default-deny + vault pattern in network_policy.py.
+    sandbox = Sandbox.create(template=template_id, timeout=args.sandbox_timeout)
+    sandbox_id = sandbox_identifier(sandbox)
+
+    try:
+        print(f"Sandbox ready: {sandbox_id}")
+
+        version_result = run_command(sandbox, "codebuddy --version", timeout=60)
+        ensure_success(version_result, "check CodeBuddy version")
+        print(f"CodeBuddy version: {getattr(version_result, 'stdout', '').strip()}")
+
+        print("\n=== Turn 1: create plan.md ===\n")
+        result_1 = run_turn(
+            sandbox, args.workspace, turn_1_prompt, args.name, args.exec_timeout, codebuddy_env
+        )
+        ensure_success(result_1, "run CodeBuddy turn 1")
+
+        print(f"\nPausing sandbox {sandbox_id} (snapshotting VM + rootfs)...")
+        paused_id = sandbox.pause()
+        # The sandbox_id is stable across pause. Some SDK versions return the
+        # resume handle as a string; others return a bool (success). Only adopt
+        # a string handle, otherwise keep the original id for connect().
+        if isinstance(paused_id, str) and paused_id:
+            sandbox_id = paused_id
+        print(f"Paused. Resume handle: {sandbox_id}")
+
+        print(f"\nReconnecting to {sandbox_id}...")
+        sandbox = Sandbox.connect(sandbox_id=sandbox_id)
+        print("Reconnected after resume.")
+
+        print("\n=== Verifying persistence after resume ===\n")
+        assert_state_survived(sandbox, args.workspace, args.codebuddy_state_dir)
+
+        print("\n=== Turn 2: continue the work ===\n")
+        result_2 = run_turn(
+            sandbox, args.workspace, turn_2_prompt, args.name, args.exec_timeout, codebuddy_env
+        )
+        ensure_success(result_2, "run CodeBuddy turn 2")
+
+        show_final_workspace(sandbox, args.workspace)
+
+        exit_code = getattr(result_2, "exit_code", 0)
+        return 0 if exit_code is None else int(exit_code)
+    finally:
+        if sandbox is not None:
+            try:
+                sandbox.kill()
+                print(f"\nSandbox {sandbox_id} killed.")
+            except Exception as exc:  # noqa: BLE001 - cleanup must not mask real errors
+                print(
+                    f"Warning: failed to kill sandbox {sandbox_id}: {exc}",
+                    file=sys.stderr,
+                )
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/examples/codebuddy-integration/run_codebuddy.py
+++ b/examples/codebuddy-integration/run_codebuddy.py
@@ -134,9 +134,6 @@ def show_workspace_result(sandbox: Sandbox, workspace: str, timeout: int) -> Non
 def main() -> int:
     load_local_dotenv()
     args = parse_args()
-    if args.raw:
-        os.environ["CODEBUDDY_STREAM_RAW"] = "1"
-
     template_id = args.template or required("CUBE_TEMPLATE_ID")
     required("E2B_API_URL")
     required("E2B_API_KEY")
@@ -175,6 +172,7 @@ def main() -> int:
             envs=codebuddy_env,
             timeout=args.exec_timeout,
             stream=True,
+            raw=args.raw,
         )
 
         print_result_summary(result)

--- a/examples/codebuddy-integration/run_codebuddy.py
+++ b/examples/codebuddy-integration/run_codebuddy.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import argparse
+import os
+import shlex
+import sys
+
+from e2b import Sandbox
+
+from _common import ensure_success, run_command, sandbox_identifier
+from env_utils import (
+    build_codebuddy_env,
+    codebuddy_command,
+    codebuddy_model,
+    codebuddy_provider,
+    codebuddy_workspace,
+    int_env,
+    load_local_dotenv,
+    require_provider_key,
+    required,
+    shell_join,
+)
+
+DEFAULT_PROMPT_TEMPLATE = (
+    "Inspect the project in {workspace}, run python3 app.py, and write a "
+    "concise summary of the result to {workspace}/result.md."
+)
+
+
+def default_prompt(workspace: str) -> str:
+    return DEFAULT_PROMPT_TEMPLATE.format(workspace=workspace)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Run a one-shot CodeBuddy coding-agent task inside CubeSandbox."
+    )
+    parser.add_argument(
+        "--template",
+        default=os.environ.get("CUBE_TEMPLATE_ID"),
+        help="CubeSandbox template ID. Defaults to CUBE_TEMPLATE_ID.",
+    )
+    parser.add_argument(
+        "--prompt",
+        default=None,
+        help="Prompt passed to CodeBuddy. Defaults to a small workspace smoke task.",
+    )
+    parser.add_argument(
+        "--workspace",
+        default=codebuddy_workspace(),
+        help="Working directory inside the sandbox. Defaults to CODEBUDDY_WORKSPACE.",
+    )
+    parser.add_argument(
+        "--name",
+        default="cube-codebuddy-demo",
+        help="CodeBuddy session name for the one-shot run.",
+    )
+    parser.add_argument(
+        "--sandbox-timeout",
+        type=int,
+        default=int_env("CODEBUDDY_SANDBOX_TIMEOUT", 1800),
+        help="Sandbox lifetime in seconds. Defaults to CODEBUDDY_SANDBOX_TIMEOUT or 1800.",
+    )
+    parser.add_argument(
+        "--exec-timeout",
+        type=int,
+        default=int_env("CODEBUDDY_EXEC_TIMEOUT", 900),
+        help="CodeBuddy command timeout in seconds. Defaults to CODEBUDDY_EXEC_TIMEOUT or 900.",
+    )
+    parser.add_argument(
+        "--no-seed",
+        action="store_true",
+        help="Skip writing the demo files into the sandbox workspace.",
+    )
+    parser.add_argument(
+        "--raw",
+        action="store_true",
+        help="Stream CodeBuddy's raw JSONL instead of the concise transcript.",
+    )
+    args = parser.parse_args()
+    if args.prompt is None:
+        args.prompt = default_prompt(args.workspace)
+    return args
+
+
+def seed_project(sandbox: Sandbox, workspace: str, timeout: int) -> None:
+    quoted_workspace = shlex.quote(workspace)
+    command = f"""mkdir -p {quoted_workspace}
+cat > {quoted_workspace}/README.md <<'EOF'
+# CubeSandbox CodeBuddy Smoke Project
+
+This tiny project exists so the CodeBuddy coding agent has a deterministic task to run.
+EOF
+cat > {quoted_workspace}/app.py <<'EOF'
+def main() -> None:
+    print("hello from CubeSandbox + CodeBuddy")
+
+
+if __name__ == "__main__":
+    main()
+EOF
+"""
+    result = run_command(sandbox, command, timeout=timeout)
+    ensure_success(result, "seed workspace")
+
+
+def print_result_summary(result) -> None:
+    exit_code = getattr(result, "exit_code", None)
+    stderr = getattr(result, "stderr", "")
+
+    print(f"\nCodeBuddy exit code: {exit_code}")
+    if stderr:
+        print("\nCaptured stderr:", file=sys.stderr)
+        print(stderr, file=sys.stderr)
+
+
+def show_workspace_result(sandbox: Sandbox, workspace: str, timeout: int) -> None:
+    quoted_workspace = shlex.quote(workspace)
+    command = shell_join(
+        f"ls -la {quoted_workspace}",
+        f"test ! -f {quoted_workspace}/result.md || "
+        f"(printf '\\n--- result.md ---\\n' && cat {quoted_workspace}/result.md)",
+    )
+    result = run_command(sandbox, command, timeout=timeout)
+    ensure_success(result, "inspect workspace")
+    if getattr(result, "stdout", ""):
+        print(result.stdout)
+
+
+def main() -> int:
+    load_local_dotenv()
+    args = parse_args()
+    if args.raw:
+        os.environ["CODEBUDDY_STREAM_RAW"] = "1"
+
+    template_id = args.template or required("CUBE_TEMPLATE_ID")
+    required("E2B_API_URL")
+    required("E2B_API_KEY")
+    require_provider_key(codebuddy_provider())
+
+    codebuddy_env = build_codebuddy_env()
+    command = shell_join(
+        f"cd {shlex.quote(args.workspace)}",
+        codebuddy_command(args.prompt, output_format="stream-json", name=args.name),
+    )
+
+    print(f"Creating sandbox from template: {template_id}")
+    result = None
+    # SECURITY: this direct-key demo keeps egress open (allow_internet_access
+    # defaults to True) for simplicity, and injects the provider key per command
+    # via envs=. A compromised agent with open egress could exfiltrate that key.
+    # For shared/production use prefer network_policy.py, which pairs default-deny
+    # egress with the CubeEgress credential vault (the key never enters the VM).
+    with Sandbox.create(template=template_id, timeout=args.sandbox_timeout) as sandbox:
+        sandbox_id = sandbox_identifier(sandbox)
+        print(f"Sandbox ready: {sandbox_id}")
+
+        version_result = run_command(sandbox, "codebuddy --version", timeout=60)
+        ensure_success(version_result, "check CodeBuddy version")
+        print(f"CodeBuddy version: {getattr(version_result, 'stdout', '').strip()}")
+
+        if not args.no_seed:
+            seed_project(sandbox, args.workspace, timeout=60)
+            print(f"Seeded demo project in {args.workspace}")
+
+        print("\nRunning CodeBuddy task...\n")
+        result = run_command(
+            sandbox,
+            command,
+            cwd=args.workspace,
+            envs=codebuddy_env,
+            timeout=args.exec_timeout,
+            stream=True,
+        )
+
+        print_result_summary(result)
+        show_workspace_result(sandbox, args.workspace, timeout=60)
+
+    exit_code = getattr(result, "exit_code", 1)
+    return 0 if exit_code is None else int(exit_code)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/examples/codebuddy-integration/test_helpers.py
+++ b/examples/codebuddy-integration/test_helpers.py
@@ -13,6 +13,21 @@ class HelperTests(unittest.TestCase):
     def test_string_zero_exit_code_is_success(self):
         _common.ensure_success(type("Result", (), {"exit_code": "0"})(), "test")
 
+    def test_missing_exit_code_is_failure(self):
+        with self.assertRaisesRegex(SystemExit, "no exit code"):
+            _common.ensure_success(type("Result", (), {"exit_code": None})(), "test")
+
+    def test_vault_env_drops_proxy_settings(self):
+        with patch.dict(os.environ, {"HTTPS_PROXY": "http://proxy.example"}, clear=True):
+            self.assertNotIn("HTTPS_PROXY", env_utils.build_codebuddy_env(False))
+
+    def test_renderer_flushes_partial_line(self):
+        writer = _common.jsonl_render_writer()
+        with patch.object(_common, "_render_jsonl_line") as render:
+            writer("partial")
+            writer.flush()
+            render.assert_called_once_with("partial")
+
     def test_provider_is_case_insensitive(self):
         with patch.dict(os.environ, {"CODEBUDDY_PROVIDER": "OpenAI"}, clear=True):
             self.assertEqual(env_utils.codebuddy_provider(), "openai")

--- a/examples/codebuddy-integration/test_helpers.py
+++ b/examples/codebuddy-integration/test_helpers.py
@@ -1,0 +1,23 @@
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+import unittest
+from unittest.mock import patch
+
+import _common
+import env_utils
+
+
+class HelperTests(unittest.TestCase):
+    def test_string_zero_exit_code_is_success(self):
+        _common.ensure_success(type("Result", (), {"exit_code": "0"})(), "test")
+
+    def test_provider_is_case_insensitive(self):
+        with patch.dict(os.environ, {"CODEBUDDY_PROVIDER": "OpenAI"}, clear=True):
+            self.assertEqual(env_utils.codebuddy_provider(), "openai")
+            self.assertEqual(env_utils.provider_key_name(), "OPENAI_API_KEY")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/examples/opencode-integration/.env.example
+++ b/examples/opencode-integration/.env.example
@@ -1,7 +1,8 @@
 # --- CubeSandbox connection ---
 
-# Required: CubeAPI address (use CubeAPI, not CubeProxy).
-E2B_API_URL="http://<cube-host>:3000"
+# Required: TLS-protected CubeAPI address (use CubeAPI, not CubeProxy).
+# Plain HTTP is suitable only for isolated local development on loopback.
+E2B_API_URL="https://<cube-host>:3000"
 
 # Required: any non-empty value in local dev; a real key when auth is enabled.
 E2B_API_KEY="e2b_000000"

--- a/examples/opencode-integration/.env.example
+++ b/examples/opencode-integration/.env.example
@@ -1,0 +1,39 @@
+# --- CubeSandbox connection ---
+
+# Required: CubeAPI address (use CubeAPI, not CubeProxy).
+E2B_API_URL="http://<cube-host>:3000"
+
+# Required: any non-empty value in local dev; a real key when auth is enabled.
+E2B_API_KEY="e2b_000000"
+
+# Required: template built from this example's Dockerfile.
+CUBE_TEMPLATE_ID="<template-id>"
+
+# Optional: only when talking to CubeProxy over HTTPS with Cube's mkcert cert.
+# SSL_CERT_FILE="/root/.local/share/mkcert/rootCA.pem"
+
+# --- OpenCode agent ---
+
+# Required: provider and model OpenCode runs against.
+OPENCODE_PROVIDER="anthropic"
+OPENCODE_MODEL="claude-sonnet-4-6"
+
+# Required: the provider API key (only the one matching OPENCODE_PROVIDER).
+ANTHROPIC_API_KEY="<your-anthropic-api-key>"
+# Other providers (uncomment the one you use):
+# OPENAI_API_KEY="<your-openai-api-key>"
+# GEMINI_API_KEY="<your-gemini-api-key>"
+# DEEPSEEK_API_KEY="<your-deepseek-api-key>"
+
+# Optional: Anthropic-compatible endpoint.
+# ANTHROPIC_BASE_URL="https://api.deepseek.com/anthropic"
+
+# Optional: OpenCode server port (for serve mode integration).
+# OPENCODE_SERVER_PORT="4096"
+
+# Optional (network_policy.py): LLM host to allow under default-deny egress.
+# Defaults to the provider host; override only for a custom endpoint.
+# OPENCODE_LLM_HOST="api.anthropic.com"
+
+# Advanced tunables (OPENCODE_EXEC_TIMEOUT, OPENCODE_SERVER_TIMEOUT, ...)
+# have sane defaults; see env_utils.py to override.

--- a/examples/opencode-integration/.gitignore
+++ b/examples/opencode-integration/.gitignore
@@ -1,0 +1,8 @@
+.env
+.env.*
+!.env.example
+__pycache__/
+*.pyc
+*.log
+output/
+workspace-seed/

--- a/examples/opencode-integration/Dockerfile
+++ b/examples/opencode-integration/Dockerfile
@@ -24,6 +24,10 @@ ARG DEBIAN_FRONTEND=noninteractive
 ARG NODE_MAJOR=24
 ARG OPENCODE_VERSION=0.5.0
 
+ENV OPENCODE_DIR=/root/.opencode \
+    OPENCODE_TELEMETRY=0 \
+    NPM_CONFIG_UPDATE_NOTIFIER=false
+
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         bash \
@@ -43,14 +47,10 @@ RUN apt-get update \
 
 # Install OpenCode in its own layer so bumping OPENCODE_VERSION does not
 # invalidate the slow OS + Node.js layer above.
-RUN npm install -g --ignore-scripts "opencode-ai@${OPENCODE_VERSION}" \
+RUN npm install -g --ignore-scripts --no-audit --no-fund "opencode-ai@${OPENCODE_VERSION}" \
     && opencode --version \
     && npm cache clean --force \
     && rm -rf /root/.npm
-
-ENV OPENCODE_DIR=/root/.opencode \
-    OPENCODE_TELEMETRY=0 \
-    NPM_CONFIG_UPDATE_NOTIFIER=false
 
 RUN mkdir -p /workspace "${OPENCODE_DIR}"
 

--- a/examples/opencode-integration/Dockerfile
+++ b/examples/opencode-integration/Dockerfile
@@ -34,7 +34,6 @@ RUN apt-get update \
         ca-certificates \
         curl \
         git \
-        gnupg \
         jq \
         less \
         procps \

--- a/examples/opencode-integration/Dockerfile
+++ b/examples/opencode-integration/Dockerfile
@@ -1,0 +1,59 @@
+# syntax=docker/dockerfile:1.7
+#
+# OpenCode coding agent inside a CubeSandbox template.
+#
+# The image installs Node.js 24 and the opencode-ai npm package on top of the
+# official CubeSandbox base image. The inherited cube-entrypoint keeps envd
+# running on :49983 so Cube can use the standard readiness probe.
+#
+# Build:
+#   docker build -t opencode-cube:latest examples/opencode-integration
+#
+# Register as a Cube template:
+#   cubemastercli tpl create-from-image \
+#     --image <your-registry>/opencode-cube:latest \
+#     --writable-layer-size 4G \
+#     --expose-port 49983 \
+#     --probe       49983 \
+#     --probe-path  /health
+
+ARG CUBE_BASE_IMAGE=ghcr.io/tencentcloud/cubesandbox-base:2026.16
+FROM ${CUBE_BASE_IMAGE}
+
+ARG DEBIAN_FRONTEND=noninteractive
+ARG NODE_MAJOR=24
+ARG OPENCODE_VERSION=0.5.0
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        bash \
+        ca-certificates \
+        curl \
+        git \
+        gnupg \
+        jq \
+        less \
+        procps \
+        python3 \
+        python3-pip \
+        ripgrep \
+    && curl -fsSL "https://deb.nodesource.com/setup_${NODE_MAJOR}.x" | bash - \
+    && apt-get install -y --no-install-recommends nodejs \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install OpenCode in its own layer so bumping OPENCODE_VERSION does not
+# invalidate the slow OS + Node.js layer above.
+RUN npm install -g --ignore-scripts "opencode-ai@${OPENCODE_VERSION}" \
+    && opencode --version \
+    && npm cache clean --force \
+    && rm -rf /root/.npm
+
+ENV OPENCODE_DIR=/root/.opencode \
+    OPENCODE_TELEMETRY=0 \
+    NPM_CONFIG_UPDATE_NOTIFIER=false
+
+RUN mkdir -p /workspace "${OPENCODE_DIR}"
+
+WORKDIR /workspace
+
+EXPOSE 49983

--- a/examples/opencode-integration/Dockerfile
+++ b/examples/opencode-integration/Dockerfile
@@ -47,9 +47,8 @@ RUN apt-get update \
 
 # Install OpenCode in its own layer so bumping OPENCODE_VERSION does not
 # invalidate the slow OS + Node.js layer above.
-RUN npm install -g --ignore-scripts --no-audit --no-fund "opencode-ai@${OPENCODE_VERSION}" \
+RUN npm install -g --no-audit --no-fund "opencode-ai@${OPENCODE_VERSION}" \
     && opencode --version \
-    && npm cache clean --force \
     && rm -rf /root/.npm
 
 RUN mkdir -p /workspace "${OPENCODE_DIR}"

--- a/examples/opencode-integration/README.md
+++ b/examples/opencode-integration/README.md
@@ -45,7 +45,8 @@ opencode-integration/
 
 ## Prerequisites
 
-- A running CubeSandbox deployment; CubeAPI reachable at `http://<node>:3000`.
+- A running CubeSandbox deployment; CubeAPI reachable at `https://<node>:3000`.
+  Use plain HTTP only for isolated local development on loopback.
 - `cubemastercli` on `$PATH`, connected to the cluster.
 - Docker on the build workstation, plus a registry the Cube nodes can pull from.
 - An LLM provider API key (Anthropic by default; OpenAI and Google also
@@ -91,7 +92,7 @@ pip install -r requirements.txt
 
 | Variable | Where it flows | Notes |
 |---|---|---|
-| `E2B_API_URL` | Local process | CubeAPI address (`http://<node>:3000`) |
+| `E2B_API_URL` | Local process | TLS-protected CubeAPI address (`https://<node>:3000`) |
 | `E2B_API_KEY` | Local process | Any non-empty string in local dev |
 | `CUBE_TEMPLATE_ID` | `Sandbox.create(template=...)` | From step 2 |
 | `OPENCODE_PROVIDER` | OpenCode CLI | `anthropic` (default), `openai`, `google` |
@@ -169,7 +170,7 @@ allow rules or preinstall those dependencies into the template.
 | `opencode: command not found` in preflight | Template not rebuilt after CLI change | Rebuild the image, re-register the template |
 | Auth error from the provider | Key not forwarded (direct) or missing inject rule (vault) | Pass `envs={...}` or fix the rule's `sni`/`host` |
 | `403 Forbidden - CubeEgress` | Default-deny with no matching allow rule | Add the LLM host (and any extra hosts) to the rules |
-| `Connection error` / TLS failure from OpenCode on the vault path | OpenCode runs on Node, which ignores the system CA store and won't trust the CubeEgress interception CA | The script sets `NODE_EXTRA_CA_CERTS` to the system bundle; override with `OPENCODE_NODE_EXTRA_CA_CERTS` if your CA lives elsewhere |
+| `Connection error` / TLS failure from OpenCode on the vault path | OpenCode runs on Node, which ignores the system CA store and won't trust the CubeEgress interception CA | The script points `NODE_EXTRA_CA_CERTS` at the dedicated CubeEgress anchor; override with `OPENCODE_NODE_EXTRA_CA_CERTS` if your CA lives elsewhere |
 | Readiness probe timeout | Image without envd | Ensure `FROM ghcr.io/tencentcloud/cubesandbox-base:...` |
 | `pause()`/`connect()` errors | Platform too old for snapshots | Upgrade the CubeSandbox platform |
 

--- a/examples/opencode-integration/README.md
+++ b/examples/opencode-integration/README.md
@@ -1,0 +1,182 @@
+# OpenCode + CubeSandbox Example
+
+[中文文档](README_zh.md)
+
+Run [OpenCode](https://www.npmjs.com/package/opencode-ai)
+— a terminal-native AI coding agent — inside a CubeSandbox MicroVM. The agent
+edits files, runs commands, and reaches an LLM API entirely within an isolated,
+reproducible sandbox.
+
+This example ships:
+
+- A `Dockerfile` that stacks Node.js 24 + the OpenCode CLI on top of the
+  CubeSandbox base image (envd already listens on `:49983`).
+- `run_opencode.py` — a headless one-shot run inside `/workspace` using
+  `opencode run "prompt"`.
+- `resume_opencode.py` — pause/resume across two turns, proving `/workspace`
+  and OpenCode's state directory survive the snapshot.
+- `network_policy.py` — a default-deny egress policy where CubeEgress injects
+  the API key on the wire, so the key never enters the VM.
+- `env_utils.py`, `.env.example`, `requirements.txt`.
+
+OpenCode has two integration modes:
+
+1. **Headless mode** — `opencode run "prompt"` processes the prompt and exits,
+   ideal for one-shot tasks driven from a host script.
+2. **Server mode** — `opencode serve --hostname 0.0.0.0 --port 4096` starts an
+   HTTP server for SDK-based programmatic control via `@opencode-ai/sdk`.
+
+## Directory layout
+
+```
+opencode-integration/
+├── Dockerfile            # CubeSandbox template image (Node.js + OpenCode CLI)
+├── .env.example          # Copy to .env and fill in
+├── .gitignore
+├── requirements.txt      # Host driver deps (e2b, cubesandbox, python-dotenv)
+├── env_utils.py          # .env loading, provider keys, OpenCode command builder
+├── _common.py            # Shared sandbox command helpers (run/ensure/id)
+├── run_opencode.py       # One-shot OpenCode task (headless mode)
+├── resume_opencode.py    # Pause / resume session persistence
+├── network_policy.py     # Default-deny egress + on-the-wire key injection
+├── README.md             # English docs (this file)
+└── README_zh.md          # Chinese docs
+```
+
+## Prerequisites
+
+- A running CubeSandbox deployment; CubeAPI reachable at `http://<node>:3000`.
+- `cubemastercli` on `$PATH`, connected to the cluster.
+- Docker on the build workstation, plus a registry the Cube nodes can pull from.
+- An LLM provider API key (Anthropic by default; OpenAI and Google also
+  supported via `OPENCODE_PROVIDER` / `OPENCODE_MODEL`).
+- Python 3.10+ for the host driver scripts.
+
+## 1. Build the template image
+
+```bash
+docker build --platform linux/amd64 \
+  -t <your-registry>/opencode-cube:latest \
+  examples/opencode-integration
+docker push <your-registry>/opencode-cube:latest
+```
+
+The image installs `opencode-ai`, plus `git`, `python3`, `ripgrep`, `jq`, and
+cleans apt/npm caches. The OpenCode version is pinned via
+`--build-arg OPENCODE_VERSION=x.y.z`.
+
+## 2. Register as a Cube template
+
+```bash
+cubemastercli tpl create-from-image \
+  --image <your-registry>/opencode-cube:latest \
+  --writable-layer-size 4G \
+  --expose-port 49983 \
+  --probe       49983 \
+  --probe-path  /health
+
+cubemastercli tpl watch --job-id <job_id>
+```
+
+Note the `template_id` once the job reaches `READY`.
+
+## 3. Configure the host driver
+
+```bash
+cd examples/opencode-integration
+cp .env.example .env
+# fill in E2B_API_URL, CUBE_TEMPLATE_ID, and your provider key
+pip install -r requirements.txt
+```
+
+| Variable | Where it flows | Notes |
+|---|---|---|
+| `E2B_API_URL` | Local process | CubeAPI address (`http://<node>:3000`) |
+| `E2B_API_KEY` | Local process | Any non-empty string in local dev |
+| `CUBE_TEMPLATE_ID` | `Sandbox.create(template=...)` | From step 2 |
+| `OPENCODE_PROVIDER` | OpenCode CLI | `anthropic` (default), `openai`, `google` |
+| `OPENCODE_MODEL` | OpenCode CLI | Model id for the provider |
+| `ANTHROPIC_API_KEY` | `envs=...` (direct) or CubeEgress inject (vault) | Provider key |
+| `OPENCODE_LLM_HOST` | `network_policy.py` | LLM API host to allow; keep aligned with the provider |
+
+## 4. One-shot run (direct key flavor)
+
+```bash
+python run_opencode.py --prompt "Create hello.py that prints 'Hello from CubeSandbox' and run it."
+```
+
+The key is forwarded per-command via `sandbox.commands.run(..., envs=...)`, so it
+lives only for the lifetime of that exec call — never written to a persistent
+file inside the VM.
+
+> **Security:** this direct flavor leaves egress open, so a compromised agent
+> could exfiltrate the injected key. For shared clusters use the vault flavor
+> (step 6): default-deny egress + on-the-wire key injection.
+
+### Advanced: Server mode with SDK
+
+For programmatic control, start OpenCode in server mode and interact via the
+`@opencode-ai/sdk` package:
+
+```bash
+# Inside the sandbox:
+opencode serve --hostname 0.0.0.0 --port 4096 --provider anthropic --model claude-sonnet-4-6
+```
+
+The host driver can then use the SDK to create sessions, send prompts, and
+retrieve results over HTTP. This mode is useful for multi-turn conversations
+where the host wants fine-grained control over each step.
+
+## 5. Pause / resume (session persistence)
+
+```bash
+python resume_opencode.py
+```
+
+Turn 1 asks OpenCode to write `/workspace/plan.md`, then `sandbox.pause()`
+snapshots the VM. The script reconnects with
+`Sandbox.connect(sandbox_id)`, verifies `/workspace/plan.md` and OpenCode's
+state directory (`/root/.opencode`) survived, then runs turn 2 to continue
+the work. The sandbox lifecycle is managed manually with `try/finally` (not a
+context manager), so the pause is not undone by an early `kill`.
+
+## 6. Restricted egress + key vault (recommended for shared clusters)
+
+```bash
+python network_policy.py
+```
+
+- Egress is default-deny — only the LLM host (`OPENCODE_LLM_HOST`) is
+  reachable.
+- CubeEgress attaches the provider key as an HTTP header on the wire
+  (`x-api-key` for Anthropic, `Authorization: Bearer` otherwise), so
+  `printenv` inside the sandbox never shows the real key — it only sees a
+  placeholder.
+- Because OpenCode runs on Node.js (which ignores the system CA store), the
+  script sets `NODE_EXTRA_CA_CERTS` so OpenCode trusts the CubeEgress
+  interception CA; without it the vault path fails with `Connection error`.
+  Override the bundle path via `OPENCODE_NODE_EXTRA_CA_CERTS` if your image
+  keeps the CA elsewhere.
+- Any other destination returns `403 Forbidden - CubeEgress`.
+
+If the agent needs extra hosts (package registries, MCP servers), add matching
+allow rules or preinstall those dependencies into the template.
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| `opencode: command not found` in preflight | Template not rebuilt after CLI change | Rebuild the image, re-register the template |
+| Auth error from the provider | Key not forwarded (direct) or missing inject rule (vault) | Pass `envs={...}` or fix the rule's `sni`/`host` |
+| `403 Forbidden - CubeEgress` | Default-deny with no matching allow rule | Add the LLM host (and any extra hosts) to the rules |
+| `Connection error` / TLS failure from OpenCode on the vault path | OpenCode runs on Node, which ignores the system CA store and won't trust the CubeEgress interception CA | The script sets `NODE_EXTRA_CA_CERTS` to the system bundle; override with `OPENCODE_NODE_EXTRA_CA_CERTS` if your CA lives elsewhere |
+| Readiness probe timeout | Image without envd | Ensure `FROM ghcr.io/tencentcloud/cubesandbox-base:...` |
+| `pause()`/`connect()` errors | Platform too old for snapshots | Upgrade the CubeSandbox platform |
+
+## References
+
+- Integration guide: [`docs/guide/integrations/opencode.md`](../../docs/guide/integrations/opencode.md)
+- Snapshot / Clone / Rollback: [`docs/guide/snapshot-rollback-clone.md`](../../docs/guide/snapshot-rollback-clone.md)
+- Network / egress policy examples: [`examples/network-policy`](../network-policy)
+- OpenCode coding agent: <https://www.npmjs.com/package/opencode-ai>
+- OpenCode SDK: <https://www.npmjs.com/package/@opencode-ai/sdk>

--- a/examples/opencode-integration/README_zh.md
+++ b/examples/opencode-integration/README_zh.md
@@ -1,0 +1,158 @@
+# OpenCode + CubeSandbox 示例
+
+[English](README.md)
+
+在 CubeSandbox MicroVM 内运行 [OpenCode](https://www.npmjs.com/package/opencode-ai)
+（面向终端的 AI 编码 Agent）。Agent 在一个隔离、可复现的沙箱内编辑文件、执行命令并访问 LLM API。
+
+本示例包含：
+
+- 一个 `Dockerfile`：在 CubeSandbox 基础镜像上叠加 Node.js 与 OpenCode CLI（envd 已监听 `:49983`）。
+- `run_opencode.py`：使用 `opencode run "prompt"` 在 `/workspace` 内的一次性无交互运行。
+- `resume_opencode.py`：跨两轮的 pause/resume，证明 `/workspace` 与 OpenCode 状态目录在快照后仍存在。
+- `network_policy.py`：默认拒绝出网的策略，由 CubeEgress 在链路上注入 API Key，密钥不进入 VM。
+- `env_utils.py`、`.env.example`、`requirements.txt`。
+
+OpenCode 有两种集成模式：
+
+1. **无交互模式** — `opencode run "prompt"` 处理 prompt 后退出，适合宿主脚本驱动的一次性任务。
+2. **服务器模式** — `opencode serve --hostname 0.0.0.0 --port 4096` 启动 HTTP 服务器，通过 `@opencode-ai/sdk` 进行编程控制。
+
+## 目录结构
+
+```
+opencode-integration/
+├── Dockerfile            # CubeSandbox 模板镜像（Node.js + OpenCode CLI）
+├── .env.example          # 复制为 .env 并填写
+├── .gitignore
+├── requirements.txt      # 宿主端驱动依赖（e2b、cubesandbox、python-dotenv）
+├── env_utils.py          # .env 加载、provider key、OpenCode 命令构造
+├── _common.py            # 共享的沙箱命令辅助（run/ensure/id）
+├── run_opencode.py       # 一次性 OpenCode 任务（无交互模式）
+├── resume_opencode.py    # pause / resume 会话持久化
+├── network_policy.py     # 默认拒绝出网 + 链路上注入密钥
+├── README.md             # 英文文档
+└── README_zh.md          # 中文文档（本文件）
+```
+
+## 前置条件
+
+- 已部署 CubeSandbox，CubeAPI 可访问（`http://<node>:3000`）。
+- `cubemastercli` 已在 `$PATH` 且已连通集群。
+- 构建机装有 Docker，且 registry 能被 Cube 集群拉取。
+- 一个 LLM provider 的 API Key（默认 Anthropic；OpenAI 和 Google 也可通过
+  `OPENCODE_PROVIDER` / `OPENCODE_MODEL` 配置）。
+- Python 3.10+（宿主端驱动脚本）。
+
+## 1. 构建模板镜像
+
+```bash
+docker build --platform linux/amd64 \
+  -t <your-registry>/opencode-cube:latest \
+  examples/opencode-integration
+docker push <your-registry>/opencode-cube:latest
+```
+
+镜像会安装 `opencode-ai`，以及 `git`、`python3`、`ripgrep`、`jq`，并清理
+apt/npm 缓存。OpenCode 版本通过 `--build-arg OPENCODE_VERSION=x.y.z` 固定。
+
+## 2. 注册为 Cube 模板
+
+```bash
+cubemastercli tpl create-from-image \
+  --image <your-registry>/opencode-cube:latest \
+  --writable-layer-size 4G \
+  --expose-port 49983 \
+  --probe       49983 \
+  --probe-path  /health
+
+cubemastercli tpl watch --job-id <job_id>
+```
+
+任务变为 `READY` 后记下 `template_id`。
+
+## 3. 配置宿主端驱动
+
+```bash
+cd examples/opencode-integration
+cp .env.example .env
+# 填写 E2B_API_URL、CUBE_TEMPLATE_ID 以及你的 provider key
+pip install -r requirements.txt
+```
+
+| 变量 | 作用位置 | 说明 |
+|---|---|---|
+| `E2B_API_URL` | 本地进程 | CubeAPI 地址（`http://<node>:3000`） |
+| `E2B_API_KEY` | 本地进程 | 本地开发填任意非空字符串 |
+| `CUBE_TEMPLATE_ID` | `Sandbox.create(template=...)` | 来自第 2 步 |
+| `OPENCODE_PROVIDER` | OpenCode CLI | `anthropic`（默认）、`openai`、`google` |
+| `OPENCODE_MODEL` | OpenCode CLI | 对应 provider 的模型 id |
+| `ANTHROPIC_API_KEY` | `envs=...`（直连）或 CubeEgress 注入（vault） | provider 密钥 |
+| `OPENCODE_LLM_HOST` | `network_policy.py` | 放行的 LLM API host，需与 provider 对齐 |
+
+## 4. 一次性运行（直连注入密钥）
+
+```bash
+python run_opencode.py --prompt "创建 hello.py 打印 'Hello from CubeSandbox' 并运行它。"
+```
+
+密钥通过 `sandbox.commands.run(..., envs=...)` 逐命令传入，只在该命令执行期间存在，不会写入 VM 内的持久文件。
+
+> **安全：** 直连方式出网是放开的，Agent 被攻破可能外泄注入的密钥。共享集群请用保险柜方式（第 6 步）：默认拒绝出网 + 链路上注入密钥。
+
+### 进阶：服务器模式 + SDK
+
+如需编程控制，可启动 OpenCode 的服务器模式，通过 `@opencode-ai/sdk` 交互：
+
+```bash
+# 在沙箱内：
+opencode serve --hostname 0.0.0.0 --port 4096 --provider anthropic --model claude-sonnet-4-6
+```
+
+宿主端驱动可用 SDK 创建会话、发送 prompt、获取结果。该模式适合需要细粒度控制每一步的多轮对话场景。
+
+## 5. pause / resume（会话持久化）
+
+```bash
+python resume_opencode.py
+```
+
+第一轮让 OpenCode 写 `/workspace/plan.md`，随后 `sandbox.pause()` 对 VM 打快照。脚本用
+`Sandbox.connect(sandbox_id)` 恢复，校验 `/workspace/plan.md` 与 OpenCode 状态目录
+（`/root/.opencode`）仍在，再执行第二轮续写。沙箱生命周期用 `try/finally` 手动管理（不用
+context manager），避免 pause 后被过早 `kill` 掉。
+
+## 6. 受限出网 + 密钥保险柜（推荐用于共享集群）
+
+```bash
+python network_policy.py
+```
+
+- 出网默认拒绝，仅放行 LLM host（`OPENCODE_LLM_HOST`）。
+- CubeEgress 在链路上把 provider 密钥作为 HTTP 头注入（Anthropic 用 `x-api-key`，其他用
+  `Authorization: Bearer`），因此沙箱内 `printenv` 看不到真实密钥，只有占位值。
+- OpenCode 基于 Node.js（忽略系统 CA 库），脚本会设置 `NODE_EXTRA_CA_CERTS` 让 OpenCode 信任
+  CubeEgress 的拦截 CA；否则 vault 路径会以 `Connection error` 失败。若镜像里 CA 路径不同，可用
+  `OPENCODE_NODE_EXTRA_CA_CERTS` 覆盖。
+- 任何其他目的地都会返回 `403 Forbidden - CubeEgress`。
+
+若 Agent 需要访问额外主机（包镜像源、MCP 服务器等），请增加对应的放行规则，或把这些依赖预装进模板。
+
+## 排错
+
+| 现象 | 可能原因 | 处理 |
+|---|---|---|
+| preflight 报 `opencode: command not found` | CLI 变更后未重建模板 | 重建镜像并重新注册模板 |
+| provider 鉴权失败 | 密钥未传入（直连）或缺少 inject 规则（vault） | 传 `envs={...}` 或修正规则的 `sni`/`host` |
+| `403 Forbidden - CubeEgress` | 默认拒绝且无匹配放行规则 | 把 LLM host（及所需其他 host）加入规则 |
+| vault 路径下 OpenCode 报 `Connection error` / TLS 失败 | OpenCode 基于 Node，忽略系统 CA 库，不信任 CubeEgress 拦截 CA | 脚本已把 `NODE_EXTRA_CA_CERTS` 指向系统 CA 包；若 CA 在别处，用 `OPENCODE_NODE_EXTRA_CA_CERTS` 覆盖 |
+| 就绪探针超时 | 镜像缺少 envd | 确认 `FROM ghcr.io/tencentcloud/cubesandbox-base:...` |
+| `pause()`/`connect()` 报错 | 平台版本过低不支持快照 | 升级 CubeSandbox 平台 |
+
+## 参考
+
+- 集成指南：[`docs/zh/guide/integrations/opencode.md`](../../docs/zh/guide/integrations/opencode.md)
+- 快照 / 克隆 / 回滚：[`docs/guide/snapshot-rollback-clone.md`](../../docs/guide/snapshot-rollback-clone.md)
+- 网络 / 出网策略示例：[`examples/network-policy`](../network-policy)
+- OpenCode coding agent：<https://www.npmjs.com/package/opencode-ai>
+- OpenCode SDK：<https://www.npmjs.com/package/@opencode-ai/sdk>

--- a/examples/opencode-integration/README_zh.md
+++ b/examples/opencode-integration/README_zh.md
@@ -37,7 +37,8 @@ opencode-integration/
 
 ## 前置条件
 
-- 已部署 CubeSandbox，CubeAPI 可访问（`http://<node>:3000`）。
+- 已部署 CubeSandbox，CubeAPI 可通过 TLS 访问（`https://<node>:3000`）。
+  明文 HTTP 只适用于隔离的本地回环开发环境。
 - `cubemastercli` 已在 `$PATH` 且已连通集群。
 - 构建机装有 Docker，且 registry 能被 Cube 集群拉取。
 - 一个 LLM provider 的 API Key（默认 Anthropic；OpenAI 和 Google 也可通过
@@ -82,7 +83,7 @@ pip install -r requirements.txt
 
 | 变量 | 作用位置 | 说明 |
 |---|---|---|
-| `E2B_API_URL` | 本地进程 | CubeAPI 地址（`http://<node>:3000`） |
+| `E2B_API_URL` | 本地进程 | 启用 TLS 的 CubeAPI 地址（`https://<node>:3000`） |
 | `E2B_API_KEY` | 本地进程 | 本地开发填任意非空字符串 |
 | `CUBE_TEMPLATE_ID` | `Sandbox.create(template=...)` | 来自第 2 步 |
 | `OPENCODE_PROVIDER` | OpenCode CLI | `anthropic`（默认）、`openai`、`google` |
@@ -145,7 +146,7 @@ python network_policy.py
 | preflight 报 `opencode: command not found` | CLI 变更后未重建模板 | 重建镜像并重新注册模板 |
 | provider 鉴权失败 | 密钥未传入（直连）或缺少 inject 规则（vault） | 传 `envs={...}` 或修正规则的 `sni`/`host` |
 | `403 Forbidden - CubeEgress` | 默认拒绝且无匹配放行规则 | 把 LLM host（及所需其他 host）加入规则 |
-| vault 路径下 OpenCode 报 `Connection error` / TLS 失败 | OpenCode 基于 Node，忽略系统 CA 库，不信任 CubeEgress 拦截 CA | 脚本已把 `NODE_EXTRA_CA_CERTS` 指向系统 CA 包；若 CA 在别处，用 `OPENCODE_NODE_EXTRA_CA_CERTS` 覆盖 |
+| vault 路径下 OpenCode 报 `Connection error` / TLS 失败 | OpenCode 基于 Node，忽略系统 CA 库，不信任 CubeEgress 拦截 CA | 脚本已把 `NODE_EXTRA_CA_CERTS` 指向专用 CubeEgress CA；若 CA 在别处，用 `OPENCODE_NODE_EXTRA_CA_CERTS` 覆盖 |
 | 就绪探针超时 | 镜像缺少 envd | 确认 `FROM ghcr.io/tencentcloud/cubesandbox-base:...` |
 | `pause()`/`connect()` 报错 | 平台版本过低不支持快照 | 升级 CubeSandbox 平台 |
 

--- a/examples/opencode-integration/README_zh.md
+++ b/examples/opencode-integration/README_zh.md
@@ -153,7 +153,7 @@ python network_policy.py
 ## 参考
 
 - 集成指南：[`docs/zh/guide/integrations/opencode.md`](../../docs/zh/guide/integrations/opencode.md)
-- 快照 / 克隆 / 回滚：[`docs/guide/snapshot-rollback-clone.md`](../../docs/guide/snapshot-rollback-clone.md)
+- 快照 / 克隆 / 回滚：[`docs/zh/guide/snapshot-rollback-clone.md`](../../docs/zh/guide/snapshot-rollback-clone.md)
 - 网络 / 出网策略示例：[`examples/network-policy`](../network-policy)
 - OpenCode coding agent：<https://www.npmjs.com/package/opencode-ai>
 - OpenCode SDK：<https://www.npmjs.com/package/@opencode-ai/sdk>

--- a/examples/opencode-integration/_common.py
+++ b/examples/opencode-integration/_common.py
@@ -59,7 +59,7 @@ def run_command(
 
 def ensure_success(result, action: str) -> None:
     exit_code = getattr(result, "exit_code", None)
-    if exit_code not in (None, 0):
+    if exit_code is not None and int(exit_code) != 0:
         stdout = getattr(result, "stdout", "")
         stderr = getattr(result, "stderr", "")
         raise SystemExit(

--- a/examples/opencode-integration/_common.py
+++ b/examples/opencode-integration/_common.py
@@ -1,0 +1,71 @@
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared sandbox command helpers for the OpenCode example scripts.
+
+Kept SDK-agnostic (duck-typed on ``sandbox.commands.run`` and the result's
+attributes) so the same helpers work with both the e2b-compatible SDK used by
+``run_opencode.py`` / ``resume_opencode.py`` and the native ``cubesandbox`` SDK
+used by ``network_policy.py``.
+"""
+
+from __future__ import annotations
+
+import sys
+from collections.abc import Callable
+from typing import Any
+
+
+def stream_writer(stream) -> Callable[[object], None]:
+    def write(chunk: object) -> None:
+        text = getattr(chunk, "line", chunk)
+        stream.write(str(text))
+        stream.flush()
+
+    return write
+
+
+def run_command(
+    sandbox: Any,
+    command: str,
+    *,
+    cwd: str | None = None,
+    envs: dict[str, str] | None = None,
+    timeout: int | float | None = None,
+    stream: bool = False,
+    user: str = "root",
+):
+    # Run as root: /workspace and OpenCode's state dir (/root/.opencode) are
+    # root-owned, and the default e2b exec user ("user") cannot write to them.
+    kwargs = {"cwd": cwd, "timeout": timeout, "user": user}
+    kwargs = {key: value for key, value in kwargs.items() if value is not None}
+    if envs:
+        kwargs["envs"] = envs
+    if stream:
+        kwargs["on_stdout"] = stream_writer(sys.stdout)
+        kwargs["on_stderr"] = stream_writer(sys.stderr)
+
+    try:
+        return sandbox.commands.run(command, **kwargs)
+    except TypeError as exc:
+        # Older SDKs name the parameter ``env`` instead of ``envs``. Only retry
+        # for that specific signature mismatch; re-raise any other TypeError so
+        # real bugs (e.g. a wrong-type command or timeout) are not masked.
+        if "envs" not in kwargs or "envs" not in str(exc):
+            raise
+        kwargs["env"] = kwargs.pop("envs")
+        return sandbox.commands.run(command, **kwargs)
+
+
+def ensure_success(result, action: str) -> None:
+    exit_code = getattr(result, "exit_code", None)
+    if exit_code not in (None, 0):
+        stdout = getattr(result, "stdout", "")
+        stderr = getattr(result, "stderr", "")
+        raise SystemExit(
+            f"Failed to {action} (exit {exit_code}).\nSTDOUT:\n{stdout}\nSTDERR:\n{stderr}"
+        )
+
+
+def sandbox_identifier(sandbox: Any) -> str:
+    return getattr(sandbox, "sandbox_id", getattr(sandbox, "id", "unknown"))

--- a/examples/opencode-integration/_common.py
+++ b/examples/opencode-integration/_common.py
@@ -61,22 +61,30 @@ def _render_stream_json_line(line: str) -> None:
     print(line)
 
 
-def stream_json_render_writer() -> Callable[[object], None]:
-    buffer = {"parts": []}
+class _BufferedJSONWriter:
+    def __init__(self) -> None:
+        self.parts: list[str] = []
 
-    def write(chunk: object) -> None:
+    def __call__(self, chunk: object) -> None:
         text = getattr(chunk, "line", chunk)
         text = text if isinstance(text, str) else str(text)
         lines = text.split("\n")
         if len(lines) == 1:
-            buffer["parts"].append(text)
+            self.parts.append(text)
             return
-        _render_stream_json_line("".join(buffer["parts"]) + lines[0])
+        _render_stream_json_line("".join(self.parts) + lines[0])
         for line in lines[1:-1]:
             _render_stream_json_line(line)
-        buffer["parts"] = [lines[-1]]
+        self.parts = [lines[-1]]
 
-    return write
+    def flush(self) -> None:
+        if self.parts:
+            _render_stream_json_line("".join(self.parts))
+            self.parts.clear()
+
+
+def stream_json_render_writer() -> Callable[[object], None]:
+    return _BufferedJSONWriter()
 
 
 def run_command(
@@ -96,30 +104,37 @@ def run_command(
     kwargs = {key: value for key, value in kwargs.items() if value is not None}
     if envs:
         kwargs["envs"] = envs
+    stdout_writer = None
     if stream:
         if raw is None:
             raw = os.environ.get("OPENCODE_STREAM_RAW", "").strip().lower() in (
                 "1", "true", "yes",
             )
-        kwargs["on_stdout"] = stream_writer(sys.stdout) if raw else stream_json_render_writer()
+        stdout_writer = stream_writer(sys.stdout) if raw else stream_json_render_writer()
+        kwargs["on_stdout"] = stdout_writer
         kwargs["on_stderr"] = stream_writer(sys.stderr)
 
     try:
-        return sandbox.commands.run(command, **kwargs)
-    except TypeError as exc:
-        # Older SDKs name the parameter ``env`` instead of ``envs``. Only retry
-        # for that specific signature mismatch; re-raise any other TypeError so
-        # real bugs (e.g. a wrong-type command or timeout) are not masked.
-        if "envs" not in kwargs or "envs" not in str(exc):
-            raise
-        kwargs["env"] = kwargs.pop("envs")
-        return sandbox.commands.run(command, **kwargs)
+        try:
+            return sandbox.commands.run(command, **kwargs)
+        except TypeError as exc:
+            # Older SDKs name the parameter ``env`` instead of ``envs``. Only retry
+            # for that specific signature mismatch; re-raise any other TypeError so
+            # real bugs (e.g. a wrong-type command or timeout) are not masked.
+            if "envs" not in kwargs or "envs" not in str(exc):
+                raise
+            kwargs["env"] = kwargs.pop("envs")
+            return sandbox.commands.run(command, **kwargs)
+    finally:
+        flush = getattr(stdout_writer, "flush", None)
+        if flush:
+            flush()
 
 
 def ensure_success(result, action: str) -> None:
     exit_code = getattr(result, "exit_code", None)
     if exit_code is None:
-        return
+        raise SystemExit(f"Failed to {action}: command returned no exit code")
     try:
         code = int(exit_code)
     except (TypeError, ValueError) as exc:

--- a/examples/opencode-integration/_common.py
+++ b/examples/opencode-integration/_common.py
@@ -11,6 +11,8 @@ used by ``network_policy.py``.
 
 from __future__ import annotations
 
+import json
+import os
 import sys
 from collections.abc import Callable
 from typing import Any
@@ -25,6 +27,58 @@ def stream_writer(stream) -> Callable[[object], None]:
     return write
 
 
+def _render_stream_json_line(line: str) -> None:
+    """Render one OpenCode JSON event, falling back to the original line."""
+    line = line.rstrip("\r\n")
+    if not line.strip():
+        return
+    try:
+        event = json.loads(line)
+    except (ValueError, TypeError):
+        print(line)
+        return
+    if not isinstance(event, dict):
+        print(line)
+        return
+
+    part = event.get("part")
+    payload = part if isinstance(part, dict) else event
+    event_type = str(payload.get("type", event.get("type", "")))
+    if event_type in ("text", "assistant", "message"):
+        text = payload.get("text", payload.get("content", ""))
+        if isinstance(text, str) and text.strip():
+            print(text.strip())
+            return
+    if event_type in ("tool", "tool_use", "tool-call"):
+        name = payload.get("tool", payload.get("name", "tool"))
+        print(f"  -> [tool] {name}")
+        return
+    if event_type in ("error", "failed"):
+        message = payload.get("error", payload.get("message", payload))
+        print(f"  [error] {str(message)[:300]}")
+        return
+    # Preserve unfamiliar events so new OpenCode versions remain observable.
+    print(line)
+
+
+def stream_json_render_writer() -> Callable[[object], None]:
+    buffer = {"parts": []}
+
+    def write(chunk: object) -> None:
+        text = getattr(chunk, "line", chunk)
+        text = text if isinstance(text, str) else str(text)
+        lines = text.split("\n")
+        if len(lines) == 1:
+            buffer["parts"].append(text)
+            return
+        _render_stream_json_line("".join(buffer["parts"]) + lines[0])
+        for line in lines[1:-1]:
+            _render_stream_json_line(line)
+        buffer["parts"] = [lines[-1]]
+
+    return write
+
+
 def run_command(
     sandbox: Any,
     command: str,
@@ -33,6 +87,7 @@ def run_command(
     envs: dict[str, str] | None = None,
     timeout: int | float | None = None,
     stream: bool = False,
+    raw: bool | None = None,
     user: str = "root",
 ):
     # Run as root: /workspace and OpenCode's state dir (/root/.opencode) are
@@ -42,7 +97,11 @@ def run_command(
     if envs:
         kwargs["envs"] = envs
     if stream:
-        kwargs["on_stdout"] = stream_writer(sys.stdout)
+        if raw is None:
+            raw = os.environ.get("OPENCODE_STREAM_RAW", "").strip().lower() in (
+                "1", "true", "yes",
+            )
+        kwargs["on_stdout"] = stream_writer(sys.stdout) if raw else stream_json_render_writer()
         kwargs["on_stderr"] = stream_writer(sys.stderr)
 
     try:
@@ -59,7 +118,13 @@ def run_command(
 
 def ensure_success(result, action: str) -> None:
     exit_code = getattr(result, "exit_code", None)
-    if exit_code is not None and int(exit_code) != 0:
+    if exit_code is None:
+        return
+    try:
+        code = int(exit_code)
+    except (TypeError, ValueError) as exc:
+        raise SystemExit(f"Cannot parse exit code {exit_code!r} for: {action}") from exc
+    if code != 0:
         stdout = getattr(result, "stdout", "")
         stderr = getattr(result, "stderr", "")
         raise SystemExit(

--- a/examples/opencode-integration/env_utils.py
+++ b/examples/opencode-integration/env_utils.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import os
 import shlex
+import warnings
 from pathlib import Path
 from urllib.parse import urlparse
 
@@ -136,6 +137,12 @@ def build_opencode_env(include_secrets: bool = True) -> dict[str, str]:
     provider key rides the wire via egress injection, so it must never enter
     the sandbox environment.
     """
+    if include_secrets and any(os.environ.get(name) for name in ("HTTP_PROXY", "HTTPS_PROXY")):
+        warnings.warn(
+            "Direct-key mode forwards proxy settings; the proxy can observe LLM traffic and credentials.",
+            RuntimeWarning,
+            stacklevel=2,
+        )
     env = {
         "OPENCODE_DIR": optional("OPENCODE_DIR", DEFAULT_OPENCODE_DIR),
         "OPENCODE_TELEMETRY": optional("OPENCODE_TELEMETRY", "0"),

--- a/examples/opencode-integration/env_utils.py
+++ b/examples/opencode-integration/env_utils.py
@@ -234,7 +234,7 @@ def opencode_run_command(
 
 
 def opencode_serve_command(
-    *, hostname: str = "0.0.0.0", port: int = 4096,
+    *, hostname: str = "127.0.0.1", port: int = 4096,
     provider: str | None = None, model: str | None = None,
 ) -> str:
     """Build an OpenCode serve invocation for SDK-based integration.

--- a/examples/opencode-integration/env_utils.py
+++ b/examples/opencode-integration/env_utils.py
@@ -33,6 +33,7 @@ PROVIDER_DEFAULT_MODEL = {
 }
 
 PASSTHROUGH_ENV_NAMES = (
+    "ANTHROPIC_BASE_URL",
     "HTTP_PROXY",
     "HTTPS_PROXY",
     "NO_PROXY",
@@ -41,10 +42,7 @@ PASSTHROUGH_ENV_NAMES = (
 
 def load_local_dotenv() -> None:
     """Best-effort load of a nearby .env file without overriding real env vars."""
-    candidate_paths = [
-        Path(__file__).with_name(".env"),
-        Path.cwd() / ".env",
-    ]
+    candidate_paths = [Path(__file__).with_name(".env")]
 
     seen_paths: set[Path] = set()
     for path in candidate_paths:
@@ -160,12 +158,19 @@ def build_opencode_env(include_secrets: bool = True) -> dict[str, str]:
 def opencode_llm_host(provider: str | None = None) -> str:
     """Resolve the LLM API host that OpenCode must reach.
 
-    Precedence: explicit ``OPENCODE_LLM_HOST`` > the provider default.
+    Precedence: explicit ``OPENCODE_LLM_HOST`` > host parsed from
+    ``ANTHROPIC_BASE_URL`` for Anthropic > the provider default.
     """
     provider_name = (provider or opencode_provider()).strip().lower()
     explicit = os.environ.get("OPENCODE_LLM_HOST")
     if explicit:
         return _host_from_url(explicit)
+    if provider_name == "anthropic":
+        base_url = os.environ.get("ANTHROPIC_BASE_URL")
+        if base_url:
+            host = _host_from_url(base_url)
+            if host:
+                return host
     return PROVIDER_DEFAULT_HOST.get(provider_name, "")
 
 

--- a/examples/opencode-integration/env_utils.py
+++ b/examples/opencode-integration/env_utils.py
@@ -35,6 +35,7 @@ PROVIDER_DEFAULT_MODEL = {
 
 PASSTHROUGH_ENV_NAMES = (
     "ANTHROPIC_BASE_URL",
+    "ANTHROPIC_MODEL",
     "HTTP_PROXY",
     "HTTPS_PROXY",
     "NO_PROXY",
@@ -90,6 +91,10 @@ def opencode_model() -> str:
     explicit = os.environ.get("OPENCODE_MODEL")
     if explicit:
         return explicit
+    if provider == "anthropic":
+        anthropic_model = os.environ.get("ANTHROPIC_MODEL")
+        if anthropic_model:
+            return anthropic_model
     default = PROVIDER_DEFAULT_MODEL.get(provider)
     if default:
         return default

--- a/examples/opencode-integration/env_utils.py
+++ b/examples/opencode-integration/env_utils.py
@@ -1,0 +1,241 @@
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import os
+import shlex
+from pathlib import Path
+from urllib.parse import urlparse
+
+from dotenv import load_dotenv
+
+DEFAULT_OPENCODE_DIR = "/root/.opencode"
+DEFAULT_WORKSPACE = "/workspace"
+
+PROVIDER_KEY_ENV = {
+    "anthropic": "ANTHROPIC_API_KEY",
+    "openai": "OPENAI_API_KEY",
+    "google": "GEMINI_API_KEY",
+}
+
+PROVIDER_DEFAULT_HOST = {
+    "anthropic": "api.anthropic.com",
+    "openai": "api.openai.com",
+    "google": "generativelanguage.googleapis.com",
+}
+
+# Only Anthropic ships a default model; other providers must set OPENCODE_MODEL
+# explicitly (model IDs are provider-specific and change often), so we fail
+# loudly instead of sending a Claude model name to, say, OpenAI.
+PROVIDER_DEFAULT_MODEL = {
+    "anthropic": "claude-sonnet-4-6",
+}
+
+PASSTHROUGH_ENV_NAMES = (
+    "HTTP_PROXY",
+    "HTTPS_PROXY",
+    "NO_PROXY",
+)
+
+
+def load_local_dotenv() -> None:
+    """Best-effort load of a nearby .env file without overriding real env vars."""
+    candidate_paths = [
+        Path(__file__).with_name(".env"),
+        Path.cwd() / ".env",
+    ]
+
+    seen_paths: set[Path] = set()
+    for path in candidate_paths:
+        resolved_path = path.resolve()
+        if resolved_path in seen_paths:
+            continue
+        seen_paths.add(resolved_path)
+
+        if path.is_file():
+            load_dotenv(dotenv_path=path, override=False)
+            return
+
+
+def required(name: str) -> str:
+    value = os.environ.get(name)
+    if not value:
+        raise SystemExit(f"Missing required environment variable: {name}")
+    return value
+
+
+def optional(name: str, default: str = "") -> str:
+    return os.environ.get(name) or default
+
+
+def int_env(name: str, default: int) -> int:
+    raw = os.environ.get(name)
+    if not raw:
+        return default
+    try:
+        return int(raw)
+    except ValueError as exc:
+        raise SystemExit(f"{name} must be an integer, got {raw!r}") from exc
+
+
+def opencode_provider() -> str:
+    # Normalize case so every downstream comparison and dict lookup
+    # (provider_inject, PROVIDER_DEFAULT_HOST, key candidates, ...) is
+    # case-insensitive; "Anthropic" and "anthropic" must behave the same.
+    return optional("OPENCODE_PROVIDER", "anthropic").strip().lower()
+
+
+def opencode_model() -> str:
+    provider = opencode_provider()
+    explicit = os.environ.get("OPENCODE_MODEL")
+    if explicit:
+        return explicit
+    default = PROVIDER_DEFAULT_MODEL.get(provider)
+    if default:
+        return default
+    raise SystemExit(
+        f"No default model for provider {provider!r}. Set OPENCODE_MODEL in your .env "
+        "(model IDs are provider-specific; there is no safe cross-provider default)."
+    )
+
+
+def opencode_workspace() -> str:
+    return optional("OPENCODE_WORKSPACE", DEFAULT_WORKSPACE)
+
+
+def provider_key_name(provider: str | None = None) -> str:
+    provider_name = provider or opencode_provider()
+    names = provider_key_candidates(provider_name)
+    for name in names:
+        if os.environ.get(name):
+            return name
+    return names[0]
+
+
+def require_provider_key(provider: str | None = None) -> str:
+    provider_name = provider or opencode_provider()
+    names = provider_key_candidates(provider_name)
+    for name in names:
+        value = os.environ.get(name)
+        if value:
+            return value
+    raise SystemExit(
+        "Missing required environment variable: one of " + ", ".join(names)
+    )
+
+
+def provider_key_candidates(provider: str) -> tuple[str, ...]:
+    provider = provider.strip().lower()
+    default_name = PROVIDER_KEY_ENV.get(provider, f"{provider.upper()}_API_KEY")
+    return (default_name,)
+
+
+def build_opencode_env(include_secrets: bool = True) -> dict[str, str]:
+    """Build the env map passed to the OpenCode command inside the sandbox.
+
+    Set ``include_secrets=False`` for the CubeEgress vault flavor: the real
+    provider key rides the wire via egress injection, so it must never enter
+    the sandbox environment.
+    """
+    env = {
+        "OPENCODE_DIR": optional("OPENCODE_DIR", DEFAULT_OPENCODE_DIR),
+        "OPENCODE_TELEMETRY": optional("OPENCODE_TELEMETRY", "0"),
+    }
+    for name in PASSTHROUGH_ENV_NAMES:
+        value = os.environ.get(name)
+        if value:
+            env[name] = value
+    if include_secrets:
+        # Forward ONLY the active provider's key(s), never every known secret —
+        # a host with several provider keys (e.g. a CI matrix) must not leak all
+        # of them into the sandbox.
+        for name in provider_key_candidates(opencode_provider()):
+            value = os.environ.get(name)
+            if value:
+                env[name] = value
+    return env
+
+
+def opencode_llm_host(provider: str | None = None) -> str:
+    """Resolve the LLM API host that OpenCode must reach.
+
+    Precedence: explicit ``OPENCODE_LLM_HOST`` > the provider default.
+    """
+    provider_name = (provider or opencode_provider()).strip().lower()
+    explicit = os.environ.get("OPENCODE_LLM_HOST")
+    if explicit:
+        return _host_from_url(explicit)
+    return PROVIDER_DEFAULT_HOST.get(provider_name, "")
+
+
+def _host_from_url(value: str) -> str:
+    candidate = value.strip()
+    if not candidate:
+        return ""
+    if "://" not in candidate:
+        candidate = f"https://{candidate}"
+    return urlparse(candidate).hostname or ""
+
+
+def provider_inject(provider: str, secret: str) -> list[dict[str, str]]:
+    """CubeEgress credential-injection specs for a provider's auth header(s).
+
+    Each dict maps directly to a ``cubesandbox.Inject(header=..., secret=...,
+    format=...)``. CubeEgress attaches these headers to matched outbound
+    requests, so the real key rides the wire and never enters the sandbox VM.
+    ``format`` defaults to ``${SECRET}`` (raw secret); bearer schemes use
+    ``Bearer ${SECRET}``. Anthropic uses ``x-api-key`` plus the required
+    API-version header; every other provider uses ``Authorization: Bearer``.
+    """
+    if provider.strip().lower() == "anthropic":
+        return [
+            {"header": "x-api-key", "secret": secret, "format": "${SECRET}"},
+            {"header": "anthropic-version", "secret": "2023-06-01", "format": "${SECRET}"},
+        ]
+    return [{"header": "Authorization", "secret": secret, "format": "Bearer ${SECRET}"}]
+
+
+def opencode_run_command(
+    prompt: str, *, provider: str | None = None, model: str | None = None
+) -> str:
+    """Build a headless (non-interactive) OpenCode invocation.
+
+    ``opencode run "prompt"`` makes OpenCode process the prompt and exit
+    instead of launching an interactive session. The prompt is passed as the
+    positional argument to the ``run`` subcommand.
+    """
+    args = ["opencode", "run"]
+    p = provider or opencode_provider()
+    m = model or opencode_model()
+    if p:
+        args.extend(["--provider", p])
+    if m:
+        args.extend(["--model", m])
+    args.append(prompt)
+    return " ".join(shlex.quote(arg) for arg in args)
+
+
+def opencode_serve_command(
+    *, hostname: str = "0.0.0.0", port: int = 4096,
+    provider: str | None = None, model: str | None = None,
+) -> str:
+    """Build an OpenCode serve invocation for SDK-based integration.
+
+    ``opencode serve --hostname 0.0.0.0 --port 4096`` starts an HTTP server
+    that the ``@opencode-ai/sdk`` can connect to for programmatic control.
+    """
+    args = ["opencode", "serve"]
+    args.extend(["--hostname", hostname])
+    args.extend(["--port", str(port)])
+    p = provider or opencode_provider()
+    m = model or opencode_model()
+    if p:
+        args.extend(["--provider", p])
+    if m:
+        args.extend(["--model", m])
+    return " ".join(shlex.quote(arg) for arg in args)
+
+
+def shell_join(*parts: str) -> str:
+    return " && ".join(part for part in parts if part)

--- a/examples/opencode-integration/env_utils.py
+++ b/examples/opencode-integration/env_utils.py
@@ -40,6 +40,7 @@ PASSTHROUGH_ENV_NAMES = (
     "HTTPS_PROXY",
     "NO_PROXY",
 )
+PROXY_ENV_NAMES = ("HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY")
 
 
 def load_local_dotenv() -> None:
@@ -66,6 +67,7 @@ def required(name: str) -> str:
 
 
 def optional(name: str, default: str = "") -> str:
+    """Return the configured non-empty value, otherwise ``default``."""
     return os.environ.get(name) or default
 
 
@@ -153,6 +155,8 @@ def build_opencode_env(include_secrets: bool = True) -> dict[str, str]:
         "OPENCODE_TELEMETRY": optional("OPENCODE_TELEMETRY", "0"),
     }
     for name in PASSTHROUGH_ENV_NAMES:
+        if not include_secrets and name in PROXY_ENV_NAMES:
+            continue
         value = os.environ.get(name)
         if value:
             env[name] = value

--- a/examples/opencode-integration/env_utils.py
+++ b/examples/opencode-integration/env_utils.py
@@ -238,7 +238,7 @@ def opencode_run_command(
 
 
 def opencode_serve_command(
-    *, hostname: str = "127.0.0.1", port: int = 4096,
+    *, hostname: str = "127.0.0.1", port: int | None = None,
     provider: str | None = None, model: str | None = None,
 ) -> str:
     """Build an OpenCode serve invocation for SDK-based integration.
@@ -246,6 +246,8 @@ def opencode_serve_command(
     ``opencode serve --hostname 0.0.0.0 --port 4096`` starts an HTTP server
     that the ``@opencode-ai/sdk`` can connect to for programmatic control.
     """
+    if port is None:
+        port = int_env("OPENCODE_SERVER_PORT", 4096)
     args = ["opencode", "serve"]
     args.extend(["--hostname", hostname])
     args.extend(["--port", str(port)])

--- a/examples/opencode-integration/network_policy.py
+++ b/examples/opencode-integration/network_policy.py
@@ -1,0 +1,233 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Restrict OpenCode's egress to the LLM API and inject the key on the wire.
+
+This is the recommended production ("credential vault") pattern:
+
+* Default-deny egress — the sandbox is created with ``allow_internet_access=False``
+  and an ``allow_out`` list containing only the LLM API host, so every other
+  destination is dropped before it can leave the sandbox.
+* The provider auth header is attached by CubeEgress via ``inject`` rules
+  (native ``cubesandbox`` SDK; see docs/guide/security-proxy.md), so the real
+  key rides the wire and never enters the sandbox VM. The agent inside only
+  sees a placeholder value.
+
+Run:
+    python network_policy.py
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import shlex
+import sys
+
+from cubesandbox import Sandbox, Rule, Match, Action, Inject
+
+from env_utils import (
+    build_opencode_env,
+    int_env,
+    load_local_dotenv,
+    opencode_llm_host,
+    opencode_provider,
+    opencode_run_command,
+    opencode_workspace,
+    provider_inject,
+    provider_key_name,
+    require_provider_key,
+    required,
+    shell_join,
+)
+from _common import ensure_success, run_command, sandbox_identifier
+
+PLACEHOLDER_KEY = "cube-egress-managed-placeholder"
+
+# OpenCode runs on Node.js, which uses its own bundled CA store and ignores the
+# system trust store. On the vault path CubeEgress terminates TLS to inject the
+# credential, so Node must trust the CubeEgress root CA or every LLM call fails
+# with "Connection error". Point NODE_EXTRA_CA_CERTS at a bundle that includes
+# it; the CubeSandbox base image installs the CA into the system bundle below.
+DEFAULT_NODE_CA_BUNDLE = "/etc/ssl/certs/ca-certificates.crt"
+
+DEFAULT_PROMPT = (
+    "Reply with a single short sentence confirming you can reach the LLM API, "
+    "then write that sentence to {workspace}/egress_check.md."
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Run OpenCode under a default-deny egress policy with on-the-wire key injection."
+    )
+    parser.add_argument(
+        "--template",
+        default=os.environ.get("CUBE_TEMPLATE_ID"),
+        help="CubeSandbox template ID. Defaults to CUBE_TEMPLATE_ID.",
+    )
+    parser.add_argument(
+        "--host",
+        default=None,
+        help="LLM API host to allow. Defaults to OPENCODE_LLM_HOST or the provider default.",
+    )
+    parser.add_argument(
+        "--workspace",
+        default=opencode_workspace(),
+        help="Working directory inside the sandbox. Defaults to OPENCODE_WORKSPACE.",
+    )
+    parser.add_argument(
+        "--prompt",
+        default=None,
+        help="Prompt passed to OpenCode. Defaults to a small egress reachability check.",
+    )
+    parser.add_argument(
+        "--sandbox-timeout",
+        type=int,
+        default=int_env("OPENCODE_SANDBOX_TIMEOUT", 1800),
+        help="Sandbox lifetime in seconds. Defaults to OPENCODE_SANDBOX_TIMEOUT or 1800.",
+    )
+    parser.add_argument(
+        "--exec-timeout",
+        type=int,
+        default=int_env("OPENCODE_EXEC_TIMEOUT", 900),
+        help="OpenCode command timeout in seconds. Defaults to OPENCODE_EXEC_TIMEOUT or 900.",
+    )
+    parser.add_argument(
+        "--skip-agent",
+        action="store_true",
+        help="Only show the egress checks; skip the actual OpenCode run.",
+    )
+    args = parser.parse_args()
+    if args.prompt is None:
+        args.prompt = DEFAULT_PROMPT.format(workspace=args.workspace)
+    return args
+
+
+def build_rules(provider: str, host: str, secret: str) -> list[Rule]:
+    # Canonical CubeEgress rule (see docs/guide/security-proxy.md): allow the LLM
+    # host and attach the provider auth header(s) on the wire via ``inject`` so
+    # the real key never enters the sandbox VM. Anything matching no rule under
+    # default-deny is rejected by CubeEgress with 403.
+    return [
+        Rule(
+            name=f"allow_{provider}_llm",
+            match=Match(scheme="https", sni=host, host=host),
+            action=Action(
+                allow=True,
+                audit="metadata",
+                inject=[Inject(**spec) for spec in provider_inject(provider, secret)],
+            ),
+        )
+    ]
+
+
+def create_sandbox(template_id: str, rules: list[Rule], timeout: int) -> Sandbox:
+    # allow_internet_access=False makes egress default-deny at L3/L4; the LLM host
+    # named in the rules is auto-allowed and its requests are injected at L7 by
+    # CubeEgress. Never silently drop this flag, or full egress is re-enabled.
+    return Sandbox.create(
+        template=template_id,
+        allow_internet_access=False,
+        network={"rules": rules},
+        timeout=timeout,
+    )
+
+
+def show_key_not_in_vm(sandbox: Sandbox, key_name: str) -> None:
+    command = f"printenv {shlex.quote(key_name)} || echo '<unset>'"
+    result = run_command(sandbox, command, timeout=30)
+    ensure_success(result, "read provider key inside sandbox")
+    value = getattr(result, "stdout", "").strip()
+    print(f"In-VM {key_name}: {value!r} (real secret stays in CubeEgress)")
+
+
+def show_non_llm_blocked(sandbox: Sandbox) -> None:
+    command = (
+        "curl -s -o /dev/null -w '%{http_code}' --max-time 8 https://example.com "
+        "|| echo blocked"
+    )
+    result = run_command(sandbox, command, timeout=30)
+    status = getattr(result, "stdout", "").strip()
+    print(f"Non-LLM host (example.com) response: {status or 'blocked'} "
+          "(expected 403/blocked under default-deny)")
+
+
+def run_agent(sandbox: Sandbox, args: argparse.Namespace, envs: dict[str, str]):
+    command = shell_join(
+        f"cd {shlex.quote(args.workspace)}",
+        opencode_run_command(args.prompt),
+    )
+    return run_command(
+        sandbox,
+        command,
+        cwd=args.workspace,
+        envs=envs,
+        timeout=args.exec_timeout,
+        stream=True,
+    )
+
+
+def main() -> int:
+    load_local_dotenv()
+    args = parse_args()
+
+    template_id = args.template or required("CUBE_TEMPLATE_ID")
+    required("E2B_API_URL")
+    required("E2B_API_KEY")
+
+    provider = opencode_provider()
+    secret = require_provider_key(provider)
+    host = args.host or opencode_llm_host(provider)
+    if not host:
+        raise SystemExit(
+            "Could not resolve the LLM host. Set OPENCODE_LLM_HOST in your .env or pass --host."
+        )
+
+    rules = build_rules(provider, host, secret)
+
+    sandbox_env = build_opencode_env(include_secrets=False)
+    key_name = provider_key_name(provider)
+    sandbox_env[key_name] = PLACEHOLDER_KEY
+    # Let the Node-based OpenCode CLI trust the CubeEgress interception CA (see
+    # note on DEFAULT_NODE_CA_BUNDLE); without this the vault path fails TLS.
+    sandbox_env["NODE_EXTRA_CA_CERTS"] = os.environ.get(
+        "OPENCODE_NODE_EXTRA_CA_CERTS", DEFAULT_NODE_CA_BUNDLE
+    )
+
+    print(f"Provider: {provider}")
+    print(f"Allowed LLM host (default-deny for everything else): {host}")
+    print(f"Creating sandbox from template: {template_id}")
+
+    sandbox = create_sandbox(template_id, rules, args.sandbox_timeout)
+    sandbox_id = sandbox_identifier(sandbox)
+    result = None
+    try:
+        print(f"Sandbox ready: {sandbox_id}\n")
+
+        show_key_not_in_vm(sandbox, key_name)
+        show_non_llm_blocked(sandbox)
+
+        if args.skip_agent:
+            print("\n--skip-agent set: not invoking OpenCode.")
+            return 0
+
+        print("\nRunning OpenCode through the injected egress path...\n")
+        result = run_agent(sandbox, args, sandbox_env)
+        exit_code = getattr(result, "exit_code", None)
+        print(f"\nOpenCode exit code: {exit_code}")
+        return 0 if exit_code is None else int(exit_code)
+    finally:
+        try:
+            sandbox.kill()
+            print(f"\nSandbox {sandbox_id} killed.")
+        except Exception as exc:  # noqa: BLE001 - cleanup must not mask real errors
+            print(
+                f"Warning: failed to kill sandbox {sandbox_id}: {exc}",
+                file=sys.stderr,
+            )
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/examples/opencode-integration/network_policy.py
+++ b/examples/opencode-integration/network_policy.py
@@ -49,8 +49,8 @@ PLACEHOLDER_KEY = "cube-egress-managed-placeholder"
 # system trust store. On the vault path CubeEgress terminates TLS to inject the
 # credential, so Node must trust the CubeEgress root CA or every LLM call fails
 # with "Connection error". Point NODE_EXTRA_CA_CERTS at a bundle that includes
-# it; the CubeSandbox base image installs the CA into the system bundle below.
-DEFAULT_NODE_CA_BUNDLE = "/etc/ssl/certs/ca-certificates.crt"
+# it; CubeMaster bakes a dedicated CubeEgress anchor into the image.
+DEFAULT_NODE_CA_BUNDLE = "/usr/local/share/ca-certificates/cube-egress-root.crt"
 
 DEFAULT_PROMPT = (
     "Reply with a single short sentence confirming you can reach the LLM API, "
@@ -98,6 +98,11 @@ def parse_args() -> argparse.Namespace:
         "--skip-agent",
         action="store_true",
         help="Only show the egress checks; skip the actual OpenCode run.",
+    )
+    parser.add_argument(
+        "--raw",
+        action="store_true",
+        help="Keep OpenCode's raw streamed output (currently the default renderer).",
     )
     args = parser.parse_args()
     if args.prompt is None:

--- a/examples/opencode-integration/network_policy.py
+++ b/examples/opencode-integration/network_policy.py
@@ -102,7 +102,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--raw",
         action="store_true",
-        help="Keep OpenCode's raw streamed output (currently the default renderer).",
+        help="Keep OpenCode's raw streamed JSON output.",
     )
     args = parser.parse_args()
     if args.prompt is None:
@@ -171,6 +171,7 @@ def run_agent(sandbox: Sandbox, args: argparse.Namespace, envs: dict[str, str]):
         envs=envs,
         timeout=args.exec_timeout,
         stream=True,
+        raw=args.raw,
     )
 
 

--- a/examples/opencode-integration/requirements.txt
+++ b/examples/opencode-integration/requirements.txt
@@ -1,0 +1,3 @@
+e2b>=2.4.1
+cubesandbox>=0.3.0
+python-dotenv>=1.0.0

--- a/examples/opencode-integration/requirements.txt
+++ b/examples/opencode-integration/requirements.txt
@@ -1,3 +1,3 @@
-e2b>=2.4.1
-cubesandbox>=0.3.0
-python-dotenv>=1.0.0
+e2b==2.4.1
+cubesandbox==0.3.0
+python-dotenv==1.0.0

--- a/examples/opencode-integration/resume_opencode.py
+++ b/examples/opencode-integration/resume_opencode.py
@@ -1,0 +1,209 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Demonstrate OpenCode session persistence across a CubeSandbox pause/resume.
+
+Turn 1 asks OpenCode to write ``/workspace/plan.md``, then the sandbox is paused.
+Turn 2 reconnects to the same sandbox, verifies both ``/workspace`` and the
+OpenCode state directory survived the snapshot, and asks OpenCode to continue
+the work.
+
+Lifecycle note: this script deliberately avoids ``with Sandbox.create(...)``.
+A context manager kills the sandbox on ``__exit__``, which would defeat the
+pause. The lifecycle is managed manually with try/finally so the sandbox stays
+alive between turns and is only killed at the very end.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import shlex
+import sys
+
+from e2b import Sandbox
+
+from env_utils import (
+    build_opencode_env,
+    int_env,
+    load_local_dotenv,
+    opencode_provider,
+    opencode_run_command,
+    opencode_workspace,
+    require_provider_key,
+    required,
+    shell_join,
+)
+from _common import ensure_success, run_command, sandbox_identifier
+
+DEFAULT_OPENCODE_STATE_DIR = "/root/.opencode"
+
+TURN_1_PROMPT = (
+    "Create {workspace}/plan.md containing a numbered 3-step plan for building a "
+    "small Python CLI that prints the current time. Only write the plan file."
+)
+TURN_2_PROMPT = (
+    "Read {workspace}/plan.md and implement step 1 by creating "
+    "{workspace}/progress.md that records which step you completed and why. "
+    "Do not delete plan.md."
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Demonstrate OpenCode session persistence across a CubeSandbox pause/resume."
+    )
+    parser.add_argument(
+        "--template",
+        default=os.environ.get("CUBE_TEMPLATE_ID"),
+        help="CubeSandbox template ID. Defaults to CUBE_TEMPLATE_ID.",
+    )
+    parser.add_argument(
+        "--workspace",
+        default=opencode_workspace(),
+        help="Working directory inside the sandbox. Defaults to OPENCODE_WORKSPACE.",
+    )
+    parser.add_argument(
+        "--opencode-state-dir",
+        default=os.environ.get("OPENCODE_DIR", DEFAULT_OPENCODE_STATE_DIR),
+        help="OpenCode state directory checked for survival after resume.",
+    )
+    parser.add_argument(
+        "--sandbox-timeout",
+        type=int,
+        default=int_env("OPENCODE_SANDBOX_TIMEOUT", 1800),
+        help="Sandbox lifetime in seconds. Defaults to OPENCODE_SANDBOX_TIMEOUT or 1800.",
+    )
+    parser.add_argument(
+        "--exec-timeout",
+        type=int,
+        default=int_env("OPENCODE_EXEC_TIMEOUT", 900),
+        help="OpenCode command timeout in seconds. Defaults to OPENCODE_EXEC_TIMEOUT or 900.",
+    )
+    return parser.parse_args()
+
+
+def run_turn(
+    sandbox: Sandbox,
+    workspace: str,
+    prompt: str,
+    exec_timeout: int,
+    envs: dict[str, str],
+):
+    command = shell_join(
+        f"cd {shlex.quote(workspace)}",
+        opencode_run_command(prompt),
+    )
+    return run_command(
+        sandbox,
+        command,
+        cwd=workspace,
+        envs=envs,
+        timeout=exec_timeout,
+        stream=True,
+    )
+
+
+def assert_state_survived(sandbox: Sandbox, workspace: str, state_dir: str) -> None:
+    quoted_workspace = shlex.quote(workspace)
+    quoted_state = shlex.quote(state_dir)
+    command = shell_join(
+        f"test -f {quoted_workspace}/plan.md",
+        f"test -d {quoted_state}",
+        "printf '\\n--- plan.md (survived pause/resume) ---\\n'",
+        f"cat {quoted_workspace}/plan.md",
+    )
+    result = run_command(sandbox, command, timeout=60)
+    ensure_success(result, "verify /workspace and OpenCode state survived pause/resume")
+    if getattr(result, "stdout", ""):
+        print(result.stdout)
+
+
+def show_final_workspace(sandbox: Sandbox, workspace: str) -> None:
+    quoted_workspace = shlex.quote(workspace)
+    command = shell_join(
+        f"ls -la {quoted_workspace}",
+        f"test ! -f {quoted_workspace}/progress.md || "
+        f"(printf '\\n--- progress.md ---\\n' && cat {quoted_workspace}/progress.md)",
+    )
+    result = run_command(sandbox, command, timeout=60)
+    ensure_success(result, "inspect final workspace")
+    if getattr(result, "stdout", ""):
+        print(result.stdout)
+
+
+def main() -> int:
+    load_local_dotenv()
+    args = parse_args()
+
+    template_id = args.template or required("CUBE_TEMPLATE_ID")
+    required("E2B_API_URL")
+    required("E2B_API_KEY")
+    require_provider_key(opencode_provider())
+
+    opencode_env = build_opencode_env()
+    turn_1_prompt = TURN_1_PROMPT.format(workspace=args.workspace)
+    turn_2_prompt = TURN_2_PROMPT.format(workspace=args.workspace)
+
+    print(f"Creating sandbox from template: {template_id}")
+    # SECURITY: like run_opencode.py this demo keeps egress open and injects the
+    # key per command. The pause() snapshot also captures the in-VM env and any
+    # credentials OpenCode caches under /root/.opencode, widening exposure — for
+    # shared clusters prefer the default-deny + vault pattern in network_policy.py.
+    sandbox = Sandbox.create(template=template_id, timeout=args.sandbox_timeout)
+    sandbox_id = sandbox_identifier(sandbox)
+
+    try:
+        print(f"Sandbox ready: {sandbox_id}")
+
+        version_result = run_command(sandbox, "opencode --version", timeout=60)
+        ensure_success(version_result, "check OpenCode version")
+        print(f"OpenCode version: {getattr(version_result, 'stdout', '').strip()}")
+
+        print("\n=== Turn 1: create plan.md ===\n")
+        result_1 = run_turn(
+            sandbox, args.workspace, turn_1_prompt, args.exec_timeout, opencode_env
+        )
+        ensure_success(result_1, "run OpenCode turn 1")
+
+        print(f"\nPausing sandbox {sandbox_id} (snapshotting VM + rootfs)...")
+        paused_id = sandbox.pause()
+        # The sandbox_id is stable across pause. Some SDK versions return the
+        # resume handle as a string; others return a bool (success). Only adopt
+        # a string handle, otherwise keep the original id for connect().
+        if isinstance(paused_id, str) and paused_id:
+            sandbox_id = paused_id
+        print(f"Paused. Resume handle: {sandbox_id}")
+
+        print(f"\nReconnecting to {sandbox_id}...")
+        sandbox = Sandbox.connect(sandbox_id=sandbox_id)
+        print("Reconnected after resume.")
+
+        print("\n=== Verifying persistence after resume ===\n")
+        assert_state_survived(sandbox, args.workspace, args.opencode_state_dir)
+
+        print("\n=== Turn 2: continue the work ===\n")
+        result_2 = run_turn(
+            sandbox, args.workspace, turn_2_prompt, args.exec_timeout, opencode_env
+        )
+        ensure_success(result_2, "run OpenCode turn 2")
+
+        show_final_workspace(sandbox, args.workspace)
+
+        exit_code = getattr(result_2, "exit_code", 0)
+        return 0 if exit_code is None else int(exit_code)
+    finally:
+        if sandbox is not None:
+            try:
+                sandbox.kill()
+                print(f"\nSandbox {sandbox_id} killed.")
+            except Exception as exc:  # noqa: BLE001 - cleanup must not mask real errors
+                print(
+                    f"Warning: failed to kill sandbox {sandbox_id}: {exc}",
+                    file=sys.stderr,
+                )
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/examples/opencode-integration/resume_opencode.py
+++ b/examples/opencode-integration/resume_opencode.py
@@ -177,10 +177,12 @@ def main() -> int:
 
         print(f"\nPausing sandbox {sandbox_id} (snapshotting VM + rootfs)...")
         paused_id = sandbox.pause()
+        if not paused_id:
+            raise SystemExit("Failed to pause sandbox: no snapshot ID returned")
         # The sandbox_id is stable across pause. Some SDK versions return the
         # resume handle as a string; others return a bool (success). Only adopt
         # a string handle, otherwise keep the original id for connect().
-        if isinstance(paused_id, str) and paused_id:
+        if isinstance(paused_id, str):
             sandbox_id = paused_id
         print(f"Paused. Resume handle: {sandbox_id}")
 

--- a/examples/opencode-integration/resume_opencode.py
+++ b/examples/opencode-integration/resume_opencode.py
@@ -81,6 +81,11 @@ def parse_args() -> argparse.Namespace:
         default=int_env("OPENCODE_EXEC_TIMEOUT", 900),
         help="OpenCode command timeout in seconds. Defaults to OPENCODE_EXEC_TIMEOUT or 900.",
     )
+    parser.add_argument(
+        "--raw",
+        action="store_true",
+        help="Keep OpenCode's raw streamed JSON output.",
+    )
     return parser.parse_args()
 
 
@@ -90,6 +95,7 @@ def run_turn(
     prompt: str,
     exec_timeout: int,
     envs: dict[str, str],
+    raw: bool = False,
 ):
     command = shell_join(
         f"cd {shlex.quote(workspace)}",
@@ -102,6 +108,7 @@ def run_turn(
         envs=envs,
         timeout=exec_timeout,
         stream=True,
+        raw=raw,
     )
 
 
@@ -163,7 +170,7 @@ def main() -> int:
 
         print("\n=== Turn 1: create plan.md ===\n")
         result_1 = run_turn(
-            sandbox, args.workspace, turn_1_prompt, args.exec_timeout, opencode_env
+            sandbox, args.workspace, turn_1_prompt, args.exec_timeout, opencode_env, args.raw
         )
         ensure_success(result_1, "run OpenCode turn 1")
 
@@ -185,7 +192,7 @@ def main() -> int:
 
         print("\n=== Turn 2: continue the work ===\n")
         result_2 = run_turn(
-            sandbox, args.workspace, turn_2_prompt, args.exec_timeout, opencode_env
+            sandbox, args.workspace, turn_2_prompt, args.exec_timeout, opencode_env, args.raw
         )
         ensure_success(result_2, "run OpenCode turn 2")
 

--- a/examples/opencode-integration/resume_opencode.py
+++ b/examples/opencode-integration/resume_opencode.py
@@ -158,10 +158,11 @@ def main() -> int:
     # key per command. The pause() snapshot also captures the in-VM env and any
     # credentials OpenCode caches under /root/.opencode, widening exposure — for
     # shared clusters prefer the default-deny + vault pattern in network_policy.py.
-    sandbox = Sandbox.create(template=template_id, timeout=args.sandbox_timeout)
-    sandbox_id = sandbox_identifier(sandbox)
-
+    sandbox = None
+    sandbox_id = "uncreated"
     try:
+        sandbox = Sandbox.create(template=template_id, timeout=args.sandbox_timeout)
+        sandbox_id = sandbox_identifier(sandbox)
         print(f"Sandbox ready: {sandbox_id}")
 
         version_result = run_command(sandbox, "opencode --version", timeout=60)
@@ -184,7 +185,7 @@ def main() -> int:
         print(f"Paused. Resume handle: {sandbox_id}")
 
         print(f"\nReconnecting to {sandbox_id}...")
-        sandbox = Sandbox.connect(sandbox_id=sandbox_id)
+        sandbox = Sandbox.connect(sandbox_id=sandbox_id, timeout=args.sandbox_timeout)
         print("Reconnected after resume.")
 
         print("\n=== Verifying persistence after resume ===\n")

--- a/examples/opencode-integration/run_opencode.py
+++ b/examples/opencode-integration/run_opencode.py
@@ -70,6 +70,11 @@ def parse_args() -> argparse.Namespace:
         action="store_true",
         help="Skip writing the demo files into the sandbox workspace.",
     )
+    parser.add_argument(
+        "--raw",
+        action="store_true",
+        help="Keep OpenCode's raw streamed JSON output.",
+    )
     args = parser.parse_args()
     if args.prompt is None:
         args.prompt = default_prompt(args.workspace)
@@ -162,6 +167,7 @@ def main() -> int:
             envs=opencode_env,
             timeout=args.exec_timeout,
             stream=True,
+            raw=args.raw,
         )
 
         print_result_summary(result)

--- a/examples/opencode-integration/run_opencode.py
+++ b/examples/opencode-integration/run_opencode.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import argparse
+import os
+import shlex
+import sys
+
+from e2b import Sandbox
+
+from _common import ensure_success, run_command, sandbox_identifier
+from env_utils import (
+    build_opencode_env,
+    int_env,
+    load_local_dotenv,
+    opencode_provider,
+    opencode_run_command,
+    opencode_workspace,
+    require_provider_key,
+    required,
+    shell_join,
+)
+
+DEFAULT_PROMPT_TEMPLATE = (
+    "Inspect the project in {workspace}, run python3 app.py, and write a "
+    "concise summary of the result to {workspace}/result.md."
+)
+
+
+def default_prompt(workspace: str) -> str:
+    return DEFAULT_PROMPT_TEMPLATE.format(workspace=workspace)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Run a one-shot OpenCode coding-agent task inside CubeSandbox."
+    )
+    parser.add_argument(
+        "--template",
+        default=os.environ.get("CUBE_TEMPLATE_ID"),
+        help="CubeSandbox template ID. Defaults to CUBE_TEMPLATE_ID.",
+    )
+    parser.add_argument(
+        "--prompt",
+        default=None,
+        help="Prompt passed to OpenCode. Defaults to a small workspace smoke task.",
+    )
+    parser.add_argument(
+        "--workspace",
+        default=opencode_workspace(),
+        help="Working directory inside the sandbox. Defaults to OPENCODE_WORKSPACE.",
+    )
+    parser.add_argument(
+        "--sandbox-timeout",
+        type=int,
+        default=int_env("OPENCODE_SANDBOX_TIMEOUT", 1800),
+        help="Sandbox lifetime in seconds. Defaults to OPENCODE_SANDBOX_TIMEOUT or 1800.",
+    )
+    parser.add_argument(
+        "--exec-timeout",
+        type=int,
+        default=int_env("OPENCODE_EXEC_TIMEOUT", 900),
+        help="OpenCode command timeout in seconds. Defaults to OPENCODE_EXEC_TIMEOUT or 900.",
+    )
+    parser.add_argument(
+        "--no-seed",
+        action="store_true",
+        help="Skip writing the demo files into the sandbox workspace.",
+    )
+    args = parser.parse_args()
+    if args.prompt is None:
+        args.prompt = default_prompt(args.workspace)
+    return args
+
+
+def seed_project(sandbox: Sandbox, workspace: str, timeout: int) -> None:
+    quoted_workspace = shlex.quote(workspace)
+    command = f"""mkdir -p {quoted_workspace}
+cat > {quoted_workspace}/README.md <<'EOF'
+# CubeSandbox OpenCode Smoke Project
+
+This tiny project exists so the OpenCode coding agent has a deterministic task to run.
+EOF
+cat > {quoted_workspace}/app.py <<'EOF'
+def main() -> None:
+    print("hello from CubeSandbox + OpenCode")
+
+
+if __name__ == "__main__":
+    main()
+EOF
+"""
+    result = run_command(sandbox, command, timeout=timeout)
+    ensure_success(result, "seed workspace")
+
+
+def print_result_summary(result) -> None:
+    exit_code = getattr(result, "exit_code", None)
+    stderr = getattr(result, "stderr", "")
+
+    print(f"\nOpenCode exit code: {exit_code}")
+    if stderr:
+        print("\nCaptured stderr:", file=sys.stderr)
+        print(stderr, file=sys.stderr)
+
+
+def show_workspace_result(sandbox: Sandbox, workspace: str, timeout: int) -> None:
+    quoted_workspace = shlex.quote(workspace)
+    command = shell_join(
+        f"ls -la {quoted_workspace}",
+        f"test ! -f {quoted_workspace}/result.md || "
+        f"(printf '\\n--- result.md ---\\n' && cat {quoted_workspace}/result.md)",
+    )
+    result = run_command(sandbox, command, timeout=timeout)
+    ensure_success(result, "inspect workspace")
+    if getattr(result, "stdout", ""):
+        print(result.stdout)
+
+
+def main() -> int:
+    load_local_dotenv()
+    args = parse_args()
+
+    template_id = args.template or required("CUBE_TEMPLATE_ID")
+    required("E2B_API_URL")
+    required("E2B_API_KEY")
+    require_provider_key(opencode_provider())
+
+    opencode_env = build_opencode_env()
+    command = shell_join(
+        f"cd {shlex.quote(args.workspace)}",
+        opencode_run_command(args.prompt),
+    )
+
+    print(f"Creating sandbox from template: {template_id}")
+    result = None
+    # SECURITY: this direct-key demo keeps egress open (allow_internet_access
+    # defaults to True) for simplicity, and injects the provider key per command
+    # via envs=. A compromised agent with open egress could exfiltrate that key.
+    # For shared/production use prefer network_policy.py, which pairs default-deny
+    # egress with the CubeEgress credential vault (the key never enters the VM).
+    with Sandbox.create(template=template_id, timeout=args.sandbox_timeout) as sandbox:
+        sandbox_id = sandbox_identifier(sandbox)
+        print(f"Sandbox ready: {sandbox_id}")
+
+        version_result = run_command(sandbox, "opencode --version", timeout=60)
+        ensure_success(version_result, "check OpenCode version")
+        print(f"OpenCode version: {getattr(version_result, 'stdout', '').strip()}")
+
+        if not args.no_seed:
+            seed_project(sandbox, args.workspace, timeout=60)
+            print(f"Seeded demo project in {args.workspace}")
+
+        print("\nRunning OpenCode task...\n")
+        result = run_command(
+            sandbox,
+            command,
+            cwd=args.workspace,
+            envs=opencode_env,
+            timeout=args.exec_timeout,
+            stream=True,
+        )
+
+        print_result_summary(result)
+        show_workspace_result(sandbox, args.workspace, timeout=60)
+
+    exit_code = getattr(result, "exit_code", 1)
+    return 0 if exit_code is None else int(exit_code)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/examples/opencode-integration/test_helpers.py
+++ b/examples/opencode-integration/test_helpers.py
@@ -46,6 +46,14 @@ class HelperTests(unittest.TestCase):
                 "claude-test",
             )
 
+    def test_serve_command_uses_configured_port(self):
+        values = {
+            "OPENCODE_PROVIDER": "anthropic",
+            "OPENCODE_SERVER_PORT": "5123",
+        }
+        with patch.dict(os.environ, values, clear=True):
+            self.assertIn("--port 5123", env_utils.opencode_serve_command())
+
     def test_non_numeric_exit_code_fails_cleanly(self):
         with self.assertRaisesRegex(SystemExit, "Cannot parse exit code"):
             _common.ensure_success(type("Result", (), {"exit_code": "error"})(), "test")

--- a/examples/opencode-integration/test_helpers.py
+++ b/examples/opencode-integration/test_helpers.py
@@ -22,6 +22,19 @@ class HelperTests(unittest.TestCase):
                 values["ANTHROPIC_BASE_URL"],
             )
 
+    def test_anthropic_model_is_forwarded_and_selected(self):
+        values = {"OPENCODE_PROVIDER": "anthropic", "ANTHROPIC_MODEL": "claude-test"}
+        with patch.dict(os.environ, values, clear=True):
+            self.assertEqual(env_utils.opencode_model(), "claude-test")
+            self.assertEqual(
+                env_utils.build_opencode_env(include_secrets=False)["ANTHROPIC_MODEL"],
+                "claude-test",
+            )
+
+    def test_non_numeric_exit_code_fails_cleanly(self):
+        with self.assertRaisesRegex(SystemExit, "Cannot parse exit code"):
+            _common.ensure_success(type("Result", (), {"exit_code": "error"})(), "test")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/examples/opencode-integration/test_helpers.py
+++ b/examples/opencode-integration/test_helpers.py
@@ -13,6 +13,21 @@ class HelperTests(unittest.TestCase):
     def test_string_zero_exit_code_is_success(self):
         _common.ensure_success(type("Result", (), {"exit_code": "0"})(), "test")
 
+    def test_missing_exit_code_is_failure(self):
+        with self.assertRaisesRegex(SystemExit, "no exit code"):
+            _common.ensure_success(type("Result", (), {"exit_code": None})(), "test")
+
+    def test_vault_env_drops_proxy_settings(self):
+        with patch.dict(os.environ, {"HTTPS_PROXY": "http://proxy.example"}, clear=True):
+            self.assertNotIn("HTTPS_PROXY", env_utils.build_opencode_env(False))
+
+    def test_renderer_flushes_partial_line(self):
+        writer = _common.stream_json_render_writer()
+        with patch.object(_common, "_render_stream_json_line") as render:
+            writer("partial")
+            writer.flush()
+            render.assert_called_once_with("partial")
+
     def test_anthropic_base_url_is_forwarded_and_selects_host(self):
         values = {"OPENCODE_PROVIDER": "anthropic", "ANTHROPIC_BASE_URL": "https://llm.example/v1"}
         with patch.dict(os.environ, values, clear=True):

--- a/examples/opencode-integration/test_helpers.py
+++ b/examples/opencode-integration/test_helpers.py
@@ -1,0 +1,27 @@
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+import unittest
+from unittest.mock import patch
+
+import _common
+import env_utils
+
+
+class HelperTests(unittest.TestCase):
+    def test_string_zero_exit_code_is_success(self):
+        _common.ensure_success(type("Result", (), {"exit_code": "0"})(), "test")
+
+    def test_anthropic_base_url_is_forwarded_and_selects_host(self):
+        values = {"OPENCODE_PROVIDER": "anthropic", "ANTHROPIC_BASE_URL": "https://llm.example/v1"}
+        with patch.dict(os.environ, values, clear=True):
+            self.assertEqual(env_utils.opencode_llm_host(), "llm.example")
+            self.assertEqual(
+                env_utils.build_opencode_env(include_secrets=False)["ANTHROPIC_BASE_URL"],
+                values["ANTHROPIC_BASE_URL"],
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add end-to-end bilingual integration guides for Claude Code, CodeBuddy, and OpenCode
- add runnable template images and Python workflows for direct execution, pause/resume persistence, and result collection
- add default-deny CubeEgress examples with on-the-wire API key injection
- add troubleshooting, best practices, and integration index entries

Closes #644

## Why

CubeSandbox did not have ready-to-run examples for these terminal coding agents. These guides and examples show how to run each agent in an isolated, reproducible sandbox while aligning with CubeSandbox template, snapshot, authentication, and egress mechanisms.

## Validation

- `python -m compileall -q examples/claude-code-integration examples/codebuddy-integration examples/opencode-integration`
- all nine Python entry points pass `--help` import/argument checks
- npm metadata verified for all three pinned CLI packages and binary names
- `git diff --check`
- VitePress build attempted; currently blocked by an unrelated pre-existing missing asset: `docs/zh/blog/posts/assets/2026-06-25-cubesandbox-snapshot-clone-rollback-deep-dive/03_ficlone_path.png`
- Docker image builds not run because Docker Desktop is unavailable in the local environment

## Impact

Users can follow the English or Chinese documentation to build a CubeSandbox template, inject provider credentials safely, run each coding agent, preserve long-running sessions with snapshots, and diagnose common deployment failures.

Assisted-by: Codex:GPT-5