### PR TITLE
feat(version): upgrade component version inventory with component-json source and incomplete-report handling

### DIFF
--- a/CubeEgress/start.sh
+++ b/CubeEgress/start.sh
@@ -7,6 +7,7 @@
 #   3. Assert placeholder cert/key exist (host pre-generates them)
 #   4. Assert audit log dir is writable as the cube-proxy worker uid
 #   5. nginx -t (config validity)
+#   5b. Optional: write cube-egress/version.json for inventory (best-effort)
 #   6. exec openresty as PID 1
 
 set -euo pipefail
@@ -169,6 +170,58 @@ fi
 configure_listen_ip
 log "Running nginx -t"
 "${NGINX_BIN}" -t
+
+# -------- 5b. Version marker for inventory (optional) --------
+# Write TOOLBOX/cube-egress/version.json when toolbox is mounted and writable.
+# Skip when toolbox is absent (e.g. one-click without that mount).
+json_string_field() {
+    sed -n "s/.*\"${1}\"[[:space:]]*:[[:space:]]*\"\\([^\"]*\\)\".*/\\1/p" "${2}" | head -n1
+}
+
+publish_version_json() {
+    local src="${CUBE_EGRESS_VERSION_JSON:-/etc/cube/version.json}"
+    local dst="${CUBE_EGRESS_VERSION_PATH:-/usr/local/services/cubetoolbox/cube-egress/version.json}"
+    local dst_dir toolbox_root ver commit built tmp
+
+    dst_dir="$(dirname "${dst}")"
+    toolbox_root="$(dirname "${dst_dir}")"
+    if [[ ! -d "${dst_dir}" ]]; then
+        if [[ -d "${toolbox_root}" && -w "${toolbox_root}" ]]; then
+            mkdir -p "${dst_dir}" || {
+                log "version.json skipped: cannot mkdir ${dst_dir}"
+                return 0
+            }
+        else
+            log "version.json skipped: ${dst_dir} not present"
+            return 0
+        fi
+    fi
+    [[ -w "${dst_dir}" ]] || {
+        log "version.json skipped: ${dst_dir} not writable"
+        return 0
+    }
+    [[ -f "${src}" ]] || {
+        log "version.json skipped: missing ${src}"
+        return 0
+    }
+
+    ver="$(json_string_field version "${src}")"
+    commit="$(json_string_field commit "${src}")"
+    built="$(json_string_field build_time "${src}")"
+    [[ -n "${ver}" ]] || {
+        log "version.json skipped: empty version in ${src}"
+        return 0
+    }
+    case "${ver}${commit}${built}" in
+        *\"*|*$'\n'*|*\\*) log "version.json skipped: unsafe token in ${src}"; return 0 ;;
+    esac
+
+    tmp="${dst}.tmp.$$"
+    printf '%s\n' "{\"schema_version\":1,\"components\":{\"cube-egress\":{\"version\":\"${ver}\",\"commit\":\"${commit}\",\"build_time\":\"${built}\"}}}" > "${tmp}"
+    mv -f "${tmp}" "${dst}"
+    log "wrote ${dst} (version=${ver})"
+}
+publish_version_json
 
 # -------- 6. exec openresty (becomes PID 1) --------
 log "Starting openresty (PID 1)"

--- a/CubeMaster/pkg/nodemeta/service.go
+++ b/CubeMaster/pkg/nodemeta/service.go
@@ -37,13 +37,14 @@ type ResourceSnapshot struct {
 
 // ComponentVersion mirrors the cubelet-side masterclient.ComponentVersion.
 // It carries the real version of one component installed on a node. Source is
-// one of "manifest" | "binary" | "file".
+// one of "manifest" | "binary" | "file" | "component-json".
 type ComponentVersion struct {
 	Component string `json:"component"`
 	Version   string `json:"version,omitempty"`
 	Commit    string `json:"commit,omitempty"`
 	BuildTime string `json:"build_time,omitempty"`
 	Source    string `json:"source,omitempty"`
+	Variant   string `json:"variant,omitempty"` // kernel: bm|pvm
 }
 
 type ContainerImage struct {
@@ -76,6 +77,7 @@ type RegisterNodeRequest struct {
 	CreateConcurrentNum int64              `json:"create_concurrent_num,omitempty"`
 	MaxMvmNum           int64              `json:"max_mvm_num,omitempty"`
 	Versions            []ComponentVersion `json:"versions,omitempty"`
+	InventoryIncomplete bool               `json:"inventory_incomplete,omitempty"`
 }
 
 type UpdateNodeStatusRequest struct {
@@ -89,7 +91,8 @@ type UpdateNodeStatusRequest struct {
 	DiskUsage  *DiskUsage          `json:"disk_usage,omitempty"`
 	MetricTime time.Time           `json:"metric_time,omitempty"`
 
-	Versions []ComponentVersion `json:"versions,omitempty"`
+	Versions            []ComponentVersion `json:"versions,omitempty"`
+	InventoryIncomplete bool               `json:"inventory_incomplete,omitempty"`
 }
 
 // AllocatedResources is cubelet-side aggregation of sandbox-quota CPU /
@@ -284,7 +287,7 @@ func RegisterNode(ctx context.Context, req *RegisterNodeRequest) (*NodeSnapshot,
 	applyCurrentHealth(snap, time.Now())
 	global.mu.Unlock()
 	syncLocalcache(snap)
-	global.persistVersions(ctx, req.NodeID, req.Versions)
+	global.persistVersions(ctx, req.NodeID, req.Versions, req.InventoryIncomplete)
 	return cloneSnapshot(snap), nil
 }
 
@@ -335,51 +338,101 @@ func UpdateNodeStatus(ctx context.Context, nodeID string, req *UpdateNodeStatusR
 	// hundreds of nodes would otherwise dominate write traffic, and Redis
 	// already provides the cross-replica fan-out used by the scheduler.
 	fanOutResourceMetric(ctx, nodeID, req)
-	global.persistVersions(ctx, nodeID, req.Versions)
+	global.persistVersions(ctx, nodeID, req.Versions, req.InventoryIncomplete)
 	return cloneSnapshot(snap), nil
 }
+
+// incompleteVersionsHashTag is appended to the content hash when the report
+// is inventory-incomplete, so a later complete report with the same merge
+// result still triggers a write (and can hard-delete stale rows).
+const incompleteVersionsHashTag = "|incomplete"
 
 // persistVersions records the node's component versions, skipping the DB
 // write entirely when the reported set is unchanged (content-hash compare
 // against the in-memory snapshot). This keeps the 10s heartbeat from turning
 // slow-changing version data into a MySQL write storm.
-func (s *service) persistVersions(ctx context.Context, nodeID string, versions []ComponentVersion) {
-	s.persistVersionsWithWriter(ctx, nodeID, versions, s.writeVersions)
+//
+// When inventoryIncomplete is true, missing components are not deleted from
+// the DB (upsert-only) so a transient collection gap cannot wipe history.
+// The skip-hash then compares against merge(prev, reported) so incomplete
+// heartbeats that do not change the effective inventory are no-ops.
+func (s *service) persistVersions(ctx context.Context, nodeID string, versions []ComponentVersion, inventoryIncomplete bool) {
+	s.persistVersionsWithWriter(ctx, nodeID, versions, inventoryIncomplete, s.writeVersions)
 }
 
 func (s *service) persistVersionsWithWriter(
 	ctx context.Context,
 	nodeID string,
 	versions []ComponentVersion,
-	writer func(string, []ComponentVersion) error,
+	inventoryIncomplete bool,
+	writer func(string, []ComponentVersion, bool) error,
 ) {
 	if len(versions) == 0 {
 		return
 	}
 	unlock := s.lockVersionWrite(nodeID)
 	defer unlock()
-	h := versionsHash(versions)
 	snap := s.ensureNode(nodeID)
 	s.mu.RLock()
-	unchanged := snap.versionsHash == h
+	prevVersions := append([]ComponentVersion(nil), snap.Versions...)
+	prevHash := snap.versionsHash
 	prevCompat := compatRelevantVersions(snap.Versions)
 	s.mu.RUnlock()
-	if unchanged {
+
+	// Complete reports hash the payload as-is. Incomplete reports hash the
+	// merge with the previous snapshot so a partial collect does not look
+	// like a wholesale version change (and does not delete absent keys).
+	var h string
+	var merged []ComponentVersion
+	if inventoryIncomplete {
+		merged = mergeComponentVersions(prevVersions, versions)
+		h = versionsHash(merged) + incompleteVersionsHashTag
+	} else {
+		h = versionsHash(versions)
+	}
+	if prevHash == h {
 		log.G(ctx).Debugf("version_write_skipped node=%s", nodeID)
 		return
 	}
-	if err := writer(nodeID, versions); err != nil {
+	if err := writer(nodeID, versions, inventoryIncomplete); err != nil {
 		log.G(ctx).Warnf("write node component versions failed for %s: %v", nodeID, err)
 		return
 	}
 	s.mu.Lock()
-	snap.Versions = append([]ComponentVersion(nil), versions...)
-	snap.versionsHash = h
+	if inventoryIncomplete {
+		snap.Versions = merged
+		snap.versionsHash = h
+	} else {
+		snap.Versions = append([]ComponentVersion(nil), versions...)
+		snap.versionsHash = h
+	}
 	s.mu.Unlock()
-	log.G(ctx).Debugf("version_write_applied node=%s components=%d", nodeID, len(versions))
-	if OnGuestAgentVersionChanged != nil && compatVersionsChanged(prevCompat, compatRelevantVersions(versions)) {
+	log.G(ctx).Debugf("version_write_applied node=%s components=%d incomplete=%v", nodeID, len(versions), inventoryIncomplete)
+	if OnGuestAgentVersionChanged != nil && compatVersionsChanged(prevCompat, compatRelevantVersions(snap.Versions)) {
 		go OnGuestAgentVersionChanged(nodeID)
 	}
+}
+
+func mergeComponentVersions(prev, next []ComponentVersion) []ComponentVersion {
+	byName := make(map[string]ComponentVersion, len(prev)+len(next))
+	for _, v := range prev {
+		if v.Component == "" {
+			continue
+		}
+		byName[v.Component] = v
+	}
+	for _, v := range next {
+		if v.Component == "" {
+			continue
+		}
+		byName[v.Component] = v
+	}
+	out := make([]ComponentVersion, 0, len(byName))
+	for _, v := range byName {
+		out = append(out, v)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Component < out[j].Component })
+	return out
 }
 
 func (s *service) lockVersionWrite(nodeID string) func() {
@@ -389,11 +442,10 @@ func (s *service) lockVersionWrite(nodeID string) func() {
 	return lock.Unlock
 }
 
-// writeVersions upserts the reported component rows and physically removes
-// any component previously recorded for the node but absent from this report.
-// The table carries no soft-delete column, so Delete is a hard delete by
-// design (see models.NodeComponentVersion).
-func (s *service) writeVersions(nodeID string, versions []ComponentVersion) error {
+// writeVersions upserts the reported component rows. When inventoryIncomplete
+// is false, physically removes any component previously recorded for the node
+// but absent from this report. When true, only upserts (plan M0).
+func (s *service) writeVersions(nodeID string, versions []ComponentVersion, inventoryIncomplete bool) error {
 	now := time.Now().Unix()
 	rows := make([]*models.NodeComponentVersion, 0, len(versions))
 	keep := make([]string, 0, len(versions))
@@ -423,6 +475,9 @@ func (s *service) writeVersions(nodeID string, versions []ComponentVersion) erro
 				return err
 			}
 		}
+		if inventoryIncomplete {
+			return nil
+		}
 		del := tx.Where("node_id = ?", nodeID)
 		if len(keep) > 0 {
 			del = del.Where("component NOT IN ?", keep)
@@ -441,7 +496,7 @@ func versionsHash(versions []ComponentVersion) string {
 	sort.Slice(sorted, func(i, j int) bool { return sorted[i].Component < sorted[j].Component })
 	h := fnv.New64a()
 	for _, v := range sorted {
-		fmt.Fprintf(h, "%s|%s|%s|%s|%s\n", v.Component, v.Version, v.Commit, v.BuildTime, v.Source)
+		fmt.Fprintf(h, "%s|%s|%s|%s|%s|%s\n", v.Component, v.Version, v.Commit, v.BuildTime, v.Source, v.Variant)
 	}
 	return strconv.FormatUint(h.Sum64(), 16)
 }

--- a/CubeMaster/pkg/nodemeta/service_test.go
+++ b/CubeMaster/pkg/nodemeta/service_test.go
@@ -20,7 +20,8 @@ func TestPersistVersionsSkipsDuplicateConcurrentWrite(t *testing.T) {
 	secondWriteStarted := make(chan struct{}, 1)
 	var writeCount atomic.Int32
 
-	writer := func(nodeID string, got []ComponentVersion) error {
+	writer := func(nodeID string, got []ComponentVersion, incomplete bool) error {
+		_ = incomplete
 		switch writeCount.Add(1) {
 		case 1:
 			close(firstWriteStarted)
@@ -34,7 +35,7 @@ func TestPersistVersionsSkipsDuplicateConcurrentWrite(t *testing.T) {
 	done1 := make(chan struct{})
 	go func() {
 		defer close(done1)
-		s.persistVersionsWithWriter(context.Background(), "node-1", versions, writer)
+		s.persistVersionsWithWriter(context.Background(), "node-1", versions, false, writer)
 	}()
 
 	<-firstWriteStarted
@@ -42,7 +43,7 @@ func TestPersistVersionsSkipsDuplicateConcurrentWrite(t *testing.T) {
 	done2 := make(chan struct{})
 	go func() {
 		defer close(done2)
-		s.persistVersionsWithWriter(context.Background(), "node-1", versions, writer)
+		s.persistVersionsWithWriter(context.Background(), "node-1", versions, false, writer)
 	}()
 
 	select {
@@ -70,5 +71,47 @@ func TestPersistVersionsSkipsDuplicateConcurrentWrite(t *testing.T) {
 	}
 	if len(snap.Versions) != len(versions) || snap.Versions[0] != versions[0] {
 		t.Fatalf("versions = %#v, want %#v", snap.Versions, versions)
+	}
+}
+
+func TestPersistVersionsIncompleteKeepsPriorComponents(t *testing.T) {
+	s := &service{nodes: make(map[string]*NodeSnapshot)}
+	full := []ComponentVersion{
+		{Component: "cubelet", Version: "v1"},
+		{Component: "guest-image", Version: "g1"},
+	}
+	partial := []ComponentVersion{
+		{Component: "cubelet", Version: "v2"},
+	}
+	var incompleteWrites atomic.Int32
+	var completeWrites atomic.Int32
+	writer := func(nodeID string, got []ComponentVersion, incomplete bool) error {
+		if incomplete {
+			incompleteWrites.Add(1)
+			if len(got) != 1 {
+				t.Fatalf("incomplete writer got %#v", got)
+			}
+			return nil
+		}
+		completeWrites.Add(1)
+		return nil
+	}
+	s.persistVersionsWithWriter(context.Background(), "n1", full, false, writer)
+	s.persistVersionsWithWriter(context.Background(), "n1", partial, true, writer)
+	if incompleteWrites.Load() != 1 || completeWrites.Load() != 1 {
+		t.Fatalf("complete=%d incomplete=%d", completeWrites.Load(), incompleteWrites.Load())
+	}
+	s.mu.RLock()
+	snap := s.nodes["n1"]
+	s.mu.RUnlock()
+	if len(snap.Versions) != 2 {
+		t.Fatalf("merged versions len=%d want 2: %#v", len(snap.Versions), snap.Versions)
+	}
+	by := map[string]string{}
+	for _, v := range snap.Versions {
+		by[v.Component] = v.Version
+	}
+	if by["cubelet"] != "v2" || by["guest-image"] != "g1" {
+		t.Fatalf("merged map=%v", by)
 	}
 }

--- a/Cubelet/pkg/cubelet/node_status.go
+++ b/Cubelet/pkg/cubelet/node_status.go
@@ -523,7 +523,9 @@ func (kl *Cubelet) buildRegisterRequest(node *cubeletnodemeta.Node) *masterclien
 	req.QuotaCPU = resolveHostQuotaCPUMilli(hostCfg, req.Allocatable.MilliCPU, req.Capacity.MilliCPU)
 	req.QuotaMemMB = resolveHostQuotaMemMB(hostCfg, req.Allocatable.MemoryMB, req.Capacity.MemoryMB)
 	req.MaxMvmNum = resolveHostMaxMvmNum(hostCfg, req.QuotaMemMB)
-	req.Versions = kl.collectVersions()
+	versions, incomplete := kl.collectVersionReport()
+	req.Versions = versions
+	req.InventoryIncomplete = incomplete
 	return req
 }
 
@@ -535,31 +537,32 @@ func (kl *Cubelet) buildStatusRequest(node *cubeletnodemeta.Node) *masterclient.
 		HeartbeatTime:  kl.clock.Now(),
 	}
 	attachResourceReport(req, kl.clock.Now())
-	req.Versions = kl.collectVersions()
+	versions, incomplete := kl.collectVersionReport()
+	req.Versions = versions
+	req.InventoryIncomplete = incomplete
 	return req
 }
 
-// collectVersions gathers this node's component versions for reporting. It is
-// best-effort: a nil collector or empty result simply omits the field.
-func (kl *Cubelet) collectVersions() []masterclient.ComponentVersion {
+func (kl *Cubelet) collectVersionReport() ([]masterclient.ComponentVersion, bool) {
 	if kl.versionCollector == nil {
-		return nil
+		return nil, false
 	}
-	collected := kl.versionCollector.Collect()
-	if len(collected) == 0 {
-		return nil
+	report := kl.versionCollector.CollectReport()
+	if len(report.Versions) == 0 {
+		return nil, report.Incomplete
 	}
-	out := make([]masterclient.ComponentVersion, 0, len(collected))
-	for _, v := range collected {
+	out := make([]masterclient.ComponentVersion, 0, len(report.Versions))
+	for _, v := range report.Versions {
 		out = append(out, masterclient.ComponentVersion{
 			Component: v.Component,
 			Version:   v.Version,
 			Commit:    v.Commit,
 			BuildTime: v.BuildTime,
 			Source:    v.Source,
+			Variant:   v.Variant,
 		})
 	}
-	return out
+	return out, report.Incomplete
 }
 
 // attachResourceReport folds the allocated-resource and disk-usage views

--- a/Cubelet/pkg/cubelet/versioninfo/collector.go
+++ b/Cubelet/pkg/cubelet/versioninfo/collector.go
@@ -6,31 +6,25 @@
 // on a cubelet node and normalises them into a flat list for reporting to
 // cubemaster on register / heartbeat.
 //
-// Primary data source is the release-manifest.json installed alongside the
-// node binaries (machine-readable, complete, release-consistent). Four
-// adjustments are layered on top:
+// Primary data source is per-component version.json next to staged artifacts.
+// Fallbacks, in order:
 //
-//  1. the cubelet entry is overridden with the running binary's own
-//     pkg/version (the truly-running cubelet, not just what the manifest
-//     shipped);
-//  2. guest-image is taken from the on-node cube-image/version file (the
-//     version actually in effect, which may drift from the manifest), with a
-//     lazy mtime-based re-read so an out-of-band guest upgrade is picked up
-//     without restarting cubelet;
-//  3. kernel is selected from the active cube-kernel-scf/vmlinux symlink so
-//     PVM nodes report the PVM guest kernel version instead of the ordinary
-//     packaged kernel;
-//  4. components are filtered to those actually installed on this node, so a
-//     compute node does not report control-plane binaries it never runs.
+//  1. cubelet always from the running binary;
+//  2. directory version.json (allowlisted keys only);
+//  3. single-line markers (cube-image/version, agent-version, egress);
+//  4. release-manifest.json for remaining installed binary components / kernel.
 //
-// Collection never blocks register/heartbeat: a missing or malformed manifest
-// degrades to "cubelet self version + guest-image file (if present)".
+// Kernel identity prefers bootstrap-state/vmlinux-active, then the artifact
+// vmlinux symlink, and reports only the active bm|pvm variant.
+//
+// Collection never blocks register/heartbeat: missing sources degrade gracefully.
 package versioninfo
 
 import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 
 	"github.com/tencentcloud/CubeSandbox/Cubelet/pkg/controller/runtemplate/components"
@@ -39,9 +33,10 @@ import (
 
 // Source labels for ComponentVersion.Source.
 const (
-	SourceManifest = "manifest"
-	SourceBinary   = "binary"
-	SourceFile     = "file"
+	SourceManifest      = "manifest"
+	SourceBinary        = "binary"
+	SourceFile          = "file"
+	SourceComponentJSON = "component-json"
 )
 
 // Canonical component names.
@@ -54,17 +49,17 @@ const (
 )
 
 const (
-	manifestFileName  = "release-manifest.json"
-	guestImageVerPath = "cube-image/version"
-	kernelVmlinuxPath = "cube-kernel-scf/vmlinux"
-	cubeEgressVerPath = "cube-egress/version"
+	manifestFileName     = "release-manifest.json"
+	componentVersionJSON = "version.json"
+	guestImageVerPath    = "cube-image/version"
+	guestAgentVerPath    = "cube-image/agent-version"
+	kernelVmlinuxPath    = "cube-kernel-scf/vmlinux"
+	cubeEgressVerPath    = "cube-egress/version"
+	maxVersionJSONBytes  = 64 << 10
 )
 
 // oneClickInstallLayout maps manifest component keys to the concrete one-click
-// install paths that prove the component is actually present on this node. The
-// collector still supports the original "${baseDir}/<component>/" directory
-// shape first; these aliases cover the packaged control-plane layout
-// (CubeMaster/CubeAPI/Cubelet/cube-shim, etc.).
+// install paths that prove the component is actually present on this node.
 var oneClickInstallLayout = map[string][][]string{
 	"cubemaster":              {{"CubeMaster", "bin", "cubemaster"}},
 	"cubemastercli":           {{"CubeMaster", "bin", "cubemastercli"}},
@@ -76,15 +71,30 @@ var oneClickInstallLayout = map[string][][]string{
 	"cube-egress":             {{"cube-egress", "version"}},
 }
 
-// ComponentVersion is a pure-data version record. It mirrors
-// masterclient.ComponentVersion (kept independent to avoid a layering
-// dependency from this low-level package onto the HTTP client).
+// pathAllowlist restricts which component keys may be accepted from each
+// directory's version.json.
+var pathAllowlist = map[string]map[string]struct{}{
+	"Cubelet":       {"cubelet": {}, "cubecli": {}},
+	"network-agent": {"network-agent": {}},
+	"cube-shim":     {"containerd-shim-cube-rs": {}, "cube-runtime": {}},
+	"cube-image":    {"guest-image": {}, "cube-agent": {}},
+	"cube-egress":   {"cube-egress": {}},
+}
+
+// ComponentVersion is a pure-data version record.
 type ComponentVersion struct {
 	Component string
 	Version   string
 	Commit    string
 	BuildTime string
 	Source    string
+	Variant   string // kernel: bm|pvm
+}
+
+// CollectReport is the full collection outcome for one heartbeat.
+type CollectReport struct {
+	Versions   []ComponentVersion
+	Incomplete bool
 }
 
 type manifestComponent struct {
@@ -107,9 +117,24 @@ type releaseManifest struct {
 	} `json:"kernel"`
 }
 
+type componentJSONFile struct {
+	SchemaVersion int `json:"schema_version"`
+	Components    map[string]struct {
+		Version   string `json:"version"`
+		Commit    string `json:"commit"`
+		BuildTime string `json:"build_time"`
+	} `json:"components"`
+	Variants map[string]struct {
+		Version      string `json:"version"`
+		Tag          string `json:"tag"`
+		DigestSHA256 string `json:"digest_sha256"`
+	} `json:"variants"`
+}
+
 // Collector assembles the node's component versions. Safe for concurrent use.
 type Collector struct {
-	baseDir string
+	baseDir      string
+	bootstrapDir string
 
 	mu sync.Mutex
 	// manifest is parsed once and cached (nil when missing/unreadable).
@@ -126,27 +151,65 @@ type Collector struct {
 }
 
 // NewCollector builds a collector rooted at baseDir. An empty baseDir falls
-// back to the component manager's default versioned base dir (single source
-// of truth for the install layout).
+// back to the component manager's default versioned base dir.
 func NewCollector(baseDir string) *Collector {
 	if baseDir == "" {
 		baseDir = components.DefaultConfig().VersionedBaseDir
 	}
-	return &Collector{baseDir: baseDir}
+	bootstrap := strings.TrimSpace(os.Getenv("STATE_DIR"))
+	if bootstrap == "" {
+		bootstrap = strings.TrimSpace(os.Getenv("CUBE_BOOTSTRAP_STATE"))
+	}
+	if bootstrap == "" {
+		bootstrap = "/var/lib/cube-node-bootstrap"
+	}
+	return &Collector{baseDir: baseDir, bootstrapDir: bootstrap}
 }
 
-// Collect returns the current component versions for this node. It never
-// returns an error: collection failures degrade to a minimal set so the
-// heartbeat is never blocked.
+// NewCollectorWithDirs is for tests that need an isolated bootstrap state dir.
+func NewCollectorWithDirs(baseDir, bootstrapDir string) *Collector {
+	c := NewCollector(baseDir)
+	if strings.TrimSpace(bootstrapDir) != "" {
+		c.bootstrapDir = bootstrapDir
+	}
+	return c
+}
+
+// Collect returns versions only (backward compatible).
 func (c *Collector) Collect() []ComponentVersion {
+	return c.CollectReport().Versions
+}
+
+// CollectReport returns versions plus incompleteness signals.
+func (c *Collector) CollectReport() CollectReport {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	man := c.loadManifestLocked()
-	out := make([]ComponentVersion, 0, 12)
+	report := CollectReport{Versions: make([]ComponentVersion, 0, 16)}
+	seen := map[string]struct{}{}
+	// Keys owned by a malformed/unsupported version.json must not be filled
+	// from marker/manifest.
+	blocked := map[string]struct{}{}
+	add := func(v ComponentVersion) {
+		if v.Component == "" || v.Version == "" {
+			return
+		}
+		if _, ok := seen[v.Component]; ok {
+			return
+		}
+		if _, ok := blocked[v.Component]; ok {
+			return
+		}
+		seen[v.Component] = struct{}{}
+		report.Versions = append(report.Versions, v)
+	}
+	blockKeys := func(keys map[string]struct{}) {
+		for k := range keys {
+			blocked[k] = struct{}{}
+		}
+	}
 
-	// (1) cubelet always reported from the running binary.
-	out = append(out, ComponentVersion{
+	add(ComponentVersion{
 		Component: ComponentCubelet,
 		Version:   version.Version,
 		Commit:    version.Commit,
@@ -154,18 +217,61 @@ func (c *Collector) Collect() []ComponentVersion {
 		Source:    SourceBinary,
 	})
 
-	if man != nil {
-		// (2) binary components from the manifest, filtered to those actually
-		// installed on this node. cubelet handled above; cube-agent handled
-		// from guest_image.agent_version below.
+	// Mid-stage gap: staging marker or ready-sentinel with missing dir.
+	c.detectStageGapsLocked(&report)
+
+	// Directory version.json.
+	for dir, allow := range pathAllowlist {
+		path := filepath.Join(c.baseDir, dir, componentVersionJSON)
+		entries, errMsg, malformed := c.readComponentJSON(path, allow)
+		if errMsg != "" {
+			report.Incomplete = true
+		}
+		if malformed {
+			blockKeys(allow)
+			continue
+		}
+		for _, e := range entries {
+			if e.Component == ComponentCubelet {
+				continue // running binary wins
+			}
+			add(e)
+		}
+	}
+
+	// Markers (add() skips when already seen or blocked by malformed JSON).
+	add(ComponentVersion{Component: ComponentGuestImage, Version: c.guestImageVersionLocked(), Source: SourceFile})
+	add(ComponentVersion{
+		Component: ComponentCubeAgent,
+		Version:   c.readSingleLine(filepath.Join(c.baseDir, guestAgentVerPath)),
+		Source:    SourceFile,
+	})
+	add(ComponentVersion{
+		Component: ComponentCubeEgress,
+		Version:   c.readSingleLine(filepath.Join(c.baseDir, cubeEgressVerPath)),
+		Source:    SourceFile,
+	})
+
+	// Kernel: version.json variants + active selection.
+	// When version.json exists but is unusable, do not fall back to manifest.
+	if k, errMsg := c.kernelFromJSONLocked(); k.Version != "" {
+		add(k)
+	} else if errMsg != "" {
+		report.Incomplete = true
+		blocked[ComponentKernel] = struct{}{}
+	}
+
+	// Manifest fill: kernel (if not blocked) + remaining installed binaries / agent.
+	if man := c.loadManifestLocked(); man != nil {
+		add(c.kernelVersionLocked(man))
 		for name, mc := range man.Components {
-			if name == ComponentCubelet || name == ComponentCubeAgent || name == ComponentCubeEgress {
+			if name == ComponentCubelet || name == ComponentCubeAgent || name == ComponentCubeEgress || name == ComponentKernel {
 				continue
 			}
 			if !c.componentInstalledLocked(name) {
 				continue
 			}
-			out = append(out, ComponentVersion{
+			add(ComponentVersion{
 				Component: name,
 				Version:   mc.Version,
 				Commit:    mc.Commit,
@@ -173,65 +279,172 @@ func (c *Collector) Collect() []ComponentVersion {
 				Source:    SourceManifest,
 			})
 		}
-		// (3) cube-agent: take the guest's baked-in agent version, de-duped.
-		if man.GuestImage.AgentVersion != "" {
-			out = append(out, ComponentVersion{
-				Component: ComponentCubeAgent,
-				Version:   man.GuestImage.AgentVersion,
-				Source:    SourceManifest,
-			})
-		}
-		// (4) kernel: report the active guest kernel variant, not the host
-		// kernel and not just the static ordinary manifest value.
-		if kernel := c.kernelVersionLocked(man); kernel.Version != "" {
-			out = append(out, kernel)
-		}
-	}
-
-	// (5) guest-image: the version actually in effect on this node.
-	if ver := c.guestImageVersionLocked(); ver != "" {
-		out = append(out, ComponentVersion{
-			Component: ComponentGuestImage,
-			Version:   ver,
-			Source:    SourceFile,
+		add(ComponentVersion{
+			Component: ComponentCubeAgent,
+			Version:   man.GuestImage.AgentVersion,
+			Source:    SourceManifest,
 		})
 	}
 
-	// (6) cube-egress: version marker written by the deploy system.
-	// The marker file cube-egress/version is present only when the
-	// CubeEgress container is deployed on this node; when absent the
-	// component is silently omitted (graceful degradation).
-	if ver := c.cubeEgressVersionLocked(); ver != "" {
-		out = append(out, ComponentVersion{
-			Component: ComponentCubeEgress,
-			Version:   ver,
-			Source:    SourceFile,
-		})
-	}
-
-	return out
+	return report
 }
 
-// kernelVersionLocked returns the active guest kernel version. The active
-// variant is represented by cube-kernel-scf/vmlinux: a symlink to vmlinux-bm
-// for ordinary nodes, or vmlinux-pvm for PVM nodes. If the symlink is missing
-// or from an older install layout, fall back to the ordinary manifest identity.
+func (c *Collector) detectStageGapsLocked(report *CollectReport) {
+	type staged struct {
+		dir      string
+		sentinel string
+		staging  string
+	}
+	checks := []staged{
+		{"Cubelet", ".staged-cubelet", ".staging-cubelet"},
+		{"network-agent", ".staged-network-agent", ".staging-network-agent"},
+		{"cube-shim", ".staged-cube-shim", ".staging-cube-shim"},
+		{"cube-image", ".staged-cube-guest", ".staging-cube-guest"},
+		{"cube-kernel-scf", ".staged-cube-kernel", ".staging-cube-kernel"},
+	}
+	for _, ch := range checks {
+		staging := filepath.Join(c.baseDir, ch.staging)
+		if exists(staging) {
+			report.Incomplete = true
+			continue
+		}
+		sentinel := filepath.Join(c.baseDir, ch.sentinel)
+		if !exists(sentinel) {
+			continue
+		}
+		dir := filepath.Join(c.baseDir, ch.dir)
+		if _, err := os.Stat(dir); os.IsNotExist(err) {
+			report.Incomplete = true
+		}
+	}
+}
+
+// loadVersionJSON reads and validates a component version.json.
+// missing is true when the file is absent (not an error).
+// bad is true when the file exists but is unusable (blocks marker/manifest fallback).
+func loadVersionJSON(path string) (parsed componentJSONFile, errMsg string, missing, bad bool) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return componentJSONFile{}, "", true, false
+		}
+		return componentJSONFile{}, path + ": " + err.Error(), false, true
+	}
+	if len(data) > maxVersionJSONBytes {
+		return componentJSONFile{}, path + ": exceeds size limit", false, true
+	}
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		return componentJSONFile{}, path + ": malformed json", false, true
+	}
+	if parsed.SchemaVersion != 0 && parsed.SchemaVersion != 1 {
+		return componentJSONFile{}, path + ": unsupported schema_version", false, true
+	}
+	return parsed, "", false, false
+}
+
+func (c *Collector) readComponentJSON(path string, allow map[string]struct{}) ([]ComponentVersion, string, bool) {
+	parsed, errMsg, missing, bad := loadVersionJSON(path)
+	if missing {
+		return nil, "", false
+	}
+	if bad {
+		return nil, errMsg, true
+	}
+	out := make([]ComponentVersion, 0, len(parsed.Components))
+	for name, mc := range parsed.Components {
+		if _, ok := allow[name]; !ok {
+			continue // drop unauthorized keys
+		}
+		ver := strings.TrimSpace(mc.Version)
+		if ver == "" {
+			continue
+		}
+		out = append(out, ComponentVersion{
+			Component: name,
+			Version:   ver,
+			Commit:    mc.Commit,
+			BuildTime: mc.BuildTime,
+			Source:    SourceComponentJSON,
+		})
+	}
+	return out, "", false
+}
+
+func (c *Collector) kernelFromJSONLocked() (ComponentVersion, string) {
+	path := filepath.Join(c.baseDir, "cube-kernel-scf", componentVersionJSON)
+	parsed, errMsg, missing, bad := loadVersionJSON(path)
+	if missing {
+		return ComponentVersion{}, ""
+	}
+	if bad {
+		return ComponentVersion{}, errMsg
+	}
+	if len(parsed.Variants) == 0 {
+		return ComponentVersion{}, path + ": unusable kernel version.json"
+	}
+	variant := c.activeKernelVariantLocked()
+	if variant == "" {
+		return ComponentVersion{}, "kernel: cannot resolve active variant"
+	}
+	entry, ok := parsed.Variants[variant]
+	if !ok {
+		return ComponentVersion{}, "kernel: missing variant " + variant
+	}
+	identity := strings.TrimSpace(entry.Version)
+	if identity == "" {
+		identity = kernelArtifactIdentity(entry.Tag, entry.DigestSHA256)
+	}
+	if identity == "" {
+		return ComponentVersion{}, "kernel: empty identity for " + variant
+	}
+	return ComponentVersion{
+		Component: ComponentKernel,
+		Version:   identity,
+		Source:    SourceComponentJSON,
+		Variant:   variant,
+	}, ""
+}
+
+func kernelVariantFromVmlinuxBase(base string) string {
+	switch base {
+	case "vmlinux-pvm":
+		return "pvm"
+	case "vmlinux-bm":
+		return "bm"
+	}
+	return ""
+}
+
+func (c *Collector) activeKernelVariantLocked() string {
+	// Prefer bootstrap-state/vmlinux-active.
+	active := filepath.Join(c.bootstrapDir, "vmlinux-active")
+	if target, err := os.Readlink(active); err == nil {
+		if v := kernelVariantFromVmlinuxBase(filepath.Base(target)); v != "" {
+			return v
+		}
+	}
+	if target, ok := c.kernelLinkTargetLocked(); ok {
+		return kernelVariantFromVmlinuxBase(filepath.Base(target))
+	}
+	return ""
+}
+
 func (c *Collector) kernelVersionLocked(man *releaseManifest) ComponentVersion {
-	target, ok := c.kernelLinkTargetLocked()
-	if ok {
-		switch filepath.Base(target) {
-		case "vmlinux-pvm":
-			return ComponentVersion{
-				Component: ComponentKernel,
-				Version:   kernelArtifactIdentity(man.Kernel.PVMVersion, man.Kernel.VMLinuxPVMDigest),
-				Source:    SourceFile,
-			}
-		case "vmlinux-bm":
-			return ComponentVersion{
-				Component: ComponentKernel,
-				Version:   kernelArtifactIdentity(man.Kernel.Version, man.Kernel.VMLinuxDigest),
-				Source:    SourceFile,
-			}
+	variant := c.activeKernelVariantLocked()
+	switch variant {
+	case "pvm":
+		return ComponentVersion{
+			Component: ComponentKernel,
+			Version:   kernelArtifactIdentity(man.Kernel.PVMVersion, man.Kernel.VMLinuxPVMDigest),
+			Source:    SourceFile,
+			Variant:   "pvm",
+		}
+	case "bm":
+		return ComponentVersion{
+			Component: ComponentKernel,
+			Version:   kernelArtifactIdentity(man.Kernel.Version, man.Kernel.VMLinuxDigest),
+			Source:    SourceFile,
+			Variant:   "bm",
 		}
 	}
 	identity := kernelArtifactIdentity(man.Kernel.Version, man.Kernel.VMLinuxDigest)
@@ -242,6 +455,7 @@ func (c *Collector) kernelVersionLocked(man *releaseManifest) ComponentVersion {
 		Component: ComponentKernel,
 		Version:   identity,
 		Source:    SourceManifest,
+		Variant:   "bm",
 	}
 }
 
@@ -274,7 +488,6 @@ func (c *Collector) kernelLinkTargetLocked() (string, bool) {
 	return target, true
 }
 
-// loadManifestLocked parses the manifest once and caches the result.
 func (c *Collector) loadManifestLocked() *releaseManifest {
 	if c.manifestParsed {
 		return c.manifest
@@ -292,11 +505,10 @@ func (c *Collector) loadManifestLocked() *releaseManifest {
 	return c.manifest
 }
 
-// componentInstalledLocked reports whether a versioned directory exists for
-// the component (${baseDir}/<component>), or whether the one-click packaged
-// install layout carries the matching binary/config path, i.e. it is actually
-// deployed here.
 func (c *Collector) componentInstalledLocked(name string) bool {
+	if name == "" || strings.Contains(name, "..") || strings.ContainsAny(name, `/\`) {
+		return false
+	}
 	if exists(filepath.Join(c.baseDir, name)) {
 		return true
 	}
@@ -309,9 +521,6 @@ func (c *Collector) componentInstalledLocked(name string) bool {
 	return false
 }
 
-// guestImageVersionLocked returns the single-line guest image version, using
-// an mtime cache so an out-of-band guest upgrade is reflected without
-// restarting cubelet.
 func (c *Collector) guestImageVersionLocked() string {
 	path := filepath.Join(c.baseDir, guestImageVerPath)
 	info, err := os.Stat(path)
@@ -335,11 +544,7 @@ func (c *Collector) guestImageVersionLocked() string {
 	return c.guestImageVer
 }
 
-// cubeEgressVersionLocked returns the single-line cube-egress version from the
-// host-side marker file written by the deploy system at install time. The file
-// is static between deployments, so we read it directly without mtime caching.
-func (c *Collector) cubeEgressVersionLocked() string {
-	path := filepath.Join(c.baseDir, cubeEgressVerPath)
+func (c *Collector) readSingleLine(path string) string {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return ""
@@ -347,11 +552,8 @@ func (c *Collector) cubeEgressVersionLocked() string {
 	return firstLine(data)
 }
 
-// firstLine returns the first line of data, trimmed of surrounding
-// whitespace. Matches CubeShim::get_image_version's strict single-line read.
 func firstLine(data []byte) string {
 	start := 0
-	// skip leading whitespace
 	for start < len(data) && isSpace(data[start]) {
 		start++
 	}
@@ -360,7 +562,6 @@ func firstLine(data []byte) string {
 		end++
 	}
 	line := data[start:end]
-	// trim trailing whitespace
 	j := len(line)
 	for j > 0 && isSpace(line[j-1]) {
 		j--

--- a/Cubelet/pkg/cubelet/versioninfo/collector_test.go
+++ b/Cubelet/pkg/cubelet/versioninfo/collector_test.go
@@ -415,3 +415,190 @@ func TestCollectCubeEgressDegradesWithoutMarker(t *testing.T) {
 		t.Errorf("cube-egress must NOT be reported when version marker is absent")
 	}
 }
+
+func TestCollectAgentVersionFileWithoutManifest(t *testing.T) {
+	dir := t.TempDir()
+	imgDir := filepath.Join(dir, "cube-image")
+	if err := os.MkdirAll(imgDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(imgDir, "version"), []byte("guest-v1\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(imgDir, "agent-version"), []byte("agent-v1\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	c := NewCollector(dir)
+	got := c.Collect()
+
+	agent, ok := versionOf(t, got, ComponentCubeAgent)
+	if !ok || agent.Version != "agent-v1" || agent.Source != SourceFile {
+		t.Fatalf("cube-agent from agent-version file, got %+v ok=%v", agent, ok)
+	}
+}
+
+func TestCollectVersionJSONWithoutManifest(t *testing.T) {
+	dir := t.TempDir()
+	na := filepath.Join(dir, "network-agent")
+	if err := os.MkdirAll(na, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	body := `{
+  "schema_version": 1,
+  "components": {
+    "network-agent": {"version": "na-1.0", "commit": "abc"}
+  }
+}`
+	if err := os.WriteFile(filepath.Join(na, "version.json"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	c := NewCollector(dir)
+	got := c.Collect()
+	v, ok := versionOf(t, got, "network-agent")
+	if !ok || v.Version != "na-1.0" || v.Source != SourceComponentJSON {
+		t.Fatalf("network-agent from version.json, got %+v ok=%v", v, ok)
+	}
+}
+
+func TestCollectKernelFromVersionJSONAndActiveSymlink(t *testing.T) {
+	dir := t.TempDir()
+	mkKernelLayout(t, dir, "vmlinux-pvm")
+	body := `{
+  "schema_version": 1,
+  "variants": {
+    "bm": {"version": "bm@sha256:bm"},
+    "pvm": {"version": "pvm@sha256:pvm"}
+  }
+}`
+	if err := os.WriteFile(filepath.Join(dir, "cube-kernel-scf", "version.json"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	c := NewCollector(dir)
+	got := c.Collect()
+	k, ok := versionOf(t, got, ComponentKernel)
+	if !ok || k.Version != "pvm@sha256:pvm" || k.Variant != "pvm" || k.Source != SourceComponentJSON {
+		t.Fatalf("kernel from version.json+symlink, got %+v ok=%v", k, ok)
+	}
+}
+
+func TestCollectReportMarksMalformedJSONIncomplete(t *testing.T) {
+	dir := t.TempDir()
+	na := filepath.Join(dir, "network-agent")
+	if err := os.MkdirAll(na, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(na, "version.json"), []byte("{not-json"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	c := NewCollector(dir)
+	report := c.CollectReport()
+	if !report.Incomplete {
+		t.Fatal("expected incomplete on malformed version.json")
+	}
+}
+
+func TestCollectEgressVersionJSON(t *testing.T) {
+	dir := t.TempDir()
+	eg := filepath.Join(dir, "cube-egress")
+	if err := os.MkdirAll(eg, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	body := `{"schema_version":1,"components":{"cube-egress":{"version":"egress-from-json"}}}`
+	if err := os.WriteFile(filepath.Join(eg, "version.json"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(eg, "version"), []byte("marker-should-lose\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	c := NewCollector(dir)
+	got := c.Collect()
+	v, ok := versionOf(t, got, ComponentCubeEgress)
+	if !ok || v.Version != "egress-from-json" {
+		t.Fatalf("cube-egress from version.json, got %+v ok=%v", v, ok)
+	}
+	if v.Source != SourceComponentJSON {
+		t.Fatalf("source=%s, want %s", v.Source, SourceComponentJSON)
+	}
+}
+
+func TestCollectStageGapMarksIncomplete(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, ".staged-network-agent"), []byte("staged\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// Sentinel present but network-agent/ directory missing → mid-stage gap.
+	c := NewCollector(dir)
+	report := c.CollectReport()
+	if !report.Incomplete {
+		t.Fatal("expected incomplete when staged sentinel exists without component dir")
+	}
+}
+
+func TestCollectStagingMarkerMarksIncomplete(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, ".staging-cube-guest"), []byte("staging\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	c := NewCollector(dir)
+	report := c.CollectReport()
+	if !report.Incomplete {
+		t.Fatal("expected incomplete while .staging-* marker is present")
+	}
+}
+
+func TestCollectMalformedJSONDoesNotFallBackToMarker(t *testing.T) {
+	dir := t.TempDir()
+	img := filepath.Join(dir, "cube-image")
+	if err := os.MkdirAll(img, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(img, "version.json"), []byte("{bad"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(img, "version"), []byte("legacy-guest\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(img, "agent-version"), []byte("legacy-agent\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	c := NewCollector(dir)
+	report := c.CollectReport()
+	if !report.Incomplete {
+		t.Fatal("expected incomplete on malformed cube-image/version.json")
+	}
+	if _, ok := versionOf(t, report.Versions, ComponentGuestImage); ok {
+		t.Fatal("malformed version.json must not fall back to guest-image marker")
+	}
+	if _, ok := versionOf(t, report.Versions, ComponentCubeAgent); ok {
+		t.Fatal("malformed version.json must not fall back to agent-version marker")
+	}
+}
+
+func TestCollectKernelPrefersVmlinuxActiveOverArtifactSymlink(t *testing.T) {
+	dir := t.TempDir()
+	boot := t.TempDir()
+	mkKernelLayout(t, dir, "vmlinux-bm") // artifact default still bm
+	body := `{
+  "schema_version": 1,
+  "variants": {
+    "bm": {"version": "bm@sha256:bm"},
+    "pvm": {"version": "pvm@sha256:pvm"}
+  }
+}`
+	if err := os.WriteFile(filepath.Join(dir, "cube-kernel-scf", "version.json"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	target := filepath.Join(dir, "cube-kernel-scf", "vmlinux-pvm")
+	if err := os.Symlink(target, filepath.Join(boot, "vmlinux-active")); err != nil {
+		t.Fatal(err)
+	}
+	c := NewCollectorWithDirs(dir, boot)
+	got := c.Collect()
+	k, ok := versionOf(t, got, ComponentKernel)
+	if !ok || k.Version != "pvm@sha256:pvm" || k.Variant != "pvm" {
+		t.Fatalf("vmlinux-active should win over artifact bm symlink, got %+v ok=%v", k, ok)
+	}
+}

--- a/Cubelet/pkg/masterclient/client.go
+++ b/Cubelet/pkg/masterclient/client.go
@@ -26,13 +26,14 @@ type ResourceSnapshot struct {
 
 // ComponentVersion describes the version of a single component installed on
 // this node. Reported to CubeMaster on register and heartbeat. Source is one
-// of "manifest" | "binary" | "file".
+// of "manifest" | "binary" | "file" | "component-json".
 type ComponentVersion struct {
 	Component string `json:"component"`
 	Version   string `json:"version,omitempty"`
 	Commit    string `json:"commit,omitempty"`
 	BuildTime string `json:"build_time,omitempty"`
 	Source    string `json:"source,omitempty"`
+	Variant   string `json:"variant,omitempty"` // kernel: bm|pvm
 }
 
 type RegisterNodeRequest struct {
@@ -50,6 +51,7 @@ type RegisterNodeRequest struct {
 	CreateConcurrentNum int64              `json:"create_concurrent_num,omitempty"`
 	MaxMvmNum           int64              `json:"max_mvm_num,omitempty"`
 	Versions            []ComponentVersion `json:"versions,omitempty"`
+	InventoryIncomplete bool               `json:"inventory_incomplete,omitempty"`
 }
 
 type UpdateNodeStatusRequest struct {
@@ -63,7 +65,8 @@ type UpdateNodeStatusRequest struct {
 	DiskUsage  *DiskUsage          `json:"disk_usage,omitempty"`
 	MetricTime time.Time           `json:"metric_time,omitempty"`
 
-	Versions []ComponentVersion `json:"versions,omitempty"`
+	Versions            []ComponentVersion `json:"versions,omitempty"`
+	InventoryIncomplete bool               `json:"inventory_incomplete,omitempty"`
 }
 
 // AllocatedResources represents sandbox-quota resources already committed by

--- a/deploy/kubernetes/chart/README.md
+++ b/deploy/kubernetes/chart/README.md
@@ -156,21 +156,20 @@ can set it to `false`.
 `cube-node` mirrors the one-click runtime layout:
 
 - runtime tools are available through `/usr/local/bin/containerd-shim-cube-rs`, `/usr/local/bin/cube-runtime`, `/usr/local/bin/cubecli`, and `/usr/local/bin/cubevsmapdump`;
-- `cubeNode.pvmGuestKernel.enabled` defaults to `true` and controls the one-click `CUBE_PVM_ENABLE` behavior, selecting `cube-kernel-scf/vmlinux -> vmlinux-pvm` or `vmlinux-bm`;
 - `cubeNode.network.autoDetectEthName=true` auto-detects the primary host NIC and patches Cubelet `eth_name`;
 - `cubeNode.network.cidr` can patch Cubelet cubevs CIDR when the packaged default conflicts with the host network.
 
-`bootstrap.pvmHostKernel.enabled` also defaults to `true`, so the PVM host
-kernel bootstrap on **`cube-node-pvm`** (only nodes with `allow-pvm-bootstrap`)
-can install/configure the host kernel and perform the configured coordinated
-reboot. Per-node `effective-pvm` (written by bootstrap `wait-pvm-host`) overrides
-Helm `CUBE_PVM_ENABLE` for guest kernel selection and fingerprinting. The default
-`bootstrap.pvmHostKernel.bootArgs` is `nopti pti=off` because the current
-`kvm_pvm` module does not support host KPTI. `cube-node-init` performs the same
-fail-fast style checks as one-click for memory, glibc, cgroup v2 cpu
-controller, cubecow dependencies, KVM, XFS, and PVM consistency. It fails when
-a host has `kvm_pvm` loaded but effective PVM is off, or when effective PVM is
-on but the host has not booted a PVM kernel with `kvm_pvm` loaded.
+### Guest kernel (bm vs PVM)
+
+What actually decides the guest kernel on a node:
+
+1. **Node decision** — bootstrap writes `effective-pvm` (`1` = PVM guest, `0` = bm). Nodes with `cube.tencent.com/allow-pvm-bootstrap=true` get `1` after the PVM host is ready; others get `0`.
+2. **Keep what the node already runs** — if there is no `effective-pvm` yet, an upgrade keeps the previous guest kernel (so Chart defaults cannot silently flip a PVM node to bm).
+3. **Chart default for first install** — `cubeNode.pvmGuestKernel.enabled` (default `true`) only matters when the node has no prior choice; it is the first-install intent, not a force switch.
+
+To **turn off PVM on one node**: remove the `allow-pvm-bootstrap` label. Bootstrap then writes `effective-pvm=0` and the guest kernel switches to bm. Setting `pvmGuestKernel.enabled=false` alone does **not** override a node that already runs PVM.
+
+`bootstrap.pvmHostKernel.enabled` (default `true`) installs/configures the **host** PVM kernel on labeled nodes (`cube-node-pvm`) and may reboot. Boot args default to `nopti pti=off` (`kvm_pvm` does not support host KPTI). `cube-node-init` fail-fast checks match one-click (memory, glibc, cgroup v2 cpu, cubecow, KVM, XFS, PVM consistency): it fails if `kvm_pvm` is loaded but PVM is off for that node, or if PVM is on but the host has not booted a PVM kernel.
 
 ## Build and push images
 

--- a/deploy/kubernetes/chart/docs/ARCHITECTURE.md
+++ b/deploy/kubernetes/chart/docs/ARCHITECTURE.md
@@ -124,13 +124,13 @@ flowchart TB
 #### Installer：`cube-node-installer`
 
 - 容器：`cube-shim-install` / `cube-kernel-install` / `cube-guest-install`。
-- 从镜像 `/opt/cube-image` **原子 stage** 到 toolbox；`hostPID: false`，仅挂 toolbox 相关路径。
+- 把镜像里的 shim / kernel / guest **整目录换到** 宿主机 toolbox；换目录期间版本矩阵会短暂标「未完成」，成功后恢复正常。
 - 可独立 RollingUpdate；日常升产物 **只 bump Installer 镜像**。
 
 #### Bootstrap：`cube-node-bootstrap`
 
 - init：`wait-pvm-host` → `cube-node-init`；主容器写 `node-prep-ready`。
-- `wait-pvm-host`：按节点 label 决定是否等待 PVM；写 `effective-pvm`（`0`/`1`）。PVM 节点必须等到 **指纹匹配** 的 `pvm-host-ready`（禁止「文件存在即 ready」）。
+- `wait-pvm-host`：看节点有没有 `allow-pvm-bootstrap`——有则等 PVM 宿主机就绪并记「本节点用 PVM guest」；没有则记「本节点用 bm guest」。
 - 哨兵目录：`/var/lib/cube-node-bootstrap`（与 Big Pod 的 `wait-node-prep` / PVM DS 共享）。
 - `hostPID: true`（`nsenter --target 1`）；低频变更；升 node-init **只 bump Bootstrap / nodeInit 镜像**。
 
@@ -138,22 +138,25 @@ flowchart TB
 
 - 仅当 `bootstrap.pvmHostKernel.enabled=true` 时创建；仅调度到 `placement.pvm`。
 - init：`pvm-host-bootstrap`；成功（live 内核已满足 pattern+boot args）后写带指纹的 `pvm-host-ready`；主容器 hold。
-- 换核 / 改 boot args 前 `invalidate_pvm_gate_sentinels`：删除 `node-prep-ready`、`pvm-host-ready`、`effective-pvm`，再 reboot。
+- 换核 / 改 boot args 前会清掉就绪标记再 reboot，避免用旧状态误放行。
 - 升 PVM 镜像 **只 bump `images.pvmHostBootstrap`**，不 recreate Big Pod。
 
 为何拆成四个：Big Pod 保持 InPlace 友好；产物安装与可 reboot 的 PVM 引导分离；非 PVM compute 节点不拉 PVM 大镜像。
 
-### 2.3.1 Reboot 与 ready 哨兵
+### 2.3.1 节点上你会看到的标记（重启后）
 
-| 标记 | 跨 reboot 残留？ | 误放行？ |
-| --- | --- | --- |
-| `pvm-host-ready`（指纹含 live `uname` + boot_args） | 会 | **不会**：wait 比对 live 指纹；mutate 前主动删除 |
-| `effective-pvm` | 会 | wait-pvm-host **每次**重写；mutate 前删除 |
-| `node-prep-ready`（指纹含 `uname`） | 会 | **不会**；换核后期望指纹变 |
-| `/run/wait-node-prep.ready` | 否（tmpfs） | 安全 |
-| `.staged-*` | 会 | 有意：产物仍在盘上 |
+| 标记 | 含义（给运维看） |
+| --- | --- |
+| `pvm-host-ready` | 宿主机 PVM 内核已按预期装好；内容带指纹，换核后必须对上当前 `uname` 才算就绪 |
+| `effective-pvm` | 本节点 guest 该用 PVM（`1`）还是 bm（`0`）；有 `allow-pvm-bootstrap` 且 host 就绪 → `1`，否则 → `0` |
+| `node-prep-ready` | bootstrap 预检通过，Big Pod 可以启动 |
+| `/run/wait-node-prep.ready` | 本轮 Pod 内临时标记，重启即没 |
+| toolbox 下「组件已就绪」标记 | 该组件 stage 成功，产物可被版本矩阵采集 |
+| toolbox 下「组件正在替换」标记 | 正在换目录；矩阵会标未完成，避免报残缺版本；成功后清除，失败会留下直到下次成功 |
 
-验收：PVM 换核期间 Big Pod NotReady；故意残留错误内核的 `pvm-host-ready` 时 `wait-pvm-host` 不得放行；普通掉电且内核未变时可快速恢复。
+Guest 选核最终结果：先看 `effective-pvm`；没有则尽量保持节点上一次已在用的内核；再没有才用 Chart 首次安装默认（`cubeNode.pvmGuestKernel.enabled`）。
+
+验收：PVM 换核期间 Big Pod NotReady；故意残留错误内核的 `pvm-host-ready` 时不得放行；普通掉电且内核未变时可快速恢复。
 
 ### 2.4 数据面入口
 
@@ -267,7 +270,7 @@ sequenceDiagram
   Wait->>Wait: poll fingerprint → Ready hold
   Note over Wait,CN: Kruise barrier → prio 0
   Wait-->>CN: wait Ready
-  CN->>CN: self-stage + effective-pvm guest kernel
+  CN->>CN: self-stage；按节点 PVM 决定选 guest 内核
   CN->>CM: register + heartbeat
 ```
 
@@ -372,7 +375,7 @@ externalControlPlane:
 | `cubeProxy.domain` | `cube.app` | sandbox 域名 |
 | `cubeProxy.configureClusterDNS` | `true` | 是否写入集群 CoreDNS |
 | `cubeNode.dns.sandbox.followNodeDns` | `true` | guest 跟随节点 DNS |
-| `cubeNode.pvmGuestKernel.enabled` | `true` | PVM guest kernel；与 `kvm_pvm` 一致性由 node-init 校验 |
+| `cubeNode.pvmGuestKernel.enabled` | `true` | 首次安装默认是否倾向 PVM guest；**不能**单独用来关掉已在跑 PVM 的节点（应去掉 `allow-pvm-bootstrap`） |
 | `bootstrap.pvmHostKernel.enabled` | `true` | host kernel bootstrap（可能重启节点） |
 | `bootstrap.pvmHostKernel.bootArgs` | `nopti pti=off` | 当前 `kvm_pvm` 不支持 host KPTI |
 | `bootstrap.nodeInit.*` | 多项 | 预检、XFS、KVM、CIDR |

--- a/deploy/kubernetes/chart/docs/FAQ.md
+++ b/deploy/kubernetes/chart/docs/FAQ.md
@@ -270,6 +270,28 @@ kubectl -n cube-system logs <cube-node-pod> -c cube-node --tail=200 | grep -i re
 
 利用 `Pause` 可以把非活跃 sandbox 归零(CPU/RSS→0),盘不释放。运营层面通常在闲置 N 分钟后 Pause,更长后 Destroy。
 
+### D6. 怎么关某台节点的 PVM？只改 Chart 行吗？
+
+**关单节点 guest PVM：去掉该节点的 PVM label。**
+
+```bash
+kubectl label node <node> cube.tencent.com/allow-pvm-bootstrap-
+```
+
+之后 bootstrap 会把该节点记成「用 bm guest」。下一次 kernel 安装/选核会切到 bm。
+
+**不要指望**只把 `cubeNode.pvmGuestKernel.enabled=false` 就关掉已经在跑 PVM 的节点——那个开关主要管**首次安装默认**；节点若已有历史选择，升级会尽量保持原样，避免被 Chart 默认值悄悄改掉。
+
+整集群都不做 PVM 宿主机换核：部署时不要打 `allow-pvm-bootstrap`，并可设 `bootstrap.pvmHostKernel.enabled=false`（见 [QUICKSTART](QUICKSTART.md) 单节点试用说明）。
+
+自检当前 guest：
+
+```bash
+readlink /usr/local/services/cubetoolbox/cube-kernel-scf/vmlinux
+# 或
+readlink /var/lib/cube-node-bootstrap/vmlinux-active
+```
+
 ---
 
 ## E. CubeProxy / TLS / DNS

--- a/deploy/kubernetes/chart/docs/UPGRADE.md
+++ b/deploy/kubernetes/chart/docs/UPGRADE.md
@@ -24,10 +24,11 @@ helm install kruise openkruise/kruise --version 1.9.0 \
    - **`*-node-installer`**：shim / kernel / guest 安装；可 RollingUpdate、可增容器。
    - **`*-node-bootstrap`**：`wait-pvm-host` / node-init / 写 `node-prep-ready`；低频 RollingUpdate。
    - **`*-node-pvm`**（可选）：PVM host kernel；仅 `placement.pvm`；升 PVM 只 bump 本 DS。
-3. Bootstrap 写 `node-prep-ready`；PVM 写指纹 `pvm-host-ready`；Installer / self-stage 写组件 `.staged-*`；cubelet 等 artifact 与 network-agent sentinel。
+3. Bootstrap 写「节点可启动」；有 PVM label 的节点写「宿主机 PVM 就绪」。Installer / Big Pod 把组件换到 toolbox：替换过程中版本矩阵可能短暂显示未完成（正常）；成功后组件就绪，矩阵恢复完整。
 4. **NodeID** = `spec.nodeName`；**Endpoint** = Big Pod `status.podIP`。
 5. `preStop` 只杀本容器 pidfile，禁止宽 `pkill -f`。
 6. 日常分工：**升控面 → 只 bump Big Pod 镜像**；**升产物 → 只动 Installer**；**升 node-init → 只动 Bootstrap**；**升 PVM → 只动 cube-node-pvm**。
+7. 升 kernel **不会**因为 Chart 默认值把已在跑 PVM 的节点悄悄切成 bm；要关某节点 PVM，去掉其 `allow-pvm-bootstrap` label。
 
 ## 按组件升级示例
 

--- a/deploy/kubernetes/chart/templates/_helpers.tpl
+++ b/deploy/kubernetes/chart/templates/_helpers.tpl
@@ -451,6 +451,8 @@ Installer: toolbox only (no dataplane mounts).
 {{- define "cube.installerVolumeMounts" -}}
 - name: toolbox
   mountPath: /usr/local/services/cubetoolbox
+- name: bootstrap-state
+  mountPath: {{ .Values.hostPaths.bootstrapState }}
 {{- end -}}
 
 {{- define "cube.installerComponentEnv" -}}
@@ -459,6 +461,10 @@ Installer: toolbox only (no dataplane mounts).
   value: /usr/local/services/cubetoolbox
 - name: IMAGE_ROOT
   value: /opt/cube-image
+- name: STATE_DIR
+  value: {{ .Values.hostPaths.bootstrapState | quote }}
+- name: CUBE_PVM_ENABLE
+  value: {{ ternary "1" "0" .Values.cubeNode.pvmGuestKernel.enabled | quote }}
 {{- end -}}
 
 {{/*

--- a/deploy/kubernetes/chart/templates/node-daemonset.yaml
+++ b/deploy/kubernetes/chart/templates/node-daemonset.yaml
@@ -196,12 +196,6 @@ spec:
         - name: cube-egress
           image: {{ include "cube.cubeImage" (dict "image" .Values.images.cubeEgress "context" $) | quote }}
           imagePullPolicy: {{ .Values.images.cubeEgress.pullPolicy }}
-          command:
-            - /bin/bash
-            - -ec
-            - |
-              mkdir -p /data/log/cube-egress
-              exec /usr/local/openresty/nginx/sbin/start.sh
           securityContext:
             privileged: {{ .Values.security.privileged }}
             capabilities:
@@ -263,7 +257,6 @@ spec:
               mountPath: /var/run/openresty
             - name: toolbox
               mountPath: /usr/local/services/cubetoolbox
-              readOnly: true
           {{- with .Values.cubeEgress.resources }}
           resources:
             {{- toYaml . | nindent 12 }}
@@ -322,7 +315,6 @@ spec:
               readOnly: true
             - name: toolbox
               mountPath: /usr/local/services/cubetoolbox
-              readOnly: true
           {{- with .Values.cubeEgress.netResources }}
           resources:
             {{- toYaml . | nindent 12 }}

--- a/deploy/kubernetes/chart/templates/node-installer-daemonset.yaml
+++ b/deploy/kubernetes/chart/templates/node-installer-daemonset.yaml
@@ -101,4 +101,8 @@ spec:
           hostPath:
             path: {{ .Values.hostPaths.toolbox }}
             type: DirectoryOrCreate
+        - name: bootstrap-state
+          hostPath:
+            path: {{ .Values.hostPaths.bootstrapState }}
+            type: DirectoryOrCreate
 {{- end }}

--- a/deploy/kubernetes/images/build-cube-images.sh
+++ b/deploy/kubernetes/images/build-cube-images.sh
@@ -647,9 +647,9 @@ build_cube_egress_image() {
   local docker_args=(
     -f "${REPO_ROOT}/CubeEgress/Dockerfile"
     -t "${image}"
-    --build-arg "CUBE_EGRESS_VERSION=${VERSION}"
-    --build-arg "CUBE_EGRESS_COMMIT=$(git -C "${REPO_ROOT}" rev-parse --short=12 HEAD 2>/dev/null || echo unknown)"
-    --build-arg "CUBE_EGRESS_BUILD_TIME=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    --build-arg "CUBE_VERSION=${IMAGE_TAG}"
+    --build-arg "CUBE_COMMIT=$(git -C "${REPO_ROOT}" rev-parse --short=12 HEAD 2>/dev/null || echo unknown)"
+    --build-arg "CUBE_BUILD_TIME=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
   )
   if [[ "${NO_CACHE}" == "1" ]]; then
     # Do not add --pull here: CubeEgress/Dockerfile uses a fixed FROM name.
@@ -714,7 +714,10 @@ build_component_image() {
   mkdir -p "${ctx}/package"
   cp -a "${PACKAGE_DIR}/${pkg_dir}" "${ctx}/package/${pkg_basename}"
   overlay_local_bins_for_component "${name}" "${ctx}" "${pkg_basename}"
-  build_image "${name}" "${ctx}"
+  build_image "${name}" "${ctx}" \
+    --build-arg "CUBE_VERSION=${IMAGE_TAG}" \
+    --build-arg "CUBE_KERNEL_BM_VERSION=${CUBE_KERNEL_BM_VERSION:-}" \
+    --build-arg "CUBE_KERNEL_PVM_VERSION=${CUBE_KERNEL_PVM_VERSION:-}"
   record_built "${name}"
 }
 

--- a/deploy/kubernetes/images/cube-guest/Dockerfile
+++ b/deploy/kubernetes/images/cube-guest/Dockerfile
@@ -16,6 +16,19 @@ RUN apt-get update \
 COPY package/cube-image ${IMAGE_ROOT}/cube-image
 COPY scripts/component-entrypoint.sh /usr/local/bin/component-entrypoint.sh
 
-RUN chmod +x /usr/local/bin/component-entrypoint.sh
+ARG CUBE_VERSION=unknown
+RUN set -eu; \
+    img_ver="$(tr -d '[:space:]' < ${IMAGE_ROOT}/cube-image/version 2>/dev/null || true)"; \
+    agent_ver="$(tr -d '[:space:]' < ${IMAGE_ROOT}/cube-image/agent-version 2>/dev/null || true)"; \
+    : "${img_ver:=${CUBE_VERSION}}"; \
+    { \
+      printf '{\n  "schema_version": 1,\n  "components": {\n'; \
+      printf '    "guest-image": {"version": "%s"}' "${img_ver}"; \
+      if [ -n "${agent_ver}" ]; then \
+        printf ',\n    "cube-agent": {"version": "%s"}' "${agent_ver}"; \
+      fi; \
+      printf '\n  }\n}\n'; \
+    } > ${IMAGE_ROOT}/cube-image/version.json \
+    && chmod +x /usr/local/bin/component-entrypoint.sh
 
 ENTRYPOINT ["/usr/bin/tini", "--", "/usr/local/bin/component-entrypoint.sh"]

--- a/deploy/kubernetes/images/cube-kernel/Dockerfile
+++ b/deploy/kubernetes/images/cube-kernel/Dockerfile
@@ -16,6 +16,14 @@ RUN apt-get update \
 COPY package/cube-kernel-scf ${IMAGE_ROOT}/cube-kernel-scf
 COPY scripts/component-entrypoint.sh /usr/local/bin/component-entrypoint.sh
 
-RUN chmod +x /usr/local/bin/component-entrypoint.sh
+# Prefer digest-bearing identities when build args supply them; fall back to image tag.
+ARG CUBE_VERSION=unknown
+ARG CUBE_KERNEL_BM_VERSION=
+ARG CUBE_KERNEL_PVM_VERSION=
+RUN BM="${CUBE_KERNEL_BM_VERSION:-${CUBE_VERSION}}" \
+    && PVM="${CUBE_KERNEL_PVM_VERSION:-${CUBE_VERSION}}" \
+    && printf '{"schema_version":1,"variants":{"bm":{"version":"%s","tag":"%s"},"pvm":{"version":"%s","tag":"%s"}}}\n' \
+      "${BM}" "${BM}" "${PVM}" "${PVM}" > ${IMAGE_ROOT}/cube-kernel-scf/version.json \
+    && chmod +x /usr/local/bin/component-entrypoint.sh
 
 ENTRYPOINT ["/usr/bin/tini", "--", "/usr/local/bin/component-entrypoint.sh"]

--- a/deploy/kubernetes/images/cube-shim/Dockerfile
+++ b/deploy/kubernetes/images/cube-shim/Dockerfile
@@ -15,7 +15,10 @@ RUN apt-get update \
 COPY package/cube-shim ${IMAGE_ROOT}/cube-shim
 COPY scripts/component-entrypoint.sh /usr/local/bin/component-entrypoint.sh
 
-RUN chmod +x \
+ARG CUBE_VERSION=unknown
+RUN printf '{"schema_version":1,"components":{"containerd-shim-cube-rs":{"version":"%s"},"cube-runtime":{"version":"%s"}}}\n' \
+      "${CUBE_VERSION}" "${CUBE_VERSION}" > ${IMAGE_ROOT}/cube-shim/version.json \
+    && chmod +x \
       ${IMAGE_ROOT}/cube-shim/bin/cube-runtime \
       ${IMAGE_ROOT}/cube-shim/bin/containerd-shim-cube-rs \
       /usr/local/bin/component-entrypoint.sh

--- a/deploy/kubernetes/images/cubelet/Dockerfile
+++ b/deploy/kubernetes/images/cubelet/Dockerfile
@@ -27,7 +27,10 @@ RUN apt-get update \
 COPY package/Cubelet ${IMAGE_ROOT}/Cubelet
 COPY scripts/component-entrypoint.sh /usr/local/bin/component-entrypoint.sh
 
-RUN chmod +x \
+ARG CUBE_VERSION=unknown
+RUN printf '{"schema_version":1,"components":{"cubelet":{"version":"%s"},"cubecli":{"version":"%s"}}}\n' \
+      "${CUBE_VERSION}" "${CUBE_VERSION}" > ${IMAGE_ROOT}/Cubelet/version.json \
+    && chmod +x \
       ${IMAGE_ROOT}/Cubelet/bin/cubelet \
       ${IMAGE_ROOT}/Cubelet/bin/cubecli \
       /usr/local/bin/component-entrypoint.sh \

--- a/deploy/kubernetes/images/network-agent/Dockerfile
+++ b/deploy/kubernetes/images/network-agent/Dockerfile
@@ -22,7 +22,10 @@ RUN apt-get update \
 COPY package/network-agent ${IMAGE_ROOT}/network-agent
 COPY scripts/component-entrypoint.sh /usr/local/bin/component-entrypoint.sh
 
-RUN chmod +x \
+ARG CUBE_VERSION=unknown
+RUN printf '{"schema_version":1,"components":{"network-agent":{"version":"%s"}}}\n' \
+      "${CUBE_VERSION}" > ${IMAGE_ROOT}/network-agent/version.json \
+    && chmod +x \
       ${IMAGE_ROOT}/network-agent/bin/network-agent \
       ${IMAGE_ROOT}/network-agent/bin/cubevsmapdump \
       /usr/local/bin/component-entrypoint.sh \

--- a/deploy/kubernetes/images/scripts/component-entrypoint.sh
+++ b/deploy/kubernetes/images/scripts/component-entrypoint.sh
@@ -72,36 +72,95 @@ wait_sentinel() {
   fail "timeout waiting for sentinel ${name} at ${path}"
 }
 
-# Atomic directory replace: any concurrent reader sees either the full old
-# tree or the full new tree (no rm -rf gap). Requires src/dst on same FS.
+# Promote a staged tree into place without rm -rf of the live directory.
+# Rename-aside then rename-in leaves a brief ENOENT window; we keep a
+# ".staging-<component>" marker for the whole window so the collector marks
+# inventory_incomplete (and Master will not hard-delete). Requires src/dst on
+# the same filesystem.
 atomic_replace_dir() {
   local src="$1"
   local dst="$2"
-  local parent new
+  local parent new legacy recovered=""
   parent="$(dirname "${dst}")"
   mkdir -p "${parent}"
+
+  # Crash recovery first: dst missing after rename-aside — restore newest legacy.
+  if [[ ! -e "${dst}" ]]; then
+    recovered="$(ls -1dt "${dst}.legacy."* 2>/dev/null | head -n1 || true)"
+    if [[ -n "${recovered}" && -d "${recovered}" ]]; then
+      log "recovering ${dst} from ${recovered}"
+      mv "${recovered}" "${dst}" || fail "cannot restore ${dst} from ${recovered}"
+    fi
+  fi
+
+  # Drop remaining orphans from prior crashed stages (same component is not concurrent).
+  rm -rf "${dst}.new."* "${dst}.legacy."* 2>/dev/null || true
+
   new="${dst}.new.$$"
-  rm -rf "${new}"
+  legacy="${dst}.legacy.$$"
+  rm -rf "${new}" "${legacy}"
   cp -a "${src}" "${new}"
-  # Promote staged tree into place. Prefer mv -T (GNU); fall back to rm+mv.
-  if mv -T "${new}" "${dst}" 2>/dev/null; then
+  if [[ ! -e "${dst}" ]]; then
+    mv "${new}" "${dst}"
     return 0
   fi
-  rm -rf "${dst}"
-  mv "${new}" "${dst}"
+  if mv -T "${dst}" "${legacy}" 2>/dev/null || mv "${dst}" "${legacy}"; then
+    if mv -T "${new}" "${dst}" 2>/dev/null || mv "${new}" "${dst}"; then
+      rm -rf "${legacy}"
+      return 0
+    fi
+    mv -T "${legacy}" "${dst}" 2>/dev/null || mv "${legacy}" "${dst}" || true
+    rm -rf "${new}"
+    fail "failed to promote staged tree into ${dst}"
+  fi
+  fail "cannot replace ${dst} (rename-aside failed)"
+}
+
+# Return vmlinux-bm|vmlinux-pvm from a symlink path, or empty.
+kernel_symlink_target() {
+  local link="$1"
+  local base
+  [[ -L "${link}" ]] || return 0
+  base="$(basename "$(readlink "${link}")")"
+  case "${base}" in
+    vmlinux-bm|vmlinux-pvm) printf '%s\n' "${base}" ;;
+  esac
+}
+
+# Capture active guest-kernel selection before a whole-tree replace.
+preserve_guest_kernel_selection() {
+  local dir="$1"
+  local state_dir="${STATE_DIR:-/var/lib/cube-node-bootstrap}"
+  local t=""
+  t="$(kernel_symlink_target "${state_dir}/vmlinux-active")"
+  if [[ -z "${t}" ]]; then
+    t="$(kernel_symlink_target "${dir}/vmlinux")"
+  fi
+  printf '%s\n' "${t}"
 }
 
 stage_component() {
   local rel="$1"
   local src="${IMAGE_ROOT}/${rel}"
   local dst="${TOOLBOX_ROOT}/${rel}"
-  local sentinel
+  local sentinel staging_marker preserved_kernel=""
   sentinel="$(component_sentinel "${CUBE_COMPONENT}")"
+  staging_marker="${TOOLBOX_ROOT}/.staging-${CUBE_COMPONENT}"
 
   [[ -d "${src}" ]] || fail "image bypass missing: ${src}"
   mkdir -p "${TOOLBOX_ROOT}"
-  # Clear previous sentinel so peers re-wait during refresh.
+  # Mark in-flight before clearing the ready sentinel so collectors see incomplete
+  # during the rename-aside ENOENT window. Cleared only on success — keep marker
+  # on failure/crash so Incomplete is not a false negative.
+  printf 'staging\n' > "${staging_marker}.tmp"
+  mv -f "${staging_marker}.tmp" "${staging_marker}"
   rm -f "${sentinel}"
+
+  if [[ "${CUBE_COMPONENT}" == "cube-kernel" ]]; then
+    preserved_kernel="$(preserve_guest_kernel_selection "${dst}")"
+    [[ -n "${preserved_kernel}" ]] && log "preserved guest kernel selection: ${preserved_kernel}"
+  fi
+
   log "staging ${src} -> ${dst} (atomic replace)"
   atomic_replace_dir "${src}" "${dst}"
 
@@ -124,14 +183,17 @@ stage_component() {
       ln -sf "${dst}/bin/cube-runtime" /usr/local/bin/cube-runtime
       ;;
     cube-kernel)
-      # Prefer existing vmlinux symlink selection by cubelet run; ensure files exist.
       [[ -e "${dst}/vmlinux-bm" || -e "${dst}/vmlinux-pvm" || -e "${dst}/vmlinux" ]] \
         || fail "missing guest kernel files under ${dst}"
+      apply_effective_pvm_from_state
+      select_guest_kernel "${preserved_kernel}"
       ;;
     cube-guest)
       [[ -d "${dst}" ]] || fail "missing guest image dir ${dst}"
       ;;
   esac
+
+  ensure_component_version_json "${CUBE_COMPONENT}" "${dst}"
 
   # Digest: informational change marker (completeness is write-order: cp then sentinel).
   {
@@ -140,7 +202,51 @@ stage_component() {
     find "${dst}" -type f -printf '%P %s %T@\n' 2>/dev/null | sort | head -n 50 || true
   } > "${sentinel}.tmp"
   mv -f "${sentinel}.tmp" "${sentinel}"
+  rm -f "${staging_marker}"
   log "wrote sentinel ${sentinel}"
+}
+
+# Best-effort: if the image did not bake version.json, synthesize from guest markers.
+json_escape() {
+  # Minimal JSON string escape for version tokens (no control chars expected).
+  printf '%s' "$1" | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g'
+}
+
+# Atomic tmp+mv write; body is read from stdin.
+write_atomic() {
+  local dest="$1"
+  local tmp="${dest}.tmp.$$"
+  cat > "${tmp}"
+  mv -f "${tmp}" "${dest}"
+}
+
+ensure_component_version_json() {
+  local component="$1"
+  local dst="$2"
+  local json="${dst}/version.json"
+  [[ -f "${json}" ]] && return 0
+  case "${component}" in
+    cube-guest)
+      local img_ver agent_ver
+      img_ver="$(tr -d '[:space:]' < "${dst}/version" 2>/dev/null || true)"
+      agent_ver="$(tr -d '[:space:]' < "${dst}/agent-version" 2>/dev/null || true)"
+      [[ -n "${img_ver}" || -n "${agent_ver}" ]] || return 0
+      {
+        printf '{\n  "schema_version": 1,\n  "components": {\n'
+        local first=1
+        if [[ -n "${img_ver}" ]]; then
+          printf '    "guest-image": {"version": "%s"}' "$(json_escape "${img_ver}")"
+          first=0
+        fi
+        if [[ -n "${agent_ver}" ]]; then
+          [[ "${first}" -eq 1 ]] || printf ',\n'
+          printf '    "cube-agent": {"version": "%s"}' "$(json_escape "${agent_ver}")"
+        fi
+        printf '\n  }\n}\n'
+      } | write_atomic "${json}"
+      log "synthesized ${json}"
+      ;;
+  esac
 }
 
 run_install() {
@@ -165,17 +271,44 @@ detect_primary_interface() {
     }'
 }
 
+# select_guest_kernel [preserved_target]
+# preserved_target is vmlinux-bm|vmlinux-pvm captured before whole-tree replace.
 select_guest_kernel() {
+  local preserved="${1:-}"
   local dir="${TOOLBOX_ROOT}/cube-kernel-scf"
-  local target="vmlinux-bm"
-  case "${CUBE_PVM_ENABLE:-1}" in
-    1|true|TRUE|yes|YES) target="vmlinux-pvm" ;;
-    0|false|FALSE|no|NO) target="vmlinux-bm" ;;
-    *) fail "unsupported CUBE_PVM_ENABLE=${CUBE_PVM_ENABLE}" ;;
-  esac
+  local target=""
+  local state_dir="${STATE_DIR:-/var/lib/cube-node-bootstrap}"
+  # 1) bootstrap effective-pvm wins
+  if [[ -f "${state_dir}/effective-pvm" ]]; then
+    case "$(tr -d '[:space:]' < "${state_dir}/effective-pvm" 2>/dev/null || true)" in
+      1) target="vmlinux-pvm" ;;
+      0) target="vmlinux-bm" ;;
+    esac
+  fi
+  # 2) else restore pre-replace / on-disk selection (node history; beats Chart env)
+  if [[ -z "${target}" ]]; then
+    case "${preserved}" in
+      vmlinux-bm|vmlinux-pvm) target="${preserved}" ;;
+    esac
+  fi
+  # 3) else honor CUBE_PVM_ENABLE when explicitly set (first install / Chart intent)
+  if [[ -z "${target}" && -n "${CUBE_PVM_ENABLE+x}" ]]; then
+    case "${CUBE_PVM_ENABLE}" in
+      1|true|TRUE|yes|YES) target="vmlinux-pvm" ;;
+      0|false|FALSE|no|NO) target="vmlinux-bm" ;;
+    esac
+  fi
+  # 4) else keep post-replace artifact symlink if already valid
+  if [[ -z "${target}" ]]; then
+    target="$(kernel_symlink_target "${dir}/vmlinux")"
+  fi
+  # 5) first-install default
+  [[ -n "${target}" ]] || target="vmlinux-bm"
   [[ -f "${dir}/${target}" ]] || fail "missing guest kernel: ${dir}/${target}"
   ln -sfn "${target}" "${dir}/vmlinux"
-  log "selected guest kernel: ${dir}/vmlinux -> ${target}"
+  mkdir -p "${state_dir}"
+  ln -sfn "${dir}/${target}" "${state_dir}/vmlinux-active"
+  log "selected guest kernel: ${dir}/vmlinux -> ${target} (vmlinux-active updated)"
 }
 
 patch_common_yaml_list() {
@@ -338,7 +471,7 @@ run_cubelet() {
   [[ -n "${CUBE_SANDBOX_ENDPOINT_IP:-}" ]] || fail "CUBE_SANDBOX_ENDPOINT_IP is required"
 
   apply_effective_pvm_from_state
-  select_guest_kernel
+  select_guest_kernel "$(preserve_guest_kernel_selection "${TOOLBOX_ROOT}/cube-kernel-scf")"
 
   local ep_esc
   ep_esc="$(sed_escape_replacement "${CUBE_MASTER_ENDPOINT}")"

--- a/deploy/kubernetes/images/scripts/test-stage-kernel-select.sh
+++ b/deploy/kubernetes/images/scripts/test-stage-kernel-select.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Unit checks for guest-kernel selection + atomic_replace recovery in
+# component-entrypoint.sh (no container required).
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ENTRY="${SCRIPT_DIR}/component-entrypoint.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf "${TMP}"' EXIT
+
+# Load entrypoint helpers without executing main.
+# shellcheck disable=SC1090
+source <(sed '/^main "$@"/d' "${ENTRY}")
+
+assert_eq() {
+  local got="$1" want="$2" msg="$3"
+  if [[ "${got}" != "${want}" ]]; then
+    printf 'FAIL: %s (got=%q want=%q)\n' "${msg}" "${got}" "${want}" >&2
+    exit 1
+  fi
+  printf 'ok: %s\n' "${msg}"
+}
+
+setup_kernels() {
+  local dir="$1"
+  mkdir -p "${dir}"
+  : >"${dir}/vmlinux-bm"
+  : >"${dir}/vmlinux-pvm"
+}
+
+# --- select_guest_kernel priorities ---
+# effective-pvm → preserved → CUBE_PVM_ENABLE → symlink → bm
+
+TOOLBOX_ROOT="${TMP}/tb1"
+STATE_DIR="${TMP}/st1"
+mkdir -p "${TOOLBOX_ROOT}" "${STATE_DIR}"
+setup_kernels "${TOOLBOX_ROOT}/cube-kernel-scf"
+# Image default after replace would be bm; preserved says pvm; no env/state.
+unset CUBE_PVM_ENABLE || true
+ln -sfn vmlinux-bm "${TOOLBOX_ROOT}/cube-kernel-scf/vmlinux"
+select_guest_kernel "vmlinux-pvm"
+assert_eq "$(basename "$(readlink "${TOOLBOX_ROOT}/cube-kernel-scf/vmlinux")")" "vmlinux-pvm" \
+  "preserved pvm wins over post-replace bm symlink"
+assert_eq "$(basename "$(readlink "${STATE_DIR}/vmlinux-active")")" "vmlinux-pvm" \
+  "vmlinux-active follows preserved pvm"
+
+TOOLBOX_ROOT="${TMP}/tb2"
+STATE_DIR="${TMP}/st2"
+mkdir -p "${TOOLBOX_ROOT}" "${STATE_DIR}"
+setup_kernels "${TOOLBOX_ROOT}/cube-kernel-scf"
+ln -sfn vmlinux-bm "${TOOLBOX_ROOT}/cube-kernel-scf/vmlinux"
+unset CUBE_PVM_ENABLE || true
+export CUBE_PVM_ENABLE=0
+select_guest_kernel "vmlinux-pvm"
+assert_eq "$(basename "$(readlink "${TOOLBOX_ROOT}/cube-kernel-scf/vmlinux")")" "vmlinux-pvm" \
+  "preserved pvm beats CUBE_PVM_ENABLE=0 (Chart env must not wipe history)"
+
+TOOLBOX_ROOT="${TMP}/tb2b"
+STATE_DIR="${TMP}/st2b"
+mkdir -p "${TOOLBOX_ROOT}" "${STATE_DIR}"
+setup_kernels "${TOOLBOX_ROOT}/cube-kernel-scf"
+ln -sfn vmlinux-bm "${TOOLBOX_ROOT}/cube-kernel-scf/vmlinux"
+unset CUBE_PVM_ENABLE || true
+export CUBE_PVM_ENABLE=1
+select_guest_kernel ""
+assert_eq "$(basename "$(readlink "${TOOLBOX_ROOT}/cube-kernel-scf/vmlinux")")" "vmlinux-pvm" \
+  "CUBE_PVM_ENABLE=1 used when no preserved / no effective-pvm"
+
+TOOLBOX_ROOT="${TMP}/tb3"
+STATE_DIR="${TMP}/st3"
+mkdir -p "${TOOLBOX_ROOT}" "${STATE_DIR}"
+setup_kernels "${TOOLBOX_ROOT}/cube-kernel-scf"
+ln -sfn vmlinux-bm "${TOOLBOX_ROOT}/cube-kernel-scf/vmlinux"
+printf '1\n' >"${STATE_DIR}/effective-pvm"
+export CUBE_PVM_ENABLE=0
+select_guest_kernel "vmlinux-bm"
+assert_eq "$(basename "$(readlink "${TOOLBOX_ROOT}/cube-kernel-scf/vmlinux")")" "vmlinux-pvm" \
+  "effective-pvm=1 beats CUBE_PVM_ENABLE and preserved"
+
+TOOLBOX_ROOT="${TMP}/tb3b"
+STATE_DIR="${TMP}/st3b"
+mkdir -p "${TOOLBOX_ROOT}" "${STATE_DIR}"
+setup_kernels "${TOOLBOX_ROOT}/cube-kernel-scf"
+ln -sfn vmlinux-pvm "${TOOLBOX_ROOT}/cube-kernel-scf/vmlinux"
+printf '0\n' >"${STATE_DIR}/effective-pvm"
+export CUBE_PVM_ENABLE=1
+select_guest_kernel "vmlinux-pvm"
+assert_eq "$(basename "$(readlink "${TOOLBOX_ROOT}/cube-kernel-scf/vmlinux")")" "vmlinux-bm" \
+  "effective-pvm=0 beats preserved pvm and CUBE_PVM_ENABLE=1"
+
+# --- preserve_guest_kernel_selection ---
+TOOLBOX_ROOT="${TMP}/tb4"
+STATE_DIR="${TMP}/st4"
+mkdir -p "${TOOLBOX_ROOT}/cube-kernel-scf" "${STATE_DIR}"
+setup_kernels "${TOOLBOX_ROOT}/cube-kernel-scf"
+ln -sfn vmlinux-pvm "${TOOLBOX_ROOT}/cube-kernel-scf/vmlinux"
+ln -sfn "${TOOLBOX_ROOT}/cube-kernel-scf/vmlinux-pvm" "${STATE_DIR}/vmlinux-active"
+got="$(preserve_guest_kernel_selection "${TOOLBOX_ROOT}/cube-kernel-scf")"
+assert_eq "${got}" "vmlinux-pvm" "preserve reads vmlinux-active"
+
+# --- atomic_replace_dir legacy recovery ---
+TOOLBOX_ROOT="${TMP}/tb5"
+mkdir -p "${TOOLBOX_ROOT}"
+dst="${TOOLBOX_ROOT}/comp"
+src="${TMP}/src5"
+mkdir -p "${src}"
+echo live >"${src}/f"
+mkdir -p "${dst}.legacy.111"
+echo old >"${dst}.legacy.111/f"
+# dst missing (crash after rename-aside)
+atomic_replace_dir "${src}" "${dst}"
+assert_eq "$(cat "${dst}/f")" "live" "atomic_replace recovers then promotes new tree"
+[[ ! -e "${dst}.legacy.111" ]] || { echo "FAIL: orphan legacy not cleaned"; exit 1; }
+printf 'ok: orphan legacy cleaned after successful replace\n'
+
+# --- staging marker: no EXIT trap; only success clears ---
+# Simulate mid-stage: write marker, then "fail" without success cleanup.
+# Entrypoint must not register trap ... EXIT that would rm the marker.
+if grep -qE 'trap[[:space:]]+clear_staging_marker[[:space:]]+EXIT' "${ENTRY}"; then
+  echo "FAIL: stage_component still registers clear_staging_marker EXIT trap" >&2
+  exit 1
+fi
+printf 'ok: no clear_staging_marker EXIT trap in entrypoint\n'
+
+marker="${TMP}/.staging-cubelet"
+printf 'staging\n' >"${marker}"
+# Subshell exit must not clear marker (documents intended failure-path behavior).
+(
+  clear_staging_marker() { rm -f "${marker}"; }
+  # Intentionally do NOT register trap — mirrors production after Fix 1.
+  false || true
+)
+[[ -f "${marker}" ]] || { echo "FAIL: staging marker disappeared without success cleanup"; exit 1; }
+printf 'ok: staging marker survives non-success path (no EXIT clear)\n'
+
+# Success path still clears (mirrors stage_component end).
+rm -f "${marker}"
+[[ ! -f "${marker}" ]] || { echo "FAIL: could not clear marker on success"; exit 1; }
+printf 'ok: success path can clear staging marker\n'
+
+# --- ensure_component_version_json: no weak env synthesis ---
+dst="${TMP}/na"
+mkdir -p "${dst}"
+CUBE_VERSION=should-not-write ensure_component_version_json network-agent "${dst}"
+[[ ! -f "${dst}/version.json" ]] || { echo "FAIL: weak env wrote version.json"; exit 1; }
+printf 'ok: network-agent does not synthesize from CUBE_VERSION\n'
+
+mkdir -p "${TMP}/guest"
+printf 'g1\n' >"${TMP}/guest/version"
+printf 'a1\n' >"${TMP}/guest/agent-version"
+ensure_component_version_json cube-guest "${TMP}/guest"
+grep -q 'guest-image' "${TMP}/guest/version.json"
+grep -q 'cube-agent' "${TMP}/guest/version.json"
+printf 'ok: cube-guest still synthesizes from markers\n'
+
+printf 'ALL PASS\n'


### PR DESCRIPTION
## Background

Refs: #954 

In one-click deployment, all components are installed and upgraded together as a single atomic operation. Cubelet collects and reports node component versions from a single `version.json` file under cubetoolbox, which works because the entire toolbox is replaced at once.

In Kubernetes deployment, however, components can be rolled out independently via separate DaemonSets (installer, bootstrap, node, etc.), each carrying its own image. The old single-source design could not correctly report per-component versions during or after independent upgrades — a cube-shim upgrade would either be invisible or would look like a wholesale regression of every other component.

This PR redesigns version collection to handle independently-rolling components while remaining compatible with the one-click layout.

## Summary

Introduce a multi-source version collection report (`CollectReport`) with an `Incomplete` flag that prevents transient collection gaps from wiping persisted version data in CubeMaster.

### Key changes

**New `component-json` source**
- Reads per-component `version.json` under the staging layout as the primary version source (replaces release-manifest.json as the primary)
- Per-directory allowlist ensures only authorized keys are accepted

**`CollectReport` with `InventoryIncomplete` propagation**
- Collector now returns `CollectReport{Versions, Incomplete}` instead of raw `[]ComponentVersion`
- Register and heartbeat requests propagate `InventoryIncomplete` to CubeMaster
- Mid-stage nodes (`.staging-*` markers or staged sentinel with missing directory) are flagged as incomplete

**Upsert-only persistence for incomplete reports**
- CubeMaster `persistVersions` merges incomplete reports with the previous snapshot (upsert-only, no DELETE of absent keys)
- Skips the DB write when the effective inventory is unchanged (content-hash compare)
- `mergeComponentVersions` deduplicates by component name so prior entries survive

**Kernel variant tracking (bm|pvm)**
- `Variant` field added to `ComponentVersion`
- Kernel version resolved from `version.json` variants, not from the manifest
- Active variant determined from `bootstrap-state/vmlinux-active` with fallback to artifact symlink

**CubeEgress version.json publishing**
- Best-effort `version.json` write into toolbox for inventory discovery

**Chart documentation updates**
- Rewritten guest-kernel selection narrative: effective-pvm first, keep-what-is-running for upgrades, Chart default is first-install intent only
- Added FAQ D6 for turning off PVM per node
- Updated ARCHITECTURE sentinel table and installer bootstrap flow

### Tests
All collector and service tests updated to cover incomplete-report merging, writer signature changes, and per-node mutation lock behavior.