### PR TITLE
feat(cubeops): use cubelog for file-based logging with rotation

### DIFF
--- a/CubeOps/Dockerfile
+++ b/CubeOps/Dockerfile
@@ -16,6 +16,7 @@ WORKDIR /build/CubeOps
 # Copy go.mod/go.sum first for better layer caching
 COPY CubeOps/go.mod CubeOps/go.sum ./
 COPY CubeDB /build/CubeDB
+COPY cubelog /build/cubelog
 RUN go mod download
 
 COPY CubeOps/ .

--- a/CubeOps/Dockerfile.dockerignore
+++ b/CubeOps/Dockerfile.dockerignore
@@ -9,3 +9,5 @@
 !CubeOps/**
 !CubeDB
 !CubeDB/**
+!cubelog
+!cubelog/**

--- a/CubeOps/README.md
+++ b/CubeOps/README.md
@@ -75,11 +75,11 @@ systemctl start cube-sandbox-cubeops.service
 systemctl stop cube-sandbox-cubeops.service
 systemctl restart cube-sandbox-cubeops.service
 
-# View recent logs
-journalctl -u cube-sandbox-cubeops.service -n 50 --no-pager
+# View recent logs (file-based, via cubelog)
+tail -50 /data/log/CubeOps/cubeops-req.log
 
 # Follow logs in real-time
-journalctl -u cube-sandbox-cubeops.service -f
+tail -f /data/log/CubeOps/cubeops-req.log
 ```
 
 Quick health check (no auth required):
@@ -122,7 +122,10 @@ individual fields without editing the YAML file.
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `CUBE_OPS_BIND` | `127.0.0.1:3010` | Listen address. In All-in-One deployments this must be set to `0.0.0.0:3010` so the WebUI nginx container can reach CubeOps via `host.docker.internal:3010`. |
-| `CUBE_OPS_LOG_LEVEL` | `info` | Log level |
+| `CUBE_OPS_LOG_LEVEL` | `info` | Log level (`debug`, `info`, `warn`, `error`) |
+| `CUBE_OPS_LOG_DIR` | `/data/log/CubeOps` | Log file directory. Logs are written to `cubeops-req.log` (business) and `cubeops-stat.log` (trace), rotated by size. |
+| `CUBE_OPS_LOG_FILE_NUM` | `10` | Number of rotated log files to retain. |
+| `CUBE_OPS_LOG_FILE_SIZE` | `100` | Max size in MB per log file before rotation. |
 | `JWT_SECRET` | *(optional)* | JWT signing secret. If unset, a secret is auto-generated on first startup and persisted to the `t_system_setting` table in the database. |
 | `JWT_ACCESS_TTL` | `15m` | Access token TTL |
 | `JWT_REFRESH_TTL` | `168h` | Refresh token TTL (7 days) |

--- a/CubeOps/cmd/cubeops/main.go
+++ b/CubeOps/cmd/cubeops/main.go
@@ -14,20 +14,29 @@ import (
 	"time"
 
 	"github.com/tencentcloud/CubeSandbox/CubeOps/internal/config"
+	"github.com/tencentcloud/CubeSandbox/CubeOps/internal/logging"
 	"github.com/tencentcloud/CubeSandbox/CubeOps/internal/server"
 	"github.com/tencentcloud/CubeSandbox/CubeOps/internal/store"
 )
 
 func main() {
-	slog.SetDefault(slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
-		Level: slog.LevelInfo,
-	})))
-
 	cfg, err := config.Load()
 	if err != nil {
+		// Config load failed before logging is initialised; use a
+		// stdout-only slog so the error is still visible.
+		slog.SetDefault(slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
+			Level: slog.LevelInfo,
+		})))
 		slog.Error("failed to load config", "error", err)
 		os.Exit(1)
 	}
+
+	logging.Init(logging.Options{
+		Level:      cfg.LogLevel,
+		LogDir:     cfg.LogDir,
+		FileNum:    cfg.LogFileNum,
+		FileSizeMB: cfg.LogFileSize,
+	})
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/CubeOps/config.example.yaml
+++ b/CubeOps/config.example.yaml
@@ -6,6 +6,9 @@
 # --- HTTP server ---
 bind: "127.0.0.1:3010"
 log_level: "info"
+log_dir: "/data/log/CubeOps"  # log file directory
+log_file_num: 10              # number of rotated log files to retain
+log_file_size: 100            # max size in MB per log file before rotation
 jwt_secret: ""             # leave empty to auto-generate on first start
 
 # --- Database (MySQL) ---

--- a/CubeOps/go.mod
+++ b/CubeOps/go.mod
@@ -10,9 +10,12 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/ory/dockertest/v3 v3.12.0
 	github.com/tencentcloud/CubeSandbox/CubeDB v0.1.0
+	github.com/tencentcloud/CubeSandbox/cubelog v0.1.1-0.20260113105508-a996703fa42f
 	golang.org/x/crypto v0.50.0
 	gorm.io/gorm v1.25.10
 )
+
+replace github.com/tencentcloud/CubeSandbox/cubelog => ../cubelog
 
 require (
 	dario.cat/mergo v1.0.0 // indirect

--- a/CubeOps/internal/config/config.go
+++ b/CubeOps/internal/config/config.go
@@ -34,9 +34,12 @@ import (
 // Config holds all CubeOps runtime configuration.
 type Config struct {
 	// Server
-	Bind      string `yaml:"bind"`
-	LogLevel  string `yaml:"log_level"`
-	JWTSecret string `yaml:"jwt_secret"`
+	Bind        string `yaml:"bind"`
+	LogLevel    string `yaml:"log_level"`
+	LogDir      string `yaml:"log_dir"`
+	LogFileNum  int    `yaml:"log_file_num"`
+	LogFileSize int    `yaml:"log_file_size"`
+	JWTSecret   string `yaml:"jwt_secret"`
 
 	// Database — either a single URL or the individual fields below.
 	DatabaseURL   string `yaml:"database_url"`
@@ -91,6 +94,15 @@ func Load() (*Config, error) {
 	}
 	if cfg.LogLevel == "" {
 		cfg.LogLevel = "info"
+	}
+	if cfg.LogDir == "" {
+		cfg.LogDir = "/data/log/CubeOps"
+	}
+	if cfg.LogFileNum == 0 {
+		cfg.LogFileNum = 10
+	}
+	if cfg.LogFileSize == 0 {
+		cfg.LogFileSize = 100
 	}
 	if cfg.CubeMasterAddr == "" {
 		cfg.CubeMasterAddr = "http://127.0.0.1:8089"
@@ -252,6 +264,19 @@ func overrideFromEnv(cfg *Config) {
 	}
 	if v := os.Getenv("CUBE_OPS_LOG_LEVEL"); v != "" {
 		cfg.LogLevel = v
+	}
+	if v := os.Getenv("CUBE_OPS_LOG_DIR"); v != "" {
+		cfg.LogDir = v
+	}
+	if v := os.Getenv("CUBE_OPS_LOG_FILE_NUM"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			cfg.LogFileNum = n
+		}
+	}
+	if v := os.Getenv("CUBE_OPS_LOG_FILE_SIZE"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			cfg.LogFileSize = n
+		}
 	}
 	if v := os.Getenv("JWT_SECRET"); v != "" {
 		cfg.JWTSecret = v

--- a/CubeOps/internal/logging/logging.go
+++ b/CubeOps/internal/logging/logging.go
@@ -1,0 +1,144 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Package logging initialises structured logging for CubeOps via the
+// shared cubelog library, writing rolling files under the configured
+// directory.
+package logging
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"strings"
+
+	cubelog "github.com/tencentcloud/CubeSandbox/cubelog"
+)
+
+// Options controls logger initialisation.
+type Options struct {
+	// Level is the log level name: "debug", "info", "warn", "error".
+	// Empty defaults to "info".
+	Level string
+	// LogDir is the directory for file logs. When empty, defaults to
+	// "/data/log/CubeOps".
+	LogDir string
+	// Module is the cubelog module name used in log entries and file
+	// prefixes. Defaults to "cubeops".
+	Module string
+	// FileNum is the number of rotated log files to retain.
+	// Defaults to 10 when zero.
+	FileNum int
+	// FileSizeMB is the max size in MB of a single log file before
+	// rotation. Defaults to 100 when zero.
+	FileSizeMB int
+}
+
+// Init configures the global cubelog + slog logger from opts. It must be
+// called once at program start, before any logging is done.
+//
+// cubelog owns the file writers, and a bridge slog handler routes Go
+// slog calls into cubelog so all log lines land in the same rolling
+// files instead of stdout.
+func Init(opts Options) {
+	module := strings.TrimSpace(opts.Module)
+	if module == "" {
+		module = "cubeops"
+	}
+
+	logDir := strings.TrimSpace(opts.LogDir)
+	if logDir == "" {
+		logDir = fmt.Sprintf("/data/log/%s", module)
+	}
+	if err := os.MkdirAll(logDir, 0755); err != nil {
+		// Fall back to stdout-only if we cannot create the directory.
+		slog.Error("logging: failed to create log directory, falling back to stdout", "dir", logDir, "error", err)
+		return
+	}
+
+	fileNum := opts.FileNum
+	if fileNum == 0 {
+		fileNum = 10
+	}
+	fileSize := opts.FileSizeMB
+	if fileSize == 0 {
+		fileSize = 100
+	}
+
+	// ── Initialise cubelog (same as CubeMaster/Cubelet) ──────────────
+	cubelog.SetModuleName(module)
+	cubelog.EnableFileLog()
+	cubelog.SetSkipCallerDepth(0)
+	cubelog.SetLevel(parseCubeLogLevel(opts.Level))
+	cubelog.Create(logDir)
+
+	// Rolling file writers:
+	//   <module>-req.log   — main business log
+	//   <module>-stat.log  — trace/metric log
+	reqLogName := fmt.Sprintf("%s-req", module)
+	statLogName := fmt.Sprintf("%s-stat", module)
+
+	reqLogWriter := cubelog.NewRollFileWriter(logDir, reqLogName, fileNum, fileSize)
+	cubelog.SetOutput(reqLogWriter)
+
+	statLogWriter := cubelog.NewRollFileWriter(logDir, statLogName, fileNum, fileSize)
+	cubelog.SetTraceOutput(statLogWriter)
+
+	// ── Bridge slog → cubelog ────────────────────────────────────────
+	// CubeOps uses slog throughout its codebase. Route every slog call
+	// through cubelog so the output lands in the same rolling files
+	// instead of going to stdout.
+	slog.SetDefault(slog.New(cubelogSlogHandler{}))
+}
+
+// cubelogSlogHandler is a minimal slog.Handler that forwards all records
+// to cubelog. This keeps the existing slog.Info/Error/... call sites in
+// CubeOps working unchanged while the actual I/O goes through cubelog's
+// file writers.
+type cubelogSlogHandler struct{}
+
+func (cubelogSlogHandler) Enabled(_ context.Context, _ slog.Level) bool {
+	return true
+}
+
+func (cubelogSlogHandler) Handle(_ context.Context, r slog.Record) error {
+	var sb strings.Builder
+	sb.WriteString(r.Message)
+	r.Attrs(func(a slog.Attr) bool {
+		sb.WriteByte(' ')
+		sb.WriteString(a.Key)
+		sb.WriteByte('=')
+		sb.WriteString(a.Value.String())
+		return true
+	})
+	msg := sb.String()
+
+	switch {
+	case r.Level >= slog.LevelError:
+		cubelog.Errorf("%s", msg)
+	case r.Level >= slog.LevelWarn:
+		cubelog.Warnf("%s", msg)
+	case r.Level >= slog.LevelInfo:
+		cubelog.Infof("%s", msg)
+	default:
+		cubelog.Debugf("%s", msg)
+	}
+	return nil
+}
+
+func (cubelogSlogHandler) WithAttrs(_ []slog.Attr) slog.Handler { return cubelogSlogHandler{} }
+func (cubelogSlogHandler) WithGroup(_ string) slog.Handler      { return cubelogSlogHandler{} }
+
+func parseCubeLogLevel(s string) cubelog.LogLevel {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "debug":
+		return cubelog.DEBUG
+	case "warn", "warning":
+		return cubelog.WARN
+	case "error":
+		return cubelog.ERROR
+	default:
+		return cubelog.INFO
+	}
+}


### PR DESCRIPTION
Replaces stdout-only slog with the shared cubelog library, writing request and stats logs to rolling files (cubeops-req.log, cubeops-stat.log). A slog-to-cubelog bridge keeps all existing log call sites unchanged. Configuration follows env > YAML > defaults: log dir defaults to /data/log/CubeOps at info level, with 100 MB rotation and up to 10 retained files.