### PR TITLE
chore(pvm): bump PVM kernel tag to 6.6.69-1.2.cubesandbox

### DIFF
--- a/.github/workflows/build-pvm-guest-vmlinux.yml
+++ b/.github/workflows/build-pvm-guest-vmlinux.yml
@@ -12,7 +12,7 @@ on:
   workflow_dispatch:
 
 env:
-  PVM_KERNEL_TAG: 6.6.69-1.cubesandbox
+  PVM_KERNEL_TAG: 6.6.69-1.2.cubesandbox
   PVM_VMLINUX_CACHE_PATH: kernel-cache/vmlinux-pvm
 
 jobs:

--- a/.github/workflows/release-one-click.yml
+++ b/.github/workflows/release-one-click.yml
@@ -19,7 +19,7 @@ env:
   VMLINUX_CACHE_PATH: kernel-cache/vmlinux
   VMLINUX_RELEASE_PATH: deploy/one-click/assets/kernel-artifacts/vmlinux
   KERNEL_TAG: 6.6.119-49.6
-  PVM_KERNEL_TAG: 6.6.69-1.cubesandbox
+  PVM_KERNEL_TAG: 6.6.69-1.2.cubesandbox
   PVM_VMLINUX_CACHE_PATH: kernel-cache/vmlinux-pvm
   PVM_VMLINUX_RELEASE_PATH: deploy/one-click/assets/kernel-artifacts/vmlinux-pvm
 

--- a/Cubelet/pkg/cubelet/versioninfo/collector_test.go
+++ b/Cubelet/pkg/cubelet/versioninfo/collector_test.go
@@ -40,7 +40,7 @@ func writeManifest(t *testing.T, dir string) {
   "guest_image": {"version": "cube-image/2026.01", "agent_version": "agent-1.2.3"},
   "kernel": {
     "version": "5.10.0-100",
-    "pvm_version": "6.6.69-1.cubesandbox",
+    "pvm_version": "6.6.69-1.2.cubesandbox",
     "vmlinux_digest_sha256": "sha256:ordinary",
     "vmlinux_pvm_digest_sha256": "sha256:pvm"
   }
@@ -245,7 +245,7 @@ func TestCollectKernelFromActivePVMSymlink(t *testing.T) {
 	got := c.Collect()
 
 	kernel, ok := versionOf(t, got, ComponentKernel)
-	if !ok || kernel.Version != "6.6.69-1.cubesandbox@sha256:pvm" || kernel.Source != SourceFile {
+	if !ok || kernel.Version != "6.6.69-1.2.cubesandbox@sha256:pvm" || kernel.Source != SourceFile {
 		t.Fatalf("kernel must follow PVM active symlink, got %+v ok=%v", kernel, ok)
 	}
 }
@@ -331,7 +331,7 @@ func TestKernelSymlinkReread(t *testing.T) {
 
 	time.Sleep(10 * time.Millisecond)
 	mkKernelLayout(t, dir, "vmlinux-pvm")
-	if kernel, _ := versionOf(t, c.Collect(), ComponentKernel); kernel.Version != "6.6.69-1.cubesandbox@sha256:pvm" {
+	if kernel, _ := versionOf(t, c.Collect(), ComponentKernel); kernel.Version != "6.6.69-1.2.cubesandbox@sha256:pvm" {
 		t.Fatalf("expected PVM kernel after symlink switch, got %q", kernel.Version)
 	}
 }

--- a/deploy/one-click/terraform/tencentcloud/create.sh
+++ b/deploy/one-click/terraform/tencentcloud/create.sh
@@ -3316,7 +3316,7 @@ step6_replace_kernel() {
 	local key_file js_public_ip
 	key_file="${TENCENTCLOUD_SSH_PRIVATE_KEY_PATH:-$SSH_PRI_KEY}"
 	js_public_ip=$(terraform output -raw jumpserver_public_ip 2>/dev/null || echo "")
-	local pvm_kernel_url="${TENCENTCLOUD_PVM_KERNEL_RPM_URL:-https://mirrors.opencloudos.tech/opencloudos/9.4/extras/x86_64/os/Packages/kernel-core-6.6.69-1.1.cubesandbox.oc9.x86_64.rpm}"
+	local pvm_kernel_url="${TENCENTCLOUD_PVM_KERNEL_RPM_URL:-https://mirrors.opencloudos.tech/opencloudos/9.6/extras/x86_64/os/Packages/kernel-core-6.6.69-1.2.cubesandbox.oc9.x86_64.rpm}"
 	local rpm_name
 	rpm_name=$(basename "$pvm_kernel_url")
 	local rpm_file="/tmp/${rpm_name}"

--- a/deploy/one-click/tests/test_release_manifest_contract.sh
+++ b/deploy/one-click/tests/test_release_manifest_contract.sh
@@ -31,7 +31,7 @@ EOF
   "guest_image": {},
   "kernel": {
     "version": "6.6.119-49.6",
-    "pvm_version": "6.6.69-1.cubesandbox",
+    "pvm_version": "6.6.69-1.2.cubesandbox",
     "vmlinux_digest_sha256": "sha256:ordinary",
     "vmlinux_pvm_digest_sha256": "sha256:pvm"
   }
@@ -61,7 +61,7 @@ ordinary_identity = kernel_identity(kernel["version"], kernel["vmlinux_digest_sh
 pvm_identity = kernel_identity(kernel["pvm_version"], kernel["vmlinux_pvm_digest_sha256"])
 if ordinary_identity != "6.6.119-49.6@sha256:ordinary":
     raise SystemExit(f"unexpected ordinary kernel identity: {ordinary_identity}")
-if pvm_identity != "6.6.69-1.cubesandbox@sha256:pvm":
+if pvm_identity != "6.6.69-1.2.cubesandbox@sha256:pvm":
     raise SystemExit(f"unexpected PVM kernel identity: {pvm_identity}")
 if kernel_identity("unknown", "sha256:fallback") != "sha256:fallback":
     raise SystemExit("kernel identity must use digest when tag is unknown")

--- a/deploy/pvm/build-pvm-guest-vmlinux.sh
+++ b/deploy/pvm/build-pvm-guest-vmlinux.sh
@@ -2,7 +2,7 @@
 # ============================================================================
 # build-pvm-guest-vmlinux.sh
 #
-# Clone https://cnb.cool/CubeSandbox/OpenCloudOS-Kernel.git (tag: 6.6.69-1.cubesandbox),
+# Clone https://cnb.cool/CubeSandbox/OpenCloudOS-Kernel.git (tag: 6.6.69-1.2.cubesandbox),
 # apply the pvm-guest kernel .config, and build only the vmlinux target
 # (no RPM/DEB packaging, no kernel modules).
 #
@@ -34,7 +34,7 @@ PVM_DEPS_LABEL="vmlinux only"
 PVM_TARGET_DESC="target system"
 
 REPO_URL="${REPO_URL:-https://cnb.cool/CubeSandbox/OpenCloudOS-Kernel.git}"
-BRANCH="${BRANCH:-6.6.69-1.cubesandbox}"
+BRANCH="${BRANCH:-6.6.69-1.2.cubesandbox}"
 CONFIG_URL="${CONFIG_URL:-https://raw.githubusercontent.com/virt-pvm/misc/refs/heads/main/pvm-guest-6.12.33.config}"
 CONFIG_SHA256="${CONFIG_SHA256:-8e579bea756b6dadeff1203a5e4f3bba851a7426e4e50abd436575eddfa019f4}"
 

--- a/deploy/pvm/build-pvm-host-kernel-pkg.sh
+++ b/deploy/pvm/build-pvm-host-kernel-pkg.sh
@@ -3,7 +3,7 @@
 # build-pvm-host-kernel-pkg.sh
 #
 # Build the pvm-host kernel installation package:
-#   - Clone https://cnb.cool/CubeSandbox/OpenCloudOS-Kernel.git (tag: 6.6.69-1.cubesandbox)
+#   - Clone https://cnb.cool/CubeSandbox/OpenCloudOS-Kernel.git (tag: 6.6.69-1.2.cubesandbox)
 #   - Apply the pvm-host kernel .config
 #   - Build an RPM or DEB package depending on the host distribution family
 #
@@ -34,7 +34,7 @@ PVM_CONFIG_NAME="pvm_host"
 PVM_TARGET_DESC="target host"
 
 REPO_URL="${REPO_URL:-https://cnb.cool/CubeSandbox/OpenCloudOS-Kernel.git}"
-BRANCH="${BRANCH:-6.6.69-1.cubesandbox}"
+BRANCH="${BRANCH:-6.6.69-1.2.cubesandbox}"
 CONFIG_URL="${CONFIG_URL:-https://raw.githubusercontent.com/virt-pvm/misc/refs/heads/main/pvm-host-6.12.33.config}"
 CONFIG_SHA256="${CONFIG_SHA256:-edc1965a48fbe972ee6eb3d1be96de3d0fd00c1edfe665974330dea819545e00}"
 

--- a/deploy/pvm/configs/README.md
+++ b/deploy/pvm/configs/README.md
@@ -11,7 +11,7 @@ build scripts:
 The configs are kept in-tree so the default build path is reproducible and
 works in offline or air-gapped environments. They are derived from the PVM
 kernel tree used by these scripts (`https://gitee.com/OpenCloudOS/OpenCloudOS-Kernel.git`,
-tag `6.6.69-1.cubesandbox`) and the upstream reference configs published by
+tag `6.6.69-1.2.cubesandbox`) and the upstream reference configs published by
 the virt-pvm project:
 
 - `https://raw.githubusercontent.com/virt-pvm/misc/refs/heads/main/pvm-host-6.12.33.config`


### PR DESCRIPTION
Update the PVM kernel tag across CI workflows, build scripts, one-click Terraform deployment, contract tests, and documentation. Also move the default kernel RPM source from the OpenCloudOS 9.4 mirror to 9.6.