### PR TITLE
test: update SDK E2E lifecycle coverage and skill guide

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,4 +66,10 @@ __pycache__
 !/tests/e2e/sdk_compat/**
 /tests/e2e/sdk_compat/.pytest_cache/
 
+# Keep the SDK E2E skills guide tracked while ignoring other tests/skills files.
+!/tests/skills/
+/tests/skills/*
+!/tests/skills/sdk-e2e-cases/
+!/tests/skills/sdk-e2e-cases/**
+
 web/tsconfig.tsbuildinfo

--- a/tests/e2e/sdk_compat/cases/lifecycle/test_auto_lifecycle.py
+++ b/tests/e2e/sdk_compat/cases/lifecycle/test_auto_lifecycle.py
@@ -3,6 +3,8 @@
 
 from __future__ import annotations
 
+import time
+
 import pytest
 
 from framework.assertions import assert_code_ok, assert_command_ok
@@ -63,6 +65,24 @@ def _assert_manual_pause_survives_lifecycle_timeout(
 
     assert fetch_state(adapter) == "paused"
     assert sandbox_listed(adapter.sandbox_id, backend, config) is True
+
+
+def _assert_sandbox_unlisted(sandbox_id, backend, config) -> None:
+    observed = sandbox_listed(sandbox_id, backend, config)
+    if observed is None:
+        pytest.skip(f"backend {backend!r} does not expose a reliable sandbox list API")
+
+    deadline = time.monotonic() + config.platform_lifecycle_poll_timeout
+    while time.monotonic() < deadline:
+        observed = sandbox_listed(sandbox_id, backend, config)
+        if observed is False:
+            return
+        time.sleep(1)
+
+    raise AssertionError(
+        f"sandbox {sandbox_id} was not absent from the list within "
+        f"{config.platform_lifecycle_poll_timeout}s (last observed={observed!r})"
+    )
 
 
 @pytest.mark.requires_capability(RUN_CODE)
@@ -224,19 +244,40 @@ def test_manual_pause_before_auto_pause_timeout_remains_paused(
 
 @pytest.mark.requires_capability(PAUSE_RESUME)
 @pytest.mark.requires_capability(PLATFORM_LIFECYCLE)
+# sdk_sandbox injects timeout=platform_lifecycle_idle_timeout for requires_cubeproxy tests.
 @pytest.mark.sandbox_create_options(lifecycle={"on_timeout": "kill"})
-def test_manual_pause_before_auto_kill_timeout_remains_paused(
+def test_manual_pause_before_auto_kill_timeout_is_deleted(
     sdk_sandbox,
     sdk_backend,
     sdk_e2e_config,
 ):
-    # TODO: Once auto-kill supports deleting explicitly paused sandboxes,
-    # change this regression to expect a terminal state and an absent listing.
-    _assert_manual_pause_survives_lifecycle_timeout(
+    sandbox_id = sdk_sandbox.sandbox_id
+
+    result = sdk_sandbox.run_command(
+        "printf manual-pause-before-auto-kill",
+        timeout=sdk_e2e_config.command_timeout,
+    )
+    assert_command_ok(result)
+
+    sdk_sandbox.pause(timeout=sdk_e2e_config.default_timeout)
+    assert wait_until_paused(sdk_sandbox, timeout=sdk_e2e_config.default_timeout) == "paused"
+
+    idle_past_timeout(
+        sdk_e2e_config.platform_lifecycle_idle_timeout,
+        margin=sdk_e2e_config.platform_lifecycle_wait_margin,
+    )
+
+    destroyed, details = wait_for_platform_destroy(
         sdk_sandbox,
+        sandbox_id,
         sdk_backend,
         sdk_e2e_config,
     )
+    assert destroyed, (
+        "manual pause before auto-kill timeout must destroy the sandbox; "
+        f"{PLATFORM_LIFECYCLE_SKIP_REASON}; last_observed={details!r}"
+    )
+    _assert_sandbox_unlisted(sandbox_id, sdk_backend, sdk_e2e_config)
 
 
 @pytest.mark.sandbox_create_options(lifecycle={"on_timeout": "kill"})

--- a/tests/skills/sdk-e2e-cases/REFERENCE.md
+++ b/tests/skills/sdk-e2e-cases/REFERENCE.md
@@ -1,0 +1,134 @@
+# SDK E2E Case Reference
+
+## Domain Mapping
+
+Use existing domains unless the new behavior has a clear API or capability boundary.
+
+```text
+commands/      command stdout/stderr, exit code, timeout, environment
+concurrency/   multi-sandbox isolation and concurrent behavior
+filesystem/    file API behavior and shell interoperability
+host-mount/    host-directory mount extension, allowlist, and boundary behavior
+lifecycle/     create, connect, pause/resume, kill, platform lifecycle
+network/       network policy, public access, traffic access token
+run_code/      Code Interpreter output, errors, stateful kernel behavior
+```
+
+## Module Marker Template
+
+```python
+import pytest
+
+from framework.capabilities import COMMANDS
+
+pytestmark = [
+    pytest.mark.e2e,
+    pytest.mark.sdk_compat,
+    pytest.mark.p1,
+    pytest.mark.commands,
+    pytest.mark.requires_capability(COMMANDS),
+]
+```
+
+Common priority and environment markers:
+
+- `smoke`: minimum live environment validation.
+- `p0`: stable PR-gate coverage.
+- `p1`: daily regression coverage.
+- `p2` / `p3`: broader, slower, or release qualification coverage.
+- `slow`: longer than the normal PR budget.
+- `requires_internet`: public egress is required.
+- `requires_cubeproxy`: CubeProxy routing or platform lifecycle is required.
+- `requires_code_interpreter`: Code Interpreter/Jupyter template is required.
+- `host_mount`: host-directory mount extension; pair with `pytest.mark.requires_capability("host_mount")`.
+
+## Template and Create Options
+
+Use the default `CUBE_TEMPLATE_ID` unless a case needs a specific template capability.
+
+```python
+@pytest.mark.sandbox_template_id("tpl-code-interpreter-xxxxxxxx")
+@pytest.mark.requires_code_interpreter
+def test_kernel_state(sdk_sandbox):
+    ...
+```
+
+Use `sandbox_create_options` for backend-neutral create options that are part of the contract under test.
+
+```python
+pytestmark = [
+    pytest.mark.e2e,
+    pytest.mark.sdk_compat,
+    pytest.mark.p1,
+    pytest.mark.lifecycle,
+    pytest.mark.sandbox_create_options(timeout=120),
+]
+```
+
+## Authoring Checklist
+
+- [ ] The behavior is assigned to the correct domain.
+- [ ] The test name describes the contract and expected outcome.
+- [ ] Shared behavior is not guarded by backend-specific branches.
+- [ ] Unsupported prerequisites use capability or environment markers.
+- [ ] The case uses existing fixtures and helpers before introducing new ones.
+- [ ] Assertions include useful diagnostics without exposing secrets.
+- [ ] The case has deterministic cleanup through existing fixtures.
+- [ ] External dependencies are explicitly marked and configurable.
+- [ ] New environment variables are added to `env.example` and README docs.
+- [ ] New markers are registered in `pytest.ini`.
+
+## Review Checklist
+
+- [ ] Does this test fail for the right product bug?
+- [ ] Does it avoid broad exception swallowing?
+- [ ] Does it avoid fixed sleeps when polling is needed?
+- [ ] Does it keep live E2E cost appropriate for its priority marker?
+- [ ] Does it avoid logging `CUBE_API_KEY`, `E2B_API_KEY`, traffic access tokens, or sensitive infrastructure details?
+- [ ] Does it preserve the distinction between setup/call failures and teardown cleanup failures?
+- [ ] Does documentation match the actual command, marker, and environment behavior?
+
+## Execution Commands
+
+Run collection after any structural or marker change:
+
+```bash
+cd tests/e2e/sdk_compat
+pytest --collect-only -q
+```
+
+Run focused live validation for a changed file:
+
+```bash
+pytest --run-e2e cases/lifecycle/test_create.py -q
+pytest --run-e2e cases/network/test_policy.py -q
+```
+
+Run selected priorities:
+
+```bash
+pytest --run-e2e -m "smoke or p0"
+pytest --run-e2e -m "p1 and not slow"
+```
+
+Run dual-backend compatibility only when both SDK environments are configured:
+
+```bash
+SDK_E2E_BACKENDS=e2b,cubesandbox pytest --run-e2e -q
+```
+
+Useful debug options:
+
+```bash
+SDK_E2E_TRACE=true pytest --run-e2e cases/lifecycle/test_create.py -q
+SDK_E2E_KEEP_SANDBOX_ON_FAILURE=true pytest --run-e2e cases/network/test_policy.py -q
+```
+
+## Output Expectations
+
+When reporting results to the user, include:
+
+- Files changed.
+- Validation commands run and whether they passed.
+- Any live E2E commands that were not run, with the reason.
+- Remaining risks, especially environment assumptions or backend-specific gaps.

--- a/tests/skills/sdk-e2e-cases/SKILL.md
+++ b/tests/skills/sdk-e2e-cases/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: sdk-e2e-cases
+description: Write, review, and execute CubeSandbox SDK compatibility E2E pytest cases. Use when the user asks to add, design, review, debug, or run SDK E2E cases under tests/e2e/sdk_compat, or mentions lifecycle, network policy, sandbox templates, backend compatibility, pytest markers, or live E2E validation.
+---
+
+# SDK E2E Cases
+
+Use this skill for CubeSandbox SDK compatibility E2E work in `tests/e2e/sdk_compat`.
+
+## Required First Steps
+
+1. Read the relevant local docs before changing tests:
+   - `tests/e2e/sdk_compat/README.md`
+   - `tests/e2e/sdk_compat/docs/case-authoring.md`
+   - `tests/e2e/sdk_compat/docs/test-coverage.md`
+   - `tests/e2e/sdk_compat/docs/framework-design.md`
+2. Inspect nearby cases in the same domain directory before writing a new case.
+3. Decide whether the request is case authoring, review, execution, or debugging, then follow the matching workflow below.
+
+## Authoring Workflow
+
+1. Classify the behavior domain: `commands`, `filesystem`, `host-mount`, `lifecycle`, `network`, `run_code`, or `concurrency`.
+2. Decide whether the behavior is a shared SDK contract or backend-specific behavior.
+3. Use capability and environment markers for unsupported prerequisites. Do not hide backend differences with loose assertions.
+4. Prefer existing fixtures and helpers over new abstractions:
+   - `sdk_sandbox`
+   - `sdk_e2e_config`
+   - `sdk_backend`
+   - `sandbox_create_options`
+   - `sandbox_template_id`
+5. Keep assertions contract-focused and diagnostics useful. Include IDs, states, URLs, status codes, and short response snippets where helpful, but do not log secrets or traffic access token values.
+6. Add or update docs only when the case introduces a new pattern, marker, environment variable, template requirement, or coverage category.
+
+## Review Workflow
+
+Review SDK E2E changes for:
+
+- Correctness: the test asserts product/SDK contracts, not incidental implementation details.
+- Backend compatibility: shared cases run across selected backends, and unsupported behavior uses capability markers.
+- Lifecycle semantics: `running` means the sandbox data plane should be usable; do not mask backend bugs with broad retries.
+- Resource cleanup: created sandboxes are cleaned with existing fixtures/helpers unless intentionally preserved by framework behavior.
+- Security: do not print API keys, traffic access tokens, machine IPs, or sensitive headers.
+- Stability: avoid fixed sleeps, public internet assumptions without markers, and unbounded polling.
+- Maintainability: prefer existing helpers, readable markers, and focused tests.
+
+## Execution Workflow
+
+From `tests/e2e/sdk_compat`, use the smallest command that validates the change:
+
+```bash
+pytest --collect-only -q
+pytest --run-e2e -m "p0 and not slow"
+pytest --run-e2e cases/lifecycle/test_create.py -q
+pytest --run-e2e cases/network/test_policy.py -q
+```
+
+For live runs, check that required environment variables are documented and intentionally set. Use `SDK_E2E_KEEP_SANDBOX_ON_FAILURE=true` only when debugging failures.
+
+## Additional Reference
+
+For concrete marker templates, review checklists, and command patterns, read `REFERENCE.md`.


### PR DESCRIPTION
## Summary
- Update the manual-pause-before-auto-kill lifecycle regression to expect deletion once explicitly paused sandboxes are supported by auto-kill.
- Add a repository-local SDK E2E case authoring/review/execution skill guide under tests/skills.
- Allow the new tests/skills/sdk-e2e-cases directory through .gitignore.

## Validation
- git diff --check HEAD^ HEAD
- pytest --collect-only -q cases/lifecycle/test_auto_lifecycle.py

Live E2E was  run for this PR.
