### PR TITLE
cubemaster: resolve sandbox request for template commit

### DIFF
--- a/CubeMaster/cmd/cubemastercli/commands/cubebox/template.go
+++ b/CubeMaster/cmd/cubemastercli/commands/cubebox/template.go
@@ -83,7 +83,6 @@ type templateImageJobResponse struct {
 type templateCommitRequest struct {
 	RequestID     string                      `json:"requestID,omitempty"`
 	SandboxID     string                      `json:"sandbox_id,omitempty"`
-	TemplateID    string                      `json:"template_id,omitempty"`
 	CreateRequest *types.CreateCubeSandboxReq `json:"create_request,omitempty"`
 }
 
@@ -662,7 +661,7 @@ var TemplateCommitCommand = cli.Command{
 		},
 		cli.StringFlag{
 			Name:  "file, f",
-			Usage: "original create_sandbox request json file",
+			Usage: "optional complete create_sandbox request json override",
 		},
 		cli.BoolFlag{
 			Name:  "allow-internet-access",
@@ -696,32 +695,8 @@ var TemplateCommitCommand = cli.Command{
 		if filePath == "" && c.NArg() > 0 {
 			filePath = c.Args().First()
 		}
-		if sandboxID == "" || filePath == "" {
-			return errors.New("sandbox-id and file are required")
-		}
-
-		reqBytes, err := getParams(filePath)
-		if err != nil {
-			return err
-		}
-		createReq := &types.CreateCubeSandboxReq{}
-		if err = jsoniter.Unmarshal(reqBytes, createReq); err != nil {
-			return err
-		}
-		if createReq.Request == nil {
-			createReq.Request = &types.Request{}
-		}
-		requestID := uuid.New().String()
-		createReq.RequestID = requestID
-		if createReq.Annotations == nil {
-			createReq.Annotations = map[string]string{}
-		}
-		createReq.CubeNetworkConfig = mergeCubeNetworkConfigFlags(c, createReq.CubeNetworkConfig)
-
-		req := &templateCommitRequest{
-			RequestID:     requestID,
-			SandboxID:     sandboxID,
-			CreateRequest: createReq,
+		if sandboxID == "" {
+			return errors.New("sandbox-id is required")
 		}
 
 		serverList = getServerAddrs(c)
@@ -729,6 +704,31 @@ var TemplateCommitCommand = cli.Command{
 			return errors.New("no server addr")
 		}
 		port = c.GlobalString("port")
+
+		hasNetworkOverrides := c.IsSet("allow-internet-access") || len(c.StringSlice("allow-out-cidr")) > 0 || len(c.StringSlice("deny-out-cidr")) > 0
+		if filePath == "" && hasNetworkOverrides {
+			return errors.New("network override flags require --file")
+		}
+
+		var createReq *types.CreateCubeSandboxReq
+		if filePath != "" {
+			reqBytes, err := getParams(filePath)
+			if err != nil {
+				return err
+			}
+			createReq = &types.CreateCubeSandboxReq{}
+			if err = jsoniter.Unmarshal(reqBytes, createReq); err != nil {
+				return err
+			}
+			createReq.CubeNetworkConfig = mergeCubeNetworkConfigFlags(c, createReq.CubeNetworkConfig)
+		}
+
+		requestID := uuid.New().String()
+		req := &templateCommitRequest{
+			RequestID:     requestID,
+			SandboxID:     sandboxID,
+			CreateRequest: createReq,
+		}
 		host := serverList[rand.Int()%len(serverList)]
 		url := fmt.Sprintf("http://%s/cube/sandbox/commit", net.JoinHostPort(host, port))
 		body, err := jsoniter.Marshal(req)

--- a/CubeMaster/cmd/cubemastercli/commands/cubebox/template_test.go
+++ b/CubeMaster/cmd/cubemastercli/commands/cubebox/template_test.go
@@ -6,8 +6,12 @@ package cubebox
 
 import (
 	"bytes"
+	"encoding/json"
 	"flag"
+	"io"
 	"log"
+	"net/http"
+	"os"
 	"strings"
 	"testing"
 
@@ -61,6 +65,182 @@ func newRedoContext(t *testing.T, args []string) *cli.Context {
 	ctx := cli.NewContext(nil, set, nil)
 	ctx.Command = TemplateRedoCommand
 	return ctx
+}
+
+func newCommitContext(t *testing.T, args []string) *cli.Context {
+	t.Helper()
+
+	set := flag.NewFlagSet("commit", flag.ContinueOnError)
+	set.String("address", "", "cubemaster address")
+	set.String("port", "", "cubemaster port")
+	set.Duration("timeout", 0, "request timeout")
+	for _, cliFlag := range TemplateCommitCommand.Flags {
+		cliFlag.Apply(set)
+	}
+	if err := set.Parse(args); err != nil {
+		t.Fatalf("parse args %v: %v", args, err)
+	}
+
+	ctx := cli.NewContext(nil, set, nil)
+	ctx.Command = TemplateCommitCommand
+	return ctx
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (fn roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return fn(req)
+}
+
+func TestCommitCommandLetsCubeMasterResolveRequest(t *testing.T) {
+	var requests []string
+	var commitBody map[string]interface{}
+	origHTTPClient := http.DefaultClient
+	http.DefaultClient = &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		requests = append(requests, req.URL.Path)
+		if req.URL.Path != "/cube/sandbox/commit" {
+			return &http.Response{
+				StatusCode: http.StatusNotFound,
+				Body:       io.NopCloser(strings.NewReader("unexpected endpoint")),
+				Header:     make(http.Header),
+				Request:    req,
+			}, nil
+		}
+		if err := json.NewDecoder(req.Body).Decode(&commitBody); err != nil {
+			t.Fatalf("decode commit body: %v", err)
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(`{"ret":{"ret_code":200,"ret_msg":"success"},"template_id":"tpl-new"}`)),
+			Header:     make(http.Header),
+			Request:    req,
+		}, nil
+	})}
+	defer func() {
+		http.DefaultClient = origHTTPClient
+	}()
+
+	ctx := newCommitContext(t, []string{
+		"--address", "127.0.0.1",
+		"--port", "8089",
+		"--sandbox-id", "sb-auto",
+		"--detach",
+	})
+	action, ok := TemplateCommitCommand.Action.(func(*cli.Context) error)
+	if !ok {
+		t.Fatalf("unexpected commit action type %T", TemplateCommitCommand.Action)
+	}
+	if err := action(ctx); err != nil {
+		t.Fatalf("commit action returned error: %v", err)
+	}
+	if got, want := strings.Join(requests, ","), "/cube/sandbox/commit"; got != want {
+		t.Fatalf("request paths=%q, want %q", got, want)
+	}
+	if _, ok := commitBody["create_request"]; ok {
+		t.Fatalf("create_request should be omitted: %v", commitBody["create_request"])
+	}
+}
+
+func TestCommitCommandRequiresFileForNetworkOverrides(t *testing.T) {
+	ctx := newCommitContext(t, []string{
+		"--address", "127.0.0.1",
+		"--port", "8089",
+		"--sandbox-id", "sb-auto",
+		"--allow-internet-access=false",
+		"--detach",
+	})
+	action := TemplateCommitCommand.Action.(func(*cli.Context) error)
+	err := action(ctx)
+	if err == nil || !strings.Contains(err.Error(), "network override flags require --file") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestCommitCommandUsesFileAsCompleteRequestWithNetworkOverrides(t *testing.T) {
+	path := t.TempDir() + "/request.json"
+	if err := os.WriteFile(path, []byte(`{
+		"instance_type":"cubebox",
+		"network_type":"tap",
+		"cube_network_config":{"allowInternetAccess":true,"allowOut":["10.0.0.0/8"]}
+	}`), 0600); err != nil {
+		t.Fatalf("write request file: %v", err)
+	}
+	var requests []string
+	var commitBody struct {
+		CreateRequest struct {
+			InstanceType      string `json:"instance_type"`
+			NetworkType       string `json:"network_type"`
+			CubeNetworkConfig struct {
+				AllowInternetAccess *bool    `json:"allowInternetAccess"`
+				AllowOut            []string `json:"allowOut"`
+				DenyOut             []string `json:"denyOut"`
+			} `json:"cube_network_config"`
+		} `json:"create_request"`
+	}
+	origHTTPClient := http.DefaultClient
+	http.DefaultClient = &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		requests = append(requests, req.URL.Path)
+		if req.URL.Path != "/cube/sandbox/commit" {
+			return &http.Response{
+				StatusCode: http.StatusNotFound,
+				Body:       io.NopCloser(strings.NewReader("unexpected endpoint")),
+				Header:     make(http.Header),
+				Request:    req,
+			}, nil
+		}
+		if err := json.NewDecoder(req.Body).Decode(&commitBody); err != nil {
+			t.Fatalf("decode commit body: %v", err)
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(`{"ret":{"ret_code":200,"ret_msg":"success"},"template_id":"tpl-new"}`)),
+			Header:     make(http.Header),
+			Request:    req,
+		}, nil
+	})}
+	defer func() {
+		http.DefaultClient = origHTTPClient
+	}()
+
+	ctx := newCommitContext(t, []string{
+		"--address", "127.0.0.1",
+		"--port", "8089",
+		"--sandbox-id", "sb-file",
+		"--file", path,
+		"--allow-internet-access=false",
+		"--allow-out-cidr", "172.67.0.0/16",
+		"--deny-out-cidr", "192.168.0.0/16",
+		"--detach",
+	})
+	action, ok := TemplateCommitCommand.Action.(func(*cli.Context) error)
+	if !ok {
+		t.Fatalf("unexpected commit action type %T", TemplateCommitCommand.Action)
+	}
+	if err := action(ctx); err != nil {
+		t.Fatalf("commit action returned error: %v", err)
+	}
+	if got, want := strings.Join(requests, ","), "/cube/sandbox/commit"; got != want {
+		t.Fatalf("request paths=%q, want %q", got, want)
+	}
+	createRequest := commitBody.CreateRequest
+	if got := createRequest.InstanceType; got != "cubebox" {
+		t.Fatalf("instance_type=%v", got)
+	}
+	if got := createRequest.NetworkType; got != "tap" {
+		t.Fatalf("network_type=%v", got)
+	}
+	if createRequest.CubeNetworkConfig.AllowInternetAccess == nil {
+		t.Fatalf("cube_network_config=%+v", createRequest.CubeNetworkConfig)
+	}
+	if got := *createRequest.CubeNetworkConfig.AllowInternetAccess; got {
+		t.Fatalf("allowInternetAccess=%v, want false", got)
+	}
+	if got, want := strings.Join(createRequest.CubeNetworkConfig.AllowOut, ","), "10.0.0.0/8,172.67.0.0/16"; got != want {
+		t.Fatalf("allowOut=%q, want %q", got, want)
+	}
+	if got, want := strings.Join(createRequest.CubeNetworkConfig.DenyOut, ","), "192.168.0.0/16"; got != want {
+		t.Fatalf("denyOut=%q, want %q", got, want)
+	}
 }
 
 func TestCreateCommandParsesNodeScope(t *testing.T) {

--- a/CubeMaster/pkg/service/httpservice/cube/template_commit.go
+++ b/CubeMaster/pkg/service/httpservice/cube/template_commit.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 
 	"github.com/gin-gonic/gin"
-	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/constants"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/log"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/errorcode"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/localcache"
@@ -53,11 +52,11 @@ func handleSandboxCommitAction(c *gin.Context) {
 		})
 		return
 	}
-	if strings.TrimSpace(req.SandboxID) == "" || req.CreateRequest == nil {
+	if strings.TrimSpace(req.SandboxID) == "" {
 		common.WriteAPI(c, &commitTemplateResponse{
 			Res: &types.Res{Ret: &types.Ret{
 				RetCode: int(errorcode.ErrorCode_MasterParamsError),
-				RetMsg:  "sandbox_id and create_request are required",
+				RetMsg:  "sandbox_id is required",
 			}},
 		})
 		return
@@ -82,17 +81,6 @@ func handleSandboxCommitAction(c *gin.Context) {
 		})
 		return
 	}
-	if req.CreateRequest.Request == nil {
-		req.CreateRequest.Request = &types.Request{RequestID: req.RequestID}
-	}
-	if req.CreateRequest.RequestID == "" {
-		req.CreateRequest.RequestID = req.RequestID
-	}
-	if req.CreateRequest.Annotations == nil {
-		req.CreateRequest.Annotations = map[string]string{}
-	}
-	req.CreateRequest.Annotations[constants.CubeAnnotationAppSnapshotTemplateID] = req.TemplateID
-
 	hostIP := ""
 	if cache := localcache.GetSandboxCache(req.SandboxID); cache != nil {
 		hostIP = cache.HostIP
@@ -140,14 +128,15 @@ func handleSandboxCommitAction(c *gin.Context) {
 		"SandboxID":   req.SandboxID,
 		"SandboxHost": hostIP,
 	}))
-	job, err := templatecenter.SubmitTemplateCommit(ctx, req.SandboxID, hostID, hostIP, req.CreateRequest)
+	job, err := templatecenter.SubmitTemplateCommit(ctx, req.RequestID, req.SandboxID, hostID, hostIP, req.TemplateID, req.CreateRequest)
 	if err != nil {
 		code := commitTemplateErrorCode(err)
+		log.G(ctx).Errorf("submit template commit failed: %v", err)
 		rt.RetCode = int64(code)
 		common.WriteAPI(c, &commitTemplateResponse{
 			Res: &types.Res{
 				RequestID: req.RequestID,
-				Ret:       &types.Ret{RetCode: code, RetMsg: err.Error()},
+				Ret:       &types.Ret{RetCode: code, RetMsg: commitTemplateErrorMessage(err)},
 			},
 			TemplateID: req.TemplateID,
 		})
@@ -171,10 +160,29 @@ func commitTemplateErrorCode(err error) int {
 		errors.Is(err, templatecenter.ErrDuplicateTemplate),
 		errors.Is(err, templatecenter.ErrTemplateAttemptInProgress):
 		return int(errorcode.ErrorCode_MasterParamsError)
+	case errors.Is(err, templatecenter.ErrTemplateNotFound):
+		return int(errorcode.ErrorCode_NotFound)
 	case errors.Is(err, templatecenter.ErrTemplateStoreNotInitialized):
 		return int(errorcode.ErrorCode_DBError)
 	default:
 		return int(errorcode.ErrorCode_MasterInternalError)
+	}
+}
+
+func commitTemplateErrorMessage(err error) string {
+	switch {
+	case errors.Is(err, templatecenter.ErrTemplateIDRequired):
+		return templatecenter.ErrTemplateIDRequired.Error()
+	case errors.Is(err, templatecenter.ErrDuplicateTemplate):
+		return templatecenter.ErrDuplicateTemplate.Error()
+	case errors.Is(err, templatecenter.ErrTemplateAttemptInProgress):
+		return templatecenter.ErrTemplateAttemptInProgress.Error()
+	case errors.Is(err, templatecenter.ErrTemplateNotFound):
+		return templatecenter.ErrTemplateNotFound.Error()
+	case errors.Is(err, templatecenter.ErrTemplateStoreNotInitialized):
+		return "template service is unavailable"
+	default:
+		return "failed to submit template commit"
 	}
 }
 

--- a/CubeMaster/pkg/service/httpservice/cube/template_commit_test.go
+++ b/CubeMaster/pkg/service/httpservice/cube/template_commit_test.go
@@ -16,11 +16,11 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/constants"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/node"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/errorcode"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/localcache"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/service/httpservice/common"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/service/sandbox"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/service/sandbox/types"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/templatecenter"
 	CubeLog "github.com/tencentcloud/CubeSandbox/cubelog"
@@ -30,6 +30,11 @@ import (
 // test gin.Context carrying rt, returning the decoded JSON response.
 func invokeCommitHandler(t *testing.T, req *http.Request, rt *CubeLog.RequestTrace) commitTemplateResponse {
 	t.Helper()
+	patches := gomonkey.NewPatches()
+	patches.ApplyFunc(sandbox.ResolveSandboxID, func(_ context.Context, sandboxID string) (string, error) {
+		return sandboxID, nil
+	})
+	defer patches.Reset()
 	ctx := CubeLog.WithRequestTrace(context.Background(), rt)
 	w := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(w)
@@ -72,7 +77,61 @@ func TestHandleSandboxCommitActionRejectsMissingFields(t *testing.T) {
 	got := invokeCommitHandler(t, req, rt)
 
 	assert.Equal(t, int(errorcode.ErrorCode_MasterParamsError), got.Res.Ret.RetCode)
-	assert.Contains(t, got.Res.Ret.RetMsg, "sandbox_id and create_request are required")
+	assert.Contains(t, got.Res.Ret.RetMsg, "sandbox_id is required")
+}
+
+func TestHandleSandboxCommitActionAllowsMissingCreateRequest(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	patches.ApplyFunc(localcache.GetSandboxCache, func(sandboxID string) *localcache.SandboxCache {
+		return &localcache.SandboxCache{SandboxID: sandboxID, HostIP: "10.0.0.1"}
+	})
+	patches.ApplyFunc(localcache.GetNodesByIp, func(ip string) (*node.Node, bool) {
+		return &node.Node{InsID: "node-1", IP: ip}, true
+	})
+	var gotRequestID, gotSandboxID, gotTemplateID string
+	var gotOverride *types.CreateCubeSandboxReq
+	patches.ApplyFunc(templatecenter.SubmitTemplateCommit, func(ctx context.Context, requestID, sandboxID, nodeID, nodeIP, templateID string, override *types.CreateCubeSandboxReq) (*types.TemplateImageJobInfo, error) {
+		gotRequestID = requestID
+		gotSandboxID = sandboxID
+		gotTemplateID = templateID
+		gotOverride = override
+		return &types.TemplateImageJobInfo{JobID: "job-1", TemplateID: templateID}, nil
+	})
+
+	body := `{"requestID":"req-1","sandbox_id":"sb-1"}`
+	req := httptest.NewRequest("POST", "/cube/sandbox/commit", strings.NewReader(body))
+	rt := &CubeLog.RequestTrace{}
+	got := invokeCommitHandler(t, req, rt)
+	assert.Equal(t, int(errorcode.ErrorCode_Success), got.Res.Ret.RetCode)
+	assert.Equal(t, "req-1", gotRequestID)
+	assert.Equal(t, "sb-1", gotSandboxID)
+	assert.Equal(t, got.TemplateID, gotTemplateID)
+	assert.Nil(t, gotOverride)
+}
+
+func TestHandleSandboxCommitActionSanitizesInternalErrors(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	patches.ApplyFunc(localcache.GetSandboxCache, func(sandboxID string) *localcache.SandboxCache {
+		return &localcache.SandboxCache{SandboxID: sandboxID, HostIP: "10.0.0.1"}
+	})
+	patches.ApplyFunc(localcache.GetNodesByIp, func(ip string) (*node.Node, bool) {
+		return &node.Node{InsID: "node-1", IP: ip}, true
+	})
+	patches.ApplyFunc(templatecenter.SubmitTemplateCommit, func(context.Context, string, string, string, string, string, *types.CreateCubeSandboxReq) (*types.TemplateImageJobInfo, error) {
+		return nil, fmt.Errorf("load sandbox spec: dial tcp 10.0.0.2:3306: connection refused")
+	})
+
+	body := `{"requestID":"req-1","sandbox_id":"sb-1"}`
+	req := httptest.NewRequest("POST", "/cube/sandbox/commit", strings.NewReader(body))
+	rt := &CubeLog.RequestTrace{}
+	got := invokeCommitHandler(t, req, rt)
+	assert.Equal(t, int(errorcode.ErrorCode_MasterInternalError), got.Res.Ret.RetCode)
+	assert.Equal(t, "failed to submit template commit", got.Res.Ret.RetMsg)
+	assert.NotContains(t, got.Res.Ret.RetMsg, "10.0.0.2:3306")
 }
 
 func TestHandleSandboxCommitActionIgnoresProvidedTemplateID(t *testing.T) {
@@ -86,8 +145,8 @@ func TestHandleSandboxCommitActionIgnoresProvidedTemplateID(t *testing.T) {
 	patches.ApplyFunc(localcache.GetNodesByIp, func(ip string) (*node.Node, bool) {
 		return &node.Node{InsID: "node-1", IP: ip}, true
 	})
-	patches.ApplyFunc(templatecenter.SubmitTemplateCommit, func(ctx context.Context, sandboxID, nodeID, nodeIP string, req *types.CreateCubeSandboxReq) (*types.TemplateImageJobInfo, error) {
-		submittedTemplateID = req.Annotations[constants.CubeAnnotationAppSnapshotTemplateID]
+	patches.ApplyFunc(templatecenter.SubmitTemplateCommit, func(ctx context.Context, requestID, sandboxID, nodeID, nodeIP, templateID string, req *types.CreateCubeSandboxReq) (*types.TemplateImageJobInfo, error) {
+		submittedTemplateID = templateID
 		return &types.TemplateImageJobInfo{
 			JobID:      "job-1",
 			TemplateID: submittedTemplateID,
@@ -145,6 +204,11 @@ func TestCommitTemplateErrorCode(t *testing.T) {
 			want: int(errorcode.ErrorCode_DBError),
 		},
 		{
+			name: "missing origin template is not found",
+			err:  fmt.Errorf("legacy fallback failed: %w", templatecenter.ErrTemplateNotFound),
+			want: int(errorcode.ErrorCode_NotFound),
+		},
+		{
 			name: "unknown error is internal error",
 			err:  fmt.Errorf("unexpected"),
 			want: int(errorcode.ErrorCode_MasterInternalError),
@@ -153,6 +217,42 @@ func TestCommitTemplateErrorCode(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			assert.Equal(t, tc.want, commitTemplateErrorCode(tc.err))
+		})
+	}
+}
+
+func TestCommitTemplateErrorMessage(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{
+			name: "attempt details are sanitized",
+			err:  fmt.Errorf("%w: template tpl-secret is building as job-secret", templatecenter.ErrTemplateAttemptInProgress),
+			want: templatecenter.ErrTemplateAttemptInProgress.Error(),
+		},
+		{
+			name: "legacy template details are sanitized",
+			err:  fmt.Errorf("base template tpl-secret lookup failed: %w", templatecenter.ErrTemplateNotFound),
+			want: templatecenter.ErrTemplateNotFound.Error(),
+		},
+		{
+			name: "store state is sanitized",
+			err:  templatecenter.ErrTemplateStoreNotInitialized,
+			want: "template service is unavailable",
+		},
+		{
+			name: "database details are sanitized",
+			err:  fmt.Errorf("dial tcp 10.0.0.2:3306: connection refused"),
+			want: "failed to submit template commit",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, commitTemplateErrorMessage(tc.err))
+			assert.NotContains(t, commitTemplateErrorMessage(tc.err), "secret")
+			assert.NotContains(t, commitTemplateErrorMessage(tc.err), "10.0.0.2:3306")
 		})
 	}
 }

--- a/CubeMaster/pkg/templatecenter/template_commit.go
+++ b/CubeMaster/pkg/templatecenter/template_commit.go
@@ -40,14 +40,18 @@ const cleanupTemplateRPCTimeout = 1 * time.Minute
 // the JobPhase* set in template_image.go; they are referenced here without
 // re-declaration to avoid duplicate constants.
 
-func SubmitTemplateCommit(ctx context.Context, sandboxID, nodeID, nodeIP string, req *sandboxtypes.CreateCubeSandboxReq) (*sandboxtypes.TemplateImageJobInfo, error) {
+func SubmitTemplateCommit(ctx context.Context, requestID, sandboxID, nodeID, nodeIP, templateID string, override *sandboxtypes.CreateCubeSandboxReq) (*sandboxtypes.TemplateImageJobInfo, error) {
 	if !isReady() {
 		return nil, ErrTemplateStoreNotInitialized
 	}
-	if req == nil || req.Request == nil || strings.TrimSpace(req.RequestID) == "" {
+	requestID = strings.TrimSpace(requestID)
+	if requestID == "" {
 		return nil, errors.New("requestID is required for commit; retry should generate a new request id")
 	}
-	requestID := strings.TrimSpace(req.RequestID)
+	req, err := prepareTemplateCommitRequest(ctx, requestID, sandboxID, templateID, override)
+	if err != nil {
+		return nil, err
+	}
 	createReq, templateID, err := NormalizeRequest(req)
 	if err != nil {
 		return nil, err
@@ -162,6 +166,31 @@ func SubmitTemplateCommit(ctx context.Context, sandboxID, nodeID, nodeIP string,
 	}), jobID, sandboxID, nodeID, nodeIP, createReq, storedReq)
 
 	return GetTemplateImageJobInfo(ctx, jobID)
+}
+
+func prepareTemplateCommitRequest(ctx context.Context, requestID, sandboxID, templateID string, override *sandboxtypes.CreateCubeSandboxReq) (*sandboxtypes.CreateCubeSandboxReq, error) {
+	var source *sandboxtypes.CreateCubeSandboxReq
+	var err error
+	if override == nil {
+		source, err = loadSandboxCreateRequestFn(ctx, sandboxID)
+	} else {
+		source, err = cloneCreateRequest(override)
+	}
+	if err != nil {
+		return nil, err
+	}
+	if source == nil {
+		return nil, errors.New("sandbox create request is empty")
+	}
+	if source.Request == nil {
+		source.Request = &sandboxtypes.Request{}
+	}
+	source.RequestID = requestID
+	if source.Annotations == nil {
+		source.Annotations = map[string]string{}
+	}
+	source.Annotations[constants.CubeAnnotationAppSnapshotTemplateID] = strings.TrimSpace(templateID)
+	return source, nil
 }
 
 func runTemplateCommitJob(ctx context.Context, jobID, sandboxID, nodeID, nodeIP string, createReq, storedReq *sandboxtypes.CreateCubeSandboxReq) {

--- a/CubeMaster/pkg/templatecenter/template_commit_test.go
+++ b/CubeMaster/pkg/templatecenter/template_commit_test.go
@@ -7,6 +7,7 @@ package templatecenter
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -156,23 +157,71 @@ func TestSubmitTemplateCommitRejectsEmptyRequestID(t *testing.T) {
 	store.db = &gorm.DB{}
 	defer func() { store.db = origDB }()
 
-	tests := []struct {
-		name string
-		req  *types.CreateCubeSandboxReq
-	}{
-		{"nil request", nil},
-		{"missing Request envelope", &types.CreateCubeSandboxReq{}},
-		{
-			name: "empty request id",
-			req: &types.CreateCubeSandboxReq{
-				Request: &types.Request{RequestID: "   "},
-			},
-		},
+	_, err := SubmitTemplateCommit(context.Background(), "   ", "sb-1", "node-a", "10.0.0.1", "tpl-out", nil)
+	if err == nil || !strings.Contains(err.Error(), "requestID is required") {
+		t.Fatalf("expected requestID guard error, got %v", err)
 	}
-	for _, tc := range tests {
-		_, err := SubmitTemplateCommit(context.Background(), "sb-1", "node-a", "10.0.0.1", tc.req)
-		if err == nil || !strings.Contains(err.Error(), "requestID is required") {
-			t.Fatalf("%s: expected requestID guard error, got %v", tc.name, err)
+}
+
+func TestPrepareTemplateCommitRequestLoadsSandboxSpec(t *testing.T) {
+	origLoad := loadSandboxCreateRequestFn
+	defer func() { loadSandboxCreateRequestFn = origLoad }()
+
+	loadSandboxCreateRequestFn = func(ctx context.Context, sandboxID string) (*types.CreateCubeSandboxReq, error) {
+		if sandboxID != "sb-1" {
+			t.Fatalf("sandboxID=%q", sandboxID)
 		}
+		return &types.CreateCubeSandboxReq{
+			Request: &types.Request{RequestID: "old-request"},
+			Annotations: map[string]string{
+				constants.CubeAnnotationAppSnapshotTemplateID: "tpl-old",
+			},
+			InstanceType: "cubebox",
+		}, nil
+	}
+
+	got, err := prepareTemplateCommitRequest(context.Background(), "req-new", "sb-1", "tpl-new", nil)
+	if err != nil {
+		t.Fatalf("prepareTemplateCommitRequest: %v", err)
+	}
+	if got.RequestID != "req-new" {
+		t.Fatalf("requestID=%q", got.RequestID)
+	}
+	if got.Annotations[constants.CubeAnnotationAppSnapshotTemplateID] != "tpl-new" {
+		t.Fatalf("template annotation=%q", got.Annotations[constants.CubeAnnotationAppSnapshotTemplateID])
+	}
+}
+
+func TestPrepareTemplateCommitRequestUsesExplicitOverride(t *testing.T) {
+	origLoad := loadSandboxCreateRequestFn
+	defer func() { loadSandboxCreateRequestFn = origLoad }()
+	loadSandboxCreateRequestFn = func(context.Context, string) (*types.CreateCubeSandboxReq, error) {
+		t.Fatal("sandbox request resolver should not be called for an explicit override")
+		return nil, nil
+	}
+
+	override := &types.CreateCubeSandboxReq{InstanceType: "custom"}
+	got, err := prepareTemplateCommitRequest(context.Background(), "req-1", "sb-1", "tpl-new", override)
+	if err != nil {
+		t.Fatalf("prepareTemplateCommitRequest: %v", err)
+	}
+	if got.InstanceType != "custom" || got.RequestID != "req-1" {
+		t.Fatalf("unexpected request: %#v", got)
+	}
+	if got == override {
+		t.Fatal("explicit override should be cloned before normalization")
+	}
+}
+
+func TestPrepareTemplateCommitRequestPropagatesResolverError(t *testing.T) {
+	origLoad := loadSandboxCreateRequestFn
+	defer func() { loadSandboxCreateRequestFn = origLoad }()
+	loadSandboxCreateRequestFn = func(context.Context, string) (*types.CreateCubeSandboxReq, error) {
+		return nil, fmt.Errorf("base template lookup failed: %w", ErrTemplateNotFound)
+	}
+
+	_, err := prepareTemplateCommitRequest(context.Background(), "req-1", "sb-legacy", "tpl-new", nil)
+	if !errors.Is(err, ErrTemplateNotFound) {
+		t.Fatalf("expected ErrTemplateNotFound, got %v", err)
 	}
 }

--- a/docs/guide/templates.md
+++ b/docs/guide/templates.md
@@ -16,6 +16,40 @@ A Template is the base image and configuration snapshot used to create Cube-Sand
 3. **Deploy (Registration & Publishing)**
    Register the packaged Rootfs and Snapshot files into the system to become an available Template. Subsequently, this Template can be used to achieve **Hot Start** for sandboxes in the tens-of-milliseconds range.
 
+## Committing a Running Sandbox
+
+`tpl commit` creates a new template from the current filesystem and memory state of a running sandbox. `--sandbox-id` identifies the source sandbox and is required.
+
+By default, the CLI sends only the sandbox ID. CubeMaster restores the sandbox's canonical create-time request from its stored sandbox spec. For legacy sandboxes without a stored spec, CubeMaster falls back to the create request of the sandbox's origin template.
+
+The CLI displays build progress and waits until template creation succeeds or fails.
+
+`--file <path>` supplies a complete `CreateCubeSandboxReq` override. The file replaces the automatically resolved request and is not merged with it.
+
+When `--file` is used, the existing network flags can adjust `cube_network_config` in that request:
+
+| Option | Effect |
+|--------|--------|
+| `--allow-internet-access=false` | Set the request's internet access value explicitly. |
+| `--allow-out-cidr <cidr>` | Append an allowed egress CIDR; repeat for multiple CIDRs. |
+| `--deny-out-cidr <cidr>` | Append a denied egress CIDR; repeat for multiple CIDRs. |
+
+Network override flags require `--file`.
+
+```bash
+# Let CubeMaster restore the sandbox's create-time request.
+cubemastercli tpl commit \
+  --sandbox-id <sandbox-id>
+
+# Supply a complete request override.
+cubemastercli tpl commit \
+  --sandbox-id <sandbox-id> \
+  --file template-request.json \
+  --allow-internet-access=false
+```
+
+CubeMaster generates the resulting `tpl-...` ID and creates its initial replica on the source sandbox's node.
+
 ## Next Steps
 
 - [Creating Templates from OCI Images](./tutorials/template-from-image.md) — step-by-step CLI guide with probe configuration, progress monitoring, and troubleshooting.

--- a/docs/zh/guide/templates.md
+++ b/docs/zh/guide/templates.md
@@ -16,6 +16,40 @@ Template（模板）是 Cube-Sandbox 创建实例的基础镜像和配置快照�
 3. **Deploy (注册与发布)**
    将打包好的 Rootfs 和 Snapshot 文件注册到系统中，成为一个可用的 Template。后续即可通过该 Template 实现沙箱的 **热启动 (Hot Start)**，实现极速启动。
 
+## 将运行中的沙箱提交为模板
+
+`tpl commit` 命令用于将运行中沙箱的当前文件系统和内存状态制作成一个新模板，使用时必须通过 `--sandbox-id` 指定源沙箱。
+
+默认情况下，CLI 仅发送沙箱 ID。CubeMaster 会根据已保存的沙箱规格记录恢复创建该沙箱时使用的完整请求。对于没有规格记录的旧沙箱，CubeMaster 会回退到该沙箱来源模板中保存的创建请求。
+
+CLI 会显示构建进度，并等待模板创建成功或失败。
+
+可以通过 `--file <path>` 提供完整的 `CreateCubeSandboxReq`，覆盖自动恢复的创建请求。该文件会完全替代控制面恢复的请求，两者不会合并。
+
+使用 `--file` 时，可以通过以下网络参数修改文件请求中的 `cube_network_config`：
+
+| 参数                              | 作用                       |
+| ------------------------------- | ------------------------ |
+| `--allow-internet-access=false` | 显式设置请求中的联网开关。            |
+| `--allow-out-cidr <cidr>`       | 追加允许访问的出站 CIDR；该参数可重复传入。 |
+| `--deny-out-cidr <cidr>`        | 追加禁止访问的出站 CIDR；该参数可重复传入。 |
+
+网络覆盖参数必须与 `--file` 一同使用。
+
+```bash
+# 由 CubeMaster 恢复创建沙箱时使用的请求。
+cubemastercli tpl commit \
+  --sandbox-id <sandbox-id>
+
+# 使用完整的请求文件覆盖自动恢复的结果。
+cubemastercli tpl commit \
+  --sandbox-id <sandbox-id> \
+  --file template-request.json \
+  --allow-internet-access=false
+```
+
+提交成功后，CubeMaster 会生成一个新的 `tpl-...` 模板 ID，并在源沙箱所在的节点上创建初始副本。
+
 ## 下一步
 
 - [从 OCI 镜像制作模板](./tutorials/template-from-image.md) — 完整的 CLI 指南，包括探针配置、进度监控和故障排查。


### PR DESCRIPTION
## Motivation

`cubemastercli tpl commit` required both a sandbox ID and the original `CreateCubeSandboxReq` JSON file.

This required users to keep and provide the original request file when committing a sandbox. The sandbox create request is already associated with the sandbox in the control plane, so users should not need to preserve and resubmit it just to commit the sandbox as a template.

CubeMaster's snapshot path already restores the canonical sandbox create request from `sandboxspec`, with an origin-template fallback for legacy sandboxes. Template commit should use the same source of truth.

## What Changed

* Allow `/cube/sandbox/commit` to omit `create_request`.
* Resolve the sandbox request inside CubeMaster using the existing snapshot resolver:

  * prefer the canonical `sandboxspec` record
  * fall back to the sandbox's origin template request for legacy sandboxes
* Keep an explicitly supplied `create_request` as a complete override.
* Simplify `cubemastercli tpl commit` so the default path sends only `sandbox_id`.
* Keep `--file` as the optional complete request override.
* Keep network override flags file-based; they still require `--file`.
* Log full template commit failures in CubeMaster while returning stable,
  sanitized error messages to clients.
* Preserve output `tpl-...` generation, host resolution, and the asynchronous `build_id` flow.
* Document the behavior and default progress-watching flow in English and Chinese.

CubeAPI is unchanged because it does not call `/cube/sandbox/commit`.

## Validation

Added focused tests for:

* The default `tpl commit --sandbox-id ...` flow, where the CLI sends only the sandbox ID and CubeMaster accepts the request without `create_request`.
* Sandbox request restoration through the shared resolver, including existing HTTP error handling for resolver failures.
* The explicit `create_request` override, which remains a complete replacement.
* The `--file` flow, including successful network flag merging and the
  requirement that network override flags be used with `--file`.
* Existing request ID validation and template commit error mapping.
* Sanitization of wrapped resolver, template, and database errors before they
  are returned in `RetMsg`.

The focused CLI, HTTP handler, and template commit tests pass. Both `cubemaster` and `cubemastercli` also build successfully.

The default flow was verified end to end against a running sandbox:

```bash
cubemastercli tpl commit --sandbox-id <sandbox-id>
```

The command completed successfully, and the generated template reached `READY` without `--file` or the original create request.

A broader test run passed the CLI and HTTP handler packages. `pkg/templatecenter` still has an unrelated nil-pointer failure in the unmodified `TestRefreshSnapshotStorageMetricsRetriesCachedUnknown` test.
