### PR TITLE
fix(webui): keep sandbox state counts across filters

### DIFF
--- a/web/src/pages/Sandboxes.tsx
+++ b/web/src/pages/Sandboxes.tsx
@@ -25,11 +25,17 @@ export default function SandboxesPage() {
   const qc = useQueryClient();
   const { t } = useTranslation('sandboxes');
 
-  const { data, isLoading } = useQuery({
-    queryKey: ['sandboxes', stateFilter],
-    queryFn: () => sandboxApi.list({ state: stateFilter === 'all' ? undefined : stateFilter }),
+  const { data, isLoading, refetch } = useQuery({
+    queryKey: ['sandboxes'],
+    queryFn: () => sandboxApi.list(),
     refetchInterval: 5_000,
   });
+
+  const onStateFilterChange = (next: StateFilter) => {
+    if (next === stateFilter) return;
+    setStateFilter(next);
+    void refetch();
+  };
 
   const [pendingId, setPendingId] = useState<string | null>(null);
   const [actionError, setActionError] = useState<string | null>(null);
@@ -77,14 +83,16 @@ export default function SandboxesPage() {
 
   const filtered = useMemo(() => {
     if (!data) return [];
-    if (!q.trim()) return data;
+    const stateFiltered =
+      stateFilter === 'all' ? data : data.filter((sb) => (sb.state ?? 'running') === stateFilter);
+    if (!q.trim()) return stateFiltered;
     const needle = q.toLowerCase();
-    return data.filter((sb) =>
+    return stateFiltered.filter((sb) =>
       [sb.sandboxID, sb.templateID, sb.alias, sb.clientID]
         .filter(Boolean)
         .some((v) => String(v).toLowerCase().includes(needle)),
     );
-  }, [data, q]);
+  }, [data, q, stateFilter]);
 
   const STATE_TABS: { key: StateFilter; label: string }[] = [
     { key: 'all', label: t('filter.all') },
@@ -127,7 +135,7 @@ export default function SandboxesPage() {
             {STATE_TABS.map(({ key, label }) => (
               <button
                 key={key}
-                onClick={() => setStateFilter(key)}
+                onClick={() => onStateFilterChange(key)}
                 className={cn(
                   'rounded-md px-3 py-1 text-xs font-medium transition-all',
                   stateFilter === key


### PR DESCRIPTION
## Background

On the WebUI sandbox page, selecting the `Running` tab could make the `Paused` badge count disappear even when paused sandboxes still existed.

The page requested a state-filtered sandbox list and then calculated all status badge counts from that already-filtered response. As a result, switching tabs could make the badge counts reflect only the current tab instead of the full sandbox list.

## What Changed

* Fetch the full sandbox list for the page.
* Derive the `Running` and `Paused` badge counts from the full list.
* Apply the selected state filter locally to the table rows.
* Apply text search after the selected state filter.
* Refetch the full list immediately when switching state tabs, preserving the existing tab-switch refresh behavior.

The state filter is now local because badge counts need the full list. The explicit tab-change refetch is intentional, it preserves the previous immediate-refresh behavior, while the five-second polling interval remains the background refresh mechanism.

## Validation

* `npm ci --no-audit --no-fund`
* `npm run build`

  * includes TypeScript checking and the Vite production build
* `git diff --check`
* Manual validation:

  * ran `npm run dev`
  * configured the `/cubeapi` Vite proxy to CubeAPI
  * verified that switching between `All`, `Running`, and `Paused` keeps the paused badge count visible when `Running` is selected
  * verified that displayed rows still follow the selected state filter

## Related

Fixes #960.
