### PR TITLE
examples: add claude-code-sandbox and qclaw-sandbox templates

### DIFF
--- a/examples/claude-code-sandbox/.env.example
+++ b/examples/claude-code-sandbox/.env.example
@@ -1,0 +1,19 @@
+# CubeSandbox connection
+E2B_API_URL=http://127.0.0.1:3000
+E2B_API_KEY=e2b_000000
+
+# Template ID (from `cubemastercli tpl create-from-image`)
+CUBE_TEMPLATE_ID=
+
+# Anthropic API key (required for Claude Code)
+ANTHROPIC_API_KEY=
+
+# Optional: custom Anthropic-compatible endpoint
+# ANTHROPIC_BASE_URL=
+
+# Optional: override Claude Code workspace
+# CLAUDE_CODE_WORKSPACE=/workspace
+
+# Optional: timeouts (seconds)
+# CLAUDE_EXEC_TIMEOUT=900
+# CLAUDE_SANDBOX_TIMEOUT=1800

--- a/examples/claude-code-sandbox/.gitignore
+++ b/examples/claude-code-sandbox/.gitignore
@@ -1,0 +1,6 @@
+.env
+__pycache__/
+*.pyc
+*.pyo
+output/
+workspace-seed/

--- a/examples/claude-code-sandbox/Dockerfile
+++ b/examples/claude-code-sandbox/Dockerfile
@@ -1,0 +1,56 @@
+# CubeSandbox 模板：Claude Code 沙箱
+#
+# 基于 CubeSandbox 官方基础镜像，安装 Node.js 22 和 Claude Code CLI。
+# 继承的 cube-entrypoint 在 :49983 端口保持 envd 运行，
+# 供 Cube 使用标准就绪探针。
+#
+# 构建：
+#   docker build -t claude-code-cube:latest examples/claude-code-sandbox
+#
+# 注册为 Cube 模板：
+#   cubemastercli tpl create-from-image \
+#     --image <your-registry>/claude-code-cube:latest \
+#     --writable-layer-size 4G \
+#     --expose-port 49983 \
+#     --probe       49983 \
+#     --probe-path  /health
+
+ARG CUBE_BASE_IMAGE=ghcr.io/tencentcloud/cubesandbox-base:2026.16
+FROM ${CUBE_BASE_IMAGE}
+
+ARG DEBIAN_FRONTEND=noninteractive
+ARG NODE_MAJOR=22
+ARG CLAUDE_CODE_VERSION=1.0.0
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        bash \
+        ca-certificates \
+        curl \
+        git \
+        gnupg \
+        jq \
+        less \
+        procps \
+        python3 \
+        python3-pip \
+        ripgrep \
+    && curl -fsSL "https://deb.nodesource.com/setup_${NODE_MAJOR}.x" | bash - \
+    && apt-get install -y --no-install-recommends nodejs \
+    && rm -rf /var/lib/apt/lists/*
+
+# 将 Claude Code 安装在独立层中，这样更新 CLAUDE_CODE_VERSION 时
+# 不会使上面耗时的 OS + Node.js 层缓存失效。
+RUN npm install -g --ignore-scripts "@anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}" \
+    && claude --version \
+    && npm cache clean --force \
+    && rm -rf /root/.npm
+
+ENV CLAUDE_CODE_DISABLE_TELEMETRY=1 \
+    CLAUDE_CODE_SKIP_UPDATE_CHECK=1
+
+RUN mkdir -p /workspace /root/.claude
+
+WORKDIR /workspace
+
+EXPOSE 49983

--- a/examples/claude-code-sandbox/README.md
+++ b/examples/claude-code-sandbox/README.md
@@ -1,0 +1,119 @@
+# Claude Code + CubeSandbox Example
+
+[中文文档](README_zh.md)
+
+Run [Claude Code](https://docs.anthropic.com/en/docs/claude-code) — Anthropic's
+official CLI coding agent — inside a CubeSandbox MicroVM. The agent edits files,
+runs commands, and reaches the Anthropic API entirely within an isolated,
+reproducible sandbox.
+
+This example ships:
+
+- A `Dockerfile` that stacks Node.js 22 + the Claude Code CLI on top of the
+  CubeSandbox base image (envd already listens on `:49983`).
+- `run_claude_agent.py` — a headless one-shot run inside `/workspace`.
+- `resume_claude_agent.py` — pause/resume across two turns, proving `/workspace`
+  survives the snapshot.
+- `env_utils.py`, `.env.example`, `requirements.txt`.
+
+## Directory layout
+
+```
+claude-code-sandbox/
+├── Dockerfile               # CubeSandbox template image (Node.js + Claude Code CLI)
+├── .env.example             # Copy to .env and fill in
+├── .gitignore
+├── requirements.txt         # Host driver deps (e2b, python-dotenv)
+├── env_utils.py             # .env loading, key management, claude command builder
+├── _claude_common.py        # Shared sandbox command helpers (run/ensure/id)
+├── run_claude_agent.py      # One-shot Claude Code task
+├── resume_claude_agent.py   # Pause / resume session persistence
+├── README.md                # English docs (this file)
+└── README_zh.md             # Chinese docs
+```
+
+## Prerequisites
+
+- A running CubeSandbox deployment; CubeAPI reachable at `http://<node>:3000`.
+- `cubemastercli` on `$PATH`, connected to the cluster.
+- Docker on the build workstation, plus a registry the Cube nodes can pull from.
+- An Anthropic API key.
+- Python 3.10+ for the host driver scripts.
+
+## 1. Build the template image
+
+```bash
+docker build --platform linux/amd64 \
+  -t <your-registry>/claude-code-cube:latest \
+  examples/claude-code-sandbox
+docker push <your-registry>/claude-code-cube:latest
+```
+
+The image installs `@anthropic-ai/claude-code`, plus `git`, `python3`,
+`ripgrep`, `jq`, and cleans apt/npm caches. The Claude Code version is pinned
+via `--build-arg CLAUDE_CODE_VERSION=x.y.z`.
+
+## 2. Register as a Cube template
+
+```bash
+cubemastercli tpl create-from-image \
+  --image <your-registry>/claude-code-cube:latest \
+  --writable-layer-size 4G \
+  --expose-port 49983 \
+  --probe       49983 \
+  --probe-path  /health
+
+cubemastercli tpl watch --job-id <job_id>
+```
+
+Note the `template_id` once the job reaches `READY`.
+
+## 3. Configure the host driver
+
+```bash
+cd examples/claude-code-sandbox
+cp .env.example .env
+# fill in E2B_API_URL, CUBE_TEMPLATE_ID, and ANTHROPIC_API_KEY
+pip install -r requirements.txt
+```
+
+| Variable | Where it flows | Notes |
+|---|---|---|
+| `E2B_API_URL` | Local process | CubeAPI address (`http://<node>:3000`) |
+| `E2B_API_KEY` | Local process | Any non-empty string in local dev |
+| `CUBE_TEMPLATE_ID` | `Sandbox.create(template=...)` | From step 2 |
+| `ANTHROPIC_API_KEY` | `envs=...` (injected per command) | Provider key |
+
+## 4. One-shot run
+
+```bash
+python run_claude_agent.py --prompt "Create hello.py that prints 'Hello from CubeSandbox' and run it."
+```
+
+The key is forwarded per-command via `sandbox.commands.run(..., envs=...)`, so
+it lives only for the lifetime of that exec call.
+
+## 5. Pause / resume (session persistence)
+
+```bash
+python resume_claude_agent.py
+```
+
+Turn 1 asks Claude Code to write `/workspace/plan.md`, then `sandbox.pause()`
+snapshots the VM. The script reconnects with `Sandbox.connect(sandbox_id)`,
+verifies `/workspace/plan.md` survived, then runs turn 2 to continue the work.
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| `claude: command not found` | Template not rebuilt after CLI change | Rebuild the image, re-register the template |
+| Auth error from Anthropic | Key not forwarded | Pass `envs={...}` with `ANTHROPIC_API_KEY` |
+| Readiness probe timeout | Image without envd | Ensure `FROM ghcr.io/tencentcloud/cubesandbox-base:...` |
+| `pause()`/`connect()` errors | Platform too old for snapshots | Upgrade the CubeSandbox platform |
+
+## References
+
+- Claude Code docs: <https://docs.anthropic.com/en/docs/claude-code>
+- CubeSandbox snapshot / clone: [`docs/guide/snapshot-rollback-clone.md`](../../docs/guide/snapshot-rollback-clone.md)
+- Pi agent example: [`examples/pi-agent-integration`](../pi-agent-integration)

--- a/examples/claude-code-sandbox/README_zh.md
+++ b/examples/claude-code-sandbox/README_zh.md
@@ -1,0 +1,113 @@
+# Claude Code + CubeSandbox 示例
+
+[English](README.md)
+
+在 CubeSandbox MicroVM 中运行 [Claude Code](https://docs.anthropic.com/en/docs/claude-code)
+—— Anthropic 的官方 CLI 编程智能体。智能体在隔离、可复现的沙箱中编辑文件、运行命令、访问 Anthropic API。
+
+本示例包含：
+
+- `Dockerfile` —— 在 CubeSandbox 基础镜像之上安装 Node.js 22 和 Claude Code CLI（envd 已在 `:49983` 上监听）。
+- `run_claude_agent.py` —— 在 `/workspace` 中进行一次性 headless 运行。
+- `resume_claude_agent.py` —— 跨两轮对话的暂停/恢复，证明 `/workspace` 在快照后仍然存活。
+- `env_utils.py`、`.env.example`、`requirements.txt`。
+
+## 目录结构
+
+```
+claude-code-sandbox/
+├── Dockerfile               # CubeSandbox 模板镜像（Node.js + Claude Code CLI）
+├── .env.example             # 复制为 .env 并填写
+├── .gitignore
+├── requirements.txt         # 宿主机驱动依赖（e2b、python-dotenv）
+├── env_utils.py             # .env 加载、密钥管理、claude 命令构建
+├── _claude_common.py        # 共享沙箱命令工具（run/ensure/id）
+├── run_claude_agent.py      # 一次性 Claude Code 任务
+├── resume_claude_agent.py   # 暂停/恢复会话持久化
+├── README.md                # 英文文档
+└── README_zh.md             # 中文文档（本文件）
+```
+
+## 前置条件
+
+- 运行中的 CubeSandbox 部署，CubeAPI 可通过 `http://<node>:3000` 访问。
+- `cubemastercli` 在 `$PATH` 中，已连接到集群。
+- 构建工作站上有 Docker，且有一个 Cube 节点可拉取的镜像仓库。
+- Anthropic API 密钥。
+- Python 3.10+ 用于运行宿主机驱动脚本。
+
+## 1. 构建模板镜像
+
+```bash
+docker build --platform linux/amd64 \
+  -t <your-registry>/claude-code-cube:latest \
+  examples/claude-code-sandbox
+docker push <your-registry>/claude-code-cube:latest
+```
+
+镜像安装 `@anthropic-ai/claude-code`，以及 `git`、`python3`、`ripgrep`、`jq`，
+并清理 apt/npm 缓存。Claude Code 版本通过 `--build-arg CLAUDE_CODE_VERSION=x.y.z` 固定。
+
+## 2. 注册为 Cube 模板
+
+```bash
+cubemastercli tpl create-from-image \
+  --image <your-registry>/claude-code-cube:latest \
+  --writable-layer-size 4G \
+  --expose-port 49983 \
+  --probe       49983 \
+  --probe-path  /health
+
+cubemastercli tpl watch --job-id <job_id>
+```
+
+任务状态变为 `READY` 后，记下 `template_id`。
+
+## 3. 配置宿主机驱动
+
+```bash
+cd examples/claude-code-sandbox
+cp .env.example .env
+# 填写 E2B_API_URL、CUBE_TEMPLATE_ID 和 ANTHROPIC_API_KEY
+pip install -r requirements.txt
+```
+
+| 变量 | 作用位置 | 说明 |
+|---|---|---|
+| `E2B_API_URL` | 本地进程 | CubeAPI 地址（`http://<node>:3000`） |
+| `E2B_API_KEY` | 本地进程 | 本地开发中可填任意非空字符串 |
+| `CUBE_TEMPLATE_ID` | `Sandbox.create(template=...)` | 来自步骤 2 |
+| `ANTHROPIC_API_KEY` | `envs=...`（每次命令注入） | Provider 密钥 |
+
+## 4. 一次性运行
+
+```bash
+python run_claude_agent.py --prompt "创建一个 hello.py，打印 'Hello from CubeSandbox' 并运行它。"
+```
+
+密钥通过 `sandbox.commands.run(..., envs=...)` 按命令转发，只在 exec 调用期间存在——不会写入 VM 内的持久文件。
+
+## 5. 暂停 / 恢复（会话持久化）
+
+```bash
+python resume_claude_agent.py
+```
+
+第一轮对话让 Claude Code 写入 `/workspace/plan.md`，然后 `sandbox.pause()` 对 VM
+进行快照。脚本通过 `Sandbox.connect(sandbox_id)` 重新连接，验证 `/workspace/plan.md`
+存活，然后运行第二轮对话继续工作。
+
+## 故障排除
+
+| 现象 | 可能原因 | 解决方法 |
+|---|---|---|
+| `claude: command not found` | CLI 变更后未重新构建模板 | 重新构建镜像，重新注册模板 |
+| Anthropic 返回认证错误 | 密钥未转发 | 通过 `envs={...}` 传入 `ANTHROPIC_API_KEY` |
+| 就绪探针超时 | 镜像不含 envd | 确保 `FROM ghcr.io/tencentcloud/cubesandbox-base:...` |
+| `pause()`/`connect()` 报错 | 平台版本过旧不支持快照 | 升级 CubeSandbox 平台 |
+
+## 参考资料
+
+- Claude Code 文档：<https://docs.anthropic.com/en/docs/claude-code>
+- CubeSandbox 快照 / 克隆： [`docs/guide/snapshot-rollback-clone.md`](../../docs/guide/snapshot-rollback-clone.md)
+- Pi 智能体示例： [`examples/pi-agent-integration`](../pi-agent-integration)

--- a/examples/claude-code-sandbox/_claude_common.py
+++ b/examples/claude-code-sandbox/_claude_common.py
@@ -1,0 +1,137 @@
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Claude Code 示例脚本的共享沙箱命令工具函数。"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from collections.abc import Callable
+from typing import Any
+
+
+def stream_writer(stream) -> Callable[[object], None]:
+    def write(chunk: object) -> None:
+        text = getattr(chunk, "line", chunk)
+        stream.write(str(text))
+        stream.flush()
+
+    return write
+
+
+def _tool_brief(arguments: dict) -> str:
+    for key in ("command", "path"):
+        value = arguments.get(key)
+        if value:
+            return str(value).replace("\n", " ")[:120]
+    return ""
+
+
+def _render_message(message: object) -> None:
+    if not isinstance(message, dict):
+        return
+    msg_type = message.get("type")
+    if msg_type == "assistant":
+        content = message.get("content")
+        if isinstance(content, str) and content.strip():
+            print(content.strip())
+        elif isinstance(content, list):
+            for block in content:
+                if not isinstance(block, dict):
+                    continue
+                btype = block.get("type")
+                if btype == "text":
+                    text = str(block.get("text", "")).strip()
+                    if text:
+                        print(text)
+                elif btype == "tool_use":
+                    name = block.get("name") or "tool"
+                    arguments = (
+                        block.get("arguments")
+                        if isinstance(block.get("arguments"), dict)
+                        else {}
+                    )
+                    brief = _tool_brief(arguments)
+                    print(f"  → [tool] {name}{': ' + brief if brief else ''}")
+    elif msg_type == "user":
+        content = message.get("content")
+        if isinstance(content, list):
+            for block in content:
+                if isinstance(block, dict) and block.get("type") == "tool_result":
+                    if block.get("is_error"):
+                        print(f"  ✗ [tool] {block.get('tool_use_id', 'unknown')} failed")
+    elif msg_type == "result":
+        if message.get("is_error"):
+            print(f"  [error] {str(message.get('error', ''))[:300]}")
+
+
+def _render_jsonl_line(line: str) -> None:
+    """将一行 Claude Code JSON 事件渲染为简洁的人类可读输出。"""
+    line = line.rstrip("\r\n")
+    if not line.strip():
+        return
+    try:
+        event = json.loads(line)
+    except (ValueError, TypeError):
+        print(line)
+        return
+    if not isinstance(event, dict):
+        return
+    _render_message(event)
+
+
+def jsonl_renderer() -> Callable[[object], None]:
+    buffer = {"text": ""}
+
+    def write(chunk: object) -> None:
+        text = getattr(chunk, "line", chunk)
+        buffer["text"] += text if isinstance(text, str) else str(text)
+        while "\n" in buffer["text"]:
+            line, buffer["text"] = buffer["text"].split("\n", 1)
+            _render_jsonl_line(line)
+
+    return write
+
+
+def run_command(
+    sandbox: Any,
+    command: str,
+    *,
+    cwd: str | None = None,
+    envs: dict[str, str] | None = None,
+    timeout: int | float | None = None,
+    stream: bool = False,
+    user: str = "root",
+):
+    kwargs = {"cwd": cwd, "timeout": timeout, "user": user}
+    kwargs = {key: value for key, value in kwargs.items() if value is not None}
+    if envs:
+        kwargs["envs"] = envs
+    if stream:
+        raw = os.environ.get("CLAUDE_STREAM_RAW", "").strip().lower() in ("1", "true", "yes")
+        kwargs["on_stdout"] = stream_writer(sys.stdout) if raw else jsonl_renderer()
+        kwargs["on_stderr"] = stream_writer(sys.stderr)
+
+    try:
+        return sandbox.commands.run(command, **kwargs)
+    except TypeError as exc:
+        if "envs" not in kwargs or "envs" not in str(exc):
+            raise
+        kwargs["env"] = kwargs.pop("envs")
+        return sandbox.commands.run(command, **kwargs)
+
+
+def ensure_success(result, action: str) -> None:
+    exit_code = getattr(result, "exit_code", None)
+    if exit_code not in (None, 0):
+        stdout = getattr(result, "stdout", "")
+        stderr = getattr(result, "stderr", "")
+        raise SystemExit(
+            f"Failed to {action} (exit {exit_code}).\nSTDOUT:\n{stdout}\nSTDERR:\n{stderr}"
+        )
+
+
+def sandbox_identifier(sandbox: Any) -> str:
+    return getattr(sandbox, "sandbox_id", getattr(sandbox, "id", "unknown"))

--- a/examples/claude-code-sandbox/env_utils.py
+++ b/examples/claude-code-sandbox/env_utils.py
@@ -1,0 +1,126 @@
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# 注意：本文件与 pi-agent-integration/env_utils.py 和 qclaw-sandbox/env_utils.py
+# 共享多个基础工具函数（load_local_dotenv、required、optional、int_env、
+# shell_join、_host_from_url）。如需修复这些函数，请同步更新所有副本。
+
+from __future__ import annotations
+
+import os
+import shlex
+from pathlib import Path
+from urllib.parse import urlparse
+
+from dotenv import load_dotenv
+
+DEFAULT_CLAUDE_DIR = "/root/.claude"
+DEFAULT_WORKSPACE = "/workspace"
+
+PASSTHROUGH_ENV_NAMES = (
+    "ANTHROPIC_BASE_URL",
+    "ANTHROPIC_MODEL",
+    "HTTP_PROXY",
+    "HTTPS_PROXY",
+    "NO_PROXY",
+)
+
+
+def load_local_dotenv() -> None:
+    candidate_paths = [
+        Path(__file__).with_name(".env"),
+        Path.cwd() / ".env",
+    ]
+    seen_paths: set[Path] = set()
+    for path in candidate_paths:
+        resolved_path = path.resolve()
+        if resolved_path in seen_paths:
+            continue
+        seen_paths.add(resolved_path)
+        if path.is_file():
+            load_dotenv(dotenv_path=path, override=False)
+            return
+
+
+def required(name: str) -> str:
+    value = os.environ.get(name)
+    if not value:
+        raise SystemExit(f"Missing required environment variable: {name}")
+    return value
+
+
+def optional(name: str, default: str = "") -> str:
+    return os.environ.get(name) or default
+
+
+def int_env(name: str, default: int) -> int:
+    raw = os.environ.get(name)
+    if not raw:
+        return default
+    try:
+        return int(raw)
+    except ValueError as exc:
+        raise SystemExit(f"{name} must be an integer, got {raw!r}") from exc
+
+
+def claude_workspace() -> str:
+    return optional("CLAUDE_CODE_WORKSPACE", DEFAULT_WORKSPACE)
+
+
+def require_anthropic_key() -> str:
+    key = os.environ.get("ANTHROPIC_API_KEY") or os.environ.get("ANTHROPIC_AUTH_TOKEN")
+    if not key:
+        raise SystemExit("Missing required environment variable: ANTHROPIC_API_KEY")
+    return key
+
+
+def build_claude_env(include_secrets: bool = True) -> dict[str, str]:
+    # CLAUDE_CODE_DISABLE_TELEMETRY 和 CLAUDE_CODE_SKIP_UPDATE_CHECK
+    # 已在 Dockerfile 中通过 ENV 设置，此处不需要重复声明。
+    env: dict[str, str] = {}
+    for name in PASSTHROUGH_ENV_NAMES:
+        value = os.environ.get(name)
+        if value:
+            env[name] = value
+    if include_secrets:
+        key = os.environ.get("ANTHROPIC_API_KEY") or os.environ.get("ANTHROPIC_AUTH_TOKEN")
+        if key:
+            env["ANTHROPIC_API_KEY"] = key
+    return env
+
+
+def claude_llm_host() -> str:
+    explicit = os.environ.get("CLAUDE_LLM_HOST")
+    if explicit:
+        return _host_from_url(explicit)
+    base_url = os.environ.get("ANTHROPIC_BASE_URL")
+    if base_url:
+        host = _host_from_url(base_url)
+        if host:
+            return host
+    return "api.anthropic.com"
+
+
+def _host_from_url(value: str) -> str:
+    candidate = value.strip()
+    if not candidate:
+        return ""
+    if "://" not in candidate:
+        candidate = f"https://{candidate}"
+    return urlparse(candidate).hostname or ""
+
+
+def claude_command(
+    prompt: str, *, output_format: str = "json", approve: bool = True
+) -> str:
+    args = ["claude", "--print"]
+    if output_format:
+        args.extend(["--output-format", output_format])
+    if approve:
+        args.append("--approve")
+    args.append(prompt)
+    return " ".join(shlex.quote(arg) for arg in args)
+
+
+def shell_join(*parts: str) -> str:
+    return " && ".join(part for part in parts if part)

--- a/examples/claude-code-sandbox/requirements.txt
+++ b/examples/claude-code-sandbox/requirements.txt
@@ -1,0 +1,2 @@
+e2b>=2.4.1
+python-dotenv>=1.0.0

--- a/examples/claude-code-sandbox/resume_claude_agent.py
+++ b/examples/claude-code-sandbox/resume_claude_agent.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""演示 Claude Code 在 CubeSandbox 暂停/恢复中的文件系统持久化。
+
+第一轮让 Claude Code 写入 ``/workspace/plan.md``，然后暂停沙箱。
+第二轮重新连接到同一沙箱，验证 ``/workspace`` 在快照后存活，
+并让 Claude Code 读取之前的结果继续工作。
+
+注意：每次 ``claude --print`` 都是独立的无状态会话，Claude Code 不保留
+跨调用的对话上下文。本演示通过文件系统（plan.md / progress.md）跨轮传递
+信息，验证的是文件系统状态持久化，而非对话上下文持久化。
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import shlex
+import sys
+
+from e2b import Sandbox
+
+from _claude_common import ensure_success, run_command, sandbox_identifier
+from env_utils import (
+    build_claude_env,
+    claude_command,
+    claude_workspace,
+    int_env,
+    load_local_dotenv,
+    required,
+    require_anthropic_key,
+    shell_join,
+)
+
+TURN_1_PROMPT = (
+    "Create {workspace}/plan.md containing a numbered 3-step plan for building a "
+    "small Python CLI that prints the current time. Only write the plan file."
+)
+TURN_2_PROMPT = (
+    "Read {workspace}/plan.md and implement step 1 by creating "
+    "{workspace}/progress.md that records which step you completed and why. "
+    "Do not delete plan.md."
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="演示 Claude Code 在 CubeSandbox 暂停/恢复中的文件系统持久化。"
+    )
+    parser.add_argument(
+        "--template",
+        default=os.environ.get("CUBE_TEMPLATE_ID"),
+        help="CubeSandbox template ID. Defaults to CUBE_TEMPLATE_ID.",
+    )
+    parser.add_argument(
+        "--workspace",
+        default=claude_workspace(),
+        help="Working directory inside the sandbox. Defaults to CLAUDE_CODE_WORKSPACE.",
+    )
+    parser.add_argument(
+        "--sandbox-timeout",
+        type=int,
+        default=int_env("CLAUDE_SANDBOX_TIMEOUT", 1800),
+        help="Sandbox lifetime in seconds.",
+    )
+    parser.add_argument(
+        "--exec-timeout",
+        type=int,
+        default=int_env("CLAUDE_EXEC_TIMEOUT", 900),
+        help="Command timeout in seconds.",
+    )
+    parser.add_argument(
+        "--raw",
+        action="store_true",
+        help="Stream raw JSON output instead of the concise transcript.",
+    )
+    return parser.parse_args()
+
+
+def run_turn(
+    sandbox: Sandbox,
+    workspace: str,
+    prompt: str,
+    exec_timeout: int,
+    envs: dict[str, str],
+):
+    command = shell_join(
+        f"cd {shlex.quote(workspace)}",
+        claude_command(prompt),
+    )
+    return run_command(
+        sandbox,
+        command,
+        cwd=workspace,
+        envs=envs,
+        timeout=exec_timeout,
+        stream=True,
+    )
+
+
+def assert_state_survived(sandbox: Sandbox, workspace: str) -> None:
+    quoted_workspace = shlex.quote(workspace)
+    command = shell_join(
+        f"test -f {quoted_workspace}/plan.md",
+        "printf '\\n--- plan.md (survived pause/resume) ---\\n'",
+        f"cat {quoted_workspace}/plan.md",
+    )
+    result = run_command(sandbox, command, timeout=60)
+    ensure_success(result, "verify /workspace survived pause/resume")
+    if getattr(result, "stdout", ""):
+        print(result.stdout)
+
+
+def show_final_workspace(sandbox: Sandbox, workspace: str) -> None:
+    quoted_workspace = shlex.quote(workspace)
+    command = shell_join(
+        f"ls -la {quoted_workspace}",
+        f"test ! -f {quoted_workspace}/progress.md || "
+        f"(printf '\\n--- progress.md ---\\n' && cat {quoted_workspace}/progress.md)",
+    )
+    result = run_command(sandbox, command, timeout=60)
+    ensure_success(result, "inspect final workspace")
+    if getattr(result, "stdout", ""):
+        print(result.stdout)
+
+
+def main() -> int:
+    load_local_dotenv()
+    args = parse_args()
+    if args.raw:
+        os.environ["CLAUDE_STREAM_RAW"] = "1"
+
+    template_id = args.template or required("CUBE_TEMPLATE_ID")
+    required("E2B_API_URL")
+    required("E2B_API_KEY")
+    require_anthropic_key()
+
+    claude_env = build_claude_env()
+    turn_1_prompt = TURN_1_PROMPT.format(workspace=args.workspace)
+    turn_2_prompt = TURN_2_PROMPT.format(workspace=args.workspace)
+
+    print(f"Creating sandbox from template: {template_id}")
+    sandbox = Sandbox.create(template=template_id, timeout=args.sandbox_timeout)
+    sandbox_id = sandbox_identifier(sandbox)
+
+    try:
+        print(f"Sandbox ready: {sandbox_id}")
+
+        version_result = run_command(sandbox, "claude --version", timeout=60)
+        ensure_success(version_result, "check Claude Code version")
+        print(f"Claude Code version: {getattr(version_result, 'stdout', '').strip()}")
+
+        print("\n=== Turn 1: create plan.md ===\n")
+        result_1 = run_turn(
+            sandbox, args.workspace, turn_1_prompt, args.exec_timeout, claude_env
+        )
+        ensure_success(result_1, "run Claude Code turn 1")
+
+        print(f"\nPausing sandbox {sandbox_id} (snapshotting VM + rootfs)...")
+        paused_id = sandbox.pause()
+        if isinstance(paused_id, str) and paused_id:
+            sandbox_id = paused_id
+        print(f"Paused. Resume handle: {sandbox_id}")
+
+        print(f"\nReconnecting to {sandbox_id}...")
+        sandbox = Sandbox.connect(sandbox_id=sandbox_id)
+        print("Reconnected after resume.")
+
+        print("\n=== Verifying persistence after resume ===\n")
+        assert_state_survived(sandbox, args.workspace)
+
+        print("\n=== Turn 2: continue the work ===\n")
+        result_2 = run_turn(
+            sandbox, args.workspace, turn_2_prompt, args.exec_timeout, claude_env
+        )
+        ensure_success(result_2, "run Claude Code turn 2")
+
+        show_final_workspace(sandbox, args.workspace)
+
+        exit_code = getattr(result_2, "exit_code", 0)
+        return 0 if exit_code is None else int(exit_code)
+    finally:
+        if sandbox is not None:
+            try:
+                sandbox.kill()
+                print(f"\nSandbox {sandbox_id} killed.")
+            except Exception as exc:
+                print(
+                    f"Warning: failed to kill sandbox {sandbox_id}: {exc}",
+                    file=sys.stderr,
+                )
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/examples/claude-code-sandbox/run_claude_agent.py
+++ b/examples/claude-code-sandbox/run_claude_agent.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import argparse
+import os
+import shlex
+import sys
+
+from e2b import Sandbox
+
+from _claude_common import ensure_success, run_command, sandbox_identifier
+from env_utils import (
+    build_claude_env,
+    claude_command,
+    claude_workspace,
+    int_env,
+    load_local_dotenv,
+    required,
+    require_anthropic_key,
+    shell_join,
+)
+
+DEFAULT_PROMPT_TEMPLATE = (
+    "Inspect the project in {workspace}, run python3 app.py, and write a "
+    "concise summary of the result to {workspace}/result.md."
+)
+
+
+def default_prompt(workspace: str) -> str:
+    return DEFAULT_PROMPT_TEMPLATE.format(workspace=workspace)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="在 CubeSandbox 中运行一次性 Claude Code 任务。"
+    )
+    parser.add_argument(
+        "--template",
+        default=os.environ.get("CUBE_TEMPLATE_ID"),
+        help="CubeSandbox 模板 ID，默认为 CUBE_TEMPLATE_ID。",
+    )
+    parser.add_argument(
+        "--prompt",
+        default=None,
+        help="传递给 Claude Code 的提示词，默认为一个工作区冒烟测试任务。",
+    )
+    parser.add_argument(
+        "--workspace",
+        default=claude_workspace(),
+        help="沙箱内的工作目录，默认为 CLAUDE_CODE_WORKSPACE。",
+    )
+    parser.add_argument(
+        "--sandbox-timeout",
+        type=int,
+        default=int_env("CLAUDE_SANDBOX_TIMEOUT", 1800),
+        help="沙箱生命周期（秒），默认为 CLAUDE_SANDBOX_TIMEOUT 或 1800。",
+    )
+    parser.add_argument(
+        "--exec-timeout",
+        type=int,
+        default=int_env("CLAUDE_EXEC_TIMEOUT", 900),
+        help="命令超时（秒），默认为 CLAUDE_EXEC_TIMEOUT 或 900。",
+    )
+    parser.add_argument(
+        "--no-seed",
+        action="store_true",
+        help="跳过在沙箱工作区写入演示文件。",
+    )
+    parser.add_argument(
+        "--raw",
+        action="store_true",
+        help="输出原始 JSON 流而非简洁文本摘要。",
+    )
+    args = parser.parse_args()
+    if args.prompt is None:
+        args.prompt = default_prompt(args.workspace)
+    if args.raw:
+        os.environ["CLAUDE_STREAM_RAW"] = "1"
+    return args
+
+
+def seed_project(sandbox: Sandbox, workspace: str, timeout: int) -> None:
+    quoted_workspace = shlex.quote(workspace)
+    command = f"""mkdir -p {quoted_workspace}
+cat > {quoted_workspace}/README.md <<'EOF'
+# CubeSandbox Claude Code Smoke Project
+
+This tiny project exists so Claude Code has a deterministic task to run.
+EOF
+cat > {quoted_workspace}/app.py <<'EOF'
+def main() -> None:
+    print("hello from CubeSandbox + Claude Code")
+
+
+if __name__ == "__main__":
+    main()
+EOF
+"""
+    result = run_command(sandbox, command, timeout=timeout)
+    ensure_success(result, "seed workspace")
+
+
+def show_workspace_result(sandbox: Sandbox, workspace: str, timeout: int) -> None:
+    quoted_workspace = shlex.quote(workspace)
+    command = shell_join(
+        f"ls -la {quoted_workspace}",
+        f"test ! -f {quoted_workspace}/result.md || "
+        f"(printf '\\n--- result.md ---\\n' && cat {quoted_workspace}/result.md)",
+    )
+    result = run_command(sandbox, command, timeout=timeout)
+    ensure_success(result, "inspect workspace")
+    if getattr(result, "stdout", ""):
+        print(result.stdout)
+
+
+def main() -> int:
+    load_local_dotenv()
+    args = parse_args()
+
+    template_id = args.template or required("CUBE_TEMPLATE_ID")
+    required("E2B_API_URL")
+    required("E2B_API_KEY")
+    require_anthropic_key()
+
+    claude_env = build_claude_env()
+    command = shell_join(
+        f"cd {shlex.quote(args.workspace)}",
+        claude_command(args.prompt),
+    )
+
+    print(f"Creating sandbox from template: {template_id}")
+    result = None
+    # SECURITY: 本演示保持默认的出站网络访问（allow_internet_access 默认为 True），
+    # 并通过 envs= 将 ANTHROPIC_API_KEY 注入沙箱。被攻破的智能体可利用开放出站流量
+    # 窃取该密钥。共享/生产环境请使用默认拒绝出口 + CubeEgress 凭证保险箱模式，
+    # 密钥不进入虚拟机。参见 pi-agent-integration/network_policy.py。
+    with Sandbox.create(template=template_id, timeout=args.sandbox_timeout) as sandbox:
+        sandbox_id = sandbox_identifier(sandbox)
+        print(f"Sandbox ready: {sandbox_id}")
+
+        version_result = run_command(sandbox, "claude --version", timeout=60)
+        ensure_success(version_result, "check Claude Code version")
+        print(f"Claude Code version: {getattr(version_result, 'stdout', '').strip()}")
+
+        if not args.no_seed:
+            seed_project(sandbox, args.workspace, timeout=60)
+            print(f"Seeded demo project in {args.workspace}")
+
+        print("\nRunning Claude Code task...\n")
+        result = run_command(
+            sandbox,
+            command,
+            cwd=args.workspace,
+            envs=claude_env,
+            timeout=args.exec_timeout,
+            stream=True,
+        )
+
+        show_workspace_result(sandbox, args.workspace, timeout=60)
+
+    exit_code = getattr(result, "exit_code", 1)
+    return 0 if exit_code is None else int(exit_code)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/examples/qclaw-sandbox/.env.example
+++ b/examples/qclaw-sandbox/.env.example
@@ -1,0 +1,27 @@
+# CubeSandbox connection
+E2B_API_URL=http://127.0.0.1:3000
+E2B_API_KEY=e2b_000000
+
+# Template ID (from `cubemastercli tpl create-from-image`)
+CUBE_TEMPLATE_ID=
+
+# LLM provider: anthropic, deepseek (default)
+QCLAW_PROVIDER=deepseek
+
+# Model ID
+QCLAW_MODEL=deepseek/deepseek-v4-flash
+
+# Provider API key
+# For Anthropic: ANTHROPIC_API_KEY
+# For DeepSeek: DEEPSEEK_API_KEY
+DEEPSEEK_API_KEY=
+
+# Optional: LLM API host for network policy
+# QCLAW_LLM_HOST=api.deepseek.com
+
+# Optional: timeouts (seconds)
+# QCLAW_EXEC_TIMEOUT=900
+# QCLAW_SANDBOX_TIMEOUT=1800
+
+# Optional: workspace path inside sandbox
+# QCLAW_WORKSPACE=/workspace

--- a/examples/qclaw-sandbox/.gitignore
+++ b/examples/qclaw-sandbox/.gitignore
@@ -1,0 +1,6 @@
+.env
+__pycache__/
+*.pyc
+*.pyo
+output/
+workspace-seed/

--- a/examples/qclaw-sandbox/Dockerfile
+++ b/examples/qclaw-sandbox/Dockerfile
@@ -1,0 +1,101 @@
+# CubeSandbox 模板：OpenClaw (QClaw) 智能体网关沙箱
+#
+# 基于 CubeSandbox 官方基础镜像，安装 Node.js 22 和 OpenClaw 网关。
+# 继承的 cube-entrypoint 在 :49983 端口保持 envd 运行，
+# 供 Cube 使用标准就绪探针。
+# OpenClaw 作为 supervisor 管理的守护进程运行在 18789 端口。
+#
+# 构建：
+#   docker build -t qclaw-cube:latest examples/qclaw-sandbox
+#
+# 注册为 Cube 模板：
+#   cubemastercli tpl create-from-image \
+#     --image <your-registry>/qclaw-cube:latest \
+#     --writable-layer-size 4G \
+#     --expose-port 49983 \
+#     --probe       49983 \
+#     --probe-path  /health
+
+ARG CUBE_BASE_IMAGE=ghcr.io/tencentcloud/cubesandbox-base:2026.16
+FROM ${CUBE_BASE_IMAGE}
+
+ARG DEBIAN_FRONTEND=noninteractive
+ARG NODE_MAJOR=22
+ARG QCLAW_VERSION=0.2.34
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        bash \
+        ca-certificates \
+        curl \
+        git \
+        gnupg \
+        jq \
+        less \
+        procps \
+        python3 \
+        python3-pip \
+        ripgrep \
+        supervisor \
+    && curl -fsSL "https://deb.nodesource.com/setup_${NODE_MAJOR}.x" | bash - \
+    && apt-get install -y --no-install-recommends nodejs \
+    && rm -rf /var/lib/apt/lists/*
+
+# 将 OpenClaw 安装在独立层中，这样更新 QCLAW_VERSION 时
+# 不会使上面耗时的 OS + Node.js 层缓存失效。
+# OpenClaw 可能需要内部 npm 源，可通过 --build-arg NPM_REGISTRY=<url> 指定。
+ARG NPM_REGISTRY=
+RUN if [ -n "${NPM_REGISTRY}" ]; then \
+        npm config set registry "${NPM_REGISTRY}"; \
+    fi \
+    && npm install -g --ignore-scripts "openclaw@${QCLAW_VERSION}" \
+    && openclaw --version \
+    && npm cache clean --force \
+    && rm -rf /root/.npm
+
+# OpenClaw 状态目录（遵循 CubeOps AgentHub 约定）。
+RUN mkdir -p /root/.openclaw/agents/main/agent \
+             /root/.openclaw/agents/main/sessions \
+             /root/.openclaw/workspace
+
+# 最小初始配置，使 OpenClaw 无需首次设置即可启动。
+# 完整配置由 CubeOps 在运行时通过 envd apply 脚本写入。
+# 包含一个默认开发令牌，确保网关就绪检查脚本能正常运行。
+RUN printf '%s\n' \
+    '{' \
+    '  "gateway": {' \
+    '    "bind": "lan",' \
+    '    "port": 18789,' \
+    '    "mode": "local",' \
+    '    "auth": {"mode": "token", "token": "dev-token-cubesandbox"}' \
+    '  },' \
+    '  "agents": {' \
+    '    "defaults": {' \
+    '      "workspace": "/root/.openclaw/workspace"' \
+    '    }' \
+    '  },' \
+    '  "session": {"dmScope": "per-channel-peer"}' \
+    '}' > /root/.openclaw/openclaw.json
+
+# OpenClaw 网关进程的 Supervisor 配置。
+RUN mkdir -p /opt/gem/supervisord /var/log \
+    && printf '%s\n' \
+        '[program:openclaw]' \
+        'command=openclaw gateway run' \
+        'directory=/root' \
+        'autostart=true' \
+        'autorestart=true' \
+        'stdout_logfile=/var/log/openclaw.log' \
+        'stderr_logfile=/var/log/openclaw.log' \
+        'environment=NODE_ENV="production",OPENCLAW_DEFAULT_MODEL="anthropic/claude-sonnet-4-6",OPENCLAW_BIND="lan"' \
+        > /opt/gem/supervisord/openclaw.conf
+
+RUN mkdir -p /workspace
+
+ENV OPENCLAW_DEFAULT_MODEL=anthropic/claude-sonnet-4-6 \
+    OPENCLAW_BIND=lan \
+    NODE_EXTRA_CA_CERTS=/etc/ssl/certs/ca-certificates.crt
+
+WORKDIR /workspace
+
+EXPOSE 49983 18789

--- a/examples/qclaw-sandbox/README.md
+++ b/examples/qclaw-sandbox/README.md
@@ -1,0 +1,150 @@
+# OpenClaw (QClaw) + CubeSandbox Example
+
+[中文文档](README_zh.md)
+
+Run [OpenClaw](https://github.com/TencentCloud/CubeSandbox) — Tencent's AI
+agent gateway — inside a CubeSandbox MicroVM. The agent gateway runs as a
+persistent daemon inside the sandbox, providing an isolated, reproducible
+runtime for AI agent workloads.
+
+OpenClaw is the core agent runtime behind QClaw (Tencent's AI desktop app)
+and the CubeOps AgentHub. It supports multiple LLM providers (DeepSeek by
+default, Anthropic, OpenAI) and manages agent sessions, tool execution, and
+workspace state within the sandbox.
+
+This example ships:
+
+- A `Dockerfile` that stacks Node.js 22 + the OpenClaw gateway on top of the
+  CubeSandbox base image (envd already listens on `:49983`).
+- `run_qclaw_agent.py` — a one-shot run: start gateway, send prompt, collect
+  result.
+- `resume_qclaw_agent.py` — pause/resume across two turns, proving `/workspace`
+  and `/root/.openclaw/` survive the snapshot.
+- `env_utils.py`, `.env.example`, `requirements.txt`.
+
+## Directory layout
+
+```
+qclaw-sandbox/
+├── Dockerfile               # CubeSandbox template image (Node.js + OpenClaw gateway)
+├── .env.example             # Copy to .env and fill in
+├── .gitignore
+├── requirements.txt         # Host driver deps (e2b, python-dotenv)
+├── env_utils.py             # .env loading, provider keys, env builder
+├── _qclaw_common.py         # Shared helpers (gateway lifecycle, HTTP interaction)
+├── run_qclaw_agent.py       # One-shot OpenClaw task
+├── resume_qclaw_agent.py    # Pause / resume session persistence
+├── README.md                # English docs (this file)
+└── README_zh.md             # Chinese docs
+```
+
+## Prerequisites
+
+- A running CubeSandbox deployment; CubeAPI reachable at `http://<node>:3000`.
+- `cubemastercli` on `$PATH`, connected to the cluster.
+- Docker on the build workstation, plus a registry the Cube nodes can pull from.
+- An LLM provider API key (DeepSeek by default; Anthropic and OpenAI also supported).
+- Python 3.10+ for the host driver scripts.
+
+## 1. Build the template image
+
+```bash
+docker build --platform linux/amd64 \
+  -t <your-registry>/qclaw-cube:latest \
+  examples/qclaw-sandbox
+docker push <your-registry>/qclaw-cube:latest
+```
+
+The image installs `openclaw`, plus `git`, `python3`, `ripgrep`, `jq`,
+`supervisor`, and cleans apt/npm caches. The OpenClaw version is pinned
+via `--build-arg QCLAW_VERSION=x.y.z`.
+
+If your registry requires an internal npm source, pass `--build-arg NPM_REGISTRY=<url>`.
+
+## 2. Register as a Cube template
+
+```bash
+cubemastercli tpl create-from-image \
+  --image <your-registry>/qclaw-cube:latest \
+  --writable-layer-size 4G \
+  --expose-port 49983 \
+  --probe       49983 \
+  --probe-path  /health
+
+cubemastercli tpl watch --job-id <job_id>
+```
+
+Note the `template_id` once the job reaches `READY`.
+
+## 3. Configure the host driver
+
+```bash
+cd examples/qclaw-sandbox
+cp .env.example .env
+# fill in E2B_API_URL, CUBE_TEMPLATE_ID, and your provider key
+pip install -r requirements.txt
+```
+
+| Variable | Where it flows | Notes |
+|---|---|---|
+| `E2B_API_URL` | Local process | CubeAPI address (`http://<node>:3000`) |
+| `E2B_API_KEY` | Local process | Any non-empty string in local dev |
+| `CUBE_TEMPLATE_ID` | `Sandbox.create(template=...)` | From step 2 |
+| `QCLAW_PROVIDER` | Host script | `anthropic`, `deepseek` (default) |
+| `QCLAW_MODEL` | OpenClaw config | Model id for the provider |
+| `DEEPSEEK_API_KEY` | `envs=...` (injected per command) | Provider key (DeepSeek) |
+| `ANTHROPIC_API_KEY` | `envs=...` (injected per command) | Provider key (Anthropic) |
+
+## 4. One-shot run
+
+```bash
+python run_qclaw_agent.py --prompt "Create hello.py that prints 'Hello from CubeSandbox' and run it."
+```
+
+The driver script:
+1. Creates a sandbox from the template
+2. Starts the OpenClaw gateway via supervisor
+3. Waits for gateway readiness (port 18789 + auth token)
+4. Sends the prompt via the gateway REST API
+5. Collects and displays the response
+6. Destroys the sandbox
+
+## 5. Pause / resume (session persistence)
+
+```bash
+python resume_qclaw_agent.py
+```
+
+Turn 1 asks OpenClaw to write `/workspace/plan.md`, then `sandbox.pause()`
+snapshots the VM. The script reconnects, verifies both `/workspace/plan.md`
+and `/root/.openclaw/` survived, restarts the gateway, and runs turn 2.
+
+## Architecture notes
+
+- **Gateway-daemon pattern**: Unlike one-shot CLI agents, OpenClaw runs as a
+  persistent process managed by `supervisor`. The gateway handles agent
+  sessions, tool execution, and LLM communication.
+- **State directory**: `/root/.openclaw/` holds config, agent state, sessions,
+  and workspace. This directory must survive pause/resume for session
+  persistence.
+- **Multi-provider**: Supports DeepSeek (default), Anthropic, and OpenAI via
+  the `QCLAW_PROVIDER` env var.
+- **AgentHub integration**: This template is a companion to the CubeOps
+  AgentHub, which manages OpenClaw instances at scale with host-side state
+  directories, egress credential injection, and snapshot/restore.
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| `openclaw: command not found` | Template not rebuilt after CLI change | Rebuild the image, re-register the template |
+| Gateway not ready after 30s | Supervisor config missing or port conflict | Check `supervisorctl status openclaw` or `/var/log/openclaw.log` |
+| Auth error from provider | Key not forwarded or wrong provider | Check `QCLAW_PROVIDER` and the matching `*_API_KEY` env var |
+| `403 Forbidden` from gateway | Token mismatch between start and read | Verify `/root/.openclaw/openclaw.json` has a valid token |
+| Readiness probe timeout | Image without envd | Ensure `FROM ghcr.io/tencentcloud/cubesandbox-base:...` |
+
+## References
+
+- CubeOps AgentHub OpenClaw service: `CubeOps/internal/service/openclaw.go`
+- CubeSandbox snapshot / clone: [`docs/guide/snapshot-rollback-clone.md`](../../docs/guide/snapshot-rollback-clone.md)
+- Pi agent example: [`examples/pi-agent-integration`](../pi-agent-integration)

--- a/examples/qclaw-sandbox/README_zh.md
+++ b/examples/qclaw-sandbox/README_zh.md
@@ -1,0 +1,143 @@
+# OpenClaw (QClaw) + CubeSandbox 示例
+
+[English](README.md)
+
+在 CubeSandbox MicroVM 中运行 [OpenClaw](https://github.com/TencentCloud/CubeSandbox)
+—— 腾讯的 AI 智能体网关。智能体网关以持久守护进程的形式运行在沙箱中，为 AI
+智能体工作负载提供隔离、可复现的运行时环境。
+
+OpenClaw 是 QClaw（腾讯 AI 桌面应用）和 CubeOps AgentHub 背后的核心智能体
+运行时，支持多种 LLM provider（默认 DeepSeek，也支持 Anthropic、OpenAI），管理
+智能体会话、工具执行和工作区状态。
+
+本示例包含：
+
+- `Dockerfile` —— 在 CubeSandbox 基础镜像之上安装 Node.js 22 和 OpenClaw 网关
+  （envd 已在 `:49983` 上监听）。
+- `run_qclaw_agent.py` —— 一次性运行：启动网关、发送 prompt、收集结果。
+- `resume_qclaw_agent.py` —— 跨两轮对话的暂停/恢复，证明 `/workspace` 和
+  `/root/.openclaw/` 在快照后仍然存活。
+- `env_utils.py`、`.env.example`、`requirements.txt`。
+
+## 目录结构
+
+```
+qclaw-sandbox/
+├── Dockerfile               # CubeSandbox 模板镜像（Node.js + OpenClaw 网关）
+├── .env.example             # 复制为 .env 并填写
+├── .gitignore
+├── requirements.txt         # 宿主机驱动依赖（e2b、python-dotenv）
+├── env_utils.py             # .env 加载、provider 密钥、环境变量构建
+├── _qclaw_common.py         # 共享工具（网关生命周期、HTTP 交互）
+├── run_qclaw_agent.py       # 一次性 OpenClaw 任务
+├── resume_qclaw_agent.py    # 暂停/恢复会话持久化
+├── README.md                # 英文文档
+└── README_zh.md             # 中文文档（本文件）
+```
+
+## 前置条件
+
+- 运行中的 CubeSandbox 部署，CubeAPI 可通过 `http://<node>:3000` 访问。
+- `cubemastercli` 在 `$PATH` 中，已连接到集群。
+- 构建工作站上有 Docker，且有一个 Cube 节点可拉取的镜像仓库。
+- LLM provider API 密钥（默认为 DeepSeek，也支持 Anthropic 和 OpenAI）。
+- Python 3.10+ 用于运行宿主机驱动脚本。
+
+## 1. 构建模板镜像
+
+```bash
+docker build --platform linux/amd64 \
+  -t <your-registry>/qclaw-cube:latest \
+  examples/qclaw-sandbox
+docker push <your-registry>/qclaw-cube:latest
+```
+
+镜像安装 `openclaw`，以及 `git`、`python3`、`ripgrep`、`jq`、`supervisor`，
+并清理 apt/npm 缓存。OpenClaw 版本通过 `--build-arg QCLAW_VERSION=x.y.z` 固定。
+
+如果注册表需要内部 npm 源，请传入 `--build-arg NPM_REGISTRY=<url>`。
+
+## 2. 注册为 Cube 模板
+
+```bash
+cubemastercli tpl create-from-image \
+  --image <your-registry>/qclaw-cube:latest \
+  --writable-layer-size 4G \
+  --expose-port 49983 \
+  --probe       49983 \
+  --probe-path  /health
+
+cubemastercli tpl watch --job-id <job_id>
+```
+
+任务状态变为 `READY` 后，记下 `template_id`。
+
+## 3. 配置宿主机驱动
+
+```bash
+cd examples/qclaw-sandbox
+cp .env.example .env
+# 填写 E2B_API_URL、CUBE_TEMPLATE_ID 和 provider 密钥
+pip install -r requirements.txt
+```
+
+| 变量 | 作用位置 | 说明 |
+|---|---|---|
+| `E2B_API_URL` | 本地进程 | CubeAPI 地址（`http://<node>:3000`） |
+| `E2B_API_KEY` | 本地进程 | 本地开发中可填任意非空字符串 |
+| `CUBE_TEMPLATE_ID` | `Sandbox.create(template=...)` | 来自步骤 2 |
+| `QCLAW_PROVIDER` | 宿主机脚本 | `anthropic`、`deepseek`（默认） |
+| `QCLAW_MODEL` | OpenClaw 配置 | Provider 的模型 ID |
+| `DEEPSEEK_API_KEY` | `envs=...`（每次命令注入） | Provider 密钥（DeepSeek） |
+| `ANTHROPIC_API_KEY` | `envs=...`（每次命令注入） | Provider 密钥（Anthropic） |
+
+## 4. 一次性运行
+
+```bash
+python run_qclaw_agent.py --prompt "创建一个 hello.py，打印 'Hello from CubeSandbox' 并运行它。"
+```
+
+驱动脚本执行以下步骤：
+1. 从模板创建沙箱
+2. 通过 supervisor 启动 OpenClaw 网关
+3. 等待网关就绪（端口 18789 + 认证令牌）
+4. 通过网关 REST API 发送 prompt
+5. 收集并显示响应
+6. 销毁沙箱
+
+## 5. 暂停 / 恢复（会话持久化）
+
+```bash
+python resume_qclaw_agent.py
+```
+
+第一轮对话让 OpenClaw 写入 `/workspace/plan.md`，然后 `sandbox.pause()` 对 VM
+进行快照。脚本重新连接，验证 `/workspace/plan.md` 和 `/root/.openclaw/` 两者均
+存活，重启网关，然后运行第二轮对话。
+
+## 架构说明
+
+- **网关守护进程模式**：与一次性 CLI 智能体不同，OpenClaw 作为由 `supervisor`
+  管理的持久进程运行。网关处理智能体会话、工具执行和 LLM 通信。
+- **状态目录**：`/root/.openclaw/` 保存配置、智能体状态、会话和工作区。此目录
+  必须在暂停/恢复中存活以确保会话持久化。
+- **多 provider**：通过 `QCLAW_PROVIDER` 环境变量支持 DeepSeek（默认）、
+  Anthropic 和 OpenAI。
+- **AgentHub 集成**：本模板是 CubeOps AgentHub 的配套组件，AgentHub 通过宿主机
+  侧状态目录、出口凭证注入和快照/恢复来大规模管理 OpenClaw 实例。
+
+## 故障排除
+
+| 现象 | 可能原因 | 解决方法 |
+|---|---|---|
+| `openclaw: command not found` | CLI 变更后未重新构建模板 | 重新构建镜像，重新注册模板 |
+| 网关 30 秒后未就绪 | Supervisor 配置缺失或端口冲突 | 检查 `supervisorctl status openclaw` 或 `/var/log/openclaw.log` |
+| Provider 返回认证错误 | 密钥未转发或 provider 错误 | 检查 `QCLAW_PROVIDER` 和对应的 `*_API_KEY` 环境变量 |
+| 网关返回 `403 Forbidden` | 启动和读取之间令牌不匹配 | 验证 `/root/.openclaw/openclaw.json` 中有有效令牌 |
+| 就绪探针超时 | 镜像不含 envd | 确保 `FROM ghcr.io/tencentcloud/cubesandbox-base:...` |
+
+## 参考资料
+
+- CubeOps AgentHub OpenClaw 服务：`CubeOps/internal/service/openclaw.go`
+- CubeSandbox 快照 / 克隆： [`docs/guide/snapshot-rollback-clone.md`](../../docs/guide/snapshot-rollback-clone.md)
+- Pi 智能体示例： [`examples/pi-agent-integration`](../pi-agent-integration)

--- a/examples/qclaw-sandbox/_qclaw_common.py
+++ b/examples/qclaw-sandbox/_qclaw_common.py
@@ -1,0 +1,167 @@
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""OpenClaw (QClaw) 示例脚本的共享沙箱命令工具函数。
+
+OpenClaw 以网关守护进程方式运行（端口 18789）。这些工具函数管理
+网关生命周期：启动、就绪检查、HTTP 交互和清理。
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import time
+from collections.abc import Callable
+from typing import Any
+
+GATEWAY_PORT = 18789
+GATEWAY_READY_SCRIPT = """python3 - <<'PY'
+import json, os, socket, sys
+try:
+    token = json.load(open("/root/.openclaw/openclaw.json")).get("gateway", {}).get("auth", {}).get("token", "")
+    port = int(os.environ.get("OPENCLAW_PORT", "18789"))
+    if not token:
+        sys.exit(1)
+    s = socket.create_connection(("127.0.0.1", port), timeout=0.5)
+    s.close()
+except Exception:
+    sys.exit(1)
+PY"""
+
+
+def stream_writer(stream) -> Callable[[object], None]:
+    def write(chunk: object) -> None:
+        text = getattr(chunk, "line", chunk)
+        stream.write(str(text))
+        stream.flush()
+
+    return write
+
+
+def run_command(
+    sandbox: Any,
+    command: str,
+    *,
+    cwd: str | None = None,
+    envs: dict[str, str] | None = None,
+    timeout: int | float | None = None,
+    stream: bool = False,
+    user: str = "root",
+):
+    kwargs = {"cwd": cwd, "timeout": timeout, "user": user}
+    kwargs = {key: value for key, value in kwargs.items() if value is not None}
+    if envs:
+        kwargs["envs"] = envs
+    if stream:
+        kwargs["on_stdout"] = stream_writer(sys.stdout)
+        kwargs["on_stderr"] = stream_writer(sys.stderr)
+
+    try:
+        return sandbox.commands.run(command, **kwargs)
+    except TypeError as exc:
+        if "envs" not in kwargs or "envs" not in str(exc):
+            raise
+        kwargs["env"] = kwargs.pop("envs")
+        return sandbox.commands.run(command, **kwargs)
+
+
+def ensure_success(result, action: str) -> None:
+    exit_code = getattr(result, "exit_code", None)
+    if exit_code not in (None, 0):
+        stdout = getattr(result, "stdout", "")
+        stderr = getattr(result, "stderr", "")
+        raise SystemExit(
+            f"Failed to {action} (exit {exit_code}).\nSTDOUT:\n{stdout}\nSTDERR:\n{stderr}"
+        )
+
+
+def sandbox_identifier(sandbox: Any) -> str:
+    return getattr(sandbox, "sandbox_id", getattr(sandbox, "id", "unknown"))
+
+
+def start_gateway(sandbox: Any, timeout: int = 60) -> None:
+    """在沙箱内启动 OpenClaw 网关。"""
+    # 优先使用 supervisorctl，失败则直接 nohup 启动。
+    start_cmd = (
+        "if command -v supervisorctl >/dev/null 2>&1; then "
+        "  supervisorctl start openclaw || supervisorctl restart openclaw; "
+        "else "
+        "  pkill -f 'openclaw gateway' 2>/dev/null || true; "
+        "  mkdir -p /var/log; "
+        "  nohup openclaw gateway run >/var/log/openclaw.log 2>&1 & "
+        "fi"
+    )
+    result = run_command(sandbox, start_cmd, timeout=timeout)
+    ensure_success(result, "start OpenClaw gateway")
+
+
+def wait_gateway_ready(sandbox: Any, max_wait: int = 30) -> bool:
+    """轮询等待 OpenClaw 网关在 18789 端口就绪。"""
+    for _ in range(max_wait):
+        result = run_command(
+            sandbox,
+            f"OPENCLAW_PORT={GATEWAY_PORT} {GATEWAY_READY_SCRIPT}",
+            timeout=10,
+        )
+        if getattr(result, "exit_code", 1) == 0:
+            return True
+        time.sleep(0.5)
+    return False
+
+
+def get_gateway_token(sandbox: Any) -> str:
+    """从沙箱内的配置文件读取网关认证令牌。"""
+    read_cmd = (
+        "python3 -c \"import json; "
+        "print(json.load(open('/root/.openclaw/openclaw.json'))"
+        ".get('gateway',{}).get('auth',{}).get('token',''))\""
+    )
+    result = run_command(sandbox, read_cmd, timeout=10)
+    ensure_success(result, "read gateway token")
+    return getattr(result, "stdout", "").strip()
+
+
+def send_prompt_via_gateway(
+    sandbox: Any,
+    prompt: str,
+    token: str,
+    timeout: int = 900,
+) -> Any:
+    """通过 REST API 向 OpenClaw 网关发送提示词并收集响应。
+
+    将 prompt 序列化为 JSON 后通过 base64 写入临时文件，
+    彻底避免用户输入中的特殊字符被当作 shell 命令执行。
+    """
+    import base64
+
+    payload = json.dumps({"prompt": prompt, "stream": False}, ensure_ascii=False)
+    payload_b64 = base64.b64encode(payload.encode()).decode()
+    header = f"Authorization: Bearer {token}"
+    header_b64 = base64.b64encode(header.encode()).decode()
+    write_files_cmd = (
+        f"echo {payload_b64} | base64 -d > /tmp/qclaw_payload.json && "
+        f"echo {header_b64} | base64 -d > /tmp/qclaw_header.txt"
+    )
+    run_command(sandbox, write_files_cmd, timeout=10)
+    send_cmd = (
+        f"curl -s -S -m {timeout} "
+        f"-H 'Content-Type: application/json' "
+        f"-H @/tmp/qclaw_header.txt "
+        f"http://127.0.0.1:{GATEWAY_PORT}/v1/chat "
+        f"-d @/tmp/qclaw_payload.json"
+    )
+    return run_command(sandbox, send_cmd, timeout=timeout + 30, stream=True)
+
+
+def gateway_status(sandbox: Any) -> str:
+    """获取 OpenClaw 网关进程状态。"""
+    cmd = (
+        "if command -v supervisorctl >/dev/null 2>&1; then "
+        "  supervisorctl status openclaw || true; "
+        "else "
+        "  ps -ef | grep -E '[o]penclaw|node .*openclaw' || true; "
+        "fi"
+    )
+    result = run_command(sandbox, cmd, timeout=10)
+    return getattr(result, "stdout", "")

--- a/examples/qclaw-sandbox/env_utils.py
+++ b/examples/qclaw-sandbox/env_utils.py
@@ -1,0 +1,150 @@
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# 注意：本文件与 pi-agent-integration/env_utils.py 和 claude-code-sandbox/env_utils.py
+# 共享多个基础工具函数（load_local_dotenv、required、optional、int_env、
+# shell_join、_host_from_url）。如需修复这些函数，请同步更新所有副本。
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from urllib.parse import urlparse
+
+from dotenv import load_dotenv
+
+PROVIDER_KEY_ENV = {
+    "anthropic": "ANTHROPIC_API_KEY",
+    "deepseek": "DEEPSEEK_API_KEY",
+    "openai": "OPENAI_API_KEY",
+    "google": "GEMINI_API_KEY",
+}
+
+PROVIDER_DEFAULT_MODEL = {
+    "anthropic": "anthropic/claude-sonnet-4-6",
+    "deepseek": "deepseek/deepseek-v4-flash",
+}
+
+PROVIDER_DEFAULT_HOST = {
+    "anthropic": "api.anthropic.com",
+    "deepseek": "api.deepseek.com",
+    "openai": "api.openai.com",
+}
+
+DEFAULT_WORKSPACE = "/workspace"
+
+PASSTHROUGH_ENV_NAMES = (
+    "ANTHROPIC_BASE_URL",
+    "HTTP_PROXY",
+    "HTTPS_PROXY",
+    "NO_PROXY",
+)
+
+
+def load_local_dotenv() -> None:
+    candidate_paths = [
+        Path(__file__).with_name(".env"),
+        Path.cwd() / ".env",
+    ]
+    seen_paths: set[Path] = set()
+    for path in candidate_paths:
+        resolved_path = path.resolve()
+        if resolved_path in seen_paths:
+            continue
+        seen_paths.add(resolved_path)
+        if path.is_file():
+            load_dotenv(dotenv_path=path, override=False)
+            return
+
+
+def required(name: str) -> str:
+    value = os.environ.get(name)
+    if not value:
+        raise SystemExit(f"Missing required environment variable: {name}")
+    return value
+
+
+def optional(name: str, default: str = "") -> str:
+    return os.environ.get(name) or default
+
+
+def int_env(name: str, default: int) -> int:
+    raw = os.environ.get(name)
+    if not raw:
+        return default
+    try:
+        return int(raw)
+    except ValueError as exc:
+        raise SystemExit(f"{name} must be an integer, got {raw!r}") from exc
+
+
+def qclaw_provider() -> str:
+    return optional("QCLAW_PROVIDER", "deepseek").strip().lower()
+
+
+def qclaw_model() -> str:
+    explicit = os.environ.get("QCLAW_MODEL")
+    if explicit:
+        return explicit
+    provider = qclaw_provider()
+    default = PROVIDER_DEFAULT_MODEL.get(provider)
+    if default:
+        return default
+    raise SystemExit(
+        f"No default model for provider {provider!r}. Set QCLAW_MODEL in your .env."
+    )
+
+
+def qclaw_workspace() -> str:
+    return optional("QCLAW_WORKSPACE", DEFAULT_WORKSPACE)
+
+
+def provider_key_name(provider: str | None = None) -> str:
+    provider_name = provider or qclaw_provider()
+    return PROVIDER_KEY_ENV.get(provider_name, f"{provider_name.upper()}_API_KEY")
+
+
+def require_provider_key(provider: str | None = None) -> str:
+    provider_name = provider or qclaw_provider()
+    key_name = PROVIDER_KEY_ENV.get(provider_name)
+    if not key_name:
+        raise SystemExit(f"Unknown provider {provider_name!r}")
+    value = os.environ.get(key_name)
+    if not value:
+        raise SystemExit(f"Missing required environment variable: {key_name}")
+    return value
+
+
+def build_qclaw_env(include_secrets: bool = True) -> dict[str, str]:
+    env = {}
+    for name in PASSTHROUGH_ENV_NAMES:
+        value = os.environ.get(name)
+        if value:
+            env[name] = value
+    if include_secrets:
+        key_name = provider_key_name()
+        value = os.environ.get(key_name)
+        if value:
+            env[key_name] = value
+    return env
+
+
+def qclaw_llm_host(provider: str | None = None) -> str:
+    provider_name = (provider or qclaw_provider()).strip().lower()
+    explicit = os.environ.get("QCLAW_LLM_HOST")
+    if explicit:
+        return _host_from_url(explicit)
+    return PROVIDER_DEFAULT_HOST.get(provider_name, "")
+
+
+def _host_from_url(value: str) -> str:
+    candidate = value.strip()
+    if not candidate:
+        return ""
+    if "://" not in candidate:
+        candidate = f"https://{candidate}"
+    return urlparse(candidate).hostname or ""
+
+
+def shell_join(*parts: str) -> str:
+    return " && ".join(part for part in parts if part)

--- a/examples/qclaw-sandbox/requirements.txt
+++ b/examples/qclaw-sandbox/requirements.txt
@@ -1,0 +1,2 @@
+e2b>=2.4.1
+python-dotenv>=1.0.0

--- a/examples/qclaw-sandbox/resume_qclaw_agent.py
+++ b/examples/qclaw-sandbox/resume_qclaw_agent.py
@@ -1,0 +1,213 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""演示 OpenClaw 会话在 CubeSandbox 暂停/恢复中的持久化。
+
+第一轮让 OpenClaw 写入 ``/workspace/plan.md``，然后暂停沙箱。
+第二轮重新连接到同一沙箱，验证 ``/workspace`` 和 ``/root/.openclaw/``
+在快照后存活，然后继续工作。
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import shlex
+import sys
+
+from e2b import Sandbox
+
+from _qclaw_common import (
+    ensure_success,
+    gateway_status,
+    get_gateway_token,
+    run_command,
+    sandbox_identifier,
+    send_prompt_via_gateway,
+    start_gateway,
+    wait_gateway_ready,
+)
+from env_utils import (
+    build_qclaw_env,
+    int_env,
+    load_local_dotenv,
+    qclaw_provider,
+    qclaw_workspace,
+    required,
+    require_provider_key,
+    shell_join,
+)
+
+TURN_1_PROMPT = (
+    "Create {workspace}/plan.md containing a numbered 3-step plan for building a "
+    "small Python CLI that prints the current time. Only write the plan file."
+)
+TURN_2_PROMPT = (
+    "Read {workspace}/plan.md and implement step 1 by creating "
+    "{workspace}/progress.md that records which step you completed and why. "
+    "Do not delete plan.md."
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="演示 OpenClaw 会话在暂停/恢复中的持久化。"
+    )
+    parser.add_argument(
+        "--template",
+        default=os.environ.get("CUBE_TEMPLATE_ID"),
+        help="CubeSandbox 模板 ID。",
+    )
+    parser.add_argument(
+        "--workspace",
+        default=qclaw_workspace(),
+        help="沙箱内的工作目录。",
+    )
+    parser.add_argument(
+        "--sandbox-timeout",
+        type=int,
+        default=int_env("QCLAW_SANDBOX_TIMEOUT", 1800),
+        help="沙箱生命周期（秒）。",
+    )
+    parser.add_argument(
+        "--exec-timeout",
+        type=int,
+        default=int_env("QCLAW_EXEC_TIMEOUT", 900),
+        help="命令超时（秒）。",
+    )
+    parser.add_argument(
+        "--raw",
+        action="store_true",
+        help="输出原始响应流而非格式化后的文本。",
+    )
+    args = parser.parse_args()
+    if args.raw:
+        os.environ["QCLAW_STREAM_RAW"] = "1"
+    return args
+
+
+def run_turn(
+    sandbox: Sandbox,
+    prompt: str,
+    token: str,
+    exec_timeout: int,
+):
+    return send_prompt_via_gateway(
+        sandbox,
+        prompt,
+        token,
+        timeout=exec_timeout,
+    )
+
+
+def assert_state_survived(sandbox: Sandbox, workspace: str) -> None:
+    quoted_workspace = shlex.quote(workspace)
+    command = shell_join(
+        f"test -f {quoted_workspace}/plan.md",
+        "test -d /root/.openclaw",
+        "printf '\\n--- plan.md (survived pause/resume) ---\\n'",
+        f"cat {quoted_workspace}/plan.md",
+        "printf '\\n--- /root/.openclaw survived ---\\n'",
+        "ls -la /root/.openclaw/",
+    )
+    result = run_command(sandbox, command, timeout=60)
+    ensure_success(result, "verify workspace and OpenClaw state survived pause/resume")
+    if getattr(result, "stdout", ""):
+        print(result.stdout)
+
+
+def show_final_workspace(sandbox: Sandbox, workspace: str) -> None:
+    quoted_workspace = shlex.quote(workspace)
+    command = shell_join(
+        f"ls -la {quoted_workspace}",
+        f"test ! -f {quoted_workspace}/progress.md || "
+        f"(printf '\\n--- progress.md ---\\n' && cat {quoted_workspace}/progress.md)",
+    )
+    result = run_command(sandbox, command, timeout=60)
+    ensure_success(result, "inspect final workspace")
+    if getattr(result, "stdout", ""):
+        print(result.stdout)
+
+
+def main() -> int:
+    load_local_dotenv()
+    args = parse_args()
+
+    template_id = args.template or required("CUBE_TEMPLATE_ID")
+    required("E2B_API_URL")
+    required("E2B_API_KEY")
+    provider = qclaw_provider()
+    require_provider_key(provider)
+
+    qclaw_env = build_qclaw_env()
+    turn_1_prompt = TURN_1_PROMPT.format(workspace=args.workspace)
+    turn_2_prompt = TURN_2_PROMPT.format(workspace=args.workspace)
+
+    print(f"Creating sandbox from template: {template_id}")
+    sandbox = Sandbox.create(template=template_id, timeout=args.sandbox_timeout)
+    sandbox_id = sandbox_identifier(sandbox)
+
+    try:
+        print(f"Sandbox ready: {sandbox_id}")
+
+        version_result = run_command(sandbox, "openclaw --version", timeout=60)
+        ensure_success(version_result, "check OpenClaw version")
+        print(f"OpenClaw version: {getattr(version_result, 'stdout', '').strip()}")
+
+        print("\nStarting OpenClaw gateway...")
+        start_gateway(sandbox)
+        if not wait_gateway_ready(sandbox, max_wait=30):
+            raise SystemExit("Gateway failed to become ready.")
+        print("Gateway is ready.")
+
+        token = get_gateway_token(sandbox)
+        if not token:
+            raise SystemExit("Could not read gateway token.")
+
+        print("\n=== Turn 1: create plan.md ===\n")
+        result_1 = run_turn(sandbox, turn_1_prompt, token, args.exec_timeout)
+        ensure_success(result_1, "run OpenClaw turn 1")
+
+        print(f"\nPausing sandbox {sandbox_id} (snapshotting VM + rootfs)...")
+        paused_id = sandbox.pause()
+        if isinstance(paused_id, str) and paused_id:
+            sandbox_id = paused_id
+        print(f"Paused. Resume handle: {sandbox_id}")
+
+        print(f"\nReconnecting to {sandbox_id}...")
+        sandbox = Sandbox.connect(sandbox_id=sandbox_id)
+        print("Reconnected after resume.")
+
+        print("\n=== Verifying persistence after resume ===\n")
+        assert_state_survived(sandbox, args.workspace)
+
+        # 恢复后重启网关（进程已被快照但可能需要刷新）
+        print("\nRestarting OpenClaw gateway after resume...")
+        start_gateway(sandbox)
+        if not wait_gateway_ready(sandbox, max_wait=30):
+            raise SystemExit("Gateway failed to become ready after resume.")
+        token = get_gateway_token(sandbox)
+
+        print("\n=== Turn 2: continue the work ===\n")
+        result_2 = run_turn(sandbox, turn_2_prompt, token, args.exec_timeout)
+        ensure_success(result_2, "run OpenClaw turn 2")
+
+        show_final_workspace(sandbox, args.workspace)
+
+        exit_code = getattr(result_2, "exit_code", 0)
+        return 0 if exit_code is None else int(exit_code)
+    finally:
+        if sandbox is not None:
+            try:
+                sandbox.kill()
+                print(f"\nSandbox {sandbox_id} killed.")
+            except Exception as exc:
+                print(
+                    f"Warning: failed to kill sandbox {sandbox_id}: {exc}",
+                    file=sys.stderr,
+                )
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/examples/qclaw-sandbox/run_qclaw_agent.py
+++ b/examples/qclaw-sandbox/run_qclaw_agent.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import argparse
+import os
+import shlex
+import sys
+
+from e2b import Sandbox
+
+from _qclaw_common import (
+    ensure_success,
+    gateway_status,
+    get_gateway_token,
+    run_command,
+    sandbox_identifier,
+    send_prompt_via_gateway,
+    start_gateway,
+    wait_gateway_ready,
+)
+from env_utils import (
+    build_qclaw_env,
+    int_env,
+    load_local_dotenv,
+    qclaw_provider,
+    qclaw_workspace,
+    required,
+    require_provider_key,
+    shell_join,
+)
+
+DEFAULT_PROMPT_TEMPLATE = (
+    "Inspect the project in {workspace}, run python3 app.py, and write a "
+    "concise summary of the result to {workspace}/result.md."
+)
+
+
+def default_prompt(workspace: str) -> str:
+    return DEFAULT_PROMPT_TEMPLATE.format(workspace=workspace)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="在 CubeSandbox 中运行一次性 OpenClaw 任务。"
+    )
+    parser.add_argument(
+        "--template",
+        default=os.environ.get("CUBE_TEMPLATE_ID"),
+        help="CubeSandbox 模板 ID。",
+    )
+    parser.add_argument(
+        "--prompt",
+        default=None,
+        help="传递给 OpenClaw 的提示词，默认为工作区冒烟测试任务。",
+    )
+    parser.add_argument(
+        "--workspace",
+        default=qclaw_workspace(),
+        help="沙箱内的工作目录。",
+    )
+    parser.add_argument(
+        "--sandbox-timeout",
+        type=int,
+        default=int_env("QCLAW_SANDBOX_TIMEOUT", 1800),
+        help="沙箱生命周期（秒）。",
+    )
+    parser.add_argument(
+        "--exec-timeout",
+        type=int,
+        default=int_env("QCLAW_EXEC_TIMEOUT", 900),
+        help="命令超时（秒）。",
+    )
+    parser.add_argument(
+        "--no-seed",
+        action="store_true",
+        help="跳过在沙箱工作区写入演示文件。",
+    )
+    parser.add_argument(
+        "--raw",
+        action="store_true",
+        help="输出原始响应流而非格式化后的文本。",
+    )
+    args = parser.parse_args()
+    if args.prompt is None:
+        args.prompt = default_prompt(args.workspace)
+    if args.raw:
+        os.environ["QCLAW_STREAM_RAW"] = "1"
+    return args
+
+
+def seed_project(sandbox: Sandbox, workspace: str, timeout: int) -> None:
+    quoted_workspace = shlex.quote(workspace)
+    command = f"""mkdir -p {quoted_workspace}
+cat > {quoted_workspace}/README.md <<'EOF'
+# CubeSandbox OpenClaw Smoke Project
+
+This tiny project exists so OpenClaw has a deterministic task to run.
+EOF
+cat > {quoted_workspace}/app.py <<'EOF'
+def main() -> None:
+    print("hello from CubeSandbox + OpenClaw")
+
+
+if __name__ == "__main__":
+    main()
+EOF
+"""
+    result = run_command(sandbox, command, timeout=timeout)
+    ensure_success(result, "seed workspace")
+
+
+def show_workspace_result(sandbox: Sandbox, workspace: str, timeout: int) -> None:
+    quoted_workspace = shlex.quote(workspace)
+    command = shell_join(
+        f"ls -la {quoted_workspace}",
+        f"test ! -f {quoted_workspace}/result.md || "
+        f"(printf '\\n--- result.md ---\\n' && cat {quoted_workspace}/result.md)",
+    )
+    result = run_command(sandbox, command, timeout=timeout)
+    ensure_success(result, "inspect workspace")
+    if getattr(result, "stdout", ""):
+        print(result.stdout)
+
+
+def main() -> int:
+    load_local_dotenv()
+    args = parse_args()
+
+    template_id = args.template or required("CUBE_TEMPLATE_ID")
+    required("E2B_API_URL")
+    required("E2B_API_KEY")
+    provider = qclaw_provider()
+    require_provider_key(provider)
+
+    qclaw_env = build_qclaw_env()
+
+    print(f"Creating sandbox from template: {template_id}")
+    result = None
+    with Sandbox.create(template=template_id, timeout=args.sandbox_timeout) as sandbox:
+        sandbox_id = sandbox_identifier(sandbox)
+        print(f"Sandbox ready: {sandbox_id}")
+
+        # 验证 OpenClaw CLI 已安装
+        version_result = run_command(sandbox, "openclaw --version", timeout=60)
+        ensure_success(version_result, "check OpenClaw version")
+        print(f"OpenClaw version: {getattr(version_result, 'stdout', '').strip()}")
+
+        # 启动 OpenClaw 网关
+        print("\nStarting OpenClaw gateway...")
+        start_gateway(sandbox)
+
+        print("Waiting for gateway to be ready...")
+        if not wait_gateway_ready(sandbox, max_wait=30):
+            print("Gateway failed to become ready. Status:")
+            print(gateway_status(sandbox))
+            return 1
+        print("Gateway is ready.")
+
+        token = get_gateway_token(sandbox)
+        if not token:
+            print("ERROR: Could not read gateway token.")
+            return 1
+
+        if not args.no_seed:
+            seed_project(sandbox, args.workspace, timeout=60)
+            print(f"Seeded demo project in {args.workspace}")
+
+        print(f"\nRunning OpenClaw task (provider: {provider})...\n")
+        result = send_prompt_via_gateway(
+            sandbox,
+            args.prompt,
+            token,
+            timeout=args.exec_timeout,
+        )
+
+        show_workspace_result(sandbox, args.workspace, timeout=60)
+
+    exit_code = getattr(result, "exit_code", 1)
+    return 0 if exit_code is None else int(exit_code)
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Add two AI agent runtime sandbox templates for the CubeSandbox template ecosystem:

- claude-code-sandbox: Claude Code CLI in a CubeSandbox MicroVM, with one-shot and pause/resume host driver scripts.
- qclaw-sandbox: OpenClaw (QClaw) agent gateway in a CubeSandbox MicroVM, with gateway lifecycle management and persistence demos.

Each template includes a Dockerfile, Python driver scripts (env_utils, _common, run, resume), .env.example, and bilingual README documentation.

Refs: #645
