### PR TITLE
fix(cubelet): make nested host mount order deterministic

### DIFF
--- a/Cubelet/integration/nested_hostdir_restore_test.go
+++ b/Cubelet/integration/nested_hostdir_restore_test.go
@@ -1,0 +1,150 @@
+// Copyright (c) 2024 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package integration
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"github.com/tencentcloud/CubeSandbox/Cubelet/api/services/cubebox/v1"
+	"github.com/tencentcloud/CubeSandbox/Cubelet/api/services/errorcode/v1"
+	"github.com/tencentcloud/CubeSandbox/Cubelet/pkg/constants"
+	"google.golang.org/protobuf/proto"
+)
+
+// TestAppSnapshotRestoreWithReadOnlyParentAndWritableNestedHostDir is a manual
+// E2E that requires CUBE_E2E_TEMPLATE_REQUEST to contain the cubelet_request
+// returned by `cubemastercli template render`. The snapshot must contain a
+// long-running, busybox-compatible container so the permission checks can exec.
+func TestAppSnapshotRestoreWithReadOnlyParentAndWritableNestedHostDir(t *testing.T) {
+	if !IsCube() {
+		t.Skip("nested host_dir restore requires the cube runtime")
+	}
+
+	fixture := appSnapshotFixture(t)
+
+	teamDir := t.TempDir()
+	agentADir := filepath.Join(teamDir, "members", "agent-a")
+	agentBDir := filepath.Join(teamDir, "members", "agent-b")
+	require.NoError(t, os.MkdirAll(agentADir, 0o755))
+	require.NoError(t, os.MkdirAll(agentBDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(teamDir, "shared-input.txt"), []byte("team-input\n"), 0o644))
+
+	// Repeating the restore catches nondeterministic map iteration. The child is
+	// deliberately listed before the parent in every request; Cubelet must still
+	// mount the parent first so that the writable child remains visible.
+	for i := 0; i < 10; i++ {
+		t.Run(fmt.Sprintf("restore-%02d", i), func(t *testing.T) {
+			suffix := uuid.New().String()
+			agentVolumeName := "agent-output-" + suffix
+			teamVolumeName := "team-share-" + suffix
+			containerTeamDir := "/cube-e2e/nested-" + suffix + "/team"
+			containerAgentADir := containerTeamDir + "/members/agent-a"
+
+			req := proto.Clone(fixture).(*cubebox.RunCubeSandboxRequest)
+			req.RequestID = uuid.New().String()
+			req.Volumes = append(req.Volumes,
+				hostDirVolume(agentVolumeName, agentADir),
+				hostDirVolume(teamVolumeName, teamDir),
+			)
+			req.Containers[0].VolumeMounts = append(req.Containers[0].VolumeMounts,
+				&cubebox.VolumeMounts{
+					Name:          agentVolumeName,
+					ContainerPath: containerAgentADir,
+				},
+				&cubebox.VolumeMounts{
+					Name:          teamVolumeName,
+					ContainerPath: containerTeamDir,
+					Readonly:      true,
+				},
+			)
+
+			createCtx, createCancel := context.WithTimeout(context.Background(), 2*time.Minute)
+			createResp, createErr := cubeClient.Create(createCtx, req)
+			createCancel()
+			require.NoError(t, createErr)
+			require.Equal(t, errorcode.ErrorCode_Success, createResp.GetRet().GetRetCode(),
+				"restore sandbox: %s", createResp.GetRet().GetRetMsg())
+			require.NotEmpty(t, createResp.GetSandboxID())
+			t.Cleanup(func() {
+				DestroyCubeboxSuccess(t, createResp.GetSandboxID())
+			})
+
+			items := ListCubebox(t, &cubebox.ListCubeSandboxRequest{Id: &createResp.SandboxID})
+			require.Len(t, items, 1)
+			require.NotEmpty(t, items[0].GetContainers())
+
+			marker := fmt.Sprintf("restore-%02d-ok", i)
+			resultPath := filepath.Join(agentADir, fmt.Sprintf("result-%02d", i))
+			parentWritePath := filepath.Join(teamDir, fmt.Sprintf("parent-write-%02d", i))
+			siblingWritePath := filepath.Join(agentBDir, fmt.Sprintf("sibling-write-%02d", i))
+			script := fmt.Sprintf(`set -eu
+test "$(cat %s/shared-input.txt)" = "team-input"
+! touch %s/parent-write-%02d
+! touch %s/members/agent-b/sibling-write-%02d
+printf '%%s' '%s' > %s/result-%02d
+`, containerTeamDir, containerTeamDir, i, containerTeamDir, i, marker, containerAgentADir, i)
+
+			execCtx, execCancel := context.WithTimeout(context.Background(), 30*time.Second)
+			execResp, execErr := cubeClient.Exec(execCtx, &cubebox.ExecCubeSandboxRequest{
+				RequestID:   uuid.New().String(),
+				SandboxId:   createResp.GetSandboxID(),
+				ContainerId: items[0].GetContainers()[0].GetId(),
+				Args:        []string{"/bin/sh", "-c", script},
+				Cwd:         "/",
+			})
+			execCancel()
+			require.NoError(t, execErr)
+			require.Equal(t, errorcode.ErrorCode_Success, execResp.GetRet().GetRetCode(),
+				"exec permission checks: %s", execResp.GetRet().GetRetMsg())
+
+			require.Eventually(t, func() bool {
+				contents, readErr := os.ReadFile(resultPath)
+				return readErr == nil && string(contents) == marker
+			}, 20*time.Second, 100*time.Millisecond, "writable nested mount did not produce its marker")
+
+			_, statErr := os.Stat(parentWritePath)
+			require.ErrorIs(t, statErr, os.ErrNotExist, "read-only parent accepted a write")
+			_, statErr = os.Stat(siblingWritePath)
+			require.ErrorIs(t, statErr, os.ErrNotExist, "read-only sibling directory accepted a write")
+		})
+	}
+}
+
+func appSnapshotFixture(t *testing.T) *cubebox.RunCubeSandboxRequest {
+	t.Helper()
+
+	fixtureJSON := os.Getenv("CUBE_E2E_TEMPLATE_REQUEST")
+	if fixtureJSON == "" {
+		t.Skip("CUBE_E2E_TEMPLATE_REQUEST must contain a rendered Cubelet template request")
+	}
+	fixture := &cubebox.RunCubeSandboxRequest{}
+	require.NoError(t, json.Unmarshal([]byte(fixtureJSON), fixture))
+	require.NotEmpty(t, fixture.GetAnnotations()[constants.MasterAnnotationAppSnapshotTemplateID],
+		"fixture must restore an app snapshot template")
+	require.NotEmpty(t, fixture.GetContainers())
+	return fixture
+}
+
+func hostDirVolume(name, hostPath string) *cubebox.Volume {
+	return &cubebox.Volume{
+		Name: name,
+		VolumeSource: &cubebox.VolumeSource{
+			HostDirVolumes: &cubebox.HostDirVolumeSources{
+				VolumeSources: []*cubebox.HostDirSource{{
+					Name:     name,
+					HostPath: hostPath,
+				}},
+			},
+		},
+	}
+}

--- a/Cubelet/plugins/cbri/cubeboxcbri/virtiofs.go
+++ b/Cubelet/plugins/cbri/cubeboxcbri/virtiofs.go
@@ -8,7 +8,9 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"path"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -103,15 +105,19 @@ func generateRestoreVirtiofsOpt(ctx context.Context, flowOpts *workflow.CreateCo
 		return specOpts, nil
 	}
 
-	vmByVolName := make(map[string]*cubebox.VolumeMounts)
+	type indexedVolumeMount struct {
+		mount *cubebox.VolumeMounts
+		index int
+	}
+	vmByVolName := make(map[string]indexedVolumeMount)
 	if containerReq != nil {
-		for _, vm := range containerReq.GetVolumeMounts() {
-			vmByVolName[vm.GetName()] = vm
+		for i, vm := range containerReq.GetVolumeMounts() {
+			vmByVolName[vm.GetName()] = indexedVolumeMount{mount: vm, index: i}
 		}
 	}
 
-	var allMnts []virtiofs.VirtioMounts
-	for _, info := range storageInfo.HostDirBackendInfos {
+	var restoreMounts []restoreVirtioMount
+	for backendKey, info := range storageInfo.HostDirBackendInfos {
 
 		base := filepath.Base(info.BindPath)
 		var containerSrc string
@@ -121,21 +127,34 @@ func generateRestoreVirtiofsOpt(ctx context.Context, flowOpts *workflow.CreateCo
 			containerSrc = constants.PropagationContainerDirRw + "/" + base
 		}
 
-		vm, ok := vmByVolName[info.VolumeName]
-		if !ok || vm.GetContainerPath() == "" {
+		indexedVM, ok := vmByVolName[info.VolumeName]
+		if !ok {
 			log.G(ctx).Warnf("[hostdir] generateRestoreVirtiofsOpt: no VolumeMount for volume %q, skip", info.VolumeName)
 			continue
 		}
+		containerPath := indexedVM.mount.GetContainerPath()
+		if containerPath == "" {
+			log.G(ctx).Warnf("[hostdir] generateRestoreVirtiofsOpt: VolumeMount for volume %q has empty container path, skip", info.VolumeName)
+			continue
+		}
 
-		log.G(ctx).Infof("[hostdir] exec.mount: %s -> %s", containerSrc, vm.GetContainerPath())
-		allMnts = append(allMnts, virtiofs.VirtioMounts{
-			VirtiofsSource: containerSrc,
-			Destination:    vm.GetContainerPath(),
+		log.G(ctx).Infof("[hostdir] exec.mount: %s -> %s", containerSrc, containerPath)
+		restoreMounts = append(restoreMounts, restoreVirtioMount{
+			mount: virtiofs.VirtioMounts{
+				VirtiofsSource: containerSrc,
+				Destination:    containerPath,
+			},
+			requestIndex: indexedVM.index,
+			backendKey:   backendKey,
 		})
 	}
+	allMnts := sortRestoreVirtioMounts(restoreMounts)
 
 	if len(allMnts) > 0 {
-		vc, _ := jsoniter.Marshal(allMnts)
+		vc, err := jsoniter.Marshal(allMnts)
+		if err != nil {
+			return nil, fmt.Errorf("marshal restore virtiofs mounts: %w", err)
+		}
 		specOpts = append(specOpts, oci.WithAnnotations(map[string]string{
 			constants.AnnotationPropagationExecMounts:       string(vc),
 			constants.AnnotationPropagationContainerUmounts: virtiofs.GenPropagationContainerUmounts(),
@@ -144,6 +163,40 @@ func generateRestoreVirtiofsOpt(ctx context.Context, flowOpts *workflow.CreateCo
 		log.G(ctx).Infof("[hostdir] %s annotation set: %s", constants.AnnotationPropagationContainerUmounts, virtiofs.GenPropagationContainerUmounts())
 	}
 	return specOpts, nil
+}
+
+type restoreVirtioMount struct {
+	mount        virtiofs.VirtioMounts
+	requestIndex int
+	backendKey   string
+}
+
+// sortRestoreVirtioMounts makes the mount order deterministic and keeps parent
+// destinations ahead of nested destinations. Equal destinations retain the
+// caller's VolumeMount order, preserving the usual last-mount-wins behavior;
+// backendKey provides the final deterministic tiebreaker.
+func sortRestoreVirtioMounts(candidates []restoreVirtioMount) []virtiofs.VirtioMounts {
+	sort.Slice(candidates, func(i, j int) bool {
+		left := path.Clean(candidates[i].mount.Destination)
+		right := path.Clean(candidates[j].mount.Destination)
+		if left != right {
+			// A cleaned parent path is a strict lexical prefix of its nested
+			// child, so lexical ordering always places the parent first. For
+			// unrelated paths, the lexical order is deterministic but has no
+			// additional semantic meaning.
+			return left < right
+		}
+		if candidates[i].requestIndex != candidates[j].requestIndex {
+			return candidates[i].requestIndex < candidates[j].requestIndex
+		}
+		return candidates[i].backendKey < candidates[j].backendKey
+	})
+
+	mounts := make([]virtiofs.VirtioMounts, 0, len(candidates))
+	for _, candidate := range candidates {
+		mounts = append(mounts, candidate.mount)
+	}
+	return mounts
 }
 
 func appendVirtiofsConfig(ctx context.Context, opts *workflow.CreateContext, allVirtios []*virtiofs.VirtiofsConfig,

--- a/Cubelet/plugins/cbri/cubeboxcbri/virtiofs_test.go
+++ b/Cubelet/plugins/cbri/cubeboxcbri/virtiofs_test.go
@@ -1,0 +1,306 @@
+// Copyright (c) 2024 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package cubeboxcbri
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/tencentcloud/CubeSandbox/Cubelet/api/services/cubebox/v1"
+	"github.com/tencentcloud/CubeSandbox/Cubelet/pkg/constants"
+	"github.com/tencentcloud/CubeSandbox/Cubelet/pkg/container/virtiofs"
+	"github.com/tencentcloud/CubeSandbox/Cubelet/plugins/workflow"
+	"github.com/tencentcloud/CubeSandbox/Cubelet/storage"
+)
+
+func TestSortRestoreVirtioMountsParentBeforeChild(t *testing.T) {
+	t.Parallel()
+
+	candidates := []restoreVirtioMount{
+		{mount: virtiofs.VirtioMounts{VirtiofsSource: "/.container_rw/deliverables", Destination: "/workspace/team-share/members/agent-a/deliverables"}},
+		{mount: virtiofs.VirtioMounts{VirtiofsSource: "/.container_rw/agent-b", Destination: "/workspace/team-share/./members/agent-b"}},
+		{mount: virtiofs.VirtioMounts{VirtiofsSource: "/.container_ro/team-share", Destination: "/workspace/team-share/"}},
+		{mount: virtiofs.VirtioMounts{VirtiofsSource: "/.container_rw/output", Destination: "/workspace/output"}},
+		{mount: virtiofs.VirtioMounts{VirtiofsSource: "/.container_rw/agent-a", Destination: "/workspace/team-share/members/agent-a"}},
+	}
+
+	mounts := sortRestoreVirtioMounts(candidates)
+
+	require.Len(t, mounts, 5)
+	require.Equal(t, []string{
+		"/workspace/output",
+		"/workspace/team-share/",
+		"/workspace/team-share/members/agent-a",
+		"/workspace/team-share/members/agent-a/deliverables",
+		"/workspace/team-share/./members/agent-b",
+	}, []string{
+		mounts[0].Destination,
+		mounts[1].Destination,
+		mounts[2].Destination,
+		mounts[3].Destination,
+		mounts[4].Destination,
+	})
+}
+
+func TestSortRestoreVirtioMountsNilInput(t *testing.T) {
+	t.Parallel()
+
+	require.Empty(t, sortRestoreVirtioMounts(nil))
+}
+
+func TestSortRestoreVirtioMountsUsesBackendKeyAsFinalTiebreaker(t *testing.T) {
+	t.Parallel()
+
+	candidates := []restoreVirtioMount{
+		{
+			mount: virtiofs.VirtioMounts{
+				VirtiofsSource: "/.container_rw/source-b",
+				Destination:    "/workspace/./data",
+			},
+			requestIndex: 0,
+			backendKey:   "shared/source-b",
+		},
+		{
+			mount: virtiofs.VirtioMounts{
+				VirtiofsSource: "/.container_rw/source-a",
+				Destination:    "/workspace/data/",
+			},
+			requestIndex: 0,
+			backendKey:   "shared/source-a",
+		},
+	}
+
+	mounts := sortRestoreVirtioMounts(candidates)
+
+	require.Equal(t, []virtiofs.VirtioMounts{
+		{VirtiofsSource: "/.container_rw/source-a", Destination: "/workspace/data/"},
+		{VirtiofsSource: "/.container_rw/source-b", Destination: "/workspace/./data"},
+	}, mounts)
+}
+
+func TestGenerateRestoreVirtiofsOptEqualDestinationsPreserveRequestOrder(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name             string
+		volumeMounts     []*cubebox.VolumeMounts
+		wantSources      []string
+		wantDestinations []string
+	}{
+		{
+			name: "later writable mount wins",
+			volumeMounts: []*cubebox.VolumeMounts{
+				{Name: "read-only", ContainerPath: "/workspace/data", Readonly: true},
+				{Name: "writable", ContainerPath: "/workspace/data"},
+			},
+			wantSources: []string{
+				constants.PropagationContainerDirRo + "/read-only",
+				constants.PropagationContainerDirRw + "/writable",
+			},
+			wantDestinations: []string{"/workspace/data", "/workspace/data"},
+		},
+		{
+			name: "later read-only mount wins for equivalent cleaned destinations",
+			volumeMounts: []*cubebox.VolumeMounts{
+				{Name: "writable", ContainerPath: "/workspace/data/"},
+				{Name: "read-only", ContainerPath: "/workspace/./data", Readonly: true},
+			},
+			wantSources: []string{
+				constants.PropagationContainerDirRw + "/writable",
+				constants.PropagationContainerDirRo + "/read-only",
+			},
+			wantDestinations: []string{"/workspace/data/", "/workspace/./data"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			flowOpts := &workflow.CreateContext{
+				StorageInfo: &storage.StorageInfo{
+					HostDirBackendInfos: map[string]*storage.HostDirBackendInfo{
+						"read-only": {
+							VolumeName: "read-only",
+							BindPath:   "/data/cubelet/hostdir/sandbox/read-only",
+							ReadOnly:   true,
+						},
+						"writable": {
+							VolumeName: "writable",
+							BindPath:   "/data/cubelet/hostdir/sandbox/writable",
+						},
+					},
+				},
+			}
+			containerReq := &cubebox.ContainerConfig{VolumeMounts: tt.volumeMounts}
+
+			for range 32 {
+				specOpts, err := generateRestoreVirtiofsOpt(context.Background(), flowOpts, containerReq)
+				require.NoError(t, err)
+
+				spec := applySpecOpts(t, context.Background(), specOpts)
+				var mounts []virtiofs.VirtioMounts
+				require.NoError(t, json.Unmarshal([]byte(spec.Annotations[constants.AnnotationPropagationExecMounts]), &mounts))
+				require.Len(t, mounts, len(tt.wantSources))
+				require.Equal(t, tt.wantSources, []string{mounts[0].VirtiofsSource, mounts[1].VirtiofsSource})
+				require.Equal(t, tt.wantDestinations, []string{mounts[0].Destination, mounts[1].Destination})
+			}
+		})
+	}
+}
+
+func TestGenerateRestoreVirtiofsOptSkipsMissingVolumeMounts(t *testing.T) {
+	t.Parallel()
+
+	flowOpts := &workflow.CreateContext{
+		StorageInfo: &storage.StorageInfo{
+			HostDirBackendInfos: map[string]*storage.HostDirBackendInfo{
+				"matched-backend": {
+					VolumeName: "matched",
+					BindPath:   "/data/cubelet/hostdir/sandbox/matched",
+				},
+				"unmatched-backend": {
+					VolumeName: "missing",
+					BindPath:   "/data/cubelet/hostdir/sandbox/missing",
+				},
+			},
+		},
+	}
+	tests := []struct {
+		name         string
+		containerReq *cubebox.ContainerConfig
+		wantMounts   []virtiofs.VirtioMounts
+	}{
+		{
+			name: "nil container request",
+		},
+		{
+			name: "all backend volume names are unmatched",
+			containerReq: &cubebox.ContainerConfig{VolumeMounts: []*cubebox.VolumeMounts{
+				{Name: "other", ContainerPath: "/workspace/other"},
+			}},
+		},
+		{
+			name: "matched volume has empty container path",
+			containerReq: &cubebox.ContainerConfig{VolumeMounts: []*cubebox.VolumeMounts{
+				{Name: "matched"},
+			}},
+		},
+		{
+			name: "matched backend remains when another is unmatched",
+			containerReq: &cubebox.ContainerConfig{VolumeMounts: []*cubebox.VolumeMounts{
+				{Name: "matched", ContainerPath: "/workspace/matched"},
+			}},
+			wantMounts: []virtiofs.VirtioMounts{{
+				VirtiofsSource: constants.PropagationContainerDirRw + "/matched",
+				Destination:    "/workspace/matched",
+			}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			specOpts, err := generateRestoreVirtiofsOpt(context.Background(), flowOpts, tt.containerReq)
+			require.NoError(t, err)
+			if len(tt.wantMounts) == 0 {
+				require.Empty(t, specOpts)
+				return
+			}
+
+			spec := applySpecOpts(t, context.Background(), specOpts)
+			var mounts []virtiofs.VirtioMounts
+			require.NoError(t, json.Unmarshal([]byte(spec.Annotations[constants.AnnotationPropagationExecMounts]), &mounts))
+			require.Equal(t, tt.wantMounts, mounts)
+		})
+	}
+}
+
+func TestGenerateRestoreVirtiofsOptOrdersParentBeforeNestedChildForAllAccessModes(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		parentRO     bool
+		childRO      bool
+		parentSource string
+		childSource  string
+	}{
+		{
+			name:         "read-only parent and read-only child",
+			parentRO:     true,
+			childRO:      true,
+			parentSource: constants.PropagationContainerDirRo + "/team-share",
+			childSource:  constants.PropagationContainerDirRo + "/member-output",
+		},
+		{
+			name:         "read-only parent and writable child",
+			parentRO:     true,
+			childRO:      false,
+			parentSource: constants.PropagationContainerDirRo + "/team-share",
+			childSource:  constants.PropagationContainerDirRw + "/member-output",
+		},
+		{
+			name:         "writable parent and read-only child",
+			parentRO:     false,
+			childRO:      true,
+			parentSource: constants.PropagationContainerDirRw + "/team-share",
+			childSource:  constants.PropagationContainerDirRo + "/member-output",
+		},
+		{
+			name:         "writable parent and writable child",
+			parentRO:     false,
+			childRO:      false,
+			parentSource: constants.PropagationContainerDirRw + "/team-share",
+			childSource:  constants.PropagationContainerDirRw + "/member-output",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			flowOpts := &workflow.CreateContext{
+				StorageInfo: &storage.StorageInfo{
+					HostDirBackendInfos: map[string]*storage.HostDirBackendInfo{
+						"child": {
+							VolumeName: "member-output",
+							BindPath:   "/data/cubelet/hostdir/sandbox/member-output",
+							ReadOnly:   tt.childRO,
+						},
+						"parent": {
+							VolumeName: "team-share",
+							BindPath:   "/data/cubelet/hostdir/sandbox/team-share",
+							ReadOnly:   tt.parentRO,
+						},
+					},
+				},
+			}
+			containerReq := &cubebox.ContainerConfig{
+				VolumeMounts: []*cubebox.VolumeMounts{
+					{Name: "member-output", ContainerPath: "/workspace/team-share/members/agent-a", Readonly: tt.childRO},
+					{Name: "team-share", ContainerPath: "/workspace/team-share", Readonly: tt.parentRO},
+				},
+			}
+
+			for range 32 {
+				specOpts, err := generateRestoreVirtiofsOpt(context.Background(), flowOpts, containerReq)
+				require.NoError(t, err)
+
+				spec := applySpecOpts(t, context.Background(), specOpts)
+				var mounts []virtiofs.VirtioMounts
+				require.NoError(t, json.Unmarshal([]byte(spec.Annotations[constants.AnnotationPropagationExecMounts]), &mounts))
+				require.Equal(t, []virtiofs.VirtioMounts{
+					{VirtiofsSource: tt.parentSource, Destination: "/workspace/team-share"},
+					{VirtiofsSource: tt.childSource, Destination: "/workspace/team-share/members/agent-a"},
+				}, mounts)
+			}
+		})
+	}
+}

--- a/docs/guide/persistent-storage.md
+++ b/docs/guide/persistent-storage.md
@@ -363,6 +363,63 @@ Even if a sandbox attempts to access another tenant's path (e.g. via traversal),
 | Application | Platform code constructs paths; user input is not trusted | Tenant isolation under normal operation |
 | OS | Directory owner/mode permissions | Last-resort protection against any bypass |
 
+## Nested Mounts: Shared Read, Writer-Scoped
+
+A nested mount is a pair of mounts where one `mountPath` is below another. This is useful when a group shares one workspace but each sandbox should only write to its own subdirectory. The group can represent an Agent Team, project, department, or tenant; Cube Sandbox does not manage that membership.
+
+For example, an Agent Team can use this host layout:
+
+```text
+/data/shared/tenant-a/team-blue/
+├── shared-input.txt
+└── members/
+    ├── agent-a/
+    └── agent-b/
+```
+
+Agent A receives the shared workspace as read-only, then its own directory as a nested read-write mount:
+
+```python
+import json
+
+mounts = json.dumps([
+    {
+        "hostPath": "/data/shared/tenant-a/team-blue",
+        "mountPath": "/workspace",
+        "readOnly": True,
+    },
+    {
+        "hostPath": "/data/shared/tenant-a/team-blue/members/agent-a",
+        "mountPath": "/workspace/members/agent-a",
+        "readOnly": False,
+    },
+])
+```
+
+Agent B uses the same read-only parent and mounts only `members/agent-b` as read-write. Agents can use different sandbox templates; the storage layout and access modes remain the same.
+
+| Path visible to Agent A | Read | Write | Why |
+|-------------------------|------|-------|-----|
+| `/workspace/shared-input.txt` | Yes | No | Provided by the shared read-only parent |
+| `/workspace/members/agent-a/` | Yes | Yes | Replaced at that path by Agent A's read-write child mount |
+| `/workspace/members/agent-b/` | Yes | No | Still provided by the shared read-only parent |
+| Another tenant's workspace | No | No | Its host path is not mounted into this sandbox |
+
+This is a **shared-readable, writer-scoped** model. “Writer-scoped” means only the selected sandbox receives a writable mount for that directory; it does not make the directory unreadable to peers when the read-only parent exposes it.
+
+### Mount Semantics and Constraints
+
+- During AppSnapshot restore, Cubelet applies parent destinations before nested destinations, regardless of the descriptor order. This prevents a later parent mount from hiding an already-mounted child. Unrelated paths have a deterministic order but no parent-child meaning.
+- A child mount shadows the parent at that exact subtree; the two directory views are not merged. Files from the parent at the child destination are hidden while the child mount is active.
+- `readOnly` applies to each mount independently, but normal Linux UID, GID, mode, and ACL checks still apply. A read-write child can still return `Permission denied` if its host permissions reject the sandbox user.
+- Prefer one read-only parent and explicit read-write children. Avoid duplicate destinations and overlapping writable mounts, because ownership and the visible result become difficult to reason about.
+- Use canonical absolute `mountPath` values without `.` or `..` segments. Do not rely on input order to resolve overlapping destinations.
+- Host mounts are node-local and remain outside the sandbox snapshot. On restore, every `hostPath` must be available on the scheduled node; use a shared filesystem at the same path on every node when required.
+
+::: warning Authorization boundary
+The platform calling `Sandbox.create()` must derive `hostPath` from the authenticated sandbox owner and the applicable group boundary, such as a tenant, team, or project. Do not accept an arbitrary host path from the user, and do not mount a global root such as `/data/shared/tenants/` into a tenant sandbox: a read-only mount prevents writes but does not prevent the sandbox from reading other tenants' data.
+:::
+
 ## Best Practices
 
 - **Prefer read-only mounts** for input data (datasets, models, configs). This prevents accidental writes from the sandbox and is the safest default.

--- a/docs/zh/guide/persistent-storage.md
+++ b/docs/zh/guide/persistent-storage.md
@@ -363,6 +363,63 @@ sudo chmod 0700 /data/shared/tenant-b
 | 应用层 | 平台代码拼接路径，不信任用户输入 | 正常场景下的租户隔离 |
 | 操作系统 | 目录 owner/mode 权限 | 兜底防护，防止任何绕过 |
 
+## 嵌套挂载：共享可读、写入范围独立
+
+当一个挂载的 `mountPath` 位于另一个挂载的子目录下时，这两个挂载构成嵌套挂载。它适用于一组沙箱共享同一个工作区、但每个沙箱只能写入自己子目录的场景。这里的“组”可以是 Agent Team、项目、部门或租户；Cube Sandbox 本身不负责管理这些成员关系。
+
+例如，一个 Agent Team 可以使用下面的宿主机目录结构：
+
+```text
+/data/shared/tenant-a/team-blue/
+├── shared-input.txt
+└── members/
+    ├── agent-a/
+    └── agent-b/
+```
+
+Agent A 以只读方式挂载共享工作区，再把自己的目录嵌套挂载为读写：
+
+```python
+import json
+
+mounts = json.dumps([
+    {
+        "hostPath": "/data/shared/tenant-a/team-blue",
+        "mountPath": "/workspace",
+        "readOnly": True,
+    },
+    {
+        "hostPath": "/data/shared/tenant-a/team-blue/members/agent-a",
+        "mountPath": "/workspace/members/agent-a",
+        "readOnly": False,
+    },
+])
+```
+
+Agent B 使用相同的只读父挂载，只把 `members/agent-b` 挂载为读写。各 Agent 可以使用不同的沙箱模板，存储目录和访问模式不需要因此改变。
+
+| Agent A 可见的路径 | 可读 | 可写 | 原因 |
+|--------------------|------|------|------|
+| `/workspace/shared-input.txt` | 是 | 否 | 来自共享的只读父挂载 |
+| `/workspace/members/agent-a/` | 是 | 是 | 该位置被 Agent A 的读写子挂载替换 |
+| `/workspace/members/agent-b/` | 是 | 否 | 仍然来自共享的只读父挂载 |
+| 其他租户的工作区 | 否 | 否 | 对应宿主机路径没有挂载到当前沙箱 |
+
+这是一种**共享可读、写入范围独立**的模型。“写入范围独立”表示只有指定沙箱会获得该目录的可写挂载；如果只读父挂载暴露了这个目录，并不代表其他成员无法读取它。
+
+### 挂载语义和约束
+
+- AppSnapshot 恢复时，无论描述符按什么顺序传入，Cubelet 都会先应用父目标路径，再应用嵌套的子目标路径，避免后挂载的父目录遮住已经挂载的子目录。无关路径也会使用确定的顺序，但这个顺序不表示它们存在父子关系。
+- 子挂载会在对应子树位置遮住父挂载；两个目录视图不会合并。子挂载生效期间，父挂载在该位置原有的文件会被隐藏。
+- `readOnly` 对每个挂载独立生效，但仍需满足 Linux 的 UID、GID、mode 和 ACL 权限。即使子挂载是读写模式，如果宿主机权限不允许沙箱用户写入，仍会返回 `Permission denied`。
+- 推荐使用一个只读父挂载和明确的读写子挂载。避免重复目标路径或相互重叠的读写挂载，否则目录归属和最终可见结果会变得难以判断。
+- `mountPath` 应使用不含 `.` 或 `..` 路径段的规范绝对路径。不要依赖输入顺序处理相互重叠的目标路径。
+- Host Mount 是节点本地的，并且数据位于沙箱快照之外。恢复时，每个 `hostPath` 都必须在调度节点上可用；如需多节点运行，应在所有节点的同一路径挂载共享文件系统。
+
+::: warning 鉴权边界
+调用 `Sandbox.create()` 的平台必须根据已经认证的沙箱归属主体和适用的组边界（如租户、团队或项目）生成 `hostPath`。不要接受用户任意传入的宿主机路径，也不要把 `/data/shared/tenants/` 之类的全局根目录挂载到某个租户的沙箱中：只读挂载只能阻止写入，不能阻止该沙箱读取其他租户的数据。
+:::
+
 ## 最佳实践
 
 - **输入数据优先使用只读挂载**（数据集、模型、配置文件等）。这可以防止沙箱意外写入，是最安全的默认选项。


### PR DESCRIPTION
## Summary

- order restore-time host mounts by cleaned container destination so parent paths are mounted before nested children
- preserve the caller's `volume_mounts` order for equivalent destinations, retaining last-mount-wins behavior
- add regression coverage for all parent/child RO/RW combinations, multi-level nesting, and equivalent destination paths

## Testing

- `CGO_ENABLED=0 go test ./plugins/cbri/cubeboxcbri -count=1`
- `CGO_ENABLED=0 go vet ./plugins/cbri/cubeboxcbri`
- targeted mount-order tests repeated with `-count=100`

Fixes #944