### PR TITLE
feat(examples): add stateful PostgreSQL sandbox

### DIFF
--- a/docs/guide/tutorials/examples.md
+++ b/docs/guide/tutorials/examples.md
@@ -5,6 +5,7 @@ Hands-on examples demonstrating various Cube Sandbox use cases. Each example is 
 | Example | Description |
 |---------|-------------|
 | [Code Sandbox Quickstart](https://github.com/tencentcloud/CubeSandbox/tree/master/examples/code-sandbox-quickstart) | The most basic usage: create a sandbox, run Python code, execute shell commands, manage network policies, and more — all via the E2B SDK. |
+| [Stateful PostgreSQL Sandbox](https://github.com/tencentcloud/CubeSandbox/tree/master/examples/postgresql-stateful-sandbox) | Run PostgreSQL 16.14 over a local Unix socket, then verify offline SQL execution, snapshot restore, and two isolated schema-migration branches. |
 | [Browser Sandbox (Playwright)](https://github.com/tencentcloud/CubeSandbox/tree/master/examples/browser-sandbox) | Run a headless Chromium inside a MicroVM and control it remotely with Playwright via CDP. |
 | [OpenClaw Integration](https://github.com/tencentcloud/CubeSandbox/tree/master/examples/openclaw-integration) | Deploy Cube Sandbox and configure the OpenClaw skill so AI agents can execute code in isolated VM environments. |
 | [SWE-bench with mini-swe-agent](https://github.com/tencentcloud/CubeSandbox/tree/master/examples/mini-rl-training) | Automate SWE-bench coding tasks in isolated sandboxes using cube-sandbox + mini-swe-agent, with multi-model support and RL training vision. |
@@ -13,5 +14,9 @@ Hands-on examples demonstrating various Cube Sandbox use cases. Each example is 
 | [cube-bench](https://github.com/tencentcloud/CubeSandbox/tree/master/examples/cube-bench) | CLI benchmark tool written in Go that measures sandbox creation/deletion latency at configurable concurrency levels. Features a real-time TUI dashboard (Bubbletea/Lipgloss), percentile report (P50/P95/P99), and JSON export. |
 
 ::: tip
-All examples share the same environment variable conventions (`E2B_API_URL`, `E2B_API_KEY`, `CUBE_TEMPLATE_ID`). See the [Quick Start](../quickstart.md) guide to set up your Cube Sandbox deployment first.
+E2B-compatible examples generally use `E2B_API_URL`, `E2B_API_KEY`, and
+`CUBE_TEMPLATE_ID`. Examples built on the Cube-native SDK use `CUBE_API_URL`,
+`CUBE_TEMPLATE_ID`, and optionally `CUBE_PROXY_NODE_IP`. Follow each example's
+README for its exact variables, and see [Quick Start](../quickstart.md) before
+running one against a new deployment.
 :::

--- a/docs/zh/guide/tutorials/examples.md
+++ b/docs/zh/guide/tutorials/examples.md
@@ -5,6 +5,7 @@
 | 示例 | 说明 |
 |------|------|
 | [代码沙箱快速入门](https://github.com/tencentcloud/CubeSandbox/tree/master/examples/code-sandbox-quickstart) | 最基础的用法：创建沙箱、执行 Python 代码、运行 Shell 命令、管理网络策略等，全部通过 E2B SDK 完成。 |
+| [PostgreSQL 有状态沙箱](https://github.com/tencentcloud/CubeSandbox/tree/master/examples/postgresql-stateful-sandbox) | 通过本地 Unix Socket 运行 PostgreSQL 16.14，并验证断网 SQL、数据库快照恢复以及两条隔离的 schema migration 分支。 |
 | [浏览器沙箱（Playwright）](https://github.com/tencentcloud/CubeSandbox/tree/master/examples/browser-sandbox) | 在 MicroVM 中运行无头 Chromium，通过 CDP 协议使用 Playwright 远程控制浏览器。 |
 | [OpenClaw 集成](https://github.com/tencentcloud/CubeSandbox/tree/master/examples/openclaw-integration) | 部署 Cube Sandbox 并配置 OpenClaw Skill，让 AI Agent 能够在隔离的虚拟机环境中执行代码。 |
 | [SWE-bench + mini-swe-agent](https://github.com/tencentcloud/CubeSandbox/tree/master/examples/mini-rl-training) | 使用 cube-sandbox + mini-swe-agent 在隔离沙箱中自动化 SWE-bench 编码任务，支持多模型切换和 RL 训练愿景。 |
@@ -13,5 +14,8 @@
 | [cube-bench](https://github.com/tencentcloud/CubeSandbox/tree/master/examples/cube-bench) | Go 编写的 CLI 压测工具，可在可配置并发数下测量沙箱创建/删除延迟。具备实时 TUI 看板（Bubbletea/Lipgloss）、分位数报告（P50/P95/P99）和 JSON 导出功能。 |
 
 ::: tip
-所有示例共享相同的环境变量约定（`E2B_API_URL`、`E2B_API_KEY`、`CUBE_TEMPLATE_ID`）。请先参考[快速开始](../quickstart.md)指南搭建 Cube Sandbox 环境。
+E2B 兼容示例通常使用 `E2B_API_URL`、`E2B_API_KEY` 和
+`CUBE_TEMPLATE_ID`；基于 Cube 原生 SDK 的示例使用 `CUBE_API_URL`、
+`CUBE_TEMPLATE_ID` 以及可选的 `CUBE_PROXY_NODE_IP`。请以各示例 README
+列出的变量为准；在新部署上运行前，请先参考[快速开始](../quickstart.md)。
 :::

--- a/examples/postgresql-stateful-sandbox/.dockerignore
+++ b/examples/postgresql-stateful-sandbox/.dockerignore
@@ -1,0 +1,4 @@
+.env
+.venv/
+__pycache__/
+*.py[cod]

--- a/examples/postgresql-stateful-sandbox/.env.example
+++ b/examples/postgresql-stateful-sandbox/.env.example
@@ -1,0 +1,10 @@
+# Required: CubeAPI address (not a CubeProxy URL).
+CUBE_API_URL="http://127.0.0.1:3000"
+
+# Required: template ID returned by cubemastercli tpl create-from-image.
+CUBE_TEMPLATE_ID="tpl-xxxxxxxxxxxxxxxx"
+
+# Optional: bypass CubeProxy DNS when the client cannot resolve cube.app.
+# CUBE_PROXY_NODE_IP="<node-ip>"
+# CUBE_PROXY_PORT_HTTP="80"
+# CUBE_SANDBOX_DOMAIN="cube.app"

--- a/examples/postgresql-stateful-sandbox/Dockerfile
+++ b/examples/postgresql-stateful-sandbox/Dockerfile
@@ -23,12 +23,9 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         ca-certificates \
         curl \
-        sudo \
         tini \
     && rm -rf /var/lib/apt/lists/* \
-    && useradd --create-home --uid 1000 --user-group --shell /bin/bash user \
-    && printf '%s\n' 'user ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/user \
-    && chmod 0440 /etc/sudoers.d/user
+    && useradd --create-home --uid 1000 --user-group --shell /bin/bash user
 
 COPY --from=cube-envd /usr/bin/envd /usr/bin/envd
 
@@ -66,7 +63,7 @@ EXPOSE 49983
 
 HEALTHCHECK --interval=2s --timeout=2s --start-period=10s --retries=30 \
     CMD curl -fsS -o /dev/null "http://127.0.0.1:${ENVD_PORT}/health" \
-        && gosu postgres pg_isready -q \
+        && gosu postgres pg_isready -q --timeout=1 \
             -h "${POSTGRES_SOCKET_DIR}" -U postgres -d postgres
 
 ENTRYPOINT ["/usr/bin/tini", "--", "/usr/local/bin/cube-entrypoint.sh"]

--- a/examples/postgresql-stateful-sandbox/Dockerfile
+++ b/examples/postgresql-stateful-sandbox/Dockerfile
@@ -31,17 +31,12 @@ RUN apt-get update \
     && chmod 0440 /etc/sudoers.d/user
 
 COPY --from=cube-envd /usr/bin/envd /usr/bin/envd
-COPY cube-entrypoint.sh start-postgres.sh postgres-ready-envd.sh /usr/local/bin/
 
 # Keep the database cluster outside the VOLUME inherited from the upstream
 # image. Cube snapshots then capture PGDATA and pg_wal in the sandbox rootfs.
 # Peer authentication is sufficient because examples execute psql as the
 # postgres operating-system user. TCP authentication is rejected explicitly.
-RUN chmod +x \
-        /usr/bin/envd \
-        /usr/local/bin/cube-entrypoint.sh \
-        /usr/local/bin/start-postgres.sh \
-        /usr/local/bin/postgres-ready-envd.sh \
+RUN chmod +x /usr/bin/envd \
     && install -d -o postgres -g postgres -m 0700 "${PGDATA}" \
     && gosu postgres initdb \
         --pgdata="${PGDATA}" \
@@ -52,6 +47,15 @@ RUN chmod +x \
         --auth-local=peer \
         --auth-host=reject \
     && mkdir -p /var/log
+
+# Keep frequently edited runtime scripts after initdb so script-only changes
+# do not invalidate the initialized database-cluster layer.
+COPY cube-entrypoint.sh start-postgres.sh postgres-ready-envd.sh /usr/local/bin/
+
+RUN chmod +x \
+        /usr/local/bin/cube-entrypoint.sh \
+        /usr/local/bin/start-postgres.sh \
+        /usr/local/bin/postgres-ready-envd.sh
 
 LABEL org.opencontainers.image.source="https://github.com/TencentCloud/CubeSandbox" \
       org.opencontainers.image.title="cubesandbox-postgresql-stateful" \

--- a/examples/postgresql-stateful-sandbox/Dockerfile
+++ b/examples/postgresql-stateful-sandbox/Dockerfile
@@ -1,0 +1,69 @@
+# syntax=docker/dockerfile:1.7
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# envd is copied from the pinned CubeSandbox base image, while PostgreSQL
+# itself comes from the official PostgreSQL image. The local entrypoint waits
+# for PostgreSQL to complete shutdown before the container exits.
+FROM ghcr.io/tencentcloud/cubesandbox-base:2026.16 AS cube-envd
+
+FROM postgres:16.14-bookworm
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+ENV ENVD_PORT=49983 \
+    ENVD_BIN=/usr/local/bin/postgres-ready-envd.sh \
+    PGDATA=/var/lib/postgresql/cube-data \
+    POSTGRES_SOCKET_DIR=/var/run/postgresql \
+    POSTGRES_READY_TIMEOUT=60 \
+    LANG=C.UTF-8 \
+    LC_ALL=C.UTF-8
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        curl \
+        sudo \
+        tini \
+    && rm -rf /var/lib/apt/lists/* \
+    && useradd --create-home --uid 1000 --user-group --shell /bin/bash user \
+    && printf '%s\n' 'user ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/user \
+    && chmod 0440 /etc/sudoers.d/user
+
+COPY --from=cube-envd /usr/bin/envd /usr/bin/envd
+COPY cube-entrypoint.sh start-postgres.sh postgres-ready-envd.sh /usr/local/bin/
+
+# Keep the database cluster outside the VOLUME inherited from the upstream
+# image. Cube snapshots then capture PGDATA and pg_wal in the sandbox rootfs.
+# Peer authentication is sufficient because examples execute psql as the
+# postgres operating-system user. TCP authentication is rejected explicitly.
+RUN chmod +x \
+        /usr/bin/envd \
+        /usr/local/bin/cube-entrypoint.sh \
+        /usr/local/bin/start-postgres.sh \
+        /usr/local/bin/postgres-ready-envd.sh \
+    && install -d -o postgres -g postgres -m 0700 "${PGDATA}" \
+    && gosu postgres initdb \
+        --pgdata="${PGDATA}" \
+        --username=postgres \
+        --encoding=UTF8 \
+        --locale=C.UTF-8 \
+        --data-checksums \
+        --auth-local=peer \
+        --auth-host=reject \
+    && mkdir -p /var/log
+
+LABEL org.opencontainers.image.source="https://github.com/TencentCloud/CubeSandbox" \
+      org.opencontainers.image.title="cubesandbox-postgresql-stateful" \
+      org.opencontainers.image.description="Stateful PostgreSQL 16.14 CubeSandbox template" \
+      org.opencontainers.image.licenses="Apache-2.0"
+
+EXPOSE 49983
+
+HEALTHCHECK --interval=2s --timeout=2s --start-period=10s --retries=30 \
+    CMD curl -fsS -o /dev/null "http://127.0.0.1:${ENVD_PORT}/health" \
+        && gosu postgres pg_isready -q \
+            -h "${POSTGRES_SOCKET_DIR}" -U postgres -d postgres
+
+ENTRYPOINT ["/usr/bin/tini", "--", "/usr/local/bin/cube-entrypoint.sh"]
+CMD ["/usr/local/bin/start-postgres.sh"]

--- a/examples/postgresql-stateful-sandbox/README.md
+++ b/examples/postgresql-stateful-sandbox/README.md
@@ -24,30 +24,36 @@ workloads. It is not a production PostgreSQL deployment or backup system.
 
 ```text
 host-side Python script
-    |
-    | cubesandbox SDK (per-sandbox traffic token)
-    v
-CubeProxy -> envd :49983 -> command executed as OS user postgres
-                                  |
-                                  v
-                         PostgreSQL Unix socket
-                         /var/run/postgresql
+    |-- control plane: create, snapshot, and delete
+    |   `-- CubeAPI -> CubeMaster
+    `-- authenticated command and file traffic
+        `-- CubeProxy -> envd :49983
+                            `-- command executed as OS user postgres
+                                `-- PostgreSQL Unix socket
+                                    /var/run/postgresql
 ```
+
+The native SDK obtains sandbox lifecycle state from CubeAPI and uses the
+per-sandbox traffic token returned at creation time for requests routed through
+CubeProxy to envd. PostgreSQL itself remains reachable only inside the MicroVM.
 
 The container process tree is:
 
 ```text
 tini
 `-- cube-entrypoint.sh
-    |-- postgres-ready-envd.sh
+    |-- postgres-ready-envd.sh (background child)
     |   `-- wait for pg_isready, then start envd :49983
-    `-- start-postgres.sh
-        `-- postgres (foreground process)
+    `-- start-postgres.sh (background child)
+        `-- postgres (foreground within the helper)
 ```
 
+`cube-entrypoint.sh` waits for and reaps both children. On TERM or INT it waits
+for PostgreSQL to finish its fast shutdown before stopping envd and exiting.
 The readiness endpoint is deliberately delayed until `pg_isready` succeeds.
 Therefore, an HTTP 204 from `:49983/health` means both the Cube command channel
-and PostgreSQL are ready.
+and PostgreSQL are ready. `POSTGRES_READY_TIMEOUT` defaults to 60 seconds; a
+value of `0` performs one immediate readiness check and fails if it is not ready.
 
 The database boundary is intentionally narrow:
 
@@ -208,6 +214,10 @@ cubemastercli tpl create-from-image \
   --with-cube-ca=false \
   --detach
 ```
+
+`--with-cube-ca=false` avoids baking a deployment-specific CubeEgress MITM CA
+into this offline template. Enable it only if the template is changed to use
+intercepted HTTPS egress and must trust CubeEgress's generated certificates.
 
 Copy the printed `job_id` and `template_id`, then wait for all target-node
 replicas to become ready:

--- a/examples/postgresql-stateful-sandbox/README.md
+++ b/examples/postgresql-stateful-sandbox/README.md
@@ -1,0 +1,437 @@
+# Stateful PostgreSQL Sandbox
+
+[中文文档](README_zh.md)
+
+Run PostgreSQL 16.14 as a self-contained, stateful service inside a
+CubeSandbox MicroVM. The database accepts local Unix-socket connections only;
+host-side Python drivers execute SQL through Cube's authenticated `envd`
+command channel.
+
+This example demonstrates three complete workflows:
+
+- `smoke.py`: create a database, execute SQL, and verify inbound and outbound
+  network restrictions.
+- `snapshot_restore.py`: checkpoint a running database, make destructive data
+  and schema changes, then restore the snapshot into a new sandbox.
+- `migration_branches.py`: create two independent migration branches from one
+  database snapshot and prove that their files, schemas, and migration ledgers
+  remain isolated.
+
+The image is intended for development, testing, migration rehearsal, and agent
+workloads. It is not a production PostgreSQL deployment or backup system.
+
+## Architecture and security model
+
+```text
+host-side Python script
+    |
+    | cubesandbox SDK (per-sandbox traffic token)
+    v
+CubeProxy -> envd :49983 -> command executed as OS user postgres
+                                  |
+                                  v
+                         PostgreSQL Unix socket
+                         /var/run/postgresql
+```
+
+The container process tree is:
+
+```text
+tini
+`-- cube-entrypoint.sh
+    |-- postgres-ready-envd.sh
+    |   `-- wait for pg_isready, then start envd :49983
+    `-- start-postgres.sh
+        `-- postgres (foreground process)
+```
+
+The readiness endpoint is deliberately delayed until `pg_isready` succeeds.
+Therefore, an HTTP 204 from `:49983/health` means both the Cube command channel
+and PostgreSQL are ready.
+
+The database boundary is intentionally narrow:
+
+- PostgreSQL listens on no TCP address; port 5432 is not registered in the
+  Cube template.
+- Local connections use `peer` authentication and host connections are
+  rejected by `pg_hba.conf`.
+- No PostgreSQL password is created or stored.
+- Every sandbox and snapshot branch disables public internet egress.
+- `network.allow_public_traffic=false` protects inbound `envd` traffic with a
+  per-sandbox token that the native SDK supplies automatically.
+
+The sandbox's root user can become the `postgres` operating-system user. The
+MicroVM, not PostgreSQL roles, is the trust boundary; do not share one instance
+between mutually untrusted users.
+
+## Directory layout
+
+```text
+postgresql-stateful-sandbox/
+|-- Dockerfile                 # PostgreSQL 16.14 + Cube envd template image
+|-- .dockerignore
+|-- cube-entrypoint.sh         # Wait for PostgreSQL to shut down cleanly
+|-- start-postgres.sh          # Unix-socket-only PostgreSQL foreground process
+|-- postgres-ready-envd.sh     # Start envd only after the database is ready
+|-- .env.example               # Host SDK configuration
+|-- requirements.txt           # cubesandbox and python-dotenv
+|-- env_utils.py               # .env loading and validation
+|-- postgres_utils.py          # Shared SQL, snapshot, and cleanup helpers
+|-- smoke.py                   # Minimal SQL and network-isolation check
+|-- snapshot_restore.py        # Data + schema restore demonstration
+|-- migration_branches.py      # Two isolated branches from one snapshot
+|-- sql/
+|   |-- base_schema.sql        # Accounts table, seed data, migration ledger
+|   |-- add_email.sql          # Branch A migration
+|   `-- add_last_login.sql     # Branch B migration
+|-- README.md
+`-- README_zh.md
+```
+
+## Prerequisites
+
+- A running CubeSandbox deployment with CubeAPI reachable from the host.
+- `cubemastercli` installed, on `PATH`, and connected to CubeMaster.
+- Docker with `linux/amd64` build support.
+- An OCI registry that every target Cube node can pull from.
+- Python 3.9 or later for the host-side scripts.
+- Cluster capacity for 2 vCPU and 2 GiB RAM per sandbox. The migration branch
+  demo runs two sandboxes concurrently, so reserve at least 4 vCPU and 4 GiB
+  RAM, plus platform overhead.
+
+## 1. Build and verify the image locally
+
+Build the one supported image:
+
+```bash
+export LOCAL_IMAGE=cubesandbox-postgresql-stateful:16.14
+
+docker build --platform linux/amd64 \
+  --tag "$LOCAL_IMAGE" \
+  examples/postgresql-stateful-sandbox
+```
+
+Start it and wait for the combined envd/PostgreSQL health check:
+
+```bash
+docker run --detach \
+  --name cubesandbox-postgresql-stateful \
+  --publish 49983:49983 \
+  "$LOCAL_IMAGE"
+
+status=starting
+attempt=0
+while [ "$attempt" -lt 60 ]; do
+  status=$(docker inspect --format '{{.State.Health.Status}}' \
+    cubesandbox-postgresql-stateful)
+  [ "$status" = healthy ] && break
+  if [ "$status" = unhealthy ]; then
+    docker logs cubesandbox-postgresql-stateful
+    exit 1
+  fi
+  attempt=$((attempt + 1))
+  sleep 2
+done
+
+if [ "$status" != healthy ]; then
+  docker logs cubesandbox-postgresql-stateful
+  echo 'ERROR: container did not become healthy within 120 seconds' >&2
+  exit 1
+fi
+
+curl --fail --silent --show-error \
+  --output /dev/null \
+  --write-out 'envd health: %{http_code}\n' \
+  http://127.0.0.1:49983/health
+```
+
+The final command must print `envd health: 204`. Verify the database version,
+data directory, and Unix socket:
+
+```bash
+docker exec --user postgres cubesandbox-postgresql-stateful \
+  psql -X -h /var/run/postgresql -U postgres -d postgres \
+  -Atqc 'SHOW server_version; SHOW data_directory; SELECT 1;'
+```
+
+Expected values include:
+
+```text
+16.14 ...
+/var/lib/postgresql/cube-data
+1
+```
+
+TCP must remain unavailable:
+
+```bash
+if docker exec --user postgres cubesandbox-postgresql-stateful \
+  pg_isready -h 127.0.0.1 -p 5432 -U postgres -d postgres; then
+  echo 'ERROR: PostgreSQL unexpectedly accepted TCP connections' >&2
+  exit 1
+else
+  echo 'OK: PostgreSQL TCP port is closed'
+fi
+```
+
+Finally, confirm a graceful stop and remove the local container:
+
+```bash
+docker stop --time 15 cubesandbox-postgresql-stateful
+docker rm cubesandbox-postgresql-stateful
+```
+
+## 2. Push and register the Cube template
+
+Tag the image for a registry visible to the Cube nodes:
+
+```bash
+export REGISTRY_IMAGE=registry.example.com/cubesandbox-postgresql-stateful:16.14
+
+docker tag "$LOCAL_IMAGE" "$REGISTRY_IMAGE"
+docker push "$REGISTRY_IMAGE"
+```
+
+Replace `registry.example.com` with your registry, then submit the template
+build. `--detach` makes the job ID available for the explicit watch step:
+
+```bash
+cubemastercli tpl create-from-image \
+  --image "$REGISTRY_IMAGE" \
+  --writable-layer-size 4G \
+  --expose-port 49983 \
+  --probe 49983 \
+  --probe-path /health \
+  --cpu 2000 \
+  --memory 2048 \
+  --allow-internet-access=false \
+  --with-cube-ca=false \
+  --detach
+```
+
+Copy the printed `job_id` and `template_id`, then wait for all target-node
+replicas to become ready:
+
+```bash
+cubemastercli tpl watch --job-id <job_id>
+cubemastercli tpl info --template-id <template_id> --json --include-request
+cubemastercli tpl render --template-id <template_id> --json
+```
+
+Do not continue until the job is `READY` and `distribution` reports every
+target node ready. Inspect the stored and rendered requests and confirm:
+
+- only container port 49983 is exposed;
+- the probe is `GET /health` on 49983;
+- CPU is 2000 millicores and memory is 2048 MB;
+- the writable layer is 4 GiB;
+- internet access is disabled.
+
+The template-level egress restriction is defense in depth. Each Python driver
+also passes `allow_internet_access=False` explicitly, including when a snapshot
+is used as a template.
+
+## 3. Configure the host-side drivers
+
+```bash
+cd examples/postgresql-stateful-sandbox
+python3 -m venv .venv
+. .venv/bin/activate
+pip install -r requirements.txt
+cp .env.example .env
+```
+
+Edit `.env`:
+
+```dotenv
+CUBE_API_URL=http://127.0.0.1:3000
+CUBE_TEMPLATE_ID=tpl-xxxxxxxxxxxxxxxx
+
+# Set these when the host cannot resolve the Cube sandbox wildcard domain.
+# CUBE_PROXY_NODE_IP=<cube-proxy-node-ip>
+# CUBE_PROXY_PORT_HTTP=80
+# CUBE_SANDBOX_DOMAIN=cube.app
+```
+
+| Variable | Required | Purpose |
+|---|:---:|---|
+| `CUBE_API_URL` | Yes | CubeAPI control-plane endpoint |
+| `CUBE_TEMPLATE_ID` | Yes | Template ID produced in step 2 |
+| `CUBE_PROXY_NODE_IP` | No | Dial CubeProxy directly instead of relying on wildcard DNS |
+| `CUBE_PROXY_PORT_HTTP` | No | CubeProxy HTTP port; defaults to `80` |
+| `CUBE_SANDBOX_DOMAIN` | No | Sandbox routing domain; defaults to `cube.app` |
+
+These examples use the native `cubesandbox` SDK, not the E2B SDK, so they do
+not require `E2B_API_URL` or `E2B_API_KEY`.
+
+## 4. Run the three workflows
+
+Run the scripts from this directory. They raise an exception on a failed
+assertion and print a single `OK:` line only after all checks pass.
+
+### Minimal SQL and network isolation
+
+```bash
+python smoke.py
+```
+
+The script creates the baseline schema, verifies PostgreSQL 16.14, and checks two
+seeded accounts with a total balance of 300. It confirms that sandbox creation
+returns a traffic token and that token-authenticated envd health returns 204,
+then proves that an outbound request to `example.com` fails, verifies local SQL
+still works, and confirms that TCP 5432 is closed.
+
+Expected final line:
+
+```text
+OK: PostgreSQL template is ready and network isolation is enforced
+```
+
+### Snapshot restore into a new sandbox
+
+```bash
+python snapshot_restore.py
+```
+
+The script loads the baseline, completes all transactions, runs `CHECKPOINT`,
+and creates a snapshot. It then sets both balances to zero and adds a
+`poisoned` column, verifies those changes, and destroys the source sandbox.
+It creates a new sandbox from the snapshot and proves that:
+
+- the restored sandbox has a different ID from the source;
+- balances returned to 100 and 200;
+- the `poisoned` column disappeared;
+- the explicitly created snapshot was deleted during cleanup.
+
+Expected final line:
+
+```text
+OK: snapshot restored PostgreSQL data and schema in a new sandbox
+```
+
+### Isolated migration branches
+
+```bash
+python migration_branches.py
+```
+
+The script checkpoints a source database, creates one snapshot, and destroys
+the source sandbox. It then creates two sandboxes concurrently from that same
+snapshot with the full inbound/outbound security settings applied to each:
+
+- branch A applies `add_email.sql`;
+- branch B applies `add_last_login.sql`.
+
+Both branches upload their migration as `/tmp/migration.sql`. The assertions
+prove that the file content, schema columns, and `schema_migrations` rows are
+isolated. Cleanup always destroys child sandboxes before deleting the shared
+snapshot, including partial-create failures.
+
+Expected final line:
+
+```text
+OK: isolated PostgreSQL migration branches passed
+```
+
+The script intentionally does not call `Sandbox.clone()`: the current helper
+creates children with default create settings. Explicit
+`Sandbox.create(template=snapshot_id, ...)` calls ensure the timeout and both
+network restrictions are applied to every branch.
+
+## Snapshot consistency
+
+Cube snapshots capture a paused MicroVM's memory and filesystem. This example
+keeps `PGDATA` and `pg_wal` together at
+`/var/lib/postgresql/cube-data`, outside the volume declared by the upstream
+image, so the complete database cluster is included.
+
+Before taking a reusable database snapshot, the scripts:
+
+1. wait for application transactions to commit;
+2. run PostgreSQL `CHECKPOINT`;
+3. call `create_snapshot()` only after the checkpoint succeeds.
+
+This reduces WAL recovery work after restoring or branch creation. It does not
+turn a Cube snapshot into a production backup or point-in-time recovery
+archive. Do not move `pg_wal` outside `PGDATA`, create external tablespaces, or
+copy these snapshots between PostgreSQL major versions.
+
+Snapshots outlive their source sandboxes and may contain sensitive data. A
+`with Sandbox.create(...)` block destroys the sandbox only; it does not delete
+snapshots. All scripts therefore call `Sandbox.delete_snapshot()` explicitly.
+
+## Resource guidance
+
+| Resource | Setting | Notes |
+|---|---:|---|
+| CPU | 2000 millicores | Per sandbox |
+| Memory | 2048 MB | Per sandbox; increase for larger datasets or queries |
+| Writable layer | 4 GiB | Contains PostgreSQL data and WAL |
+| Concurrent branch capacity | 4 vCPU / 4 GiB minimum | Two 2-vCPU/2-GiB branches, excluding platform overhead |
+
+Monitor the writable layer when inserting larger datasets. PostgreSQL may need
+temporary disk space in addition to table and WAL storage, and each retained
+snapshot consumes persistent image storage.
+
+## Known limitations
+
+- The image contains exactly PostgreSQL 16.14 and targets `linux/amd64`.
+- It is a single-node, ephemeral development database: no HA, replication,
+  PITR, external tablespaces, TLS listener, or raw PostgreSQL ingress.
+- Destroying a sandbox without first taking a snapshot permanently discards
+  its state.
+- Snapshot compatibility is limited to this image and PostgreSQL major
+  version.
+- Image construction requires registry/package access; sandbox runtime is
+  deliberately offline.
+- Cube SDK control-plane operations such as create and snapshot do
+  not currently expose a separate per-call timeout. Command execution uses its
+  own finite timeout.
+- Raw TCP clients cannot connect to port 5432 by design. Use the SDK command
+  channel and local Unix socket.
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| Docker build stalls while pulling Docker Hub/GHCR layers | The Docker daemon cannot use the shell's proxy, or host DNS/direct registry routing is broken | Configure a Docker daemon proxy or registry mirror; alternatively pre-pull and locally tag the two base images. If `apt` also needs the host proxy, pass lowercase `http_proxy`/`https_proxy` build args and use an appropriate build network mode |
+| Docker health remains `starting` or turns `unhealthy` | PostgreSQL did not initialize, socket permissions are wrong, or envd did not start | Run `docker logs cubesandbox-postgresql-stateful`; confirm `pg_isready` succeeds as `postgres` |
+| Template build probe times out | Port/path mismatch or PostgreSQL did not become ready within the probe window | Expose/probe 49983 at `/health`; inspect the image job and Cubelet logs |
+| Template is `READY` but distribution is not complete | One or more target nodes have not received the artifact | Wait and rerun `tpl info`; inspect the affected Cubelet's image/storage logs |
+| A manual envd request is rejected | The request omitted the per-sandbox traffic token | Use the same returned `Sandbox` object; for manual HTTP requests supply its traffic token header |
+| SDK cannot resolve `*.cube.app` | Host DNS cannot resolve the sandbox wildcard domain | Set `CUBE_PROXY_NODE_IP` and, if needed, `CUBE_PROXY_PORT_HTTP` |
+| Local CubeAPI calls return HTTP 502 while `HTTP_PROXY`/`HTTPS_PROXY` is set | Loopback control-plane traffic was sent through the host proxy | Add `127.0.0.1`, `localhost`, and the CubeProxy node IP to both `NO_PROXY` and `no_proxy` |
+| `psql: Peer authentication failed` | Command ran as the wrong OS user | Execute through the provided helpers or pass `user="postgres"` |
+| `pg_isready -h 127.0.0.1` fails | None; this is the expected secure configuration | Use `-h /var/run/postgresql` |
+| `No space left on device` | The 4-GiB writable layer is full | Remove test data/snapshots or rebuild the template with a larger writable layer |
+| Script exits before its final `OK:` line | An assertion or platform call failed | Read the printed command stdout/stderr, then list sandboxes and snapshots to confirm cleanup |
+
+## Acceptance checklist
+
+Run these checks in the environment where the contribution will be reviewed;
+this README does not claim that a particular external cluster has already
+passed them.
+
+```bash
+python3 -m compileall examples/postgresql-stateful-sandbox
+ruff check examples/postgresql-stateful-sandbox
+shellcheck examples/postgresql-stateful-sandbox/*.sh
+git diff --check
+
+npm --prefix docs ci
+npm --prefix docs run docs:build
+```
+
+In addition, complete the local image checks in step 1, reach template
+`READY` with full distribution, run all three Python scripts, and compare the
+sandbox/snapshot lists before and after the run to ensure no resources leaked.
+
+## References
+
+- [Create a template from an OCI image](../../docs/guide/tutorials/template-from-image.md)
+- [Connect to an existing Cube cluster](../../docs/guide/connect-existing-cluster.md)
+- [Snapshot, rollback, and clone](../../docs/guide/snapshot-rollback-clone.md)
+- [Network policy](../../docs/guide/network-policy.md)
+- [Restrict public access](../../docs/guide/restrict-public-access.md)
+- [PostgreSQL file-system backup consistency](https://www.postgresql.org/docs/16/backup-file.html)
+- [PostgreSQL `CHECKPOINT`](https://www.postgresql.org/docs/16/sql-checkpoint.html)

--- a/examples/postgresql-stateful-sandbox/README.md
+++ b/examples/postgresql-stateful-sandbox/README.md
@@ -50,6 +50,9 @@ tini
 
 `cube-entrypoint.sh` waits for and reaps both children. On TERM or INT it waits
 for PostgreSQL to finish its fast shutdown before stopping envd and exiting.
+If envd exits unexpectedly, the entrypoint stops PostgreSQL cleanly and exits
+non-zero instead of leaving a database process running without its command
+channel.
 The readiness endpoint is deliberately delayed until `pg_isready` succeeds.
 Therefore, an HTTP 204 from `:49983/health` means both the Cube command channel
 and PostgreSQL are ready. `POSTGRES_READY_TIMEOUT` defaults to 60 seconds; a
@@ -66,8 +69,10 @@ The database boundary is intentionally narrow:
 - `network.allow_public_traffic=false` protects inbound `envd` traffic with a
   per-sandbox token that the native SDK supplies automatically.
 
-The sandbox's root user can become the `postgres` operating-system user. The
-MicroVM, not PostgreSQL roles, is the trust boundary; do not share one instance
+The conventional UID 1000 `user` account has no `sudo` access. Database
+commands are explicitly executed as the `postgres` operating-system user
+through envd. The sandbox's root user can still become `postgres`; the MicroVM,
+not PostgreSQL roles, is the trust boundary, so do not share one instance
 between mutually untrusted users.
 
 ## Directory layout
@@ -287,9 +292,12 @@ python smoke.py
 
 The script creates the baseline schema, verifies PostgreSQL 16.14, and checks two
 seeded accounts with a total balance of 300. It confirms that sandbox creation
-returns a traffic token and that token-authenticated envd health returns 204,
-then proves that an outbound request to `example.com` fails, verifies local SQL
-still works, and confirms that TCP 5432 is closed.
+returns a traffic token, that token-authenticated envd health returns 204, and
+that the same request without a token does not receive envd's 204 success
+response. The exact anonymous error status is a CubeProxy contract rather than
+a PostgreSQL template contract. The script then proves that an outbound request
+to `example.com` fails, verifies local SQL still works, and confirms that TCP
+5432 is closed.
 
 Expected final line:
 

--- a/examples/postgresql-stateful-sandbox/README_zh.md
+++ b/examples/postgresql-stateful-sandbox/README_zh.md
@@ -20,29 +20,34 @@
 
 ```text
 宿主端 Python 脚本
-    |
-    | cubesandbox SDK（每个沙箱独立的流量令牌）
-    v
-CubeProxy -> envd :49983 -> 以 postgres 系统用户执行命令
-                                  |
-                                  v
-                         PostgreSQL Unix Socket
-                         /var/run/postgresql
+    |-- 控制面：创建、snapshot 和删除
+    |   `-- CubeAPI -> CubeMaster
+    `-- 已鉴权的命令与文件流量
+        `-- CubeProxy -> envd :49983
+                            `-- 以 postgres 系统用户执行命令
+                                `-- PostgreSQL Unix Socket
+                                    /var/run/postgresql
 ```
+
+原生 SDK 从 CubeAPI 获取沙箱生命周期状态，并使用创建时返回的每沙箱流量令牌，通过
+CubeProxy 向 envd 发起请求。PostgreSQL 本身仍然只能从 MicroVM 内部访问。
 
 容器进程树：
 
 ```text
 tini
 `-- cube-entrypoint.sh
-    |-- postgres-ready-envd.sh
+    |-- postgres-ready-envd.sh（后台子进程）
     |   `-- 等待 pg_isready，再启动 envd :49983
-    `-- start-postgres.sh
-        `-- postgres（前台进程）
+    `-- start-postgres.sh（后台子进程）
+        `-- postgres（helper 内的前台进程）
 ```
 
+`cube-entrypoint.sh` 会等待并回收两个子进程。收到 TERM 或 INT 后，它会等待 PostgreSQL
+完成 fast shutdown，再停止 envd 并退出。
 就绪端点会等待 `pg_isready` 成功后才启动。因此，`:49983/health` 返回 HTTP 204 表示
-Cube 命令通道和 PostgreSQL 都已经就绪。
+Cube 命令通道和 PostgreSQL 都已经就绪。`POSTGRES_READY_TIMEOUT` 默认为 60 秒；设为
+`0` 时只执行一次即时就绪检查，未就绪则失败。
 
 数据库边界有意保持最小：
 
@@ -198,6 +203,9 @@ cubemastercli tpl create-from-image \
   --with-cube-ca=false \
   --detach
 ```
+
+`--with-cube-ca=false` 避免把特定部署的 CubeEgress MITM CA 烘焙进这个离线模板。只有在
+模板改为使用受拦截的 HTTPS 出站，并且需要信任 CubeEgress 生成的证书时，才应启用该选项。
 
 保存输出的 `job_id` 和 `template_id`，等待全部目标节点的副本就绪：
 

--- a/examples/postgresql-stateful-sandbox/README_zh.md
+++ b/examples/postgresql-stateful-sandbox/README_zh.md
@@ -45,6 +45,8 @@ tini
 
 `cube-entrypoint.sh` 会等待并回收两个子进程。收到 TERM 或 INT 后，它会等待 PostgreSQL
 完成 fast shutdown，再停止 envd 并退出。
+如果 envd 意外退出，entrypoint 会先干净停止 PostgreSQL，再以非零状态退出，不会让数据库
+在失去命令通道后继续运行。
 就绪端点会等待 `pg_isready` 成功后才启动。因此，`:49983/health` 返回 HTTP 204 表示
 Cube 命令通道和 PostgreSQL 都已经就绪。`POSTGRES_READY_TIMEOUT` 默认为 60 秒；设为
 `0` 时只执行一次即时就绪检查，未就绪则失败。
@@ -58,7 +60,8 @@ Cube 命令通道和 PostgreSQL 都已经就绪。`POSTGRES_READY_TIMEOUT` 默�
 - `network.allow_public_traffic=false` 使用每个沙箱独立的令牌保护入站 `envd` 流量，
   原生 SDK 会自动携带该令牌。
 
-沙箱内的 root 可以切换到 `postgres` 系统用户。因此，安全边界是 MicroVM，而不是
+约定的 UID 1000 `user` 账户没有 `sudo` 权限；数据库命令由 envd 显式以 `postgres`
+系统用户执行。沙箱内的 root 仍可切换到 `postgres`，因此安全边界是 MicroVM，而不是
 PostgreSQL role；不要让互不信任的用户共享同一个实例。
 
 ## 目录结构
@@ -271,8 +274,10 @@ python smoke.py
 ```
 
 脚本创建基线 schema、验证 PostgreSQL 16.14，并检查两条种子账户及余额总和 300。随后确认
-创建响应包含流量令牌、携带该令牌访问 envd health 返回 204，再确认访问 `example.com` 的
-出站请求失败、本地 SQL 仍可执行，并确认 TCP 5432 关闭。
+创建响应包含流量令牌、携带该令牌访问 envd health 返回 204，且不携带令牌的相同请求不会
+得到 envd 的 204 成功响应。匿名请求的精确错误状态码属于 CubeProxy 契约，而不是
+PostgreSQL 模板契约。脚本随后确认访问 `example.com` 的出站请求失败、本地 SQL 仍可执行，
+并确认 TCP 5432 关闭。
 
 预期最后一行：
 

--- a/examples/postgresql-stateful-sandbox/README_zh.md
+++ b/examples/postgresql-stateful-sandbox/README_zh.md
@@ -1,0 +1,405 @@
+# PostgreSQL 有状态沙箱
+
+[English](README.md)
+
+在 CubeSandbox MicroVM 中运行一个自包含的 PostgreSQL 16.14 有状态服务。数据库只接受
+本地 Unix Socket 连接；宿主端 Python 驱动通过 Cube 已鉴权的 `envd` 命令通道执行 SQL。
+
+本示例提供三个完整流程：
+
+- `smoke.py`：创建数据库、执行 SQL，并验证入站和出站网络限制。
+- `snapshot_restore.py`：为运行中的数据库创建检查点，执行破坏性数据和 schema 变更，
+  再把 snapshot 恢复到新沙箱。
+- `migration_branches.py`：从同一个数据库快照创建两条独立 migration 分支，证明文件、
+  schema 和 migration ledger 相互隔离。
+
+该镜像适用于开发、测试、migration 演练和 Agent 工作负载，不是生产 PostgreSQL 部署或
+备份系统。
+
+## 架构与安全模型
+
+```text
+宿主端 Python 脚本
+    |
+    | cubesandbox SDK（每个沙箱独立的流量令牌）
+    v
+CubeProxy -> envd :49983 -> 以 postgres 系统用户执行命令
+                                  |
+                                  v
+                         PostgreSQL Unix Socket
+                         /var/run/postgresql
+```
+
+容器进程树：
+
+```text
+tini
+`-- cube-entrypoint.sh
+    |-- postgres-ready-envd.sh
+    |   `-- 等待 pg_isready，再启动 envd :49983
+    `-- start-postgres.sh
+        `-- postgres（前台进程）
+```
+
+就绪端点会等待 `pg_isready` 成功后才启动。因此，`:49983/health` 返回 HTTP 204 表示
+Cube 命令通道和 PostgreSQL 都已经就绪。
+
+数据库边界有意保持最小：
+
+- PostgreSQL 不监听任何 TCP 地址；Cube 模板不登记 5432 端口。
+- 本地连接使用 `peer` 鉴权，`pg_hba.conf` 拒绝 host 连接。
+- 不创建或保存 PostgreSQL 密码。
+- 每个沙箱和快照分支都禁止公网出站。
+- `network.allow_public_traffic=false` 使用每个沙箱独立的令牌保护入站 `envd` 流量，
+  原生 SDK 会自动携带该令牌。
+
+沙箱内的 root 可以切换到 `postgres` 系统用户。因此，安全边界是 MicroVM，而不是
+PostgreSQL role；不要让互不信任的用户共享同一个实例。
+
+## 目录结构
+
+```text
+postgresql-stateful-sandbox/
+|-- Dockerfile                 # PostgreSQL 16.14 + Cube envd 模板镜像
+|-- .dockerignore
+|-- cube-entrypoint.sh         # 等待 PostgreSQL 完成干净退出
+|-- start-postgres.sh          # 仅 Unix Socket 的 PostgreSQL 前台进程
+|-- postgres-ready-envd.sh     # 数据库就绪后才启动 envd
+|-- .env.example               # 宿主端 SDK 配置
+|-- requirements.txt           # cubesandbox 和 python-dotenv
+|-- env_utils.py               # 加载并校验 .env
+|-- postgres_utils.py          # SQL、快照和清理公共辅助函数
+|-- smoke.py                   # 最小 SQL 与网络隔离验证
+|-- snapshot_restore.py        # 数据 + schema 恢复演示
+|-- migration_branches.py      # 同一快照派生两条隔离分支
+|-- sql/
+|   |-- base_schema.sql        # 账户表、种子数据、migration ledger
+|   |-- add_email.sql          # 分支 A migration
+|   `-- add_last_login.sql     # 分支 B migration
+|-- README.md
+`-- README_zh.md
+```
+
+## 前置条件
+
+- 已部署 CubeSandbox，且宿主机可以访问 CubeAPI。
+- `cubemastercli` 已安装到 `PATH` 并连接 CubeMaster。
+- Docker 支持构建 `linux/amd64` 镜像。
+- 所有目标 Cube 节点都可以拉取的 OCI registry。
+- 宿主端驱动脚本使用 Python 3.9 或更高版本。
+- 每个沙箱需要 2 vCPU 和 2 GiB 内存。migration 分支演示会同时运行两个沙箱，
+  因此至少预留 4 vCPU、4 GiB 内存以及平台自身开销。
+
+## 1. 本地构建并验证镜像
+
+构建唯一支持的镜像：
+
+```bash
+export LOCAL_IMAGE=cubesandbox-postgresql-stateful:16.14
+
+docker build --platform linux/amd64 \
+  --tag "$LOCAL_IMAGE" \
+  examples/postgresql-stateful-sandbox
+```
+
+启动镜像并等待 envd/PostgreSQL 组合健康检查：
+
+```bash
+docker run --detach \
+  --name cubesandbox-postgresql-stateful \
+  --publish 49983:49983 \
+  "$LOCAL_IMAGE"
+
+status=starting
+attempt=0
+while [ "$attempt" -lt 60 ]; do
+  status=$(docker inspect --format '{{.State.Health.Status}}' \
+    cubesandbox-postgresql-stateful)
+  [ "$status" = healthy ] && break
+  if [ "$status" = unhealthy ]; then
+    docker logs cubesandbox-postgresql-stateful
+    exit 1
+  fi
+  attempt=$((attempt + 1))
+  sleep 2
+done
+
+if [ "$status" != healthy ]; then
+  docker logs cubesandbox-postgresql-stateful
+  echo 'ERROR: container did not become healthy within 120 seconds' >&2
+  exit 1
+fi
+
+curl --fail --silent --show-error \
+  --output /dev/null \
+  --write-out 'envd health: %{http_code}\n' \
+  http://127.0.0.1:49983/health
+```
+
+最后一条命令必须打印 `envd health: 204`。验证数据库版本、数据目录和 Unix Socket：
+
+```bash
+docker exec --user postgres cubesandbox-postgresql-stateful \
+  psql -X -h /var/run/postgresql -U postgres -d postgres \
+  -Atqc 'SHOW server_version; SHOW data_directory; SELECT 1;'
+```
+
+预期值包括：
+
+```text
+16.14 ...
+/var/lib/postgresql/cube-data
+1
+```
+
+TCP 必须保持不可用：
+
+```bash
+if docker exec --user postgres cubesandbox-postgresql-stateful \
+  pg_isready -h 127.0.0.1 -p 5432 -U postgres -d postgres; then
+  echo 'ERROR: PostgreSQL unexpectedly accepted TCP connections' >&2
+  exit 1
+else
+  echo 'OK: PostgreSQL TCP port is closed'
+fi
+```
+
+最后验证优雅停止并删除本地容器：
+
+```bash
+docker stop --time 15 cubesandbox-postgresql-stateful
+docker rm cubesandbox-postgresql-stateful
+```
+
+## 2. 推送镜像并注册 Cube 模板
+
+把镜像标记到 Cube 节点可访问的 registry：
+
+```bash
+export REGISTRY_IMAGE=registry.example.com/cubesandbox-postgresql-stateful:16.14
+
+docker tag "$LOCAL_IMAGE" "$REGISTRY_IMAGE"
+docker push "$REGISTRY_IMAGE"
+```
+
+把 `registry.example.com` 替换成你的 registry，然后提交模板构建。`--detach` 会返回供后续
+显式 watch 使用的 job ID：
+
+```bash
+cubemastercli tpl create-from-image \
+  --image "$REGISTRY_IMAGE" \
+  --writable-layer-size 4G \
+  --expose-port 49983 \
+  --probe 49983 \
+  --probe-path /health \
+  --cpu 2000 \
+  --memory 2048 \
+  --allow-internet-access=false \
+  --with-cube-ca=false \
+  --detach
+```
+
+保存输出的 `job_id` 和 `template_id`，等待全部目标节点的副本就绪：
+
+```bash
+cubemastercli tpl watch --job-id <job_id>
+cubemastercli tpl info --template-id <template_id> --json --include-request
+cubemastercli tpl render --template-id <template_id> --json
+```
+
+任务达到 `READY` 且 `distribution` 显示所有目标节点 ready 后再继续。检查保存和渲染后的
+请求，确认：
+
+- 只公开容器端口 49983；
+- 探针为 49983 上的 `GET /health`；
+- CPU 为 2000 millicores、内存为 2048 MB；
+- 可写层为 4 GiB；
+- 禁止访问互联网。
+
+模板级断网是纵深防御。包括从 snapshot 创建分支时，每个 Python 驱动也会显式传入
+`allow_internet_access=False`。
+
+## 3. 配置宿主端驱动
+
+```bash
+cd examples/postgresql-stateful-sandbox
+python3 -m venv .venv
+. .venv/bin/activate
+pip install -r requirements.txt
+cp .env.example .env
+```
+
+编辑 `.env`：
+
+```dotenv
+CUBE_API_URL=http://127.0.0.1:3000
+CUBE_TEMPLATE_ID=tpl-xxxxxxxxxxxxxxxx
+
+# 宿主机无法解析 Cube 沙箱通配域名时设置以下变量。
+# CUBE_PROXY_NODE_IP=<cube-proxy-node-ip>
+# CUBE_PROXY_PORT_HTTP=80
+# CUBE_SANDBOX_DOMAIN=cube.app
+```
+
+| 变量 | 必填 | 用途 |
+|---|:---:|---|
+| `CUBE_API_URL` | 是 | CubeAPI 控制面地址 |
+| `CUBE_TEMPLATE_ID` | 是 | 第 2 步生成的模板 ID |
+| `CUBE_PROXY_NODE_IP` | 否 | 直接连接 CubeProxy，不依赖通配域名解析 |
+| `CUBE_PROXY_PORT_HTTP` | 否 | CubeProxy HTTP 端口，默认 `80` |
+| `CUBE_SANDBOX_DOMAIN` | 否 | 沙箱路由域名，默认 `cube.app` |
+
+这些示例使用原生 `cubesandbox` SDK，而不是 E2B SDK，因此不需要 `E2B_API_URL` 或
+`E2B_API_KEY`。
+
+## 4. 运行三个流程
+
+在当前目录执行脚本。断言失败时脚本会抛出异常，只有全部检查通过后才打印一行 `OK:`。
+
+### 最小 SQL 与网络隔离
+
+```bash
+python smoke.py
+```
+
+脚本创建基线 schema、验证 PostgreSQL 16.14，并检查两条种子账户及余额总和 300。随后确认
+创建响应包含流量令牌、携带该令牌访问 envd health 返回 204，再确认访问 `example.com` 的
+出站请求失败、本地 SQL 仍可执行，并确认 TCP 5432 关闭。
+
+预期最后一行：
+
+```text
+OK: PostgreSQL template is ready and network isolation is enforced
+```
+
+### 恢复快照到新沙箱
+
+```bash
+python snapshot_restore.py
+```
+
+脚本加载基线，等待全部事务结束，执行 `CHECKPOINT` 并创建 snapshot。随后把两个账户的
+余额改为 0、增加 `poisoned` 列并验证破坏状态，再销毁源沙箱。脚本从 snapshot 创建一个
+新沙箱，并断言证明：
+
+- 恢复沙箱的 ID 与源沙箱不同；
+- 余额恢复为 100 和 200；
+- `poisoned` 列消失；
+- 显式创建的 snapshot 在清理阶段被删除。
+
+预期最后一行：
+
+```text
+OK: snapshot restored PostgreSQL data and schema in a new sandbox
+```
+
+### 隔离的 migration 分支
+
+```bash
+python migration_branches.py
+```
+
+脚本为源数据库创建检查点和一个 snapshot，然后销毁源沙箱。接着从同一个 snapshot 并行
+创建两个沙箱，并为每个分支完整应用入站和出站安全配置：
+
+- 分支 A 应用 `add_email.sql`；
+- 分支 B 应用 `add_last_login.sql`。
+
+两个分支都把各自的 migration 上传为 `/tmp/migration.sql`。断言会证明文件内容、schema
+字段和 `schema_migrations` 记录相互隔离。即使部分创建失败，清理逻辑也会先销毁所有已创建
+的子沙箱，再删除共享 snapshot。
+
+预期最后一行：
+
+```text
+OK: isolated PostgreSQL migration branches passed
+```
+
+脚本有意不调用 `Sandbox.clone()`：当前 helper 会用默认创建配置生成子沙箱。显式调用
+`Sandbox.create(template=snapshot_id, ...)` 可以确保每条分支都应用 timeout 和两项网络限制。
+
+## 快照一致性
+
+Cube snapshot 会捕获暂停后的 MicroVM 内存和文件系统。本示例把 `PGDATA` 与 `pg_wal`
+一起保存在 `/var/lib/postgresql/cube-data`，并避开上游镜像声明的 volume，确保完整数据库
+集群都包含在 snapshot 中。
+
+创建可复用数据库 snapshot 前，脚本会：
+
+1. 等待应用事务提交；
+2. 执行 PostgreSQL `CHECKPOINT`；
+3. 仅在 checkpoint 成功后调用 `create_snapshot()`。
+
+这样可以减少从 snapshot 启动恢复或创建分支后的 WAL 恢复工作，但不会让 Cube snapshot 变成生产
+备份或时间点恢复归档。不要把 `pg_wal` 移出 `PGDATA`、创建外部 tablespace，或在不同
+PostgreSQL 主版本之间复制这些 snapshot。
+
+Snapshot 的生命周期独立于源沙箱，并且可能包含敏感数据。`with Sandbox.create(...)` 只会
+销毁沙箱，不会删除 snapshot。因此，所有脚本都会显式调用 `Sandbox.delete_snapshot()`。
+
+## 资源建议
+
+| 资源 | 配置 | 说明 |
+|---|---:|---|
+| CPU | 2000 millicores | 每个沙箱 |
+| 内存 | 2048 MB | 每个沙箱；更大数据集或查询需要提高 |
+| 可写层 | 4 GiB | 保存 PostgreSQL 数据和 WAL |
+| 并行分支容量 | 至少 4 vCPU / 4 GiB | 两个 2-vCPU/2-GiB 分支，不含平台自身开销 |
+
+插入较大数据集时要监控可写层。除表和 WAL 外，PostgreSQL 还可能需要临时磁盘空间；每个
+保留的 snapshot 也会消耗持久化镜像存储。
+
+## 已知限制
+
+- 镜像只包含 PostgreSQL 16.14，目标架构为 `linux/amd64`。
+- 这是单节点临时开发数据库：不提供 HA、复制、PITR、外部 tablespace、TLS listener 或
+  PostgreSQL 原生入站访问。
+- 未创建 snapshot 就销毁沙箱会永久丢弃其状态。
+- Snapshot 只保证与当前镜像和 PostgreSQL 主版本兼容。
+- 构建镜像需要访问 registry/软件源；沙箱运行阶段有意保持断网。
+- Cube SDK 的 create、snapshot 等控制面操作目前不暴露独立的单次调用 timeout；
+  命令执行使用自己的有限 timeout。
+- 按设计，原生 TCP 客户端无法连接 5432；请使用 SDK 命令通道和本地 Unix Socket。
+
+## 排错
+
+| 现象 | 可能原因 | 处理 |
+|---|---|---|
+| Docker 构建在 Docker Hub/GHCR 镜像层长时间卡住 | Docker daemon 不会自动继承 shell 代理，或宿主 DNS/registry 直连路由异常 | 配置 Docker daemon 代理或 registry mirror；也可以预拉取两个基础镜像并打成本地标签。若 `apt` 同样需要宿主代理，请传入小写 `http_proxy`/`https_proxy` build args，并选择合适的 build network mode |
+| Docker health 一直为 `starting` 或变为 `unhealthy` | PostgreSQL 未初始化、socket 权限错误或 envd 未启动 | 执行 `docker logs cubesandbox-postgresql-stateful`；确认以 `postgres` 运行 `pg_isready` 可以成功 |
+| 模板构建的探针超时 | 端口/路径不匹配，或 PostgreSQL 未能在探针窗口内就绪 | 公开并探测 49983 的 `/health`；检查镜像 job 和 Cubelet 日志 |
+| 模板为 `READY`，但 distribution 未完成 | 一个或多个目标节点还没有收到 artifact | 等待后重新运行 `tpl info`；检查对应 Cubelet 的镜像/存储日志 |
+| 手动 envd 请求被拒绝 | 请求没有携带该沙箱的流量令牌 | 复用 create 返回的 `Sandbox` 对象；手动 HTTP 请求需携带其流量令牌 header |
+| SDK 无法解析 `*.cube.app` | 宿主机无法解析沙箱通配域名 | 设置 `CUBE_PROXY_NODE_IP`，必要时同时设置 `CUBE_PROXY_PORT_HTTP` |
+| 已设置 `HTTP_PROXY`/`HTTPS_PROXY` 时，本地 CubeAPI 请求返回 HTTP 502 | 指向回环地址的控制面请求被错误送入宿主代理 | 把 `127.0.0.1`、`localhost` 和 CubeProxy 节点 IP 同时加入 `NO_PROXY` 与 `no_proxy` |
+| `psql: Peer authentication failed` | 命令使用了错误的系统用户 | 使用示例 helper，或传入 `user="postgres"` |
+| `pg_isready -h 127.0.0.1` 失败 | 无需处理，这是预期的安全配置 | 改用 `-h /var/run/postgresql` |
+| `No space left on device` | 4-GiB 可写层已满 | 删除测试数据/snapshot，或用更大的可写层重建模板 |
+| 脚本未打印最终 `OK:` 就退出 | 断言或平台调用失败 | 查看输出的命令 stdout/stderr，再列出 sandbox 和 snapshot 确认清理结果 |
+
+## 验收清单
+
+请在实际评审该贡献的环境中执行以下检查；本文档不声称某个外部集群已经通过这些检查。
+
+```bash
+python3 -m compileall examples/postgresql-stateful-sandbox
+ruff check examples/postgresql-stateful-sandbox
+shellcheck examples/postgresql-stateful-sandbox/*.sh
+git diff --check
+
+npm --prefix docs ci
+npm --prefix docs run docs:build
+```
+
+此外，还必须完成第 1 步的本地镜像检查、让模板达到 `READY` 且全部节点分发完成、运行三个
+Python 脚本，并比较运行前后的 sandbox/snapshot 列表，确认没有资源泄漏。
+
+## 参考
+
+- [从 OCI 镜像创建模板](../../docs/zh/guide/tutorials/template-from-image.md)
+- [连接已有 Cube 集群](../../docs/zh/guide/connect-existing-cluster.md)
+- [快照、回滚与克隆](../../docs/zh/guide/snapshot-rollback-clone.md)
+- [网络策略](../../docs/zh/guide/network-policy.md)
+- [限制公网访问](../../docs/zh/guide/restrict-public-access.md)
+- [PostgreSQL 文件系统备份一致性](https://www.postgresql.org/docs/16/backup-file.html)
+- [PostgreSQL `CHECKPOINT`](https://www.postgresql.org/docs/16/sql-checkpoint.html)

--- a/examples/postgresql-stateful-sandbox/cube-entrypoint.sh
+++ b/examples/postgresql-stateful-sandbox/cube-entrypoint.sh
@@ -1,0 +1,103 @@
+#!/bin/sh
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# Start envd beside the foreground PostgreSQL process and wait for PostgreSQL
+# to finish shutting down before the container exits. The generic entrypoint in
+# cubesandbox-base forwards stop signals, but its interrupted wait can return
+# before PostgreSQL has completed its fast shutdown.
+
+set -eu
+
+ENVD_BIN="${ENVD_BIN:-/usr/bin/envd}"
+ENVD_PORT="${ENVD_PORT:-49983}"
+ENVD_LOG_FILE="${ENVD_LOG_FILE:-/var/log/envd.log}"
+ENVD_EXTRA_ARGS="${ENVD_EXTRA_ARGS:-}"
+
+if [ ! -x "${ENVD_BIN}" ]; then
+    echo "cube-entrypoint: envd binary not found or not executable at ${ENVD_BIN}" >&2
+    exit 127
+fi
+
+start_envd() {
+    # shellcheck disable=SC2086
+    if [ "${ENVD_LOG_FILE}" = "-" ]; then
+        "${ENVD_BIN}" -port "${ENVD_PORT}" ${ENVD_EXTRA_ARGS} &
+    else
+        mkdir -p "$(dirname "${ENVD_LOG_FILE}")"
+        "${ENVD_BIN}" -port "${ENVD_PORT}" ${ENVD_EXTRA_ARGS} \
+            >>"${ENVD_LOG_FILE}" 2>&1 &
+    fi
+    ENVD_PID=$!
+    echo "cube-entrypoint: started envd (pid=${ENVD_PID}) on port ${ENVD_PORT}" >&2
+}
+
+stop_envd() {
+    if kill -0 "${ENVD_PID}" 2>/dev/null; then
+        kill -TERM "${ENVD_PID}" 2>/dev/null || true
+    fi
+    wait "${ENVD_PID}" 2>/dev/null || true
+}
+
+start_envd
+
+if [ "$#" -eq 0 ]; then
+    trap 'stop_envd; exit 0' TERM INT
+    wait "${ENVD_PID}"
+    exit $?
+fi
+
+USER_PID=""
+
+# Invoked by the TERM/INT traps below.
+# shellcheck disable=SC2329
+shutdown() {
+    signal="$1"
+    trap - TERM INT HUP
+
+    if [ -n "${USER_PID}" ] && kill -0 "${USER_PID}" 2>/dev/null; then
+        kill -s "${signal}" "${USER_PID}" 2>/dev/null || true
+        set +e
+        wait "${USER_PID}"
+        rc=$?
+        set -e
+    else
+        rc=0
+    fi
+
+    stop_envd
+    exit "${rc}"
+}
+
+# Invoked by the HUP trap below.
+# shellcheck disable=SC2329
+forward_hup() {
+    if [ -n "${USER_PID}" ]; then
+        kill -HUP "${USER_PID}" 2>/dev/null || true
+    fi
+}
+
+trap 'shutdown TERM' TERM
+trap 'shutdown INT' INT
+trap 'forward_hup' HUP
+
+"$@" &
+USER_PID=$!
+echo "cube-entrypoint: exec user command (pid=${USER_PID}): $*" >&2
+
+# A non-terminating signal such as HUP interrupts wait(1). Keep waiting while
+# the PostgreSQL process is still alive instead of treating that interruption
+# as the process exit status.
+while true; do
+    set +e
+    wait "${USER_PID}"
+    rc=$?
+    set -e
+    if kill -0 "${USER_PID}" 2>/dev/null; then
+        continue
+    fi
+    break
+done
+
+stop_envd
+exit "${rc}"

--- a/examples/postgresql-stateful-sandbox/cube-entrypoint.sh
+++ b/examples/postgresql-stateful-sandbox/cube-entrypoint.sh
@@ -2,30 +2,50 @@
 # Copyright (c) 2026 Tencent Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-# Start envd beside the foreground PostgreSQL process and wait for PostgreSQL
-# to finish shutting down before the container exits. The generic entrypoint in
-# cubesandbox-base forwards stop signals, but its interrupted wait can return
-# before PostgreSQL has completed its fast shutdown.
+# Supervise envd beside the PostgreSQL process. Both children are reaped, envd
+# startup failures stop PostgreSQL, and TERM/INT wait for PostgreSQL to complete
+# its fast shutdown before the container exits.
 
 set -eu
 
 ENVD_BIN="${ENVD_BIN:-/usr/bin/envd}"
 ENVD_PORT="${ENVD_PORT:-49983}"
 ENVD_LOG_FILE="${ENVD_LOG_FILE:-/var/log/envd.log}"
-ENVD_EXTRA_ARGS="${ENVD_EXTRA_ARGS:-}"
+
+ENVD_PID=""
+USER_PID=""
+PENDING_SIGNAL=""
+WAIT_STATUS=0
 
 if [ ! -x "${ENVD_BIN}" ]; then
     echo "cube-entrypoint: envd binary not found or not executable at ${ENVD_BIN}" >&2
     exit 127
 fi
 
+child_is_running() {
+    [ -n "$1" ] && kill -0 "$1" 2>/dev/null
+}
+
+wait_for_child() {
+    wait_child_pid="$1"
+    while true; do
+        set +e
+        wait "${wait_child_pid}"
+        WAIT_STATUS=$?
+        set -e
+        if child_is_running "${wait_child_pid}"; then
+            continue
+        fi
+        return
+    done
+}
+
 start_envd() {
-    # shellcheck disable=SC2086
     if [ "${ENVD_LOG_FILE}" = "-" ]; then
-        "${ENVD_BIN}" -port "${ENVD_PORT}" ${ENVD_EXTRA_ARGS} &
+        "${ENVD_BIN}" -port "${ENVD_PORT}" &
     else
         mkdir -p "$(dirname "${ENVD_LOG_FILE}")"
-        "${ENVD_BIN}" -port "${ENVD_PORT}" ${ENVD_EXTRA_ARGS} \
+        "${ENVD_BIN}" -port "${ENVD_PORT}" \
             >>"${ENVD_LOG_FILE}" 2>&1 &
     fi
     ENVD_PID=$!
@@ -33,34 +53,67 @@ start_envd() {
 }
 
 stop_envd() {
-    if kill -0 "${ENVD_PID}" 2>/dev/null; then
+    if [ -z "${ENVD_PID}" ]; then
+        return
+    fi
+    if child_is_running "${ENVD_PID}"; then
         kill -TERM "${ENVD_PID}" 2>/dev/null || true
     fi
-    wait "${ENVD_PID}" 2>/dev/null || true
+    wait_for_child "${ENVD_PID}"
+    ENVD_PID=""
 }
+
+queue_signal() {
+    queued_signal="$1"
+    case "${PENDING_SIGNAL}:${queued_signal}" in
+        TERM:*|INT:*)
+            ;;
+        *:TERM|*:INT)
+            PENDING_SIGNAL="${queued_signal}"
+            ;;
+        *)
+            PENDING_SIGNAL="${queued_signal}"
+            ;;
+    esac
+}
+
+# Install queueing traps before either child is launched. POSIX sh cannot block
+# signals around "$@" and "$!" atomically, so a signal received during startup
+# is handled after the child PID has been recorded.
+trap 'queue_signal TERM' TERM
+trap 'queue_signal INT' INT
+trap 'queue_signal HUP' HUP
 
 start_envd
 
 if [ "$#" -eq 0 ]; then
     trap 'stop_envd; exit 0' TERM INT
-    wait "${ENVD_PID}"
-    exit $?
+    trap ':' HUP
+    case "${PENDING_SIGNAL}" in
+        TERM|INT)
+            stop_envd
+            exit 0
+            ;;
+    esac
+    wait_for_child "${ENVD_PID}"
+    rc=${WAIT_STATUS}
+    ENVD_PID=""
+    exit "${rc}"
 fi
-
-USER_PID=""
 
 # Invoked by the TERM/INT traps below.
 # shellcheck disable=SC2329
 shutdown() {
-    signal="$1"
-    trap - TERM INT HUP
+    shutdown_signal="$1"
+    trap '' TERM INT HUP
 
-    if [ -n "${USER_PID}" ] && kill -0 "${USER_PID}" 2>/dev/null; then
-        kill -s "${signal}" "${USER_PID}" 2>/dev/null || true
-        set +e
-        wait "${USER_PID}"
-        rc=$?
-        set -e
+    if [ -n "${USER_PID}" ]; then
+        if child_is_running "${USER_PID}"; then
+            kill -s "${shutdown_signal}" "${USER_PID}" 2>/dev/null || true
+        fi
+        wait_for_child "${USER_PID}"
+        rc=${WAIT_STATUS}
+        USER_PID=""
     else
         rc=0
     fi
@@ -72,32 +125,63 @@ shutdown() {
 # Invoked by the HUP trap below.
 # shellcheck disable=SC2329
 forward_hup() {
-    if [ -n "${USER_PID}" ]; then
+    if child_is_running "${USER_PID}"; then
         kill -HUP "${USER_PID}" 2>/dev/null || true
     fi
 }
 
-trap 'shutdown TERM' TERM
-trap 'shutdown INT' INT
-trap 'forward_hup' HUP
+case "${PENDING_SIGNAL}" in
+    TERM|INT)
+        stop_envd
+        exit 0
+        ;;
+esac
 
 "$@" &
 USER_PID=$!
 echo "cube-entrypoint: exec user command (pid=${USER_PID}): $*" >&2
 
-# A non-terminating signal such as HUP interrupts wait(1). Keep waiting while
-# the PostgreSQL process is still alive instead of treating that interruption
-# as the process exit status.
-while true; do
-    set +e
-    wait "${USER_PID}"
-    rc=$?
-    set -e
-    if kill -0 "${USER_PID}" 2>/dev/null; then
-        continue
-    fi
-    break
+trap 'shutdown TERM' TERM
+trap 'shutdown INT' INT
+trap 'forward_hup' HUP
+
+startup_signal=${PENDING_SIGNAL}
+PENDING_SIGNAL=""
+case "${startup_signal}" in
+    TERM|INT)
+        shutdown "${startup_signal}"
+        ;;
+    HUP)
+        forward_hup
+        ;;
+esac
+
+# dash has no portable wait -n. Poll both children, then reap whichever owns
+# the lifecycle transition. A one-second interval is sufficient for startup
+# failure propagation without introducing a shell-specific dependency.
+while child_is_running "${USER_PID}" && child_is_running "${ENVD_PID}"; do
+    sleep 1 || true
 done
 
-stop_envd
-exit "${rc}"
+if ! child_is_running "${USER_PID}"; then
+    wait_for_child "${USER_PID}"
+    rc=${WAIT_STATUS}
+    USER_PID=""
+    stop_envd
+    exit "${rc}"
+fi
+
+# envd exited while the user command (normally PostgreSQL) was still running.
+# Preserve a non-zero envd status and make an unexpected clean exit fail too.
+wait_for_child "${ENVD_PID}"
+envd_rc=${WAIT_STATUS}
+ENVD_PID=""
+if [ "${envd_rc}" -eq 0 ]; then
+    envd_rc=1
+fi
+echo "cube-entrypoint: envd exited unexpectedly with status ${envd_rc}" >&2
+
+kill -TERM "${USER_PID}" 2>/dev/null || true
+wait_for_child "${USER_PID}"
+USER_PID=""
+exit "${envd_rc}"

--- a/examples/postgresql-stateful-sandbox/env_utils.py
+++ b/examples/postgresql-stateful-sandbox/env_utils.py
@@ -1,0 +1,38 @@
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Environment helpers shared by the PostgreSQL examples."""
+
+import os
+from pathlib import Path
+
+from dotenv import load_dotenv
+
+
+def load_local_dotenv() -> None:
+    """Load the nearest example ``.env`` without overriding real variables."""
+    candidate_paths = [
+        Path(__file__).with_name(".env"),
+        Path.cwd() / ".env",
+    ]
+
+    seen_paths = set()
+    for path in candidate_paths:
+        resolved_path = path.resolve()
+        if resolved_path in seen_paths:
+            continue
+        seen_paths.add(resolved_path)
+
+        if path.is_file():
+            load_dotenv(dotenv_path=path, override=False)
+            return
+
+
+def require_env(name: str) -> str:
+    """Return a required environment variable or raise a useful error."""
+    value = os.environ.get(name, "").strip()
+    if not value:
+        raise RuntimeError(
+            f"{name} is required. Copy .env.example to .env and set it first."
+        )
+    return value

--- a/examples/postgresql-stateful-sandbox/env_utils.py
+++ b/examples/postgresql-stateful-sandbox/env_utils.py
@@ -16,13 +16,7 @@ def load_local_dotenv() -> None:
         Path.cwd() / ".env",
     ]
 
-    seen_paths = set()
     for path in candidate_paths:
-        resolved_path = path.resolve()
-        if resolved_path in seen_paths:
-            continue
-        seen_paths.add(resolved_path)
-
         if path.is_file():
             load_dotenv(dotenv_path=path, override=False)
             return

--- a/examples/postgresql-stateful-sandbox/migration_branches.py
+++ b/examples/postgresql-stateful-sandbox/migration_branches.py
@@ -1,0 +1,237 @@
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Run two isolated PostgreSQL schema migrations from one CubeSnapshot."""
+
+from concurrent.futures import Future, ThreadPoolExecutor, as_completed
+from pathlib import Path
+from typing import Optional
+
+from cubesandbox import Config, Sandbox
+from env_utils import load_local_dotenv
+from postgres_utils import (
+    POSTGRES_USER,
+    apply_sql_file,
+    checkpoint,
+    create_secure_sandbox,
+    cube_config,
+    delete_snapshot,
+    kill_sandbox,
+    sql,
+    wait_for_postgres,
+    wait_for_snapshot,
+)
+
+EXAMPLE_DIR = Path(__file__).resolve().parent
+REMOTE_MIGRATION_PATH = "/tmp/migration.sql"
+
+
+def create_branches(
+    snapshot_id: str,
+    config: Config,
+    branches: dict[str, Sandbox],
+) -> None:
+    """Populate a caller-owned map so partial branches remain cleanable."""
+    first_error: Optional[BaseException] = None
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        futures: dict[Future, str] = {
+            executor.submit(
+                create_secure_sandbox,
+                snapshot_id,
+                config=config,
+            ): branch_name
+            for branch_name in ("email", "last_login")
+        }
+        for future in as_completed(futures):
+            branch_name = futures[future]
+            try:
+                branches[branch_name] = future.result()
+                print(f"{branch_name} branch: {branches[branch_name].sandbox_id}")
+            except BaseException as exc:  # noqa: BLE001 - collect sibling result
+                if first_error is None:
+                    first_error = exc
+
+    if first_error is not None:
+        raise first_error
+
+
+def run_migration(sandbox: Sandbox, local_path: Path) -> str:
+    """Apply one migration and return the uploaded file for isolation checks."""
+    wait_for_postgres(sandbox)
+    apply_sql_file(
+        sandbox,
+        local_path,
+        remote_path=REMOTE_MIGRATION_PATH,
+    )
+    return sandbox.files.read(REMOTE_MIGRATION_PATH, user=POSTGRES_USER)
+
+
+def assert_branch_state(
+    sandbox: Sandbox,
+    *,
+    expected_column: str,
+    expected_migration: str,
+) -> None:
+    """Assert one branch contains only its own schema and migration record."""
+    inherited_rows = sql(
+        sandbox,
+        "SELECT owner || ':' || balance::text FROM accounts ORDER BY owner;",
+    )
+    if inherited_rows != "alice:100\nbob:200":
+        raise AssertionError(f"branch inherited unexpected rows: {inherited_rows!r}")
+
+    columns = sql(
+        sandbox,
+        """
+        SELECT column_name
+        FROM information_schema.columns
+        WHERE table_schema = 'public'
+          AND table_name = 'accounts'
+          AND column_name IN ('email', 'last_login_at')
+        ORDER BY column_name;
+        """,
+    )
+    if columns != expected_column:
+        raise AssertionError(
+            f"expected only column {expected_column!r}, got {columns!r}"
+        )
+
+    migrations = sql(
+        sandbox,
+        """
+        SELECT string_agg(
+            version,
+            ',' ORDER BY CASE WHEN version = 'base_v1' THEN 0 ELSE 1 END
+        )
+        FROM schema_migrations;
+        """,
+    )
+    expected = f"base_v1,{expected_migration}"
+    if migrations != expected:
+        raise AssertionError(f"expected migrations {expected!r}, got {migrations!r}")
+
+
+def cleanup_resources(
+    source: Optional[Sandbox],
+    branches: dict[str, Sandbox],
+    snapshot_id: Optional[str],
+    config: Config,
+) -> None:
+    """Attempt every cleanup in dependency order and report any failures."""
+    cleanup_errors: list[BaseException] = []
+    for branch in branches.values():
+        try:
+            kill_sandbox(branch)
+        except BaseException as exc:  # noqa: BLE001 - attempt every cleanup
+            cleanup_errors.append(exc)
+
+    if source is not None:
+        try:
+            kill_sandbox(source)
+        except BaseException as exc:  # noqa: BLE001 - snapshot must still be tried
+            cleanup_errors.append(exc)
+
+    if snapshot_id is not None:
+        try:
+            delete_snapshot(snapshot_id, config=config)
+            wait_for_snapshot(snapshot_id, config=config, present=False)
+        except BaseException as exc:  # noqa: BLE001 - include cleanup failure
+            cleanup_errors.append(exc)
+
+    if cleanup_errors:
+        details = "; ".join(
+            f"{type(error).__name__}: {error}" for error in cleanup_errors
+        )
+        raise RuntimeError(f"resource cleanup failed: {details}") from cleanup_errors[0]
+
+
+def main() -> None:
+    load_local_dotenv()
+    config = cube_config()
+    source: Optional[Sandbox] = None
+    branches: dict[str, Sandbox] = {}
+    snapshot_id: Optional[str] = None
+
+    try:
+        source = create_secure_sandbox(config=config)
+        source_id = source.sandbox_id
+        print(f"source sandbox: {source_id}")
+        wait_for_postgres(source)
+        apply_sql_file(source, EXAMPLE_DIR / "sql" / "base_schema.sql")
+
+        source_columns = sql(
+            source,
+            """
+            SELECT count(*)
+            FROM information_schema.columns
+            WHERE table_schema = 'public'
+              AND table_name = 'accounts'
+              AND column_name IN ('email', 'last_login_at');
+            """,
+        )
+        if source_columns != "0":
+            raise AssertionError("source unexpectedly contains a branch migration")
+
+        checkpoint(source)
+        snapshot = source.create_snapshot()
+        snapshot_id = snapshot.snapshot_id
+        if not snapshot_id:
+            raise RuntimeError("snapshot creation returned an empty snapshot ID")
+        print(f"snapshot: {snapshot_id}")
+        wait_for_snapshot(
+            snapshot_id,
+            config=config,
+            present=True,
+            sandbox_id=source_id,
+        )
+
+        kill_sandbox(source)
+        source = None
+
+        create_branches(snapshot_id, config, branches)
+        branch_ids = {branch.sandbox_id for branch in branches.values()}
+        if len(branch_ids) != 2 or source_id in branch_ids:
+            raise AssertionError("source and branch sandboxes do not have distinct IDs")
+
+        email_path = EXAMPLE_DIR / "sql" / "add_email.sql"
+        last_login_path = EXAMPLE_DIR / "sql" / "add_last_login.sql"
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            email_future = executor.submit(
+                run_migration,
+                branches["email"],
+                email_path,
+            )
+            last_login_future = executor.submit(
+                run_migration,
+                branches["last_login"],
+                last_login_path,
+            )
+            uploaded_email = email_future.result()
+            uploaded_last_login = last_login_future.result()
+
+        if uploaded_email != email_path.read_text(encoding="utf-8"):
+            raise AssertionError("email branch migration file changed after upload")
+        if uploaded_last_login != last_login_path.read_text(encoding="utf-8"):
+            raise AssertionError("last-login branch migration file changed after upload")
+        if uploaded_email == uploaded_last_login:
+            raise AssertionError("branch migration files unexpectedly have identical content")
+
+        assert_branch_state(
+            branches["email"],
+            expected_column="email",
+            expected_migration="add_email",
+        )
+        assert_branch_state(
+            branches["last_login"],
+            expected_column="last_login_at",
+            expected_migration="add_last_login",
+        )
+    finally:
+        cleanup_resources(source, branches, snapshot_id, config)
+
+    print("OK: isolated PostgreSQL migration branches passed")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/postgresql-stateful-sandbox/migration_branches.py
+++ b/examples/postgresql-stateful-sandbox/migration_branches.py
@@ -32,7 +32,7 @@ def create_branches(
     branches: dict[str, Sandbox],
 ) -> None:
     """Populate a caller-owned map so partial branches remain cleanable."""
-    first_error: Optional[BaseException] = None
+    first_error: Optional[Exception] = None
 
     with ThreadPoolExecutor(max_workers=2) as executor:
         futures: dict[Future, str] = {
@@ -48,7 +48,7 @@ def create_branches(
             try:
                 branches[branch_name] = future.result()
                 print(f"{branch_name} branch: {branches[branch_name].sandbox_id}")
-            except BaseException as exc:  # noqa: BLE001 - collect sibling result
+            except Exception as exc:  # noqa: BLE001 - collect sibling result
                 if first_error is None:
                     first_error = exc
 
@@ -65,6 +65,40 @@ def run_migration(sandbox: Sandbox, local_path: Path) -> str:
         remote_path=REMOTE_MIGRATION_PATH,
     )
     return sandbox.files.read(REMOTE_MIGRATION_PATH, user=POSTGRES_USER)
+
+
+def run_branch_migrations(
+    branches: dict[str, Sandbox],
+    migration_paths: dict[str, Path],
+) -> dict[str, str]:
+    """Run every branch migration and report all observed task failures."""
+    uploaded_files: dict[str, str] = {}
+    errors: list[tuple[str, Exception]] = []
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        futures: dict[Future, str] = {
+            executor.submit(
+                run_migration,
+                branches[branch_name],
+                migration_path,
+            ): branch_name
+            for branch_name, migration_path in migration_paths.items()
+        }
+        for future in as_completed(futures):
+            branch_name = futures[future]
+            try:
+                uploaded_files[branch_name] = future.result()
+            except Exception as exc:  # noqa: BLE001 - observe every sibling task
+                errors.append((branch_name, exc))
+
+    if errors:
+        details = "; ".join(
+            f"{branch_name}: {type(error).__name__}: {error}"
+            for branch_name, error in errors
+        )
+        raise RuntimeError(f"branch migration failed: {details}") from errors[0][1]
+
+    return uploaded_files
 
 
 def assert_branch_state(
@@ -102,7 +136,8 @@ def assert_branch_state(
         """
         SELECT string_agg(
             version,
-            ',' ORDER BY CASE WHEN version = 'base_v1' THEN 0 ELSE 1 END
+            ',' ORDER BY CASE WHEN version = 'base_v1' THEN 0 ELSE 1 END,
+            version
         )
         FROM schema_migrations;
         """,
@@ -119,24 +154,24 @@ def cleanup_resources(
     config: Config,
 ) -> None:
     """Attempt every cleanup in dependency order and report any failures."""
-    cleanup_errors: list[BaseException] = []
+    cleanup_errors: list[Exception] = []
     for branch in branches.values():
         try:
             kill_sandbox(branch)
-        except BaseException as exc:  # noqa: BLE001 - attempt every cleanup
+        except Exception as exc:  # noqa: BLE001 - attempt every cleanup
             cleanup_errors.append(exc)
 
     if source is not None:
         try:
             kill_sandbox(source)
-        except BaseException as exc:  # noqa: BLE001 - snapshot must still be tried
+        except Exception as exc:  # noqa: BLE001 - snapshot must still be tried
             cleanup_errors.append(exc)
 
     if snapshot_id is not None:
         try:
             delete_snapshot(snapshot_id, config=config)
             wait_for_snapshot(snapshot_id, config=config, present=False)
-        except BaseException as exc:  # noqa: BLE001 - include cleanup failure
+        except Exception as exc:  # noqa: BLE001 - include cleanup failure
             cleanup_errors.append(exc)
 
     if cleanup_errors:
@@ -196,19 +231,15 @@ def main() -> None:
 
         email_path = EXAMPLE_DIR / "sql" / "add_email.sql"
         last_login_path = EXAMPLE_DIR / "sql" / "add_last_login.sql"
-        with ThreadPoolExecutor(max_workers=2) as executor:
-            email_future = executor.submit(
-                run_migration,
-                branches["email"],
-                email_path,
-            )
-            last_login_future = executor.submit(
-                run_migration,
-                branches["last_login"],
-                last_login_path,
-            )
-            uploaded_email = email_future.result()
-            uploaded_last_login = last_login_future.result()
+        uploaded_files = run_branch_migrations(
+            branches,
+            {
+                "email": email_path,
+                "last_login": last_login_path,
+            },
+        )
+        uploaded_email = uploaded_files["email"]
+        uploaded_last_login = uploaded_files["last_login"]
 
         if uploaded_email != email_path.read_text(encoding="utf-8"):
             raise AssertionError("email branch migration file changed after upload")

--- a/examples/postgresql-stateful-sandbox/migration_branches.py
+++ b/examples/postgresql-stateful-sandbox/migration_branches.py
@@ -32,7 +32,7 @@ def create_branches(
     branches: dict[str, Sandbox],
 ) -> None:
     """Populate a caller-owned map so partial branches remain cleanable."""
-    first_error: Optional[Exception] = None
+    errors: list[tuple[str, Exception]] = []
 
     with ThreadPoolExecutor(max_workers=2) as executor:
         futures: dict[Future, str] = {
@@ -49,11 +49,14 @@ def create_branches(
                 branches[branch_name] = future.result()
                 print(f"{branch_name} branch: {branches[branch_name].sandbox_id}")
             except Exception as exc:  # noqa: BLE001 - collect sibling result
-                if first_error is None:
-                    first_error = exc
+                errors.append((branch_name, exc))
 
-    if first_error is not None:
-        raise first_error
+    if errors:
+        details = "; ".join(
+            f"{branch_name}: {type(error).__name__}: {error}"
+            for branch_name, error in errors
+        )
+        raise RuntimeError(f"branch creation failed: {details}") from errors[0][1]
 
 
 def run_migration(sandbox: Sandbox, local_path: Path) -> str:
@@ -104,16 +107,18 @@ def run_branch_migrations(
 def assert_branch_state(
     sandbox: Sandbox,
     *,
+    branch_name: str,
     expected_column: str,
     expected_migration: str,
 ) -> None:
     """Assert one branch contains only its own schema and migration record."""
+    context = f"branch {branch_name!r} (sandbox {sandbox.sandbox_id})"
     inherited_rows = sql(
         sandbox,
         "SELECT owner || ':' || balance::text FROM accounts ORDER BY owner;",
     )
     if inherited_rows != "alice:100\nbob:200":
-        raise AssertionError(f"branch inherited unexpected rows: {inherited_rows!r}")
+        raise AssertionError(f"{context} inherited unexpected rows: {inherited_rows!r}")
 
     columns = sql(
         sandbox,
@@ -128,7 +133,7 @@ def assert_branch_state(
     )
     if columns != expected_column:
         raise AssertionError(
-            f"expected only column {expected_column!r}, got {columns!r}"
+            f"{context} expected only column {expected_column!r}, got {columns!r}"
         )
 
     migrations = sql(
@@ -144,7 +149,9 @@ def assert_branch_state(
     )
     expected = f"base_v1,{expected_migration}"
     if migrations != expected:
-        raise AssertionError(f"expected migrations {expected!r}, got {migrations!r}")
+        raise AssertionError(
+            f"{context} expected migrations {expected!r}, got {migrations!r}"
+        )
 
 
 def cleanup_resources(
@@ -242,19 +249,29 @@ def main() -> None:
         uploaded_last_login = uploaded_files["last_login"]
 
         if uploaded_email != email_path.read_text(encoding="utf-8"):
-            raise AssertionError("email branch migration file changed after upload")
+            raise AssertionError(
+                "email branch "
+                f"(sandbox {branches['email'].sandbox_id}) migration file "
+                "changed after upload"
+            )
         if uploaded_last_login != last_login_path.read_text(encoding="utf-8"):
-            raise AssertionError("last-login branch migration file changed after upload")
+            raise AssertionError(
+                "last-login branch "
+                f"(sandbox {branches['last_login'].sandbox_id}) migration file "
+                "changed after upload"
+            )
         if uploaded_email == uploaded_last_login:
             raise AssertionError("branch migration files unexpectedly have identical content")
 
         assert_branch_state(
             branches["email"],
+            branch_name="email",
             expected_column="email",
             expected_migration="add_email",
         )
         assert_branch_state(
             branches["last_login"],
+            branch_name="last_login",
             expected_column="last_login_at",
             expected_migration="add_last_login",
         )

--- a/examples/postgresql-stateful-sandbox/postgres-ready-envd.sh
+++ b/examples/postgresql-stateful-sandbox/postgres-ready-envd.sh
@@ -16,6 +16,7 @@ esac
 
 elapsed=0
 until gosu postgres pg_isready -q \
+    --timeout=1 \
     -h "${POSTGRES_SOCKET_DIR}" -U postgres -d postgres; do
     if [ "${elapsed}" -ge "${POSTGRES_READY_TIMEOUT}" ]; then
         echo "postgres-ready-envd: PostgreSQL was not ready after ${POSTGRES_READY_TIMEOUT}s" >&2

--- a/examples/postgresql-stateful-sandbox/postgres-ready-envd.sh
+++ b/examples/postgresql-stateful-sandbox/postgres-ready-envd.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+set -eu
+
+POSTGRES_SOCKET_DIR="${POSTGRES_SOCKET_DIR:-/var/run/postgresql}"
+POSTGRES_READY_TIMEOUT="${POSTGRES_READY_TIMEOUT:-60}"
+
+case "${POSTGRES_READY_TIMEOUT}" in
+    ''|*[!0-9]*)
+        echo "postgres-ready-envd: POSTGRES_READY_TIMEOUT must be a non-negative integer" >&2
+        exit 2
+        ;;
+esac
+
+elapsed=0
+until gosu postgres pg_isready -q \
+    -h "${POSTGRES_SOCKET_DIR}" -U postgres -d postgres; do
+    if [ "${elapsed}" -ge "${POSTGRES_READY_TIMEOUT}" ]; then
+        echo "postgres-ready-envd: PostgreSQL was not ready after ${POSTGRES_READY_TIMEOUT}s" >&2
+        exit 1
+    fi
+
+    sleep 1
+    elapsed=$((elapsed + 1))
+done
+
+echo "postgres-ready-envd: PostgreSQL is ready; starting envd" >&2
+exec /usr/bin/envd "$@"

--- a/examples/postgresql-stateful-sandbox/postgres_utils.py
+++ b/examples/postgresql-stateful-sandbox/postgres_utils.py
@@ -237,4 +237,6 @@ def delete_snapshot(snapshot_id: str, *, config: Config) -> None:
     try:
         Sandbox.delete_snapshot(snapshot_id, config=config)
     except TemplateNotFoundError:
+        # Cube stores snapshots as templates, and the SDK maps a missing
+        # snapshot deletion (DELETE /templates/:id) to this exception.
         pass

--- a/examples/postgresql-stateful-sandbox/postgres_utils.py
+++ b/examples/postgresql-stateful-sandbox/postgres_utils.py
@@ -1,0 +1,238 @@
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared CubeSandbox and PostgreSQL helpers for the stateful examples."""
+
+import shlex
+import time
+from pathlib import Path
+from typing import Optional
+
+from cubesandbox import (
+    CommandResult,
+    Config,
+    Sandbox,
+    SandboxNotFoundError,
+    TemplateNotFoundError,
+)
+from env_utils import require_env
+
+POSTGRES_DATABASE = "postgres"
+POSTGRES_SOCKET_DIRECTORY = "/var/run/postgresql"
+POSTGRES_USER = "postgres"
+SANDBOX_TIMEOUT_SECONDS = 600
+DEFAULT_COMMAND_TIMEOUT_SECONDS = 60.0
+DEFAULT_READY_TIMEOUT_SECONDS = 60.0
+
+
+def cube_config() -> Config:
+    """Build SDK configuration after validating the two required variables."""
+    return Config(
+        api_url=require_env("CUBE_API_URL"),
+        template_id=require_env("CUBE_TEMPLATE_ID"),
+    )
+
+
+def create_secure_sandbox(
+    template: Optional[str] = None,
+    *,
+    config: Optional[Config] = None,
+) -> Sandbox:
+    """Create a sandbox with outbound internet and public ingress disabled."""
+    sdk_config = config or Config()
+    template_id = template or sdk_config.template_id or require_env("CUBE_TEMPLATE_ID")
+    return Sandbox.create(
+        template=template_id,
+        timeout=SANDBOX_TIMEOUT_SECONDS,
+        allow_internet_access=False,
+        network={"allow_public_traffic": False},
+        config=sdk_config,
+    )
+
+
+def run_checked(
+    sandbox: Sandbox,
+    command: str,
+    *,
+    timeout: float = DEFAULT_COMMAND_TIMEOUT_SECONDS,
+    user: str = POSTGRES_USER,
+    cwd: Optional[str] = None,
+) -> CommandResult:
+    """Run a command and turn a non-zero process result into an exception."""
+    result = sandbox.commands.run(
+        command,
+        timeout=timeout,
+        user=user,
+        cwd=cwd,
+    )
+    if result.exit_code != 0:
+        raise RuntimeError(
+            "command failed with exit code "
+            f"{result.exit_code}: {command}\n"
+            f"stdout:\n{result.stdout.rstrip()}\n"
+            f"stderr:\n{result.stderr.rstrip()}"
+        )
+    return result
+
+
+def wait_for_postgres(
+    sandbox: Sandbox,
+    *,
+    timeout: float = DEFAULT_READY_TIMEOUT_SECONDS,
+) -> None:
+    """Wait until PostgreSQL accepts connections through its Unix socket."""
+    deadline = time.monotonic() + timeout
+    last_detail = "no readiness attempt completed"
+    command = (
+        "pg_isready --quiet --timeout=3 "
+        f"--host={shlex.quote(POSTGRES_SOCKET_DIRECTORY)} "
+        f"--username={shlex.quote(POSTGRES_USER)} "
+        f"--dbname={shlex.quote(POSTGRES_DATABASE)}"
+    )
+
+    while True:
+        try:
+            result = sandbox.commands.run(
+                command,
+                timeout=5,
+                user=POSTGRES_USER,
+            )
+            if result.exit_code == 0:
+                return
+            last_detail = (
+                f"exit_code={result.exit_code}, "
+                f"stderr={result.stderr.strip()!r}"
+            )
+        except Exception as exc:  # noqa: BLE001 - snapshot startup may drop envd
+            last_detail = f"{type(exc).__name__}: {exc}"
+
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            raise TimeoutError(
+                f"PostgreSQL did not become ready within {timeout:.0f}s "
+                f"({last_detail})"
+            )
+        time.sleep(min(1.0, remaining))
+
+
+def sql(
+    sandbox: Sandbox,
+    statement: str,
+    *,
+    database: str = POSTGRES_DATABASE,
+) -> str:
+    """Execute one SQL statement with psql and return stripped stdout."""
+    command = " ".join(
+        [
+            "psql",
+            "-X",
+            "--no-align",
+            "--tuples-only",
+            "--quiet",
+            "--set=ON_ERROR_STOP=1",
+            f"--host={shlex.quote(POSTGRES_SOCKET_DIRECTORY)}",
+            f"--username={shlex.quote(POSTGRES_USER)}",
+            f"--dbname={shlex.quote(database)}",
+            f"--command={shlex.quote(statement)}",
+        ]
+    )
+    return run_checked(sandbox, command).stdout.strip()
+
+
+def apply_sql_file(
+    sandbox: Sandbox,
+    local_path: Path,
+    *,
+    remote_path: str = "/tmp/migration.sql",
+    database: str = POSTGRES_DATABASE,
+) -> str:
+    """Upload a local SQL file as postgres and execute it with psql."""
+    sql_text = local_path.read_text(encoding="utf-8")
+    sandbox.files.write(remote_path, sql_text, user=POSTGRES_USER)
+    command = " ".join(
+        [
+            "psql",
+            "-X",
+            "--quiet",
+            "--set=ON_ERROR_STOP=1",
+            f"--host={shlex.quote(POSTGRES_SOCKET_DIRECTORY)}",
+            f"--username={shlex.quote(POSTGRES_USER)}",
+            f"--dbname={shlex.quote(database)}",
+            f"--file={shlex.quote(remote_path)}",
+        ]
+    )
+    return run_checked(sandbox, command).stdout.strip()
+
+
+def checkpoint(sandbox: Sandbox) -> None:
+    """Flush a PostgreSQL checkpoint after the caller has committed its work."""
+    sql(sandbox, "CHECKPOINT;")
+
+
+def list_snapshot_ids(
+    *,
+    config: Config,
+    sandbox_id: Optional[str] = None,
+) -> set[str]:
+    """List every matching snapshot ID, following all pagination cursors."""
+    snapshot_ids = set()
+    next_token = None
+    seen_tokens = set()
+
+    while True:
+        items, next_token = Sandbox.list_snapshots(
+            sandbox_id=sandbox_id,
+            limit=100,
+            next_token=next_token,
+            config=config,
+        )
+        snapshot_ids.update(item.snapshot_id for item in items)
+        if not next_token:
+            return snapshot_ids
+        if next_token in seen_tokens:
+            raise RuntimeError("snapshot pagination returned a repeated next token")
+        seen_tokens.add(next_token)
+
+
+def wait_for_snapshot(
+    snapshot_id: str,
+    *,
+    config: Config,
+    present: bool,
+    sandbox_id: Optional[str] = None,
+    timeout: float = 30.0,
+) -> None:
+    """Wait for a snapshot list operation to reflect creation or deletion."""
+    deadline = time.monotonic() + timeout
+    while True:
+        found = snapshot_id in list_snapshot_ids(
+            config=config,
+            sandbox_id=sandbox_id,
+        )
+        if found is present:
+            return
+        if time.monotonic() >= deadline:
+            state = "appear in" if present else "disappear from"
+            raise TimeoutError(
+                f"snapshot {snapshot_id} did not {state} the snapshot list "
+                f"within {timeout:.0f}s"
+            )
+        time.sleep(1.0)
+
+
+def kill_sandbox(sandbox: Sandbox) -> None:
+    """Destroy a sandbox and close local clients; tolerate prior deletion."""
+    try:
+        sandbox.kill()
+    except SandboxNotFoundError:
+        pass
+    finally:
+        sandbox.close()
+
+
+def delete_snapshot(snapshot_id: str, *, config: Config) -> None:
+    """Delete a snapshot; tolerate a snapshot that is already absent."""
+    try:
+        Sandbox.delete_snapshot(snapshot_id, config=config)
+    except TemplateNotFoundError:
+        pass

--- a/examples/postgresql-stateful-sandbox/postgres_utils.py
+++ b/examples/postgresql-stateful-sandbox/postgres_utils.py
@@ -169,13 +169,13 @@ def checkpoint(sandbox: Sandbox) -> None:
     sql(sandbox, "CHECKPOINT;")
 
 
-def list_snapshot_ids(
+def snapshot_exists(
+    snapshot_id: str,
     *,
     config: Config,
     sandbox_id: Optional[str] = None,
-) -> set[str]:
-    """List every matching snapshot ID, following all pagination cursors."""
-    snapshot_ids = set()
+) -> bool:
+    """Find one snapshot, stopping pagination as soon as its ID appears."""
     next_token = None
     seen_tokens = set()
 
@@ -186,9 +186,10 @@ def list_snapshot_ids(
             next_token=next_token,
             config=config,
         )
-        snapshot_ids.update(item.snapshot_id for item in items)
+        if any(item.snapshot_id == snapshot_id for item in items):
+            return True
         if not next_token:
-            return snapshot_ids
+            return False
         if next_token in seen_tokens:
             raise RuntimeError("snapshot pagination returned a repeated next token")
         seen_tokens.add(next_token)
@@ -205,7 +206,8 @@ def wait_for_snapshot(
     """Wait for a snapshot list operation to reflect creation or deletion."""
     deadline = time.monotonic() + timeout
     while True:
-        found = snapshot_id in list_snapshot_ids(
+        found = snapshot_exists(
+            snapshot_id,
             config=config,
             sandbox_id=sandbox_id,
         )

--- a/examples/postgresql-stateful-sandbox/requirements.txt
+++ b/examples/postgresql-stateful-sandbox/requirements.txt
@@ -1,0 +1,2 @@
+cubesandbox>=0.5.0
+python-dotenv>=1.0.0

--- a/examples/postgresql-stateful-sandbox/smoke.py
+++ b/examples/postgresql-stateful-sandbox/smoke.py
@@ -4,6 +4,8 @@
 """Verify SQL execution and the PostgreSQL template's network isolation."""
 
 from pathlib import Path
+from typing import Optional
+from urllib.error import HTTPError
 from urllib.request import ProxyHandler, Request, build_opener
 
 from cubesandbox import Config, Sandbox
@@ -26,10 +28,12 @@ def envd_health_status(
     sandbox: Sandbox,
     config: Config,
     *,
-    traffic_token: str,
+    traffic_token: Optional[str] = None,
 ) -> int:
-    """Read envd health with its traffic token and no host proxy settings."""
-    headers = {"e2b-traffic-access-token": traffic_token}
+    """Read envd health with no host proxy settings and return any HTTP code."""
+    headers = {}
+    if traffic_token is not None:
+        headers["e2b-traffic-access-token"] = traffic_token
     if config.proxy_node_ip:
         url = f"http://{config.proxy_node_ip}:{config.proxy_port}/health"
         headers["Host"] = sandbox.get_host(ENVD_PORT)
@@ -37,8 +41,13 @@ def envd_health_status(
         url = f"http://{sandbox.get_host(ENVD_PORT)}/health"
     request = Request(url, headers=headers, method="GET")
     opener = build_opener(ProxyHandler({}))
-    with opener.open(request, timeout=5) as response:
-        return response.status
+    try:
+        with opener.open(request, timeout=5) as response:
+            return response.status
+    except HTTPError as exc:
+        status = exc.code
+        exc.close()
+        return status
 
 
 def main() -> None:
@@ -82,6 +91,12 @@ def main() -> None:
             raise AssertionError(
                 "envd health with a traffic token returned "
                 f"HTTP {authenticated_status}, expected 204"
+            )
+
+        unauthenticated_status = envd_health_status(sandbox, config)
+        if unauthenticated_status == 204:
+            raise AssertionError(
+                "envd health without a traffic token unexpectedly returned HTTP 204"
             )
 
         internet = sandbox.commands.run(

--- a/examples/postgresql-stateful-sandbox/smoke.py
+++ b/examples/postgresql-stateful-sandbox/smoke.py
@@ -1,0 +1,114 @@
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Verify SQL execution and the PostgreSQL template's network isolation."""
+
+from pathlib import Path
+from urllib.request import ProxyHandler, Request, build_opener
+
+from cubesandbox import Config, Sandbox
+from env_utils import load_local_dotenv
+from postgres_utils import (
+    POSTGRES_USER,
+    apply_sql_file,
+    create_secure_sandbox,
+    cube_config,
+    kill_sandbox,
+    sql,
+    wait_for_postgres,
+)
+
+EXAMPLE_DIR = Path(__file__).resolve().parent
+ENVD_PORT = 49983
+
+
+def envd_health_status(
+    sandbox: Sandbox,
+    config: Config,
+    *,
+    traffic_token: str,
+) -> int:
+    """Read envd health with its traffic token and no host proxy settings."""
+    headers = {"e2b-traffic-access-token": traffic_token}
+    if config.proxy_node_ip:
+        url = f"http://{config.proxy_node_ip}:{config.proxy_port}/health"
+        headers["Host"] = sandbox.get_host(ENVD_PORT)
+    else:
+        url = f"http://{sandbox.get_host(ENVD_PORT)}/health"
+    request = Request(url, headers=headers, method="GET")
+    opener = build_opener(ProxyHandler({}))
+    with opener.open(request, timeout=5) as response:
+        return response.status
+
+
+def main() -> None:
+    load_local_dotenv()
+    config = cube_config()
+    sandbox = create_secure_sandbox(config=config)
+    print(f"sandbox: {sandbox.sandbox_id}")
+
+    try:
+        wait_for_postgres(sandbox)
+        apply_sql_file(sandbox, EXAMPLE_DIR / "sql" / "base_schema.sql")
+
+        server_version_num = sql(
+            sandbox,
+            "SELECT current_setting('server_version_num');",
+        )
+        if server_version_num != "160014":
+            raise AssertionError(
+                "expected PostgreSQL 16.14 (server_version_num 160014), got "
+                f"{server_version_num!r}"
+            )
+
+        account_summary = sql(
+            sandbox,
+            "SELECT count(*)::text || ':' || sum(balance)::text FROM accounts;",
+        )
+        if account_summary != "2:300":
+            raise AssertionError(
+                f"expected two accounts with balance 300, got {account_summary!r}"
+            )
+
+        traffic_token = sandbox.traffic_access_token
+        if not traffic_token:
+            raise AssertionError("sandbox creation did not return a traffic access token")
+        authenticated_status = envd_health_status(
+            sandbox,
+            config,
+            traffic_token=traffic_token,
+        )
+        if authenticated_status != 204:
+            raise AssertionError(
+                "envd health with a traffic token returned "
+                f"HTTP {authenticated_status}, expected 204"
+            )
+
+        internet = sandbox.commands.run(
+            "curl --fail --insecure --silent --show-error --max-time 3 "
+            "https://example.com --output /dev/null",
+            timeout=5,
+            user=POSTGRES_USER,
+        )
+        if internet.exit_code == 0:
+            raise AssertionError("public internet unexpectedly remained reachable")
+
+        if sql(sandbox, "SELECT 1;") != "1":
+            raise AssertionError("local PostgreSQL stopped responding after egress denial")
+
+        tcp = sandbox.commands.run(
+            "pg_isready --quiet --timeout=3 --host=127.0.0.1 "
+            "--port=5432 --username=postgres --dbname=postgres",
+            timeout=5,
+            user=POSTGRES_USER,
+        )
+        if tcp.exit_code == 0:
+            raise AssertionError("PostgreSQL unexpectedly accepted TCP connections")
+    finally:
+        kill_sandbox(sandbox)
+
+    print("OK: PostgreSQL template is ready and network isolation is enforced")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/postgresql-stateful-sandbox/snapshot_restore.py
+++ b/examples/postgresql-stateful-sandbox/snapshot_restore.py
@@ -1,0 +1,157 @@
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Restore PostgreSQL data and schema into a new sandbox from a snapshot."""
+
+from pathlib import Path
+from typing import Optional
+
+from cubesandbox import Config, Sandbox
+from env_utils import load_local_dotenv
+from postgres_utils import (
+    apply_sql_file,
+    checkpoint,
+    create_secure_sandbox,
+    cube_config,
+    delete_snapshot,
+    kill_sandbox,
+    sql,
+    wait_for_postgres,
+    wait_for_snapshot,
+)
+
+EXAMPLE_DIR = Path(__file__).resolve().parent
+
+
+def cleanup_resources(
+    restore_sandbox: Optional[Sandbox],
+    source_sandbox: Optional[Sandbox],
+    snapshot_id: Optional[str],
+    *,
+    config: Config,
+) -> None:
+    """Best-effort cleanup in dependency order, reporting every failure."""
+    errors = []
+
+    for label, sandbox in (
+        ("restore sandbox", restore_sandbox),
+        ("source sandbox", source_sandbox),
+    ):
+        if sandbox is None:
+            continue
+        try:
+            kill_sandbox(sandbox)
+        except Exception as exc:  # noqa: BLE001 - cleanup must continue
+            errors.append(f"{label} {sandbox.sandbox_id}: {exc}")
+
+    if snapshot_id is not None:
+        try:
+            delete_snapshot(snapshot_id, config=config)
+            wait_for_snapshot(snapshot_id, config=config, present=False)
+        except Exception as exc:  # noqa: BLE001 - report after all cleanup attempts
+            errors.append(f"snapshot {snapshot_id}: {exc}")
+
+    if errors:
+        raise RuntimeError("resource cleanup failed: " + "; ".join(errors))
+
+
+def main() -> None:
+    load_local_dotenv()
+    config = cube_config()
+    source_sandbox: Optional[Sandbox] = None
+    restore_sandbox: Optional[Sandbox] = None
+    snapshot_id: Optional[str] = None
+
+    try:
+        source_sandbox = create_secure_sandbox(config=config)
+        source_sandbox_id = source_sandbox.sandbox_id
+        print(f"source sandbox: {source_sandbox_id}")
+
+        wait_for_postgres(source_sandbox)
+        apply_sql_file(source_sandbox, EXAMPLE_DIR / "sql" / "base_schema.sql")
+        baseline = sql(
+            source_sandbox,
+            "SELECT owner || ':' || balance::text FROM accounts ORDER BY owner;",
+        )
+        if baseline != "alice:100\nbob:200":
+            raise AssertionError(f"unexpected baseline rows: {baseline!r}")
+
+        checkpoint(source_sandbox)
+        snapshot = source_sandbox.create_snapshot()
+        snapshot_id = snapshot.snapshot_id
+        if not snapshot_id:
+            raise RuntimeError("snapshot creation returned an empty snapshot ID")
+        print(f"snapshot: {snapshot_id}")
+        wait_for_snapshot(
+            snapshot_id,
+            config=config,
+            present=True,
+            sandbox_id=source_sandbox_id,
+        )
+
+        sql(
+            source_sandbox,
+            """
+            BEGIN;
+            UPDATE accounts SET balance = 0;
+            ALTER TABLE accounts
+                ADD COLUMN poisoned boolean NOT NULL DEFAULT true;
+            COMMIT;
+            """,
+        )
+        if sql(source_sandbox, "SELECT sum(balance) FROM accounts;") != "0":
+            raise AssertionError("the destructive data mutation was not applied")
+        if sql(
+            source_sandbox,
+            """
+            SELECT count(*)
+            FROM information_schema.columns
+            WHERE table_schema = 'public'
+              AND table_name = 'accounts'
+              AND column_name = 'poisoned';
+            """,
+        ) != "1":
+            raise AssertionError("the destructive schema mutation was not applied")
+
+        kill_sandbox(source_sandbox)
+        source_sandbox = None
+
+        restore_sandbox = create_secure_sandbox(snapshot_id, config=config)
+        print(f"restore sandbox: {restore_sandbox.sandbox_id}")
+        if restore_sandbox.sandbox_id == source_sandbox_id:
+            raise AssertionError("snapshot restore reused the source sandbox ID")
+        wait_for_postgres(restore_sandbox)
+
+        restored = sql(
+            restore_sandbox,
+            "SELECT owner || ':' || balance::text FROM accounts ORDER BY owner;",
+        )
+        if restored != baseline:
+            raise AssertionError(
+                f"snapshot restored {restored!r}, expected {baseline!r}"
+            )
+        poisoned_columns = sql(
+            restore_sandbox,
+            """
+            SELECT count(*)
+            FROM information_schema.columns
+            WHERE table_schema = 'public'
+              AND table_name = 'accounts'
+              AND column_name = 'poisoned';
+            """,
+        )
+        if poisoned_columns != "0":
+            raise AssertionError("snapshot restore retained the poisoned column")
+    finally:
+        cleanup_resources(
+            restore_sandbox,
+            source_sandbox,
+            snapshot_id,
+            config=config,
+        )
+
+    print("OK: snapshot restored PostgreSQL data and schema in a new sandbox")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/postgresql-stateful-sandbox/sql/add_email.sql
+++ b/examples/postgresql-stateful-sandbox/sql/add_email.sql
@@ -1,0 +1,20 @@
+-- Copyright (c) 2026 Tencent Inc.
+-- SPDX-License-Identifier: Apache-2.0
+
+BEGIN;
+
+ALTER TABLE accounts
+    ADD COLUMN IF NOT EXISTS email text;
+
+UPDATE accounts
+SET email = owner || '@example.test'
+WHERE email IS NULL;
+
+ALTER TABLE accounts
+    ALTER COLUMN email SET NOT NULL;
+
+INSERT INTO schema_migrations (version)
+VALUES ('add_email')
+ON CONFLICT (version) DO NOTHING;
+
+COMMIT;

--- a/examples/postgresql-stateful-sandbox/sql/add_last_login.sql
+++ b/examples/postgresql-stateful-sandbox/sql/add_last_login.sql
@@ -1,0 +1,20 @@
+-- Copyright (c) 2026 Tencent Inc.
+-- SPDX-License-Identifier: Apache-2.0
+
+BEGIN;
+
+ALTER TABLE accounts
+    ADD COLUMN IF NOT EXISTS last_login_at timestamptz;
+
+UPDATE accounts
+SET last_login_at = TIMESTAMPTZ '2026-01-01 00:00:00+00'
+WHERE last_login_at IS NULL;
+
+ALTER TABLE accounts
+    ALTER COLUMN last_login_at SET NOT NULL;
+
+INSERT INTO schema_migrations (version)
+VALUES ('add_last_login')
+ON CONFLICT (version) DO NOTHING;
+
+COMMIT;

--- a/examples/postgresql-stateful-sandbox/sql/base_schema.sql
+++ b/examples/postgresql-stateful-sandbox/sql/base_schema.sql
@@ -1,0 +1,28 @@
+-- Copyright (c) 2026 Tencent Inc.
+-- SPDX-License-Identifier: Apache-2.0
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS accounts (
+    id bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    owner text UNIQUE NOT NULL,
+    balance integer NOT NULL CHECK (balance >= 0)
+);
+
+CREATE TABLE IF NOT EXISTS schema_migrations (
+    version text PRIMARY KEY,
+    applied_at timestamptz NOT NULL DEFAULT now()
+);
+
+INSERT INTO accounts (owner, balance)
+VALUES
+    ('alice', 100),
+    ('bob', 200)
+ON CONFLICT (owner) DO UPDATE
+SET balance = EXCLUDED.balance;
+
+INSERT INTO schema_migrations (version)
+VALUES ('base_v1')
+ON CONFLICT (version) DO NOTHING;
+
+COMMIT;

--- a/examples/postgresql-stateful-sandbox/start-postgres.sh
+++ b/examples/postgresql-stateful-sandbox/start-postgres.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+set -eu
+
+PGDATA="${PGDATA:-/var/lib/postgresql/cube-data}"
+POSTGRES_SOCKET_DIR="${POSTGRES_SOCKET_DIR:-/var/run/postgresql}"
+
+if [ ! -s "${PGDATA}/PG_VERSION" ]; then
+    echo "start-postgres: initialized cluster not found at ${PGDATA}" >&2
+    exit 1
+fi
+
+# /run is normally a tmpfs, so its contents and permissions must be restored
+# on every container boot. The socket is only accessible to postgres' group.
+install -d -o postgres -g postgres -m 0770 "${POSTGRES_SOCKET_DIR}"
+
+exec gosu postgres postgres \
+    -D "${PGDATA}" \
+    -c "listen_addresses=" \
+    -c "unix_socket_directories=${POSTGRES_SOCKET_DIR}" \
+    -c "unix_socket_permissions=0770" \
+    -c "max_connections=20"


### PR DESCRIPTION
## Summary

Add a stateful PostgreSQL 16.14 CubeSandbox example with:

- Unix-socket-only PostgreSQL access
- traffic-token-protected envd ingress and disabled internet egress
- authenticated envd command access
- snapshot restore into a new sandbox
- two isolated migration branches
- English and Chinese documentation

## Validation

- [x] Python compileall
- [x] Ruff
- [x] ShellCheck
- [x] git diff --check
- [x] VitePress documentation build
- [x] Docker image build
- [x] PostgreSQL 16.14 and data checksums
- [x] Unix Socket available and TCP 5432 closed
- [x] Graceful shutdown and restart without crash recovery
- [x] Cube template READY with 1/1 node distribution
- [x] smoke.py
- [x] snapshot_restore.py
- [x] migration_branches.py
- [x] No leaked sandboxes or snapshots

## Scope

This contribution does not modify CubeProxy, CubeMaster, the Cube SDK,
deployment configuration, or CI.

Anonymous envd HTTP status-code consistency is a separate platform concern and
is not treated as part of the PostgreSQL template contract.

Refs #645

Assisted-by: Codex:GPT-5