### PR TITLE
test(e2e): add host-mount SDK compatibility and boundary cases

### DIFF
--- a/examples/host-mount/README.md
+++ b/examples/host-mount/README.md
@@ -187,8 +187,9 @@ with Sandbox.create(
 
 | Step | What happens |
 |------|-------------|
-| `Sandbox.create(metadata=...)` | CubeAPI passes the `host-mount` JSON to Cubelet |
-| Cubelet receives the request | Parses the mount list and performs bind-mounts before booting the VM |
+| `Sandbox.create(metadata=...)` | CubeAPI lifts `metadata["host-mount"]` onto the sandbox annotation of the same name |
+| CubeMaster validates | Parses the mount list, checks each `hostPath` against the allowed prefixes, and injects the volumes/volume-mounts into the sandbox spec |
+| Cubelet mounts | Bind-mounts each validated `hostPath` before booting the VM |
 | VM boots | The paths appear inside the sandbox at the specified `mountPath` locations |
 | Read-only mount | The kernel enforces `MS_RDONLY`; writes are rejected with `EROFS` |
 
@@ -197,7 +198,7 @@ with Sandbox.create(
 | Symptom | Likely Cause | Fix |
 |---------|-------------|-----|
 | `hostPath "..." is not within an allowed mount prefix` | `hostPath` is outside the configured allowed prefixes | Move data under `/data/shared/`, or update `allowed_host_mount_prefixes` as described in `docs/guide/persistent-storage.md` |
-| `No such file or directory` inside sandbox | `hostPath` does not exist on the Cubelet node | Create the directory on the node before running |
+| Sandbox creation fails with a `bind mount ... ->` error | `hostPath` does not exist on the Cubelet node (Cubelet bind-mounts the source directly and does not create it) | Create the directory on the node before creating the sandbox |
 | `Read-only file system` when writing to `/mnt/ro/...` | Mounted with `readOnly: true` | Set that mount to `readOnly: false`, or write to the read-write sandbox path `/mnt/rw/...` instead |
 | `Template not found` | Wrong template ID | Run `cubemastercli tpl list` |
 | `Connection refused` | CubeAPI not reachable | Check `E2B_API_URL` and that port 3000 is open |

--- a/tests/e2e/sdk_compat/README.md
+++ b/tests/e2e/sdk_compat/README.md
@@ -332,6 +332,8 @@ Current capability domains:
 - `cases/run_code/`: expression text, stdout, kernel state, Python error reporting.
 - `cases/network/`: create-time network policy for allow/deny and public egress access.
 - `cases/concurrency/`: simultaneous multi-sandbox isolation.
+- `cases/host-mount/`: host-directory mount extension — happy path plus create-time
+  validation, runtime bind-mount failures, and cross-sandbox sharing boundary cases.
 
 Keep new cases backend-neutral. Add backend-specific behavior through capability
 markers instead of branching inside test bodies. Future domains can be added next
@@ -356,6 +358,9 @@ Capability markers:
 - Common capabilities include `lifecycle`, `commands`, `filesystem`, and `run_code`.
 - Shared optional capabilities include `pause_resume`, `network_allow_deny`, and `network_public_access`.
 - `platform_lifecycle` is available only to CubeSandbox platform-managed lifecycle cases.
+- `host_mount` is a CubeSandbox-only extension; `cases/host-mount/` uses it via
+  `@pytest.mark.requires_capability("host_mount")` to skip backends (e.g. e2b) that
+  do not support host-directory mounts.
 
 ## Cleanup
 
@@ -364,3 +369,6 @@ fails, the suite falls back to `DELETE /sandboxes/{sandboxID}` against
 `CUBE_API_URL`.
 
 Set `SDK_E2E_KEEP_SANDBOX_ON_FAILURE=true` to preserve sandboxes while debugging.
+It only preserves sandboxes of *failed* tests created through the `sdk_sandbox`
+fixture; passed and skipped tests are always cleaned up, and boundary tests that
+create sandboxes directly (via their own helpers) always clean up regardless.

--- a/tests/e2e/sdk_compat/README_zh.md
+++ b/tests/e2e/sdk_compat/README_zh.md
@@ -328,7 +328,9 @@ tests/e2e/sdk_compat/
 - `cases/filesystem/`：读写、覆盖、多行内容、文件 API 与 shell 互操作；
 - `cases/run_code/`：表达式结果、stdout、kernel 状态和 Python 错误；
 - `cases/network/`：创建时的 allow/deny 和公网出站策略；
-- `cases/concurrency/`：同时运行多个 sandbox 时的数据隔离。
+- `cases/concurrency/`：同时运行多个 sandbox 时的数据隔离；
+- `cases/host-mount/`：宿主目录挂载扩展——happy path，以及创建时校验、
+  运行期 bind-mount 失败和跨 sandbox 共享等边界用例。
 
 新增测试应保持后端无关，通过 capability marker 表达后端差异。
 
@@ -361,6 +363,8 @@ Capability marker：
 接收字段尚未对齐，导致 E2B 生命周期参数暂未生效。相关兼容修复见
 [PR #988](https://github.com/TencentCloud/CubeSandbox/pull/988)；修复合并并
 完成版本验证后，应重新启用 E2B 平台生命周期 capability 和双 backend 用例。
+`host_mount` 是 CubeSandbox 独有扩展；`cases/host-mount/` 通过
+`@pytest.mark.requires_capability("host_mount")` 跳过不支持宿主目录挂载的后端（如 e2b）。
 
 ## 清理
 
@@ -373,4 +377,5 @@ Capability marker：
 export SDK_E2E_KEEP_SANDBOX_ON_FAILURE=true
 ```
 
-通过和跳过的测试仍会清理 sandbox。
+该开关仅保留通过 `sdk_sandbox` fixture 创建、且**失败**的测试的 sandbox；通过和
+跳过的测试始终会被清理，直接创建 sandbox 的边界用例（使用各自的 helper）也始终清理。

--- a/tests/e2e/sdk_compat/cases/host-mount/test_boundary.py
+++ b/tests/e2e/sdk_compat/cases/host-mount/test_boundary.py
@@ -1,0 +1,469 @@
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Host-mount boundary and behavior tests not covered by the example.
+
+The example (test_create_with_mount.py) covers the happy path and a single
+disallowed hostPath. This module covers behaviors that only an end-to-end run
+can prove:
+
+- create-time rejection by CubeMaster's lexical validation of illegal hostPath
+  shapes (traversal, prefix spoofing, relative/empty/root paths) and mountPath
+  shapes (relative/empty), surfaced through the SDK/API;
+- create-time rejection of malformed host-mount annotations (non-JSON string,
+  JSON that is not an array of descriptors);
+- runtime rejection by Cubelet for hostPaths that pass lexical validation but
+  cannot be bind-mounted (source does not exist, source is a regular file);
+- acceptance of the exact allowed-prefix directory and of an empty mount list;
+- real read-write host sharing: two sandboxes bind-mounting the same host dir
+  observe each other's writes (proving it is a genuine host mount, not a
+  per-sandbox overlay);
+- the symlink TOCTOU escape: CubeMaster validates the path lexically while
+  Cubelet resolves symlinks before mounting, so a symlink planted under the
+  allowed prefix can redirect the mount to an arbitrary host path.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from framework.assertions import assert_command_ok
+from framework.capabilities import HOST_MOUNT
+from framework.host_mount import (
+    HOST_MOUNT_KEY,
+    expect_create_rejected,
+    host_mount_metadata,
+    mount_option,
+    provision_host_dirs,
+    skip_if_host_mount_unavailable,
+    under_prefix,
+)
+from framework.lifecycle import managed_control_sandbox
+
+pytestmark = [
+    pytest.mark.e2e,
+    pytest.mark.sdk_compat,
+    pytest.mark.host_mount,
+    pytest.mark.p1,
+    pytest.mark.requires_capability(HOST_MOUNT),
+]
+
+
+@pytest.fixture(autouse=True)
+def _require_host_mount_backend(sdk_backend, sdk_e2e_config):
+    """Gate every test in this module on host-mount support.
+
+    Most tests here create sandboxes directly (via ``expect_create_rejected`` or
+    ``managed_control_sandbox``) instead of requesting the ``sdk_sandbox``
+    fixture, so they never pass through the ``requires_capability`` check that
+    fixture performs. Without this gate the
+    create-rejection assertions would run against a backend (e.g. e2b) that
+    silently ignores the host-mount metadata, creating the sandbox and failing
+    the test spuriously. Skip the same cases ``sdk_sandbox`` would.
+    """
+    skip_if_host_mount_unavailable(sdk_backend, sdk_e2e_config)
+
+
+# --- Create-time rejections --------------------------------------------------
+
+
+# Each case pins the *reason* CubeMaster rejects it, so a regression that swaps
+# which branch fires (absolute-path check vs. allowed-prefix check) is caught
+# rather than masked by a permissive OR. "absolute": rejected by the
+# leading-slash check before validateHostPath; "prefix": rejected by
+# validateHostPath's allowed-prefix comparison (see hostdir_mount.go).
+#
+# The values are the *exact* production phrases CubeMaster emits (hostdir_mount.go:
+# "hostPath must be an absolute path", "is not within an allowed mount prefix"),
+# so a generic error that merely contains the word "prefix"/"absolute" cannot
+# satisfy the assertion for the wrong reason.
+_REASON_PHRASE = {
+    "absolute": "must be an absolute path",
+    "prefix": "is not within an allowed mount prefix",
+}
+
+_ILLEGAL_HOSTPATHS = [
+    ("path_traversal", under_prefix("..", "etc", "shadow"), "prefix"),
+    ("prefix_spoof", f"{under_prefix()}_evil/data", "prefix"),
+    ("relative_host_path", "data/shared/foo", "absolute"),
+    ("outside_prefix", "/var/run/secret", "prefix"),
+    ("root_hostpath", "/", "prefix"),
+    ("empty_hostpath", "", "absolute"),
+]
+
+
+@pytest.mark.parametrize(
+    ("case", "host_path", "reason"),
+    _ILLEGAL_HOSTPATHS,
+    ids=[c[0] for c in _ILLEGAL_HOSTPATHS],
+)
+def test_illegal_hostpath_rejected(case, host_path, reason, sdk_backend, sdk_e2e_config):
+    """Illegal hostPath shapes are rejected before the sandbox boots."""
+    metadata = host_mount_metadata([mount_option(host_path, "/mnt/x")])
+    message = expect_create_rejected(
+        sdk_backend, sdk_e2e_config, metadata, role=f"reject_{case}"
+    )
+    phrase = _REASON_PHRASE[reason]
+    assert phrase in message.lower(), (
+        f"expected a {reason!r} rejection ({phrase!r}) for {case!r} "
+        f"({host_path!r}), got: {message!r}"
+    )
+
+
+@pytest.mark.parametrize(
+    ("case", "mount_path"),
+    [
+        ("relative_mountpath", "mnt/rel"),
+        ("empty_mountpath", ""),
+    ],
+    ids=["relative_mountpath", "empty_mountpath"],
+)
+def test_illegal_mountpath_rejected(case, mount_path, sdk_backend, sdk_e2e_config):
+    """mountPath must be an absolute path; relative or empty is rejected."""
+    metadata = host_mount_metadata([mount_option(under_prefix("ok"), mount_path)])
+    message = expect_create_rejected(
+        sdk_backend, sdk_e2e_config, metadata, role=f"reject_{case}"
+    )
+    assert "mountpath must be an absolute path" in message.lower(), (
+        f"expected an absolute-mountPath rejection for {case!r} "
+        f"({mount_path!r}), got: {message!r}"
+    )
+
+
+def test_mixed_valid_and_invalid_entries_rejected(sdk_backend, sdk_e2e_config):
+    """A list mixing a legal and an illegal entry is rejected atomically.
+
+    Neither mount should be applied: one bad entry fails the whole create.
+    """
+    metadata = host_mount_metadata(
+        [
+            mount_option(under_prefix("ok"), "/mnt/ok"),
+            mount_option("/etc/secret", "/mnt/secret"),
+        ]
+    )
+    message = expect_create_rejected(
+        sdk_backend, sdk_e2e_config, metadata, role="reject_mixed"
+    )
+    assert "is not within an allowed mount prefix" in message.lower(), (
+        f"expected the illegal entry to fail the whole create, got: {message!r}"
+    )
+
+
+@pytest.mark.parametrize(
+    ("case", "raw"),
+    [
+        ("not_json", "this-is-not-json"),
+        ("json_object_not_array", '{"hostPath": "/data/shared", "mountPath": "/mnt/x"}'),
+        ("json_scalar", '"just-a-string"'),
+    ],
+    ids=["not_json", "json_object_not_array", "json_scalar"],
+)
+def test_malformed_annotation_rejected(case, raw, sdk_backend, sdk_e2e_config):
+    """A host-mount annotation that is not a JSON array of descriptors is rejected.
+
+    CubeMaster unmarshals the value into ``[]HostDirMountOption``; a non-JSON
+    string, a bare object, or a scalar all fail to decode and abort create.
+    """
+    message = expect_create_rejected(
+        sdk_backend,
+        sdk_e2e_config,
+        {HOST_MOUNT_KEY: raw},
+        role=f"reject_{case}",
+    )
+    # CubeMaster wraps a decode failure as `invalid "host-mount" annotation: ...`
+    # (hostdir_mount.go). Assert on that decode-specific text so an unrelated
+    # transient API/network error cannot satisfy the assertion for the wrong
+    # reason.
+    lowered = message.lower()
+    assert "invalid" in lowered and HOST_MOUNT_KEY in lowered, (
+        f"expected a decode-failure rejection for {case!r}, got: {message!r}"
+    )
+
+
+# --- Runtime bind-mount failures (pass lexical check, fail in Cubelet) --------
+
+
+def test_nonexistent_hostpath_rejected_at_create(sdk_backend, sdk_e2e_config):
+    """A hostPath under the allowed prefix that does not exist fails create.
+
+    This passes CubeMaster's lexical validation but Cubelet cannot bind-mount a
+    missing source, so ``prepareHostDirVolume`` fails the create. We assert on
+    Cubelet's own wrapper text (``bind mount ... ->``, see hostdir.go) rather
+    than the underlying mount(8) stderr, which is util-linux-version- and
+    locale-dependent. Uses a random unprovisioned subdir so it is guaranteed
+    absent.
+    """
+    missing = under_prefix("definitely-missing", uuid.uuid4().hex)
+    metadata = host_mount_metadata([mount_option(missing, "/mnt/missing")])
+    message = expect_create_rejected(
+        sdk_backend, sdk_e2e_config, metadata, role="reject_nonexistent_hostpath"
+    )
+    assert "bind mount" in message.lower(), (
+        f"expected a bind-mount failure for the missing source {missing!r}, "
+        f"got: {message!r}"
+    )
+
+
+def test_file_hostpath_rejected_at_create(sdk_backend, sdk_e2e_config):
+    """A hostPath that is a regular file (not a directory) fails create.
+
+    Cubelet creates the bind *destination* as a directory and bind-mounts the
+    source onto it; binding a file onto a directory fails at mount time. We
+    first materialize a file on the host under the allowed prefix, then attempt
+    to mount it.
+    """
+    token = uuid.uuid4().hex
+    rel_dir = f"filecase/{token}"
+    file_rel = f"{rel_dir}/regular.txt"
+    file_host_path = under_prefix(file_rel)
+
+    # Materialize the host file: mount the prefix root RW and write it. Scope the
+    # RW mount to the per-test subdir, not the whole prefix root, to avoid a
+    # broad writable mount of shared host state.
+    provision_host_dirs(sdk_backend, sdk_e2e_config, [rel_dir])
+    seed_mount = "/mnt/seed"
+    seed_metadata = host_mount_metadata(
+        [mount_option(under_prefix(rel_dir), seed_mount, read_only=False)]
+    )
+    with managed_control_sandbox(
+        sdk_backend,
+        sdk_e2e_config,
+        metadata={"test_role": "host_mount_file_seed", **seed_metadata},
+    ) as seeder:
+        seed = seeder.run_command(
+            f"echo file-not-dir > {seed_mount}/regular.txt",
+            timeout=sdk_e2e_config.command_timeout,
+        )
+        assert_command_ok(seed)
+
+        try:
+            metadata = host_mount_metadata([mount_option(file_host_path, "/mnt/asfile")])
+            message = expect_create_rejected(
+                sdk_backend, sdk_e2e_config, metadata, role="reject_file_hostpath"
+            )
+            # Cubelet wraps every bind failure with "bind mount ... ->" (hostdir.go);
+            # assert on that stable text rather than the mount(8) "not a directory"
+            # tail, which varies by util-linux version/locale.
+            assert "bind mount" in message.lower(), (
+                f"expected a bind-mount failure for the file source {file_host_path!r}, "
+                f"got: {message!r}"
+            )
+        finally:
+            # Reuse the still-open seeder (RW-mounted at seed_mount) to remove the
+            # per-token subtree so it does not accumulate on shared host storage
+            # across CI runs. seed_mount maps to <prefix>/filecase/<token>.
+            seeder.run_command(
+                f"rm -rf {seed_mount}/regular.txt",
+                timeout=sdk_e2e_config.command_timeout,
+            )
+
+
+# --- Accepted edge cases -----------------------------------------------------
+
+
+@pytest.mark.sandbox_create_options(
+    metadata=host_mount_metadata([mount_option(under_prefix(), "/mnt/exact")])
+)
+def test_exact_allowed_prefix_dir_mounts(sdk_sandbox, sdk_e2e_config):
+    """The allowed-prefix directory itself (no child) is a valid hostPath."""
+    result = sdk_sandbox.run_command(
+        "test -d /mnt/exact && echo mounted",
+        timeout=sdk_e2e_config.command_timeout,
+    )
+    assert_command_ok(result)
+    assert "mounted" in result.stdout, (
+        f"expected /mnt/exact to be mounted; "
+        f"stdout={result.stdout!r} stderr={result.stderr!r}"
+    )
+
+
+@pytest.mark.sandbox_create_options(metadata=host_mount_metadata([]))
+def test_empty_mount_list_is_noop(sdk_sandbox, sdk_e2e_config):
+    """An empty host-mount list creates a normal sandbox with no extra mount."""
+    result = sdk_sandbox.run_command(
+        "echo alive",
+        timeout=sdk_e2e_config.command_timeout,
+    )
+    assert_command_ok(result)
+    assert result.stdout.strip() == "alive"
+
+
+# --- Real host sharing -------------------------------------------------------
+
+
+def test_rw_mount_shares_data_across_sandboxes(sdk_backend, sdk_e2e_config):
+    """Two sandboxes mounting the same host dir see each other's writes.
+
+    Proves the mount is a genuine host bind-mount (shared state on the node),
+    not a per-sandbox copy. Uses a unique subdirectory so parallel runs do not
+    collide.
+    """
+    token = uuid.uuid4().hex[:12]
+    rel = f"share/{token}"
+    host_dir = under_prefix(rel)
+    mount = "/mnt/shared"
+    payload = f"payload-{token}"
+    metadata = host_mount_metadata([mount_option(host_dir, mount, read_only=False)])
+
+    # The host dir must exist before it can be bind-mounted (Cubelet does not
+    # create the source path).
+    provision_host_dirs(sdk_backend, sdk_e2e_config, [rel])
+
+    with managed_control_sandbox(
+        sdk_backend,
+        sdk_e2e_config,
+        metadata={"test_role": "host_mount_writer", **metadata},
+    ) as writer:
+        write = writer.run_command(
+            f"echo {payload} > {mount}/note.txt && sync",
+            timeout=sdk_e2e_config.command_timeout,
+        )
+        assert_command_ok(write)
+
+        try:
+            with managed_control_sandbox(
+                sdk_backend,
+                sdk_e2e_config,
+                metadata={"test_role": "host_mount_reader", **metadata},
+            ) as reader:
+                read = reader.run_command(
+                    f"cat {mount}/note.txt",
+                    timeout=sdk_e2e_config.command_timeout,
+                )
+                assert_command_ok(read)
+                assert payload in read.stdout, (
+                    "second sandbox did not observe the first sandbox's write to the "
+                    f"shared host dir {host_dir}; "
+                    f"stdout={read.stdout!r} stderr={read.stderr!r}"
+                )
+        finally:
+            # Reuse the still-open writer (RW-mounted at mount) to remove the
+            # per-token payload so it does not accumulate on shared host storage
+            # across CI runs. mount maps to <prefix>/share/<token>.
+            writer.run_command(
+                f"rm -rf {mount}/note.txt",
+                timeout=sdk_e2e_config.command_timeout,
+            )
+
+
+# --- Symlink TOCTOU escape ---------------------------------------------------
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="known-open host-mount symlink TOCTOU (see docstring); strict=True "
+    "turns the fix into a loud XPASS and catches later regressions.",
+)
+def test_symlink_escapes_allowed_prefix(sdk_backend, sdk_e2e_config):
+    """Reproduce the symlink TOCTOU escape of the host-mount whitelist.
+
+    1. Sandbox A mounts the allowed prefix and plants a symlink
+       `escape-<id> -> /bin` inside it (materialized on the host as
+       `<prefix>/escape-<id> -> /bin`).
+    2. Sandbox B requests host-mount of `<prefix>/escape-<id>`. CubeMaster's
+       lexical check sees a path under the allowed prefix and admits it;
+       Cubelet resolves the symlink and bind-mounts the host `/bin`.
+    3. If B can read host `/bin` through the mount, the whitelist is bypassed:
+       `/bin` is the node root filesystem, which cannot appear under the prefix.
+
+    The escape target is `/bin` rather than a secret directory such as `/etc`
+    on purpose: it proves the same lexical-vs-resolved bypass (a directory
+    outside the allowed prefix, on the node root filesystem) while reading no
+    host secret, and a stray `-> /bin` link left on shared host state if the
+    harness is killed mid-test is far less dangerous than `-> /etc`. `/bin` also
+    exists on every Cubelet node, so the probe is deterministic.
+
+    Two secure outcomes make this test pass: the escaper create is rejected
+    (path re-validated after symlink resolution), or the create succeeds but the
+    mount does not expose the symlink target. The current code allows the
+    escape, so the test xfails. Once the resolved path is validated it will
+    XPASS, and because the marker is ``strict=True`` that XPASS fails the suite,
+    forcing removal of the marker; a later regression re-introducing the escape
+    then fails loudly instead of being silently tolerated.
+    """
+    token = uuid.uuid4().hex[:12]
+    link_name = f"escape-{token}"
+    link_host_path = under_prefix(link_name)
+    symlink_target = "/bin"
+
+    plant_mount = "/mnt/hostdir-plant"
+    plant_metadata = host_mount_metadata(
+        [mount_option(under_prefix(), plant_mount, read_only=False)]
+    )
+    with managed_control_sandbox(
+        sdk_backend,
+        sdk_e2e_config,
+        metadata={"test_role": "host_mount_planter", **plant_metadata},
+    ) as planter:
+        plant = planter.run_command(
+            f"ln -sfn {symlink_target} {plant_mount}/{link_name} && "
+            f"readlink {plant_mount}/{link_name}",
+            timeout=sdk_e2e_config.command_timeout,
+        )
+        assert_command_ok(plant)
+        assert plant.stdout.strip() == symlink_target, (
+            f"failed to plant symlink; stdout={plant.stdout!r} stderr={plant.stderr!r}"
+        )
+
+        try:
+            victim_mount = "/mnt/hostdir-escaped"
+            # Read-only: the probe only reads the target, and a RO mount removes
+            # any chance of a stray write reaching the symlink target (host /bin).
+            escape_metadata = host_mount_metadata(
+                [mount_option(link_host_path, victim_mount, read_only=True)]
+            )
+            try:
+                with managed_control_sandbox(
+                    sdk_backend,
+                    sdk_e2e_config,
+                    metadata={"test_role": "host_mount_escaper", **escape_metadata},
+                ) as escaper:
+                    # Detect a core binary that only exists on the node root
+                    # filesystem's /bin, never under the allowed prefix.
+                    probe = escaper.run_command(
+                        f"ls {victim_mount} 2>/dev/null | "
+                        f"grep -Ex '(sh|ls|cat)' | head",
+                        timeout=sdk_e2e_config.command_timeout,
+                    )
+                    escaped = bool(probe.stdout.strip())
+                    assert not escaped, (
+                        "host-mount whitelist bypassed via symlink: sandbox B "
+                        f"mounted host {symlink_target} through {link_host_path}. "
+                        f"probe stdout={probe.stdout!r} stderr={probe.stderr!r}. "
+                        "Cubelet must re-validate the symlink-resolved path "
+                        "against the allowed prefix before mounting."
+                    )
+            except AssertionError:
+                # The deliberate ``assert not escaped`` above (the bypass
+                # detection) must surface with its own diagnostic, not be
+                # mistaken for a create failure below.
+                raise
+            except Exception as exc:  # noqa: BLE001 - a rejected create is the secure outcome
+                # A backend that re-validates the resolved path rejects the
+                # escaper create outright; that is a pass, not an error. The
+                # rejection may come from the control-plane prefix/absolute check
+                # or, if the fix lives in Cubelet, from a bind-mount/symlink
+                # failure at mount time -- accept any of these secure signals.
+                secure_tokens = ("prefix", "absolute", "bind mount", "symlink")
+                assert any(t in str(exc).lower() for t in secure_tokens), (
+                    f"escaper create failed for an unexpected reason: {exc!r}"
+                )
+        finally:
+            # Remove the planted symlink from the shared host dir so a "-> /bin"
+            # link cannot leak to later tests or other tenants on the node. The
+            # planter still has the prefix mounted RW. Assert the unlink so a
+            # failed cleanup surfaces loudly instead of leaving a live escape
+            # hatch on shared host state. rm -f on the link path unlinks the
+            # symlink itself; it does not follow the link.
+            cleanup = planter.run_command(
+                f"rm -f {plant_mount}/{link_name} && "
+                f"test ! -e {plant_mount}/{link_name} && echo removed",
+                timeout=sdk_e2e_config.command_timeout,
+            )
+            assert cleanup.exit_code == 0 and "removed" in cleanup.stdout, (
+                f"failed to remove planted symlink {link_host_path!r}; it may "
+                f"leak to other sandboxes. stdout={cleanup.stdout!r} "
+                f"stderr={cleanup.stderr!r}"
+            )

--- a/tests/e2e/sdk_compat/cases/host-mount/test_create_with_mount.py
+++ b/tests/e2e/sdk_compat/cases/host-mount/test_create_with_mount.py
@@ -1,0 +1,138 @@
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Host-mount happy-path tests, equivalent to examples/host-mount.
+
+Mirrors examples/host-mount/create_with_mount.py: create a sandbox with a
+read-write and a read-only host directory mounted, verify both are visible
+inside the VM, that the read-only mount rejects writes, and that a hostPath
+outside the allowed prefix is rejected at create time (README section 1).
+
+A host-mount ``hostPath`` must already exist on the Cubelet node: Cubelet
+bind-mounts it directly and does not create it. Only the allowed-prefix root is
+guaranteed to exist, so the ``_provision_host_dirs`` autouse fixture creates the
+``rw`` and ``ro`` subdirectories before the mount sandbox is created.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from framework.assertions import assert_command_ok
+from framework.capabilities import HOST_MOUNT
+from framework.host_mount import (
+    expect_create_rejected,
+    host_mount_metadata,
+    mount_option,
+    provision_host_dirs,
+    skip_if_host_mount_unavailable,
+    under_prefix,
+)
+
+pytestmark = [
+    pytest.mark.e2e,
+    pytest.mark.sdk_compat,
+    pytest.mark.host_mount,
+    pytest.mark.p1,
+    pytest.mark.requires_capability(HOST_MOUNT),
+]
+
+_RW_MOUNT = "/mnt/rw"
+_RO_MOUNT = "/mnt/ro"
+
+# Equivalent to the example's metadata: one RW mount and one RO mount.
+_RW_RO_METADATA = host_mount_metadata(
+    [
+        mount_option(under_prefix("rw"), _RW_MOUNT, read_only=False),
+        mount_option(under_prefix("ro"), _RO_MOUNT, read_only=True),
+    ]
+)
+
+
+# Backends whose rw/ro host dirs have already been provisioned this session.
+# The dirs are created idempotently and persist on the host after the throwaway
+# provisioning sandbox is killed, so one provisioning boot per backend suffices
+# for the whole module instead of one per test.
+_provisioned_backends: set[str] = set()
+
+
+@pytest.fixture(autouse=True)
+def _provision_host_dirs(sdk_backend, sdk_e2e_config):
+    """Ensure the rw/ro host dirs exist before the mount sandbox is created.
+
+    Autouse function-scoped fixtures run before an explicitly requested fixture
+    such as ``sdk_sandbox``, so the directories are in place by the time the
+    marker-driven create happens. Delegates the skip decision to the shared
+    ``skip_if_host_mount_unavailable`` helper (the same two conditions
+    ``sdk_sandbox`` applies), so a third gating condition added there is picked
+    up here automatically instead of drifting. Provisioning is memoized per
+    backend: only the first test in the module pays the throwaway-sandbox boot;
+    the rest reuse the persisted host dirs.
+    """
+    skip_if_host_mount_unavailable(sdk_backend, sdk_e2e_config)
+    if sdk_backend in _provisioned_backends:
+        return
+    provision_host_dirs(sdk_backend, sdk_e2e_config, ["rw", "ro"])
+    _provisioned_backends.add(sdk_backend)
+
+
+@pytest.mark.sandbox_create_options(metadata=_RW_RO_METADATA)
+def test_rw_and_ro_mounts_visible(sdk_sandbox, sdk_e2e_config):
+    """Both mounts appear inside the sandbox (example's `ls /mnt/rw /mnt/ro`)."""
+    result = sdk_sandbox.run_command(
+        f"test -d {_RW_MOUNT} && test -d {_RO_MOUNT} && echo both-present",
+        timeout=sdk_e2e_config.command_timeout,
+    )
+    assert_command_ok(result)
+    assert "both-present" in result.stdout, (
+        f"expected both {_RW_MOUNT} and {_RO_MOUNT} to be mounted directories; "
+        f"stdout={result.stdout!r} stderr={result.stderr!r}"
+    )
+
+
+@pytest.mark.sandbox_create_options(metadata=_RW_RO_METADATA)
+def test_rw_mount_accepts_writes(sdk_sandbox, sdk_e2e_config):
+    """The read-write mount is writable from inside the sandbox."""
+    result = sdk_sandbox.run_command(
+        f"echo cube > {_RW_MOUNT}/sdk-compat-rw.txt && cat {_RW_MOUNT}/sdk-compat-rw.txt",
+        timeout=sdk_e2e_config.command_timeout,
+    )
+    assert_command_ok(result)
+    assert "cube" in result.stdout, (
+        f"expected write to {_RW_MOUNT} to succeed; "
+        f"stdout={result.stdout!r} stderr={result.stderr!r}"
+    )
+
+
+@pytest.mark.sandbox_create_options(metadata=_RW_RO_METADATA)
+def test_ro_mount_rejects_writes(sdk_sandbox, sdk_e2e_config):
+    """Writes to the read-only mount fail (README: kernel enforces MS_RDONLY)."""
+    result = sdk_sandbox.run_command(
+        f"echo denied > {_RO_MOUNT}/sdk-compat-ro.txt",
+        timeout=sdk_e2e_config.command_timeout,
+    )
+    assert result.exit_code != 0, (
+        f"expected write to read-only mount {_RO_MOUNT} to fail; "
+        f"stdout={result.stdout!r} stderr={result.stderr!r}"
+    )
+    assert "read-only" in result.stderr.lower() or "read only" in result.stderr.lower(), (
+        f"expected a read-only filesystem error, got stderr={result.stderr!r}"
+    )
+
+
+def test_disallowed_hostpath_rejected_at_create(sdk_backend, sdk_e2e_config):
+    """A hostPath outside the allowed prefix is rejected at create time.
+
+    README section 1: mounting e.g. /etc/passwd raises ApiError with the
+    message "not within an allowed mount prefix". Gated by the same host-mount
+    availability check ``sdk_sandbox`` would apply, without booting a sandbox we
+    never use.
+    """
+    skip_if_host_mount_unavailable(sdk_backend, sdk_e2e_config)
+    metadata = host_mount_metadata([mount_option("/etc/passwd", "/mnt/passwd")])
+    message = expect_create_rejected(
+        sdk_backend, sdk_e2e_config, metadata, role="host_mount_disallowed"
+    )
+    assert "is not within an allowed mount prefix" in message.lower(), (
+        f"expected an allowed-prefix rejection message, got {message!r}"
+    )

--- a/tests/e2e/sdk_compat/conftest.py
+++ b/tests/e2e/sdk_compat/conftest.py
@@ -18,7 +18,7 @@ sys.path.insert(0, str(SDK_COMPAT_ROOT))
 
 from adapters import create_adapter  # noqa: E402
 from framework.cleanup import safe_kill  # noqa: E402
-from framework.capabilities import CODE_INTERPRETER, CUBESANDBOX_CAPABILITIES, E2B_CAPABILITIES  # noqa: E402
+from framework.capabilities import CODE_INTERPRETER, capabilities_for_backend  # noqa: E402
 from framework.config import SdkE2EConfig  # noqa: E402
 from framework.preflight import run_preflight  # noqa: E402
 from framework.reporting import JsonlReporter  # noqa: E402
@@ -329,11 +329,7 @@ def _config_from_pytest(config: pytest.Config) -> SdkE2EConfig:
 
 
 def _capabilities_for_backend(backend: str) -> frozenset[str]:
-    if backend == "cubesandbox":
-        return CUBESANDBOX_CAPABILITIES
-    if backend == "e2b":
-        return E2B_CAPABILITIES
-    return frozenset()
+    return capabilities_for_backend(backend)
 
 
 def _create_options_for_node(node: pytest.Item) -> dict:

--- a/tests/e2e/sdk_compat/framework/capabilities.py
+++ b/tests/e2e/sdk_compat/framework/capabilities.py
@@ -12,6 +12,7 @@ PAUSE_RESUME = "pause_resume"
 NETWORK_ALLOW_DENY = "network_allow_deny"
 NETWORK_PUBLIC_ACCESS = "network_public_access"
 PLATFORM_LIFECYCLE = "platform_lifecycle"
+HOST_MOUNT = "host_mount"
 
 COMMON_CAPABILITIES = frozenset({LIFECYCLE, COMMANDS, FILESYSTEM, RUN_CODE})
 
@@ -33,5 +34,20 @@ CUBESANDBOX_CAPABILITIES = frozenset(
         NETWORK_ALLOW_DENY,
         NETWORK_PUBLIC_ACCESS,
         PLATFORM_LIFECYCLE,
+        HOST_MOUNT,
     }
 )
+
+# Canonical backend -> capability-set map. Single source of truth for both the
+# sdk_sandbox fixture gate (conftest._capabilities_for_backend) and the helpers
+# that drive create_adapter directly (framework.host_mount). Unknown backends
+# resolve to the empty set.
+BACKEND_CAPABILITIES = {
+    "cubesandbox": CUBESANDBOX_CAPABILITIES,
+    "e2b": E2B_CAPABILITIES,
+}
+
+
+def capabilities_for_backend(backend: str) -> frozenset[str]:
+    """Return the capability set a backend supports (empty for unknown)."""
+    return BACKEND_CAPABILITIES.get(backend, frozenset())

--- a/tests/e2e/sdk_compat/framework/host_mount.py
+++ b/tests/e2e/sdk_compat/framework/host_mount.py
@@ -1,0 +1,136 @@
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Helpers for the host-mount extension.
+
+Host mounts are a Cube-specific extension to the E2B API: they are requested
+through ``metadata["host-mount"]`` as a JSON-encoded list of descriptors, each
+with ``hostPath`` / ``mountPath`` / ``readOnly``. CubeAPI lifts the value onto
+the sandbox annotation of the same name; CubeMaster validates ``hostPath``
+against the allowed-prefix whitelist (default ``/data/shared/``) and Cubelet
+performs the bind-mount before the VM boots.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+
+import pytest
+
+from adapters import create_adapter
+from framework.capabilities import HOST_MOUNT, capabilities_for_backend
+from framework.cleanup import safe_kill
+
+HOST_MOUNT_KEY = "host-mount"
+
+# Internal mount point used only for provisioning host subdirectories.
+_PROVISION_MOUNT = "/mnt/.host-mount-provision"
+
+# Allowed prefix on the target environment. Must match CubeMaster's
+# ``allowed_host_mount_prefixes`` (default ``/data/shared/``). Trailing slash is
+# stripped so it can be composed with child paths.
+ALLOWED_PREFIX = os.environ.get("SDK_E2E_HOST_MOUNT_PREFIX", "/data/shared").rstrip("/")
+
+
+def backend_supports_host_mount(backend: str) -> bool:
+    """Whether ``backend`` implements the host-mount extension.
+
+    Boundary tests drive ``create_adapter`` directly and never pass through the
+    ``sdk_sandbox`` fixture's ``requires_capability`` check, so they consult this
+    against the same canonical backend->capability map the fixture uses.
+    """
+    return HOST_MOUNT in capabilities_for_backend(backend)
+
+
+def skip_if_host_mount_unavailable(backend: str, config) -> None:
+    """Skip the current test unless a real host-mount create is possible.
+
+    Boundary tests drive ``create_adapter`` directly instead of requesting the
+    ``sdk_sandbox`` fixture, so they never pass through the fixture's
+    ``requires_capability`` / template gates. Apply the same two conditions here
+    so those tests skip exactly the cases ``sdk_sandbox`` would.
+    """
+    if not backend_supports_host_mount(backend):
+        pytest.skip(f"backend {backend!r} does not support host-mount")
+    if not config.cube_template_id:
+        pytest.skip("CUBE_TEMPLATE_ID or --cube-template-id is required for SDK E2E")
+
+
+def expect_create_rejected(
+    backend: str,
+    config,
+    metadata: dict[str, str],
+    *,
+    role: str,
+) -> str:
+    """Attempt a create expected to fail; return the error text.
+
+    If the create unexpectedly succeeds, clean up the sandbox and fail the test
+    so it never leaks.
+    """
+    try:
+        adapter = create_adapter(
+            backend,
+            config,
+            metadata={"test_role": role, **metadata},
+        )
+    except Exception as exc:  # noqa: BLE001 - the rejection is the assertion
+        return str(exc)
+    safe_kill(adapter, config)
+    pytest.fail(f"expected create to be rejected ({role}), but the sandbox was created")
+    raise AssertionError("unreachable")  # pytest.fail raises; keeps type checkers happy
+
+
+def mount_option(host_path: str, mount_path: str, *, read_only: bool = False) -> dict:
+    """One entry of the host-mount list.
+
+    Field names match CubeMaster's ``HostDirMountOption`` json tags
+    (hostPath / mountPath / readOnly).
+    """
+    return {"hostPath": host_path, "mountPath": mount_path, "readOnly": read_only}
+
+
+def host_mount_metadata(options: list[dict]) -> dict[str, str]:
+    """Wrap descriptors into the ``metadata`` dict the SDK expects."""
+    return {HOST_MOUNT_KEY: json.dumps(options)}
+
+
+def under_prefix(*parts: str) -> str:
+    """Join path components under the allowed prefix."""
+    return "/".join([ALLOWED_PREFIX, *(p.strip("/") for p in parts)])
+
+
+def provision_host_dirs(backend: str, config, subpaths: list[str]) -> None:
+    """Create subdirectories under the allowed prefix on the Cubelet host node.
+
+    A host-mount ``hostPath`` must already exist on the node: Cubelet's
+    ``prepareHostDirVolume`` bind-mounts it directly and does NOT create it, so
+    a missing source dir fails the create at bind-mount time. Only the
+    allowed-prefix root itself is guaranteed to exist.
+
+    This helper mounts the prefix root read-write into a throwaway sandbox and
+    runs ``mkdir -p`` for each subpath. The directories persist on the host
+    after the sandbox is killed, so later tests can mount them.
+    """
+    rel = [p.strip("/") for p in subpaths if p.strip("/")]
+    if not rel:
+        return
+    metadata = host_mount_metadata(
+        [mount_option(ALLOWED_PREFIX, _PROVISION_MOUNT, read_only=False)]
+    )
+    targets = " ".join(f"{_PROVISION_MOUNT}/{r}" for r in rel)
+    adapter = create_adapter(
+        backend, config, metadata={"test_role": "host_mount_provision", **metadata}
+    )
+    try:
+        result = adapter.run_command(
+            f"mkdir -p {targets}", timeout=config.command_timeout
+        )
+        if result.exit_code != 0:
+            raise RuntimeError(
+                f"failed to provision host dirs {rel!r}: "
+                f"exit={result.exit_code} stderr={result.stderr!r}"
+            )
+    finally:
+        safe_kill(adapter, config)

--- a/tests/e2e/sdk_compat/pytest.ini
+++ b/tests/e2e/sdk_compat/pytest.ini
@@ -16,6 +16,7 @@ markers =
     concurrency: multi-sandbox isolation and concurrency compatibility tests
     network: sandbox network policy compatibility tests
     run_code: sandbox code interpreter compatibility tests
+    host_mount: host-directory mount extension compatibility and boundary tests
     requires_capability(name): current backend must support the named capability
     sandbox_create_options(**kwargs): SDK sandbox create options for this test
     sandbox_template_id(template_id): override template ID for a test or module


### PR DESCRIPTION
Add end-to-end coverage for the host-mount extension in the sdk_compat suite: the example happy path (RW/RO mounts, read-only enforcement), allowed-prefix validation, malformed annotations, runtime bind-mount failures, cross-sandbox host sharing, and the symlink whitelist escape.