### PR TITLE
fix(templatecenter): make loop-mount streaming ext4 build robust

### DIFF
--- a/CubeMaster/pkg/templatecenter/image/align_test.go
+++ b/CubeMaster/pkg/templatecenter/image/align_test.go
@@ -1,0 +1,43 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package image
+
+import "testing"
+
+func TestAlignUp(t *testing.T) {
+	const twoMiB = int64(2 * 1024 * 1024)
+
+	cases := []struct {
+		name      string
+		size      int64
+		alignment int64
+		want      int64
+	}{
+		{"zero size stays zero", 0, twoMiB, 0},
+		{"already 2MiB-aligned is unchanged", twoMiB, twoMiB, twoMiB},
+		{"one byte over rounds up to next boundary", twoMiB + 1, twoMiB, 2 * twoMiB},
+		{"one byte under rounds up to the boundary", twoMiB - 1, twoMiB, twoMiB},
+		// 438304768 B = 418 MiB = 209 * 2 MiB (a real minimized-rootfs size).
+		{"realistic fs length rounds up", 438304767, twoMiB, 438304768},
+		{"realistic aligned length is unchanged", 438304768, twoMiB, 438304768},
+		{"non-positive alignment returns size unchanged", 12345, 0, 12345},
+		{"negative alignment returns size unchanged", 12345, -1, 12345},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := alignUp(tc.size, tc.alignment)
+			if got != tc.want {
+				t.Fatalf("alignUp(%d, %d) = %d, want %d", tc.size, tc.alignment, got, tc.want)
+			}
+			if tc.alignment > 0 && got%tc.alignment != 0 {
+				t.Fatalf("alignUp(%d, %d) = %d is not a multiple of %d", tc.size, tc.alignment, got, tc.alignment)
+			}
+			if got < tc.size {
+				t.Fatalf("alignUp(%d, %d) = %d rounded DOWN below input", tc.size, tc.alignment, got)
+			}
+		})
+	}
+}

--- a/CubeMaster/pkg/templatecenter/image/disk.go
+++ b/CubeMaster/pkg/templatecenter/image/disk.go
@@ -46,6 +46,12 @@ func createExt4ImageStreaming(ctx context.Context, source *PreparedSource, workD
 		return fmt.Errorf("loop mount not available")
 	}
 
+	// Ensure the per-artifact store dir exists (Phase-1 creates it lazily via relocate); otherwise truncate ENOENTs → silent fallback.
+	// 0o700 (owner-only, matching the mount point below): the finished image is a full container rootfs and must not be world-readable on a shared host.
+	if err := os.MkdirAll(filepath.Dir(ext4Path), 0o700); err != nil {
+		return fmt.Errorf("create artifact store dir for streaming: %w", err)
+	}
+
 	// 2. Create empty ext4 image using the caller-provided size estimate.
 	if err := runCommand(ctx, "", "truncate", "-s", strconv.FormatInt(estimatedSizeBytes, 10), ext4Path); err != nil {
 		return fmt.Errorf("truncate ext4 image for streaming: %w", err)
@@ -74,10 +80,18 @@ func createExt4ImageStreaming(ctx context.Context, source *PreparedSource, workD
 	}
 	defer cleanup()
 
-	// Allocate a free loop device and mount.
-	loopOut, err := exec.CommandContext(ctx, "losetup", "--find", "--show", ext4Path).CombinedOutput()
+	// Allocate a free loop device and mount. Capture stdout ONLY for the device
+	// path: losetup emits warnings (e.g. "file does not fit into a 512-byte
+	// sector") to stderr, and CombinedOutput would fold that warning into the
+	// parsed device path — corrupting the loopDevice string so every later mount
+	// and detach receives a garbage argument (mount fails "bad option", detach
+	// fails → loop device leaks).
+	losetupCmd := exec.CommandContext(ctx, "losetup", "--find", "--show", "--", ext4Path)
+	var losetupErr bytes.Buffer
+	losetupCmd.Stderr = &losetupErr
+	loopOut, err := losetupCmd.Output()
 	if err != nil {
-		return fmt.Errorf("losetup --find --show %s failed: %w: %s", ext4Path, err, string(loopOut))
+		return fmt.Errorf("losetup --find --show %s failed: %w: %s", ext4Path, err, strings.TrimSpace(losetupErr.String()))
 	}
 	loopDevice := strings.TrimSpace(string(loopOut))
 	detachLoop := func() {
@@ -127,11 +141,35 @@ func createExt4ImageStreaming(ctx context.Context, source *PreparedSource, workD
 		log.G(ctx).Warnf("resize2fs -M failed (best-effort, using original size): %v", err)
 	}
 
-	// 7. Truncate to actual block size.
-	finalSize := getFileBlockSize(ext4Path)
-	if finalSize > 0 && finalSize < estimatedSizeBytes {
-		if err := runCommand(cleanupCtx, "", "truncate", "-s", strconv.FormatInt(finalSize, 10), ext4Path); err != nil {
-			log.G(ctx).Warnf("truncate to final size %d failed: %v", finalSize, err)
+	// 7. Round the image file UP to a pmem-compatible size. The microVM boots the
+	// rootfs as a virtio-pmem device whose backing-file size MUST be a multiple of
+	// 2 MiB, else the host device manager rejects it ("PmemSizeNotAligned"). Phase-1
+	// sizing gets this for free (it aligns up to a 256 MiB boundary); the streaming
+	// path shrinks with resize2fs -M, which truncates the file to the exact
+	// filesystem length (not 2 MiB-aligned). Align that apparent size up here —
+	// rounding UP never cuts into live filesystem blocks; the small tail is just
+	// unused device space. Use the apparent size (fi.Size(), the fs logical length
+	// after resize2fs -M), NOT the physically-allocated block count, which can be
+	// smaller than the fs length for a minimized image and would truncate below it.
+	const pmemAlignmentBytes = int64(2 * 1024 * 1024)
+	fsSize := estimatedSizeBytes
+	haveActualSize := false
+	if fi, statErr := os.Stat(ext4Path); statErr != nil {
+		log.G(ctx).Warnf("stat %s for pmem alignment failed, using estimated size %d (may over-provision guest address space): %v", ext4Path, estimatedSizeBytes, statErr)
+	} else if fi.Size() > 0 {
+		fsSize = fi.Size()
+		haveActualSize = true
+		if fi.Size() > estimatedSizeBytes {
+			log.G(ctx).Warnf("stat %s reported size %d exceeding estimate %d (unexpected); using the actual size for pmem alignment", ext4Path, fi.Size(), estimatedSizeBytes)
+		}
+	}
+	alignedSize := alignUp(fsSize, pmemAlignmentBytes)
+	// Skip the truncate only when the real file size is already exactly aligned. If
+	// the stat failed we must still truncate: the file sits at resize2fs -M's length
+	// (very likely unaligned) and estimatedSizeBytes is only a fallback target.
+	if !haveActualSize || alignedSize != fsSize {
+		if err := runCommand(cleanupCtx, "", "truncate", "-s", strconv.FormatInt(alignedSize, 10), ext4Path); err != nil {
+			log.G(ctx).Warnf("truncate to pmem-aligned size %d failed: %v", alignedSize, err)
 		}
 	}
 

--- a/CubeMaster/pkg/templatecenter/image/util.go
+++ b/CubeMaster/pkg/templatecenter/image/util.go
@@ -165,17 +165,12 @@ func hasCapability(cap uintptr) bool {
 	return false
 }
 
-// getFileBlockSize returns the actual on-disk size of a file (as reported by
-// stat(2) st_blocks * 512), which for sparse files is smaller than the apparent
-// length.
-func getFileBlockSize(path string) int64 {
-	fi, err := os.Stat(path)
-	if err != nil {
-		return 0
+// alignUp rounds size up to the nearest multiple of alignment (alignment must be
+// positive). Rounding up never cuts into live data — the extra tail is unused
+// space. Used to satisfy the virtio-pmem 2 MiB backing-file size requirement.
+func alignUp(size, alignment int64) int64 {
+	if alignment <= 0 {
+		return size
 	}
-	stat, ok := fi.Sys().(*syscall.Stat_t)
-	if !ok || stat == nil {
-		return fi.Size() // fallback to apparent size
-	}
-	return stat.Blocks * 512
+	return ((size + alignment - 1) / alignment) * alignment
 }


### PR DESCRIPTION
## Summary

`createExt4ImageStreaming` — the Phase-2 loop-mount rootfs build path gated by
`CUBEMASTER_LOOP_MOUNT_EXT4_ENABLED` — has three bugs. The first two make the
loop-mount path fail and silently fall back to the slow Phase-1
`mkfs.ext4 -d` build; the third builds fast but yields an artifact the compute
node refuses to boot.

## Bugs & fixes (all in `createExt4ImageStreaming`)

1. **Truncate before the store sub-dir exists → ENOENT.**
   The image is `truncate`d at `<store>/<artifact>/<artifact>.ext4` before that
   per-artifact directory exists (`ResolveArtifactStoreDir` only creates the
   `storage/` root; Phase-1 creates the sub-dir lazily during its `cp -a`
   relocate). The streaming path never relocates, so the truncate fails and the
   whole build falls back to Phase-1.
   **Fix:** `os.MkdirAll(filepath.Dir(ext4Path), 0o755)` before truncate.

2. **`losetup` stderr folded into the device path.**
   `losetup --find --show` is run with `CombinedOutput()`. losetup prints
   warnings to stderr (e.g. `Warning: file does not fit into a 512-byte sector;
   the end of the file will be ignored.`), which `CombinedOutput` merges into the
   returned string. The parsed `loopDevice` becomes a multiline value, so `mount`
   fails with exit 32 ("bad option"), and the same corrupt string breaks the
   deferred `losetup --detach`, leaking the loop device.
   **Fix:** capture stdout only via `cmd.Output()`, route stderr to a separate
   buffer used only for the error message.

3. **Final image not 2 MiB-aligned → boot rejected.**
   After `resize2fs -M`, the image is truncated to the filesystem length, which
   is only 512-byte aligned. The rootfs is later attached as a **virtio-pmem**
   device whose backing-file size must be a multiple of 2 MiB, otherwise the host
   device manager rejects it (`PmemSizeNotAligned`). Phase-1 avoids this for free
   because it sizes up to a 256 MiB boundary.
   **Fix:** round the apparent filesystem size **up** to 2 MiB before the final
   truncate. Rounding up never cuts into live filesystem blocks; the small tail
   is unused device space. Uses the apparent size (`os.Stat().Size()`), not
   `getFileBlockSize` (physically-allocated blocks), which can be smaller than
   the filesystem length for a minimized image and would truncate below it.

## Testing

Verified on a FUSE-mounted network filesystem artifact store, `from-image` build of a
`python:3.11-slim`-based template distributed to a bare-metal compute node:

- Phase-2 loop-mount path runs **end-to-end with no fallback** (0 "falling back
  to phase-1" warnings; `losetup`/`mount` show the loop device mounted at the
  streaming mount point).
- Build time **POST→READY ≈ 14 s** vs **~12 min** on Phase-1 for the same image
  on the same store (~50x; Phase-1 is dominated by per-small-file FUSE metadata
  round-trips during the `cp -a` relocate + `mkfs.ext4 -d` readback).
- Resulting artifact is **2 MiB-aligned** (e.g. 438304768 B = 418 MiB exactly)
  and the from-image job reaches **READY** — the compute node accepts the pmem
  device with **0** `PmemSizeNotAligned` errors.
