### PR TITLE
fix(cubebox): allow deleting paused sandboxes via shim binary delete

### DIFF
--- a/Cubelet/services/cubebox/destroy.go
+++ b/Cubelet/services/cubebox/destroy.go
@@ -17,6 +17,7 @@ import (
 	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/containerd/v2/pkg/cio"
 	"github.com/containerd/containerd/v2/pkg/namespaces"
+	shimclient "github.com/containerd/containerd/v2/pkg/shim"
 	"github.com/containerd/errdefs"
 	"github.com/containerd/errdefs/pkg/errgrpc"
 	"github.com/hashicorp/go-multierror"
@@ -117,12 +118,29 @@ func (l *local) Destroy(ctx context.Context, opts *workflow.DestroyContext) (err
 		containers = append(containers, ci)
 	}
 	if sb.GetStatus().IsPaused() {
-
-		ctx = constants.WithSkipRuntimeAPI(ctx)
-		if _, err := l.localTask.Delete(ctx, &tasks.DeleteTaskRequest{
-			ContainerID: sb.ID,
-		}); err != nil {
-			result = multierror.Append(result, fmt.Errorf("delete sandbox by binary failed: %w", err))
+		// A paused VM can't serve its runtime API, so the shim rejects the task
+		// delete. Force it down through the shim's own binary delete subcommand,
+		// which reaps the shim (and its in-process VMM) and reclaims the VM workdir,
+		// pause snapshot, and ivshmem file.
+		if err := l.destroyPausedSandbox(ctx, sb.ID); err != nil {
+			result = multierror.Append(result, fmt.Errorf("delete paused sandbox failed: %w", err))
+		}
+		// The shim reclaims VM-layer state; reclaim the host-side per-container
+		// resources it does not touch (containerd record, rootfs mount, fifos),
+		// which the normal (non-paused) path does via destroyContainer.
+		for _, cntr := range append(containers, sb.FirstContainer()) {
+			if cntr == nil {
+				continue
+			}
+			if er := l.cleanPausedContainerHost(ctx, cntr); er != nil {
+				result = multierror.Append(result, fmt.Errorf("clean paused container [%s]: %w", cntr.ID, er))
+			}
+			if er := l.cubeboxManger.Delete(ctx, &cubes.DeleteOption{
+				CubeboxID:   sb.ID,
+				ContainerID: cntr.ID,
+			}); er != nil {
+				log.G(ctx).Warnf("Delete container [%s] in cubestore fail: %v", cntr.ID, er)
+			}
 		}
 	} else {
 
@@ -171,6 +189,67 @@ func (l *local) Destroy(ctx context.Context, opts *workflow.DestroyContext) (err
 		return ret.Errorf(errorcode.ErrorCode_RemoveContainerFailed, "%s", er.Error())
 	}
 	return nil
+}
+
+// destroyPausedSandbox tears down a paused sandbox that can no longer serve its
+// runtime API. It runs the shim's own `delete` subcommand (the same path
+// containerd uses to reap a dead shim), which SIGKILLs the shim process,
+// reaping the in-process VMM, and reclaims the VM workdir, pause snapshot, and
+// ivshmem file via the shim's clean_sandbox_resource. It then detaches the shim
+// from the runtime manager. No custom kill logic lives in Cubelet.
+func (l *local) destroyPausedSandbox(ctx context.Context, sandboxID string) error {
+	shim, err := l.shims.Get(ctx, sandboxID)
+	if err != nil {
+		if errdefs.IsNotFound(err) {
+			return nil
+		}
+		return fmt.Errorf("get shim: %w", err)
+	}
+	bundlePath := shim.Bundle()
+	cmd, err := shimclient.Command(ctx, &shimclient.CommandConfig{
+		Runtime:      l.config.CubeShimPath,
+		Address:      l.containerdAddr,
+		TTRPCAddress: l.containerdTTRPCAddr,
+		Path:         bundlePath,
+		Args:         []string{"-id", sandboxID, "-bundle", bundlePath, "delete"},
+	})
+	if err != nil {
+		return fmt.Errorf("build shim delete command: %w", err)
+	}
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("shim delete: %w: %s", err, stderr.String())
+	}
+	// The shim (and its VMM) is already reaped; detaching only drops the runtime
+	// manager's record and removes the bundle dir, so a hiccup there must not fail
+	// the delete (a leftover bundle is reconciled by GC / on restart).
+	if err := l.shims.Delete(ctx, sandboxID); err != nil && !errdefs.IsNotFound(err) {
+		log.G(ctx).Warnf("detach shim %s after force delete: %v", sandboxID, err)
+	}
+	return nil
+}
+
+// cleanPausedContainerHost reclaims a container's host-side resources after its
+// sandbox was force-deleted while paused: the containerd container record, the
+// rootfs mount/dir, and the task IO fifos. The shim's clean_sandbox_resource
+// reclaims only VM-layer state, and the shim's task API is already gone, so this
+// makes no runtime-API call.
+func (l *local) cleanPausedContainerHost(ctx context.Context, c *cubeboxstore.Container) error {
+	var result *multierror.Error
+	if c.Container != nil {
+		if er := deleteContainer(ctx, c.Container); er != nil &&
+			!cubes.IsNotFoundContainerError(er) && !isTtrpcError(er) {
+			result = multierror.Append(result, fmt.Errorf("delete containerd container: %w", er))
+		}
+	}
+	if er := rootfs.CleanRootfs(ctx, c.ID); er != nil {
+		result = multierror.Append(result, fmt.Errorf("clean rootfs: %w", er))
+	}
+	if er := taskio.Clean(ctx, c.ID); er != nil {
+		result = multierror.Append(result, fmt.Errorf("clean fifo: %w", er))
+	}
+	return result.ErrorOrNil()
 }
 
 func sandboxDeletable(sb *cubeboxstore.CubeBox, filter *cubebox.CubeSandboxFilter) bool {

--- a/Cubelet/services/cubebox/local.go
+++ b/Cubelet/services/cubebox/local.go
@@ -204,15 +204,17 @@ func init() {
 			}
 
 			l := &local{
-				client:         client,
-				localTask:      i.(tasks.TasksClient),
-				config:         config,
-				criImage:       obj.(*cubeimages.CubeImageService),
-				cbriManager:    cbriManager,
-				cubeboxManger:  cubeboxAPIObj.(cubes.CubeboxAPI),
-				shims:          shimPlugin.(*v2.ShimManager),
-				envdHTTPClient: newEnvdHTTPClient(),
-				envdInitPort:   defaultEnvdInitPort,
+				client:              client,
+				localTask:           i.(tasks.TasksClient),
+				config:              config,
+				criImage:            obj.(*cubeimages.CubeImageService),
+				cbriManager:         cbriManager,
+				cubeboxManger:       cubeboxAPIObj.(cubes.CubeboxAPI),
+				shims:               shimPlugin.(*v2.ShimManager),
+				containerdAddr:      ic.Properties[plugins.PropertyGRPCAddress],
+				containerdTTRPCAddr: ic.Properties[plugins.PropertyTTRPCAddress],
+				envdHTTPClient:      newEnvdHTTPClient(),
+				envdInitPort:        defaultEnvdInitPort,
 			}
 
 			CubeLog.Info("Start recovering state")
@@ -257,12 +259,14 @@ type local struct {
 	config    *CubeConfig
 	shims     *v2.ShimManager
 
-	criImage       *cubeimages.CubeImageService
-	cbriManager    cbri.APIManager
-	cubeboxManger  cubes.CubeboxAPI
-	envdHTTPClient *http.Client
-	envdInitPort   int
-	destroyFn      func(context.Context, *workflow.DestroyContext) error
+	criImage            *cubeimages.CubeImageService
+	cbriManager         cbri.APIManager
+	cubeboxManger       cubes.CubeboxAPI
+	containerdAddr      string
+	containerdTTRPCAddr string
+	envdHTTPClient      *http.Client
+	envdInitPort        int
+	destroyFn           func(context.Context, *workflow.DestroyContext) error
 }
 
 const (
@@ -460,10 +464,23 @@ func (l *local) CleanUp(ctx context.Context, opts *workflow.CleanContext) error 
 		ctrLists = append(ctrLists, ctr)
 	}
 	ctrLists = append(ctrLists, info.FirstContainer())
-	for _, ctr := range ctrLists {
-		err = l.stopTask(ctx, ctr.Container)
-		if err != nil {
-			stepLog.Warnf("CleanUp stopTask %s fail: %v", sandBoxID, err)
+	// A paused VM can't serve its runtime API, so stopTask would fail and the
+	// shim-still-Exists guard below would loop forever. Force it down out-of-band
+	// (mirrors Destroy). The IsPaused read is unlocked, matching CleanUp's existing
+	// lock-free pattern. CleanUp only runs for a sandbox already converging to
+	// deleted; a concurrent resume racing paused->running here would have its shim
+	// reaped without a guest flush (power-loss semantics for that one sandbox),
+	// acceptable for a sandbox being torn down and never affecting others.
+	if info.GetStatus() != nil && info.GetStatus().IsPaused() {
+		if er := l.destroyPausedSandbox(ctx, sandBoxID); er != nil {
+			stepLog.Warnf("CleanUp force delete paused sandbox %s fail: %v", sandBoxID, er)
+		}
+	} else {
+		for _, ctr := range ctrLists {
+			err = l.stopTask(ctx, ctr.Container)
+			if err != nil {
+				stepLog.Warnf("CleanUp stopTask %s fail: %v", sandBoxID, err)
+			}
 		}
 	}
 	if info.GetStatus() != nil &&


### PR DESCRIPTION
## Problem

Deleting a **paused** sandbox fails and the sandbox becomes undeletable.

`DELETE /sandboxes/<id>` on a paused sandbox returns HTTP 500:

```
CubeMaster error 130593 -> delete paused sandbox failed
  -> shim ttrpc: Others("sandbox not in normal state")
```

A paused VM cannot serve its runtime (ttrpc) API, so the shim's per-container task-delete handler rejects the request with `sandbox not in normal state`. Retries fail identically. The GC / `CleanUp` path is affected the same way: `stopTask` fails on the guard and the reconcile loops forever on `shim process still Exists`, so a paused sandbox is never reclaimed.

This is issue #219. Two earlier attempts did not land:

- #317 removed the `sb.paused()` guard in the shim's task-delete handler. Review raised state-consistency concerns (sandbox state vs container state, the `delete_exec` path).
- #480 force-deleted from Cubelet with a hand-rolled `syscall.Kill` + `/proc` PID check. In review, @fslongjin requested changes (2026-06-16): Cubelet should not reimplement the shim's teardown; the cube shim already has `delete_shim()` which SIGKILLs the shim and reclaims resources, and containerd already has a standard binary-delete flow for an unresponsive shim. The manual kill also skipped the pause-snapshot and ivshmem cleanup that `delete_shim()` does. That PR was closed without the rework.

## Approach

This PR follows @fslongjin's suggested direction: reuse the shim's own binary delete instead of any custom kill logic in Cubelet.

For a paused sandbox, `destroyPausedSandbox` runs the shim's `delete` subcommand the same way containerd reaps a dead shim — via `pkg/shim.Command` against the bundle from `l.shims.Get(id).Bundle()`:

```
containerd-shim-cube-rs -namespace <ns> -id <id> -bundle <bundle> ... delete
```

The containerd-shim framework dispatches this to the shim's `delete_shim()`, which SIGKILLs the original shim process (reaping the in-process cube-hypervisor VMM) and reclaims the VM workdir, pause snapshot, and ivshmem file through `clean_sandbox_resource`. Cubelet then detaches the shim from the runtime manager with `l.shims.Delete`. Both `Destroy` and `CleanUp` take this path when the sandbox is paused, so GC reclaims paused sandboxes instead of looping.

How this addresses the earlier review:

- **No custom kill logic in Cubelet** — the SIGKILL and all resource cleanup stay owned by the shim's `delete_shim()` / `clean_sandbox_resource`; the earlier `syscall.Kill` + `/proc` PID verification is gone.
- **Pause snapshot and ivshmem are reclaimed** — because `delete_shim()` runs, not just a bare kill.
- **Standard mechanism** — `pkg/shim.Command` with the bundle path is exactly what containerd's own `binary.Delete` builds; the bundle comes from `ShimInstance.Bundle()`, not a hand-reconstructed path.
- The addresses passed to the shim are read from the same `PropertyGRPCAddress` / `PropertyTTRPCAddress` init properties that `ShimManager` itself uses to start shims.

Detaching after the kill is best-effort: the shim and VMM are already reaped by the `delete` subcommand, so a hiccup while removing the bundle dir is logged rather than failing the delete (a leftover bundle is reconciled by GC / on restart), matching the existing `CleanUp` behavior.

## Files

- `Cubelet/services/cubebox/destroy.go` — `destroyPausedSandbox` helper; the paused branch of `Destroy` now force-deletes and cleans up the cubestore container records.
- `Cubelet/services/cubebox/local.go` — capture the containerd grpc/ttrpc addresses at plugin init; `CleanUp` takes the same force-delete path when paused.

## Testing

Verified end-to-end on a two-node cluster (both nodes on this build).

Before: `create -> pause -> DELETE` returns 500 (`sandbox not in normal state`), retries fail identically.

After, `create -> pause -> DELETE`:

| check | result |
|---|---|
| DELETE (Destroy path) | 200/204 (was 500) |
| shim process + in-process VMM | reaped |
| pause snapshot dir (`root/pausevm/<id>`) | reclaimed |
| runtime bundle (`state/io.containerd.runtime.v2.task/.../<id>`) | reclaimed |
| cubecow writable-layer volume | reclaimed |
| residual process | none |
| sandbox detail API | 404 |

GC / `CleanUp` path (exercised via a delete that routes to `engine.CleanUp`):

| check | result |
|---|---|
| result | success |
| shim / VMM / pause snapshot / bundle / volume | all reclaimed |
| log | takes the `CleanUp` force-delete branch, no `shim process still Exists` loop |

A previously stuck paused sandbox (undeletable before) also deletes cleanly once this build is running, with the same full reclamation.
