### PR TITLE
fix(cubemaster): make PostgreSQL runtime paths work after dao migration

### DIFF
--- a/CubeMaster/pkg/base/db/db.go
+++ b/CubeMaster/pkg/base/db/db.go
@@ -6,94 +6,17 @@
 package db
 
 import (
-	"context"
-	"database/sql"
-	"fmt"
-	"time"
-
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/config"
-	"github.com/tencentcloud/CubeSandbox/cubelog"
-	"gorm.io/driver/mysql"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/dao"
 	"gorm.io/gorm"
-	"gorm.io/gorm/logger"
 )
 
-func generateURL(user, password, addr, dbname string, connTimeout, readTimeout, writeTimeout int) string {
-	return fmt.Sprintf(
-		"%s:%s@tcp(%s)/%s?charset=utf8&parseTime=true&loc=Local&timeout=%ds&readTimeout=%ds&writeTimeout=%ds",
-		user, password, addr, dbname, connTimeout, readTimeout, writeTimeout)
-}
-
-// Init opens a *gorm.DB against the given DBConfig.
-//
-// Deprecated: prefer pkg/base/dao.Open / dao.Default. This shim is kept
-// so the v0.2.2 call-sites in templatecenter / nodemeta / instancecache /
-// localcache keep compiling while they are migrated module-by-module.
-//
-// Unlike dao.Open, Init does NOT run schema migrations; the cmd/cubemaster
-// main loop is responsible for invoking dao.Migrate exactly once at
-// startup before any Init() in business packages.
+// Init returns the global dao handle. Retained for backwards compatibility
+// with v0.2.2-era callers (nodemeta / localcache / instancecache /
+// templatecenter) that still pass a DBConfig. cfg is accepted but ignored —
+// the connection is already established by dao.Open before any business
+// package Init runs.
 func Init(cfg *config.DBConfig) *gorm.DB {
-	db, err := initDB(cfg.User, cfg.Pwd, cfg.Addr, cfg.DBName,
-		cfg.ConnTimeout, cfg.ReadTimeout, cfg.WriteTimeout,
-		cfg.MaxIdleConns, cfg.MaxOpenConns, cfg.MaxConnLifeTimeSeconds)
-	if err != nil {
-		panic(err)
-	}
-	return db
-}
-
-func initDB(user, pwd, addr, dbname string, connTimeout, readTimeout, writeTimeout, maxIdleConns, maxOpenConns,
-	maxLifeTimeSeconds int) (*gorm.DB, error) {
-	url := generateURL(user, pwd, addr, dbname, connTimeout, readTimeout, writeTimeout)
-	sqlDB, err := sql.Open("mysql", url)
-	if err != nil {
-		return nil, err
-	}
-
-	sqlDB.SetMaxIdleConns(maxIdleConns)
-	sqlDB.SetMaxOpenConns(maxOpenConns)
-	sqlDB.SetConnMaxLifetime(time.Duration(maxLifeTimeSeconds) * time.Second)
-	client, err := gorm.Open(mysql.New(mysql.Config{
-		Conn: sqlDB,
-	}), &gorm.Config{
-		Logger: &Logger{},
-	})
-
-	if err != nil {
-		return nil, err
-	}
-
-	return client, nil
-}
-
-type Logger struct {
-}
-
-func (ml *Logger) LogMode(logger.LogLevel) logger.Interface {
-	return ml
-}
-
-func (ml *Logger) Info(ctx context.Context, f string, v ...interface{}) {
-	if ctx == nil {
-		ctx = context.Background()
-	}
-	CubeLog.WithContext(ctx).Infof(f, v...)
-}
-
-func (ml *Logger) Warn(ctx context.Context, f string, v ...interface{}) {
-	if ctx == nil {
-		ctx = context.Background()
-	}
-	CubeLog.WithContext(ctx).Warnf(f, v...)
-}
-
-func (ml *Logger) Error(ctx context.Context, f string, v ...interface{}) {
-	if ctx == nil {
-		ctx = context.Background()
-	}
-	CubeLog.WithContext(ctx).Errorf(f, v...)
-}
-
-func (ml *Logger) Trace(ctx context.Context, begin time.Time, fc func() (string, int64), err error) {
+	_ = cfg
+	return dao.Default()
 }

--- a/CubeMaster/pkg/base/db/db_test.go
+++ b/CubeMaster/pkg/base/db/db_test.go
@@ -1,0 +1,40 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package db_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/config"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/dao"
+	_ "github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/dao/driver/postgres"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/db"
+)
+
+func TestInitReturnsDaoDefaultOnPostgreSQL(t *testing.T) {
+	env := newPostgresTestEnv(t)
+	defer env.teardown()
+
+	cfg := dao.Config{
+		Driver: "postgres",
+		Addr:   env.addr,
+		User:   "cube",
+		Pwd:    "cube_pass",
+		DBName: "cube_test",
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	defer cancel()
+	if _, err := dao.Open(ctx, cfg); err != nil {
+		t.Fatalf("dao.Open: %v", err)
+	}
+	defer func() { _ = dao.Close() }()
+
+	got := db.Init(&config.DBConfig{Driver: "postgres"})
+	if got != dao.Default() {
+		t.Fatal("db.Init must return the global dao handle opened by dao.Open")
+	}
+}

--- a/CubeMaster/pkg/base/db/postgres_testutil_test.go
+++ b/CubeMaster/pkg/base/db/postgres_testutil_test.go
@@ -1,0 +1,142 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package db_test
+
+import (
+	"database/sql"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	_ "github.com/jackc/pgx/v5/stdlib"
+	"github.com/ory/dockertest/v3"
+	"github.com/ory/dockertest/v3/docker"
+)
+
+const (
+	postgresDSNEnv        = "CUBEMASTER_DAO_TEST_POSTGRES_DSN"
+	requireDockerTestsEnv = "CUBEMASTER_REQUIRE_DOCKER_TESTS"
+	postgresImage         = "postgres"
+	postgresImageTag      = "16-alpine"
+	containerProbeTimeout = 90 * time.Second
+)
+
+type postgresTestEnv struct {
+	addr     string
+	teardown func()
+}
+
+func requireDockerTests() bool {
+	v := os.Getenv(requireDockerTestsEnv)
+	if v == "1" || strings.EqualFold(v, "true") {
+		return true
+	}
+	ci := os.Getenv("CI")
+	return ci == "true" || ci == "1"
+}
+
+func abortOrSkipDocker(t *testing.T, format string, args ...any) {
+	t.Helper()
+	msg := fmt.Sprintf(format, args...)
+	if requireDockerTests() {
+		t.Fatal(msg)
+	}
+	t.Skip(msg)
+}
+
+func newPostgresTestEnv(t *testing.T) *postgresTestEnv {
+	t.Helper()
+	if dsn := os.Getenv(postgresDSNEnv); dsn != "" {
+		t.Logf("using external PostgreSQL from %s", postgresDSNEnv)
+		db := openPostgresDB(t, dsn)
+		defer db.Close()
+		host, port, err := splitHostPortFromDSN(dsn)
+		if err != nil {
+			t.Fatalf("parse %s: %v", postgresDSNEnv, err)
+		}
+		return &postgresTestEnv{
+			addr:     host + ":" + port,
+			teardown: func() {},
+		}
+	}
+
+	pool, err := dockertest.NewPool("")
+	if err != nil {
+		abortOrSkipDocker(t, "dockertest not available (%v); set %s", err, postgresDSNEnv)
+	}
+	if err := pool.Client.Ping(); err != nil {
+		abortOrSkipDocker(t, "docker daemon not reachable (%v); set %s", err, postgresDSNEnv)
+	}
+	resource, err := pool.RunWithOptions(&dockertest.RunOptions{
+		Repository: postgresImage,
+		Tag:        postgresImageTag,
+		Env: []string{
+			"POSTGRES_USER=cube",
+			"POSTGRES_PASSWORD=cube_pass",
+			"POSTGRES_DB=cube_test",
+		},
+	}, func(hostConfig *docker.HostConfig) {
+		hostConfig.AutoRemove = true
+		hostConfig.RestartPolicy = docker.RestartPolicy{Name: "no"}
+	})
+	if err != nil {
+		abortOrSkipDocker(t, "could not start postgres container (%v); set %s", err, postgresDSNEnv)
+	}
+	port := resource.GetPort("5432/tcp")
+	dsn := fmt.Sprintf(
+		"host=127.0.0.1 port=%s user=cube password=cube_pass dbname=cube_test sslmode=disable",
+		port,
+	)
+
+	pool.MaxWait = containerProbeTimeout
+	if err := pool.Retry(func() error {
+		db, err := sql.Open("pgx", dsn)
+		if err != nil {
+			return err
+		}
+		defer db.Close()
+		return db.Ping()
+	}); err != nil {
+		_ = pool.Purge(resource)
+		t.Fatalf("postgres container never became reachable: %v", err)
+	}
+
+	return &postgresTestEnv{
+		addr: "127.0.0.1:" + port,
+		teardown: func() {
+			_ = pool.Purge(resource)
+		},
+	}
+}
+
+func openPostgresDB(t *testing.T, dsn string) *sql.DB {
+	t.Helper()
+	db, err := sql.Open("pgx", dsn)
+	if err != nil {
+		t.Fatalf("sql.Open(pgx): %v", err)
+	}
+	if err := db.Ping(); err != nil {
+		_ = db.Close()
+		t.Fatalf("ping postgres: %v", err)
+	}
+	return db
+}
+
+func splitHostPortFromDSN(dsn string) (host, port string, err error) {
+	for _, part := range strings.Fields(dsn) {
+		if strings.HasPrefix(part, "host=") {
+			host = strings.TrimPrefix(part, "host=")
+		}
+		if strings.HasPrefix(part, "port=") {
+			port = strings.TrimPrefix(part, "port=")
+		}
+	}
+	if host == "" || port == "" {
+		return "", "", fmt.Errorf("missing host/port in dsn %q", dsn)
+	}
+	return host, port, nil
+}

--- a/CubeMaster/pkg/templatecenter/artifact_gc.go
+++ b/CubeMaster/pkg/templatecenter/artifact_gc.go
@@ -6,7 +6,7 @@ package templatecenter
 
 import (
 	"context"
-	"database/sql"
+	"errors"
 	"runtime/debug"
 	"sync"
 	"time"
@@ -14,6 +14,7 @@ import (
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/constants"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/db/models"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/log"
+	"gorm.io/gorm"
 )
 
 const (
@@ -26,17 +27,57 @@ const (
 var (
 	artifactGCOnce         sync.Once
 	cleanupArtifactFullyGC = cleanupArtifactFully
+	// errArtifactGCLockNotAcquired is returned from the candidate-selection
+	// transaction when another instance already holds the session lock.
+	errArtifactGCLockNotAcquired = errors.New("artifact gc lock not acquired")
 )
+
+// trySessionLock attempts to acquire a cross-instance session lock with 0
+// timeout (immediate return). MySQL: GET_LOCK(name, 0); PG: pg_try_advisory_lock(hashtext(name)).
+// Caller must pass a *gorm.DB that is pinned to one connection (e.g. inside
+// Transaction) so acquire and release share the same session.
+func trySessionLock(tx *gorm.DB, name string) bool {
+	driver := tx.Dialector.Name()
+	switch driver {
+	case "postgres":
+		var ok bool
+		err := tx.Raw("SELECT pg_try_advisory_lock(hashtext(?))", name).Scan(&ok).Error
+		return err == nil && ok
+	default: // mysql
+		var res int64
+		err := tx.Raw("SELECT GET_LOCK(?, 0)", name).Scan(&res).Error
+		return err == nil && res == 1
+	}
+}
+
+// releaseSessionLock releases a cross-instance session lock on the same
+// connection that acquired it.
+func releaseSessionLock(tx *gorm.DB, name string) {
+	driver := tx.Dialector.Name()
+	var err error
+	switch driver {
+	case "postgres":
+		err = tx.Exec("SELECT pg_advisory_unlock(hashtext(?))", name).Error
+	default:
+		err = tx.Exec("SELECT RELEASE_LOCK(?)", name).Error
+	}
+	if err != nil {
+		ctx := context.Background()
+		if tx.Statement != nil && tx.Statement.Context != nil {
+			ctx = tx.Statement.Context
+		}
+		log.G(ctx).Warnf("artifact gc: release lock %q failed: %v", name, err)
+	}
+}
 
 // startArtifactGC launches the orphan/expired rootfs-artifact garbage
 // collector. It is registered alongside the snapshot reconciler (not folded
 // into it) and converges the cases online deletion cannot finish in one pass:
 // interrupted builds, artifacts whose nodes were busy (CLEANUP_PENDING), and
-// TTL-expired artifacts. A component-scoped MySQL GET_LOCK keeps candidate
+// TTL-expired artifacts. A component-scoped advisory lock keeps candidate
 // selection single-instance across the HA cluster without covering slow
 // cross-node cleanup RPCs; the lock name is intentionally distinct from
-// schema-migration locks (`cubemaster_schema_migration_global` and
-// `cubemaster_migration_*`).
+// schema-migration locks.
 func startArtifactGC(ctx context.Context) {
 	artifactGCOnce.Do(func() {
 		go func() {
@@ -115,32 +156,30 @@ func cleanupArtifactGCCandidate(ctx context.Context, artifact models.RootfsArtif
 
 func listArtifactGCCandidatesLocked(ctx context.Context) ([]models.RootfsArtifact, bool) {
 	logger := log.G(ctx).WithFields(map[string]any{"component": "artifact_gc"})
-	// Single-instance execution across the cluster: GET_LOCK with a 0s timeout
-	// returns immediately; another instance holding it means we skip this pass.
-	// The lock protects only candidate selection. cleanupArtifactFully performs
-	// its own row-level serialisation and idempotent physical deletes, so slow
-	// RPCs must not keep this HA-wide lock held.
-	var lockRes sql.NullInt64
-	if err := store.db.WithContext(ctx).
-		Raw("SELECT GET_LOCK(?, ?)", artifactGCLockName, 0).Scan(&lockRes).Error; err != nil {
-		logger.Warnf("artifact gc: acquire lock failed: %v", err)
+
+	// Pin one connection for acquire + query + release: MySQL GET_LOCK and
+	// PostgreSQL pg_try_advisory_lock are session-scoped, so unlocking on a
+	// different pooled connection would silently no-op and leak the lock.
+	var candidates []models.RootfsArtifact
+	err := store.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		if !trySessionLock(tx, artifactGCLockName) {
+			return errArtifactGCLockNotAcquired
+		}
+		defer releaseSessionLock(tx, artifactGCLockName)
+
+		now := time.Now().Unix()
+		if err := tx.Table(constants.RootfsArtifactTableName).
+			Where("status IN ? OR (gc_deadline > 0 AND gc_deadline < ?)",
+				[]string{ArtifactStatusFailed, ArtifactStatusOrphaned, ArtifactStatusCleanupPending}, now).
+			Limit(artifactGCMaxPerPass).Find(&candidates).Error; err != nil {
+			return err
+		}
+		return nil
+	})
+	if errors.Is(err, errArtifactGCLockNotAcquired) {
 		return nil, false
 	}
-	if !lockRes.Valid || lockRes.Int64 != 1 {
-		return nil, false // another instance is selecting candidates
-	}
-	defer func() {
-		if err := store.db.WithContext(ctx).Exec("SELECT RELEASE_LOCK(?)", artifactGCLockName).Error; err != nil {
-			logger.Warnf("artifact gc: release lock failed: %v", err)
-		}
-	}()
-
-	now := time.Now().Unix()
-	var candidates []models.RootfsArtifact
-	if err := store.db.WithContext(ctx).Table(constants.RootfsArtifactTableName).
-		Where("status IN ? OR (gc_deadline > 0 AND gc_deadline < ?)",
-			[]string{ArtifactStatusFailed, ArtifactStatusOrphaned, ArtifactStatusCleanupPending}, now).
-		Limit(artifactGCMaxPerPass).Find(&candidates).Error; err != nil {
+	if err != nil {
 		logger.Warnf("artifact gc: list candidates failed: %v", err)
 		return nil, false
 	}

--- a/CubeMaster/pkg/templatecenter/artifact_gc_test.go
+++ b/CubeMaster/pkg/templatecenter/artifact_gc_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/db/models"
+	"gorm.io/gorm"
 )
 
 func TestProcessArtifactGCCandidatesRecoversPanicAndContinues(t *testing.T) {
@@ -44,5 +45,25 @@ func TestProcessArtifactGCCandidatesRecoversPanicAndContinues(t *testing.T) {
 		if seen[i] != want[i] {
 			t.Fatalf("unexpected processed artifacts: got %v want %v", seen, want)
 		}
+	}
+}
+
+func TestTrySessionLockPostgreSQL(t *testing.T) {
+	env := newPGDockerEnv(t)
+	defer env.teardown()
+
+	gormDB := openMigratedPostgresGORM(t, env)
+	ctx := context.Background()
+
+	// Pin one connection via Transaction so acquire and release share a session.
+	err := gormDB.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		if !trySessionLock(tx, "cubemaster_test_lock") {
+			t.Fatal("expected pg_try_advisory_lock to succeed on fresh database")
+		}
+		releaseSessionLock(tx, "cubemaster_test_lock")
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("transaction: %v", err)
 	}
 }

--- a/CubeMaster/pkg/templatecenter/postgres_testutil_test.go
+++ b/CubeMaster/pkg/templatecenter/postgres_testutil_test.go
@@ -1,0 +1,162 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package templatecenter
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	_ "github.com/jackc/pgx/v5/stdlib"
+	"github.com/ory/dockertest/v3"
+	"github.com/ory/dockertest/v3/docker"
+	"github.com/pressly/goose/v3/lock"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/dao/migrate"
+	"gorm.io/driver/postgres"
+	"gorm.io/gorm"
+)
+
+const (
+	pgTestDSNEnv          = "CUBEMASTER_DAO_TEST_POSTGRES_DSN"
+	pgRequireDockerEnv    = "CUBEMASTER_REQUIRE_DOCKER_TESTS"
+	pgDockerImage         = "postgres"
+	pgDockerImageTag      = "16-alpine"
+	pgContainerProbeLimit = 90 * time.Second
+)
+
+type pgDockerEnv struct {
+	dsn      string
+	teardown func()
+}
+
+func requirePGDockerTests() bool {
+	v := os.Getenv(pgRequireDockerEnv)
+	if v == "1" || strings.EqualFold(v, "true") {
+		return true
+	}
+	ci := os.Getenv("CI")
+	return ci == "true" || ci == "1"
+}
+
+func skipOrFailPGDocker(t *testing.T, format string, args ...any) {
+	t.Helper()
+	msg := fmt.Sprintf(format, args...)
+	if requirePGDockerTests() {
+		t.Fatal(msg)
+	}
+	t.Skip(msg)
+}
+
+func newPGDockerEnv(t *testing.T) *pgDockerEnv {
+	t.Helper()
+	if dsn := os.Getenv(pgTestDSNEnv); dsn != "" {
+		t.Logf("using external PostgreSQL from %s", pgTestDSNEnv)
+		return &pgDockerEnv{dsn: dsn, teardown: func() {}}
+	}
+	pool, err := dockertest.NewPool("")
+	if err != nil {
+		skipOrFailPGDocker(t, "dockertest not available (%v); set %s", err, pgTestDSNEnv)
+	}
+	if err := pool.Client.Ping(); err != nil {
+		skipOrFailPGDocker(t, "docker daemon not reachable (%v); set %s", err, pgTestDSNEnv)
+	}
+	resource, err := pool.RunWithOptions(&dockertest.RunOptions{
+		Repository: pgDockerImage,
+		Tag:        pgDockerImageTag,
+		Env: []string{
+			"POSTGRES_USER=cube",
+			"POSTGRES_PASSWORD=cube_pass",
+			"POSTGRES_DB=cube_test",
+		},
+	}, func(hostConfig *docker.HostConfig) {
+		hostConfig.AutoRemove = true
+		hostConfig.RestartPolicy = docker.RestartPolicy{Name: "no"}
+	})
+	if err != nil {
+		skipOrFailPGDocker(t, "could not start postgres container (%v); set %s", err, pgTestDSNEnv)
+	}
+	port := resource.GetPort("5432/tcp")
+	dsn := fmt.Sprintf(
+		"host=127.0.0.1 port=%s user=cube password=cube_pass dbname=cube_test sslmode=disable",
+		port,
+	)
+	pool.MaxWait = pgContainerProbeLimit
+	if err := pool.Retry(func() error {
+		db, err := sql.Open("pgx", dsn)
+		if err != nil {
+			return err
+		}
+		defer db.Close()
+		return db.Ping()
+	}); err != nil {
+		_ = pool.Purge(resource)
+		t.Fatalf("postgres container never became reachable: %v", err)
+	}
+	return &pgDockerEnv{
+		dsn: dsn,
+		teardown: func() {
+			_ = pool.Purge(resource)
+		},
+	}
+}
+
+type pgTestLocker struct {
+	id      int64
+	timeout int
+}
+
+func (l *pgTestLocker) SessionLock(ctx context.Context, conn *sql.Conn) error {
+	deadline := time.Now().Add(time.Duration(l.timeout) * time.Second)
+	for {
+		var acquired bool
+		if err := conn.QueryRowContext(ctx, "SELECT pg_try_advisory_lock($1)", l.id).Scan(&acquired); err != nil {
+			return err
+		}
+		if acquired {
+			return nil
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("pg advisory lock timeout")
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+}
+
+func (l *pgTestLocker) SessionUnlock(ctx context.Context, conn *sql.Conn) error {
+	_, err := conn.ExecContext(ctx, "SELECT pg_advisory_unlock($1)", l.id)
+	return err
+}
+
+func openMigratedPostgresGORM(t *testing.T, env *pgDockerEnv) *gorm.DB {
+	t.Helper()
+	sqlDB, err := sql.Open("pgx", env.dsn)
+	if err != nil {
+		t.Fatalf("sql.Open: %v", err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+	if err := migrate.Run(ctx, sqlDB, "postgres", &pgTestLocker{id: 424242, timeout: 30}); err != nil {
+		_ = sqlDB.Close()
+		t.Fatalf("migrate.Run: %v", err)
+	}
+	gormDB, err := gorm.Open(postgres.New(postgres.Config{Conn: sqlDB}), &gorm.Config{})
+	if err != nil {
+		_ = sqlDB.Close()
+		t.Fatalf("gorm.Open: %v", err)
+	}
+	t.Cleanup(func() {
+		raw, cerr := gormDB.DB()
+		if cerr == nil {
+			_ = raw.Close()
+		}
+	})
+	return gormDB
+}
+
+var _ lock.SessionLocker = (*pgTestLocker)(nil)

--- a/CubeMaster/pkg/templatecenter/store.go
+++ b/CubeMaster/pkg/templatecenter/store.go
@@ -1126,9 +1126,11 @@ func UpsertReplica(ctx context.Context, templateID, instanceType string, replica
 		return ErrTemplateStoreNotInitialized
 	}
 	record := &models.TemplateReplica{}
-	dbq := store.db.WithContext(ctx).Table(constants.TemplateReplicaTableName).
-		Where("template_id = ? AND node_id = ?", templateID, replica.NodeID)
-	err := dbq.First(record).Error
+	// Do not reuse the *gorm.DB chain after First on PostgreSQL: GORM may emit
+	// UPDATE ... FROM t_cube_template_replica (SQLSTATE 42712).
+	err := store.db.WithContext(ctx).Table(constants.TemplateReplicaTableName).
+		Where("template_id = ? AND node_id = ?", templateID, replica.NodeID).
+		First(record).Error
 	if err != nil {
 		if !errors.Is(err, gorm.ErrRecordNotFound) {
 			return err
@@ -1136,7 +1138,9 @@ func UpsertReplica(ctx context.Context, templateID, instanceType string, replica
 		return store.db.WithContext(ctx).Table(constants.TemplateReplicaTableName).
 			Create(replicaStatusToModel(templateID, instanceType, replica)).Error
 	}
-	return dbq.Updates(replicaStatusUpdateFields(instanceType, replica)).Error
+	return store.db.WithContext(ctx).Table(constants.TemplateReplicaTableName).
+		Where("template_id = ? AND node_id = ?", templateID, replica.NodeID).
+		Updates(replicaStatusUpdateFields(instanceType, replica)).Error
 }
 
 func EnsureReadyReplica(ctx context.Context, templateID string) error {

--- a/CubeMaster/pkg/templatecenter/store_postgres_test.go
+++ b/CubeMaster/pkg/templatecenter/store_postgres_test.go
@@ -1,0 +1,35 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package templatecenter
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestUpsertReplicaPostgreSQLUpdatePath(t *testing.T) {
+	env := newPGDockerEnv(t)
+	defer env.teardown()
+
+	oldDB := store.db
+	store.db = openMigratedPostgresGORM(t, env)
+	defer func() { store.db = oldDB }()
+
+	ctx := context.Background()
+	templateID := "tpl-pg-upsert"
+	replica := ReplicaStatus{
+		NodeID: "node-a",
+		NodeIP: "10.0.0.1",
+		Status: "BUILDING",
+		Phase:  "pulling",
+	}
+	require.NoError(t, UpsertReplica(ctx, templateID, "cubebox", replica))
+
+	replica.Status = "READY"
+	replica.Phase = "ready"
+	require.NoError(t, UpsertReplica(ctx, templateID, "cubebox", replica))
+}


### PR DESCRIPTION
## Summary

PR #674 introduced the PostgreSQL driver and schema migrations, but three runtime paths still assumed MySQL and broke real PostgreSQL deployments:

1. **`db.Init` opened a separate MySQL pool** — `cmd/cubemaster` calls `dao.Open(postgres)` first, yet legacy callers (`templatecenter`, `nodemeta`, `instancecache`, `localcache`) still invoke `db.Init`, which ignored the global dao handle and tried to connect via MySQL DSN. This fix returns `dao.Default()` so all packages share the connection opened at startup.

2. **Artifact GC lock was MySQL-only** — `listArtifactGCCandidatesLocked` used `GET_LOCK` / `RELEASE_LOCK`, which fail on PostgreSQL. Added driver-aware `trySessionLock` / `releaseSessionLock` (`pg_try_advisory_lock(hashtext(name))` on PG, existing MySQL behavior preserved).

3. **`UpsertReplica` update path failed on PostgreSQL** — reusing the same `*gorm.DB` chain after `First` caused GORM to emit `UPDATE ... FROM t_cube_template_replica`, which PostgreSQL rejects with `SQLSTATE 42712`. The update now runs on a fresh chain with an explicit `Where` clause.

## Test plan

- [x] `go test ./pkg/base/db/ -run TestInitReturnsDaoDefault -count=1 -v` — passed (Docker PostgreSQL 16 via dockertest)
- [x] `go test ./pkg/templatecenter/ -run PostgreSQL -count=1 -v` — passed
  - `TestTrySessionLockPostgreSQL` — advisory lock acquire/release
  - `TestUpsertReplicaPostgreSQLUpdatePath` — insert then update without SQLSTATE 42712
- [x] Docker (`cube-compiler:ubuntu22` on ubuntu22, `/var/run/docker.sock` mounted): same commands above — all passed
