### PR TITLE
fix(ci): allow fork PR checkout in Claude Auto Review workflow

### DIFF
--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -30,6 +30,10 @@ jobs:
           # Strip the GITHUB_TOKEN from .git/config so even an accidental
           # git push from a future step cannot use base-repo write creds.
           persist-credentials: false
+          # Opt-in required since actions/checkout v6.1.0 (2026-07-20 backport
+          # from v7). Safe here: checked-out fork code is only READ by Claude
+          # for review context — no build, test, or execution steps follow.
+          allow-unsafe-pr-checkout: true
 
       - name: Generate GitHub App token
         id: app-token


### PR DESCRIPTION
## Summary

Fix the `Claude Auto Review` CI check failure  caused by the `actions/checkout` v6.1.0 security backport.

## Root Cause Analysis

### What happened

On **2026-07-20**, GitHub backported the `actions/checkout` v7 fork-PR security check to all supported major versions:

| Version | Release | Date |
|---------|---------|------|
| v7.0.0 | Initial release with the check | 2026-06-18 |
| v6.1.0 | Backport (BREAKING) | 2026-07-20 |
| v5.1.0 | Backport | 2026-07-20 |
| v4.4.0 | Backport | 2026-07-20 |

Since our `code-review.yml` uses the floating tag `actions/checkout@v6`, it automatically picked up v6.1.0 on July 20th.

### Why it fails

The new default behavior **refuses to check out fork PR code** in `pull_request_target` workflows. This is designed to prevent ["pwn request" vulnerabilities](https://gh.io/securely-using-pull_request_target) — where a fork's untrusted code runs in a privileged context with access to base-repo secrets, tokens, and runner access.

Our workflow checks out the PR HEAD via `ref: ${{ github.event.pull_request.head.sha }}` in a `pull_request_target` trigger, which now hits this block:

```
Refusing to check out fork pull request code from a 'pull_request_target' workflow.
```

### Why our workflow is safe to opt-in

This is a **review-only** workflow — Claude reads the source code for review context but never executes it. The existing security measures are sufficient:

1. **No execution steps**: No `npm install`, `make`, `cargo build`, or any build/test commands run against the checked-out code
2. **`persist-credentials: false`**: The GITHUB_TOKEN is stripped from `.git/config`, preventing accidental git push with base-repo write credentials
3. **Restricted tool access**: `claude_args` limits allowed tools to `gh.sh` wrapper and `gh pr diff/view` — no arbitrary command execution is possible
4. **Read-only purpose**: Claude only reads files to generate review comments posted through the constrained `scripts/gh.sh` wrapper

## Change

Add `allow-unsafe-pr-checkout: true` to the `actions/checkout` step, explicitly opting in after confirming the checked-out fork code is treated as data only.

## References

- [GitHub Changelog: Safer pull_request_target defaults (2026-06-18)](https://github.blog/changelog/2026-06-18-safer-pull_request_target-defaults-for-github-actions-checkout/)
- [GitHub Docs: Securely using pull_request_target](https://docs.github.com/en/actions/reference/security/securely-using-pull_request_target)
- [actions/checkout PR #2454: block checking out fork PR](https://github.com/actions/checkout/pull/2454)
- Affected PR: #1044

Assisted-by: Cursor:claude-opus-4-8-thinking-high

Made with [Cursor](https://cursor.com)