### PR TITLE
CubeVS: Minor cleanup around DNS BPF helpers

### DIFF
--- a/CubeNet/src/cubevs.h
+++ b/CubeNet/src/cubevs.h
@@ -115,16 +115,6 @@ struct mvm_meta {
 	__u8 reserved[55];
 };
 
-static __always_inline bool dns_policy_learning_enabled(const struct mvm_meta *mvm_meta)
-{
-	return mvm_meta && (mvm_meta->dns_policy_flags & DNS_POLICY_FLAG_LEARNING_ENABLED);
-}
-
-static __always_inline bool dns_policy_enabled(const struct mvm_meta *mvm_meta)
-{
-	return mvm_meta && mvm_meta->dns_policy_flags;
-}
-
 /* https://elixir.bootlin.com/linux/v5.4.217/source/include/uapi/linux/if_arp.h#L144 */
 /* Linux kernel defines struct arphdr ONLY, we need the Ethernet part */
 struct arphdr_eth {
@@ -242,6 +232,23 @@ struct snat_ip {
 	__u16 reserved;
 };
 
+/* Tail-call state for DNS response handling on the ingress UDP NAT path.
+ *
+ * The response handler is split into its own tail-called program to keep the
+ * from_world verifier complexity within the 1M instruction budget. We stash
+ * the values the caller already derived (DNS payload offset, target sandbox
+ * ifindex, DNS server IP, sandbox-side port) so the tail-called program can
+ * re-pull headers, learn A records, and finish UDP NAT without re-deriving
+ * them from scratch.
+ */
+struct dns_response_state {
+	__u32 dns_off;
+	__u32 ifindex;		/* sandbox tap ifindex (sess->vm_ifindex) */
+	__u32 server_ip;	/* DNS server IP (l3->saddr in network byte order) */
+	__u16 source_port;	/* sandbox-side UDP port (sess->vm_port in nbo) */
+	__u16 reserved;
+};
+
 /* skb->cb[0] is reserved as a per-invocation NAT status word used by
  * create_nat_session() to communicate the failure reason back to callers
  * in from_cube(). skb->cb[] is 5 * u32 scratch that survives across
@@ -280,6 +287,13 @@ static __always_inline int _()
 	int q[sizeof(struct snat_ip) % 16 == 0 ? 1 : -1] = {};
 
 	return b[0] + d[0] + r[0] + f[0] + g[0] + h[0] + i[0] + l[0] + n[0] + o[0] + p[0] + q[0];
+}
+
+static __always_inline __attribute__((used)) __u32 __btf_pin(void)
+{
+	return __builtin_btf_type_id(*(struct lpm_key *)0, BPF_TYPE_ID_LOCAL) +
+	       __builtin_btf_type_id(*(struct net_policy_value_v2 *)0, BPF_TYPE_ID_LOCAL) +
+	       __builtin_btf_type_id(*(struct dns_allow_value *)0, BPF_TYPE_ID_LOCAL);
 }
 
 #endif /* __CUBEVS_H */

--- a/CubeNet/src/dns_parser.h
+++ b/CubeNet/src/dns_parser.h
@@ -135,7 +135,7 @@ static __always_inline bool dns_response_header_is_supported(const struct dns_wi
 
 /* Read a DNS request header and reject packets that are already responses. */
 static __always_inline bool dns_read_query_header(struct __sk_buff *skb, __u32 dns_off,
-						 struct dns_wire_header *hdr, __u16 *flags)
+						  struct dns_wire_header *hdr, __u16 *flags)
 {
 	if (bpf_skb_load_bytes(skb, dns_off, hdr, sizeof(*hdr)))
 		return false;
@@ -146,7 +146,7 @@ static __always_inline bool dns_read_query_header(struct __sk_buff *skb, __u32 d
 
 /* Read a DNS response header and reject packets that are not responses. */
 static __always_inline bool dns_read_response_header(struct __sk_buff *skb, __u32 dns_off,
-						    struct dns_wire_header *hdr, __u16 *flags)
+						     struct dns_wire_header *hdr, __u16 *flags)
 {
 	if (bpf_skb_load_bytes(skb, dns_off, hdr, sizeof(*hdr)))
 		return false;
@@ -202,8 +202,8 @@ static __always_inline void dns_hash_qname_byte(__u64 *hash, __u8 byte)
 
 /* Hash one plain DNS QNAME exactly as it appears on the wire. */
 static __noinline bool dns_hash_qname(struct __sk_buff *skb, __u32 *cursor,
-					      struct dns_question_footer *question,
-					      __u64 *qname_hash)
+				      struct dns_question_footer *question,
+				      __u64 *qname_hash)
 {
 	__u32 label_remaining = 0;
 	__u64 hash = DNS_QNAME_HASH_OFFSET;
@@ -246,14 +246,9 @@ read_footer:
 	return true;
 }
 
-static __always_inline bool dns_question_footer_is_in(const struct dns_question_footer *question)
-{
-	return question->qclass == bpf_htons(DNS_CLASS_IN);
-}
-
 static __always_inline bool dns_question_footer_is_ipv4_a(const struct dns_question_footer *question)
 {
-	return question->qtype == bpf_htons(DNS_TYPE_A) && dns_question_footer_is_in(question);
+	return question->qtype == bpf_htons(DNS_TYPE_A) && question->qclass == bpf_htons(DNS_CLASS_IN);
 }
 
 #endif /* __DNS_PARSER_H */

--- a/CubeNet/src/dns_query.h
+++ b/CubeNet/src/dns_query.h
@@ -33,7 +33,7 @@
 
 /* Parse one bounded chunk of the DNS QNAME into a lower-case dotted name. */
 static __always_inline void dns_parse_query_name_chunk(struct __sk_buff *skb,
-					       struct dns_query_state *state)
+						       struct dns_query_state *state)
 {
 	int i;
 
@@ -126,7 +126,7 @@ static __always_inline bool dns_reverse_query_name_chunk(struct dns_query_state 
 
 /* Match the reversed DNS question against the per-sandbox DNS allow trie. */
 static __noinline struct dns_allow_value *dns_allow_match_value(void *inner_map,
-							 const struct dns_allow_key *question)
+								const struct dns_allow_key *question)
 {
 	struct dns_allow_value *value;
 	__u32 name_len = question->prefixlen >> 3;
@@ -245,23 +245,20 @@ static __always_inline int dns_handle_query(struct __sk_buff *skb, __u32 dns_off
 
 	inner_map = bpf_map_lookup_elem(&dns_allow, &ifindex);
 	if (!inner_map)
-		goto pass;
+		return CUBE_DNS_PASS;
 
 	if (!dns_query_should_filter_ipv4_a(skb, dns_off, &hdr, flags))
-		goto pass;
+		return CUBE_DNS_PASS;
 
 	state = bpf_map_lookup_elem(&dns_query_state, &key);
 	if (!state)
-		goto pass;
+		return CUBE_DNS_PASS;
 
 	dns_init_query_state(state, dns_off, ifindex, flags);
 
 	/* The tail-call programs parse, reverse, match, and then finish NAT. */
 	bpf_tail_call(skb, &dns_tail_calls, DNS_TAIL_CALL_PARSE);
 	return TC_ACT_SHOT;
-
-pass:
-	return CUBE_DNS_PASS;
 }
 
 #endif /* __DNS_QUERY_H */

--- a/CubeNet/src/dns_response.h
+++ b/CubeNet/src/dns_response.h
@@ -95,7 +95,7 @@ static __always_inline bool dns_response_learning_enabled(__u32 ifindex)
 	struct mvm_meta *mvm_meta;
 
 	mvm_meta = bpf_map_lookup_elem(&ifindex_to_mvmmeta, &ifindex);
-	return dns_policy_learning_enabled(mvm_meta);
+	return mvm_meta && (mvm_meta->dns_policy_flags & DNS_POLICY_FLAG_LEARNING_ENABLED);
 }
 
 /* Add an IPv4 A-record address as a temporary DNS-learned allow_out_v2 entry. */
@@ -173,12 +173,9 @@ static __always_inline bool dns_process_response_answer(struct __sk_buff *skb,
 }
 
 /* Lookup the pending DNS query that authorizes this response. */
-static __always_inline struct dns_query_track_value *dns_lookup_response_query(__u32 ifindex,
-									 __u32 server_ip,
-									 __u16 source_port,
-									 __be16 dns_id,
-									 __u64 qname_hash,
-									 struct dns_query_track_key *track_key)
+static __always_inline struct dns_query_track_value *dns_lookup_response_query(
+	__u32 ifindex, __u32 server_ip, __u16 source_port, __be16 dns_id,
+	__u64 qname_hash, struct dns_query_track_key *track_key)
 {
 	track_key->ifindex = ifindex;
 	track_key->server_ip = server_ip;

--- a/CubeNet/src/map.h
+++ b/CubeNet/src/map.h
@@ -96,19 +96,6 @@ struct {
 	__uint(pinning, LIBBPF_PIN_BY_NAME);
 } snat_iplist SEC(".maps");
 
-/* Inner map template for network policy (LPM trie)
- *
- * key:   struct lpm_key (prefixlen + IP)
- * value: struct net_policy_value_v2 (expiration and policy flags)
- */
-struct {
-	__uint(type, BPF_MAP_TYPE_LPM_TRIE);
-	__uint(max_entries, MAX_IP_RULE_ENTRIES);
-	__type(key, struct lpm_key);
-	__type(value, struct net_policy_value_v2);
-	__uint(map_flags, BPF_F_NO_PREALLOC);
-} net_policy_inner SEC(".maps");
-
 /* Egress allow list v2 (hash of maps)
  *
  * key:   ifindex of the TAP device
@@ -152,36 +139,6 @@ struct {
 		__uint(map_flags, BPF_F_NO_PREALLOC);
 	});
 } deny_out SEC(".maps");
-
-/* Inner map template for dns_allow (LPM trie).
- *
- * The standalone map below registers struct dns_allow_key / struct
- * dns_allow_value as map types so libbpf has them in BTF. That alone is
- * sufficient for compilation units that never touch the value type from
- * program code (e.g. localgw.bpf.c), but as soon as a unit references
- * `struct dns_allow_value *` from program code (e.g. mvmtap.bpf.c via
- * dns_query.h), clang's BPF BTF emitter degrades the value type to a
- * BTF_KIND_FWD entry, which makes bpf2go fail to load the dns_allow
- * hash-of-maps inner map definition with "type is unsized".
- *
- * The fix is the LLVM CO-RE intrinsic right below the template: it tells
- * the BPF backend "this type must be preserved as a complete BTF entry."
- * It is the canonical way to anchor BTF for a referenced type.
- */
-struct {
-	__uint(type, BPF_MAP_TYPE_LPM_TRIE);
-	__uint(max_entries, MAX_DOMAIN_RULE_ENTRIES);
-	__type(key, struct dns_allow_key);
-	__type(value, struct dns_allow_value);
-	__uint(map_flags, BPF_F_NO_PREALLOC);
-} dns_allow_inner SEC(".maps");
-
-/* BTF anchor for struct dns_allow_value — see comment above. */
-static __always_inline __attribute__((used)) __u32 __dns_allow_value_btf_pin(void)
-{
-	return __builtin_btf_type_id(*(struct dns_allow_value *)0,
-				     BPF_TYPE_ID_LOCAL);
-}
 
 /* DNS policy rules (hash of maps)
  *
@@ -240,23 +197,6 @@ struct {
 	__type(key, __u32);
 	__type(value, struct dns_query_state);
 } dns_query_state SEC(".maps");
-
-/* Tail-call state for DNS response handling on the ingress UDP NAT path.
- *
- * The response handler is split into its own tail-called program to keep the
- * from_world verifier complexity within the 1M instruction budget. We stash
- * the values the caller already derived (DNS payload offset, target sandbox
- * ifindex, DNS server IP, sandbox-side port) so the tail-called program can
- * re-pull headers, learn A records, and finish UDP NAT without re-deriving
- * them from scratch.
- */
-struct dns_response_state {
-	__u32 dns_off;
-	__u32 ifindex;		/* sandbox tap ifindex (sess->vm_ifindex) */
-	__u32 server_ip;	/* DNS server IP (l3->saddr in network byte order) */
-	__u16 source_port;	/* sandbox-side UDP port (sess->vm_port in nbo) */
-	__u16 reserved;
-};
 
 struct {
 	__uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);

--- a/CubeNet/src/mvmtap.bpf.c
+++ b/CubeNet/src/mvmtap.bpf.c
@@ -790,6 +790,11 @@ do_nat:
 	return TCP_NAT_PACK(sess->node_ifindex, TCP_NAT_OK);
 }
 
+static __always_inline bool dns_policy_enabled(const struct mvm_meta *mvm_meta)
+{
+	return mvm_meta && mvm_meta->dns_policy_flags;
+}
+
 /* Parse one DNS QNAME chunk and dispatch to reverse or finish stage. */
 SEC("tc")
 int dns_parse_chunk(struct __sk_buff *skb)


### PR DESCRIPTION
* Unify BTF anchors for inner-map key/value types (struct lpm_key, net_policy_value_v2, dns_allow_value) into a single __btf_pin() in cubevs.h; drop the now-unused net_policy_inner / dns_allow_inner template maps from map.h.
* Relocate struct dns_response_state from map.h to cubevs.h alongside other shared state structs.
* Inline single-use helpers (dns_policy_learning_enabled, dns_question_footer_is_in) into their sole call sites; relocate dns_policy_enabled from cubevs.h to mvmtap.bpf.c as a file-local static; drop the "goto pass" idiom in dns_handle_query().
* Whitespace-only re-indentation on a few multi-line signatures.

No functional changes intended.