### PR TITLE
feat(sdk): supplement Go/Python/Node SDK support for template alias

### DIFF
--- a/sdk/go/sdk_test.go
+++ b/sdk/go/sdk_test.go
@@ -1466,6 +1466,104 @@ func TestGetTemplateParsesNetworkFields(t *testing.T) {
 	}
 }
 
+func TestBuildTemplateForwardsName(t *testing.T) {
+	var got map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/templates" {
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&got); err != nil {
+			t.Fatalf("decode body: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusAccepted)
+		fmt.Fprint(w, `{"jobID":"job-name","templateID":"tpl-name","status":"accepted"}`)
+	}))
+	defer server.Close()
+
+	client := NewClient(Config{APIURL: server.URL, Timeout: 300 * time.Second})
+	if _, err := client.BuildTemplate(context.Background(), BuildTemplateOptions{
+		Image: "python:3.11-slim",
+		Name:  "my-alias",
+	}); err != nil {
+		t.Fatalf("BuildTemplate returned error: %v", err)
+	}
+	assertString(t, got, "name", "my-alias")
+	assertString(t, got, "image", "python:3.11-slim")
+}
+
+func TestBuildTemplateOmitsNameWhenBlank(t *testing.T) {
+	var got map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&got); err != nil {
+			t.Fatalf("decode body: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusAccepted)
+		fmt.Fprint(w, `{"jobID":"j","templateID":"t","status":"accepted"}`)
+	}))
+	defer server.Close()
+
+	client := NewClient(Config{APIURL: server.URL, Timeout: 300 * time.Second})
+	if _, err := client.BuildTemplate(context.Background(), BuildTemplateOptions{
+		Image: "python:3.11-slim",
+		Name:  "   ",
+	}); err != nil {
+		t.Fatalf("BuildTemplate returned error: %v", err)
+	}
+	if _, ok := got["name"]; ok {
+		t.Fatalf("name should be omitted when blank: %#v", got)
+	}
+}
+
+func TestGetTemplateParsesNameAndAliases(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/templates/tpl-alias" {
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{
+			"templateID":"tpl-alias",
+			"name":"my-alias",
+			"aliases":["my-alias"],
+			"status":"READY"
+		}`)
+	}))
+	defer server.Close()
+
+	client := NewClient(Config{APIURL: server.URL, Timeout: 300 * time.Second})
+	info, err := client.GetTemplate(context.Background(), "tpl-alias")
+	if err != nil {
+		t.Fatalf("GetTemplate returned error: %v", err)
+	}
+	if info.Name != "my-alias" {
+		t.Fatalf("Name=%q, want my-alias", info.Name)
+	}
+	if len(info.Aliases) != 1 || info.Aliases[0] != "my-alias" {
+		t.Fatalf("Aliases=%#v, want [my-alias]", info.Aliases)
+	}
+}
+
+func TestGetTemplateFallsBackToFirstAliasForName(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"templateID":"tpl-fb","aliases":["fallback-alias"],"status":"READY"}`)
+	}))
+	defer server.Close()
+
+	client := NewClient(Config{APIURL: server.URL, Timeout: 300 * time.Second})
+	info, err := client.GetTemplate(context.Background(), "tpl-fb")
+	if err != nil {
+		t.Fatalf("GetTemplate returned error: %v", err)
+	}
+	if info.Name != "fallback-alias" {
+		t.Fatalf("Name=%q, want fallback-alias (from aliases[0])", info.Name)
+	}
+	if len(info.Aliases) != 1 || info.Aliases[0] != "fallback-alias" {
+		t.Fatalf("Aliases=%#v", info.Aliases)
+	}
+}
+
 // ── SetTimeout ─────────────────────────────────────────────────────────────
 
 func TestSetTimeoutWireValues(t *testing.T) {

--- a/sdk/go/sdk_test.go
+++ b/sdk/go/sdk_test.go
@@ -1516,7 +1516,7 @@ func TestBuildTemplateOmitsNameWhenBlank(t *testing.T) {
 	}
 }
 
-func TestGetTemplateParsesNameAndAliases(t *testing.T) {
+func TestGetTemplateDerivesNameFromAliases(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet || r.URL.Path != "/templates/tpl-alias" {
 			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
@@ -1524,7 +1524,6 @@ func TestGetTemplateParsesNameAndAliases(t *testing.T) {
 		w.Header().Set("Content-Type", "application/json")
 		fmt.Fprint(w, `{
 			"templateID":"tpl-alias",
-			"name":"my-alias",
 			"aliases":["my-alias"],
 			"status":"READY"
 		}`)

--- a/sdk/go/sdk_test.go
+++ b/sdk/go/sdk_test.go
@@ -1539,9 +1539,6 @@ func TestGetTemplateParsesNameAndAliases(t *testing.T) {
 	if info.Name != "my-alias" {
 		t.Fatalf("Name=%q, want my-alias", info.Name)
 	}
-	if len(info.Aliases) != 1 || info.Aliases[0] != "my-alias" {
-		t.Fatalf("Aliases=%#v, want [my-alias]", info.Aliases)
-	}
 }
 
 func TestGetTemplateFallsBackToFirstAliasForName(t *testing.T) {
@@ -1558,9 +1555,6 @@ func TestGetTemplateFallsBackToFirstAliasForName(t *testing.T) {
 	}
 	if info.Name != "fallback-alias" {
 		t.Fatalf("Name=%q, want fallback-alias (from aliases[0])", info.Name)
-	}
-	if len(info.Aliases) != 1 || info.Aliases[0] != "fallback-alias" {
-		t.Fatalf("Aliases=%#v", info.Aliases)
 	}
 }
 

--- a/sdk/go/template.go
+++ b/sdk/go/template.go
@@ -5,6 +5,7 @@ package cubesandbox
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -22,16 +23,33 @@ type TemplateBuildJob struct {
 }
 
 type TemplateInfo struct {
-	TemplateID          string `json:"templateID"`
-	InstanceType        string `json:"instanceType,omitempty"`
-	Version             string `json:"version,omitempty"`
-	Status              string `json:"status,omitempty"`
-	LastError           string `json:"lastError,omitempty"`
-	CreatedAt           string `json:"createdAt,omitempty"`
-	ImageInfo           string `json:"imageInfo,omitempty"`
-	JobID               string `json:"jobID,omitempty"`
-	NetworkType         string `json:"networkType,omitempty"`
-	AllowInternetAccess *bool  `json:"allowInternetAccess,omitempty"`
+	TemplateID          string   `json:"templateID"`
+	Name                string   `json:"name,omitempty"`
+	Aliases             []string `json:"aliases,omitempty"`
+	InstanceType        string   `json:"instanceType,omitempty"`
+	Version             string   `json:"version,omitempty"`
+	Status              string   `json:"status,omitempty"`
+	LastError           string   `json:"lastError,omitempty"`
+	CreatedAt           string   `json:"createdAt,omitempty"`
+	ImageInfo           string   `json:"imageInfo,omitempty"`
+	JobID               string   `json:"jobID,omitempty"`
+	NetworkType         string   `json:"networkType,omitempty"`
+	AllowInternetAccess *bool   `json:"allowInternetAccess,omitempty"`
+}
+
+// UnmarshalJSON populates Name from aliases[0] when the server omits the
+// top-level name field (CubeSandbox returns only the aliases array).
+func (t *TemplateInfo) UnmarshalJSON(data []byte) error {
+	type alias TemplateInfo
+	var tmp alias
+	if err := json.Unmarshal(data, &tmp); err != nil {
+		return err
+	}
+	if tmp.Name == "" && len(tmp.Aliases) > 0 {
+		tmp.Name = tmp.Aliases[0]
+	}
+	*t = TemplateInfo(tmp)
+	return nil
 }
 
 type TemplateBuildStatus struct {
@@ -44,6 +62,7 @@ type TemplateBuildStatus struct {
 
 type BuildTemplateOptions struct {
 	Image               string
+	Name                string
 	InstanceType        string
 	WritableLayerSize   string
 	ExposedPorts        []uint16
@@ -142,6 +161,9 @@ func buildTemplatePayload(opts BuildTemplateOptions) (map[string]any, error) {
 
 	payload := map[string]any{
 		"image": image,
+	}
+	if name := strings.TrimSpace(opts.Name); name != "" {
+		payload["name"] = name
 	}
 	if instanceType := strings.TrimSpace(opts.InstanceType); instanceType != "" {
 		payload["instanceType"] = instanceType

--- a/sdk/go/template.go
+++ b/sdk/go/template.go
@@ -23,32 +23,35 @@ type TemplateBuildJob struct {
 }
 
 type TemplateInfo struct {
-	TemplateID          string   `json:"templateID"`
-	Name                string   `json:"name,omitempty"`
-	Aliases             []string `json:"aliases,omitempty"`
-	InstanceType        string   `json:"instanceType,omitempty"`
-	Version             string   `json:"version,omitempty"`
-	Status              string   `json:"status,omitempty"`
-	LastError           string   `json:"lastError,omitempty"`
-	CreatedAt           string   `json:"createdAt,omitempty"`
-	ImageInfo           string   `json:"imageInfo,omitempty"`
-	JobID               string   `json:"jobID,omitempty"`
-	NetworkType         string   `json:"networkType,omitempty"`
-	AllowInternetAccess *bool    `json:"allowInternetAccess,omitempty"`
+	TemplateID          string `json:"templateID"`
+	Name                string `json:"name,omitempty"`
+	InstanceType        string `json:"instanceType,omitempty"`
+	Version             string `json:"version,omitempty"`
+	Status              string `json:"status,omitempty"`
+	LastError           string `json:"lastError,omitempty"`
+	CreatedAt           string `json:"createdAt,omitempty"`
+	ImageInfo           string `json:"imageInfo,omitempty"`
+	JobID               string `json:"jobID,omitempty"`
+	NetworkType         string `json:"networkType,omitempty"`
+	AllowInternetAccess *bool  `json:"allowInternetAccess,omitempty"`
 }
 
 // UnmarshalJSON populates Name from aliases[0] when the server omits the
-// top-level name field (CubeSandbox returns only the aliases array).
+// top-level name field (CubeSandbox returns only the aliases array). The
+// aliases array is parsed into a local helper and not exposed as a field.
 func (t *TemplateInfo) UnmarshalJSON(data []byte) error {
 	type alias TemplateInfo
-	var tmp alias
+	var tmp struct {
+		alias
+		Aliases []string `json:"aliases"`
+	}
 	if err := json.Unmarshal(data, &tmp); err != nil {
 		return err
 	}
 	if tmp.Name == "" && len(tmp.Aliases) > 0 {
 		tmp.Name = tmp.Aliases[0]
 	}
-	*t = TemplateInfo(tmp)
+	*t = TemplateInfo(tmp.alias)
 	return nil
 }
 

--- a/sdk/go/template.go
+++ b/sdk/go/template.go
@@ -34,7 +34,7 @@ type TemplateInfo struct {
 	ImageInfo           string   `json:"imageInfo,omitempty"`
 	JobID               string   `json:"jobID,omitempty"`
 	NetworkType         string   `json:"networkType,omitempty"`
-	AllowInternetAccess *bool   `json:"allowInternetAccess,omitempty"`
+	AllowInternetAccess *bool    `json:"allowInternetAccess,omitempty"`
 }
 
 // UnmarshalJSON populates Name from aliases[0] when the server omits the

--- a/sdk/go/template.go
+++ b/sdk/go/template.go
@@ -48,7 +48,9 @@ func (t *TemplateInfo) UnmarshalJSON(data []byte) error {
 	if err := json.Unmarshal(data, &tmp); err != nil {
 		return err
 	}
-	if tmp.Name == "" && len(tmp.Aliases) > 0 {
+	// CubeSandbox returns only the aliases array (no top-level name); derive
+	// Name from aliases[0] for E2B API compatibility.
+	if len(tmp.Aliases) > 0 {
 		tmp.Name = tmp.Aliases[0]
 	}
 	*t = TemplateInfo(tmp.alias)

--- a/sdk/node/src/template.ts
+++ b/sdk/node/src/template.ts
@@ -88,6 +88,7 @@ export class TemplateBuild {
 export class TemplateInfo {
   templateId: string;
   name: string;
+  aliases: string[];
   instanceType: string;
   version: string;
   status: string;
@@ -107,6 +108,7 @@ export class TemplateInfo {
   constructor(fields: Partial<TemplateInfo> = {}) {
     this.templateId = fields.templateId ?? "";
     this.name = fields.name ?? "";
+    this.aliases = fields.aliases ?? [];
     this.instanceType = fields.instanceType ?? "";
     this.version = fields.version ?? "";
     this.status = fields.status ?? "";
@@ -129,6 +131,7 @@ export class TemplateInfo {
     return new TemplateInfo({
       templateId: data.templateID ?? data.template_id ?? "",
       name: data.name || (aliases.length ? aliases[0] : "") || "",
+      aliases,
       instanceType: data.instanceType ?? data.instance_type ?? "",
       version: data.version ?? "",
       status: data.status ?? "",
@@ -154,6 +157,7 @@ export class TemplateInfo {
 /** Options for {@link Template.build}. */
 export interface TemplateBuildOptions {
   image?: string;
+  name?: string;
   dockerfile?: string;
   startCmd?: string;
   instanceType?: string;
@@ -229,6 +233,7 @@ export class Template {
 
     const cfg = resolveConfig(options.config);
     const payload: Record<string, unknown> = { image: options.image.trim() };
+    if (options.name !== undefined) payload.name = options.name;
     if (options.instanceType !== undefined) payload.instanceType = options.instanceType;
     if (options.writableLayerSize !== undefined) {
       payload.writableLayerSize = options.writableLayerSize;

--- a/sdk/node/src/template.ts
+++ b/sdk/node/src/template.ts
@@ -128,7 +128,7 @@ export class TemplateInfo {
     const aliases: string[] = data.aliases ?? [];
     return new TemplateInfo({
       templateId: data.templateID ?? data.template_id ?? "",
-      name: data.name || (aliases.length ? aliases[0] : "") || "",
+      name: aliases.length ? aliases[0] : "",
       instanceType: data.instanceType ?? data.instance_type ?? "",
       version: data.version ?? "",
       status: data.status ?? "",

--- a/sdk/node/src/template.ts
+++ b/sdk/node/src/template.ts
@@ -88,7 +88,6 @@ export class TemplateBuild {
 export class TemplateInfo {
   templateId: string;
   name: string;
-  aliases: string[];
   instanceType: string;
   version: string;
   status: string;
@@ -108,7 +107,6 @@ export class TemplateInfo {
   constructor(fields: Partial<TemplateInfo> = {}) {
     this.templateId = fields.templateId ?? "";
     this.name = fields.name ?? "";
-    this.aliases = fields.aliases ?? [];
     this.instanceType = fields.instanceType ?? "";
     this.version = fields.version ?? "";
     this.status = fields.status ?? "";
@@ -131,7 +129,6 @@ export class TemplateInfo {
     return new TemplateInfo({
       templateId: data.templateID ?? data.template_id ?? "",
       name: data.name || (aliases.length ? aliases[0] : "") || "",
-      aliases,
       instanceType: data.instanceType ?? data.instance_type ?? "",
       version: data.version ?? "",
       status: data.status ?? "",

--- a/sdk/node/src/template.ts
+++ b/sdk/node/src/template.ts
@@ -233,7 +233,8 @@ export class Template {
 
     const cfg = resolveConfig(options.config);
     const payload: Record<string, unknown> = { image: options.image.trim() };
-    if (options.name !== undefined) payload.name = options.name;
+    const name = options.name?.trim();
+    if (name) payload.name = name;
     if (options.instanceType !== undefined) payload.instanceType = options.instanceType;
     if (options.writableLayerSize !== undefined) {
       payload.writableLayerSize = options.writableLayerSize;

--- a/sdk/node/test/template.test.ts
+++ b/sdk/node/test/template.test.ts
@@ -86,7 +86,6 @@ describe("Template.list", () => {
     expect(templates).toHaveLength(1);
     expect(templates[0].templateId).toBe("tpl-a");
     expect(templates[0].status).toBe("READY");
-    expect(templates[0].aliases).toEqual(["alpha"]);
     expect(templates[0].name).toBe("alpha");
   });
 });
@@ -121,7 +120,6 @@ describe("Template.get", () => {
       },
     });
     const info = await Template.get("tpl-alias", { config: makeConfig() });
-    expect(info.aliases).toEqual(["my-alias"]);
     expect(info.name).toBe("my-alias");
   });
 
@@ -131,7 +129,6 @@ describe("Template.get", () => {
       json: { templateID: "tpl-noalias", status: "READY" },
     });
     const info = await Template.get("tpl-noalias", { config: makeConfig() });
-    expect(info.aliases).toEqual([]);
     expect(info.name).toBe("");
   });
 });

--- a/sdk/node/test/template.test.ts
+++ b/sdk/node/test/template.test.ts
@@ -86,6 +86,8 @@ describe("Template.list", () => {
     expect(templates).toHaveLength(1);
     expect(templates[0].templateId).toBe("tpl-a");
     expect(templates[0].status).toBe("READY");
+    expect(templates[0].aliases).toEqual(["alpha"]);
+    expect(templates[0].name).toBe("alpha");
   });
 });
 
@@ -107,6 +109,30 @@ describe("Template.get", () => {
     expect(info.templateId).toBe("tpl-network");
     expect(info.networkType).toBe("tap");
     expect(info.allowInternetAccess).toBe(false);
+  });
+
+  it("parses aliases and falls back to aliases[0] for name", async () => {
+    handler = () => ({
+      status: 200,
+      json: {
+        templateID: "tpl-alias",
+        status: "READY",
+        aliases: ["my-alias"],
+      },
+    });
+    const info = await Template.get("tpl-alias", { config: makeConfig() });
+    expect(info.aliases).toEqual(["my-alias"]);
+    expect(info.name).toBe("my-alias");
+  });
+
+  it("exposes empty aliases array when server omits it", async () => {
+    handler = () => ({
+      status: 200,
+      json: { templateID: "tpl-noalias", status: "READY" },
+    });
+    const info = await Template.get("tpl-noalias", { config: makeConfig() });
+    expect(info.aliases).toEqual([]);
+    expect(info.name).toBe("");
   });
 });
 
@@ -137,6 +163,25 @@ describe("Template.build", () => {
     expect(build.jobId).toBe("job-001");
     expect(build.templateId).toBe("tpl-python");
     expect(build.status).toBe("running");
+  });
+
+  it("forwards name into the request body when provided", async () => {
+    handler = (req) => {
+      const body = JSON.parse(req.body.toString());
+      expect(body.name).toBe("my-alias");
+      expect(body.image).toBe("python:3.11-slim");
+      return { status: 200, json: { jobID: "job-name", templateID: "tpl-name" } };
+    };
+    await Template.build({ image: "python:3.11-slim", name: "my-alias", config: makeConfig() });
+  });
+
+  it("omits name when undefined", async () => {
+    handler = (req) => {
+      const body = JSON.parse(req.body.toString());
+      expect(body.name).toBeUndefined();
+      return { status: 200, json: { jobID: "j", templateID: "t" } };
+    };
+    await Template.build({ image: "python:3.11-slim", config: makeConfig() });
   });
 });
 

--- a/sdk/python/cubesandbox/_template.py
+++ b/sdk/python/cubesandbox/_template.py
@@ -70,7 +70,6 @@ class TemplateInfo:
 
     template_id: str
     name: str = ""
-    aliases: list[str] = field(default_factory=list)
     instance_type: str = ""
     version: str = ""
     status: str = ""
@@ -94,7 +93,6 @@ class TemplateInfo:
         return cls(
             template_id=data.get("templateID") or data.get("template_id", ""),
             name=data.get("name") or (aliases[0] if aliases else "") or "",
-            aliases=list(aliases),
             instance_type=data.get("instanceType") or data.get("instance_type", ""),
             version=data.get("version") or "",
             status=data.get("status") or "",

--- a/sdk/python/cubesandbox/_template.py
+++ b/sdk/python/cubesandbox/_template.py
@@ -92,7 +92,7 @@ class TemplateInfo:
         aliases = data.get("aliases") or []
         return cls(
             template_id=data.get("templateID") or data.get("template_id", ""),
-            name=data.get("name") or (aliases[0] if aliases else "") or "",
+            name=aliases[0] if aliases else "",
             instance_type=data.get("instanceType") or data.get("instance_type", ""),
             version=data.get("version") or "",
             status=data.get("status") or "",

--- a/sdk/python/cubesandbox/_template.py
+++ b/sdk/python/cubesandbox/_template.py
@@ -298,7 +298,8 @@ class Template:
 
         cfg = config or Config()
         payload: dict = {"image": image.strip()}
-        if name is not None:
+        name = name.strip() if name else ""
+        if name:
             payload["name"] = name
         if instance_type is not None:
             payload["instanceType"] = instance_type

--- a/sdk/python/cubesandbox/_template.py
+++ b/sdk/python/cubesandbox/_template.py
@@ -70,6 +70,7 @@ class TemplateInfo:
 
     template_id: str
     name: str = ""
+    aliases: list[str] = field(default_factory=list)
     instance_type: str = ""
     version: str = ""
     status: str = ""
@@ -93,6 +94,7 @@ class TemplateInfo:
         return cls(
             template_id=data.get("templateID") or data.get("template_id", ""),
             name=data.get("name") or (aliases[0] if aliases else "") or "",
+            aliases=list(aliases),
             instance_type=data.get("instanceType") or data.get("instance_type", ""),
             version=data.get("version") or "",
             status=data.get("status") or "",

--- a/sdk/python/tests/test_sandbox.py
+++ b/sdk/python/tests/test_sandbox.py
@@ -2305,20 +2305,12 @@ class TestTemplateAPI:
         assert info.network_type == "tap"
         assert info.allow_internet_access is True
 
-    def test_template_info_from_dict_exposes_aliases_and_name_fallback(self):
+    def test_template_info_from_dict_name_fallback_from_aliases(self):
         info = TemplateInfo.from_dict({
             "templateID": "tpl-alias",
             "aliases": ["my-alias"],
         })
         assert info.name == "my-alias"
-
-    def test_template_info_from_dict_prefers_explicit_name_over_alias(self):
-        info = TemplateInfo.from_dict({
-            "templateID": "tpl-named",
-            "name": "explicit-name",
-            "aliases": ["alias-name"],
-        })
-        assert info.name == "explicit-name"
 
     def test_build_forwards_name_into_payload(self):
         body = {"jobID": "job-name", "templateID": "tpl-name", "status": "accepted"}

--- a/sdk/python/tests/test_sandbox.py
+++ b/sdk/python/tests/test_sandbox.py
@@ -2302,7 +2302,6 @@ class TestTemplateAPI:
         })
         assert info.template_id == "tpl-test"
         assert info.name == ""
-        assert info.aliases == []
         assert info.network_type == "tap"
         assert info.allow_internet_access is True
 
@@ -2311,7 +2310,6 @@ class TestTemplateAPI:
             "templateID": "tpl-alias",
             "aliases": ["my-alias"],
         })
-        assert info.aliases == ["my-alias"]
         assert info.name == "my-alias"
 
     def test_template_info_from_dict_prefers_explicit_name_over_alias(self):
@@ -2321,7 +2319,6 @@ class TestTemplateAPI:
             "aliases": ["alias-name"],
         })
         assert info.name == "explicit-name"
-        assert info.aliases == ["alias-name"]
 
     def test_build_forwards_name_into_payload(self):
         body = {"jobID": "job-name", "templateID": "tpl-name", "status": "accepted"}

--- a/sdk/python/tests/test_sandbox.py
+++ b/sdk/python/tests/test_sandbox.py
@@ -2302,8 +2302,40 @@ class TestTemplateAPI:
         })
         assert info.template_id == "tpl-test"
         assert info.name == ""
+        assert info.aliases == []
         assert info.network_type == "tap"
         assert info.allow_internet_access is True
+
+    def test_template_info_from_dict_exposes_aliases_and_name_fallback(self):
+        info = TemplateInfo.from_dict({
+            "templateID": "tpl-alias",
+            "aliases": ["my-alias"],
+        })
+        assert info.aliases == ["my-alias"]
+        assert info.name == "my-alias"
+
+    def test_template_info_from_dict_prefers_explicit_name_over_alias(self):
+        info = TemplateInfo.from_dict({
+            "templateID": "tpl-named",
+            "name": "explicit-name",
+            "aliases": ["alias-name"],
+        })
+        assert info.name == "explicit-name"
+        assert info.aliases == ["alias-name"]
+
+    def test_build_forwards_name_into_payload(self):
+        body = {"jobID": "job-name", "templateID": "tpl-name", "status": "accepted"}
+        with patch("requests.Session.post", return_value=mock_response(body)) as post:
+            Template.build(image="python:3.11-slim", name="my-alias", config=make_config())
+        sent = post.call_args.kwargs["json"]
+        assert sent["name"] == "my-alias"
+        assert sent["image"] == "python:3.11-slim"
+
+    def test_build_omits_name_when_none(self):
+        body = {"jobID": "j", "templateID": "t", "status": "accepted"}
+        with patch("requests.Session.post", return_value=mock_response(body)) as post:
+            Template.build(image="python:3.11-slim", config=make_config())
+        assert "name" not in post.call_args.kwargs["json"]
 
     def test_template_get_parses_network_fields(self):
         body = {


### PR DESCRIPTION
## Summary

PR #749 shipped template alias support on the backend (CubeMaster Go + CubeAPI Rust), but SDK support was incomplete. This PR completes the three SDKs for the **create-time alias** feature: forwarding `name` in `build()` and deriving `TemplateInfo.name` from the server's `aliases` array.

## Changes

### Go SDK (`sdk/go/`)
- `BuildTemplateOptions` gains a `Name` field, trimmed and forwarded as `"name"` in the `POST /templates` request body (omitted when empty).
- `TemplateInfo.Name` is derived from `aliases[0]` via a custom `UnmarshalJSON` (CubeSandbox's `TemplateDetail` response has only the `aliases` array, no top-level `name`).

### Node SDK (`sdk/node/`)
- `TemplateBuildOptions` gains a `name` field, trimmed and forwarded in `Template.build()` (omitted when empty).
- `TemplateInfo.name` is derived from `aliases[0]` in `fromDict`.

### Python SDK (`sdk/python/`)
- `Template.build(name=...)` now trims `name` and omits it when empty (the parameter and forwarding were already present from #749; this PR adds the trim for consistency with Go/Node).
- `TemplateInfo.name` is derived from `aliases[0]` in `from_dict`.

### Design notes
- **No public `aliases` field**: CubeSandbox's `aliases` array is always 0 or 1 element (no namespace model), and `name` already captures that value via the `aliases[0]` derivation — exposing `aliases` separately would be redundant. The `aliases` array is parsed internally (Go: `UnmarshalJSON` helper struct; Node/Python: local variable) only to populate `name`.
- **No dead `name` fallback**: the server never returns a top-level `name` field, so `name` is derived directly from `aliases[0]` (no `data.get("name") or ...` dead branch).

### No SDK change needed
Transparent alias resolution in `get` / `delete` needs no SDK change — CubeMaster resolves aliases in the URL path via `ResolveTemplateIdentifier`.

## Tests
- Go: 4 unit tests (name forwarding, omit-when-blank, name derived from `aliases`, `aliases[0]` fallback).
- Node: 4 new unit tests + enhanced list/get assertions (name forwarding, name from `aliases`, empty case).
- Python: 4 unit tests (empty `aliases` → empty name, name fallback from `aliases`, build forwards name, build omits when None).
- All three SDK test suites pass. (One pre-existing unrelated Python test failure: `test_template_get_parses_network_fields` — a `headers={}` mock assertion mismatch present on `master`, verified via `git stash`.)

## Out of scope
- A dedicated SDK method for the `GET /templates/aliases/:alias` E2B-compat endpoint is deliberately not added (returns a minimal `{templateID, public}` shape; transparent `get(alias)` covers the use case).
- The "set alias on an existing template" feature (`PUT /templates/:id/alias`) is tracked separately in #1120 and is not part of this PR.

Assisted-by: CodeBuddy:GLM-5.2