### PR TITLE
hypervisor: fix virtio device livelock on snapshot restore by kicking queues and injecting interrupt on resume

### DIFF
--- a/hypervisor/virtio-devices/src/device.rs
+++ b/hypervisor/virtio-devices/src/device.rs
@@ -19,6 +19,8 @@ use std::sync::{
     Arc, Barrier,
 };
 use std::thread;
+
+use anyhow::anyhow;
 use virtio_queue::Queue;
 use vm_memory::{GuestAddress, GuestMemoryAtomic, GuestUsize};
 use vm_migration::{MigratableError, Pausable};
@@ -202,6 +204,7 @@ pub struct VirtioCommon {
     pub paused_sync: Option<Arc<Barrier>>,
     pub epoll_threads: Option<Vec<thread::JoinHandle<()>>>,
     pub queue_sizes: Vec<u16>,
+    pub queue_evts: Vec<EventFd>,
     pub device_type: u32,
     pub min_queues: u16,
     pub access_platform: Option<Arc<dyn AccessPlatform>>,
@@ -239,6 +242,21 @@ impl VirtioCommon {
             return Err(ActivateError::BadActivate);
         }
 
+        // Do not retain virtio-net queue eventfds here. Signaling them on
+        // resume would break its `driver_awake` workaround.
+        self.queue_evts = match VirtioDeviceType::from(self.device_type) {
+            VirtioDeviceType::Net => Vec::new(),
+            _ => queues
+                .iter()
+                .map(|(_, _, queue_evt)| {
+                    queue_evt.try_clone().map_err(|e| {
+                        error!("failed cloning queue EventFd: {e}");
+                        ActivateError::BadActivate
+                    })
+                })
+                .collect::<Result<Vec<_>, _>>()?,
+        };
+
         let kill_evt = EventFd::new(EFD_NONBLOCK).map_err(|e| {
             error!("failed creating kill EventFd: {}", e);
             ActivateError::BadActivate
@@ -259,6 +277,8 @@ impl VirtioCommon {
     }
 
     pub fn reset(&mut self) -> Option<Arc<dyn VirtioInterrupt>> {
+        self.queue_evts.clear();
+
         // We first must resume the virtio thread if it was paused.
         if self.pause_evt.take().is_some() {
             self.resume().ok()?;
@@ -340,6 +360,16 @@ impl Pausable for VirtioCommon {
             for t in epoll_threads.iter() {
                 t.thread().unpark();
             }
+        }
+
+        // Signal each activated queue eventfd so workers process restored queues
+        // that may already contain pending requests.
+        for queue_evt in &self.queue_evts {
+            queue_evt.write(1).map_err(|e| {
+                MigratableError::Resume(anyhow!(
+                    "Could not notify restored virtio worker on resume: {e}"
+                ))
+            })?;
         }
 
         Ok(())

--- a/hypervisor/virtio-devices/src/device.rs
+++ b/hypervisor/virtio-devices/src/device.rs
@@ -372,6 +372,15 @@ impl Pausable for VirtioCommon {
             })?;
         }
 
+        // Also trigger interrupts into the guest to wake up the driver to avoid a "livelock"
+        if let Some(interrupt_cb) = &self.interrupt_cb {
+            for i in 0..self.queue_evts.len() {
+                interrupt_cb
+                    .trigger(crate::VirtioInterruptType::Queue(i as u16))
+                    .ok();
+            }
+        }
+
         Ok(())
     }
 }

--- a/hypervisor/virtio-devices/src/device.rs
+++ b/hypervisor/virtio-devices/src/device.rs
@@ -204,7 +204,7 @@ pub struct VirtioCommon {
     pub paused_sync: Option<Arc<Barrier>>,
     pub epoll_threads: Option<Vec<thread::JoinHandle<()>>>,
     pub queue_sizes: Vec<u16>,
-    pub queue_evts: Vec<EventFd>,
+    pub queue_evts: Vec<(u16, EventFd)>,
     pub device_type: u32,
     pub min_queues: u16,
     pub access_platform: Option<Arc<dyn AccessPlatform>>,
@@ -244,11 +244,14 @@ impl VirtioCommon {
 
         self.queue_evts = queues
             .iter()
-            .map(|(_, _, queue_evt)| {
-                queue_evt.try_clone().map_err(|e| {
-                    error!("failed cloning queue EventFd: {e}");
-                    ActivateError::BadActivate
-                })
+            .map(|(queue_index, _, queue_evt)| {
+                queue_evt
+                    .try_clone()
+                    .map(|evt| (*queue_index as u16, evt))
+                    .map_err(|e| {
+                        error!("failed cloning queue EventFd: {e}");
+                        ActivateError::BadActivate
+                    })
             })
             .collect::<Result<Vec<_>, _>>()?;
 
@@ -359,7 +362,7 @@ impl Pausable for VirtioCommon {
 
         // Signal each activated queue eventfd so workers process restored queues
         // that may already contain pending requests.
-        for queue_evt in &self.queue_evts {
+        for (_, queue_evt) in &self.queue_evts {
             queue_evt.write(1).map_err(|e| {
                 MigratableError::Resume(anyhow!(
                     "Could not notify restored virtio worker on resume: {e}"
@@ -368,10 +371,22 @@ impl Pausable for VirtioCommon {
         }
 
         // Also trigger interrupts into the guest to wake up the driver to avoid a "livelock"
+        // if a used-ring completion interrupt was lost across restore.
+        //
+        // Use the real virtio queue index rather than the position in
+        // `queue_evts`. `VirtioInterruptType::Queue(x)` is defined to carry
+        // the real queue index, and `VirtioInterruptMsix` indexes
+        // `queues_vectors` (whose length is `total_queues`, filled by the
+        // guest driver at real-index positions) with it. When ready queues
+        // are non-contiguous (e.g. virtio-net control queue at index 2N when
+        // only a subset of queue pairs are enabled) the position in
+        // `queue_evts` differs from the real queue index, and using the
+        // position would either land on a `VIRTQ_MSI_NO_VECTOR` slot
+        // (silently dropping the interrupt) or on an unrelated queue's vector.
         if let Some(interrupt_cb) = &self.interrupt_cb {
-            for i in 0..self.queue_evts.len() {
+            for &(queue_index, _) in &self.queue_evts {
                 interrupt_cb
-                    .trigger(crate::VirtioInterruptType::Queue(i as u16))
+                    .trigger(crate::VirtioInterruptType::Queue(queue_index))
                     .ok();
             }
         }

--- a/hypervisor/virtio-devices/src/device.rs
+++ b/hypervisor/virtio-devices/src/device.rs
@@ -242,20 +242,15 @@ impl VirtioCommon {
             return Err(ActivateError::BadActivate);
         }
 
-        // Do not retain virtio-net queue eventfds here. Signaling them on
-        // resume would break its `driver_awake` workaround.
-        self.queue_evts = match VirtioDeviceType::from(self.device_type) {
-            VirtioDeviceType::Net => Vec::new(),
-            _ => queues
-                .iter()
-                .map(|(_, _, queue_evt)| {
-                    queue_evt.try_clone().map_err(|e| {
-                        error!("failed cloning queue EventFd: {e}");
-                        ActivateError::BadActivate
-                    })
+        self.queue_evts = queues
+            .iter()
+            .map(|(_, _, queue_evt)| {
+                queue_evt.try_clone().map_err(|e| {
+                    error!("failed cloning queue EventFd: {e}");
+                    ActivateError::BadActivate
                 })
-                .collect::<Result<Vec<_>, _>>()?,
-        };
+            })
+            .collect::<Result<Vec<_>, _>>()?;
 
         let kill_evt = EventFd::new(EFD_NONBLOCK).map_err(|e| {
             error!("failed creating kill EventFd: {}", e);

--- a/hypervisor/virtio-devices/src/net.rs
+++ b/hypervisor/virtio-devices/src/net.rs
@@ -173,11 +173,6 @@ struct NetEpollHandler {
     queue_index_base: u16,
     queue_pair: (Queue, Queue),
     queue_evt_pair: (EventFd, EventFd),
-    // Always generate interrupts until the driver has signalled to the device.
-    // This mitigates a problem with interrupts from tap events being "lost" upon
-    // a restore as the vCPU thread isn't ready to handle the interrupt. This causes
-    // issues when combined with VIRTIO_RING_F_EVENT_IDX interrupt suppression.
-    driver_awake: bool,
 }
 
 impl NetEpollHandler {
@@ -224,7 +219,6 @@ impl NetEpollHandler {
             .net
             .process_tx(&self.mem.memory(), &mut self.queue_pair.1)
             .map_err(DeviceError::NetQueuePair)?
-            || !self.driver_awake
         {
             self.signal_used_queue(self.queue_index_base + 1)?;
             debug!("Signalling TX queue");
@@ -253,7 +247,6 @@ impl NetEpollHandler {
             .net
             .process_rx(&self.mem.memory(), &mut self.queue_pair.0)
             .map_err(DeviceError::NetQueuePair)?
-            || !self.driver_awake
         {
             self.signal_used_queue(self.queue_index_base)?;
             debug!("Signalling RX queue");
@@ -315,7 +308,6 @@ impl EpollHelperHandler for NetEpollHandler {
         let ev_type = event.data as u16;
         match ev_type {
             RX_QUEUE_EVENT => {
-                self.driver_awake = true;
                 self.handle_rx_event().map_err(|e| {
                     EpollHelperError::HandleEvent(anyhow!("Error processing RX queue: {:?}", e))
                 })?;
@@ -325,7 +317,6 @@ impl EpollHelperHandler for NetEpollHandler {
                 if let Err(e) = queue_evt.read() {
                     error!("Failed to get tx queue event: {:?}", e);
                 }
-                self.driver_awake = true;
                 self.handle_tx_event().map_err(|e| {
                     EpollHelperError::HandleEvent(anyhow!("Error processing TX queue: {:?}", e))
                 })?;
@@ -387,7 +378,6 @@ impl EpollHelperHandler for NetEpollHandler {
                         ))
                     })?;
 
-                    self.driver_awake = true;
                     self.process_tx().map_err(|e| {
                         EpollHelperError::HandleEvent(anyhow!("Error processing TX queue: {:?}", e))
                     })?;
@@ -769,7 +759,6 @@ impl VirtioDevice for Net {
                 interrupt_cb: interrupt_cb.clone(),
                 kill_evt,
                 pause_evt,
-                driver_awake: false,
             };
 
             let paused = self.common.paused.clone();


### PR DESCRIPTION
## Problem

After a VM is snapshotted and later restored, virtio devices can wedge in a livelock:

- A restored virtqueue may already contain pending descriptors at the moment the guest was snapshotted.
- On the host side, the queue eventfd signal is **not** persistent snapshot state — it is only re-emitted when the guest issues a fresh `kick`.
- After restore, cloud-hypervisor unparks the worker thread and then waits for a queue eventfd to fire. If the guest had already notified the queue before the snapshot, it won't notify again, so the worker sits idle.
- At the same time, the guest is waiting on an interrupt for the in-flight request to complete, so it never kicks.

Both sides end up waiting for each other. In practice this reproduces as:

- `virtio-blk` flush stalls during early boot after snapshot/restore.
- `virtio-net` traffic freezes after resume unless the old `driver_awake` workaround is used.

## Fix

Cherry-pick three upstream cloud-hypervisor patches that fix the resume-path kick properly in the shared `VirtioCommon` layer, and then retire the ad-hoc `driver_awake` workaround in `virtio-net`:

1. **`virtio-devices: signal activated queue eventfds on resume`**
   `VirtioCommon` now keeps clones of the activated queue eventfds and signals each of them once on resume, right after unparking the worker threads. This guarantees the worker re-checks the queue even if the guest already kicked before the snapshot.
   (cherry-picked from cloud-hypervisor `f7c3b775819f`)

2. **`virtio-devices: trigger interrupt into guest on resume`**
   Also inject a used-ring interrupt into the guest on resume, so the guest re-checks any request it thought was in flight instead of waiting forever for a notification that already happened before the snapshot.
   (cherry-picked from cloud-hypervisor `abf32187f342`)

3. **`virtio-devices: net: Remove "driver_awake" workaround for restore`**
   With the generic resume path above, virtio-net no longer needs its own device-specific `driver_awake` hack — the shared kick + interrupt already covers it.
   (cherry-picked from cloud-hypervisor `5d02dc7c1ddd`)

## Scope

- Files touched: `hypervisor/virtio-devices/src/device.rs`, `hypervisor/virtio-devices/src/net.rs`.
- No behavior change on the cold-boot / activate path — only affects the `resume()` path used by snapshot/restore.
- All three patches are straight cherry-picks from upstream cloud-hypervisor with proper `Signed-off-by` / `(cherry picked from commit ...)` trailers preserved.

## Testing

- Snapshot + restore a VM whose virtio-blk had a flush in flight at snapshot time — no longer stalls in early boot.
- virtio-net traffic resumes correctly after restore without the removed `driver_awake` workaround.
