### PR TITLE
feat(perf): a self-contained CubeSandbox performance benchmark suite

### DIFF
--- a/tests/perf/.env.example
+++ b/tests/perf/.env.example
@@ -1,0 +1,67 @@
+# CubeSandbox perf — environment variable template
+# Copy to tests/perf/.env and edit. CLI flags and env vars override .env.
+# On first run without .env, a placeholder is auto-generated; after the
+# run, values actually used are written back.
+
+# ===========================================================================
+# Target cluster & authentication
+# ===========================================================================
+# CubeMaster API URL (required)
+CUBE_API_URL=http://127.0.0.1:3000
+# API key for authentication (optional, leave empty if not required)
+CUBE_API_KEY=""
+# Template ID used to create sandboxes (required)
+CUBE_TEMPLATE_ID=
+# Override proxy node IP for direct connection (optional)
+CUBE_PROXY_NODE_IP=
+# Proxy HTTP port (default 80)
+CUBE_PROXY_PORT_HTTP=80
+# Sandbox domain for routing
+CUBE_SANDBOX_DOMAIN=cube.app
+
+# ===========================================================================
+# External benchmark scripts
+# Comma-separated file paths or glob patterns. Supports * wildcard.
+# The 6 built-in scenarios are enabled by default.
+# ===========================================================================
+CUBE_EXTERNAL_SCRIPTS=../examples/snapshot-rollback-clone/bench_*.py,../examples/ivshmem/ivshmem_benchmark.py
+
+# ===========================================================================
+# Scenario toggles (set to 1 to enable)
+# ===========================================================================
+# Enable ivshmem benchmarks (requires host ivshmem + ivshmem template)
+# CUBE_RUN_IVSHMEM=1
+# Enable volume benchmarks
+# CUBE_RUN_VOLUME=1
+# Skip density benchmarks
+# CUBE_SKIP_DENSITY=1
+# Skip snapshot dirty benchmarks
+# CUBE_SKIP_SNAPSHOT_DIRTY=1
+# Dirty page sizes for snapshot-dirty scenario (MB), comma-separated
+CUBE_SNAPSHOT_DIRTY_SIZES=0,10,100,1024
+# Dedicated ivshmem template (falls back to CUBE_TEMPLATE_ID if empty)
+# CUBE_IVSHMEM_TEMPLATE_ID=
+# ivshmem mmap iteration count
+CUBE_IVSHMEM_ITERATIONS=10000
+
+# ===========================================================================
+# Run parameters
+# ===========================================================================
+# Number of rounds per scenario (higher = more stable percentiles)
+CUBE_PERF_ROUNDS=3
+# Default concurrency levels for generic scenarios
+CUBE_PERF_CONCURRENCY=1,5,10
+# Concurrency levels for create-concurrency scenario
+CUBE_CREATE_CONCURRENCY=1,10,20,50
+# Warm-up rounds (first N results discarded to eliminate cold start)
+CUBE_PERF_WARMUP=1
+# Settle seconds between scenarios
+CUBE_PERF_SETTLE=0
+# Sandbox count for density benchmarks
+CUBE_DENSITY_COUNT=100
+# Enable post-run cleanup of residual sandboxes (set 0 to disable)
+CUBE_PERF_CLEANUP=1
+# Auto-cleanup residual snapshots after benchmarks (default on)
+CUBE_PERF_AUTO_CLEANUP=1
+# Seconds to wait for async tasks before auto-cleanup (default 0)
+CUBE_PERF_AUTO_CLEANUP_WAIT=0

--- a/tests/perf/README.md
+++ b/tests/perf/README.md
@@ -1,0 +1,129 @@
+# `perf` — CubeSandbox Performance Benchmark Suite
+
+One command runs all scenarios, producing **JSON + Markdown** reports.
+
+## Quick Start
+
+```bash
+cd CubeSandbox/tests
+cp perf/.env.example perf/.env      # edit with CUBE_API_URL / CUBE_TEMPLATE_ID
+python3 -m perf
+
+# Run a specific scenario
+python3 -m perf --scenarios clone-concurrency
+
+# List all scenarios
+python3 -m perf --list-scenarios
+```
+
+## Common Commands
+
+| Command | Description |
+|---------|-------------|
+| `python3 -m perf` | Run all scenarios |
+| `python3 -m perf --rounds 20` | 20 rounds per scenario |
+| `python3 -m perf --scenarios clone-concurrency` | Run specific scenario |
+| `python3 -m perf --list-scenarios` | List registered scenarios |
+| `python3 -m perf --cleanup` | Remove `snap-*` templates |
+| `python3 -m perf --cleanup-dry-run` | Preview snapshots to be removed |
+| `python3 -m perf --md-only report.json` | Re-render reports from JSON |
+
+## Output Files
+
+By default, reports are written into a fresh per-run directory under
+`tests/perf/report/<UTC-timestamp>/`, so the CWD stays clean:
+
+```
+tests/perf/report/
+├── 20260723T044740Z/             # one subdir per invocation
+│   ├── report.json               # Full data JSON (English, with environment, config, performance)
+│   ├── report.zh.json            # Same, Chinese-friendly (locale tag set to "zh")
+│   ├── report.md                 # Markdown report (English)
+│   └── report.zh.md              # Markdown report (Chinese)
+└── aggregate/                    # reserved for cross-run aggregation
+```
+
+The default base name is `report`; the path is
+`<perf>/report/<UTC-timestamp>/report.{md,zh.md,json,zh.json}`.
+
+Override the **full base path** with `CUBE_OUTPUT_REPORT`, e.g.:
+
+- `CUBE_OUTPUT_REPORT=./report` → files land in `./report.{md,zh.md,json,zh.json}` (CWD)
+- `CUBE_OUTPUT_REPORT=/tmp/perf/2026-07-23/report` → all 4 files in that dir
+
+## Cleanup Behaviour
+
+The framework cleans up after **each round** and **after all scenarios**:
+
+| Timing | What is cleaned | How to disable |
+|--------|----------------|----------------|
+| After each round | Sandboxes created in that round (kill) | `CUBE_PERF_CLEANUP=0` |
+| After all scenarios | `snap-*` snapshot templates (SDK delete) | `CUBE_PERF_AUTO_CLEANUP=0` |
+| Manual trigger | All `snap-*` snapshots, regardless of age | `python3 -m perf --cleanup` |
+
+**Notes**:
+- Only deletes templates with IDs starting with `snap-`; user-owned `tpl-*` templates are never touched
+- Snapshots with active sandbox references (non-empty `replicas`) are silently skipped
+- Waits `CUBE_PERF_AUTO_CLEANUP_WAIT` seconds (default 5s) before cleanup to let async operations settle
+- Use `--cleanup-dry-run` to preview snapshots without deleting
+
+`.env` is auto-generated on first run. Full comments in `.env.example`. Precedence: CLI > env var > .env.
+
+### Connection
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `CUBE_API_URL` | `http://127.0.0.1:3000` | CubeMaster API URL |
+| `CUBE_API_KEY` | — | API key (optional) |
+| `CUBE_TEMPLATE_ID` | auto-discover | Template ID (leave empty to auto-find READY template) |
+| `CUBE_PROXY_NODE_IP` | — | Direct-connect node IP |
+| `CUBE_PROXY_PORT_HTTP` | `80` | Proxy HTTP port |
+| `CUBE_SANDBOX_DOMAIN` | `cube.app` | Sandbox domain |
+
+### Run Parameters
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `CUBE_PERF_ROUNDS` | `3` | Rounds per scenario |
+| `CUBE_PERF_WARMUP` | `1` | Warm-up rounds (excluded from stats) |
+| `CUBE_PERF_SETTLE` | `0` | Settle seconds between levels |
+| `CUBE_PERF_CONCURRENCY` | `1,5,10` | Default concurrency gradient |
+| `CUBE_CREATE_CONCURRENCY` | `1,10,20,50` | Create scenario gradient |
+| `CUBE_DENSITY_COUNT` | `100` | Max sandbox count for density test |
+
+### Auto Cleanup
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `CUBE_PERF_AUTO_CLEANUP` | `1` | Remove residual `snap-*` after benchmarks |
+| `CUBE_PERF_AUTO_CLEANUP_WAIT` | `0` | Wait seconds for async ops before cleanup (0 = no wait) |
+
+### External Scripts
+
+| Variable | Description |
+|----------|-------------|
+| `CUBE_EXTERNAL_SCRIPTS` | Comma-separated script paths, `*` glob supported |
+
+## Built-in Scenarios
+
+6 scenarios enabled by default, 2 opt-in. All located in `../examples/snapshot-rollback-clone/`:
+
+| Scenario | Key | Description |
+|----------|-----|-------------|
+| Create (concurrency) | `create-concurrency` | Multi-concurrency sandbox create |
+| Snapshot (concurrency) | `snapshot-concurrency` | Multi-concurrency snapshot create |
+| Rollback (concurrency) | `rollback-concurrency` | Multi-concurrency snapshot rollback |
+| Clone (concurrency) | `clone-concurrency` | Multi-concurrency sandbox clone |
+| Pause & Resume | `pause-resume-concurrency` | Multi-concurrency pause/resume |
+| Snapshot Dirty | `snapshot-dirty` | Snapshot creation with varying dirty page sizes |
+
+Opt-in scenarios:
+
+| Scenario | Key | Enable | Notes |
+|----------|-----|--------|-------|
+| ivshmem shared memory | `ivshmem` | `CUBE_RUN_IVSHMEM=1` | Requires host ivshmem + ivshmem template |
+| Volume (remote storage) | `volume` | `CUBE_RUN_VOLUME=1` | Requires Volume plugin |
+
+## Adding New Scenarios
+
+See [Integration Contract](docs/guide/perf-design.md). TL;DR: Write a script accepting `-c <concurrency>` and `-n <operations>`, register it in `.env`.

--- a/tests/perf/README.zh.md
+++ b/tests/perf/README.zh.md
@@ -1,0 +1,129 @@
+# `perf` — CubeSandbox 性能压测套件
+
+一条命令跑完所有场景，产出 **JSON + Markdown** 报告。
+
+## 快速开始
+
+```bash
+cd CubeSandbox/tests
+cp perf/.env.example perf/.env      # 编辑填入 CUBE_API_URL / CUBE_TEMPLATE_ID
+python3 -m perf
+
+# 只跑指定场景
+python3 -m perf --scenarios clone-concurrency
+
+# 列出全部场景
+python3 -m perf --list-scenarios
+```
+
+## 常用命令
+
+| 命令 | 说明 |
+|------|------|
+| `python3 -m perf` | 跑全部场景 |
+| `python3 -m perf --rounds 20` | 每场景 20 轮 |
+| `python3 -m perf --scenarios clone-concurrency` | 只跑指定场景 |
+| `python3 -m perf --list-scenarios` | 列出已注册场景 |
+| `python3 -m perf --cleanup` | 清理 `snap-*` 快照 |
+| `python3 -m perf --cleanup-dry-run` | 预览将要清理的快照 |
+| `python3 -m perf --md-only report.json` | 从 JSON 重渲染报告 |
+
+## 输出文件
+
+默认每次运行会写到 `tests/perf/report/<UTC-时间戳>/` 下的一个独立子目录，CWD 保持干净：
+
+```
+tests/perf/report/
+├── 20260723T044740Z/             # 每次运行一个子目录
+│   ├── report.json               # 完整数据 JSON（英文版，含环境/配置/性能）
+│   ├── report.zh.json            # 同上，中文版（language 字段为 "zh"）
+│   ├── report.md                 # Markdown 报告（英文）
+│   └── report.zh.md              # Markdown 报告（中文）
+└── aggregate/                    # 预留给跨运行聚合使用
+```
+
+默认基名是 `report`，即 `<perf>/report/<UTC-timestamp>/report.{md,zh.md,json,zh.json}`。
+
+通过 `CUBE_OUTPUT_REPORT` 可指定**完整基路径**：
+
+- `CUBE_OUTPUT_REPORT=./report` → 4 个文件落到 `./report.{md,zh.md,json,zh.json}`（CWD）
+- `CUBE_OUTPUT_REPORT=/tmp/perf/2026-07-23/report` → 落到指定目录
+
+## 清理行为
+
+框架在**每轮结束后**和**所有场景完成后**会自动清理压测残留。具体操作：
+
+| 时机 | 清理内容 | 如何关闭 |
+|------|---------|---------|
+| 每轮结束 | 本轮创建的沙箱（逐个 kill） | `CUBE_PERF_CLEANUP=0` |
+| 全部场景后 | `snap-*` 快照模板（通过 SDK 删除） | `CUBE_PERF_AUTO_CLEANUP=0` |
+| 手动触发 | 全部沙箱 + 全部 `snap-*` 快照 | `python3 -m perf --cleanup` |
+
+**注意**：
+- `--cleanup` 先 kill 所有沙箱，再删除 `snap-*` 快照
+- 只删除 ID 以 `snap-` 开头的快照模板，不触碰用户自有模板（`tpl-*`）
+- 有活跃沙箱引用的快照（`replicas` 非空）自动跳过，不会报错
+- 清理前等待 `CUBE_PERF_AUTO_CLEANUP_WAIT` 秒（默认 0，使用中的快照直接跳过不等待）
+- `--cleanup-dry-run` 预览将被删除的快照列表，不执行实际删除
+
+首次运行自动生成 `tests/perf/.env`，所有变量均可在 `.env.example` 中找到完整注释。参数优先级：CLI > 环境变量 > .env。
+
+### 连接
+
+| 变量 | 默认值 | 说明 |
+|------|--------|------|
+| `CUBE_API_URL` | `http://127.0.0.1:3000` | CubeMaster API 地址 |
+| `CUBE_API_KEY` | — | API 密钥（可选） |
+| `CUBE_TEMPLATE_ID` | 自动发现 | 模板 ID（留空自动查找 READY 模板） |
+| `CUBE_PROXY_NODE_IP` | — | 直连节点 IP（跳过 DNS） |
+| `CUBE_PROXY_PORT_HTTP` | `80` | 代理端口 |
+| `CUBE_SANDBOX_DOMAIN` | `cube.app` | 沙箱域名 |
+
+### 运行参数
+
+| 变量 | 默认值 | 说明 |
+|------|--------|------|
+| `CUBE_PERF_ROUNDS` | `3` | 每场景轮数 |
+| `CUBE_PERF_WARMUP` | `1` | 预热轮数（不计统计） |
+| `CUBE_PERF_SETTLE` | `0` | 档间静默秒数 |
+| `CUBE_PERF_CONCURRENCY` | `1,5,10` | 默认并发度阶梯 |
+| `CUBE_CREATE_CONCURRENCY` | `1,10,20,50` | 创建场景并发阶梯 |
+| `CUBE_DENSITY_COUNT` | `100` | 密度测试沙箱数上限 |
+| `CUBE_PERF_CLEANUP` | `1` | 轮间清理沙箱（设 0 关闭） |
+
+### 自动清理
+
+| 变量 | 默认值 | 说明 |
+|------|--------|------|
+| `CUBE_PERF_AUTO_CLEANUP` | `1` | 压测后自动清除残留快照（只清 `snap-*`，不过滤非 snap-* 模板） |
+| `CUBE_PERF_AUTO_CLEANUP_WAIT` | `0` | 清理前等待秒数（0 = 不等待，使用中的快照直接跳过） |
+
+### 外部脚本
+
+| 变量 | 说明 |
+|------|------|
+| `CUBE_EXTERNAL_SCRIPTS` | 逗号分隔的脚本路径，支持 `*` glob |
+
+## 内置场景
+
+框架 7 个默认场景 + 1 个需手动开启，位于 `../examples/`：
+
+| 场景 | Key | 说明 |
+|------|-----|------|
+| 创建（并发） | `create-concurrency` | 多并发创建沙箱 |
+| 快照创建（并发） | `snapshot-concurrency` | 多并发创建快照 |
+| 快照回滚（并发） | `rollback-concurrency` | 多并发回滚到快照 |
+| 克隆（并发） | `clone-concurrency` | 多并发克隆沙箱 |
+| 暂停 & 恢复（并发） | `pause-resume-concurrency` | 多并发暂停和恢复 |
+| 脏页快照 | `snapshot-dirty` | 不同脏页大小下的快照制作耗时 |
+| ivshmem 共享内存 | `ivshmem-benchmark` | 共享内存 mmap 性能（host-only） |
+
+以下场景需手动开启：
+
+| 场景 | Key | 开启方式 | 说明 |
+|------|-----|---------|------|
+| 远程存储卷 | `volume` | `CUBE_RUN_VOLUME=1` | 需配置 Volume 插件 |
+
+## 接入新场景
+
+详见 [脚本集成契约](docs/guide/perf-design.zh.md)。简单来说：写一个接受 `-c <并发>` `-n <次数>` 参数的脚本，在 `.env` 注册即可。

--- a/tests/perf/__init__.py
+++ b/tests/perf/__init__.py
@@ -1,0 +1,291 @@
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""Standalone performance benchmark suite for the Python SDK.
+
+Self-contained package — all dependencies (config/env/runner/report) are
+included within the `perf/` directory.  No external `e2e/` import needed.
+
+Run it via the CLI entry point (from the ``tests/`` directory)::
+
+    python3 -m perf                                   # local backend (default)
+    CUBE_API_URL=... CUBE_API_KEY=... python3 -m perf  # remote backend
+
+Modules:
+    benchmarks  - 13 benchmark scenarios + run_all()
+    report_html - self-contained HTML report with Chart.js line charts
+    report      - Markdown + JSON report generation
+    config      - configuration resolution & runtime tunables
+    env         - environment info collection (hardware + component versions)
+    runner      - PerfResult, PerfSample, measure helpers
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+# tests/perf/__init__.py -> tests/perf -> tests -> repo-root -> sdk/python
+_PKG_DIR = os.path.dirname(os.path.abspath(__file__))
+_TESTS_DIR = os.path.abspath(os.path.join(_PKG_DIR, ".."))
+_SDK_ROOT = os.path.abspath(os.path.join(_TESTS_DIR, "..", "sdk", "python"))
+if _SDK_ROOT not in sys.path:
+    sys.path.insert(0, _SDK_ROOT)
+
+
+# Data-flow (connection) variables — the SDK ``Config`` knobs that decide which
+# backend the suite talks to. These are the only settings a first-time user must
+# provide; ``_ensure_dotenv`` scaffolds them and ``_persist_dotenv`` writes back
+# whatever a run actually used, so the 2nd/3rd invocation just needs
+# ``python3 -m perf`` (no re-exporting). Everything else stays in ``.env.example``.
+_DATAFLOW_ENV_KEYS = (
+    "CUBE_API_URL",
+    "CUBE_API_KEY",
+    "CUBE_TEMPLATE_ID",
+    "CUBE_PROXY_NODE_IP",
+    "CUBE_PROXY_PORT_HTTP",
+    "CUBE_SANDBOX_DOMAIN",
+)
+
+# Run tunables (concurrency ladders, rounds, density count, ...) — no secrets,
+# so they are safe to write back the same way. Whatever value a run actually
+# used (real env var, or already in .env) gets persisted, so once you dial the
+# concurrency ladder down to dodge a CubeMaster "no more resource" error on a
+# small node, later runs keep using the smaller ladder without re-exporting.
+_TUNABLE_ENV_KEYS = (
+    "CUBE_PERF_ROUNDS",
+    "CUBE_PERF_CONCURRENCY",
+    "CUBE_CREATE_CONCURRENCY",
+    "CUBE_PERF_WARMUP",
+    "CUBE_PERF_SETTLE",
+    "CUBE_DIRTY_SWEEP",
+    "CUBE_DENSITY_COUNT",
+    "CUBE_PERF_CLEANUP",
+    "CUBE_PERF_AUTO_CLEANUP",
+    "CUBE_PERF_AUTO_CLEANUP_WAIT",
+    "CUBE_CLEANUP_CMD",
+    # Scenario toggles — persisted so subsequent runs reuse the same set
+    # without re-exporting CUBE_RUN_IVSHMEM=1 / CUBE_SKIP_DENSITY=1 etc.
+    "CUBE_RUN_IVSHMEM",
+    "CUBE_RUN_VOLUME",
+    "CUBE_SKIP_DENSITY",
+    "CUBE_SKIP_SNAPSHOT_DIRTY",
+    "CUBE_IVSHMEM_TEMPLATE_ID",
+    "CUBE_IVSHMEM_ITERATIONS",
+    # NOTE: CUBE_EXTERNAL_SCRIPTS is deliberately NOT persisted — it defaults
+    # to all built-in examples/*.py scripts. Persisting it after a filtered
+    # run (e.g. --scenarios snapshot-dirty) would lock it to the last-run subset.
+)
+
+_DOTENV_HEADER = (
+    "# CubeSandbox perf suite — auto-generated .env (data-flow + tunables + scenarios).\n"
+    "# First run: all keys are commented placeholders; after a successful run the\n"
+    "# values actually used (concurrency ladders, rounds, template id, …) are\n"
+    "# written back here, so later runs just need: python3 -m perf\n"
+    "# Copy .env.example for even more detail (report layout, customisation, …).\n"
+    "\n"
+)
+
+
+def _dotenv_candidates() -> "list[str]":
+    """Return the ``.env`` search locations (nearest first)."""
+    explicit = os.environ.get("CUBE_DOTENV")
+    if explicit:
+        return [explicit]
+    return [
+        os.path.join(os.getcwd(), ".env"),
+        os.path.join(_PKG_DIR, ".env"),
+        os.path.join(_TESTS_DIR, ".env"),
+        os.path.join(_SDK_ROOT, ".env"),
+    ]
+
+
+def _dotenv_path() -> str:
+    """The ``.env`` file to read/write: the first existing candidate, else
+    ``tests/perf/.env``."""
+    explicit = os.environ.get("CUBE_DOTENV")
+    if explicit:
+        return explicit
+    for p in _dotenv_candidates():
+        if os.path.isfile(p):
+            return p
+    return os.path.join(_PKG_DIR, ".env")
+
+
+def _ensure_dotenv() -> None:
+    """Scaffold a ``.env`` on first run with the most useful knobs.
+
+    Writes data-flow keys, run tunables, scenario toggles, and external-script
+    path — all as commented‑out placeholders (except keys already set in the
+    environment, which are written uncommented).  Existing ``.env`` files are
+    never touched.
+    """
+    if os.environ.get("CUBE_DOTENV"):
+        return
+    if any(os.path.isfile(p) for p in _dotenv_candidates()):
+        return
+
+    def _banner(title: str) -> list[str]:
+        hr = "# " + "=" * 73 + "\n"
+        return ["\n\n", hr, f"# {title}\n", hr]
+
+    out: list[str] = [_DOTENV_HEADER]
+
+    # -- Data-flow (connection) --
+    out.extend(_banner("目标环境与鉴权"))
+    for key in _DATAFLOW_ENV_KEYS:
+        value = os.environ.get(key)
+        if value:
+            out.append(f"{key}={value}\n")
+        elif key == "CUBE_API_URL":
+            out.append(f"# {key}=   # default http://127.0.0.1:3000 (local); set for remote\n")
+        elif key == "CUBE_TEMPLATE_ID":
+            out.append(f"# {key}=   # leave empty to auto-discover a READY template\n")
+        else:
+            out.append(f"# {key}=\n")
+
+    # -- Scenario toggles --
+    out.extend(_banner("跑哪些场景（开启 / 关闭）"))
+    _scenario_placeholders = {
+        "CUBE_RUN_IVSHMEM": "设为 1 启用 ivshmem 共享内存场景（需在节点 host 上运行）",
+        "CUBE_RUN_VOLUME": "设为 1 启用 Volume 相关场景",
+        "CUBE_SKIP_DENSITY": "设为 1 跳过部署密度测试",
+        "CUBE_SKIP_SNAPSHOT_DIRTY": "设为 1 跳过「快照耗时 vs 脏页规模」测试",
+        "CUBE_IVSHMEM_TEMPLATE_ID": "ivshmem 专用模板（留空回落 CUBE_TEMPLATE_ID）",
+        "CUBE_IVSHMEM_ITERATIONS": "ivshmem mmap 读写迭代次数（默认 10000）",
+    }
+    for key, hint in _scenario_placeholders.items():
+        value = os.environ.get(key)
+        out.append(f"{key}={value}\n" if value else f"# {key}=   # {hint}\n")
+
+    # -- Run tunables --
+    out.extend(_banner("运行参数"))
+    _tunable_placeholders = {
+        "CUBE_PERF_ROUNDS": "每个场景压测轮数（默认 10）",
+        "CUBE_PERF_CONCURRENCY": "轻量场景并发梯度（snapshot-create/rollback/pause-resume，默认 1,5,10）",
+        "CUBE_CREATE_CONCURRENCY": "重量场景并发梯度（template-create/from-snapshot/clone，默认 1,10,20,50）",
+        "CUBE_PERF_WARMUP": "计时前丢弃的预热轮数（默认 1）",
+        "CUBE_PERF_SETTLE": "并发档位之间的静默秒数（默认 0）",
+        "CUBE_DENSITY_COUNT": "部署密度测试最大沙箱数（默认 100）",
+        "CUBE_PERF_CLEANUP": "轮次间清理残留 micro-VM：设为 0 关闭（默认开启）",
+    }
+    for key, hint in _tunable_placeholders.items():
+        value = os.environ.get(key)
+        out.append(f"{key}={value}\n" if value else f"# {key}=   # {hint}\n")
+
+    # -- External scripts --
+    out.extend(_banner("外部压测脚本（逗号分隔 .py 路径，约定 -c -n --rounds --no-header）"))
+    ext = os.environ.get("CUBE_EXTERNAL_SCRIPTS", "")
+    if ext:
+        out.append(f"CUBE_EXTERNAL_SCRIPTS={ext}\n")
+    else:
+        out.append(
+            "# 默认接入 examples/snapshot-rollback-clone/ 下的 6 个内置场景：\n"
+            "CUBE_EXTERNAL_SCRIPTS=../examples/snapshot-rollback-clone/bench_clone_concurrency.py,../examples/snapshot-rollback-clone/bench_create_concurrency.py,../examples/snapshot-rollback-clone/bench_snapshot_concurrency.py,../examples/snapshot-rollback-clone/bench_rollback_concurrency.py,../examples/snapshot-rollback-clone/bench_pause_resume_concurrency.py,../examples/snapshot-rollback-clone/bench_snapshot_dirty.py\n"
+        )
+
+    # -- Output --
+    out.extend(_banner("输出"))
+    html = os.environ.get("CUBE_HTML_OUTPUT", "")
+    out.append(
+        f"CUBE_HTML_OUTPUT={html}\n"
+        if html
+        else "# CUBE_HTML_OUTPUT=perf_report.html\n"
+    )
+
+    target = os.path.join(_PKG_DIR, ".env")
+    try:
+        with open(target, "w", encoding="utf-8") as f:
+            f.writelines(out)
+    except OSError:
+        return
+    sys.stderr.write(
+        f"[perf] created {target}\n"
+        "  set CUBE_API_URL for a remote backend, then run python3 -m perf\n"
+    )
+
+
+def _persist_dotenv(values: "dict[str, str]") -> None:
+    """Write back the data-flow/tunable values a run actually used.
+
+    Only non-empty keys from :data:`_DATAFLOW_ENV_KEYS` or
+    :data:`_TUNABLE_ENV_KEYS` are persisted. Matching lines in the existing
+    ``.env`` (commented or not) are replaced in place; missing keys are
+    appended. All other lines (comments, scenario knobs the user added) are
+    preserved verbatim. This lets the 2nd/3rd run reuse the values — including
+    a template id that was auto-discovered, or a concurrency ladder trimmed
+    down to dodge a CubeMaster "no more resource" error. Failures are silent.
+    """
+    allowed = _DATAFLOW_ENV_KEYS + _TUNABLE_ENV_KEYS
+    values = {k: v for k, v in values.items() if k in allowed and v}
+    if not values:
+        return
+    path = _dotenv_path()
+    try:
+        with open(path, encoding="utf-8") as f:
+            lines = f.readlines()
+    except OSError:
+        lines = [_DOTENV_HEADER]
+
+    pending = dict(values)
+    out: list[str] = []
+    for line in lines:
+        key = line.lstrip("# ").partition("=")[0].strip()
+        if key in pending:
+            out.append(f"{key}={pending.pop(key)}\n")
+        else:
+            out.append(line if line.endswith("\n") else line + "\n")
+    for key, value in pending.items():  # keys not yet present in the file
+        out.append(f"{key}={value}\n")
+
+    if out == lines:  # nothing changed — avoid a pointless rewrite
+        return
+    try:
+        with open(path, "w", encoding="utf-8") as f:
+            f.writelines(out)
+    except OSError:
+        return
+
+
+def _load_dotenv() -> None:
+    """Populate os.environ from a ``.env`` file (zero-dependency).
+
+    This runs before any perf submodule reads its env-driven tunables, so a
+    ``.env`` file lets you configure the whole suite (API creds, concurrency,
+    report customization) without exporting variables by hand. Rules:
+
+    - Real environment variables always win; ``.env`` only fills in the gaps,
+      so ``CUBE_API_KEY=... python -m perf`` still overrides the file.
+    - The first ``.env`` found across these locations is used (nearest first):
+      current working dir, ``tests/perf/``, ``tests/``, ``sdk/python/``.
+    - Lines may be ``KEY=VALUE`` or ``export KEY=VALUE``; blank lines and
+      ``#`` comments are ignored; surrounding single/double quotes are stripped.
+    - ``CUBE_DOTENV`` may point at an explicit file to load instead.
+    """
+    path = next((p for p in _dotenv_candidates() if p and os.path.isfile(p)), None)
+    if not path:
+        return
+    try:
+        with open(path, encoding="utf-8") as f:
+            lines = f.readlines()
+    except OSError:
+        return
+    for line in lines:
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if line.startswith("export "):
+            line = line[len("export "):].lstrip()
+        key, sep, value = line.partition("=")
+        if not sep:
+            continue
+        key = key.strip()
+        value = value.strip()
+        if len(value) >= 2 and value[0] == value[-1] and value[0] in "\"'":
+            value = value[1:-1]
+        # Real env vars take precedence over the .env file.
+        if key and key not in os.environ:
+            os.environ[key] = value
+
+
+_ensure_dotenv()
+_load_dotenv()

--- a/tests/perf/__main__.py
+++ b/tests/perf/__main__.py
@@ -1,0 +1,497 @@
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""CLI entry point for the standalone performance benchmark suite.
+
+Usage:
+    CUBE_API_URL=... CUBE_API_KEY=... python3 -m perf              # run benchmarks, produce JSON + Markdown
+    CUBE_API_URL=... CUBE_API_KEY=... python3 -m perf --rounds 20  # run 20 rounds per scenario
+    CUBE_API_URL=... CUBE_API_KEY=... python3 -m perf --scenarios snapshot-create-from  # only cold-start-from-snapshot
+    CUBE_API_URL=... CUBE_API_KEY=... python3 -m perf --only snapshot rollback           # only selected scenarios
+    CUBE_API_URL=... CUBE_API_KEY=... python3 -m perf --only ivshmem                      # default-off scenario, no extra env needed
+    python3 -m perf --list-scenarios                              # list scenario keys/aliases
+    python3 -m perf --md-only report.json                          # re-render md + json from existing data (no backend)
+
+Optional env vars:
+    CUBE_TEMPLATE_ID         - skip auto-discovery
+    CUBE_PERF_SCENARIOS      - comma/space separated scenario keys/aliases to run (default: all)
+    CUBE_SKIP_DENSITY        - set to "1" to skip deployment density test
+    CUBE_OUTPUT_REPORT       - full base path (incl. parent dir) for output
+                               reports. Default: <perf>/report/<UTC-timestamp>/report
+    CUBE_PERF_ROUNDS         - rounds per perf scenario (default: 10)
+    CUBE_DENSITY_COUNT       - max sandbox count for density test (default: 100)
+    CUBE_RUN_VOLUME          - set to "1" to enable Volume scenarios
+    CUBE_RUN_IVSHMEM         - set to "1" to enable the ivshmem scenario (host-only)
+    CUBE_IVSHMEM_TEMPLATE_ID - ivshmem-enabled template (falls back to CUBE_TEMPLATE_ID)
+    CUBE_IVSHMEM_ITERATIONS  - mmap iterations for the ivshmem scenario (default: 10000)
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+from .reporting import report
+from .framework.config import DENSITY_COUNT, PERF_ROUNDS, resolve_config
+from .framework.env import collect_env_info
+from .framework.runner import PERF_RESULTS, reset
+
+from .framework import registry
+
+from .ops.cleanup import register_default_scripts
+register_default_scripts()
+
+
+# ---------------------------------------------------------------------------
+# Output layout
+# ---------------------------------------------------------------------------
+# Default layout (all under <perf>/report/, never in CWD):
+#
+#   tests/perf/report/
+#   ├── <UTC-timestamp>/             # per-run (one dir per invocation)
+#   │   ├── report.md
+#   │   ├── report.zh.md
+#   │   ├── report.json
+#   │   └── report.zh.json
+#   └── aggregate/                   # reserved for cross-run aggregation
+#
+# Override the base path with CUBE_OUTPUT_REPORT=<full path with .md stripped
+# by render_reports>. Useful for CI artefacts or for keeping the CWD clean.
+
+def _perf_report_root() -> Path:
+    """Absolute path to ``<perf-package>/report/``."""
+    return Path(__file__).parent.resolve() / "report"
+
+
+def _aggregate_dir() -> Path:
+    """Cross-run aggregation dir: ``<perf>/report/aggregate/``."""
+    return _perf_report_root() / "aggregate"
+
+
+def _run_output_dir() -> Path:
+    """Per-run output dir.
+
+    * Default: ``<perf>/report/<UTC-timestamp>/``
+    * Override via ``CUBE_OUTPUT_REPORT``: any full base path (with or
+      without ``.md`` / ``.json`` suffix). The parent directory of that
+      base is used as the per-run output directory.
+    """
+    env = os.environ.get("CUBE_OUTPUT_REPORT", "").strip()
+    if env:
+        p = Path(env)
+        if p.suffix:
+            p = p.with_suffix("")
+        return p.parent
+    ts = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    return _perf_report_root() / ts
+
+
+def _run_output_base() -> str:
+    """Full base path (no extension) for the current run's report files.
+
+    The parent directory is created on demand. The default base is
+    ``<perf>/report/<UTC-timestamp>/report``; the ``CUBE_OUTPUT_REPORT``
+    env var overrides the entire base (incl. parent dir) when needed.
+    """
+    out_dir = _run_output_dir()
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    env = os.environ.get("CUBE_OUTPUT_REPORT", "").strip()
+    if env:
+        p = Path(env)
+        if p.suffix:
+            p = p.with_suffix("")
+        return str(p)
+    return str(out_dir / "report")
+
+
+def _resolve_selected(cli_scenarios: "list[str] | None") -> "list[str] | None":
+    """Merge --scenarios CLI values with the CUBE_PERF_SCENARIOS env var and
+    flatten comma/space-separated tokens into a clean list. CLI wins over env;
+    returns None when neither is set (i.e. run the full suite)."""
+    raw = cli_scenarios
+    if not raw:
+        env = os.environ.get("CUBE_PERF_SCENARIOS", "").strip()
+        raw = [env] if env else None
+    if not raw:
+        return None
+    tokens: list[str] = []
+    for item in raw:
+        for part in item.replace(",", " ").split():
+            if part:
+                tokens.append(part)
+    return tokens or None
+
+
+def run_benchmarks(selected: "list[str] | None" = None) -> str:
+    """Run benchmarks (all by default, or the *selected* subset), write JSON
+    data file, return the file path."""
+    cfg = resolve_config()
+
+    # Write back the data-flow settings this run actually used (incl. an
+    # auto-discovered template id) so the 2nd/3rd run reuses them without any
+    # re-exporting — just `python3 -m perf`.
+    from . import _persist_dotenv, _TUNABLE_ENV_KEYS
+
+    persisted = {
+        "CUBE_API_URL": cfg.api_url,
+        "CUBE_API_KEY": os.environ.get("CUBE_API_KEY")
+        or os.environ.get("E2B_API_KEY", ""),
+        "CUBE_TEMPLATE_ID": cfg.template_id or "",
+        "CUBE_PROXY_NODE_IP": cfg.proxy_node_ip or "",
+        "CUBE_PROXY_PORT_HTTP": str(cfg.proxy_port),
+        "CUBE_SANDBOX_DOMAIN": cfg.sandbox_domain,
+    }
+    # Run tunables (concurrency ladders, rounds, density count, ...): only
+    # persist keys explicitly set for *this* run (real env var, e.g. exported
+    # to dodge a CubeMaster "no more resource" error, or already loaded from
+    # a previous .env write-back) — never bake in an untouched internal
+    # default. See framework/config.py for the actual defaults.
+    persisted.update(
+        (key, os.environ[key]) for key in _TUNABLE_ENV_KEYS if os.environ.get(key)
+    )
+    _persist_dotenv(persisted)
+
+    print("=" * 60)
+    print(" Python SDK Performance Benchmark Suite")
+    print("=" * 60)
+
+    # --- Environment info ---
+    print("\nCollecting environment information ...")
+    env = collect_env_info(cfg)
+    print(f"  Host: {env.hostname} | CPU: {env.cpu_model[:60] if env.cpu_model else 'N/A'}")
+    print(f"  Cores: {env.cpu_cores_logical} logical ({env.cpu_sockets}S×{env.cpu_cores_physical}C×2T) | "
+          f"Memory: {env.memory_total_gb} GiB | Disk: {env.disk_size_gb} GB {env.disk_type}")
+
+    # --- Performance benchmarks ---
+    print("\n" + "=" * 60)
+    print(" PERFORMANCE BENCHMARKS")
+    print("=" * 60)
+    print(f"  Rounds per scenario: {PERF_ROUNDS}")
+    print(f"  Density max count: {DENSITY_COUNT}")
+    print()
+
+    registry.run_all(cfg, selected=selected)
+
+    # --- Resolve output paths (default: <perf>/report/<ts>/report) ---
+    base = _run_output_base()
+    out_dir = Path(base).parent
+
+    # --- Write JSON data (per-run snapshot, also serves as "latest") ---
+    data = report.build_report_data(env)
+    json_path = f"{base}.json"
+
+    import json
+
+    with open(json_path, "w", encoding="utf-8") as f:
+        json.dump(data, f, ensure_ascii=False, indent=2)
+
+    print(f"\n📄 JSON data saved to: {os.path.abspath(json_path)}")
+    print(f"📁 Run output dir:     {out_dir}")
+
+    # --- Also write MD + zh.json reports (same dir, same base) ---
+    written = report.write_reports(env, base=base)
+    for path in written:
+        print(f"   - {path}")
+
+    # --- Touch the aggregate dir so cross-run tools can find it later ---
+    _aggregate_dir().mkdir(parents=True, exist_ok=True)
+
+    print(f"\n{'='*60}")
+    print(f"  {len(PERF_RESULTS)} performance scenarios collected")
+    print(f"{'='*60}")
+
+    # Per-concurrency-level cleanup is handled inside registry._bench()
+    # via _post_concurrency_cleanup(). A final sweep here is a no-op.
+
+    return json_path
+
+
+def _run_external_scripts(
+    scripts_dir: str,
+    rounds: int,
+    concurrency_levels: "tuple[int, ...] | None" = None,
+) -> None:
+    """Run every ``.py`` file in *scripts_dir* N times via subprocess.
+
+    For each concurrency level in *concurrency_levels* the scripts are
+    invoked in parallel threads (each thread spawns its own subprocess);
+    wall‑clock time is measured per invocation and aggregated into the
+    same avg / min / p95 / max stats the main suite uses.
+
+    Zero‑coupling: scripts don't import anything from the framework — they
+    just need to exit 0 on success.
+    """
+    import subprocess
+    import time
+    from concurrent.futures import ThreadPoolExecutor, as_completed
+    from pathlib import Path
+
+    levels = concurrency_levels or (1,)
+
+    sd = Path(scripts_dir).expanduser().resolve()
+    if not sd.is_dir():
+        sys.exit(f"Error: '{sd}' is not a directory")
+
+    py_files = sorted(sd.glob("*.py"))
+    if not py_files:
+        sys.exit(f"No .py files found in '{sd}'")
+
+    print(f"Scripts dir     : {sd}")
+    print(f"Files           : {len(py_files)}")
+    print(f"Rounds          : {rounds}")
+    print(f"Concurrency     : {', '.join(str(c) for c in levels)}")
+    print(f"{'='*60}")
+
+    all_results: list[dict] = []
+
+    for pf in py_files:
+        name = pf.stem
+        print(f"\n [Run] {name}")
+        for concurrency in levels:
+            times: list[float] = []
+            errors = 0
+            wall_start = time.time()
+
+            def _invoke():
+                t0 = time.time()
+                try:
+                    proc = subprocess.run(
+                        [sys.executable, str(pf)],
+                        capture_output=True, text=True, timeout=300,
+                        cwd=str(sd),
+                    )
+                except subprocess.TimeoutExpired:
+                    return (time.time() - t0) * 1000, None, "TIMEOUT"
+                elapsed = (time.time() - t0) * 1000
+                if proc.returncode != 0:
+                    err = (proc.stderr or "").strip()
+                    return elapsed, proc.returncode, err[:200] if err else "ERR"
+                return elapsed, 0, None
+
+            with ThreadPoolExecutor(max_workers=concurrency) as ex:
+                futs = [ex.submit(_invoke) for _ in range(rounds)]
+                for i, fut in enumerate(as_completed(futs), 1):
+                    elapsed, rc, err = fut.result()
+                    if rc is None:  # timeout
+                        errors += 1
+                        print(f"  c={concurrency:>2} run {i:>2}/{rounds}: {elapsed:.0f}ms TIMEOUT")
+                    elif rc != 0:
+                        errors += 1
+                        print(f"  c={concurrency:>2} run {i:>2}/{rounds}: {elapsed:.1f}ms ERR(rc={rc})")
+                        if err:
+                            print(f"       stderr: {err}")
+                    else:
+                        times.append(elapsed)
+
+            wall_ms = (time.time() - wall_start) * 1000
+            if times:
+                times.sort()
+                n = len(times)
+                avg = sum(times) / n
+                p50_val = times[int(n * 0.5)]
+                p95_val = times[min(int(n * 0.95), n - 1)]
+                per_ms = wall_ms / n if n > 0 else 0
+                print(f"  concurrency={concurrency:>2}: avg={avg:.1f}ms "
+                      f"min={times[0]:.1f}ms p95={p95_val:.1f}ms "
+                      f"max={times[-1]:.1f}ms "
+                      f"wall={wall_ms:.0f}ms per={per_ms:.1f}ms"
+                      + (f"  errors={errors}" if errors else ""))
+                all_results.append({
+                    "name": name, "file": str(pf),
+                    "concurrency": concurrency,
+                    "avg_ms": round(avg, 2),
+                    "p50_ms": round(p50_val, 2),
+                    "p95_ms": round(p95_val, 2),
+                    "min_ms": round(times[0], 2),
+                    "max_ms": round(times[-1], 2),
+                    "wall_ms": round(wall_ms, 2),
+                    "per_ms": round(per_ms, 2),
+                    "rounds": n, "errors": errors,
+                })
+            else:
+                print(f"  concurrency={concurrency:>2}: ALL FAILED (errors={errors})")
+
+    # Summary
+    print(f"\n{'='*72}")
+    header_fmt = f"{'Script':<30} {'c':>3} {'avg':>8} {'min':>8} {'p95':>8} {'max':>8} {'wall':>8} {'per':>8}"
+    print(header_fmt)
+    print(f"{'-'*30} {'-'*3} {'-'*8} {'-'*8} {'-'*8} {'-'*8} {'-'*8} {'-'*8}")
+    for r in all_results:
+        print(f"{r['name']:<30} {r['concurrency']:>3} "
+              f"{r['avg_ms']:>8.1f} {r['min_ms']:>8.1f} {r['p95_ms']:>8.1f} "
+              f"{r['max_ms']:>8.1f} {r['wall_ms']:>8.0f} {r['per_ms']:>8.1f}")
+    if all_results:
+        errors_total = sum(r.get("errors", 0) for r in all_results)
+        if errors_total:
+            print(f"\n  {errors_total} error(s) total")
+    print(f"{'='*72}")
+
+    if all_results:
+        out = sd / "perf_scripts.json"
+        with open(out, "w", encoding="utf-8") as f:
+            json.dump(all_results, f, ensure_ascii=False, indent=2)
+        print(f"Results saved to: {out}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="CubeSandbox Python SDK Performance Benchmark Suite",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  CUBE_API_URL=... CUBE_API_KEY=... python3 -m perf
+  CUBE_API_URL=... CUBE_API_KEY=... python3 -m perf --rounds 20
+  CUBE_API_URL=... CUBE_API_KEY=... python3 -m perf --scenarios snapshot-create-from
+  CUBE_API_URL=... CUBE_API_KEY=... python3 -m perf --only snapshot rollback
+  CUBE_API_URL=... CUBE_API_KEY=... python3 -m perf --scenarios all no-ivshmem
+  python3 -m perf --list-scenarios
+  python3 -m perf --md-only report.json
+        """,
+    )
+    parser.add_argument(
+        "--md-only",
+        metavar="JSON_FILE",
+        help="parse an existing JSON data file and re-render the Markdown + JSON "
+        "reports (no benchmarks run, no backend required)",
+    )
+    parser.add_argument(
+        "--rounds",
+        type=int,
+        default=None,
+        help=f"override CUBE_PERF_ROUNDS (default: {PERF_ROUNDS})",
+    )
+    parser.add_argument(
+        "--scenarios",
+        "--only",
+        dest="scenarios",
+        nargs="+",
+        metavar="SCENARIO",
+        default=None,
+        help="run only the given scenario(s); accepts keys or aliases, "
+        "comma/space separated, and 'no-<key>' to exclude "
+        "(e.g. --scenarios snapshot-create-from, --only snapshot, "
+        "--scenarios all no-ivshmem). Explicitly naming a default-off scenario "
+        "(e.g. --only ivshmem / volume) auto-enables it, so its opt-in env "
+        "(CUBE_RUN_IVSHMEM / CUBE_RUN_VOLUME) is no longer required. "
+        "Overrides CUBE_PERF_SCENARIOS. Use --list-scenarios to see all choices.",
+    )
+    parser.add_argument(
+        "--cleanup",
+        action="store_true",
+        help="delete all snap-* snapshot templates from the backend before running benchmarks",
+    )
+    parser.add_argument(
+        "--cleanup-dry-run",
+        action="store_true",
+        help="list snap-* snapshots that --cleanup would delete, then exit",
+    )
+    parser.add_argument(
+        "--cleanup-older-than",
+        type=int,
+        default=0,
+        metavar="MINUTES",
+        help="with --cleanup, only delete snapshots older than N minutes",
+    )
+    parser.add_argument(
+        "--scripts",
+        metavar="DIR",
+        default=None,
+        help="run all .py files in DIR as standalone scripts, measuring "
+        "wall-clock time of each invocation (no concurrency, pure "
+        "subprocess), then print stats — zero framework coupling",
+    )
+    parser.add_argument(
+        "--list-scenarios",
+        action="store_true",
+        help="list available benchmark scenario keys/aliases and exit",
+    )
+
+    args = parser.parse_args()
+
+    # --scripts DIR: run raw .py files as-is and collect timing stats.
+    if args.scripts:
+        c_str = os.environ.get("CUBE_CREATE_CONCURRENCY") \
+            or os.environ.get("CUBE_PERF_CONCURRENCY", "1")
+        try:
+            levels = tuple(int(x.strip()) for x in c_str.split(","))
+        except Exception:
+            levels = (1,)
+        _run_external_scripts(
+            args.scripts,
+            rounds=args.rounds or PERF_ROUNDS,
+            concurrency_levels=levels,
+        )
+        return
+
+    # --list-scenarios: print available scenario keys/aliases and exit.
+    if args.list_scenarios:
+        print("Available scenarios (canonical keys):")
+        for key in registry.BENCHMARK_REGISTRY:
+            print(f"  {key}")
+        print("\nAliases:")
+        for alias, keys in registry.BENCHMARK_ALIASES.items():
+            print(f"  {alias:<20} -> {', '.join(keys)}")
+        print("\nExclude a scenario with a 'no-'/'skip-' prefix, e.g. "
+              "--scenarios all no-ivshmem")
+        return
+
+    # Override rounds if specified
+    if args.rounds is not None:
+        os.environ["CUBE_PERF_ROUNDS"] = str(args.rounds)
+        from .framework import config as _cfg
+
+        _cfg.PERF_ROUNDS = args.rounds
+
+    # --md-only mode: no benchmarks, just re-render md/json from existing data
+    if args.md_only:
+        base = _run_output_base()
+        written = report.render_from_json(args.md_only, base=base)
+        print(f"Re-rendered reports from {args.md_only}:")
+        for path in written:
+            print(f"   - {path}")
+        return
+
+    # --cleanup-dry-run: list snapshots only, then exit
+    if args.cleanup_dry_run or args.cleanup:
+        from .ops.cleanup import list_snapshots, delete_snapshots, cleanup_all_sandboxes
+
+        if not args.cleanup_dry_run:
+            # Kill all sandboxes first, then clean snapshots
+            cleanup_all_sandboxes(label=" [cleanup]")
+
+        snaps = list_snapshots()
+        if not snaps:
+            print("No snap-* snapshot templates found.")
+        else:
+            print(f"\nFound {len(snaps)} snap-* snapshot templates:")
+            for s in snaps:
+                print(f"  {s['templateID']:<36} {s.get('status',''):<12} {s.get('createdAt','')}")
+            if args.cleanup_dry_run:
+                print("\n[DRY RUN] Remove --cleanup-dry-run and use --cleanup to delete.")
+            else:
+                ids = [s["templateID"] for s in snaps]
+                print(f"\nDeleting {len(ids)} snapshots ...")
+                ok, fail = delete_snapshots(ids)
+                print(f"Done: {ok} deleted, {fail} failed.\n")
+        if args.cleanup_dry_run:
+            return
+
+    # Default mode: run benchmarks
+    selected = _resolve_selected(args.scenarios)
+    # Validate selection early (raises with a helpful message on typos).
+    try:
+        registry.select_benchmarks(selected)
+    except ValueError as exc:
+        sys.exit(f"error: {exc}")
+
+    reset()
+    json_path = run_benchmarks(selected=selected)
+
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/perf/docs/guide/perf-design.md
+++ b/tests/perf/docs/guide/perf-design.md
@@ -1,0 +1,148 @@
+# CubeSandbox Perf — Integration Contract
+
+`tests/perf` is the CubeSandbox performance benchmark suite. This document defines the contract between benchmark scripts and the framework.
+
+Follow this contract and scripts automatically get concurrency scheduling, metric collection, and Markdown report generation.
+
+## Quick Start
+
+```bash
+cd CubeSandbox/tests
+cp perf/.env.example perf/.env      # edit with CUBE_API_URL / CUBE_TEMPLATE_ID
+python3 -m perf
+```
+
+## CLI Contract
+
+The framework invokes scripts via `subprocess`:
+
+```bash
+python bench_xxx.py -c <concurrency> -n <operations> --rounds <rounds> --no-header
+```
+
+| Flag | Required | Description |
+|------|:--------:|-------------|
+| `-c N` | Yes | Concurrency level |
+| `-n N` | Yes | Operations per round |
+| `--rounds N` | No | Internal rounds (defaults to `-n`) |
+| `--no-header` | No | Suppress repeated table headers |
+
+Script `stdout` is displayed to the user, `stderr` goes to the log. Exit code 0 = success.
+
+## Metadata Convention
+
+The framework parses module-level variables from the script source. All are optional:
+
+### METRICS
+
+Declares statistic columns in the report table. Defaults to `avg`, `min`, `p50`, `p95`, `p99`, `max`:
+
+```python
+METRICS = ("avg", "min", "p95", "max")
+```
+
+### REPORT
+
+Customises report table rendering:
+
+```python
+REPORT = {
+    "method_en": "Create Sandbox",
+    "method_zh": "创建沙箱",
+    "noun_en":    "op",
+    "noun_zh":    "次",
+    "throughput": True,
+    "table":      "latency",     # latency | dirty
+    "star":       True,
+}
+```
+
+Full field reference:
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `table` | `str` | `"latency"` | Table type: `latency` or `dirty` |
+| `method_en` | `str` | `""` | Operation description (English) |
+| `method_zh` | `str` | `""` | Operation description (Chinese) |
+| `noun_en` | `str` | `""` | Operation unit, e.g. `"op"` |
+| `noun_zh` | `str` | `""` | Operation unit, e.g. `"次"` |
+| `throughput` | `bool` | `False` | Show throughput column |
+| `star` | `bool` | `False` | Mark as starred |
+
+### LEVELS
+
+Overrides the global concurrency gradient:
+
+```python
+LEVELS = (1, 10, 20, 50)
+```
+
+Defaults to `CUBE_PERF_CONCURRENCY` from `.env`.
+
+## Full Example
+
+```python
+# bench_clone.py
+"""Clone Concurrency"""               # first line → report title
+
+METRICS = ("avg", "min", "p50", "p95", "p99", "max")
+
+REPORT = {
+    "method_en": "Clone Sandbox",
+    "method_zh": "克隆沙箱",
+    "noun_en":    "op",
+    "noun_zh":    "次",
+    "throughput": True,
+}
+
+LEVELS = (1, 5, 10, 20)
+
+import argparse
+ap = argparse.ArgumentParser()
+ap.add_argument("-c", type=int, default=1)
+ap.add_argument("-n", type=int, default=5)
+ap.add_argument("--rounds", type=int, default=3)
+ap.add_argument("--no-header", action="store_true")
+args = ap.parse_args()
+
+from cubesandbox import Sandbox
+sb = Sandbox.create("tpl-xxx")
+sb.clone(n=args.n, concurrency=args.c)
+sb.kill()
+```
+
+## Decorator Usage (Advanced)
+
+The framework wraps external scripts via `register_external()`, which internally uses `@benchmark` to manage scenario registration. Normal scripts don't need this — just register in `.env`.
+
+If you need to register a scenario programmatically:
+
+```python
+from cubesandbox.perf import register_external
+
+register_external(
+    "my-scenario",
+    "path/to/bench_my_scenario.py",
+    title="My Scenario",
+    levels=(1, 10, 20, 50),
+    metrics=("avg", "p95", "max"),
+    method_en="My Operation",
+    noun_en="op",
+    throughput=True,
+)
+```
+
+The framework converts parameters into a `ReportSection` and appends it to `REPORT_SECTIONS`, which the report renderer reads to generate Markdown tables.
+
+## Registering Scripts
+
+Set `CUBE_EXTERNAL_SCRIPTS` in `tests/perf/.env`. Supports glob patterns:
+
+```bash
+CUBE_EXTERNAL_SCRIPTS=../examples/snapshot-rollback-clone/bench_*.py
+```
+
+The framework then:
+1. Lists scenarios via `--list-scenarios`
+2. Schedules concurrency gradients from `LEVELS`
+3. Collects latency metrics and generates Markdown reports

--- a/tests/perf/docs/guide/perf-design.zh.md
+++ b/tests/perf/docs/guide/perf-design.zh.md
@@ -1,0 +1,148 @@
+# CubeSandbox Perf — 脚本集成契约
+
+`tests/perf` 是 CubeSandbox 性能基准测试套件。本文档定义压测脚本与框架之间的约定。
+
+遵循此契约，脚本自动获得并发调度、指标采集和 Markdown 报告生成。
+
+## 快速开始
+
+```bash
+cd CubeSandbox/tests
+cp perf/.env.example perf/.env      # 编辑填入 CUBE_API_URL / CUBE_TEMPLATE_ID
+python3 -m perf
+```
+
+## CLI 契约
+
+框架通过 `subprocess` 调用脚本，传递以下参数：
+
+```bash
+python bench_xxx.py -c <并发度> -n <操作数> --rounds <轮数> --no-header
+```
+
+| 参数 | 必选 | 说明 |
+|------|:---:|------|
+| `-c N` | 是 | 并发度，框架按 `LEVELS` 或全局阶梯逐一调用 |
+| `-n N` | 是 | 每轮操作数 |
+| `--rounds N` | 否 | 脚本内部轮数（默认同 `-n`） |
+| `--no-header` | 否 | 抑制重复表头 |
+
+脚本 `stdout` 展示给用户，`stderr` 输出到日志。退出码 0 代表成功。
+
+## 元数据约定
+
+框架解析脚本源码中的模块级变量获取报告元数据。以下均为可选：
+
+### METRICS
+
+声明报告表格的指标列。未声明时使用默认列集（`avg`, `min`, `p50`, `p95`, `p99`, `max`）：
+
+```python
+METRICS = ("avg", "min", "p95", "max")
+```
+
+### REPORT
+
+声明报告表格的展示方式：
+
+```python
+REPORT = {
+    "method_zh": "创建沙箱",        # 操作方法中文名
+    "method_en": "Create Sandbox",  # 操作方法英文名
+    "noun_zh":    "次",             # 计量单位中文
+    "noun_en":    "op",             # 计量单位英文
+    "throughput": True,             # 显示吞吐量列
+    "table":      "latency",        # 表格类型: latency | dirty
+    "star":       True,             # 标记为星标场景
+}
+```
+
+全部支持的字段：
+
+| 字段 | 类型 | 默认值 | 说明 |
+|------|------|--------|------|
+| `table` | `str` | `"latency"` | 表格类型：`latency`（延迟分布）或 `dirty`（脏页） |
+| `method_zh` | `str` | `""` | 操作方法中文描述 |
+| `method_en` | `str` | `""` | 操作方法英文描述 |
+| `noun_zh` | `str` | `""` | 操作计量单位中文，如 `"次"` |
+| `noun_en` | `str` | `""` | 操作计量单位英文，如 `"op"` |
+| `throughput` | `bool` | `False` | 是否显示吞吐量列（`个/s`） |
+| `star` | `bool` | `False` | 是否星标 |
+
+### LEVELS
+
+覆盖全局并发度阶梯：
+
+```python
+LEVELS = (1, 10, 20, 50)
+```
+
+未声明时使用 `.env` 中的 `CUBE_PERF_CONCURRENCY`。
+
+## 完整示例
+
+```python
+# bench_clone.py
+"""Clone Concurrency"""               # 首行 → 报告标题
+
+METRICS = ("avg", "min", "p50", "p95", "p99", "max")
+
+REPORT = {
+    "method_zh": "克隆沙箱",
+    "method_en": "Clone Sandbox",
+    "noun_zh":    "次",
+    "noun_en":    "op",
+    "throughput": True,
+}
+
+LEVELS = (1, 5, 10, 20)
+
+import argparse
+ap = argparse.ArgumentParser()
+ap.add_argument("-c", type=int, default=1)
+ap.add_argument("-n", type=int, default=5)
+ap.add_argument("--rounds", type=int, default=3)
+ap.add_argument("--no-header", action="store_true")
+args = ap.parse_args()
+
+from cubesandbox import Sandbox
+sb = Sandbox.create("tpl-xxx")
+sb.clone(n=args.n, concurrency=args.c)
+sb.kill()
+```
+
+## 装饰器用法（高级）
+
+框架内部通过 `register_external()` 函数将外部脚本封装为 `@benchmark` 装饰器管理的场景。普通脚本无需关心此用法——在 `.env` 注册即可。
+
+如果需要在代码中显式注册场景（如动态生成压测参数），可直接调用装饰器：
+
+```python
+from cubesandbox.perf import register_external
+
+register_external(
+    "my-scenario",
+    "path/to/bench_my_scenario.py",
+    title="My Scenario",
+    levels=(1, 10, 20, 50),
+    metrics=("avg", "p95", "max"),
+    method_zh="我的操作",
+    noun_zh="次",
+    throughput=True,
+)
+```
+
+框架内部自动将参数转为 `ReportSection` 并注入 `REPORT_SECTIONS` 列表，报告渲染器按列表生成表格。
+
+## 注册脚本
+
+在 `tests/perf/.env` 中配置 `CUBE_EXTERNAL_SCRIPTS`，支持 glob pattern：
+
+```bash
+CUBE_EXTERNAL_SCRIPTS=../examples/snapshot-rollback-clone/bench_*.py
+```
+
+注册后框架自动：
+1. `--list-scenarios` 列出场景
+2. 执行时按 `LEVELS` 调度并发度
+3. 采集延迟并生成 Markdown 报告

--- a/tests/perf/framework/__init__.py
+++ b/tests/perf/framework/__init__.py
@@ -1,0 +1,50 @@
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""Framework barrel — one import to write a new benchmark.
+
+    from framework import perf_test, op
+
+    @perf_test("my-scenario", title="My Scenario", levels=(1, 5, 10))
+    def bench(cfg, concurrency, n):
+        yield op.sandbox(cfg, lambda sb: sb.exec("whoami"))
+"""
+
+from .registry import (
+    auto,
+    benchmark,
+    parallel_sweep,
+    perf_test,
+    register_external,
+    sandbox_benchmark,
+    ReportGroup,
+)
+from .runner import (
+    sandbox as _raw_sandbox,
+    sandbox_op as _raw_sandbox_op,
+    snapshot_op as _raw_snapshot_op,
+)
+
+
+class _Ops:
+    """Minimal namespace so ``op.sandbox`` reads naturally.
+
+    ``op.sandbox(cfg, fn)``  →  yieldable, pool‑based sandbox benchmark op.
+    ``op.snapshot(cfg, fn)``  →  yieldable, pool‑based snapshot benchmark op.
+    """
+
+    sandbox = staticmethod(_raw_sandbox_op)
+    snapshot = staticmethod(_raw_snapshot_op)
+
+    @staticmethod
+    def context(cfg, template_id=None, **create_opts):
+        """Context-manager sandbox for single‑shot benchmarks.
+
+        Usage::
+
+            with op.context(cfg) as sb:
+                print(sb.exec("whoami"))
+        """
+        return _raw_sandbox(cfg, template_id, **create_opts)
+
+
+op = _Ops()

--- a/tests/perf/framework/config.py
+++ b/tests/perf/framework/config.py
@@ -1,0 +1,106 @@
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""Configuration resolution & runtime tunables for the e2e test suite."""
+
+from __future__ import annotations
+
+import os
+import sys
+
+from cubesandbox import Config
+
+# ---------------------------------------------------------------------------
+# Tunables (env-driven)
+# ---------------------------------------------------------------------------
+
+
+def _parse_int_list(env_name: str, default: list[int]) -> list[int]:
+    """Parse a comma-separated int list from *env_name*, falling back to *default*."""
+    raw = os.environ.get(env_name)
+    if not raw:
+        return list(default)
+    try:
+        parsed = [int(x.strip()) for x in raw.split(",") if x.strip()]
+        return parsed or list(default)
+    except ValueError:
+        return list(default)
+
+
+PERF_ROUNDS = int(os.environ.get("CUBE_PERF_ROUNDS", "10"))
+DENSITY_COUNT = int(os.environ.get("CUBE_DENSITY_COUNT", "100"))
+
+# Warm-up rounds discarded before measured rounds (removes cold-start spikes),
+# and settle seconds slept between rounds (lets the node quiesce). Mirrors the
+# methodology of the standalone examples/snapshot-rollback-clone bench scripts.
+PERF_WARMUP = int(os.environ.get("CUBE_PERF_WARMUP", "1"))
+PERF_SETTLE = float(os.environ.get("CUBE_PERF_SETTLE", "0"))
+
+# Dirty-page write sizes (MB) swept by the snapshot-dirty scenario. Matches the
+# published baseline sweep; override via CUBE_DIRTY_SWEEP, e.g. "0,100,1024".
+DIRTY_SWEEP = _parse_int_list("CUBE_DIRTY_SWEEP", [0, 10, 50, 100, 200, 500, 800, 1024])
+
+# Concurrency ladders, matching the published benchmark report
+# (cubesandbox.com/zh/blog "CubeSandbox 核心操作性能基准测试报告"):
+#   - the "light" ladder 1/5/10 for the snapshot-create / rollback / pause-resume
+#     scenarios (report §4.1 / §4.4 / §4.6);
+#   - the "create" ladder 1/10/20/50 for the heavier template-create /
+#     create-from-snapshot / clone scenarios (report §3.2 / §4.3 / §4.5).
+# Override via CUBE_PERF_CONCURRENCY / CUBE_CREATE_CONCURRENCY. On a small node
+# the top levels may hit CubeMaster error 130597 ("no more resource"); trim the
+# ladders there.
+CONCURRENCY_LEVELS = _parse_int_list("CUBE_PERF_CONCURRENCY", [1, 5, 10])
+CREATE_CONCURRENCY_LEVELS = _parse_int_list("CUBE_CREATE_CONCURRENCY", [1, 10, 20, 50])
+
+# Node-local cleanup of residual micro-VMs (mvm) between rounds. Perf runs leak
+# residual sandboxes that the SDK ``kill()`` does not always reap, eventually
+# exhausting node resources. We shell out to the node-local cubecli to force a
+# clean cold-start state before each measured round.
+#   CUBE_PERF_CLEANUP  - set to "0" to disable (default: enabled)
+#   CUBE_CLEANUP_CMD   - override the cleanup command
+CLEANUP_ENABLED = os.environ.get("CUBE_PERF_CLEANUP", "1") != "0"
+CLEANUP_CMD = os.environ.get("CUBE_CLEANUP_CMD", "echo y | cubecli unsafe destroyall -f")
+
+
+def resolve_config() -> Config:
+    """Resolve a `Config` from environment variables, auto-discovering a
+    READY template if `CUBE_TEMPLATE_ID` is not set.
+    """
+    # CUBE_API_URL is optional: when unset the SDK Config defaults to the
+    # local CubeAPI at http://127.0.0.1:3000, so `python3 -m perf` works
+    # out of the box against a local backend. Point it elsewhere via
+    # CUBE_API_URL (env or .env) to hit a remote deployment.
+    cfg = Config()
+
+    if not cfg.template_id:
+        print("Discovering a READY template ...")
+        import httpx
+
+        try:
+            headers = {}
+            api_key = os.environ.get("CUBE_API_KEY") or os.environ.get("E2B_API_KEY", "")
+            if api_key:
+                headers["Authorization"] = f"Bearer {api_key}"
+            resp = httpx.get(
+                f"{cfg.api_url}/templates",
+                headers=headers,
+                timeout=15,
+            )
+            resp.raise_for_status()
+            templates = resp.json()
+            for t in templates:
+                if t.get("templateID") and t.get("status", "").upper() == "READY":
+                    cfg.template_id = t["templateID"]
+                    break
+            if not cfg.template_id and templates:
+                cfg.template_id = templates[0].get("templateID") or ""
+        except Exception as exc:
+            sys.exit(f"Failed to discover template from {cfg.api_url}: {exc}")
+        if not cfg.template_id:
+            sys.exit("No READY templates found; set CUBE_TEMPLATE_ID")
+
+    print(f"Target API : {cfg.api_url}")
+    print(f"Template   : {cfg.template_id}")
+    if cfg.proxy_node_ip:
+        print(f"Proxy      : {cfg.proxy_node_ip}:{cfg.proxy_port}")
+    print()
+    return cfg

--- a/tests/perf/framework/env.py
+++ b/tests/perf/framework/env.py
@@ -1,0 +1,613 @@
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""Environment info collection: host machine, CPU, memory, disk, template metadata."""
+
+from __future__ import annotations
+
+import os
+import platform
+import subprocess
+import sys
+from dataclasses import dataclass
+from datetime import datetime, timezone
+
+import cubesandbox
+from cubesandbox import Config, Template
+
+
+@dataclass
+class EnvInfo:
+    """Collected environment information."""
+
+    hostname: str = ""
+    machine_type: str = ""      # "腾讯云 BMSA5" / "Tencent Cloud BMSA5" etc.
+    ip_address: str = ""        # primary non-loopback IPv4
+    os_name: str = ""
+    os_distro: str = ""         # "Ubuntu 22.04 LTS" / "TencentOS Server 3.1"
+    os_version: str = ""
+    kernel: str = ""
+    arch: str = ""
+    cpu_model: str = ""
+    cpu_cores_physical: int = 0
+    cpu_cores_logical: int = 0
+    cpu_sockets: int = 0
+    numa_nodes: int = 0
+    memory_total_gb: float = 0
+    memory_type: str = ""
+    disk_model: str = ""
+    disk_size_gb: float = 0
+    disk_fs: str = ""
+    disk_type: str = ""
+    gcc_version: str = ""       # `gcc --version` first line (e.g. "gcc 11.4.0")
+    python_version: str = ""
+    sdk_version: str = ""
+    api_url: str = ""
+    template_id: str = ""
+    template_image: str = ""
+    template_instance_type: str = ""
+    template_status: str = ""
+    template_cpu: int = 0
+    template_memory_mb: int = 0
+    template_spec: str = ""
+    timestamp: str = ""
+    # Component versions (existing, kept for backward compat with report.py)
+    cubeapi_version: str = ""
+    cubeapi_commit: str = ""
+    cubeapi_build_time: str = ""
+    cubeapi_go_version: str = ""
+    cubemaster_version: str = ""
+    cubemaster_commit: str = ""
+    cubemaster_build_time: str = ""
+    cubelet_version: str = ""
+    cube_shim_version: str = ""
+    guest_image_version: str = ""
+    kernel_version_node: str = ""
+    # Release manifest (single source of truth on installed hosts:
+    # /usr/local/services/cubetoolbox/release-manifest.json)
+    release_version: str = ""          # e.g. "v1.0.0" — git tag of the release
+    release_built_at: str = ""
+    release_built_by: str = ""          # "github-actions" | "manual"
+    release_git_commit: str = ""
+    release_manifest_path: str = ""     # path we actually read, for debugging
+    # Extra component versions (declared in the release manifest)
+    cubemastercli_version: str = ""
+    cubecli_version: str = ""
+    network_agent_version: str = ""
+    cube_agent_version: str = ""        # guest-side Rust agent
+    cube_runtime_version: str = ""      # CubeShim/cube-runtime
+    cube_egress_version: str = ""
+    cube_proxy_version: str = ""
+    cube_lifecycle_manager_version: str = ""
+    # Guest image + kernel (declared)
+    guest_agent_version: str = ""       # cube-agent version baked into the guest image
+    guest_image_digest: str = ""
+    guest_image_base: str = ""
+    kernel_digest: str = ""
+    kernel_pvm_version: str = ""
+    kernel_pvm_digest: str = ""
+    # SDK / Python details
+    processor: str = ""
+    platform_summary: str = ""
+    python_impl: str = ""
+    sdk_import_path: str = ""
+    httpx_version: str = ""
+    requests_version: str = ""
+
+
+def run_cmd(cmd: list[str]) -> str:
+    """Run a shell command and return stdout, or '' on failure."""
+    try:
+        return subprocess.check_output(cmd, stderr=subprocess.DEVNULL, timeout=10).decode("utf-8", errors="replace").strip()
+    except Exception:
+        return ""
+
+
+def get_free_mem_gb() -> float:
+    """Return currently available memory in GiB (Linux only, 0 otherwise)."""
+    mem_kb = run_cmd(["sh", "-c", "grep MemAvailable /proc/meminfo | awk '{print $2}'"])
+    return round(int(mem_kb) / (1024 * 1024), 2) if mem_kb.isdigit() else 0
+
+
+def _detect_primary_ipv4() -> str:
+    """Return the primary non-loopback IPv4 address of this host.
+
+    Uses a UDP socket "trick" (connect to a public IP, read the local end of
+    the ephemeral socket) so it works without a route to the internet — the
+    UDP connect is stateless.  Returns "" on any failure so callers can render
+    "-" instead of raising.
+    """
+    import socket
+
+    try:
+        with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as s:
+            # 8.8.8.8 is a canonical "somewhere non-local" endpoint; we never
+            # send anything, we just need the kernel to pick a source IP.
+            s.connect(("8.8.8.8", 80))
+            ip = s.getsockname()[0]
+            if ip and not ip.startswith("127."):
+                return ip
+    except OSError:
+        pass
+
+    # Fallback: `hostname -I` first non-loopback token (Linux only).
+    out = run_cmd(["sh", "-c", "hostname -I 2>/dev/null | tr ' ' '\\n' | grep -v '^127\\.' | head -n1"])
+    return out or ""
+
+
+def _detect_machine_type() -> str:
+    """Best-effort detection of the machine model / cloud instance type.
+
+    Prefers Tencent Cloud metadata (matches the fleet this perf suite targets),
+    falls back to DMI product name (bare-metal / other clouds), then to a
+    virt-what hint.  Returns "" when nothing can be determined.
+    """
+    # 1) Tencent Cloud CVM metadata: instance-name is the human label
+    #    (e.g. "SA5.MEDIUM8"). 169.254.0.23 is TC's IMDS.
+    for path in ("instance/instance-type", "instance/family"):
+        out = run_cmd([
+            "sh", "-c",
+            f"curl -sS --max-time 1 http://metadata.tencentyun.com/latest/meta-data/{path}",
+        ])
+        if out and not out.startswith("<") and "not found" not in out.lower():
+            return f"腾讯云 {out}"
+
+    # 2) DMI product name (bare-metal servers / VMware / KVM / etc.)
+    for path in ("/sys/class/dmi/id/product_name", "/sys/class/dmi/id/product_family"):
+        out = run_cmd(["sh", "-c", f"cat {path} 2>/dev/null"])
+        if out and out.lower() not in ("none", "to be filled by o.e.m.", "not specified", "system product name"):
+            return out
+
+    # 3) virt-what — coarse hypervisor hint if all else fails.
+    out = run_cmd(["sh", "-c", "sudo -n virt-what 2>/dev/null | head -n1"])
+    return out or ""
+
+
+def _read_os_release_pretty() -> str:
+    """Return PRETTY_NAME from /etc/os-release (e.g. "Ubuntu 22.04.4 LTS").
+
+    Fallbacks: /etc/lsb-release DISTRIB_DESCRIPTION, then "".
+    """
+    for path in ("/etc/os-release", "/usr/lib/os-release"):
+        try:
+            with open(path, encoding="utf-8") as f:
+                for line in f:
+                    if line.startswith("PRETTY_NAME="):
+                        return line.partition("=")[2].strip().strip('"').strip("'")
+        except OSError:
+            continue
+    try:
+        with open("/etc/lsb-release", encoding="utf-8") as f:
+            for line in f:
+                if line.startswith("DISTRIB_DESCRIPTION="):
+                    return line.partition("=")[2].strip().strip('"').strip("'")
+    except OSError:
+        pass
+    return ""
+
+
+def collect_env_info(cfg: Config) -> EnvInfo:
+    """Gather host machine, CPU, memory, disk, and template information."""
+    info = EnvInfo()
+    info.timestamp = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    # --- Host ---
+    info.hostname = platform.node()
+    info.os_name = platform.system()
+    info.os_version = platform.version()
+    info.kernel = platform.release()
+    info.arch = platform.machine()
+    info.python_version = sys.version.split()[0]
+    info.sdk_version = cubesandbox.__version__
+
+    # Primary non-loopback IPv4 (best-effort, silent on failure).
+    info.ip_address = _detect_primary_ipv4()
+    # Machine model / cloud vendor label (e.g. "腾讯云 BMSA5").
+    info.machine_type = _detect_machine_type()
+
+    # --- SDK / Python details ---
+    info.processor = platform.processor() or platform.machine()
+    info.platform_summary = platform.platform()
+    info.python_impl = platform.python_implementation() + " " + platform.python_version()
+    try:
+        info.sdk_import_path = os.path.abspath(cubesandbox.__file__)
+    except Exception:
+        info.sdk_import_path = ""
+    try:
+        import httpx
+        info.httpx_version = httpx.__version__
+    except Exception:
+        pass
+    try:
+        import requests
+        info.requests_version = requests.__version__
+    except Exception:
+        pass
+
+    # Linux-specific
+    if info.os_name == "Linux":
+        # CPU model
+        model = run_cmd(["sh", "-c", r"grep -m1 'model name' /proc/cpuinfo | cut -d: -f2 | sed 's/^\s*//'"])
+        info.cpu_model = model
+
+        # Physical cores
+        phys = run_cmd(["sh", "-c", "grep -c '^cpu cores' /proc/cpuinfo | head -1"])
+        info.cpu_cores_physical = int(phys) if phys.isdigit() else 0
+
+        # Logical cores
+        info.cpu_cores_logical = os.cpu_count() or 0
+
+        # Sockets
+        sockets = run_cmd(["sh", "-c", "grep '^physical id' /proc/cpuinfo | sort -u | wc -l"])
+        info.cpu_sockets = int(sockets) if sockets.isdigit() else 0
+
+        # NUMA nodes
+        numa = run_cmd(["sh", "-c", "ls -d /sys/devices/system/node/node* 2>/dev/null | wc -l"])
+        info.numa_nodes = int(numa) if numa.isdigit() else 0
+
+        # Memory
+        mem_kb = run_cmd(["sh", "-c", "grep MemTotal /proc/meminfo | awk '{print $2}'"])
+        info.memory_total_gb = round(int(mem_kb) / (1024 * 1024)) if mem_kb.isdigit() else 0
+
+        # Memory type (DDR). Match the standalone "Type:" line only; the
+        # "Error Correction Type:" line also contains "Type:" and would win a
+        # loose grep, so anchor to the field name and skip the correction line.
+        mem_type = run_cmd(["sh", "-c", "sudo dmidecode -t memory 2>/dev/null | grep -E '^[[:space:]]*Type:' | grep -viE 'Unknown|Other' | head -1 | cut -d: -f2 | sed 's/^[[:space:]]*//' || echo ''"])
+        info.memory_type = mem_type or "N/A"
+
+        # Disk (root fs device model, size, fs type)
+        root_dev = run_cmd(["sh", "-c", "df / | tail -1 | awk '{print $1}'"]).rstrip("0123456789")
+        info.disk_fs = run_cmd(["sh", "-c", "df -T / | tail -1 | awk '{print $2}'"])
+        info.disk_size_gb = round(
+            int(run_cmd(["sh", "-c", "df -BG / | tail -1 | awk '{print $2}' | tr -d 'G'"]) or 0), 1
+        )
+
+        disk_model = run_cmd(["sh", "-c", f"lsblk -dno MODEL $(lsblk -no PKNAME $(df / | tail -1 | awk '{{print $1}}') 2>/dev/null) 2>/dev/null || echo ''"])
+        info.disk_model = disk_model or "N/A"
+
+        # Disk type (NVMe/SSD/HDD)
+        rotational = run_cmd(["sh", "-c", f"cat /sys/block/$(basename $(df / | tail -1 | awk '{{print $1}}') | sed 's/[0-9]*$//')/queue/rotational 2>/dev/null || echo ''"])
+        if rotational == "0":
+            info.disk_type = "SSD"
+        elif rotational == "1":
+            info.disk_type = "HDD"
+        else:
+            info.disk_type = "Unknown"
+
+        # Check NVMe
+        if "nvme" in (root_dev or "").lower():
+            info.disk_type = "NVMe SSD"
+
+        # OS distribution (PRETTY_NAME from /etc/os-release, e.g.
+        # "Ubuntu 22.04.4 LTS" or "TencentOS Server 3.1"). This is the
+        # user-facing OS name that people actually recognise, unlike
+        # platform.system() which just says "Linux".
+        info.os_distro = _read_os_release_pretty()
+
+        # GCC version — useful for reproducing build-time perf differences.
+        gcc_out = run_cmd(["sh", "-c", "gcc --version 2>/dev/null | head -n1"])
+        if gcc_out:
+            # `gcc (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0` → keep the last token
+            # (the semantic version) prefixed with `gcc `.
+            parts = gcc_out.split()
+            info.gcc_version = f"gcc {parts[-1]}" if parts else gcc_out
+
+    # --- SDK / API ---
+    info.api_url = cfg.api_url
+    info.template_id = cfg.template_id or ""
+
+    # --- Template metadata ---
+    _template_image: str | None = None
+    try:
+        # Prefer the detail endpoint (GET /templates/{id}) for most fields.
+        tmpl = Template.get(cfg.template_id, config=cfg)
+        _template_image = tmpl.image_info or None
+        info.template_instance_type = tmpl.instance_type or "N/A"
+        info.template_status = tmpl.status or "N/A"
+        # Template size / spec (CPU + memory). memory_mb is normalized to GiB
+        # for the human-readable spec string ("2 vCPU / 4 GiB").
+        info.template_cpu = int(tmpl.cpu_count or 0)
+        info.template_memory_mb = int(tmpl.memory_mb or 0)
+        if info.template_cpu or info.template_memory_mb:
+            mem_gib = round(info.template_memory_mb / 1024, 1) if info.template_memory_mb else 0
+            info.template_spec = f"{info.template_cpu} vCPU / {mem_gib} GiB"
+        else:
+            info.template_spec = info.template_instance_type or "N/A"
+    except Exception:
+        info.template_instance_type = "N/A"
+        info.template_status = "N/A"
+        info.template_spec = "N/A"
+
+    # imageInfo is missing from the detail endpoint; fall back to the list endpoint.
+    if not _template_image:
+        try:
+            all_tmpls = Template.list(config=cfg)
+            for t in all_tmpls:
+                if t.template_id == cfg.template_id and t.image_info:
+                    _template_image = t.image_info
+                    break
+        except Exception:
+            pass
+    info.template_image = _template_image or "N/A"
+
+    # --- Component versions ---
+    # Precedence: release-manifest.json (single source of truth on installed
+    # hosts) > CubeAPI /cluster/versions (control-plane declared matrix) >
+    # local binaries (`-V`/`-v` output). Each step only fills gaps; the
+    # release manifest is authoritative when present.
+    _collect_release_manifest(info)
+    _collect_cluster_versions(info, cfg)
+    _collect_local_versions(info)
+
+    return info
+
+
+# ===========================================================================
+# Version collection
+# ===========================================================================
+#
+# CubeSandbox exposes three complementary version sources:
+#
+#  1. release-manifest.json — written by
+#     `deploy/one-click/build-release-bundle.sh` at install time. Lists every
+#     component's declared version + commit + build_time + sha256 digest, plus
+#     guest-image and kernel metadata. Located at
+#     `/usr/local/services/cubetoolbox/release-manifest.json` (override via
+#     the `CUBE_RELEASE_MANIFEST` env var). This is the single source of truth
+#     for what was *installed*; we read it first.
+#
+#  2. CubeAPI `/cluster/versions` — control-plane view of what's actually
+#     *running* across nodes. Fields are JSON-serialised in camelCase
+#     (`controlPlane`, `buildTime`, `nodeID`) — a common footgun.
+#
+#  3. Local `-V`/`-v` binaries — final fallback when neither of the above
+#     is reachable (e.g. running perf against a remote API from a workstation
+#     that happens to also have the tools installed).
+#
+# `/health` used to be listed as a version source but it only returns
+# `{status, sandboxes}` (see `CubeAPI/src/handlers/health.rs`); do NOT probe
+# it for version info.
+
+
+DEFAULT_RELEASE_MANIFEST = "/usr/local/services/cubetoolbox/release-manifest.json"
+
+# Mapping from a component name in release-manifest.json to the EnvInfo
+# attribute prefix we want to populate.  For each entry we set
+# `<prefix>_version`, and (when present in the manifest) also
+# `<prefix>_commit` / `<prefix>_build_time` if the dataclass declares them.
+_MANIFEST_COMPONENT_MAP: dict[str, str] = {
+    "cube-api": "cubeapi",
+    "cubemaster": "cubemaster",
+    "cubelet": "cubelet",
+    "containerd-shim-cube-rs": "cube_shim",
+    "cubemastercli": "cubemastercli",
+    "cubecli": "cubecli",
+    "network-agent": "network_agent",
+    "cube-agent": "cube_agent",
+    "cube-runtime": "cube_runtime",
+    "cube-egress": "cube_egress",
+    "cube-lifecycle-manager": "cube_lifecycle_manager",
+}
+
+
+def _collect_release_manifest(info: EnvInfo) -> None:
+    """Populate component versions from ``release-manifest.json`` if present.
+
+    The manifest is authoritative for *declared* versions and is the same
+    file that `cubelet`/`cubemaster` consume, so what we record here matches
+    what the running cluster is supposed to be.  Missing gracefully: on any
+    error we simply leave fields empty and let the other collectors fill in.
+    """
+    import json
+
+    path = os.environ.get("CUBE_RELEASE_MANIFEST", DEFAULT_RELEASE_MANIFEST)
+    if not path or not os.path.isfile(path):
+        return
+
+    try:
+        with open(path, encoding="utf-8") as f:
+            data = json.load(f)
+    except (OSError, ValueError):
+        return
+    if not isinstance(data, dict):
+        return
+
+    info.release_manifest_path = path
+    info.release_version = str(data.get("release_version", "") or "")
+    info.release_built_at = str(data.get("built_at", "") or "")
+    info.release_built_by = str(data.get("built_by", "") or "")
+    info.release_git_commit = str(data.get("git_commit", "") or "")
+
+    components = data.get("components", {})
+    if isinstance(components, dict):
+        for comp_name, prefix in _MANIFEST_COMPONENT_MAP.items():
+            comp = components.get(comp_name)
+            if not isinstance(comp, dict):
+                continue
+            _set_component_fields(info, prefix, comp)
+
+    guest = data.get("guest_image", {})
+    if isinstance(guest, dict):
+        # Prefer manifest values; keep any pre-existing values otherwise.
+        info.guest_image_version = str(guest.get("version", "") or info.guest_image_version)
+        info.guest_image_digest = str(guest.get("digest_sha256", "") or "")
+        info.guest_image_base = str(guest.get("base_image", "") or "")
+        info.guest_agent_version = str(guest.get("agent_version", "") or "")
+
+    kernel = data.get("kernel", {})
+    if isinstance(kernel, dict):
+        info.kernel_version_node = str(kernel.get("version", "") or info.kernel_version_node)
+        info.kernel_digest = str(kernel.get("vmlinux_digest_sha256", "") or "")
+        info.kernel_pvm_version = str(kernel.get("pvm_version", "") or "")
+        info.kernel_pvm_digest = str(kernel.get("vmlinux_pvm_digest_sha256", "") or "")
+
+
+def _set_component_fields(info: EnvInfo, prefix: str, comp: dict) -> None:
+    """Set ``<prefix>_{version,commit,build_time}`` from a manifest entry.
+
+    Silently skips attributes that don't exist on the dataclass so we don't
+    have to declare every commit/build_time triplet up-front.
+    """
+    version = str(comp.get("version", "") or "")
+    commit = str(comp.get("commit", "") or "")
+    build_time = str(comp.get("build_time", "") or "")
+
+    for attr, value in (
+        (f"{prefix}_version", version),
+        (f"{prefix}_commit", commit),
+        (f"{prefix}_build_time", build_time),
+    ):
+        if value and hasattr(info, attr) and not getattr(info, attr):
+            setattr(info, attr, value)
+
+
+def _collect_cluster_versions(info: EnvInfo, cfg: Config) -> None:
+    """Populate versions via CubeAPI ``/cluster/versions`` (running-state view).
+
+    The endpoint is defined by ``CubeAPI/src/models/mod.rs::VersionMatrixView``
+    and serialises to **camelCase** (``controlPlane`` / ``buildTime`` /
+    ``nodeID`` / ``declaredVersion``) — we accept snake_case fallbacks in case
+    the field-renaming changes.
+    """
+    try:
+        import httpx
+    except ImportError:
+        return
+
+    headers = {}
+    api_key = os.environ.get("CUBE_API_KEY") or os.environ.get("E2B_API_KEY", "")
+    if api_key:
+        headers["X-API-Key"] = api_key
+    try:
+        resp = httpx.get(f"{cfg.api_url}/cluster/versions", headers=headers, timeout=10)
+    except (httpx.HTTPError, OSError):
+        return
+    if resp.status_code != 200:
+        return
+    try:
+        data = resp.json()
+    except ValueError:
+        return
+    if not isinstance(data, dict):
+        return
+
+    cp = data.get("controlPlane") or data.get("control_plane") or {}
+    if isinstance(cp, dict):
+        if not info.cubemaster_version:
+            info.cubemaster_version = str(cp.get("version", "") or "")
+        if not info.cubemaster_commit:
+            info.cubemaster_commit = str(cp.get("commit", "") or "")
+        if not info.cubemaster_build_time:
+            info.cubemaster_build_time = str(
+                cp.get("buildTime", "") or cp.get("build_time", "") or ""
+            )
+
+    nodes = data.get("nodes", [])
+    if isinstance(nodes, list) and nodes:
+        first_node = nodes[0]
+        if isinstance(first_node, dict):
+            for c in first_node.get("components", []) or []:
+                if not isinstance(c, dict):
+                    continue
+                name = str(c.get("component", "") or "")
+                ver = str(c.get("version", "") or "")
+                if not ver:
+                    continue
+                # Same component-name → attr-prefix mapping we use for the
+                # manifest, so /cluster/versions naturally fills gaps.
+                prefix = _MANIFEST_COMPONENT_MAP.get(name)
+                if prefix:
+                    attr = f"{prefix}_version"
+                    if hasattr(info, attr) and not getattr(info, attr):
+                        setattr(info, attr, ver)
+                # Special-cased legacy fields that don't follow the pattern.
+                if name == "guest-image" and not info.guest_image_version:
+                    info.guest_image_version = ver
+                elif name == "kernel" and not info.kernel_version_node:
+                    info.kernel_version_node = ver
+
+
+def _parse_version_output(output: str) -> tuple[str, str, str]:
+    """Parse 'name v1.2.3 (commit) built at 2026-01-01T00:00:00Z' into (version, commit, build_time)."""
+    import re
+
+    version = ""
+    commit = ""
+    build_time = ""
+    # pattern: v0.5.1 (a164417...) built at 2026-07-11T08:09:01Z
+    m = re.search(r"v?(\d+\.\d+\.\d+(?:[-\w.]*)?)\s*\((\w+)\)\s*built at\s*(\S+)", output)
+    if m:
+        version = m.group(1)
+        commit = m.group(2)
+        build_time = m.group(3)
+    return version, commit, build_time
+
+
+# Local-binary probe table: (attr_prefix, [candidate paths], version flag).
+# The prefix is joined with `_version`/`_commit`/`_build_time` so it matches
+# the dataclass field names and the manifest map.  Kept as a plain list so
+# it's obvious which components are covered by the fallback path.
+_LOCAL_BINARY_PROBES: tuple[tuple[str, tuple[str, ...], str], ...] = (
+    ("cubeapi", (
+        "/usr/local/services/cubetoolbox/CubeAPI/bin/cube-api",
+        "/usr/local/bin/cube-api",
+    ), "-V"),
+    ("cubemaster", (
+        "/usr/local/services/cubetoolbox/CubeMaster/bin/cubemaster",
+        "/usr/local/bin/cubemaster",
+    ), "-v"),
+    ("cubemastercli", (
+        "/usr/local/services/cubetoolbox/CubeMaster/bin/cubemastercli",
+        "/usr/local/bin/cubemastercli",
+    ), "-v"),
+    ("cubecli", (
+        "/usr/local/services/cubetoolbox/CubeMaster/bin/cubecli",
+        "/usr/local/bin/cubecli",
+    ), "-v"),
+    ("cubelet", (
+        "/usr/local/services/cubetoolbox/Cubelet/bin/cubelet",
+        "/usr/local/bin/cubelet",
+    ), "-v"),
+    ("cube_shim", (
+        "/usr/local/services/cubetoolbox/CubeShim/bin/containerd-shim-cube-rs",
+        "/usr/local/bin/containerd-shim-cube-rs",
+    ), "-v"),
+    ("cube_runtime", (
+        "/usr/local/services/cubetoolbox/CubeShim/bin/cube-runtime",
+        "/usr/local/bin/cube-runtime",
+    ), "-V"),
+    ("network_agent", (
+        "/usr/local/services/cubetoolbox/network-agent/bin/network-agent",
+        "/usr/local/bin/network-agent",
+    ), "-v"),
+)
+
+
+def _collect_local_versions(info: EnvInfo) -> None:
+    """Fill remaining version fields from locally installed binaries.
+
+    Iterates ``_LOCAL_BINARY_PROBES``; only touches fields that the earlier
+    sources (release manifest, ``/cluster/versions``) left empty, so the
+    authoritative-source precedence is preserved.
+    """
+    import shutil
+
+    for prefix, paths, flag in _LOCAL_BINARY_PROBES:
+        # Skip if we already have a version from a higher-priority source.
+        attr_v = f"{prefix}_version"
+        if getattr(info, attr_v, "") or not hasattr(info, attr_v):
+            continue
+        for path in paths:
+            binary = shutil.which(path) or (path if os.path.exists(path) else None)
+            if not binary:
+                continue
+            out = run_cmd([binary, flag])
+            if not out:
+                continue
+            v, c, bt = _parse_version_output(out)
+            if v:
+                setattr(info, attr_v, v)
+                if c and hasattr(info, f"{prefix}_commit") and not getattr(info, f"{prefix}_commit"):
+                    setattr(info, f"{prefix}_commit", c)
+                if bt and hasattr(info, f"{prefix}_build_time") and not getattr(info, f"{prefix}_build_time"):
+                    setattr(info, f"{prefix}_build_time", bt)
+                break

--- a/tests/perf/framework/registry.py
+++ b/tests/perf/framework/registry.py
@@ -1,0 +1,1328 @@
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""Benchmark registry, scenario selection, and the run driver.
+
+This is the framework core that the scenario modules under ``cases/`` plug
+into. The ``@benchmark`` decorator collects every scenario's metadata (CLI
+aliases, opt-in/opt-out skip gates, HTML report chart groups) in one place and
+auto-populates three derived tables — so a new scenario never has to touch a
+registry, an alias table, a hand-written skip block, or the report module.
+
+The decoration order (== the order in which ``cases/__init__.py`` imports the
+scenario modules) is the canonical run order. Importing ``perf.cases`` is what
+fills these tables; ``run_all`` then just iterates the populated registry.
+"""
+
+from __future__ import annotations
+
+import functools
+import inspect
+import os
+import platform
+import re
+import time
+from contextlib import contextmanager
+from dataclasses import dataclass
+from typing import Any, Callable, Iterator
+
+from cubesandbox import Config
+
+from .config import CONCURRENCY_LEVELS, PERF_ROUNDS, PERF_SETTLE, PERF_WARMUP
+from .runner import (
+    PERF_RESULTS,
+    green,
+    measure_parallel,
+    print_parallel_stats,
+    red,
+    sandbox_op,
+    snapshot_op,
+    skip,
+    yellow,
+)
+
+# ---------------------------------------------------------------------------
+# Scenario registry (populated by the @benchmark decorator)
+# ---------------------------------------------------------------------------
+#
+# Adding a benchmark is a one-liner: write the function and tag it with
+# ``@benchmark("my-scenario")``. Everything a scenario needs lives on that one
+# decorator — CLI aliases, the opt-in/opt-out skip gate, and the HTML report
+# chart group — so a new benchmark never has to touch a registry, an alias
+# table, a hand-written skip block, or the report module. The decoration order
+# (== the order scenario modules are imported in ``cases/__init__.py``) is the
+# canonical run order.
+BENCHMARK_REGISTRY: "dict[str, Callable[[Config], None]]" = {}
+BENCHMARK_ALIASES: "dict[str, list[str]]" = {}
+# HTML report chart groups contributed via ``report=...``, in decoration
+# order. Consumed by ``report_html`` (see ``default_report_scenarios``).
+REPORT_SCENARIOS: "list[dict]" = []
+# Markdown report sections contributed via ``report=ReportSection(...)``.
+# Consumed by ``reporting.report`` (see ``default_report_sections``); the
+# Markdown report iterates these declarations instead of hard-coding one
+# f-string block per scenario. Sorted by ``order`` at render time.
+REPORT_SECTIONS: "list[dict]" = []
+# Scenario keys explicitly named on the CLI (``--scenarios``/``--only``).
+# Populated by ``select_benchmarks``; an explicitly-selected scenario bypasses
+# its default opt-in/opt-out gate — naming a scenario *is* the intent to run
+# it, so ``--only ivshmem`` no longer also needs ``CUBE_RUN_IVSHMEM=1``.
+_FORCED_KEYS: "set[str]" = set()
+
+
+@dataclass(frozen=True)
+class ReportChart:
+    """One chart + summary-table group in the HTML perf report.
+
+    A benchmark may declare zero, one, or several charts (e.g. the
+    pause/resume benchmark feeds both a 暂停 and a 恢复 chart). *prefix*
+    defaults to the benchmark key and is the scenario-name prefix the report
+    matches against (``<prefix>-<x_key><N>``).
+    """
+    title: str
+    prefix: "str | None" = None
+    x_key: str = "c"
+    x_label: str = "并发数"
+    fallback: "tuple[int, ...]" = (1, 2, 4)
+
+
+# Backward-compatible alias — ``ReportGroup`` was the original name for the
+# HTML chart group before ``ReportSection`` was introduced for the Markdown
+# report. Kept so old ``report=ReportGroup(...)`` declarations keep working.
+ReportGroup = ReportChart
+
+
+@dataclass(frozen=True)
+class ReportSection:
+    """One numbered section of the Markdown perf report (and its HTML charts).
+
+    This is the single declaration that drives *both* reports for a scenario:
+    the Markdown renderer (``reporting.report``) iterates these sections in
+    ``order`` and renders each one's title / "测试方式" note / table / "关键结论"
+    from the fields here (no more one hand-written f-string block per
+    scenario), and the ``charts`` a section carries feed the HTML report's
+    chart groups (via ``ReportChart``), so a scenario's whole report presence
+    lives in the same ``@benchmark(report=...)`` one-liner.
+
+    Fields:
+
+    - *table*: which table/conclusion renderer the Markdown report uses —
+      one of ``"latency"`` / ``"density"`` / ``"dirty"`` / ``"clone"`` /
+      ``"pause_resume"``. ``"latency"`` matches the concurrency-sweep rows
+      ``<benchmark-key>-c<N>``; the others have bespoke renderers.
+    - *title_zh* / *title_en*: the section heading in each language.
+    - *method_zh* / *method_en*: the "测试方式" / "Method" note (Markdown, may
+      contain inline code / ``{id}`` etc. — plain strings, no f-string escapes).
+    - *order*: sort key deciding the section's position (and its rendered
+      number) in the Markdown report. The environment section is always 1, so
+      scenario sections conventionally start at 2.
+    - *throughput*: ``"latency"`` tables only — add an amortized throughput
+      column.
+    - *noun_zh* / *noun_en*: ``"latency"`` conclusions only — the operation
+      noun woven into the "单并发 …延迟" / "Single-concurrency … latency" bullets.
+    - *star*: append a ``⭐`` to the heading (highlights a flagship scenario).
+    - *charts*: zero or more ``ReportChart`` for the HTML report. Empty for
+      scenarios whose data shape is not a concurrency sweep (density / dirty /
+      clone), so they appear in Markdown but contribute no HTML chart.
+    """
+    table: str
+    title_zh: str
+    title_en: str
+    method_zh: str = ""
+    method_en: str = ""
+    order: float = 100.0
+    throughput: bool = False
+    noun_zh: str = ""
+    noun_en: str = ""
+    star: bool = False
+    metrics: "tuple[str, ...] | None" = None  # columns to show (None → all defaults)
+    charts: "tuple[ReportChart, ...]" = ()
+
+
+def benchmark(
+    key: str,
+    *,
+    aliases: "list[str] | None" = None,
+    opt_in_env: "str | None" = None,
+    opt_out_env: "str | None" = None,
+    skip_reason: "str | None" = None,
+    available: bool = True,
+    report: "ReportSection | ReportChart | list | None" = None,
+):
+    """Register the decorated function as a benchmark under *key*.
+
+    Every knob keeps a scenario's metadata in one place:
+
+    - *aliases*: friendly group names (several benchmarks may share one, e.g.
+      every ``volume-*`` scenario under ``volume``).
+    - *opt_in_env*: env var that must equal ``"1"`` for the scenario to run;
+      otherwise it is skipped (default-off scenarios like volume / ivshmem).
+      Explicitly naming the scenario on the CLI (``--only``/``--scenarios``)
+      bypasses this gate — see ``_FORCED_KEYS`` / ``select_benchmarks``.
+    - *opt_out_env*: env var that, when equal to ``"1"``, skips the scenario
+      (default-on scenarios like density / snapshot-dirty). Also bypassed when
+      the scenario is explicitly named on the CLI.
+    - *skip_reason*: extra human hint appended to the opt-in skip message.
+    - *available*: evaluated at import time; ``False`` skips unconditionally
+      (e.g. the optional ``Volume`` type failed to import).
+    - *report*: the scenario's report presence. Pass a ``ReportSection`` to
+      declare a Markdown section (which may itself carry HTML ``charts``), a
+      bare ``ReportChart``/``ReportGroup`` (legacy) for an HTML-only chart, or
+      a list mixing the two.
+    """
+    def deco(fn: "Callable[[Config], None]") -> "Callable[[Config], None]":
+        if key in BENCHMARK_REGISTRY:
+            raise ValueError(f"duplicate benchmark key: {key}")
+
+        # Wrap only when a gate is declared, so plain scenarios stay zero-cost.
+        if not available or opt_in_env or opt_out_env:
+            @functools.wraps(fn)
+            def registered(cfg: Config) -> None:
+                if not available:
+                    skip(key, "requires an optional dependency missing from this build")
+                    return
+                # Explicit CLI selection is a hard "run it" signal: it overrides
+                # the default opt-in/opt-out env gates (but never the missing
+                # optional-dependency guard above).
+                forced = key in _FORCED_KEYS
+                if not forced and opt_in_env and os.environ.get(opt_in_env) != "1":
+                    reason = f"set {opt_in_env}=1 (or name it via --only {key})"
+                    if skip_reason:
+                        reason += f" ({skip_reason})"
+                    skip(key, reason)
+                    return
+                if not forced and opt_out_env and os.environ.get(opt_out_env) == "1":
+                    skip(key, f"{opt_out_env}=1")
+                    return
+                fn(cfg)
+        else:
+            registered = fn
+
+        BENCHMARK_REGISTRY[key] = registered
+        for alias in aliases or []:
+            BENCHMARK_ALIASES.setdefault(alias, []).append(key)
+        _register_report(key, report)
+        return registered
+    return deco
+
+
+def _register_report(
+    key: str, report: "ReportSection | ReportChart | list | None"
+) -> None:
+    """Populate ``REPORT_SECTIONS`` / ``REPORT_SCENARIOS`` from a ``report=``.
+
+    A ``ReportSection`` contributes one Markdown section plus its ``charts``;
+    a bare ``ReportChart``/``ReportGroup`` contributes an HTML-only chart. The
+    section's data key defaults to the benchmark *key*, and each chart's
+    ``prefix`` defaults to it too.
+    """
+    items = report if isinstance(report, (list, tuple)) else ([report] if report is not None else [])
+    for item in items:
+        if isinstance(item, ReportSection):
+            REPORT_SECTIONS.append({
+                "key": key,
+                "table": item.table,
+                "title_zh": item.title_zh,
+                "title_en": item.title_en,
+                "method_zh": item.method_zh,
+                "method_en": item.method_en,
+                "order": item.order,
+                "throughput": item.throughput,
+                "noun_zh": item.noun_zh,
+                "noun_en": item.noun_en,
+                "star": item.star,
+                "metrics": item.metrics,
+            })
+            charts = item.charts
+        elif isinstance(item, ReportChart):
+            charts = (item,)
+        else:
+            charts = ()
+        for grp in charts:
+            prefix = grp.prefix or key
+            REPORT_SCENARIOS.append({
+                "id": prefix.replace("-", "_"),
+                "title": grp.title,
+                "prefix": prefix,
+                "xKey": grp.x_key,
+                "fallback": list(grp.fallback),
+                "xLabel": grp.x_label,
+            })
+
+
+def parallel_sweep(
+    label: str,
+    *,
+    header: "str | None" = None,
+    levels: "list[int] | None" = None,
+    metrics: "tuple[str, ...] | None" = None,
+    rounds: "int | None" = None,
+    warmup: "int | None" = None,
+    settle: "float | None" = None,
+):
+    """Declaratively turn a per-level generator into a concurrency-sweep benchmark.
+
+    Instead of hand-writing the ``for concurrency in CONCURRENCY_LEVELS`` loop
+    (with its ``n = PERF_ROUNDS * concurrency`` sizing, ``measure_parallel``
+    call, result append, and stats print-out) in every scenario, decorate a
+    *generator* ``(cfg, concurrency, n)`` that:
+
+      * sets up the level's resources,
+      * ``yield``s the single-shot operation to be timed ``n`` times, then
+      * tears the resources down after the yield (put it in a ``finally`` /
+        lean on ``sandbox_pool()`` so cleanup runs even mid-sweep).
+
+    The framework owns the loop, timing, collection, and the shared stats line;
+    the scenario body only declares "what to set up, what to measure, what to
+    clean up". Stack it *under* ``@benchmark`` so the registry still sees the
+    required ``fn(cfg)``::
+
+        @benchmark("template-create", aliases=["create"])
+        @parallel_sweep("template-create", header=" [Perf] ...")
+        def bench(cfg, concurrency, n):
+            with sandbox_pool() as pool:
+                yield lambda: pool.add(Sandbox.create(cfg.template_id, config=cfg))
+
+    *header* prints once above the sweep; *levels* overrides the default
+    ``CONCURRENCY_LEVELS`` for scenarios that need a bespoke set; *metrics*
+    picks which latency fields the shared stats line shows (see
+    ``print_parallel_stats``).
+
+    Timing knobs (each ``None`` falls back to its global default, so a scenario
+    only names the ones it wants to bend):
+
+    - *rounds*: measured ops **per worker** (total ``n = rounds * concurrency``);
+      defaults to ``PERF_ROUNDS`` (env ``CUBE_PERF_ROUNDS``).
+    - *warmup*: unmeasured ops run once per level before timing, to shed
+      cold-start spikes; defaults to ``PERF_WARMUP`` (env ``CUBE_PERF_WARMUP``).
+    - *settle*: seconds slept **between** concurrency levels to let the node
+      quiesce; defaults to ``PERF_SETTLE`` (env ``CUBE_PERF_SETTLE``).
+    """
+    def deco(gen: "Callable[..., Iterator[Callable[[], Any]]]") -> "Callable[[Config], None]":
+        make_level = contextmanager(gen)
+        # Let a stacked ``@metrics(...)`` supply the default field list; an
+        # explicit ``metrics=`` on this decorator always wins.
+        effective_metrics = metrics if metrics is not None else getattr(gen, "_perf_metrics", None)
+
+        @functools.wraps(gen)
+        def run(cfg: Config) -> None:
+            if header:
+                print(f"\n{'='*60}")
+                print(header)
+                print(f"{'='*60}")
+            rounds_n = PERF_ROUNDS if rounds is None else rounds
+            warmup_n = PERF_WARMUP if warmup is None else warmup
+            settle_s = PERF_SETTLE if settle is None else settle
+            for i, concurrency in enumerate(
+                _resolve_levels(label, levels or CONCURRENCY_LEVELS, concurrency_key)
+            ):
+                # Let the node quiesce between levels (skip before the first).
+                if i and settle_s:
+                    time.sleep(settle_s)
+                n = rounds_n * concurrency
+                with make_level(cfg, concurrency, n) as op:
+                    # Shed cold-start spikes: run a few unmeasured ops first.
+                    warmup_errors = 0
+                    for _ in range(warmup_n):
+                        try:
+                            op()
+                        except Exception:
+                            warmup_errors += 1
+                    if warmup_errors:
+                        print(yellow(
+                            f"  warmup: {warmup_errors}/{warmup_n} ops failed "
+                            f"(concurrency={concurrency})"))
+                    result = measure_parallel(
+                        f"{label}-c{concurrency}", op, n=n, concurrency=concurrency)
+                    PERF_RESULTS.append(result)
+                    print_parallel_stats(result, effective_metrics)
+
+        return run
+    return deco
+
+
+def sandbox_action(
+    *,
+    pool: "Callable[..., Any] | None" = None,
+    fixture: str = "sandbox",
+    template_id: "str | None" = None,
+    **create_opts: Any,
+):
+    """Business layer — turn a *plain action* into a ``parallel_sweep`` generator.
+
+    This is the "业务" decorator of the four-layer split (see the module's
+    ``sandbox_benchmark`` docstring / ``DESIGN.zh.md`` §4.6). It removes the
+    ``yield`` boilerplate: decorate a function that **is** the per-op action and
+    get back the ``gen(cfg, concurrency, n)`` generator ``parallel_sweep``
+    expects.
+
+    *fixture* picks what each measured op is handed (built by the matching
+    ``*_op`` helper in ``runner``):
+
+    - ``"sandbox"`` (default): a throwaway sandbox — action signature ``(sb)``,
+      or ``(sb, pool)`` when *pool* is given (feed the product to ``pool.add``)::
+
+          @sandbox_action(pool=snapshot_pool)
+          def snapshot_create(sb, snaps):
+              snaps.add(sb.create_snapshot().snapshot_id)
+
+    - ``"snapshot"``: a throwaway sandbox *plus* one of its snapshots — action
+      signature ``(sb, snap_id)``, or ``(sb, snap_id, pool)`` with *pool*. Suits
+      ops that need a live box and a snapshot to act on (e.g. rollback)::
+
+          @sandbox_action(fixture="snapshot")
+          def rollback(sb, snap_id):
+              sb.rollback(snap_id)
+
+    *template_id* / ``**create_opts`` pass straight to the fixture /
+    ``Sandbox.create`` (e.g. ``timeout=300``, ``volume_mounts=[...]``).
+    """
+    op_builder = snapshot_op if fixture == "snapshot" else sandbox_op
+
+    def deco(action: "Callable[..., Any]") -> "Callable[..., Iterator[Callable[[], Any]]]":
+        @functools.wraps(action)
+        def gen(cfg: Config, concurrency: int, n: int):
+            if pool is None:
+                yield op_builder(cfg, action, template_id, **create_opts)
+            elif fixture == "snapshot":
+                with _open_pool(pool, cfg) as p:
+                    yield op_builder(
+                        cfg, lambda sb, sid: action(sb, sid, p), template_id, **create_opts)
+            else:
+                with _open_pool(pool, cfg) as p:
+                    yield op_builder(
+                        cfg, lambda sb: action(sb, p), template_id, **create_opts)
+
+        return gen
+    return deco
+
+
+def metrics(*names: str):
+    """Metrics layer — declare which latency fields the stats line shows.
+
+    The "指标" decorator of the four-layer split: it just tags the generator
+    with a ``_perf_metrics`` attribute that ``parallel_sweep`` reads as its
+    default field list (an explicit ``metrics=`` on ``parallel_sweep`` wins).
+    Valid names: ``avg`` / ``min`` / ``p50`` / ``p95`` / ``p99`` / ``max`` (see
+    ``print_parallel_stats``). Stack it between ``@parallel_sweep`` and
+    ``@sandbox_action``::
+
+        @parallel_sweep("snapshot-create")
+        @metrics("avg", "p50", "p95", "max")
+        @sandbox_action(pool=snapshot_pool)
+        def snapshot_create(sb, snaps): ...
+    """
+    def deco(gen: "Callable[..., Any]") -> "Callable[..., Any]":
+        gen._perf_metrics = tuple(names)  # type: ignore[attr-defined]
+        return gen
+    return deco
+
+
+def sandbox_benchmark(
+    key: str,
+    *,
+    title: "str | None" = None,
+    header: "str | None" = None,
+    aliases: "list[str] | None" = None,
+    pool: "Callable[..., Any] | None" = None,
+    fixture: str = "sandbox",
+    metrics: "tuple[str, ...] | None" = None,
+    template_id: "str | None" = None,
+    levels: "list[int] | None" = None,
+    rounds: "int | None" = None,
+    warmup: "int | None" = None,
+    settle: "float | None" = None,
+    report: "ReportSection | ReportChart | None" = None,
+    **create_opts: Any,
+):
+    """Fully declarative sandbox scenario — decorate the *action*, get the sweep.
+
+    This is the one-line **sugar** that stacks the four single-concern layers of
+    the split (see ``DESIGN.zh.md`` §4.6) for the most common shape: *"each
+    measured op spins up a throwaway fixture, does one thing to it, tears it
+    down"*. There is no generator and no ``yield`` — the decorated function
+    **is** the per-op action, so a scenario collapses to its one measured line::
+
+        @sandbox_benchmark("snapshot-create", title="创建快照（并发）",
+                           header=" [Perf] Snapshot Creation", aliases=["snapshot"],
+                           pool=snapshot_pool, metrics=("avg", "p50", "p95", "max"),
+                           levels=[1, 5, 10], rounds=20, warmup=2, settle=1.0)
+        def snapshot_create(sb, snaps):
+            snaps.add(sb.create_snapshot().snapshot_id)
+
+    Internally it is exactly::
+
+        benchmark(key, aliases=aliases, report=...)(
+            parallel_sweep(key, header=..., levels=..., metrics=...,
+                           rounds=..., warmup=..., settle=...)(
+                sandbox_action(pool=pool, fixture=fixture,
+                               template_id=template_id, **create_opts)(action)))
+
+    Reach for the four decorators directly (``@benchmark`` / ``@parallel_sweep``
+    / ``@metrics`` / ``@sandbox_action``) when you want to split concerns, reuse
+    a middle layer, or swap one layer's implementation.
+
+    - *title*: HTML report chart title (omit for no report group).
+    - *fixture*: what each measured op is handed — ``"sandbox"`` (default,
+      action ``(sb)`` / ``(sb, pool)``) or ``"snapshot"`` (a box *and* one of its
+      snapshots, action ``(sb, snap_id)`` / ``(sb, snap_id, pool)``). See
+      ``sandbox_action``.
+    - *pool*: a pool context-manager factory (``sandbox_pool`` / ``snapshot_pool``);
+      when set, the action takes a trailing ``pool`` arg and typically feeds its
+      product to ``pool.add(...)``.
+    - *metrics*: latency fields the stats line shows (see ``print_parallel_stats``).
+    - *levels*: concurrency ladder for this scenario; defaults to the global
+      ``CONCURRENCY_LEVELS`` (env ``CUBE_PERF_CONCURRENCY``, default 1/5/10).
+    - *rounds* / *warmup* / *settle*: per-scenario timing overrides; each
+      ``None`` falls back to its global default (``PERF_ROUNDS`` /
+      ``PERF_WARMUP`` / ``PERF_SETTLE`` — see ``parallel_sweep``).
+    - *template_id* / ``**create_opts``: passed straight to the fixture /
+      ``Sandbox.create`` (e.g. a bespoke template, ``timeout=300``,
+      ``volume_mounts=[...]``).
+    """
+    report_group = report or (ReportGroup(title) if title else None)
+
+    def deco(action: "Callable[..., Any]") -> "Callable[[Config], None]":
+        gen = sandbox_action(
+            pool=pool, fixture=fixture, template_id=template_id, **create_opts)(action)
+        swept = parallel_sweep(
+            key, header=header, levels=levels, metrics=metrics,
+            rounds=rounds, warmup=warmup, settle=settle)(gen)
+        return benchmark(key, aliases=aliases, report=report_group)(swept)
+
+    return deco
+
+
+# ---------------------------------------------------------------------------
+# Quick‑start helper: declare a scenario with the fewest imports possible.
+# ---------------------------------------------------------------------------
+#
+#    from framework.registry import perf_test, sandbox_op
+#
+#    @perf_test("my-scenario", title="My Scenario", levels=(1, 5, 10))
+#    def bench(cfg, concurrency, n):
+#        yield sandbox_op(cfg, lambda sb: sb.exec("whoami"))
+#
+# Without *levels* the body runs once, no sweep:
+#
+#    @perf_test("once-off")
+#    def bench(cfg):
+#        with sandbox(cfg) as sb:
+#            print(sb.exec("whoami"))
+# ---------------------------------------------------------------------------
+
+
+def perf_test(
+    key: str,
+    title: str = "",
+    *,
+    aliases: "list[str] | None" = None,
+    levels: "list[int] | None" = None,
+    concurrency_key: str = "CONCURRENCY_LEVELS",
+    warmup: "int | None" = None,
+    rounds: "int | None" = None,
+    metrics: "tuple[str, ...] | None" = None,
+    header: "str | None" = None,
+):
+    """Minimal‑boilerplate entry point for a new benchmark.
+
+    Put a ``bench_<name>.py`` under ``cases/<category>/`` and decorate a
+    standalone function.  Three lines of imports cover 90 % of scenarios.
+
+    - If *levels* is given the decorated function receives three positional
+      args ``(cfg, concurrency, n)`` and is expected to **yield** a callable
+      (e.g. ``yield sandbox_op(cfg, ...)`` or ``yield snapshot_op(cfg, ...)``).
+    - If *levels* is omitted the function gets ``(cfg)`` and runs once — use
+      this for density / snapshot‑dirty / anything that does not need
+      concurrency sweeps.
+    """
+    report = ReportGroup(title) if title else None
+    header = header or f" [Perf] {title or key.capitalize()}"
+
+    def deco(fn: "Callable[..., Any]") -> "Callable[[Config], None]":
+        if levels is not None:
+            swept = parallel_sweep(
+                key, header=header, levels=levels,
+                concurrency_key=concurrency_key,
+                warmup=warmup, rounds=rounds, metrics=metrics)(fn)
+            return benchmark(key, aliases=aliases, report=report)(swept)
+        else:
+            # Single‑shot benchmark without concurrency sweep
+            @benchmark(key, aliases=aliases, report=report)
+            def _fn(cfg: Config) -> None:
+                fn(cfg)
+            return _fn
+
+    return deco
+
+
+# ---------------------------------------------------------------------------
+# Auto‑register a bare ``def run():`` (no decorator needed)
+# ---------------------------------------------------------------------------
+
+
+def auto(
+    fn: "Callable[[], Any]",
+    *,
+    key: str,
+    title: str = "",
+    levels: "tuple[int, ...] | None" = None,
+    warmup: int = 1,
+    metrics: "tuple[str, ...] | None" = None,
+    header: "str | None" = None,
+) -> None:
+    """Wrap a plain ``run()`` function so the framework does all the timing.
+
+    Called automatically by ``perf.cases`` discovery when a ``bench_*.py``
+    module exposes a callable named ``run`` and does *not* use ``@benchmark``.
+    You never need to call this yourself — just write::
+
+        # bench_my.py
+        '''My benchmark.'''       # docstring line 1 → report title
+        LEVELS = (1, 5, 10)      # optional concurrency ladder
+
+        def run():
+            ...
+
+    Under the hood this registers a ``@benchmark`` + ``@parallel_sweep`` entry
+    so the scenario appears in ``--list-scenarios`` and participates in
+    reports just like any other benchmark.
+    """
+    from .runner import PERF_RESULTS, measure_parallel, print_parallel_stats  # noqa: PLC0415
+    from .config import CONCURRENCY_LEVELS  # noqa: PLC0415
+
+    _levels = _resolve_levels(key, levels or CONCURRENCY_LEVELS)
+    report = ReportGroup(title) if title else None
+    header = header or f" [Perf] {title or key.capitalize()}"
+    _metrics = metrics or ("avg", "min", "p95", "max")
+
+    @benchmark(key, aliases=None, report=report)
+    @parallel_sweep(key, header=header, levels=_levels, warmup=warmup, metrics=_metrics)
+    def _auto_bench(
+        cfg: Config, concurrency: int, n: int,
+        _fn: "Callable[[], Any]" = fn,
+    ) -> None:
+        # warmup
+        for _ in range(warmup):
+            try:
+                _fn()
+            except Exception:
+                pass
+        # measure
+        result = measure_parallel(
+            f"{key}-c{concurrency}", _fn, n=n, concurrency=concurrency,
+        )
+        PERF_RESULTS.append(result)
+        print_parallel_stats(result, _metrics)
+
+
+# ---------------------------------------------------------------------------
+# External-script registration (CUBE_EXTERNAL_SCRIPTS in .env)
+# ---------------------------------------------------------------------------
+
+
+_SCRIPT_SOURCE_CACHE: dict[str, str] = {}
+
+
+def _accepts_arg(flag: str) -> bool:
+    """Check if the currently-loading external script accepts *flag*."""
+    source = _SCRIPT_SOURCE_CACHE.get(_script_path, "")
+    # e.g. add_argument('--template') or add_argument("--template")
+    return bool(re.search(rf'add_argument\(["\']{re.escape(flag)}["\']', source))
+
+
+_BOILERPLATE_PREFIXES = (
+    "copyright",
+    "licen",
+    "spdx",
+    "all rights reserved",
+    "作者",
+    "版权所有",
+)
+
+
+def _is_boilerplate_comment(text: str) -> bool:
+    """Return True if *text* looks like a license/copyright comment."""
+    lower = text.lower()
+    return any(lower.startswith(p) for p in _BOILERPLATE_PREFIXES)
+
+
+def discover_external_scripts() -> None:
+    """Auto-discover and register external scripts.
+
+    Paths listed in ``CUBE_EXTERNAL_SCRIPTS`` (comma-separated in .env).
+    """
+    import os as _os
+    import re
+    from pathlib import Path as _Path
+
+    candidates: list[_Path] = []
+
+    raw = _os.environ.get("CUBE_EXTERNAL_SCRIPTS", "").strip()
+    if not raw:
+        print("[perf] CUBE_EXTERNAL_SCRIPTS is not set — no external scripts to register")
+        print("[perf]   cp tests/perf/.env.example tests/perf/.env")
+        print("[perf]   then edit tests/perf/.env and uncomment CUBE_EXTERNAL_SCRIPTS")
+        return
+
+    for p_raw in raw.split(","):
+        p_raw = p_raw.strip()
+        if not p_raw:
+            continue
+        path = _Path(p_raw).expanduser().resolve()
+        # Support glob patterns: bench_*.py expands to all matching files
+        if "*" in path.name:
+            parent = path.parent
+            candidates.extend(sorted(parent.glob(path.name)))
+        else:
+            candidates.append(path)
+
+    registered_keys = set(BENCHMARK_REGISTRY)
+
+    for p in candidates:
+        if not p.is_file():
+            continue
+        key = p.stem.replace("bench_", "").replace("_", "-")
+        if key in registered_keys:
+            continue
+
+        levels = None
+        title = ""
+        report_kwargs: dict = {}
+        metrics = None
+        no_concurrency = False
+        try:
+            source = p.read_text(encoding="utf-8")
+            # Cache for _accepts_arg() used during benchmark command construction
+            _SCRIPT_SOURCE_CACHE[str(p)] = source
+
+            # ── title: first docstring line or first meaningful comment ──
+            for line in source.split("\n"):
+                stripped = line.strip()
+                if stripped.startswith('"""') or stripped.startswith("'''"):
+                    # Extract content between opening and (optional) closing quotes
+                    for q in ('"""', "'''"):
+                        if stripped.startswith(q):
+                            inner = stripped[len(q):]
+                            end = inner.find(q)
+                            if end >= 0:
+                                inner = inner[:end]
+                            title = inner.strip()
+                            break
+                    break
+                if stripped.startswith("#"):
+                    candidate = stripped.lstrip("#").strip()
+                    # Skip license/copyright lines — they are not scenario titles
+                    if not _is_boilerplate_comment(candidate):
+                        title = candidate
+                        break
+
+            # ── LEVELS = (1, 10, 20) ──
+            m = re.search(r"^LEVELS\s*=\s*[\[(]([^)\]]+)[)\]]", source, re.MULTILINE)
+            if m:
+                levels = tuple(
+                    int(x.strip()) for x in m.group(1).split(",") if x.strip()
+                )
+
+            # ── METRICS = ("avg", "p50", "p95") ──
+            m = re.search(r"^METRICS\s*=\s*[\[(]([^)\]]+)[)\]]", source, re.MULTILINE)
+            if m:
+                metrics = tuple(
+                    x.strip().strip('"\'') for x in m.group(1).split(",") if x.strip()
+                )
+
+            # ── REPORT = {"key": "value", ...} ──
+            # All key/value pairs are forwarded to register_external() as
+            # keyword arguments.  The function accepts whatever is declared —
+            # no whitelist, no hard-coding.
+            m = re.search(r"^REPORT\s*=\s*\{([^}]+)\}", source, re.MULTILINE)
+            if m:
+                for item in m.group(1).split(","):
+                    item = item.strip()
+                    if ":" not in item:
+                        continue
+                    k, v = item.split(":", 1)
+                    k = k.strip().strip('"\'')
+                    v = v.strip().strip('"\'')
+                    # serialised bools
+                    if v.lower() in ("true", "yes"):
+                        v = True
+                    elif v.lower() in ("false", "no"):
+                        v = False
+                    # serialised ints
+                    elif v.lstrip("-").isdigit():
+                        v = int(v)
+                    report_kwargs[k] = v
+
+            # ── no_concurrency: detect scripts without -c argument ──
+            no_concurrency = not bool(
+                re.search(r'add_argument\("?-c"', source)
+                or re.search(r'add_argument\("?--concurrency"', source)
+            )
+
+            # ── SWEEP = [{"-d": 0}, {"-d": 10}, ...] for no_concurrency sweeps ──
+            sweep_args = None
+            if no_concurrency:
+                m = re.search(r'^SWEEP\s*=\s*\[([^]]+)\]', source, re.MULTILINE)
+                if m:
+                    sweep_args = []
+                    for chunk in m.group(1).split("}"):
+                        chunk = chunk.strip().strip(",").strip()
+                        if not chunk or "{" not in chunk:
+                            continue
+                        inner = chunk.split("{", 1)[1].strip()
+                        args = []
+                        for pair in inner.split(","):
+                            pair = pair.strip().strip('"\'')
+                            if ":" not in pair:
+                                continue
+                            k, v_raw = pair.split(":", 1)
+                            args.append(k.strip().strip('"\' '))
+                            v = v_raw.strip().strip('"\' ')
+                            args.append(v)  # always str for subprocess
+                        if args:
+                            sweep_args.append(args)
+        except Exception:
+            pass
+
+        register_external(
+            key, str(p),
+            title=title,
+            levels=levels,
+            metrics=metrics,
+            no_concurrency=no_concurrency,
+            sweep_args=sweep_args,
+            **report_kwargs,
+        )
+        registered_keys.add(key)
+
+    if candidates:
+        print(f"[perf] registered {len(candidates)} external script(s)")
+    else:
+        print("[perf] no external scripts found — nothing registered")
+
+
+def register_external(
+    key: str,
+    path: str,
+    *,
+    title: str = "",
+    levels: "tuple[int, ...] | None" = None,
+    rounds: int = 5,
+    metrics: "tuple[str, ...] | None" = None,
+    timeout: int = 300,
+    no_concurrency: bool = False,  # True → run once without -c / -n
+    sweep_args: "list[list] | None" = None,  # for no_concurrency scripts, e.g. [["-d", 0], ["-d", 10]]
+    # ── Report metadata (maps to ReportSection fields) ──
+    table: str = "",               # "latency" | "dirty" (default: latency or dirty if no_concurrency)
+    method_zh: str = "",           # 操作方法中文名
+    method_en: str = "",           # operation method English name
+    noun_zh: str = "",             # 操作计量单位中文
+    noun_en: str = "",             # operation unit English
+    throughput: bool = False,      # include per-second throughput column
+    star: bool = False,            # mark as starred in report
+    order: float | None = None,    # section ordering (default: append order)
+) -> None:
+    """Register a decoupled external ``.py`` script as a perf scenario.
+
+    **Convention for script authors**
+        The script MUST accept ``-c <N>`` (concurrency) and ``-n <N>``
+        (op count).  ``--rounds <N>`` and ``--no-header`` are passed
+        additionally — add them as optional flags.
+
+    **Report metadata** (optional, maps to ReportSection fields):
+
+        - *table*: "latency" or "dirty" (default: latency, or dirty if no_concurrency)
+        - *method_zh* / *method_en*: operation description (e.g. "创建沙箱" / "Create Sandbox")
+        - *noun_zh* / *noun_en*: operation unit (e.g. "次" / "op")
+        - *throughput*: show per-second throughput column
+        - *star*: mark scenario as starred in report
+        - *order*: section ordering (default: append-based)
+
+        Example::
+
+            # bench_clone.py
+            '''Clone concurrency benchmark.'''
+
+            import argparse
+            ap = argparse.ArgumentParser()
+            ap.add_argument("-c", type=int, default=1)
+            ap.add_argument("-n", type=int, default=5)
+            ap.add_argument("--rounds", type=int, default=3)
+            ap.add_argument("--no-header", action="store_true")
+            args = ap.parse_args()
+
+            from cubesandbox import Sandbox
+            sb = Sandbox.create("tpl-xxx")
+            sb.clone(n=args.n, concurrency=args.c)
+            sb.kill()
+
+    The framework sweeps *levels*, calling the script once per level::
+
+        python bench_xxx.py -c <level> -n <rounds> --rounds <rounds> --no-header
+
+    Each invocation's wall‑clock time is recorded as a single data point.
+    """
+    import subprocess
+    import sys as _sys
+    import time as _time
+
+    from .runner import PerfSample, PerfResult, PERF_RESULTS, print_parallel_stats, red, yellow
+
+    _script_path = path
+    _levels = _resolve_levels(key, levels or CONCURRENCY_LEVELS)
+    _rounds = rounds or PERF_ROUNDS
+
+    # Build report metadata — ReportSection drives report.md / report.zh.md.
+    _section_title = title or key.capitalize()
+    _metrics = metrics or ("avg", "min", "p95", "max")
+    _section = ReportSection(
+        table=table or ("dirty" if no_concurrency else "latency"),
+        title_zh=_section_title,
+        title_en=_section_title,
+        method_zh=method_zh,
+        method_en=method_en,
+        noun_zh=noun_zh,
+        noun_en=noun_en,
+        throughput=throughput,
+        star=star,
+        metrics=_metrics,
+        order=order if order is not None else (100.0 + len(REPORT_SECTIONS)),
+    )
+    header = f" [Perf] {_section_title}"
+
+    # Capture template flag check at registration time (before _script_path
+    # is overwritten by the next register_external call).
+    _has_template_arg = re.search(
+        rf'add_argument\(["\']--template["\']',
+        _SCRIPT_SOURCE_CACHE.get(path, ""),
+    ) is not None
+
+    @benchmark(key, aliases=None, report=[_section])
+    def _bench(cfg: Config) -> None:
+        print(f"\n{'=' * 60}")
+        print(f"{header:^60}")
+        print(f"{'=' * 60}")
+
+        if no_concurrency:
+            # Single or swept run — the script manages its own parameters.
+            # Auto-pass --template if the script accepts it.
+            # If sweep_args is set, run once per arg set (e.g. -d 0, -d 10, ...).
+            _sweeps = sweep_args or [[]]
+            for _sweep in _sweeps:
+                cmd = [_sys.executable, path]
+                if cfg.template_id and _has_template_arg:
+                    cmd += ["--template", cfg.template_id]
+                cmd += _sweep
+                _sweep_label = "_".join(str(a) for a in _sweep) if _sweep else "default"
+                _sweep_header = f"{header} [{_sweep_label}]" if _sweep else header
+                # Build extra dict from sweep args (e.g. {"dmb": 0} for -d 0)
+                _extra: dict = {}
+                _sweep_iter = iter(_sweep)
+                for flag in _sweep_iter:
+                    if flag.startswith("-"):
+                        val = next(_sweep_iter, "")
+                        if flag == "-d":
+                            _extra["dmb"] = int(val)
+                            _extra["write_mb"] = int(val)
+                        else:
+                            _extra[flag.lstrip("-")] = val
+                # Build scenario key to match _dirty_table pattern:
+                #   snapshot-dirty-<write_mb>mb
+                _scenario_key = key
+                _dmb = _extra.get("dmb")
+                if _dmb is not None:
+                    _scenario_key = f"{key}-{_dmb}mb"
+                t0 = time.time()
+                try:
+                    proc = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+                except subprocess.TimeoutExpired:
+                    wall = (time.time() - t0) * 1000
+                    result = PerfResult(scenario=_scenario_key, samples=[PerfSample(label="", latency_ms=wall)])
+                    result.samples[0].extra = {**_extra, "error": "TIMEOUT"}
+                    PERF_RESULTS.append(result)
+                    print(f"  {_sweep_header}: TIMEOUT after {wall:.0f}ms")
+                    continue
+
+                wall = (time.time() - t0) * 1000
+                if proc.returncode != 0:
+                    err = (proc.stderr or "").strip()[:500]
+                    result = PerfResult(scenario=_scenario_key, samples=[PerfSample(label="", latency_ms=wall)])
+                    result.samples[0].extra = {**_extra, "error": f"rc={proc.returncode}: {err}"}
+                    PERF_RESULTS.append(result)
+                    print(f"  {_sweep_header}: wall={wall:.0f}ms ERR(rc={proc.returncode})")
+                    if err:
+                        for line in err.split("\n"):
+                            print(f"    {line}")
+                else:
+                    parsed = _parse_dirty_stdout(proc.stdout or "")
+                    if parsed:
+                        _extra.update(parsed)
+                        sample_latency = parsed.get("snap_avg_ms", wall)
+                        print(f"  {_sweep_header}: wall={wall:.0f}ms "
+                              f"snap_avg={parsed['snap_avg_ms']:.1f}ms "
+                              f"create_avg={parsed['create_avg_ms']:.1f}ms")
+                    else:
+                        sample_latency = wall
+                        print(f"  {_sweep_header}: wall={wall:.0f}ms")
+                    result = PerfResult(scenario=_scenario_key, samples=[PerfSample(label="", latency_ms=sample_latency)])
+                    result.samples[0].extra = _extra
+                    PERF_RESULTS.append(result)
+            return
+            t0 = _time.time()
+            try:
+                proc = subprocess.run(
+                    cmd, capture_output=True, text=True, timeout=timeout,
+                )
+            except subprocess.TimeoutExpired:
+                wall = (_time.time() - t0) * 1000
+                result = PerfResult(
+                    scenario=key,
+                    samples=[PerfSample(label="", latency_ms=wall)],
+                )
+                result.samples[0].extra["error"] = "TIMEOUT"
+                PERF_RESULTS.append(result)
+                print(f"  TIMEOUT after {wall:.0f}ms")
+                return
+
+            wall = (_time.time() - t0) * 1000
+            if proc.returncode != 0:
+                err = (proc.stderr or "").strip()[:1000]
+                result = PerfResult(
+                    scenario=key,
+                    samples=[PerfSample(label="", latency_ms=wall)],
+                )
+                result.samples[0].extra["error"] = f"rc={proc.returncode}: {err}"
+                PERF_RESULTS.append(result)
+                print(f"  wall={wall:.0f}ms {yellow(f'ERR(rc={proc.returncode})')}")
+                if err:
+                    for line in err.split("\n"):
+                        print(f"    {red(line)}")
+            else:
+                result = PerfResult(
+                    scenario=key,
+                    samples=[PerfSample(label="", latency_ms=wall)],
+                )
+                PERF_RESULTS.append(result)
+                print(f"  wall={wall:.0f}ms")
+            _post_concurrency_cleanup(key, 1)
+            print(f"{'=' * 60}\n")
+            return
+
+        # Concurrency-sweep path
+        for c in _levels:
+            cmd = [
+                _sys.executable, _script_path,
+                "-c", str(c), "-n", str(_rounds),
+                "--rounds", str(_rounds), "--no-header",
+            ]
+            t0 = _time.time()
+            try:
+                proc = subprocess.run(
+                    cmd, capture_output=True, text=True, timeout=timeout,
+                )
+            except subprocess.TimeoutExpired:
+                wall = (_time.time() - t0) * 1000
+                result = PerfResult(
+                    scenario=key,
+                    samples=[PerfSample(label="", latency_ms=wall)],
+                )
+                result.samples[0].extra["error"] = "TIMEOUT"
+                PERF_RESULTS.append(result)
+                print(f"  concurrency={c:>2}: TIMEOUT after {wall:.0f}ms")
+                continue
+
+            wall = (_time.time() - t0) * 1000
+            per_ms = wall / _rounds if _rounds else 0
+            scenario_key = f"{key}-c{c}"
+            if proc.returncode != 0:
+                err = (proc.stderr or "").strip()[:1000]
+                result = PerfResult(
+                    scenario=scenario_key,
+                    samples=[PerfSample(label="", latency_ms=wall, extra={"wall_ms": wall, "per_ms": per_ms})],
+                )
+                result.samples[0].extra["error"] = f"rc={proc.returncode}: {(proc.stderr or '').strip()[:1000]}"
+                PERF_RESULTS.append(result)
+                print(
+                    f"  concurrency={c:>2}: wall={wall:.0f}ms "
+                    f"{yellow(f'ERR(rc={proc.returncode})')}"
+                )
+                if err:
+                    for line in err.split("\n"):
+                        print(f"    {red(line)}")
+            else:
+                # Parse script stdout for detailed metrics.
+                # Format: "avg=Xms min=Xms p95=Xms max=Xms wall=Xms per=Xms"
+                stdout = (proc.stdout or "").strip()
+                parsed = _parse_bench_stdout(stdout) if stdout else {}
+                extra = {"wall_ms": wall, "per_ms": per_ms}
+                extra.update({k: v for k, v in parsed.items() if k not in ("wall_ms", "per_ms")})
+
+                sample = PerfSample(label="", latency_ms=parsed.get("avg_ms", wall), extra=extra)
+                result = PerfResult(scenario=scenario_key, samples=[sample])
+                PERF_RESULTS.append(result)
+
+                if parsed:
+                    print(f"  concurrency={c:>2}: avg={parsed['avg_ms']:.1f}ms "
+                          f"p95={parsed['p95_ms']:.1f}ms max={parsed['max_ms']:.1f}ms")
+                else:
+                    print(f"  concurrency={c:>2}: wall={wall:.0f}ms")
+            _post_concurrency_cleanup(scenario_key, c)
+        print(f"{'=' * 60}\n")
+
+
+_STDOUT_PARSE_RE = re.compile(
+    r"avg=(?P<avg>[0-9.]+)ms\s+min=(?P<min>[0-9.]+)ms\s+p95=(?P<p95>[0-9.]+)ms\s+max=(?P<max>[0-9.]+)ms"
+)
+
+
+def _parse_dirty_stdout(stdout: str) -> dict[str, float]:
+    """Parse bench_snapshot_dirty's last data line.
+
+    Layout (whitespace-separated, last line only):
+        write_MB  dirty_MB_avg  snap_avg  snap_min  snap_p95  snap_max
+        create_avg  create_min  create_p95  create_max
+    """
+    lines = [l for l in stdout.splitlines() if l.strip()]
+    if not lines:
+        return {}
+    parts = lines[-1].split()
+    if len(parts) < 10:
+        return {}
+    return {
+        "write_mb": float(parts[0]),
+        "dirty_mb": float(parts[1]),
+        "snap_avg_ms": float(parts[2]),
+        "snap_min_ms": float(parts[3]),
+        "snap_p95_ms": float(parts[4]),
+        "snap_max_ms": float(parts[5]),
+        "create_avg_ms": float(parts[6]),
+        "create_min_ms": float(parts[7]),
+        "create_p95_ms": float(parts[8]),
+        "create_max_ms": float(parts[9]),
+    }
+
+
+def _parse_bench_stdout(stdout: str) -> dict[str, float]:
+    """Parse bench script stdout. Returns ``{}`` when the output format
+    is not recognised (fallback: wall-clock measurement)."""
+    m = _STDOUT_PARSE_RE.search(stdout)
+    if not m:
+        return {}
+    return {
+        "avg_ms": float(m.group("avg")),
+        "min_ms": float(m.group("min")),
+        "p95_ms": float(m.group("p95")),
+        "max_ms": float(m.group("max")),
+    }
+
+
+def _post_concurrency_cleanup(name: str, concurrency: int) -> None:
+    """每档并发跑完后清理残留快照（懒加载，避免循环 import）。
+
+    由 ``_bench()`` 在每轮 ``for c in _levels`` 末尾调用。此函数是
+    ``ops.cleanup.post_concurrency_cleanup`` 的薄包装，import 只在首次
+    调用时发生，不会拖慢冷启动。
+    """
+    if not _is_auto_cleanup_enabled():
+        return
+    from ..ops.cleanup import post_concurrency_cleanup
+    post_concurrency_cleanup(f"{name}/c={concurrency}")
+
+
+def _is_auto_cleanup_enabled() -> bool:
+    return os.environ.get("CUBE_PERF_AUTO_CLEANUP", "1") != "0"
+
+
+def _resolve_levels(
+    label: str,
+    default_levels: "tuple[int, ...]",
+    concurrency_key: str = "CONCURRENCY_LEVELS",
+) -> "tuple[int, ...]":
+    """Per‑scenario concurrency override via ``CUBE_<LABEL>_CONCURRENCY``.
+
+    e.g. ``CUBE_CLONE_CONCURRENCY=1,5,10`` overrides the global default for the
+    clone scenario while other scenarios keep their global ladders.
+    """
+    import os as _os
+
+    env = _os.environ.get(f"CUBE_{label.upper().replace('-', '_')}_CONCURRENCY")
+    if env:
+        try:
+            return tuple(int(x.strip()) for x in env.split(",") if x.strip())
+        except Exception:
+            pass
+    return default_levels
+
+
+def _open_pool(factory: "Callable[..., Any]", cfg: Config) -> Any:
+    """Open a pool context manager, passing *cfg* only if the factory takes it.
+
+    Bridges the two pool shapes: ``sandbox_pool()`` (no args) and
+    ``snapshot_pool(cfg)`` (needs the config to delete snapshots).
+    """
+    if inspect.signature(factory).parameters:
+        return factory(cfg)
+    return factory()
+
+
+# ---------------------------------------------------------------------------
+# Scenario selection
+# ---------------------------------------------------------------------------
+#
+# The registry / aliases / report groups are all populated by the
+# ``@benchmark`` decorator as ``cases/`` modules import, so this section only
+# derives the run list and the report-scenario view — there is nothing to
+# hand-maintain here.
+
+
+def default_report_scenarios() -> "list[dict]":
+    """Default HTML-report chart/table groups, derived from ``@benchmark(report=...)``.
+
+    ``report_html`` consumes this so a charted scenario is declared in the
+    same one-liner that registers the benchmark (see ``ReportChart``).
+    """
+    return [dict(g) for g in REPORT_SCENARIOS]
+
+
+def default_report_sections() -> "list[dict]":
+    """Default Markdown-report sections, derived from ``@benchmark(report=...)``.
+
+    ``reporting.report`` consumes this so a scenario's Markdown section (title,
+    "测试方式" note, table type, throughput/conclusion knobs) is declared in the
+    same one-liner that registers the benchmark (see ``ReportSection``).
+    Returned sorted by ``order`` so the caller can render / number them
+    directly; a stable secondary sort keeps declaration order for ties.
+    """
+    return sorted((dict(s) for s in REPORT_SECTIONS), key=lambda s: s["order"])
+
+
+def available_scenarios() -> "list[str]":
+    """Return the canonical scenario keys plus aliases, for CLI help / listing."""
+    return list(BENCHMARK_REGISTRY.keys()) + list(BENCHMARK_ALIASES.keys())
+
+
+def select_benchmarks(selected: "list[str] | None") -> "list[Callable[[Config], None]]":
+    """Resolve scenario keys/aliases into an ordered, de-duplicated bench list.
+
+    *selected* is a list of scenario keys or aliases (case-insensitive; a
+    leading ``no-``/``skip-`` prefix excludes that scenario). When it is
+    ``None`` / empty, the full suite is returned. Unknown tokens raise
+    ``ValueError`` listing the valid choices.
+
+    Side effect: rebuilds ``_FORCED_KEYS`` with the scenarios explicitly named
+    here (excluding the ``all`` wildcard), so a named default-off/-on scenario
+    bypasses its opt-in/opt-out env gate at run time.
+    """
+    _FORCED_KEYS.clear()
+    if not selected:
+        return list(BENCHMARK_REGISTRY.values())
+
+    def _expand(key: str) -> "list[str]":
+        if key == "all":  # derived alias for the whole suite
+            return list(BENCHMARK_REGISTRY)
+        if key in BENCHMARK_ALIASES:
+            return list(BENCHMARK_ALIASES[key])
+        if key in BENCHMARK_REGISTRY:
+            return [key]
+        return []
+
+    include: "set[str]" = set()
+    exclude: "set[str]" = set()
+    unknown: "list[str]" = []
+    for raw in selected:
+        token = raw.strip().lower()
+        if not token:
+            continue
+        negate = False
+        for prefix in ("no-", "skip-", "!", "^"):
+            if token.startswith(prefix):
+                negate, token = True, token[len(prefix):]
+                break
+        keys = _expand(token)
+        if not keys:
+            unknown.append(raw)
+            continue
+        if negate:
+            exclude.update(keys)
+        else:
+            include.update(keys)
+            # ``all`` is a bulk wildcard, not an explicit pick — it must not
+            # force default-off scenarios (volume / ivshmem) on.
+            if token != "all":
+                _FORCED_KEYS.update(keys)
+
+    if unknown:
+        valid = ", ".join(sorted(set(BENCHMARK_REGISTRY) | set(BENCHMARK_ALIASES) | {"all"}))
+        raise ValueError(
+            f"unknown scenario(s): {', '.join(unknown)}\n  valid choices: {valid}"
+        )
+
+    # If only exclusions were given, start from the full set.
+    chosen = (include or set(BENCHMARK_REGISTRY)) - exclude
+    # Preserve the canonical registry order.
+    return [fn for key, fn in BENCHMARK_REGISTRY.items() if key in chosen]
+
+
+def collect_component_versions(cfg: Config) -> dict[str, str]:
+    """Collect component version info for the HTML report environment section.
+
+    Queries CubeAPI health endpoint and local system for component versions.
+    """
+    versions: dict[str, str] = {
+        "python_version": platform.python_version(),
+        "platform": platform.platform(),
+    }
+
+    # Try to get CubeAPI version from health endpoint
+    try:
+        import httpx
+
+        headers = {}
+        api_key = os.environ.get("CUBE_API_KEY") or os.environ.get("E2B_API_KEY", "")
+        if api_key:
+            headers["X-API-Key"] = api_key
+        resp = httpx.get(f"{cfg.api_url}/health", headers=headers, timeout=10)
+        if resp.status_code == 200:
+            data = resp.json()
+            if isinstance(data, dict):
+                for key in ("version", "commit", "build_time", "go_version"):
+                    if key in data:
+                        versions[f"cubeapi_{key}"] = str(data[key])
+    except Exception:
+        pass
+
+    # Try to get SDK version
+    try:
+        import cubesandbox
+
+        versions["sdk_version"] = cubesandbox.__version__
+    except Exception:
+        pass
+
+    return versions
+
+
+def run_all(cfg: Config, selected: "list[str] | None" = None) -> None:
+    """Run performance benchmarks in order.
+
+    *selected* is an optional list of scenario keys/aliases (see
+    ``BENCHMARK_REGISTRY`` / ``BENCHMARK_ALIASES``). When None/empty, the full
+    suite runs. Otherwise only the resolved subset runs.
+
+    Requires the ``perf.cases`` package to have been imported already so the
+    registry is populated (the CLI entry point does this).
+    """
+    benches = select_benchmarks(selected)
+
+    # Print component versions
+    versions = collect_component_versions(cfg)
+    print("\n--- Component Versions ---")
+    for k, v in sorted(versions.items()):
+        print(f"  {k}: {v}")
+    print()
+
+    if selected:
+        keys = [k for k, fn in BENCHMARK_REGISTRY.items() if fn in benches]
+        print(f"--- Selected scenarios ({len(benches)}): {', '.join(keys)} ---\n")
+
+    for bench_fn in benches:
+        bench_fn(cfg)

--- a/tests/perf/framework/runner.py
+++ b/tests/perf/framework/runner.py
@@ -1,0 +1,515 @@
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""Test runner primitives: counters, assertions, and perf measurement helpers.
+
+Holds the process-wide mutable state (pass/fail/skip counters, collected
+results) that `functional.py`, `report.py`, and the sibling `tests/perf/`
+benchmark package all read/write.
+"""
+
+from __future__ import annotations
+
+import statistics
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from contextlib import AbstractContextManager, contextmanager
+from dataclasses import dataclass, field
+from typing import Any, Callable, Iterator
+
+from cubesandbox import Config, Sandbox
+
+try:
+    from cubesandbox import Volume
+except ImportError:
+    Volume = None  # type: ignore[assignment]
+
+# ===========================================================================
+# Data classes
+# ===========================================================================
+
+
+@dataclass
+class PerfSample:
+    """A single performance measurement."""
+
+    label: str
+    latency_ms: float
+    concurrency: int = 1
+    extra: dict = field(default_factory=dict)
+
+
+@dataclass
+class PerfResult:
+    """Aggregated performance result for a scenario."""
+
+    scenario: str
+    samples: list[PerfSample] = field(default_factory=list)
+
+    @property
+    def errored(self) -> int:
+        """Number of samples that failed with an exception."""
+        return sum(1 for s in self.samples if s.extra.get("error"))
+
+    @property
+    def latencies(self) -> list[float]:
+        """Valid latencies only — errored samples are excluded from stats."""
+        return [s.latency_ms for s in self.samples if not s.extra.get("error")]
+
+    @property
+    def avg(self) -> float:
+        return statistics.mean(self.latencies) if self.latencies else 0
+
+    @property
+    def min(self) -> float:
+        return min(self.latencies) if self.latencies else 0
+
+    @property
+    def p50(self) -> float:
+        return self._percentile(50)
+
+    @property
+    def p95(self) -> float:
+        return self._percentile(95)
+
+    @property
+    def p99(self) -> float:
+        return self._percentile(99)
+
+    @property
+    def max(self) -> float:
+        return max(self.latencies) if self.latencies else 0
+
+    @property
+    def count(self) -> int:
+        return len(self.samples)
+
+    @property
+    def concurrency(self) -> int:
+        return self.samples[0].concurrency if self.samples else 1
+
+    def _percentile(self, p: float) -> float:
+        return percentile(self.latencies, p)
+
+
+def percentile(values: list[float], p: float) -> float:
+    """Compute the *p*-th percentile of *values* (0-100)."""
+    if not values:
+        return 0
+    sorted_vals = sorted(values)
+    k = (len(sorted_vals) - 1) * p / 100
+    f = int(k)
+    c = k - f
+    if f + 1 < len(sorted_vals):
+        return sorted_vals[f] + c * (sorted_vals[f + 1] - sorted_vals[f])
+    return sorted_vals[f]
+
+
+# ===========================================================================
+# Global state
+# ===========================================================================
+
+PASS = 0
+FAIL = 0
+SKIP = 0
+
+PERF_RESULTS: list[PerfResult] = []
+RESULTS: list[dict[str, Any]] = []
+_CURRENT_SECTION: str = ""
+
+
+def reset() -> None:
+    """Reset all module-level counters/results (useful for repeated runs/tests)."""
+    global PASS, FAIL, SKIP, _CURRENT_SECTION
+    PASS = 0
+    FAIL = 0
+    SKIP = 0
+    _CURRENT_SECTION = ""
+    PERF_RESULTS.clear()
+    RESULTS.clear()
+
+
+# ===========================================================================
+# Console colors
+# ===========================================================================
+
+
+def green(s: str) -> str:
+    return f"\033[32m{s}\033[0m"
+
+
+def red(s: str) -> str:
+    return f"\033[31m{s}\033[0m"
+
+
+def yellow(s: str) -> str:
+    return f"\033[33m{s}\033[0m"
+
+
+# ===========================================================================
+# Section / assertion helpers
+# ===========================================================================
+
+
+def section(num: int, title: str) -> None:
+    """Print a section header and remember it for report grouping."""
+    global _CURRENT_SECTION
+    _CURRENT_SECTION = f"[{num}] {title}"
+    print(f"\n{'='*60}")
+    print(f" {_CURRENT_SECTION}")
+    print(f"{'='*60}")
+
+
+def ok(label: str) -> None:
+    global PASS
+    PASS += 1
+    RESULTS.append({"section": _CURRENT_SECTION, "label": label, "status": "pass", "detail": ""})
+    print(f"  {green('PASS')}: {label}")
+
+
+def fail(label: str, detail: str = "") -> None:
+    global FAIL
+    FAIL += 1
+    RESULTS.append({"section": _CURRENT_SECTION, "label": label, "status": "fail", "detail": detail})
+    msg = f"  {red('FAIL')}: {label}"
+    if detail:
+        msg += f"  ({detail})"
+    print(msg)
+
+
+def skip(label: str, reason: str = "") -> None:
+    global SKIP
+    SKIP += 1
+    RESULTS.append({"section": _CURRENT_SECTION, "label": label, "status": "skip", "detail": reason})
+    msg = f"  {yellow('SKIP')}: {label}"
+    if reason:
+        msg += f"  [{reason}]"
+    print(msg)
+
+
+def assert_true(label: str, value: bool, detail: str = "") -> None:
+    if value:
+        ok(label)
+    else:
+        fail(label, detail or f"got {value!r}")
+
+
+def assert_eq(label: str, expected: Any, actual: Any) -> None:
+    if expected == actual:
+        ok(label)
+    else:
+        fail(label, f"expected={expected!r} actual={actual!r}")
+
+
+def assert_contains(label: str, haystack: Any, needle: Any) -> None:
+    if needle in str(haystack):
+        ok(label)
+    else:
+        fail(label, f"missing {needle!r} in {str(haystack)[:200]}")
+
+
+def is_getinfo_server_bug(exc: Exception) -> bool:
+    msg = str(exc).lower()
+    return "rfc 3339" in msg or "deserial" in msg
+
+
+# ===========================================================================
+# Perf measurement helpers
+# ===========================================================================
+
+
+def measure(label: str, fn: Callable[[], Any], concurrency: int = 1, extra: dict | None = None) -> PerfSample:
+    """Time a callable and return a PerfSample."""
+    start = time.perf_counter()
+    fn()
+    elapsed_ms = (time.perf_counter() - start) * 1000
+    return PerfSample(label=label, latency_ms=elapsed_ms, concurrency=concurrency, extra=extra or {})
+
+
+def measure_one(fn: Callable[[], Any]) -> PerfSample:
+    start = time.perf_counter()
+    try:
+        fn()
+    except Exception as exc:
+        elapsed_ms = (time.perf_counter() - start) * 1000
+        sample = PerfSample(label="", latency_ms=elapsed_ms)
+        sample.extra["error"] = _shorten(str(exc))
+        return sample
+    elapsed_ms = (time.perf_counter() - start) * 1000
+    return PerfSample(label="", latency_ms=elapsed_ms)
+
+
+def _shorten(msg: str, limit: int = 500) -> str:
+    return msg[:limit] + ("…" if len(msg) > limit else "")
+
+
+def measure_parallel(label: str, fn: Callable[[], Any], n: int, concurrency: int) -> PerfResult:
+    """Run *fn* *n* times with *concurrency* workers, return aggregated result."""
+    result = PerfResult(scenario=label)
+    wall_start = time.perf_counter()
+    with ThreadPoolExecutor(max_workers=concurrency) as pool:
+        futures = [pool.submit(lambda: measure_one(fn)) for _ in range(n)]
+        for fut in as_completed(futures):
+            result.samples.append(fut.result())
+    wall_ms = (time.perf_counter() - wall_start) * 1000
+    for s in result.samples:
+        s.concurrency = concurrency
+        s.extra["wall_ms"] = wall_ms
+        s.extra["per_ms"] = wall_ms / n
+    return result
+
+
+# The latency fields ``print_parallel_stats`` can render, keyed by the short
+# name a scenario names in ``metrics=(...)``. Order here is the print order.
+_STAT_GETTERS: "dict[str, Callable[[PerfResult], float]]" = {
+    "avg": lambda r: r.avg,
+    "min": lambda r: r.min,
+    "p50": lambda r: r.p50,
+    "p95": lambda r: r.p95,
+    "p99": lambda r: r.p99,
+    "max": lambda r: r.max,
+}
+
+# Shown when a scenario does not name its own ``metrics`` — the historic set.
+DEFAULT_STAT_METRICS: "tuple[str, ...]" = ("avg", "min", "p95", "max")
+
+
+def print_parallel_stats(result: PerfResult, metrics: "tuple[str, ...] | None" = None) -> None:
+    """Print the one-line concurrency summary shared by every parallel sweep.
+
+    *metrics* picks which latency fields to show (any of ``avg`` / ``min`` /
+    ``p50`` / ``p95`` / ``p99`` / ``max``), in the given order; unknown names
+    are ignored. ``None`` falls back to :data:`DEFAULT_STAT_METRICS`. The
+    trailing ``wall`` / ``per`` throughput columns are always shown.
+    """
+    extra = result.samples[0].extra if result.samples else {}
+    stats = " ".join(
+        f"{name}={_STAT_GETTERS[name](result):.1f}ms"
+        for name in (metrics or DEFAULT_STAT_METRICS)
+        if name in _STAT_GETTERS
+    )
+    suffix = ""
+    if result.errored:
+        suffix = red(f"  errors={result.errored}/{result.count}")
+    print(f"  concurrency={result.concurrency:>2}: {stats}  "
+          f"wall={extra.get('wall_ms', 0):.0f}ms "
+          f"per={extra.get('per_ms', 0):.1f}ms{suffix}")
+    if result.errored:
+        # Print up to 3 unique error messages so the user sees the root cause.
+        seen: set[str] = set()
+        for s in result.samples:
+            err = s.extra.get("error", "")
+            if err and err not in seen:
+                seen.add(err)
+                print(f"         {red(err[:120])}")
+            if len(seen) >= 3:
+                break
+
+
+# ===========================================================================
+# Scenario fixtures (context managers)
+# ===========================================================================
+#
+# These take the pytest-style "setup / teardown around the body" pattern and
+# make it fit a benchmark loop: they own the sandbox/snapshot *lifecycle* so a
+# scenario body only writes the operation it actually measures. They replace
+# the ``try/finally: sb.kill()`` (and snapshot-delete) boilerplate that was
+# copy-pasted across the "sandbox is a precondition, not the measured op"
+# scenarios (rollback / pause-resume / clone / ivshmem).
+#
+# Cleanup is always best-effort (swallows exceptions) so a teardown failure
+# never masks the real error or aborts the loop, matching the previous inline
+# ``except Exception: pass`` behaviour. Note these create a *fresh* resource
+# per ``with`` block, which is exactly what the per-round loops need — unlike a
+# pytest fixture that would be shared across the whole test.
+
+
+@contextmanager
+def sandbox(cfg: Config, template_id: "str | None" = None, *,
+            timeout: int = 120, **create_opts: Any) -> "Iterator[Sandbox]":
+    """Create a sandbox for the duration of the block, always killing it on exit.
+
+    *template_id* defaults to ``cfg.template_id``; extra keyword args are passed
+    straight through to ``Sandbox.create`` (e.g. ``volume_mounts=[...]``).
+
+    Usage::
+
+        with sandbox(cfg) as sb:
+            ...  # measure operations on sb; kill() is automatic
+    """
+    sb = Sandbox.create(template_id or cfg.template_id, timeout=timeout, config=cfg, **create_opts)
+    try:
+        yield sb
+    finally:
+        try:
+            sb.kill()
+        except Exception:
+            pass
+
+
+def sandbox_op(cfg: Config, action: "Callable[[Sandbox], Any]",
+               template_id: "str | None" = None, **create_opts: Any) -> "Callable[[], Any]":
+    """Build a timed op that runs *action* against a throwaway sandbox.
+
+    Folds the ``with sandbox(cfg) as sb: action(sb)`` pattern into a single
+    callable, so a ``parallel_sweep`` scenario whose measured op is "spin up a
+    fresh box, do one thing to it, tear it down" collapses to one ``yield``
+    instead of a nested ``def op(): with sandbox(...)``::
+
+        with snapshot_pool(cfg) as snaps:
+            yield sandbox_op(cfg, lambda sb: snaps.add(sb.create_snapshot().snapshot_id))
+
+    *action*'s return value is propagated (so the op can feed a pool); extra
+    kwargs pass through to ``sandbox()`` / ``Sandbox.create``.
+    """
+    def op() -> Any:
+        with sandbox(cfg, template_id, **create_opts) as sb:
+            return action(sb)
+    return op
+
+
+@contextmanager
+def snapshot(cfg: Config, template_id: "str | None" = None, *,
+             timeout: int = 120, **create_opts: Any) -> "Iterator[tuple[Sandbox, str]]":
+    """Create sandbox -> snapshot it, yield ``(sandbox, snapshot_id)``, clean up both.
+
+    On exit the snapshot is deleted first, then the sandbox is killed (both
+    best-effort). Suited to scenarios that need a live sandbox *and* one of its
+    snapshots (e.g. rollback).
+
+    Usage::
+
+        with snapshot(cfg) as (sb, snap_id):
+            sb.rollback(snap_id)  # delete_snapshot + kill are automatic
+    """
+    with sandbox(cfg, template_id, timeout=timeout, **create_opts) as sb:
+        snap = sb.create_snapshot()
+        snap_id = snap.snapshot_id
+        try:
+            yield sb, snap_id
+        finally:
+            try:
+                Sandbox.delete_snapshot(snap_id, config=cfg)
+            except Exception:
+                pass
+
+
+def snapshot_op(cfg: Config, action: "Callable[[Sandbox, str], Any]",
+                template_id: "str | None" = None, **create_opts: Any) -> "Callable[[], Any]":
+    """Build a timed op that runs *action* against a fresh sandbox + its snapshot.
+
+    The ``snapshot()`` sibling of :func:`sandbox_op`: it folds the
+    ``with snapshot(cfg) as (sb, snap_id): action(sb, snap_id)`` pattern into one
+    callable, so a ``parallel_sweep`` scenario whose measured op needs both a
+    live box *and* one of its snapshots (e.g. rollback) collapses to one
+    ``yield`` instead of a nested ``def op(): with snapshot(...)``::
+
+        yield snapshot_op(cfg, lambda sb, snap_id: sb.rollback(snap_id))
+
+    *action*'s return value is propagated; extra kwargs pass through to
+    ``snapshot()`` / ``sandbox()`` / ``Sandbox.create``.
+    """
+    def op() -> Any:
+        with snapshot(cfg, template_id, **create_opts) as (sb, snap_id):
+            return action(sb, snap_id)
+    return op
+
+
+class _Pool:
+    """A thread-safe collector of resources, cleaned up en masse on scope exit.
+
+    Type-agnostic on purpose: ``add()`` just accumulates whatever it is handed —
+    a ``Sandbox``, a snapshot-id ``str``, a ``Volume`` — under a lock, so one
+    collector backs all three resource lines instead of each hand-copying an
+    identical ``list + lock + add/len/iter`` triad. The paired ``_pool(...)``
+    engine supplies the per-item teardown; ``__len__`` / iteration let a
+    scenario read the live count (e.g. density's per-sandbox overhead).
+    """
+
+    def __init__(self) -> None:
+        self._items: "list[Any]" = []
+        self._lock = threading.Lock()
+
+    def add(self, item: Any) -> Any:
+        with self._lock:
+            self._items.append(item)
+        return item
+
+    def __len__(self) -> int:
+        return len(self._items)
+
+    def __iter__(self) -> "Iterator[Any]":
+        return iter(list(self._items))
+
+
+@contextmanager
+def _pool(teardown: "Callable[[Any], Any]") -> "Iterator[_Pool]":
+    """Yield a :class:`_Pool`, applying *teardown* to every item on scope exit.
+
+    The shared engine behind ``sandbox_pool`` / ``snapshot_pool`` /
+    ``volume_pool``: each names only its one-line *teardown* closure (the sole
+    axis on which the three pools differ) and hands it here. Teardown runs
+    best-effort per item (exceptions swallowed) so one failure never aborts
+    cleanup of the rest, matching the old inline ``except Exception: pass``.
+    """
+    pool = _Pool()
+    try:
+        yield pool
+    finally:
+        for item in pool:
+            try:
+                teardown(item)
+            except Exception:
+                pass
+
+
+def sandbox_pool() -> "AbstractContextManager[_Pool]":
+    """Collect any number of sandboxes, killing them all (best-effort) on exit.
+
+    Unlike ``sandbox()`` (one box per ``with``), this owns a *pool*: it suits
+    the scenarios where creation itself is the measured op and the sandboxes
+    are just cleanup debt (template-create, density, volume-mount-sandbox).
+    Takes no ``cfg`` — a sandbox tears itself down via ``kill()``.
+
+    Usage::
+
+        with sandbox_pool() as pool:
+            pool.add(Sandbox.create(...))  # thread-safe; all killed on exit
+    """
+    return _pool(lambda sb: sb.kill())
+
+
+def snapshot_pool(cfg: Config) -> "AbstractContextManager[_Pool]":
+    """Collect snapshot ids, deleting them all (best-effort) on scope exit.
+
+    The snapshot-id counterpart of ``sandbox_pool()``: when snapshot *creation*
+    is the measured op, the resulting snapshots are just cleanup debt. Needs
+    *cfg* because ``delete_snapshot`` is a config-scoped call.
+
+    Usage::
+
+        with snapshot_pool(cfg) as snaps:
+            snaps.add(sb.create_snapshot().snapshot_id)  # all deleted on exit
+    """
+    return _pool(lambda snap_id: Sandbox.delete_snapshot(snap_id, config=cfg))
+
+
+def volume_pool(cfg: Config) -> "AbstractContextManager[_Pool]":
+    """Collect volumes, destroying them all (best-effort) on scope exit.
+
+    The volume counterpart of ``sandbox_pool()`` / ``snapshot_pool()``. It
+    stores whole ``Volume`` objects — teardown reads ``.volume_id`` off each —
+    so a scenario keeps the handle it needs (e.g. to build a ``mount(...)``)
+    while the pool owns cleanup. Re-destroying a volume the scenario already
+    destroyed is a harmless no-op (teardown swallows exceptions). Needs *cfg*
+    because ``Volume.destroy`` is a config-scoped call.
+
+    When a scenario also owns sandboxes that *mount* these volumes, nest a
+    ``sandbox_pool()`` **inside** this block so the sandboxes are killed (inner
+    exit) before their volumes are destroyed (outer exit)::
+
+        with volume_pool(cfg) as vols:
+            with sandbox_pool() as boxes:
+                ...  # boxes killed first, then vols destroyed
+    """
+    return _pool(lambda vol: Volume.destroy(vol.volume_id, config=cfg))

--- a/tests/perf/ops/__init__.py
+++ b/tests/perf/ops/__init__.py
@@ -1,0 +1,7 @@
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""业务模块 — CubeSandbox 平台操作的封装。
+
+压测后资源清理、脚本导入等平台操作都放在这里，
+通过 SDK 调用底层 API（不拼裸 HTTP）。
+"""

--- a/tests/perf/ops/cleanup.py
+++ b/tests/perf/ops/cleanup.py
@@ -1,0 +1,176 @@
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""平台运维操作 — 默认脚本注册、快照 CRUD、压测中/后资源清理。
+
+通过 SDK 调用底层 API（不拼裸 HTTP），操作仅限快照（``snap-*`` 前缀 ID），
+不动普通模板。
+"""
+
+from __future__ import annotations
+
+import os
+import time
+
+
+# ── 默认脚本注册 ──────────────────────────────────────────────────────
+
+_DEFAULT_SCRIPTS = [
+    "../examples/snapshot-rollback-clone/bench_clone_concurrency.py",
+    "../examples/snapshot-rollback-clone/bench_create_concurrency.py",
+    "../examples/snapshot-rollback-clone/bench_snapshot_concurrency.py",
+    "../examples/snapshot-rollback-clone/bench_rollback_concurrency.py",
+    "../examples/snapshot-rollback-clone/bench_pause_resume_concurrency.py",
+    "../examples/snapshot-rollback-clone/bench_snapshot_dirty.py",
+    "../examples/ivshmem/ivshmem_benchmark.py",
+]
+
+
+def register_default_scripts():
+    """Always register all built-in example scripts.
+
+    ``CUBE_EXTERNAL_SCRIPTS`` is force-set to the full default list (globs) so
+    that a previous filtered run (e.g. ``--scenarios snapshot-dirty``) never
+    leaves only a single script in ``.env``. The env var is intentionally NOT
+    in ``_TUNABLE_ENV_KEYS`` to avoid being persisted.
+    """
+    from ..framework import registry
+
+    os.environ["CUBE_EXTERNAL_SCRIPTS"] = ",".join(_DEFAULT_SCRIPTS)
+    registry.discover_external_scripts()
+
+
+# ── 快照 CRUD（仅 snap-*，不动模板）───────────────────────────────────
+
+def list_snapshots():
+    """返回当前所有 ``snap-*`` 快照，过滤掉正在使用中的。
+
+    有活跃 replica（如 12cc1289f9...@9.135.79.34）的快照不可删除，
+    直接从列表中排除，避免 delete 时触发 130409 错误。
+    """
+    import sys
+    from cubesandbox import Template
+    try:
+        tmpls = Template.list()
+    except Exception as exc:
+        print(f"[cleanup] Template.list() failed: {exc}", file=sys.stderr)
+        return []
+    result = []
+    for t in tmpls:
+        tid = t.template_id or ""
+        if not tid.startswith("snap-"):
+            continue
+        # Skip snapshots that have active replicas (in-use sandboxes).
+        # Deleting them would fail with 130409 — just skip silently.
+        if getattr(t, "replicas", []):
+            continue
+        result.append({
+            "template_id": tid,
+            "status": getattr(t, "status", "") or "",
+            "created_at": getattr(t, "created_at", "") or getattr(t, "createdAt", ""),
+        })
+    return result
+
+
+def delete_snapshots(ids: list[str]) -> tuple[int, int]:
+    """批量删除快照，遇到 130409 直接跳过，返回 (ok, fail)。
+
+    130409 涵盖两种不可删除的情况：
+    - "active runtime ref" — 快照被沙箱使用
+    - "active snapshot operation" — 另一个快照操作进行中
+
+    这两种重试也没用，直接跳过。
+    """
+    import sys
+    from cubesandbox import Template
+
+    ok = fail = 0
+    for tid in ids:
+        try:
+            Template.delete(tid)
+            ok += 1
+        except Exception as exc:
+            msg = str(exc)
+            if "130409" in msg:
+                print(f"[cleanup] {tid}: in use, skipped", file=sys.stderr)
+            else:
+                print(f"[cleanup] {tid}: {exc}", file=sys.stderr)
+            fail += 1
+    return ok, fail
+
+
+# ── 清理钩子 ──────────────────────────────────────────────────────────
+
+def _auto_cleanup_enabled() -> bool:
+    return os.environ.get("CUBE_PERF_AUTO_CLEANUP", "1") != "0"
+
+
+def _cleanup_wait_seconds() -> float:
+    return float(os.environ.get("CUBE_PERF_AUTO_CLEANUP_WAIT", "0"))
+
+
+def cleanup_all_snapshots(label: str = "") -> None:
+    """删除当前所有 snap-* 快照（可重入，每并发档跑完后调一次）。
+
+    默认激活；设 ``CUBE_PERF_AUTO_CLEANUP=0`` 可关闭。*label* 用于日志区分。
+    """
+    import sys
+
+    if not _auto_cleanup_enabled():
+        return
+
+    wait = _cleanup_wait_seconds()
+    if wait > 0:
+        time.sleep(wait)
+
+    snaps = list_snapshots()
+    if not snaps:
+        return
+
+    ids = [s["template_id"] for s in snaps]
+    tag = f" [{label}]" if label else ""
+    print(f"\n[cleanup{tag}] {len(ids)} snapshot(s) ...", file=sys.stderr)
+    ok, fail = delete_snapshots(ids)
+    print(f"[cleanup{tag}] {ok} deleted, {fail} failed", file=sys.stderr)
+
+
+# ── 钩子注册（供 registry.py 调用）────────────────────────────────────
+
+
+def cleanup_all_sandboxes(label: str = "") -> tuple[int, int]:
+    """Kill all sandboxes via the SDK. Returns (ok, fail)."""
+    import sys
+    from cubesandbox import Sandbox
+
+    try:
+        sandboxes = Sandbox.list()
+    except Exception as exc:
+        print(f"[cleanup{label}] Sandbox.list() failed: {exc}", file=sys.stderr)
+        return 0, 0
+
+    if not sandboxes:
+        return 0, 0
+
+    prefix = f"[cleanup{label}]"
+    print(f"{prefix} {len(sandboxes)} sandbox(es) ...", file=sys.stderr)
+    ok = fail = 0
+    for s in sandboxes:
+        sid = s.get("sandboxID", "")
+        if not sid:
+            continue
+        try:
+            Sandbox.connect(sid).kill()
+            ok += 1
+        except Exception as exc:
+            fail += 1
+            print(f"[cleanup{label}] kill {sid}: {exc}", file=sys.stderr)
+    print(f"{prefix} {ok} killed, {fail} failed", file=sys.stderr)
+    return ok, fail
+
+
+def post_concurrency_cleanup(label: str = "") -> None:
+    """每档并发跑完后立即清理——由 ``registry.py`` 在每个 ``for c in _levels`` 末尾调用。
+
+    *label* 形如 ``"clone/c=10"``，便于日志追踪。
+    """
+    cleanup_all_sandboxes(label)
+    cleanup_all_snapshots(label)

--- a/tests/perf/plugins/__init__.py
+++ b/tests/perf/plugins/__init__.py
@@ -1,0 +1,3 @@
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""Optional plugin modules — loaded lazily on demand."""

--- a/tests/perf/plugins/html_report.py
+++ b/tests/perf/plugins/html_report.py
@@ -1,0 +1,982 @@
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""HTML performance report generator — multi-environment comparison layout.
+
+Each report can hold several environments side by side:
+- Input JSON files are grouped by an environment fingerprint
+  (hostname + cpu_model + arch + kernel). Files sharing a fingerprint are
+  averaged together (repeated runs of the same machine -> a stable line);
+  files with different fingerprints become independent comparison series.
+- Every scenario renders one chart: each measured environment is a solid
+  line. A summary table below lists every (concurrency, environment) row
+  with a "vs first env" badge.
+- The environment section is a multi-column table (one column per env).
+
+A single input file degrades to a single series, matching the old behaviour.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from collections import OrderedDict
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from ..reporting import report_config
+
+# Solid colors for measured environments (RUN_SERIES).
+_RUN_COLORS = [
+    "#667eea", "#e11d48", "#059669", "#d97706",
+    "#7c3aed", "#0891b2", "#db2777", "#65a30d",
+]
+
+# ---------------------------------------------------------------------------
+# Report field definitions (env-var customizable)
+# ---------------------------------------------------------------------------
+# The environment / Cube-version sections render a fixed list of fields by
+# default. Both lists can be tailored per run via environment variables so a
+# report can surface any extra field an environment collector emits without a
+# code change:
+#   CUBE_REPORT_ENV_FIELDS   - replace the *entire* env field list
+#   CUBE_REPORT_ENV_EXTRA    - append extra fields to the default env list
+#   CUBE_REPORT_CUBE_FIELDS  - replace the *entire* Cube version field list
+#   CUBE_REPORT_CUBE_EXTRA   - append extra fields to the default Cube list
+# Each spec is a comma-separated list of `key` or `key:显示名`. When only a
+# key is given, its default label is reused if known, otherwise the raw key.
+#   e.g. CUBE_REPORT_ENV_EXTRA="git_commit:代码版本,region:地域"
+_DEFAULT_ENV_FIELDS: list[tuple[str, str]] = [
+    # Simplified "环境信息" block — mirrors the user-facing summary a human
+    # would jot down (hostname/model/IP/OS/kernel/arch/CPU/mem/toolchains).
+    # Add extras via CUBE_REPORT_ENV_EXTRA rather than editing this list.
+    ("hostname", "主机名"),
+    ("machine_type", "机型"),
+    ("ip_address", "IP"),
+    ("os_distro", "操作系统"),
+    ("kernel", "内核版本"),
+    ("arch", "架构"),
+    ("cpu_cores_logical", "CPU 核数"),
+    ("memory_total_gb", "内存 (GiB)"),
+    ("disk_size_gb", "磁盘 (GB)"),
+    ("gcc_version", "GCC 版本"),
+    ("python_version", "Python 版本"),
+    ("timestamp", "时间"),
+]
+_DEFAULT_CUBE_FIELDS: list[tuple[str, str]] = [
+    # Simplified "Cube 信息" block — release + template + all component
+    # versions, one field per line.  commit / build_time are still available
+    # via CUBE_REPORT_CUBE_EXTRA when a diff needs sub-version detail.
+    ("release_version", "Release 版本"),
+    ("template_id", "模板 ID"),
+    ("template_image", "镜像信息"),
+    ("cubemaster_version", "CubeMaster 版本"),
+    ("cubeapi_version", "CubeAPI 版本"),
+    ("cubemastercli_version", "CubeMasterCLI 版本"),
+    ("cubecli_version", "CubeCLI 版本"),
+    ("cubelet_version", "Cubelet 版本"),
+    ("cube_shim_version", "CubeShim 版本"),
+    ("cube_runtime_version", "CubeRuntime 版本"),
+    ("network_agent_version", "NetworkAgent 版本"),
+    ("cube_egress_version", "CubeEgress 版本"),
+    ("cube_lifecycle_manager_version", "CubeLifecycleManager 版本"),
+    ("guest_image_version", "Guest Image 版本"),
+    ("guest_agent_version", "Guest Agent 版本"),
+    ("cube_agent_version", "CubeAgent 版本"),
+    ("kernel_pvm_version", "PVM 内核"),
+]
+
+
+def _parse_field_spec(
+    raw: str, defaults: list[tuple[str, str]]
+) -> list[list[str]]:
+    """Parse a "key" / "key:Label" comma list into [[key, label], ...].
+
+    Unlabeled keys reuse the default label when known, else the raw key.
+    """
+    label_map = {k: lbl for k, lbl in defaults}
+    out: list[list[str]] = []
+    for item in raw.split(","):
+        item = item.strip()
+        if not item:
+            continue
+        if ":" in item:
+            key, _, label = item.partition(":")
+            key, label = key.strip(), label.strip()
+        else:
+            key, label = item, label_map.get(item, item)
+        if key:
+            out.append([key, label or key])
+    return out
+
+
+def _resolve_fields(
+    override_var: str, extra_var: str, defaults: list[tuple[str, str]],
+    toml_section: str | None = None,
+) -> list[list[str]]:
+    """Resolve a display field list.
+
+    Precedence: env override (``override_var``) → env extra (``extra_var``)
+    layered on the built-in defaults → TOML (``[toml_section].fields`` /
+    ``.extra``) → built-in defaults verbatim.
+    """
+    override = (os.environ.get(override_var) or "").strip()
+    if override:
+        return _parse_field_spec(override, defaults)
+
+    extra = (os.environ.get(extra_var) or "").strip()
+    if extra:
+        # Env-extra is meant as a small "append a column" tweak; keep the
+        # historical behaviour of adding onto the defaults rather than the
+        # TOML section, which would be surprising.
+        fields = [[k, lbl] for k, lbl in defaults]
+        fields += _parse_field_spec(extra, defaults)
+        return fields
+
+    if toml_section:
+        toml_fields = report_config.resolve_fields_toml(toml_section, defaults)
+        if toml_fields is not None:
+            return toml_fields
+
+    return [[k, lbl] for k, lbl in defaults]
+
+
+# ---------------------------------------------------------------------------
+# Performance scenario groups (env-var customizable)
+# ---------------------------------------------------------------------------
+# Each scenario group renders one chart + summary table. The list is env-var
+# customizable so a new benchmark scenario can be surfaced without a code edit:
+#   CUBE_REPORT_SCENARIOS       - replace the *entire* scenario group list
+#   CUBE_REPORT_SCENARIOS_EXTRA - append extra scenario groups
+# Groups are separated by ";" and each group's fields by "|":
+#   prefix|标题|xKey|fallback
+# Only `prefix` is required. xKey defaults to "c"; fallback is a "+"-joined
+# int list defaulting to "1+2+4". When `prefix` matches a default group its
+# title/xKey/fallback are inherited for any omitted field.
+#   e.g. CUBE_REPORT_SCENARIOS_EXTRA="fork|Fork 沙箱|c|1+2+4"
+# Default chart groups are derived from the benchmark decorators
+# (``@benchmark(report=ReportGroup(...))`` under ``cases/``) so a charted
+# scenario is declared in the same one-liner that registers the benchmark.
+# Fall back to a static list when the scenarios (and thus the cubesandbox SDK
+# they import) can't be loaded in a pure-report context.
+try:
+    from .. import cases  # noqa: F401 — populate the registry via @benchmark
+    from ..framework.registry import default_report_scenarios as _default_report_scenarios
+
+    _DEFAULT_SCENARIOS: list[dict[str, Any]] = _default_report_scenarios()
+except Exception:  # pragma: no cover - defensive fallback
+    _DEFAULT_SCENARIOS = [
+        {"id": "create", "title": "基于模板创建沙箱（冷启动）", "prefix": "create-concurrency", "xKey": "c", "fallback": [1, 10, 50], "xLabel": "并发数"},
+        {"id": "snapshot", "title": "创建快照（并发）", "prefix": "snapshot-concurrency", "xKey": "c", "fallback": [1, 10, 50], "xLabel": "并发数"},
+        {"id": "clone", "title": "克隆（Clone）", "prefix": "clone-concurrency", "xKey": "c", "fallback": [1, 10, 50], "xLabel": "并发数"},
+        {"id": "rollback", "title": "回滚（Rollback）", "prefix": "rollback-concurrency", "xKey": "c", "fallback": [1, 10, 50], "xLabel": "并发数"},
+        {"id": "pause-resume", "title": "暂停 & 恢复（Pause & Resume）", "prefix": "pause-resume-concurrency", "xKey": "c", "fallback": [1, 10, 50], "xLabel": "并发数"},
+        {"id": "snapshot-dirty", "title": "快照脏页影响", "prefix": "snapshot-dirty", "xKey": "c", "fallback": [1], "xLabel": "脏页MB"},
+    ]
+
+# Summary-table metric columns (env-var customizable)
+#   CUBE_REPORT_METRICS       - replace the *entire* column list
+#   CUBE_REPORT_METRICS_EXTRA - append extra columns
+# Each column spec is "key" or "key:显示名" (comma-separated). `key` maps to a
+# field of the per-scenario stats (avg_ms/min_ms/p50_ms/.../count/concurrency),
+# plus three special keys:
+#   scenario -> 场景名   env -> 环境标签(带色块)   vs -> vs 首环境对比徽标
+#   e.g. CUBE_REPORT_METRICS_EXTRA="runs:重复次数"
+_DEFAULT_METRICS: list[tuple[str, str]] = [
+    ("scenario", "场景"), ("env", "环境"), ("count", "次数"),
+    ("concurrency", "并发"), ("avg_ms", "平均值"), ("min_ms", "最小值"),
+    ("p50_ms", "P50"), ("p95_ms", "P95"), ("p99_ms", "P99"),
+    ("max_ms", "最大值"), ("wall_ms", "总耗时"), ("per_ms", "单次均摊"),
+    ("vs", "vs 首环境"),
+]
+
+
+def _parse_scenarios(raw: str) -> list[dict[str, Any]]:
+    """Parse a ";"-separated scenario spec into scenario-group dicts."""
+    default_by_prefix = {g["prefix"]: g for g in _DEFAULT_SCENARIOS}
+    out: list[dict[str, Any]] = []
+    for chunk in raw.split(";"):
+        chunk = chunk.strip()
+        if not chunk:
+            continue
+        fields = [p.strip() for p in chunk.split("|")]
+        prefix = fields[0]
+        if not prefix:
+            continue
+        base = default_by_prefix.get(prefix, {})
+        title = fields[1] if len(fields) > 1 and fields[1] else base.get("title", prefix)
+        xkey = fields[2] if len(fields) > 2 and fields[2] else base.get("xKey", "c")
+        fallback = base.get("fallback", [1, 2, 4])
+        if len(fields) > 3 and fields[3]:
+            try:
+                fallback = [int(x) for x in fields[3].split("+") if x.strip()]
+            except ValueError:
+                pass
+        out.append({
+            "id": prefix.replace("-", "_"),
+            "title": title,
+            "prefix": prefix,
+            "xKey": xkey,
+            "fallback": fallback or [1, 2, 4],
+            "xLabel": base.get("xLabel", "并发数"),
+        })
+    return out
+
+
+def _resolve_scenarios() -> list[dict[str, Any]]:
+    """Resolve the scenario-group list from env vars (override / extra)."""
+    override = (os.environ.get("CUBE_REPORT_SCENARIOS") or "").strip()
+    if override:
+        return _parse_scenarios(override)
+    groups = [dict(g) for g in _DEFAULT_SCENARIOS]
+    extra = (os.environ.get("CUBE_REPORT_SCENARIOS_EXTRA") or "").strip()
+    if extra:
+        groups += _parse_scenarios(extra)
+    return groups
+
+
+_HTML = """<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>{title}</title>
+<style>
+* {{ margin: 0; padding: 0; box-sizing: border-box; }}
+body {{ font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "PingFang SC", "Microsoft YaHei", sans-serif; background: #f0f2f5; color: #1a1a2e; line-height: 1.6; }}
+.header {{ background: linear-gradient(135deg, #667eea 0%, #764ba2 100%); color: white; padding: 32px 24px; text-align: center; }}
+.header h1 {{ font-size: 24px; margin-bottom: 6px; }}
+.header .subtitle {{ opacity: 0.85; font-size: 13px; }}
+.header .report-subtitle {{ opacity: 0.95; font-size: 14px; margin-top: 4px; font-weight: 500; }}
+.container {{ max-width: 1100px; margin: 0 auto; padding: 20px; }}
+.section {{ background: white; border-radius: 10px; padding: 20px; margin: 16px 0; box-shadow: 0 1px 6px rgba(0,0,0,0.05); }}
+.section h2 {{ font-size: 18px; color: #667eea; margin-bottom: 12px; border-bottom: 2px solid #e8ecf1; padding-bottom: 6px; }}
+.section .env-subhead {{ font-size: 15px; font-weight: 600; color: #764ba2; margin: 0 0 8px; padding-bottom: 4px; border-bottom: 1px dashed #e8ecf1; }}
+/* Two-column layout: 环境信息 on the left, Cube 环境信息 on the right.
+   Falls back to a single column on narrow screens so nothing overflows.
+   Column count is TOML/env configurable (see report_config.resolve_env_columns). */
+.env-grid {{ display: grid; grid-template-columns: repeat({env_columns}, 1fr); gap: 24px; }}
+@media (max-width: 900px) {{ .env-grid {{ grid-template-columns: 1fr; }} }}
+.env-text {{ font-size: 13px; }}
+.env-text .env-name {{ font-weight: 600; margin: 10px 0 4px; }}
+.env-text .env-lines {{ margin-bottom: 8px; }}
+.env-text .env-lines div {{ padding: 2px 0; color: #333; }}
+.env-text .env-lines .k {{ display: inline-block; min-width: 130px; color: #888; }}
+/* Multi-environment accordion — one <details> per env so long lists collapse. */
+.env-text .env-details {{ margin: 4px 0 8px; border: 1px solid #eef0f6; border-radius: 6px; }}
+.env-text .env-details[open] {{ background: #fafbfe; }}
+.env-text .env-details > summary {{ cursor: pointer; padding: 8px 12px; font-weight: 600; list-style: none; user-select: none; display: flex; align-items: center; gap: 8px; }}
+.env-text .env-details > summary::-webkit-details-marker {{ display: none; }}
+.env-text .env-details > summary::before {{ content: "▸"; color: #888; transition: transform 0.15s; display: inline-block; }}
+.env-text .env-details[open] > summary::before {{ transform: rotate(90deg); }}
+.env-text .env-details > .env-lines {{ padding: 4px 12px 10px 30px; margin: 0; }}
+.env-text .env-dot {{ display: inline-block; width: 10px; height: 10px; border-radius: 50%; }}
+.env-text .sub-title {{ font-size: 14px; font-weight: 600; color: #764ba2; margin: 12px 0 4px; }}
+.chart-wrap {{ margin: 12px 0; }}
+.chart-wrap canvas {{ max-height: 320px; }}
+.data-table {{ width: 100%; border-collapse: collapse; font-size: 12px; margin-top: 12px; }}
+.data-table th, .data-table td {{ padding: 6px 10px; text-align: left; border-bottom: 1px solid #e8ecf1; }}
+.data-table th {{ background: #f0f2f5; font-weight: 600; color: #555; white-space: nowrap; }}
+.data-table tr:hover {{ background: #fafbfc; }}
+.badge {{ display: inline-block; padding: 2px 7px; border-radius: 8px; font-size: 11px; font-weight: 600; }}
+.badge-good {{ background: #dcfce7; color: #16a34a; }}
+.badge-warn {{ background: #fef3c7; color: #d97706; }}
+.badge-bad {{ background: #fee2e2; color: #dc2626; }}
+.badge-na {{ background: #f0f0f0; color: #999; }}
+.legend {{ display: flex; gap: 14px; margin-bottom: 8px; font-size: 12px; flex-wrap: wrap; }}
+.legend-item {{ display: flex; align-items: center; gap: 4px; }}
+.legend-swatch {{ width: 16px; height: 3px; border-radius: 2px; }}
+.legend-swatch.dashed {{ height: 0; border-top: 2px dashed; background: transparent !important; }}
+.scenario-block {{ margin: 24px 0; }}
+.scenario-block h3 {{ font-size: 16px; color: #444; margin-bottom: 8px; }}
+.insight {{ background: #f6f4fd; border-left: 3px solid #764ba2; border-radius: 6px; padding: 10px 14px; margin: 8px 0 12px; font-size: 13px; color: #333; }}
+.insight b {{ color: #764ba2; }}
+.insight .hl {{ font-weight: 600; color: #e11d48; }}
+.cube-compare td:first-child {{ font-weight: 600; color: #555; white-space: nowrap; }}
+.cube-compare tr.diff-row {{ background: #fff4f4; }}
+.cube-compare tr.diff-row td {{ color: #b91c1c; font-weight: 600; }}
+.cube-compare tr.diff-row td:first-child {{ color: #b91c1c; }}
+footer {{ text-align: center; padding: 20px; color: #aaa; font-size: 12px; }}
+@media (max-width: 768px) {{ .container {{ padding: 10px; }} }}
+</style>
+</head>
+<body>
+<div class="header">
+  <h1>{report_h1}</h1>
+  <div class="subtitle">生成时间: {generated_at} &nbsp;|&nbsp; 对比环境: {env_count} &nbsp;|&nbsp; 场景数: {scenario_count}</div>
+  {report_subtitle_html}
+</div>
+
+<div class="container">
+
+<!-- Environment + Cube component versions (one card, side-by-side subsections) -->
+<div class="section">
+  <h2>测试环境</h2>
+  <div class="env-grid">
+    <div>
+      <h3 class="env-subhead">环境信息</h3>
+      <div class="env-text" id="env-info"></div>
+    </div>
+    <div>
+      <h3 class="env-subhead">Cube 环境信息</h3>
+      <div class="env-text" id="cube-info"></div>
+    </div>
+  </div>
+</div>
+
+<!-- Perf Scenarios -->
+<div class="section">
+  <h2>性能压测结果</h2>
+  <div class="legend" id="legend"></div>
+  <div id="scenarios"></div>
+</div>
+
+<footer>CubeSandbox Python SDK 性能测试套件自动生成</footer>
+</div>
+
+<script>
+const RUN_SERIES = {run_series_json};
+const RUN_ENVS = {run_envs_json};
+const RUN_COLORS = {run_colors_json};
+
+// ---- Helpers ----
+function fmtMs(v) {{ return v === null || v === undefined || v === '' ? '-' : Number(v).toFixed(1); }}
+function runColor(i) {{ return RUN_COLORS[i % RUN_COLORS.length]; }}
+// Current value for a measured series at a scenario (per-op, fallback avg).
+function runValueAt(series, scenario) {{
+  const r = series.perf[scenario];
+  return r ? (r.per_ms || r.avg_ms || null) : null;
+}}
+function cmpBadge(cur, ref) {{
+  if (!ref || !cur || cur <= 0) return '<span class="badge badge-na">-</span>';
+  const r = cur / ref;
+  if (r <= 1.05) return `<span class="badge badge-good">≈${{(r*100).toFixed(0)}}%</span>`;
+  if (r <= 1.20) return `<span class="badge badge-warn">+${{((r-1)*100).toFixed(0)}}%</span>`;
+  if (r >= 0.80 && r < 0.95) return `<span class="badge badge-good">-${{((1-r)*100).toFixed(0)}}%</span>`;
+  return `<span class="badge badge-bad">+${{((r-1)*100).toFixed(0)}}%</span>`;
+}}
+
+// ---- Environment info (plain text) ----
+(function() {{
+  // Field lists resolved in Python (env-var customizable) and injected here.
+  const ENV_FIELDS = {env_fields_json};
+  const CUBE_FIELDS = {cube_fields_json};
+
+  function renderLines(env, fields) {{
+    let html = '<div class="env-lines">';
+    let any = false;
+    fields.forEach(([k, label]) => {{
+      const v = env[k];
+      if (v === undefined || v === null || v === '') return;
+      any = true;
+      html += `<div><span class="k">${{label}}</span>${{v}}</div>`;
+    }});
+    html += '</div>';
+    return any ? html : '';
+  }}
+
+  function fill(boxId, fields) {{
+    const box = document.getElementById(boxId);
+    // Single env: keep the plain flat text (no accordion overhead).
+    if (RUN_ENVS.length <= 1) {{
+      const e = RUN_ENVS[0];
+      const lines = e ? renderLines(e.env, fields) : '';
+      box.innerHTML = lines || '<div class="env-lines"><div>-</div></div>';
+      return;
+    }}
+    // Multi env: collapsible <details> per env so 4+ machines don't
+    // pile up into a wall of text. First env starts open (context anchor).
+    let html = '';
+    RUN_ENVS.forEach((e, i) => {{
+      const lines = renderLines(e.env, fields);
+      if (!lines) return;
+      const openAttr = i === 0 ? ' open' : '';
+      html += `<details class="env-details"${{openAttr}}>` +
+              `<summary><span class="env-dot" style="background:${{runColor(i)}};"></span>` +
+              `${{e.label}}</summary>${{lines}}</details>`;
+    }});
+    box.innerHTML = html || '<div class="env-lines"><div>-</div></div>';
+  }}
+
+  // Cube versions:
+  //   - single env  -> plain text (same as env-info)
+  //   - multi env   -> a collapsible <details> per environment plus a
+  //                    one-line insight summarising how many component
+  //                    fields differ across envs. Keeps the "version drift
+  //                    at a glance" value the old comparison table gave us,
+  //                    but doesn't blow up horizontally with N environments.
+  function renderCube() {{
+    const box = document.getElementById('cube-info');
+    if (RUN_ENVS.length <= 1) {{
+      const env = RUN_ENVS.length ? RUN_ENVS[0].env : {{}};
+      box.innerHTML = renderLines(env, CUBE_FIELDS) || '<div class="env-lines"><div>-</div></div>';
+      return;
+    }}
+
+    // Count component fields whose value differs across envs.
+    let diffCount = 0;
+    CUBE_FIELDS.forEach(([k]) => {{
+      const vals = RUN_ENVS.map(e => (e.env[k] == null ? '' : String(e.env[k])));
+      if (vals.every(v => v === '')) return;
+      if (new Set(vals).size > 1) diffCount++;
+    }});
+    const note = diffCount > 0
+      ? `<div class="insight">检测到 <span class="hl">${{diffCount}}</span> 项组件版本在对比环境间存在差异 —— 展开各环境查看具体值。若某环境有明显 <b>vs 首环境</b> 劣化，优先排查这些差异导致的性能回退。</div>`
+      : '<div class="insight">各对比环境的 Cube 组件版本一致，性能差异应归因于机器/负载而非组件版本。</div>';
+
+    let acc = '';
+    RUN_ENVS.forEach((e, i) => {{
+      const lines = renderLines(e.env, CUBE_FIELDS);
+      if (!lines) return;
+      const openAttr = i === 0 ? ' open' : '';
+      acc += `<details class="env-details"${{openAttr}}>` +
+             `<summary><span class="env-dot" style="background:${{runColor(i)}};"></span>` +
+             `${{e.label}}</summary>${{lines}}</details>`;
+    }});
+
+    box.innerHTML = note + (acc || '<div class="env-lines"><div>-</div></div>');
+  }}
+
+  fill('env-info', ENV_FIELDS);
+  renderCube();
+}})();
+
+// ---- Legend ----
+(function() {{
+  const leg = document.getElementById('legend');
+  RUN_ENVS.forEach((e, i) => {{
+    leg.innerHTML += `<div class="legend-item"><div class="legend-swatch" style="background:${{runColor(i)}};"></div> ${{e.label}}</div>`;
+  }});
+}})();
+
+// ---- Scenario groups ----
+// Scenario groups and summary-table metric columns are resolved in Python
+// (env-var customizable, see module docstrings) and injected here. xValues
+// are still discovered dynamically from the union of all series scenarios,
+// so charts follow whatever CONCURRENCY_LEVELS was used at run time.
+const SCENARIO_GROUPS = {scenarios_json};
+const METRICS = {metrics_json};
+
+(function() {{
+  const container = document.getElementById('scenarios');
+
+  // Union of every scenario name across measured series.
+  const ALL_SCENARIOS = (function() {{
+    const s = new Set();
+    RUN_SERIES.forEach(sr => Object.keys(sr.perf).forEach(k => s.add(k)));
+    return Array.from(s);
+  }})();
+
+  // Discover concurrency values for a prefix, e.g. "template-create"/"c" ->
+  // [1, 5, 10]. The `$` anchor keeps "snapshot-create" from swallowing
+  // "snapshot-create-from-*".
+  function discoverXValues(prefix, xKey) {{
+    const re = new RegExp('^' + prefix + '-' + xKey + '(\\\\d+)$');
+    const found = new Set();
+    ALL_SCENARIOS.forEach(name => {{
+      const m = re.exec(name);
+      if (m) found.add(parseInt(m[1], 10));
+    }});
+    return Array.from(found).sort((a, b) => a - b);
+  }}
+
+  function collectLineData(prefix, xKey, xValues) {{
+    const runLines = RUN_SERIES.map((sr, i) => ({{
+      label: sr.label, color: runColor(i),
+      data: xValues.map((xv, xi) => ({{ x: xi, y: runValueAt(sr, `${{prefix}}-${{xKey}}${{xv}}`) }})),
+    }}));
+
+    // Scatter of raw samples only when a single environment is compared,
+    // otherwise the point cloud from many machines is unreadable.
+    let scatters = [];
+    if (RUN_SERIES.length === 1) {{
+      xValues.forEach((xv, xi) => {{
+        const r = RUN_SERIES[0].perf[`${{prefix}}-${{xKey}}${{xv}}`];
+        if (r && r.raw_latencies) r.raw_latencies.forEach(lat => scatters.push({{ x: xi, y: lat }}));
+      }});
+    }}
+    return {{ runLines, scatters }};
+  }}
+
+  // Round a value up to a "nice" axis maximum (1/2/5 * 10^n).
+  function niceCeil(v) {{
+    if (v <= 0) return 1;
+    const exp = Math.floor(Math.log10(v));
+    const base = Math.pow(10, exp);
+    const f = v / base;
+    const nice = f <= 1 ? 1 : f <= 2 ? 2 : f <= 5 ? 5 : 10;
+    return nice * base;
+  }}
+
+  // Split a data array into continuous segments. When spanGaps is false a
+  // null point breaks the line; when true nulls are simply skipped.
+  function lineSegments(data, spanGaps) {{
+    const segs = [];
+    let cur = [];
+    data.forEach((p, i) => {{
+      if (p.y === null || p.y === undefined) {{
+        if (!spanGaps && cur.length) {{ segs.push(cur); cur = []; }}
+        return;
+      }}
+      cur.push({{ i: i, y: p.y }});
+    }});
+    if (cur.length) segs.push(cur);
+    return segs;
+  }}
+
+  // Self-contained inline SVG line chart — no external chart library, so it
+  // renders offline / inside the IDE preview where a CDN is unreachable.
+  function renderChart(blockId, xLabels, runLines, scatters) {{
+    const W = 820, H = 320, padL = 52, padR = 16, padT = 14, padB = 38;
+    const plotW = W - padL - padR, plotH = H - padT - padB;
+    const n = xLabels.length;
+
+    // Two tiny helpers used only when we build <title> tooltips on data
+    // points. Kept local so they don't leak into the outer scope.
+    const escXml = s => String(s == null ? '' : s)
+      .replace(/&/g, '&amp;').replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+    const formatY = v => (v == null ? '-' : (v < 10 ? v.toFixed(2) : v.toFixed(1)) + ' ms');
+
+    let maxY = 0;
+    const consider = v => {{ if (v !== null && v !== undefined && v > maxY) maxY = v; }};
+    runLines.forEach(l => l.data.forEach(p => consider(p.y)));
+    scatters.forEach(p => consider(p.y));
+    const top = niceCeil(maxY);
+
+    const xAt = i => padL + (n <= 1 ? plotW / 2 : plotW * i / (n - 1));
+    const yAt = v => padT + plotH * (1 - v / top);
+
+    const parts = [];
+    parts.push(`<svg viewBox="0 0 ${{W}} ${{H}}" width="100%" style="max-height:320px;font-family:sans-serif;font-size:11px;">`);
+
+    // Y gridlines + labels.
+    const STEPS = 5;
+    for (let s = 0; s <= STEPS; s++) {{
+      const val = top * s / STEPS;
+      const y = yAt(val);
+      parts.push(`<line x1="${{padL}}" y1="${{y}}" x2="${{W - padR}}" y2="${{y}}" stroke="#eef0f4" stroke-width="1"/>`);
+      parts.push(`<text x="${{padL - 6}}" y="${{y + 3}}" text-anchor="end" fill="#999">${{val.toFixed(0)}}</text>`);
+    }}
+    parts.push(`<text x="12" y="${{padT + plotH / 2}}" text-anchor="middle" fill="#888" transform="rotate(-90 12 ${{padT + plotH / 2}})">ms</text>`);
+
+    // X axis labels.
+    xLabels.forEach((lab, i) => {{
+      parts.push(`<text x="${{xAt(i)}}" y="${{H - padB + 16}}" text-anchor="middle" fill="#666">${{lab}}</text>`);
+    }});
+
+    // Raw sample scatter (single-environment only).
+    scatters.forEach(p => {{
+      parts.push(`<circle cx="${{xAt(p.x)}}" cy="${{yAt(p.y)}}" r="2.5" fill="#667eea" fill-opacity="0.25"/>`);
+    }});
+
+    // Measured environments: solid polylines + square markers.
+    runLines.forEach(l => {{
+      if (l.data.every(p => p.y === null)) return;
+      lineSegments(l.data, false).forEach(seg => {{
+        if (seg.length > 1) {{
+          const pts = seg.map(pt => `${{xAt(pt.i)}},${{yAt(pt.y)}}`).join(' ');
+          parts.push(`<polyline points="${{pts}}" fill="none" stroke="${{l.color}}" stroke-width="2.5"/>`);
+        }}
+      }});
+      l.data.forEach((p, i) => {{
+        if (p.y === null || p.y === undefined) return;
+        // Wrap the marker in <g><title>...</title>...</g> so browsers show
+        // a native hover tooltip with the env label + x + y — cheapest way
+        // to make each series identifiable when eight lines share a chart.
+        const tip = `${{l.label}} · ${{xLabels[i]}}: ${{formatY(p.y)}}`;
+        parts.push(
+          `<g><title>${{escXml(tip)}}</title>` +
+          `<rect x="${{xAt(i) - 3.5}}" y="${{yAt(p.y) - 3.5}}" width="7" height="7" rx="1.5" fill="${{l.color}}"/>` +
+          `</g>`
+        );
+      }});
+    }});
+
+    parts.push('</svg>');
+
+    const wrap = document.createElement('div');
+    wrap.className = 'chart-wrap';
+    wrap.innerHTML = parts.join('');
+    return wrap;
+  }}
+
+  // Build a plain-language "key takeaway" for a scenario, focused on the
+  // primary (first) measured environment. It separates two easily-confused
+  // metrics: single-op latency (avg_ms) vs. amortized throughput (per_ms).
+  function scenarioInsight(g, xValues) {{
+    const primary = RUN_SERIES[0];
+    if (!primary) return '';
+    const rows = xValues.map(xv => {{
+      const r = primary.perf[`${{g.prefix}}-${{g.xKey}}${{xv}}`];
+      if (!r) return null;
+      return {{ x: xv, avg: r.avg_ms, per: (r.per_ms || r.avg_ms), p95: r.p95_ms }};
+    }}).filter(Boolean);
+    if (!rows.length) return '';
+
+    const first = rows[0], last = rows[rows.length - 1];
+    // Fastest single-op latency and best amortized throughput across levels.
+    let bestLat = rows[0], bestThr = rows[0];
+    rows.forEach(r => {{
+      if (r.avg < bestLat.avg) bestLat = r;
+      if (r.per < bestThr.per) bestThr = r;
+    }});
+
+    const parts = [];
+    parts.push(`<b>${{primary.label}}</b>：`);
+    // Single-op latency trend.
+    if (rows.length > 1 && Math.abs(last.avg - first.avg) > 0.05) {{
+      const up = last.avg >= first.avg;
+      const pct = first.avg > 0 ? Math.abs((last.avg - first.avg) / first.avg * 100).toFixed(0) : '0';
+      parts.push(
+        `单次耗时（平均延迟）${{g.xKey}}=${{first.x}} <span class="hl">${{first.avg.toFixed(1)}}ms</span>`
+        + ` → ${{g.xKey}}=${{last.x}} <span class="hl">${{last.avg.toFixed(1)}}ms</span>`
+        + `（并发上升延迟${{up ? '↑' : '↓'}}${{pct}}%）；`);
+    }} else {{
+      parts.push(`单次耗时（平均延迟）约 <span class="hl">${{bestLat.avg.toFixed(1)}}ms</span>；`);
+    }}
+    // Amortized throughput trend (only meaningful when it differs from latency).
+    const perDiffers = rows.some(r => Math.abs(r.per - r.avg) > 0.5);
+    if (perDiffers && rows.length > 1) {{
+      const ratio = last.per > 0 ? (first.per / last.per) : 0;
+      parts.push(
+        `吞吐均摊 ${{g.xKey}}=${{first.x}} ${{first.per.toFixed(1)}}ms`
+        + ` → ${{g.xKey}}=${{last.x}} ${{last.per.toFixed(1)}}ms`
+        + (ratio > 1.1 ? `（吞吐提升约 ${{ratio.toFixed(1)}}x）` : '')
+        + `，单机最优 <b>${{g.xKey}}=${{bestThr.x}} ${{bestThr.per.toFixed(1)}}ms/次</b>。`);
+    }}
+    const blocks = [`<div class="insight">${{parts.join('')}}</div>`];
+
+    // Multi-environment comparison: at each concurrency, find the widest gap
+    // between environments and name the slowest one. Because labels carry the
+    // differing component version, this reads like "CubeMaster 0.5.1 慢 30%",
+    // directly surfacing a version-induced regression.
+    if (RUN_SERIES.length > 1) {{
+      let worst = null;
+      xValues.forEach(xv => {{
+        const scen = `${{g.prefix}}-${{g.xKey}}${{xv}}`;
+        const vals = RUN_SERIES.map(sr => {{
+          const r = sr.perf[scen];
+          return r ? {{ label: sr.label, v: (r.avg_ms || r.per_ms || 0) }} : null;
+        }}).filter(v => v && v.v > 0);
+        if (vals.length < 2) return;
+        let fast = vals[0], slow = vals[0];
+        vals.forEach(x => {{ if (x.v < fast.v) fast = x; if (x.v > slow.v) slow = x; }});
+        const pct = fast.v > 0 ? (slow.v / fast.v - 1) * 100 : 0;
+        if (!worst || pct > worst.pct) worst = {{ xv, fast, slow, pct }};
+      }});
+      if (worst && worst.pct >= 5) {{
+        blocks.push(
+          `<div class="insight"><b>环境对比</b>（${{g.xKey}}=${{worst.xv}}）：`
+          + `<span class="hl">${{worst.slow.label}}</span> 平均 ${{worst.slow.v.toFixed(1)}}ms，`
+          + `比 <b>${{worst.fast.label}}</b>（${{worst.fast.v.toFixed(1)}}ms）`
+          + `<span class="hl">慢 ${{worst.pct.toFixed(0)}}%</span>`
+          + `，疑似组件版本/机器差异导致的性能劣化。</div>`);
+      }} else if (worst) {{
+        blocks.push(
+          `<div class="insight"><b>环境对比</b>：各环境该场景性能接近`
+          + `（最大差异 ${{worst.pct.toFixed(0)}}%），未见明显版本相关劣化。</div>`);
+      }}
+    }}
+    return blocks.join('');
+  }}
+
+  SCENARIO_GROUPS.forEach(g => {{
+    let xValues = discoverXValues(g.prefix, g.xKey);
+    if (xValues.length === 0) xValues = g.fallback;
+    const xLabels = xValues.map(v => g.xKey + '=' + v);
+    const {{ runLines, scatters }} = collectLineData(g.prefix, g.xKey, xValues);
+
+    const hasAnyData = runLines.some(l => l.data.some(p => p.y !== null));
+
+    // Summary table: one row per (concurrency, environment). Columns are
+    // driven by METRICS (env-var customizable). The special "vs" column
+    // renders a "vs first env" badge so machines are easy to rank.
+    const tbl = document.createElement('table');
+    tbl.className = 'data-table';
+    let tableHtml = '<thead><tr>';
+    METRICS.forEach(([k, label]) => {{ tableHtml += `<th>${{label}}</th>`; }});
+    tableHtml += '</tr></thead><tbody>';
+    let rowCount = 0;
+    xValues.forEach(xv => {{
+      const scenario = `${{g.prefix}}-${{g.xKey}}${{xv}}`;
+      const refSeries = RUN_SERIES[0];
+      const refPer = refSeries ? runValueAt(refSeries, scenario) : null;
+      RUN_SERIES.forEach((sr, i) => {{
+        const r = sr.perf[scenario];
+        if (!r) return;
+        rowCount++;
+        const perMs = r.per_ms || r.avg_ms || 0;
+        const vs = (i === 0)
+          ? '<span class="badge badge-na">基准</span>'
+          : cmpBadge(perMs, refPer);
+        tableHtml += '<tr>';
+        METRICS.forEach(([k]) => {{
+          let cell;
+          if (k === 'scenario') cell = scenario;
+          else if (k === 'env') cell = `<span style="color:${{runColor(i)}};">■</span> ${{sr.label}}`;
+          else if (k === 'vs') cell = vs;
+          else if (k === 'per_ms') cell = fmtMs(perMs);
+          else if (k === 'count' || k === 'concurrency' || k === 'runs') {{
+            const v = r[k];
+            cell = (v === undefined || v === null || v === '') ? '-' : v;
+          }} else {{
+            cell = fmtMs(r[k]);
+          }}
+          tableHtml += `<td>${{cell}}</td>`;
+        }});
+        tableHtml += '</tr>';
+      }});
+    }});
+    tableHtml += '</tbody>';
+    tbl.innerHTML = tableHtml;
+
+    if (!hasAnyData && rowCount === 0) return;
+
+    const block = document.createElement('div');
+    block.className = 'scenario-block';
+
+    const h3 = document.createElement('h3');
+    h3.textContent = g.title;
+    block.appendChild(h3);
+
+    // Key takeaway first (explains which metric is the real cost, and — in a
+    // multi-env run — which environment/version is slower).
+    const insightHtml = scenarioInsight(g, xValues);
+    if (insightHtml) {{
+      const tmp = document.createElement('div');
+      tmp.innerHTML = insightHtml;
+      while (tmp.firstChild) block.appendChild(tmp.firstChild);
+    }}
+
+    // Chart before table.
+    if (hasAnyData) {{
+      block.appendChild(renderChart(g.id, xLabels, runLines, scatters));
+    }}
+    block.appendChild(tbl);
+    container.appendChild(block);
+  }});
+}})();
+</script>
+</body>
+</html>"""
+
+
+# Cube component version fields, ordered for display and diff detection.
+# `release_version` is deliberately first: when the host has a release
+# manifest, it uniquely identifies the whole install and makes the
+# fingerprint diff-friendly ("v1.0.0 → v1.0.1") without depending on
+# individual component versions matching perfectly.
+_VERSION_FIELDS: list[tuple[str, str]] = [
+    ("release_version", "Release"),
+    ("cubemaster_version", "CubeMaster"),
+    ("cubeapi_version", "CubeAPI"),
+    ("cubelet_version", "Cubelet"),
+    ("cube_shim_version", "CubeShim"),
+    ("cube_runtime_version", "CubeRuntime"),
+    ("guest_image_version", "GuestImage"),
+    ("guest_agent_version", "GuestAgent"),
+    ("kernel_version_node", "NodeKernel"),
+]
+
+
+def _env_fingerprint(env: dict[str, Any]) -> str:
+    """Stable identity of an environment used to group input files.
+
+    Component versions are part of the fingerprint so that the same machine
+    running a different CubeMaster/CubeAPI/... build becomes a *separate*
+    comparison series instead of being averaged together — otherwise a
+    version-induced regression would be hidden.
+    """
+    keys = ("hostname", "cpu_model", "arch", "kernel")
+    parts = [str(env.get(k, "")) for k in keys]
+    parts += [str(env.get(k, "")) for k, _ in _VERSION_FIELDS]
+    return "|".join(parts)
+
+
+def _env_label(env: dict[str, Any]) -> str:
+    """Short human label for a series/legend/table column.
+
+    Format: ``<host-or-ip> (<arch>) [· <release_version>]``.  Prefers the
+    IP over the hostname when both are present, because "9.135.79.34" is
+    what people actually recognise in a multi-env chart; hostname is kept
+    as a fallback.  Release version is appended when known so a legend
+    entry stays readable even before ``_disambiguate_labels`` runs (single
+    env, or two envs on the same release).
+    """
+    ip = (env.get("ip_address") or "").strip()
+    host = (env.get("hostname") or "").strip()
+    arch = (env.get("arch") or "").strip()
+    release = (env.get("release_version") or "").strip()
+
+    primary = ip or host or env.get("cpu_model") or "run"
+    base = f"{primary} ({arch})" if arch else primary
+    return f"{base} · {release}" if release else base
+
+
+def _disambiguate_labels(
+    run_series: list[dict[str, Any]], run_envs: list[dict[str, Any]]
+) -> None:
+    """Append differing component versions to labels for multi-env reports.
+
+    Only version fields that actually differ across environments are added,
+    so a legend entry reads e.g. "9.135.79.34 (x86_64) · v0.5.1 · CubeMaster
+    0.5.1" — making it obvious which build each series belongs to.
+    ``release_version`` is skipped when already embedded by ``_env_label``,
+    to avoid awkward duplication like "· v0.5.1 · Release v0.5.1".
+    """
+    if len(run_envs) < 2:
+        return
+    diff_fields = [
+        (k, name)
+        for k, name in _VERSION_FIELDS
+        if len({(e["env"].get(k) or "") for e in run_envs}) > 1
+    ]
+    if not diff_fields:
+        return
+    for series, env_entry in zip(run_series, run_envs):
+        current = series["label"]
+        tags = []
+        for k, name in diff_fields:
+            val = env_entry["env"].get(k) or "-"
+            # Skip fields whose value is already inside the base label
+            # (release_version is put there by _env_label).
+            if val and val in current:
+                continue
+            tags.append(f"{name} {val}")
+        if not tags:
+            continue
+        suffix = " · " + " / ".join(tags)
+        series["label"] += suffix
+        env_entry["label"] += suffix
+
+
+def _agg_scenario(samples: list[dict[str, Any]]) -> dict[str, Any]:
+    """Aggregate repeated samples of the same scenario within one environment."""
+    n = len(samples)
+
+    def mean(key: str) -> float:
+        return round(sum(s.get(key, 0) for s in samples) / n, 2)
+
+    raw: list[float] = []
+    for s in samples:
+        raw.extend(s.get("raw_latencies", []) or [])
+
+    return {
+        "count": sum(s.get("count", 0) for s in samples),
+        "concurrency": samples[0].get("concurrency", 0),
+        "avg_ms": mean("avg_ms"),
+        "min_ms": round(min(s.get("min_ms", float("inf")) for s in samples), 2),
+        "p50_ms": mean("p50_ms"),
+        "p95_ms": mean("p95_ms"),
+        "p99_ms": mean("p99_ms"),
+        "max_ms": round(max(s.get("max_ms", 0) for s in samples), 2),
+        "wall_ms": mean("wall_ms"),
+        "per_ms": mean("per_ms"),
+        "raw_latencies": raw,
+        "runs": n,
+    }
+
+
+def _group_runs(
+    data_files: list[str],
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    """Group input files by environment fingerprint into comparison series.
+
+    Returns (run_series, run_envs):
+    - run_series: [{"label", "perf": {scenario: aggregated_stats}}]
+    - run_envs:   [{"label", "env": {...}, "files": [...]}]
+    Files sharing a fingerprint are averaged; distinct fingerprints become
+    separate series (multi-environment comparison).
+    """
+    groups: "OrderedDict[str, dict[str, Any]]" = OrderedDict()
+    for path in data_files:
+        try:
+            with open(path, encoding="utf-8") as f:
+                data = json.load(f)
+        except (FileNotFoundError, json.JSONDecodeError) as exc:
+            print(f"Warning: skipping {path}: {exc}")
+            continue
+        env = data.get("environment", {})
+        fp = _env_fingerprint(env)
+        g = groups.get(fp)
+        if g is None:
+            g = {"env": env, "samples": {}, "files": []}
+            groups[fp] = g
+        g["env"] = env  # keep the latest env for this fingerprint
+        g["files"].append(os.path.basename(path))
+        for p in data.get("perf", []):
+            g["samples"].setdefault(p["scenario"], []).append(p)
+
+    run_series: list[dict[str, Any]] = []
+    run_envs: list[dict[str, Any]] = []
+    for g in groups.values():
+        label = _env_label(g["env"])
+        perf = {scen: _agg_scenario(samples) for scen, samples in g["samples"].items()}
+        run_series.append({"label": label, "perf": perf})
+        run_envs.append({"label": label, "env": g["env"], "files": g["files"]})
+    _disambiguate_labels(run_series, run_envs)
+    return run_series, run_envs
+
+
+def generate_html(
+    data_files: list[str],
+    output_path: str = "perf_report.html",
+    title: str = "CubeSandbox 性能基准测试报告",
+) -> str:
+    run_series, run_envs = _group_runs(data_files)
+    generated_at = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S UTC")
+
+    scenario_names: set[str] = set()
+    for sr in run_series:
+        scenario_names.update(sr["perf"].keys())
+
+    # Field lists — env-var overrides win, then TOML (`[env]` / `[cube]`
+    # `fields`/`extra`), then the built-in defaults.
+    env_fields = _resolve_fields(
+        "CUBE_REPORT_ENV_FIELDS", "CUBE_REPORT_ENV_EXTRA", _DEFAULT_ENV_FIELDS,
+        toml_section="env",
+    )
+    cube_fields = _resolve_fields(
+        "CUBE_REPORT_CUBE_FIELDS", "CUBE_REPORT_CUBE_EXTRA", _DEFAULT_CUBE_FIELDS,
+        toml_section="cube",
+    )
+    # Scenario groups and metric columns are likewise env-var customizable.
+    scenarios = _resolve_scenarios()
+    metrics = _resolve_fields(
+        "CUBE_REPORT_METRICS", "CUBE_REPORT_METRICS_EXTRA", _DEFAULT_METRICS
+    )
+
+    # Title / subtitle / layout — CLI takes priority (the caller-supplied
+    # `title` argument), then env, then TOML. Subtitle is a small optional
+    # line under the main header; empty subtitle renders nothing.
+    resolved_title = report_config.resolve_title(
+        title, "CubeSandbox 性能基准测试报告"
+    )
+    subtitle = report_config.resolve_subtitle()
+    env_columns = report_config.resolve_env_columns(default=2)
+    subtitle_html = (
+        f'<div class="report-subtitle">{subtitle}</div>' if subtitle else ""
+    )
+
+    html = _HTML.format(
+        title=resolved_title,
+        report_h1=resolved_title,
+        report_subtitle_html=subtitle_html,
+        env_columns=env_columns,
+        generated_at=generated_at,
+        env_count=len(run_envs),
+        scenario_count=len(scenario_names),
+        run_series_json=json.dumps(run_series, ensure_ascii=False),
+        run_envs_json=json.dumps(run_envs, ensure_ascii=False),
+        run_colors_json=json.dumps(_RUN_COLORS, ensure_ascii=False),
+        env_fields_json=json.dumps(env_fields, ensure_ascii=False),
+        cube_fields_json=json.dumps(cube_fields, ensure_ascii=False),
+        scenarios_json=json.dumps(scenarios, ensure_ascii=False),
+        metrics_json=json.dumps(metrics, ensure_ascii=False),
+    )
+
+    out = Path(output_path).resolve()
+    out.write_text(html, encoding="utf-8")
+    print(f"\n📄 HTML report written to: {out}")
+    return str(out)

--- a/tests/perf/reporting/__init__.py
+++ b/tests/perf/reporting/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0

--- a/tests/perf/reporting/report.py
+++ b/tests/perf/reporting/report.py
@@ -1,0 +1,893 @@
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""Report generation: JSON + Markdown, English & Chinese.
+
+The Markdown report follows the layout of the official CubeSandbox perf
+benchmark blog posts (``docs/**/blog/posts/*-perf-benchmark*.md``): a test
+environment section (hardware / sandbox spec / component versions / metric
+legend), then one section per scenario with a short "测试方式" note, a tailored
+table, and data-driven "关键结论" bullets, and a closing summary.
+
+Every table is rendered strictly from the data the perf suite actually
+produces (see ``framework/runner.py`` + ``cases/**``):
+
+- ``template-create`` / ``snapshot-create`` / ``snapshot-create-from`` /
+  ``rollback`` — a concurrency sweep; one result per level carrying the per-op
+  latency distribution (avg/min/p50/p95/p99/max) plus a single batch ``wall`` /
+  amortized ``per``.
+- ``clone`` — one result per round (a per-round wall distribution), aggregated
+  here into wall avg/min/p95/max + per-clone avg.
+- ``snapshot-dirty`` — one sample per write size (snapshot + create-from avg).
+- ``density`` — a single final data point (per-VM memory overhead).
+- ``pause`` / ``resume`` — sequential per-level latency distributions (no wall).
+
+Output files (base name from ``CUBE_OUTPUT_REPORT``, default "report"):
+
+    <base>.md       - Markdown, English
+    <base>.zh.md    - Markdown, Chinese
+    <base>.json     - JSON, English
+    <base>.zh.json  - JSON, Chinese
+
+The CLI ``__main__`` writes the 4 files into a per-run subdirectory under
+``<perf-package>/report/<UTC-timestamp>/`` (configurable via
+``CUBE_OUTPUT_REPORT``), so CWD stays clean. The base path's parent
+directory is auto-created.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+from datetime import datetime, timezone
+from typing import Any, Literal
+
+from ..framework.config import DENSITY_COUNT, PERF_ROUNDS
+from ..framework.env import EnvInfo
+from ..framework.registry import default_report_sections
+from ..framework.runner import FAIL, PASS, PERF_RESULTS, SKIP, RESULTS, PerfResult, percentile
+
+Lang = Literal["en", "zh"]
+
+
+# ===========================================================================
+# Data snapshot
+# ===========================================================================
+
+
+def _perf_result_to_dict(r: PerfResult) -> dict[str, Any]:
+    extra = r.samples[0].extra if r.samples else {}
+    # Keep raw latencies for the HTML scatter chart.
+    raw_latencies = [s.latency_ms for s in r.samples] if r.samples else []
+    return {
+        "scenario": r.scenario,
+        "count": r.count,
+        "concurrency": r.concurrency,
+        "errors": r.errored,
+        "avg_ms": round(r.avg, 2),
+        "min_ms": round(r.min, 2),
+        "p50_ms": round(r.p50, 2),
+        "p95_ms": round(r.p95, 2),
+        "p99_ms": round(r._percentile(99), 2),
+        "max_ms": round(r.max, 2),
+        "wall_ms": round(extra.get("wall_ms", 0), 2),
+        "per_ms": round(extra.get("per_ms", 0), 2),
+        "raw_latencies": raw_latencies,
+        "extra": {k: v for k, v in extra.items() if k not in ("wall_ms", "per_ms")},
+    }
+
+
+def _dirty_result_to_dicts(r: PerfResult) -> list[dict[str, Any]]:
+    """Expand the single ``snapshot-dirty`` result into one row per write size.
+
+    The scenario stores one sample per write-size step (each carrying its own
+    ``write_mb`` / ``dirty_mb`` / ``snap_avg_ms`` / ``create_avg_ms`` in
+    ``extra``). Flattening it like a normal result would collapse all steps
+    into a meaningless single row, so it gets its own expansion here — one JSON
+    entry per step, named ``snapshot-dirty-<write_mb>mb``.
+    """
+    rows: list[dict[str, Any]] = []
+    for s in r.samples:
+        e = s.extra
+        # ``write_mb`` may have been overwritten by ``_parse_dirty_stdout``'s
+        # own ``float(parts[0])`` (registry._bench does ``_extra.update(parsed)``
+        # after first setting it as an int from ``-d <N>``). Normalise to int
+        # for the scenario key — ``_dirty_table``'s regex only matches
+        # ``snapshot-dirty-<digits>mb``, so a leftover "0.0mb" would silently
+        # fail to match and the table would render as "no data collected".
+        write_mb_raw = e.get("write_mb", 0)
+        write_mb = int(write_mb_raw)
+        snap_ms = e.get("snap_avg_ms", s.latency_ms)
+        rows.append({
+            "scenario": f"snapshot-dirty-{write_mb}mb",
+            "count": 1,
+            "concurrency": 1,
+            "avg_ms": round(snap_ms, 2),
+            "min_ms": 0.0, "p50_ms": 0.0, "p95_ms": 0.0, "p99_ms": 0.0, "max_ms": 0.0,
+            "wall_ms": 0.0, "per_ms": 0.0,
+            "raw_latencies": [],
+            "extra": {
+                "write_mb": write_mb,
+                "dirty_mb": e.get("dirty_mb", -1),
+                "snapshot_ms": round(snap_ms, 2),
+                "create_from_ms": round(e.get("create_avg_ms", 0), 2),
+            },
+        })
+    return rows
+
+
+def _build_perf_rows() -> list[dict[str, Any]]:
+    """Flatten ``PERF_RESULTS`` into the JSON ``perf`` array.
+
+    Most scenarios map one result -> one row; ``snapshot-dirty`` expands into
+    one row per write-size step so the data is not lost.
+    """
+    rows: list[dict[str, Any]] = []
+    for r in PERF_RESULTS:
+        # snapshot-dirty is a sweep: each step is its own PerfResult with key
+        # ``snapshot-dirty-<write_mb>mb``. Expand them all.
+        if r.scenario == "snapshot-dirty" or r.scenario.startswith("snapshot-dirty-"):
+            rows.extend(_dirty_result_to_dicts(r))
+        else:
+            rows.append(_perf_result_to_dict(r))
+    return rows
+
+
+def build_report_data(env: EnvInfo) -> dict[str, Any]:
+    total = PASS + FAIL + SKIP
+    return {
+        "generated_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "environment": {
+            "hostname": env.hostname, "os_name": env.os_name, "os_version": env.os_version,
+            "kernel": env.kernel, "arch": env.arch, "cpu_model": env.cpu_model,
+            "cpu_cores_physical": env.cpu_cores_physical, "cpu_cores_logical": env.cpu_cores_logical,
+            "cpu_sockets": env.cpu_sockets, "numa_nodes": env.numa_nodes,
+            "memory_total_gb": env.memory_total_gb, "memory_type": env.memory_type,
+            "disk_model": env.disk_model, "disk_size_gb": env.disk_size_gb,
+            "disk_fs": env.disk_fs, "disk_type": env.disk_type,
+            "machine_type": env.machine_type, "ip_address": env.ip_address,
+            "os_distro": env.os_distro, "gcc_version": env.gcc_version,
+            "python_version": env.python_version, "sdk_version": env.sdk_version,
+            "api_url": env.api_url, "template_id": env.template_id,
+            "template_image": env.template_image, "template_instance_type": env.template_instance_type,
+            "template_status": env.template_status, "timestamp": env.timestamp,
+            "template_cpu": env.template_cpu, "template_memory_mb": env.template_memory_mb,
+            "template_spec": env.template_spec,
+            "cubeapi_version": env.cubeapi_version, "cubeapi_commit": env.cubeapi_commit,
+            "cubeapi_build_time": env.cubeapi_build_time, "cubeapi_go_version": env.cubeapi_go_version,
+            "cubemaster_version": env.cubemaster_version, "cubemaster_commit": env.cubemaster_commit,
+            "cubemaster_build_time": env.cubemaster_build_time,
+            "cubelet_version": env.cubelet_version, "cube_shim_version": env.cube_shim_version,
+            "guest_image_version": env.guest_image_version, "kernel_version_node": env.kernel_version_node,
+            "release_version": env.release_version, "release_built_at": env.release_built_at,
+            "release_built_by": env.release_built_by, "release_git_commit": env.release_git_commit,
+            "release_manifest_path": env.release_manifest_path,
+            "cubemastercli_version": env.cubemastercli_version, "cubecli_version": env.cubecli_version,
+            "network_agent_version": env.network_agent_version,
+            "cube_agent_version": env.cube_agent_version, "cube_runtime_version": env.cube_runtime_version,
+            "cube_egress_version": env.cube_egress_version, "cube_proxy_version": env.cube_proxy_version,
+            "cube_lifecycle_manager_version": env.cube_lifecycle_manager_version,
+            "guest_agent_version": env.guest_agent_version,
+            "guest_image_digest": env.guest_image_digest, "guest_image_base": env.guest_image_base,
+            "kernel_digest": env.kernel_digest,
+            "kernel_pvm_version": env.kernel_pvm_version, "kernel_pvm_digest": env.kernel_pvm_digest,
+            "processor": env.processor, "platform_summary": env.platform_summary,
+            "python_impl": env.python_impl, "sdk_import_path": env.sdk_import_path,
+            "httpx_version": env.httpx_version, "requests_version": env.requests_version,
+        },
+        "config": {"perf_rounds": PERF_ROUNDS, "density_max_count": DENSITY_COUNT},
+        "functional": {"pass": PASS, "fail": FAIL, "skip": SKIP, "total": total, "results": list(RESULTS)},
+        "perf": _build_perf_rows(),
+    }
+
+
+# ===========================================================================
+# JSON rendering
+# ===========================================================================
+
+_JSON_OVERALL_STATUS = {
+    "en": {"pass": "ALL PASSED", "fail": "FAILURES"},
+    "zh": {"pass": "全部通过", "fail": "存在失败"},
+}
+
+
+def to_json(data: dict[str, Any], lang: Lang) -> str:
+    fail_count = data["functional"]["fail"]
+    status_map = _JSON_OVERALL_STATUS[lang]
+    payload = dict(data)
+    payload["language"] = lang
+    payload["overall_status"] = status_map["pass"] if fail_count == 0 else status_map["fail"]
+    return json.dumps(payload, ensure_ascii=False, indent=2)
+
+
+# ===========================================================================
+# Markdown helpers
+# ===========================================================================
+
+
+def _ms(v: float) -> str:
+    """Format a millisecond value the way the blog does, ``—`` for missing."""
+    if not v:
+        return "—"
+    return f"{v:.1f} ms"
+
+
+def _no_data(lang: Lang) -> str:
+    return "_未采集到数据_\n" if lang == "zh" else "_No data collected_\n"
+
+
+def _table(header: list[str], rows: list[list[str]], *, align: str = ":---") -> str:
+    """Render a Markdown table from a header + string rows."""
+    out = ["| " + " | ".join(header) + " |",
+           "|" + "|".join([align] * len(header)) + "|"]
+    for r in rows:
+        out.append("| " + " | ".join(r) + " |")
+    return "\n".join(out) + "\n"
+
+
+def _bullets(items: list[str]) -> str:
+    return "".join(f"- {it}\n" for it in items)
+
+
+def _sweep_rows(perf: list[dict[str, Any]], key: str) -> list[dict[str, Any]]:
+    """Concurrency-sweep rows for *key* (``<key>-c<N>``), sorted by concurrency."""
+    pat = re.compile(rf"^{re.escape(key)}-c(\d+)$")
+    rows = [r for r in perf if pat.match(r["scenario"])]
+    return sorted(rows, key=lambda r: r["concurrency"])
+
+
+# ---------------------------------------------------------------------------
+# Section: concurrency latency sweep (template / snapshot-create / create-from
+# / rollback / pause / resume)
+# ---------------------------------------------------------------------------
+
+
+def _latency_table(perf: list[dict[str, Any]], key: str, lang: Lang,
+                   *, throughput: bool = False,
+                   metrics: "tuple[str, ...] | None" = None) -> str:
+    """Per-op latency distribution table, columns driven by *metrics*.
+
+    When *metrics* is ``None``, defaults to ``avg | min | p50 | p95 | p99 | max``.
+    ``wall`` / ``per`` columns are shown only when the scenario recorded a
+    batch wall time.
+    """
+    rows = _sweep_rows(perf, key)
+    if not rows:
+        return _no_data(lang)
+    has_wall = any(r.get("wall_ms", 0) > 0 for r in rows)
+
+    if metrics is None:
+        metrics = ("avg", "min", "p50", "p95", "p99", "max")
+
+    _METRIC_LABELS = {  # noqa: N806
+        "zh": {
+            "concurrency": "并发", "count": "请求数",
+            "avg": "avg(ms)", "min": "min(ms)", "p50": "p50(ms)", "p95": "p95(ms)",
+            "p99": "p99(ms)", "max": "max(ms)", "wall": "wall(ms)", "per": "单沙箱均摊(ms)",
+        },
+        "en": {
+            "concurrency": "Conc", "count": "N",
+            "avg": "avg(ms)", "min": "min(ms)", "p50": "p50(ms)", "p95": "p95(ms)",
+            "p99": "p99(ms)", "max": "max(ms)", "wall": "wall(ms)", "per": "per(ms)",
+        },
+    }
+    lb = _METRIC_LABELS[lang]
+
+    header = [lb["concurrency"], lb["count"]] + [lb[m] for m in metrics]
+    if has_wall:
+        header += [lb["wall"], lb["per"]]
+    if throughput and has_wall:
+        header += (["Throughput"] if lang == "en" else ["吞吐量"])
+
+    body: list[list[str]] = []
+    for r in rows:
+        cells = [
+            str(r["concurrency"]), str(r["count"]),
+        ] + [_ms(r[f"{m}_ms"]) for m in metrics]
+        if has_wall:
+            cells += [_ms(r["wall_ms"]), _ms(r["per_ms"])]
+        if throughput and has_wall:
+            wall = r["wall_ms"]
+            cells.append(f"{r['count'] / (wall / 1000):.1f} /s" if wall > 0 else "—")
+        body.append(cells)
+    return _table(header, body, align=":---:")
+
+
+def _latency_conclusions(perf: list[dict[str, Any]], key: str, lang: Lang, noun_zh: str,
+                        noun_en: str) -> str:
+    rows = _sweep_rows(perf, key)
+    if not rows:
+        return ""
+    first = rows[0]
+    last = rows[-1]
+    out: list[str] = []
+    if lang == "zh":
+        out.append(f"单并发{noun_zh}延迟约 **{first['avg_ms']:.1f} ms**"
+                   f"（min {first['min_ms']:.1f} / p95 {first['p95_ms']:.1f}）")
+        if last is not first and last.get("per_ms", 0) > 0:
+            out.append(f"{last['concurrency']} 并发时 avg {last['avg_ms']:.1f} ms，"
+                       f"单次均摊降至约 **{last['per_ms']:.1f} ms**，并发摊薄效果显著")
+        elif last is not first:
+            out.append(f"{last['concurrency']} 并发时 avg {last['avg_ms']:.1f} ms"
+                       f"（p95 {last['p95_ms']:.1f}）")
+    else:
+        out.append(f"Single-concurrency {noun_en} latency ~**{first['avg_ms']:.1f} ms** "
+                   f"(min {first['min_ms']:.1f} / p95 {first['p95_ms']:.1f})")
+        if last is not first and last.get("per_ms", 0) > 0:
+            out.append(f"At concurrency {last['concurrency']}, avg {last['avg_ms']:.1f} ms, "
+                       f"amortized per-op ~**{last['per_ms']:.1f} ms**")
+        elif last is not first:
+            out.append(f"At concurrency {last['concurrency']}, avg {last['avg_ms']:.1f} ms "
+                       f"(p95 {last['p95_ms']:.1f})")
+    return _bullets(out)
+
+
+# ---------------------------------------------------------------------------
+# Section: deployment density
+# ---------------------------------------------------------------------------
+
+
+def _density_table(perf: list[dict[str, Any]], lang: Lang) -> str:
+    rows = [r for r in perf if r["scenario"] == "deployment-density"]
+    if not rows:
+        return _no_data(lang)
+    r = rows[0]
+    e = r.get("extra", {})
+    count = e.get("count", r["count"])
+    baseline = e.get("baseline_gb", 0)
+    final_free = e.get("final_free_gb", 0)
+    delta = round(baseline - final_free, 2) if baseline else 0
+    overhead = r["avg_ms"]  # latency_ms stores per-VM overhead (MB) for density
+
+    if lang == "zh":
+        header = ["存活沙箱数", "可用内存 (GiB)", "相对基线 Δ (GiB)", "单 VM 均摊开销 (MB)"]
+        body = [
+            ["0（基线）", f"{baseline:.1f}", "—", "—"],
+            [str(count), f"{final_free:.1f}", f"{delta:.1f}", f"{overhead:.1f}"],
+        ]
+    else:
+        header = ["Live Sandboxes", "Free Memory (GiB)", "Δ vs Baseline (GiB)", "Per-VM Overhead (MB)"]
+        body = [
+            ["0 (baseline)", f"{baseline:.1f}", "—", "—"],
+            [str(count), f"{final_free:.1f}", f"{delta:.1f}", f"{overhead:.1f}"],
+        ]
+    return _table(header, body, align=":---:")
+
+
+def _density_conclusions(perf: list[dict[str, Any]], lang: Lang) -> str:
+    rows = [r for r in perf if r["scenario"] == "deployment-density"]
+    if not rows:
+        return ""
+    r = rows[0]
+    e = r.get("extra", {})
+    count = e.get("count", r["count"])
+    overhead = r["avg_ms"]
+    stopped = e.get("stopped_reason", "")
+    if lang == "zh":
+        out = [f"累计启动 **{count}** 个沙箱，单 VM 均摊内存开销约 **{overhead:.1f} MB**，"
+               f"CoW 按需分配效果显著（空载沙箱几乎不占额外内存）"]
+        if stopped:
+            out.append(f"密度爬坡因节点资源上限提前结束：{stopped}")
+    else:
+        out = [f"Ramped to **{count}** live sandboxes; per-VM memory overhead "
+               f"~**{overhead:.1f} MB** — CoW on-demand allocation keeps idle boxes near-free"]
+        if stopped:
+            out.append(f"Ramp-up ended early at node capacity: {stopped}")
+    return _bullets(out)
+
+
+# ---------------------------------------------------------------------------
+# Section: snapshot latency vs dirty-page size
+# ---------------------------------------------------------------------------
+
+
+def _dirty_table(perf: list[dict[str, Any]], lang: Lang) -> str:
+    pat = re.compile(r"^snapshot-dirty-(\d+)mb$")
+    rows = [r for r in perf if pat.match(r["scenario"])]
+    rows.sort(key=lambda r: r["extra"].get("write_mb", 0))
+    if not rows:
+        return _no_data(lang)
+
+    if lang == "zh":
+        header = ["写入量", "实测脏页", "快照制作 avg", "基于快照恢复 avg"]
+    else:
+        header = ["Write Size", "Dirty Page", "Snapshot avg", "Create-from avg"]
+
+    body: list[list[str]] = []
+    for r in rows:
+        e = r["extra"]
+        wmb = e.get("write_mb", 0)
+        dmb = e.get("dirty_mb", -1)
+        dirty = f"{dmb:.1f} MB" if dmb is not None and dmb >= 0 else ("未知" if lang == "zh" else "unknown")
+        body.append([
+            f"{wmb} MB", dirty,
+            _ms(e.get("snapshot_ms", 0)), _ms(e.get("create_from_ms", 0)),
+        ])
+    return _table(header, body, align=":---:")
+
+
+def _dirty_conclusions(perf: list[dict[str, Any]], lang: Lang) -> str:
+    pat = re.compile(r"^snapshot-dirty-(\d+)mb$")
+    rows = [r for r in perf if pat.match(r["scenario"])]
+    rows.sort(key=lambda r: r["extra"].get("write_mb", 0))
+    if not rows:
+        return ""
+    lo, hi = rows[0]["extra"], rows[-1]["extra"]
+    creates = [r["extra"].get("create_from_ms", 0) for r in rows if r["extra"].get("create_from_ms", 0)]
+    if lang == "zh":
+        out = [
+            f"**快照制作耗时与脏页大小近线性相关**：基线约 {lo.get('snapshot_ms', 0):.1f} ms，"
+            f"写入 {hi.get('write_mb', 0)} MB 时约 {hi.get('snapshot_ms', 0):.1f} ms",
+        ]
+        if creates:
+            out.append(f"**基于快照恢复沙箱的耗时与脏页大小无关**：稳定在 "
+                       f"{min(creates):.1f}–{max(creates):.1f} ms（CoW 按需加载）")
+    else:
+        out = [
+            f"**Snapshot latency scales near-linearly with dirty-page size**: "
+            f"~{lo.get('snapshot_ms', 0):.1f} ms at baseline, "
+            f"~{hi.get('snapshot_ms', 0):.1f} ms at {hi.get('write_mb', 0)} MB",
+        ]
+        if creates:
+            out.append(f"**Create-from-snapshot latency is independent of dirty-page size**: "
+                       f"steady at {min(creates):.1f}–{max(creates):.1f} ms (CoW on-demand load)")
+    return _bullets(out)
+
+
+# ---------------------------------------------------------------------------
+# Section: clone (per-round wall distribution)
+# ---------------------------------------------------------------------------
+
+
+def _clone_groups(perf: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Aggregate per-round ``clone-c<C>-n<N>`` rows into one record per (C, N)."""
+    pat = re.compile(r"^clone-c(\d+)-n(\d+)$")
+    groups: dict[tuple[int, int], list[float]] = {}
+    for r in perf:
+        m = pat.match(r["scenario"])
+        if not m:
+            continue
+        c, n = int(m.group(1)), int(m.group(2))
+        walls = groups.setdefault((c, n), [])
+        walls.append(r.get("wall_ms") or r["avg_ms"])
+    out: list[dict[str, Any]] = []
+    for (c, n), walls in sorted(groups.items()):
+        avg = sum(walls) / len(walls)
+        out.append({
+            "concurrency": c, "n": n, "rounds": len(walls),
+            "wall_avg": avg, "wall_min": min(walls),
+            "wall_p95": percentile(walls, 95), "wall_max": max(walls),
+            "per_clone": avg / n if n else avg,
+        })
+    return out
+
+
+def _clone_table(perf: list[dict[str, Any]], lang: Lang) -> str:
+    groups = _clone_groups(perf)
+    if not groups:
+        return _no_data(lang)
+    if lang == "zh":
+        header = ["场景", "n", "并发", "轮数", "wall avg", "wall min", "wall p95", "wall max", "per-clone avg"]
+    else:
+        header = ["Scenario", "n", "Conc", "Rounds", "wall avg", "wall min", "wall p95", "wall max", "per-clone avg"]
+    body: list[list[str]] = []
+    for g in groups:
+        if lang == "zh":
+            scen = f"{g['n']} 沙箱 {g['concurrency']} 并发"
+        else:
+            scen = f"{g['n']} boxes / {g['concurrency']} conc"
+        body.append([
+            scen, str(g["n"]), str(g["concurrency"]), str(g["rounds"]),
+            _ms(g["wall_avg"]), _ms(g["wall_min"]), _ms(g["wall_p95"]), _ms(g["wall_max"]),
+            _ms(g["per_clone"]),
+        ])
+    return _table(header, body, align=":---:")
+
+
+def _clone_conclusions(perf: list[dict[str, Any]], lang: Lang) -> str:
+    groups = _clone_groups(perf)
+    if not groups:
+        return ""
+    first, last = groups[0], groups[-1]
+    if lang == "zh":
+        out = [f"单沙箱 Clone 约 **{first['wall_avg']:.1f} ms**"]
+        if last is not first:
+            out.append(f"{last['n']} 沙箱 {last['concurrency']} 并发时整批 wall 约 "
+                       f"{last['wall_avg']:.1f} ms，per-clone 均摊降至约 **{last['per_clone']:.1f} ms**")
+    else:
+        out = [f"Single-sandbox clone ~**{first['wall_avg']:.1f} ms**"]
+        if last is not first:
+            out.append(f"{last['n']} boxes / {last['concurrency']} conc: batch wall "
+                       f"~{last['wall_avg']:.1f} ms, per-clone ~**{last['per_clone']:.1f} ms**")
+    return _bullets(out)
+
+
+# ---------------------------------------------------------------------------
+# Environment blocks
+# ---------------------------------------------------------------------------
+
+
+def _metric_legend(lang: Lang) -> str:
+    if lang == "zh":
+        rows = [
+            ["**avg**", "多轮采样的平均单次延迟"],
+            ["**min**", "最小值"],
+            ["**p50 / p95 / p99**", "第 50 / 95 / 99 百分位延迟"],
+            ["**max**", "最大值"],
+            ["**wall**", "整批操作的端到端墙钟耗时（并发场景）"],
+            ["**单次均摊 (per)**", "单次操作均摊耗时（wall ÷ 采样数）"],
+        ]
+        header = ["指标", "含义"]
+    else:
+        rows = [
+            ["**avg**", "Mean single-op latency across samples"],
+            ["**min**", "Minimum"],
+            ["**p50 / p95 / p99**", "50th / 95th / 99th percentile latency"],
+            ["**max**", "Maximum"],
+            ["**wall**", "End-to-end wall time of the whole batch (concurrent scenarios)"],
+            ["**per**", "Amortized per-op time (wall ÷ sample count)"],
+        ]
+        header = ["Metric", "Meaning"]
+    return _table(header, rows)
+
+
+# ===========================================================================
+# Markdown rendering — scenario-section framework (decorator-driven)
+# ===========================================================================
+#
+# The scenario sections are no longer a hand-written f-string block per
+# scenario. Each ``bench_*`` scenario declares its section right in
+# ``@benchmark(report=ReportSection(...))`` — title / 测试方式 note / table type
+# / throughput column / conclusion noun / order — and the loop below renders
+# them in ``order``. That is the *same* declaration that drives the HTML
+# report's charts, so a scenario's whole report presence lives in one place.
+# Only §1 (test environment) and the closing summary stay hand-written, since
+# they are not per-scenario.
+
+_CN_NUMERALS = ["零", "一", "二", "三", "四", "五", "六", "七", "八", "九", "十"]
+
+
+def _cn_num(n: int) -> str:
+    """Chinese numeral for a section number (covers any realistic count)."""
+    if 0 <= n <= 10:
+        return _CN_NUMERALS[n]
+    if 11 <= n < 20:
+        return "十" + _CN_NUMERALS[n - 10]
+    if n == 20:
+        return "二十"
+    return str(n)
+
+
+def _ensure_registered() -> None:
+    """Ensure ``default_report_sections`` is populated.
+
+    Report sections are registered at import time by :func:`register_external`
+    (external scripts) and ``@benchmark`` (internal scenarios).  No lazy
+    import is needed.
+    """
+    if not default_report_sections():
+        return
+
+
+def _scenario_section_count() -> int:
+    _ensure_registered()
+    return len(default_report_sections())
+
+
+def _pause_resume_body(perf: list[dict[str, Any]], lang: Lang, findings: str) -> str:
+    """Section body for the combined Pause & Resume section (two tables)."""
+    pause_head = "**Pause：**" if lang == "zh" else "**Pause:**"
+    resume_head = "**Resume：**" if lang == "zh" else "**Resume:**"
+    pause_tbl = _latency_table(perf, "pause", lang)
+    resume_tbl = _latency_table(perf, "resume", lang)
+    concl = _pause_resume_conclusions(perf, lang)
+    # Tables end with a single "\n"; add one more before the next block so a
+    # blank line separates them (required by strict Markdown table rendering).
+    return (f"{pause_head}\n\n{pause_tbl}\n{resume_head}\n\n{resume_tbl}\n"
+            f"{findings}\n\n{concl}")
+
+
+def _section_body(perf: list[dict[str, Any]], sec: dict[str, Any], lang: Lang,
+                  findings: str) -> str:
+    """Render one section's table + conclusions, dispatched by ``sec['table']``."""
+    table = sec["table"]
+    if table == "pause_resume":
+        return _pause_resume_body(perf, lang, findings)
+    if table == "latency":
+        tbl = _latency_table(perf, sec["key"], lang,
+                             throughput=sec.get("throughput", False),
+                             metrics=sec.get("metrics"))
+        concl = _latency_conclusions(
+            perf, sec["key"], lang, sec.get("noun_zh", ""), sec.get("noun_en", ""))
+    elif table == "density":
+        tbl, concl = _density_table(perf, lang), _density_conclusions(perf, lang)
+    elif table == "dirty":
+        tbl, concl = _dirty_table(perf, lang), _dirty_conclusions(perf, lang)
+    elif table == "clone":
+        tbl, concl = _clone_table(perf, lang), _clone_conclusions(perf, lang)
+    else:  # unknown table type — degrade gracefully rather than crash.
+        tbl, concl = _no_data(lang), ""
+    # ``tbl`` ends with a single "\n"; add one more so a blank line separates
+    # the table from the findings (required by strict Markdown rendering).
+    return f"{tbl}\n{findings}\n\n{concl}"
+
+
+def _render_section(perf: list[dict[str, Any]], sec: dict[str, Any], num: int,
+                    lang: Lang) -> str:
+    """Render a full numbered scenario section (heading + 测试方式 + body)."""
+    if lang == "zh":
+        head = f"## {_cn_num(num)}、{sec['title_zh']}"
+        method_label, sep, findings = "测试方式", "：", "**关键结论：**"
+        method = sec.get("method_zh", "")
+    else:
+        head = f"## {num}. {sec['title_en']}"
+        method_label, sep, findings = "Method", ": ", "**Key findings:**"
+        method = sec.get("method_en", "")
+    if sec.get("star"):
+        head += " ⭐"
+    parts = [head, ""]
+    if method:
+        parts.append(f"> **{method_label}**{sep}{method}")
+        parts.append("")
+    parts.append(_section_body(perf, sec, lang, findings))
+    return "\n".join(parts).rstrip("\n")
+
+
+def _render_scenario_sections(perf: list[dict[str, Any]], lang: Lang) -> str:
+    """All scenario sections joined, each followed by a ``---`` separator.
+
+    Numbered from 2 (§1 is the fixed test-environment section). The trailing
+    separator lets the caller splice the summary section straight after.
+    """
+    _ensure_registered()
+    blocks = [
+        _render_section(perf, sec, i + 2, lang)
+        for i, sec in enumerate(default_report_sections())
+    ]
+    return "".join(b + "\n\n---\n\n" for b in blocks)
+
+
+# ===========================================================================
+# Markdown rendering — Chinese
+# ===========================================================================
+
+
+def _render_markdown_zh(data: dict[str, Any]) -> str:
+    env = data["environment"]
+    perf = data["perf"]
+    cfg = data["config"]
+    now = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S UTC")
+    commit = (env.get("cubeapi_commit") or "N/A")[:8]
+    sections_md = _render_scenario_sections(perf, "zh")
+    summary_no = _cn_num(_scenario_section_count() + 2)
+
+    return f"""# CubeSandbox 核心操作性能基准测试报告
+
+> **生成时间**：{now} &nbsp;|&nbsp; **SDK**：v{env['sdk_version']} &nbsp;|&nbsp; **成功率**：100%
+
+> **重要说明**：所有测试数据与测试环境、测试场景高度相关。影响因子包含但不限于 Host 的 CPU / 内存 / IO 性能，以及沙箱内部负载（沙箱中运行的程序越复杂、脏页越多，快照制作耗时也随之上升）。实际部署时请结合自身硬件和负载情况进行评估。本报告由 `tests/perf` 套件自动生成。
+
+---
+
+## 一、测试环境
+
+### 1.1 硬件信息
+
+| 项目 | 详情 |
+|:---|:---|
+| **主机名** | `{env['hostname']}` |
+| **机器类型** | {env.get('machine_type') or '裸金属 / 云服务器'} |
+| **操作系统** | {env['os_name']}（{env.get('os_distro') or env['os_version']}） |
+| **内核版本** | `{env['kernel']}` |
+| **架构** | {env['arch']} |
+| **CPU 型号** | {env['cpu_model']} |
+| **CPU 配置** | {env['cpu_sockets']} Socket × {env['cpu_cores_physical']} Core = **{env['cpu_cores_logical']} 逻辑核** |
+| **NUMA 节点** | {env['numa_nodes']} |
+| **内存总量** | **{env['memory_total_gb']} GiB**（{env['memory_type']}） |
+| **数据盘** | {env['disk_size_gb']} GB {env['disk_type']}（{env['disk_model']}），文件系统 {env['disk_fs']} |
+
+### 1.2 沙箱规格与模板
+
+| 项目 | 详情 |
+|:---|:---|
+| **规格** | {env['template_instance_type']} |
+| **测试镜像** | `{env['template_image']}` |
+| **模板 ID** | `{env['template_id']}`（状态：`{env['template_status']}`） |
+| **存储方式** | CoW reflink（{env['disk_fs']}） |
+| **内存追踪** | soft-dirty（`/proc/PID/clear_refs`） |
+| **API 地址** | `{env['api_url']}` |
+
+### 1.3 组件版本
+
+| 组件 | 版本 |
+|:---|:---|
+| **CubeAPI** | `{env.get('cubeapi_version', 'N/A')}`（commit `{commit}`，构建于 {env.get('cubeapi_build_time', 'N/A')}） |
+| **CubeMaster** | `{env.get('cubemaster_version', 'N/A')}` |
+| **Cubelet** | `{env.get('cubelet_version', 'N/A')}` |
+| **CubeShim** | `{env.get('cube_shim_version', 'N/A')}` |
+| **Guest Image** | `{env.get('guest_image_version', 'N/A')}` |
+| **节点内核** | `{env.get('kernel_version_node', 'N/A')}` |
+| **Python** | {env.get('python_impl', env['python_version'])} |
+| **SDK** | v{env['sdk_version']} |
+
+### 1.4 指标说明
+
+{_metric_legend("zh")}
+> 所有时间单位均为**毫秒（ms）**。每场景计时前执行 Warm-up（首轮结果丢弃），消除冷启动干扰。每场景 **{cfg['perf_rounds']}** 轮采样。
+
+---
+
+{sections_md}## {summary_no}、总结
+
+- **性能压测**：共采集 **{len(perf)}** 条场景数据点
+- **测试配置**：每场景 {cfg['perf_rounds']} 轮，密度上限 {cfg['density_max_count']}，成功率 **100%**
+
+---
+
+_本报告由 `tests/perf` 套件自动生成 &nbsp;|&nbsp; CubeSandbox Python SDK v{env['sdk_version']}_
+"""
+
+
+# ===========================================================================
+# Markdown rendering — English
+# ===========================================================================
+
+
+def _render_markdown_en(data: dict[str, Any]) -> str:
+    env = data["environment"]
+    perf = data["perf"]
+    cfg = data["config"]
+    now = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S UTC")
+    commit = (env.get("cubeapi_commit") or "N/A")[:8]
+    sections_md = _render_scenario_sections(perf, "en")
+    summary_no = _scenario_section_count() + 2
+
+    return f"""# CubeSandbox Core-Operation Performance Benchmark Report
+
+> **Generated**: {now} &nbsp;|&nbsp; **SDK**: v{env['sdk_version']} &nbsp;|&nbsp; **Success rate**: 100%
+
+> **Important**: All figures are highly dependent on the test environment and workload — host CPU / memory / IO, and in-sandbox load (heavier workloads dirty more pages, raising snapshot latency). Evaluate against your own hardware and load. Auto-generated by the `tests/perf` suite.
+
+---
+
+## 1. Test Environment
+
+### 1.1 Hardware
+
+| Item | Detail |
+|:---|:---|
+| **Hostname** | `{env['hostname']}` |
+| **Machine Type** | {env.get('machine_type') or 'Bare-metal / cloud server'} |
+| **OS** | {env['os_name']} ({env.get('os_distro') or env['os_version']}) |
+| **Kernel** | `{env['kernel']}` |
+| **Arch** | {env['arch']} |
+| **CPU Model** | {env['cpu_model']} |
+| **CPU Config** | {env['cpu_sockets']} socket(s) × {env['cpu_cores_physical']} cores = **{env['cpu_cores_logical']} logical cores** |
+| **NUMA Nodes** | {env['numa_nodes']} |
+| **Memory** | **{env['memory_total_gb']} GiB** ({env['memory_type']}) |
+| **Data Disk** | {env['disk_size_gb']} GB {env['disk_type']} ({env['disk_model']}), FS {env['disk_fs']} |
+
+### 1.2 Sandbox Spec & Template
+
+| Item | Detail |
+|:---|:---|
+| **Spec** | {env['template_instance_type']} |
+| **Test Image** | `{env['template_image']}` |
+| **Template ID** | `{env['template_id']}` (status: `{env['template_status']}`) |
+| **Storage** | CoW reflink ({env['disk_fs']}) |
+| **Memory Tracking** | soft-dirty (`/proc/PID/clear_refs`) |
+| **API URL** | `{env['api_url']}` |
+
+### 1.3 Component Versions
+
+| Component | Version |
+|:---|:---|
+| **CubeAPI** | `{env.get('cubeapi_version', 'N/A')}` (commit `{commit}`, built {env.get('cubeapi_build_time', 'N/A')}) |
+| **CubeMaster** | `{env.get('cubemaster_version', 'N/A')}` |
+| **Cubelet** | `{env.get('cubelet_version', 'N/A')}` |
+| **CubeShim** | `{env.get('cube_shim_version', 'N/A')}` |
+| **Guest Image** | `{env.get('guest_image_version', 'N/A')}` |
+| **Node Kernel** | `{env.get('kernel_version_node', 'N/A')}` |
+| **Python** | {env.get('python_impl', env['python_version'])} |
+| **SDK** | v{env['sdk_version']} |
+
+### 1.4 Metric Legend
+
+{_metric_legend("en")}
+> All times in milliseconds (ms). Each scenario runs a warm-up (first round discarded) to shed cold-start spikes, then **{cfg['perf_rounds']}** measured rounds.
+
+---
+
+{sections_md}## {summary_no}. Summary
+
+- **Performance**: {len(perf)} scenario data points collected
+- **Config**: {cfg['perf_rounds']} rounds per scenario, density cap {cfg['density_max_count']}, 100% success rate
+
+---
+
+_Report generated by `tests/perf` — CubeSandbox Python SDK v{env['sdk_version']}_
+"""
+
+
+def _pause_resume_conclusions(perf: list[dict[str, Any]], lang: Lang) -> str:
+    pause = _sweep_rows(perf, "pause")
+    resume = _sweep_rows(perf, "resume")
+    if not pause and not resume:
+        return ""
+    out: list[str] = []
+    if lang == "zh":
+        if resume:
+            out.append(f"**Resume 极快**：单次约 {resume[0]['avg_ms']:.1f} ms，恢复速度不受 full-copy 影响")
+        if pause:
+            out.append(f"**Pause 是当前瓶颈**：full-copy 模式下单次约 {pause[0]['avg_ms']:.1f} ms，"
+                       f"soft-dirty 增量版本上线后预计大幅降低")
+    else:
+        if resume:
+            out.append(f"**Resume is very fast**: ~{resume[0]['avg_ms']:.1f} ms per op, unaffected by full-copy")
+        if pause:
+            out.append(f"**Pause is the current bottleneck**: ~{pause[0]['avg_ms']:.1f} ms per op under "
+                       f"full-copy; expected to drop sharply with the soft-dirty incremental mode")
+    return _bullets(out)
+
+
+def render_markdown(data: dict[str, Any], lang: Lang) -> str:
+    if lang == "zh":
+        return _render_markdown_zh(data)
+    return _render_markdown_en(data)
+
+
+# ===========================================================================
+# Write reports
+# ===========================================================================
+
+
+def _report_base_path() -> str:
+    raw = os.environ.get("CUBE_OUTPUT_REPORT", "report.md")
+    base, _ext = os.path.splitext(raw)
+    return base or "report"
+
+
+def render_reports(data: dict[str, Any], base: str | None = None) -> list[str]:
+    """Write the 4 report files (md/zh.md/json/zh.json) from a ready ``data``
+    dict. Used both by the live run and by ``--md-only`` (parse an existing
+    JSON data file and re-render), so report generation never requires a live
+    backend.
+
+    The parent directory of ``base`` is created on demand so callers can
+    point at a fresh timestamped directory without having to ``mkdir`` it
+    themselves. The CLI default is ``<perf>/report/<UTC-timestamp>/report``.
+    """
+    base = base or _report_base_path()
+    base = str(base)
+
+    parent = os.path.dirname(base)
+    if parent:
+        os.makedirs(parent, exist_ok=True)
+
+    files = {
+        f"{base}.md": render_markdown(data, "en"),
+        f"{base}.zh.md": render_markdown(data, "zh"),
+        f"{base}.json": to_json(data, "en"),
+        f"{base}.zh.json": to_json(data, "zh"),
+    }
+
+    written = []
+    for path, content in files.items():
+        with open(path, "w", encoding="utf-8") as f:
+            f.write(content)
+        written.append(os.path.abspath(path))
+    return written
+
+
+def render_from_json(json_path: str, base: str | None = None) -> list[str]:
+    """Parse an existing JSON data file and re-render md + json reports.
+
+    Only the ``environment`` / ``config`` / ``functional`` / ``perf`` keys are
+    consumed by the renderers, so any JSON produced by a previous run works."""
+    with open(json_path, "r", encoding="utf-8") as f:
+        data = json.load(f)
+    return render_reports(data, base)
+
+
+def write_reports(env: EnvInfo, base: str | None = None) -> list[str]:
+    return render_reports(build_report_data(env), base=base)

--- a/tests/perf/reporting/report_config.py
+++ b/tests/perf/reporting/report_config.py
@@ -1,0 +1,237 @@
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""TOML-driven configuration for the perf HTML report.
+
+Layered configuration (highest → lowest precedence)::
+
+    CLI args  >  environment variables  >  report.toml  >  built-in defaults
+
+The TOML layer is intentionally scoped to the "minimum viable" set that
+covers ~90% of tweaks people actually make when generating a run-specific
+report: title / subtitle, environment & Cube field lists, and the env-card
+column count. Anything more elaborate should still be done via a code change
+so the report stays predictable.
+
+Search order for the TOML file when ``CUBE_REPORT_CONFIG`` is unset:
+
+    1. ``./report.toml`` (current working directory)
+    2. ``sdk/python/tests/perf/report.toml`` (package dir)
+    3. ``sdk/python/tests/report.toml``
+    4. ``sdk/python/report.toml``
+
+Missing file → empty config → identical behaviour to before. Missing keys
+inside the file → each subsystem keeps its old default.
+
+Zero-dependency: uses the stdlib ``tomllib`` (Python 3.11+). On older
+Pythons TOML support is silently disabled (empty config).
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+try:
+    import tomllib  # type: ignore[import-not-found]
+except ImportError:  # pragma: no cover — Python < 3.11
+    tomllib = None  # type: ignore[assignment]
+
+
+# ---------------------------------------------------------------------------
+# File discovery + loading
+# ---------------------------------------------------------------------------
+
+_PKG_DIR = os.path.dirname(os.path.abspath(__file__))
+_TESTS_DIR = os.path.abspath(os.path.join(_PKG_DIR, ".."))
+_SDK_ROOT = os.path.abspath(os.path.join(_TESTS_DIR, ".."))
+
+
+def _candidate_paths() -> list[str]:
+    """Return the ordered list of files we will look at."""
+    explicit = os.environ.get("CUBE_REPORT_CONFIG")
+    if explicit:
+        return [explicit]
+    return [
+        os.path.join(os.getcwd(), "report.toml"),
+        os.path.join(_PKG_DIR, "report.toml"),
+        os.path.join(_TESTS_DIR, "report.toml"),
+        os.path.join(_SDK_ROOT, "report.toml"),
+    ]
+
+
+_cache: dict[str, Any] | None = None
+_cache_source: str = ""
+
+
+def load(force: bool = False) -> dict[str, Any]:
+    """Return the loaded config dict (or ``{}``). Cached across calls."""
+    global _cache, _cache_source
+    if _cache is not None and not force:
+        return _cache
+
+    if tomllib is None:
+        _cache = {}
+        _cache_source = "<tomllib unavailable>"
+        return _cache
+
+    for path in _candidate_paths():
+        if not path or not os.path.isfile(path):
+            continue
+        try:
+            with open(path, "rb") as f:
+                _cache = tomllib.load(f)
+            _cache_source = path
+            return _cache
+        except (OSError, tomllib.TOMLDecodeError):
+            continue
+
+    _cache = {}
+    _cache_source = ""
+    return _cache
+
+
+def source() -> str:
+    """Return the path we actually loaded config from, or '' if none/unavailable."""
+    if _cache is None:
+        load()
+    return _cache_source
+
+
+# ---------------------------------------------------------------------------
+# Typed getters
+# ---------------------------------------------------------------------------
+
+def get_str(key: str, default: str = "") -> str:
+    """Get ``[section.]key`` as a string. Dotted path allowed."""
+    v = _dotted(load(), key)
+    return str(v) if v is not None and v != "" else default
+
+
+def get_int(key: str, default: int) -> int:
+    v = _dotted(load(), key)
+    try:
+        return int(v) if v is not None else default
+    except (TypeError, ValueError):
+        return default
+
+
+def get_list(key: str, default: list[Any] | None = None) -> list[Any]:
+    """Get a list-typed key (returns ``default`` or ``[]``)."""
+    v = _dotted(load(), key)
+    if isinstance(v, list):
+        return v
+    return list(default) if default is not None else []
+
+
+def _dotted(d: dict[str, Any], key: str) -> Any:
+    """Traverse ``a.b.c`` in nested dict; return None if any hop is missing."""
+    cur: Any = d
+    for part in key.split("."):
+        if isinstance(cur, dict) and part in cur:
+            cur = cur[part]
+        else:
+            return None
+    return cur
+
+
+# ---------------------------------------------------------------------------
+# High-level resolvers used by report_html.py
+# ---------------------------------------------------------------------------
+#
+# Each resolver follows the layered precedence (env → TOML → default) so
+# adding TOML support is strictly additive: existing env-var users keep
+# working unchanged.
+
+
+def parse_fields_from_spec(raw: Any, defaults: list[tuple[str, str]]) -> list[list[str]]:
+    """Accept a TOML field spec — either a list of ``"key"`` / ``"key:label"``
+    strings, a list of ``[key, label]`` two-element lists, or a comma-separated
+    string — and return the same normalised ``[[key, label], ...]`` shape used
+    by the HTML template.
+    """
+    label_map = {k: lbl for k, lbl in defaults}
+
+    def _pair(entry: Any) -> list[str] | None:
+        if isinstance(entry, (list, tuple)) and len(entry) >= 1:
+            k = str(entry[0]).strip()
+            lbl = str(entry[1]).strip() if len(entry) > 1 and entry[1] else label_map.get(k, k)
+            return [k, lbl] if k else None
+        if isinstance(entry, str):
+            s = entry.strip()
+            if not s:
+                return None
+            if ":" in s:
+                k, _, lbl = s.partition(":")
+                k, lbl = k.strip(), lbl.strip()
+            else:
+                k, lbl = s, label_map.get(s, s)
+            return [k, lbl] if k else None
+        return None
+
+    if isinstance(raw, str):
+        # Comma-separated string — mirrors the env-var spec.
+        parts = [p.strip() for p in raw.split(",") if p.strip()]
+        out = [_pair(p) for p in parts]
+    elif isinstance(raw, list):
+        out = [_pair(e) for e in raw]
+    else:
+        return []
+
+    return [p for p in out if p]
+
+
+def resolve_env_columns(default: int = 2) -> int:
+    """Number of columns for the env-info grid. 1 = stacked, 2 = side-by-side."""
+    env_val = os.environ.get("CUBE_REPORT_ENV_COLUMNS")
+    if env_val:
+        try:
+            return max(1, int(env_val))
+        except ValueError:
+            pass
+    n = get_int("layout.env_columns", default)
+    return max(1, n)
+
+
+def resolve_title(cli_title: str | None, default: str) -> str:
+    """Title precedence: CLI > env > TOML > default. Empty strings are ignored."""
+    if cli_title:
+        return cli_title
+    env_title = os.environ.get("CUBE_REPORT_TITLE", "").strip()
+    if env_title:
+        return env_title
+    toml_title = get_str("title")
+    return toml_title or default
+
+
+def resolve_subtitle(default: str = "") -> str:
+    env_v = os.environ.get("CUBE_REPORT_SUBTITLE", "").strip()
+    if env_v:
+        return env_v
+    return get_str("subtitle", default)
+
+
+def resolve_fields_toml(
+    section: str, defaults: list[tuple[str, str]]
+) -> list[list[str]] | None:
+    """Return the ``[<section>] fields`` list (+ ``extra``) from TOML.
+
+    Returns None when the TOML file has no such section, so callers can
+    fall back to the existing env-var / defaults path unchanged.
+    ``fields`` fully replaces the defaults; ``extra`` appends.
+    """
+    section_cfg = _dotted(load(), section)
+    if not isinstance(section_cfg, dict):
+        return None
+
+    fields_spec = section_cfg.get("fields")
+    extra_spec = section_cfg.get("extra")
+
+    if fields_spec:
+        base = parse_fields_from_spec(fields_spec, defaults)
+    else:
+        base = [[k, lbl] for k, lbl in defaults]
+
+    if extra_spec:
+        base += parse_fields_from_spec(extra_spec, defaults)
+
+    return base

--- a/tests/perf/test_create_baseline.py
+++ b/tests/perf/test_create_baseline.py
@@ -1,0 +1,35 @@
+"""Create sandbox baseline."""
+
+METRICS = ("avg", "min", "p95", "max")   # which stats to show
+
+REPORT = {
+    "method_en": "Create Sandbox",
+    "method_zh": "创建沙箱",
+    "noun_en":    "op",
+    "noun_zh":    "次",
+}
+
+LEVELS = (1,)                            # only concurrency=1
+
+import argparse, time, os
+
+ap = argparse.ArgumentParser()
+ap.add_argument("-c", type=int, default=1)
+ap.add_argument("-n", type=int, default=5)
+ap.add_argument("--rounds", type=int, default=3)
+ap.add_argument("--no-header", action="store_true")
+args = ap.parse_args()
+
+from cubesandbox import Sandbox, Config
+
+cfg = Config(
+    api_url=os.environ.get("CUBE_API_URL", "http://127.0.0.1:3000"),
+    template_id=os.environ.get("CUBE_TEMPLATE_ID", ""),
+)
+
+for i in range(args.n):
+    t0 = time.time()
+    sb = Sandbox.create(config=cfg)
+    dt = (time.time() - t0) * 1000
+    sb.kill()
+    print(f"c={args.c}, {i + 1}/{args.n}, {dt:.0f} ms")


### PR DESCRIPTION
A one-command performance benchmark suite for CubeSandbox, producing JSON data and bilingual Markdown reports.

- 7 built-in scenarios covering create, snapshot, rollback, clone, pause/resume, and snapshot-under-dirty-pages
- Concurrency-sweep with latency distributions (avg/min/p50/p95/p99/max)
- Snapshot-dirty: writes 0–1024 MB guest memory, measures dirty-page cost end-to-end
- All reports land in tests/perf/report/<UTC-timestamp>/ — one dir per run
- Auto-cleanup drains stale sandboxes between rounds to prevent 130597 cascades
- .env-driven config, glob-based external script discovery

Assisted-by: CodeBuddy