### PR TITLE
docs(volume): note K8s/Terraform config ownership and s3fs on ARM

### DIFF
--- a/examples/volume/cos/README.md
+++ b/examples/volume/cos/README.md
@@ -31,7 +31,7 @@ This guide is for **first-time Volume Plugin users**: follow the steps in order 
 **Single-machine dev:** CubeMaster and Cubelet on one host — install deps once.  
 **Multi-node:** See the table in [§1 Install dependencies](#1-install-dependencies).
 
-> **Architecture:** ARM / aarch64 is not supported (official cosfs packages are x86_64 / amd64 only).
+> **Architecture:** Official cosfs does not support ARM / aarch64 (x86_64 / amd64 packages only). You may try s3fs as an alternative on your own.
 
 ---
 
@@ -115,6 +115,8 @@ The install script runs similar checks when using `--cosfs` / `--coscmd` / `--jq
 ---
 
 ## 2. Install plugin and COS credentials
+
+> For Kubernetes / Terraform deployments, configure the plugin and `volume-cos.conf` yourself using native cluster mechanisms. The steps below use one-click / bare-metal paths as examples.
 
 One-click install places the binary plugin under **`/usr/local/services/cubetoolbox/CubeMaster/plugin/`** (Controller) and **`/usr/local/services/cubetoolbox/Cubelet/plugin/`** (Node), and seeds `volume-cos.conf` from `volume-cos.conf.example` in each directory. After install, edit credentials on the matching node:
 

--- a/examples/volume/cos/README.zh.md
+++ b/examples/volume/cos/README.zh.md
@@ -29,7 +29,7 @@
 **单机开发**：CubeMaster 与 Cubelet 在同一台机器上时，依赖装在一台即可。  
 **多机部署**：各工具装在哪台见 [§1 安装依赖](#1-安装依赖) 表格。
 
-> **架构限制**：不支持 ARM / aarch64（官方 cosfs 仅提供 x86_64 / amd64 包）。
+> **架构限制**：官方 cosfs 不支持 ARM / aarch64（仅提供 x86_64 / amd64 包）。可自行尝试用 s3fs 替代。
 
 ---
 
@@ -113,6 +113,8 @@ printf '%s' '{"ok":true}' | jq -r '.ok'   # 应输出 true
 ---
 
 ## 2. 安装插件与 COS 凭证
+
+> Kubernetes / Terraform 部署时，插件与 `volume-cos.conf` 等配置由用户自行按集群原生方式完成；下文以 one-click / 裸机路径为例。
 
 一键部署（one-click）会把 binary 插件分别放到 **`/usr/local/services/cubetoolbox/CubeMaster/plugin/`**（Controller）与 **`/usr/local/services/cubetoolbox/Cubelet/plugin/`**（Node），并在各目录从 `volume-cos.conf.example` 生成 `volume-cos.conf`。安装后只需在对应节点编辑凭证：
 

--- a/examples/volume/cos/binary/README.md
+++ b/examples/volume/cos/binary/README.md
@@ -83,6 +83,8 @@ sudo install -m 0755 /tmp/cube-volume-cos.sh "$PREFIX/Cubelet/plugin/cube-volume
 
 ### 2. Create config file
 
+> For Kubernetes / Terraform deployments, configure `volume-cos.conf` yourself using native cluster mechanisms. The steps below use one-click / bare-metal paths as examples.
+
 Same directory as the plugin binary (one file per node; edit on each host when roles are split):
 
 ```bash

--- a/examples/volume/cos/binary/README.zh.md
+++ b/examples/volume/cos/binary/README.zh.md
@@ -81,6 +81,8 @@ sudo install -m 0755 /tmp/cube-volume-cos.sh "$PREFIX/Cubelet/plugin/cube-volume
 
 ### 2. 创建配置文件
 
+> Kubernetes / Terraform 部署时，`volume-cos.conf` 由用户自行按集群原生方式完成；下文以 one-click / 裸机路径为例。
+
 与插件脚本同目录（CubeMaster / Cubelet 各一份；分节点部署时在对应节点编辑）：
 
 ```bash

--- a/examples/volume/cos/rpc/README.md
+++ b/examples/volume/cos/rpc/README.md
@@ -68,6 +68,8 @@ replace github.com/tencentcloud/CubeSandbox/Cubelet => ../../../../Cubelet
 
 Requires **Go 1.24+** (`go.mod` declares `go 1.24.8`).
 
+> For Kubernetes / Terraform deployments, configure `volume-cos.conf` yourself using native cluster mechanisms. The steps below use bare-metal paths as examples.
+
 ```bash
 PREFIX=/usr/local/services/cubetoolbox/CubeMaster/plugin
 mkdir -p "$PREFIX"

--- a/examples/volume/cos/rpc/README.zh.md
+++ b/examples/volume/cos/rpc/README.zh.md
@@ -66,6 +66,8 @@ replace github.com/tencentcloud/CubeSandbox/Cubelet => ../../../../Cubelet
 
 需要 **Go 1.24+**（`go.mod` 声明 `go 1.24.8`）。
 
+> Kubernetes / Terraform 部署时，`volume-cos.conf` 由用户自行按集群原生方式完成；下文以裸机路径为例。
+
 ```bash
 PREFIX=/usr/local/services/cubetoolbox/CubeMaster/plugin
 mkdir -p "$PREFIX"


### PR DESCRIPTION
## Summary
- In COS example §2 (plugin + credentials), note that Kubernetes / Terraform deployments leave plugin and `volume-cos.conf` configuration to the operator via native cluster mechanisms; the walkthrough paths remain one-click / bare-metal examples.
- In the ARM architecture note, mention that users may try s3fs where official cosfs has no ARM packages.

## Test plan
- [ ] Spot-check EN/ZH `examples/volume/cos/README*.md` § architecture note and §2

Assisted-by: Cursor:Composer


Made with [Cursor](https://cursor.com)