### PR TITLE
fix(template): fence concurrent rootfs artifact builds in HA

### DIFF
--- a/CubeMaster/pkg/base/dao/migrate/migrations/mysql/20260720090000_rootfs_artifact_build_lease.sql
+++ b/CubeMaster/pkg/base/dao/migrate/migrations/mysql/20260720090000_rootfs_artifact_build_lease.sql
@@ -1,0 +1,39 @@
+-- Copyright (c) 2026 Tencent Inc.
+-- SPDX-License-Identifier: Apache-2.0
+--
+-- Fence concurrent rootfs artifact builders across CubeMaster replicas.
+
+-- +goose NO TRANSACTION
+-- +goose Up
+
+CALL cubemaster_acquire_migration_lock('cubemaster_migration_20260720090000_rootfs_artifact_build_lease', 60);
+
+CALL cubemaster_assert_table_exists('t_cube_rootfs_artifact');
+
+CALL cubemaster_add_column_if_missing(
+  't_cube_rootfs_artifact',
+  'build_owner_token',
+  "varchar(128) NOT NULL DEFAULT '' COMMENT 'opaque token of the active artifact builder' AFTER `gc_deadline`"
+);
+CALL cubemaster_add_column_if_missing(
+  't_cube_rootfs_artifact',
+  'build_generation',
+  "bigint NOT NULL DEFAULT 0 COMMENT 'monotonic artifact build generation' AFTER `build_owner_token`"
+);
+CALL cubemaster_add_column_if_missing(
+  't_cube_rootfs_artifact',
+  'build_lease_expire_at',
+  "bigint NOT NULL DEFAULT 0 COMMENT 'unix seconds when the active build lease expires' AFTER `build_generation`"
+);
+
+SELECT RELEASE_LOCK('cubemaster_migration_20260720090000_rootfs_artifact_build_lease');
+
+-- +goose Down
+
+CALL cubemaster_acquire_migration_lock('cubemaster_migration_20260720090000_rootfs_artifact_build_lease', 60);
+
+CALL cubemaster_drop_column_if_exists('t_cube_rootfs_artifact', 'build_lease_expire_at');
+CALL cubemaster_drop_column_if_exists('t_cube_rootfs_artifact', 'build_generation');
+CALL cubemaster_drop_column_if_exists('t_cube_rootfs_artifact', 'build_owner_token');
+
+SELECT RELEASE_LOCK('cubemaster_migration_20260720090000_rootfs_artifact_build_lease');

--- a/CubeMaster/pkg/base/dao/migrate/migrations/postgres/20260720090000_rootfs_artifact_build_lease.sql
+++ b/CubeMaster/pkg/base/dao/migrate/migrations/postgres/20260720090000_rootfs_artifact_build_lease.sql
@@ -1,0 +1,39 @@
+-- Copyright (c) 2026 Tencent Inc.
+-- SPDX-License-Identifier: Apache-2.0
+--
+-- Fence concurrent rootfs artifact builders across CubeMaster replicas.
+
+-- +goose NO TRANSACTION
+-- +goose Up
+
+SELECT cubemaster_acquire_migration_lock('cubemaster_migration_20260720090000_rootfs_artifact_build_lease', 60);
+
+SELECT cubemaster_assert_table_exists('t_cube_rootfs_artifact');
+
+SELECT cubemaster_add_column_if_missing(
+  't_cube_rootfs_artifact',
+  'build_owner_token',
+  'varchar(128) NOT NULL DEFAULT '''''
+);
+SELECT cubemaster_add_column_if_missing(
+  't_cube_rootfs_artifact',
+  'build_generation',
+  'bigint NOT NULL DEFAULT 0'
+);
+SELECT cubemaster_add_column_if_missing(
+  't_cube_rootfs_artifact',
+  'build_lease_expire_at',
+  'bigint NOT NULL DEFAULT 0'
+);
+
+SELECT pg_advisory_unlock(hashtext('cubemaster_migration_20260720090000_rootfs_artifact_build_lease'));
+
+-- +goose Down
+
+SELECT cubemaster_acquire_migration_lock('cubemaster_migration_20260720090000_rootfs_artifact_build_lease', 60);
+
+SELECT cubemaster_drop_column_if_exists('t_cube_rootfs_artifact', 'build_lease_expire_at');
+SELECT cubemaster_drop_column_if_exists('t_cube_rootfs_artifact', 'build_generation');
+SELECT cubemaster_drop_column_if_exists('t_cube_rootfs_artifact', 'build_owner_token');
+
+SELECT pg_advisory_unlock(hashtext('cubemaster_migration_20260720090000_rootfs_artifact_build_lease'));

--- a/CubeMaster/pkg/base/db/models/template_image.go
+++ b/CubeMaster/pkg/base/db/models/template_image.go
@@ -27,6 +27,12 @@ type RootfsArtifact struct {
 	Status                  string `json:"status" gorm:"column:status"`
 	LastError               string `json:"last_error" gorm:"column:last_error"`
 	GCDeadline              int64  `json:"gc_deadline" gorm:"column:gc_deadline"`
+	// BuildOwnerToken, BuildGeneration, and BuildLeaseExpireAt fence
+	// cross-CubeMaster artifact builds. The token identifies one build attempt;
+	// a stale attempt must never publish over a newer generation.
+	BuildOwnerToken    string `json:"build_owner_token" gorm:"column:build_owner_token"`
+	BuildGeneration    int64  `json:"build_generation" gorm:"column:build_generation"`
+	BuildLeaseExpireAt int64  `json:"build_lease_expire_at" gorm:"column:build_lease_expire_at"`
 
 	// CubeEgress CA bake metadata (see design/cube-egress-ca-bake.md).
 	// Used for audit/triage; the artifact reuse cache key folds

--- a/CubeMaster/pkg/templatecenter/artifact_build.go
+++ b/CubeMaster/pkg/templatecenter/artifact_build.go
@@ -9,10 +9,13 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"time"
 
+	mysqldriver "github.com/go-sql-driver/mysql"
 	"github.com/google/uuid"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/constants"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/db/models"
@@ -23,21 +26,88 @@ import (
 	"gorm.io/gorm/clause"
 )
 
-// artifactBuildLocks serializes ensureRootfsArtifact callers that target the
-// same artifactID. Without this, two templates submitted in quick succession
-// for the same image spec race on buildRootfsArtifact: both goroutines share
-// the same workDir/storeDir/ext4Path, and one goroutine's defer cleanup can
-// wipe the ext4 file while the other is still relying on it — the surviving
-// caller then reaches distributeRootfsArtifact with a partial record
-// (ext4_size_bytes=0, download_token=""), cubelet rejects the pull with
-// "invalid size:0", and the template is marked FAILED.
-//
-// The lock is keyed by artifactID (deterministic from image+spec fingerprint)
-// so only racing submits for the same image spec are serialized; different
-// images build in parallel as before. DB claimRootfsArtifactForBuild only
-// covers a short FOR UPDATE transaction and does not protect the filesystem
-// build in image.BuildExt4.
+// artifactBuildLocks is a same-process optimization for callers targeting the
+// same deterministic artifact ID. Cross-CubeMaster exclusion is enforced by
+// the durable lease/generation fields in claimRootfsArtifactForBuild.
 var artifactBuildLocks sync.Map // map[string]*sync.Mutex
+
+const (
+	rootfsArtifactBuildLeaseTTL          = 15 * time.Minute
+	rootfsArtifactBuildRenewEvery        = time.Minute
+	rootfsArtifactBuildWaitEvery         = 500 * time.Millisecond
+	rootfsArtifactBuildStateWriteTimeout = 10 * time.Second
+	rootfsArtifactClaimMaxAttempts       = 8
+)
+
+var errRootfsArtifactBuildLeaseLost = errors.New("rootfs artifact build lease lost")
+
+type publishedArtifactFinalizeError struct {
+	publishedPath string
+	cause         error
+}
+
+func (e *publishedArtifactFinalizeError) Error() string { return e.cause.Error() }
+func (e *publishedArtifactFinalizeError) Unwrap() error { return e.cause }
+
+var finalizeRootfsArtifactRecord = func(ctx context.Context, record *models.RootfsArtifact, values map[string]any) error {
+	if record == nil || record.BuildOwnerToken == "" || record.BuildGeneration < 1 {
+		return errRootfsArtifactBuildLeaseLost
+	}
+	tx := store.db.WithContext(ctx).Table(constants.RootfsArtifactTableName).
+		Where("artifact_id = ? AND status = ? AND build_owner_token = ? AND build_generation = ? AND build_lease_expire_at > ?",
+			record.ArtifactID, ArtifactStatusBuilding, record.BuildOwnerToken, record.BuildGeneration, time.Now().Unix()).
+		Updates(values)
+	if tx.Error == nil && tx.RowsAffected == 1 {
+		return nil
+	}
+
+	// A transport error does not prove that the UPDATE was rolled back: the
+	// database may have committed READY before the response was lost. Re-read
+	// the fenced generation on a detached context before reporting failure so
+	// callers never delete a generation that durable metadata already uses.
+	verifyCtx, verifyCancel := context.WithTimeout(context.WithoutCancel(ctx), rootfsArtifactBuildStateWriteTimeout)
+	defer verifyCancel()
+	committed, verifyErr := rootfsArtifactFinalizeCommitted(verifyCtx, record)
+	if committed {
+		return nil
+	}
+	if tx.Error != nil {
+		if verifyErr != nil {
+			return errors.Join(tx.Error, fmt.Errorf("verify rootfs artifact finalization: %w", verifyErr))
+		}
+		return tx.Error
+	}
+	if verifyErr != nil {
+		return errors.Join(errRootfsArtifactBuildLeaseLost, fmt.Errorf("verify rootfs artifact finalization: %w", verifyErr))
+	}
+	return errRootfsArtifactBuildLeaseLost
+}
+
+func rootfsArtifactFinalizeCommitted(ctx context.Context, intended *models.RootfsArtifact) (bool, error) {
+	var current models.RootfsArtifact
+	err := store.db.WithContext(ctx).Unscoped().
+		Select("artifact_id", "status", "build_owner_token", "build_generation", "ext4_path", "ext4_sha256", "ext4_size_bytes", "generated_request_json", "download_token").
+		Table(constants.RootfsArtifactTableName).
+		Where("artifact_id = ?", intended.ArtifactID).
+		First(&current).Error
+	if err != nil {
+		return false, err
+	}
+	return rootfsArtifactFinalizationMatches(&current, intended), nil
+}
+
+func rootfsArtifactFinalizationMatches(current, intended *models.RootfsArtifact) bool {
+	return current != nil && intended != nil &&
+		current.ArtifactID == intended.ArtifactID &&
+		current.Status == ArtifactStatusReady &&
+		current.BuildOwnerToken == intended.BuildOwnerToken &&
+		current.BuildGeneration == intended.BuildGeneration &&
+		current.Ext4Path == intended.Ext4Path &&
+		current.Ext4SHA256 == intended.Ext4SHA256 &&
+		current.Ext4SizeBytes == intended.Ext4SizeBytes &&
+		current.GeneratedRequestJSON == intended.GeneratedRequestJSON &&
+		current.DownloadToken == intended.DownloadToken
+}
 
 func ensureRootfsArtifact(ctx context.Context, req *types.CreateTemplateFromImageReq, source *image.PreparedSource, downloadBaseURL string) (*models.RootfsArtifact, *types.CreateCubeSandboxReq, bool, error) {
 	var generatedReq *types.CreateCubeSandboxReq
@@ -48,85 +118,73 @@ func ensureRootfsArtifact(ctx context.Context, req *types.CreateTemplateFromImag
 	}
 	fingerprint := buildTemplateSpecFingerprintWithCA(req, source.Digest, caFingerprint)
 	artifactID := buildArtifactID(fingerprint)
-	// Serialize concurrent builds of the same artifactID. Without this, two
-	// submits of the same image spec race on workDir/storeDir/ext4Path; the
-	// losing goroutine's defer cleanup can wipe the ext4 file while the
-	// winner is still relying on it. See artifactBuildLocks comment for the
-	// full failure mode.
+	// Avoid duplicate polling/waiting inside this process; the DB lease below
+	// is still authoritative across CubeMaster replicas.
 	muV, _ := artifactBuildLocks.LoadOrStore(artifactID, &sync.Mutex{})
 	mu := muV.(*sync.Mutex)
 	mu.Lock()
 	defer mu.Unlock()
-	record, wasDeleted, err := findReusableRootfsArtifact(ctx, fingerprint, artifactID)
-	if err == nil && wasDeleted {
-		if restoreErr := restoreRootfsArtifact(ctx, artifactID); restoreErr != nil {
-			return nil, nil, false, restoreErr
-		}
-		record.DeletedAt = gorm.DeletedAt{}
-	}
-	if err == nil && record.Status == ArtifactStatusReady && record.GeneratedRequestJSON != "" {
-		generatedReq, err = generateTemplateCreateRequest(req, record, source.Config, downloadBaseURL)
-		if err == nil {
-			return record, generatedReq, false, nil
-		}
-	}
-	if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
-		return nil, nil, false, err
-	}
-	if record == nil {
-		record = &models.RootfsArtifact{
-			ArtifactID:              artifactID,
-			TemplateSpecFingerprint: fingerprint,
-			SourceImageRef:          req.SourceImageRef,
-			SourceImageDigest:       source.Digest,
-			WritableLayerSize:       req.WritableLayerSize,
-			Status:                  ArtifactStatusPending,
-		}
-		if createErr := store.db.WithContext(ctx).Table(constants.RootfsArtifactTableName).Create(record).Error; createErr != nil {
-			if !errors.Is(createErr, gorm.ErrDuplicatedKey) &&
-				!strings.Contains(createErr.Error(), "1062") &&
-				!strings.Contains(createErr.Error(), "Duplicate entry") {
-				return nil, nil, false, createErr
+	for {
+		record, wasDeleted, findErr := findReusableRootfsArtifact(ctx, fingerprint, artifactID)
+		if findErr == nil && wasDeleted {
+			if restoreErr := restoreRootfsArtifact(ctx, artifactID); restoreErr != nil {
+				return nil, nil, false, restoreErr
 			}
-			record, wasDeleted, err = findReusableRootfsArtifact(ctx, fingerprint, artifactID)
-			if err != nil {
-				return nil, nil, false, createErr
+			record.DeletedAt = gorm.DeletedAt{}
+		}
+		if findErr == nil && record.Status == ArtifactStatusReady && record.GeneratedRequestJSON != "" {
+			generatedReq, err = generateTemplateCreateRequest(req, record, source.Config, downloadBaseURL)
+			if err == nil {
+				return record, generatedReq, false, nil
 			}
-			if wasDeleted {
-				if restoreErr := restoreRootfsArtifact(ctx, artifactID); restoreErr != nil {
-					return nil, nil, false, restoreErr
-				}
-				record.DeletedAt = gorm.DeletedAt{}
-			}
-			if record.Status == ArtifactStatusReady && record.GeneratedRequestJSON != "" {
-				generatedReq, err = generateTemplateCreateRequest(req, record, source.Config, downloadBaseURL)
+		}
+		if findErr != nil && !errors.Is(findErr, gorm.ErrRecordNotFound) {
+			return nil, nil, false, findErr
+		}
+
+		// Claim the row under its FOR UPDATE lock. The returned ownership bit is
+		// deliberately process-independent: a BUILDING row with a live lease is
+		// observed and waited on, not rebuilt by another CubeMaster replica.
+		claimed, owner, claimErr := claimRootfsArtifactForBuild(ctx, artifactID, fingerprint, req, source.Digest)
+		if claimErr != nil {
+			return nil, nil, false, claimErr
+		}
+		if !owner {
+			if claimed.Status == ArtifactStatusReady && claimed.GeneratedRequestJSON != "" {
+				generatedReq, err = generateTemplateCreateRequest(req, claimed, source.Config, downloadBaseURL)
 				if err == nil {
-					return record, generatedReq, false, nil
+					return claimed, generatedReq, false, nil
 				}
 			}
+			if err := waitForRootfsArtifactBuild(ctx, artifactID, fingerprint, claimed.BuildGeneration); err != nil {
+				return nil, nil, false, err
+			}
+			continue
 		}
+
+		buildCtx, stopLease := startRootfsArtifactBuildLease(ctx, claimed)
+		record, generatedReq, err = buildRootfsArtifact(buildCtx, claimed, req, source, downloadBaseURL, caPEM, caFingerprint)
+		leaseErr := stopLease()
+		if err == nil && leaseErr != nil {
+			err = leaseErr
+		}
+		if err != nil {
+			failureCtx, failureCancel := context.WithTimeout(context.WithoutCancel(ctx), rootfsArtifactBuildStateWriteTimeout)
+			markErr := markRootfsArtifactBuildFailed(failureCtx, claimed, err)
+			failureCancel()
+			// A successful fenced FAILED transition proves that a preceding
+			// ambiguous finalize did not commit READY: both updates require the
+			// same BUILDING generation. Only then is its published file safe to
+			// remove. If marking fails or loses the fence, preserve the immutable
+			// generation for READY readers or later lifecycle GC.
+			err = cleanupPublishedArtifactAfterFailedFinalize(ctx, claimed, err, markErr)
+			if markErr != nil && !errors.Is(markErr, errRootfsArtifactBuildLeaseLost) {
+				err = errors.Join(err, fmt.Errorf("mark rootfs artifact build failed: %w", markErr))
+			}
+			return nil, nil, false, err
+		}
+		return record, generatedReq, true, nil
 	}
-	// Claim the artifact row under its FOR UPDATE lock before (re)building. This
-	// serialises against last-owner-cleanup (which locks the same row in its
-	// phases) and resurrects a CLEANUP_PENDING / soft-deleted row, so a
-	// concurrent deletion cannot remove the artifact out from under this build
-	// (FIX-1 create/reuse guard).
-	claimed, claimErr := claimRootfsArtifactForBuild(ctx, artifactID, fingerprint, req, source.Digest)
-	if claimErr != nil {
-		return nil, nil, false, claimErr
-	}
-	if claimed != nil {
-		record = claimed
-	}
-	record, generatedReq, err = buildRootfsArtifact(ctx, record, req, source, downloadBaseURL, caPEM, caFingerprint)
-	if err != nil {
-		_ = updateRootfsArtifact(ctx, artifactID, map[string]any{
-			"status":     ArtifactStatusFailed,
-			"last_error": err.Error(),
-		})
-		return nil, nil, false, err
-	}
-	return record, generatedReq, true, nil
 }
 
 // claimRootfsArtifactForBuild atomically ensures the artifact row exists and is
@@ -137,8 +195,35 @@ func ensureRootfsArtifact(ctx context.Context, req *types.CreateTemplateFromImag
 // decision (TX1) and finalisation (TX2) phases, after this commit the deleter's
 // phase-3 re-check observes a live BUILDING row plus the active build job and
 // backs off without deleting or overwriting the in-flight build status.
-func claimRootfsArtifactForBuild(ctx context.Context, artifactID, fingerprint string, req *types.CreateTemplateFromImageReq, sourceDigest string) (*models.RootfsArtifact, error) {
-	var claimed *models.RootfsArtifact
+func claimRootfsArtifactForBuild(ctx context.Context, artifactID, fingerprint string, req *types.CreateTemplateFromImageReq, sourceDigest string) (*models.RootfsArtifact, bool, error) {
+	for attempt := 0; attempt < rootfsArtifactClaimMaxAttempts; attempt++ {
+		claimed, owner, err := claimRootfsArtifactForBuildOnce(ctx, artifactID, fingerprint, req, sourceDigest)
+		if !isRetryableRootfsArtifactClaimError(err) {
+			return claimed, owner, err
+		}
+		if attempt == rootfsArtifactClaimMaxAttempts-1 {
+			return nil, false, fmt.Errorf("claim rootfs artifact after %d attempts: %w", rootfsArtifactClaimMaxAttempts, err)
+		}
+		// Concurrent first claims can both observe an absent row before one
+		// inserts it. PostgreSQL normally reports a duplicate key; InnoDB can
+		// instead abort one transaction with a deadlock/lock-timeout while both
+		// sessions hold gap locks. Retry either transient result so the loser
+		// observes the winner's live lease instead of failing the request.
+		delay := 10 * time.Millisecond * time.Duration(1<<min(attempt, 4))
+		select {
+		case <-ctx.Done():
+			return nil, false, ctx.Err()
+		case <-time.After(delay):
+		}
+	}
+	return nil, false, errors.New("unreachable rootfs artifact claim retry state")
+}
+
+func claimRootfsArtifactForBuildOnce(ctx context.Context, artifactID, fingerprint string, req *types.CreateTemplateFromImageReq, sourceDigest string) (*models.RootfsArtifact, bool, error) {
+	var (
+		claimed *models.RootfsArtifact
+		owner   bool
+	)
 	err := store.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		var existing models.RootfsArtifact
 		err := tx.Clauses(clause.Locking{Strength: "UPDATE"}).Unscoped().
@@ -146,6 +231,7 @@ func claimRootfsArtifactForBuild(ctx context.Context, artifactID, fingerprint st
 			Where("artifact_id = ?", artifactID).First(&existing).Error
 		switch {
 		case errors.Is(err, gorm.ErrRecordNotFound):
+			token := uuid.NewString()
 			row := &models.RootfsArtifact{
 				ArtifactID:              artifactID,
 				TemplateSpecFingerprint: fingerprint,
@@ -153,15 +239,42 @@ func claimRootfsArtifactForBuild(ctx context.Context, artifactID, fingerprint st
 				SourceImageDigest:       sourceDigest,
 				WritableLayerSize:       req.WritableLayerSize,
 				Status:                  ArtifactStatusBuilding,
+				BuildOwnerToken:         token,
+				BuildGeneration:         1,
+				BuildLeaseExpireAt:      time.Now().Add(rootfsArtifactBuildLeaseTTL).Unix(),
 			}
 			if createErr := tx.Table(constants.RootfsArtifactTableName).Create(row).Error; createErr != nil {
 				return createErr
 			}
 			claimed = row
+			owner = true
 			return nil
 		case err != nil:
 			return err
 		default:
+			if _, err := validateReusableRootfsArtifact(&existing, fingerprint, artifactID); err != nil {
+				return err
+			}
+			// A READY row without the serialized Cubelet request is incomplete
+			// metadata (for example, from an interrupted legacy build). It cannot
+			// be reused and must be claimed for a new generation instead of making
+			// followers wait on a state that can never become usable.
+			if existing.Status == ArtifactStatusReady && existing.GeneratedRequestJSON != "" && !rootfsArtifactSoftDeleted(&existing) {
+				claimed = &existing
+				return nil
+			}
+			now := time.Now()
+			if existing.Status == ArtifactStatusBuilding &&
+				existing.BuildOwnerToken != "" &&
+				existing.BuildLeaseExpireAt > now.Unix() {
+				claimed = &existing
+				return nil
+			}
+			generation := existing.BuildGeneration + 1
+			if generation < 1 {
+				generation = 1
+			}
+			token := uuid.NewString()
 			if updErr := tx.Unscoped().Table(constants.RootfsArtifactTableName).
 				Where("artifact_id = ?", artifactID).
 				Updates(map[string]any{
@@ -170,6 +283,9 @@ func claimRootfsArtifactForBuild(ctx context.Context, artifactID, fingerprint st
 					"source_image_digest":       sourceDigest,
 					"writable_layer_size":       req.WritableLayerSize,
 					"status":                    ArtifactStatusBuilding,
+					"build_owner_token":         token,
+					"build_generation":          generation,
+					"build_lease_expire_at":     now.Add(rootfsArtifactBuildLeaseTTL).Unix(),
 					"last_error":                "",
 					"deleted_at":                nil,
 					"updated_at":                time.Now(),
@@ -178,14 +294,183 @@ func claimRootfsArtifactForBuild(ctx context.Context, artifactID, fingerprint st
 			}
 			existing.Status = ArtifactStatusBuilding
 			existing.DeletedAt = gorm.DeletedAt{}
+			existing.BuildOwnerToken = token
+			existing.BuildGeneration = generation
+			existing.BuildLeaseExpireAt = now.Add(rootfsArtifactBuildLeaseTTL).Unix()
 			claimed = &existing
+			owner = true
 			return nil
 		}
 	})
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
-	return claimed, nil
+	return claimed, owner, nil
+}
+
+func isRootfsArtifactDuplicateKeyError(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, gorm.ErrDuplicatedKey) {
+		return true
+	}
+	message := strings.ToLower(err.Error())
+	return strings.Contains(message, "duplicate entry") ||
+		strings.Contains(message, "duplicate key") ||
+		strings.Contains(message, "unique constraint") ||
+		strings.Contains(message, "1062")
+}
+
+func isRetryableRootfsArtifactClaimError(err error) bool {
+	if isRootfsArtifactDuplicateKeyError(err) {
+		return true
+	}
+	var mysqlErr *mysqldriver.MySQLError
+	if errors.As(err, &mysqlErr) && (mysqlErr.Number == 1205 || mysqlErr.Number == 1213) {
+		return true
+	}
+	if err == nil {
+		return false
+	}
+	message := strings.ToLower(err.Error())
+	return strings.Contains(message, "error 1205") ||
+		strings.Contains(message, "error 1213") ||
+		strings.Contains(message, "lock wait timeout exceeded") ||
+		strings.Contains(message, "deadlock found when trying to get lock")
+}
+
+// waitForRootfsArtifactBuild waits for the current generation to publish or
+// lose its lease. Callers loop back through claimRootfsArtifactForBuild after
+// this returns so that an expired/failed generation can be safely taken over.
+func waitForRootfsArtifactBuild(ctx context.Context, artifactID, fingerprint string, generation int64) error {
+	ticker := time.NewTicker(rootfsArtifactBuildWaitEvery)
+	defer ticker.Stop()
+	for {
+		record, _, err := findReusableRootfsArtifact(ctx, fingerprint, artifactID)
+		if err == nil {
+			switch record.Status {
+			case ArtifactStatusReady:
+				return nil
+			case ArtifactStatusBuilding:
+				if record.BuildGeneration != generation || record.BuildLeaseExpireAt <= time.Now().Unix() {
+					return nil
+				}
+			default:
+				return nil
+			}
+		} else if !errors.Is(err, gorm.ErrRecordNotFound) {
+			return err
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+		}
+	}
+}
+
+func renewRootfsArtifactBuildLease(ctx context.Context, record *models.RootfsArtifact) error {
+	if record == nil || record.BuildOwnerToken == "" || record.BuildGeneration < 1 {
+		return errRootfsArtifactBuildLeaseLost
+	}
+	tx := store.db.WithContext(ctx).Table(constants.RootfsArtifactTableName).
+		Where("artifact_id = ? AND status = ? AND build_owner_token = ? AND build_generation = ? AND build_lease_expire_at > ?",
+			record.ArtifactID, ArtifactStatusBuilding, record.BuildOwnerToken, record.BuildGeneration, time.Now().Unix()).
+		Updates(map[string]any{
+			"build_lease_expire_at": time.Now().Add(rootfsArtifactBuildLeaseTTL).Unix(),
+			"updated_at":            time.Now(),
+		})
+	if tx.Error != nil {
+		return tx.Error
+	}
+	if tx.RowsAffected == 1 {
+		return nil
+	}
+	// MySQL reports zero changed rows when a rapid renewal writes the same
+	// second-resolution values. A concurrent READY transition has the same
+	// result. Re-read the fence tuple to distinguish both safe outcomes from an
+	// actual takeover/expiry; this also closes the renew-vs-finalize race.
+	var current models.RootfsArtifact
+	if err := store.db.WithContext(ctx).Select("status", "build_owner_token", "build_generation", "build_lease_expire_at").
+		Table(constants.RootfsArtifactTableName).
+		Where("artifact_id = ?", record.ArtifactID).First(&current).Error; err != nil {
+		return err
+	}
+	if current.BuildOwnerToken != record.BuildOwnerToken || current.BuildGeneration != record.BuildGeneration {
+		return errRootfsArtifactBuildLeaseLost
+	}
+	if current.Status == ArtifactStatusReady ||
+		(current.Status == ArtifactStatusBuilding && current.BuildLeaseExpireAt > time.Now().Unix()) {
+		return nil
+	}
+	return errRootfsArtifactBuildLeaseLost
+}
+
+func markRootfsArtifactBuildFailed(ctx context.Context, record *models.RootfsArtifact, buildErr error) error {
+	if record == nil || record.BuildOwnerToken == "" || record.BuildGeneration < 1 {
+		return errRootfsArtifactBuildLeaseLost
+	}
+	updates := map[string]any{
+		"status":                ArtifactStatusFailed,
+		"last_error":            buildErr.Error(),
+		"build_lease_expire_at": int64(0),
+		"updated_at":            time.Now(),
+	}
+	var finalizeErr *publishedArtifactFinalizeError
+	if errors.As(buildErr, &finalizeErr) {
+		// Keep enough metadata for lifecycle GC to retry if immediate shared
+		// storage cleanup fails after the FAILED fence is committed.
+		updates["ext4_path"] = finalizeErr.publishedPath
+		updates["ext4_sha256"] = record.Ext4SHA256
+		updates["ext4_size_bytes"] = record.Ext4SizeBytes
+	}
+	tx := store.db.WithContext(ctx).Table(constants.RootfsArtifactTableName).
+		Where("artifact_id = ? AND status = ? AND build_owner_token = ? AND build_generation = ?",
+			record.ArtifactID, ArtifactStatusBuilding, record.BuildOwnerToken, record.BuildGeneration).
+		Updates(updates)
+	if tx.Error != nil {
+		return tx.Error
+	}
+	if tx.RowsAffected != 1 {
+		return errRootfsArtifactBuildLeaseLost
+	}
+	return nil
+}
+
+func startRootfsArtifactBuildLease(ctx context.Context, record *models.RootfsArtifact) (context.Context, func() error) {
+	buildCtx, cancel := context.WithCancel(ctx)
+	done := make(chan struct{})
+	stopped := make(chan struct{})
+	var leaseErr error
+	go func() {
+		defer close(stopped)
+		ticker := time.NewTicker(rootfsArtifactBuildRenewEvery)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-done:
+				return
+			case <-buildCtx.Done():
+				return
+			case <-ticker.C:
+				renewCtx, renewCancel := context.WithTimeout(context.Background(), 10*time.Second)
+				err := renewRootfsArtifactBuildLease(renewCtx, record)
+				renewCancel()
+				if err != nil {
+					leaseErr = err
+					cancel()
+					return
+				}
+			}
+		}
+	}()
+	return buildCtx, func() error {
+		close(done)
+		cancel()
+		<-stopped
+		return leaseErr
+	}
 }
 
 func findReusableRootfsArtifact(ctx context.Context, fingerprint, artifactID string) (*models.RootfsArtifact, bool, error) {
@@ -253,7 +538,7 @@ func restoreRootfsArtifact(ctx context.Context, artifactID string) error {
 
 func buildRootfsArtifact(ctx context.Context, record *models.RootfsArtifact, req *types.CreateTemplateFromImageReq, source *image.PreparedSource, downloadBaseURL string, caPEM []byte, caFingerprint string) (*models.RootfsArtifact, *types.CreateCubeSandboxReq, error) {
 	var caBakeResult cube_egress_ca.Result
-	opts := image.BuildOptions{ArtifactID: record.ArtifactID}
+	opts := image.BuildOptions{ArtifactID: record.ArtifactID, Generation: record.BuildGeneration}
 	// Bake the CubeEgress root CA into the rootfs while it's still a mutable
 	// host-side directory, before mkfs.ext4 freezes the layout. See
 	// design/cube-egress-ca-bake.md for the contract.
@@ -266,11 +551,49 @@ func buildRootfsArtifact(ctx context.Context, record *models.RootfsArtifact, req
 	if err != nil {
 		return nil, nil, err
 	}
-	return finalizeArtifact(ctx, record, source, result.Ext4Path, result.SHA256, result.SizeBytes, downloadBaseURL, req, caBakeResult)
+	localBuildDir := filepath.Dir(result.Ext4Path)
+	if rel, relErr := filepath.Rel(filepath.Clean(image.ArtifactWorkRootDir()), localBuildDir); relErr == nil && rel != "." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)) && rel != ".." {
+		defer func() {
+			_ = os.RemoveAll(localBuildDir) // NOCC:Path Traversal()
+		}()
+	}
+	publishedPath, publishedSize, err := image.PublishExt4(ctx, record.ArtifactID, record.BuildGeneration, result.SHA256, result.Ext4Path)
+	if err != nil {
+		return nil, nil, fmt.Errorf("publish rootfs artifact generation %d: %w", record.BuildGeneration, err)
+	}
+	if publishedSize != result.SizeBytes {
+		sizeErr := fmt.Errorf("published rootfs artifact size mismatch: got %d want %d", publishedSize, result.SizeBytes)
+		return nil, nil, cleanupUncommittedPublishedExt4(ctx, record, publishedPath, sizeErr)
+	}
+	finalRecord, generatedReq, err := finalizeArtifact(ctx, record, source, publishedPath, result.SHA256, result.SizeBytes, downloadBaseURL, req, caBakeResult)
+	if err != nil {
+		return nil, nil, &publishedArtifactFinalizeError{publishedPath: publishedPath, cause: err}
+	}
+	return finalRecord, generatedReq, nil
 }
 
-// finalizeArtifact populates the artifact record with computed values, persists it,
-// and returns the latest version.
+func cleanupUncommittedPublishedExt4(ctx context.Context, record *models.RootfsArtifact, publishedPath string, cause error) error {
+	cleanupCtx, cleanupCancel := context.WithTimeout(context.WithoutCancel(ctx), rootfsArtifactBuildStateWriteTimeout)
+	defer cleanupCancel()
+	if err := image.RemovePublishedExt4(cleanupCtx, record.ArtifactID, record.BuildGeneration, publishedPath); err != nil {
+		return errors.Join(cause, fmt.Errorf("cleanup uncommitted rootfs artifact generation %d: %w", record.BuildGeneration, err))
+	}
+	return cause
+}
+
+func cleanupPublishedArtifactAfterFailedFinalize(ctx context.Context, record *models.RootfsArtifact, buildErr, markErr error) error {
+	if markErr != nil {
+		return buildErr
+	}
+	var finalizeErr *publishedArtifactFinalizeError
+	if !errors.As(buildErr, &finalizeErr) {
+		return buildErr
+	}
+	return cleanupUncommittedPublishedExt4(ctx, record, finalizeErr.publishedPath, buildErr)
+}
+
+// finalizeArtifact populates the artifact record with computed values and
+// atomically persists READY under the live lease fence.
 func finalizeArtifact(ctx context.Context, record *models.RootfsArtifact, source *image.PreparedSource, ext4Path, shaValue string, sizeBytes int64, downloadBaseURL string, req *types.CreateTemplateFromImageReq, caBakeResult cube_egress_ca.Result) (*models.RootfsArtifact, *types.CreateCubeSandboxReq, error) {
 	downloadToken := uuid.New().String()
 	record.SourceImageDigest = source.Digest
@@ -295,7 +618,7 @@ func finalizeArtifact(ctx context.Context, record *models.RootfsArtifact, source
 		return nil, nil, err
 	}
 	record.GeneratedRequestJSON = string(reqPayload)
-	if err := updateRootfsArtifact(ctx, record.ArtifactID, map[string]any{
+	if err := finalizeRootfsArtifactRecord(ctx, record, map[string]any{
 		"source_image_digest":            record.SourceImageDigest,
 		"master_node_ip":                 record.MasterNodeIP,
 		"ext4_path":                      record.Ext4Path,
@@ -310,12 +633,11 @@ func finalizeArtifact(ctx context.Context, record *models.RootfsArtifact, source
 		"cube_egress_ca_baked":           record.CubeEgressCABaked,
 		"cube_egress_ca_fingerprint":     record.CubeEgressCAFingerprint,
 		"cube_egress_ca_targets_written": record.CubeEgressCATargetsWritten,
+		"build_lease_expire_at":          int64(0),
+		"updated_at":                     time.Now(),
 	}); err != nil {
 		return nil, nil, err
 	}
-	latest, err := getRootfsArtifactByID(ctx, record.ArtifactID)
-	if err != nil {
-		return nil, nil, err
-	}
-	return latest, generatedReq, nil
+	record.BuildLeaseExpireAt = 0
+	return record, generatedReq, nil
 }

--- a/CubeMaster/pkg/templatecenter/artifact_build_mysql_test.go
+++ b/CubeMaster/pkg/templatecenter/artifact_build_mysql_test.go
@@ -1,0 +1,112 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package templatecenter
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/constants"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/db/models"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/service/sandbox/types"
+)
+
+// TestClaimRootfsArtifactForBuildConcurrentMySQL covers the production-default
+// dialect. InnoDB may resolve concurrent first inserts with a duplicate key,
+// deadlock, or lock timeout; all callers must still converge on one live owner.
+func TestClaimRootfsArtifactForBuildConcurrentMySQL(t *testing.T) {
+	gormDB, _ := newArtifactGCMySQL(t)
+	// The shared MySQL fixture uses AutoMigrate, while the production baseline
+	// defines artifact_id as unique. Recreate that constraint explicitly so the
+	// contention behavior matches the real schema.
+	if err := gormDB.Exec("CREATE UNIQUE INDEX idx_artifact_build_test_id ON " + constants.RootfsArtifactTableName + " (artifact_id(128))").Error; err != nil {
+		t.Fatalf("create artifact_id test index: %v", err)
+	}
+	oldDB := store.db
+	store.db = gormDB
+	t.Cleanup(func() { store.db = oldDB })
+
+	const callers = 24
+	artifactID := fmt.Sprintf("artifact-concurrent-mysql-%d", time.Now().UnixNano())
+	req := &types.CreateTemplateFromImageReq{
+		SourceImageRef:    "docker.io/library/busybox:latest",
+		WritableLayerSize: "1Gi",
+	}
+	type outcome struct {
+		record *models.RootfsArtifact
+		owner  bool
+		err    error
+	}
+	start := make(chan struct{})
+	outcomes := make(chan outcome, callers)
+	var wg sync.WaitGroup
+	for range callers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			record, owner, err := claimRootfsArtifactForBuild(context.Background(), artifactID, "fingerprint-concurrent-mysql", req, "sha256:source")
+			outcomes <- outcome{record: record, owner: owner, err: err}
+		}()
+	}
+	close(start)
+	wg.Wait()
+	close(outcomes)
+
+	owners := 0
+	for result := range outcomes {
+		if result.err != nil {
+			t.Fatalf("concurrent MySQL claim failed: %v", result.err)
+		}
+		if result.record == nil {
+			t.Fatal("concurrent MySQL claim returned no record")
+		}
+		if result.owner {
+			owners++
+		}
+	}
+	if owners != 1 {
+		t.Fatalf("owners=%d, want exactly one", owners)
+	}
+
+	var record models.RootfsArtifact
+	if err := gormDB.Table(constants.RootfsArtifactTableName).Where("artifact_id = ?", artifactID).First(&record).Error; err != nil {
+		t.Fatalf("load claimed artifact: %v", err)
+	}
+	if record.Status != ArtifactStatusBuilding || record.BuildGeneration != 1 || record.BuildOwnerToken == "" {
+		t.Fatalf("unexpected claimed record: status=%q generation=%d owner=%q", record.Status, record.BuildGeneration, record.BuildOwnerToken)
+	}
+	if record.BuildLeaseExpireAt <= time.Now().Unix() {
+		t.Fatalf("lease is not live: %d", record.BuildLeaseExpireAt)
+	}
+
+	if err := finalizeRootfsArtifactRecord(context.Background(), &record, map[string]any{
+		"status":                ArtifactStatusReady,
+		"build_lease_expire_at": int64(0),
+	}); err != nil {
+		t.Fatalf("finalize claimed artifact: %v", err)
+	}
+	if err := renewRootfsArtifactBuildLease(context.Background(), &record); err != nil {
+		t.Fatalf("late renewal after READY must be treated as a completed lease, got %v", err)
+	}
+
+	expired := &models.RootfsArtifact{
+		ArtifactID:         fmt.Sprintf("artifact-expired-mysql-%d", time.Now().UnixNano()),
+		Status:             ArtifactStatusBuilding,
+		BuildOwnerToken:    "expired-owner",
+		BuildGeneration:    1,
+		BuildLeaseExpireAt: time.Now().Add(-time.Minute).Unix(),
+	}
+	if err := gormDB.Create(expired).Error; err != nil {
+		t.Fatalf("seed expired build: %v", err)
+	}
+	if err := finalizeRootfsArtifactRecord(context.Background(), expired, map[string]any{"status": ArtifactStatusReady}); !errors.Is(err, errRootfsArtifactBuildLeaseLost) {
+		t.Fatalf("expired owner finalize error=%v, want lease lost", err)
+	}
+}

--- a/CubeMaster/pkg/templatecenter/artifact_build_postgres_test.go
+++ b/CubeMaster/pkg/templatecenter/artifact_build_postgres_test.go
@@ -1,0 +1,84 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package templatecenter
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/constants"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/db/models"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/service/sandbox/types"
+)
+
+// TestClaimRootfsArtifactForBuildConcurrentPostgres exercises independent DB
+// transactions, as separate CubeMaster replicas would. The unique artifact ID
+// plus live lease must elect exactly one builder; every other caller observes
+// the same BUILDING generation instead of starting another mkfs.ext4 build.
+func TestClaimRootfsArtifactForBuildConcurrentPostgres(t *testing.T) {
+	env := newPGDockerEnv(t)
+	defer env.teardown()
+
+	oldDB := store.db
+	store.db = openMigratedPostgresGORM(t, env)
+	t.Cleanup(func() { store.db = oldDB })
+
+	const callers = 24
+	artifactID := fmt.Sprintf("artifact-concurrent-%d", time.Now().UnixNano())
+	req := &types.CreateTemplateFromImageReq{
+		SourceImageRef:    "docker.io/library/busybox:latest",
+		WritableLayerSize: "1Gi",
+	}
+	type outcome struct {
+		record *models.RootfsArtifact
+		owner  bool
+		err    error
+	}
+	start := make(chan struct{})
+	outcomes := make(chan outcome, callers)
+	var wg sync.WaitGroup
+	for range callers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			record, owner, err := claimRootfsArtifactForBuild(context.Background(), artifactID, "fingerprint-concurrent", req, "sha256:source")
+			outcomes <- outcome{record: record, owner: owner, err: err}
+		}()
+	}
+	close(start)
+	wg.Wait()
+	close(outcomes)
+
+	owners := 0
+	for result := range outcomes {
+		if result.err != nil {
+			t.Fatalf("concurrent claim failed: %v", result.err)
+		}
+		if result.record == nil {
+			t.Fatal("concurrent claim returned no record")
+		}
+		if result.owner {
+			owners++
+		}
+	}
+	if owners != 1 {
+		t.Fatalf("owners=%d, want exactly one", owners)
+	}
+
+	var record models.RootfsArtifact
+	if err := store.db.Table(constants.RootfsArtifactTableName).Where("artifact_id = ?", artifactID).First(&record).Error; err != nil {
+		t.Fatalf("load claimed artifact: %v", err)
+	}
+	if record.Status != ArtifactStatusBuilding || record.BuildGeneration != 1 || record.BuildOwnerToken == "" {
+		t.Fatalf("unexpected claimed record: status=%q generation=%d owner=%q", record.Status, record.BuildGeneration, record.BuildOwnerToken)
+	}
+	if record.BuildLeaseExpireAt <= time.Now().Unix() {
+		t.Fatalf("lease is not live: %d", record.BuildLeaseExpireAt)
+	}
+}

--- a/CubeMaster/pkg/templatecenter/artifact_cleanup.go
+++ b/CubeMaster/pkg/templatecenter/artifact_cleanup.go
@@ -69,9 +69,6 @@ func managedArtifactDir(artifactID, ext4Path string) (string, bool) {
 		return "", false
 	}
 	dir := filepath.Clean(filepath.Dir(ext4Path))
-	if filepath.Base(dir) != artifactID {
-		return "", false
-	}
 	roots := []string{image.ArtifactWorkRootDir(), image.ArtifactStoreRootDir()}
 	if strings.TrimSpace(os.Getenv("CUBEMASTER_ROOTFS_ARTIFACT_STORE_DIR")) == "" {
 		roots = append(roots, image.ArtifactFallbackStoreRootDir())
@@ -81,8 +78,11 @@ func managedArtifactDir(artifactID, ext4Path string) (string, bool) {
 		if err != nil {
 			continue
 		}
-		if rel == artifactID {
-			return dir, true
+		parts := strings.Split(rel, string(filepath.Separator))
+		if len(parts) >= 1 && parts[0] == artifactID && parts[0] != ".." {
+			// Generation files live below <root>/<artifactID>/generations/...;
+			// artifact lifecycle cleanup reclaims the whole managed artifact tree.
+			return filepath.Join(filepath.Clean(root), artifactID), true
 		}
 	}
 	return "", false

--- a/CubeMaster/pkg/templatecenter/image/artifact_publish.go
+++ b/CubeMaster/pkg/templatecenter/image/artifact_publish.go
@@ -1,0 +1,165 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package image
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strconv"
+
+	"github.com/google/uuid"
+)
+
+const artifactPublishBufferSize = 4 * 1024 * 1024
+
+type contextReader struct {
+	ctx context.Context
+	r   io.Reader
+}
+
+func (r contextReader) Read(p []byte) (int, error) {
+	select {
+	case <-r.ctx.Done():
+		return 0, r.ctx.Err()
+	default:
+		return r.r.Read(p)
+	}
+}
+
+// PublishExt4 copies a completed local ext4 image into an immutable shared
+// generation path. The temporary file and final file live in the same CFS
+// directory so rename is atomic for readers of that directory.
+func PublishExt4(ctx context.Context, artifactID string, generation int64, shaValue string, srcPath string) (string, int64, error) {
+	if artifactID == "" || generation < 1 || shaValue == "" || srcPath == "" {
+		return "", 0, fmt.Errorf("invalid artifact publish arguments")
+	}
+	shaBytes, err := hex.DecodeString(shaValue)
+	if err != nil || len(shaBytes) != sha256.Size || hex.EncodeToString(shaBytes) != shaValue {
+		return "", 0, fmt.Errorf("invalid artifact SHA-256 %q", shaValue)
+	}
+	if err := ctx.Err(); err != nil {
+		return "", 0, err
+	}
+	src, err := os.Open(srcPath)
+	if err != nil {
+		return "", 0, err
+	}
+	defer src.Close()
+	storeDir, err := ResolveArtifactStoreDir(ctx, artifactID)
+	if err != nil {
+		return "", 0, err
+	}
+	generationDir := filepath.Join(storeDir, "generations", strconv.FormatInt(generation, 10))
+	if err := os.MkdirAll(generationDir, 0o755); err != nil {
+		return "", 0, err
+	}
+	finalPath := filepath.Join(generationDir, shaValue+".ext4")
+	tmpPath := filepath.Join(generationDir, "."+shaValue+"."+uuid.NewString()+".partial")
+	dst, err := os.OpenFile(tmpPath, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o644)
+	if err != nil {
+		return "", 0, err
+	}
+	cleanup := true
+	renamed := false
+	defer func() {
+		_ = dst.Close()
+		if cleanup {
+			_ = os.Remove(tmpPath)
+			if renamed {
+				_ = os.Remove(finalPath)
+				if dir, err := os.Open(generationDir); err == nil {
+					_ = dir.Sync()
+					_ = dir.Close()
+				}
+			}
+		}
+	}()
+	hasher := sha256.New()
+	written, err := io.CopyBuffer(io.MultiWriter(dst, hasher), contextReader{ctx: ctx, r: src}, make([]byte, artifactPublishBufferSize))
+	if err != nil {
+		return "", 0, err
+	}
+	actualSHA := hex.EncodeToString(hasher.Sum(nil))
+	if actualSHA != shaValue {
+		return "", 0, fmt.Errorf("artifact SHA-256 changed while publishing: got %s want %s", actualSHA, shaValue)
+	}
+	if err := ctx.Err(); err != nil {
+		return "", 0, err
+	}
+	if err := dst.Sync(); err != nil {
+		return "", 0, err
+	}
+	if err := dst.Close(); err != nil {
+		return "", 0, err
+	}
+	if err := ctx.Err(); err != nil {
+		return "", 0, err
+	}
+	if err := os.Rename(tmpPath, finalPath); err != nil {
+		return "", 0, err
+	}
+	renamed = true
+	dir, err := os.Open(generationDir)
+	if err != nil {
+		return "", 0, err
+	}
+	err = dir.Sync()
+	closeErr := dir.Close()
+	if err != nil {
+		return "", 0, err
+	}
+	if closeErr != nil {
+		return "", 0, closeErr
+	}
+	cleanup = false
+	return finalPath, written, nil
+}
+
+// RemovePublishedExt4 removes only the exact generation file returned by
+// PublishExt4. It is used when the fenced database finalization fails after a
+// successful copy, preventing an unreferenced multi-gigabyte artifact from
+// being stranded in shared storage.
+func RemovePublishedExt4(ctx context.Context, artifactID string, generation int64, publishedPath string) error {
+	if artifactID == "" || generation < 1 || publishedPath == "" {
+		return fmt.Errorf("invalid published artifact cleanup arguments")
+	}
+	storeDir, err := ResolveArtifactStoreDir(ctx, artifactID)
+	if err != nil {
+		return err
+	}
+	generationDir := filepath.Join(storeDir, "generations", strconv.FormatInt(generation, 10))
+	cleanPath := filepath.Clean(publishedPath)
+	rel, err := filepath.Rel(generationDir, cleanPath)
+	if err != nil || rel == "." || filepath.Dir(rel) != "." {
+		return fmt.Errorf("published artifact path %q is outside generation directory %q", publishedPath, generationDir)
+	}
+	if err := os.Remove(cleanPath); err != nil && !os.IsNotExist(err) { // NOCC:Path Traversal()
+		return err
+	}
+	if err := os.Remove(generationDir); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	parent, err := os.Open(filepath.Dir(generationDir))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	syncErr := parent.Sync()
+	closeErr := parent.Close()
+	if syncErr != nil {
+		return syncErr
+	}
+	if closeErr != nil {
+		return closeErr
+	}
+	return nil
+}

--- a/CubeMaster/pkg/templatecenter/image/artifact_publish_test.go
+++ b/CubeMaster/pkg/templatecenter/image/artifact_publish_test.go
@@ -1,0 +1,185 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package image
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/agiledragon/gomonkey/v2"
+)
+
+func TestPublishExt4PublishesImmutableGenerationPath(t *testing.T) {
+	storeRoot := filepath.Join(t.TempDir(), "store")
+	t.Setenv("CUBEMASTER_ROOTFS_ARTIFACT_STORE_DIR", storeRoot)
+	srcPath := filepath.Join(t.TempDir(), "artifact.ext4")
+	content := []byte("ext4 artifact bytes")
+	if err := os.WriteFile(srcPath, content, 0o644); err != nil {
+		t.Fatalf("WriteFile source: %v", err)
+	}
+	digest := sha256.Sum256(content)
+	shaValue := hex.EncodeToString(digest[:])
+
+	path, size, err := PublishExt4(context.Background(), "rfs-test", 2, shaValue, srcPath)
+	if err != nil {
+		t.Fatalf("PublishExt4: %v", err)
+	}
+	wantPath := filepath.Join(storeRoot, "rfs-test", "generations", "2", shaValue+".ext4")
+	if path != wantPath {
+		t.Fatalf("published path=%q, want %q", path, wantPath)
+	}
+	if size != int64(len(content)) {
+		t.Fatalf("published size=%d, want %d", size, len(content))
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile published artifact: %v", err)
+	}
+	if string(got) != string(content) {
+		t.Fatalf("published content=%q, want %q", got, content)
+	}
+}
+
+func TestPublishExt4RejectsChangedSourceBytes(t *testing.T) {
+	storeRoot := filepath.Join(t.TempDir(), "store")
+	t.Setenv("CUBEMASTER_ROOTFS_ARTIFACT_STORE_DIR", storeRoot)
+	srcPath := filepath.Join(t.TempDir(), "artifact.ext4")
+	if err := os.WriteFile(srcPath, []byte("changed bytes"), 0o644); err != nil {
+		t.Fatalf("WriteFile source: %v", err)
+	}
+	wantDigest := sha256.Sum256([]byte("original bytes"))
+	wantSHA := hex.EncodeToString(wantDigest[:])
+
+	if _, _, err := PublishExt4(context.Background(), "rfs-test", 3, wantSHA, srcPath); err == nil {
+		t.Fatal("PublishExt4 should reject bytes that no longer match the build SHA")
+	}
+	generationDir := filepath.Join(storeRoot, "rfs-test", "generations", "3")
+	entries, err := os.ReadDir(generationDir)
+	if err != nil {
+		t.Fatalf("ReadDir generation: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("failed publish left files behind: %v", entries)
+	}
+}
+
+func TestPublishExt4HonorsCanceledContext(t *testing.T) {
+	storeRoot := filepath.Join(t.TempDir(), "store")
+	t.Setenv("CUBEMASTER_ROOTFS_ARTIFACT_STORE_DIR", storeRoot)
+	srcPath := filepath.Join(t.TempDir(), "artifact.ext4")
+	content := []byte("ext4 bytes")
+	if err := os.WriteFile(srcPath, content, 0o644); err != nil {
+		t.Fatalf("WriteFile source: %v", err)
+	}
+	digest := sha256.Sum256(content)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, _, err := PublishExt4(ctx, "rfs-test", 4, hex.EncodeToString(digest[:]), srcPath)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("PublishExt4 error=%v, want context.Canceled", err)
+	}
+	if _, statErr := os.Stat(filepath.Join(storeRoot, "rfs-test")); !os.IsNotExist(statErr) {
+		t.Fatalf("canceled publish should not create shared files: %v", statErr)
+	}
+}
+
+func TestRemovePublishedExt4OnlyRemovesRequestedGeneration(t *testing.T) {
+	storeRoot := filepath.Join(t.TempDir(), "store")
+	t.Setenv("CUBEMASTER_ROOTFS_ARTIFACT_STORE_DIR", storeRoot)
+	srcPath := filepath.Join(t.TempDir(), "artifact.ext4")
+	content := []byte("ext4 bytes")
+	if err := os.WriteFile(srcPath, content, 0o644); err != nil {
+		t.Fatalf("WriteFile source: %v", err)
+	}
+	digest := sha256.Sum256(content)
+	shaValue := hex.EncodeToString(digest[:])
+	publishedPath, _, err := PublishExt4(context.Background(), "rfs-test", 5, shaValue, srcPath)
+	if err != nil {
+		t.Fatalf("PublishExt4: %v", err)
+	}
+	otherGeneration := filepath.Join(storeRoot, "rfs-test", "generations", "6")
+	if err := os.MkdirAll(otherGeneration, 0o755); err != nil {
+		t.Fatalf("MkdirAll other generation: %v", err)
+	}
+	otherPath := filepath.Join(otherGeneration, "keep.ext4")
+	if err := os.WriteFile(otherPath, []byte("keep"), 0o644); err != nil {
+		t.Fatalf("WriteFile other generation: %v", err)
+	}
+
+	if err := RemovePublishedExt4(context.Background(), "rfs-test", 5, publishedPath); err != nil {
+		t.Fatalf("RemovePublishedExt4: %v", err)
+	}
+	if _, err := os.Stat(publishedPath); !os.IsNotExist(err) {
+		t.Fatalf("published generation should be removed: %v", err)
+	}
+	if _, err := os.Stat(otherPath); err != nil {
+		t.Fatalf("other generation must remain: %v", err)
+	}
+	if err := RemovePublishedExt4(context.Background(), "rfs-test", 5, otherPath); err == nil {
+		t.Fatal("RemovePublishedExt4 should reject a path from another generation")
+	}
+}
+
+func TestBuildExt4ThenPublishExt4KeepsLocalResultUntilCopied(t *testing.T) {
+	workRoot := filepath.Join(t.TempDir(), "work")
+	storeRoot := filepath.Join(t.TempDir(), "store")
+	t.Setenv("CUBEMASTER_ROOTFS_ARTIFACT_DIR", workRoot)
+	t.Setenv("CUBEMASTER_ROOTFS_ARTIFACT_STORE_DIR", storeRoot)
+
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+	patches.ApplyFuncReturn(loopMountExt4Enabled, false)
+	patches.ApplyFuncReturn(estimateImageSizeFromInspect, int64(1024), nil)
+	patches.ApplyFuncReturn(checkDiskSpace, nil)
+	patches.ApplyFunc(exportImageRootfs, func(ctx context.Context, source *PreparedSource, rootfsDir string) error {
+		if err := os.MkdirAll(rootfsDir, 0o755); err != nil {
+			return err
+		}
+		return os.WriteFile(filepath.Join(rootfsDir, "rootfs-file"), []byte("rootfs"), 0o644)
+	})
+	ext4Content := []byte("completed local ext4 bytes")
+	patches.ApplyFunc(createExt4Image, func(ctx context.Context, rootfsDir, ext4Path string) error {
+		if _, err := os.Stat(filepath.Join(rootfsDir, "rootfs-file")); err != nil {
+			return err
+		}
+		return os.WriteFile(ext4Path, ext4Content, 0o644)
+	})
+
+	result, err := BuildExt4(context.Background(), &PreparedSource{}, BuildOptions{ArtifactID: "rfs-integration", Generation: 9})
+	if err != nil {
+		t.Fatalf("BuildExt4: %v", err)
+	}
+	if _, err := os.Stat(result.Ext4Path); err != nil {
+		t.Fatalf("local ext4 disappeared before publication: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(filepath.Dir(result.Ext4Path), "rootfs")); !os.IsNotExist(err) {
+		t.Fatalf("mutable rootfs should be removed after build: %v", err)
+	}
+
+	publishedPath, publishedSize, err := PublishExt4(context.Background(), "rfs-integration", 9, result.SHA256, result.Ext4Path)
+	if err != nil {
+		t.Fatalf("PublishExt4: %v", err)
+	}
+	if publishedSize != result.SizeBytes || publishedSize != int64(len(ext4Content)) {
+		t.Fatalf("published size=%d build size=%d want=%d", publishedSize, result.SizeBytes, len(ext4Content))
+	}
+	wantPath := filepath.Join(storeRoot, "rfs-integration", "generations", "9", result.SHA256+".ext4")
+	if publishedPath != wantPath {
+		t.Fatalf("published path=%q, want %q", publishedPath, wantPath)
+	}
+	got, err := os.ReadFile(publishedPath)
+	if err != nil {
+		t.Fatalf("ReadFile published ext4: %v", err)
+	}
+	if string(got) != string(ext4Content) {
+		t.Fatalf("published content=%q, want %q", got, ext4Content)
+	}
+}

--- a/CubeMaster/pkg/templatecenter/image/ext4.go
+++ b/CubeMaster/pkg/templatecenter/image/ext4.go
@@ -6,7 +6,6 @@ package image
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/log"
 	"os"
@@ -14,7 +13,6 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
-	"syscall"
 )
 
 func createExt4Image(ctx context.Context, rootfsDir, ext4Path string) error {
@@ -58,7 +56,7 @@ func createExt4Image(ctx context.Context, rootfsDir, ext4Path string) error {
 // EnsureArtifactBuildPreflight asserts that the host has all necessary tools
 // installed to build images before starting a long-running workflow.
 func EnsureArtifactBuildPreflight(ctx context.Context) error {
-	requiredCommands := []string{"mkfs.ext4", "truncate", "cp"}
+	requiredCommands := []string{"mkfs.ext4", "truncate"}
 	if !nativeRootfsExportEnabled() {
 		if hasDockerlessRootfsExportTools() {
 			requiredCommands = append(requiredCommands, "skopeo", "umoci")
@@ -90,41 +88,36 @@ func checkMkfsExt4DSupport(ctx context.Context) error {
 	return nil
 }
 
-func relocateRootfsToArtifactStore(ctx context.Context, srcRootfsDir, dstRootfsDir string) error {
-	if err := os.RemoveAll(dstRootfsDir); err != nil { // NOCC:Path Traversal()
-		return err
-	}
-	if err := os.MkdirAll(filepath.Dir(dstRootfsDir), 0o755); err != nil {
-		return err
-	}
-	if err := os.Rename(srcRootfsDir, dstRootfsDir); err == nil {
-		return nil
-	} else if !isCrossDeviceRenameErr(err) {
-		return err
-	}
-	if err := runCommand(ctx, "", "cp", "-a", srcRootfsDir, dstRootfsDir); err != nil {
-		return fmt.Errorf("copy rootfs to artifact store failed: %w", err)
-	}
-	return os.RemoveAll(srcRootfsDir) // NOCC:Path Traversal()
-}
-
-func isCrossDeviceRenameErr(err error) bool {
-	var linkErr *os.LinkError
-	if errors.As(err, &linkErr) {
-		return errors.Is(linkErr.Err, syscall.EXDEV)
-	}
-	return errors.Is(err, syscall.EXDEV)
-}
-
 func BuildExt4(ctx context.Context, source *PreparedSource, opts BuildOptions) (BuildResult, error) {
-	workDir := filepath.Join(ArtifactWorkRootDir(), opts.ArtifactID)
-	storeDir, err := ResolveArtifactStoreDir(ctx, opts.ArtifactID)
-	if err != nil {
-		return BuildResult{}, err
+	generation := opts.Generation
+	if generation < 1 {
+		generation = 1
 	}
-	storeRootfsDir := filepath.Join(storeDir, "rootfs")
-	ext4Path := filepath.Join(storeDir, opts.ArtifactID+".ext4")
-	keepStoreDir := false
+	// Do all mutable work locally. In HA the artifact store can be CFS/NFS, so
+	// exporting rootfs and running mkfs there would expose concurrent builders
+	// to the same mutable directory. The caller publishes the completed ext4
+	// once into the shared generation path.
+	workDir := filepath.Join(ArtifactWorkRootDir(), opts.ArtifactID, "build-"+strconv.FormatInt(generation, 10))
+	rootfsDir := filepath.Join(workDir, "rootfs")
+	ext4Path := filepath.Join(workDir, opts.ArtifactID+".ext4")
+	keepExt4 := false
+	if err := os.RemoveAll(workDir); err != nil { // NOCC:Path Traversal()
+		return BuildResult{}, fmt.Errorf("clean stale local artifact workdir: %w", err)
+	}
+	if err := os.MkdirAll(workDir, 0o755); err != nil {
+		return BuildResult{}, fmt.Errorf("prepare local artifact workdir: %w", err)
+	}
+	defer func() {
+		if keepExt4 {
+			if err := os.RemoveAll(rootfsDir); err != nil { // NOCC:Path Traversal()
+				log.G(ctx).Warnf("cleanup rootfsDir %s failed: %v", rootfsDir, err)
+			}
+			return
+		}
+		if err := os.RemoveAll(workDir); err != nil { // NOCC:Path Traversal()
+			log.G(ctx).Warnf("cleanup workDir %s failed: %v", workDir, err)
+		}
+	}()
 
 	// Phase 2: loop-mount streaming build (optional, auto-detects capability).
 	// Passes PostRootfsExport down to be executed before unmounting the loop device.
@@ -134,20 +127,21 @@ func BuildExt4(ctx context.Context, source *PreparedSource, opts BuildOptions) (
 		if err != nil {
 			log.G(ctx).Warnf("cannot estimate image size for Phase 2, falling back to Phase 1: %v", err)
 		} else {
-			if err := checkDiskSpace(ctx, storeDir, estimatedPhase2); err != nil {
+			if err := checkDiskSpace(ctx, workDir, estimatedPhase2); err != nil {
 				return BuildResult{}, err
 			}
 			if err := createExt4ImageStreaming(ctx, source, workDir, ext4Path, estimatedPhase2, opts.PostRootfsExport); err != nil {
 				log.G(ctx).Warnf("loop-mount streaming ext4 build failed, falling back to phase-1: %v", err)
 				_ = os.RemoveAll(workDir)
-				_ = os.Remove(ext4Path)
+				if err := os.MkdirAll(workDir, 0o755); err != nil {
+					return BuildResult{}, fmt.Errorf("recreate local artifact workdir after streaming fallback: %w", err)
+				}
 			} else {
 				shaValue, sizeBytes, err := computeFileSHA256(ext4Path)
 				if err != nil {
 					return BuildResult{}, err
 				}
-				_ = os.RemoveAll(workDir)
-				keepStoreDir = true
+				keepExt4 = true
 				return BuildResult{Ext4Path: ext4Path, SHA256: shaValue, SizeBytes: sizeBytes}, nil
 			}
 		}
@@ -157,68 +151,28 @@ func BuildExt4(ctx context.Context, source *PreparedSource, opts BuildOptions) (
 	if err != nil {
 		log.G(ctx).Warnf("cannot estimate image size for disk-space check, skipping: %v", err)
 	} else if estimatedSizeBytes > 0 {
-		if err := checkDiskSpace(ctx, storeDir, estimatedSizeBytes); err != nil {
+		if err := checkDiskSpace(ctx, workDir, estimatedSizeBytes); err != nil {
 			return BuildResult{}, err
 		}
 	}
 
-	defer func() {
-		if workDir != "" {
-			if err := os.RemoveAll(workDir); err != nil {
-				log.G(ctx).Warnf("cleanup workDir %s failed: %v", workDir, err)
-			}
-		}
-		if !keepStoreDir {
-			if storeDir != "" {
-				if err := os.RemoveAll(storeDir); err != nil {
-					log.G(ctx).Warnf("cleanup storeDir %s failed: %v", storeDir, err)
-				}
-			}
-		} else {
-			if storeRootfsDir != "" {
-				if err := os.RemoveAll(storeRootfsDir); err != nil {
-					log.G(ctx).Warnf("cleanup storeRootfsDir %s failed: %v", storeRootfsDir, err)
-				}
-			}
-		}
-	}()
-
-	if isLocalFastFS(storeDir) {
-		if err := exportImageRootfs(ctx, source, storeRootfsDir); err != nil {
-			return BuildResult{}, err
-		}
-	} else {
-		rootfsDir := filepath.Join(workDir, "rootfs")
-		if err := os.MkdirAll(rootfsDir, 0o755); err != nil {
-			return BuildResult{}, err
-		}
-		if err := exportImageRootfs(ctx, source, rootfsDir); err != nil {
-			return BuildResult{}, err
-		}
-		if err := relocateRootfsToArtifactStore(ctx, rootfsDir, storeRootfsDir); err != nil {
-			return BuildResult{}, err
-		}
-	}
-
-	if workDir != "" {
-		if err := os.RemoveAll(workDir); err != nil {
-			log.G(ctx).Warnf("cleanup workDir %s failed: %v", workDir, err)
-		}
+	if err := exportImageRootfs(ctx, source, rootfsDir); err != nil {
+		return BuildResult{}, err
 	}
 
 	if opts.PostRootfsExport != nil {
-		if err := opts.PostRootfsExport(ctx, storeRootfsDir); err != nil {
+		if err := opts.PostRootfsExport(ctx, rootfsDir); err != nil {
 			return BuildResult{}, err
 		}
 	}
 
-	if err := createExt4Image(ctx, storeRootfsDir, ext4Path); err != nil {
+	if err := createExt4Image(ctx, rootfsDir, ext4Path); err != nil {
 		return BuildResult{}, err
 	}
 	shaValue, sizeBytes, err := computeFileSHA256(ext4Path)
 	if err != nil {
 		return BuildResult{}, err
 	}
-	keepStoreDir = true
+	keepExt4 = true
 	return BuildResult{Ext4Path: ext4Path, SHA256: shaValue, SizeBytes: sizeBytes}, nil
 }

--- a/CubeMaster/pkg/templatecenter/image/image_test.go
+++ b/CubeMaster/pkg/templatecenter/image/image_test.go
@@ -948,7 +948,7 @@ func TestBuildExt4StreamingSuccessSkipsPhase1(t *testing.T) {
 		return nil
 	})
 
-	result, err := BuildExt4(context.Background(), &PreparedSource{LocalRef: "docker.io/library/nginx:latest", ExportMode: ExportModeNative}, BuildOptions{ArtifactID: "artifact-stream"})
+	result, err := BuildExt4(context.Background(), &PreparedSource{LocalRef: "docker.io/library/nginx:latest", ExportMode: ExportModeNative}, BuildOptions{ArtifactID: "artifact-stream", Generation: 2})
 	if err != nil {
 		t.Fatalf("BuildExt4 failed: %v", err)
 	}
@@ -958,8 +958,12 @@ func TestBuildExt4StreamingSuccessSkipsPhase1(t *testing.T) {
 	if result.SHA256 != "sha-streaming" || result.SizeBytes != 9 {
 		t.Fatalf("unexpected result: %#v", result)
 	}
-	if _, err := os.Stat(filepath.Join(workRoot, "artifact-stream")); !os.IsNotExist(err) {
-		t.Fatalf("workDir should be removed after streaming success, stat err=%v", err)
+	wantPath := filepath.Join(workRoot, "artifact-stream", "build-2", "artifact-stream.ext4")
+	if result.Ext4Path != wantPath {
+		t.Fatalf("Ext4Path=%q, want %q", result.Ext4Path, wantPath)
+	}
+	if _, err := os.Stat(result.Ext4Path); err != nil {
+		t.Fatalf("local ext4 must remain available for publication: %v", err)
 	}
 }
 
@@ -1064,22 +1068,29 @@ func TestBuildExt4StreamingFailureFallsBackToPhase1(t *testing.T) {
 		return "sha-phase-1", 7, nil
 	})
 
-	result, err := BuildExt4(context.Background(), &PreparedSource{LocalRef: "docker.io/library/nginx:latest"}, BuildOptions{ArtifactID: "artifact-fallback"})
+	result, err := BuildExt4(context.Background(), &PreparedSource{LocalRef: "docker.io/library/nginx:latest"}, BuildOptions{ArtifactID: "artifact-fallback", Generation: 3})
 	if err != nil {
 		t.Fatalf("BuildExt4 failed: %v", err)
 	}
 	if result.SHA256 != "sha-phase-1" || result.SizeBytes != 7 {
 		t.Fatalf("unexpected result: %#v", result)
 	}
-	if _, err := os.Stat(filepath.Join(storeRoot, "artifact-fallback", "rootfs")); !os.IsNotExist(err) {
+	if _, err := os.Stat(filepath.Join(workRoot, "artifact-fallback", "build-3", "rootfs")); !os.IsNotExist(err) {
 		t.Fatalf("rootfs dir should be removed after successful phase-1 build, stat err=%v", err)
 	}
-	if _, err := os.Stat(filepath.Join(storeRoot, "artifact-fallback", "artifact-fallback.ext4")); err != nil {
-		t.Fatalf("ext4 should remain after successful phase-1 build: %v", err)
+	wantPath := filepath.Join(workRoot, "artifact-fallback", "build-3", "artifact-fallback.ext4")
+	if result.Ext4Path != wantPath {
+		t.Fatalf("Ext4Path=%q, want %q", result.Ext4Path, wantPath)
+	}
+	if _, err := os.Stat(result.Ext4Path); err != nil {
+		t.Fatalf("local ext4 should remain after successful phase-1 build: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(storeRoot, "artifact-fallback")); !os.IsNotExist(err) {
+		t.Fatalf("phase-1 build must not write mutable data to the shared store: %v", err)
 	}
 }
 
-func TestBuildExt4Phase1FailureCleansStoreDir(t *testing.T) {
+func TestBuildExt4Phase1FailureCleansWorkDir(t *testing.T) {
 	workRoot := t.TempDir()
 	storeRoot := t.TempDir()
 	t.Setenv("CUBEMASTER_ROOTFS_ARTIFACT_DIR", workRoot)
@@ -1106,8 +1117,11 @@ func TestBuildExt4Phase1FailureCleansStoreDir(t *testing.T) {
 	if err == nil || !strings.Contains(err.Error(), "export failed") {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	if _, statErr := os.Stat(filepath.Join(workRoot, "artifact-fail", "build-1")); !os.IsNotExist(statErr) {
+		t.Fatalf("workDir should be removed on phase-1 failure, stat err=%v", statErr)
+	}
 	if _, statErr := os.Stat(filepath.Join(storeRoot, "artifact-fail")); !os.IsNotExist(statErr) {
-		t.Fatalf("storeDir should be removed on phase-1 failure, stat err=%v", statErr)
+		t.Fatalf("failed local build must not touch shared storage, stat err=%v", statErr)
 	}
 }
 

--- a/CubeMaster/pkg/templatecenter/image/types.go
+++ b/CubeMaster/pkg/templatecenter/image/types.go
@@ -24,6 +24,10 @@ type SourceSpec struct {
 
 type BuildOptions struct {
 	ArtifactID string
+	// Generation scopes one fenced artifact build attempt. It is used only for
+	// local build paths; publication assigns the same generation on the shared
+	// artifact store.
+	Generation int64
 	// PostRootfsExport is invoked after the image rootfs has been exported to
 	// the working directory but before mkfs.ext4 runs, so callers can mutate
 	// the rootfs (e.g. bake the CubeEgress root CA into the trust store). The

--- a/CubeMaster/pkg/templatecenter/template_image_test.go
+++ b/CubeMaster/pkg/templatecenter/template_image_test.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/agiledragon/gomonkey/v2"
+	mysqldriver "github.com/go-sql-driver/mysql"
 	cubeboxv1 "github.com/tencentcloud/CubeSandbox/CubeMaster/api/services/cubebox/v1"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/constants"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/db/models"
@@ -1033,6 +1034,28 @@ func TestValidateReusableRootfsArtifactHandlesMissingRecord(t *testing.T) {
 	}
 }
 
+func TestIsRetryableRootfsArtifactClaimError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "nil", err: nil, want: false},
+		{name: "duplicate key", err: gorm.ErrDuplicatedKey, want: true},
+		{name: "mysql deadlock", err: &mysqldriver.MySQLError{Number: 1213, Message: "deadlock"}, want: true},
+		{name: "mysql lock timeout", err: &mysqldriver.MySQLError{Number: 1205, Message: "timeout"}, want: true},
+		{name: "raw deadlock", err: errors.New("Deadlock found when trying to get lock"), want: true},
+		{name: "unrelated", err: errors.New("connection refused"), want: false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isRetryableRootfsArtifactClaimError(tc.err); got != tc.want {
+				t.Fatalf("isRetryableRootfsArtifactClaimError(%v)=%v, want %v", tc.err, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestRootfsArtifactSoftDeleted(t *testing.T) {
 	if rootfsArtifactSoftDeleted(nil) {
 		t.Fatal("nil record should not be treated as deleted")
@@ -1058,6 +1081,9 @@ func TestManagedArtifactDirRecognizesWorkAndStoreRoots(t *testing.T) {
 	}
 	if dir, ok := managedArtifactDir("artifact-2", filepath.Join(storeRoot, "artifact-2", "artifact-2.ext4")); !ok || dir != filepath.Join(storeRoot, "artifact-2") {
 		t.Fatalf("managedArtifactDir should accept store root, got dir=%q ok=%v", dir, ok)
+	}
+	if dir, ok := managedArtifactDir("artifact-2", filepath.Join(storeRoot, "artifact-2", "generations", "3", "sha.ext4")); !ok || dir != filepath.Join(storeRoot, "artifact-2") {
+		t.Fatalf("managedArtifactDir should accept an immutable generation path, got dir=%q ok=%v", dir, ok)
 	}
 	if _, ok := managedArtifactDir("artifact-3", filepath.Join(t.TempDir(), "artifact-3", "artifact-3.ext4")); ok {
 		t.Fatal("managedArtifactDir should reject unmanaged roots")
@@ -1136,6 +1162,8 @@ func TestBuildRootfsArtifactFinalizesBuildResult(t *testing.T) {
 		ArtifactID:              "artifact-1",
 		TemplateSpecFingerprint: "fingerprint-1",
 		WritableLayerSize:       "20Gi",
+		BuildOwnerToken:         "build-token",
+		BuildGeneration:         1,
 	}
 	source := &image.PreparedSource{
 		Digest:       "sha256:digest",
@@ -1159,30 +1187,31 @@ func TestBuildRootfsArtifactFinalizesBuildResult(t *testing.T) {
 		if opts.ArtifactID != artifact.ArtifactID {
 			t.Fatalf("BuildOptions.ArtifactID=%q, want %q", opts.ArtifactID, artifact.ArtifactID)
 		}
+		if opts.Generation != artifact.BuildGeneration {
+			t.Fatalf("BuildOptions.Generation=%d, want %d", opts.Generation, artifact.BuildGeneration)
+		}
 		return image.BuildResult{Ext4Path: "/tmp/artifact-1.ext4", SHA256: "sha-ext4", SizeBytes: 1234}, nil
+	})
+	patches.ApplyFunc(image.PublishExt4, func(ctx context.Context, artifactID string, generation int64, shaValue string, srcPath string) (string, int64, error) {
+		if artifactID != artifact.ArtifactID || generation != artifact.BuildGeneration || shaValue != "sha-ext4" {
+			t.Fatalf("unexpected publish arguments: artifact=%q generation=%d sha=%q", artifactID, generation, shaValue)
+		}
+		return "/shared/artifact-1/generations/1/sha-ext4.ext4", 1234, nil
 	})
 
 	var updateValues map[string]any
-	patches.ApplyFunc(updateRootfsArtifact, func(ctx context.Context, artifactID string, values map[string]any) error {
-		if artifactID != artifact.ArtifactID {
-			t.Fatalf("artifactID=%q, want %q", artifactID, artifact.ArtifactID)
+	patches.ApplyFunc(finalizeRootfsArtifactRecord, func(ctx context.Context, record *models.RootfsArtifact, values map[string]any) error {
+		if record != artifact {
+			t.Fatalf("record=%p, want %p", record, artifact)
 		}
 		updateValues = values
 		return nil
 	})
-	patches.ApplyFunc(getRootfsArtifactByID, func(ctx context.Context, artifactID string) (*models.RootfsArtifact, error) {
-		if artifactID != artifact.ArtifactID {
-			t.Fatalf("artifactID=%q, want %q", artifactID, artifact.ArtifactID)
-		}
-		latest := *artifact
-		return &latest, nil
-	})
-
 	got, generatedReq, err := buildRootfsArtifact(context.Background(), artifact, req, source, "http://master.example", nil, "")
 	if err != nil {
 		t.Fatalf("buildRootfsArtifact failed: %v", err)
 	}
-	if got.Ext4Path != "/tmp/artifact-1.ext4" || got.Ext4SHA256 != "sha-ext4" || got.Ext4SizeBytes != 1234 {
+	if got.Ext4Path != "/shared/artifact-1/generations/1/sha-ext4.ext4" || got.Ext4SHA256 != "sha-ext4" || got.Ext4SizeBytes != 1234 {
 		t.Fatalf("artifact build result was not finalized: %#v", got)
 	}
 	if got.Status != ArtifactStatusReady {
@@ -1197,7 +1226,7 @@ func TestBuildRootfsArtifactFinalizesBuildResult(t *testing.T) {
 	if generatedReq.Containers[0].Image.Annotations[constants.CubeAnnotationRootfsArtifactSHA256] != "sha-ext4" {
 		t.Fatalf("generated request did not include ext4 sha annotation")
 	}
-	if updateValues["ext4_path"] != "/tmp/artifact-1.ext4" ||
+	if updateValues["ext4_path"] != "/shared/artifact-1/generations/1/sha-ext4.ext4" ||
 		updateValues["ext4_sha256"] != "sha-ext4" ||
 		updateValues["ext4_size_bytes"] != int64(1234) ||
 		updateValues["status"] != ArtifactStatusReady {
@@ -1205,6 +1234,116 @@ func TestBuildRootfsArtifactFinalizesBuildResult(t *testing.T) {
 	}
 	if _, ok := updateValues["generated_request_json"].(string); !ok {
 		t.Fatalf("generated_request_json was not persisted as string: %#v", updateValues)
+	}
+}
+
+func TestBuildRootfsArtifactPreservesPublishedGenerationUntilFinalizeOutcomeIsFenced(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	artifact := &models.RootfsArtifact{
+		ArtifactID:      "artifact-1",
+		BuildOwnerToken: "build-token",
+		BuildGeneration: 7,
+	}
+	source := &image.PreparedSource{
+		Digest:     "sha256:digest",
+		ConfigJSON: `{}`,
+		Config:     image.DockerImageConfig{},
+	}
+	req := &types.CreateTemplateFromImageReq{
+		Request:           &types.Request{RequestID: "req-1"},
+		TemplateID:        "tpl-1",
+		SourceImageRef:    "docker.io/library/nginx:latest",
+		WritableLayerSize: "20Gi",
+		InstanceType:      cubeboxv1.InstanceType_cubebox.String(),
+		NetworkType:       cubeboxv1.NetworkType_tap.String(),
+	}
+	patches.ApplyFunc(image.BuildExt4, func(context.Context, *image.PreparedSource, image.BuildOptions) (image.BuildResult, error) {
+		return image.BuildResult{Ext4Path: "/tmp/artifact-1.ext4", SHA256: "sha-ext4", SizeBytes: 1234}, nil
+	})
+	publishedPath := "/shared/artifact-1/generations/7/sha-ext4.ext4"
+	patches.ApplyFunc(image.PublishExt4, func(context.Context, string, int64, string, string) (string, int64, error) {
+		return publishedPath, 1234, nil
+	})
+	finalizeErr := errors.New("fenced finalization failed")
+	patches.ApplyFunc(finalizeRootfsArtifactRecord, func(context.Context, *models.RootfsArtifact, map[string]any) error {
+		return finalizeErr
+	})
+	cleanupCalled := false
+	patches.ApplyFunc(image.RemovePublishedExt4, func(ctx context.Context, artifactID string, generation int64, path string) error {
+		cleanupCalled = true
+		if artifactID != artifact.ArtifactID || generation != artifact.BuildGeneration || path != publishedPath {
+			t.Fatalf("unexpected cleanup arguments: artifact=%q generation=%d path=%q", artifactID, generation, path)
+		}
+		return nil
+	})
+
+	_, _, err := buildRootfsArtifact(context.Background(), artifact, req, source, "http://master.example", nil, "")
+	if !errors.Is(err, finalizeErr) {
+		t.Fatalf("buildRootfsArtifact error=%v, want finalize error", err)
+	}
+	if cleanupCalled {
+		t.Fatal("published generation was removed before the database outcome was fenced")
+	}
+}
+
+func TestCleanupPublishedArtifactAfterFailedFinalizeRequiresFailedFence(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	artifact := &models.RootfsArtifact{
+		ArtifactID:      "artifact-1",
+		BuildOwnerToken: "build-token",
+		BuildGeneration: 7,
+	}
+	publishedPath := "/shared/artifact-1/generations/7/sha-ext4.ext4"
+	finalizeCause := errors.New("finalize response lost")
+	buildErr := &publishedArtifactFinalizeError{publishedPath: publishedPath, cause: finalizeCause}
+	cleanupCalls := 0
+	patches.ApplyFunc(image.RemovePublishedExt4, func(ctx context.Context, artifactID string, generation int64, path string) error {
+		cleanupCalls++
+		if artifactID != artifact.ArtifactID || generation != artifact.BuildGeneration || path != publishedPath {
+			t.Fatalf("unexpected cleanup arguments: artifact=%q generation=%d path=%q", artifactID, generation, path)
+		}
+		return nil
+	})
+
+	if err := cleanupPublishedArtifactAfterFailedFinalize(context.Background(), artifact, buildErr, errRootfsArtifactBuildLeaseLost); !errors.Is(err, finalizeCause) {
+		t.Fatalf("unfenced cleanup error=%v, want finalize cause", err)
+	}
+	if cleanupCalls != 0 {
+		t.Fatalf("cleanup calls=%d after ambiguous/lease-lost outcome, want 0", cleanupCalls)
+	}
+
+	if err := cleanupPublishedArtifactAfterFailedFinalize(context.Background(), artifact, buildErr, nil); !errors.Is(err, finalizeCause) {
+		t.Fatalf("fenced cleanup error=%v, want finalize cause", err)
+	}
+	if cleanupCalls != 1 {
+		t.Fatalf("cleanup calls=%d after FAILED fence, want 1", cleanupCalls)
+	}
+}
+
+func TestRootfsArtifactFinalizationMatchesExactPublishedGeneration(t *testing.T) {
+	intended := &models.RootfsArtifact{
+		ArtifactID:           "artifact-1",
+		Status:               ArtifactStatusReady,
+		BuildOwnerToken:      "build-token",
+		BuildGeneration:      7,
+		Ext4Path:             "/shared/artifact-1/generations/7/sha-ext4.ext4",
+		Ext4SHA256:           "sha-ext4",
+		Ext4SizeBytes:        1234,
+		GeneratedRequestJSON: `{"template_id":"tpl-1"}`,
+		DownloadToken:        "download-token",
+	}
+	current := *intended
+	if !rootfsArtifactFinalizationMatches(&current, intended) {
+		t.Fatal("exact READY generation should reconcile as committed")
+	}
+
+	current.Ext4Path = "/shared/artifact-1/generations/8/other.ext4"
+	if rootfsArtifactFinalizationMatches(&current, intended) {
+		t.Fatal("different published generation must not reconcile as committed")
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes #1005.

When two CubeMaster replicas build the same rootfs artifact, the existing
process-local mutex does not serialize them. Independent `mkfs.ext4` runs can
produce different filesystem metadata and SHA-256 values, allowing the stored
SHA to disagree with the ext4 file Cubelet downloads.

This change coordinates the build through the shared database while retaining
the existing Service/LB download route and `rewriteDownloadHost` behavior.

## Changes

- Add a renewable owner-token lease and generation fence to
  `t_cube_rootfs_artifact`, with MySQL and PostgreSQL migrations.
- Permit one live lease holder to build; concurrent callers wait for the
  result, while expired or failed leases can be acquired by a later generation.
- Conditionally finalize READY/FAILED with the owner token and generation so a
  stale builder cannot overwrite a newer result. Retry transient first-claim
  conflicts.
- Build mutable rootfs data locally, then publish only the finished ext4 to the
  shared store at an immutable path:
  `<artifact>/generations/<generation>/<sha>.ext4`.
- Publish with copy, file `fsync`, rename, and directory `fsync`. Preserve a
  published generation when a final database outcome is ambiguous; remove it
  only after a fenced FAILED update proves READY did not commit.
- Update artifact cleanup for the generation directory layout.

## Validation

Focused immutable-publish tests:

```bash
cd CubeMaster
go test -gcflags=all=-l ./pkg/templatecenter/image -run '^(TestPublishExt4|TestRemovePublishedExt4|TestBuildExt4StreamingSuccessSkipsPhase1|TestBuildExt4StreamingWithPostExport|TestBuildExt4Phase1FailureCleansWorkDir|TestBuildExt4ThenPublishExt4KeepsLocalResultUntilCopied)' -count=1 -v
```

```text
=== RUN   TestPublishExt4PublishesImmutableGenerationPath
--- PASS: TestPublishExt4PublishesImmutableGenerationPath (0.01s)
=== RUN   TestPublishExt4RejectsChangedSourceBytes
--- PASS: TestPublishExt4RejectsChangedSourceBytes (0.00s)
=== RUN   TestRemovePublishedExt4OnlyRemovesRequestedGeneration
--- PASS: TestRemovePublishedExt4OnlyRemovesRequestedGeneration (0.01s)
=== RUN   TestBuildExt4ThenPublishExt4KeepsLocalResultUntilCopied
--- PASS: TestBuildExt4ThenPublishExt4KeepsLocalResultUntilCopied (0.01s)
PASS
ok  github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/templatecenter/image  0.039s
```

Lease, finalize, and cleanup tests:

```bash
cd CubeMaster
go test -gcflags=all=-l ./pkg/templatecenter -run '^(TestIsRetryableRootfsArtifactClaimError|TestBuildRootfsArtifactFinalizesBuildResult|TestBuildRootfsArtifactPreservesPublishedGenerationUntilFinalizeOutcomeIsFenced|TestCleanupPublishedArtifactAfterFailedFinalizeRequiresFailedFence|TestRootfsArtifactFinalizationMatchesExactPublishedGeneration|TestManagedArtifactDirRecognizesWorkAndStoreRoots)$' -count=1 -v
```

```text
=== RUN   TestBuildRootfsArtifactFinalizesBuildResult
--- PASS: TestBuildRootfsArtifactFinalizesBuildResult (0.00s)
=== RUN   TestBuildRootfsArtifactPreservesPublishedGenerationUntilFinalizeOutcomeIsFenced
--- PASS: TestBuildRootfsArtifactPreservesPublishedGenerationUntilFinalizeOutcomeIsFenced (0.00s)
=== RUN   TestCleanupPublishedArtifactAfterFailedFinalizeRequiresFailedFence
--- PASS: TestCleanupPublishedArtifactAfterFailedFinalizeRequiresFailedFence (0.00s)
=== RUN   TestRootfsArtifactFinalizationMatchesExactPublishedGeneration
--- PASS: TestRootfsArtifactFinalizationMatchesExactPublishedGeneration (0.00s)
PASS
ok  github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/templatecenter  0.011s
```

Concurrent database claims (24 transactions per dialect):

```bash
cd CubeMaster
go test -gcflags=all=-l ./pkg/templatecenter -run '^TestClaimRootfsArtifactForBuildConcurrent(Postgres|MySQL)$' -count=1
```

```text
ok  github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/templatecenter  18.690s
```

Fresh migrations and schema alignment:

```bash
cd CubeMaster
go test ./pkg/base/dao/migrate -run '^(TestRun_Fresh|TestPostgres_Run_Fresh|TestSchemaAlignment_MySQL_vs_Postgres)$' -count=1
```

```text
ok  github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/dao/migrate  49.308s
```

Development-VM end-to-end regression:

```bash
cubemastercli tpl create-from-image \
  --image cube-sandbox-cn.tencentcloudcr.com/cube-sandbox/sandbox-code:latest \
  --writable-layer-size 1G \
  --expose-port 49999 --expose-port 49983 --probe 49999 --json
cubemastercli tpl watch --job-id 4b94da4e-c53b-484e-9ec8-e11e7fd78cfc \
  --interval 5s --json
```

```text
2026/07/21 11:46:01 [7/7] READY progress=100% distribution=1/1 ready, 0 failed template_id=tpl-105d5d8660d04ff78d487772 job_id=4b94da4e-c53b-484e-9ec8-e11e7fd78cfc artifact_id=rfs-ff15cb68b74a2be829f86b89
2026/07/21 11:46:01 template image job succeeded template_id=tpl-105d5d8660d04ff78d487772 job_id=4b94da4e-c53b-484e-9ec8-e11e7fd78cfc artifact_id=rfs-ff15cb68b74a2be829f86b89 distribution=1/1 ready, 0 failed
```

The job pulled 110110149 bytes in 11 layers, built a 1073741824-byte ext4,
and published generation 1. The VM-side SHA-256 matched the artifact record
and filename. The temporary template was deleted afterward and its artifact
directory was removed.

Two-CubeMaster lease takeover regression:

- Started a second CubeMaster process on port 8090 with a separate local
  workdir, sharing the development VM's MySQL, Redis, and artifact directory
  with the primary process on port 8089.
- Submitted an image-template build to port 8090, confirmed it held artifact
  `rfs-c722c02e2a477f41447afa99` at generation 1, and sent `SIGKILL` before
  it could publish.
- Submitted the same request to port 8089. It waited for the unmodified
  15-minute lease to expire, then atomically acquired generation 2 and
  completed the real build and Cubelet distribution.

```text
BUILDING  1  62f3a3a8-1a92-42b8-a233-921227749b75
BUILDING  2  db273963-7004-490d-ad88-93e077d9355e
2026/07/21 13:59:06 [7/7] READY progress=100% distribution=1/1 ready, 0 failed template_id=tpl-f8b9eeb173d147a88cee8618 job_id=66de2251-9acc-4ba4-a754-8c09469c8aaa artifact_id=rfs-c722c02e2a477f41447afa99
```

The final artifact was:

```text
/data/CubeMaster/storage/rfs-c722c02e2a477f41447afa99/generations/2/966a84ad38ed919b3e945af45907f170b0ec6f12e559c623e716057321a2c218.ext4
```

Its recorded SHA-256 and filename matched. The test templates, artifact
directory, and second CubeMaster process were removed afterward.

Formatting and build:

```bash
env -u ALL_PROXY -u HTTPS_PROXY -u HTTP_PROXY \
  -u all_proxy -u https_proxy -u http_proxy make fmt
make cubemaster
git diff --check
```

```text
<no output from git diff --check>
```