### PR TITLE
docs(cubelet): translate configuration comments to English

### DIFF
--- a/Cubelet/config/config.toml
+++ b/Cubelet/config/config.toml
@@ -1,6 +1,6 @@
 oom_score = 0
 root = "/data/cubelet/root"
-#独立空间 存放元数据
+# Dedicated space for metadata.
 #mount -t tmpfs -o size=1024m none /data/cubelet/state/
 state = "/data/cubelet/state"
 version = 3
@@ -42,11 +42,11 @@ dynamic_config_path = "/usr/local/services/cubetoolbox/Cubelet/dynamicconf/conf.
 
   [plugins."io.cubelet.internal.v1.volume"]
   [plugins."io.cubelet.internal.v1.shimlog"]
-    #独立空间
+    # Dedicated space.
     #mount -t tmpfs -o size=100m none /data/cubelet/shimlog
     root_path = "/data/cubelet/shimlog"
   [plugins."io.cubelet.internal.v1.cleanup"]
-    #独立空间
+    # Dedicated space.
     #mount -t tmpfs -o size=100m none /data/cubelet/cleanup
     root_path = "/data/cubelet/cleanup"
   [plugins."io.cubelet.internal.v1.cgroup"]
@@ -162,14 +162,14 @@ dynamic_config_path = "/usr/local/services/cubetoolbox/Cubelet/dynamicconf/conf.
     startup_delay = "5s"
 
   [plugins."io.containerd.snapshotter.v1.overlayfs"]
-    #独立空间 存放metada
+    # Dedicated space for metadata.
     #mount -t tmpfs -o size=300m none /data/cubelet/state/
     root_path = "/data/cubelet/state"
-    #独立空间 存放镜像unpack数据和snashot数据
+    # Dedicated space for unpacked image and snapshot data.
     data_path = "/data/cubelet/root"
 
   [plugins."io.containerd.metadata.v1.bolt"]
-    #独立空间
+    # Dedicated space.
     #mount -t tmpfs -o size=300m none /data/cubelet/state/
     root_path = "/data/cubelet/state"
     content_sharing_policy = "shared"

--- a/Cubelet/config/plugin.conf
+++ b/Cubelet/config/plugin.conf
@@ -1,32 +1,32 @@
 [meta]
 name="Cubelet"
-#1表示周期插件，2表示常驻插件,3表示资源包
+# 1: periodic plugin, 2: long-running plugin, 3: resource package.
 type=2
 
 [plugin]
-#插件的可执行文件的路径,如果写相对路径会以cubetoolbox的路径(/usr/local/services/cubetoolbox/${plugin_name}/)为根路径
+# Path to the plugin executable. Relative paths are resolved from /usr/local/services/cubetoolbox/${plugin_name}/.
 entrypoint="bin/cubelet"
-#获取版本信息命令
+# Command used to retrieve version information.
 version_cmd="bin/cubelet -v"
-#可选,程序启动命令,如果不填,默认为entrypoint的值
+# Optional startup command. Defaults to entrypoint when omitted.
 start_cmd="/usr/local/services/cubetoolbox/Cubelet/bin/cubelet -c /usr/local/services/cubetoolbox/Cubelet/config/config.toml --dynamic-conf-path /usr/local/services/cubetoolbox/Cubelet/dynamicconf/conf.yaml"
-#可选,结束插件的可执行文件路径，如果选项未指定，框架将发送SIGKILL信号到插件启动时的进程PID。
+# Optional executable used to stop the plugin. If omitted, the framework sends SIGKILL to the plugin process PID.
 stop_cmd=""
-#可选 重启脚本
+# Optional restart script.
 reload_cmd=""
-#可选 检查插件运行状态，这个选项目前有三种形式：
-#     如果值为 $pid : 检测拉起时进程的pid。不推荐使用。
-#     如果值以@开头：以@以后的字符串作为进程名，检测进程名是否在系统中存在, 推荐使用。
-#     如果不符合上面两种：选项指定的是检测脚本的路径, 脚本返回值为0表示正在运行，否则表示未运行。
-#     若不设置，则不检测插件运行状态。
+# Optional plugin health check. Supported forms:
+#     $pid: check the PID recorded when the plugin started. Not recommended.
+#     Values starting with @: treat the suffix as a process name and check whether it exists. Recommended.
+#     Any other value: path to a check script; exit 0 means running, nonzero means not running.
+#     Omit this option to disable plugin health checks.
 plugin_health_check="@cubelet"
 is_fork=true
 pid_file = "/run/cube-let.pid"
 start_secs = 180
 [mode]
-#值为 yes 表示框架启动时启动此插件，值为 no 表示框架启动时不启动此插件
+# yes starts the plugin with the framework; no leaves it stopped.
 run_start="yes"
-#可选 如果为周期插件 按照crontab表达式解析执行周期
+# Optional crontab expression for periodic plugins.
 cron_pattern=""
 
 [cgroup]

--- a/Cubelet/dynamicconf/conf.yaml
+++ b/Cubelet/dynamicconf/conf.yaml
@@ -8,9 +8,9 @@ common:
    - "/usr/local/cubetools/cube_exec_cmd_before_exist.sh"
   cgroup_set_memory_reparent_file: ""
   disable_host_cgroup: true
-  # 禁用传统的netfile
+  # Disable the legacy netfile.
   disable_host_netfile: true
-  # guest 容器默认 DNS，模板/请求中的 dns_config.servers 优先于这里
+  # Default DNS servers for guest containers. dns_config.servers in a template or request takes precedence.
   default_dns_servers:
     - 119.29.29.29
 

--- a/Cubelet/dynamicconf/resource.conf
+++ b/Cubelet/dynamicconf/resource.conf
@@ -1,12 +1,12 @@
 [meta]
-#插件名称,也作为目录名
+# Plugin name, also used as the directory name.
 name="Cubelet-dynamicconf"
-#1表示周期插件,2表示常驻插件,3表示资源包
+# 1: periodic plugin, 2: long-running plugin, 3: resource package.
 type=3
 [resource]
-#资源文件或目录在主机上的路径(绝对路径)
+# Absolute host path to the resource file or directory.
 host_path="/usr/local/services/cubetoolbox/Cubelet/dynamicconf/conf.yaml"
-#资源文件在压缩包内的路径(压缩包内相对路径)
+# Path to the resource file inside the archive, relative to the archive root.
 src_path="conf.yaml"
-#获取版本信息文件路径
+# File path used to retrieve version information.
 version_file="version"


### PR DESCRIPTION
## Motivation

The Cubelet configuration shipped in the one-click release bundle contains Chinese-only comments. This makes the packaged configuration harder to review and customize for users who do not read Chinese.

## What Changed

- Translate comments in `Cubelet/config` to English.
- Translate comments in `Cubelet/dynamicconf` to English.
- Keep all configuration keys and values unchanged.

## Validation

- Confirmed that `Cubelet/config` and `Cubelet/dynamicconf` contain no remaining Chinese text.
- Compared all non-comment lines with `origin/master`; no configuration data changed.