### PR TITLE
feat(volume): support read-only volume attachments

### DIFF
--- a/CubeAPI/src/models/mod.rs
+++ b/CubeAPI/src/models/mod.rs
@@ -156,6 +156,14 @@ impl Default for SandboxOnTimeout {
 pub struct SandboxVolumeMount {
     pub name: String,
     pub path: String,
+    /// CubeSandbox extension: mount this volume read-only for this sandbox
+    /// attachment. Defaults to false when omitted.
+    #[serde(rename = "readOnly", default, skip_serializing_if = "is_false")]
+    pub read_only: bool,
+}
+
+fn is_false(value: &bool) -> bool {
+    !*value
 }
 
 // ─── Sandbox — create request ──────────────────────────────────────────────
@@ -604,6 +612,36 @@ mod tests {
                 .and_then(|envs| envs.get("CUBE_TEST_ENV"))
                 .map(String::as_str),
             Some("value")
+        );
+    }
+
+    #[test]
+    fn new_sandbox_volume_mount_read_only_is_optional() {
+        let req: NewSandbox = serde_json::from_value(serde_json::json!({
+            "templateID": "tpl-1",
+            "volumeMounts": [
+                {"name": "dataset", "path": "/data", "readOnly": true},
+                {"name": "workspace", "path": "/workspace"},
+                {"name": "cache", "path": "/cache", "readOnly": false}
+            ]
+        }))
+        .expect("volume mounts should deserialize");
+
+        let mounts = req.volume_mounts.expect("volume mounts");
+        assert!(mounts[0].read_only);
+        assert!(!mounts[1].read_only);
+        assert!(!mounts[2].read_only);
+        assert_eq!(
+            serde_json::to_value(&mounts[0]).expect("serialize read-only mount"),
+            serde_json::json!({"name": "dataset", "path": "/data", "readOnly": true})
+        );
+        assert_eq!(
+            serde_json::to_value(&mounts[1]).expect("serialize read-write mount"),
+            serde_json::json!({"name": "workspace", "path": "/workspace"})
+        );
+        assert_eq!(
+            serde_json::to_value(&mounts[2]).expect("serialize explicit read-write mount"),
+            serde_json::json!({"name": "cache", "path": "/cache"})
         );
     }
 

--- a/CubeAPI/src/services/sandboxes.rs
+++ b/CubeAPI/src/services/sandboxes.rs
@@ -229,12 +229,15 @@ impl SandboxService {
                 struct MountEntry<'a> {
                     name: &'a str,
                     container_path: &'a str,
+                    #[serde(skip_serializing_if = "Option::is_none")]
+                    readonly: Option<bool>,
                 }
                 let entries: Vec<MountEntry> = mounts
                     .iter()
                     .map(|m| MountEntry {
                         name: &m.name,
                         container_path: &m.path,
+                        readonly: m.read_only.then_some(true),
                     })
                     .collect();
                 if let Ok(json) = serde_json::to_string(&entries) {
@@ -1074,7 +1077,7 @@ mod tests {
     use crate::error::AppError;
     use crate::models::{
         EgressRule, EgressRuleAction, EgressRuleInject, EgressRuleMatch, NewSandbox,
-        SandboxNetworkConfig, SandboxState,
+        SandboxNetworkConfig, SandboxState, SandboxVolumeMount,
     };
     use axum::{
         extract::State,
@@ -1738,6 +1741,90 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn create_sandbox_forwards_read_only_volume_mount_to_cubemaster() {
+        #[derive(Clone, Default)]
+        struct Capture {
+            create_body: Arc<Mutex<Option<Value>>>,
+        }
+
+        async fn create_handler(
+            State(capture): State<Capture>,
+            Json(body): Json<Value>,
+        ) -> Json<Value> {
+            *capture.create_body.lock().await = Some(body);
+            Json(serde_json::json!({
+                "requestID": "req-volume",
+                "sandbox_id": "sb-volume",
+                "ret": { "ret_code": 0, "ret_msg": "ok" }
+            }))
+        }
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("listener should bind");
+        let addr = listener.local_addr().expect("listener addr");
+        let capture = Capture::default();
+        let app = Router::new()
+            .route("/cube/sandbox", post(create_handler))
+            .with_state(capture.clone());
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.expect("server should run");
+        });
+
+        let service = SandboxService::new(
+            CubeMasterClient::new(format!("http://{addr}"), reqwest::Client::new()),
+            "cubebox".to_string(),
+            "cube.app".to_string(),
+        );
+
+        service
+            .create_sandbox(NewSandbox {
+                template_id: "tpl-1".to_string(),
+                timeout: Some(15),
+                lifecycle: None,
+                secure: None,
+                allow_internet_access: None,
+                network: None,
+                metadata: None,
+                distribution_scope: None,
+                env_vars: None,
+                mcp: None,
+                volume_mounts: Some(vec![
+                    SandboxVolumeMount {
+                        name: "dataset".to_string(),
+                        path: "/data".to_string(),
+                        read_only: true,
+                    },
+                    SandboxVolumeMount {
+                        name: "workspace".to_string(),
+                        path: "/workspace".to_string(),
+                        read_only: false,
+                    },
+                ]),
+            })
+            .await
+            .expect("sandbox create should succeed");
+
+        let create_body = capture
+            .create_body
+            .lock()
+            .await
+            .clone()
+            .expect("create body");
+        let raw = create_body["annotations"]["plugin-volume-mounts"]
+            .as_str()
+            .expect("plugin volume mounts annotation");
+        let mounts: Value = serde_json::from_str(raw).expect("annotation JSON");
+        assert_eq!(
+            mounts,
+            serde_json::json!([
+                {"name": "dataset", "container_path": "/data", "readonly": true},
+                {"name": "workspace", "container_path": "/workspace"}
+            ])
+        );
+    }
+
+    #[tokio::test]
     async fn kill_sandbox_maps_cubemaster_not_found_to_app_not_found() {
         async fn delete_handler() -> Json<Value> {
             Json(serde_json::json!({
@@ -2005,10 +2092,12 @@ mod tests {
             SandboxVolumeMount {
                 name: "data".to_string(),
                 path: "/mnt/a".to_string(),
+                read_only: false,
             },
             SandboxVolumeMount {
                 name: "data".to_string(),
                 path: "/mnt/b".to_string(),
+                read_only: false,
             },
         ];
         let err = super::validate_unique_volume_mount_names(&mounts)
@@ -2022,10 +2111,12 @@ mod tests {
             SandboxVolumeMount {
                 name: "data".to_string(),
                 path: "/mnt/a".to_string(),
+                read_only: false,
             },
             SandboxVolumeMount {
                 name: "logs".to_string(),
                 path: "/mnt/b".to_string(),
+                read_only: false,
             },
         ];
         super::validate_unique_volume_mount_names(&ok)
@@ -2046,28 +2137,36 @@ mod tests {
             SandboxVolumeMount {
                 name: "data".to_string(),
                 path: "/mnt/data".to_string(),
+                read_only: true,
             },
             SandboxVolumeMount {
                 name: "logs".to_string(),
                 path: "/mnt/logs".to_string(),
+                read_only: false,
             },
         ];
 
         let (specs, bindings): (Vec<VolumeSpec>, Vec<VolumeMount>) = mounts
             .into_iter()
-            .map(|SandboxVolumeMount { name, path }| {
-                (
-                    VolumeSpec {
-                        name: Some(name.clone()),
-                        volume_source: None,
-                    },
-                    VolumeMount {
-                        name,
-                        container_path: path,
-                        readonly: None,
-                    },
-                )
-            })
+            .map(
+                |SandboxVolumeMount {
+                     name,
+                     path,
+                     read_only,
+                 }| {
+                    (
+                        VolumeSpec {
+                            name: Some(name.clone()),
+                            volume_source: None,
+                        },
+                        VolumeMount {
+                            name,
+                            container_path: path,
+                            readonly: read_only.then_some(true),
+                        },
+                    )
+                },
+            )
             .unzip();
 
         assert_eq!(specs.len(), 2);
@@ -2076,8 +2175,10 @@ mod tests {
 
         assert_eq!(bindings[0].name, "data");
         assert_eq!(bindings[0].container_path, "/mnt/data");
+        assert_eq!(bindings[0].readonly, Some(true));
         assert_eq!(bindings[1].name, "logs");
         assert_eq!(bindings[1].container_path, "/mnt/logs");
+        assert_eq!(bindings[1].readonly, None);
     }
 
     /// When no `volumeMounts` are provided, `volumes` and `containers` in the

--- a/CubeMaster/pkg/service/sandbox/hostdir_mount_test.go
+++ b/CubeMaster/pkg/service/sandbox/hostdir_mount_test.go
@@ -129,6 +129,61 @@ func TestInjectHostDirMounts_MalformedJSON(t *testing.T) {
 	}
 }
 
+func TestInjectPluginVolumeMounts_Readonly(t *testing.T) {
+	tests := []struct {
+		name         string
+		annotation   string
+		wantReadonly bool
+	}{
+		{
+			name:         "readonly forwarded",
+			annotation:   `[{"name":"dataset-volume","container_path":"/dataset","readonly":true}]`,
+			wantReadonly: true,
+		},
+		{
+			name:         "readonly omitted defaults to false",
+			annotation:   `[{"name":"workspace-volume","container_path":"/workspace"}]`,
+			wantReadonly: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := &types.CreateCubeSandboxReq{
+				Annotations: map[string]string{
+					AnnotationPluginVolumeMounts: tt.annotation,
+				},
+				Containers: []*types.Container{{Name: "main"}, {Name: "sidecar"}},
+			}
+
+			if err := injectPluginVolumeMounts(context.Background(), req); err != nil {
+				t.Fatalf("injectPluginVolumeMounts() error = %v", err)
+			}
+			for _, container := range req.Containers {
+				if got := len(container.VolumeMounts); got != 1 {
+					t.Fatalf("container %q len(VolumeMounts) = %d, want 1", container.Name, got)
+				}
+				if got := container.VolumeMounts[0].Readonly; got != tt.wantReadonly {
+					t.Errorf("container %q VolumeMounts[0].Readonly = %v, want %v", container.Name, got, tt.wantReadonly)
+				}
+			}
+		})
+	}
+}
+
+func TestInjectPluginVolumeMounts_InvalidReadonlyType(t *testing.T) {
+	req := &types.CreateCubeSandboxReq{
+		Annotations: map[string]string{
+			AnnotationPluginVolumeMounts: `[{"name":"dataset","container_path":"/dataset","readonly":"true"}]`,
+		},
+		Containers: []*types.Container{{Name: "main"}},
+	}
+
+	if err := injectPluginVolumeMounts(context.Background(), req); err == nil {
+		t.Fatal("injectPluginVolumeMounts() error = nil, want invalid readonly type error")
+	}
+}
+
 func TestValidateHostPath(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/docs/guide/volume-plugin.md
+++ b/docs/guide/volume-plugin.md
@@ -17,6 +17,7 @@ CubeSandbox is gradually adopting e2b Volume compatibility to provide persistent
 > | SDK `Volume.create` / `connect` / `list` / `get_info` / `destroy` | ✅ Supported (SDK ≥ 0.6.0) |
 > | SDK `Sandbox.create(volume_mounts={path: volume})` | ✅ Supported (e2b dict mapping) |
 > | One volume mounted by multiple sandboxes | ✅ Supported |
+> | Per-sandbox read-only attachment | ✅ Cube SDK extension (`VolumeMount(..., read_only=True)`); the official e2b SDK itself has no read-only mount option |
 > | Omit `driver` on create (e2b default) | ✅ Supported |
 
 > **e2b API vs SDK**
@@ -372,6 +373,7 @@ Examples below use **Python SDK `cubesandbox` ≥ 0.6.0**. CubeAPI exposes e2b-c
 | Official e2b Python SDK | ❌ No | Hardcoded to e2b.cloud; **do not use** with CubeSandbox |
 | `cubesandbox` Python SDK | ✅ Yes | `Volume`, `Sandbox.create(volume_mounts={path: volume})` (e2b dict) |
 | Omit `driver` on create | ✅ Yes | CubeMaster uses the **first** `volume_plugins` entry |
+| Per-sandbox read-only attachment | ❌ No | The official e2b SDK itself has no read-only Volume mount option; Cube SDK adds `VolumeMount(volume, read_only=True)` |
 
 For a full COS plugin walkthrough, see [`examples/volume/cos/README.md`](https://github.com/TencentCloud/CubeSandbox/blob/master/examples/volume/cos/README.md).
 
@@ -439,9 +441,33 @@ Volume.destroy(vol.volume_id)  # returns True; False when already gone (idempote
 | `Volume.destroy(volume_id)` | e2b-compatible delete; `True` on success, `False` on 404 (idempotent) |
 | `Volume.delete(...)` | Backward-compat alias for `destroy` (prefer `destroy`) |
 | `driver` | Optional plugin name; **e2b compatible usage omits it** — SDK sends no field, CubeMaster uses the **first** entry in `volume_plugins` |
-| `volume_mounts` | e2b dict `{mount_path: Volume \| volume_id \| name}` — key is path inside sandbox, value is a `Volume` instance or volume ID string |
+| `volume_mounts` | e2b dict `{mount_path: Volume \| volume_id \| name}` — key is path inside sandbox, value is a `Volume` instance or volume ID string; Cube SDK can additionally wrap the value with `VolumeMount(..., read_only=True)` for a read-only attachment |
 
 `driver` is stored in `t_cube_volume` and forwarded to Cubelet via annotations — `volume_plugins[].name` must match on both CubeMaster and Cubelet.
+
+### Per-sandbox access mode
+
+The e2b-compatible mapping remains the default and creates a read-write attachment. CubeSandbox extends the mapping value with `VolumeMount`, allowing each sandbox to choose its own access mode for the same persistent Volume:
+
+```python
+from cubesandbox import Sandbox, Volume, VolumeMount
+
+dataset = Volume.create("shared-dataset")
+
+# This sandbox may update the Volume.
+writer = Sandbox.create(
+    volume_mounts={"/dataset": dataset},
+)
+
+# The same Volume is protected from mutations in this sandbox.
+reader = Sandbox.create(
+    volume_mounts={"/dataset": VolumeMount(dataset, read_only=True)},
+)
+```
+
+The official e2b SDK's Volume mount API has no read-only option; this is not a CubeSandbox compatibility limitation. Cube SDK and REST clients can opt into the Cube extension `volumeMounts[].readOnly: true`, while existing e2b-shaped requests omit `readOnly` and keep their original read-write behavior.
+
+Read-only is an **attachment property**, not a property of the Volume itself. The reader cannot create, modify, rename, or delete files through its mount, but it can observe changes made through another read-write attachment. It is not an immutable snapshot. A sandbox may currently attach a given Volume only once; mounting the same Volume twice in one sandbox remains rejected.
 
 ### Multiple Sandboxes Sharing One Volume
 

--- a/docs/zh/guide/volume-plugin.md
+++ b/docs/zh/guide/volume-plugin.md
@@ -17,6 +17,7 @@ CubeSandbox 正在逐步兼容 e2b Volume，为沙箱提供跨生命周期的持
 > | SDK `Volume.create` / `connect` / `list` / `get_info` / `destroy` | ✅ 已支持（SDK ≥ 0.6.0） |
 > | SDK `Sandbox.create(volume_mounts={path: volume})` | ✅ 已支持（e2b dict 映射） |
 > | 同一 Volume 被多个沙箱同时挂载 | ✅ 已支持 |
+> | 按沙箱只读挂载 | ✅ Cube SDK 扩展（`VolumeMount(..., read_only=True)`）；官方 e2b SDK 自身没有只读挂载选项 |
 > | 创建时省略 `driver`（e2b 默认行为） | ✅ 已支持 |
 
 > **e2b API 与 SDK**
@@ -370,6 +371,7 @@ sequenceDiagram
 | 官方 e2b Python SDK | ❌ 否 | 硬编码 e2b.cloud 后端；**勿**用于 CubeSandbox |
 | `cubesandbox` Python SDK | ✅ 是 | `Volume`、`Sandbox.create(volume_mounts={path: volume})`（e2b dict） |
 | 创建时省略 `driver` | ✅ 是 | CubeMaster 取 `volume_plugins` **列表第一项** |
+| 按沙箱只读挂载 | ❌ 否 | 官方 e2b SDK 自身没有只读 Volume 挂载选项；Cube SDK 增加 `VolumeMount(volume, read_only=True)` 扩展 |
 
 完整 COS 插件体验见 [`examples/volume/cos/README.zh.md`](https://github.com/TencentCloud/CubeSandbox/blob/master/examples/volume/cos/README.zh.md)。
 
@@ -437,9 +439,33 @@ Volume.destroy(vol.volume_id)  # 返回 True；卷不存在时返回 False（幂
 | `Volume.destroy(volume_id)` | e2b 兼容删除；成功返回 `True`，404 返回 `False`（幂等） |
 | `Volume.delete(...)` | `destroy` 的兼容别名（旧代码可用，推荐 `destroy`） |
 | `driver` | 可选；插件名；**e2b 兼容用法下省略**——SDK 不发送该字段，CubeMaster 取 `volume_plugins` **列表第一项** |
-| `volume_mounts` | e2b dict `{挂载路径: Volume \| volume_id \| name}` — key 为沙箱内路径，value 为 `Volume` 实例或 volume ID 字符串 |
+| `volume_mounts` | e2b dict `{挂载路径: Volume \| volume_id \| name}` — key 为沙箱内路径，value 为 `Volume` 实例或 volume ID 字符串；Cube SDK 还可将 value 包装为 `VolumeMount(..., read_only=True)` 以启用只读挂载 |
 
 `driver` 写入 `t_cube_volume`，沙箱创建时经 annotation 传给 Cubelet——CubeMaster 与 Cubelet 两侧 `volume_plugins[].name` 须与之一致。
+
+### 按沙箱选择访问模式
+
+e2b 兼容的 mapping 仍是默认写法，并创建读写挂载。CubeSandbox 在 mapping 的 value 上增加了 `VolumeMount`，因此同一个持久 Volume 可以由不同沙箱分别选择读写或只读：
+
+```python
+from cubesandbox import Sandbox, Volume, VolumeMount
+
+dataset = Volume.create("shared-dataset")
+
+# 该沙箱可以更新 Volume。
+writer = Sandbox.create(
+    volume_mounts={"/dataset": dataset},
+)
+
+# 同一个 Volume 在该沙箱中禁止修改。
+reader = Sandbox.create(
+    volume_mounts={"/dataset": VolumeMount(dataset, read_only=True)},
+)
+```
+
+官方 e2b SDK 的 Volume 挂载接口自身没有只读选项，这不是 CubeSandbox 的兼容性限制。Cube SDK 和 REST 客户端可以显式使用 Cube 扩展 `volumeMounts[].readOnly: true`，原有 e2b 形式的请求不发送 `readOnly`，继续保持读写。
+
+只读是**单次沙箱挂载属性**，不是 Volume 自身的全局属性。reader 不能通过该挂载创建、修改、重命名或删除文件，但仍可能看到其他读写挂载产生的变化，因此它不是不可变快照。当前一个沙箱内仍只能挂载同一个 Volume 一次；同一沙箱重复挂载同一个 Volume 会继续被拒绝。
 
 ### 多沙箱共用同一 Volume
 

--- a/openapi.yml
+++ b/openapi.yml
@@ -1378,6 +1378,11 @@ components:
           type: string
         path:
           type: string
+        readOnly:
+          type: boolean
+          description: |-
+            CubeSandbox extension: mount this volume read-only for this sandbox
+            attachment. Defaults to false when omitted.
     TemplateAliasLookupResponse:
       type: object
       required:

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -241,7 +241,7 @@ them into a sandbox via `Sandbox.create(volume_mounts={...})` (e2b mapping). Dat
 across sandbox restarts and can be shared between sandboxes.
 
 ```python
-from cubesandbox import Sandbox, Volume
+from cubesandbox import Sandbox, Volume, VolumeMount
 
 # Create a volume — name is optional (server generates a UUID when omitted).
 # Omitting driver is e2b-compatible: NO driver is sent, so the backend uses its
@@ -258,6 +258,11 @@ with Sandbox.create(
     print(sb.files.read("/workspace/note.txt"))
 
 # The value can be a Volume, a VolumeInfo, or a bare volume_id string.
+# Wrap a value to make only this sandbox attachment read-only. Plain values remain read-write and e2b-compatible.
+with Sandbox.create(
+    volume_mounts={"/dataset": VolumeMount(vol, read_only=True)},
+) as sb:
+    print(sb.files.read("/dataset/note.txt"))
 
 # List / get_info / connect / destroy
 for v in Volume.list():                 # list[VolumeInfo] (token always "")
@@ -266,6 +271,8 @@ Volume.get_info(vol.volume_id)          # -> VolumeInfo (with token)
 vol = Volume.connect(vol.volume_id)     # -> live Volume instance
 Volume.destroy(vol.volume_id)           # -> bool; kill any mounting sandbox first (no auto-detach)
 ```
+
+The access mode is selected per sandbox attachment. The same Volume can be read-write in one sandbox and read-only in another; existing e2b-shaped calls remain unchanged.
 
 Volume `name` must match `^[a-zA-Z0-9_-]+$` and be at most 128 characters;
 invalid names raise `ValueError` before any network call. See
@@ -356,10 +363,7 @@ with Sandbox.create(config=cfg) as sb:
 | `Volume.get_info(volume_id, *, config)` | `GET /volumes/:id` — get one volume's info (with token) → `VolumeInfo` |
 | `Volume.destroy(volume_id, *, config)` | `DELETE /volumes/:id` — delete a volume → `bool` |
 
-Mount a volume into a sandbox with `Sandbox.create(volume_mounts={path: vol})`.
-`Volume.create` / `connect` return a live `Volume` instance; `list` / `get_info`
-return `VolumeInfo`. Both expose `.volume_id`, `.name`, `.token`. Full reference:
-[`docs/volume.md`](docs/volume.md).
+Mount a volume into a sandbox with `Sandbox.create(volume_mounts={path: vol})`. Use `VolumeMount(vol, read_only=True)` for a read-only attachment; this does not turn the volume into an immutable snapshot. `Volume.create` / `connect` return a live `Volume` instance; `list` / `get_info` return `VolumeInfo`. Both expose `.volume_id`, `.name`, `.token`. Full reference: [`docs/volume.md`](docs/volume.md).
 
 ### `Execution` object
 

--- a/sdk/python/README.zh.md
+++ b/sdk/python/README.zh.md
@@ -230,7 +230,7 @@ with Sandbox.create(metadata={"host-mount": mounts}) as sb:
 也可在多个沙箱之间共享。
 
 ```python
-from cubesandbox import Sandbox, Volume
+from cubesandbox import Sandbox, Volume, VolumeMount
 
 # 创建卷 —— name 可选（省略时服务端生成 UUID）。
 # 省略 driver 即 e2b 兼容：不发送 driver，后端使用第一个已配置的插件。
@@ -247,6 +247,11 @@ with Sandbox.create(
     print(sb.files.read("/workspace/note.txt"))
 
 # 值可以是 Volume、VolumeInfo 或 volume_id 字符串。
+# 包装某个值可将本次沙箱挂载设为只读；原有写法继续保持读写且兼容 e2b。
+with Sandbox.create(
+    volume_mounts={"/dataset": VolumeMount(vol, read_only=True)},
+) as sb:
+    print(sb.files.read("/dataset/note.txt"))
 
 # 列出 / 查询信息 / 连接 / 销毁
 for v in Volume.list():                 # list[VolumeInfo]（token 恒为 ""）
@@ -255,6 +260,8 @@ Volume.get_info(vol.volume_id)          # -> VolumeInfo（含 token）
 vol = Volume.connect(vol.volume_id)     # -> 返回 Volume 实例
 Volume.destroy(vol.volume_id)           # -> bool；先杀掉所有挂载它的沙箱（不会自动 detach）
 ```
+
+访问模式按沙箱挂载设置。同一个 Volume 可以在一个沙箱中读写，在另一个沙箱中只读；原有 e2b 形式无需修改。
 
 卷的 `name` 必须匹配 `^[a-zA-Z0-9_-]+$` 且不超过 128 字符；非法名称
 会在任何网络请求之前抛出 `ValueError`。完整 API、参数和错误码请参阅
@@ -343,10 +350,7 @@ with Sandbox.create(config=cfg) as sb:
 | `Volume.get_info(volume_id, *, config)` | `GET /volumes/:id` — 查询单个卷信息（含 token）→ `VolumeInfo` |
 | `Volume.destroy(volume_id, *, config)` | `DELETE /volumes/:id` — 删除卷 → `bool` |
 
-通过 `Sandbox.create(volume_mounts={path: vol})` 将卷挂载进沙箱。
-`Volume.create` / `connect` 返回 `Volume` 实例，`list` / `get_info` 返回
-`VolumeInfo`；二者都暴露 `.volume_id`、`.name`、`.token`。完整参考：
-[`docs/volume.zh.md`](docs/volume.zh.md)。
+通过 `Sandbox.create(volume_mounts={path: vol})` 将卷挂载进沙箱。使用 `VolumeMount(vol, read_only=True)` 可将单次挂载设为只读；这不会把卷变成不可变快照。`Volume.create` / `connect` 返回 `Volume` 实例，`list` / `get_info` 返回 `VolumeInfo`；二者都暴露 `.volume_id`、`.name`、`.token`。完整参考：[`docs/volume.zh.md`](docs/volume.zh.md)。
 
 ### `Execution` 对象
 

--- a/sdk/python/cubesandbox/__init__.py
+++ b/sdk/python/cubesandbox/__init__.py
@@ -8,7 +8,7 @@ from ._exceptions import CubeSandboxError, SandboxNotFoundError, ApiError, Templ
 from ._commands import CommandResult
 from ._pty import Pty, PtyHandle, PtyOutput, PtySize
 from ._template import Template, TemplateInfo, TemplateBuild
-from ._volume import Volume, VolumeInfo
+from ._volume import Volume, VolumeInfo, VolumeMount
 from ._policy import Rule, Match, Action, Inject
 
 __all__ = [
@@ -40,6 +40,7 @@ __all__ = [
     "TemplateBuild",
     "Volume",
     "VolumeInfo",
+    "VolumeMount",
     "Rule",
     "Match",
     "Action",

--- a/sdk/python/cubesandbox/_volume.py
+++ b/sdk/python/cubesandbox/_volume.py
@@ -143,9 +143,22 @@ class VolumeInfo:
         )
 
 
-# ``Sandbox.create(volume_mounts=...)`` argument — e2b-compatible mapping:
-# ``{mount_path: Volume | VolumeInfo | volume_id_str}``.
-VolumeMountsArg = "Dict[str, Union[Volume, VolumeInfo, str]]"
+@dataclass(frozen=True)
+class VolumeMount:
+    """CubeSandbox mount options for one Volume attachment.
+
+    Plain ``Volume``, ``VolumeInfo`` and volume-ID string values remain the
+    e2b-compatible shorthand. Wrap a value only when Cube-specific attachment
+    options such as ``read_only`` are needed.
+    """
+
+    volume: "Volume | VolumeInfo | str"
+    read_only: bool = False
+
+
+# ``Sandbox.create(volume_mounts=...)`` argument — e2b-compatible mapping with
+# an optional CubeSandbox value wrapper for attachment-specific options.
+VolumeMountsArg = Dict[str, Union["Volume", VolumeInfo, str, VolumeMount]]
 
 
 def _resolve_volume_id(vol: "Volume | VolumeInfo | str") -> str:
@@ -185,12 +198,25 @@ def _validate_mount_path(path: str) -> str:
     return path
 
 
-def _serialize_volume_mounts(mounts: VolumeMountsArg) -> list[dict[str, str]]:
+def _serialize_volume_mounts(mounts: VolumeMountsArg) -> list[dict[str, object]]:
     """Serialize the e2b-style ``{path: volume}`` mapping into the wire format."""
-    return [
-        {"name": _resolve_volume_id(vol), "path": _validate_mount_path(str(path))}
-        for path, vol in mounts.items()
-    ]
+    serialized: list[dict[str, object]] = []
+    for path, value in mounts.items():
+        if isinstance(value, VolumeMount):
+            volume = value.volume
+            read_only = value.read_only
+        else:
+            volume = value
+            read_only = False
+
+        item: dict[str, object] = {
+            "name": _resolve_volume_id(volume),
+            "path": _validate_mount_path(str(path)),
+        }
+        if read_only:
+            item["readOnly"] = True
+        serialized.append(item)
+    return serialized
 
 
 class Volume:
@@ -223,6 +249,13 @@ class Volume:
         Volume.get_info(vol.volume_id)    # VolumeInfo
         vol = Volume.connect("my-data")   # Volume instance (== e2b)
         Volume.destroy(vol.volume_id)     # bool
+
+        # CubeSandbox extension: make only this attachment read-only.
+        from cubesandbox import VolumeMount
+        with Sandbox.create(
+            volume_mounts={"/dataset": VolumeMount(vol, read_only=True)},
+        ) as sb:
+            print(sb.files.read("/dataset/note.txt"))
     """
 
     def __init__(
@@ -471,5 +504,3 @@ class Volume:
             return False
         _check_response(resp)
         return True
-
-

--- a/sdk/python/cubesandbox/sandbox.py
+++ b/sdk/python/cubesandbox/sandbox.py
@@ -237,14 +237,21 @@ class Sandbox:
                 are killed).
             volume_mounts: Optional dict mapping mount paths to volumes
                 (e2b-compatible). Key is the sandbox mount path, value is a
-                :class:`~cubesandbox.Volume` instance (or a plain ``volumeID``
-                string)::
+                :class:`~cubesandbox.Volume`,
+                :class:`~cubesandbox.VolumeInfo`, or plain ``volumeID`` string.
+                Wrap any of those in :class:`~cubesandbox.VolumeMount` to set
+                Cube-specific attachment options such as ``read_only``::
 
                     Sandbox.create(volume_mounts={"/workspace": vol})
                     Sandbox.create(volume_mounts={"/workspace": "vol-123"})
+                    Sandbox.create(
+                        volume_mounts={"/dataset": VolumeMount(vol, read_only=True)}
+                    )
 
                 Each value must resolve to an existing ``volumeID`` created via
-                :meth:`cubesandbox.Volume.create`.
+                :meth:`cubesandbox.Volume.create`. ``read_only`` applies to this
+                sandbox attachment; it does not make the volume an immutable
+                snapshot.
             config: SDK config. Uses default (env-based) config if omitted.
 
         Returns:

--- a/sdk/python/docs/volume.md
+++ b/sdk/python/docs/volume.md
@@ -7,7 +7,7 @@ Create a volume, mount it into a sandbox via
 survives sandbox restarts and can be shared across sandboxes.
 
 ```python
-from cubesandbox import Sandbox, Volume
+from cubesandbox import Sandbox, Volume, VolumeMount
 ```
 
 All `Volume` methods are **class methods** — no instance needed. Mirroring
@@ -72,7 +72,7 @@ Modeled on e2b, where `Volume.create(name)` takes no driver:
 | `.name` | `str` | Display name. |
 | `.token` | `str` | Plugin-issued token. Populated on `create` / `get_info`; **empty on `list`**. |
 
-### Mounting
+### Mounting and per-sandbox access modes
 
 Pass a dict mapping mount paths to volumes (e2b-compatible):
 
@@ -81,7 +81,22 @@ Sandbox.create(volume_mounts={"/workspace": vol})
 Sandbox.create(volume_mounts={"/workspace": "vol-xxx"})
 ```
 
-Each value must resolve to an existing `volume_id`.
+Each value can be a `Volume`, `VolumeInfo`, or bare `volume_id` string and must resolve to an existing volume. Existing e2b-style values remain read-write.
+
+To make one sandbox attachment read-only, wrap its value in `VolumeMount`:
+
+```python
+from cubesandbox import Sandbox, VolumeMount
+
+Sandbox.create(
+    volume_mounts={
+        "/dataset": VolumeMount(vol, read_only=True),
+        "/workspace": workspace_vol,
+    }
+)
+```
+
+`read_only` only mounts that attachment as read-only. It prevents the current sandbox from writing or modifying files through that mount, but does not create an immutable snapshot. The same Volume can be attached with different access modes in different sandboxes, for example read-write in sandbox A and read-only in sandbox B.
 
 ---
 
@@ -195,3 +210,4 @@ except ApiError as e:
   `get_info`; call `Volume.get_info(volume_id)` when you need the token.
 - **`name` is optional.** Omit it and the server assigns a UUID that serves as
   both `volume_id` and `name`.
+- **Read-only is per attachment.** Use `VolumeMount(volume, read_only=True)` at sandbox creation time. Creating the `Volume` itself remains unchanged.

--- a/sdk/python/docs/volume.zh.md
+++ b/sdk/python/docs/volume.zh.md
@@ -8,7 +8,7 @@
 沙箱之间共享。
 
 ```python
-from cubesandbox import Sandbox, Volume
+from cubesandbox import Sandbox, Volume, VolumeMount
 ```
 
 `Volume` 的方法均为**类方法**——无需手动实例化即可调用。对齐 e2b：`create` 与
@@ -82,7 +82,7 @@ from cubesandbox import Sandbox, Volume
 | `.name` | `str` | 显示名称。 |
 | `.token` | `str` | 插件签发的 token。`create` / `get_info` 时填充；**`list` 时恒为空串**。 |
 
-### 挂载
+### 挂载与按沙箱访问模式
 
 传入一个 mount 路径到卷的映射（e2b 兼容）：
 
@@ -91,7 +91,22 @@ Sandbox.create(volume_mounts={"/workspace": vol})
 Sandbox.create(volume_mounts={"/workspace": "vol-xxx"})
 ```
 
-每个值必须能解析为已存在的 `volume_id`。
+每个值可以是 `Volume`、`VolumeInfo` 或 `volume_id` 字符串，且必须能解析为已存在的卷。原有 e2b 风格写法继续保持读写挂载。
+
+若只想把某次沙箱挂载设为只读，用 `VolumeMount` 包装对应值：
+
+```python
+from cubesandbox import Sandbox, VolumeMount
+
+Sandbox.create(
+    volume_mounts={
+        "/dataset": VolumeMount(vol, read_only=True),
+        "/workspace": workspace_vol,
+    }
+)
+```
+
+`read_only` 仅表示该挂载点以只读方式挂载。只会禁止当前沙箱经由该挂载点写入或修改文件，不会生成不可变快照。同一个 Volume 可以同时在不同沙箱中以不同权限挂载，例如在沙箱 A 中读写，在沙箱 B 中只读。
 
 ---
 
@@ -201,3 +216,4 @@ except ApiError as e:
 - **`list` 不返回 token。** token 仅在 `create` 和 `get_info` 时暴露；需要 token 时请调用
   `Volume.get_info(volume_id)`。
 - **`name` 可选。** 省略时服务端分配一个 UUID，该 UUID 同时用作 `volume_id` 和 `name`。
+- **只读是单次挂载属性。** 在创建沙箱时使用 `VolumeMount(volume, read_only=True)`；创建 `Volume` 本身的接口不变。

--- a/sdk/python/tests/test_volume.py
+++ b/sdk/python/tests/test_volume.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from cubesandbox import Sandbox, Volume, VolumeInfo, VolumeMount
+from cubesandbox._config import Config
+
+
+def _config() -> Config:
+    return Config(api_url="http://localhost:3000", template_id="tpl-test")
+
+
+def _sandbox_response() -> MagicMock:
+    response = MagicMock()
+    response.ok = True
+    response.status_code = 201
+    response.json.return_value = {
+        "sandboxID": "sb-test",
+        "templateID": "tpl-test",
+    }
+    return response
+
+
+def test_create_serializes_read_only_volume_mount_without_changing_plain_mounts():
+    dataset = VolumeInfo(volume_id="dataset-vol", name="dataset")
+
+    with patch("requests.Session.post", return_value=_sandbox_response()) as post:
+        Sandbox.create(
+            volume_mounts={
+                "/data": VolumeMount(dataset, read_only=True),
+                "/workspace": "workspace-vol",
+            },
+            config=_config(),
+        )
+
+    assert post.call_args.kwargs["json"]["volumeMounts"] == [
+        {"name": "dataset-vol", "path": "/data", "readOnly": True},
+        {"name": "workspace-vol", "path": "/workspace"},
+    ]
+
+
+@pytest.mark.parametrize(
+    "volume",
+    [
+        Volume("shared-vol", "shared"),
+        VolumeInfo(volume_id="shared-vol", name="shared"),
+        "shared-vol",
+    ],
+)
+def test_read_only_volume_mount_preserves_existing_volume_reference_styles(volume):
+    with patch("requests.Session.post", return_value=_sandbox_response()) as post:
+        Sandbox.create(
+            volume_mounts={"/shared": VolumeMount(volume, read_only=True)},
+            config=_config(),
+        )
+
+    assert post.call_args.kwargs["json"]["volumeMounts"] == [
+        {"name": "shared-vol", "path": "/shared", "readOnly": True}
+    ]
+
+
+def test_volume_mount_default_does_not_change_e2b_payload():
+    with patch("requests.Session.post", return_value=_sandbox_response()) as post:
+        Sandbox.create(
+            volume_mounts={"/workspace": VolumeMount("workspace-vol")},
+            config=_config(),
+        )
+
+    assert post.call_args.kwargs["json"]["volumeMounts"] == [
+        {"name": "workspace-vol", "path": "/workspace"}
+    ]

--- a/tests/e2e/sdk_compat/README.md
+++ b/tests/e2e/sdk_compat/README.md
@@ -348,9 +348,7 @@ Current capability domains:
 - `cases/concurrency/`: simultaneous multi-sandbox isolation.
 - `cases/host-mount/`: host-directory mount extension — happy path plus create-time
   validation, runtime bind-mount failures, and cross-sandbox sharing boundary cases.
-- `cases/volume/`: Volume Plugin CRUD plus sandbox `volumeMounts` bind/unbind
-  (opt-in via `SDK_E2E_VOLUME_PLUGIN=true`; CubeSandbox only). Requires a
-  manually deployed/configured Volume Plugin and `cubesandbox` >= 0.6.0.
+- `cases/volume/`: Volume Plugin CRUD plus sandbox `volumeMounts` bind/unbind and per-sandbox read-only attachment enforcement (opt-in via `SDK_E2E_VOLUME_PLUGIN=true`; CubeSandbox only). Requires a manually deployed/configured Volume Plugin and `cubesandbox` >= 0.6.0.
 - `cases/auth/`: `CUBE_API_KEY` simple-key authentication against the CubeAPI
   control plane — `X-API-Key`/`Bearer` accept, wrong/missing 401, `/health`
   exempt (CubeSandbox only). Skipped unless the server was started with

--- a/tests/e2e/sdk_compat/README_zh.md
+++ b/tests/e2e/sdk_compat/README_zh.md
@@ -344,9 +344,7 @@ tests/e2e/sdk_compat/
 - `cases/concurrency/`：同时运行多个 sandbox 时的数据隔离；
 - `cases/host-mount/`：宿主目录挂载扩展——happy path，以及创建时校验、
   运行期 bind-mount 失败和跨 sandbox 共享等边界用例。
-- `cases/volume/`：Volume Plugin CRUD 与 sandbox `volumeMounts` 绑定/解绑
-  （需 `SDK_E2E_VOLUME_PLUGIN=true`；仅 CubeSandbox）。插件需手动部署并配置，
-  且要求 `cubesandbox` >= 0.6.0。
+- `cases/volume/`：Volume Plugin CRUD、sandbox `volumeMounts` 绑定/解绑，以及每个沙箱挂载点的只读约束（需 `SDK_E2E_VOLUME_PLUGIN=true`；仅 CubeSandbox）。插件需手动部署并配置，且要求 `cubesandbox` >= 0.6.0。
 - `cases/auth/`：`CUBE_API_KEY` 简单密钥鉴权，针对 CubeAPI 控制面——
   `X-API-Key`/`Bearer` 通过、错误/缺失返回 401、`/health` 豁免（仅 CubeSandbox）。
   仅当服务端以 `CUBE_API_KEY` 启动且 runner 导出相同 key 时才运行，否则跳过。

--- a/tests/e2e/sdk_compat/cases/volume/test_read_only.py
+++ b/tests/e2e/sdk_compat/cases/volume/test_read_only.py
@@ -1,0 +1,114 @@
+"""Per-sandbox read-only Volume attachment cases.
+
+Prerequisites (manual; not provisioned by this suite):
+- Deploy and configure a Volume Plugin on CubeMaster (Controller) and Cubelet
+  (Node), e.g. COS binary/rpc under ``volume_plugins``, with credentials.
+  Guide: https://github.com/TencentCloud/CubeSandbox/blob/master/examples/volume/cos/README.md
+- Platform Volume API available (CubeAPI / CubeMaster / Cubelet >= 0.6.0).
+- Python SDK ``cubesandbox`` with ``VolumeMount`` support.
+- A READY template (``CUBE_TEMPLATE_ID``) for sandbox create with mounts.
+- Opt-in: ``SDK_E2E_VOLUME_PLUGIN=true`` (and usually ``SDK_E2E_VOLUME_DRIVER``).
+"""
+
+from __future__ import annotations
+
+import shlex
+import sys
+import uuid
+
+import pytest
+from adapters import create_adapter
+from framework.capabilities import VOLUME_PLUGIN
+from framework.cleanup import safe_kill
+from framework.volume import managed_volume
+
+pytestmark = [
+    pytest.mark.e2e,
+    pytest.mark.sdk_compat,
+    pytest.mark.volume,
+    pytest.mark.p1,
+    pytest.mark.requires_capability(VOLUME_PLUGIN),
+]
+
+MOUNT_PATH = "/mnt/readonly-volume"
+
+
+def test_read_only_volume_attachment_rejects_mutations(
+    sdk_backend,
+    sdk_e2e_config,
+):
+    if not sdk_e2e_config.cube_template_id:
+        pytest.skip("CUBE_TEMPLATE_ID or --cube-template-id is required for volume bind")
+
+    # Import after sdk_e2e_config prepends the source checkout's Python SDK.
+    from cubesandbox import VolumeMount
+
+    seed_path = f"{MOUNT_PATH}/seed.txt"
+    renamed_path = f"{MOUNT_PATH}/renamed.txt"
+    new_path = f"{MOUNT_PATH}/new.txt"
+    sdk_write_path = f"{MOUNT_PATH}/sdk-write.txt"
+    concurrent_write_path = f"{MOUNT_PATH}/rw-during-ro.txt"
+    payload = f"readonly-e2e-{uuid.uuid4().hex}"
+
+    with managed_volume(sdk_e2e_config) as (volume_id, _api):
+        read_write = None
+        read_only = None
+        try:
+            read_write = create_adapter(
+                sdk_backend,
+                sdk_e2e_config,
+                metadata={
+                    "test_suite": "sdk_compat",
+                    "test_role": "volume_read_write",
+                    "test_backend": sdk_backend,
+                },
+                create_options={
+                    "volume_mounts": {MOUNT_PATH: volume_id},
+                },
+            )
+            read_write.write_file(seed_path, payload)
+            assert read_write.read_file(seed_path) == payload
+
+            read_only = create_adapter(
+                sdk_backend,
+                sdk_e2e_config,
+                metadata={
+                    "test_suite": "sdk_compat",
+                    "test_role": "volume_read_only",
+                    "test_backend": sdk_backend,
+                },
+                create_options={
+                    "volume_mounts": {
+                        MOUNT_PATH: VolumeMount(volume_id, read_only=True),
+                    },
+                },
+            )
+            assert read_only.read_file(seed_path) == payload
+
+            with pytest.raises(IOError):
+                read_only.write_file(sdk_write_path, "blocked")
+
+            mutations = {
+                "create": f"touch {shlex.quote(new_path)}",
+                "write": f"printf changed > {shlex.quote(seed_path)}",
+                "rename": f"mv {shlex.quote(seed_path)} {shlex.quote(renamed_path)}",
+                "delete": f"rm {shlex.quote(seed_path)}",
+            }
+            for operation, command in mutations.items():
+                result = read_only.run_command(command)
+                assert result.exit_code != 0, (
+                    f"{operation} unexpectedly succeeded on read-only volume attachment"
+                )
+
+            assert read_only.read_file(seed_path) == payload
+
+            read_write.write_file(concurrent_write_path, "writable")
+            assert read_write.read_file(concurrent_write_path) == "writable"
+        finally:
+            active_failure = sys.exc_info()[0] is not None
+            cleanup_errors: list[str] = []
+            for adapter in (read_only, read_write):
+                if adapter is not None:
+                    cleanup_errors.extend(safe_kill(adapter, sdk_e2e_config))
+            if cleanup_errors and not active_failure:
+                pytest.fail("sandbox cleanup failed: " + "; ".join(cleanup_errors))

--- a/tests/e2e/sdk_compat/docs/test-coverage.md
+++ b/tests/e2e/sdk_compat/docs/test-coverage.md
@@ -115,6 +115,10 @@ created and cleaned up through `managed_control_sandbox`.
 This proves basic instance isolation, but it is not a concurrency stress test,
 resource contention test or multi-worker safety validation.
 
+### 2.7 Volume
+
+`cases/volume/` covers Volume Plugin CRUD, sandbox bind/unbind and delete-while-bound behavior. It also verifies that one Volume can remain writable in one sandbox while a concurrent attachment is read-only in another sandbox, including read access and rejected create, write, rename and delete operations. These cases are CubeSandbox-only and remain skipped unless `SDK_E2E_VOLUME_PLUGIN=true` explicitly confirms that the deployment has a configured Volume Plugin.
+
 ## 3. Coverage Boundaries
 
 The current suite mainly validates synchronous Python SDK paths and the

--- a/tests/e2e/sdk_compat/docs/zh/test-coverage.md
+++ b/tests/e2e/sdk_compat/docs/zh/test-coverage.md
@@ -108,6 +108,10 @@ pytest --run-e2e -m "lifecycle and slow"
 
 它证明了基础实例隔离，但不等于并发压力、资源竞争或多 worker 安全性验证。
 
+### 2.7 Volume
+
+`cases/volume/` 覆盖 Volume Plugin CRUD、sandbox 绑定/解绑和绑定期间禁止删除。它还验证同一个 Volume 可以在一个沙箱中保持读写，同时在另一个沙箱中以只读方式挂载，包括正常读取，以及 create、write、rename、delete 均被拒绝。这些用例仅适用于 CubeSandbox，只有通过 `SDK_E2E_VOLUME_PLUGIN=true` 明确确认部署已配置 Volume Plugin 后才会执行，否则保持 skip。
+
 ## 3. 覆盖边界
 
 当前 suite 主要验证 Python SDK 的同步常用路径和 CubeSandbox/E2B 兼容表面：


### PR DESCRIPTION
## Motivation

Some workloads need to share the same Volume across sandboxes while preventing selected sandboxes from modifying it. Typical examples include shared datasets, model artifacts, reference outputs, or baseline files that should be readable by many sandboxes but writable only by designated writers.

This is naturally a per-attachment access mode: the same Volume may be attached read-write in one sandbox and read-only in another.

The official e2b SDK's Volume mount API does not provide a read-only option, so the existing e2b-compatible `volume_mounts={path: volume}` shape can only express read-write mounts. This PR adds read-only mounts as an opt-in Cube extension while preserving that existing default behavior.

Cube already has the lower-level support needed for this in the plugin-volume path and Cubelet's bind-mount / virtiofs read-only enforcement. This PR threads the access mode through the existing flow instead of changing the Volume model itself.

## What Changed

* Add optional `volumeMounts[].readOnly` support to CubeAPI and forward it through CubeMaster's existing plugin-volume mount path.
* Add the Python SDK `VolumeMount` wrapper as a Cube extension.
* Keep plain `Volume`, `VolumeInfo`, and volume ID values read-write by default.
* Omit `readOnly` when `read_only=False` to preserve the existing request shape.
* Keep the existing restriction that a sandbox cannot attach the same Volume more than once.
* Use Cubelet's existing bind-mount and virtiofs read-only enforcement.
* Update the Python SDK reference and the English and Chinese Volume Plugin guides.
* Add API, forwarding, serialization, multi-container, and opt-in `sdk_compat` data-plane coverage. Volume Plugin cases remain skipped unless the deployment explicitly enables them with `SDK_E2E_VOLUME_PLUGIN=true`.

## Example

```python
from cubesandbox import Sandbox, VolumeMount

writer = Sandbox.create(
    volume_mounts={"/dataset": dataset_volume},
)

reader = Sandbox.create(
    volume_mounts={
        "/dataset": VolumeMount(dataset_volume, read_only=True),
    },
)
```

## Validation

* Ran the CubeAPI test suite.
* Ran the CubeMaster plugin-volume forwarding tests.
* Ran the Python SDK Volume tests.
* Ran the `sdk_compat` Volume suite against a COS-backed Volume.
* Verified that the same Volume could be attached read-write and read-only to concurrent sandboxes.
* Verified that the read-only attachment could read existing data but could not create, write, rename, or delete files.
* Verified that the read-write attachment remained writable while the read-only attachment was active.

## Scope

This PR only adds an access mode to individual sandbox Volume attachments.

It does not change:

* the Volume database schema
* the plugin protocol
* create or destroy lifecycle behavior
* refcount behavior
* the default read-write behavior of existing mounts

A read-only attachment is not an immutable snapshot and may observe changes made through another read-write attachment.
