### PR TITLE
feat(ci): add arm64 kernel release asset support to one-click release

### DIFF
--- a/.github/workflows/release-one-click.yml
+++ b/.github/workflows/release-one-click.yml
@@ -141,18 +141,26 @@ jobs:
               --notes "Automated one-click release bundle."
 
   # Upload guest kernel Release assets before release-docker-images so cube-kernel
-  # can download vmlinux-amd64 + vmlinux-pvm-amd64 without waiting for the full
-  # one-click bundle job.
+  # can download vmlinux-{amd64,arm64} (and amd64 PVM) without waiting for the
+  # full one-click bundle job.
   publish_kernel_release_assets:
-    name: Publish kernel Release assets (amd64)
+    name: Publish kernel Release assets (${{ matrix.arch }})
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            kernel_arch: x86_64
+          - arch: arm64
+            kernel_arch: aarch64
     runs-on: ubuntu-latest
     needs:
       - ensure_release
       - build_pvm_guest_vmlinux
     env:
-      KERNEL_ARCH: x86_64
-      BUNDLE_ARCH: amd64
-      VMLINUX_CACHE_PATH: kernel-cache/x86_64/vmlinux
+      KERNEL_ARCH: ${{ matrix.kernel_arch }}
+      BUNDLE_ARCH: ${{ matrix.arch }}
+      VMLINUX_CACHE_PATH: kernel-cache/${{ matrix.kernel_arch }}/vmlinux
       VMLINUX_RELEASE_PATH: deploy/one-click/assets/kernel-artifacts/vmlinux
       PVM_VMLINUX_RELEASE_PATH: deploy/one-click/assets/kernel-artifacts/vmlinux-pvm
 
@@ -261,6 +269,7 @@ jobs:
 
       - name: Compute PVM vmlinux cache metadata
         id: pvm_vmlinux_metadata
+        if: matrix.arch == 'amd64'
         run: |
           source_hash="$(
             sha256sum \
@@ -273,6 +282,7 @@ jobs:
           echo "artifact_name=vmlinux-pvm-${PVM_KERNEL_TAG}-x86_64-${source_hash}" >> "${GITHUB_OUTPUT}"
 
       - name: Download PVM vmlinux artifact
+        if: matrix.arch == 'amd64'
         uses: actions/download-artifact@v4
         with:
           name: ${{ steps.pvm_vmlinux_metadata.outputs.artifact_name }}
@@ -281,30 +291,39 @@ jobs:
       - name: Stage kernel Release assets
         run: |
           test -f "${VMLINUX_RELEASE_PATH}"
-          install -D -m 0644 \
-            downloaded-pvm-vmlinux/vmlinux-pvm \
-            "${PVM_VMLINUX_RELEASE_PATH}"
           rm -rf kernel-release-assets
           mkdir -p kernel-release-assets
           install -D -m 0644 \
             "${VMLINUX_RELEASE_PATH}" \
             "kernel-release-assets/vmlinux-${BUNDLE_ARCH}"
-          install -D -m 0644 \
-            "${PVM_VMLINUX_RELEASE_PATH}" \
-            "kernel-release-assets/vmlinux-pvm-${BUNDLE_ARCH}"
-          # Compat alias for older consumers / docs.
-          install -D -m 0644 \
-            "${PVM_VMLINUX_RELEASE_PATH}" \
-            "kernel-release-assets/vmlinux-pvm"
+          if [[ "${BUNDLE_ARCH}" == "amd64" ]]; then
+            install -D -m 0644 \
+              downloaded-pvm-vmlinux/vmlinux-pvm \
+              "${PVM_VMLINUX_RELEASE_PATH}"
+            install -D -m 0644 \
+              "${PVM_VMLINUX_RELEASE_PATH}" \
+              "kernel-release-assets/vmlinux-pvm-${BUNDLE_ARCH}"
+            # Compat alias for older consumers / docs.
+            install -D -m 0644 \
+              "${PVM_VMLINUX_RELEASE_PATH}" \
+              "kernel-release-assets/vmlinux-pvm"
+          fi
 
       - name: Upload kernel assets to Release
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          upload_args=(
+            "kernel-release-assets/vmlinux-${BUNDLE_ARCH}"
+          )
+          if [[ "${BUNDLE_ARCH}" == "amd64" ]]; then
+            upload_args+=(
+              "kernel-release-assets/vmlinux-pvm-${BUNDLE_ARCH}"
+              "kernel-release-assets/vmlinux-pvm"
+            )
+          fi
           gh release upload "${GITHUB_REF_NAME}" \
-            "kernel-release-assets/vmlinux-${BUNDLE_ARCH}" \
-            "kernel-release-assets/vmlinux-pvm-${BUNDLE_ARCH}" \
-            "kernel-release-assets/vmlinux-pvm" \
+            "${upload_args[@]}" \
             --repo "${GITHUB_REPOSITORY}" \
             --clobber
 


### PR DESCRIPTION
## Summary

Extend the `publish_kernel_release_assets` job in the one-click release workflow to support both `amd64` and `arm64` architectures via a matrix strategy.

## Changes

- Add matrix strategy with `amd64` and `arm64` variants to the kernel release assets job
- Make PVM vmlinux download, staging, and upload steps conditional on `amd64` only (PVM is x86-only)
- Dynamically construct upload arguments based on architecture instead of hardcoding
- Update job name to reflect the current architecture being published

## Motivation

The release workflow currently only publishes kernel assets for `amd64`. Adding `arm64` support enables ARM-based deployments to consume pre-built kernel artifacts from releases.