### PR TITLE
fix(sdk/python): update template get test for auth headers

### DIFF
--- a/sdk/python/tests/test_sandbox.py
+++ b/sdk/python/tests/test_sandbox.py
@@ -2328,6 +2328,7 @@ class TestTemplateAPI:
         get.assert_called_once_with(
             "http://localhost:3000/templates/tpl-network",
             params={},
+            headers={}
         )
         assert info.template_id == "tpl-network"
         assert info.network_type == "tap"


### PR DESCRIPTION
https://github.com/TencentCloud/CubeSandbox/pull/995 added authentication headers to Template.get(), but the existing test still expected the old request signature without headers.

Update the assertion to include the authentication headers.