### PR TITLE
fix(web&&cubeops): OpenClaw apply startup race and template install poll timeout

### DIFF
--- a/CubeOps/internal/service/openclaw.go
+++ b/CubeOps/internal/service/openclaw.go
@@ -1238,7 +1238,8 @@ print("Applied ~/.openclaw/openclaw.json")
 PY
          python3 /tmp/agenthub-openclaw-apply.py && \
          restart_openclaw_service && \
-         for i in $(seq 1 30); do \
+         sleep 2 && \
+         for i in $(seq 1 60); do \
            if openclaw_ready; then \
              openclaw_status; \
              break; \

--- a/web/src/pages/TemplateStore.tsx
+++ b/web/src/pages/TemplateStore.tsx
@@ -134,7 +134,7 @@ function InstallModal({ item, enableForAgentHub = false, onClose }: InstallModal
   const startPolling = useCallback(
     (tplID: string) => {
       let attempts = 0;
-      const MAX = 60; // 60 × 2s = 2min
+      const MAX = 300; // 300 × 2s = 10min
       pollRef.current = setInterval(async () => {
         attempts++;
         try {


### PR DESCRIPTION
OpenClaw apply: add sleep 2 after restart_openclaw_service and double the readiness poll window (30→60 × 0.5s = 30s). On first sandbox boot supervisor starts the process but the gateway port is not immediately ready, causing openclaw_ready to fail and the apply script to exit 1. The 2s sleep gives the process time to initialise before polling.

Template store: increase install poll timeout from 2min to 10min(60→300 × 2s). Large images can take longer than 2 minutes to build; the modal showed a false timeout even though the template was READY.