### PR TITLE
CubeMaster: Drop unused GoFrame p/v struct tags from sandbox types

### DIFF
--- a/CubeMaster/pkg/service/sandbox/types/types.go
+++ b/CubeMaster/pkg/service/sandbox/types/types.go
@@ -23,7 +23,7 @@ func TimeoutPtr(v int) *int {
 }
 
 type Request struct {
-	RequestID string `json:"requestID" p:"requestID"  v:"required"`
+	RequestID string `json:"requestID"`
 }
 
 type Res struct {
@@ -38,8 +38,8 @@ type Ret struct {
 
 type HostChangeEvent struct {
 	*Request
-	HostIDs   []string `p:"hostIDs"  v:"required"`
-	EventType string   `p:"eventType"  v:"required"`
+	HostIDs   []string
+	EventType string
 }
 
 type CreateCubeSandboxReq struct {
@@ -289,7 +289,7 @@ type HostAlias struct {
 }
 
 type ImageSpec struct {
-	Image             string            `json:"image,omitempty" v:"required"`
+	Image             string            `json:"image,omitempty"`
 	Name              string            `json:"name,omitempty"`
 	Token             string            `json:"token,omitempty"`
 	Annotations       map[string]string `json:"annotations,omitempty" `
@@ -424,7 +424,7 @@ type DeleteCubeSandboxRes struct {
 }
 
 type DeleteCubeSandboxReq struct {
-	RequestID   string            `json:"requestID,omitempty" p:"requestID"  v:"required"`
+	RequestID   string            `json:"requestID,omitempty"`
 	SandboxID   string            `json:"sandbox_id,omitempty"`
 	HostIP      string            `json:"host_ip,omitempty"`
 	Annotations map[string]string `json:"annotations,omitempty" `
@@ -441,7 +441,7 @@ type DeleteCubeSandboxReq struct {
 }
 
 type ListCubeSandboxReq struct {
-	RequestID string `json:"requestID,omitempty" p:"requestID"  v:"required"`
+	RequestID string `json:"requestID,omitempty"`
 	StartIdx  int    `json:"start_idx,omitempty"`
 	Size      int    `json:"size,omitempty"`
 
@@ -478,8 +478,8 @@ type SandboxBriefData struct {
 
 type GetCubeSandboxReq struct {
 	RequestID     string `json:"requestID,omitempty"`
-	SandboxID     string `json:"sandbox_id,omitempty" v:"required-without:host_id#sandbox_id or host_id is required"`
-	HostID        string `json:"host_id,omitempty" v:"required-without:sandbox_id#sandbox_id or host_id is required"`
+	SandboxID     string `json:"sandbox_id,omitempty"`
+	HostID        string `json:"host_id,omitempty"`
 	InstanceType  string `json:"instance_type,omitempty"`
 	ContainerPort int32  `json:"container_port,omitempty"`
 }
@@ -520,8 +520,8 @@ type ContainerInfo struct {
 }
 
 type CreateImageReq struct {
-	RequestID         string            `json:"requestID,omitempty" p:"requestID"  v:"required"`
-	Image             string            `json:"image,omitempty" p:"image"  v:"required"`
+	RequestID         string            `json:"requestID,omitempty"`
+	Image             string            `json:"image,omitempty"`
 	Username          string            `json:"username,omitempty"`
 	Token             string            `json:"token,omitempty"`
 	StorageMedia      string            `json:"storage_media,omitempty"`
@@ -546,10 +546,10 @@ type ContainerOverrides struct {
 
 type CreateTemplateFromImageReq struct {
 	*Request
-	SourceImageRef   string `json:"source_image_ref,omitempty" p:"source_image_ref" v:"required"`
+	SourceImageRef   string `json:"source_image_ref,omitempty"`
 	RegistryUsername string `json:"registry_username,omitempty"`
 	RegistryPassword string `json:"registry_password,omitempty"`
-	TemplateID       string `json:"template_id,omitempty" p:"template_id"`
+	TemplateID       string `json:"template_id,omitempty"`
 	// Alias is a human-readable, stable name for the template. When set,
 	// sandboxes can reference the template by this alias instead of the
 	// auto-generated template ID, surviving rebuilds that produce a new ID.
@@ -558,7 +558,7 @@ type CreateTemplateFromImageReq struct {
 	InstanceType       string              `json:"instance_type,omitempty"`
 	NetworkType        string              `json:"network_type,omitempty"`
 	CubeNetworkConfig  *CubeNetworkConfig  `json:"cube_network_config,omitempty"`
-	WritableLayerSize  string              `json:"writable_layer_size,omitempty" p:"writable_layer_size" v:"required"`
+	WritableLayerSize  string              `json:"writable_layer_size,omitempty"`
 	ExposedPorts       []int32             `json:"exposed_ports,omitempty"`
 	DistributionScope  []string            `json:"distribution_scope,omitempty"`
 	ContainerOverrides *ContainerOverrides `json:"container_overrides,omitempty"`
@@ -584,7 +584,7 @@ type CreateTemplateFromImageReq struct {
 
 type RedoTemplateFromImageReq struct {
 	*Request
-	TemplateID        string   `json:"template_id,omitempty" p:"template_id" v:"required"`
+	TemplateID        string   `json:"template_id,omitempty"`
 	DistributionScope []string `json:"distribution_scope,omitempty"`
 	FailedOnly        bool     `json:"failed_only,omitempty"`
 	Wait              bool     `json:"wait,omitempty"`
@@ -645,15 +645,15 @@ type CreateTemplateFromImageRes struct {
 }
 
 type DeleteImageReq struct {
-	RequestID    string `json:"requestID,omitempty" p:"requestID"  v:"required"`
-	Image        string `json:"image,omitempty" p:"image"  v:"required"`
+	RequestID    string `json:"requestID,omitempty"`
+	Image        string `json:"image,omitempty"`
 	StorageMedia string `json:"storage_media,omitempty"`
 	InstanceType string `json:"instance_type,omitempty"`
 }
 
 type GetNodeReq struct {
 	RequestID    string `json:"requestID,omitempty"`
-	HostID       string `json:"host_id,omitempty" v:"required-without:sandbox_id#sandbox_id or host_id is required"`
+	HostID       string `json:"host_id,omitempty"`
 	ScoreOnly    bool   `json:"score_only,omitempty"`
 	InstanceType string `json:"instance_type,omitempty"`
 }
@@ -697,10 +697,10 @@ var FastestJsoniter = jsoniter.Config{
 }.Froze()
 
 type UpdateRequest struct {
-	RequestID    string `json:"requestID" p:"requestID"  v:"required"`
-	SandboxID    string `json:"sandbox_id" p:"sandbox_id"  v:"required"`
-	InstanceType string `json:"instance_type" p:"instance_type"  v:"required"`
-	Action       string `json:"action" p:"action"  v:"required"`
+	RequestID    string `json:"requestID"`
+	SandboxID    string `json:"sandbox_id"`
+	InstanceType string `json:"instance_type"`
+	Action       string `json:"action"`
 }
 
 // SetTimeoutRequest is the wire shape for POST /cube/sandbox/timeout.
@@ -713,10 +713,10 @@ type UpdateRequest struct {
 // rule treats the sandbox as freshly active and re-arms the
 // timeout-then-kill (or pause) ladder.
 type SetTimeoutRequest struct {
-	RequestID    string `json:"requestID" p:"requestID" v:"required"`
-	SandboxID    string `json:"sandboxID" p:"sandboxID" v:"required"`
-	InstanceType string `json:"instanceType" p:"instanceType"`
-	Timeout      int32  `json:"timeout" p:"timeout"`
+	RequestID    string `json:"requestID"`
+	SandboxID    string `json:"sandboxID"`
+	InstanceType string `json:"instanceType"`
+	Timeout      int32  `json:"timeout"`
 }
 
 // SetTimeoutRes is the master-side response for /cube/sandbox/timeout.
@@ -733,10 +733,10 @@ type SetTimeoutRes struct {
 // this implementation: both rebase CreatedAt to "now" and set the new
 // TimeoutSeconds. Mirrors e2b's refresh-then-set-timeout convergence.
 type RefreshSandboxRequest struct {
-	RequestID    string `json:"requestID" p:"requestID" v:"required"`
-	SandboxID    string `json:"sandboxID" p:"sandboxID" v:"required"`
-	InstanceType string `json:"instanceType" p:"instanceType"`
-	Duration     int32  `json:"duration" p:"duration"`
+	RequestID    string `json:"requestID"`
+	SandboxID    string `json:"sandboxID"`
+	InstanceType string `json:"instanceType"`
+	Duration     int32  `json:"duration"`
 }
 
 // RefreshSandboxRes mirrors SetTimeoutRes.
@@ -748,8 +748,8 @@ type RefreshSandboxRes struct {
 }
 
 type ListInventoryReq struct {
-	RequestID    string        `json:"requestID,omitempty" p:"requestID"  v:"required"`
-	Filters      []*FilterItem `json:"filters,omitempty" p:"filters"`
+	RequestID    string        `json:"requestID,omitempty"`
+	Filters      []*FilterItem `json:"filters,omitempty"`
 	InstanceType string        `json:"instance_type,omitempty"`
 }
 


### PR DESCRIPTION
We don't use GoFrame, strip all p/v struct tags.