### PR TITLE
fix(dev-sidecar): preserve content-encoded response bodies

### DIFF
--- a/examples/e2b-dev-sidecar/dev_sidecar.py
+++ b/examples/e2b-dev-sidecar/dev_sidecar.py
@@ -284,7 +284,8 @@ async def on_startup(app: web.Application) -> None:
     config = app[CONFIG_KEY]
     connector = TCPConnector(ssl=config["verify_ssl"])
     timeout = ClientTimeout(total=None, connect=30, sock_read=None)
-    # Preserve coded response bytes and the downstream client's encoding negotiation.
+    # Disable upstream decompression so bytes stay aligned with Content-Encoding/ETag.
+    # Do not inject Accept-Encoding; downstream clients own content-coding negotiation.
     app[SESSION_KEY] = ClientSession(
         connector=connector,
         timeout=timeout,

--- a/examples/e2b-dev-sidecar/dev_sidecar.py
+++ b/examples/e2b-dev-sidecar/dev_sidecar.py
@@ -284,7 +284,13 @@ async def on_startup(app: web.Application) -> None:
     config = app[CONFIG_KEY]
     connector = TCPConnector(ssl=config["verify_ssl"])
     timeout = ClientTimeout(total=None, connect=30, sock_read=None)
-    app[SESSION_KEY] = ClientSession(connector=connector, timeout=timeout)
+    # Preserve coded response bytes and the downstream client's encoding negotiation.
+    app[SESSION_KEY] = ClientSession(
+        connector=connector,
+        timeout=timeout,
+        auto_decompress=False,
+        skip_auto_headers={hdrs.ACCEPT_ENCODING},
+    )
 
 
 async def on_cleanup(app: web.Application) -> None:

--- a/examples/e2b-dev-sidecar/test_dev_sidecar.py
+++ b/examples/e2b-dev-sidecar/test_dev_sidecar.py
@@ -114,8 +114,10 @@ async def _content_encoding_proxy(monkeypatch, dev_sidecar):
             accepted_encodings=accepted_encodings,
         )
     finally:
-        await sidecar_runner.cleanup()
-        await upstream_runner.cleanup()
+        try:
+            await sidecar_runner.cleanup()
+        finally:
+            await upstream_runner.cleanup()
 
 
 @pytest.mark.asyncio
@@ -270,6 +272,7 @@ async def test_http_proxy_allows_downstream_client_to_decode_once(
     dev_sidecar,
 ):
     async with _content_encoding_proxy(monkeypatch, dev_sidecar) as proxy:
+        # Keep this local request independent of host proxy environment variables.
         async with httpx.AsyncClient(trust_env=False) as client:
             response = await client.get(
                 proxy.proxy_url,

--- a/examples/e2b-dev-sidecar/test_dev_sidecar.py
+++ b/examples/e2b-dev-sidecar/test_dev_sidecar.py
@@ -5,6 +5,7 @@ import importlib
 import json
 import os
 import sys
+from contextlib import asynccontextmanager
 from pathlib import Path
 
 import httpx
@@ -62,6 +63,43 @@ async def _start_web_app(app: web.Application) -> tuple[web.AppRunner, str]:
     await site.start()
     host, port = runner.addresses[0][:2]
     return runner, f"http://{host}:{port}"
+
+
+@asynccontextmanager
+async def _content_encoding_proxy(monkeypatch, dev_sidecar):
+    payload = b"compressed sandbox response"
+    encoded_payload = gzip.compress(payload, mtime=0)
+    etag = '"encoded-representation"'
+    accepted_encodings: list[str | None] = []
+
+    async def upstream_handler(request: web.Request) -> web.Response:
+        accepted_encoding = request.headers.get(hdrs.ACCEPT_ENCODING)
+        accepted_encodings.append(accepted_encoding)
+        if accepted_encoding is None:
+            return web.Response(body=payload)
+        return web.Response(
+            body=encoded_payload,
+            headers={
+                hdrs.CONTENT_ENCODING: "gzip",
+                hdrs.ETAG: etag,
+                hdrs.VARY: hdrs.ACCEPT_ENCODING,
+            },
+        )
+
+    upstream = web.Application()
+    upstream.router.add_get("/{tail:.*}", upstream_handler)
+    upstream_runner, upstream_url = await _start_web_app(upstream)
+
+    monkeypatch.setenv("CUBE_REMOTE_PROXY_BASE", upstream_url)
+    monkeypatch.setenv("CUBE_REMOTE_SANDBOX_DOMAIN", "cube.app")
+    sidecar_runner, sidecar_url = await _start_web_app(dev_sidecar.build_app())
+    proxy_url = f"{sidecar_url}/sandboxes/router/sbx-1/49983/files"
+
+    try:
+        yield proxy_url, payload, encoded_payload, etag, accepted_encodings
+    finally:
+        await sidecar_runner.cleanup()
+        await upstream_runner.cleanup()
 
 
 @pytest.mark.asyncio
@@ -191,32 +229,12 @@ async def test_http_proxy_forwards_path_query_body_and_host(monkeypatch, dev_sid
 
 
 @pytest.mark.asyncio
-async def test_http_proxy_preserves_content_encoded_response(monkeypatch, dev_sidecar):
-    payload = b"compressed sandbox response"
-    encoded_payload = gzip.compress(payload, mtime=0)
-    etag = '"encoded-representation"'
-    accepted_encodings: list[str | None] = []
-
-    async def upstream_handler(request: web.Request) -> web.Response:
-        accepted_encoding = request.headers.get(hdrs.ACCEPT_ENCODING)
-        accepted_encodings.append(accepted_encoding)
-        if accepted_encoding is None:
-            return web.Response(body=payload)
-        return web.Response(
-            body=encoded_payload,
-            headers={hdrs.CONTENT_ENCODING: "gzip", hdrs.ETAG: etag},
-        )
-
-    upstream = web.Application()
-    upstream.router.add_get("/{tail:.*}", upstream_handler)
-    upstream_runner, upstream_url = await _start_web_app(upstream)
-
-    monkeypatch.setenv("CUBE_REMOTE_PROXY_BASE", upstream_url)
-    monkeypatch.setenv("CUBE_REMOTE_SANDBOX_DOMAIN", "cube.app")
-    sidecar_runner, sidecar_url = await _start_web_app(dev_sidecar.build_app())
-    proxy_url = f"{sidecar_url}/sandboxes/router/sbx-1/49983/files"
-
-    try:
+async def test_http_proxy_preserves_encoded_response_representation(
+    monkeypatch,
+    dev_sidecar,
+):
+    async with _content_encoding_proxy(monkeypatch, dev_sidecar) as proxy:
+        proxy_url, _, encoded_payload, etag, accepted_encodings = proxy
         async with ClientSession(auto_decompress=False) as session:
             async with session.get(
                 proxy_url,
@@ -225,13 +243,31 @@ async def test_http_proxy_preserves_content_encoded_response(monkeypatch, dev_si
                 assert response.status == 200
                 assert response.headers[hdrs.CONTENT_ENCODING] == "gzip"
                 assert response.headers[hdrs.ETAG] == etag
+                assert response.headers[hdrs.VARY] == hdrs.ACCEPT_ENCODING
                 assert await response.read() == encoded_payload
 
+        assert accepted_encodings == ["gzip"]
+
+
+@pytest.mark.asyncio
+async def test_http_proxy_allows_downstream_client_to_decode_once(
+    monkeypatch,
+    dev_sidecar,
+):
+    async with _content_encoding_proxy(monkeypatch, dev_sidecar) as proxy:
+        proxy_url, payload, _, _, accepted_encodings = proxy
         async with httpx.AsyncClient(trust_env=False) as client:
             response = await client.get(proxy_url)
 
         assert response.content == payload
+        assert len(accepted_encodings) == 1
+        assert "gzip" in (accepted_encodings[0] or "")
 
+
+@pytest.mark.asyncio
+async def test_http_proxy_does_not_inject_accept_encoding(monkeypatch, dev_sidecar):
+    async with _content_encoding_proxy(monkeypatch, dev_sidecar) as proxy:
+        proxy_url, payload, _, _, accepted_encodings = proxy
         async with ClientSession(
             skip_auto_headers={hdrs.ACCEPT_ENCODING},
         ) as session:
@@ -239,12 +275,7 @@ async def test_http_proxy_preserves_content_encoded_response(monkeypatch, dev_si
                 assert hdrs.CONTENT_ENCODING not in response.headers
                 assert await response.read() == payload
 
-        assert accepted_encodings[0] == "gzip"
-        assert "gzip" in (accepted_encodings[1] or "")
-        assert accepted_encodings[2] is None
-    finally:
-        await sidecar_runner.cleanup()
-        await upstream_runner.cleanup()
+        assert accepted_encodings == [None]
 
 
 @pytest.mark.asyncio

--- a/examples/e2b-dev-sidecar/test_dev_sidecar.py
+++ b/examples/e2b-dev-sidecar/test_dev_sidecar.py
@@ -6,6 +6,7 @@ import json
 import os
 import sys
 from contextlib import asynccontextmanager
+from dataclasses import dataclass
 from pathlib import Path
 
 import httpx
@@ -65,6 +66,15 @@ async def _start_web_app(app: web.Application) -> tuple[web.AppRunner, str]:
     return runner, f"http://{host}:{port}"
 
 
+@dataclass
+class _ContentEncodingProxyResult:
+    proxy_url: str
+    payload: bytes
+    encoded_payload: bytes
+    etag: str
+    accepted_encodings: list[str | None]
+
+
 @asynccontextmanager
 async def _content_encoding_proxy(monkeypatch, dev_sidecar):
     payload = b"compressed sandbox response"
@@ -96,7 +106,13 @@ async def _content_encoding_proxy(monkeypatch, dev_sidecar):
     proxy_url = f"{sidecar_url}/sandboxes/router/sbx-1/49983/files"
 
     try:
-        yield proxy_url, payload, encoded_payload, etag, accepted_encodings
+        yield _ContentEncodingProxyResult(
+            proxy_url=proxy_url,
+            payload=payload,
+            encoded_payload=encoded_payload,
+            etag=etag,
+            accepted_encodings=accepted_encodings,
+        )
     finally:
         await sidecar_runner.cleanup()
         await upstream_runner.cleanup()
@@ -234,19 +250,18 @@ async def test_http_proxy_preserves_encoded_response_representation(
     dev_sidecar,
 ):
     async with _content_encoding_proxy(monkeypatch, dev_sidecar) as proxy:
-        proxy_url, _, encoded_payload, etag, accepted_encodings = proxy
         async with ClientSession(auto_decompress=False) as session:
             async with session.get(
-                proxy_url,
+                proxy.proxy_url,
                 headers={hdrs.ACCEPT_ENCODING: "gzip"},
             ) as response:
                 assert response.status == 200
                 assert response.headers[hdrs.CONTENT_ENCODING] == "gzip"
-                assert response.headers[hdrs.ETAG] == etag
+                assert response.headers[hdrs.ETAG] == proxy.etag
                 assert response.headers[hdrs.VARY] == hdrs.ACCEPT_ENCODING
-                assert await response.read() == encoded_payload
+                assert await response.read() == proxy.encoded_payload
 
-        assert accepted_encodings == ["gzip"]
+        assert proxy.accepted_encodings == ["gzip"]
 
 
 @pytest.mark.asyncio
@@ -255,27 +270,27 @@ async def test_http_proxy_allows_downstream_client_to_decode_once(
     dev_sidecar,
 ):
     async with _content_encoding_proxy(monkeypatch, dev_sidecar) as proxy:
-        proxy_url, payload, _, _, accepted_encodings = proxy
         async with httpx.AsyncClient(trust_env=False) as client:
-            response = await client.get(proxy_url)
+            response = await client.get(
+                proxy.proxy_url,
+                headers={hdrs.ACCEPT_ENCODING: "gzip"},
+            )
 
-        assert response.content == payload
-        assert len(accepted_encodings) == 1
-        assert "gzip" in (accepted_encodings[0] or "")
+        assert response.content == proxy.payload
+        assert proxy.accepted_encodings == ["gzip"]
 
 
 @pytest.mark.asyncio
 async def test_http_proxy_does_not_inject_accept_encoding(monkeypatch, dev_sidecar):
     async with _content_encoding_proxy(monkeypatch, dev_sidecar) as proxy:
-        proxy_url, payload, _, _, accepted_encodings = proxy
         async with ClientSession(
             skip_auto_headers={hdrs.ACCEPT_ENCODING},
         ) as session:
-            async with session.get(proxy_url) as response:
+            async with session.get(proxy.proxy_url) as response:
                 assert hdrs.CONTENT_ENCODING not in response.headers
-                assert await response.read() == payload
+                assert await response.read() == proxy.payload
 
-        assert accepted_encodings == [None]
+        assert proxy.accepted_encodings == [None]
 
 
 @pytest.mark.asyncio

--- a/examples/e2b-dev-sidecar/test_dev_sidecar.py
+++ b/examples/e2b-dev-sidecar/test_dev_sidecar.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import gzip
 import importlib
 import json
 import os
@@ -8,7 +9,7 @@ from pathlib import Path
 
 import httpx
 import pytest
-from aiohttp import ClientSession, WSMsgType, web
+from aiohttp import ClientSession, WSMsgType, hdrs, web
 from packaging.version import Version
 
 from e2b import ConnectionConfig
@@ -184,6 +185,63 @@ async def test_http_proxy_forwards_path_query_body_and_host(monkeypatch, dev_sid
             "path_qs": "/api/v1/run?hello=1",
             "body": "payload",
         }
+    finally:
+        await sidecar_runner.cleanup()
+        await upstream_runner.cleanup()
+
+
+@pytest.mark.asyncio
+async def test_http_proxy_preserves_content_encoded_response(monkeypatch, dev_sidecar):
+    payload = b"compressed sandbox response"
+    encoded_payload = gzip.compress(payload, mtime=0)
+    etag = '"encoded-representation"'
+    accepted_encodings: list[str | None] = []
+
+    async def upstream_handler(request: web.Request) -> web.Response:
+        accepted_encoding = request.headers.get(hdrs.ACCEPT_ENCODING)
+        accepted_encodings.append(accepted_encoding)
+        if accepted_encoding is None:
+            return web.Response(body=payload)
+        return web.Response(
+            body=encoded_payload,
+            headers={hdrs.CONTENT_ENCODING: "gzip", hdrs.ETAG: etag},
+        )
+
+    upstream = web.Application()
+    upstream.router.add_get("/{tail:.*}", upstream_handler)
+    upstream_runner, upstream_url = await _start_web_app(upstream)
+
+    monkeypatch.setenv("CUBE_REMOTE_PROXY_BASE", upstream_url)
+    monkeypatch.setenv("CUBE_REMOTE_SANDBOX_DOMAIN", "cube.app")
+    sidecar_runner, sidecar_url = await _start_web_app(dev_sidecar.build_app())
+    proxy_url = f"{sidecar_url}/sandboxes/router/sbx-1/49983/files"
+
+    try:
+        async with ClientSession(auto_decompress=False) as session:
+            async with session.get(
+                proxy_url,
+                headers={hdrs.ACCEPT_ENCODING: "gzip"},
+            ) as response:
+                assert response.status == 200
+                assert response.headers[hdrs.CONTENT_ENCODING] == "gzip"
+                assert response.headers[hdrs.ETAG] == etag
+                assert await response.read() == encoded_payload
+
+        async with httpx.AsyncClient(trust_env=False) as client:
+            response = await client.get(proxy_url)
+
+        assert response.content == payload
+
+        async with ClientSession(
+            skip_auto_headers={hdrs.ACCEPT_ENCODING},
+        ) as session:
+            async with session.get(proxy_url) as response:
+                assert hdrs.CONTENT_ENCODING not in response.headers
+                assert await response.read() == payload
+
+        assert accepted_encodings[0] == "gzip"
+        assert "gzip" in (accepted_encodings[1] or "")
+        assert accepted_encodings[2] is None
     finally:
         await sidecar_runner.cleanup()
         await upstream_runner.cleanup()


### PR DESCRIPTION
## Summary

- preserve content-encoded response bytes and their representation metadata through the E2B dev sidecar
- avoid adding `Accept-Encoding` when the downstream client did not request content coding
- add regression coverage for gzip forwarding, normal client decoding, and encoding negotiation

## Reproduction

1. Configure `examples/e2b-dev-sidecar/.env` as described in its README, using a reachable CubeAPI, CubeProxy, and a valid template.
2. From `examples/e2b-dev-sidecar`, run:

```python
import os

from dotenv import load_dotenv

load_dotenv()

from dev_sidecar import setup_dev_sidecar

setup_dev_sidecar()

from e2b_code_interpreter import Sandbox

with Sandbox.create(template=os.environ["CUBE_TEMPLATE_ID"]) as sandbox:
    path = "/tmp/cube-sidecar-gzip.txt"
    sandbox.files.write(path, "sidecar gzip check")
    print(sandbox.files.read(path))
```

Expected: the file content is returned.

## Before fix

On the unmodified implementation:

- sandbox creation succeeded
- `sandbox.run_code(...)` succeeded
- `sandbox.files.read(...)` failed with `httpx.DecodingError` containing `incorrect header check`

The regression test added by this PR also fails before the fix: the sidecar sends an already-decoded response body while retaining `Content-Encoding: gzip`.

## Root cause

The proxy forwards the upstream `Content-Encoding` header, but its shared aiohttp `ClientSession` automatically decompresses response bodies by default. The downstream E2B/httpx client therefore receives decoded bytes labeled as gzip and attempts to decompress them a second time.

The same aiohttp session also adds `Accept-Encoding` by default when the downstream request omitted it, changing encoding negotiation at the proxy boundary.

## Fix

Configure the proxy-only aiohttp session to:

- use `auto_decompress=False`, keeping the response bytes consistent with `Content-Encoding` and representation metadata such as `ETag`
- skip automatic `Accept-Encoding` generation while continuing to forward an explicitly supplied downstream header

## After fix

The same deployed-cluster reproduction completed successfully:

- sandbox creation: passed
- `sandbox.run_code(...)`: passed
- `sandbox.commands.run(...)`: passed
- `sandbox.files.write(...)` and `sandbox.files.read(...)`: passed
- sandbox cleanup on context exit: passed

The reproduction prints `sidecar gzip check` as expected.

## Validation

Automated regression coverage verifies that:

- raw gzip bytes, `Content-Encoding`, `ETag`, and `Vary` are preserved through the proxy
- a normal httpx client decodes the response exactly once
- a request without `Accept-Encoding` is forwarded without the sidecar adding one

Commands run:

```text
cd examples/e2b-dev-sidecar
python3 -m pytest test_dev_sidecar.py -q
# 10 passed

python3 -m py_compile dev_sidecar.py test_dev_sidecar.py
git diff --check
```

A live E2B flow was also validated against a deployed CubeSandbox cluster using sandbox creation, code execution, command execution, file write/read, and cleanup.

## Scope

This change only affects the HTTP response path and content-coding negotiation in `examples/e2b-dev-sidecar`. CubeAPI and CubeProxy behavior are unchanged.

Autonomously-by: Codex:GPT-5
