### PR TITLE
fix(volume): CubeMaster/Cubelet mixed-version volumeMounts compatibility

### DIFF
--- a/CubeMaster/pkg/service/sandbox/plugin_volume_annotation_test.go
+++ b/CubeMaster/pkg/service/sandbox/plugin_volume_annotation_test.go
@@ -10,6 +10,20 @@ import (
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/service/sandbox/types"
 )
 
+func TestPluginVolumeWireVolume_hasNoDefaultEmptyDir(t *testing.T) {
+	t.Parallel()
+
+	v := pluginVolumeWireVolume("max-data")
+	if v.GetVolumeSource() == nil {
+		t.Fatal("VolumeSource must be non-nil so the volume is still declared")
+	}
+	if v.GetVolumeSource().GetEmptyDir() != nil {
+		t.Fatalf("plugin volumes must not use EmptyDir placeholders; old Cubelets "+
+			"derive rootfs for StorageMediumDefault EmptyDir and collide with "+
+			"cube_rootfs_rw: got %+v", v.GetVolumeSource().GetEmptyDir())
+	}
+}
+
 func TestAppendPluginVolumeSourceAnnotation_includesPrivateData(t *testing.T) {
 	t.Parallel()
 

--- a/CubeMaster/pkg/service/sandbox/util.go
+++ b/CubeMaster/pkg/service/sandbox/util.go
@@ -718,11 +718,6 @@ func checkAndGetVolumes(req *types.CreateCubeSandboxReq, out *cubebox.RunCubeSan
 				return fmt.Errorf("volume name must not be empty")
 			}
 
-			v := &cubebox.Volume{
-				Name:         e.Name,
-				VolumeSource: &cubebox.VolumeSource{},
-			}
-
 			// Identify plugin volumes by name appearing in plugin-volume-mounts
 			// annotation, or by having a nil VolumeSource.
 			if e.VolumeSource == nil || pluginVolumeNames[e.Name] {
@@ -733,11 +728,18 @@ func checkAndGetVolumes(req *types.CreateCubeSandboxReq, out *cubebox.RunCubeSan
 				if err := appendPluginVolumeSourceAnnotation(req, e.Name, record.Driver, record.PrivateData); err != nil {
 					return fmt.Errorf("volume [%s]: annotation: %w", e.Name, err)
 				}
-				v.VolumeSource.EmptyDir = &cubebox.EmptyDirVolumeSource{
-					SizeLimit: "1Gi",
-				}
-				out.Volumes = append(out.Volumes, v)
+				// Compatibility with older Cubelets: do NOT inject
+				// EmptyDir(StorageMediumDefault) as a placeholder. Pre-plugin
+				// Cubelets treat every Default EmptyDir as a rootfs derive
+				// (sb-<id>-rootfs-gen0); a second Default EmptyDir then collides
+				// with cube_rootfs_rw ("cubecow object already exists").
+				out.Volumes = append(out.Volumes, pluginVolumeWireVolume(e.Name))
 				continue
+			}
+
+			v := &cubebox.Volume{
+				Name:         e.Name,
+				VolumeSource: &cubebox.VolumeSource{},
 			}
 
 			if e.VolumeSource.EmptyDir != nil {
@@ -1064,6 +1066,16 @@ func checkAndGetContainerHooks(out *cubebox.ContainerConfig, in *types.Container
 		}
 	}
 	return nil
+}
+
+// pluginVolumeWireVolume is the Cubelet-facing Volume shape for a plugin volume.
+// VolumeSource is intentionally empty: do not use EmptyDir(StorageMediumDefault)
+// placeholders (see checkAndGetVolumes).
+func pluginVolumeWireVolume(name string) *cubebox.Volume {
+	return &cubebox.Volume{
+		Name:         name,
+		VolumeSource: &cubebox.VolumeSource{},
+	}
 }
 
 // appendPluginVolumeSourceAnnotation records name+driver(+private_data) for a

--- a/Cubelet/storage/local.go
+++ b/Cubelet/storage/local.go
@@ -995,12 +995,11 @@ func (l *local) prepareDefaultMedium(ctx context.Context, opts *workflow.CreateC
 		v.GetVolumeSource().GetEmptyDir().GetMedium() != cubebox.StorageMedium_StorageMediumDefault {
 		return nil
 	}
-	// Plugin volumes are injected by CubeMaster as EmptyDir placeholders but
-	// must NOT be provisioned here — they are handled entirely by
-	// attachPluginVolume via the VolumePlugin binary framework.
-	// Provisioning them here would create a spurious cubecow snapshot with the
-	// same sandboxID, causing an "already exists" collision when the real
-	// rootfs snapshot is created moments later.
+	// Plugin volumes are handled by attachPluginVolume (via the
+	// plugin-volume-sources annotation). Keep this skip for mixed-version
+	// clusters: a CubeMaster that still injects Default EmptyDir placeholders
+	// for plugin volumes must not cause a second rootfs derive
+	// (sb-<id>-rootfs-gen0) that collides with cube_rootfs_rw.
 	if isPluginVolume(opts.ReqInfo.GetAnnotations(), v.GetName()) {
 		return nil
 	}

--- a/docs/guide/volume-plugin.md
+++ b/docs/guide/volume-plugin.md
@@ -611,6 +611,18 @@ For COS-specific manual tests, see [`examples/volume/cos/README.md`](https://git
 | FUSE OK but invisible in sandbox | Mount in host mntns, not Cubelet mntns | Let Cubelet fork the plugin |
 | Detach leak after attach | Unmount shared FUSE when `ref_count > 0` | Follow RefCount semantics |
 
+## Compatibility Notes
+
+Volume requires **both** CubeMaster and Cubelet to be on a release that supports the Volume Plugin. During a rolling upgrade:
+
+| CubeMaster | Cubelet | Volume create / delete | Sandbox `volumeMounts` |
+|---|---|---|---|
+| New | New | Supported | Supported |
+| New | Old (e.g. v0.5.x) | Supported | No-op (create must not fail; the volume is not mounted) |
+| Old (e.g. v0.5.x) | New / old | Unsupported | Unsupported; do not send `volumeMounts` — plain create is unaffected |
+
+Do not assume mounts succeed on old nodes; schedule onto an upgraded Cubelet when you need mount behavior.
+
 ---
 
 ## Known Limitations and Roadmap

--- a/docs/zh/guide/volume-plugin.md
+++ b/docs/zh/guide/volume-plugin.md
@@ -609,6 +609,18 @@ COS 插件的手动测试命令见 [`examples/volume/cos/README.zh.md`](https://
 | FUSE 挂载成功但沙箱内看不到 | 挂载在宿主机 mntns 而非 Cubelet mntns | 确保插件由 Cubelet fork，不要手动在宿主机 mount |
 | attach 成功但 detach 泄漏 | `ref_count > 0` 时误卸载了共享 FUSE | 检查 detach 逻辑是否遵守 RefCount 语义 |
 
+## 兼容性说明
+
+Volume 依赖 CubeMaster 与 Cubelet **双侧**均升级到支持 Volume 插件的版本。滚动升级期间：
+
+| CubeMaster | Cubelet | Volume 创建 / 删除 | 沙箱 `volumeMounts` |
+|---|---|---|---|
+| 新 | 新 | 可用 | 可用 |
+| 新 | 旧（如 v0.5.x） | 可用 | 不生效（创建不因此失败，但不会挂载） |
+| 旧（如 v0.5.x） | 新 / 旧 | 不可用 | 不可用；勿传 `volumeMounts`，普通创建不受影响 |
+
+混合版本时勿假设旧节点已挂载成功；需要挂载效果时，请确认调度到的 Cubelet 已升级。
+
 ---
 
 ## 已知限制与路线图


### PR DESCRIPTION
## Summary

- **Goal:** keep CubeMaster and Cubelet **new/old versions mutually compatible** when sandboxes use plugin `volumeMounts` (rolling upgrades / mixed clusters).
- **Bug:** newer CubeMaster injected plugin volumes as `EmptyDir(StorageMediumDefault)` placeholders plus `plugin-volume-sources`. Older Cubelets have no plugin skip path and treat every Default EmptyDir as a second rootfs derive (`sb-<id>-rootfs-gen0`), which collides with `cube_rootfs_rw` and fails create with `cubecow object already exists` (e.g. CubeAPI `130545`).
- **Fix (CubeMaster):** stop injecting Default EmptyDir for plugin volumes; wire an empty `VolumeSource` name-only entry. New Cubelets still Attach via the Volume Plugin framework + annotation; older Cubelets skip the empty source in `prepareDefaultMedium` and no longer collide on rootfs.
- **Defense (Cubelet):** keep `isPluginVolume` skip so a CubeMaster that still sends Default EmptyDir placeholders does not break a newer Cubelet.

### Compatibility matrix (intended)

| CubeMaster | Cubelet | Plugin volumeMounts create |
|---|---|---|
| new (this PR) | old | OK — no Default EmptyDir placeholder |
| new (this PR) | new | OK — annotation + plugin Attach |
| old (EmptyDir placeholder) | new | OK — Cubelet skips plugin EmptyDir |
| old (no volume plugin) | old | N/A — volumes API not used |

## Test plan

- [x] Unit: `CubeMaster/pkg/service/sandbox` plugin volume annotation test asserts no Default EmptyDir on the wire
- [x] Smoke: create sandbox with COS `volumeMounts` succeeds after deploying fixed CubeMaster
- [x] E2E: `examples/volume/tests/e2e-volume-lifecycle.sh` with `DRIVER=cos` and `DRIVER=cos-rpc`
- [x] SDK examples: `verify_volume.py` (cos / cos-rpc) and `volume_complex_concurrent_test.py`

Assisted-by: Cursor:Composer

Made with [Cursor](https://cursor.com)