### PR TITLE
fix(CubeMaster): ListSandbox fail-loud when no queryable nodes exist

### DIFF
--- a/CubeMaster/pkg/errorcode/error.go
+++ b/CubeMaster/pkg/errorcode/error.go
@@ -49,9 +49,9 @@ var (
 		"Conflict":               130409,
 		"NotFound":               130404,
 		"NotFoundAtCubelet":      130406,
+		"CubeletUnHealthy":       130408,
 		"TooManyRequests":        130429,
 		"ClientCancel":           130499,
-		"CubeletUnHealthy":       130408,
 		"AuthFailed":             130401,
 	}
 	errorCode_name = map[int32]string{
@@ -69,9 +69,9 @@ var (
 		130401: "AuthFailed",
 		130404: "NotFound",
 		130406: "NotFoundAtCubelet",
+		130408: "CubeletUnHealthy",
 		130429: "TooManyRequests",
 		130499: "ClientCancel",
-		130408: "CubeletUnHealthy",
 	}
 )
 

--- a/CubeMaster/pkg/errorcode/error.go
+++ b/CubeMaster/pkg/errorcode/error.go
@@ -51,6 +51,7 @@ var (
 		"NotFoundAtCubelet":      130406,
 		"TooManyRequests":        130429,
 		"ClientCancel":           130499,
+		"CubeletUnHealthy":       130408,
 		"AuthFailed":             130401,
 	}
 	errorCode_name = map[int32]string{
@@ -70,6 +71,7 @@ var (
 		130406: "NotFoundAtCubelet",
 		130429: "TooManyRequests",
 		130499: "ClientCancel",
+		130408: "CubeletUnHealthy",
 	}
 )
 

--- a/CubeMaster/pkg/localcache/export_range_db_host_test.go
+++ b/CubeMaster/pkg/localcache/export_range_db_host_test.go
@@ -1,0 +1,38 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package localcache
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/constants"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/node"
+)
+
+// ListSandbox pages over RangeDBHost and treats an empty first page as "no
+// queryable node exists" (see hasAnyDBHost in sandbox_list.go). That only holds
+// because sortedNodesByClusters never keeps a node whose health has lapsed, so
+// pin the invariant here: when the last node turns unhealthy the page empties.
+func TestRangeDBHostDropsNodeWhoseHealthLapses(t *testing.T) {
+	origSorted := l.sortedNodesByClusters
+	defer func() {
+		l.sortedNodesByClusters = origSorted
+	}()
+
+	n := &node.Node{InsID: "n1", IP: "10.0.0.1", Healthy: true}
+	l.sortedNodesByClusters = map[string]node.NodeList{
+		constants.DefaultInstanceTypeName: {n},
+	}
+
+	page, _ := RangeDBHost(1, 1, constants.DefaultInstanceTypeName)
+	assert.Len(t, page, 1)
+
+	n.Healthy = false
+	l.updateSortedNodes(n)
+
+	page, _ = RangeDBHost(1, 1, constants.DefaultInstanceTypeName)
+	assert.Empty(t, page)
+}

--- a/CubeMaster/pkg/service/sandbox/sandbox_list.go
+++ b/CubeMaster/pkg/service/sandbox/sandbox_list.go
@@ -36,18 +36,11 @@ var (
 )
 
 // hasAnyDBHost reports whether the node source ListSandbox pages over has any
-// entry at all. IndexByPage collapses "empty list" and "start index past the
-// last node" into the same nil result, so an empty page alone cannot tell a
-// service outage from the legitimate end of pagination; probing the first page
-// disambiguates using the same source (and instance-type fallback) as the
-// paged read.
-//
-// No explicit health check is needed here: the source RangeDBHost pages over,
-// localcache's sortedNodesByClusters, only ever holds healthy nodes —
-// appendSortedNodes skips !n.Healthy, updateSortedNodes removes a node as soon
-// as it turns unhealthy, and the reported-not-ready path calls delSortedNodes.
-// So "every node unhealthy" already reduces to an empty list here and is
-// reported as CubeletUnHealthy, matching GetSandbox's per-node n.Healthy check.
+// entry at all: IndexByPage returns nil both for an empty list and for a start
+// index past the last node, so an empty page alone cannot tell a service outage
+// from the end of pagination. The source only ever holds healthy nodes (see
+// TestRangeDBHostDropsNodeWhoseHealthLapses), so "no entry at all" covers the
+// all-unhealthy case too.
 func hasAnyDBHost(instanceType string) bool {
 	firstPage, _ := rangeDBHostFn(1, 1, instanceType)
 	return len(firstPage) != 0
@@ -103,20 +96,10 @@ func ListSandbox(ctx context.Context, req *types.ListCubeSandboxReq) (rsp *types
 
 	if len(nodeList) == 0 {
 		if req.HostID == "" && !hasAnyDBHost(req.InstanceType) {
-			// Fail loud instead of fail-open: with no queryable nodes at all
-			// (e.g. the only cubelet's health registration briefly lapsed) the
-			// list cannot be authoritatively answered, and "Success + empty" is
-			// indistinguishable from "there are genuinely no sandboxes" — a
-			// caller reconciling its inventory against this list would treat
-			// the transient outage as mass deletion. Return CubeletUnHealthy
-			// instead, mirroring GetSandbox's handling of unhealthy nodes.
-			// "Retryable" here means from the API consumer's perspective (the
-			// condition is transient); the code is deliberately not added to
-			// the internal cubeCodeRetryMap that drives task-level retries —
-			// operators can opt it in via CubeletConf.RetryCode now that
-			// 130408 is registered in errorCode_value. Paginating past the
-			// last node while nodes are still registered keeps returning an
-			// empty Success page.
+			// No queryable node at all: "Success + empty" is indistinguishable
+			// from "there are genuinely no sandboxes", so a caller reconciling
+			// its inventory would read a transient outage as mass deletion.
+			// Fail loud instead, as GetSandbox already does.
 			rsp.Ret.RetCode = int(errorcode.ErrorCode_CubeletUnHealthy)
 			rsp.Ret.RetMsg = errorcode.ErrorCode_CubeletUnHealthy.String()
 		}

--- a/CubeMaster/pkg/service/sandbox/sandbox_list.go
+++ b/CubeMaster/pkg/service/sandbox/sandbox_list.go
@@ -101,10 +101,15 @@ func ListSandbox(ctx context.Context, req *types.ListCubeSandboxReq) (rsp *types
 			// list cannot be authoritatively answered, and "Success + empty" is
 			// indistinguishable from "there are genuinely no sandboxes" — a
 			// caller reconciling its inventory against this list would treat
-			// the transient outage as mass deletion. Return the retryable
-			// CubeletUnHealthy instead, mirroring GetSandbox's handling of
-			// unhealthy nodes. Paginating past the last node while nodes are
-			// still registered keeps returning an empty Success page.
+			// the transient outage as mass deletion. Return CubeletUnHealthy
+			// instead, mirroring GetSandbox's handling of unhealthy nodes.
+			// "Retryable" here means from the API consumer's perspective (the
+			// condition is transient); the code is deliberately not added to
+			// the internal cubeCodeRetryMap that drives task-level retries —
+			// operators can opt it in via CubeletConf.RetryCode now that
+			// 130408 is registered in errorCode_value. Paginating past the
+			// last node while nodes are still registered keeps returning an
+			// empty Success page.
 			rsp.Ret.RetCode = int(errorcode.ErrorCode_CubeletUnHealthy)
 			rsp.Ret.RetMsg = errorcode.ErrorCode_CubeletUnHealthy.String()
 		}

--- a/CubeMaster/pkg/service/sandbox/sandbox_list.go
+++ b/CubeMaster/pkg/service/sandbox/sandbox_list.go
@@ -41,6 +41,13 @@ var (
 // service outage from the legitimate end of pagination; probing the first page
 // disambiguates using the same source (and instance-type fallback) as the
 // paged read.
+//
+// No explicit health check is needed here: the source RangeDBHost pages over,
+// localcache's sortedNodesByClusters, only ever holds healthy nodes —
+// appendSortedNodes skips !n.Healthy, updateSortedNodes removes a node as soon
+// as it turns unhealthy, and the reported-not-ready path calls delSortedNodes.
+// So "every node unhealthy" already reduces to an empty list here and is
+// reported as CubeletUnHealthy, matching GetSandbox's per-node n.Healthy check.
 func hasAnyDBHost(instanceType string) bool {
 	firstPage, _ := rangeDBHostFn(1, 1, instanceType)
 	return len(firstPage) != 0

--- a/CubeMaster/pkg/service/sandbox/sandbox_list.go
+++ b/CubeMaster/pkg/service/sandbox/sandbox_list.go
@@ -29,6 +29,23 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 )
 
+// Test seams (see setSandboxProxyMapFn in sandbox_run.go for the convention).
+var (
+	rangeDBHostFn           = localcache.RangeDBHost
+	healthyNodesByProductFn = localcache.GetHealthyNodesByInstanceType
+)
+
+// hasAnyDBHost reports whether the node source ListSandbox pages over has any
+// entry at all. IndexByPage collapses "empty list" and "start index past the
+// last node" into the same nil result, so an empty page alone cannot tell a
+// service outage from the legitimate end of pagination; probing the first page
+// disambiguates using the same source (and instance-type fallback) as the
+// paged read.
+func hasAnyDBHost(instanceType string) bool {
+	firstPage, _ := rangeDBHostFn(1, 1, instanceType)
+	return len(firstPage) != 0
+}
+
 func ListSandbox(ctx context.Context, req *types.ListCubeSandboxReq) (rsp *types.ListCubeSandboxRes) {
 	if req.RequestID == "" {
 		req.RequestID = uuid.New().String()
@@ -51,7 +68,7 @@ func ListSandbox(ctx context.Context, req *types.ListCubeSandboxReq) (rsp *types
 			RetMsg:  errorcode.ErrorCode_Success.String(),
 		},
 
-		Total: localcache.GetHealthyNodesByInstanceType(-1, req.InstanceType).Len(),
+		Total: healthyNodesByProductFn(-1, req.InstanceType).Len(),
 	}
 
 	var nodeList []*node.Node
@@ -74,10 +91,23 @@ func ListSandbox(ctx context.Context, req *types.ListCubeSandboxReq) (rsp *types
 			req.StartIdx = 1
 		}
 
-		nodeList, rsp.EndIdx = localcache.RangeDBHost(req.StartIdx, req.Size, req.InstanceType)
+		nodeList, rsp.EndIdx = rangeDBHostFn(req.StartIdx, req.Size, req.InstanceType)
 	}
 
 	if len(nodeList) == 0 {
+		if req.HostID == "" && !hasAnyDBHost(req.InstanceType) {
+			// Fail loud instead of fail-open: with no queryable nodes at all
+			// (e.g. the only cubelet's health registration briefly lapsed) the
+			// list cannot be authoritatively answered, and "Success + empty" is
+			// indistinguishable from "there are genuinely no sandboxes" — a
+			// caller reconciling its inventory against this list would treat
+			// the transient outage as mass deletion. Return the retryable
+			// CubeletUnHealthy instead, mirroring GetSandbox's handling of
+			// unhealthy nodes. Paginating past the last node while nodes are
+			// still registered keeps returning an empty Success page.
+			rsp.Ret.RetCode = int(errorcode.ErrorCode_CubeletUnHealthy)
+			rsp.Ret.RetMsg = errorcode.ErrorCode_CubeletUnHealthy.String()
+		}
 		return
 	}
 

--- a/CubeMaster/pkg/service/sandbox/sandbox_list_test.go
+++ b/CubeMaster/pkg/service/sandbox/sandbox_list_test.go
@@ -7,6 +7,8 @@ import (
 	"context"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/node"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/errorcode"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/service/sandbox/types"
@@ -85,16 +87,9 @@ func TestListSandboxEmptyResultClassification(t *testing.T) {
 
 		rsp := ListSandbox(context.Background(), &types.ListCubeSandboxReq{StartIdx: 1, Size: 10})
 
-		if rsp.Ret.RetCode != int(errorcode.ErrorCode_CubeletUnHealthy) {
-			t.Fatalf("RetCode=%d, want CubeletUnHealthy(%d)",
-				rsp.Ret.RetCode, int(errorcode.ErrorCode_CubeletUnHealthy))
-		}
-		if len(rsp.Data) != 0 {
-			t.Fatalf("Data=%v, want empty", rsp.Data)
-		}
-		if rsp.Ret.RetMsg != "CubeletUnHealthy" {
-			t.Fatalf("RetMsg=%q, want CubeletUnHealthy", rsp.Ret.RetMsg)
-		}
+		assert.Equal(t, int(errorcode.ErrorCode_CubeletUnHealthy), rsp.Ret.RetCode)
+		assert.Equal(t, "CubeletUnHealthy", rsp.Ret.RetMsg)
+		assert.Empty(t, rsp.Data)
 	})
 
 	t.Run("paginating past the last node keeps Success with an empty page", func(t *testing.T) {
@@ -102,11 +97,7 @@ func TestListSandboxEmptyResultClassification(t *testing.T) {
 
 		rsp := ListSandbox(context.Background(), &types.ListCubeSandboxReq{StartIdx: 5, Size: 10})
 
-		if rsp.Ret.RetCode != int(errorcode.ErrorCode_Success) {
-			t.Fatalf("RetCode=%d, want Success", rsp.Ret.RetCode)
-		}
-		if len(rsp.Data) != 0 {
-			t.Fatalf("Data=%v, want empty page", rsp.Data)
-		}
+		assert.Equal(t, int(errorcode.ErrorCode_Success), rsp.Ret.RetCode)
+		assert.Empty(t, rsp.Data)
 	})
 }

--- a/CubeMaster/pkg/service/sandbox/sandbox_list_test.go
+++ b/CubeMaster/pkg/service/sandbox/sandbox_list_test.go
@@ -98,6 +98,7 @@ func TestListSandboxEmptyResultClassification(t *testing.T) {
 		rsp := ListSandbox(context.Background(), &types.ListCubeSandboxReq{StartIdx: 5, Size: 10})
 
 		assert.Equal(t, int(errorcode.ErrorCode_Success), rsp.Ret.RetCode)
+		assert.Equal(t, "Success", rsp.Ret.RetMsg)
 		assert.Empty(t, rsp.Data)
 	})
 }

--- a/CubeMaster/pkg/service/sandbox/sandbox_list_test.go
+++ b/CubeMaster/pkg/service/sandbox/sandbox_list_test.go
@@ -3,7 +3,14 @@
 
 package sandbox
 
-import "testing"
+import (
+	"context"
+	"testing"
+
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/node"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/errorcode"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/service/sandbox/types"
+)
 
 func TestParseCPUCount(t *testing.T) {
 	tests := []struct {
@@ -54,4 +61,52 @@ func TestParseMemoryMB(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestListSandboxEmptyResultClassification(t *testing.T) {
+	origRange := rangeDBHostFn
+	origHealthy := healthyNodesByProductFn
+	defer func() {
+		rangeDBHostFn = origRange
+		healthyNodesByProductFn = origHealthy
+	}()
+
+	stub := func(nodes node.NodeList) {
+		rangeDBHostFn = func(index, size int, product string) ([]*node.Node, int) {
+			return nodes.IndexByPage(index, size)
+		}
+		healthyNodesByProductFn = func(n int, product string) node.NodeList {
+			return nodes
+		}
+	}
+
+	t.Run("no queryable nodes returns retryable CubeletUnHealthy", func(t *testing.T) {
+		stub(node.NodeList{})
+
+		rsp := ListSandbox(context.Background(), &types.ListCubeSandboxReq{StartIdx: 1, Size: 10})
+
+		if rsp.Ret.RetCode != int(errorcode.ErrorCode_CubeletUnHealthy) {
+			t.Fatalf("RetCode=%d, want CubeletUnHealthy(%d)",
+				rsp.Ret.RetCode, int(errorcode.ErrorCode_CubeletUnHealthy))
+		}
+		if len(rsp.Data) != 0 {
+			t.Fatalf("Data=%v, want empty", rsp.Data)
+		}
+		if rsp.Ret.RetMsg != "CubeletUnHealthy" {
+			t.Fatalf("RetMsg=%q, want CubeletUnHealthy", rsp.Ret.RetMsg)
+		}
+	})
+
+	t.Run("paginating past the last node keeps Success with an empty page", func(t *testing.T) {
+		stub(node.NodeList{{InsID: "host-1"}, {InsID: "host-2"}})
+
+		rsp := ListSandbox(context.Background(), &types.ListCubeSandboxReq{StartIdx: 5, Size: 10})
+
+		if rsp.Ret.RetCode != int(errorcode.ErrorCode_Success) {
+			t.Fatalf("RetCode=%d, want Success", rsp.Ret.RetCode)
+		}
+		if len(rsp.Data) != 0 {
+			t.Fatalf("Data=%v, want empty page", rsp.Data)
+		}
+	})
 }


### PR DESCRIPTION
Fixes #933

## Problem

The full-list branch of `ListSandbox` returns `RetCode=Success` with an empty sandbox list whenever `RangeDBHost` yields no nodes — including when **no healthy node is registered at all** (e.g. the only cubelet's health registration briefly lapsing on heartbeat TTL jitter). A caller reconciling its inventory against the list cannot distinguish that transient outage from "there are genuinely no sandboxes" and may perform destructive cleanup (details and real-world impact in #933).

## Change

- When the node source `ListSandbox` pages over has **no entry at all**, return the retryable `CubeletUnHealthy` (130408) instead of Success + empty — mirroring `GetSandbox`'s existing handling of unhealthy nodes in `sandbox_info.go`.
- **Pagination contract preserved**: `IndexByPage` collapses "empty list" and "start index past the last node" into the same nil result, so the empty-page case is disambiguated by probing the first page of the same source (`hasAnyDBHost`). Paginating past the last node while nodes are still registered keeps returning an empty Success page.
- The `HostID != ""` branch is untouched (it already fails loud with `NotFound`).
- Also registers the missing `130408` entries in `errorCode_name` / `errorCode_value` — every `CubeletUnHealthy` response so far (including `sandbox_info.go`'s) carried an empty `RetMsg` because both maps lacked the code.
- `localcache.RangeDBHost` / `GetHealthyNodesByInstanceType` call sites are routed through package-level function vars following the existing `setSandboxProxyMapFn` seam convention in `sandbox_run.go`, so the new behavior is unit-testable without a live localcache.

## Tests

`TestListSandboxEmptyResultClassification` covers both sides of the classification:
- no queryable nodes → `CubeletUnHealthy` with non-empty `RetMsg`, empty data;
- paginating past the last node with nodes registered → `Success` + empty page.

```
ok  github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/service/sandbox
```

`go build ./...`, `go vet`, `gofmt` clean on the touched packages.

Note: `Test_local_appendNodeByCluster` (pkg/localcache) and `TestSetProxyToRedisPropagatesMaskRequestHost` (pkg/service/sandbox) currently fail on a clean checkout of `master` (07c95b9) as well — verified by stashing this change and re-running; they are unrelated to this PR.

## Compatibility note

Callers that today tolerate the fail-open Success+empty (if any rely on it) will start seeing a retryable error during no-healthy-node windows. That is the intent of #933 — the transient condition becomes distinguishable — but flagging it for reviewers in case a config gate is preferred.

## Retry semantics (moved here from an inline comment)

"Retryable" above means from the **API consumer's** perspective: the no-queryable-node condition is transient, so a caller can safely retry the list. 130408 is deliberately **not** added to the hardcoded `initRetryMap` that drives task-level retries inside CubeMaster — that map's blast radius is the task handler, not this API. Operators who do want internal retries can now opt in via `CubeletConf.RetryCode`, which works precisely because this PR registers 130408 in `errorCode_value`.

## Why no explicit health check in `hasAnyDBHost`

`localcache.sortedNodesByClusters` — the source `RangeDBHost` pages over — only ever holds healthy nodes: `appendSortedNodes` skips `!n.Healthy`, `updateSortedNodes` removes a node on the unhealthy transition, and the reported-not-ready path calls `delSortedNodes`. So "every node unhealthy" already reduces to the empty-source case this PR fails loud on, reaching the same conclusion as `GetSandbox`'s per-node `n.Healthy` check. `TestRangeDBHostDropsNodeWhoseHealthLapses` pins that invariant next to the code that depends on it.


## What this looks like at the SDK surface

Worth stating explicitly, since it is the visible half of the compatibility note above. CubeAPI runs every CubeMaster list response through `ensure_create_result`, which maps anything that is not Success / NotFound / Conflict to `AppError::Internal` (`CubeAPI/src/services/sandboxes.rs:700-710`). So during a no-queryable-node window:

- before this PR: `GET /sandboxes` → `200` with an empty array, indistinguishable from "no sandboxes exist";
- after this PR: `GET /sandboxes` → `500` carrying `CubeletUnHealthy`, and the E2B SDK's `list()` raises instead of returning an empty list.

That is the intended #933 semantic reaching the SDK surface — a consumer reconciling inventory now sees an error it can retry rather than a false empty. Incidentally, registering 130408 in `errorCode_name` is what makes that response carry a message at all; without it `code.String()` returned `""` and the 500 body would have been empty.

## TOCTOU between the paged read and the probe

The node list can change between the `rangeDBHostFn` call and the `hasAnyDBHost` probe. This is deliberate and harmless in both directions: if nodes disappeared, `CubeletUnHealthy` is the right answer anyway; if nodes appeared, the caller gets the pre-existing `Success` + empty page and a retry picks them up. Recording it here rather than in an inline comment, per the review request to keep the comments short.
