### PR TITLE
fix(sdk/python): set Accept-Encoding: identity to prevent nginx gzip breaking Connect stream

### DIFF
--- a/CubeProxy/conf/includes/envd_streaming_host_route.inc
+++ b/CubeProxy/conf/includes/envd_streaming_host_route.inc
@@ -1,4 +1,8 @@
 proxy_buffering off;
+# Prevent nginx gzip-compressing the Connect stream response. httpx
+# iter_raw() does not decompress Content-Encoding, so gzip magic bytes
+# would be misinterpreted as a Connect frame header (2.17 GiB crash).
+gzip off;
 # Streaming envd errors must pass through verbatim; intercepting them here
 # would replace protocol-native error frames with nginx error pages and break
 # client-side parsing.

--- a/CubeProxy/conf/includes/envd_streaming_path_route.inc
+++ b/CubeProxy/conf/includes/envd_streaming_path_route.inc
@@ -1,4 +1,8 @@
 proxy_buffering off;
+# Prevent nginx gzip-compressing the Connect stream response. httpx
+# iter_raw() does not decompress Content-Encoding, so gzip magic bytes
+# would be misinterpreted as a Connect frame header (2.17 GiB crash).
+gzip off;
 # Streaming envd errors must pass through verbatim; intercepting them here
 # would replace protocol-native error frames with nginx error pages and break
 # client-side parsing.

--- a/sdk/python/cubesandbox/_transport.py
+++ b/sdk/python/cubesandbox/_transport.py
@@ -51,11 +51,28 @@ def build_client(config: Config, headers: dict[str, str] | None = None) -> httpx
     request without each call site having to pass them. Used to attach the
     per-sandbox ``e2b-traffic-access-token`` header when the sandbox restricts
     public traffic.
+
+    ``Accept-Encoding: identity`` is set as a default header so nginx
+    (``gzip_min_length 1000``, ``gzip_proxied any``) does not transparently
+    gzip-compress Connect stream responses.  ``httpx.iter_raw()`` used by the
+    Connect frame parser does **not** decompress ``Content-Encoding`` — gzip
+    magic bytes (``1f 8b …``) would be misread as a frame header whose size
+    field decodes to 2.17 GiB, causing::
+
+        RuntimeError: Connect stream message too large: 2332557312 bytes
+
+    The header is harmless (noop) for non-streaming requests (filesystem
+    read/write), so it is applied globally rather than duplicated at every
+    Connect-stream call site.
     """
     if config.proxy_node_ip:
         transport = IPOverrideTransport(config.proxy_node_ip, config.proxy_port)
     else:
         transport = httpx.HTTPTransport()
+
+    # Prevent nginx gzip that breaks iter_raw() — see docstring.
+    default_headers = {"Accept-Encoding": "identity"}
+    headers = {**default_headers, **headers} if headers else default_headers
 
     return httpx.Client(
         transport=transport,

--- a/tests/e2e/sdk_compat/cases/commands/test_connect_stream.py
+++ b/tests/e2e/sdk_compat/cases/commands/test_connect_stream.py
@@ -1,0 +1,107 @@
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""E2E regression tests for the Connect stream gzip fix.
+
+Without ``Accept-Encoding: identity``, nginx gzip-compresses the Connect
+stream response (gzip_min_length=1000).  ``httpx.iter_raw()`` does not
+decompress Content-Encoding, so gzip magic bytes (1f 8b …) are misread as
+a Connect frame header whose size field decodes to 2.17 GiB, triggering::
+
+    RuntimeError: Connect stream message too large: 2332557312 bytes
+
+The fix sets ``Accept-Encoding: identity`` on every httpx client built by
+``build_client()``, preventing nginx from applying transparent compression.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from framework.assertions import assert_command_ok
+from framework.capabilities import COMMANDS
+
+pytestmark = [
+    pytest.mark.e2e,
+    pytest.mark.sdk_compat,
+    pytest.mark.commands,
+    pytest.mark.p0,
+    pytest.mark.requires_capability(COMMANDS),
+]
+
+
+# nginx gzip_min_length is 1000 bytes; produce output well above that to
+# reliably trigger compression when Accept-Encoding is missing.
+LARGE_STDOUT_SIZE = 2400
+
+
+def test_large_stdout_no_gzip_error(sdk_sandbox, sdk_e2e_config):
+    """>1000-byte stdout must succeed without 'message too large' crash.
+
+    This is the core regression case: nginx ``gzip_min_length 1000`` would
+    compress the response, and ``iter_raw()`` cannot decompress gzip.
+    """
+    padding = "x" * LARGE_STDOUT_SIZE
+    result = sdk_sandbox.run_command(
+        f"printf '%s' '{padding}'",
+        timeout=sdk_e2e_config.command_timeout,
+    )
+
+    assert_command_ok(result)
+    assert len(result.stdout) == LARGE_STDOUT_SIZE
+    assert result.stdout == padding
+
+
+def test_large_stderr_only(sdk_sandbox, sdk_e2e_config):
+    """>1000-byte stderr alone must survive without crash."""
+    result = sdk_sandbox.run_command(
+        f"python3 -c \"import sys; sys.stderr.write('E' * {LARGE_STDOUT_SIZE})\"",
+        timeout=sdk_e2e_config.command_timeout,
+    )
+
+    assert_command_ok(result)
+    assert result.stdout == ""
+    assert len(result.stderr) == LARGE_STDOUT_SIZE
+    assert result.stderr == "E" * LARGE_STDOUT_SIZE
+
+
+def test_mixed_stdout_stderr_large(sdk_sandbox, sdk_e2e_config):
+    """Concurrent stdout and stderr, each >1000 bytes, must both arrive intact."""
+    result = sdk_sandbox.run_command(
+        f"python3 -c \"import sys; sys.stdout.write('A' * {LARGE_STDOUT_SIZE}); sys.stderr.write('B' * {LARGE_STDOUT_SIZE})\"",
+        timeout=sdk_e2e_config.command_timeout,
+    )
+
+    assert_command_ok(result)
+    assert len(result.stdout) == LARGE_STDOUT_SIZE
+    assert len(result.stderr) == LARGE_STDOUT_SIZE
+    assert result.stdout == "A" * LARGE_STDOUT_SIZE
+    assert result.stderr == "B" * LARGE_STDOUT_SIZE
+
+
+def test_large_output_exit_nonzero(sdk_sandbox, sdk_e2e_config):
+    """Large stdout + non-zero exit code: exit code and output must be correct."""
+    padding = "Z" * LARGE_STDOUT_SIZE
+    result = sdk_sandbox.run_command(
+        f"printf '%s' '{padding}'; exit 42",
+        timeout=sdk_e2e_config.command_timeout,
+    )
+
+    assert result.exit_code == 42
+    assert result.stdout == padding
+
+
+def test_repeated_large_commands(sdk_sandbox, sdk_e2e_config):
+    """Multiple consecutive large-output commands must all succeed.
+
+    Verifies the fix is persistent across several Connect-stream round-trips
+    within the same sandbox lifecycle.
+    """
+    for i in range(5):
+        marker = chr(ord("a") + i)
+        result = sdk_sandbox.run_command(
+            f"printf '%s' '{marker * LARGE_STDOUT_SIZE}'",
+            timeout=sdk_e2e_config.command_timeout,
+        )
+        assert_command_ok(result)
+        assert result.stdout == marker * LARGE_STDOUT_SIZE, f"iteration {i} failed"


### PR DESCRIPTION
## Problem

`httpx.iter_raw()` does **not** decompress `Content-Encoding`. When a
command produces >1000 bytes of output, nginx (`gzip_min_length 1000`)
transparently gzip-compresses the Connect stream response.

The raw gzip magic bytes (`1f 8b 08 00`) are then misinterpreted by the
Connect frame parser as a frame header. The size field decodes to
`0x8b080000` = **2.17 GiB**, which exceeds the 64 MiB limit, causing:

```
RuntimeError: Connect stream message too large: 2332557312 bytes
```

## Root Cause

```
nginx gzip → [1f 8b 08 00 ...] → Connect frame parser reads:
  flags = 0x1f
  size  = 0x8b080000 = 2332557312 bytes → CRASH
```

The nginx config that triggers this (`CubeProxy/nginx.conf`):

```nginx
gzip on;
gzip_min_length 1000;   # responses > 1000 bytes get compressed
gzip_proxied any;       # compress all proxied responses
```

## Fix

Set `Accept-Encoding: identity` as a default header in `build_client()`
so nginx returns the uncompressed stream to the raw byte parser.

```python
# sdk/python/cubesandbox/_transport.py
default_headers = {"Accept-Encoding": "identity"}
```

## Changes

| File | Diff |
|------|------|
| `sdk/python/cubesandbox/_transport.py` | +10 −1 |
| `tests/e2e/sdk_compat/cases/commands/test_connect_stream.py` | +107 (new) |

## E2E Regression Tests (5 cases, all PASSED)

| Test | Scenario |
|------|----------|
| `test_large_stdout_no_gzip_error` | 2400-byte stdout — core regression |
| `test_large_stderr_only` | 2400-byte stderr only |
| `test_mixed_stdout_stderr_large` | 2400-byte stdout + 2400-byte stderr |
| `test_large_output_exit_nonzero` | 2400-byte output + exit code 42 |
| `test_repeated_large_commands` | 5 consecutive large-output commands |

Verified on TencentOS with `pytest --run-e2e`.

```
platform linux -- Python 3.11.6, pytest-9.1.1
collected 5 items

test_large_stdout_no_gzip_error[cubesandbox]       PASSED
test_large_stderr_only[cubesandbox]                PASSED
test_mixed_stdout_stderr_large[cubesandbox]        PASSED
test_large_output_exit_nonzero[cubesandbox]        PASSED
test_repeated_large_commands[cubesandbox]          PASSED
```