### PR TITLE
fix(sdk): defer clone snapshot cleanup until last sandbox kill

### DIFF
--- a/sdk/go/aligned_test.go
+++ b/sdk/go/aligned_test.go
@@ -12,6 +12,8 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -219,25 +221,82 @@ func TestSnapshotLifecycle(t *testing.T) {
 	}
 }
 
+func TestCloneDeletesSnapshotAfterLastCloneIsKilled(t *testing.T) {
+	var created atomic.Int32
+	var snapshotDeletes atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/snapshots"):
+			fmt.Fprint(w, `{"snapshotID":"snap-clone"}`)
+		case r.Method == http.MethodPost && r.URL.Path == "/sandboxes":
+			id := created.Add(1)
+			w.WriteHeader(http.StatusCreated)
+			fmt.Fprint(w, sandboxJSON(fmt.Sprintf("clone-%d", id), "snap-clone"))
+		case r.Method == http.MethodDelete && strings.HasPrefix(r.URL.Path, "/sandboxes/"):
+			w.WriteHeader(http.StatusNoContent)
+		case r.Method == http.MethodDelete && r.URL.Path == "/templates/snap-clone":
+			snapshotDeletes.Add(1)
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			t.Fatalf("unexpected %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	client := NewClient(Config{APIURL: server.URL, Timeout: 300 * time.Second})
+	source := &Sandbox{client: client, SandboxID: testSandboxID}
+	clones, err := source.Clone(context.Background(), CloneOptions{N: 2})
+	if err != nil {
+		t.Fatalf("Clone: %v", err)
+	}
+	if snapshotDeletes.Load() != 0 {
+		t.Fatalf("snapshot deleted before clones were killed")
+	}
+	var wg sync.WaitGroup
+	errs := make(chan error, len(clones))
+	for _, clone := range clones {
+		wg.Add(1)
+		go func(clone *Sandbox) {
+			defer wg.Done()
+			errs <- clone.Kill(context.Background())
+		}(clone)
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		if err != nil {
+			t.Fatalf("kill clone: %v", err)
+		}
+	}
+	if err := clones[1].Kill(context.Background()); err != nil {
+		t.Fatalf("repeat kill last clone: %v", err)
+	}
+	if got := snapshotDeletes.Load(); got != 1 {
+		t.Fatalf("snapshotDeletes=%d, want 1", got)
+	}
+}
+
 func TestCloneKillsSiblingsOnFailure(t *testing.T) {
-	var created, killed int
+	var created, killed, snapshotDeletes atomic.Int32
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		switch {
 		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/snapshots"):
 			fmt.Fprint(w, `{"snapshotID":"snap-1"}`)
 		case r.Method == http.MethodPost && r.URL.Path == "/sandboxes":
-			created++
-			if created == 2 { // fail the second clone
+			id := created.Add(1)
+			if id == 2 { // fail the second clone
 				http.Error(w, `{"message":"boom"}`, http.StatusInternalServerError)
 				return
 			}
 			w.WriteHeader(http.StatusCreated)
-			fmt.Fprint(w, sandboxJSON(fmt.Sprintf("clone-%d", created), "snap-1"))
+			fmt.Fprint(w, sandboxJSON(fmt.Sprintf("clone-%d", id), "snap-1"))
 		case r.Method == http.MethodDelete && strings.HasPrefix(r.URL.Path, "/sandboxes/"):
-			killed++
-			w.WriteHeader(http.StatusNoContent)
+			killed.Add(1)
+			http.Error(w, `{"message":"transient kill failure"}`, http.StatusInternalServerError)
 		case r.Method == http.MethodDelete && r.URL.Path == "/templates/snap-1":
+			snapshotDeletes.Add(1)
 			w.WriteHeader(http.StatusNoContent)
 		default:
 			t.Fatalf("unexpected %s %s", r.Method, r.URL.Path)
@@ -250,8 +309,11 @@ func TestCloneKillsSiblingsOnFailure(t *testing.T) {
 	if _, err := sb.Clone(context.Background(), CloneOptions{N: 2}); err == nil {
 		t.Fatal("Clone with a failing create returned nil error")
 	}
-	if killed != 1 {
-		t.Fatalf("killed=%d, want 1 surviving sibling cleaned up", killed)
+	if got := killed.Load(); got != 1 {
+		t.Fatalf("killed=%d, want 1 surviving sibling cleanup attempted", got)
+	}
+	if got := snapshotDeletes.Load(); got != 1 {
+		t.Fatalf("snapshotDeletes=%d, want 1 after sibling kill failure", got)
 	}
 }
 

--- a/sdk/go/models.go
+++ b/sdk/go/models.go
@@ -7,7 +7,8 @@ import "time"
 
 // Sandbox is a connected CubeSandbox instance returned by create/connect.
 type Sandbox struct {
-	client *Client `json:"-"`
+	client       *Client       `json:"-"`
+	cloneCleanup *cloneCleanup `json:"-"`
 
 	TemplateID         string `json:"templateID"`
 	SandboxID          string `json:"sandboxID"`

--- a/sdk/go/sandbox.go
+++ b/sdk/go/sandbox.go
@@ -140,7 +140,13 @@ func (s *Sandbox) Kill(ctx context.Context) error {
 	}
 
 	path := "/sandboxes/" + url.PathEscape(s.SandboxID)
-	return s.client.doJSON(ctx, http.MethodDelete, path, nil, nil, http.StatusOK, http.StatusNoContent)
+	if err := s.client.doJSON(ctx, http.MethodDelete, path, nil, nil, http.StatusOK, http.StatusNoContent); err != nil {
+		return err
+	}
+	if s.cloneCleanup != nil {
+		s.cloneCleanup.release(ctx, s.SandboxID)
+	}
+	return nil
 }
 
 // Close releases idle HTTP connections used by this sandbox's client. It does

--- a/sdk/go/snapshot.go
+++ b/sdk/go/snapshot.go
@@ -35,6 +35,53 @@ type CloneOptions struct {
 	Concurrency int
 }
 
+type cloneCleanup struct {
+	mu             sync.Mutex
+	client         *Client
+	snapshotID     string
+	remaining      int
+	released       map[string]struct{}
+	cleanupStarted bool
+}
+
+func (c *cloneCleanup) release(ctx context.Context, sandboxID string) {
+	if c == nil {
+		return
+	}
+	c.mu.Lock()
+	if _, ok := c.released[sandboxID]; ok {
+		c.mu.Unlock()
+		return
+	}
+	c.released[sandboxID] = struct{}{}
+	c.remaining--
+	shouldCleanup := c.startCleanupLocked(c.remaining == 0)
+	c.mu.Unlock()
+	if shouldCleanup {
+		_ = c.client.DeleteSnapshot(context.WithoutCancel(ctx), c.snapshotID)
+	}
+}
+
+func (c *cloneCleanup) cleanup(ctx context.Context) {
+	if c == nil {
+		return
+	}
+	c.mu.Lock()
+	shouldCleanup := c.startCleanupLocked(true)
+	c.mu.Unlock()
+	if shouldCleanup {
+		_ = c.client.DeleteSnapshot(context.WithoutCancel(ctx), c.snapshotID)
+	}
+}
+
+func (c *cloneCleanup) startCleanupLocked(ready bool) bool {
+	if !ready || c.cleanupStarted {
+		return false
+	}
+	c.cleanupStarted = true
+	return true
+}
+
 // CreateSnapshot captures the current sandbox state (POST
 // /sandboxes/:id/snapshots). The snapshot outlives the sandbox. An empty name
 // lets the server pick one; a known name attaches a new build to it.
@@ -121,10 +168,10 @@ func (s *Sandbox) Rollback(ctx context.Context, snapshotID string) (map[string]a
 	return result, nil
 }
 
-// Clone snapshots this sandbox and spins up opts.N fresh sandboxes from it,
-// then deletes the ephemeral snapshot (best-effort). On any create failure all
-// successful siblings are killed and the first error is returned, so a partial
-// fan-out never leaks sandboxes.
+// Clone snapshots this sandbox and spins up opts.N fresh sandboxes from it.
+// The temporary snapshot is deleted after the last clone is killed through
+// this SDK process. On any create failure all successful siblings are killed
+// and the first error is returned, so a partial fan-out never leaks sandboxes.
 func (s *Sandbox) Clone(ctx context.Context, opts CloneOptions) ([]*Sandbox, error) {
 	if err := s.ensureClient(); err != nil {
 		return nil, err
@@ -142,10 +189,6 @@ func (s *Sandbox) Clone(ctx context.Context, opts CloneOptions) ([]*Sandbox, err
 	if err != nil {
 		return nil, err
 	}
-	// Cleanup must run even if ctx is cancelled, matching the Python SDK's
-	// unconditional best-effort delete.
-	defer func() { _ = s.client.DeleteSnapshot(context.WithoutCancel(ctx), snapshot.SnapshotID) }()
-
 	createOne := func() (*Sandbox, error) {
 		return s.client.Create(ctx, CreateOptions{TemplateID: snapshot.SnapshotID})
 	}
@@ -177,11 +220,24 @@ func (s *Sandbox) Clone(ctx context.Context, opts CloneOptions) ([]*Sandbox, err
 		}()
 	}
 	wg.Wait()
+	cleanup := &cloneCleanup{
+		client:     s.client,
+		snapshotID: snapshot.SnapshotID,
+		remaining:  len(clones),
+		released:   make(map[string]struct{}, len(clones)),
+	}
+	for _, clone := range clones {
+		clone.cloneCleanup = cleanup
+	}
 
 	if firstErr != nil {
 		for _, clone := range clones {
 			_ = clone.Kill(context.WithoutCancel(ctx))
 		}
+		// A failed Kill does not release its clone ownership. Force the
+		// best-effort snapshot cleanup after all surviving siblings have been
+		// handled so a transient teardown failure cannot leak the snapshot.
+		cleanup.cleanup(context.WithoutCancel(ctx))
 		return nil, firstErr
 	}
 	return clones, nil

--- a/sdk/node/src/sandbox.ts
+++ b/sdk/node/src/sandbox.ts
@@ -183,6 +183,35 @@ function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+class CloneCleanup {
+  private readonly released = new Set<string>();
+  private cleanupStarted = false;
+
+  constructor(
+    private readonly snapshotId: string,
+    private remaining: number,
+    private readonly config: Config,
+  ) {}
+
+  async release(sandboxId: string): Promise<void> {
+    if (this.released.has(sandboxId)) return;
+    this.released.add(sandboxId);
+    this.remaining -= 1;
+    if (this.remaining !== 0) return;
+    await this.cleanup();
+  }
+
+  async cleanup(): Promise<void> {
+    if (this.cleanupStarted) return;
+    this.cleanupStarted = true;
+    try {
+      await Sandbox.deleteSnapshot(this.snapshotId, { config: this.config });
+    } catch {
+      // best-effort snapshot cleanup
+    }
+  }
+}
+
 /**
  * Resolve the effective {@link Config} for {@link Sandbox.create}, merging the
  * inline config overrides on {@link CreateOptions} over ``options.config`` over
@@ -235,6 +264,7 @@ export class Sandbox {
   private readonly _commands: Commands;
   private readonly _files: Filesystem;
   private readonly _pty: Pty;
+  private _cloneCleanup: CloneCleanup | undefined;
 
   constructor(data: Record<string, any>, config: Config) {
     this._data = data;
@@ -555,6 +585,7 @@ export class Sandbox {
       method: "DELETE",
     });
     await checkControlResponse(resp);
+    await this._cloneCleanup?.release(this.sandboxId);
   }
 
   /** POST /sandboxes/:id/snapshots — create a snapshot. */
@@ -588,7 +619,8 @@ export class Sandbox {
   }
 
   /**
-   * Clone this sandbox ``n`` times: snapshot -> create ×n -> delete snapshot.
+   * Clone this sandbox ``n`` times. The temporary snapshot is deleted after
+   * the last clone is killed through this SDK process.
    *
    * ``concurrency`` caps how many ``Sandbox.create`` calls run in parallel at
    * ``min(n, concurrency)`` (default 1 = sequential), mirroring the Python
@@ -606,17 +638,16 @@ export class Sandbox {
     const sandboxes: Sandbox[] = [];
     let firstError: unknown = null;
 
-    try {
-      if (concurrency <= 1 || n <= 1) {
-        for (let i = 0; i < n; i++) {
-          try {
-            sandboxes.push(await createOne());
-          } catch (err) {
-            firstError = err;
-            break;
-          }
+    if (concurrency <= 1 || n <= 1) {
+      for (let i = 0; i < n; i++) {
+        try {
+          sandboxes.push(await createOne());
+        } catch (err) {
+          firstError = err;
+          break;
         }
-      } else {
+      }
+    } else {
         // Bounded fan-out: at most min(n, concurrency) create calls are in
         // flight at once (workers pull from a shared cursor), matching the
         // Python (ThreadPoolExecutor) and Go (semaphore) SDKs. Every task is
@@ -639,18 +670,26 @@ export class Sandbox {
           }
         };
         await Promise.all(Array.from({ length: limit }, () => worker()));
-      }
-    } finally {
-      try {
-        await Sandbox.deleteSnapshot(snapId, { config: cfg });
-      } catch {
-        // best-effort cleanup
-      }
     }
+
+    const cleanup = new CloneCleanup(snapId, sandboxes.length, cfg);
+    sandboxes.forEach((sandbox) => {
+      sandbox._cloneCleanup = cleanup;
+    });
 
     if (firstError !== null) {
       await Promise.allSettled(sandboxes.map((sb) => sb.kill()));
+      // A failed kill cannot release its ownership. Force the idempotent
+      // backstop after every surviving sibling has settled.
+      await cleanup.cleanup();
       throw firstError;
+    }
+    if (sandboxes.length === 0) {
+      try {
+        await Sandbox.deleteSnapshot(snapId, { config: cfg });
+      } catch {
+        // best-effort snapshot cleanup
+      }
     }
     return sandboxes;
   }

--- a/sdk/node/test/snapshots.test.ts
+++ b/sdk/node/test/snapshots.test.ts
@@ -210,6 +210,9 @@ describe("Sandbox.clone", () => {
         createdIds.push(id);
         return { status: 201, json: { ...SANDBOX_DATA, sandboxID: id } };
       }
+      if (req.method === "DELETE" && req.pathname.startsWith("/sandboxes/")) {
+        return { status: 204 };
+      }
       if (req.method === "DELETE" && req.pathname === "/templates/snap-clone") {
         snapshotDeleted = true;
         return { status: 204 };
@@ -219,6 +222,12 @@ describe("Sandbox.clone", () => {
 
     const clones = await sb.clone(2);
     expect(clones.map((c) => c.sandboxId)).toEqual(["sb-clone-0", "sb-clone-1"]);
+    expect(snapshotDeleted).toBe(false);
+    await clones[0].kill();
+    expect(snapshotDeleted).toBe(false);
+    await clones[1].kill();
+    expect(snapshotDeleted).toBe(true);
+    await clones[1].kill();
     expect(snapshotDeleted).toBe(true);
     clones.forEach((c) => c.close());
     sb.close();
@@ -273,7 +282,7 @@ describe("Sandbox.clone", () => {
       }
       if (req.method === "DELETE" && req.pathname.startsWith("/sandboxes/")) {
         killed.push(req.pathname);
-        return { status: 204 };
+        return { status: 500, json: { message: "transient kill failure" } };
       }
       if (req.method === "DELETE" && req.pathname === "/templates/snap-clone") {
         snapshotDeleted = true;

--- a/sdk/python/cubesandbox/sandbox.py
+++ b/sdk/python/cubesandbox/sandbox.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import threading
 from typing import Any, Callable, Dict
 
 import httpx
@@ -28,6 +29,38 @@ JUPYTER_PORT = 49999
 
 #: Never-timeout sentinel. See docs/guide/lifecycle.md.
 NEVER_TIMEOUT = -1
+
+class _CloneCleanup:
+    """Process-local ownership of one clone operation's temporary snapshot."""
+
+    def __init__(self, snapshot_id: str, remaining: int, config: Config) -> None:
+        self.snapshot_id = snapshot_id
+        self.remaining = remaining
+        self.config = config
+        self._released: set[str] = set()
+        self._cleanup_started = False
+        self._lock = threading.Lock()
+
+    def release(self, sandbox_id: str) -> None:
+        with self._lock:
+            if sandbox_id in self._released:
+                return
+            self._released.add(sandbox_id)
+            self.remaining -= 1
+            should_cleanup = self.remaining == 0
+        if should_cleanup:
+            self.cleanup()
+
+    def cleanup(self) -> None:
+        """Start best-effort deletion once, including failure backstops."""
+        with self._lock:
+            if self._cleanup_started:
+                return
+            self._cleanup_started = True
+        try:
+            Sandbox.delete_snapshot(self.snapshot_id, config=self.config)
+        except Exception:  # noqa: BLE001 — best-effort snapshot cleanup
+            return
 
 
 def _check_response(resp: requests.Response) -> None:
@@ -94,6 +127,7 @@ class Sandbox:
         self._commands = Commands(self)
         self._files = Filesystem(self)
         self._pty = Pty(self)
+        self._clone_cleanup: _CloneCleanup | None = None
 
 
     @property
@@ -504,6 +538,8 @@ class Sandbox:
         """
         resp = self._session.delete(f"{self._config.api_url}/sandboxes/{self.sandbox_id}")
         _check_response(resp)
+        if self._clone_cleanup is not None:
+            self._clone_cleanup.release(self.sandbox_id)
 
     def get_info(self) -> dict:
         """GET /sandboxes/:sandboxID - Get sandbox detail.
@@ -703,15 +739,17 @@ class Sandbox:
 
         1. :meth:`create_snapshot` — capture the current state.
         2. :func:`Sandbox.create` × n — spin up *n* sandboxes from the snapshot.
-        3. :meth:`delete_snapshot` — clean up the ephemeral snapshot.
+        3. Attach shared cleanup state to the clones. The temporary snapshot
+           is deleted after the last clone is killed through this SDK process.
 
         If any sandbox creation fails, **all sibling sandboxes that did
         succeed are killed** before the exception propagates. This prevents
         leaked sandboxes when a partial failure happens halfway through a
         concurrent fan-out — the alternative (returning a partial list and
         raising) loses one or the other in any caller that doesn't carefully
-        wrap the call in try/except. ``delete_snapshot`` for the ephemeral
-        snapshot is still best-effort and runs unconditionally.
+        wrap the call in try/except. Snapshot cleanup is best-effort and is
+        process-local; server-side timeout or deletion by another process is
+        not observable by this SDK instance.
 
         Args:
             n: Number of clones to create (default: 1).
@@ -745,55 +783,59 @@ class Sandbox:
 
         sandboxes: list[Sandbox] = []
         first_error: BaseException | None = None
-        try:
-            if concurrency <= 1 or n <= 1:
-                # Sequential: short-circuit on first failure to preserve the
-                # historical fail-fast behaviour. Anything created before the
-                # failure stays in ``sandboxes`` and is returned via finally.
-                for _ in range(n):
-                    try:
-                        sandboxes.append(_create_one())
-                    except BaseException as exc:  # noqa: BLE001
-                        first_error = exc
-                        break
-            else:
-                # Local import: keeps the default (sequential) path free of
-                # threading machinery for callers that never opt-in.
-                from concurrent.futures import ThreadPoolExecutor, as_completed
+        if concurrency <= 1 or n <= 1:
+            # Sequential: short-circuit on first failure to preserve the
+            # historical fail-fast behaviour.
+            for _ in range(n):
+                try:
+                    sandboxes.append(_create_one())
+                except BaseException as exc:  # noqa: BLE001
+                    first_error = exc
+                    break
+        else:
+            # Local import: keeps the default (sequential) path free of
+            # threading machinery for callers that never opt-in.
+            from concurrent.futures import ThreadPoolExecutor, as_completed
 
-                workers = min(n, concurrency)
-                with ThreadPoolExecutor(max_workers=workers) as pool:
-                    futures = [pool.submit(_create_one) for _ in range(n)]
-                    # Drain every future — never leak a Sandbox just because
-                    # an earlier sibling raised. We collect successes and the
-                    # first exception, then decide what to do once all futures
-                    # have settled.
-                    for fut in as_completed(futures):
-                        try:
-                            sandboxes.append(fut.result())
-                        except BaseException as exc:  # noqa: BLE001
-                            if first_error is None:
-                                first_error = exc
-                            # Keep draining: another in-flight create may
-                            # still succeed and we must not drop its result.
-        finally:
-            try:
-                Sandbox.delete_snapshot(snap_id, config=cfg)
-            except Exception:  # noqa: BLE001 — best-effort cleanup
-                pass
+            workers = min(n, concurrency)
+            with ThreadPoolExecutor(max_workers=workers) as pool:
+                futures = [pool.submit(_create_one) for _ in range(n)]
+                # Drain every future — never leak a Sandbox just because
+                # an earlier sibling raised. We collect successes and the
+                # first exception, then decide what to do once all futures
+                # have settled.
+                for fut in as_completed(futures):
+                    try:
+                        sandboxes.append(fut.result())
+                    except BaseException as exc:  # noqa: BLE001
+                        if first_error is None:
+                            first_error = exc
+                        # Keep draining: another in-flight create may
+                        # still succeed and we must not drop its result.
+        cleanup = _CloneCleanup(snap_id, len(sandboxes), cfg)
+        for sb in sandboxes:
+            sb._clone_cleanup = cleanup
 
         if first_error is not None:
             # We hit at least one failure. The caller asked for *n* clones
             # and got fewer — there is no clean way to return both partial
             # successes and an exception, so kill the orphans and propagate.
-            # This is "all-or-nothing" semantics for the failure case;
-            # without it, a partial result is silently lost when we raise.
+            # This is "all-or-nothing" semantics for the failure case.
             for sb in sandboxes:
                 try:
                     sb.kill()
                 except Exception:  # noqa: BLE001 — best-effort cleanup
                     pass
+            # A failed kill cannot release its ownership. Force the idempotent
+            # backstop after every surviving sibling has been attempted.
+            cleanup.cleanup()
             raise first_error
+
+        if not sandboxes:
+            try:
+                Sandbox.delete_snapshot(snap_id, config=cfg)
+            except Exception:  # noqa: BLE001 — best-effort cleanup
+                pass
         return sandboxes
 
 

--- a/sdk/python/tests/test_sandbox.py
+++ b/sdk/python/tests/test_sandbox.py
@@ -1890,9 +1890,14 @@ class TestClone:
         stack, _snap, create_p, delete_p = self._patch_clone_internals()
         with stack:
             result = sb.clone()
-        assert len(result) == 1
-        assert create_p.call_count == 1
-        delete_p.assert_called_once()
+            assert len(result) == 1
+            assert create_p.call_count == 1
+            delete_p.assert_not_called()
+
+            response = MagicMock(ok=True)
+            with patch.object(result[0]._session, "delete", return_value=response):
+                result[0].kill()
+            delete_p.assert_called_once_with("snap-test", config=sb._config)
 
     def test_clone_n_sequential(self):
         sb = make_sandbox()
@@ -1922,14 +1927,52 @@ class TestClone:
         for call in create_p.call_args_list:
             assert call.kwargs["template"] == "snap-xyz"
 
-    def test_clone_deletes_snapshot_on_success(self):
+    def test_clone_deletes_snapshot_after_last_clone_is_killed(self):
         sb = make_sandbox()
         stack, _snap, _create, delete_p = self._patch_clone_internals(
             snapshot_id="snap-to-clean"
         )
         with stack:
-            sb.clone(n=3)
-        delete_p.assert_called_once_with("snap-to-clean", config=sb._config)
+            clones = sb.clone(n=3)
+            delete_p.assert_not_called()
+            response = MagicMock(ok=True)
+            for clone in clones:
+                with patch.object(clone._session, "delete", return_value=response):
+                    clone.kill()
+            delete_p.assert_called_once_with("snap-to-clean", config=sb._config)
+
+    def test_clone_cleanup_is_idempotent_for_repeated_kill(self):
+        sb = make_sandbox()
+        stack, _snap, _create, delete_p = self._patch_clone_internals()
+        with stack:
+            clone = sb.clone()[0]
+            response = MagicMock(ok=True)
+            with patch.object(clone._session, "delete", return_value=response):
+                clone.kill()
+                clone.kill()
+            delete_p.assert_called_once()
+
+    def test_clone_cleanup_is_thread_safe(self):
+        from concurrent.futures import ThreadPoolExecutor
+
+        sb = make_sandbox()
+        stack, _snap, _create, delete_p = self._patch_clone_internals()
+        with stack:
+            clones = sb.clone(n=8)
+            response = MagicMock(ok=True)
+            patches = [
+                patch.object(clone._session, "delete", return_value=response)
+                for clone in clones
+            ]
+            for session_patch in patches:
+                session_patch.start()
+            try:
+                with ThreadPoolExecutor(max_workers=8) as pool:
+                    list(pool.map(lambda clone: clone.kill(), clones))
+            finally:
+                for session_patch in patches:
+                    session_patch.stop()
+            delete_p.assert_called_once()
 
     def test_clone_deletes_snapshot_even_on_error(self):
         """If a Sandbox.create call raises, the ephemeral snapshot is still
@@ -1952,8 +1995,12 @@ class TestClone:
         stack, _snap, _create, delete_p = self._patch_clone_internals()
         delete_p.side_effect = ApiError("snapshot delete failed")
         with stack:
-            result = sb.clone(n=2)  # should not raise
-        assert len(result) == 2
+            result = sb.clone(n=2)
+            response = MagicMock(ok=True)
+            for clone in result:
+                with patch.object(clone._session, "delete", return_value=response):
+                    clone.kill()  # should not raise
+            assert len(result) == 2
 
     # ─── concurrent ──────────────────────────────────────────────────────────
 
@@ -2019,8 +2066,9 @@ class TestClone:
             with pytest.raises(ApiError, match="create failed"):
                 sb.clone(n=5, concurrency=3)
 
-        # Snapshot got cleaned up exactly once.
-        delete_p.assert_called_once()
+        # kill() is mocked and therefore cannot release clone ownership. The
+        # error-path backstop must still delete the temporary snapshot.
+        delete_p.assert_called_once_with("snap-partial", config=sb._config)
         # Every sandbox that ``Sandbox.create`` actually returned must have
         # been killed by clone() before it raised. We assert the count
         # matches what _flaky produced — n=5 with the 3rd raising means 4


### PR DESCRIPTION
Ref issue https://github.com/TencentCloud/CubeSandbox/issues/820

The previous `clone()` function would delete the temporary snapshot immediately after creating the cloned sandbox. Since the sandbox still held a reference to the snapshot at that time, the deletion would fail, resulting in leftover snapshot templates.

The solution involves maintaining a shared reference counter for the cloned sandboxes. This counter decrements whenever a cloned sandbox is destroyed; the snapshot is deleted only when all cloned sandboxes have been destroyed and the counter reaches zero.

This commit updates the implementations for the Python, Go, and Node SDKs to incorporate this shared reference counter mechanism. The cleanup process is both thread-safe and idempotent, ensuring that repeated or concurrent calls to `kill()` do not result in multiple attempts to delete the snapshot.