### PR TITLE
docs: add node isolation guide

### DIFF
--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -170,6 +170,7 @@ export default withMermaid(defineConfig({
               items: [
                 { text: 'WebUI Dashboard', link: '/guide/webui' },
                 { text: 'Service Management & Logs', link: '/guide/service-management' },
+                { text: 'Node Isolation', link: '/guide/node-isolation' },
                 { text: 'Sandbox Logs', link: '/guide/sandbox-logs' },
                 { text: 'Template Inspection & Request Preview', link: '/guide/template-inspection-and-preview' },
                 { text: 'HTTPS & Domain Resolution', link: '/guide/https-and-domain' },
@@ -317,6 +318,7 @@ export default withMermaid(defineConfig({
               items: [
                 { text: 'WebUI 控制台', link: '/zh/guide/webui' },
                 { text: '服务管理与日志', link: '/zh/guide/service-management' },
+                { text: '隔离节点', link: '/zh/guide/node-isolation' },
                 { text: '沙箱日志', link: '/zh/guide/sandbox-logs' },
                 { text: '模板检查与请求预览', link: '/zh/guide/template-inspection-and-preview' },
                 { text: 'HTTPS 证书与域名解析', link: '/zh/guide/https-and-domain' },

--- a/docs/guide/kubernetes/upgrade.md
+++ b/docs/guide/kubernetes/upgrade.md
@@ -5,7 +5,7 @@ The goal in one sentence: **the control plane can roll in an orderly fashion; co
 ---
 
 ::: warning Preview version warning
-The compute plane uses native `apps/v1` DaemonSets: image / resource / template changes **delete and recreate** the Big Pod (PodIP / netns change), which breaks existing sandbox networking. Compute-plane upgrades **recreate the `cube-node` Big Pod** (native DaemonSet) and **will interrupt existing sandboxes on that node**. Before upgrading, call CubeMaster’s isolate API, isolate the node for at least 60 seconds, and destroy the sandboxes on that node. Only after sandboxes are destroyed is it safe to upgrade the node.
+The compute plane uses native `apps/v1` DaemonSets: image / resource / template changes **delete and recreate** the Big Pod (PodIP / netns change), which breaks existing sandbox networking. Compute-plane upgrades **recreate the `cube-node` Big Pod** (native DaemonSet) and **will interrupt existing sandboxes on that node**. Before upgrading, call CubeMaster’s isolate API, isolate the node for at least 60 seconds, and destroy the sandboxes on that node. Only after sandboxes are destroyed is it safe to upgrade the node. See [Node Isolation](../node-isolation.md) for the isolate / unisolate commands.
 
 **To smooth upgrades, you may use a Kubernetes plugin you are familiar with to achieve “in-place upgrade”** — update container images without recreating the Pod. After deploying the current version, carefully evaluate changes and test before upgrading further.
 

--- a/docs/guide/node-isolation.md
+++ b/docs/guide/node-isolation.md
@@ -1,0 +1,188 @@
+---
+title: Node Isolation
+lang: en-US
+---
+
+# Node Isolation
+
+Node isolation (isolate) temporarily **stops CubeMaster from scheduling new sandboxes onto a compute node** during maintenance, upgrades, or troubleshooting. It behaves like Kubernetes `cordon`: the node can stay healthy and existing sandboxes keep running — it simply stops receiving new work.
+
+::: tip Current entry points
+WebUI / CubeOps / the public OpenAPI surface do **not** expose isolation yet. Use the **CubeMaster HTTP API**, or **`cubemastercli`** on the control node, to isolate and unisolate nodes.
+:::
+
+## What you'll learn
+
+- How isolation differs from taking a node offline or draining it
+- How to find a `node_id` and isolate / unisolate it
+- How to verify that isolation took effect
+- Recommended order of operations for upgrades and maintenance
+
+## Behavior
+
+| Aspect | After isolation |
+|---|---|
+| **New sandbox scheduling** | The node is skipped; creates fail if no other schedulable node remains |
+| **Existing sandboxes** | **Unaffected** — nothing is destroyed or migrated automatically |
+| **Node health** | Orthogonal to isolation: an isolated node can still report `healthy=true` |
+| **Cubelet heartbeat / register** | Continues normally; the node cannot override or clear the isolation mark itself |
+
+Under the hood, CubeMaster writes a reserved label on the node metadata:
+
+```text
+cube.cloud.tencentcloud.com/scheduling-disabled=true
+```
+
+That label **cannot** be forged or cleared via the generic labels API or Cubelet registration — only the isolate / unisolate APIs on this page can change it.
+
+::: warning Isolation is not drain
+Isolation does **not** evict existing sandboxes. If your next step will interrupt sandbox networking or processes (for example, a Kubernetes compute-plane upgrade that recreates the Big Pod), **destroy sandboxes on that node yourself** after isolating, then proceed. See the [Kubernetes upgrade guide](./kubernetes/upgrade.md).
+:::
+
+## Prerequisites
+
+- Reachable CubeMaster on the control node (default HTTP port **8089**)
+- The target node is already registered with CubeMaster (`node_id` exists)
+- For CLI use: `cubemastercli` is installed on the control node and can reach CubeMaster
+
+Examples below assume you run commands on the control node itself (`127.0.0.1:8089`). In multi-node deployments, replace the address with the control-plane IP.
+
+## Find the node ID
+
+List cluster nodes and check the current isolation state:
+
+```bash
+# CLI
+cubemastercli --address 127.0.0.1 --port 8089 node list
+
+# Or call the API directly
+curl -s http://127.0.0.1:8089/internal/meta/nodes | jq .
+```
+
+In the CLI output, watch the `SCHEDULING_DISABLED` column: `true` means the node is isolated.
+
+You can also inspect a single node:
+
+```bash
+curl -s http://127.0.0.1:8089/internal/meta/nodes/<node_id> | jq '{
+  node_id,
+  host_ip,
+  healthy,
+  scheduling_disabled,
+  labels
+}'
+```
+
+## Isolate a node
+
+### Option 1: HTTP API (best for scripts / automation)
+
+```bash
+curl -X PUT "http://127.0.0.1:8089/internal/meta/nodes/<node_id>/isolation"
+```
+
+A successful response looks like:
+
+```json
+{
+  "ret": {
+    "RetCode": 200,
+    "RetMsg": "Success"
+  },
+  "data": {
+    "node_id": "node-1",
+    "host_ip": "10.0.0.1",
+    "healthy": true,
+    "scheduling_disabled": true,
+    "labels": {
+      "cube.cloud.tencentcloud.com/scheduling-disabled": "true"
+    }
+  }
+}
+```
+
+The call is **idempotent**: repeating `PUT` on an already-isolated node is safe. No request body is required.
+
+### Option 2: cubemastercli
+
+```bash
+# Isolate one node
+cubemastercli --address 127.0.0.1 --port 8089 node isolate <node_id>
+
+# Isolate multiple nodes
+cubemastercli --address 127.0.0.1 --port 8089 node isolate <node_id_1> <node_id_2>
+
+# Raw JSON response
+cubemastercli --address 127.0.0.1 --port 8089 node isolate --json <node_id>
+```
+
+On success the CLI prints something like:
+
+```text
+node node-1 isolated: scheduling_disabled=true
+```
+
+## Verify isolation
+
+Query the node again and confirm `scheduling_disabled` is `true`:
+
+```bash
+curl -s http://127.0.0.1:8089/internal/meta/nodes/<node_id> | jq '.scheduling_disabled'
+# Expected: true
+
+cubemastercli --address 127.0.0.1 --port 8089 node list
+# SCHEDULING_DISABLED should be true
+```
+
+::: tip Wait window
+After isolating, wait **≥ 60 seconds** so in-flight schedule / create windows can finish before you perform disruptive maintenance (reboot, upgrade, take-down, and so on).
+:::
+
+## Unisolate a node
+
+When maintenance is done, remove the cordon so the node can receive new sandboxes again:
+
+```bash
+# HTTP
+curl -X DELETE "http://127.0.0.1:8089/internal/meta/nodes/<node_id>/isolation"
+
+# CLI
+cubemastercli --address 127.0.0.1 --port 8089 node unisolate <node_id>
+```
+
+Afterwards `scheduling_disabled` should be `false`, and the `scheduling-disabled` label should be gone.
+
+## Typical workflows
+
+### Before node maintenance / reboot
+
+1. Isolate the target node
+2. Wait ≥ 60 seconds
+3. (If needed) destroy existing sandboxes on that node
+4. Perform maintenance or reboot
+5. After the node is back and re-registered, unisolate it
+
+### Kubernetes compute-plane upgrade (recreates the Big Pod)
+
+Compute-plane upgrades interrupt existing sandbox networking on that node. Recommended order:
+
+1. Call the isolate API
+2. Wait ≥ 60 seconds
+3. **Destroy** sandboxes on that node
+4. Proceed with the upgrade
+
+Full steps: [Kubernetes upgrade guide](./kubernetes/upgrade.md).
+
+## Scope and limitations
+
+- **Not a drain**: existing sandboxes are not migrated or destroyed automatically.
+- **Single-node / all-isolated clusters**: if no other schedulable node remains, new sandbox creates fail (no host selected).
+- **Orthogonal to health checks**: an isolated node can stay Healthy and may still appear in healthy-node listings; it is only excluded from the schedulable set.
+- **Independent of Kubernetes `kubectl cordon`**: this only affects CubeMaster scheduling; it does not cordon the Kubernetes Node.
+- **Auth**: with CubeMaster HTTP auth disabled (the default), you can call the API directly. If you enable CubeMaster auth, add the required signature headers per your cluster config. Current `cubemastercli node isolate/unisolate` does **not** attach signatures automatically — prefer signed HTTP requests when auth is on.
+
+## Related
+
+- [Service Management & Logs](./service-management.md) — control / compute service lifecycle and logs
+- [Kubernetes Upgrade](./kubernetes/upgrade.md) — isolate the node and clear sandboxes before upgrading
+- [Multi-Node Deploy](./multi-node-deploy.md) — node registration and `/internal/meta/nodes` checks

--- a/docs/zh/guide/kubernetes/upgrade.md
+++ b/docs/zh/guide/kubernetes/upgrade.md
@@ -5,7 +5,7 @@
 ---
 
 ::: warning Preview 版本警告
-计算面使用原生 `apps/v1` DaemonSet：镜像 / 资源 / template 变更会导致 Big Pod **删除重建**（PodIP / netns 变化），存量沙箱网络会中断。计算面升级会 **recreate `cube-node` Big Pod**（原生 DaemonSet），**会中断该节点上的存量沙箱**。升级前请先调用 CubeMaster 的 isolate API，将节点隔离 60 秒以上；并且销毁节点上的沙箱。在销毁沙箱后，才能安全的升级节点。
+计算面使用原生 `apps/v1` DaemonSet：镜像 / 资源 / template 变更会导致 Big Pod **删除重建**（PodIP / netns 变化），存量沙箱网络会中断。计算面升级会 **recreate `cube-node` Big Pod**（原生 DaemonSet），**会中断该节点上的存量沙箱**。升级前请先调用 CubeMaster 的 isolate API，将节点隔离 60 秒以上；并且销毁节点上的沙箱。在销毁沙箱后，才能安全的升级节点。隔离操作详见 [隔离节点](../node-isolation.md)。
 
 **为解决平滑升级问题，您可采用您熟悉的k8s插件去实现“原地升级”  ** —— 即不重建pod，仅升级容器镜像。部署当前版本后若计划升级，应当仔细评估更改、做测试后再实施。
 

--- a/docs/zh/guide/node-isolation.md
+++ b/docs/zh/guide/node-isolation.md
@@ -1,0 +1,188 @@
+---
+title: 隔离节点
+lang: zh-CN
+---
+
+# 隔离节点
+
+节点隔离（isolate）用于在维护、升级或排障时，**临时阻止 CubeMaster 向指定计算节点调度新沙箱**。它类似 Kubernetes 的 `cordon`：节点仍可保持健康、已有沙箱继续运行，只是不再接收新负载。
+
+::: tip 当前入口
+WebUI / CubeOps / 对外 OpenAPI **暂不提供**隔离操作。请通过 **CubeMaster HTTP 接口**，或控制节点上的 **`cubemastercli`** 完成隔离与取消隔离。
+:::
+
+## 读完本页你会知道
+
+- 隔离与「下线 / 驱逐」的区别
+- 如何查找 `node_id` 并隔离 / 取消隔离
+- 如何确认隔离是否生效
+- 升级、维护等常见场景下的推荐操作顺序
+
+## 行为说明
+
+| 维度 | 隔离后的表现 |
+|---|---|
+| **新沙箱调度** | 该节点不再被选中；若集群中没有其他可调度节点，创建会失败 |
+| **已有沙箱** | **不受影响**，不会自动销毁或迁移 |
+| **节点健康状态** | 与隔离正交：隔离节点仍可显示为 `healthy=true` |
+| **Cubelet 心跳 / 注册** | 继续正常；节点侧无法自行覆盖或清除隔离标记 |
+
+内部实现上，CubeMaster 会在节点元数据中写入保留 label：
+
+```text
+cube.cloud.tencentcloud.com/scheduling-disabled=true
+```
+
+该 label **不能**通过普通 labels API 或 Cubelet 注册伪造 / 清除，只能走本文的隔离 / 取消隔离接口。
+
+::: warning 隔离 ≠ 清空节点
+隔离**不会**驱逐存量沙箱。若你要做会中断沙箱网络或进程的操作（例如 K8s 计算面升级会 recreate Big Pod），需要在隔离之后**自行销毁**该节点上的沙箱，再进行维护。详见 [K8s 升级指南](./kubernetes/upgrade.md)。
+:::
+
+## 前置条件
+
+- 能访问控制节点上的 CubeMaster（默认 HTTP 端口 **8089**）
+- 目标节点已在 CubeMaster 完成注册（`node_id` 存在）
+- 若使用 CLI：控制节点上已安装 `cubemastercli`，并可连通 CubeMaster
+
+下文示例默认在控制节点本机执行（`127.0.0.1:8089`）。多机部署时，把地址换成控制节点 IP 即可。
+
+## 查找节点 ID
+
+先列出集群节点，确认要操作的 `NODE_ID` 与当前隔离状态：
+
+```bash
+# CLI
+cubemastercli --address 127.0.0.1 --port 8089 node list
+
+# 或直接调接口
+curl -s http://127.0.0.1:8089/internal/meta/nodes | jq .
+```
+
+CLI 输出中关注 `SCHEDULING_DISABLED` 列：`true` 表示已隔离。
+
+也可以查询单个节点：
+
+```bash
+curl -s http://127.0.0.1:8089/internal/meta/nodes/<node_id> | jq '{
+  node_id,
+  host_ip,
+  healthy,
+  scheduling_disabled,
+  labels
+}'
+```
+
+## 隔离节点
+
+### 方式一：HTTP 接口（推荐脚本 / 自动化）
+
+```bash
+curl -X PUT "http://127.0.0.1:8089/internal/meta/nodes/<node_id>/isolation"
+```
+
+成功时返回类似：
+
+```json
+{
+  "ret": {
+    "RetCode": 200,
+    "RetMsg": "Success"
+  },
+  "data": {
+    "node_id": "node-1",
+    "host_ip": "10.0.0.1",
+    "healthy": true,
+    "scheduling_disabled": true,
+    "labels": {
+      "cube.cloud.tencentcloud.com/scheduling-disabled": "true"
+    }
+  }
+}
+```
+
+接口**幂等**：对已隔离节点重复 `PUT` 是安全的。无需请求体。
+
+### 方式二：cubemastercli
+
+```bash
+# 隔离单个节点
+cubemastercli --address 127.0.0.1 --port 8089 node isolate <node_id>
+
+# 一次隔离多个节点
+cubemastercli --address 127.0.0.1 --port 8089 node isolate <node_id_1> <node_id_2>
+
+# 需要原始 JSON 时
+cubemastercli --address 127.0.0.1 --port 8089 node isolate --json <node_id>
+```
+
+成功时 CLI 会打印类似：
+
+```text
+node node-1 isolated: scheduling_disabled=true
+```
+
+## 确认隔离生效
+
+再次查询节点，确认 `scheduling_disabled` 为 `true`：
+
+```bash
+curl -s http://127.0.0.1:8089/internal/meta/nodes/<node_id> | jq '.scheduling_disabled'
+# 期望输出: true
+
+cubemastercli --address 127.0.0.1 --port 8089 node list
+# SCHEDULING_DISABLED 列应为 true
+```
+
+::: tip 建议等待窗口
+隔离后建议再等待 **≥ 60 秒**，让进行中的调度 / 创建窗口结束，再对该节点做破坏性维护（重启、升级、下线等）。
+:::
+
+## 取消隔离
+
+维护完成后，取消隔离，节点即可重新接收新沙箱：
+
+```bash
+# HTTP
+curl -X DELETE "http://127.0.0.1:8089/internal/meta/nodes/<node_id>/isolation"
+
+# CLI
+cubemastercli --address 127.0.0.1 --port 8089 node unisolate <node_id>
+```
+
+成功后 `scheduling_disabled` 应为 `false`，且 labels 中不再包含 `scheduling-disabled`。
+
+## 典型场景
+
+### 节点维护 / 重启前
+
+1. 隔离目标节点
+2. 等待 ≥ 60 秒
+3. （按需要）销毁该节点上的存量沙箱
+4. 执行维护或重启
+5. 节点恢复并重新注册后，取消隔离
+
+### K8s 计算面升级（会 recreate Big Pod）
+
+计算面升级会中断该节点上的存量沙箱网络。推荐顺序：
+
+1. 调用 isolate API 隔离节点
+2. 等待 ≥ 60 秒
+3. **销毁**该节点上的沙箱
+4. 再执行升级
+
+完整步骤见 [K8s 升级指南](./kubernetes/upgrade.md)。
+
+## 范围与限制
+
+- **不是 drain**：不会自动迁移或销毁已有沙箱。
+- **单节点 / 全部隔离**：若集群中没有其它可调度节点，新沙箱创建会失败（调度选不到节点）。
+- **与健康检查正交**：隔离节点仍可保持 Healthy，仍会出现在健康节点列表中，只是不进入可调度集合。
+- **与 Kubernetes `kubectl cordon` 无关**：本能力只影响 CubeMaster 调度，不会自动对 K8s Node 执行 cordon。
+- **鉴权**：CubeMaster 默认关闭 HTTP 鉴权时可直接调用。若你开启了 CubeMaster 鉴权，需按集群配置补齐签名头；当前 `cubemastercli node isolate/unisolate` **不会**自动附加签名，鉴权开启时请优先使用带签的 HTTP 请求。
+
+## 相关文档
+
+- [服务管理与日志](./service-management.md) — 控制面 / 计算面服务启停与日志
+- [K8s 升级](./kubernetes/upgrade.md) — 升级前隔离节点并清空沙箱
+- [多机部署](./multi-node-deploy.md) — 节点注册与 `/internal/meta/nodes` 验收


### PR DESCRIPTION
Add comprehensive node isolation documentation in both English and Chinese:

- New page: Node Isolation guide covering isolate/unisolate operations via CubeMaster HTTP API and `cubemastercli`
- New page: Chinese translation (`zh/guide/node-isolation.md`)
- Update VitePress sidebar config to include the new pages in both language sections
- Add cross-reference links from the Kubernetes upgrade guide to the node isolation docs