### PR TITLE
fix(cubelet): skip capacity admission for delete-triggered auto-resume

### DIFF
--- a/Cubelet/services/cubebox/delete_resume.go
+++ b/Cubelet/services/cubebox/delete_resume.go
@@ -138,6 +138,7 @@ func (s *service) resumePausedSandboxForDestroy(ctx context.Context, sb *cubebox
 		taskDeadline:      budget.resumeDeadline(now),
 		reconcileDeadline: budget.resumeDeadline(now),
 		persist:           false,
+		skipAdmission:     true, // sandbox will be destroyed immediately after resume
 	})
 	durationMS := time.Since(now).Milliseconds()
 	if result.running {

--- a/Cubelet/services/cubebox/destroy_auto_resume_test.go
+++ b/Cubelet/services/cubebox/destroy_auto_resume_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/tencentcloud/CubeSandbox/Cubelet/api/services/cubebox/v1"
 	"github.com/tencentcloud/CubeSandbox/Cubelet/api/services/errorcode/v1"
+	"github.com/tencentcloud/CubeSandbox/Cubelet/pkg/config"
 	"github.com/tencentcloud/CubeSandbox/Cubelet/pkg/semaphore"
 	cubeboxstore "github.com/tencentcloud/CubeSandbox/Cubelet/pkg/store/cubebox"
 	"github.com/tencentcloud/CubeSandbox/Cubelet/pkg/utils"
@@ -366,6 +367,40 @@ func TestDestroyReturnsLongRetryWhenResponseReserveIsExhausted(t *testing.T) {
 		rsp.Ret.RetMsg)
 	assert.Zero(t, flow.destroyCalls)
 	assert.Nil(t, sb.UserMarkDeletedTime)
+}
+
+func TestDestroyPausedSandboxSucceedsWhenCapacityWouldRejectResume(t *testing.T) {
+	sb := sandboxWithResourceForTest("paused-delete-overcommit", cubeboxstore.Status{
+		PausedAt: time.Now().Add(-time.Minute).UnixNano(),
+	}, "4000m", "8Gi", 4, 0, 0)
+	task := &fakeDestroyTask{}
+	container := &fakeDestroyContainer{task: task}
+	sb.FirstContainer().Container = container
+	s, manager, flow := newDestroyAutoResumeServiceForTest(sb)
+
+	_, err := config.Init("", true)
+	require.NoError(t, err)
+	hostConf := config.GetHostConf()
+	hostConf.Quota.PausedResourceReleaseRatio = 1.0
+	hostConf.Quota.Cpu = 4000
+	hostConf.Quota.Mem = "4Gi"
+	defer func() {
+		hostConf.Quota.PausedResourceReleaseRatio = 0
+		hostConf.Quota.Cpu = 0
+		hostConf.Quota.Mem = ""
+	}()
+
+	rsp := destroySandboxForTest(t, s, sb.ID)
+
+	assert.Equal(t, errorcode.ErrorCode_Success, rsp.Ret.RetCode,
+		"delete must succeed even when the node cannot admit a normal resume")
+	assert.Equal(t, 1, task.resumeCalls)
+	assert.Equal(t, 1, flow.destroyCalls)
+	require.NotNil(t, sb.UserMarkDeletedTime)
+	assert.Equal(t, "delete-request", sb.DeleteRequestID)
+	assert.Equal(t, int64(0), sb.GetStatus().Get().PausedAt)
+	assert.NotZero(t, sb.GetStatus().Get().StartedAt)
+	assert.Len(t, manager.syncIDs, 2)
 }
 
 func TestDestroyDebugCleanupPreservesDeleteMarker(t *testing.T) {

--- a/Cubelet/services/cubebox/release_paused_resources_test.go
+++ b/Cubelet/services/cubebox/release_paused_resources_test.go
@@ -14,6 +14,8 @@ import (
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/api/resource"
 
+	"github.com/tencentcloud/CubeSandbox/Cubelet/api/services/errorcode/v1"
+	"github.com/tencentcloud/CubeSandbox/Cubelet/pkg/config"
 	cubeboxstore "github.com/tencentcloud/CubeSandbox/Cubelet/pkg/store/cubebox"
 )
 
@@ -236,4 +238,115 @@ func TestResumeQuotaRejectionMessageFormat(t *testing.T) {
 		cpuQuotaMilli: 8000,
 	})
 	assert.Equal(t, "need 2000m + used 7000m > cpu quota 8000m", cpu)
+}
+
+func TestAdmitResumeRejectsWhenResourceMetadataIsMissing(t *testing.T) {
+	_, err := config.Init("", true)
+	require.NoError(t, err)
+	hostConf := config.GetHostConf()
+	hostConf.Quota.PausedResourceReleaseRatio = 1.0
+	defer func() { hostConf.Quota.PausedResourceReleaseRatio = 0 }()
+
+	sb := newCubeboxWithStatusForTest("sb-no-resource", cubeboxstore.Status{PausedAt: time.Now().UnixNano()})
+	s := &service{cubeboxMgr: &local{cubeboxManger: &fakeCubeboxAPI{cb: sb}}}
+
+	ret := s.admitResume(context.Background(), sb)
+
+	require.NotNil(t, ret)
+	assert.Equal(t, errorcode.ErrorCode_Conflict, ret.RetCode)
+	assert.Contains(t, ret.RetMsg, "missing resource metadata")
+}
+
+func TestAdmitResumeRejectsWhenCapacityExceeded(t *testing.T) {
+	_, err := config.Init("", true)
+	require.NoError(t, err)
+	hostConf := config.GetHostConf()
+	hostConf.Quota.PausedResourceReleaseRatio = 1.0
+	hostConf.Quota.Cpu = 4000
+	hostConf.Quota.Mem = "4Gi"
+	defer func() {
+		hostConf.Quota.PausedResourceReleaseRatio = 0
+		hostConf.Quota.Cpu = 0
+		hostConf.Quota.Mem = ""
+	}()
+
+	sb := sandboxWithResourceForTest("sb-overcommit", cubeboxstore.Status{
+		PausedAt: time.Now().UnixNano(),
+	}, "4000m", "8Gi", 4, 0, 0)
+	s := &service{cubeboxMgr: &local{cubeboxManger: &fakeCubeboxAPI{cb: sb}}}
+
+	ret := s.admitResume(context.Background(), sb)
+
+	require.NotNil(t, ret, "admitResume must reject when post-resume demand exceeds quota")
+	assert.Equal(t, errorcode.ErrorCode_Conflict, ret.RetCode)
+}
+
+func TestResumeLockedSkipsAdmissionWhenFlagSet(t *testing.T) {
+	_, err := config.Init("", true)
+	require.NoError(t, err)
+	hostConf := config.GetHostConf()
+	hostConf.Quota.PausedResourceReleaseRatio = 1.0
+	hostConf.Quota.Cpu = 4000
+	hostConf.Quota.Mem = "4Gi"
+	defer func() {
+		hostConf.Quota.PausedResourceReleaseRatio = 0
+		hostConf.Quota.Cpu = 0
+		hostConf.Quota.Mem = ""
+	}()
+
+	sb := sandboxWithResourceForTest("sb-skip-admit", cubeboxstore.Status{
+		PausedAt: time.Now().UnixNano(),
+	}, "4000m", "8Gi", 4, 0, 0)
+	task := &fakeResumeTask{}
+	sb.FirstContainer().Container = &fakeDestroyContainer{task: task}
+	s := &service{cubeboxMgr: &local{cubeboxManger: &fakeCubeboxAPI{cb: sb}}}
+
+	now := time.Now()
+	result := s.resumeLocked(context.Background(), sb, resumeOptions{
+		taskDeadline:      now.Add(5 * time.Second),
+		reconcileDeadline: now.Add(5 * time.Second),
+		persist:           false,
+		skipAdmission:     true,
+	})
+
+	require.True(t, result.running,
+		"resumeLocked with skipAdmission must proceed despite capacity pressure")
+	assert.Equal(t, 1, task.resumeCalls)
+	assert.Equal(t, int64(0), sb.GetStatus().Get().PausedAt)
+	assert.NotZero(t, sb.GetStatus().Get().StartedAt)
+}
+
+func TestResumeLockedRejectsWithoutSkipAdmissionUnderCapacityPressure(t *testing.T) {
+	_, err := config.Init("", true)
+	require.NoError(t, err)
+	hostConf := config.GetHostConf()
+	hostConf.Quota.PausedResourceReleaseRatio = 1.0
+	hostConf.Quota.Cpu = 4000
+	hostConf.Quota.Mem = "4Gi"
+	defer func() {
+		hostConf.Quota.PausedResourceReleaseRatio = 0
+		hostConf.Quota.Cpu = 0
+		hostConf.Quota.Mem = ""
+	}()
+
+	sb := sandboxWithResourceForTest("sb-no-skip-admit", cubeboxstore.Status{
+		PausedAt: time.Now().UnixNano(),
+	}, "4000m", "8Gi", 4, 0, 0)
+	task := &fakeResumeTask{}
+	sb.FirstContainer().Container = &fakeDestroyContainer{task: task}
+	s := &service{cubeboxMgr: &local{cubeboxManger: &fakeCubeboxAPI{cb: sb}}}
+
+	now := time.Now()
+	result := s.resumeLocked(context.Background(), sb, resumeOptions{
+		taskDeadline:      now.Add(5 * time.Second),
+		reconcileDeadline: now.Add(5 * time.Second),
+		persist:           false,
+		skipAdmission:     false,
+	})
+
+	require.False(t, result.running,
+		"resumeLocked without skipAdmission must reject under capacity pressure")
+	require.NotNil(t, result.ret)
+	assert.Equal(t, errorcode.ErrorCode_Conflict, result.ret.RetCode)
+	assert.Zero(t, task.resumeCalls, "task.Resume must not be called when admission rejects")
 }

--- a/Cubelet/services/cubebox/update.go
+++ b/Cubelet/services/cubebox/update.go
@@ -254,6 +254,7 @@ type resumeOptions struct {
 	taskDeadline      time.Time
 	reconcileDeadline time.Time
 	persist           bool
+	skipAdmission     bool // true only for delete-triggered auto-resume; overcommit is bounded by destroy deadline
 }
 
 type resumeResult struct {
@@ -273,8 +274,10 @@ func (s *service) resumeLocked(ctx context.Context, sb *cubeboxstore.CubeBox, op
 	preflightCtx, preflightCancel := context.WithDeadline(ctx, opts.taskDeadline)
 	defer preflightCancel()
 
-	if rejected := s.admitResume(preflightCtx, sb); rejected != nil {
-		return resumeResult{ret: rejected}
+	if !opts.skipAdmission {
+		if rejected := s.admitResume(preflightCtx, sb); rejected != nil {
+			return resumeResult{ret: rejected}
+		}
 	}
 	if err := preflightCtx.Err(); err != nil {
 		return resumeResult{ret: &errorcode.Ret{


### PR DESCRIPTION
## Summary

- When `paused_resource_release_ratio > 0` and a node is overcommitted, deleting a paused sandbox was blocked by the same `admitResume` capacity check used for user-initiated resume, creating a deadlock: the user wants to free resources by deleting, but the delete is blocked because the node lacks resources.
- Add a `skipAdmission` flag to `resumeOptions` so that `resumePausedSandboxForDestroy` bypasses the capacity check. The resume is a transient step before immediate destruction, so the brief overcommit is bounded by the destroy deadline.
- User-initiated resume (`UpdateWithResume`) remains subject to the full capacity admission check.

## Changes

| File | Change |
|------|--------|
| `Cubelet/services/cubebox/update.go` | Add `skipAdmission bool` to `resumeOptions`; guard `admitResume` call with `!opts.skipAdmission` |
| `Cubelet/services/cubebox/delete_resume.go` | Set `skipAdmission: true` in `resumePausedSandboxForDestroy` |
| `Cubelet/services/cubebox/destroy_auto_resume_test.go` | Integration test: delete succeeds under capacity pressure |
| `Cubelet/services/cubebox/release_paused_resources_test.go` | Unit tests: `admitResume` rejects when exceeded; `resumeLocked` bypasses with flag; `resumeLocked` rejects without flag |

## Test plan

- [x] `TestDestroyPausedSandboxSucceedsWhenCapacityWouldRejectResume` — end-to-end: delete of a paused sandbox succeeds even when node quota would reject a normal resume
- [x] `TestAdmitResumeRejectsWhenCapacityExceeded` — confirms `admitResume` correctly rejects when post-resume demand exceeds quota
- [x] `TestResumeLockedSkipsAdmissionWhenFlagSet` — `skipAdmission: true` bypasses admission and resume succeeds
- [x] `TestResumeLockedRejectsWithoutSkipAdmissionUnderCapacityPressure` — `skipAdmission: false` (user resume path) still rejected under capacity pressure
- [x] All existing `destroy_auto_resume_test.go` and `delete_resume_test.go` tests remain passing
- [x] `GOOS=linux go test -c` compilation verified


Made with [Cursor](https://cursor.com)