### PR TITLE
CubeProxy: Return 403 for traffic-token failures to preserve E2B comp…

### DIFF
--- a/CubeProxy/lua/sandbox_backend.lua
+++ b/CubeProxy/lua/sandbox_backend.lua
@@ -19,10 +19,13 @@ local _M = { _VERSION = "0.01" }
 --
 -- Both args are the raw values stored in Redis (string form). expected_token
 -- being empty while allow_public is "false" indicates a server-side
--- inconsistency. Both failure paths return 404 (not 403/500) so that a
--- caller cannot distinguish "sandbox exists but access denied" from
--- "sandbox does not exist"; silently letting the request through would be
--- worse.
+-- inconsistency. Both failure paths return 403 (not the collapsed 404 used
+-- for "sandbox not found") to preserve E2B behavioral compatibility — E2B's
+-- restrict-public-access contract, our public docs, and the SDK all promise
+-- that unauthenticated / mismatched tokens are rejected with 403. This does
+-- leak the fact that the sandbox exists (vs. non-existent → 404), but the
+-- sandbox ID space is already unguessable and the wire compatibility win
+-- outweighs the enumeration signal.
 local function enforce_traffic_token(allow_public, expected_token, ins_id)
     if allow_public ~= "false" then
         return
@@ -31,7 +34,7 @@ local function enforce_traffic_token(allow_public, expected_token, ins_id)
         ngx.log(ngx.ERR, "LEVEL_ERROR||",
             string.format("request %s sandbox %s marked restricted but token missing in metadata",
                 ngx.var.http_x_cube_request_id, ins_id))
-        utils:respond_not_found()
+        utils:respond_forbidden()
     end
     local provided = ngx.var.http_e2b_traffic_access_token
                   or ngx.var.http_cube_traffic_access_token
@@ -39,7 +42,7 @@ local function enforce_traffic_token(allow_public, expected_token, ins_id)
         ngx.log(ngx.ERR, "LEVEL_WARN||",
             string.format("request %s sandbox %s traffic token mismatch",
                 ngx.var.http_x_cube_request_id, ins_id))
-        utils:respond_not_found()
+        utils:respond_forbidden()
     end
 end
 

--- a/CubeProxy/lua/utils.lua
+++ b/CubeProxy/lua/utils.lua
@@ -60,11 +60,17 @@ function _M.respond_with(self, status, body)
     ngx.exit(status)
 end
 
--- Convenience wrappers for the three error shapes the dataplane returns.
--- 400 = malformed request; 404 hides sandbox existence; 503 hides the
--- specific failing subsystem.
+-- Convenience wrappers for the error shapes the dataplane returns.
+-- 400 = malformed request; 403 = traffic-token gate rejection
+-- (deliberately distinct from 404 to preserve E2B header/status
+-- compatibility for restricted-public-access clients); 404 hides
+-- sandbox existence; 503 hides the specific failing subsystem.
 function _M.respond_bad_request(self)
     self:respond_with(400, '{"error":"bad request"}')
+end
+
+function _M.respond_forbidden(self)
+    self:respond_with(403, '{"error":"forbidden"}')
 end
 
 function _M.respond_not_found(self)


### PR DESCRIPTION
…atibility

The 404-collapse in e052abd7 swept enforce_traffic_token()'s two failure paths into the "hide sandbox existence" bucket, unintentionally breaking the E2B wire contract that #639 was built to mirror. The demo, the Restrict-Public-Access docs (en + zh), the v0.5.0 changelog, and the Python SDK docstrings all promise HTTP 403 for missing / mismatched tokens — E2B does the same. 404 makes restrict_public_access.py's Step-2 verdict fail.

Add utils:respond_forbidden() (403 + {"error":"forbidden"}) and route enforce_traffic_token()'s two rejection paths through it. The comment above the function now records the deliberate tradeoff: we accept the sandbox-existence signal e052abd wanted to hide in exchange for keeping the E2B contract and already-shipped SDK/docs behavior intact. All other 404/503/400 responses e052abd introduced remain untouched.

Verified locally with restrict_public_access.py — all three probes (no-header 403, e2b header 200, cube header 200) now PASS.

Refs:  e3ecfc138a53 ("network: Restrict public access via per-sandbox traffic token")
Fixes: e052abd7c698 ("CubeProxy: Remove cube_retcode to stop leaking implementation details")