### PR TITLE
chore: bump hard-coded image tags to v0.6.0-rc1

### DIFF
--- a/deploy/kubernetes/chart/README.md
+++ b/deploy/kubernetes/chart/README.md
@@ -172,7 +172,7 @@ To **turn off PVM on one node**: remove the `allow-pvm-bootstrap` label. Bootstr
 ## Build and push images
 
 ```bash
-PUSH=1 REGISTRY=cube-sandbox-int.tencentcloudcr.com/cube-sandbox IMAGE_TAG=v0.5.1 ./deploy/kubernetes/images/build-cube-images.sh
+PUSH=1 REGISTRY=cube-sandbox-int.tencentcloudcr.com/cube-sandbox IMAGE_TAG=v0.6.0-rc1 ./deploy/kubernetes/images/build-cube-images.sh
 ```
 
 Cube-owned images default to `imagePullPolicy: IfNotPresent`. To pick up a

--- a/deploy/kubernetes/images/README.md
+++ b/deploy/kubernetes/images/README.md
@@ -5,7 +5,7 @@ This directory contains image build definitions used by the Kubernetes/TKE chart
 ## Build entrypoint
 
 ```bash
-PUSH=1 REGISTRY=cube-sandbox-int.tencentcloudcr.com/cube-sandbox IMAGE_TAG=v0.5.1 ./deploy/kubernetes/images/build-cube-images.sh
+PUSH=1 REGISTRY=cube-sandbox-int.tencentcloudcr.com/cube-sandbox IMAGE_TAG=v0.6.0-rc1 ./deploy/kubernetes/images/build-cube-images.sh
 ```
 
 Before a real release, run `scripts/bump-image.sh vX.Y.Z` so hard-coded tags
@@ -18,7 +18,7 @@ Use `NO_CACHE=1` when every Docker image layer must be rebuilt instead of
 using Docker's build cache:
 
 ```bash
-NO_CACHE=1 PUSH=1 REGISTRY=cube-sandbox-int.tencentcloudcr.com/cube-sandbox IMAGE_TAG=v0.5.1 ./deploy/kubernetes/images/build-cube-images.sh
+NO_CACHE=1 PUSH=1 REGISTRY=cube-sandbox-int.tencentcloudcr.com/cube-sandbox IMAGE_TAG=v0.6.0-rc1 ./deploy/kubernetes/images/build-cube-images.sh
 ```
 
 The script defaults its temporary `BUILD_ROOT` to
@@ -68,7 +68,7 @@ CUBE_KERNEL_VMLINUX=/path/to/vmlinux \
 ONE_CLICK_ARCH=arm64 CUBE_KERNEL_VMLINUX=/path/to/vmlinux \
   IMAGE_TAG=dev ./deploy/kubernetes/images/build-cube-images.sh cube-kernel
 
-IMAGE_TAG=v0.5.1 ./deploy/kubernetes/images/build-cube-images.sh cube-kernel
+IMAGE_TAG=v0.6.0-rc1 ./deploy/kubernetes/images/build-cube-images.sh cube-kernel
 ```
 
 `cube-guest` does not use the one-click package. It stages guest rootfs from:
@@ -83,7 +83,7 @@ IMAGE_TAG=v0.5.1 ./deploy/kubernetes/images/build-cube-images.sh cube-kernel
 CUBE_GUEST_IMAGE_DIR=/path/to/cube-image IMAGE_TAG=dev \
   ./deploy/kubernetes/images/build-cube-images.sh cube-guest
 
-IMAGE_TAG=v0.5.1 ./deploy/kubernetes/images/build-cube-images.sh cube-guest
+IMAGE_TAG=v0.6.0-rc1 ./deploy/kubernetes/images/build-cube-images.sh cube-guest
 ```
 
 ## Pinning source to a release tag
@@ -144,7 +144,7 @@ entrypoint into it:
 
 ```bash
 CUBE_NODE_BASE_IMAGE=ccr.ccs.tencentyun.com/pavleli/cube-node:v0.4.0-cubevsfix-20260627 \
-  PUSH=1 REGISTRY=cube-sandbox-int.tencentcloudcr.com/cube-sandbox IMAGE_TAG=v0.5.1 \
+  PUSH=1 REGISTRY=cube-sandbox-int.tencentcloudcr.com/cube-sandbox IMAGE_TAG=v0.6.0-rc1 \
   ./deploy/kubernetes/images/build-cube-images.sh
 ```
 

--- a/deploy/kubernetes/images/build-cube-images.sh
+++ b/deploy/kubernetes/images/build-cube-images.sh
@@ -183,9 +183,9 @@ Examples:
   SOURCE_REF="" IMAGE_TAG=dev $0 cube-shim
   CUBE_KERNEL_VMLINUX=/path/vmlinux CUBE_KERNEL_PVM_VMLINUX=/path/vmlinux-pvm \\
     IMAGE_TAG=dev $0 cube-kernel
-  IMAGE_TAG=v0.5.1 $0 cube-kernel
+  IMAGE_TAG=v0.6.0-rc1 $0 cube-kernel
   CUBE_GUEST_IMAGE_DIR=/path/to/cube-image IMAGE_TAG=dev $0 cube-guest
-  IMAGE_TAG=v0.5.1 $0 cube-guest
+  IMAGE_TAG=v0.6.0-rc1 $0 cube-guest
   SOURCE_REF="" IMAGE_TAG=dev $0 cube-api
   SOURCE_REF="" IMAGE_TAG=dev $0 cube-ops
 

--- a/deploy/one-click/build-guest-image.sh
+++ b/deploy/one-click/build-guest-image.sh
@@ -3,7 +3,7 @@
 #
 # Usage:
 #   OUTPUT_DIR=/path/to/cube-image [ONE_CLICK_CUBE_AGENT_BIN=/path/to/cube-agent] \
-#     CUBE_VERSION=v0.5.1 ./deploy/one-click/build-guest-image.sh
+#     CUBE_VERSION=v0.6.0-rc1 ./deploy/one-click/build-guest-image.sh
 #
 # When ONE_CLICK_CUBE_AGENT_BIN is unset, cube-agent is built locally (or via
 # ONE_CLICK_CUBE_AGENT_BUILD_MODE=docker).

--- a/deploy/one-click/tests/test_bump_image.sh
+++ b/deploy/one-click/tests/test_bump_image.sh
@@ -26,6 +26,12 @@ FILES=(
 	docs/guide/tencentcloud-terraform-deploy.md
 	docs/zh/guide/tencentcloud-terraform-deploy.md
 	deploy/kubernetes/chart/values.yaml
+	deploy/kubernetes/images/build-cube-images.sh
+	deploy/kubernetes/images/README.md
+	deploy/kubernetes/chart/README.md
+	deploy/one-click/build-guest-image.sh
+	docs/guide/kubernetes/faq.md
+	docs/zh/guide/kubernetes/faq.md
 )
 
 failures=0

--- a/docs/guide/kubernetes/faq.md
+++ b/docs/guide/kubernetes/faq.md
@@ -424,7 +424,7 @@ See [`deploy/kubernetes/images/README.md`](https://github.com/TencentCloud/CubeS
 
 ```bash
 ONE_CLICK_ARCH=arm64 \
-PUSH=1 REGISTRY=<your-registry> IMAGE_TAG=v0.5.1 \
+PUSH=1 REGISTRY=<your-registry> IMAGE_TAG=v0.6.0-rc1 \
 ./deploy/kubernetes/images/build-cube-images.sh
 ```
 

--- a/docs/zh/guide/kubernetes/faq.md
+++ b/docs/zh/guide/kubernetes/faq.md
@@ -424,7 +424,7 @@ PVC/PV 是否删除取决于实际 StorageClass 的 `reclaimPolicy`（TKE 的 `c
 
 ```bash
 ONE_CLICK_ARCH=arm64 \
-PUSH=1 REGISTRY=<your-registry> IMAGE_TAG=v0.5.1 \
+PUSH=1 REGISTRY=<your-registry> IMAGE_TAG=v0.6.0-rc1 \
 ./deploy/kubernetes/images/build-cube-images.sh
 ```
 

--- a/scripts/bump-image.sh
+++ b/scripts/bump-image.sh
@@ -4,8 +4,9 @@
 #
 # Single source of truth for the release image tag hard-coded across the
 # one-click deployment surface (terraform defaults, systemd launcher, env
-# examples, CubeEgress Makefile, install docs) and the Helm chart defaults
-# (deploy/kubernetes/chart/values.yaml component image tags).
+# examples, CubeEgress Makefile, install docs), the Helm chart defaults
+# (deploy/kubernetes/chart/values.yaml component image tags), and the
+# kubernetes image-build docs / usage examples (IMAGE_TAG= / CUBE_VERSION=).
 #
 # Run it before tagging a release to bump every hard-coded cube-* component
 # image tag to the target version; the release workflow runs it with --check to
@@ -118,6 +119,17 @@ edit_expr() {
 		# use quoted non-v tags (e.g. "1.28.15", "8.0") and are left alone.
 		echo "s{(^\\s+tag:\\s+)${PERL_SEMVER}}{\$1\$ENV{VER}}"
 		;;
+	deploy/kubernetes/images/build-cube-images.sh | \
+		deploy/kubernetes/images/README.md | \
+		deploy/kubernetes/chart/README.md | \
+		deploy/one-click/build-guest-image.sh | \
+		docs/guide/kubernetes/faq.md | \
+		docs/zh/guide/kubernetes/faq.md)
+		# Docs / usage examples that hard-code IMAGE_TAG=vX or CUBE_VERSION=vX.
+		# Leave non-semver placeholders alone (e.g. IMAGE_TAG=dev) and do not
+		# touch unrelated tags on the same line (e.g. cube-node:v0.4.0-...).
+		echo "s{((?:IMAGE_TAG|CUBE_VERSION)=)${PERL_SEMVER}}{\$1\$ENV{VER}}g"
+		;;
 	*)
 		echo "error: no edit rule for $1" >&2
 		exit 3
@@ -142,6 +154,12 @@ FILES=(
 	docs/guide/tencentcloud-terraform-deploy.md
 	docs/zh/guide/tencentcloud-terraform-deploy.md
 	deploy/kubernetes/chart/values.yaml
+	deploy/kubernetes/images/build-cube-images.sh
+	deploy/kubernetes/images/README.md
+	deploy/kubernetes/chart/README.md
+	deploy/one-click/build-guest-image.sh
+	docs/guide/kubernetes/faq.md
+	docs/zh/guide/kubernetes/faq.md
 )
 
 do_bump() {


### PR DESCRIPTION
## Summary

Update hard-coded `IMAGE_TAG` and `CUBE_VERSION` references from `v0.5.1` to `v0.6.0-rc1` across deployment scripts, docs, and image build tooling.

## Changes

- **deploy/kubernetes/images/build-cube-images.sh** — bump example image tags in usage docs
- **deploy/kubernetes/images/README.md** — sync example commands to v0.6.0-rc1
- **deploy/kubernetes/chart/README.md** — update build-and-push example
- **deploy/one-click/build-guest-image.sh** — bump CUBE_VERSION in usage comment
- **docs/guide/kubernetes/faq.md** — update image build example
- **docs/zh/guide/kubernetes/faq.md** — update image build example (zh)
- **scripts/bump-image.sh** — extend coverage to the newly added files so future bumps are automated