### PR TITLE
build(builder): speed up and harden builder image builds

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,8 +44,9 @@ Cube Sandbox provides a Docker-based builder image for a consistent build enviro
 # Build the builder image
 make builder-image
 
-# From mainland China, fetch the llvm.sh installer and clang-14 apt packages from
-# a China mirror (the LLVM GPG key still comes from apt.llvm.org)
+# From mainland China, source apt packages from China-reachable mirrors: the
+# Ubuntu apt archive plus the llvm.sh installer and clang-14 packages (the LLVM
+# GPG key still comes from apt.llvm.org)
 make builder-image MIRROR=cn
 
 # Start an interactive shell inside the builder

--- a/CONTRIBUTING_zh.md
+++ b/CONTRIBUTING_zh.md
@@ -44,8 +44,8 @@ Cube Sandbox 提供了基于 Docker 的构建镜像，以确保一致的构建�
 # 构建构建镜像
 make builder-image
 
-# 中国大陆用户可通过镜像源获取 llvm.sh 安装脚本与 clang-14 apt 软件包
-# （LLVM GPG 签名密钥仍从 apt.llvm.org 获取）
+# 中国大陆用户可通过镜像源获取 apt 软件包：包括 Ubuntu apt 仓库，以及 llvm.sh
+# 安装脚本与 clang-14 软件包（LLVM GPG 签名密钥仍从 apt.llvm.org 获取）
 make builder-image MIRROR=cn
 
 # 进入构建容器的交互式 Shell

--- a/CubeEgress/openresty/Dockerfile
+++ b/CubeEgress/openresty/Dockerfile
@@ -1,4 +1,39 @@
-FROM ubuntu:24.04 AS builder
+# Shared base carrying the (optional) apt-mirror rewrite so both the builder and
+# runtime stages inherit the patched sources.list without duplicating the logic.
+FROM ubuntu:24.04 AS base
+
+# Base URL of a China-reachable Ubuntu apt mirror (set via `make build MIRROR=cn`).
+# amd64 packages resolve under ${APT_MIRROR_BASE}/ubuntu, arm64 under
+# ${APT_MIRROR_BASE}/ubuntu-ports; empty leaves the image default (archive.ubuntu.com
+# on amd64, ports.ubuntu.com on arm64).
+ARG APT_MIRROR_BASE=
+# Skip the mirror rewrite when GITHUB_ACTIONS=true so CI always builds against
+# upstream, matching docker/Dockerfile.builder.
+ARG GITHUB_ACTIONS=false
+
+# Must stay http:// -- `apt update` below runs before ca-certificates is installed,
+# so TLS is not yet available and an https mirror would fail to verify.
+RUN set -eux; \
+	if [ "${GITHUB_ACTIONS}" != "true" ] && [ -n "${APT_MIRROR_BASE}" ]; then \
+		case "${APT_MIRROR_BASE}" in \
+			http://*) ;; \
+			*) echo "APT_MIRROR_BASE must be an http:// URL (ca-certificates is not yet installed): ${APT_MIRROR_BASE}" >&2; exit 1;; \
+		esac; \
+		case "${APT_MIRROR_BASE}" in \
+			*[\$\`\"\;\!\&\|\\]*) echo "APT_MIRROR_BASE contains characters unsafe for sed: ${APT_MIRROR_BASE}" >&2; exit 1;; \
+		esac; \
+		target=/etc/apt/sources.list.d/ubuntu.sources; \
+		if [ -f "${target}" ]; then \
+			sed -i "s|http://archive.ubuntu.com/ubuntu|${APT_MIRROR_BASE}/ubuntu|g; \
+				s|http://security.ubuntu.com/ubuntu|${APT_MIRROR_BASE}/ubuntu|g; \
+				s|http://ports.ubuntu.com/ubuntu-ports|${APT_MIRROR_BASE}/ubuntu-ports|g" \
+				"${target}"; \
+		else \
+			echo "WARNING: ${target} not found; apt mirror rewrite skipped" >&2; \
+		fi; \
+	fi
+
+FROM base AS builder
 
 ARG OPENRESTY_VERSION=1.29.2.5
 ARG NGINX_VERSION=1.29.2
@@ -31,7 +66,7 @@ RUN cd /tmp && \
 	make -j && \
 	make install
 
-FROM ubuntu:24.04 AS runtime
+FROM base AS runtime
 
 ENV PATH=/usr/local/openresty/bin:/usr/local/openresty/nginx/sbin:${PATH}
 
@@ -41,7 +76,8 @@ RUN apt update && \
 		libpcre3 \
 		libssl3 \
 		perl-base \
-		zlib1g
+		zlib1g && \
+	rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /usr/local/openresty /usr/local/openresty
 

--- a/CubeEgress/openresty/Makefile
+++ b/CubeEgress/openresty/Makefile
@@ -7,6 +7,18 @@ IMAGE_TAG         := $(OPENRESTY_VERSION)-tproxy
 # Override with: make build ARCH=amd64  or  make build ARCH=arm64
 ARCH ?= $(shell uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')
 
+# Set MIRROR=cn to source apt packages from a China-reachable Ubuntu mirror
+# (amd64 -> $(APT_MIRROR_BASE)/ubuntu, arm64 -> $(APT_MIRROR_BASE)/ubuntu-ports).
+# The mirror is only wired into the build when MIRROR=cn; any other value builds
+# against the image default (archive.ubuntu.com on amd64, ports.ubuntu.com on arm64).
+APT_MIRROR_BASE ?= http://mirrors.tencent.com
+BUILD_ARGS ?=
+ifeq ($(MIRROR),cn)
+BUILD_ARGS += --build-arg 'APT_MIRROR_BASE=$(APT_MIRROR_BASE)'
+else ifneq ($(MIRROR),)
+$(warning MIRROR='$(MIRROR)' is not recognized; expected 'cn' or empty -- building against the image default apt sources)
+endif
+
 IMAGES := \
 	cube-sandbox-cn.tencentcloudcr.com/cube-sandbox/openresty-tproxy \
 	cube-sandbox-int.tencentcloudcr.com/cube-sandbox/openresty-tproxy \
@@ -36,6 +48,7 @@ build:
 		--platform linux/$(ARCH)				\
 		--build-arg OPENRESTY_VERSION=$(OPENRESTY_VERSION)	\
 		--build-arg NGINX_VERSION=$(NGINX_VERSION)		\
+		$(BUILD_ARGS)						\
 		-t $(IMAGE_LOCAL):$(IMAGE_TAG)-$(ARCH)			\
 		.
 

--- a/Makefile
+++ b/Makefile
@@ -72,19 +72,23 @@ ifneq ($(wildcard $(HOME)/.git-credentials),)
 DOCKER_GIT_CRED += -v $(TMP_GIT_CREDENTIALS):$(BUILDER_CONTAINER_HOME)/.git-credentials
 endif
 
-# Builder image build-args. Set MIRROR=cn to fetch the llvm.sh installer script
-# and the clang-14 apt packages from a China-reachable mirror (override the mirror
-# host with LLVM_MIRROR_BASE=...); unset uses upstream apt.llvm.org. The LLVM GPG
-# signing key is always fetched from apt.llvm.org -- llvm.sh hardcodes that URL and
-# the mirror does not serve the key -- but that is a small request that usually
-# succeeds even when bulk package downloads from apt.llvm.org are slow. This
+# Builder image build-args. Set MIRROR=cn to source packages from China-reachable
+# mirrors: the ubuntu apt archive (amd64 -> $(APT_MIRROR_BASE)/ubuntu, arm64 ->
+# $(APT_MIRROR_BASE)/ubuntu-ports) plus the llvm.sh installer script and clang-14
+# apt packages (override the LLVM mirror host with LLVM_MIRROR_BASE=...). Unset
+# builds against upstream archive.ubuntu.com/ports.ubuntu.com and apt.llvm.org. The
+# LLVM GPG signing key is always fetched from apt.llvm.org -- llvm.sh hardcodes that
+# URL and the mirror does not serve the key -- but that is a small request that
+# usually succeeds even when bulk package downloads from apt.llvm.org are slow. This
 # build-time MIRROR is unrelated to the runtime MIRROR=cn used by deploy/one-click.
+APT_MIRROR_BASE ?= http://mirrors.tencent.com
 LLVM_MIRROR_BASE ?= https://mirrors.zju.edu.cn/llvm-apt
 BUILDER_BUILD_ARGS ?=
 ifeq ($(MIRROR),cn)
-BUILDER_BUILD_ARGS += --build-arg LLVM_MIRROR_BASE=$(LLVM_MIRROR_BASE)
+BUILDER_BUILD_ARGS += --build-arg 'APT_MIRROR_BASE=$(APT_MIRROR_BASE)'
+BUILDER_BUILD_ARGS += --build-arg 'LLVM_MIRROR_BASE=$(LLVM_MIRROR_BASE)'
 else ifneq ($(MIRROR),)
-$(warning MIRROR='$(MIRROR)' is not recognized by builder-image; expected 'cn' or empty -- building against upstream apt.llvm.org)
+$(warning MIRROR='$(MIRROR)' is not recognized by builder-image; expected 'cn' or empty -- building against upstream ubuntu and apt.llvm.org sources)
 endif
 
 .PHONY: all
@@ -141,7 +145,7 @@ builder-image:
 	@if [ -z "$(BUILDER_FORCE_REBUILD)" ] && docker image inspect $(BUILDER_IMAGE) >/dev/null 2>&1; then \
 		printf 'Builder image %s already present, skipping build (set BUILDER_FORCE_REBUILD=1 to rebuild)\n' "$(BUILDER_IMAGE)"; \
 	else \
-		docker build $(if $(BUILDER_FORCE_REBUILD),--no-cache) $(BUILDER_BUILD_ARGS) -t $(BUILDER_IMAGE) -f $(BUILDER_DOCKERFILE) ./docker; \
+		docker build $(if $(filter-out 0,$(BUILDER_FORCE_REBUILD)),--no-cache) $(BUILDER_BUILD_ARGS) -t $(BUILDER_IMAGE) -f $(BUILDER_DOCKERFILE) ./docker; \
 	fi
 
 .PHONY: prepare-builder-home

--- a/Makefile
+++ b/Makefile
@@ -134,11 +134,14 @@ help:
 	@printf "  - Run 'make builder-image' first if image %s is missing\n" "$(BUILDER_IMAGE)"
 
 .PHONY: builder-image
+# BUILDER_FORCE_REBUILD rebuilds even when the image is present, and adds
+# --no-cache so a stale image is refreshed from scratch rather than reproduced
+# from the Docker layer cache. A plain first build (image missing) stays cached.
 builder-image:
 	@if [ -z "$(BUILDER_FORCE_REBUILD)" ] && docker image inspect $(BUILDER_IMAGE) >/dev/null 2>&1; then \
 		printf 'Builder image %s already present, skipping build (set BUILDER_FORCE_REBUILD=1 to rebuild)\n' "$(BUILDER_IMAGE)"; \
 	else \
-		docker build $(BUILDER_BUILD_ARGS) -t $(BUILDER_IMAGE) -f $(BUILDER_DOCKERFILE) ./docker; \
+		docker build $(if $(BUILDER_FORCE_REBUILD),--no-cache) $(BUILDER_BUILD_ARGS) -t $(BUILDER_IMAGE) -f $(BUILDER_DOCKERFILE) ./docker; \
 	fi
 
 .PHONY: prepare-builder-home

--- a/docker/Dockerfile.builder
+++ b/docker/Dockerfile.builder
@@ -3,8 +3,12 @@
 FROM ubuntu:20.04
 
 ARG DEBIAN_FRONTEND=noninteractive
-ARG APT_PRIMARY_MIRROR=http://mirrors.tencent.com/ubuntu
-ARG APT_SECURITY_MIRROR=http://mirrors.tencent.com/ubuntu
+# Base URL of a China-reachable Ubuntu apt mirror (set via `make builder-image
+# MIRROR=cn`). When set, amd64 packages resolve under ${APT_MIRROR_BASE}/ubuntu and
+# arm64 under ${APT_MIRROR_BASE}/ubuntu-ports; empty leaves the image default
+# (archive.ubuntu.com on amd64, ports.ubuntu.com on arm64). The rewrite is also
+# skipped when GITHUB_ACTIONS=true so CI always builds against upstream.
+ARG APT_MIRROR_BASE=
 ARG GO_VERSION=1.24.8
 ARG PROTOC_VERSION=28.3
 ARG LIBSECCOMP_VERSION=2.5.5
@@ -53,9 +57,18 @@ RUN set -eux; \
 RUN apt-get update -o Acquire::Retries=3 \
     && apt install -y ca-certificates --no-install-recommends
 
-RUN if [ "${GITHUB_ACTIONS}" != "true" ]; then \
-        sed -i "s|http://archive.ubuntu.com/ubuntu|${APT_PRIMARY_MIRROR}|g; \
-                s|http://security.ubuntu.com/ubuntu|${APT_SECURITY_MIRROR}|g" \
+RUN set -eux; \
+    if [ "${GITHUB_ACTIONS}" != "true" ] && [ -n "${APT_MIRROR_BASE}" ]; then \
+        case "${APT_MIRROR_BASE}" in \
+            http://*|https://*) ;; \
+            *) echo "APT_MIRROR_BASE must be an http(s) URL: ${APT_MIRROR_BASE}" >&2; exit 1;; \
+        esac; \
+        case "${APT_MIRROR_BASE}" in \
+            *[\$\`\"\;\!\&\|\\]*) echo "APT_MIRROR_BASE contains characters unsafe for sed: ${APT_MIRROR_BASE}" >&2; exit 1;; \
+        esac; \
+        sed -i "s|http://archive.ubuntu.com/ubuntu|${APT_MIRROR_BASE}/ubuntu|g; \
+                s|http://security.ubuntu.com/ubuntu|${APT_MIRROR_BASE}/ubuntu|g; \
+                s|http://ports.ubuntu.com/ubuntu-ports|${APT_MIRROR_BASE}/ubuntu-ports|g" \
             /etc/apt/sources.list; \
     fi
 


### PR DESCRIPTION
This PR contains two related improvements to the builder image workflow.

1. Route Ubuntu apt packages through the China mirror (e46989d)

The MIRROR=cn opt-in previously only redirected the llvm.sh installer and clang-14 packages to a China-reachable mirror. The bulk of the Ubuntu apt packages still came from archive.ubuntu.com
/ ports.ubuntu.com, which are slow or unreachable from mainland China — leaving builds bottlenecked on exactly the part MIRROR=cn was meant to speed up.

This change extends MIRROR=cn to also source the Ubuntu apt archive from the mirror, covering:
- Both amd64 and arm64
- The builder image and the CubeEgress openresty images

When MIRROR is unset, builds keep using the upstream defaults, and CI continues to build against upstream. The LLVM GPG key still comes from apt.llvm.org. Docs (CONTRIBUTING.md /
CONTRIBUTING_zh.md) are updated to match.

2. Add --no-cache to BUILDER_FORCE_REBUILD rebuilds (e512211)

When BUILDER_FORCE_REBUILD was set, the builder-image target rebuilt the image but still let Docker reuse cached layers, so a forced rebuild could silently reproduce a stale image instead of
refreshing it.

Now --no-cache is passed only on forced rebuilds, so the image is rebuilt from scratch. A plain first build (image missing) still uses the layer cache for speed.

Test plan

- MIRROR=cn make builder-image builds successfully on amd64 and arm64
- Default (MIRROR unset) build still pulls from upstream mirrors
- BUILDER_FORCE_REBUILD=1 make builder-image rebuilds without reusing cached layers