### PR TITLE
cubelet: replace jsoniter with encoding/json

### DIFF
--- a/Cubelet/cmd/cubecli/commands/cubebox/create.go
+++ b/Cubelet/cmd/cubecli/commands/cubebox/create.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	jsoniter "github.com/json-iterator/go"
 	"github.com/tencentcloud/CubeSandbox/Cubelet/api/services/cubebox/v1"
 	"github.com/tencentcloud/CubeSandbox/Cubelet/api/services/errorcode/v1"
 	"github.com/tencentcloud/CubeSandbox/Cubelet/cmd/cubecli/commands"
@@ -60,11 +59,12 @@ var Create = &cli.Command{
 				log.Printf("create failure:%v", err)
 				os.Exit(1)
 			}
-			respStr, err := jsoniter.MarshalToString(rsp)
+			data, err := json.Marshal(rsp)
 			if err != nil {
 				log.Printf("failed to marshal resp: %v", err)
 				os.Exit(1)
 			}
+			respStr := string(data)
 			log.Printf("create sandbox rspesponse: %s", respStr)
 			if rsp.Ret.RetCode == errorcode.ErrorCode_Success {
 				log.Printf("create sandbox %s success", rsp.SandboxID)

--- a/Cubelet/cmd/cubecli/commands/image/fix.go
+++ b/Cubelet/cmd/cubecli/commands/image/fix.go
@@ -5,6 +5,7 @@
 package image
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"os/exec"
@@ -13,7 +14,6 @@ import (
 	"syscall"
 	"time"
 
-	jsoniter "github.com/json-iterator/go"
 	imagestore "github.com/tencentcloud/CubeSandbox/Cubelet/pkg/store/image"
 	"github.com/tencentcloud/CubeSandbox/Cubelet/pkg/utils"
 	"github.com/urfave/cli/v2"
@@ -79,7 +79,7 @@ var Fix = &cli.Command{
 
 		for _, data := range nfsImageMap {
 			img := &imagestore.Image{}
-			err = jsoniter.Unmarshal(data, img)
+			err = json.Unmarshal(data, &img)
 			if err != nil {
 				fmt.Printf("unmarshal nfs image failed %s\n", err.Error())
 				continue

--- a/Cubelet/cmd/cubecli/commands/image/fix.go
+++ b/Cubelet/cmd/cubecli/commands/image/fix.go
@@ -79,7 +79,7 @@ var Fix = &cli.Command{
 
 		for _, data := range nfsImageMap {
 			img := &imagestore.Image{}
-			err = json.Unmarshal(data, &img)
+			err = json.Unmarshal(data, img)
 			if err != nil {
 				fmt.Printf("unmarshal nfs image failed %s\n", err.Error())
 				continue

--- a/Cubelet/cmd/cubecli/commands/image/remove.go
+++ b/Cubelet/cmd/cubecli/commands/image/remove.go
@@ -6,10 +6,10 @@ package image
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 
-	jsoniter "github.com/json-iterator/go"
 	"github.com/sirupsen/logrus"
 	"github.com/tencentcloud/CubeSandbox/Cubelet/api/services/cubebox/v1"
 	"github.com/tencentcloud/CubeSandbox/Cubelet/cmd/cubecli/commands"
@@ -84,7 +84,7 @@ var removeImageCommand = &cli.Command{
 			}
 			for _, box := range resp.GetItems() {
 				cubeBox := &cubeboxstore.CubeBox{}
-				err := jsoniter.Unmarshal(box.PrivateCubeboxStorageData, cubeBox)
+				err := json.Unmarshal(box.PrivateCubeboxStorageData, cubeBox)
 				if err != nil {
 					return fmt.Errorf("failed to unmarshal cubebox for %s: %w", box.Id, err)
 				}

--- a/Cubelet/cmd/cubecli/commands/storage/ls.go
+++ b/Cubelet/cmd/cubecli/commands/storage/ls.go
@@ -11,7 +11,7 @@ import (
 	"os"
 	"text/tabwriter"
 
-	jsoniter "github.com/json-iterator/go"
+	"encoding/json"
 	"github.com/urfave/cli/v2"
 	"google.golang.org/grpc/status"
 
@@ -70,7 +70,8 @@ var lsdb = &cli.Command{
 
 		if cliCtx.Bool("raw") {
 			for _, sb := range resp.GetSandboxes() {
-				out, _ := jsoniter.MarshalToString(sb)
+				data, _ := json.Marshal(sb)
+				out := string(data)
 				fmt.Printf("%s\t%s\n", sb.GetSandboxID(), out)
 			}
 			return nil
@@ -107,7 +108,8 @@ func printStorageRows(w io.Writer, sandboxes []*cubebox.SandboxStorageInfo, each
 				volume.GetGen(),
 			)
 			if eachRaw {
-				raw, _ := jsoniter.MarshalToString(volume)
+				data, _ := json.Marshal(volume)
+				raw := string(data)
 				row += fmt.Sprintf("\t%s", raw)
 			}
 			if _, err := fmt.Fprintln(tw, row); err != nil {

--- a/Cubelet/cmd/cubecli/commands/unsafe/volumedb.go
+++ b/Cubelet/cmd/cubecli/commands/unsafe/volumedb.go
@@ -13,7 +13,7 @@ import (
 	"path/filepath"
 	"time"
 
-	jsoniter "github.com/json-iterator/go"
+	"encoding/json"
 	"github.com/tencentcloud/CubeSandbox/Cubelet/api/services/cubebox/v1"
 	"github.com/tencentcloud/CubeSandbox/Cubelet/cmd/cubecli/commands"
 	"github.com/tencentcloud/CubeSandbox/Cubelet/pkg/constants"
@@ -88,7 +88,7 @@ var volumedb = &cli.Command{
 		allSandboxVolumes := map[string]*createInfo{}
 		for k, v := range all {
 			bf := &createInfo{}
-			err = jsoniter.ConfigFastest.Unmarshal(v, bf)
+			err = json.Unmarshal(v, bf)
 			if err != nil {
 				log.Printf("decode[%s]  fail:%v", k, err)
 				continue

--- a/Cubelet/go.mod
+++ b/Cubelet/go.mod
@@ -18,7 +18,6 @@ require (
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/imdario/mergo v0.3.12
 	github.com/ipfs/go-cid v0.4.1
-	github.com/json-iterator/go v1.1.12
 	github.com/marspere/goencrypt v1.0.7
 	github.com/moby/sys/mountinfo v0.7.2
 	github.com/opencontainers/go-digest v1.0.0
@@ -97,6 +96,7 @@ require (
 	github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.3.0 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/intel/goresctrl v0.10.0 // indirect
+	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/klauspost/compress v1.18.1 // indirect
 	github.com/klauspost/cpuid/v2 v2.3.0 // indirect
 	github.com/leodido/go-urn v1.4.0 // indirect

--- a/Cubelet/internal/cube/server/images/uids_file.go
+++ b/Cubelet/internal/cube/server/images/uids_file.go
@@ -11,12 +11,12 @@ import (
 	"path/filepath"
 	"time"
 
+	"encoding/json"
 	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/containerd/v2/core/images"
 	"github.com/containerd/containerd/v2/core/mount"
 	"github.com/containerd/containerd/v2/pkg/namespaces"
 	"github.com/containerd/errdefs"
-	jsoniter "github.com/json-iterator/go"
 	"github.com/opencontainers/image-spec/identity"
 
 	"github.com/tencentcloud/CubeSandbox/Cubelet/pkg/constants"
@@ -75,11 +75,13 @@ func (c *CubeImageService) GenImageExtraAttributes(ctx context.Context, oldimg, 
 				fieldPaths = append(fieldPaths, "labels."+constants.LabelImageHostLowerDirsPrefix)
 
 				dirs = utils.RemoveStringPrefix(dirs, prefix)
-				s, _ := jsoniter.MarshalToString(dirs)
+				data, _ := json.Marshal(dirs)
+				s := string(data)
 				i.Labels[constants.LabelImageLayerDirs] = s
 				fieldPaths = append(fieldPaths, "labels."+constants.LabelImageLayerDirs)
 			} else {
-				s, _ := jsoniter.MarshalToString(dirs)
+				data, _ := json.Marshal(dirs)
+				s := string(data)
 				i.Labels[constants.LabelImageHostLowerDirs] = s
 				fieldPaths = append(fieldPaths, "labels."+constants.LabelImageHostLowerDirs)
 			}

--- a/Cubelet/network/proto/network.go
+++ b/Cubelet/network/proto/network.go
@@ -11,7 +11,6 @@ import (
 	"os"
 
 	"github.com/containerd/containerd/v2/pkg/oci"
-	jsoniter "github.com/json-iterator/go"
 	"github.com/tencentcloud/CubeSandbox/Cubelet/pkg/constants"
 	"github.com/tencentcloud/CubeSandbox/Cubelet/pkg/log"
 )
@@ -133,7 +132,7 @@ func (r *ShimNetReq) AllocatedPorts() []PortMapping {
 }
 
 func (r *ShimNetReq) OCISpecOpts() oci.SpecOpts {
-	b, _ := jsoniter.Marshal(r)
+	b, _ := json.Marshal(r)
 
 	return oci.WithAnnotations(map[string]string{
 		constants.AnnotationsNetWork: string(b),

--- a/Cubelet/pkg/apis/shimapi/devices.go
+++ b/Cubelet/pkg/apis/shimapi/devices.go
@@ -8,8 +8,8 @@ import (
 	"context"
 	"fmt"
 
+	"encoding/json"
 	"github.com/containerd/containerd/v2/client"
-	jsoniter "github.com/json-iterator/go"
 	"github.com/tencentcloud/CubeSandbox/Cubelet/pkg/apis/shimapi/shimtypes"
 	"github.com/tencentcloud/CubeSandbox/Cubelet/pkg/log"
 	"github.com/tencentcloud/CubeSandbox/cubelog"
@@ -47,7 +47,8 @@ func (csc *cubeShimControl) AddDevices(ctx context.Context, devices []*shimtypes
 			API_UPDATE_ACTION_KEY: API_ACTION_HOT_PLUGIN_ADD,
 		})
 
-		b, err := jsoniter.MarshalToString(toAppendDevices)
+		data, err := json.Marshal(toAppendDevices)
+		b := string(data)
 		if err != nil {
 			logEntry.WithError(err).Errorf("failed to marshal device list")
 			return fmt.Errorf("failed to marshal device list")
@@ -90,7 +91,8 @@ func (csc *cubeShimControl) DelDevices(ctx context.Context, devices []*shimtypes
 			"action":  "HotPlugDevice.del",
 		})
 
-		b, err := jsoniter.MarshalToString(toADeletedDevices)
+		data, err := json.Marshal(toADeletedDevices)
+		b := string(data)
 		if err != nil {
 			logEntry.WithError(err).Errorf("failed to marshal device list")
 			return fmt.Errorf("failed to marshal device list")

--- a/Cubelet/pkg/apis/shimapi/virtiofs.go
+++ b/Cubelet/pkg/apis/shimapi/virtiofs.go
@@ -8,8 +8,8 @@ import (
 	"context"
 	"fmt"
 
+	"encoding/json"
 	"github.com/containerd/containerd/v2/client"
-	jsoniter "github.com/json-iterator/go"
 	"github.com/tencentcloud/CubeSandbox/Cubelet/pkg/constants"
 	"github.com/tencentcloud/CubeSandbox/Cubelet/pkg/container/virtiofs"
 	"github.com/tencentcloud/CubeSandbox/Cubelet/pkg/log"
@@ -45,7 +45,8 @@ func (csc *cubeShimControl) AddAllowedDirs(ctx context.Context, toAppendLayer []
 
 		defaultVfs.VirtioBackendFsConfig.AllowedDirs = allowedDir.UnsortedList()
 		cubebox.VirtiofsMap[constants.CubeDefaultNamespace] = defaultVfs
-		cubeFsValue, err := jsoniter.MarshalToString(defaultVfs)
+		data, err := json.Marshal(defaultVfs)
+		cubeFsValue := string(data)
 		if err != nil {
 			logEntry.WithError(err).Errorf("failed to marshal cube fs config")
 			return fmt.Errorf("failed to marshal cube fs config")

--- a/Cubelet/pkg/container/netfile/netfile.go
+++ b/Cubelet/pkg/container/netfile/netfile.go
@@ -15,8 +15,8 @@ import (
 	"sort"
 	"strings"
 
+	"encoding/json"
 	"github.com/containerd/containerd/v2/pkg/oci"
-	jsoniter "github.com/json-iterator/go"
 
 	"github.com/tencentcloud/CubeSandbox/Cubelet/api/services/cubebox/v1"
 	"github.com/tencentcloud/CubeSandbox/Cubelet/pkg/config"
@@ -173,7 +173,8 @@ func (cn *CubeboxNetfile) OciContainerNetfileSpec(ctx context.Context, container
 			files = append(files, f)
 		}
 
-		d, err := jsoniter.MarshalToString(files)
+		data, err := json.Marshal(files)
+		d := string(data)
 		if err != nil {
 			log.G(ctx).Errorf("container %s marshal netfile files to string failed:%v", containerName, err)
 			return nil

--- a/Cubelet/pkg/log/log_filter.go
+++ b/Cubelet/pkg/log/log_filter.go
@@ -9,7 +9,7 @@ import (
 	"reflect"
 	"strings"
 
-	jsoniter "github.com/json-iterator/go"
+	"encoding/json"
 )
 
 const (
@@ -113,7 +113,8 @@ func (w *CubeWrapperLogEntry) extralFieldsToContent() string {
 	}
 
 	if len(extendsFields) > 0 {
-		jsonStr, _ := jsoniter.MarshalToString(extendsFields)
+		jsonBytes, _ := json.Marshal(extendsFields)
+		jsonStr := string(jsonBytes)
 		return fmt.Sprintf(" with additional fields: %s", jsonStr)
 	}
 	return ""

--- a/Cubelet/pkg/log/logger.go
+++ b/Cubelet/pkg/log/logger.go
@@ -7,7 +7,7 @@ package log
 import (
 	"runtime/debug"
 
-	jsoniter "github.com/json-iterator/go"
+	"encoding/json"
 	"github.com/tencentcloud/CubeSandbox/cubelog"
 )
 
@@ -18,11 +18,11 @@ func IsDebug() bool {
 }
 
 func WithJsonValue(obj any) string {
-	bs, err := jsoniter.MarshalToString(obj)
+	data, err := json.Marshal(obj)
 	if err != nil {
 		return ""
 	}
-	return bs
+	return string(data)
 }
 
 func WithDebugStack() string {

--- a/Cubelet/pkg/store/cubebox/cubebox_test.go
+++ b/Cubelet/pkg/store/cubebox/cubebox_test.go
@@ -11,8 +11,8 @@ import (
 	"testing"
 	"time"
 
+	"encoding/json"
 	containerd "github.com/containerd/containerd/v2/client"
-	jsoniter "github.com/json-iterator/go"
 	"github.com/stretchr/testify/assert"
 	"github.com/tencentcloud/CubeSandbox/Cubelet/api/services/cubebox/v1"
 	v1 "github.com/tencentcloud/CubeSandbox/Cubelet/api/services/images/v1"
@@ -86,13 +86,13 @@ func TestCubeBoxOldFromNew(t *testing.T) {
 	assert.Equal(t, ci.ID, ctr.ID)
 	assert.Equal(t, cubebox.ContainerState_CONTAINER_RUNNING, ctr.Status.Status.State())
 
-	bs, err := jsoniter.Marshal(&info)
+	bs, err := json.Marshal(&info)
 	if err != nil {
 		t.Fatalf("Marshal error: %v", err)
 	}
 
 	var cb CubeBox
-	if err := jsoniter.Unmarshal(bs, &cb); err != nil {
+	if err := json.Unmarshal(bs, &cb); err != nil {
 		t.Fatalf("Unmarshal error: %v", err)
 	}
 
@@ -106,7 +106,7 @@ func TestCubeBoxOldFromNew(t *testing.T) {
 	assert.Equal(t, cubebox.ContainerState_CONTAINER_RUNNING, cntr.Status.Status.State())
 
 	var oldcb OldCubeBox
-	if err := jsoniter.Unmarshal(bs, &oldcb); err != nil {
+	if err := json.Unmarshal(bs, &oldcb); err != nil {
 		t.Fatalf("Unmarshal error: %v", err)
 	}
 
@@ -151,13 +151,13 @@ func TestCubeBoxNewFromOld(t *testing.T) {
 	assert.Equal(t, ci.ID, cntr.ID)
 	assert.Equal(t, cubebox.ContainerState_CONTAINER_RUNNING, cntr.Status.Status.State())
 
-	oldbs, err := jsoniter.Marshal(&oldInfo)
+	oldbs, err := json.Marshal(&oldInfo)
 	if err != nil {
 		t.Fatalf("Marshal error: %v", err)
 	}
 
 	var oldcb OldCubeBox
-	if err := jsoniter.Unmarshal(oldbs, &oldcb); err != nil {
+	if err := json.Unmarshal(oldbs, &oldcb); err != nil {
 		t.Fatalf("Unmarshal error: %v", err)
 	}
 
@@ -167,7 +167,7 @@ func TestCubeBoxNewFromOld(t *testing.T) {
 	assert.Equal(t, cubebox.ContainerState_CONTAINER_RUNNING, cntr.Status.Status.State())
 
 	var newcb CubeBox
-	if err := jsoniter.Unmarshal(oldbs, &newcb); err != nil {
+	if err := json.Unmarshal(oldbs, &newcb); err != nil {
 		t.Fatalf("Unmarshal error: %v", err)
 	}
 
@@ -217,13 +217,13 @@ func TestCubeBoxEncodeDecode(t *testing.T) {
 	assert.Equal(t, ci.ID, ctr.ID)
 	assert.Equal(t, cubebox.ContainerState_CONTAINER_RUNNING, ctr.Status.Status.State())
 
-	bs, err := jsoniter.Marshal(&info)
+	bs, err := json.Marshal(&info)
 	if err != nil {
 		t.Fatalf("Marshal error: %v", err)
 	}
 
 	var cb CubeBox
-	if err := jsoniter.Unmarshal(bs, &cb); err != nil {
+	if err := json.Unmarshal(bs, &cb); err != nil {
 		t.Fatalf("Unmarshal error: %v", err)
 	}
 
@@ -320,7 +320,7 @@ func TestAddContainer(t *testing.T) {
 	assert.Equal(t, ctr.ID, ci.ID)
 	assert.True(t, ctr.Status.Status.State() == cubebox.ContainerState_CONTAINER_RUNNING)
 
-	bs, err := jsoniter.Marshal(info)
+	bs, err := json.Marshal(info)
 	if err != nil {
 		t.Fatalf("Marshal error: %v", err)
 	}
@@ -334,7 +334,7 @@ func TestAddContainer(t *testing.T) {
 		t.Fatalf("Get error: %v", err)
 	}
 	var cb CubeBox
-	if err := jsoniter.Unmarshal(sandboxBytes, &cb); err != nil {
+	if err := json.Unmarshal(sandboxBytes, &cb); err != nil {
 		t.Fatalf("Unmarshal error: %v", err)
 	}
 

--- a/Cubelet/pkg/store/cubebox/pod_image.go
+++ b/Cubelet/pkg/store/cubebox/pod_image.go
@@ -8,8 +8,8 @@ import (
 	"context"
 	"errors"
 
+	"encoding/json"
 	"github.com/containerd/continuity/fs"
-	jsoniter "github.com/json-iterator/go"
 	"github.com/tencentcloud/CubeSandbox/Cubelet/api/services/cubehost/v1"
 	corev1 "k8s.io/api/core/v1"
 )
@@ -83,7 +83,7 @@ func (cb *PodConfig) appendImageLayer(layers []*cubehost.LayerMount) error {
 		if _, ok := cb.HostSharedLayers[l.Name]; !ok {
 			if l.Usage != "" {
 				usage := &fs.Usage{}
-				err := jsoniter.Unmarshal([]byte(l.Usage), usage)
+				err := json.Unmarshal([]byte(l.Usage), usage)
 				if err == nil {
 					newSize = newSize + usage.Size
 					if newSize > cb.ImageStorageQuota && cb.ImageStorageQuota > 0 {
@@ -111,7 +111,7 @@ func (cb *PodConfig) DeleteImageLayer(name string) {
 	if l, ok := cb.HostSharedLayers[name]; ok {
 		if l.Usage != "" {
 			usage := &fs.Usage{}
-			err := jsoniter.Unmarshal([]byte(l.Usage), usage)
+			err := json.Unmarshal([]byte(l.Usage), usage)
 			if err == nil {
 				cb.ImageStorageUsed -= usage.Size
 				if cb.ImageStorageUsed < 0 {

--- a/Cubelet/pkg/store/cubebox/store.go
+++ b/Cubelet/pkg/store/cubebox/store.go
@@ -7,7 +7,7 @@ package cubebox
 import (
 	"errors"
 
-	jsoniter "github.com/json-iterator/go"
+	"encoding/json"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/tools/cache"
 
@@ -214,7 +214,7 @@ func (s *Store) Sync(id string) error {
 
 	sbCopy := s.createSafeCopy(sb)
 
-	bs, err := jsoniter.Marshal(sbCopy)
+	bs, err := json.Marshal(sbCopy)
 	if err != nil {
 		return err
 	}

--- a/Cubelet/pkg/store/network/store.go
+++ b/Cubelet/pkg/store/network/store.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 	"sync"
 
-	jsoniter "github.com/json-iterator/go"
+	"encoding/json"
 
 	"github.com/tencentcloud/CubeSandbox/Cubelet/api/services/cubebox/v1"
 	"github.com/tencentcloud/CubeSandbox/Cubelet/network/proto"
@@ -43,7 +43,7 @@ func RecoverFromDB(db *utils.CubeStore) (*Store, error) {
 
 	for id, netBytes := range all {
 		var net NetworkAllocation
-		if err := jsoniter.Unmarshal(netBytes, &net); err != nil {
+		if err := json.Unmarshal(netBytes, &net); err != nil {
 			return nil, err
 		}
 		var metadata provider.NetworkProvider
@@ -111,7 +111,7 @@ func (s *Store) Sync(id string) error {
 		return utils.ErrorKeyNotFound
 	}
 
-	bs, err := jsoniter.Marshal(net)
+	bs, err := json.Marshal(net)
 	if err != nil {
 		return err
 	}

--- a/Cubelet/pkg/telnet/telnet.go
+++ b/Cubelet/pkg/telnet/telnet.go
@@ -12,7 +12,7 @@ import (
 	"net/http"
 	"time"
 
-	jsoniter "github.com/json-iterator/go"
+	"encoding/json"
 	"github.com/tatsushid/go-fastping"
 
 	"github.com/tencentcloud/CubeSandbox/Cubelet/api/services/errorcode/v1"
@@ -267,7 +267,7 @@ func doHTTPGet(req *http.Request, timeout time.Duration, instanceType string) (e
 	}
 
 	pRes := &httpProbeRet{}
-	err = jsoniter.Unmarshal(b, pRes)
+	err = json.Unmarshal(b, pRes)
 	if err != nil {
 		pRes.ErrorCode = int(errorcode.ErrorCode_PortBindingFailed)
 		pRes.ErrorMsg = string(b)

--- a/Cubelet/pkg/utils/localstorage_test.go
+++ b/Cubelet/pkg/utils/localstorage_test.go
@@ -13,7 +13,7 @@ import (
 	"testing"
 	"time"
 
-	jsoniter "github.com/json-iterator/go"
+	"encoding/json"
 	"github.com/stretchr/testify/assert"
 	bolt "go.etcd.io/bbolt"
 )
@@ -306,7 +306,7 @@ func TestSetBs_Multidb_SingelKey_BenchMark(t *testing.T) {
 			FileSize:  1024 * 1024 * 50,
 			Timestamp: time.Now().Unix(),
 		}
-		value, _ := jsoniter.Marshal(vv)
+		value, _ := json.Marshal(vv)
 
 		key := strconv.FormatInt(int64(i), 10) + strconv.FormatInt(int64(i), 10)
 		err = db.Set(b1, key, value)
@@ -320,7 +320,7 @@ func TestSetBs_Multidb_SingelKey_BenchMark(t *testing.T) {
 	assert.Equal(t, len(all), num)
 	for _, v := range all {
 		m := &meta{}
-		_ = jsoniter.Unmarshal(v, m)
+		_ = json.Unmarshal(v, m)
 
 	}
 }
@@ -361,7 +361,7 @@ func TestSetBs_Multidb_MultiKeys_BenchMark(t *testing.T) {
 			FileSize:  1024 * 1024 * 50,
 			Timestamp: time.Now().Unix(),
 		}
-		value, _ := jsoniter.Marshal(vv)
+		value, _ := json.Marshal(vv)
 		key := strconv.FormatInt(int64(i), 10)
 		err = db.SetBs(key, value, b1, b2s[i])
 		if err != nil {
@@ -384,7 +384,7 @@ func TestSetBs_Multidb_MultiKeys_BenchMark(t *testing.T) {
 		}
 		for _, v := range all {
 			m := &meta{}
-			_ = jsoniter.Unmarshal(v, m)
+			_ = json.Unmarshal(v, m)
 
 		}
 	}

--- a/Cubelet/pkg/utils/strings.go
+++ b/Cubelet/pkg/utils/strings.go
@@ -65,7 +65,7 @@ var ErrLimitReached = errors.New("the read limit is reached")
 
 func ReadAtMost(r io.Reader, limit int64) ([]byte, error) {
 	limitedReader := &io.LimitedReader{R: r, N: limit}
-	// data, err := ioutil.ReadAll(limitedReader)
+		data, err := io.ReadAll(limitedReader)
 	data, err := io.ReadAll(limitedReader)
 	if err != nil {
 		return data, err

--- a/Cubelet/pkg/utils/strings.go
+++ b/Cubelet/pkg/utils/strings.go
@@ -16,17 +16,14 @@ import (
 	"errors"
 	"hash/crc32"
 	"io"
-	"io/ioutil"
 	"reflect"
 	"strings"
 	"unsafe"
 
-	jsoniter "github.com/json-iterator/go"
+	"encoding/json"
 	cubelog "github.com/tencentcloud/CubeSandbox/cubelog"
 	"k8s.io/apimachinery/pkg/util/sets"
 )
-
-var JSONTool = jsoniter.ConfigCompatibleWithStandardLibrary
 
 func String2Slice(s string) []byte {
 	sh := (*reflect.StringHeader)(unsafe.Pointer(&s))
@@ -48,7 +45,7 @@ func InStringSlice(ss []string, str string) bool {
 }
 
 func Decode(body string, req interface{}) error {
-	return JSONTool.Unmarshal([]byte(body), req)
+	return json.Unmarshal([]byte(body), req)
 }
 
 func HashCode(dimension string) uint32 {
@@ -56,7 +53,7 @@ func HashCode(dimension string) uint32 {
 }
 
 func InterfaceToString(obj interface{}) string {
-	body, _ := JSONTool.Marshal(obj)
+	body, _ := json.Marshal(obj)
 	return string(body)
 }
 
@@ -68,7 +65,8 @@ var ErrLimitReached = errors.New("the read limit is reached")
 
 func ReadAtMost(r io.Reader, limit int64) ([]byte, error) {
 	limitedReader := &io.LimitedReader{R: r, N: limit}
-	data, err := ioutil.ReadAll(limitedReader)
+	// data, err := ioutil.ReadAll(limitedReader)
+	data, err := io.ReadAll(limitedReader)
 	if err != nil {
 		return data, err
 	}

--- a/Cubelet/pkg/utils/utils.go
+++ b/Cubelet/pkg/utils/utils.go
@@ -7,6 +7,7 @@ package utils
 import (
 	"bytes"
 	"encoding/binary"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -76,7 +77,7 @@ func GetBodyData(rsp *http.Response, object any) error {
 	if err != nil {
 		return err
 	}
-	err = JSONTool.Unmarshal(data, object)
+	err = json.Unmarshal(data, object)
 	if err != nil {
 		return err
 	}

--- a/Cubelet/plugins/cbri/cubeboxcbri/virtiofs.go
+++ b/Cubelet/plugins/cbri/cubeboxcbri/virtiofs.go
@@ -12,8 +12,8 @@ import (
 	"strconv"
 	"strings"
 
+	"encoding/json"
 	"github.com/containerd/containerd/v2/pkg/oci"
-	jsoniter "github.com/json-iterator/go"
 	"github.com/tencentcloud/CubeSandbox/Cubelet/api/services/cubebox/v1"
 	"github.com/tencentcloud/CubeSandbox/Cubelet/api/services/errorcode/v1"
 	"github.com/tencentcloud/CubeSandbox/Cubelet/pkg/constants"
@@ -84,7 +84,7 @@ func generateSandboxVirtiofsOpt(ctx context.Context, flowOpts *workflow.CreateCo
 	}
 
 	if len(allVirtios) > 0 {
-		vc, _ := jsoniter.Marshal(allVirtios)
+		vc, _ := json.Marshal(allVirtios)
 		specOpts = append(specOpts, oci.WithAnnotations(map[string]string{
 			constants.AnnotationVirtiofs: string(vc),
 		}))
@@ -135,7 +135,7 @@ func generateRestoreVirtiofsOpt(ctx context.Context, flowOpts *workflow.CreateCo
 	}
 
 	if len(allMnts) > 0 {
-		vc, _ := jsoniter.Marshal(allMnts)
+		vc, _ := json.Marshal(allMnts)
 		specOpts = append(specOpts, oci.WithAnnotations(map[string]string{
 			constants.AnnotationPropagationExecMounts:       string(vc),
 			constants.AnnotationPropagationContainerUmounts: virtiofs.GenPropagationContainerUmounts(),
@@ -203,7 +203,7 @@ func generateEmptyVirtiofsDevices(ctx context.Context) (map[string]string, error
 	allVirtios = append(allVirtios, rwVirtioCfg)
 
 	log.G(ctx).Debugf("%s: %+v", constants.AnnotationVirtiofs, allVirtios)
-	vc, _ := jsoniter.Marshal(allVirtios)
+	vc, _ := json.Marshal(allVirtios)
 
 	return map[string]string{
 		constants.AnnotationPropagationMounts:          virtiofs.GenPropagationVirtioDirs(),
@@ -289,7 +289,7 @@ func (e *cubeboxInstancePlugin) genVideoAnnotationOpt(ctx context.Context, opts 
 	videomemoryParam := fmt.Sprintf("vfb.videomemorysize=%d", videoMemorySize)
 
 	cmdlineAppend := []string{videoParam, videomemoryParam}
-	cmdlineAppendJSON, err := jsoniter.Marshal(cmdlineAppend)
+	cmdlineAppendJSON, err := json.Marshal(cmdlineAppend)
 	if err != nil {
 		return tmpSpecs, fmt.Errorf("failed to marshal cmdline append: %v", err)
 	}

--- a/Cubelet/plugins/chi/chics/host_forward_image.go
+++ b/Cubelet/plugins/chi/chics/host_forward_image.go
@@ -12,9 +12,9 @@ import (
 	"sync/atomic"
 	"time"
 
+	"encoding/json"
 	"github.com/containerd/errdefs"
 	"github.com/containerd/typeurl/v2"
-	jsoniter "github.com/json-iterator/go"
 	"github.com/opencontainers/go-digest"
 	"github.com/opencontainers/image-spec/identity"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
@@ -225,7 +225,7 @@ func (s *cubeHostImageReverseClient) sharedHostSnapshotToVm(ctx context.Context,
 func appendImageDescriptors(image imagestore.Image, response *cubehost.ForwardImageResponse) error {
 
 	imageSpec := image.ImageSpec
-	configBytes, err := jsoniter.Marshal(imageSpec)
+	configBytes, err := json.Marshal(imageSpec)
 	if err != nil {
 		return fmt.Errorf("failed to marshal image config: %w", err)
 	}

--- a/Cubelet/plugins/chi/chics/host_image_reverse_client.go
+++ b/Cubelet/plugins/chi/chics/host_image_reverse_client.go
@@ -13,12 +13,12 @@ import (
 	"sync"
 	"time"
 
+	"encoding/json"
 	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/containerd/v2/defaults"
 	"github.com/containerd/containerd/v2/pkg/namespaces"
 	"github.com/containerd/errdefs"
 	"github.com/google/uuid"
-	jsoniter "github.com/json-iterator/go"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/backoff"
 	"google.golang.org/grpc/credentials/insecure"
@@ -424,7 +424,8 @@ func (s *cubeHostImageReverseClient) handleRemoveSnapshot(ctx context.Context, c
 		start = time.Now()
 	)
 	toRemove := vmReq.GetRemoveSnapshotRequest().GetLayerMounts()
-	v, _ := jsoniter.MarshalToString(toRemove)
+	data, _ := json.Marshal(toRemove)
+	v := string(data)
 	log := log.G(ctx).WithFields(CubeLog.Fields{
 		"toRemove":  v,
 		"requestID": vmReq.Id,

--- a/Cubelet/plugins/cube/internals/cgroup/cgroup.go
+++ b/Cubelet/plugins/cube/internals/cgroup/cgroup.go
@@ -11,7 +11,7 @@ import (
 	"path"
 	"time"
 
-	jsoniter "github.com/json-iterator/go"
+	"encoding/json"
 	"github.com/shopspring/decimal"
 	"k8s.io/apimachinery/pkg/api/resource"
 
@@ -81,7 +81,7 @@ func loadVmSnapshotSpec(path string, overhead *OverheadConfig) (VMSnapshotSpecsB
 	if err != nil {
 		return nil, err
 	}
-	err = jsoniter.Unmarshal(bb, &specs)
+	err = json.Unmarshal(bb, &specs)
 	if err != nil {
 		return nil, err
 	}

--- a/Cubelet/plugins/cube/internals/cubes/restart.go
+++ b/Cubelet/plugins/cube/internals/cubes/restart.go
@@ -10,10 +10,10 @@ import (
 	"strings"
 	"time"
 
+	"encoding/json"
 	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/containerd/v2/pkg/namespaces"
 	"github.com/containerd/errdefs"
-	jsoniter "github.com/json-iterator/go"
 
 	"github.com/tencentcloud/CubeSandbox/Cubelet/pkg/constants"
 	"github.com/tencentcloud/CubeSandbox/Cubelet/pkg/log"
@@ -33,7 +33,7 @@ func (l *local) RecoverAllCubebox(ctx context.Context, afterRecover func(ctx con
 	}
 	for id, sandboxBytes := range all {
 		var cb = new(cubeboxstore.CubeBox)
-		if err := jsoniter.Unmarshal(sandboxBytes, &cb); err != nil {
+		if err := json.Unmarshal(sandboxBytes, &cb); err != nil {
 			log.G(ctx).Errorf("Unmarshal to cubebox %s from meta: %v", id, err)
 			continue
 		}

--- a/Cubelet/plugins/cube/internals/shimlog/local.go
+++ b/Cubelet/plugins/cube/internals/shimlog/local.go
@@ -14,10 +14,10 @@ import (
 	"sync"
 	"time"
 
+	"encoding/json"
 	"github.com/containerd/containerd/v2/core/mount"
 	"github.com/containerd/containerd/v2/pkg/namespaces"
 	"github.com/containerd/fifo"
-	jsoniter "github.com/json-iterator/go"
 	"github.com/moby/sys/mountinfo"
 	"github.com/tencentcloud/CubeSandbox/Cubelet/api/services/errorcode/v1"
 	"github.com/tencentcloud/CubeSandbox/Cubelet/pkg/constants"
@@ -236,7 +236,7 @@ func (l *local) shimStatlog(ctx context.Context, sandBoxID string, f io.ReadClos
 					lines := logBuf.Write(buf[:n])
 					for _, line := range lines {
 						trace := &CubeLog.RequestTrace{}
-						err := jsoniter.Unmarshal(line, trace)
+						err := json.Unmarshal(line, trace)
 						if err != nil {
 							logEntry.Warnf("json.Unmarshal ShimStatLog error: %+v", err)
 							continue

--- a/Cubelet/services/cubebox/annotation.go
+++ b/Cubelet/services/cubebox/annotation.go
@@ -10,9 +10,9 @@ import (
 	"net"
 	"strings"
 
+	"encoding/json"
 	"github.com/containerd/containerd/v2/core/containers"
 	"github.com/containerd/containerd/v2/pkg/oci"
-	jsoniter "github.com/json-iterator/go"
 	"github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/tencentcloud/CubeSandbox/Cubelet/api/services/cubebox/v1"
 	"github.com/tencentcloud/CubeSandbox/Cubelet/api/services/errorcode/v1"
@@ -107,7 +107,7 @@ func getDiskQos(ctx context.Context, realReq *cubebox.RunCubeSandboxRequest, key
 func (l *local) genVirtFsAnnotationOpt(ctx context.Context,
 	opts *workflow.CreateContext,
 	mountsConfig *virtiofs.CubeRootfsInfo) oci.SpecOpts {
-	mc, _ := jsoniter.Marshal(mountsConfig)
+	mc, _ := json.Marshal(mountsConfig)
 	return oci.WithAnnotations(map[string]string{
 		constants.AnnotationsRootfsKey: string(mc),
 	})
@@ -155,7 +155,7 @@ func (l *local) genStorageMediumDefaultAnnotationOpt(ctx context.Context,
 	}
 
 	if len(annotationInfo) > 0 {
-		b, _ := jsoniter.Marshal(annotationInfo)
+		b, _ := json.Marshal(annotationInfo)
 		log.G(ctx).Debugf("%s genContainerTmpOpt %s: %s", opts.SandboxID, constants.AnnotationsMountListKey, string(b))
 		tmpSpecs = append(tmpSpecs, oci.WithAnnotations(map[string]string{
 			constants.AnnotationsMountListKey: string(b),
@@ -200,7 +200,7 @@ func (l *local) genCgroupAnnotationOpt(ctx context.Context, c *cubebox.Container
 		return tmpSpecs
 	}
 
-	resJson, _ := jsoniter.Marshal(cgInfo.VmSnapshotSpec)
+	resJson, _ := json.Marshal(cgInfo.VmSnapshotSpec)
 	log.G(ctx).Debugf("%v genCgroupAnnotationOpt:%+v,vmres:%v", opts.SandboxID,
 		cgInfo.CgroupID, string(resJson))
 

--- a/Cubelet/services/cubebox/cube_container_create.go
+++ b/Cubelet/services/cubebox/cube_container_create.go
@@ -26,7 +26,6 @@ import (
 	"github.com/containerd/containerd/v2/pkg/oci"
 	"github.com/containerd/errdefs"
 	"github.com/containerd/typeurl/v2"
-	jsoniter "github.com/json-iterator/go"
 	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/opencontainers/runtime-spec/specs-go"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -432,7 +431,7 @@ func (l *local) genSandboxOptions(ctx context.Context, realReq *cubebox.RunCubeS
 		return nil, ret.Errorf(errorcode.ErrorCode_InvalidParamFormat, "generate sandbox dns annotation failed: %v", err)
 	}
 	if len(dnsServers) > 0 {
-		data, err := jsoniter.Marshal(dnsServers)
+		data, err := json.Marshal(dnsServers)
 		if err != nil {
 			return nil, ret.Errorf(errorcode.ErrorCode_InvalidParamFormat, "marshal dns servers failed: %v", err)
 		}
@@ -687,7 +686,7 @@ func WithCubeFsAnnotation(ctx context.Context,
 			sandBox.VirtiofsMap = make(map[string]*virtiofs.VirtiofsConfig)
 		}
 		sandBox.VirtiofsMap[constants.CubeDefaultNamespace] = virtiofsConfig
-		vc, err := jsoniter.Marshal(virtiofsConfig)
+		vc, err := json.Marshal(virtiofsConfig)
 		if err != nil {
 			return nil, ret.Errorf(errorcode.ErrorCode_InvalidParamFormat, "marshal virtiofs config failed: %v", err)
 		}

--- a/Cubelet/services/cubebox/service.go
+++ b/Cubelet/services/cubebox/service.go
@@ -14,13 +14,13 @@ import (
 	"strings"
 	"time"
 
+	"encoding/json"
 	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/containerd/v2/core/events/exchange"
 	"github.com/containerd/containerd/v2/pkg/namespaces"
 	"github.com/containerd/containerd/v2/plugins"
 	"github.com/containerd/plugin"
 	"github.com/containerd/plugin/registry"
-	jsoniter "github.com/json-iterator/go"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
 	"k8s.io/utils/clock"
@@ -200,8 +200,8 @@ func (s *service) Register(server *grpc.Server) error {
 
 func safePrint(req *cubebox.RunCubeSandboxRequest) string {
 	tmpReq := &cubebox.RunCubeSandboxRequest{}
-	body, _ := jsoniter.Marshal(req)
-	jsoniter.Unmarshal(body, tmpReq)
+	body, _ := json.Marshal(req)
+	json.Unmarshal(body, tmpReq)
 	for _, c := range tmpReq.GetContainers() {
 		c.Envs = []*cubebox.KeyValue{
 			{
@@ -803,7 +803,7 @@ func toGRPCCubeBox(box *cubeboxstore.CubeBox, opt *cubebox.ListCubeSandboxOption
 		cb.Containers = append(cb.Containers, cc)
 	}
 	if opt != nil && opt.GetPrivateWithCubeboxStore() {
-		v, err := jsoniter.MarshalIndent(box, "", "    ")
+		v, err := json.MarshalIndent(box, "", "    ")
 		if err != nil {
 			log.L.Errorf("marshal cubebox to json failed: %v", err)
 		}

--- a/Cubelet/services/gc/gc.go
+++ b/Cubelet/services/gc/gc.go
@@ -12,10 +12,10 @@ import (
 	"path/filepath"
 	"time"
 
+	"encoding/json"
 	"github.com/containerd/containerd/v2/core/mount"
 	"github.com/containerd/containerd/v2/plugins"
 	"github.com/containerd/plugin/registry"
-	jsoniter "github.com/json-iterator/go"
 	"github.com/moby/sys/mountinfo"
 	"github.com/tencentcloud/CubeSandbox/Cubelet/pkg/ret"
 
@@ -209,7 +209,7 @@ type sandBoxInfo struct {
 }
 
 func (l *local) saveSandBoxInfo(info *sandBoxInfo) error {
-	b, _ := jsoniter.Marshal(info)
+	b, _ := json.Marshal(info)
 	return l.db.Set(bucketName, info.SandboxID, b)
 }
 
@@ -229,7 +229,7 @@ func (l *local) readAll() (infos []*sandBoxInfo, _ error) {
 
 	for k, v := range all {
 		bf := &sandBoxInfo{}
-		err = jsoniter.Unmarshal(v, bf)
+		err = json.Unmarshal(v, bf)
 		if err != nil {
 			CubeLog.Warnf("readAll [%s] failed:%s", k, err.Error())
 			continue

--- a/Cubelet/services/images/volume.go
+++ b/Cubelet/services/images/volume.go
@@ -13,8 +13,8 @@ import (
 	"strconv"
 	"time"
 
+	"encoding/json"
 	"github.com/containerd/containerd/v2/pkg/namespaces"
-	jsoniter "github.com/json-iterator/go"
 	"github.com/tencentcloud/CubeSandbox/Cubelet/api/services/errorcode/v1"
 	"github.com/tencentcloud/CubeSandbox/Cubelet/api/services/multimetadb/v1"
 	"github.com/tencentcloud/CubeSandbox/Cubelet/pkg/constants"
@@ -254,7 +254,7 @@ func (l *volumeLocal) CleanUp(ctx context.Context, opts *workflow.CleanContext) 
 }
 
 func (l *volumeLocal) writeVolumeInfo(ctx context.Context, id string, info *createInfo) error {
-	b, _ := jsoniter.ConfigFastest.Marshal(info)
+	b, _ := json.Marshal(info)
 	err := l.db.Set(bucketName, id, b)
 	if err != nil {
 		return err
@@ -271,7 +271,7 @@ func (l *volumeLocal) readVolumeInfo(ctx context.Context, id string) (*createInf
 	_ = l.db.Delete(bucketName, id)
 
 	bf := &createInfo{}
-	err = jsoniter.ConfigFastest.Unmarshal(b, bf)
+	err = json.Unmarshal(b, bf)
 	if err != nil {
 		return nil, err
 	}

--- a/Cubelet/services/images/volumelifetime.go
+++ b/Cubelet/services/images/volumelifetime.go
@@ -21,7 +21,7 @@ import (
 	"time"
 	"unsafe"
 
-	jsoniter "github.com/json-iterator/go"
+	"encoding/json"
 	"github.com/tencentcloud/CubeSandbox/Cubelet/api/services/multimetadb/v1"
 	"github.com/tencentcloud/CubeSandbox/Cubelet/internal/tomlext"
 	"github.com/tencentcloud/CubeSandbox/Cubelet/pkg/constants"
@@ -289,7 +289,7 @@ func (l *volumeLifetime) asyncClean(ctx context.Context,
 			continue
 		}
 		m := &meta{}
-		err = jsoniter.Unmarshal(v, m)
+		err = json.Unmarshal(v, m)
 		if err != nil {
 			CubeLog.Errorf("volumeLifetime[%s] asyncClean ReadAll[%d] Fatal:%v,err:%v,value:%v",
 				bucket, len(all), k, err, string(v))
@@ -572,7 +572,7 @@ func (l *volumeLifetime) isStillRef(m *meta) bool {
 		return false
 	}
 	dbMeta := &meta{}
-	err = jsoniter.Unmarshal(tmpV, dbMeta)
+	err = json.Unmarshal(tmpV, dbMeta)
 	if err != nil {
 		return false
 	}
@@ -685,7 +685,7 @@ func (l *volumeLifetime) syncDb(m *meta) error {
 	if err == nil {
 
 		oldM := &meta{}
-		err := jsoniter.Unmarshal(tmpV, oldM)
+		err := json.Unmarshal(tmpV, oldM)
 		if err == nil {
 			if m.Del == metaDelete || m.Ref < 0 {
 
@@ -726,7 +726,7 @@ func (l *volumeLifetime) syncDb(m *meta) error {
 			CubeLog.Warnf("syncDb Unmarshal key [%s] failed. %s", m.realKey(), err)
 		}
 	}
-	value, err := jsoniter.Marshal(m)
+	value, err := json.Marshal(m)
 	if err != nil {
 		return err
 	}

--- a/Cubelet/services/images/volumeutils.go
+++ b/Cubelet/services/images/volumeutils.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"time"
 
-	jsoniter "github.com/json-iterator/go"
+	"encoding/json"
 	"github.com/tencentcloud/CubeSandbox/Cubelet/api/services/cubebox/v1"
 	"github.com/tencentcloud/CubeSandbox/Cubelet/api/services/errorcode/v1"
 	"github.com/tencentcloud/CubeSandbox/Cubelet/api/services/images/v1"
@@ -67,7 +67,7 @@ func (s *service) doResetVolumeRefExec(ctx context.Context, req *images.VolumUti
 				continue
 			}
 			m := &meta{}
-			err = jsoniter.Unmarshal(v, m)
+			err = json.Unmarshal(v, m)
 			if err != nil {
 				continue
 			}
@@ -92,7 +92,7 @@ func (s *service) doResetVolumeRefExec(ctx context.Context, req *images.VolumUti
 			}
 			m.Ref = 0
 			m.Timestamp = time.Now().Unix()
-			value, err := jsoniter.Marshal(m)
+			value, err := json.Marshal(m)
 			if err != nil {
 				return err
 			}
@@ -146,7 +146,7 @@ func (s *service) doResetVolumeRef(ctx context.Context, req *images.VolumUtilsRe
 				continue
 			}
 			m := &meta{}
-			err = jsoniter.Unmarshal(v, m)
+			err = json.Unmarshal(v, m)
 			if err != nil {
 				continue
 			}
@@ -169,7 +169,7 @@ func (s *service) doResetVolumeRef(ctx context.Context, req *images.VolumUtilsRe
 			}
 			m.Ref = cnt
 			m.Timestamp = time.Now().Unix()
-			value, err := jsoniter.Marshal(m)
+			value, err := json.Marshal(m)
 			if err != nil {
 				return err
 			}

--- a/Cubelet/services/server/tap_provider.go
+++ b/Cubelet/services/server/tap_provider.go
@@ -11,7 +11,7 @@ import (
 	"syscall"
 	"time"
 
-	jsoniter "github.com/json-iterator/go"
+	"encoding/json"
 	"github.com/tencentcloud/CubeSandbox/Cubelet/network"
 	netproto "github.com/tencentcloud/CubeSandbox/Cubelet/network/proto"
 	"github.com/tencentcloud/CubeSandbox/cubelog"
@@ -53,7 +53,7 @@ func matchTapFd(buf []byte) (errCode errCode, retFile *os.File, du1, du2 time.Du
 	startTime := time.Now()
 
 	var req Req
-	err := jsoniter.Unmarshal(buf, &req)
+	err := json.Unmarshal(buf, &req)
 	if err != nil {
 		return ParseJsonFailed, nil, du1, du2
 	}

--- a/Cubelet/storage/local.go
+++ b/Cubelet/storage/local.go
@@ -28,9 +28,9 @@ import (
 	"github.com/tencentcloud/CubeSandbox/Cubelet/plugins/cube/internals/cubes"
 	"github.com/tencentcloud/CubeSandbox/Cubelet/plugins/cube/multimeta"
 
+	"encoding/json"
 	"github.com/containerd/containerd/v2/pkg/namespaces"
 	"github.com/containerd/plugin"
-	jsoniter "github.com/json-iterator/go"
 	"k8s.io/apimachinery/pkg/api/resource"
 
 	"github.com/tencentcloud/CubeSandbox/Cubelet/api/services/cubebox/v1"
@@ -226,7 +226,7 @@ func (l *local) RecoverStorageState(ctx context.Context) error {
 			continue
 		}
 		info := &StorageInfo{}
-		if err := jsoniter.ConfigFastest.Unmarshal(data, info); err != nil {
+		if err := json.Unmarshal(data, info); err != nil {
 			return fmt.Errorf("unmarshal storage info %s during recover: %w", id, err)
 		}
 		if err := l.recoverStorageInfo(ctx, id, info); err != nil {
@@ -499,7 +499,7 @@ func (l *local) listDirtyStorage() map[string]bool {
 			continue
 		}
 		bf := &StorageInfo{}
-		err = jsoniter.ConfigFastest.Unmarshal(data, bf)
+		err = json.Unmarshal(data, bf)
 		if err != nil {
 			logEntry.Errorf("storage data leak: failed to unmarshal StorageInfo: %v", err)
 			continue
@@ -582,7 +582,7 @@ func (l *local) Init(ctx context.Context, opts *workflow.InitInfo) error {
 				continue
 			}
 			bf := &StorageInfo{}
-			err = jsoniter.ConfigFastest.Unmarshal(v, bf)
+			err = json.Unmarshal(v, bf)
 			if err != nil {
 				log.G(ctx).Errorf("Init:load Metadata,unmarshal fail:%v", err)
 				continue
@@ -1373,7 +1373,7 @@ func (l *local) readBackendFileInfoRaw(ctx context.Context, id string) (*Storage
 		}
 	}
 	bf := &StorageInfo{}
-	err = jsoniter.ConfigFastest.Unmarshal(b, bf)
+	err = json.Unmarshal(b, bf)
 	if err != nil {
 		return nil, err
 	}
@@ -1392,7 +1392,7 @@ func (l *local) readBackendFileInfo(ctx context.Context, id string) (*StorageInf
 }
 
 func (l *local) writeBackendFileInfo(ctx context.Context, id string, info *StorageInfo) error {
-	b, _ := jsoniter.ConfigFastest.Marshal(info)
+	b, _ := json.Marshal(info)
 	err := l.db.Set(bucketName, id, b)
 	if err != nil {
 
@@ -1414,7 +1414,7 @@ func (l *local) updateCubeBoxBaseInfo(ctx context.Context, templateID string) er
 		return err
 	}
 	info.UpdateAt = time.Now()
-	b, _ := jsoniter.ConfigFastest.Marshal(info)
+	b, _ := json.Marshal(info)
 	err = l.db.Set(bucketName, templateID, b)
 	if err != nil {
 
@@ -1458,7 +1458,7 @@ func (l *local) readAllStorageInfo() (map[string]*StorageInfo, error) {
 	storageInfo := make(map[string]*StorageInfo)
 	for id, data := range all {
 		info := &StorageInfo{}
-		err := jsoniter.ConfigFastest.Unmarshal(data, info)
+		err := json.Unmarshal(data, info)
 		if err != nil {
 			continue
 		}
@@ -1650,7 +1650,7 @@ func (l *local) readStorageInfo(ctx context.Context, id string, bucketName strin
 			return utils.ErrorKeyNotFound
 		}
 	}
-	err = jsoniter.ConfigFastest.Unmarshal(b, infoType)
+	err = json.Unmarshal(b, infoType)
 	if err != nil {
 		return err
 	}
@@ -1658,7 +1658,7 @@ func (l *local) readStorageInfo(ctx context.Context, id string, bucketName strin
 }
 
 func (l *local) writeStorageInfo(ctx context.Context, id string, info interface{}, bucketName string, failoverDirFunc func() string) error {
-	b, _ := jsoniter.ConfigFastest.Marshal(info)
+	b, _ := json.Marshal(info)
 	err := l.db.Set(bucketName, id, b)
 	if err != nil {
 


### PR DESCRIPTION
## Summary

  - Replace Cubelet source usage of `github.com/json-iterator/go` with direct `encoding/json` calls
  - Convert `MarshalToString` callsites to `json.Marshal` plus explicit `string(data)` conversion
  - Replace former `ConfigFastest` / `ConfigCompatibleWithStandardLibrary` paths with standard-library JSON calls
  - Remove `github.com/json-iterator/go` as a direct Cubelet dependency; it remains only as an indirect dependency after `go mod tidy`
  - Add a storage benchmark covering large `StorageInfo` JSON marshal/unmarshal performance

  Closes #48