### PR TITLE
lifecycle: Sync pause/resume state from CubeMaster to CLM

### DIFF
--- a/CubeMaster/pkg/lifecycle/init.go
+++ b/CubeMaster/pkg/lifecycle/init.go
@@ -44,6 +44,8 @@ func Init(ctx context.Context) error {
 	sandbox.RegisterAfterDestroySandboxSuccessHook(onAfterDestroy)
 	task.RegisterAfterDestroyTaskSuccessHook(onAfterDestroy)
 
+	sandbox.RegisterAfterUpdateSandboxSuccessHook(onAfterUpdate)
+
 	sandbox.SetTimeoutProvider(&storeTimeoutProvider{store: store})
 
 	log.G(ctx).Infof("lifecycle: auto-pause metadata channel ready (key=%s, stream=%s)",
@@ -156,4 +158,34 @@ func onAfterDestroy(ctx context.Context, sandboxID string) error {
 		store.PublishDelete(ctx, sandboxID)
 	}
 	return nil
+}
+
+// PublishStateDefault is the public entry point for callers that don't hold a
+// *Store reference to announce a pause / resume transition to the CLM.
+// Safe to call when lifecycle is disabled or Redis is unreachable — the
+// underlying Store swallows those cases.
+func PublishStateDefault(ctx context.Context, sandboxID, state, source string) {
+	if store := getDefaultStore(); store != nil {
+		store.PublishState(ctx, sandboxID, state, source)
+	}
+}
+
+// onAfterUpdate maps a successful pause / resume action to the corresponding
+// terminal state and forwards it to the CLM via the events stream.
+// Registered with sandbox.RegisterAfterUpdateSandboxSuccessHook in Init.
+//
+// Unknown actions are ignored (the update handler already validates that
+// action ∈ {"pause","resume"}; this is defence-in-depth against future
+// action codes reaching the hook chain without a schema update here).
+func onAfterUpdate(ctx context.Context, sandboxID, _ /*instanceType*/, action, _ /*requestID*/ string) {
+	var state string
+	switch action {
+	case "pause":
+		state = StatePaused
+	case "resume":
+		state = StateRunning
+	default:
+		return
+	}
+	PublishStateDefault(ctx, sandboxID, state, "api")
 }

--- a/CubeMaster/pkg/lifecycle/schema.go
+++ b/CubeMaster/pkg/lifecycle/schema.go
@@ -3,20 +3,33 @@
 //
 
 // Package lifecycle owns the cross-process metadata channel used by
-// CubeProxy-sidecar to track auto-pause / auto-resume decisions.
+// CLM to track auto-pause / auto-resume decisions.
 //
 // CubeMaster is the single writer for the canonical view:
 //
 //   - cube:v1:shared:sandbox:lifecycle:meta    HSet, field=sandboxID,
-//     value=JSON snapshot. Sidecars HGETALL it on startup to bootstrap
+//     value=JSON snapshot. CLM HGETALL it on startup to bootstrap
 //     the registry.
 //   - cube:v1:shared:sandbox:lifecycle:events  Stream, append-only event
-//     log of create/delete operations. Sidecars consume via XREADGROUP for
-//     incremental updates after the bootstrap.
+//     log of create/delete/update/state operations. CLM consumes via
+//     XREADGROUP for incremental updates after the bootstrap.
 //
-// Updates (pause/resume action) intentionally do NOT publish to the stream:
-// state transitions are driven and observed by the sidecar itself, so making
-// CubeMaster also publish them would just be a redundant round trip.
+// Stream events cover two classes of change:
+//
+//  1. Metadata mutations: create / delete / update. These carry a full
+//     SandboxLifecycleMeta payload (except delete). The CLM mirrors
+//     them into its in-memory registry and pushes the meta to CubeProxy.
+//
+//  2. Runtime state mutations: state. Emitted after a successful
+//     pause / resume RPC (see sandbox_update.go). Payload is a
+//     StatePayload describing the new terminal state ("paused" / "running").
+//     The CLM reconciles Redis state key + CubeProxy state dict so
+//     externally driven pause/resume calls do not desync the fleet.
+//
+// State keys (cube:v1:shared:sandbox:lifecycle:state:<id>) remain
+// exclusively written by the CLM — CubeMaster only signals intent
+// via the stream. This preserves the SETNX-based transition-lock semantics
+// (pausing / resuming) owned by the CLM's sweeper and resumer.
 package lifecycle
 
 import "github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/rediskey"
@@ -45,6 +58,12 @@ const (
 	OpCreate = "create"
 	OpDelete = "delete"
 	OpUpdate = "update"
+	// OpState carries a runtime state transition (paused / running) after
+	// a successful pause / resume RPC. The payload is a StatePayload. It
+	// does NOT mutate MetaKey: state is a runtime attribute the CLM
+	// tracks separately (state keys), and MetaKey should stay stable
+	// across pause/resume cycles.
+	OpState = "state"
 )
 
 // Stream entry field names. Stream values are flat key/value pairs in redigo,
@@ -77,4 +96,38 @@ type SandboxLifecycleMeta struct {
 	// API consumers (and the SDK's get_info endpoint) can return it
 	// without recomputing.
 	EndAt int64 `json:"end_at,omitempty"`
+}
+
+// State values carried by StatePayload.State. Only terminal states are
+// broadcast — transition markers ("pausing", "resuming") remain private to
+// the CLM's state-key coordination logic.
+const (
+	StatePaused  = "paused"
+	StateRunning = "running"
+)
+
+// Actor values distinguishing who initiated the state change. The CLM
+// uses this to decide whether to reconcile registry / proxy dict; events
+// authored by the CLM itself (actor="clm") are typically no-ops on the
+// consumer side because the CLM has already made the updates locally.
+const (
+	ActorCubeMaster = "cubemaster"
+	ActorCLM        = "clm"
+)
+
+// StatePayload is the JSON body of an OpState stream entry.
+//
+// Emitted by CubeMaster after a successful pause / resume RPC so the
+// CLM can synchronise Redis state, in-memory registry, and CubeProxy's
+// per-worker state dict with externally-driven state changes (e.g. the SDK
+// calling connect() to resume a sandbox the sweeper had paused).
+type StatePayload struct {
+	// State is the new terminal state. Must be one of StatePaused / StateRunning.
+	State string `json:"state"`
+	// Actor identifies the driver of the state change. Used for logging
+	// and to give the CLM a hook for cheap no-op detection.
+	Actor string `json:"actor,omitempty"`
+	// Source is a free-form label for the trigger (e.g. "api", "admin").
+	// Purely informational; not consumed by the CLM's decision logic.
+	Source string `json:"source,omitempty"`
 }

--- a/CubeMaster/pkg/lifecycle/store.go
+++ b/CubeMaster/pkg/lifecycle/store.go
@@ -84,6 +84,41 @@ func (s *Store) PublishDelete(ctx context.Context, sandboxID string) {
 	}
 }
 
+// PublishState emits an OpState event announcing that the sandbox has
+// transitioned to a new terminal runtime state (paused or running) as a
+// result of a successful pause / resume RPC.
+//
+// Unlike PublishCreate/Update this deliberately does NOT touch MetaKey:
+// runtime state is tracked separately by the CLM via per-sandbox state
+// keys, and stuffing state into the meta snapshot would blur the "meta is
+// stable" invariant that consumers rely on for restart bootstrap.
+//
+// Only the two terminal states are broadcast — transition markers
+// ("pausing", "resuming") stay private to the CLM. Invalid values are
+// warned and dropped rather than propagated.
+func (s *Store) PublishState(ctx context.Context, sandboxID, state, source string) {
+	if s == nil || !s.enabled.Load() || s.doer == nil || sandboxID == "" {
+		return
+	}
+	if state != StatePaused && state != StateRunning {
+		log.G(ctx).Warnf("lifecycle: PublishState sandbox=%s invalid state %q; dropped",
+			sandboxID, state)
+		return
+	}
+	payload, err := json.Marshal(StatePayload{
+		State:  state,
+		Actor:  ActorCubeMaster,
+		Source: source,
+	})
+	if err != nil {
+		log.G(ctx).Warnf("lifecycle: marshal state payload sandbox=%s: %v", sandboxID, err)
+		return
+	}
+	if _, err := s.xadd(OpState, sandboxID, payload); err != nil {
+		log.G(ctx).Warnf("lifecycle: XADD state %s failed: %v", sandboxID, err)
+	}
+}
+
 // PublishUpdate refreshes the snapshot for an already-existing sandbox: HSET
 // the new meta JSON, then XADD an OpUpdate event. Used by set_timeout /
 // refresh when only mutable fields (TimeoutSeconds, CreatedAt, EndAt) change.

--- a/CubeMaster/pkg/lifecycle/store_test.go
+++ b/CubeMaster/pkg/lifecycle/store_test.go
@@ -174,9 +174,108 @@ func TestStore_DisabledIsNoOp(t *testing.T) {
 
 	s.PublishCreate(context.Background(), &SandboxLifecycleMeta{SandboxID: "sbx-1"})
 	s.PublishDelete(context.Background(), "sbx-1")
+	s.PublishState(context.Background(), "sbx-1", StatePaused, "api")
 
 	if got := len(r.snapshot()); got != 0 {
 		t.Fatalf("disabled store should make zero calls, got %d", got)
+	}
+}
+
+func TestStore_PublishState_HappyPath(t *testing.T) {
+	cases := []struct {
+		name  string
+		state string
+	}{
+		{"paused", StatePaused},
+		{"running", StateRunning},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := &fakeRedis{}
+			s := NewStore(r)
+
+			s.PublishState(context.Background(), "sbx-1", tc.state, "api")
+
+			calls := r.snapshot()
+			if len(calls) != 1 {
+				t.Fatalf("want single XADD, got %d: %+v", len(calls), calls)
+			}
+			c := calls[0]
+			if c.cmd != "XADD" || c.args[0] != EventStreamKey {
+				t.Fatalf("XADD target wrong: %+v", c)
+			}
+			// State events MUST NOT touch MetaKey.
+			for _, prev := range calls {
+				if prev.cmd == "HSET" || prev.cmd == "HDEL" {
+					t.Fatalf("state event must not mutate MetaKey: %+v", prev)
+				}
+			}
+			if c.args[5] != FieldOp || c.args[6] != OpState {
+				t.Fatalf("XADD op wrong: %+v", c.args)
+			}
+			if c.args[7] != FieldSandboxID || c.args[8] != "sbx-1" {
+				t.Fatalf("XADD sandbox_id wrong: %+v", c.args)
+			}
+			// Locate payload field.
+			var payloadBytes []byte
+			for i := 0; i < len(c.args); i++ {
+				if s, ok := c.args[i].(string); ok && s == FieldPayload && i+1 < len(c.args) {
+					if b, bok := c.args[i+1].([]byte); bok {
+						payloadBytes = b
+					}
+				}
+			}
+			if payloadBytes == nil {
+				t.Fatalf("payload not found in XADD args: %+v", c.args)
+			}
+			var got StatePayload
+			if err := json.Unmarshal(payloadBytes, &got); err != nil {
+				t.Fatalf("payload json: %v", err)
+			}
+			if got.State != tc.state {
+				t.Fatalf("payload state = %q, want %q", got.State, tc.state)
+			}
+			if got.Actor != ActorCubeMaster {
+				t.Fatalf("payload actor = %q, want %q", got.Actor, ActorCubeMaster)
+			}
+			if got.Source != "api" {
+				t.Fatalf("payload source = %q, want api", got.Source)
+			}
+		})
+	}
+}
+
+func TestStore_PublishState_InvalidState(t *testing.T) {
+	cases := []string{"", "pausing", "resuming", "PAUSED", "unknown"}
+	for _, state := range cases {
+		t.Run(state, func(t *testing.T) {
+			r := &fakeRedis{}
+			s := NewStore(r)
+			s.PublishState(context.Background(), "sbx-1", state, "api")
+			if got := len(r.snapshot()); got != 0 {
+				t.Fatalf("invalid state %q must not reach Redis, got %d calls", state, got)
+			}
+		})
+	}
+}
+
+func TestStore_PublishState_EmptySandboxID(t *testing.T) {
+	r := &fakeRedis{}
+	s := NewStore(r)
+	s.PublishState(context.Background(), "", StatePaused, "api")
+	if got := len(r.snapshot()); got != 0 {
+		t.Fatalf("empty sandbox id must not reach Redis, got %d calls", got)
+	}
+}
+
+func TestStore_PublishState_XADDFailureSwallowed(t *testing.T) {
+	r := &fakeRedis{failXADD: true}
+	s := NewStore(r)
+	// Must not panic and must not propagate the error.
+	s.PublishState(context.Background(), "sbx-1", StateRunning, "api")
+	calls := r.snapshot()
+	if len(calls) != 1 || calls[0].cmd != "XADD" {
+		t.Fatalf("expected single XADD attempt, got %+v", calls)
 	}
 }
 
@@ -185,16 +284,19 @@ func TestStore_NilGuards(t *testing.T) {
 	var s *Store
 	s.PublishCreate(context.Background(), &SandboxLifecycleMeta{SandboxID: "x"})
 	s.PublishDelete(context.Background(), "x")
+	s.PublishState(context.Background(), "x", StatePaused, "api")
 
 	s2 := NewStore(nil)
 	s2.PublishCreate(context.Background(), &SandboxLifecycleMeta{SandboxID: "x"})
 	s2.PublishDelete(context.Background(), "x")
+	s2.PublishState(context.Background(), "x", StatePaused, "api")
 
 	r := &fakeRedis{}
 	s3 := NewStore(r)
 	s3.PublishCreate(context.Background(), nil)
 	s3.PublishCreate(context.Background(), &SandboxLifecycleMeta{})
 	s3.PublishDelete(context.Background(), "")
+	s3.PublishState(context.Background(), "", StatePaused, "api")
 	if got := len(r.snapshot()); got != 0 {
 		t.Fatalf("nil/empty inputs must not reach Redis, got %d calls", got)
 	}

--- a/CubeMaster/pkg/service/sandbox/runtime_ref_hook.go
+++ b/CubeMaster/pkg/service/sandbox/runtime_ref_hook.go
@@ -119,3 +119,56 @@ func runAfterCreateSandboxSuccessHook(ctx context.Context, sandboxID, hostID, ho
 	}
 	return firstErr
 }
+
+// UpdateSandboxSuccessHook is invoked after a sandbox pause / resume RPC
+// (POST /cube/sandbox/update) succeeds. Subscribers use it to fan out state
+// transitions to downstream consumers such as the lifecycle metadata
+// channel. The hook MUST NOT fail the update path — implementations should
+// log and swallow errors.
+//
+// Action carries "pause" or "resume" (validated upstream). RequestID is
+// forwarded from the incoming request for log correlation.
+type UpdateSandboxSuccessHook func(ctx context.Context, sandboxID, instanceType, action, requestID string)
+
+var (
+	updateHooksMu sync.RWMutex
+	updateHooks   []UpdateSandboxSuccessHook
+)
+
+// RegisterAfterUpdateSandboxSuccessHook appends a hook to the update chain.
+// Hooks run sequentially in registration order.
+func RegisterAfterUpdateSandboxSuccessHook(hook UpdateSandboxSuccessHook) {
+	if hook == nil {
+		return
+	}
+	updateHooksMu.Lock()
+	updateHooks = append(updateHooks, hook)
+	updateHooksMu.Unlock()
+}
+
+// ResetAfterUpdateSandboxSuccessHooks clears every registered update hook.
+// Test-only helper.
+func ResetAfterUpdateSandboxSuccessHooks() {
+	updateHooksMu.Lock()
+	updateHooks = nil
+	updateHooksMu.Unlock()
+}
+
+func runAfterUpdateSandboxSuccessHook(ctx context.Context, sandboxID, instanceType, action, requestID string) {
+	updateHooksMu.RLock()
+	hooks := append([]UpdateSandboxSuccessHook(nil), updateHooks...)
+	updateHooksMu.RUnlock()
+
+	for _, h := range hooks {
+		// Hooks are best-effort; recover in case a subscriber panics so
+		// we can't take down the update path.
+		func() {
+			defer func() {
+				if r := recover(); r != nil {
+					log.G(ctx).Warnf("afterUpdateSandboxSuccess hook panicked: %v", r)
+				}
+			}()
+			h(ctx, sandboxID, instanceType, action, requestID)
+		}()
+	}
+}

--- a/CubeMaster/pkg/service/sandbox/runtime_ref_hook_test.go
+++ b/CubeMaster/pkg/service/sandbox/runtime_ref_hook_test.go
@@ -72,3 +72,61 @@ func TestNilHookIgnored(t *testing.T) {
 		t.Fatalf("nil hook must be skipped silently, got %v", err)
 	}
 }
+
+func TestUpdateHookChain_FIFO(t *testing.T) {
+	ResetAfterUpdateSandboxSuccessHooks()
+	defer ResetAfterUpdateSandboxSuccessHooks()
+
+	type call struct {
+		sandboxID    string
+		instanceType string
+		action       string
+		requestID    string
+	}
+	var calls []call
+	RegisterAfterUpdateSandboxSuccessHook(func(_ context.Context, sid, it, action, rid string) {
+		calls = append(calls, call{sid, it, action, rid})
+	})
+	RegisterAfterUpdateSandboxSuccessHook(func(_ context.Context, sid, _, _, _ string) {
+		calls = append(calls, call{sandboxID: "second:" + sid})
+	})
+
+	runAfterUpdateSandboxSuccessHook(context.Background(), "sbx-z", "cubebox", "pause", "req-1")
+	if len(calls) != 2 {
+		t.Fatalf("want 2 hook calls, got %d", len(calls))
+	}
+	if calls[0].sandboxID != "sbx-z" || calls[0].instanceType != "cubebox" ||
+		calls[0].action != "pause" || calls[0].requestID != "req-1" {
+		t.Fatalf("first hook received wrong args: %+v", calls[0])
+	}
+	if calls[1].sandboxID != "second:sbx-z" {
+		t.Fatalf("second hook did not run: %+v", calls)
+	}
+}
+
+func TestUpdateHook_PanicRecovered(t *testing.T) {
+	ResetAfterUpdateSandboxSuccessHooks()
+	defer ResetAfterUpdateSandboxSuccessHooks()
+
+	RegisterAfterUpdateSandboxSuccessHook(func(_ context.Context, _, _, _, _ string) {
+		panic("boom")
+	})
+	var reached bool
+	RegisterAfterUpdateSandboxSuccessHook(func(_ context.Context, _, _, _, _ string) {
+		reached = true
+	})
+
+	// Must not panic; must still run subsequent hooks.
+	runAfterUpdateSandboxSuccessHook(context.Background(), "sbx-z", "cubebox", "resume", "req-2")
+	if !reached {
+		t.Fatalf("panicking hook must not prevent later hooks from running")
+	}
+}
+
+func TestUpdateHook_NilIgnored(t *testing.T) {
+	ResetAfterUpdateSandboxSuccessHooks()
+	defer ResetAfterUpdateSandboxSuccessHooks()
+
+	RegisterAfterUpdateSandboxSuccessHook(nil)
+	runAfterUpdateSandboxSuccessHook(context.Background(), "x", "cubebox", "pause", "")
+}

--- a/CubeMaster/pkg/service/sandbox/sandbox_update.go
+++ b/CubeMaster/pkg/service/sandbox/sandbox_update.go
@@ -89,5 +89,11 @@ func Update(ctx context.Context, req *types.UpdateRequest) (rsp *types.Res) {
 	}
 	rsp.Ret.RetCode = int(cubeRsp.GetRet().GetRetCode())
 	rsp.Ret.RetMsg = cubeRsp.GetRet().GetRetMsg()
+	if rsp.Ret.RetCode == int(errorcode.ErrorCode_Success) {
+		// Only on genuine success — IsAlreadyInState / NotFound are handled
+		// upstream by CLM's own reconciliation and would send misleading
+		// state signals through the lifecycle channel.
+		runAfterUpdateSandboxSuccessHook(ctx, req.SandboxID, req.InstanceType, req.Action, req.RequestID)
+	}
 	return
 }

--- a/cube-lifecycle-manager/cmd/cube-lifecycle-manager/main.go
+++ b/cube-lifecycle-manager/cmd/cube-lifecycle-manager/main.go
@@ -27,6 +27,7 @@ import (
 	"github.com/tencentcloud/CubeSandbox/cube-lifecycle-manager/internal/redisstream"
 	"github.com/tencentcloud/CubeSandbox/cube-lifecycle-manager/internal/registry"
 	"github.com/tencentcloud/CubeSandbox/cube-lifecycle-manager/internal/resumer"
+	"github.com/tencentcloud/CubeSandbox/cube-lifecycle-manager/internal/statesync"
 	"github.com/tencentcloud/CubeSandbox/cube-lifecycle-manager/internal/sweeper"
 )
 
@@ -173,8 +174,18 @@ func run() error {
 	if discSvc != nil {
 		loopCount++
 	}
+	stateSyncDeps := statesync.Deps{
+		Registry:  reg,
+		Redis:     stream,
+		ProxyPush: pushClient,
+		TTL:       cfg.StateLockTTL,
+		Log:       logger.Named("statesync"),
+	}
+
 	errs := make(chan error, loopCount)
-	go func() { errs <- consumeStream(rootCtx, stream, pushClient, reg, cfg, logger.Named("stream")) }()
+	go func() {
+		errs <- consumeStream(rootCtx, stream, pushClient, reg, cfg, stateSyncDeps, logger.Named("stream"))
+	}()
 	go func() { errs <- pollLastActive(rootCtx, pushClient, reg, cfg.LastActivePoll, logger.Named("active")) }()
 	go func() { errs <- sweep.Run(rootCtx) }()
 	go func() { errs <- apiSrv.Run(rootCtx) }()
@@ -271,7 +282,7 @@ func bootstrapRegistry(ctx context.Context, stream *redisstream.Client,
 // consumeStream is the increment-side of the lifecycle channel. It maintains
 // the registry + pushes deltas to CubeProxy as create / delete events arrive.
 func consumeStream(ctx context.Context, stream *redisstream.Client, push *proxypush.Client,
-	reg *registry.Registry, cfg *config.Config, log *zap.Logger) error {
+	reg *registry.Registry, cfg *config.Config, ssDeps statesync.Deps, log *zap.Logger) error {
 
 	for {
 		if ctx.Err() != nil {
@@ -289,7 +300,7 @@ func consumeStream(ctx context.Context, stream *redisstream.Client, push *proxyp
 			continue
 		}
 		for _, ev := range events {
-			handleEvent(ctx, ev, push, reg, log)
+			handleEvent(ctx, ev, push, reg, ssDeps, log)
 			if err := stream.Ack(ctx, cfg.ConsumerGroup, ev.StreamID); err != nil {
 				log.Warn("ack failed",
 					zap.String("id", ev.StreamID), zap.Error(err))
@@ -299,7 +310,7 @@ func consumeStream(ctx context.Context, stream *redisstream.Client, push *proxyp
 }
 
 func handleEvent(ctx context.Context, ev redisstream.Event, push *proxypush.Client,
-	reg *registry.Registry, log *zap.Logger) {
+	reg *registry.Registry, ssDeps statesync.Deps, log *zap.Logger) {
 
 	switch ev.Op {
 	case lifecycle.OpCreate:
@@ -351,6 +362,10 @@ func handleEvent(ctx context.Context, ev redisstream.Event, push *proxypush.Clie
 			log.Warn("update event push failed",
 				zap.String("sandbox_id", ev.SandboxID), zap.Error(err))
 		}
+	case lifecycle.OpState:
+		// Reconcile externally-driven pause/resume (e.g. SDK connect())
+		// against the CLM's Redis state key + CubeProxy dict.
+		statesync.Handle(ctx, ssDeps, ev)
 	default:
 		log.Warn("unknown event op",
 			zap.String("op", ev.Op),

--- a/cube-lifecycle-manager/internal/lifecycle/parity_test.go
+++ b/cube-lifecycle-manager/internal/lifecycle/parity_test.go
@@ -24,10 +24,15 @@ func TestSchemaConstants(t *testing.T) {
 		{"OpCreate", OpCreate, "create"},
 		{"OpDelete", OpDelete, "delete"},
 		{"OpUpdate", OpUpdate, "update"},
+		{"OpState", OpState, "state"},
 		{"FieldOp", FieldOp, "op"},
 		{"FieldSandboxID", FieldSandboxID, "sandbox_id"},
 		{"FieldPayload", FieldPayload, "payload"},
 		{"FieldTimestamp", FieldTimestamp, "ts"},
+		{"StatePaused", StatePaused, "paused"},
+		{"StateRunning", StateRunning, "running"},
+		{"ActorCubeMaster", ActorCubeMaster, "cubemaster"},
+		{"ActorCLM", ActorCLM, "clm"},
 	}
 	for _, c := range cases {
 		if c.got != c.want {

--- a/cube-lifecycle-manager/internal/lifecycle/schema.go
+++ b/cube-lifecycle-manager/internal/lifecycle/schema.go
@@ -42,6 +42,11 @@ const (
 	OpCreate = "create"
 	OpDelete = "delete"
 	OpUpdate = "update"
+	// OpState carries a runtime state transition (paused / running) emitted
+	// by CubeMaster after a successful pause / resume RPC. The payload is a
+	// StatePayload. See CubeMaster/pkg/lifecycle/schema.go for the canonical
+	// definition; the CLM consumes these events in statesync.Handle.
+	OpState = "state"
 )
 
 // Stream entry field names.
@@ -71,4 +76,26 @@ type SandboxLifecycleMeta struct {
 // pointer field. Prefer it over inline &v so intent reads clearly.
 func TimeoutSecondsPtr(v int) *int {
 	return &v
+}
+
+// State values carried by StatePayload.State. Only terminal states are
+// broadcast on the stream — transition markers ("pausing", "resuming")
+// stay private to the CLM's state-key coordination logic.
+const (
+	StatePaused  = "paused"
+	StateRunning = "running"
+)
+
+// Actor values distinguishing who initiated the state change.
+const (
+	ActorCubeMaster = "cubemaster"
+	ActorCLM        = "clm"
+)
+
+// StatePayload mirrors CubeMaster/pkg/lifecycle.StatePayload. Whenever you
+// change one side, change the other in the same commit.
+type StatePayload struct {
+	State  string `json:"state"`
+	Actor  string `json:"actor,omitempty"`
+	Source string `json:"source,omitempty"`
 }

--- a/cube-lifecycle-manager/internal/redisstream/stream.go
+++ b/cube-lifecycle-manager/internal/redisstream/stream.go
@@ -71,9 +71,14 @@ func (c *Client) EnsureGroup(ctx context.Context, group string) error {
 // Event is a decoded entry from the events stream.
 type Event struct {
 	StreamID  string
-	Op        string // create | delete
+	Op        string // create | delete | update | state
 	SandboxID string
-	Meta      *lifecycle.SandboxLifecycleMeta // populated only on create
+	// Meta is populated for create/update events (delete carries only the
+	// sandbox ID).
+	Meta *lifecycle.SandboxLifecycleMeta
+	// State is populated for state events emitted by CubeMaster after a
+	// successful pause / resume RPC. Consumed by statesync.
+	State     *lifecycle.StatePayload
 	Timestamp int64
 }
 
@@ -184,13 +189,24 @@ func decodeEvent(msg redis.XMessage) *Event {
 			ev.Timestamp = t
 		}
 	}
-	if op == lifecycle.OpCreate || op == lifecycle.OpUpdate {
+	switch op {
+	case lifecycle.OpCreate, lifecycle.OpUpdate:
 		if payload, ok := msg.Values[lifecycle.FieldPayload].(string); ok && payload != "" {
 			var meta lifecycle.SandboxLifecycleMeta
 			if err := json.Unmarshal([]byte(payload), &meta); err == nil {
 				meta.SandboxID = sid
 				ev.Meta = &meta
 			}
+		}
+	case lifecycle.OpState:
+		if payload, ok := msg.Values[lifecycle.FieldPayload].(string); ok && payload != "" {
+			var sp lifecycle.StatePayload
+			if err := json.Unmarshal([]byte(payload), &sp); err == nil {
+				ev.State = &sp
+			}
+			// If unmarshal fails ev.State stays nil; downstream
+			// statesync warns and drops, keeping the stream consumer
+			// resilient to schema drift.
 		}
 	}
 	return ev

--- a/cube-lifecycle-manager/internal/redisstream/stream_test.go
+++ b/cube-lifecycle-manager/internal/redisstream/stream_test.go
@@ -1,0 +1,187 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package redisstream
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/redis/go-redis/v9"
+
+	"github.com/tencentcloud/CubeSandbox/cube-lifecycle-manager/internal/lifecycle"
+)
+
+func metaEntry(t *testing.T, op, sid string, meta lifecycle.SandboxLifecycleMeta) redis.XMessage {
+	t.Helper()
+	payload, err := json.Marshal(meta)
+	if err != nil {
+		t.Fatalf("marshal meta: %v", err)
+	}
+	return redis.XMessage{
+		ID: "1-0",
+		Values: map[string]interface{}{
+			lifecycle.FieldOp:        op,
+			lifecycle.FieldSandboxID: sid,
+			lifecycle.FieldPayload:   string(payload),
+			lifecycle.FieldTimestamp: "1700000000000",
+		},
+	}
+}
+
+func stateEntry(t *testing.T, sid string, sp lifecycle.StatePayload) redis.XMessage {
+	t.Helper()
+	payload, err := json.Marshal(sp)
+	if err != nil {
+		t.Fatalf("marshal state: %v", err)
+	}
+	return redis.XMessage{
+		ID: "2-0",
+		Values: map[string]interface{}{
+			lifecycle.FieldOp:        lifecycle.OpState,
+			lifecycle.FieldSandboxID: sid,
+			lifecycle.FieldPayload:   string(payload),
+			lifecycle.FieldTimestamp: "1700000001000",
+		},
+	}
+}
+
+func TestDecodeEvent_Create(t *testing.T) {
+	msg := metaEntry(t, lifecycle.OpCreate, "sbx-1", lifecycle.SandboxLifecycleMeta{
+		SandboxID:  "sbx-1",
+		AutoPause:  true,
+		AutoResume: false,
+	})
+	ev := decodeEvent(msg)
+	if ev == nil {
+		t.Fatal("decodeEvent returned nil")
+	}
+	if ev.Op != lifecycle.OpCreate || ev.SandboxID != "sbx-1" {
+		t.Fatalf("wrong op/sid: %+v", ev)
+	}
+	if ev.Meta == nil || !ev.Meta.AutoPause {
+		t.Fatalf("meta not decoded: %+v", ev.Meta)
+	}
+	if ev.State != nil {
+		t.Fatalf("state must be nil for create: %+v", ev.State)
+	}
+	if ev.Timestamp != 1700000000000 {
+		t.Fatalf("timestamp not decoded: %d", ev.Timestamp)
+	}
+}
+
+func TestDecodeEvent_State_Paused(t *testing.T) {
+	msg := stateEntry(t, "sbx-1", lifecycle.StatePayload{
+		State:  lifecycle.StatePaused,
+		Actor:  lifecycle.ActorCubeMaster,
+		Source: "api",
+	})
+	ev := decodeEvent(msg)
+	if ev == nil {
+		t.Fatal("decodeEvent returned nil")
+	}
+	if ev.Op != lifecycle.OpState || ev.SandboxID != "sbx-1" {
+		t.Fatalf("wrong op/sid: %+v", ev)
+	}
+	if ev.Meta != nil {
+		t.Fatalf("state event must not carry meta: %+v", ev.Meta)
+	}
+	if ev.State == nil {
+		t.Fatal("state payload not decoded")
+	}
+	if ev.State.State != lifecycle.StatePaused {
+		t.Fatalf("state = %q, want %q", ev.State.State, lifecycle.StatePaused)
+	}
+	if ev.State.Actor != lifecycle.ActorCubeMaster {
+		t.Fatalf("actor = %q", ev.State.Actor)
+	}
+	if ev.State.Source != "api" {
+		t.Fatalf("source = %q", ev.State.Source)
+	}
+}
+
+func TestDecodeEvent_State_Running(t *testing.T) {
+	msg := stateEntry(t, "sbx-2", lifecycle.StatePayload{
+		State: lifecycle.StateRunning,
+		Actor: lifecycle.ActorCubeMaster,
+	})
+	ev := decodeEvent(msg)
+	if ev == nil || ev.State == nil || ev.State.State != lifecycle.StateRunning {
+		t.Fatalf("running state decode failed: %+v", ev)
+	}
+}
+
+func TestDecodeEvent_State_MissingPayload(t *testing.T) {
+	msg := redis.XMessage{
+		ID: "3-0",
+		Values: map[string]interface{}{
+			lifecycle.FieldOp:        lifecycle.OpState,
+			lifecycle.FieldSandboxID: "sbx-1",
+			// no payload
+		},
+	}
+	ev := decodeEvent(msg)
+	if ev == nil {
+		t.Fatal("decodeEvent returned nil for state event without payload")
+	}
+	if ev.State != nil {
+		t.Fatalf("state must be nil when payload absent: %+v", ev.State)
+	}
+	// downstream statesync is responsible for warning; we just must not panic.
+}
+
+func TestDecodeEvent_State_MalformedPayload(t *testing.T) {
+	msg := redis.XMessage{
+		ID: "4-0",
+		Values: map[string]interface{}{
+			lifecycle.FieldOp:        lifecycle.OpState,
+			lifecycle.FieldSandboxID: "sbx-1",
+			lifecycle.FieldPayload:   "not-json",
+		},
+	}
+	ev := decodeEvent(msg)
+	if ev == nil {
+		t.Fatal("decodeEvent returned nil for malformed state payload")
+	}
+	if ev.State != nil {
+		t.Fatalf("state must be nil when payload is malformed: %+v", ev.State)
+	}
+}
+
+func TestDecodeEvent_MissingOpOrSID(t *testing.T) {
+	cases := []redis.XMessage{
+		{ID: "a", Values: map[string]interface{}{lifecycle.FieldSandboxID: "x"}},
+		{ID: "b", Values: map[string]interface{}{lifecycle.FieldOp: "create"}},
+		{ID: "c", Values: map[string]interface{}{}},
+	}
+	for _, m := range cases {
+		if ev := decodeEvent(m); ev != nil {
+			t.Fatalf("expected nil for %+v, got %+v", m, ev)
+		}
+	}
+}
+
+func TestDecodeEvent_UnknownOpSurvives(t *testing.T) {
+	// Old CLM should tolerate future op codes: decoder produces an Event with
+	// no Meta/State payload; upstream handleEvent falls into the default arm
+	// and warn+ACKs.
+	msg := redis.XMessage{
+		ID: "5-0",
+		Values: map[string]interface{}{
+			lifecycle.FieldOp:        "future-op",
+			lifecycle.FieldSandboxID: "sbx-1",
+			lifecycle.FieldPayload:   `{"foo":"bar"}`,
+		},
+	}
+	ev := decodeEvent(msg)
+	if ev == nil {
+		t.Fatal("decoder must not drop unknown ops (upstream handles them)")
+	}
+	if ev.Op != "future-op" || ev.SandboxID != "sbx-1" {
+		t.Fatalf("op/sid corrupted: %+v", ev)
+	}
+	if ev.Meta != nil || ev.State != nil {
+		t.Fatalf("unknown op must not populate Meta/State: %+v", ev)
+	}
+}

--- a/cube-lifecycle-manager/internal/resumer/resumer.go
+++ b/cube-lifecycle-manager/internal/resumer/resumer.go
@@ -96,10 +96,17 @@ func (r *Resumer) doResume(ctx context.Context, sandboxID string) error {
 	if entry == nil {
 		return errors.New("sandbox not in registry")
 	}
-	if !entry.Meta.AutoResume {
-		return errors.New("auto_resume not enabled for sandbox")
-	}
 
+	// AutoResume is intentionally NOT checked here: the flag governs whether
+	// CLM is allowed to drive a resume RPC on the user's behalf, not whether
+	// the dataplane request is allowed through when the sandbox is *already*
+	// running. If the user (via CubeMaster.Resume) has already brought the
+	// sandbox back up, the state event synchroniser will have flipped Redis
+	// state to "running"; we want acquireResumeOwnership to hit
+	// errAlreadyRunning and let this request pass, regardless of AutoResume.
+	// The check therefore lives inside the `ownErr == nil` branch, right
+	// before we'd actually call CubeMaster.
+	//
 	// cube:v1:shared:sandbox:lifecycle:state:<id> is dual-purpose: terminal
 	// markers (paused / running) AND in-flight transition locks (pausing /
 	// resuming) live in the same key. SETNX alone can't distinguish "I'm
@@ -107,15 +114,29 @@ func (r *Resumer) doResume(ctx context.Context, sandboxID string) error {
 	// for someone to resume it" — we need to peek first.
 	switch ownErr := r.acquireResumeOwnership(ctx, sandboxID); {
 	case ownErr == nil:
-		// We own the resume; call CubeMaster.
+		// We took the "resuming" lock; we're on the hook to drive the RPC.
+		// AutoResume gate lives here (the only path that would call
+		// CubeMaster.Resume) — return early if the sandbox opted out of
+		// auto-resume, and release the lock we just SET so the sweeper
+		// doesn't skip decisions for its TTL window.
+		if !entry.Meta.AutoResume {
+			_ = r.o.Redis.ClearState(ctx, sandboxID)
+			return errors.New("auto_resume not enabled for sandbox")
+		}
 		if err := r.callCubeMasterResume(ctx, sandboxID, entry.Meta.InstanceType); err != nil {
 			return err
 		}
 	case errors.Is(ownErr, errAlreadyRunning):
 		// Sandbox is already running per Redis. Skip the RPC and run the
 		// success bookkeeping below so we re-assert state to the proxy.
-		// (This is the case where a peer resume already completed but the
-		// proxy's local dict still says "paused".)
+		// This covers two important cases:
+		//   1. A peer resume already completed but the proxy's local dict
+		//      still says "paused".
+		//   2. The user called CubeMaster.Resume directly and the state
+		//      event synchroniser flipped Redis to "running" before the
+		//      next dataplane request arrived. In this case AutoResume may
+		//      well be false — that's fine; the sandbox is running and the
+		//      request should be forwarded.
 	default:
 		return ownErr
 	}

--- a/cube-lifecycle-manager/internal/resumer/resumer_test.go
+++ b/cube-lifecycle-manager/internal/resumer/resumer_test.go
@@ -168,15 +168,66 @@ func TestResumer_HappyPath(t *testing.T) {
 }
 
 func TestResumer_RejectsAutoResumeDisabled(t *testing.T) {
+	// AutoResume=false + state=paused: resumer would need to drive
+	// CubeMaster.Resume to bring the sandbox back, but the sandbox opted
+	// out. Must return an error AND release the "resuming" lock it took
+	// during acquireResumeOwnership, otherwise the state key would sit at
+	// "resuming" for its full TTL and make the sweeper skip decisions.
 	reg := registry.New()
 	reg.Upsert(lifecycle.SandboxLifecycleMeta{
 		SandboxID: "sbx", InstanceType: "cubebox", AutoResume: false,
 	})
-	r := newTestResumer(reg, newFakeStore(), &fakeMaster{}, &fakePush{})
+	store := newFakeStore()
+	store.states["sbx"] = "paused"
+	master := &fakeMaster{}
+	push := &fakePush{}
+	r := newTestResumer(reg, store, master, push)
 
 	err := r.Resume(context.Background(), "sbx")
 	if err == nil || err.Error() != "auto_resume not enabled for sandbox" {
 		t.Fatalf("expected auto_resume disabled error, got %v", err)
+	}
+	if got := store.state("sbx"); got != "" {
+		t.Fatalf("resuming lock must be released on AutoResume rejection, got %q", got)
+	}
+	if got := atomic.LoadInt32(&master.calls); got != 0 {
+		t.Fatalf("master.Resume must not be called when AutoResume=false, got %d", got)
+	}
+}
+
+// TestResumer_AutoResumeFalseAllowedWhenAlreadyRunning is the regression
+// this scenario targets: the SDK called Sandbox.connect() to manually resume
+// a paused sandbox that was configured with auto_resume=false. CubeMaster
+// forwarded the resume to Cubelet and the state event synchroniser
+// (statesync.Handle) flipped Redis state to "running". The proxy's local
+// dict is momentarily still "paused", so the next dataplane request lands
+// on /internal/resume. The resumer must NOT reject the request just because
+// auto_resume is false — the sandbox is objectively running and we're only
+// being asked to re-assert state, not to drive the resume RPC ourselves.
+func TestResumer_AutoResumeFalseAllowedWhenAlreadyRunning(t *testing.T) {
+	reg := registry.New()
+	reg.Upsert(lifecycle.SandboxLifecycleMeta{
+		SandboxID: "sbx", InstanceType: "cubebox", AutoResume: false,
+	})
+	store := newFakeStore()
+	store.states["sbx"] = "running" // state synced from CubeMaster→CLM
+	master := &fakeMaster{}
+	push := &fakePush{}
+	r := newTestResumer(reg, store, master, push)
+
+	if err := r.Resume(context.Background(), "sbx"); err != nil {
+		t.Fatalf("resume must succeed when sandbox already running, got %v", err)
+	}
+	if got := atomic.LoadInt32(&master.calls); got != 0 {
+		t.Fatalf("master.Resume must NOT be called, got %d", got)
+	}
+	// Success bookkeeping still re-asserts running into the proxy dict so
+	// the local cache converges even if the initial push missed the mark.
+	push.mu.Lock()
+	pushed := append([]string(nil), push.pushed...)
+	push.mu.Unlock()
+	if len(pushed) != 1 || pushed[0] != "running" {
+		t.Fatalf("proxy push should re-assert running, got %+v", pushed)
 	}
 }
 

--- a/cube-lifecycle-manager/internal/statesync/handler.go
+++ b/cube-lifecycle-manager/internal/statesync/handler.go
@@ -1,0 +1,154 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+// Package statesync reconciles the CLM's view of a sandbox's runtime
+// state with pause / resume actions driven externally through CubeMaster.
+//
+// CubeMaster is a stateless proxy: when the SDK calls Sandbox.connect() to
+// resume a paused sandbox, CubeMaster forwards the RPC to Cubelet but does
+// not touch the CLM's state key or CubeProxy's per-worker state dict.
+// Without a nudge from CubeMaster the CLM would keep thinking the
+// sandbox is paused and reject the next request from the dataplane.
+//
+// CubeMaster now emits an OpState event on the lifecycle events stream after
+// every successful pause / resume RPC (see CubeMaster/pkg/lifecycle/store.go
+// PublishState). This package consumes those events and reconciles:
+//
+//   - Redis state key (cube:v1:shared:sandbox:lifecycle:state:<id>)
+//   - CubeProxy's cube_sandbox_state dict (via proxypush.SetState)
+//   - registry.Entry.LastActiveMs when the new state is "running"
+//     (mirrors resumer.doResume: avoids the sweeper re-pausing a sandbox
+//     that just came back).
+//
+// The event source (CubeMaster) is stateless with respect to the CLM's
+// SETNX-based transition locks ("pausing", "resuming"). To avoid a state
+// event racing an in-flight sweeper.tryPause or resumer.doResume, Handle
+// skips reconciliation whenever the current state key holds a transition
+// marker; the CLM's own flow will write the terminal state moments
+// later, so the event is redundant.
+package statesync
+
+import (
+	"context"
+	"time"
+
+	"go.uber.org/zap"
+
+	"github.com/tencentcloud/CubeSandbox/cube-lifecycle-manager/internal/lifecycle"
+	"github.com/tencentcloud/CubeSandbox/cube-lifecycle-manager/internal/redisstream"
+	"github.com/tencentcloud/CubeSandbox/cube-lifecycle-manager/internal/registry"
+)
+
+// Deps bundles the dependencies a Handle call needs. Constructed once at
+// startup in main.go and reused for every event.
+type Deps struct {
+	Registry  *registry.Registry
+	Redis     stateStore
+	ProxyPush stateNotifier
+	// TTL is the state key TTL applied when we SET the new state. Uses the
+	// same value as sweeper/resumer's StateLockTTL so a state written from
+	// this path is indistinguishable from one written by the CLM itself.
+	TTL time.Duration
+	Log *zap.Logger
+	// Now returns the current time. Injectable for tests.
+	Now func() time.Time
+}
+
+// Handle applies a single OpState event. It is intentionally best-effort:
+// partial failures are logged and swallowed so a Redis blip cannot poison
+// the stream consumer loop.
+func Handle(ctx context.Context, d Deps, ev redisstream.Event) {
+	log := d.Log
+	if log == nil {
+		log = zap.NewNop()
+	}
+	now := d.Now
+	if now == nil {
+		now = time.Now
+	}
+
+	if ev.SandboxID == "" {
+		log.Warn("state event missing sandbox id")
+		return
+	}
+	if ev.State == nil {
+		log.Warn("state event missing payload",
+			zap.String("sandbox_id", ev.SandboxID),
+			zap.String("stream_id", ev.StreamID))
+		return
+	}
+
+	newState := ev.State.State
+	if newState != lifecycle.StatePaused && newState != lifecycle.StateRunning {
+		log.Warn("state event has invalid state",
+			zap.String("sandbox_id", ev.SandboxID),
+			zap.String("state", newState))
+		return
+	}
+
+	if d.Registry == nil || d.Registry.Get(ev.SandboxID) == nil {
+		// Sandbox is not (yet) known to the CLM. This can happen when
+		// the state event overtakes its own create event (unlikely — same
+		// stream, same partition — but cheap to guard). Ignore: the create
+		// event will populate the registry and any subsequent state
+		// reconciliation will pick things up.
+		log.Warn("state event for unknown sandbox",
+			zap.String("sandbox_id", ev.SandboxID),
+			zap.String("state", newState))
+		return
+	}
+
+	cur, _, err := d.Redis.GetState(ctx, ev.SandboxID)
+	if err != nil {
+		log.Warn("state event: get current state failed",
+			zap.String("sandbox_id", ev.SandboxID), zap.Error(err))
+		return
+	}
+
+	// Transition-lock protection: the CLM itself is mid-flight and will
+	// write the terminal state as part of tryPause / doResume. Applying an
+	// external event here would race against that write and could clobber
+	// a "resuming" lock with a "paused" verdict — the opposite of what we
+	// want.
+	if cur == "pausing" || cur == "resuming" {
+		log.Info("state event skipped: transition in progress",
+			zap.String("sandbox_id", ev.SandboxID),
+			zap.String("cur", cur),
+			zap.String("new", newState))
+		return
+	}
+
+	// Idempotence: already at the desired state.
+	if cur == newState {
+		return
+	}
+
+	if err := d.Redis.SetState(ctx, ev.SandboxID, newState, d.TTL); err != nil {
+		log.Warn("state event: set state failed",
+			zap.String("sandbox_id", ev.SandboxID),
+			zap.String("new", newState), zap.Error(err))
+		// Continue: try to push to proxy anyway so at least one side
+		// converges. Next sweep will retry Redis via its own path.
+	}
+	if d.ProxyPush != nil {
+		if err := d.ProxyPush.SetState(ctx, ev.SandboxID, newState); err != nil {
+			log.Warn("state event: push proxy state failed",
+				zap.String("sandbox_id", ev.SandboxID),
+				zap.String("new", newState), zap.Error(err))
+		}
+	}
+	if newState == lifecycle.StateRunning {
+		// Mirror resumer.doResume: bump LastActiveMs so sweeper won't
+		// immediately re-pause a sandbox that was just resumed by the
+		// user. The proxy's log_phase will eventually overwrite this via
+		// last_active polling, but we want an accurate baseline now.
+		d.Registry.MergeLastActive(ev.SandboxID, now().UnixMilli())
+	}
+	log.Info("state event applied",
+		zap.String("sandbox_id", ev.SandboxID),
+		zap.String("cur", cur),
+		zap.String("new", newState),
+		zap.String("actor", ev.State.Actor),
+		zap.String("source", ev.State.Source))
+}

--- a/cube-lifecycle-manager/internal/statesync/handler_test.go
+++ b/cube-lifecycle-manager/internal/statesync/handler_test.go
@@ -1,0 +1,270 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package statesync
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"go.uber.org/zap"
+
+	"github.com/tencentcloud/CubeSandbox/cube-lifecycle-manager/internal/lifecycle"
+	"github.com/tencentcloud/CubeSandbox/cube-lifecycle-manager/internal/redisstream"
+	"github.com/tencentcloud/CubeSandbox/cube-lifecycle-manager/internal/registry"
+)
+
+type fakeRedis struct {
+	mu       sync.Mutex
+	states   map[string]string
+	getErr   error
+	setErr   error
+	setCalls int
+}
+
+func newFakeRedis() *fakeRedis {
+	return &fakeRedis{states: map[string]string{}}
+}
+
+func (f *fakeRedis) GetState(_ context.Context, sid string) (string, bool, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.getErr != nil {
+		return "", false, f.getErr
+	}
+	v, ok := f.states[sid]
+	return v, ok, nil
+}
+
+func (f *fakeRedis) SetState(_ context.Context, sid, state string, _ time.Duration) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.setCalls++
+	if f.setErr != nil {
+		return f.setErr
+	}
+	f.states[sid] = state
+	return nil
+}
+
+type fakeProxy struct {
+	mu    sync.Mutex
+	calls []string // "sid=state"
+	err   error
+}
+
+func (p *fakeProxy) SetState(_ context.Context, sid, state string) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.calls = append(p.calls, sid+"="+state)
+	return p.err
+}
+
+func (p *fakeProxy) recorded() []string {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	out := make([]string, len(p.calls))
+	copy(out, p.calls)
+	return out
+}
+
+func stateEvent(sid, state, actor string) redisstream.Event {
+	return redisstream.Event{
+		StreamID:  "1-0",
+		Op:        lifecycle.OpState,
+		SandboxID: sid,
+		State: &lifecycle.StatePayload{
+			State: state,
+			Actor: actor,
+		},
+		Timestamp: 1700000000000,
+	}
+}
+
+func buildDeps(t *testing.T) (Deps, *fakeRedis, *fakeProxy, *registry.Registry) {
+	t.Helper()
+	r := newFakeRedis()
+	p := &fakeProxy{}
+	reg := registry.New()
+	// Register a sandbox so Registry.Get returns non-nil.
+	reg.Upsert(lifecycle.SandboxLifecycleMeta{SandboxID: "sbx-1"})
+	d := Deps{
+		Registry:  reg,
+		Redis:     r,
+		ProxyPush: p,
+		TTL:       60 * time.Second,
+		Log:       zap.NewNop(),
+		Now:       func() time.Time { return time.UnixMilli(1_700_000_500_000) },
+	}
+	return d, r, p, reg
+}
+
+func TestHandle_PausedToRunning(t *testing.T) {
+	d, r, p, reg := buildDeps(t)
+	r.states["sbx-1"] = "paused"
+
+	Handle(context.Background(), d, stateEvent("sbx-1", lifecycle.StateRunning, lifecycle.ActorCubeMaster))
+
+	if got := r.states["sbx-1"]; got != "running" {
+		t.Fatalf("redis state = %q, want running", got)
+	}
+	if got := p.recorded(); len(got) != 1 || got[0] != "sbx-1=running" {
+		t.Fatalf("proxy push wrong: %+v", got)
+	}
+	entry := reg.Get("sbx-1")
+	if entry == nil || entry.LastActiveMs != 1_700_000_500_000 {
+		t.Fatalf("LastActiveMs not bumped: %+v", entry)
+	}
+}
+
+func TestHandle_RunningToPaused(t *testing.T) {
+	d, r, p, reg := buildDeps(t)
+	r.states["sbx-1"] = "running"
+
+	Handle(context.Background(), d, stateEvent("sbx-1", lifecycle.StatePaused, lifecycle.ActorCubeMaster))
+
+	if got := r.states["sbx-1"]; got != "paused" {
+		t.Fatalf("redis state = %q, want paused", got)
+	}
+	if got := p.recorded(); len(got) != 1 || got[0] != "sbx-1=paused" {
+		t.Fatalf("proxy push wrong: %+v", got)
+	}
+	entry := reg.Get("sbx-1")
+	if entry.LastActiveMs != 0 {
+		t.Fatalf("LastActiveMs must not change on paused event: %d", entry.LastActiveMs)
+	}
+}
+
+func TestHandle_IdempotentSameState(t *testing.T) {
+	d, r, p, _ := buildDeps(t)
+	r.states["sbx-1"] = "paused"
+
+	Handle(context.Background(), d, stateEvent("sbx-1", lifecycle.StatePaused, lifecycle.ActorCubeMaster))
+
+	if r.setCalls != 0 {
+		t.Fatalf("SetState must not be called on no-op: %d", r.setCalls)
+	}
+	if got := p.recorded(); len(got) != 0 {
+		t.Fatalf("proxy push must not be called on no-op: %+v", got)
+	}
+}
+
+func TestHandle_SkipDuringPausingTransition(t *testing.T) {
+	d, r, p, _ := buildDeps(t)
+	r.states["sbx-1"] = "pausing"
+
+	Handle(context.Background(), d, stateEvent("sbx-1", lifecycle.StateRunning, lifecycle.ActorCubeMaster))
+
+	if got := r.states["sbx-1"]; got != "pausing" {
+		t.Fatalf("state must remain pausing, got %q", got)
+	}
+	if got := p.recorded(); len(got) != 0 {
+		t.Fatalf("proxy push must not fire during transition: %+v", got)
+	}
+}
+
+func TestHandle_SkipDuringResumingTransition(t *testing.T) {
+	d, r, p, _ := buildDeps(t)
+	r.states["sbx-1"] = "resuming"
+
+	Handle(context.Background(), d, stateEvent("sbx-1", lifecycle.StatePaused, lifecycle.ActorCubeMaster))
+
+	if got := r.states["sbx-1"]; got != "resuming" {
+		t.Fatalf("state must remain resuming, got %q", got)
+	}
+	if got := p.recorded(); len(got) != 0 {
+		t.Fatalf("proxy push must not fire during transition: %+v", got)
+	}
+}
+
+func TestHandle_UnknownSandboxSkipped(t *testing.T) {
+	d, r, p, _ := buildDeps(t)
+
+	Handle(context.Background(), d, stateEvent("sbx-does-not-exist", lifecycle.StateRunning, lifecycle.ActorCubeMaster))
+
+	if r.setCalls != 0 {
+		t.Fatalf("SetState called for unknown sandbox: %d", r.setCalls)
+	}
+	if got := p.recorded(); len(got) != 0 {
+		t.Fatalf("proxy push called for unknown sandbox: %+v", got)
+	}
+}
+
+func TestHandle_NilStatePayload(t *testing.T) {
+	d, r, p, _ := buildDeps(t)
+
+	ev := redisstream.Event{
+		Op:        lifecycle.OpState,
+		SandboxID: "sbx-1",
+		// State intentionally nil
+	}
+	Handle(context.Background(), d, ev)
+
+	if r.setCalls != 0 || len(p.recorded()) != 0 {
+		t.Fatal("nil state payload must be a no-op")
+	}
+}
+
+func TestHandle_InvalidState(t *testing.T) {
+	cases := []string{"pausing", "resuming", "", "UNKNOWN"}
+	for _, bad := range cases {
+		t.Run(bad, func(t *testing.T) {
+			d, r, p, _ := buildDeps(t)
+			Handle(context.Background(), d, stateEvent("sbx-1", bad, lifecycle.ActorCubeMaster))
+			if r.setCalls != 0 || len(p.recorded()) != 0 {
+				t.Fatalf("invalid state %q must be no-op", bad)
+			}
+		})
+	}
+}
+
+func TestHandle_SetStateErrorStillPushesProxy(t *testing.T) {
+	d, r, p, _ := buildDeps(t)
+	r.states["sbx-1"] = "paused"
+	r.setErr = errors.New("redis boom")
+
+	Handle(context.Background(), d, stateEvent("sbx-1", lifecycle.StateRunning, lifecycle.ActorCubeMaster))
+
+	if got := p.recorded(); len(got) != 1 {
+		t.Fatalf("proxy push must still fire when Redis SetState fails: %+v", got)
+	}
+}
+
+func TestHandle_ProxyPushErrorSwallowed(t *testing.T) {
+	d, r, p, _ := buildDeps(t)
+	r.states["sbx-1"] = "paused"
+	p.err = errors.New("proxy boom")
+
+	// Must not panic; must still bump LastActiveMs since Redis SetState succeeded.
+	Handle(context.Background(), d, stateEvent("sbx-1", lifecycle.StateRunning, lifecycle.ActorCubeMaster))
+
+	if got := r.states["sbx-1"]; got != "running" {
+		t.Fatalf("redis state should have flipped, got %q", got)
+	}
+}
+
+func TestHandle_GetStateErrorEarlyReturn(t *testing.T) {
+	d, r, p, _ := buildDeps(t)
+	r.getErr = errors.New("redis get boom")
+
+	Handle(context.Background(), d, stateEvent("sbx-1", lifecycle.StateRunning, lifecycle.ActorCubeMaster))
+
+	if r.setCalls != 0 {
+		t.Fatal("must not attempt SetState when GetState fails")
+	}
+	if got := p.recorded(); len(got) != 0 {
+		t.Fatalf("must not push proxy when GetState fails: %+v", got)
+	}
+}
+
+func TestHandle_EmptySandboxID(t *testing.T) {
+	d, r, p, _ := buildDeps(t)
+	Handle(context.Background(), d, stateEvent("", lifecycle.StateRunning, lifecycle.ActorCubeMaster))
+	if r.setCalls != 0 || len(p.recorded()) != 0 {
+		t.Fatal("empty sandbox id must be no-op")
+	}
+}

--- a/cube-lifecycle-manager/internal/statesync/iface.go
+++ b/cube-lifecycle-manager/internal/statesync/iface.go
@@ -1,0 +1,22 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package statesync
+
+import (
+	"context"
+	"time"
+)
+
+// stateStore is the subset of redisstream.Client we use. Tests substitute an
+// in-memory fake so we don't depend on a live Redis.
+type stateStore interface {
+	GetState(ctx context.Context, sandboxID string) (string, bool, error)
+	SetState(ctx context.Context, sandboxID, state string, ttl time.Duration) error
+}
+
+// stateNotifier is the subset of proxypush.Client we use.
+type stateNotifier interface {
+	SetState(ctx context.Context, sandboxID, state string) error
+}


### PR DESCRIPTION
CubeMaster's /cube/sandbox/update handler is stateless — it forwards pause/resume to Cubelet but never tells CLM. When a user manually resumes a paused sandbox via connect(), CLM's Redis state key and CubeProxy's per-worker state dict stay stuck at "paused". The next dataplane request lands on /internal/resume, where CLM's resumer rejects it because auto_resume=False, and the client sees 503 until either the next sweep or a full TTL expiry lets state converge.

This change plumbs a state signal end-to-end:

  * CubeMaster: new OpState event on the existing lifecycle stream, emitted from a new UpdateSandboxSuccessHook after any RetCode==200 pause/resume. Only terminal states ("paused"/"running") are broadcast; transition markers stay private to CLM's SETNX flow. Introducing a hook (instead of calling lifecycle.PublishState directly from sandbox_update.go) keeps the sandbox→lifecycle dependency direction and mirrors the existing create/destroy hooks.

  * CLM: new statesync package consumes OpState events. Reconciles the Redis state key + CubeProxy state dict + registry.LastActiveMs (for running events, so sweeper doesn't immediately re-pause). Skips reconciliation when Redis is at a transition marker (pausing/resuming) so the CLM's own tryPause/doResume can't be clobbered by an external event.

  * Resumer fix: the AutoResume check used to run at the top of doResume, rejecting every request even when Redis already reports "running". After this change it lives inside the ownErr==nil branch — the only path that would call CubeMaster.Resume — so the errAlreadyRunning no-op path lets requests through when the state is already correct (regardless of AutoResume), and a false AutoResume with a still-paused state releases the resuming lock via ClearState so the sweeper isn't stuck for a full TTL.