### PR TITLE
feat: move volume plugin base dir to /data/cube-shared/volume and add shared hostPath

### DIFF
--- a/Cubelet/config/config.toml
+++ b/Cubelet/config/config.toml
@@ -100,7 +100,7 @@ dynamic_config_path = "/usr/local/services/cubetoolbox/Cubelet/dynamicconf/conf.
     data_path = "/data/cubelet/storage"
 
     # Parent directory for volume plugin host_path mounts (Attach --volume-base-dir).
-    volume_plugin_base_dir = "/data/volume"
+    volume_plugin_base_dir = "/data/cube-shared/volume"
 
     [[plugins."io.cubelet.internal.v1.storage".volume_plugins]]
       name        = "cos"

--- a/Cubelet/storage/plugin.go
+++ b/Cubelet/storage/plugin.go
@@ -44,7 +44,7 @@ const cowBackendReflink = "reflink"
 // defaultVolumePluginBaseDir is the fallback parent directory that
 // plugin_volume Attach must mount volumes under when Config.VolumePluginBaseDir
 // is not set in TOML.
-const defaultVolumePluginBaseDir = "/data/volume"
+const defaultVolumePluginBaseDir = "/data/cube-shared/volume"
 
 // reflinkExt4InitCommands lists the external commands the **cubelet
 // upper layers** need when they initialise an ext4 default-medium
@@ -118,7 +118,7 @@ type Config struct {
 	// Attach must mount its volume under. Cubelet passes this path to the
 	// plugin (AttachRequest.VolumeBaseDir / --volume-base-dir) and rejects any
 	// attach whose returned host_path is not located inside it. Defaults to
-	// defaultVolumePluginBaseDir ("/data/volume") when empty.
+	// defaultVolumePluginBaseDir ("/data/cube-shared/volume") when empty.
 	VolumePluginBaseDir string `toml:"volume_plugin_base_dir"`
 }
 

--- a/deploy/kubernetes/chart/README.md
+++ b/deploy/kubernetes/chart/README.md
@@ -543,7 +543,7 @@ Prepare a separate host-kernel rollback runbook for production.
 
 - operator-provided node labels/taints;
 - external MySQL/Redis resources;
-- hostPath data such as `/data/CubeMaster/storage`, `/data/cubelet`, `/data/cube-shim`, `/data/snapshot_pack`, and logs;
+- hostPath data such as `/data/CubeMaster/storage`, `/data/cubelet`, `/data/cube-shim`, `/data/cube-shared`, `/data/snapshot_pack`, and logs;
 - host kernel, GRUB, udev, fstab, or XFS changes made by bootstrap containers;
 - external DNS or load balancer records.
 

--- a/deploy/kubernetes/chart/README.md
+++ b/deploy/kubernetes/chart/README.md
@@ -543,7 +543,7 @@ Prepare a separate host-kernel rollback runbook for production.
 
 - operator-provided node labels/taints;
 - external MySQL/Redis resources;
-- hostPath data such as `/data/CubeMaster/storage`, `/data/cubelet`, `/data/cube-shim`, `/data/cube-shared`, `/data/snapshot_pack`, and logs;
+- hostPath data such as `/data/CubeMaster/storage`, `/data/cubelet`, `/data/cube-shim`, `/data/cube-shared`, `/data/shared`, `/data/snapshot_pack`, and logs;
 - host kernel, GRUB, udev, fstab, or XFS changes made by bootstrap containers;
 - external DNS or load balancer records.
 

--- a/deploy/kubernetes/chart/scripts/cleanup-node-host.sh
+++ b/deploy/kubernetes/chart/scripts/cleanup-node-host.sh
@@ -13,6 +13,7 @@ set -euo pipefail
 TOOLBOX_ROOT="${TOOLBOX_ROOT:-/usr/local/services/cubetoolbox}"
 DATA_CUBELET="${DATA_CUBELET:-/data/cubelet}"
 DATA_CUBE_SHIM="${DATA_CUBE_SHIM:-/data/cube-shim}"
+DATA_CUBE_SHARED="${DATA_CUBE_SHARED:-/data/cube-shared}"
 TMP_CUBE="${TMP_CUBE:-/tmp/cube}"
 BOOTSTRAP_STATE="${BOOTSTRAP_STATE:-/var/lib/cube-node-bootstrap}"
 DRY_RUN="${DRY_RUN:-0}"
@@ -35,8 +36,8 @@ run "rm -rf '${TOOLBOX_ROOT}'"
 log "removing bootstrap state ${BOOTSTRAP_STATE}"
 run "rm -rf '${BOOTSTRAP_STATE}'"
 
-log "removing data dirs ${DATA_CUBELET} ${DATA_CUBE_SHIM} ${TMP_CUBE}"
-run "rm -rf '${DATA_CUBELET}' '${DATA_CUBE_SHIM}' '${TMP_CUBE}'"
+log "removing data dirs ${DATA_CUBELET} ${DATA_CUBE_SHIM} ${DATA_CUBE_SHARED} ${TMP_CUBE}"
+run "rm -rf '${DATA_CUBELET}' '${DATA_CUBE_SHIM}' '${DATA_CUBE_SHARED}' '${TMP_CUBE}'"
 run "rm -rf /data/cubelet-xfs.img /data/log/Cubelet /data/log/CubeShim /data/log/CubeVmm /data/snapshot_pack || true"
 
 # Best-effort residual dataplane cleanup (safe if devices/rules absent).

--- a/deploy/kubernetes/chart/templates/_helpers.tpl
+++ b/deploy/kubernetes/chart/templates/_helpers.tpl
@@ -655,6 +655,9 @@ Toolbox is mounted whole at the fixed path.
 - name: data-cube-shared
   mountPath: {{ .Values.hostPaths.dataCubeShared }}
   mountPropagation: Bidirectional
+- name: data-shared
+  mountPath: {{ .Values.hostPaths.dataShared }}
+  mountPropagation: Bidirectional
 - name: tmp-cube
   mountPath: {{ .Values.hostPaths.tmpCube }}
   mountPropagation: Bidirectional
@@ -748,6 +751,9 @@ Bootstrap: host mutation mounts for pvm / node-init.
 - name: data-cube-shared
   mountPath: {{ .Values.hostPaths.dataCubeShared }}
   mountPropagation: Bidirectional
+- name: data-shared
+  mountPath: {{ .Values.hostPaths.dataShared }}
+  mountPropagation: Bidirectional
 - name: tmp-cube
   mountPath: {{ .Values.hostPaths.tmpCube }}
   mountPropagation: Bidirectional
@@ -789,6 +795,10 @@ Bootstrap: host mutation mounts for pvm / node-init.
 - name: data-cube-shared
   hostPath:
     path: {{ .Values.hostPaths.dataCubeShared }}
+    type: DirectoryOrCreate
+- name: data-shared
+  hostPath:
+    path: {{ .Values.hostPaths.dataShared }}
     type: DirectoryOrCreate
 - name: tmp-cube
   hostPath:

--- a/deploy/kubernetes/chart/templates/_helpers.tpl
+++ b/deploy/kubernetes/chart/templates/_helpers.tpl
@@ -652,6 +652,9 @@ Toolbox is mounted whole at the fixed path.
   mountPropagation: Bidirectional
 - name: data-snapshot-pack
   mountPath: {{ .Values.hostPaths.dataSnapshotPack }}
+- name: data-cube-shared
+  mountPath: {{ .Values.hostPaths.dataCubeShared }}
+  mountPropagation: Bidirectional
 - name: tmp-cube
   mountPath: {{ .Values.hostPaths.tmpCube }}
   mountPropagation: Bidirectional
@@ -742,6 +745,9 @@ Bootstrap: host mutation mounts for pvm / node-init.
   mountPropagation: Bidirectional
 - name: data-snapshot-pack
   mountPath: {{ .Values.hostPaths.dataSnapshotPack }}
+- name: data-cube-shared
+  mountPath: {{ .Values.hostPaths.dataCubeShared }}
+  mountPropagation: Bidirectional
 - name: tmp-cube
   mountPath: {{ .Values.hostPaths.tmpCube }}
   mountPropagation: Bidirectional
@@ -779,6 +785,10 @@ Bootstrap: host mutation mounts for pvm / node-init.
 - name: data-snapshot-pack
   hostPath:
     path: {{ .Values.hostPaths.dataSnapshotPack }}
+    type: DirectoryOrCreate
+- name: data-cube-shared
+  hostPath:
+    path: {{ .Values.hostPaths.dataCubeShared }}
     type: DirectoryOrCreate
 - name: tmp-cube
   hostPath:

--- a/deploy/kubernetes/chart/templates/node-daemonset.yaml
+++ b/deploy/kubernetes/chart/templates/node-daemonset.yaml
@@ -328,6 +328,10 @@ spec:
           hostPath:
             path: {{ .Values.hostPaths.dataSnapshotPack }}
             type: DirectoryOrCreate
+        - name: data-cube-shared
+          hostPath:
+            path: {{ .Values.hostPaths.dataCubeShared }}
+            type: DirectoryOrCreate
         - name: tmp-cube
           hostPath:
             path: {{ .Values.hostPaths.tmpCube }}

--- a/deploy/kubernetes/chart/templates/node-daemonset.yaml
+++ b/deploy/kubernetes/chart/templates/node-daemonset.yaml
@@ -332,6 +332,10 @@ spec:
           hostPath:
             path: {{ .Values.hostPaths.dataCubeShared }}
             type: DirectoryOrCreate
+        - name: data-shared
+          hostPath:
+            path: {{ .Values.hostPaths.dataShared }}
+            type: DirectoryOrCreate
         - name: tmp-cube
           hostPath:
             path: {{ .Values.hostPaths.tmpCube }}

--- a/deploy/kubernetes/chart/values.yaml
+++ b/deploy/kubernetes/chart/values.yaml
@@ -918,6 +918,10 @@ hostPaths:
   dataLog: /data/log
   dataCubeShim: /data/cube-shim
   dataSnapshotPack: /data/snapshot_pack
+  # Host tree shared across compute-node Cube components (same path in Big Pod).
+  # Current use: volume plugin base dir at <dataCubeShared>/volume; more shared
+  # subdirs may land here later.
+  dataCubeShared: /data/cube-shared
   tmpCube: /tmp/cube
   # pvm/node-init state + node-prep-ready / pvm-host-ready / effective-pvm
   # (shared by cube-node-pvm, bootstrap DS, and Big Pod wait-node-prep).

--- a/deploy/kubernetes/chart/values.yaml
+++ b/deploy/kubernetes/chart/values.yaml
@@ -922,6 +922,9 @@ hostPaths:
   # Current use: volume plugin base dir at <dataCubeShared>/volume; more shared
   # subdirs may land here later.
   dataCubeShared: /data/cube-shared
+  # Default CubeMaster allowed_host_mount_prefixes path. Must be visible inside
+  # the Big Pod mount namespace so metadata["host-mount"] can bind host dirs.
+  dataShared: /data/shared
   tmpCube: /tmp/cube
   # pvm/node-init state + node-prep-ready / pvm-host-ready / effective-pvm
   # (shared by cube-node-pvm, bootstrap DS, and Big Pod wait-node-prep).

--- a/deploy/kubernetes/images/build-cube-images.sh
+++ b/deploy/kubernetes/images/build-cube-images.sh
@@ -737,6 +737,14 @@ build_component_image() {
     # Inject single-source installer (deploy/scripts/docker-install-volume-deps.sh).
     cp "${REPO_ROOT}/deploy/scripts/docker-install-volume-deps.sh" "${ctx}/docker-install-volume-deps.sh"
     chmod +x "${ctx}/docker-install-volume-deps.sh"
+    # Prefer in-tree Cubelet config so image builds pick up worktree defaults
+    # (e.g. volume_plugin_base_dir) instead of only the release package snapshot.
+    if [[ -f "${REPO_ROOT}/Cubelet/config/config.toml" ]]; then
+      mkdir -p "${ctx}/package/${pkg_basename}/config"
+      cp "${REPO_ROOT}/Cubelet/config/config.toml" \
+        "${ctx}/package/${pkg_basename}/config/config.toml"
+      log "overlay Cubelet config.toml from worktree"
+    fi
   fi
   build_image "${name}" "${ctx}" \
     --build-arg "CUBE_VERSION=${IMAGE_TAG}" \

--- a/deploy/kubernetes/images/scripts/cube-node-init.sh
+++ b/deploy/kubernetes/images/scripts/cube-node-init.sh
@@ -340,6 +340,7 @@ if [ "$CREATE_HOST_DIRS" = "true" ]; then
     "$(host_path /data/snapshot_pack)" \
     "$(host_path /data/cube-shared)" \
     "$(host_path /data/cube-shared/volume)" \
+    "$(host_path /data/shared)" \
     "$(host_path /tmp/cube)"
 fi
 

--- a/deploy/kubernetes/images/scripts/cube-node-init.sh
+++ b/deploy/kubernetes/images/scripts/cube-node-init.sh
@@ -338,6 +338,8 @@ if [ "$CREATE_HOST_DIRS" = "true" ]; then
     "$(host_path /data/log)" \
     "$(host_path /data/cube-shim)" \
     "$(host_path /data/snapshot_pack)" \
+    "$(host_path /data/cube-shared)" \
+    "$(host_path /data/cube-shared/volume)" \
     "$(host_path /tmp/cube)"
 fi
 

--- a/deploy/one-click/install.sh
+++ b/deploy/one-click/install.sh
@@ -1068,7 +1068,8 @@ mkdir -p \
   /data/log/CubeVmm \
   /data/cube-shim/disks \
   /data/snapshot_pack/disks \
-  /data/volume
+  /data/cube-shared \
+  /data/cube-shared/volume
 
 if [[ "${DEPLOY_ROLE}" != "compute" ]]; then
   mkdir -p \

--- a/deploy/one-click/install.sh
+++ b/deploy/one-click/install.sh
@@ -1069,7 +1069,8 @@ mkdir -p \
   /data/cube-shim/disks \
   /data/snapshot_pack/disks \
   /data/cube-shared \
-  /data/cube-shared/volume
+  /data/cube-shared/volume \
+  /data/shared
 
 if [[ "${DEPLOY_ROLE}" != "compute" ]]; then
   mkdir -p \

--- a/deploy/one-click/scripts/one-click/up-compute.sh
+++ b/deploy/one-click/scripts/one-click/up-compute.sh
@@ -46,7 +46,9 @@ mkdir -p \
   /data/log/CubeShim \
   /data/log/CubeVmm \
   /data/cube-shim/disks \
-  /data/snapshot_pack/disks
+  /data/snapshot_pack/disks \
+  /data/cube-shared \
+  /data/cube-shared/volume
 
 "${SCRIPT_DIR}/down-compute.sh" >/dev/null 2>&1 || true
 

--- a/deploy/one-click/scripts/one-click/up-compute.sh
+++ b/deploy/one-click/scripts/one-click/up-compute.sh
@@ -48,7 +48,8 @@ mkdir -p \
   /data/cube-shim/disks \
   /data/snapshot_pack/disks \
   /data/cube-shared \
-  /data/cube-shared/volume
+  /data/cube-shared/volume \
+  /data/shared
 
 "${SCRIPT_DIR}/down-compute.sh" >/dev/null 2>&1 || true
 

--- a/deploy/one-click/scripts/systemd/cubelet-start.sh
+++ b/deploy/one-click/scripts/systemd/cubelet-start.sh
@@ -29,7 +29,9 @@ mkdir -p \
   /data/log/CubeShim \
   /data/log/CubeVmm \
   /data/cube-shim/disks \
-  /data/snapshot_pack/disks
+  /data/snapshot_pack/disks \
+  /data/cube-shared \
+  /data/cube-shared/volume
 
 if [[ -f "${PID_FILE}" ]]; then
   existing_pid="$(<"${PID_FILE}")"

--- a/docs/guide/kubernetes/faq.md
+++ b/docs/guide/kubernetes/faq.md
@@ -399,7 +399,7 @@ Typical Big Pod recreate triggers: bump `images.cubelet` and other runtime image
 By design. Uninstall only deletes Chart-managed objects. Common leftovers on compute nodes:
 
 ```bash
-sudo rm -rf /data/cubelet /data/cube-shim /data/snapshot_pack \
+sudo rm -rf /data/cubelet /data/cube-shim /data/cube-shared /data/snapshot_pack \
   /data/log/Cubelet /data/log/CubeShim /data/log/CubeVmm \
   /usr/local/services/cubetoolbox /var/lib/cube-node-bootstrap /tmp/cube \
   /data/cubelet-xfs.img

--- a/docs/guide/kubernetes/install.md
+++ b/docs/guide/kubernetes/install.md
@@ -270,7 +270,7 @@ kubectl delete namespace cube-system
 Uninstall **does not** automatically clean up:
 
 - Cube labels / role taints on nodes
-- Compute-node hostPath data (e.g. `/data/cubelet`, `/usr/local/services/cubetoolbox`, etc.)
+- Compute-node hostPath data (e.g. `/data/cubelet`, `/data/cube-shared`, `/usr/local/services/cubetoolbox`, etc.)
 - PVM host kernel changes (roll back per platform runbook)
 - External MySQL / Redis, DNS / LB records
 

--- a/docs/guide/volume-plugin.md
+++ b/docs/guide/volume-plugin.md
@@ -228,7 +228,7 @@ Output (stdout JSON, exit 0):
 
 - `refCount == 0`: **first attach on this node** — perform backend mount.
 - `refCount > 0`: **another sandbox on this node** already references the volume — return existing `hostPath` (+ `metadata`); do not mount again.
-- **`hostPath`:** absolute path under `volumeBaseDir` (recommended `<volumeBaseDir>/<plugin-name>-<volumeID>`). Otherwise Cubelet rejects attach, rolls back, and fails sandbox create. Default `volumeBaseDir`: `/data/volume`.
+- **`hostPath`:** absolute path under `volumeBaseDir` (recommended `<volumeBaseDir>/<plugin-name>-<volumeID>`). Otherwise Cubelet rejects attach, rolls back, and fails sandbox create. Default `volumeBaseDir`: `/data/cube-shared/volume`.
 
 **binary example**
 
@@ -238,7 +238,7 @@ Input (CLI):
 /path/to/my-plugin --op attach \
   --sandbox-id sb-001 --namespace default \
   --volume-id my-vol --ref-count 0 \
-  --volume-base-dir /data/volume
+  --volume-base-dir /data/cube-shared/volume
 # optional when Create returned non-empty private_data:
 #   --private-data 'volumes/my-vol/'
 ```
@@ -246,7 +246,7 @@ Input (CLI):
 Output (stdout JSON, exit 0):
 
 ```json
-{"host_path":"/data/volume/my-storage-my-vol","metadata":{"mount_dir":"/data/volume/my-storage-my-vol"},"error":""}
+{"host_path":"/data/cube-shared/volume/my-storage-my-vol","metadata":{"mount_dir":"/data/cube-shared/volume/my-storage-my-vol"},"error":""}
 ```
 
 #### Detach
@@ -271,7 +271,7 @@ Input (CLI):
 /path/to/my-plugin --op detach \
   --sandbox-id sb-001 --namespace default \
   --volume-id my-vol --ref-count 0 \
-  --metadata '{"mount_dir":"/data/volume/my-storage-my-vol"}'
+  --metadata '{"mount_dir":"/data/cube-shared/volume/my-storage-my-vol"}'
 ```
 
 Output (stdout JSON, exit 0):
@@ -511,7 +511,7 @@ volume_plugins:
 
 **`driver` name must be consistent end-to-end:** `Volume.create(..., driver=...)` (or first list entry when omitted) → DB → annotations → Cubelet routes by the same `name`. CubeMaster and Cubelet **`volume_plugins[].name` must match**.
 
-**`volume_plugin_base_dir`:** every plugin `host_path` **must** be under this directory (default `/data/volume` when unset). Cubelet passes it to plugins as `volumeBaseDir` (rpc) / `--volume-base-dir` (binary) and rejects attach if `host_path` is outside it.
+**`volume_plugin_base_dir`:** every plugin `host_path` **must** be under this directory (default `/data/cube-shared/volume` when unset). Cubelet passes it to plugins as `volumeBaseDir` (rpc) / `--volume-base-dir` (binary) and rejects attach if `host_path` is outside it.
 
 **`name` must be unique** within each process: no two `volume_plugins` entries with the same `name`. List order sets the default plugin when API/SDK omits `driver`.
 
@@ -596,7 +596,7 @@ Replace `/path/to/my-plugin` and `my-storage` with your plugin binary and config
 /path/to/my-plugin \
   --op attach --sandbox-id sb-001 --namespace default \
   --volume-id test-vol --ref-count 0 \
-  --volume-base-dir /data/volume
+  --volume-base-dir /data/cube-shared/volume
 ```
 
 For COS-specific manual tests, see [`examples/volume/cos/README.md`](https://github.com/TencentCloud/CubeSandbox/blob/master/examples/volume/cos/README.md).

--- a/docs/zh/guide/kubernetes/faq.md
+++ b/docs/zh/guide/kubernetes/faq.md
@@ -399,7 +399,7 @@ kubectl -n cube-system logs <cube-node-pod> -c cube-egress-net --tail=100
 设计如此。卸载只删 Chart 管理的对象。计算节点上常见残留：
 
 ```bash
-sudo rm -rf /data/cubelet /data/cube-shim /data/snapshot_pack \
+sudo rm -rf /data/cubelet /data/cube-shim /data/cube-shared /data/snapshot_pack \
   /data/log/Cubelet /data/log/CubeShim /data/log/CubeVmm \
   /usr/local/services/cubetoolbox /var/lib/cube-node-bootstrap /tmp/cube \
   /data/cubelet-xfs.img

--- a/docs/zh/guide/kubernetes/install.md
+++ b/docs/zh/guide/kubernetes/install.md
@@ -271,7 +271,7 @@ kubectl delete namespace cube-system
 卸载**不会**自动清理：
 
 - 节点上的 Cube 标签 / 角色污点
-- 计算节点 hostPath 数据（如 `/data/cubelet`、`/usr/local/services/cubetoolbox` 等）
+- 计算节点 hostPath 数据（如 `/data/cubelet`、`/data/cube-shared`、`/usr/local/services/cubetoolbox` 等）
 - PVM 宿主机内核改动（需按平台 runbook 回滚）
 - 外部 MySQL / Redis、DNS / LB 记录
 

--- a/docs/zh/guide/volume-plugin.md
+++ b/docs/zh/guide/volume-plugin.md
@@ -228,7 +228,7 @@ flowchart LR
 
 - `refCount == 0`：**本 node 首次挂载** — 执行后端挂载。
 - `refCount > 0`：**本 node 已有沙箱引用该 Volume** — 返回已有 `hostPath`（及 `metadata`），不要再次挂载。
-- **`hostPath`：** 位于 `volumeBaseDir` 下的绝对路径（推荐 `<volumeBaseDir>/<插件名>-<volumeID>`）。否则 Cubelet 拒绝 attach、回滚并导致沙箱创建失败。默认 `volumeBaseDir`：`/data/volume`。
+- **`hostPath`：** 位于 `volumeBaseDir` 下的绝对路径（推荐 `<volumeBaseDir>/<插件名>-<volumeID>`）。否则 Cubelet 拒绝 attach、回滚并导致沙箱创建失败。默认 `volumeBaseDir`：`/data/cube-shared/volume`。
 
 **binary 示例**
 
@@ -238,7 +238,7 @@ flowchart LR
 /path/to/my-plugin --op attach \
   --sandbox-id sb-001 --namespace default \
   --volume-id my-vol --ref-count 0 \
-  --volume-base-dir /data/volume
+  --volume-base-dir /data/cube-shared/volume
 # Create 返回非空 private_data 时可选附加：
 #   --private-data 'volumes/my-vol/'
 ```
@@ -246,7 +246,7 @@ flowchart LR
 输出（stdout JSON，exit 0）：
 
 ```json
-{"host_path":"/data/volume/my-storage-my-vol","metadata":{"mount_dir":"/data/volume/my-storage-my-vol"},"error":""}
+{"host_path":"/data/cube-shared/volume/my-storage-my-vol","metadata":{"mount_dir":"/data/cube-shared/volume/my-storage-my-vol"},"error":""}
 ```
 
 #### Detach
@@ -271,7 +271,7 @@ flowchart LR
 /path/to/my-plugin --op detach \
   --sandbox-id sb-001 --namespace default \
   --volume-id my-vol --ref-count 0 \
-  --metadata '{"mount_dir":"/data/volume/my-storage-my-vol"}'
+  --metadata '{"mount_dir":"/data/cube-shared/volume/my-storage-my-vol"}'
 ```
 
 输出（stdout JSON，exit 0）：
@@ -509,7 +509,7 @@ volume_plugins:
 
 **`driver` 名须全链路一致：** `Volume.create(..., driver=...)`（省略则取列表第一项）→ 写入 DB → annotation → Cubelet 按同名路由。CubeMaster 与 Cubelet 的 **`volume_plugins[].name` 必须一致**。
 
-**`volume_plugin_base_dir`：** 所有插件返回的 `host_path` **必须**落在该目录内（未配置时默认 `/data/volume`）。Cubelet 经 `volumeBaseDir`（rpc）/ `--volume-base-dir`（binary）传给插件；`host_path` 越界则 attach 被拒绝并回滚。
+**`volume_plugin_base_dir`：** 所有插件返回的 `host_path` **必须**落在该目录内（未配置时默认 `/data/cube-shared/volume`）。Cubelet 经 `volumeBaseDir`（rpc）/ `--volume-base-dir`（binary）传给插件；`host_path` 越界则 attach 被拒绝并回滚。
 
 **`name` 必须唯一**：同一进程内不能有两条相同 `name` 的 `volume_plugins`。列表顺序决定省略 `driver` 时的默认插件。
 
@@ -594,7 +594,7 @@ nsenter -t "$CPID" -m -- mount | grep -E 'volume|fuse'
 /path/to/my-plugin \
   --op attach --sandbox-id sb-001 --namespace default \
   --volume-id test-vol --ref-count 0 \
-  --volume-base-dir /data/volume
+  --volume-base-dir /data/cube-shared/volume
 ```
 
 COS 插件的手动测试命令见 [`examples/volume/cos/README.zh.md`](https://github.com/TencentCloud/CubeSandbox/blob/master/examples/volume/cos/README.zh.md)。

--- a/examples/volume/cos/README.md
+++ b/examples/volume/cos/README.md
@@ -163,7 +163,7 @@ Required fields in `volume-cos.conf`:
 | `BUCKET` | `BucketName-APPID` | `mybucket-1250000000` |
 | `REGION` | Region | `ap-guangzhou` |
 
-Mount base directory is **not** in this file — Cubelet passes it on attach (default `/data/volume`; see [§4](#4-configure-cubelet)).
+Mount base directory is **not** in this file — Cubelet passes it on attach (default `/data/cube-shared/volume`; see [§4](#4-configure-cubelet)).
 
 ---
 
@@ -191,11 +191,11 @@ Save and restart together with Cubelet ([§5](#5-restart-services-and-verify)).
 
 Edit Cubelet config (common path: `/usr/local/services/cubetoolbox/Cubelet/config/config.toml`).
 
-Under `[plugins."io.cubelet.internal.v1.storage"]`, confirm mount parent (optional; default `/data/volume`):
+Under `[plugins."io.cubelet.internal.v1.storage"]`, confirm mount parent (optional; default `/data/cube-shared/volume`):
 
 ```toml
 [plugins."io.cubelet.internal.v1.storage"]
-  volume_plugin_base_dir = "/data/volume"
+  volume_plugin_base_dir = "/data/cube-shared/volume"
 ```
 
 Add the **Node** plugin (Attach / Detach):
@@ -208,7 +208,7 @@ Add the **Node** plugin (Attach / Detach):
 ```
 
 **`name` must match CubeMaster** (both `cos` here).  
-Plugin `host_path` must be under `volume_plugin_base_dir` (example script uses `/data/volume/cos-<volumeID>`).
+Plugin `host_path` must be under `volume_plugin_base_dir` (example script uses `/data/cube-shared/volume/cos-<volumeID>`).
 
 ---
 
@@ -246,8 +246,8 @@ Expected (binary example):
   --namespace default \
   --volume-id test-vol \
   --ref-count 0 \
-  --volume-base-dir /data/volume
-# Success: one JSON line on stdout with "host_path":"/data/volume/cos-test-vol", "error":""
+  --volume-base-dir /data/cube-shared/volume
+# Success: one JSON line on stdout with "host_path":"/data/cube-shared/volume/cos-test-vol", "error":""
 ```
 
 ---
@@ -373,7 +373,7 @@ More: [Framework §8 Troubleshooting](../../docs/guide/volume-plugin.md#8-debugg
 <bucket>/volumes/<volumeID>/   ← one directory per Volume
 ```
 
-Attach mounts cosfs to `/data/volume/cos-<volumeID>/` on the host, then virtiofs into the sandbox.
+Attach mounts cosfs to `/data/cube-shared/volume/cos-<volumeID>/` on the host, then virtiofs into the sandbox.
 
 ### Hook behavior (RefCount)
 

--- a/examples/volume/cos/README.zh.md
+++ b/examples/volume/cos/README.zh.md
@@ -161,7 +161,7 @@ sudo install -m 0600 examples/volume/cos/volume-cos.conf.example \
 | `BUCKET` | `BucketName-APPID` | `mybucket-1250000000` |
 | `REGION` | 地域 | `ap-guangzhou` |
 
-挂载基目录**不在此文件配置**——由 Cubelet 在 attach 时传入（默认 `/data/volume`，见 [§4](#4-配置-cubelet)）。
+挂载基目录**不在此文件配置**——由 Cubelet 在 attach 时传入（默认 `/data/cube-shared/volume`，见 [§4](#4-配置-cubelet)）。
 
 ---
 
@@ -189,11 +189,11 @@ volume_plugins:
 
 编辑 Cubelet 配置（常见路径：`/usr/local/services/cubetoolbox/Cubelet/config/config.toml`）。
 
-在 `[plugins."io.cubelet.internal.v1.storage"]` 段中确认挂载父目录（可选，默认已是 `/data/volume`）：
+在 `[plugins."io.cubelet.internal.v1.storage"]` 段中确认挂载父目录（可选，默认已是 `/data/cube-shared/volume`）：
 
 ```toml
 [plugins."io.cubelet.internal.v1.storage"]
-  volume_plugin_base_dir = "/data/volume"
+  volume_plugin_base_dir = "/data/cube-shared/volume"
 ```
 
 在同一段下增加 **Node** 侧插件（Attach / Detach）：
@@ -206,7 +206,7 @@ volume_plugins:
 ```
 
 **两侧 `name` 必须与 CubeMaster 一致**（此处均为 `cos`）。  
-插件返回的 `host_path` 必须是 `volume_plugin_base_dir` 下的子路径（示例脚本挂载为 `/data/volume/cos-<volumeID>`）。
+插件返回的 `host_path` 必须是 `volume_plugin_base_dir` 下的子路径（示例脚本挂载为 `/data/cube-shared/volume/cos-<volumeID>`）。
 
 ---
 
@@ -245,8 +245,8 @@ grep -aF '[plugin_volume] initialized' /data/log/Cubelet/Cubelet-req.log | tail 
   --namespace default \
   --volume-id test-vol \
   --ref-count 0 \
-  --volume-base-dir /data/volume
-# 成功时 stdout 一行 JSON，含 "host_path":"/data/volume/cos-test-vol", "error":""
+  --volume-base-dir /data/cube-shared/volume
+# 成功时 stdout 一行 JSON，含 "host_path":"/data/cube-shared/volume/cos-test-vol", "error":""
 ```
 
 ---
@@ -372,7 +372,7 @@ python3 verify_volume.py
 <bucket>/volumes/<volumeID>/   ← 每个 Volume 一个目录
 ```
 
-Attach 时 cosfs 挂到宿主机 `/data/volume/cos-<volumeID>/`，再经 virtiofs 进沙箱。
+Attach 时 cosfs 挂到宿主机 `/data/cube-shared/volume/cos-<volumeID>/`，再经 virtiofs 进沙箱。
 
 ### Hook 行为（RefCount）
 

--- a/examples/volume/cos/binary/README.md
+++ b/examples/volume/cos/binary/README.md
@@ -104,7 +104,7 @@ SECRET_ID=AKIDxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 SECRET_KEY=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 BUCKET=mybucket-1250000000
 REGION=ap-guangzhou
-# Mount path comes from Cubelet --volume-base-dir (default /data/volume/cos-<id>).
+# Mount path comes from Cubelet --volume-base-dir (default /data/cube-shared/volume/cos-<id>).
 EOF
 sudo chmod 600 "$PREFIX/CubeMaster/plugin/volume-cos.conf"
 # On Cubelet node, edit $PREFIX/Cubelet/plugin/volume-cos.conf similarly
@@ -117,7 +117,7 @@ sudo chmod 600 "$PREFIX/CubeMaster/plugin/volume-cos.conf"
 | `BUCKET` | COS bucket `BucketName-APPID` | `mybucket-1250000000` |
 | `REGION` | Region | `ap-guangzhou` |
 
-Mount path is passed as `--volume-base-dir` (`volume_plugin_base_dir`, default `/data/volume`). `host_path` must be under it, e.g. `/data/volume/cos-<id>`.
+Mount path is passed as `--volume-base-dir` (`volume_plugin_base_dir`, default `/data/cube-shared/volume`). `host_path` must be under it, e.g. `/data/cube-shared/volume/cos-<id>`.
 
 > **Security:** Prefer a sub-account key with bucket read/write only.
 
@@ -350,10 +350,10 @@ ensure_passwd_file() {
   --namespace default \
   --volume-id my-vol \
   --ref-count 0 \
-  --volume-base-dir /data/volume
+  --volume-base-dir /data/cube-shared/volume
 
 CPID=$(pgrep -f "cubelet --config" | head -1)
-nsenter -t $CPID -m -- mountpoint /data/volume/cos-my-vol
+nsenter -t $CPID -m -- mountpoint /data/cube-shared/volume/cos-my-vol
 ```
 
 ### Manual detach
@@ -365,7 +365,7 @@ nsenter -t $CPID -m -- mountpoint /data/volume/cos-my-vol
   --namespace default \
   --volume-id my-vol \
   --ref-count 0 \
-  --metadata '{"mount_dir":"/data/volume/cos-my-vol"}'
+  --metadata '{"mount_dir":"/data/cube-shared/volume/cos-my-vol"}'
 ```
 
 ### Plugin logs

--- a/examples/volume/cos/binary/README.zh.md
+++ b/examples/volume/cos/binary/README.zh.md
@@ -102,7 +102,7 @@ SECRET_ID=AKIDxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 SECRET_KEY=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 BUCKET=mybucket-1250000000
 REGION=ap-guangzhou
-# 挂载路径由 Cubelet 的 --volume-base-dir 决定（默认 /data/volume/cos-<id>），无需在此配置。
+# 挂载路径由 Cubelet 的 --volume-base-dir 决定（默认 /data/cube-shared/volume/cos-<id>），无需在此配置。
 EOF
 sudo chmod 600 "$PREFIX/CubeMaster/plugin/volume-cos.conf"
 # Cubelet 节点同样编辑 $PREFIX/Cubelet/plugin/volume-cos.conf
@@ -117,7 +117,7 @@ sudo chmod 600 "$PREFIX/CubeMaster/plugin/volume-cos.conf"
 | `BUCKET` | COS bucket，格式 `BucketName-APPID` | `mybucket-1250000000` |
 | `REGION` | COS 地域 | `ap-guangzhou` |
 
-挂载路径由 Cubelet 在 attach 时传入 `--volume-base-dir`（配置项 `volume_plugin_base_dir`，默认 `/data/volume`），插件返回的 `host_path` 须在其下，例如 `/data/volume/cos-<id>`。
+挂载路径由 Cubelet 在 attach 时传入 `--volume-base-dir`（配置项 `volume_plugin_base_dir`，默认 `/data/cube-shared/volume`），插件返回的 `host_path` 须在其下，例如 `/data/cube-shared/volume/cos-<id>`。
 
 > **安全建议**：建议使用仅拥有该 bucket 读写权限的子账号密钥，避免使用主账号密钥。
 
@@ -288,7 +288,7 @@ do_destroy() {
 ```bash
 do_attach() {
     local sandbox_id="$1" volume_id="$2" ref_count="$3"
-    # VOLUME_BASE_DIR comes from --volume-base-dir (default /data/volume)
+    # VOLUME_BASE_DIR comes from --volume-base-dir (default /data/cube-shared/volume)
 
     load_config                          # Step 1: read COS credentials
     ensure_passwd_file                   # Step 2: write /etc/cube/.passwd-cosfs for cosfs
@@ -298,7 +298,7 @@ do_attach() {
 
     cosfs_mount_volume "$volume_id"      # Step 4: mount BUCKET:/volumes/<id> (skip if already up)
 
-    local mnt="$(volume_mountpoint "$volume_id")"   # e.g. /data/volume/cos-my-vol
+    local mnt="$(volume_mountpoint "$volume_id")"   # e.g. /data/cube-shared/volume/cos-my-vol
 
     # Step 5: return host_path; Cubelet bind-mounts it into the sandbox
     jq -cn --arg path "$mnt" --arg vid "$volume_id" \
@@ -358,13 +358,13 @@ ensure_passwd_file() {
   --namespace default \
   --volume-id my-vol \
   --ref-count 0 \
-  --volume-base-dir /data/volume
-# → {"host_path":"/data/volume/cos-my-vol","metadata":{...},"error":""}
+  --volume-base-dir /data/cube-shared/volume
+# → {"host_path":"/data/cube-shared/volume/cos-my-vol","metadata":{...},"error":""}
 
 # 验证挂载（在 Cubelet mntns 里）
 CPID=$(pgrep -f "cubelet --config" | head -1)
-nsenter -t $CPID -m -- mountpoint /data/volume/cos-my-vol
-# → /data/volume/cos-my-vol is a mountpoint
+nsenter -t $CPID -m -- mountpoint /data/cube-shared/volume/cos-my-vol
+# → /data/cube-shared/volume/cos-my-vol is a mountpoint
 ```
 
 ### 手动测试 detach
@@ -376,7 +376,7 @@ nsenter -t $CPID -m -- mountpoint /data/volume/cos-my-vol
   --namespace default \
   --volume-id my-vol \
   --ref-count 0 \
-  --metadata '{"mount_dir":"/data/volume/cos-my-vol"}'
+  --metadata '{"mount_dir":"/data/cube-shared/volume/cos-my-vol"}'
 # → {"error":""}
 ```
 

--- a/examples/volume/cos/binary/cube-volume-cos.sh
+++ b/examples/volume/cos/binary/cube-volume-cos.sh
@@ -26,7 +26,7 @@
 #   REGION=ap-guangzhou
 #
 # The FUSE mount path is not configured here: Cubelet passes it on attach via
-# --volume-base-dir (default /data/volume) and the plugin mounts at
+# --volume-base-dir (default /data/cube-shared/volume) and the plugin mounts at
 # <volume-base-dir>/cos-<volume_id>.
 #
 # chmod 600 <plugin-dir>/volume-cos.conf
@@ -46,7 +46,7 @@
 # Mount layout (one cosfs process per volume):
 #   <volume-base-dir>/cos-<volume_id>/  →  BUCKET:/volumes/<volume_id>/
 #   where <volume-base-dir> is passed by Cubelet via --volume-base-dir
-#   (default /data/volume). host_path MUST live inside it.
+#   (default /data/cube-shared/volume). host_path MUST live inside it.
 #
 # Locking: per-volume flock on /run/cube-volume-cos/<volume_id>.lock
 # ensures concurrent attach/detach for the same volume is serialised.
@@ -64,9 +64,9 @@ LOCK_DIR="/run/cube-volume-cos"
 PASSWD_FILE="/etc/cube/.passwd-cosfs"
 
 # Parent directory Cubelet requires cosfs mounts to live under.
-# Cubelet passes --volume-base-dir on attach (default /data/volume).
+# Cubelet passes --volume-base-dir on attach (default /data/cube-shared/volume).
 # Each volume gets its own subdir: <volume-base-dir>/cos-<volume_id>.
-VOLUME_BASE_DIR="/data/volume"
+VOLUME_BASE_DIR="/data/cube-shared/volume"
 
 # Read SECRET_ID, SECRET_KEY, BUCKET, REGION from the config file.
 load_config() {

--- a/examples/volume/cos/binary/volume-cos.conf.example
+++ b/examples/volume/cos/binary/volume-cos.conf.example
@@ -15,5 +15,5 @@ BUCKET=mybucket-1250000000
 REGION=ap-guangzhou
 
 # FUSE mount base: Cubelet passes --volume-base-dir on attach
-# (volume_plugin_base_dir, default /data/volume). host_path must be under it,
-# e.g. /data/volume/cos-<volume_id>.
+# (volume_plugin_base_dir, default /data/cube-shared/volume). host_path must be under it,
+# e.g. /data/cube-shared/volume/cos-<volume_id>.

--- a/examples/volume/cos/rpc/internal/config/config.go
+++ b/examples/volume/cos/rpc/internal/config/config.go
@@ -13,7 +13,7 @@ import (
 
 // DefaultVolumeBaseDir mirrors Cubelet's default parent directory, used when
 // AttachRequest.VolumeBaseDir is empty (older Cubelet).
-const DefaultVolumeBaseDir = "/data/volume"
+const DefaultVolumeBaseDir = "/data/cube-shared/volume"
 
 // Config holds COS credentials and mount settings for the plugin.
 type Config struct {

--- a/examples/volume/cos/rpc/volume-cos.conf.example
+++ b/examples/volume/cos/rpc/volume-cos.conf.example
@@ -7,7 +7,7 @@ BUCKET=mybucket-1250000000
 REGION=ap-guangzhou
 
 # FUSE mount base: Cubelet AttachRequest.volumeBaseDir
-# (volume_plugin_base_dir, default /data/volume/cos-<id>).
+# (volume_plugin_base_dir, default /data/cube-shared/volume/cos-<id>).
 # PASSWD_FILE=/etc/cube/.passwd-cosfs
 # Must match CubeMaster / Cubelet socket_path
 SOCKET=/run/cube-volume-cos-rpc.sock

--- a/examples/volume/cos/volume-cos.conf.example
+++ b/examples/volume/cos/volume-cos.conf.example
@@ -9,8 +9,8 @@ BUCKET=mybucket-1250000000
 REGION=ap-guangzhou
 
 # FUSE mount base is passed by Cubelet on attach (--volume-base-dir,
-# default /data/volume). host_path must be under it, e.g.
-# /data/volume/cos-<volume_id>.
+# default /data/cube-shared/volume). host_path must be under it, e.g.
+# /data/cube-shared/volume/cos-<volume_id>.
 
 # rpc plugin only (see cos/rpc/volume-cos.conf.example):
 # SOCKET=/run/cube-volume-cos-rpc.sock


### PR DESCRIPTION
Previous: https://github.com/TencentCloud/CubeSandbox/pull/1067

## Summary

Move the volume plugin base directory from `/data/volume` to `/data/cube-shared/volume`, and introduce `/data/cube-shared` as a new shared hostPath across Cube components on compute nodes.

## Changes

### Core
- Change `volume_plugin_base_dir` default from `/data/volume` to `/data/cube-shared/volume` in Cubelet config and Go code

### K8s Deployment (Helm Chart)
- Add `dataCubeShared` hostPath (`/data/cube-shared`) with `Bidirectional` mount propagation to node DaemonSet and bootstrap containers
- Update `values.yaml` with the new hostPath entry
- Update cleanup scripts and node-init to create/remove the new directory

### Image Build
- Overlay Cubelet `config.toml` from the worktree during image build so image defaults match the repo

### One-Click Deploy
- Create `/data/cube-shared` and `/data/cube-shared/volume` directories in install and up-compute scripts

### Documentation
- Update all docs (EN/ZH) and COS volume plugin examples to reference `/data/cube-shared/volume` instead of `/data/volume`

## Motivation

The `/data/cube-shared` directory provides a shared host tree for Cube components running on the same compute node. The volume plugin base directory is the first consumer; more shared subdirectories may be added in the future.