### PR TITLE
test(cubemaster): resolve unit test debt in builder CI

### DIFF
--- a/.github/workflows/unit-test-check.yml
+++ b/.github/workflows/unit-test-check.yml
@@ -8,6 +8,7 @@ on:
       - 'CubeOps/**'
       - 'CubeDB/**'
       - 'CubeProxy/**'
+      - 'CubeMaster/**'
       - 'CubeShim/**'
       - 'CubeNet/**'
       - 'network-agent/**'
@@ -21,6 +22,7 @@ on:
       - 'CubeOps/**'
       - 'CubeDB/**'
       - 'CubeProxy/**'
+      - 'CubeMaster/**'
       - 'CubeShim/**'
       - 'CubeNet/**'
       - 'network-agent/**'
@@ -39,6 +41,7 @@ on:
           - all
           - cubeapi
           - cubeproxy
+          - cubemaster
           - cubeshim
           - network-agent
 
@@ -88,6 +91,7 @@ jobs:
             add_component "CubeAPI"
             add_component "CubeOps"
             add_component "CubeProxy"
+            add_component "CubeMaster"
             add_component "CubeShim"
             add_component "network-agent"
           }
@@ -99,6 +103,7 @@ jobs:
               cubeapi) add_component "CubeAPI" ;;
               cubeops) add_component "CubeOps" ;;
               cubeproxy) add_component "CubeProxy" ;;
+              cubemaster) add_component "CubeMaster" ;;
               cubeshim) add_component "CubeShim" ;;
               network-agent) add_component "network-agent" ;;
               *)
@@ -138,6 +143,9 @@ jobs:
                 CubeProxy/*)
                   add_component "CubeProxy"
                   ;;
+                CubeMaster/*)
+                  add_component "CubeMaster"
+                  ;;
                 CubeShim/*)
                   add_component "CubeShim"
                   ;;
@@ -163,6 +171,7 @@ jobs:
                     if . == "CubeAPI" then "CubeAPI"
                     elif . == "CubeOps" then "CubeOps"
                     elif . == "CubeProxy" then "CubeProxy"
+                    elif . == "CubeMaster" then "CubeMaster"
                     elif . == "CubeShim" then "CubeShim"
                     elif . == "network-agent" then "Network Agent"
                     else error("unsupported component: " + .)
@@ -172,6 +181,7 @@ jobs:
                     if . == "CubeAPI" then "cube-api-test"
                     elif . == "CubeOps" then "cubeops-test"
                     elif . == "CubeProxy" then "cube-proxy-test"
+                    elif . == "CubeMaster" then "cubemaster-test"
                     elif . == "CubeShim" then "shim-test"
                     elif . == "network-agent" then "network-agent-test"
                     else error("unsupported component: " + .)

--- a/CubeMaster/Makefile
+++ b/CubeMaster/Makefile
@@ -99,8 +99,7 @@ test:
 	$(Q)go clean -testcache
 	$(Q)mkdir -p coverage
 	@( for pkg in ${COVERAGE_PACKAGES}; do \
-		if [ -f "$(ROOT_DIR)/test/conf.yaml" ]; then export CUBE_MASTER_CONFIG_PATH="$(ROOT_DIR)/test/conf.yaml"; fi; \
-		CI=true && go test -v -timeout=20m ${TEST_FLAGS} \
+		CI=true go test -short -v -timeout=20m ${TEST_FLAGS} \
 			-coverprofile=coverage/unit-test-`echo $$pkg | tr "/" "_"`.cov \
 			$$pkg || exit 1 ;\
 	done )
@@ -141,4 +140,3 @@ push-image-dev:
 
 push-image-release:
 	$(call push-images,release)
-

--- a/CubeMaster/api/services/cubebox/v1/cubebox.pb.go
+++ b/CubeMaster/api/services/cubebox/v1/cubebox.pb.go
@@ -2539,7 +2539,11 @@ type VolumeSource struct {
 	// host_dir_volumes shares host directories into the container via virtiofs.
 	HostDirVolumes *HostDirVolumeSources `protobuf:"bytes,7,opt,name=host_dir_volumes,json=hostDirVolumes,proto3" json:"host_dir_volumes,omitempty"`
 	// image volume source for image volume mount
-	Image         *v1.ImageVolumeSource `protobuf:"bytes,9,opt,name=image,proto3" json:"image,omitempty"`
+	Image *v1.ImageVolumeSource `protobuf:"bytes,9,opt,name=image,proto3" json:"image,omitempty"`
+	// plugin_volume delegates provisioning to a named external VolumePlugin
+	// registered in Cubelet's volume.Manager.  Field number matches
+	// Cubelet's cubebox.proto to ensure wire compatibility.
+	PluginVolume  *PluginVolumeSource `protobuf:"bytes,11,opt,name=plugin_volume,json=pluginVolume,proto3" json:"plugin_volume,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -2602,6 +2606,71 @@ func (x *VolumeSource) GetImage() *v1.ImageVolumeSource {
 	return nil
 }
 
+func (x *VolumeSource) GetPluginVolume() *PluginVolumeSource {
+	if x != nil {
+		return x.PluginVolume
+	}
+	return nil
+}
+
+// PluginVolumeSource selects an external volume plugin by driver name.
+// Mirrors cubelet.services.volumeplugin.v1.PluginVolumeSource for
+// wire-format compatibility (same field numbers).
+type PluginVolumeSource struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// driver is the registered plugin name (e.g. "cos", "nfs").
+	Driver string `protobuf:"bytes,1,opt,name=driver,proto3" json:"driver,omitempty"`
+	// options are driver-specific key-value pairs forwarded to the plugin.
+	// MUST include "volume_id".
+	Options       map[string]string `protobuf:"bytes,2,rep,name=options,proto3" json:"options,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *PluginVolumeSource) Reset() {
+	*x = PluginVolumeSource{}
+	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[32]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *PluginVolumeSource) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*PluginVolumeSource) ProtoMessage() {}
+
+func (x *PluginVolumeSource) ProtoReflect() protoreflect.Message {
+	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[32]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use PluginVolumeSource.ProtoReflect.Descriptor instead.
+func (*PluginVolumeSource) Descriptor() ([]byte, []int) {
+	return file_api_services_cubebox_v1_cubebox_proto_rawDescGZIP(), []int{32}
+}
+
+func (x *PluginVolumeSource) GetDriver() string {
+	if x != nil {
+		return x.Driver
+	}
+	return ""
+}
+
+func (x *PluginVolumeSource) GetOptions() map[string]string {
+	if x != nil {
+		return x.Options
+	}
+	return nil
+}
+
 // Volume represents a named volume in a pod that may be accessed by any container in the pod.
 type Volume struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
@@ -2617,7 +2686,7 @@ type Volume struct {
 
 func (x *Volume) Reset() {
 	*x = Volume{}
-	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[32]
+	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[33]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2629,7 +2698,7 @@ func (x *Volume) String() string {
 func (*Volume) ProtoMessage() {}
 
 func (x *Volume) ProtoReflect() protoreflect.Message {
-	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[32]
+	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[33]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2642,7 +2711,7 @@ func (x *Volume) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Volume.ProtoReflect.Descriptor instead.
 func (*Volume) Descriptor() ([]byte, []int) {
-	return file_api_services_cubebox_v1_cubebox_proto_rawDescGZIP(), []int{32}
+	return file_api_services_cubebox_v1_cubebox_proto_rawDescGZIP(), []int{33}
 }
 
 func (x *Volume) GetName() string {
@@ -2697,7 +2766,7 @@ type RunCubeSandboxRequest struct {
 
 func (x *RunCubeSandboxRequest) Reset() {
 	*x = RunCubeSandboxRequest{}
-	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[33]
+	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[34]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2709,7 +2778,7 @@ func (x *RunCubeSandboxRequest) String() string {
 func (*RunCubeSandboxRequest) ProtoMessage() {}
 
 func (x *RunCubeSandboxRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[33]
+	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[34]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2722,7 +2791,7 @@ func (x *RunCubeSandboxRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RunCubeSandboxRequest.ProtoReflect.Descriptor instead.
 func (*RunCubeSandboxRequest) Descriptor() ([]byte, []int) {
-	return file_api_services_cubebox_v1_cubebox_proto_rawDescGZIP(), []int{33}
+	return file_api_services_cubebox_v1_cubebox_proto_rawDescGZIP(), []int{34}
 }
 
 func (x *RunCubeSandboxRequest) GetRequestID() string {
@@ -2822,7 +2891,7 @@ type RunCubeSandboxResponse struct {
 
 func (x *RunCubeSandboxResponse) Reset() {
 	*x = RunCubeSandboxResponse{}
-	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[34]
+	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[35]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2834,7 +2903,7 @@ func (x *RunCubeSandboxResponse) String() string {
 func (*RunCubeSandboxResponse) ProtoMessage() {}
 
 func (x *RunCubeSandboxResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[34]
+	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[35]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2847,7 +2916,7 @@ func (x *RunCubeSandboxResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RunCubeSandboxResponse.ProtoReflect.Descriptor instead.
 func (*RunCubeSandboxResponse) Descriptor() ([]byte, []int) {
-	return file_api_services_cubebox_v1_cubebox_proto_rawDescGZIP(), []int{34}
+	return file_api_services_cubebox_v1_cubebox_proto_rawDescGZIP(), []int{35}
 }
 
 func (x *RunCubeSandboxResponse) GetRequestID() string {
@@ -2911,7 +2980,7 @@ type PortMapping struct {
 
 func (x *PortMapping) Reset() {
 	*x = PortMapping{}
-	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[35]
+	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[36]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2923,7 +2992,7 @@ func (x *PortMapping) String() string {
 func (*PortMapping) ProtoMessage() {}
 
 func (x *PortMapping) ProtoReflect() protoreflect.Message {
-	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[35]
+	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[36]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2936,7 +3005,7 @@ func (x *PortMapping) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PortMapping.ProtoReflect.Descriptor instead.
 func (*PortMapping) Descriptor() ([]byte, []int) {
-	return file_api_services_cubebox_v1_cubebox_proto_rawDescGZIP(), []int{35}
+	return file_api_services_cubebox_v1_cubebox_proto_rawDescGZIP(), []int{36}
 }
 
 func (x *PortMapping) GetContainerPort() int32 {
@@ -2966,7 +3035,7 @@ type CubeNetworkConfig struct {
 
 func (x *CubeNetworkConfig) Reset() {
 	*x = CubeNetworkConfig{}
-	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[36]
+	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[37]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2978,7 +3047,7 @@ func (x *CubeNetworkConfig) String() string {
 func (*CubeNetworkConfig) ProtoMessage() {}
 
 func (x *CubeNetworkConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[36]
+	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[37]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2991,7 +3060,7 @@ func (x *CubeNetworkConfig) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CubeNetworkConfig.ProtoReflect.Descriptor instead.
 func (*CubeNetworkConfig) Descriptor() ([]byte, []int) {
-	return file_api_services_cubebox_v1_cubebox_proto_rawDescGZIP(), []int{36}
+	return file_api_services_cubebox_v1_cubebox_proto_rawDescGZIP(), []int{37}
 }
 
 func (x *CubeNetworkConfig) GetAllowInternetAccess() bool {
@@ -3033,7 +3102,7 @@ type EgressRule struct {
 
 func (x *EgressRule) Reset() {
 	*x = EgressRule{}
-	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[37]
+	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[38]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3045,7 +3114,7 @@ func (x *EgressRule) String() string {
 func (*EgressRule) ProtoMessage() {}
 
 func (x *EgressRule) ProtoReflect() protoreflect.Message {
-	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[37]
+	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[38]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3058,7 +3127,7 @@ func (x *EgressRule) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use EgressRule.ProtoReflect.Descriptor instead.
 func (*EgressRule) Descriptor() ([]byte, []int) {
-	return file_api_services_cubebox_v1_cubebox_proto_rawDescGZIP(), []int{37}
+	return file_api_services_cubebox_v1_cubebox_proto_rawDescGZIP(), []int{38}
 }
 
 func (x *EgressRule) GetName() string {
@@ -3095,7 +3164,7 @@ type EgressRuleMatch struct {
 
 func (x *EgressRuleMatch) Reset() {
 	*x = EgressRuleMatch{}
-	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[38]
+	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[39]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3107,7 +3176,7 @@ func (x *EgressRuleMatch) String() string {
 func (*EgressRuleMatch) ProtoMessage() {}
 
 func (x *EgressRuleMatch) ProtoReflect() protoreflect.Message {
-	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[38]
+	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[39]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3120,7 +3189,7 @@ func (x *EgressRuleMatch) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use EgressRuleMatch.ProtoReflect.Descriptor instead.
 func (*EgressRuleMatch) Descriptor() ([]byte, []int) {
-	return file_api_services_cubebox_v1_cubebox_proto_rawDescGZIP(), []int{38}
+	return file_api_services_cubebox_v1_cubebox_proto_rawDescGZIP(), []int{39}
 }
 
 func (x *EgressRuleMatch) GetSni() string {
@@ -3169,7 +3238,7 @@ type EgressRuleAction struct {
 
 func (x *EgressRuleAction) Reset() {
 	*x = EgressRuleAction{}
-	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[39]
+	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[40]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3181,7 +3250,7 @@ func (x *EgressRuleAction) String() string {
 func (*EgressRuleAction) ProtoMessage() {}
 
 func (x *EgressRuleAction) ProtoReflect() protoreflect.Message {
-	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[39]
+	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[40]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3194,7 +3263,7 @@ func (x *EgressRuleAction) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use EgressRuleAction.ProtoReflect.Descriptor instead.
 func (*EgressRuleAction) Descriptor() ([]byte, []int) {
-	return file_api_services_cubebox_v1_cubebox_proto_rawDescGZIP(), []int{39}
+	return file_api_services_cubebox_v1_cubebox_proto_rawDescGZIP(), []int{40}
 }
 
 func (x *EgressRuleAction) GetAllow() bool {
@@ -3229,7 +3298,7 @@ type EgressRuleInject struct {
 
 func (x *EgressRuleInject) Reset() {
 	*x = EgressRuleInject{}
-	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[40]
+	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[41]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3241,7 +3310,7 @@ func (x *EgressRuleInject) String() string {
 func (*EgressRuleInject) ProtoMessage() {}
 
 func (x *EgressRuleInject) ProtoReflect() protoreflect.Message {
-	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[40]
+	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[41]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3254,7 +3323,7 @@ func (x *EgressRuleInject) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use EgressRuleInject.ProtoReflect.Descriptor instead.
 func (*EgressRuleInject) Descriptor() ([]byte, []int) {
-	return file_api_services_cubebox_v1_cubebox_proto_rawDescGZIP(), []int{40}
+	return file_api_services_cubebox_v1_cubebox_proto_rawDescGZIP(), []int{41}
 }
 
 func (x *EgressRuleInject) GetHeader() string {
@@ -3298,7 +3367,7 @@ type DestroyCubeSandboxRequest struct {
 
 func (x *DestroyCubeSandboxRequest) Reset() {
 	*x = DestroyCubeSandboxRequest{}
-	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[41]
+	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[42]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3310,7 +3379,7 @@ func (x *DestroyCubeSandboxRequest) String() string {
 func (*DestroyCubeSandboxRequest) ProtoMessage() {}
 
 func (x *DestroyCubeSandboxRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[41]
+	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[42]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3323,7 +3392,7 @@ func (x *DestroyCubeSandboxRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DestroyCubeSandboxRequest.ProtoReflect.Descriptor instead.
 func (*DestroyCubeSandboxRequest) Descriptor() ([]byte, []int) {
-	return file_api_services_cubebox_v1_cubebox_proto_rawDescGZIP(), []int{41}
+	return file_api_services_cubebox_v1_cubebox_proto_rawDescGZIP(), []int{42}
 }
 
 func (x *DestroyCubeSandboxRequest) GetRequestID() string {
@@ -3369,7 +3438,7 @@ type DestroyCubeSandboxResponse struct {
 
 func (x *DestroyCubeSandboxResponse) Reset() {
 	*x = DestroyCubeSandboxResponse{}
-	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[42]
+	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[43]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3381,7 +3450,7 @@ func (x *DestroyCubeSandboxResponse) String() string {
 func (*DestroyCubeSandboxResponse) ProtoMessage() {}
 
 func (x *DestroyCubeSandboxResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[42]
+	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[43]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3394,7 +3463,7 @@ func (x *DestroyCubeSandboxResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DestroyCubeSandboxResponse.ProtoReflect.Descriptor instead.
 func (*DestroyCubeSandboxResponse) Descriptor() ([]byte, []int) {
-	return file_api_services_cubebox_v1_cubebox_proto_rawDescGZIP(), []int{42}
+	return file_api_services_cubebox_v1_cubebox_proto_rawDescGZIP(), []int{43}
 }
 
 func (x *DestroyCubeSandboxResponse) GetRequestID() string {
@@ -3450,7 +3519,7 @@ type CubeSandbox struct {
 
 func (x *CubeSandbox) Reset() {
 	*x = CubeSandbox{}
-	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[43]
+	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[44]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3462,7 +3531,7 @@ func (x *CubeSandbox) String() string {
 func (*CubeSandbox) ProtoMessage() {}
 
 func (x *CubeSandbox) ProtoReflect() protoreflect.Message {
-	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[43]
+	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[44]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3475,7 +3544,7 @@ func (x *CubeSandbox) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CubeSandbox.ProtoReflect.Descriptor instead.
 func (*CubeSandbox) Descriptor() ([]byte, []int) {
-	return file_api_services_cubebox_v1_cubebox_proto_rawDescGZIP(), []int{43}
+	return file_api_services_cubebox_v1_cubebox_proto_rawDescGZIP(), []int{44}
 }
 
 func (x *CubeSandbox) GetId() string {
@@ -3566,7 +3635,7 @@ type Container struct {
 
 func (x *Container) Reset() {
 	*x = Container{}
-	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[44]
+	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[45]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3578,7 +3647,7 @@ func (x *Container) String() string {
 func (*Container) ProtoMessage() {}
 
 func (x *Container) ProtoReflect() protoreflect.Message {
-	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[44]
+	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[45]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3591,7 +3660,7 @@ func (x *Container) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Container.ProtoReflect.Descriptor instead.
 func (*Container) Descriptor() ([]byte, []int) {
-	return file_api_services_cubebox_v1_cubebox_proto_rawDescGZIP(), []int{44}
+	return file_api_services_cubebox_v1_cubebox_proto_rawDescGZIP(), []int{45}
 }
 
 func (x *Container) GetId() string {
@@ -3668,7 +3737,7 @@ type ContainerStateValue struct {
 
 func (x *ContainerStateValue) Reset() {
 	*x = ContainerStateValue{}
-	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[45]
+	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[46]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3680,7 +3749,7 @@ func (x *ContainerStateValue) String() string {
 func (*ContainerStateValue) ProtoMessage() {}
 
 func (x *ContainerStateValue) ProtoReflect() protoreflect.Message {
-	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[45]
+	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[46]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3693,7 +3762,7 @@ func (x *ContainerStateValue) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ContainerStateValue.ProtoReflect.Descriptor instead.
 func (*ContainerStateValue) Descriptor() ([]byte, []int) {
-	return file_api_services_cubebox_v1_cubebox_proto_rawDescGZIP(), []int{45}
+	return file_api_services_cubebox_v1_cubebox_proto_rawDescGZIP(), []int{46}
 }
 
 func (x *ContainerStateValue) GetState() ContainerState {
@@ -3722,7 +3791,7 @@ type CubeSandboxFilter struct {
 
 func (x *CubeSandboxFilter) Reset() {
 	*x = CubeSandboxFilter{}
-	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[46]
+	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[47]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3734,7 +3803,7 @@ func (x *CubeSandboxFilter) String() string {
 func (*CubeSandboxFilter) ProtoMessage() {}
 
 func (x *CubeSandboxFilter) ProtoReflect() protoreflect.Message {
-	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[46]
+	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[47]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3747,7 +3816,7 @@ func (x *CubeSandboxFilter) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CubeSandboxFilter.ProtoReflect.Descriptor instead.
 func (*CubeSandboxFilter) Descriptor() ([]byte, []int) {
-	return file_api_services_cubebox_v1_cubebox_proto_rawDescGZIP(), []int{46}
+	return file_api_services_cubebox_v1_cubebox_proto_rawDescGZIP(), []int{47}
 }
 
 func (x *CubeSandboxFilter) GetState() *ContainerStateValue {
@@ -3784,7 +3853,7 @@ type ListCubeSandboxRequest struct {
 
 func (x *ListCubeSandboxRequest) Reset() {
 	*x = ListCubeSandboxRequest{}
-	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[47]
+	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[48]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3796,7 +3865,7 @@ func (x *ListCubeSandboxRequest) String() string {
 func (*ListCubeSandboxRequest) ProtoMessage() {}
 
 func (x *ListCubeSandboxRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[47]
+	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[48]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3809,7 +3878,7 @@ func (x *ListCubeSandboxRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListCubeSandboxRequest.ProtoReflect.Descriptor instead.
 func (*ListCubeSandboxRequest) Descriptor() ([]byte, []int) {
-	return file_api_services_cubebox_v1_cubebox_proto_rawDescGZIP(), []int{47}
+	return file_api_services_cubebox_v1_cubebox_proto_rawDescGZIP(), []int{48}
 }
 
 func (x *ListCubeSandboxRequest) GetId() string {
@@ -3843,7 +3912,7 @@ type ListCubeSandboxResponse struct {
 
 func (x *ListCubeSandboxResponse) Reset() {
 	*x = ListCubeSandboxResponse{}
-	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[48]
+	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[49]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3855,7 +3924,7 @@ func (x *ListCubeSandboxResponse) String() string {
 func (*ListCubeSandboxResponse) ProtoMessage() {}
 
 func (x *ListCubeSandboxResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[48]
+	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[49]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3868,7 +3937,7 @@ func (x *ListCubeSandboxResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListCubeSandboxResponse.ProtoReflect.Descriptor instead.
 func (*ListCubeSandboxResponse) Descriptor() ([]byte, []int) {
-	return file_api_services_cubebox_v1_cubebox_proto_rawDescGZIP(), []int{48}
+	return file_api_services_cubebox_v1_cubebox_proto_rawDescGZIP(), []int{49}
 }
 
 func (x *ListCubeSandboxResponse) GetItems() []*CubeSandbox {
@@ -3895,7 +3964,7 @@ type UpdateCubeSandboxRequest struct {
 
 func (x *UpdateCubeSandboxRequest) Reset() {
 	*x = UpdateCubeSandboxRequest{}
-	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[49]
+	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[50]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3907,7 +3976,7 @@ func (x *UpdateCubeSandboxRequest) String() string {
 func (*UpdateCubeSandboxRequest) ProtoMessage() {}
 
 func (x *UpdateCubeSandboxRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[49]
+	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[50]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3920,7 +3989,7 @@ func (x *UpdateCubeSandboxRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateCubeSandboxRequest.ProtoReflect.Descriptor instead.
 func (*UpdateCubeSandboxRequest) Descriptor() ([]byte, []int) {
-	return file_api_services_cubebox_v1_cubebox_proto_rawDescGZIP(), []int{49}
+	return file_api_services_cubebox_v1_cubebox_proto_rawDescGZIP(), []int{50}
 }
 
 func (x *UpdateCubeSandboxRequest) GetRequestID() string {
@@ -3956,7 +4025,7 @@ type UpdateCubeSandboxResponse struct {
 
 func (x *UpdateCubeSandboxResponse) Reset() {
 	*x = UpdateCubeSandboxResponse{}
-	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[50]
+	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[51]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3968,7 +4037,7 @@ func (x *UpdateCubeSandboxResponse) String() string {
 func (*UpdateCubeSandboxResponse) ProtoMessage() {}
 
 func (x *UpdateCubeSandboxResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[50]
+	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[51]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3981,7 +4050,7 @@ func (x *UpdateCubeSandboxResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateCubeSandboxResponse.ProtoReflect.Descriptor instead.
 func (*UpdateCubeSandboxResponse) Descriptor() ([]byte, []int) {
-	return file_api_services_cubebox_v1_cubebox_proto_rawDescGZIP(), []int{50}
+	return file_api_services_cubebox_v1_cubebox_proto_rawDescGZIP(), []int{51}
 }
 
 func (x *UpdateCubeSandboxResponse) GetRequestID() string {
@@ -4013,7 +4082,7 @@ type IDMapping struct {
 
 func (x *IDMapping) Reset() {
 	*x = IDMapping{}
-	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[51]
+	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[52]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4025,7 +4094,7 @@ func (x *IDMapping) String() string {
 func (*IDMapping) ProtoMessage() {}
 
 func (x *IDMapping) ProtoReflect() protoreflect.Message {
-	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[51]
+	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[52]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4038,7 +4107,7 @@ func (x *IDMapping) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use IDMapping.ProtoReflect.Descriptor instead.
 func (*IDMapping) Descriptor() ([]byte, []int) {
-	return file_api_services_cubebox_v1_cubebox_proto_rawDescGZIP(), []int{51}
+	return file_api_services_cubebox_v1_cubebox_proto_rawDescGZIP(), []int{52}
 }
 
 func (x *IDMapping) GetHostId() uint32 {
@@ -4073,7 +4142,7 @@ type ListCubeSandboxOption struct {
 
 func (x *ListCubeSandboxOption) Reset() {
 	*x = ListCubeSandboxOption{}
-	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[52]
+	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[53]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4085,7 +4154,7 @@ func (x *ListCubeSandboxOption) String() string {
 func (*ListCubeSandboxOption) ProtoMessage() {}
 
 func (x *ListCubeSandboxOption) ProtoReflect() protoreflect.Message {
-	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[52]
+	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[53]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4098,7 +4167,7 @@ func (x *ListCubeSandboxOption) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListCubeSandboxOption.ProtoReflect.Descriptor instead.
 func (*ListCubeSandboxOption) Descriptor() ([]byte, []int) {
-	return file_api_services_cubebox_v1_cubebox_proto_rawDescGZIP(), []int{52}
+	return file_api_services_cubebox_v1_cubebox_proto_rawDescGZIP(), []int{53}
 }
 
 func (x *ListCubeSandboxOption) GetPrivateWithCubeboxStore() bool {
@@ -4131,7 +4200,7 @@ type ExecCubeSandboxRequest struct {
 
 func (x *ExecCubeSandboxRequest) Reset() {
 	*x = ExecCubeSandboxRequest{}
-	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[53]
+	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[54]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4143,7 +4212,7 @@ func (x *ExecCubeSandboxRequest) String() string {
 func (*ExecCubeSandboxRequest) ProtoMessage() {}
 
 func (x *ExecCubeSandboxRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[53]
+	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[54]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4156,7 +4225,7 @@ func (x *ExecCubeSandboxRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExecCubeSandboxRequest.ProtoReflect.Descriptor instead.
 func (*ExecCubeSandboxRequest) Descriptor() ([]byte, []int) {
-	return file_api_services_cubebox_v1_cubebox_proto_rawDescGZIP(), []int{53}
+	return file_api_services_cubebox_v1_cubebox_proto_rawDescGZIP(), []int{54}
 }
 
 func (x *ExecCubeSandboxRequest) GetRequestID() string {
@@ -4220,7 +4289,7 @@ type ExecCubeSandboxResponse struct {
 
 func (x *ExecCubeSandboxResponse) Reset() {
 	*x = ExecCubeSandboxResponse{}
-	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[54]
+	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[55]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4232,7 +4301,7 @@ func (x *ExecCubeSandboxResponse) String() string {
 func (*ExecCubeSandboxResponse) ProtoMessage() {}
 
 func (x *ExecCubeSandboxResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[54]
+	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[55]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4245,7 +4314,7 @@ func (x *ExecCubeSandboxResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExecCubeSandboxResponse.ProtoReflect.Descriptor instead.
 func (*ExecCubeSandboxResponse) Descriptor() ([]byte, []int) {
-	return file_api_services_cubebox_v1_cubebox_proto_rawDescGZIP(), []int{54}
+	return file_api_services_cubebox_v1_cubebox_proto_rawDescGZIP(), []int{55}
 }
 
 func (x *ExecCubeSandboxResponse) GetRequestID() string {
@@ -4280,7 +4349,7 @@ type AppSnapshotRequest struct {
 
 func (x *AppSnapshotRequest) Reset() {
 	*x = AppSnapshotRequest{}
-	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[55]
+	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[56]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4292,7 +4361,7 @@ func (x *AppSnapshotRequest) String() string {
 func (*AppSnapshotRequest) ProtoMessage() {}
 
 func (x *AppSnapshotRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[55]
+	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[56]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4305,7 +4374,7 @@ func (x *AppSnapshotRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AppSnapshotRequest.ProtoReflect.Descriptor instead.
 func (*AppSnapshotRequest) Descriptor() ([]byte, []int) {
-	return file_api_services_cubebox_v1_cubebox_proto_rawDescGZIP(), []int{55}
+	return file_api_services_cubebox_v1_cubebox_proto_rawDescGZIP(), []int{56}
 }
 
 func (x *AppSnapshotRequest) GetCreateRequest() *RunCubeSandboxRequest {
@@ -4359,7 +4428,7 @@ type AppSnapshotResponse struct {
 
 func (x *AppSnapshotResponse) Reset() {
 	*x = AppSnapshotResponse{}
-	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[56]
+	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[57]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4371,7 +4440,7 @@ func (x *AppSnapshotResponse) String() string {
 func (*AppSnapshotResponse) ProtoMessage() {}
 
 func (x *AppSnapshotResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[56]
+	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[57]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4384,7 +4453,7 @@ func (x *AppSnapshotResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AppSnapshotResponse.ProtoReflect.Descriptor instead.
 func (*AppSnapshotResponse) Descriptor() ([]byte, []int) {
-	return file_api_services_cubebox_v1_cubebox_proto_rawDescGZIP(), []int{56}
+	return file_api_services_cubebox_v1_cubebox_proto_rawDescGZIP(), []int{57}
 }
 
 func (x *AppSnapshotResponse) GetRequestID() string {
@@ -4501,7 +4570,7 @@ type CommitSandboxRequest struct {
 
 func (x *CommitSandboxRequest) Reset() {
 	*x = CommitSandboxRequest{}
-	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[57]
+	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[58]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4513,7 +4582,7 @@ func (x *CommitSandboxRequest) String() string {
 func (*CommitSandboxRequest) ProtoMessage() {}
 
 func (x *CommitSandboxRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[57]
+	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[58]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4526,7 +4595,7 @@ func (x *CommitSandboxRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CommitSandboxRequest.ProtoReflect.Descriptor instead.
 func (*CommitSandboxRequest) Descriptor() ([]byte, []int) {
-	return file_api_services_cubebox_v1_cubebox_proto_rawDescGZIP(), []int{57}
+	return file_api_services_cubebox_v1_cubebox_proto_rawDescGZIP(), []int{58}
 }
 
 func (x *CommitSandboxRequest) GetRequestID() string {
@@ -4597,7 +4666,7 @@ type CommitSandboxResponse struct {
 
 func (x *CommitSandboxResponse) Reset() {
 	*x = CommitSandboxResponse{}
-	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[58]
+	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[59]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4609,7 +4678,7 @@ func (x *CommitSandboxResponse) String() string {
 func (*CommitSandboxResponse) ProtoMessage() {}
 
 func (x *CommitSandboxResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[58]
+	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[59]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4622,7 +4691,7 @@ func (x *CommitSandboxResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CommitSandboxResponse.ProtoReflect.Descriptor instead.
 func (*CommitSandboxResponse) Descriptor() ([]byte, []int) {
-	return file_api_services_cubebox_v1_cubebox_proto_rawDescGZIP(), []int{58}
+	return file_api_services_cubebox_v1_cubebox_proto_rawDescGZIP(), []int{59}
 }
 
 func (x *CommitSandboxResponse) GetRequestID() string {
@@ -4765,7 +4834,7 @@ type RollbackSandboxRequest struct {
 
 func (x *RollbackSandboxRequest) Reset() {
 	*x = RollbackSandboxRequest{}
-	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[59]
+	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[60]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4777,7 +4846,7 @@ func (x *RollbackSandboxRequest) String() string {
 func (*RollbackSandboxRequest) ProtoMessage() {}
 
 func (x *RollbackSandboxRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[59]
+	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[60]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4790,7 +4859,7 @@ func (x *RollbackSandboxRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RollbackSandboxRequest.ProtoReflect.Descriptor instead.
 func (*RollbackSandboxRequest) Descriptor() ([]byte, []int) {
-	return file_api_services_cubebox_v1_cubebox_proto_rawDescGZIP(), []int{59}
+	return file_api_services_cubebox_v1_cubebox_proto_rawDescGZIP(), []int{60}
 }
 
 func (x *RollbackSandboxRequest) GetRequestID() string {
@@ -4881,7 +4950,7 @@ type RollbackSandboxResponse struct {
 
 func (x *RollbackSandboxResponse) Reset() {
 	*x = RollbackSandboxResponse{}
-	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[60]
+	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[61]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4893,7 +4962,7 @@ func (x *RollbackSandboxResponse) String() string {
 func (*RollbackSandboxResponse) ProtoMessage() {}
 
 func (x *RollbackSandboxResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[60]
+	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[61]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4906,7 +4975,7 @@ func (x *RollbackSandboxResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RollbackSandboxResponse.ProtoReflect.Descriptor instead.
 func (*RollbackSandboxResponse) Descriptor() ([]byte, []int) {
-	return file_api_services_cubebox_v1_cubebox_proto_rawDescGZIP(), []int{60}
+	return file_api_services_cubebox_v1_cubebox_proto_rawDescGZIP(), []int{61}
 }
 
 func (x *RollbackSandboxResponse) GetRequestID() string {
@@ -5000,7 +5069,7 @@ type CowObjectRef struct {
 
 func (x *CowObjectRef) Reset() {
 	*x = CowObjectRef{}
-	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[61]
+	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[62]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5012,7 +5081,7 @@ func (x *CowObjectRef) String() string {
 func (*CowObjectRef) ProtoMessage() {}
 
 func (x *CowObjectRef) ProtoReflect() protoreflect.Message {
-	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[61]
+	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[62]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5025,7 +5094,7 @@ func (x *CowObjectRef) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CowObjectRef.ProtoReflect.Descriptor instead.
 func (*CowObjectRef) Descriptor() ([]byte, []int) {
-	return file_api_services_cubebox_v1_cubebox_proto_rawDescGZIP(), []int{61}
+	return file_api_services_cubebox_v1_cubebox_proto_rawDescGZIP(), []int{62}
 }
 
 func (x *CowObjectRef) GetName() string {
@@ -5069,7 +5138,7 @@ type CleanupTemplateRequest struct {
 
 func (x *CleanupTemplateRequest) Reset() {
 	*x = CleanupTemplateRequest{}
-	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[62]
+	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[63]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5081,7 +5150,7 @@ func (x *CleanupTemplateRequest) String() string {
 func (*CleanupTemplateRequest) ProtoMessage() {}
 
 func (x *CleanupTemplateRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[62]
+	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[63]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5094,7 +5163,7 @@ func (x *CleanupTemplateRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CleanupTemplateRequest.ProtoReflect.Descriptor instead.
 func (*CleanupTemplateRequest) Descriptor() ([]byte, []int) {
-	return file_api_services_cubebox_v1_cubebox_proto_rawDescGZIP(), []int{62}
+	return file_api_services_cubebox_v1_cubebox_proto_rawDescGZIP(), []int{63}
 }
 
 func (x *CleanupTemplateRequest) GetRequestID() string {
@@ -5139,7 +5208,7 @@ type CleanupTemplateResponse struct {
 
 func (x *CleanupTemplateResponse) Reset() {
 	*x = CleanupTemplateResponse{}
-	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[63]
+	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[64]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5151,7 +5220,7 @@ func (x *CleanupTemplateResponse) String() string {
 func (*CleanupTemplateResponse) ProtoMessage() {}
 
 func (x *CleanupTemplateResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[63]
+	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[64]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5164,7 +5233,7 @@ func (x *CleanupTemplateResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CleanupTemplateResponse.ProtoReflect.Descriptor instead.
 func (*CleanupTemplateResponse) Descriptor() ([]byte, []int) {
-	return file_api_services_cubebox_v1_cubebox_proto_rawDescGZIP(), []int{63}
+	return file_api_services_cubebox_v1_cubebox_proto_rawDescGZIP(), []int{64}
 }
 
 func (x *CleanupTemplateResponse) GetRequestID() string {
@@ -5204,7 +5273,7 @@ type ListSandboxSnapshotsRequest struct {
 
 func (x *ListSandboxSnapshotsRequest) Reset() {
 	*x = ListSandboxSnapshotsRequest{}
-	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[64]
+	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[65]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5216,7 +5285,7 @@ func (x *ListSandboxSnapshotsRequest) String() string {
 func (*ListSandboxSnapshotsRequest) ProtoMessage() {}
 
 func (x *ListSandboxSnapshotsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[64]
+	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[65]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5229,7 +5298,7 @@ func (x *ListSandboxSnapshotsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListSandboxSnapshotsRequest.ProtoReflect.Descriptor instead.
 func (*ListSandboxSnapshotsRequest) Descriptor() ([]byte, []int) {
-	return file_api_services_cubebox_v1_cubebox_proto_rawDescGZIP(), []int{64}
+	return file_api_services_cubebox_v1_cubebox_proto_rawDescGZIP(), []int{65}
 }
 
 func (x *ListSandboxSnapshotsRequest) GetRequestID() string {
@@ -5282,7 +5351,7 @@ type CowObjectStatus struct {
 
 func (x *CowObjectStatus) Reset() {
 	*x = CowObjectStatus{}
-	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[65]
+	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[66]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5294,7 +5363,7 @@ func (x *CowObjectStatus) String() string {
 func (*CowObjectStatus) ProtoMessage() {}
 
 func (x *CowObjectStatus) ProtoReflect() protoreflect.Message {
-	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[65]
+	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[66]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5307,7 +5376,7 @@ func (x *CowObjectStatus) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CowObjectStatus.ProtoReflect.Descriptor instead.
 func (*CowObjectStatus) Descriptor() ([]byte, []int) {
-	return file_api_services_cubebox_v1_cubebox_proto_rawDescGZIP(), []int{65}
+	return file_api_services_cubebox_v1_cubebox_proto_rawDescGZIP(), []int{66}
 }
 
 func (x *CowObjectStatus) GetName() string {
@@ -5383,7 +5452,7 @@ type ListSandboxSnapshotsResponse struct {
 
 func (x *ListSandboxSnapshotsResponse) Reset() {
 	*x = ListSandboxSnapshotsResponse{}
-	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[66]
+	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[67]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5395,7 +5464,7 @@ func (x *ListSandboxSnapshotsResponse) String() string {
 func (*ListSandboxSnapshotsResponse) ProtoMessage() {}
 
 func (x *ListSandboxSnapshotsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[66]
+	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[67]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5408,7 +5477,7 @@ func (x *ListSandboxSnapshotsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListSandboxSnapshotsResponse.ProtoReflect.Descriptor instead.
 func (*ListSandboxSnapshotsResponse) Descriptor() ([]byte, []int) {
-	return file_api_services_cubebox_v1_cubebox_proto_rawDescGZIP(), []int{66}
+	return file_api_services_cubebox_v1_cubebox_proto_rawDescGZIP(), []int{67}
 }
 
 func (x *ListSandboxSnapshotsResponse) GetRequestID() string {
@@ -5477,7 +5546,7 @@ type ListLocalSnapshotsRequest struct {
 
 func (x *ListLocalSnapshotsRequest) Reset() {
 	*x = ListLocalSnapshotsRequest{}
-	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[67]
+	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[68]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5489,7 +5558,7 @@ func (x *ListLocalSnapshotsRequest) String() string {
 func (*ListLocalSnapshotsRequest) ProtoMessage() {}
 
 func (x *ListLocalSnapshotsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[67]
+	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[68]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5502,7 +5571,7 @@ func (x *ListLocalSnapshotsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListLocalSnapshotsRequest.ProtoReflect.Descriptor instead.
 func (*ListLocalSnapshotsRequest) Descriptor() ([]byte, []int) {
-	return file_api_services_cubebox_v1_cubebox_proto_rawDescGZIP(), []int{67}
+	return file_api_services_cubebox_v1_cubebox_proto_rawDescGZIP(), []int{68}
 }
 
 func (x *ListLocalSnapshotsRequest) GetRequestID() string {
@@ -5550,7 +5619,7 @@ type LocalSnapshotInfo struct {
 
 func (x *LocalSnapshotInfo) Reset() {
 	*x = LocalSnapshotInfo{}
-	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[68]
+	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[69]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5562,7 +5631,7 @@ func (x *LocalSnapshotInfo) String() string {
 func (*LocalSnapshotInfo) ProtoMessage() {}
 
 func (x *LocalSnapshotInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[68]
+	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[69]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5575,7 +5644,7 @@ func (x *LocalSnapshotInfo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LocalSnapshotInfo.ProtoReflect.Descriptor instead.
 func (*LocalSnapshotInfo) Descriptor() ([]byte, []int) {
-	return file_api_services_cubebox_v1_cubebox_proto_rawDescGZIP(), []int{68}
+	return file_api_services_cubebox_v1_cubebox_proto_rawDescGZIP(), []int{69}
 }
 
 func (x *LocalSnapshotInfo) GetSnapshotID() string {
@@ -5690,7 +5759,7 @@ type ListLocalSnapshotsResponse struct {
 
 func (x *ListLocalSnapshotsResponse) Reset() {
 	*x = ListLocalSnapshotsResponse{}
-	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[69]
+	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[70]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5702,7 +5771,7 @@ func (x *ListLocalSnapshotsResponse) String() string {
 func (*ListLocalSnapshotsResponse) ProtoMessage() {}
 
 func (x *ListLocalSnapshotsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[69]
+	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[70]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5715,7 +5784,7 @@ func (x *ListLocalSnapshotsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListLocalSnapshotsResponse.ProtoReflect.Descriptor instead.
 func (*ListLocalSnapshotsResponse) Descriptor() ([]byte, []int) {
-	return file_api_services_cubebox_v1_cubebox_proto_rawDescGZIP(), []int{69}
+	return file_api_services_cubebox_v1_cubebox_proto_rawDescGZIP(), []int{70}
 }
 
 func (x *ListLocalSnapshotsResponse) GetRequestID() string {
@@ -5751,7 +5820,7 @@ type GetLocalSnapshotRequest struct {
 
 func (x *GetLocalSnapshotRequest) Reset() {
 	*x = GetLocalSnapshotRequest{}
-	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[70]
+	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[71]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5763,7 +5832,7 @@ func (x *GetLocalSnapshotRequest) String() string {
 func (*GetLocalSnapshotRequest) ProtoMessage() {}
 
 func (x *GetLocalSnapshotRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[70]
+	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[71]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5776,7 +5845,7 @@ func (x *GetLocalSnapshotRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetLocalSnapshotRequest.ProtoReflect.Descriptor instead.
 func (*GetLocalSnapshotRequest) Descriptor() ([]byte, []int) {
-	return file_api_services_cubebox_v1_cubebox_proto_rawDescGZIP(), []int{70}
+	return file_api_services_cubebox_v1_cubebox_proto_rawDescGZIP(), []int{71}
 }
 
 func (x *GetLocalSnapshotRequest) GetRequestID() string {
@@ -5807,7 +5876,7 @@ type GetLocalSnapshotResponse struct {
 
 func (x *GetLocalSnapshotResponse) Reset() {
 	*x = GetLocalSnapshotResponse{}
-	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[71]
+	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[72]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5819,7 +5888,7 @@ func (x *GetLocalSnapshotResponse) String() string {
 func (*GetLocalSnapshotResponse) ProtoMessage() {}
 
 func (x *GetLocalSnapshotResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[71]
+	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[72]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5832,7 +5901,7 @@ func (x *GetLocalSnapshotResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetLocalSnapshotResponse.ProtoReflect.Descriptor instead.
 func (*GetLocalSnapshotResponse) Descriptor() ([]byte, []int) {
-	return file_api_services_cubebox_v1_cubebox_proto_rawDescGZIP(), []int{71}
+	return file_api_services_cubebox_v1_cubebox_proto_rawDescGZIP(), []int{72}
 }
 
 func (x *GetLocalSnapshotResponse) GetRequestID() string {
@@ -5866,7 +5935,7 @@ type GetStorageMetricsRequest struct {
 
 func (x *GetStorageMetricsRequest) Reset() {
 	*x = GetStorageMetricsRequest{}
-	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[72]
+	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[73]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5878,7 +5947,7 @@ func (x *GetStorageMetricsRequest) String() string {
 func (*GetStorageMetricsRequest) ProtoMessage() {}
 
 func (x *GetStorageMetricsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[72]
+	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[73]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5891,7 +5960,7 @@ func (x *GetStorageMetricsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetStorageMetricsRequest.ProtoReflect.Descriptor instead.
 func (*GetStorageMetricsRequest) Descriptor() ([]byte, []int) {
-	return file_api_services_cubebox_v1_cubebox_proto_rawDescGZIP(), []int{72}
+	return file_api_services_cubebox_v1_cubebox_proto_rawDescGZIP(), []int{73}
 }
 
 func (x *GetStorageMetricsRequest) GetRequestID() string {
@@ -5919,7 +5988,7 @@ type GetStorageMetricsResponse struct {
 
 func (x *GetStorageMetricsResponse) Reset() {
 	*x = GetStorageMetricsResponse{}
-	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[73]
+	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[74]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5931,7 +6000,7 @@ func (x *GetStorageMetricsResponse) String() string {
 func (*GetStorageMetricsResponse) ProtoMessage() {}
 
 func (x *GetStorageMetricsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[73]
+	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[74]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5944,7 +6013,7 @@ func (x *GetStorageMetricsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetStorageMetricsResponse.ProtoReflect.Descriptor instead.
 func (*GetStorageMetricsResponse) Descriptor() ([]byte, []int) {
-	return file_api_services_cubebox_v1_cubebox_proto_rawDescGZIP(), []int{73}
+	return file_api_services_cubebox_v1_cubebox_proto_rawDescGZIP(), []int{74}
 }
 
 func (x *GetStorageMetricsResponse) GetRequestID() string {
@@ -5998,7 +6067,7 @@ type StorageVolumeInfo struct {
 
 func (x *StorageVolumeInfo) Reset() {
 	*x = StorageVolumeInfo{}
-	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[74]
+	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[75]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6010,7 +6079,7 @@ func (x *StorageVolumeInfo) String() string {
 func (*StorageVolumeInfo) ProtoMessage() {}
 
 func (x *StorageVolumeInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[74]
+	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[75]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6023,7 +6092,7 @@ func (x *StorageVolumeInfo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StorageVolumeInfo.ProtoReflect.Descriptor instead.
 func (*StorageVolumeInfo) Descriptor() ([]byte, []int) {
-	return file_api_services_cubebox_v1_cubebox_proto_rawDescGZIP(), []int{74}
+	return file_api_services_cubebox_v1_cubebox_proto_rawDescGZIP(), []int{75}
 }
 
 func (x *StorageVolumeInfo) GetName() string {
@@ -6079,7 +6148,7 @@ type SandboxStorageInfo struct {
 
 func (x *SandboxStorageInfo) Reset() {
 	*x = SandboxStorageInfo{}
-	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[75]
+	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[76]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6091,7 +6160,7 @@ func (x *SandboxStorageInfo) String() string {
 func (*SandboxStorageInfo) ProtoMessage() {}
 
 func (x *SandboxStorageInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[75]
+	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[76]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6104,7 +6173,7 @@ func (x *SandboxStorageInfo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SandboxStorageInfo.ProtoReflect.Descriptor instead.
 func (*SandboxStorageInfo) Descriptor() ([]byte, []int) {
-	return file_api_services_cubebox_v1_cubebox_proto_rawDescGZIP(), []int{75}
+	return file_api_services_cubebox_v1_cubebox_proto_rawDescGZIP(), []int{76}
 }
 
 func (x *SandboxStorageInfo) GetNamespace() string {
@@ -6138,7 +6207,7 @@ type InspectStorageVolumesRequest struct {
 
 func (x *InspectStorageVolumesRequest) Reset() {
 	*x = InspectStorageVolumesRequest{}
-	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[76]
+	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[77]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6150,7 +6219,7 @@ func (x *InspectStorageVolumesRequest) String() string {
 func (*InspectStorageVolumesRequest) ProtoMessage() {}
 
 func (x *InspectStorageVolumesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[76]
+	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[77]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6163,7 +6232,7 @@ func (x *InspectStorageVolumesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use InspectStorageVolumesRequest.ProtoReflect.Descriptor instead.
 func (*InspectStorageVolumesRequest) Descriptor() ([]byte, []int) {
-	return file_api_services_cubebox_v1_cubebox_proto_rawDescGZIP(), []int{76}
+	return file_api_services_cubebox_v1_cubebox_proto_rawDescGZIP(), []int{77}
 }
 
 func (x *InspectStorageVolumesRequest) GetRequestID() string {
@@ -6191,7 +6260,7 @@ type InspectStorageVolumesResponse struct {
 
 func (x *InspectStorageVolumesResponse) Reset() {
 	*x = InspectStorageVolumesResponse{}
-	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[77]
+	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[78]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6203,7 +6272,7 @@ func (x *InspectStorageVolumesResponse) String() string {
 func (*InspectStorageVolumesResponse) ProtoMessage() {}
 
 func (x *InspectStorageVolumesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[77]
+	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[78]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6216,7 +6285,7 @@ func (x *InspectStorageVolumesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use InspectStorageVolumesResponse.ProtoReflect.Descriptor instead.
 func (*InspectStorageVolumesResponse) Descriptor() ([]byte, []int) {
-	return file_api_services_cubebox_v1_cubebox_proto_rawDescGZIP(), []int{77}
+	return file_api_services_cubebox_v1_cubebox_proto_rawDescGZIP(), []int{78}
 }
 
 func (x *InspectStorageVolumesResponse) GetRequestID() string {
@@ -6252,7 +6321,7 @@ type CleanupOrphanStorageFilesRequest struct {
 
 func (x *CleanupOrphanStorageFilesRequest) Reset() {
 	*x = CleanupOrphanStorageFilesRequest{}
-	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[78]
+	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[79]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6264,7 +6333,7 @@ func (x *CleanupOrphanStorageFilesRequest) String() string {
 func (*CleanupOrphanStorageFilesRequest) ProtoMessage() {}
 
 func (x *CleanupOrphanStorageFilesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[78]
+	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[79]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6277,7 +6346,7 @@ func (x *CleanupOrphanStorageFilesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CleanupOrphanStorageFilesRequest.ProtoReflect.Descriptor instead.
 func (*CleanupOrphanStorageFilesRequest) Descriptor() ([]byte, []int) {
-	return file_api_services_cubebox_v1_cubebox_proto_rawDescGZIP(), []int{78}
+	return file_api_services_cubebox_v1_cubebox_proto_rawDescGZIP(), []int{79}
 }
 
 func (x *CleanupOrphanStorageFilesRequest) GetRequestID() string {
@@ -6320,7 +6389,7 @@ type StorageOrphanEntry struct {
 
 func (x *StorageOrphanEntry) Reset() {
 	*x = StorageOrphanEntry{}
-	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[79]
+	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[80]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6332,7 +6401,7 @@ func (x *StorageOrphanEntry) String() string {
 func (*StorageOrphanEntry) ProtoMessage() {}
 
 func (x *StorageOrphanEntry) ProtoReflect() protoreflect.Message {
-	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[79]
+	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[80]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6345,7 +6414,7 @@ func (x *StorageOrphanEntry) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StorageOrphanEntry.ProtoReflect.Descriptor instead.
 func (*StorageOrphanEntry) Descriptor() ([]byte, []int) {
-	return file_api_services_cubebox_v1_cubebox_proto_rawDescGZIP(), []int{79}
+	return file_api_services_cubebox_v1_cubebox_proto_rawDescGZIP(), []int{80}
 }
 
 func (x *StorageOrphanEntry) GetFormat() string {
@@ -6387,7 +6456,7 @@ type CleanupOrphanStorageFilesResponse struct {
 
 func (x *CleanupOrphanStorageFilesResponse) Reset() {
 	*x = CleanupOrphanStorageFilesResponse{}
-	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[80]
+	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[81]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6399,7 +6468,7 @@ func (x *CleanupOrphanStorageFilesResponse) String() string {
 func (*CleanupOrphanStorageFilesResponse) ProtoMessage() {}
 
 func (x *CleanupOrphanStorageFilesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[80]
+	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[81]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6412,7 +6481,7 @@ func (x *CleanupOrphanStorageFilesResponse) ProtoReflect() protoreflect.Message 
 
 // Deprecated: Use CleanupOrphanStorageFilesResponse.ProtoReflect.Descriptor instead.
 func (*CleanupOrphanStorageFilesResponse) Descriptor() ([]byte, []int) {
-	return file_api_services_cubebox_v1_cubebox_proto_rawDescGZIP(), []int{80}
+	return file_api_services_cubebox_v1_cubebox_proto_rawDescGZIP(), []int{81}
 }
 
 func (x *CleanupOrphanStorageFilesResponse) GetRequestID() string {
@@ -6612,12 +6681,19 @@ const file_api_services_cubebox_v1_cubebox_proto_rawDesc = "" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x1b\n" +
 	"\thost_path\x18\x02 \x01(\tR\bhostPath\"i\n" +
 	"\x14HostDirVolumeSources\x12Q\n" +
-	"\x0evolume_sources\x18\x01 \x03(\v2*.cubelet.services.cubebox.v1.HostDirSourceR\rvolumeSources\"\xd9\x02\n" +
+	"\x0evolume_sources\x18\x01 \x03(\v2*.cubelet.services.cubebox.v1.HostDirSourceR\rvolumeSources\"\xaf\x03\n" +
 	"\fVolumeSource\x12N\n" +
 	"\tempty_dir\x18\x01 \x01(\v21.cubelet.services.cubebox.v1.EmptyDirVolumeSourceR\bemptyDir\x12W\n" +
 	"\fsandbox_path\x18\x05 \x01(\v24.cubelet.services.cubebox.v1.SandboxPathVolumeSourceR\vsandboxPath\x12[\n" +
 	"\x10host_dir_volumes\x18\a \x01(\v21.cubelet.services.cubebox.v1.HostDirVolumeSourcesR\x0ehostDirVolumes\x12C\n" +
-	"\x05image\x18\t \x01(\v2-.cubelet.services.images.v1.ImageVolumeSourceR\x05image\"l\n" +
+	"\x05image\x18\t \x01(\v2-.cubelet.services.images.v1.ImageVolumeSourceR\x05image\x12T\n" +
+	"\rplugin_volume\x18\v \x01(\v2/.cubelet.services.cubebox.v1.PluginVolumeSourceR\fpluginVolume\"\xc0\x01\n" +
+	"\x12PluginVolumeSource\x12\x16\n" +
+	"\x06driver\x18\x01 \x01(\tR\x06driver\x12V\n" +
+	"\aoptions\x18\x02 \x03(\v2<.cubelet.services.cubebox.v1.PluginVolumeSource.OptionsEntryR\aoptions\x1a:\n" +
+	"\fOptionsEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"l\n" +
 	"\x06Volume\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12N\n" +
 	"\rvolume_source\x18\x02 \x01(\v2).cubelet.services.cubebox.v1.VolumeSourceR\fvolumeSource\"\xad\x06\n" +
@@ -7054,7 +7130,7 @@ func file_api_services_cubebox_v1_cubebox_proto_rawDescGZIP() []byte {
 }
 
 var file_api_services_cubebox_v1_cubebox_proto_enumTypes = make([]protoimpl.EnumInfo, 6)
-var file_api_services_cubebox_v1_cubebox_proto_msgTypes = make([]protoimpl.MessageInfo, 93)
+var file_api_services_cubebox_v1_cubebox_proto_msgTypes = make([]protoimpl.MessageInfo, 95)
 var file_api_services_cubebox_v1_cubebox_proto_goTypes = []any{
 	(MountPropagation)(0),                     // 0: cubelet.services.cubebox.v1.MountPropagation
 	(StorageMedium)(0),                        // 1: cubelet.services.cubebox.v1.StorageMedium
@@ -7094,78 +7170,80 @@ var file_api_services_cubebox_v1_cubebox_proto_goTypes = []any{
 	(*HostDirSource)(nil),                     // 35: cubelet.services.cubebox.v1.HostDirSource
 	(*HostDirVolumeSources)(nil),              // 36: cubelet.services.cubebox.v1.HostDirVolumeSources
 	(*VolumeSource)(nil),                      // 37: cubelet.services.cubebox.v1.VolumeSource
-	(*Volume)(nil),                            // 38: cubelet.services.cubebox.v1.Volume
-	(*RunCubeSandboxRequest)(nil),             // 39: cubelet.services.cubebox.v1.RunCubeSandboxRequest
-	(*RunCubeSandboxResponse)(nil),            // 40: cubelet.services.cubebox.v1.RunCubeSandboxResponse
-	(*PortMapping)(nil),                       // 41: cubelet.services.cubebox.v1.PortMapping
-	(*CubeNetworkConfig)(nil),                 // 42: cubelet.services.cubebox.v1.CubeNetworkConfig
-	(*EgressRule)(nil),                        // 43: cubelet.services.cubebox.v1.EgressRule
-	(*EgressRuleMatch)(nil),                   // 44: cubelet.services.cubebox.v1.EgressRuleMatch
-	(*EgressRuleAction)(nil),                  // 45: cubelet.services.cubebox.v1.EgressRuleAction
-	(*EgressRuleInject)(nil),                  // 46: cubelet.services.cubebox.v1.EgressRuleInject
-	(*DestroyCubeSandboxRequest)(nil),         // 47: cubelet.services.cubebox.v1.DestroyCubeSandboxRequest
-	(*DestroyCubeSandboxResponse)(nil),        // 48: cubelet.services.cubebox.v1.DestroyCubeSandboxResponse
-	(*CubeSandbox)(nil),                       // 49: cubelet.services.cubebox.v1.CubeSandbox
-	(*Container)(nil),                         // 50: cubelet.services.cubebox.v1.Container
-	(*ContainerStateValue)(nil),               // 51: cubelet.services.cubebox.v1.ContainerStateValue
-	(*CubeSandboxFilter)(nil),                 // 52: cubelet.services.cubebox.v1.CubeSandboxFilter
-	(*ListCubeSandboxRequest)(nil),            // 53: cubelet.services.cubebox.v1.ListCubeSandboxRequest
-	(*ListCubeSandboxResponse)(nil),           // 54: cubelet.services.cubebox.v1.ListCubeSandboxResponse
-	(*UpdateCubeSandboxRequest)(nil),          // 55: cubelet.services.cubebox.v1.UpdateCubeSandboxRequest
-	(*UpdateCubeSandboxResponse)(nil),         // 56: cubelet.services.cubebox.v1.UpdateCubeSandboxResponse
-	(*IDMapping)(nil),                         // 57: cubelet.services.cubebox.v1.IDMapping
-	(*ListCubeSandboxOption)(nil),             // 58: cubelet.services.cubebox.v1.ListCubeSandboxOption
-	(*ExecCubeSandboxRequest)(nil),            // 59: cubelet.services.cubebox.v1.ExecCubeSandboxRequest
-	(*ExecCubeSandboxResponse)(nil),           // 60: cubelet.services.cubebox.v1.ExecCubeSandboxResponse
-	(*AppSnapshotRequest)(nil),                // 61: cubelet.services.cubebox.v1.AppSnapshotRequest
-	(*AppSnapshotResponse)(nil),               // 62: cubelet.services.cubebox.v1.AppSnapshotResponse
-	(*CommitSandboxRequest)(nil),              // 63: cubelet.services.cubebox.v1.CommitSandboxRequest
-	(*CommitSandboxResponse)(nil),             // 64: cubelet.services.cubebox.v1.CommitSandboxResponse
-	(*RollbackSandboxRequest)(nil),            // 65: cubelet.services.cubebox.v1.RollbackSandboxRequest
-	(*RollbackSandboxResponse)(nil),           // 66: cubelet.services.cubebox.v1.RollbackSandboxResponse
-	(*CowObjectRef)(nil),                      // 67: cubelet.services.cubebox.v1.CowObjectRef
-	(*CleanupTemplateRequest)(nil),            // 68: cubelet.services.cubebox.v1.CleanupTemplateRequest
-	(*CleanupTemplateResponse)(nil),           // 69: cubelet.services.cubebox.v1.CleanupTemplateResponse
-	(*ListSandboxSnapshotsRequest)(nil),       // 70: cubelet.services.cubebox.v1.ListSandboxSnapshotsRequest
-	(*CowObjectStatus)(nil),                   // 71: cubelet.services.cubebox.v1.CowObjectStatus
-	(*ListSandboxSnapshotsResponse)(nil),      // 72: cubelet.services.cubebox.v1.ListSandboxSnapshotsResponse
-	(*ListLocalSnapshotsRequest)(nil),         // 73: cubelet.services.cubebox.v1.ListLocalSnapshotsRequest
-	(*LocalSnapshotInfo)(nil),                 // 74: cubelet.services.cubebox.v1.LocalSnapshotInfo
-	(*ListLocalSnapshotsResponse)(nil),        // 75: cubelet.services.cubebox.v1.ListLocalSnapshotsResponse
-	(*GetLocalSnapshotRequest)(nil),           // 76: cubelet.services.cubebox.v1.GetLocalSnapshotRequest
-	(*GetLocalSnapshotResponse)(nil),          // 77: cubelet.services.cubebox.v1.GetLocalSnapshotResponse
-	(*GetStorageMetricsRequest)(nil),          // 78: cubelet.services.cubebox.v1.GetStorageMetricsRequest
-	(*GetStorageMetricsResponse)(nil),         // 79: cubelet.services.cubebox.v1.GetStorageMetricsResponse
-	(*StorageVolumeInfo)(nil),                 // 80: cubelet.services.cubebox.v1.StorageVolumeInfo
-	(*SandboxStorageInfo)(nil),                // 81: cubelet.services.cubebox.v1.SandboxStorageInfo
-	(*InspectStorageVolumesRequest)(nil),      // 82: cubelet.services.cubebox.v1.InspectStorageVolumesRequest
-	(*InspectStorageVolumesResponse)(nil),     // 83: cubelet.services.cubebox.v1.InspectStorageVolumesResponse
-	(*CleanupOrphanStorageFilesRequest)(nil),  // 84: cubelet.services.cubebox.v1.CleanupOrphanStorageFilesRequest
-	(*StorageOrphanEntry)(nil),                // 85: cubelet.services.cubebox.v1.StorageOrphanEntry
-	(*CleanupOrphanStorageFilesResponse)(nil), // 86: cubelet.services.cubebox.v1.CleanupOrphanStorageFilesResponse
-	nil,                          // 87: cubelet.services.cubebox.v1.ContainerConfig.SysctlsEntry
-	nil,                          // 88: cubelet.services.cubebox.v1.ContainerConfig.AnnotationsEntry
-	nil,                          // 89: cubelet.services.cubebox.v1.RunCubeSandboxRequest.AnnotationsEntry
-	nil,                          // 90: cubelet.services.cubebox.v1.RunCubeSandboxRequest.LabelsEntry
-	nil,                          // 91: cubelet.services.cubebox.v1.RunCubeSandboxResponse.ExtInfoEntry
-	nil,                          // 92: cubelet.services.cubebox.v1.DestroyCubeSandboxRequest.AnnotationsEntry
-	nil,                          // 93: cubelet.services.cubebox.v1.DestroyCubeSandboxResponse.ExtInfoEntry
-	nil,                          // 94: cubelet.services.cubebox.v1.CubeSandbox.LabelsEntry
-	nil,                          // 95: cubelet.services.cubebox.v1.Container.LabelsEntry
-	nil,                          // 96: cubelet.services.cubebox.v1.CubeSandboxFilter.LabelSelectorEntry
-	nil,                          // 97: cubelet.services.cubebox.v1.UpdateCubeSandboxRequest.AnnotationsEntry
-	nil,                          // 98: cubelet.services.cubebox.v1.GetStorageMetricsResponse.MetricsEntry
-	(*v1.ImageSpec)(nil),         // 99: cubelet.services.images.v1.ImageSpec
-	(*v1.ImageVolumeSource)(nil), // 100: cubelet.services.images.v1.ImageVolumeSource
-	(*v11.Ret)(nil),              // 101: cubelet.services.errorcode.v1.Ret
+	(*PluginVolumeSource)(nil),                // 38: cubelet.services.cubebox.v1.PluginVolumeSource
+	(*Volume)(nil),                            // 39: cubelet.services.cubebox.v1.Volume
+	(*RunCubeSandboxRequest)(nil),             // 40: cubelet.services.cubebox.v1.RunCubeSandboxRequest
+	(*RunCubeSandboxResponse)(nil),            // 41: cubelet.services.cubebox.v1.RunCubeSandboxResponse
+	(*PortMapping)(nil),                       // 42: cubelet.services.cubebox.v1.PortMapping
+	(*CubeNetworkConfig)(nil),                 // 43: cubelet.services.cubebox.v1.CubeNetworkConfig
+	(*EgressRule)(nil),                        // 44: cubelet.services.cubebox.v1.EgressRule
+	(*EgressRuleMatch)(nil),                   // 45: cubelet.services.cubebox.v1.EgressRuleMatch
+	(*EgressRuleAction)(nil),                  // 46: cubelet.services.cubebox.v1.EgressRuleAction
+	(*EgressRuleInject)(nil),                  // 47: cubelet.services.cubebox.v1.EgressRuleInject
+	(*DestroyCubeSandboxRequest)(nil),         // 48: cubelet.services.cubebox.v1.DestroyCubeSandboxRequest
+	(*DestroyCubeSandboxResponse)(nil),        // 49: cubelet.services.cubebox.v1.DestroyCubeSandboxResponse
+	(*CubeSandbox)(nil),                       // 50: cubelet.services.cubebox.v1.CubeSandbox
+	(*Container)(nil),                         // 51: cubelet.services.cubebox.v1.Container
+	(*ContainerStateValue)(nil),               // 52: cubelet.services.cubebox.v1.ContainerStateValue
+	(*CubeSandboxFilter)(nil),                 // 53: cubelet.services.cubebox.v1.CubeSandboxFilter
+	(*ListCubeSandboxRequest)(nil),            // 54: cubelet.services.cubebox.v1.ListCubeSandboxRequest
+	(*ListCubeSandboxResponse)(nil),           // 55: cubelet.services.cubebox.v1.ListCubeSandboxResponse
+	(*UpdateCubeSandboxRequest)(nil),          // 56: cubelet.services.cubebox.v1.UpdateCubeSandboxRequest
+	(*UpdateCubeSandboxResponse)(nil),         // 57: cubelet.services.cubebox.v1.UpdateCubeSandboxResponse
+	(*IDMapping)(nil),                         // 58: cubelet.services.cubebox.v1.IDMapping
+	(*ListCubeSandboxOption)(nil),             // 59: cubelet.services.cubebox.v1.ListCubeSandboxOption
+	(*ExecCubeSandboxRequest)(nil),            // 60: cubelet.services.cubebox.v1.ExecCubeSandboxRequest
+	(*ExecCubeSandboxResponse)(nil),           // 61: cubelet.services.cubebox.v1.ExecCubeSandboxResponse
+	(*AppSnapshotRequest)(nil),                // 62: cubelet.services.cubebox.v1.AppSnapshotRequest
+	(*AppSnapshotResponse)(nil),               // 63: cubelet.services.cubebox.v1.AppSnapshotResponse
+	(*CommitSandboxRequest)(nil),              // 64: cubelet.services.cubebox.v1.CommitSandboxRequest
+	(*CommitSandboxResponse)(nil),             // 65: cubelet.services.cubebox.v1.CommitSandboxResponse
+	(*RollbackSandboxRequest)(nil),            // 66: cubelet.services.cubebox.v1.RollbackSandboxRequest
+	(*RollbackSandboxResponse)(nil),           // 67: cubelet.services.cubebox.v1.RollbackSandboxResponse
+	(*CowObjectRef)(nil),                      // 68: cubelet.services.cubebox.v1.CowObjectRef
+	(*CleanupTemplateRequest)(nil),            // 69: cubelet.services.cubebox.v1.CleanupTemplateRequest
+	(*CleanupTemplateResponse)(nil),           // 70: cubelet.services.cubebox.v1.CleanupTemplateResponse
+	(*ListSandboxSnapshotsRequest)(nil),       // 71: cubelet.services.cubebox.v1.ListSandboxSnapshotsRequest
+	(*CowObjectStatus)(nil),                   // 72: cubelet.services.cubebox.v1.CowObjectStatus
+	(*ListSandboxSnapshotsResponse)(nil),      // 73: cubelet.services.cubebox.v1.ListSandboxSnapshotsResponse
+	(*ListLocalSnapshotsRequest)(nil),         // 74: cubelet.services.cubebox.v1.ListLocalSnapshotsRequest
+	(*LocalSnapshotInfo)(nil),                 // 75: cubelet.services.cubebox.v1.LocalSnapshotInfo
+	(*ListLocalSnapshotsResponse)(nil),        // 76: cubelet.services.cubebox.v1.ListLocalSnapshotsResponse
+	(*GetLocalSnapshotRequest)(nil),           // 77: cubelet.services.cubebox.v1.GetLocalSnapshotRequest
+	(*GetLocalSnapshotResponse)(nil),          // 78: cubelet.services.cubebox.v1.GetLocalSnapshotResponse
+	(*GetStorageMetricsRequest)(nil),          // 79: cubelet.services.cubebox.v1.GetStorageMetricsRequest
+	(*GetStorageMetricsResponse)(nil),         // 80: cubelet.services.cubebox.v1.GetStorageMetricsResponse
+	(*StorageVolumeInfo)(nil),                 // 81: cubelet.services.cubebox.v1.StorageVolumeInfo
+	(*SandboxStorageInfo)(nil),                // 82: cubelet.services.cubebox.v1.SandboxStorageInfo
+	(*InspectStorageVolumesRequest)(nil),      // 83: cubelet.services.cubebox.v1.InspectStorageVolumesRequest
+	(*InspectStorageVolumesResponse)(nil),     // 84: cubelet.services.cubebox.v1.InspectStorageVolumesResponse
+	(*CleanupOrphanStorageFilesRequest)(nil),  // 85: cubelet.services.cubebox.v1.CleanupOrphanStorageFilesRequest
+	(*StorageOrphanEntry)(nil),                // 86: cubelet.services.cubebox.v1.StorageOrphanEntry
+	(*CleanupOrphanStorageFilesResponse)(nil), // 87: cubelet.services.cubebox.v1.CleanupOrphanStorageFilesResponse
+	nil,                          // 88: cubelet.services.cubebox.v1.ContainerConfig.SysctlsEntry
+	nil,                          // 89: cubelet.services.cubebox.v1.ContainerConfig.AnnotationsEntry
+	nil,                          // 90: cubelet.services.cubebox.v1.PluginVolumeSource.OptionsEntry
+	nil,                          // 91: cubelet.services.cubebox.v1.RunCubeSandboxRequest.AnnotationsEntry
+	nil,                          // 92: cubelet.services.cubebox.v1.RunCubeSandboxRequest.LabelsEntry
+	nil,                          // 93: cubelet.services.cubebox.v1.RunCubeSandboxResponse.ExtInfoEntry
+	nil,                          // 94: cubelet.services.cubebox.v1.DestroyCubeSandboxRequest.AnnotationsEntry
+	nil,                          // 95: cubelet.services.cubebox.v1.DestroyCubeSandboxResponse.ExtInfoEntry
+	nil,                          // 96: cubelet.services.cubebox.v1.CubeSandbox.LabelsEntry
+	nil,                          // 97: cubelet.services.cubebox.v1.Container.LabelsEntry
+	nil,                          // 98: cubelet.services.cubebox.v1.CubeSandboxFilter.LabelSelectorEntry
+	nil,                          // 99: cubelet.services.cubebox.v1.UpdateCubeSandboxRequest.AnnotationsEntry
+	nil,                          // 100: cubelet.services.cubebox.v1.GetStorageMetricsResponse.MetricsEntry
+	(*v1.ImageSpec)(nil),         // 101: cubelet.services.images.v1.ImageSpec
+	(*v1.ImageVolumeSource)(nil), // 102: cubelet.services.images.v1.ImageVolumeSource
+	(*v11.Ret)(nil),              // 103: cubelet.services.errorcode.v1.Ret
 }
 var file_api_services_cubebox_v1_cubebox_proto_depIdxs = []int32{
 	7,   // 0: cubelet.services.cubebox.v1.ContainerSecurityContext.capabilities:type_name -> cubelet.services.cubebox.v1.Capability
 	8,   // 1: cubelet.services.cubebox.v1.ContainerSecurityContext.run_as_user:type_name -> cubelet.services.cubebox.v1.Int64Value
 	8,   // 2: cubelet.services.cubebox.v1.ContainerSecurityContext.run_as_group:type_name -> cubelet.services.cubebox.v1.Int64Value
 	0,   // 3: cubelet.services.cubebox.v1.VolumeMounts.propagation:type_name -> cubelet.services.cubebox.v1.MountPropagation
-	57,  // 4: cubelet.services.cubebox.v1.VolumeMounts.uidMappings:type_name -> cubelet.services.cubebox.v1.IDMapping
-	57,  // 5: cubelet.services.cubebox.v1.VolumeMounts.gidMappings:type_name -> cubelet.services.cubebox.v1.IDMapping
+	58,  // 4: cubelet.services.cubebox.v1.VolumeMounts.uidMappings:type_name -> cubelet.services.cubebox.v1.IDMapping
+	58,  // 5: cubelet.services.cubebox.v1.VolumeMounts.gidMappings:type_name -> cubelet.services.cubebox.v1.IDMapping
 	16,  // 6: cubelet.services.cubebox.v1.HTTPGetAction.http_headers:type_name -> cubelet.services.cubebox.v1.HTTPHeader
 	13,  // 7: cubelet.services.cubebox.v1.ProbeHandler.tcp_socket:type_name -> cubelet.services.cubebox.v1.TCPSocketAction
 	14,  // 8: cubelet.services.cubebox.v1.ProbeHandler.ping:type_name -> cubelet.services.cubebox.v1.PingAction
@@ -7175,17 +7253,17 @@ var file_api_services_cubebox_v1_cubebox_proto_depIdxs = []int32{
 	19,  // 12: cubelet.services.cubebox.v1.PreStop.lifecyle_handler:type_name -> cubelet.services.cubebox.v1.LifecycleHandler
 	19,  // 13: cubelet.services.cubebox.v1.PostStop.lifecyle_handler:type_name -> cubelet.services.cubebox.v1.LifecycleHandler
 	22,  // 14: cubelet.services.cubebox.v1.Hooks.Prestart:type_name -> cubelet.services.cubebox.v1.Hook
-	99,  // 15: cubelet.services.cubebox.v1.ContainerConfig.image:type_name -> cubelet.services.images.v1.ImageSpec
+	101, // 15: cubelet.services.cubebox.v1.ContainerConfig.image:type_name -> cubelet.services.images.v1.ImageSpec
 	24,  // 16: cubelet.services.cubebox.v1.ContainerConfig.envs:type_name -> cubelet.services.cubebox.v1.KeyValue
 	12,  // 17: cubelet.services.cubebox.v1.ContainerConfig.volume_mounts:type_name -> cubelet.services.cubebox.v1.VolumeMounts
 	11,  // 18: cubelet.services.cubebox.v1.ContainerConfig.r_limit:type_name -> cubelet.services.cubebox.v1.RLimit
 	32,  // 19: cubelet.services.cubebox.v1.ContainerConfig.resources:type_name -> cubelet.services.cubebox.v1.Resource
 	9,   // 20: cubelet.services.cubebox.v1.ContainerConfig.security_context:type_name -> cubelet.services.cubebox.v1.ContainerSecurityContext
 	18,  // 21: cubelet.services.cubebox.v1.ContainerConfig.probe:type_name -> cubelet.services.cubebox.v1.Probe
-	87,  // 22: cubelet.services.cubebox.v1.ContainerConfig.sysctls:type_name -> cubelet.services.cubebox.v1.ContainerConfig.SysctlsEntry
+	88,  // 22: cubelet.services.cubebox.v1.ContainerConfig.sysctls:type_name -> cubelet.services.cubebox.v1.ContainerConfig.SysctlsEntry
 	31,  // 23: cubelet.services.cubebox.v1.ContainerConfig.syscalls:type_name -> cubelet.services.cubebox.v1.SysCall
 	10,  // 24: cubelet.services.cubebox.v1.ContainerConfig.dns_config:type_name -> cubelet.services.cubebox.v1.DNSConfig
-	88,  // 25: cubelet.services.cubebox.v1.ContainerConfig.annotations:type_name -> cubelet.services.cubebox.v1.ContainerConfig.AnnotationsEntry
+	89,  // 25: cubelet.services.cubebox.v1.ContainerConfig.annotations:type_name -> cubelet.services.cubebox.v1.ContainerConfig.AnnotationsEntry
 	25,  // 26: cubelet.services.cubebox.v1.ContainerConfig.hostAliases:type_name -> cubelet.services.cubebox.v1.HostAlias
 	20,  // 27: cubelet.services.cubebox.v1.ContainerConfig.prestop:type_name -> cubelet.services.cubebox.v1.PreStop
 	21,  // 28: cubelet.services.cubebox.v1.ContainerConfig.poststop:type_name -> cubelet.services.cubebox.v1.PostStop
@@ -7199,94 +7277,96 @@ var file_api_services_cubebox_v1_cubebox_proto_depIdxs = []int32{
 	33,  // 36: cubelet.services.cubebox.v1.VolumeSource.empty_dir:type_name -> cubelet.services.cubebox.v1.EmptyDirVolumeSource
 	34,  // 37: cubelet.services.cubebox.v1.VolumeSource.sandbox_path:type_name -> cubelet.services.cubebox.v1.SandboxPathVolumeSource
 	36,  // 38: cubelet.services.cubebox.v1.VolumeSource.host_dir_volumes:type_name -> cubelet.services.cubebox.v1.HostDirVolumeSources
-	100, // 39: cubelet.services.cubebox.v1.VolumeSource.image:type_name -> cubelet.services.images.v1.ImageVolumeSource
-	37,  // 40: cubelet.services.cubebox.v1.Volume.volume_source:type_name -> cubelet.services.cubebox.v1.VolumeSource
-	38,  // 41: cubelet.services.cubebox.v1.RunCubeSandboxRequest.volumes:type_name -> cubelet.services.cubebox.v1.Volume
-	26,  // 42: cubelet.services.cubebox.v1.RunCubeSandboxRequest.containers:type_name -> cubelet.services.cubebox.v1.ContainerConfig
-	89,  // 43: cubelet.services.cubebox.v1.RunCubeSandboxRequest.annotations:type_name -> cubelet.services.cubebox.v1.RunCubeSandboxRequest.AnnotationsEntry
-	90,  // 44: cubelet.services.cubebox.v1.RunCubeSandboxRequest.labels:type_name -> cubelet.services.cubebox.v1.RunCubeSandboxRequest.LabelsEntry
-	42,  // 45: cubelet.services.cubebox.v1.RunCubeSandboxRequest.cube_network_config:type_name -> cubelet.services.cubebox.v1.CubeNetworkConfig
-	101, // 46: cubelet.services.cubebox.v1.RunCubeSandboxResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
-	91,  // 47: cubelet.services.cubebox.v1.RunCubeSandboxResponse.ext_info:type_name -> cubelet.services.cubebox.v1.RunCubeSandboxResponse.ExtInfoEntry
-	41,  // 48: cubelet.services.cubebox.v1.RunCubeSandboxResponse.port_mappings:type_name -> cubelet.services.cubebox.v1.PortMapping
-	43,  // 49: cubelet.services.cubebox.v1.CubeNetworkConfig.rules:type_name -> cubelet.services.cubebox.v1.EgressRule
-	44,  // 50: cubelet.services.cubebox.v1.EgressRule.match:type_name -> cubelet.services.cubebox.v1.EgressRuleMatch
-	45,  // 51: cubelet.services.cubebox.v1.EgressRule.action:type_name -> cubelet.services.cubebox.v1.EgressRuleAction
-	46,  // 52: cubelet.services.cubebox.v1.EgressRuleAction.inject:type_name -> cubelet.services.cubebox.v1.EgressRuleInject
-	92,  // 53: cubelet.services.cubebox.v1.DestroyCubeSandboxRequest.annotations:type_name -> cubelet.services.cubebox.v1.DestroyCubeSandboxRequest.AnnotationsEntry
-	52,  // 54: cubelet.services.cubebox.v1.DestroyCubeSandboxRequest.filter:type_name -> cubelet.services.cubebox.v1.CubeSandboxFilter
-	101, // 55: cubelet.services.cubebox.v1.DestroyCubeSandboxResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
-	93,  // 56: cubelet.services.cubebox.v1.DestroyCubeSandboxResponse.ext_info:type_name -> cubelet.services.cubebox.v1.DestroyCubeSandboxResponse.ExtInfoEntry
-	50,  // 57: cubelet.services.cubebox.v1.CubeSandbox.containers:type_name -> cubelet.services.cubebox.v1.Container
-	41,  // 58: cubelet.services.cubebox.v1.CubeSandbox.port_mappings:type_name -> cubelet.services.cubebox.v1.PortMapping
-	94,  // 59: cubelet.services.cubebox.v1.CubeSandbox.labels:type_name -> cubelet.services.cubebox.v1.CubeSandbox.LabelsEntry
-	32,  // 60: cubelet.services.cubebox.v1.Container.resources:type_name -> cubelet.services.cubebox.v1.Resource
-	5,   // 61: cubelet.services.cubebox.v1.Container.state:type_name -> cubelet.services.cubebox.v1.ContainerState
-	95,  // 62: cubelet.services.cubebox.v1.Container.labels:type_name -> cubelet.services.cubebox.v1.Container.LabelsEntry
-	5,   // 63: cubelet.services.cubebox.v1.ContainerStateValue.state:type_name -> cubelet.services.cubebox.v1.ContainerState
-	51,  // 64: cubelet.services.cubebox.v1.CubeSandboxFilter.state:type_name -> cubelet.services.cubebox.v1.ContainerStateValue
-	96,  // 65: cubelet.services.cubebox.v1.CubeSandboxFilter.label_selector:type_name -> cubelet.services.cubebox.v1.CubeSandboxFilter.LabelSelectorEntry
-	52,  // 66: cubelet.services.cubebox.v1.ListCubeSandboxRequest.filter:type_name -> cubelet.services.cubebox.v1.CubeSandboxFilter
-	58,  // 67: cubelet.services.cubebox.v1.ListCubeSandboxRequest.option:type_name -> cubelet.services.cubebox.v1.ListCubeSandboxOption
-	49,  // 68: cubelet.services.cubebox.v1.ListCubeSandboxResponse.items:type_name -> cubelet.services.cubebox.v1.CubeSandbox
-	97,  // 69: cubelet.services.cubebox.v1.UpdateCubeSandboxRequest.annotations:type_name -> cubelet.services.cubebox.v1.UpdateCubeSandboxRequest.AnnotationsEntry
-	101, // 70: cubelet.services.cubebox.v1.UpdateCubeSandboxResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
-	101, // 71: cubelet.services.cubebox.v1.ExecCubeSandboxResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
-	39,  // 72: cubelet.services.cubebox.v1.AppSnapshotRequest.create_request:type_name -> cubelet.services.cubebox.v1.RunCubeSandboxRequest
-	101, // 73: cubelet.services.cubebox.v1.AppSnapshotResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
-	101, // 74: cubelet.services.cubebox.v1.CommitSandboxResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
-	101, // 75: cubelet.services.cubebox.v1.RollbackSandboxResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
-	67,  // 76: cubelet.services.cubebox.v1.CleanupTemplateRequest.objects:type_name -> cubelet.services.cubebox.v1.CowObjectRef
-	101, // 77: cubelet.services.cubebox.v1.CleanupTemplateResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
-	67,  // 78: cubelet.services.cubebox.v1.ListSandboxSnapshotsRequest.objects:type_name -> cubelet.services.cubebox.v1.CowObjectRef
-	101, // 79: cubelet.services.cubebox.v1.ListSandboxSnapshotsResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
-	71,  // 80: cubelet.services.cubebox.v1.ListSandboxSnapshotsResponse.objects:type_name -> cubelet.services.cubebox.v1.CowObjectStatus
-	101, // 81: cubelet.services.cubebox.v1.ListLocalSnapshotsResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
-	74,  // 82: cubelet.services.cubebox.v1.ListLocalSnapshotsResponse.snapshots:type_name -> cubelet.services.cubebox.v1.LocalSnapshotInfo
-	101, // 83: cubelet.services.cubebox.v1.GetLocalSnapshotResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
-	74,  // 84: cubelet.services.cubebox.v1.GetLocalSnapshotResponse.snapshot:type_name -> cubelet.services.cubebox.v1.LocalSnapshotInfo
-	101, // 85: cubelet.services.cubebox.v1.GetStorageMetricsResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
-	98,  // 86: cubelet.services.cubebox.v1.GetStorageMetricsResponse.metrics:type_name -> cubelet.services.cubebox.v1.GetStorageMetricsResponse.MetricsEntry
-	80,  // 87: cubelet.services.cubebox.v1.SandboxStorageInfo.volumes:type_name -> cubelet.services.cubebox.v1.StorageVolumeInfo
-	101, // 88: cubelet.services.cubebox.v1.InspectStorageVolumesResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
-	81,  // 89: cubelet.services.cubebox.v1.InspectStorageVolumesResponse.sandboxes:type_name -> cubelet.services.cubebox.v1.SandboxStorageInfo
-	101, // 90: cubelet.services.cubebox.v1.CleanupOrphanStorageFilesResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
-	85,  // 91: cubelet.services.cubebox.v1.CleanupOrphanStorageFilesResponse.orphans:type_name -> cubelet.services.cubebox.v1.StorageOrphanEntry
-	39,  // 92: cubelet.services.cubebox.v1.CubeboxMgr.Create:input_type -> cubelet.services.cubebox.v1.RunCubeSandboxRequest
-	47,  // 93: cubelet.services.cubebox.v1.CubeboxMgr.Destroy:input_type -> cubelet.services.cubebox.v1.DestroyCubeSandboxRequest
-	53,  // 94: cubelet.services.cubebox.v1.CubeboxMgr.List:input_type -> cubelet.services.cubebox.v1.ListCubeSandboxRequest
-	55,  // 95: cubelet.services.cubebox.v1.CubeboxMgr.Update:input_type -> cubelet.services.cubebox.v1.UpdateCubeSandboxRequest
-	59,  // 96: cubelet.services.cubebox.v1.CubeboxMgr.Exec:input_type -> cubelet.services.cubebox.v1.ExecCubeSandboxRequest
-	61,  // 97: cubelet.services.cubebox.v1.CubeboxMgr.AppSnapshot:input_type -> cubelet.services.cubebox.v1.AppSnapshotRequest
-	63,  // 98: cubelet.services.cubebox.v1.CubeboxMgr.CommitSandbox:input_type -> cubelet.services.cubebox.v1.CommitSandboxRequest
-	65,  // 99: cubelet.services.cubebox.v1.CubeboxMgr.RollbackSandbox:input_type -> cubelet.services.cubebox.v1.RollbackSandboxRequest
-	68,  // 100: cubelet.services.cubebox.v1.CubeboxMgr.CleanupTemplate:input_type -> cubelet.services.cubebox.v1.CleanupTemplateRequest
-	70,  // 101: cubelet.services.cubebox.v1.CubeboxMgr.ListSandboxSnapshots:input_type -> cubelet.services.cubebox.v1.ListSandboxSnapshotsRequest
-	73,  // 102: cubelet.services.cubebox.v1.CubeboxMgr.ListLocalSnapshots:input_type -> cubelet.services.cubebox.v1.ListLocalSnapshotsRequest
-	76,  // 103: cubelet.services.cubebox.v1.CubeboxMgr.GetLocalSnapshot:input_type -> cubelet.services.cubebox.v1.GetLocalSnapshotRequest
-	78,  // 104: cubelet.services.cubebox.v1.CubeboxMgr.GetStorageMetrics:input_type -> cubelet.services.cubebox.v1.GetStorageMetricsRequest
-	82,  // 105: cubelet.services.cubebox.v1.CubeboxMgr.InspectStorageVolumes:input_type -> cubelet.services.cubebox.v1.InspectStorageVolumesRequest
-	84,  // 106: cubelet.services.cubebox.v1.CubeboxMgr.CleanupOrphanStorageFiles:input_type -> cubelet.services.cubebox.v1.CleanupOrphanStorageFilesRequest
-	40,  // 107: cubelet.services.cubebox.v1.CubeboxMgr.Create:output_type -> cubelet.services.cubebox.v1.RunCubeSandboxResponse
-	48,  // 108: cubelet.services.cubebox.v1.CubeboxMgr.Destroy:output_type -> cubelet.services.cubebox.v1.DestroyCubeSandboxResponse
-	54,  // 109: cubelet.services.cubebox.v1.CubeboxMgr.List:output_type -> cubelet.services.cubebox.v1.ListCubeSandboxResponse
-	56,  // 110: cubelet.services.cubebox.v1.CubeboxMgr.Update:output_type -> cubelet.services.cubebox.v1.UpdateCubeSandboxResponse
-	60,  // 111: cubelet.services.cubebox.v1.CubeboxMgr.Exec:output_type -> cubelet.services.cubebox.v1.ExecCubeSandboxResponse
-	62,  // 112: cubelet.services.cubebox.v1.CubeboxMgr.AppSnapshot:output_type -> cubelet.services.cubebox.v1.AppSnapshotResponse
-	64,  // 113: cubelet.services.cubebox.v1.CubeboxMgr.CommitSandbox:output_type -> cubelet.services.cubebox.v1.CommitSandboxResponse
-	66,  // 114: cubelet.services.cubebox.v1.CubeboxMgr.RollbackSandbox:output_type -> cubelet.services.cubebox.v1.RollbackSandboxResponse
-	69,  // 115: cubelet.services.cubebox.v1.CubeboxMgr.CleanupTemplate:output_type -> cubelet.services.cubebox.v1.CleanupTemplateResponse
-	72,  // 116: cubelet.services.cubebox.v1.CubeboxMgr.ListSandboxSnapshots:output_type -> cubelet.services.cubebox.v1.ListSandboxSnapshotsResponse
-	75,  // 117: cubelet.services.cubebox.v1.CubeboxMgr.ListLocalSnapshots:output_type -> cubelet.services.cubebox.v1.ListLocalSnapshotsResponse
-	77,  // 118: cubelet.services.cubebox.v1.CubeboxMgr.GetLocalSnapshot:output_type -> cubelet.services.cubebox.v1.GetLocalSnapshotResponse
-	79,  // 119: cubelet.services.cubebox.v1.CubeboxMgr.GetStorageMetrics:output_type -> cubelet.services.cubebox.v1.GetStorageMetricsResponse
-	83,  // 120: cubelet.services.cubebox.v1.CubeboxMgr.InspectStorageVolumes:output_type -> cubelet.services.cubebox.v1.InspectStorageVolumesResponse
-	86,  // 121: cubelet.services.cubebox.v1.CubeboxMgr.CleanupOrphanStorageFiles:output_type -> cubelet.services.cubebox.v1.CleanupOrphanStorageFilesResponse
-	107, // [107:122] is the sub-list for method output_type
-	92,  // [92:107] is the sub-list for method input_type
-	92,  // [92:92] is the sub-list for extension type_name
-	92,  // [92:92] is the sub-list for extension extendee
-	0,   // [0:92] is the sub-list for field type_name
+	102, // 39: cubelet.services.cubebox.v1.VolumeSource.image:type_name -> cubelet.services.images.v1.ImageVolumeSource
+	38,  // 40: cubelet.services.cubebox.v1.VolumeSource.plugin_volume:type_name -> cubelet.services.cubebox.v1.PluginVolumeSource
+	90,  // 41: cubelet.services.cubebox.v1.PluginVolumeSource.options:type_name -> cubelet.services.cubebox.v1.PluginVolumeSource.OptionsEntry
+	37,  // 42: cubelet.services.cubebox.v1.Volume.volume_source:type_name -> cubelet.services.cubebox.v1.VolumeSource
+	39,  // 43: cubelet.services.cubebox.v1.RunCubeSandboxRequest.volumes:type_name -> cubelet.services.cubebox.v1.Volume
+	26,  // 44: cubelet.services.cubebox.v1.RunCubeSandboxRequest.containers:type_name -> cubelet.services.cubebox.v1.ContainerConfig
+	91,  // 45: cubelet.services.cubebox.v1.RunCubeSandboxRequest.annotations:type_name -> cubelet.services.cubebox.v1.RunCubeSandboxRequest.AnnotationsEntry
+	92,  // 46: cubelet.services.cubebox.v1.RunCubeSandboxRequest.labels:type_name -> cubelet.services.cubebox.v1.RunCubeSandboxRequest.LabelsEntry
+	43,  // 47: cubelet.services.cubebox.v1.RunCubeSandboxRequest.cube_network_config:type_name -> cubelet.services.cubebox.v1.CubeNetworkConfig
+	103, // 48: cubelet.services.cubebox.v1.RunCubeSandboxResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
+	93,  // 49: cubelet.services.cubebox.v1.RunCubeSandboxResponse.ext_info:type_name -> cubelet.services.cubebox.v1.RunCubeSandboxResponse.ExtInfoEntry
+	42,  // 50: cubelet.services.cubebox.v1.RunCubeSandboxResponse.port_mappings:type_name -> cubelet.services.cubebox.v1.PortMapping
+	44,  // 51: cubelet.services.cubebox.v1.CubeNetworkConfig.rules:type_name -> cubelet.services.cubebox.v1.EgressRule
+	45,  // 52: cubelet.services.cubebox.v1.EgressRule.match:type_name -> cubelet.services.cubebox.v1.EgressRuleMatch
+	46,  // 53: cubelet.services.cubebox.v1.EgressRule.action:type_name -> cubelet.services.cubebox.v1.EgressRuleAction
+	47,  // 54: cubelet.services.cubebox.v1.EgressRuleAction.inject:type_name -> cubelet.services.cubebox.v1.EgressRuleInject
+	94,  // 55: cubelet.services.cubebox.v1.DestroyCubeSandboxRequest.annotations:type_name -> cubelet.services.cubebox.v1.DestroyCubeSandboxRequest.AnnotationsEntry
+	53,  // 56: cubelet.services.cubebox.v1.DestroyCubeSandboxRequest.filter:type_name -> cubelet.services.cubebox.v1.CubeSandboxFilter
+	103, // 57: cubelet.services.cubebox.v1.DestroyCubeSandboxResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
+	95,  // 58: cubelet.services.cubebox.v1.DestroyCubeSandboxResponse.ext_info:type_name -> cubelet.services.cubebox.v1.DestroyCubeSandboxResponse.ExtInfoEntry
+	51,  // 59: cubelet.services.cubebox.v1.CubeSandbox.containers:type_name -> cubelet.services.cubebox.v1.Container
+	42,  // 60: cubelet.services.cubebox.v1.CubeSandbox.port_mappings:type_name -> cubelet.services.cubebox.v1.PortMapping
+	96,  // 61: cubelet.services.cubebox.v1.CubeSandbox.labels:type_name -> cubelet.services.cubebox.v1.CubeSandbox.LabelsEntry
+	32,  // 62: cubelet.services.cubebox.v1.Container.resources:type_name -> cubelet.services.cubebox.v1.Resource
+	5,   // 63: cubelet.services.cubebox.v1.Container.state:type_name -> cubelet.services.cubebox.v1.ContainerState
+	97,  // 64: cubelet.services.cubebox.v1.Container.labels:type_name -> cubelet.services.cubebox.v1.Container.LabelsEntry
+	5,   // 65: cubelet.services.cubebox.v1.ContainerStateValue.state:type_name -> cubelet.services.cubebox.v1.ContainerState
+	52,  // 66: cubelet.services.cubebox.v1.CubeSandboxFilter.state:type_name -> cubelet.services.cubebox.v1.ContainerStateValue
+	98,  // 67: cubelet.services.cubebox.v1.CubeSandboxFilter.label_selector:type_name -> cubelet.services.cubebox.v1.CubeSandboxFilter.LabelSelectorEntry
+	53,  // 68: cubelet.services.cubebox.v1.ListCubeSandboxRequest.filter:type_name -> cubelet.services.cubebox.v1.CubeSandboxFilter
+	59,  // 69: cubelet.services.cubebox.v1.ListCubeSandboxRequest.option:type_name -> cubelet.services.cubebox.v1.ListCubeSandboxOption
+	50,  // 70: cubelet.services.cubebox.v1.ListCubeSandboxResponse.items:type_name -> cubelet.services.cubebox.v1.CubeSandbox
+	99,  // 71: cubelet.services.cubebox.v1.UpdateCubeSandboxRequest.annotations:type_name -> cubelet.services.cubebox.v1.UpdateCubeSandboxRequest.AnnotationsEntry
+	103, // 72: cubelet.services.cubebox.v1.UpdateCubeSandboxResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
+	103, // 73: cubelet.services.cubebox.v1.ExecCubeSandboxResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
+	40,  // 74: cubelet.services.cubebox.v1.AppSnapshotRequest.create_request:type_name -> cubelet.services.cubebox.v1.RunCubeSandboxRequest
+	103, // 75: cubelet.services.cubebox.v1.AppSnapshotResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
+	103, // 76: cubelet.services.cubebox.v1.CommitSandboxResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
+	103, // 77: cubelet.services.cubebox.v1.RollbackSandboxResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
+	68,  // 78: cubelet.services.cubebox.v1.CleanupTemplateRequest.objects:type_name -> cubelet.services.cubebox.v1.CowObjectRef
+	103, // 79: cubelet.services.cubebox.v1.CleanupTemplateResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
+	68,  // 80: cubelet.services.cubebox.v1.ListSandboxSnapshotsRequest.objects:type_name -> cubelet.services.cubebox.v1.CowObjectRef
+	103, // 81: cubelet.services.cubebox.v1.ListSandboxSnapshotsResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
+	72,  // 82: cubelet.services.cubebox.v1.ListSandboxSnapshotsResponse.objects:type_name -> cubelet.services.cubebox.v1.CowObjectStatus
+	103, // 83: cubelet.services.cubebox.v1.ListLocalSnapshotsResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
+	75,  // 84: cubelet.services.cubebox.v1.ListLocalSnapshotsResponse.snapshots:type_name -> cubelet.services.cubebox.v1.LocalSnapshotInfo
+	103, // 85: cubelet.services.cubebox.v1.GetLocalSnapshotResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
+	75,  // 86: cubelet.services.cubebox.v1.GetLocalSnapshotResponse.snapshot:type_name -> cubelet.services.cubebox.v1.LocalSnapshotInfo
+	103, // 87: cubelet.services.cubebox.v1.GetStorageMetricsResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
+	100, // 88: cubelet.services.cubebox.v1.GetStorageMetricsResponse.metrics:type_name -> cubelet.services.cubebox.v1.GetStorageMetricsResponse.MetricsEntry
+	81,  // 89: cubelet.services.cubebox.v1.SandboxStorageInfo.volumes:type_name -> cubelet.services.cubebox.v1.StorageVolumeInfo
+	103, // 90: cubelet.services.cubebox.v1.InspectStorageVolumesResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
+	82,  // 91: cubelet.services.cubebox.v1.InspectStorageVolumesResponse.sandboxes:type_name -> cubelet.services.cubebox.v1.SandboxStorageInfo
+	103, // 92: cubelet.services.cubebox.v1.CleanupOrphanStorageFilesResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
+	86,  // 93: cubelet.services.cubebox.v1.CleanupOrphanStorageFilesResponse.orphans:type_name -> cubelet.services.cubebox.v1.StorageOrphanEntry
+	40,  // 94: cubelet.services.cubebox.v1.CubeboxMgr.Create:input_type -> cubelet.services.cubebox.v1.RunCubeSandboxRequest
+	48,  // 95: cubelet.services.cubebox.v1.CubeboxMgr.Destroy:input_type -> cubelet.services.cubebox.v1.DestroyCubeSandboxRequest
+	54,  // 96: cubelet.services.cubebox.v1.CubeboxMgr.List:input_type -> cubelet.services.cubebox.v1.ListCubeSandboxRequest
+	56,  // 97: cubelet.services.cubebox.v1.CubeboxMgr.Update:input_type -> cubelet.services.cubebox.v1.UpdateCubeSandboxRequest
+	60,  // 98: cubelet.services.cubebox.v1.CubeboxMgr.Exec:input_type -> cubelet.services.cubebox.v1.ExecCubeSandboxRequest
+	62,  // 99: cubelet.services.cubebox.v1.CubeboxMgr.AppSnapshot:input_type -> cubelet.services.cubebox.v1.AppSnapshotRequest
+	64,  // 100: cubelet.services.cubebox.v1.CubeboxMgr.CommitSandbox:input_type -> cubelet.services.cubebox.v1.CommitSandboxRequest
+	66,  // 101: cubelet.services.cubebox.v1.CubeboxMgr.RollbackSandbox:input_type -> cubelet.services.cubebox.v1.RollbackSandboxRequest
+	69,  // 102: cubelet.services.cubebox.v1.CubeboxMgr.CleanupTemplate:input_type -> cubelet.services.cubebox.v1.CleanupTemplateRequest
+	71,  // 103: cubelet.services.cubebox.v1.CubeboxMgr.ListSandboxSnapshots:input_type -> cubelet.services.cubebox.v1.ListSandboxSnapshotsRequest
+	74,  // 104: cubelet.services.cubebox.v1.CubeboxMgr.ListLocalSnapshots:input_type -> cubelet.services.cubebox.v1.ListLocalSnapshotsRequest
+	77,  // 105: cubelet.services.cubebox.v1.CubeboxMgr.GetLocalSnapshot:input_type -> cubelet.services.cubebox.v1.GetLocalSnapshotRequest
+	79,  // 106: cubelet.services.cubebox.v1.CubeboxMgr.GetStorageMetrics:input_type -> cubelet.services.cubebox.v1.GetStorageMetricsRequest
+	83,  // 107: cubelet.services.cubebox.v1.CubeboxMgr.InspectStorageVolumes:input_type -> cubelet.services.cubebox.v1.InspectStorageVolumesRequest
+	85,  // 108: cubelet.services.cubebox.v1.CubeboxMgr.CleanupOrphanStorageFiles:input_type -> cubelet.services.cubebox.v1.CleanupOrphanStorageFilesRequest
+	41,  // 109: cubelet.services.cubebox.v1.CubeboxMgr.Create:output_type -> cubelet.services.cubebox.v1.RunCubeSandboxResponse
+	49,  // 110: cubelet.services.cubebox.v1.CubeboxMgr.Destroy:output_type -> cubelet.services.cubebox.v1.DestroyCubeSandboxResponse
+	55,  // 111: cubelet.services.cubebox.v1.CubeboxMgr.List:output_type -> cubelet.services.cubebox.v1.ListCubeSandboxResponse
+	57,  // 112: cubelet.services.cubebox.v1.CubeboxMgr.Update:output_type -> cubelet.services.cubebox.v1.UpdateCubeSandboxResponse
+	61,  // 113: cubelet.services.cubebox.v1.CubeboxMgr.Exec:output_type -> cubelet.services.cubebox.v1.ExecCubeSandboxResponse
+	63,  // 114: cubelet.services.cubebox.v1.CubeboxMgr.AppSnapshot:output_type -> cubelet.services.cubebox.v1.AppSnapshotResponse
+	65,  // 115: cubelet.services.cubebox.v1.CubeboxMgr.CommitSandbox:output_type -> cubelet.services.cubebox.v1.CommitSandboxResponse
+	67,  // 116: cubelet.services.cubebox.v1.CubeboxMgr.RollbackSandbox:output_type -> cubelet.services.cubebox.v1.RollbackSandboxResponse
+	70,  // 117: cubelet.services.cubebox.v1.CubeboxMgr.CleanupTemplate:output_type -> cubelet.services.cubebox.v1.CleanupTemplateResponse
+	73,  // 118: cubelet.services.cubebox.v1.CubeboxMgr.ListSandboxSnapshots:output_type -> cubelet.services.cubebox.v1.ListSandboxSnapshotsResponse
+	76,  // 119: cubelet.services.cubebox.v1.CubeboxMgr.ListLocalSnapshots:output_type -> cubelet.services.cubebox.v1.ListLocalSnapshotsResponse
+	78,  // 120: cubelet.services.cubebox.v1.CubeboxMgr.GetLocalSnapshot:output_type -> cubelet.services.cubebox.v1.GetLocalSnapshotResponse
+	80,  // 121: cubelet.services.cubebox.v1.CubeboxMgr.GetStorageMetrics:output_type -> cubelet.services.cubebox.v1.GetStorageMetricsResponse
+	84,  // 122: cubelet.services.cubebox.v1.CubeboxMgr.InspectStorageVolumes:output_type -> cubelet.services.cubebox.v1.InspectStorageVolumesResponse
+	87,  // 123: cubelet.services.cubebox.v1.CubeboxMgr.CleanupOrphanStorageFiles:output_type -> cubelet.services.cubebox.v1.CleanupOrphanStorageFilesResponse
+	109, // [109:124] is the sub-list for method output_type
+	94,  // [94:109] is the sub-list for method input_type
+	94,  // [94:94] is the sub-list for extension type_name
+	94,  // [94:94] is the sub-list for extension extendee
+	0,   // [0:94] is the sub-list for field type_name
 }
 
 func init() { file_api_services_cubebox_v1_cubebox_proto_init() }
@@ -7297,20 +7377,20 @@ func file_api_services_cubebox_v1_cubebox_proto_init() {
 	file_api_services_cubebox_v1_cubebox_proto_msgTypes[9].OneofWrappers = []any{}
 	file_api_services_cubebox_v1_cubebox_proto_msgTypes[10].OneofWrappers = []any{}
 	file_api_services_cubebox_v1_cubebox_proto_msgTypes[16].OneofWrappers = []any{}
-	file_api_services_cubebox_v1_cubebox_proto_msgTypes[33].OneofWrappers = []any{}
-	file_api_services_cubebox_v1_cubebox_proto_msgTypes[36].OneofWrappers = []any{}
+	file_api_services_cubebox_v1_cubebox_proto_msgTypes[34].OneofWrappers = []any{}
 	file_api_services_cubebox_v1_cubebox_proto_msgTypes[37].OneofWrappers = []any{}
 	file_api_services_cubebox_v1_cubebox_proto_msgTypes[38].OneofWrappers = []any{}
 	file_api_services_cubebox_v1_cubebox_proto_msgTypes[39].OneofWrappers = []any{}
 	file_api_services_cubebox_v1_cubebox_proto_msgTypes[40].OneofWrappers = []any{}
-	file_api_services_cubebox_v1_cubebox_proto_msgTypes[47].OneofWrappers = []any{}
+	file_api_services_cubebox_v1_cubebox_proto_msgTypes[41].OneofWrappers = []any{}
+	file_api_services_cubebox_v1_cubebox_proto_msgTypes[48].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_api_services_cubebox_v1_cubebox_proto_rawDesc), len(file_api_services_cubebox_v1_cubebox_proto_rawDesc)),
 			NumEnums:      6,
-			NumMessages:   93,
+			NumMessages:   95,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/CubeMaster/cmd/cubemastercli/commands/cubebox/template_test.go
+++ b/CubeMaster/cmd/cubemastercli/commands/cubebox/template_test.go
@@ -614,7 +614,7 @@ func TestPrintTemplateSummaryIncludesOptionalMetadata(t *testing.T) {
 	logOutput := logBuf.String()
 	for _, want := range []string{
 		"template_id: tpl-1",
-		"display_name: python-template",
+		"alias: python-template",
 		"created_at: 2026-06-17 12:00:00",
 		"image_info: docker.io/library/python:3.12",
 	} {

--- a/CubeMaster/pkg/base/db/postgres_testutil_test.go
+++ b/CubeMaster/pkg/base/db/postgres_testutil_test.go
@@ -50,6 +50,9 @@ func abortOrSkipDocker(t *testing.T, format string, args ...any) {
 
 func newPostgresTestEnv(t *testing.T) *postgresTestEnv {
 	t.Helper()
+	if testing.Short() {
+		t.Skip("skipping Docker-backed PostgreSQL test in short mode")
+	}
 	if dsn := os.Getenv(postgresDSNEnv); dsn != "" {
 		t.Logf("using external PostgreSQL from %s", postgresDSNEnv)
 		db := openPostgresDB(t, dsn)

--- a/CubeMaster/pkg/base/localcache/localcache.go
+++ b/CubeMaster/pkg/base/localcache/localcache.go
@@ -319,18 +319,37 @@ func (localCache *LocalCache) errStrategy() {
 }
 
 func (localCache *LocalCache) saveFile(file string) {
+	snapshot := cache.New(0, 0)
 	for key, item := range localCache.cache.Items() {
-		element := item.Object.(*list.Element)
-		itm := element.Value.(*util.CacheValue)
-		localCache.cache.Set(key, itm, -1)
+		var itm *util.CacheValue
+		switch value := item.Object.(type) {
+		case *list.Element:
+			var ok bool
+			itm, ok = value.Value.(*util.CacheValue)
+			if !ok {
+				CubeLog.Errorf("Cache(%s) cannot persist key %s: list element contains %T", localCache.name, key, value.Value)
+				continue
+			}
+		case *util.CacheValue:
+			itm = value
+		default:
+			CubeLog.Errorf("Cache(%s) cannot persist key %s: unsupported value type %T", localCache.name, key, item.Object)
+			continue
+		}
+		snapshot.Set(key, itm, -1)
 	}
 
-	_ = localCache.cache.SaveFile(file)
+	if err := snapshot.SaveFile(file); err != nil {
+		CubeLog.Errorf("Cache(%s) failed to save cache file %s: %v", localCache.name, file, err)
+	}
 }
 
 func (localCache *LocalCache) loadFile(file string) {
 	gob.Register(&util.CacheValue{})
-	_ = localCache.cache.LoadFile(file)
+	if err := localCache.cache.LoadFile(file); err != nil {
+		CubeLog.Errorf("Cache(%s) failed to load cache file %s: %v", localCache.name, file, err)
+		return
+	}
 	for key, item := range localCache.cache.Items() {
 		cacheValue := item.Object.(*util.CacheValue)
 		atomic.AddInt64(&localCache.curCacheSize, cacheValue.Size())

--- a/CubeMaster/pkg/base/localcache/localcache_test.go
+++ b/CubeMaster/pkg/base/localcache/localcache_test.go
@@ -6,15 +6,19 @@
 package localcache
 
 import (
+	"container/list"
 	"context"
 	"encoding/json"
 	"fmt"
 	"math/rand"
+	"path/filepath"
 	"sync"
 	"testing"
 	"time"
 
+	"github.com/patrickmn/go-cache"
 	"github.com/stretchr/testify/assert"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/localcache/util"
 )
 
 func TestLocalCache(t *testing.T) {
@@ -139,13 +143,14 @@ func TestNoValue(t *testing.T) {
 }
 
 func TestSaveFile(t *testing.T) {
+	cacheFile := filepath.Join(t.TempDir(), "cache.gob")
 	localCache := NewCache("test",
 		func(ctx context.Context, key string) (val interface{}, found bool, err error) {
 			return "Test", true, nil
 		},
 		&LocalCacheConfig{
 			OpenCacheFile: true,
-			LoadFileName:  "a.txt",
+			LoadFileName:  cacheFile,
 			ExpiredUse:    true,
 			Expired:       5 * time.Second,
 		})
@@ -163,7 +168,7 @@ func TestSaveFile(t *testing.T) {
 		},
 		&LocalCacheConfig{
 			OpenCacheFile: true,
-			LoadFileName:  "a.txt",
+			LoadFileName:  cacheFile,
 			ExpiredUse:    true,
 			Expired:       5 * time.Second,
 		})
@@ -177,6 +182,55 @@ func TestSaveFile(t *testing.T) {
 	}
 	assert.Equal(t, found, true)
 	assert.Equal(t, v.(string), "Test")
+}
+
+func TestSaveFileDoesNotMutateLiveCache(t *testing.T) {
+	valueList := list.New()
+	cacheValue := &util.CacheValue{Key: "key", Value: "value"}
+	liveCache := cache.New(0, 0)
+	element := valueList.PushBack(cacheValue)
+	liveCache.Set("key", element, cache.NoExpiration)
+	localCache := &LocalCache{cache: liveCache}
+
+	localCache.saveFile(filepath.Join(t.TempDir(), "cache.gob"))
+
+	item, found := liveCache.Get("key")
+	if assert.True(t, found) {
+		assert.Same(t, element, item)
+	}
+	assert.Equal(t, 1, valueList.Len())
+}
+
+func TestSaveFileDoesNotPanicOnInvalidCacheEntries(t *testing.T) {
+	valueList := list.New()
+	liveCache := cache.New(0, 0)
+	liveCache.Set("invalid-element", valueList.PushBack("invalid"), cache.NoExpiration)
+	liveCache.Set("invalid-value", "invalid", cache.NoExpiration)
+	localCache := &LocalCache{name: "test", cache: liveCache}
+
+	assert.NotPanics(t, func() {
+		localCache.saveFile(filepath.Join(t.TempDir(), "cache.gob"))
+	})
+}
+
+func TestLoadFileFailurePreservesLiveCache(t *testing.T) {
+	valueList := list.New()
+	cacheValue := &util.CacheValue{Key: "key", Value: "value"}
+	element := valueList.PushBack(cacheValue)
+	liveCache := cache.New(0, 0)
+	liveCache.Set("key", element, cache.NoExpiration)
+	localCache := &LocalCache{name: "test", valueList: valueList, cache: liveCache}
+
+	assert.NotPanics(t, func() {
+		localCache.loadFile(filepath.Join(t.TempDir(), "missing.gob"))
+	})
+
+	item, found := liveCache.Get("key")
+	if assert.True(t, found) {
+		assert.Same(t, element, item)
+	}
+	assert.Equal(t, 1, valueList.Len())
+	assert.Zero(t, localCache.curCacheSize)
 }
 
 func RandString(len int) string {

--- a/CubeMaster/pkg/base/node/node_test.go
+++ b/CubeMaster/pkg/base/node/node_test.go
@@ -5,10 +5,7 @@
 package node
 
 import (
-	"crypto/rand"
 	"fmt"
-	"math"
-	"math/big"
 	pseudorand "math/rand"
 	"testing"
 
@@ -207,42 +204,6 @@ func TestNodes_IndexByPageFallbackRejectsOutOfRangeStart(t *testing.T) {
 	result, endIndex := nodes.IndexByPage(3, 1)
 	assert.Equal(t, 0, len(result))
 	assert.Equal(t, -1, endIndex)
-}
-
-func TestRandNode(t *testing.T) {
-	nodes := NodeList{}
-	testNum := 10
-	for i := 1; i <= testNum; i++ {
-		n := &Node{
-			Index: i,
-			InsID: fmt.Sprintf("%d", i),
-		}
-		nodes.Append(n)
-	}
-	nodes.AllSortByIndex()
-	statm := map[string]int{}
-	max := nodes.Len()
-	for i := 0; i < 100; i++ {
-		n := nodes[pseudorand.Intn(max)]
-		statm[n.InsID]++
-	}
-
-	expected := 100 / max
-	expectdiff := float64(10)
-	for _, v := range statm {
-		assert.LessOrEqual(t, math.Abs(float64((int64(v - expected)))), expectdiff)
-	}
-
-	statmm := map[string]int{}
-	for i := 0; i < 100; i++ {
-		rindex, _ := rand.Int(rand.Reader, big.NewInt(int64(max)))
-		n := nodes[int(rindex.Int64())]
-		statmm[n.InsID]++
-	}
-	for _, v := range statmm {
-		assert.LessOrEqual(t, math.Abs(float64((int64(v - expected)))), expectdiff)
-	}
-
 }
 
 func TestNodeScoreListSorted(t *testing.T) {

--- a/CubeMaster/pkg/base/ret/ret_test.go
+++ b/CubeMaster/pkg/base/ret/ret_test.go
@@ -32,7 +32,7 @@ func TestNewf(t *testing.T) {
 	assert.Equal(t, "test message 1", s.Message())
 
 	str := "test no format"
-	s = Newf(c, str)
+	s = Newf(c, "%s", str)
 	assert.NotNil(t, s)
 	assert.Equal(t, c, s.Code())
 	assert.Equal(t, str, s.Message())

--- a/CubeMaster/pkg/base/wrapredis/redis_test.go
+++ b/CubeMaster/pkg/base/wrapredis/redis_test.go
@@ -22,7 +22,7 @@ func init() {
 	}
 	fmt.Printf("mydir=%s\n", mydir)
 	if os.Getenv("CUBE_MASTER_CONFIG_PATH") == "" {
-		os.Setenv("CUBE_MASTER_CONFIG_PATH", filepath.Clean(filepath.Join(mydir, "../../../test/conf.yaml")))
+		os.Setenv("CUBE_MASTER_CONFIG_PATH", filepath.Clean(filepath.Join(mydir, "../../../conf.yaml")))
 	}
 	config.Init()
 }

--- a/CubeMaster/pkg/selector/prefilter/prefilter.go
+++ b/CubeMaster/pkg/selector/prefilter/prefilter.go
@@ -21,6 +21,8 @@ import (
 type prefilter struct {
 }
 
+var getSchedulableNodesByInstanceType = localcache.GetSchedulableNodesByInstanceType
+
 func NewPreFilter() *prefilter {
 	filter := &prefilter{}
 	return filter
@@ -36,7 +38,7 @@ func (l *prefilter) Select(selCtx *selctx.SelectorCtx) (node.NodeList, error) {
 		return nil, ret.Errorf(errorcode.ErrorCode_MasterInternalError, "scheduler config is nil")
 	}
 
-	nodes := localcache.GetSchedulableNodesByInstanceType(sconf.PreSelectNum, selCtx.InstanceType)
+	nodes := getSchedulableNodesByInstanceType(sconf.PreSelectNum, selCtx.InstanceType)
 
 	if log.IsDebug() {
 		log.G(selCtx.Ctx).Debugf("GetSchedulableNodesByInstanceType:%+v,size:%d", nodes.String(), nodes.Len())

--- a/CubeMaster/pkg/selector/prefilter/prefilter_test.go
+++ b/CubeMaster/pkg/selector/prefilter/prefilter_test.go
@@ -7,10 +7,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/agiledragon/gomonkey/v2"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/config"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/node"
-	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/localcache"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/scheduler/selctx"
 )
 
@@ -38,11 +36,11 @@ func TestPreFilterExcludesUnhealthyNode(t *testing.T) {
 		MetaDataUpdateAt: now, MetricUpdate: now, MetricLocalUpdateAt: now,
 	}
 
-	patches := gomonkey.NewPatches()
-	defer patches.Reset()
-	patches.ApplyFunc(localcache.GetSchedulableNodesByInstanceType, func(n int, product string) node.NodeList {
+	original := getSchedulableNodesByInstanceType
+	getSchedulableNodesByInstanceType = func(n int, product string) node.NodeList {
 		return node.NodeList{fresh, stale}
-	})
+	}
+	t.Cleanup(func() { getSchedulableNodesByInstanceType = original })
 
 	got, err := NewPreFilter().Select(&selctx.SelectorCtx{Ctx: context.Background(), InstanceType: "valid"})
 	if err != nil {
@@ -67,11 +65,11 @@ func TestPreFilterExcludesMetricTimeoutNode(t *testing.T) {
 		MetricLocalUpdateAt: now.Add(-(timeout + time.Second)),
 	}
 
-	patches := gomonkey.NewPatches()
-	defer patches.Reset()
-	patches.ApplyFunc(localcache.GetSchedulableNodesByInstanceType, func(n int, product string) node.NodeList {
+	original := getSchedulableNodesByInstanceType
+	getSchedulableNodesByInstanceType = func(n int, product string) node.NodeList {
 		return node.NodeList{fresh, staleMetric}
-	})
+	}
+	t.Cleanup(func() { getSchedulableNodesByInstanceType = original })
 
 	got, err := NewPreFilter().Select(&selctx.SelectorCtx{Ctx: context.Background(), InstanceType: "valid"})
 	if err != nil {

--- a/CubeMaster/pkg/selector/score/asyncscore_test.go
+++ b/CubeMaster/pkg/selector/score/asyncscore_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/config"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/constants"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/node"
 )
 
@@ -22,9 +23,37 @@ func init() {
 	}
 	fmt.Printf("mydir=%s\n", mydir)
 	if os.Getenv("CUBE_MASTER_CONFIG_PATH") == "" {
-		os.Setenv("CUBE_MASTER_CONFIG_PATH", filepath.Clean(filepath.Join(mydir, "../../../test/conf.yaml")))
+		os.Setenv("CUBE_MASTER_CONFIG_PATH", filepath.Clean(filepath.Join(mydir, "../../../conf.yaml")))
 	}
 	config.Init()
+	if cfg := config.GetConfig(); cfg.Scheduler.Score == nil {
+		cfg.Scheduler.Score = &config.SchedulerScoreConf{
+			ResourceWeights: map[string]float64{
+				constants.WeightFactorMvmNum:            1,
+				constants.WeightFactorQuotaCpu:          1,
+				constants.WeightFactorQuotaMem:          1,
+				constants.WeightFactorCpuUtil:           1,
+				constants.WeightFactorMemUsage:          1,
+				constants.WeightFactorCpuLoadUsage:      1,
+				constants.WeightFactorRealTimeCreateNum: 1,
+				constants.WeightFactorLocalCreateNum:    1,
+			},
+			ScorePluginConf: config.ScorePluginConf{
+				MultiFactorWeightedAverage: &config.MultiFactorWeightedAverage{
+					EnableWeightFactors: []string{
+						constants.WeightFactorMvmNum,
+						constants.WeightFactorQuotaCpu,
+						constants.WeightFactorQuotaMem,
+						constants.WeightFactorCpuUtil,
+						constants.WeightFactorMemUsage,
+						constants.WeightFactorCpuLoadUsage,
+						constants.WeightFactorRealTimeCreateNum,
+						constants.WeightFactorLocalCreateNum,
+					},
+				},
+			},
+		}
+	}
 }
 
 func TestGetMultiFactorWeightedAverageScore(t *testing.T) {

--- a/CubeMaster/pkg/selector/score/imagescore.go
+++ b/CubeMaster/pkg/selector/score/imagescore.go
@@ -28,6 +28,8 @@ type imageScore struct {
 	weight float64
 }
 
+var getImageStateByNode = localcache.GetImageStateByNode
+
 func NewImageScore() *imageScore {
 	if config.GetConfig().Scheduler.Score.ScorePluginConf.ImageScore == nil {
 		panic("config.Scheduler.Score.ScorePluginConf.ImageScore is nil")
@@ -155,7 +157,7 @@ func calculatePriority(sumScores int64, numContainers int) int64 {
 func sumImageScores(nodeInfo *node.Node, images []*selctx.ImageSpec) int64 {
 	var sum int64 = 0
 	for _, image := range images {
-		if state := localcache.GetImageStateByNode(image.ImageID, nodeInfo.ID()); state != nil {
+		if state := getImageStateByNode(image.ImageID, nodeInfo.ID()); state != nil {
 			sum += int64(state.ScaledImageScore)
 		}
 	}
@@ -164,7 +166,7 @@ func sumImageScores(nodeInfo *node.Node, images []*selctx.ImageSpec) int64 {
 
 func sumTemplateScores(nodeInfo *node.Node, templateID string) int64 {
 	var sum int64 = 0
-	if state := localcache.GetImageStateByNode(templateID, nodeInfo.ID()); state != nil {
+	if state := getImageStateByNode(templateID, nodeInfo.ID()); state != nil {
 		sum += int64(state.ScaledImageScore)
 	}
 	return sum

--- a/CubeMaster/pkg/selector/score/imagescore_test.go
+++ b/CubeMaster/pkg/selector/score/imagescore_test.go
@@ -13,9 +13,21 @@ import (
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/constants"
 	fwk "github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/framework"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/node"
-	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/localcache"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/scheduler/selctx"
 )
+
+func stubImageStateLookup(t *testing.T, lookup func(string, string) *fwk.ImageStateSummary) {
+	t.Helper()
+	original := getImageStateByNode
+	getImageStateByNode = lookup
+	t.Cleanup(func() { getImageStateByNode = original })
+}
+
+func missingImageState(string, string) *fwk.ImageStateSummary { return nil }
+
+func imageState(score int64) *fwk.ImageStateSummary {
+	return &fwk.ImageStateSummary{ScaledImageScore: score}
+}
 
 func TestNewImageScore(t *testing.T) {
 	t.Run("正常创建imageScore实例", func(t *testing.T) {
@@ -94,8 +106,7 @@ func TestGetImageWeightedAverageScore(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-
-	localcache.Init(ctx)
+	stubImageStateLookup(t, missingImageState)
 
 	t.Run("配置为空时返回0", func(t *testing.T) {
 		originalConfig := config.GetConfig().Scheduler.Score.ScorePluginConf.ImageScore
@@ -110,6 +121,11 @@ func TestGetImageWeightedAverageScore(t *testing.T) {
 	})
 
 	t.Run("只启用image_id权重因子", func(t *testing.T) {
+		stubImageStateLookup(t, func(imageID, nodeID string) *fwk.ImageStateSummary {
+			assert.Equal(t, "nginx:latest", imageID)
+			assert.Equal(t, "node-1", nodeID)
+			return imageState(40000 * mb)
+		})
 		originalConfig := config.GetConfig().Scheduler.Score.ScorePluginConf.ImageScore
 		originalWeights := config.GetConfig().Scheduler.Score.ResourceWeights
 		defer func() {
@@ -129,51 +145,65 @@ func TestGetImageWeightedAverageScore(t *testing.T) {
 				{ImageID: "nginx:latest"},
 			},
 		}
-		nodeInfo := &node.Node{}
+		nodeInfo := &node.Node{InsID: "node-1"}
 
 		score := getImageWeightedAverageScore(ctx, res, nodeInfo)
-		assert.Equal(t, 0.0, score)
+		assert.Equal(t, float64(calculatePriority(40000*mb, 1))*0.8, score)
+		assert.Positive(t, score)
 	})
 }
 
 func TestGetImageScore(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-
-	localcache.Init(ctx)
+	stubImageStateLookup(t, missingImageState)
 	t.Run("空参数返回0", func(t *testing.T) {
 		score := getImageScore(ctx, nil, nil)
 		assert.Equal(t, 0.0, score)
 	})
 
 	t.Run("正常计算镜像分数", func(t *testing.T) {
+		stubImageStateLookup(t, func(imageID, nodeID string) *fwk.ImageStateSummary {
+			assert.Equal(t, "node-1", nodeID)
+			scores := map[string]int64{
+				"nginx:latest": 60000 * mb,
+				"redis:latest": 40000 * mb,
+			}
+			return imageState(scores[imageID])
+		})
 		images := []*selctx.ImageSpec{
 			{ImageID: "nginx:latest"},
 			{ImageID: "redis:latest"},
 		}
-		nodeInfo := &node.Node{}
+		nodeInfo := &node.Node{InsID: "node-1"}
 
 		score := getImageScore(ctx, images, nodeInfo)
-		assert.Equal(t, 0.0, score)
+		assert.Equal(t, float64(calculatePriority(100000*mb, 2)), score)
+		assert.Positive(t, score)
 	})
 }
 
 func TestGetTemplateScore(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-
-	localcache.Init(ctx)
+	stubImageStateLookup(t, missingImageState)
 	t.Run("空参数返回0", func(t *testing.T) {
 		score := getTemplateScore(ctx, "", nil)
 		assert.Equal(t, 0.0, score)
 	})
 
 	t.Run("正常计算模板分数", func(t *testing.T) {
+		stubImageStateLookup(t, func(templateID, nodeID string) *fwk.ImageStateSummary {
+			assert.Equal(t, "template-123", templateID)
+			assert.Equal(t, "node-1", nodeID)
+			return imageState(40000 * mb)
+		})
 		templateID := "template-123"
-		nodeInfo := &node.Node{}
+		nodeInfo := &node.Node{InsID: "node-1"}
 
 		score := getTemplateScore(ctx, templateID, nodeInfo)
-		assert.Equal(t, 0.0, score)
+		assert.Equal(t, float64(calculatePriority(40000*mb, 1)), score)
+		assert.Positive(t, score)
 	})
 }
 
@@ -192,21 +222,21 @@ func TestCalculatePriority(t *testing.T) {
 		},
 		{
 			name:          "分数在范围内时正常计算",
-			sumScores:     500 * 1024 * 1024,
+			sumScores:     40000 * 1024 * 1024,
 			numContainers: 1,
-			expectedScore: fwk.MaxNodeScore * (500*1024*1024 - minThreshold) / (maxContainerThreshold - minThreshold),
+			expectedScore: 49,
 		},
 		{
 			name:          "分数超过最大值时使用最大值",
-			sumScores:     2000 * 1024 * 1024,
+			sumScores:     90000 * 1024 * 1024,
 			numContainers: 1,
 			expectedScore: fwk.MaxNodeScore,
 		},
 		{
 			name:          "多容器时调整最大阈值",
-			sumScores:     500 * 1024 * 1024,
+			sumScores:     100000 * 1024 * 1024,
 			numContainers: 2,
-			expectedScore: fwk.MaxNodeScore * (500*1024*1024 - minThreshold) / (2*maxContainerThreshold - minThreshold),
+			expectedScore: 62,
 		},
 	}
 
@@ -219,10 +249,23 @@ func TestCalculatePriority(t *testing.T) {
 }
 
 func TestSumImageScores(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	stubImageStateLookup(t, missingImageState)
+	t.Run("累加节点上的镜像状态分数", func(t *testing.T) {
+		stubImageStateLookup(t, func(imageID, nodeID string) *fwk.ImageStateSummary {
+			assert.Equal(t, "node-1", nodeID)
+			return map[string]*fwk.ImageStateSummary{
+				"nginx:latest": imageState(300 * mb),
+				"redis:latest": imageState(200 * mb),
+			}[imageID]
+		})
 
-	localcache.Init(ctx)
+		sum := sumImageScores(&node.Node{InsID: "node-1"}, []*selctx.ImageSpec{
+			{ImageID: "nginx:latest"},
+			{ImageID: "redis:latest"},
+		})
+		assert.Equal(t, int64(500*mb), sum)
+	})
+
 	t.Run("镜像状态为空时返回0", func(t *testing.T) {
 		nodeInfo := &node.Node{}
 		images := []*selctx.ImageSpec{
@@ -244,10 +287,18 @@ func TestSumImageScores(t *testing.T) {
 }
 
 func TestSumTemplateScores(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	stubImageStateLookup(t, missingImageState)
+	t.Run("读取节点上的模板状态分数", func(t *testing.T) {
+		stubImageStateLookup(t, func(templateID, nodeID string) *fwk.ImageStateSummary {
+			assert.Equal(t, "template-123", templateID)
+			assert.Equal(t, "node-1", nodeID)
+			return imageState(500 * mb)
+		})
 
-	localcache.Init(ctx)
+		sum := sumTemplateScores(&node.Node{InsID: "node-1"}, "template-123")
+		assert.Equal(t, int64(500*mb), sum)
+	})
+
 	t.Run("模板状态为空时返回0", func(t *testing.T) {
 		nodeInfo := &node.Node{}
 		templateID := "template-123"
@@ -268,8 +319,7 @@ func TestSumTemplateScores(t *testing.T) {
 func TestImageScoreSelect(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-
-	localcache.Init(ctx)
+	stubImageStateLookup(t, missingImageState)
 
 	t.Run("空亲和性配置返回空节点列表", func(t *testing.T) {
 		originalConfig := config.GetConfig().Scheduler.Score.ScorePluginConf.ImageScore
@@ -319,6 +369,15 @@ func TestImageScoreSelect(t *testing.T) {
 	})
 
 	t.Run("正常计算节点分数 - 镜像亲和性", func(t *testing.T) {
+		stubImageStateLookup(t, func(imageID, nodeID string) *fwk.ImageStateSummary {
+			if nodeID != "node-1" {
+				return nil
+			}
+			return map[string]*fwk.ImageStateSummary{
+				"nginx:latest": imageState(60000 * mb),
+				"redis:latest": imageState(40000 * mb),
+			}[imageID]
+		})
 		originalConfig := config.GetConfig().Scheduler.Score.ScorePluginConf.ImageScore
 		originalWeights := config.GetConfig().Scheduler.Score.ResourceWeights
 		defer func() {
@@ -360,16 +419,20 @@ func TestImageScoreSelect(t *testing.T) {
 		assert.NotNil(t, nodes)
 		assert.Equal(t, 2, nodes.Len())
 
-		for i := 0; i < nodes.Len(); i++ {
-			nodeScore := nodes[i]
-			assert.NotNil(t, nodeScore)
-			assert.Contains(t, []string{"node-1", "node-2"}, nodeScore.InsID)
-
-			assert.Equal(t, 0.0, nodeScore.Score)
-		}
+		assert.Equal(t, "node-1", nodes[0].InsID)
+		assert.Equal(t, float64(calculatePriority(100000*mb, 2)), nodes[0].Score)
+		assert.Positive(t, nodes[0].Score)
+		assert.Equal(t, "node-2", nodes[1].InsID)
+		assert.Zero(t, nodes[1].Score)
+		assert.Greater(t, nodes[0].Score, nodes[1].Score)
 	})
 
 	t.Run("正常计算节点分数 - 模板亲和性", func(t *testing.T) {
+		stubImageStateLookup(t, func(templateID, nodeID string) *fwk.ImageStateSummary {
+			assert.Equal(t, "template-123", templateID)
+			assert.Equal(t, "node-1", nodeID)
+			return imageState(40000 * mb)
+		})
 		originalConfig := config.GetConfig().Scheduler.Score.ScorePluginConf.ImageScore
 		originalWeights := config.GetConfig().Scheduler.Score.ResourceWeights
 		defer func() {
@@ -409,10 +472,18 @@ func TestImageScoreSelect(t *testing.T) {
 		assert.NotNil(t, nodeScore)
 		assert.Equal(t, "node-1", nodeScore.InsID)
 
-		assert.Equal(t, 0.0, nodeScore.Score)
+		assert.Equal(t, float64(calculatePriority(40000*mb, 1)), nodeScore.Score)
+		assert.Positive(t, nodeScore.Score)
 	})
 
 	t.Run("多权重因子组合计算", func(t *testing.T) {
+		stubImageStateLookup(t, func(id, nodeID string) *fwk.ImageStateSummary {
+			assert.Equal(t, "node-1", nodeID)
+			return map[string]*fwk.ImageStateSummary{
+				"nginx:latest": imageState(50000 * mb),
+				"template-123": imageState(30000 * mb),
+			}[id]
+		})
 		originalConfig := config.GetConfig().Scheduler.Score.ScorePluginConf.ImageScore
 		originalWeights := config.GetConfig().Scheduler.Score.ResourceWeights
 		defer func() {
@@ -456,7 +527,10 @@ func TestImageScoreSelect(t *testing.T) {
 		assert.NotNil(t, nodeScore)
 		assert.Equal(t, "node-1", nodeScore.InsID)
 
-		assert.Equal(t, 0.0, nodeScore.Score)
+		expected := float64(calculatePriority(50000*mb, 1))*0.6 +
+			float64(calculatePriority(30000*mb, 1))*0.4
+		assert.Equal(t, expected, nodeScore.Score)
+		assert.Positive(t, nodeScore.Score)
 	})
 
 	t.Run("禁用imageScore时返回空列表", func(t *testing.T) {

--- a/CubeMaster/pkg/service/httpservice/cube/sandboxutil_test.go
+++ b/CubeMaster/pkg/service/httpservice/cube/sandboxutil_test.go
@@ -7,10 +7,24 @@ package cube
 import (
 	"fmt"
 	"os"
-	"path/filepath"
+	"testing"
 
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/config"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/localcache"
 )
+
+const knownSandboxTestID = "0123456789abcdef0123456789abcdef"
+
+func registerKnownSandboxTestID(t *testing.T) {
+	t.Helper()
+	localcache.SetSandboxCache(knownSandboxTestID, &localcache.SandboxCache{
+		SandboxID: knownSandboxTestID,
+		HostIP:    "10.0.0.1",
+	})
+	t.Cleanup(func() {
+		localcache.DeleteSandboxCache(knownSandboxTestID)
+	})
+}
 
 // minimalTestConfig is a bare-minimum configuration that passes validate().
 // It is written to disk on demand so that tests which require a non-nil
@@ -31,23 +45,20 @@ scheduler:
 `
 
 func init() {
-	mydir, err := os.Getwd()
-	if err != nil {
-		panic(err)
-	}
-	fmt.Printf("mydir=%s\n", mydir)
 	if os.Getenv("CUBE_MASTER_CONFIG_PATH") == "" {
-		cfgPath := filepath.Clean(filepath.Join(mydir, "../../../../test/conf.yaml"))
-		os.Setenv("CUBE_MASTER_CONFIG_PATH", cfgPath)
-		// Create a minimal config file on the fly so that config.Init()
-		// succeeds regardless of whether a fixture file was checked in.
-		if _, statErr := os.Stat(cfgPath); os.IsNotExist(statErr) {
-			if err := os.MkdirAll(filepath.Dir(cfgPath), 0755); err != nil {
-				panic(fmt.Sprintf("cannot create test config dir: %v", err))
-			}
-			if err := os.WriteFile(cfgPath, []byte(minimalTestConfig), 0644); err != nil {
-				panic(fmt.Sprintf("cannot write test config: %v", err))
-			}
+		file, err := os.CreateTemp("", "cubemaster-test-conf-*.yaml")
+		if err != nil {
+			panic(fmt.Sprintf("cannot create test config: %v", err))
+		}
+		if _, err := file.WriteString(minimalTestConfig); err != nil {
+			_ = file.Close()
+			panic(fmt.Sprintf("cannot write test config: %v", err))
+		}
+		if err := file.Close(); err != nil {
+			panic(fmt.Sprintf("cannot close test config: %v", err))
+		}
+		if err := os.Setenv("CUBE_MASTER_CONFIG_PATH", file.Name()); err != nil {
+			panic(fmt.Sprintf("cannot set test config path: %v", err))
 		}
 	}
 	config.Init()

--- a/CubeMaster/pkg/service/httpservice/cube/snapshot_test.go
+++ b/CubeMaster/pkg/service/httpservice/cube/snapshot_test.go
@@ -24,6 +24,8 @@ import (
 )
 
 func TestCreateSnapshotSuccessResponse(t *testing.T) {
+	registerKnownSandboxTestID(t)
+
 	origCreateSnapshotFn := createSnapshotFn
 	origGetSnapshotInfoFn := getSnapshotInfoFn
 	origResolveSnapshotHostFn := resolveSnapshotHostFn
@@ -58,14 +60,14 @@ func TestCreateSnapshotSuccessResponse(t *testing.T) {
 		return &templatecenter.SnapshotInfo{
 			SnapshotID:      snapshotID,
 			Status:          "READY",
-			OriginSandboxID: "sb-1",
+			OriginSandboxID: knownSandboxTestID,
 			StorageBackend:  "cubecow",
 		}, nil
 	}
 
 	req := httptest.NewRequest(http.MethodPost, "/cube/snapshot", strings.NewReader(`{
 		"requestID":"req-1",
-		"sandbox_id":"sb-1",
+		"sandbox_id":"`+knownSandboxTestID+`",
 		"display_name":"snap-name"
 	}`))
 	rt := &CubeLog.RequestTrace{}
@@ -78,7 +80,7 @@ func TestCreateSnapshotSuccessResponse(t *testing.T) {
 	assert.Equal(t, int(errorcode.ErrorCode_Success), got.Ret.RetCode)
 	if assert.NotNil(t, got.Snapshot) {
 		assert.Equal(t, "snap-1", got.Snapshot.SnapshotID)
-		assert.Equal(t, "sb-1", got.Snapshot.OriginSandboxID)
+		assert.Equal(t, knownSandboxTestID, got.Snapshot.OriginSandboxID)
 	}
 	if assert.NotNil(t, got.Operation) {
 		assert.Equal(t, "op-1", got.Operation.OperationID)
@@ -98,6 +100,8 @@ func TestSnapshotErrorCodeMapsMySQLLockErrorsToDBError(t *testing.T) {
 }
 
 func TestCreateSnapshotAcceptsSnakeCaseRequestID(t *testing.T) {
+	registerKnownSandboxTestID(t)
+
 	origCreateSnapshotFn := createSnapshotFn
 	origGetSnapshotInfoFn := getSnapshotInfoFn
 	origResolveSnapshotHostFn := resolveSnapshotHostFn
@@ -119,7 +123,7 @@ func TestCreateSnapshotAcceptsSnakeCaseRequestID(t *testing.T) {
 
 	req := httptest.NewRequest(http.MethodPost, "/cube/snapshot", strings.NewReader(`{
 		"request_id":"req-snake",
-		"sandbox_id":"sb-1"
+		"sandbox_id":"`+knownSandboxTestID+`"
 	}`))
 	rt := &CubeLog.RequestTrace{}
 	resp := createSnapshot(req, rt)
@@ -131,6 +135,8 @@ func TestCreateSnapshotAcceptsSnakeCaseRequestID(t *testing.T) {
 }
 
 func TestCreateSnapshotDetachesExecutionFromCanceledRequest(t *testing.T) {
+	registerKnownSandboxTestID(t)
+
 	origCreateSnapshotFn := createSnapshotFn
 	origGetSnapshotInfoFn := getSnapshotInfoFn
 	origResolveSnapshotHostFn := resolveSnapshotHostFn
@@ -172,7 +178,7 @@ func TestCreateSnapshotDetachesExecutionFromCanceledRequest(t *testing.T) {
 
 	baseReq := httptest.NewRequest(http.MethodPost, "/cube/snapshot", strings.NewReader(`{
 		"request_id":"req-detached",
-		"sandbox_id":"sb-1"
+		"sandbox_id":"`+knownSandboxTestID+`"
 	}`))
 	canceledCtx, cancel := context.WithCancel(baseReq.Context())
 	cancel()
@@ -249,13 +255,15 @@ func TestGetSnapshotListSupportsFiltersAndPagination(t *testing.T) {
 }
 
 func TestHandleSandboxRollbackActionUsesPathSandboxID(t *testing.T) {
+	registerKnownSandboxTestID(t)
+
 	origRollbackSnapshotFn := rollbackSnapshotFn
 	t.Cleanup(func() {
 		rollbackSnapshotFn = origRollbackSnapshotFn
 	})
 	rollbackSnapshotFn = func(ctx context.Context, requestID, sandboxID, snapshotID, instanceType string) (*types.TemplateImageJobInfo, error) {
 		assert.Equal(t, "req-rb", requestID)
-		assert.Equal(t, "sb-path", sandboxID)
+		assert.Equal(t, knownSandboxTestID, sandboxID)
 		assert.Equal(t, "snap-1", snapshotID)
 		return &types.TemplateImageJobInfo{
 			JobID:      "op-rb",
@@ -266,7 +274,7 @@ func TestHandleSandboxRollbackActionUsesPathSandboxID(t *testing.T) {
 		}, nil
 	}
 
-	req := httptest.NewRequest(http.MethodPost, "/cube/sandbox/sb-path/rollback", strings.NewReader(`{
+	req := httptest.NewRequest(http.MethodPost, "/cube/sandbox/"+knownSandboxTestID+"/rollback", strings.NewReader(`{
 		"request_id":"req-rb",
 		"snapshot_id":"snap-1"
 	}`))
@@ -275,7 +283,7 @@ func TestHandleSandboxRollbackActionUsesPathSandboxID(t *testing.T) {
 	w := httptest.NewRecorder()
 	gc, _ := gin.CreateTestContext(w)
 	gc.Request = req.WithContext(ctx)
-	gc.Params = gin.Params{{Key: "sandbox_id", Value: "sb-path"}}
+	gc.Params = gin.Params{{Key: "sandbox_id", Value: knownSandboxTestID}}
 	handleSandboxRollbackAction(gc)
 
 	var got operationResponse

--- a/CubeMaster/pkg/service/httpservice/cube/template_commit_test.go
+++ b/CubeMaster/pkg/service/httpservice/cube/template_commit_test.go
@@ -46,8 +46,10 @@ func invokeCommitHandler(t *testing.T, req *http.Request, rt *CubeLog.RequestTra
 }
 
 func TestHandleSandboxCommitActionRejectsEmptyRequestID(t *testing.T) {
+	registerKnownSandboxTestID(t)
+
 	body := `{
-		"sandbox_id":"sb-1",
+		"sandbox_id":"` + knownSandboxTestID + `",
 		"template_id":"tpl-1",
 		"create_request":{
 			"instance_type":"cubebox",
@@ -135,13 +137,12 @@ func TestHandleSandboxCommitActionSanitizesInternalErrors(t *testing.T) {
 }
 
 func TestHandleSandboxCommitActionIgnoresProvidedTemplateID(t *testing.T) {
+	registerKnownSandboxTestID(t)
+
 	patches := gomonkey.NewPatches()
 	defer patches.Reset()
 
 	var submittedTemplateID string
-	patches.ApplyFunc(localcache.GetSandboxCache, func(sandboxID string) *localcache.SandboxCache {
-		return &localcache.SandboxCache{SandboxID: sandboxID, HostIP: "10.0.0.1"}
-	})
 	patches.ApplyFunc(localcache.GetNodesByIp, func(ip string) (*node.Node, bool) {
 		return &node.Node{InsID: "node-1", IP: ip}, true
 	})
@@ -155,7 +156,7 @@ func TestHandleSandboxCommitActionIgnoresProvidedTemplateID(t *testing.T) {
 
 	body := `{
 		"requestID":"req-1",
-		"sandbox_id":"sb-1",
+		"sandbox_id":"` + knownSandboxTestID + `",
 		"template_id":"custom-template",
 		"create_request":{
 			"instance_type":"cubebox",

--- a/CubeMaster/pkg/service/sandbox/sandbox_test.go
+++ b/CubeMaster/pkg/service/sandbox/sandbox_test.go
@@ -109,7 +109,7 @@ func init() {
 	}
 	fmt.Printf("mydir=%s\n", mydir)
 	if os.Getenv("CUBE_MASTER_CONFIG_PATH") == "" {
-		os.Setenv("CUBE_MASTER_CONFIG_PATH", filepath.Clean(filepath.Join(mydir, "../../../test/conf.yaml")))
+		os.Setenv("CUBE_MASTER_CONFIG_PATH", filepath.Clean(filepath.Join(mydir, "../../../conf.yaml")))
 	}
 	config.Init()
 }

--- a/CubeMaster/pkg/service/sandbox/sandbox_timeout.go
+++ b/CubeMaster/pkg/service/sandbox/sandbox_timeout.go
@@ -42,13 +42,13 @@ func SetTimeout(ctx context.Context, req *types.SetTimeoutRequest) (rsp *types.S
 		rsp.Ret.RetMsg = "should provide sandboxID"
 		return
 	}
-	if ret := normalizeSandboxIDInReq(ctx, &req.SandboxID); ret != nil {
-		rsp.Ret = ret
-		return
-	}
 	if req.Timeout < -1 {
 		rsp.Ret.RetCode = int(errorcode.ErrorCode_MasterParamsError)
 		rsp.Ret.RetMsg = "timeout must be >= -1 (use -1 for never timeout)"
+		return
+	}
+	if ret := normalizeSandboxIDInReq(ctx, &req.SandboxID); ret != nil {
+		rsp.Ret = ret
 		return
 	}
 
@@ -90,13 +90,13 @@ func Refresh(ctx context.Context, req *types.RefreshSandboxRequest) (rsp *types.
 		rsp.Ret.RetMsg = "should provide sandboxID"
 		return
 	}
-	if ret := normalizeSandboxIDInReq(ctx, &req.SandboxID); ret != nil {
-		rsp.Ret = ret
-		return
-	}
 	if req.Duration <= 0 {
 		rsp.Ret.RetCode = int(errorcode.ErrorCode_MasterParamsError)
 		rsp.Ret.RetMsg = "duration must be positive (seconds)"
+		return
+	}
+	if ret := normalizeSandboxIDInReq(ctx, &req.SandboxID); ret != nil {
+		rsp.Ret = ret
 		return
 	}
 

--- a/CubeMaster/pkg/service/sandbox/sandbox_timeout_test.go
+++ b/CubeMaster/pkg/service/sandbox/sandbox_timeout_test.go
@@ -48,6 +48,53 @@ func TestSetTimeoutValidationRejectsNegative(t *testing.T) {
 	}
 }
 
+func TestRefreshValidationRejectsNonPositiveDuration(t *testing.T) {
+	for _, duration := range []int32{0, -1} {
+		rsp := Refresh(context.Background(), &types.RefreshSandboxRequest{
+			RequestID: "req-invalid-duration",
+			SandboxID: "sandbox-does-not-need-resolution",
+			Duration:  duration,
+		})
+
+		if rsp.Ret.RetCode != int(errorcode.ErrorCode_MasterParamsError) {
+			t.Fatalf("duration=%d should be rejected as params error, got ret=%+v", duration, rsp.Ret)
+		}
+	}
+}
+
+func TestTimeoutValidationPrecedesSandboxIDResolution(t *testing.T) {
+	const unresolvedSandboxID = " "
+	ctx := context.Background()
+	// A whitespace-only ID passes the initial non-empty check, but normalization
+	// deterministically rejects it before consulting cache or cluster state.
+
+	t.Run("set timeout", func(t *testing.T) {
+		rsp := SetTimeout(ctx, &types.SetTimeoutRequest{
+			RequestID: "req-invalid-timeout-and-sandbox-id",
+			SandboxID: unresolvedSandboxID,
+			Timeout:   -2,
+		})
+
+		if rsp.Ret.RetCode != int(errorcode.ErrorCode_MasterParamsError) ||
+			rsp.Ret.RetMsg != "timeout must be >= -1 (use -1 for never timeout)" {
+			t.Fatalf("timeout validation should take precedence, got ret=%+v", rsp.Ret)
+		}
+	})
+
+	t.Run("refresh", func(t *testing.T) {
+		rsp := Refresh(ctx, &types.RefreshSandboxRequest{
+			RequestID: "req-invalid-duration-and-sandbox-id",
+			SandboxID: unresolvedSandboxID,
+			Duration:  0,
+		})
+
+		if rsp.Ret.RetCode != int(errorcode.ErrorCode_MasterParamsError) ||
+			rsp.Ret.RetMsg != "duration must be positive (seconds)" {
+			t.Fatalf("duration validation should take precedence, got ret=%+v", rsp.Ret)
+		}
+	})
+}
+
 func TestSetTimeoutValidationAllowsNeverTimeout(t *testing.T) {
 	const sandboxID = "sb-timeout-never-validation"
 	localcache.SetSandboxCache(sandboxID, &localcache.SandboxCache{

--- a/CubeMaster/pkg/templatecenter/artifact_gc_mysql_test.go
+++ b/CubeMaster/pkg/templatecenter/artifact_gc_mysql_test.go
@@ -516,6 +516,9 @@ func assertArtifactGCLockCanBeReacquired(t *testing.T, sqlDB *sql.DB) {
 
 func newArtifactGCMySQL(t *testing.T) (*gorm.DB, *sql.DB) {
 	t.Helper()
+	if testing.Short() {
+		t.Skip("skipping Docker-backed MySQL test in short mode")
+	}
 	pool, err := dockertest.NewPool("")
 	if err != nil {
 		abortOrSkipArtifactGCDocker(t, "dockertest not available (%v)", err)

--- a/CubeMaster/pkg/templatecenter/image/image_test.go
+++ b/CubeMaster/pkg/templatecenter/image/image_test.go
@@ -60,7 +60,13 @@ func disableEngineClient(t *testing.T) {
 	})
 }
 
+func disableNativeRootfsExport(t *testing.T) {
+	t.Helper()
+	t.Setenv("CUBEMASTER_NATIVE_ROOTFS_EXPORT_ENABLED", "false")
+}
+
 func TestPrepareSourceImageSkipsPullWhenImageExistsLocally(t *testing.T) {
+	disableNativeRootfsExport(t)
 	patches := gomonkey.NewPatches()
 	defer patches.Reset()
 	disableEngineClient(t)
@@ -98,6 +104,7 @@ func TestPrepareSourceImageSkipsPullWhenImageExistsLocally(t *testing.T) {
 }
 
 func TestPrepareSourceImagePullsAfterLocalInspectMiss(t *testing.T) {
+	disableNativeRootfsExport(t)
 	patches := gomonkey.NewPatches()
 	defer patches.Reset()
 	disableEngineClient(t)
@@ -143,6 +150,7 @@ func TestPrepareSourceImagePullsAfterLocalInspectMiss(t *testing.T) {
 }
 
 func TestPrepareSourceImageReturnsPullErrorAfterInspectMiss(t *testing.T) {
+	disableNativeRootfsExport(t)
 	patches := gomonkey.NewPatches()
 	defer patches.Reset()
 	disableEngineClient(t)
@@ -178,6 +186,7 @@ func TestPrepareSourceImageReturnsPullErrorAfterInspectMiss(t *testing.T) {
 }
 
 func TestPrepareSourceImageUsesSkopeoWhenDockerlessToolsAvailable(t *testing.T) {
+	disableNativeRootfsExport(t)
 	patches := gomonkey.NewPatches()
 	defer patches.Reset()
 	withExecutableLookPath(t, func(file string) (string, error) {
@@ -425,6 +434,7 @@ func TestCreateSkopeoAuthFileNoCredentials(t *testing.T) {
 }
 
 func TestPrepareDockerlessSourceImageCleansAuthFileOnInspectFailure(t *testing.T) {
+	disableNativeRootfsExport(t)
 	patches := gomonkey.NewPatches()
 	defer patches.Reset()
 	withExecutableLookPath(t, func(file string) (string, error) {
@@ -823,11 +833,13 @@ func TestEnsureArtifactBuildPreflightAllowsDockerlessWithoutDockerOrTar(t *testi
 }
 
 func TestEnsureArtifactBuildPreflightRequiresTarForDockerFallback(t *testing.T) {
+	disableNativeRootfsExport(t)
 	binDir := t.TempDir()
 	t.Setenv("PATH", binDir)
-	for _, cmd := range []string{"docker", "mkfs.ext4", "truncate", "cp", "skopeo"} {
+	for _, cmd := range []string{"docker", "truncate", "cp", "skopeo"} {
 		installFakeCommand(t, binDir, cmd, "exit 0")
 	}
+	installFakeCommand(t, binDir, "mkfs.ext4", "echo 'mkfs.ext4 help supports -d'")
 
 	err := EnsureArtifactBuildPreflight(context.Background())
 	if err == nil || !strings.Contains(err.Error(), `required command "tar"`) {
@@ -1112,6 +1124,7 @@ func TestBuildExt4Phase1FailureCleansStoreDir(t *testing.T) {
 }
 
 func TestPrepareLocalSourceUsesDockerlessWhenAvailable(t *testing.T) {
+	disableNativeRootfsExport(t)
 	patches := gomonkey.NewPatches()
 	defer patches.Reset()
 	withExecutableLookPath(t, func(file string) (string, error) {
@@ -1148,6 +1161,7 @@ func TestPrepareLocalSourceUsesDockerlessWhenAvailable(t *testing.T) {
 }
 
 func TestPrepareLocalSourceRequiresLocalDockerImage(t *testing.T) {
+	disableNativeRootfsExport(t)
 	patches := gomonkey.NewPatches()
 	defer patches.Reset()
 	withExecutableLookPath(t, func(file string) (string, error) {

--- a/CubeMaster/pkg/templatecenter/image/native_test.go
+++ b/CubeMaster/pkg/templatecenter/image/native_test.go
@@ -79,7 +79,7 @@ func TestPrepareNativeSourceExtractsDigestAndConfig(t *testing.T) {
 	// Create a dummy layer
 	var b bytes.Buffer
 	tw := tar.NewWriter(&b)
-	tw.WriteHeader(&tar.Header{Name: "test.txt", Size: 4, Mode: 0644})
+	tw.WriteHeader(withCurrentOwnership(&tar.Header{Name: "test.txt", Size: 4, Mode: 0644}))
 	tw.Write([]byte("test"))
 	tw.Close()
 	layer, _ := tarball.LayerFromOpener(func() (io.ReadCloser, error) {
@@ -211,10 +211,10 @@ func TestStreamRegistryWhiteoutResolution(t *testing.T) {
 	// Base layer: creates /dir/file1 and /dir/file2
 	var b1 bytes.Buffer
 	tw1 := tar.NewWriter(&b1)
-	tw1.WriteHeader(&tar.Header{Name: "dir/", Mode: 0755, Typeflag: tar.TypeDir})
-	tw1.WriteHeader(&tar.Header{Name: "dir/file1", Size: 4, Mode: 0644})
+	tw1.WriteHeader(withCurrentOwnership(&tar.Header{Name: "dir/", Mode: 0755, Typeflag: tar.TypeDir}))
+	tw1.WriteHeader(withCurrentOwnership(&tar.Header{Name: "dir/file1", Size: 4, Mode: 0644}))
 	tw1.Write([]byte("data"))
-	tw1.WriteHeader(&tar.Header{Name: "dir/file2", Size: 4, Mode: 0644})
+	tw1.WriteHeader(withCurrentOwnership(&tar.Header{Name: "dir/file2", Size: 4, Mode: 0644}))
 	tw1.Write([]byte("data"))
 	tw1.Close()
 	l1, _ := tarball.LayerFromOpener(func() (io.ReadCloser, error) {
@@ -224,9 +224,9 @@ func TestStreamRegistryWhiteoutResolution(t *testing.T) {
 	// Second layer: deletes /dir/file1 via whiteout, and makes an opaque dir marker /dir/.wh..wh..opq
 	var b2 bytes.Buffer
 	tw2 := tar.NewWriter(&b2)
-	tw2.WriteHeader(&tar.Header{Name: "dir/.wh.file1", Size: 0, Mode: 0644})
-	tw2.WriteHeader(&tar.Header{Name: "dir/.wh..wh..opq", Size: 0, Mode: 0644})
-	tw2.WriteHeader(&tar.Header{Name: "dir/file3", Size: 4, Mode: 0644}) // New file
+	tw2.WriteHeader(withCurrentOwnership(&tar.Header{Name: "dir/.wh.file1", Size: 0, Mode: 0644}))
+	tw2.WriteHeader(withCurrentOwnership(&tar.Header{Name: "dir/.wh..wh..opq", Size: 0, Mode: 0644}))
+	tw2.WriteHeader(withCurrentOwnership(&tar.Header{Name: "dir/file3", Size: 4, Mode: 0644})) // New file
 	tw2.Write([]byte("data"))
 	tw2.Close()
 	l2, _ := tarball.LayerFromOpener(func() (io.ReadCloser, error) {
@@ -264,8 +264,8 @@ func TestStreamRegistryWhiteoutResolution(t *testing.T) {
 func TestStreamRegistryUsesPreparedNativeImage(t *testing.T) {
 	var b1 bytes.Buffer
 	tw1 := tar.NewWriter(&b1)
-	tw1.WriteHeader(&tar.Header{Name: "dir/", Mode: 0755, Typeflag: tar.TypeDir})
-	tw1.WriteHeader(&tar.Header{Name: "dir/file1", Size: 4, Mode: 0644})
+	tw1.WriteHeader(withCurrentOwnership(&tar.Header{Name: "dir/", Mode: 0755, Typeflag: tar.TypeDir}))
+	tw1.WriteHeader(withCurrentOwnership(&tar.Header{Name: "dir/file1", Size: 4, Mode: 0644}))
 	tw1.Write([]byte("data"))
 	tw1.Close()
 	l1, _ := tarball.LayerFromOpener(func() (io.ReadCloser, error) {
@@ -381,7 +381,7 @@ func TestStreamRegistryConcurrencyAndPipelining(t *testing.T) {
 	makeTar := func(filename string) []byte {
 		var buf bytes.Buffer
 		tw := tar.NewWriter(&buf)
-		_ = tw.WriteHeader(&tar.Header{Name: filename, Size: 4, Mode: 0644})
+		_ = tw.WriteHeader(withCurrentOwnership(&tar.Header{Name: filename, Size: 4, Mode: 0644}))
 		_, _ = tw.Write([]byte("data"))
 		_ = tw.Close()
 		return buf.Bytes()
@@ -482,6 +482,14 @@ func TestStreamRegistryConcurrencyAndPipelining(t *testing.T) {
 			}
 		})
 	})
+}
+
+func withCurrentOwnership(header *tar.Header) *tar.Header {
+	// archive.Apply preserves layer ownership. Unit fixtures that do not test
+	// ownership must therefore use IDs the unprivileged builder can apply.
+	header.Uid = os.Getuid()
+	header.Gid = os.Getgid()
+	return header
 }
 
 // --- Test helpers for gated layers ---

--- a/CubeMaster/pkg/templatecenter/postgres_testutil_test.go
+++ b/CubeMaster/pkg/templatecenter/postgres_testutil_test.go
@@ -55,6 +55,9 @@ func skipOrFailPGDocker(t *testing.T, format string, args ...any) {
 
 func newPGDockerEnv(t *testing.T) *pgDockerEnv {
 	t.Helper()
+	if testing.Short() {
+		t.Skip("skipping Docker-backed PostgreSQL test in short mode")
+	}
 	if dsn := os.Getenv(pgTestDSNEnv); dsn != "" {
 		t.Logf("using external PostgreSQL from %s", pgTestDSNEnv)
 		return &pgDockerEnv{dsn: dsn, teardown: func() {}}

--- a/CubeMaster/pkg/templatecenter/snapshot_reconciler.go
+++ b/CubeMaster/pkg/templatecenter/snapshot_reconciler.go
@@ -26,6 +26,8 @@ import (
 	"gorm.io/gorm"
 )
 
+var getSnapshotReconcilerNodes = localcache.GetHealthyNodesByInstanceType
+
 const (
 	snapshotReconcilerInterval  = 5 * time.Minute
 	snapshotOperationTimeout    = 15 * time.Minute
@@ -277,7 +279,7 @@ func reconcileSnapshotReplicaPresence(ctx context.Context) error {
 }
 
 func reconcileSnapshotRuntimeRefs(ctx context.Context) error {
-	nodes := localcache.GetHealthyNodesByInstanceType(-1, cubeboxv1.InstanceType_cubebox.String())
+	nodes := getSnapshotReconcilerNodes(-1, cubeboxv1.InstanceType_cubebox.String())
 	var reconcileErr error
 	for i := range nodes {
 		nodeID := strings.TrimSpace(nodes[i].ID())
@@ -357,7 +359,7 @@ func refreshSnapshotStorageMetrics(ctx context.Context) error {
 		targets = append(targets, refreshTarget{nodeID: nodeID, nodeIP: nodeIP})
 	}
 
-	nodes := localcache.GetHealthyNodesByInstanceType(-1, cubeboxv1.InstanceType_cubebox.String())
+	nodes := getSnapshotReconcilerNodes(-1, cubeboxv1.InstanceType_cubebox.String())
 	for i := range nodes {
 		addTarget(nodes[i].ID(), nodes[i].HostIP())
 	}

--- a/CubeMaster/pkg/templatecenter/snapshot_reconciler_test.go
+++ b/CubeMaster/pkg/templatecenter/snapshot_reconciler_test.go
@@ -137,9 +137,11 @@ func TestRefreshSnapshotStorageMetricsRetriesCachedUnknown(t *testing.T) {
 	patches := gomonkey.NewPatches()
 	defer patches.Reset()
 
-	patches.ApplyFunc(localcache.GetHealthyNodesByInstanceType, func(n int, product string) node.NodeList {
+	originalGetNodes := getSnapshotReconcilerNodes
+	getSnapshotReconcilerNodes = func(n int, product string) node.NodeList {
 		return nil
-	})
+	}
+	t.Cleanup(func() { getSnapshotReconcilerNodes = originalGetNodes })
 	patches.ApplyFunc(cubelet.GetCubeletAddr, func(hostIP string) string { return hostIP })
 
 	type call struct {

--- a/CubeMaster/pkg/volume/plugin/binary/driver_test.go
+++ b/CubeMaster/pkg/volume/plugin/binary/driver_test.go
@@ -11,8 +11,6 @@ import (
 )
 
 func TestCreateParsesPrivateData(t *testing.T) {
-	t.Parallel()
-
 	dir := t.TempDir()
 	script := filepath.Join(dir, "fake-plugin.sh")
 	content := "#!/bin/sh\n" +
@@ -38,8 +36,6 @@ func TestCreateParsesPrivateData(t *testing.T) {
 }
 
 func TestCreateAllowsEmptyPrivateData(t *testing.T) {
-	t.Parallel()
-
 	dir := t.TempDir()
 	script := filepath.Join(dir, "fake-plugin.sh")
 	content := "#!/bin/sh\nprintf '%s\\n' '{\"token\":\"\",\"private_data\":\"\",\"error\":\"\"}'\n"

--- a/docker/Dockerfile.builder
+++ b/docker/Dockerfile.builder
@@ -9,7 +9,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 # (archive.ubuntu.com on amd64, ports.ubuntu.com on arm64). The rewrite is also
 # skipped when GITHUB_ACTIONS=true so CI always builds against upstream.
 ARG APT_MIRROR_BASE=
-ARG GO_VERSION=1.24.8
+ARG GO_VERSION=1.25.7
 ARG PROTOC_VERSION=28.3
 ARG LIBSECCOMP_VERSION=2.5.5
 ARG RUST_TOOLCHAIN_DEFAULT=1.89

--- a/tests/unittest/run.sh
+++ b/tests/unittest/run.sh
@@ -12,7 +12,7 @@
 #
 # By default it runs only the self-contained components (the green gate) and
 # skips "gated" components that need a live database or a full VM. Naming a
-# gated component explicitly (e.g. `run.sh cubemaster`) forces it to run.
+# gated component explicitly (e.g. `run.sh cubelet`) forces it to run.
 #
 # Usage:
 #   tests/unittest/run.sh                 # run the default (self-contained) gate
@@ -70,7 +70,7 @@ cd "$REPO_ROOT"
 #   Components that DO have tests but need an environment the builder lacks
 #   (a live MySQL/PostgreSQL/Redis, or a full VM for hypervisor integration
 #   tests). Skipped by default so the sweep stays green, but run when named
-#   explicitly (e.g. `run.sh cubemaster`). This keeps them visible and runnable
+#   explicitly (e.g. `run.sh cubelet`). This keeps them visible and runnable
 #   without wedging the default gate on environment-only failures.
 #
 # NO_TESTS: "name|reason" — printed as an explicit skip so the absence of unit
@@ -82,6 +82,7 @@ cd "$REPO_ROOT"
 # same package set (`-short` skips the Redis/KVM-dependent cases).
 WITH_TESTS=(
 	"cubeops|Go|0|make cubeops-test"
+	"cubemaster|Go|0|make builder-run BUILDER_CMD='cd /workspace/CubeMaster && go mod download && make proto && if [ -f test/conf.yaml ]; then export CUBE_MASTER_CONFIG_PATH=/workspace/CubeMaster/test/conf.yaml; fi && CI=true go test -short -timeout=20m ./api/... ./pkg/...'"
 	"network-agent|Go|0|make network-agent-test"
 	"cubecow|Go+CGO|0|make cubecow-test-native"
 	"cube-lifecycle-manager|Go|0|make builder-run BUILDER_CMD='cd /workspace/cube-lifecycle-manager && go mod download && go test ./...'"
@@ -98,7 +99,6 @@ WITH_TESTS=(
 
 GATED_TESTS=(
 	"cubelet|Go|0|some pkg tests need a writable cgroupfs / host caps the builder lacks|make builder-run BUILDER_CMD='cd /workspace && IN_CUBE_SANDBOX_BUILDER=1 make cubecow-sdk && cd /workspace/Cubelet && go mod download && make proto && go test -short ./pkg/...'"
-	"cubemaster|Go|0|some tests need a live MySQL/PostgreSQL/Redis|make builder-run BUILDER_CMD='cd /workspace/CubeMaster && go mod download && make proto && if [ -f test/conf.yaml ]; then export CUBE_MASTER_CONFIG_PATH=/workspace/CubeMaster/test/conf.yaml; fi && CI=true go test -short -timeout=20m ./api/... ./pkg/...'"
 	"hypervisor|Rust|1|integration tests need a full VM (windows guest, RAM hotplug)|make builder-run BUILDER_CMD='cd /workspace/hypervisor && cargo test --features kvm'"
 )
 


### PR DESCRIPTION
## Motivation

The change-aware unit-test workflow introduced in #833 initially omitted CubeMaster because its suite did not run reliably in the shared builder CI environment.

CubeMaster declares Go 1.25.7, while the builder image currently uses Go 1.24.8. Letting the older Go command auto-download the module-required toolchain caused coverage collection to fail with `go: no such tool "covdata"`. The suite also contained configuration-path assumptions, root-owned OCI fixtures, inline-sensitive runtime patches, vet-invalid formatting calls, and positive scoring tests that did not exercise non-zero results.

This PR resolves those CubeMaster-specific blockers and then adds the component to the existing unit-test workflow.

## What Changed

- Update the builder image to Go 1.25.7, matching `CubeMaster/go.mod`, while preserving the existing `go list ./...` coverage enumeration.
- Make test configuration deterministic by using the correct component configuration path or an isolated temporary configuration file.
- Use the current test UID/GID for OCI layer fixtures where ownership is not part of the behavior under test.
- Replace inline-sensitive runtime monkey patches with package-local test seams whose default production paths remain unchanged.
- Serialize local-cache data through a detached snapshot instead of mutating the live LRU cache representation.
- Strengthen image-score tests with non-zero lookup results and assertions for lookup IDs, aggregation, threshold conversion, and weighted combinations.
- Update the CubeMaster CLI template-summary assertion to expect the `alias` label introduced by #749 instead of the former `display_name` label.
- Correct stale fixtures and vet-invalid formatting calls without changing the production scoring algorithm.
- Add CubeMaster path detection, manual dispatch, and the `cubemaster-test` target to the change-aware unit-test workflow.

## Review Focus

This PR updates several existing tests and includes a small production fix exposed by the suite. Please pay particular attention to whether:

- The refreshed assertions preserve the original behavior contracts instead of accommodating incorrect behavior.
- The local-cache snapshot fix preserves the live cache representation while retaining the persisted value format.
- The package-level test seams leave the default production paths unchanged.
- The OCI ownership changes only remove unprivileged-builder assumptions from tests where ownership is not under test.

## Validation

The complete CubeMaster unit target passed in the Linux builder:

```bash
cd CubeMaster
make test
```

- `Test CubeMaster` passed in 9m59s with the original coverage-package loop and no `covdata` failure.
- The amd64 and arm64 builder image checks passed with Go 1.25.7.
- Build checks passed for CubeAPI, CubeMaster, Cubelet, CubeShim, agent, and network-agent.
- Code Format Check, DCO Check, and the existing Network Agent unit test passed.

Fork validation: https://github.com/zyl1121/CubeSandbox/pull/7

## Scope

This PR changes:

- `CubeMaster/**`
- `docker/Dockerfile.builder`
- CubeMaster-only entries in `.github/workflows/unit-test-check.yml`

The workflow change does not add a Cubelet mapping or test job. Because the builder Dockerfile is shared infrastructure, its change intentionally revalidates the existing component builds and unit-test targets; those checks passed in the fork validation PR.

Follow-up to #833.
