### PR TITLE
feat(cubeapi): add reusable outbound URL security layer for callbacks and webhooks

### DIFF
--- a/CubeAPI/Cargo.lock
+++ b/CubeAPI/Cargo.lock
@@ -542,6 +542,7 @@ dependencies = [
  "tower-http 0.5.2",
  "tracing",
  "tracing-subscriber",
+ "url",
  "utoipa",
  "uuid",
  "validator",
@@ -1857,6 +1858,7 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "futures-core",
+ "futures-util",
  "http 1.4.0",
  "http-body",
  "http-body-util",
@@ -1876,12 +1878,14 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
+ "tokio-util",
  "tower 0.5.3",
  "tower-http 0.6.11",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
  "webpki-roots",
 ]
@@ -2898,6 +2902,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "wasmparser"
 version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3315,9 +3332,9 @@ dependencies = [
 
 [[package]]
 name = "zmij"
-version = "1.0.21"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"
 
 [[package]]
 name = "zstd"

--- a/CubeAPI/Cargo.toml
+++ b/CubeAPI/Cargo.toml
@@ -74,6 +74,9 @@ reqwest = { version = "0.12", features = ["json", "rustls-tls"], default-feature
 # ── Validation ────────────────────────────────────────────────────────────
 validator = { version = "0.16", features = ["derive"] }
 
+# ── URL parsing for outbound security ─────────────────────────────────────
+url = "2"
+
 # ── Async trait support ───────────────────────────────────────────────────
 async-trait = "0.1"
 
@@ -88,6 +91,11 @@ utoipa = { version = "5.4.0", features = ["chrono", "uuid", "yaml"] }
 tokio = { version = "1", features = ["full"] }
 tower = { version = "0.4" }
 axum-test = "14"
+
+[features]
+default = ["webhooks"]
+# Enables webhook-specific helpers (response body streaming, dev policy, etc.).
+webhooks = ["reqwest/stream"]
 
 [profile.release]
 # Maximize single-binary performance

--- a/CubeAPI/src/config/mod.rs
+++ b/CubeAPI/src/config/mod.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+use crate::security::outbound_url::OutboundUrlSecurityConfig;
 use serde::Deserialize;
 
 #[derive(Debug, Deserialize, Clone)]
@@ -76,6 +77,13 @@ pub struct ServerConfig {
     /// Env var: CUBE_API_KEY
     #[serde(default)]
     pub cube_api_key: Option<String>,
+
+    /// Outbound URL security configuration.
+    ///
+    /// Controls how CubeAPI validates URLs for outbound requests such as
+    /// auth callbacks and (in the future) webhooks.
+    #[serde(default)]
+    pub outbound_url_security: OutboundUrlSecurityConfig,
 }
 
 fn default_bind() -> String {
@@ -135,6 +143,7 @@ impl Default for ServerConfig {
             log_prefix: default_log_prefix(),
             auth_callback_url: None,
             cube_api_key: std::env::var("CUBE_API_KEY").ok().filter(|s| !s.is_empty()),
+            outbound_url_security: OutboundUrlSecurityConfig::default(),
         }
     }
 }

--- a/CubeAPI/src/main.rs
+++ b/CubeAPI/src/main.rs
@@ -12,6 +12,7 @@ mod middleware;
 mod models;
 mod openapi;
 mod routes;
+mod security;
 mod services;
 mod state;
 
@@ -227,7 +228,7 @@ async fn async_main(cfg: config::ServerConfig, debug: bool) -> anyhow::Result<()
     );
 
     // ── App state ─────────────────────────────────────────────────────────
-    let state = state::AppState::new(cfg.clone(), logger.clone()).await;
+    let state = state::AppState::new(cfg.clone(), logger.clone()).await?;
 
     // ── Router ────────────────────────────────────────────────────────────
     let app = routes::build_router(state);

--- a/CubeAPI/src/middleware/auth.rs
+++ b/CubeAPI/src/middleware/auth.rs
@@ -83,41 +83,42 @@ pub async fn unified_auth(
 ) -> Result<Response, AppError> {
     // Mode 1: callback auth — if a callback URL is configured, forward the
     // credential and let the external system decide.
-    let callback_url = match state.config.auth_callback_url.as_deref() {
-        Some(url) if !url.is_empty() => url.to_string(),
-        _ => String::new(),
-    };
-
-    if callback_url.is_empty() {
-        // Mode 2: simple key auth — if CUBE_API_KEY is configured, compare
-        // the extracted credential against it locally.
-        if let Some(expected_key) = state.config.cube_api_key.as_deref() {
-            if !expected_key.is_empty() {
-                let credential = extract_credential(&request).ok_or_else(|| {
-                    AppError::Unauthorized(
-                        "Missing authentication: provide 'Authorization: Bearer <token>' or 'X-API-Key: <key>'"
-                            .to_string(),
-                    )
-                })?;
-                let provided = match &credential {
-                    AuthCredential::Bearer(t) => t.as_str(),
-                    AuthCredential::ApiKey(k) => k.as_str(),
-                };
-                if provided != expected_key {
-                    tracing::warn!(
-                        path = %request.uri().path(),
-                        method = %request.method(),
-                        "simple key auth: credential mismatch"
-                    );
-                    return Err(AppError::Unauthorized(
-                        "Invalid API key or token".to_string(),
-                    ));
+    let auth_callback = match state.auth_callback.as_ref() {
+        Some(cb) if !cb.url.is_empty() => cb,
+        _ => {
+            // Mode 2: simple key auth — if CUBE_API_KEY is configured, compare
+            // the extracted credential against it locally.
+            if let Some(expected_key) = state.config.cube_api_key.as_deref() {
+                if !expected_key.is_empty() {
+                    let credential = extract_credential(&request).ok_or_else(|| {
+                        AppError::Unauthorized(
+                            "Missing authentication: provide 'Authorization: Bearer <token>' or 'X-API-Key: <key>'"
+                                .to_string(),
+                        )
+                    })?;
+                    let provided = match &credential {
+                        AuthCredential::Bearer(t) => t.as_str(),
+                        AuthCredential::ApiKey(k) => k.as_str(),
+                    };
+                    if provided != expected_key {
+                        tracing::warn!(
+                            path = %request.uri().path(),
+                            method = %request.method(),
+                            "simple key auth: credential mismatch"
+                        );
+                        return Err(AppError::Unauthorized(
+                            "Invalid API key or token".to_string(),
+                        ));
+                    }
                 }
             }
+            // Mode 3: no auth (both unset) or simple-key match — pass through.
+            return Ok(next.run(request).await);
         }
-        // Mode 3: no auth (both unset) or simple-key match — pass through.
-        return Ok(next.run(request).await);
-    }
+    };
+
+    let callback_url = &auth_callback.url;
+    let client = &auth_callback.client;
 
     // ── Callback mode continuation ──────────────────────────────────────
 
@@ -136,9 +137,11 @@ pub async fn unified_auth(
     // Build the callback POST, forwarding the credential headers, request path, and HTTP method.
     // X-Request-Method is required for correct authz: the same path (e.g. /templates/:id)
     // serves GET/POST/DELETE/PATCH, so path alone is insufficient to distinguish read vs write.
-    let req_builder = state
-        .http_client
-        .post(&callback_url)
+    //
+    // The bundled client has DNS pinning, redirects/proxies disabled, and strict
+    // timeouts because it was built together with this callback URL in AppState.
+    let req_builder = client
+        .post(callback_url)
         .header("X-Request-Path", &request_path)
         .header("X-Request-Method", &request_method);
 
@@ -235,7 +238,12 @@ mod tests {
     async fn build_test_server_with_callback(callback_url: &str) -> TestServer {
         let mut config = ServerConfig::default();
         config.auth_callback_url = Some(callback_url.to_string());
-        let state = AppState::new(config, arc(NoopLogger)).await;
+        // Unit-test callback servers bind to loopback addresses, so relax the
+        // outbound URL policy for tests only.
+        config.outbound_url_security.allow_private_ips = true;
+        config.outbound_url_security.allowed_schemes =
+            vec!["http".to_string(), "https".to_string()];
+        let state = AppState::new(config, arc(NoopLogger)).await.unwrap();
         let router = Router::new()
             .route("/templates/:id", any(|| async { "ok" }))
             .route("/sandboxes/:id", any(|| async { "ok" }))
@@ -333,7 +341,7 @@ mod tests {
     #[tokio::test]
     async fn no_callback_configured_passthrough() {
         let config = ServerConfig::default(); // auth_callback_url = None
-        let state = AppState::new(config, arc(NoopLogger)).await;
+        let state = AppState::new(config, arc(NoopLogger)).await.unwrap();
         let router = Router::new()
             .route("/sandboxes/:id", any(|| async { "ok" }))
             .layer(axum::middleware::from_fn_with_state(
@@ -392,7 +400,7 @@ mod tests {
     async fn build_test_server_with_api_key(api_key: &str) -> TestServer {
         let mut config = ServerConfig::default();
         config.cube_api_key = Some(api_key.to_string());
-        let state = AppState::new(config, arc(NoopLogger)).await;
+        let state = AppState::new(config, arc(NoopLogger)).await.unwrap();
         let router = Router::new()
             .route("/sandboxes/:id", any(|| async { "ok" }))
             .layer(axum::middleware::from_fn_with_state(

--- a/CubeAPI/src/routes.rs
+++ b/CubeAPI/src/routes.rs
@@ -240,7 +240,7 @@ mod tests {
         let mut config = ServerConfig::default();
         config.cubemaster_url = "http://127.0.0.1:9".to_string();
 
-        let state = AppState::new(config, arc(NoopLogger)).await;
+        let state = AppState::new(config, arc(NoopLogger)).await.unwrap();
         TestServer::new(build_router(state)).expect("router should build")
     }
 
@@ -283,7 +283,7 @@ mod tests {
 
         let mut config = ServerConfig::default();
         config.cubemaster_url = format!("http://{address}");
-        let state = AppState::new(config, arc(NoopLogger)).await;
+        let state = AppState::new(config, arc(NoopLogger)).await.unwrap();
         let server = TestServer::new(build_router(state)).expect("router should build");
 
         for (sandbox_id, retry_after, message) in [

--- a/CubeAPI/src/security/mod.rs
+++ b/CubeAPI/src/security/mod.rs
@@ -1,0 +1,21 @@
+// Copyright (c) 2024 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+//! Security primitives for CubeAPI.
+//!
+//! The `outbound_url` module provides SSRF-resistant URL validation,
+//! DNS pinning, and hardened HTTP client construction for any feature
+//! that needs to call an external URL (auth callbacks, webhooks, etc.).
+
+pub mod outbound_url;
+
+#[allow(unused_imports)]
+pub use outbound_url::{
+    build_secure_client, OutboundUrlError, OutboundUrlPolicy, OutboundUrlSecurityConfig,
+    ValidatedUrl,
+};
+
+#[cfg(feature = "webhooks")]
+#[allow(unused_imports)]
+pub use outbound_url::{read_body_with_limit, BodyLimitError};

--- a/CubeAPI/src/security/outbound_url.rs
+++ b/CubeAPI/src/security/outbound_url.rs
@@ -1,0 +1,1085 @@
+// Copyright (c) 2024 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+//! Outbound URL security layer.
+//!
+//! This module validates URLs before CubeAPI calls them, preventing SSRF
+//! attacks against loopback, private, link-local, and metadata-service
+//! addresses. It also pins resolved DNS names to a `reqwest::Client` so
+//! that the IP address used at validation time is the same one used at
+//! request time, defeating DNS rebinding.
+//!
+//! The public API is intentionally small:
+//!
+//! - [`OutboundUrlSecurityConfig`]: configuration (deserializable from env vars).
+//! - [`OutboundUrlPolicy`]: the validation policy.
+//! - [`ValidatedUrl`]: the result of a successful validation.
+//! - [`build_secure_client`]: builds a hardened `reqwest::Client` from a validated URL.
+//! - [`read_body_with_limit`]: reads a response body with an upper size bound.
+
+use async_trait::async_trait;
+#[cfg(feature = "webhooks")]
+use futures::StreamExt;
+use serde::Deserialize;
+use std::collections::HashSet;
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
+use std::time::Duration;
+use thiserror::Error;
+use tokio::time::timeout;
+use tracing::{debug, warn};
+use url::Host;
+
+/// Configuration for outbound URL security.
+///
+/// Loaded from environment variables using the `__` separator, e.g.:
+///
+/// ```bash
+/// OUTBOUND_URL_SECURITY__ALLOWED_SCHEMES=https
+/// OUTBOUND_URL_SECURITY__ALLOW_PRIVATE_IPS=false
+/// OUTBOUND_URL_SECURITY__RESOLVE_TIMEOUT_MS=5000
+/// ```
+#[derive(Debug, Clone, Deserialize)]
+pub struct OutboundUrlSecurityConfig {
+    /// Allowed URL schemes. Defaults to `["https"]`.
+    ///
+    /// Accepts either a comma-separated string (`"https,http"`) or a list
+    /// (`["https", "http"]`), so it can be loaded from a single environment
+    /// variable without enabling global typed parsing.
+    ///
+    /// The custom deserializer uses `deserialize_any` because the `config`
+    /// crate supplies either a string or a sequence depending on the source.
+    /// If the configuration source changes to TOML/YAML/etc., re-validate this
+    /// behavior.
+    #[serde(default = "default_allowed_schemes", deserialize_with = "deserialize_schemes")]
+    pub allowed_schemes: Vec<String>,
+
+    /// Whether to allow resolved addresses in private/link-local/etc. ranges.
+    /// Defaults to `false`.
+    #[serde(default)]
+    pub allow_private_ips: bool,
+
+    /// DNS resolution timeout in milliseconds. Defaults to 5000.
+    #[serde(default = "default_resolve_timeout_ms")]
+    pub resolve_timeout_ms: u64,
+}
+
+impl Default for OutboundUrlSecurityConfig {
+    fn default() -> Self {
+        Self {
+            allowed_schemes: default_allowed_schemes(),
+            allow_private_ips: false,
+            resolve_timeout_ms: default_resolve_timeout_ms(),
+        }
+    }
+}
+
+fn default_allowed_schemes() -> Vec<String> {
+    vec!["https".to_string()]
+}
+
+fn default_resolve_timeout_ms() -> u64 {
+    5000
+}
+
+fn deserialize_schemes<'de, D>(deserializer: D) -> Result<Vec<String>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    struct StringOrVec;
+
+    impl<'de> serde::de::Visitor<'de> for StringOrVec {
+        type Value = Vec<String>;
+
+        fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+            formatter.write_str("a string or a list of strings")
+        }
+
+        fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
+        where
+            E: serde::de::Error,
+        {
+            Ok(value.split(',').map(String::from).collect())
+        }
+
+        fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+        where
+            A: serde::de::SeqAccess<'de>,
+        {
+            let mut schemes = Vec::new();
+            while let Some(scheme) = seq.next_element::<String>()? {
+                schemes.push(scheme);
+            }
+            Ok(schemes)
+        }
+    }
+
+    deserializer.deserialize_any(StringOrVec)
+}
+
+/// Errors produced while validating an outbound URL.
+#[derive(Debug, Error)]
+pub enum OutboundUrlError {
+    /// The input could not be parsed as a URL.
+    #[error("invalid URL: {0}")]
+    InvalidUrl(String),
+
+    /// The URL scheme is not in the allow-list.
+    #[error("unsupported URL scheme: {0}")]
+    UnsupportedScheme(String),
+
+    /// The scheme is allowed but has no well-known default port and the URL
+    /// does not specify one explicitly.
+    #[error("scheme {0} has no well-known default port; specify host:port explicitly")]
+    NoDefaultPort(String),
+
+    /// The URL has no host component.
+    #[error("URL has no host")]
+    MissingHost,
+
+    /// The URL contains embedded credentials (`user:pass@host`).
+    #[error("URL contains embedded credentials")]
+    EmbeddedCredentials,
+
+    /// The host is explicitly disallowed (e.g. `localhost`).
+    #[error("host is not allowed: {0}")]
+    HostNotAllowed(String),
+
+    /// DNS resolution failed.
+    #[error("DNS resolution failed for {host}: {source}")]
+    ResolutionFailed {
+        host: String,
+        #[source]
+        source: std::io::Error,
+    },
+
+    /// DNS resolution timed out.
+    #[error("DNS resolution timed out for {0}")]
+    ResolutionTimeout(String),
+
+    /// A resolved address is not public and `allow_private_ips` is false.
+    #[error("resolved address {0} is not a public IP")]
+    NonPublicAddress(IpAddr),
+}
+
+/// Errors produced while reading a bounded response body.
+#[cfg(feature = "webhooks")]
+#[derive(Debug, Error)]
+pub enum BodyLimitError {
+    /// The response body exceeds the configured maximum size.
+    #[error("response body exceeds maximum allowed size")]
+    BodyTooLarge,
+
+    /// An underlying network or decoding error occurred.
+    #[error("failed to read response body: {0}")]
+    ReadError(#[from] reqwest::Error),
+}
+
+/// A URL that has passed outbound-security validation.
+#[derive(Debug, Clone)]
+pub struct ValidatedUrl {
+    /// The parsed URL. Path, query, and fragment are preserved.
+    pub url: Url,
+
+    /// The addresses that the host resolved to. Empty for IP-literal hosts.
+    pub resolved: Vec<SocketAddr>,
+}
+
+/// Trait for DNS resolution. Used internally and swapped out in tests.
+#[async_trait]
+trait Resolver: Send + Sync {
+    async fn resolve(&self, host: &str, port: u16) -> Result<Vec<SocketAddr>, std::io::Error>;
+}
+
+/// Default resolver backed by `tokio::net::lookup_host`.
+struct TokioResolver;
+
+#[async_trait]
+impl Resolver for TokioResolver {
+    async fn resolve(&self, host: &str, port: u16) -> Result<Vec<SocketAddr>, std::io::Error> {
+        tokio::net::lookup_host((host, port))
+            .await
+            .map(|iter| iter.collect())
+    }
+}
+
+/// Policy for validating outbound URLs.
+///
+/// Create a policy with one of the constructors:
+///
+/// - [`OutboundUrlPolicy::strict`]: production defaults (https only, no private IPs).
+/// - [`OutboundUrlPolicy::development`]: allows http and private IPs for local testing.
+/// - [`OutboundUrlPolicy::webhook_default`]: intended for future webhook endpoint validation.
+/// - [`OutboundUrlPolicy::from_config`]: loads from [`OutboundUrlSecurityConfig`].
+pub struct OutboundUrlPolicy {
+    allowed_schemes: HashSet<String>,
+    allow_private_ips: bool,
+    resolve_timeout: Duration,
+    resolver: Box<dyn Resolver>,
+}
+
+impl std::fmt::Debug for OutboundUrlPolicy {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("OutboundUrlPolicy")
+            .field("allowed_schemes", &self.allowed_schemes)
+            .field("allow_private_ips", &self.allow_private_ips)
+            .field("resolve_timeout", &self.resolve_timeout)
+            .field("resolver", &"<dyn Resolver>")
+            .finish()
+    }
+}
+
+impl OutboundUrlPolicy {
+    /// Production-strict policy: only `https`, no private IPs.
+    pub fn strict() -> Self {
+        Self {
+            allowed_schemes: HashSet::from(["https".to_string()]),
+            allow_private_ips: false,
+            resolve_timeout: Duration::from_secs(5),
+            resolver: Box::new(TokioResolver),
+        }
+    }
+
+    /// Development policy: allows `http` and private IPs.
+    ///
+    /// Test helper that relaxes the policy for local development scenarios.
+    /// It is gated to tests so that production binaries do not ship unused
+    /// code; local development can achieve the same effect through
+    /// [`OutboundUrlSecurityConfig`].
+    #[cfg(test)]
+    pub fn development() -> Self {
+        Self {
+            allowed_schemes: HashSet::from(["http".to_string(), "https".to_string()]),
+            allow_private_ips: true,
+            resolve_timeout: Duration::from_secs(5),
+            resolver: Box::new(TokioResolver),
+        }
+    }
+
+    /// Recommended policy for future webhook endpoints.
+    #[cfg(feature = "webhooks")]
+    pub fn webhook_default() -> Self {
+        Self::strict()
+    }
+
+    /// Build a policy from application configuration.
+    ///
+    /// This constructor initializes every field explicitly rather than
+    /// starting from [`Self::strict()`] and overwriting, so adding a new field
+    /// to [`OutboundUrlPolicy`] forces this function to be updated at compile
+    /// time and prevents silent divergence from the configured defaults.
+    pub fn from_config(cfg: &OutboundUrlSecurityConfig) -> Self {
+        Self {
+            allowed_schemes: cfg
+                .allowed_schemes
+                .iter()
+                .map(|s| s.to_lowercase())
+                .collect(),
+            allow_private_ips: cfg.allow_private_ips,
+            resolve_timeout: Duration::from_millis(cfg.resolve_timeout_ms),
+            resolver: Box::new(TokioResolver),
+        }
+    }
+
+    /// Validate an outbound URL.
+    ///
+    /// On success, returns a [`ValidatedUrl`] carrying the parsed URL and the
+    /// resolved addresses. The resolved addresses can later be pinned to a
+    /// `reqwest::Client` via [`build_secure_client`].
+    pub async fn validate(&self, raw: &str) -> Result<ValidatedUrl, OutboundUrlError> {
+        let url = Url::parse(raw).map_err(|e| OutboundUrlError::InvalidUrl(e.to_string()))?;
+
+        self.validate_scheme(&url)?;
+        self.validate_credentials(&url)?;
+        self.validate_host(&url)?;
+
+        let port = url
+            .port_or_known_default()
+            .ok_or_else(|| OutboundUrlError::NoDefaultPort(url.scheme().to_string()))?;
+
+        // Resolve and classify addresses. Prefer `url.host()` over `host_str()`
+        // so IPv6 literals are returned as `IpAddr` without square brackets.
+        let resolved = match url.host() {
+            Some(Host::Ipv4(ip)) => {
+                debug!(%url, %ip, "outbound URL uses IPv4 literal");
+                self.validate_ip(IpAddr::V4(ip))?;
+                vec![SocketAddr::new(IpAddr::V4(ip), port)]
+            }
+            Some(Host::Ipv6(ip)) => {
+                debug!(%url, %ip, "outbound URL uses IPv6 literal");
+                self.validate_ip(IpAddr::V6(ip))?;
+                vec![SocketAddr::new(IpAddr::V6(ip), port)]
+            }
+            Some(Host::Domain(domain)) => {
+                debug!(%url, host = %domain, "resolving outbound URL host");
+                let addrs = self.resolve_with_timeout(domain, port).await?;
+                if addrs.is_empty() {
+                    return Err(OutboundUrlError::ResolutionFailed {
+                        host: domain.to_string(),
+                        source: std::io::Error::new(
+                            std::io::ErrorKind::NotFound,
+                            "no addresses returned",
+                        ),
+                    });
+                }
+                for addr in &addrs {
+                    self.validate_ip(addr.ip())?;
+                }
+                addrs
+            }
+            // Defensive: with the current `url` crate this arm is unreachable from
+            // `Url::parse` output because an empty/absent host is rejected at parse
+            // time. It is kept to guard against future `url` behavior changes or
+            // programmatically constructed `Url` values without a host.
+            None => return Err(OutboundUrlError::MissingHost),
+        };
+
+        Ok(ValidatedUrl { url, resolved })
+    }
+
+    fn validate_scheme(&self, url: &Url) -> Result<(), OutboundUrlError> {
+        let scheme = url.scheme();
+        if !self.allowed_schemes.contains(scheme) {
+            return Err(OutboundUrlError::UnsupportedScheme(scheme.to_string()));
+        }
+        Ok(())
+    }
+
+    fn validate_host(&self, url: &Url) -> Result<(), OutboundUrlError> {
+        let host = url
+            .host_str()
+            .ok_or(OutboundUrlError::MissingHost)?
+            .to_lowercase();
+
+        if host.is_empty() {
+            return Err(OutboundUrlError::MissingHost);
+        }
+
+        // Reject localhost explicitly regardless of DNS behavior.
+        if host == "localhost" {
+            return Err(OutboundUrlError::HostNotAllowed(host));
+        }
+
+        Ok(())
+    }
+
+    fn validate_credentials(&self, url: &Url) -> Result<(), OutboundUrlError> {
+        if !url.username().is_empty() || url.password().is_some() {
+            return Err(OutboundUrlError::EmbeddedCredentials);
+        }
+        Ok(())
+    }
+
+    async fn resolve_with_timeout(
+        &self,
+        host: &str,
+        port: u16,
+    ) -> Result<Vec<SocketAddr>, OutboundUrlError> {
+        let fut = self.resolver.resolve(host, port);
+        timeout(self.resolve_timeout, fut)
+            .await
+            .map_err(|_| OutboundUrlError::ResolutionTimeout(host.to_string()))?
+            .map_err(|e| OutboundUrlError::ResolutionFailed {
+                host: host.to_string(),
+                source: e,
+            })
+    }
+
+    fn validate_ip(&self, ip: IpAddr) -> Result<(), OutboundUrlError> {
+        if self.allow_private_ips {
+            return Ok(());
+        }
+        if is_public_ip(ip) {
+            Ok(())
+        } else {
+            warn!(%ip, "rejecting non-public outbound IP address");
+            Err(OutboundUrlError::NonPublicAddress(ip))
+        }
+    }
+
+    /// Test-only constructor that swaps the DNS resolver.
+    #[cfg(test)]
+    fn with_resolver(mut self, resolver: Box<dyn Resolver>) -> Self {
+        self.resolver = resolver;
+        self
+    }
+
+    /// Test-only setter for the DNS resolution timeout.
+    #[cfg(test)]
+    fn with_resolve_timeout(mut self, timeout: Duration) -> Self {
+        self.resolve_timeout = timeout;
+        self
+    }
+}
+
+/// Return `true` if `ip` is a publicly routable address.
+fn is_public_ip(ip: IpAddr) -> bool {
+    match ip {
+        IpAddr::V4(v4) => is_public_ipv4(v4),
+        IpAddr::V6(v6) => {
+            // Treat IPv4-mapped and IPv4-compatible addresses as their inner IPv4.
+            if let Some(v4) = v6.to_ipv4_mapped().or(v6.to_ipv4()) {
+                return is_public_ipv4(v4);
+            }
+            !(v6.is_loopback()
+                || v6.is_unique_local()
+                || v6.is_unicast_link_local()
+                || v6.is_multicast()
+                || v6.is_unspecified()
+                || is_ipv6_benchmarking(v6)
+                || is_ipv6_ietf_protocol_assignment(v6)
+                || is_ipv6_documentation(v6))
+        }
+    }
+}
+
+fn is_public_ipv4(v4: Ipv4Addr) -> bool {
+    !(v4.is_loopback()
+        || v4.is_private()
+        || v4.is_link_local()
+        || v4.is_multicast()
+        || v4.is_broadcast()
+        || v4.is_documentation()
+        || v4.is_unspecified()
+        || is_shared_address_space(v4)
+        || is_ietf_protocol_assignments(v4)
+        || is_this_network(v4))
+}
+
+/// 2001:db8::/32 (IPv6 documentation range).
+fn is_ipv6_documentation(v6: Ipv6Addr) -> bool {
+    let segments = v6.segments();
+    segments[0] == 0x2001 && segments[1] == 0x0db8
+}
+
+/// 2001:2::/48 (IPv6 benchmarking range).
+fn is_ipv6_benchmarking(v6: Ipv6Addr) -> bool {
+    let segments = v6.segments();
+    segments[0] == 0x2001 && segments[1] == 0x0002 && segments[2] == 0x0000
+}
+
+/// 2001:3::/32 (IPv6 IETF protocol assignments).
+fn is_ipv6_ietf_protocol_assignment(v6: Ipv6Addr) -> bool {
+    let segments = v6.segments();
+    segments[0] == 0x2001 && segments[1] == 0x0003
+}
+
+/// 100.64.0.0/10 (CGNAT / shared address space).
+fn is_shared_address_space(v4: Ipv4Addr) -> bool {
+    let octets = v4.octets();
+    octets[0] == 100 && (64..=127).contains(&octets[1])
+}
+
+/// 192.0.0.0/24 (IETF protocol assignments, includes DS-Lite 192.0.0.1/2).
+fn is_ietf_protocol_assignments(v4: Ipv4Addr) -> bool {
+    let octets = v4.octets();
+    octets[0] == 192 && octets[1] == 0 && octets[2] == 0
+}
+
+/// 0.0.0.0/8 (this network).
+fn is_this_network(v4: Ipv4Addr) -> bool {
+    v4.octets()[0] == 0
+}
+
+/// Build a hardened `reqwest::Client` for a validated outbound URL.
+///
+/// The client:
+///
+/// - Disables automatic redirects.
+/// - Disables HTTP proxies.
+/// - Sets connect and request timeouts.
+/// - Pins the validated DNS addresses to the host name, preventing DNS rebinding.
+///
+/// Because resolved IPs are pinned at construction time, the client will not
+/// follow DNS record changes (e.g., CDN rotation or load-balancer failover).
+/// The application must be restarted to re-resolve and pin new addresses.
+///
+/// # Errors
+///
+/// Returns an error if `reqwest` fails to build the client.
+pub fn build_secure_client(
+    validated: &ValidatedUrl,
+    connect_timeout: Duration,
+    request_timeout: Duration,
+) -> Result<reqwest::Client, reqwest::Error> {
+    let mut builder = reqwest::Client::builder()
+        .redirect(reqwest::redirect::Policy::none())
+        .no_proxy()
+        .connect_timeout(connect_timeout)
+        .timeout(request_timeout);
+
+    // Pin resolved addresses for domain hosts. IP-literal hosts do not need
+    // pinning because no DNS lookup is performed at request time.
+    if matches!(validated.url.host(), Some(Host::Domain(_))) {
+        if let Some(host) = validated.url.host_str() {
+            for addr in &validated.resolved {
+                builder = builder.resolve(host, *addr);
+            }
+        }
+    }
+
+    builder.build()
+}
+
+/// Read a response body up to `max_bytes`.
+///
+/// If `Content-Length` is present and larger than `max_bytes`, the function
+/// returns immediately. Otherwise chunks are streamed until the body is
+/// complete or the limit is exceeded.
+///
+/// This prevents an attacker from exhausting CubeAPI memory with a huge
+/// response body.
+#[cfg(feature = "webhooks")]
+pub async fn read_body_with_limit(
+    response: reqwest::Response,
+    max_bytes: usize,
+) -> Result<Vec<u8>, BodyLimitError> {
+    if let Some(len) = response
+        .headers()
+        .get(reqwest::header::CONTENT_LENGTH)
+        .and_then(|v| v.to_str().ok())
+        .and_then(|s| s.parse::<u64>().ok())
+    {
+        if len > max_bytes as u64 {
+            return Err(BodyLimitError::BodyTooLarge);
+        }
+    }
+
+    let mut body = Vec::with_capacity(max_bytes.min(4096));
+    let mut stream = response.bytes_stream();
+
+    while let Some(chunk) = stream.next().await {
+        let chunk = chunk?;
+        if body.len().saturating_add(chunk.len()) > max_bytes {
+            return Err(BodyLimitError::BodyTooLarge);
+        }
+        body.extend_from_slice(&chunk);
+    }
+
+    Ok(body)
+}
+
+// Re-export `Url` so callers do not need to add the `url` crate themselves.
+pub use url::Url;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    /// A resolver that returns fixed addresses for configured hosts.
+    struct StaticResolver {
+        records: HashMap<String, Vec<IpAddr>>,
+    }
+
+    impl StaticResolver {
+        fn new(records: HashMap<String, Vec<IpAddr>>) -> Self {
+            Self { records }
+        }
+    }
+
+    #[async_trait]
+    impl Resolver for StaticResolver {
+        async fn resolve(&self, host: &str, port: u16) -> Result<Vec<SocketAddr>, std::io::Error> {
+            let addrs = self
+                .records
+                .get(host)
+                .cloned()
+                .unwrap_or_default()
+                .into_iter()
+                .map(|ip| SocketAddr::new(ip, port))
+                .collect();
+            Ok(addrs)
+        }
+    }
+
+    fn policy_with_resolver(records: HashMap<String, Vec<IpAddr>>) -> OutboundUrlPolicy {
+        OutboundUrlPolicy::strict().with_resolver(Box::new(StaticResolver::new(records)))
+    }
+
+    fn ipv4(a: u8, b: u8, c: u8, d: u8) -> IpAddr {
+        IpAddr::V4(Ipv4Addr::new(a, b, c, d))
+    }
+
+    #[tokio::test]
+    async fn valid_https_url_passes() {
+        let records = HashMap::from([("example.com".to_string(), vec![ipv4(1, 2, 3, 4)])]);
+        let policy = policy_with_resolver(records);
+        let result = policy.validate("https://example.com/hook").await;
+        assert!(result.is_ok(), "unexpected error: {:?}", result.err());
+    }
+
+    #[tokio::test]
+    async fn http_scheme_rejected_by_default() {
+        let policy = OutboundUrlPolicy::strict();
+        let err = policy
+            .validate("http://example.com/hook")
+            .await
+            .unwrap_err();
+        assert!(matches!(err, OutboundUrlError::UnsupportedScheme(_)));
+    }
+
+    #[tokio::test]
+    #[cfg(feature = "webhooks")]
+    async fn webhook_default_uses_strict_policy() {
+        let policy = OutboundUrlPolicy::webhook_default();
+        let records = HashMap::from([("example.com".to_string(), vec![ipv4(1, 2, 3, 4)])]);
+        let policy = policy.with_resolver(Box::new(StaticResolver::new(records)));
+        assert!(policy.validate("https://example.com/hook").await.is_ok());
+        let err = policy
+            .validate("http://example.com/hook")
+            .await
+            .unwrap_err();
+        assert!(matches!(err, OutboundUrlError::UnsupportedScheme(_)));
+    }
+
+    #[tokio::test]
+    async fn http_scheme_allowed_when_configured() {
+        let policy = OutboundUrlPolicy::development();
+        let records = HashMap::from([("example.com".to_string(), vec![ipv4(1, 2, 3, 4)])]);
+        let policy = policy.with_resolver(Box::new(StaticResolver::new(records)));
+        let result = policy.validate("http://example.com/hook").await;
+        assert!(result.is_ok(), "unexpected error: {:?}", result.err());
+    }
+
+    #[tokio::test]
+    async fn ftp_scheme_rejected() {
+        // Use a mock resolver so the test never performs real DNS even if the
+        // validation ordering changes in the future.
+        let policy = policy_with_resolver(HashMap::new());
+        let err = policy.validate("ftp://example.com").await.unwrap_err();
+        assert!(matches!(err, OutboundUrlError::UnsupportedScheme(_)));
+    }
+
+    #[tokio::test]
+    async fn allowed_scheme_without_default_port_rejected() {
+        let cfg = OutboundUrlSecurityConfig {
+            allowed_schemes: vec!["custom".to_string(), "https".to_string()],
+            ..Default::default()
+        };
+        let policy = OutboundUrlPolicy::from_config(&cfg);
+        let err = policy
+            .validate("custom://example.com/path")
+            .await
+            .unwrap_err();
+        assert!(matches!(err, OutboundUrlError::NoDefaultPort(_)));
+    }
+
+    #[tokio::test]
+    async fn allowed_scheme_with_explicit_port_passes() {
+        let cfg = OutboundUrlSecurityConfig {
+            allowed_schemes: vec!["custom".to_string(), "https".to_string()],
+            ..Default::default()
+        };
+        let records = HashMap::from([("example.com".to_string(), vec![ipv4(1, 2, 3, 4)])]);
+        let policy = OutboundUrlPolicy::from_config(&cfg)
+            .with_resolver(Box::new(StaticResolver::new(records)));
+        let result = policy.validate("custom://example.com:8080/path").await;
+        assert!(result.is_ok(), "unexpected error: {:?}", result.err());
+    }
+
+    #[tokio::test]
+    async fn empty_url_rejected() {
+        let policy = OutboundUrlPolicy::strict();
+        let err = policy.validate("").await.unwrap_err();
+        assert!(matches!(err, OutboundUrlError::InvalidUrl(_)));
+    }
+
+    #[tokio::test]
+    async fn missing_host_rejected() {
+        let policy = OutboundUrlPolicy::strict();
+        let err = policy.validate("https:///").await.unwrap_err();
+        assert!(matches!(err, OutboundUrlError::InvalidUrl(_)));
+    }
+
+    #[tokio::test]
+    async fn scheme_only_url_rejected() {
+        // `Url::parse("https://")` rejects at parse time, so this tests the
+        // InvalidUrl path rather than MissingHost.
+        let policy = OutboundUrlPolicy::strict();
+        let err = policy.validate("https://").await.unwrap_err();
+        assert!(matches!(err, OutboundUrlError::InvalidUrl(_)));
+    }
+
+    #[tokio::test]
+    async fn localhost_rejected() {
+        let policy = OutboundUrlPolicy::strict();
+        let err = policy.validate("https://localhost/hook").await.unwrap_err();
+        assert!(matches!(err, OutboundUrlError::HostNotAllowed(_)));
+    }
+
+    #[tokio::test]
+    async fn embedded_credentials_rejected() {
+        let policy = OutboundUrlPolicy::strict();
+        let cases = ["https://user:pass@example.com", "https://user@example.com"];
+        for url in cases {
+            let err = policy.validate(url).await.unwrap_err();
+            assert!(
+                matches!(err, OutboundUrlError::EmbeddedCredentials),
+                "URL {} should be rejected, got {:?}",
+                url,
+                err
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn ipv4_loopback_rejected() {
+        let policy = OutboundUrlPolicy::strict();
+        let err = policy.validate("https://127.0.0.1/hook").await.unwrap_err();
+        assert!(matches!(err, OutboundUrlError::NonPublicAddress(_)));
+    }
+
+    #[tokio::test]
+    async fn ipv6_loopback_rejected() {
+        let policy = OutboundUrlPolicy::strict();
+        let err = policy.validate("https://[::1]/hook").await.unwrap_err();
+        assert!(matches!(err, OutboundUrlError::NonPublicAddress(_)));
+    }
+
+    #[tokio::test]
+    async fn private_ipv4_rejected() {
+        let policy = OutboundUrlPolicy::strict();
+        let cases = ["10.0.0.1", "192.168.1.1", "172.16.0.1"];
+        for host in cases {
+            let url = format!("https://{}/hook", host);
+            let err = policy.validate(&url).await.unwrap_err();
+            assert!(
+                matches!(err, OutboundUrlError::NonPublicAddress(_)),
+                "{} should be rejected, got {:?}",
+                url,
+                err
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn link_local_and_metadata_rejected() {
+        let policy = OutboundUrlPolicy::strict();
+        let cases = ["169.254.169.254", "169.254.1.1"];
+        for host in cases {
+            let url = format!("https://{}/hook", host);
+            let err = policy.validate(&url).await.unwrap_err();
+            assert!(
+                matches!(err, OutboundUrlError::NonPublicAddress(_)),
+                "{} should be rejected, got {:?}",
+                url,
+                err
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn ipv4_mapped_ipv6_loopback_rejected() {
+        let policy = OutboundUrlPolicy::strict();
+        let err = policy
+            .validate("https://[::ffff:127.0.0.1]/hook")
+            .await
+            .unwrap_err();
+        assert!(matches!(err, OutboundUrlError::NonPublicAddress(_)));
+    }
+
+    #[tokio::test]
+    async fn ipv4_mapped_ipv6_private_rejected() {
+        let policy = OutboundUrlPolicy::strict();
+        let err = policy
+            .validate("https://[::ffff:192.168.1.1]/hook")
+            .await
+            .unwrap_err();
+        assert!(matches!(err, OutboundUrlError::NonPublicAddress(_)));
+    }
+
+    #[tokio::test]
+    async fn ipv6_unique_local_rejected() {
+        let policy = OutboundUrlPolicy::strict();
+        let err = policy.validate("https://[fc00::1]/hook").await.unwrap_err();
+        assert!(matches!(err, OutboundUrlError::NonPublicAddress(_)));
+    }
+
+    #[tokio::test]
+    async fn ipv6_multicast_rejected() {
+        let policy = OutboundUrlPolicy::strict();
+        let err = policy.validate("https://[ff02::1]/hook").await.unwrap_err();
+        assert!(matches!(err, OutboundUrlError::NonPublicAddress(_)));
+    }
+
+    #[tokio::test]
+    async fn ipv6_benchmarking_rejected() {
+        let policy = OutboundUrlPolicy::strict();
+        let err = policy
+            .validate("https://[2001:2::1]/hook")
+            .await
+            .unwrap_err();
+        assert!(matches!(err, OutboundUrlError::NonPublicAddress(_)));
+    }
+
+    #[tokio::test]
+    async fn ipv6_ietf_protocol_assignment_rejected() {
+        let policy = OutboundUrlPolicy::strict();
+        let err = policy
+            .validate("https://[2001:3::1]/hook")
+            .await
+            .unwrap_err();
+        assert!(matches!(err, OutboundUrlError::NonPublicAddress(_)));
+    }
+
+    #[tokio::test]
+    async fn shared_address_space_cgnat_rejected() {
+        let policy = OutboundUrlPolicy::strict();
+        let err = policy
+            .validate("https://100.64.0.1/hook")
+            .await
+            .unwrap_err();
+        assert!(matches!(err, OutboundUrlError::NonPublicAddress(_)));
+    }
+
+    #[tokio::test]
+    async fn ietf_protocol_assignments_rejected() {
+        let policy = OutboundUrlPolicy::strict();
+        let err = policy.validate("https://192.0.0.1/hook").await.unwrap_err();
+        assert!(matches!(err, OutboundUrlError::NonPublicAddress(_)));
+    }
+
+    #[tokio::test]
+    async fn this_network_rejected() {
+        let policy = OutboundUrlPolicy::strict();
+        let err = policy.validate("https://0.1.2.3/hook").await.unwrap_err();
+        assert!(matches!(err, OutboundUrlError::NonPublicAddress(_)));
+    }
+
+    #[tokio::test]
+    async fn allow_private_ips_permits_loopback() {
+        let policy = OutboundUrlPolicy::development();
+        let result = policy.validate("https://127.0.0.1/hook").await;
+        assert!(result.is_ok(), "unexpected error: {:?}", result.err());
+    }
+
+    #[tokio::test]
+    async fn domain_resolves_to_public_ip_passes() {
+        let records = HashMap::from([("service.example.com".to_string(), vec![ipv4(1, 2, 3, 4)])]);
+        let policy = policy_with_resolver(records);
+        let validated = policy
+            .validate("https://service.example.com/hook")
+            .await
+            .unwrap();
+        assert_eq!(validated.resolved.len(), 1);
+        assert_eq!(validated.resolved[0].ip(), ipv4(1, 2, 3, 4));
+    }
+
+    #[tokio::test]
+    async fn domain_resolves_to_private_ip_rejected() {
+        let records = HashMap::from([("evil.example.com".to_string(), vec![ipv4(10, 0, 0, 1)])]);
+        let policy = policy_with_resolver(records);
+        let err = policy
+            .validate("https://evil.example.com/hook")
+            .await
+            .unwrap_err();
+        assert!(matches!(err, OutboundUrlError::NonPublicAddress(_)));
+    }
+
+    #[tokio::test]
+    async fn empty_dns_result_rejected() {
+        let records = HashMap::<String, Vec<IpAddr>>::new();
+        let policy = policy_with_resolver(records);
+        let err = policy
+            .validate("https://unknown.example.com/hook")
+            .await
+            .unwrap_err();
+        assert!(matches!(err, OutboundUrlError::ResolutionFailed { .. }));
+    }
+
+    #[tokio::test]
+    async fn secure_client_pins_resolved_addresses() {
+        let records = HashMap::from([("service.example.com".to_string(), vec![ipv4(1, 2, 3, 4)])]);
+        let policy = policy_with_resolver(records);
+        let validated = policy
+            .validate("https://service.example.com/hook")
+            .await
+            .unwrap();
+
+        let client =
+            build_secure_client(&validated, Duration::from_secs(5), Duration::from_secs(10))
+                .unwrap();
+
+        // reqwest does not expose its resolve table directly. We verify the
+        // client builds and is usable; the pinning behavior is covered by the
+        // resolver contract and manual inspection of the builder configuration.
+        assert_eq!(validated.resolved.len(), 1);
+        drop(client);
+    }
+
+    #[tokio::test]
+    #[cfg(feature = "webhooks")]
+    async fn read_body_under_limit_succeeds() {
+        let body = reqwest::Body::from("hello world");
+        let response = http_response_from_body(body);
+        let bytes = read_body_with_limit(response, 1024).await.unwrap();
+        assert_eq!(bytes, b"hello world");
+    }
+
+    #[tokio::test]
+    #[cfg(feature = "webhooks")]
+    async fn read_body_over_limit_fails() {
+        let body = reqwest::Body::from(vec![0u8; 2048]);
+        let response = http_response_from_body(body);
+        let err = read_body_with_limit(response, 1024).await.unwrap_err();
+        assert!(matches!(err, BodyLimitError::BodyTooLarge));
+    }
+
+    #[tokio::test]
+    #[cfg(feature = "webhooks")]
+    async fn content_length_over_limit_fails_immediately() {
+        let response = reqwest::Response::from(
+            axum::http::Response::builder()
+                .header("content-length", "2048")
+                .body(reqwest::Body::from(""))
+                .unwrap(),
+        );
+        let err = read_body_with_limit(response, 1024).await.unwrap_err();
+        assert!(matches!(err, BodyLimitError::BodyTooLarge));
+    }
+
+    #[tokio::test]
+    async fn custom_port_is_preserved() {
+        let records = HashMap::from([("service.example.com".to_string(), vec![ipv4(1, 2, 3, 4)])]);
+        let policy = policy_with_resolver(records);
+        let validated = policy
+            .validate("https://service.example.com:8443/hook")
+            .await
+            .unwrap();
+        assert_eq!(validated.url.port(), Some(8443));
+        assert_eq!(validated.resolved[0].port(), 8443);
+    }
+
+    #[tokio::test]
+    async fn path_query_and_fragment_are_preserved() {
+        let records = HashMap::from([("service.example.com".to_string(), vec![ipv4(1, 2, 3, 4)])]);
+        let policy = policy_with_resolver(records);
+        let validated = policy
+            .validate("https://service.example.com/hook?event=create#section")
+            .await
+            .unwrap();
+        assert_eq!(validated.url.path(), "/hook");
+        assert_eq!(validated.url.query(), Some("event=create"));
+        assert_eq!(validated.url.fragment(), Some("section"));
+    }
+
+    #[tokio::test]
+    async fn mixed_public_and_private_resolved_addresses_rejected() {
+        let records = HashMap::from([(
+            "evil.example.com".to_string(),
+            vec![ipv4(1, 2, 3, 4), ipv4(10, 0, 0, 1)],
+        )]);
+        let policy = policy_with_resolver(records);
+        let err = policy
+            .validate("https://evil.example.com/hook")
+            .await
+            .unwrap_err();
+        assert!(matches!(err, OutboundUrlError::NonPublicAddress(_)));
+    }
+
+    #[tokio::test]
+    async fn ipv4_mapped_ipv6_public_passes() {
+        let policy = OutboundUrlPolicy::strict();
+        let result = policy.validate("https://[::ffff:8.8.8.8]/hook").await;
+        assert!(result.is_ok(), "unexpected error: {:?}", result.err());
+    }
+
+    #[tokio::test]
+    async fn ip_literal_host_is_not_pinned() {
+        let policy = OutboundUrlPolicy::strict();
+        let validated = policy.validate("https://1.2.3.4/hook").await.unwrap();
+        let client =
+            build_secure_client(&validated, Duration::from_secs(5), Duration::from_secs(10))
+                .unwrap();
+        assert_eq!(validated.resolved.len(), 1);
+        drop(client);
+    }
+
+    #[tokio::test]
+    async fn uppercase_scheme_is_normalized_and_validated() {
+        let records = HashMap::from([("example.com".to_string(), vec![ipv4(1, 2, 3, 4)])]);
+        let policy = policy_with_resolver(records);
+        // Url::parse normalizes the scheme to lowercase.
+        let result = policy.validate("HTTPS://example.com/hook").await;
+        assert!(result.is_ok(), "unexpected error: {:?}", result.err());
+    }
+
+    #[tokio::test]
+    async fn uppercase_allowed_schemes_from_config_are_normalized() {
+        let cfg = OutboundUrlSecurityConfig {
+            allowed_schemes: vec!["HTTPS".to_string()],
+            ..Default::default()
+        };
+        let records = HashMap::from([("example.com".to_string(), vec![ipv4(1, 2, 3, 4)])]);
+        let policy = OutboundUrlPolicy::from_config(&cfg)
+            .with_resolver(Box::new(StaticResolver::new(records)));
+        let result = policy.validate("https://example.com/hook").await;
+        assert!(result.is_ok(), "unexpected error: {:?}", result.err());
+    }
+
+    #[tokio::test]
+    async fn dns_resolution_timeout_returns_timeout_error() {
+        struct HangingResolver;
+
+        #[async_trait]
+        impl Resolver for HangingResolver {
+            async fn resolve(
+                &self,
+                _host: &str,
+                _port: u16,
+            ) -> Result<Vec<SocketAddr>, std::io::Error> {
+                std::future::pending::<()>().await;
+                Ok(vec![])
+            }
+        }
+
+        let policy = OutboundUrlPolicy::strict()
+            .with_resolver(Box::new(HangingResolver))
+            .with_resolve_timeout(Duration::from_millis(50));
+
+        let err = policy
+            .validate("https://slow.example.com/hook")
+            .await
+            .unwrap_err();
+        assert!(matches!(err, OutboundUrlError::ResolutionTimeout(_)));
+    }
+
+    #[tokio::test]
+    #[cfg(feature = "webhooks")]
+    async fn read_body_exactly_at_limit_succeeds() {
+        let body = reqwest::Body::from(vec![0u8; 1024]);
+        let response = http_response_from_body(body);
+        let bytes = read_body_with_limit(response, 1024).await.unwrap();
+        assert_eq!(bytes.len(), 1024);
+    }
+
+    /// Helper to build a `reqwest::Response` from a `reqwest::Body` for unit tests.
+    #[cfg(feature = "webhooks")]
+    fn http_response_from_body(body: reqwest::Body) -> reqwest::Response {
+        let response = axum::http::Response::builder().body(body).unwrap();
+        reqwest::Response::from(response)
+    }
+
+    #[test]
+    fn allowed_schemes_deserializes_from_comma_separated_string() {
+        let cfg: OutboundUrlSecurityConfig =
+            serde_json::from_str(r#"{"allowed_schemes": "https,http"}"#).unwrap();
+        assert_eq!(cfg.allowed_schemes, vec!["https", "http"]);
+    }
+
+    #[test]
+    fn allowed_schemes_deserializes_from_array() {
+        let cfg: OutboundUrlSecurityConfig =
+            serde_json::from_str(r#"{"allowed_schemes": ["https", "http"]}"#).unwrap();
+        assert_eq!(cfg.allowed_schemes, vec!["https", "http"]);
+    }
+
+    #[test]
+    fn config_defaults_preserve_expected_types() {
+        let cfg = OutboundUrlSecurityConfig::default();
+        assert_eq!(cfg.allowed_schemes, vec!["https"]);
+        assert!(!cfg.allow_private_ips);
+        assert_eq!(cfg.resolve_timeout_ms, 5000);
+    }
+}

--- a/CubeAPI/src/state.rs
+++ b/CubeAPI/src/state.rs
@@ -4,10 +4,13 @@
 
 use crate::cubemaster::CubeMasterClient;
 use crate::logging::ArcLogger;
+use crate::security::outbound_url::{build_secure_client, OutboundUrlPolicy};
 use crate::services::AppServices;
+use anyhow::Context;
 use governor::{DefaultKeyedRateLimiter, Quota, RateLimiter};
 use std::num::NonZeroU32;
 use std::sync::Arc;
+use std::time::Duration;
 
 /// Shared application state passed to every handler via Axum's `State` extractor.
 /// All fields must be cheap to clone (Arc / DashMap / etc.) — Axum clones State
@@ -17,8 +20,12 @@ pub struct AppState {
     /// Per-API-key rate limiter (token bucket).
     pub rate_limiter: Arc<DefaultKeyedRateLimiter<String>>,
 
-    /// Shared reqwest connection pool.
-    pub http_client: reqwest::Client,
+    /// Hardened auth callback configuration.
+    ///
+    /// Only present when `auth_callback_url` is configured. The bundled client
+    /// uses a pinned DNS address, disables redirects/proxies, and enforces
+    /// timeouts.
+    pub auth_callback: Option<AuthCallbackConfig>,
 
     /// Shared business services built on top of CubeMaster.
     pub services: AppServices,
@@ -30,12 +37,25 @@ pub struct AppState {
     pub config: Arc<crate::config::ServerConfig>,
 }
 
+/// Auth callback URL together with its dedicated, hardened HTTP client.
+///
+/// Bundling the URL and client guarantees that a configured callback always has
+/// a matching secure client, so callers do not need to assert this invariant.
+#[derive(Clone)]
+pub struct AuthCallbackConfig {
+    pub url: String,
+    pub client: reqwest::Client,
+}
+
 impl AppState {
     /// Construct AppState with all backends initialised.
     ///
     /// The `logger` is built externally (in `main.rs`) because `FileLogger::new`
     /// is async and requires the Tokio runtime to be running.
-    pub async fn new(config: crate::config::ServerConfig, logger: ArcLogger) -> Self {
+    pub async fn new(
+        config: crate::config::ServerConfig,
+        logger: ArcLogger,
+    ) -> anyhow::Result<Self> {
         let quota = Quota::per_second(NonZeroU32::new(config.rate_limit_per_sec.max(1)).unwrap());
         let rate_limiter = Arc::new(RateLimiter::keyed(quota));
 
@@ -45,15 +65,33 @@ impl AppState {
             .build()
             .expect("failed to build HTTP client");
 
+        // Validate and build a hardened client for the auth callback URL.
+        let auth_callback = if let Some(ref url) = config.auth_callback_url {
+            let policy = OutboundUrlPolicy::from_config(&config.outbound_url_security);
+            let validated = policy
+                .validate(url)
+                .await
+                .with_context(|| format!("invalid auth_callback_url: {}", url))?;
+            let client =
+                build_secure_client(&validated, Duration::from_secs(5), Duration::from_secs(10))
+                    .context("failed to build auth callback HTTP client")?;
+            Some(AuthCallbackConfig {
+                url: url.clone(),
+                client,
+            })
+        } else {
+            None
+        };
+
         let cubemaster = CubeMasterClient::new(config.cubemaster_url.clone(), http_client.clone());
         let services = AppServices::new(&config, cubemaster);
 
-        Self {
+        Ok(Self {
             rate_limiter,
-            http_client,
+            auth_callback,
             services,
             logger,
             config: Arc::new(config),
-        }
+        })
     }
 }

--- a/docs/guide/outbound-url-security.md
+++ b/docs/guide/outbound-url-security.md
@@ -1,0 +1,114 @@
+# Outbound URL Security Layer
+
+Before CubeAPI calls an external URL (such as `auth_callback_url`), the request goes through the outbound URL security layer to prevent SSRF (Server-Side Request Forgery) attacks and DNS rebinding bypasses.
+
+## Protection Goals
+
+The following protections are always active (default build):
+
+- Block local loopback addresses: `127.0.0.1`, `::1`, `localhost`
+- Block private network addresses: `10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`, `100.64.0.0/10`, etc.
+- Block link-local addresses: `169.254.0.0/16` (including cloud metadata service `169.254.169.254`)
+- Block IPv6 unique-local, multicast, and other non-public addresses
+- Prevent DNS rebinding attacks where a hostname resolves to a public IP during validation but to an internal IP at request time (DNS pinning)
+
+Additional webhook-specific helpers (including response body size limiting via `read_body_with_limit`) are included in the default build through the `webhooks` Cargo feature. To disable them, build with `--no-default-features`.
+
+## Configuration
+
+Configure through environment variables using `__` as the nested separator:
+
+```bash
+# Allowed URL schemes, default: https
+OUTBOUND_URL_SECURITY__ALLOWED_SCHEMES=https
+
+# Whether to allow resolving to private/loopback/link-local addresses, default: false
+OUTBOUND_URL_SECURITY__ALLOW_PRIVATE_IPS=false
+
+# DNS resolution timeout in milliseconds, default: 5000
+OUTBOUND_URL_SECURITY__RESOLVE_TIMEOUT_MS=5000
+```
+
+`ALLOWED_SCHEMES` supports multiple comma-separated values:
+
+```bash
+OUTBOUND_URL_SECURITY__ALLOWED_SCHEMES=http,https
+```
+
+## Default Behavior
+
+Production defaults:
+
+- Only `https` is allowed
+- All private/loopback/link-local addresses are rejected
+- DNS resolution timeout is 5 seconds
+
+If the configured `auth_callback_url` violates the above policy, CubeAPI fails immediately on startup with a clear error message.
+
+## Local Development
+
+In local development or test environments, callback URLs often use `http://127.0.0.1` or LAN addresses. You can relax the restrictions with:
+
+```bash
+OUTBOUND_URL_SECURITY__ALLOWED_SCHEMES=http,https
+OUTBOUND_URL_SECURITY__ALLOW_PRIVATE_IPS=true
+```
+
+::: warning Do not enable allow_private_ips in production
+Setting `allow_private_ips=true` allows CubeAPI to access internal services, which significantly increases SSRF risk. Use it only in local development.
+:::
+
+## Changes to auth_callback_url
+
+When `auth_callback_url` is enabled:
+
+1. CubeAPI validates the URL against the outbound security policy during startup.
+2. After validation, a dedicated hardened HTTP client is built:
+   - Automatic redirects are disabled
+   - HTTP proxy is disabled (the client ignores `HTTP_PROXY`/`HTTPS_PROXY`)
+   - Connection and request timeouts are set
+   - DNS resolution results are pinned to prevent DNS rebinding
+3. The auth middleware uses this dedicated client to send POST requests to the callback URL.
+
+Because the proxy is disabled, environments that require a forward proxy for egress cannot
+use `auth_callback_url` unless the policy is relaxed or a future proxy-aware option is added.
+
+If startup fails with an error like `resolved address 127.0.0.1 is not a public IP`, it means `auth_callback_url` points to a forbidden address. Change it to a public reachable address, or relax the policy in a local development environment.
+
+## Future Reuse by Webhooks
+
+This security layer is also designed for future webhook implementations. Webhook code can use it as follows:
+
+```rust
+use cube_api::security::outbound_url::{OutboundUrlPolicy, build_secure_client};
+use std::time::Duration;
+
+let policy = OutboundUrlPolicy::webhook_default();
+let validated = policy.validate("https://your-webhook.example.com/hook").await?;
+let client = build_secure_client(&validated, Duration::from_secs(5), Duration::from_secs(10))?;
+```
+
+`webhook_default()` uses the same strict policy as production: `https` only and private addresses rejected.
+
+## Validation Examples
+
+The following URLs are rejected by the default policy:
+
+| URL | Rejection Reason |
+|---|---|
+| `http://example.com/hook` | Scheme not in allowlist |
+| `https://127.0.0.1/hook` | Loopback address |
+| `https://localhost/hook` | Explicitly forbidden host |
+| `https://10.0.0.1/hook` | Private address |
+| `https://192.168.1.1/hook` | Private address |
+| `https://169.254.169.254/hook` | Link-local / metadata address |
+| `https://[::ffff:127.0.0.1]/hook` | IPv4-mapped loopback address |
+| `https://user:pass@example.com/hook` | Embedded credentials |
+
+The following URLs pass by default:
+
+| URL | Reason |
+|---|---|
+| `https://example.com/hook` | Public domain resolving to a public IP |
+| `https://1.2.3.4/hook` | Public IP literal |
+| `https://example.com:8443/hook` | Custom port is preserved |

--- a/docs/zh/guide/outbound-url-security.md
+++ b/docs/zh/guide/outbound-url-security.md
@@ -1,0 +1,112 @@
+# 出站 URL 安全层
+
+CubeAPI 在调用外部 URL（如 `auth_callback_url`）之前，会先经过出站 URL 安全层校验，防止 SSRF（Server-Side Request Forgery）攻击和 DNS rebinding 绕过。
+
+## 防护目标
+
+以下保护在默认构建中始终生效：
+
+- 阻止访问本地回环地址：`127.0.0.1`、`::1`、`localhost`
+- 阻止访问私网地址：`10.0.0.0/8`、`172.16.0.0/12`、`192.168.0.0/16`、`100.64.0.0/10` 等
+- 阻止访问链路本地地址：`169.254.0.0/16`（含云厂商 metadata 服务 `169.254.169.254`）
+- 阻止访问 IPv6 唯一本地地址、多播地址等
+- 通过 DNS pinning 防止“校验时公网 IP、请求时内网 IP”的 DNS rebinding 攻击
+
+额外的 Webhook 专用辅助函数（包括通过 `read_body_with_limit` 限制响应体大小）默认通过 `webhooks` Cargo feature 启用；如需禁用，可使用 `--no-default-features` 构建。
+
+## 配置项
+
+通过环境变量配置，使用 `__` 作为嵌套分隔符：
+
+```bash
+# 允许的 URL scheme，默认 https
+OUTBOUND_URL_SECURITY__ALLOWED_SCHEMES=https
+
+# 是否允许解析到私网/回环/链路本地地址，默认 false
+OUTBOUND_URL_SECURITY__ALLOW_PRIVATE_IPS=false
+
+# DNS 解析超时（毫秒），默认 5000
+OUTBOUND_URL_SECURITY__RESOLVE_TIMEOUT_MS=5000
+```
+
+`ALLOWED_SCHEMES` 支持多个值，使用逗号分隔：
+
+```bash
+OUTBOUND_URL_SECURITY__ALLOWED_SCHEMES=http,https
+```
+
+## 默认行为
+
+生产环境默认：
+
+- 只允许 `https`
+- 拒绝所有私网/回环/链路本地地址
+- DNS 解析超时 5 秒
+
+如果配置的 `auth_callback_url` 不符合上述安全策略，CubeAPI 启动会立即失败并输出明确错误。
+
+## 本地开发
+
+在本地开发或测试环境中，回调地址可能是 `http://127.0.0.1` 或局域网地址。可以通过以下配置放宽限制：
+
+```bash
+OUTBOUND_URL_SECURITY__ALLOWED_SCHEMES=http,https
+OUTBOUND_URL_SECURITY__ALLOW_PRIVATE_IPS=true
+```
+
+::: warning 生产环境不要开启 allow_private_ips
+开启 `allow_private_ips=true` 会让 CubeAPI 能够访问内网服务，显著增加 SSRF 风险。请仅在本地开发环境中使用。
+:::
+
+## auth_callback_url 的变化
+
+启用 `auth_callback_url` 后：
+
+1. CubeAPI 启动时会校验该 URL 是否符合出站安全策略。
+2. 校验通过后，会构建一个专用的加固 HTTP client：
+   - 禁用自动 redirect
+   - 禁用 HTTP proxy（会忽略 `HTTP_PROXY`/`HTTPS_PROXY`）
+   - 设置连接超时和请求超时
+   - 固定 DNS 解析结果，防止 DNS rebinding
+3. 鉴权中间件使用该专用 client 向回调地址发送 POST 请求。
+
+由于代理被禁用，需要通过正向代理才能访问外网的环境目前无法使用 `auth_callback_url`，除非放宽策略或后续增加支持代理的选项。
+
+如果启动时报错例如 `resolved address 127.0.0.1 is not a public IP`，说明 `auth_callback_url` 指向了被禁止的地址。请改为公网可访问地址，或在本地开发环境中放宽策略。
+
+## 未来 Webhook 复用
+
+该安全层同样适用于未来的 Webhook 实现。Webhook 代码可以：
+
+```rust
+use cube_api::security::outbound_url::{OutboundUrlPolicy, build_secure_client};
+
+let policy = OutboundUrlPolicy::webhook_default();
+let validated = policy.validate("https://your-webhook.example.com/hook").await?;
+let client = build_secure_client(&validated, Duration::from_secs(5), Duration::from_secs(10))?;
+```
+
+`webhook_default()` 使用与生产环境一致的严格策略：仅 `https`，拒绝私网地址。
+
+## 验证示例
+
+以下 URL 在默认策略下会被拒绝：
+
+| URL | 拒绝原因 |
+|---|---|
+| `http://example.com/hook` | scheme 不在白名单 |
+| `https://127.0.0.1/hook` | 回环地址 |
+| `https://localhost/hook` | 显式禁止的 host |
+| `https://10.0.0.1/hook` | 私网地址 |
+| `https://192.168.1.1/hook` | 私网地址 |
+| `https://169.254.169.254/hook` | 链路本地 / metadata 地址 |
+| `https://[::ffff:127.0.0.1]/hook` | IPv4-mapped 回环地址 |
+| `https://user:pass@example.com/hook` | URL 嵌入凭证 |
+
+以下 URL 在默认策略下会通过：
+
+| URL | 说明 |
+|---|---|
+| `https://example.com/hook` | 公网域名，解析到公网 IP |
+| `https://1.2.3.4/hook` | 公网 IP 字面量 |
+| `https://example.com:8443/hook` | 自定义端口被保留 |


### PR DESCRIPTION
## Summary

This PR introduces a reusable outbound URL security primitive for CubeAPI. Its immediate purpose is to harden `auth_callback_url` against SSRF and DNS rebinding; its longer-term purpose is to serve as the security foundation for upcoming webhook and event-delivery features.

## Background & Motivation

`auth_callback_url` allows CubeAPI to delegate authentication to an external HTTP endpoint. Today the URL is accepted without validation, so a misconfigured or malicious value can target internal services such as `127.0.0.1`, `169.254.169.254`, or private subnets. This is a classic SSRF surface.

Several Webhook PRs (e.g., lifecycle event delivery) are also in flight. They will share the same problem: how to safely dispatch HTTP requests to user-controlled URLs. Instead of baking ad-hoc checks into each feature, this PR provides a single, reviewable, testable security layer that any outbound-calling feature can reuse.

## What This PR Does

- **Adds `CubeAPI/src/security/outbound_url.rs`** — a self-contained SSRF-protection module that covers:
  - URL parsing and scheme validation
  - Host validation (no missing host, no embedded credentials, explicit `localhost` block)
  - IPv4/IPv6 classification: loopback, private, link-local, multicast, documentation, unique-local, IPv4-mapped addresses, etc.
  - DNS resolution with timeout and address pinning via `reqwest::ClientBuilder::resolve`
  - Hardened `reqwest::Client` construction: no redirects, no proxy, explicit timeouts
  - Bounded response-body helper `read_body_with_limit`

- **Adds `OutboundUrlSecurityConfig`** to `ServerConfig` and loads it from environment variables.

- **Integrates with `auth_callback_url`**:
  - Validates the callback URL during `AppState::new()`; startup fails fast on policy violation
  - Builds a dedicated hardened client for callback dispatch
  - Auth middleware uses this client instead of a default `reqwest::Client`

- **Adds user documentation**:
  - `docs/zh/guide/outbound-url-security.md`
  - `docs/guide/outbound-url-security.md`

## Threat Model & Key Protections

| Threat | Protection |
|---|---|
| Loopback / localhost | Rejects `127.0.0.1`, `::1`, `localhost`, and IPv4-mapped loopback |
| Private subnets | Rejects `10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`, `100.64.0.0/10`, etc. |
| Link-local / metadata | Rejects `169.254.0.0/16` including `169.254.169.254` |
| IPv6 non-public | Rejects unique-local, multicast, documentation, etc. |
| DNS rebinding | Resolves at validation time and pins addresses with `reqwest::resolve` |
| Scheme abuse | Defaults to `https` only; `http` must be explicitly allowed |
| Credential leaks | Rejects URLs containing `user:pass@` |
| Redirect hijacking | Hardened client disables automatic redirects |
| Proxy leakage | Hardened client disables HTTP proxy usage |
| OOM from huge responses | `read_body_with_limit` caps response body size |

## Design Decisions

1. **Use `url.host()` instead of `url.host_str()` for IP detection**  
   `host_str()` returns IPv6 literals with square brackets (e.g., `"[::ffff:127.0.0.1]"`), which cannot be parsed directly as `IpAddr`. Using `url.host()` avoids this platform/version-sensitive parsing issue entirely.

2. **Return a `reqwest::Client`, not a raw response**  
   The security layer validates the URL and builds a hardened client, then hands control back to the caller. This keeps the primitive focused and reusable for callbacks, webhooks, log shippers, or any other outbound caller.

3. **Disable proxy by default**  
   In WSL test environments we observed that `reqwest::Client::new()` routes traffic through `HTTP_PROXY`, which can return 502 for local test servers and is undesirable for callback/webhook traffic. The hardened client explicitly calls `.no_proxy()`.

4. **Startup-time validation for `auth_callback_url`**  
   Failing at startup is safer than failing on the first request. It also makes misconfigurations obvious during deployment.

## How Webhook Modules Can Reuse This

```rust
use cube_api::security::outbound_url::{OutboundUrlPolicy, build_secure_client};
use std::time::Duration;

let policy = OutboundUrlPolicy::webhook_default();
let validated = policy.validate("https://your-webhook.example.com/hook").await?;
let client = build_secure_client(&validated, Duration::from_secs(5), Duration::from_secs(10))?;

let response = client
    .post("https://your-webhook.example.com/hook")
    .json(&payload)
    .send()
    .await?;
```

`webhook_default()` uses the same strict defaults as production: `https` only and no private addresses.

## Configuration

Environment variables use `__` as the nested separator:

```bash
OUTBOUND_URL_SECURITY__ALLOWED_SCHEMES=https
OUTBOUND_URL_SECURITY__ALLOW_PRIVATE_IPS=false
OUTBOUND_URL_SECURITY__RESOLVE_TIMEOUT_MS=5000
```

For local development only:

```bash
OUTBOUND_URL_SECURITY__ALLOWED_SCHEMES=http,https
OUTBOUND_URL_SECURITY__ALLOW_PRIVATE_IPS=true
```

## Testing

```bash
cargo fmt -- --check
cargo clippy --package cube-api --all-targets
cargo test --package cube-api
```

Results: **130 passed; 0 failed**.

Additional deployment-level smoke tests were performed in WSL:
1. `AUTH_CALLBACK_URL=http://127.0.0.1:9999/auth` with default policy → CubeAPI exits with an SSRF policy error.
2. With `OUTBOUND_URL_SECURITY__ALLOW_PRIVATE_IPS=true` and a local Python HTTP server as callback → CubeAPI starts and the callback server receives the expected `X-Request-Path`, `X-Request-Method`, and `X-API-Key` headers.

## Validation Examples

Rejected by default:

| URL | Reason |
|---|---|
| `http://example.com/hook` | Scheme not allowed |
| `https://127.0.0.1/hook` | Loopback |
| `https://localhost/hook` | Forbidden host |
| `https://10.0.0.1/hook` | Private |
| `https://169.254.169.254/hook` | Link-local / metadata |
| `https://[::ffff:127.0.0.1]/hook` | IPv4-mapped loopback |
| `https://user:pass@example.com/hook` | Embedded credentials |

Accepted by default:

| URL | Reason |
|---|---|
| `https://example.com/hook` | Public domain → public IP |
| `https://1.2.3.4/hook` | Public IP literal |
| `https://example.com:8443/hook` | Custom port preserved |

## Checklist

- [x] Code follows `rustfmt` style
- [x] `cargo clippy --package cube-api --all-targets` passes
- [x] Unit tests added and all existing tests pass
- [x] User-facing documentation updated (EN + ZH)
- [x] Deployment-level smoke test performed
- [ ] Real staging/deployment test (follow-up recommended)

## Future Work

- Wire the hardened client into the `HttpLogger` webhook log backend stub.
- Build a full webhook subscription/delivery module on top of this security primitive.

Related to #642
