### PR TITLE
feat(cubelet): refactor state tmpfs mount with safer resize logic

### DIFF
--- a/Cubelet/cmd/cubelet/main.go
+++ b/Cubelet/cmd/cubelet/main.go
@@ -280,7 +280,7 @@ func App() *cli.App {
 		},
 		&cli.IntFlag{
 			Name:  "state-tmpfs-size",
-			Value: 500,
+			Value: 1024,
 			Usage: "state-tmpfs-size(MB)",
 		},
 		&cli.IntFlag{
@@ -660,27 +660,6 @@ func ensureRootSharedMount(rootDir string) error {
 	return nil
 }
 
-func mountTmpfsDir(stateDir string, context *cli.Context) error {
-	exist, _ := mountinfo.Mounted(stateDir)
-	if exist {
-		return nil
-	}
-	size := context.Int("state-tmpfs-size")
-	_ = mount.UnmountAll(stateDir, 0)
-	m := &mount.Mount{
-		Type:    "tmpfs",
-		Source:  "none",
-		Options: []string{fmt.Sprintf("size=%dm", size)},
-	}
-	if err := m.Mount(stateDir); err != nil {
-		return err
-	}
-	exist, _ = mountinfo.Mounted(stateDir)
-	if !exist {
-		return fmt.Errorf("mount tmpfs:%v fail", stateDir)
-	}
-	return nil
-}
 func setPidFile(pidFile string) error {
 	if pidFile == "" {
 		return nil

--- a/Cubelet/cmd/cubelet/state_tmpfs.go
+++ b/Cubelet/cmd/cubelet/state_tmpfs.go
@@ -1,0 +1,186 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"fmt"
+	stdlog "log"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/containerd/containerd/v2/core/mount"
+	"github.com/moby/sys/mountinfo"
+	"github.com/urfave/cli/v2"
+	"golang.org/x/sys/unix"
+)
+
+// mountTmpfsDir ensures stateDir is a tmpfs with the configured size ceiling.
+//
+// An existing mount is never umount+remounted (that would wipe state). Non-tmpfs
+// mounts are left alone; genuine tmpfs resizes use MS_REMOUNT. Remount failure
+// on an existing mount only warns — fresh mount failure fails startup.
+func mountTmpfsDir(stateDir string, context *cli.Context) error {
+	stateDir = filepath.Clean(stateDir)
+	sizeMB := context.Int("state-tmpfs-size")
+	if sizeMB <= 0 {
+		return fmt.Errorf("invalid state-tmpfs-size: %d", sizeMB)
+	}
+
+	info, err := lookupExactMount(stateDir)
+	if err != nil {
+		return fmt.Errorf("lookup mount %s: %w", stateDir, err)
+	}
+	if info == nil {
+		return mountFreshStateTmpfs(stateDir, sizeMB)
+	}
+	return maybeRemountStateTmpfs(stateDir, info, sizeMB)
+}
+
+func tmpfsSizeFromMB(sizeMB int) uint64 {
+	return uint64(sizeMB) * 1024 * 1024
+}
+
+func stateTmpfsMount(sizeMB int, remount bool) *mount.Mount {
+	opts := []string{fmt.Sprintf("size=%dm", sizeMB)}
+	if remount {
+		opts = []string{"remount", opts[0]}
+	}
+	return &mount.Mount{Type: "tmpfs", Source: "none", Options: opts}
+}
+
+func mountFreshStateTmpfs(stateDir string, sizeMB int) error {
+	if err := stateTmpfsMount(sizeMB, false).Mount(stateDir); err != nil {
+		return err
+	}
+	exist, err := mountinfo.Mounted(stateDir)
+	if err != nil {
+		return fmt.Errorf("verify tmpfs mount %s: %w", stateDir, err)
+	}
+	if !exist {
+		return fmt.Errorf("mount tmpfs:%v fail", stateDir)
+	}
+	stdlog.Printf("mounted state tmpfs %s size=%dm", stateDir, sizeMB)
+	return nil
+}
+
+func maybeRemountStateTmpfs(stateDir string, info *mountinfo.Info, sizeMB int) error {
+	if info.FSType != "tmpfs" {
+		stdlog.Printf("state dir %s already mounted as %s, skip tmpfs remount", stateDir, info.FSType)
+		return nil
+	}
+
+	desiredBytes := tmpfsSizeFromMB(sizeMB)
+	currentBytes, hasSize := parseTmpfsSizeBytes(info.VFSOptions)
+	if hasSize && tmpfsSizeEqual(currentBytes, desiredBytes) {
+		return nil
+	}
+
+	if hasSize && desiredBytes < currentBytes && refuseShrinkStateTmpfs(stateDir, currentBytes, desiredBytes) {
+		return nil
+	}
+
+	prevSize := "unknown"
+	if hasSize {
+		prevSize = strconv.FormatUint(currentBytes, 10)
+	}
+	if err := stateTmpfsMount(sizeMB, true).Mount(stateDir); err != nil {
+		stdlog.Printf("warn: remount state tmpfs %s size %s -> %d bytes failed: %v; keeping existing mount",
+			stateDir, prevSize, desiredBytes, err)
+		return nil
+	}
+	stdlog.Printf("remounted state tmpfs %s size %s -> %dm (%d bytes)", stateDir, prevSize, sizeMB, desiredBytes)
+	return nil
+}
+
+func refuseShrinkStateTmpfs(stateDir string, currentBytes, desiredBytes uint64) bool {
+	used, err := tmpfsUsedBytes(stateDir)
+	if err != nil {
+		stdlog.Printf("warn: cannot measure usage of state tmpfs %s (%v); refuse shrink %d -> %d bytes",
+			stateDir, err, currentBytes, desiredBytes)
+		return true
+	}
+	if used > desiredBytes {
+		stdlog.Printf("warn: refuse shrink state tmpfs %s from %d to %d bytes: used %d bytes",
+			stateDir, currentBytes, desiredBytes, used)
+		return true
+	}
+	return false
+}
+
+func lookupExactMount(mountpoint string) (*mountinfo.Info, error) {
+	mounts, err := mountinfo.GetMounts(mountinfo.SingleEntryFilter(mountpoint))
+	if err != nil {
+		return nil, err
+	}
+	if len(mounts) == 0 {
+		return nil, nil
+	}
+	return mounts[0], nil
+}
+
+// parseTmpfsSizeBytes parses the size= option from mountinfo VFSOptions.
+// Kernel typically shows size in kilobytes (e.g. size=512000k for size=500m).
+// Percent-of-RAM sizes are treated as unparseable.
+func parseTmpfsSizeBytes(vfsOptions string) (uint64, bool) {
+	for _, opt := range strings.Split(vfsOptions, ",") {
+		opt = strings.TrimSpace(opt)
+		if !strings.HasPrefix(opt, "size=") {
+			continue
+		}
+		raw := strings.TrimPrefix(opt, "size=")
+		if raw == "" || strings.HasSuffix(raw, "%") {
+			return 0, false
+		}
+		return parseLinuxSizeBytes(raw)
+	}
+	return 0, false
+}
+
+func parseLinuxSizeBytes(s string) (uint64, bool) {
+	if s == "" {
+		return 0, false
+	}
+	mult := uint64(1)
+	switch s[len(s)-1] {
+	case 'k', 'K':
+		mult = 1024
+		s = s[:len(s)-1]
+	case 'm', 'M':
+		mult = 1024 * 1024
+		s = s[:len(s)-1]
+	case 'g', 'G':
+		mult = 1024 * 1024 * 1024
+		s = s[:len(s)-1]
+	}
+	if s == "" {
+		return 0, false
+	}
+	n, err := strconv.ParseUint(s, 10, 64)
+	if err != nil {
+		return 0, false
+	}
+	return n * mult, true
+}
+
+// tmpfsSizeEqual treats sizes within one page as equal to avoid remount churn
+// from PAGE_SIZE rounding in the kernel.
+func tmpfsSizeEqual(a, b uint64) bool {
+	page := uint64(unix.Getpagesize())
+	if a > b {
+		return a-b < page
+	}
+	return b-a < page
+}
+
+func tmpfsUsedBytes(path string) (uint64, error) {
+	var st unix.Statfs_t
+	if err := unix.Statfs(path, &st); err != nil {
+		return 0, err
+	}
+	if st.Blocks < st.Bfree {
+		return 0, fmt.Errorf("invalid statfs blocks=%d bfree=%d", st.Blocks, st.Bfree)
+	}
+	return (st.Blocks - st.Bfree) * uint64(st.Bsize), nil
+}

--- a/Cubelet/cmd/cubelet/state_tmpfs_test.go
+++ b/Cubelet/cmd/cubelet/state_tmpfs_test.go
@@ -1,0 +1,116 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"testing"
+
+	"github.com/moby/sys/mountinfo"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/unix"
+)
+
+func TestParseTmpfsSizeBytes(t *testing.T) {
+	tests := []struct {
+		name   string
+		opts   string
+		want   uint64
+		wantOK bool
+	}{
+		{
+			name:   "kernel kilobytes for 500m",
+			opts:   "rw,size=512000k,nr_inodes=1048576",
+			want:   500 * 1024 * 1024,
+			wantOK: true,
+		},
+		{
+			name:   "kernel kilobytes for 1024m",
+			opts:   "rw,size=1048576k",
+			want:   1024 * 1024 * 1024,
+			wantOK: true,
+		},
+		{
+			name:   "explicit megabytes",
+			opts:   "rw,size=500m",
+			want:   500 * 1024 * 1024,
+			wantOK: true,
+		},
+		{
+			name:   "explicit gigabytes",
+			opts:   "size=1g",
+			want:   1024 * 1024 * 1024,
+			wantOK: true,
+		},
+		{
+			name:   "bare bytes",
+			opts:   "size=524288000",
+			want:   524288000,
+			wantOK: true,
+		},
+		{
+			name:   "percent of ram unsupported",
+			opts:   "rw,size=50%",
+			wantOK: false,
+		},
+		{
+			name:   "missing size",
+			opts:   "rw,nr_inodes=1024",
+			wantOK: false,
+		},
+		{
+			name:   "empty",
+			opts:   "",
+			wantOK: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := parseTmpfsSizeBytes(tt.opts)
+			require.Equal(t, tt.wantOK, ok)
+			if tt.wantOK {
+				assert.Equal(t, tt.want, got)
+			}
+		})
+	}
+}
+
+func TestTmpfsSizeEqual(t *testing.T) {
+	page := uint64(unix.Getpagesize())
+	base := uint64(1024 * 1024 * 1024)
+
+	assert.True(t, tmpfsSizeEqual(base, base))
+	assert.True(t, tmpfsSizeEqual(base, base+page-1))
+	assert.False(t, tmpfsSizeEqual(base, base+page))
+	assert.False(t, tmpfsSizeEqual(500*1024*1024, 1024*1024*1024))
+}
+
+func TestMaybeRemountStateTmpfsSkipsNonTmpfs(t *testing.T) {
+	err := maybeRemountStateTmpfs("/data/cubelet/state", &mountinfo.Info{
+		FSType:     "ext4",
+		VFSOptions: "rw",
+	}, 1024)
+	require.NoError(t, err)
+}
+
+func TestMaybeRemountStateTmpfsNoopWhenSizeMatches(t *testing.T) {
+	err := maybeRemountStateTmpfs("/data/cubelet/state", &mountinfo.Info{
+		FSType:     "tmpfs",
+		VFSOptions: "rw,size=1048576k",
+	}, 1024)
+	require.NoError(t, err)
+}
+
+func TestMaybeRemountStateTmpfsRefuseShrinkWhenUsedExceeds(t *testing.T) {
+	// Statfs on a normal temp dir reports the backing filesystem's used bytes,
+	// which is >> 1. With a claimed current size of 1Gi, the shrink guard must
+	// refuse and return without attempting remount.
+	dir := t.TempDir()
+	err := maybeRemountStateTmpfs(dir, &mountinfo.Info{
+		FSType:     "tmpfs",
+		VFSOptions: "rw,size=1048576k",
+	}, 1)
+	require.NoError(t, err)
+}

--- a/Cubelet/config/config.toml
+++ b/Cubelet/config/config.toml
@@ -1,7 +1,7 @@
 oom_score = 0
 root = "/data/cubelet/root"
 #独立空间 存放元数据
-#mount -t tmpfs -o size=500m none /data/cubelet/state/
+#mount -t tmpfs -o size=1024m none /data/cubelet/state/
 state = "/data/cubelet/state"
 version = 3
 pid_file = "/run/cube-let.pid"

--- a/deploy/kubernetes/images/scripts/cube-node-entrypoint.sh
+++ b/deploy/kubernetes/images/scripts/cube-node-entrypoint.sh
@@ -205,7 +205,7 @@ mkdir -p \
 
 # Keep shim bundle metadata on the dataCubelet hostPath across Pod rebuilds.
 # cubelet mountTmpfsDir() skips when state is already mounted; without this,
-# a 500Mi tmpfs in cubelet's private mount NS holds bootstrap.json/address and
+# a 1Gi tmpfs in cubelet's private mount NS holds bootstrap.json/address and
 # is discarded when the Pod (and that mount NS) goes away, breaking
 # LoadExistingShims even if shim processes and /run/containerd sockets survive.
 if ! findmnt --mountpoint /data/cubelet/state >/dev/null 2>&1; then


### PR DESCRIPTION
## Background

Some machines have larger specifications and can create a very high number of sandboxes. The existing default 500Mi state tmpfs is insufficient to hold the metadata for all those sandboxes.

To address this, the following adjustments were made:

1. Bump the default state tmpfs size from 500Mi to 1Gi.
2. Add automatic remount logic so that after users manually adjust the size configuration, the tmpfs is resized automatically on next startup without requiring a manual remount.

## Summary

Refactor cubelet's state tmpfs mount logic to be safer and more robust.

## Changes

- Extract `mountTmpfsDir` from `main.go` into dedicated `state_tmpfs.go`
- Add remount-on-start support for existing tmpfs mounts without wiping state data
- Add shrink guard: refuse to shrink tmpfs when used bytes exceed the target size
- Add kernel size-option parsing (k/m/g suffixes, percent-of-RAM rejection)
- Add page-size-aware equality check to avoid unnecessary remount churn
- Bump default `state-tmpfs-size` from 500Mi → 1024Mi

## Test

- Unit tests cover size parsing, equality checks, skip-non-tmpfs, noop-when-size-matches, and shrink-refusal scenarios