### PR TITLE
fix(sdk/python): send X-API-Key on all control- and data-plane requests

### DIFF
--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -280,7 +280,7 @@ print(Sandbox.list_v2())    # v2 API (supports filtering)
 | `CUBE_API_URL` | ✅ | `http://127.0.0.1:3000` | CubeAPI management plane address |
 | `CUBE_TEMPLATE_ID` | ✅ | — | Template ID for sandbox creation |
 | `CUBE_PROXY_NODE_IP` | remote | — | CubeProxy node IP, bypasses DNS for `*.cube.app` |
-| `CUBE_API_KEY` | | — | API key for auth-enabled deployments (also reads `E2B_API_KEY`) |
+| `CUBE_API_KEY` | | — | API key for auth-enabled deployments |
 | `CUBE_PROXY_PORT_HTTP` | | `80` | CubeProxy HTTP port |
 | `CUBE_SANDBOX_DOMAIN` | | `cube.app` | Sandbox domain suffix |
 

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -280,6 +280,7 @@ print(Sandbox.list_v2())    # v2 API (supports filtering)
 | `CUBE_API_URL` | ✅ | `http://127.0.0.1:3000` | CubeAPI management plane address |
 | `CUBE_TEMPLATE_ID` | ✅ | — | Template ID for sandbox creation |
 | `CUBE_PROXY_NODE_IP` | remote | — | CubeProxy node IP, bypasses DNS for `*.cube.app` |
+| `CUBE_API_KEY` | | — | API key for auth-enabled deployments (also reads `E2B_API_KEY`) |
 | `CUBE_PROXY_PORT_HTTP` | | `80` | CubeProxy HTTP port |
 | `CUBE_SANDBOX_DOMAIN` | | `cube.app` | Sandbox domain suffix |
 
@@ -290,6 +291,7 @@ from cubesandbox import Config, Sandbox
 
 cfg = Config(
     api_url="http://10.0.0.1:3000",
+    api_key="my-secret-key",
     template_id="tpl-xxxxxxxxxxxxxxxxxxxxxxxx",
     proxy_node_ip="10.0.0.1",
 )

--- a/sdk/python/cubesandbox/_commands.py
+++ b/sdk/python/cubesandbox/_commands.py
@@ -167,7 +167,12 @@ class Commands:
 
 
 def _envd_rpc_base_url_and_headers(sandbox: "Sandbox") -> tuple[str, dict[str, str]]:
-    headers: dict[str, str] = {}
+    from ._config import _auth_headers
+
+    # The e2b-connect path uses its own httpcore pool (not sandbox._client),
+    # so it does not inherit the client's default headers. Attach the API key
+    # here so CubeAPI's auth middleware accepts the request. No-op when unset.
+    headers: dict[str, str] = dict(_auth_headers(sandbox._config))
     access_token = sandbox._data.get("envdAccessToken")
     if access_token:
         headers["X-Access-Token"] = access_token

--- a/sdk/python/cubesandbox/_commands.py
+++ b/sdk/python/cubesandbox/_commands.py
@@ -10,6 +10,8 @@ import struct
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
+from ._config import _auth_headers
+
 if TYPE_CHECKING:
     from .sandbox import Sandbox
 
@@ -167,12 +169,10 @@ class Commands:
 
 
 def _envd_rpc_base_url_and_headers(sandbox: "Sandbox") -> tuple[str, dict[str, str]]:
-    from ._config import _auth_headers
-
     # The e2b-connect path uses its own httpcore pool (not sandbox._client),
     # so it does not inherit the client's default headers. Attach the API key
     # here so CubeAPI's auth middleware accepts the request. No-op when unset.
-    headers: dict[str, str] = dict(_auth_headers(sandbox._config))
+    headers: dict[str, str] = _auth_headers(sandbox._config)
     access_token = sandbox._data.get("envdAccessToken")
     if access_token:
         headers["X-Access-Token"] = access_token

--- a/sdk/python/cubesandbox/_config.py
+++ b/sdk/python/cubesandbox/_config.py
@@ -17,8 +17,8 @@ class Config:
         default_factory=lambda: os.environ.get("CUBE_API_URL", "http://127.0.0.1:3000")
     )
     api_key: str | None = field(
-        default_factory=lambda: os.environ.get("CUBE_API_KEY")
-        or os.environ.get("E2B_API_KEY")
+        default_factory=lambda: os.environ.get("CUBE_API_KEY"),
+        repr=False,
     )
     template_id: str | None = field(
         default_factory=lambda: os.environ.get("CUBE_TEMPLATE_ID")
@@ -81,7 +81,7 @@ def _auth_headers(cfg: "Config") -> dict[str, str]:
     CubeAPI only enforces auth when it is started with an auth-callback URL;
     in the default deployment no callback is set and every request passes
     through unauthenticated. So the key is optional here: when
-    ``CUBE_API_KEY`` / ``E2B_API_KEY`` / ``Config.api_key`` is unset we send no
+    ``CUBE_API_KEY`` / ``Config.api_key`` is unset we send no
     auth header and behavior is unchanged; when set we attach
     ``X-API-Key: <key>`` so the SDK also works against an auth-enabled backend.
 

--- a/sdk/python/cubesandbox/_config.py
+++ b/sdk/python/cubesandbox/_config.py
@@ -18,6 +18,7 @@ class Config:
     )
     api_key: str | None = field(
         default_factory=lambda: os.environ.get("CUBE_API_KEY")
+        or os.environ.get("E2B_API_KEY")
     )
     template_id: str | None = field(
         default_factory=lambda: os.environ.get("CUBE_TEMPLATE_ID")
@@ -72,3 +73,22 @@ class Config:
             f"sandbox_domain={self.sandbox_domain!r}, timeout={self.timeout!r}, "
             f"request_timeout={self.request_timeout!r})"
         )
+
+
+def _auth_headers(cfg: "Config") -> dict[str, str]:
+    """Return the ``X-API-Key`` header when an API key is configured.
+
+    CubeAPI only enforces auth when it is started with an auth-callback URL;
+    in the default deployment no callback is set and every request passes
+    through unauthenticated. So the key is optional here: when
+    ``CUBE_API_KEY`` / ``E2B_API_KEY`` / ``Config.api_key`` is unset we send no
+    auth header and behavior is unchanged; when set we attach
+    ``X-API-Key: <key>`` so the SDK also works against an auth-enabled backend.
+
+    This is the single source of truth shared by the control plane
+    (``sandbox``/``template`` REST calls to CubeAPI) and the data plane
+    (envd requests routed through CubeProxy).
+    """
+    if cfg.api_key:
+        return {"X-API-Key": cfg.api_key}
+    return {}

--- a/sdk/python/cubesandbox/_template.py
+++ b/sdk/python/cubesandbox/_template.py
@@ -8,7 +8,7 @@ from typing import Any, Dict
 
 import requests
 
-from ._config import Config
+from ._config import Config, _auth_headers
 from ._exceptions import ApiError, AuthenticationError, TemplateNotFoundError
 from ._policy import _validate_allow_out_domains_require_deny_all
 
@@ -160,7 +160,7 @@ class Template:
         """
         cfg = config or Config()
         s = requests.Session()
-        resp = s.get(f"{cfg.api_url}/templates")
+        resp = s.get(f"{cfg.api_url}/templates", headers=_auth_headers(cfg))
         _check_response(resp)
         data = resp.json() or []
         if isinstance(data, dict):
@@ -200,7 +200,8 @@ class Template:
         if next_token is not None:
             params["nextToken"] = next_token
         s = requests.Session()
-        resp = s.get(f"{cfg.api_url}/templates/{template_id}", params=params)
+        resp = s.get(f"{cfg.api_url}/templates/{template_id}", params=params,
+                     headers=_auth_headers(cfg))
         _check_response(resp)
         return TemplateInfo.from_dict(resp.json())
 
@@ -341,7 +342,7 @@ class Template:
         resp = s.post(
             f"{cfg.api_url}/templates",
             json=payload,
-            headers={"Content-Type": "application/json"},
+            headers={"Content-Type": "application/json", **_auth_headers(cfg)},
         )
         _check_response(resp)
         return TemplateBuild.from_dict(resp.json())
@@ -361,7 +362,7 @@ class Template:
         resp = s.post(
             f"{cfg.api_url}/templates/{template_id}",
             json=extra,
-            headers={"Content-Type": "application/json"},
+            headers={"Content-Type": "application/json", **_auth_headers(cfg)},
         )
         _check_response(resp)
         return TemplateBuild.from_dict(resp.json())
@@ -378,7 +379,8 @@ class Template:
         """GET /templates/:templateID/builds/:buildID/status."""
         cfg = config or Config()
         s = requests.Session()
-        resp = s.get(f"{cfg.api_url}/templates/{template_id}/builds/{build_id}/status")
+        resp = s.get(f"{cfg.api_url}/templates/{template_id}/builds/{build_id}/status",
+                     headers=_auth_headers(cfg))
         _check_response(resp)
         return TemplateBuild.from_dict(resp.json())
 
@@ -394,7 +396,8 @@ class Template:
         """GET /templates/:templateID/builds/:buildID/logs."""
         cfg = config or Config()
         s = requests.Session()
-        resp = s.get(f"{cfg.api_url}/templates/{template_id}/builds/{build_id}/logs")
+        resp = s.get(f"{cfg.api_url}/templates/{template_id}/builds/{build_id}/logs",
+                     headers=_auth_headers(cfg))
         _check_response(resp)
         return resp.json()
 
@@ -443,5 +446,5 @@ class Template:
         """
         cfg = config or Config()
         s = requests.Session()
-        resp = s.delete(f"{cfg.api_url}/templates/{template_id}")
+        resp = s.delete(f"{cfg.api_url}/templates/{template_id}", headers=_auth_headers(cfg))
         _check_response(resp)

--- a/sdk/python/cubesandbox/sandbox.py
+++ b/sdk/python/cubesandbox/sandbox.py
@@ -9,7 +9,7 @@ import httpx
 import requests
 
 from ._commands import CommandResult, Commands
-from ._config import Config
+from ._config import Config, _auth_headers
 from ._exceptions import ApiError, AuthenticationError, CubeSandboxError, SandboxNotFoundError, TemplateNotFoundError
 from ._filesystem import Filesystem
 from ._models import Execution, ExecutionError, OutputMessage, Result, SnapshotInfo
@@ -265,7 +265,7 @@ class Sandbox:
 
         s = requests.Session()
         resp = s.post(f"{cfg.api_url}/sandboxes", json=payload,
-                      headers={"Content-Type": "application/json"})
+                      headers={"Content-Type": "application/json", **_auth_headers(cfg)})
         _check_response(resp)
         return cls(resp.json(), config=cfg)
 
@@ -291,7 +291,7 @@ class Sandbox:
         # Connect omits timeout; see docs/guide/lifecycle.md.
         resp = s.post(f"{cfg.api_url}/sandboxes/{sandbox_id}/connect",
                       json={},
-                      headers={"Content-Type": "application/json"})
+                      headers={"Content-Type": "application/json", **_auth_headers(cfg)})
         _check_response(resp)
         return cls(resp.json(), config=cfg)
 
@@ -309,7 +309,7 @@ class Sandbox:
         """
         cfg = config or Config()
         s = requests.Session()
-        resp = s.get(f"{cfg.api_url}/sandboxes")
+        resp = s.get(f"{cfg.api_url}/sandboxes", headers=_auth_headers(cfg))
         _check_response(resp)
         return resp.json()
 
@@ -327,7 +327,7 @@ class Sandbox:
         """
         cfg = config or Config()
         s = requests.Session()
-        resp = s.get(f"{cfg.api_url}/v2/sandboxes")
+        resp = s.get(f"{cfg.api_url}/v2/sandboxes", headers=_auth_headers(cfg))
         _check_response(resp)
         return resp.json()
 
@@ -344,7 +344,7 @@ class Sandbox:
         """
         cfg = config or Config()
         s = requests.Session()
-        resp = s.get(f"{cfg.api_url}/health")
+        resp = s.get(f"{cfg.api_url}/health", headers=_auth_headers(cfg))
         _check_response(resp)
         return resp.json()
 
@@ -600,7 +600,7 @@ class Sandbox:
         if next_token is not None:
             params["nextToken"] = next_token
         s = requests.Session()
-        resp = s.get(f"{cfg.api_url}/snapshots", params=params)
+        resp = s.get(f"{cfg.api_url}/snapshots", params=params, headers=_auth_headers(cfg))
         _check_response(resp)
         items = [SnapshotInfo.from_dict(d) for d in (resp.json() or [])]
         nt = resp.headers.get("x-next-token") or None
@@ -624,7 +624,7 @@ class Sandbox:
         """
         cfg = config or Config()
         s = requests.Session()
-        resp = s.delete(f"{cfg.api_url}/templates/{snapshot_id}")
+        resp = s.delete(f"{cfg.api_url}/templates/{snapshot_id}", headers=_auth_headers(cfg))
         _check_response(resp)
 
     # 1.4 — create_from_snapshot is covered by Sandbox.create(template=snapshot_id).
@@ -795,7 +795,7 @@ class Sandbox:
 
     def _build_session(self) -> requests.Session:
         s = requests.Session()
-        s.headers.update({"Content-Type": "application/json"})
+        s.headers.update({"Content-Type": "application/json", **_auth_headers(self._config)})
         return s
 
     def _build_data_client(self) -> httpx.Client:
@@ -809,6 +809,16 @@ class Sandbox:
         CubeProxy rejects unauthenticated traffic with 403. Attaching the token
         as a default header on the httpx client covers run_code, the Connect
         fallback path, and filesystem read/write in one place.
+
+        Data-plane requests are also routed through CubeAPI's auth middleware,
+        which requires ``X-API-Key`` (or ``Authorization: Bearer``) whenever the
+        backend is started with an auth-callback URL. We therefore attach the
+        API key here as well so run_code / commands / filesystem / pty all
+        authenticate. When no key is configured ``_auth_headers`` returns ``{}``
+        and behavior is unchanged.
         """
+        headers = dict(_auth_headers(self._config))
         token = self.traffic_access_token
-        return {"e2b-traffic-access-token": token} if token else {}
+        if token:
+            headers["e2b-traffic-access-token"] = token
+        return headers

--- a/sdk/python/cubesandbox/sandbox.py
+++ b/sdk/python/cubesandbox/sandbox.py
@@ -817,7 +817,7 @@ class Sandbox:
         authenticate. When no key is configured ``_auth_headers`` returns ``{}``
         and behavior is unchanged.
         """
-        headers = dict(_auth_headers(self._config))
+        headers = _auth_headers(self._config)
         token = self.traffic_access_token
         if token:
             headers["e2b-traffic-access-token"] = token


### PR DESCRIPTION
When CubeAPI is started with an auth-callback URL, every request must carry
X-API-Key. Before this fix the Python SDK never sent an API key, so both
control-plane and data-plane calls were rejected with 401.

- Add Config.api_key reading CUBE_API_KEY (fallback E2B_API_KEY)
- Add _auth_headers(cfg) as single source of truth
- Attach X-API-Key to all Sandbox.* and Template.* control-plane calls
- Attach X-API-Key to data-plane requests (commands/run_code/files/pty)
- Document CUBE_API_KEY in README

Backward compatible: no key set → no header sent, behavior unchanged.
