### PR TITLE
feat(kubernetes): split PVM host bootstrap into dedicated DaemonSet

### DIFF
--- a/deploy/kubernetes/chart/README.md
+++ b/deploy/kubernetes/chart/README.md
@@ -6,9 +6,10 @@ Current compute-plane shape (per compute node):
 
 - **`cube-node` (Big Pod)**: OpenKruise Advanced DaemonSet (`InPlaceIfPossible`; hard dependency); `wait-node-prep` sidecar + `cubelet` / `network-agent` + optional egress + six frozen `cube-slot-*` pause placeholders; **no initContainers**; Pod network (`hostNetwork=false`).
 - **`cube-node-installer`**: DaemonSet that stages shim / kernel / guest into the host toolbox tree.
-- **`cube-node-bootstrap`**: DaemonSet that runs PVM host-kernel prep and `cube-node-init`, then writes `node-prep-ready`.
+- **`cube-node-bootstrap`**: DaemonSet that runs `wait-pvm-host` + `cube-node-init`, then writes `node-prep-ready`.
+- **`cube-node-pvm`**: DaemonSet scheduled only via `placement.pvm` (`allow-pvm-bootstrap`); installs PVM host kernel and writes fingerprint `pvm-host-ready`. Non-PVM compute nodes never pull this image.
 
-Control-plane vs compute scheduling uses `placement.controlPlane` and `placement.compute`. MySQL schema migration is embedded in CubeMaster. Control-plane and runtime components use separate images.
+Control-plane vs compute scheduling uses `placement.controlPlane` and `placement.compute`. PVM host install uses `placement.pvm`. MySQL schema migration is embedded in CubeMaster. Control-plane and runtime components use separate images.
 
 ## Directory
 
@@ -33,15 +34,15 @@ deploy/kubernetes/chart/
 
 ## Architecture
 
-See [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) for component layering, the three compute DaemonSets, DNS/Proxy/Egress flows, and external control plane / compute-only mode.
+See [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) for component layering, the four compute DaemonSets, DNS/Proxy/Egress flows, and external control plane / compute-only mode.
 
 ## Image responsibilities
 
 | Image | Role |
 |---|---|
-| `cube-pvm-host-bootstrap` | Bootstrap DaemonSet init. Installs/configures PVM host kernel and may reboot the node. |
-| `cube-node-init` | Bootstrap DaemonSet init. Loads KVM, prepares host paths, validates `/dev/kvm` and XFS. |
-| `cube-wait-node-prep` | Big Pod high-priority sidecar (poll `node-prep-ready`) and bootstrap write-ready container. |
+| `cube-pvm-host-bootstrap` | **cube-node-pvm** init. Installs/configures PVM host kernel and may reboot the node. |
+| `cube-node-init` | Bootstrap DaemonSet: `wait-pvm-host` + `cube-node-init`. Loads KVM, prepares host paths, validates `/dev/kvm` and XFS. |
+| `cube-wait-node-prep` | Big Pod high-priority sidecar (poll `node-prep-ready`), bootstrap write-ready, and PVM hold container. |
 | `cube-shim` / `cube-kernel` / `cube-guest` | Installer DaemonSet containers; stage artifacts into `/usr/local/services/cubetoolbox`. |
 | `cubelet` / `network-agent` | Big Pod runtime containers (self-stage then run). |
 | `pause` | Big Pod `cube-slot-1`…`6` placeholders (InPlace-replace later). |
@@ -58,15 +59,17 @@ See [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) for component layering, the t
 
 The chart separates placement into dedicated control-plane nodes and compute
 nodes. Control-plane Deployments, StatefulSets, and `cube-proxy` use
-`placement.controlPlane`; `cube-node` uses `placement.compute`. In-cluster
-`*.cube.app` is wired automatically when CubeProxy is enabled: the chart
-patches cluster CoreDNS so the domain rewrites to the CubeProxy Service.
+`placement.controlPlane`; `cube-node` / installer / bootstrap use
+`placement.compute`. PVM host install (`cube-node-pvm`) uses `placement.pvm`
+and requires `cube.tencent.com/allow-pvm-bootstrap=true` so non-PVM compute
+nodes never pull the heavy PVM bootstrap image. In-cluster `*.cube.app` is
+wired automatically when CubeProxy is enabled: the chart patches cluster
+CoreDNS so the domain rewrites to the CubeProxy Service.
 
 The chart refuses to render host-mutating compute components without
-`placement.compute.nodeSelector`. This prevents PVM bootstrap and Cube runtime
-setup from running on ordinary nodes. The default compute selector includes
-`cube.tencent.com/allow-pvm-bootstrap=true` because the default profile
-initializes the PVM host kernel and may reboot selected compute nodes.
+`placement.compute.nodeSelector`. When `bootstrap.pvmHostKernel.enabled=true`,
+`placement.pvm.nodeSelector` must include `allow-pvm-bootstrap`, and that key
+must **not** appear under `placement.compute`.
 
 Default placement values:
 
@@ -104,6 +107,16 @@ placement:
     nodeSelector:
       cube.tencent.com/role: compute
       cube.tencent.com/cube-node: "true"
+    tolerations:
+      - key: cube.tencent.com/compute
+        operator: Equal
+        value: "true"
+        effect: NoSchedule
+
+  pvm:
+    nodeSelector:
+      cube.tencent.com/role: compute
+      cube.tencent.com/cube-node: "true"
       cube.tencent.com/allow-pvm-bootstrap: "true"
     tolerations:
       - key: cube.tencent.com/compute
@@ -119,9 +132,12 @@ kubectl label node <control-node>   cube.tencent.com/role=control   cube.tencent
 
 kubectl taint node <control-node>   cube.tencent.com/control=true:NoSchedule   --overwrite
 
-kubectl label node <compute-node>   cube.tencent.com/role=compute   cube.tencent.com/cube-node=true   cube.tencent.com/allow-pvm-bootstrap=true   --overwrite
+kubectl label node <compute-node>   cube.tencent.com/role=compute   cube.tencent.com/cube-node=true   --overwrite
 
 kubectl taint node <compute-node>   cube.tencent.com/compute=true:NoSchedule   --overwrite
+
+# Only on nodes that should install the PVM host kernel:
+kubectl label node <pvm-compute-node>   cube.tencent.com/allow-pvm-bootstrap=true   --overwrite
 ```
 
 The chart does not label or taint nodes. The platform operator must prepare node labels and taints before installation.
@@ -145,15 +161,16 @@ can set it to `false`.
 - `cubeNode.network.cidr` can patch Cubelet cubevs CIDR when the packaged default conflicts with the host network.
 
 `bootstrap.pvmHostKernel.enabled` also defaults to `true`, so the PVM host
-kernel bootstrap on `cube-node-bootstrap` can install/configure the host kernel and
-perform the configured coordinated reboot. The default
+kernel bootstrap on **`cube-node-pvm`** (only nodes with `allow-pvm-bootstrap`)
+can install/configure the host kernel and perform the configured coordinated
+reboot. Per-node `effective-pvm` (written by bootstrap `wait-pvm-host`) overrides
+Helm `CUBE_PVM_ENABLE` for guest kernel selection and fingerprinting. The default
 `bootstrap.pvmHostKernel.bootArgs` is `nopti pti=off` because the current
 `kvm_pvm` module does not support host KPTI. `cube-node-init` performs the same
 fail-fast style checks as one-click for memory, glibc, cgroup v2 cpu
 controller, cubecow dependencies, KVM, XFS, and PVM consistency. It fails when
-a host has `kvm_pvm` loaded but `cubeNode.pvmGuestKernel.enabled=false`, or
-when `cubeNode.pvmGuestKernel.enabled=true` but the host has not booted a PVM
-kernel with `kvm_pvm` loaded.
+a host has `kvm_pvm` loaded but effective PVM is off, or when effective PVM is
+on but the host has not booted a PVM kernel with `kvm_pvm` loaded.
 
 ## Build and push images
 
@@ -489,7 +506,8 @@ kubectl get pods -n cube-system -o wide
 kubectl get ads -n cube-system cube-node
 kubectl get deploy -n cube-system cube-proxy
 kubectl get sts -n cube-system cube-mysql cube-redis
-kubectl logs -n cube-system -l app.kubernetes.io/component=cube-node-bootstrap -c pvm-host-bootstrap --tail=100
+kubectl logs -n cube-system -l app.kubernetes.io/component=cube-node-pvm -c pvm-host-bootstrap --tail=100
+kubectl logs -n cube-system -l app.kubernetes.io/component=cube-node-bootstrap -c wait-pvm-host --tail=100
 kubectl logs -n cube-system -l app.kubernetes.io/component=cube-node-bootstrap -c cube-node-init --tail=100
 kubectl logs -n cube-system -l app.kubernetes.io/component=cube-node -c cubelet --tail=100
 kubectl logs -n cube-system -l app.kubernetes.io/component=cube-node -c wait-node-prep --tail=50
@@ -506,9 +524,10 @@ helm test cube -n cube-system --timeout 20m
 (`images.cubelet`, `images.networkAgent`, `images.waitNodePrep`, slot images, …)
 or slot service annotations keeps Pod UID/IP/netns. **First introducing
 `cube-slot-1`…`6` recreates Big Pods once** (adding containers is not InPlace).
-Artifact images bump only `cube-node-installer`; node-prep images bump only
-`cube-node-bootstrap`. See `docs/UPGRADE.md`. Cluster must have OpenKruise
-installed (see `docs/QUICKSTART.md` §1.4).
+Artifact images bump only `cube-node-installer`; node-init images bump
+`cube-node-bootstrap`; PVM host image bumps only `cube-node-pvm`. See
+`docs/UPGRADE.md`. Cluster must have OpenKruise installed (see
+`docs/QUICKSTART.md` §1.4).
 
 Set `cubeNode.updateStrategy.type: OnDelete` for fully manual
 per-node upgrades.

--- a/deploy/kubernetes/chart/docs/ARCHITECTURE.md
+++ b/deploy/kubernetes/chart/docs/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # CubeSandbox Chart 架构
 
-本文描述 `deploy/kubernetes/chart` **当前**交付形态：组件分层、计算面三个 DaemonSet 的分工、安装与启动顺序、以及 DNS / Proxy / Egress 等运行期链路。升级操作见 [`UPGRADE.md`](UPGRADE.md)；排障见 [`FAQ.md`](FAQ.md)。
+本文描述 `deploy/kubernetes/chart` **当前**交付形态：组件分层、计算面 DaemonSet 的分工、安装与启动顺序、以及 DNS / Proxy / Egress 等运行期链路。升级操作见 [`UPGRADE.md`](UPGRADE.md)；排障见 [`FAQ.md`](FAQ.md)。
 
 ## 1. 总体分层
 
@@ -13,7 +13,8 @@
 | 依赖存储 | MySQL / Redis | 内置 StatefulSet 或第三方 | 业务数据 / Proxy 与 lifecycle 状态 |
 | 计算面 · 运行时 | `cube-node`（Big Pod） | OpenKruise Advanced DaemonSet（InPlaceIfPossible） | `wait-node-prep` + cubelet / network-agent + 可选 egress；**无 initContainers** |
 | 计算面 · 产物 | `cube-node-installer` | DaemonSet | 将 shim / kernel / guest 安装到宿主机 toolbox |
-| 计算面 · 节点引导 | `cube-node-bootstrap` | DaemonSet | PVM host kernel、`cube-node-init`、写 `node-prep-ready` |
+| 计算面 · 节点引导 | `cube-node-bootstrap` | DaemonSet | `wait-pvm-host`、`cube-node-init`、写 `node-prep-ready` |
+| 计算面 · PVM 宿主机 | `cube-node-pvm` | DaemonSet（仅 `placement.pvm`） | PVM host kernel 安装（可 reboot）；写带指纹的 `pvm-host-ready` |
 | 数据面入口 | CubeProxy + 集群 DNS | Deployment；可选改写 CoreDNS | HTTP/HTTPS sandbox 入口；`*.domain` 泛解析 |
 | 生命周期 | cube-lifecycle-manager | Deployment + ClusterIP | sandbox pause/resume；经 Redis 发现 Proxy 副本 |
 
@@ -35,9 +36,14 @@ flowchart TB
     KDNS["CoreDNS · *.cube.app → Proxy Service"]
   end
 
+  subgraph PVMN["PVM nodes · placement.pvm"]
+    PVMDS["cube-node-pvm"]
+    PVMREADY["pvm-host-ready fingerprint"]
+  end
+
   subgraph COMPUTE["Compute · placement.compute"]
     subgraph BOOT["cube-node-bootstrap"]
-      PVM["init: pvm-host-bootstrap"]
+      WAITPVM["init: wait-pvm-host"]
       NINIT["init: cube-node-init"]
       READY["write node-prep-ready"]
     end
@@ -60,7 +66,9 @@ flowchart TB
   PROXY --> REDIS
   PROXY --> CM
   KDNS --> PROXY
-  PVM --> READY
+  PVMDS --> PVMREADY
+  PVMREADY --> WAITPVM
+  WAITPVM --> NINIT
   NINIT --> READY
   READY --> WAIT
   WAIT --> RUN
@@ -92,9 +100,9 @@ flowchart TB
 | 内置 Redis | `redis.host=""` 且控制面或 Proxy 需要时安装 |
 | 第三方 Redis | `redis.host` 非空 → 不装内置 Redis |
 
-### 2.3 计算面：三个 DaemonSet
+### 2.3 计算面：四个 DaemonSet
 
-同节点、同 `placement.compute`，**selector 互斥**，各司其职。
+`cube-node` / `cube-node-installer` / `cube-node-bootstrap` 用 `placement.compute`（**不含** `allow-pvm-bootstrap`）。`cube-node-pvm` 用 `placement.pvm`（含 `allow-pvm-bootstrap`），因此非 PVM 节点不会拉取 `cube-pvm-host-bootstrap` 大镜像。
 
 #### Big Pod：`cube-node`
 
@@ -121,11 +129,31 @@ flowchart TB
 
 #### Bootstrap：`cube-node-bootstrap`
 
-- init：`pvm-host-bootstrap` → `cube-node-init`；主容器写 `node-prep-ready`。
-- 哨兵目录：`/var/lib/cube-node-bootstrap`（与 Big Pod 的 `wait-node-prep` 共享）。
-- `hostPID: true`（`nsenter --target 1`）；低频变更；升引导 **只 bump Bootstrap 镜像**。
+- init：`wait-pvm-host` → `cube-node-init`；主容器写 `node-prep-ready`。
+- `wait-pvm-host`：按节点 label 决定是否等待 PVM；写 `effective-pvm`（`0`/`1`）。PVM 节点必须等到 **指纹匹配** 的 `pvm-host-ready`（禁止「文件存在即 ready」）。
+- 哨兵目录：`/var/lib/cube-node-bootstrap`（与 Big Pod 的 `wait-node-prep` / PVM DS 共享）。
+- `hostPID: true`（`nsenter --target 1`）；低频变更；升 node-init **只 bump Bootstrap / nodeInit 镜像**。
 
-为何拆成三个：Big Pod 保持 InPlace 友好（不因升 shim / 升 node-init 而 recreate）；产物安装与可 reboot 的节点引导分离，避免日常 artifact 升级触发 host kernel 路径。
+#### PVM：`cube-node-pvm`
+
+- 仅当 `bootstrap.pvmHostKernel.enabled=true` 时创建；仅调度到 `placement.pvm`。
+- init：`pvm-host-bootstrap`；成功（live 内核已满足 pattern+boot args）后写带指纹的 `pvm-host-ready`；主容器 hold。
+- 换核 / 改 boot args 前 `invalidate_pvm_gate_sentinels`：删除 `node-prep-ready`、`pvm-host-ready`、`effective-pvm`，再 reboot。
+- 升 PVM 镜像 **只 bump `images.pvmHostBootstrap`**，不 recreate Big Pod。
+
+为何拆成四个：Big Pod 保持 InPlace 友好；产物安装与可 reboot 的 PVM 引导分离；非 PVM compute 节点不拉 PVM 大镜像。
+
+### 2.3.1 Reboot 与 ready 哨兵
+
+| 标记 | 跨 reboot 残留？ | 误放行？ |
+| --- | --- | --- |
+| `pvm-host-ready`（指纹含 live `uname` + boot_args） | 会 | **不会**：wait 比对 live 指纹；mutate 前主动删除 |
+| `effective-pvm` | 会 | wait-pvm-host **每次**重写；mutate 前删除 |
+| `node-prep-ready`（指纹含 `uname`） | 会 | **不会**；换核后期望指纹变 |
+| `/run/wait-node-prep.ready` | 否（tmpfs） | 安全 |
+| `.staged-*` | 会 | 有意：产物仍在盘上 |
+
+验收：PVM 换核期间 Big Pod NotReady；故意残留错误内核的 `pvm-host-ready` 时 `wait-pvm-host` 不得放行；普通掉电且内核未变时可快速恢复。
 
 ### 2.4 数据面入口
 
@@ -176,7 +204,7 @@ flowchart TD
   D --> E["MySQL / Redis 或外部"]
   E --> F["控制面 Deployment"]
   F --> G["Proxy / cluster-dns"]
-  G --> H["cube-node + installer + bootstrap"]
+  G --> H["cube-node + installer + bootstrap + pvm"]
 ```
 
 主要校验：
@@ -184,9 +212,10 @@ flowchart TD
 - 启用控制面 / 计算面 / Proxy 时须配置对应 `placement.*.nodeSelector`。
 - `configureClusterDNS=true` 须配置 `cubeProxy.domain`。
 - compute-only 须配置 `externalControlPlane.masterEndpoint`。
+- `pvmHostKernel.enabled=true` 时 `placement.pvm` 须含 `allow-pvm-bootstrap`，且 **不得** 写在 `placement.compute`。
 - 已移除 `security.hostNetwork`；cube-node 固定 Pod 网络。
 
-调度：控制面组件（含 Proxy、lifecycle、内置 DB）用 `placement.controlPlane`；三个计算面 DaemonSet 用 `placement.compute`。Chart 管理的容器经 `global.timezone` 注入 `TZ`（默认 `Asia/Shanghai`）。
+调度：控制面用 `placement.controlPlane`；`cube-node` / installer / bootstrap 用 `placement.compute`；`cube-node-pvm` 用 `placement.pvm`。Chart 管理的容器经 `global.timezone` 注入 `TZ`（默认 `Asia/Shanghai`）。
 
 ### 4.2 控制面启动
 
@@ -217,15 +246,19 @@ sequenceDiagram
 
 ```mermaid
 sequenceDiagram
+  participant PVM as cube-node-pvm
   participant Boot as cube-node-bootstrap
   participant Inst as cube-node-installer
   participant Wait as wait-node-prep
   participant CN as cube-node
   participant CM as CubeMaster
 
-  opt pvmHostKernel.enabled
-    Boot->>Boot: pvm-host-bootstrap
+  alt allow-pvm-bootstrap node
+    PVM->>PVM: pvm-host-bootstrap may reboot
+    Note over PVM: mutate 前删各类 ready
+    PVM->>PVM: write pvm-host-ready fingerprint
   end
+  Boot->>Boot: wait-pvm-host label + fingerprint gate
   opt nodeInit.enabled
     Boot->>Boot: cube-node-init
   end
@@ -234,7 +267,7 @@ sequenceDiagram
   Wait->>Wait: poll fingerprint → Ready hold
   Note over Wait,CN: Kruise barrier → prio 0
   Wait-->>CN: wait Ready
-  CN->>CN: self-stage cubelet / network-agent
+  CN->>CN: self-stage + effective-pvm guest kernel
   CN->>CM: register + heartbeat
 ```
 
@@ -250,7 +283,7 @@ sequenceDiagram
 
 - CubeMaster `/notify/health`、CubeAPI `/health`。
 - CubeAPI 能查到 healthy node。
-- 三个计算面 DaemonSet ready 数等于命中 `placement.compute` 的节点数。
+- `cube-node` / installer / bootstrap ready 数等于命中 `placement.compute` 的节点数；`cube-node-pvm` ready 数等于命中 `placement.pvm` 的节点数。
 - egress 启用时 sidecar Ready。
 
 ## 5. 运行期数据流
@@ -334,7 +367,8 @@ externalControlPlane:
 | `controlPlane.enabled` | `true` | 内置控制面 |
 | `externalControlPlane.enabled` | `false` | 外部 CubeMaster |
 | `placement.controlPlane.nodeSelector` | `cube.tencent.com/role=control` | 控制面调度 |
-| `placement.compute.nodeSelector` | 含 `allow-pvm-bootstrap=true` | 计算面调度；显式授权 PVM bootstrap |
+| `placement.compute.nodeSelector` | `role=compute` + `cube-node=true` | 计算面（不含 allow-pvm） |
+| `placement.pvm.nodeSelector` | 另含 `allow-pvm-bootstrap=true` | 仅 PVM 宿主机 DaemonSet |
 | `cubeProxy.domain` | `cube.app` | sandbox 域名 |
 | `cubeProxy.configureClusterDNS` | `true` | 是否写入集群 CoreDNS |
 | `cubeNode.dns.sandbox.followNodeDns` | `true` | guest 跟随节点 DNS |

--- a/deploy/kubernetes/chart/docs/FAQ.md
+++ b/deploy/kubernetes/chart/docs/FAQ.md
@@ -31,7 +31,8 @@ placement:
 | 报错关键字 | 说明 |
 |---|---|
 | `cube-node requires placement.compute.nodeSelector` | 计算节点必须显式指定,不能空 |
-| `bootstrap.pvmHostKernel.enabled=true requires ... allow-pvm-bootstrap=true` | 计算节点 nodeSelector 必须包含 `allow-pvm-bootstrap=true`,防止误替换内核 |
+| `bootstrap.pvmHostKernel.enabled=true requires ... placement.pvm ... allow-pvm-bootstrap` | PVM DaemonSet 的 nodeSelector 必须含该 label；不要写在 `placement.compute` |
+| `placement.compute.nodeSelector must not include ... allow-pvm-bootstrap` | 该 label 只属于 `placement.pvm`，写在 compute 会让所有计算节点拉 PVM 镜像 |
 | `cubeProxy.enabled=true requires placement.controlPlane.nodeSelector` | CubeProxy 只跑在 control 节点上 |
 | `cubeProxy.configureClusterDNS=true requires cubeProxy.domain` | 开启集群 DNS 注入时必须有 sandbox 域名 |
 
@@ -40,7 +41,7 @@ placement:
 先看三个计算面 DaemonSet 的 desiredNumberScheduled 是否与实际 compute 节点数一致:
 
 ```bash
-kubectl -n cube-system get ds -l 'app.kubernetes.io/component in (cube-node,cube-node-installer,cube-node-bootstrap)'
+kubectl -n cube-system get ds -l 'app.kubernetes.io/component in (cube-node,cube-node-installer,cube-node-bootstrap,cube-node-pvm)'
 # OpenKruise Advanced DaemonSet:
 kubectl -n cube-system get ads cube-node
 ```
@@ -197,21 +198,23 @@ cubemastercli sandbox list
 
 ### D1. `pvm-host-bootstrap` 反复重启 / 节点 reboot
 
-`pvm-host-bootstrap` 跑在 **`cube-node-bootstrap`** DaemonSet（与 Big Pod、Installer 分离）。绝大多数反复重启是 host kernel 替换后节点需要 reboot。观察:
+`pvm-host-bootstrap` 跑在 **`cube-node-pvm`** DaemonSet（仅 `placement.pvm` / `allow-pvm-bootstrap` 节点）。绝大多数反复重启是 host kernel 替换后节点需要 reboot。观察:
 
 ```bash
-kubectl -n cube-system logs -l app.kubernetes.io/component=cube-node-bootstrap -c pvm-host-bootstrap --tail=100
-kubectl -n cube-system describe pod -l app.kubernetes.io/component=cube-node-bootstrap
+kubectl -n cube-system logs -l app.kubernetes.io/component=cube-node-pvm -c pvm-host-bootstrap --tail=100
+kubectl -n cube-system describe pod -l app.kubernetes.io/component=cube-node-pvm
+kubectl -n cube-system logs -l app.kubernetes.io/component=cube-node-bootstrap -c wait-pvm-host --tail=50
 kubectl -n cube-system logs -l app.kubernetes.io/component=cube-node -c wait-node-prep --tail=50
 ```
 
 正常流程:
 
-1. 首次运行:检测 host kernel → 若不是 PVM kernel,安装 RPM/DEB → **先删 `node-prep-ready`** → 触发节点重启
-2. 节点重启后:bootstrap 再次运行 → 检测到 PVM kernel（快速路径，**不抢**集群 lease）→ `cube-node-init` → 写 `node-prep-ready`
-3. Big Pod `wait-node-prep` sidecar（Kruise prio 10）校验指纹 Ready → 主容器启动
+1. 首次运行:检测 host kernel → 若不是 PVM kernel,安装 RPM/DEB → **先删 `node-prep-ready` / `pvm-host-ready` / `effective-pvm`** → 触发节点重启
+2. 节点重启后:PVM DS 再次运行 → 检测到 PVM kernel（快速路径，**不抢**集群 lease）→ 写带指纹的 `pvm-host-ready`
+3. bootstrap `wait-pvm-host` 校验指纹（禁止「文件存在即 ready」）→ 写 `effective-pvm=1` → `cube-node-init` → 写 `node-prep-ready`
+4. Big Pod `wait-node-prep` sidecar（Kruise prio 10）校验指纹 Ready → 主容器启动
 
-若卡在 wait-node-prep Not Ready，先查 bootstrap 是否 Ready、`/var/lib/cube-node-bootstrap/node-prep-ready` 是否存在且指纹匹配，再看 wait 容器是否写出 `/run/wait-node-prep.ready`。
+若卡在 wait-node-prep Not Ready，先查 bootstrap 是否 Ready、`/var/lib/cube-node-bootstrap/node-prep-ready` 是否存在且指纹匹配，再看 wait 容器是否写出 `/run/wait-node-prep.ready`。若卡在 `wait-pvm-host`，查 `cube-node-pvm` 与 `pvm-host-ready` 指纹是否与 live `uname` 一致。
 
 若卡在"waiting for reboot",通常是节点没有 sudo/reboot 权限或 GRUB 未更新,需人工登录节点执行 `reboot` 并检查:
 
@@ -372,7 +375,7 @@ kubectl -n cube-system logs <cube-node-pod> -c cube-egress-net --tail=100
 
 机制对齐一键包「停服务、不杀 shim、覆盖二进制、重启」：
 
-1. **`cube-node-installer`** 与 Big Pod **self-stage** 从 `/opt/cube-image` stage 到 `/usr/local/services/cubetoolbox`（整树 hostPath；原子目录替换）。升产物只动 Installer；升控面只动 Big Pod。**`cube-node-bootstrap`** 负责 pvm / node-init 并写 `node-prep-ready`；升 nodeInit/pvm 只动 Bootstrap。分工见 [`ARCHITECTURE.md`](ARCHITECTURE.md)；步骤见 [`UPGRADE.md`](UPGRADE.md)。
+1. **`cube-node-installer`** 与 Big Pod **self-stage** 从 `/opt/cube-image` stage 到 `/usr/local/services/cubetoolbox`（整树 hostPath；原子目录替换）。升产物只动 Installer；升控面只动 Big Pod。**`cube-node-pvm`** 负责 PVM host；**`cube-node-bootstrap`** 负责 wait-pvm / node-init 并写 `node-prep-ready`。分工见 [`ARCHITECTURE.md`](ARCHITECTURE.md)；步骤见 [`UPGRADE.md`](UPGRADE.md)。
 2. shim ttrpc / VMM socket 目录也是 hostPath：容器 `/run/containerd` → 宿主机 `/data/cubelet/run/containerd`，容器 `/run/vc` → 宿主机 `/data/cubelet/run/vc`。
 3. `/data/cubelet/state` 通过启动前 `mount --bind` 留在 hostPath 上。
 4. `preStop` / entrypoint 只 TERM **cubelet** 与 **network-agent**，不匹配 `containerd-shim-cube-rs` / `cube-runtime`。

--- a/deploy/kubernetes/chart/docs/QUICKSTART.md
+++ b/deploy/kubernetes/chart/docs/QUICKSTART.md
@@ -37,15 +37,19 @@ Chart **不会自动打 label**,请部署前手动执行:
 kubectl label nodes <control-node-1> cube.tencent.com/role=control cube.tencent.com/cube-control=true
 kubectl taint nodes <control-node-1> cube.tencent.com/control=true:NoSchedule --overwrite
 
-# 计算节点
+# 计算节点（运行 cube-node / bootstrap / installer）
 kubectl label nodes <compute-node-1> \
   cube.tencent.com/role=compute \
-  cube.tencent.com/cube-node=true \
-  cube.tencent.com/allow-pvm-bootstrap=true
+  cube.tencent.com/cube-node=true
 kubectl taint nodes <compute-node-1> cube.tencent.com/compute=true:NoSchedule --overwrite
+
+# 需要 PVM 宿主机内核的节点额外授权（才会调度 cube-node-pvm、拉取 PVM 镜像）
+kubectl label nodes <pvm-compute-node> cube.tencent.com/allow-pvm-bootstrap=true
 ```
 
-`allow-pvm-bootstrap=true` 显式授权该节点可以被 chart 替换 host kernel;不打这个 label 就无法作为 compute 节点部署。
+- compute 节点：打 `role=compute` + `cube-node=true` 即可跑 Big Pod / bootstrap / installer。
+- **仅**需要替换 host kernel 的节点再打 `allow-pvm-bootstrap=true`；不打则不会拉 `cube-pvm-host-bootstrap`。
+- 混部：部分 compute 打 allow-pvm，其余不打即可。
 
 ### 1.4 安装 OpenKruise（计算面原地升级）
 
@@ -145,7 +149,7 @@ helm upgrade --install cube ./deploy/kubernetes/chart \
 1. **秒级**:控制面 Secret / ConfigMap / RBAC 创建
 2. **1-3 分钟**:MySQL / Redis StatefulSet ready,CubeMaster 完成 schema migration
 3. **1-2 分钟**:CubeAPI / CubeProxy / WebUI ready
-4. **首次 5-15 分钟**:每 compute 节点上 `cube-node-bootstrap` 执行 `pvm-host-bootstrap`(可能触发重启)→ `cube-node-init` → 写 `node-prep-ready`；Big Pod `wait-node-prep` sidecar（Kruise prio 10）Ready 后主容器启动 → 节点向 CubeMaster 注册
+4. **首次 5-15 分钟**:有 `allow-pvm-bootstrap` 的节点上 `cube-node-pvm` 执行 `pvm-host-bootstrap`(可能触发重启)→ 写指纹 `pvm-host-ready`；全部 compute 上 `cube-node-bootstrap` 的 `wait-pvm-host` → `cube-node-init` → 写 `node-prep-ready`；Big Pod `wait-node-prep` Ready 后主容器启动 → 节点向 CubeMaster 注册
 5. **之后**:后续升级/滚动更新只需秒级
 
 ---
@@ -188,6 +192,7 @@ kubectl label nodes <node> \
   cube.tencent.com/cube-node=true \
   cube.tencent.com/allow-pvm-bootstrap=true
 # 不要打 taint
+# 单节点试用若需要 PVM，保留 allow-pvm；纯 BM 可去掉 allow-pvm 并设 bootstrap.pvmHostKernel.enabled=false
 ```
 
 `runtime-values.yaml` 中把持久化改成 hostPath 以避免依赖任何 CSI:

--- a/deploy/kubernetes/chart/docs/UPGRADE.md
+++ b/deploy/kubernetes/chart/docs/UPGRADE.md
@@ -19,14 +19,15 @@ helm install kruise openkruise/kruise --version 1.9.0 \
 ## 原理
 
 1. toolbox 整树 hostPath 挂在 `/usr/local/services/cubetoolbox`（Big Pod volumeMount **冻结**）。
-2. 同 `placement.compute`、selector 互斥的三个 DaemonSet：
+2. 计算面 DaemonSet：
    - **`*-node`（Big Pod）**：`wait-node-prep`（Kruise prio 10）+ `network-agent` / `cubelet`（self-stage）+ 可选 egress + **6 个冻结 `cube-slot-*` pause 占位**；**零 init**；日常只 **InPlace** bump **containers** 镜像 / slot annotation / slot resources。
    - **`*-node-installer`**：shim / kernel / guest 安装；可 RollingUpdate、可增容器。
-   - **`*-node-bootstrap`**：pvm / node-init / 写 `node-prep-ready`；低频 RollingUpdate。
-3. Bootstrap 写 `node-prep-ready`；Installer / self-stage 写组件 `.staged-*`；cubelet 等 artifact 与 network-agent sentinel。
+   - **`*-node-bootstrap`**：`wait-pvm-host` / node-init / 写 `node-prep-ready`；低频 RollingUpdate。
+   - **`*-node-pvm`**（可选）：PVM host kernel；仅 `placement.pvm`；升 PVM 只 bump 本 DS。
+3. Bootstrap 写 `node-prep-ready`；PVM 写指纹 `pvm-host-ready`；Installer / self-stage 写组件 `.staged-*`；cubelet 等 artifact 与 network-agent sentinel。
 4. **NodeID** = `spec.nodeName`；**Endpoint** = Big Pod `status.podIP`。
 5. `preStop` 只杀本容器 pidfile，禁止宽 `pkill -f`。
-6. 日常分工：**升控面 → 只 bump Big Pod 镜像**；**升产物 → 只动 Installer**；**升节点引导 → 只动 Bootstrap**。
+6. 日常分工：**升控面 → 只 bump Big Pod 镜像**；**升产物 → 只动 Installer**；**升 node-init → 只动 Bootstrap**；**升 PVM → 只动 cube-node-pvm**。
 
 ## 按组件升级示例
 
@@ -63,6 +64,7 @@ helm upgrade cube ./deploy/kubernetes/chart -n cube-system \
 | Big Pod `rollingUpdateType: Standard` / 删 Big Pod | 数据面中断 |
 | 把新产物 install 塞进 Big Pod | 破坏冻结契约（应加在 Installer） |
 | 把 pvm / node-init 并进 Installer | 日常升 shim 可能 reboot / 扩大 hostPID 面 |
+| 把 `allow-pvm-bootstrap` 写进 `placement.compute` | validate 失败；且会让所有 compute 拉 PVM 镜像 |
 
 ## 相关镜像键
 
@@ -74,9 +76,9 @@ helm upgrade cube ./deploy/kubernetes/chart -n cube-system \
 | `images.cubeShim` | Installer | `cube-shim-install` |
 | `images.cubeKernel` | Installer | `cube-kernel-install` |
 | `images.cubeGuest` | Installer | `cube-guest-install` |
-| `images.pvmHostBootstrap` | Bootstrap | `pvm-host-bootstrap` |
-| `images.nodeInit` | Bootstrap | `cube-node-init` |
-| `images.waitNodePrep` | Bootstrap | `write-node-prep-ready`（同镜像） |
+| `images.pvmHostBootstrap` | **cube-node-pvm** | `pvm-host-bootstrap` |
+| `images.nodeInit` | Bootstrap | `wait-pvm-host` / `cube-node-init` |
+| `images.waitNodePrep` | Bootstrap / PVM hold | `write-node-prep-ready` / `hold-pvm-ready` |
 
 ## 卸载后全新安装
 

--- a/deploy/kubernetes/chart/templates/NOTES.txt
+++ b/deploy/kubernetes/chart/templates/NOTES.txt
@@ -61,11 +61,17 @@ Useful commands:
   kubectl get pods -n {{ .Release.Namespace }} -o wide
   kubectl get ads -n {{ .Release.Namespace }} {{ include "cube.nodeName" . }}
   kubectl get ds -n {{ .Release.Namespace }} {{ include "cube.nodeBootstrapName" . }}
+{{- if .Values.bootstrap.pvmHostKernel.enabled }}
+  kubectl get ds -n {{ .Release.Namespace }} {{ include "cube.nodePvmName" . }}
+{{- end }}
   kubectl get ds -n {{ .Release.Namespace }} {{ include "cube.nodeInstallerName" . }}
 {{- if eq (include "cube.proxyEnabled" .) "true" }}
   kubectl get deploy -n {{ .Release.Namespace }} {{ include "cube.proxyName" . }}
 {{- end }}
-  kubectl logs -n {{ .Release.Namespace }} -l app.kubernetes.io/component=cube-node-bootstrap -c pvm-host-bootstrap --tail=100
+{{- if .Values.bootstrap.pvmHostKernel.enabled }}
+  kubectl logs -n {{ .Release.Namespace }} -l app.kubernetes.io/component=cube-node-pvm -c pvm-host-bootstrap --tail=100
+{{- end }}
+  kubectl logs -n {{ .Release.Namespace }} -l app.kubernetes.io/component=cube-node-bootstrap -c wait-pvm-host --tail=100
   kubectl logs -n {{ .Release.Namespace }} -l app.kubernetes.io/component=cube-node-bootstrap -c cube-node-init --tail=100
   kubectl logs -n {{ .Release.Namespace }} -l app.kubernetes.io/component=cube-node -c wait-node-prep --tail=100
   kubectl logs -n {{ .Release.Namespace }} -l app.kubernetes.io/component=cube-node -c cubelet --tail=100
@@ -79,6 +85,6 @@ Useful commands:
   sh /tmp/cube-diag-k8s.sh {{ .Release.Namespace }} {{ .Release.Name }}
 {{- end }}
 
-WARNING: If bootstrap.pvmHostKernel.enabled=true, this release may install a host kernel and reboot selected compute nodes (via cube-node-bootstrap).
+WARNING: If bootstrap.pvmHostKernel.enabled=true, this release may install a host kernel and reboot nodes labeled allow-pvm-bootstrap (via cube-node-pvm).
 Helm rollback does not roll back host kernel/GRUB changes.
 Bump images.waitNodePrep image-only for InPlace; changing wait env/mounts forces Big Pod recreate.

--- a/deploy/kubernetes/chart/templates/_helpers.tpl
+++ b/deploy/kubernetes/chart/templates/_helpers.tpl
@@ -98,6 +98,21 @@ tolerations:
 {{- end }}
 {{- end -}}
 
+{{- define "cube.pvmPlacement" -}}
+{{- with .Values.placement.pvm.nodeSelector }}
+nodeSelector:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- with .Values.placement.pvm.affinity }}
+affinity:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- with .Values.placement.pvm.tolerations }}
+tolerations:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- end -}}
+
 {{/* Proxy Service FQDN and cluster-DNS enablement helpers. */}}
 
 {{- define "cube.nodeServiceAccountName" -}}
@@ -134,6 +149,10 @@ tolerations:
 
 {{- define "cube.nodeBootstrapName" -}}
 {{- printf "%s-node-bootstrap" (include "cube.fullname" .) -}}
+{{- end -}}
+
+{{- define "cube.nodePvmName" -}}
+{{- printf "%s-node-pvm" (include "cube.fullname" .) -}}
 {{- end -}}
 
 {{- define "cube.proxyName" -}}
@@ -399,6 +418,8 @@ Toolbox is mounted whole at the fixed path (InPlace-stable).
 
 {{- define "cube.nodeDataplaneVolumeMounts" -}}
 {{- include "cube.nodeToolboxVolumeMounts" . }}
+- name: bootstrap-state
+  mountPath: {{ .Values.hostPaths.bootstrapState }}
 - name: dev
   mountPath: /dev
 - name: sys
@@ -520,6 +541,8 @@ Bootstrap: host mutation mounts for pvm / node-init.
   value: /opt/cube-image
 - name: CUBE_PID_DIR
   value: /run/cube-node
+- name: STATE_DIR
+  value: {{ .Values.hostPaths.bootstrapState | quote }}
 - name: CUBE_MASTER_ENDPOINT
   value: {{ include "cube.masterEndpoint" . | quote }}
 - name: CUBE_SANDBOX_NODE_ID

--- a/deploy/kubernetes/chart/templates/node-bootstrap-daemonset.yaml
+++ b/deploy/kubernetes/chart/templates/node-bootstrap-daemonset.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.cubeNode.enabled }}
-# Node prep DaemonSet (pvm + node-init + write node-prep-ready).
-# Low-churn workload: bumping nodeInit/pvmHostBootstrap recreates THIS pod only,
-# not the Big Pod. Artifact install stays on cube-node-installer (narrow mounts).
+# Node prep DaemonSet (wait-pvm-host + node-init + write node-prep-ready).
+# PVM host install is on cube-node-pvm. Low-churn: bumping nodeInit recreates
+# THIS pod only, not the Big Pod. Artifact install stays on cube-node-installer.
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -35,7 +35,7 @@ spec:
     spec:
       serviceAccountName: {{ include "cube.nodeServiceAccountName" . }}
       automountServiceAccountToken: true
-      # nsenter --target 1 for pvm/node-init (same privilege model as former Big Pod inits).
+      # nsenter --target 1 for node-init (same privilege model as former Big Pod inits).
       hostPID: true
       dnsPolicy: ClusterFirst
       terminationGracePeriodSeconds: {{ .Values.cubeNodeBootstrap.terminationGracePeriodSeconds }}
@@ -45,10 +45,10 @@ spec:
       {{- end }}
       {{- include "cube.computePlacement" . | nindent 6 }}
       initContainers:
-        {{- if .Values.bootstrap.pvmHostKernel.enabled }}
-        - name: pvm-host-bootstrap
-          image: {{ include "cube.cubeImage" (dict "image" .Values.images.pvmHostBootstrap "context" $) | quote }}
-          imagePullPolicy: {{ .Values.images.pvmHostBootstrap.pullPolicy }}
+        - name: wait-pvm-host
+          image: {{ include "cube.cubeImage" (dict "image" .Values.images.nodeInit "context" $) | quote }}
+          imagePullPolicy: {{ .Values.images.nodeInit.pullPolicy }}
+          command: ["/usr/bin/tini", "-s", "--", "/scripts/wait-pvm-host.sh"]
           securityContext:
             privileged: {{ .Values.security.privileged }}
           env:
@@ -57,43 +57,24 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
-            - name: POD_NAMESPACE
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
             - name: HOST_ROOT
               value: /host
             - name: STATE_DIR
               value: {{ .Values.hostPaths.bootstrapState | quote }}
-            - name: PVM_ENABLED
-              value: "1"
+            - name: PVM_FEATURE_ENABLED
+              value: {{ ternary "1" "0" .Values.bootstrap.pvmHostKernel.enabled | quote }}
+            - name: CUBE_PVM_ENABLE
+              value: {{ ternary "1" "0" .Values.cubeNode.pvmGuestKernel.enabled | quote }}
+            - name: ALLOW_PVM_LABEL
+              value: cube.tencent.com/allow-pvm-bootstrap
             - name: DESIRED_KERNEL_PATTERN
               value: {{ .Values.bootstrap.pvmHostKernel.desiredKernelPattern | quote }}
-            - name: PVM_KERNEL_BOOT_ARGS
+            - name: KERNEL_BOOT_ARGS
               value: {{ .Values.bootstrap.pvmHostKernel.bootArgs | quote }}
-            - name: PVM_KERNEL_RPM_PATH
-              value: {{ .Values.bootstrap.pvmHostKernel.package.rpmPath | quote }}
-            - name: PVM_KERNEL_DEB_PATH
-              value: {{ .Values.bootstrap.pvmHostKernel.package.debPath | quote }}
-            - name: PVM_KERNEL_RPM_URL
-              value: {{ .Values.bootstrap.pvmHostKernel.package.rpmUrl | quote }}
-            - name: PVM_KERNEL_DEB_URL
-              value: {{ .Values.bootstrap.pvmHostKernel.package.debUrl | quote }}
-            - name: PVM_KERNEL_PACKAGE_SOURCE
-              value: {{ .Values.bootstrap.pvmHostKernel.package.source | quote }}
-            - name: REBOOT_ENABLED
-              value: {{ .Values.bootstrap.pvmHostKernel.reboot.enabled | quote }}
-            - name: REBOOT_COORDINATED
-              value: {{ .Values.bootstrap.pvmHostKernel.reboot.coordinated | quote }}
-            - name: LEASE_NAME
-              value: {{ .Values.bootstrap.pvmHostKernel.reboot.leaseName | quote }}
-            - name: LEASE_TTL_SECONDS
-              value: {{ .Values.bootstrap.pvmHostKernel.reboot.leaseTTLSeconds | quote }}
-            - name: REBOOT_MAX_COUNT
-              value: {{ .Values.bootstrap.pvmHostKernel.reboot.maxCount | quote }}
+            - name: WAIT_TIMEOUT_SECONDS
+              value: {{ .Values.cubeNodeBootstrap.pvmWaitTimeoutSeconds | default "900" | quote }}
           volumeMounts:
             {{- include "cube.bootstrapHostVolumeMounts" . | nindent 12 }}
-        {{- end }}
         {{- if .Values.bootstrap.nodeInit.enabled }}
         - name: cube-node-init
           image: {{ include "cube.cubeImage" (dict "image" .Values.images.nodeInit "context" $) | quote }}

--- a/deploy/kubernetes/chart/templates/node-pvm-daemonset.yaml
+++ b/deploy/kubernetes/chart/templates/node-pvm-daemonset.yaml
@@ -1,0 +1,110 @@
+{{- if and .Values.cubeNode.enabled .Values.bootstrap.pvmHostKernel.enabled }}
+# PVM host-kernel DaemonSet. Schedules only via placement.pvm (allow-pvm-bootstrap).
+# Non-PVM compute nodes never pull images.pvmHostBootstrap. Reboot-capable;
+# invalidates node-prep / pvm-host-ready sentinels before mutate.
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: {{ include "cube.nodePvmName" . }}
+  labels:
+    {{- include "cube.labels" . | nindent 4 }}
+    app.kubernetes.io/component: cube-node-pvm
+spec:
+  updateStrategy:
+    type: {{ .Values.cubeNodePvm.updateStrategy.type | default "RollingUpdate" }}
+    {{- if .Values.cubeNodePvm.updateStrategy.rollingUpdate }}
+    rollingUpdate:
+      maxUnavailable: {{ .Values.cubeNodePvm.updateStrategy.rollingUpdate.maxUnavailable | default 1 }}
+      {{- with .Values.cubeNodePvm.updateStrategy.rollingUpdate.maxSurge }}
+      maxSurge: {{ . }}
+      {{- end }}
+    {{- end }}
+  selector:
+    matchLabels:
+      {{- include "cube.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: cube-node-pvm
+  template:
+    metadata:
+      labels:
+        {{- include "cube.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: cube-node-pvm
+      annotations:
+        {{- with .Values.cubeNodePvm.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      serviceAccountName: {{ include "cube.nodeServiceAccountName" . }}
+      automountServiceAccountToken: true
+      hostPID: true
+      dnsPolicy: ClusterFirst
+      terminationGracePeriodSeconds: {{ .Values.cubeNodePvm.terminationGracePeriodSeconds }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- include "cube.pvmPlacement" . | nindent 6 }}
+      initContainers:
+        - name: pvm-host-bootstrap
+          image: {{ include "cube.cubeImage" (dict "image" .Values.images.pvmHostBootstrap "context" $) | quote }}
+          imagePullPolicy: {{ .Values.images.pvmHostBootstrap.pullPolicy }}
+          securityContext:
+            privileged: {{ .Values.security.privileged }}
+          env:
+            {{- include "cube.timezoneEnv" . | nindent 12 }}
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: HOST_ROOT
+              value: /host
+            - name: STATE_DIR
+              value: {{ .Values.hostPaths.bootstrapState | quote }}
+            - name: PVM_ENABLED
+              value: "1"
+            - name: DESIRED_KERNEL_PATTERN
+              value: {{ .Values.bootstrap.pvmHostKernel.desiredKernelPattern | quote }}
+            - name: KERNEL_BOOT_ARGS
+              value: {{ .Values.bootstrap.pvmHostKernel.bootArgs | quote }}
+            - name: PVM_KERNEL_RPM_PATH
+              value: {{ .Values.bootstrap.pvmHostKernel.package.rpmPath | quote }}
+            - name: PVM_KERNEL_DEB_PATH
+              value: {{ .Values.bootstrap.pvmHostKernel.package.debPath | quote }}
+            - name: PVM_KERNEL_RPM_URL
+              value: {{ .Values.bootstrap.pvmHostKernel.package.rpmUrl | quote }}
+            - name: PVM_KERNEL_DEB_URL
+              value: {{ .Values.bootstrap.pvmHostKernel.package.debUrl | quote }}
+            - name: PVM_KERNEL_PACKAGE_SOURCE
+              value: {{ .Values.bootstrap.pvmHostKernel.package.source | quote }}
+            - name: REBOOT_ENABLED
+              value: {{ .Values.bootstrap.pvmHostKernel.reboot.enabled | quote }}
+            - name: REBOOT_COORDINATED
+              value: {{ .Values.bootstrap.pvmHostKernel.reboot.coordinated | quote }}
+            - name: LEASE_NAME
+              value: {{ .Values.bootstrap.pvmHostKernel.reboot.leaseName | quote }}
+            - name: LEASE_TTL_SECONDS
+              value: {{ .Values.bootstrap.pvmHostKernel.reboot.leaseTTLSeconds | quote }}
+            - name: REBOOT_MAX_COUNT
+              value: {{ .Values.bootstrap.pvmHostKernel.reboot.maxCount | quote }}
+          volumeMounts:
+            {{- include "cube.bootstrapHostVolumeMounts" . | nindent 12 }}
+      containers:
+        - name: hold-pvm-ready
+          image: {{ include "cube.cubeImage" (dict "image" .Values.images.waitNodePrep "context" $) | quote }}
+          imagePullPolicy: {{ .Values.images.waitNodePrep.pullPolicy }}
+          command: ["/usr/bin/tini", "-s", "--", "sleep", "infinity"]
+          env:
+            {{- include "cube.timezoneEnv" . | nindent 12 }}
+          volumeMounts:
+            - name: bootstrap-state
+              mountPath: {{ .Values.hostPaths.bootstrapState }}
+          {{- with .Values.cubeNodePvm.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      volumes:
+        {{- include "cube.bootstrapVolumes" . | nindent 8 }}
+{{- end }}

--- a/deploy/kubernetes/chart/templates/validate.yaml
+++ b/deploy/kubernetes/chart/templates/validate.yaml
@@ -7,8 +7,18 @@
 {{- if not $computeSelector }}
 {{- fail "cube-node requires placement.compute.nodeSelector, otherwise host-mutating bootstrap may run on all nodes" }}
 {{- end }}
-{{- if and .Values.bootstrap.pvmHostKernel.enabled (not (hasKey $computeSelector "cube.tencent.com/allow-pvm-bootstrap")) }}
-{{- fail "bootstrap.pvmHostKernel.enabled=true requires placement.compute.nodeSelector to include cube.tencent.com/allow-pvm-bootstrap=true" }}
+{{- $pvmSelector := ((.Values.placement).pvm).nodeSelector | default dict -}}
+{{- if .Values.bootstrap.pvmHostKernel.enabled }}
+{{- if not (hasKey $pvmSelector "cube.tencent.com/allow-pvm-bootstrap") }}
+{{- fail "bootstrap.pvmHostKernel.enabled=true requires placement.pvm.nodeSelector to include cube.tencent.com/allow-pvm-bootstrap=true (PVM DaemonSet only; keep it out of placement.compute so non-PVM nodes skip the PVM image)" }}
+{{- end }}
+{{- $allowPvmRaw := index $pvmSelector "cube.tencent.com/allow-pvm-bootstrap" -}}
+{{- if or (not (kindIs "string" $allowPvmRaw)) (ne $allowPvmRaw "true") }}
+{{- fail (printf "placement.pvm.nodeSelector[cube.tencent.com/allow-pvm-bootstrap] must be the YAML string \"true\" (got %T %v)" $allowPvmRaw $allowPvmRaw) }}
+{{- end }}
+{{- if hasKey $computeSelector "cube.tencent.com/allow-pvm-bootstrap" }}
+{{- fail "placement.compute.nodeSelector must not include cube.tencent.com/allow-pvm-bootstrap; that label belongs only in placement.pvm.nodeSelector" }}
+{{- end }}
 {{- end }}
 {{- if and (eq (.Values.cubeNode.nodeIDSource | default "specNodeName") "static") (not .Values.cubeNode.staticNodeID) }}
 {{- fail "cubeNode.nodeIDSource=static requires cubeNode.staticNodeID" }}

--- a/deploy/kubernetes/chart/values.yaml
+++ b/deploy/kubernetes/chart/values.yaml
@@ -175,8 +175,23 @@ placement:
         value: "true"
         effect: NoSchedule
 
-  # Compute placement is used by cube-node.
+  # Compute placement is used by cube-node / bootstrap / installer.
+  # Do NOT require allow-pvm-bootstrap here — that label is only for placement.pvm
+  # so non-PVM compute nodes never pull cube-pvm-host-bootstrap.
   compute:
+    nodeSelector:
+      cube.tencent.com/role: compute
+      cube.tencent.com/cube-node: "true"
+    affinity: {}
+    tolerations:
+      - key: cube.tencent.com/compute
+        operator: Equal
+        value: "true"
+        effect: NoSchedule
+
+  # PVM host-kernel DaemonSet only. Nodes without this label skip PVM install
+  # and do not pull the PVM bootstrap image (mixed-cluster safe).
+  pvm:
     nodeSelector:
       cube.tencent.com/role: compute
       cube.tencent.com/cube-node: "true"
@@ -564,15 +579,18 @@ cubeNodeInstaller:
     limits:
       memory: "512Mi"
 
-# Node prep DaemonSet (pvm + node-init + write node-prep-ready). Low churn;
-# bumping nodeInit/pvmHostBootstrap recreates this DS only. hostPID=true and
-# wide host mounts — do NOT merge into cube-node-installer.
+# Node prep DaemonSet (wait-pvm-host + node-init + write node-prep-ready).
+# Low churn; bumping nodeInit recreates this DS only. hostPID=true and wide
+# host mounts — do NOT merge into cube-node-installer. PVM host install lives
+# on cube-node-pvm (placement.pvm).
 cubeNodeBootstrap:
   podAnnotations: {}
   # Bump only when intentionally invalidating all nodes' prep fingerprint
   # (forces wait-node-prep to re-block until bootstrap rewrites sentinel).
   prepGeneration: "1"
   waitTimeoutSeconds: "600"
+  # How long wait-pvm-host polls pvm-host-ready on PVM-labeled nodes.
+  pvmWaitTimeoutSeconds: "900"
   # Resources for Big Pod wait-node-prep sidecar.
   waitResources:
     requests:
@@ -580,6 +598,22 @@ cubeNodeBootstrap:
       memory: "32Mi"
     limits:
       memory: "64Mi"
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+  terminationGracePeriodSeconds: 30
+  resources:
+    requests:
+      cpu: "50m"
+      memory: "64Mi"
+    limits:
+      memory: "256Mi"
+
+# PVM host-kernel DaemonSet (only on placement.pvm). Bumping pvmHostBootstrap
+# recreates this DS only — not bootstrap or Big Pod.
+cubeNodePvm:
+  podAnnotations: {}
   updateStrategy:
     type: RollingUpdate
     rollingUpdate:
@@ -872,8 +906,8 @@ hostPaths:
   dataCubeShim: /data/cube-shim
   dataSnapshotPack: /data/snapshot_pack
   tmpCube: /tmp/cube
-  # pvm/node-init state + node-prep-ready sentinel (shared by bootstrap DS and
-  # Big Pod wait-node-prep).
+  # pvm/node-init state + node-prep-ready / pvm-host-ready / effective-pvm
+  # (shared by cube-node-pvm, bootstrap DS, and Big Pod wait-node-prep).
   bootstrapState: /var/lib/cube-node-bootstrap
   # Host-persistent toolbox tree. Big Pod mounts this path whole at
   # /usr/local/services/cubetoolbox (stable volumeMount for InPlace). Installer

--- a/deploy/kubernetes/images/README.md
+++ b/deploy/kubernetes/images/README.md
@@ -124,7 +124,7 @@ entrypoint behavior.
   It is a Kubernetes delivery image that bundles the node-side runtime components required by the Cube Node Big Pod, including `Cubelet`, `network-agent`, `cube-shim`, `cube-kernel-scf`, `cube-image`, `cube-vs`, and `cube-snapshot`. `cube-egress` is intentionally not bundled in this image because it is delivered as a separate sidecar image.
   If `CUBE_NODE_BASE_IMAGE` is set, the build script rebases that image instead
   and only replaces `/usr/local/bin/cube-node-entrypoint.sh`.
-- `cube-node-init` and `cube-pvm-host-bootstrap` run on the **`cube-node-bootstrap`** DaemonSet (REV3.2; not Big Pod init).
+- `cube-node-init` (`wait-pvm-host` + `cube-node-init`) runs on the **`cube-node-bootstrap`** DaemonSet; `cube-pvm-host-bootstrap` runs on **`cube-node-pvm`** (placement.pvm only).
 - `cube-wait-node-prep` is the Big Pod `wait-node-prep` **sidecar** (Kruise container launch priority) and the bootstrap `write-node-prep-ready` hold container. Bumping only the wait **image** on Big Pod may InPlace; do not change wait env/mounts routinely.
 - `cube-master` is built directly from `CubeMaster/docker/Dockerfile`. The build script prepares a temporary Docker context with the release-package `cubemaster` binary and the `CubeMaster/docker/tools` directory expected by that Dockerfile.
 - `cube-api` is built from `CubeAPI/Dockerfile`; no duplicate Dockerfile is kept here.

--- a/deploy/kubernetes/images/build-cube-images.sh
+++ b/deploy/kubernetes/images/build-cube-images.sh
@@ -797,7 +797,7 @@ run_selected_builds() {
 
   if should_build cube-node-init; then
     ctx="$(prepare_context cube-node-init)"
-    copy_scripts "${ctx}" cube-node-init.sh node-prep-lib.sh
+    copy_scripts "${ctx}" cube-node-init.sh wait-pvm-host.sh node-prep-lib.sh
     build_image cube-node-init "${ctx}"
     record_built cube-node-init
   fi

--- a/deploy/kubernetes/images/cube-node-init/Dockerfile
+++ b/deploy/kubernetes/images/cube-node-init/Dockerfile
@@ -1,24 +1,33 @@
 FROM ubuntu:22.04
 
 ARG DEBIAN_FRONTEND=noninteractive
+ARG KUBECTL_CHANNEL=v1.30
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
       ca-certificates \
       curl \
       e2fsprogs \
+      gnupg \
       iproute2 \
       kmod \
       mount \
       tini \
       util-linux \
       xfsprogs \
+    && curl -fsSL "https://pkgs.k8s.io/core:/stable:/${KUBECTL_CHANNEL}/deb/Release.key" \
+      | gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg \
+    && echo "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/${KUBECTL_CHANNEL}/deb/ /" \
+      > /etc/apt/sources.list.d/kubernetes.list \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends kubectl \
     && rm -rf /var/lib/apt/lists/*
 
 COPY scripts/node-prep-lib.sh /scripts/node-prep-lib.sh
 COPY scripts/cube-node-init.sh /scripts/cube-node-init.sh
+COPY scripts/wait-pvm-host.sh /scripts/wait-pvm-host.sh
 
-RUN chmod +x /scripts/cube-node-init.sh \
+RUN chmod +x /scripts/cube-node-init.sh /scripts/wait-pvm-host.sh \
     && chmod 644 /scripts/node-prep-lib.sh
 
 ENTRYPOINT ["/usr/bin/tini", "-s", "--", "/scripts/cube-node-init.sh"]

--- a/deploy/kubernetes/images/scripts/component-entrypoint.sh
+++ b/deploy/kubernetes/images/scripts/component-entrypoint.sh
@@ -17,9 +17,24 @@ TOOLBOX_ROOT="${TOOLBOX_ROOT:-/usr/local/services/cubetoolbox}"
 CUBE_COMPONENT="${CUBE_COMPONENT:-}"
 CUBE_ROLE="${CUBE_ROLE:-install}"
 CUBE_PID_DIR="${CUBE_PID_DIR:-/run/cube-node}"
+STATE_DIR="${STATE_DIR:-/var/lib/cube-node-bootstrap}"
 
 log() { printf '[cube-component:%s:%s] %s\n' "${CUBE_COMPONENT:-?}" "${CUBE_ROLE}" "$*"; }
 fail() { printf '[cube-component:%s:%s] ERROR: %s\n' "${CUBE_COMPONENT:-?}" "${CUBE_ROLE}" "$*" >&2; exit 1; }
+
+apply_effective_pvm_from_state() {
+  local path="${STATE_DIR}/effective-pvm"
+  local val
+  [[ -f "${path}" ]] || return 0
+  val="$(tr -d '[:space:]' < "${path}" 2>/dev/null || true)"
+  case "${val}" in
+    0|1)
+      CUBE_PVM_ENABLE="${val}"
+      export CUBE_PVM_ENABLE
+      log "CUBE_PVM_ENABLE overridden from ${path}=${val}"
+      ;;
+  esac
+}
 
 component_relpath() {
   case "$1" in
@@ -322,6 +337,7 @@ run_cubelet() {
   [[ -n "${CUBE_SANDBOX_NODE_ID:-}${CUBE_SANDBOX_NODE_IP:-}" ]] || fail "CUBE_SANDBOX_NODE_ID or CUBE_SANDBOX_NODE_IP is required"
   [[ -n "${CUBE_SANDBOX_ENDPOINT_IP:-}" ]] || fail "CUBE_SANDBOX_ENDPOINT_IP is required"
 
+  apply_effective_pvm_from_state
   select_guest_kernel
 
   local ep_esc

--- a/deploy/kubernetes/images/scripts/cube-node-entrypoint.sh
+++ b/deploy/kubernetes/images/scripts/cube-node-entrypoint.sh
@@ -19,9 +19,24 @@ if [[ -z "${CUBE_MASTER_ENDPOINT:-}" ]]; then
 fi
 CUBE_PVM_ENABLE="${CUBE_PVM_ENABLE:-1}"
 CUBE_SANDBOX_AUTO_DETECT_ETH="${CUBE_SANDBOX_AUTO_DETECT_ETH:-true}"
+STATE_DIR="${STATE_DIR:-/var/lib/cube-node-bootstrap}"
 
 log() { printf '[cube-node-entrypoint] %s\n' "$*"; }
 fail() { printf '[cube-node-entrypoint] ERROR: %s\n' "$*" >&2; exit 1; }
+
+apply_effective_pvm_from_state() {
+  local path="${STATE_DIR}/effective-pvm"
+  local val
+  [[ -f "${path}" ]] || return 0
+  val="$(tr -d '[:space:]' < "${path}" 2>/dev/null || true)"
+  case "${val}" in
+    0|1)
+      CUBE_PVM_ENABLE="${val}"
+      export CUBE_PVM_ENABLE
+      log "CUBE_PVM_ENABLE overridden from ${path}=${val}"
+      ;;
+  esac
+}
 
 require_cmd() {
   command -v "$1" >/dev/null 2>&1 || fail "missing command in cube-node image: $1"
@@ -147,6 +162,7 @@ configure_sandbox_dns() {
 [[ -n "${CUBE_SANDBOX_NODE_IP:-}" ]] || fail "CUBE_SANDBOX_NODE_IP is required"
 
 validate_runtime_commands
+apply_effective_pvm_from_state
 select_guest_kernel
 
 # Escape backslashes, ampersands, and forward slashes so they cannot terminate

--- a/deploy/kubernetes/images/scripts/cube-node-init.sh
+++ b/deploy/kubernetes/images/scripts/cube-node-init.sh
@@ -5,10 +5,8 @@ log() { printf '[cube-node-init] %s\n' "$*"; }
 fail() { printf '[cube-node-init] ERROR: %s\n' "$*" >&2; exit 1; }
 
 SCRIPT_DIR="$(CDPATH= cd -- "$(dirname "$0")" && pwd)"
-if [ -f "${SCRIPT_DIR}/node-prep-lib.sh" ]; then
-  # shellcheck disable=SC1091
-  . "${SCRIPT_DIR}/node-prep-lib.sh"
-fi
+# shellcheck disable=SC1091
+. "${SCRIPT_DIR}/node-prep-lib.sh"
 
 HOST_ROOT="${HOST_ROOT:-/host}"
 STATE_DIR="${STATE_DIR:-/var/lib/cube-node-bootstrap}"
@@ -33,7 +31,7 @@ CUBE_SANDBOX_NETWORK_CIDR_SKIP_CONFLICT_CHECK="${CUBE_SANDBOX_NETWORK_CIDR_SKIP_
 LOOPBACK_ENABLED="${LOOPBACK_ENABLED:-false}"
 LOOPBACK_IMAGE_PATH="${LOOPBACK_IMAGE_PATH:-/data/cubelet-xfs.img}"
 LOOPBACK_SIZE="${LOOPBACK_SIZE:-25G}"
-# REV3.2: when bootstrap Pod restarts and fingerprint already matches, skip
+# When bootstrap Pod restarts and fingerprint already matches, skip
 # (avoids blocking artifact-unrelated paths on Master/preflight). Default true
 # for bootstrap DS; set false to force a full re-run.
 SKIP_IF_NODE_PREP_READY="${SKIP_IF_NODE_PREP_READY:-true}"
@@ -43,9 +41,10 @@ export HOST_ROOT STATE_DIR NODE_INIT_ENABLED PVM_ENABLED
 
 host_path() { printf '%s%s' "$HOST_ROOT" "$1"; }
 
-if [ "$SKIP_IF_NODE_PREP_READY" = "true" ] \
-  && command -v node_prep_fingerprint_matches_file >/dev/null 2>&1 \
-  && node_prep_fingerprint_matches_file; then
+# Per-node effective-pvm (from wait-pvm-host) overrides Helm CUBE_PVM_ENABLE / PVM_ENABLED.
+apply_effective_pvm_env
+
+if [ "$SKIP_IF_NODE_PREP_READY" = "true" ] && node_prep_fingerprint_matches_file; then
   log "node-prep-ready fingerprint matches; skipping node-init"
   exit 0
 fi

--- a/deploy/kubernetes/images/scripts/node-prep-lib.sh
+++ b/deploy/kubernetes/images/scripts/node-prep-lib.sh
@@ -1,14 +1,25 @@
 #!/bin/sh
-# Shared helpers for node-prep-ready sentinel (Big Pod REV3.2).
-# Source from pvm-host-bootstrap / cube-node-init / write-node-prep-ready / wait-node-prep.
+# Shared helpers for node-prep / pvm-host sentinels (Big Pod + PVM DS).
+# Source from pvm-host-bootstrap / wait-pvm-host / cube-node-init /
+# write-node-prep-ready / wait-node-prep.
 #
-# Fingerprint fields (version=1):
+# Fingerprint fields for node-prep-ready (version=1):
 #   version, mode (full|noop), kernel, boot_args (space-separated required tokens),
 #   prep_generation, pvm_enabled, node_init_enabled
+#
+# Fingerprint fields for pvm-host-ready (version=1):
+#   version, kernel, boot_args, desired_pattern
+# Presence alone is NEVER enough — waiters compare against live uname/cmdline.
+#
+# pvm-mutating: set while host kernel/bootloader mutation is in progress so
+# waiters fail closed across the invalidate → reboot window.
 
 STATE_DIR="${STATE_DIR:-/var/lib/cube-node-bootstrap}"
 HOST_ROOT="${HOST_ROOT:-}"
 NODE_PREP_READY_NAME="${NODE_PREP_READY_NAME:-node-prep-ready}"
+PVM_HOST_READY_NAME="${PVM_HOST_READY_NAME:-pvm-host-ready}"
+EFFECTIVE_PVM_NAME="${EFFECTIVE_PVM_NAME:-effective-pvm}"
+PVM_MUTATING_NAME="${PVM_MUTATING_NAME:-pvm-mutating}"
 PREP_GENERATION="${PREP_GENERATION:-1}"
 PVM_ENABLED="${PVM_ENABLED:-0}"
 NODE_INIT_ENABLED="${NODE_INIT_ENABLED:-0}"
@@ -30,6 +41,18 @@ node_prep_state_dir() {
 
 node_prep_ready_path() {
   node_prep_host_path "${STATE_DIR}/${NODE_PREP_READY_NAME}"
+}
+
+pvm_host_ready_path() {
+  node_prep_host_path "${STATE_DIR}/${PVM_HOST_READY_NAME}"
+}
+
+effective_pvm_path() {
+  node_prep_host_path "${STATE_DIR}/${EFFECTIVE_PVM_NAME}"
+}
+
+pvm_mutating_path() {
+  node_prep_host_path "${STATE_DIR}/${PVM_MUTATING_NAME}"
 }
 
 node_prep_resolve_mode() {
@@ -65,14 +88,69 @@ node_prep_missing_boot_args() {
   [ -z "$missing" ] || printf '%s' "$missing"
 }
 
+node_prep_normalize_boot_args() {
+  printf '%s' "$KERNEL_BOOT_ARGS" | tr -s ' ' | sed 's/^ //;s/ $//'
+}
+
+# Prefer per-node effective-pvm (written by wait-pvm-host) over Helm env.
+apply_effective_pvm_env() {
+  path="$(effective_pvm_path)"
+  [ -f "$path" ] || return 0
+  val="$(tr -d '[:space:]' < "$path" 2>/dev/null || true)"
+  case "$val" in
+    0|1)
+      PVM_ENABLED="$val"
+      CUBE_PVM_ENABLE="$val"
+      export PVM_ENABLED CUBE_PVM_ENABLE
+      ;;
+  esac
+}
+
+write_effective_pvm() {
+  val="$(node_prep_bool01 "$1")"
+  dir="$(node_prep_state_dir)"
+  mkdir -p "$dir"
+  path="$(effective_pvm_path)"
+  tmp="${path}.tmp"
+  printf '%s\n' "$val" > "$tmp"
+  mv -f "$tmp" "$path"
+  PVM_ENABLED="$val"
+  CUBE_PVM_ENABLE="$val"
+  export PVM_ENABLED CUBE_PVM_ENABLE
+  printf '[node-prep] wrote %s=%s\n' "$path" "$val"
+}
+
+mark_pvm_mutating() {
+  dir="$(node_prep_state_dir)"
+  mkdir -p "$dir"
+  path="$(pvm_mutating_path)"
+  tmp="${path}.tmp"
+  printf '1\n' > "$tmp"
+  mv -f "$tmp" "$path"
+  printf '[node-prep] marked %s\n' "$path"
+}
+
+clear_pvm_mutating() {
+  path="$(pvm_mutating_path)"
+  if [ -e "$path" ] || [ -e "${path}.tmp" ]; then
+    rm -f "$path" "${path}.tmp"
+    printf '[node-prep] cleared %s\n' "$path"
+  fi
+}
+
+pvm_is_mutating() {
+  [ -f "$(pvm_mutating_path)" ]
+}
+
 node_prep_compute_fingerprint() {
+  apply_effective_pvm_env
   mode="$(node_prep_resolve_mode)"
   kernel="$(uname -r 2>/dev/null || true)"
   pvm="$(node_prep_bool01 "$PVM_ENABLED")"
   ninit="$(node_prep_bool01 "$NODE_INIT_ENABLED")"
   boot_args=""
   if [ "$mode" = "full" ] && [ "$pvm" = "1" ]; then
-    boot_args="$(printf '%s' "$KERNEL_BOOT_ARGS" | tr -s ' ' | sed 's/^ //;s/ $//')"
+    boot_args="$(node_prep_normalize_boot_args)"
   fi
   printf 'version=1\n'
   printf 'mode=%s\n' "$mode"
@@ -81,37 +159,6 @@ node_prep_compute_fingerprint() {
   printf 'prep_generation=%s\n' "$PREP_GENERATION"
   printf 'pvm_enabled=%s\n' "$pvm"
   printf 'node_init_enabled=%s\n' "$ninit"
-}
-
-node_prep_fingerprint_matches_file() {
-  ready="$(node_prep_ready_path)"
-  [ -f "$ready" ] || return 1
-  expected="$(node_prep_compute_fingerprint)"
-  actual="$(cat "$ready")"
-  [ "$expected" = "$actual" ]
-}
-
-node_prep_fingerprint_valid_for_wait() {
-  # Wait accepts a ready file whose fields match the currently desired fingerprint.
-  node_prep_fingerprint_matches_file
-}
-
-invalidate_node_prep_ready() {
-  ready="$(node_prep_ready_path)"
-  if [ -e "$ready" ] || [ -e "${ready}.tmp" ]; then
-    rm -f "$ready" "${ready}.tmp"
-    printf '[node-prep] invalidated %s\n' "$ready"
-  fi
-}
-
-write_node_prep_ready() {
-  dir="$(node_prep_state_dir)"
-  mkdir -p "$dir"
-  ready="$(node_prep_ready_path)"
-  tmp="${ready}.tmp"
-  node_prep_compute_fingerprint > "$tmp"
-  mv -f "$tmp" "$ready"
-  printf '[node-prep] wrote %s\n' "$ready"
 }
 
 node_prep_kernel_ready() {
@@ -124,4 +171,117 @@ node_prep_kernel_ready() {
   printf '%s' "$current_kernel" | grep -q "$DESIRED_KERNEL_PATTERN" || return 1
   missing="$(node_prep_missing_boot_args)"
   [ -z "$missing" ]
+}
+
+pvm_host_compute_fingerprint() {
+  kernel="$(uname -r 2>/dev/null || true)"
+  boot_args="$(node_prep_normalize_boot_args)"
+  printf 'version=1\n'
+  printf 'kernel=%s\n' "$kernel"
+  printf 'boot_args=%s\n' "$boot_args"
+  printf 'desired_pattern=%s\n' "$DESIRED_KERNEL_PATTERN"
+}
+
+pvm_host_fingerprint_matches_file() {
+  # File must exist AND match what live uname/cmdline would produce now.
+  # Fail closed while mutation is in progress.
+  pvm_is_mutating && return 1
+  ready="$(pvm_host_ready_path)"
+  [ -f "$ready" ] || return 1
+  node_prep_kernel_ready || return 1
+  expected="$(pvm_host_compute_fingerprint)"
+  actual="$(cat "$ready")"
+  [ "$expected" = "$actual" ]
+}
+
+write_pvm_host_ready() {
+  # Only call after live kernel already satisfies pattern + boot args.
+  if ! node_prep_kernel_ready; then
+    printf '[node-prep] ERROR: refusing to write pvm-host-ready; live kernel not ready\n' >&2
+    return 1
+  fi
+  dir="$(node_prep_state_dir)"
+  mkdir -p "$dir"
+  ready="$(pvm_host_ready_path)"
+  tmp="${ready}.tmp"
+  pvm_host_compute_fingerprint > "$tmp"
+  mv -f "$tmp" "$ready"
+  clear_pvm_mutating
+  printf '[node-prep] wrote %s\n' "$ready"
+}
+
+node_prep_fingerprint_matches_file() {
+  ready="$(node_prep_ready_path)"
+  [ -f "$ready" ] || return 1
+  expected="$(node_prep_compute_fingerprint)"
+  actual="$(cat "$ready")"
+  [ "$expected" = "$actual" ] || return 1
+  # When this node is in PVM mode, also require live PVM host readiness.
+  # Prevents accepting a self-consistent but wrong-kernel node-prep-ready.
+  pvm="$(node_prep_bool01 "$PVM_ENABLED")"
+  if [ "$pvm" = "1" ]; then
+    pvm_is_mutating && return 1
+    node_prep_kernel_ready || return 1
+    pvm_host_fingerprint_matches_file || return 1
+  fi
+  return 0
+}
+
+invalidate_node_prep_ready() {
+  ready="$(node_prep_ready_path)"
+  if [ -e "$ready" ] || [ -e "${ready}.tmp" ]; then
+    rm -f "$ready" "${ready}.tmp"
+    printf '[node-prep] invalidated %s\n' "$ready"
+  fi
+}
+
+write_node_prep_ready() {
+  apply_effective_pvm_env
+  pvm="$(node_prep_bool01 "$PVM_ENABLED")"
+  if [ "$pvm" = "1" ]; then
+    if pvm_is_mutating; then
+      printf '[node-prep] ERROR: refusing to write node-prep-ready while pvm-mutating\n' >&2
+      return 1
+    fi
+    if ! node_prep_kernel_ready; then
+      printf '[node-prep] ERROR: refusing to write node-prep-ready; live PVM kernel not ready\n' >&2
+      return 1
+    fi
+    if ! pvm_host_fingerprint_matches_file; then
+      printf '[node-prep] ERROR: refusing to write node-prep-ready; pvm-host-ready fingerprint mismatch\n' >&2
+      return 1
+    fi
+  fi
+  dir="$(node_prep_state_dir)"
+  mkdir -p "$dir"
+  ready="$(node_prep_ready_path)"
+  tmp="${ready}.tmp"
+  # Write fingerprint directly (do not capture via $(); trailing newlines matter).
+  node_prep_compute_fingerprint > "$tmp"
+  mv -f "$tmp" "$ready"
+  printf '[node-prep] wrote %s\n' "$ready"
+}
+
+invalidate_pvm_host_ready() {
+  ready="$(pvm_host_ready_path)"
+  if [ -e "$ready" ] || [ -e "${ready}.tmp" ]; then
+    rm -f "$ready" "${ready}.tmp"
+    printf '[node-prep] invalidated %s\n' "$ready"
+  fi
+}
+
+invalidate_effective_pvm() {
+  path="$(effective_pvm_path)"
+  if [ -e "$path" ] || [ -e "${path}.tmp" ]; then
+    rm -f "$path" "${path}.tmp"
+    printf '[node-prep] invalidated %s\n' "$path"
+  fi
+}
+
+# Call before any host mutate that may reboot (PVM install / boot-args change).
+invalidate_pvm_gate_sentinels() {
+  mark_pvm_mutating
+  invalidate_node_prep_ready
+  invalidate_pvm_host_ready
+  invalidate_effective_pvm
 }

--- a/deploy/kubernetes/images/scripts/pvm-host-bootstrap.sh
+++ b/deploy/kubernetes/images/scripts/pvm-host-bootstrap.sh
@@ -5,10 +5,8 @@ log() { printf '[pvm-host-bootstrap] %s\n' "$*"; }
 fail() { printf '[pvm-host-bootstrap] ERROR: %s\n' "$*" >&2; exit 1; }
 
 SCRIPT_DIR="$(CDPATH= cd -- "$(dirname "$0")" && pwd)"
-if [ -f "${SCRIPT_DIR}/node-prep-lib.sh" ]; then
-  # shellcheck disable=SC1091
-  . "${SCRIPT_DIR}/node-prep-lib.sh"
-fi
+# shellcheck disable=SC1091
+. "${SCRIPT_DIR}/node-prep-lib.sh"
 
 HOST_ROOT="${HOST_ROOT:-/host}"
 STATE_DIR="${STATE_DIR:-/var/lib/cube-node-bootstrap}"
@@ -18,7 +16,7 @@ DEB_PATH="${PVM_KERNEL_DEB_PATH:-/artifacts/linux-image-pvm-host.deb}"
 RPM_URL="${PVM_KERNEL_RPM_URL:-}"
 DEB_URL="${PVM_KERNEL_DEB_URL:-}"
 PACKAGE_SOURCE="${PVM_KERNEL_PACKAGE_SOURCE:-image}"
-KERNEL_BOOT_ARGS="${PVM_KERNEL_BOOT_ARGS:-}"
+KERNEL_BOOT_ARGS="${KERNEL_BOOT_ARGS:-${PVM_KERNEL_BOOT_ARGS:-}}"
 REBOOT_ENABLED="${REBOOT_ENABLED:-true}"
 REBOOT_MAX_COUNT="${REBOOT_MAX_COUNT:-1}"
 REBOOT_COORDINATED="${REBOOT_COORDINATED:-true}"
@@ -26,7 +24,6 @@ LEASE_NAME="${LEASE_NAME:-cube-node-pvm-bootstrap}"
 LEASE_TTL_SECONDS="${LEASE_TTL_SECONDS:-900}"
 NODE_NAME="${NODE_NAME:-$(hostname)}"
 NAMESPACE="${POD_NAMESPACE:-default}"
-# REV3.2: export for node-prep-lib fingerprint helpers
 PVM_ENABLED="${PVM_ENABLED:-1}"
 export HOST_ROOT STATE_DIR DESIRED_KERNEL_PATTERN KERNEL_BOOT_ARGS PVM_ENABLED
 
@@ -127,16 +124,8 @@ EOF
   done
 }
 
-# REV3.2: only acquire the cluster reboot lease on paths that may reboot.
+# Only acquire the cluster reboot lease on paths that may reboot.
 # Do NOT acquire on the fast-success path (already on desired kernel).
-
-will_mutate_host() {
-  if command -v invalidate_node_prep_ready >/dev/null 2>&1; then
-    invalidate_node_prep_ready
-  else
-    rm -f "$(host_path "$STATE_DIR/node-prep-ready")" "$(host_path "$STATE_DIR/node-prep-ready.tmp")"
-  fi
-}
 
 install_kernel() {
   if [ "$PACKAGE_SOURCE" = "download" ]; then
@@ -183,19 +172,6 @@ configure_bootloader() {
   printf 'KERNEL=="kvm", MODE="0666"\n' > "$(host_path /etc/udev/rules.d/99-kvm.rules)"
 }
 
-missing_boot_args() {
-  [ -n "$KERNEL_BOOT_ARGS" ] || return 0
-  cmdline=" $(cat /proc/cmdline 2>/dev/null || true) "
-  missing=""
-  for arg in $KERNEL_BOOT_ARGS; do
-    case "$cmdline" in
-      *" ${arg} "*) ;;
-      *) missing="${missing} ${arg}" ;;
-    esac
-  done
-  [ -z "$missing" ] || printf '%s\n' "$missing"
-}
-
 request_reboot_or_fail() {
   count_name="${1:-reboot-count}"
   not_ready_message="${2:-PVM kernel installed but host is not running it yet}"
@@ -218,26 +194,30 @@ request_reboot_or_fail() {
     exit 1
   fi
 
-  fail "${not_ready_message}; reboot_enabled=${REBOOT_ENABLED}, reboot_count=${count}/${REBOOT_MAX_COUNT}, missing_boot_args=$(missing_boot_args)"
+  fail "${not_ready_message}; reboot_enabled=${REBOOT_ENABLED}, reboot_count=${count}/${REBOOT_MAX_COUNT}, missing_boot_args=$(node_prep_missing_boot_args)"
 }
 
 current_kernel="$(uname -r || true)"
 log "current kernel: ${current_kernel}"
+
+# Fast path: live kernel already matches pattern + required boot args.
+# No lease; write fingerprint-matched pvm-host-ready for wait-pvm-host.
+if node_prep_kernel_ready; then
+  log "PVM kernel check passed (fast path; no lease)"
+  write_pvm_host_ready || fail "failed to write fingerprint pvm-host-ready"
+  release_lease
+  exit 0
+fi
+
 if printf '%s' "$current_kernel" | grep -q "$DESIRED_KERNEL_PATTERN"; then
-  missing_args="$(missing_boot_args)"
-  if [ -z "$missing_args" ]; then
-    log "PVM kernel check passed (fast path; no lease)"
-    echo "$current_kernel" > "$(host_path "$STATE_DIR/pvm-ready")"
-    exit 0
-  fi
-  log "PVM kernel is running but required boot args are missing:${missing_args}"
-  will_mutate_host
+  log "PVM kernel is running but required boot args are missing: $(node_prep_missing_boot_args)"
+  invalidate_pvm_gate_sentinels
   acquire_lease
   configure_bootloader
   request_reboot_or_fail boot-args-reboot-count "PVM kernel boot args configured but host is not running with required boot args yet"
 fi
 
-will_mutate_host
+invalidate_pvm_gate_sentinels
 acquire_lease
 install_kernel
 configure_bootloader

--- a/deploy/kubernetes/images/scripts/wait-node-prep.sh
+++ b/deploy/kubernetes/images/scripts/wait-node-prep.sh
@@ -2,8 +2,8 @@
 set -eu
 
 # Big Pod REV3.2.1: Kruise high-priority sidecar (not an initContainer).
-# Poll hostPath node-prep-ready until fingerprint matches, then mark Ready and
-# sleep forever so Container Launch Priority can release lower-priority containers.
+# Poll hostPath node-prep-ready until fingerprint matches, mark Ready, and
+# KEEP polling so mutate/reboot that invalidates the sentinel clears readiness.
 # Does NOT watch Installer Pod Ready.
 # Day-1: freeze wait env/mounts; bumping only images.waitNodePrep may InPlace.
 
@@ -22,24 +22,34 @@ ready="$(node_prep_ready_path)"
 rm -f "$WAIT_READY_MARKER"
 log "waiting for ${ready} (timeout=${WAIT_TIMEOUT_SECONDS}s)"
 start="$(date +%s)"
+became_ready=0
 while true; do
-  if node_prep_fingerprint_valid_for_wait; then
-    log "node-prep-ready fingerprint matched; marking ready and holding"
-    : > "$WAIT_READY_MARKER"
-    exec sleep infinity
-  fi
-  now="$(date +%s)"
-  elapsed=$((now - start))
-  if [ "$elapsed" -ge "$WAIT_TIMEOUT_SECONDS" ]; then
-    if [ -f "$ready" ]; then
-      printf '[wait-node-prep] ERROR: timeout after %ss; sentinel present but fingerprint mismatch\n' "$elapsed" >&2
-      printf '--- want ---\n' >&2
-      node_prep_compute_fingerprint >&2
-      printf '--- have ---\n' >&2
-      cat "$ready" >&2
-      exit 1
+  if node_prep_fingerprint_matches_file; then
+    if [ ! -f "$WAIT_READY_MARKER" ]; then
+      log "node-prep-ready fingerprint matched; marking ready and continuing to re-validate"
+      became_ready=1
     fi
-    fail "timeout after ${elapsed}s; ${ready} not ready"
+    : > "$WAIT_READY_MARKER"
+  else
+    if [ -f "$WAIT_READY_MARKER" ]; then
+      log "node-prep-ready lost or fingerprint mismatch; clearing readiness marker"
+      rm -f "$WAIT_READY_MARKER"
+    fi
+    if [ "$became_ready" = "0" ]; then
+      now="$(date +%s)"
+      elapsed=$((now - start))
+      if [ "$elapsed" -ge "$WAIT_TIMEOUT_SECONDS" ]; then
+        if [ -f "$ready" ]; then
+          printf '[wait-node-prep] ERROR: timeout after %ss; sentinel present but fingerprint mismatch\n' "$elapsed" >&2
+          printf '%s\n' '--- want ---' >&2
+          node_prep_compute_fingerprint >&2
+          printf '%s\n' '--- have ---' >&2
+          cat "$ready" >&2
+          exit 1
+        fi
+        fail "timeout after ${elapsed}s; ${ready} not ready"
+      fi
+    fi
   fi
   sleep "$WAIT_POLL_SECONDS"
 done

--- a/deploy/kubernetes/images/scripts/wait-pvm-host.sh
+++ b/deploy/kubernetes/images/scripts/wait-pvm-host.sh
@@ -1,0 +1,100 @@
+#!/bin/sh
+set -eu
+
+# Bootstrap init: decide per-node PVM mode and gate on fingerprint-matched
+# pvm-host-ready (never "file exists"). Writes effective-pvm for downstream
+# node-init / fingerprint / cubelet guest selection.
+
+SCRIPT_DIR="$(CDPATH= cd -- "$(dirname "$0")" && pwd)"
+# shellcheck disable=SC1091
+. "${SCRIPT_DIR}/node-prep-lib.sh"
+
+log() { printf '[wait-pvm-host] %s\n' "$*"; }
+fail() { printf '[wait-pvm-host] ERROR: %s\n' "$*" >&2; exit 1; }
+
+PVM_FEATURE_ENABLED="${PVM_FEATURE_ENABLED:-0}"
+# When chart-managed host bootstrap is off, still honor guest PVM expectation
+# for externally pre-provisioned PVM hosts (CUBE_PVM_ENABLE / pvmGuestKernel).
+CUBE_PVM_ENABLE="${CUBE_PVM_ENABLE:-0}"
+ALLOW_PVM_LABEL="${ALLOW_PVM_LABEL:-cube.tencent.com/allow-pvm-bootstrap}"
+NODE_NAME="${NODE_NAME:-}"
+WAIT_TIMEOUT_SECONDS="${WAIT_TIMEOUT_SECONDS:-900}"
+WAIT_POLL_SECONDS="${WAIT_POLL_SECONDS:-2}"
+export HOST_ROOT STATE_DIR DESIRED_KERNEL_PATTERN KERNEL_BOOT_ARGS
+
+finish_external_or_disabled() {
+  # Chart-managed cube-node-pvm is off.
+  if [ "$(node_prep_bool01 "$CUBE_PVM_ENABLE")" != "1" ]; then
+    log "PVM host bootstrap disabled and guest PVM off; effective-pvm=0"
+    write_effective_pvm 0
+    exit 0
+  fi
+  # External / pre-provisioned PVM: require live kernel, write fingerprint gate.
+  PVM_ENABLED=1
+  export PVM_ENABLED
+  log "PVM host bootstrap disabled but CUBE_PVM_ENABLE=1; requiring live PVM kernel (external prep)"
+  if ! node_prep_kernel_ready; then
+    fail "CUBE_PVM_ENABLE=1 with bootstrap.pvmHostKernel.enabled=false requires a running PVM host kernel matching DESIRED_KERNEL_PATTERN=${DESIRED_KERNEL_PATTERN} and KERNEL_BOOT_ARGS"
+  fi
+  write_pvm_host_ready || fail "failed to write pvm-host-ready for external PVM host"
+  write_effective_pvm 1
+  exit 0
+}
+
+# Fail-closed node label lookup. Use go-template index() so dotted label keys
+# work; jsonpath {.metadata.labels['a.b/c']} is unreliable for this key shape.
+node_allows_pvm() {
+  [ -n "$NODE_NAME" ] || fail "NODE_NAME is required"
+  command -v kubectl >/dev/null 2>&1 || fail "kubectl is required in cube-node-init image for wait-pvm-host"
+  # shellcheck disable=SC2016
+  label_val="$(kubectl get node "$NODE_NAME" -o go-template='{{index .metadata.labels "'"${ALLOW_PVM_LABEL}"'"}}{{"\n"}}')" \
+    || fail "kubectl get node ${NODE_NAME} failed (API/RBAC); refusing to treat as non-PVM"
+  [ "$(node_prep_bool01 "$label_val")" = "1" ]
+}
+
+wait_for_pvm_host_ready() {
+  ready="$(pvm_host_ready_path)"
+  log "PVM node ${NODE_NAME}; waiting for fingerprint-matched ${ready} (timeout=${WAIT_TIMEOUT_SECONDS}s)"
+  start="$(date +%s)"
+  while true; do
+    if pvm_host_fingerprint_matches_file; then
+      log "pvm-host-ready fingerprint matched live kernel; effective-pvm=1"
+      write_effective_pvm 1
+      exit 0
+    fi
+    now="$(date +%s)"
+    elapsed=$((now - start))
+    if [ "$elapsed" -ge "$WAIT_TIMEOUT_SECONDS" ]; then
+      if [ -f "$ready" ]; then
+        printf '[wait-pvm-host] ERROR: timeout after %ss; sentinel present but fingerprint/live mismatch\n' "$elapsed" >&2
+        printf '%s\n' '--- want ---' >&2
+        pvm_host_compute_fingerprint >&2
+        printf '%s\n' '--- have ---' >&2
+        cat "$ready" >&2 || true
+        printf '%s\n' '--- live kernel ---' >&2
+        uname -r >&2 || true
+        if pvm_is_mutating; then
+          printf '%s\n' '--- pvm-mutating present ---' >&2
+        fi
+        exit 1
+      fi
+      fail "timeout after ${elapsed}s; ${ready} not ready (cube-node-pvm may still be installing/rebooting)"
+    fi
+    sleep "$WAIT_POLL_SECONDS"
+  done
+}
+
+if [ "$(node_prep_bool01 "$PVM_FEATURE_ENABLED")" != "1" ]; then
+  finish_external_or_disabled
+fi
+
+PVM_ENABLED=1
+export PVM_ENABLED
+
+if ! node_allows_pvm; then
+  log "node ${NODE_NAME} lacks ${ALLOW_PVM_LABEL}=true; skip PVM gate; effective-pvm=0"
+  write_effective_pvm 0
+  exit 0
+fi
+
+wait_for_pvm_host_ready

--- a/deploy/kubernetes/images/scripts/write-node-prep-ready.sh
+++ b/deploy/kubernetes/images/scripts/write-node-prep-ready.sh
@@ -10,7 +10,8 @@ SCRIPT_DIR="$(CDPATH= cd -- "$(dirname "$0")" && pwd)"
 
 log() { printf '[write-node-prep-ready] %s\n' "$*"; }
 
-log "computing fingerprint (mode=$(node_prep_resolve_mode))"
+apply_effective_pvm_env
+log "computing fingerprint (mode=$(node_prep_resolve_mode) pvm_enabled=$(node_prep_bool01 "$PVM_ENABLED"))"
 write_node_prep_ready
 log "node prep ready; holding bootstrap pod"
 exec sleep infinity


### PR DESCRIPTION
Introduce a separate **cube-node-pvm** DaemonSet to decouple PVM host kernel installation from the general node bootstrap flow.

## Summary of changes

- **New `node-pvm-daemonset.yaml`**: DaemonSet gated by `placement.pvm` (`allow-pvm-bootstrap`), installs PVM host kernel and writes `pvm-host-ready` fingerprint. Non-PVM compute nodes skip this workload entirely.
- **New `wait-pvm-host.sh`**: Sidecar script that waits for `pvm-host-ready` before `cube-node-bootstrap` proceeds.
- **Refactored `node-prep-lib.sh`**: Extracted reusable helper functions for kernel pattern matching, status checking, and file readiness.
- **Simplified `cube-node-bootstrap`**: Replaced inline PVM kernel prep with `wait-pvm-host` initContainer; streamlined `pvm-host-bootstrap.sh`.
- **Updated `values.yaml`**: Added `placement.pvm` configuration block.
- **Updated chart docs**: README, ARCHITECTURE, FAQ, QUICKSTART, UPGRADE, and NOTES.txt now reflect the four-DaemonSet compute plane shape.
- **Updated image build scripts and Dockerfiles** for the new entrypoint.