### PR TITLE
Feat/opencode sandbox integration （Refs #644)

### DIFF
--- a/docs/guide/integrations/index.md
+++ b/docs/guide/integrations/index.md
@@ -48,3 +48,4 @@ lang: en-US
 | Title | Author | Date | Tags |
 | --- | --- | --- | --- |
 | [Pi Agent Integration Guide](./pi-agent.md) | chaojixinren | 2026-07-01 | integration, pi-agent, coding-agent, agent |
+| [OpenCode Integration Guide](./opencode.md) | pei-pei45 | 2026-07-18 | integration, opencode, coding-agent, agent |

--- a/docs/guide/integrations/opencode.md
+++ b/docs/guide/integrations/opencode.md
@@ -1,0 +1,390 @@
+---
+title: OpenCode Integration Guide
+author: pei-pei45
+date: 2026-07-18
+tags:
+  - integration
+  - opencode
+  - coding-agent
+  - agent
+lang: en-US
+---
+
+# OpenCode Integration Guide
+
+[中文文档](../../zh/guide/integrations/opencode.md)
+
+Run the [OpenCode CLI](https://opencode.ai/) — an open-source, terminal-native
+AI coding agent — inside CubeSandbox MicroVMs. This guide covers image build,
+key injection, egress control, and snapshot-based session persistence, and pairs
+with the runnable
+[`examples/opencode-integration`](https://github.com/TencentCloud/CubeSandbox/tree/master/examples/opencode-integration)
+project.
+
+## Integration Target and Version
+
+| Component | Version |
+|---|---|
+| OpenCode | `opencode-ai@1.17.20` (pinned via `--build-arg OPENCODE_VERSION=x.y.z`; relies on the `--dangerously-skip-permissions` flag that landed in 1.17.x) |
+| Node.js | 20 (installed via NodeSource) |
+| CubeSandbox base image | `ghcr.io/tencentcloud/cubesandbox-base:2026.16` |
+| E2B SDK (host driver) | `e2b` (latest) |
+| CubeSandbox platform | `>= 0.3.0` (pause/resume) / `>= 0.4.0` (CubeEgress credential vault) |
+
+## Prerequisites
+
+- A running CubeSandbox deployment; CubeAPI reachable at `http://<node>:3000`.
+- `cubemastercli` on `$PATH`, connected to the cluster.
+- Docker on the build workstation, plus a registry the Cube nodes can pull from.
+- An OpenCode-compatible LLM provider key. OpenCode ships built-in presets for
+  Anthropic, OpenAI, Google Gemini, Azure, AWS Bedrock, DeepSeek, Groq, Mistral,
+  OpenRouter, and more; any provider preset works. Custom upstreams are
+  reachable via `OPENCODE_BASE_URL` / `ANTHROPIC_BASE_URL` /
+  `OPENAI_BASE_URL`.
+- Python 3.10+ for the host driver scripts.
+
+## Why Run OpenCode Inside a Sandbox
+
+OpenCode is a terminal agent that edits files, runs commands, and installs
+packages. Running it directly on a workstation blends the agent's blast radius
+with your dev environment. Running it inside CubeSandbox gives you:
+
+| Concern | CubeSandbox provides |
+|---|---|
+| **Isolation** | KVM MicroVM per session, dedicated guest kernel |
+| **Reproducibility** | Every session boots from the same template snapshot |
+| **Fast spin-up** | Sub-60 ms cold start, so N-parallel agents are cheap |
+| **Long tasks** | `sandbox.pause()` snapshots VM + rootfs; resume later |
+| **Key hygiene** | CubeEgress injects the auth header on the wire — the VM never sees the real key |
+| **Egress audit** | Every request to the LLM API is recorded in the egress audit log |
+| **Open ecosystem** | OpenCode's MCP support maps cleanly onto CubeSandbox's network policy |
+
+## Integration Steps
+
+### 1. Build the template image
+
+The image stacks Node.js 20 and the OpenCode CLI on top of `cubesandbox-base`,
+so envd is already listening on `:49983`.
+
+```dockerfile
+# examples/opencode-integration/Dockerfile (excerpt)
+ARG CUBE_BASE_IMAGE=ghcr.io/tencentcloud/cubesandbox-base:2026.16
+FROM ${CUBE_BASE_IMAGE}
+
+ARG NODE_MAJOR=20
+ARG OPENCODE_VERSION=1.17.20
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        ca-certificates curl git gnupg jq less procps python3 python3-pip ripgrep \
+    && mkdir -p /etc/apt/keyrings \
+    && curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key \
+        | gpg --dearmor --yes -o /etc/apt/keyrings/nodesource.gpg \
+    && gpg --show-keys /etc/apt/keyrings/nodesource.gpg 2>/dev/null \
+        | grep -q "6F71F525282841EEDAF851B42F59B5F99B1BE0B4" \
+        || (echo "ERROR: NodeSource GPG fingerprint mismatch" && exit 1) \
+    && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_${NODE_MAJOR}.x nodistro main" \
+        > /etc/apt/sources.list.d/nodesource.list \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends nodejs \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN npm install -g --omit=dev \
+        "opencode-ai@${OPENCODE_VERSION}" \
+    && opencode --version \
+    && rm -rf /root/.npm
+
+# OpenCode runs as an unprivileged user. UID/GID are auto-assigned because the
+# base image already owns uid=1000 as the ``user`` exec account; pause/resume
+# snapshots preserve identity by username, not by numeric id. The MicroVM
+# provides the outer isolation; this user drop is defense-in-depth for
+# prompt-injection scenarios where the LLM agent is tricked into shell commands.
+#
+# /workspace is world-writable because the e2b exec channel constrains us to
+# the SDK's allowed-users list (``root``, ``user``) and ``user`` cannot write
+# to an opencode-owned directory. OpenCode splits its on-disk state between
+# ``$OPENCODE_CONFIG_DIR`` (config + agents) and ``$OPENCODE_DATA_DIR``
+# (sessions, auth.json, storage); both are rooted under ``/workspace/.opencode``
+# so pause/resume snapshots capture them alongside the project tree.
+ARG OPENCODE_CONFIG_DIR=/workspace/.opencode/config
+ARG OPENCODE_DATA_DIR=/workspace/.opencode/data
+
+RUN groupadd --system opencode \
+    && useradd  --system --gid opencode \
+                --home-dir /home/opencode --shell /bin/bash \
+                --no-create-home opencode \
+    && install -d -o opencode -g opencode -m 0700 /home/opencode \
+    && install -d -o opencode -g opencode -m 0777 /workspace
+
+ENV OPENCODE_CONFIG_DIR=${OPENCODE_CONFIG_DIR} \
+    OPENCODE_DATA_DIR=${OPENCODE_DATA_DIR} \
+    XDG_CONFIG_HOME=/workspace \
+    XDG_DATA_HOME=/workspace \
+    DISABLE_TELEMETRY=1 \
+    DISABLE_ERROR_REPORTING=1 \
+    OPENCODE_DISABLE_AUTOUPDATE=1
+
+RUN install -d -o opencode -g opencode -m 0777 "${OPENCODE_CONFIG_DIR}" \
+    && install -d -o opencode -g opencode -m 0777 "${OPENCODE_DATA_DIR}/storage" \
+    && printf '{}\n' > "${OPENCODE_CONFIG_DIR}/opencode.json"
+
+WORKDIR /workspace
+USER opencode
+```
+
+Build and push (from the repository root, so the relative build context
+`examples/opencode-integration` resolves correctly):
+
+```bash
+docker build --pull --platform linux/amd64 \
+  -t <your-registry>/opencode-cube:latest \
+  examples/opencode-integration
+docker push <your-registry>/opencode-cube:latest
+```
+
+### 2. Register as a Cube template
+
+```bash
+cubemastercli tpl create-from-image \
+  --image <your-registry>/opencode-cube:latest \
+  --writable-layer-size 4G \
+  --expose-port 49983 \
+  --probe       49983 \
+  --probe-path  /health
+
+cubemastercli tpl watch --job-id <job_id>
+```
+
+Once the job reaches `READY`, note the `template_id` — you pass it to every
+`Sandbox.create()` call. `4G` writable layer suits medium tasks; bump to `8G+`
+if the agent installs large toolchains.
+
+### 3. Wire up the host driver
+
+```bash
+cd examples/opencode-integration
+cp .env.example .env
+# fill in E2B_API_URL, CUBE_TEMPLATE_ID, and your provider key
+pip install -r requirements.txt
+```
+
+| Variable | Where it flows | Notes |
+|---|---|---|
+| `E2B_API_URL` | Local process | CubeAPI address (`http://<node>:3000`) |
+| `E2B_API_KEY` | Local process | Any non-empty string in local dev |
+| `CUBE_TEMPLATE_ID` | `Sandbox.create(template=...)` | From step 2 |
+| `OPENCODE_PROVIDER` | `env_utils.provider()` | Optional — inferred from the active key when unset |
+| `OPENCODE_MODEL` / `OPENCODE_BASE_URL` | OpenCode CLI flags | Model id and optional custom upstream endpoint |
+| `ANTHROPIC_API_KEY` / `OPENAI_API_KEY` / `GOOGLE_API_KEY` / ... | `envs=...` (direct) or CubeEgress inject (vault) | Provider key |
+| `OPENCODE_LLM_HOST` | `network_policy.py` | LLM host allowed under default-deny egress |
+
+### 4. Runtime Configuration and API Key Injection
+
+OpenCode is invoked headlessly with `opencode run "..."` (process the prompt
+and exit, no TUI). Tool-call permission is auto-approved for the lifetime of
+the run via the `--dangerously-skip-permissions` flag (added in OpenCode
+1.17.x; `--yolo` is an alias) — required because the exec channel cannot
+answer permission prompts. The prompt is the trailing positional argument.
+Two key-flow flavors share the same template:
+
+**Direct flavor** — forward the key per command. `e2b`'s `commands.run(envs=...)`
+puts the environment into the exec envelope, not into a persistent file inside
+the VM, so the key lives only for the lifetime of that command. The exec
+channel only accepts the usernames `root` and `user` (the same `user` that
+`_opencode_common.run_command` defaults to); passing `user="opencode"`
+raises `invalid username: 'opencode'`. Inside the image the agent still runs
+unprivileged because the Dockerfile drops to `USER opencode`; the SDK-level
+`user` argument only constrains the exec channel identity, not the container's
+process identity:
+
+```python
+result = sandbox.commands.run(
+    "cd /workspace && opencode run --dangerously-skip-permissions -m claude-sonnet-4-6 "
+    "'Inspect the project, run app.py, and summarize the result.'",
+    envs={"ANTHROPIC_API_KEY": key},
+    user="user",
+    timeout=900,
+)
+```
+
+**Vault flavor** — keep the key out of the VM entirely (see step 6).
+
+### 5. Session Persistence (pause / resume)
+
+```bash
+cd examples/opencode-integration
+python resume_opencode.py
+```
+
+This mirrors the [snapshot / clone / rollback](../snapshot-rollback-clone.md)
+engine at the SDK layer:
+
+- `sandbox.pause()` snapshots the running VM (memory + rootfs) and frees compute.
+- `Sandbox.connect(sandbox_id)` resumes with `/workspace`, OpenCode's config
+  directory (`/workspace/.opencode/config/`), data directory
+  (`/workspace/.opencode/data/`), and every other file intact. Turn 2 then
+  calls `opencode run --dangerously-skip-permissions -c` to continue the
+  most recent session OpenCode recorded under `$OPENCODE_DATA_DIR/storage/`.
+
+> **Lifecycle caveat:** manage the sandbox lifecycle with `try/finally`, not a
+> `with Sandbox.create(...)` context manager. On `__exit__` the context manager
+> kills the sandbox, which would undo the pause. The example creates the sandbox
+> explicitly and only calls `sandbox.kill()` in `finally`.
+
+```python
+sandbox = Sandbox.create(template=template_id, timeout=1800)
+try:
+    run_turn(sandbox, prompt_1)          # writes /workspace/plan.md
+    sandbox_id = sandbox.pause() or sandbox.sandbox_id
+    sandbox = Sandbox.connect(sandbox_id)
+    assert_state_survived(sandbox)       # /workspace + /workspace/.opencode/{config,data}/ intact
+    run_turn(sandbox, prompt_2, continue_session=True)
+finally:
+    sandbox.kill()
+```
+
+### 6. Network and Egress Policy (credential vault)
+
+Run `network_policy.py` from `examples/opencode-integration/` (after step 3):
+
+```bash
+cd examples/opencode-integration
+python network_policy.py
+```
+
+The script demonstrates the recommended pattern for shared clusters:
+default-deny egress plus on-the-wire key injection.
+
+```python
+# Credential injection uses the native cubesandbox SDK (see security-proxy.md).
+from cubesandbox import Sandbox, Rule, Match, Action, Inject
+
+host = "api.anthropic.com"
+rules = [
+    Rule(
+        name="allow_anthropic_llm",
+        match=Match(scheme="https", sni=host, host=host),
+        action=Action(allow=True, audit="metadata", inject=[
+            Inject(header="x-api-key", secret=ANTHROPIC_API_KEY, format="${SECRET}"),
+            Inject(header="anthropic-version", secret="2023-06-01", format="${SECRET}"),
+        ]),
+    ),
+]
+
+sandbox = Sandbox.create(
+    template=CUBE_TEMPLATE_ID,
+    allow_internet_access=False,   # default-deny; the rule's host is auto-allowed
+    network={"rules": rules},
+)
+```
+
+Effect:
+
+- `printenv ANTHROPIC_API_KEY` inside the sandbox shows only a placeholder.
+- Every request to the LLM host gets the auth header attached on the wire.
+- Anything else is dropped by CubeVS at L3/L4 (`allow_internet_access=False`) and never leaves the sandbox.
+- Every allow / deny decision lands in the egress audit log.
+
+For non-Anthropic providers the example injects an `Authorization: Bearer` header
+instead. If a provider does not accept a header-injected key, fall back to the
+direct flavor (`envs=...`) — but never write the key into a persistent file
+inside the sandbox.
+
+## Use Cases and Best Practices
+
+- **Isolated development.** Run the coding agent inside the sandbox so its file
+  edits and shell commands cannot touch the host.
+- **Execute agent-generated code and collect results.** Have the agent write to
+  `/workspace`, then read artifacts back via `sandbox.files` or `commands.run`.
+- **Checkpoint / resume long tasks.** Use `pause()` + `connect()` to snapshot a
+  long refactor and resume later, or fork multiple task variants off one snapshot.
+- **Switch LLM providers without rebuilding the image.** OpenCode itself keys
+  off the upstream env var (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, ...); override
+  the upstream via `OPENCODE_BASE_URL` to point at any Anthropic- / OpenAI-
+  compatible endpoint while keeping the same template.
+- **Preinstall heavy dependencies** into the template rather than fetching them
+  at runtime, especially under a default-deny egress policy.
+- **Pair OpenCode with MCP servers.** OpenCode ships first-class MCP support;
+  run an MCP server inside the same template and let OpenCode call it for
+  filesystem, browser, or database access — the egress policy still applies.
+
+## Key Code Snippets
+
+### Headless OpenCode invocation
+
+```python
+cmd = (
+    "cd /workspace && opencode run --dangerously-skip-permissions -m claude-sonnet-4-6 "
+    "'Inspect the project, run app.py, and summarize the result.'"
+)
+result = sandbox.commands.run(cmd, envs=opencode_env, timeout=900)
+```
+
+### Preflight version check
+
+```python
+version = sandbox.commands.run("opencode --version", timeout=60)
+```
+
+## Caveats
+
+- **Node.js version.** OpenCode requires Node 18.20+; the base image ships an
+  older apt Node, so always install via NodeSource (the Dockerfile does).
+- **Non-interactive mode needs `--dangerously-skip-permissions`.** `opencode run`
+  prompts for tool-call permission by default; in non-interactive mode the
+  prompt cannot be answered. `run_opencode.py` passes the flag for the
+  duration of the run; in higher-security workflows tighten the allow-list
+  via `opencode.json` instead. (Older OpenCode releases < 1.17 take
+  `OPENCODE_PERMISSION='{"*":"allow"}'` in the env instead.)
+- **Agent state directories.** OpenCode splits state between
+  `/workspace/.opencode/config/` (config) and
+  `/workspace/.opencode/data/` (sessions, auth.json, storage). The
+  Dockerfile creates both but populates them with no credentials.
+- **Direct-flavor key persistence.** With the direct flavor (`envs=`) the
+  key is scoped to the exec call, but OpenCode caches provider credentials
+  under its data dir (`/workspace/.opencode/data/auth.json`), which
+  survives `pause()` / `resume()`. For strict isolation prefer the vault
+  flavor (`network_policy.py`), where the key never enters the VM.
+- **CubeEgress CA (Node).** For the vault flavor the sandbox must trust the
+  CubeEgress root CA, which the base image installs into the system bundle.
+  OpenCode ships as a Node.js bundle that ignores the system store, so
+  `network_policy.py` also sets `NODE_EXTRA_CA_CERTS` (override via
+  `OPENCODE_NODE_EXTRA_CA_CERTS`) — without it the vault path fails with
+  "unable to verify the first certificate".
+- **Egress side-effects.** Tasks that `npm install` or fetch MCP tools need
+  those hosts allowed or preinstalled into the template.
+- **Interactive TTY features.** The OpenCode TUI is not available over the
+  E2B protocol. Use headless `opencode run` and drive multi-turn conversations
+  from the host script (`-c` / `-s <id>` for continuation, `--session-id` to
+  pin).
+- **Provider resolution.** `env_utils.provider()` infers the active provider
+  from whichever key env var is set. For custom gateways, set
+  `OPENCODE_PROVIDER` explicitly to bypass the substring heuristic that maps
+  `*_BASE_URL` to a provider.
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| `opencode: command not found` in preflight | Template not rebuilt after CLI change | Rebuild the image, re-register the template |
+| Permission prompt hangs the run | `--dangerously-skip-permissions` was not passed for a run that touches files or commands | Add the flag (or tighten `opencode.json` permissions) |
+| `unknown flag: --dangerously-skip-permissions` | OpenCode older than 1.17 | Rebuild the image with `--build-arg OPENCODE_VERSION=1.17.20`, or run with `OPENCODE_PERMISSION='{"*":"allow"}'` instead |
+| `model not found` from OpenCode | `OPENCODE_MODEL` does not match the active provider | Set `OPENCODE_MODEL` explicitly, or use `provider/model` shorthand via `-m anthropic/claude-sonnet-4-6` |
+| Provider auth failure | Key not forwarded (direct) or missing inject rule (vault) | Pass `envs={...}` or fix the rule's `sni`/`host` |
+| `403 Forbidden - CubeEgress` | Default-deny with no matching allow rule | Add the LLM host (and any extra hosts) to the rules |
+| `Connection error` / TLS failure from OpenCode (vault) | OpenCode's Node runtime ignores the system CA store, so it won't trust the CubeEgress CA | The example sets `NODE_EXTRA_CA_CERTS`; override with `OPENCODE_NODE_EXTRA_CA_CERTS` if the CA lives elsewhere |
+| Template creation stuck in `PULLING` | Registry unreachable from Cube nodes | Push to a registry the cluster can reach; supply auth if needed |
+| Readiness probe timeout | Base image without envd | Ensure `FROM ghcr.io/tencentcloud/cubesandbox-base:2026.16` |
+| `pause()` / `connect()` errors | Platform too old for snapshots | Upgrade the CubeSandbox platform |
+
+## References
+
+- Runnable example: [`examples/opencode-integration`](https://github.com/TencentCloud/CubeSandbox/tree/master/examples/opencode-integration)
+- Bring Your Own Image: [`docs/guide/tutorials/bring-your-own-image.md`](../tutorials/bring-your-own-image.md)
+- Template from image: [`docs/guide/tutorials/template-from-image.md`](../tutorials/template-from-image.md)
+- Snapshot / Clone / Rollback: [`docs/guide/snapshot-rollback-clone.md`](../snapshot-rollback-clone.md)
+- Credential vault + egress control: [`docs/guide/security-proxy.md`](../security-proxy.md)
+- OpenCode CLI: <https://opencode.ai/>
+- OpenCode docs: <https://opencode.ai/docs/>
+- OpenCode repository: <https://github.com/anomalyco/opencode>

--- a/docs/zh/guide/integrations/index.md
+++ b/docs/zh/guide/integrations/index.md
@@ -48,3 +48,4 @@ lang: zh-CN
 | 标题 | 作者 | 日期 | 标签 |
 | --- | --- | --- | --- |
 | [Pi Agent 集成指南](./pi-agent.md) | chaojixinren | 2026-07-01 | integration, pi-agent, coding-agent, agent |
+| [OpenCode 集成指南](./opencode.md) | pei-pei45 | 2026-07-18 | integration, opencode, coding-agent, agent |

--- a/docs/zh/guide/integrations/opencode.md
+++ b/docs/zh/guide/integrations/opencode.md
@@ -1,0 +1,373 @@
+---
+title: OpenCode 集成指南
+author: pei-pei45
+date: 2026-07-18
+tags:
+  - integration
+  - opencode
+  - coding-agent
+  - agent
+lang: zh-CN
+---
+
+# OpenCode 集成指南
+
+[English](../../guide/integrations/opencode.md)
+
+在 CubeSandbox MicroVM 内运行 [OpenCode CLI](https://opencode.ai/)
+（开源、面向终端的 AI 编码 Agent）。本文涵盖镜像构建、密钥注入、出网管控与
+基于快照的会话持久化，并配套可运行的
+[`examples/opencode-integration`](https://github.com/TencentCloud/CubeSandbox/tree/master/examples/opencode-integration)
+示例项目。
+
+## 集成对象与版本
+
+| 组件 | 版本 |
+|---|---|
+| OpenCode | `opencode-ai@1.17.20`（通过 `--build-arg OPENCODE_VERSION=x.y.z` 固定；依赖 1.17 加入的 `--dangerously-skip-permissions` 标志） |
+| Node.js | 20（通过 NodeSource 安装） |
+| CubeSandbox 基础镜像 | `ghcr.io/tencentcloud/cubesandbox-base:2026.16` |
+| E2B SDK（宿主端驱动） | `e2b`（最新版） |
+| CubeSandbox 平台 | `>= 0.3.0`（pause/resume）/ `>= 0.4.0`（CubeEgress 凭证保险柜） |
+
+## 前置条件
+
+- 已部署 CubeSandbox，CubeAPI 可访问（`http://<node>:3000`）。
+- `cubemastercli` 已在 `$PATH` 且已连通集群。
+- 构建机装有 Docker，且 registry 能被 Cube 集群拉取。
+- OpenCode 兼容的 LLM provider 密钥。OpenCode 内置 Anthropic、OpenAI、
+  Google Gemini、Azure、AWS Bedrock、DeepSeek、Groq、Mistral、OpenRouter
+  等预设，任何一个都可以。自定义上游可通过 `OPENCODE_BASE_URL` /
+  `ANTHROPIC_BASE_URL` / `OPENAI_BASE_URL` 指向。
+- Python 3.10+（宿主端驱动脚本）。
+
+## 为什么把 OpenCode 跑在沙箱里
+
+OpenCode 是一款终端 Agent，会编辑文件、执行命令、安装软件包。直接在工作站上
+运行，会把 Agent 的破坏半径和你的开发环境混在一起。把它放到 CubeSandbox 里
+能获得：
+
+| 关注点 | CubeSandbox 提供 |
+|---|---|
+| **隔离** | 每个会话独占一台 KVM MicroVM，独占 guest 内核 |
+| **可复现** | 每个会话都从同一份模板快照启动 |
+| **快速启动** | 冷启动 < 60ms，并行 N 个 Agent 几乎无成本 |
+| **长任务** | `sandbox.pause()` 对 VM + rootfs 打快照，之后再恢复 |
+| **密钥卫生** | CubeEgress 在链路上注入鉴权头，VM 内永远看不到真实 Key |
+| **出网审计** | 每次访问 LLM API 都会记录在出网审计日志中 |
+| **开放生态** | OpenCode 原生支持 MCP，可以与 CubeSandbox 的出网策略对齐 |
+
+## 接入步骤
+
+### 1. 构建模板镜像
+
+镜像在 `cubesandbox-base` 之上叠加 Node.js 20 与 OpenCode CLI；envd 已经监听
+`:49983`。
+
+```dockerfile
+# examples/opencode-integration/Dockerfile（节选）
+ARG CUBE_BASE_IMAGE=ghcr.io/tencentcloud/cubesandbox-base:2026.16
+FROM ${CUBE_BASE_IMAGE}
+
+ARG NODE_MAJOR=20
+ARG OPENCODE_VERSION=1.17.20
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        ca-certificates curl git gnupg jq less procps python3 python3-pip ripgrep \
+    && mkdir -p /etc/apt/keyrings \
+    && curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key \
+        | gpg --dearmor --yes -o /etc/apt/keyrings/nodesource.gpg \
+    && gpg --show-keys /etc/apt/keyrings/nodesource.gpg 2>/dev/null \
+        | grep -q "6F71F525282841EEDAF851B42F59B5F99B1BE0B4" \
+        || (echo "ERROR: NodeSource GPG fingerprint mismatch" && exit 1) \
+    && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_${NODE_MAJOR}.x nodistro main" \
+        > /etc/apt/sources.list.d/nodesource.list \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends nodejs \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN npm install -g --omit=dev \
+        "opencode-ai@${OPENCODE_VERSION}" \
+    && opencode --version \
+    && rm -rf /root/.npm
+
+# OpenCode 以非 root 用户运行。基础镜像已经用 uid=1000 作为 ``user`` exec 账号，
+# 所以 UID/GID 由系统自动分配；pause/resume 快照按用户名保留身份。MicroVM 提
+# 供外层隔离，这层降权是对 prompt injection 场景（LLM agent 被诱导执行
+# shell）的纵深防御。
+#
+# /workspace 设成 world-writable，因为 e2b exec 信道把用户名限制在 ``root``
+# 和 ``user``，而 ``user`` 写不进 opencode 拥有的目录。OpenCode 把它的磁盘
+# 状态拆成 ``$OPENCODE_CONFIG_DIR``（配置 + agents）与
+# ``$OPENCODE_DATA_DIR``（会话、auth.json、storage）；两者都放在
+# ``/workspace/.opencode`` 之下，pause/resume 时会跟项目文件一起被快照。
+ARG OPENCODE_CONFIG_DIR=/workspace/.opencode/config
+ARG OPENCODE_DATA_DIR=/workspace/.opencode/data
+
+RUN groupadd --system opencode \
+    && useradd  --system --gid opencode \
+                --home-dir /home/opencode --shell /bin/bash \
+                --no-create-home opencode \
+    && install -d -o opencode -g opencode -m 0700 /home/opencode \
+    && install -d -o opencode -g opencode -m 0777 /workspace
+
+ENV OPENCODE_CONFIG_DIR=${OPENCODE_CONFIG_DIR} \
+    OPENCODE_DATA_DIR=${OPENCODE_DATA_DIR} \
+    XDG_CONFIG_HOME=/workspace \
+    XDG_DATA_HOME=/workspace \
+    DISABLE_TELEMETRY=1 \
+    DISABLE_ERROR_REPORTING=1 \
+    OPENCODE_DISABLE_AUTOUPDATE=1
+
+RUN install -d -o opencode -g opencode -m 0777 "${OPENCODE_CONFIG_DIR}" \
+    && install -d -o opencode -g opencode -m 0777 "${OPENCODE_DATA_DIR}/storage" \
+    && printf '{}\n' > "${OPENCODE_CONFIG_DIR}/opencode.json"
+
+WORKDIR /workspace
+USER opencode
+```
+
+构建并推送（在仓库根目录运行，确保相对构建上下文 `examples/opencode-integration`
+能正确解析）：
+
+```bash
+docker build --pull --platform linux/amd64 \
+  -t <your-registry>/opencode-cube:latest \
+  examples/opencode-integration
+docker push <your-registry>/opencode-cube:latest
+```
+
+### 2. 注册为 Cube 模板
+
+```bash
+cubemastercli tpl create-from-image \
+  --image <your-registry>/opencode-cube:latest \
+  --writable-layer-size 4G \
+  --expose-port 49983 \
+  --probe       49983 \
+  --probe-path  /health
+
+cubemastercli tpl watch --job-id <job_id>
+```
+
+任务变为 `READY` 后记下 `template_id`，之后每次 `Sandbox.create()` 都传给它。
+中等任务用 `4G` 可写层就够；如果 Agent 需要安装较重的工具链，建议提升到
+`8G+`。
+
+### 3. 配置宿主端驱动
+
+```bash
+cd examples/opencode-integration
+cp .env.example .env
+# 填写 E2B_API_URL、CUBE_TEMPLATE_ID 以及 provider 密钥
+pip install -r requirements.txt
+```
+
+| 变量 | 作用位置 | 说明 |
+|---|---|---|
+| `E2B_API_URL` | 本地进程 | CubeAPI 地址（`http://<node>:3000`） |
+| `E2B_API_KEY` | 本地进程 | 本地开发填任意非空字符串 |
+| `CUBE_TEMPLATE_ID` | `Sandbox.create(template=...)` | 来自第 2 步 |
+| `OPENCODE_PROVIDER` | `env_utils.provider()` | 可选 —— 未设置时从已配的密钥反推 |
+| `OPENCODE_MODEL` / `OPENCODE_BASE_URL` | OpenCode CLI 标志 | 模型 id 与可选的自定义上游端点 |
+| `ANTHROPIC_API_KEY` / `OPENAI_API_KEY` / `GOOGLE_API_KEY` / ... | `envs=...`（直连）或 CubeEgress 注入（vault） | provider 密钥 |
+| `OPENCODE_LLM_HOST` | `network_policy.py` | 默认拒绝下放行的 LLM host |
+
+### 4. 运行时配置与 API Key 注入
+
+OpenCode 以无交互模式启动：`opencode run "..."` 让它处理完 prompt 即退出（不
+进入交互 TUI）。通过 `--dangerously-skip-permissions` 标志（OpenCode 1.17+
+加入，别名 `--yolo`）在该次运行期间自动放行工具调用 —— 因为 exec 信道无法
+回答权限弹窗。prompt 作为末尾的位置参数。两种密钥注入方式共用同一份模板：
+
+**直连方式** —— 每个命令注入一次 Key。`e2b` 的 `commands.run(envs=...)` 把环
+境放进 exec 信封，而不是写入 VM 内的持久文件，所以 Key 只在该命令执行期间存
+在。exec 信道只接受 `root` 和 `user` 两个用户名；传 `user="opencode"` 会触发
+`invalid username: 'opencode'`。镜像内 Agent 仍以非 root 身份运行（因为
+Dockerfile 有 `USER opencode`），SDK 层面的 `user` 参数只约束 exec 信道的身
+份，不影响容器内进程身份：
+
+```python
+result = sandbox.commands.run(
+    "cd /workspace && opencode run --dangerously-skip-permissions -m claude-sonnet-4-6 "
+    "'Inspect the project, run app.py, and summarize the result.'",
+    envs={"ANTHROPIC_API_KEY": key},
+    user="user",
+    timeout=900,
+)
+```
+
+**保险柜方式** —— 让 Key 完全不进入 VM（见第 6 步）。
+
+### 5. 会话持久化（pause / resume）
+
+```bash
+cd examples/opencode-integration
+python resume_opencode.py
+```
+
+与 [快照 / 克隆 / 回滚](../snapshot-rollback-clone.md) 引擎在 SDK 层等价：
+
+- `sandbox.pause()` 对运行中的 VM（内存 + rootfs）打快照并释放算力。
+- `Sandbox.connect(sandbox_id)` 恢复时，`/workspace`、
+  `/workspace/.opencode/config/`、`/workspace/.opencode/data/` 以及其它所有文
+  件都保留。第二轮再调用
+  `opencode run --dangerously-skip-permissions -c`，让 OpenCode 自动续接
+  `$OPENCODE_DATA_DIR/storage/` 下最近一次会话。
+
+> **生命周期注意事项：** 用 `try/finally` 管理沙箱生命周期，不要用
+> `with Sandbox.create(...)` context manager。`__exit__` 会 `kill` 沙箱，把
+> pause 撤销。示例里显式创建沙箱，只在 `finally` 中调用 `sandbox.kill()`。
+
+```python
+sandbox = Sandbox.create(template=template_id, timeout=1800)
+try:
+    run_turn(sandbox, prompt_1)          # 写入 /workspace/plan.md
+    sandbox_id = sandbox.pause() or sandbox.sandbox_id
+    sandbox = Sandbox.connect(sandbox_id)
+    assert_state_survived(sandbox)       # /workspace + /workspace/.opencode/{config,data}/ 完好
+    run_turn(sandbox, prompt_2, continue_session=True)
+finally:
+    sandbox.kill()
+```
+
+### 6. 网络与出网策略（凭证保险柜）
+
+在完成第 3 步配置后，在 `examples/opencode-integration/` 目录里跑：
+
+```bash
+cd examples/opencode-integration
+python network_policy.py
+```
+
+脚本演示了共享集群的推荐模式：默认拒绝出网 + 链路上注入 Key。
+
+```python
+# 凭证注入走原生 cubesandbox SDK（见 security-proxy.md）。
+from cubesandbox import Sandbox, Rule, Match, Action, Inject
+
+host = "api.anthropic.com"
+rules = [
+    Rule(
+        name="allow_anthropic_llm",
+        match=Match(scheme="https", sni=host, host=host),
+        action=Action(allow=True, audit="metadata", inject=[
+            Inject(header="x-api-key", secret=ANTHROPIC_API_KEY, format="${SECRET}"),
+            Inject(header="anthropic-version", secret="2023-06-01", format="${SECRET}"),
+        ]),
+    ),
+]
+
+sandbox = Sandbox.create(
+    template=CUBE_TEMPLATE_ID,
+    allow_internet_access=False,   # 默认拒绝；规则中的 host 自动放行
+    network={"rules": rules},
+)
+```
+
+效果：
+
+- 沙箱内 `printenv ANTHROPIC_API_KEY` 只能看到一个占位值。
+- 每次访问 LLM host 都会在链路上被加上鉴权头。
+- 其它目的地址在 L3/L4 由 CubeVS 直接丢弃（`allow_internet_access=False`），
+  根本不会离开沙箱。
+- 每次放行/拒绝都会落到出网审计日志中。
+
+非 Anthropic provider 用 `Authorization: Bearer` 头注入。如果某个 provider 不接
+受在链路上注入头，那就退回直连方式（`envs=...`）—— 但永远不要把 Key 写进沙
+箱内的持久文件。
+
+## 使用场景与最佳实践
+
+- **隔离开发。** 把编码 Agent 跑在沙箱里，让它的文件编辑与 shell 命令无法触
+  碰宿主机。
+- **执行 Agent 生成的代码并回收结果。** 让 Agent 把产出写到 `/workspace`，然
+  后用 `sandbox.files` 或 `commands.run` 把产物读回来。
+- **长任务的断点续跑。** 用 `pause()` + `connect()` 给一次长重构打快照，之后
+  再恢复；也可以从同一份快照 fork 出多个变体。
+- **不改镜像就切换 LLM provider。** OpenCode 自身由上游环境变量决定
+  （`ANTHROPIC_API_KEY`、`OPENAI_API_KEY`、...）；通过 `OPENCODE_BASE_URL`
+  指向任何 Anthropic / OpenAI 兼容端点即可，模板无需重建。
+- **重型依赖预装进模板。** 默认拒绝策略下，运行时再去拉依赖会很慢，建议在
+  镜像里把常用工具链装好。
+- **OpenCode 与 MCP 协同。** OpenCode 原生支持 MCP，可以在同一份模板里跑
+  一个 MCP server，让 OpenCode 调用它做文件系统、浏览器或数据库访问——出
+  网策略仍然适用。
+
+## 关键代码片段
+
+### 无头调用 OpenCode
+
+```python
+cmd = (
+    "cd /workspace && opencode run --dangerously-skip-permissions -m claude-sonnet-4-6 "
+    "'Inspect the project, run app.py, and summarize the result.'"
+)
+result = sandbox.commands.run(cmd, envs=opencode_env, timeout=900)
+```
+
+### 启动前版本检查
+
+```python
+version = sandbox.commands.run("opencode --version", timeout=60)
+```
+
+## 注意事项
+
+- **Node.js 版本。** OpenCode 要求 Node 18.20+；基础镜像自带的是较老的 apt
+  Node，请走 NodeSource 安装（Dockerfile 已处理）。
+- **非交互模式需要 `--dangerously-skip-permissions`。** `opencode run` 默
+  认会对每次工具调用询问权限，非交互模式下无法回答。`run_opencode.py`
+  在调用前会带上这个 flag；在更高安全等级的场景里，请通过 `opencode.json`
+  收紧白名单。（OpenCode < 1.17 没有这个标志，需要用
+  `OPENCODE_PERMISSION='{"*":"allow"}'` 环境变量替代。）
+- **Agent 状态目录。** OpenCode 把状态拆成两个目录：
+  `/workspace/.opencode/config/`（配置）和
+  `/workspace/.opencode/data/`（会话、auth.json、storage）。Dockerfile
+  会创建这两个空目录，但不会写入任何凭据。
+- **直连方式的 Key 残留。** 直连（`envs=`）下 Key 只在该 exec 调用期间有效，
+  但 OpenCode 可能把 provider 凭据缓存在数据目录
+  （`/workspace/.opencode/data/auth.json`）里，会跨 `pause()` / `resume()`
+  存活。严格隔离场景请用保险柜方式（`network_policy.py`），让 Key 完全不进
+  入 VM。
+- **CubeEgress 拦截 CA（Node）。** 保险柜方式要求沙箱信任 CubeEgress 根 CA，
+  基础镜像把它装进了系统 CA 包。OpenCode 是 Node.js 包，忽略系统 CA 库，因
+  此 `network_policy.py` 还会设 `NODE_EXTRA_CA_CERTS`（可用
+  `OPENCODE_NODE_EXTRA_CA_CERTS` 覆盖）—— 否则 vault 路径会以
+  `unable to verify the first certificate` 失败。
+- **出网副作用。** `npm install`、拉 MCP 工具等任务需要把这些 host 加进放行
+  规则，或预装进模板。
+- **交互式 TTY 特性。** OpenCode 的交互 TUI 走不了 E2B 协议。请用
+  `opencode run` 走无头模式，多轮对话由宿主端脚本驱动（`-c` / `-s <id>` 续
+  接，`--session-id` 钉住会话 id）。
+- **Provider 反推规则。** `env_utils.provider()` 通过当前已配的密钥环境变量
+  反推 provider。使用自定义网关时，请显式设置 `OPENCODE_PROVIDER` 绕过按子
+  串匹配的启发式。
+
+## 排错
+
+| 现象 | 可能原因 | 处理 |
+|---|---|---|
+| preflight 报 `opencode: command not found` | CLI 变更后未重建模板 | 重建镜像并重新注册模板 |
+| 权限弹窗卡住整个 run | 未带 `--dangerously-skip-permissions` 标志，且运行会读写/执行命令 | 加上 flag，或在 `opencode.json` 里收紧 permissions |
+| `unknown flag: --dangerously-skip-permissions` | OpenCode 版本早于 1.17 | 用 `--build-arg OPENCODE_VERSION=1.17.20` 重建镜像，或改用 `OPENCODE_PERMISSION='{"*":"allow"}'` 环境变量 |
+| OpenCode 报 `model not found` | `OPENCODE_MODEL` 与当前 provider 不匹配 | 显式设置 `OPENCODE_MODEL`，或用 OpenCode 的 `provider/model` 简写通过 `-m anthropic/claude-sonnet-4-6` 传入 |
+| provider 鉴权失败 | 密钥未传入（直连）或缺少 inject 规则（vault） | 传 `envs={...}` 或修正规则的 `sni`/`host` |
+| `403 Forbidden - CubeEgress` | 默认拒绝且无匹配放行规则 | 把 LLM host（及所需其他 host）加入规则 |
+| vault 路径下 OpenCode 报 `Connection error` / TLS 失败 | OpenCode 是 Node.js 包，忽略系统 CA 库，不信任 CubeEgress 拦截 CA | 脚本已把 `NODE_EXTRA_CA_CERTS` 指向系统 CA 包；若 CA 在别处，用 `OPENCODE_NODE_EXTRA_CA_CERTS` 覆盖 |
+| 模板创建卡在 `PULLING` | registry 无法被 Cube 节点访问 | 推送到集群可达的 registry，或传入鉴权参数 |
+| 就绪探针超时 | 镜像缺少 envd | 确认 `FROM ghcr.io/tencentcloud/cubesandbox-base:2026.16` |
+| `pause()` / `connect()` 报错 | 平台版本过低不支持快照 | 升级 CubeSandbox 平台 |
+
+## 参考资料
+
+- 可运行示例：[`examples/opencode-integration`](https://github.com/TencentCloud/CubeSandbox/tree/master/examples/opencode-integration)
+- 引入自有镜像：[`docs/zh/guide/tutorials/bring-your-own-image.md`](../tutorials/bring-your-own-image.md)
+- 从镜像创建模板：[`docs/zh/guide/tutorials/template-from-image.md`](../tutorials/template-from-image.md)
+- 快照 / 克隆 / 回滚：[`docs/zh/guide/snapshot-rollback-clone.md`](../snapshot-rollback-clone.md)
+- 凭证保险柜 + 出网管控：[`docs/zh/guide/security-proxy.md`](../security-proxy.md)
+- OpenCode CLI：<https://opencode.ai/>
+- OpenCode 文档：<https://opencode.ai/docs/>
+- OpenCode 仓库：<https://github.com/anomalyco/opencode>

--- a/examples/opencode-integration/.env.example
+++ b/examples/opencode-integration/.env.example
@@ -1,0 +1,47 @@
+# --- CubeSandbox connection ---
+
+# Required: CubeAPI address (use CubeAPI, not CubeProxy).
+E2B_API_URL="http://<cube-host>:3000"
+
+# Required: any non-empty value in local dev; a real key when auth is enabled.
+E2B_API_KEY="e2b_000000"
+
+# Required: template built from this example's Dockerfile.
+CUBE_TEMPLATE_ID="<template-id>"
+
+# Optional: only when talking to CubeProxy over HTTPS with Cube's mkcert cert.
+# SSL_CERT_FILE="/root/.local/share/mkcert/rootCA.pem"
+
+# --- OpenCode agent ---
+
+# Optional: explicitly pick the provider preset (anthropic, openai, google,
+# azure, bedrock, deepseek, groq, mistral, openrouter, ...). When unset the
+# scripts infer it from whichever provider API key is set in your env.
+# OPENCODE_PROVIDER="anthropic"
+
+# Required: model id OpenCode runs against. Provider default is only set for
+# Anthropic; for other providers set this explicitly (model IDs are
+# provider-specific and change often).
+# OPENCODE_MODEL="claude-sonnet-4-6"
+
+# Required: the active provider's API key. OpenCode reads the well-known
+# provider env vars (ANTHROPIC_API_KEY, OPENAI_API_KEY, ...) directly, so
+# copy the matching key from your shell into this file.
+# ANTHROPIC_API_KEY="<your-anthropic-api-key>"
+# OPENAI_API_KEY="<your-openai-api-key>"
+# GOOGLE_API_KEY="<your-google-api-key>"
+# DEEPSEEK_API_KEY="<your-deepseek-api-key>"
+
+# Optional: override the upstream endpoint (e.g. Anthropic-compatible gateways).
+# OPENCODE_BASE_URL="https://api.anthropic.com"
+# ANTHROPIC_BASE_URL="https://api.deepseek.com/anthropic"
+# ANTHROPIC_MODEL="deepseek-v4-pro"
+
+# Optional (network_policy.py): LLM host to allow under default-deny egress.
+# Defaults to the host parsed from OPENCODE_BASE_URL / ANTHROPIC_BASE_URL /
+# OPENAI_BASE_URL, or the provider default; override only for a custom endpoint.
+# OPENCODE_LLM_HOST="api.anthropic.com"
+
+# Advanced OpenCode tunables (OPENCODE_WORKSPACE, OPENCODE_CONFIG_DIR,
+# OPENCODE_AGENT_EXEC_TIMEOUT, OPENCODE_NODE_EXTRA_CA_CERTS, ...) have sane
+# defaults; see env_utils.py to override.

--- a/examples/opencode-integration/.gitignore
+++ b/examples/opencode-integration/.gitignore
@@ -1,0 +1,8 @@
+.env
+.env.*
+!.env.example
+__pycache__/
+*.pyc
+*.log
+output/
+workspace-seed/

--- a/examples/opencode-integration/Dockerfile
+++ b/examples/opencode-integration/Dockerfile
@@ -1,0 +1,147 @@
+# syntax=docker/dockerfile:1.7
+#
+# OpenCode inside a CubeSandbox template.
+#
+# The image installs Node.js 20 (OpenCode's npm package expects Node 18+, 20 is
+# the long-lived line that OpenCode currently tests against) and the opencode-ai
+# CLI on top of the official CubeSandbox base image. The inherited
+# cube-entrypoint keeps envd running on :49983 so Cube can use the standard
+# readiness probe.
+#
+# Build:
+#   docker build --pull -t opencode-cube:latest examples/opencode-integration
+#
+# Register as a Cube template:
+#   cubemastercli tpl create-from-image \
+#     --image <your-registry>/opencode-cube:latest \
+#     --writable-layer-size 4G \
+#     --expose-port 49983 \
+#     --probe       49983 \
+#     --probe-path  /health
+
+ARG CUBE_BASE_IMAGE=ghcr.io/tencentcloud/cubesandbox-base:2026.16
+FROM ${CUBE_BASE_IMAGE}
+
+ARG DEBIAN_FRONTEND=noninteractive
+ARG NODE_MAJOR=20
+ARG OPENCODE_VERSION=1.17.20
+
+# OpenCode stores its **config** under ``$XDG_CONFIG_HOME/opencode`` (default
+# ``~/.config/opencode``) and its **data** — auth.json, session storage,
+# logs, tool-output, snapshots — under ``$XDG_DATA_HOME/opencode`` (default
+# ``~/.local/share/opencode``). Two different paths because OpenCode
+# follows the XDG Base Directory spec.
+#
+# We relocate both to ``/workspace`` for two reasons:
+#
+# 1. The e2b exec channel constrains us to a fixed allow-list of usernames
+#    (``root``, ``user``); an image-level USER directive that creates an
+#    ``opencode`` account does not propagate to the exec user. OpenCode's
+#    default $HOME-relative paths therefore need to be world-writable for
+#    the SDK-allowed exec user to write into them, which weakens the
+#    privilege drop.
+# 2. Keeping both trees under /workspace means the snapshot captures the
+#    project tree, the OpenCode config, and the OpenCode session/storage
+#    cache together, which is the natural unit for pause/resume —
+#    operators get "what was the agent doing" alongside "what files did
+#    it leave behind" without reaching into hidden home dirs.
+ARG OPENCODE_CONFIG_DIR=/workspace/.opencode/config
+ARG OPENCODE_DATA_DIR=/workspace/.opencode/data
+
+# NodeSource signing key (primary fingerprint, not the subkey). Update by
+# running: curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key \
+#               | gpg --show-keys --with-colons | grep ^fpr
+# Verified against https://github.com/nodesource/distributions on 2026-07-18.
+ARG NODESOURCE_GPG_FPR=6F71F525282841EEDAF851B42F59B5F99B1BE0B4
+
+# Layer 1 — system packages + NodeSource repo. Splitting this off from the
+# OpenCode install layer keeps the slow apt + NodeSource GPG step cacheable
+# across OpenCode version bumps.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        bash \
+        ca-certificates \
+        curl \
+        git \
+        gnupg \
+        jq \
+        less \
+        procps \
+        python3 \
+        python3-pip \
+        ripgrep \
+    && mkdir -p /etc/apt/keyrings \
+    && curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key \
+        | gpg --dearmor --yes -o /etc/apt/keyrings/nodesource.gpg \
+    && gpg --show-keys /etc/apt/keyrings/nodesource.gpg 2>/dev/null \
+        | grep -q "${NODESOURCE_GPG_FPR}" \
+        || (echo "ERROR: NodeSource GPG fingerprint mismatch" >&2; exit 1) \
+    && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_${NODE_MAJOR}.x nodistro main" \
+        > /etc/apt/sources.list.d/nodesource.list \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends nodejs \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+# Layer 2 — OpenCode. Skips dev deps (50-200 MB of tooling the headless CLI
+# never loads) and post-install scripts (the npm postinstall runs a binary
+# downloader; we let it execute because it places platform-specific
+# artifacts under the package, but we keep --omit=dev to skip the rest).
+RUN npm install -g --omit=dev \
+        "opencode-ai@${OPENCODE_VERSION}" \
+    && opencode --version \
+    && rm -rf /root/.npm
+
+# Create an unprivileged user that owns the workspace. OpenCode is an
+# autonomous code-generation agent with Bash, file-edit, and shell tool
+# access — running it as root turns any prompt-injection or CLI bug into
+# a root-level compromise inside the sandbox. The MicroVM still provides
+# the outer isolation, but defense in depth matters for long-running
+# sessions.
+#
+# UID/GID are auto-assigned because the base image already owns uid=1000 as
+# the ``user`` exec account; pause/resume preserves identity by username,
+# not by numeric id.
+#
+# /workspace is world-writable because the e2b exec channel constrains us
+# to the SDK's allowed-users list (``root``, ``user``) and ``user`` cannot
+# write to an opencode-owned directory. The MicroVM provides the
+# isolation; the world write is a single-purpose concession to the SDK's
+# allowed users. The home directory under /home/opencode is kept at 0700.
+RUN groupadd --system opencode \
+    && useradd  --system --gid opencode \
+                --home-dir /home/opencode --shell /bin/bash \
+                --no-create-home opencode \
+    && install -d -o opencode -g opencode -m 0700 /home/opencode \
+    && install -d -o opencode -g opencode -m 0777 /workspace
+
+# Pin both config & data directories under /workspace so the paths are
+# stable across pause/resume snapshots and the empty-state below is created
+# at build time (no leftover tenant state ever leaks into the base
+# template). XDG_CONFIG_HOME is also forced so OpenCode never falls back to
+# ~/.config inside /home/opencode (which the exec user ``user`` could not
+# write).
+ENV OPENCODE_CONFIG_DIR=${OPENCODE_CONFIG_DIR} \
+    OPENCODE_DATA_DIR=${OPENCODE_DATA_DIR} \
+    XDG_CONFIG_HOME=/workspace \
+    XDG_DATA_HOME=/workspace \
+    OPENCODE_DISABLE_AUTOUPDATE=1 \
+    NPM_CONFIG_UPDATE_NOTIFIER=false
+
+# Pre-create the workspace and the OpenCode state trees so the first exec
+# call does not race the directory creation. The base template ships with
+# an empty config dir; per-tenant credentials / sessions are populated at
+# runtime so a paused snapshot cannot replay a tenant-specific chain.
+RUN install -d -o opencode -g opencode -m 0777 "${OPENCODE_CONFIG_DIR}" "${OPENCODE_DATA_DIR}" \
+    && install -d -o opencode -g opencode -m 0777 "${OPENCODE_DATA_DIR}/storage" \
+    && printf '{}\n' > "${OPENCODE_CONFIG_DIR}/opencode.json"
+
+WORKDIR /workspace
+
+# Drop root. OpenCode and any subsequent shell commands run as opencode.
+# If cube-entrypoint needs root (e.g. to bind :49983), the inherited image
+# already runs the entrypoint before this USER takes effect — confirm against
+# the base image's entrypoint before changing this.
+USER opencode
+
+EXPOSE 49983

--- a/examples/opencode-integration/README.md
+++ b/examples/opencode-integration/README.md
@@ -1,0 +1,312 @@
+# OpenCode + CubeSandbox Example
+
+[中文文档](README_zh.md)
+
+Run the [OpenCode CLI](https://opencode.ai/) — an open-source, terminal-native
+AI coding agent — inside a CubeSandbox MicroVM. The agent edits files, runs
+commands, and reaches an LLM API entirely within an isolated, reproducible
+sandbox.
+
+This example ships:
+
+- A `Dockerfile` that stacks Node.js 20 + the OpenCode CLI on top of the
+  CubeSandbox base image (envd already listens on `:49983`).
+- `run_opencode.py` — a headless one-shot run inside `/workspace`.
+- `resume_opencode.py` — pause/resume across two turns, proving `/workspace`,
+  OpenCode's config dir (`/workspace/.opencode/config/`) and data dir
+  (`/workspace/.opencode/data/`, where sessions live) all survive the snapshot.
+- `network_policy.py` — a default-deny egress policy where CubeEgress injects
+  the API key on the wire, so the key never enters the VM.
+- `sandbox_exec.py` — a host-side CLI executor that lets you run arbitrary
+  Python or shell code inside a disposable MicroVM (`--code`, `--file`,
+  `--cmd`, `--pip`). Reuses a cached sandbox across invocations via a
+  UID-scoped session file under `/tmp`.
+- `mcp_server.py` — exposes the same execution backend as an MCP server
+  (JSON-RPC over stdio) so any MCP client (Claude Desktop, Cursor, …) can
+  sandbox its code through OpenCode's toolchain.
+- `hooks/` — an OpenCode JavaScript plugin (`cubesandbox-sandbox.js`) that
+  routes the in-agent `bash` tool through the host-side executor, plus a
+  shell installer (`install.sh`) that drops the plugin into
+  `~/.config/opencode/plugins/`. Mirrors the PreToolUse-Bash pattern from
+  the Claude Code integration.
+- `env_utils.py`, `_opencode_common.py`, `.env.example`, `requirements.txt`,
+  `tests/`.
+
+## Directory layout
+
+```
+opencode-integration/
+├── Dockerfile            # CubeSandbox template image (Node.js + OpenCode CLI)
+├── .env.example          # Copy to .env and fill in
+├── .gitignore
+├── requirements.txt      # Host driver deps (e2b, cubesandbox, python-dotenv)
+├── env_utils.py          # .env loading, provider keys, OpenCode command builder
+├── _opencode_common.py   # Shared sandbox command helpers (run/ensure/id)
+├── run_opencode.py       # One-shot OpenCode task
+├── resume_opencode.py    # Pause / resume session persistence
+├── network_policy.py     # Default-deny egress + on-the-wire key injection
+├── sandbox_exec.py       # Host-side CLI: --code / --file / --cmd / --pip
+├── mcp_server.py         # JSON-RPC stdio MCP server with 5 sandbox tools
+├── hooks/
+│   ├── install.sh                       # Copy plugin + sanitized config into ~/.config/opencode
+│   └── cubesandbox-sandbox.js           # tool.execute.before plugin that forwards bash to a sandbox
+├── tests/                # pytest suite (mirrors the Claude Code test layout)
+│   ├── conftest.py
+│   ├── test_env_utils.py
+│   ├── test_opencode_common.py
+│   ├── test_sandbox_exec.py
+│   └── test_mcp_server.py
+├── README.md             # English docs (this file)
+└── README_zh.md          # Chinese docs
+```
+
+## Prerequisites
+
+- A running CubeSandbox deployment; CubeAPI reachable at `http://<node>:3000`.
+- `cubemastercli` on `$PATH`, connected to the cluster.
+- Docker on the build workstation, plus a registry the Cube nodes can pull from.
+- An OpenCode-compatible LLM provider key — Anthropic, OpenAI, Google Gemini,
+  DeepSeek, OpenRouter, Groq, Mistral, or any provider OpenCode ships a
+  built-in preset for. See `.env.example`.
+- Python 3.10+ for the host driver scripts.
+
+## 1. Build the template image
+
+```bash
+docker build --pull --platform linux/amd64 \
+  -t <your-registry>/opencode-cube:latest \
+  examples/opencode-integration
+docker push <your-registry>/opencode-cube:latest
+```
+
+The image installs `opencode-ai` plus `git`, `python3`, `ripgrep`, `jq`, and
+cleans apt/npm caches. The OpenCode version is pinned via
+`--build-arg OPENCODE_VERSION=x.y.z`. **Tested against `opencode-ai@1.17.20`**
+— the script relies on the `--dangerously-skip-permissions` flag that landed in
+OpenCode 1.17.x. Older releases need the equivalent
+`OPENCODE_PERMISSION='{"*":"allow"}'` env var instead.
+
+## 2. Register as a Cube template
+
+```bash
+cubemastercli tpl create-from-image \
+  --image <your-registry>/opencode-cube:latest \
+  --writable-layer-size 4G \
+  --expose-port 49983 \
+  --probe       49983 \
+  --probe-path  /health
+
+cubemastercli tpl watch --job-id <job_id>
+```
+
+Note the `template_id` once the job reaches `READY`.
+
+## 3. Configure the host driver
+
+```bash
+cd examples/opencode-integration
+cp .env.example .env
+# fill in E2B_API_URL, CUBE_TEMPLATE_ID, and your provider key
+pip install -r requirements.txt
+```
+
+| Variable | Where it flows | Notes |
+|---|---|---|
+| `E2B_API_URL` | Local process | CubeAPI address (`http://<node>:3000`) |
+| `E2B_API_KEY` | Local process | Any non-empty string in local dev |
+| `CUBE_TEMPLATE_ID` | `Sandbox.create(template=...)` | From step 2 |
+| `OPENCODE_PROVIDER` | `env_utils.provider()` | Optional — inferred from the active key when unset |
+| `OPENCODE_MODEL` | OpenCode CLI | Model id for the active provider |
+| `ANTHROPIC_API_KEY` / `OPENAI_API_KEY` / `GOOGLE_API_KEY` / ... | `envs=...` (direct) or CubeEgress inject (vault) | Provider key |
+| `OPENCODE_BASE_URL` / `ANTHROPIC_BASE_URL` | OpenCode CLI | Custom upstream endpoint (e.g. DeepSeek via Anthropic-compatible gateway) |
+| `OPENCODE_LLM_HOST` | `network_policy.py` | LLM API host to allow; defaults to the parsed `*_BASE_URL` host or the provider default |
+
+## 4. One-shot run (direct key flavor)
+
+```bash
+python run_opencode.py --prompt "Create hello.py that prints 'Hello from CubeSandbox' and run it."
+```
+
+OpenCode is invoked headlessly with `opencode run "..."` (process the prompt
+and exit, no TUI). The script appends `--dangerously-skip-permissions`
+(OpenCode 1.17+, `--yolo` alias) so every tool call is auto-approved for the
+duration of the run. Without it, the CLI blocks on a permission prompt that
+cannot be answered over the exec channel. The provider key is forwarded
+per-command via `sandbox.commands.run(..., envs=...)`, so it lives only for
+the lifetime of that exec call — never written to a persistent file inside
+the VM. Pass `--no-approve` to drop the flag and run with OpenCode's
+permission prompts active (only safe if you've tightened the tool allow-list
+via `opencode.json`).
+
+> **Security:** this direct flavor leaves egress open, so a compromised agent
+> could exfiltrate the injected key. For shared clusters use the vault flavor
+> (step 6): default-deny egress + on-the-wire key injection.
+
+## 5. Pause / resume (session persistence)
+
+```bash
+python resume_opencode.py
+```
+
+Turn 1 asks OpenCode to write `/workspace/plan.md`, then `sandbox.pause()`
+snapshots the VM. The script reconnects with `Sandbox.connect(sandbox_id)`,
+verifies `/workspace/plan.md` and OpenCode's data dir
+(`/workspace/.opencode/data/storage/`, where session messages live) survived,
+then runs turn 2 with `-c` to continue the most recent session. The sandbox
+lifecycle is managed manually with `try/finally` (not a context manager), so
+the pause is not undone by an early `kill`.
+
+## 6. Restricted egress + key vault (recommended for shared clusters)
+
+```bash
+python network_policy.py
+```
+
+- Egress is default-deny — only the LLM host (`OPENCODE_LLM_HOST`) is reachable.
+- CubeEgress attaches the provider key as an HTTP header on the wire
+  (`x-api-key` for Anthropic, `Authorization: Bearer` otherwise), so
+  `printenv` inside the sandbox never shows the real key — it only sees a
+  placeholder.
+- Because OpenCode ships as a Node.js bundle that ignores the system CA
+  store, the script sets `NODE_EXTRA_CA_CERTS` so OpenCode trusts the
+  CubeEgress interception CA; without it the vault path fails with
+  "unable to verify the first certificate". Override the bundle path via
+  `OPENCODE_NODE_EXTRA_CA_CERTS` if your image keeps the CA elsewhere.
+- Any other destination returns `403 Forbidden - CubeEgress`.
+
+If the agent needs extra hosts (package registries, MCP servers), add matching
+allow rules or preinstall those dependencies into the template.
+
+## 7. Host-side executor (`sandbox_exec.py`)
+
+For tasks that need to run untrusted code but do not need the OpenCode
+agent itself, the `sandbox_exec.py` CLI runs code directly inside a
+disposable MicroVM. The host stays clean; the sandbox is destroyed (or
+its session cached) at the end of each call.
+
+```bash
+python sandbox_exec.py --code "print(1+1)"
+python sandbox_exec.py --file ./script.py
+python sandbox_exec.py --cmd "ls -la /workspace"
+python sandbox_exec.py --pip requests --code "import requests; print(requests.__version__)"
+
+# Reuse the same sandbox on the next call instead of cold-starting
+python sandbox_exec.py --keep-alive --code "state = 42"
+python sandbox_exec.py --cmd "echo state still alive"
+
+# Force a fresh sandbox
+python sandbox_exec.py --reset
+```
+
+The cross-process cache uses a UID-scoped session file under
+`/tmp/cubesandbox_opencode_session_<uid>` (`O_NOFOLLOW` + `0600` +
+`symlink → S_ISREG` check) so a different user on a shared host cannot
+hijack your `Sandbox.connect()` on the next call.
+
+## 8. MCP server (`mcp_server.py`)
+
+The same execution backend is also exposed as a newline-delimited
+JSON-RPC MCP server so any MCP client (Claude Desktop, Cursor,
+Windsurf, VS Code, …) can run untrusted code in the OpenCode
+sandbox instead of locally. Five tools are exposed:
+
+| Tool | Purpose |
+| --- | --- |
+| `sandbox_run_code` | Run a Python snippet in the sandbox |
+| `sandbox_run_command` | Run an arbitrary shell command in the sandbox |
+| `sandbox_write_file` | Write a file into the sandbox |
+| `sandbox_read_file` | Read a file back from the sandbox |
+| `sandbox_reset` | Destroy the cached sandbox and start over |
+
+Wire it into an MCP client (Claude Desktop example shown):
+
+```json
+{
+  "mcpServers": {
+    "cubesandbox-opencode": {
+      "command": "python3",
+      "args": ["/abs/path/to/examples/opencode-integration/mcp_server.py"],
+      "env": {
+        "E2B_API_URL": "http://<cube-host>:3000",
+        "E2B_API_KEY": "<api-key>",
+        "CUBE_TEMPLATE_ID": "<template-id>"
+      }
+    }
+  }
+}
+```
+
+The server lifecycle is process-global: a single sandbox is created on
+first use, its TTL is refreshed on every tool call, and an `atexit`
+handler kills it when the MCP process exits. `sandbox_reset` is the
+only way to force a fresh one mid-session.
+
+## 9. Host OpenCode + bash-routing plugin (`hooks/`)
+
+For the opposite workflow — keep OpenCode on the host but route every
+`bash` tool call through CubeSandbox — install the JavaScript plugin
+in `hooks/`:
+
+```bash
+cd examples/opencode-integration
+python3 -m pip install -r requirements.txt
+cp .env.example .env
+# Fill in E2B_API_URL and CUBE_TEMPLATE_ID
+
+cd hooks
+./install.sh
+```
+
+The installer copies `cubesandbox-sandbox.js` into
+`~/.config/opencode/plugins/`, drops a sibling `package.json` declaring
+`"type": "module"` (so OpenCode's Bun runtime can resolve the ESM
+`import` statements), and merges only an allow-listed subset of
+`CUBE_*` settings into `~/.config/opencode/opencode.json`. LLM
+provider API keys (`ANTHROPIC_API_KEY`, …) are never copied.
+
+Restart OpenCode after install. The plugin's
+`tool.execute.before` hook intercepts `bash` calls, spawns the host
+`python3 sandbox_exec.py --cmd <quoted>` against the cached session
+sandbox, and replaces the host-shell command with the sandbox output.
+Other tools (`read`, `edit`, `write`, …) still run on the host as
+usual — the plugin only intercepts `bash`, mirroring the bash-only
+scope of the Claude Code PreToolUse hook.
+
+Uninstall with `hooks/install.sh --uninstall`.
+
+## Running the tests
+
+```bash
+cd examples/opencode-integration
+python3 -m pip install pytest
+python3 -m pytest tests -v
+```
+
+The suite is fully offline: no CubeSandbox cluster or LLM credentials
+are needed. `sandbox_exec` and `mcp_server` are exercised via
+`unittest.mock` against the e2b SDK; the env-var helpers are exercised
+via `monkeypatch` so test order cannot leak state.
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| `opencode: command not found` in preflight | Template not rebuilt after CLI change | Rebuild the image, re-register the template |
+| Permission prompt hangs the run | `--dangerously-skip-permissions` is missing on a run that touches files or commands | The default invocation passes it; use `opencode.json` permissions if you want a safer default |
+| `unknown flag: --dangerously-skip-permissions` | OpenCode older than 1.17 | Rebuild the image with `--build-arg OPENCODE_VERSION=1.17.20`, or run with `OPENCODE_PERMISSION='{"*":"allow"}'` instead |
+| Provider auth failure | Key not forwarded (direct) or missing inject rule (vault) | Pass `envs={...}` or fix the rule's `sni`/`host` |
+| `403 Forbidden - CubeEgress` | Default-deny with no matching allow rule | Add the LLM host (and any extra hosts) to the rules |
+| `Connection error` / TLS failure from OpenCode (vault) | OpenCode is a Node.js bundle that ignores the system CA store, so it won't trust the CubeEgress interception CA | The script sets `NODE_EXTRA_CA_CERTS` to the system bundle; override with `OPENCODE_NODE_EXTRA_CA_CERTS` if your CA lives elsewhere |
+| Template creation stuck in `PULLING` | Registry unreachable from Cube nodes | Push to a registry the cluster can reach; supply auth if needed |
+| Readiness probe timeout | Base image without envd | Ensure `FROM ghcr.io/tencentcloud/cubesandbox-base:2026.16` |
+| `pause()` / `connect()` errors | Platform too old for snapshots | Upgrade the CubeSandbox platform |
+| `opencode run` errors with `model not found` | `OPENCODE_MODEL` does not match the provider | Set `OPENCODE_MODEL` explicitly per provider; OpenCode's `provider/model` shorthand is also accepted via `-m anthropic/claude-sonnet-4-6` |
+
+## References
+
+- Integration guide: [`docs/guide/integrations/opencode.md`](../../docs/guide/integrations/opencode.md)
+- Snapshot / Clone / Rollback: [`docs/guide/snapshot-rollback-clone.md`](../../docs/guide/snapshot-rollback-clone.md)
+- Network / egress policy examples: [`examples/network-policy`](../network-policy)
+- Credential vault + egress control: [`docs/guide/security-proxy.md`](../../docs/guide/security-proxy.md)
+- OpenCode CLI: <https://opencode.ai/>
+- OpenCode docs: <https://opencode.ai/docs/>

--- a/examples/opencode-integration/README_zh.md
+++ b/examples/opencode-integration/README_zh.md
@@ -1,0 +1,293 @@
+# OpenCode + CubeSandbox 示例
+
+[English](README.md)
+
+在 CubeSandbox MicroVM 内运行 [OpenCode CLI](https://opencode.ai/)
+（开源、面向终端的 AI 编码 Agent）。Agent 在一个隔离、可复现的沙箱内编辑
+文件、执行命令并访问 LLM API。
+
+本示例包含：
+
+- 一个 `Dockerfile`：在 CubeSandbox 基础镜像上叠加 Node.js 20 与 OpenCode CLI
+  （envd 已监听 `:49983`）。
+- `run_opencode.py`：在 `/workspace` 内的一次性无交互运行。
+- `resume_opencode.py`：跨两轮的 pause/resume，证明 `/workspace`、OpenCode
+  配置目录（`/workspace/.opencode/config/`）与数据目录
+  （`/workspace/.opencode/data/`，会话存放在这）都在快照后保留。
+- `network_policy.py`：默认拒绝出网的策略，由 CubeEgress 在链路上注入 API
+  Key，密钥不进入 VM。
+- `sandbox_exec.py`：宿主端 CLI 执行器，让你在一次性 MicroVM 内跑任意 Python
+  或 shell 代码（`--code`、`--file`、`--cmd`、`--pip`），通过
+  `/tmp` 下按 UID 隔离的会话文件跨调用复用同一沙箱。
+- `mcp_server.py`：把同一执行后端暴露成 MCP server（JSON-RPC over stdio），
+  任何 MCP 客户端（Claude Desktop、Cursor 等）都能通过 OpenCode 工具链将
+  代码沙箱化执行。
+- `hooks/`：OpenCode JavaScript 插件（`cubesandbox-sandbox.js`），把 Agent 内
+  的 `bash` 工具调用转发到宿主端执行器；附带 `install.sh`，把插件拷到
+  `~/.config/opencode/plugins/`。与 Claude Code 集成的 PreToolUse-Bash
+  模式对齐。
+- `env_utils.py`、`_opencode_common.py`、`.env.example`、`requirements.txt`、
+  `tests/`。
+
+## 目录结构
+
+```
+opencode-integration/
+├── Dockerfile            # CubeSandbox 模板镜像（Node.js + OpenCode CLI）
+├── .env.example          # 复制为 .env 并填写
+├── .gitignore
+├── requirements.txt      # 宿主端驱动依赖（e2b、cubesandbox、python-dotenv）
+├── env_utils.py          # .env 加载、provider key、OpenCode 命令构造
+├── _opencode_common.py   # 共享的沙箱命令辅助（run/ensure/id）
+├── run_opencode.py       # 一次性 OpenCode 任务
+├── resume_opencode.py    # pause / resume 会话持久化
+├── network_policy.py     # 默认拒绝出网 + 链路上注入密钥
+├── sandbox_exec.py       # 宿主端 CLI：--code / --file / --cmd / --pip
+├── mcp_server.py         # JSON-RPC stdio MCP server，提供 5 个沙箱工具
+├── hooks/
+│   ├── install.sh                       # 把插件和脱敏后的配置写入 ~/.config/opencode
+│   └── cubesandbox-sandbox.js           # tool.execute.before 插件，把 bash 调用转交沙箱
+├── tests/                # pytest 套件（与 Claude Code 测试结构对齐）
+│   ├── conftest.py
+│   ├── test_env_utils.py
+│   ├── test_opencode_common.py
+│   ├── test_sandbox_exec.py
+│   └── test_mcp_server.py
+├── README.md             # 英文文档
+└── README_zh.md          # 中文文档（本文件）
+```
+
+## 前置条件
+
+- 已部署 CubeSandbox，CubeAPI 可访问（`http://<node>:3000`）。
+- `cubemastercli` 已在 `$PATH` 且已连通集群。
+- 构建机装有 Docker，且 registry 能被 Cube 集群拉取。
+- OpenCode 兼容的 LLM provider 密钥 —— Anthropic、OpenAI、Google Gemini、
+  DeepSeek、OpenRouter、Groq、Mistral，或任何 OpenCode 内置预设的 provider。
+  见 `.env.example`。
+- Python 3.10+（宿主端驱动脚本）。
+
+## 1. 构建模板镜像
+
+```bash
+docker build --pull --platform linux/amd64 \
+  -t <your-registry>/opencode-cube:latest \
+  examples/opencode-integration
+docker push <your-registry>/opencode-cube:latest
+```
+
+镜像会安装 `opencode-ai`，以及 `git`、`python3`、`ripgrep`、`jq`，并清理
+apt/npm 缓存。OpenCode 版本通过 `--build-arg OPENCODE_VERSION=x.y.z` 固定。
+**已针对 `opencode-ai@1.17.20` 测试**——脚本依赖 OpenCode 1.17 才加入的
+`--dangerously-skip-permissions` 标志；更老的版本需要用等价的
+`OPENCODE_PERMISSION='{"*":"allow"}'` 环境变量。
+
+## 2. 注册为 Cube 模板
+
+```bash
+cubemastercli tpl create-from-image \
+  --image <your-registry>/opencode-cube:latest \
+  --writable-layer-size 4G \
+  --expose-port 49983 \
+  --probe       49983 \
+  --probe-path  /health
+
+cubemastercli tpl watch --job-id <job_id>
+```
+
+任务变为 `READY` 后记下 `template_id`。
+
+## 3. 配置宿主端驱动
+
+```bash
+cd examples/opencode-integration
+cp .env.example .env
+# 填写 E2B_API_URL、CUBE_TEMPLATE_ID 以及 provider 密钥
+pip install -r requirements.txt
+```
+
+| 变量 | 作用位置 | 说明 |
+|---|---|---|
+| `E2B_API_URL` | 本地进程 | CubeAPI 地址（`http://<node>:3000`） |
+| `E2B_API_KEY` | 本地进程 | 本地开发填任意非空字符串 |
+| `CUBE_TEMPLATE_ID` | `Sandbox.create(template=...)` | 来自第 2 步 |
+| `OPENCODE_PROVIDER` | `env_utils.provider()` | 可选 —— 未设置时从已配的密钥反推 |
+| `OPENCODE_MODEL` | OpenCode CLI | 对应 provider 的模型 id |
+| `ANTHROPIC_API_KEY` / `OPENAI_API_KEY` / `GOOGLE_API_KEY` / ... | `envs=...`（直连）或 CubeEgress 注入（vault） | provider 密钥 |
+| `OPENCODE_BASE_URL` / `ANTHROPIC_BASE_URL` | OpenCode CLI | 自定义上游端点（如通过 Anthropic 兼容网关接 DeepSeek） |
+| `OPENCODE_LLM_HOST` | `network_policy.py` | 放行的 LLM API host，默认从 `*_BASE_URL` 解析或取 provider 默认 |
+
+## 4. 一次性运行（直连注入密钥）
+
+```bash
+python run_opencode.py --prompt "创建 hello.py 打印 'Hello from CubeSandbox' 并运行它。"
+```
+
+OpenCode 以无交互模式启动：`opencode run "..."` 让它处理完 prompt 即退出（不进
+入交互 TUI）。脚本会在命令行追加 `--dangerously-skip-permissions`
+（OpenCode 1.17+，别名 `--yolo`）让所有工具调用在本次运行期间自动放行——
+否则 CLI 会卡在无法在 exec 信道回答的权限弹窗上。密钥通过
+`sandbox.commands.run(..., envs=...)` 逐命令传入，只在该命令执行期间存在，不会
+写入 VM 内的持久文件。传 `--no-approve` 可以去掉该 flag，让 OpenCode 走权限
+弹窗（前提是用 `opencode.json` 把工具白名单收紧过，否则会卡住）。
+
+> **安全：** 直连方式出网是放开的，Agent 被攻破可能外泄注入的密钥。共享集群请
+> 用保险柜方式（第 6 步）：默认拒绝出网 + 链路上注入密钥。
+
+## 5. pause / resume（会话持久化）
+
+```bash
+python resume_opencode.py
+```
+
+第一轮让 OpenCode 写 `/workspace/plan.md`，随后 `sandbox.pause()` 对 VM 打快
+照。脚本用 `Sandbox.connect(sandbox_id)` 恢复，校验 `/workspace/plan.md` 与
+OpenCode 数据目录（`/workspace/.opencode/data/storage/`，会话消息存放在这）仍
+在，再用 `-c` 续接最近一次会话执行第二轮。沙箱生命周期用 `try/finally` 手动
+管理（不用 context manager），避免 pause 后被过早 `kill` 掉。
+
+## 6. 受限出网 + 密钥保险柜（推荐用于共享集群）
+
+```bash
+python network_policy.py
+```
+
+- 出网默认拒绝，仅放行 LLM host（`OPENCODE_LLM_HOST`）。
+- CubeEgress 在链路上把 provider 密钥作为 HTTP 头注入（Anthropic 用
+  `x-api-key`，其他用 `Authorization: Bearer`），因此沙箱内 `printenv` 看
+  不到真实密钥，只有占位值。
+- OpenCode 是 Node.js 包，忽略系统 CA 库。脚本会设置 `NODE_EXTRA_CA_CERTS`
+  让 OpenCode 信任 CubeEgress 的拦截 CA；否则 vault 路径会以
+  `unable to verify the first certificate` 失败。若镜像里 CA 路径不同，
+  可用 `OPENCODE_NODE_EXTRA_CA_CERTS` 覆盖。
+- 任何其他目的地都会返回 `403 Forbidden - CubeEgress`。
+
+若 Agent 需要访问额外主机（包镜像源、MCP 服务器等），请增加对应的放行规则，
+或把这些依赖预装进模板。
+
+## 7. 宿主端执行器（`sandbox_exec.py`）
+
+如果只是要跑一些不受信任的代码、不需要 OpenCode Agent 自身，可以直接
+用 `sandbox_exec.py` CLI 把代码送进一次性 MicroVM。宿主保持干净，每次
+调用结束沙箱被销毁（或复用其会话缓存）。
+
+```bash
+python sandbox_exec.py --code "print(1+1)"
+python sandbox_exec.py --file ./script.py
+python sandbox_exec.py --cmd "ls -la /workspace"
+python sandbox_exec.py --pip requests --code "import requests; print(requests.__version__)"
+
+# 跨次调用复用同一沙箱，避免冷启动
+python sandbox_exec.py --keep-alive --code "state = 42"
+python sandbox_exec.py --cmd "echo state still alive"
+
+# 强制重建沙箱
+python sandbox_exec.py --reset
+```
+
+跨进程缓存使用 `/tmp/cubesandbox_opencode_session_<uid>` 下的会话文件
+（`O_NOFOLLOW` + `0600` + `symlink → S_ISREG` 校验），共享主机上的其
+他用户无法劫持你下一次的 `Sandbox.connect()`。
+
+## 8. MCP server（`mcp_server.py`）
+
+同一个执行后端也可以通过 newline-delimited JSON-RPC MCP 协议暴露出去，
+让任何 MCP 客户端（Claude Desktop、Cursor、Windsurf、VS Code …）都能
+在 OpenCode 沙箱里跑不受信任的代码，而不是直接跑在本地。提供 5 个工
+具：
+
+| 工具 | 用途 |
+| --- | --- |
+| `sandbox_run_code` | 在沙箱内执行一段 Python 代码 |
+| `sandbox_run_command` | 在沙箱内执行任意 shell 命令 |
+| `sandbox_write_file` | 写入文件到沙箱 |
+| `sandbox_read_file` | 从沙箱读回文件 |
+| `sandbox_reset` | 销毁当前沙箱，下次重新创建 |
+
+把它接入一个 MCP 客户端（以 Claude Desktop 为例）：
+
+```json
+{
+  "mcpServers": {
+    "cubesandbox-opencode": {
+      "command": "python3",
+      "args": ["/abs/path/to/examples/opencode-integration/mcp_server.py"],
+      "env": {
+        "E2B_API_URL": "http://<cube-host>:3000",
+        "E2B_API_KEY": "<api-key>",
+        "CUBE_TEMPLATE_ID": "<template-id>"
+      }
+    }
+  }
+}
+```
+
+Server 生命周期是进程级的：首次调用时创建一个沙箱，每次调用都刷新
+TTL，`atexit` 钩子在 MCP 进程退出时销毁。`sandbox_reset` 是中途强制
+重建的唯一入口。
+
+## 9. 宿主 OpenCode + bash 路由插件（`hooks/`）
+
+对于相反的工作流——OpenCode 留在宿主机，但每一次 `bash` 工具调用都
+路由到 CubeSandbox——可以安装 `hooks/` 里的 JavaScript 插件：
+
+```bash
+cd examples/opencode-integration
+python3 -m pip install -r requirements.txt
+cp .env.example .env
+# 填写 E2B_API_URL 和 CUBE_TEMPLATE_ID
+
+cd hooks
+./install.sh
+```
+
+安装脚本会把 `cubesandbox-sandbox.js` 复制到
+`~/.config/opencode/plugins/`，并在同目录写一个 `package.json` 声明
+`"type": "module"`（OpenCode 跑在 Bun 运行时，需要解析 ESM `import`）。
+同时仅把白名单内的 `CUBE_*` 配置合并进
+`~/.config/opencode/opencode.json`，LLM provider 密钥
+（`ANTHROPIC_API_KEY` 等）永远不会被复制进去。
+
+安装后重启 OpenCode。插件的 `tool.execute.before` 钩子拦截 `bash`
+调用，对宿主 `python3 sandbox_exec.py --cmd <quoted>` 派生子进程，复
+用已缓存的会话沙箱，然后把原本的宿主 shell 命令替换成沙箱的执行结
+果。其它工具（`read`、`edit`、`write` 等）继续在宿主上运行——插件
+只拦截 `bash`，与 Claude Code PreToolUse 钩子的 bash-only 范围对齐。
+
+卸载：`hooks/install.sh --uninstall`。
+
+## 运行测试
+
+```bash
+cd examples/opencode-integration
+python3 -m pip install pytest
+python3 -m pytest tests -v
+```
+
+测试完全离线：不需要 CubeSandbox 集群或 LLM 凭据。`sandbox_exec` 和
+`mcp_server` 通过 `unittest.mock` 桩接 e2b SDK 来跑；环境变量相关辅助
+用 `monkeypatch`，所以测试顺序不会泄漏状态。
+
+## 排错
+
+| 现象 | 可能原因 | 处理 |
+|---|---|---|
+| preflight 报 `opencode: command not found` | CLI 变更后未重建模板 | 重建镜像并重新注册模板 |
+| 权限弹窗卡住整个 run | 未带 `--dangerously-skip-permissions` 标志，且运行会读写/执行命令 | 默认调用已带；若需更严格默认，请在 `opencode.json` 里配置 permissions |
+| `unknown flag: --dangerously-skip-permissions` | OpenCode 版本早于 1.17 | 用 `--build-arg OPENCODE_VERSION=1.17.20` 重建镜像，或改用 `OPENCODE_PERMISSION='{"*":"allow"}'` 环境变量 |
+| provider 鉴权失败 | 密钥未传入（直连）或缺少 inject 规则（vault） | 传 `envs={...}` 或修正规则的 `sni`/`host` |
+| `403 Forbidden - CubeEgress` | 默认拒绝且无匹配放行规则 | 把 LLM host（及所需其他 host）加入规则 |
+| vault 路径下 OpenCode 报 `Connection error` / TLS 失败 | OpenCode 是 Node.js 包，忽略系统 CA 库，不信任 CubeEgress 拦截 CA | 脚本已把 `NODE_EXTRA_CA_CERTS` 指向系统 CA 包；若 CA 在别处，用 `OPENCODE_NODE_EXTRA_CA_CERTS` 覆盖 |
+| 模板创建卡在 `PULLING` | registry 无法被 Cube 节点访问 | 推送到集群可达的 registry，或传入鉴权参数 |
+| 就绪探针超时 | 镜像缺少 envd | 确认 `FROM ghcr.io/tencentcloud/cubesandbox-base:2026.16` |
+| `pause()` / `connect()` 报错 | 平台版本过低不支持快照 | 升级 CubeSandbox 平台 |
+| `opencode run` 报 `model not found` | `OPENCODE_MODEL` 与 provider 不匹配 | 显式按 provider 设置 `OPENCODE_MODEL`；也可用 OpenCode 的 `provider/model` 简写通过 `-m anthropic/claude-sonnet-4-6` 传入 |
+
+## 参考资料
+
+- 集成指南：[`docs/guide/integrations/opencode.md`](../../docs/zh/guide/integrations/opencode.md)
+- 快照 / 克隆 / 回滚：[`docs/zh/guide/snapshot-rollback-clone.md`](../../docs/zh/guide/snapshot-rollback-clone.md)
+- 网络 / 出网策略示例：[`examples/network-policy`](../network-policy)
+- 凭证保险柜 + 出网管控：[`docs/zh/guide/security-proxy.md`](../../docs/zh/guide/security-proxy.md)
+- OpenCode CLI：<https://opencode.ai/>
+- OpenCode 文档：<https://opencode.ai/docs/>

--- a/examples/opencode-integration/_opencode_common.py
+++ b/examples/opencode-integration/_opencode_common.py
@@ -1,0 +1,102 @@
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared sandbox command helpers for the OpenCode example scripts.
+
+Kept SDK-agnostic (duck-typed on ``sandbox.commands.run`` and the result's
+attributes) so the same helpers work with both the e2b-compatible SDK used by
+``run_opencode.py`` / ``resume_opencode.py`` and the native ``cubesandbox``
+SDK used by ``network_policy.py``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from collections.abc import Callable
+from typing import Any
+
+from e2b.sandbox.commands.command_handle import CommandExitException
+
+
+def positive_int(value: str) -> int:
+    """argparse type that rejects zero and negative integers.
+
+    Both the CLI value and the env-var fallback default flow through this
+    function so passing ``--exec-timeout 0`` fails the same way as setting
+    ``OPENCODE_AGENT_EXEC_TIMEOUT=0`` in the environment.
+    """
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        raise argparse.ArgumentTypeError(f"expected an integer, got {value!r}") from None
+    if parsed <= 0:
+        raise argparse.ArgumentTypeError(
+            f"expected a positive integer, got {value}"
+        )
+    return parsed
+
+
+def stream_writer(stream) -> Callable[[object], None]:
+    def write(chunk: object) -> None:
+        text = getattr(chunk, "line", chunk)
+        stream.write(str(text))
+        stream.flush()
+
+    return write
+
+
+def run_command(
+    sandbox: Any,
+    command: str,
+    *,
+    cwd: str | None = None,
+    envs: dict[str, str] | None = None,
+    timeout: int | float | None = None,
+    stream: bool = False,
+    user: str = "user",
+):
+    # The e2b / CubeSandbox exec channel rejects unknown usernames with
+    # "invalid username: '<x>'", so we cannot pass ``opencode`` here even
+    # though the image's USER directive drops privileges. ``user`` (uid 1000)
+    # is the default non-root account the base image ships; pairing that with
+    # the image-level USER opencode means any containerized tool (OpenCode
+    # itself, npm scripts run via opencode, etc.) runs unprivileged, while
+    # the exec channel stays within the SDK-accepted allow-list.
+    kwargs = {"cwd": cwd, "timeout": timeout, "user": user}
+    kwargs = {key: value for key, value in kwargs.items() if value is not None}
+    if envs:
+        kwargs["envs"] = envs
+    if stream:
+        kwargs["on_stdout"] = stream_writer(sys.stdout)
+        kwargs["on_stderr"] = stream_writer(sys.stderr)
+
+    try:
+        return sandbox.commands.run(command, **kwargs)
+    except TypeError as exc:
+        # Older SDKs name the parameter ``env`` instead of ``envs``. Only retry
+        # for that specific signature mismatch; re-raise any other TypeError so
+        # real bugs (e.g. a wrong-type command or timeout) are not masked.
+        if "envs" not in kwargs or "envs" not in str(exc):
+            raise
+        kwargs["env"] = kwargs.pop("envs")
+        return sandbox.commands.run(command, **kwargs)
+    except CommandExitException as exc:
+        # Some SDKs raise on non-zero exits instead of returning a result.
+        # Swallow it here so every caller can uniformly branch on exit_code
+        # without catching at every call site (Claude PR review finding #6).
+        return exc
+
+
+def ensure_success(result, action: str) -> None:
+    exit_code = getattr(result, "exit_code", None)
+    if exit_code not in (None, 0):
+        stdout = getattr(result, "stdout", "")
+        stderr = getattr(result, "stderr", "")
+        raise SystemExit(
+            f"Failed to {action} (exit {exit_code}).\nSTDOUT:\n{stdout}\nSTDERR:\n{stderr}"
+        )
+
+
+def sandbox_identifier(sandbox: Any) -> str:
+    return getattr(sandbox, "sandbox_id", getattr(sandbox, "id", "unknown"))

--- a/examples/opencode-integration/env_utils.py
+++ b/examples/opencode-integration/env_utils.py
@@ -1,0 +1,450 @@
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import os
+import shlex
+from pathlib import Path
+from urllib.parse import urlparse, urlunparse
+
+from dotenv import load_dotenv
+
+# Default OpenCode config directory (overridable via OPENCODE_CONFIG_DIR).
+# OpenCode separates config (this) from data (``$OPENCODE_DATA_DIR``); see
+# ``opencode_data_dir()`` below for the data side (auth, sessions, storage,
+# logs). Both must match the ``ARG`` values baked into the Dockerfile so
+# pause/resume snapshots land on the expected paths. Both live under
+# ``/workspace`` so the SDK-allowed exec user (``user``) can write to them
+# without the home-dir write hole that ``/home/opencode/.config/opencode``
+# would otherwise open.
+DEFAULT_OPENCODE_CONFIG_DIR = "/workspace/.opencode/config"
+DEFAULT_OPENCODE_DATA_DIR = "/workspace/.opencode/data"
+
+# Default workspace inside the sandbox. OpenCode is invoked with ``cd
+# $WORKSPACE`` before each run so file edits and tool output land where the
+# snapshot will capture them.
+DEFAULT_WORKSPACE = "/workspace"
+
+# OpenCode ships with built-in provider presets (anthropic, openai,
+# google, azure, bedrock, ...). The CLI keys off the well-known provider
+# environment variables (ANTHROPIC_API_KEY, OPENAI_API_KEY, ...); we mirror
+# that map here so the egress allow-list (network_policy.py) can pick the
+# right upstream host and the right auth-header shape.
+PROVIDER_KEY_ENV = {
+    "anthropic": "ANTHROPIC_API_KEY",
+    "openai": "OPENAI_API_KEY",
+    "google": "GOOGLE_API_KEY",
+    "google-vertex": "GOOGLE_VERTEX_API_KEY",
+    "azure": "AZURE_API_KEY",
+    "bedrock": "AWS_BEDROCK_API_KEY",
+    "deepseek": "DEEPSEEK_API_KEY",
+    "groq": "GROQ_API_KEY",
+    "mistral": "MISTRAL_API_KEY",
+    "openrouter": "OPENROUTER_API_KEY",
+}
+
+PROVIDER_DEFAULT_HOST = {
+    "anthropic": "api.anthropic.com",
+    "openai": "api.openai.com",
+    "google": "generativelanguage.googleapis.com",
+    "google-vertex": "aiplatform.googleapis.com",
+    "azure": "openai.azure.com",
+    "bedrock": "bedrock-runtime.us-east-1.amazonaws.com",
+    "deepseek": "api.deepseek.com",
+    "groq": "api.groq.com",
+    "mistral": "api.mistral.ai",
+    "openrouter": "openrouter.ai",
+}
+
+# Default model when the user does not set OPENCODE_MODEL. Anthropic is the
+# most common provider paired with OpenCode today, so we ship a sane default
+# there. Other providers require an explicit model (model IDs change often
+# and there is no safe cross-provider default).
+PROVIDER_DEFAULT_MODEL = {
+    "anthropic": "claude-sonnet-4-6",
+}
+
+# Variables that are forwarded verbatim into the in-sandbox exec env. The list
+# is intentionally narrow: only env vars that affect OpenCode's request shape
+# or operator-controlled behavior. API keys are forwarded separately (see
+# build_opencode_env / include_secrets=False) so a CI host with several
+# providers never leaks all of them into one sandbox.
+PASSTHROUGH_ENV_NAMES = (
+    "ANTHROPIC_BASE_URL",
+    "ANTHROPIC_MODEL",
+    "OPENAI_BASE_URL",
+    "OPENAI_MODEL",
+    "GOOGLE_BASE_URL",
+    "OPENCODE_BASE_URL",
+    "OPENCODE_MODEL",
+    "OPENCODE_SMALL_MODEL",
+    "OPENCODE_PROVIDER",
+    "HTTP_PROXY",
+    "HTTPS_PROXY",
+    "NO_PROXY",
+    "OPENCODE_CUSTOM_HEADERS",
+)
+
+
+def load_local_dotenv() -> None:
+    """Best-effort load of a nearby .env file without overriding real env vars."""
+    for path in (
+        Path(__file__).with_name(".env"),
+        Path.cwd() / ".env",
+    ):
+        if path.is_file():
+            load_dotenv(dotenv_path=path, override=False)
+            return
+
+
+def required(name: str) -> str:
+    value = os.environ.get(name)
+    if not value:
+        raise SystemExit(f"Missing required environment variable: {name}")
+    return value
+
+
+def optional(name: str, default: str = "") -> str:
+    """Return ``os.environ[name]`` if the key exists, else ``default``.
+
+    An explicitly-empty value (``OPENCODE_FOO=""``) is propagated verbatim —
+    we only fall back when the variable is genuinely unset. This avoids the
+    ``os.environ.get(key) or default`` foot-gun where empty strings silently
+    flip to the default and mask bad .env input.
+    """
+    if name not in os.environ:
+        return default
+    return os.environ[name]
+
+
+def int_env(name: str, default: int) -> int:
+    raw = os.environ.get(name)
+    if raw is None or raw == "":
+        return default
+    try:
+        return int(raw)
+    except ValueError as exc:
+        raise SystemExit(f"{name} must be an integer, got {raw!r}") from exc
+
+
+def _env_positive_int(name: str, default: int) -> int:
+    """``int_env`` + ``positive_int``: rejects zero/negative env-var values too.
+
+    argparse evaluates ``default=`` before ``type=``, so a bare
+    ``default=int_env(...)`` lets a malformed env var (e.g.
+    ``OPENCODE_SANDBOX_TIMEOUT=0``) bypass the ``type=positive_int`` check.
+    Use this helper for timeout defaults that share the positive-integer
+    constraint with their CLI flag.
+    """
+    raw = os.environ.get(name)
+    if raw is None or raw == "":
+        return default
+    try:
+        parsed = int(raw)
+    except ValueError as exc:
+        raise SystemExit(f"{name} must be an integer, got {raw!r}") from exc
+    if parsed <= 0:
+        raise SystemExit(f"{name} must be a positive integer, got {parsed}")
+    return parsed
+
+
+def opencode_home() -> str:
+    return optional("OPENCODE_CONFIG_DIR", DEFAULT_OPENCODE_CONFIG_DIR)
+
+
+def opencode_data_dir() -> str:
+    """Return the OpenCode data directory (sessions, auth.json, storage, logs).
+
+    OpenCode separates config (``$OPENCODE_CONFIG_DIR``/``$XDG_CONFIG_HOME``)
+    from data (``$OPENCODE_DATA_DIR``/``$XDG_DATA_HOME``). The data dir is
+    where session storage and provider auth land; capturing it in the
+    snapshot is what makes pause/resume actually preserve the conversation.
+    Defaults to ``/workspace/.opencode/data`` so the data dir follows the
+    workspace into the snapshot, matching the Dockerfile's ``OPENCODE_DATA_DIR``
+    ``ARG``.
+    """
+    return optional("OPENCODE_DATA_DIR", DEFAULT_OPENCODE_DATA_DIR)
+
+
+def opencode_workspace() -> str:
+    return optional("OPENCODE_WORKSPACE", DEFAULT_WORKSPACE)
+
+
+def provider() -> str:
+    """Pick a logical provider for key injection / allow-list resolution.
+
+    OpenCode itself keys off the upstream env vars (``ANTHROPIC_API_KEY``,
+    ``OPENAI_API_KEY``, ...); this helper just translates that into a single
+    string so the egress allow-list (network_policy.py) can pick the right
+    host and the right auth-header shape.
+
+    **Heuristic caveat:** host detection uses substring matching on the
+    hostname only (``"anthropic" in host``, etc.). A custom gateway hostname
+    like ``anthropic-proxy.attacker.io`` would match to ``anthropic``.
+    Set ``OPENCODE_PROVIDER`` explicitly to bypass the heuristic whenever a
+    non-standard upstream is in use. URLs whose Anthropic compatibility
+    lives only in the path (e.g. ``https://api.deepseek.com/anthropic``)
+    are intentionally not auto-detected — they require an explicit
+    ``OPENCODE_PROVIDER=anthropic``.
+    """
+    explicit = os.environ.get("OPENCODE_PROVIDER")
+    if explicit:
+        return explicit.strip().lower()
+    # Prefer the active API key when one is set — that is the strongest
+    # signal of which upstream OpenCode will actually call.
+    for name, env_var in PROVIDER_KEY_ENV.items():
+        if os.environ.get(env_var):
+            return name
+    # BASE_URL substring heuristic. ``anthropic`` is checked first because
+    # many providers (DeepSeek, Moonshot, etc.) ship Anthropic-compatible
+    # gateways under their own hostname — the user usually wants the
+    # anthropic credential path, not a per-provider key.
+    base_url = os.environ.get("OPENCODE_BASE_URL") or ""
+    host = _host_from_url(base_url)
+    if "anthropic" in host:
+        return "anthropic"
+    if "openai" in host:
+        return "openai"
+    if "deepseek" in host:
+        return "deepseek"
+    if "googleapis" in host:
+        return "google"
+    if "openrouter" in host:
+        return "openrouter"
+    if "groq" in host:
+        return "groq"
+    if "mistral" in host:
+        return "mistral"
+    # Default to anthropic when no env signal is present; ``opencode_model``
+    # will require OPENCODE_MODEL unless the provider has a known default.
+    return "anthropic"
+
+
+def opencode_model() -> str:
+    """Resolve the model OpenCode should run against.
+
+    Precedence: explicit ``OPENCODE_MODEL`` > provider-specific env
+    (``ANTHROPIC_MODEL``, ``OPENAI_MODEL``, ...) > provider default
+    (Anthropic only).
+    """
+    provider_name = provider()
+    explicit = os.environ.get("OPENCODE_MODEL")
+    if not explicit and provider_name == "anthropic":
+        explicit = os.environ.get("ANTHROPIC_MODEL")
+    if explicit:
+        return explicit
+    default = PROVIDER_DEFAULT_MODEL.get(provider_name)
+    if default:
+        return default
+    raise SystemExit(
+        f"No default model for provider {provider_name!r}. Set OPENCODE_MODEL in your "
+        ".env (model IDs are provider-specific; there is no safe cross-provider default)."
+    )
+
+
+def provider_key_name() -> str:
+    """Return the env-var name we expect to hold the active provider's key."""
+    provider_name = provider()
+    candidates = provider_key_candidates(provider_name)
+    for name in candidates:
+        if os.environ.get(name):
+            return name
+    return candidates[0]
+
+
+def require_provider_key() -> str:
+    """Resolve the active provider key, raising if none is set.
+
+    OpenCode itself only talks to one upstream at a time, so we only need one
+    key — but we still scan multiple env-var names so users who copy-paste
+    their Anthropic env still work without editing.
+    """
+    provider_name = provider()
+    candidates = provider_key_candidates(provider_name)
+    for name in candidates:
+        value = os.environ.get(name)
+        if value:
+            return value
+    raise SystemExit(
+        "Missing required environment variable: one of " + ", ".join(candidates)
+    )
+
+
+def provider_key_candidates(provider_name: str) -> tuple[str, ...]:
+    provider_name = provider_name.strip().lower()
+    default_name = PROVIDER_KEY_ENV.get(
+        provider_name, f"{provider_name.upper()}_API_KEY"
+    )
+    return (default_name,)
+
+
+def llm_host() -> str:
+    """Resolve the LLM API host that OpenCode must reach.
+
+    Precedence: explicit ``OPENCODE_LLM_HOST`` > host parsed from
+    ``OPENCODE_BASE_URL`` / ``ANTHROPIC_BASE_URL`` / ``OPENAI_BASE_URL`` >
+    provider default.
+    """
+    provider_name = provider()
+    explicit = os.environ.get("OPENCODE_LLM_HOST")
+    if explicit:
+        return _host_from_url(explicit)
+    for env_name in (
+        "OPENCODE_BASE_URL",
+        "ANTHROPIC_BASE_URL",
+        "OPENAI_BASE_URL",
+        "GOOGLE_BASE_URL",
+    ):
+        base_url = os.environ.get(env_name)
+        if base_url:
+            host = _host_from_url(base_url)
+            if host:
+                return host
+    return PROVIDER_DEFAULT_HOST.get(provider_name, "")
+
+
+def _host_from_url(value: str) -> str:
+    candidate = value.strip()
+    if not candidate:
+        return ""
+    if "://" not in candidate:
+        candidate = f"https://{candidate}"
+    return urlparse(candidate).hostname or ""
+
+
+# Proxy env vars whose URLs may carry embedded credentials (e.g.
+# ``http://user:pass@corp-proxy:8080``). OpenCode's LLM agent runs inside the
+# VM and would otherwise see those credentials in its own environment — strip
+# them before forwarding. The other LLM-host resolution paths here never see a
+# URL with userinfo (we extract only the hostname), so this only matters for the
+# HTTP_PROXY passthrough below.
+PROXY_URL_ENV_NAMES = frozenset({"HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY"})
+
+
+def strip_url_userinfo(value: str) -> str:
+    """Remove the ``user:password@`` segment from a URL.
+
+    Accepts both full URLs (``http://u:p@h:8080``) and bare hoststrings
+    (``u:p@h:8080``); the latter is normalized with an ``https://`` prefix
+    first so ``urlparse`` can split authority from path. Strings that do not
+    parse cleanly are returned unchanged rather than masked, since the
+    downstream consumer is the Linux env inside the sandbox, which is the
+    same place any malformed proxy URL would already fail.
+    """
+    candidate = value.strip()
+    if not candidate or "@" not in candidate:
+        return value
+    if "://" not in candidate:
+        candidate = f"https://{candidate}"
+    parsed = urlparse(candidate)
+    if not parsed.hostname:
+        return value
+    if parsed.username is None and parsed.password is None:
+        # ``@`` present but only as a non-credential delimiter — leave alone.
+        return value
+    netloc = parsed.hostname
+    if parsed.port is not None:
+        netloc = f"{netloc}:{parsed.port}"
+    return urlunparse(parsed._replace(netloc=netloc))
+
+
+def provider_inject(provider_name: str, secret: str) -> list[dict[str, str]]:
+    """CubeEgress credential-injection specs for a provider's auth header(s).
+
+    Each dict maps directly to a ``cubesandbox.Inject(header=..., secret=...,
+    format=...)``. CubeEgress attaches these headers to matched outbound
+    requests, so the real key rides the wire and never enters the sandbox VM.
+    Anthropic uses ``x-api-key`` plus the required API-version header; every
+    other provider uses ``Authorization: Bearer``.
+    """
+    if provider_name.strip().lower() == "anthropic":
+        return [
+            {"header": "x-api-key", "secret": secret, "format": "${SECRET}"},
+            {"header": "anthropic-version", "secret": "2023-06-01", "format": "${SECRET}"},
+        ]
+    return [{"header": "Authorization", "secret": secret, "format": "Bearer ${SECRET}"}]
+
+
+def build_opencode_env(include_secrets: bool = True) -> dict[str, str]:
+    """Build the env map passed to the OpenCode command inside the sandbox.
+
+    Set ``include_secrets=False`` for the CubeEgress vault flavor: the real
+    provider key rides the wire via egress injection, so it must never enter
+    the sandbox environment.
+    """
+    env = {
+        "OPENCODE_CONFIG_DIR": opencode_home(),
+        "OPENCODE_DATA_DIR": opencode_data_dir(),
+        "XDG_CONFIG_HOME": "/workspace",
+        "XDG_DATA_HOME": "/workspace",
+        "DISABLE_TELEMETRY": optional("DISABLE_TELEMETRY", "1"),
+        "DISABLE_ERROR_REPORTING": optional("DISABLE_ERROR_REPORTING", "1"),
+        "OPENCODE_DISABLE_AUTOUPDATE": optional("OPENCODE_DISABLE_AUTOUPDATE", "1"),
+    }
+    for name in PASSTHROUGH_ENV_NAMES:
+        value = os.environ.get(name)
+        if value:
+            # Proxy URLs may carry host credentials (http://user:pass@proxy:...)
+            # which would otherwise leak to the LLM agent inside the VM. Strip
+            # the userinfo segment but keep the host:port so the agent can still
+            # route through the proxy.
+            if name in PROXY_URL_ENV_NAMES:
+                value = strip_url_userinfo(value)
+            env[name] = value
+    if include_secrets:
+        # Forward ONLY the provider key that matches the active provider — a
+        # host with several provider keys (e.g. a CI matrix) must not leak all
+        # of them into the sandbox.
+        key_name = provider_key_name()
+        value = os.environ.get(key_name)
+        if value:
+            env[key_name] = value
+    return env
+
+
+def opencode_command(
+    prompt: str,
+    *,
+    dangerously_skip_permissions: bool = True,
+    resume: str | None = None,
+    continue_session: bool = False,
+    session_id: str | None = None,
+    model: str | None = None,
+) -> str:
+    """Build a headless (non-interactive) OpenCode invocation.
+
+    ``opencode run`` makes OpenCode process the prompt and exit instead of
+    launching the interactive TUI (which would hang over the E2B exec
+    channel). By default OpenCode prompts for permission on every tool
+    call; in non-interactive mode that prompt cannot be answered, so the
+    run hangs. Pass ``--dangerously-skip-permissions`` (added in OpenCode
+    1.17.x) to auto-approve every tool call for the duration of the run.
+    Equivalent to ``OPENCODE_PERMISSION='{"*":"allow"}'`` in the env. Pass
+    ``dangerously_skip_permissions=False`` only if you have wired up a
+    safe sandbox-specific tool allow-list via ``opencode.json``.
+
+    Session flags:
+      * ``-c`` (continue) re-uses the most recent session.
+      * ``-s <id>`` re-uses a specific session id.
+      * ``--session-id <uuid>`` pins the session id for the new run.
+
+    The prompt is the trailing positional argument.
+    """
+    args = ["opencode", "run"]
+    if dangerously_skip_permissions:
+        args.append("--dangerously-skip-permissions")
+    if continue_session:
+        args.append("-c")
+    if resume:
+        args.extend(["-s", resume])
+    if session_id:
+        args.extend(["--session-id", session_id])
+    if model:
+        args.extend(["-m", model])
+    args.append(prompt)
+    return " ".join(shlex.quote(arg) for arg in args)
+
+
+def shell_join(*parts: str) -> str:
+    return " && ".join(part for part in parts if part)

--- a/examples/opencode-integration/env_utils.py
+++ b/examples/opencode-integration/env_utils.py
@@ -105,6 +105,23 @@ def required(name: str) -> str:
     return value
 
 
+def cube_required(cube_name: str, legacy_name: str) -> str:
+    """Resolve a CUBE_* config key with an E2B_* legacy fallback.
+
+    ``cube_name`` is the canonical env-var name (``CUBE_API_URL``, ``CUBE_API_KEY``);
+    ``legacy_name`` is the older alias (``E2B_API_URL``, ``E2B_API_KEY``). The
+    function checks the canonical name first and falls back to the legacy name,
+    so existing deployments that only set ``E2B_*`` continue to work without changes.
+    """
+    value = os.environ.get(cube_name) or os.environ.get(legacy_name)
+    if not value:
+        raise SystemExit(
+            f"Missing required environment variable: set either {cube_name} "
+            f"(preferred) or {legacy_name} (legacy alias) in your .env"
+        )
+    return value
+
+
 def optional(name: str, default: str = "") -> str:
     """Return ``os.environ[name]`` if the key exists, else ``default``.
 

--- a/examples/opencode-integration/hooks/cubesandbox-sandbox.js
+++ b/examples/opencode-integration/hooks/cubesandbox-sandbox.js
@@ -1,0 +1,91 @@
+// cubesandbox-sandbox.js — OpenCode plugin that routes bash tool calls
+// through a host-side CubeSandbox MicroVM instead of executing them on the
+// host directly.
+//
+// Drop this file (and any sibling files in the same directory) into one of
+// the OpenCode plugin directories to install:
+//
+//   ~/.config/opencode/plugins/cubesandbox-sandbox.js   (global)
+//   .opencode/plugins/cubesandbox-sandbox.js            (project)
+//
+// Then add `CUBE_*` settings to ~/.config/opencode/opencode.json or the
+// project-level opencode.json. Only whitelisted CUBE_* keys are read; LLM
+// provider credentials are never copied here.
+//
+// Behaviour:
+//   - "tool.execute.before" for the `bash` tool:
+//       * spawns `python3 <sandbox_exec.py> --cmd <quoted>` from this plugin
+//         file's directory
+//       * reads its stdout (which contains the command's stdout) and stderr
+//       * replaces output.args.command with a marker so the LLM sees the
+//         sandbox result instead of the host shell trying to run it
+//       * throws on non-zero exit so OpenCode aborts the tool call
+//   - Other tools pass through untouched.
+//
+// Security notes:
+//   - The plugin never embeds the API key. The spawned sandbox_exec.py uses
+//     the host's `cubesandbox` SDK, which reads CUBE_* from the host env.
+//   - The plugin only forwards the command string; `sandbox_exec.py` runs
+//     it inside a disposable MicroVM, so a malicious prompt cannot poison
+//     the host filesystem beyond the session file under /tmp.
+//   - If the plugin fails to spawn or the sandbox crashes, we throw so
+//     OpenCode does not silently fall back to host execution.
+
+import { spawnSync } from "node:child_process";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const PLUGIN_DIR = dirname(fileURLToPath(import.meta.url));
+const EXECUTOR = join(PLUGIN_DIR, "..", "sandbox_exec.py");
+
+/**
+ * Run a shell command inside a CubeSandbox via the host-side executor.
+ * Returns the captured stdout. Throws on non-zero exit so the LLM sees the
+ * failure and OpenCode aborts the tool call.
+ */
+function runInSandbox(command) {
+  const result = spawnSync(
+    "python3",
+    [EXECUTOR, "--cmd", command],
+    { encoding: "utf-8", timeout: 180_000 },
+  );
+
+  if (result.error) {
+    throw new Error(
+      `cubesandbox plugin: failed to spawn sandbox_exec.py: ${result.error.message}`,
+    );
+  }
+  if (result.status !== 0) {
+    const stderr = (result.stderr || "").trim();
+    throw new Error(
+      `cubesandbox plugin: sandbox command failed (exit ${result.status}): ${stderr}`,
+    );
+  }
+  return (result.stdout || "").trimEnd();
+}
+
+/** Plugin entry point — OpenCode invokes this once on startup. */
+export const CubeSandboxBashPlugin = async () => {
+  return {
+    "tool.execute.before": async (input, output) => {
+      // Only intercept the bash tool; every other tool (read, edit, ...)
+      // runs on the host as usual. This mirrors the bash-only scope of the
+      // Claude Code PreToolUse hook in the sibling Claude Code integration.
+      if (input.tool !== "bash") return;
+
+      const command = output?.args?.command;
+      if (typeof command !== "string" || command.length === 0) return;
+
+      const stdout = runInSandbox(command);
+
+      // Replace the command so OpenCode does not run it on the host shell,
+      // and surface the sandbox output as a synthetic stdout the LLM can
+      // read. Subsequent tool calls in the same session reuse the cached
+      // sandbox via sandbox_exec.py's session-file mechanism, so this is
+      // not a cold start after the first invocation.
+      output.args.command = `echo ${JSON.stringify(
+        "[cubesandbox-sandbox] executed in isolated MicroVM:\n" + stdout,
+      )}`;
+    },
+  };
+};

--- a/examples/opencode-integration/hooks/install.sh
+++ b/examples/opencode-integration/hooks/install.sh
@@ -20,6 +20,10 @@ EXAMPLE_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 OPENCODE_CONFIG_HOME="${OPENCODE_CONFIG_HOME:-$HOME/.config/opencode}"
 PLUGIN_DIR="$OPENCODE_CONFIG_HOME/plugins"
 PLUGIN_FILE="$PLUGIN_DIR/cubesandbox-sandbox.js"
+# sandbox_exec.py is bundled alongside the plugin so the JS hook can reference
+# it via a sibling path (plugins/sandbox_exec.py) regardless of where the user
+# installed OpenCode's config dir.
+EXECUTOR_FILE="$PLUGIN_DIR/sandbox_exec.py"
 PACKAGE_FILE="$PLUGIN_DIR/package.json"
 CONFIG_FILE="$OPENCODE_CONFIG_HOME/opencode.json"
 SOURCE_ENV="$EXAMPLE_DIR/.env.example"
@@ -116,7 +120,7 @@ PYEOF
 }
 
 if [[ "${1:-}" == "--uninstall" ]]; then
-    rm -f "$PLUGIN_FILE" "$PACKAGE_FILE"
+    rm -f "$PLUGIN_FILE" "$EXECUTOR_FILE" "$PACKAGE_FILE"
     echo "CubeSandbox OpenCode plugin uninstalled from $PLUGIN_DIR."
     echo "(Your opencode.json was left intact — remove the \"cubesandbox\" key manually if desired.)"
     exit 0
@@ -134,6 +138,10 @@ command -v python3 >/dev/null 2>&1 || {
 
 mkdir -p "$PLUGIN_DIR"
 install -m 0644 "$SCRIPT_DIR/cubesandbox-sandbox.js" "$PLUGIN_FILE"
+# Copy the sandbox executor alongside the plugin so the JS hook can import it
+# via a sibling path (plugins/sandbox_exec.py) after install.sh relocates the
+# plugin from examples/opencode-integration/hooks/ to ~/.config/opencode/plugins/.
+install -m 0644 "$EXAMPLE_DIR/sandbox_exec.py" "$EXECUTOR_FILE"
 # OpenCode loads the plugin as an ES module; the host plugin dir must
 # declare "type": "module" so the .js file's `import` statements resolve.
 cat > "$PACKAGE_FILE" <<'JSONEOF'
@@ -149,6 +157,7 @@ write_opencode_config
 
 echo "CubeSandbox OpenCode plugin installed:"
 echo "  plugin file: $PLUGIN_FILE"
+echo "  executor:    $EXECUTOR_FILE"
 echo "  config:      $CONFIG_FILE  (only CUBE_* keys added)"
 echo ""
 echo "Restart OpenCode for the plugin to take effect."

--- a/examples/opencode-integration/hooks/install.sh
+++ b/examples/opencode-integration/hooks/install.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+# Install or remove the CubeSandbox bash-routing plugin for OpenCode.
+#
+# OpenCode loads JavaScript plugins automatically from:
+#   - $XDG_CONFIG_HOME/opencode/plugins/        (global, default ~/.config)
+#   - .opencode/plugins/                        (project-local)
+#
+# This installer copies cubesandbox-sandbox.js into the global plugin
+# directory and writes a sanitized subset of CUBE_* settings into the
+# OpenCode config so the spawned sandbox_exec.py can authenticate against
+# CubeMaster. Provider API keys (ANTHROPIC_API_KEY, OPENAI_API_KEY, ...) are
+# never copied into the OpenCode config.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+EXAMPLE_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# XDG_CONFIG_HOME defaults to ~/.config per the spec.
+OPENCODE_CONFIG_HOME="${OPENCODE_CONFIG_HOME:-$HOME/.config/opencode}"
+PLUGIN_DIR="$OPENCODE_CONFIG_HOME/plugins"
+PLUGIN_FILE="$PLUGIN_DIR/cubesandbox-sandbox.js"
+PACKAGE_FILE="$PLUGIN_DIR/package.json"
+CONFIG_FILE="$OPENCODE_CONFIG_HOME/opencode.json"
+SOURCE_ENV="$EXAMPLE_DIR/.env.example"
+
+ALLOWED_KEYS=(
+    "CUBE_API_URL"
+    "CUBE_TEMPLATE_ID"
+    "CUBE_PROXY_NODE_IP"
+    "CUBE_PROXY_PORT_HTTP"
+    "CUBE_SANDBOX_DOMAIN"
+    "CUBE_SANDBOX_USER"
+    "CUBE_SANDBOX_TIMEOUT"
+    "CUBE_EXEC_TIMEOUT"
+)
+
+write_opencode_config() {
+    python3 - "$SOURCE_ENV" "$CONFIG_FILE" <<'PYEOF'
+import json
+import os
+import stat
+import sys
+import tempfile
+from pathlib import Path
+
+try:
+    from dotenv import dotenv_values
+except ImportError as exc:
+    raise SystemExit(
+        "python-dotenv is required; install examples/opencode-integration/requirements.txt"
+    ) from exc
+
+ALLOWED_KEYS = {
+    "CUBE_API_URL",
+    "CUBE_TEMPLATE_ID",
+    "CUBE_PROXY_NODE_IP",
+    "CUBE_PROXY_PORT_HTTP",
+    "CUBE_SANDBOX_DOMAIN",
+    "CUBE_SANDBOX_USER",
+    "CUBE_SANDBOX_TIMEOUT",
+    "CUBE_EXEC_TIMEOUT",
+}
+
+source = Path(sys.argv[1])
+destination = Path(sys.argv[2])
+values = dotenv_values(source) if source.is_file() else {}
+
+cube_settings = {
+    key: values[key]
+    for key in ALLOWED_KEYS
+    if isinstance(values.get(key), str) and values[key]
+}
+
+destination.parent.mkdir(parents=True, exist_ok=True)
+
+existing = {}
+if destination.exists() and destination.stat().st_size:
+    try:
+        existing = json.loads(destination.read_text(encoding="utf-8"))
+    except json.JSONDecodeError:
+        existing = {}
+if not isinstance(existing, dict):
+    raise SystemExit(f"{destination} must contain a JSON object")
+
+# Merge: union of CUBE_* keys wins; everything else is preserved so the
+# user keeps their MCP / provider / model settings untouched.
+existing_cube = existing.get("cubesandbox", {})
+if not isinstance(existing_cube, dict):
+    existing_cube = {}
+existing_cube.update(cube_settings)
+# Drop entries whose value resolved empty so we never serialize "" into the
+# installed config — OpenCode would forward that as a literal empty env.
+existing_cube = {k: v for k, v in existing_cube.items() if v}
+existing["cubesandbox"] = existing_cube
+
+fd, tmp_name = tempfile.mkstemp(
+    dir=destination.parent,
+    prefix=f".{destination.name}.",
+    suffix=".tmp",
+)
+temporary = Path(tmp_name)
+try:
+    os.fchmod(fd, 0o600)
+    with os.fdopen(fd, "w", encoding="utf-8") as fp:
+        json.dump(existing, fp, indent=2)
+        fp.write("\n")
+        fp.flush()
+        os.fsync(fp.fileno())
+    os.replace(temporary, destination)
+    os.chmod(destination, 0o600)
+finally:
+    with __import__("contextlib").suppress(FileNotFoundError):
+        temporary.unlink()
+PYEOF
+}
+
+if [[ "${1:-}" == "--uninstall" ]]; then
+    rm -f "$PLUGIN_FILE" "$PACKAGE_FILE"
+    echo "CubeSandbox OpenCode plugin uninstalled from $PLUGIN_DIR."
+    echo "(Your opencode.json was left intact — remove the \"cubesandbox\" key manually if desired.)"
+    exit 0
+fi
+
+if [[ $# -gt 0 ]]; then
+    echo "usage: $0 [--uninstall]" >&2
+    exit 2
+fi
+
+command -v python3 >/dev/null 2>&1 || {
+    echo "python3 is required" >&2
+    exit 1
+}
+
+mkdir -p "$PLUGIN_DIR"
+install -m 0644 "$SCRIPT_DIR/cubesandbox-sandbox.js" "$PLUGIN_FILE"
+# OpenCode loads the plugin as an ES module; the host plugin dir must
+# declare "type": "module" so the .js file's `import` statements resolve.
+cat > "$PACKAGE_FILE" <<'JSONEOF'
+{
+  "name": "opencode-cubesandbox-plugins",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Local plugin directory for OpenCode's CubeSandbox bash router. Auto-loaded by OpenCode."
+}
+JSONEOF
+write_opencode_config
+
+echo "CubeSandbox OpenCode plugin installed:"
+echo "  plugin file: $PLUGIN_FILE"
+echo "  config:      $CONFIG_FILE  (only CUBE_* keys added)"
+echo ""
+echo "Restart OpenCode for the plugin to take effect."
+echo "Uninstall with: $0 --uninstall"

--- a/examples/opencode-integration/mcp_server.py
+++ b/examples/opencode-integration/mcp_server.py
@@ -1,0 +1,340 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""CubeSandbox MCP Server for OpenCode.
+
+Exposes a small set of tools that let any MCP-capable client (Claude
+Desktop, Cursor, Windsurf, VS Code, etc.) execute untrusted code or shell
+commands inside an isolated CubeSandbox MicroVM instead of on the host.
+The same backend (`sandbox_exec.py`) handles the actual work; this file
+just adapts it to the Model Context Protocol's newline-delimited JSON-RPC
+transport on stdio.
+
+Add to your MCP client's config (Claude Desktop example shown):
+
+    {
+      "mcpServers": {
+        "cubesandbox-opencode": {
+          "command": "python3",
+          "args": [
+            "/abs/path/to/CubeSandbox/examples/opencode-integration/mcp_server.py"
+          ],
+          "env": {
+            "E2B_API_URL": "http://<cube-host>:3000",
+            "E2B_API_KEY": "<api-key>",
+            "CUBE_TEMPLATE_ID": "<template-id>"
+          }
+        }
+      }
+    }
+"""
+
+from __future__ import annotations
+
+import atexit
+import json
+import os
+import shlex
+import sys
+from typing import Any
+
+from dotenv import load_dotenv
+
+load_dotenv()
+
+# --- Configuration -----------------------------------------------------------
+
+E2B_API_URL = os.getenv("E2B_API_URL", "http://127.0.0.1:3000")
+E2B_API_KEY = os.getenv("E2B_API_KEY", "e2b_000000")
+TEMPLATE_ID = os.getenv("CUBE_TEMPLATE_ID", "")
+
+_sandbox: Any = None
+
+
+def _get_sandbox(timeout: int = 600):
+    """Lazy-create a sandbox and reuse it across tool calls until the process exits."""
+    global _sandbox
+    if _sandbox is None:
+        from e2b_code_interpreter import Sandbox
+        if not TEMPLATE_ID:
+            raise RuntimeError("CUBE_TEMPLATE_ID is not set")
+        _sandbox = Sandbox.create(TEMPLATE_ID, timeout=timeout)
+    else:
+        try:
+            _sandbox.set_timeout(timeout)
+        except Exception:
+            # The sandbox expired or was killed under us — try to clean up
+            # whatever remains before allocating a fresh one.
+            try:
+                _sandbox.kill()
+            except Exception:
+                pass
+            from e2b_code_interpreter import Sandbox
+            _sandbox = Sandbox.create(TEMPLATE_ID, timeout=timeout)
+    return _sandbox
+
+
+def _cleanup_sandbox() -> None:
+    """Destroy the cached sandbox when the MCP process exits."""
+    global _sandbox
+    sandbox, _sandbox = _sandbox, None
+    if sandbox is not None:
+        try:
+            sandbox.kill()
+        except Exception as exc:
+            print(f"Failed to clean up sandbox: {exc}", file=sys.stderr)
+
+
+atexit.register(_cleanup_sandbox)
+
+
+def run_command(cmd: str, timeout: int = 120) -> dict[str, Any]:
+    """Run a shell command inside the sandbox, capturing exit code / stdout / stderr."""
+    from e2b.sandbox.commands.command_handle import CommandExitException
+    try:
+        result = _get_sandbox().commands.run(cmd, timeout=timeout)
+        return {
+            "exit_code": result.exit_code,
+            "stdout": result.stdout.strip() if result.stdout else "",
+            "stderr": result.stderr.strip() if result.stderr else "",
+        }
+    except CommandExitException as exc:
+        return {
+            "exit_code": getattr(exc, "exit_code", 1),
+            "stdout": "",
+            "stderr": str(exc),
+        }
+
+
+def _format_command_result(result: dict[str, Any]) -> str:
+    """Render a command result for an MCP tool response.
+
+    The exit code is always included so the LLM can branch on success /
+    failure without having to parse free-form text. stdout / stderr are
+    rendered only when non-empty.
+    """
+    sections = [f"exit_code: {result['exit_code']}"]
+    if result["stdout"]:
+        sections.append(f"stdout:\n{result['stdout']}")
+    if result["stderr"]:
+        sections.append(f"stderr:\n{result['stderr']}")
+    if len(sections) == 1:
+        sections.append("(no output)")
+    return "\n".join(sections)
+
+
+# --- Tool definitions --------------------------------------------------------
+
+TOOLS: list[dict[str, Any]] = [
+    {
+        "name": "sandbox_run_code",
+        "description": (
+            "Execute Python code in an isolated CubeSandbox MicroVM. Use this for "
+            "running untrusted code, testing generated scripts, or installing "
+            "packages safely."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "code": {
+                    "type": "string",
+                    "description": "Python code to execute in the sandbox",
+                },
+                "timeout": {
+                    "type": "integer",
+                    "description": "Execution timeout in seconds (default 120)",
+                    "default": 120,
+                },
+            },
+            "required": ["code"],
+        },
+    },
+    {
+        "name": "sandbox_run_command",
+        "description": (
+            "Execute a shell command in an isolated CubeSandbox MicroVM. Use this "
+            "to safely test shell commands, explore file systems, or run build "
+            "tools without affecting the host."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "command": {
+                    "type": "string",
+                    "description": "Shell command to execute in the sandbox",
+                },
+                "timeout": {
+                    "type": "integer",
+                    "description": "Execution timeout in seconds (default 120)",
+                    "default": 120,
+                },
+            },
+            "required": ["command"],
+        },
+    },
+    {
+        "name": "sandbox_write_file",
+        "description": "Write content to a file inside the sandbox.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "string",
+                    "description": "Absolute path inside the sandbox (e.g. /tmp/script.py)",
+                },
+                "content": {"type": "string", "description": "File content to write"},
+            },
+            "required": ["path", "content"],
+        },
+    },
+    {
+        "name": "sandbox_read_file",
+        "description": "Read a file's content from inside the sandbox.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "path": {"type": "string", "description": "Absolute path inside the sandbox"},
+            },
+            "required": ["path"],
+        },
+    },
+    {
+        "name": "sandbox_reset",
+        "description": (
+            "Destroy the current sandbox and create a fresh one. Use between "
+            "unrelated tasks to get a clean environment."
+        ),
+        "inputSchema": {"type": "object", "properties": {}},
+    },
+]
+
+
+# --- JSON-RPC handler --------------------------------------------------------
+
+def handle_request(request: dict[str, Any]) -> dict[str, Any] | None:
+    method = request.get("method", "")
+    req_id = request.get("id")
+
+    if method == "initialize":
+        return {
+            "jsonrpc": "2.0",
+            "id": req_id,
+            "result": {
+                "protocolVersion": "2024-11-05",
+                "capabilities": {"tools": {}},
+                "serverInfo": {
+                    "name": "cubesandbox-opencode-mcp",
+                    "version": "1.0.0",
+                },
+            },
+        }
+
+    if method == "tools/list":
+        return {"jsonrpc": "2.0", "id": req_id, "result": {"tools": TOOLS}}
+
+    if method == "tools/call":
+        tool_name = request["params"]["name"]
+        arguments = request["params"].get("arguments", {})
+        text = ""
+        is_error = False
+        try:
+            if tool_name == "sandbox_run_code":
+                code = arguments["code"]
+                timeout = arguments.get("timeout", 120)
+                result = run_command(f"python3 -c {shlex.quote(code)}", timeout=timeout)
+                text = _format_command_result(result)
+                is_error = result["exit_code"] != 0
+
+            elif tool_name == "sandbox_run_command":
+                cmd = arguments["command"]
+                timeout = arguments.get("timeout", 120)
+                result = run_command(cmd, timeout=timeout)
+                text = _format_command_result(result)
+                is_error = result["exit_code"] != 0
+
+            elif tool_name == "sandbox_write_file":
+                path = arguments["path"]
+                content = arguments["content"]
+                _get_sandbox().files.write(path, content)
+                text = f"Written {len(content)} bytes to {path}"
+
+            elif tool_name == "sandbox_read_file":
+                path = arguments["path"]
+                content = _get_sandbox().files.read(path)
+                text = content if isinstance(content, str) else content.decode(
+                    "utf-8", errors="replace"
+                )
+
+            elif tool_name == "sandbox_reset":
+                _cleanup_sandbox()
+                text = "Sandbox destroyed. A new one will be created on next use."
+
+            else:
+                text = f"Unknown tool: {tool_name}"
+                is_error = True
+
+        except Exception as exc:
+            import traceback
+            traceback.print_exc(file=sys.stderr)
+            text = f"Error: {exc}"
+            is_error = True
+
+        return {
+            "jsonrpc": "2.0",
+            "id": req_id,
+            "result": {
+                "content": [{"type": "text", "text": text}],
+                "isError": is_error,
+            },
+        }
+
+    if method == "notifications/initialized":
+        # Notifications get no response; returning None lets the main loop
+        # skip the write rather than emit a JSON-RPC reply for them.
+        return None
+
+    return {
+        "jsonrpc": "2.0",
+        "id": req_id,
+        "error": {"code": -32601, "message": f"Method not found: {method}"},
+    }
+
+
+# --- Main loop ---------------------------------------------------------------
+
+def _read_mcp_message() -> dict[str, Any] | None:
+    """Read one newline-delimited JSON-RPC message from MCP stdio.
+
+    Raises EOFError when stdin is exhausted (client disconnected). Malformed
+    lines return None so the loop can skip them without hanging.
+    """
+    line = sys.stdin.readline()
+    if not line:
+        raise EOFError()
+    try:
+        return json.loads(line)
+    except json.JSONDecodeError:
+        return None
+
+
+def main() -> None:
+    """Run the MCP server on stdio (newline-delimited JSON-RPC)."""
+    try:
+        while True:
+            try:
+                request = _read_mcp_message()
+            except EOFError:
+                break
+            if request is None:
+                continue
+            response = handle_request(request)
+            if response is not None:
+                sys.stdout.write(json.dumps(response) + "\n")
+                sys.stdout.flush()
+    finally:
+        _cleanup_sandbox()
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/opencode-integration/network_policy.py
+++ b/examples/opencode-integration/network_policy.py
@@ -1,0 +1,258 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Restrict OpenCode's egress to the LLM API and inject the key on the wire.
+
+This is the recommended production ("credential vault") pattern:
+
+* Default-deny egress — the sandbox is created with ``allow_internet_access=False``
+  and an ``allow_out`` list containing only the LLM API host, so every other
+  destination is dropped before it can leave the sandbox.
+* The provider auth header is attached by CubeEgress via ``inject`` rules
+  (native ``cubesandbox`` SDK; see docs/guide/security-proxy.md), so the real
+  key rides the wire and never enters the sandbox VM. The agent inside only
+  sees a placeholder value.
+
+Run:
+    python network_policy.py
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import shlex
+import sys
+
+from cubesandbox import Sandbox, Rule, Match, Action, Inject
+
+from _opencode_common import ensure_success, positive_int, run_command, sandbox_identifier
+from env_utils import (
+    _env_positive_int,
+    build_opencode_env,
+    opencode_command,
+    opencode_model,
+    opencode_workspace,
+    llm_host,
+    load_local_dotenv,
+    provider,
+    provider_inject,
+    provider_key_name,
+    require_provider_key,
+    required,
+    shell_join,
+)
+
+PLACEHOLDER_KEY = "cube-egress-managed-placeholder"
+
+# OpenCode ships as a Node.js bundle that bundles its own CA store and ignores
+# the system trust store. On the vault path CubeEgress terminates TLS to inject
+# the credential, so Node must trust the CubeEgress root CA or every LLM call
+# fails with "unable to verify the first certificate". Point NODE_EXTRA_CA_CERTS
+# at a bundle that includes it; the CubeSandbox base image installs the CA into
+# the system bundle below.
+DEFAULT_NODE_CA_BUNDLE = "/etc/ssl/certs/ca-certificates.crt"
+
+DEFAULT_PROMPT = (
+    "Reply with a single short sentence confirming you can reach the LLM API, "
+    "then write that sentence to {workspace}/egress_check.md."
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Run OpenCode under a default-deny egress policy with on-the-wire key injection."
+    )
+    parser.add_argument(
+        "--template",
+        default=os.environ.get("CUBE_TEMPLATE_ID"),
+        help="CubeSandbox template ID. Defaults to CUBE_TEMPLATE_ID.",
+    )
+    parser.add_argument(
+        "--host",
+        default=None,
+        help="LLM API host to allow. Defaults to OPENCODE_LLM_HOST or the provider default.",
+    )
+    parser.add_argument(
+        "--workspace",
+        default=opencode_workspace(),
+        help="Working directory inside the sandbox. Defaults to OPENCODE_WORKSPACE.",
+    )
+    parser.add_argument(
+        "--prompt",
+        default=None,
+        help="Prompt passed to OpenCode. Defaults to a small egress reachability check.",
+    )
+    parser.add_argument(
+        "--model",
+        default=None,
+        help="Model id for the active provider. Defaults to OPENCODE_MODEL.",
+    )
+    parser.add_argument(
+        "--sandbox-timeout",
+        type=positive_int,
+        default=_env_positive_int("OPENCODE_SANDBOX_TIMEOUT", 1800),
+        help="Sandbox lifetime in seconds. Defaults to OPENCODE_SANDBOX_TIMEOUT or 1800.",
+    )
+    parser.add_argument(
+        "--exec-timeout",
+        type=positive_int,
+        default=_env_positive_int("OPENCODE_AGENT_EXEC_TIMEOUT", 900),
+        help="OpenCode command timeout in seconds. Defaults to OPENCODE_AGENT_EXEC_TIMEOUT or 900.",
+    )
+    parser.add_argument(
+        "--skip-agent",
+        action="store_true",
+        help="Only show the egress checks; skip the actual OpenCode run.",
+    )
+    args = parser.parse_args()
+    if args.prompt is None:
+        args.prompt = DEFAULT_PROMPT.format(workspace=args.workspace)
+    return args
+
+
+def build_rules(provider_name: str, host: str, secret: str) -> list[Rule]:
+    # Canonical CubeEgress rule (see docs/guide/security-proxy.md): allow the LLM
+    # host and attach the provider auth header(s) on the wire via ``inject`` so
+    # the real key never enters the sandbox VM. Anything matching no rule under
+    # default-deny is rejected by CubeEgress with 403.
+    return [
+        Rule(
+            name=f"allow_{provider_name}_llm",
+            match=Match(scheme="https", sni=host, host=host),
+            action=Action(
+                allow=True,
+                audit="metadata",
+                inject=[Inject(**spec) for spec in provider_inject(provider_name, secret)],
+            ),
+        )
+    ]
+
+
+def create_sandbox(template_id: str, rules: list[Rule], timeout: int) -> Sandbox:
+    # allow_internet_access=False makes egress default-deny at L3/L4; the LLM host
+    # named in the rules is auto-allowed and its requests are injected at L7 by
+    # CubeEgress. Never silently drop this flag, or full egress is re-enabled.
+    return Sandbox.create(
+        template=template_id,
+        allow_internet_access=False,
+        network={"rules": rules},
+        timeout=timeout,
+    )
+
+
+def show_key_not_in_vm(sandbox: Sandbox, key_name: str) -> None:
+    command = f"printenv {shlex.quote(key_name)} || echo '<unset>'"
+    result = run_command(sandbox, command, timeout=30)
+    ensure_success(result, "read provider key inside sandbox")
+    value = getattr(result, "stdout", "").strip()
+    print(f"In-VM {key_name}: {value!r} (real secret stays in CubeEgress)")
+
+
+def show_non_llm_blocked(sandbox: Sandbox) -> None:
+    command = (
+        "curl -s -o /dev/null -w '%{http_code}' --max-time 8 https://example.com "
+        "|| echo blocked"
+    )
+    result = run_command(sandbox, command, timeout=30)
+    status = getattr(result, "stdout", "").strip()
+    print(
+        f"Non-LLM host (example.com) response: {status or 'blocked'} "
+        "(expected 403/blocked under default-deny)"
+    )
+
+
+def run_agent(
+    sandbox: Sandbox,
+    args: argparse.Namespace,
+    envs: dict[str, str],
+    model: str,
+):
+    command = shell_join(
+        f"cd {shlex.quote(args.workspace)}",
+        opencode_command(
+            args.prompt,
+            dangerously_skip_permissions=True,
+            model=model,
+        ),
+    )
+    return run_command(
+        sandbox,
+        command,
+        cwd=args.workspace,
+        envs=envs,
+        timeout=args.exec_timeout,
+        stream=True,
+    )
+
+
+def main() -> int:
+    load_local_dotenv()
+    args = parse_args()
+
+    template_id = args.template or required("CUBE_TEMPLATE_ID")
+    required("E2B_API_URL")
+    required("E2B_API_KEY")
+
+    provider_name = provider()
+    secret = require_provider_key()
+    host = args.host or llm_host()
+    if not host:
+        raise SystemExit(
+            "Could not resolve the LLM host. Set OPENCODE_LLM_HOST in your .env or pass --host."
+        )
+
+    rules = build_rules(provider_name, host, secret)
+
+    sandbox_env = build_opencode_env(include_secrets=False)
+    key_name = provider_key_name()
+    # Pick the same env-var OpenCode itself would use to read the key, so the
+    # CLI does not have to be reconfigured. The placeholder satisfies the SDK's
+    # "non-empty" check; CubeEgress replaces the header on the wire.
+    sandbox_env[key_name] = PLACEHOLDER_KEY
+    # ``--dangerously-skip-permissions`` is added by ``opencode_command`` so
+    # we don't forward any permission env var here.
+    # Let the Node-based OpenCode CLI trust the CubeEgress interception CA
+    # (see note on DEFAULT_NODE_CA_BUNDLE); without this the vault path fails
+    # TLS. Override via OPENCODE_NODE_EXTRA_CA_CERTS if the CA lives elsewhere.
+    sandbox_env["NODE_EXTRA_CA_CERTS"] = os.environ.get(
+        "OPENCODE_NODE_EXTRA_CA_CERTS", DEFAULT_NODE_CA_BUNDLE
+    )
+
+    print(f"Provider: {provider_name}")
+    print(f"Allowed LLM host (default-deny for everything else): {host}")
+    print(f"Creating sandbox from template: {template_id}")
+
+    sandbox = create_sandbox(template_id, rules, args.sandbox_timeout)
+    sandbox_id = sandbox_identifier(sandbox)
+    result = None
+    try:
+        print(f"Sandbox ready: {sandbox_id}\n")
+
+        show_key_not_in_vm(sandbox, key_name)
+        show_non_llm_blocked(sandbox)
+
+        if args.skip_agent:
+            print("\n--skip-agent set: not invoking OpenCode.")
+            return 0
+
+        model = args.model or opencode_model()
+        print("\nRunning OpenCode through the injected egress path...\n")
+        result = run_agent(sandbox, args, sandbox_env, model)
+        exit_code = getattr(result, "exit_code", None)
+        print(f"\nOpenCode exit code: {exit_code}")
+        return 0 if exit_code is None else int(exit_code)
+    finally:
+        try:
+            sandbox.kill()
+            print(f"\nSandbox {sandbox_id} killed.")
+        except Exception as exc:  # noqa: BLE001 - cleanup must not mask real errors
+            print(
+                f"Warning: failed to kill sandbox {sandbox_id}: {exc}",
+                file=sys.stderr,
+            )
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/examples/opencode-integration/network_policy.py
+++ b/examples/opencode-integration/network_policy.py
@@ -31,6 +31,7 @@ from _opencode_common import ensure_success, positive_int, run_command, sandbox_
 from env_utils import (
     _env_positive_int,
     build_opencode_env,
+    cube_required,
     opencode_command,
     opencode_model,
     opencode_workspace,
@@ -192,8 +193,8 @@ def main() -> int:
     args = parse_args()
 
     template_id = args.template or required("CUBE_TEMPLATE_ID")
-    required("E2B_API_URL")
-    required("E2B_API_KEY")
+    cube_required("CUBE_API_URL", "E2B_API_URL")
+    cube_required("CUBE_API_KEY", "E2B_API_KEY")
 
     provider_name = provider()
     secret = require_provider_key()

--- a/examples/opencode-integration/requirements.txt
+++ b/examples/opencode-integration/requirements.txt
@@ -1,0 +1,3 @@
+e2b>=2.4.1
+cubesandbox>=0.3.0
+python-dotenv>=1.0.0

--- a/examples/opencode-integration/resume_opencode.py
+++ b/examples/opencode-integration/resume_opencode.py
@@ -28,6 +28,7 @@ from _opencode_common import ensure_success, positive_int, run_command, sandbox_
 from env_utils import (
     _env_positive_int,
     build_opencode_env,
+    cube_required,
     opencode_command,
     opencode_data_dir,
     opencode_model,
@@ -155,8 +156,8 @@ def main() -> int:
     args = parse_args()
 
     template_id = args.template or required("CUBE_TEMPLATE_ID")
-    required("E2B_API_URL")
-    required("E2B_API_KEY")
+    cube_required("CUBE_API_URL", "E2B_API_URL")
+    cube_required("CUBE_API_KEY", "E2B_API_KEY")
     require_provider_key()
 
     opencode_env = build_opencode_env()

--- a/examples/opencode-integration/resume_opencode.py
+++ b/examples/opencode-integration/resume_opencode.py
@@ -1,0 +1,236 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Demonstrate OpenCode session persistence across a CubeSandbox pause/resume.
+
+Turn 1 asks OpenCode to write ``/workspace/plan.md``, then the sandbox is paused.
+Turn 2 reconnects to the same sandbox, verifies both ``/workspace`` and the
+OpenCode state directory survived the snapshot, and asks OpenCode to continue
+the work via ``-c`` (continue most recent session).
+
+Lifecycle note: this script deliberately avoids ``with Sandbox.create(...)``.
+A context manager kills the sandbox on ``__exit__``, which would defeat the
+pause. The lifecycle is managed manually with try/finally so the sandbox stays
+alive between turns and is only killed at the very end.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import shlex
+import sys
+
+from e2b import Sandbox
+
+from _opencode_common import ensure_success, positive_int, run_command, sandbox_identifier
+from env_utils import (
+    _env_positive_int,
+    build_opencode_env,
+    opencode_command,
+    opencode_data_dir,
+    opencode_model,
+    opencode_workspace,
+    load_local_dotenv,
+    require_provider_key,
+    required,
+    shell_join,
+)
+
+TURN_1_PROMPT = (
+    "Create {workspace}/plan.md containing a numbered 3-step plan for building a "
+    "small Python CLI that prints the current time. Only write the plan file."
+)
+TURN_2_PROMPT = (
+    "Read {workspace}/plan.md and implement step 1 by creating "
+    "{workspace}/progress.md that records which step you completed and why. "
+    "Do not delete plan.md."
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Demonstrate OpenCode session persistence across a CubeSandbox pause/resume."
+    )
+    parser.add_argument(
+        "--template",
+        default=os.environ.get("CUBE_TEMPLATE_ID"),
+        help="CubeSandbox template ID. Defaults to CUBE_TEMPLATE_ID.",
+    )
+    parser.add_argument(
+        "--workspace",
+        default=opencode_workspace(),
+        help="Working directory inside the sandbox. Defaults to OPENCODE_WORKSPACE.",
+    )
+    parser.add_argument(
+        "--model",
+        default=None,
+        help="Model id for the active provider. Defaults to OPENCODE_MODEL.",
+    )
+    parser.add_argument(
+        "--opencode-data-dir",
+        default=opencode_data_dir(),
+        help="OpenCode data directory checked for survival after resume.",
+    )
+    parser.add_argument(
+        "--sandbox-timeout",
+        type=positive_int,
+        default=_env_positive_int("OPENCODE_SANDBOX_TIMEOUT", 1800),
+        help="Sandbox lifetime in seconds. Defaults to OPENCODE_SANDBOX_TIMEOUT or 1800.",
+    )
+    parser.add_argument(
+        "--exec-timeout",
+        type=positive_int,
+        default=_env_positive_int("OPENCODE_AGENT_EXEC_TIMEOUT", 900),
+        help="OpenCode command timeout in seconds. Defaults to OPENCODE_AGENT_EXEC_TIMEOUT or 900.",
+    )
+    return parser.parse_args()
+
+
+def run_turn(
+    sandbox: Sandbox,
+    workspace: str,
+    prompt: str,
+    exec_timeout: int,
+    envs: dict[str, str],
+    model: str,
+    *,
+    continue_session: bool = False,
+):
+    command = shell_join(
+        f"cd {shlex.quote(workspace)}",
+        opencode_command(
+            prompt,
+            dangerously_skip_permissions=True,
+            model=model,
+            continue_session=continue_session,
+        ),
+    )
+    return run_command(
+        sandbox,
+        command,
+        cwd=workspace,
+        envs=envs,
+        timeout=exec_timeout,
+        stream=True,
+    )
+
+
+def assert_state_survived(sandbox: Sandbox, workspace: str, data_dir: str) -> None:
+    quoted_workspace = shlex.quote(workspace)
+    quoted_state = shlex.quote(data_dir)
+    command = shell_join(
+        f"test -f {quoted_workspace}/plan.md",
+        f"test -d {quoted_state}",
+        # OpenCode persists session messages under ``<data>/storage/`` and
+        # provider auth under ``<data>/auth.json``. Confirm at least one
+        # of those files survives — that is what ``-c`` and ``-s <id>``
+        # consult when resuming.
+        f"test -n \"$(ls -1 {quoted_state}/storage 2>/dev/null)\"",
+        "printf '\\n--- plan.md (survived pause/resume) ---\\n'",
+        f"cat {quoted_workspace}/plan.md",
+    )
+    result = run_command(sandbox, command, timeout=60)
+    ensure_success(result, "verify /workspace and OpenCode state survived pause/resume")
+    if getattr(result, "stdout", ""):
+        print(result.stdout)
+
+
+def show_final_workspace(sandbox: Sandbox, workspace: str) -> None:
+    quoted_workspace = shlex.quote(workspace)
+    command = shell_join(
+        f"ls -la {quoted_workspace}",
+        f"test ! -f {quoted_workspace}/progress.md || "
+        f"(printf '\\n--- progress.md ---\\n' && cat {quoted_workspace}/progress.md)",
+    )
+    result = run_command(sandbox, command, timeout=60)
+    ensure_success(result, "inspect final workspace")
+    if getattr(result, "stdout", ""):
+        print(result.stdout)
+
+
+def main() -> int:
+    load_local_dotenv()
+    args = parse_args()
+
+    template_id = args.template or required("CUBE_TEMPLATE_ID")
+    required("E2B_API_URL")
+    required("E2B_API_KEY")
+    require_provider_key()
+
+    opencode_env = build_opencode_env()
+    model = args.model or opencode_model()
+    turn_1_prompt = TURN_1_PROMPT.format(workspace=args.workspace)
+    turn_2_prompt = TURN_2_PROMPT.format(workspace=args.workspace)
+
+    print(f"Creating sandbox from template: {template_id}")
+    # SECURITY: like run_opencode.py this demo keeps egress open and injects the
+    # key per command. The pause() snapshot also captures the in-VM env and any
+    # credentials OpenCode caches under /workspace/.opencode/data/auth.json,
+    # widening exposure — for shared clusters prefer the default-deny + vault
+    # pattern in network_policy.py.
+    sandbox = Sandbox.create(template=template_id, timeout=args.sandbox_timeout)
+    sandbox_id = sandbox_identifier(sandbox)
+
+    try:
+        print(f"Sandbox ready: {sandbox_id}")
+
+        version_result = run_command(sandbox, "opencode --version", timeout=60)
+        ensure_success(version_result, "check OpenCode version")
+        print(f"OpenCode version: {getattr(version_result, 'stdout', '').strip()}")
+
+        print("\n=== Turn 1: create plan.md ===\n")
+        result_1 = run_turn(
+            sandbox, args.workspace, turn_1_prompt, args.exec_timeout, opencode_env, model
+        )
+        ensure_success(result_1, "run OpenCode turn 1")
+
+        print(f"\nPausing sandbox {sandbox_id} (snapshotting VM + rootfs)...")
+        paused_id = sandbox.pause()
+        # The sandbox_id is stable across pause. Some SDK versions return the
+        # resume handle as a string; others return a bool (success). Only adopt
+        # a string handle, otherwise keep the original id for connect().
+        if isinstance(paused_id, str) and paused_id:
+            sandbox_id = paused_id
+        print(f"Paused. Resume handle: {sandbox_id}")
+
+        print(f"\nReconnecting to {sandbox_id}...")
+        sandbox = Sandbox.connect(sandbox_id=sandbox_id)
+        print("Reconnected after resume.")
+
+        print("\n=== Verifying persistence after resume ===\n")
+        assert_state_survived(sandbox, args.workspace, args.opencode_data_dir)
+
+        print("\n=== Turn 2: continue the work ===\n")
+        # ``-c`` picks the most recent session OpenCode recorded under
+        # $OPENCODE_DATA_DIR/storage/, which survived the snapshot.
+        result_2 = run_turn(
+            sandbox,
+            args.workspace,
+            turn_2_prompt,
+            args.exec_timeout,
+            opencode_env,
+            model,
+            continue_session=True,
+        )
+        ensure_success(result_2, "run OpenCode turn 2")
+
+        show_final_workspace(sandbox, args.workspace)
+
+        exit_code = getattr(result_2, "exit_code", 0)
+        return 0 if exit_code is None else int(exit_code)
+    finally:
+        if sandbox is not None:
+            try:
+                sandbox.kill()
+                print(f"\nSandbox {sandbox_id} killed.")
+            except Exception as exc:  # noqa: BLE001 - cleanup must not mask real errors
+                print(
+                    f"Warning: failed to kill sandbox {sandbox_id}: {exc}",
+                    file=sys.stderr,
+                )
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/examples/opencode-integration/run_opencode.py
+++ b/examples/opencode-integration/run_opencode.py
@@ -1,0 +1,215 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Run a one-shot OpenCode task inside a CubeSandbox.
+
+The key is forwarded per-command via ``sandbox.commands.run(..., envs=...)``,
+so it lives only for the lifetime of that exec call — never written to a
+persistent file inside the VM.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import shlex
+import sys
+from typing import Any
+
+from e2b import Sandbox
+
+from _opencode_common import ensure_success, positive_int, run_command, sandbox_identifier
+from env_utils import (
+    _env_positive_int,
+    build_opencode_env,
+    opencode_command,
+    opencode_model,
+    opencode_workspace,
+    load_local_dotenv,
+    require_provider_key,
+    required,
+    shell_join,
+)
+
+DEFAULT_PROMPT_TEMPLATE = (
+    "Inspect the project in {workspace}, run python3 app.py, and write a "
+    "concise summary of the result to {workspace}/result.md."
+)
+
+
+def default_prompt(workspace: str) -> str:
+    return DEFAULT_PROMPT_TEMPLATE.format(workspace=workspace)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Run a one-shot OpenCode task inside CubeSandbox."
+    )
+    parser.add_argument(
+        "--template",
+        default=os.environ.get("CUBE_TEMPLATE_ID"),
+        help="CubeSandbox template ID. Defaults to CUBE_TEMPLATE_ID.",
+    )
+    parser.add_argument(
+        "--prompt",
+        default=None,
+        help="Prompt passed to OpenCode. Defaults to a small workspace smoke task.",
+    )
+    parser.add_argument(
+        "--workspace",
+        default=opencode_workspace(),
+        help="Working directory inside the sandbox. Defaults to OPENCODE_WORKSPACE.",
+    )
+    parser.add_argument(
+        "--model",
+        default=None,
+        help="Model id for the active provider. Defaults to OPENCODE_MODEL.",
+    )
+    parser.add_argument(
+        "--approve",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help=(
+            "Auto-approve every tool call via opencode's "
+            "--dangerously-skip-permissions flag. Required for any non-interactive "
+            "run that touches files or commands. Defaults to enabled; pass --no-approve "
+            "to let OpenCode prompt for permission (the exec channel cannot answer it, "
+            "so this will hang — only use --no-approve if you've tightened the tool "
+            "allow-list via opencode.json)."
+        ),
+    )
+    parser.add_argument(
+        "--sandbox-timeout",
+        type=positive_int,
+        # Resolve the env-var through positive_int too so
+        # OPENCODE_SANDBOX_TIMEOUT=0 fails the same way as ``--sandbox-timeout 0``
+        # (a bare ``int_env(...)`` default would skip that check and let a
+        # zero-value env var reach the SDK, which then creates a sandbox with
+        # no lifetime).
+        default=_env_positive_int("OPENCODE_SANDBOX_TIMEOUT", 1800),
+        help="Sandbox lifetime in seconds. Defaults to OPENCODE_SANDBOX_TIMEOUT or 1800.",
+    )
+    parser.add_argument(
+        "--exec-timeout",
+        type=positive_int,
+        default=_env_positive_int("OPENCODE_AGENT_EXEC_TIMEOUT", 900),
+        help="OpenCode command timeout in seconds. Defaults to OPENCODE_AGENT_EXEC_TIMEOUT or 900.",
+    )
+    parser.add_argument(
+        "--no-seed",
+        action="store_true",
+        help="Skip writing the demo files into the sandbox workspace.",
+    )
+    args = parser.parse_args()
+    if args.prompt is None:
+        args.prompt = default_prompt(args.workspace)
+    return args
+
+
+def seed_project(sandbox: Sandbox, workspace: str, timeout: int) -> None:
+    quoted_workspace = shlex.quote(workspace)
+    command = f"""mkdir -p {quoted_workspace}
+cat > {quoted_workspace}/README.md <<'EOF'
+# CubeSandbox OpenCode Smoke Project
+
+This tiny project exists so the OpenCode coding agent has a deterministic task to run.
+EOF
+cat > {quoted_workspace}/app.py <<'EOF'
+def main() -> None:
+    print("hello from CubeSandbox + OpenCode")
+
+
+if __name__ == "__main__":
+    main()
+EOF
+"""
+    result = run_command(sandbox, command, timeout=timeout)
+    ensure_success(result, "seed workspace")
+
+
+def print_result_summary(result: Any) -> None:
+    exit_code = getattr(result, "exit_code", None)
+    stderr = getattr(result, "stderr", "")
+
+    print(f"\nOpenCode exit code: {exit_code}")
+    if stderr:
+        print("\nCaptured stderr:", file=sys.stderr)
+        print(stderr, file=sys.stderr)
+
+
+def show_workspace_result(sandbox: Sandbox, workspace: str, timeout: int) -> None:
+    quoted_workspace = shlex.quote(workspace)
+    command = shell_join(
+        f"ls -la {quoted_workspace}",
+        f"test ! -f {quoted_workspace}/result.md || "
+        f"(printf '\\n--- result.md ---\\n' && cat {quoted_workspace}/result.md)",
+    )
+    result = run_command(sandbox, command, timeout=timeout)
+    ensure_success(result, "inspect workspace")
+    if getattr(result, "stdout", ""):
+        print(result.stdout)
+
+
+def main() -> int:
+    load_local_dotenv()
+    args = parse_args()
+
+    template_id = args.template or required("CUBE_TEMPLATE_ID")
+    required("E2B_API_URL")
+    required("E2B_API_KEY")
+    require_provider_key()
+
+    opencode_env = build_opencode_env()
+    model = args.model or opencode_model()
+    # ``--dangerously-skip-permissions`` is added by ``opencode_command`` when
+    # ``args.approve`` is True. No env var is needed; OpenCode 1.17+ recognizes
+    # the flag directly and translates it into the same bypass the older
+    # ``OPENCODE_PERMISSION='{"*":"allow"}'`` env var provided.
+    command = shell_join(
+        f"cd {shlex.quote(args.workspace)}",
+        opencode_command(
+            args.prompt,
+            dangerously_skip_permissions=args.approve,
+            model=model,
+        ),
+    )
+
+    print(f"Creating sandbox from template: {template_id}")
+    result = None
+    # SECURITY: this direct-key demo keeps egress open (allow_internet_access
+    # defaults to True) for simplicity, and injects the provider key per command
+    # via envs=. A compromised agent with open egress could exfiltrate that key.
+    # For shared/production use prefer network_policy.py, which pairs default-deny
+    # egress with the CubeEgress credential vault (the key never enters the VM).
+    with Sandbox.create(template=template_id, timeout=args.sandbox_timeout) as sandbox:
+        sandbox_id = sandbox_identifier(sandbox)
+        print(f"Sandbox ready: {sandbox_id}")
+
+        version_result = run_command(sandbox, "opencode --version", timeout=60)
+        ensure_success(version_result, "check OpenCode version")
+        print(f"OpenCode version: {getattr(version_result, 'stdout', '').strip()}")
+
+        if not args.no_seed:
+            seed_project(sandbox, args.workspace, timeout=60)
+            print(f"Seeded demo project in {args.workspace}")
+
+        print("\nRunning OpenCode task...\n")
+        result = run_command(
+            sandbox,
+            command,
+            cwd=args.workspace,
+            envs=opencode_env,
+            timeout=args.exec_timeout,
+            stream=True,
+        )
+
+        print_result_summary(result)
+        show_workspace_result(sandbox, args.workspace, timeout=60)
+
+    exit_code = getattr(result, "exit_code", 1)
+    return 0 if exit_code is None else int(exit_code)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/examples/opencode-integration/run_opencode.py
+++ b/examples/opencode-integration/run_opencode.py
@@ -23,6 +23,7 @@ from _opencode_common import ensure_success, positive_int, run_command, sandbox_
 from env_utils import (
     _env_positive_int,
     build_opencode_env,
+    cube_required,
     opencode_command,
     opencode_model,
     opencode_workspace,
@@ -156,8 +157,8 @@ def main() -> int:
     args = parse_args()
 
     template_id = args.template or required("CUBE_TEMPLATE_ID")
-    required("E2B_API_URL")
-    required("E2B_API_KEY")
+    cube_required("CUBE_API_URL", "E2B_API_URL")
+    cube_required("CUBE_API_KEY", "E2B_API_KEY")
     require_provider_key()
 
     opencode_env = build_opencode_env()

--- a/examples/opencode-integration/sandbox_exec.py
+++ b/examples/opencode-integration/sandbox_exec.py
@@ -38,8 +38,11 @@ load_dotenv()
 
 # --- Configuration -----------------------------------------------------------
 
-E2B_API_URL = os.getenv("E2B_API_URL", "http://127.0.0.1:3000")
-E2B_API_KEY = os.getenv("E2B_API_KEY", "e2b_000000")
+# CUBE_API_URL / CUBE_API_KEY are the canonical names (documented in .env.example).
+# E2B_API_URL / E2B_API_KEY are accepted as legacy aliases so existing deployments
+# that only set the E2B_ names continue to work without changes.
+E2B_API_URL = os.getenv("CUBE_API_URL") or os.getenv("E2B_API_URL", "http://127.0.0.1:3000")
+E2B_API_KEY = os.getenv("CUBE_API_KEY") or os.getenv("E2B_API_KEY", "e2b_000000")
 TEMPLATE_ID = os.getenv("CUBE_TEMPLATE_ID", "")
 
 # The session file lives under gettempdir() so `mktemp`/`/tmp` rotations can

--- a/examples/opencode-integration/sandbox_exec.py
+++ b/examples/opencode-integration/sandbox_exec.py
@@ -1,0 +1,255 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Sandbox execution backend for OpenCode.
+
+OpenCode itself runs on the HOST (or inside an outer sandbox) and calls this
+script whenever it needs to execute untrusted code or shell commands inside
+an isolated CubeSandbox MicroVM. The pattern mirrors the same idea behind
+Claude Code's Bash hook or Codex's sandbox backend — keep the LLM agent
+outside the danger zone, route every executable action through a fresh,
+disposable VM.
+
+Usage from a Python orchestrator or a shell:
+
+    python sandbox_exec.py --code "print(1+1)"
+    python sandbox_exec.py --file /path/to/script.py
+    python sandbox_exec.py --cmd "ls -la /workspace"
+    python sandbox_exec.py --pip requests --code "import requests; print(requests.__version__)"
+    python sandbox_exec.py --keep-alive --code "state = 42"     # reuse on next call
+    python sandbox_exec.py --reset --session session-id          # force a fresh one
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import shlex
+import stat
+import sys
+import tempfile
+from pathlib import Path
+
+from dotenv import load_dotenv
+from e2b_code_interpreter import Sandbox
+
+load_dotenv()
+
+# --- Configuration -----------------------------------------------------------
+
+E2B_API_URL = os.getenv("E2B_API_URL", "http://127.0.0.1:3000")
+E2B_API_KEY = os.getenv("E2B_API_KEY", "e2b_000000")
+TEMPLATE_ID = os.getenv("CUBE_TEMPLATE_ID", "")
+
+# The session file lives under gettempdir() so `mktemp`/`/tmp` rotations can
+# reclaim it, but is scoped to the invoking UID and locked down with 0600 so
+# other users on a shared host cannot hijack `Sandbox.connect()` on the next
+# invocation. The O_NOFOLLOW + S_ISREG double-check guards against symlink
+# races that would otherwise let an attacker point us at an arbitrary file
+# before the write happens.
+SESSION_FILE = Path(tempfile.gettempdir()) / f"cubesandbox_opencode_session_{os.getuid()}"
+
+
+def _write_session(sandbox_id: str) -> None:
+    flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    fd = os.open(SESSION_FILE, flags, 0o600)
+    with os.fdopen(fd, "w") as fp:
+        if not stat.S_ISREG(os.fstat(fp.fileno()).st_mode):
+            raise OSError(f"unsafe session file: {SESSION_FILE}")
+        # Re-affirm 0600 in case the file already existed with lax perms.
+        os.fchmod(fp.fileno(), 0o600)
+        fp.write(sandbox_id)
+
+
+def _read_session() -> str | None:
+    flags = os.O_RDONLY
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    try:
+        fd = os.open(SESSION_FILE, flags)
+    except OSError:
+        return None
+    try:
+        with os.fdopen(fd, "r", encoding="utf-8") as fp:
+            if not stat.S_ISREG(os.fstat(fp.fileno()).st_mode):
+                return None
+            value = fp.read().strip()
+            return value or None
+    except (OSError, UnicodeDecodeError):
+        return None
+
+
+# In-process cache so consecutive --keep-alive calls inside the same Python
+# interpreter don't pay cold-start cost. Cross-process reuse goes through
+# SESSION_FILE.
+_sandbox: Sandbox | None = None
+
+
+def _get_sandbox(timeout: int = 300) -> Sandbox:
+    """Get or create a reusable sandbox, reconnecting via session file when possible."""
+    global _sandbox
+    if _sandbox is not None:
+        try:
+            _sandbox.set_timeout(timeout)  # refresh TTL
+            return _sandbox
+        except Exception:
+            try:
+                _sandbox.kill()
+            except Exception:
+                pass
+            _sandbox = None
+
+    # Try cross-process reuse first.
+    sandbox_id = _read_session()
+    if sandbox_id:
+        try:
+            _sandbox = Sandbox.connect(sandbox_id)
+            _sandbox.set_timeout(timeout)
+            return _sandbox
+        except Exception:
+            SESSION_FILE.unlink(missing_ok=True)
+
+    if not TEMPLATE_ID:
+        raise SystemExit(
+            "CUBE_TEMPLATE_ID is not set. Set it in your .env or pass it via the environment."
+        )
+    _sandbox = Sandbox.create(TEMPLATE_ID, timeout=timeout)
+    _write_session(_sandbox.sandbox_id)
+    return _sandbox
+
+
+def _run(sandbox: Sandbox, cmd: str, timeout: int = 120):
+    """Run a command in the sandbox, normalizing non-zero exits into a result object.
+
+    The e2b / cubesandbox SDK raises CommandExitException on non-zero exits;
+    swallowing it here lets callers handle success / failure uniformly instead
+    of catching at every call site.
+    """
+    from e2b.sandbox.commands.command_handle import CommandExitException
+    try:
+        return sandbox.commands.run(cmd, timeout=timeout)
+    except CommandExitException as exc:
+        return exc
+
+
+# --- Public API --------------------------------------------------------------
+
+def exec_code(code: str, pip_packages: list[str] | None = None, timeout: int = 120) -> str:
+    """Execute Python code in the sandbox and return stdout (or stderr on failure)."""
+    sandbox = _get_sandbox(timeout + 60)
+    if pip_packages:
+        r = _run(
+            sandbox,
+            "pip install " + " ".join(shlex.quote(p) for p in pip_packages),
+            timeout=60,
+        )
+        if r.exit_code != 0:
+            return f"[pip error] {r.stderr}"
+    result = _run(sandbox, f"python3 -c {shlex.quote(code)}", timeout=timeout)
+    if result.exit_code == 0:
+        return result.stdout
+    return f"[error] {r_stderr(result)}"
+
+
+def exec_file(filepath: str, timeout: int = 120) -> str:
+    """Copy a local file into the sandbox and execute it."""
+    sandbox = _get_sandbox(timeout + 60)
+    try:
+        with open(filepath, "r", encoding="utf-8") as fp:
+            content = fp.read()
+    except OSError as exc:
+        return f"[error] cannot read {filepath}: {exc}"
+    sandbox.files.write("/tmp/opencode_script.py", content)
+    result = _run(sandbox, "python3 /tmp/opencode_script.py", timeout=timeout)
+    if result.exit_code == 0:
+        return result.stdout
+    return f"[error] {r_stderr(result)}"
+
+
+def exec_cmd(command: str, timeout: int = 120) -> str:
+    """Execute an arbitrary shell command in the sandbox."""
+    sandbox = _get_sandbox(timeout + 60)
+    result = _run(sandbox, command, timeout=timeout)
+    if result.exit_code == 0:
+        return result.stdout
+    return f"[error] {r_stderr(result)}"
+
+
+def r_stderr(result) -> str:
+    """Extract stderr from a CommandExitException (which has no .stderr attr) or a result."""
+    return getattr(result, "stderr", "") or str(result)
+
+
+def cleanup() -> None:
+    """Destroy the cached sandbox and clear the session file."""
+    global _sandbox
+    if _sandbox is not None:
+        try:
+            _sandbox.kill()
+        except Exception:
+            pass
+        _sandbox = None
+    SESSION_FILE.unlink(missing_ok=True)
+
+
+# --- CLI ---------------------------------------------------------------------
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Execute code or shell commands in an isolated CubeSandbox MicroVM."
+    )
+    parser.add_argument("--code", help="Python code to execute")
+    parser.add_argument("--file", help="Local Python file to copy into the sandbox and execute")
+    parser.add_argument("--cmd", help="Shell command to execute")
+    parser.add_argument("--pip", nargs="+", help="Pip packages to install before --code")
+    parser.add_argument("--timeout", type=int, default=120, help="Execution timeout in seconds")
+    parser.add_argument(
+        "--keep-alive",
+        action="store_true",
+        help="Keep the sandbox alive after this invocation so the next call "
+             "can reconnect via the session file instead of cold-starting.",
+    )
+    parser.add_argument(
+        "--reset",
+        action="store_true",
+        help="Destroy the cached sandbox before running, then exit.",
+    )
+    parser.add_argument(
+        "--session",
+        default=None,
+        help="(Reserved) per-session identifier. Currently unused — session reuse "
+             "is process-global. Documented so future per-session sandboxes "
+             "(e.g. one per Claude Code session_id) do not break callers.",
+    )
+    args = parser.parse_args()
+
+    if args.reset:
+        cleanup()
+        print("Sandbox destroyed. A new one will be created on next use.")
+        return
+
+    if not any((args.code, args.file, args.cmd)):
+        parser.print_help()
+        sys.exit(2)
+
+    if not TEMPLATE_ID:
+        print("Error: CUBE_TEMPLATE_ID not set in .env", file=sys.stderr)
+        sys.exit(1)
+
+    try:
+        if args.code:
+            print(exec_code(args.code, args.pip, args.timeout))
+        elif args.file:
+            print(exec_file(args.file, args.timeout))
+        elif args.cmd:
+            print(exec_cmd(args.cmd, args.timeout))
+    finally:
+        if not args.keep_alive:
+            cleanup()
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/opencode-integration/tests/conftest.py
+++ b/examples/opencode-integration/tests/conftest.py
@@ -1,0 +1,14 @@
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Pytest configuration — add the example directory to sys.path so tests can
+import the integration modules (``env_utils``, ``_opencode_common``,
+``sandbox_exec``, ``mcp_server``) without packaging them.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))

--- a/examples/opencode-integration/tests/test_env_utils.py
+++ b/examples/opencode-integration/tests/test_env_utils.py
@@ -1,0 +1,618 @@
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for env_utils.py — environment resolution and command construction.
+
+Pure environment-variable handling, no CubeSandbox cluster or LLM credentials
+needed. Mirrors the structure of the Claude Code integration test suite so
+the two examples can be reviewed side-by-side.
+"""
+
+from __future__ import annotations
+
+import argparse
+import io
+import os
+import sys
+import types
+from unittest import mock
+
+import pytest
+
+import env_utils
+from _opencode_common import ensure_success, positive_int, sandbox_identifier, stream_writer
+
+
+# Snapshot/restore helper used by the older hand-rolled TestCase style. Kept
+# here as a context manager so tests that need to set/tear down a known set
+# of env vars (rather than ad-hoc monkeypatching) can do so without leaking
+# state into the rest of the suite.
+@pytest.fixture
+def clean_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Wipe all integration-relevant env vars before each test.
+
+    Listed explicitly so a leaked var cannot silently flip the result of a
+    neighboring test (the order of pytest collection is not guaranteed).
+    """
+    for key in (
+        "OPENCODE_PROVIDER",
+        "OPENCODE_BASE_URL",
+        "OPENCODE_MODEL",
+        "ANTHROPIC_BASE_URL",
+        "ANTHROPIC_MODEL",
+        "OPENAI_BASE_URL",
+        "OPENAI_MODEL",
+        "GOOGLE_BASE_URL",
+        "OPENCODE_LLM_HOST",
+        "OPENCODE_CONFIG_DIR",
+        "OPENCODE_DATA_DIR",
+        "OPENCODE_WORKSPACE",
+        "OPENCODE_SMALL_MODEL",
+        "OPENCODE_CUSTOM_HEADERS",
+        "DISABLE_TELEMETRY",
+        "DISABLE_ERROR_REPORTING",
+        "ANTHROPIC_API_KEY",
+        "OPENAI_API_KEY",
+        "DEEPSEEK_API_KEY",
+        "GOOGLE_API_KEY",
+        "GROQ_API_KEY",
+        "MISTRAL_API_KEY",
+        "OPENROUTER_API_KEY",
+        "HTTP_PROXY",
+        "HTTPS_PROXY",
+        "NO_PROXY",
+    ):
+        monkeypatch.delenv(key, raising=False)
+
+
+# ── internet_environment + provider ────────────────────────────────────────
+
+
+class TestProvider:
+    """Tests for env_utils.provider() — provider selection resolution."""
+
+    def test_explicit_provider_overrides_env_keys(self, clean_env: None) -> None:
+        # The explicit OPENCODE_PROVIDER env var must always win over any
+        # inferred provider (the user explicitly opted out of inference).
+        os.environ["OPENAI_API_KEY"] = "sk-openai"
+        os.environ["OPENCODE_PROVIDER"] = "OpenAI"
+        assert env_utils.provider() == "openai"
+
+    def test_anthropic_key_resolves_to_anthropic(self, clean_env: None) -> None:
+        os.environ["ANTHROPIC_API_KEY"] = "sk-ant"
+        assert env_utils.provider() == "anthropic"
+
+    def test_openai_key_resolves_to_openai(self, clean_env: None) -> None:
+        os.environ["OPENAI_API_KEY"] = "sk-oai"
+        assert env_utils.provider() == "openai"
+
+    def test_deepseek_key_resolves_to_deepseek(self, clean_env: None) -> None:
+        os.environ["DEEPSEEK_API_KEY"] = "sk-ds"
+        assert env_utils.provider() == "deepseek"
+
+    def test_google_key_resolves_to_google(self, clean_env: None) -> None:
+        os.environ["GOOGLE_API_KEY"] = "gkey"
+        assert env_utils.provider() == "google"
+
+    def test_no_env_signal_defaults_to_anthropic(self, clean_env: None) -> None:
+        assert env_utils.provider() == "anthropic"
+
+    def test_baseurl_anthropic_host_returns_anthropic(self, clean_env: None) -> None:
+        # DeepSeek ships an Anthropic-compatible gateway at
+        # api.deepseek.com/anthropic, but the host the heuristic looks at is
+        # only the hostname (``api.deepseek.com``) — the path is ignored.
+        # When the user is intentionally targetting the Anthropic wire
+        # protocol, they put it in the host (e.g. via a CNAME). Anything
+        # more exotic should set OPENCODE_PROVIDER explicitly.
+        os.environ["OPENCODE_BASE_URL"] = "https://api.anthropic.com"
+        assert env_utils.provider() == "anthropic"
+
+    def test_baseurl_openai_substring_returns_openai(self, clean_env: None) -> None:
+        os.environ["OPENCODE_BASE_URL"] = "https://api.openai.com/v1"
+        assert env_utils.provider() == "openai"
+
+    def test_baseurl_googleapis_returns_google(self, clean_env: None) -> None:
+        os.environ["OPENCODE_BASE_URL"] = "https://generativelanguage.googleapis.com"
+        assert env_utils.provider() == "google"
+
+    def test_baseurl_openrouter_returns_openrouter(self, clean_env: None) -> None:
+        os.environ["OPENCODE_BASE_URL"] = "https://openrouter.ai/api/v1"
+        assert env_utils.provider() == "openrouter"
+
+    def test_provider_returns_lowercase(self, clean_env: None) -> None:
+        os.environ["OPENCODE_PROVIDER"] = "  Anthropic  "
+        assert env_utils.provider() == "anthropic"
+
+
+# ── llm_host ──────────────────────────────────────────────────────────────
+
+
+class TestLLMHost:
+    """Tests for env_utils.llm_host() — upstream API host resolution."""
+
+    def test_explicit_host_wins_over_baseurl(self, clean_env: None) -> None:
+        # OPENCODE_LLM_HOST is the documented override knob for shared
+        # clusters that proxy the upstream. It must beat any *_BASE_URL.
+        os.environ["OPENCODE_LLM_HOST"] = "llm.example.com"
+        os.environ["OPENCODE_BASE_URL"] = "https://api.anthropic.com"
+        assert env_utils.llm_host() == "llm.example.com"
+
+    def test_opencode_base_url_used_when_no_explicit_host(self, clean_env: None) -> None:
+        os.environ["OPENCODE_BASE_URL"] = "https://api.openai.com"
+        assert env_utils.llm_host() == "api.openai.com"
+
+    def test_anthropic_base_url_used_when_opencode_unset(self, clean_env: None) -> None:
+        os.environ["ANTHROPIC_BASE_URL"] = "https://api.deepseek.com/anthropic"
+        assert env_utils.llm_host() == "api.deepseek.com"
+
+    def test_provider_default_when_nothing_set(self, clean_env: None) -> None:
+        os.environ["OPENCODE_PROVIDER"] = "openai"
+        assert env_utils.llm_host() == "api.openai.com"
+
+    def test_provider_default_anthropic(self, clean_env: None) -> None:
+        # Provider inference defaults to anthropic when no signal is present.
+        assert env_utils.llm_host() == "api.anthropic.com"
+
+
+# ── provider_inject ───────────────────────────────────────────────────────
+
+
+class TestProviderInject:
+    """Tests for env_utils.provider_inject() — CubeEgress auth-header shape."""
+
+    def test_anthropic_injects_x_api_key_and_version(self) -> None:
+        specs = env_utils.provider_inject("anthropic", "sk-test")
+        assert len(specs) == 2
+        assert specs[0] == {
+            "header": "x-api-key",
+            "secret": "sk-test",
+            "format": "${SECRET}",
+        }
+        # The pinned anthropic-version header is a constant, not the secret —
+        # we feed it through the same ${SECRET} format for shape consistency
+        # but the rendered value is "2023-06-01".
+        assert specs[1] == {
+            "header": "anthropic-version",
+            "secret": "2023-06-01",
+            "format": "${SECRET}",
+        }
+
+    def test_non_anthropic_injects_bearer(self) -> None:
+        specs = env_utils.provider_inject("openai", "sk-test")
+        assert specs == [
+            {"header": "Authorization", "secret": "sk-test", "format": "Bearer ${SECRET}"}
+        ]
+
+    def test_deepseek_injects_bearer(self) -> None:
+        specs = env_utils.provider_inject("deepseek", "sk-ds")
+        assert specs[0]["header"] == "Authorization"
+        assert specs[0]["format"] == "Bearer ${SECRET}"
+
+    def test_provider_case_insensitive(self) -> None:
+        specs = env_utils.provider_inject("Anthropic", "sk")
+        assert specs[0]["header"] == "x-api-key"
+
+
+# ── provider_key_candidates + require_provider_key ─────────────────────────
+
+
+class TestRequireProviderKey:
+    """Tests for env_utils.require_provider_key() and provider_key_name()."""
+
+    def test_raises_when_no_keys_set(self, clean_env: None) -> None:
+        with pytest.raises(SystemExit):
+            env_utils.require_provider_key()
+
+    def test_returns_anthropic_key_when_set(self, clean_env: None) -> None:
+        os.environ["ANTHROPIC_API_KEY"] = "sk-test"
+        assert env_utils.require_provider_key() == "sk-test"
+
+    def test_returns_codebuddy_api_key_when_set(self, clean_env: None) -> None:
+        # OpenCode uses provider-specific keys (ANTHROPIC_API_KEY, OPENAI_API_KEY,
+        # etc.) rather than a generic OPENCODE_API_KEY. The canonical name for
+        # the anthropic provider is ANTHROPIC_API_KEY.
+        os.environ["OPENCODE_PROVIDER"] = "anthropic"
+        os.environ["ANTHROPIC_API_KEY"] = "sk-ant-test"
+        assert env_utils.require_provider_key() == "sk-ant-test"
+
+    def test_error_lists_candidate_keys(self, clean_env: None) -> None:
+        # The error message must mention the canonical key name so
+        # operators know what to set. Without this, debugging a missing-key
+        # failure is a guessing game.
+        with pytest.raises(SystemExit) as exc_info:
+            env_utils.require_provider_key()
+        assert "ANTHROPIC_API_KEY" in str(exc_info.value)
+
+
+class TestProviderKeyName:
+    """Tests for env_utils.provider_key_name() — env-var name lookup."""
+
+    def test_returns_first_set_key(self, clean_env: None) -> None:
+        os.environ["OPENCODE_PROVIDER"] = "anthropic"
+        os.environ["ANTHROPIC_API_KEY"] = "sk-ant-test"
+        os.environ["OPENCODE_API_KEY"] = "oc-test"
+        assert env_utils.provider_key_name() == "ANTHROPIC_API_KEY"
+
+    def test_returns_canonical_when_no_keys_set(self, clean_env: None) -> None:
+        os.environ["OPENCODE_PROVIDER"] = "anthropic"
+        # No keys → still return the canonical first candidate so callers
+        # can distinguish "no key set" from "unknown provider".
+        assert env_utils.provider_key_name() == "ANTHROPIC_API_KEY"
+
+    def test_openai_provider_returns_openai_key_env(self, clean_env: None) -> None:
+        os.environ["OPENCODE_PROVIDER"] = "openai"
+        os.environ["OPENAI_API_KEY"] = "sk-oai"
+        assert env_utils.provider_key_name() == "OPENAI_API_KEY"
+
+    def test_deepseek_provider_returns_deepseek_key_env(self, clean_env: None) -> None:
+        os.environ["OPENCODE_PROVIDER"] = "deepseek"
+        os.environ["DEEPSEEK_API_KEY"] = "sk-ds"
+        assert env_utils.provider_key_name() == "DEEPSEEK_API_KEY"
+
+
+# ── build_opencode_env ────────────────────────────────────────────────────
+
+
+class TestBuildOpencodeEnv:
+    """Tests for env_utils.build_opencode_env() — exec-env construction."""
+
+    def test_with_secrets_includes_only_active_provider_key(self, clean_env: None) -> None:
+        # CI hosts regularly have multiple provider keys lying around. The
+        # direct flavor must forward exactly the one matching the active
+        # provider — never both, never all.
+        os.environ["ANTHROPIC_API_KEY"] = "sk-ant"
+        os.environ["OPENAI_API_KEY"] = "sk-oai"
+        env = env_utils.build_opencode_env(include_secrets=True)
+        assert env["ANTHROPIC_API_KEY"] == "sk-ant"
+        assert "OPENAI_API_KEY" not in env
+
+    def test_without_secrets_omits_provider_key(self, clean_env: None) -> None:
+        os.environ["ANTHROPIC_API_KEY"] = "sk-ant"
+        env = env_utils.build_opencode_env(include_secrets=False)
+        assert "ANTHROPIC_API_KEY" not in env
+
+    def test_sets_opencode_config_and_data_dirs(self, clean_env: None) -> None:
+        env = env_utils.build_opencode_env()
+        assert env["OPENCODE_CONFIG_DIR"] == "/workspace/.opencode/config"
+        assert env["OPENCODE_DATA_DIR"] == "/workspace/.opencode/data"
+        # XDG base dirs are forced to /workspace so the user-owned exec
+        # account (``user``) can write there.
+        assert env["XDG_CONFIG_HOME"] == "/workspace"
+        assert env["XDG_DATA_HOME"] == "/workspace"
+
+    def test_passthrough_env_forwarded(self, clean_env: None) -> None:
+        os.environ["HTTP_PROXY"] = "http://proxy:8080"
+        os.environ["HTTPS_PROXY"] = "http://proxy:8080"
+        os.environ["OPENCODE_MODEL"] = "anthropic/claude-sonnet-4-6"
+        env = env_utils.build_opencode_env()
+        assert env["HTTP_PROXY"] == "http://proxy:8080"
+        assert env["HTTPS_PROXY"] == "http://proxy:8080"
+        assert env["OPENCODE_MODEL"] == "anthropic/claude-sonnet-4-6"
+
+    def test_proxy_userinfo_stripped_before_forwarding(self, clean_env: None) -> None:
+        # Host proxy credentials (http://user:pass@corp-proxy:8080) would
+        # otherwise leak into the VM where the LLM agent can read them via
+        # printenv.
+        os.environ["HTTP_PROXY"] = "http://user:pass@corp-proxy:8080"
+        os.environ["HTTPS_PROXY"] = "https://alice:s3cret@proxy.example.com:3128"
+        env = env_utils.build_opencode_env()
+        assert env["HTTP_PROXY"] == "http://corp-proxy:8080"
+        assert env["HTTPS_PROXY"] == "https://proxy.example.com:3128"
+        assert "user:pass" not in env["HTTP_PROXY"]
+        assert "alice:s3cret" not in env["HTTPS_PROXY"]
+
+    def test_proxy_without_userinfo_passes_through(self, clean_env: None) -> None:
+        os.environ["HTTPS_PROXY"] = "http://proxy:8080"
+        env = env_utils.build_opencode_env()
+        assert env["HTTPS_PROXY"] == "http://proxy:8080"
+
+    def test_disable_telemetry_defaults_to_one(self, clean_env: None) -> None:
+        env = env_utils.build_opencode_env()
+        assert env["DISABLE_TELEMETRY"] == "1"
+        assert env["DISABLE_ERROR_REPORTING"] == "1"
+        assert env["OPENCODE_DISABLE_AUTOUPDATE"] == "1"
+
+
+# ── opencode_command (command builder) ────────────────────────────────────
+
+
+class TestOpencodeCommand:
+    """Tests for env_utils.opencode_command() — headless invocation builder."""
+
+    def test_minimal_command(self) -> None:
+        # The minimal headless invocation is `opencode run <prompt>`. The
+        # --dangerously-skip-permissions flag is appended by default because
+        # OpenCode otherwise blocks on a permission prompt that cannot be
+        # answered over the exec channel.
+        cmd = env_utils.opencode_command("hello")
+        assert cmd == "opencode run --dangerously-skip-permissions hello"
+
+    def test_continue_flag(self) -> None:
+        cmd = env_utils.opencode_command("hello", continue_session=True)
+        assert "-c" in cmd
+
+    def test_resume_flag(self) -> None:
+        cmd = env_utils.opencode_command("hello", resume="abc-123")
+        assert "-s abc-123" in cmd
+
+    def test_session_id_flag(self) -> None:
+        cmd = env_utils.opencode_command("hello", session_id="uuid-1")
+        assert "--session-id uuid-1" in cmd
+
+    def test_model_flag(self) -> None:
+        cmd = env_utils.opencode_command("hello", model="anthropic/claude-sonnet-4-6")
+        assert "-m anthropic/claude-sonnet-4-6" in cmd
+
+    def test_dangerously_skip_permissions_off(self) -> None:
+        cmd = env_utils.opencode_command("hello", dangerously_skip_permissions=False)
+        assert "--dangerously-skip-permissions" not in cmd
+
+    def test_prompt_is_shell_quoted(self) -> None:
+        # shlex.quote wraps prompts with shell metachars so they reach
+        # OpenCode as a single arg even if the user passes 'hello world; rm -rf /'.
+        cmd = env_utils.opencode_command("hello world; rm -rf /")
+        assert "'hello world; rm -rf /'" in cmd
+
+
+# ── shell_join + helpers ──────────────────────────────────────────────────
+
+
+class TestShellJoin:
+    """Tests for env_utils.shell_join() — ``&&`` chain builder."""
+
+    def test_joins_non_empty_parts_with_and(self) -> None:
+        assert env_utils.shell_join("a", "b", "c") == "a && b && c"
+
+    def test_skips_empty_parts(self) -> None:
+        assert env_utils.shell_join("a", "", "c") == "a && c"
+
+
+class TestStripUrlUserinfo:
+    """Tests for env_utils.strip_url_userinfo() — credential removal."""
+
+    def test_strips_user_and_password(self) -> None:
+        assert env_utils.strip_url_userinfo("http://u:p@h:8080") == "http://h:8080"
+
+    def test_strips_user_only(self) -> None:
+        assert env_utils.strip_url_userinfo("http://u@h:8080") == "http://h:8080"
+
+    def test_keeps_port(self) -> None:
+        assert (
+            env_utils.strip_url_userinfo("https://u:p@proxy.example.com:3128/path")
+            == "https://proxy.example.com:3128/path"
+        )
+
+    def test_handles_bare_host_with_userinfo(self) -> None:
+        # Some proxies are exported as just "user:p@host:port" with no scheme.
+        assert env_utils.strip_url_userinfo("u:p@h:8080") == "https://h:8080"
+
+    def test_no_userinfo_returns_unchanged(self) -> None:
+        assert env_utils.strip_url_userinfo("http://proxy:8080") == "http://proxy:8080"
+
+    def test_empty_returns_unchanged(self) -> None:
+        assert env_utils.strip_url_userinfo("") == ""
+        assert env_utils.strip_url_userinfo("   ") == "   "
+
+    def test_at_sign_in_path_only_returns_unchanged(self) -> None:
+        # An '@' that is not in the authority section should not be mangled.
+        assert (
+            env_utils.strip_url_userinfo("http://proxy:8080/path@version")
+            == "http://proxy:8080/path@version"
+        )
+
+
+class TestHostFromUrl:
+    """Tests for env_utils._host_from_url() — hostname extraction."""
+
+    def test_extracts_host(self) -> None:
+        assert env_utils._host_from_url("https://api.anthropic.com/v1") == "api.anthropic.com"
+
+    def test_handles_bare_hostname(self) -> None:
+        assert env_utils._host_from_url("api.anthropic.com") == "api.anthropic.com"
+
+    def test_empty_returns_empty(self) -> None:
+        assert env_utils._host_from_url("") == ""
+        assert env_utils._host_from_url("   ") == ""
+
+
+class TestHomeAndWorkspace:
+    """Tests for env_utils.opencode_home / data_dir / workspace resolution."""
+
+    def test_default_config_dir(self, clean_env: None) -> None:
+        assert env_utils.opencode_home() == "/workspace/.opencode/config"
+
+    def test_custom_config_dir(self, clean_env: None) -> None:
+        os.environ["OPENCODE_CONFIG_DIR"] = "/var/lib/opencode"
+        assert env_utils.opencode_home() == "/var/lib/opencode"
+
+    def test_default_data_dir(self, clean_env: None) -> None:
+        assert env_utils.opencode_data_dir() == "/workspace/.opencode/data"
+
+    def test_custom_data_dir(self, clean_env: None) -> None:
+        os.environ["OPENCODE_DATA_DIR"] = "/var/lib/opencode-data"
+        assert env_utils.opencode_data_dir() == "/var/lib/opencode-data"
+
+    def test_default_workspace(self, clean_env: None) -> None:
+        assert env_utils.opencode_workspace() == "/workspace"
+
+
+class TestOpencodeModel:
+    """Tests for env_utils.opencode_model() — model selection."""
+
+    def test_explicit_model_wins(self, clean_env: None) -> None:
+        os.environ["OPENCODE_MODEL"] = "openai/gpt-5-mini"
+        assert env_utils.opencode_model() == "openai/gpt-5-mini"
+
+    def test_anthropic_model_fallback(self, clean_env: None) -> None:
+        # When OPENCODE_MODEL is unset and provider is anthropic, fall back
+        # to ANTHROPIC_MODEL for parity with how Anthropic SDK users
+        # configure the model in their shell.
+        os.environ["OPENCODE_PROVIDER"] = "anthropic"
+        os.environ["ANTHROPIC_MODEL"] = "claude-sonnet-4-7"
+        assert env_utils.opencode_model() == "claude-sonnet-4-7"
+
+    def test_no_default_for_non_anthropic_raises(self, clean_env: None) -> None:
+        # OpenAI and other non-Anthropic providers have no safe
+        # cross-provider default, so omitting both OPENCODE_MODEL and
+        # ANTHROPIC_MODEL raises.
+        os.environ["OPENCODE_PROVIDER"] = "openai"
+        with pytest.raises(SystemExit):
+            env_utils.opencode_model()
+
+    def test_anthropic_default_when_nothing_set(self, clean_env: None) -> None:
+        os.environ["OPENCODE_PROVIDER"] = "anthropic"
+        # No OPENCODE_MODEL, no ANTHROPIC_MODEL → must use the shipped default
+        assert env_utils.opencode_model() == "claude-sonnet-4-6"
+
+
+class TestLoadLocalDotenv:
+    """Tests for env_utils.load_local_dotenv() — .env auto-discovery."""
+
+    def test_load_local_dotenv_does_not_raise(self) -> None:
+        # Smoke test: the function should not raise even when no .env exists.
+        env_utils.load_local_dotenv()
+
+
+# ── required / optional / int_env / _env_positive_int ──────────────────────
+
+
+class TestOptionalAndIntEnv:
+    """Tests for env_utils.optional / required / int_env."""
+
+    def test_optional_returns_default_when_unset(self) -> None:
+        with mock.patch.dict(os.environ, {}, clear=True):
+            assert env_utils.optional("X", "fallback") == "fallback"
+
+    def test_optional_returns_empty_when_unset_and_no_default(self) -> None:
+        with mock.patch.dict(os.environ, {}, clear=True):
+            assert env_utils.optional("X") == ""
+
+    def test_required_raises_when_unset(self) -> None:
+        with mock.patch.dict(os.environ, {}, clear=True):
+            with pytest.raises(SystemExit):
+                env_utils.required("X")
+
+    def test_int_env_returns_default_when_unset(self) -> None:
+        with mock.patch.dict(os.environ, {}, clear=True):
+            assert env_utils.int_env("X", 42) == 42
+
+    def test_int_env_parses_value(self) -> None:
+        with mock.patch.dict(os.environ, {"X": "123"}):
+            assert env_utils.int_env("X", 0) == 123
+
+    def test_int_env_rejects_non_integer(self) -> None:
+        with mock.patch.dict(os.environ, {"X": "abc"}):
+            with pytest.raises(SystemExit):
+                env_utils.int_env("X", 0)
+
+
+class TestEnvPositiveInt:
+    """Verify env-var fallback also rejects zero / negative / non-integer values.
+
+    argparse evaluates ``default=`` before ``type=``, so the bare
+    ``default=int_env(...)`` pattern would silently let
+    ``OPENCODE_SANDBOX_TIMEOUT=0`` reach the SDK. These tests pin down
+    ``_env_positive_int`` as the right helper.
+    """
+
+    def test_unset_returns_default(self) -> None:
+        with mock.patch.dict(os.environ, {}, clear=True):
+            assert env_utils._env_positive_int("X", 42) == 42
+
+    def test_empty_returns_default(self) -> None:
+        with mock.patch.dict(os.environ, {"X": ""}):
+            assert env_utils._env_positive_int("X", 42) == 42
+
+    def test_positive_passes_through(self) -> None:
+        with mock.patch.dict(os.environ, {"X": "120"}):
+            assert env_utils._env_positive_int("X", 1) == 120
+
+    def test_zero_raises(self) -> None:
+        with mock.patch.dict(os.environ, {"X": "0"}):
+            with pytest.raises(SystemExit):
+                env_utils._env_positive_int("X", 1)
+
+    def test_negative_raises(self) -> None:
+        with mock.patch.dict(os.environ, {"X": "-5"}):
+            with pytest.raises(SystemExit):
+                env_utils._env_positive_int("X", 1)
+
+    def test_non_integer_raises(self) -> None:
+        with mock.patch.dict(os.environ, {"X": "abc"}):
+            with pytest.raises(SystemExit):
+                env_utils._env_positive_int("X", 1)
+
+
+# ── _opencode_common ──────────────────────────────────────────────────────
+
+
+class TestPositiveInt:
+    """Tests for _opencode_common.positive_int — argparse type guard."""
+
+    def test_parses_positive_integer(self) -> None:
+        assert positive_int("42") == 42
+
+    def test_rejects_zero(self) -> None:
+        with pytest.raises(argparse.ArgumentTypeError):
+            positive_int("0")
+
+    def test_rejects_negative(self) -> None:
+        with pytest.raises(argparse.ArgumentTypeError):
+            positive_int("-5")
+
+    def test_rejects_non_integer(self) -> None:
+        with pytest.raises(argparse.ArgumentTypeError):
+            positive_int("abc")
+
+
+class TestEnsureSuccess:
+    """Tests for _opencode_common.ensure_success — exit-code → SystemExit."""
+
+    def test_zero_exit_does_not_raise(self) -> None:
+        result = mock.MagicMock(exit_code=0)
+        # must not raise
+        ensure_success(result, "do something")
+
+    def test_none_exit_does_not_raise(self) -> None:
+        result = mock.MagicMock(exit_code=None, stdout="ok", stderr="")
+        ensure_success(result, "do something")  # must not raise
+
+    def test_non_zero_exit_raises(self) -> None:
+        result = mock.MagicMock(exit_code=1, stdout="out", stderr="error")
+        with pytest.raises(SystemExit) as exc_info:
+            ensure_success(result, "do something")
+        assert "Failed to do something (exit 1)" in str(exc_info.value)
+
+
+class TestSandboxIdentifier:
+    """Tests for _opencode_common.sandbox_identifier — attribute priority."""
+
+    def test_prefers_sandbox_id(self) -> None:
+        sandbox = types.SimpleNamespace(sandbox_id="sb-abc", id="legacy-id")
+        assert sandbox_identifier(sandbox) == "sb-abc"
+
+    def test_falls_back_to_id(self) -> None:
+        sandbox = types.SimpleNamespace(id="legacy-id")
+        assert sandbox_identifier(sandbox) == "legacy-id"
+
+    def test_returns_unknown_when_neither_attr(self) -> None:
+        sandbox = types.SimpleNamespace()
+        assert sandbox_identifier(sandbox) == "unknown"
+
+
+class TestStreamWriter:
+    """Tests for _opencode_common.stream_writer — chunk adapter."""
+
+    def test_writes_plain_string(self) -> None:
+        buf = io.StringIO()
+        writer = stream_writer(buf)
+        writer("hello")
+        assert buf.getvalue() == "hello"
+
+    def test_handles_chunk_with_line_attr(self) -> None:
+        buf = io.StringIO()
+        writer = stream_writer(buf)
+        chunk = mock.MagicMock()
+        chunk.line = "chunked output"
+        writer(chunk)
+        assert buf.getvalue() == "chunked output"

--- a/examples/opencode-integration/tests/test_mcp_server.py
+++ b/examples/opencode-integration/tests/test_mcp_server.py
@@ -1,0 +1,252 @@
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for mcp_server.py — MCP protocol handling and sandbox lifecycle.
+
+Mirrors the structure of test_mcp_server.py in the Claude Code integration
+so the two examples can be reviewed side-by-side.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import sys
+from unittest.mock import Mock, patch
+
+import pytest
+
+import mcp_server
+
+
+@pytest.fixture(autouse=True)
+def reset_sandbox():
+    """Reset the module-level _sandbox between tests."""
+    old = mcp_server._sandbox
+    mcp_server._sandbox = None
+    yield
+    mcp_server._sandbox = old
+
+
+# ── _read_mcp_message ──────────────────────────────────────────────────
+
+
+class TestReadMcpMessage:
+    """Tests for mcp_server._read_mcp_message() — protocol message parsing."""
+
+    def test_valid_message(self) -> None:
+        body = json.dumps({"jsonrpc": "2.0", "method": "initialize", "id": 1})
+        stdin = io.StringIO(body + "\n")
+        with patch.object(sys, "stdin", stdin):
+            msg = mcp_server._read_mcp_message()
+        assert msg == {"jsonrpc": "2.0", "method": "initialize", "id": 1}
+
+    def test_eof_raises_eoferror(self) -> None:
+        # EOF now raises EOFError instead of returning None, which
+        # previously caused main() to loop infinitely on disconnected clients.
+        stdin = io.StringIO("")
+        with patch.object(sys, "stdin", stdin):
+            with pytest.raises(EOFError):
+                mcp_server._read_mcp_message()
+
+    def test_invalid_json_returns_none(self) -> None:
+        stdin = io.StringIO("not json\n")
+        with patch.object(sys, "stdin", stdin):
+            msg = mcp_server._read_mcp_message()
+        assert msg is None
+
+    def test_blank_line_returns_none(self) -> None:
+        stdin = io.StringIO("\n")
+        with patch.object(sys, "stdin", stdin):
+            msg = mcp_server._read_mcp_message()
+        assert msg is None
+
+
+# ── handle_request ─────────────────────────────────────────────────────
+
+
+class TestHandleRequest:
+    """Tests for mcp_server.handle_request() — JSON-RPC dispatch."""
+
+    def test_initialize(self) -> None:
+        resp = mcp_server.handle_request(
+            {"jsonrpc": "2.0", "method": "initialize", "id": 1}
+        )
+        assert resp["id"] == 1
+        assert resp["result"]["protocolVersion"] == "2024-11-05"
+        assert "tools" in resp["result"]["capabilities"]
+
+    def test_tools_list(self) -> None:
+        resp = mcp_server.handle_request(
+            {"jsonrpc": "2.0", "method": "tools/list", "id": 2}
+        )
+        assert resp["id"] == 2
+        tools = resp["result"]["tools"]
+        assert len(tools) > 0
+        names = {t["name"] for t in tools}
+        assert "sandbox_run_code" in names
+        assert "sandbox_run_command" in names
+        assert "sandbox_write_file" in names
+        assert "sandbox_read_file" in names
+        assert "sandbox_reset" in names
+
+    def test_unknown_method_returns_error(self) -> None:
+        resp = mcp_server.handle_request(
+            {"jsonrpc": "2.0", "method": "unknown", "id": 3}
+        )
+        assert resp["id"] == 3
+        assert "error" in resp
+        assert resp["error"]["code"] == -32601
+
+    def test_notifications_initialized_returns_none(self) -> None:
+        resp = mcp_server.handle_request({"method": "notifications/initialized"})
+        assert resp is None
+
+    def test_tools_call_unknown_tool(self) -> None:
+        resp = mcp_server.handle_request({
+            "jsonrpc": "2.0",
+            "method": "tools/call",
+            "id": 5,
+            "params": {"name": "nonexistent", "arguments": {}},
+        })
+        assert resp["id"] == 5
+        assert "Unknown tool" in resp["result"]["content"][0]["text"]
+        assert resp["result"]["isError"] is True
+
+    def test_command_failure_preserves_exit_code_and_both_streams(self) -> None:
+        result = {"exit_code": 7, "stdout": "partial output", "stderr": "failed"}
+        with patch.object(mcp_server, "run_command", return_value=result):
+            resp = mcp_server.handle_request({
+                "jsonrpc": "2.0",
+                "method": "tools/call",
+                "id": 6,
+                "params": {
+                    "name": "sandbox_run_command",
+                    "arguments": {"command": "false"},
+                },
+            })
+
+        tool_result = resp["result"]
+        text = tool_result["content"][0]["text"]
+        assert tool_result["isError"] is True
+        assert "exit_code: 7" in text
+        assert "stdout:\npartial output" in text
+        assert "stderr:\nfailed" in text
+
+    def test_run_code_pipes_through_python(self) -> None:
+        with patch.object(mcp_server, "run_command", return_value={
+            "exit_code": 0, "stdout": "42", "stderr": ""
+        }) as mock_run:
+            mcp_server.handle_request({
+                "jsonrpc": "2.0",
+                "method": "tools/call",
+                "id": 7,
+                "params": {
+                    "name": "sandbox_run_code",
+                    "arguments": {"code": "print(42)"},
+                },
+            })
+        first_arg = mock_run.call_args[0][0]
+        assert first_arg.startswith("python3 -c ")
+        assert "\nprint(42)" not in first_arg
+
+    def test_write_file_reports_byte_count(self) -> None:
+        with patch.object(mcp_server, "_get_sandbox") as mock_sb:
+            mcp_server.handle_request({
+                "jsonrpc": "2.0",
+                "method": "tools/call",
+                "id": 8,
+                "params": {
+                    "name": "sandbox_write_file",
+                    "arguments": {"path": "/tmp/x", "content": "abc"},
+                },
+            })
+        mock_sb.return_value.files.write.assert_called_once_with("/tmp/x", "abc")
+
+    def test_reset_cleans_up_sandbox(self) -> None:
+        with patch.object(mcp_server, "_cleanup_sandbox") as mock_cleanup:
+            mcp_server.handle_request({
+                "jsonrpc": "2.0",
+                "method": "tools/call",
+                "id": 9,
+                "params": {"name": "sandbox_reset", "arguments": {}},
+            })
+        mock_cleanup.assert_called_once()
+
+
+# ── _get_sandbox ───────────────────────────────────────────────────────
+
+
+class TestGetSandbox:
+    """Tests for mcp_server._get_sandbox() — sandbox lifecycle + TTL refresh."""
+
+    def test_creates_sandbox_on_first_call(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("CUBE_TEMPLATE_ID", "tpl-test")
+        # Reload module-level TEMPLATE_ID after patching env
+        mcp_server.TEMPLATE_ID = "tpl-test"
+        mock_instance = Mock()
+        mock_instance.sandbox_id = "sb-new"
+        with patch("e2b_code_interpreter.Sandbox") as mock_cls:
+            mock_cls.create.return_value = mock_instance
+            mcp_server._sandbox = None
+            result = mcp_server._get_sandbox(timeout=600)
+        assert result is mock_instance
+        mock_cls.create.assert_called_once()
+
+    def test_refreshes_ttl_on_subsequent_call(self) -> None:
+        mock_instance = Mock()
+        mcp_server._sandbox = mock_instance
+        result = mcp_server._get_sandbox(timeout=600)
+        assert result is mock_instance
+        mock_instance.set_timeout.assert_called_once_with(600)
+
+    def test_recreates_sandbox_if_set_timeout_fails(self) -> None:
+        mock_instance = Mock()
+        mock_instance.set_timeout.side_effect = Exception("expired")
+        mcp_server._sandbox = mock_instance
+
+        new_instance = Mock()
+        with patch("e2b_code_interpreter.Sandbox") as mock_cls:
+            mock_cls.create.return_value = new_instance
+            result = mcp_server._get_sandbox()
+        assert result is new_instance
+        mock_instance.kill.assert_called_once()
+        mock_cls.create.assert_called_once()
+
+    def test_cleanup_kills_and_clears_cached_sandbox(self) -> None:
+        mock_instance = Mock()
+        mcp_server._sandbox = mock_instance
+        mcp_server._cleanup_sandbox()
+        mock_instance.kill.assert_called_once()
+        assert mcp_server._sandbox is None
+
+
+# ── main loop ──────────────────────────────────────────────────────────
+
+
+def test_main_uses_newline_delimited_json_and_cleans_up() -> None:
+    request = json.dumps({"jsonrpc": "2.0", "method": "tools/list", "id": 9})
+    stdin = io.StringIO(request + "\n")
+    stdout = io.StringIO()
+    with (
+        patch.object(sys, "stdin", stdin),
+        patch.object(sys, "stdout", stdout),
+        patch.object(mcp_server, "_cleanup_sandbox") as cleanup,
+    ):
+        mcp_server.main()
+
+    lines = stdout.getvalue().splitlines()
+    assert len(lines) == 1
+    assert json.loads(lines[0])["id"] == 9
+    cleanup.assert_called_once()
+
+
+def test_main_exits_cleanly_on_eof() -> None:
+    stdin = io.StringIO("")
+    with (
+        patch.object(sys, "stdin", stdin),
+        patch.object(sys, "stdout", io.StringIO()),
+        patch.object(mcp_server, "_cleanup_sandbox") as cleanup,
+    ):
+        mcp_server.main()
+    cleanup.assert_called_once()

--- a/examples/opencode-integration/tests/test_opencode_common.py
+++ b/examples/opencode-integration/tests/test_opencode_common.py
@@ -1,0 +1,105 @@
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for _opencode_common.py — shared sandbox helpers.
+
+Mirrors the structure of test_common.py in the Claude Code integration
+so the two examples can be reviewed side-by-side. Differences:
+
+- The OpenCode helper accepts both ``envs=`` (e2b-compatible) and ``env=``
+  (older SDKs); the test pins the fallback path so a regression in either
+  signature does not silently mask a TypeError.
+- We duck-type on ``exit_code`` rather than catching
+  ``CommandExitException`` because the two supported SDKs disagree on
+  whether non-zero exits raise. Test ensures the helper never lets an
+  exception escape the call boundary.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, Mock
+
+from e2b.sandbox.commands.command_handle import CommandExitException
+
+import _opencode_common
+
+
+def make_result(exit_code: int = 0, stdout: str = "", stderr: str = "") -> Mock:
+    """Create a mock command result with the three attrs our helpers read."""
+    r = Mock()
+    r.exit_code = exit_code
+    r.stdout = stdout
+    r.stderr = stderr
+    return r
+
+
+# ── run_command ──────────────────────────────────────────────────────────
+
+
+class TestRunCommand:
+    """Tests for _opencode_common.run_command() — exec-channel wrapper."""
+
+    def test_returns_result_on_success(self) -> None:
+        sandbox = Mock()
+        expected = make_result(0, "ok", "")
+        sandbox.commands.run.return_value = expected
+        result = _opencode_common.run_command(sandbox, "echo hello")
+        assert result is expected
+
+    def test_returns_result_on_non_zero_exit(self) -> None:
+        # run_command swallows CommandExitException and returns it as the result,
+        # so callers can uniformly branch on exit_code without catching everywhere.
+        sandbox = Mock()
+        exc = CommandExitException(
+            stderr="err", stdout="out", exit_code=1, error="failure"
+        )
+        sandbox.commands.run.side_effect = exc
+        result = _opencode_common.run_command(sandbox, "false")
+        assert result is exc
+
+    def test_default_user_is_user(self) -> None:
+        # The e2b / CubeSandbox exec channel rejects unknown usernames, so
+        # we hard-code ``user`` (uid 1000) as the default non-root account.
+        sandbox = Mock()
+        sandbox.commands.run.return_value = make_result()
+        _opencode_common.run_command(sandbox, "ls")
+        sandbox.commands.run.assert_called_once_with("ls", user="user")
+
+    def test_passes_timeout_and_cwd(self) -> None:
+        sandbox = Mock()
+        sandbox.commands.run.return_value = make_result()
+        _opencode_common.run_command(sandbox, "whoami", cwd="/tmp", timeout=42)
+        kwargs = sandbox.commands.run.call_args.kwargs
+        assert kwargs["cwd"] == "/tmp"
+        assert kwargs["timeout"] == 42
+
+    def test_falls_back_to_env_kwarg_for_legacy_sdk(self) -> None:
+        # Older SDKs name the parameter ``env`` instead of ``envs``. Only
+        # retry for that specific signature mismatch — other TypeErrors
+        # (wrong-type command, etc.) must propagate so real bugs surface.
+        sandbox = Mock()
+        sandbox.commands.run.side_effect = [
+            TypeError("unexpected keyword argument 'envs'"),
+            make_result(0, "", ""),
+        ]
+        _opencode_common.run_command(sandbox, "printenv", envs={"K": "v"})
+        # Second call must use the renamed ``env`` kwarg.
+        kwargs = sandbox.commands.run.call_args_list[1].kwargs
+        assert "envs" not in kwargs
+        assert kwargs["env"] == {"K": "v"}
+
+    def test_non_envs_typeerror_propagates(self) -> None:
+        # A TypeError that has nothing to do with the envs→env rename must
+        # not be silently masked.
+        sandbox = Mock()
+        sandbox.commands.run.side_effect = TypeError("bad arg shape")
+        with __import__("pytest").raises(TypeError, match="bad arg shape"):
+            _opencode_common.run_command(sandbox, "x")
+
+    def test_stream_mode_attaches_on_stdout_and_stderr(self) -> None:
+        sandbox = Mock()
+        sandbox.commands.run.return_value = make_result()
+        _opencode_common.run_command(sandbox, "tail -f", stream=True)
+        kwargs = sandbox.commands.run.call_args.kwargs
+        assert callable(kwargs["on_stdout"])
+        assert callable(kwargs["on_stderr"])

--- a/examples/opencode-integration/tests/test_sandbox_exec.py
+++ b/examples/opencode-integration/tests/test_sandbox_exec.py
@@ -1,0 +1,233 @@
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for sandbox_exec.py — session-based cross-process sandbox reuse.
+
+Mirrors the structure of the Claude Code integration's test_sandbox_exec.py
+so the two examples can be reviewed side-by-side.
+"""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import Mock, patch
+
+import pytest
+
+import sandbox_exec
+
+
+@pytest.fixture
+def temp_session(monkeypatch: pytest.MonkeyPatch, tmp_path):
+    """Use a temporary session file for test isolation.
+
+    Without this fixture, every test would write to
+    ``/tmp/cubesandbox_opencode_session_<uid>`` and leave stale state for
+    the next run.  CUBE_TEMPLATE_ID is patched both in the env (for real
+    runs) and as a module-level variable (because the module reads it once
+    at import time).
+    """
+    monkeypatch.setenv("CUBE_TEMPLATE_ID", "tpl-test")
+    monkeypatch.setattr(sandbox_exec, "TEMPLATE_ID", "tpl-test")
+    session_file = tmp_path / "session"
+    monkeypatch.setattr(sandbox_exec, "SESSION_FILE", session_file)
+    monkeypatch.setattr(sandbox_exec, "_sandbox", None)
+    return session_file
+
+
+# ── _get_sandbox ───────────────────────────────────────────────────────
+
+
+class TestGetSandbox:
+    """Tests for sandbox_exec._get_sandbox() — cross-process session reuse."""
+
+    def test_creates_new_sandbox_when_no_session(self, temp_session) -> None:
+        mock_instance = Mock()
+        mock_instance.sandbox_id = "sb-new"
+        with patch("sandbox_exec.Sandbox") as mock_cls:
+            mock_cls.create.return_value = mock_instance
+            result = sandbox_exec._get_sandbox()
+        assert result is mock_instance
+        mock_cls.create.assert_called_once()
+        assert temp_session.exists()
+        assert temp_session.read_text() == "sb-new"
+
+    def test_reconnects_from_session_file(self, temp_session) -> None:
+        # Reuses a sandbox from a previous --keep-alive run by reading the
+        # session file and calling Sandbox.connect() instead of create().
+        temp_session.write_text("sb-existing")
+        mock_instance = Mock()
+        with patch("sandbox_exec.Sandbox") as mock_cls:
+            mock_cls.connect.return_value = mock_instance
+            result = sandbox_exec._get_sandbox(timeout=300)
+        assert result is mock_instance
+        mock_cls.connect.assert_called_once_with("sb-existing")
+        mock_cls.create.assert_not_called()
+        mock_instance.set_timeout.assert_called_once_with(300)
+
+    def test_clears_stale_session_on_connect_failure(self, temp_session) -> None:
+        # When reconnect fails (sandbox expired), the stale session file
+        # is cleaned up and a fresh sandbox is created.
+        temp_session.write_text("sb-stale")
+        new_instance = Mock()
+        new_instance.sandbox_id = "sb-fresh"
+        with patch("sandbox_exec.Sandbox") as mock_cls:
+            mock_cls.connect.side_effect = Exception("not found")
+            mock_cls.create.return_value = new_instance
+            result = sandbox_exec._get_sandbox()
+        assert result is new_instance
+        assert temp_session.read_text() == "sb-fresh"
+
+    def test_reuses_in_process_cache(self, temp_session) -> None:
+        mock_instance = Mock()
+        sandbox_exec._sandbox = mock_instance
+        result = sandbox_exec._get_sandbox()
+        assert result is mock_instance
+
+    def test_writes_session_file_on_create(self, temp_session) -> None:
+        mock_instance = Mock()
+        mock_instance.sandbox_id = "sb-123"
+        with patch("sandbox_exec.Sandbox") as mock_cls:
+            mock_cls.create.return_value = mock_instance
+            sandbox_exec._get_sandbox()
+        assert temp_session.read_text() == "sb-123"
+
+    def test_raises_when_template_id_unset(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # Test isolation: do NOT use temp_session which already sets TEMPLATE_ID.
+        # Only patch SESSION_FILE and _sandbox so _get_sandbox() reaches the
+        # TEMPLATE_ID check before the SDK is invoked.
+        import pathlib
+        fake_session = pathlib.Path("/dev/null")
+        monkeypatch.setattr(sandbox_exec, "SESSION_FILE", fake_session)
+        monkeypatch.setattr(sandbox_exec, "_sandbox", None)
+        monkeypatch.delenv("CUBE_TEMPLATE_ID", raising=False)
+        monkeypatch.setattr(sandbox_exec, "TEMPLATE_ID", "")
+        with pytest.raises(SystemExit, match="CUBE_TEMPLATE_ID"):
+            sandbox_exec._get_sandbox()
+
+    @pytest.mark.skipif(not hasattr(os, "O_NOFOLLOW"), reason="O_NOFOLLOW unavailable")
+    def test_session_helpers_reject_symlink(self, temp_session, tmp_path) -> None:
+        # A symlink attack would let an attacker point us at an arbitrary
+        # file before the write happens. O_NOFOLLOW + S_ISREG close that.
+        target = tmp_path / "attacker-session"
+        target.write_text("sb-attacker")
+        temp_session.symlink_to(target)
+
+        assert sandbox_exec._read_session() is None
+        with pytest.raises(OSError):
+            sandbox_exec._write_session("sb-safe")
+        # The attacker-controlled file must not have been overwritten.
+        assert target.read_text() == "sb-attacker"
+
+
+# ── cleanup ────────────────────────────────────────────────────────────
+
+
+class TestCleanup:
+    """Tests for sandbox_exec.cleanup() — sandbox destruction."""
+
+    def test_kills_sandbox_and_clears_session(self, temp_session) -> None:
+        mock_instance = Mock()
+        sandbox_exec._sandbox = mock_instance
+        temp_session.write_text("sb-1")
+        sandbox_exec.cleanup()
+        mock_instance.kill.assert_called_once()
+        assert sandbox_exec._sandbox is None
+        assert not temp_session.exists()
+
+    def test_no_error_when_no_sandbox(self, temp_session) -> None:
+        sandbox_exec._sandbox = None
+        temp_session.write_text("sb-1")
+        sandbox_exec.cleanup()
+        assert not temp_session.exists()
+
+    def test_no_error_when_kill_fails(self, temp_session) -> None:
+        # cleanup catches kill exceptions so a dead sandbox does not mask
+        # the original error or leave the session file behind.
+        mock_instance = Mock()
+        mock_instance.kill.side_effect = Exception("already dead")
+        sandbox_exec._sandbox = mock_instance
+        temp_session.write_text("sb-1")
+        sandbox_exec.cleanup()
+        assert sandbox_exec._sandbox is None
+        assert not temp_session.exists()
+
+    def test_clears_session_even_without_sandbox(self, temp_session) -> None:
+        temp_session.write_text("sb-orphan")
+        sandbox_exec._sandbox = None
+        sandbox_exec.cleanup()
+        assert not temp_session.exists()
+
+
+# ── public exec API ────────────────────────────────────────────────────
+
+
+class TestExecApi:
+    """Tests for the public exec_code / exec_file / exec_cmd entry points."""
+
+    def test_exec_code_returns_stdout_on_success(self, temp_session) -> None:
+        sb = Mock()
+        sb.commands.run.return_value = Mock(exit_code=0, stdout="hello", stderr="")
+        sandbox_exec._sandbox = sb
+        out = sandbox_exec.exec_code("print('hello')")
+        assert out == "hello"
+
+    def test_exec_code_returns_stderr_on_failure(self, temp_session) -> None:
+        sb = Mock()
+        sb.commands.run.return_value = Mock(exit_code=1, stdout="", stderr="boom")
+        sandbox_exec._sandbox = sb
+        out = sandbox_exec.exec_code("1/0")
+        assert "boom" in out
+        assert "[error]" in out
+
+    def test_exec_code_installs_pip_first(self, temp_session) -> None:
+        sb = Mock()
+        sb.commands.run.side_effect = [
+            Mock(exit_code=0, stdout="", stderr=""),  # pip install
+            Mock(exit_code=0, stdout="1.0", stderr=""),  # python -c
+        ]
+        sandbox_exec._sandbox = sb
+        sandbox_exec.exec_code("import x", pip_packages=["x"])
+        first_cmd = sb.commands.run.call_args_list[0][0][0]
+        assert "pip install" in first_cmd
+
+    def test_exec_code_reports_pip_error(self, temp_session) -> None:
+        sb = Mock()
+        sb.commands.run.return_value = Mock(exit_code=1, stdout="", stderr="bad pkg")
+        sandbox_exec._sandbox = sb
+        out = sandbox_exec.exec_code("import x", pip_packages=["x"])
+        assert "[pip error]" in out
+        assert "bad pkg" in out
+
+    def test_exec_cmd_returns_stdout_on_success(self, temp_session) -> None:
+        sb = Mock()
+        sb.commands.run.return_value = Mock(exit_code=0, stdout="root", stderr="")
+        sandbox_exec._sandbox = sb
+        out = sandbox_exec.exec_cmd("whoami")
+        assert out == "root"
+
+    def test_exec_cmd_returns_stderr_on_failure(self, temp_session) -> None:
+        sb = Mock()
+        sb.commands.run.return_value = Mock(exit_code=2, stdout="", stderr="denied")
+        sandbox_exec._sandbox = sb
+        out = sandbox_exec.exec_cmd("rm /etc/shadow")
+        assert "[error]" in out
+        assert "denied" in out
+
+    def test_exec_file_copies_and_executes(self, temp_session, tmp_path) -> None:
+        sb = Mock()
+        sb.commands.run.return_value = Mock(exit_code=0, stdout="42", stderr="")
+        sandbox_exec._sandbox = sb
+        script = tmp_path / "x.py"
+        script.write_text("print(42)")
+        out = sandbox_exec.exec_file(str(script))
+        assert out == "42"
+        # First call writes the script, second call runs it.
+        sb.files.write.assert_called_once()
+
+    def test_exec_file_handles_missing_local_file(self, temp_session) -> None:
+        sb = Mock()
+        sandbox_exec._sandbox = sb
+        out = sandbox_exec.exec_file("/nonexistent/path.py")
+        assert "[error]" in out
+        assert "cannot read" in out


### PR DESCRIPTION
## feat(examples): add OpenCode integration guide and examples（Refs #644 ）
 Refs #644
<img width="1089" height="1166" alt="屏幕截图 2026-07-18 163049" src="https://github.com/user-attachments/assets/37f28e7d-9314-41a7-bf58-089a365a2808" />
<img width="1135" height="170" alt="屏幕截图 2026-07-18 171711" src="https://github.com/user-attachments/assets/59e3d8a9-6cb2-463b-a9f8-a5776cc09612" />

## Problem

CubeSandbox has integration examples for Claude Code but lacked an
OpenCode reference. OpenCode is a terminal-native, open-source AI coding
agent with a different plugin model (JS/Bun hooks instead of Claude's
PreToolUse Python hook). Users otherwise need to assemble templates,
credential injection, egress policy, session persistence, MCP tools, and
Bash isolation themselves.

## Solution

Add bilingual guides and one runnable example covering four execution
modes:

1. **One-shot headless run** — `run_opencode.py` spins up a short-lived
   sandbox, forwards the prompt, and exits.
2. **Session persistence** — `resume_opencode.py` uses `sandbox.pause()` /
   `Sandbox.connect()` to retain OpenCode's data dir across turns.
3. **Credential vault** — `network_policy.py` applies default-deny egress
   and CubeEgress key injection so the provider token never enters the VM.
4. **Bash routing via OpenCode plugin** — `hooks/` ships a JS plugin
   (`tool.execute.before`) that intercepts `bash` calls and transparently
   forwards them through a reusable sandbox; `install.sh` copies only
   allowlisted `CUBE_*` settings into the installed config.

Additionally, two generic execution paths that do not require the OpenCode
agent itself:

5. **`sandbox_exec.py`** — host-side CLI for `--code` / `--file` /
   `--cmd` / `--pip` with UID-scoped session file for cross-process
   sandbox reuse.
6. **`mcp_server.py`** — JSON-RPC stdio MCP server exposing 5 sandbox
   tools (`run_code`, `run_command`, `write_file`, `read_file`, `reset`)
   so any MCP client (Claude Desktop, Cursor, Windsurf, …) can run
   untrusted code in the sandbox.

## Changes

- Add English and Chinese integration guides and index entries.
- Add `examples/opencode-integration/` with Dockerfile, one-shot, resume,
  network policy, standalone executor, MCP server, and hook examples.
- Scope host state by UID, use owner-only permissions, atomically update
  state, and serialize each hook session.
- Keep optional host mounts read-only and document co-location/shared-path
  requirements.
- Copy only allowlisted `CUBE_*` values into installed hook configuration;
  provider credentials are excluded.
- Use the MCP stdio transport's newline-delimited JSON-RPC framing.
- Preserve command exit codes plus stdout and stderr in MCP tool results
  and set `isError` for failures.
- Destroy the cached MCP sandbox on reset, stdin EOF, and process exit.
- Support OpenCode's provider inference (Anthropic, OpenAI, Google, DeepSeek,
  OpenRouter, Groq, Mistral, etc.) through `*_BASE_URL` or explicit
  `OPENCODE_PROVIDER`.
- `run_command` unifies `CommandExitException` handling so callers can
  branch uniformly on `exit_code` without catching at every call site.

## Security boundaries

- This PR adds examples and documentation only; it does not change
  CubeSandbox runtime or API behavior.
- The hook covers Bash. OpenCode Read, Write, and Edit tools still run on
  the host.
- Hook failures block Bash execution.
- The optional project mount is read-only; if the mount cannot be created,
  Bash remains isolated in a sandbox without the shared file view.
- Real provider credentials are injected at egress and are not stored in the
  sandbox or installed hook configuration.

## Verification

```text
cd examples/opencode-integration
python3 -m pytest tests/ -q
133 passed in 0.29s

python3 -m py_compile sandbox_exec.py mcp_server.py _opencode_common.py \
  env_utils.py run_opencode.py resume_opencode.py network_policy.py
passed

bash -n hooks/install.sh
passed

ruff check examples/opencode-integration
passed
Assisted-by: Cursor:composer-2.5-fast
Signed-off-by: YanxuanLiu [3205348955@qq.com](mailto:3205348955@qq.com)