### PR TITLE
network-agent: fix stale tap-pool assertions in reuse test

### DIFF
--- a/network-agent/internal/service/local_service_test.go
+++ b/network-agent/internal/service/local_service_test.go
@@ -584,15 +584,15 @@ func TestEnsureReleaseEnsureReusesTapFromPool(t *testing.T) {
 	if _, err := svc.ReleaseNetwork(t.Context(), &ReleaseNetworkRequest{SandboxID: "sandbox-1"}); err != nil {
 		t.Fatalf("ReleaseNetwork error=%v", err)
 	}
-	if len(svc.tapPool) != 0 {
-		t.Fatalf("tapPool len=%d, want 0 before async preparation", len(svc.tapPool))
-	}
-	if len(svc.abnormalTapPool) != 1 {
-		t.Fatalf("abnormalTapPool len=%d, want 1 pending async preparation", len(svc.abnormalTapPool))
-	}
-	svc.handleAbnormalTaps()
+	// On the success path releaseState prepares and stages the recycled tap
+	// synchronously (prepareAndStageTapForPool), so it lands directly in the
+	// free pool. Only a preparation *failure* defers it into abnormalTapPool
+	// (see TestReleaseNetworkQueuesTapWhenPoolPrepareFails).
 	if len(svc.tapPool) != 1 {
-		t.Fatalf("tapPool len=%d, want 1", len(svc.tapPool))
+		t.Fatalf("tapPool len=%d, want 1 (recycled tap staged synchronously on release)", len(svc.tapPool))
+	}
+	if len(svc.abnormalTapPool) != 0 {
+		t.Fatalf("abnormalTapPool len=%d, want 0 (no preparation failure to defer)", len(svc.abnormalTapPool))
 	}
 	second, err := svc.EnsureNetwork(t.Context(), &EnsureNetworkRequest{SandboxID: "sandbox-2"})
 	if err != nil {


### PR DESCRIPTION
## Summary
Fixes the deterministically-failing test `TestEnsureReleaseEnsureReusesTapFromPool` in `network-agent/internal/service`. Closes #1013.

## Problem
After a successful `ReleaseNetwork`, the test asserted the recycled tap is deferred into `abnormalTapPool` (empty `tapPool`) "before async preparation," then promoted by `handleAbnormalTaps()`. But `releaseState → prepareAndStageTapForPool` stages the tap synchronously into `tapPool` on success and only defers to `abnormalTapPool` on a preparation *failure* — the path `TestReleaseNetworkQueuesTapWhenPoolPrepareFails` covers by injecting an error. With only success mocks installed, the assertion failed 10/10.

## Fix
Test-only: assert the synchronous outcome (`tapPool==1`, `abnormalTapPool==0`) and drop the `handleAbnormalTaps()` step. Production code is unchanged.

## Verification
- Before: `go test ./internal/service/ -run '^TestEnsureReleaseEnsureReusesTapFromPool$'` → 10/10 FAIL
- After: 50/50 PASS; sibling `TestReleaseNetworkQueuesTapWhenPoolPrepareFails` still passes; `go vet ./internal/service/` clean.
