### PR TITLE
ci: add Go SDK publish workflow

### DIFF
--- a/.github/workflows/publish-go-sdk.yml
+++ b/.github/workflows/publish-go-sdk.yml
@@ -1,0 +1,147 @@
+name: Publish Go SDK
+
+# When a go-sdk-v* tag is pushed, auto-create the nested
+# sdk/go/v* tag (Go convention) and run validation tests.
+#
+# Usage:
+#   git tag go-sdk-v0.6.0
+#   git push origin go-sdk-v0.6.0
+#
+# Automatically creates the sdk/go/v0.6.0 tag. Fixes Issue #1016.
+# Follows the same tag convention as python-sdk-v*.
+
+on:
+  push:
+    tags:
+      - 'go-sdk-v*'
+
+concurrency:
+  group: go-sdk-publish-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  create-go-sdk-tag:
+    name: Create Go SDK tag
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout (full history, blobless)
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          filter: 'blob:none'
+
+      - name: Extract version from tag
+        id: extract
+        run: |
+          # go-sdk-v0.6.0 → 0.6.0
+          VERSION="${{ github.ref_name }}"
+          VERSION="${VERSION#go-sdk-v}"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Extracted version: $VERSION"
+
+      - name: Check if sdk/go/ changed since last tag
+        id: check_changes
+        run: |
+          CURRENT_TAG="${{ github.ref_name }}"
+          GO_SDK_TAG="sdk/go/${{ steps.extract.outputs.version }}"
+
+          # Skip if Go SDK tag already exists
+          if git rev-parse -q --verify "refs/tags/$GO_SDK_TAG" > /dev/null 2>&1; then
+            echo "Go SDK tag $GO_SDK_TAG already exists, skipping."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Find the previous go-sdk-v* tag
+          PREV_TAG=$(git describe --tags --first-parent --match 'go-sdk-v*' --abbrev=0 "${CURRENT_TAG}^" 2>/dev/null || true)
+
+          if [ -z "$PREV_TAG" ]; then
+            echo "No previous go-sdk tag found — first release, proceeding."
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Comparing $PREV_TAG -> $CURRENT_TAG for sdk/go/ changes"
+            CHANGED=$(git diff --name-only "$PREV_TAG" "$CURRENT_TAG" -- sdk/go/)
+            if [ -n "$CHANGED" ]; then
+              echo "sdk/go/ has changes:"
+              echo "$CHANGED"
+              echo "changed=true" >> "$GITHUB_OUTPUT"
+            else
+              echo "No changes in sdk/go/ since $PREV_TAG — skipping."
+              echo "changed=false" >> "$GITHUB_OUTPUT"
+            fi
+          fi
+
+      - name: Set up Go
+        if: steps.check_changes.outputs.changed == 'true'
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.22'
+          check-latest: true
+          cache-dependency-path: sdk/go/go.sum
+
+      - name: Verify version consistency (go.mod)
+        if: steps.check_changes.outputs.changed == 'true'
+        working-directory: sdk/go
+        run: |
+          VERSION="${{ steps.extract.outputs.version }}"
+          EXPECTED_MODULE="module github.com/tencentcloud/CubeSandbox/sdk/go"
+
+          # Assert go.mod module path matches the canonical path for this SDK
+          MODULE=$(head -1 go.mod)
+          if [ "$MODULE" != "$EXPECTED_MODULE" ]; then
+            echo "::error::go.mod module path mismatch: expected '$EXPECTED_MODULE', got '$MODULE'"
+            exit 1
+          fi
+          echo "go.mod module path OK: $MODULE"
+
+          # Assert version is valid semver (prevent malformed tag names)
+          if ! echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?(\+[a-zA-Z0-9.]+)?$'; then
+            echo "::error::Tag version '$VERSION' is not valid semver"
+            exit 1
+          fi
+          echo "Version OK: $VERSION (semver)"
+
+      - name: Build Go SDK
+        if: steps.check_changes.outputs.changed == 'true'
+        working-directory: sdk/go
+        run: go build ./...
+
+      - name: Vet Go SDK
+        if: steps.check_changes.outputs.changed == 'true'
+        working-directory: sdk/go
+        run: go vet ./...
+
+      - name: Run Go SDK unit tests
+        if: steps.check_changes.outputs.changed == 'true'
+        working-directory: sdk/go
+        run: go test -v -short -count=1 ./...
+
+      - name: Create and push Go SDK tag
+        if: steps.check_changes.outputs.changed == 'true'
+        run: |
+          GO_SDK_TAG="sdk/go/${{ steps.extract.outputs.version }}"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          git tag -a "$GO_SDK_TAG" -m "Go SDK ${{ steps.extract.outputs.version }} — auto-generated from ${{ github.ref_name }}"
+          git push origin "$GO_SDK_TAG"
+
+          echo "Created and pushed: $GO_SDK_TAG"
+
+      - name: Summary
+        if: always()
+        run: |
+          echo "### Go SDK Publish Summary" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **Trigger tag**: \`${{ github.ref_name }}\` → version \`${{ steps.extract.outputs.version }}\`" >> "$GITHUB_STEP_SUMMARY"
+          if [[ "${{ steps.check_changes.outputs.skip }}" == "true" ]]; then
+            echo "- **Result**: Go SDK tag \`sdk/go/${{ steps.extract.outputs.version }}\` already exists" >> "$GITHUB_STEP_SUMMARY"
+          elif [[ "${{ steps.check_changes.outputs.changed }}" == "false" ]]; then
+            echo "- **Result**: Skipped (no changes in sdk/go/)" >> "$GITHUB_STEP_SUMMARY"
+          elif [[ "${{ steps.check_changes.outputs.changed }}" == "true" ]]; then
+            echo "- **Result**: ✅ \`sdk/go/${{ steps.extract.outputs.version }}\` created, build + tests passed" >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/.github/workflows/publish-go-sdk.yml
+++ b/.github/workflows/publish-go-sdk.yml
@@ -17,7 +17,7 @@ on:
 
 concurrency:
   group: go-sdk-publish-${{ github.ref_name }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   create-go-sdk-tag:
@@ -90,7 +90,7 @@ jobs:
           EXPECTED_MODULE="module github.com/tencentcloud/CubeSandbox/sdk/go"
 
           # Assert go.mod module path matches the canonical path for this SDK
-          MODULE=$(head -1 go.mod)
+          MODULE=$(head -1 go.mod | tr -d '\r')
           if [ "$MODULE" != "$EXPECTED_MODULE" ]; then
             echo "::error::go.mod module path mismatch: expected '$EXPECTED_MODULE', got '$MODULE'"
             exit 1
@@ -98,7 +98,7 @@ jobs:
           echo "go.mod module path OK: $MODULE"
 
           # Assert version is valid semver (prevent malformed tag names)
-          if ! echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?(\+[a-zA-Z0-9.]+)?$'; then
+          if ! echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.-]+)?(\+[a-zA-Z0-9.-]+)?$'; then
             echo "::error::Tag version '$VERSION' is not valid semver"
             exit 1
           fi
@@ -114,13 +114,18 @@ jobs:
         working-directory: sdk/go
         run: go vet ./...
 
+      - name: Check Go formatting
+        if: steps.check_changes.outputs.changed == 'true'
+        working-directory: sdk/go
+        run: test -z "$(gofmt -l .)"
+
       - name: Run Go SDK unit tests
         if: steps.check_changes.outputs.changed == 'true'
         working-directory: sdk/go
         run: go test -v -short -count=1 ./...
 
       - name: Create and push Go SDK tag
-        if: steps.check_changes.outputs.changed == 'true'
+        if: success() && steps.check_changes.outputs.changed == 'true'
         run: |
           GO_SDK_TAG="sdk/go/${{ steps.extract.outputs.version }}"
 
@@ -138,7 +143,9 @@ jobs:
           echo "### Go SDK Publish Summary" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
           echo "- **Trigger tag**: \`${{ github.ref_name }}\` → version \`${{ steps.extract.outputs.version }}\`" >> "$GITHUB_STEP_SUMMARY"
-          if [[ "${{ steps.check_changes.outputs.skip }}" == "true" ]]; then
+          if [[ "${{ job.status }}" == "failure" ]]; then
+            echo "- **Result**: ❌ Job failed — check logs above" >> "$GITHUB_STEP_SUMMARY"
+          elif [[ "${{ steps.check_changes.outputs.skip }}" == "true" ]]; then
             echo "- **Result**: Go SDK tag \`sdk/go/${{ steps.extract.outputs.version }}\` already exists" >> "$GITHUB_STEP_SUMMARY"
           elif [[ "${{ steps.check_changes.outputs.changed }}" == "false" ]]; then
             echo "- **Result**: Skipped (no changes in sdk/go/)" >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
Fixes #1016

Adds a GitHub Actions workflow triggered by `go-sdk-v*` tags.
When pushed, it validates the Go SDK, auto-creates the `sdk/go/v*`
tag required by Go's nested module convention, and runs unit tests.

Follows the same `*-sdk-v*` tag prefix convention as `publish-python-sdk.yml`.

Usage:
```bash
git tag go-sdk-v0.6.0 && git push origin go-sdk-v0.6.0
# Auto-creates sdk/go/v0.6.0 and runs tests
```

Also verified: all tags from v0.3.0 to v0.5.1 already contain `sdk/go/`
code but lack the corresponding `sdk/go/v*` Go module tags.
This workflow prevents the issue for future releases.
