### PR TITLE
feat(helm): deploy CubeOps on k8s

### DIFF
--- a/CubeOps/internal/handler/cluster.go
+++ b/CubeOps/internal/handler/cluster.go
@@ -255,26 +255,25 @@ func (h *ClusterHandler) GetNode(c *gin.Context) {
 
 // Versions handles GET /cluster/versions.
 //
-// CubeMaster's version endpoint sometimes returns an empty data field when
-// the cluster is freshly bootstrapped; we then return an empty shell so the
-// UI doesn't blow up on a nil object.
+// Empty/missing CubeMaster data returns an empty shell for the UI. Otherwise
+// keys are rewritten with camelCaseJSON (same path as writeSDKResponse).
 func (h *ClusterHandler) Versions(c *gin.Context) {
+	empty := map[string]interface{}{
+		"controlPlane": map[string]string{},
+		"components":   []interface{}{},
+		"nodes":        []interface{}{},
+	}
 	data, err := h.cm.ClusterVersions(c.Request.Context())
 	if err != nil {
-		httputil.WriteJSON(c, http.StatusOK, map[string]interface{}{
-			"controlPlane": map[string]string{},
-			"components":   []interface{}{},
-			"nodes":        []interface{}{},
-		})
+		httputil.WriteJSON(c, http.StatusOK, empty)
 		return
 	}
-	// Extract data field if wrapped, otherwise pass through
 	var resp cmResponse
-	if err := json.Unmarshal(data, &resp); err != nil || resp.Data == nil {
-		httputil.WriteRawJSON(c, http.StatusOK, data)
+	if err := json.Unmarshal(data, &resp); err != nil || len(resp.Data) == 0 || string(resp.Data) == "null" {
+		httputil.WriteJSON(c, http.StatusOK, empty)
 		return
 	}
-	httputil.WriteRawJSON(c, http.StatusOK, resp.Data)
+	httputil.WriteRawJSON(c, http.StatusOK, camelCaseJSON(resp.Data))
 }
 
 // --- Transformation helpers ---

--- a/CubeOps/internal/handler/cluster_test.go
+++ b/CubeOps/internal/handler/cluster_test.go
@@ -141,25 +141,69 @@ func TestCluster_GetNode_NotFound(t *testing.T) {
 	}
 }
 
-func TestCluster_Versions_PassThrough(t *testing.T) {
+func TestCluster_Versions_RewritesCamelCase(t *testing.T) {
 	cm := &fakeCM{
 		clusterVersions: func(_ context.Context) (json.RawMessage, error) {
-			return raw(`{"data": {"control_plane": "v1.0"}}`), nil
+			return raw(`{
+				"data": {
+					"control_plane": {"version": "v1.0", "commit": "abc", "build_time": "2026-01-01T00:00:00Z"},
+					"components": [{
+						"component": "cubelet",
+						"declared_version": "v1.0",
+						"declared_versions": ["v1.0"],
+						"consistent": true,
+						"versions": [{"version": "v1.0", "nodes": ["n-1"]}]
+					}],
+					"nodes": [{
+						"node_id": "n-1",
+						"healthy": true,
+						"components": [{"component": "cubelet", "version": "v1.0", "declared": true}]
+					}]
+				}
+			}`), nil
 		},
 	}
 	r := newClusterRouter(t, cm)
 
 	w := httptestRecorder(t, r, "GET", "/api/v1/cluster/versions")
 	if w.Code != http.StatusOK {
-		t.Fatalf("status = %d, want 200", w.Code)
+		t.Fatalf("status = %d, want 200; body=%s", w.Code, w.Body.String())
 	}
-	// The data field is passed through verbatim.
 	var resp map[string]interface{}
 	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
 		t.Fatalf("unmarshal: %v body=%s", err, w.Body.String())
 	}
-	if resp["control_plane"] != "v1.0" {
-		t.Errorf("control_plane = %v, want v1.0", resp["control_plane"])
+	cp, ok := resp["controlPlane"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("controlPlane missing or wrong type: %v", resp)
+	}
+	if cp["version"] != "v1.0" || cp["buildTime"] != "2026-01-01T00:00:00Z" {
+		t.Errorf("controlPlane = %v", cp)
+	}
+	if _, ok := resp["control_plane"]; ok {
+		t.Errorf("snake_case control_plane must not leak into response: %v", resp)
+	}
+	nodes, ok := resp["nodes"].([]interface{})
+	if !ok || len(nodes) != 1 {
+		t.Fatalf("nodes = %v", resp["nodes"])
+	}
+	n0, ok := nodes[0].(map[string]interface{})
+	if !ok {
+		t.Fatalf("node[0] = %v", nodes[0])
+	}
+	if n0["nodeID"] != "n-1" {
+		t.Errorf("nodeID = %v, want n-1", n0["nodeID"])
+	}
+	if _, ok := n0["node_id"]; ok {
+		t.Errorf("snake_case node_id must not leak into response: %v", n0)
+	}
+	comps, ok := resp["components"].([]interface{})
+	if !ok || len(comps) != 1 {
+		t.Fatalf("components = %v", resp["components"])
+	}
+	c0 := comps[0].(map[string]interface{})
+	if c0["declaredVersion"] != "v1.0" {
+		t.Errorf("declaredVersion = %v", c0["declaredVersion"])
 	}
 }
 

--- a/deploy/kubernetes/chart/README.md
+++ b/deploy/kubernetes/chart/README.md
@@ -47,7 +47,8 @@ See [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) for component layering, the f
 | `cubelet` / `network-agent` | Big Pod runtime containers (self-stage then run). |
 | `pause` | Big Pod `cube-slot-1`…`6` placeholders (InPlace-replace later). |
 | `cube-master` | Control-plane master; embedded schema migrations. |
-| `cube-api` | HTTP API. |
+| `cube-api` | External E2B-compatible HTTP API. |
+| `cube-ops` | Ops/admin backend (JWT) + WebUI SDK proxy to CubeMaster. |
 | `cubemastercli` | Operational CLI for exec-based ops. |
 | `cube-proxy` | Data-plane proxy (control-plane placement when enabled). |
 | `cube-lifecycle-manager` | Sandbox auto-pause / auto-resume; discovered via Service DNS and Redis. |
@@ -441,13 +442,16 @@ cubeNode:
       followNodeDns: true          # guests use node/cluster DNS
 ```
 
-## WebUI
+## WebUI and CubeOps
 
-`webui.enabled=true` delivers the one-click WebUI by default:
+`webui.enabled=true` delivers the one-click WebUI by default and **requires** `cubeOps.enabled=true`:
 
 - `cube-webui` image packages one-click `webui/dist` static assets;
-- a chart-rendered nginx config proxies `/cubeapi/` to the CubeAPI Service;
+- a chart-rendered nginx config proxies `/opsapi/` and `/cubeapi/v1/` (SDK) to the CubeOps Service (`0.0.0.0:3010` in-pod, ClusterIP);
+- `/sandbox/` proxies to CubeProxy; static assets are unchanged;
 - the Service listens on port `12088`, matching one-click `WEB_UI_HOST_PORT`.
+
+CubeAPI serves external E2B-compatible SDK clients.
 
 Expose the WebUI externally by changing `webui.service.type` or by adding your platform's ingress/load balancer configuration.
 

--- a/deploy/kubernetes/chart/docs/ARCHITECTURE.md
+++ b/deploy/kubernetes/chart/docs/ARCHITECTURE.md
@@ -7,8 +7,9 @@
 | 层级 | 组件 | Kubernetes 形态 | 主要职责 |
 | --- | --- | --- | --- |
 | 控制面 | CubeMaster | OpenKruise CloneSet + Service + Secret + PVC/hostPath | 节点注册、模板/rootfs artifact、内置 DB migration、调度/元数据 |
-| 控制面 API | CubeAPI | CloneSet + Service | 对外 HTTP API；读写 MySQL；访问 CubeMaster |
-| 管理入口 | WebUI | CloneSet + Service + ConfigMap | 静态控制台；`/cubeapi/` 反代到 CubeAPI |
+| 控制面 API | CubeAPI | CloneSet + Service | 对外 E2B 兼容 HTTP API；读写 MySQL；访问 CubeMaster |
+| 运维后端 | CubeOps | CloneSet + Service | JWT 运维 API + WebUI SDK；监听 `0.0.0.0:3010`；读写 MySQL；访问 CubeMaster |
+| 管理入口 | WebUI | CloneSet + Service + ConfigMap | 静态控制台；`/opsapi/`、`/cubeapi/v1/` 反代到 CubeOps（依赖 `cubeOps.enabled`） |
 | 运维入口 | cubemastercli | CloneSet | `kubectl exec` 用 CLI；注入本 Release 的 CubeMaster endpoint |
 | 依赖存储 | MySQL / Redis | 内置 StatefulSet 或第三方 | 业务数据 / Proxy 与 lifecycle 状态 |
 | 计算面 · 运行时 | `cube-node`（Big Pod） | OpenKruise Advanced DaemonSet（InPlaceIfPossible） | `wait-node-prep` + cubelet / network-agent + 可选 egress；**无 initContainers** |
@@ -25,6 +26,7 @@ flowchart TB
   subgraph CP["Control Plane · placement.controlPlane"]
     CM["cube-master"]
     API["cube-api"]
+    OPS["cube-ops"]
     WEB["cube-webui"]
     CLI["cubemastercli"]
     MYSQL[("MySQL")]
@@ -57,8 +59,11 @@ flowchart TB
     end
   end
 
-  WEB --> API
+  WEB -->|"/opsapi /cubeapi/v1"| OPS
+  WEB -->|"/sandbox/"| PROXY
   CLI --> CM
+  OPS --> CM
+  OPS --> MYSQL
   API --> CM
   API --> MYSQL
   CM --> MYSQL
@@ -86,9 +91,10 @@ flowchart TB
 | `cube-master` | `templates/master.yaml` | `images.master`；挂载 Chart 渲染的 `conf.yaml`；内置 schema migration |
 | `cube-master-config` | `templates/master-config-secret.yaml` | `files/cube-master/conf.yaml` 渲染结果 |
 | `cube-master-storage` | `master.yaml` / `master-pvc.yaml` | 默认 PVC；可选 existingClaim / hostPath / emptyDir |
-| `cube-api` | `templates/api.yaml` | `images.api` |
+| `cube-api` | `templates/api.yaml` | `images.api`（外部 E2B） |
+| `cube-ops` | `templates/ops.yaml` | `images.ops`；ClusterIP；bind `0.0.0.0:3010` |
 | `cubemastercli` | `templates/cubemastercli.yaml` | `images.cubemastercli` |
-| `cube-webui` | `templates/webui.yaml` | `images.webui` + nginx ConfigMap |
+| `cube-webui` | `templates/webui.yaml` | `images.webui` + nginx ConfigMap（上游 CubeOps） |
 | `cube-secret` | `templates/secret.yaml` | MySQL / Redis / Proxy 等密码 |
 
 ### 2.2 MySQL / Redis
@@ -104,7 +110,7 @@ flowchart TB
 
 `cube-node` / `cube-node-installer` / `cube-node-bootstrap` 用 `placement.compute`（**不含** `allow-pvm-bootstrap`）。`cube-node-pvm` 用 `placement.pvm`（含 `allow-pvm-bootstrap`），因此非 PVM 节点不会拉取 `cube-pvm-host-bootstrap` 大镜像。
 
-三条计算面（Big Pod / installer / bootstrap）为 OpenKruise Advanced DaemonSet：Big Pod 使用 `InPlaceIfPossible`，bootstrap/installer 使用 `Standard`。**PVM 为原生 `apps/v1` DaemonSet**（不依赖 kruise-manager 创建 Pod）。无状态控制面（master/api/webui/proxy/lifecycle/cubemastercli）为 CloneSet；MySQL/Redis 继续使用原生 StatefulSet。
+三条计算面（Big Pod / installer / bootstrap）为 OpenKruise Advanced DaemonSet：Big Pod 使用 `InPlaceIfPossible`，bootstrap/installer 使用 `Standard`。**PVM 为原生 `apps/v1` DaemonSet**（不依赖 kruise-manager 创建 Pod）。无状态控制面（master/api/ops/webui/proxy/lifecycle/cubemastercli）为 CloneSet；MySQL/Redis 继续使用原生 StatefulSet。
 
 #### Big Pod：`cube-node`
 
@@ -234,6 +240,7 @@ sequenceDiagram
   participant R as Redis
   participant CM as CubeMaster
   participant API as CubeAPI
+  participant OPS as CubeOps
   participant WEB as WebUI
   participant CLI as cubemastercli
 
@@ -244,7 +251,9 @@ sequenceDiagram
   CM-->>H: /notify/health
   H->>API: CUBE_MASTER_ENDPOINT + MySQL
   API-->>H: /health
-  H->>WEB: nginx → CubeAPI
+  H->>OPS: CUBE_MASTER_ADDR + MySQL
+  OPS-->>H: /health
+  H->>WEB: nginx → CubeOps
   H->>CLI: CUBEMASTERCLI_ADDRESS / PORT
 ```
 
@@ -289,21 +298,24 @@ sequenceDiagram
 
 ### 4.4 注册与验收关注点
 
-- CubeMaster `/notify/health`、CubeAPI `/health`。
-- CubeAPI 能查到 healthy node。
+- CubeMaster `/notify/health`、CubeOps `/health`、CubeAPI `/health`（若启用）。
+- CubeAPI（或经 CubeOps SDK）能查到 healthy node。
 - `cube-node` / installer / bootstrap ready 数等于命中 `placement.compute` 的节点数；`cube-node-pvm` ready 数等于命中 `placement.pvm` 的节点数。
 - egress 启用时 sidecar Ready。
 
 ## 5. 运行期数据流
 
-### 5.1 WebUI / API / Master
+### 5.1 WebUI / CubeOps / CubeAPI / Master
 
 ```mermaid
 flowchart LR
   U["Browser / Operator"] --> WEB["cube-webui"]
-  WEB -->|/cubeapi/*| API["cube-api"]
-  API --> CM["cube-master"]
-  API --> MYSQL[("MySQL")]
+  WEB -->|"/opsapi/ /cubeapi/v1/"| OPS["cube-ops"]
+  Ext["External E2B SDK"] --> API["cube-api"]
+  OPS --> CM["cube-master"]
+  OPS --> MYSQL[("MySQL")]
+  API --> CM
+  API --> MYSQL
   CM --> MYSQL
   CM --> REDIS[("Redis")]
 ```
@@ -389,14 +401,15 @@ externalControlPlane:
 | `cubeProxy.enabled` / `ingress.enabled` | `true` | Proxy / Ingress |
 | `lifecycleManager.enabled` | `true` | Proxy 启用时必开 |
 | `cubeEgress.enabled` | `true` | Big Pod egress sidecar |
-| `webui.enabled` | `true` | WebUI |
+| `cubeOps.enabled` | `true` | CubeOps（JWT 运维 API；WebUI `/opsapi` / SDK 上游） |
+| `webui.enabled` | `true` | WebUI（要求 `cubeOps.enabled=true`） |
 | `controlPlane.templateBuilder.enabled` | `false` | 模板构建 sidecar |
 
 ## 8. Helm test
 
 | Test Pod | 覆盖 |
 | --- | --- |
-| `<release>-health-test` | Master / API / 节点注册 / WebUI / Proxy / 工作负载 Ready / Egress 存在性 |
+| `<release>-health-test` | Master / Ops / API / 节点注册 / WebUI / Proxy / 工作负载 Ready / Egress 存在性 |
 | `<release>-mysql-test` / `redis-test` | 内置依赖连通性 |
 | `<release>-dns-test` | `cube.app` / wildcard → Proxy Service |
 | `<release>-node-image-test` | 镜像内 runtime 工具与 asset |

--- a/deploy/kubernetes/chart/docs/QUICKSTART.md
+++ b/deploy/kubernetes/chart/docs/QUICKSTART.md
@@ -189,11 +189,11 @@ helm test cube -n cube-system --timeout 20m --logs
 **期望结果**:
 
 - `cube-node` DaemonSet Ready 数量 = 打了 compute label 的节点数量
-- `cube-master` / `cube-api` / `cube-proxy` / `cube-webui` CloneSet Ready
+- `cube-master` / `cube-ops` / `cube-api` / `cube-proxy` / `cube-webui` CloneSet Ready
 - `cube-mysql` / `cube-redis` StatefulSet Ready(若使用内置)
 - `helm test` 全绿
 
-登录 WebUI(默认在 `http://<control-node-hostip>:12088`)开始使用。
+登录 WebUI（默认 `http://<control-node-hostip>:12088`）开始使用。WebUI 将 `/opsapi` 与 SDK 路径反代到 CubeOps；外部 E2B 客户端使用 CubeAPI。
 
 ---
 

--- a/deploy/kubernetes/chart/docs/SINGLE-NODE-HELM.md
+++ b/deploy/kubernetes/chart/docs/SINGLE-NODE-HELM.md
@@ -255,8 +255,9 @@ helm test cube -n cube-system --timeout 20m --logs
 
 - `cube-node-pvm` 的 apiVersion 为 `apps/v1`，且 Ready
 - `cube-node` / bootstrap / installer ADS Ready
-- master / api / proxy / webui CloneSet Ready；内置 MySQL/Redis Ready
-- WebUI：`http://<advertiseIP 或 HostIP>:12088`
+- master / ops / api / proxy / webui CloneSet Ready；内置 MySQL/Redis Ready
+- WebUI：`http://<advertiseIP 或 HostIP>:12088`（`/opsapi` 与 SDK 上游为 CubeOps）
+- CubeAPI：对外 E2B 兼容 HTTP API
 
 ---
 

--- a/deploy/kubernetes/chart/runtime-values.example.yaml
+++ b/deploy/kubernetes/chart/runtime-values.example.yaml
@@ -85,3 +85,11 @@ redis:
 # Optional: mirror Cube-owned images into a private registry
 # global:
 #   imageRegistry: my-mirror.example.com/cubesandbox
+#
+# Or override per-image repositories (required when the path differs from the
+# chart default cubesandbox-chart/... — e.g. private TCR cube-sandbox/...):
+# images:
+#   ops:
+#     repository: my-mirror.example.com/cube-sandbox/cube-ops
+#     tag: v0.5.1
+#     pullPolicy: Always

--- a/deploy/kubernetes/chart/templates/NOTES.txt
+++ b/deploy/kubernetes/chart/templates/NOTES.txt
@@ -18,8 +18,13 @@ Persistence (CubeMaster / MySQL / Redis):
 {{- if .Values.controlPlane.enabled }}
 Control plane:
   CubeMaster Service: {{ include "cube.masterName" . }}:{{ .Values.controlPlane.master.service.port }}
-  CubeAPI Service:    {{ include "cube.apiName" . }}:{{ .Values.controlPlane.api.service.port }}
-{{- if .Values.webui.enabled }}
+{{- if .Values.controlPlane.api.enabled }}
+  CubeAPI Service:    {{ include "cube.apiName" . }}:{{ .Values.controlPlane.api.service.port }} (external E2B SDK)
+{{- end }}
+{{- if eq (include "cube.opsEnabled" .) "true" }}
+  CubeOps Service:    {{ include "cube.opsName" . }}:{{ .Values.cubeOps.service.port }} (WebUI /opsapi + SDK)
+{{- end }}
+{{- if and .Values.webui.enabled (eq (include "cube.opsEnabled" .) "true") }}
   WebUI Service:      {{ include "cube.webuiName" . }}:{{ .Values.webui.service.port }}
 {{- end }}
 {{- if eq (include "cube.cubemastercliEnabled" .) "true" }}

--- a/deploy/kubernetes/chart/templates/_helpers.tpl
+++ b/deploy/kubernetes/chart/templates/_helpers.tpl
@@ -188,6 +188,164 @@ tolerations:
 {{- printf "%s-webui" (include "cube.fullname" .) -}}
 {{- end -}}
 
+{{- define "cube.opsName" -}}
+{{- printf "%s-ops" (include "cube.fullname" .) -}}
+{{- end -}}
+
+{{- define "cube.opsEnabled" -}}
+{{- $ops := default dict .Values.cubeOps -}}
+{{- if and .Values.controlPlane.enabled (dig "enabled" true $ops) -}}true{{- else -}}false{{- end -}}
+{{- end -}}
+
+{{- define "cube.opsFQDN" -}}
+{{- printf "%s.%s.svc.%s" (include "cube.opsName" .) .Release.Namespace (include "cube.clusterDomain" .) -}}
+{{- end -}}
+
+{{- define "cube.opsUpstream" -}}
+{{- $override := dig "opsUpstream" "" (default dict .Values.webui) | trimSuffix "/" -}}
+{{- if $override -}}
+{{- $override -}}
+{{- else -}}
+{{- printf "http://%s:%v" (include "cube.opsFQDN" .) .Values.cubeOps.service.port -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "cube.webuiProxyUpstream" -}}
+{{- $override := dig "proxyUpstream" "" (default dict .Values.webui) | trimSuffix "/" -}}
+{{- if $override -}}
+{{- $override -}}
+{{- else if eq (include "cube.proxyEnabled" .) "true" -}}
+{{- printf "http://%s:%v" (include "cube.proxyServiceFQDN" .) .Values.cubeProxy.ports.http.containerPort -}}
+{{- else -}}
+{{- "" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+WebUI OpenResty config: static SPA + /opsapi|/cubeapi/v1/SDK → CubeOps, optional /sandbox/ → CubeProxy.
+Rendered into cube-webui-config and checksum'd so edits roll the CloneSet.
+*/}}
+{{- define "cube.webuiNginxConf" -}}
+{{- $opsUpstream := include "cube.opsUpstream" . -}}
+{{- $proxyUpstream := include "cube.webuiProxyUpstream" . -}}
+worker_processes auto;
+
+events {
+    worker_connections 1024;
+}
+
+http {
+    include /usr/local/openresty/nginx/conf/mime.types;
+    default_type application/octet-stream;
+
+    sendfile on;
+    tcp_nopush on;
+    tcp_nodelay on;
+    keepalive_timeout 65;
+
+    gzip on;
+    gzip_types text/plain text/css application/javascript application/json application/xml;
+
+    map $http_upgrade $connection_upgrade {
+        default upgrade;
+        ''      '';
+    }
+
+    server {
+        listen 80;
+        server_name _;
+
+        root /usr/share/nginx/html;
+        index index.html;
+
+        location = /cubeapi {
+            return 308 /cubeapi/;
+        }
+
+        {{- if $proxyUpstream }}
+        location ^~ /sandbox/ {
+            proxy_http_version 1.1;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection $connection_upgrade;
+            proxy_read_timeout 7206s;
+            proxy_send_timeout 7206s;
+
+            proxy_pass {{ $proxyUpstream }};
+        }
+        {{- end }}
+
+        location /opsapi/ {
+            proxy_http_version 1.1;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_read_timeout 300s;
+            proxy_send_timeout 300s;
+
+            proxy_pass {{ $opsUpstream }}/api/;
+        }
+
+        location /cubeapi/v1/ {
+            proxy_http_version 1.1;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_read_timeout 300s;
+            proxy_send_timeout 300s;
+
+            rewrite ^/cubeapi/v1/(.*)$ /api/v1/sdk/$1 break;
+            proxy_pass {{ $opsUpstream }};
+        }
+
+        location = /health {
+            proxy_pass {{ $opsUpstream }}/health;
+        }
+
+        location ~ ^/(sandboxes|v2/sandboxes|templates|snapshots) {
+            if ($http_authorization = "") {
+                return 418;
+            }
+            add_header Vary "Authorization" always;
+            add_header Cache-Control "no-store" always;
+            proxy_http_version 1.1;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_read_timeout 300s;
+            proxy_send_timeout 300s;
+
+            rewrite ^/(.*)$ /api/v1/sdk/$1 break;
+            proxy_pass {{ $opsUpstream }};
+        }
+
+        error_page 418 = @spa_fallback;
+        location @spa_fallback {
+            root /usr/share/nginx/html;
+            try_files /index.html =404;
+            add_header Vary "Authorization" always;
+            add_header Cache-Control "no-store, no-cache, must-revalidate" always;
+        }
+
+        location /assets/ {
+            try_files $uri =404;
+            expires 1y;
+            add_header Cache-Control "public, immutable";
+        }
+
+        location / {
+            try_files $uri $uri/ /index.html;
+        }
+    }
+}
+{{- end -}}
+
 {{- define "cube.nodeName" -}}
 {{- printf "%s-node" (include "cube.fullname" .) -}}
 {{- end -}}
@@ -397,7 +555,7 @@ iptables -t mangle -S "${chain}" | grep -q -- "--dport 443"
 {{- end -}}
 
 {{- define "cube.secretEnabled" -}}
-{{- if or (and .Values.controlPlane.enabled (or .Values.controlPlane.master.enabled .Values.controlPlane.api.enabled)) (eq (include "cube.proxyEnabled" .) "true") (eq (include "cube.mysqlBuiltinEnabled" .) "true") (eq (include "cube.redisBuiltinEnabled" .) "true") -}}true{{- else -}}false{{- end -}}
+{{- if or (and .Values.controlPlane.enabled (or .Values.controlPlane.master.enabled .Values.controlPlane.api.enabled (eq (include "cube.opsEnabled" .) "true"))) (eq (include "cube.proxyEnabled" .) "true") (eq (include "cube.mysqlBuiltinEnabled" .) "true") (eq (include "cube.redisBuiltinEnabled" .) "true") -}}true{{- else -}}false{{- end -}}
 {{- end -}}
 
 {{/*

--- a/deploy/kubernetes/chart/templates/diagnostics.yaml
+++ b/deploy/kubernetes/chart/templates/diagnostics.yaml
@@ -40,7 +40,7 @@ data:
     run helm-values helm get values "${RELEASE}" -n "${NS}" -o yaml
     run helm-manifest helm get manifest "${RELEASE}" -n "${NS}"
 
-    for component in master api cube-node cube-proxy webui dns mysql redis; do
+    for component in master api ops cube-node cube-proxy webui dns mysql redis; do
       run "pods-${component}" kubectl get pods -n "${NS}" -l "app.kubernetes.io/component=${component}" -o wide
       kubectl get pods -n "${NS}" -l "app.kubernetes.io/component=${component}" -o name 2>/dev/null \
         | while read -r pod; do

--- a/deploy/kubernetes/chart/templates/ops.yaml
+++ b/deploy/kubernetes/chart/templates/ops.yaml
@@ -1,0 +1,106 @@
+{{- if eq (include "cube.opsEnabled" .) "true" }}
+{{- $opsPort := .Values.cubeOps.service.port -}}
+apiVersion: {{ include "cube.cloneSetAPIVersion" . }}
+kind: CloneSet
+metadata:
+  name: {{ include "cube.opsName" . }}
+  labels:
+    {{- include "cube.labels" . | nindent 4 }}
+    app.kubernetes.io/component: ops
+spec:
+  replicas: {{ .Values.cubeOps.replicas }}
+  {{- include "cube.cloneSetUpdateStrategy" . | nindent 2 }}
+  selector:
+    matchLabels:
+      {{- include "cube.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: ops
+  template:
+    metadata:
+      labels:
+        {{- include "cube.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: ops
+      {{- with .Values.cubeOps.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- include "cube.controlPlanePlacement" . | nindent 6 }}
+      containers:
+        - name: cube-ops
+          image: {{ include "cube.cubeImage" (dict "image" .Values.images.ops "context" $) | quote }}
+          imagePullPolicy: {{ .Values.images.ops.pullPolicy }}
+          env:
+            {{- include "cube.timezoneEnv" . | nindent 12 }}
+            - name: CUBE_OPS_BIND
+              value: {{ .Values.cubeOps.bind | quote }}
+            - name: CUBE_MASTER_ADDR
+              value: {{ printf "http://%s" (include "cube.masterEndpoint" .) | quote }}
+            - name: CUBE_SANDBOX_MYSQL_HOST
+              value: {{ include "cube.mysqlHost" . | quote }}
+            - name: CUBE_SANDBOX_MYSQL_PORT
+              value: {{ .Values.mysql.port | quote }}
+            - name: CUBE_SANDBOX_MYSQL_USER
+              value: {{ .Values.mysql.user | quote }}
+            - name: CUBE_SANDBOX_MYSQL_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "cube.secretName" . }}
+                  key: mysql-password
+            - name: CUBE_SANDBOX_MYSQL_DB
+              value: {{ .Values.mysql.database | quote }}
+            - name: CUBE_API_SANDBOX_DOMAIN
+              value: {{ default .Values.cubeProxy.domain .Values.cubeOps.sandboxDomain | quote }}
+            # Shared CubeDB with CubeMaster; skip fingerprint so chart upgrades
+            # do not fail when Master already applied the same migrations.
+            - name: CUBEMASTER_MIGRATION_SKIP_FINGERPRINT_CHECK
+              value: "true"
+            {{- with .Values.cubeOps.env }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          ports:
+            - name: http
+              containerPort: {{ $opsPort }}
+          {{- if .Values.cubeOps.probes.readiness.enabled }}
+          readinessProbe:
+            httpGet:
+              path: {{ .Values.cubeOps.probes.readiness.path | quote }}
+              port: http
+            initialDelaySeconds: {{ .Values.cubeOps.probes.readiness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.cubeOps.probes.readiness.periodSeconds }}
+            failureThreshold: {{ .Values.cubeOps.probes.readiness.failureThreshold }}
+          {{- end }}
+          {{- if .Values.cubeOps.probes.liveness.enabled }}
+          livenessProbe:
+            httpGet:
+              path: {{ .Values.cubeOps.probes.liveness.path | quote }}
+              port: http
+            initialDelaySeconds: {{ .Values.cubeOps.probes.liveness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.cubeOps.probes.liveness.periodSeconds }}
+            failureThreshold: {{ .Values.cubeOps.probes.liveness.failureThreshold }}
+          {{- end }}
+          {{- with .Values.cubeOps.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "cube.opsName" . }}
+  labels:
+    {{- include "cube.labels" . | nindent 4 }}
+    app.kubernetes.io/component: ops
+spec:
+  type: {{ .Values.cubeOps.service.type }}
+  selector:
+    {{- include "cube.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: ops
+  ports:
+    - name: http
+      port: {{ $opsPort }}
+      targetPort: http
+{{- end }}

--- a/deploy/kubernetes/chart/templates/tests/node-health.yaml
+++ b/deploy/kubernetes/chart/templates/tests/node-health.yaml
@@ -2,6 +2,7 @@
 {{- $domain := .Values.cubeProxy.domain -}}
 {{- $internalMaster := and .Values.controlPlane.enabled .Values.controlPlane.master.enabled -}}
 {{- $internalAPI := and .Values.controlPlane.enabled .Values.controlPlane.api.enabled -}}
+{{- $internalOps := eq (include "cube.opsEnabled" .) "true" -}}
 {{- $externalAPIEndpoint := default "" .Values.externalControlPlane.apiEndpoint -}}
 apiVersion: v1
 kind: Pod
@@ -45,6 +46,13 @@ spec:
           echo '[health-test] skip CubeMaster: no internal or external control plane'
           {{- end }}
 
+          {{- if $internalOps }}
+          echo '[health-test] check CubeOps'
+          curl --connect-timeout 5 --max-time 15 -fsS http://{{ include "cube.opsFQDN" . }}:{{ .Values.cubeOps.service.port }}/health
+          {{- else }}
+          echo '[health-test] skip CubeOps: cubeOps.enabled=false'
+          {{- end }}
+
           {{- if or $internalAPI $externalAPIEndpoint }}
           echo '[health-test] check CubeAPI'
           api_endpoint={{ include "cube.apiEndpoint" . | quote }}
@@ -69,10 +77,10 @@ spec:
           echo '[health-test] skip CubeAPI: no internal API and externalControlPlane.apiEndpoint is empty'
           {{- end }}
 
-          {{- if and .Values.webui.enabled $internalAPI }}
+          {{- if and .Values.webui.enabled $internalOps }}
           echo '[health-test] check WebUI'
           curl --connect-timeout 5 --max-time 15 -fsS http://{{ include "cube.webuiName" . }}.{{ .Release.Namespace }}.svc.{{ include "cube.clusterDomain" . }}:{{ .Values.webui.service.port }}/ >/dev/null
-          curl --connect-timeout 5 --max-time 15 -fsS http://{{ include "cube.webuiName" . }}.{{ .Release.Namespace }}.svc.{{ include "cube.clusterDomain" . }}:{{ .Values.webui.service.port }}/cubeapi/v1/health
+          curl --connect-timeout 5 --max-time 15 -fsS http://{{ include "cube.webuiName" . }}.{{ .Release.Namespace }}.svc.{{ include "cube.clusterDomain" . }}:{{ .Values.webui.service.port }}/health
           {{- end }}
 
           {{- if eq (include "cube.proxyEnabled" .) "true" }}

--- a/deploy/kubernetes/chart/templates/validate.yaml
+++ b/deploy/kubernetes/chart/templates/validate.yaml
@@ -136,6 +136,17 @@
 {{- end }}
 {{- end }}
 {{- end }}
+{{- if and .Values.webui.enabled .Values.controlPlane.enabled (ne (include "cube.opsEnabled" .) "true") }}
+{{- fail "webui.enabled=true requires cubeOps.enabled=true (WebUI proxies /opsapi and SDK paths to CubeOps)" }}
+{{- end }}
+{{- if eq (include "cube.opsEnabled" .) "true" }}
+{{- if not (include "cube.masterEndpoint" .) }}
+{{- fail "cubeOps.enabled=true requires a CubeMaster endpoint (controlPlane.master or externalControlPlane.masterEndpoint)" }}
+{{- end }}
+{{- if not .Values.images.ops.repository }}
+{{- fail "cubeOps.enabled=true requires images.ops.repository" }}
+{{- end }}
+{{- end }}
 {{- if .Values.cubeEgress.enabled }}
 {{- if not (has .Values.cubeEgress.ca.mode (list "existingSecret" "selfSigned" "inline")) }}
 {{- fail "cubeEgress.ca.mode must be one of: existingSecret, selfSigned, inline" }}

--- a/deploy/kubernetes/chart/templates/webui.yaml
+++ b/deploy/kubernetes/chart/templates/webui.yaml
@@ -1,5 +1,8 @@
-{{- if and .Values.webui.enabled .Values.controlPlane.enabled .Values.controlPlane.api.enabled }}
-{{- $apiUpstream := default (printf "http://%s.%s.svc.%s:%v" (include "cube.apiName" .) .Release.Namespace (include "cube.clusterDomain" .) .Values.controlPlane.api.service.port) .Values.webui.upstream | trimSuffix "/" -}}
+{{- if and .Values.webui.enabled .Values.controlPlane.enabled (eq (include "cube.opsEnabled" .) "true") }}
+{{- /* Hash full nginx body so ConfigMap edits force a pod roll (InPlace + subPath
+     would otherwise keep a stale file). Mount is a directory (no subPath). */ -}}
+{{- $nginxBody := include "cube.webuiNginxConf" . -}}
+{{- $nginxChecksum := $nginxBody | sha256sum -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -9,60 +12,7 @@ metadata:
     app.kubernetes.io/component: webui
 data:
   nginx.conf: |-
-    worker_processes auto;
-
-    events {
-        worker_connections 1024;
-    }
-
-    http {
-        include mime.types;
-        default_type application/octet-stream;
-
-        sendfile on;
-        tcp_nopush on;
-        tcp_nodelay on;
-        keepalive_timeout 65;
-
-        gzip on;
-        gzip_types text/plain text/css application/javascript application/json application/xml;
-
-        server {
-            listen 80;
-            server_name _;
-
-            root /usr/share/nginx/html;
-            index index.html;
-
-            location = /cubeapi {
-                return 308 /cubeapi/;
-            }
-
-            location /cubeapi/ {
-                proxy_http_version 1.1;
-                proxy_set_header Host $host;
-                proxy_set_header X-Real-IP $remote_addr;
-                proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-                proxy_set_header X-Forwarded-Proto $scheme;
-                proxy_set_header Upgrade $http_upgrade;
-                proxy_set_header Connection "upgrade";
-                proxy_read_timeout 300s;
-                proxy_send_timeout 300s;
-
-                proxy_pass {{ $apiUpstream }}/cubeapi/;
-            }
-
-            location /assets/ {
-                try_files $uri =404;
-                expires 1y;
-                add_header Cache-Control "public, immutable";
-            }
-
-            location / {
-                try_files $uri $uri/ /index.html;
-            }
-        }
-    }
+{{- $nginxBody | nindent 4 }}
 ---
 apiVersion: {{ include "cube.cloneSetAPIVersion" . }}
 kind: CloneSet
@@ -84,7 +34,7 @@ spec:
         {{- include "cube.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: webui
       annotations:
-        checksum/nginx-conf: {{ $apiUpstream | sha256sum | quote }}
+        checksum/nginx-conf: {{ $nginxChecksum | quote }}
       {{- with .Values.webui.podAnnotations }}
         {{- toYaml . | nindent 8 }}
       {{- end }}
@@ -98,6 +48,15 @@ spec:
         - name: webui
           image: {{ include "cube.cubeImage" (dict "image" .Values.images.webui "context" $) | quote }}
           imagePullPolicy: {{ .Values.images.webui.pullPolicy }}
+          # Image ENTRYPOINT embeds "-g daemon off;"; override so we can load the
+          # chart ConfigMap without a subPath file mount (which does not refresh).
+          command:
+            - /usr/local/openresty/bin/openresty
+          args:
+            - -c
+            - /etc/cube-webui/nginx.conf
+            - -g
+            - daemon off;
           {{- if .Values.global.timezone }}
           env:
             {{- include "cube.timezoneEnv" . | nindent 12 }}
@@ -121,8 +80,7 @@ spec:
             failureThreshold: 6
           volumeMounts:
             - name: webui-config
-              mountPath: /usr/local/openresty/nginx/conf/nginx.conf
-              subPath: nginx.conf
+              mountPath: /etc/cube-webui
               readOnly: true
           {{- with .Values.webui.resources }}
           resources:

--- a/deploy/kubernetes/chart/values.yaml
+++ b/deploy/kubernetes/chart/values.yaml
@@ -16,7 +16,7 @@ global:
   # exactly as declared. Set to e.g. "my-registry.example.com/cubesandbox"
   # to mirror all images into a private registry without editing each entry
   # individually. Applies to the pvmHostBootstrap / nodeInit / node / master
-  # / api / cubemastercli / proxy / lifecycleManager / cubeEgress /
+  # / api / ops / cubemastercli / proxy / lifecycleManager / cubeEgress /
   # cubeEgressNet / webui / cubelet / networkAgent / cubeShim / cubeKernel /
   # cubeGuest / waitNodePrep / pause entries but not to third-party images such as mysql /
   # redis / docker-in-docker / alpine/k8s.
@@ -82,6 +82,11 @@ images:
 
   api:
     repository: ccr.ccs.tencentyun.com/cubesandbox-chart/cube-api
+    tag: v0.5.1
+    pullPolicy: Always
+
+  ops:
+    repository: ccr.ccs.tencentyun.com/cubesandbox-chart/cube-ops
     tag: v0.5.1
     pullPolicy: Always
 
@@ -320,8 +325,8 @@ cubemastercli:
   resources: {}
 
 webui:
-  # One-click enables WebUI by default on host port 12088. In Kubernetes the
-  # chart delivers it as a Service on port 12088 and proxies /cubeapi to CubeAPI.
+  # Dashboard nginx. Proxies /opsapi and WebUI SDK paths to CubeOps.
+  # CubeAPI is a separate Service for external E2B SDK clients.
   enabled: true
   replicas: 1
   podAnnotations: {}
@@ -330,8 +335,37 @@ webui:
     port: 12088
     targetPort: 80
     annotations: {}
-  # Empty upstream uses the chart-managed CubeAPI Service.
-  upstream: ""
+  # Optional overrides (empty = chart-managed Service FQDNs).
+  opsUpstream: ""
+  proxyUpstream: ""
+  resources: {}
+
+cubeOps:
+  # Stateful ops/admin backend (JWT) + WebUI SDK proxy to CubeMaster.
+  # Required when webui.enabled=true.
+  enabled: true
+  replicas: 1
+  podAnnotations: {}
+  bind: "0.0.0.0:3010"
+  # Empty uses cubeProxy.domain for CUBE_API_SANDBOX_DOMAIN.
+  sandboxDomain: ""
+  service:
+    type: ClusterIP
+    port: 3010
+  env: []
+  probes:
+    readiness:
+      enabled: true
+      path: /health
+      initialDelaySeconds: 5
+      periodSeconds: 10
+      failureThreshold: 12
+    liveness:
+      enabled: true
+      path: /health
+      initialDelaySeconds: 30
+      periodSeconds: 20
+      failureThreshold: 6
   resources: {}
 
 lifecycleManager:

--- a/deploy/kubernetes/images/README.md
+++ b/deploy/kubernetes/images/README.md
@@ -61,7 +61,7 @@ Override the binary directory with `LOCAL_BIN_DIR` if needed. The script does
 not run `make` itself; missing binaries fail with a hint to build the matching
 target first.
 
-For source-built images (`cube-api`, `cube-proxy`, …), use `SOURCE_REF=""` to
+For source-built images (`cube-api`, `cube-ops`, `cube-proxy`, …), use `SOURCE_REF=""` to
 compile from the current worktree (see below).
 
 ## `pause` image (Big Pod placeholder slots)
@@ -80,15 +80,18 @@ Dockerfile: `deploy/kubernetes/images/pause/Dockerfile` (`FROM registry.k8s.io/p
 
 ## Pinning source to a release tag
 
-`cube-api`, `cube-proxy`, `cube-egress`, `cube-lifecycle-manager`, and
+`cube-api`, `cube-ops`, `cube-proxy`, `cube-egress`, `cube-lifecycle-manager`, and
 `cube-webui` are compiled from repository source (rather than binaries in the
 release tarball). By default the script pins those source trees to
 `${SOURCE_REF}` (defaulting to `${VERSION}`, so `v0.5.1` for the default
 build). It exports `CubeMaster/`, `CubeAPI/`, `CubeProxy/`, `CubeEgress/`,
 `cube-lifecycle-manager/`, `web/`, and `deploy/one-click/webui/` at that git
 ref into `${BUILD_ROOT}/source-tree/` via `git archive` and points `REPO_ROOT`
-there for the duration of the build. This guarantees the images match the
-release tag even when the current worktree is ahead of it.
+there for the duration of the build. When building `cube-ops`, it also exports
+`CubeOps/` and `CubeDB/` (required by `CubeOps/Dockerfile`; not present on
+older release tags such as `v0.5.1` — use `SOURCE_REF=""` for worktree builds).
+This guarantees the images match the release tag even when the current worktree
+is ahead of it.
 
 To build from the current worktree instead (typically for development), set
 `SOURCE_REF=""`:
@@ -128,6 +131,9 @@ entrypoint behavior.
 - `cube-wait-node-prep` is the Big Pod `wait-node-prep` **sidecar** (Kruise container launch priority) and the bootstrap `write-node-prep-ready` hold container. Bumping only the wait **image** on Big Pod may InPlace; do not change wait env/mounts routinely.
 - `cube-master` is built directly from `CubeMaster/docker/Dockerfile`. The build script prepares a temporary Docker context with the release-package `cubemaster` binary and the `CubeMaster/docker/tools` directory expected by that Dockerfile.
 - `cube-api` is built from `CubeAPI/Dockerfile`; no duplicate Dockerfile is kept here.
+- `cube-ops` is built from `CubeOps/Dockerfile` with context = repository root
+  (needs sibling `CubeDB/` via `CubeOps/Dockerfile.dockerignore`); same as CI
+  `release-docker-images.yml`. No duplicate Dockerfile is kept here.
 - `cubemastercli` is an operational CLI image. It packages only the
   release-package `CubeMaster/bin/cubemastercli` binary and minimal runtime
   dependencies. It is separate from `cube-master` and `cube-node` so runtime

--- a/deploy/kubernetes/images/build-cube-images.sh
+++ b/deploy/kubernetes/images/build-cube-images.sh
@@ -20,12 +20,12 @@ WORKTREE_ROOT="${REPO_ROOT}"
 VERSION="${VERSION:-v0.5.1}"
 IMAGE_TAG="${IMAGE_TAG:-${VERSION}}"
 REGISTRY="${REGISTRY:-ccr.ccs.tencentyun.com/cubesandbox-chart}"
-# SOURCE_REF pins the CubeMaster / CubeAPI / CubeProxy / CubeEgress /
-# cube-lifecycle-manager / web / deploy/one-click/webui source tree used when
-# building cube-api / cube-proxy / cube-egress / cube-lifecycle-manager /
-# cube-webui from repository source, ensuring the delivered images match the
-# release tag rather than the current worktree. Set SOURCE_REF="" to build from
-# the current worktree.
+# SOURCE_REF pins the CubeMaster / CubeAPI / CubeOps / CubeDB / CubeProxy /
+# CubeEgress / cube-lifecycle-manager / web / deploy/one-click/webui source tree
+# used when building cube-api / cube-ops / cube-proxy / cube-egress /
+# cube-lifecycle-manager / cube-webui from repository source, ensuring the
+# delivered images match the release tag rather than the current worktree. Set
+# SOURCE_REF="" to build from the current worktree.
 SOURCE_REF="${SOURCE_REF-${VERSION}}"
 PUSH="${PUSH:-0}"
 NO_CACHE="${NO_CACHE:-0}"
@@ -87,6 +87,7 @@ DOWNLOAD_CONNECT_TIMEOUT="${DOWNLOAD_CONNECT_TIMEOUT:-20}"
 ALL_IMAGES=(
   cube-master
   cube-api
+  cube-ops
   cubemastercli
   cube-proxy
   cube-lifecycle-manager
@@ -119,6 +120,7 @@ PACKAGE_IMAGES=(
 SOURCE_IMAGES=(
   cube-master
   cube-api
+  cube-ops
   cube-proxy
   cube-lifecycle-manager
   cube-egress
@@ -170,6 +172,7 @@ Examples:
 
   $0 --local cube-shim
   SOURCE_REF="" IMAGE_TAG=dev $0 cube-api
+  SOURCE_REF="" IMAGE_TAG=dev $0 cube-ops
 
 Available images:
 $(printf '  %s\n' "${ALL_IMAGES[@]}")
@@ -341,12 +344,12 @@ ensure_source_tree() {
   SOURCE_READY=1
 
   # When SOURCE_REF is set (default: ${VERSION}), export the CubeMaster / CubeAPI /
-  # CubeProxy / CubeEgress / cube-lifecycle-manager / web / deploy/one-click/webui
-  # trees at that ref into ${SOURCE_TREE_DIR} and point REPO_ROOT there. This
-  # ensures cube-api, cube-proxy, cube-egress, cube-lifecycle-manager,
-  # cube-webui and related contexts are compiled from the release-tag source, not
-  # from whatever happens to be in the current worktree (which may be ahead of
-  # the tag).
+  # CubeOps / CubeDB / CubeProxy / CubeEgress / cube-lifecycle-manager / web /
+  # deploy/one-click/webui trees at that ref into ${SOURCE_TREE_DIR} and point
+  # REPO_ROOT there. This ensures cube-api, cube-ops, cube-proxy, cube-egress,
+  # cube-lifecycle-manager, cube-webui and related contexts are compiled from the
+  # release-tag source, not from whatever happens to be in the current worktree
+  # (which may be ahead of the tag).
   if [[ -z "${SOURCE_REF}" ]]; then
     REPO_ROOT="${WORKTREE_ROOT}"
     log "using current worktree source (SOURCE_REF empty)"
@@ -358,7 +361,12 @@ ensure_source_tree() {
     || fail "SOURCE_REF=${SOURCE_REF} is not a valid git ref in ${WORKTREE_ROOT}"
   SOURCE_REF_SHA="$(git -C "${WORKTREE_ROOT}" rev-parse "${SOURCE_REF}^{commit}")"
   SOURCE_TREE_STAMP="${SOURCE_TREE_DIR}/.exported-sha"
+  # CubeOps/CubeDB are post-v0.5.1; only export when building cube-ops so older
+  # release tags still work for cube-api / cube-proxy / webui / etc.
   SOURCE_EXPORT_SET="CubeMaster CubeAPI CubeProxy CubeEgress cube-lifecycle-manager web deploy/one-click/webui"
+  if should_build cube-ops; then
+    SOURCE_EXPORT_SET="${SOURCE_EXPORT_SET} CubeOps CubeDB"
+  fi
   if [[ ! -f "${SOURCE_TREE_STAMP}" ]] \
     || [[ "$(cat "${SOURCE_TREE_STAMP}")" != "${SOURCE_REF_SHA}"$'\n'"${SOURCE_EXPORT_SET}" ]]; then
     log "exporting source tree at ${SOURCE_REF} (${SOURCE_REF_SHA:0:12}) into ${SOURCE_TREE_DIR}"
@@ -627,6 +635,15 @@ build_cube_api_image() {
   record_built cube-api
 }
 
+# Same as .github/workflows/release-docker-images.yml for component "cube-ops":
+# context=., file=CubeOps/Dockerfile (needs sibling CubeDB via Dockerfile.dockerignore).
+build_cube_ops_image() {
+  [[ -f "${REPO_ROOT}/CubeOps/go.mod" ]] || fail "missing CubeOps go.mod in ${REPO_ROOT}"
+  [[ -d "${REPO_ROOT}/CubeDB" ]] || fail "missing CubeDB sibling module in ${REPO_ROOT}"
+  build_image cube-ops "${REPO_ROOT}" "${REPO_ROOT}/CubeOps/Dockerfile"
+  record_built cube-ops
+}
+
 build_cube_egress_openresty_base_image() {
   local image="cube-egress/openresty:1.29.2.5-tproxy"
   local docker_args=(
@@ -736,6 +753,11 @@ run_selected_builds() {
   if should_build cube-api; then
     ensure_source_tree
     build_cube_api_image
+  fi
+
+  if should_build cube-ops; then
+    ensure_source_tree
+    build_cube_ops_image
   fi
 
   if should_build cubemastercli; then

--- a/web/src/pages/Versions.tsx
+++ b/web/src/pages/Versions.tsx
@@ -77,7 +77,7 @@ function stripPlatformVersionSuffix(version: string): string {
 }
 
 function rowHasUndeclaredVersion(row: ComponentRow): boolean {
-  return row.versions.some((g) => isVersionUndeclared(row, g.version));
+  return (row.versions ?? []).some((g) => isVersionUndeclared(row, g.version));
 }
 
 function hasReleaseDeclaration(rows: ComponentRow[]): boolean {
@@ -523,13 +523,16 @@ function MatrixSection({ nodes, components }: { nodes: NodeRow[]; components: Co
     const q = query.trim().toLowerCase();
     return nodes
       .filter((n) => {
-        if (q && !n.nodeID.toLowerCase().includes(q)) return false;
+        const nodeID = n.nodeID ?? '';
+        if (q && !nodeID.toLowerCase().includes(q)) return false;
         if (filter === 'healthy' && !n.healthy) return false;
         if (filter === 'notReady' && n.healthy) return false;
         return true;
       })
       .sort((a, b) => {
-        if (sortBy.col == null) return a.nodeID.localeCompare(b.nodeID);
+        const aID = a.nodeID ?? '';
+        const bID = b.nodeID ?? '';
+        if (sortBy.col == null) return aID.localeCompare(bID);
         const aEntry = a.components.find((e) => e.component === sortBy.col);
         const bEntry = b.components.find((e) => e.component === sortBy.col);
         const av = aEntry?.version ?? '';
@@ -594,10 +597,11 @@ function MatrixSection({ nodes, components }: { nodes: NodeRow[]; components: Co
           </thead>
           <tbody className="divide-y divide-border/40">
             {filtered.map((n) => {
-              const byComponent = new Map(n.components.map((e) => [e.component, e]));
+              const nodeID = n.nodeID ?? '';
+              const byComponent = new Map((n.components ?? []).map((e) => [e.component, e]));
               return (
                 <tr
-                  key={n.nodeID}
+                  key={nodeID}
                   className={cn(
                     'group transition-colors hover:bg-muted/40',
                     !n.healthy && 'bg-cube-err/[0.04]',
@@ -605,7 +609,7 @@ function MatrixSection({ nodes, components }: { nodes: NodeRow[]; components: Co
                 >
                   <td className="sticky left-0 z-10 bg-card/40 px-4 py-3 group-hover:bg-muted/40">
                     <Link
-                      to={`/nodes/${n.nodeID}`}
+                      to={`/nodes/${nodeID}`}
                       className="flex items-center gap-2 text-foreground/90 hover:text-cube-info"
                     >
                       <span
@@ -614,7 +618,7 @@ function MatrixSection({ nodes, components }: { nodes: NodeRow[]; components: Co
                           n.healthy ? 'bg-cube-ok' : 'bg-cube-err',
                         )}
                       />
-                      <MonoId size="sm">{n.nodeID}</MonoId>
+                      <MonoId size="sm">{nodeID}</MonoId>
                       <ChevronRight
                         size={11}
                         className="ml-0.5 text-muted-foreground/30 group-hover:text-cube-info"


### PR DESCRIPTION
## Summary

Add the **CubeOps** ops/admin backend (JWT) as a new Helm chart component, refactoring the WebUI nginx configuration to proxy `/opsapi` and SDK paths through CubeOps instead of CubeAPI directly.

## Changes

### New: CubeOps Component
- New `templates/ops.yaml` — CloneSet + Service for `cube-ops`
- Default values in `values.yaml` (`cubeOps` section + `images.ops`)
- Validation: `webui.enabled` requires `cubeOps.enabled`; CubeOps requires a master endpoint and `images.ops.repository`
- Health test updated to verify CubeOps `/health` endpoint
- Diagnostics now include `ops` component pod collection

### WebUI Nginx Refactoring
- Extracted inline nginx config into a shared `cube.webuiNginxConf` template
- Checksum-based annotation for automatic CloneSet roll on config changes
- Mounted as directory (not subPath) so ConfigMap edits propagate correctly
- New proxy routes:
  - `/opsapi/` → CubeOps `/api/`
  - `/cubeapi/v1/` → CubeOps `/api/v1/sdk/`
  - `/sandbox/` → CubeProxy (optional)
  - SDK-style paths (`/sandboxes`, `/v2/sandboxes`, etc.) with auth gate (418 → SPA fallback when no Authorization header)

### Cluster Handler
- Versions endpoint now applies `camelCaseJSON` key rewriting to responses
- Improved handling of empty/null data from CubeMaster

### Frontend (Versions.tsx)
- Null-safety for `nodeID`, `components`, and `versions` arrays

### Build Script
- Added `cube-ops` to image build script (`build-cube-images.sh`)
- Source export now conditionally includes `CubeOps/` and `CubeDB/` trees (not present on older release tags)

### Documentation
- Updated README, ARCHITECTURE, QUICKSTART, SINGLE-NODE-HELM with CubeOps role and new data-flow diagrams

## Verification
- Helm lint/template passes with default values
- `helm test` health checks pass including CubeOps endpoint
- Build script successfully builds `cube-ops` image

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Refs: https://github.com/TencentCloud/CubeSandbox/issues/954