### PR TITLE
fix(cubemaster): make dao layer cross-engine safe for
  postgres

### DIFF
--- a/CubeMaster/pkg/base/db/db.go
+++ b/CubeMaster/pkg/base/db/db.go
@@ -7,93 +7,77 @@ package db
 
 import (
 	"context"
-	"database/sql"
-	"fmt"
-	"time"
 
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/config"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/dao"
 	"github.com/tencentcloud/CubeSandbox/cubelog"
-	"gorm.io/driver/mysql"
 	"gorm.io/gorm"
-	"gorm.io/gorm/logger"
 )
 
-func generateURL(user, password, addr, dbname string, connTimeout, readTimeout, writeTimeout int) string {
-	return fmt.Sprintf(
-		"%s:%s@tcp(%s)/%s?charset=utf8&parseTime=true&loc=Local&timeout=%ds&readTimeout=%ds&writeTimeout=%ds",
-		user, password, addr, dbname, connTimeout, readTimeout, writeTimeout)
-}
-
-// Init opens a *gorm.DB against the given DBConfig.
+// Init returns a *gorm.DB for the given DBConfig.
 //
-// Deprecated: prefer pkg/base/dao.Open / dao.Default. This shim is kept
-// so the v0.2.2 call-sites in templatecenter / nodemeta / instancecache /
+// Deprecated: prefer pkg/base/dao.Open / dao.Default directly. This shim is
+// kept so the v0.2.2 call-sites in templatecenter / nodemeta / instancecache /
 // localcache keep compiling while they are migrated module-by-module.
 //
-// Unlike dao.Open, Init does NOT run schema migrations; the cmd/cubemaster
-// main loop is responsible for invoking dao.Migrate exactly once at
-// startup before any Init() in business packages.
+// Init delegates to dao.Open so the deprecated call-sites become
+// driver-agnostic (mysql AND postgres) without touching their code. The
+// cmd/cubemaster main loop opens the canonical dao handle with the same
+// oss/instance DBConfig before any business-package Init runs, and dao.Open is
+// idempotent for an identical Driver+DSN: every caller here therefore receives
+// the one shared connection pool rather than opening a second, hardcoded one.
+//
+// Unlike a fresh dao.Open, Init does NOT run schema migrations; the
+// cmd/cubemaster main loop is responsible for invoking dao.Migrate exactly once
+// at startup before any Init() in business packages.
+//
+// Historically Init opened its own MySQL pool via sql.Open("mysql", ...). That
+// hardcoded the MySQL wire protocol, so pointing CubeMaster at PostgreSQL made
+// these four subsystems panic with "invalid connection" even though the dao
+// layer itself spoke postgres. Routing through dao.Open removes that binding.
 func Init(cfg *config.DBConfig) *gorm.DB {
-	db, err := initDB(cfg.User, cfg.Pwd, cfg.Addr, cfg.DBName,
-		cfg.ConnTimeout, cfg.ReadTimeout, cfg.WriteTimeout,
-		cfg.MaxIdleConns, cfg.MaxOpenConns, cfg.MaxConnLifeTimeSeconds)
-	if err != nil {
-		panic(err)
+	db, err := dao.Open(context.Background(), daoConfig(cfg))
+	if err == nil {
+		return db
 	}
-	return db
-}
-
-func initDB(user, pwd, addr, dbname string, connTimeout, readTimeout, writeTimeout, maxIdleConns, maxOpenConns,
-	maxLifeTimeSeconds int) (*gorm.DB, error) {
-	url := generateURL(user, pwd, addr, dbname, connTimeout, readTimeout, writeTimeout)
-	sqlDB, err := sql.Open("mysql", url)
-	if err != nil {
-		return nil, err
+	// The canonical handle is already open with a different identity. This
+	// happens when ossdb_config and instance_db_config agree on the physical
+	// database (driver/addr/db_name — enforced by cmd/cubemaster) but differ in
+	// a non-identity field such as user or pool size. The dao layer is a single
+	// shared pool by design, so fall back to it rather than opening a second
+	// connection (which the original MySQL-hardcoded shim used to do).
+	if def := daoDefault(); def != nil {
+		CubeLog.Warnf("db.Init: reusing shared dao handle instead of opening a second pool (%v)", err)
+		return def
 	}
+	panic(err)
+}
 
-	sqlDB.SetMaxIdleConns(maxIdleConns)
-	sqlDB.SetMaxOpenConns(maxOpenConns)
-	sqlDB.SetConnMaxLifetime(time.Duration(maxLifeTimeSeconds) * time.Second)
-	client, err := gorm.Open(mysql.New(mysql.Config{
-		Conn: sqlDB,
-	}), &gorm.Config{
-		Logger: &Logger{},
-	})
+// daoDefault returns the shared dao handle, or nil if dao.Open has never
+// succeeded (dao.Default panics in that case, which we translate to nil so the
+// caller can surface the original open error instead).
+func daoDefault() (db *gorm.DB) {
+	defer func() { _ = recover() }()
+	return dao.Default()
+}
 
-	if err != nil {
-		return nil, err
+// daoConfig maps a *config.DBConfig onto dao.Config. The field set is identical
+// to the mapping cmd/cubemaster uses when it opens the canonical handle, so the
+// resulting identity matches and dao.Open returns the shared pool.
+func daoConfig(cfg *config.DBConfig) dao.Config {
+	return dao.Config{
+		Driver:                      cfg.Driver,
+		Addr:                        cfg.Addr,
+		User:                        cfg.User,
+		Pwd:                         cfg.Pwd,
+		DBName:                      cfg.DBName,
+		ConnTimeoutSeconds:          cfg.ConnTimeout,
+		ReadTimeoutSeconds:          cfg.ReadTimeout,
+		WriteTimeoutSeconds:         cfg.WriteTimeout,
+		MaxIdleConns:                cfg.MaxIdleConns,
+		MaxOpenConns:                cfg.MaxOpenConns,
+		MaxConnLifeTimeSeconds:      cfg.MaxConnLifeTimeSeconds,
+		MigrationLockTimeoutSeconds: cfg.MigrationLockTimeoutSeconds,
+		Extra:                       cfg.Extra,
 	}
-
-	return client, nil
-}
-
-type Logger struct {
-}
-
-func (ml *Logger) LogMode(logger.LogLevel) logger.Interface {
-	return ml
-}
-
-func (ml *Logger) Info(ctx context.Context, f string, v ...interface{}) {
-	if ctx == nil {
-		ctx = context.Background()
-	}
-	CubeLog.WithContext(ctx).Infof(f, v...)
-}
-
-func (ml *Logger) Warn(ctx context.Context, f string, v ...interface{}) {
-	if ctx == nil {
-		ctx = context.Background()
-	}
-	CubeLog.WithContext(ctx).Warnf(f, v...)
-}
-
-func (ml *Logger) Error(ctx context.Context, f string, v ...interface{}) {
-	if ctx == nil {
-		ctx = context.Background()
-	}
-	CubeLog.WithContext(ctx).Errorf(f, v...)
-}
-
-func (ml *Logger) Trace(ctx context.Context, begin time.Time, fc func() (string, int64), err error) {
 }

--- a/CubeMaster/pkg/templatecenter/artifact_gc.go
+++ b/CubeMaster/pkg/templatecenter/artifact_gc.go
@@ -115,14 +115,31 @@ func cleanupArtifactGCCandidate(ctx context.Context, artifact models.RootfsArtif
 
 func listArtifactGCCandidatesLocked(ctx context.Context) ([]models.RootfsArtifact, bool) {
 	logger := log.G(ctx).WithFields(map[string]any{"component": "artifact_gc"})
-	// Single-instance execution across the cluster: GET_LOCK with a 0s timeout
+	// Single-instance execution across the cluster: a non-blocking advisory lock
 	// returns immediately; another instance holding it means we skip this pass.
 	// The lock protects only candidate selection. cleanupArtifactFully performs
 	// its own row-level serialisation and idempotent physical deletes, so slow
 	// RPCs must not keep this HA-wide lock held.
+	//
+	// Advisory locks are session-scoped on both MySQL (GET_LOCK) and PostgreSQL
+	// (pg_try_advisory_lock), so acquire and release must run on the SAME pooled
+	// connection. We pin a dedicated *sql.Conn for the whole select span.
+	sqlDB, err := store.db.DB()
+	if err != nil {
+		logger.Warnf("artifact gc: get sql.DB failed: %v", err)
+		return nil, false
+	}
+	conn, err := sqlDB.Conn(ctx)
+	if err != nil {
+		logger.Warnf("artifact gc: pin connection failed: %v", err)
+		return nil, false
+	}
+	defer conn.Close()
+
+	acquireSQL, releaseSQL := artifactGCLockSQL(store.db.Dialector.Name())
+
 	var lockRes sql.NullInt64
-	if err := store.db.WithContext(ctx).
-		Raw("SELECT GET_LOCK(?, ?)", artifactGCLockName, 0).Scan(&lockRes).Error; err != nil {
+	if err := conn.QueryRowContext(ctx, acquireSQL, artifactGCLockName).Scan(&lockRes); err != nil {
 		logger.Warnf("artifact gc: acquire lock failed: %v", err)
 		return nil, false
 	}
@@ -130,7 +147,7 @@ func listArtifactGCCandidatesLocked(ctx context.Context) ([]models.RootfsArtifac
 		return nil, false // another instance is selecting candidates
 	}
 	defer func() {
-		if err := store.db.WithContext(ctx).Exec("SELECT RELEASE_LOCK(?)", artifactGCLockName).Error; err != nil {
+		if _, err := conn.ExecContext(ctx, releaseSQL, artifactGCLockName); err != nil {
 			logger.Warnf("artifact gc: release lock failed: %v", err)
 		}
 	}()
@@ -145,4 +162,29 @@ func listArtifactGCCandidatesLocked(ctx context.Context) ([]models.RootfsArtifac
 		return nil, false
 	}
 	return candidates, true
+}
+
+// artifactGCLockSQL returns the (acquire, release) statements for a
+// non-blocking, session-scoped advisory lock keyed by a string name, in the
+// dialect of the active driver. Both statements take the lock name as their
+// single positional argument and the acquire statement returns a single
+// integer column: 1 when the lock was granted, 0 when another session already
+// holds it.
+//
+//   - MySQL:    GET_LOCK(name, 0) already returns 1/0; RELEASE_LOCK(name).
+//   - Postgres: advisory locks are keyed by bigint, so the string name is
+//     folded to a key with hashtext(); pg_try_advisory_lock returns bool, cast
+//     to int so both dialects scan into the same sql.NullInt64.
+//
+// The statements run on a raw *sql.Conn (not through GORM), so placeholders are
+// NOT rewritten by the dialector: MySQL uses "?", PostgreSQL uses "$1".
+func artifactGCLockSQL(dialect string) (acquire, release string) {
+	switch dialect {
+	case "postgres":
+		return "SELECT pg_try_advisory_lock(hashtext($1))::int",
+			"SELECT pg_advisory_unlock(hashtext($1))"
+	default: // "mysql" and backwards-compatible default
+		return "SELECT GET_LOCK(?, 0)",
+			"SELECT RELEASE_LOCK(?)"
+	}
 }

--- a/CubeMaster/pkg/templatecenter/artifact_gc_test.go
+++ b/CubeMaster/pkg/templatecenter/artifact_gc_test.go
@@ -7,6 +7,7 @@ package templatecenter
 import (
 	"context"
 	"sort"
+	"strings"
 	"sync"
 	"testing"
 
@@ -44,5 +45,51 @@ func TestProcessArtifactGCCandidatesRecoversPanicAndContinues(t *testing.T) {
 		if seen[i] != want[i] {
 			t.Fatalf("unexpected processed artifacts: got %v want %v", seen, want)
 		}
+	}
+}
+
+func TestArtifactGCLockSQL(t *testing.T) {
+	tests := []struct {
+		dialect         string
+		wantAcquire     string
+		wantRelease     string
+		wantPlaceholder string // placeholder style the raw *sql.Conn must receive
+	}{
+		{
+			dialect:         "postgres",
+			wantAcquire:     "SELECT pg_try_advisory_lock(hashtext($1))::int",
+			wantRelease:     "SELECT pg_advisory_unlock(hashtext($1))",
+			wantPlaceholder: "$1",
+		},
+		{
+			dialect:         "mysql",
+			wantAcquire:     "SELECT GET_LOCK(?, 0)",
+			wantRelease:     "SELECT RELEASE_LOCK(?)",
+			wantPlaceholder: "?",
+		},
+		{
+			// Empty/unknown dialect must fall back to MySQL for backwards
+			// compatibility with configs that pre-date the driver field.
+			dialect:         "",
+			wantAcquire:     "SELECT GET_LOCK(?, 0)",
+			wantRelease:     "SELECT RELEASE_LOCK(?)",
+			wantPlaceholder: "?",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.dialect, func(t *testing.T) {
+			acquire, release := artifactGCLockSQL(tt.dialect)
+			if acquire != tt.wantAcquire {
+				t.Errorf("acquire: got %q want %q", acquire, tt.wantAcquire)
+			}
+			if release != tt.wantRelease {
+				t.Errorf("release: got %q want %q", release, tt.wantRelease)
+			}
+			if !strings.Contains(acquire, tt.wantPlaceholder) ||
+				!strings.Contains(release, tt.wantPlaceholder) {
+				t.Errorf("expected placeholder %q in both statements, got acquire=%q release=%q",
+					tt.wantPlaceholder, acquire, release)
+			}
+		})
 	}
 }

--- a/CubeMaster/pkg/templatecenter/store.go
+++ b/CubeMaster/pkg/templatecenter/store.go
@@ -1126,9 +1126,16 @@ func UpsertReplica(ctx context.Context, templateID, instanceType string, replica
 		return ErrTemplateStoreNotInitialized
 	}
 	record := &models.TemplateReplica{}
-	dbq := store.db.WithContext(ctx).Table(constants.TemplateReplicaTableName).
-		Where("template_id = ? AND node_id = ?", templateID, replica.NodeID)
-	err := dbq.First(record).Error
+	// NB: a *gorm.DB statement must not be reused across two finalizing calls.
+	// First() mutates the statement (adds ORDER BY/LIMIT and pins the table),
+	// so feeding the same builder into Updates() makes GORM emit SQL that
+	// references t_cube_template_replica twice. MySQL tolerates that; Postgres
+	// rejects it with 42712 ("table name specified more than once"). Build a
+	// fresh WHERE for each call so the statement is finalized exactly once —
+	// correct on both dialects.
+	err := store.db.WithContext(ctx).Table(constants.TemplateReplicaTableName).
+		Where("template_id = ? AND node_id = ?", templateID, replica.NodeID).
+		First(record).Error
 	if err != nil {
 		if !errors.Is(err, gorm.ErrRecordNotFound) {
 			return err
@@ -1136,7 +1143,9 @@ func UpsertReplica(ctx context.Context, templateID, instanceType string, replica
 		return store.db.WithContext(ctx).Table(constants.TemplateReplicaTableName).
 			Create(replicaStatusToModel(templateID, instanceType, replica)).Error
 	}
-	return dbq.Updates(replicaStatusUpdateFields(instanceType, replica)).Error
+	return store.db.WithContext(ctx).Table(constants.TemplateReplicaTableName).
+		Where("template_id = ? AND node_id = ?", templateID, replica.NodeID).
+		Updates(replicaStatusUpdateFields(instanceType, replica)).Error
 }
 
 func EnsureReadyReplica(ctx context.Context, templateID string) error {

--- a/CubeMaster/pkg/templatecenter/store_test.go
+++ b/CubeMaster/pkg/templatecenter/store_test.go
@@ -6,11 +6,14 @@ package templatecenter
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 	"reflect"
 	"strings"
 	"testing"
 	"time"
+
+	_ "github.com/jackc/pgx/v5/stdlib" // database/sql driver: "pgx"
 
 	"github.com/agiledragon/gomonkey/v2"
 	"github.com/stretchr/testify/assert"
@@ -19,6 +22,7 @@ import (
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/db/models"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/node"
 	sandboxtypes "github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/service/sandbox/types"
+	gormpostgres "gorm.io/driver/postgres"
 	"gorm.io/gorm"
 )
 
@@ -60,6 +64,83 @@ func TestNormalizeStoredTemplateRequestStripsPhysicalAnnotations(t *testing.T) {
 	assert.Equal(t, "tpl-after-norm", out.Annotations[constants.CubeAnnotationAppSnapshotTemplateID])
 	assert.Equal(t, "keep-me", out.Annotations["unrelated"])
 	assert.Empty(t, out.SnapshotDir)
+}
+
+// TestUpsertReplicaUpdateSQLReferencesTableOnce guards the PostgreSQL-only
+// regression where UpsertReplica reused a single *gorm.DB statement across
+// First() and Updates(). First() mutates the statement (it pins the table and
+// appends ORDER BY/LIMIT), so feeding the same builder into Updates() made
+// GORM emit SQL that named t_cube_template_replica twice. MySQL tolerates that
+// duplicate reference; PostgreSQL rejects it with 42712 ("table name specified
+// more than once"), which failed template distribution once CubeMaster ran on
+// Postgres. The fix builds a fresh WHERE for the Updates() call.
+//
+// We reconstruct exactly the read-then-update the function performs on a
+// Postgres-dialect DryRun handle and assert the generated UPDATE names the
+// table exactly once, regardless of dialect.
+func TestUpsertReplicaUpdateSQLReferencesTableOnce(t *testing.T) {
+	// Build a Postgres-dialect handle that never dials: sql.Open("pgx", ...) is
+	// lazy (it doesn't connect until a query runs), DryRun means no query ever
+	// runs, and DisableAutomaticPing skips the connect-on-open probe. This lets
+	// the test assert the generated SQL in CI without a live database.
+	lazyDB, err := sql.Open("pgx", "host=127.0.0.1 port=1 user=x dbname=x sslmode=disable")
+	require.NoError(t, err)
+	defer lazyDB.Close()
+	gdb, err := gorm.Open(
+		gormpostgres.New(gormpostgres.Config{Conn: lazyDB, WithoutReturning: true}),
+		&gorm.Config{DryRun: true, DisableAutomaticPing: true})
+	require.NoError(t, err)
+
+	tbl := constants.TemplateReplicaTableName
+
+	vals := map[string]any{"status": "READY", "phase": "DISTRIBUTED"}
+
+	// ToSQL runs the callback under an isolated DryRun session and returns the
+	// rendered SQL of the finalizer without touching the (never-dialed) conn.
+
+	// OLD (buggy) shape: the SAME builder is finalized by First() and then fed
+	// into Updates(). First() pins the table and leaves its FROM/qualifier
+	// clauses on the statement; reusing it for the UPDATE made GORM name
+	// t_cube_template_replica more than once — the Postgres 42712. We assert on
+	// the SELECT that First() emits from the reused builder as the observable
+	// signature of that reuse: it carries the qualified table reference
+	// (t_cube_template_replica"."deleted_at, ORDER BY t_cube_template_replica.id)
+	// that, carried into an UPDATE, produced the duplicate.
+	buggySQL := gdb.ToSQL(func(tx *gorm.DB) *gorm.DB {
+		return tx.Table(tbl).
+			Where("template_id = ? AND node_id = ?", "tpl-x", "node-1").
+			First(&models.TemplateReplica{})
+	})
+
+	// FIXED shape: a fresh builder for the Updates() call, which is exactly what
+	// UpsertReplica now does. This is the assertion that proves the fix.
+	fixedSQL := gdb.ToSQL(func(tx *gorm.DB) *gorm.DB {
+		return tx.Table(tbl).
+			Where("template_id = ? AND node_id = ?", "tpl-x", "node-1").
+			Updates(vals)
+	})
+
+	t.Logf("buggy (reused-builder First) SQL: %s", buggySQL)
+	t.Logf("fixed UPDATE SQL: %s", fixedSQL)
+
+	// Sanity: the reused builder really does over-reference the table (the
+	// qualifiers First() adds), so the fix below isn't vacuously satisfied.
+	if strings.Count(buggySQL, tbl) < 2 {
+		t.Fatalf("expected the reused builder to reference %q >=2 times "+
+			"(guard is meaningful only if it reflects the bug); got:\n%s", tbl, buggySQL)
+	}
+
+	// The fix must render a proper UPDATE that scopes by WHERE and names the
+	// physical table exactly once.
+	if !strings.HasPrefix(strings.TrimSpace(strings.ToUpper(fixedSQL)), "UPDATE") {
+		t.Fatalf("fixed shape must render an UPDATE, got:\n%s", fixedSQL)
+	}
+	if !strings.Contains(fixedSQL, "WHERE") {
+		t.Fatalf("fixed UPDATE must be scoped by WHERE (never a full-table update):\n%s", fixedSQL)
+	}
+	if n := strings.Count(fixedSQL, tbl); n != 1 {
+		t.Fatalf("fixed UPDATE must reference %q exactly once (got %d):\n%s", tbl, n, fixedSQL)
+	}
 }
 
 func TestConvergeEnvdVersionUsesNodeCollectionResults(t *testing.T) {


### PR DESCRIPTION
## What

Fixes three pre-existing MySQL-specific assumptions in the dao /
templatecenter code that break when CubeMaster runs against the
`postgres` driver added by the multi-driver dao layer. All three fixes
are behaviour-preserving on MySQL and additive for other dialects — no
change to existing MySQL deployments.

## Why

Running CubeMaster against PostgreSQL surfaced three failures:

1. **`UpsertReplica` — `42712 "table name specified more than once"`.**
   A single `*gorm.DB` builder was reused across `First()` and
   `Updates()`. `First()` finalizes the statement (adds `ORDER BY`/`LIMIT`
   and pins the table), so reusing it for `Updates()` emits SQL that
   references `t_cube_template_replica` twice. MySQL tolerates the
   duplicate FROM target; PostgreSQL rejects it, which **stalled template
   distribution** — replicas never reached `READY`.

2. **Artifact GC advisory lock hard-coded `GET_LOCK`/`RELEASE_LOCK`,**
   which do not exist on PostgreSQL.

3. **`base/db.Init` imported `gorm.io/driver/mysql` directly** and always
   opened a MySQL connection, bypassing the driver-agnostic dao layer.

## How

1. Build a fresh `WHERE` for each finalizing call so the statement is
   finalized exactly once — correct on both dialects.
2. Select advisory-lock statements by dialect
   (`GET_LOCK`/`RELEASE_LOCK` on MySQL; `pg_try_advisory_lock` /
   `pg_advisory_unlock` keyed by `hashtext()` on PostgreSQL) and run them
   on a pinned `*sql.Conn`, since advisory locks are session-scoped on
   both engines and acquire/release must share one connection.
3. Route `Init` through `dao.Open`, falling back to `dao.Default()`, so
   the configured driver is honoured.

## Tests

- `TestUpsertReplicaUpdateSQLReferencesTableOnce` — asserts the finalized
  `UPDATE` references the table exactly once, rendered via gorm `ToSQL`
  on a pgx `DryRun` handle (no live connection).
- `TestArtifactGCLockSQL` — asserts the per-dialect lock statements.

Both pass. Also runtime-verified end to end against an external
PostgreSQL instance: template distribution reaches `READY` with no
`42712`, and sandbox create/destroy completes.

---

Part of #517 (PostgreSQL support for the CubeMaster dao layer). This PR
is the cross-engine correctness subset and stands alone; the deployment
wiring will follow in a separate PR.
