### PR TITLE
feat(volume): pass Create private_data through to Attach

### DIFF
--- a/CubeDB/migrate/migrations/mysql/20260722120000_volume_private_data.sql
+++ b/CubeDB/migrate/migrations/mysql/20260722120000_volume_private_data.sql
@@ -1,0 +1,30 @@
+-- Copyright (c) 2026 Tencent Inc.
+-- SPDX-License-Identifier: Apache-2.0
+--
+-- Add private_data to t_cube_volume for Create→Attach plugin opaque state.
+-- Idempotent for clusters that already have t_cube_volume from
+-- 20260702050000_create_volume_table (with or without this column).
+-- Column inherits table utf8mb4 (same as token).
+
+-- +goose NO TRANSACTION
+-- +goose Up
+
+CALL cubemaster_acquire_migration_lock('cubemaster_migration_20260722120000_volume_private_data', 60);
+
+CALL cubemaster_assert_table_exists('t_cube_volume');
+
+CALL cubemaster_add_column_if_missing(
+  't_cube_volume',
+  'private_data',
+  "varchar(1024) NOT NULL DEFAULT '' COMMENT 'opaque plugin state from Create; forwarded to Attach' AFTER `token`"
+);
+
+SELECT RELEASE_LOCK('cubemaster_migration_20260722120000_volume_private_data');
+
+-- +goose Down
+
+CALL cubemaster_acquire_migration_lock('cubemaster_migration_20260722120000_volume_private_data', 60);
+
+CALL cubemaster_drop_column_if_exists('t_cube_volume', 'private_data');
+
+SELECT RELEASE_LOCK('cubemaster_migration_20260722120000_volume_private_data');

--- a/CubeDB/migrate/migrations/postgres/20260722120000_volume_private_data.sql
+++ b/CubeDB/migrate/migrations/postgres/20260722120000_volume_private_data.sql
@@ -1,0 +1,25 @@
+-- Copyright (c) 2026 Tencent Inc.
+-- SPDX-License-Identifier: Apache-2.0
+--
+-- Add private_data to t_cube_volume (PostgreSQL).
+-- Idempotent for existing tables via cubemaster_add_column_if_missing.
+-- varchar(1024) matches MySQL / token column width.
+
+-- +goose NO TRANSACTION
+-- +goose Up
+
+SELECT cubemaster_acquire_migration_lock('cubemaster_migration_20260722120000_volume_private_data', 60);
+
+SELECT cubemaster_assert_table_exists('t_cube_volume');
+
+SELECT cubemaster_add_column_if_missing('t_cube_volume', 'private_data', 'varchar(1024) NOT NULL DEFAULT ''''');
+
+SELECT pg_advisory_unlock(hashtext('cubemaster_migration_20260722120000_volume_private_data'));
+
+-- +goose Down
+
+SELECT cubemaster_acquire_migration_lock('cubemaster_migration_20260722120000_volume_private_data', 60);
+
+SELECT cubemaster_drop_column_if_exists('t_cube_volume', 'private_data');
+
+SELECT pg_advisory_unlock(hashtext('cubemaster_migration_20260722120000_volume_private_data'));

--- a/CubeMaster/cmd/cubemastercli/app/main.go
+++ b/CubeMaster/cmd/cubemastercli/app/main.go
@@ -60,6 +60,7 @@ func New() *cli.App {
 		cubebox.OperationCommand,
 		cubebox.NodeCommand,
 		cubebox.TemplateCommand,
+		cubebox.VolumeCommand,
 		cubebox.ListInventoryCommand,
 	}, extraCmds...)
 	app.Before = func(context *cli.Context) error {

--- a/CubeMaster/cmd/cubemastercli/commands/cubebox/cubebox.go
+++ b/CubeMaster/cmd/cubemastercli/commands/cubebox/cubebox.go
@@ -25,6 +25,7 @@ var Command = cli.Command{
 		StorageCommand,
 		OperationCommand,
 		TemplateCommand,
+		VolumeCommand,
 	},
 }
 

--- a/CubeMaster/cmd/cubemastercli/commands/cubebox/volume.go
+++ b/CubeMaster/cmd/cubemastercli/commands/cubebox/volume.go
@@ -1,0 +1,257 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package cubebox
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"math/rand"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"text/tabwriter"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/cmd/cubemastercli/commands"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/service/sandbox/types"
+	"github.com/urfave/cli"
+)
+
+// volumeWireItem mirrors CubeMaster VolumeItem JSON. Token may be present in
+// the HTTP response but is never shown by this CLI (same for private_data,
+// which the API does not return).
+type volumeWireItem struct {
+	VolumeID  string `json:"volumeID"`
+	Name      string `json:"name"`
+	Driver    string `json:"driver"`
+	Token     string `json:"token,omitempty"`
+	RefCount  int64  `json:"refCount"`
+	CreatedAt int64  `json:"createdAt"`
+}
+
+// volumeView is the CLI-facing volume record without sensitive fields.
+type volumeView struct {
+	VolumeID  string `json:"volumeID"`
+	Name      string `json:"name"`
+	Driver    string `json:"driver"`
+	RefCount  int64  `json:"refCount"`
+	CreatedAt int64  `json:"createdAt"`
+}
+
+type volumeListResponse struct {
+	Ret     *types.Ret       `json:"ret,omitempty"`
+	Volumes []volumeWireItem `json:"volumes"`
+}
+
+type volumeGetResponse struct {
+	Ret    *types.Ret      `json:"ret,omitempty"`
+	Volume *volumeWireItem `json:"volume,omitempty"`
+}
+
+type volumeDeleteResponse struct {
+	Ret      *types.Ret `json:"ret,omitempty"`
+	VolumeID string     `json:"volumeID,omitempty"`
+}
+
+type volumeListViewResponse struct {
+	Ret     *types.Ret   `json:"ret,omitempty"`
+	Volumes []volumeView `json:"volumes"`
+}
+
+type volumeGetViewResponse struct {
+	Ret    *types.Ret  `json:"ret,omitempty"`
+	Volume *volumeView `json:"volume,omitempty"`
+}
+
+var VolumeCommand = cli.Command{
+	Name:    "volume",
+	Aliases: []string{"vol"},
+	Usage:   "manage volumes (CubeMaster /cube/volume)",
+	Subcommands: cli.Commands{
+		VolumeListCommand,
+		VolumeGetCommand,
+		VolumeDeleteCommand,
+	},
+}
+
+var VolumeListCommand = cli.Command{
+	Name:    "list",
+	Aliases: []string{"ls"},
+	Usage:   "list volumes (omits token and private_data)",
+	Flags: []cli.Flag{
+		cli.BoolFlag{Name: "json", Usage: "print json (without sensitive fields)"},
+	},
+	Action: func(c *cli.Context) error {
+		rsp := &volumeListResponse{}
+		if err := doVolumeReq(c, http.MethodGet, "/cube/volume", uuid.NewString(), nil, rsp); err != nil {
+			return err
+		}
+		if err := ensureVolumeSuccessRet(rsp.Ret); err != nil {
+			return err
+		}
+		view := volumeListViewResponse{
+			Ret:     rsp.Ret,
+			Volumes: make([]volumeView, 0, len(rsp.Volumes)),
+		}
+		for i := range rsp.Volumes {
+			view.Volumes = append(view.Volumes, toVolumeView(&rsp.Volumes[i]))
+		}
+		if c.Bool("json") {
+			commands.PrintAsJSON(view)
+			return nil
+		}
+		printVolumeList(view.Volumes)
+		return nil
+	},
+}
+
+var VolumeGetCommand = cli.Command{
+	Name:    "get",
+	Aliases: []string{"info", "describe"},
+	Usage:   "get a volume by id (omits token and private_data)",
+	Flags: []cli.Flag{
+		cli.StringFlag{Name: "volume-id", Usage: "volume id to query"},
+		cli.BoolFlag{Name: "json", Usage: "print json (without sensitive fields)"},
+	},
+	Action: func(c *cli.Context) error {
+		volumeID := resolveVolumeID(c)
+		if volumeID == "" {
+			return errors.New("volume id is required (positional arg or --volume-id)")
+		}
+		endpoint := "/cube/volume/" + url.PathEscape(volumeID)
+		rsp := &volumeGetResponse{}
+		if err := doVolumeReq(c, http.MethodGet, endpoint, uuid.NewString(), nil, rsp); err != nil {
+			return err
+		}
+		if err := ensureVolumeSuccessRet(rsp.Ret); err != nil {
+			return err
+		}
+		view := volumeGetViewResponse{Ret: rsp.Ret}
+		if rsp.Volume != nil {
+			v := toVolumeView(rsp.Volume)
+			view.Volume = &v
+		}
+		if c.Bool("json") {
+			commands.PrintAsJSON(view)
+			return nil
+		}
+		if view.Volume == nil {
+			return errors.New("empty volume in response")
+		}
+		printVolumeInfo(view.Volume)
+		return nil
+	},
+}
+
+var VolumeDeleteCommand = cli.Command{
+	Name:    "delete",
+	Aliases: []string{"rm", "remove"},
+	Usage:   "delete a volume by id",
+	Flags: []cli.Flag{
+		cli.StringFlag{Name: "volume-id", Usage: "volume id to delete"},
+		cli.BoolFlag{Name: "json", Usage: "print json response"},
+	},
+	Action: func(c *cli.Context) error {
+		volumeID := resolveVolumeID(c)
+		if volumeID == "" {
+			return errors.New("volume id is required (positional arg or --volume-id)")
+		}
+		endpoint := "/cube/volume/" + url.PathEscape(volumeID)
+		rsp := &volumeDeleteResponse{}
+		if err := doVolumeReq(c, http.MethodDelete, endpoint, uuid.NewString(), nil, rsp); err != nil {
+			return err
+		}
+		if err := ensureVolumeSuccessRet(rsp.Ret); err != nil {
+			return err
+		}
+		if c.Bool("json") {
+			commands.PrintAsJSON(rsp)
+			return nil
+		}
+		fmt.Printf("deleted volume: %s\n", rsp.VolumeID)
+		return nil
+	},
+}
+
+func resolveVolumeID(c *cli.Context) string {
+	if id := strings.TrimSpace(c.String("volume-id")); id != "" {
+		return id
+	}
+	if c.NArg() > 0 {
+		return strings.TrimSpace(c.Args().First())
+	}
+	return ""
+}
+
+func toVolumeView(item *volumeWireItem) volumeView {
+	if item == nil {
+		return volumeView{}
+	}
+	return volumeView{
+		VolumeID:  item.VolumeID,
+		Name:      item.Name,
+		Driver:    item.Driver,
+		RefCount:  item.RefCount,
+		CreatedAt: item.CreatedAt,
+	}
+}
+
+func ensureVolumeSuccessRet(ret *types.Ret) error {
+	if ret == nil {
+		return errors.New("empty response")
+	}
+	// Volume handlers use ret_code 0; other CubeMaster APIs often use 200.
+	if ret.RetCode != 0 && ret.RetCode != 200 {
+		if ret.RetMsg != "" {
+			return errors.New(ret.RetMsg)
+		}
+		return fmt.Errorf("request failed with ret_code %d", ret.RetCode)
+	}
+	return nil
+}
+
+func doVolumeReq(c *cli.Context, method, endpoint, requestID string, body io.Reader, rsp interface{}) error {
+	serverList = getServerAddrs(c)
+	if len(serverList) == 0 {
+		return errors.New("no server addr")
+	}
+	port = c.GlobalString("port")
+	host := serverList[rand.Int()%len(serverList)]
+	urlStr := fmt.Sprintf("http://%s%s", net.JoinHostPort(host, port), endpoint)
+	return doHttpReq(c, urlStr, method, requestID, body, rsp)
+}
+
+func printVolumeList(items []volumeView) {
+	w := tabwriter.NewWriter(os.Stdout, 4, 8, 4, ' ', 0)
+	fmt.Fprintln(w, "VOLUME_ID\tNAME\tDRIVER\tREFCOUNT\tCREATED_AT")
+	for _, item := range items {
+		fmt.Fprintf(w, "%s\t%s\t%s\t%d\t%s\n",
+			item.VolumeID,
+			item.Name,
+			item.Driver,
+			item.RefCount,
+			formatVolumeCreatedAt(item.CreatedAt),
+		)
+	}
+	_ = w.Flush()
+}
+
+func printVolumeInfo(item *volumeView) {
+	fmt.Printf("volume_id:  %s\n", item.VolumeID)
+	fmt.Printf("name:       %s\n", item.Name)
+	fmt.Printf("driver:     %s\n", item.Driver)
+	fmt.Printf("ref_count:  %d\n", item.RefCount)
+	fmt.Printf("created_at: %s\n", formatVolumeCreatedAt(item.CreatedAt))
+}
+
+func formatVolumeCreatedAt(unixSec int64) string {
+	if unixSec <= 0 {
+		return "-"
+	}
+	return time.Unix(unixSec, 0).UTC().Format(time.RFC3339)
+}

--- a/CubeMaster/cmd/cubemastercli/commands/cubebox/volume_test.go
+++ b/CubeMaster/cmd/cubemastercli/commands/cubebox/volume_test.go
@@ -1,0 +1,59 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package cubebox
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/service/sandbox/types"
+)
+
+func TestToVolumeViewOmitsToken(t *testing.T) {
+	wire := &volumeWireItem{
+		VolumeID:  "vol-1",
+		Name:      "vol-1",
+		Driver:    "cos",
+		Token:     "secret-token",
+		RefCount:  2,
+		CreatedAt: 1700000000,
+	}
+	view := toVolumeView(wire)
+	if view.VolumeID != "vol-1" || view.Driver != "cos" || view.RefCount != 2 {
+		t.Fatalf("unexpected view: %+v", view)
+	}
+	// volumeView has no Token field; ensure wire token is not copied into JSON tags we care about.
+	if view.Name != "vol-1" {
+		t.Fatalf("name=%q", view.Name)
+	}
+
+	raw, err := json.Marshal(view)
+	if err != nil {
+		t.Fatalf("marshal view: %v", err)
+	}
+	var m map[string]any
+	if err := json.Unmarshal(raw, &m); err != nil {
+		t.Fatalf("unmarshal view: %v", err)
+	}
+	for _, key := range []string{"token", "private_data", "privateData"} {
+		if _, ok := m[key]; ok {
+			t.Fatalf("CLI volumeView must omit %s; got %s", key, raw)
+		}
+	}
+}
+
+func TestEnsureVolumeSuccessRet(t *testing.T) {
+	if err := ensureVolumeSuccessRet(&types.Ret{RetCode: 0, RetMsg: "ok"}); err != nil {
+		t.Fatalf("ret_code 0 should succeed: %v", err)
+	}
+	if err := ensureVolumeSuccessRet(&types.Ret{RetCode: 200, RetMsg: "ok"}); err != nil {
+		t.Fatalf("ret_code 200 should succeed: %v", err)
+	}
+	if err := ensureVolumeSuccessRet(&types.Ret{RetCode: 404, RetMsg: "not found"}); err == nil {
+		t.Fatal("expected error for ret_code 404")
+	}
+	if err := ensureVolumeSuccessRet(nil); err == nil {
+		t.Fatal("expected error for nil ret")
+	}
+}

--- a/CubeMaster/pkg/base/db/models/volume.go
+++ b/CubeMaster/pkg/base/db/models/volume.go
@@ -14,6 +14,12 @@ const VolumeTableName = "t_cube_volume"
 // Must match the varchar(128) columns for volume_id and name in t_cube_volume.
 const MaxVolumeNameLen = 128
 
+// MaxPrivateDataLen is the maximum length of Create-hook private_data in bytes
+// (Go len()). The DB column is varchar(1024) under utf8mb4 (character-length),
+// same as token; byte validation is a conservative upper bound for opaque
+// plugin state (typically ASCII / short UTF-8).
+const MaxPrivateDataLen = 1024
+
 // VolumeRecord persists a single managed volume.
 //
 // Field layout:
@@ -21,6 +27,7 @@ const MaxVolumeNameLen = 128
 //   - Name        : human-readable label; UNIQUE, cannot be reused while the row exists
 //   - Driver      : plugin name (ControllerPlugin.Name()) used to create the volume
 //   - Token       : per-volume credential returned by the plugin; may be empty
+//   - PrivateData : opaque plugin state from Create; forwarded to Attach; not API-visible
 //   - RefCount    : number of nodes currently referencing (mounting) the volume
 //
 // Deletion is hard-delete (row removed). There is no deleted_at column.
@@ -32,6 +39,10 @@ type VolumeRecord struct {
 	Name      string    `gorm:"column:name;uniqueIndex:uniq_volume_name;not null;default:'';size:128"`
 	Driver    string    `gorm:"column:driver;not null;default:''"`
 	Token     string    `gorm:"column:token;not null;default:''"`
+	// PrivateData is opaque plugin state returned by Create (max 1024 bytes).
+	// CubeMaster stores it and forwards it to the Node Attach hook on sandbox
+	// create. It is not exposed on the Volume HTTP/SDK response.
+	PrivateData string `gorm:"column:private_data;not null;default:'';size:1024"`
 	// RefCount tracks how many nodes currently have the volume attached
 	// (mounted by at least one sandbox). It is maintained from the node-level
 	// 0→1 / 1→0 transitions Cubelet reports on sandbox create/destroy. A volume

--- a/CubeMaster/pkg/service/httpservice/cube/volume.go
+++ b/CubeMaster/pkg/service/httpservice/cube/volume.go
@@ -74,6 +74,8 @@ func volErr(rt *CubeLog.RequestTrace, code errorcode.ErrorCode, msg string) *typ
 }
 
 // volumeItemFromRecord converts a DB row to the wire type.
+// PrivateData is intentionally omitted: it is plugin-internal state and must
+// not appear on the Volume HTTP/SDK response.
 func volumeItemFromRecord(r *models.VolumeRecord) VolumeItem {
 	return VolumeItem{
 		VolumeID:  r.VolumeID,
@@ -83,6 +85,15 @@ func volumeItemFromRecord(r *models.VolumeRecord) VolumeItem {
 		RefCount:  r.RefCount,
 		CreatedAt: r.CreatedAt.Unix(),
 	}
+}
+
+// validatePluginPrivateData rejects Create-hook private_data that exceeds
+// models.MaxPrivateDataLen (1024 bytes via Go len()).
+func validatePluginPrivateData(privateData string) error {
+	if len(privateData) > models.MaxPrivateDataLen {
+		return fmt.Errorf("plugin private_data exceeds max length %d", models.MaxPrivateDataLen)
+	}
+	return nil
 }
 
 // ─── Handlers ───────────────────────────────────────────────────────────────
@@ -179,16 +190,33 @@ func handleCreateVolume(c *gin.Context) {
 		return
 	}
 
+	if err := validatePluginPrivateData(info.PrivateData); err != nil {
+		_ = p.Destroy(c.Request.Context(), volumeID)
+		_ = dao.Default().WithContext(c.Request.Context()).
+			Where("volume_id = ?", volumeID).
+			Delete(&models.VolumeRecord{}).Error
+		common.WriteAPI(c, &singleVolumeRes{Ret: volErr(rt, errorcode.ErrorCode_MasterParamsError, err.Error())})
+		return
+	}
+
+	updates := map[string]any{}
 	if info.Token != "" {
 		record.Token = info.Token
+		updates["token"] = info.Token
+	}
+	if info.PrivateData != "" {
+		record.PrivateData = info.PrivateData
+		updates["private_data"] = info.PrivateData
+	}
+	if len(updates) > 0 {
 		if err := dao.Default().WithContext(c.Request.Context()).
 			Model(record).
-			Update("token", info.Token).Error; err != nil {
+			Updates(updates).Error; err != nil {
 			_ = p.Destroy(c.Request.Context(), volumeID)
 			_ = dao.Default().WithContext(c.Request.Context()).
 				Where("volume_id = ?", volumeID).
 				Delete(&models.VolumeRecord{}).Error
-			common.WriteAPI(c, &singleVolumeRes{Ret: volErr(rt, errorcode.ErrorCode_DBError, "db update token error: "+err.Error())})
+			common.WriteAPI(c, &singleVolumeRes{Ret: volErr(rt, errorcode.ErrorCode_DBError, "db update volume fields error: "+err.Error())})
 			return
 		}
 	}

--- a/CubeMaster/pkg/service/httpservice/cube/volume_private_data_test.go
+++ b/CubeMaster/pkg/service/httpservice/cube/volume_private_data_test.go
@@ -1,0 +1,67 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package cube
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/db/models"
+)
+
+func TestValidatePluginPrivateData(t *testing.T) {
+	t.Parallel()
+
+	if err := validatePluginPrivateData(""); err != nil {
+		t.Fatalf("empty private_data should be allowed: %v", err)
+	}
+	if err := validatePluginPrivateData("volumes/vol-1/"); err != nil {
+		t.Fatalf("short private_data should be allowed: %v", err)
+	}
+	exact := strings.Repeat("a", models.MaxPrivateDataLen)
+	if err := validatePluginPrivateData(exact); err != nil {
+		t.Fatalf("exact max length should be allowed: %v", err)
+	}
+	tooLong := strings.Repeat("a", models.MaxPrivateDataLen+1)
+	if err := validatePluginPrivateData(tooLong); err == nil {
+		t.Fatal("expected error for private_data exceeding max length")
+	} else if !strings.Contains(err.Error(), "exceeds max length") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestVolumeItemFromRecordOmitsPrivateData(t *testing.T) {
+	t.Parallel()
+
+	rec := &models.VolumeRecord{
+		VolumeID:    "vol-1",
+		Name:        "vol-1",
+		Driver:      "cos",
+		Token:       "secret-token",
+		PrivateData: "volumes/vol-1/",
+		RefCount:    1,
+		CreatedAt:   time.Unix(1700000000, 0).UTC(),
+	}
+	item := volumeItemFromRecord(rec)
+	if item.VolumeID != "vol-1" || item.Token != "secret-token" || item.Driver != "cos" {
+		t.Fatalf("unexpected item: %+v", item)
+	}
+
+	raw, err := json.Marshal(item)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var m map[string]any
+	if err := json.Unmarshal(raw, &m); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if _, ok := m["private_data"]; ok {
+		t.Fatalf("wire VolumeItem must not expose private_data: %s", raw)
+	}
+	if _, ok := m["privateData"]; ok {
+		t.Fatalf("wire VolumeItem must not expose privateData: %s", raw)
+	}
+}

--- a/CubeMaster/pkg/service/sandbox/plugin_volume_annotation_test.go
+++ b/CubeMaster/pkg/service/sandbox/plugin_volume_annotation_test.go
@@ -1,0 +1,58 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package sandbox
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/service/sandbox/types"
+)
+
+func TestAppendPluginVolumeSourceAnnotation_includesPrivateData(t *testing.T) {
+	t.Parallel()
+
+	req := &types.CreateCubeSandboxReq{}
+	if err := appendPluginVolumeSourceAnnotation(req, "vol-a", "cos", "volumes/vol-a/"); err != nil {
+		t.Fatalf("append: %v", err)
+	}
+	if err := appendPluginVolumeSourceAnnotation(req, "vol-b", "cos-rpc", ""); err != nil {
+		t.Fatalf("append empty private_data: %v", err)
+	}
+
+	raw := req.Annotations["plugin-volume-sources"]
+	if raw == "" {
+		t.Fatal("missing plugin-volume-sources annotation")
+	}
+
+	var entries []map[string]string
+	if err := json.Unmarshal([]byte(raw), &entries); err != nil {
+		t.Fatalf("unmarshal annotation: %v\nraw=%s", err, raw)
+	}
+	if len(entries) != 2 {
+		t.Fatalf("want 2 entries, got %d (%s)", len(entries), raw)
+	}
+	if entries[0]["name"] != "vol-a" || entries[0]["driver"] != "cos" || entries[0]["private_data"] != "volumes/vol-a/" {
+		t.Fatalf("entry0=%v", entries[0])
+	}
+	if entries[1]["name"] != "vol-b" || entries[1]["driver"] != "cos-rpc" {
+		t.Fatalf("entry1=%v", entries[1])
+	}
+	if _, ok := entries[1]["private_data"]; ok {
+		t.Fatalf("empty private_data must be omitted from JSON: %s", raw)
+	}
+}
+
+func TestAppendPluginVolumeSourceAnnotation_malformedExisting(t *testing.T) {
+	t.Parallel()
+
+	req := &types.CreateCubeSandboxReq{
+		Annotations: map[string]string{
+			"plugin-volume-sources": "{not-json",
+		},
+	}
+	if err := appendPluginVolumeSourceAnnotation(req, "vol-a", "cos", "x"); err == nil {
+		t.Fatal("expected error for malformed existing annotation")
+	}
+}

--- a/CubeMaster/pkg/service/sandbox/util.go
+++ b/CubeMaster/pkg/service/sandbox/util.go
@@ -660,7 +660,7 @@ func checkAndGetVolumes(req *types.CreateCubeSandboxReq, out *cubebox.RunCubeSan
 				if err != nil {
 					return fmt.Errorf("volume [%s]: %w", e.Name, err)
 				}
-				if err := appendPluginVolumeSourceAnnotation(req, e.Name, record.Driver); err != nil {
+				if err := appendPluginVolumeSourceAnnotation(req, e.Name, record.Driver, record.PrivateData); err != nil {
 					return fmt.Errorf("volume [%s]: annotation: %w", e.Name, err)
 				}
 				v.VolumeSource.EmptyDir = &cubebox.EmptyDirVolumeSource{
@@ -996,16 +996,21 @@ func checkAndGetContainerHooks(out *cubebox.ContainerConfig, in *types.Container
 	return nil
 }
 
-// appendPluginVolumeSourceAnnotation records name+driver for a plugin volume
-// in the "plugin-volume-sources" annotation so Cubelet can call the right
-// Node Hook binary at attach time.
+// appendPluginVolumeSourceAnnotation records name+driver(+private_data) for a
+// plugin volume in the "plugin-volume-sources" annotation so Cubelet can call
+// the right Node Hook at attach time and forward Create-time private_data.
 //
-// Format: JSON array of {"name": "<volumeID>", "driver": "<driver>"}
-func appendPluginVolumeSourceAnnotation(req *types.CreateCubeSandboxReq, name, driver string) error {
+// Format: JSON array of
+//
+//	{"name":"<volumeID>","driver":"<driver>","private_data":"<opaque>"}
+//
+// private_data is omitted from the JSON object when empty.
+func appendPluginVolumeSourceAnnotation(req *types.CreateCubeSandboxReq, name, driver, privateData string) error {
 	const key = "plugin-volume-sources"
 	type entry struct {
-		Name   string `json:"name"`
-		Driver string `json:"driver"`
+		Name        string `json:"name"`
+		Driver      string `json:"driver"`
+		PrivateData string `json:"private_data,omitempty"`
 	}
 	if req.Annotations == nil {
 		req.Annotations = make(map[string]string)
@@ -1016,7 +1021,7 @@ func appendPluginVolumeSourceAnnotation(req *types.CreateCubeSandboxReq, name, d
 			return err
 		}
 	}
-	entries = append(entries, entry{Name: name, Driver: driver})
+	entries = append(entries, entry{Name: name, Driver: driver, PrivateData: privateData})
 	b, err := json.Marshal(entries)
 	if err != nil {
 		return err

--- a/CubeMaster/pkg/volume/plugin/binary/driver.go
+++ b/CubeMaster/pkg/volume/plugin/binary/driver.go
@@ -17,7 +17,7 @@
 //	create
 //	  --volume-id  <volumeID>   pre-generated UUIDv4
 //	  --name       <name>       human-readable label
-//	  stdout JSON: {"token":"...","error":""}
+//	  stdout JSON: {"token":"...","private_data":"...","error":""}
 //
 //	destroy
 //	  --volume-id  <volumeID>
@@ -66,8 +66,9 @@ func (p *Plugin) Create(
 	volumeID, name string,
 ) (*plugin.VolumeInfo, error) {
 	var resp struct {
-		Token string `json:"token"`
-		Error string `json:"error"`
+		Token       string `json:"token"`
+		PrivateData string `json:"private_data"`
+		Error       string `json:"error"`
 	}
 	if err := p.run(ctx, &resp,
 		"--op", "create",
@@ -80,10 +81,11 @@ func (p *Plugin) Create(
 		return nil, fmt.Errorf("binary plugin %q create: %s", p.name, resp.Error)
 	}
 	return &plugin.VolumeInfo{
-		VolumeID:   volumeID,
-		Name:       name,
-		Token:      resp.Token,
-		PluginName: p.name,
+		VolumeID:    volumeID,
+		Name:        name,
+		Token:       resp.Token,
+		PrivateData: resp.PrivateData,
+		PluginName:  p.name,
 	}, nil
 }
 

--- a/CubeMaster/pkg/volume/plugin/binary/driver_test.go
+++ b/CubeMaster/pkg/volume/plugin/binary/driver_test.go
@@ -1,0 +1,58 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package binary
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestCreateParsesPrivateData(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	script := filepath.Join(dir, "fake-plugin.sh")
+	content := "#!/bin/sh\n" +
+		"printf '%s\\n' '{\"token\":\"tok\",\"private_data\":\"volumes/vol-1/\",\"error\":\"\"}'\n"
+	if err := os.WriteFile(script, []byte(content), 0o755); err != nil {
+		t.Fatalf("write script: %v", err)
+	}
+
+	p := New("cos", script)
+	info, err := p.Create(context.Background(), "vol-1", "vol-1")
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if info.Token != "tok" {
+		t.Fatalf("token=%q", info.Token)
+	}
+	if info.PrivateData != "volumes/vol-1/" {
+		t.Fatalf("private_data=%q", info.PrivateData)
+	}
+	if info.PluginName != "cos" || info.VolumeID != "vol-1" {
+		t.Fatalf("unexpected info: %+v", info)
+	}
+}
+
+func TestCreateAllowsEmptyPrivateData(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	script := filepath.Join(dir, "fake-plugin.sh")
+	content := "#!/bin/sh\nprintf '%s\\n' '{\"token\":\"\",\"private_data\":\"\",\"error\":\"\"}'\n"
+	if err := os.WriteFile(script, []byte(content), 0o755); err != nil {
+		t.Fatalf("write script: %v", err)
+	}
+
+	p := New("cos", script)
+	info, err := p.Create(context.Background(), "vol-2", "vol-2")
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if info.PrivateData != "" {
+		t.Fatalf("private_data=%q", info.PrivateData)
+	}
+}

--- a/CubeMaster/pkg/volume/plugin/plugin.go
+++ b/CubeMaster/pkg/volume/plugin/plugin.go
@@ -139,7 +139,8 @@ func SetRPCFactory(f func(name, socketPath string) (ControllerPlugin, error)) {
 // ─── Wire types ────────────────────────────────────────────────────────────
 
 // VolumeInfo is the canonical result returned by the plugin after a
-// successful create or get-info call.  All fields except Token are required.
+// successful create or get-info call.  All fields except Token and
+// PrivateData are required.
 type VolumeInfo struct {
 	// VolumeID is the stable identifier assigned by the plugin (or generated
 	// by the caller before invoking the plugin).
@@ -151,6 +152,11 @@ type VolumeInfo struct {
 	// Token is the auth credential used by the volume-content service.
 	// May be empty for backends that do not require per-volume tokens.
 	Token string `json:"token"`
+
+	// PrivateData is opaque plugin state persisted in t_cube_volume and
+	// forwarded to the Node Attach hook. Not returned to API/SDK clients.
+	// Max length: models.MaxPrivateDataLen (1024). May be empty.
+	PrivateData string `json:"privateData,omitempty"`
 
 	// PluginName identifies which plugin produced this record.
 	// Populated automatically by the registry before returning to the caller.

--- a/CubeMaster/pkg/volume/plugin/rpc/driver.go
+++ b/CubeMaster/pkg/volume/plugin/rpc/driver.go
@@ -68,10 +68,11 @@ func (p *Plugin) Create(ctx context.Context, volumeID, name string) (*plugin.Vol
 		return nil, fmt.Errorf("rpc volume plugin %q create: %w", p.name, err)
 	}
 	return &plugin.VolumeInfo{
-		VolumeID:   volumeID,
-		Name:       name,
-		Token:      resp.GetToken(),
-		PluginName: p.name,
+		VolumeID:    volumeID,
+		Name:        name,
+		Token:       resp.GetToken(),
+		PrivateData: resp.GetPrivateData(),
+		PluginName:  p.name,
 	}, nil
 }
 

--- a/Cubelet/api/services/volumeplugin/v1/volumeplugin.pb.go
+++ b/Cubelet/api/services/volumeplugin/v1/volumeplugin.pb.go
@@ -89,7 +89,12 @@ type AttachRequest struct {
 	// ref_count is the number of sandboxes already attached to this volume
 	// BEFORE this call (i.e. the pre-attach count).
 	// 0 → first attach; plugin should perform host-level setup.
-	RefCount      int64 `protobuf:"varint,6,opt,name=ref_count,json=refCount,proto3" json:"ref_count,omitempty"`
+	RefCount int64 `protobuf:"varint,6,opt,name=ref_count,json=refCount,proto3" json:"ref_count,omitempty"`
+	// private_data is opaque plugin state returned by Create and persisted in
+	// t_cube_volume. CubeMaster forwards it on sandbox create so Attach can
+	// reuse Create-time context without a second control-plane round-trip.
+	// Max length: 1024 bytes. May be empty.
+	PrivateData   string `protobuf:"bytes,7,opt,name=private_data,json=privateData,proto3" json:"private_data,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -157,6 +162,13 @@ func (x *AttachRequest) GetRefCount() int64 {
 		return x.RefCount
 	}
 	return 0
+}
+
+func (x *AttachRequest) GetPrivateData() string {
+	if x != nil {
+		return x.PrivateData
+	}
+	return ""
 }
 
 type AttachResponse struct {
@@ -388,7 +400,11 @@ type CreateResponse struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// token is an optional credential for volume-content access.
 	// volume_id and name come from the CreateRequest; plugins must not echo them.
-	Token         string `protobuf:"bytes,1,opt,name=token,proto3" json:"token,omitempty"`
+	Token string `protobuf:"bytes,1,opt,name=token,proto3" json:"token,omitempty"`
+	// private_data is opaque plugin state persisted in t_cube_volume and
+	// forwarded to Attach on sandbox create. Not returned to API/SDK clients.
+	// Max length: 1024 bytes. May be empty.
+	PrivateData   string `protobuf:"bytes,2,opt,name=private_data,json=privateData,proto3" json:"private_data,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -426,6 +442,13 @@ func (*CreateResponse) Descriptor() ([]byte, []int) {
 func (x *CreateResponse) GetToken() string {
 	if x != nil {
 		return x.Token
+	}
+	return ""
+}
+
+func (x *CreateResponse) GetPrivateData() string {
+	if x != nil {
+		return x.PrivateData
 	}
 	return ""
 }
@@ -516,14 +539,15 @@ const file_api_services_volumeplugin_v1_volumeplugin_proto_rawDesc = "" +
 	"\n" +
 	"/api/services/volumeplugin/v1/volumeplugin.proto\x12 cubelet.services.volumeplugin.v1\",\n" +
 	"\x12PluginVolumeSource\x12\x16\n" +
-	"\x06driver\x18\x01 \x01(\tR\x06driver\"\xb4\x01\n" +
+	"\x06driver\x18\x01 \x01(\tR\x06driver\"\xd7\x01\n" +
 	"\rAttachRequest\x12\x1d\n" +
 	"\n" +
 	"sandbox_id\x18\x01 \x01(\tR\tsandboxId\x12\x1c\n" +
 	"\tnamespace\x18\x02 \x01(\tR\tnamespace\x12\x1b\n" +
 	"\tvolume_id\x18\x03 \x01(\tR\bvolumeId\x12&\n" +
 	"\x0fvolume_base_dir\x18\x05 \x01(\tR\rvolumeBaseDir\x12\x1b\n" +
-	"\tref_count\x18\x06 \x01(\x03R\brefCountJ\x04\b\x04\x10\x05\"\xd2\x01\n" +
+	"\tref_count\x18\x06 \x01(\x03R\brefCount\x12!\n" +
+	"\fprivate_data\x18\a \x01(\tR\vprivateDataJ\x04\b\x04\x10\x05\"\xd2\x01\n" +
 	"\x0eAttachResponse\x12\x1b\n" +
 	"\thost_path\x18\x02 \x01(\tR\bhostPath\x12Z\n" +
 	"\bmetadata\x18\x04 \x03(\v2>.cubelet.services.volumeplugin.v1.AttachResponse.MetadataEntryR\bmetadata\x1a;\n" +
@@ -543,9 +567,10 @@ const file_api_services_volumeplugin_v1_volumeplugin_proto_rawDesc = "" +
 	"\x0eDetachResponse\"F\n" +
 	"\rCreateRequest\x12\x1b\n" +
 	"\tvolume_id\x18\x01 \x01(\tR\bvolumeId\x12\x12\n" +
-	"\x04name\x18\x02 \x01(\tR\x04nameJ\x04\b\x03\x10\x04\"&\n" +
+	"\x04name\x18\x02 \x01(\tR\x04nameJ\x04\b\x03\x10\x04\"I\n" +
 	"\x0eCreateResponse\x12\x14\n" +
-	"\x05token\x18\x01 \x01(\tR\x05token\"3\n" +
+	"\x05token\x18\x01 \x01(\tR\x05token\x12!\n" +
+	"\fprivate_data\x18\x02 \x01(\tR\vprivateData\"3\n" +
 	"\x0eDestroyRequest\x12\x1b\n" +
 	"\tvolume_id\x18\x01 \x01(\tR\bvolumeIdJ\x04\b\x02\x10\x03\"\x11\n" +
 	"\x0fDestroyResponse2\xef\x01\n" +

--- a/Cubelet/api/services/volumeplugin/v1/volumeplugin.proto
+++ b/Cubelet/api/services/volumeplugin/v1/volumeplugin.proto
@@ -48,6 +48,11 @@ message AttachRequest {
   // BEFORE this call (i.e. the pre-attach count).
   // 0 → first attach; plugin should perform host-level setup.
   int64  ref_count   = 6;
+  // private_data is opaque plugin state returned by Create and persisted in
+  // t_cube_volume. CubeMaster forwards it on sandbox create so Attach can
+  // reuse Create-time context without a second control-plane round-trip.
+  // Max length: 1024 bytes. May be empty.
+  string private_data = 7;
 }
 
 message AttachResponse {
@@ -98,6 +103,10 @@ message CreateResponse {
   // token is an optional credential for volume-content access.
   // volume_id and name come from the CreateRequest; plugins must not echo them.
   string token = 1;
+  // private_data is opaque plugin state persisted in t_cube_volume and
+  // forwarded to Attach on sandbox create. Not returned to API/SDK clients.
+  // Max length: 1024 bytes. May be empty.
+  string private_data = 2;
 }
 
 message DestroyRequest {

--- a/Cubelet/doc/cubelet-api.md
+++ b/Cubelet/doc/cubelet-api.md
@@ -3077,6 +3077,7 @@ Service for machine level operations.
 | volume_id | [string](#string) |  | volume_id is the CubeMaster VolumeRecord identifier. Used as the ref-count DB key for cross-sandbox deduplication. |
 | volume_base_dir | [string](#string) |  | volume_base_dir is the parent directory that Cubelet requires the plugin to mount this volume under. The plugin MUST return a host_path located inside this directory (typically &#34;&lt;volume_base_dir&gt;/&lt;plugin&gt;-&lt;volume_id&gt;&#34;). Cubelet rejects the attach if host_path is not within volume_base_dir. |
 | ref_count | [int64](#int64) |  | ref_count is the number of sandboxes already attached to this volume BEFORE this call (i.e. the pre-attach count). 0 → first attach; plugin should perform host-level setup. |
+| private_data | [string](#string) |  | private_data is opaque plugin state returned by Create and persisted in t_cube_volume. CubeMaster forwards it on sandbox create so Attach can reuse Create-time context without a second control-plane round-trip. Max length: 1024 bytes. May be empty. |
 
 
 
@@ -3140,6 +3141,7 @@ Service for machine level operations.
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | token | [string](#string) |  | token is an optional credential for volume-content access. volume_id and name come from the CreateRequest; plugins must not echo them. |
+| private_data | [string](#string) |  | private_data is opaque plugin state persisted in t_cube_volume and forwarded to Attach on sandbox create. Not returned to API/SDK clients. Max length: 1024 bytes. May be empty. |
 
 
 

--- a/Cubelet/plugins/volume/binary/driver.go
+++ b/Cubelet/plugins/volume/binary/driver.go
@@ -22,6 +22,7 @@
 //	  --volume-id       <volumeID>
 //	  --ref-count       <int64>       pre-attach count; 0 = first attach
 //	  --volume-base-dir <path>        required parent dir; host_path MUST be inside it
+//	  --private-data    <string>      optional; omitted when empty (Create-time state)
 //	  stdout: {"host_path":"...","metadata":{...},"error":""}
 //
 //	detach
@@ -86,6 +87,11 @@ func (p *Plugin) Attach(ctx context.Context, req *volume.AttachRequest) (*volume
 		"--volume-id", req.VolumeID,
 		"--ref-count", strconv.FormatInt(req.RefCount, 10),
 		"--volume-base-dir", req.VolumeBaseDir,
+	}
+	// --private-data is optional: omit when empty so older plugins that do not
+	// recognize the flag keep working (pre-private_data volumes, empty Create).
+	if req.PrivateData != "" {
+		args = append(args, "--private-data", req.PrivateData)
 	}
 
 	var resp struct {

--- a/Cubelet/plugins/volume/binary/driver_test.go
+++ b/Cubelet/plugins/volume/binary/driver_test.go
@@ -1,0 +1,102 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package binary
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/tencentcloud/CubeSandbox/Cubelet/plugins/volume"
+)
+
+func writeAttachStub(t *testing.T, dir, argsFile string) string {
+	t.Helper()
+	wrapper := filepath.Join(dir, "wrapper.sh")
+	content := "#!/bin/sh\n" +
+		"printf '%s\\n' \"$*\" > \"" + argsFile + "\"\n" +
+		"base=\"\"\n" +
+		"prev=\"\"\n" +
+		"for a in \"$@\"; do\n" +
+		"  if [ \"$prev\" = \"--volume-base-dir\" ]; then base=\"$a\"; fi\n" +
+		"  prev=\"$a\"\n" +
+		"done\n" +
+		"mkdir -p \"$base/vol-1\"\n" +
+		"printf '%s\\n' \"{\\\"host_path\\\":\\\"$base/vol-1\\\",\\\"metadata\\\":{},\\\"error\\\":\\\"\\\"}\"\n"
+	if err := os.WriteFile(wrapper, []byte(content), 0o755); err != nil {
+		t.Fatalf("write wrapper: %v", err)
+	}
+	return wrapper
+}
+
+func TestAttachPassesPrivateDataFlag(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	argsFile := filepath.Join(dir, "args.txt")
+	wrapper := writeAttachStub(t, dir, argsFile)
+
+	p := New("cos")
+	if err := p.Init(context.Background(), volume.PluginConfig{BinaryPath: wrapper}); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+
+	baseDir := filepath.Join(dir, "plugin-base")
+	res, err := p.Attach(context.Background(), &volume.AttachRequest{
+		SandboxID:     "sb-1",
+		Namespace:     "default",
+		VolumeID:      "vol-1",
+		Driver:        "cos",
+		VolumeBaseDir: baseDir,
+		PrivateData:   "volumes/vol-1/",
+		RefCount:      0,
+	})
+	if err != nil {
+		t.Fatalf("Attach: %v", err)
+	}
+	wantHost := filepath.Join(baseDir, "vol-1")
+	if res.HostPath != wantHost {
+		t.Fatalf("host_path=%q want %q", res.HostPath, wantHost)
+	}
+
+	raw, err := os.ReadFile(argsFile)
+	if err != nil {
+		t.Fatalf("read args: %v", err)
+	}
+	if !strings.Contains(string(raw), "--private-data volumes/vol-1/") {
+		t.Fatalf("Attach argv missing --private-data; got %q", raw)
+	}
+}
+
+func TestAttachPassesEmptyPrivateDataFlag(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	argsFile := filepath.Join(dir, "args.txt")
+	wrapper := writeAttachStub(t, dir, argsFile)
+
+	p := New("cos")
+	if err := p.Init(context.Background(), volume.PluginConfig{BinaryPath: wrapper}); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+	baseDir := filepath.Join(dir, "plugin-base")
+	if _, err := p.Attach(context.Background(), &volume.AttachRequest{
+		SandboxID:     "sb-1",
+		Namespace:     "default",
+		VolumeID:      "vol-1",
+		VolumeBaseDir: baseDir,
+		PrivateData:   "",
+	}); err != nil {
+		t.Fatalf("Attach: %v", err)
+	}
+	raw, err := os.ReadFile(argsFile)
+	if err != nil {
+		t.Fatalf("read args: %v", err)
+	}
+	if strings.Contains(string(raw), "--private-data") {
+		t.Fatalf("empty private_data must omit --private-data flag; got %q", raw)
+	}
+}

--- a/Cubelet/plugins/volume/context.go
+++ b/Cubelet/plugins/volume/context.go
@@ -73,6 +73,11 @@ type AttachRequest struct {
 	// inside this directory (typically "<VolumeBaseDir>/<plugin-name>-<volumeID>").
 	// Cubelet rejects the attach if HostPath is not within VolumeBaseDir.
 	VolumeBaseDir string
+
+	// PrivateData is opaque plugin state returned by Create, persisted in
+	// t_cube_volume, and forwarded by CubeMaster via plugin-volume-sources.
+	// Max length: 1024 bytes. May be empty.
+	PrivateData string
 }
 
 // AttachResult is returned by VolumePlugin.Attach.

--- a/Cubelet/plugins/volume/rpc/driver.go
+++ b/Cubelet/plugins/volume/rpc/driver.go
@@ -69,6 +69,7 @@ func (p *Plugin) Attach(ctx context.Context, req *volume.AttachRequest) (*volume
 		VolumeId:      req.VolumeID,
 		RefCount:      req.RefCount,
 		VolumeBaseDir: req.VolumeBaseDir,
+		PrivateData:   req.PrivateData,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("rpc volume plugin %q attach: %w", p.name, err)

--- a/Cubelet/storage/pluginvolume.go
+++ b/Cubelet/storage/pluginvolume.go
@@ -48,29 +48,41 @@ type PluginVolumeBackendInfo struct {
 // The ref-count for (namespace, volumeID) is incremented via Manager.Attach;
 // the pre-attach count is embedded in AttachRequest.RefCount so the plugin
 // can decide whether host-level setup is needed (RefCount == 0 → first attach).
-// isPluginVolume reports whether volumeName is listed in the
-// "plugin-volume-sources" annotation injected by CubeMaster.
-func isPluginVolume(annotations map[string]string, volumeName string) bool {
+// pluginVolumeSourceEntry is one element of the plugin-volume-sources annotation.
+type pluginVolumeSourceEntry struct {
+	Name        string `json:"name"`
+	Driver      string `json:"driver"`
+	PrivateData string `json:"private_data"`
+}
+
+// lookupPluginVolumeSource returns driver and private_data for volumeName from
+// the CubeMaster-injected plugin-volume-sources annotation. ok is false when
+// the annotation is missing, malformed, or does not list volumeName.
+func lookupPluginVolumeSource(annotations map[string]string, volumeName string) (driver, privateData string, ok bool) {
 	if annotations == nil {
-		return false
+		return "", "", false
 	}
 	raw := annotations["plugin-volume-sources"]
 	if raw == "" {
-		return false
+		return "", "", false
 	}
-	type entry struct {
-		Name string `json:"name"`
-	}
-	var entries []entry
+	var entries []pluginVolumeSourceEntry
 	if err := json.Unmarshal([]byte(raw), &entries); err != nil {
-		return false
+		return "", "", false
 	}
 	for _, e := range entries {
 		if e.Name == volumeName {
-			return true
+			return e.Driver, e.PrivateData, true
 		}
 	}
-	return false
+	return "", "", false
+}
+
+// isPluginVolume reports whether volumeName is listed in the
+// "plugin-volume-sources" annotation injected by CubeMaster.
+func isPluginVolume(annotations map[string]string, volumeName string) bool {
+	_, _, ok := lookupPluginVolumeSource(annotations, volumeName)
+	return ok
 }
 
 // volumePluginBaseDir returns the configured parent directory that every
@@ -107,28 +119,11 @@ func (l *local) attachPluginVolume(
 	v *cubebox.Volume,
 	result *StorageInfo,
 ) error {
-	// Resolve driver: first try the plugin-volume-sources annotation (preferred
-	// path set by CubeMaster), then fall back to VolumeSource.plugin_volume.
-	driver := ""
+	// Resolve driver + private_data: first try the plugin-volume-sources
+	// annotation (preferred path set by CubeMaster), then fall back to
+	// VolumeSource.plugin_volume for driver only.
 	volumeName := v.GetName()
-
-	if annotations := opts.ReqInfo.GetAnnotations(); annotations != nil {
-		if raw := annotations["plugin-volume-sources"]; raw != "" {
-			type entry struct {
-				Name   string `json:"name"`
-				Driver string `json:"driver"`
-			}
-			var entries []entry
-			if err := json.Unmarshal([]byte(raw), &entries); err == nil {
-				for _, e := range entries {
-					if e.Name == volumeName {
-						driver = e.Driver
-						break
-					}
-				}
-			}
-		}
-	}
+	driver, privateData, _ := lookupPluginVolumeSource(opts.ReqInfo.GetAnnotations(), volumeName)
 
 	// Fallback: VolumeSource.plugin_volume (proto field 11).
 	if driver == "" {
@@ -170,6 +165,7 @@ func (l *local) attachPluginVolume(
 		VolumeID:      volumeID,
 		Driver:        driver,
 		VolumeBaseDir: volumeBaseDir,
+		PrivateData:   privateData,
 		// RefCount (pre-attach) filled in by Manager.Attach after Acquire.
 	}
 

--- a/Cubelet/storage/pluginvolume_test.go
+++ b/Cubelet/storage/pluginvolume_test.go
@@ -1,0 +1,45 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package storage
+
+import "testing"
+
+func TestLookupPluginVolumeSource(t *testing.T) {
+	t.Parallel()
+
+	raw := `[{"name":"vol-a","driver":"cos","private_data":"volumes/vol-a/"},{"name":"vol-b","driver":"cos-rpc"}]`
+	annotations := map[string]string{"plugin-volume-sources": raw}
+
+	driver, pd, ok := lookupPluginVolumeSource(annotations, "vol-a")
+	if !ok || driver != "cos" || pd != "volumes/vol-a/" {
+		t.Fatalf("vol-a: driver=%q private_data=%q ok=%v", driver, pd, ok)
+	}
+	driver, pd, ok = lookupPluginVolumeSource(annotations, "vol-b")
+	if !ok || driver != "cos-rpc" || pd != "" {
+		t.Fatalf("vol-b: driver=%q private_data=%q ok=%v", driver, pd, ok)
+	}
+	if _, _, ok := lookupPluginVolumeSource(annotations, "missing"); ok {
+		t.Fatal("expected ok=false for missing volume")
+	}
+	if _, _, ok := lookupPluginVolumeSource(nil, "vol-a"); ok {
+		t.Fatal("expected ok=false for nil annotations")
+	}
+	if _, _, ok := lookupPluginVolumeSource(map[string]string{"plugin-volume-sources": "{bad"}, "vol-a"); ok {
+		t.Fatal("expected ok=false for malformed JSON")
+	}
+}
+
+func TestIsPluginVolume(t *testing.T) {
+	t.Parallel()
+
+	annotations := map[string]string{
+		"plugin-volume-sources": `[{"name":"vol-a","driver":"cos","private_data":"x"}]`,
+	}
+	if !isPluginVolume(annotations, "vol-a") {
+		t.Fatal("expected vol-a to be a plugin volume")
+	}
+	if isPluginVolume(annotations, "vol-b") {
+		t.Fatal("expected vol-b not to be a plugin volume")
+	}
+}

--- a/docs/guide/volume-plugin.md
+++ b/docs/guide/volume-plugin.md
@@ -172,6 +172,7 @@ Config field `type` selects the plugin type; **`name` (driver) must match end-to
 | Input | `volumeID` | string | Stable ID (UUID or same as `name`) |
 | Input | `name` | string | Display name |
 | Output | `token` | string | Optional auth token returned to SDK |
+| Output | `private_data` | string | Opaque plugin state (max **1024** bytes). Persisted in `t_cube_volume` and forwarded to **Attach** on sandbox create. **Not** returned to API/SDK clients. May be empty. |
 | Output | `error` | string | `""` on success (binary stdout JSON only) |
 
 **binary example**
@@ -185,7 +186,7 @@ Input (CLI):
 Output (stdout JSON, exit 0):
 
 ```json
-{"token":"","error":""}
+{"token":"","private_data":"","error":""}
 ```
 
 #### Destroy
@@ -220,6 +221,7 @@ Output (stdout JSON, exit 0):
 | Input | `volumeID` | string | Same as `volumeMounts[].name` |
 | Input | `refCount` | int64 | Sandbox count **on this node before** attach; `0` = first on this node |
 | Input | `volumeBaseDir` | string | Parent dir; `hostPath` **must** be inside it |
+| Input | `private_data` | string | Same opaque blob Create returned (from `t_cube_volume`); may be empty. binary: optional `--private-data` (omitted when empty) |
 | Output | `hostPath` | string | Path in Cubelet mntns for virtiofs bind |
 | Output | `metadata` | map[string]string | Opaque state; echoed back on Detach |
 | Output | `error` | string | `""` on success (binary stdout JSON only) |
@@ -237,6 +239,8 @@ Input (CLI):
   --sandbox-id sb-001 --namespace default \
   --volume-id my-vol --ref-count 0 \
   --volume-base-dir /data/volume
+# optional when Create returned non-empty private_data:
+#   --private-data 'volumes/my-vol/'
 ```
 
 Output (stdout JSON, exit 0):
@@ -320,7 +324,7 @@ sequenceDiagram
     U->>API: POST /volumes {name, driver}
     API->>M: POST /cube/volume
     M->>P: Create(volumeID, name)
-    P-->>M: stdout JSON {"token":"...","error":""}
+    P-->>M: stdout JSON {"token":"...","private_data":"...","error":""}
     M->>M: write t_cube_volume
     M-->>U: {volumeID, name, token}
 

--- a/docs/zh/guide/volume-plugin.md
+++ b/docs/zh/guide/volume-plugin.md
@@ -172,6 +172,7 @@ flowchart LR
 | 输入 | `volumeID` | string | 稳定 ID（UUID 或与 `name` 相同） |
 | 输入 | `name` | string | 展示名 |
 | 输出 | `token` | string | 可选鉴权令牌，返回给 SDK |
+| 输出 | `private_data` | string | 插件私有状态（最长 **1024** 字节）。写入 `t_cube_volume`，沙箱创建绑定时转发给 **Attach**。**不**对 API/SDK 暴露。可为空。 |
 | 输出 | `error` | string | 成功为 `""`（仅 binary stdout JSON） |
 
 **binary 示例**
@@ -185,7 +186,7 @@ flowchart LR
 输出（stdout JSON，exit 0）：
 
 ```json
-{"token":"","error":""}
+{"token":"","private_data":"","error":""}
 ```
 
 #### Destroy
@@ -220,6 +221,7 @@ flowchart LR
 | 输入 | `volumeID` | string | 与 `volumeMounts[].name` 相同 |
 | 输入 | `refCount` | int64 | **本 node 挂载前**沙箱数；`0` = 本 node 首次 |
 | 输入 | `volumeBaseDir` | string | 父目录；`hostPath` **必须**在其内 |
+| 输入 | `private_data` | string | Create 返回并落库的同一私有状态；可为空。binary：可选 `--private-data`（为空时不传） |
 | 输出 | `hostPath` | string | Cubelet mntns 内路径，供 virtiofs bind |
 | 输出 | `metadata` | map[string]string | opaque 状态；Detach 原样回传 |
 | 输出 | `error` | string | 成功为 `""`（仅 binary stdout JSON） |
@@ -237,6 +239,8 @@ flowchart LR
   --sandbox-id sb-001 --namespace default \
   --volume-id my-vol --ref-count 0 \
   --volume-base-dir /data/volume
+# Create 返回非空 private_data 时可选附加：
+#   --private-data 'volumes/my-vol/'
 ```
 
 输出（stdout JSON，exit 0）：
@@ -320,7 +324,7 @@ sequenceDiagram
     U->>API: POST /volumes {name, driver}
     API->>M: POST /cube/volume
     M->>P: Create(volumeID, name)
-    P-->>M: stdout JSON {"token":"...","error":""}
+    P-->>M: stdout JSON {"token":"...","private_data":"...","error":""}
     M->>M: 写入 t_cube_volume
     M-->>U: {volumeID, name, token}
 

--- a/examples/volume/cos/binary/README.md
+++ b/examples/volume/cos/binary/README.md
@@ -256,7 +256,8 @@ do_create() {
 
     load_config                          # Step 1: read SECRET_ID/KEY, BUCKET, REGION
     cos_create_dir "$volume_id"          # Step 2: upload volumes/<id>/.keep via coscmd
-    jq -cn '{ token: "", error: "" }'    # Step 3: return success (COS has no extra token)
+    jq -cn --arg pd "volumes/${volume_id}/" \
+        '{ token: "", private_data: $pd, error: "" }'  # Step 3: private_data → Attach
 }
 ```
 

--- a/examples/volume/cos/binary/README.zh.md
+++ b/examples/volume/cos/binary/README.zh.md
@@ -262,7 +262,8 @@ do_create() {
 
     load_config                          # Step 1: read SECRET_ID/KEY, BUCKET, REGION
     cos_create_dir "$volume_id"          # Step 2: upload volumes/<id>/.keep via coscmd
-    jq -cn '{ token: "", error: "" }'    # Step 3: return success (no extra token for COS)
+    jq -cn --arg pd "volumes/${volume_id}/" \
+        '{ token: "", private_data: $pd, error: "" }'  # Step 3: private_data 会转给 Attach
 }
 ```
 

--- a/examples/volume/cos/binary/cube-volume-cos.sh
+++ b/examples/volume/cos/binary/cube-volume-cos.sh
@@ -233,10 +233,13 @@ cosfs_unmount_volume() {
 # ---------------------------------------------------------------------------
 
 # create: provision backend storage for a new volume.
-# Steps: load config -> create COS folder -> return empty token JSON.
+# Steps: load config -> create COS folder -> return token/private_data JSON.
 #
 # Input:  --volume-id <id>  --name <name>
-# Output: stdout JSON {"token":"","error":""}
+# Output: stdout JSON {"token":"","private_data":"volumes/<id>/","error":""}
+#
+# private_data is opaque Create→Attach state (max 1024 bytes). This COS demo
+# stores the object-key prefix so Attach can log/reuse it without hardcoding.
 do_create() {
     local volume_id="$1" name="$2"
     log "create volumeID=${volume_id} name=${name}"
@@ -245,8 +248,9 @@ do_create() {
     # Step 1: create volumes/<volume_id>/ in the COS bucket
     cos_create_dir "$volume_id" || { err_json "coscmd create dir failed for ${volume_id}"; exit 1; }
 
-    # Step 2: return success (COS plugin has no extra token to hand back)
-    jq -cn '{ token: "", error: "" }'
+    # Step 2: return success; private_data carries the COS key prefix for Attach
+    jq -cn --arg pd "volumes/${volume_id}/" \
+        '{ token: "", private_data: $pd, error: "" }'
 }
 
 # destroy: remove backend storage when user deletes a volume.
@@ -277,12 +281,13 @@ do_destroy() {
 # Cubelet bind-mounts host_path into the sandbox at the user's chosen path.
 #
 # Input:  --sandbox-id <id>  --namespace <ns>  --volume-id <vid>
-#         --ref-count <n>  --volume-base-dir <dir>
+#         --ref-count <n>  --volume-base-dir <dir>  [--private-data <str>]
 # Output: {"host_path":"<volume-base-dir>/cos-<vid>","metadata":{...},"error":""}
 do_attach() {
     local sandbox_id="$1" volume_id="$2" ref_count="$3"
+    local private_data="${4:-}"
 
-    log "attach sandbox=${sandbox_id} volumeID=${volume_id} refcount_before=${ref_count}"
+    log "attach sandbox=${sandbox_id} volumeID=${volume_id} refcount_before=${ref_count} private_data=${private_data}"
 
     load_config
     ensure_passwd_file
@@ -360,6 +365,7 @@ OP=""
 VOLUME_ID="" NAME=""
 SANDBOX_ID="" NAMESPACE="" REF_COUNT="0"
 METADATA="{}"
+PRIVATE_DATA=""
 
 # CubeMaster/Cubelet pass arguments like --op attach --volume-id xxx ...
 while [[ $# -gt 0 ]]; do
@@ -372,6 +378,7 @@ while [[ $# -gt 0 ]]; do
         --ref-count)    REF_COUNT="$2";    shift 2 ;;
         --volume-base-dir)
             [[ -n "${2:-}" ]] && VOLUME_BASE_DIR="$2"; shift 2 ;;
+        --private-data) PRIVATE_DATA="$2"; shift 2 ;;
         --metadata)     METADATA="$2";     shift 2 ;;
         *) die "unknown argument: $1" ;;
     esac
@@ -384,7 +391,7 @@ case "$OP" in
     create)  do_create  "$VOLUME_ID" "$NAME" ;;
     destroy) do_destroy "$VOLUME_ID" ;;
     # Cubelet (data plane)
-    attach)  do_attach  "$SANDBOX_ID" "$VOLUME_ID" "$REF_COUNT" ;;
+    attach)  do_attach  "$SANDBOX_ID" "$VOLUME_ID" "$REF_COUNT" "$PRIVATE_DATA" ;;
     detach)  do_detach  "$SANDBOX_ID" "$VOLUME_ID" "$REF_COUNT" "$METADATA" ;;
     *)       err_json "unknown op: ${OP}"; exit 1 ;;
 esac

--- a/examples/volume/cos/rpc/internal/grpcsrv/server.go
+++ b/examples/volume/cos/rpc/internal/grpcsrv/server.go
@@ -49,8 +49,10 @@ func (s *Server) Create(ctx context.Context, req *vpb.CreateRequest) (*vpb.Creat
 	if err := s.cos.CreateVolume(ctx, volumeID); err != nil {
 		return nil, fmt.Errorf("create volume %q: %w", volumeID, err)
 	}
-	log.Printf("[cos-rpc] create volumeID=%s name=%s", volumeID, name)
-	return &vpb.CreateResponse{Token: ""}, nil
+	// private_data carries the COS key prefix for Attach (max 1024 bytes).
+	privateData := fmt.Sprintf("volumes/%s/", volumeID)
+	log.Printf("[cos-rpc] create volumeID=%s name=%s private_data=%s", volumeID, name, privateData)
+	return &vpb.CreateResponse{Token: "", PrivateData: privateData}, nil
 }
 
 func (s *Server) Destroy(ctx context.Context, req *vpb.DestroyRequest) (*vpb.DestroyResponse, error) {
@@ -65,6 +67,7 @@ func (s *Server) Destroy(ctx context.Context, req *vpb.DestroyRequest) (*vpb.Des
 func (s *Server) Attach(_ context.Context, req *vpb.AttachRequest) (*vpb.AttachResponse, error) {
 	volumeID := req.GetVolumeId()
 	baseDir := req.GetVolumeBaseDir()
+	privateData := req.GetPrivateData()
 	if req.GetRefCount() > 0 {
 		mnt := s.fs.MountPoint(baseDir, volumeID)
 		return &vpb.AttachResponse{
@@ -80,7 +83,8 @@ func (s *Server) Attach(_ context.Context, req *vpb.AttachRequest) (*vpb.AttachR
 	if err != nil {
 		return nil, fmt.Errorf("attach volume %q: %w", volumeID, err)
 	}
-	log.Printf("[cos-rpc] attach sandbox=%s volume=%s host_path=%s", req.GetSandboxId(), volumeID, hostPath)
+	log.Printf("[cos-rpc] attach sandbox=%s volume=%s host_path=%s private_data=%s",
+		req.GetSandboxId(), volumeID, hostPath, privateData)
 
 	return &vpb.AttachResponse{
 		HostPath: hostPath,


### PR DESCRIPTION
## Summary
- Add optional `private_data` (max 1024 bytes) to volume plugin **Create** response; persist it on `t_cube_volume`
- Forward `private_data` to the Node **Attach** hook when a sandbox mounts the volume (`plugin-volume-sources` annotation → binary `--private-data` / proto field)
- Idempotent SQL migration for existing clusters (`cubemaster_add_column_if_missing`); also update CREATE TABLE for fresh installs
- Update COS binary/rpc examples and EN/ZH volume-plugin guide
- Add **cubemastercli** volume subcommands (`list` / `get` / `delete`) against CubeMaster `/cube/volume` (same API CubeAPI uses); query output omits sensitive fields (`token`, `private_data`)

## Details
- Create: `CreateResponse.private_data` / binary stdout `private_data`
- DB: `t_cube_volume.private_data varchar(1024)` (not exposed on Volume HTTP/SDK responses)
- Attach: `AttachRequest.private_data` / `--private-data`
- Validation: reject Create if `len(private_data) > 1024`
- CLI:
  - `cubemastercli volume list` (`ls`)
  - `cubemastercli volume get <volume-id>` (`info` / `describe`, or `--volume-id`)
  - `cubemastercli volume delete <volume-id>` (`rm` / `remove`, or `--volume-id`)
  - `--json` supported; list/get never print `token` or `private_data`

## Test plan
- [ ] Run CubeDB migration on an existing DB that already has `t_cube_volume` (column added once; re-run is no-op)
- [ ] Fresh install: confirm CREATE TABLE includes `private_data`
- [ ] Create volume with COS binary/rpc plugin; confirm `private_data` stored when plugin returns it
- [ ] Create sandbox with `volumeMounts`; confirm Attach receives `--private-data` / proto field (plugin logs)
- [ ] Create with empty `private_data` still works; oversized (>1024) Create is rejected
- [ ] `cubemastercli volume list` / `get` show volume metadata without token/private_data (including `--json`)
- [ ] `cubemastercli volume delete <id>` deletes via `/cube/volume/{id}`

Assisted-by: Cursor:Composer