### PR TITLE
CubeVS: Pin BTF type for struct dns_allow_key

### DIFF
--- a/CubeNet/src/cubevs.h
+++ b/CubeNet/src/cubevs.h
@@ -293,6 +293,7 @@ static __always_inline __attribute__((used)) __u32 __btf_pin(void)
 {
 	return __builtin_btf_type_id(*(struct lpm_key *)0, BPF_TYPE_ID_LOCAL) +
 	       __builtin_btf_type_id(*(struct net_policy_value_v2 *)0, BPF_TYPE_ID_LOCAL) +
+	       __builtin_btf_type_id(*(struct dns_allow_key *)0, BPF_TYPE_ID_LOCAL) +
 	       __builtin_btf_type_id(*(struct dns_allow_value *)0, BPF_TYPE_ID_LOCAL);
 }
 


### PR DESCRIPTION
This fixes build failure with LLVM/Clang 14.