### PR TITLE
docs(k8s): add tested environments section to Kubernetes guide

### DIFF
--- a/docs/guide/kubernetes/index.md
+++ b/docs/guide/kubernetes/index.md
@@ -41,4 +41,16 @@ The current K8s deployment is a **preview** release. Known issues:
 
 The control plane uses native Deployments; the compute plane uses native `apps/v1` DaemonSets. Install needs only standard Kubernetes / Helm.
 
+
+## Tested environments
+
+CubeSandbox has been verified on Tencent Cloud TKE, Kubernetes, and K3s. Tencent Cloud TKE uses VPC-CNI as the CNI plugin; the other two environments use Flannel.
+
+| Environment | CNI plugin |
+| --- | --- |
+| Tencent Cloud TKE | VPC-CNI |
+| Kubernetes | Flannel |
+| K3s | Flannel |
+
+
 Next → [Helm Install](./install.md)

--- a/docs/zh/guide/kubernetes/index.md
+++ b/docs/zh/guide/kubernetes/index.md
@@ -41,4 +41,15 @@
 
 控制面为原生 Deployment，计算面为原生 `apps/v1` DaemonSet；安装只需标准 Kubernetes / Helm。
 
+## 已测试环境
+
+当前已在腾讯云 TKE、Kubernetes 与 K3s 上完成验证。其中腾讯云 TKE 使用 VPC-CNI 作为网络插件，另外两个环境使用 Flannel。
+
+| 环境 | 网络插件 |
+| --- | --- |
+| 腾讯云 TKE | VPC-CNI |
+| Kubernetes | Flannel |
+| K3s | Flannel |
+
+
 下一步 → [Helm 安装](./install.md)


### PR DESCRIPTION
## Summary

Add a **Tested environments** section to the Kubernetes guide documentation (both English and Chinese versions), listing verified deployment environments and their respective CNI plugins.

## Changes

- `docs/guide/kubernetes/index.md`: Added tested environments table (TKE/VPC-CNI, Kubernetes/Flannel, K3s/Flannel)
- `docs/zh/guide/kubernetes/index.md`: Added corresponding Chinese version

## Verification

| Environment | CNI Plugin |
|-------------|------------|
| Tencent Cloud TKE | VPC-CNI |
| Kubernetes | Flannel |
| K3s | Flannel |