### PR TITLE
feat(metrics): expose guest workload metrics through Task.Stats

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,6 +65,8 @@ __pycache__
 !/tests/e2e/sdk_compat/
 !/tests/e2e/sdk_compat/**
 /tests/e2e/sdk_compat/.pytest_cache/
+!/tests/e2e/resource_metrics/
+!/tests/e2e/resource_metrics/**
 
 # Keep the SDK E2E skills guide tracked while ignoring other tests/skills files.
 !/tests/skills/

--- a/CubeShim/protoc/build.rs
+++ b/CubeShim/protoc/build.rs
@@ -23,6 +23,17 @@ fn replace_text_in_file(file_name: &str, from: &str, to: &str) -> Result<(), std
     Ok(())
 }
 
+fn ensure_trailing_newline(file_name: &str) -> Result<(), std::io::Error> {
+    let mut contents = String::new();
+    File::open(file_name)?.read_to_string(&mut contents)?;
+    if contents.ends_with('\n') {
+        return Ok(());
+    }
+
+    contents.push('\n');
+    File::create(file_name)?.write_all(contents.as_bytes())
+}
+
 fn use_serde(protos: &[&str], out_dir: &Path) -> Result<(), std::io::Error> {
     protos
         .iter()
@@ -181,6 +192,12 @@ fn real_main() -> Result<(), std::io::Error> {
         .try_for_each(|&f| -> Result<(), std::io::Error> {
             replace_text_in_file(f, "#![allow(box_pointers)]", "")
         })?;
+    replace_text_in_file(
+        "src/agent.rs",
+        "\n    // uint32 resource_metrics_version = 3;\n\n\n",
+        "\n",
+    )?;
+    ensure_trailing_newline("src/agent.rs")?;
 
     Ok(())
 }

--- a/CubeShim/protoc/protos/agent.proto
+++ b/CubeShim/protoc/protos/agent.proto
@@ -257,6 +257,9 @@ message NetworkStats {
 message StatsContainerResponse {
 	CgroupStats cgroup_stats = 1;
 	repeated NetworkStats network_stats = 2;
+	// Version 1 certifies unified cgroup v2 workload accounting with all
+	// container-owned processes below the reported accounting cgroup.
+	uint32 resource_metrics_version = 3;
 }
 
 message WriteStreamRequest {

--- a/CubeShim/protoc/src/agent.rs
+++ b/CubeShim/protoc/src/agent.rs
@@ -6458,6 +6458,7 @@ pub struct StatsContainerResponse {
     // message fields
     pub cgroup_stats: ::protobuf::SingularPtrField<CgroupStats>,
     pub network_stats: ::protobuf::RepeatedField<NetworkStats>,
+    pub resource_metrics_version: u32,
     // special fields
     #[cfg_attr(feature = "with-serde", serde(skip))]
     pub unknown_fields: ::protobuf::UnknownFields,
@@ -6533,6 +6534,18 @@ impl StatsContainerResponse {
     pub fn take_network_stats(&mut self) -> ::protobuf::RepeatedField<NetworkStats> {
         ::std::mem::replace(&mut self.network_stats, ::protobuf::RepeatedField::new())
     }
+
+    pub fn get_resource_metrics_version(&self) -> u32 {
+        self.resource_metrics_version
+    }
+    pub fn clear_resource_metrics_version(&mut self) {
+        self.resource_metrics_version = 0;
+    }
+
+    // Param is passed by value, moved
+    pub fn set_resource_metrics_version(&mut self, v: u32) {
+        self.resource_metrics_version = v;
+    }
 }
 
 impl ::protobuf::Message for StatsContainerResponse {
@@ -6560,6 +6573,13 @@ impl ::protobuf::Message for StatsContainerResponse {
                 2 => {
                     ::protobuf::rt::read_repeated_message_into(wire_type, is, &mut self.network_stats)?;
                 },
+                3 => {
+                    if wire_type != ::protobuf::wire_format::WireTypeVarint {
+                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
+                    }
+                    let tmp = is.read_uint32()?;
+                    self.resource_metrics_version = tmp;
+                },
                 _ => {
                     ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
                 },
@@ -6580,6 +6600,9 @@ impl ::protobuf::Message for StatsContainerResponse {
             let len = value.compute_size();
             my_size += 1 + ::protobuf::rt::compute_raw_varint32_size(len) + len;
         };
+        if self.resource_metrics_version != 0 {
+            my_size += ::protobuf::rt::value_size(3, self.resource_metrics_version, ::protobuf::wire_format::WireTypeVarint);
+        }
         my_size += ::protobuf::rt::unknown_fields_size(self.get_unknown_fields());
         self.cached_size.set(my_size);
         my_size
@@ -6596,6 +6619,9 @@ impl ::protobuf::Message for StatsContainerResponse {
             os.write_raw_varint32(v.get_cached_size())?;
             v.write_to_with_cached_sizes(os)?;
         };
+        if self.resource_metrics_version != 0 {
+            os.write_uint32(3, self.resource_metrics_version)?;
+        }
         os.write_unknown_fields(self.get_unknown_fields())?;
         ::std::result::Result::Ok(())
     }
@@ -6644,6 +6670,11 @@ impl ::protobuf::Message for StatsContainerResponse {
                 |m: &StatsContainerResponse| { &m.network_stats },
                 |m: &mut StatsContainerResponse| { &mut m.network_stats },
             ));
+            fields.push(::protobuf::reflect::accessor::make_simple_field_accessor::<_, ::protobuf::types::ProtobufTypeUint32>(
+                "resource_metrics_version",
+                |m: &StatsContainerResponse| { &m.resource_metrics_version },
+                |m: &mut StatsContainerResponse| { &mut m.resource_metrics_version },
+            ));
             ::protobuf::reflect::MessageDescriptor::new_pb_name::<StatsContainerResponse>(
                 "StatsContainerResponse",
                 fields,
@@ -6662,6 +6693,7 @@ impl ::protobuf::Clear for StatsContainerResponse {
     fn clear(&mut self) {
         self.cgroup_stats.clear();
         self.network_stats.clear();
+        self.resource_metrics_version = 0;
         self.unknown_fields.clear();
     }
 }
@@ -15580,108 +15612,109 @@ static file_descriptor_proto_data: &'static [u8] = b"\
     \x18\x05\x20\x01(\x04R\trxDroppedB\0\x12\x1b\n\x08tx_bytes\x18\x06\x20\
     \x01(\x04R\x07txBytesB\0\x12\x1f\n\ntx_packets\x18\x07\x20\x01(\x04R\ttx\
     PacketsB\0\x12\x1d\n\ttx_errors\x18\x08\x20\x01(\x04R\x08txErrorsB\0\x12\
-    \x1f\n\ntx_dropped\x18\t\x20\x01(\x04R\ttxDroppedB\0:\0\"\x8d\x01\n\x16S\
+    \x1f\n\ntx_dropped\x18\t\x20\x01(\x04R\ttxDroppedB\0:\0\"\xc9\x01\n\x16S\
     tatsContainerResponse\x126\n\x0ccgroup_stats\x18\x01\x20\x01(\x0b2\x11.g\
     rpc.CgroupStatsR\x0bcgroupStatsB\0\x129\n\rnetwork_stats\x18\x02\x20\x03\
-    (\x0b2\x12.grpc.NetworkStatsR\x0cnetworkStatsB\0:\0\"l\n\x12WriteStreamR\
-    equest\x12#\n\x0ccontainer_id\x18\x01\x20\x01(\tR\x0bcontainerIdB\0\x12\
-    \x19\n\x07exec_id\x18\x02\x20\x01(\tR\x06execIdB\0\x12\x14\n\x04data\x18\
-    \x03\x20\x01(\x0cR\x04dataB\0:\0\"+\n\x13WriteStreamResponse\x12\x12\n\
-    \x03len\x18\x01\x20\x01(\rR\x03lenB\0:\0\"i\n\x11ReadStreamRequest\x12#\
-    \n\x0ccontainer_id\x18\x01\x20\x01(\tR\x0bcontainerIdB\0\x12\x19\n\x07ex\
-    ec_id\x18\x02\x20\x01(\tR\x06execIdB\0\x12\x12\n\x03len\x18\x03\x20\x01(\
-    \rR\x03lenB\0:\0\",\n\x12ReadStreamResponse\x12\x14\n\x04data\x18\x01\
-    \x20\x01(\x0cR\x04dataB\0:\0\"U\n\x11CloseStdinRequest\x12#\n\x0ccontain\
-    er_id\x18\x01\x20\x01(\tR\x0bcontainerIdB\0\x12\x19\n\x07exec_id\x18\x02\
-    \x20\x01(\tR\x06execIdB\0:\0\"\x85\x01\n\x13TtyWinResizeRequest\x12#\n\
+    (\x0b2\x12.grpc.NetworkStatsR\x0cnetworkStatsB\0\x12:\n\x18resource_metr\
+    ics_version\x18\x03\x20\x01(\rR\x16resourceMetricsVersionB\0:\0\"l\n\x12\
+    WriteStreamRequest\x12#\n\x0ccontainer_id\x18\x01\x20\x01(\tR\x0bcontain\
+    erIdB\0\x12\x19\n\x07exec_id\x18\x02\x20\x01(\tR\x06execIdB\0\x12\x14\n\
+    \x04data\x18\x03\x20\x01(\x0cR\x04dataB\0:\0\"+\n\x13WriteStreamResponse\
+    \x12\x12\n\x03len\x18\x01\x20\x01(\rR\x03lenB\0:\0\"i\n\x11ReadStreamReq\
+    uest\x12#\n\x0ccontainer_id\x18\x01\x20\x01(\tR\x0bcontainerIdB\0\x12\
+    \x19\n\x07exec_id\x18\x02\x20\x01(\tR\x06execIdB\0\x12\x12\n\x03len\x18\
+    \x03\x20\x01(\rR\x03lenB\0:\0\",\n\x12ReadStreamResponse\x12\x14\n\x04da\
+    ta\x18\x01\x20\x01(\x0cR\x04dataB\0:\0\"U\n\x11CloseStdinRequest\x12#\n\
     \x0ccontainer_id\x18\x01\x20\x01(\tR\x0bcontainerIdB\0\x12\x19\n\x07exec\
-    _id\x18\x02\x20\x01(\tR\x06execIdB\0\x12\x12\n\x03row\x18\x03\x20\x01(\r\
-    R\x03rowB\0\x12\x18\n\x06column\x18\x04\x20\x01(\rR\x06columnB\0:\0\"H\n\
-    \x0cKernelModule\x12\x14\n\x04name\x18\x01\x20\x01(\tR\x04nameB\0\x12\
-    \x20\n\nparameters\x18\x02\x20\x03(\tR\nparametersB\0:\0\"\xe8\x04\n\x14\
-    CreateSandboxRequest\x12\x1c\n\x08hostname\x18\x01\x20\x01(\tR\x08hostna\
-    meB\0\x12\x12\n\x03dns\x18\x02\x20\x03(\tR\x03dnsB\0\x12+\n\x08storages\
-    \x18\x03\x20\x03(\x0b2\r.grpc.StorageR\x08storagesB\0\x12%\n\rsandbox_pi\
-    dns\x18\x04\x20\x01(\x08R\x0csandboxPidnsB\0\x12\x1f\n\nsandbox_id\x18\
-    \x05\x20\x01(\tR\tsandboxIdB\0\x12(\n\x0fguest_hook_path\x18\x06\x20\x01\
-    (\tR\rguestHookPathB\0\x12;\n\x0ekernel_modules\x18\x07\x20\x03(\x0b2\
-    \x12.grpc.KernelModuleR\rkernelModulesB\0\x122\n\ninterfaces\x18\x08\x20\
-    \x03(\x0b2\x10.types.InterfaceR\ninterfacesB\0\x12&\n\x06routes\x18\t\
-    \x20\x03(\x0b2\x0c.types.RouteR\x06routesB\0\x128\n\x0cARPNeighbors\x18\
-    \n\x20\x03(\x0b2\x12.types.ARPNeighborR\x0cARPNeighborsB\0\x12\x1b\n\x08\
-    cube_vip\x18\x0b\x20\x01(\tR\x07cubeVipB\0\x12/\n\x13cube_preserve_mem_m\
-    \x18\x0c\x20\x01(\rR\x10cubePreserveMemMB\0\x12*\n\x10cube_mvm_monitor\
-    \x18\r\x20\x01(\x08R\x0ecubeMvmMonitorB\0\x120\n\nstart_mode\x18\x0e\x20\
-    \x01(\x0e2\x0f.grpc.StartModeR\tstartModeB\0:\0\"\x19\n\x15DestroySandbo\
-    xRequest:\0\"B\n\nInterfaces\x122\n\nInterfaces\x18\x01\x20\x03(\x0b2\
-    \x10.types.InterfaceR\nInterfacesB\0:\0\"2\n\x06Routes\x12&\n\x06Routes\
-    \x18\x01\x20\x03(\x0b2\x0c.types.RouteR\x06RoutesB\0:\0\"L\n\x16UpdateIn\
-    terfaceRequest\x120\n\tinterface\x18\x01\x20\x01(\x0b2\x10.types.Interfa\
-    ceR\tinterfaceB\0:\0\"?\n\x13UpdateRoutesRequest\x12&\n\x06routes\x18\
-    \x01\x20\x01(\x0b2\x0c.grpc.RoutesR\x06routesB\0:\0\"\x19\n\x15ListInter\
-    facesRequest:\0\"\x15\n\x11ListRoutesRequest:\0\"J\n\x0cARPNeighbors\x12\
-    8\n\x0cARPNeighbors\x18\x01\x20\x03(\x0b2\x12.types.ARPNeighborR\x0cARPN\
-    eighborsB\0:\0\"N\n\x16AddARPNeighborsRequest\x122\n\tneighbors\x18\x01\
-    \x20\x01(\x0b2\x12.grpc.ARPNeighborsR\tneighborsB\0:\0\"1\n\x12GetIPTabl\
-    esRequest\x12\x19\n\x07is_ipv6\x18\x01\x20\x01(\x08R\x06isIpv6B\0:\0\"-\
-    \n\x13GetIPTablesResponse\x12\x14\n\x04data\x18\x01\x20\x01(\x0cR\x04dat\
-    aB\0:\0\"G\n\x12SetIPTablesRequest\x12\x19\n\x07is_ipv6\x18\x01\x20\x01(\
-    \x08R\x06isIpv6B\0\x12\x14\n\x04data\x18\x02\x20\x01(\x0cR\x04dataB\0:\0\
-    \"-\n\x13SetIPTablesResponse\x12\x14\n\x04data\x18\x01\x20\x01(\x0cR\x04\
-    dataB\0:\0\"e\n\x13OnlineCPUMemRequest\x12\x14\n\x04wait\x18\x01\x20\x01\
-    (\x08R\x04waitB\0\x12\x19\n\x07nb_cpus\x18\x02\x20\x01(\rR\x06nbCpusB\0\
-    \x12\x1b\n\x08cpu_only\x18\x03\x20\x01(\x08R\x07cpuOnlyB\0:\0\"0\n\x16Re\
-    seedRandomDevRequest\x12\x14\n\x04data\x18\x02\x20\x01(\x0cR\x04dataB\0:\
-    \0\"\xd4\x01\n\x0cAgentDetails\x12\x1a\n\x07version\x18\x01\x20\x01(\tR\
-    \x07versionB\0\x12!\n\x0binit_daemon\x18\x02\x20\x01(\x08R\ninitDaemonB\
-    \0\x12)\n\x0fdevice_handlers\x18\x03\x20\x03(\tR\x0edeviceHandlersB\0\
-    \x12+\n\x10storage_handlers\x18\x04\x20\x03(\tR\x0fstorageHandlersB\0\
-    \x12+\n\x10supports_seccomp\x18\x05\x20\x01(\x08R\x0fsupportsSeccompB\0:\
-    \0\"m\n\x13GuestDetailsRequest\x12&\n\x0emem_block_size\x18\x01\x20\x01(\
-    \x08R\x0cmemBlockSizeB\0\x12,\n\x11mem_hotplug_probe\x18\x02\x20\x01(\
-    \x08R\x0fmemHotplugProbeB\0:\0\"\xc3\x01\n\x14GuestDetailsResponse\x121\
-    \n\x14mem_block_size_bytes\x18\x01\x20\x01(\x04R\x11memBlockSizeBytesB\0\
-    \x129\n\ragent_details\x18\x02\x20\x01(\x0b2\x12.grpc.AgentDetailsR\x0ca\
-    gentDetailsB\0\x12;\n\x19support_mem_hotplug_probe\x18\x03\x20\x01(\x08R\
-    \x16supportMemHotplugProbeB\0:\0\"P\n\x18MemHotplugByProbeRequest\x122\n\
-    \x13memHotplugProbeAddr\x18\x01\x20\x03(\x04R\x13memHotplugProbeAddrB\0:\
-    \0\"E\n\x17SetGuestDateTimeRequest\x12\x12\n\x03Sec\x18\x01\x20\x01(\x03\
-    R\x03SecB\0\x12\x14\n\x04Usec\x18\x02\x20\x01(\x03R\x04UsecB\0:\0\"v\n\
-    \x07FSGroup\x12\x1b\n\x08group_id\x18\x02\x20\x01(\rR\x07groupIdB\0\x12L\
-    \n\x13group_change_policy\x18\x03\x20\x01(\x0e2\x1a.types.FSGroupChangeP\
-    olicyR\x11groupChangePolicyB\0:\0\"\xb3\x02\n\x07Storage\x12\x18\n\x06dr\
-    iver\x18\x01\x20\x01(\tR\x06driverB\0\x12'\n\x0edriver_options\x18\x02\
-    \x20\x03(\tR\rdriverOptionsB\0\x12\x18\n\x06source\x18\x03\x20\x01(\tR\
-    \x06sourceB\0\x12\x18\n\x06fstype\x18\x04\x20\x01(\tR\x06fstypeB\0\x12\
-    \x1a\n\x07options\x18\x05\x20\x03(\tR\x07optionsB\0\x12!\n\x0bmount_poin\
-    t\x18\x06\x20\x01(\tR\nmountPointB\0\x12*\n\x08fs_group\x18\x07\x20\x01(\
-    \x0b2\r.grpc.FSGroupR\x07fsGroupB\0\x12!\n\x0bneed_format\x18\x08\x20\
-    \x01(\x08R\nneedFormatB\0\x12!\n\x0bneed_resize\x18\t\x20\x01(\x08R\nnee\
-    dResizeB\0:\0\"\x92\x01\n\x06Device\x12\x10\n\x02id\x18\x01\x20\x01(\tR\
-    \x02idB\0\x12\x14\n\x04type\x18\x02\x20\x01(\tR\x04typeB\0\x12\x19\n\x07\
-    vm_path\x18\x03\x20\x01(\tR\x06vmPathB\0\x12'\n\x0econtainer_path\x18\
-    \x04\x20\x01(\tR\rcontainerPathB\0\x12\x1a\n\x07options\x18\x05\x20\x03(\
-    \tR\x07optionsB\0:\0\"`\n\nStringUser\x12\x12\n\x03uid\x18\x01\x20\x01(\
-    \tR\x03uidB\0\x12\x12\n\x03gid\x18\x02\x20\x01(\tR\x03gidB\0\x12(\n\x0ea\
-    dditionalGids\x18\x03\x20\x03(\tR\x0eadditionalGidsB\0:\0\"\xdc\x01\n\
-    \x0fCopyFileRequest\x12\x14\n\x04path\x18\x01\x20\x01(\tR\x04pathB\0\x12\
-    \x1d\n\tfile_size\x18\x02\x20\x01(\x03R\x08fileSizeB\0\x12\x1d\n\tfile_m\
-    ode\x18\x03\x20\x01(\rR\x08fileModeB\0\x12\x1b\n\x08dir_mode\x18\x04\x20\
-    \x01(\rR\x07dirModeB\0\x12\x12\n\x03uid\x18\x05\x20\x01(\x05R\x03uidB\0\
-    \x12\x12\n\x03gid\x18\x06\x20\x01(\x05R\x03gidB\0\x12\x18\n\x06offset\
-    \x18\x07\x20\x01(\x03R\x06offsetB\0\x12\x14\n\x04data\x18\x08\x20\x01(\
-    \x0cR\x04dataB\0:\0\"\x16\n\x12GetOOMEventRequest:\0\"1\n\x08OOMEvent\
-    \x12#\n\x0ccontainer_id\x18\x01\x20\x01(\tR\x0bcontainerIdB\0:\0\".\n\
-    \x0eAddSwapRequest\x12\x1a\n\x07PCIPath\x18\x01\x20\x03(\rR\x07PCIPathB\
-    \0:\0\"\x15\n\x11GetMetricsRequest:\0\"'\n\x07Metrics\x12\x1a\n\x07metri\
-    cs\x18\x01\x20\x01(\tR\x07metricsB\0:\0\"D\n\x12VolumeStatsRequest\x12,\
-    \n\x11volume_guest_path\x18\x01\x20\x01(\tR\x0fvolumeGuestPathB\0:\0\"[\
-    \n\x13ResizeVolumeRequest\x12,\n\x11volume_guest_path\x18\x01\x20\x01(\t\
-    R\x0fvolumeGuestPathB\0\x12\x14\n\x04size\x18\x02\x20\x01(\x04R\x04sizeB\
-    \0:\0\"@\n\nCustomFile\x12\x14\n\x04path\x18\x01\x20\x01(\tR\x04pathB\0\
-    \x12\x1a\n\x07content\x18\x02\x20\x01(\tR\x07contentB\0:\0*3\n\tStartMod\
-    e\x12\t\n\x05START\x10\0\x12\x0c\n\x08SNAPSHOT\x10\x01\x12\x0b\n\x07REST\
-    ORE\x10\x02\x1a\0B\0b\x06proto3\
+    _id\x18\x02\x20\x01(\tR\x06execIdB\0:\0\"\x85\x01\n\x13TtyWinResizeReque\
+    st\x12#\n\x0ccontainer_id\x18\x01\x20\x01(\tR\x0bcontainerIdB\0\x12\x19\
+    \n\x07exec_id\x18\x02\x20\x01(\tR\x06execIdB\0\x12\x12\n\x03row\x18\x03\
+    \x20\x01(\rR\x03rowB\0\x12\x18\n\x06column\x18\x04\x20\x01(\rR\x06column\
+    B\0:\0\"H\n\x0cKernelModule\x12\x14\n\x04name\x18\x01\x20\x01(\tR\x04nam\
+    eB\0\x12\x20\n\nparameters\x18\x02\x20\x03(\tR\nparametersB\0:\0\"\xe8\
+    \x04\n\x14CreateSandboxRequest\x12\x1c\n\x08hostname\x18\x01\x20\x01(\tR\
+    \x08hostnameB\0\x12\x12\n\x03dns\x18\x02\x20\x03(\tR\x03dnsB\0\x12+\n\
+    \x08storages\x18\x03\x20\x03(\x0b2\r.grpc.StorageR\x08storagesB\0\x12%\n\
+    \rsandbox_pidns\x18\x04\x20\x01(\x08R\x0csandboxPidnsB\0\x12\x1f\n\nsand\
+    box_id\x18\x05\x20\x01(\tR\tsandboxIdB\0\x12(\n\x0fguest_hook_path\x18\
+    \x06\x20\x01(\tR\rguestHookPathB\0\x12;\n\x0ekernel_modules\x18\x07\x20\
+    \x03(\x0b2\x12.grpc.KernelModuleR\rkernelModulesB\0\x122\n\ninterfaces\
+    \x18\x08\x20\x03(\x0b2\x10.types.InterfaceR\ninterfacesB\0\x12&\n\x06rou\
+    tes\x18\t\x20\x03(\x0b2\x0c.types.RouteR\x06routesB\0\x128\n\x0cARPNeigh\
+    bors\x18\n\x20\x03(\x0b2\x12.types.ARPNeighborR\x0cARPNeighborsB\0\x12\
+    \x1b\n\x08cube_vip\x18\x0b\x20\x01(\tR\x07cubeVipB\0\x12/\n\x13cube_pres\
+    erve_mem_m\x18\x0c\x20\x01(\rR\x10cubePreserveMemMB\0\x12*\n\x10cube_mvm\
+    _monitor\x18\r\x20\x01(\x08R\x0ecubeMvmMonitorB\0\x120\n\nstart_mode\x18\
+    \x0e\x20\x01(\x0e2\x0f.grpc.StartModeR\tstartModeB\0:\0\"\x19\n\x15Destr\
+    oySandboxRequest:\0\"B\n\nInterfaces\x122\n\nInterfaces\x18\x01\x20\x03(\
+    \x0b2\x10.types.InterfaceR\nInterfacesB\0:\0\"2\n\x06Routes\x12&\n\x06Ro\
+    utes\x18\x01\x20\x03(\x0b2\x0c.types.RouteR\x06RoutesB\0:\0\"L\n\x16Upda\
+    teInterfaceRequest\x120\n\tinterface\x18\x01\x20\x01(\x0b2\x10.types.Int\
+    erfaceR\tinterfaceB\0:\0\"?\n\x13UpdateRoutesRequest\x12&\n\x06routes\
+    \x18\x01\x20\x01(\x0b2\x0c.grpc.RoutesR\x06routesB\0:\0\"\x19\n\x15ListI\
+    nterfacesRequest:\0\"\x15\n\x11ListRoutesRequest:\0\"J\n\x0cARPNeighbors\
+    \x128\n\x0cARPNeighbors\x18\x01\x20\x03(\x0b2\x12.types.ARPNeighborR\x0c\
+    ARPNeighborsB\0:\0\"N\n\x16AddARPNeighborsRequest\x122\n\tneighbors\x18\
+    \x01\x20\x01(\x0b2\x12.grpc.ARPNeighborsR\tneighborsB\0:\0\"1\n\x12GetIP\
+    TablesRequest\x12\x19\n\x07is_ipv6\x18\x01\x20\x01(\x08R\x06isIpv6B\0:\0\
+    \"-\n\x13GetIPTablesResponse\x12\x14\n\x04data\x18\x01\x20\x01(\x0cR\x04\
+    dataB\0:\0\"G\n\x12SetIPTablesRequest\x12\x19\n\x07is_ipv6\x18\x01\x20\
+    \x01(\x08R\x06isIpv6B\0\x12\x14\n\x04data\x18\x02\x20\x01(\x0cR\x04dataB\
+    \0:\0\"-\n\x13SetIPTablesResponse\x12\x14\n\x04data\x18\x01\x20\x01(\x0c\
+    R\x04dataB\0:\0\"e\n\x13OnlineCPUMemRequest\x12\x14\n\x04wait\x18\x01\
+    \x20\x01(\x08R\x04waitB\0\x12\x19\n\x07nb_cpus\x18\x02\x20\x01(\rR\x06nb\
+    CpusB\0\x12\x1b\n\x08cpu_only\x18\x03\x20\x01(\x08R\x07cpuOnlyB\0:\0\"0\
+    \n\x16ReseedRandomDevRequest\x12\x14\n\x04data\x18\x02\x20\x01(\x0cR\x04\
+    dataB\0:\0\"\xd4\x01\n\x0cAgentDetails\x12\x1a\n\x07version\x18\x01\x20\
+    \x01(\tR\x07versionB\0\x12!\n\x0binit_daemon\x18\x02\x20\x01(\x08R\ninit\
+    DaemonB\0\x12)\n\x0fdevice_handlers\x18\x03\x20\x03(\tR\x0edeviceHandler\
+    sB\0\x12+\n\x10storage_handlers\x18\x04\x20\x03(\tR\x0fstorageHandlersB\
+    \0\x12+\n\x10supports_seccomp\x18\x05\x20\x01(\x08R\x0fsupportsSeccompB\
+    \0:\0\"m\n\x13GuestDetailsRequest\x12&\n\x0emem_block_size\x18\x01\x20\
+    \x01(\x08R\x0cmemBlockSizeB\0\x12,\n\x11mem_hotplug_probe\x18\x02\x20\
+    \x01(\x08R\x0fmemHotplugProbeB\0:\0\"\xc3\x01\n\x14GuestDetailsResponse\
+    \x121\n\x14mem_block_size_bytes\x18\x01\x20\x01(\x04R\x11memBlockSizeByt\
+    esB\0\x129\n\ragent_details\x18\x02\x20\x01(\x0b2\x12.grpc.AgentDetailsR\
+    \x0cagentDetailsB\0\x12;\n\x19support_mem_hotplug_probe\x18\x03\x20\x01(\
+    \x08R\x16supportMemHotplugProbeB\0:\0\"P\n\x18MemHotplugByProbeRequest\
+    \x122\n\x13memHotplugProbeAddr\x18\x01\x20\x03(\x04R\x13memHotplugProbeA\
+    ddrB\0:\0\"E\n\x17SetGuestDateTimeRequest\x12\x12\n\x03Sec\x18\x01\x20\
+    \x01(\x03R\x03SecB\0\x12\x14\n\x04Usec\x18\x02\x20\x01(\x03R\x04UsecB\0:\
+    \0\"v\n\x07FSGroup\x12\x1b\n\x08group_id\x18\x02\x20\x01(\rR\x07groupIdB\
+    \0\x12L\n\x13group_change_policy\x18\x03\x20\x01(\x0e2\x1a.types.FSGroup\
+    ChangePolicyR\x11groupChangePolicyB\0:\0\"\xb3\x02\n\x07Storage\x12\x18\
+    \n\x06driver\x18\x01\x20\x01(\tR\x06driverB\0\x12'\n\x0edriver_options\
+    \x18\x02\x20\x03(\tR\rdriverOptionsB\0\x12\x18\n\x06source\x18\x03\x20\
+    \x01(\tR\x06sourceB\0\x12\x18\n\x06fstype\x18\x04\x20\x01(\tR\x06fstypeB\
+    \0\x12\x1a\n\x07options\x18\x05\x20\x03(\tR\x07optionsB\0\x12!\n\x0bmoun\
+    t_point\x18\x06\x20\x01(\tR\nmountPointB\0\x12*\n\x08fs_group\x18\x07\
+    \x20\x01(\x0b2\r.grpc.FSGroupR\x07fsGroupB\0\x12!\n\x0bneed_format\x18\
+    \x08\x20\x01(\x08R\nneedFormatB\0\x12!\n\x0bneed_resize\x18\t\x20\x01(\
+    \x08R\nneedResizeB\0:\0\"\x92\x01\n\x06Device\x12\x10\n\x02id\x18\x01\
+    \x20\x01(\tR\x02idB\0\x12\x14\n\x04type\x18\x02\x20\x01(\tR\x04typeB\0\
+    \x12\x19\n\x07vm_path\x18\x03\x20\x01(\tR\x06vmPathB\0\x12'\n\x0econtain\
+    er_path\x18\x04\x20\x01(\tR\rcontainerPathB\0\x12\x1a\n\x07options\x18\
+    \x05\x20\x03(\tR\x07optionsB\0:\0\"`\n\nStringUser\x12\x12\n\x03uid\x18\
+    \x01\x20\x01(\tR\x03uidB\0\x12\x12\n\x03gid\x18\x02\x20\x01(\tR\x03gidB\
+    \0\x12(\n\x0eadditionalGids\x18\x03\x20\x03(\tR\x0eadditionalGidsB\0:\0\
+    \"\xdc\x01\n\x0fCopyFileRequest\x12\x14\n\x04path\x18\x01\x20\x01(\tR\
+    \x04pathB\0\x12\x1d\n\tfile_size\x18\x02\x20\x01(\x03R\x08fileSizeB\0\
+    \x12\x1d\n\tfile_mode\x18\x03\x20\x01(\rR\x08fileModeB\0\x12\x1b\n\x08di\
+    r_mode\x18\x04\x20\x01(\rR\x07dirModeB\0\x12\x12\n\x03uid\x18\x05\x20\
+    \x01(\x05R\x03uidB\0\x12\x12\n\x03gid\x18\x06\x20\x01(\x05R\x03gidB\0\
+    \x12\x18\n\x06offset\x18\x07\x20\x01(\x03R\x06offsetB\0\x12\x14\n\x04dat\
+    a\x18\x08\x20\x01(\x0cR\x04dataB\0:\0\"\x16\n\x12GetOOMEventRequest:\0\"\
+    1\n\x08OOMEvent\x12#\n\x0ccontainer_id\x18\x01\x20\x01(\tR\x0bcontainerI\
+    dB\0:\0\".\n\x0eAddSwapRequest\x12\x1a\n\x07PCIPath\x18\x01\x20\x03(\rR\
+    \x07PCIPathB\0:\0\"\x15\n\x11GetMetricsRequest:\0\"'\n\x07Metrics\x12\
+    \x1a\n\x07metrics\x18\x01\x20\x01(\tR\x07metricsB\0:\0\"D\n\x12VolumeSta\
+    tsRequest\x12,\n\x11volume_guest_path\x18\x01\x20\x01(\tR\x0fvolumeGuest\
+    PathB\0:\0\"[\n\x13ResizeVolumeRequest\x12,\n\x11volume_guest_path\x18\
+    \x01\x20\x01(\tR\x0fvolumeGuestPathB\0\x12\x14\n\x04size\x18\x02\x20\x01\
+    (\x04R\x04sizeB\0:\0\"@\n\nCustomFile\x12\x14\n\x04path\x18\x01\x20\x01(\
+    \tR\x04pathB\0\x12\x1a\n\x07content\x18\x02\x20\x01(\tR\x07contentB\0:\0\
+    *3\n\tStartMode\x12\t\n\x05START\x10\0\x12\x0c\n\x08SNAPSHOT\x10\x01\x12\
+    \x0b\n\x07RESTORE\x10\x02\x1a\0B\0b\x06proto3\
 ";
 
 static file_descriptor_proto_lazy: ::protobuf::rt::LazyV2<::protobuf::descriptor::FileDescriptorProto> = ::protobuf::rt::LazyV2::INIT;

--- a/CubeShim/shim/src/sandbox/sb.rs
+++ b/CubeShim/shim/src/sandbox/sb.rs
@@ -1065,6 +1065,33 @@ impl SandBox {
         ci
     }
 
+    async fn guest_container_id(&self, id: &str) -> Result<String> {
+        let containers = self.containers.lock().await;
+        containers
+            .get(id)
+            .ok_or_else(|| Error::NotFoundError(format!("not found container:{}", id)))
+            .map(Container::get_id)
+    }
+
+    pub async fn stats_container(&self, id: &str) -> Result<agent::StatsContainerResponse> {
+        let guest_container_id = self.guest_container_id(id).await?;
+        let client = self
+            .client
+            .as_ref()
+            .ok_or_else(|| Error::Other("guest agent is not connected".to_string()))?
+            .lock()
+            .await;
+        let req = agent::StatsContainerRequest {
+            container_id: guest_container_id,
+            ..Default::default()
+        };
+
+        client
+            .stats_container(self.ctx.clone(), &req)
+            .await
+            .map_err(|e| Error::Other(format!("StatsContainer failed for {}: {}", id, e)))
+    }
+
     pub async fn wait_container(&self, id: &String, exec_id: &str) -> Result<(u32, DateTime<Utc>)> {
         let mut cid = exec_id.to_owned();
         if cid.is_empty() {
@@ -1448,15 +1475,24 @@ fn normalize_dns_for_agent(entry: &str) -> CResult<String> {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashSet;
-
+    use nix::sys::socket::{socketpair, AddressFamily, SockFlag, SockType};
+    use oci_spec::runtime::SpecBuilder;
     use protobuf::MessageDyn;
+    use std::collections::{HashMap, HashSet};
+    use std::os::fd::IntoRawFd;
+    use std::sync::Arc;
     use tokio::sync::mpsc::channel;
+    use tokio::sync::Mutex;
 
+    use crate::common::PRODUCT_CUBEBOX;
+    use crate::container::container_mgr::ContainerInfo;
+    use crate::container::{Container, ANNO_APP_SNAPSHOT_CONTAINER_ID};
+
+    use super::agent_ttrpc;
+    use super::config;
     use super::normalize_dns_for_agent;
     use super::Log;
     use super::SandBox;
-    use crate::common::PRODUCT_CUBEBOX;
 
     #[tokio::test]
     async fn test_sandbox_prepare_resource() {
@@ -1520,5 +1556,49 @@ mod tests {
     fn test_normalize_dns_for_agent_accepts_prefixed_entry() {
         let got = normalize_dns_for_agent(" nameserver 8.8.8.8 ").unwrap();
         assert_eq!(got, "nameserver 8.8.8.8");
+    }
+
+    #[tokio::test]
+    async fn guest_container_id_uses_restored_container_identity() {
+        let (client_fd, _peer_fd) = socketpair(
+            AddressFamily::Unix,
+            SockType::Stream,
+            None,
+            SockFlag::empty(),
+        )
+        .unwrap();
+        let client = ttrpc::r#async::Client::new(client_fd.into_raw_fd());
+        let agent_client = Arc::new(Mutex::new(agent_ttrpc::AgentServiceClient::new(client)));
+        let (tx, _) = channel::<(String, Box<dyn MessageDyn>)>(128);
+        let spec = SpecBuilder::default()
+            .annotations(HashMap::from([(
+                ANNO_APP_SNAPSHOT_CONTAINER_ID.to_string(),
+                "guest-container".to_string(),
+            )]))
+            .build()
+            .unwrap();
+        let container = Container::new(
+            "sandbox".to_string(),
+            "real-task".to_string(),
+            spec,
+            agent_client,
+            Log::default(),
+            config::Config::default(),
+            ContainerInfo::default(),
+            tx.clone(),
+            false,
+        )
+        .unwrap();
+        let sandbox = SandBox::new("sandbox".to_string(), Log::default(), false, tx);
+        sandbox
+            .containers
+            .lock()
+            .await
+            .insert("real-task".to_string(), container);
+
+        assert_eq!(
+            sandbox.guest_container_id("real-task").await.unwrap(),
+            "guest-container"
+        );
     }
 }

--- a/CubeShim/shim/src/service/task_srv.rs
+++ b/CubeShim/shim/src/service/task_srv.rs
@@ -13,12 +13,17 @@ use containerd_shim::{
         TaskCreate, TaskDelete, TaskExecAdded, TaskExecStarted, TaskIO, TaskStart,
     },
     protos::{
-        api, protobuf::MessageDyn, shim_async::Task, ttrpc::r#async::TtrpcContext,
-        ttrpc::Error::Others, types::task,
+        api,
+        cgroups::metrics::{CPUStat, CPUUsage, MemoryEntry, MemoryStat, Metrics, Throttle},
+        protobuf::MessageDyn,
+        shim_async::Task,
+        ttrpc::r#async::TtrpcContext,
+        ttrpc::Error::Others,
+        types::task,
     },
     Context, Error, TtrpcResult,
 };
-use protobuf::Enum;
+use protobuf::{Enum, Message};
 use tokio::sync::mpsc::{channel, Receiver, Sender};
 use tokio::sync::Mutex;
 
@@ -30,6 +35,239 @@ use crate::service::update_ext;
 use crate::{debugf, errf, infof, warnf};
 const MODULE: &str = "Shim";
 const INTERNAL_PROBE_EXEC_ID_PREFIX: &str = "cubesandbox-internal-probe-";
+const CGROUP_V1_METRICS_TYPE_URL: &str = "io.containerd.cgroups.v1.Metrics";
+const RESOURCE_METRICS_VERSION_V1: u32 = 1;
+
+fn normalize_guest_stats(stats: &protoc::agent::StatsContainerResponse) -> Result<Metrics, String> {
+    let version = stats.get_resource_metrics_version();
+    if version != RESOURCE_METRICS_VERSION_V1 {
+        return Err(format!(
+            "guest does not support resource metrics version {} (reported version {})",
+            RESOURCE_METRICS_VERSION_V1, version
+        ));
+    }
+    if !stats.has_cgroup_stats() {
+        return Err("guest response is missing cgroup stats".to_string());
+    }
+    let guest = stats.get_cgroup_stats();
+    if !guest.has_cpu_stats() || !guest.has_memory_stats() {
+        return Err("guest response is missing CPU or memory stats".to_string());
+    }
+    let guest_cpu = guest.get_cpu_stats();
+    if !guest_cpu.has_cpu_usage() || !guest_cpu.has_throttling_data() {
+        return Err("guest response is missing CPU usage or throttling stats".to_string());
+    }
+    if !guest.get_memory_stats().has_usage() {
+        return Err("guest response is missing memory usage stats".to_string());
+    }
+    let guest_usage = guest_cpu.get_cpu_usage();
+    let guest_throttling = guest_cpu.get_throttling_data();
+    let guest_memory = guest.get_memory_stats().get_usage();
+
+    let cpu = CPUStat {
+        usage: Some(CPUUsage {
+            total: guest_usage.get_total_usage(),
+            kernel: guest_usage.get_usage_in_kernelmode(),
+            user: guest_usage.get_usage_in_usermode(),
+            per_cpu: guest_usage.get_percpu_usage().to_vec(),
+            ..Default::default()
+        })
+        .into(),
+        throttling: Some(Throttle {
+            periods: guest_throttling.get_periods(),
+            throttled_periods: guest_throttling.get_throttled_periods(),
+            throttled_time: guest_throttling.get_throttled_time(),
+            ..Default::default()
+        })
+        .into(),
+        ..Default::default()
+    };
+    let memory = MemoryStat {
+        usage: Some(MemoryEntry {
+            usage: guest_memory.get_usage(),
+            max: guest_memory.get_max_usage(),
+            failcnt: guest_memory.get_failcnt(),
+            limit: guest_memory.get_limit(),
+            ..Default::default()
+        })
+        .into(),
+        ..Default::default()
+    };
+
+    Ok(Metrics {
+        cpu: Some(cpu).into(),
+        memory: Some(memory).into(),
+        ..Default::default()
+    })
+}
+
+fn encode_guest_stats(
+    stats: &protoc::agent::StatsContainerResponse,
+) -> Result<protobuf::well_known_types::any::Any, String> {
+    let metrics = normalize_guest_stats(stats)?;
+    let value = metrics
+        .write_to_bytes()
+        .map_err(|e| format!("encode cgroup metrics failed: {}", e))?;
+    Ok(protobuf::well_known_types::any::Any {
+        type_url: CGROUP_V1_METRICS_TYPE_URL.to_string(),
+        value,
+        ..Default::default()
+    })
+}
+
+#[cfg(test)]
+mod stats_tests {
+    use super::{encode_guest_stats, normalize_guest_stats, CGROUP_V1_METRICS_TYPE_URL};
+    use protoc::agent::{
+        CgroupStats, CpuStats, CpuUsage as GuestCpuUsage, MemoryData, MemoryStats,
+        StatsContainerResponse, ThrottlingData,
+    };
+
+    fn complete_guest_stats_response() -> StatsContainerResponse {
+        let mut response = StatsContainerResponse::new();
+        let mut cgroup = CgroupStats::new();
+        let mut cpu = CpuStats::new();
+        cpu.set_cpu_usage(GuestCpuUsage {
+            // cube-agent normalizes cgroup v2 microsecond counters to
+            // nanoseconds before returning StatsContainerResponse.
+            total_usage: 101_000,
+            usage_in_kernelmode: 31_000,
+            usage_in_usermode: 70_000,
+            percpu_usage: vec![40_000, 61_000],
+            ..Default::default()
+        });
+        cpu.set_throttling_data(ThrottlingData {
+            periods: 9,
+            throttled_periods: 3,
+            throttled_time: 17,
+            ..Default::default()
+        });
+        cgroup.set_cpu_stats(cpu);
+
+        let mut memory = MemoryStats::new();
+        memory.set_usage(MemoryData {
+            usage: 4096,
+            max_usage: 8192,
+            failcnt: 2,
+            limit: 16384,
+            ..Default::default()
+        });
+        cgroup.set_memory_stats(memory);
+        response.set_cgroup_stats(cgroup);
+        response.set_resource_metrics_version(1);
+        response
+    }
+
+    #[test]
+    fn normalizes_guest_cpu_and_memory_into_containerd_metrics() {
+        let response = complete_guest_stats_response();
+
+        let metrics = normalize_guest_stats(&response).unwrap();
+        assert_eq!(metrics.cpu().usage().total, 101_000);
+        assert_eq!(metrics.cpu().usage().kernel, 31_000);
+        assert_eq!(metrics.cpu().usage().user, 70_000);
+        assert_eq!(metrics.cpu().throttling().periods, 9);
+        assert_eq!(metrics.cpu().throttling().throttled_periods, 3);
+        assert_eq!(metrics.cpu().throttling().throttled_time, 17);
+        assert_eq!(metrics.memory().usage().usage, 4096);
+        assert_eq!(metrics.memory().usage().max, 8192);
+        assert_eq!(metrics.memory().usage().failcnt, 2);
+        assert_eq!(metrics.memory().usage().limit, 16384);
+
+        let encoded = encode_guest_stats(&response).unwrap();
+        assert_eq!(encoded.type_url, CGROUP_V1_METRICS_TYPE_URL);
+        assert!(!encoded.value.is_empty());
+    }
+
+    #[test]
+    fn rejects_incomplete_guest_cpu_and_memory_stats() {
+        let mut missing_cpu_stats = complete_guest_stats_response();
+        missing_cpu_stats.mut_cgroup_stats().clear_cpu_stats();
+
+        let mut missing_memory_stats = complete_guest_stats_response();
+        missing_memory_stats.mut_cgroup_stats().clear_memory_stats();
+
+        let mut missing_cpu_usage = complete_guest_stats_response();
+        missing_cpu_usage
+            .mut_cgroup_stats()
+            .mut_cpu_stats()
+            .clear_cpu_usage();
+
+        let mut missing_throttling = complete_guest_stats_response();
+        missing_throttling
+            .mut_cgroup_stats()
+            .mut_cpu_stats()
+            .clear_throttling_data();
+
+        let mut missing_memory_usage = complete_guest_stats_response();
+        missing_memory_usage
+            .mut_cgroup_stats()
+            .mut_memory_stats()
+            .clear_usage();
+
+        for (name, response, expected) in [
+            (
+                "cpu stats",
+                missing_cpu_stats,
+                "guest response is missing CPU or memory stats",
+            ),
+            (
+                "memory stats",
+                missing_memory_stats,
+                "guest response is missing CPU or memory stats",
+            ),
+            (
+                "CPU usage",
+                missing_cpu_usage,
+                "guest response is missing CPU usage or throttling stats",
+            ),
+            (
+                "CPU throttling",
+                missing_throttling,
+                "guest response is missing CPU usage or throttling stats",
+            ),
+            (
+                "memory usage",
+                missing_memory_usage,
+                "guest response is missing memory usage stats",
+            ),
+        ] {
+            assert_eq!(
+                normalize_guest_stats(&response).unwrap_err(),
+                expected,
+                "{name}"
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_missing_guest_cgroup_stats() {
+        let mut response = StatsContainerResponse::new();
+        response.set_resource_metrics_version(1);
+        let err = normalize_guest_stats(&response).unwrap_err();
+        assert_eq!(err, "guest response is missing cgroup stats");
+    }
+
+    #[test]
+    fn rejects_guest_without_resource_metrics_capability() {
+        let err = normalize_guest_stats(&StatsContainerResponse::new()).unwrap_err();
+        assert_eq!(
+            err,
+            "guest does not support resource metrics version 1 (reported version 0)"
+        );
+    }
+
+    #[test]
+    fn rejects_unknown_resource_metrics_capability_version() {
+        let mut response = StatsContainerResponse::new();
+        response.set_resource_metrics_version(2);
+        let err = normalize_guest_stats(&response).unwrap_err();
+        assert_eq!(
+            err,
+            "guest does not support resource metrics version 1 (reported version 2)"
+        );
+    }
+}
 
 #[derive(Clone)]
 pub struct TaskService {
@@ -287,6 +525,31 @@ impl Task for TaskService {
         Ok(api::WaitResponse {
             exit_status: code,
             exited_at: Some(e_tm).into(),
+            ..Default::default()
+        })
+    }
+
+    async fn stats(
+        &self,
+        _ctx: &TtrpcContext,
+        req: api::StatsRequest,
+    ) -> TtrpcResult<api::StatsResponse> {
+        if req.id.is_empty() {
+            return Err(Error::InvalidArgument("stats request id is empty".to_string()).into());
+        }
+
+        let sb = {
+            let sb = self.sandbox.lock().await;
+            sb.clone()
+        };
+        let guest_stats = sb.stats_container(&req.id).await.map_err(|e| {
+            errf!(self.log, "StatsContainer failed for {}: {}", req.id, e);
+            e
+        })?;
+        let stats = encode_guest_stats(&guest_stats).map_err(Error::FailedPreconditionError)?;
+
+        Ok(api::StatsResponse {
+            stats: Some(stats).into(),
             ..Default::default()
         })
     }

--- a/agent/libs/protocols/protos/agent.proto
+++ b/agent/libs/protocols/protos/agent.proto
@@ -257,6 +257,9 @@ message NetworkStats {
 message StatsContainerResponse {
 	CgroupStats cgroup_stats = 1;
 	repeated NetworkStats network_stats = 2;
+	// Version 1 certifies unified cgroup v2 workload accounting with all
+	// container-owned processes below the reported accounting cgroup.
+	uint32 resource_metrics_version = 3;
 }
 
 message WriteStreamRequest {

--- a/agent/rustjail/src/cgroups/fs/mod.rs
+++ b/agent/rustjail/src/cgroups/fs/mod.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-use crate::cgroups::Manager as CgroupManager;
+use crate::cgroups::{Manager as CgroupManager, RESOURCE_METRICS_VERSION_V1};
 use crate::container::DEFAULT_DEVICES;
 use anyhow::{anyhow, Context, Result};
 use cgroups::blkio::{BlkIoController, BlkIoData, IoService};
@@ -32,8 +32,11 @@ use protocols::agent::{
     BlkioStats, BlkioStatsEntry, CgroupStats, CpuStats, CpuUsage, HugetlbStats, MemoryData,
     MemoryStats, PidsStats, ThrottlingData,
 };
-use std::collections::HashMap;
+use std::collections::{BTreeSet, HashMap};
 use std::fs;
+use std::path::{Path, PathBuf};
+use std::thread;
+use std::time::Duration;
 //use std::path::Path;
 use lazy_static::lazy_static;
 
@@ -52,6 +55,14 @@ lazy_static! {
 }
 
 const GUEST_CPUS_PATH: &str = "/sys/devices/system/cpu/online";
+
+fn resource_metrics_version_for_layout(cgroup_v2: bool, has_process_cgroup: bool) -> u32 {
+    if cgroup_v2 && has_process_cgroup {
+        RESOURCE_METRICS_VERSION_V1
+    } else {
+        0
+    }
+}
 
 // Convenience macro to obtain the scope logger
 macro_rules! sl {
@@ -76,6 +87,11 @@ pub struct Manager {
     pub cpath: String,
     #[serde(skip)]
     cgroup: cgroups::Cgroup,
+    // On cgroup v2 the accounting cgroup must remain process-free so its
+    // controllers can be delegated to envd's child cgroups. Runtime-created
+    // OCI processes are placed in this leaf instead.
+    #[serde(skip)]
+    process_cgroup: Option<cgroups::Cgroup>,
 }
 
 // set_resource is used to set reources by cgroup controller.
@@ -91,10 +107,11 @@ macro_rules! set_resource {
 impl CgroupManager for Manager {
     fn apply(&self, pid: pid_t) -> Result<()> {
         let cgroup_pid = CgroupPid::from(pid as u64);
-        if self.cgroup.v2() {
-            self.cgroup.add_task_by_tgid(cgroup_pid)?;
+        let target = self.process_cgroup.as_ref().unwrap_or(&self.cgroup);
+        if target.v2() {
+            target.add_task_by_tgid(cgroup_pid)?;
         } else {
-            self.cgroup.add_task(cgroup_pid)?;
+            target.add_task(cgroup_pid)?;
         }
         Ok(())
     }
@@ -143,9 +160,9 @@ impl CgroupManager for Manager {
 
     fn get_stats(&self) -> Result<CgroupStats> {
         // CpuStats
-        let cpu_usage = get_cpuacct_stats(&self.cgroup);
+        let cpu_usage = get_cpuacct_stats_strict(&self.cgroup)?;
 
-        let throttling_data = get_cpu_stats(&self.cgroup);
+        let throttling_data = get_cpu_stats_strict(&self.cgroup)?;
 
         let cpu_stats = MessageField::some(CpuStats {
             cpu_usage,
@@ -154,7 +171,7 @@ impl CgroupManager for Manager {
         });
 
         // Memorystats
-        let memory_stats = get_memory_stats(&self.cgroup);
+        let memory_stats = get_memory_stats_strict(&self.cgroup)?;
 
         // PidsStats
         let pids_stats = get_pids_stats(&self.cgroup);
@@ -176,6 +193,10 @@ impl CgroupManager for Manager {
         })
     }
 
+    fn resource_metrics_version(&self) -> u32 {
+        resource_metrics_version_for_layout(self.cgroup.v2(), self.process_cgroup.is_some())
+    }
+
     fn freeze(&self, state: FreezerState) -> Result<()> {
         let freezer_controller: &FreezerController = self.cgroup.controller_of().unwrap();
         match state {
@@ -194,21 +215,199 @@ impl CgroupManager for Manager {
     }
 
     fn destroy(&mut self) -> Result<()> {
+        if self.cgroup.v2() {
+            // cgroup.kill is recursive on supported cgroup v2 kernels. It is
+            // best-effort because the caller already kills tracked PIDs.
+            let _ = self.cgroup.kill();
+            return remove_cgroup_tree(&self.cpath);
+        }
+
         let _ = self.cgroup.delete();
         Ok(())
     }
 
     fn get_pids(&self) -> Result<Vec<pid_t>> {
-        let pids = if self.cgroup.v2() {
-            self.cgroup.procs()
+        let pids: Vec<pid_t> = if self.cgroup.v2() {
+            let mut pids = BTreeSet::new();
+            collect_cgroup_pids(&cgroup_filesystem_path(&self.cpath)?, &mut pids)?;
+            pids.into_iter().collect::<Vec<_>>()
         } else {
             let mem_controller: &MemController = self.cgroup.controller_of().unwrap();
-            mem_controller.tasks()
+            mem_controller
+                .tasks()
+                .into_iter()
+                .map(|pid| pid.pid as pid_t)
+                .collect()
         };
-        let result = pids.iter().map(|x| x.pid as i32).collect::<Vec<i32>>();
+        let result = pids.into_iter().map(|pid| pid as i32).collect::<Vec<i32>>();
 
         Ok(result)
     }
+}
+
+const CGROUP2_MOUNTPOINT: &str = "/sys/fs/cgroup";
+const PROCESS_CGROUP_NAME: &str = "runtime";
+const REQUIRED_DELEGATED_CONTROLLERS: [&str; 3] = ["cpu", "memory", "pids"];
+
+pub fn process_cgroup_path(cpath: &str) -> String {
+    format!("{}/{}", cpath.trim_end_matches('/'), PROCESS_CGROUP_NAME)
+}
+
+pub fn cgroup_filesystem_path(cpath: &str) -> Result<PathBuf> {
+    let relative = cpath.trim_matches('/');
+    let mut path = PathBuf::from(CGROUP2_MOUNTPOINT);
+    if relative.is_empty() {
+        return Ok(path);
+    }
+
+    for component in relative.split('/') {
+        if component.is_empty() || component == "." || component == ".." {
+            return Err(anyhow!("invalid cgroup path component in {cpath:?}"));
+        }
+        path.push(component);
+    }
+    Ok(path)
+}
+
+fn read_cgroup_words(path: &Path) -> Result<BTreeSet<String>> {
+    Ok(fs::read_to_string(path)
+        .with_context(|| format!("read cgroup controller file {}", path.display()))?
+        .split_whitespace()
+        .map(str::to_string)
+        .collect())
+}
+
+fn verify_delegated_controllers_at(path: &Path) -> Result<()> {
+    let available = read_cgroup_words(&path.join("cgroup.controllers"))?;
+    let delegated = read_cgroup_words(&path.join("cgroup.subtree_control"))?;
+
+    for controller in REQUIRED_DELEGATED_CONTROLLERS {
+        if !available.contains(controller) {
+            return Err(anyhow!(
+                "required cgroup v2 controller {controller} is unavailable at {}",
+                path.display()
+            ));
+        }
+        if !delegated.contains(controller) {
+            return Err(anyhow!(
+                "required cgroup v2 controller {controller} is not delegated at {}",
+                path.display()
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn collect_cgroup_pids(path: &Path, pids: &mut BTreeSet<pid_t>) -> Result<()> {
+    let procs = path.join("cgroup.procs");
+    match fs::read_to_string(&procs) {
+        Ok(content) => {
+            for line in content.lines() {
+                let pid = line
+                    .trim()
+                    .parse::<pid_t>()
+                    .with_context(|| format!("parse cgroup pid {line:?}"))?;
+                pids.insert(pid);
+            }
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => {
+            return Err(error)
+                .with_context(|| format!("read cgroup process list {}", procs.display()))
+        }
+    }
+
+    let entries = match fs::read_dir(path) {
+        Ok(entries) => entries,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => {
+            return Err(error).with_context(|| format!("read cgroup directory {}", path.display()))
+        }
+    };
+    for entry in entries {
+        let entry = match entry {
+            Ok(entry) => entry,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => continue,
+            Err(error) => return Err(error.into()),
+        };
+        let file_type = match entry.file_type() {
+            Ok(file_type) => file_type,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => continue,
+            Err(error) => return Err(error.into()),
+        };
+        if file_type.is_dir() {
+            collect_cgroup_pids(&entry.path(), pids)?;
+        }
+    }
+    Ok(())
+}
+
+fn collect_cgroup_dirs(path: &Path, dirs: &mut Vec<PathBuf>) -> Result<()> {
+    let entries = match fs::read_dir(path) {
+        Ok(entries) => entries,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => {
+            return Err(error).with_context(|| format!("read cgroup directory {}", path.display()))
+        }
+    };
+    for entry in entries {
+        let entry = match entry {
+            Ok(entry) => entry,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => continue,
+            Err(error) => return Err(error.into()),
+        };
+        let file_type = match entry.file_type() {
+            Ok(file_type) => file_type,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => continue,
+            Err(error) => return Err(error.into()),
+        };
+        if file_type.is_dir() {
+            let child = entry.path();
+            collect_cgroup_dirs(&child, dirs)?;
+            dirs.push(child);
+        }
+    }
+    Ok(())
+}
+
+fn remove_cgroup_tree(cpath: &str) -> Result<()> {
+    remove_cgroup_tree_at(&cgroup_filesystem_path(cpath)?)
+}
+
+fn remove_cgroup_tree_at(root: &Path) -> Result<()> {
+    for _ in 0..20 {
+        if !root.exists() {
+            return Ok(());
+        }
+
+        let mut dirs = Vec::new();
+        collect_cgroup_dirs(root, &mut dirs)?;
+        dirs.push(root.to_path_buf());
+        let mut retry = false;
+
+        for dir in dirs {
+            match fs::remove_dir(&dir) {
+                Ok(()) => {}
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+                Err(error)
+                    if error.raw_os_error() == Some(libc::EBUSY)
+                        || error.raw_os_error() == Some(libc::ENOTEMPTY) =>
+                {
+                    retry = true;
+                }
+                Err(error) => {
+                    return Err(error).with_context(|| format!("remove cgroup {}", dir.display()));
+                }
+            }
+        }
+
+        if !retry && !root.exists() {
+            return Ok(());
+        }
+        thread::sleep(Duration::from_millis(10));
+    }
+
+    Err(anyhow!("cgroup {} remained busy", root.display()))
 }
 
 fn set_network_resources(
@@ -489,25 +688,6 @@ fn linux_device_group_to_cgroup_device(d: &LinuxDeviceCgroup) -> Option<DeviceRe
     })
 }
 
-// split space separated values into an vector of u64
-fn line_to_vec(line: &str) -> Vec<u64> {
-    line.split_whitespace()
-        .filter_map(|x| x.parse::<u64>().ok())
-        .collect::<Vec<u64>>()
-}
-
-// split flat keyed values into an hashmap of <String, u64>
-fn lines_to_map(content: &str) -> HashMap<String, u64> {
-    content
-        .lines()
-        .map(|x| x.split_whitespace().collect::<Vec<&str>>())
-        .filter(|x| x.len() == 2 && x[1].parse::<u64>().is_ok())
-        .fold(HashMap::new(), |mut hm, x| {
-            hm.insert(x[0].to_string(), x[1].parse::<u64>().unwrap());
-            hm
-        })
-}
-
 pub const NANO_PER_SECOND: u64 = 1000000000;
 pub const WILDCARD: i64 = -1;
 
@@ -577,68 +757,295 @@ lazy_static! {
     };
 }
 
-fn get_cpu_stats(cg: &cgroups::Cgroup) -> MessageField<ThrottlingData> {
-    let cpu_controller: &CpuController = get_controller_or_return_singular_none!(cg);
-    let stat = cpu_controller.cpu().stat;
-    let h = lines_to_map(&stat);
+#[derive(Debug, PartialEq, Eq)]
+struct V2CpuStats {
+    usage_ns: u64,
+    user_ns: u64,
+    system_ns: u64,
+    periods: u64,
+    throttled_periods: u64,
+    throttled_time_ns: u64,
+}
 
-    MessageField::some(ThrottlingData {
-        periods: *h.get("nr_periods").unwrap_or(&0),
-        throttled_periods: *h.get("nr_throttled").unwrap_or(&0),
-        throttled_time: *h.get("throttled_time").unwrap_or(&0),
-        ..Default::default()
+#[derive(Debug, PartialEq, Eq)]
+struct V1CpuAcctStats {
+    usage_ns: u64,
+    user_ns: u64,
+    system_ns: u64,
+    per_cpu_ns: Vec<u64>,
+}
+
+fn required_counter(content: &str, key: &str, source: &str) -> Result<u64> {
+    let value = content
+        .lines()
+        .find_map(|line| {
+            let mut fields = line.split_whitespace();
+            match (fields.next(), fields.next(), fields.next()) {
+                (Some(name), Some(value), None) if name == key => Some(value),
+                _ => None,
+            }
+        })
+        .ok_or_else(|| anyhow!("missing required cgroup key {} in {}", key, source))?;
+    value
+        .parse::<u64>()
+        .with_context(|| format!("invalid cgroup value for {} in {}: {}", key, source, value))
+}
+
+fn micros_to_nanos(value: u64, key: &str, source: &str) -> Result<u64> {
+    value.checked_mul(1_000).ok_or_else(|| {
+        anyhow!(
+            "cgroup value for {} in {} overflows nanoseconds",
+            key,
+            source
+        )
     })
 }
 
-fn get_cpuacct_stats(cg: &cgroups::Cgroup) -> MessageField<CpuUsage> {
-    if let Some(cpuacct_controller) = cg.controller_of::<CpuAcctController>() {
-        let cpuacct = cpuacct_controller.cpuacct();
-
-        let h = lines_to_map(&cpuacct.stat);
-        let usage_in_usermode =
-            (((*h.get("user").unwrap_or(&0) * NANO_PER_SECOND) as f64) / *CLOCK_TICKS) as u64;
-        let usage_in_kernelmode =
-            (((*h.get("system").unwrap_or(&0) * NANO_PER_SECOND) as f64) / *CLOCK_TICKS) as u64;
-
-        let total_usage = cpuacct.usage;
-
-        let percpu_usage = line_to_vec(&cpuacct.usage_percpu);
-
-        return MessageField::some(CpuUsage {
-            total_usage,
-            percpu_usage,
-            usage_in_kernelmode,
-            usage_in_usermode,
-            ..Default::default()
-        });
+fn ticks_to_nanos(value: u64, ticks_per_second: u64, key: &str) -> Result<u64> {
+    if ticks_per_second == 0 {
+        return Err(anyhow!("system clock ticks per second is zero"));
     }
-
-    if cg.v2() {
-        return MessageField::some(CpuUsage {
-            total_usage: 0,
-            percpu_usage: vec![],
-            usage_in_kernelmode: 0,
-            usage_in_usermode: 0,
-            ..Default::default()
-        });
+    let nanos = u128::from(value) * u128::from(NANO_PER_SECOND) / u128::from(ticks_per_second);
+    if nanos > u128::from(u64::MAX) {
+        return Err(anyhow!("cgroup value for {} overflows nanoseconds", key));
     }
+    Ok(nanos as u64)
+}
 
-    // try to get from cpu controller
-    let cpu_controller: &CpuController = get_controller_or_return_singular_none!(cg);
-    let stat = cpu_controller.cpu().stat;
-    let h = lines_to_map(&stat);
-    let usage_in_usermode = *h.get("user_usec").unwrap_or(&0);
-    let usage_in_kernelmode = *h.get("system_usec").unwrap_or(&0);
-    let total_usage = *h.get("usage_usec").unwrap_or(&0);
-    let percpu_usage = vec![];
-
-    MessageField::some(CpuUsage {
-        total_usage,
-        percpu_usage,
-        usage_in_kernelmode,
-        usage_in_usermode,
-        ..Default::default()
+fn parse_v1_cpuacct_stats(
+    usage: &str,
+    stat: &str,
+    per_cpu: &str,
+    ticks_per_second: u64,
+) -> Result<V1CpuAcctStats> {
+    Ok(V1CpuAcctStats {
+        usage_ns: usage
+            .trim()
+            .parse::<u64>()
+            .context("invalid cgroup value for cpuacct.usage")?,
+        user_ns: ticks_to_nanos(
+            required_counter(stat, "user", "cpuacct.stat")?,
+            ticks_per_second,
+            "cpuacct.stat user",
+        )?,
+        system_ns: ticks_to_nanos(
+            required_counter(stat, "system", "cpuacct.stat")?,
+            ticks_per_second,
+            "cpuacct.stat system",
+        )?,
+        per_cpu_ns: per_cpu
+            .split_whitespace()
+            .map(|value| {
+                value
+                    .parse::<u64>()
+                    .with_context(|| format!("invalid cpuacct.usage_percpu value {}", value))
+            })
+            .collect::<Result<Vec<_>>>()?,
     })
+}
+
+fn parse_v2_cpu_stats(content: &str) -> Result<V2CpuStats> {
+    Ok(V2CpuStats {
+        usage_ns: micros_to_nanos(
+            required_counter(content, "usage_usec", "cpu.stat")?,
+            "usage_usec",
+            "cpu.stat",
+        )?,
+        user_ns: micros_to_nanos(
+            required_counter(content, "user_usec", "cpu.stat")?,
+            "user_usec",
+            "cpu.stat",
+        )?,
+        system_ns: micros_to_nanos(
+            required_counter(content, "system_usec", "cpu.stat")?,
+            "system_usec",
+            "cpu.stat",
+        )?,
+        periods: required_counter(content, "nr_periods", "cpu.stat")?,
+        throttled_periods: required_counter(content, "nr_throttled", "cpu.stat")?,
+        throttled_time_ns: micros_to_nanos(
+            required_counter(content, "throttled_usec", "cpu.stat")?,
+            "throttled_usec",
+            "cpu.stat",
+        )?,
+    })
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct V2MemoryStats {
+    current: u64,
+    limit: u64,
+    peak: u64,
+    failures: u64,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct V1MemoryUsage {
+    current: u64,
+    limit: u64,
+    peak: u64,
+    failures: u64,
+}
+
+fn parse_v1_memory_usage(
+    current: &str,
+    limit: &str,
+    peak: &str,
+    failures: &str,
+) -> Result<V1MemoryUsage> {
+    let parse = |value: &str, key: &str| {
+        value
+            .trim()
+            .parse::<u64>()
+            .with_context(|| format!("invalid cgroup value for {}: {}", key, value.trim()))
+    };
+    Ok(V1MemoryUsage {
+        current: parse(current, "memory.usage_in_bytes")?,
+        limit: parse(limit, "memory.limit_in_bytes")?,
+        peak: parse(peak, "memory.max_usage_in_bytes")?,
+        failures: parse(failures, "memory.failcnt")?,
+    })
+}
+
+fn parse_v2_limit(value: &str, key: &str) -> Result<u64> {
+    if value.trim() == "max" {
+        return Ok(u64::MAX);
+    }
+    value
+        .trim()
+        .parse::<u64>()
+        .with_context(|| format!("invalid cgroup value for {}: {}", key, value.trim()))
+}
+
+fn parse_v2_memory_stats(
+    current: &str,
+    limit: &str,
+    peak: &str,
+    events: &str,
+) -> Result<V2MemoryStats> {
+    Ok(V2MemoryStats {
+        current: current
+            .trim()
+            .parse::<u64>()
+            .context("invalid cgroup value for memory.current")?,
+        limit: parse_v2_limit(limit, "memory.max")?,
+        peak: peak
+            .trim()
+            .parse::<u64>()
+            .context("invalid cgroup value for memory.peak")?,
+        failures: required_counter(events, "max", "memory.events")?,
+    })
+}
+
+fn read_required(path: &Path) -> Result<String> {
+    fs::read_to_string(path).with_context(|| format!("read cgroup stat {}", path.display()))
+}
+
+fn get_cpuacct_stats_strict(cg: &cgroups::Cgroup) -> Result<MessageField<CpuUsage>> {
+    if !cg.v2() {
+        let controller: &CpuAcctController = cg
+            .controller_of()
+            .ok_or_else(|| anyhow!("cpu accounting controller is unavailable"))?;
+        let usage = read_required(&controller.path().join("cpuacct.usage"))?;
+        let stat = read_required(&controller.path().join("cpuacct.stat"))?;
+        let per_cpu = read_required(&controller.path().join("cpuacct.usage_percpu"))?;
+        if *CLOCK_TICKS <= 0.0 {
+            return Err(anyhow!("failed to determine system clock ticks per second"));
+        }
+        let stats = parse_v1_cpuacct_stats(&usage, &stat, &per_cpu, *CLOCK_TICKS as u64)?;
+        return Ok(MessageField::some(CpuUsage {
+            total_usage: stats.usage_ns,
+            percpu_usage: stats.per_cpu_ns,
+            usage_in_kernelmode: stats.system_ns,
+            usage_in_usermode: stats.user_ns,
+            ..Default::default()
+        }));
+    }
+    let controller: &CpuController = cg
+        .controller_of()
+        .ok_or_else(|| anyhow!("CPU controller is unavailable"))?;
+    let stats = parse_v2_cpu_stats(&read_required(&controller.path().join("cpu.stat"))?)?;
+    Ok(MessageField::some(CpuUsage {
+        total_usage: stats.usage_ns,
+        usage_in_kernelmode: stats.system_ns,
+        usage_in_usermode: stats.user_ns,
+        ..Default::default()
+    }))
+}
+
+fn get_cpu_stats_strict(cg: &cgroups::Cgroup) -> Result<MessageField<ThrottlingData>> {
+    if !cg.v2() {
+        let controller: &CpuController = cg
+            .controller_of()
+            .ok_or_else(|| anyhow!("CPU controller is unavailable"))?;
+        let stat = read_required(&controller.path().join("cpu.stat"))?;
+        return Ok(MessageField::some(ThrottlingData {
+            periods: required_counter(&stat, "nr_periods", "cpu.stat")?,
+            throttled_periods: required_counter(&stat, "nr_throttled", "cpu.stat")?,
+            throttled_time: required_counter(&stat, "throttled_time", "cpu.stat")?,
+            ..Default::default()
+        }));
+    }
+    let controller: &CpuController = cg
+        .controller_of()
+        .ok_or_else(|| anyhow!("CPU controller is unavailable"))?;
+    let stats = parse_v2_cpu_stats(&read_required(&controller.path().join("cpu.stat"))?)?;
+    Ok(MessageField::some(ThrottlingData {
+        periods: stats.periods,
+        throttled_periods: stats.throttled_periods,
+        throttled_time: stats.throttled_time_ns,
+        ..Default::default()
+    }))
+}
+
+fn get_memory_stats_strict(cg: &cgroups::Cgroup) -> Result<MessageField<MemoryStats>> {
+    if !cg.v2() {
+        let controller: &MemController = cg
+            .controller_of()
+            .ok_or_else(|| anyhow!("memory controller is unavailable"))?;
+        let path = controller.path();
+        let usage = parse_v1_memory_usage(
+            &read_required(&path.join("memory.usage_in_bytes"))?,
+            &read_required(&path.join("memory.limit_in_bytes"))?,
+            &read_required(&path.join("memory.max_usage_in_bytes"))?,
+            &read_required(&path.join("memory.failcnt"))?,
+        )?;
+        let mut value = get_memory_stats(cg)
+            .into_option()
+            .ok_or_else(|| anyhow!("memory stats are unavailable"))?;
+        value.usage = MessageField::some(MemoryData {
+            usage: usage.current,
+            max_usage: usage.peak,
+            failcnt: usage.failures,
+            limit: usage.limit,
+            ..Default::default()
+        });
+        return Ok(MessageField::some(value));
+    }
+    let controller: &MemController = cg
+        .controller_of()
+        .ok_or_else(|| anyhow!("memory controller is unavailable"))?;
+    let path = controller.path();
+    let stats = parse_v2_memory_stats(
+        &read_required(&path.join("memory.current"))?,
+        &read_required(&path.join("memory.max"))?,
+        &read_required(&path.join("memory.peak"))?,
+        &read_required(&path.join("memory.events"))?,
+    )?;
+    // Preserve the cache and raw memory.stat fields exposed by the existing
+    // StatsContainer contract while replacing its usage entry with values
+    // read from the accounting cgroup using strict cgroup v2 semantics.
+    let mut value = get_memory_stats(cg)
+        .into_option()
+        .ok_or_else(|| anyhow!("memory stats are unavailable"))?;
+    value.usage = MessageField::some(MemoryData {
+        usage: stats.current,
+        max_usage: stats.peak,
+        failcnt: stats.failures,
+        limit: stats.limit,
+        ..Default::default()
+    });
+    Ok(MessageField::some(value))
 }
 
 fn get_memory_stats(cg: &cgroups::Cgroup) -> MessageField<MemoryStats> {
@@ -960,6 +1367,7 @@ fn new_cgroup(h: Box<dyn cgroups::Hierarchy>, path: &str) -> Result<Cgroup> {
 
 impl Manager {
     pub fn new(cpath: &str) -> Result<Self> {
+        let cgroup_path = cgroup_filesystem_path(cpath)?;
         let mut m = HashMap::new();
         let paths = get_paths()?;
         let mounts = get_mounts()?;
@@ -975,12 +1383,35 @@ impl Manager {
 
             m.insert(key.to_string(), p);
         }
+        let cgroup = new_cgroup(cgroups::hierarchies::auto(), cpath)?;
+        let process_cgroup = if cgroup.v2() {
+            let process_path = process_cgroup_path(cpath);
+            match new_cgroup(cgroups::hierarchies::auto(), &process_path) {
+                Ok(process_cgroup) => {
+                    if let Err(error) = verify_delegated_controllers_at(&cgroup_path) {
+                        let _ = process_cgroup.delete();
+                        let _ = cgroup.delete();
+                        return Err(error).context("verify runtime cgroup delegation");
+                    }
+                    Some(process_cgroup)
+                }
+                Err(error) => {
+                    let _ = cgroup.delete();
+                    return Err(error)
+                        .with_context(|| format!("create runtime process cgroup {process_path}"));
+                }
+            }
+        } else {
+            None
+        };
+
         Ok(Self {
             paths: m,
             mounts,
             // rels: paths,
             cpath: cpath.to_string(),
-            cgroup: new_cgroup(cgroups::hierarchies::auto(), cpath)?,
+            cgroup,
+            process_cgroup,
         })
     }
 
@@ -1108,49 +1539,224 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_line_to_vec() {
-        let test_cases = vec![
-            ("1 2 3", vec![1, 2, 3]),
-            ("a 1 b 2 3 c", vec![1, 2, 3]),
-            ("a b c", vec![]),
-        ];
-
-        for test_case in test_cases {
-            let result = line_to_vec(test_case.0);
-            assert_eq!(
-                result, test_case.1,
-                "except: {:?} for input {}",
-                test_case.1, test_case.0
-            );
-        }
+    fn resource_metrics_capability_requires_complete_v2_accounting_layout() {
+        assert_eq!(resource_metrics_version_for_layout(false, false), 0);
+        assert_eq!(resource_metrics_version_for_layout(false, true), 0);
+        assert_eq!(resource_metrics_version_for_layout(true, false), 0);
+        assert_eq!(
+            resource_metrics_version_for_layout(true, true),
+            RESOURCE_METRICS_VERSION_V1
+        );
     }
 
     #[test]
-    fn test_lines_to_map() {
-        let hm1: HashMap<String, u64> = [
-            ("a".to_string(), 1),
-            ("b".to_string(), 2),
-            ("c".to_string(), 3),
-            ("e".to_string(), 5),
-        ]
-        .iter()
-        .cloned()
-        .collect();
-        let hm2: HashMap<String, u64> = [("a".to_string(), 1)].iter().cloned().collect();
+    fn process_cgroup_path_uses_a_runtime_leaf() {
+        assert_eq!(
+            process_cgroup_path("/default/container"),
+            "/default/container/runtime"
+        );
+        assert_eq!(
+            process_cgroup_path("default/container/"),
+            "default/container/runtime"
+        );
+    }
 
-        let test_cases = vec![
-            ("a 1\nb 2\nc 3\nd X\ne 5\n", hm1),
-            ("a 1", hm2),
-            ("a c", HashMap::new()),
-        ];
+    #[test]
+    fn cgroup_filesystem_path_stays_below_the_unified_mount() {
+        assert_eq!(
+            cgroup_filesystem_path("/default/container").unwrap(),
+            PathBuf::from("/sys/fs/cgroup/default/container")
+        );
+        assert!(cgroup_filesystem_path("/default/../escape").is_err());
+        assert!(cgroup_filesystem_path("/default//escape").is_err());
+    }
 
-        for test_case in test_cases {
-            let result = lines_to_map(test_case.0);
-            assert_eq!(
-                result, test_case.1,
-                "except: {:?} for input {}",
-                test_case.1, test_case.0
-            );
-        }
+    #[test]
+    fn delegated_controller_check_requires_cpu_memory_and_pids() {
+        let root = tempfile::tempdir().unwrap();
+        fs::write(
+            root.path().join("cgroup.controllers"),
+            "cpu io memory pids\n",
+        )
+        .unwrap();
+        fs::write(
+            root.path().join("cgroup.subtree_control"),
+            "cpu memory pids\n",
+        )
+        .unwrap();
+        verify_delegated_controllers_at(root.path()).unwrap();
+
+        fs::write(root.path().join("cgroup.subtree_control"), "cpu memory\n").unwrap();
+        assert!(verify_delegated_controllers_at(root.path()).is_err());
+    }
+
+    #[test]
+    fn collect_cgroup_pids_includes_nested_envd_groups() {
+        let root = tempfile::tempdir().unwrap();
+        let user = root.path().join("user");
+        let ptys = user.join("ptys");
+        fs::create_dir_all(&ptys).unwrap();
+        fs::write(root.path().join("cgroup.procs"), "10\n").unwrap();
+        fs::write(user.join("cgroup.procs"), "11\n").unwrap();
+        fs::write(ptys.join("cgroup.procs"), "12\n11\n").unwrap();
+
+        let mut pids = BTreeSet::new();
+        collect_cgroup_pids(root.path(), &mut pids).unwrap();
+        assert_eq!(pids.into_iter().collect::<Vec<_>>(), vec![10, 11, 12]);
+    }
+
+    #[test]
+    fn remove_cgroup_tree_deletes_descendants_before_the_parent() {
+        let parent = tempfile::tempdir().unwrap();
+        let root = parent.path().join("container");
+        fs::create_dir_all(root.join("user/ptys")).unwrap();
+        fs::create_dir_all(root.join("runtime")).unwrap();
+
+        remove_cgroup_tree_at(&root).unwrap();
+
+        assert!(!root.exists());
+    }
+
+    #[test]
+    fn remove_cgroup_tree_retries_after_enotempty() {
+        let parent = tempfile::tempdir().unwrap();
+        let root = parent.path().join("container");
+        let user = root.join("user");
+        fs::create_dir_all(&user).unwrap();
+        let hold = user.join("hold");
+        fs::write(&hold, "busy").unwrap();
+
+        let cleanup = thread::spawn(move || {
+            thread::sleep(Duration::from_millis(25));
+            fs::remove_file(hold).unwrap();
+        });
+        remove_cgroup_tree_at(&root).unwrap();
+        cleanup.join().unwrap();
+
+        assert!(!root.exists());
+    }
+
+    #[test]
+    fn parse_v2_cpu_stats_converts_microseconds_to_nanoseconds() {
+        let got = parse_v2_cpu_stats(
+            "usage_usec 12\nuser_usec 7\nsystem_usec 5\nnr_periods 9\nnr_throttled 2\nthrottled_usec 3\n",
+        )
+        .unwrap();
+        assert_eq!(
+            got,
+            V2CpuStats {
+                usage_ns: 12_000,
+                user_ns: 7_000,
+                system_ns: 5_000,
+                periods: 9,
+                throttled_periods: 2,
+                throttled_time_ns: 3_000,
+            }
+        );
+    }
+
+    #[test]
+    fn parse_v1_cpuacct_stats_preserves_nanosecond_and_tick_semantics() {
+        let got =
+            parse_v1_cpuacct_stats("12000\n", "user 7\nsystem 5\n", "4000 8000\n", 100).unwrap();
+        assert_eq!(
+            got,
+            V1CpuAcctStats {
+                usage_ns: 12_000,
+                user_ns: 70_000_000,
+                system_ns: 50_000_000,
+                per_cpu_ns: vec![4_000, 8_000],
+            }
+        );
+    }
+
+    #[test]
+    fn parse_v1_cpuacct_stats_accepts_large_ticks_when_final_nanoseconds_fit() {
+        let got =
+            parse_v1_cpuacct_stats("1\n", "user 20000000000\nsystem 1\n", "1\n", 100).unwrap();
+        assert_eq!(got.user_ns, 200_000_000_000_000_000);
+    }
+
+    #[test]
+    fn parse_v1_cpuacct_stats_rejects_bad_values_and_tick_overflow() {
+        assert!(parse_v1_cpuacct_stats("bad\n", "user 1\nsystem 1\n", "1\n", 100).is_err());
+        assert!(parse_v1_cpuacct_stats("1\n", "user 1\nsystem 1\n", "bad\n", 100).is_err());
+        assert!(parse_v1_cpuacct_stats("1\n", "user 1\nsystem 1\n", "1\n", 0).is_err());
+        assert!(
+            parse_v1_cpuacct_stats("1\n", "user 18446744073709551615\nsystem 1\n", "1\n", 100,)
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn parse_v2_cpu_stats_rejects_missing_malformed_and_overflow_values() {
+        let error = parse_v2_cpu_stats("usage_usec 1\n").unwrap_err();
+        assert_eq!(
+            error.to_string(),
+            "missing required cgroup key user_usec in cpu.stat"
+        );
+        assert!(parse_v2_cpu_stats("usage_usec nope\nuser_usec 1\nsystem_usec 1\nnr_periods 1\nnr_throttled 1\nthrottled_usec 1\n").is_err());
+        let error = parse_v2_cpu_stats("usage_usec 18446744073709552\nuser_usec 1\nsystem_usec 1\nnr_periods 1\nnr_throttled 1\nthrottled_usec 1\n").unwrap_err();
+        assert_eq!(
+            error.to_string(),
+            "cgroup value for usage_usec in cpu.stat overflows nanoseconds"
+        );
+    }
+
+    #[test]
+    fn parse_v2_memory_stats_reads_current_limit_peak_and_failures() {
+        let got = parse_v2_memory_stats(
+            "4096\n",
+            "max\n",
+            "8192\n",
+            "low 0\nmax 4\nome 1\noom_kill 1\n",
+        )
+        .unwrap();
+        assert_eq!(
+            got,
+            V2MemoryStats {
+                current: 4096,
+                limit: u64::MAX,
+                peak: 8192,
+                failures: 4,
+            }
+        );
+    }
+
+    #[test]
+    fn parse_v2_memory_stats_reads_numeric_limit() {
+        let got = parse_v2_memory_stats("4096\n", "16384\n", "8192\n", "max 4\n").unwrap();
+        assert_eq!(got.limit, 16_384);
+    }
+
+    #[test]
+    fn parse_v1_memory_usage_preserves_failcnt_semantics() {
+        let got = parse_v1_memory_usage("4096\n", "16384\n", "8192\n", "4\n").unwrap();
+        assert_eq!(
+            got,
+            V1MemoryUsage {
+                current: 4096,
+                limit: 16_384,
+                peak: 8192,
+                failures: 4,
+            }
+        );
+    }
+
+    #[test]
+    fn parse_v2_memory_stats_rejects_missing_or_malformed_values() {
+        let error = parse_v2_memory_stats("4096\n", "1024\n", "8192\n", "low 0\n").unwrap_err();
+        assert_eq!(
+            error.to_string(),
+            "missing required cgroup key max in memory.events"
+        );
+        assert!(parse_v2_memory_stats("bad\n", "1024\n", "8192\n", "max 1\n").is_err());
+        assert!(parse_v2_memory_stats("4096\n", "bad\n", "8192\n", "max 1\n").is_err());
+    }
+
+    #[test]
+    fn read_required_rejects_missing_file() {
+        let dir = tempfile::tempdir().unwrap();
+        assert!(read_required(&dir.path().join("cpu.stat")).is_err());
     }
 }

--- a/agent/rustjail/src/cgroups/mock.rs
+++ b/agent/rustjail/src/cgroups/mock.rs
@@ -5,7 +5,7 @@
 
 use protobuf::MessageField;
 
-use crate::cgroups::Manager as CgroupManager;
+use crate::cgroups::{Manager as CgroupManager, RESOURCE_METRICS_VERSION_V1};
 use crate::protocols::agent::{BlkioStats, CgroupStats, CpuStats, MemoryStats, PidsStats};
 use anyhow::Result;
 use cgroups::freezer::FreezerState;
@@ -39,6 +39,10 @@ impl CgroupManager for Manager {
             hugetlb_stats: HashMap::new(),
             ..Default::default()
         })
+    }
+
+    fn resource_metrics_version(&self) -> u32 {
+        RESOURCE_METRICS_VERSION_V1
     }
 
     fn freeze(&self, _: FreezerState) -> Result<()> {

--- a/agent/rustjail/src/cgroups/mod.rs
+++ b/agent/rustjail/src/cgroups/mod.rs
@@ -14,6 +14,8 @@ pub mod mock;
 pub mod notifier;
 pub mod systemd;
 
+pub const RESOURCE_METRICS_VERSION_V1: u32 = 1;
+
 pub trait Manager {
     fn apply(&self, _pid: i32) -> Result<()> {
         Err(anyhow!("not supported!".to_string()))
@@ -27,6 +29,10 @@ pub trait Manager {
         Err(anyhow!("not supported!"))
     }
 
+    fn resource_metrics_version(&self) -> u32 {
+        0
+    }
+
     fn freeze(&self, _state: FreezerState) -> Result<()> {
         Err(anyhow!("not supported!"))
     }
@@ -37,5 +43,19 @@ pub trait Manager {
 
     fn set(&self, _container: &LinuxResources, _update: bool) -> Result<()> {
         Err(anyhow!("not supported!"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Manager;
+
+    struct UnsupportedManager;
+
+    impl Manager for UnsupportedManager {}
+
+    #[test]
+    fn managers_must_explicitly_claim_resource_metrics_support() {
+        assert_eq!(UnsupportedManager.resource_metrics_version(), 0);
     }
 }

--- a/agent/rustjail/src/container.rs
+++ b/agent/rustjail/src/container.rs
@@ -526,8 +526,15 @@ fn do_init_child(cwfd: RawFd) -> Result<()> {
 
     if to_new.contains(CloneFlags::CLONE_NEWNS) {
         // setup rootfs
-        mount::init_rootfs(cfd_log, &spec, &cm.paths, &cm.mounts, bind_device)
-            .map_err(|e| anyhow!("init_rootfs faild.{:}", e))?;
+        mount::init_rootfs(
+            cfd_log,
+            &spec,
+            &cm.paths,
+            &cm.mounts,
+            &cm.cpath,
+            bind_device,
+        )
+        .map_err(|e| anyhow!("init_rootfs failed.{:}", e))?;
     }
 
     if init {
@@ -828,8 +835,9 @@ impl BaseContainer for LinuxContainer {
     fn stats(&self) -> Result<StatsContainerResponse> {
         let mut r = StatsContainerResponse::default();
 
-        if self.cgroup_manager.is_some() {
-            r.cgroup_stats = MessageField::some(self.cgroup_manager.as_ref().unwrap().get_stats()?);
+        if let Some(manager) = self.cgroup_manager.as_ref() {
+            r.cgroup_stats = MessageField::some(manager.get_stats()?);
+            r.resource_metrics_version = manager.resource_metrics_version();
         }
 
         // what about network interface stats?
@@ -2123,6 +2131,17 @@ mod tests {
     fn test_linuxcontainer_stats() {
         let ret = new_linux_container_and_then(|c: LinuxContainer| c.stats());
         assert!(ret.is_ok(), "Expecting Ok, Got {:?}", ret);
+        assert_eq!(ret.unwrap().resource_metrics_version(), 1);
+    }
+
+    #[test]
+    fn test_linuxcontainer_without_cgroup_manager_does_not_claim_resource_metrics() {
+        let ret = new_linux_container_and_then(|mut c: LinuxContainer| {
+            c.cgroup_manager = None;
+            c.stats()
+        });
+        assert!(ret.is_ok(), "Expecting Ok, Got {:?}", ret);
+        assert_eq!(ret.unwrap().resource_metrics_version(), 0);
     }
 
     #[test]

--- a/agent/rustjail/src/mount.rs
+++ b/agent/rustjail/src/mount.rs
@@ -162,6 +162,7 @@ pub fn init_rootfs(
     spec: &Spec,
     cpath: &HashMap<String, String>,
     mounts: &HashMap<String, String>,
+    cgroup_path: &str,
     bind_device: bool,
 ) -> Result<()> {
     lazy_static::initialize(&OPTIONS);
@@ -217,7 +218,7 @@ pub fn init_rootfs(
         }
 
         if m.r#type == "cgroup" {
-            mount_cgroups(cfd_log, m, rootfs, flags, &data, cpath, mounts)
+            mount_cgroups(cfd_log, m, rootfs, flags, &data, cpath, mounts, cgroup_path)
                 .map_err(|e| anyhow!("mount cgroup {:} failed:{:}", m.source.as_str(), e))?;
         } else {
             if m.destination == "/dev" {
@@ -365,19 +366,39 @@ fn check_proc_mount(m: &Mount) -> Result<()> {
     Ok(())
 }
 
-fn mount_cgroups_v2(cfd_log: RawFd, m: &Mount, rootfs: &str, flags: MsFlags) -> Result<()> {
+fn cgroup2_scoped_source(cgroup_path: &str) -> Result<String> {
+    Ok(crate::cgroups::fs::cgroup_filesystem_path(cgroup_path)?
+        .to_string_lossy()
+        .into_owned())
+}
+
+fn mount_cgroups_v2(
+    cfd_log: RawFd,
+    m: &Mount,
+    rootfs: &str,
+    flags: MsFlags,
+    cgroup_path: &str,
+) -> Result<()> {
     let olddir = unistd::getcwd()?;
     unistd::chdir(rootfs)?;
 
-    // https://github.com/opencontainers/runc/blob/09ddc63afdde16d5fb859a1d3ab010bd45f08497/libcontainer/rootfs_linux.go#L287
+    // Mount only this container's accounting subtree. envd creates `user`,
+    // `ptys`, and `socats` relative to /sys/fs/cgroup; binding the subtree
+    // makes those groups descendants of the Task.Stats cgroup instead of
+    // siblings at the guest hierarchy root.
+    let source = cgroup2_scoped_source(cgroup_path)?;
+    if !Path::new(&source).is_dir() {
+        return Err(anyhow!("guest cgroup path does not exist: {source}"));
+    }
+
     let bm = Mount {
-        source: "cgroup".to_string(),
-        r#type: "cgroup2".to_string(),
+        source,
+        r#type: "bind".to_string(),
         destination: m.destination.clone(),
         options: Vec::new(),
     };
 
-    let mount_flags: MsFlags = flags;
+    let mount_flags = flags | MsFlags::MS_BIND | MsFlags::MS_REC;
 
     mount_from(cfd_log, &bm, rootfs, mount_flags, "", "")?;
 
@@ -405,9 +426,10 @@ fn mount_cgroups(
     _data: &str,
     cpath: &HashMap<String, String>,
     mounts: &HashMap<String, String>,
+    cgroup_path: &str,
 ) -> Result<()> {
     if cgroups::hierarchies::is_cgroup2_unified_mode() {
-        return mount_cgroups_v2(cfd_log, m, rootfs, flags);
+        return mount_cgroups_v2(cfd_log, m, rootfs, flags, cgroup_path);
     }
     // mount tmpfs
     let ctm = Mount {
@@ -1105,6 +1127,17 @@ mod tests {
     use tempfile::tempdir;
 
     #[test]
+    fn cgroup2_scoped_source_keeps_paths_under_guest_mount() {
+        assert_eq!(
+            cgroup2_scoped_source("/default/container").unwrap(),
+            "/sys/fs/cgroup/default/container"
+        );
+        assert_eq!(cgroup2_scoped_source("").unwrap(), "/sys/fs/cgroup");
+        assert!(cgroup2_scoped_source("/default/../escape").is_err());
+        assert!(cgroup2_scoped_source("/default//escape").is_err());
+    }
+
+    #[test]
     #[serial(chdir)]
     fn test_init_rootfs() {
         let stdout_fd = std::io::stdout().as_raw_fd();
@@ -1113,7 +1146,7 @@ mod tests {
         let mounts = HashMap::new();
 
         // there is no spec.linux, should fail
-        let ret = init_rootfs(stdout_fd, &spec, &cpath, &mounts, true);
+        let ret = init_rootfs(stdout_fd, &spec, &cpath, &mounts, "", true);
         assert!(
             ret.is_err(),
             "Should fail: there is no spec.linux. Got: {:?}",
@@ -1122,7 +1155,7 @@ mod tests {
 
         // there is no spec.Root, should fail
         spec.linux = Some(oci::Linux::default());
-        let ret = init_rootfs(stdout_fd, &spec, &cpath, &mounts, true);
+        let ret = init_rootfs(stdout_fd, &spec, &cpath, &mounts, "", true);
         assert!(
             ret.is_err(),
             "should fail: there is no spec.Root. Got: {:?}",
@@ -1139,7 +1172,7 @@ mod tests {
         });
 
         // there is no spec.mounts, but should pass
-        let ret = init_rootfs(stdout_fd, &spec, &cpath, &mounts, true);
+        let ret = init_rootfs(stdout_fd, &spec, &cpath, &mounts, "", true);
         assert!(ret.is_ok(), "Should pass. Got: {:?}", ret);
         let _ = remove_dir_all(rootfs.path().join("dev"));
         let _ = create_dir(rootfs.path().join("dev"));
@@ -1153,7 +1186,7 @@ mod tests {
         });
 
         // destination doesn't start with /, should fail
-        let ret = init_rootfs(stdout_fd, &spec, &cpath, &mounts, true);
+        let ret = init_rootfs(stdout_fd, &spec, &cpath, &mounts, "", true);
         assert!(
             ret.is_err(),
             "Should fail: destination doesn't start with '/'. Got: {:?}",
@@ -1171,7 +1204,7 @@ mod tests {
             options: vec!["shared".into()],
         });
 
-        let ret = init_rootfs(stdout_fd, &spec, &cpath, &mounts, true);
+        let ret = init_rootfs(stdout_fd, &spec, &cpath, &mounts, "", true);
         assert!(ret.is_ok(), "Should pass. Got: {:?}", ret);
         spec.mounts.pop();
         let _ = remove_dir_all(rootfs.path().join("dev"));
@@ -1185,7 +1218,7 @@ mod tests {
             options: vec!["shared".into()],
         });
 
-        let ret = init_rootfs(stdout_fd, &spec, &cpath, &mounts, true);
+        let ret = init_rootfs(stdout_fd, &spec, &cpath, &mounts, "", true);
         assert!(ret.is_ok(), "Should pass. Got: {:?}", ret);
     }
 
@@ -1227,6 +1260,7 @@ mod tests {
             "",
             &cpath,
             &cgroup_mounts,
+            "",
         );
         assert!(ret.is_ok(), "Should pass. Got: {:?}", ret);
     }

--- a/tests/e2e/resource_metrics/README.md
+++ b/tests/e2e/resource_metrics/README.md
@@ -1,0 +1,26 @@
+# Resource metrics E2E
+
+These tests validate CubeSandbox CPU and memory metrics on a deployed Linux node. Sandbox lifecycle operations must use CubeAPI and CubeProxy; host-side assertions may use `cubecli` or the Cubelet metrics endpoint.
+
+## Guest workload transport
+
+`guest_workload_task_stats.sh` validates the runtime transport introduced by the guest workload metrics change:
+
+1. Create a sandbox through CubeAPI with the Python SDK before running the script.
+2. Run a controlled CPU and memory workload through CubeProxy.
+3. Run the script on the selected Cubelet node with the sandbox ID.
+4. Repeat the query for a sandbox restored from a snapshot or template.
+
+The test is explicitly node-local. Set both `CUBECLI` and `CUBELET_ADDRESS` to opt in when running on a Cubelet node; cluster E2E runners leave these node-local settings unset, report `SKIP`, and exit successfully. The SDK/API-initiated lifecycle case remains in the Cubelet resource-metrics change.
+
+```bash
+CUBECLI=/usr/local/services/cubetoolbox/Cubelet/bin/cubecli \
+  CUBELET_ADDRESS=/data/cubelet/cubelet.sock \
+  tests/e2e/resource_metrics/guest_workload_task_stats.sh <sandbox-id>
+```
+
+The script checks that containerd successfully decodes `Task.Stats` as the canonical cgroup v1 metrics shape used by the locked shim contract, that CPU counters are nanoseconds, and that memory usage and limit are present. The focused CubeShim test separately asserts the exact `io.containerd.cgroups.v1.Metrics` type URL.
+
+## Lifecycle metrics
+
+The lifecycle and Prometheus E2E is added with the Cubelet resource metrics collector. It requires the guest workload transport above and validates fresh collection, CPU and memory load, snapshot rollback, pause/resume, deletion, and series cleanup through `/v1/metrics/resource`.

--- a/tests/e2e/resource_metrics/guest_workload_task_stats.sh
+++ b/tests/e2e/resource_metrics/guest_workload_task_stats.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ -z "${CUBECLI:-}" ]]; then
+  echo "SKIP: set CUBECLI and CUBELET_ADDRESS to run the node-local Task.Stats validation"
+  exit 0
+fi
+
+if [[ -z "${CUBELET_ADDRESS:-}" ]]; then
+  echo "SKIP: set CUBECLI and CUBELET_ADDRESS to run the node-local Task.Stats validation"
+  exit 0
+fi
+
+if [[ ! -x "$CUBECLI" ]]; then
+  echo "cubecli is not executable: $CUBECLI" >&2
+  exit 2
+fi
+
+if [[ ! -S "$CUBELET_ADDRESS" ]]; then
+  echo "Cubelet socket is not available: $CUBELET_ADDRESS" >&2
+  exit 2
+fi
+
+sandbox_id="${1:-}"
+if [[ -z "$sandbox_id" ]]; then
+  echo "usage: $0 <sandbox-id>" >&2
+  exit 2
+fi
+
+output="$($CUBECLI --address "$CUBELET_ADDRESS" containerd tasks metrics --format json "$sandbox_id")"
+if [[ -z "$output" ]]; then
+  echo "Task.Stats returned no metrics for sandbox $sandbox_id" >&2
+  exit 1
+fi
+
+printf '%s\n' "$output"
+
+METRICS_JSON="$output" python3 - "$sandbox_id" <<'PY'
+import json
+import os
+import sys
+
+sandbox_id = sys.argv[1]
+raw = os.environ["METRICS_JSON"].strip()
+try:
+    metric = json.loads(raw)
+except json.JSONDecodeError as exc:
+    raise SystemExit(f"cubecli metrics output is not JSON: {exc}")
+
+data = metric.get("data", metric)
+cpu = data.get("cpu", {}).get("usage", {})
+memory = data.get("memory", {}).get("usage", {})
+
+total = int(cpu.get("total", 0))
+user = int(cpu.get("user", 0))
+kernel = int(cpu.get("kernel", 0))
+current = int(memory.get("usage", 0))
+limit = int(memory.get("limit", 0))
+
+if total <= 0 or user + kernel <= 0:
+    raise SystemExit(f"CPU counters are missing for {sandbox_id}: {cpu}")
+if total < 1_000_000:
+    raise SystemExit(
+        f"CPU total is too small for a nanosecond counter: {total}; "
+        "check cgroup v2 microsecond-to-nanosecond normalization"
+    )
+if current <= 0 or limit <= 0:
+    raise SystemExit(f"memory usage or limit is missing for {sandbox_id}: {memory}")
+
+print(
+    json.dumps(
+        {
+            "sandbox_id": sandbox_id,
+            "cpu_total_ns": total,
+            "cpu_user_ns": user,
+            "cpu_system_ns": kernel,
+            "memory_current_bytes": current,
+            "memory_limit_bytes": limit,
+            "result": "PASS",
+        },
+        sort_keys=True,
+    )
+)
+PY

--- a/tests/e2e/resource_metrics/guest_workload_task_stats_test.sh
+++ b/tests/e2e/resource_metrics/guest_workload_task_stats_test.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+script="$script_dir/guest_workload_task_stats.sh"
+tmp_dir="$(mktemp -d)"
+socket_pid=""
+cleanup() {
+  if [[ -n "$socket_pid" ]]; then
+    kill "$socket_pid" 2>/dev/null || true
+    wait "$socket_pid" 2>/dev/null || true
+  fi
+  rm -rf "$tmp_dir"
+}
+trap cleanup EXIT
+
+assert_contains() {
+  local output="$1"
+  local expected="$2"
+  if [[ "$output" != *"$expected"* ]]; then
+    echo "expected output to contain: $expected" >&2
+    echo "$output" >&2
+    exit 1
+  fi
+}
+
+skip_output="$(env -u CUBECLI -u CUBELET_ADDRESS "$script")"
+assert_contains "$skip_output" "SKIP:"
+
+cat >"$tmp_dir/cubecli" <<'EOF'
+#!/usr/bin/env bash
+if [[ "$1" != "--address" || "$2" != "$CUBELET_ADDRESS" ]]; then
+  echo "unexpected Cubelet address arguments: $*" >&2
+  exit 1
+fi
+printf '%s\n' '{"data":{"cpu":{"usage":{"total":2000000,"user":1200000,"kernel":800000}},"memory":{"usage":{"usage":4096,"limit":536870912}}}}'
+EOF
+chmod +x "$tmp_dir/cubecli"
+
+skip_without_socket_output="$(CUBECLI="$tmp_dir/cubecli" env -u CUBELET_ADDRESS "$script")"
+assert_contains "$skip_without_socket_output" "SKIP:"
+
+set +e
+missing_socket_output="$(CUBECLI="$tmp_dir/cubecli" CUBELET_ADDRESS="$tmp_dir/missing.sock" "$script" sandbox-id 2>&1)"
+missing_socket_status=$?
+set -e
+if [[ $missing_socket_status -ne 2 ]]; then
+  echo "expected explicit missing CUBELET_ADDRESS to exit 2, got $missing_socket_status" >&2
+  exit 1
+fi
+assert_contains "$missing_socket_output" "Cubelet socket is not available"
+
+python3 - "$tmp_dir/cubelet.sock" "$tmp_dir/socket-ready" <<'PY' &
+import signal
+import socket
+import sys
+
+server = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+server.bind(sys.argv[1])
+open(sys.argv[2], "w", encoding="utf-8").close()
+signal.pause()
+PY
+socket_pid=$!
+for _ in {1..50}; do
+  [[ -e "$tmp_dir/socket-ready" ]] && break
+  sleep 0.02
+done
+if [[ ! -S "$tmp_dir/cubelet.sock" ]]; then
+  echo "failed to create test Cubelet socket" >&2
+  exit 1
+fi
+
+set +e
+missing_output="$(CUBECLI="$tmp_dir/missing-cubecli" CUBELET_ADDRESS="$tmp_dir/cubelet.sock" "$script" sandbox-id 2>&1)"
+missing_status=$?
+set -e
+if [[ $missing_status -ne 2 ]]; then
+  echo "expected explicit missing CUBECLI to exit 2, got $missing_status" >&2
+  exit 1
+fi
+assert_contains "$missing_output" "cubecli is not executable"
+
+pass_output="$(CUBECLI="$tmp_dir/cubecli" CUBELET_ADDRESS="$tmp_dir/cubelet.sock" "$script" sandbox-id)"
+assert_contains "$pass_output" '"result": "PASS"'
+
+echo "guest_workload_task_stats tests: PASS"


### PR DESCRIPTION
## Motivation

CubeSandbox does not currently expose guest workload CPU and memory accounting through the standard containerd task metrics contract. CubeShim does not implement `Task.Stats`, so host-side callers cannot retrieve the existing cube-agent `StatsContainer` data through containerd.

This PR adds the minimal host-initiated transport seam required by later Cubelet resource collection:

```text
containerd Task.Stats -> CubeShim -> cube-agent StatsContainer
```

The sandbox does not push metrics to the host.

## PR Series

This work is split into two PRs so the guest runtime transport and Cubelet-owned metrics semantics can be reviewed independently:

* #1090 (this PR): guest workload cgroup accounting, capability negotiation, and standard `Task.Stats` transport.
* #1122: lifecycle-aware guest and host accounting, bounded sampling, caching, Prometheus export, and operator documentation.

#1122 depends on #1090 and should be merged after it.

## What Changed

* Add strict guest workload CPU and memory accounting to `cube-agent StatsContainer` for the unified cgroup v2 layout.
* Keep the workload accounting cgroup process-free and place runtime processes in a child leaf so delegated envd cgroups remain descendants of the measured workload.
* Bind the sandbox-visible cgroup v2 mount to the workload subtree so envd-created cgroups are included in workload accounting.
* Add an internal resource-metrics capability version; incomplete or older guest layouts fail closed.
* Implement CubeShim `Task.Stats` by calling `StatsContainer` for the requested container and encoding the result as the canonical containerd cgroup metrics type.

## Contract

The current single-container sandbox model uses `container_id == sandbox_id`, while the transport keeps both identifiers explicit for later multi-container discovery.

CPU total/user/system/throttling and memory current/limit/failures are guest-kernel workload cgroup values. This PR transports raw cumulative counters and point-in-time gauges; it does not define lifecycle baselines or Prometheus semantics.

Guests without resource-metrics capability version `1` return `FailedPrecondition` instead of an all-zero or partial metric.

## Scope

This PR intentionally does not add lifecycle epochs, counter baselines, host sandbox accounting, background sampling, cache, Prometheus export, one-click packaging changes, or operator documentation. Those remain in the dependent Cubelet PR.

## Validation

* CubeShim's complete package test suite passes 43 tests, including guest capability validation, CPU/memory conversion, canonical type URL encoding, missing-field rejection, and generated-code stability.
* cube-agent/rustjail tests pass for cgroup v2 CPU and memory parsing, delegated controllers, descendant PID collection, scoped cgroup mounts, and cleanup.
* CubeShim's restored container-ID mapping test verifies that containerd task identity is translated to the guest workload identity before `StatsContainer` is called.
* A standard one-click bundle installed CubeShim and cube-agent from the exact combined commit. The reusable node-local `tests/e2e/resource_metrics/guest_workload_task_stats.sh` case passed on a fresh sandbox with nanosecond CPU counters and non-zero memory current/limit. Cluster runners without explicit node-local `CUBECLI` and `CUBELET_ADDRESS` settings skip this check successfully; SDK/API lifecycle E2E remains in #1122.
* The combined CubeAPI/CubeProxy lifecycle E2E exercised this transport through Cubelet, CubeShim, cube-agent, and the guest workload cgroup. CPU/memory load, snapshot/rollback, pause/resume, delete, and complete resource cleanup passed.
