### PR TITLE
fix(dev-env): bind QEMU port forwards to loopback

### DIFF
--- a/dev-env/run_vm.sh
+++ b/dev-env/run_vm.sh
@@ -203,7 +203,7 @@ QEMU_ARGS=(
   -device virtio-rng-pci
   -drive if=none,id=drive0,format=qcow2,file="${IMAGE_PATH}"
   -device virtio-blk-pci,drive=drive0
-  -nic user,model=virtio-net-pci,hostfwd=tcp::"${SSH_PORT}"-:22,hostfwd=tcp::"${CUBE_API_PORT}"-:3000,hostfwd=tcp::"${CUBE_PROXY_HTTP_PORT}"-:80,hostfwd=tcp::"${CUBE_PROXY_HTTPS_PORT}"-:443,hostfwd=tcp::"${WEB_UI_PORT}"-:12088
+  -nic "user,model=virtio-net-pci,hostfwd=tcp:127.0.0.1:${SSH_PORT}-:22,hostfwd=tcp:127.0.0.1:${CUBE_API_PORT}-:3000,hostfwd=tcp:127.0.0.1:${CUBE_PROXY_HTTP_PORT}-:80,hostfwd=tcp:127.0.0.1:${CUBE_PROXY_HTTPS_PORT}-:443,hostfwd=tcp:127.0.0.1:${WEB_UI_PORT}-:12088"
 )
 
 if [[ "${VM_BACKGROUND}" == "1" ]]; then


### PR DESCRIPTION
## Summary

- bind every QEMU user-network host forward in `dev-env/run_vm.sh` explicitly to loopback
- make the VM's actual listeners match the localhost-only behavior documented by the dev-environment guides and printed at startup

## Reproduction

1. Start the development VM from an unmodified checkout:

```bash
cd dev-env
./run_vm.sh
```

2. In another terminal, inspect the listeners for the default forwarded ports:

```bash
ss -ltnp | grep -E ':(10022|13000|11080|11443|12088)\b'
```

The README and startup output identify these endpoints as `127.0.0.1`, but the unmodified QEMU arguments use `hostfwd=tcp::...`. QEMU interprets the omitted host address as a wildcard bind, so the listeners appear on `0.0.0.0` instead of loopback.

## Root cause

All five forwarding rules omit QEMU's optional `hostaddr` field:

```text
hostfwd=tcp::<host-port>-:<guest-port>
```

An empty `hostaddr` does not mean localhost. It allows QEMU to listen on every IPv4 interface, contrary to the existing documentation and log output.

## Fix

Set `hostaddr` to `127.0.0.1` in the SSH, Cube API, CubeProxy HTTP, CubeProxy HTTPS, and WebUI forwarding rules:

```text
hostfwd=tcp:127.0.0.1:<host-port>-:<guest-port>
```

## Before and after validation

Before the fix:

- the generated QEMU network argument contained five `hostfwd=tcp::...` rules
- a minimal QEMU user-network reproduction with an empty `hostaddr` listened on `0.0.0.0`

After the fix:

- the generated QEMU network argument contains five `hostfwd=tcp:127.0.0.1:...` rules
- the equivalent QEMU reproduction with an explicit host address listens only on `127.0.0.1`
- the documented localhost endpoints and startup output are unchanged and now match runtime behavior

## Validation

```text
bash -n dev-env/run_vm.sh
git diff --check
```

A stubbed QEMU invocation was also used to capture the argument generated by `run_vm.sh`; it confirmed that all five forwarding rules use explicit loopback addresses after the change. A separate minimal QEMU invocation confirmed the listener behavior for omitted and explicit host addresses, and all test processes were stopped afterward.

## Scope

This changes only the local QEMU development helper. It does not alter production deployment networking or make the forwarding address configurable.

Autonomously-by: Codex:GPT-5
