### PR TITLE
ci(one-click): support reusing prebuilt guest image tar in release pipeline

### DIFF
--- a/.github/workflows/release-one-click.yml
+++ b/.github/workflows/release-one-click.yml
@@ -527,15 +527,17 @@ jobs:
             --repo "${GITHUB_REPOSITORY}" \
             --clobber
 
-  # Build one-click bundles after per-arch kernel assets are on the Release
-  # (consumed via gh release download). Runs in parallel with
-  # release_docker_images; publish_one_click_* uploads only after images
-  # (including CN sync) are published.
+  # Build one-click bundles after per-arch kernel + guest assets are on the
+  # Release. Guest image is reused from cube-guest-image-*.tar.gz (same asset
+  # as release_docker_images / cube-guest) via ONE_CLICK_GUEST_IMAGE_TAR so
+  # the one-click package stays consistent with published docker images.
+  # publish_one_click_* still waits for release_docker_images (incl. CN sync).
   build_one_click_amd64:
     name: Build one-click bundle (amd64)
     runs-on: ubuntu-latest
     needs:
       - publish_kernel_amd64
+      - publish_guest_release_assets
     env:
       VMLINUX_RELEASE_PATH: deploy/one-click/assets/kernel-artifacts/vmlinux
       PVM_VMLINUX_RELEASE_PATH: deploy/one-click/assets/kernel-artifacts/vmlinux-pvm
@@ -580,6 +582,20 @@ jobs:
           file "${VMLINUX_RELEASE_PATH}"
           file "${PVM_VMLINUX_RELEASE_PATH}"
 
+      - name: Download guest image from Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          rm -rf downloaded-guest
+          mkdir -p downloaded-guest
+          gh release download "${GITHUB_REF_NAME}" \
+            --repo "${GITHUB_REPOSITORY}" \
+            --pattern "cube-guest-image-amd64.tar.gz" \
+            --dir downloaded-guest
+          test -f downloaded-guest/cube-guest-image-amd64.tar.gz
+          ls -lh downloaded-guest/cube-guest-image-amd64.tar.gz
+
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3
         with:
@@ -596,6 +612,7 @@ jobs:
           CUBE_VERSION: ${{ github.ref_name }}
           CUBE_COMMIT: ${{ github.sha }}
           ONE_CLICK_DIST_VERSION: ${{ github.ref_name }}-amd64
+          ONE_CLICK_GUEST_IMAGE_TAR: ${{ github.workspace }}/downloaded-guest/cube-guest-image-amd64.tar.gz
         run: CUBE_BUILD_TIME="$(date -u +'%Y-%m-%dT%H:%M:%SZ')" ./deploy/one-click/build-release-bundle-builder.sh
 
       - name: Upload one-click bundle artifact
@@ -635,6 +652,7 @@ jobs:
     runs-on: ubuntu-24.04-arm
     needs:
       - publish_kernel_arm64
+      - publish_guest_release_assets
     env:
       VMLINUX_RELEASE_PATH: deploy/one-click/assets/kernel-artifacts/vmlinux
 
@@ -672,6 +690,20 @@ jobs:
           test -f "${VMLINUX_RELEASE_PATH}"
           file "${VMLINUX_RELEASE_PATH}"
 
+      - name: Download guest image from Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          rm -rf downloaded-guest
+          mkdir -p downloaded-guest
+          gh release download "${GITHUB_REF_NAME}" \
+            --repo "${GITHUB_REPOSITORY}" \
+            --pattern "cube-guest-image-arm64.tar.gz" \
+            --dir downloaded-guest
+          test -f downloaded-guest/cube-guest-image-arm64.tar.gz
+          ls -lh downloaded-guest/cube-guest-image-arm64.tar.gz
+
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3
         with:
@@ -688,6 +720,7 @@ jobs:
           CUBE_VERSION: ${{ github.ref_name }}
           CUBE_COMMIT: ${{ github.sha }}
           ONE_CLICK_DIST_VERSION: ${{ github.ref_name }}-arm64
+          ONE_CLICK_GUEST_IMAGE_TAR: ${{ github.workspace }}/downloaded-guest/cube-guest-image-arm64.tar.gz
         run: CUBE_BUILD_TIME="$(date -u +'%Y-%m-%dT%H:%M:%SZ')" ./deploy/one-click/build-release-bundle-builder.sh
 
       - name: Upload one-click bundle artifact

--- a/deploy/one-click/README.md
+++ b/deploy/one-click/README.md
@@ -42,7 +42,7 @@ export ONE_CLICK_CUBE_KERNEL_PVM_VMLINUX=/abs/path/to/vmlinux-pvm
 
 The installed runtime still uses `cube-kernel-scf/vmlinux` as the active guest kernel path. The package stores the ordinary guest kernel as `vmlinux-bm` and keeps `vmlinux` as a symlink: by default it points to `vmlinux-bm`; if the target machine sets `CUBE_PVM_ENABLE=1` during installation, the installer points it to `vmlinux-pvm`.
 
-The guest image no longer depends on a local zip file. Instead, it is generated locally from `deploy/guest-image/Dockerfile` during the one-click release package build. Common override parameters:
+The guest image no longer depends on a local zip file. By default it is generated locally from `deploy/guest-image/Dockerfile` during the one-click release package build. Common override parameters:
 
 ```bash
 export ONE_CLICK_GUEST_IMAGE_DOCKERFILE=/abs/path/to/cube-sandbox/deploy/guest-image/Dockerfile
@@ -52,6 +52,9 @@ export ONE_CLICK_GUEST_IMAGE_CONTEXT_DIR=/abs/path/to/cube-sandbox/deploy/guest-
 export ONE_CLICK_GUEST_IMAGE_REF=cube-sandbox-guest-image:one-click
 # Optional; defaults to the current repository revision
 export ONE_CLICK_GUEST_IMAGE_VERSION=custom-guest-image-version
+# Optional; reuse a prebuilt cube-guest-image-*.tar.gz (same layout as the
+# Release / docker asset). When set, local docker/mkfs rebuild is skipped.
+export ONE_CLICK_GUEST_IMAGE_TAR=/abs/path/to/cube-guest-image-amd64.tar.gz
 ```
 
 ## Building the Release Package

--- a/deploy/one-click/README_zh.md
+++ b/deploy/one-click/README_zh.md
@@ -42,7 +42,7 @@ export ONE_CLICK_CUBE_KERNEL_PVM_VMLINUX=/abs/path/to/vmlinux-pvm
 
 运行时仍然使用 `cube-kernel-scf/vmlinux`。默认情况下该文件是普通 guest kernel；如果目标机安装时设置 `CUBE_PVM_ENABLE=1`，安装脚本会把包内的 `vmlinux-pvm` 覆盖安装为 `cube-kernel-scf/vmlinux`。
 
-guest image 不再依赖本地 zip，而是在构建 one-click 发布包时基于 `deploy/guest-image/Dockerfile` 本地生成。常用覆盖参数如下：
+guest image 不再依赖本地 zip。默认在构建 one-click 发布包时基于 `deploy/guest-image/Dockerfile` 本地生成。常用覆盖参数如下：
 
 ```bash
 export ONE_CLICK_GUEST_IMAGE_DOCKERFILE=/abs/path/to/cube-sandbox/deploy/guest-image/Dockerfile
@@ -52,6 +52,9 @@ export ONE_CLICK_GUEST_IMAGE_CONTEXT_DIR=/abs/path/to/cube-sandbox/deploy/guest-
 export ONE_CLICK_GUEST_IMAGE_REF=cube-sandbox-guest-image:one-click
 # 可选，默认跟随当前仓库 revision
 export ONE_CLICK_GUEST_IMAGE_VERSION=custom-guest-image-version
+# 可选；复用已有的 cube-guest-image-*.tar.gz（与 Release / docker 资产同布局）。
+# 设置后会跳过本地 docker/mkfs 重建。
+export ONE_CLICK_GUEST_IMAGE_TAR=/abs/path/to/cube-guest-image-amd64.tar.gz
 ```
 
 ## 构建发布包

--- a/deploy/one-click/assets/kernel-artifacts/README.md
+++ b/deploy/one-click/assets/kernel-artifacts/README.md
@@ -3,9 +3,12 @@
 - `vmlinux`
 - `vmlinux-pvm`（可选，PVM guest kernel）
 
-guest image 会在构建 one-click 发布包时，基于 `deploy/guest-image/Dockerfile` 在本地动态构建，不再依赖预制 zip。
+guest image 默认在构建 one-click 发布包时基于 `deploy/guest-image/Dockerfile` 本地生成。
+也可通过 `ONE_CLICK_GUEST_IMAGE_TAR` 指向已有的 `cube-guest-image-*.tar.gz`
+（与 Release / docker 资产同布局）直接复用，跳过本地重建。
 
 如需覆盖 kernel 默认路径，可以通过环境变量指定：
 
 - `ONE_CLICK_CUBE_KERNEL_VMLINUX`
 - `ONE_CLICK_CUBE_KERNEL_PVM_VMLINUX`
+- `ONE_CLICK_GUEST_IMAGE_TAR`

--- a/deploy/one-click/build-guest-image.sh
+++ b/deploy/one-click/build-guest-image.sh
@@ -7,6 +7,10 @@
 #
 # When ONE_CLICK_CUBE_AGENT_BIN is unset, cube-agent is built locally (or via
 # ONE_CLICK_CUBE_AGENT_BUILD_MODE=docker).
+#
+# When ONE_CLICK_GUEST_IMAGE_TAR is set to a cube-guest-image-*.tar.gz (same
+# layout as the Release / docker asset), extract it into OUTPUT_DIR and skip
+# the local docker/mkfs rebuild so CI can reuse the published guest image.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -22,6 +26,44 @@ fi
 WORK_ROOT="${ONE_CLICK_WORK_ROOT:-${SCRIPT_DIR}/.work}"
 OUTPUT_DIR="${OUTPUT_DIR:-${ONE_CLICK_GUEST_IMAGE_OUTPUT_DIR:-}}"
 [[ -n "${OUTPUT_DIR}" ]] || die "OUTPUT_DIR (or ONE_CLICK_GUEST_IMAGE_OUTPUT_DIR) is required"
+
+install_prebuilt_guest_image_tar() {
+  local archive="${1:?archive path is required}"
+  local required=(
+    cube-guest-image-cpu.img
+    version
+    agent-version
+  )
+  local name
+
+  [[ -f "${archive}" ]] || die "prebuilt guest image archive not found: ${archive}"
+  require_cmd tar
+
+  if [[ -e "${OUTPUT_DIR}" ]]; then
+    if [[ "${EUID}" -eq 0 ]]; then
+      rm -rf "${OUTPUT_DIR}"
+    else
+      rm -rf "${OUTPUT_DIR}" 2>/dev/null || {
+        require_cmd sudo
+        sudo rm -rf "${OUTPUT_DIR}"
+      }
+    fi
+  fi
+  mkdir -p "${OUTPUT_DIR}"
+  log "using prebuilt guest image archive ${archive}"
+  tar -xzf "${archive}" -C "${OUTPUT_DIR}"
+
+  for name in "${required[@]}"; do
+    ensure_file "${OUTPUT_DIR}/${name}"
+  done
+
+  log "guest image artifacts ready from archive: ${OUTPUT_DIR}"
+}
+
+if [[ -n "${ONE_CLICK_GUEST_IMAGE_TAR:-}" ]]; then
+  install_prebuilt_guest_image_tar "${ONE_CLICK_GUEST_IMAGE_TAR}"
+  exit 0
+fi
 
 LATEST_RELEASE_TAG="$(git -C "${ROOT_DIR}" describe --tags --abbrev=0 --match 'v*' 2>/dev/null || true)"
 : "${CUBE_VERSION:=${LATEST_RELEASE_TAG:-0.0.0-dev}}"

--- a/deploy/one-click/env.example
+++ b/deploy/one-click/env.example
@@ -33,6 +33,10 @@ ONE_CLICK_CUBE_SHIM_BUILD_MODE=local
 # ONE_CLICK_GUEST_IMAGE_CONTEXT_DIR=/abs/path/to/cube-sandbox/deploy/guest-image
 # ONE_CLICK_GUEST_IMAGE_REF=cube-sandbox-guest-image:one-click
 # ONE_CLICK_GUEST_IMAGE_VERSION=custom-guest-image-version
+# Optional: reuse a prebuilt guest image archive (same layout as the Release /
+# docker asset cube-guest-image-*.tar.gz). When set, build-guest-image.sh
+# extracts it into the output directory and skips the local docker/mkfs rebuild.
+# ONE_CLICK_GUEST_IMAGE_TAR=/abs/path/to/cube-guest-image-amd64.tar.gz
 # ONE_CLICK_CUBE_KERNEL_VMLINUX=/abs/path/to/vmlinux
 # Optional PVM guest kernel. When present, it is packaged as cube-kernel-scf/vmlinux-pvm.
 # ONE_CLICK_CUBE_KERNEL_PVM_VMLINUX=/abs/path/to/vmlinux-pvm


### PR DESCRIPTION
## Summary

Add `ONE_CLICK_GUEST_IMAGE_TAR` support to the one-click release pipeline, allowing CI to reuse the published `cube-guest-image-*.tar.gz` from the Release instead of rebuilding it locally.

## Changes

- **build-guest-image.sh**: When `ONE_CLICK_GUEST_IMAGE_TAR` is set, extract it directly and skip local docker/mkfs rebuild
- **CI (release-one-click.yml)**: `build_one_click_amd64` and `build_one_click_arm64` now depend on `publish_guest_release_assets`, download the guest image tar from the Release, and pass it to the bundle builder
- **Documentation**: Updated README, README_zh, kernel-artifacts README, and env.example with the new variable

## Motivation

This keeps the one-click package consistent with the published docker images and avoids redundant guest image rebuilds in CI.