### PR TITLE
feat(cubemaster): add CUBEMASTER_AUTO_MIGRATION switch to skip startup schema migration

### DIFF
--- a/CubeDB/migrate/automigration_test.go
+++ b/CubeDB/migrate/automigration_test.go
@@ -1,0 +1,50 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package migrate
+
+import (
+	"os"
+	"testing"
+)
+
+func TestAutoMigrationEnabled(t *testing.T) {
+	cases := []struct {
+		name string
+		set  bool // whether to set the env var at all
+		val  string
+		want bool
+	}{
+		{name: "unset", set: false, want: true},
+		{name: "empty", set: true, val: "", want: true},
+		{name: "true", set: true, val: "true", want: true},
+		{name: "one", set: true, val: "1", want: true},
+		{name: "True mixed case", set: true, val: "True", want: true},
+		{name: "on", set: true, val: "on", want: true},
+		{name: "yes", set: true, val: "yes", want: true},
+		{name: "garbage keeps default", set: true, val: "maybe", want: true},
+		{name: "false", set: true, val: "false", want: false},
+		{name: "zero", set: true, val: "0", want: false},
+		{name: "no", set: true, val: "no", want: false},
+		{name: "off", set: true, val: "off", want: false},
+		{name: "FALSE upper case", set: true, val: "FALSE", want: false},
+		{name: "false with surrounding whitespace", set: true, val: "  false  ", want: false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.set {
+				t.Setenv(autoMigrationEnv, tc.val)
+			} else {
+				// t.Setenv registers restoration of the prior value on cleanup;
+				// call it once so the original env is restored, then Unsetenv to
+				// model a genuinely absent variable for this case.
+				t.Setenv(autoMigrationEnv, "")
+				os.Unsetenv(autoMigrationEnv)
+			}
+			if got := AutoMigrationEnabled(); got != tc.want {
+				t.Errorf("AutoMigrationEnabled() with set=%v val=%q = %v, want %v", tc.set, tc.val, got, tc.want)
+			}
+		})
+	}
+}

--- a/CubeDB/migrate/migrate.go
+++ b/CubeDB/migrate/migrate.go
@@ -14,11 +14,35 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
+	"os"
+	"strings"
 
 	"github.com/pressly/goose/v3"
 	"github.com/pressly/goose/v3/database"
 	"github.com/pressly/goose/v3/lock"
 )
+
+// autoMigrationEnv gates the schema migration performed at CubeMaster
+// startup. A runtime database account with no DDL grant cannot run the
+// migrator at all — not even the fingerprint layer's CREATE TABLE — so
+// such a deployment sets this to a falsey value and applies the schema
+// out-of-band with a privileged account.
+const autoMigrationEnv = "CUBEMASTER_AUTO_MIGRATION"
+
+// AutoMigrationEnabled reports whether CubeMaster should run schema
+// migrations at startup. It defaults to true and returns false only for
+// an explicit falsey value (false/0/no/off, case-insensitive). We do not
+// use strconv.ParseBool because it rejects "no"/"off", and any unset,
+// empty, or unrecognised value must keep the safe default (migrate) so a
+// typo can never silently skip migration.
+func AutoMigrationEnabled() bool {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv(autoMigrationEnv))) {
+	case "false", "0", "no", "off":
+		return false
+	default:
+		return true
+	}
+}
 
 //go:embed migrations/mysql/*.sql
 var mysqlMigrations embed.FS

--- a/CubeMaster/cmd/cubemaster/app/main.go
+++ b/CubeMaster/cmd/cubemaster/app/main.go
@@ -21,6 +21,7 @@ import (
 	"github.com/tencentcloud/CubeSandbox/CubeDB/dao"
 	_ "github.com/tencentcloud/CubeSandbox/CubeDB/dao/driver/mysql"    // register mysql driver
 	_ "github.com/tencentcloud/CubeSandbox/CubeDB/dao/driver/postgres" // register postgres driver
+	"github.com/tencentcloud/CubeSandbox/CubeDB/migrate"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/config"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/log"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/recov"
@@ -237,6 +238,16 @@ func initDatabaseSchema(ctx context.Context, cfg *config.Config) error {
 	}
 	if _, err := dao.Open(ctx, daoCfg); err != nil {
 		return fmt.Errorf("dao open: %w", err)
+	}
+	// A runtime account with no DDL permission cannot run the migrator (not even
+	// the fingerprint CREATE TABLE), so let such a deployment skip migration and
+	// apply schema out-of-band with a privileged account. Default is enabled,
+	// so unset/typo never disables migration.
+	if !migrate.AutoMigrationEnabled() {
+		CubeLog.WithContext(ctx).Warnf(
+			"CUBEMASTER_AUTO_MIGRATION=false: skipping schema migration; DDL must be " +
+				"applied out-of-band by a privileged account")
+		return nil
 	}
 	if err := dao.Migrate(ctx); err != nil {
 		return fmt.Errorf("dao migrate: %w", err)


### PR DESCRIPTION
## Summary

Adds an opt-out switch, `CUBEMASTER_AUTO_MIGRATION`, that lets a CubeMaster deployment skip the schema migration it runs at startup.

## Motivation

In a hardened deployment the CubeMaster **runtime** database account is granted DML only, no DDL. Such an account cannot run the startup migrator at all — even when the schema is already at HEAD, the fingerprint defence layer issues an unconditional `CREATE TABLE IF NOT EXISTS`, which fails with `ERROR 1142 (command denied)`. CubeMaster then refuses to boot.

The operational fix in these environments is to apply the schema **out-of-band** with a privileged account (CI job, DBA, etc.) and have CubeMaster boot without touching DDL. Today there is no way to tell CubeMaster to do that.

## Change

- New `migrate.AutoMigrationEnabled()` reads `CUBEMASTER_AUTO_MIGRATION`.
  - Defaults to **true** (migrate).
  - Returns **false** only for an explicit falsey value: `false` / `0` / `no` / `off` (case-insensitive, whitespace-trimmed).
  - Any unset, empty, or unrecognised value keeps the safe default, so a typo can never silently disable migration. (`strconv.ParseBool` is deliberately avoided because it rejects `no`/`off`.)
- `initDatabaseSchema` gates `dao.Migrate` behind the switch, between `dao.Open` and `dao.Migrate`. Because the gate sits at the top level it is dialect-agnostic (applies to both mysql and postgres).
- When the switch is off, CubeMaster logs a clear warning that DDL must be applied out-of-band.

No behaviour change for existing deployments: the default is unchanged (migrate on boot).

## Test plan

- [x] `go build ./...` in both `CubeDB` and `CubeMaster` modules
- [x] `go vet` clean on the changed packages
- [x] New table-driven unit test `TestAutoMigrationEnabled` covering unset / empty / true / 1 / True / on / yes / garbage (→ enabled) and false / 0 / no / off / FALSE / whitespace-wrapped (→ disabled); 14/14 pass