### PR TITLE
feat: rename CUBEMASTER_AUTO_MIGRATION to CUBE_AUTO_MIGRATION and app…

### DIFF
--- a/CubeDB/migrate/migrate.go
+++ b/CubeDB/migrate/migrate.go
@@ -22,14 +22,14 @@ import (
 	"github.com/pressly/goose/v3/lock"
 )
 
-// autoMigrationEnv gates the schema migration performed at CubeMaster
-// startup. A runtime database account with no DDL grant cannot run the
-// migrator at all — not even the fingerprint layer's CREATE TABLE — so
-// such a deployment sets this to a falsey value and applies the schema
-// out-of-band with a privileged account.
-const autoMigrationEnv = "CUBEMASTER_AUTO_MIGRATION"
+// autoMigrationEnv gates the schema migration performed at startup by
+// CubeMaster and CubeOps. A runtime database account with no DDL grant
+// cannot run the migrator at all — not even the fingerprint layer's
+// CREATE TABLE — so such a deployment sets this to a falsey value and
+// applies the schema out-of-band with a privileged account.
+const autoMigrationEnv = "CUBE_AUTO_MIGRATION"
 
-// AutoMigrationEnabled reports whether CubeMaster should run schema
+// AutoMigrationEnabled reports whether a component should run schema
 // migrations at startup. It defaults to true and returns false only for
 // an explicit falsey value (false/0/no/off, case-insensitive). We do not
 // use strconv.ParseBool because it rejects "no"/"off", and any unset,

--- a/CubeMaster/cmd/cubemaster/app/main.go
+++ b/CubeMaster/cmd/cubemaster/app/main.go
@@ -245,7 +245,7 @@ func initDatabaseSchema(ctx context.Context, cfg *config.Config) error {
 	// so unset/typo never disables migration.
 	if !migrate.AutoMigrationEnabled() {
 		CubeLog.WithContext(ctx).Warnf(
-			"CUBEMASTER_AUTO_MIGRATION=false: skipping schema migration; DDL must be " +
+			"CUBE_AUTO_MIGRATION=false: skipping schema migration; DDL must be " +
 				"applied out-of-band by a privileged account")
 		return nil
 	}

--- a/CubeOps/README.md
+++ b/CubeOps/README.md
@@ -50,8 +50,13 @@ export JWT_SECRET=$(openssl rand -hex 32)
 > was previously migrated by an older version of the codebase, you may see
 > a `migration fingerprint check failed` error on startup. This is a safety
 > guard against silent schema drift. To bypass it (e.g. in dev), set
-> `CUBEMASTER_MIGRATION_SKIP_FINGERPRINT_CHECK=1`. The one-click deployment
-> sets this automatically in `.one-click.env`.
+> `CUBEMASTER_MIGRATION_SKIP_FINGERPRINT_CHECK=1`.
+>
+> **Disabling auto-migration**: in production environments where the
+> runtime database account has DML-only grants (no DDL), set
+> `CUBE_AUTO_MIGRATION=false` to skip schema migration at startup. The
+> schema must then be applied out-of-band by a privileged account. Default
+> is enabled (migrate on boot).
 
 ## Service Management
 

--- a/CubeOps/internal/store/db.go
+++ b/CubeOps/internal/store/db.go
@@ -11,6 +11,7 @@ import (
 	"github.com/tencentcloud/CubeSandbox/CubeDB/dao"
 	"github.com/tencentcloud/CubeSandbox/CubeDB/dao/driver/mysql"
 	"github.com/tencentcloud/CubeSandbox/CubeDB/dao/driver/postgres"
+	"github.com/tencentcloud/CubeSandbox/CubeDB/migrate"
 	"github.com/tencentcloud/CubeSandbox/CubeOps/internal/crypto"
 	"gorm.io/gorm"
 )
@@ -31,9 +32,13 @@ func New(ctx context.Context, cfg dao.Config) (*Store, error) {
 		return nil, fmt.Errorf("open database: %w", err)
 	}
 
-	slog.Info("running database migrations")
-	if err := dao.Migrate(ctx); err != nil {
-		return nil, fmt.Errorf("schema migration failed: %w", err)
+	if migrate.AutoMigrationEnabled() {
+		slog.Info("running database migrations")
+		if err := dao.Migrate(ctx); err != nil {
+			return nil, fmt.Errorf("schema migration failed: %w", err)
+		}
+	} else {
+		slog.Warn("CUBE_AUTO_MIGRATION=false: skipping schema migration; DDL must be applied out-of-band by a privileged account")
 	}
 
 	s := &Store{db: gormDB}


### PR DESCRIPTION
Rename the environment variable from CUBEMASTER_AUTO_MIGRATION to CUBE_AUTO_MIGRATION so it is shared by both CubeMaster and CubeOps.

CubeOps previously always ran schema migrations at startup with no way to skip them. In production environments where the runtime database account has DML-only grants (no DDL), this causes CubeOps to fail on boot. Add the same opt-out switch CubeMaster already has: when CUBE_AUTO_MIGRATION is set to false/0/no/off, CubeOps skips migration and logs a warning that DDL must be applied out-of-band by a privileged account.

Default behaviour is unchanged (migrate on boot) for both components.

Verified on a single-node deployment: deleted t_refresh_token table +goose version record, confirmed the table is NOT recreated with CUBE_AUTO_MIGRATION=false and IS recreated by default, for both CubeOps and CubeMaster.