### PR TITLE
ci(code-review): harden pull_request_target workflow and add inline comment support

### DIFF
--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -4,8 +4,9 @@ on:
   # IMPORTANT: pull_request_target makes secrets available to fork PRs.
   # SECURITY RULE: never add steps that EXECUTE code from the PR
   # (no npm install / make / cargo build / pre-commit / etc.).
-  # Claude only READS files (safe), reads PR metadata, and posts review output
-  # through the constrained scripts/gh.sh wrapper below.
+  # Checkout only the base branch (trusted root). Claude reads PR changes via
+  # gh pr diff/view and posts review output through constrained tools below.
+  # See: https://github.com/anthropics/claude-code-action/blob/main/docs/security.md
   pull_request_target:
     types: [opened, synchronize, reopened]
 
@@ -20,16 +21,14 @@ permissions:
 jobs:
   review:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout PR head for review context
         uses: actions/checkout@v6
         with:
-          # Check out the PR's HEAD so Claude can read the post-change source
-          # for richer context. SAFE only because no step below executes it.
-          ref: ${{ github.event.pull_request.head.sha }}
-          # Strip the GITHUB_TOKEN from .git/config so even an accidental
-          # git push from a future step cannot use base-repo write creds.
           persist-credentials: false
+          submodules: false
+          lfs: false
 
       - name: Generate GitHub App token
         id: app-token
@@ -37,36 +36,45 @@ jobs:
         with:
           app-id: ${{ secrets.CLAUDE_APP_ID }}
           private-key: ${{ secrets.CLAUDE_APP_PRIVATE_KEY }}
+          permission-contents: read
+          permission-pull-requests: write
 
       - uses: anthropics/claude-code-action@v1
         env:
-            ANTHROPIC_BASE_URL: https://tokenhub.tencentmaas.com
-            ANTHROPIC_MODEL: deepseek-v4-flash-202605
-            ANTHROPIC_SMALL_FAST_MODEL: deepseek-v4-flash-202605
+          ANTHROPIC_BASE_URL: https://tokenhub.tencentmaas.com
+          ANTHROPIC_MODEL: deepseek-v4-flash-202605
+          ANTHROPIC_SMALL_FAST_MODEL: deepseek-v4-flash-202605
+          CLAUDE_CODE_SCRIPT_CAPS: '{"gh.sh":3}'
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ steps.app-token.outputs.token }}
           allowed_non_write_users: "*"
+          show_full_output: true
+          classify_inline_comments: true
           prompt: |
-            /review-pr REPO: ${{ github.repository }} PR NUMBER: ${{ github.event.pull_request.number }}
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
+
+            Review this pull request. Use `gh pr diff` / `gh pr view` for changes.
+            The workspace is the base branch; do not assume PR files are checked out.
 
             Comment management requirements:
-            - Use a single top-level PR review comment for this workflow.
-            - To publish top-level PR feedback, pass the full review body to the
-              wrapper through stdin; do not write review files into the checkout:
+            - Use a single top-level sticky PR comment for this workflow.
+            - Inline issues: use mcp__github_inline_comment__create_inline_comment
+              (set confirmed: true for final review comments).
+            - To publish the sticky top-level review, pass the full body through stdin:
             ./scripts/gh.sh pr review-comment ${{ github.event.pull_request.number }} --body-file - <<'EOF'
             <!-- cubesandbox-auto-review:start -->
             ...review body...
             <!-- cubesandbox-auto-review:end -->
             EOF
-            - Wrap the review body with these exact hidden markers so future
-              runs can reliably recognize and update the same review comment:
+            - Wrap the review body with these exact hidden markers:
               <!-- cubesandbox-auto-review:start -->
               <!-- cubesandbox-auto-review:end -->
-            - Do not call `gh pr comment` or `gh api` directly for top-level
-              comments; the wrapper enforces the current PR, fixed markers, and
-              the cubesandboxbot[bot] author check before editing any comment.
-          show_full_output: true
+            - Do not call `gh pr comment` or `gh api` directly for top-level comments.
+            - Mark the review as AI-generated; do not claim human approval.
+            - Only post GitHub comments — don't submit review text as messages only.
 
           claude_args: |
-            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(./scripts/gh.sh pr review-comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr diff:*),Bash(gh pr view:*),Bash(./scripts/gh.sh pr review-comment:*)"
+            --disallowedTools "Write,Edit,NotebookEdit,Agent,WebFetch,WebSearch"


### PR DESCRIPTION
## Summary

This PR hardens the `.github/workflows/code-review.yml` security and adds inline comment capabilities to the automated code review workflow.

## Changes

- **Security**: Remove PR head sha checkout — the workspace is the trusted base branch only. Claude reads PR changes via `gh pr diff`/`gh pr view`.
- **Security**: Remove `GITHUB_TOKEN` from `.git/config` by setting `persist-credentials: false`.
- **Job timeout**: Add `timeout-minutes: 15` to prevent runaway jobs.
- **Permissions**: Restrict GitHub App token to `contents: read` and `pull-requests: write` only.
- **Inline comments**: Enable `mcp__github_inline_comment__create_inline_comment` and add `CLAUDE_CODE_SCRIPT_CAPS` env for tool capability control.
- **Tool restrictions**: Disallow `Write`, `Edit`, `NotebookEdit`, `Agent`, `WebFetch`, `WebSearch` — keeping the workflow read-only and safe.
- **Prompt refinement**: Clearer instructions for using `gh pr diff`/`gh pr view`, sticky comment markers, and inline comment posting.
- **Checkout optimization**: Disable submodules and LFS to speed up checkout.

## Motivation

This aligns with the security model documented at [claude-code-action/security.md](https://github.com/anthropics/claude-code-action/blob/main/docs/security.md) — `pull_request_target` must never execute untrusted PR code. The workflow now reads changes safely via `gh` CLI without ever checking out the PR branch.