### PR TITLE
fix(cubeproxy): set ngx.status before responding with JSON errors

### DIFF
--- a/CubeProxy/lua/utils.lua
+++ b/CubeProxy/lua/utils.lua
@@ -54,6 +54,7 @@ end
         - body:   response body string (JSON)
 --]]
 function _M.respond_with(self, status, body)
+    ngx.status = status
     ngx.header["Content-Type"] = "application/json"
     ngx.say(body)
     ngx.exit(status)


### PR DESCRIPTION
## Summary

Fix CubeProxy dataplane error responses returning HTTP 200 instead of the intended 4xx/5xx.

`respond_with` called `ngx.say(body)` before `ngx.status` was set. In OpenResty, that flushes the response with the default status **200**, so a later `ngx.exit(400/404/503)` cannot correct the status line already sent to the client.

This matches the existing admin path in `admin_phase.lua`, which correctly sets `ngx.status` before writing the body.

## Impact

When Redis/backend lookup failed, clients often saw:

- HTTP **200**
- body `{"error":"service unavailable"}` (or `bad request` / `not found`)

Connect/JSON stream clients then mis-parsed the bare JSON as a Connect frame (e.g. bogus "message too large"), which hid the real dataplane error.

OpenResty also logs:

`attempt to set status 503 via ngx.exit after sending out the response status 200`

## Change

In `CubeProxy/lua/utils.lua` `respond_with`:

1. Set `ngx.status = status`
2. Then set `Content-Type` and `ngx.say(body)`
3. Then `ngx.exit(status)`

## Test plan

- [ ] Reproduce before fix: force a dataplane error path (e.g. unreachable Redis / missing sandbox proxy metadata); confirm response status is **200** with `{"error":"..."}` and OpenResty error.log contains `after sending out the response status 200`
- [ ] After fix: same failure path returns the intended status (**400** / **404** / **503**) with the same JSON body
- [ ] Confirm happy-path sandbox traffic (e.g. envd `process.Process/Start`) is unchanged when Redis metadata resolves successfully
