### PR TITLE
cubelet: store cubebox_os_image artifacts on /data by default

### DIFF
--- a/Cubelet/config/config.toml
+++ b/Cubelet/config/config.toml
@@ -119,6 +119,16 @@ dynamic_config_path = "/usr/local/services/cubetoolbox/Cubelet/dynamicconf/conf.
     # pool_trigger_interval_in_ms = 800
   [plugins."io.cubelet.internal.v1.images"]
     runtime_type = "io.containerd.cube.v2"
+    # cubetoolbox install root (shared kernel).
+    cubetool_base_dir = "/usr/local/services/cubetoolbox"
+    # Template rootfs parent defaults to /data (→ /data/cubebox_os_image).
+    # If you override this, also set CBRI image_base_path and kernel_base_path
+    # to the matching <parent>/cubebox_os_image so write/read paths stay aligned.
+    # os_image_parent_dir = "/data"
+  [plugins."io.cubelet.cbri.v1.cubebox"]
+    # Defaults match images os_image_parent_dir (/data/cubebox_os_image).
+    # image_base_path = "/data/cubebox_os_image"
+    # kernel_base_path = "/data/cubebox_os_image"
   [plugins."io.cubelet.internal.v1.cubebox"]
     default_runtime_name = "cube"
     [plugins."io.cubelet.internal.v1.cubebox".runtimes]
@@ -128,7 +138,6 @@ dynamic_config_path = "/usr/local/services/cubetoolbox/Cubelet/dynamicconf/conf.
       [plugins."io.cubelet.internal.v1.cubebox".runtimes.runc]
         runtime_type = "io.containerd.runc.v2"
     #cube_host_shared_dir = "/run/cube-containers/shared/sandboxes/"
-    cubetool_base_dir = "/usr/local/services/cubetoolbox"
   [plugins."io.cubelet.cubebox-service.v1.cubebox-service"]
     destroy_dead_line = "60s"
     dead_container_ttl = "1h"

--- a/Cubelet/pkg/container/pmem/pmem.go
+++ b/Cubelet/pkg/container/pmem/pmem.go
@@ -5,15 +5,57 @@
 package pmem
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 )
 
-var baseDirPath string
+// DefaultOsImageParentDir is the parent directory for per-instance OS image
+// artifacts (<parent>/<instanceType>_os_image/...). Kept on /data so large
+// template rootfs files do not fill the system disk under cubetoolbox.
+const DefaultOsImageParentDir = "/data"
 
+var (
+	// toolboxBasePath holds the cubetoolbox install root (shared kernel, etc.).
+	toolboxBasePath string
+	// osImageParentPath holds the parent of <instanceType>_os_image directories.
+	osImageParentPath string
+)
+
+// DefaultCubeboxOsImageDir returns the default directory for cubebox OS-image
+// artifacts (/data/cubebox_os_image). Shared by images/pmem and CBRI defaults.
+func DefaultCubeboxOsImageDir() string {
+	return filepath.Join(DefaultOsImageParentDir, "cubebox_os_image")
+}
+
+// ResolveOsImageParentDir returns configured if non-empty, otherwise the
+// default parent for OS-image artifacts.
+func ResolveOsImageParentDir(configured string) string {
+	if configured == "" {
+		return DefaultOsImageParentDir
+	}
+	return configured
+}
+
+// Init configures toolbox paths and stores OS-image artifacts under the same
+// root (backward compatible for tests). Prefer InitWithPaths in production.
 func Init(dataDir string) {
-	baseDirPath = dataDir
-	_ = os.MkdirAll(baseDirPath, os.ModeDir|0755)
+	_ = InitWithPaths(dataDir, dataDir)
+}
+
+// InitWithPaths separates the toolbox install root from the OS-image parent dir.
+// Returns an error if either directory cannot be created so callers fail early.
+func InitWithPaths(toolboxDir, osImageParentDir string) error {
+	toolboxBasePath = toolboxDir
+	osImageParentPath = osImageParentDir
+	if err := os.MkdirAll(toolboxBasePath, os.ModeDir|0755); err != nil {
+		return fmt.Errorf("mkdir toolbox base %s: %w", toolboxBasePath, err)
+	}
+	osImageDir := filepath.Join(osImageParentPath, "cubebox_os_image")
+	if err := os.MkdirAll(osImageDir, os.ModeDir|0755); err != nil {
+		return fmt.Errorf("mkdir os image dir %s: %w", osImageDir, err)
+	}
+	return nil
 }
 
 func GetRawImageFilePath(instanceType, imageID string) string {
@@ -29,11 +71,11 @@ func GetKoFilePath(instanceType, imageID string) string {
 }
 
 func GetSharedKernelFilePath() string {
-	return filepath.Join(baseDirPath, "cube-kernel-scf", "vmlinux")
+	return filepath.Join(toolboxBasePath, "cube-kernel-scf", "vmlinux")
 }
 
 func GetPmemBasePath(instanceType string) string {
-	return filepath.Join(baseDirPath, instanceType+"_os_image")
+	return filepath.Join(osImageParentPath, instanceType+"_os_image")
 }
 
 type CubePmem struct {

--- a/Cubelet/pkg/container/pmem/pmem_test.go
+++ b/Cubelet/pkg/container/pmem/pmem_test.go
@@ -1,0 +1,79 @@
+// Copyright (c) 2024 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package pmem
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestInitWithPathsSeparatesToolboxAndOsImage(t *testing.T) {
+	toolbox := t.TempDir()
+	osParent := t.TempDir()
+	if err := InitWithPaths(toolbox, osParent); err != nil {
+		t.Fatalf("InitWithPaths: %v", err)
+	}
+
+	shared := GetSharedKernelFilePath()
+	wantShared := filepath.Join(toolbox, "cube-kernel-scf", "vmlinux")
+	if shared != wantShared {
+		t.Fatalf("GetSharedKernelFilePath=%q, want %q", shared, wantShared)
+	}
+
+	base := GetPmemBasePath("cubebox")
+	wantBase := filepath.Join(osParent, "cubebox_os_image")
+	if base != wantBase {
+		t.Fatalf("GetPmemBasePath=%q, want %q", base, wantBase)
+	}
+
+	img := GetRawImageFilePath("cubebox", "img-1")
+	wantImg := filepath.Join(wantBase, "img-1", "img-1.ext4")
+	if img != wantImg {
+		t.Fatalf("GetRawImageFilePath=%q, want %q", img, wantImg)
+	}
+}
+
+func TestInitKeepsLegacySingleRoot(t *testing.T) {
+	root := t.TempDir()
+	Init(root)
+
+	if got, want := GetSharedKernelFilePath(), filepath.Join(root, "cube-kernel-scf", "vmlinux"); got != want {
+		t.Fatalf("GetSharedKernelFilePath=%q, want %q", got, want)
+	}
+	if got, want := GetPmemBasePath("cubebox"), filepath.Join(root, "cubebox_os_image"); got != want {
+		t.Fatalf("GetPmemBasePath=%q, want %q", got, want)
+	}
+}
+
+func TestDefaultOsImagePaths(t *testing.T) {
+	if DefaultOsImageParentDir != "/data" {
+		t.Fatalf("DefaultOsImageParentDir=%q, want /data", DefaultOsImageParentDir)
+	}
+	want := "/data/cubebox_os_image"
+	if got := DefaultCubeboxOsImageDir(); got != want {
+		t.Fatalf("DefaultCubeboxOsImageDir=%q, want %q", got, want)
+	}
+}
+
+func TestResolveOsImageParentDir(t *testing.T) {
+	if got := ResolveOsImageParentDir(""); got != DefaultOsImageParentDir {
+		t.Fatalf("empty ResolveOsImageParentDir=%q, want %q", got, DefaultOsImageParentDir)
+	}
+	if got := ResolveOsImageParentDir("/custom"); got != "/custom" {
+		t.Fatalf("custom ResolveOsImageParentDir=%q, want /custom", got)
+	}
+}
+
+func TestInitWithPathsReturnsMkdirError(t *testing.T) {
+	root := t.TempDir()
+	blocker := filepath.Join(root, "blocker")
+	if err := os.WriteFile(blocker, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := InitWithPaths(root, blocker); err == nil {
+		t.Fatal("InitWithPaths: want error when os-image parent is a file")
+	}
+}

--- a/Cubelet/plugins/cbri/cubeboxcbri/cubebox.go
+++ b/Cubelet/plugins/cbri/cubeboxcbri/cubebox.go
@@ -63,8 +63,11 @@ func defaultConfig() *cubeboxInstancePluginConfig {
 	cfg := &cubeboxInstancePluginConfig{
 		BasePath: "/usr/local/services/cubetoolbox",
 	}
-	cfg.ImageBasePath = filepath.Join(cfg.BasePath, "cubebox_os_image")
-	cfg.KernelBasePath = filepath.Join(cfg.BasePath, "cubebox_os_image")
+	// Keep in sync with images plugin default (pmem.DefaultOsImageParentDir).
+	// Overriding os_image_parent_dir also requires updating image_base_path and
+	// kernel_base_path below so write/read paths stay aligned.
+	cfg.ImageBasePath = pmem.DefaultCubeboxOsImageDir()
+	cfg.KernelBasePath = pmem.DefaultCubeboxOsImageDir()
 	cfg.SnapShotBasePath = filepath.Join(cfg.BasePath, "cube-snapshot")
 	cfg.instanceType = cubebox.InstanceType_cubebox.String()
 	return cfg

--- a/Cubelet/plugins/cbri/cubeboxcbri/default_config_test.go
+++ b/Cubelet/plugins/cbri/cubeboxcbri/default_config_test.go
@@ -1,0 +1,22 @@
+// Copyright (c) 2024 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package cubeboxcbri
+
+import (
+	"testing"
+
+	"github.com/tencentcloud/CubeSandbox/Cubelet/pkg/container/pmem"
+)
+
+func TestDefaultConfigOsImageOnData(t *testing.T) {
+	cfg := defaultConfig()
+	want := pmem.DefaultCubeboxOsImageDir()
+	if cfg.ImageBasePath != want {
+		t.Fatalf("ImageBasePath=%q, want %q", cfg.ImageBasePath, want)
+	}
+	if cfg.KernelBasePath != want {
+		t.Fatalf("KernelBasePath=%q, want %q", cfg.KernelBasePath, want)
+	}
+}

--- a/Cubelet/services/images/local.go
+++ b/Cubelet/services/images/local.go
@@ -43,6 +43,10 @@ type Config struct {
 	DiscardUnpackedLayers bool `toml:"discard_unpacked_layers"`
 
 	CubeToolBaseDir string `toml:"cubetool_base_dir"`
+	// OsImageParentDir is the parent of <instanceType>_os_image (default /data).
+	// Large template rootfs artifacts are stored there so they do not fill the
+	// system disk under cubetoolbox.
+	OsImageParentDir string `toml:"os_image_parent_dir"`
 }
 
 type local struct {
@@ -79,6 +83,7 @@ func init() {
 			if config.CubeToolBaseDir == "" {
 				config.CubeToolBaseDir = "/usr/local/services/cubetoolbox"
 			}
+			config.OsImageParentDir = pmem.ResolveOsImageParentDir(config.OsImageParentDir)
 			t, err := time.ParseDuration(config.PullDeadlineStr)
 			if err != nil || t == 0 {
 				config.pullDeadline = defaultPullDeadline
@@ -122,7 +127,9 @@ func init() {
 			ois := oldimagestore.NewStore(client, config.RuntimeType, db, oldimagestore.WithUidFileDir(uidFileDir))
 			_ = ois
 
-			pmem.Init(config.CubeToolBaseDir)
+			if err := pmem.InitWithPaths(config.CubeToolBaseDir, config.OsImageParentDir); err != nil {
+				return nil, fmt.Errorf("init pmem paths: %w", err)
+			}
 			err = imgSrv.recover()
 			if err != nil {
 				return nil, fmt.Errorf("recover images failed: %w", err)

--- a/deploy/kubernetes/chart/values.yaml
+++ b/deploy/kubernetes/chart/values.yaml
@@ -912,8 +912,9 @@ hostPaths:
   # Host-persistent toolbox tree. Big Pod mounts this path whole at
   # /usr/local/services/cubetoolbox (stable volumeMount for InPlace). Installer
   # and Big Pod self-stage copy from /opt/cube-image into this tree; preserve
-  # dirs such as cube-snapshot / cubebox_os_image / cubeletmnt / cube-vs are not
-  # wiped by component installs.
+  # dirs such as cube-snapshot / cubeletmnt / cube-vs are not wiped by component
+  # installs. Template rootfs artifacts live under /data/cubebox_os_image
+  # (not under toolbox) on fresh installs.
   toolbox: /usr/local/services/cubetoolbox
   # Shim ttrpc listen sockets: containerd-shim SOCKET_ROOT is hardcoded to
   # /run/containerd, and LoadExistingShims dials unix:///run/containerd/s/{hash}

--- a/deploy/kubernetes/images/cube-node/Dockerfile
+++ b/deploy/kubernetes/images/cube-node/Dockerfile
@@ -52,6 +52,7 @@ RUN chmod +x \
       /data/log/CubeVmm \
       /data/cube-shim/disks \
       /data/snapshot_pack/disks \
+      /data/cubebox_os_image \
       /tmp/cube
 
 EXPOSE 9999 9998 9966 19090

--- a/deploy/kubernetes/images/cubelet/Dockerfile
+++ b/deploy/kubernetes/images/cubelet/Dockerfile
@@ -41,6 +41,7 @@ RUN printf '{"schema_version":1,"components":{"cubelet":{"version":"%s"},"cubecl
       /data/log/CubeVmm \
       /data/cube-shim/disks \
       /data/snapshot_pack/disks \
+      /data/cubebox_os_image \
       /tmp/cube \
       /run/cube-node
 

--- a/deploy/kubernetes/images/scripts/component-entrypoint.sh
+++ b/deploy/kubernetes/images/scripts/component-entrypoint.sh
@@ -511,6 +511,7 @@ run_cubelet() {
     /data/log/CubeVmm \
     /data/cube-shim/disks \
     /data/snapshot_pack/disks \
+    /data/cubebox_os_image \
     /data/cubelet/state \
     "${TOOLBOX_ROOT}/cube-snapshot" \
     "${TOOLBOX_ROOT}/cube-vs/network"

--- a/deploy/kubernetes/images/scripts/cube-node-entrypoint.sh
+++ b/deploy/kubernetes/images/scripts/cube-node-entrypoint.sh
@@ -217,6 +217,7 @@ mkdir -p \
   /data/log/CubeVmm \
   /data/cube-shim/disks \
   /data/snapshot_pack/disks \
+  /data/cubebox_os_image \
   /data/cubelet/state
 
 # Keep shim bundle metadata on the dataCubelet hostPath across Pod rebuilds.

--- a/deploy/kubernetes/images/scripts/cube-node-init.sh
+++ b/deploy/kubernetes/images/scripts/cube-node-init.sh
@@ -338,6 +338,7 @@ if [ "$CREATE_HOST_DIRS" = "true" ]; then
     "$(host_path /data/log)" \
     "$(host_path /data/cube-shim)" \
     "$(host_path /data/snapshot_pack)" \
+    "$(host_path /data/cubebox_os_image)" \
     "$(host_path /tmp/cube)"
 fi
 

--- a/deploy/one-click/install.sh
+++ b/deploy/one-click/install.sh
@@ -1056,6 +1056,7 @@ select_installed_kernel_vmlinux
 mkdir -p \
   "${INSTALL_PREFIX}/cube-vs/network" \
   "${INSTALL_PREFIX}/cube-snapshot" \
+  /data/cubebox_os_image \
   /data/log/Cubelet \
   /data/log/CubeShim \
   /data/log/CubeVmm \

--- a/docs/guide/troubleshooting/templates.md
+++ b/docs/guide/troubleshooting/templates.md
@@ -8,5 +8,18 @@ lang: en-US
 | Title | Description | Related Issues |
 | --- | --- | --- |
 | Custom `tpl create-from-image` keeps timing out | Two common root causes: (1) the custom image either ships no `envd` or doesn't start it at container startup — the default readiness probe hits `envd` at `49983/health`, so without it the probe `connection refused` until timeout; (2) the host is in a nested-virt environment (e.g. AWS EC2) — missing instruction-set bits (XSAVE family) panic the MicroVM, and doubled VM-exits on page faults slow the in-guest agent enough to blow `VsockServerReady` / probe budget. Fixes: follow the [Bring Your Own Image](../tutorials/bring-your-own-image.md) tutorial for the image; switch to PVM deployment to avoid nested virt. | [#312](https://github.com/TencentCloud/CubeSandbox/issues/312), [#95](https://github.com/TencentCloud/CubeSandbox/issues/95), [#94](https://github.com/TencentCloud/CubeSandbox/issues/94), [#161](https://github.com/TencentCloud/CubeSandbox/issues/161), [#253](https://github.com/TencentCloud/CubeSandbox/issues/253) |
-| Template build fails due to insufficient disk space | Building a template requires unpacking the OCI image and writing it to disk, which consumes a lot of temporary space. When the partition holding `/tmp`, `/data/cubelet` or `/usr/local/services/cubetoolbox/` runs low, the template can stall at `UNPACKING` / `BUILDING_EXT4`, or surface as mkfs.ext4 errors such as directory block checksum mismatch or "Ext2 inode is not a directory". | [#240](https://github.com/TencentCloud/CubeSandbox/issues/240), [#251](https://github.com/TencentCloud/CubeSandbox/issues/251) |
+| Template build fails due to insufficient disk space | Building a template requires unpacking the OCI image and writing it to disk, which consumes a lot of temporary space. When the partition holding `/tmp`, `/data/cubelet` or `/data/cubebox_os_image` (template rootfs artifacts; formerly under `/usr/local/services/cubetoolbox/cubebox_os_image`) runs low, the template can stall at `UNPACKING` / `BUILDING_EXT4`, or surface as mkfs.ext4 errors such as directory block checksum mismatch or "Ext2 inode is not a directory". | [#240](https://github.com/TencentCloud/CubeSandbox/issues/240), [#251](https://github.com/TencentCloud/CubeSandbox/issues/251) |
 | Template Creation Times Out When the Sandbox CIDR Overlaps the LAN | The one-click deployment defaults the sandbox network to `192.168.0.0/18`. If the host LAN also uses `192.168.1.x`, Cube may allocate sandbox IPs that overlap the physical network, causing template creation or port probing to fail with `context deadline exceeded`. Change the Cubelet CIDR to a non-overlapping range and remove the old TAP devices plus `cube-dev` before restarting. | [Guide](./local-network-cidr-conflict.md) |
+
+## Migrating `cubebox_os_image` to `/data`
+
+Template rootfs artifacts default to `/data/cubebox_os_image`. On nodes that still keep them under `/usr/local/services/cubetoolbox/cubebox_os_image`, move once after upgrade (before or right after restarting Cubelet):
+
+```bash
+mkdir -p /data
+mv /usr/local/services/cubetoolbox/cubebox_os_image /data/
+# optional compat symlink for any leftover absolute paths
+ln -sfn /data/cubebox_os_image /usr/local/services/cubetoolbox/cubebox_os_image
+```
+
+If you customize `os_image_parent_dir`, also set CBRI `image_base_path` and `kernel_base_path` to `<parent>/cubebox_os_image` so write and read paths stay aligned.

--- a/docs/zh/guide/troubleshooting/templates.md
+++ b/docs/zh/guide/troubleshooting/templates.md
@@ -8,5 +8,18 @@ lang: zh-CN
 | 标题 | 描述 | 相关 Issues |
 | --- | --- | --- |
 | 自定义模板制作 `tpl create-from-image` 总是超时 | 两类主因：① 自定义镜像里没有 envd 或未在容器启动时拉起（默认 readiness probe 打的就是 envd 的 `49983/health`，未起则 `connection refused` 到超时）；② 在 AWS EC2 等嵌套虚拟化环境部署，受 XSAVE 等指令集缺失导致 MicroVM panic、嵌套页错误慢启动撞 `VsockServerReady` / probe budget。解法分别是按 [自带镜像接入](../tutorials/bring-your-own-image.md) 教程做镜像、以及切到 PVM 部署。 | [#312](https://github.com/TencentCloud/CubeSandbox/issues/312), [#95](https://github.com/TencentCloud/CubeSandbox/issues/95), [#94](https://github.com/TencentCloud/CubeSandbox/issues/94), [#161](https://github.com/TencentCloud/CubeSandbox/issues/161), [#253](https://github.com/TencentCloud/CubeSandbox/issues/253) |
-| 磁盘空间不足导致模板制作失败 | 制作模板时需要把 OCI 镜像解压并写入到磁盘文件，会占用大量临时空间。当 `/tmp`、`/data/cubelet` 或 `/usr/local/services/cubetoolbox/` 所在分区空间不足时，模板可能卡在 `UNPACKING` / `BUILDING_EXT4` 阶段，或表现为 mkfs.ext4 校验和不匹配、inode 类型冲突等错误。 | [#240](https://github.com/TencentCloud/CubeSandbox/issues/240), [#251](https://github.com/TencentCloud/CubeSandbox/issues/251) |
+| 磁盘空间不足导致模板制作失败 | 制作模板时需要把 OCI 镜像解压并写入到磁盘文件，会占用大量临时空间。当 `/tmp`、`/data/cubelet` 或 `/data/cubebox_os_image`（模板 rootfs 制品；旧路径为 `/usr/local/services/cubetoolbox/cubebox_os_image`）所在分区空间不足时，模板可能卡在 `UNPACKING` / `BUILDING_EXT4` 阶段，或表现为 mkfs.ext4 校验和不匹配、inode 类型冲突等错误。 | [#240](https://github.com/TencentCloud/CubeSandbox/issues/240), [#251](https://github.com/TencentCloud/CubeSandbox/issues/251) |
 | 沙箱网段和局域网冲突导致创建模板超时 | one-click 部署默认沙箱网段是 `192.168.0.0/18`。如果宿主机局域网也使用 `192.168.1.x`，Cube 可能给沙箱分配到和真实局域网重叠的 IP 导致模板创建或端口探测以 `context deadline exceeded` 失败。将 Cubelet CIDR 改成不冲突的网段，并在重启前清理旧 TAP 网卡和 `cube-dev`。 | [指南](./local-network-cidr-conflict.md) |
+
+## 将 `cubebox_os_image` 迁移到 `/data`
+
+模板 rootfs 制品默认落在 `/data/cubebox_os_image`。若节点上仍保存在 `/usr/local/services/cubetoolbox/cubebox_os_image`，升级后（重启 Cubelet 前后均可）执行一次迁移：
+
+```bash
+mkdir -p /data
+mv /usr/local/services/cubetoolbox/cubebox_os_image /data/
+# 可选：兼容旧绝对路径的软链
+ln -sfn /data/cubebox_os_image /usr/local/services/cubetoolbox/cubebox_os_image
+```
+
+若自定义了 `os_image_parent_dir`，请同步把 CBRI 的 `image_base_path` / `kernel_base_path` 设为 `<parent>/cubebox_os_image`，保证读写路径一致。


### PR DESCRIPTION
## Summary

- Store template rootfs artifacts under `/data/cubebox_os_image` by default instead of `/usr/local/services/cubetoolbox/cubebox_os_image`, so large ext4 images do not fill the system disk.
- Split pmem toolbox root (shared kernel under cubetoolbox) from OS-image parent (`os_image_parent_dir`, default `/data`).
- Ensure one-click and cube-node entrypoints create `/data/cubebox_os_image`; document the new default in templates troubleshooting (EN/ZH).

Upgrade note: existing nodes with artifacts under cubetoolbox can move them with:

```bash
mkdir -p /data
mv /usr/local/services/cubetoolbox/cubebox_os_image /data/
# optional compat symlink for any leftover absolute paths
ln -sfn /data/cubebox_os_image /usr/local/services/cubetoolbox/cubebox_os_image
```

## Test plan

- [x] `go test ./pkg/container/pmem/ -count=1` in `cube-compiler:ubuntu22` on ubuntu22 — passed
- [x] Path separation: shared kernel stays under toolbox; `GetPmemBasePath("cubebox")` → `<os_image_parent>/cubebox_os_image`
