### PR TITLE
cubecow: add opt-in Ceph RBD storage backend

### DIFF
--- a/CubeShim/shim/src/common/utils.rs
+++ b/CubeShim/shim/src/common/utils.rs
@@ -45,6 +45,17 @@ pub const DISK_DEVICE_ID_PRE: &str = "disk";
 const IVSHMEM_SHM_DIR: &str = "/dev/shm";
 const IVSHMEM_PREFIX: &str = "ivshmem-";
 
+/// Whether to open a sandbox volume disk with O_DIRECT: only block
+/// devices qualify (per-sandbox rbd volumes, where the host page cache
+/// merely duplicates the guest's own). File-backed volumes and
+/// un-stat-able paths stay buffered.
+pub fn wants_direct_io(path: &str) -> bool {
+    use std::os::unix::fs::FileTypeExt;
+    fs::metadata(path)
+        .map(|m| m.file_type().is_block_device())
+        .unwrap_or(false)
+}
+
 pub struct Utils {}
 pub struct AsyncUtils {}
 impl Utils {
@@ -309,6 +320,7 @@ impl Utils {
                 id: Some(format!("{}-{}", DISK_DEVICE_ID_PRE, disk_configs.len())),
                 path: Some(PathBuf::from(d.path.clone())),
                 rate_limiter_config: d.rate_limiter_config,
+                direct: wants_direct_io(&d.path),
                 ..Default::default()
             };
             disk_configs.push(disk_config);
@@ -576,6 +588,25 @@ mod tests {
             disk_configs[0].id,
             Some(format!("{}-{}", DISK_DEVICE_ID_PRE, disk_configs.len() - 1))
         )
+    }
+
+    #[test]
+    fn wants_direct_io_only_for_block_devices() {
+        let dir = std::env::temp_dir().join(format!("cube_direct_io_{}", process::id()));
+        fs::create_dir_all(&dir).unwrap();
+
+        // A regular file (reflink-backend volume) keeps buffered I/O.
+        let file = dir.join("vol.raw");
+        fs::write(&file, b"x").unwrap();
+        assert!(!wants_direct_io(file.to_str().unwrap()));
+
+        // A directory is not a block device either.
+        assert!(!wants_direct_io(dir.to_str().unwrap()));
+
+        // A path that cannot be stat'd falls back to buffered.
+        assert!(!wants_direct_io(dir.join("missing").to_str().unwrap()));
+
+        fs::remove_dir_all(&dir).ok();
     }
 
     #[test]

--- a/CubeShim/shim/src/hypervisor/config.rs
+++ b/CubeShim/shim/src/hypervisor/config.rs
@@ -290,6 +290,7 @@ impl VmConfig {
                 id: Some(format!("{}-{}", utils::DISK_DEVICE_ID_PRE, ds.len())),
                 path: Some(d.path.clone().into()),
                 rate_limiter_config: d.rate_limiter_config,
+                direct: utils::wants_direct_io(&d.path),
                 ..Default::default()
             };
             ds.push(disk_conf);

--- a/CubeShim/shim/src/service/update_ext.rs
+++ b/CubeShim/shim/src/service/update_ext.rs
@@ -114,7 +114,20 @@ async fn do_rollback_snapshot(
         rollback_cfg.source_url
     );
 
-    let restore_config: RestoreConfig = rollback_cfg.into();
+    let mut restore_config: RestoreConfig = rollback_cfg.into();
+
+    // Rollback disks arrive as pre-built DiskConfigs and bypass the
+    // Disk -> wants_direct_io path, so re-derive O_DIRECT here.
+    if let Some(disks) = restore_config.disks.as_mut() {
+        for d in disks.iter_mut() {
+            d.direct = d
+                .path
+                .as_deref()
+                .and_then(|p| p.to_str())
+                .map(crate::common::utils::wants_direct_io)
+                .unwrap_or(false);
+        }
+    }
 
     // --- delegate to sb ---
     sb.rollback_vm(restore_config).await.map_err(|e| {

--- a/Cubelet/config/config.toml
+++ b/Cubelet/config/config.toml
@@ -91,12 +91,13 @@ dynamic_config_path = "/usr/local/services/cubetoolbox/Cubelet/dynamicconf/conf.
     network_agent_tap_fd_timeout = "2s"
 
   [plugins."io.cubelet.internal.v1.storage"]
-    # Default storage backend: cubecow (reflink-only copy-on-write).
+    # Default storage backend: cubecow (copy-on-write).
     storage_backend = "cubecow"
 
-    # Working directory for the cubelet storage plugin. cubecow reflink volumes land at
-    # <data_path>/cubecow-reflink, so the filesystem backing data_path must support
-    # FICLONE (e.g. xfs with `-m reflink=1` or btrfs).
+    # Working directory for the cubelet storage plugin. With the default reflink
+    # backend, cubecow volumes land at <data_path>/cubecow-reflink, so the
+    # filesystem backing data_path must support FICLONE (e.g. xfs with
+    # `-m reflink=1` or btrfs).
     data_path = "/data/cubelet/storage"
 
 
@@ -105,6 +106,20 @@ dynamic_config_path = "/usr/local/services/cubetoolbox/Cubelet/dynamicconf/conf.
     format = "compact"
     file = "/data/log/cubecow/cubecow.log"
     rotation = "daily"
+
+    # cubecow backend selection. "reflink" (default) keeps volumes as FICLONE
+    # files on the local filesystem; "rbd" stores them as images in a Ceph RBD
+    # pool, reachable from every node. The pool must be dedicated to cubecow.
+    # [plugins."io.cubelet.internal.v1.storage".cow.backend]
+    # kind = "rbd"
+    # [plugins."io.cubelet.internal.v1.storage".cow.backend.rbd]
+    # pool = "cubecow"
+    # namespace = ""
+    # conf = "/etc/ceph/ceph.conf"
+    # client = "admin"
+    # map_options = ""
+    # cmd_timeout_secs = 60         # regular rbd/ceph calls
+    # slow_cmd_timeout_secs = 3600  # data-copying calls (flatten, rm)
 
     # Only needed when switching back to the legacy ext4 / raw / reflink-pool
     # backend: change storage_backend to the corresponding value (e.g. "ext4")

--- a/Cubelet/pkg/cubecow/cubecow_mock_test.go
+++ b/Cubelet/pkg/cubecow/cubecow_mock_test.go
@@ -18,6 +18,7 @@ func TestMapError(t *testing.T) {
 		{name: "already_exists", rc: -2, wantCode: SemAlreadyExists, wantAction: ActFail},
 		{name: "resource_exhausted", rc: -3, wantCode: SemResourceExhausted, wantAction: ActFail},
 		{name: "invalid_argument", rc: -4, wantCode: SemInvalidArgument, wantAction: ActBug},
+		{name: "command_failed", rc: -5, wantCode: SemCommandFailed, wantAction: ActMarkStorageUnhealthy},
 		{name: "io_error", rc: -6, wantCode: SemIoError, wantAction: ActMarkStorageUnhealthy},
 		{name: "config_error", rc: -10, wantCode: SemConfigError, wantAction: ActOpsIntervention},
 		{name: "precondition_failed", rc: -11, wantCode: SemPreconditionFailed, wantAction: ActFail},

--- a/Cubelet/pkg/cubecow/doc.go
+++ b/Cubelet/pkg/cubecow/doc.go
@@ -4,9 +4,12 @@
 
 // Package cubecow provides Go bindings for the cubecow C FFI library.
 //
-// cubecow is a reflink-only copy-on-write storage engine. Volumes are
-// regular files on a reflink-capable filesystem (XFS or Btrfs) and
-// snapshots are O(1) FICLONE-based clones of those files.
+// cubecow is a copy-on-write storage engine with two backends. With the
+// default reflink backend, volumes are regular files on a
+// reflink-capable filesystem (XFS or Btrfs) and snapshots are O(1)
+// FICLONE-based clones of those files. With the rbd backend, volumes
+// are Ceph RBD images and snapshots are independent flattened RBD
+// clones, reachable from any node in the cluster.
 //
 // Thread model:
 //   - cubecow_last_error() is thread-local on the Rust FFI side.
@@ -36,8 +39,8 @@
 //   - sb-<sandboxID>-rootfs-gen<N>
 //   - tpl-<templateID>-build-rootfs
 //
-// Device paths returned by cubecow are stable regular file paths on the
-// reflink filesystem; persisted device_path values can be reused after
-// restart without re-resolution (refresh on startup is still recommended
-// to detect manual filesystem changes).
+// Device paths returned by the reflink backend are stable regular file
+// paths on the reflink filesystem; the rbd backend returns kernel block
+// device paths (/dev/rbdN) that change across activations and nodes.
+// Callers must re-resolve device paths instead of persisting them.
 package cubecow

--- a/Cubelet/pkg/cubecow/errors.go
+++ b/Cubelet/pkg/cubecow/errors.go
@@ -14,6 +14,7 @@ const (
 	SemAlreadyExists      SemanticCode = -2
 	SemResourceExhausted  SemanticCode = -3
 	SemInvalidArgument    SemanticCode = -4
+	SemCommandFailed      SemanticCode = -5
 	SemIoError            SemanticCode = -6
 	SemConfigError        SemanticCode = -10
 	SemPreconditionFailed SemanticCode = -11
@@ -68,6 +69,8 @@ func (c SemanticCode) String() string {
 		return "resource_exhausted"
 	case SemInvalidArgument:
 		return "invalid_argument"
+	case SemCommandFailed:
+		return "command_failed"
 	case SemIoError:
 		return "io_error"
 	case SemConfigError:
@@ -116,6 +119,8 @@ func MapError(rc int32) (SemanticCode, Action) {
 		return SemResourceExhausted, ActFail
 	case int32(SemInvalidArgument):
 		return SemInvalidArgument, ActBug
+	case int32(SemCommandFailed):
+		return SemCommandFailed, ActMarkStorageUnhealthy
 	case int32(SemIoError):
 		return SemIoError, ActMarkStorageUnhealthy
 	case int32(SemConfigError):

--- a/Cubelet/storage/cubecow_snapshot_artifacts.go
+++ b/Cubelet/storage/cubecow_snapshot_artifacts.go
@@ -20,8 +20,9 @@ const (
 )
 
 // cowMetricKeys mirrors the keys the cubecow Rust crate emits via
-// `cubecow_get_metrics()` for the reflink-only backend. The legacy
-// dm-thin pool_* keys are no longer surfaced.
+// `cubecow_get_metrics()`; both backends surface the same set (the rbd
+// backend reports Ceph pool capacity as total/used). The legacy dm-thin
+// pool_* keys are no longer surfaced.
 var cowMetricKeys = []string{
 	"total_bytes",
 	"used_bytes",

--- a/Cubelet/storage/local.go
+++ b/Cubelet/storage/local.go
@@ -170,8 +170,8 @@ func (l *local) cleanupCowStateOnDisk() error {
 		return err
 	}
 	if rootDir == "" {
-		// External cubecow.toml owns its own layout; skip best-effort
-		// cleanup rather than reach into a directory we did not pick.
+		// Non-reflink backend (rbd): volumes live in the cluster, so
+		// there is no node-local reflink layout to clean.
 		return nil
 	}
 	volumesDir := filepath.Join(path.Clean(rootDir), "volumes")

--- a/Cubelet/storage/local_test.go
+++ b/Cubelet/storage/local_test.go
@@ -1926,6 +1926,79 @@ func TestPrepareCowInlineConfigStampsBackendDefaults(t *testing.T) {
 	assert.Equal(t, "/var/lib/cubelet/cubecow-reflink", *cfg.Cow.Backend.Reflink.RootDir)
 }
 
+func TestPrepareCowInlineConfigRbdRequiresPool(t *testing.T) {
+	cfg := &Config{
+		Cow: CowInlineConfig{Backend: CowBackendConfig{Kind: cowBackendRbd}},
+	}
+	require.Error(t, cfg.PrepareCowInlineConfig())
+
+	cfg.Cow.Backend.Rbd.Pool = stringPtr("cubecow")
+	require.NoError(t, cfg.PrepareCowInlineConfig())
+	assert.Nil(t, cfg.Cow.Backend.Reflink.RootDir)
+}
+
+func TestPrepareCowInlineConfigRejectsUnknownKind(t *testing.T) {
+	cfg := &Config{
+		Cow: CowInlineConfig{Backend: CowBackendConfig{Kind: "dm-thin"}},
+	}
+	err := cfg.PrepareCowInlineConfig()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "dm-thin")
+}
+
+func TestBuildCowInitJSONEmitsRbdBackend(t *testing.T) {
+	cfg := &Config{
+		Cow: CowInlineConfig{
+			Backend: CowBackendConfig{
+				Kind: cowBackendRbd,
+				Rbd: CowRbdBackendConfig{
+					Pool:   stringPtr("cubecow"),
+					Client: stringPtr("cubelet"),
+				},
+			},
+		},
+	}
+	raw, err := cfg.BuildCowInitJSON()
+	require.NoError(t, err)
+
+	var payload map[string]any
+	require.NoError(t, json.Unmarshal(raw, &payload))
+	backendCfg, ok := payload["backend"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, cowBackendRbd, backendCfg["kind"])
+	rbdCfg, ok := backendCfg["rbd"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "cubecow", rbdCfg["pool"])
+	assert.Equal(t, "cubelet", rbdCfg["client"])
+	_, hasNamespace := rbdCfg["namespace"]
+	assert.False(t, hasNamespace)
+	_, hasReflink := backendCfg["reflink"]
+	assert.False(t, hasReflink)
+}
+
+func TestCowStartupCommandsPerBackend(t *testing.T) {
+	reflinkCfg := &Config{}
+	assert.Contains(t, reflinkCfg.cowStartupCommands(), "losetup")
+
+	rbdCfg := &Config{
+		Cow: CowInlineConfig{Backend: CowBackendConfig{Kind: cowBackendRbd}},
+	}
+	cmds := rbdCfg.cowStartupCommands()
+	assert.Contains(t, cmds, "rbd")
+	assert.Contains(t, cmds, "ceph")
+	assert.NotContains(t, cmds, "losetup")
+}
+
+func TestCowReflinkRootDirEmptyForRbd(t *testing.T) {
+	cfg := &Config{
+		DataPath: "/var/lib/cubelet/io.cubelet.internal.v1.storage",
+		Cow:      CowInlineConfig{Backend: CowBackendConfig{Kind: cowBackendRbd}},
+	}
+	rootDir, err := cfg.cowReflinkRootDir()
+	require.NoError(t, err)
+	assert.Equal(t, "", rootDir)
+}
+
 func uint32Ptr(v uint32) *uint32 {
 	return &v
 }

--- a/Cubelet/storage/plugin.go
+++ b/Cubelet/storage/plugin.go
@@ -28,29 +28,43 @@ var cowLookPath = exec.LookPath
 var initCowEngine = initCowEngineWithConfig
 
 // StorageBackendCow is the canonical value of `storage_backend` for the
-// cubecow (reflink-only copy-on-write) backend. cubelet refuses to boot
-// when `storage_backend` is set to anything else under this build.
+// cubecow copy-on-write backend (reflink or rbd, selected via
+// `cow.backend.kind`). cubelet refuses to boot when `storage_backend`
+// is set to anything else under this build.
 const StorageBackendCow = "cubecow"
 
-// cowBackendReflink is the only backend `kind` cubecow now supports.
-// It is forwarded verbatim into the cubecow inline JSON payload and
-// matches the `BackendKind::Reflink` variant on the Rust side.
-const cowBackendReflink = "reflink"
+// Backend `kind` values forwarded verbatim into the cubecow inline
+// JSON payload; they match the `BackendKind` variants on the Rust side.
+const (
+	cowBackendReflink = "reflink"
+	cowBackendRbd     = "rbd"
+)
 
 // reflinkExt4InitCommands lists the external commands the **cubelet
 // upper layers** need when they initialise an ext4 default-medium
-// volume on top of a reflink-backed file. cubecow itself uses zero
-// external commands (mkdir/open/FICLONE/statvfs are pure libc) — but
-// `initExt4BlockDevice` in `cubecow_volume_manager.go` formats the
-// reflink file as ext4 and mounts it, which under the hood pulls in
-// `losetup` (auto-loop in mount(8)). Surface those commands here so a
-// missing binary is reported at startup rather than at the first
-// `CreateDefaultMediumVolume` call.
+// volume on top of a reflink-backed file. The reflink backend itself
+// uses zero external commands (mkdir/open/FICLONE/statvfs are pure
+// libc) — but `initExt4BlockDevice` in `cubecow_volume_manager.go`
+// formats the reflink file as ext4 and mounts it, which under the hood
+// pulls in `losetup` (auto-loop in mount(8)). Surface those commands
+// here so a missing binary is reported at startup rather than at the
+// first `CreateDefaultMediumVolume` call.
 var reflinkExt4InitCommands = []string{
 	"mkfs.ext4",
 	"mount",
 	"umount",
 	"losetup",
+}
+
+// rbdStartupCommands is the rbd-backend equivalent: volumes are real
+// block devices (no losetup), and cubecow itself shells out to `rbd`
+// (image lifecycle, map/unmap) and `ceph` (pool capacity metrics).
+var rbdStartupCommands = []string{
+	"mkfs.ext4",
+	"mount",
+	"umount",
+	"rbd",
+	"ceph",
 }
 
 type Config struct {
@@ -96,15 +110,15 @@ type Config struct {
 	CmdTimeout tomlext.Duration `toml:"cmd_timeout"`
 }
 
-// CowInlineConfig mirrors the cubecow `AppConfig` schema. cubecow is
-// reflink-only and cubelet always owns the cubecow init payload
-// (there is no external cubecow.toml fallback), so the only thing
-// users can tune through TOML is the `[log]` block. The reflink
+// CowInlineConfig mirrors the cubecow `AppConfig` schema. cubelet
+// always owns the cubecow init payload (there is no external
+// cubecow.toml fallback); users tune the `[log]` block, select the
+// backend kind, and provide rbd cluster settings. The reflink
 // backend's `root_dir` is derived from `data_path` and stamped onto
 // `Backend.Reflink` in PrepareCowInlineConfig.
 type CowInlineConfig struct {
 	Log     CowLogConfig     `toml:"log"`
-	Backend CowBackendConfig `toml:"-"`
+	Backend CowBackendConfig `toml:"backend"`
 }
 
 type CowLogConfig struct {
@@ -114,11 +128,13 @@ type CowLogConfig struct {
 	Rotation *string `toml:"rotation"`
 }
 
-// CowBackendConfig is filled in by cubelet at init time, never by the
-// user, and shipped to cubecow as the `[backend]` block.
+// CowBackendConfig is shipped to cubecow as the `[backend]` block.
+// `kind` selects the backend ("reflink" default, or "rbd"); reflink
+// settings stay cubelet-owned while rbd settings come from the user.
 type CowBackendConfig struct {
-	Kind    string `toml:"-"`
-	Reflink CowReflinkBackendConfig
+	Kind    string                  `toml:"kind"`
+	Reflink CowReflinkBackendConfig `toml:"-"`
+	Rbd     CowRbdBackendConfig     `toml:"rbd"`
 }
 
 // CowReflinkBackendConfig is the `[backend.reflink]` payload.
@@ -127,6 +143,19 @@ type CowBackendConfig struct {
 // cubelet's state.
 type CowReflinkBackendConfig struct {
 	RootDir *string `toml:"-"`
+}
+
+// CowRbdBackendConfig is the `[backend.rbd]` payload, forwarded to
+// cubecow. Only `pool` is required; unset fields fall back to the
+// cubecow-side defaults (standard Ceph client conventions).
+type CowRbdBackendConfig struct {
+	Pool               *string `toml:"pool"`
+	Namespace          *string `toml:"namespace"`
+	Conf               *string `toml:"conf"`
+	Client             *string `toml:"client"`
+	MapOptions         *string `toml:"map_options"`
+	CmdTimeoutSecs     *uint64 `toml:"cmd_timeout_secs"`
+	SlowCmdTimeoutSecs *uint64 `toml:"slow_cmd_timeout_secs"`
 }
 
 func (c *Config) BuildCowInitJSON() ([]byte, error) {
@@ -143,24 +172,40 @@ func (c *Config) BuildCowInitJSON() ([]byte, error) {
 	return json.Marshal(payload)
 }
 
-// PrepareCowInlineConfig stamps cubelet-owned defaults (currently the
-// reflink backend kind and its `root_dir` derived from `data_path`)
-// onto the config so BuildCowInitJSON has everything cubecow needs.
+// PrepareCowInlineConfig stamps cubelet-owned defaults onto the config
+// so BuildCowInitJSON has everything cubecow needs: the reflink
+// backend's `root_dir` is derived from `data_path`; the rbd backend
+// requires a user-provided pool.
 func (c *Config) PrepareCowInlineConfig() error {
 	if c == nil {
 		return fmt.Errorf("nil storage config")
 	}
-	c.Cow.Backend.Kind = cowBackendReflink
-	autoDir := defaultReflinkAutoRootDir(c.DataPath)
-	c.Cow.Backend.Reflink.RootDir = &autoDir
+	switch c.Cow.Backend.Kind {
+	case "", cowBackendReflink:
+		c.Cow.Backend.Kind = cowBackendReflink
+		autoDir := defaultReflinkAutoRootDir(c.DataPath)
+		c.Cow.Backend.Reflink.RootDir = &autoDir
+	case cowBackendRbd:
+		if c.Cow.Backend.Rbd.Pool == nil || *c.Cow.Backend.Rbd.Pool == "" {
+			return fmt.Errorf("storage cow backend %q requires cow.backend.rbd.pool", cowBackendRbd)
+		}
+	default:
+		return fmt.Errorf("unsupported cow backend kind %q (expected %q or %q)",
+			c.Cow.Backend.Kind, cowBackendReflink, cowBackendRbd)
+	}
 	return nil
 }
 
 // cowReflinkRootDir returns the effective reflink root_dir for this
 // deployment so cleanup/diagnostics can act on the right directory.
+// Empty for non-reflink backends: there is no node-local layout to
+// clean.
 func (c *Config) cowReflinkRootDir() (string, error) {
 	if c == nil {
 		return "", fmt.Errorf("nil storage config")
+	}
+	if c.Cow.Backend.Kind == cowBackendRbd {
+		return "", nil
 	}
 	return defaultReflinkAutoRootDir(c.DataPath), nil
 }
@@ -181,6 +226,9 @@ func defaultReflinkAutoRootDir(dataPath string) string {
 }
 
 func (c *Config) cowStartupCommands() []string {
+	if c != nil && c.Cow.Backend.Kind == cowBackendRbd {
+		return append([]string{}, rbdStartupCommands...)
+	}
 	return append([]string{}, reflinkExt4InitCommands...)
 }
 
@@ -235,6 +283,21 @@ func (c CowBackendConfig) toMap() map[string]any {
 	if sub := c.Reflink.toMap(); len(sub) > 0 {
 		m["reflink"] = sub
 	}
+	if sub := c.Rbd.toMap(); len(sub) > 0 {
+		m["rbd"] = sub
+	}
+	return m
+}
+
+func (c CowRbdBackendConfig) toMap() map[string]any {
+	m := map[string]any{}
+	setIfNotNil(m, "pool", c.Pool)
+	setIfNotNil(m, "namespace", c.Namespace)
+	setIfNotNil(m, "conf", c.Conf)
+	setIfNotNil(m, "client", c.Client)
+	setIfNotNil(m, "map_options", c.MapOptions)
+	setIfNotNil(m, "cmd_timeout_secs", c.CmdTimeoutSecs)
+	setIfNotNil(m, "slow_cmd_timeout_secs", c.SlowCmdTimeoutSecs)
 	return m
 }
 

--- a/cubecow/README.md
+++ b/cubecow/README.md
@@ -1,12 +1,13 @@
 # cubecow
 
-A Copy-On-Write storage engine built on xfs-reflink (FICLONE), shipped as a Rust library crate that provides thin-provisioned volume management and O(1) snapshot/clone capabilities.
+A Copy-On-Write storage engine shipped as a Rust library crate that provides thin-provisioned volume management and snapshot/clone capabilities, with node-local (xfs-reflink) and cluster-shared (Ceph RBD) backends.
 
 ## Overview
 
-cubecow is a library crate that exposes a uniform interface through the `Engine` trait. It currently ships with a single backend:
+cubecow is a library crate that exposes a uniform interface through the `Engine` trait. It ships with two backends:
 
-- **xfs-reflink (`ReflinkEngine`)** — uses regular files as volumes and snapshots inside a directory on a FICLONE-capable filesystem (XFS with reflink=1 / Btrfs / OCFS2 / …), and relies on the kernel `FICLONE` ioctl for O(1) metadata snapshots.
+- **xfs-reflink (`ReflinkEngine`)** — the default. Uses regular files as volumes and snapshots inside a directory on a FICLONE-capable filesystem (XFS with reflink=1 / Btrfs / OCFS2 / …), and relies on the kernel `FICLONE` ioctl for O(1) metadata snapshots.
+- **Ceph RBD (`RbdEngine`)** — opt-in. Stores volumes and snapshots as standalone RBD images in a dedicated pool, reachable from any node in the cluster. A snapshot is an independent flattened clone of its source (a full copy — snapshot cost is O(allocated data), traded for cross-node independence). Requires Ceph Nautilus or newer.
 
 
 ## Key Features
@@ -99,10 +100,13 @@ file = "/var/log/cubecow.log"    # optional; logs go to stdout when unset
 rotation = "daily"               # "daily" | "hourly" | "never"
 
 [backend]
-kind = "reflink"                 # the only backend currently supported
+kind = "reflink"                 # "reflink" (default) | "rbd"
 
 [backend.reflink]
 root_dir = "/var/lib/cubecow/reflink"
+
+[backend.rbd]                    # only read when kind = "rbd"
+pool = "cubecow"                 # required; dedicated to cubecow
 ```
 
 ### JSON

--- a/cubecow/include/cubecow.h
+++ b/cubecow/include/cubecow.h
@@ -52,6 +52,7 @@ typedef void* CubecowEngineHandle;
 #define COW_ERR_ALREADY_EXISTS      -2
 #define COW_ERR_RESOURCE_EXHAUSTED  -3
 #define COW_ERR_INVALID_ARG         -4
+#define COW_ERR_COMMAND_FAILED      -5
 #define COW_ERR_IO_ERROR            -6
 #define COW_ERR_CONFIG_ERROR        -10
 #define COW_ERR_PRECONDITION_FAILED -11
@@ -210,6 +211,9 @@ int32_t cubecow_list_volumes(
  *   - activate = false: metadata-only; out_device_path is written as
  *                       an empty string. Call cubecow_activate_volume()
  *                       later to materialise the device.
+ *
+ * The snapshot is an independent, writable copy of the source (no shared
+ * lifetime or storage dependency).
  *
  * Regardless of `activate`, the snapshot is identified by snapshot_name
  * for every subsequent operation.

--- a/cubecow/src/config/mod.rs
+++ b/cubecow/src/config/mod.rs
@@ -38,6 +38,9 @@ pub struct BackendConfig {
     /// Settings for the xfs-reflink backend.
     #[serde(default)]
     pub reflink: ReflinkConfig,
+    /// Settings for the Ceph RBD backend.
+    #[serde(default)]
+    pub rbd: RbdConfig,
 }
 
 /// Configuration for the xfs-reflink backend.
@@ -72,14 +75,106 @@ fn default_reflink_root_dir() -> PathBuf {
     PathBuf::from("/var/lib/cubecow/reflink")
 }
 
+/// Configuration for the Ceph RBD backend.
+///
+/// The backend drives the `rbd` CLI (and `ceph` for pool capacity), so
+/// cluster connectivity follows the standard Ceph client conventions:
+/// `/etc/ceph/ceph.conf` and the default admin keyring unless `conf` /
+/// `client` say otherwise. The configured pool (optionally narrowed to
+/// an RBD namespace) should be dedicated to cubecow: the backend lists
+/// and classifies every image in it by convention. `reset_node_storage`
+/// only unmaps this node's local devices in the pool and never deletes
+/// cluster data.
+///
+/// A deletion that is positively blocked (image busy or still watched)
+/// falls back to `rbd trash mv` so the name frees up immediately; the
+/// trash itself is never purged by cubecow — reclaiming that capacity
+/// (`rbd trash purge` or a purge schedule) is the operator's call.
+///
+/// Requires Ceph Nautilus or newer: the backend relies on clone
+/// format 2, the array form of `rbd showmapped --format json`, and
+/// (preferred, with a fallback) `stored` in `ceph df`.
+#[derive(Debug, Clone, Deserialize)]
+pub struct RbdConfig {
+    /// RBD pool holding all cubecow images. Required.
+    #[serde(default)]
+    pub pool: String,
+    /// Optional RBD namespace within the pool.
+    #[serde(default)]
+    pub namespace: String,
+    /// Optional ceph.conf path, forwarded as `--conf`.
+    #[serde(default)]
+    pub conf: Option<PathBuf>,
+    /// Optional Ceph client id (without the `client.` prefix),
+    /// forwarded as `--id`.
+    #[serde(default)]
+    pub client: Option<String>,
+    /// `rbd` binary. Default: resolved from PATH.
+    #[serde(default = "default_rbd_bin")]
+    pub rbd_bin: String,
+    /// `ceph` binary, used for pool capacity metrics.
+    #[serde(default = "default_ceph_bin")]
+    pub ceph_bin: String,
+    /// Per-command timeout in seconds for regular rbd/ceph calls.
+    #[serde(default = "default_rbd_cmd_timeout_secs")]
+    pub cmd_timeout_secs: u64,
+    /// Timeout in seconds for long-running maintenance commands
+    /// (`rbd flatten`), which copy image data and scale with size.
+    #[serde(default = "default_rbd_slow_cmd_timeout_secs")]
+    pub slow_cmd_timeout_secs: u64,
+    /// Image features for `rbd create` / `rbd clone`. Restricted to
+    /// krbd-mappable features by default.
+    #[serde(default = "default_rbd_image_features")]
+    pub image_features: String,
+    /// Optional krbd map options, forwarded as `rbd map -o <value>`
+    /// (e.g. "exclusive").
+    #[serde(default)]
+    pub map_options: Option<String>,
+}
+
+impl Default for RbdConfig {
+    fn default() -> Self {
+        Self {
+            pool: String::new(),
+            namespace: String::new(),
+            conf: None,
+            client: None,
+            rbd_bin: default_rbd_bin(),
+            ceph_bin: default_ceph_bin(),
+            cmd_timeout_secs: default_rbd_cmd_timeout_secs(),
+            slow_cmd_timeout_secs: default_rbd_slow_cmd_timeout_secs(),
+            image_features: default_rbd_image_features(),
+            map_options: None,
+        }
+    }
+}
+
+fn default_rbd_bin() -> String {
+    "rbd".to_string()
+}
+fn default_ceph_bin() -> String {
+    "ceph".to_string()
+}
+fn default_rbd_cmd_timeout_secs() -> u64 {
+    60
+}
+fn default_rbd_slow_cmd_timeout_secs() -> u64 {
+    3600
+}
+fn default_rbd_image_features() -> String {
+    "layering,exclusive-lock".to_string()
+}
+
 /// Available storage backends.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Default)]
 #[serde(rename_all = "lowercase")]
 pub enum BackendKind {
-    /// xfs-reflink backend (FICLONE-based snapshots) — the **default**
-    /// and currently the only shipping backend.
+    /// xfs-reflink backend (FICLONE-based snapshots) — the **default**.
     #[default]
     Reflink,
+    /// Ceph RBD backend (network block devices; snapshots and clones
+    /// live in the cluster, so any node can attach any volume).
+    Rbd,
 }
 
 /// Logging configuration.
@@ -196,6 +291,7 @@ impl AppConfig {
         // ---- Backend-specific required fields ----------------------------
         match self.backend.kind {
             BackendKind::Reflink => self.validate_reflink_requirements(),
+            BackendKind::Rbd => self.validate_rbd_requirements(),
         }
     }
 
@@ -218,6 +314,33 @@ impl AppConfig {
                 "[backend.reflink] root_dir = \"{}\" must be an absolute path",
                 root_dir.display()
             )));
+        }
+        Ok(())
+    }
+
+    /// Field-level validation for the rbd backend.
+    ///
+    /// Cluster reachability is probed at engine startup, not here —
+    /// `validate()` is meant to be cheap and side-effect free.
+    fn validate_rbd_requirements(&self) -> CubecowResult<()> {
+        let rbd = &self.backend.rbd;
+        if rbd.pool.is_empty() {
+            return Err(CubecowError::ConfigError(
+                "[backend.rbd] pool must not be empty when backend.kind = \"rbd\"".to_string(),
+            ));
+        }
+        for (field, value) in [("pool", &rbd.pool), ("namespace", &rbd.namespace)] {
+            if value.contains('/') || value.contains('@') || value.starts_with('-') {
+                return Err(CubecowError::ConfigError(format!(
+                    "[backend.rbd] {field} = \"{value}\" must not contain '/' or '@' \
+                     or start with '-'"
+                )));
+            }
+        }
+        if rbd.cmd_timeout_secs == 0 || rbd.slow_cmd_timeout_secs == 0 {
+            return Err(CubecowError::ConfigError(
+                "[backend.rbd] command timeouts must be positive".to_string(),
+            ));
         }
         Ok(())
     }
@@ -319,6 +442,24 @@ mod tests {
             CubecowError::ConfigError(msg) => {
                 assert!(msg.contains("[backend.reflink] root_dir"));
                 assert!(msg.contains("absolute"));
+            }
+            other => panic!("unexpected error: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn validate_rejects_rbd_pool_that_parses_as_flag() {
+        let err = AppConfig::from_json_str(
+            r#"{
+                "log": {},
+                "backend": {"kind": "rbd", "rbd": {"pool": "--read-only"}}
+            }"#,
+        )
+        .unwrap_err();
+        match err {
+            CubecowError::ConfigError(msg) => {
+                assert!(msg.contains("[backend.rbd] pool"));
+                assert!(msg.contains("start with '-'"));
             }
             other => panic!("unexpected error: {other:?}"),
         }

--- a/cubecow/src/engine/mod.rs
+++ b/cubecow/src/engine/mod.rs
@@ -6,13 +6,14 @@
 // This module hosts:
 //
 // * [`Engine`] — the trait that every snapshot backend must implement.
-// * [`reflink::ReflinkEngine`] — the xfs-reflink backend; the only
-//   backend currently shipping with cubecow.
+// * [`reflink::ReflinkEngine`] — the xfs-reflink backend.
+// * [`rbd::RbdEngine`] — the Ceph RBD backend.
 //
 // New backends live as siblings of `reflink` and implement the same
 // trait. Selection between backends happens at construction time via
 // [`crate::initialize`] based on [`crate::config::BackendKind`].
 
+pub mod rbd;
 pub mod reflink;
 
 use std::collections::HashMap;
@@ -26,12 +27,12 @@ use crate::{Snapshot, Volume, VolumeBlockInfo};
 /// concrete backend is selected at construction time via
 /// [`crate::initialize`] based on `AppConfig.backend.kind`.
 ///
-/// The interface is intentionally pool-free: the reflink backend (the
-/// only one that ships) treats its `[backend.reflink].root_dir` as a
-/// single flat namespace and has no notion of LVM PV/VG/thin-pool
-/// partitioning. Any future backend that needs sub-namespaces is
-/// expected to model them with explicit prefixes in the volume name
-/// rather than re-introducing a pool concept here.
+/// The interface is intentionally pool-free: each backend maps its
+/// storage (the reflink `root_dir`, the rbd pool/namespace) to a single
+/// flat namespace, with no notion of LVM PV/VG/thin-pool partitioning.
+/// Any future backend that needs sub-namespaces is expected to model
+/// them with explicit prefixes in the volume name rather than
+/// re-introducing a pool concept here.
 pub trait Engine: Send + Sync {
     // -----------------------------------------------------------------------
     // Volume operations

--- a/cubecow/src/engine/rbd.rs
+++ b/cubecow/src/engine/rbd.rs
@@ -1,0 +1,1777 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Ceph RBD backed implementation of [`crate::engine::Engine`].
+//
+// Where the reflink backend stores volumes as files on one node's local
+// filesystem, this backend stores them as RBD images in a Ceph pool, so
+// every object is reachable from every node in the cluster. Compute
+// nodes keep no persistent storage state: activation maps an image into
+// the local kernel (`rbd map` -> /dev/rbdX), deactivation unmaps it,
+// and the truth stays in the cluster.
+//
+// # Object model
+//
+// Every engine object — volume or snapshot — is a standalone RBD image
+// in one flat pool namespace (trait contract). A snapshot is an
+// *independent flattened clone* of its source: `create_snapshot` clones
+// through a transient anchor snapshot and immediately `rbd flatten`s the
+// result, so the new image shares no parent chain or lifetime with its
+// source. There is no read-only-snapshot concept and no clone chain.
+//
+// The object kind is encoded in the pool image name — `vol-<name>` /
+// `snap-<name>` — so a single `rbd ls` classifies the whole pool with
+// no per-image reads; the prefix never leaves this backend (callers use
+// plain engine names). A snapshot's origin volume is recorded on the
+// image itself as image-meta `cubecow.origin`, cluster-visible with no
+// separate index and no node-local cache.
+//
+// # Deletion
+//
+// Because a snapshot is an independent image (not an RBD snapshot on its
+// source), deleting a volume never conflicts with snapshots derived from
+// it: each is removed with a plain `rbd rm`. An image whose removal is
+// still blocked (e.g. a leftover transient anchor) falls back to
+// `rbd trash mv`, freeing the name immediately.
+//
+// # reset_node_storage
+//
+// Resetting *node* storage on a shared backend means detaching this
+// node, not destroying cluster data: every locally mapped image of the
+// pool is unmapped and nothing else is touched.
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use chrono::{DateTime, NaiveDateTime, Utc};
+use serde::Deserialize;
+use tracing::{info, warn};
+
+use crate::config::{AppConfig, RbdConfig};
+use crate::engine::Engine;
+use crate::pkg::errors::{CubecowError, CubecowResult};
+use crate::pkg::executor::{CommandExecutor, CommandRunner};
+use crate::pkg::metrics::{
+    METRIC_SNAPSHOT_COUNT, METRIC_TOTAL_BYTES, METRIC_USED_BYTES, METRIC_VOLUME_COUNT,
+};
+use crate::{Snapshot, Volume, VolumeBlockInfo};
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/// Block size advertised through `get_volume_block_info`, matching the
+/// reflink backend.
+const RBD_BLOCK_SIZE: u32 = 512;
+
+/// Image-name prefix for volumes. The object kind is encoded in the
+/// image name (`vol-<name>` / `snap-<name>`), so one `rbd ls` classifies
+/// the whole pool without a per-image metadata read. The prefix never
+/// leaves this backend: callers use plain engine names.
+const VOLUME_PREFIX: &str = "vol-";
+
+/// Image-name prefix for snapshots. See [`VOLUME_PREFIX`].
+const SNAPSHOT_PREFIX: &str = "snap-";
+
+/// image-meta key: a snapshot's origin volume (engine name).
+const META_ORIGIN: &str = "cubecow.origin";
+
+/// Prefix for the transient anchor snapshot `create_snapshot` clones
+/// from. It exists only between clone and flatten and is removed within
+/// the same call.
+const TRANSIENT_SNAP_PREFIX: &str = "__cow_";
+
+/// Cache TTL for pool metrics; the heartbeat polls metrics every second
+/// and three cluster round-trips per tick would be wasteful.
+const METRICS_CACHE_TTL: Duration = Duration::from_secs(5);
+
+/// Cache TTL for `rbd showmapped` output used by read-only projections.
+/// Mapping state only changes through this engine's own map/unmap
+/// (which refresh the cache), so the TTL merely bounds staleness
+/// against out-of-band manual maps.
+const MAPPINGS_CACHE_TTL: Duration = Duration::from_secs(1);
+
+// ---------------------------------------------------------------------------
+// Resolution
+// ---------------------------------------------------------------------------
+
+/// A resolved engine object: a real RBD image plus what it is. The
+/// `rbd info` result is carried along so projections do not re-fetch it.
+struct RbdObject {
+    kind: ImageKind,
+    info: RbdInfo,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+enum ImageKind {
+    Volume,
+    Snapshot,
+}
+
+impl ImageKind {
+    fn prefix(self) -> &'static str {
+        match self {
+            ImageKind::Volume => VOLUME_PREFIX,
+            ImageKind::Snapshot => SNAPSHOT_PREFIX,
+        }
+    }
+
+    /// Pool image name for an engine name of this kind.
+    fn image_name(self, name: &str) -> String {
+        format!("{}{}", self.prefix(), name)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// rbd CLI JSON shapes (serde views of the fields we consume)
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Deserialize)]
+struct RbdInfo {
+    size: u64,
+    #[serde(default)]
+    create_timestamp: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct RbdMapping {
+    #[serde(default)]
+    pool: String,
+    #[serde(default)]
+    namespace: String,
+    name: String,
+    #[serde(default)]
+    snap: String,
+    device: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct RbdSnapLsEntry {
+    name: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct CephDf {
+    pools: Vec<CephDfPool>,
+}
+
+#[derive(Debug, Deserialize)]
+struct CephDfPool {
+    name: String,
+    stats: CephDfPoolStats,
+}
+
+#[derive(Debug, Deserialize)]
+struct CephDfPoolStats {
+    /// Logical bytes stored (pre-replication). Absent on very old
+    /// clusters, hence optional.
+    #[serde(default)]
+    stored: Option<u64>,
+    /// Raw bytes consumed, including replication/EC overhead.
+    bytes_used: u64,
+    /// Projected writable capacity, already divided by the replication
+    /// factor (logical bytes).
+    max_avail: u64,
+}
+
+// ---------------------------------------------------------------------------
+// RbdEngine
+// ---------------------------------------------------------------------------
+
+/// Ceph RBD backed engine. Stateless on the node: every operation is
+/// resolved against the cluster through the `rbd` CLI.
+pub struct RbdEngine {
+    cfg: RbdConfig,
+    runner: Arc<dyn CommandRunner>,
+    /// Runner with a long timeout for data-copying maintenance
+    /// commands (`rbd flatten`).
+    slow_runner: Arc<dyn CommandRunner>,
+    metrics_cache: Mutex<Option<(Instant, HashMap<String, u64>)>>,
+    /// Single-flights the metrics recompute (ceph df + one image-meta
+    /// call per image) so slow refreshes don't stampede the cluster.
+    metrics_refresh: Mutex<()>,
+    mappings_cache: Mutex<Option<(Instant, Vec<RbdMapping>)>>,
+    /// Serializes map/unmap check-then-act: concurrent activations of
+    /// one image would otherwise both observe "not mapped" and krbd
+    /// maps it twice, leaking a device.
+    map_lock: Mutex<()>,
+    /// Serializes the anchor-create → clone window of create_snapshot:
+    /// anchors are keyed by destination name, so racing same-name
+    /// creates would remove each other's anchor mid-clone.
+    snapshot_lock: Mutex<()>,
+}
+
+impl RbdEngine {
+    /// Initialize the rbd engine from an `AppConfig`, setting up logging.
+    pub fn initialize(config: AppConfig) -> anyhow::Result<Self> {
+        crate::pkg::logger::init_logging(&config.log)
+            .map_err(|e| anyhow::anyhow!("failed to init logging: {e}"))?;
+        info!("rbd engine initializing");
+        Self::initialize_with_config(config)
+    }
+
+    /// Same as [`Self::initialize`] but skips logging setup.
+    pub fn initialize_without_logging(config: AppConfig) -> anyhow::Result<Self> {
+        info!("rbd engine initializing (logging managed externally)");
+        Self::initialize_with_config(config)
+    }
+
+    fn initialize_with_config(config: AppConfig) -> anyhow::Result<Self> {
+        config
+            .validate()
+            .map_err(|e| anyhow::anyhow!("invalid config for rbd backend: {e}"))?;
+        let cfg = config.backend.rbd.clone();
+        let runner = Arc::new(CommandExecutor::new(Duration::from_secs(
+            cfg.cmd_timeout_secs,
+        )));
+        let slow_runner = Arc::new(CommandExecutor::new(Duration::from_secs(
+            cfg.slow_cmd_timeout_secs,
+        )));
+        let engine = Self::new_with_runners(cfg, runner, slow_runner);
+
+        // Probe cluster reachability so a misconfigured pool fails engine
+        // startup, not the first volume operation (mirrors the reflink
+        // FICLONE probe).
+        let pool = engine.pool_spec();
+        engine.run_rbd(&["ls", &pool]).map_err(|e| {
+            anyhow::anyhow!("rbd pool '{pool}' unusable: {}", Self::classify(e, &pool))
+        })?;
+        info!(
+            pool = %engine.cfg.pool,
+            namespace = %engine.cfg.namespace,
+            "rbd engine initialized"
+        );
+        Ok(engine)
+    }
+
+    fn new_with_runners(
+        cfg: RbdConfig,
+        runner: Arc<dyn CommandRunner>,
+        slow_runner: Arc<dyn CommandRunner>,
+    ) -> Self {
+        Self {
+            cfg,
+            runner,
+            slow_runner,
+            metrics_cache: Mutex::new(None),
+            metrics_refresh: Mutex::new(()),
+            mappings_cache: Mutex::new(None),
+            map_lock: Mutex::new(()),
+            snapshot_lock: Mutex::new(()),
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // CLI plumbing
+    // -----------------------------------------------------------------------
+
+    /// Global `rbd` arguments derived from config (cluster selection).
+    /// Empty strings count as unset — a TOML `conf = ""` must not become
+    /// a literal `--conf ""`.
+    fn base_args(&self) -> Vec<String> {
+        let mut args = Vec::new();
+        if let Some(conf) = &self.cfg.conf {
+            if !conf.as_os_str().is_empty() {
+                args.push("--conf".to_string());
+                args.push(conf.to_string_lossy().into_owned());
+            }
+        }
+        if let Some(client) = &self.cfg.client {
+            if !client.is_empty() {
+                args.push("--id".to_string());
+                args.push(client.clone());
+            }
+        }
+        args
+    }
+
+    fn run_cmd(
+        &self,
+        runner: &dyn CommandRunner,
+        bin: &str,
+        args: &[&str],
+    ) -> CubecowResult<String> {
+        let mut full = self.base_args();
+        full.extend(args.iter().map(|s| s.to_string()));
+        let refs: Vec<&str> = full.iter().map(String::as_str).collect();
+        runner.run(bin, &refs)
+    }
+
+    fn run_rbd(&self, args: &[&str]) -> CubecowResult<String> {
+        self.run_cmd(&*self.runner, &self.cfg.rbd_bin, args)
+    }
+
+    /// Like [`Self::run_rbd`] but on the long-timeout runner, for
+    /// commands whose runtime scales with image size (`flatten`, `rm`).
+    fn run_rbd_slow(&self, args: &[&str]) -> CubecowResult<String> {
+        self.run_cmd(&*self.slow_runner, &self.cfg.rbd_bin, args)
+    }
+
+    fn run_ceph(&self, args: &[&str]) -> CubecowResult<String> {
+        self.run_cmd(&*self.runner, &self.cfg.ceph_bin, args)
+    }
+
+    /// Flatten an image into an independent copy using the slow runner
+    /// (the data copy can take minutes).
+    fn flatten_image(&self, image: &str) -> CubecowResult<()> {
+        let spec = self.spec(image);
+        self.run_rbd_slow(&["flatten", &spec])
+            .map_err(|e| Self::classify(e, image))?;
+        Ok(())
+    }
+
+    /// `pool[/namespace]/image` spec for rbd commands. `image` is a pool
+    /// image name (kind prefix included), not an engine name.
+    fn spec(&self, image: &str) -> String {
+        if self.cfg.namespace.is_empty() {
+            format!("{}/{}", self.cfg.pool, image)
+        } else {
+            format!("{}/{}/{}", self.cfg.pool, self.cfg.namespace, image)
+        }
+    }
+
+    /// Spec for the image backing an engine name of a known kind.
+    fn spec_of(&self, kind: ImageKind, name: &str) -> String {
+        self.spec(&kind.image_name(name))
+    }
+
+    /// `pool[/namespace]/image@snap` spec.
+    fn snap_spec(&self, image: &str, snap: &str) -> String {
+        format!("{}@{}", self.spec(image), snap)
+    }
+
+    /// Pool (with namespace) spec for listing commands.
+    fn pool_spec(&self) -> String {
+        if self.cfg.namespace.is_empty() {
+            self.cfg.pool.clone()
+        } else {
+            format!("{}/{}", self.cfg.pool, self.cfg.namespace)
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Error classification
+    // -----------------------------------------------------------------------
+
+    /// Reinterpret a failed rbd command as a well-known error. The
+    /// errno-style exit code is authoritative; stderr phrases are only a
+    /// fallback for results without a usable code, matched as full
+    /// messages — stderr echoes image names, so a bare "busy" would
+    /// misfire on a name like "busybox". `what` names the object.
+    fn classify(err: CubecowError, what: &str) -> CubecowError {
+        let CubecowError::CommandFailed { cmd, reason, code } = &err else {
+            return err;
+        };
+        match code {
+            Some(2) => return CubecowError::NotFound(what.to_string()),
+            Some(17) => return CubecowError::AlreadyExists(what.to_string()),
+            // EBUSY(16) / ENOTEMPTY(39): the object is positively
+            // blocked (mapped, watched, or has dependents) — a
+            // retryable precondition.
+            Some(16) | Some(39) => {
+                return CubecowError::PreconditionFailed(format!("{what}: {cmd}: {reason}"))
+            }
+            _ => {}
+        }
+        if reason.contains("(2) No such file or directory") {
+            return CubecowError::NotFound(what.to_string());
+        }
+        if reason.contains("(17) File exists") {
+            return CubecowError::AlreadyExists(what.to_string());
+        }
+        if reason.contains("(16) Device or resource busy")
+            || reason.contains("image still has watchers")
+            || reason.contains("(39) Directory not empty")
+            || reason.contains("image has snapshots")
+        {
+            return CubecowError::PreconditionFailed(format!("{what}: {cmd}: {reason}"));
+        }
+        err
+    }
+
+    /// Best-effort cleanup on error paths: log failures instead of
+    /// silently leaking the object, without masking the primary error.
+    fn cleanup_warn<T>(op: &str, object: &str, result: CubecowResult<T>) {
+        if let Err(e) = result {
+            warn!(object, error = %e, "rbd cleanup '{op}' failed (leftover may remain)");
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Validation
+    // -----------------------------------------------------------------------
+
+    /// Reject names that would break the layout: empty, path or snap
+    /// separators, a leading '.' (reserved for internal images), or a
+    /// leading '-' (would parse as a CLI flag).
+    fn validate_name(name: &str, kind: &str) -> CubecowResult<()> {
+        if name.is_empty() {
+            return Err(CubecowError::InvalidArg(format!("{kind} name is empty")));
+        }
+        if name.contains('/') || name.contains('@') || name.contains('\0') {
+            return Err(CubecowError::InvalidArg(format!(
+                "{kind} name '{name}' contains an invalid character"
+            )));
+        }
+        if name.starts_with('.') || name.starts_with('-') {
+            return Err(CubecowError::InvalidArg(format!(
+                "{kind} name '{name}' must not start with '.' or '-'"
+            )));
+        }
+        Ok(())
+    }
+
+    // -----------------------------------------------------------------------
+    // Image helpers
+    // -----------------------------------------------------------------------
+
+    fn image_info(&self, spec: &str, what: &str) -> CubecowResult<RbdInfo> {
+        let out = self
+            .run_rbd(&["info", spec, "--format", "json"])
+            .map_err(|e| Self::classify(e, what))?;
+        serde_json::from_str(out.trim()).map_err(|e| {
+            CubecowError::PreconditionFailed(format!("parse rbd info for '{what}': {e}"))
+        })
+    }
+
+    /// Sorted `rbd ls` names of the pool, internal images filtered out.
+    /// Failures warn and degrade to an empty listing (the list/metrics
+    /// trait surface cannot propagate them).
+    fn pool_image_names(&self, op: &str) -> Vec<String> {
+        let out = match self.run_rbd(&["ls", &self.pool_spec(), "--format", "json"]) {
+            Ok(out) => out,
+            Err(e) => {
+                warn!(error = %e, op, "rbd ls failed");
+                return Vec::new();
+            }
+        };
+        let mut names: Vec<String> = serde_json::from_str(out.trim()).unwrap_or_else(|e| {
+            warn!(error = %e, op, "parse rbd ls output failed");
+            Vec::new()
+        });
+        names.retain(|n| !n.starts_with('.'));
+        names.sort();
+        names
+    }
+
+    fn image_meta(&self, image: &str) -> CubecowResult<HashMap<String, String>> {
+        let out = match self.run_rbd(&["image-meta", "list", &self.spec(image), "--format", "json"])
+        {
+            Ok(out) => out,
+            Err(e) => match Self::classify(e, image) {
+                CubecowError::NotFound(_) => return Ok(HashMap::new()),
+                other => return Err(other),
+            },
+        };
+        Ok(serde_json::from_str(out.trim()).unwrap_or_else(|e| {
+            warn!(image, error = %e, "parse rbd image-meta failed; treating as untagged");
+            HashMap::new()
+        }))
+    }
+
+    fn image_meta_set(&self, image: &str, key: &str, value: &str) -> CubecowResult<()> {
+        self.run_rbd(&["image-meta", "set", &self.spec(image), key, value])?;
+        Ok(())
+    }
+
+    /// Existence probe for an engine name of a given kind.
+    fn exists(&self, kind: ImageKind, name: &str) -> CubecowResult<bool> {
+        match self.image_info(&self.spec_of(kind, name), name) {
+            Ok(_) => Ok(true),
+            Err(CubecowError::NotFound(_)) => Ok(false),
+            Err(e) => Err(e),
+        }
+    }
+
+    /// Resolve an engine name to its backing image and kind, probing the
+    /// two kind prefixes (validate_name keeps the name from reaching
+    /// another pool or namespace).
+    fn resolve(&self, name: &str) -> CubecowResult<RbdObject> {
+        Self::validate_name(name, "image")?;
+        match self.image_info(&self.spec_of(ImageKind::Volume, name), name) {
+            Ok(info) => {
+                return Ok(RbdObject {
+                    kind: ImageKind::Volume,
+                    info,
+                })
+            }
+            Err(CubecowError::NotFound(_)) => {}
+            Err(e) => return Err(e),
+        }
+        let info = self.image_info(&self.spec_of(ImageKind::Snapshot, name), name)?;
+        Ok(RbdObject {
+            kind: ImageKind::Snapshot,
+            info,
+        })
+    }
+
+    // -----------------------------------------------------------------------
+    // Mapping
+    // -----------------------------------------------------------------------
+
+    /// Run `rbd showmapped` and refresh the projection cache.
+    fn load_mappings(&self) -> CubecowResult<Vec<RbdMapping>> {
+        let out = self.run_rbd(&["showmapped", "--format", "json"])?;
+        // A parse failure must surface as an error, not an empty list:
+        // treating "unknown" as "nothing mapped" would double-map images
+        // and make unmap/reset silently no-op.
+        let mappings: Vec<RbdMapping> = serde_json::from_str(out.trim()).map_err(|e| {
+            CubecowError::PreconditionFailed(format!("parse rbd showmapped output: {e}"))
+        })?;
+        *self.mappings_cache.lock().expect("mappings cache poisoned") =
+            Some((Instant::now(), mappings.clone()));
+        Ok(mappings)
+    }
+
+    fn invalidate_mappings_cache(&self) {
+        *self.mappings_cache.lock().expect("mappings cache poisoned") = None;
+    }
+
+    fn match_mapping(&self, mappings: &[RbdMapping], image: &str, snap: &str) -> Option<String> {
+        let want_snap = if snap.is_empty() { "-" } else { snap };
+        for m in mappings {
+            if m.pool == self.cfg.pool
+                && m.namespace == self.cfg.namespace
+                && m.name == image
+                && (m.snap == want_snap || (snap.is_empty() && m.snap.is_empty()))
+            {
+                return Some(m.device.clone());
+            }
+        }
+        None
+    }
+
+    /// Device path if `image[@snap]` is currently mapped on this node,
+    /// answered from a live `rbd showmapped`. Used before map/unmap
+    /// decisions, where a stale answer would double-map an image.
+    fn find_mapping(&self, image: &str, snap: &str) -> CubecowResult<Option<String>> {
+        let mappings = self.load_mappings()?;
+        Ok(self.match_mapping(&mappings, image, snap))
+    }
+
+    /// Cached variant for read-only projections (device_path display),
+    /// where bounded staleness is fine and the extra process spawn per
+    /// info call is not.
+    fn find_mapping_cached(&self, image: &str, snap: &str) -> CubecowResult<Option<String>> {
+        if let Some((at, mappings)) = self
+            .mappings_cache
+            .lock()
+            .expect("mappings cache poisoned")
+            .as_ref()
+        {
+            if at.elapsed() < MAPPINGS_CACHE_TTL {
+                return Ok(self.match_mapping(mappings, image, snap));
+            }
+        }
+        self.find_mapping(image, snap)
+    }
+
+    /// Idempotently map `image`, returning the local device path.
+    fn map_device(&self, image: &str, snap: &str) -> CubecowResult<String> {
+        let _serialized = self.map_lock.lock().expect("map lock poisoned");
+        if let Some(dev) = self.find_mapping(image, snap)? {
+            return Ok(dev);
+        }
+        let spec = if snap.is_empty() {
+            self.spec(image)
+        } else {
+            self.snap_spec(image, snap)
+        };
+        let mut args = vec!["map"];
+        if let Some(opts) = &self.cfg.map_options {
+            if !opts.is_empty() {
+                args.push("-o");
+                args.push(opts);
+            }
+        }
+        args.push(&spec);
+        let out = self.run_rbd(&args).map_err(|e| Self::classify(e, &spec))?;
+        self.invalidate_mappings_cache();
+        let device = out.trim().to_string();
+        if device.is_empty() {
+            return Err(CubecowError::PreconditionFailed(format!(
+                "rbd map '{spec}' returned no device path"
+            )));
+        }
+        Ok(device)
+    }
+
+    /// Idempotently unmap `image[@snap]` if mapped on this node.
+    fn unmap_device(&self, image: &str, snap: &str) -> CubecowResult<()> {
+        let _serialized = self.map_lock.lock().expect("map lock poisoned");
+        if let Some(dev) = self.find_mapping(image, snap)? {
+            self.run_rbd(&["unmap", &dev])
+                .map_err(|e| Self::classify(e, &dev))?;
+            self.invalidate_mappings_cache();
+        }
+        Ok(())
+    }
+
+    // -----------------------------------------------------------------------
+    // Projections
+    // -----------------------------------------------------------------------
+
+    fn volume_view(name: &str, info: &RbdInfo, device_path: String) -> Volume {
+        Volume {
+            name: name.to_string(),
+            size_bytes: info.size,
+            device_path,
+            // Counting snapshots would cost an extra cluster round-trip
+            // on the hot info path and no caller consumes the value.
+            snapshot_count: 0,
+            created_at: rfc3339_from_rbd_timestamp(&info.create_timestamp),
+        }
+    }
+
+    fn snapshot_view(name: &str, origin: &str, info: &RbdInfo, device_path: String) -> Snapshot {
+        Snapshot {
+            name: name.to_string(),
+            size_bytes: info.size,
+            device_path,
+            origin_volume: origin.to_string(),
+            created_at: rfc3339_from_rbd_timestamp(&info.create_timestamp),
+        }
+    }
+
+    fn project_volume(&self, name: &str, obj: &RbdObject) -> CubecowResult<Volume> {
+        let image = obj.kind.image_name(name);
+        let device_path = self.find_mapping_cached(&image, "")?.unwrap_or_default();
+        Ok(Self::volume_view(name, &obj.info, device_path))
+    }
+
+    fn project_snapshot(
+        &self,
+        name: &str,
+        origin: &str,
+        info: &RbdInfo,
+    ) -> CubecowResult<Snapshot> {
+        let image = ImageKind::Snapshot.image_name(name);
+        let device_path = self.find_mapping_cached(&image, "")?.unwrap_or_default();
+        Ok(Self::snapshot_view(name, origin, info, device_path))
+    }
+
+    // -----------------------------------------------------------------------
+    // Deletion helper
+    // -----------------------------------------------------------------------
+
+    /// Remove an image: purge any leftover snapshots (a crashed
+    /// `create_snapshot` may leave a transient anchor), then `rbd rm`,
+    /// falling back to `rbd trash mv` when removal is still blocked.
+    fn remove_image(&self, image: &str) -> CubecowResult<()> {
+        let spec = self.spec(image);
+        let out = match self.run_rbd(&["snap", "ls", &spec, "--format", "json"]) {
+            Ok(out) => out,
+            Err(e) => match Self::classify(e, image) {
+                CubecowError::NotFound(_) => return Ok(()),
+                other => return Err(other),
+            },
+        };
+        let snaps: Vec<RbdSnapLsEntry> = serde_json::from_str(out.trim()).map_err(|e| {
+            CubecowError::PreconditionFailed(format!("parse rbd snap ls for '{image}': {e}"))
+        })?;
+        for snap in snaps {
+            let snap_spec = self.snap_spec(image, &snap.name);
+            if let Err(e) = self.run_rbd(&["snap", "rm", &snap_spec]) {
+                warn!(spec = %snap_spec, error = %e, "rbd snap rm failed during image removal");
+            }
+        }
+        match self.run_rbd_slow(&["rm", &spec]) {
+            Ok(_) => Ok(()),
+            Err(e) => match Self::classify(e, image) {
+                CubecowError::NotFound(_) => Ok(()),
+                CubecowError::PreconditionFailed(_) => {
+                    // Positively blocked (errno 16/39) — free the name via
+                    // trash. Anything else must surface, not silently defer
+                    // deletion and leak pool capacity.
+                    self.run_rbd(&["trash", "mv", &spec])
+                        .map_err(|e| Self::classify(e, image))?;
+                    info!(image, "rbd image moved to trash (removal blocked)");
+                    Ok(())
+                }
+                other => Err(other),
+            },
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Engine trait impl
+// ---------------------------------------------------------------------------
+
+impl Engine for RbdEngine {
+    fn create_volume(&self, name: &str, size_bytes: u64) -> CubecowResult<Volume> {
+        Self::validate_name(name, "volume")?;
+        // Engine names share one flat namespace across kinds; `rbd create`
+        // only guards the vol- side (17), so probe the snap- side first.
+        if self.exists(ImageKind::Snapshot, name)? {
+            return Err(CubecowError::AlreadyExists(format!(
+                "name '{name}' already exists in rbd namespace"
+            )));
+        }
+        let size = format!("{size_bytes}B");
+        let image = ImageKind::Volume.image_name(name);
+        self.run_rbd(&[
+            "create",
+            "--size",
+            &size,
+            "--image-feature",
+            &self.cfg.image_features,
+            &self.spec(&image),
+        ])
+        .map_err(|e| Self::classify(e, name))?;
+
+        let result = (|| -> CubecowResult<Volume> {
+            // Map immediately: callers format the fresh volume right
+            // away and expect a usable device path (reflink returns
+            // the file path for the same reason).
+            let device = self.map_device(&image, "")?;
+            let info = self.image_info(&self.spec(&image), name)?;
+            info!(volume = name, size_bytes, device, "rbd volume created");
+            Ok(Self::volume_view(name, &info, device))
+        })();
+
+        if result.is_err() {
+            Self::cleanup_warn("unmap", &image, self.unmap_device(&image, ""));
+            Self::cleanup_warn("rm", &image, self.run_rbd(&["rm", &self.spec(&image)]));
+        }
+        result
+    }
+
+    fn delete_volume(&self, name: &str) -> CubecowResult<()> {
+        if self.resolve(name)?.kind != ImageKind::Volume {
+            return Err(CubecowError::InvalidArg(format!(
+                "'{name}' is a snapshot; use delete_snapshot instead"
+            )));
+        }
+        let image = ImageKind::Volume.image_name(name);
+        self.unmap_device(&image, "")?;
+        self.remove_image(&image)?;
+        info!(volume = name, "rbd volume deleted");
+        Ok(())
+    }
+
+    fn resize_volume(&self, name: &str, new_size_bytes: u64) -> CubecowResult<(u64, u64)> {
+        // Any engine image is resizable (a snapshot is an independent
+        // writable image, e.g. a sandbox rootfs generation grown by
+        // resizeSnapshotIfTooSmall).
+        let obj = self.resolve(name)?;
+        let old_size = obj.info.size;
+        if new_size_bytes < old_size {
+            return Err(CubecowError::InvalidArg(format!(
+                "shrinking is not supported (current={old_size}, requested={new_size_bytes})"
+            )));
+        }
+        if new_size_bytes == old_size {
+            return Ok((old_size, old_size));
+        }
+        let size = format!("{new_size_bytes}B");
+        self.run_rbd(&["resize", "--size", &size, &self.spec_of(obj.kind, name)])
+            .map_err(|e| Self::classify(e, name))?;
+        info!(
+            volume = name,
+            old_size,
+            new_size = new_size_bytes,
+            "rbd volume resized"
+        );
+        Ok((old_size, new_size_bytes))
+    }
+
+    fn get_volume_info(&self, name: &str) -> CubecowResult<Volume> {
+        let obj = self.resolve(name)?;
+        self.project_volume(name, &obj)
+    }
+
+    fn get_volume_block_info(&self, name: &str) -> CubecowResult<VolumeBlockInfo> {
+        let vol = self.get_volume_info(name)?;
+        Ok(VolumeBlockInfo {
+            num_blocks: vol.size_bytes / RBD_BLOCK_SIZE as u64,
+            block_size: RBD_BLOCK_SIZE,
+        })
+    }
+
+    fn list_volumes(
+        &self,
+        page_size: usize,
+        page_token: Option<&str>,
+    ) -> (Vec<Volume>, Option<String>, usize) {
+        let volumes: Vec<String> = self
+            .pool_image_names("list_volumes")
+            .iter()
+            .filter_map(|n| n.strip_prefix(VOLUME_PREFIX).map(str::to_string))
+            .collect();
+        let total = volumes.len();
+
+        let start = match page_token {
+            Some(tok) => volumes.iter().position(|n| n == tok).unwrap_or(total),
+            None => 0,
+        };
+        let effective_page_size = if page_size == 0 { total } else { page_size };
+        let end = (start + effective_page_size).min(total);
+
+        let mut out = Vec::with_capacity(end.saturating_sub(start));
+        for name in &volumes[start..end] {
+            let projected = self
+                .image_info(&self.spec_of(ImageKind::Volume, name), name)
+                .and_then(|info| {
+                    self.project_volume(
+                        name,
+                        &RbdObject {
+                            kind: ImageKind::Volume,
+                            info,
+                        },
+                    )
+                });
+            match projected {
+                Ok(v) => out.push(v),
+                Err(e) => {
+                    warn!(volume = %name, error = %e, "rbd volume disappeared mid-list");
+                }
+            }
+        }
+        let next_token = if end < total {
+            Some(volumes[end].clone())
+        } else {
+            None
+        };
+        (out, next_token, total)
+    }
+
+    fn create_snapshot(
+        &self,
+        source_name: &str,
+        snapshot_name: &str,
+        activate: bool,
+    ) -> CubecowResult<Snapshot> {
+        Self::validate_name(snapshot_name, "snapshot")?;
+        // Ownership-check the source before creating an anchor snapshot on it.
+        let source = self.resolve(source_name).map_err(|e| match e {
+            CubecowError::NotFound(_) => {
+                CubecowError::NotFound(format!("source '{source_name}' for snapshot"))
+            }
+            other => other,
+        })?;
+        let src_image = source.kind.image_name(source_name);
+        // A snapshot-of-a-snapshot inherits the recorded origin, so every
+        // snapshot points at the real volume (reflink's flattened ancestry).
+        let origin = if source.kind == ImageKind::Snapshot {
+            self.image_meta(&src_image)?
+                .get(META_ORIGIN)
+                .cloned()
+                .unwrap_or_else(|| source_name.to_string())
+        } else {
+            source_name.to_string()
+        };
+        // Uniqueness across the flat namespace: the clone itself guards
+        // the snap- side (17), so probe the vol- side.
+        if self.exists(ImageKind::Volume, snapshot_name)? {
+            return Err(CubecowError::AlreadyExists(format!(
+                "name '{snapshot_name}' already exists in rbd namespace"
+            )));
+        }
+
+        // Anchor snapshot on the source to clone from; removed once the
+        // clone is flattened. A leftover from a crashed attempt froze the
+        // source as of the crash, so it is recreated, never reused.
+        let tmp_snap = format!("{TRANSIENT_SNAP_PREFIX}{snapshot_name}");
+        let tmp_spec = self.snap_spec(&src_image, &tmp_snap);
+        // Clone, then flatten into an independent image (no parent chain).
+        let dst_image = ImageKind::Snapshot.image_name(snapshot_name);
+        let dst = self.spec(&dst_image);
+        {
+            // Locked so a racing same-name create cannot remove this
+            // anchor mid-clone. The clone is O(1) metadata; the long
+            // flatten runs unlocked (a removed clone-v2 parent snapshot
+            // is merely trashed until the child flattens).
+            let _serialized = self.snapshot_lock.lock().expect("snapshot lock poisoned");
+            if let Err(e) = self.run_rbd(&["snap", "create", &tmp_spec]) {
+                match Self::classify(e, &tmp_spec) {
+                    CubecowError::AlreadyExists(_) => {
+                        self.run_rbd(&["snap", "rm", &tmp_spec])
+                            .map_err(|e| Self::classify(e, &tmp_spec))?;
+                        self.run_rbd(&["snap", "create", &tmp_spec])
+                            .map_err(|e| Self::classify(e, &tmp_spec))?;
+                    }
+                    other => return Err(other),
+                }
+            }
+            if let Err(e) = self.run_rbd(&[
+                "--rbd_default_clone_format",
+                "2",
+                "clone",
+                "--image-feature",
+                &self.cfg.image_features,
+                &tmp_spec,
+                &dst,
+            ]) {
+                Self::cleanup_warn(
+                    "snap rm",
+                    &tmp_spec,
+                    self.run_rbd(&["snap", "rm", &tmp_spec]),
+                );
+                return Err(Self::classify(e, snapshot_name));
+            }
+        }
+        // Record the origin before the long flatten (the kind is already
+        // carried by the image name). The clone copies the source's meta,
+        // so the key must be overwritten.
+        if let Err(e) = self.image_meta_set(&dst_image, META_ORIGIN, &origin) {
+            Self::cleanup_warn("rm", &dst, self.run_rbd(&["rm", &dst]));
+            Self::cleanup_warn(
+                "snap rm",
+                &tmp_spec,
+                self.run_rbd(&["snap", "rm", &tmp_spec]),
+            );
+            return Err(e);
+        }
+        if let Err(e) = self.flatten_image(&dst_image) {
+            Self::cleanup_warn("rm", &dst, self.run_rbd_slow(&["rm", &dst]));
+            Self::cleanup_warn(
+                "snap rm",
+                &tmp_spec,
+                self.run_rbd(&["snap", "rm", &tmp_spec]),
+            );
+            return Err(e);
+        }
+        // The clone is now independent; drop the anchor snapshot.
+        if let Err(e) = self.run_rbd(&["snap", "rm", &tmp_spec]) {
+            warn!(
+                spec = %tmp_spec,
+                error = %Self::classify(e, &tmp_spec),
+                "rbd anchor snapshot cleanup failed (harmless leftover)"
+            );
+        }
+
+        // Finish projection under a cleanup guard: any failure must not
+        // leave a completed image behind (a retry would otherwise hit
+        // AlreadyExists).
+        let result = (|| -> CubecowResult<Snapshot> {
+            let info = self.image_info(&dst, snapshot_name)?;
+            // A just-created image is only mapped if we map it here.
+            let device_path = if activate {
+                self.map_device(&dst_image, "")?
+            } else {
+                String::new()
+            };
+            Ok(Self::snapshot_view(
+                snapshot_name,
+                &origin,
+                &info,
+                device_path,
+            ))
+        })();
+        let snapshot = match result {
+            Ok(s) => s,
+            Err(e) => {
+                Self::cleanup_warn("unmap", &dst_image, self.unmap_device(&dst_image, ""));
+                Self::cleanup_warn("rm", &dst, self.run_rbd_slow(&["rm", &dst]));
+                return Err(e);
+            }
+        };
+        info!(
+            snapshot = snapshot_name,
+            source = source_name,
+            activate,
+            "rbd snapshot created"
+        );
+        Ok(snapshot)
+    }
+
+    fn delete_snapshot(&self, snapshot_name: &str) -> CubecowResult<()> {
+        let obj = match self.resolve(snapshot_name) {
+            Ok(obj) => obj,
+            Err(CubecowError::NotFound(_)) => {
+                return Err(CubecowError::NotFound(format!(
+                    "snapshot '{snapshot_name}'"
+                )))
+            }
+            Err(e) => return Err(e),
+        };
+        if obj.kind != ImageKind::Snapshot {
+            return Err(CubecowError::InvalidArg(format!(
+                "'{snapshot_name}' is a volume; use delete_volume instead"
+            )));
+        }
+        let image = ImageKind::Snapshot.image_name(snapshot_name);
+        self.unmap_device(&image, "")?;
+        self.remove_image(&image)?;
+        info!(snapshot = snapshot_name, "rbd snapshot deleted");
+        Ok(())
+    }
+
+    fn list_snapshots(
+        &self,
+        volume_name: &str,
+        page_size: usize,
+        page_token: Option<&str>,
+    ) -> (Vec<Snapshot>, Option<String>) {
+        // Kind comes from the name; only snap-* images pay a meta read
+        // (for the origin filter).
+        let mut matching: Vec<String> = Vec::new();
+        for image in &self.pool_image_names("list_snapshots") {
+            let Some(name) = image.strip_prefix(SNAPSHOT_PREFIX) else {
+                continue;
+            };
+            match self.image_meta(image) {
+                Ok(meta) => {
+                    if meta.get(META_ORIGIN).map(String::as_str) == Some(volume_name) {
+                        matching.push(name.to_string());
+                    }
+                }
+                Err(e) => {
+                    warn!(image = %image, error = %e, "rbd image-meta failed during list_snapshots");
+                }
+            }
+        }
+        let total = matching.len();
+
+        let start = match page_token {
+            Some(tok) => matching.iter().position(|n| n == tok).unwrap_or(total),
+            None => 0,
+        };
+        let effective_page_size = if page_size == 0 { total } else { page_size };
+        let end = (start + effective_page_size).min(total);
+
+        let mut out = Vec::with_capacity(end.saturating_sub(start));
+        for name in &matching[start..end] {
+            let projected = self
+                .image_info(&self.spec_of(ImageKind::Snapshot, name), name)
+                .and_then(|info| self.project_snapshot(name, volume_name, &info));
+            match projected {
+                Ok(s) => out.push(s),
+                Err(e) => {
+                    warn!(snapshot = %name, error = %e, "rbd snapshot disappeared mid-list");
+                }
+            }
+        }
+        let next_token = if end < total {
+            Some(matching[end].clone())
+        } else {
+            None
+        };
+        (out, next_token)
+    }
+
+    fn activate_volume(&self, name: &str) -> CubecowResult<Volume> {
+        let obj = self.resolve(name)?;
+        let device = self.map_device(&obj.kind.image_name(name), "")?;
+        Ok(Self::volume_view(name, &obj.info, device))
+    }
+
+    fn deactivate_volume(&self, name: &str) -> CubecowResult<()> {
+        let obj = self.resolve(name)?;
+        self.unmap_device(&obj.kind.image_name(name), "")
+    }
+
+    fn reset_node_storage(&self) -> CubecowResult<()> {
+        // Resetting *node* storage on a shared backend detaches this
+        // node instead of destroying cluster data: unmap every locally
+        // mapped image of our pool/namespace and touch nothing else.
+        let _serialized = self.map_lock.lock().expect("map lock poisoned");
+        let mappings = self.load_mappings()?;
+        let mut cleared = 0usize;
+        for m in &mappings {
+            if m.pool != self.cfg.pool || m.namespace != self.cfg.namespace {
+                continue;
+            }
+            self.run_rbd(&["unmap", &m.device])
+                .map_err(|e| Self::classify(e, &m.device))?;
+            cleared += 1;
+        }
+        self.invalidate_mappings_cache();
+        info!(pool = %self.pool_spec(), cleared, "rbd node storage reset (local mappings only)");
+        Ok(())
+    }
+
+    fn metrics(&self) -> HashMap<String, u64> {
+        if let Some((at, cached)) = self
+            .metrics_cache
+            .lock()
+            .expect("metrics cache poisoned")
+            .clone()
+        {
+            if at.elapsed() < METRICS_CACHE_TTL {
+                return cached;
+            }
+        }
+        // Latecomers on the single-flight reuse the cache the winner wrote.
+        let _flight = self
+            .metrics_refresh
+            .lock()
+            .expect("metrics refresh poisoned");
+        let prev = self
+            .metrics_cache
+            .lock()
+            .expect("metrics cache poisoned")
+            .clone();
+        if let Some((at, cached)) = &prev {
+            if at.elapsed() < METRICS_CACHE_TTL {
+                return cached.clone();
+            }
+        }
+
+        let mut metrics = HashMap::new();
+        let capacity: Option<(u64, u64)> = match self.run_ceph(&["df", "--format", "json"]) {
+            Ok(out) => match serde_json::from_str::<CephDf>(out.trim()) {
+                Ok(df) => match df.pools.iter().find(|p| p.name == self.cfg.pool) {
+                    Some(pool) => {
+                        // `stored` is logical bytes; `bytes_used` is raw
+                        // (replication overhead included) while `max_avail`
+                        // is logical — mixing them overstates the fill by
+                        // the replication factor. Old clusters lack `stored`.
+                        let used = pool.stats.stored.unwrap_or(pool.stats.bytes_used);
+                        Some((used, used + pool.stats.max_avail))
+                    }
+                    None => {
+                        warn!(pool = %self.cfg.pool, "pool missing from ceph df output");
+                        None
+                    }
+                },
+                Err(e) => {
+                    warn!(error = %e, "parse ceph df output failed");
+                    None
+                }
+            },
+            Err(e) => {
+                warn!(error = %e, "ceph df failed");
+                None
+            }
+        };
+        // Omit the capacity keys when `ceph df` fails: consumers treat
+        // absence as "capacity unknown" and degrade safely; fabricating 0
+        // or stale values would report a possibly-full pool as healthy.
+        if let Some((used, total)) = capacity {
+            metrics.insert(METRIC_USED_BYTES.to_string(), used);
+            metrics.insert(METRIC_TOTAL_BYTES.to_string(), total);
+        }
+        // Kind is encoded in the image name, so one `rbd ls` classifies
+        // the pool with no per-image reads.
+        let names = self.pool_image_names("metrics");
+        let volume_count = names
+            .iter()
+            .filter(|n| n.starts_with(VOLUME_PREFIX))
+            .count() as u64;
+        let snapshot_count = names
+            .iter()
+            .filter(|n| n.starts_with(SNAPSHOT_PREFIX))
+            .count() as u64;
+        metrics.insert(METRIC_VOLUME_COUNT.to_string(), volume_count);
+        metrics.insert(METRIC_SNAPSHOT_COUNT.to_string(), snapshot_count);
+        *self.metrics_cache.lock().expect("metrics cache poisoned") =
+            Some((Instant::now(), metrics.clone()));
+        metrics
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Convert rbd's ctime-style `create_timestamp` ("Thu Jul  3 15:04:05
+/// 2026") to RFC3339, matching the other backends. Falls back to the
+/// raw string when the format is unexpected. The CLI prints the
+/// node-local time but no zone, so it is taken as UTC — on a non-UTC
+/// host `created_at` is skewed by the zone offset (display-only).
+fn rfc3339_from_rbd_timestamp(ts: &str) -> String {
+    if ts.is_empty() {
+        return String::new();
+    }
+    // ctime pads the day with a space ("Jul  3"); collapse runs of
+    // whitespace and drop the weekday so the rest parses as plain
+    // fields (chrono would reject an inconsistent weekday).
+    let fields: Vec<&str> = ts.split_whitespace().collect();
+    let without_weekday = match fields.as_slice() {
+        [_, rest @ ..] if rest.len() == 4 => rest.join(" "),
+        _ => return ts.to_string(),
+    };
+    match NaiveDateTime::parse_from_str(&without_weekday, "%b %d %H:%M:%S %Y") {
+        Ok(naive) => DateTime::<Utc>::from_naive_utc_and_offset(naive, Utc).to_rfc3339(),
+        Err(_) => ts.to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::VecDeque;
+    use std::sync::Mutex as StdMutex;
+
+    /// Scripted command runner: a FIFO of expected (program, args)
+    /// pairs with canned results. Any mismatch or leftover expectation
+    /// fails the test.
+    struct MockRunner {
+        expectations: StdMutex<VecDeque<(String, Vec<String>, CubecowResult<String>)>>,
+    }
+
+    impl MockRunner {
+        fn new() -> Arc<Self> {
+            Arc::new(Self {
+                expectations: StdMutex::new(VecDeque::new()),
+            })
+        }
+
+        fn expect(self: &Arc<Self>, program: &str, args: &[&str], result: CubecowResult<String>) {
+            self.expectations.lock().unwrap().push_back((
+                program.to_string(),
+                args.iter().map(|s| s.to_string()).collect(),
+                result,
+            ));
+        }
+
+        fn verify_drained(self: &Arc<Self>) {
+            let left = self.expectations.lock().unwrap();
+            assert!(
+                left.is_empty(),
+                "unconsumed command expectations: {:?}",
+                left.iter()
+                    .map(|(p, a, _)| format!("{p} {a:?}"))
+                    .collect::<Vec<_>>()
+            );
+        }
+    }
+
+    impl CommandRunner for MockRunner {
+        fn run(&self, program: &str, args: &[&str]) -> CubecowResult<String> {
+            let mut q = self.expectations.lock().unwrap();
+            let (want_prog, want_args, result) = q
+                .pop_front()
+                .unwrap_or_else(|| panic!("unexpected command: {program} {args:?}"));
+            assert_eq!(program, want_prog, "program mismatch (args: {args:?})");
+            let got: Vec<String> = args.iter().map(|s| s.to_string()).collect();
+            assert_eq!(got, want_args, "args mismatch for {program}");
+            result
+        }
+    }
+
+    fn cmd_failed(reason: &str) -> CubecowError {
+        CubecowError::CommandFailed {
+            cmd: "rbd".to_string(),
+            reason: reason.to_string(),
+            code: None,
+        }
+    }
+
+    fn cmd_failed_code(reason: &str, code: i32) -> CubecowError {
+        CubecowError::CommandFailed {
+            cmd: "rbd".to_string(),
+            reason: reason.to_string(),
+            code: Some(code),
+        }
+    }
+
+    fn test_engine(runner: Arc<MockRunner>) -> RbdEngine {
+        let cfg = RbdConfig {
+            pool: "cubecow".to_string(),
+            ..RbdConfig::default()
+        };
+        // One mock backs both the fast and slow runners, so a `flatten`
+        // (slow runner) appears in the same scripted FIFO.
+        RbdEngine::new_with_runners(cfg, runner.clone(), runner)
+    }
+
+    const NO_MAPPINGS: &str = "[]";
+
+    fn info_json(size: u64) -> String {
+        format!(
+            "{{\"name\":\"x\",\"size\":{size},\"create_timestamp\":\"Thu Jul  3 15:04:05 2026\"}}"
+        )
+    }
+
+    fn expect_info_not_found(runner: &Arc<MockRunner>, image: &str) {
+        runner.expect(
+            "rbd",
+            &["info", &format!("cubecow/{image}"), "--format", "json"],
+            Err(cmd_failed("(2) No such file or directory")),
+        );
+    }
+
+    /// Script `resolve(name)`: probe `vol-<name>`, then `snap-<name>`.
+    fn expect_resolve(runner: &Arc<MockRunner>, name: &str, size: u64, kind: &str) {
+        if kind == "volume" {
+            runner.expect(
+                "rbd",
+                &["info", &format!("cubecow/vol-{name}"), "--format", "json"],
+                Ok(info_json(size)),
+            );
+        } else {
+            expect_info_not_found(runner, &format!("vol-{name}"));
+            runner.expect(
+                "rbd",
+                &["info", &format!("cubecow/snap-{name}"), "--format", "json"],
+                Ok(info_json(size)),
+            );
+        }
+    }
+
+    #[test]
+    fn create_volume_maps() {
+        let runner = MockRunner::new();
+        let engine = test_engine(runner.clone());
+
+        // flat-namespace probe of the snap- side
+        expect_info_not_found(&runner, "snap-v1");
+        runner.expect(
+            "rbd",
+            &[
+                "create",
+                "--size",
+                "1048576B",
+                "--image-feature",
+                "layering,exclusive-lock",
+                "cubecow/vol-v1",
+            ],
+            Ok(String::new()),
+        );
+        runner.expect(
+            "rbd",
+            &["showmapped", "--format", "json"],
+            Ok(NO_MAPPINGS.to_string()),
+        );
+        runner.expect(
+            "rbd",
+            &["map", "cubecow/vol-v1"],
+            Ok("/dev/rbd0\n".to_string()),
+        );
+        runner.expect(
+            "rbd",
+            &["info", "cubecow/vol-v1", "--format", "json"],
+            Ok(info_json(1048576)),
+        );
+
+        let vol = engine.create_volume("v1", 1048576).unwrap();
+        assert_eq!(vol.name, "v1");
+        assert_eq!(vol.size_bytes, 1048576);
+        assert_eq!(vol.device_path, "/dev/rbd0");
+        assert_eq!(vol.snapshot_count, 0);
+        assert!(vol.created_at.starts_with("2026-07-03T15:04:05"));
+        runner.verify_drained();
+    }
+
+    #[test]
+    fn create_volume_duplicate_is_already_exists() {
+        let runner = MockRunner::new();
+        let engine = test_engine(runner.clone());
+
+        expect_info_not_found(&runner, "snap-v1");
+        runner.expect(
+            "rbd",
+            &[
+                "create",
+                "--size",
+                "1048576B",
+                "--image-feature",
+                "layering,exclusive-lock",
+                "cubecow/vol-v1",
+            ],
+            Err(cmd_failed("rbd: create error: (17) File exists")),
+        );
+        let err = engine.create_volume("v1", 1048576).unwrap_err();
+        assert!(matches!(err, CubecowError::AlreadyExists(_)), "{err:?}");
+        runner.verify_drained();
+    }
+
+    #[test]
+    fn classify_prefers_exit_code_over_stderr_text() {
+        // stderr echoes image names: "busybox" must not shadow the errno.
+        let not_found = cmd_failed_code(
+            "exit code 2: rbd: error opening image busybox-rootfs: (2) No such file or directory",
+            2,
+        );
+        assert!(matches!(
+            RbdEngine::classify(not_found, "busybox-rootfs"),
+            CubecowError::NotFound(_)
+        ));
+        // A marker-free reason classifies on the exit code alone.
+        let blocked = cmd_failed_code("exit code 16: ", 16);
+        assert!(matches!(
+            RbdEngine::classify(blocked, "v1"),
+            CubecowError::PreconditionFailed(_)
+        ));
+        // Bare name fragments in stderr never classify without a code.
+        let unknown = cmd_failed("something about busybox failed");
+        assert!(matches!(
+            RbdEngine::classify(unknown, "busybox"),
+            CubecowError::CommandFailed { .. }
+        ));
+    }
+
+    #[test]
+    fn validate_name_rejects_bad_inputs() {
+        assert!(RbdEngine::validate_name("", "volume").is_err());
+        assert!(RbdEngine::validate_name("a/b", "volume").is_err());
+        assert!(RbdEngine::validate_name("a@b", "volume").is_err());
+        assert!(RbdEngine::validate_name(".hidden", "volume").is_err());
+        assert!(RbdEngine::validate_name("-flag", "volume").is_err());
+        assert!(RbdEngine::validate_name("ok-name_1", "volume").is_ok());
+    }
+
+    #[test]
+    fn create_snapshot_clones_flattens_and_tags() {
+        let runner = MockRunner::new();
+        let engine = test_engine(runner.clone());
+
+        // source resolve (volume: origin = source, no meta read)
+        expect_resolve(&runner, "src", 4096, "volume");
+        // flat-namespace probe of the vol- side of the destination
+        expect_info_not_found(&runner, "vol-snap");
+        // anchor snap -> clone -> tag origin -> flatten -> anchor rm
+        runner.expect(
+            "rbd",
+            &["snap", "create", "cubecow/vol-src@__cow_snap"],
+            Ok(String::new()),
+        );
+        runner.expect(
+            "rbd",
+            &[
+                "--rbd_default_clone_format",
+                "2",
+                "clone",
+                "--image-feature",
+                "layering,exclusive-lock",
+                "cubecow/vol-src@__cow_snap",
+                "cubecow/snap-snap",
+            ],
+            Ok(String::new()),
+        );
+        runner.expect(
+            "rbd",
+            &[
+                "image-meta",
+                "set",
+                "cubecow/snap-snap",
+                "cubecow.origin",
+                "src",
+            ],
+            Ok(String::new()),
+        );
+        runner.expect("rbd", &["flatten", "cubecow/snap-snap"], Ok(String::new()));
+        runner.expect(
+            "rbd",
+            &["snap", "rm", "cubecow/vol-src@__cow_snap"],
+            Ok(String::new()),
+        );
+        // projection (not activated: no mapping lookup for a fresh image)
+        runner.expect(
+            "rbd",
+            &["info", "cubecow/snap-snap", "--format", "json"],
+            Ok(info_json(4096)),
+        );
+
+        let snap = engine.create_snapshot("src", "snap", false).unwrap();
+        assert_eq!(snap.name, "snap");
+        assert_eq!(snap.origin_volume, "src");
+        assert_eq!(snap.size_bytes, 4096);
+        assert_eq!(snap.device_path, "");
+        runner.verify_drained();
+    }
+
+    #[test]
+    fn create_snapshot_recreates_stale_anchor() {
+        let runner = MockRunner::new();
+        let engine = test_engine(runner.clone());
+
+        expect_resolve(&runner, "src", 4096, "volume");
+        expect_info_not_found(&runner, "vol-snap");
+        // A leftover anchor from a crashed attempt froze the source as of
+        // the crash: it must be removed and recreated, never cloned from.
+        runner.expect(
+            "rbd",
+            &["snap", "create", "cubecow/vol-src@__cow_snap"],
+            Err(cmd_failed("(17) File exists")),
+        );
+        runner.expect(
+            "rbd",
+            &["snap", "rm", "cubecow/vol-src@__cow_snap"],
+            Ok(String::new()),
+        );
+        runner.expect(
+            "rbd",
+            &["snap", "create", "cubecow/vol-src@__cow_snap"],
+            Ok(String::new()),
+        );
+        // Fail the clone to end the call here: the fresh anchor is
+        // cleaned up and the error propagates.
+        runner.expect(
+            "rbd",
+            &[
+                "--rbd_default_clone_format",
+                "2",
+                "clone",
+                "--image-feature",
+                "layering,exclusive-lock",
+                "cubecow/vol-src@__cow_snap",
+                "cubecow/snap-snap",
+            ],
+            Err(cmd_failed("(5) Input/output error")),
+        );
+        runner.expect(
+            "rbd",
+            &["snap", "rm", "cubecow/vol-src@__cow_snap"],
+            Ok(String::new()),
+        );
+
+        assert!(engine.create_snapshot("src", "snap", false).is_err());
+        runner.verify_drained();
+    }
+
+    #[test]
+    fn create_snapshot_rejects_missing_source() {
+        let runner = MockRunner::new();
+        let engine = test_engine(runner.clone());
+        expect_info_not_found(&runner, "vol-nope");
+        expect_info_not_found(&runner, "snap-nope");
+        let err = engine.create_snapshot("nope", "s", false).unwrap_err();
+        assert!(matches!(err, CubecowError::NotFound(_)), "{err:?}");
+        runner.verify_drained();
+    }
+
+    #[test]
+    fn delete_volume_removes_image() {
+        let runner = MockRunner::new();
+        let engine = test_engine(runner.clone());
+
+        expect_resolve(&runner, "v1", 4096, "volume");
+        // unmap: not mapped
+        runner.expect(
+            "rbd",
+            &["showmapped", "--format", "json"],
+            Ok(NO_MAPPINGS.to_string()),
+        );
+        // remove_image: snap ls (none) then rm
+        runner.expect(
+            "rbd",
+            &["snap", "ls", "cubecow/vol-v1", "--format", "json"],
+            Ok("[]".to_string()),
+        );
+        runner.expect("rbd", &["rm", "cubecow/vol-v1"], Ok(String::new()));
+
+        engine.delete_volume("v1").unwrap();
+        runner.verify_drained();
+    }
+
+    #[test]
+    fn delete_volume_rejects_snapshot() {
+        let runner = MockRunner::new();
+        let engine = test_engine(runner.clone());
+        expect_resolve(&runner, "s1", 4096, "snapshot");
+        let err = engine.delete_volume("s1").unwrap_err();
+        assert!(matches!(err, CubecowError::InvalidArg(_)), "{err:?}");
+        runner.verify_drained();
+    }
+
+    #[test]
+    fn delete_snapshot_removes_image() {
+        let runner = MockRunner::new();
+        let engine = test_engine(runner.clone());
+
+        expect_resolve(&runner, "s1", 4096, "snapshot");
+        runner.expect(
+            "rbd",
+            &["showmapped", "--format", "json"],
+            Ok(NO_MAPPINGS.to_string()),
+        );
+        runner.expect(
+            "rbd",
+            &["snap", "ls", "cubecow/snap-s1", "--format", "json"],
+            Ok("[]".to_string()),
+        );
+        runner.expect("rbd", &["rm", "cubecow/snap-s1"], Ok(String::new()));
+
+        engine.delete_snapshot("s1").unwrap();
+        runner.verify_drained();
+    }
+
+    #[test]
+    fn delete_volume_blocked_goes_to_trash() {
+        let runner = MockRunner::new();
+        let engine = test_engine(runner.clone());
+
+        expect_resolve(&runner, "v1", 4096, "volume");
+        runner.expect(
+            "rbd",
+            &["showmapped", "--format", "json"],
+            Ok(NO_MAPPINGS.to_string()),
+        );
+        runner.expect(
+            "rbd",
+            &["snap", "ls", "cubecow/vol-v1", "--format", "json"],
+            Ok("[]".to_string()),
+        );
+        // Real watcher output has neither "(16)" nor "busy": the exit
+        // code alone must classify it.
+        runner.expect(
+            "rbd",
+            &["rm", "cubecow/vol-v1"],
+            Err(cmd_failed_code(
+                "exit code 16: rbd: error: image still has watchers",
+                16,
+            )),
+        );
+        runner.expect("rbd", &["trash", "mv", "cubecow/vol-v1"], Ok(String::new()));
+
+        engine.delete_volume("v1").unwrap();
+        runner.verify_drained();
+    }
+
+    #[test]
+    fn resize_grows_and_rejects_shrink() {
+        let runner = MockRunner::new();
+        let engine = test_engine(runner.clone());
+
+        expect_resolve(&runner, "v1", 100, "volume");
+        runner.expect(
+            "rbd",
+            &["resize", "--size", "200B", "cubecow/vol-v1"],
+            Ok(String::new()),
+        );
+        let (old, new) = engine.resize_volume("v1", 200).unwrap();
+        assert_eq!((old, new), (100, 200));
+
+        expect_resolve(&runner, "v1", 100, "volume");
+        let err = engine.resize_volume("v1", 50).unwrap_err();
+        assert!(matches!(err, CubecowError::InvalidArg(_)), "{err:?}");
+        runner.verify_drained();
+    }
+
+    #[test]
+    fn activate_is_idempotent_when_already_mapped() {
+        let runner = MockRunner::new();
+        let engine = test_engine(runner.clone());
+
+        expect_resolve(&runner, "v1", 4096, "volume");
+        runner.expect(
+            "rbd",
+            &["showmapped", "--format", "json"],
+            Ok(r#"[{"pool":"cubecow","namespace":"","name":"vol-v1","snap":"-","device":"/dev/rbd0"}]"#
+                .to_string()),
+        );
+
+        let vol = engine.activate_volume("v1").unwrap();
+        assert_eq!(vol.device_path, "/dev/rbd0");
+        runner.verify_drained();
+    }
+
+    #[test]
+    fn deactivate_unmaps_and_is_idempotent() {
+        let runner = MockRunner::new();
+        let engine = test_engine(runner.clone());
+
+        expect_resolve(&runner, "v1", 4096, "volume");
+        runner.expect(
+            "rbd",
+            &["showmapped", "--format", "json"],
+            Ok(r#"[{"pool":"cubecow","namespace":"","name":"vol-v1","snap":"-","device":"/dev/rbd0"}]"#
+                .to_string()),
+        );
+        runner.expect("rbd", &["unmap", "/dev/rbd0"], Ok(String::new()));
+
+        engine.deactivate_volume("v1").unwrap();
+        runner.verify_drained();
+    }
+
+    #[test]
+    fn list_snapshots_filters_by_origin() {
+        let runner = MockRunner::new();
+        let engine = test_engine(runner.clone());
+
+        runner.expect(
+            "rbd",
+            &["ls", "cubecow", "--format", "json"],
+            Ok(r#"["snap-s1","vol-v1"]"#.to_string()),
+        );
+        // Only the snap-* image pays a meta read (origin filter).
+        runner.expect(
+            "rbd",
+            &["image-meta", "list", "cubecow/snap-s1", "--format", "json"],
+            Ok(r#"{"cubecow.origin":"v1"}"#.to_string()),
+        );
+        // project s1
+        runner.expect(
+            "rbd",
+            &["info", "cubecow/snap-s1", "--format", "json"],
+            Ok(info_json(4096)),
+        );
+        runner.expect(
+            "rbd",
+            &["showmapped", "--format", "json"],
+            Ok(NO_MAPPINGS.to_string()),
+        );
+
+        let (snaps, next) = engine.list_snapshots("v1", 0, None);
+        assert_eq!(snaps.len(), 1);
+        assert_eq!(snaps[0].name, "s1");
+        assert_eq!(snaps[0].origin_volume, "v1");
+        assert!(next.is_none());
+        runner.verify_drained();
+    }
+
+    #[test]
+    fn metrics_reports_pool_capacity_and_counts() {
+        let runner = MockRunner::new();
+        let engine = test_engine(runner.clone());
+
+        // stored is logical, bytes_used raw (3x-replicated here): the
+        // metric must come from stored so used=100, not 300.
+        runner.expect(
+            "ceph",
+            &["df", "--format", "json"],
+            Ok(r#"{"pools":[{"name":"cubecow","stats":{"stored":100,"bytes_used":300,"max_avail":900}}]}"#
+                .to_string()),
+        );
+        // Counts come from the name prefixes alone: no per-image reads.
+        runner.expect(
+            "rbd",
+            &["ls", "cubecow", "--format", "json"],
+            Ok(r#"["snap-s1","vol-v1"]"#.to_string()),
+        );
+
+        let m = engine.metrics();
+        assert_eq!(m.get(METRIC_USED_BYTES), Some(&100));
+        assert_eq!(m.get(METRIC_TOTAL_BYTES), Some(&1000));
+        assert_eq!(m.get(METRIC_VOLUME_COUNT), Some(&1));
+        assert_eq!(m.get(METRIC_SNAPSHOT_COUNT), Some(&1));
+        runner.verify_drained();
+    }
+
+    #[test]
+    fn metrics_omits_capacity_keys_when_ceph_df_fails() {
+        let runner = MockRunner::new();
+        let engine = test_engine(runner.clone());
+
+        runner.expect(
+            "ceph",
+            &["df", "--format", "json"],
+            Err(cmd_failed("timed out after 60s")),
+        );
+        runner.expect(
+            "rbd",
+            &["ls", "cubecow", "--format", "json"],
+            Ok("[]".to_string()),
+        );
+
+        // Absent keys mean "capacity unknown"; a fabricated 0 would read
+        // as a healthy empty pool.
+        let m = engine.metrics();
+        assert!(m.get(METRIC_USED_BYTES).is_none());
+        assert!(m.get(METRIC_TOTAL_BYTES).is_none());
+        assert_eq!(m.get(METRIC_VOLUME_COUNT), Some(&0));
+        runner.verify_drained();
+    }
+
+    #[test]
+    fn reset_unmaps_only_local_pool_mappings() {
+        let runner = MockRunner::new();
+        let engine = test_engine(runner.clone());
+
+        runner.expect(
+            "rbd",
+            &["showmapped", "--format", "json"],
+            Ok(r#"[{"pool":"cubecow","namespace":"","name":"vol-v1","snap":"-","device":"/dev/rbd0"},{"pool":"other","namespace":"","name":"x","snap":"-","device":"/dev/rbd9"}]"#
+                .to_string()),
+        );
+        runner.expect("rbd", &["unmap", "/dev/rbd0"], Ok(String::new()));
+
+        engine.reset_node_storage().unwrap();
+        runner.verify_drained();
+    }
+}

--- a/cubecow/src/ffi.rs
+++ b/cubecow/src/ffi.rs
@@ -49,6 +49,7 @@ const COW_ERR_NOT_FOUND: i32 = -1;
 const COW_ERR_ALREADY_EXISTS: i32 = -2;
 const COW_ERR_RESOURCE_EXHAUSTED: i32 = -3;
 const COW_ERR_INVALID_ARG: i32 = -4;
+const COW_ERR_COMMAND_FAILED: i32 = -5;
 const COW_ERR_IO_ERROR: i32 = -6;
 const COW_ERR_CONFIG_ERROR: i32 = -10;
 const COW_ERR_PRECONDITION_FAILED: i32 = -11;
@@ -84,6 +85,7 @@ fn handle_cow_error(e: &CubecowError) -> i32 {
         CubecowError::AlreadyExists(_) => COW_ERR_ALREADY_EXISTS,
         CubecowError::ResourceExhausted(_) => COW_ERR_RESOURCE_EXHAUSTED,
         CubecowError::InvalidArg(_) => COW_ERR_INVALID_ARG,
+        CubecowError::CommandFailed { .. } => COW_ERR_COMMAND_FAILED,
         CubecowError::IoError(_) => COW_ERR_IO_ERROR,
         CubecowError::ConfigError(_) => COW_ERR_CONFIG_ERROR,
         CubecowError::PreconditionFailed(_) => COW_ERR_PRECONDITION_FAILED,

--- a/cubecow/src/lib.rs
+++ b/cubecow/src/lib.rs
@@ -3,15 +3,15 @@
 //
 // cubecow library crate
 //
-// Provides programmatic access to the cubecow xfs-reflink storage
+// Provides programmatic access to the cubecow copy-on-write storage
 // engine.
 //
 // The public entry points are:
 //
 // * [`Engine`] — backend-agnostic trait describing the operations every
 //   storage backend supports.
-// * [`ReflinkEngine`] — the xfs-reflink backend (currently the only
-//   shipping backend). Implements [`Engine`].
+// * [`ReflinkEngine`] — the xfs-reflink backend. Implements [`Engine`].
+// * [`RbdEngine`] — the Ceph RBD backend. Implements [`Engine`].
 // * [`initialize`] / [`initialize_without_logging`] — backend-selecting
 //   factory functions that read [`config::AppConfig::backend`] and
 //   return the appropriate `Box<dyn Engine>`. New code should prefer
@@ -26,6 +26,7 @@ mod pkg;
 pub use crate::pkg::errors::{CubecowError, CubecowResult};
 
 // Engine trait + concrete backends.
+pub use crate::engine::rbd::RbdEngine;
 pub use crate::engine::reflink::ReflinkEngine;
 pub use crate::engine::Engine;
 
@@ -45,7 +46,9 @@ pub struct Volume {
     pub size_bytes: u64,
     /// Backend device path used for block IO. For the xfs-reflink
     /// backend this is the regular file path inside the
-    /// reflink-enabled mount.
+    /// reflink-enabled mount; for the rbd backend it is a kernel block
+    /// device (/dev/rbdN) valid only on this node for the current
+    /// activation, and empty when the image is not mapped locally.
     pub device_path: String,
     /// Number of snapshots derived from this volume.
     pub snapshot_count: i32,
@@ -112,6 +115,7 @@ use crate::config::{AppConfig, BackendKind};
 pub fn initialize(config: AppConfig) -> anyhow::Result<Box<dyn Engine>> {
     match config.backend.kind {
         BackendKind::Reflink => Ok(Box::new(ReflinkEngine::initialize(config)?)),
+        BackendKind::Rbd => Ok(Box::new(RbdEngine::initialize(config)?)),
     }
 }
 
@@ -120,5 +124,6 @@ pub fn initialize(config: AppConfig) -> anyhow::Result<Box<dyn Engine>> {
 pub fn initialize_without_logging(config: AppConfig) -> anyhow::Result<Box<dyn Engine>> {
     match config.backend.kind {
         BackendKind::Reflink => Ok(Box::new(ReflinkEngine::initialize_without_logging(config)?)),
+        BackendKind::Rbd => Ok(Box::new(RbdEngine::initialize_without_logging(config)?)),
     }
 }

--- a/cubecow/src/pkg/errors/mod.rs
+++ b/cubecow/src/pkg/errors/mod.rs
@@ -27,6 +27,17 @@ pub enum CubecowError {
     #[error("invalid argument: {0}")]
     InvalidArg(String),
 
+    /// External command spawn failure, timeout, or non-zero exit.
+    /// `code` is the numeric exit status when the command completed
+    /// (None for spawn failures, timeouts, signals), letting callers
+    /// classify on stable errno-style codes instead of stderr wording.
+    #[error("command failed: {cmd}: {reason}")]
+    CommandFailed {
+        cmd: String,
+        reason: String,
+        code: Option<i32>,
+    },
+
     /// IO error from the underlying system
     #[error("io error: {0}")]
     IoError(#[from] io::Error),

--- a/cubecow/src/pkg/executor/mod.rs
+++ b/cubecow/src/pkg/executor/mod.rs
@@ -3,8 +3,8 @@
 //
 // System command executor with timeout and error handling
 //
-// Wraps calls to external commands (lvm2, mdadm, etc.)
-// using `std::process::Command` with configurable timeout.
+// Wraps calls to external commands (rbd, ceph, ...) using
+// `std::process::Command` with configurable timeout.
 
 use std::process::Command;
 use std::time::Duration;
@@ -15,6 +15,20 @@ use crate::pkg::errors::{CubecowError, CubecowResult};
 
 /// Default command execution timeout.
 const DEFAULT_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Abstraction over external command execution so engines that shell
+/// out (e.g. the rbd backend) can be unit-tested with a scripted
+/// runner instead of real binaries.
+pub trait CommandRunner: Send + Sync {
+    /// Execute `program` with `args`, returning stdout on success.
+    fn run(&self, program: &str, args: &[&str]) -> CubecowResult<String>;
+}
+
+impl CommandRunner for CommandExecutor {
+    fn run(&self, program: &str, args: &[&str]) -> CubecowResult<String> {
+        CommandExecutor::run(self, program, args)
+    }
+}
 
 /// Sync system command executor with timeout and structured error handling.
 #[derive(Debug, Clone)]
@@ -40,73 +54,94 @@ impl CommandExecutor {
     ///
     /// Returns `CubecowError::CommandFailed` on timeout or non-zero exit code.
     pub fn run(&self, program: &str, args: &[&str]) -> CubecowResult<String> {
+        use std::io::Read;
+
         let cmd_str = format!("{} {}", program, args.join(" "));
         debug!(cmd = %cmd_str, "executing command");
 
         let mut child = Command::new(program)
             .args(args)
+            .stdin(std::process::Stdio::null())
             .stdout(std::process::Stdio::piped())
             .stderr(std::process::Stdio::piped())
             .spawn()
             .map_err(|e| CubecowError::CommandFailed {
                 cmd: cmd_str.clone(),
                 reason: format!("failed to spawn: {e}"),
+                code: None,
             })?;
 
-        // Wait with timeout using a polling approach
+        // Drain stdout/stderr on dedicated threads so output larger than
+        // the pipe buffer cannot block the child and be mistaken for a
+        // timeout.
+        let mut stdout_pipe = child.stdout.take().expect("stdout is piped");
+        let mut stderr_pipe = child.stderr.take().expect("stderr is piped");
+        let stdout_reader = std::thread::spawn(move || {
+            let mut buf = Vec::new();
+            let _ = stdout_pipe.read_to_end(&mut buf);
+            buf
+        });
+        let stderr_reader = std::thread::spawn(move || {
+            let mut buf = Vec::new();
+            let _ = stderr_pipe.read_to_end(&mut buf);
+            buf
+        });
+
+        // Poll for exit or timeout without touching the pipes. On the
+        // timeout and io-error paths the readers are deliberately not
+        // joined: a grandchild that inherited the pipes could keep them
+        // open past the kill and hang the join, and no output is needed
+        // to report those failures.
         let start = std::time::Instant::now();
         let poll_interval = Duration::from_millis(50);
-        loop {
+        let status = loop {
             match child.try_wait() {
-                Ok(Some(_status)) => {
-                    // Process has exited, collect output
-                    let output =
-                        child
-                            .wait_with_output()
-                            .map_err(|e| CubecowError::CommandFailed {
-                                cmd: cmd_str.clone(),
-                                reason: format!("io error: {e}"),
-                            })?;
-
-                    if output.status.success() {
-                        let stdout = String::from_utf8_lossy(&output.stdout).to_string();
-                        debug!(cmd = %cmd_str, "command succeeded");
-                        return Ok(stdout);
-                    } else {
-                        let stderr = String::from_utf8_lossy(&output.stderr).to_string();
-                        let code = output
-                            .status
-                            .code()
-                            .map(|c| c.to_string())
-                            .unwrap_or_else(|| "signal".to_string());
-                        warn!(cmd = %cmd_str, exit_code = %code, stderr = %stderr, "command failed");
-                        return Err(CubecowError::CommandFailed {
-                            cmd: cmd_str,
-                            reason: format!("exit code {code}: {stderr}"),
-                        });
-                    }
-                }
+                Ok(Some(status)) => break status,
                 Ok(None) => {
-                    // Process still running, check timeout
                     if start.elapsed() >= self.timeout {
-                        // Kill the process on timeout
                         let _ = child.kill();
                         let _ = child.wait();
                         warn!(cmd = %cmd_str, timeout = ?self.timeout, "command timed out");
                         return Err(CubecowError::CommandFailed {
                             cmd: cmd_str,
                             reason: format!("timed out after {:?}", self.timeout),
+                            code: None,
                         });
                     }
                     std::thread::sleep(poll_interval);
                 }
                 Err(e) => {
+                    let _ = child.kill();
+                    let _ = child.wait();
                     return Err(CubecowError::CommandFailed {
                         cmd: cmd_str,
                         reason: format!("io error: {e}"),
+                        code: None,
                     });
                 }
             }
+        };
+
+        // The child has exited, so its pipe write ends are closed and
+        // the reader threads finish.
+        let stdout = stdout_reader.join().unwrap_or_default();
+        let stderr = stderr_reader.join().unwrap_or_default();
+
+        if status.success() {
+            debug!(cmd = %cmd_str, "command succeeded");
+            Ok(String::from_utf8_lossy(&stdout).to_string())
+        } else {
+            let stderr = String::from_utf8_lossy(&stderr).to_string();
+            let code_str = status
+                .code()
+                .map(|c| c.to_string())
+                .unwrap_or_else(|| "signal".to_string());
+            warn!(cmd = %cmd_str, exit_code = %code_str, stderr = %stderr, "command failed");
+            Err(CubecowError::CommandFailed {
+                cmd: cmd_str,
+                reason: format!("exit code {code_str}: {stderr}"),
+                code: status.code(),
+            })
         }
     }
 }

--- a/cubecow/src/pkg/mod.rs
+++ b/cubecow/src/pkg/mod.rs
@@ -6,5 +6,6 @@
 // Common infrastructure shared across all layers.
 
 pub mod errors;
+pub mod executor;
 pub mod logger;
 pub mod metrics;


### PR DESCRIPTION
## Summary

Adds an **opt-in Ceph RBD backend** to `cubecow`, next to the existing xfs-reflink backend, selected with `cow.backend.kind = "rbd"`. The default stays reflink and is untouched, so nothing changes when rbd isn't enabled. Under rbd, each volume and snapshot is a standalone RBD image in a dedicated pool, so any node can attach any volume — the storage foundation for cross-node workloads. Requires Ceph Nautilus or newer.

This is the first increment from discussion #874, following the "implement the backend first, refine the architecture later" direction there.

## Scope

This PR is only the storage backend. Cross-node orchestration (lease / fencing / shared-storage mode), memory-snapshot pause/resume, and disk-only snapshots are out of scope, left to the cross-node/failover roadmap.

Commits are split one-per-component, infra first: `cubecow` executor/error → `cubecow` rbd backend → `cubelet` wiring → `shim` O_DIRECT.

## Design

**Snapshots are independent images, not native RBD snapshots**

In Ceph, an RBD image is a named virtual disk in a shared pool; a *native* RBD snapshot (`image@snap`) is a read-only point-in-time attached to its source image. That model doesn't fit cubecow's snapshot contract (set by the reflink backend):

| native RBD snapshot | cubecow contract |
|---|---|
| read-only | writable — rootfs generations are snapshots the VM then writes to |
| lives and dies with its source image | deletable independently of the source, in any order |
| clones keep a parent-chain data dependency | no chains — derivation must not degrade with depth |

So `create_snapshot` produces an **independent flattened clone** instead (transient anchor snap → `rbd clone` → `rbd flatten`): the result is just another image, matching the reflink backend's semantics exactly (a FICLONE copy is likewise an independent writable file).

*Alternative considered:* exposing native snapshots and clones directly would keep snapshot creation O(1) and share storage between snapshots, but it changes the `Engine` contract (a read-only-snapshot notion plus a `writable` flag on `create_snapshot`) and brings clone-chain lifecycle management (depth limits, ordered deletion, background flattening). Following the preference expressed in #874 for keeping core semantics unchanged, this PR takes the uniform model; the trade-off is that a flattened clone is a full copy (space, plus `flatten` time proportional to data) — the price of lifetime independence.

**Image naming**

Volumes and snapshots are both plain images, so the kind is encoded in the image name — `vol-<name>` / `snap-<name>` — letting a single `rbd ls` classify the pool; a snapshot's origin volume is recorded on the image as image-meta `cubecow.origin`. The prefixes are internal to the backend (callers use plain engine names), but they are what an operator sees when inspecting the pool directly, and they persist on the cluster.

**O_DIRECT for rbd disks**

An rbd volume is a per-sandbox network block device, so the host page cache only duplicates the guest's own. The shim opens block-device disks with `O_DIRECT`, derived from the disk path at each `DiskConfig`-build site; file-backed reflink disks and the pmem base stay buffered.

**Testability**

The backend drives the `rbd`/`ceph` CLIs through a `CommandRunner` seam, so unit tests script a mock runner and need no cluster.

## Testing

- Unit: cubecow (31) and shim (34) test suites pass; CubeShim `cargo build` and Cubelet `go build` pass.
- Real Ceph (nested-KVM VM + microceph squid, Ceph 19.2.x):
  - Full engine lifecycle via the smoke CLI — create / resize / snapshot (clone+flatten) / list / metrics / delete, pool left clean.
  - A sandbox cold-starts on the rbd backend; the hypervisor opens the writable rbd volume with O_DIRECT while the pmem base stays buffered (fd-verified).
  - Block-level cross-node cold migration: a volume written on one node reads back byte-identical after being mapped on another.
- Not exercised (out of scope): warm start / memory snapshot — a minimal sandbox hits an upstream `--pmem` wiring gap in the snapshot path, unrelated to storage — and cross-node control-plane migration.
- Deletion semantics to note: when `rbd rm` is positively blocked, the image is moved to `rbd trash` to free the name, and trash is not auto-purged (left to operator policy).

## Questions

1. Is an in-tree backend like this a good fit, or is a pluggable storage interface planned that it should target instead?
2. The `vol-`/`snap-` image-name prefixes become the pool's persistent layout (changing them later would mean migrating existing images) — flag if a different convention is preferred for cubecow pools.

*Draft — feedback welcome.*
