### PR TITLE
feat(metrics): add real-time metrics for a single sandbox

### DIFF
--- a/CubeAPI/src/cubemaster/mod.rs
+++ b/CubeAPI/src/cubemaster/mod.rs
@@ -11,6 +11,7 @@
 ///
 /// Implemented on CubeMaster (see pkg/service/sandbox/types):
 ///   - GET    /cube/sandbox/info       get single sandbox detail (query: sandbox_id, instance_type)
+///   - GET    /cube/sandbox/metrics    get single sandbox metrics snapshot
 ///   - POST   /cube/sandbox/update     update sandbox (action: "pause" | "resume")
 /// Implemented on CubeMaster (snapshot APIs):
 ///   - POST   /cube/snapshot                          create runtime snapshot (synchronous terminal result)
@@ -119,6 +120,36 @@ impl CubeMasterClient {
             .inner
             .get(&url)
             .query(&[("sandbox_id", sandbox_id), ("instance_type", instance_type)])
+            .send()
+            .await
+            .map_err(CubeMasterError::Http)?;
+        parse_response(resp).await
+    }
+
+    /// GET /cube/sandbox/metrics — fetch one sandbox's current metrics snapshot.
+    /// Query: sandbox_id, instance_type, optional start/end Unix seconds.
+    pub async fn get_sandbox_metrics(
+        &self,
+        sandbox_id: &str,
+        instance_type: &str,
+        start: Option<i64>,
+        end: Option<i64>,
+    ) -> Result<GetSandboxMetricsResponse, CubeMasterError> {
+        let url = format!("{}/cube/sandbox/metrics", self.base_url);
+        let mut query = vec![
+            ("sandbox_id", sandbox_id.to_string()),
+            ("instance_type", instance_type.to_string()),
+        ];
+        if let Some(start) = start {
+            query.push(("start", start.to_string()));
+        }
+        if let Some(end) = end {
+            query.push(("end", end.to_string()));
+        }
+        let resp = self
+            .inner
+            .get(&url)
+            .query(&query)
             .send()
             .await
             .map_err(CubeMasterError::Http)?;
@@ -1058,6 +1089,37 @@ pub struct GetSandboxContainerItem {
     pub kind: String,
     #[serde(default)]
     pub pause_at: i64,
+}
+
+#[derive(Debug, Deserialize)]
+#[allow(dead_code)]
+pub struct GetSandboxMetricsResponse {
+    #[serde(rename = "RequestID", alias = "requestID", default)]
+    pub request_id: String,
+    #[serde(default)]
+    pub data: Vec<SandboxMetricItem>,
+    pub ret: RetCode,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+#[allow(dead_code)]
+pub struct SandboxMetricItem {
+    #[serde(default)]
+    pub timestamp_unix_nano: i64,
+    #[serde(default)]
+    pub cpu_count: i32,
+    #[serde(default)]
+    pub cpu_used_pct: f64,
+    #[serde(default)]
+    pub mem_used: i64,
+    #[serde(default)]
+    pub mem_total: i64,
+    #[serde(default)]
+    pub mem_cache: i64,
+    #[serde(default)]
+    pub disk_used: i64,
+    #[serde(default)]
+    pub disk_total: i64,
 }
 
 /// Normalized sandbox detail used by handlers (built from GetSandboxDataItem).

--- a/CubeAPI/src/handlers/sandboxes.rs
+++ b/CubeAPI/src/handlers/sandboxes.rs
@@ -16,7 +16,7 @@ use crate::{
     models::{
         ApiError, ConnectSandbox, ListSandboxesQuery, ListSandboxesV2Query, NewSandbox,
         RefreshRequest, ResumedSandbox, Sandbox, SandboxDetail, SandboxLogsQuery,
-        SandboxLogsV2Query, SandboxLogsV2Response, SetTimeoutRequest,
+        SandboxLogsV2Query, SandboxLogsV2Response, SandboxMetricsQuery, SetTimeoutRequest,
     },
     state::AppState,
 };
@@ -152,6 +152,55 @@ pub async fn get_sandbox(
         )
         .await;
     Ok(Json(detail))
+}
+
+// ─── GET /sandboxes/:sandboxID/metrics ─────────────────────────────────────
+
+/// Handles the public E2B-compatible metrics route and delegates range
+/// validation plus CubeMaster error translation to SandboxService.
+#[utoipa::path(
+    get,
+    path = "/sandboxes/{sandboxID}/metrics",
+    params(
+        ("sandboxID" = String, Path, description = "Sandbox identifier"),
+        SandboxMetricsQuery
+    ),
+    responses(
+        (status = 200, description = "Sandbox metrics", body = [crate::models::SandboxMetric]),
+        (status = 400, description = "Invalid time range", body = ApiError),
+        (status = 404, description = "Sandbox not found", body = ApiError),
+        (status = 500, description = "Unexpected backend error", body = ApiError)
+    )
+)]
+pub async fn get_sandbox_metrics(
+    State(state): State<AppState>,
+    Path(sandbox_id): Path<String>,
+    Query(params): Query<SandboxMetricsQuery>,
+) -> AppResult<impl IntoResponse> {
+    state
+        .logger
+        .log(
+            LogEvent::new(LogLevel::Debug, "api.request")
+                .field("handler", "get_sandbox_metrics")
+                .field("sandbox_id", &sandbox_id),
+        )
+        .await;
+
+    let metrics = state
+        .services
+        .sandboxes
+        .get_metrics(&sandbox_id, params.start, params.end)
+        .await?;
+    state
+        .logger
+        .log(
+            LogEvent::new(LogLevel::Info, "api.response")
+                .field("handler", "get_sandbox_metrics")
+                .field("sandbox_id", &sandbox_id)
+                .field_value("count", metrics.len()),
+        )
+        .await;
+    Ok(Json(metrics))
 }
 
 // ─── POST /sandboxes ──────────────────────────────────────────────────────────

--- a/CubeAPI/src/models/mod.rs
+++ b/CubeAPI/src/models/mod.rs
@@ -316,6 +316,39 @@ pub struct SandboxDetail {
     pub volume_mounts: Option<Vec<SandboxVolumeMount>>,
 }
 
+/// Query parameters for GET /sandboxes/{sandboxID}/metrics.
+#[derive(Debug, Deserialize, IntoParams)]
+#[into_params(parameter_in = Query)]
+pub struct SandboxMetricsQuery {
+    /// Unix timestamp for the start of the interval, in seconds.
+    pub start: Option<i64>,
+    /// Unix timestamp for the end of the interval, in seconds.
+    pub end: Option<i64>,
+}
+
+/// One E2B-compatible sandbox metric entry.
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
+pub struct SandboxMetric {
+    /// Deprecated by E2B but still returned for compatibility.
+    pub timestamp: DateTime<Utc>,
+    #[serde(rename = "timestampUnix")]
+    pub timestamp_unix: i64,
+    #[serde(rename = "cpuCount")]
+    pub cpu_count: i32,
+    #[serde(rename = "cpuUsedPct")]
+    pub cpu_used_pct: f64,
+    #[serde(rename = "memUsed")]
+    pub mem_used: i64,
+    #[serde(rename = "memTotal")]
+    pub mem_total: i64,
+    #[serde(rename = "memCache")]
+    pub mem_cache: i64,
+    #[serde(rename = "diskUsed")]
+    pub disk_used: i64,
+    #[serde(rename = "diskTotal")]
+    pub disk_total: i64,
+}
+
 // ─── Sandbox — pause/resume/connect/snapshot ──────────────────────────────
 
 /// Request body for POST /sandboxes/{id}/resume (deprecated).

--- a/CubeAPI/src/routes.rs
+++ b/CubeAPI/src/routes.rs
@@ -121,6 +121,10 @@ fn build_sandbox_routes(state: &AppState, auth_configured: bool) -> Router<AppSt
         .route("/sandboxes/:sandboxID", get(sandboxes::get_sandbox))
         .route("/sandboxes/:sandboxID", delete(sandboxes::kill_sandbox))
         .route(
+            "/sandboxes/:sandboxID/metrics",
+            get(sandboxes::get_sandbox_metrics),
+        )
+        .route(
             "/sandboxes/:sandboxID/logs",
             get(sandboxes::get_sandbox_logs),
         )
@@ -364,7 +368,7 @@ fn apply_http_layers(router: Router<AppState>, timeout: Duration) -> Router<AppS
 
 #[cfg(test)]
 mod tests {
-    use super::build_router;
+    use super::{build_router, build_sandbox_routes};
     use crate::{
         config::ServerConfig,
         logging::{arc, noop::NoopLogger},
@@ -496,6 +500,40 @@ mod tests {
                 .status_code(),
             StatusCode::NOT_FOUND
         );
+    }
+
+    #[tokio::test]
+    async fn exposes_sandbox_metrics_routes_on_root_and_cubeapi_prefix() {
+        let server = test_server().await;
+
+        server
+            .get("/sandboxes/sb-1/metrics")
+            .add_query_param("start", "2")
+            .add_query_param("end", "1")
+            .await
+            .assert_status(StatusCode::BAD_REQUEST);
+        server
+            .get("/cubeapi/v1/sandboxes/sb-1/metrics")
+            .add_query_param("start", "2")
+            .add_query_param("end", "1")
+            .await
+            .assert_status(StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn sandbox_metrics_route_matches_inside_sandbox_router() {
+        let mut config = ServerConfig::default();
+        config.cubemaster_url = "http://127.0.0.1:9".to_string();
+        let state = AppState::new(config, arc(NoopLogger)).await;
+        let app = build_sandbox_routes(&state, false).with_state(state);
+        let server = TestServer::new(app).expect("sandbox router should build");
+
+        server
+            .get("/sandboxes/sb-1/metrics")
+            .add_query_param("start", "2")
+            .add_query_param("end", "1")
+            .await
+            .assert_status(StatusCode::BAD_REQUEST);
     }
 
     #[tokio::test]

--- a/CubeAPI/src/services/sandboxes.rs
+++ b/CubeAPI/src/services/sandboxes.rs
@@ -12,13 +12,14 @@ use crate::{
         datetime_from_unix_nanos, extract_template_id, CreateSandboxRequest, CubeEgressRule,
         CubeEgressRuleAction, CubeEgressRuleInject, CubeEgressRuleMatch, CubeMasterClient,
         CubeMasterError, CubeNetworkConfig, DeleteSandboxRequest, ListSandboxRequest, SandboxInfo,
-        SandboxLogsRequest, SandboxRefreshRequest, SandboxStatus, SandboxTimeoutRequest,
-        SandboxUpdateRequest,
+        SandboxLogsRequest, SandboxMetricItem, SandboxRefreshRequest, SandboxStatus,
+        SandboxTimeoutRequest, SandboxUpdateRequest,
     },
     error::{AppError, AppResult},
     models::{
         EgressRule, LogLevel as ModelLogLevel, NewSandbox, Sandbox, SandboxDetail, SandboxLog,
-        SandboxLogEntry, SandboxLogs, SandboxLogsV2Response, SandboxNetworkConfig, SandboxState,
+        SandboxLogEntry, SandboxLogs, SandboxLogsV2Response, SandboxMetric, SandboxNetworkConfig,
+        SandboxState,
     },
 };
 
@@ -31,6 +32,8 @@ const RET_CODE_TASK_RESUME_FAILED: i32 = 130589;
 const HOSTDIR_MOUNT_KEY: &str = "host-mount";
 const ENV_VAR_NAME_MAX_LEN: usize = 256;
 const ENV_VAR_VALUE_MAX_LEN: usize = 4096;
+const RET_CODE_MASTER_PARAMS: i32 = 130400;
+const RET_CODE_PRECONDITION_FAILED: i32 = 130568;
 
 /// Environment variable names that may compromise sandbox isolation if injected
 /// at the runtime level (loader overrides, language runtime paths).
@@ -145,6 +148,39 @@ impl SandboxService {
             state: sandbox_state_from_status(d.status),
             volume_mounts: None,
         })
+    }
+
+    /// Fetches one sandbox's metrics through CubeMaster and normalizes the
+    /// internal response into the E2B-compatible API shape.
+    pub async fn get_metrics(
+        &self,
+        sandbox_id: &str,
+        start: Option<i64>,
+        end: Option<i64>,
+    ) -> AppResult<Vec<SandboxMetric>> {
+        if start.is_some_and(|v| v < 0) || end.is_some_and(|v| v < 0) {
+            return Err(AppError::BadRequest(
+                "start/end must be greater than or equal to 0".to_string(),
+            ));
+        }
+        if let (Some(start), Some(end)) = (start, end) {
+            if start > end {
+                return Err(AppError::BadRequest(
+                    "start must be less than or equal to end".to_string(),
+                ));
+            }
+        }
+        let resp = self
+            .cubemaster
+            .get_sandbox_metrics(sandbox_id, &self.instance_type, start, end)
+            .await
+            .map_err(|e| map_metrics_cubemaster_err(e, sandbox_id))?;
+
+        resp.ret
+            .into_result()
+            .map_err(|e| map_metrics_cubemaster_err(e, sandbox_id))?;
+
+        Ok(resp.data.into_iter().map(from_master_metric).collect())
     }
 
     pub async fn create_sandbox(&self, body: NewSandbox) -> AppResult<Sandbox> {
@@ -714,6 +750,43 @@ fn map_update_cubemaster_err(e: CubeMasterError, sandbox_id: &str) -> AppError {
     }
 }
 
+// Metrics has a different public error contract from generic sandbox actions:
+// invalid ranges must remain 400, while "not found" can come back either as
+// CubeMaster NotFound or a Cubelet precondition failure.
+fn map_metrics_cubemaster_err(e: CubeMasterError, sandbox_id: &str) -> AppError {
+    match e {
+        CubeMasterError::Api { ret_code, ret_msg } if ret_code == RET_CODE_MASTER_PARAMS => {
+            AppError::BadRequest(ret_msg)
+        }
+        CubeMasterError::Api { ret_code, .. } if ret_code == RET_CODE_NOT_FOUND => {
+            AppError::NotFound(format!("sandbox {} not found", sandbox_id))
+        }
+        CubeMasterError::Api { ret_code, ret_msg }
+            if ret_code == RET_CODE_PRECONDITION_FAILED
+                && ret_msg.to_ascii_lowercase().contains("not found") =>
+        {
+            AppError::NotFound(format!("sandbox {} not found", sandbox_id))
+        }
+        other => sandbox_not_found_or_internal(other, sandbox_id),
+    }
+}
+
+fn from_master_metric(metric: SandboxMetricItem) -> SandboxMetric {
+    let timestamp =
+        datetime_from_unix_nanos(metric.timestamp_unix_nano).unwrap_or_else(chrono::Utc::now);
+    SandboxMetric {
+        timestamp,
+        timestamp_unix: metric.timestamp_unix_nano / 1_000_000_000,
+        cpu_count: metric.cpu_count,
+        cpu_used_pct: metric.cpu_used_pct,
+        mem_used: metric.mem_used,
+        mem_total: metric.mem_total,
+        mem_cache: metric.mem_cache,
+        disk_used: metric.disk_used,
+        disk_total: metric.disk_total,
+    }
+}
+
 fn ensure_update_result(
     ret_code: i32,
     ret_msg: String,
@@ -947,10 +1020,10 @@ mod tests {
         SandboxNetworkConfig, SandboxState,
     };
     use axum::{
-        extract::State,
+        extract::{Query, State},
         http::{header::RETRY_AFTER, StatusCode},
         response::IntoResponse,
-        routing::{delete, post},
+        routing::{delete, get, post},
         Json, Router,
     };
     use serde_json::Value;
@@ -1465,6 +1538,105 @@ mod tests {
             serde_json::json!("from-create")
         );
         assert!(create_body.get("envVars").is_none());
+    }
+
+    #[tokio::test]
+    async fn get_metrics_returns_e2b_metric_shape_from_cubemaster_snapshot() {
+        #[derive(Clone, Default)]
+        struct Capture {
+            query: Arc<Mutex<Option<HashMap<String, String>>>>,
+        }
+
+        async fn metrics_handler(
+            State(capture): State<Capture>,
+            Query(query): Query<HashMap<String, String>>,
+        ) -> Json<Value> {
+            *capture.query.lock().await = Some(query);
+            Json(serde_json::json!({
+                "requestID": "req-1",
+                "ret": { "ret_code": 0, "ret_msg": "ok" },
+                "data": [{
+                    "timestamp_unix_nano": 1700000000123456789i64,
+                    "cpu_count": 2,
+                    "cpu_used_pct": 12.5,
+                    "mem_used": 1024,
+                    "mem_total": 4096,
+                    "mem_cache": 512,
+                    "disk_used": 2048,
+                    "disk_total": 8192
+                }]
+            }))
+        }
+
+        async fn spawn_server(app: Router) -> String {
+            let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+                .await
+                .expect("listener should bind");
+            let addr = listener.local_addr().expect("listener addr");
+            tokio::spawn(async move {
+                axum::serve(listener, app).await.expect("server should run");
+            });
+            format!("http://{}", addr)
+        }
+
+        let capture = Capture::default();
+        let cubemaster_url = spawn_server(
+            Router::new()
+                .route("/cube/sandbox/metrics", get(metrics_handler))
+                .with_state(capture.clone()),
+        )
+        .await;
+        let service = SandboxService::new(
+            CubeMasterClient::new(cubemaster_url, reqwest::Client::new()),
+            "cubebox".to_string(),
+            "cube.app".to_string(),
+        );
+
+        let metrics = service
+            .get_metrics("sb-1", Some(1700000000), Some(1700000001))
+            .await
+            .expect("metrics request should succeed");
+
+        let query = capture
+            .query
+            .lock()
+            .await
+            .clone()
+            .expect("query should be captured");
+        assert_eq!(query.get("sandbox_id").map(String::as_str), Some("sb-1"));
+        assert_eq!(
+            query.get("instance_type").map(String::as_str),
+            Some("cubebox")
+        );
+        assert_eq!(query.get("start").map(String::as_str), Some("1700000000"));
+        assert_eq!(query.get("end").map(String::as_str), Some("1700000001"));
+
+        assert_eq!(metrics.len(), 1);
+        let metric = &metrics[0];
+        assert_eq!(metric.timestamp_unix, 1700000000);
+        assert_eq!(metric.cpu_count, 2);
+        assert_eq!(metric.cpu_used_pct, 12.5);
+        assert_eq!(metric.mem_used, 1024);
+        assert_eq!(metric.mem_total, 4096);
+        assert_eq!(metric.mem_cache, 512);
+        assert_eq!(metric.disk_used, 2048);
+        assert_eq!(metric.disk_total, 8192);
+    }
+
+    #[tokio::test]
+    async fn get_metrics_rejects_invalid_time_range_before_cubemaster() {
+        let service = SandboxService::new(
+            CubeMasterClient::new("http://127.0.0.1:9", reqwest::Client::new()),
+            "cubebox".to_string(),
+            "cube.app".to_string(),
+        );
+
+        let err = service
+            .get_metrics("sb-1", Some(10), Some(9))
+            .await
+            .expect_err("invalid range should fail before network call");
+
+        assert!(matches!(err, AppError::BadRequest(_)));
     }
 
     #[tokio::test]

--- a/CubeMaster/api/services/cubebox/v1/cubebox.pb.go
+++ b/CubeMaster/api/services/cubebox/v1/cubebox.pb.go
@@ -5982,6 +5982,240 @@ func (x *GetStorageMetricsResponse) GetMetrics() map[string]uint64 {
 	return nil
 }
 
+type GetSandboxMetricsRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// requestID reqID
+	RequestID string `protobuf:"bytes,1,opt,name=requestID,proto3" json:"requestID,omitempty"`
+	// Sandbox identifier to inspect.
+	SandboxID     string `protobuf:"bytes,2,opt,name=sandboxID,proto3" json:"sandboxID,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetSandboxMetricsRequest) Reset() {
+	*x = GetSandboxMetricsRequest{}
+	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[74]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetSandboxMetricsRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetSandboxMetricsRequest) ProtoMessage() {}
+
+func (x *GetSandboxMetricsRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[74]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetSandboxMetricsRequest.ProtoReflect.Descriptor instead.
+func (*GetSandboxMetricsRequest) Descriptor() ([]byte, []int) {
+	return file_api_services_cubebox_v1_cubebox_proto_rawDescGZIP(), []int{74}
+}
+
+func (x *GetSandboxMetricsRequest) GetRequestID() string {
+	if x != nil {
+		return x.RequestID
+	}
+	return ""
+}
+
+func (x *GetSandboxMetricsRequest) GetSandboxID() string {
+	if x != nil {
+		return x.SandboxID
+	}
+	return ""
+}
+
+type SandboxMetric struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Timestamp when metrics were collected.
+	TimestampUnixNano int64 `protobuf:"varint,1,opt,name=timestamp_unix_nano,json=timestampUnixNano,proto3" json:"timestamp_unix_nano,omitempty"`
+	// Number of CPU cores assigned to the sandbox.
+	CpuCount int32 `protobuf:"varint,2,opt,name=cpu_count,json=cpuCount,proto3" json:"cpu_count,omitempty"`
+	// CPU usage percentage. Best-effort in the current implementation.
+	CpuUsedPct float64 `protobuf:"fixed64,3,opt,name=cpu_used_pct,json=cpuUsedPct,proto3" json:"cpu_used_pct,omitempty"`
+	// Memory used in bytes. Best-effort in the current implementation.
+	MemUsed int64 `protobuf:"varint,4,opt,name=mem_used,json=memUsed,proto3" json:"mem_used,omitempty"`
+	// Total memory in bytes.
+	MemTotal int64 `protobuf:"varint,5,opt,name=mem_total,json=memTotal,proto3" json:"mem_total,omitempty"`
+	// Cached memory in bytes. Best-effort in the current implementation.
+	MemCache int64 `protobuf:"varint,6,opt,name=mem_cache,json=memCache,proto3" json:"mem_cache,omitempty"`
+	// Disk used in bytes. Best-effort in the current implementation.
+	DiskUsed int64 `protobuf:"varint,7,opt,name=disk_used,json=diskUsed,proto3" json:"disk_used,omitempty"`
+	// Total sandbox disk quota in bytes.
+	DiskTotal     int64 `protobuf:"varint,8,opt,name=disk_total,json=diskTotal,proto3" json:"disk_total,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SandboxMetric) Reset() {
+	*x = SandboxMetric{}
+	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[75]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SandboxMetric) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SandboxMetric) ProtoMessage() {}
+
+func (x *SandboxMetric) ProtoReflect() protoreflect.Message {
+	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[75]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SandboxMetric.ProtoReflect.Descriptor instead.
+func (*SandboxMetric) Descriptor() ([]byte, []int) {
+	return file_api_services_cubebox_v1_cubebox_proto_rawDescGZIP(), []int{75}
+}
+
+func (x *SandboxMetric) GetTimestampUnixNano() int64 {
+	if x != nil {
+		return x.TimestampUnixNano
+	}
+	return 0
+}
+
+func (x *SandboxMetric) GetCpuCount() int32 {
+	if x != nil {
+		return x.CpuCount
+	}
+	return 0
+}
+
+func (x *SandboxMetric) GetCpuUsedPct() float64 {
+	if x != nil {
+		return x.CpuUsedPct
+	}
+	return 0
+}
+
+func (x *SandboxMetric) GetMemUsed() int64 {
+	if x != nil {
+		return x.MemUsed
+	}
+	return 0
+}
+
+func (x *SandboxMetric) GetMemTotal() int64 {
+	if x != nil {
+		return x.MemTotal
+	}
+	return 0
+}
+
+func (x *SandboxMetric) GetMemCache() int64 {
+	if x != nil {
+		return x.MemCache
+	}
+	return 0
+}
+
+func (x *SandboxMetric) GetDiskUsed() int64 {
+	if x != nil {
+		return x.DiskUsed
+	}
+	return 0
+}
+
+func (x *SandboxMetric) GetDiskTotal() int64 {
+	if x != nil {
+		return x.DiskTotal
+	}
+	return 0
+}
+
+type GetSandboxMetricsResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// requestID reqID
+	RequestID string `protobuf:"bytes,1,opt,name=requestID,proto3" json:"requestID,omitempty"`
+	// Ret.
+	Ret *v11.Ret `protobuf:"bytes,2,opt,name=ret,proto3" json:"ret,omitempty"`
+	// Sandbox identifier that produced this metric snapshot.
+	SandboxID string `protobuf:"bytes,3,opt,name=sandboxID,proto3" json:"sandboxID,omitempty"`
+	// Current sandbox metric snapshot. Empty when no sample is available.
+	Metrics       []*SandboxMetric `protobuf:"bytes,4,rep,name=metrics,proto3" json:"metrics,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetSandboxMetricsResponse) Reset() {
+	*x = GetSandboxMetricsResponse{}
+	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[76]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetSandboxMetricsResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetSandboxMetricsResponse) ProtoMessage() {}
+
+func (x *GetSandboxMetricsResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[76]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetSandboxMetricsResponse.ProtoReflect.Descriptor instead.
+func (*GetSandboxMetricsResponse) Descriptor() ([]byte, []int) {
+	return file_api_services_cubebox_v1_cubebox_proto_rawDescGZIP(), []int{76}
+}
+
+func (x *GetSandboxMetricsResponse) GetRequestID() string {
+	if x != nil {
+		return x.RequestID
+	}
+	return ""
+}
+
+func (x *GetSandboxMetricsResponse) GetRet() *v11.Ret {
+	if x != nil {
+		return x.Ret
+	}
+	return nil
+}
+
+func (x *GetSandboxMetricsResponse) GetSandboxID() string {
+	if x != nil {
+		return x.SandboxID
+	}
+	return ""
+}
+
+func (x *GetSandboxMetricsResponse) GetMetrics() []*SandboxMetric {
+	if x != nil {
+		return x.Metrics
+	}
+	return nil
+}
+
 // StorageVolumeInfo describes a single backend file/volume entry attached to a
 // sandbox, as understood by cubelet at the time of inspection.
 type StorageVolumeInfo struct {
@@ -5998,7 +6232,7 @@ type StorageVolumeInfo struct {
 
 func (x *StorageVolumeInfo) Reset() {
 	*x = StorageVolumeInfo{}
-	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[74]
+	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[77]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6010,7 +6244,7 @@ func (x *StorageVolumeInfo) String() string {
 func (*StorageVolumeInfo) ProtoMessage() {}
 
 func (x *StorageVolumeInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[74]
+	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[77]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6023,7 +6257,7 @@ func (x *StorageVolumeInfo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StorageVolumeInfo.ProtoReflect.Descriptor instead.
 func (*StorageVolumeInfo) Descriptor() ([]byte, []int) {
-	return file_api_services_cubebox_v1_cubebox_proto_rawDescGZIP(), []int{74}
+	return file_api_services_cubebox_v1_cubebox_proto_rawDescGZIP(), []int{77}
 }
 
 func (x *StorageVolumeInfo) GetName() string {
@@ -6079,7 +6313,7 @@ type SandboxStorageInfo struct {
 
 func (x *SandboxStorageInfo) Reset() {
 	*x = SandboxStorageInfo{}
-	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[75]
+	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[78]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6091,7 +6325,7 @@ func (x *SandboxStorageInfo) String() string {
 func (*SandboxStorageInfo) ProtoMessage() {}
 
 func (x *SandboxStorageInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[75]
+	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[78]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6104,7 +6338,7 @@ func (x *SandboxStorageInfo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SandboxStorageInfo.ProtoReflect.Descriptor instead.
 func (*SandboxStorageInfo) Descriptor() ([]byte, []int) {
-	return file_api_services_cubebox_v1_cubebox_proto_rawDescGZIP(), []int{75}
+	return file_api_services_cubebox_v1_cubebox_proto_rawDescGZIP(), []int{78}
 }
 
 func (x *SandboxStorageInfo) GetNamespace() string {
@@ -6138,7 +6372,7 @@ type InspectStorageVolumesRequest struct {
 
 func (x *InspectStorageVolumesRequest) Reset() {
 	*x = InspectStorageVolumesRequest{}
-	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[76]
+	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[79]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6150,7 +6384,7 @@ func (x *InspectStorageVolumesRequest) String() string {
 func (*InspectStorageVolumesRequest) ProtoMessage() {}
 
 func (x *InspectStorageVolumesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[76]
+	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[79]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6163,7 +6397,7 @@ func (x *InspectStorageVolumesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use InspectStorageVolumesRequest.ProtoReflect.Descriptor instead.
 func (*InspectStorageVolumesRequest) Descriptor() ([]byte, []int) {
-	return file_api_services_cubebox_v1_cubebox_proto_rawDescGZIP(), []int{76}
+	return file_api_services_cubebox_v1_cubebox_proto_rawDescGZIP(), []int{79}
 }
 
 func (x *InspectStorageVolumesRequest) GetRequestID() string {
@@ -6191,7 +6425,7 @@ type InspectStorageVolumesResponse struct {
 
 func (x *InspectStorageVolumesResponse) Reset() {
 	*x = InspectStorageVolumesResponse{}
-	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[77]
+	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[80]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6203,7 +6437,7 @@ func (x *InspectStorageVolumesResponse) String() string {
 func (*InspectStorageVolumesResponse) ProtoMessage() {}
 
 func (x *InspectStorageVolumesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[77]
+	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[80]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6216,7 +6450,7 @@ func (x *InspectStorageVolumesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use InspectStorageVolumesResponse.ProtoReflect.Descriptor instead.
 func (*InspectStorageVolumesResponse) Descriptor() ([]byte, []int) {
-	return file_api_services_cubebox_v1_cubebox_proto_rawDescGZIP(), []int{77}
+	return file_api_services_cubebox_v1_cubebox_proto_rawDescGZIP(), []int{80}
 }
 
 func (x *InspectStorageVolumesResponse) GetRequestID() string {
@@ -6252,7 +6486,7 @@ type CleanupOrphanStorageFilesRequest struct {
 
 func (x *CleanupOrphanStorageFilesRequest) Reset() {
 	*x = CleanupOrphanStorageFilesRequest{}
-	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[78]
+	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[81]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6264,7 +6498,7 @@ func (x *CleanupOrphanStorageFilesRequest) String() string {
 func (*CleanupOrphanStorageFilesRequest) ProtoMessage() {}
 
 func (x *CleanupOrphanStorageFilesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[78]
+	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[81]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6277,7 +6511,7 @@ func (x *CleanupOrphanStorageFilesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CleanupOrphanStorageFilesRequest.ProtoReflect.Descriptor instead.
 func (*CleanupOrphanStorageFilesRequest) Descriptor() ([]byte, []int) {
-	return file_api_services_cubebox_v1_cubebox_proto_rawDescGZIP(), []int{78}
+	return file_api_services_cubebox_v1_cubebox_proto_rawDescGZIP(), []int{81}
 }
 
 func (x *CleanupOrphanStorageFilesRequest) GetRequestID() string {
@@ -6320,7 +6554,7 @@ type StorageOrphanEntry struct {
 
 func (x *StorageOrphanEntry) Reset() {
 	*x = StorageOrphanEntry{}
-	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[79]
+	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[82]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6332,7 +6566,7 @@ func (x *StorageOrphanEntry) String() string {
 func (*StorageOrphanEntry) ProtoMessage() {}
 
 func (x *StorageOrphanEntry) ProtoReflect() protoreflect.Message {
-	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[79]
+	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[82]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6345,7 +6579,7 @@ func (x *StorageOrphanEntry) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StorageOrphanEntry.ProtoReflect.Descriptor instead.
 func (*StorageOrphanEntry) Descriptor() ([]byte, []int) {
-	return file_api_services_cubebox_v1_cubebox_proto_rawDescGZIP(), []int{79}
+	return file_api_services_cubebox_v1_cubebox_proto_rawDescGZIP(), []int{82}
 }
 
 func (x *StorageOrphanEntry) GetFormat() string {
@@ -6387,7 +6621,7 @@ type CleanupOrphanStorageFilesResponse struct {
 
 func (x *CleanupOrphanStorageFilesResponse) Reset() {
 	*x = CleanupOrphanStorageFilesResponse{}
-	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[80]
+	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[83]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6399,7 +6633,7 @@ func (x *CleanupOrphanStorageFilesResponse) String() string {
 func (*CleanupOrphanStorageFilesResponse) ProtoMessage() {}
 
 func (x *CleanupOrphanStorageFilesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[80]
+	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[83]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6412,7 +6646,7 @@ func (x *CleanupOrphanStorageFilesResponse) ProtoReflect() protoreflect.Message 
 
 // Deprecated: Use CleanupOrphanStorageFilesResponse.ProtoReflect.Descriptor instead.
 func (*CleanupOrphanStorageFilesResponse) Descriptor() ([]byte, []int) {
-	return file_api_services_cubebox_v1_cubebox_proto_rawDescGZIP(), []int{80}
+	return file_api_services_cubebox_v1_cubebox_proto_rawDescGZIP(), []int{83}
 }
 
 func (x *CleanupOrphanStorageFilesResponse) GetRequestID() string {
@@ -6964,7 +7198,26 @@ const file_api_services_cubebox_v1_cubebox_proto_rawDesc = "" +
 	"\ametrics\x18\x05 \x03(\v2C.cubelet.services.cubebox.v1.GetStorageMetricsResponse.MetricsEntryR\ametrics\x1a:\n" +
 	"\fMetricsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\x04R\x05value:\x028\x01\"\xaa\x01\n" +
+	"\x05value\x18\x02 \x01(\x04R\x05value:\x028\x01\"V\n" +
+	"\x18GetSandboxMetricsRequest\x12\x1c\n" +
+	"\trequestID\x18\x01 \x01(\tR\trequestID\x12\x1c\n" +
+	"\tsandboxID\x18\x02 \x01(\tR\tsandboxID\"\x8f\x02\n" +
+	"\rSandboxMetric\x12.\n" +
+	"\x13timestamp_unix_nano\x18\x01 \x01(\x03R\x11timestampUnixNano\x12\x1b\n" +
+	"\tcpu_count\x18\x02 \x01(\x05R\bcpuCount\x12 \n" +
+	"\fcpu_used_pct\x18\x03 \x01(\x01R\n" +
+	"cpuUsedPct\x12\x19\n" +
+	"\bmem_used\x18\x04 \x01(\x03R\amemUsed\x12\x1b\n" +
+	"\tmem_total\x18\x05 \x01(\x03R\bmemTotal\x12\x1b\n" +
+	"\tmem_cache\x18\x06 \x01(\x03R\bmemCache\x12\x1b\n" +
+	"\tdisk_used\x18\a \x01(\x03R\bdiskUsed\x12\x1d\n" +
+	"\n" +
+	"disk_total\x18\b \x01(\x03R\tdiskTotal\"\xd3\x01\n" +
+	"\x19GetSandboxMetricsResponse\x12\x1c\n" +
+	"\trequestID\x18\x01 \x01(\tR\trequestID\x124\n" +
+	"\x03ret\x18\x02 \x01(\v2\".cubelet.services.errorcode.v1.RetR\x03ret\x12\x1c\n" +
+	"\tsandboxID\x18\x03 \x01(\tR\tsandboxID\x12D\n" +
+	"\ametrics\x18\x04 \x03(\v2*.cubelet.services.cubebox.v1.SandboxMetricR\ametrics\"\xaa\x01\n" +
 	"\x11StorageVolumeInfo\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x1b\n" +
 	"\tfile_path\x18\x02 \x01(\tR\bfilePath\x12\x1d\n" +
@@ -7022,7 +7275,7 @@ const file_api_services_cubebox_v1_cubebox_proto_rawDesc = "" +
 	"\x10CONTAINER_EXITED\x10\x02\x12\x15\n" +
 	"\x11CONTAINER_UNKNOWN\x10\x03\x12\x15\n" +
 	"\x11CONTAINER_PAUSING\x10\x04\x12\x14\n" +
-	"\x10CONTAINER_PAUSED\x10\x052\x8a\x0f\n" +
+	"\x10CONTAINER_PAUSED\x10\x052\x8f\x10\n" +
 	"\n" +
 	"CubeboxMgr\x12q\n" +
 	"\x06Create\x122.cubelet.services.cubebox.v1.RunCubeSandboxRequest\x1a3.cubelet.services.cubebox.v1.RunCubeSandboxResponse\x12z\n" +
@@ -7037,7 +7290,8 @@ const file_api_services_cubebox_v1_cubebox_proto_rawDesc = "" +
 	"\x14ListSandboxSnapshots\x128.cubelet.services.cubebox.v1.ListSandboxSnapshotsRequest\x1a9.cubelet.services.cubebox.v1.ListSandboxSnapshotsResponse\x12\x85\x01\n" +
 	"\x12ListLocalSnapshots\x126.cubelet.services.cubebox.v1.ListLocalSnapshotsRequest\x1a7.cubelet.services.cubebox.v1.ListLocalSnapshotsResponse\x12\x7f\n" +
 	"\x10GetLocalSnapshot\x124.cubelet.services.cubebox.v1.GetLocalSnapshotRequest\x1a5.cubelet.services.cubebox.v1.GetLocalSnapshotResponse\x12\x82\x01\n" +
-	"\x11GetStorageMetrics\x125.cubelet.services.cubebox.v1.GetStorageMetricsRequest\x1a6.cubelet.services.cubebox.v1.GetStorageMetricsResponse\x12\x8e\x01\n" +
+	"\x11GetStorageMetrics\x125.cubelet.services.cubebox.v1.GetStorageMetricsRequest\x1a6.cubelet.services.cubebox.v1.GetStorageMetricsResponse\x12\x82\x01\n" +
+	"\x11GetSandboxMetrics\x125.cubelet.services.cubebox.v1.GetSandboxMetricsRequest\x1a6.cubelet.services.cubebox.v1.GetSandboxMetricsResponse\x12\x8e\x01\n" +
 	"\x15InspectStorageVolumes\x129.cubelet.services.cubebox.v1.InspectStorageVolumesRequest\x1a:.cubelet.services.cubebox.v1.InspectStorageVolumesResponse\x12\x9a\x01\n" +
 	"\x19CleanupOrphanStorageFiles\x12=.cubelet.services.cubebox.v1.CleanupOrphanStorageFilesRequest\x1a>.cubelet.services.cubebox.v1.CleanupOrphanStorageFilesResponseBPZNgithub.com/tencentcloud/CubeSandbox/CubeMaster/api/services/cubebox/v1;cubeboxb\x06proto3"
 
@@ -7054,7 +7308,7 @@ func file_api_services_cubebox_v1_cubebox_proto_rawDescGZIP() []byte {
 }
 
 var file_api_services_cubebox_v1_cubebox_proto_enumTypes = make([]protoimpl.EnumInfo, 6)
-var file_api_services_cubebox_v1_cubebox_proto_msgTypes = make([]protoimpl.MessageInfo, 93)
+var file_api_services_cubebox_v1_cubebox_proto_msgTypes = make([]protoimpl.MessageInfo, 96)
 var file_api_services_cubebox_v1_cubebox_proto_goTypes = []any{
 	(MountPropagation)(0),                     // 0: cubelet.services.cubebox.v1.MountPropagation
 	(StorageMedium)(0),                        // 1: cubelet.services.cubebox.v1.StorageMedium
@@ -7136,28 +7390,31 @@ var file_api_services_cubebox_v1_cubebox_proto_goTypes = []any{
 	(*GetLocalSnapshotResponse)(nil),          // 77: cubelet.services.cubebox.v1.GetLocalSnapshotResponse
 	(*GetStorageMetricsRequest)(nil),          // 78: cubelet.services.cubebox.v1.GetStorageMetricsRequest
 	(*GetStorageMetricsResponse)(nil),         // 79: cubelet.services.cubebox.v1.GetStorageMetricsResponse
-	(*StorageVolumeInfo)(nil),                 // 80: cubelet.services.cubebox.v1.StorageVolumeInfo
-	(*SandboxStorageInfo)(nil),                // 81: cubelet.services.cubebox.v1.SandboxStorageInfo
-	(*InspectStorageVolumesRequest)(nil),      // 82: cubelet.services.cubebox.v1.InspectStorageVolumesRequest
-	(*InspectStorageVolumesResponse)(nil),     // 83: cubelet.services.cubebox.v1.InspectStorageVolumesResponse
-	(*CleanupOrphanStorageFilesRequest)(nil),  // 84: cubelet.services.cubebox.v1.CleanupOrphanStorageFilesRequest
-	(*StorageOrphanEntry)(nil),                // 85: cubelet.services.cubebox.v1.StorageOrphanEntry
-	(*CleanupOrphanStorageFilesResponse)(nil), // 86: cubelet.services.cubebox.v1.CleanupOrphanStorageFilesResponse
-	nil,                          // 87: cubelet.services.cubebox.v1.ContainerConfig.SysctlsEntry
-	nil,                          // 88: cubelet.services.cubebox.v1.ContainerConfig.AnnotationsEntry
-	nil,                          // 89: cubelet.services.cubebox.v1.RunCubeSandboxRequest.AnnotationsEntry
-	nil,                          // 90: cubelet.services.cubebox.v1.RunCubeSandboxRequest.LabelsEntry
-	nil,                          // 91: cubelet.services.cubebox.v1.RunCubeSandboxResponse.ExtInfoEntry
-	nil,                          // 92: cubelet.services.cubebox.v1.DestroyCubeSandboxRequest.AnnotationsEntry
-	nil,                          // 93: cubelet.services.cubebox.v1.DestroyCubeSandboxResponse.ExtInfoEntry
-	nil,                          // 94: cubelet.services.cubebox.v1.CubeSandbox.LabelsEntry
-	nil,                          // 95: cubelet.services.cubebox.v1.Container.LabelsEntry
-	nil,                          // 96: cubelet.services.cubebox.v1.CubeSandboxFilter.LabelSelectorEntry
-	nil,                          // 97: cubelet.services.cubebox.v1.UpdateCubeSandboxRequest.AnnotationsEntry
-	nil,                          // 98: cubelet.services.cubebox.v1.GetStorageMetricsResponse.MetricsEntry
-	(*v1.ImageSpec)(nil),         // 99: cubelet.services.images.v1.ImageSpec
-	(*v1.ImageVolumeSource)(nil), // 100: cubelet.services.images.v1.ImageVolumeSource
-	(*v11.Ret)(nil),              // 101: cubelet.services.errorcode.v1.Ret
+	(*GetSandboxMetricsRequest)(nil),          // 80: cubelet.services.cubebox.v1.GetSandboxMetricsRequest
+	(*SandboxMetric)(nil),                     // 81: cubelet.services.cubebox.v1.SandboxMetric
+	(*GetSandboxMetricsResponse)(nil),         // 82: cubelet.services.cubebox.v1.GetSandboxMetricsResponse
+	(*StorageVolumeInfo)(nil),                 // 83: cubelet.services.cubebox.v1.StorageVolumeInfo
+	(*SandboxStorageInfo)(nil),                // 84: cubelet.services.cubebox.v1.SandboxStorageInfo
+	(*InspectStorageVolumesRequest)(nil),      // 85: cubelet.services.cubebox.v1.InspectStorageVolumesRequest
+	(*InspectStorageVolumesResponse)(nil),     // 86: cubelet.services.cubebox.v1.InspectStorageVolumesResponse
+	(*CleanupOrphanStorageFilesRequest)(nil),  // 87: cubelet.services.cubebox.v1.CleanupOrphanStorageFilesRequest
+	(*StorageOrphanEntry)(nil),                // 88: cubelet.services.cubebox.v1.StorageOrphanEntry
+	(*CleanupOrphanStorageFilesResponse)(nil), // 89: cubelet.services.cubebox.v1.CleanupOrphanStorageFilesResponse
+	nil,                          // 90: cubelet.services.cubebox.v1.ContainerConfig.SysctlsEntry
+	nil,                          // 91: cubelet.services.cubebox.v1.ContainerConfig.AnnotationsEntry
+	nil,                          // 92: cubelet.services.cubebox.v1.RunCubeSandboxRequest.AnnotationsEntry
+	nil,                          // 93: cubelet.services.cubebox.v1.RunCubeSandboxRequest.LabelsEntry
+	nil,                          // 94: cubelet.services.cubebox.v1.RunCubeSandboxResponse.ExtInfoEntry
+	nil,                          // 95: cubelet.services.cubebox.v1.DestroyCubeSandboxRequest.AnnotationsEntry
+	nil,                          // 96: cubelet.services.cubebox.v1.DestroyCubeSandboxResponse.ExtInfoEntry
+	nil,                          // 97: cubelet.services.cubebox.v1.CubeSandbox.LabelsEntry
+	nil,                          // 98: cubelet.services.cubebox.v1.Container.LabelsEntry
+	nil,                          // 99: cubelet.services.cubebox.v1.CubeSandboxFilter.LabelSelectorEntry
+	nil,                          // 100: cubelet.services.cubebox.v1.UpdateCubeSandboxRequest.AnnotationsEntry
+	nil,                          // 101: cubelet.services.cubebox.v1.GetStorageMetricsResponse.MetricsEntry
+	(*v1.ImageSpec)(nil),         // 102: cubelet.services.images.v1.ImageSpec
+	(*v1.ImageVolumeSource)(nil), // 103: cubelet.services.images.v1.ImageVolumeSource
+	(*v11.Ret)(nil),              // 104: cubelet.services.errorcode.v1.Ret
 }
 var file_api_services_cubebox_v1_cubebox_proto_depIdxs = []int32{
 	7,   // 0: cubelet.services.cubebox.v1.ContainerSecurityContext.capabilities:type_name -> cubelet.services.cubebox.v1.Capability
@@ -7175,17 +7432,17 @@ var file_api_services_cubebox_v1_cubebox_proto_depIdxs = []int32{
 	19,  // 12: cubelet.services.cubebox.v1.PreStop.lifecyle_handler:type_name -> cubelet.services.cubebox.v1.LifecycleHandler
 	19,  // 13: cubelet.services.cubebox.v1.PostStop.lifecyle_handler:type_name -> cubelet.services.cubebox.v1.LifecycleHandler
 	22,  // 14: cubelet.services.cubebox.v1.Hooks.Prestart:type_name -> cubelet.services.cubebox.v1.Hook
-	99,  // 15: cubelet.services.cubebox.v1.ContainerConfig.image:type_name -> cubelet.services.images.v1.ImageSpec
+	102, // 15: cubelet.services.cubebox.v1.ContainerConfig.image:type_name -> cubelet.services.images.v1.ImageSpec
 	24,  // 16: cubelet.services.cubebox.v1.ContainerConfig.envs:type_name -> cubelet.services.cubebox.v1.KeyValue
 	12,  // 17: cubelet.services.cubebox.v1.ContainerConfig.volume_mounts:type_name -> cubelet.services.cubebox.v1.VolumeMounts
 	11,  // 18: cubelet.services.cubebox.v1.ContainerConfig.r_limit:type_name -> cubelet.services.cubebox.v1.RLimit
 	32,  // 19: cubelet.services.cubebox.v1.ContainerConfig.resources:type_name -> cubelet.services.cubebox.v1.Resource
 	9,   // 20: cubelet.services.cubebox.v1.ContainerConfig.security_context:type_name -> cubelet.services.cubebox.v1.ContainerSecurityContext
 	18,  // 21: cubelet.services.cubebox.v1.ContainerConfig.probe:type_name -> cubelet.services.cubebox.v1.Probe
-	87,  // 22: cubelet.services.cubebox.v1.ContainerConfig.sysctls:type_name -> cubelet.services.cubebox.v1.ContainerConfig.SysctlsEntry
+	90,  // 22: cubelet.services.cubebox.v1.ContainerConfig.sysctls:type_name -> cubelet.services.cubebox.v1.ContainerConfig.SysctlsEntry
 	31,  // 23: cubelet.services.cubebox.v1.ContainerConfig.syscalls:type_name -> cubelet.services.cubebox.v1.SysCall
 	10,  // 24: cubelet.services.cubebox.v1.ContainerConfig.dns_config:type_name -> cubelet.services.cubebox.v1.DNSConfig
-	88,  // 25: cubelet.services.cubebox.v1.ContainerConfig.annotations:type_name -> cubelet.services.cubebox.v1.ContainerConfig.AnnotationsEntry
+	91,  // 25: cubelet.services.cubebox.v1.ContainerConfig.annotations:type_name -> cubelet.services.cubebox.v1.ContainerConfig.AnnotationsEntry
 	25,  // 26: cubelet.services.cubebox.v1.ContainerConfig.hostAliases:type_name -> cubelet.services.cubebox.v1.HostAlias
 	20,  // 27: cubelet.services.cubebox.v1.ContainerConfig.prestop:type_name -> cubelet.services.cubebox.v1.PreStop
 	21,  // 28: cubelet.services.cubebox.v1.ContainerConfig.poststop:type_name -> cubelet.services.cubebox.v1.PostStop
@@ -7199,94 +7456,98 @@ var file_api_services_cubebox_v1_cubebox_proto_depIdxs = []int32{
 	33,  // 36: cubelet.services.cubebox.v1.VolumeSource.empty_dir:type_name -> cubelet.services.cubebox.v1.EmptyDirVolumeSource
 	34,  // 37: cubelet.services.cubebox.v1.VolumeSource.sandbox_path:type_name -> cubelet.services.cubebox.v1.SandboxPathVolumeSource
 	36,  // 38: cubelet.services.cubebox.v1.VolumeSource.host_dir_volumes:type_name -> cubelet.services.cubebox.v1.HostDirVolumeSources
-	100, // 39: cubelet.services.cubebox.v1.VolumeSource.image:type_name -> cubelet.services.images.v1.ImageVolumeSource
+	103, // 39: cubelet.services.cubebox.v1.VolumeSource.image:type_name -> cubelet.services.images.v1.ImageVolumeSource
 	37,  // 40: cubelet.services.cubebox.v1.Volume.volume_source:type_name -> cubelet.services.cubebox.v1.VolumeSource
 	38,  // 41: cubelet.services.cubebox.v1.RunCubeSandboxRequest.volumes:type_name -> cubelet.services.cubebox.v1.Volume
 	26,  // 42: cubelet.services.cubebox.v1.RunCubeSandboxRequest.containers:type_name -> cubelet.services.cubebox.v1.ContainerConfig
-	89,  // 43: cubelet.services.cubebox.v1.RunCubeSandboxRequest.annotations:type_name -> cubelet.services.cubebox.v1.RunCubeSandboxRequest.AnnotationsEntry
-	90,  // 44: cubelet.services.cubebox.v1.RunCubeSandboxRequest.labels:type_name -> cubelet.services.cubebox.v1.RunCubeSandboxRequest.LabelsEntry
+	92,  // 43: cubelet.services.cubebox.v1.RunCubeSandboxRequest.annotations:type_name -> cubelet.services.cubebox.v1.RunCubeSandboxRequest.AnnotationsEntry
+	93,  // 44: cubelet.services.cubebox.v1.RunCubeSandboxRequest.labels:type_name -> cubelet.services.cubebox.v1.RunCubeSandboxRequest.LabelsEntry
 	42,  // 45: cubelet.services.cubebox.v1.RunCubeSandboxRequest.cube_network_config:type_name -> cubelet.services.cubebox.v1.CubeNetworkConfig
-	101, // 46: cubelet.services.cubebox.v1.RunCubeSandboxResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
-	91,  // 47: cubelet.services.cubebox.v1.RunCubeSandboxResponse.ext_info:type_name -> cubelet.services.cubebox.v1.RunCubeSandboxResponse.ExtInfoEntry
+	104, // 46: cubelet.services.cubebox.v1.RunCubeSandboxResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
+	94,  // 47: cubelet.services.cubebox.v1.RunCubeSandboxResponse.ext_info:type_name -> cubelet.services.cubebox.v1.RunCubeSandboxResponse.ExtInfoEntry
 	41,  // 48: cubelet.services.cubebox.v1.RunCubeSandboxResponse.port_mappings:type_name -> cubelet.services.cubebox.v1.PortMapping
 	43,  // 49: cubelet.services.cubebox.v1.CubeNetworkConfig.rules:type_name -> cubelet.services.cubebox.v1.EgressRule
 	44,  // 50: cubelet.services.cubebox.v1.EgressRule.match:type_name -> cubelet.services.cubebox.v1.EgressRuleMatch
 	45,  // 51: cubelet.services.cubebox.v1.EgressRule.action:type_name -> cubelet.services.cubebox.v1.EgressRuleAction
 	46,  // 52: cubelet.services.cubebox.v1.EgressRuleAction.inject:type_name -> cubelet.services.cubebox.v1.EgressRuleInject
-	92,  // 53: cubelet.services.cubebox.v1.DestroyCubeSandboxRequest.annotations:type_name -> cubelet.services.cubebox.v1.DestroyCubeSandboxRequest.AnnotationsEntry
+	95,  // 53: cubelet.services.cubebox.v1.DestroyCubeSandboxRequest.annotations:type_name -> cubelet.services.cubebox.v1.DestroyCubeSandboxRequest.AnnotationsEntry
 	52,  // 54: cubelet.services.cubebox.v1.DestroyCubeSandboxRequest.filter:type_name -> cubelet.services.cubebox.v1.CubeSandboxFilter
-	101, // 55: cubelet.services.cubebox.v1.DestroyCubeSandboxResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
-	93,  // 56: cubelet.services.cubebox.v1.DestroyCubeSandboxResponse.ext_info:type_name -> cubelet.services.cubebox.v1.DestroyCubeSandboxResponse.ExtInfoEntry
+	104, // 55: cubelet.services.cubebox.v1.DestroyCubeSandboxResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
+	96,  // 56: cubelet.services.cubebox.v1.DestroyCubeSandboxResponse.ext_info:type_name -> cubelet.services.cubebox.v1.DestroyCubeSandboxResponse.ExtInfoEntry
 	50,  // 57: cubelet.services.cubebox.v1.CubeSandbox.containers:type_name -> cubelet.services.cubebox.v1.Container
 	41,  // 58: cubelet.services.cubebox.v1.CubeSandbox.port_mappings:type_name -> cubelet.services.cubebox.v1.PortMapping
-	94,  // 59: cubelet.services.cubebox.v1.CubeSandbox.labels:type_name -> cubelet.services.cubebox.v1.CubeSandbox.LabelsEntry
+	97,  // 59: cubelet.services.cubebox.v1.CubeSandbox.labels:type_name -> cubelet.services.cubebox.v1.CubeSandbox.LabelsEntry
 	32,  // 60: cubelet.services.cubebox.v1.Container.resources:type_name -> cubelet.services.cubebox.v1.Resource
 	5,   // 61: cubelet.services.cubebox.v1.Container.state:type_name -> cubelet.services.cubebox.v1.ContainerState
-	95,  // 62: cubelet.services.cubebox.v1.Container.labels:type_name -> cubelet.services.cubebox.v1.Container.LabelsEntry
+	98,  // 62: cubelet.services.cubebox.v1.Container.labels:type_name -> cubelet.services.cubebox.v1.Container.LabelsEntry
 	5,   // 63: cubelet.services.cubebox.v1.ContainerStateValue.state:type_name -> cubelet.services.cubebox.v1.ContainerState
 	51,  // 64: cubelet.services.cubebox.v1.CubeSandboxFilter.state:type_name -> cubelet.services.cubebox.v1.ContainerStateValue
-	96,  // 65: cubelet.services.cubebox.v1.CubeSandboxFilter.label_selector:type_name -> cubelet.services.cubebox.v1.CubeSandboxFilter.LabelSelectorEntry
+	99,  // 65: cubelet.services.cubebox.v1.CubeSandboxFilter.label_selector:type_name -> cubelet.services.cubebox.v1.CubeSandboxFilter.LabelSelectorEntry
 	52,  // 66: cubelet.services.cubebox.v1.ListCubeSandboxRequest.filter:type_name -> cubelet.services.cubebox.v1.CubeSandboxFilter
 	58,  // 67: cubelet.services.cubebox.v1.ListCubeSandboxRequest.option:type_name -> cubelet.services.cubebox.v1.ListCubeSandboxOption
 	49,  // 68: cubelet.services.cubebox.v1.ListCubeSandboxResponse.items:type_name -> cubelet.services.cubebox.v1.CubeSandbox
-	97,  // 69: cubelet.services.cubebox.v1.UpdateCubeSandboxRequest.annotations:type_name -> cubelet.services.cubebox.v1.UpdateCubeSandboxRequest.AnnotationsEntry
-	101, // 70: cubelet.services.cubebox.v1.UpdateCubeSandboxResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
-	101, // 71: cubelet.services.cubebox.v1.ExecCubeSandboxResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
+	100, // 69: cubelet.services.cubebox.v1.UpdateCubeSandboxRequest.annotations:type_name -> cubelet.services.cubebox.v1.UpdateCubeSandboxRequest.AnnotationsEntry
+	104, // 70: cubelet.services.cubebox.v1.UpdateCubeSandboxResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
+	104, // 71: cubelet.services.cubebox.v1.ExecCubeSandboxResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
 	39,  // 72: cubelet.services.cubebox.v1.AppSnapshotRequest.create_request:type_name -> cubelet.services.cubebox.v1.RunCubeSandboxRequest
-	101, // 73: cubelet.services.cubebox.v1.AppSnapshotResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
-	101, // 74: cubelet.services.cubebox.v1.CommitSandboxResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
-	101, // 75: cubelet.services.cubebox.v1.RollbackSandboxResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
+	104, // 73: cubelet.services.cubebox.v1.AppSnapshotResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
+	104, // 74: cubelet.services.cubebox.v1.CommitSandboxResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
+	104, // 75: cubelet.services.cubebox.v1.RollbackSandboxResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
 	67,  // 76: cubelet.services.cubebox.v1.CleanupTemplateRequest.objects:type_name -> cubelet.services.cubebox.v1.CowObjectRef
-	101, // 77: cubelet.services.cubebox.v1.CleanupTemplateResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
+	104, // 77: cubelet.services.cubebox.v1.CleanupTemplateResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
 	67,  // 78: cubelet.services.cubebox.v1.ListSandboxSnapshotsRequest.objects:type_name -> cubelet.services.cubebox.v1.CowObjectRef
-	101, // 79: cubelet.services.cubebox.v1.ListSandboxSnapshotsResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
+	104, // 79: cubelet.services.cubebox.v1.ListSandboxSnapshotsResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
 	71,  // 80: cubelet.services.cubebox.v1.ListSandboxSnapshotsResponse.objects:type_name -> cubelet.services.cubebox.v1.CowObjectStatus
-	101, // 81: cubelet.services.cubebox.v1.ListLocalSnapshotsResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
+	104, // 81: cubelet.services.cubebox.v1.ListLocalSnapshotsResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
 	74,  // 82: cubelet.services.cubebox.v1.ListLocalSnapshotsResponse.snapshots:type_name -> cubelet.services.cubebox.v1.LocalSnapshotInfo
-	101, // 83: cubelet.services.cubebox.v1.GetLocalSnapshotResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
+	104, // 83: cubelet.services.cubebox.v1.GetLocalSnapshotResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
 	74,  // 84: cubelet.services.cubebox.v1.GetLocalSnapshotResponse.snapshot:type_name -> cubelet.services.cubebox.v1.LocalSnapshotInfo
-	101, // 85: cubelet.services.cubebox.v1.GetStorageMetricsResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
-	98,  // 86: cubelet.services.cubebox.v1.GetStorageMetricsResponse.metrics:type_name -> cubelet.services.cubebox.v1.GetStorageMetricsResponse.MetricsEntry
-	80,  // 87: cubelet.services.cubebox.v1.SandboxStorageInfo.volumes:type_name -> cubelet.services.cubebox.v1.StorageVolumeInfo
-	101, // 88: cubelet.services.cubebox.v1.InspectStorageVolumesResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
-	81,  // 89: cubelet.services.cubebox.v1.InspectStorageVolumesResponse.sandboxes:type_name -> cubelet.services.cubebox.v1.SandboxStorageInfo
-	101, // 90: cubelet.services.cubebox.v1.CleanupOrphanStorageFilesResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
-	85,  // 91: cubelet.services.cubebox.v1.CleanupOrphanStorageFilesResponse.orphans:type_name -> cubelet.services.cubebox.v1.StorageOrphanEntry
-	39,  // 92: cubelet.services.cubebox.v1.CubeboxMgr.Create:input_type -> cubelet.services.cubebox.v1.RunCubeSandboxRequest
-	47,  // 93: cubelet.services.cubebox.v1.CubeboxMgr.Destroy:input_type -> cubelet.services.cubebox.v1.DestroyCubeSandboxRequest
-	53,  // 94: cubelet.services.cubebox.v1.CubeboxMgr.List:input_type -> cubelet.services.cubebox.v1.ListCubeSandboxRequest
-	55,  // 95: cubelet.services.cubebox.v1.CubeboxMgr.Update:input_type -> cubelet.services.cubebox.v1.UpdateCubeSandboxRequest
-	59,  // 96: cubelet.services.cubebox.v1.CubeboxMgr.Exec:input_type -> cubelet.services.cubebox.v1.ExecCubeSandboxRequest
-	61,  // 97: cubelet.services.cubebox.v1.CubeboxMgr.AppSnapshot:input_type -> cubelet.services.cubebox.v1.AppSnapshotRequest
-	63,  // 98: cubelet.services.cubebox.v1.CubeboxMgr.CommitSandbox:input_type -> cubelet.services.cubebox.v1.CommitSandboxRequest
-	65,  // 99: cubelet.services.cubebox.v1.CubeboxMgr.RollbackSandbox:input_type -> cubelet.services.cubebox.v1.RollbackSandboxRequest
-	68,  // 100: cubelet.services.cubebox.v1.CubeboxMgr.CleanupTemplate:input_type -> cubelet.services.cubebox.v1.CleanupTemplateRequest
-	70,  // 101: cubelet.services.cubebox.v1.CubeboxMgr.ListSandboxSnapshots:input_type -> cubelet.services.cubebox.v1.ListSandboxSnapshotsRequest
-	73,  // 102: cubelet.services.cubebox.v1.CubeboxMgr.ListLocalSnapshots:input_type -> cubelet.services.cubebox.v1.ListLocalSnapshotsRequest
-	76,  // 103: cubelet.services.cubebox.v1.CubeboxMgr.GetLocalSnapshot:input_type -> cubelet.services.cubebox.v1.GetLocalSnapshotRequest
-	78,  // 104: cubelet.services.cubebox.v1.CubeboxMgr.GetStorageMetrics:input_type -> cubelet.services.cubebox.v1.GetStorageMetricsRequest
-	82,  // 105: cubelet.services.cubebox.v1.CubeboxMgr.InspectStorageVolumes:input_type -> cubelet.services.cubebox.v1.InspectStorageVolumesRequest
-	84,  // 106: cubelet.services.cubebox.v1.CubeboxMgr.CleanupOrphanStorageFiles:input_type -> cubelet.services.cubebox.v1.CleanupOrphanStorageFilesRequest
-	40,  // 107: cubelet.services.cubebox.v1.CubeboxMgr.Create:output_type -> cubelet.services.cubebox.v1.RunCubeSandboxResponse
-	48,  // 108: cubelet.services.cubebox.v1.CubeboxMgr.Destroy:output_type -> cubelet.services.cubebox.v1.DestroyCubeSandboxResponse
-	54,  // 109: cubelet.services.cubebox.v1.CubeboxMgr.List:output_type -> cubelet.services.cubebox.v1.ListCubeSandboxResponse
-	56,  // 110: cubelet.services.cubebox.v1.CubeboxMgr.Update:output_type -> cubelet.services.cubebox.v1.UpdateCubeSandboxResponse
-	60,  // 111: cubelet.services.cubebox.v1.CubeboxMgr.Exec:output_type -> cubelet.services.cubebox.v1.ExecCubeSandboxResponse
-	62,  // 112: cubelet.services.cubebox.v1.CubeboxMgr.AppSnapshot:output_type -> cubelet.services.cubebox.v1.AppSnapshotResponse
-	64,  // 113: cubelet.services.cubebox.v1.CubeboxMgr.CommitSandbox:output_type -> cubelet.services.cubebox.v1.CommitSandboxResponse
-	66,  // 114: cubelet.services.cubebox.v1.CubeboxMgr.RollbackSandbox:output_type -> cubelet.services.cubebox.v1.RollbackSandboxResponse
-	69,  // 115: cubelet.services.cubebox.v1.CubeboxMgr.CleanupTemplate:output_type -> cubelet.services.cubebox.v1.CleanupTemplateResponse
-	72,  // 116: cubelet.services.cubebox.v1.CubeboxMgr.ListSandboxSnapshots:output_type -> cubelet.services.cubebox.v1.ListSandboxSnapshotsResponse
-	75,  // 117: cubelet.services.cubebox.v1.CubeboxMgr.ListLocalSnapshots:output_type -> cubelet.services.cubebox.v1.ListLocalSnapshotsResponse
-	77,  // 118: cubelet.services.cubebox.v1.CubeboxMgr.GetLocalSnapshot:output_type -> cubelet.services.cubebox.v1.GetLocalSnapshotResponse
-	79,  // 119: cubelet.services.cubebox.v1.CubeboxMgr.GetStorageMetrics:output_type -> cubelet.services.cubebox.v1.GetStorageMetricsResponse
-	83,  // 120: cubelet.services.cubebox.v1.CubeboxMgr.InspectStorageVolumes:output_type -> cubelet.services.cubebox.v1.InspectStorageVolumesResponse
-	86,  // 121: cubelet.services.cubebox.v1.CubeboxMgr.CleanupOrphanStorageFiles:output_type -> cubelet.services.cubebox.v1.CleanupOrphanStorageFilesResponse
-	107, // [107:122] is the sub-list for method output_type
-	92,  // [92:107] is the sub-list for method input_type
-	92,  // [92:92] is the sub-list for extension type_name
-	92,  // [92:92] is the sub-list for extension extendee
-	0,   // [0:92] is the sub-list for field type_name
+	104, // 85: cubelet.services.cubebox.v1.GetStorageMetricsResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
+	101, // 86: cubelet.services.cubebox.v1.GetStorageMetricsResponse.metrics:type_name -> cubelet.services.cubebox.v1.GetStorageMetricsResponse.MetricsEntry
+	104, // 87: cubelet.services.cubebox.v1.GetSandboxMetricsResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
+	81,  // 88: cubelet.services.cubebox.v1.GetSandboxMetricsResponse.metrics:type_name -> cubelet.services.cubebox.v1.SandboxMetric
+	83,  // 89: cubelet.services.cubebox.v1.SandboxStorageInfo.volumes:type_name -> cubelet.services.cubebox.v1.StorageVolumeInfo
+	104, // 90: cubelet.services.cubebox.v1.InspectStorageVolumesResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
+	84,  // 91: cubelet.services.cubebox.v1.InspectStorageVolumesResponse.sandboxes:type_name -> cubelet.services.cubebox.v1.SandboxStorageInfo
+	104, // 92: cubelet.services.cubebox.v1.CleanupOrphanStorageFilesResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
+	88,  // 93: cubelet.services.cubebox.v1.CleanupOrphanStorageFilesResponse.orphans:type_name -> cubelet.services.cubebox.v1.StorageOrphanEntry
+	39,  // 94: cubelet.services.cubebox.v1.CubeboxMgr.Create:input_type -> cubelet.services.cubebox.v1.RunCubeSandboxRequest
+	47,  // 95: cubelet.services.cubebox.v1.CubeboxMgr.Destroy:input_type -> cubelet.services.cubebox.v1.DestroyCubeSandboxRequest
+	53,  // 96: cubelet.services.cubebox.v1.CubeboxMgr.List:input_type -> cubelet.services.cubebox.v1.ListCubeSandboxRequest
+	55,  // 97: cubelet.services.cubebox.v1.CubeboxMgr.Update:input_type -> cubelet.services.cubebox.v1.UpdateCubeSandboxRequest
+	59,  // 98: cubelet.services.cubebox.v1.CubeboxMgr.Exec:input_type -> cubelet.services.cubebox.v1.ExecCubeSandboxRequest
+	61,  // 99: cubelet.services.cubebox.v1.CubeboxMgr.AppSnapshot:input_type -> cubelet.services.cubebox.v1.AppSnapshotRequest
+	63,  // 100: cubelet.services.cubebox.v1.CubeboxMgr.CommitSandbox:input_type -> cubelet.services.cubebox.v1.CommitSandboxRequest
+	65,  // 101: cubelet.services.cubebox.v1.CubeboxMgr.RollbackSandbox:input_type -> cubelet.services.cubebox.v1.RollbackSandboxRequest
+	68,  // 102: cubelet.services.cubebox.v1.CubeboxMgr.CleanupTemplate:input_type -> cubelet.services.cubebox.v1.CleanupTemplateRequest
+	70,  // 103: cubelet.services.cubebox.v1.CubeboxMgr.ListSandboxSnapshots:input_type -> cubelet.services.cubebox.v1.ListSandboxSnapshotsRequest
+	73,  // 104: cubelet.services.cubebox.v1.CubeboxMgr.ListLocalSnapshots:input_type -> cubelet.services.cubebox.v1.ListLocalSnapshotsRequest
+	76,  // 105: cubelet.services.cubebox.v1.CubeboxMgr.GetLocalSnapshot:input_type -> cubelet.services.cubebox.v1.GetLocalSnapshotRequest
+	78,  // 106: cubelet.services.cubebox.v1.CubeboxMgr.GetStorageMetrics:input_type -> cubelet.services.cubebox.v1.GetStorageMetricsRequest
+	80,  // 107: cubelet.services.cubebox.v1.CubeboxMgr.GetSandboxMetrics:input_type -> cubelet.services.cubebox.v1.GetSandboxMetricsRequest
+	85,  // 108: cubelet.services.cubebox.v1.CubeboxMgr.InspectStorageVolumes:input_type -> cubelet.services.cubebox.v1.InspectStorageVolumesRequest
+	87,  // 109: cubelet.services.cubebox.v1.CubeboxMgr.CleanupOrphanStorageFiles:input_type -> cubelet.services.cubebox.v1.CleanupOrphanStorageFilesRequest
+	40,  // 110: cubelet.services.cubebox.v1.CubeboxMgr.Create:output_type -> cubelet.services.cubebox.v1.RunCubeSandboxResponse
+	48,  // 111: cubelet.services.cubebox.v1.CubeboxMgr.Destroy:output_type -> cubelet.services.cubebox.v1.DestroyCubeSandboxResponse
+	54,  // 112: cubelet.services.cubebox.v1.CubeboxMgr.List:output_type -> cubelet.services.cubebox.v1.ListCubeSandboxResponse
+	56,  // 113: cubelet.services.cubebox.v1.CubeboxMgr.Update:output_type -> cubelet.services.cubebox.v1.UpdateCubeSandboxResponse
+	60,  // 114: cubelet.services.cubebox.v1.CubeboxMgr.Exec:output_type -> cubelet.services.cubebox.v1.ExecCubeSandboxResponse
+	62,  // 115: cubelet.services.cubebox.v1.CubeboxMgr.AppSnapshot:output_type -> cubelet.services.cubebox.v1.AppSnapshotResponse
+	64,  // 116: cubelet.services.cubebox.v1.CubeboxMgr.CommitSandbox:output_type -> cubelet.services.cubebox.v1.CommitSandboxResponse
+	66,  // 117: cubelet.services.cubebox.v1.CubeboxMgr.RollbackSandbox:output_type -> cubelet.services.cubebox.v1.RollbackSandboxResponse
+	69,  // 118: cubelet.services.cubebox.v1.CubeboxMgr.CleanupTemplate:output_type -> cubelet.services.cubebox.v1.CleanupTemplateResponse
+	72,  // 119: cubelet.services.cubebox.v1.CubeboxMgr.ListSandboxSnapshots:output_type -> cubelet.services.cubebox.v1.ListSandboxSnapshotsResponse
+	75,  // 120: cubelet.services.cubebox.v1.CubeboxMgr.ListLocalSnapshots:output_type -> cubelet.services.cubebox.v1.ListLocalSnapshotsResponse
+	77,  // 121: cubelet.services.cubebox.v1.CubeboxMgr.GetLocalSnapshot:output_type -> cubelet.services.cubebox.v1.GetLocalSnapshotResponse
+	79,  // 122: cubelet.services.cubebox.v1.CubeboxMgr.GetStorageMetrics:output_type -> cubelet.services.cubebox.v1.GetStorageMetricsResponse
+	82,  // 123: cubelet.services.cubebox.v1.CubeboxMgr.GetSandboxMetrics:output_type -> cubelet.services.cubebox.v1.GetSandboxMetricsResponse
+	86,  // 124: cubelet.services.cubebox.v1.CubeboxMgr.InspectStorageVolumes:output_type -> cubelet.services.cubebox.v1.InspectStorageVolumesResponse
+	89,  // 125: cubelet.services.cubebox.v1.CubeboxMgr.CleanupOrphanStorageFiles:output_type -> cubelet.services.cubebox.v1.CleanupOrphanStorageFilesResponse
+	110, // [110:126] is the sub-list for method output_type
+	94,  // [94:110] is the sub-list for method input_type
+	94,  // [94:94] is the sub-list for extension type_name
+	94,  // [94:94] is the sub-list for extension extendee
+	0,   // [0:94] is the sub-list for field type_name
 }
 
 func init() { file_api_services_cubebox_v1_cubebox_proto_init() }
@@ -7310,7 +7571,7 @@ func file_api_services_cubebox_v1_cubebox_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_api_services_cubebox_v1_cubebox_proto_rawDesc), len(file_api_services_cubebox_v1_cubebox_proto_rawDesc)),
 			NumEnums:      6,
-			NumMessages:   93,
+			NumMessages:   96,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/CubeMaster/api/services/cubebox/v1/cubebox.proto
+++ b/CubeMaster/api/services/cubebox/v1/cubebox.proto
@@ -40,6 +40,8 @@ service CubeboxMgr {
   rpc GetLocalSnapshot(GetLocalSnapshotRequest) returns (GetLocalSnapshotResponse);
   // GetStorageMetrics returns node-local cubecow storage metrics.
   rpc GetStorageMetrics(GetStorageMetricsRequest) returns (GetStorageMetricsResponse);
+  // GetSandboxMetrics returns the current metrics snapshot for one sandbox.
+  rpc GetSandboxMetrics(GetSandboxMetricsRequest) returns (GetSandboxMetricsResponse);
   // InspectStorageVolumes lists every sandbox storage record cubelet owns and
   // re-resolves cubecow device paths so cubecli can render an authoritative
   // view without touching boltdb or the cubecow SDK directly.
@@ -1089,6 +1091,43 @@ message GetStorageMetricsResponse {
   int64 timestamp_unix_nano = 4;
   // Storage metrics reported by cubecow.
   map<string, uint64> metrics = 5;
+}
+
+message GetSandboxMetricsRequest {
+  // requestID reqID
+  string requestID = 1;
+  // Sandbox identifier to inspect.
+  string sandboxID = 2;
+}
+
+message SandboxMetric {
+  // Timestamp when metrics were collected.
+  int64 timestamp_unix_nano = 1;
+  // Number of CPU cores assigned to the sandbox.
+  int32 cpu_count = 2;
+  // CPU usage percentage. Best-effort in the current implementation.
+  double cpu_used_pct = 3;
+  // Memory used in bytes. Best-effort in the current implementation.
+  int64 mem_used = 4;
+  // Total memory in bytes.
+  int64 mem_total = 5;
+  // Cached memory in bytes. Best-effort in the current implementation.
+  int64 mem_cache = 6;
+  // Disk used in bytes. Best-effort in the current implementation.
+  int64 disk_used = 7;
+  // Total sandbox disk quota in bytes.
+  int64 disk_total = 8;
+}
+
+message GetSandboxMetricsResponse {
+  // requestID reqID
+  string requestID = 1;
+  // Ret.
+  cubelet.services.errorcode.v1.Ret ret = 2;
+  // Sandbox identifier that produced this metric snapshot.
+  string sandboxID = 3;
+  // Current sandbox metric snapshot. Empty when no sample is available.
+  repeated SandboxMetric metrics = 4;
 }
 
 // StorageVolumeInfo describes a single backend file/volume entry attached to a

--- a/CubeMaster/api/services/cubebox/v1/cubebox_grpc.pb.go
+++ b/CubeMaster/api/services/cubebox/v1/cubebox_grpc.pb.go
@@ -36,6 +36,7 @@ const (
 	CubeboxMgr_ListLocalSnapshots_FullMethodName        = "/cubelet.services.cubebox.v1.CubeboxMgr/ListLocalSnapshots"
 	CubeboxMgr_GetLocalSnapshot_FullMethodName          = "/cubelet.services.cubebox.v1.CubeboxMgr/GetLocalSnapshot"
 	CubeboxMgr_GetStorageMetrics_FullMethodName         = "/cubelet.services.cubebox.v1.CubeboxMgr/GetStorageMetrics"
+	CubeboxMgr_GetSandboxMetrics_FullMethodName         = "/cubelet.services.cubebox.v1.CubeboxMgr/GetSandboxMetrics"
 	CubeboxMgr_InspectStorageVolumes_FullMethodName     = "/cubelet.services.cubebox.v1.CubeboxMgr/InspectStorageVolumes"
 	CubeboxMgr_CleanupOrphanStorageFiles_FullMethodName = "/cubelet.services.cubebox.v1.CubeboxMgr/CleanupOrphanStorageFiles"
 )
@@ -73,6 +74,8 @@ type CubeboxMgrClient interface {
 	GetLocalSnapshot(ctx context.Context, in *GetLocalSnapshotRequest, opts ...grpc.CallOption) (*GetLocalSnapshotResponse, error)
 	// GetStorageMetrics returns node-local cubecow storage metrics.
 	GetStorageMetrics(ctx context.Context, in *GetStorageMetricsRequest, opts ...grpc.CallOption) (*GetStorageMetricsResponse, error)
+	// GetSandboxMetrics returns the current metrics snapshot for one sandbox.
+	GetSandboxMetrics(ctx context.Context, in *GetSandboxMetricsRequest, opts ...grpc.CallOption) (*GetSandboxMetricsResponse, error)
 	// InspectStorageVolumes lists every sandbox storage record cubelet owns and
 	// re-resolves cubecow device paths so cubecli can render an authoritative
 	// view without touching boltdb or the cubecow SDK directly.
@@ -220,6 +223,16 @@ func (c *cubeboxMgrClient) GetStorageMetrics(ctx context.Context, in *GetStorage
 	return out, nil
 }
 
+func (c *cubeboxMgrClient) GetSandboxMetrics(ctx context.Context, in *GetSandboxMetricsRequest, opts ...grpc.CallOption) (*GetSandboxMetricsResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(GetSandboxMetricsResponse)
+	err := c.cc.Invoke(ctx, CubeboxMgr_GetSandboxMetrics_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 func (c *cubeboxMgrClient) InspectStorageVolumes(ctx context.Context, in *InspectStorageVolumesRequest, opts ...grpc.CallOption) (*InspectStorageVolumesResponse, error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(InspectStorageVolumesResponse)
@@ -273,6 +286,8 @@ type CubeboxMgrServer interface {
 	GetLocalSnapshot(context.Context, *GetLocalSnapshotRequest) (*GetLocalSnapshotResponse, error)
 	// GetStorageMetrics returns node-local cubecow storage metrics.
 	GetStorageMetrics(context.Context, *GetStorageMetricsRequest) (*GetStorageMetricsResponse, error)
+	// GetSandboxMetrics returns the current metrics snapshot for one sandbox.
+	GetSandboxMetrics(context.Context, *GetSandboxMetricsRequest) (*GetSandboxMetricsResponse, error)
 	// InspectStorageVolumes lists every sandbox storage record cubelet owns and
 	// re-resolves cubecow device paths so cubecli can render an authoritative
 	// view without touching boltdb or the cubecow SDK directly.
@@ -328,6 +343,9 @@ func (UnimplementedCubeboxMgrServer) GetLocalSnapshot(context.Context, *GetLocal
 }
 func (UnimplementedCubeboxMgrServer) GetStorageMetrics(context.Context, *GetStorageMetricsRequest) (*GetStorageMetricsResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method GetStorageMetrics not implemented")
+}
+func (UnimplementedCubeboxMgrServer) GetSandboxMetrics(context.Context, *GetSandboxMetricsRequest) (*GetSandboxMetricsResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method GetSandboxMetrics not implemented")
 }
 func (UnimplementedCubeboxMgrServer) InspectStorageVolumes(context.Context, *InspectStorageVolumesRequest) (*InspectStorageVolumesResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method InspectStorageVolumes not implemented")
@@ -590,6 +608,24 @@ func _CubeboxMgr_GetStorageMetrics_Handler(srv interface{}, ctx context.Context,
 	return interceptor(ctx, in, info, handler)
 }
 
+func _CubeboxMgr_GetSandboxMetrics_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(GetSandboxMetricsRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(CubeboxMgrServer).GetSandboxMetrics(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: CubeboxMgr_GetSandboxMetrics_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(CubeboxMgrServer).GetSandboxMetrics(ctx, req.(*GetSandboxMetricsRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 func _CubeboxMgr_InspectStorageVolumes_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
 	in := new(InspectStorageVolumesRequest)
 	if err := dec(in); err != nil {
@@ -684,6 +720,10 @@ var CubeboxMgr_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "GetStorageMetrics",
 			Handler:    _CubeboxMgr_GetStorageMetrics_Handler,
+		},
+		{
+			MethodName: "GetSandboxMetrics",
+			Handler:    _CubeboxMgr_GetSandboxMetrics_Handler,
 		},
 		{
 			MethodName: "InspectStorageVolumes",

--- a/CubeMaster/pkg/cubelet/actions.go
+++ b/CubeMaster/pkg/cubelet/actions.go
@@ -133,6 +133,19 @@ func GetStorageMetrics(ctx context.Context, calleeEp string,
 	return c.GetStorageMetrics(ctx, req)
 }
 
+// GetSandboxMetrics calls the target Cubelet over gRPC. CubeMaster resolves the
+// target node first; Cubelet then reads the sandbox-local envd endpoint.
+func GetSandboxMetrics(ctx context.Context, calleeEp string,
+	req *cubebox.GetSandboxMetricsRequest) (*cubebox.GetSandboxMetricsResponse, error) {
+	conn, err := grpcconn.GetWorkerConn(ctx, calleeEp)
+	if err != nil {
+		return nil, ret.Err(errorcode.ErrorCode_ConnHostFailed, err.Error())
+	}
+	defer conn.Close()
+	c := cubebox.NewCubeboxMgrClient(conn.Value())
+	return c.GetSandboxMetrics(ctx, req)
+}
+
 func List(ctx context.Context, calleeEp string,
 	req *cubebox.ListCubeSandboxRequest) (*cubebox.ListCubeSandboxResponse, error) {
 	conn, err := grpcconn.GetWorkerConn(ctx, calleeEp)

--- a/CubeMaster/pkg/server/server_test.go
+++ b/CubeMaster/pkg/server/server_test.go
@@ -157,3 +157,14 @@ func TestMiddlewareSkippedOnNotFoundAndMethodMismatch(t *testing.T) {
 	assert.Equal(t, http.StatusMethodNotAllowed, w.Code)
 	assert.Empty(t, w.Header().Get(mwHeader), "middleware must not run on method-mismatch (no auth on 405)")
 }
+
+func TestRegisterHandlersIncludesSandboxMetricsRoute(t *testing.T) {
+	s := &internalHttp{router: mux.NewRouter()}
+	s.registerHandlers()
+
+	req := httptest.NewRequest(http.MethodGet, "/cube/sandbox/metrics", nil)
+	var match mux.RouteMatch
+	if !s.router.Match(req, &match) {
+		t.Fatal("GET /cube/sandbox/metrics did not match any route")
+	}
+}

--- a/CubeMaster/pkg/service/httpservice/cube/cube.go
+++ b/CubeMaster/pkg/service/httpservice/cube/cube.go
@@ -19,6 +19,7 @@ const (
 	ImageAction                    = "/image"
 	SandboxListAction              = "/sandbox/list"
 	SandboxInfoAction              = "/sandbox/info"
+	SandboxMetricsAction           = "/sandbox/metrics"
 	SandboxExecAction              = "/sandbox/exec"
 	SandboxUpdateAction            = "/sandbox/update"
 	SandboxTimeoutAction           = "/sandbox/timeout"

--- a/CubeMaster/pkg/service/httpservice/cube/routes.go
+++ b/CubeMaster/pkg/service/httpservice/cube/routes.go
@@ -33,6 +33,7 @@ func RegisterCubeRoutes(g *gin.RouterGroup) {
 	g.POST(SandboxInfoAction, handleInfoAction)
 	g.GET(SandboxListAction, handleListAction)
 	g.POST(SandboxListAction, handleListAction)
+	g.GET(SandboxMetricsAction, handleSandboxMetricsAction)
 	g.GET(SandboxLogsAction, handleSandboxLogsAction)
 	g.POST(SandboxLogsAction, handleSandboxLogsAction)
 

--- a/CubeMaster/pkg/service/httpservice/cube/sandbox_metrics.go
+++ b/CubeMaster/pkg/service/httpservice/cube/sandbox_metrics.go
@@ -1,0 +1,82 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package cube
+
+import (
+	"errors"
+	"io"
+	"strconv"
+
+	"github.com/gin-gonic/gin"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/api/services/cubebox/v1"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/log"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/utils"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/errorcode"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/service/httpservice/common"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/service/sandbox"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/service/sandbox/types"
+	"github.com/tencentcloud/CubeSandbox/cubelog"
+)
+
+// handleSandboxMetricsAction accepts both CubeAPI's GET query form and the
+// existing CubeMaster JSON body form, then forwards the normalized request into
+// the sandbox service layer.
+func handleSandboxMetricsAction(c *gin.Context) {
+	rt := CubeLog.GetTraceInfo(c.Request.Context())
+	req := &types.GetSandboxMetricsReq{}
+	err := utils.DecodeHttpBody(c.Request.Body, req)
+	if err != nil {
+		if errors.Is(err, io.EOF) {
+			req.RequestID = c.Query("requestID")
+			req.HostID = c.Query("host_id")
+			req.SandboxID = c.Query("sandbox_id")
+			req.InstanceType = c.Query("instance_type")
+			if start := c.Query("start"); start != "" {
+				v, parseErr := strconv.ParseInt(start, 10, 64)
+				if parseErr != nil {
+					rt.RetCode = int64(errorcode.ErrorCode_MasterParamsError)
+					common.WriteAPI(c, metricsParamError(parseErr.Error()))
+					return
+				}
+				req.Start = v
+			}
+			if end := c.Query("end"); end != "" {
+				v, parseErr := strconv.ParseInt(end, 10, 64)
+				if parseErr != nil {
+					rt.RetCode = int64(errorcode.ErrorCode_MasterParamsError)
+					common.WriteAPI(c, metricsParamError(parseErr.Error()))
+					return
+				}
+				req.End = v
+			}
+		} else {
+			rt.RetCode = int64(errorcode.ErrorCode_MasterParamsError)
+			common.WriteAPI(c, metricsParamError(err.Error()))
+			return
+		}
+	}
+	rt.RequestID = req.RequestID
+	if req.InstanceType == "" {
+		req.InstanceType = cubebox.InstanceType_cubebox.String()
+	}
+	rt.InstanceType = req.InstanceType
+	ctx := log.WithLogger(c.Request.Context(), log.G(c.Request.Context()).WithFields(map[string]any{
+		"RequestId":    req.RequestID,
+		"InstanceType": req.InstanceType,
+	}))
+	rsp := sandbox.SandboxMetrics(ctx, req)
+	rt.RetCode = int64(rsp.Ret.RetCode)
+	common.WriteAPI(c, rsp)
+}
+
+func metricsParamError(msg string) *types.GetSandboxMetricsRes {
+	return &types.GetSandboxMetricsRes{
+		Data: []*types.SandboxMetricData{},
+		Ret: &types.Ret{
+			RetCode: int(errorcode.ErrorCode_MasterParamsError),
+			RetMsg:  msg,
+		},
+	}
+}

--- a/CubeMaster/pkg/service/httpservice/cube/sandbox_metrics_test.go
+++ b/CubeMaster/pkg/service/httpservice/cube/sandbox_metrics_test.go
@@ -1,0 +1,35 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package cube
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/errorcode"
+	CubeLog "github.com/tencentcloud/CubeSandbox/cubelog"
+)
+
+func TestHandleSandboxMetricsActionRejectsInvalidStartQuery(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	rt := &CubeLog.RequestTrace{}
+	req := httptest.NewRequest(http.MethodGet, "/cube/sandbox/metrics?sandbox_id=sb-1&start=bad", nil)
+	req = req.WithContext(CubeLog.WithRequestTrace(req.Context(), rt))
+	c.Request = req
+
+	handleSandboxMetricsAction(c)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), `"ret_code":`+strconv.Itoa(int(errorcode.ErrorCode_MasterParamsError)))
+	assert.Contains(t, w.Body.String(), "invalid syntax")
+	assert.Equal(t, int64(errorcode.ErrorCode_MasterParamsError), rt.RetCode)
+	assert.Contains(t, w.Body.String(), `"data":[]`)
+}

--- a/CubeMaster/pkg/service/sandbox/sandbox_metrics.go
+++ b/CubeMaster/pkg/service/sandbox/sandbox_metrics.go
@@ -1,0 +1,158 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package sandbox
+
+import (
+	"context"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/api/services/cubebox/v1"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/constants"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/log"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/node"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/utils"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/cubelet"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/errorcode"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/localcache"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/service/sandbox/types"
+	"github.com/tencentcloud/CubeSandbox/cubelog"
+)
+
+// SandboxMetrics resolves the Cubelet that owns the sandbox, requests one
+// current metrics snapshot from that Cubelet, and applies optional start/end
+// filtering before returning the CubeMaster HTTP response.
+func SandboxMetrics(ctx context.Context, req *types.GetSandboxMetricsReq) (rsp *types.GetSandboxMetricsRes) {
+	if req.RequestID == "" {
+		req.RequestID = uuid.New().String()
+	}
+	rsp = &types.GetSandboxMetricsRes{
+		RequestID: req.RequestID,
+		Data:      []*types.SandboxMetricData{},
+		Ret: &types.Ret{
+			RetCode: int(errorcode.ErrorCode_Success),
+			RetMsg:  errorcode.ErrorCode_Success.String(),
+		},
+	}
+	log.G(ctx).Infof("GetSandboxMetrics:%+v", utils.InterfaceToString(req))
+	defer func() {
+		if log.IsDebug() {
+			log.G(ctx).Debugf("GetSandboxMetrics_rsp:%+v", utils.InterfaceToString(rsp))
+		} else if rsp.Ret.RetCode != int(errorcode.ErrorCode_Success) {
+			log.G(ctx).WithFields(map[string]interface{}{
+				"RetCode": int64(rsp.Ret.RetCode),
+			}).Warnf("GetSandboxMetrics fail:%+v", utils.InterfaceToString(rsp))
+		}
+	}()
+
+	start := time.Now()
+	rt := CubeLog.GetTraceInfo(ctx).DeepCopy()
+	rt.Callee = constants.CubeLet
+	defer func() {
+		rt.Cost = time.Since(start)
+		rt.RetCode = int64(rsp.Ret.RetCode)
+		rt.CalleeAction = "GetSandboxMetrics"
+		CubeLog.Trace(rt)
+	}()
+
+	if req.SandboxID == "" {
+		setMetricsError(errorcode.ErrorCode_MasterParamsError, rsp, "sandbox_id is required")
+		return rsp
+	}
+	if req.Start < 0 || req.End < 0 {
+		setMetricsError(errorcode.ErrorCode_MasterParamsError, rsp, "start/end must be greater than or equal to 0")
+		return rsp
+	}
+	if req.Start > 0 && req.End > 0 && req.Start > req.End {
+		setMetricsError(errorcode.ErrorCode_MasterParamsError, rsp, "start must be less than or equal to end")
+		return rsp
+	}
+
+	var calleeEndpoint string
+	if req.HostID != "" {
+		n, exist := localcache.GetNode(req.HostID)
+		if !metricsNodeReady(n, exist, rsp) {
+			return rsp
+		}
+		calleeEndpoint = cubelet.GetCubeletAddr(n.IP)
+	} else {
+		var hostIP string
+		if v := localcache.GetSandboxCache(req.SandboxID); v != nil {
+			hostIP = v.HostIP
+		} else if proxyMap, ok := localcache.GetSandboxProxyMap(ctx, req.SandboxID); ok {
+			hostIP = proxyMap.HostIP
+		} else {
+			setMetricsError(errorcode.ErrorCode_NotFound, rsp, "sandbox "+req.SandboxID+" not found")
+			return rsp
+		}
+		n, exist := localcache.GetNodesByIp(hostIP)
+		if !metricsNodeReady(n, exist, rsp) {
+			return rsp
+		}
+		calleeEndpoint = cubelet.GetCubeletAddr(n.IP)
+	}
+	rt.CalleeEndpoint = calleeEndpoint
+
+	cubeRsp, err := cubelet.GetSandboxMetrics(ctx, calleeEndpoint, &cubebox.GetSandboxMetricsRequest{
+		RequestID: req.RequestID,
+		SandboxID: req.SandboxID,
+	})
+	if err != nil {
+		setMetricsError(errorcode.ErrorCode_ReqCubeAPIFailed, rsp, err.Error())
+		return rsp
+	}
+	if int(cubeRsp.GetRet().GetRetCode()) != int(errorcode.ErrorCode_Success) {
+		rsp.Ret.RetCode = int(cubeRsp.GetRet().GetRetCode())
+		rsp.Ret.RetMsg = cubeRsp.GetRet().GetRetMsg()
+		return rsp
+	}
+	for _, metric := range cubeRsp.GetMetrics() {
+		if !metricInRange(metric.GetTimestampUnixNano(), req.Start, req.End) {
+			continue
+		}
+		rsp.Data = append(rsp.Data, &types.SandboxMetricData{
+			TimestampUnixNano: metric.GetTimestampUnixNano(),
+			CPUCount:          metric.GetCpuCount(),
+			CPUUsedPct:        metric.GetCpuUsedPct(),
+			MemUsed:           metric.GetMemUsed(),
+			MemTotal:          metric.GetMemTotal(),
+			MemCache:          metric.GetMemCache(),
+			DiskUsed:          metric.GetDiskUsed(),
+			DiskTotal:         metric.GetDiskTotal(),
+		})
+	}
+	return rsp
+}
+
+func setMetricsError(code errorcode.ErrorCode, rsp *types.GetSandboxMetricsRes, msg string) {
+	rsp.Ret.RetCode = int(code)
+	if msg == "" {
+		msg = code.String()
+	}
+	rsp.Ret.RetMsg = msg
+}
+
+func metricsNodeReady(n *node.Node, exist bool, rsp *types.GetSandboxMetricsRes) bool {
+	if !exist {
+		setMetricsError(errorcode.ErrorCode_NotFound, rsp, errorcode.ErrorCode_NotFound.String())
+		return false
+	}
+	if !n.Healthy {
+		setMetricsError(errorcode.ErrorCode_CubeletUnHealthy, rsp, errorcode.ErrorCode_CubeletUnHealthy.String())
+		return false
+	}
+	return true
+}
+
+func metricInRange(timestampUnixNano, startUnix, endUnix int64) bool {
+	timestampUnix := timestampUnixNano / int64(time.Second)
+	if startUnix > 0 && timestampUnix < startUnix {
+		return false
+	}
+	if endUnix > 0 && timestampUnix > endUnix {
+		return false
+	}
+	return true
+}

--- a/CubeMaster/pkg/service/sandbox/sandbox_metrics_test.go
+++ b/CubeMaster/pkg/service/sandbox/sandbox_metrics_test.go
@@ -1,0 +1,33 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package sandbox
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/service/sandbox/types"
+)
+
+func TestMetricInRangeUsesUnixSecondsBoundaries(t *testing.T) {
+	ts := time.Unix(1700000000, 999_000_000).UnixNano()
+
+	assert.True(t, metricInRange(ts, 0, 0))
+	assert.True(t, metricInRange(ts, 1700000000, 1700000000))
+	assert.True(t, metricInRange(ts, 1699999999, 1700000001))
+	assert.False(t, metricInRange(ts, 1700000001, 0))
+	assert.False(t, metricInRange(ts, 0, 1699999999))
+}
+
+func TestSandboxMetricsResponseSerializesEmptyDataArray(t *testing.T) {
+	body, err := json.Marshal(&types.GetSandboxMetricsRes{
+		Data: []*types.SandboxMetricData{},
+	})
+
+	assert.NoError(t, err)
+	assert.JSONEq(t, `{"data":[]}`, string(body))
+}

--- a/CubeMaster/pkg/service/sandbox/types/types.go
+++ b/CubeMaster/pkg/service/sandbox/types/types.go
@@ -485,6 +485,32 @@ type GetCubeSandboxRes struct {
 	Data      []*SandboxData `json:"data,omitempty"`
 }
 
+type GetSandboxMetricsReq struct {
+	RequestID    string `json:"requestID,omitempty"`
+	SandboxID    string `json:"sandbox_id,omitempty"`
+	HostID       string `json:"host_id,omitempty"`
+	InstanceType string `json:"instance_type,omitempty"`
+	Start        int64  `json:"start,omitempty"`
+	End          int64  `json:"end,omitempty"`
+}
+
+type GetSandboxMetricsRes struct {
+	RequestID string               `json:"requestID,omitempty"`
+	Ret       *Ret                 `json:"ret,omitempty"`
+	Data      []*SandboxMetricData `json:"data"`
+}
+
+type SandboxMetricData struct {
+	TimestampUnixNano int64   `json:"timestamp_unix_nano,omitempty"`
+	CPUCount          int32   `json:"cpu_count,omitempty"`
+	CPUUsedPct        float64 `json:"cpu_used_pct,omitempty"`
+	MemUsed           int64   `json:"mem_used,omitempty"`
+	MemTotal          int64   `json:"mem_total,omitempty"`
+	MemCache          int64   `json:"mem_cache,omitempty"`
+	DiskUsed          int64   `json:"disk_used,omitempty"`
+	DiskTotal         int64   `json:"disk_total,omitempty"`
+}
+
 type SandboxData struct {
 	SandboxID              string            `json:"sandbox_id,omitempty"`
 	Status                 int32             `json:"status,omitempty"`

--- a/Cubelet/api/services/cubebox/v1/cubebox.pb.go
+++ b/Cubelet/api/services/cubebox/v1/cubebox.pb.go
@@ -5982,6 +5982,240 @@ func (x *GetStorageMetricsResponse) GetMetrics() map[string]uint64 {
 	return nil
 }
 
+type GetSandboxMetricsRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// requestID reqID
+	RequestID string `protobuf:"bytes,1,opt,name=requestID,proto3" json:"requestID,omitempty"`
+	// Sandbox identifier to inspect.
+	SandboxID     string `protobuf:"bytes,2,opt,name=sandboxID,proto3" json:"sandboxID,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetSandboxMetricsRequest) Reset() {
+	*x = GetSandboxMetricsRequest{}
+	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[74]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetSandboxMetricsRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetSandboxMetricsRequest) ProtoMessage() {}
+
+func (x *GetSandboxMetricsRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[74]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetSandboxMetricsRequest.ProtoReflect.Descriptor instead.
+func (*GetSandboxMetricsRequest) Descriptor() ([]byte, []int) {
+	return file_api_services_cubebox_v1_cubebox_proto_rawDescGZIP(), []int{74}
+}
+
+func (x *GetSandboxMetricsRequest) GetRequestID() string {
+	if x != nil {
+		return x.RequestID
+	}
+	return ""
+}
+
+func (x *GetSandboxMetricsRequest) GetSandboxID() string {
+	if x != nil {
+		return x.SandboxID
+	}
+	return ""
+}
+
+type SandboxMetric struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Timestamp when metrics were collected.
+	TimestampUnixNano int64 `protobuf:"varint,1,opt,name=timestamp_unix_nano,json=timestampUnixNano,proto3" json:"timestamp_unix_nano,omitempty"`
+	// Number of CPU cores assigned to the sandbox.
+	CpuCount int32 `protobuf:"varint,2,opt,name=cpu_count,json=cpuCount,proto3" json:"cpu_count,omitempty"`
+	// CPU usage percentage. Best-effort in the current implementation.
+	CpuUsedPct float64 `protobuf:"fixed64,3,opt,name=cpu_used_pct,json=cpuUsedPct,proto3" json:"cpu_used_pct,omitempty"`
+	// Memory used in bytes. Best-effort in the current implementation.
+	MemUsed int64 `protobuf:"varint,4,opt,name=mem_used,json=memUsed,proto3" json:"mem_used,omitempty"`
+	// Total memory in bytes.
+	MemTotal int64 `protobuf:"varint,5,opt,name=mem_total,json=memTotal,proto3" json:"mem_total,omitempty"`
+	// Cached memory in bytes. Best-effort in the current implementation.
+	MemCache int64 `protobuf:"varint,6,opt,name=mem_cache,json=memCache,proto3" json:"mem_cache,omitempty"`
+	// Disk used in bytes. Best-effort in the current implementation.
+	DiskUsed int64 `protobuf:"varint,7,opt,name=disk_used,json=diskUsed,proto3" json:"disk_used,omitempty"`
+	// Total sandbox disk quota in bytes.
+	DiskTotal     int64 `protobuf:"varint,8,opt,name=disk_total,json=diskTotal,proto3" json:"disk_total,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SandboxMetric) Reset() {
+	*x = SandboxMetric{}
+	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[75]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SandboxMetric) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SandboxMetric) ProtoMessage() {}
+
+func (x *SandboxMetric) ProtoReflect() protoreflect.Message {
+	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[75]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SandboxMetric.ProtoReflect.Descriptor instead.
+func (*SandboxMetric) Descriptor() ([]byte, []int) {
+	return file_api_services_cubebox_v1_cubebox_proto_rawDescGZIP(), []int{75}
+}
+
+func (x *SandboxMetric) GetTimestampUnixNano() int64 {
+	if x != nil {
+		return x.TimestampUnixNano
+	}
+	return 0
+}
+
+func (x *SandboxMetric) GetCpuCount() int32 {
+	if x != nil {
+		return x.CpuCount
+	}
+	return 0
+}
+
+func (x *SandboxMetric) GetCpuUsedPct() float64 {
+	if x != nil {
+		return x.CpuUsedPct
+	}
+	return 0
+}
+
+func (x *SandboxMetric) GetMemUsed() int64 {
+	if x != nil {
+		return x.MemUsed
+	}
+	return 0
+}
+
+func (x *SandboxMetric) GetMemTotal() int64 {
+	if x != nil {
+		return x.MemTotal
+	}
+	return 0
+}
+
+func (x *SandboxMetric) GetMemCache() int64 {
+	if x != nil {
+		return x.MemCache
+	}
+	return 0
+}
+
+func (x *SandboxMetric) GetDiskUsed() int64 {
+	if x != nil {
+		return x.DiskUsed
+	}
+	return 0
+}
+
+func (x *SandboxMetric) GetDiskTotal() int64 {
+	if x != nil {
+		return x.DiskTotal
+	}
+	return 0
+}
+
+type GetSandboxMetricsResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// requestID reqID
+	RequestID string `protobuf:"bytes,1,opt,name=requestID,proto3" json:"requestID,omitempty"`
+	// Ret.
+	Ret *v11.Ret `protobuf:"bytes,2,opt,name=ret,proto3" json:"ret,omitempty"`
+	// Sandbox identifier that produced this metric snapshot.
+	SandboxID string `protobuf:"bytes,3,opt,name=sandboxID,proto3" json:"sandboxID,omitempty"`
+	// Current sandbox metric snapshot. Empty when no sample is available.
+	Metrics       []*SandboxMetric `protobuf:"bytes,4,rep,name=metrics,proto3" json:"metrics,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetSandboxMetricsResponse) Reset() {
+	*x = GetSandboxMetricsResponse{}
+	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[76]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetSandboxMetricsResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetSandboxMetricsResponse) ProtoMessage() {}
+
+func (x *GetSandboxMetricsResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[76]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetSandboxMetricsResponse.ProtoReflect.Descriptor instead.
+func (*GetSandboxMetricsResponse) Descriptor() ([]byte, []int) {
+	return file_api_services_cubebox_v1_cubebox_proto_rawDescGZIP(), []int{76}
+}
+
+func (x *GetSandboxMetricsResponse) GetRequestID() string {
+	if x != nil {
+		return x.RequestID
+	}
+	return ""
+}
+
+func (x *GetSandboxMetricsResponse) GetRet() *v11.Ret {
+	if x != nil {
+		return x.Ret
+	}
+	return nil
+}
+
+func (x *GetSandboxMetricsResponse) GetSandboxID() string {
+	if x != nil {
+		return x.SandboxID
+	}
+	return ""
+}
+
+func (x *GetSandboxMetricsResponse) GetMetrics() []*SandboxMetric {
+	if x != nil {
+		return x.Metrics
+	}
+	return nil
+}
+
 // StorageVolumeInfo describes a single backend file/volume entry attached to a
 // sandbox, as understood by cubelet at the time of inspection.
 type StorageVolumeInfo struct {
@@ -6006,7 +6240,7 @@ type StorageVolumeInfo struct {
 
 func (x *StorageVolumeInfo) Reset() {
 	*x = StorageVolumeInfo{}
-	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[74]
+	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[77]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6018,7 +6252,7 @@ func (x *StorageVolumeInfo) String() string {
 func (*StorageVolumeInfo) ProtoMessage() {}
 
 func (x *StorageVolumeInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[74]
+	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[77]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6031,7 +6265,7 @@ func (x *StorageVolumeInfo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StorageVolumeInfo.ProtoReflect.Descriptor instead.
 func (*StorageVolumeInfo) Descriptor() ([]byte, []int) {
-	return file_api_services_cubebox_v1_cubebox_proto_rawDescGZIP(), []int{74}
+	return file_api_services_cubebox_v1_cubebox_proto_rawDescGZIP(), []int{77}
 }
 
 func (x *StorageVolumeInfo) GetName() string {
@@ -6089,7 +6323,7 @@ type SandboxStorageInfo struct {
 
 func (x *SandboxStorageInfo) Reset() {
 	*x = SandboxStorageInfo{}
-	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[75]
+	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[78]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6101,7 +6335,7 @@ func (x *SandboxStorageInfo) String() string {
 func (*SandboxStorageInfo) ProtoMessage() {}
 
 func (x *SandboxStorageInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[75]
+	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[78]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6114,7 +6348,7 @@ func (x *SandboxStorageInfo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SandboxStorageInfo.ProtoReflect.Descriptor instead.
 func (*SandboxStorageInfo) Descriptor() ([]byte, []int) {
-	return file_api_services_cubebox_v1_cubebox_proto_rawDescGZIP(), []int{75}
+	return file_api_services_cubebox_v1_cubebox_proto_rawDescGZIP(), []int{78}
 }
 
 func (x *SandboxStorageInfo) GetNamespace() string {
@@ -6150,7 +6384,7 @@ type InspectStorageVolumesRequest struct {
 
 func (x *InspectStorageVolumesRequest) Reset() {
 	*x = InspectStorageVolumesRequest{}
-	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[76]
+	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[79]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6162,7 +6396,7 @@ func (x *InspectStorageVolumesRequest) String() string {
 func (*InspectStorageVolumesRequest) ProtoMessage() {}
 
 func (x *InspectStorageVolumesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[76]
+	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[79]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6175,7 +6409,7 @@ func (x *InspectStorageVolumesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use InspectStorageVolumesRequest.ProtoReflect.Descriptor instead.
 func (*InspectStorageVolumesRequest) Descriptor() ([]byte, []int) {
-	return file_api_services_cubebox_v1_cubebox_proto_rawDescGZIP(), []int{76}
+	return file_api_services_cubebox_v1_cubebox_proto_rawDescGZIP(), []int{79}
 }
 
 func (x *InspectStorageVolumesRequest) GetRequestID() string {
@@ -6206,7 +6440,7 @@ type InspectStorageVolumesResponse struct {
 
 func (x *InspectStorageVolumesResponse) Reset() {
 	*x = InspectStorageVolumesResponse{}
-	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[77]
+	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[80]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6218,7 +6452,7 @@ func (x *InspectStorageVolumesResponse) String() string {
 func (*InspectStorageVolumesResponse) ProtoMessage() {}
 
 func (x *InspectStorageVolumesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[77]
+	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[80]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6231,7 +6465,7 @@ func (x *InspectStorageVolumesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use InspectStorageVolumesResponse.ProtoReflect.Descriptor instead.
 func (*InspectStorageVolumesResponse) Descriptor() ([]byte, []int) {
-	return file_api_services_cubebox_v1_cubebox_proto_rawDescGZIP(), []int{77}
+	return file_api_services_cubebox_v1_cubebox_proto_rawDescGZIP(), []int{80}
 }
 
 func (x *InspectStorageVolumesResponse) GetRequestID() string {
@@ -6272,7 +6506,7 @@ type CleanupOrphanStorageFilesRequest struct {
 
 func (x *CleanupOrphanStorageFilesRequest) Reset() {
 	*x = CleanupOrphanStorageFilesRequest{}
-	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[78]
+	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[81]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6284,7 +6518,7 @@ func (x *CleanupOrphanStorageFilesRequest) String() string {
 func (*CleanupOrphanStorageFilesRequest) ProtoMessage() {}
 
 func (x *CleanupOrphanStorageFilesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[78]
+	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[81]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6297,7 +6531,7 @@ func (x *CleanupOrphanStorageFilesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CleanupOrphanStorageFilesRequest.ProtoReflect.Descriptor instead.
 func (*CleanupOrphanStorageFilesRequest) Descriptor() ([]byte, []int) {
-	return file_api_services_cubebox_v1_cubebox_proto_rawDescGZIP(), []int{78}
+	return file_api_services_cubebox_v1_cubebox_proto_rawDescGZIP(), []int{81}
 }
 
 func (x *CleanupOrphanStorageFilesRequest) GetRequestID() string {
@@ -6345,7 +6579,7 @@ type StorageOrphanEntry struct {
 
 func (x *StorageOrphanEntry) Reset() {
 	*x = StorageOrphanEntry{}
-	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[79]
+	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[82]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6357,7 +6591,7 @@ func (x *StorageOrphanEntry) String() string {
 func (*StorageOrphanEntry) ProtoMessage() {}
 
 func (x *StorageOrphanEntry) ProtoReflect() protoreflect.Message {
-	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[79]
+	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[82]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6370,7 +6604,7 @@ func (x *StorageOrphanEntry) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StorageOrphanEntry.ProtoReflect.Descriptor instead.
 func (*StorageOrphanEntry) Descriptor() ([]byte, []int) {
-	return file_api_services_cubebox_v1_cubebox_proto_rawDescGZIP(), []int{79}
+	return file_api_services_cubebox_v1_cubebox_proto_rawDescGZIP(), []int{82}
 }
 
 func (x *StorageOrphanEntry) GetFormat() string {
@@ -6415,7 +6649,7 @@ type CleanupOrphanStorageFilesResponse struct {
 
 func (x *CleanupOrphanStorageFilesResponse) Reset() {
 	*x = CleanupOrphanStorageFilesResponse{}
-	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[80]
+	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[83]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6427,7 +6661,7 @@ func (x *CleanupOrphanStorageFilesResponse) String() string {
 func (*CleanupOrphanStorageFilesResponse) ProtoMessage() {}
 
 func (x *CleanupOrphanStorageFilesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[80]
+	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[83]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6440,7 +6674,7 @@ func (x *CleanupOrphanStorageFilesResponse) ProtoReflect() protoreflect.Message 
 
 // Deprecated: Use CleanupOrphanStorageFilesResponse.ProtoReflect.Descriptor instead.
 func (*CleanupOrphanStorageFilesResponse) Descriptor() ([]byte, []int) {
-	return file_api_services_cubebox_v1_cubebox_proto_rawDescGZIP(), []int{80}
+	return file_api_services_cubebox_v1_cubebox_proto_rawDescGZIP(), []int{83}
 }
 
 func (x *CleanupOrphanStorageFilesResponse) GetRequestID() string {
@@ -6992,7 +7226,26 @@ const file_api_services_cubebox_v1_cubebox_proto_rawDesc = "" +
 	"\ametrics\x18\x05 \x03(\v2C.cubelet.services.cubebox.v1.GetStorageMetricsResponse.MetricsEntryR\ametrics\x1a:\n" +
 	"\fMetricsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\x04R\x05value:\x028\x01\"\xaa\x01\n" +
+	"\x05value\x18\x02 \x01(\x04R\x05value:\x028\x01\"V\n" +
+	"\x18GetSandboxMetricsRequest\x12\x1c\n" +
+	"\trequestID\x18\x01 \x01(\tR\trequestID\x12\x1c\n" +
+	"\tsandboxID\x18\x02 \x01(\tR\tsandboxID\"\x8f\x02\n" +
+	"\rSandboxMetric\x12.\n" +
+	"\x13timestamp_unix_nano\x18\x01 \x01(\x03R\x11timestampUnixNano\x12\x1b\n" +
+	"\tcpu_count\x18\x02 \x01(\x05R\bcpuCount\x12 \n" +
+	"\fcpu_used_pct\x18\x03 \x01(\x01R\n" +
+	"cpuUsedPct\x12\x19\n" +
+	"\bmem_used\x18\x04 \x01(\x03R\amemUsed\x12\x1b\n" +
+	"\tmem_total\x18\x05 \x01(\x03R\bmemTotal\x12\x1b\n" +
+	"\tmem_cache\x18\x06 \x01(\x03R\bmemCache\x12\x1b\n" +
+	"\tdisk_used\x18\a \x01(\x03R\bdiskUsed\x12\x1d\n" +
+	"\n" +
+	"disk_total\x18\b \x01(\x03R\tdiskTotal\"\xd3\x01\n" +
+	"\x19GetSandboxMetricsResponse\x12\x1c\n" +
+	"\trequestID\x18\x01 \x01(\tR\trequestID\x124\n" +
+	"\x03ret\x18\x02 \x01(\v2\".cubelet.services.errorcode.v1.RetR\x03ret\x12\x1c\n" +
+	"\tsandboxID\x18\x03 \x01(\tR\tsandboxID\x12D\n" +
+	"\ametrics\x18\x04 \x03(\v2*.cubelet.services.cubebox.v1.SandboxMetricR\ametrics\"\xaa\x01\n" +
 	"\x11StorageVolumeInfo\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x1b\n" +
 	"\tfile_path\x18\x02 \x01(\tR\bfilePath\x12\x1d\n" +
@@ -7050,7 +7303,7 @@ const file_api_services_cubebox_v1_cubebox_proto_rawDesc = "" +
 	"\x10CONTAINER_EXITED\x10\x02\x12\x15\n" +
 	"\x11CONTAINER_UNKNOWN\x10\x03\x12\x15\n" +
 	"\x11CONTAINER_PAUSING\x10\x04\x12\x14\n" +
-	"\x10CONTAINER_PAUSED\x10\x052\x8a\x0f\n" +
+	"\x10CONTAINER_PAUSED\x10\x052\x8f\x10\n" +
 	"\n" +
 	"CubeboxMgr\x12q\n" +
 	"\x06Create\x122.cubelet.services.cubebox.v1.RunCubeSandboxRequest\x1a3.cubelet.services.cubebox.v1.RunCubeSandboxResponse\x12z\n" +
@@ -7065,7 +7318,8 @@ const file_api_services_cubebox_v1_cubebox_proto_rawDesc = "" +
 	"\x14ListSandboxSnapshots\x128.cubelet.services.cubebox.v1.ListSandboxSnapshotsRequest\x1a9.cubelet.services.cubebox.v1.ListSandboxSnapshotsResponse\x12\x85\x01\n" +
 	"\x12ListLocalSnapshots\x126.cubelet.services.cubebox.v1.ListLocalSnapshotsRequest\x1a7.cubelet.services.cubebox.v1.ListLocalSnapshotsResponse\x12\x7f\n" +
 	"\x10GetLocalSnapshot\x124.cubelet.services.cubebox.v1.GetLocalSnapshotRequest\x1a5.cubelet.services.cubebox.v1.GetLocalSnapshotResponse\x12\x82\x01\n" +
-	"\x11GetStorageMetrics\x125.cubelet.services.cubebox.v1.GetStorageMetricsRequest\x1a6.cubelet.services.cubebox.v1.GetStorageMetricsResponse\x12\x8e\x01\n" +
+	"\x11GetStorageMetrics\x125.cubelet.services.cubebox.v1.GetStorageMetricsRequest\x1a6.cubelet.services.cubebox.v1.GetStorageMetricsResponse\x12\x82\x01\n" +
+	"\x11GetSandboxMetrics\x125.cubelet.services.cubebox.v1.GetSandboxMetricsRequest\x1a6.cubelet.services.cubebox.v1.GetSandboxMetricsResponse\x12\x8e\x01\n" +
 	"\x15InspectStorageVolumes\x129.cubelet.services.cubebox.v1.InspectStorageVolumesRequest\x1a:.cubelet.services.cubebox.v1.InspectStorageVolumesResponse\x12\x9a\x01\n" +
 	"\x19CleanupOrphanStorageFiles\x12=.cubelet.services.cubebox.v1.CleanupOrphanStorageFilesRequest\x1a>.cubelet.services.cubebox.v1.CleanupOrphanStorageFilesResponseBMZKgithub.com/tencentcloud/CubeSandbox/Cubelet/api/services/cubebox/v1;cubeboxb\x06proto3"
 
@@ -7082,7 +7336,7 @@ func file_api_services_cubebox_v1_cubebox_proto_rawDescGZIP() []byte {
 }
 
 var file_api_services_cubebox_v1_cubebox_proto_enumTypes = make([]protoimpl.EnumInfo, 6)
-var file_api_services_cubebox_v1_cubebox_proto_msgTypes = make([]protoimpl.MessageInfo, 93)
+var file_api_services_cubebox_v1_cubebox_proto_msgTypes = make([]protoimpl.MessageInfo, 96)
 var file_api_services_cubebox_v1_cubebox_proto_goTypes = []any{
 	(MountPropagation)(0),                     // 0: cubelet.services.cubebox.v1.MountPropagation
 	(StorageMedium)(0),                        // 1: cubelet.services.cubebox.v1.StorageMedium
@@ -7164,28 +7418,31 @@ var file_api_services_cubebox_v1_cubebox_proto_goTypes = []any{
 	(*GetLocalSnapshotResponse)(nil),          // 77: cubelet.services.cubebox.v1.GetLocalSnapshotResponse
 	(*GetStorageMetricsRequest)(nil),          // 78: cubelet.services.cubebox.v1.GetStorageMetricsRequest
 	(*GetStorageMetricsResponse)(nil),         // 79: cubelet.services.cubebox.v1.GetStorageMetricsResponse
-	(*StorageVolumeInfo)(nil),                 // 80: cubelet.services.cubebox.v1.StorageVolumeInfo
-	(*SandboxStorageInfo)(nil),                // 81: cubelet.services.cubebox.v1.SandboxStorageInfo
-	(*InspectStorageVolumesRequest)(nil),      // 82: cubelet.services.cubebox.v1.InspectStorageVolumesRequest
-	(*InspectStorageVolumesResponse)(nil),     // 83: cubelet.services.cubebox.v1.InspectStorageVolumesResponse
-	(*CleanupOrphanStorageFilesRequest)(nil),  // 84: cubelet.services.cubebox.v1.CleanupOrphanStorageFilesRequest
-	(*StorageOrphanEntry)(nil),                // 85: cubelet.services.cubebox.v1.StorageOrphanEntry
-	(*CleanupOrphanStorageFilesResponse)(nil), // 86: cubelet.services.cubebox.v1.CleanupOrphanStorageFilesResponse
-	nil,                          // 87: cubelet.services.cubebox.v1.ContainerConfig.SysctlsEntry
-	nil,                          // 88: cubelet.services.cubebox.v1.ContainerConfig.AnnotationsEntry
-	nil,                          // 89: cubelet.services.cubebox.v1.RunCubeSandboxRequest.AnnotationsEntry
-	nil,                          // 90: cubelet.services.cubebox.v1.RunCubeSandboxRequest.LabelsEntry
-	nil,                          // 91: cubelet.services.cubebox.v1.RunCubeSandboxResponse.ExtInfoEntry
-	nil,                          // 92: cubelet.services.cubebox.v1.DestroyCubeSandboxRequest.AnnotationsEntry
-	nil,                          // 93: cubelet.services.cubebox.v1.DestroyCubeSandboxResponse.ExtInfoEntry
-	nil,                          // 94: cubelet.services.cubebox.v1.CubeSandbox.LabelsEntry
-	nil,                          // 95: cubelet.services.cubebox.v1.Container.LabelsEntry
-	nil,                          // 96: cubelet.services.cubebox.v1.CubeSandboxFilter.LabelSelectorEntry
-	nil,                          // 97: cubelet.services.cubebox.v1.UpdateCubeSandboxRequest.AnnotationsEntry
-	nil,                          // 98: cubelet.services.cubebox.v1.GetStorageMetricsResponse.MetricsEntry
-	(*v1.ImageSpec)(nil),         // 99: cubelet.services.images.v1.ImageSpec
-	(*v1.ImageVolumeSource)(nil), // 100: cubelet.services.images.v1.ImageVolumeSource
-	(*v11.Ret)(nil),              // 101: cubelet.services.errorcode.v1.Ret
+	(*GetSandboxMetricsRequest)(nil),          // 80: cubelet.services.cubebox.v1.GetSandboxMetricsRequest
+	(*SandboxMetric)(nil),                     // 81: cubelet.services.cubebox.v1.SandboxMetric
+	(*GetSandboxMetricsResponse)(nil),         // 82: cubelet.services.cubebox.v1.GetSandboxMetricsResponse
+	(*StorageVolumeInfo)(nil),                 // 83: cubelet.services.cubebox.v1.StorageVolumeInfo
+	(*SandboxStorageInfo)(nil),                // 84: cubelet.services.cubebox.v1.SandboxStorageInfo
+	(*InspectStorageVolumesRequest)(nil),      // 85: cubelet.services.cubebox.v1.InspectStorageVolumesRequest
+	(*InspectStorageVolumesResponse)(nil),     // 86: cubelet.services.cubebox.v1.InspectStorageVolumesResponse
+	(*CleanupOrphanStorageFilesRequest)(nil),  // 87: cubelet.services.cubebox.v1.CleanupOrphanStorageFilesRequest
+	(*StorageOrphanEntry)(nil),                // 88: cubelet.services.cubebox.v1.StorageOrphanEntry
+	(*CleanupOrphanStorageFilesResponse)(nil), // 89: cubelet.services.cubebox.v1.CleanupOrphanStorageFilesResponse
+	nil,                          // 90: cubelet.services.cubebox.v1.ContainerConfig.SysctlsEntry
+	nil,                          // 91: cubelet.services.cubebox.v1.ContainerConfig.AnnotationsEntry
+	nil,                          // 92: cubelet.services.cubebox.v1.RunCubeSandboxRequest.AnnotationsEntry
+	nil,                          // 93: cubelet.services.cubebox.v1.RunCubeSandboxRequest.LabelsEntry
+	nil,                          // 94: cubelet.services.cubebox.v1.RunCubeSandboxResponse.ExtInfoEntry
+	nil,                          // 95: cubelet.services.cubebox.v1.DestroyCubeSandboxRequest.AnnotationsEntry
+	nil,                          // 96: cubelet.services.cubebox.v1.DestroyCubeSandboxResponse.ExtInfoEntry
+	nil,                          // 97: cubelet.services.cubebox.v1.CubeSandbox.LabelsEntry
+	nil,                          // 98: cubelet.services.cubebox.v1.Container.LabelsEntry
+	nil,                          // 99: cubelet.services.cubebox.v1.CubeSandboxFilter.LabelSelectorEntry
+	nil,                          // 100: cubelet.services.cubebox.v1.UpdateCubeSandboxRequest.AnnotationsEntry
+	nil,                          // 101: cubelet.services.cubebox.v1.GetStorageMetricsResponse.MetricsEntry
+	(*v1.ImageSpec)(nil),         // 102: cubelet.services.images.v1.ImageSpec
+	(*v1.ImageVolumeSource)(nil), // 103: cubelet.services.images.v1.ImageVolumeSource
+	(*v11.Ret)(nil),              // 104: cubelet.services.errorcode.v1.Ret
 }
 var file_api_services_cubebox_v1_cubebox_proto_depIdxs = []int32{
 	7,   // 0: cubelet.services.cubebox.v1.ContainerSecurityContext.capabilities:type_name -> cubelet.services.cubebox.v1.Capability
@@ -7203,17 +7460,17 @@ var file_api_services_cubebox_v1_cubebox_proto_depIdxs = []int32{
 	19,  // 12: cubelet.services.cubebox.v1.PreStop.lifecyle_handler:type_name -> cubelet.services.cubebox.v1.LifecycleHandler
 	19,  // 13: cubelet.services.cubebox.v1.PostStop.lifecyle_handler:type_name -> cubelet.services.cubebox.v1.LifecycleHandler
 	22,  // 14: cubelet.services.cubebox.v1.Hooks.Prestart:type_name -> cubelet.services.cubebox.v1.Hook
-	99,  // 15: cubelet.services.cubebox.v1.ContainerConfig.image:type_name -> cubelet.services.images.v1.ImageSpec
+	102, // 15: cubelet.services.cubebox.v1.ContainerConfig.image:type_name -> cubelet.services.images.v1.ImageSpec
 	24,  // 16: cubelet.services.cubebox.v1.ContainerConfig.envs:type_name -> cubelet.services.cubebox.v1.KeyValue
 	12,  // 17: cubelet.services.cubebox.v1.ContainerConfig.volume_mounts:type_name -> cubelet.services.cubebox.v1.VolumeMounts
 	11,  // 18: cubelet.services.cubebox.v1.ContainerConfig.r_limit:type_name -> cubelet.services.cubebox.v1.RLimit
 	32,  // 19: cubelet.services.cubebox.v1.ContainerConfig.resources:type_name -> cubelet.services.cubebox.v1.Resource
 	9,   // 20: cubelet.services.cubebox.v1.ContainerConfig.security_context:type_name -> cubelet.services.cubebox.v1.ContainerSecurityContext
 	18,  // 21: cubelet.services.cubebox.v1.ContainerConfig.probe:type_name -> cubelet.services.cubebox.v1.Probe
-	87,  // 22: cubelet.services.cubebox.v1.ContainerConfig.sysctls:type_name -> cubelet.services.cubebox.v1.ContainerConfig.SysctlsEntry
+	90,  // 22: cubelet.services.cubebox.v1.ContainerConfig.sysctls:type_name -> cubelet.services.cubebox.v1.ContainerConfig.SysctlsEntry
 	31,  // 23: cubelet.services.cubebox.v1.ContainerConfig.syscalls:type_name -> cubelet.services.cubebox.v1.SysCall
 	10,  // 24: cubelet.services.cubebox.v1.ContainerConfig.dns_config:type_name -> cubelet.services.cubebox.v1.DNSConfig
-	88,  // 25: cubelet.services.cubebox.v1.ContainerConfig.annotations:type_name -> cubelet.services.cubebox.v1.ContainerConfig.AnnotationsEntry
+	91,  // 25: cubelet.services.cubebox.v1.ContainerConfig.annotations:type_name -> cubelet.services.cubebox.v1.ContainerConfig.AnnotationsEntry
 	25,  // 26: cubelet.services.cubebox.v1.ContainerConfig.hostAliases:type_name -> cubelet.services.cubebox.v1.HostAlias
 	20,  // 27: cubelet.services.cubebox.v1.ContainerConfig.prestop:type_name -> cubelet.services.cubebox.v1.PreStop
 	21,  // 28: cubelet.services.cubebox.v1.ContainerConfig.poststop:type_name -> cubelet.services.cubebox.v1.PostStop
@@ -7227,94 +7484,98 @@ var file_api_services_cubebox_v1_cubebox_proto_depIdxs = []int32{
 	33,  // 36: cubelet.services.cubebox.v1.VolumeSource.empty_dir:type_name -> cubelet.services.cubebox.v1.EmptyDirVolumeSource
 	34,  // 37: cubelet.services.cubebox.v1.VolumeSource.sandbox_path:type_name -> cubelet.services.cubebox.v1.SandboxPathVolumeSource
 	36,  // 38: cubelet.services.cubebox.v1.VolumeSource.host_dir_volumes:type_name -> cubelet.services.cubebox.v1.HostDirVolumeSources
-	100, // 39: cubelet.services.cubebox.v1.VolumeSource.image:type_name -> cubelet.services.images.v1.ImageVolumeSource
+	103, // 39: cubelet.services.cubebox.v1.VolumeSource.image:type_name -> cubelet.services.images.v1.ImageVolumeSource
 	37,  // 40: cubelet.services.cubebox.v1.Volume.volume_source:type_name -> cubelet.services.cubebox.v1.VolumeSource
 	38,  // 41: cubelet.services.cubebox.v1.RunCubeSandboxRequest.volumes:type_name -> cubelet.services.cubebox.v1.Volume
 	26,  // 42: cubelet.services.cubebox.v1.RunCubeSandboxRequest.containers:type_name -> cubelet.services.cubebox.v1.ContainerConfig
-	89,  // 43: cubelet.services.cubebox.v1.RunCubeSandboxRequest.annotations:type_name -> cubelet.services.cubebox.v1.RunCubeSandboxRequest.AnnotationsEntry
-	90,  // 44: cubelet.services.cubebox.v1.RunCubeSandboxRequest.labels:type_name -> cubelet.services.cubebox.v1.RunCubeSandboxRequest.LabelsEntry
+	92,  // 43: cubelet.services.cubebox.v1.RunCubeSandboxRequest.annotations:type_name -> cubelet.services.cubebox.v1.RunCubeSandboxRequest.AnnotationsEntry
+	93,  // 44: cubelet.services.cubebox.v1.RunCubeSandboxRequest.labels:type_name -> cubelet.services.cubebox.v1.RunCubeSandboxRequest.LabelsEntry
 	42,  // 45: cubelet.services.cubebox.v1.RunCubeSandboxRequest.cube_network_config:type_name -> cubelet.services.cubebox.v1.CubeNetworkConfig
-	101, // 46: cubelet.services.cubebox.v1.RunCubeSandboxResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
-	91,  // 47: cubelet.services.cubebox.v1.RunCubeSandboxResponse.ext_info:type_name -> cubelet.services.cubebox.v1.RunCubeSandboxResponse.ExtInfoEntry
+	104, // 46: cubelet.services.cubebox.v1.RunCubeSandboxResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
+	94,  // 47: cubelet.services.cubebox.v1.RunCubeSandboxResponse.ext_info:type_name -> cubelet.services.cubebox.v1.RunCubeSandboxResponse.ExtInfoEntry
 	41,  // 48: cubelet.services.cubebox.v1.RunCubeSandboxResponse.port_mappings:type_name -> cubelet.services.cubebox.v1.PortMapping
 	43,  // 49: cubelet.services.cubebox.v1.CubeNetworkConfig.rules:type_name -> cubelet.services.cubebox.v1.EgressRule
 	44,  // 50: cubelet.services.cubebox.v1.EgressRule.match:type_name -> cubelet.services.cubebox.v1.EgressRuleMatch
 	45,  // 51: cubelet.services.cubebox.v1.EgressRule.action:type_name -> cubelet.services.cubebox.v1.EgressRuleAction
 	46,  // 52: cubelet.services.cubebox.v1.EgressRuleAction.inject:type_name -> cubelet.services.cubebox.v1.EgressRuleInject
-	92,  // 53: cubelet.services.cubebox.v1.DestroyCubeSandboxRequest.annotations:type_name -> cubelet.services.cubebox.v1.DestroyCubeSandboxRequest.AnnotationsEntry
+	95,  // 53: cubelet.services.cubebox.v1.DestroyCubeSandboxRequest.annotations:type_name -> cubelet.services.cubebox.v1.DestroyCubeSandboxRequest.AnnotationsEntry
 	52,  // 54: cubelet.services.cubebox.v1.DestroyCubeSandboxRequest.filter:type_name -> cubelet.services.cubebox.v1.CubeSandboxFilter
-	101, // 55: cubelet.services.cubebox.v1.DestroyCubeSandboxResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
-	93,  // 56: cubelet.services.cubebox.v1.DestroyCubeSandboxResponse.ext_info:type_name -> cubelet.services.cubebox.v1.DestroyCubeSandboxResponse.ExtInfoEntry
+	104, // 55: cubelet.services.cubebox.v1.DestroyCubeSandboxResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
+	96,  // 56: cubelet.services.cubebox.v1.DestroyCubeSandboxResponse.ext_info:type_name -> cubelet.services.cubebox.v1.DestroyCubeSandboxResponse.ExtInfoEntry
 	50,  // 57: cubelet.services.cubebox.v1.CubeSandbox.containers:type_name -> cubelet.services.cubebox.v1.Container
 	41,  // 58: cubelet.services.cubebox.v1.CubeSandbox.port_mappings:type_name -> cubelet.services.cubebox.v1.PortMapping
-	94,  // 59: cubelet.services.cubebox.v1.CubeSandbox.labels:type_name -> cubelet.services.cubebox.v1.CubeSandbox.LabelsEntry
+	97,  // 59: cubelet.services.cubebox.v1.CubeSandbox.labels:type_name -> cubelet.services.cubebox.v1.CubeSandbox.LabelsEntry
 	32,  // 60: cubelet.services.cubebox.v1.Container.resources:type_name -> cubelet.services.cubebox.v1.Resource
 	5,   // 61: cubelet.services.cubebox.v1.Container.state:type_name -> cubelet.services.cubebox.v1.ContainerState
-	95,  // 62: cubelet.services.cubebox.v1.Container.labels:type_name -> cubelet.services.cubebox.v1.Container.LabelsEntry
+	98,  // 62: cubelet.services.cubebox.v1.Container.labels:type_name -> cubelet.services.cubebox.v1.Container.LabelsEntry
 	5,   // 63: cubelet.services.cubebox.v1.ContainerStateValue.state:type_name -> cubelet.services.cubebox.v1.ContainerState
 	51,  // 64: cubelet.services.cubebox.v1.CubeSandboxFilter.state:type_name -> cubelet.services.cubebox.v1.ContainerStateValue
-	96,  // 65: cubelet.services.cubebox.v1.CubeSandboxFilter.label_selector:type_name -> cubelet.services.cubebox.v1.CubeSandboxFilter.LabelSelectorEntry
+	99,  // 65: cubelet.services.cubebox.v1.CubeSandboxFilter.label_selector:type_name -> cubelet.services.cubebox.v1.CubeSandboxFilter.LabelSelectorEntry
 	52,  // 66: cubelet.services.cubebox.v1.ListCubeSandboxRequest.filter:type_name -> cubelet.services.cubebox.v1.CubeSandboxFilter
 	58,  // 67: cubelet.services.cubebox.v1.ListCubeSandboxRequest.option:type_name -> cubelet.services.cubebox.v1.ListCubeSandboxOption
 	49,  // 68: cubelet.services.cubebox.v1.ListCubeSandboxResponse.items:type_name -> cubelet.services.cubebox.v1.CubeSandbox
-	97,  // 69: cubelet.services.cubebox.v1.UpdateCubeSandboxRequest.annotations:type_name -> cubelet.services.cubebox.v1.UpdateCubeSandboxRequest.AnnotationsEntry
-	101, // 70: cubelet.services.cubebox.v1.UpdateCubeSandboxResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
-	101, // 71: cubelet.services.cubebox.v1.ExecCubeSandboxResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
+	100, // 69: cubelet.services.cubebox.v1.UpdateCubeSandboxRequest.annotations:type_name -> cubelet.services.cubebox.v1.UpdateCubeSandboxRequest.AnnotationsEntry
+	104, // 70: cubelet.services.cubebox.v1.UpdateCubeSandboxResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
+	104, // 71: cubelet.services.cubebox.v1.ExecCubeSandboxResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
 	39,  // 72: cubelet.services.cubebox.v1.AppSnapshotRequest.create_request:type_name -> cubelet.services.cubebox.v1.RunCubeSandboxRequest
-	101, // 73: cubelet.services.cubebox.v1.AppSnapshotResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
-	101, // 74: cubelet.services.cubebox.v1.CommitSandboxResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
-	101, // 75: cubelet.services.cubebox.v1.RollbackSandboxResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
+	104, // 73: cubelet.services.cubebox.v1.AppSnapshotResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
+	104, // 74: cubelet.services.cubebox.v1.CommitSandboxResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
+	104, // 75: cubelet.services.cubebox.v1.RollbackSandboxResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
 	67,  // 76: cubelet.services.cubebox.v1.CleanupTemplateRequest.objects:type_name -> cubelet.services.cubebox.v1.CowObjectRef
-	101, // 77: cubelet.services.cubebox.v1.CleanupTemplateResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
+	104, // 77: cubelet.services.cubebox.v1.CleanupTemplateResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
 	67,  // 78: cubelet.services.cubebox.v1.ListSandboxSnapshotsRequest.objects:type_name -> cubelet.services.cubebox.v1.CowObjectRef
-	101, // 79: cubelet.services.cubebox.v1.ListSandboxSnapshotsResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
+	104, // 79: cubelet.services.cubebox.v1.ListSandboxSnapshotsResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
 	71,  // 80: cubelet.services.cubebox.v1.ListSandboxSnapshotsResponse.objects:type_name -> cubelet.services.cubebox.v1.CowObjectStatus
-	101, // 81: cubelet.services.cubebox.v1.ListLocalSnapshotsResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
+	104, // 81: cubelet.services.cubebox.v1.ListLocalSnapshotsResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
 	74,  // 82: cubelet.services.cubebox.v1.ListLocalSnapshotsResponse.snapshots:type_name -> cubelet.services.cubebox.v1.LocalSnapshotInfo
-	101, // 83: cubelet.services.cubebox.v1.GetLocalSnapshotResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
+	104, // 83: cubelet.services.cubebox.v1.GetLocalSnapshotResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
 	74,  // 84: cubelet.services.cubebox.v1.GetLocalSnapshotResponse.snapshot:type_name -> cubelet.services.cubebox.v1.LocalSnapshotInfo
-	101, // 85: cubelet.services.cubebox.v1.GetStorageMetricsResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
-	98,  // 86: cubelet.services.cubebox.v1.GetStorageMetricsResponse.metrics:type_name -> cubelet.services.cubebox.v1.GetStorageMetricsResponse.MetricsEntry
-	80,  // 87: cubelet.services.cubebox.v1.SandboxStorageInfo.volumes:type_name -> cubelet.services.cubebox.v1.StorageVolumeInfo
-	101, // 88: cubelet.services.cubebox.v1.InspectStorageVolumesResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
-	81,  // 89: cubelet.services.cubebox.v1.InspectStorageVolumesResponse.sandboxes:type_name -> cubelet.services.cubebox.v1.SandboxStorageInfo
-	101, // 90: cubelet.services.cubebox.v1.CleanupOrphanStorageFilesResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
-	85,  // 91: cubelet.services.cubebox.v1.CleanupOrphanStorageFilesResponse.orphans:type_name -> cubelet.services.cubebox.v1.StorageOrphanEntry
-	39,  // 92: cubelet.services.cubebox.v1.CubeboxMgr.Create:input_type -> cubelet.services.cubebox.v1.RunCubeSandboxRequest
-	47,  // 93: cubelet.services.cubebox.v1.CubeboxMgr.Destroy:input_type -> cubelet.services.cubebox.v1.DestroyCubeSandboxRequest
-	53,  // 94: cubelet.services.cubebox.v1.CubeboxMgr.List:input_type -> cubelet.services.cubebox.v1.ListCubeSandboxRequest
-	55,  // 95: cubelet.services.cubebox.v1.CubeboxMgr.Update:input_type -> cubelet.services.cubebox.v1.UpdateCubeSandboxRequest
-	59,  // 96: cubelet.services.cubebox.v1.CubeboxMgr.Exec:input_type -> cubelet.services.cubebox.v1.ExecCubeSandboxRequest
-	61,  // 97: cubelet.services.cubebox.v1.CubeboxMgr.AppSnapshot:input_type -> cubelet.services.cubebox.v1.AppSnapshotRequest
-	63,  // 98: cubelet.services.cubebox.v1.CubeboxMgr.CommitSandbox:input_type -> cubelet.services.cubebox.v1.CommitSandboxRequest
-	65,  // 99: cubelet.services.cubebox.v1.CubeboxMgr.RollbackSandbox:input_type -> cubelet.services.cubebox.v1.RollbackSandboxRequest
-	68,  // 100: cubelet.services.cubebox.v1.CubeboxMgr.CleanupTemplate:input_type -> cubelet.services.cubebox.v1.CleanupTemplateRequest
-	70,  // 101: cubelet.services.cubebox.v1.CubeboxMgr.ListSandboxSnapshots:input_type -> cubelet.services.cubebox.v1.ListSandboxSnapshotsRequest
-	73,  // 102: cubelet.services.cubebox.v1.CubeboxMgr.ListLocalSnapshots:input_type -> cubelet.services.cubebox.v1.ListLocalSnapshotsRequest
-	76,  // 103: cubelet.services.cubebox.v1.CubeboxMgr.GetLocalSnapshot:input_type -> cubelet.services.cubebox.v1.GetLocalSnapshotRequest
-	78,  // 104: cubelet.services.cubebox.v1.CubeboxMgr.GetStorageMetrics:input_type -> cubelet.services.cubebox.v1.GetStorageMetricsRequest
-	82,  // 105: cubelet.services.cubebox.v1.CubeboxMgr.InspectStorageVolumes:input_type -> cubelet.services.cubebox.v1.InspectStorageVolumesRequest
-	84,  // 106: cubelet.services.cubebox.v1.CubeboxMgr.CleanupOrphanStorageFiles:input_type -> cubelet.services.cubebox.v1.CleanupOrphanStorageFilesRequest
-	40,  // 107: cubelet.services.cubebox.v1.CubeboxMgr.Create:output_type -> cubelet.services.cubebox.v1.RunCubeSandboxResponse
-	48,  // 108: cubelet.services.cubebox.v1.CubeboxMgr.Destroy:output_type -> cubelet.services.cubebox.v1.DestroyCubeSandboxResponse
-	54,  // 109: cubelet.services.cubebox.v1.CubeboxMgr.List:output_type -> cubelet.services.cubebox.v1.ListCubeSandboxResponse
-	56,  // 110: cubelet.services.cubebox.v1.CubeboxMgr.Update:output_type -> cubelet.services.cubebox.v1.UpdateCubeSandboxResponse
-	60,  // 111: cubelet.services.cubebox.v1.CubeboxMgr.Exec:output_type -> cubelet.services.cubebox.v1.ExecCubeSandboxResponse
-	62,  // 112: cubelet.services.cubebox.v1.CubeboxMgr.AppSnapshot:output_type -> cubelet.services.cubebox.v1.AppSnapshotResponse
-	64,  // 113: cubelet.services.cubebox.v1.CubeboxMgr.CommitSandbox:output_type -> cubelet.services.cubebox.v1.CommitSandboxResponse
-	66,  // 114: cubelet.services.cubebox.v1.CubeboxMgr.RollbackSandbox:output_type -> cubelet.services.cubebox.v1.RollbackSandboxResponse
-	69,  // 115: cubelet.services.cubebox.v1.CubeboxMgr.CleanupTemplate:output_type -> cubelet.services.cubebox.v1.CleanupTemplateResponse
-	72,  // 116: cubelet.services.cubebox.v1.CubeboxMgr.ListSandboxSnapshots:output_type -> cubelet.services.cubebox.v1.ListSandboxSnapshotsResponse
-	75,  // 117: cubelet.services.cubebox.v1.CubeboxMgr.ListLocalSnapshots:output_type -> cubelet.services.cubebox.v1.ListLocalSnapshotsResponse
-	77,  // 118: cubelet.services.cubebox.v1.CubeboxMgr.GetLocalSnapshot:output_type -> cubelet.services.cubebox.v1.GetLocalSnapshotResponse
-	79,  // 119: cubelet.services.cubebox.v1.CubeboxMgr.GetStorageMetrics:output_type -> cubelet.services.cubebox.v1.GetStorageMetricsResponse
-	83,  // 120: cubelet.services.cubebox.v1.CubeboxMgr.InspectStorageVolumes:output_type -> cubelet.services.cubebox.v1.InspectStorageVolumesResponse
-	86,  // 121: cubelet.services.cubebox.v1.CubeboxMgr.CleanupOrphanStorageFiles:output_type -> cubelet.services.cubebox.v1.CleanupOrphanStorageFilesResponse
-	107, // [107:122] is the sub-list for method output_type
-	92,  // [92:107] is the sub-list for method input_type
-	92,  // [92:92] is the sub-list for extension type_name
-	92,  // [92:92] is the sub-list for extension extendee
-	0,   // [0:92] is the sub-list for field type_name
+	104, // 85: cubelet.services.cubebox.v1.GetStorageMetricsResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
+	101, // 86: cubelet.services.cubebox.v1.GetStorageMetricsResponse.metrics:type_name -> cubelet.services.cubebox.v1.GetStorageMetricsResponse.MetricsEntry
+	104, // 87: cubelet.services.cubebox.v1.GetSandboxMetricsResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
+	81,  // 88: cubelet.services.cubebox.v1.GetSandboxMetricsResponse.metrics:type_name -> cubelet.services.cubebox.v1.SandboxMetric
+	83,  // 89: cubelet.services.cubebox.v1.SandboxStorageInfo.volumes:type_name -> cubelet.services.cubebox.v1.StorageVolumeInfo
+	104, // 90: cubelet.services.cubebox.v1.InspectStorageVolumesResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
+	84,  // 91: cubelet.services.cubebox.v1.InspectStorageVolumesResponse.sandboxes:type_name -> cubelet.services.cubebox.v1.SandboxStorageInfo
+	104, // 92: cubelet.services.cubebox.v1.CleanupOrphanStorageFilesResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
+	88,  // 93: cubelet.services.cubebox.v1.CleanupOrphanStorageFilesResponse.orphans:type_name -> cubelet.services.cubebox.v1.StorageOrphanEntry
+	39,  // 94: cubelet.services.cubebox.v1.CubeboxMgr.Create:input_type -> cubelet.services.cubebox.v1.RunCubeSandboxRequest
+	47,  // 95: cubelet.services.cubebox.v1.CubeboxMgr.Destroy:input_type -> cubelet.services.cubebox.v1.DestroyCubeSandboxRequest
+	53,  // 96: cubelet.services.cubebox.v1.CubeboxMgr.List:input_type -> cubelet.services.cubebox.v1.ListCubeSandboxRequest
+	55,  // 97: cubelet.services.cubebox.v1.CubeboxMgr.Update:input_type -> cubelet.services.cubebox.v1.UpdateCubeSandboxRequest
+	59,  // 98: cubelet.services.cubebox.v1.CubeboxMgr.Exec:input_type -> cubelet.services.cubebox.v1.ExecCubeSandboxRequest
+	61,  // 99: cubelet.services.cubebox.v1.CubeboxMgr.AppSnapshot:input_type -> cubelet.services.cubebox.v1.AppSnapshotRequest
+	63,  // 100: cubelet.services.cubebox.v1.CubeboxMgr.CommitSandbox:input_type -> cubelet.services.cubebox.v1.CommitSandboxRequest
+	65,  // 101: cubelet.services.cubebox.v1.CubeboxMgr.RollbackSandbox:input_type -> cubelet.services.cubebox.v1.RollbackSandboxRequest
+	68,  // 102: cubelet.services.cubebox.v1.CubeboxMgr.CleanupTemplate:input_type -> cubelet.services.cubebox.v1.CleanupTemplateRequest
+	70,  // 103: cubelet.services.cubebox.v1.CubeboxMgr.ListSandboxSnapshots:input_type -> cubelet.services.cubebox.v1.ListSandboxSnapshotsRequest
+	73,  // 104: cubelet.services.cubebox.v1.CubeboxMgr.ListLocalSnapshots:input_type -> cubelet.services.cubebox.v1.ListLocalSnapshotsRequest
+	76,  // 105: cubelet.services.cubebox.v1.CubeboxMgr.GetLocalSnapshot:input_type -> cubelet.services.cubebox.v1.GetLocalSnapshotRequest
+	78,  // 106: cubelet.services.cubebox.v1.CubeboxMgr.GetStorageMetrics:input_type -> cubelet.services.cubebox.v1.GetStorageMetricsRequest
+	80,  // 107: cubelet.services.cubebox.v1.CubeboxMgr.GetSandboxMetrics:input_type -> cubelet.services.cubebox.v1.GetSandboxMetricsRequest
+	85,  // 108: cubelet.services.cubebox.v1.CubeboxMgr.InspectStorageVolumes:input_type -> cubelet.services.cubebox.v1.InspectStorageVolumesRequest
+	87,  // 109: cubelet.services.cubebox.v1.CubeboxMgr.CleanupOrphanStorageFiles:input_type -> cubelet.services.cubebox.v1.CleanupOrphanStorageFilesRequest
+	40,  // 110: cubelet.services.cubebox.v1.CubeboxMgr.Create:output_type -> cubelet.services.cubebox.v1.RunCubeSandboxResponse
+	48,  // 111: cubelet.services.cubebox.v1.CubeboxMgr.Destroy:output_type -> cubelet.services.cubebox.v1.DestroyCubeSandboxResponse
+	54,  // 112: cubelet.services.cubebox.v1.CubeboxMgr.List:output_type -> cubelet.services.cubebox.v1.ListCubeSandboxResponse
+	56,  // 113: cubelet.services.cubebox.v1.CubeboxMgr.Update:output_type -> cubelet.services.cubebox.v1.UpdateCubeSandboxResponse
+	60,  // 114: cubelet.services.cubebox.v1.CubeboxMgr.Exec:output_type -> cubelet.services.cubebox.v1.ExecCubeSandboxResponse
+	62,  // 115: cubelet.services.cubebox.v1.CubeboxMgr.AppSnapshot:output_type -> cubelet.services.cubebox.v1.AppSnapshotResponse
+	64,  // 116: cubelet.services.cubebox.v1.CubeboxMgr.CommitSandbox:output_type -> cubelet.services.cubebox.v1.CommitSandboxResponse
+	66,  // 117: cubelet.services.cubebox.v1.CubeboxMgr.RollbackSandbox:output_type -> cubelet.services.cubebox.v1.RollbackSandboxResponse
+	69,  // 118: cubelet.services.cubebox.v1.CubeboxMgr.CleanupTemplate:output_type -> cubelet.services.cubebox.v1.CleanupTemplateResponse
+	72,  // 119: cubelet.services.cubebox.v1.CubeboxMgr.ListSandboxSnapshots:output_type -> cubelet.services.cubebox.v1.ListSandboxSnapshotsResponse
+	75,  // 120: cubelet.services.cubebox.v1.CubeboxMgr.ListLocalSnapshots:output_type -> cubelet.services.cubebox.v1.ListLocalSnapshotsResponse
+	77,  // 121: cubelet.services.cubebox.v1.CubeboxMgr.GetLocalSnapshot:output_type -> cubelet.services.cubebox.v1.GetLocalSnapshotResponse
+	79,  // 122: cubelet.services.cubebox.v1.CubeboxMgr.GetStorageMetrics:output_type -> cubelet.services.cubebox.v1.GetStorageMetricsResponse
+	82,  // 123: cubelet.services.cubebox.v1.CubeboxMgr.GetSandboxMetrics:output_type -> cubelet.services.cubebox.v1.GetSandboxMetricsResponse
+	86,  // 124: cubelet.services.cubebox.v1.CubeboxMgr.InspectStorageVolumes:output_type -> cubelet.services.cubebox.v1.InspectStorageVolumesResponse
+	89,  // 125: cubelet.services.cubebox.v1.CubeboxMgr.CleanupOrphanStorageFiles:output_type -> cubelet.services.cubebox.v1.CleanupOrphanStorageFilesResponse
+	110, // [110:126] is the sub-list for method output_type
+	94,  // [94:110] is the sub-list for method input_type
+	94,  // [94:94] is the sub-list for extension type_name
+	94,  // [94:94] is the sub-list for extension extendee
+	0,   // [0:94] is the sub-list for field type_name
 }
 
 func init() { file_api_services_cubebox_v1_cubebox_proto_init() }
@@ -7338,7 +7599,7 @@ func file_api_services_cubebox_v1_cubebox_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_api_services_cubebox_v1_cubebox_proto_rawDesc), len(file_api_services_cubebox_v1_cubebox_proto_rawDesc)),
 			NumEnums:      6,
-			NumMessages:   93,
+			NumMessages:   96,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/Cubelet/api/services/cubebox/v1/cubebox.proto
+++ b/Cubelet/api/services/cubebox/v1/cubebox.proto
@@ -40,6 +40,8 @@ service CubeboxMgr {
   rpc GetLocalSnapshot(GetLocalSnapshotRequest) returns (GetLocalSnapshotResponse);
   // GetStorageMetrics returns node-local cubecow storage metrics.
   rpc GetStorageMetrics(GetStorageMetricsRequest) returns (GetStorageMetricsResponse);
+  // GetSandboxMetrics returns the current metrics snapshot for one sandbox.
+  rpc GetSandboxMetrics(GetSandboxMetricsRequest) returns (GetSandboxMetricsResponse);
   // InspectStorageVolumes lists every sandbox storage record cubelet owns and
   // re-resolves cubecow device paths so cubecli can render an authoritative
   // view without touching boltdb or the cubecow SDK directly.
@@ -1089,6 +1091,43 @@ message GetStorageMetricsResponse {
   int64 timestamp_unix_nano = 4;
   // Storage metrics reported by cubecow.
   map<string, uint64> metrics = 5;
+}
+
+message GetSandboxMetricsRequest {
+  // requestID reqID
+  string requestID = 1;
+  // Sandbox identifier to inspect.
+  string sandboxID = 2;
+}
+
+message SandboxMetric {
+  // Timestamp when metrics were collected.
+  int64 timestamp_unix_nano = 1;
+  // Number of CPU cores assigned to the sandbox.
+  int32 cpu_count = 2;
+  // CPU usage percentage. Best-effort in the current implementation.
+  double cpu_used_pct = 3;
+  // Memory used in bytes. Best-effort in the current implementation.
+  int64 mem_used = 4;
+  // Total memory in bytes.
+  int64 mem_total = 5;
+  // Cached memory in bytes. Best-effort in the current implementation.
+  int64 mem_cache = 6;
+  // Disk used in bytes. Best-effort in the current implementation.
+  int64 disk_used = 7;
+  // Total sandbox disk quota in bytes.
+  int64 disk_total = 8;
+}
+
+message GetSandboxMetricsResponse {
+  // requestID reqID
+  string requestID = 1;
+  // Ret.
+  cubelet.services.errorcode.v1.Ret ret = 2;
+  // Sandbox identifier that produced this metric snapshot.
+  string sandboxID = 3;
+  // Current sandbox metric snapshot. Empty when no sample is available.
+  repeated SandboxMetric metrics = 4;
 }
 
 // StorageVolumeInfo describes a single backend file/volume entry attached to a

--- a/Cubelet/api/services/cubebox/v1/cubebox_grpc.pb.go
+++ b/Cubelet/api/services/cubebox/v1/cubebox_grpc.pb.go
@@ -36,6 +36,7 @@ const (
 	CubeboxMgr_ListLocalSnapshots_FullMethodName        = "/cubelet.services.cubebox.v1.CubeboxMgr/ListLocalSnapshots"
 	CubeboxMgr_GetLocalSnapshot_FullMethodName          = "/cubelet.services.cubebox.v1.CubeboxMgr/GetLocalSnapshot"
 	CubeboxMgr_GetStorageMetrics_FullMethodName         = "/cubelet.services.cubebox.v1.CubeboxMgr/GetStorageMetrics"
+	CubeboxMgr_GetSandboxMetrics_FullMethodName         = "/cubelet.services.cubebox.v1.CubeboxMgr/GetSandboxMetrics"
 	CubeboxMgr_InspectStorageVolumes_FullMethodName     = "/cubelet.services.cubebox.v1.CubeboxMgr/InspectStorageVolumes"
 	CubeboxMgr_CleanupOrphanStorageFiles_FullMethodName = "/cubelet.services.cubebox.v1.CubeboxMgr/CleanupOrphanStorageFiles"
 )
@@ -73,6 +74,8 @@ type CubeboxMgrClient interface {
 	GetLocalSnapshot(ctx context.Context, in *GetLocalSnapshotRequest, opts ...grpc.CallOption) (*GetLocalSnapshotResponse, error)
 	// GetStorageMetrics returns node-local cubecow storage metrics.
 	GetStorageMetrics(ctx context.Context, in *GetStorageMetricsRequest, opts ...grpc.CallOption) (*GetStorageMetricsResponse, error)
+	// GetSandboxMetrics returns the current metrics snapshot for one sandbox.
+	GetSandboxMetrics(ctx context.Context, in *GetSandboxMetricsRequest, opts ...grpc.CallOption) (*GetSandboxMetricsResponse, error)
 	// InspectStorageVolumes lists every sandbox storage record cubelet owns and
 	// re-resolves cubecow device paths so cubecli can render an authoritative
 	// view without touching boltdb or the cubecow SDK directly.
@@ -220,6 +223,16 @@ func (c *cubeboxMgrClient) GetStorageMetrics(ctx context.Context, in *GetStorage
 	return out, nil
 }
 
+func (c *cubeboxMgrClient) GetSandboxMetrics(ctx context.Context, in *GetSandboxMetricsRequest, opts ...grpc.CallOption) (*GetSandboxMetricsResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(GetSandboxMetricsResponse)
+	err := c.cc.Invoke(ctx, CubeboxMgr_GetSandboxMetrics_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 func (c *cubeboxMgrClient) InspectStorageVolumes(ctx context.Context, in *InspectStorageVolumesRequest, opts ...grpc.CallOption) (*InspectStorageVolumesResponse, error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(InspectStorageVolumesResponse)
@@ -273,6 +286,8 @@ type CubeboxMgrServer interface {
 	GetLocalSnapshot(context.Context, *GetLocalSnapshotRequest) (*GetLocalSnapshotResponse, error)
 	// GetStorageMetrics returns node-local cubecow storage metrics.
 	GetStorageMetrics(context.Context, *GetStorageMetricsRequest) (*GetStorageMetricsResponse, error)
+	// GetSandboxMetrics returns the current metrics snapshot for one sandbox.
+	GetSandboxMetrics(context.Context, *GetSandboxMetricsRequest) (*GetSandboxMetricsResponse, error)
 	// InspectStorageVolumes lists every sandbox storage record cubelet owns and
 	// re-resolves cubecow device paths so cubecli can render an authoritative
 	// view without touching boltdb or the cubecow SDK directly.
@@ -328,6 +343,9 @@ func (UnimplementedCubeboxMgrServer) GetLocalSnapshot(context.Context, *GetLocal
 }
 func (UnimplementedCubeboxMgrServer) GetStorageMetrics(context.Context, *GetStorageMetricsRequest) (*GetStorageMetricsResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method GetStorageMetrics not implemented")
+}
+func (UnimplementedCubeboxMgrServer) GetSandboxMetrics(context.Context, *GetSandboxMetricsRequest) (*GetSandboxMetricsResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method GetSandboxMetrics not implemented")
 }
 func (UnimplementedCubeboxMgrServer) InspectStorageVolumes(context.Context, *InspectStorageVolumesRequest) (*InspectStorageVolumesResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method InspectStorageVolumes not implemented")
@@ -590,6 +608,24 @@ func _CubeboxMgr_GetStorageMetrics_Handler(srv interface{}, ctx context.Context,
 	return interceptor(ctx, in, info, handler)
 }
 
+func _CubeboxMgr_GetSandboxMetrics_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(GetSandboxMetricsRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(CubeboxMgrServer).GetSandboxMetrics(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: CubeboxMgr_GetSandboxMetrics_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(CubeboxMgrServer).GetSandboxMetrics(ctx, req.(*GetSandboxMetricsRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 func _CubeboxMgr_InspectStorageVolumes_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
 	in := new(InspectStorageVolumesRequest)
 	if err := dec(in); err != nil {
@@ -684,6 +720,10 @@ var CubeboxMgr_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "GetStorageMetrics",
 			Handler:    _CubeboxMgr_GetStorageMetrics_Handler,
+		},
+		{
+			MethodName: "GetSandboxMetrics",
+			Handler:    _CubeboxMgr_GetSandboxMetrics_Handler,
 		},
 		{
 			MethodName: "InspectStorageVolumes",

--- a/Cubelet/doc/cubelet-api.md
+++ b/Cubelet/doc/cubelet-api.md
@@ -43,6 +43,8 @@
     - [ExecCubeSandboxResponse](#cubelet-services-cubebox-v1-ExecCubeSandboxResponse)
     - [GetLocalSnapshotRequest](#cubelet-services-cubebox-v1-GetLocalSnapshotRequest)
     - [GetLocalSnapshotResponse](#cubelet-services-cubebox-v1-GetLocalSnapshotResponse)
+    - [GetSandboxMetricsRequest](#cubelet-services-cubebox-v1-GetSandboxMetricsRequest)
+    - [GetSandboxMetricsResponse](#cubelet-services-cubebox-v1-GetSandboxMetricsResponse)
     - [GetStorageMetricsRequest](#cubelet-services-cubebox-v1-GetStorageMetricsRequest)
     - [GetStorageMetricsResponse](#cubelet-services-cubebox-v1-GetStorageMetricsResponse)
     - [GetStorageMetricsResponse.MetricsEntry](#cubelet-services-cubebox-v1-GetStorageMetricsResponse-MetricsEntry)
@@ -85,6 +87,7 @@
     - [RunCubeSandboxResponse](#cubelet-services-cubebox-v1-RunCubeSandboxResponse)
     - [RunCubeSandboxResponse.ExtInfoEntry](#cubelet-services-cubebox-v1-RunCubeSandboxResponse-ExtInfoEntry)
     - [SELinuxOption](#cubelet-services-cubebox-v1-SELinuxOption)
+    - [SandboxMetric](#cubelet-services-cubebox-v1-SandboxMetric)
     - [SandboxPathVolumeSource](#cubelet-services-cubebox-v1-SandboxPathVolumeSource)
     - [SandboxStorageInfo](#cubelet-services-cubebox-v1-SandboxStorageInfo)
     - [StorageOrphanEntry](#cubelet-services-cubebox-v1-StorageOrphanEntry)
@@ -931,6 +934,40 @@ EmptyDirVolumeSource represents an empty directory for a sandbox.
 
 
 
+<a name="cubelet-services-cubebox-v1-GetSandboxMetricsRequest"></a>
+
+### GetSandboxMetricsRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| requestID | [string](#string) |  | requestID reqID |
+| sandboxID | [string](#string) |  | Sandbox identifier to inspect. |
+
+
+
+
+
+
+<a name="cubelet-services-cubebox-v1-GetSandboxMetricsResponse"></a>
+
+### GetSandboxMetricsResponse
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| requestID | [string](#string) |  | requestID reqID |
+| ret | [cubelet.services.errorcode.v1.Ret](#cubelet-services-errorcode-v1-Ret) |  | Ret. |
+| sandboxID | [string](#string) |  | Sandbox identifier that produced this metric snapshot. |
+| metrics | [SandboxMetric](#cubelet-services-cubebox-v1-SandboxMetric) | repeated | Current sandbox metric snapshot. Empty when no sample is available. |
+
+
+
+
+
+
 <a name="cubelet-services-cubebox-v1-GetStorageMetricsRequest"></a>
 
 ### GetStorageMetricsRequest
@@ -1672,6 +1709,28 @@ SELinuxOption are the labels to be applied to the container.
 
 
 
+<a name="cubelet-services-cubebox-v1-SandboxMetric"></a>
+
+### SandboxMetric
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| timestamp_unix_nano | [int64](#int64) |  | Timestamp when metrics were collected. |
+| cpu_count | [int32](#int32) |  | Number of CPU cores assigned to the sandbox. |
+| cpu_used_pct | [double](#double) |  | CPU usage percentage. Best-effort in the current implementation. |
+| mem_used | [int64](#int64) |  | Memory used in bytes. Best-effort in the current implementation. |
+| mem_total | [int64](#int64) |  | Total memory in bytes. |
+| mem_cache | [int64](#int64) |  | Cached memory in bytes. Best-effort in the current implementation. |
+| disk_used | [int64](#int64) |  | Disk used in bytes. Best-effort in the current implementation. |
+| disk_total | [int64](#int64) |  | Total sandbox disk quota in bytes. |
+
+
+
+
+
+
 <a name="cubelet-services-cubebox-v1-SandboxPathVolumeSource"></a>
 
 ### SandboxPathVolumeSource
@@ -1995,6 +2054,7 @@ Service for handling cubesandbox
 | ListLocalSnapshots | [ListLocalSnapshotsRequest](#cubelet-services-cubebox-v1-ListLocalSnapshotsRequest) | [ListLocalSnapshotsResponse](#cubelet-services-cubebox-v1-ListLocalSnapshotsResponse) | ListLocalSnapshots returns the full catalog of snapshots known to this node. It is intended for master discovery / inspection so master does not need to persist physical references (vol/dev/path/meta_dir) in its tables. |
 | GetLocalSnapshot | [GetLocalSnapshotRequest](#cubelet-services-cubebox-v1-GetLocalSnapshotRequest) | [GetLocalSnapshotResponse](#cubelet-services-cubebox-v1-GetLocalSnapshotResponse) | GetLocalSnapshot returns the physical catalog entry for a single snapshot by snapshot id. Returns PreConditionFailed when no local record exists. |
 | GetStorageMetrics | [GetStorageMetricsRequest](#cubelet-services-cubebox-v1-GetStorageMetricsRequest) | [GetStorageMetricsResponse](#cubelet-services-cubebox-v1-GetStorageMetricsResponse) | GetStorageMetrics returns node-local cubecow storage metrics. |
+| GetSandboxMetrics | [GetSandboxMetricsRequest](#cubelet-services-cubebox-v1-GetSandboxMetricsRequest) | [GetSandboxMetricsResponse](#cubelet-services-cubebox-v1-GetSandboxMetricsResponse) | GetSandboxMetrics returns the current metrics snapshot for one sandbox. |
 | InspectStorageVolumes | [InspectStorageVolumesRequest](#cubelet-services-cubebox-v1-InspectStorageVolumesRequest) | [InspectStorageVolumesResponse](#cubelet-services-cubebox-v1-InspectStorageVolumesResponse) | InspectStorageVolumes lists every sandbox storage record cubelet owns and re-resolves cubecow device paths so cubecli can render an authoritative view without touching boltdb or the cubecow SDK directly. |
 | CleanupOrphanStorageFiles | [CleanupOrphanStorageFilesRequest](#cubelet-services-cubebox-v1-CleanupOrphanStorageFilesRequest) | [CleanupOrphanStorageFilesResponse](#cubelet-services-cubebox-v1-CleanupOrphanStorageFilesResponse) | CleanupOrphanStorageFiles scans configured emptydir format roots, drops files that have no live sandbox owner, and reports the action taken. |
 

--- a/Cubelet/services/cubebox/sandbox_metrics.go
+++ b/Cubelet/services/cubebox/sandbox_metrics.go
@@ -1,0 +1,311 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+// Sandbox metrics are served as a Cubelet gRPC method and collected from envd
+// on demand. The gRPC request/response shape is defined in cubebox.proto; this
+// file implements the server side and the envd HTTP fetch.
+//
+// Flow with fallback branch:
+//
+//	CubeMaster
+//	   |
+//	   | gRPC GetSandboxMetrics(sandboxID)
+//	   v
+//	Cubelet services/cubebox
+//	   |
+//	   | 1. load CubeBox metadata from local store
+//	   | 2. build a fallback snapshot from resource quotas
+//	   | 3. GET http://<sandbox-ip>:49983/metrics from envd
+//	   |
+//	   +-- envd returns JSON
+//	   |      |
+//	   |      v
+//	   |   merge live usage into fallback snapshot
+//	   |
+//	   +-- envd request fails or old envd has no endpoint
+//	          |
+//	          v
+//	       keep fallback snapshot
+//	   |
+//	   v
+//	return one current metrics point to CubeMaster
+//
+// If envd is not reachable, Cubelet still returns the fallback snapshot so old
+// templates or short startup races do not make the metrics API fail outright.
+package cubebox
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"k8s.io/apimachinery/pkg/api/resource"
+
+	"github.com/tencentcloud/CubeSandbox/Cubelet/api/services/cubebox/v1"
+	"github.com/tencentcloud/CubeSandbox/Cubelet/api/services/errorcode/v1"
+	"github.com/tencentcloud/CubeSandbox/Cubelet/pkg/log"
+	"github.com/tencentcloud/CubeSandbox/Cubelet/pkg/pathutil"
+	cubeboxstore "github.com/tencentcloud/CubeSandbox/Cubelet/pkg/store/cubebox"
+	"github.com/tencentcloud/CubeSandbox/Cubelet/pkg/utils"
+)
+
+const bytesPerMiB = int64(1024 * 1024)
+
+const (
+	envdMetricsPath    = "/metrics"
+	envdMetricsTimeout = 500 * time.Millisecond
+)
+
+type envdSandboxMetrics struct {
+	Timestamp      int64   `json:"ts"`
+	CPUCount       int64   `json:"cpu_count"`
+	CPUUsedPercent float64 `json:"cpu_used_pct"`
+	MemTotal       int64   `json:"mem_total"`
+	MemUsed        int64   `json:"mem_used"`
+	MemCache       int64   `json:"mem_cache"`
+	DiskUsed       int64   `json:"disk_used"`
+	DiskTotal      int64   `json:"disk_total"`
+
+	// Older envd builds reported memory in MiB. Keep these as a compatibility
+	// bridge so mixed template fleets still produce useful totals.
+	MemTotalMiB int64 `json:"mem_total_mib"`
+	MemUsedMiB  int64 `json:"mem_used_mib"`
+}
+
+// GetSandboxMetrics implements the Cubelet gRPC endpoint used by CubeMaster to
+// fetch one sandbox's current metrics snapshot.
+func (s *service) GetSandboxMetrics(ctx context.Context, req *cubebox.GetSandboxMetricsRequest) (*cubebox.GetSandboxMetricsResponse, error) {
+	sandboxID := strings.TrimSpace(req.GetSandboxID())
+	rsp := &cubebox.GetSandboxMetricsResponse{
+		RequestID: req.GetRequestID(),
+		SandboxID: sandboxID,
+		Ret:       &errorcode.Ret{RetCode: errorcode.ErrorCode_Success},
+	}
+	if sandboxID == "" {
+		rsp.Ret.RetCode = errorcode.ErrorCode_InvalidParamFormat
+		rsp.Ret.RetMsg = "sandboxID is required"
+		return rsp, nil
+	}
+	if err := pathutil.ValidateSafeID(sandboxID); err != nil {
+		rsp.Ret.RetCode = errorcode.ErrorCode_InvalidParamFormat
+		rsp.Ret.RetMsg = fmt.Sprintf("invalid sandboxID: %v", err)
+		return rsp, nil
+	}
+	if s.cubeboxMgr == nil || s.cubeboxMgr.cubeboxManger == nil {
+		rsp.Ret.RetCode = errorcode.ErrorCode_PreConditionFailed
+		rsp.Ret.RetMsg = "cubebox manager is not ready"
+		return rsp, nil
+	}
+	cb, err := s.cubeboxMgr.cubeboxManger.Get(ctx, sandboxID)
+	if err != nil {
+		rsp.Ret.RetCode = errorcode.ErrorCode_PreConditionFailed
+		if errors.Is(err, utils.ErrorKeyNotFound) || utils.IsNotFound(err) {
+			rsp.Ret.RetMsg = fmt.Sprintf("sandbox %s not found", sandboxID)
+		} else {
+			rsp.Ret.RetMsg = fmt.Sprintf("failed to get sandbox %s: %v", sandboxID, err)
+		}
+		return rsp, nil
+	}
+	metric := currentSandboxMetric(cb, time.Now())
+	if err := s.cubeboxMgr.mergeEnvdSandboxMetric(ctx, cb, metric); err != nil {
+		log.G(ctx).Warnf("GetSandboxMetrics envd metrics fallback sandbox=%s: %v", sandboxID, err)
+	}
+	rsp.Metrics = []*cubebox.SandboxMetric{metric}
+	return rsp, nil
+}
+
+// mergeEnvdSandboxMetric overlays envd's live usage metrics onto the fallback
+// snapshot built from CubeBox metadata.
+func (l *local) mergeEnvdSandboxMetric(ctx context.Context, cb *cubeboxstore.CubeBox, metric *cubebox.SandboxMetric) error {
+	if cb == nil || metric == nil {
+		return nil
+	}
+	sandboxIP := strings.TrimSpace(cb.IP)
+	if sandboxIP == "" || sandboxIP == "<nil>" {
+		return fmt.Errorf("sandbox IP is empty")
+	}
+
+	envdMetric, err := l.getEnvdSandboxMetric(ctx, sandboxIP)
+	if err != nil {
+		return err
+	}
+	if envdMetric.Timestamp > 0 {
+		metric.TimestampUnixNano = time.Unix(envdMetric.Timestamp, 0).UnixNano()
+	}
+	if envdMetric.CPUCount > 0 {
+		metric.CpuCount = int32(envdMetric.CPUCount)
+	}
+	metric.CpuUsedPct = envdMetric.CPUUsedPercent
+	if envdMetric.MemTotal > 0 {
+		metric.MemTotal = envdMetric.MemTotal
+	} else if envdMetric.MemTotalMiB > 0 {
+		metric.MemTotal = envdMetric.MemTotalMiB * bytesPerMiB
+	}
+	if envdMetric.MemUsed > 0 {
+		metric.MemUsed = envdMetric.MemUsed
+	} else if envdMetric.MemUsedMiB > 0 {
+		metric.MemUsed = envdMetric.MemUsedMiB * bytesPerMiB
+	}
+	metric.MemCache = envdMetric.MemCache
+	metric.DiskUsed = envdMetric.DiskUsed
+	if envdMetric.DiskTotal > 0 {
+		metric.DiskTotal = envdMetric.DiskTotal
+	}
+	return nil
+}
+
+// getEnvdSandboxMetric fetches envd's E2B-compatible JSON metrics endpoint from
+// inside the sandbox network namespace.
+func (l *local) getEnvdSandboxMetric(ctx context.Context, sandboxIP string) (*envdSandboxMetrics, error) {
+	reqCtx, cancel := context.WithTimeout(ctx, envdMetricsTimeout)
+	defer cancel()
+
+	reqURL := formatURL("http", sandboxIP, l.getEnvdInitPort(), envdMetricsPath)
+	httpReq, err := http.NewRequestWithContext(reqCtx, http.MethodGet, reqURL.String(), nil)
+	if err != nil {
+		return nil, fmt.Errorf("build envd metrics request: %w", err)
+	}
+	httpReq.Header.Set("Accept", "application/json")
+	httpReq.Header.Set("User-Agent", userAgent("sandbox-metrics"))
+
+	resp, err := l.getEnvdHTTPClient().Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("envd metrics request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return nil, fmt.Errorf("read envd metrics response body: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("envd metrics returned HTTP %d: %s", resp.StatusCode, strings.TrimSpace(string(respBody)))
+	}
+
+	var metric envdSandboxMetrics
+	if err := json.Unmarshal(respBody, &metric); err != nil {
+		return nil, fmt.Errorf("decode envd metrics response: %w", err)
+	}
+	return &metric, nil
+}
+
+func currentSandboxMetric(cb *cubeboxstore.CubeBox, now time.Time) *cubebox.SandboxMetric {
+	if cb == nil {
+		return &cubebox.SandboxMetric{TimestampUnixNano: now.UnixNano()}
+	}
+	return &cubebox.SandboxMetric{
+		TimestampUnixNano: now.UnixNano(),
+		CpuCount:          sandboxCPUCount(cb),
+		CpuUsedPct:        0,
+		MemUsed:           0,
+		MemTotal:          sandboxMemoryTotalBytes(cb),
+		MemCache:          0,
+		DiskUsed:          0,
+		DiskTotal:         sandboxDiskTotalBytes(cb),
+	}
+}
+
+func sandboxCPUCount(cb *cubeboxstore.CubeBox) int32 {
+	if cb == nil {
+		return 0
+	}
+	if cb.ResourceWithOverHead != nil {
+		if milli := cb.ResourceWithOverHead.VmCpuQ.MilliValue(); milli > 0 {
+			return int32((milli + 999) / 1000)
+		}
+		if milli := cb.ResourceWithOverHead.HostCpuQ.MilliValue(); milli > 0 {
+			return int32((milli + 999) / 1000)
+		}
+	}
+	if res := firstContainerResources(cb); res != nil {
+		if v := quantityMilli(res.GetCpuLimit()); v > 0 {
+			return int32((v + 999) / 1000)
+		}
+		if v := quantityMilli(res.GetCpu()); v > 0 {
+			return int32((v + 999) / 1000)
+		}
+	}
+	return 0
+}
+
+func sandboxMemoryTotalBytes(cb *cubeboxstore.CubeBox) int64 {
+	if cb == nil {
+		return 0
+	}
+	if cb.ResourceWithOverHead != nil {
+		if v := cb.ResourceWithOverHead.VmMemQ.Value(); v > 0 {
+			return v
+		}
+		if v := cb.ResourceWithOverHead.HostMemQ.Value(); v > 0 {
+			return v
+		}
+		if v := cb.ResourceWithOverHead.MemReq.Value(); v > 0 {
+			return v
+		}
+	}
+	if res := firstContainerResources(cb); res != nil {
+		if v := quantityValue(res.GetMemLimit()); v > 0 {
+			return v
+		}
+		if v := quantityValue(res.GetMem()); v > 0 {
+			return v
+		}
+	}
+	return 0
+}
+
+func sandboxDiskTotalBytes(cb *cubeboxstore.CubeBox) int64 {
+	if cb == nil || cb.ResourceWithOverHead == nil {
+		return 0
+	}
+	totalMB := cb.ResourceWithOverHead.HostDataDiskMB + cb.ResourceWithOverHead.HostStorageDiskMB
+	if totalMB <= 0 {
+		return 0
+	}
+	return totalMB * bytesPerMiB
+}
+
+func firstContainerResources(cb *cubeboxstore.CubeBox) *cubebox.Resource {
+	if cb == nil {
+		return nil
+	}
+	id := cb.FirstContainerName
+	if id == "" {
+		id = cb.ID
+	}
+	var c *cubeboxstore.Container
+	if cb.ContainersMap != nil {
+		if got, err := cb.ContainersMap.Get(id); err == nil {
+			c = got
+		}
+	}
+	if c == nil && cb.Containers != nil {
+		c = cb.Containers[id]
+	}
+	if c == nil || c.Config == nil {
+		return nil
+	}
+	return c.Config.GetResources()
+}
+
+func quantityMilli(raw string) int64 {
+	q, err := resource.ParseQuantity(strings.TrimSpace(raw))
+	if err != nil {
+		return 0
+	}
+	return q.MilliValue()
+}
+
+func quantityValue(raw string) int64 {
+	q, err := resource.ParseQuantity(strings.TrimSpace(raw))
+	if err != nil {
+		return 0
+	}
+	return q.Value()
+}

--- a/Cubelet/services/cubebox/sandbox_metrics_test.go
+++ b/Cubelet/services/cubebox/sandbox_metrics_test.go
@@ -1,0 +1,204 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package cubebox
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/api/resource"
+
+	cubeboxv1 "github.com/tencentcloud/CubeSandbox/Cubelet/api/services/cubebox/v1"
+	cubeboxstore "github.com/tencentcloud/CubeSandbox/Cubelet/pkg/store/cubebox"
+)
+
+func TestCurrentSandboxMetricUsesCubeboxResourceSnapshot(t *testing.T) {
+	cb := &cubeboxstore.CubeBox{
+		Metadata: cubeboxstore.Metadata{
+			ID: "sandbox-1",
+			ResourceWithOverHead: &cubeboxstore.ResourceWithOverHead{
+				VmCpuQ:            resource.MustParse("2500m"),
+				VmMemQ:            resource.MustParse("512Mi"),
+				HostDataDiskMB:    100,
+				HostStorageDiskMB: 25,
+			},
+		},
+	}
+	now := time.Unix(1700000000, 123)
+
+	metric := currentSandboxMetric(cb, now)
+
+	assert.Equal(t, now.UnixNano(), metric.GetTimestampUnixNano())
+	assert.Equal(t, int32(3), metric.GetCpuCount())
+	assert.Equal(t, int64(512*1024*1024), metric.GetMemTotal())
+	assert.Equal(t, int64(125*1024*1024), metric.GetDiskTotal())
+	assert.Zero(t, metric.GetCpuUsedPct())
+	assert.Zero(t, metric.GetMemUsed())
+	assert.Zero(t, metric.GetMemCache())
+	assert.Zero(t, metric.GetDiskUsed())
+}
+
+func TestMergeEnvdSandboxMetricUsesEnvdUsageSnapshot(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, envdMetricsPath, r.URL.Path)
+		assert.True(t, strings.HasPrefix(r.Header.Get("User-Agent"), "cubelet-sandbox-metrics/"))
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"ts": 1700000001,
+			"cpu_count": 4,
+			"cpu_used_pct": 12.5,
+			"mem_total": 8192,
+			"mem_used": 4096,
+			"mem_cache": 512,
+			"disk_used": 2048,
+			"disk_total": 16384
+		}`))
+	}))
+	defer server.Close()
+	host, port := serverHostPort(t, server)
+	l := &local{envdHTTPClient: server.Client(), envdInitPort: port}
+	cb := &cubeboxstore.CubeBox{
+		Metadata: cubeboxstore.Metadata{
+			ID: "sandbox-1",
+			ResourceWithOverHead: &cubeboxstore.ResourceWithOverHead{
+				VmCpuQ:            resource.MustParse("2000m"),
+				VmMemQ:            resource.MustParse("512Mi"),
+				HostDataDiskMB:    100,
+				HostStorageDiskMB: 25,
+			},
+		},
+		IP: host,
+	}
+	metric := currentSandboxMetric(cb, time.Unix(1700000000, 0))
+
+	err := l.mergeEnvdSandboxMetric(context.Background(), cb, metric)
+
+	require.NoError(t, err)
+	assert.Equal(t, time.Unix(1700000001, 0).UnixNano(), metric.GetTimestampUnixNano())
+	assert.Equal(t, int32(4), metric.GetCpuCount())
+	assert.Equal(t, 12.5, metric.GetCpuUsedPct())
+	assert.Equal(t, int64(4096), metric.GetMemUsed())
+	assert.Equal(t, int64(8192), metric.GetMemTotal())
+	assert.Equal(t, int64(512), metric.GetMemCache())
+	assert.Equal(t, int64(2048), metric.GetDiskUsed())
+	assert.Equal(t, int64(16384), metric.GetDiskTotal())
+}
+
+func TestMergeEnvdSandboxMetricFallsBackToDeprecatedMemoryMiB(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{
+			"cpu_count": 1,
+			"cpu_used_pct": 2.5,
+			"mem_total_mib": 256,
+			"mem_used_mib": 64
+		}`))
+	}))
+	defer server.Close()
+	host, port := serverHostPort(t, server)
+	l := &local{envdHTTPClient: server.Client(), envdInitPort: port}
+	cb := &cubeboxstore.CubeBox{Metadata: cubeboxstore.Metadata{ID: "sandbox-1"}, IP: host}
+	metric := currentSandboxMetric(cb, time.Unix(1700000000, 0))
+
+	err := l.mergeEnvdSandboxMetric(context.Background(), cb, metric)
+
+	require.NoError(t, err)
+	assert.Equal(t, int64(256*1024*1024), metric.GetMemTotal())
+	assert.Equal(t, int64(64*1024*1024), metric.GetMemUsed())
+	assert.Equal(t, 2.5, metric.GetCpuUsedPct())
+}
+
+func TestGetSandboxMetricsFallsBackToResourceSnapshotWhenEnvdUnavailable(t *testing.T) {
+	cb := &cubeboxstore.CubeBox{
+		Metadata: cubeboxstore.Metadata{
+			ID: "sandbox-1",
+			ResourceWithOverHead: &cubeboxstore.ResourceWithOverHead{
+				VmCpuQ: resource.MustParse("1000m"),
+				VmMemQ: resource.MustParse("128Mi"),
+			},
+		},
+		IP: "127.0.0.1",
+	}
+	s := &service{
+		cubeboxMgr: &local{
+			cubeboxManger:  &fakeCubeboxAPI{cb: cb},
+			envdHTTPClient: serverThatAlwaysFails(t).Client(),
+			envdInitPort:   1,
+		},
+	}
+
+	rsp, err := s.GetSandboxMetrics(context.Background(), &cubeboxv1.GetSandboxMetricsRequest{SandboxID: "sandbox-1"})
+
+	require.NoError(t, err)
+	require.Len(t, rsp.GetMetrics(), 1)
+	metric := rsp.GetMetrics()[0]
+	assert.Equal(t, int32(1), metric.GetCpuCount())
+	assert.Equal(t, int64(128*1024*1024), metric.GetMemTotal())
+	assert.Zero(t, metric.GetCpuUsedPct())
+	assert.Zero(t, metric.GetMemUsed())
+}
+
+func TestCurrentSandboxMetricFallsBackToContainerResources(t *testing.T) {
+	cb := &cubeboxstore.CubeBox{
+		Metadata: cubeboxstore.Metadata{ID: "sandbox-1"},
+		ContainersMap: &cubeboxstore.ContainersMap{
+			ContainerMap: map[string]*cubeboxstore.Container{
+				"sandbox-1": {
+					Metadata: cubeboxstore.Metadata{
+						ID: "sandbox-1",
+						Config: &cubeboxv1.ContainerConfig{
+							Resources: &cubeboxv1.Resource{
+								CpuLimit: "1500m",
+								MemLimit: "256Mi",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	metric := currentSandboxMetric(cb, time.Unix(1700000000, 0))
+
+	assert.Equal(t, int32(2), metric.GetCpuCount())
+	assert.Equal(t, int64(256*1024*1024), metric.GetMemTotal())
+	assert.Zero(t, metric.GetDiskTotal())
+}
+
+func TestFirstContainerResourcesMissingContainerIsQuietFallback(t *testing.T) {
+	cb := &cubeboxstore.CubeBox{
+		Metadata:      cubeboxstore.Metadata{ID: "sandbox-1"},
+		ContainersMap: &cubeboxstore.ContainersMap{},
+	}
+
+	assert.Nil(t, firstContainerResources(cb))
+	assert.Zero(t, sandboxCPUCount(cb))
+	assert.Zero(t, sandboxMemoryTotalBytes(cb))
+}
+
+func serverHostPort(t *testing.T, server *httptest.Server) (string, int) {
+	t.Helper()
+	host, portStr, err := net.SplitHostPort(server.Listener.Addr().String())
+	require.NoError(t, err)
+	port, err := strconv.Atoi(portStr)
+	require.NoError(t, err)
+	return host, port
+}
+
+func serverThatAlwaysFails(t *testing.T) *httptest.Server {
+	t.Helper()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "not ready", http.StatusServiceUnavailable)
+	}))
+	t.Cleanup(server.Close)
+	return server
+}


### PR DESCRIPTION
## Summary

Related to #1021 

This PR implements the sandbox metrics API requested in the issue by adding `GET /sandboxes/{sandboxID}/metrics`, with optional `start` and `end` Unix timestamps in seconds. The endpoint returns an E2B-compatible JSON array containing the sample time, CPU allocation and utilization, memory usage, and disk usage for the requested sandbox.

This API gives users a standard way to inspect sandbox resource usage. It supports performance analysis, CPU and memory bottleneck detection, disk capacity monitoring, operational troubleshooting, sandbox health monitoring, and resource quota evaluation.

## Changes

The request flows through the following components:

```text
Client
  -> CubeAPI: GET /sandboxes/{sandboxID}/metrics
  -> CubeMaster: GET /cube/sandbox/metrics
  -> Cubelet: gRPC GetSandboxMetrics
  -> envd: GET http://<sandbox-ip>:49983/metrics
```

CubeAPI registers the public route, validates the optional time range, calls CubeMaster, maps internal errors to public API errors, and converts the response to the E2B-compatible JSON format. The related files are:

- `CubeAPI/src/routes.rs`
- `CubeAPI/src/handlers/sandboxes.rs`
- `CubeAPI/src/models/mod.rs`
- `CubeAPI/src/cubemaster/mod.rs`
- `CubeAPI/src/services/sandboxes.rs`

CubeMaster registers the internal HTTP endpoint, resolves the Cubelet that owns the sandbox, verifies that the node is available, calls Cubelet with the inherited request context, filters the current sample using `start` and `end`, and returns empty results as `[]`. The related files are:

- `CubeMaster/pkg/cubelet/actions.go`
- `CubeMaster/pkg/server/server_test.go`
- `CubeMaster/pkg/service/httpservice/cube/cube.go`
- `CubeMaster/pkg/service/httpservice/cube/routes.go`
- `CubeMaster/pkg/service/httpservice/cube/sandbox_metrics.go`
- `CubeMaster/pkg/service/httpservice/cube/sandbox_metrics_test.go`
- `CubeMaster/pkg/service/sandbox/sandbox_metrics.go`
- `CubeMaster/pkg/service/sandbox/sandbox_metrics_test.go`
- `CubeMaster/pkg/service/sandbox/types/types.go`

Cubelet adds the `GetSandboxMetrics` gRPC method, requests the current metrics from envd, and falls back to CubeBox resource metadata when envd is unavailable or does not provide a value. The protobuf definitions and generated Go files are updated on both the CubeMaster and Cubelet sides. The related files are:

- `CubeMaster/api/services/cubebox/v1/cubebox.proto`
- `CubeMaster/api/services/cubebox/v1/cubebox.pb.go`
- `CubeMaster/api/services/cubebox/v1/cubebox_grpc.pb.go`
- `Cubelet/api/services/cubebox/v1/cubebox.proto`
- `Cubelet/api/services/cubebox/v1/cubebox.pb.go`
- `Cubelet/api/services/cubebox/v1/cubebox_grpc.pb.go`
- `Cubelet/services/cubebox/sandbox_metrics.go`
- `Cubelet/services/cubebox/sandbox_metrics_test.go`
- `Cubelet/doc/cubelet-api.md`

## Limitations and TODO

This PR provides a real-time metrics snapshot and does not persist metrics. The optional `start` and `end` parameters only determine whether the current sample falls within the requested range; they do not query historical samples.

The remaining work is split into three follow-up PRs, in priority order:

1. Add periodic metrics collection and persistence, and implement E2B-compatible historical range queries so `start` and `end` return all samples within the requested time window.
2. Replace the MVP collector with HA-safe, node-batched metrics collection for multi-node and multi-CubeMaster deployments.
3. Improve query and storage scalability with dynamic downsampling, query protection, retention hardening, and complete observability.