### PR TITLE
fix(web): session invalidation, template deletion UX

### DIFF
--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -255,7 +255,11 @@ export const templateApi = {
     api<{ lines?: string[]; status?: string; progress?: number }>(
       `/templates/${id}/builds/${buildID}/logs`,
     ),
-  remove: (id: string) => api<void>(`/templates/${id}`, { method: 'DELETE' }),
+  remove: (id: string) =>
+    api<void>(`/templates/${encodeURIComponent(id)}`, {
+      method: 'DELETE',
+      params: { sync: true },
+    }),
   compat: () => api<TemplateCompatMatrix>('/templates/compat'),
   adoptCompatBaseline: (id: string) =>
     api<{ updated: number }>(`/templates/compat/${id}/adopt-baseline`, { method: 'POST' }),

--- a/web/src/components/AuthGuard.tsx
+++ b/web/src/components/AuthGuard.tsx
@@ -5,7 +5,8 @@ import { useEffect, useState } from 'react';
 import { Navigate, Outlet, useLocation } from 'react-router-dom';
 import { Loader2 } from 'lucide-react';
 import { authApi } from '@/api/client';
-import { getLastAuthStatus, setLastAuthStatus } from '@/lib/session';
+import { ApiError } from '@/lib/api';
+import { clearSession, getLastAuthStatus, setLastAuthStatus } from '@/lib/session';
 
 type GuardState = 'checking' | 'allowed' | 'guest';
 
@@ -28,10 +29,19 @@ export function AuthGuard() {
         setLastAuthStatus(nextState);
         setState(nextState);
       })
-      .catch(() => {
+      .catch((err) => {
+        if (cancelled) return;
+        // A 401 means both the access token and any refresh token are no
+        // longer usable (for example after a password change). Do not trust
+        // the cached "allowed" state in this case.
+        if (err instanceof ApiError && err.status === 401) {
+          clearSession();
+          setState('guest');
+          return;
+        }
         // Keep previously verified sessions usable during transient backend
         // errors, but do not grant access when there is no verified state.
-        if (!cancelled) setState(getLastAuthStatus() ?? 'guest');
+        setState(getLastAuthStatus() ?? 'guest');
       });
     return () => {
       cancelled = true;

--- a/web/src/pages/AgentHub.tsx
+++ b/web/src/pages/AgentHub.tsx
@@ -493,8 +493,10 @@ function TemplateListDialog({
     setError(null);
     try {
       await agentHubApi.deleteTemplate(template.templateId);
+      setTemplates((previous) =>
+        previous.filter((item) => item.templateId !== template.templateId),
+      );
       setDeleteTemplate(null);
-      loadTemplates();
     } catch (e) {
       setError(e instanceof Error ? e.message : String(e));
     } finally {

--- a/web/src/pages/Settings.tsx
+++ b/web/src/pages/Settings.tsx
@@ -4,7 +4,7 @@
 import { useTranslation } from 'react-i18next';
 import { useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { useRuntimeConfig } from '@/hooks/useRuntimeConfig';
 import {
   Palette,
@@ -256,6 +256,7 @@ function ClusterSection() {
 function AccountSection() {
   const { t } = useTranslation('auth');
   const navigate = useNavigate();
+  const queryClient = useQueryClient();
   const username = getSessionUser() || 'admin';
   const [oldPassword, setOldPassword] = useState('');
   const [newPassword, setNewPassword] = useState('');
@@ -270,6 +271,7 @@ function AccountSection() {
       // ignore network errors on logout
     }
     clearSession();
+    queryClient.clear();
     navigate('/login', { replace: true });
   };
 
@@ -287,10 +289,14 @@ function AccountSection() {
     setSubmitting(true);
     try {
       await authApi.changePassword({ username, oldPassword, newPassword });
-      setMsg({ ok: true, text: t('changePassword.success') });
-      setOldPassword('');
-      setNewPassword('');
-      setConfirm('');
+      // Password changes revoke all existing refresh tokens on the server.
+      // Force a fresh login instead of leaving an unusable session in place.
+      clearSession();
+      queryClient.clear();
+      navigate('/login', {
+        replace: true,
+        state: { from: '/settings?tab=account' },
+      });
     } catch (err) {
       const text =
         err instanceof ApiError && err.status === 401

--- a/web/src/pages/TemplateDetail.tsx
+++ b/web/src/pages/TemplateDetail.tsx
@@ -5,7 +5,12 @@ import { useState, useRef, useEffect } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { useNavigate, useParams, Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
-import { templateApi, type TemplateNodeCompat, type TemplateCompatRow } from '@/api/client';
+import {
+  templateApi,
+  type TemplateNodeCompat,
+  type TemplateCompatRow,
+  type TemplateSummary,
+} from '@/api/client';
 import { ApiError } from '@/lib/api';
 import { Card, CardHeader, CardTitle, CardDescription, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
@@ -667,7 +672,16 @@ export default function TemplateDetailPage() {
 
   const deleteMutation = useMutation({
     mutationFn: () => templateApi.remove(templateID!),
-    onSuccess: () => navigate('/templates'),
+    onSuccess: async () => {
+      qc.setQueryData<TemplateSummary[]>(
+        ['templates'],
+        (previous) => previous?.filter((template) => template.templateID !== templateID) ?? [],
+      );
+      await qc.invalidateQueries({ queryKey: ['templates'], exact: true });
+      await qc.invalidateQueries({ queryKey: ['templates', 'compat'], exact: true });
+      qc.removeQueries({ queryKey: ['template', templateID], exact: true });
+      navigate('/templates');
+    },
   });
 
   // ── loading ──

--- a/web/src/pages/Templates.tsx
+++ b/web/src/pages/Templates.tsx
@@ -6,7 +6,12 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { ChevronDown, ChevronRight } from 'lucide-react';
-import { templateApi, type TemplateCompatMatrix, type TemplateCompatRow } from '@/api/client';
+import {
+  templateApi,
+  type TemplateCompatMatrix,
+  type TemplateCompatRow,
+  type TemplateSummary,
+} from '@/api/client';
 import { Card, CardHeader, CardTitle, CardDescription, CardContent } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -515,8 +520,12 @@ function DeleteTemplateModal({ templateID, onClose }: DeleteModalProps) {
   const qc = useQueryClient();
   const mutation = useMutation({
     mutationFn: () => templateApi.remove(templateID),
-    onSuccess: () => {
-      qc.invalidateQueries({ queryKey: ['templates'] });
+    onSuccess: async () => {
+      qc.setQueryData<TemplateSummary[]>(
+        ['templates'],
+        (previous) => previous?.filter((template) => template.templateID !== templateID) ?? [],
+      );
+      await qc.invalidateQueries({ queryKey: ['templates'] });
       onClose();
     },
   });


### PR DESCRIPTION
-AuthGuard: evict cached session on 401 instead of relying on stale 
"allowed" state, so password changes now force immediate re-login.
-Settings: redirect to /login after password change (server already 
revokes all refresh tokens) and purge react-query cache on explicit 
logout to prevent stale data reuse.
-Templates/TemplateDetail: adopt optimistic removal on delete, 
invalidate compat queries without triggering a full page reload; 
properly encode template ID in DELETE requests and pass `sync=true` 
for guaranteed server-side cleanup.