### PR TITLE
CubeEgress: Emit subjectAltName on MITM leaf certs

### DIFF
--- a/CubeEgress/lua/cert_signer.lua
+++ b/CubeEgress/lua/cert_signer.lua
@@ -130,7 +130,8 @@ local function sign_leaf(sni, dst_ip)
     elseif dst_ip then
         sans:add("IP", dst_ip)
     end
-    cert:add_extension(ext_lib.new("subjectAltName", sans))
+    local ok_san, err_san = cert:set_subject_alt_name(sans)
+    if not ok_san then return nil, "set SAN: " .. tostring(err_san) end
 
     cert:add_extension(ext_lib.new("basicConstraints", "critical,CA:FALSE"))
     cert:add_extension(ext_lib.new("keyUsage",


### PR DESCRIPTION
sign_leaf() built an altname object and passed it to ext_lib.new("subjectAltName", sans), but resty.openssl's x509.extension.new expects the value as a config-syntax *string* (e.g. "DNS:foo,IP:1.2.3.4") — it invokes X509V3_EXT_nconf_nid under the hood. Handed an altname object, it returns nil,err, and because the return value was never checked, cert:add_extension(nil) also silently failed. Result: leaf certs shipped with CN only and no SAN, so modern clients (which have ignored CN since RFC 2818 was deprecated by RFC 6125, and which Chrome/Firefox enforce strictly) rejected them with ERR_CERT_COMMON_NAME_INVALID.

Switch to x509:set_subject_alt_name(altname_obj), which is the purpose-built API that takes an altname instance directly, and check its return value so a future breakage surfaces loudly instead of producing SAN-less certs again.

Before the fix:
```
    * Server certificate:
    *  subject: CN=www.deepseek.com
    *  start date: Jul 13 12:09:56 2026 GMT
    *  expire date: Jul 20 12:10:56 2026 GMT
    *  common name: www.deepseek.com (matched)
    *  issuer: CN=CubeSandbox Egress MITM CA
```
After the fix:
```
    * Server certificate:
    *  subject: CN=www.deepseek.com
    *  start date: Jul 14 01:42:47 2026 GMT
    *  expire date: Jul 21 01:43:47 2026 GMT
    *  subjectAltName: host "www.deepseek.com" matched cert's "www.deepseek.com"
    *  issuer: CN=CubeSandbox Egress MITM CA
```