### PR TITLE
feat(cubeapi): add webhook lifecycle event delivery

### DIFF
--- a/CubeAPI/Cargo.lock
+++ b/CubeAPI/Cargo.lock
@@ -533,9 +533,11 @@ dependencies = [
  "dotenvy",
  "futures",
  "governor",
+ "hmac",
  "reqwest",
  "serde",
  "serde_json",
+ "sha2",
  "thiserror 1.0.69",
  "tokio",
  "tower 0.4.13",
@@ -589,6 +591,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -915,6 +918,15 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
 
 [[package]]
 name = "http"

--- a/CubeAPI/Cargo.toml
+++ b/CubeAPI/Cargo.toml
@@ -56,6 +56,10 @@ dotenvy = "0.15"
 # ── UUID ──────────────────────────────────────────────────────────────────
 uuid = { version = "1", features = ["v4", "serde"] }
 
+# ── Webhook signing ───────────────────────────────────────────────────────
+hmac = "0.12"
+sha2 = "0.10"
+
 # ── High-concurrency in-memory state ──────────────────────────────────────
 # Lock-free concurrent HashMap: O(1) reads without global lock
 dashmap = "5"

--- a/CubeAPI/src/config/mod.rs
+++ b/CubeAPI/src/config/mod.rs
@@ -3,6 +3,7 @@
 //
 
 use serde::Deserialize;
+use std::fmt;
 
 #[derive(Debug, Deserialize, Clone)]
 pub struct ServerConfig {
@@ -76,6 +77,54 @@ pub struct ServerConfig {
     /// Env var: CUBE_API_KEY
     #[serde(default)]
     pub cube_api_key: Option<String>,
+
+    /// Webhook endpoints for structured lifecycle event delivery.
+    ///
+    /// Env var: CUBE_API_WEBHOOK_ENDPOINTS
+    /// Value: JSON array of WebhookEndpointConfig objects.
+    #[serde(default)]
+    pub webhook_endpoints: Vec<WebhookEndpointConfig>,
+}
+
+#[derive(Deserialize, Clone)]
+pub struct WebhookEndpointConfig {
+    pub url: String,
+
+    #[serde(default = "default_webhook_events")]
+    pub events: Vec<String>,
+
+    #[serde(default)]
+    pub secret: Option<String>,
+
+    #[serde(default = "default_webhook_queue_capacity")]
+    pub queue_capacity: usize,
+
+    #[serde(default = "default_webhook_max_retries")]
+    pub max_retries: usize,
+
+    #[serde(default = "default_webhook_retry_base_ms")]
+    pub retry_base_ms: u64,
+
+    #[serde(default = "default_webhook_retry_max_ms")]
+    pub retry_max_ms: u64,
+
+    #[serde(default = "default_webhook_timeout_secs")]
+    pub timeout_secs: u64,
+}
+
+impl fmt::Debug for WebhookEndpointConfig {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("WebhookEndpointConfig")
+            .field("url", &self.url)
+            .field("events", &self.events)
+            .field("secret", &self.secret.as_ref().map(|_| "<redacted>"))
+            .field("queue_capacity", &self.queue_capacity)
+            .field("max_retries", &self.max_retries)
+            .field("retry_base_ms", &self.retry_base_ms)
+            .field("retry_max_ms", &self.retry_max_ms)
+            .field("timeout_secs", &self.timeout_secs)
+            .finish()
+    }
 }
 
 fn default_bind() -> String {
@@ -109,14 +158,54 @@ fn default_log_dir() -> String {
 fn default_log_prefix() -> String {
     "cube-api".to_string()
 }
+fn default_webhook_events() -> Vec<String> {
+    [
+        "sandbox.created",
+        "sandbox.deleted",
+        "sandbox.paused",
+        "sandbox.resumed",
+    ]
+    .into_iter()
+    .map(str::to_string)
+    .collect()
+}
+fn default_webhook_queue_capacity() -> usize {
+    1024
+}
+fn default_webhook_max_retries() -> usize {
+    3
+}
+fn default_webhook_retry_base_ms() -> u64 {
+    500
+}
+fn default_webhook_retry_max_ms() -> u64 {
+    30_000
+}
+fn default_webhook_timeout_secs() -> u64 {
+    5
+}
+
+fn webhook_endpoints_from_env() -> anyhow::Result<Option<Vec<WebhookEndpointConfig>>> {
+    let value = match std::env::var("CUBE_API_WEBHOOK_ENDPOINTS") {
+        Ok(value) if !value.trim().is_empty() => value,
+        _ => return Ok(None),
+    };
+
+    let endpoints = serde_json::from_str::<Vec<WebhookEndpointConfig>>(&value)
+        .map_err(|e| anyhow::anyhow!("invalid CUBE_API_WEBHOOK_ENDPOINTS JSON: {e}"))?;
+    Ok(Some(endpoints))
+}
 
 impl ServerConfig {
     pub fn from_env() -> anyhow::Result<Self> {
         let _ = dotenvy::dotenv();
-        let cfg = config::Config::builder()
+        let mut cfg: Self = config::Config::builder()
             .add_source(config::Environment::default().separator("__"))
             .build()?
             .try_deserialize()?;
+        if let Some(endpoints) = webhook_endpoints_from_env()? {
+            cfg.webhook_endpoints = endpoints;
+        }
         Ok(cfg)
     }
 }
@@ -135,6 +224,44 @@ impl Default for ServerConfig {
             log_prefix: default_log_prefix(),
             auth_callback_url: None,
             cube_api_key: std::env::var("CUBE_API_KEY").ok().filter(|s| !s.is_empty()),
+            webhook_endpoints: webhook_endpoints_from_env()
+                .ok()
+                .flatten()
+                .unwrap_or_default(),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn webhook_endpoint_defaults_to_sandbox_lifecycle_events() {
+        let endpoint: WebhookEndpointConfig =
+            serde_json::from_str(r#"{"url":"http://127.0.0.1:9000/webhook"}"#)
+                .expect("endpoint config");
+
+        assert_eq!(
+            endpoint.events,
+            vec![
+                "sandbox.created",
+                "sandbox.deleted",
+                "sandbox.paused",
+                "sandbox.resumed",
+            ]
+        );
+    }
+
+    #[test]
+    fn webhook_endpoint_debug_redacts_secret() {
+        let endpoint: WebhookEndpointConfig = serde_json::from_str(
+            r#"{"url":"http://127.0.0.1:9000/webhook","secret":"super-secret"}"#,
+        )
+        .expect("endpoint config");
+        let debug = format!("{endpoint:?}");
+
+        assert!(debug.contains("<redacted>"));
+        assert!(!debug.contains("super-secret"));
     }
 }

--- a/CubeAPI/src/logging/http.rs
+++ b/CubeAPI/src/logging/http.rs
@@ -2,83 +2,513 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-//! HTTP webhook log backend — stub.
+//! HTTP webhook log backend.
 //!
-//! Sends log events as JSON POST requests to a configurable endpoint.
-//! Useful for forwarding to log aggregators (Elasticsearch, Loki, custom
-//! ingest APIs) that accept HTTP.
-//!
-//! # TODO (wire-up checklist)
-//!
-//! 1. Add `http_log_url: Option<String>` to `ServerConfig`.
-//! 2. Construct `HttpLogger::new(client, url, batch_size, flush_interval)`.
-//! 3. Register it in `AppState::new()` inside `MultiLogger`.
-//!
-//! # Batching strategy (suggested)
-//!
-//! Buffer events into a `Vec<LogEvent>` and POST when either:
-//! - The buffer reaches `batch_size` (default 100), or
-//! - A ticker fires every `flush_interval` (default 5 s).
-//!
-//! Use `tokio::select!` in the background task to wait on whichever fires
-//! first.
+//! The backend fans selected structured events out to configured HTTP
+//! endpoints. Each endpoint owns a bounded queue and a background worker, so
+//! `Logger::log` never waits on external network I/O.
 
 use super::{LogEvent, Logger};
+use crate::config::WebhookEndpointConfig;
 use async_trait::async_trait;
+use hmac::{Hmac, Mac};
+use reqwest::{redirect::Policy, Client, StatusCode};
+use sha2::Sha256;
+use std::{collections::HashSet, time::Duration};
+use tokio::sync::{mpsc, oneshot};
+use tracing::{error, info, warn};
+use uuid::Uuid;
 
-/// Configuration for the HTTP webhook backend.
-#[derive(Debug, Clone)]
-#[allow(dead_code)]
-pub struct HttpLoggerConfig {
-    /// Full URL to POST batches to, e.g. `"http://log-ingest.internal/api/logs"`.
-    pub url: String,
-    /// Max events per batch (default: 100).
-    pub batch_size: usize,
-    /// Flush interval in seconds even if batch is not full (default: 5).
-    pub flush_interval_secs: u64,
+type HmacSha256 = Hmac<Sha256>;
+
+const HEADER_EVENT: &str = "X-Cube-Event";
+const HEADER_DELIVERY: &str = "X-Cube-Delivery";
+const HEADER_TIMESTAMP: &str = "X-Cube-Timestamp";
+const HEADER_NONCE: &str = "X-Cube-Nonce";
+const HEADER_SIGNATURE: &str = "X-Cube-Signature-256";
+const KNOWN_WEBHOOK_EVENTS: &[&str] = &[
+    "sandbox.created",
+    "sandbox.deleted",
+    "sandbox.paused",
+    "sandbox.resumed",
+];
+
+enum WorkerMsg {
+    Event(LogEvent),
+    Flush(oneshot::Sender<()>),
 }
 
-impl Default for HttpLoggerConfig {
-    fn default() -> Self {
-        Self {
-            url: String::new(),
-            batch_size: 100,
-            flush_interval_secs: 5,
-        }
-    }
+#[derive(Clone)]
+struct EndpointWorker {
+    url: String,
+    events: HashSet<String>,
+    tx: mpsc::Sender<WorkerMsg>,
 }
 
-/// HTTP webhook log backend (stub — not yet implemented).
+/// HTTP webhook logger.
 #[derive(Clone)]
 pub struct HttpLogger {
-    #[allow(dead_code)]
-    config: HttpLoggerConfig,
+    endpoints: Vec<EndpointWorker>,
 }
 
 impl HttpLogger {
-    /// Create an `HttpLogger`.  Currently a no-op; implement the background
-    /// task described in the module doc when ready.
-    #[allow(dead_code)]
-    pub fn new(config: HttpLoggerConfig) -> Self {
-        Self { config }
+    pub fn new(endpoints: Vec<WebhookEndpointConfig>) -> anyhow::Result<Self> {
+        let mut workers = Vec::with_capacity(endpoints.len());
+
+        for endpoint in endpoints {
+            let url = endpoint.url.trim().to_string();
+            let parsed_url = reqwest::Url::parse(&url)?;
+            if !matches!(parsed_url.scheme(), "http" | "https") {
+                anyhow::bail!("webhook endpoint URL must use http or https: {url}");
+            }
+
+            let client = Client::builder()
+                .timeout(Duration::from_secs(endpoint.timeout_secs.max(1)))
+                .redirect(Policy::none())
+                .build()?;
+
+            let events = endpoint
+                .events
+                .iter()
+                .map(|event| event.trim().to_string())
+                .filter(|event| !event.is_empty())
+                .collect::<HashSet<_>>();
+            for event in &events {
+                if !KNOWN_WEBHOOK_EVENTS.contains(&event.as_str()) {
+                    warn!(
+                        url = %url,
+                        event = %event,
+                        "webhook endpoint subscribes to an unknown lifecycle event"
+                    );
+                }
+            }
+            let queue_capacity = endpoint.queue_capacity.max(1);
+            let (tx, rx) = mpsc::channel(queue_capacity);
+
+            let worker_endpoint = endpoint.clone();
+            tokio::spawn(async move {
+                run_endpoint_worker(client, worker_endpoint, rx).await;
+            });
+
+            workers.push(EndpointWorker { url, events, tx });
+        }
+
+        Ok(Self { endpoints: workers })
     }
 }
 
 #[async_trait]
 impl Logger for HttpLogger {
-    async fn log(&self, _event: LogEvent) {
-        // TODO: send to internal channel; background task batches + POSTs.
-        // Example batch payload:
-        // POST config.url
-        // Content-Type: application/json
-        // Body: { "events": [ <LogEvent>, ... ] }
+    async fn log(&self, event: LogEvent) {
+        for endpoint in &self.endpoints {
+            if !endpoint.events.contains(&event.event) {
+                continue;
+            }
+
+            match endpoint.tx.try_send(WorkerMsg::Event(event.clone())) {
+                Ok(()) => {}
+                Err(mpsc::error::TrySendError::Full(_)) => {
+                    warn!(
+                        url = %endpoint.url,
+                        event = %event.event,
+                        "webhook queue full, dropping event"
+                    );
+                }
+                Err(mpsc::error::TrySendError::Closed(_)) => {
+                    error!(
+                        url = %endpoint.url,
+                        event = %event.event,
+                        "webhook worker stopped, dropping event"
+                    );
+                }
+            }
+        }
     }
 
     async fn flush(&self) {
-        // TODO: drain the buffer and send the final batch.
+        let flushes = self.endpoints.iter().map(|endpoint| async {
+            let (tx, rx) = oneshot::channel();
+            if endpoint.tx.send(WorkerMsg::Flush(tx)).await.is_ok() {
+                let _ = rx.await;
+            }
+        });
+        futures::future::join_all(flushes).await;
     }
 
     fn name(&self) -> &'static str {
         "http"
+    }
+}
+
+async fn run_endpoint_worker(
+    client: Client,
+    endpoint: WebhookEndpointConfig,
+    mut rx: mpsc::Receiver<WorkerMsg>,
+) {
+    while let Some(msg) = rx.recv().await {
+        match msg {
+            WorkerMsg::Event(event) => {
+                deliver_event(&client, &endpoint, event).await;
+            }
+            WorkerMsg::Flush(reply) => {
+                let _ = reply.send(());
+            }
+        }
+    }
+}
+
+async fn deliver_event(client: &Client, endpoint: &WebhookEndpointConfig, event: LogEvent) {
+    let body = match serde_json::to_vec(&event) {
+        Ok(body) => body,
+        Err(e) => {
+            error!(
+                url = %endpoint.url,
+                event = %event.event,
+                error = %e,
+                "failed to serialize webhook payload"
+            );
+            return;
+        }
+    };
+
+    let delivery_id = Uuid::new_v4().to_string();
+    let max_retries = endpoint.max_retries;
+    let attempts = max_retries.saturating_add(1);
+
+    for attempt in 0..attempts {
+        let request = build_request(client, endpoint, &event, &delivery_id, &body);
+
+        match request.send().await {
+            Ok(response) if response.status().is_success() => {
+                info!(
+                    url = %endpoint.url,
+                    event = %event.event,
+                    delivery_id = %delivery_id,
+                    attempt = attempt + 1,
+                    "webhook delivered"
+                );
+                return;
+            }
+            Ok(response) => {
+                let status = response.status();
+                let retryable = is_retryable_status(status);
+                warn!(
+                    url = %endpoint.url,
+                    event = %event.event,
+                    delivery_id = %delivery_id,
+                    status = status.as_u16(),
+                    attempt = attempt + 1,
+                    retryable,
+                    "webhook delivery returned non-success status"
+                );
+                if !retryable || attempt == max_retries {
+                    return;
+                }
+            }
+            Err(e) => {
+                warn!(
+                    url = %endpoint.url,
+                    event = %event.event,
+                    delivery_id = %delivery_id,
+                    attempt = attempt + 1,
+                    error = %e,
+                    "webhook delivery request failed"
+                );
+                if attempt == max_retries {
+                    return;
+                }
+            }
+        }
+
+        tokio::time::sleep(retry_delay(endpoint, attempt)).await;
+    }
+}
+
+fn build_request(
+    client: &Client,
+    endpoint: &WebhookEndpointConfig,
+    event: &LogEvent,
+    delivery_id: &str,
+    body: &[u8],
+) -> reqwest::RequestBuilder {
+    let mut request = client
+        .post(&endpoint.url)
+        .header(reqwest::header::CONTENT_TYPE, "application/json")
+        .header(HEADER_EVENT, event.event.as_str())
+        .header(HEADER_DELIVERY, delivery_id);
+
+    if let Some(secret) = endpoint
+        .secret
+        .as_deref()
+        .filter(|secret| !secret.is_empty())
+    {
+        let timestamp = chrono::Utc::now().timestamp_millis().to_string();
+        let nonce = Uuid::new_v4().to_string();
+        let signature = sign_body(secret, &timestamp, &nonce, &body);
+        request = request
+            .header(HEADER_TIMESTAMP, timestamp)
+            .header(HEADER_NONCE, nonce)
+            .header(HEADER_SIGNATURE, signature);
+    }
+
+    request.body(body.to_vec())
+}
+
+fn sign_body(secret: &str, timestamp: &str, nonce: &str, body: &[u8]) -> String {
+    let mut mac =
+        HmacSha256::new_from_slice(secret.as_bytes()).expect("HMAC accepts keys of any length");
+    mac.update(timestamp.as_bytes());
+    mac.update(b".");
+    mac.update(nonce.as_bytes());
+    mac.update(b".");
+    mac.update(body);
+    format!("sha256={}", to_hex(&mac.finalize().into_bytes()))
+}
+
+fn to_hex(bytes: &[u8]) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut out = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        out.push(HEX[(byte >> 4) as usize] as char);
+        out.push(HEX[(byte & 0x0f) as usize] as char);
+    }
+    out
+}
+
+fn is_retryable_status(status: StatusCode) -> bool {
+    status == StatusCode::REQUEST_TIMEOUT
+        || status == StatusCode::TOO_MANY_REQUESTS
+        || status.is_server_error()
+}
+
+fn retry_delay(endpoint: &WebhookEndpointConfig, attempt: usize) -> Duration {
+    let base_ms = endpoint.retry_base_ms.max(1);
+    let max_ms = endpoint.retry_max_ms.max(base_ms);
+    let factor = 1u64.checked_shl(attempt.min(20) as u32).unwrap_or(u64::MAX);
+    Duration::from_millis(base_ms.saturating_mul(factor).min(max_ms))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::{
+        body::Bytes,
+        extract::State,
+        http::{HeaderMap, StatusCode},
+        routing::post,
+        Router,
+    };
+    use serde_json::Value;
+    use std::{collections::VecDeque, sync::Arc, time::Instant};
+    use tokio::sync::Mutex;
+
+    #[derive(Clone, Debug)]
+    struct CapturedRequest {
+        headers: HeaderMap,
+        body: Vec<u8>,
+    }
+
+    #[derive(Clone)]
+    struct ReceiverState {
+        requests: Arc<Mutex<Vec<CapturedRequest>>>,
+        statuses: Arc<Mutex<VecDeque<StatusCode>>>,
+    }
+
+    async fn capture(
+        State(state): State<ReceiverState>,
+        headers: HeaderMap,
+        body: Bytes,
+    ) -> StatusCode {
+        state.requests.lock().await.push(CapturedRequest {
+            headers,
+            body: body.to_vec(),
+        });
+        state
+            .statuses
+            .lock()
+            .await
+            .pop_front()
+            .unwrap_or(StatusCode::OK)
+    }
+
+    async fn spawn_receiver(
+        statuses: Vec<StatusCode>,
+    ) -> (String, Arc<Mutex<Vec<CapturedRequest>>>) {
+        let requests = Arc::new(Mutex::new(Vec::new()));
+        let state = ReceiverState {
+            requests: requests.clone(),
+            statuses: Arc::new(Mutex::new(statuses.into())),
+        };
+        let app = Router::new()
+            .route("/webhook", post(capture))
+            .with_state(state);
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind test receiver");
+        let address = listener.local_addr().expect("receiver address");
+        tokio::spawn(async move {
+            axum::serve(listener, app)
+                .await
+                .expect("test receiver should run");
+        });
+        (format!("http://{address}/webhook"), requests)
+    }
+
+    fn endpoint(url: String) -> WebhookEndpointConfig {
+        WebhookEndpointConfig {
+            url,
+            events: vec![
+                "sandbox.created".to_string(),
+                "sandbox.deleted".to_string(),
+                "sandbox.paused".to_string(),
+                "sandbox.resumed".to_string(),
+            ],
+            secret: None,
+            queue_capacity: 16,
+            max_retries: 0,
+            retry_base_ms: 1,
+            retry_max_ms: 10,
+            timeout_secs: 1,
+        }
+    }
+
+    #[tokio::test]
+    async fn delivers_subscribed_event_payload() {
+        let (url, requests) = spawn_receiver(vec![StatusCode::OK]).await;
+        let logger = HttpLogger::new(vec![endpoint(url)]).expect("logger");
+        logger
+            .log(
+                LogEvent::new(super::super::LogLevel::Info, "sandbox.created")
+                    .field("sandbox_id", "sbx-1")
+                    .field("template_id", "tpl-1"),
+            )
+            .await;
+        logger.flush().await;
+
+        let requests = requests.lock().await;
+        assert_eq!(requests.len(), 1);
+        let payload: Value =
+            serde_json::from_slice(&requests[0].body).expect("payload should be json");
+        assert_eq!(payload["event"], "sandbox.created");
+        assert_eq!(payload["sandbox_id"], "sbx-1");
+        assert_eq!(payload["template_id"], "tpl-1");
+        assert!(payload.get("timestamp").is_some());
+    }
+
+    #[tokio::test]
+    async fn filters_unsubscribed_events() {
+        let (url, requests) = spawn_receiver(vec![StatusCode::OK]).await;
+        let mut config = endpoint(url);
+        config.events = vec!["sandbox.deleted".to_string()];
+        let logger = HttpLogger::new(vec![config]).expect("logger");
+        logger
+            .log(LogEvent::new(
+                super::super::LogLevel::Info,
+                "sandbox.created",
+            ))
+            .await;
+        logger.flush().await;
+
+        assert!(requests.lock().await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn signs_requests_when_secret_is_configured() {
+        let (url, requests) = spawn_receiver(vec![StatusCode::OK]).await;
+        let mut config = endpoint(url);
+        config.secret = Some("test-secret".to_string());
+        let logger = HttpLogger::new(vec![config]).expect("logger");
+        logger
+            .log(LogEvent::new(
+                super::super::LogLevel::Info,
+                "sandbox.deleted",
+            ))
+            .await;
+        logger.flush().await;
+
+        let requests = requests.lock().await;
+        let request = requests.first().expect("request");
+        let timestamp = request
+            .headers
+            .get(HEADER_TIMESTAMP)
+            .and_then(|value| value.to_str().ok())
+            .expect("timestamp header");
+        let nonce = request
+            .headers
+            .get(HEADER_NONCE)
+            .and_then(|value| value.to_str().ok())
+            .expect("nonce header");
+        let signature = request
+            .headers
+            .get(HEADER_SIGNATURE)
+            .and_then(|value| value.to_str().ok())
+            .expect("signature header");
+        assert_eq!(
+            signature,
+            sign_body("test-secret", timestamp, nonce, &request.body)
+        );
+    }
+
+    #[tokio::test]
+    async fn retries_retryable_failures() {
+        let (url, requests) =
+            spawn_receiver(vec![StatusCode::INTERNAL_SERVER_ERROR, StatusCode::OK]).await;
+        let mut config = endpoint(url);
+        config.max_retries = 2;
+        let logger = HttpLogger::new(vec![config]).expect("logger");
+        logger
+            .log(LogEvent::new(
+                super::super::LogLevel::Info,
+                "sandbox.paused",
+            ))
+            .await;
+        logger.flush().await;
+
+        assert_eq!(requests.lock().await.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn does_not_retry_non_retryable_client_errors() {
+        let (url, requests) = spawn_receiver(vec![StatusCode::BAD_REQUEST, StatusCode::OK]).await;
+        let mut config = endpoint(url);
+        config.max_retries = 2;
+        let logger = HttpLogger::new(vec![config]).expect("logger");
+        logger
+            .log(LogEvent::new(
+                super::super::LogLevel::Info,
+                "sandbox.resumed",
+            ))
+            .await;
+        logger.flush().await;
+
+        assert_eq!(requests.lock().await.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn log_returns_without_waiting_for_delivery() {
+        let mut config = endpoint("http://127.0.0.1:9/webhook".to_string());
+        config.max_retries = 3;
+        config.timeout_secs = 1;
+        let logger = HttpLogger::new(vec![config]).expect("logger");
+        let start = Instant::now();
+        logger
+            .log(LogEvent::new(
+                super::super::LogLevel::Info,
+                "sandbox.deleted",
+            ))
+            .await;
+
+        assert!(start.elapsed() < Duration::from_millis(50));
+    }
+
+    #[tokio::test]
+    async fn rejects_non_http_endpoint_urls() {
+        let config = endpoint("file:///tmp/webhook".to_string());
+        let err = match HttpLogger::new(vec![config]) {
+            Ok(_) => panic!("invalid scheme should fail"),
+            Err(err) => err,
+        };
+
+        assert!(err.to_string().contains("http or https"));
     }
 }

--- a/CubeAPI/src/main.rs
+++ b/CubeAPI/src/main.rs
@@ -15,6 +15,7 @@ mod routes;
 mod services;
 mod state;
 
+use anyhow::Context;
 use clap::Parser;
 use tracing_subscriber::{fmt, prelude::*, EnvFilter};
 
@@ -131,7 +132,8 @@ fn main() -> anyhow::Result<()> {
     }
 
     // ── Config ─────────────────────────────────────────────────────────────
-    let mut cfg = config::ServerConfig::from_env().unwrap_or_default();
+    let mut cfg = config::ServerConfig::from_env()
+        .context("failed to load CubeAPI configuration from environment")?;
 
     // CLI flags override env vars / config file (highest priority)
     if cli.debug {
@@ -209,20 +211,21 @@ async fn async_main(cfg: config::ServerConfig, debug: bool) -> anyhow::Result<()
 
     let file_logger = FileLogger::new(cfg.log_dir.clone(), cfg.log_prefix.clone()).await?;
 
-    // FilteredLogger gates by level → MultiLogger fans out to file (+ future backends)
-    let logger: logging::ArcLogger = arc(FilteredLogger::new(
-        arc(
-            MultiLogger::new().add(arc(file_logger)), // Uncomment to add more backends:
-                                                      // .add(arc(logging::http::HttpLogger::new(Default::default())))
-                                                      // .add(arc(logging::otlp::OtlpLogger::new()))
-        ),
-        min_level,
-    ));
+    let mut multi_logger = MultiLogger::new().add(arc(file_logger));
+    let webhook_endpoint_count = cfg.webhook_endpoints.len();
+    if webhook_endpoint_count > 0 {
+        let http_logger = logging::http::HttpLogger::new(cfg.webhook_endpoints.clone())?;
+        multi_logger = multi_logger.add(arc(http_logger));
+    }
+
+    // FilteredLogger gates by level → MultiLogger fans out to file + configured backends.
+    let logger: logging::ArcLogger = arc(FilteredLogger::new(arc(multi_logger), min_level));
 
     tracing::info!(
         log_dir = %cfg.log_dir,
         log_prefix = %cfg.log_prefix,
         min_level = %min_level,
+        webhook_endpoints = webhook_endpoint_count,
         "structured event logger started"
     );
 

--- a/docs/guide/integrations/index.md
+++ b/docs/guide/integrations/index.md
@@ -48,3 +48,4 @@ lang: en-US
 | Title | Author | Date | Tags |
 | --- | --- | --- | --- |
 | [Pi Agent Integration Guide](./pi-agent.md) | chaojixinren | 2026-07-01 | integration, pi-agent, coding-agent, agent |
+| [Webhook Event Notifications](./webhooks.md) | io-wy | 2026-07-22 | integration, webhook, cubeapi |

--- a/docs/guide/integrations/webhooks.md
+++ b/docs/guide/integrations/webhooks.md
@@ -1,0 +1,137 @@
+---
+title: Webhook Event Notifications
+author: io-wy
+date: 2026-07-22
+tags:
+  - integration
+  - webhook
+  - cubeapi
+lang: en-US
+---
+
+# Webhook Event Notifications
+
+CubeAPI can deliver sandbox lifecycle events to one or more HTTP endpoints. The
+delivery path is asynchronous: sandbox API requests enqueue events and do not
+wait for remote webhook receivers.
+
+## Supported Events
+
+The default lifecycle subscription contains:
+
+- `sandbox.created`
+- `sandbox.deleted`
+- `sandbox.paused`
+- `sandbox.resumed`
+
+`sandbox.created` includes `sandbox_id` and `template_id`. The other lifecycle
+events include `sandbox_id`.
+
+## Configuration
+
+Set `CUBE_API_WEBHOOK_ENDPOINTS` to a JSON array before starting CubeAPI:
+
+```bash
+export CUBE_API_WEBHOOK_ENDPOINTS='[
+  {
+    "url": "http://127.0.0.1:9000/webhook",
+    "events": [
+      "sandbox.created",
+      "sandbox.deleted",
+      "sandbox.paused",
+      "sandbox.resumed"
+    ],
+    "secret": "dev-secret",
+    "queue_capacity": 1024,
+    "max_retries": 3,
+    "retry_base_ms": 500,
+    "retry_max_ms": 30000,
+    "timeout_secs": 5
+  }
+]'
+```
+
+Fields:
+
+| Field | Required | Description |
+| --- | --- | --- |
+| `url` | Yes | HTTP or HTTPS endpoint that receives JSON `POST` requests. |
+| `events` | No | Event names subscribed by this endpoint. Defaults to the four sandbox lifecycle events. |
+| `secret` | No | HMAC-SHA256 signing secret. Omit or set empty to disable signing. Use a strong random value; 16 bytes or longer is recommended. |
+| `queue_capacity` | No | Bounded in-memory queue size per endpoint. Default: `1024`. |
+| `max_retries` | No | Retry count after the initial attempt. Default: `3`. |
+| `retry_base_ms` | No | Initial exponential backoff delay. Default: `500`. |
+| `retry_max_ms` | No | Maximum retry delay. Default: `30000`. |
+| `timeout_secs` | No | HTTP request timeout per delivery attempt. Default: `5`. |
+
+## Payload
+
+CubeAPI sends each event as JSON. Example:
+
+```json
+{
+  "timestamp": "2026-07-22T10:00:00Z",
+  "level": "info",
+  "event": "sandbox.created",
+  "sandbox_id": "sbx-123",
+  "template_id": "tpl-456"
+}
+```
+
+Additional structured fields may be included as CubeAPI adds more event context.
+
+## Headers
+
+Every delivery includes:
+
+- `Content-Type: application/json`
+- `X-Cube-Event`
+- `X-Cube-Delivery`
+
+When `secret` is configured, CubeAPI also sends:
+
+- `X-Cube-Timestamp`
+- `X-Cube-Nonce`
+- `X-Cube-Signature-256`
+
+The signature is calculated from the raw request body:
+
+```text
+sha256=HMAC_SHA256(secret, timestamp + "." + nonce + "." + raw_body)
+```
+
+Receivers should compare signatures with a constant-time comparison function.
+`X-Cube-Timestamp` is a Unix millisecond timestamp generated for each delivery
+attempt.
+They may also reject stale `X-Cube-Timestamp` values according to their own
+clock-skew policy, for example a five-minute tolerance window.
+
+## Failure Handling
+
+CubeAPI retries delivery failures for network errors and retryable HTTP status
+codes: `408`, `429`, and `5xx`. Other `4xx` responses are treated as
+non-retryable receiver-side failures.
+
+Each webhook endpoint has an independent bounded queue and background worker. A
+slow or unreachable endpoint does not block sandbox lifecycle API requests or
+other webhook endpoints. If an endpoint queue is full, CubeAPI drops the event
+for that endpoint and writes a warning log.
+
+## Local Receiver
+
+A runnable receiver is available under `examples/webhook-receiver`:
+
+```bash
+cd examples/webhook-receiver
+WEBHOOK_SECRET=dev-secret python3 receiver.py
+```
+
+Trigger sandbox create, pause, resume, or delete operations. The receiver prints
+the delivery ID, event name, signature result, and JSON payload.
+
+## Generic Alerting
+
+The receiver can forward accepted events to a generic HTTP alerting service or
+an enterprise chat robot. Keep the CubeAPI webhook endpoint private when
+possible, verify the HMAC signature before forwarding, and avoid sending secrets
+or large payloads to third-party chat systems.

--- a/docs/zh/guide/integrations/index.md
+++ b/docs/zh/guide/integrations/index.md
@@ -48,3 +48,4 @@ lang: zh-CN
 | 标题 | 作者 | 日期 | 标签 |
 | --- | --- | --- | --- |
 | [Pi Agent 集成指南](./pi-agent.md) | chaojixinren | 2026-07-01 | integration, pi-agent, coding-agent, agent |
+| [Webhook 事件通知](./webhooks.md) | io-wy | 2026-07-22 | integration, webhook, cubeapi |

--- a/docs/zh/guide/integrations/webhooks.md
+++ b/docs/zh/guide/integrations/webhooks.md
@@ -1,0 +1,132 @@
+---
+title: Webhook 事件通知
+author: io-wy
+date: 2026-07-22
+tags:
+  - integration
+  - webhook
+  - cubeapi
+lang: zh-CN
+---
+
+# Webhook 事件通知
+
+CubeAPI 可以把沙箱生命周期事件投递到一个或多个 HTTP endpoint。投递路径是异步的：
+沙箱 API 请求只负责把事件放入队列，不会等待远端 Webhook 接收端响应。
+
+## 支持的事件
+
+默认生命周期订阅包含：
+
+- `sandbox.created`
+- `sandbox.deleted`
+- `sandbox.paused`
+- `sandbox.resumed`
+
+`sandbox.created` 包含 `sandbox_id` 和 `template_id`。其它生命周期事件包含
+`sandbox_id`。
+
+## 配置
+
+启动 CubeAPI 前，把 `CUBE_API_WEBHOOK_ENDPOINTS` 设置为 JSON 数组：
+
+```bash
+export CUBE_API_WEBHOOK_ENDPOINTS='[
+  {
+    "url": "http://127.0.0.1:9000/webhook",
+    "events": [
+      "sandbox.created",
+      "sandbox.deleted",
+      "sandbox.paused",
+      "sandbox.resumed"
+    ],
+    "secret": "dev-secret",
+    "queue_capacity": 1024,
+    "max_retries": 3,
+    "retry_base_ms": 500,
+    "retry_max_ms": 30000,
+    "timeout_secs": 5
+  }
+]'
+```
+
+字段说明：
+
+| 字段 | 必填 | 说明 |
+| --- | --- | --- |
+| `url` | 是 | 接收 JSON `POST` 请求的 HTTP 或 HTTPS endpoint。 |
+| `events` | 否 | 当前 endpoint 订阅的事件名。默认订阅四个沙箱生命周期事件。 |
+| `secret` | 否 | HMAC-SHA256 签名密钥。省略或设为空字符串表示不启用签名。建议使用 16 字节或更长的强随机值。 |
+| `queue_capacity` | 否 | 每个 endpoint 的内存队列上限。默认值：`1024`。 |
+| `max_retries` | 否 | 初次投递失败后的重试次数。默认值：`3`。 |
+| `retry_base_ms` | 否 | 指数退避的初始延迟。默认值：`500`。 |
+| `retry_max_ms` | 否 | 最大重试延迟。默认值：`30000`。 |
+| `timeout_secs` | 否 | 单次投递请求超时时间。默认值：`5`。 |
+
+## Payload
+
+CubeAPI 以 JSON 格式发送事件。示例：
+
+```json
+{
+  "timestamp": "2026-07-22T10:00:00Z",
+  "level": "info",
+  "event": "sandbox.created",
+  "sandbox_id": "sbx-123",
+  "template_id": "tpl-456"
+}
+```
+
+随着 CubeAPI 增加更多事件上下文，payload 可能包含其它结构化字段。
+
+## 请求头
+
+每次投递都会包含：
+
+- `Content-Type: application/json`
+- `X-Cube-Event`
+- `X-Cube-Delivery`
+
+配置 `secret` 后，CubeAPI 还会发送：
+
+- `X-Cube-Timestamp`
+- `X-Cube-Nonce`
+- `X-Cube-Signature-256`
+
+签名基于原始请求体计算：
+
+```text
+sha256=HMAC_SHA256(secret, timestamp + "." + nonce + "." + raw_body)
+```
+
+接收端应使用常量时间比较函数校验签名。
+`X-Cube-Timestamp` 是每次投递时生成的 Unix 毫秒时间戳。
+接收端也可以按照自己的时钟偏移策略拒绝过旧的 `X-Cube-Timestamp`，例如设置 5 分钟
+容忍窗口。
+
+## 失败处理
+
+网络错误以及这些 HTTP 状态码会触发重试：`408`、`429`、`5xx`。其它 `4xx`
+响应会被视为接收端侧的不可重试失败。
+
+每个 Webhook endpoint 都有独立的有界队列和后台 worker。某个 endpoint 变慢或不可达，
+不会阻塞沙箱生命周期 API 请求，也不会影响其它 Webhook endpoint。如果某个 endpoint
+队列已满，CubeAPI 会丢弃该 endpoint 上的事件并写入 warning 日志。
+
+## 本地接收端
+
+可运行的接收端位于 `examples/webhook-receiver`：
+
+```bash
+cd examples/webhook-receiver
+WEBHOOK_SECRET=dev-secret python3 receiver.py
+```
+
+触发沙箱创建、暂停、恢复或删除操作后，接收端会打印 delivery ID、事件名、签名结果和
+JSON payload。
+
+## 通用告警对接
+
+接收端可以把验签通过的事件转发到通用 HTTP 告警系统或企业 IM 机器人。建议尽量让
+CubeAPI Webhook endpoint 处在内网，先完成 HMAC 验签再转发，并避免把密钥或大型
+payload 发到第三方聊天系统。

--- a/examples/webhook-receiver/README.md
+++ b/examples/webhook-receiver/README.md
@@ -1,0 +1,55 @@
+# CubeSandbox Webhook Receiver
+
+This example starts a local HTTP receiver for CubeAPI webhook events. It uses
+only the Python standard library.
+
+## Run
+
+```bash
+cd examples/webhook-receiver
+WEBHOOK_SECRET=dev-secret python3 receiver.py
+```
+
+The receiver listens on `http://127.0.0.1:9000/webhook` by default.
+
+Configure CubeAPI with a webhook endpoint:
+
+```bash
+export CUBE_API_WEBHOOK_ENDPOINTS='[
+  {
+    "url": "http://127.0.0.1:9000/webhook",
+    "events": [
+      "sandbox.created",
+      "sandbox.deleted",
+      "sandbox.paused",
+      "sandbox.resumed"
+    ],
+    "secret": "dev-secret"
+  }
+]'
+```
+
+Start CubeAPI with the environment variable above. When a sandbox is created,
+paused, resumed, or deleted, the receiver prints the event payload.
+
+## Signature
+
+When `secret` is set, CubeAPI sends these headers:
+
+- `X-Cube-Timestamp`
+- `X-Cube-Nonce`
+- `X-Cube-Signature-256`
+
+The signature is:
+
+```text
+sha256=HMAC_SHA256(secret, timestamp + "." + nonce + "." + raw_body)
+```
+
+Set `WEBHOOK_SECRET` to the same value in the receiver to verify requests.
+
+## Test
+
+```bash
+python3 -m unittest discover -s examples/webhook-receiver
+```

--- a/examples/webhook-receiver/README_zh.md
+++ b/examples/webhook-receiver/README_zh.md
@@ -1,0 +1,55 @@
+# CubeSandbox Webhook 接收端示例
+
+这个示例启动一个本地 HTTP 接收端，用来接收 CubeAPI Webhook 事件。示例只使用
+Python 标准库。
+
+## 运行
+
+```bash
+cd examples/webhook-receiver
+WEBHOOK_SECRET=dev-secret python3 receiver.py
+```
+
+默认监听地址是 `http://127.0.0.1:9000/webhook`。
+
+为 CubeAPI 配置 Webhook endpoint：
+
+```bash
+export CUBE_API_WEBHOOK_ENDPOINTS='[
+  {
+    "url": "http://127.0.0.1:9000/webhook",
+    "events": [
+      "sandbox.created",
+      "sandbox.deleted",
+      "sandbox.paused",
+      "sandbox.resumed"
+    ],
+    "secret": "dev-secret"
+  }
+]'
+```
+
+带着上面的环境变量启动 CubeAPI。创建、暂停、恢复或删除沙箱时，接收端会打印事件
+payload。
+
+## 签名
+
+配置 `secret` 后，CubeAPI 会发送这些请求头：
+
+- `X-Cube-Timestamp`
+- `X-Cube-Nonce`
+- `X-Cube-Signature-256`
+
+签名计算方式：
+
+```text
+sha256=HMAC_SHA256(secret, timestamp + "." + nonce + "." + raw_body)
+```
+
+接收端设置相同的 `WEBHOOK_SECRET` 后即可完成验签。
+
+## 测试
+
+```bash
+python3 -m unittest discover -s examples/webhook-receiver
+```

--- a/examples/webhook-receiver/receiver.py
+++ b/examples/webhook-receiver/receiver.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+# Copyright (c) 2024 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+import hashlib
+import hmac
+import json
+import os
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+
+def expected_signature(secret: str, timestamp: str, nonce: str, body: bytes) -> str:
+    message = timestamp.encode() + b"." + nonce.encode() + b"." + body
+    digest = hmac.new(secret.encode(), message, hashlib.sha256).hexdigest()
+    return "sha256=" + digest
+
+
+class WebhookHandler(BaseHTTPRequestHandler):
+    server_version = "CubeWebhookReceiver/1.0"
+
+    def do_POST(self) -> None:
+        if self.path != "/webhook":
+            self.send_response(404)
+            self.end_headers()
+            self.wfile.write(b"not found\n")
+            return
+
+        length = int(self.headers.get("content-length", "0"))
+        body = self.rfile.read(length)
+        secret = os.environ.get("WEBHOOK_SECRET", "")
+
+        if secret:
+            timestamp = self.headers.get("X-Cube-Timestamp", "")
+            nonce = self.headers.get("X-Cube-Nonce", "")
+            signature = self.headers.get("X-Cube-Signature-256", "")
+            expected = expected_signature(secret, timestamp, nonce, body)
+            if not hmac.compare_digest(signature, expected):
+                self.send_response(401)
+                self.end_headers()
+                self.wfile.write(b"invalid signature\n")
+                print("signature=invalid")
+                return
+            print("signature=valid")
+
+        try:
+            payload = json.loads(body.decode("utf-8"))
+        except json.JSONDecodeError:
+            payload = {"raw": body.decode("utf-8", errors="replace")}
+
+        print(
+            json.dumps(
+                {
+                    "event": self.headers.get("X-Cube-Event"),
+                    "delivery": self.headers.get("X-Cube-Delivery"),
+                    "payload": payload,
+                },
+                ensure_ascii=False,
+                sort_keys=True,
+            ),
+            flush=True,
+        )
+
+        self.send_response(204)
+        self.end_headers()
+
+    def log_message(self, fmt: str, *args) -> None:
+        print("%s - %s" % (self.address_string(), fmt % args))
+
+
+def main() -> None:
+    host = os.environ.get("WEBHOOK_HOST", "127.0.0.1")
+    port = int(os.environ.get("WEBHOOK_PORT", "9000"))
+    server = ThreadingHTTPServer((host, port), WebhookHandler)
+    print(f"listening on http://{host}:{port}/webhook")
+    server.serve_forever()
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/webhook-receiver/test_receiver.py
+++ b/examples/webhook-receiver/test_receiver.py
@@ -1,0 +1,27 @@
+# Copyright (c) 2024 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+import hmac
+import unittest
+
+from receiver import expected_signature
+
+
+class SignatureTest(unittest.TestCase):
+    def test_expected_signature_matches_hmac_sha256_contract(self) -> None:
+        body = b'{"event":"sandbox.created","sandbox_id":"sbx-1"}'
+        timestamp = "1784678400"
+        nonce = "nonce-1"
+        signature = expected_signature("secret", timestamp, nonce, body)
+
+        self.assertTrue(signature.startswith("sha256="))
+        self.assertTrue(
+            hmac.compare_digest(
+                signature,
+                "sha256=4d517163105f8aea5c37b35dd132611ac1d2d58e5af1d81ec34d529bb14ad3cd",
+            )
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 背景

Refs #642

Issue #642 要求 CubeAPI 提供 Webhook 事件通知能力，让上层 Agent 编排、运维平台或告警系统不再依赖轮询，就能实时感知沙箱生命周期变化。

当前 CubeAPI 已经在沙箱 handler 成功路径里产出结构化事件：

- `sandbox.created`
- `sandbox.deleted`
- `sandbox.paused`
- `sandbox.resumed`

这些事件通过 `logging::LogEvent` 进入统一 logging pipeline。因此本 PR 选择把 Webhook 实现为一个新的 logging backend，而不是在每个 handler 里单独写 HTTP 投递逻辑。这样生命周期事件只需要在业务代码中产生一次，后续文件日志、Webhook 或其它 backend 都能复用同一份事件流。

## 设计逻辑

### 1. 配置驱动，而不是先做 REST API 管理

Issue 中 REST API 管理是可选项。当前 CubeAPI 没有持久化的用户配置资源，也没有 webhook secret 的存储/读取权限模型。如果直接加入 REST 管理接口，需要额外决定：配置存哪里、重启是否保留、多 CubeAPI 实例如何同步、secret 是否允许读取、谁有权限修改等问题。

所以本 PR 先交付配置驱动版本：

- 通过 `CUBE_API_WEBHOOK_ENDPOINTS` JSON 数组配置一个或多个 endpoint。
- 每个 endpoint 可以独立订阅事件、配置 secret、重试次数、超时和队列大小。
- 投递引擎保持独立，后续如果需要 REST API 管理，可以复用同一套 endpoint/worker 模型。

### 2. 非阻塞投递

Webhook 不应该拖慢沙箱创建、暂停、恢复或删除路径。本 PR 中每个 endpoint 都有独立 bounded queue 和 background worker：

- `Logger::log()` 只做 `try_send`。
- 外部 HTTP 请求全部在后台 worker 中执行。
- 某个 endpoint 慢、超时或不可达，不会影响其它 endpoint，也不会阻塞 sandbox API。
- endpoint 队列满时，只丢弃该 endpoint 的事件并记录 warning。

### 3. 签名与重试

签名使用 HMAC-SHA256，相关 header：

- `X-Cube-Timestamp`
- `X-Cube-Nonce`
- `X-Cube-Signature-256`

签名内容：

```text
sha256=HMAC_SHA256(secret, timestamp + "." + nonce + "." + raw_body)
```

重试策略：

- 网络错误：重试
- `408` / `429` / `5xx`：重试
- 其它 `4xx`：不重试
- 指数退避，支持配置 base/max delay

## 主要改动

### CubeAPI

- `CubeAPI/src/logging/http.rs`
  - 实现 HTTP Webhook backend
  - 支持事件订阅过滤
  - 支持多 endpoint
  - 支持 bounded queue 非阻塞投递
  - 支持 HMAC-SHA256 签名
  - 支持 retry / timeout / 禁用 redirect
  - 补充单元测试

- `CubeAPI/src/config/mod.rs`
  - 新增 `WebhookEndpointConfig`
  - 新增 `CUBE_API_WEBHOOK_ENDPOINTS` JSON 配置解析
  - 默认订阅四个 sandbox lifecycle event
  - `Debug` 输出中对 secret 脱敏

- `CubeAPI/src/main.rs`
  - 将配置的 HTTP webhook backend 接入 `MultiLogger`
  - 配置加载失败时返回错误，避免 webhook JSON 配错后静默退回默认配置

### Example

- `examples/webhook-receiver/receiver.py`
  - 纯 Python 标准库 receiver
  - 支持验签
  - 打印 delivery id、event 和 payload

- `examples/webhook-receiver/test_receiver.py`
  - 覆盖 receiver 端签名算法

### Docs

- `docs/guide/integrations/webhooks.md`
- `docs/zh/guide/integrations/webhooks.md`
- 更新中英文 integrations index

文档包含：配置方式、payload 示例、签名算法、失败处理、receiver 使用方式。

## 配置示例

```bash
export CUBE_API_WEBHOOK_ENDPOINTS='[
  {
    "url": "http://127.0.0.1:9000/webhook",
    "events": [
      "sandbox.created",
      "sandbox.deleted",
      "sandbox.paused",
      "sandbox.resumed"
    ],
    "secret": "dev-secret",
    "queue_capacity": 1024,
    "max_retries": 3,
    "retry_base_ms": 500,
    "retry_max_ms": 30000,
    "timeout_secs": 5
  }
]'
```

## Payload 示例

```json
{
  "timestamp": "2026-07-22T06:48:51.373069438Z",
  "level": "info",
  "event": "sandbox.created",
  "sandbox_id": "f690dc8b332b4aa689c86651743263b8",
  "template_id": "tpl-6d57ad2206644bae8a4793a3"
}
```

## 验证

### 自动化测试

```text
cargo test --manifest-path CubeAPI/Cargo.toml

running 107 tests
...
test result: ok. 107 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

```text
python3 -m unittest discover -s examples/webhook-receiver

Ran 1 test in 0.000s
OK
```

```text
git diff --check
# no output
```

### 远端真实 CubeAPI 验收

在 mindsurf 上用 Docker 构建并启动本 PR 的 CubeAPI 镜像，配置 webhook receiver 后，真实触发 create / pause / resume / delete。

构建镜像：

```text
docker build -t cube-api-webhook:issue642 CubeAPI
# build succeeded
```

CubeAPI 启动日志确认 webhook 已启用：

```text
structured event logger started log_dir=/var/log/cube-api log_prefix=cube-api min_level=info webhook_endpoints=1
cube-api listening on 127.0.0.1:13042
```

Receiver 收到四个 lifecycle event，且签名校验通过：

```text
signature=valid
{"delivery": "8deb364d-c4fe-459d-8053-98f2b15fccad", "event": "sandbox.created", "payload": {"event": "sandbox.created", "level": "info", "sandbox_id": "f690dc8b332b4aa689c86651743263b8", "template_id": "tpl-6d57ad2206644bae8a4793a3", "timestamp": "2026-07-22T06:48:51.373069438Z"}}
127.0.0.1 - "POST /webhook HTTP/1.1" 204 -

signature=valid
{"delivery": "dc4f9038-aed3-4193-83e2-f62b5d852048", "event": "sandbox.paused", "payload": {"event": "sandbox.paused", "level": "info", "sandbox_id": "f690dc8b332b4aa689c86651743263b8", "timestamp": "2026-07-22T06:49:06.563708620Z"}}
127.0.0.1 - "POST /webhook HTTP/1.1" 204 -

signature=valid
{"delivery": "37ac4d04-c410-456e-826f-ffb8252abfb6", "event": "sandbox.resumed", "payload": {"event": "sandbox.resumed", "level": "info", "sandbox_id": "f690dc8b332b4aa689c86651743263b8", "timestamp": "2026-07-22T06:49:31.241213788Z"}}
127.0.0.1 - "POST /webhook HTTP/1.1" 204 -

signature=valid
{"delivery": "fa78dd59-689d-4cc3-82c5-7faad054dabb", "event": "sandbox.deleted", "payload": {"event": "sandbox.deleted", "level": "info", "sandbox_id": "f690dc8b332b4aa689c86651743263b8", "timestamp": "2026-07-22T06:49:39.402570712Z"}}
```

CubeAPI delivered 日志：

```text
create_sandbox: success sandbox_id=f690dc8b332b4aa689c86651743263b8 template_id=tpl-6d57ad2206644bae8a4793a3
webhook delivered url=http://127.0.0.1:19091/webhook event=sandbox.created delivery_id=8deb364d-c4fe-459d-8053-98f2b15fccad attempt=1

pause_sandbox: success sandbox_id=f690dc8b332b4aa689c86651743263b8
webhook delivered url=http://127.0.0.1:19091/webhook event=sandbox.paused delivery_id=dc4f9038-aed3-4193-83e2-f62b5d852048 attempt=1

resume_sandbox: success sandbox_id=f690dc8b332b4aa689c86651743263b8
webhook delivered url=http://127.0.0.1:19091/webhook event=sandbox.resumed delivery_id=37ac4d04-c410-456e-826f-ffb8252abfb6 attempt=1

kill_sandbox: success sandbox_id=f690dc8b332b4aa689c86651743263b8
webhook delivered url=http://127.0.0.1:19091/webhook event=sandbox.deleted delivery_id=fa78dd59-689d-4cc3-82c5-7faad054dabb attempt=1
```

### 失败与重试验收

另起一只 CubeAPI，Webhook endpoint 指向未监听端口 `127.0.0.1:19092`。

结果：sandbox create/delete API 均成功；Webhook 后台 worker 记录失败并重试。

```text
create_sandbox: success sandbox_id=4cde640d3a3342bdb0c5a6e8667f806c template_id=tpl-6d57ad2206644bae8a4793a3
webhook delivery request failed url=http://127.0.0.1:19092/webhook event=sandbox.created delivery_id=09ddc7a4-257b-4140-a4ba-729945cbab65 attempt=1 error=error sending request for url (http://127.0.0.1:19092/webhook)
webhook delivery request failed url=http://127.0.0.1:19092/webhook event=sandbox.created delivery_id=09ddc7a4-257b-4140-a4ba-729945cbab65 attempt=2 error=error sending request for url (http://127.0.0.1:19092/webhook)

kill_sandbox: success sandbox_id=4cde640d3a3342bdb0c5a6e8667f806c
webhook delivery request failed url=http://127.0.0.1:19092/webhook event=sandbox.deleted delivery_id=51563987-7064-4249-82ce-e64bed906650 attempt=1 error=error sending request for url (http://127.0.0.1:19092/webhook)
webhook delivery request failed url=http://127.0.0.1:19092/webhook event=sandbox.deleted delivery_id=51563987-7064-4249-82ce-e64bed906650 attempt=2 error=error sending request for url (http://127.0.0.1:19092/webhook)
```
