### PR TITLE
ch-remote: default snapshot type to full instead of incremental

### DIFF
--- a/hypervisor/src/bin/ch-remote.rs
+++ b/hypervisor/src/bin/ch-remote.rs
@@ -694,7 +694,7 @@ fn main() {
                         .long("snapshot-type")
                         .help("Snapshot type: 'full', 'incremental' (saves only CoW anonymous pages) or 'soft-dirty' (true delta of pages written since the previous soft-dirty snapshot; falls back to 'incremental' on kernels without CONFIG_MEM_SOFT_DIRTY)")
                         .num_args(1)
-                        .default_value("incremental"),
+                        .default_value("full"),
                 )
                 .arg(
                     Arg::new("memory_vol_url")
@@ -725,7 +725,7 @@ fn main() {
                         .long("snapshot-type")
                         .help("Snapshot type: 'full', 'incremental' (saves only CoW anonymous pages) or 'soft-dirty' (true delta of pages written since the previous soft-dirty snapshot; falls back to 'incremental' on kernels without CONFIG_MEM_SOFT_DIRTY)")
                         .num_args(1)
-                        .default_value("incremental"),
+                        .default_value("full"),
                 )
                 .arg(
                     Arg::new("memory_vol_url")


### PR DESCRIPTION
The `snapshot` and `pause2snapshot` subcommands of ch-remote hardcoded `--snapshot-type` to `.default_value("incremental")`. This contradicted the `#[default]` marker on `SnapshotType::Full` in vm-migration and, more importantly, made every cold-start snapshot fail because the incremental (pagemap_anon) path requires a pre-existing base file at the destination:

    Cannot send VM snapshot: Failed to send migratable component
    snapshot: Base snapshot file not found at
    "/tmp/.../snapshot/memory-ranges", incremental (pagemap_anon)
    snapshot requires an existing base file

Integration tests that take a first snapshot via
`snapshot_and_check_events` (e.g.
`test_restored_vsock_accepts_new_passthrough_fd`) never pass `--snapshot-type`, so they consistently tripped this failure.

Change the CLI default back to `full` so that the unspecified case matches `SnapshotType::default()` and produces a self-contained memory image on the first snapshot. Users who want the incremental or soft-dirty paths can still opt in explicitly via `--snapshot-type incremental` / `--snapshot-type soft-dirty`. Also clarify the help text to note that `incremental` needs an existing base snapshot.