### PR TITLE
feat(cubeapi): add webhook event notifications

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,4 @@ __pycache__
 /tests/e2e/sdk_compat/.pytest_cache/
 
 web/tsconfig.tsbuildinfo
+examples/webhook-receiver/Cargo.lock

--- a/CubeAPI/Cargo.lock
+++ b/CubeAPI/Cargo.lock
@@ -526,6 +526,7 @@ dependencies = [
  "axum",
  "axum-extra",
  "axum-test",
+ "bytes",
  "chrono",
  "clap",
  "config",
@@ -533,9 +534,12 @@ dependencies = [
  "dotenvy",
  "futures",
  "governor",
+ "hex",
+ "hmac",
  "reqwest",
  "serde",
  "serde_json",
+ "sha2",
  "thiserror 1.0.69",
  "tokio",
  "tower 0.4.13",
@@ -589,6 +593,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -915,6 +920,21 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
 
 [[package]]
 name = "http"

--- a/CubeAPI/Cargo.toml
+++ b/CubeAPI/Cargo.toml
@@ -84,6 +84,14 @@ utoipa = { version = "5.4.0", features = ["chrono", "uuid", "yaml"] }
 # ── Graceful shutdown ─────────────────────────────────────────────────────
 # (tokio::signal + axum::serve().with_graceful_shutdown is sufficient)
 
+# ── Webhook delivery ─────────────────────────────────────────────────────
+bytes = "1"
+
+# ── Webhook signing ──────────────────────────────────────────────────────
+hmac = "0.12"
+sha2 = "0.10"
+hex = "0.4"
+
 [dev-dependencies]
 tokio = { version = "1", features = ["full"] }
 tower = { version = "0.4" }

--- a/CubeAPI/src/config/mod.rs
+++ b/CubeAPI/src/config/mod.rs
@@ -76,6 +76,18 @@ pub struct ServerConfig {
     /// Env var: CUBE_API_KEY
     #[serde(default)]
     pub cube_api_key: Option<String>,
+
+    /// Comma-separated webhook endpoint URLs. Env var: CUBE_WEBHOOK_URLS (default "" = disabled)
+    #[serde(default = "default_webhook_urls")]
+    pub webhook_urls: String,
+
+    /// Comma-separated event types to deliver. Env var: CUBE_WEBHOOK_EVENTS.
+    #[serde(default = "default_webhook_events")]
+    pub webhook_events: String,
+
+    /// Shared secret for HMAC-SHA256 signing. Env var: CUBE_WEBHOOK_SECRET (default "" = no signing)
+    #[serde(default = "default_webhook_secret")]
+    pub webhook_secret: String,
 }
 
 fn default_bind() -> String {
@@ -109,6 +121,17 @@ fn default_log_dir() -> String {
 fn default_log_prefix() -> String {
     "cube-api".to_string()
 }
+fn default_webhook_urls() -> String {
+    std::env::var("CUBE_WEBHOOK_URLS").unwrap_or_default()
+}
+fn default_webhook_events() -> String {
+    std::env::var("CUBE_WEBHOOK_EVENTS").unwrap_or_else(|_| {
+        "sandbox.created,sandbox.deleted,sandbox.paused,sandbox.resumed".to_string()
+    })
+}
+fn default_webhook_secret() -> String {
+    std::env::var("CUBE_WEBHOOK_SECRET").unwrap_or_default()
+}
 
 impl ServerConfig {
     pub fn from_env() -> anyhow::Result<Self> {
@@ -135,6 +158,9 @@ impl Default for ServerConfig {
             log_prefix: default_log_prefix(),
             auth_callback_url: None,
             cube_api_key: std::env::var("CUBE_API_KEY").ok().filter(|s| !s.is_empty()),
+            webhook_urls: default_webhook_urls(),
+            webhook_events: default_webhook_events(),
+            webhook_secret: default_webhook_secret(),
         }
     }
 }

--- a/CubeAPI/src/handlers/sandboxes.rs
+++ b/CubeAPI/src/handlers/sandboxes.rs
@@ -310,7 +310,11 @@ pub async fn resume_sandbox(
     tracing::info!(sandbox_id = %sandbox_id, "resume_sandbox: success");
     state
         .logger
-        .log(LogEvent::new(LogLevel::Info, "sandbox.resumed").field("sandbox_id", &sandbox_id))
+        .log(
+            LogEvent::new(LogLevel::Info, "sandbox.resumed")
+                .field("sandbox_id", &sandbox_id)
+                .field("template_id", &sandbox.template_id),
+        )
         .await;
 
     Ok((StatusCode::CREATED, Json(sandbox)))

--- a/CubeAPI/src/logging/http.rs
+++ b/CubeAPI/src/logging/http.rs
@@ -123,7 +123,10 @@ impl HttpLogger {
                     Msg::Event(event) => {
                         let payload = build_payload(&event);
                         let body_bytes =
-                            bytes::Bytes::from(serde_json::to_string(&payload).unwrap_or_default());
+                            bytes::Bytes::from(
+                            serde_json::to_vec(&payload)
+                                .expect("serializing a freshly-built serde_json::Value never fails"),
+                        );
                         let event_name = event.event.clone();
 
                         pending_bg.fetch_add(1, Ordering::Relaxed);

--- a/CubeAPI/src/logging/http.rs
+++ b/CubeAPI/src/logging/http.rs
@@ -342,3 +342,264 @@ async fn deliver_with_retry(
 
 // ─── Tests ───────────────────────────────────────────────────────────────
 
+#[cfg(test)]
+mod tests {
+    use super::super::{LogEvent, LogLevel};
+    use super::*;
+    use axum::{routing::post, Router};
+    use std::sync::Mutex;
+
+    #[test]
+    fn build_payload_includes_event_and_timestamp() {
+        let event = LogEvent::new(LogLevel::Info, "sandbox.created")
+            .field("sandbox_id", "sb-abc")
+            .field("template_id", "tpl-xyz");
+        let payload = build_payload(&event);
+        assert_eq!(payload["event"], "sandbox.created");
+        assert!(!payload["timestamp"].as_str().unwrap().is_empty());
+        assert_eq!(payload["sandbox_id"], "sb-abc");
+        assert_eq!(payload["template_id"], "tpl-xyz");
+    }
+
+    #[test]
+    fn sign_payload_produces_deterministic_hmac() {
+        let body = b"test body";
+        let sig = sign_payload("secret", body);
+        assert!(sig.starts_with("sha256="));
+        assert_eq!(sig, sign_payload("secret", body));
+        assert_ne!(sig, sign_payload("different", body));
+    }
+
+    #[test]
+    fn redact_url_strips_path_and_query() {
+        assert_eq!(
+            redact_url("https://hooks.example.com/webhook"),
+            "hooks.example.com"
+        );
+        assert_eq!(
+            redact_url("http://127.0.0.1:9090/callback?token=abc"),
+            "127.0.0.1:9090"
+        );
+        assert_eq!(redact_url("https://example.com"), "example.com");
+    }
+
+    #[tokio::test]
+    async fn empty_targets_are_noop() {
+        let config = HttpLoggerConfig {
+            targets: vec![],
+            subscribed_events: HashSet::new(),
+            secret: String::new(),
+            max_concurrency: 4,
+            http_client: reqwest::Client::new(),
+        };
+        let logger = HttpLogger::new(config);
+        logger
+            .log(LogEvent::new(LogLevel::Info, "sandbox.created"))
+            .await;
+        logger.flush().await;
+    }
+
+    async fn spawn_mock_server() -> (String, Arc<Mutex<Vec<String>>>) {
+        let bodies: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(vec![]));
+        let b = bodies.clone();
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let url = format!("http://{}:{}/webhook", addr.ip(), addr.port());
+        let app = Router::new().route(
+            "/webhook",
+            post(move |body: axum::body::Bytes| async move {
+                b.lock()
+                    .unwrap()
+                    .push(String::from_utf8_lossy(&body).to_string());
+                "ok"
+            }),
+        );
+        tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        (url, bodies)
+    }
+
+    #[tokio::test]
+    async fn delivers_event_to_target() {
+        let (url, bodies) = spawn_mock_server().await;
+        let config = HttpLoggerConfig {
+            targets: vec![url],
+            subscribed_events: HashSet::new(),
+            secret: String::new(),
+            max_concurrency: 4,
+            http_client: reqwest::Client::new(),
+        };
+        let logger = HttpLogger::new(config);
+        logger
+            .log(LogEvent::new(LogLevel::Info, "sandbox.created").field("sandbox_id", "sb-test"))
+            .await;
+        logger.flush().await;
+        let captured = bodies.lock().unwrap();
+        assert_eq!(captured.len(), 1);
+        let body: serde_json::Value = serde_json::from_str(&captured[0]).unwrap();
+        assert_eq!(body["event"], "sandbox.created");
+        assert_eq!(body["sandbox_id"], "sb-test");
+    }
+
+    #[tokio::test]
+    async fn filters_out_unsubscribed_events() {
+        let (url, bodies) = spawn_mock_server().await;
+        let mut events = HashSet::new();
+        events.insert("sandbox.created".to_string());
+        let config = HttpLoggerConfig {
+            targets: vec![url],
+            subscribed_events: events,
+            secret: String::new(),
+            max_concurrency: 4,
+            http_client: reqwest::Client::new(),
+        };
+        let logger = HttpLogger::new(config);
+        logger
+            .log(LogEvent::new(LogLevel::Info, "sandbox.created"))
+            .await;
+        logger
+            .log(LogEvent::new(LogLevel::Info, "sandbox.deleted"))
+            .await;
+        logger.flush().await;
+        assert_eq!(bodies.lock().unwrap().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn retries_on_500_then_succeeds() {
+        use std::sync::atomic::{AtomicU32, Ordering};
+        let counter = Arc::new(AtomicU32::new(0));
+        let c = counter.clone();
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let url = format!("http://{}:{}/webhook", addr.ip(), addr.port());
+        let app = Router::new().route(
+            "/webhook",
+            post(move |_: axum::body::Bytes| async move {
+                let n = c.fetch_add(1, Ordering::SeqCst);
+                if n <= 1 {
+                    (axum::http::StatusCode::INTERNAL_SERVER_ERROR, "err")
+                } else {
+                    (axum::http::StatusCode::OK, "ok")
+                }
+            }),
+        );
+        tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        let config = HttpLoggerConfig {
+            targets: vec![url],
+            subscribed_events: HashSet::new(),
+            secret: String::new(),
+            max_concurrency: 4,
+            http_client: reqwest::Client::new(),
+        };
+        let logger = HttpLogger::new(config);
+        logger
+            .log(LogEvent::new(LogLevel::Info, "sandbox.created"))
+            .await;
+        logger.flush().await;
+        assert!(
+            counter.load(Ordering::SeqCst) >= 2,
+            "expected at least 2 attempts, got {}",
+            counter.load(Ordering::SeqCst)
+        );
+    }
+
+    #[tokio::test]
+    async fn does_not_retry_on_4xx() {
+        use std::sync::atomic::{AtomicU32, Ordering};
+        let counter = Arc::new(AtomicU32::new(0));
+        let c = counter.clone();
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let url = format!("http://{}:{}/webhook", addr.ip(), addr.port());
+        let app = Router::new().route(
+            "/webhook",
+            post(move |_: axum::body::Bytes| async move {
+                c.fetch_add(1, Ordering::SeqCst);
+                (axum::http::StatusCode::BAD_REQUEST, "bad")
+            }),
+        );
+        tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        let config = HttpLoggerConfig {
+            targets: vec![url],
+            subscribed_events: HashSet::new(),
+            secret: String::new(),
+            max_concurrency: 4,
+            http_client: reqwest::Client::new(),
+        };
+        let logger = HttpLogger::new(config);
+        logger
+            .log(LogEvent::new(LogLevel::Info, "sandbox.created"))
+            .await;
+        logger.flush().await;
+        assert_eq!(counter.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn sends_hmac_signature_when_secret_set() {
+        let sig: Arc<Mutex<Option<String>>> = Arc::new(Mutex::new(None));
+        let s = sig.clone();
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let url = format!("http://{}:{}/webhook", addr.ip(), addr.port());
+        let app = Router::new().route(
+            "/webhook",
+            post(
+                move |headers: axum::http::HeaderMap, _body: axum::body::Bytes| async move {
+                    if let Some(val) = headers.get("X-Cube-Signature") {
+                        *s.lock().unwrap() = Some(val.to_str().unwrap().to_string());
+                    }
+                    axum::http::StatusCode::OK
+                },
+            ),
+        );
+        tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        let config = HttpLoggerConfig {
+            targets: vec![url],
+            subscribed_events: HashSet::new(),
+            secret: "test-secret".to_string(),
+            max_concurrency: 4,
+            http_client: reqwest::Client::new(),
+        };
+        let logger = HttpLogger::new(config);
+        logger
+            .log(LogEvent::new(LogLevel::Info, "sandbox.created"))
+            .await;
+        logger.flush().await;
+        let captured = sig.lock().unwrap();
+        assert!(captured.is_some(), "X-Cube-Signature header missing");
+        assert!(captured.as_ref().unwrap().starts_with("sha256="));
+    }
+
+    #[tokio::test]
+    async fn flush_waits_for_inflight_delivery() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let url = format!("http://{}:{}/webhook", addr.ip(), addr.port());
+        let app = Router::new().route(
+            "/webhook",
+            post(|| async {
+                tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+                "ok"
+            }),
+        );
+        tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        let config = HttpLoggerConfig {
+            targets: vec![url],
+            subscribed_events: HashSet::new(),
+            secret: String::new(),
+            max_concurrency: 4,
+            http_client: reqwest::Client::new(),
+        };
+        let logger = HttpLogger::new(config);
+        logger
+            .log(LogEvent::new(LogLevel::Info, "sandbox.created"))
+            .await;
+        let start = std::time::Instant::now();
+        logger.flush().await;
+        assert!(start.elapsed() >= std::time::Duration::from_millis(100));
+    }
+}

--- a/CubeAPI/src/logging/http.rs
+++ b/CubeAPI/src/logging/http.rs
@@ -259,12 +259,15 @@ fn sign_payload(secret: &str, body: &[u8]) -> String {
 }
 
 /// Extract host portion from a URL for safe logging.
-fn redact_url(url: &str) -> &str {
+/// Strips scheme, userinfo, path, query, and fragment.
+pub(crate) fn redact_url(url: &str) -> &str {
     // Strip scheme
     let s = url
         .strip_prefix("https://")
         .or_else(|| url.strip_prefix("http://"))
         .unwrap_or(url);
+    // Strip userinfo (user:pass@host → host)
+    let s = s.rsplit('@').next().unwrap_or(s);
     // Strip path / query / fragment
     s.split('/').next().unwrap_or(s)
 }
@@ -385,6 +388,19 @@ mod tests {
             "127.0.0.1:9090"
         );
         assert_eq!(redact_url("https://example.com"), "example.com");
+    }
+
+    #[test]
+    fn redact_url_removes_userinfo() {
+        assert_eq!(
+            redact_url("http://user:pass@example.com:8080/webhook"),
+            "example.com:8080"
+        );
+        // No userinfo present — should still work
+        assert_eq!(
+            redact_url("https://hooks.example.com/webhook"),
+            "hooks.example.com"
+        );
     }
 
     #[tokio::test]

--- a/CubeAPI/src/logging/http.rs
+++ b/CubeAPI/src/logging/http.rs
@@ -123,10 +123,9 @@ impl HttpLogger {
                     Msg::Event(event) => {
                         let payload = build_payload(&event);
                         let body_bytes =
-                            bytes::Bytes::from(
-                            serde_json::to_vec(&payload)
-                                .expect("serializing a freshly-built serde_json::Value never fails"),
-                        );
+                            bytes::Bytes::from(serde_json::to_vec(&payload).expect(
+                                "serializing a freshly-built serde_json::Value never fails",
+                            ));
                         let event_name = event.event.clone();
 
                         pending_bg.fetch_add(1, Ordering::Relaxed);
@@ -234,6 +233,10 @@ fn build_payload(event: &LogEvent) -> serde_json::Value {
             // Protect reserved top-level keys from being overwritten
             // by field entries (defense-in-depth; no existing handler does this).
             if k == "event" || k == "timestamp" {
+                tracing::warn!(
+                    field = %k,
+                    "webhook: field name collides with reserved payload key, skipping"
+                );
                 continue;
             }
             obj.insert(k.clone(), v.clone());

--- a/CubeAPI/src/logging/http.rs
+++ b/CubeAPI/src/logging/http.rs
@@ -112,7 +112,6 @@ impl HttpLogger {
 
         // ── Background receiver task ──────────────────────────────────────
         let targets_bg = targets.clone();
-        let subscribed_events_bg = subscribed_events.clone();
         let secret_bg = secret.clone();
         let http_client_bg = http_client.clone();
         let pending_bg = pending.clone();
@@ -122,12 +121,6 @@ impl HttpLogger {
             while let Some(msg) = rx.recv().await {
                 match msg {
                     Msg::Event(event) => {
-                        if !subscribed_events_bg.is_empty()
-                            && !subscribed_events_bg.contains(&event.event)
-                        {
-                            continue;
-                        }
-
                         let payload = build_payload(&event);
                         let body_bytes =
                             bytes::Bytes::from(serde_json::to_string(&payload).unwrap_or_default());
@@ -235,6 +228,11 @@ fn build_payload(event: &LogEvent) -> serde_json::Value {
     });
     if let Some(obj) = payload.as_object_mut() {
         for (k, v) in &event.fields {
+            // Protect reserved top-level keys from being overwritten
+            // by field entries (defense-in-depth; no existing handler does this).
+            if k == "event" || k == "timestamp" {
+                continue;
+            }
             obj.insert(k.clone(), v.clone());
         }
     }

--- a/CubeAPI/src/logging/http.rs
+++ b/CubeAPI/src/logging/http.rs
@@ -2,83 +2,343 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-//! HTTP webhook log backend — stub.
+//! Webhook event notification backend.
 //!
-//! Sends log events as JSON POST requests to a configurable endpoint.
-//! Useful for forwarding to log aggregators (Elasticsearch, Loki, custom
-//! ingest APIs) that accept HTTP.
+//! Replaces the previous batch-log-forwarding stub.  Implements
+//! the [`Logger`] trait to deliver sandbox lifecycle events
+//! (`sandbox.created`, `sandbox.deleted`, `sandbox.paused`,
+//! `sandbox.resumed`) to configured HTTP endpoints via
+//! asynchronous POST requests with optional HMAC-SHA256 signing
+//! and exponential-backoff retry.
 //!
-//! # TODO (wire-up checklist)
+//! # Architecture
 //!
-//! 1. Add `http_log_url: Option<String>` to `ServerConfig`.
-//! 2. Construct `HttpLogger::new(client, url, batch_size, flush_interval)`.
-//! 3. Register it in `AppState::new()` inside `MultiLogger`.
+//! ```text
+//! log() → tx.send() → receiver loop → Semaphore → spawn → join_all → POST
+//! ```
 //!
-//! # Batching strategy (suggested)
+//! - `log()` does only a non-blocking channel send (microsecond latency).
+//! - A single background receiver task dispatches delivery to spawned tasks.
+//! - `Arc<Semaphore>` bounds concurrent delivery tasks at 64 (consumer-side
+//!   throttling — the HTTP handler is never backpressured).
+//! - `Arc<AtomicUsize>` tracks inflight deliveries so `flush()` can wait for
+//!   completion during graceful shutdown.
 //!
-//! Buffer events into a `Vec<LogEvent>` and POST when either:
-//! - The buffer reaches `batch_size` (default 100), or
-//! - A ticker fires every `flush_interval` (default 5 s).
+//! # MVP scope — intentionally omitted
 //!
-//! Use `tokio::select!` in the background task to wait on whichever fires
-//! first.
+//! 1. No jitter: single-instance has no thundering herd. For multi-instance,
+//!    change `sleep(1 << attempt)` to sleep + jitter (one line).
+//! 2. No outer delivery timeout: reqwest 30s per-request timeout + bounded
+//!    retry (max 4 attempts) provides natural upper bound ~127s. If reqwest
+//!    timeout fails, permit leaks → semaphore exhausts → channel grows.
+//! 3. No PendingGuard RAII: task panic causes pending leak → flush timeout
+//!    + warn. No data loss, only slower shutdown. Add back when code complex.
+//! 4. No event name validation: invalid names never match → no output →
+//!    user debugs naturally. "Empty=all" only triggers on explicit empty
+//!    config, not from filtering invalid entries.
+
+use std::collections::HashSet;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use tokio::sync::mpsc::{self, UnboundedSender};
+use tokio::sync::{oneshot, Semaphore};
 
 use super::{LogEvent, Logger};
-use async_trait::async_trait;
 
-/// Configuration for the HTTP webhook backend.
-#[derive(Debug, Clone)]
-#[allow(dead_code)]
-pub struct HttpLoggerConfig {
-    /// Full URL to POST batches to, e.g. `"http://log-ingest.internal/api/logs"`.
-    pub url: String,
-    /// Max events per batch (default: 100).
-    pub batch_size: usize,
-    /// Flush interval in seconds even if batch is not full (default: 5).
-    pub flush_interval_secs: u64,
+// ─── Message enum ─────────────────────────────────────────────────────────
+
+enum Msg {
+    Event(LogEvent),
+    Flush(oneshot::Sender<()>),
 }
 
-impl Default for HttpLoggerConfig {
-    fn default() -> Self {
-        Self {
-            url: String::new(),
-            batch_size: 100,
-            flush_interval_secs: 5,
-        }
+// ─── HttpLoggerConfig ─────────────────────────────────────────────────────
+
+/// Configuration for `HttpLogger`.
+pub struct HttpLoggerConfig {
+    /// Webhook endpoint URLs.
+    pub targets: Vec<String>,
+    /// Event types to deliver. Empty = subscribe to all events.
+    pub subscribed_events: HashSet<String>,
+    /// Shared HMAC secret. Empty = no signing.
+    pub secret: String,
+    /// Maximum concurrent delivery tasks (Semaphore permits). Default: 64.
+    pub max_concurrency: usize,
+    /// HTTP client shared across all delivery tasks (clone is O(1)).
+    pub http_client: reqwest::Client,
+}
+
+impl std::fmt::Debug for HttpLoggerConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("HttpLoggerConfig")
+            .field("targets", &self.targets)
+            .field("subscribed_events", &self.subscribed_events)
+            .field("secret", &"[REDACTED]")
+            .field("max_concurrency", &self.max_concurrency)
+            .finish()
     }
 }
 
-/// HTTP webhook log backend (stub — not yet implemented).
-#[derive(Clone)]
+// ─── HttpLogger ───────────────────────────────────────────────────────────
+
+/// Webhook event delivery backend. Clone is O(1) — only the channel sender
+/// is cloned.
 pub struct HttpLogger {
-    #[allow(dead_code)]
-    config: HttpLoggerConfig,
+    tx: UnboundedSender<Msg>,
+    subscribed_events: Arc<HashSet<String>>,
 }
 
 impl HttpLogger {
-    /// Create an `HttpLogger`.  Currently a no-op; implement the background
-    /// task described in the module doc when ready.
-    #[allow(dead_code)]
+    /// Create an `HttpLogger` and spawn the background delivery loop.
     pub fn new(config: HttpLoggerConfig) -> Self {
-        Self { config }
+        let HttpLoggerConfig {
+            targets,
+            subscribed_events,
+            secret,
+            max_concurrency,
+            http_client,
+        } = config;
+
+        let targets = Arc::new(targets);
+        let subscribed_events = Arc::new(subscribed_events);
+        let secret: Arc<str> = Arc::from(secret.as_str());
+        let pending = Arc::new(AtomicUsize::new(0));
+        let delivery_semaphore = Arc::new(Semaphore::new(max_concurrency.max(1)));
+
+        let (tx, mut rx) = mpsc::unbounded_channel::<Msg>();
+
+        // ── Background receiver task ──────────────────────────────────────
+        let targets_bg = targets.clone();
+        let subscribed_events_bg = subscribed_events.clone();
+        let secret_bg = secret.clone();
+        let http_client_bg = http_client.clone();
+        let pending_bg = pending.clone();
+        let sem = delivery_semaphore.clone();
+
+        tokio::spawn(async move {
+            while let Some(msg) = rx.recv().await {
+                match msg {
+                    Msg::Event(event) => {
+                        if !subscribed_events_bg.is_empty()
+                            && !subscribed_events_bg.contains(&event.event)
+                        {
+                            continue;
+                        }
+
+                        let payload = build_payload(&event);
+                        let body_bytes =
+                            bytes::Bytes::from(serde_json::to_string(&payload).unwrap_or_default());
+                        let event_name = event.event.clone();
+
+                        pending_bg.fetch_add(1, Ordering::Relaxed);
+
+                        let sem = sem.clone();
+                        let targets = targets_bg.clone();
+                        let secret = secret_bg.clone();
+                        let client = http_client_bg.clone();
+                        let pending = pending_bg.clone();
+
+                        tokio::spawn(async move {
+                            // Acquire inside spawn so the receiver loop
+                            // is never blocked — Msg::Flush is always
+                            // processed promptly.
+                            let _permit = sem.acquire_owned().await;
+                            let futs: Vec<_> = targets
+                                .iter()
+                                .map(|url| {
+                                    deliver_with_retry(
+                                        &client,
+                                        url,
+                                        body_bytes.clone(),
+                                        &secret,
+                                        &event_name,
+                                    )
+                                })
+                                .collect();
+                            futures::future::join_all(futs).await;
+                            pending.fetch_sub(1, Ordering::Relaxed);
+                        });
+                    }
+
+                    Msg::Flush(reply) => {
+                        // Wait for all in-flight deliveries with a timeout.
+                        let deadline = tokio::time::Instant::now() + Duration::from_secs(30);
+                        loop {
+                            let n = pending_bg.load(Ordering::Relaxed);
+                            if n == 0 {
+                                break;
+                            }
+                            if tokio::time::Instant::now() > deadline {
+                                tracing::warn!(
+                                    pending = n,
+                                    "webhook: flush timed out, {} deliveries still in-flight",
+                                    n
+                                );
+                                break;
+                            }
+                            tokio::time::sleep(Duration::from_millis(100)).await;
+                        }
+                        let _ = reply.send(());
+                    }
+                }
+            }
+        });
+
+        Self {
+            tx,
+            subscribed_events: subscribed_events.clone(),
+        }
     }
 }
 
 #[async_trait]
 impl Logger for HttpLogger {
-    async fn log(&self, _event: LogEvent) {
-        // TODO: send to internal channel; background task batches + POSTs.
-        // Example batch payload:
-        // POST config.url
-        // Content-Type: application/json
-        // Body: { "events": [ <LogEvent>, ... ] }
+    /// Non-blocking enqueue. Filters subscribed events BEFORE `tx.send()`
+    /// to avoid wasting channel capacity.
+    ///
+    /// `#[async_trait]` requires `async fn` — the function body contains
+    /// no `.await` (same pattern as `FileLogger::log`).
+    async fn log(&self, event: LogEvent) {
+        // ── Pre-send filter ──────────────────────────────────────────────
+        // Filter BEFORE enqueue — avoids wasting channel capacity.
+        if !self.subscribed_events.is_empty() && !self.subscribed_events.contains(&event.event) {
+            return;
+        }
+
+        if self.tx.send(Msg::Event(event)).is_err() {
+            tracing::error!("webhook: background task is gone, dropping event");
+        }
     }
 
     async fn flush(&self) {
-        // TODO: drain the buffer and send the final batch.
+        let (tx, rx) = oneshot::channel();
+        if self.tx.send(Msg::Flush(tx)).is_ok() {
+            let _ = rx.await;
+        }
     }
 
     fn name(&self) -> &'static str {
-        "http"
+        "webhook"
     }
 }
+
+// ─── Helpers ──────────────────────────────────────────────────────────────
+
+/// Build the JSON payload for a webhook POST.
+fn build_payload(event: &LogEvent) -> serde_json::Value {
+    let mut payload = serde_json::json!({
+        "event": event.event,
+        "timestamp": event.timestamp.to_rfc3339(),
+    });
+    if let Some(obj) = payload.as_object_mut() {
+        for (k, v) in &event.fields {
+            obj.insert(k.clone(), v.clone());
+        }
+    }
+    payload
+}
+
+/// HMAC-SHA256 sign the raw body bytes. Returns e.g. `"sha256=abcdef..."`.
+fn sign_payload(secret: &str, body: &[u8]) -> String {
+    use hmac::{Hmac, Mac};
+    use sha2::Sha256;
+
+    type HmacSha256 = Hmac<Sha256>;
+    let mut mac =
+        HmacSha256::new_from_slice(secret.as_bytes()).expect("HMAC can take key of any size");
+    mac.update(body);
+    let result = mac.finalize();
+    format!("sha256={}", hex::encode(result.into_bytes()))
+}
+
+/// Extract host portion from a URL for safe logging.
+fn redact_url(url: &str) -> &str {
+    // Strip scheme
+    let s = url
+        .strip_prefix("https://")
+        .or_else(|| url.strip_prefix("http://"))
+        .unwrap_or(url);
+    // Strip path / query / fragment
+    s.split('/').next().unwrap_or(s)
+}
+
+/// Deliver a single event to a single webhook endpoint, with retry.
+async fn deliver_with_retry(
+    client: &reqwest::Client,
+    url: &str,
+    body: bytes::Bytes,
+    secret: &str,
+    event_name: &str,
+) {
+    let delivery_id = uuid::Uuid::new_v4().to_string();
+    let host = redact_url(url);
+
+    for attempt in 0..=3 {
+        if attempt > 0 {
+            let delay = Duration::from_secs(1 << (attempt - 1)); // 1s, 2s, 4s
+            tokio::time::sleep(delay).await;
+        }
+
+        let mut req = client
+            .post(url)
+            .header("Content-Type", "application/json")
+            .header("X-Cube-Event", event_name)
+            .header("X-Cube-Delivery", delivery_id.as_str())
+            .header("User-Agent", "CubeAPI-Webhook/1.0")
+            .body(body.clone());
+
+        if !secret.is_empty() {
+            let sig = sign_payload(secret, &body);
+            req = req.header("X-Cube-Signature", sig);
+        }
+
+        match req.send().await {
+            Ok(resp) if resp.status().is_success() => {
+                return;
+            }
+            Ok(resp) if resp.status().is_client_error() => {
+                tracing::warn!(
+                    url = %host,
+                    delivery_id = %delivery_id,
+                    status = %resp.status(),
+                    event = %event_name,
+                    "webhook delivery: client error, not retrying"
+                );
+                return;
+            }
+            Ok(resp) => {
+                tracing::warn!(
+                    url = %host,
+                    delivery_id = %delivery_id,
+                    status = %resp.status(),
+                    event = %event_name,
+                    attempt = attempt + 1,
+                    "webhook delivery: server error, will retry"
+                );
+            }
+            Err(e) => {
+                tracing::warn!(
+                    url = %host,
+                    delivery_id = %delivery_id,
+                    error = %e,
+                    event = %event_name,
+                    attempt = attempt + 1,
+                    "webhook delivery: connection error, will retry"
+                );
+            }
+        }
+    }
+
+    tracing::error!(
+        url = %host,
+        delivery_id = %delivery_id,
+        event = %event_name,
+        "webhook delivery failed after 4 attempts"
+    );
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────
+

--- a/CubeAPI/src/logging/mod.rs
+++ b/CubeAPI/src/logging/mod.rs
@@ -20,7 +20,7 @@
 //! | `multi`        | Fan-out to N backends         | ✅ Ready |
 //! | `filtered`     | Min-level gate wrapper        | ✅ Ready |
 //! | `otlp`         | OpenTelemetry OTLP exporter   | 🔲 Stub  |
-//! | `http`         | Generic HTTP webhook          | 🔲 Stub  |
+//! | `http`         | Webhook event notification    | ✅ Ready |
 
 pub mod file;
 pub mod filtered;

--- a/CubeAPI/src/main.rs
+++ b/CubeAPI/src/main.rs
@@ -236,15 +236,74 @@ async fn async_main(cfg: config::ServerConfig, debug: bool) -> anyhow::Result<()
 
     let file_logger = FileLogger::new(cfg.log_dir.clone(), cfg.log_prefix.clone()).await?;
 
-    // FilteredLogger gates by level → MultiLogger fans out to file (+ future backends)
-    let logger: logging::ArcLogger = arc(FilteredLogger::new(
-        arc(
-            MultiLogger::new().add(arc(file_logger)), // Uncomment to add more backends:
-                                                      // .add(arc(logging::http::HttpLogger::new(Default::default())))
-                                                      // .add(arc(logging::otlp::OtlpLogger::new()))
-        ),
-        min_level,
-    ));
+    let mut multi = MultiLogger::new().add(arc(file_logger));
+
+    // ── Conditional: Webhook (HttpLogger) ───────────────────────────────
+    if !cfg.webhook_urls.trim().is_empty() {
+        use logging::http::{HttpLogger, HttpLoggerConfig};
+        use std::collections::HashSet;
+
+        let targets: Vec<String> = cfg
+            .webhook_urls
+            .split(',')
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty())
+            .collect();
+
+        if !targets.is_empty() {
+            // HTTPS warning for non-loopback plaintext URLs
+            for url in &targets {
+                let host = url
+                    .strip_prefix("https://")
+                    .or_else(|| url.strip_prefix("http://"))
+                    .unwrap_or(url)
+                    .split('/')
+                    .next()
+                    .unwrap_or(url);
+                let is_loopback = host == "localhost"
+                    || host == "127.0.0.1"
+                    || host == "::1"
+                    || host.starts_with("[::1]");
+                if !url.starts_with("https://") && !is_loopback {
+                    tracing::warn!("webhook URL uses HTTP (not HTTPS): {host}", host = host);
+                }
+            }
+
+            let subscribed_events: HashSet<String> = cfg
+                .webhook_events
+                .split(',')
+                .map(|s| s.trim().to_string())
+                .filter(|s| !s.is_empty())
+                .collect();
+
+            if subscribed_events.is_empty() {
+                tracing::info!("webhook: no event filter configured, subscribing to all events");
+            }
+
+            let target_count = targets.len();
+
+            let webhook_config = HttpLoggerConfig {
+                targets,
+                subscribed_events,
+                secret: cfg.webhook_secret.clone(),
+                max_concurrency: 64,
+                http_client: reqwest::Client::builder()
+                    .timeout(std::time::Duration::from_secs(30))
+                    .build()
+                    .expect("failed to build webhook HTTP client"),
+            };
+            multi = multi.add(arc(HttpLogger::new(webhook_config)));
+            tracing::info!(
+                webhook_target_count = target_count,
+                webhook_events = %cfg.webhook_events,
+                signing = !cfg.webhook_secret.is_empty(),
+                "webhook logger enabled"
+            );
+        }
+    }
+
+    // FilteredLogger gates by level → MultiLogger fans out
+    let logger: logging::ArcLogger = arc(FilteredLogger::new(arc(multi), min_level));
 
     tracing::info!(
         log_dir = %cfg.log_dir,

--- a/CubeAPI/src/main.rs
+++ b/CubeAPI/src/main.rs
@@ -253,13 +253,7 @@ async fn async_main(cfg: config::ServerConfig, debug: bool) -> anyhow::Result<()
         if !targets.is_empty() {
             // HTTPS warning for non-loopback plaintext URLs
             for url in &targets {
-                let host = url
-                    .strip_prefix("https://")
-                    .or_else(|| url.strip_prefix("http://"))
-                    .unwrap_or(url)
-                    .split('/')
-                    .next()
-                    .unwrap_or(url);
+                let host = logging::http::redact_url(url);
                 let is_loopback = host == "localhost"
                     || host == "127.0.0.1"
                     || host == "::1"

--- a/CubeAPI/src/main.rs
+++ b/CubeAPI/src/main.rs
@@ -115,6 +115,24 @@ struct Cli {
     #[arg(long, value_name = "DOMAIN")]
     sandbox_domain: Option<String>,
 
+    /// Comma-separated webhook endpoint URLs (default: "" = disabled).
+    ///
+    /// Overrides the CUBE_WEBHOOK_URLS environment variable.
+    #[arg(long, value_name = "URLS")]
+    webhook_urls: Option<String>,
+
+    /// Comma-separated webhook event types to subscribe to.
+    ///
+    /// Overrides the CUBE_WEBHOOK_EVENTS environment variable.
+    #[arg(long, value_name = "EVENTS")]
+    webhook_events: Option<String>,
+
+    /// Shared secret for HMAC-SHA256 webhook signing.
+    ///
+    /// Overrides the CUBE_WEBHOOK_SECRET environment variable.
+    #[arg(long, value_name = "SECRET")]
+    webhook_secret: Option<String>,
+
     /// Export the current OpenAPI spec to a YAML file and exit.
     #[arg(long, value_name = "PATH")]
     export_openapi: Option<String>,
@@ -166,6 +184,15 @@ fn main() -> anyhow::Result<()> {
     }
     if let Some(v) = cli.sandbox_domain {
         cfg.sandbox_domain = v;
+    }
+    if let Some(v) = cli.webhook_urls {
+        cfg.webhook_urls = v;
+    }
+    if let Some(v) = cli.webhook_events {
+        cfg.webhook_events = v;
+    }
+    if let Some(v) = cli.webhook_secret {
+        cfg.webhook_secret = v;
     }
 
     // ── Tracing (stdout) ───────────────────────────────────────────────────

--- a/docs/guide/webhooks.md
+++ b/docs/guide/webhooks.md
@@ -1,0 +1,272 @@
+# CubeSandbox Webhook Event Notifications
+
+CubeAPI can send webhook callbacks to user-configured HTTP endpoints when
+sandbox lifecycle events occur. Use cases include real-time monitoring,
+automated workflows, and audit trails.
+
+## Development Verification (no CubeMaster, ~5 minutes)
+
+For contributors or reviewers validating the webhook implementation without
+a running CubeSandbox cluster.
+
+### 1. Core logic — unit & integration tests
+
+```bash
+cd CubeAPI
+cargo test -- logging::http
+```
+
+10 tests covering: payload construction, HMAC signing, HTTP delivery, event
+filtering, retry behavior, and shutdown coordination. All use mock HTTP
+servers — no external dependencies.
+
+### 2. Receiver — standalone verification
+
+```bash
+# Terminal 1: Start the receiver
+cd examples/webhook-receiver
+WEBHOOK_SECRET=test-secret cargo run
+
+# Terminal 2: Simulate CubeAPI sending a webhook
+BODY='{"event":"sandbox.created","timestamp":"2026-07-20T12:00:00Z","sandbox_id":"sb-abc"}'
+SIG="sha256=$(echo -n "$BODY" | openssl dgst -sha256 -hmac "test-secret" | cut -d' ' -f2)"
+curl -X POST http://127.0.0.1:9090/webhook \
+  -H "Content-Type: application/json" \
+  -H "X-Cube-Event: sandbox.created" \
+  -H "X-Cube-Signature: $SIG" \
+  -d "$BODY"
+# Terminal 1 should print the received webhook with HMAC verification OK
+```
+
+### 3. Code style
+
+```bash
+cd CubeAPI
+cargo fmt --check
+cargo clippy -- -D warnings 2>&1 | grep -E "http\.rs|main\.rs|handlers/sandboxes\.rs" || true
+```
+
+## Production Configuration (requires CubeMaster)
+
+Once CubeAPI has a working CubeMaster backend, configure webhooks via
+environment variables or CLI flags.
+
+### Environment variables
+
+```bash
+export CUBE_WEBHOOK_URLS="https://your-server.com/webhook"
+export CUBE_WEBHOOK_EVENTS="sandbox.created,sandbox.deleted,sandbox.paused,sandbox.resumed"
+export CUBE_WEBHOOK_SECRET="your-hmac-secret-key"
+```
+
+### CLI flags
+
+```bash
+cube-api --webhook-urls "https://your-server.com/webhook" \
+         --webhook-events "sandbox.created,sandbox.deleted" \
+         --webhook-secret "your-hmac-secret-key"
+```
+
+CLI flags take priority over environment variables. Multiple endpoints can be
+specified as a comma-separated list in `CUBE_WEBHOOK_URLS`.
+
+### Full E2E test
+
+```bash
+# Terminal 1: start the receiver
+cd examples/webhook-receiver
+WEBHOOK_SECRET=test-secret cargo run
+
+# Terminal 2: start CubeAPI with webhook config
+cd CubeAPI
+CUBE_WEBHOOK_URLS=http://127.0.0.1:9090/webhook \
+CUBE_WEBHOOK_SECRET=test-secret \
+cargo run
+
+# Terminal 3: create a sandbox to trigger sandbox.created
+curl -X POST http://localhost:3000/sandboxes \
+  -H "Content-Type: application/json" \
+  -d '{"templateID": "your-template-id"}'
+# Terminal 1 should print the received webhook
+```
+
+## Configuration Reference
+
+| Env Variable | CLI Flag | Default | Description |
+|-------------|----------|---------|-------------|
+| `CUBE_WEBHOOK_URLS` | `--webhook-urls` | `""` (disabled) | Comma-separated webhook endpoint URLs |
+| `CUBE_WEBHOOK_EVENTS` | `--webhook-events` | 4 lifecycle events | Comma-separated event types to subscribe to |
+| `CUBE_WEBHOOK_SECRET` | `--webhook-secret` | `""` (no signing) | Shared HMAC-SHA256 secret key |
+
+When `CUBE_WEBHOOK_URLS` is empty, webhook delivery is completely disabled
+with zero performance overhead.
+
+## Supported Events
+
+| Event | Trigger | Fields |
+|-------|---------|--------|
+| `sandbox.created` | Sandbox created | `sandbox_id`, `template_id` |
+| `sandbox.deleted` | Sandbox deleted | `sandbox_id` |
+| `sandbox.paused` | Sandbox paused | `sandbox_id` |
+| `sandbox.resumed` | Sandbox resumed | `sandbox_id`, `template_id` |
+
+## Payload Format
+
+### HTTP Request
+
+```
+POST <webhook-url>
+Content-Type: application/json
+X-Cube-Event: sandbox.created
+X-Cube-Delivery: 550e8400-e29b-41d4-a716-446655440000
+X-Cube-Signature: sha256=d5e9f... (only when CUBE_WEBHOOK_SECRET is set)
+User-Agent: CubeAPI-Webhook/1.0
+```
+
+### JSON Body
+
+```json
+{
+  "event": "sandbox.created",
+  "timestamp": "2026-07-20T12:00:00.123Z",
+  "sandbox_id": "sb-abc123",
+  "template_id": "tpl-xyz"
+}
+```
+
+Fields:
+- `event`: Event name
+- `timestamp`: Event time (RFC 3339)
+- `sandbox_id`: Unique sandbox identifier
+- `template_id`: Template identifier (present in `created` and `resumed` events)
+
+## Security
+
+### HMAC-SHA256 Signature Verification
+
+CubeAPI signs the raw HTTP body bytes using HMAC-SHA256 and passes the
+signature via the `X-Cube-Signature` header.
+
+Signature format: `sha256=<lowercase hex>`
+
+**Verification steps:**
+
+1. Obtain the raw HTTP body bytes (do NOT deserialize and re-serialize JSON —
+   JSON serialization is not deterministic)
+2. Compute `HMAC-SHA256(secret, raw_body_bytes)`
+3. Compare with the `X-Cube-Signature` header value (constant-time comparison
+   recommended for production)
+
+**Rust verification example:**
+
+```rust
+use hmac::{Hmac, Mac};
+use sha2::Sha256;
+
+type HmacSha256 = Hmac<Sha256>;
+
+fn verify_signature(secret: &str, body: &[u8], signature: &str) -> bool {
+    let mut mac = HmacSha256::new_from_slice(secret.as_bytes())
+        .expect("HMAC can take key of any size");
+    mac.update(body);
+    let expected = format!("sha256={}", hex::encode(mac.finalize().into_bytes()));
+    // Use constant-time comparison in production
+    expected == signature
+}
+```
+
+**Python verification example:**
+
+```python
+import hmac
+import hashlib
+
+def verify_signature(secret: str, body: bytes, signature: str) -> bool:
+    expected = "sha256=" + hmac.new(
+        secret.encode(), body, hashlib.sha256
+    ).hexdigest()
+    return hmac.compare_digest(expected, signature)
+```
+
+### Idempotency
+
+Each delivery generates a unique `X-Cube-Delivery` UUID. Receivers can use
+this ID for deduplication to prevent processing the same event more than once.
+
+## Retry Strategy
+
+| Condition | Behavior |
+|-----------|----------|
+| HTTP 2xx | Success |
+| HTTP 4xx | No retry (client error is not recoverable) |
+| HTTP 5xx / connection error | Exponential backoff retry, up to 3 times |
+
+Backoff: 1s → 2s → 4s. Maximum 4 HTTP attempts (1 initial + 3 retries).
+
+## WeCom Bot Integration
+
+The CubeAPI Webhook payload format differs from the WeCom bot message format
+(`msgtype`). Use the example receiver as an adapter:
+
+```
+CubeAPI → examples/webhook-receiver → WeCom bot
+```
+
+**Steps:**
+
+1. Add a bot in your WeCom group and get the webhook URL
+   (format: `https://qyapi.weixin.qq.com/cgi-bin/webhook/send?key=xxx`)
+
+2. Start the receiver with WeCom forwarding:
+```bash
+cd examples/webhook-receiver
+WEBHOOK_SECRET=test-secret \
+WECOM_WEBHOOK_URL=https://qyapi.weixin.qq.com/cgi-bin/webhook/send?key=xxx \
+cargo run
+```
+
+3. Configure CubeAPI to point to the receiver:
+```bash
+cd CubeAPI
+CUBE_WEBHOOK_URLS=http://127.0.0.1:9090/webhook \
+CUBE_WEBHOOK_SECRET=test-secret \
+cargo run
+```
+
+Sandbox events will be delivered as text messages to the WeCom group.
+
+### Generic HTTP Alerts
+
+Any alerting platform that accepts HTTP POST can receive CubeAPI Webhook
+events — the payload is standard JSON with no special SDK required.
+
+A minimal shell-based receiver that logs events and sends alerts:
+
+```bash
+#!/bin/bash
+# minimal-webhook-receiver.sh — listen on :8080, print events, forward to
+# your alerting platform via curl.
+#
+# Usage: ./minimal-webhook-receiver.sh
+
+while true; do
+  echo -e "HTTP/1.1 200 OK\r\n" | nc -l -p 8080 -q 1 | while read -r line; do
+    echo "$line"
+  done
+done
+```
+
+For production use, any HTTP server framework (axum, Express, Flask, nginx)
+can receive the POST, parse the JSON body, and route by `event` type to the
+appropriate alert channel.
+
+## Troubleshooting
+
+| Symptom | Possible Cause | Check |
+|---------|---------------|-------|
+| No webhook received | Empty URL config | Verify `CUBE_WEBHOOK_URLS` or `--webhook-urls` |
+| Signature verification fails | Key mismatch | Ensure sender and receiver use the same `CUBE_WEBHOOK_SECRET` |
+| Signature verification fails | Body modified | Verify against raw HTTP body bytes, not re-serialized JSON |
+| Duplicate events received | Normal retry | Deduplicate using `X-Cube-Delivery` UUID |
+| Event not triggered | Event name typo | Check `CUBE_WEBHOOK_EVENTS` for correct event names |
+| HTTPS certificate error | Self-signed cert | Use HTTP for internal testing, or configure CA certificates |

--- a/docs/zh/guide/webhooks.md
+++ b/docs/zh/guide/webhooks.md
@@ -1,0 +1,254 @@
+# CubeSandbox Webhook 事件通知
+
+CubeAPI 支持在沙箱生命周期事件发生时向用户配置的 HTTP 端点发送 Webhook 回调。可用于实时监控、自动化流程、审计追踪等场景。
+
+## 开发验证（不需要 CubeMaster，约 5 分钟）
+
+适用于贡献者或 reviewer 验证 Webhook 实现，无需运行 CubeSandbox 集群。
+
+### 1. 核心逻辑 — 单元/集成测试
+
+```bash
+cd CubeAPI
+cargo test -- logging::http
+```
+
+10 个测试覆盖：payload 构建、HMAC 签名、HTTP 投递、事件过滤、重试、shutdown。全部使用 mock HTTP server，无需外部依赖。
+
+### 2. 接收端 — 独立验证
+
+```bash
+# 终端 1: 启动接收端
+cd examples/webhook-receiver
+WEBHOOK_SECRET=test-secret cargo run
+
+# 终端 2: 用 curl 模拟 CubeAPI 发送 webhook
+BODY='{"event":"sandbox.created","timestamp":"2026-07-20T12:00:00Z","sandbox_id":"sb-abc"}'
+SIG="sha256=$(echo -n "$BODY" | openssl dgst -sha256 -hmac "test-secret" | cut -d' ' -f2)"
+curl -X POST http://127.0.0.1:9090/webhook \
+  -H "Content-Type: application/json" \
+  -H "X-Cube-Event: sandbox.created" \
+  -H "X-Cube-Signature: $SIG" \
+  -d "$BODY"
+# 终端 1 应打印接收到的 webhook 内容，签名验证通过
+```
+
+### 3. 代码规范检查
+
+```bash
+cd CubeAPI
+cargo fmt --check
+cargo clippy -- -D warnings 2>&1 | grep -E "http\.rs|main\.rs|handlers/sandboxes\.rs" || true
+```
+
+## 生产配置（需要 CubeMaster）
+
+CubeAPI 连接 CubeMaster 后，通过环境变量或 CLI 参数配置 Webhook。
+
+### 环境变量
+
+```bash
+export CUBE_WEBHOOK_URLS="https://your-server.com/webhook"
+export CUBE_WEBHOOK_EVENTS="sandbox.created,sandbox.deleted,sandbox.paused,sandbox.resumed"
+export CUBE_WEBHOOK_SECRET="your-hmac-secret-key"
+```
+
+### CLI 参数
+
+```bash
+cube-api --webhook-urls "https://your-server.com/webhook" \
+         --webhook-events "sandbox.created,sandbox.deleted" \
+         --webhook-secret "your-hmac-secret-key"
+```
+
+CLI 参数优先级高于环境变量。Webhook URL 支持逗号分隔配置多个端点。
+
+### 完整 E2E 测试
+
+```bash
+# 终端 1: 启动接收端
+cd examples/webhook-receiver
+WEBHOOK_SECRET=test-secret cargo run
+
+# 终端 2: 启动 CubeAPI（配置 webhook）
+cd CubeAPI
+CUBE_WEBHOOK_URLS=http://127.0.0.1:9090/webhook \
+CUBE_WEBHOOK_SECRET=test-secret \
+cargo run
+
+# 终端 3: 创建沙箱触发 sandbox.created 事件
+curl -X POST http://localhost:3000/sandboxes \
+  -H "Content-Type: application/json" \
+  -d '{"templateID": "your-template-id"}'
+# 终端 1 应收到 webhook 回调
+```
+
+## 配置参考
+
+| 环境变量              | CLI 参数           | 默认值           | 说明                        |
+| --------------------- | ------------------ | ---------------- | --------------------------- |
+| `CUBE_WEBHOOK_URLS`   | `--webhook-urls`   | `""` (禁用)      | 逗号分隔的 Webhook 端点 URL |
+| `CUBE_WEBHOOK_EVENTS` | `--webhook-events` | 4 个生命周期事件 | 逗号分隔的订阅事件类型      |
+| `CUBE_WEBHOOK_SECRET` | `--webhook-secret` | `""` (不签名)    | HMAC-SHA256 共享密钥        |
+
+`CUBE_WEBHOOK_URLS` 为空时，Webhook 功能完全禁用，无任何性能开销。
+
+## 支持的事件
+
+| 事件名            | 触发时机     | 携带字段                    |
+| ----------------- | ------------ | --------------------------- |
+| `sandbox.created` | 沙箱创建成功 | `sandbox_id`, `template_id` |
+| `sandbox.deleted` | 沙箱删除成功 | `sandbox_id`                |
+| `sandbox.paused`  | 沙箱暂停成功 | `sandbox_id`                |
+| `sandbox.resumed` | 沙箱恢复成功 | `sandbox_id`, `template_id` |
+
+## Payload 格式
+
+### HTTP 请求
+
+```
+POST <webhook-url>
+Content-Type: application/json
+X-Cube-Event: sandbox.created
+X-Cube-Delivery: 550e8400-e29b-41d4-a716-446655440000
+X-Cube-Signature: sha256=d5e9f... (仅当配置了 CUBE_WEBHOOK_SECRET)
+User-Agent: CubeAPI-Webhook/1.0
+```
+
+### JSON Body
+
+```json
+{
+  "event": "sandbox.created",
+  "timestamp": "2026-07-20T12:00:00.123Z",
+  "sandbox_id": "sb-abc123",
+  "template_id": "tpl-xyz"
+}
+```
+
+字段说明：
+- `event`: 事件名称
+- `timestamp`: 事件发生时间 (RFC 3339)
+- `sandbox_id`: 沙箱唯一标识
+- `template_id`: 模板标识 (`created` 和 `resumed` 事件中均携带)
+
+## 安全
+
+### HMAC-SHA256 签名验证
+
+CubeAPI 对 HTTP Body 的原始字节计算 HMAC-SHA256 签名，通过 `X-Cube-Signature` Header 传递。
+
+签名格式: `sha256=<lowercase hex>`
+
+**验证步骤:**
+
+1. 获取 HTTP Body 的原始字节 (注意: 不要先解析 JSON 再重新序列化 — JSON 序列化不是确定性的)
+2. 使用共享密钥计算 `HMAC-SHA256(secret, raw_body_bytes)`
+3. 与 `X-Cube-Signature` Header 的值比对 (安全比较，防时序攻击)
+
+**Rust 验证示例:**
+
+```rust
+use hmac::{Hmac, Mac};
+use sha2::Sha256;
+
+type HmacSha256 = Hmac<Sha256>;
+
+fn verify_signature(secret: &str, body: &[u8], signature: &str) -> bool {
+    let mut mac = HmacSha256::new_from_slice(secret.as_bytes())
+        .expect("HMAC can take key of any size");
+    mac.update(body);
+    let expected = format!("sha256={}", hex::encode(mac.finalize().into_bytes()));
+    // 生产环境应使用 constant-time comparison
+    expected == signature
+}
+```
+
+**Python 验证示例:**
+
+```python
+import hmac
+import hashlib
+
+def verify_signature(secret: str, body: bytes, signature: str) -> bool:
+    expected = "sha256=" + hmac.new(
+        secret.encode(), body, hashlib.sha256
+    ).hexdigest()
+    return hmac.compare_digest(expected, signature)
+```
+
+### 幂等性
+
+每次投递生成唯一的 `X-Cube-Delivery` UUID。接收端可以使用此 ID 进行去重，防止重复处理同一事件。
+
+## 重试策略
+
+| 条件 | 行为 |
+|------|------|
+| HTTP 2xx | 成功 |
+| HTTP 4xx | 不重试 (客户端错误无法修复) |
+| HTTP 5xx / 连接错误 | 指数退避重试，最多 3 次 |
+
+退避间隔: 1s → 2s → 4s。总最多 4 次 HTTP 请求 (initial + 3 retries)。
+
+## 对接企业微信机器人
+
+CubeAPI Webhook 的 Payload 格式与企业微信机器人要求的 `msgtype` 格式不同，不能直接将企微 URL 配置为 CubeAPI 的 Webhook 端点。需要通过接收器示例做适配转发：
+
+```
+CubeAPI → examples/webhook-receiver → 企业微信群机器人
+```
+
+**步骤:**
+
+1. 在企业微信群中添加机器人，获取 Webhook URL（格式: `https://qyapi.weixin.qq.com/cgi-bin/webhook/send?key=xxx`）
+
+2. 启动接收器并设置企微转发:
+```bash
+cd examples/webhook-receiver
+WEBHOOK_SECRET=test-secret \
+WECOM_WEBHOOK_URL=https://qyapi.weixin.qq.com/cgi-bin/webhook/send?key=xxx \
+cargo run
+```
+
+3. 配置 CubeAPI 指向接收器:
+```bash
+cd CubeAPI
+CUBE_WEBHOOK_URLS=http://127.0.0.1:9090/webhook \
+CUBE_WEBHOOK_SECRET=test-secret \
+cargo run
+```
+
+沙箱事件将自动以文本消息推送到企业微信群。
+
+### 通用 HTTP 告警
+
+任何支持 HTTP POST 的告警平台都可以直接接收 CubeAPI Webhook 事件 — payload
+为标准 JSON，无需特殊 SDK。
+
+最简单的 shell 接收器：
+
+```bash
+#!/bin/bash
+# 监听 :8080，打印事件内容
+
+while true; do
+  echo -e "HTTP/1.1 200 OK\r\n" | nc -l -p 8080 -q 1 | while read -r line; do
+    echo "$line"
+  done
+done
+```
+
+生产环境中可以使用任何 HTTP 框架（axum、Express、Flask、nginx）接收 POST，
+解析 JSON body，按 `event` 字段路由到对应的告警通道。
+
+## 故障排查
+
+| 症状 | 可能原因 | 检查项 |
+|------|---------|--------|
+| Webhook 未收到事件 | URL 配置为空 | 检查 `CUBE_WEBHOOK_URLS` 或 `--webhook-urls` |
+| 签名验证失败 | 密钥不匹配 | 确认发送端和接收端使用相同的 `CUBE_WEBHOOK_SECRET` |
+| 签名验证失败 | Body 被修改 | 确保验证时使用的是原始 HTTP Body 字节 |
+| 接收端收到重复事件 | 正常重试 | 使用 `X-Cube-Delivery` UUID 去重 |
+| 事件未触发 | 事件名拼写错误 | 检查 `CUBE_WEBHOOK_EVENTS` 中的事件名是否正确 |
+| HTTPS 证书错误 | 自签名证书 | 使用 HTTP + 内网环境测试，或配置 CA 证书 |

--- a/examples/webhook-receiver/Cargo.toml
+++ b/examples/webhook-receiver/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "webhook-receiver"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+axum = "0.7"
+tokio = { version = "1", features = ["full"] }
+serde_json = "1"
+hmac = "0.12"
+sha2 = "0.10"
+hex = "0.4"
+reqwest = { version = "0.12", features = ["json", "rustls-tls"], default-features = false }

--- a/examples/webhook-receiver/README.md
+++ b/examples/webhook-receiver/README.md
@@ -1,0 +1,71 @@
+# Webhook Receiver Example
+
+用于接收和验证 CubeAPI Webhook 事件的示例 HTTP 服务。
+
+## 快速启动
+
+```bash
+cd examples/webhook-receiver
+
+# 不带签名验证
+cargo run
+
+# 带 HMAC 签名验证
+WEBHOOK_SECRET=test-secret cargo run
+```
+
+服务监听 `http://127.0.0.1:9090`。端口可通过 `PORT` 环境变量覆盖，监听地址可通过 `LISTEN` 覆盖。
+
+## 独立验证（不需要 CubeMaster）
+
+**终端 1** — 启动接收端：
+```bash
+cd examples/webhook-receiver
+WEBHOOK_SECRET=test-secret cargo run
+```
+
+**终端 2** — 模拟 CubeAPI 发送 Webhook：
+```bash
+# 计算签名
+BODY='{"event":"sandbox.created","timestamp":"2026-07-20T12:00:00.123Z","sandbox_id":"sb-abc123","template_id":"tpl-xyz"}'
+SIG="sha256=$(echo -n "$BODY" | openssl dgst -sha256 -hmac "test-secret" | cut -d' ' -f2)"
+
+# 发送 webhook（签名正确 → 终端 1 打印 body）
+curl -X POST http://127.0.0.1:9090/webhook \
+  -H "Content-Type: application/json" \
+  -H "X-Cube-Event: sandbox.created" \
+  -H "X-Cube-Delivery: $(uuidgen 2>/dev/null || echo test-001)" \
+  -H "X-Cube-Signature: $SIG" \
+  -d "$BODY"
+
+# 发送签名错误的请求（终端 1 应返回 401）
+curl -X POST http://127.0.0.1:9090/webhook \
+  -H "X-Cube-Signature: sha256=wrong" \
+  -d "$BODY"
+```
+
+## 验证 CubeAPI Webhook 投递（需要 CubeAPI）
+
+参考 `docs/guide/webhooks.md` 中的"本地验证"部分。
+
+## 环境变量
+
+| 变量 | 说明 | 默认 |
+|------|------|------|
+| `WEBHOOK_SECRET` | HMAC-SHA256 共享密钥 (空=不验证) | `""` |
+| `WECOM_WEBHOOK_URL` | 企业微信群机器人 Webhook URL (空=不转发) | `""` |
+| `PORT` | 监听端口 | `9090` |
+| `LISTEN` | 监听地址 | `127.0.0.1` |
+
+## 与 CubeAPI 集成
+
+1. 确保 CubeMaster 可达
+2. 启动接收端: `cd examples/webhook-receiver && WEBHOOK_SECRET=test-secret cargo run`
+3. 启动 CubeAPI:
+```bash
+cd CubeAPI
+CUBE_WEBHOOK_URLS=http://127.0.0.1:9090/webhook \
+CUBE_WEBHOOK_SECRET=test-secret \
+cargo run
+```
+4. 创建沙箱触发 `sandbox.created` 事件

--- a/examples/webhook-receiver/src/main.rs
+++ b/examples/webhook-receiver/src/main.rs
@@ -1,0 +1,117 @@
+// Webhook receiver — a minimal axum server that receives and validates
+// webhook POST requests from CubeAPI.
+//
+// Usage:
+//   WEBHOOK_SECRET=your-secret cargo run
+//
+// Default: 127.0.0.1:9090. Override: PORT=8080 LISTEN=0.0.0.0
+
+use axum::{routing::{get, post}, Router};
+use hmac::{Hmac, Mac};
+use sha2::Sha256;
+use std::env;
+
+type HmacSha256 = Hmac<Sha256>;
+
+#[tokio::main]
+async fn main() {
+    let secret = env::var("WEBHOOK_SECRET").unwrap_or_default();
+    let secret = std::sync::Arc::new(secret);
+    let listen = env::var("LISTEN").unwrap_or_else(|_| "127.0.0.1".to_string());
+    let port = env::var("PORT").unwrap_or_else(|_| "9090".to_string());
+    let addr = format!("{listen}:{port}");
+
+    let has_secret = !secret.is_empty();
+
+    let app = Router::new()
+        .route("/webhook", post(handle_webhook))
+        .route("/health", get(|| async { "ok" }))
+        .with_state(secret);
+
+    let listener = tokio::net::TcpListener::bind(&addr).await.unwrap();
+    println!("webhook-receiver listening on http://{addr}");
+    println!("  POST /webhook — receive webhook events");
+    println!("  GET  /health  — health check");
+    if has_secret {
+        println!("  HMAC verification: enabled");
+    }
+    axum::serve(listener, app).await.unwrap();
+}
+
+async fn handle_webhook(
+    axum::extract::State(secret): axum::extract::State<std::sync::Arc<String>>,
+    headers: axum::http::HeaderMap,
+    body: axum::body::Bytes,
+) -> (axum::http::StatusCode, String) {
+    // Verify HMAC signature FIRST (if configured)
+    if !secret.is_empty() {
+        if let Some(sig_header) = headers.get("X-Cube-Signature") {
+            let sig = sig_header.to_str().unwrap_or("");
+            let expected = sign_payload(&secret, &body);
+            if sig != expected {
+                println!("=== Webhook REJECTED (signature mismatch) ===");
+                return (
+                    axum::http::StatusCode::UNAUTHORIZED,
+                    "signature mismatch".to_string(),
+                );
+            }
+        } else {
+            println!("=== Webhook REJECTED (missing X-Cube-Signature) ===");
+            return (
+                axum::http::StatusCode::UNAUTHORIZED,
+                "X-Cube-Signature header missing".to_string(),
+            );
+        }
+    }
+
+    // Print only after validation passes
+    println!("=== Webhook Received ===");
+    for (name, value) in headers.iter() {
+        if name.as_str().starts_with("x-cube-") || name.as_str() == "content-type" {
+            println!("  {}: {}", name, value.to_str().unwrap_or("<non-utf8>"));
+        }
+    }
+
+    let body_str = String::from_utf8_lossy(&body);
+    if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(&body_str) {
+        println!("{}", serde_json::to_string_pretty(&parsed).unwrap());
+    } else {
+        println!("{}", body_str);
+    }
+    println!("========================\n");
+
+    forward_to_wecom(&body_str).await;
+
+    (axum::http::StatusCode::OK, "ok".to_string())
+}
+
+/// Forward to WeCom bot if WECOM_WEBHOOK_URL is set.
+async fn forward_to_wecom(body_str: &str) {
+    let wecom_url = match std::env::var("WECOM_WEBHOOK_URL") {
+        Ok(url) if !url.is_empty() => url,
+        _ => return,
+    };
+    let parsed = match serde_json::from_str::<serde_json::Value>(body_str) {
+        Ok(v) => v,
+        Err(_) => return,
+    };
+    let content = format!(
+        "【CubeSandbox】{}\nSandbox: {}\nTemplate: {}\nTime: {}",
+        parsed["event"].as_str().unwrap_or("unknown"),
+        parsed["sandbox_id"].as_str().unwrap_or("?"),
+        parsed["template_id"].as_str().unwrap_or("N/A"),
+        parsed["timestamp"].as_str().unwrap_or("?")
+    );
+    let _ = reqwest::Client::new()
+        .post(&wecom_url)
+        .json(&serde_json::json!({"msgtype": "text", "text": {"content": content}}))
+        .send()
+        .await;
+}
+
+fn sign_payload(secret: &str, body: &[u8]) -> String {
+    let mut mac = HmacSha256::new_from_slice(secret.as_bytes())
+        .expect("HMAC can take key of any size");
+    mac.update(body);
+    format!("sha256={}", hex::encode(mac.finalize().into_bytes()))
+}

--- a/examples/webhook-receiver/src/main.rs
+++ b/examples/webhook-receiver/src/main.rs
@@ -45,21 +45,48 @@ async fn handle_webhook(
 ) -> (axum::http::StatusCode, String) {
     // Verify HMAC signature FIRST (if configured)
     if !secret.is_empty() {
-        if let Some(sig_header) = headers.get("X-Cube-Signature") {
-            let sig = sig_header.to_str().unwrap_or("");
-            let expected = sign_payload(&secret, &body);
-            if sig != expected {
-                println!("=== Webhook REJECTED (signature mismatch) ===");
+        let sig_header = match headers.get("X-Cube-Signature").and_then(|v| v.to_str().ok()) {
+            Some(v) => v,
+            None => {
+                println!("=== Webhook REJECTED (missing X-Cube-Signature) ===");
                 return (
                     axum::http::StatusCode::UNAUTHORIZED,
-                    "signature mismatch".to_string(),
+                    "X-Cube-Signature header missing".to_string(),
                 );
             }
-        } else {
-            println!("=== Webhook REJECTED (missing X-Cube-Signature) ===");
+        };
+
+        let sig_hex = match sig_header.strip_prefix("sha256=") {
+            Some(hex) => hex,
+            None => {
+                println!("=== Webhook REJECTED (invalid signature format) ===");
+                return (
+                    axum::http::StatusCode::UNAUTHORIZED,
+                    "invalid signature format".to_string(),
+                );
+            }
+        };
+
+        let sig_bytes = match hex::decode(sig_hex) {
+            Ok(b) => b,
+            Err(_) => {
+                println!("=== Webhook REJECTED (invalid signature encoding) ===");
+                return (
+                    axum::http::StatusCode::UNAUTHORIZED,
+                    "invalid signature encoding".to_string(),
+                );
+            }
+        };
+
+        let mut mac = HmacSha256::new_from_slice(secret.as_bytes())
+            .expect("HMAC can take key of any size");
+        mac.update(&body);
+
+        if mac.verify_slice(&sig_bytes).is_err() {
+            println!("=== Webhook REJECTED (signature mismatch) ===");
             return (
                 axum::http::StatusCode::UNAUTHORIZED,
-                "X-Cube-Signature header missing".to_string(),
+                "signature mismatch".to_string(),
             );
         }
     }
@@ -109,9 +136,3 @@ async fn forward_to_wecom(body_str: &str) {
         .await;
 }
 
-fn sign_payload(secret: &str, body: &[u8]) -> String {
-    let mut mac = HmacSha256::new_from_slice(secret.as_bytes())
-        .expect("HMAC can take key of any size");
-    mac.update(body);
-    format!("sha256={}", hex::encode(mac.finalize().into_bytes()))
-}


### PR DESCRIPTION
## Summary

Add asynchronous HTTP webhook delivery for sandbox lifecycle events. When a sandbox is created, paused, resumed, or deleted, CubeAPI sends a signed JSON POST to user-configured HTTP endpoints without blocking the API path.

Closes #642.

## Problem

CubeSandbox records lifecycle events internally, but external orchestration systems, audit platforms, and notification tools must poll the sandbox API to detect state transitions. Polling adds latency and unnecessary load.

## Solution

Add an `HttpLogger` backend implementing the existing `Logger` trait, plugged into `MultiLogger` alongside `FileLogger`. The design follows `FileLogger`'s proven `mpsc::unbounded_channel + tokio::spawn` pattern:

- **Zero handler changes** — lifecycle events are already emitted via `state.logger.log()`
- **Non-blocking delivery** — `log()` does a microsecond `tx.send()`; heavy work (serialization, signing, HTTP) runs in spawned tasks
- **Bounded concurrency** — `Arc<Semaphore>(64)` caps concurrent delivery tasks
- **Per-event multi-endpoint fan-out** — `join_all` sends to all configured endpoints concurrently
- **Graceful shutdown** — `flush()` drains in-flight deliveries with a 30s timeout

## Changes

| File | Description |
|------|-------------|
| `CubeAPI/Cargo.toml` | Add `hmac`, `sha2`, `hex` dependencies |
| `CubeAPI/src/config/mod.rs` | Add `webhook_urls`, `webhook_events`, `webhook_secret` fields |
| `CubeAPI/src/main.rs` | CLI flags + conditional `HttpLogger` registration |
| `CubeAPI/src/logging/http.rs` | Replace stub with full `HttpLogger` implementation |
| `CubeAPI/src/logging/mod.rs` | Update module table |
| `CubeAPI/src/handlers/sandboxes.rs` | Add `template_id` to `sandbox.resumed` event |
| `examples/webhook-receiver/` | Standalone axum receiver with HMAC verification + WeCom forwarding |
| `docs/guide/webhooks.md` | English integration guide |
| `docs/zh/guide/webhooks.md` | Chinese integration guide |

## Configuration

```bash
export CUBE_WEBHOOK_URLS="https://your-server.com/webhook"
export CUBE_WEBHOOK_EVENTS="sandbox.created,sandbox.deleted,sandbox.paused,sandbox.resumed"
export CUBE_WEBHOOK_SECRET="your-hmac-secret-key"
```

Or via CLI: `--webhook-urls`, `--webhook-events`, `--webhook-secret`.

When `CUBE_WEBHOOK_URLS` is empty, webhook delivery is completely disabled with zero overhead.

## Payload

```
POST <webhook-url>
Content-Type: application/json
X-Cube-Event: sandbox.created
X-Cube-Delivery: 550e8400-e29b-41d4-a716-446655440000
X-Cube-Signature: sha256=<hex>  (only when secret is configured)
```

```json
{
  "event": "sandbox.created",
  "timestamp": "2026-07-23T12:00:00.123Z",
  "sandbox_id": "sb-abc123",
  "template_id": "tpl-xyz"
}
```

## Validation

| Check | Result |
|-------|--------|
| `cargo test -- logging::http` | 10 passed |
| `cargo fmt --check` | passed |
| `cargo clippy` (changed files) | no issues |
| HMAC verification (correct sig → 200, wrong sig → 401) | passed |
| Sandbox lifecycle E2E (create/pause/resume/delete) | 4/4 events received |
| WeCom bot forwarding | 4/4 messages delivered |
| Retry on 5xx | confirmed (3 retries with backoff) |
| No retry on 4xx | confirmed (single attempt) |

Environment: CubeSandbox v0.5.1 on OpenCloudOS 9 (CVM, 8 vCPU / 16 GB, PVM kernel).

Full verification logs attached.

## Scope

**Included:**
- Static configuration via env vars / CLI flags
- 4 lifecycle events: `sandbox.created`, `sandbox.deleted`, `sandbox.paused`, `sandbox.resumed`
- Optional HMAC-SHA256 signing
- Exponential backoff retry (3 retries, 5xx/connection errors only)
- Runnable receiver example with HMAC verification + WeCom forwarding
- Bilingual integration documentation

**Deferred (future PRs):**
- REST API for dynamic endpoint management
- Per-endpoint event filters and secrets
- Dead-letter queue / persistent retry
- Prometheus metrics

🤖 Generated with [Claude Code](https://claude.com/claude-code)