### PR TITLE
network-agent: durable live update of a sandbox's L7 egress rule

### DIFF
--- a/network-agent/cmd/network-agent/main_test.go
+++ b/network-agent/cmd/network-agent/main_test.go
@@ -25,6 +25,9 @@ func (s *typedNilService) ReleaseNetwork(ctx context.Context, req *service.Relea
 func (s *typedNilService) ReconcileNetwork(ctx context.Context, req *service.ReconcileNetworkRequest) (*service.ReconcileNetworkResponse, error) {
 	return nil, nil
 }
+func (s *typedNilService) UpdateEgressRule(ctx context.Context, req *service.UpdateEgressRuleRequest) (*service.UpdateEgressRuleResponse, error) {
+	return nil, nil
+}
 
 func (s *typedNilService) GetNetwork(ctx context.Context, req *service.GetNetworkRequest) (*service.GetNetworkResponse, error) {
 	return nil, nil

--- a/network-agent/internal/httpserver/server.go
+++ b/network-agent/internal/httpserver/server.go
@@ -66,6 +66,15 @@ func New(listen string, svc service.Service) *Server {
 			return svc.ReconcileNetwork(r.Context(), req)
 		})
 	})
+	mux.HandleFunc("/v1/egress/update", func(w http.ResponseWriter, r *http.Request) {
+		handleJSON(w, r, func(body []byte) (interface{}, error) {
+			req := &service.UpdateEgressRuleRequest{}
+			if err := json.Unmarshal(body, req); err != nil {
+				return nil, err
+			}
+			return svc.UpdateEgressRule(r.Context(), req)
+		})
+	})
 	mux.HandleFunc("/v1/network/get", func(w http.ResponseWriter, r *http.Request) {
 		handleJSON(w, r, func(body []byte) (interface{}, error) {
 			req := &service.GetNetworkRequest{}

--- a/network-agent/internal/httpserver/server.go
+++ b/network-agent/internal/httpserver/server.go
@@ -66,7 +66,7 @@ func New(listen string, svc service.Service) *Server {
 			return svc.ReconcileNetwork(r.Context(), req)
 		})
 	})
-	mux.HandleFunc("/v1/egress/update", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/v1/network/updateEgress", func(w http.ResponseWriter, r *http.Request) {
 		handleJSON(w, r, func(body []byte) (interface{}, error) {
 			req := &service.UpdateEgressRuleRequest{}
 			if err := json.Unmarshal(body, req); err != nil {

--- a/network-agent/internal/httpserver/server_test.go
+++ b/network-agent/internal/httpserver/server_test.go
@@ -152,6 +152,9 @@ func (f *fakeDumpService) ReleaseNetwork(ctx context.Context, req *service.Relea
 func (f *fakeDumpService) ReconcileNetwork(ctx context.Context, req *service.ReconcileNetworkRequest) (*service.ReconcileNetworkResponse, error) {
 	return &service.ReconcileNetworkResponse{}, nil
 }
+func (f *fakeDumpService) UpdateEgressRule(ctx context.Context, req *service.UpdateEgressRuleRequest) (*service.UpdateEgressRuleResponse, error) {
+	return &service.UpdateEgressRuleResponse{}, nil
+}
 func (f *fakeDumpService) GetNetwork(ctx context.Context, req *service.GetNetworkRequest) (*service.GetNetworkResponse, error) {
 	return &service.GetNetworkResponse{}, nil
 }

--- a/network-agent/internal/service/cubeegress_push.go
+++ b/network-agent/internal/service/cubeegress_push.go
@@ -118,7 +118,6 @@ func (s *localService) pushEgressForState(ctx context.Context, state *managedSta
 	if s.egress == nil || !s.egress.Configured() {
 		return
 	}
-	logger := CubeLog.WithContext(ctx)
 	in := toEgressInput(state.CubeNetworkConfig)
 	if in == nil {
 		// No L7 rules; nothing for CubeEgress to do. Make sure any
@@ -126,22 +125,25 @@ func (s *localService) pushEgressForState(ctx context.Context, state *managedSta
 		state.pendingEgressPush = false
 		return
 	}
-	err := s.egress.PutPolicy(ctx, state.SandboxIP, in)
+	applyEgressPushResult(ctx, state, s.egress.PutPolicy(ctx, state.SandboxIP, in))
+}
+
+// applyEgressPushResult records the outcome of a CubeEgress PutPolicy call on
+// state.pendingEgressPush: cleared on success or a permanent (4xx) failure —
+// where a replay can't help and the operator must fix the rule — and set on a
+// transient failure so retryPendingEgressPushes tries again later. The caller
+// must have exclusive access to state (hold s.mu, or own a state not yet
+// published to s.states).
+func applyEgressPushResult(ctx context.Context, state *managedState, err error) {
 	switch {
-	case err == nil:
-		state.pendingEgressPush = false
-	case errors.Is(err, cubeegress.ErrNotConfigured):
-		// Race: client unconfigured by the time we got here. Treat as
-		// no-op; nothing to retry.
+	case err == nil, errors.Is(err, cubeegress.ErrNotConfigured):
 		state.pendingEgressPush = false
 	case cubeegress.IsPermanent(err):
-		logger.Errorf("network-agent push egress policy permanently failed: sandbox_id=%s sandbox_ip=%s err=%v",
+		CubeLog.WithContext(ctx).Errorf("network-agent push egress policy permanently failed: sandbox_id=%s sandbox_ip=%s err=%v",
 			state.SandboxID, state.SandboxIP, err)
-		// Don't keep retrying a malformed body — operator must fix the
-		// upstream rule. Clear the pending flag so we don't loop.
 		state.pendingEgressPush = false
 	default:
-		logger.Warnf("network-agent push egress policy transiently failed; will retry: sandbox_id=%s sandbox_ip=%s err=%v",
+		CubeLog.WithContext(ctx).Warnf("network-agent push egress policy transiently failed; will retry: sandbox_id=%s sandbox_ip=%s err=%v",
 			state.SandboxID, state.SandboxIP, err)
 		state.pendingEgressPush = true
 	}

--- a/network-agent/internal/service/cubeegress_push.go
+++ b/network-agent/internal/service/cubeegress_push.go
@@ -164,76 +164,73 @@ func (s *localService) deleteEgressForState(ctx context.Context, sandboxID, sand
 	}
 }
 
+// pushEgressSerialized renders the sandbox's CURRENT egress policy and pushes it
+// to CubeEgress, serialized per sandbox via state.egressPushMu. This prevents a
+// live UpdateEgressRule and a maintenance retry (or two concurrent updates) from
+// interleaving and leaving a stale policy live: whichever push acquires
+// egressPushMu last re-renders under s.mu and therefore reflects the latest
+// rules. It returns whether the push is still pending (a transient failure the
+// maintenance loop will retry).
+//
+// Must be called WITHOUT s.mu held; egressPushMu is always taken before s.mu.
+func (s *localService) pushEgressSerialized(ctx context.Context, state *managedState) bool {
+	state.egressPushMu.Lock()
+	defer state.egressPushMu.Unlock()
+
+	s.mu.Lock()
+	pushable := s.egress != nil && s.egress.Configured()
+	input := toEgressInput(state.CubeNetworkConfig)
+	s.mu.Unlock()
+
+	if !pushable {
+		return false
+	}
+	if input == nil {
+		// No L7 rules to push; clear any stale pending flag.
+		s.mu.Lock()
+		state.pendingEgressPush = false
+		s.mu.Unlock()
+		return false
+	}
+
+	err := s.egress.PutPolicy(ctx, state.SandboxIP, input)
+
+	s.mu.Lock()
+	applyEgressPushResult(ctx, state, err)
+	pending := state.pendingEgressPush
+	s.mu.Unlock()
+	return pending
+}
+
 // retryPendingEgressPushes is invoked from the maintenance loop. It re-pushes
-// every managed state with pendingEgressPush=true. Each push renders the policy
-// under s.mu, releases the lock for the HTTP call, then re-acquires it to record
-// the result — and skips any state whose flag was cleared by a concurrent
-// UpdateEgressRule in the meantime, so a stale snapshot can never overwrite a
-// freshly rotated credential in CubeEgress.
+// every managed state with pendingEgressPush=true via pushEgressSerialized, which
+// serializes per sandbox against a live UpdateEgressRule so a retry can never
+// overwrite a freshly rotated credential with a stale policy.
 func (s *localService) retryPendingEgressPushes() {
 	if s.egress == nil || !s.egress.Configured() {
 		return
 	}
-	// Snapshot which sandboxes need a retry; we don't hold the lock during HTTP
-	// I/O. We deliberately do NOT capture the rendered policy here: it is
-	// re-read under the lock just before each push so a concurrent
-	// UpdateEgressRule can't have us overwrite a freshly rotated credential with
-	// a stale snapshot (TOCTOU).
-	type pending struct {
-		state *managedState
-		ip    string
-	}
-	var todo []pending
 	s.mu.Lock()
+	var todo []*managedState
 	for _, st := range s.states {
 		if st.pendingEgressPush {
-			todo = append(todo, pending{state: st, ip: st.SandboxIP})
+			todo = append(todo, st)
 		}
 	}
 	s.mu.Unlock()
 
-	if len(todo) == 0 {
-		return
-	}
-
-	logger := CubeLog.WithContext(context.Background())
-	for _, item := range todo {
-		// Re-check and re-render under the lock: a concurrent UpdateEgressRule
-		// may have pushed a fresh policy and cleared the flag since we
-		// snapshotted. If so, skip — that push already superseded this retry.
+	for _, st := range todo {
+		// Skip if a concurrent UpdateEgressRule already resolved this sandbox;
+		// pushEgressSerialized would otherwise redundantly re-push the same policy.
 		s.mu.Lock()
-		if !item.state.pendingEgressPush {
-			s.mu.Unlock()
-			continue
-		}
-		input := toEgressInput(item.state.CubeNetworkConfig)
+		stillPending := st.pendingEgressPush
 		s.mu.Unlock()
-		if input == nil {
-			// Pending was set but the rules are gone; clear the flag.
-			s.mu.Lock()
-			item.state.pendingEgressPush = false
-			s.mu.Unlock()
+		if !stillPending {
 			continue
 		}
-
 		ctx, cancel := context.WithTimeout(context.Background(), egressRetryCallTimeout)
-		err := s.egress.PutPolicy(ctx, item.ip, input)
+		s.pushEgressSerialized(ctx, st)
 		cancel()
-		s.mu.Lock()
-		switch {
-		case err == nil:
-			item.state.pendingEgressPush = false
-			logger.Infof("network-agent retry egress policy succeeded: sandbox_ip=%s", item.ip)
-		case cubeegress.IsPermanent(err):
-			item.state.pendingEgressPush = false
-			logger.Errorf("network-agent retry egress policy permanently failed: sandbox_ip=%s err=%v",
-				item.ip, err)
-		default:
-			// Leave pending=true; next maintenance tick tries again.
-			logger.Debugf("network-agent retry egress policy still transient: sandbox_ip=%s err=%v",
-				item.ip, err)
-		}
-		s.mu.Unlock()
 	}
 }
 

--- a/network-agent/internal/service/cubeegress_push.go
+++ b/network-agent/internal/service/cubeegress_push.go
@@ -170,10 +170,11 @@ func (s *localService) deleteEgressForState(ctx context.Context, sandboxID, sand
 // interleaving and leaving a stale policy live: whichever push acquires
 // egressPushMu last re-renders under s.mu and therefore reflects the latest
 // rules. It returns whether the push is still pending (a transient failure the
-// maintenance loop will retry).
+// maintenance loop will retry) and the push error (nil on success or when no
+// push was needed) so callers can log the outcome.
 //
 // Must be called WITHOUT s.mu held; egressPushMu is always taken before s.mu.
-func (s *localService) pushEgressSerialized(ctx context.Context, state *managedState) bool {
+func (s *localService) pushEgressSerialized(ctx context.Context, state *managedState) (pending bool, err error) {
 	state.egressPushMu.Lock()
 	defer state.egressPushMu.Unlock()
 
@@ -183,23 +184,23 @@ func (s *localService) pushEgressSerialized(ctx context.Context, state *managedS
 	s.mu.Unlock()
 
 	if !pushable {
-		return false
+		return false, nil
 	}
 	if input == nil {
 		// No L7 rules to push; clear any stale pending flag.
 		s.mu.Lock()
 		state.pendingEgressPush = false
 		s.mu.Unlock()
-		return false
+		return false, nil
 	}
 
-	err := s.egress.PutPolicy(ctx, state.SandboxIP, input)
+	err = s.egress.PutPolicy(ctx, state.SandboxIP, input)
 
 	s.mu.Lock()
 	applyEgressPushResult(ctx, state, err)
-	pending := state.pendingEgressPush
+	pending = state.pendingEgressPush
 	s.mu.Unlock()
-	return pending
+	return pending, err
 }
 
 // retryPendingEgressPushes is invoked from the maintenance loop. It re-pushes
@@ -229,8 +230,12 @@ func (s *localService) retryPendingEgressPushes() {
 			continue
 		}
 		ctx, cancel := context.WithTimeout(context.Background(), egressRetryCallTimeout)
-		s.pushEgressSerialized(ctx, st)
+		pending, err := s.pushEgressSerialized(ctx, st)
 		cancel()
+		if err == nil && !pending {
+			CubeLog.WithContext(context.Background()).Infof(
+				"network-agent retry egress policy succeeded: sandbox_ip=%s", st.SandboxIP)
+		}
 	}
 }
 

--- a/network-agent/internal/service/cubeegress_push.go
+++ b/network-agent/internal/service/cubeegress_push.go
@@ -164,35 +164,31 @@ func (s *localService) deleteEgressForState(ctx context.Context, sandboxID, sand
 	}
 }
 
-// retryPendingEgressPushes is invoked from the maintenance loop. It
-// iterates current managed states and re-pushes any that have
-// pendingEgressPush=true. Holds s.mu for the duration of each per-state
-// push so the state map can't change underneath us; the actual HTTP
-// call happens with the lock released to avoid blocking the data plane.
+// retryPendingEgressPushes is invoked from the maintenance loop. It re-pushes
+// every managed state with pendingEgressPush=true. Each push renders the policy
+// under s.mu, releases the lock for the HTTP call, then re-acquires it to record
+// the result — and skips any state whose flag was cleared by a concurrent
+// UpdateEgressRule in the meantime, so a stale snapshot can never overwrite a
+// freshly rotated credential in CubeEgress.
 func (s *localService) retryPendingEgressPushes() {
 	if s.egress == nil || !s.egress.Configured() {
 		return
 	}
-	// Snapshot states needing retry so we don't hold the lock during HTTP I/O.
+	// Snapshot which sandboxes need a retry; we don't hold the lock during HTTP
+	// I/O. We deliberately do NOT capture the rendered policy here: it is
+	// re-read under the lock just before each push so a concurrent
+	// UpdateEgressRule can't have us overwrite a freshly rotated credential with
+	// a stale snapshot (TOCTOU).
 	type pending struct {
 		state *managedState
 		ip    string
-		input *cubeegress.PolicyInput
 	}
 	var todo []pending
 	s.mu.Lock()
 	for _, st := range s.states {
-		if !st.pendingEgressPush {
-			continue
+		if st.pendingEgressPush {
+			todo = append(todo, pending{state: st, ip: st.SandboxIP})
 		}
-		input := toEgressInput(st.CubeNetworkConfig)
-		if input == nil {
-			// Pending got set but rules are gone (mutation we don't yet
-			// support). Clear the flag.
-			st.pendingEgressPush = false
-			continue
-		}
-		todo = append(todo, pending{state: st, ip: st.SandboxIP, input: input})
 	}
 	s.mu.Unlock()
 
@@ -202,8 +198,26 @@ func (s *localService) retryPendingEgressPushes() {
 
 	logger := CubeLog.WithContext(context.Background())
 	for _, item := range todo {
+		// Re-check and re-render under the lock: a concurrent UpdateEgressRule
+		// may have pushed a fresh policy and cleared the flag since we
+		// snapshotted. If so, skip — that push already superseded this retry.
+		s.mu.Lock()
+		if !item.state.pendingEgressPush {
+			s.mu.Unlock()
+			continue
+		}
+		input := toEgressInput(item.state.CubeNetworkConfig)
+		s.mu.Unlock()
+		if input == nil {
+			// Pending was set but the rules are gone; clear the flag.
+			s.mu.Lock()
+			item.state.pendingEgressPush = false
+			s.mu.Unlock()
+			continue
+		}
+
 		ctx, cancel := context.WithTimeout(context.Background(), egressRetryCallTimeout)
-		err := s.egress.PutPolicy(ctx, item.ip, item.input)
+		err := s.egress.PutPolicy(ctx, item.ip, input)
 		cancel()
 		s.mu.Lock()
 		switch {

--- a/network-agent/internal/service/cubeegress_update_test.go
+++ b/network-agent/internal/service/cubeegress_update_test.go
@@ -200,3 +200,34 @@ func TestUpdateEgressRuleValidation(t *testing.T) {
 		})
 	}
 }
+
+// TestUpdateEgressRuleClonesCallerRule guards the aliasing hazard: the stored
+// and persisted state must be independent of the caller's rule pointer, so a
+// later mutation of it cannot silently diverge in-memory state from disk.
+func TestUpdateEgressRuleClonesCallerRule(t *testing.T) {
+	s, _ := ueService(t)
+	ueSeed(s, "sb-1", "sb-1", "192.168.0.10")
+
+	rule := ueRule("gitlab_token", "tok-A")
+	if _, err := s.UpdateEgressRule(context.Background(), &UpdateEgressRuleRequest{
+		SandboxID: "sb-1",
+		Rule:      rule,
+	}); err != nil {
+		t.Fatalf("UpdateEgressRule error=%v", err)
+	}
+
+	// Mutate the caller's rule after the call returned.
+	rule.Name = "renamed"
+	rule.Action.Inject[0].Secret = "MUTATED"
+
+	stored := s.states["sb-1"].CubeNetworkConfig.Rules[0]
+	if stored.Name != "gitlab_token" || stored.Action.Inject[0].Secret != "tok-A" {
+		t.Fatalf("in-memory state aliased the caller's rule: name=%q secret=%q",
+			stored.Name, stored.Action.Inject[0].Secret)
+	}
+	persisted := ueLoadRules(t, s, "sb-1")
+	if persisted[0].Name != "gitlab_token" || persisted[0].Action.Inject[0].Secret != "tok-A" {
+		t.Fatalf("persisted state aliased the caller's rule: name=%q secret=%q",
+			persisted[0].Name, persisted[0].Action.Inject[0].Secret)
+	}
+}

--- a/network-agent/internal/service/cubeegress_update_test.go
+++ b/network-agent/internal/service/cubeegress_update_test.go
@@ -333,6 +333,32 @@ func TestUpdateEgressRuleRollsBackOnPersistFailure(t *testing.T) {
 	}
 }
 
+// TestUpdateEgressRulePermanentPushFailureNotApplied verifies Applied honestly
+// reports not-live on a permanent CubeEgress rejection: the rule is persisted,
+// but both Applied and Pending are false (a 4xx is not retried).
+func TestUpdateEgressRulePermanentPushFailureNotApplied(t *testing.T) {
+	s, fake := ueService(t)
+	fake.putErrs["192.168.0.10"] = []error{&cubeegress.PermanentError{Status: 400, Body: "bad rule"}}
+	ueSeed(s, "sb-1", "sb-1", "192.168.0.10")
+
+	resp, err := s.UpdateEgressRule(context.Background(), &UpdateEgressRuleRequest{
+		SandboxID: "sb-1",
+		Rule:      ueRule("gitlab_token", "tok-A"),
+	})
+	if err != nil {
+		t.Fatalf("a permanent push failure must not fail the call, got err=%v", err)
+	}
+	if resp.Applied {
+		t.Fatal("Applied must be false when CubeEgress permanently rejected the rule")
+	}
+	if resp.Pending {
+		t.Fatal("Pending must be false on a permanent failure (a 4xx is not retried)")
+	}
+	if rules := ueLoadRules(t, s, "sb-1"); len(rules) != 1 || rules[0].Name != "gitlab_token" {
+		t.Fatalf("rule not persisted on permanent failure: %+v", rules)
+	}
+}
+
 // TestPushEgressSerializedPerSandbox verifies that concurrent pushes for the same
 // sandbox are serialized by egressPushMu (the fix for the retry/update TOCTOU
 // window): the hook records how many pushes are inside PutPolicy at once, which

--- a/network-agent/internal/service/cubeegress_update_test.go
+++ b/network-agent/internal/service/cubeegress_update_test.go
@@ -7,7 +7,9 @@ package service
 import (
 	"context"
 	"errors"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/tencentcloud/CubeSandbox/network-agent/internal/cubeegress"
 )
@@ -193,6 +195,11 @@ func TestUpdateEgressRuleFindsStateByNetworkHandle(t *testing.T) {
 	if resp.RuleCount != 1 {
 		t.Fatalf("RuleCount=%d, want 1", resp.RuleCount)
 	}
+	// The response reports the resolved state's sandbox ID, not the (empty)
+	// SandboxID from a handle-based request.
+	if resp.SandboxID != "sb-1" {
+		t.Fatalf("SandboxID=%q, want sb-1 (resolved from the network handle)", resp.SandboxID)
+	}
 }
 
 func TestUpdateEgressRuleValidation(t *testing.T) {
@@ -287,5 +294,80 @@ func TestRetryPendingEgressPushesSkipsFlagClearedMidBatch(t *testing.T) {
 	}
 	if pushed != 1 {
 		t.Fatalf("expected exactly 1 retry push (second skipped after its flag cleared mid-batch), got %d", pushed)
+	}
+}
+
+// TestUpdateEgressRuleRollsBackOnPersistFailure verifies the in-memory rule set
+// is restored when store.Save fails, so it can't diverge from disk. A SandboxID
+// containing '.' makes stateStore.path (and thus Save) fail deterministically.
+func TestUpdateEgressRuleRollsBackOnPersistFailure(t *testing.T) {
+	s, _ := ueService(t)
+	ueSeed(s, "nh-1", "bad.id", "192.168.0.10", ueRule("keep", "v1"))
+
+	// Append path: the appended rule must be rolled back.
+	if _, err := s.UpdateEgressRule(context.Background(), &UpdateEgressRuleRequest{
+		NetworkHandle: "nh-1",
+		Rule:          ueRule("added", "v2"),
+	}); err == nil {
+		t.Fatal("expected a persist error for an invalid sandbox id")
+	}
+	rules := s.states["nh-1"].CubeNetworkConfig.Rules
+	if len(rules) != 1 || rules[0].Name != "keep" {
+		t.Fatalf("append not rolled back on persist failure: %+v", rules)
+	}
+
+	// Replace path: the original rule must be restored, not the new value.
+	if _, err := s.UpdateEgressRule(context.Background(), &UpdateEgressRuleRequest{
+		NetworkHandle: "nh-1",
+		Rule:          ueRule("keep", "v2-new"),
+	}); err == nil {
+		t.Fatal("expected a persist error for an invalid sandbox id")
+	}
+	rules = s.states["nh-1"].CubeNetworkConfig.Rules
+	if len(rules) != 1 || rules[0].Action.Inject[0].Secret != "v1" {
+		t.Fatalf("replace not rolled back on persist failure: %+v", rules)
+	}
+}
+
+// TestPushEgressSerializedPerSandbox verifies that concurrent pushes for the same
+// sandbox are serialized by egressPushMu (the fix for the retry/update TOCTOU
+// window): the hook records how many pushes are inside PutPolicy at once, which
+// must never exceed 1.
+func TestPushEgressSerializedPerSandbox(t *testing.T) {
+	store, err := newStateStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("newStateStore error=%v", err)
+	}
+	hook := &hookEgress{fakeEgress: newFakeEgress()}
+	s := &localService{store: store, egress: hook, states: map[string]*managedState{}}
+	ueSeed(s, "sb-1", "sb-1", "192.168.0.10", ueRule("cred", "v"))
+
+	var mu sync.Mutex
+	active, maxActive := 0, 0
+	hook.onPut = func(string) {
+		mu.Lock()
+		active++
+		if active > maxActive {
+			maxActive = active
+		}
+		mu.Unlock()
+		time.Sleep(2 * time.Millisecond) // widen the window so a missing lock would overlap
+		mu.Lock()
+		active--
+		mu.Unlock()
+	}
+
+	var wg sync.WaitGroup
+	for i := 0; i < 4; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			s.pushEgressSerialized(context.Background(), s.states["sb-1"])
+		}()
+	}
+	wg.Wait()
+
+	if maxActive != 1 {
+		t.Fatalf("pushes for the same sandbox overlapped (maxActive=%d); egressPushMu not serializing", maxActive)
 	}
 }

--- a/network-agent/internal/service/cubeegress_update_test.go
+++ b/network-agent/internal/service/cubeegress_update_test.go
@@ -1,0 +1,202 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package service
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+func ueStrPtr(s string) *string { return &s }
+
+// ueRule builds a minimal inject rule whose injected secret is the one thing a
+// credential refresh changes, so tests can assert what UpdateEgressRule persisted.
+func ueRule(name, secret string) *EgressRule {
+	return &EgressRule{
+		Name:  name,
+		Match: &EgressRuleMatch{Path: ueStrPtr("/api/*")},
+		Action: &EgressRuleAction{
+			Allow:  true,
+			Inject: []*EgressRuleInject{{Header: "Authorization", Secret: secret}},
+		},
+	}
+}
+
+// ueService builds a localService with a real on-disk store (so persistence is
+// exercised for real) and an injectable fake CubeEgress client.
+func ueService(t *testing.T) (*localService, *fakeEgress) {
+	t.Helper()
+	store, err := newStateStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("newStateStore error=%v", err)
+	}
+	fake := newFakeEgress()
+	return &localService{
+		store:  store,
+		egress: fake,
+		states: map[string]*managedState{},
+	}, fake
+}
+
+func ueSeed(s *localService, key, sandboxID, sandboxIP string, rules ...*EgressRule) {
+	s.states[key] = &managedState{
+		persistedState: persistedState{
+			SandboxID:         sandboxID,
+			SandboxIP:         sandboxIP,
+			CubeNetworkConfig: &CubeNetworkConfig{Rules: rules},
+		},
+	}
+}
+
+// ueLoadRules reads the rule set back from the store to prove it was persisted,
+// not merely mutated in memory.
+func ueLoadRules(t *testing.T, s *localService, sandboxID string) []*EgressRule {
+	t.Helper()
+	all, err := s.store.LoadAll()
+	if err != nil {
+		t.Fatalf("LoadAll error=%v", err)
+	}
+	for _, st := range all {
+		if st.SandboxID == sandboxID {
+			if st.CubeNetworkConfig == nil {
+				return nil
+			}
+			return st.CubeNetworkConfig.Rules
+		}
+	}
+	t.Fatalf("sandbox %q not found in store", sandboxID)
+	return nil
+}
+
+func TestUpdateEgressRuleAppendsNewRule(t *testing.T) {
+	s, fake := ueService(t)
+	ueSeed(s, "sb-1", "sb-1", "192.168.0.10")
+
+	resp, err := s.UpdateEgressRule(context.Background(), &UpdateEgressRuleRequest{
+		SandboxID: "sb-1",
+		Rule:      ueRule("gitlab_token", "tok-A"),
+	})
+	if err != nil {
+		t.Fatalf("UpdateEgressRule error=%v", err)
+	}
+	if !resp.Applied || resp.Pending {
+		t.Fatalf("want applied on a healthy push, got applied=%v pending=%v", resp.Applied, resp.Pending)
+	}
+	if resp.RuleCount != 1 {
+		t.Fatalf("RuleCount=%d, want 1", resp.RuleCount)
+	}
+	if resp.SandboxIP != "192.168.0.10" {
+		t.Fatalf("SandboxIP=%q, want 192.168.0.10", resp.SandboxIP)
+	}
+	if fake.putCount() != 1 {
+		t.Fatalf("put count=%d, want 1 (live re-push)", fake.putCount())
+	}
+	rules := ueLoadRules(t, s, "sb-1")
+	if len(rules) != 1 || rules[0].Name != "gitlab_token" {
+		t.Fatalf("persisted rules=%+v, want one gitlab_token rule", rules)
+	}
+	if got := rules[0].Action.Inject[0].Secret; got != "tok-A" {
+		t.Fatalf("persisted secret=%q, want tok-A", got)
+	}
+}
+
+func TestUpdateEgressRuleReplacesByNameInPlace(t *testing.T) {
+	s, fake := ueService(t)
+	ueSeed(s, "sb-1", "sb-1", "192.168.0.10",
+		ueRule("api_bearer", "old"),
+		ueRule("git_basic", "keep-me"),
+	)
+
+	resp, err := s.UpdateEgressRule(context.Background(), &UpdateEgressRuleRequest{
+		SandboxID: "sb-1",
+		Rule:      ueRule("api_bearer", "fresh"),
+	})
+	if err != nil {
+		t.Fatalf("UpdateEgressRule error=%v", err)
+	}
+	// Replace, not append: count stays 2 and order is preserved.
+	if resp.RuleCount != 2 {
+		t.Fatalf("RuleCount=%d, want 2 (replace-by-name, not append)", resp.RuleCount)
+	}
+	rules := ueLoadRules(t, s, "sb-1")
+	if len(rules) != 2 {
+		t.Fatalf("persisted %d rules, want 2", len(rules))
+	}
+	if rules[0].Name != "api_bearer" || rules[1].Name != "git_basic" {
+		t.Fatalf("rule order changed: %q, %q", rules[0].Name, rules[1].Name)
+	}
+	if got := rules[0].Action.Inject[0].Secret; got != "fresh" {
+		t.Fatalf("api_bearer secret=%q, want fresh (refreshed in place)", got)
+	}
+	if got := rules[1].Action.Inject[0].Secret; got != "keep-me" {
+		t.Fatalf("git_basic secret=%q, want keep-me (untouched)", got)
+	}
+	if n := fake.puts[len(fake.puts)-1].rules; n != 2 {
+		t.Fatalf("re-pushed %d rules, want the full set of 2", n)
+	}
+}
+
+// TestUpdateEgressRulePersistsEvenWhenPushFails is the durability guarantee:
+// the rule is saved to disk BEFORE the CubeEgress push, so a transient push
+// failure still leaves the refreshed credential persisted for the retry loop.
+func TestUpdateEgressRulePersistsEvenWhenPushFails(t *testing.T) {
+	s, fake := ueService(t)
+	fake.putErrs["192.168.0.10"] = []error{errors.New("connection refused")}
+	ueSeed(s, "sb-1", "sb-1", "192.168.0.10")
+
+	resp, err := s.UpdateEgressRule(context.Background(), &UpdateEgressRuleRequest{
+		SandboxID: "sb-1",
+		Rule:      ueRule("gitlab_token", "tok-A"),
+	})
+	if err != nil {
+		t.Fatalf("a transient push failure must not fail the call, got err=%v", err)
+	}
+	if resp.Applied || !resp.Pending {
+		t.Fatalf("want pending on a transient push failure, got applied=%v pending=%v", resp.Applied, resp.Pending)
+	}
+	rules := ueLoadRules(t, s, "sb-1")
+	if len(rules) != 1 || rules[0].Action.Inject[0].Secret != "tok-A" {
+		t.Fatalf("rule not persisted despite push failure: %+v", rules)
+	}
+}
+
+func TestUpdateEgressRuleFindsStateByNetworkHandle(t *testing.T) {
+	s, _ := ueService(t)
+	ueSeed(s, "nh-1", "sb-1", "192.168.0.10")
+
+	resp, err := s.UpdateEgressRule(context.Background(), &UpdateEgressRuleRequest{
+		NetworkHandle: "nh-1",
+		Rule:          ueRule("gitlab_token", "tok-A"),
+	})
+	if err != nil {
+		t.Fatalf("UpdateEgressRule via network handle error=%v", err)
+	}
+	if resp.RuleCount != 1 {
+		t.Fatalf("RuleCount=%d, want 1", resp.RuleCount)
+	}
+}
+
+func TestUpdateEgressRuleValidation(t *testing.T) {
+	s, _ := ueService(t)
+	ueSeed(s, "sb-1", "sb-1", "192.168.0.10")
+
+	cases := []struct {
+		name string
+		req  *UpdateEgressRuleRequest
+	}{
+		{"nil request", nil},
+		{"nil rule", &UpdateEgressRuleRequest{SandboxID: "sb-1"}},
+		{"empty rule name", &UpdateEgressRuleRequest{SandboxID: "sb-1", Rule: &EgressRule{}}},
+		{"unknown sandbox", &UpdateEgressRuleRequest{SandboxID: "nope", Rule: ueRule("r", "v")}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := s.UpdateEgressRule(context.Background(), tc.req); err == nil {
+				t.Fatalf("expected error for %s, got nil", tc.name)
+			}
+		})
+	}
+}

--- a/network-agent/internal/service/cubeegress_update_test.go
+++ b/network-agent/internal/service/cubeegress_update_test.go
@@ -8,7 +8,23 @@ import (
 	"context"
 	"errors"
 	"testing"
+
+	"github.com/tencentcloud/CubeSandbox/network-agent/internal/cubeegress"
 )
+
+// hookEgress wraps fakeEgress to run a callback on each PutPolicy, letting a
+// test simulate a concurrent operation landing mid-batch.
+type hookEgress struct {
+	*fakeEgress
+	onPut func(ip string)
+}
+
+func (h *hookEgress) PutPolicy(ctx context.Context, ip string, in *cubeegress.PolicyInput) error {
+	if h.onPut != nil {
+		h.onPut(ip)
+	}
+	return h.fakeEgress.PutPolicy(ctx, ip, in)
+}
 
 func ueStrPtr(s string) *string { return &s }
 
@@ -229,5 +245,47 @@ func TestUpdateEgressRuleClonesCallerRule(t *testing.T) {
 	if persisted[0].Name != "gitlab_token" || persisted[0].Action.Inject[0].Secret != "tok-A" {
 		t.Fatalf("persisted state aliased the caller's rule: name=%q secret=%q",
 			persisted[0].Name, persisted[0].Action.Inject[0].Secret)
+	}
+}
+
+// TestRetryPendingEgressPushesSkipsFlagClearedMidBatch guards the TOCTOU race:
+// the retry loop must not overwrite CubeEgress with a stale snapshot after a
+// concurrent UpdateEgressRule has pushed a fresh policy and cleared the pending
+// flag. Two sandboxes are pending; whichever the retry pushes first simulates
+// that concurrent push by clearing the OTHER's flag, so exactly one push must
+// happen — the second must be skipped, not re-pushed with stale data.
+func TestRetryPendingEgressPushesSkipsFlagClearedMidBatch(t *testing.T) {
+	store, err := newStateStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("newStateStore error=%v", err)
+	}
+	fake := newFakeEgress()
+	hook := &hookEgress{fakeEgress: fake}
+	s := &localService{store: store, egress: hook, states: map[string]*managedState{}}
+	ueSeed(s, "sb-a", "sb-a", "192.168.0.10", ueRule("cred", "old"))
+	ueSeed(s, "sb-b", "sb-b", "192.168.0.11", ueRule("cred", "old"))
+	s.states["sb-a"].pendingEgressPush = true
+	s.states["sb-b"].pendingEgressPush = true
+
+	hook.onPut = func(ip string) {
+		other := "sb-b"
+		if ip == "192.168.0.11" {
+			other = "sb-a"
+		}
+		s.mu.Lock()
+		s.states[other].pendingEgressPush = false
+		s.mu.Unlock()
+	}
+
+	s.retryPendingEgressPushes()
+
+	pushed := 0
+	for _, p := range fake.puts {
+		if p.ip == "192.168.0.10" || p.ip == "192.168.0.11" {
+			pushed++
+		}
+	}
+	if pushed != 1 {
+		t.Fatalf("expected exactly 1 retry push (second skipped after its flag cleared mid-batch), got %d", pushed)
 	}
 }

--- a/network-agent/internal/service/cubeegress_update_test.go
+++ b/network-agent/internal/service/cubeegress_update_test.go
@@ -59,6 +59,10 @@ func ueService(t *testing.T) (*localService, *fakeEgress) {
 	}, fake
 }
 
+// ueSeed registers a managed state directly in s.states, in memory only — it does
+// NOT write the store, so a test must call UpdateEgressRule (which persists)
+// before relying on ueLoadRules. key is the s.states map key and may differ from
+// sandboxID (e.g. a network handle), letting tests exercise handle-based lookups.
 func ueSeed(s *localService, key, sandboxID, sandboxIP string, rules ...*EgressRule) {
 	s.states[key] = &managedState{
 		persistedState: persistedState{

--- a/network-agent/internal/service/local_service.go
+++ b/network-agent/internal/service/local_service.go
@@ -1049,40 +1049,49 @@ func cloneEgressRules(in []*EgressRule) []*EgressRule {
 	}
 	out := make([]*EgressRule, 0, len(in))
 	for _, r := range in {
-		if r == nil {
-			continue
+		if cp := cloneEgressRule(r); cp != nil {
+			out = append(out, cp)
 		}
-		cp := &EgressRule{Name: r.Name}
-		if r.Match != nil {
-			match := *r.Match
-			match.Method = append([]string(nil), r.Match.Method...)
-			cp.Match = &match
-		}
-		if r.Action != nil {
-			action := &EgressRuleAction{Allow: r.Action.Allow}
-			if r.Action.Audit != nil {
-				audit := *r.Action.Audit
-				action.Audit = &audit
-			}
-			if len(r.Action.Inject) > 0 {
-				action.Inject = make([]*EgressRuleInject, 0, len(r.Action.Inject))
-				for _, inj := range r.Action.Inject {
-					if inj == nil {
-						continue
-					}
-					injCopy := *inj
-					if inj.Format != nil {
-						format := *inj.Format
-						injCopy.Format = &format
-					}
-					action.Inject = append(action.Inject, &injCopy)
-				}
-			}
-			cp.Action = action
-		}
-		out = append(out, cp)
 	}
 	return out
+}
+
+// cloneEgressRule deep-copies a single egress rule (including its Match, Action,
+// and Inject secrets) so a pointer retained by the caller can't later mutate
+// stored state. Returns nil for a nil input.
+func cloneEgressRule(r *EgressRule) *EgressRule {
+	if r == nil {
+		return nil
+	}
+	cp := &EgressRule{Name: r.Name}
+	if r.Match != nil {
+		match := *r.Match
+		match.Method = append([]string(nil), r.Match.Method...)
+		cp.Match = &match
+	}
+	if r.Action != nil {
+		action := &EgressRuleAction{Allow: r.Action.Allow}
+		if r.Action.Audit != nil {
+			audit := *r.Action.Audit
+			action.Audit = &audit
+		}
+		if len(r.Action.Inject) > 0 {
+			action.Inject = make([]*EgressRuleInject, 0, len(r.Action.Inject))
+			for _, inj := range r.Action.Inject {
+				if inj == nil {
+					continue
+				}
+				injCopy := *inj
+				if inj.Format != nil {
+					format := *inj.Format
+					injCopy.Format = &format
+				}
+				action.Inject = append(action.Inject, &injCopy)
+			}
+		}
+		cp.Action = action
+	}
+	return cp
 }
 
 func formatCubeNetworkConfig(in *CubeNetworkConfig) string {

--- a/network-agent/internal/service/local_service.go
+++ b/network-agent/internal/service/local_service.go
@@ -331,6 +331,63 @@ func (s *localService) ReconcileNetwork(ctx context.Context, req *ReconcileNetwo
 	}, nil
 }
 
+// UpdateEgressRule upserts a single L7 egress rule (keyed by Name == CubeEgress
+// rule id) into a RUNNING sandbox's policy. It is the durable counterpart to
+// CubeEgress's ephemeral admin PATCH: the rule is written into the persisted
+// CubeNetworkConfig and Saved to disk, so it survives a CubeEgress restart
+// (bootstrap re-hydrates from DumpEgressPolicies, which reads this state), and
+// then the full policy is re-pushed so the change takes effect on the next
+// request. Typical use: refresh an injected per-user credential when its token
+// rotates, without recreating the sandbox.
+func (s *localService) UpdateEgressRule(ctx context.Context, req *UpdateEgressRuleRequest) (*UpdateEgressRuleResponse, error) {
+	if req == nil || req.Rule == nil || req.Rule.Name == "" {
+		return nil, fmt.Errorf("a rule with a name is required")
+	}
+	s.mu.Lock()
+	state, ok := s.lookupStateLocked(req.SandboxID, req.NetworkHandle)
+	if !ok {
+		s.mu.Unlock()
+		return nil, fmt.Errorf("network %q not found", req.SandboxID)
+	}
+	if state.CubeNetworkConfig == nil {
+		state.CubeNetworkConfig = &CubeNetworkConfig{}
+	}
+	replaced := false
+	for i, r := range state.CubeNetworkConfig.Rules {
+		if r != nil && r.Name == req.Rule.Name {
+			state.CubeNetworkConfig.Rules[i] = req.Rule
+			replaced = true
+			break
+		}
+	}
+	if !replaced {
+		state.CubeNetworkConfig.Rules = append(state.CubeNetworkConfig.Rules, req.Rule)
+	}
+	// Persist BEFORE pushing so the change survives a CubeEgress restart even if
+	// the push below fails and only the maintenance loop lands it later.
+	if err := s.store.Save(&state.persistedState); err != nil {
+		s.mu.Unlock()
+		return nil, fmt.Errorf("persist updated egress rule: %w", err)
+	}
+	ip := state.SandboxIP
+	ruleCount := len(state.CubeNetworkConfig.Rules)
+	// Re-push the full updated policy via the same best-effort dispatcher
+	// EnsureNetwork uses; a transient failure sets pendingEgressPush so the
+	// maintenance loop retries. Held under s.mu (a bounded localhost call) so the
+	// pendingEgressPush read is race-free.
+	s.pushEgressForState(ctx, state)
+	pending := state.pendingEgressPush
+	s.mu.Unlock()
+
+	return &UpdateEgressRuleResponse{
+		SandboxID: req.SandboxID,
+		SandboxIP: ip,
+		Applied:   !pending,
+		Pending:   pending,
+		RuleCount: ruleCount,
+	}, nil
+}
+
 func (s *localService) GetNetwork(ctx context.Context, req *GetNetworkRequest) (*GetNetworkResponse, error) {
 	_ = ctx
 	s.mu.Lock()

--- a/network-agent/internal/service/local_service.go
+++ b/network-agent/internal/service/local_service.go
@@ -343,6 +343,12 @@ func (s *localService) UpdateEgressRule(ctx context.Context, req *UpdateEgressRu
 	if req == nil || req.Rule == nil || req.Rule.Name == "" {
 		return nil, fmt.Errorf("a rule with a name is required")
 	}
+	// Clone the caller's rule before storing it. EnsureNetwork deep-clones its
+	// config for the same reason: a caller that retains and later mutates
+	// req.Rule must not be able to silently diverge our in-memory state from
+	// what we persisted to disk.
+	rule := cloneEgressRule(req.Rule)
+
 	s.mu.Lock()
 	state, ok := s.lookupStateLocked(req.SandboxID, req.NetworkHandle)
 	if !ok {
@@ -354,14 +360,14 @@ func (s *localService) UpdateEgressRule(ctx context.Context, req *UpdateEgressRu
 	}
 	replaced := false
 	for i, r := range state.CubeNetworkConfig.Rules {
-		if r != nil && r.Name == req.Rule.Name {
-			state.CubeNetworkConfig.Rules[i] = req.Rule
+		if r != nil && r.Name == rule.Name {
+			state.CubeNetworkConfig.Rules[i] = rule
 			replaced = true
 			break
 		}
 	}
 	if !replaced {
-		state.CubeNetworkConfig.Rules = append(state.CubeNetworkConfig.Rules, req.Rule)
+		state.CubeNetworkConfig.Rules = append(state.CubeNetworkConfig.Rules, rule)
 	}
 	// Persist BEFORE pushing so the change survives a CubeEgress restart even if
 	// the push below fails and only the maintenance loop lands it later.
@@ -371,13 +377,23 @@ func (s *localService) UpdateEgressRule(ctx context.Context, req *UpdateEgressRu
 	}
 	ip := state.SandboxIP
 	ruleCount := len(state.CubeNetworkConfig.Rules)
-	// Re-push the full updated policy via the same best-effort dispatcher
-	// EnsureNetwork uses; a transient failure sets pendingEgressPush so the
-	// maintenance loop retries. Held under s.mu (a bounded localhost call) so the
-	// pendingEgressPush read is race-free.
-	s.pushEgressForState(ctx, state)
-	pending := state.pendingEgressPush
+	// Render the policy under the lock, then push with the lock RELEASED so a
+	// slow CubeEgress call can't block the data plane for every other sandbox.
+	// Unlike createState (which pushes before the state is visible in s.states),
+	// this state is already shared, so we mirror retryPendingEgressPushes:
+	// snapshot here, push lock-free, and re-acquire only to record the outcome.
+	input := toEgressInput(state.CubeNetworkConfig)
+	pushable := s.egress != nil && s.egress.Configured()
 	s.mu.Unlock()
+
+	pending := false
+	if pushable && input != nil {
+		err := s.egress.PutPolicy(ctx, ip, input)
+		s.mu.Lock()
+		applyEgressPushResult(ctx, state, err)
+		pending = state.pendingEgressPush
+		s.mu.Unlock()
+	}
 
 	return &UpdateEgressRuleResponse{
 		SandboxID: req.SandboxID,

--- a/network-agent/internal/service/local_service.go
+++ b/network-agent/internal/service/local_service.go
@@ -53,6 +53,13 @@ type managedState struct {
 	// sandbox is released. Permanent failures (4xx) clear the flag —
 	// retrying a malformed body won't fix it.
 	pendingEgressPush bool
+
+	// egressPushMu serializes CubeEgress pushes for THIS sandbox so a live
+	// UpdateEgressRule and a maintenance retry can't interleave and leave a
+	// stale policy live: whichever push runs last re-renders the rules and
+	// therefore reflects the latest state. It is distinct from s.mu (which is
+	// never held during the HTTP call) and is only ever taken without s.mu held.
+	egressPushMu sync.Mutex
 }
 
 type localService struct {
@@ -353,14 +360,17 @@ func (s *localService) UpdateEgressRule(ctx context.Context, req *UpdateEgressRu
 	state, ok := s.lookupStateLocked(req.SandboxID, req.NetworkHandle)
 	if !ok {
 		s.mu.Unlock()
-		return nil, fmt.Errorf("network %q not found", req.SandboxID)
+		return nil, fmt.Errorf("network %q not found", nonEmpty(req.SandboxID, req.NetworkHandle))
 	}
 	if state.CubeNetworkConfig == nil {
 		state.CubeNetworkConfig = &CubeNetworkConfig{}
 	}
 	replaced := false
+	replacedIdx := -1
+	var replacedOld *EgressRule
 	for i, r := range state.CubeNetworkConfig.Rules {
 		if r != nil && r.Name == rule.Name {
+			replacedIdx, replacedOld = i, r
 			state.CubeNetworkConfig.Rules[i] = rule
 			replaced = true
 			break
@@ -370,33 +380,31 @@ func (s *localService) UpdateEgressRule(ctx context.Context, req *UpdateEgressRu
 		state.CubeNetworkConfig.Rules = append(state.CubeNetworkConfig.Rules, rule)
 	}
 	// Persist BEFORE pushing so the change survives a CubeEgress restart even if
-	// the push below fails and only the maintenance loop lands it later.
+	// the push below fails and only the maintenance loop lands it later. On a
+	// persist failure, roll back the in-memory mutation so state can't diverge
+	// from disk — a later restart would otherwise drop or resurrect a rule.
 	if err := s.store.Save(&state.persistedState); err != nil {
+		if replaced {
+			state.CubeNetworkConfig.Rules[replacedIdx] = replacedOld
+		} else {
+			state.CubeNetworkConfig.Rules = state.CubeNetworkConfig.Rules[:len(state.CubeNetworkConfig.Rules)-1]
+		}
 		s.mu.Unlock()
 		return nil, fmt.Errorf("persist updated egress rule: %w", err)
 	}
+	sandboxID := state.SandboxID
 	ip := state.SandboxIP
 	ruleCount := len(state.CubeNetworkConfig.Rules)
-	// Render the policy under the lock, then push with the lock RELEASED so a
-	// slow CubeEgress call can't block the data plane for every other sandbox.
-	// Unlike createState (which pushes before the state is visible in s.states),
-	// this state is already shared, so we mirror retryPendingEgressPushes:
-	// snapshot here, push lock-free, and re-acquire only to record the outcome.
-	input := toEgressInput(state.CubeNetworkConfig)
-	pushable := s.egress != nil && s.egress.Configured()
 	s.mu.Unlock()
 
-	pending := false
-	if pushable && input != nil {
-		err := s.egress.PutPolicy(ctx, ip, input)
-		s.mu.Lock()
-		applyEgressPushResult(ctx, state, err)
-		pending = state.pendingEgressPush
-		s.mu.Unlock()
-	}
+	// Push to CubeEgress serialized per sandbox (see pushEgressSerialized) so a
+	// concurrent maintenance retry can't overwrite this update with a stale
+	// policy. The rule is persisted above regardless, so a transient push
+	// failure is picked up by the maintenance loop.
+	pending := s.pushEgressSerialized(ctx, state)
 
 	return &UpdateEgressRuleResponse{
-		SandboxID: req.SandboxID,
+		SandboxID: sandboxID,
 		SandboxIP: ip,
 		Applied:   !pending,
 		Pending:   pending,

--- a/network-agent/internal/service/local_service.go
+++ b/network-agent/internal/service/local_service.go
@@ -401,12 +401,15 @@ func (s *localService) UpdateEgressRule(ctx context.Context, req *UpdateEgressRu
 	// concurrent maintenance retry can't overwrite this update with a stale
 	// policy. The rule is persisted above regardless, so a transient push
 	// failure is picked up by the maintenance loop.
-	pending := s.pushEgressSerialized(ctx, state)
+	pending, err := s.pushEgressSerialized(ctx, state)
 
 	return &UpdateEgressRuleResponse{
 		SandboxID: sandboxID,
 		SandboxIP: ip,
-		Applied:   !pending,
+		// Applied reflects reality: true only when the push actually landed (or
+		// none was needed). A permanent rejection clears Pending but leaves the
+		// rule not-live, so err != nil keeps Applied false there too.
+		Applied:   err == nil,
 		Pending:   pending,
 		RuleCount: ruleCount,
 	}, nil

--- a/network-agent/internal/service/service.go
+++ b/network-agent/internal/service/service.go
@@ -11,6 +11,7 @@ type Service interface {
 	EnsureNetwork(ctx context.Context, req *EnsureNetworkRequest) (*EnsureNetworkResponse, error)
 	ReleaseNetwork(ctx context.Context, req *ReleaseNetworkRequest) (*ReleaseNetworkResponse, error)
 	ReconcileNetwork(ctx context.Context, req *ReconcileNetworkRequest) (*ReconcileNetworkResponse, error)
+	UpdateEgressRule(ctx context.Context, req *UpdateEgressRuleRequest) (*UpdateEgressRuleResponse, error)
 	GetNetwork(ctx context.Context, req *GetNetworkRequest) (*GetNetworkResponse, error)
 	ListNetworks(ctx context.Context, req *ListNetworksRequest) (*ListNetworksResponse, error)
 	Health(ctx context.Context) error
@@ -56,6 +57,10 @@ func (s *noopService) ReconcileNetwork(ctx context.Context, req *ReconcileNetwor
 		Converged:       true,
 		PersistMetadata: req.PersistMetadata,
 	}, nil
+}
+
+func (s *noopService) UpdateEgressRule(ctx context.Context, req *UpdateEgressRuleRequest) (*UpdateEgressRuleResponse, error) {
+	return &UpdateEgressRuleResponse{SandboxID: req.SandboxID, Applied: true}, nil
 }
 
 func (s *noopService) GetNetwork(ctx context.Context, req *GetNetworkRequest) (*GetNetworkResponse, error) {

--- a/network-agent/internal/service/types.go
+++ b/network-agent/internal/service/types.go
@@ -74,8 +74,9 @@ type UpdateEgressRuleRequest struct {
 type UpdateEgressRuleResponse struct {
 	SandboxID string `json:"sandboxID,omitempty"`
 	SandboxIP string `json:"sandboxIP,omitempty"`
-	// Applied is true when the rule was pushed to CubeEgress successfully and is
-	// already live on the data plane.
+	// Applied is true when the sandbox's latest egress policy is live and nothing
+	// is pending — either the push to CubeEgress succeeded, or no push was needed
+	// (no egress client is configured, or the sandbox has no L7 rules).
 	Applied bool `json:"applied"`
 	// Pending is true when the rule was persisted but its CubeEgress push failed
 	// transiently and was deferred to the maintenance retry loop. Applied and

--- a/network-agent/internal/service/types.go
+++ b/network-agent/internal/service/types.go
@@ -60,6 +60,25 @@ type ReconcileNetworkResponse struct {
 	PersistMetadata map[string]string `json:"persistMetadata,omitempty"`
 }
 
+// UpdateEgressRuleRequest upserts a single L7 egress rule on a RUNNING sandbox
+// without recreating it — used to refresh an injected credential (e.g. a rotated
+// per-user OAuth token) whose value lives only in the rule's inject secret.
+type UpdateEgressRuleRequest struct {
+	SandboxID     string `json:"sandboxID,omitempty"`
+	NetworkHandle string `json:"networkHandle,omitempty"`
+	// Rule is upserted by Name (== the CubeEgress rule id): a rule with the same
+	// Name is replaced in place (order preserved); otherwise it is appended.
+	Rule *EgressRule `json:"rule,omitempty"`
+}
+
+type UpdateEgressRuleResponse struct {
+	SandboxID string `json:"sandboxID,omitempty"`
+	SandboxIP string `json:"sandboxIP,omitempty"`
+	Applied   bool   `json:"applied"`
+	Pending   bool   `json:"pending,omitempty"`
+	RuleCount int    `json:"ruleCount"`
+}
+
 type GetNetworkRequest struct {
 	SandboxID     string `json:"sandboxID,omitempty"`
 	NetworkHandle string `json:"networkHandle,omitempty"`

--- a/network-agent/internal/service/types.go
+++ b/network-agent/internal/service/types.go
@@ -74,9 +74,11 @@ type UpdateEgressRuleRequest struct {
 type UpdateEgressRuleResponse struct {
 	SandboxID string `json:"sandboxID,omitempty"`
 	SandboxIP string `json:"sandboxIP,omitempty"`
-	// Applied is true when the sandbox's latest egress policy is live and nothing
-	// is pending — either the push to CubeEgress succeeded, or no push was needed
-	// (no egress client is configured, or the sandbox has no L7 rules).
+	// Applied is true when the sandbox's latest policy is live on CubeEgress: the
+	// push succeeded, or no push was needed (no egress client configured, or no L7
+	// rules). It is false when the push failed — transiently (Pending is then true
+	// and the maintenance loop retries) or permanently (Pending is false; the rule
+	// is persisted but CubeEgress rejected it, so it is not live).
 	Applied bool `json:"applied"`
 	// Pending is true when the rule was persisted but its CubeEgress push failed
 	// transiently and was deferred to the maintenance retry loop. Applied and

--- a/network-agent/internal/service/types.go
+++ b/network-agent/internal/service/types.go
@@ -74,9 +74,15 @@ type UpdateEgressRuleRequest struct {
 type UpdateEgressRuleResponse struct {
 	SandboxID string `json:"sandboxID,omitempty"`
 	SandboxIP string `json:"sandboxIP,omitempty"`
-	Applied   bool   `json:"applied"`
-	Pending   bool   `json:"pending,omitempty"`
-	RuleCount int    `json:"ruleCount"`
+	// Applied is true when the rule was pushed to CubeEgress successfully and is
+	// already live on the data plane.
+	Applied bool `json:"applied"`
+	// Pending is true when the rule was persisted but its CubeEgress push failed
+	// transiently and was deferred to the maintenance retry loop. Applied and
+	// Pending are mutually exclusive.
+	Pending bool `json:"pending,omitempty"`
+	// RuleCount is the number of egress rules on the sandbox after the upsert.
+	RuleCount int `json:"ruleCount"`
 }
 
 type GetNetworkRequest struct {


### PR DESCRIPTION
This adds a durable, live update path for a single L7 egress rule on a running sandbox, at the `network-agent` source-of-truth layer. A colocated caller can refresh an injected credential — e.g. a rotated short-lived OAuth token — without recreating the sandbox, and unlike a raw CubeEgress admin PATCH the change survives a CubeEgress or `network-agent` restart. I wrote this up in #1009 and that issue could be closed when this change is accepted and merged.

## Motivation

See #1009 for the full write-up. In short: injected credentials are effectively create-time today, and there is no way to swap the injected secret on a live sandbox that also persists. A direct `PATCH /admin/v1/policies/{ip}` updates the live data plane but is ephemeral, because CubeEgress re-bootstraps from `network-agent`'s `GET /v1/policies/dump` on restart and `network-agent` is the source of truth.

## What this changes

Scoped entirely to `network-agent`, split into three focused commits:

- **types** — add `UpdateEgressRuleRequest` / `UpdateEgressRuleResponse`.
- **service** — add `UpdateEgressRule` to `localService` (plus a noop stub). It upserts the rule into the sandbox's persisted `CubeNetworkConfig` by name (replaced in place when the name already exists, with order preserved; appended otherwise), calls `store.Save` **before** pushing, then re-pushes to CubeEgress via the same best-effort dispatcher `EnsureNetwork` already uses.
- **server** — expose `POST /v1/egress/update` alongside the existing `ensure` / `release` / `reconcile` / `get` / `list` routes on the loopback surface.

## Behavior

- **Live:** the rule applies on the next request with no restart, the same as the admin PATCH.
- **Durable:** persisted before the push, so it survives a CubeEgress restart (it is now part of the `/v1/policies/dump` bootstrap) and a `network-agent` restart (it is on disk).
- **Resilient:** a transient push failure does not fail the call — the rule is still persisted and `pending: true` is returned, so the existing maintenance retry loop lands it.

```jsonc
// POST /v1/egress/update
{
  "sandboxID": "sb-123",
  "rule": {
    "name": "gitlab_token",            // upsert key
    "match":  { "path": "/api/*" },
    "action": { "allow": true, "inject": [
      { "header": "Authorization", "secret": "…", "format": "Bearer %s" }
    ]}
  }
}
// -> { "sandboxID": "sb-123", "sandboxIP": "…", "applied": true, "ruleCount": 2 }
```

## Testing

- New `cubeegress_update_test.go` covers: append, in-place replace with order preserved, persist-before-push on a transient push failure, lookup by network handle, and input validation. The tests are hermetic — a real on-disk store plus a fake CubeEgress client, no netns or privileges required.
- `go vet ./internal/service/` is clean.
- Run locally: `cd network-agent && go test ./internal/service/ -run UpdateEgress -v`.

## Scope / follow-ups

- Deliberately scoped to the `network-agent` source-of-truth layer, which is where durability is decided. Threading the update up to an authenticated SDK / CubeAPI edge is a natural follow-up and can be a separate PR if that's wanted.
- The endpoint name and request/response shape are open to whatever the maintainers prefer before merge.

## Checklist

- [x] Commits are focused and atomic (one component each)
- [x] All commits are DCO signed-off
- [x] Tests added for the new behavior
- [ ] Docs — none needed for an internal loopback endpoint; happy to add a note to the `network-agent` docs if preferred