### PR TITLE
docs: add CodeBuddy CI integration example

### DIFF
--- a/docs/guide/integrations/codebuddy-ci.md
+++ b/docs/guide/integrations/codebuddy-ci.md
@@ -1,0 +1,69 @@
+---
+title: CodeBuddy CI Integration Guide
+author: dujunjin
+date: 2026-07-23
+tags:
+  - integration
+  - codebuddy
+  - ci
+  - coding-agent
+lang: en-US
+---
+
+# CodeBuddy CI integration guide
+
+Run [CodeBuddy Code CLI](https://www.npmjs.com/package/@tencent-ai/codebuddy-code) inside a CubeSandbox MicroVM when CI must inspect, test, or report on an untrusted checkout. Source and agent tools stay in the MicroVM, while the runner retains only the minimal CubeAPI and CodeBuddy secrets.
+
+The runnable companion is in the repository at `examples/codebuddy-ci-integration/`.
+
+## Supported interface
+
+The example pins CodeBuddy Code `2.125.5` and uses its headless interface: `--print --output-format json --session-id <id>`. A later turn uses the same ID and `--resume <id>`. Check `codebuddy --help` after any CLI upgrade; interactive flags are not suitable for an E2B command channel.
+
+## Setup
+
+1. Build the supplied Dockerfile on top of `cubesandbox-base` and register the image with a health probe on port `49983`.
+2. Store `E2B_API_URL`, `E2B_API_KEY`, and `CODEBUDDY_AUTH_TOKEN` as CI secrets; store the ready `CUBE_TEMPLATE_ID` as a non-secret CI variable.
+3. Give the runner network access to CubeAPI, but apply default-deny CubeEgress to the template. Allow only the CodeBuddy API hostname required by the tenant and explicitly justified endpoints.
+4. Upload a source `.tar` rather than mounting the CI workspace. Exclude `.git`, credentials, and files the task does not need.
+
+The driver forwards only `CODEBUDDY_AUTH_TOKEN` into the command environment. It does not forward the runner's GitHub token, registry password, or arbitrary host environment variables.
+
+## Minimal execution
+
+```bash
+tar --exclude=.git -cf /tmp/project.tar .
+cd examples/codebuddy-ci-integration
+python -m pip install -r requirements.txt
+python run_codebuddy_ci.py --source-tar /tmp/project.tar
+```
+
+The default prompt runs the smallest relevant test and writes `/workspace/codebuddy-ci-report.md`. Provide a narrow `--prompt` for a real pipeline and keep the instruction to avoid commits/pushes. The CLI uses `bypassPermissions` only inside the disposable, egress-restricted MicroVM; never combine it with broad outbound access or production secrets.
+
+## Snapshot-backed continuation
+
+```bash
+python run_codebuddy_ci.py --source-tar /tmp/project.tar --pause
+python resume_codebuddy_ci.py <printed-sandbox-id>
+```
+
+`pause()` captures the writable layer, including `/workspace` and the CodeBuddy session directory. The resume driver reconnects using `Sandbox.connect` and invokes the CLI with the same session ID. Snapshots are sensitive artifacts: limit access, use expiry, and kill the sandbox after collecting the final report.
+
+## GitHub Actions pattern
+
+Copy the companion `github-actions.yml` into the repository that owns the CI job. It uses `pull_request`, `permissions: contents: read`, a tarball upload, and no `pull_request_target`. Keep external side effects out of the agent prompt; publish a comment or commit only in a separate reviewed workflow step.
+
+## Troubleshooting
+
+| Symptom | Resolution |
+| --- | --- |
+| Auth failure | Confirm `CODEBUDDY_AUTH_TOKEN` is a CI secret and injected at command time, not in the Dockerfile. |
+| `403` or model timeout | Adjust only the necessary CubeEgress allow rule; default deny should remain enabled. |
+| Template readiness failure | Preserve the base image's envd health endpoint on port `49983`. |
+| Session not found after resume | Use the same `CODEBUDDY_SESSION_ID` and do not kill the paused sandbox first. |
+
+## References
+
+- `examples/codebuddy-ci-integration/` in this repository
+- [Issue #644](https://github.com/TencentCloud/CubeSandbox/issues/644)
+- [CodeBuddy Code CLI package](https://www.npmjs.com/package/@tencent-ai/codebuddy-code)

--- a/docs/guide/integrations/index.md
+++ b/docs/guide/integrations/index.md
@@ -48,3 +48,4 @@ lang: en-US
 | Title | Author | Date | Tags |
 | --- | --- | --- | --- |
 | [Pi Agent Integration Guide](./pi-agent.md) | chaojixinren | 2026-07-01 | integration, pi-agent, coding-agent, agent |
+| [CodeBuddy CI Integration Guide](./codebuddy-ci.md) | dujunjin | 2026-07-23 | integration, codebuddy, ci, coding-agent |

--- a/docs/zh/guide/integrations/codebuddy-ci.md
+++ b/docs/zh/guide/integrations/codebuddy-ci.md
@@ -1,0 +1,69 @@
+---
+title: CodeBuddy CI 集成指南
+author: dujunjin
+date: 2026-07-23
+tags:
+  - integration
+  - codebuddy
+  - ci
+  - coding-agent
+lang: zh-CN
+---
+
+# CodeBuddy CI 集成指南
+
+当 CI 需要让 Agent 检查、测试或生成不受信任代码的报告时，可在 CubeSandbox MicroVM 中运行 [CodeBuddy Code CLI](https://www.npmjs.com/package/@tencent-ai/codebuddy-code)。源码和 Agent 工具留在 MicroVM 内，CI Runner 只保留最少的 CubeAPI 与 CodeBuddy 凭据，避免把 Agent 放在高权限 Runner 上执行。
+
+配套可运行示例位于仓库中的 `examples/codebuddy-ci-integration/`。
+
+## 支持的接口
+
+示例固定 CodeBuddy Code `2.125.5`，使用无交互接口：`--print --output-format json --session-id <id>`。后续轮次保持同一 ID 并使用 `--resume <id>`。升级 CLI 后请先执行 `codebuddy --help`，不要假定交互式参数能在 E2B 命令通道中工作。
+
+## 接入步骤
+
+1. 基于提供的 Dockerfile 构建镜像（继承 `cubesandbox-base`），并使用 49983 端口健康检查注册模板。
+2. 将 `E2B_API_URL`、`E2B_API_KEY`、`CODEBUDDY_AUTH_TOKEN` 保存为 CI Secret，将就绪的 `CUBE_TEMPLATE_ID` 保存为非敏感 CI Variable。
+3. 仅允许 CI Runner 访问 CubeAPI；模板应配置 CubeEgress 默认拒绝，只放行租户所需的 CodeBuddy API 主机和经明确评估的端点。
+4. 上传源码 `.tar`，不要挂载 CI 工作区；排除 `.git`、凭据和任务不需要的文件。
+
+驱动只向 Agent 命令转发 `CODEBUDDY_AUTH_TOKEN`，不会转发 Runner 的 GitHub Token、镜像仓库密码或其他宿主环境变量。
+
+## 最小执行流程
+
+```bash
+tar --exclude=.git -cf /tmp/project.tar .
+cd examples/codebuddy-ci-integration
+python -m pip install -r requirements.txt
+python run_codebuddy_ci.py --source-tar /tmp/project.tar
+```
+
+默认提示词会运行最小相关测试并写入 `/workspace/codebuddy-ci-report.md`。生产流水线应使用更小、更便于审计的 `--prompt`，并保留“不 commit、不 push”的约束。CLI 使用 `bypassPermissions` 仅限一次性、出口受限的 MicroVM；不要与宽松外网或生产机密并用。
+
+## 使用快照继续长任务
+
+```bash
+python run_codebuddy_ci.py --source-tar /tmp/project.tar --pause
+python resume_codebuddy_ci.py <输出的-sandbox-id>
+```
+
+`pause()` 会保存可写层，包括 `/workspace` 与 CodeBuddy 会话目录。恢复驱动用 `Sandbox.connect` 连接同一实例，再以相同会话 ID 调用 CLI。快照属于敏感产物：应限制访问、设置过期策略，并在取得最终报告后销毁 Sandbox。
+
+## GitHub Actions 模式
+
+将配套的 `github-actions.yml` 复制到实际 CI 仓库。它使用 `pull_request`、`permissions: contents: read`、tar 上传，并且不使用 `pull_request_target`，从而避免 Fork 代码取得写 Token。不要让 Agent 直接发布评论或 commit；这些副作用应放到另一个经过审查的工作流步骤。
+
+## 常见问题
+
+| 现象 | 处理方式 |
+| --- | --- |
+| 鉴权失败 | 确认 `CODEBUDDY_AUTH_TOKEN` 是 CI Secret，并在命令执行时注入，而不是写进 Dockerfile。 |
+| 403 或模型超时 | 只增加必需的 CubeEgress allow 规则，保持默认拒绝。 |
+| 模板未就绪 | 保留基础镜像中 envd 的 49983 健康检查端点。 |
+| 恢复后找不到会话 | 使用相同的 `CODEBUDDY_SESSION_ID`，且不要提前 kill 已暂停的 Sandbox。 |
+
+## 参考
+
+- 本仓库的 `examples/codebuddy-ci-integration/`
+- [Issue #644](https://github.com/TencentCloud/CubeSandbox/issues/644)
+- [CodeBuddy Code CLI npm 包](https://www.npmjs.com/package/@tencent-ai/codebuddy-code)

--- a/docs/zh/guide/integrations/index.md
+++ b/docs/zh/guide/integrations/index.md
@@ -48,3 +48,4 @@ lang: zh-CN
 | 标题 | 作者 | 日期 | 标签 |
 | --- | --- | --- | --- |
 | [Pi Agent 集成指南](./pi-agent.md) | chaojixinren | 2026-07-01 | integration, pi-agent, coding-agent, agent |
+| [CodeBuddy CI 集成指南](./codebuddy-ci.md) | dujunjin | 2026-07-23 | integration, codebuddy, ci, coding-agent |

--- a/examples/codebuddy-ci-integration/.env.example
+++ b/examples/codebuddy-ci-integration/.env.example
@@ -1,0 +1,17 @@
+# Local CubeSandbox API endpoint and credentials. Keep this file free of real
+# credentials; copy it to .env before running the driver.
+E2B_API_URL=http://127.0.0.1:3000
+E2B_API_KEY=local-development-key
+CUBE_TEMPLATE_ID=replace-with-ready-template-id
+
+# CodeBuddy authentication is injected for one command only. Never bake this
+# value into an image or commit it to a workflow file.
+CODEBUDDY_AUTH_TOKEN=
+CODEBUDDY_MODEL=
+
+# Optional driver settings.
+CODEBUDDY_MAX_TURNS=3
+CODEBUDDY_SANDBOX_TIMEOUT=1800
+CODEBUDDY_EXEC_TIMEOUT=900
+CODEBUDDY_SESSION_ID=cube-ci-snapshot
+CODEBUDDY_WORKSPACE=/workspace

--- a/examples/codebuddy-ci-integration/.gitignore
+++ b/examples/codebuddy-ci-integration/.gitignore
@@ -1,0 +1,3 @@
+.env
+__pycache__/
+*.py[cod]

--- a/examples/codebuddy-ci-integration/Dockerfile
+++ b/examples/codebuddy-ci-integration/Dockerfile
@@ -1,0 +1,30 @@
+# syntax=docker/dockerfile:1.7
+#
+# CodeBuddy Code CLI template for CubeSandbox CI jobs. The inherited
+# cube-entrypoint keeps envd listening on :49983 for Cube's readiness probe.
+ARG CUBE_BASE_IMAGE=ghcr.io/tencentcloud/cubesandbox-base:2026.16
+FROM ${CUBE_BASE_IMAGE}
+
+ARG DEBIAN_FRONTEND=noninteractive
+ARG NODE_MAJOR=24
+ARG CODEBUDDY_VERSION=2.125.5
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        bash ca-certificates curl git jq python3 ripgrep \
+    && curl -fsSL "https://deb.nodesource.com/setup_${NODE_MAJOR}.x" | bash - \
+    && apt-get install -y --no-install-recommends nodejs \
+    && npm install -g --ignore-scripts "@tencent-ai/codebuddy-code@${CODEBUDDY_VERSION}" \
+    && codebuddy --version \
+    && npm cache clean --force \
+    && rm -rf /var/lib/apt/lists/* /root/.npm
+
+# Keep CodeBuddy's session store on the writable layer. A CubeSandbox snapshot
+# therefore captures it together with /workspace and can resume the CI task.
+ENV CODEBUDDY_CONFIG_DIR=/root/.codebuddy \
+    CODEBUDDY_DISABLE_TELEMETRY=1 \
+    NPM_CONFIG_UPDATE_NOTIFIER=false
+
+RUN mkdir -p /workspace "${CODEBUDDY_CONFIG_DIR}"
+WORKDIR /workspace
+EXPOSE 49983

--- a/examples/codebuddy-ci-integration/README.md
+++ b/examples/codebuddy-ci-integration/README.md
@@ -1,0 +1,90 @@
+# CodeBuddy CI + CubeSandbox example
+
+[中文文档](README_zh.md)
+
+This example runs a non-interactive [CodeBuddy Code CLI](https://www.npmjs.com/package/@tencent-ai/codebuddy-code) task inside a disposable CubeSandbox MicroVM. A CI runner uploads a source archive, the agent inspects or tests the checkout, and the driver prints the generated report. The MicroVM never receives GitHub or registry credentials.
+
+## Layout
+
+```text
+codebuddy-ci-integration/
+├── Dockerfile                 # Node.js + pinned CodeBuddy CLI template
+├── build-template.sh          # Build and push the template image
+├── run_codebuddy_ci.py        # Create VM, upload .tar, run one CI task
+├── resume_codebuddy_ci.py     # Resume a paused task and its CLI session
+├── config.py                  # Validated env and headless command builder
+├── github-actions.yml         # Copy into the consumer project
+└── test_config.py             # Offline unit tests
+```
+
+## Build and register the image
+
+```bash
+cd examples/codebuddy-ci-integration
+./build-template.sh <your-registry>/codebuddy-ci-cube:2.125.5
+
+cubemastercli tpl create-from-image \
+  --image <your-registry>/codebuddy-ci-cube:2.125.5 \
+  --writable-layer-size 4G \
+  --expose-port 49983 --probe 49983 --probe-path /health
+cubemastercli tpl watch --job-id <job-id>
+```
+
+Put the ready template ID in `CUBE_TEMPLATE_ID`. The image pins `@tencent-ai/codebuddy-code` to `2.125.5`; upgrade deliberately and rerun the CLI interface checks first.
+
+## Configure credentials and egress
+
+```bash
+cp .env.example .env
+# Set E2B_API_URL, E2B_API_KEY, CUBE_TEMPLATE_ID and CODEBUDDY_AUTH_TOKEN.
+python -m pip install -r requirements.txt
+```
+
+For a shared cluster, apply a **default-deny CubeEgress policy** to this template and allow only the CodeBuddy API host your tenant uses. The runner needs CubeAPI access; the MicroVM should not receive GitHub, registry, or CI provider credentials. The driver uses `--permission-mode bypassPermissions` only inside a disposable MicroVM; do not use that mode with broad egress or production secrets.
+
+## Run locally
+
+Create an archive rather than giving the VM a host mount:
+
+```bash
+tar --exclude=.git -cf /tmp/project.tar .
+cd examples/codebuddy-ci-integration
+python run_codebuddy_ci.py --source-tar /tmp/project.tar
+```
+
+The default prompt asks CodeBuddy to run the smallest relevant test and write `/workspace/codebuddy-ci-report.md`. Use `--prompt` for a narrow review task. The example instructs the agent not to commit or push.
+
+## Pause and resume a long CI task
+
+```bash
+python run_codebuddy_ci.py --source-tar /tmp/project.tar --pause
+# Copy the printed resume handle, then:
+python resume_codebuddy_ci.py <sandbox-id>
+```
+
+`--pause` snapshots `/workspace` and `/root/.codebuddy`. The resume driver reconnects to that sandbox and calls CodeBuddy with the same `--session-id` plus `--resume`. Treat snapshots as sensitive and kill them after the job finishes.
+
+## Use from GitHub Actions
+
+Copy [`github-actions.yml`](github-actions.yml) to `.github/workflows/codebuddy-cubesandbox.yml` in the consumer project, then configure `CUBE_API_URL`, `CUBE_API_KEY`, and `CODEBUDDY_AUTH_TOKEN` as secrets plus `CUBE_TEMPLATE_ID` as a variable. The sample never enables `pull_request_target`; untrusted PR code does not get repository write permissions.
+
+## Troubleshooting
+
+| Symptom | Cause and fix |
+| --- | --- |
+| `codebuddy: command not found` | Rebuild/re-register the image and verify `codebuddy --version`. |
+| Authentication failure | Check the CI secret; do not add the token to the image or archive. |
+| Egress `403` or model timeout | Add only the required CodeBuddy API hostname to CubeEgress. |
+| Resume cannot find the session | Keep `CODEBUDDY_SESSION_ID` unchanged and do not kill the paused sandbox. |
+| Archive rejected | Use a regular `.tar` below 100 MiB; exclude `.git` and secrets. |
+
+## Validate without a cluster
+
+```bash
+python -m py_compile config.py run_codebuddy_ci.py resume_codebuddy_ci.py
+python -m unittest -v test_config.py
+bash -n build-template.sh
+docker build --check .
+```
+
+The tests cover validation, headless JSON output, resume arguments, and the fact that only `CODEBUDDY_AUTH_TOKEN` is forwarded to the sandbox command.

--- a/examples/codebuddy-ci-integration/README_zh.md
+++ b/examples/codebuddy-ci-integration/README_zh.md
@@ -1,0 +1,90 @@
+# CodeBuddy CI + CubeSandbox 示例
+
+[English](README.md)
+
+本示例在一次性 CubeSandbox MicroVM 中运行无交互的 [CodeBuddy Code CLI](https://www.npmjs.com/package/@tencent-ai/codebuddy-code)。CI Runner 上传源码归档，Agent 在隔离环境中检查或测试代码，再由驱动输出报告。MicroVM 不会获得 GitHub、镜像仓库或 Runner 凭据。
+
+## 目录结构
+
+```text
+codebuddy-ci-integration/
+├── Dockerfile                 # Node.js + 固定版本 CodeBuddy CLI 模板
+├── build-template.sh          # 构建并推送模板镜像
+├── run_codebuddy_ci.py        # 创建 VM、上传 .tar、执行一次 CI 任务
+├── resume_codebuddy_ci.py     # 恢复已暂停的任务及 CLI 会话
+├── config.py                  # 环境校验与无交互命令构造
+├── github-actions.yml         # 复制到使用方仓库
+└── test_config.py             # 离线单元测试
+```
+
+## 构建并注册模板
+
+```bash
+cd examples/codebuddy-ci-integration
+./build-template.sh <你的镜像仓库>/codebuddy-ci-cube:2.125.5
+
+cubemastercli tpl create-from-image \
+  --image <你的镜像仓库>/codebuddy-ci-cube:2.125.5 \
+  --writable-layer-size 4G \
+  --expose-port 49983 --probe 49983 --probe-path /health
+cubemastercli tpl watch --job-id <job-id>
+```
+
+将就绪后的模板 ID 填入 `CUBE_TEMPLATE_ID`。镜像固定 `@tencent-ai/codebuddy-code` 为 `2.125.5`；升级前请重新验证 CLI 接口。
+
+## 配置凭据与网络出口
+
+```bash
+cp .env.example .env
+# 填入 E2B_API_URL、E2B_API_KEY、CUBE_TEMPLATE_ID、CODEBUDDY_AUTH_TOKEN
+python -m pip install -r requirements.txt
+```
+
+共享集群应为该模板配置 **CubeEgress 默认拒绝**，仅放行租户实际使用的 CodeBuddy API 主机。Runner 可以访问 CubeAPI，但 MicroVM 不应接收 GitHub、镜像仓库或 CI 平台凭据。`--permission-mode bypassPermissions` 仅限一次性、出口受限的 MicroVM；不要与宽松外网或生产机密并用。
+
+## 本地运行
+
+通过归档上传源码，不给 MicroVM 提供宿主机挂载：
+
+```bash
+tar --exclude=.git -cf /tmp/project.tar .
+cd examples/codebuddy-ci-integration
+python run_codebuddy_ci.py --source-tar /tmp/project.tar
+```
+
+默认提示词会执行最小相关测试并写入 `/workspace/codebuddy-ci-report.md`。生产流水线应使用更小、更便于审计的 `--prompt`，并保留“不 commit、不 push”的约束。
+
+## 长任务暂停与恢复
+
+```bash
+python run_codebuddy_ci.py --source-tar /tmp/project.tar --pause
+# 复制输出的 resume handle，然后：
+python resume_codebuddy_ci.py <sandbox-id>
+```
+
+`--pause` 会快照 `/workspace` 与 `/root/.codebuddy`。恢复驱动连接同一 Sandbox，以相同 `--session-id` 并加上 `--resume` 继续 CodeBuddy 会话。快照可能包含源码、报告和 Agent 状态，应按敏感数据处理，并在完成后销毁。
+
+## GitHub Actions
+
+将 [`github-actions.yml`](github-actions.yml) 复制到使用方仓库的 `.github/workflows/codebuddy-cubesandbox.yml`，然后将 `CUBE_API_URL`、`CUBE_API_KEY`、`CODEBUDDY_AUTH_TOKEN` 配置为 Secret，并将 `CUBE_TEMPLATE_ID` 配置为 Variable。示例没有使用 `pull_request_target`，因此不受信任 PR 不会获得仓库写权限。
+
+## 常见问题
+
+| 现象 | 原因与处理 |
+| --- | --- |
+| `codebuddy: command not found` | 重建并重新注册镜像，再确认 `codebuddy --version`。 |
+| 鉴权失败 | 检查 CI Secret；不要把 Token 放进镜像或源码归档。 |
+| 出口 403 或模型超时 | 仅将需要的 CodeBuddy API 主机加入 CubeEgress allowlist。 |
+| 恢复后找不到会话 | 保持 `CODEBUDDY_SESSION_ID` 不变，且不要提前 kill 已暂停的 Sandbox。 |
+| 归档被拒绝 | 使用不超过 100 MiB 的普通 `.tar`，排除 `.git` 和机密文件。 |
+
+## 无集群验证
+
+```bash
+python -m py_compile config.py run_codebuddy_ci.py resume_codebuddy_ci.py
+python -m unittest -v test_config.py
+bash -n build-template.sh
+docker build --check .
+```
+
+单元测试覆盖参数校验、无交互 JSON 输出、恢复参数，以及只把 `CODEBUDDY_AUTH_TOKEN` 转发给 Sandbox 命令这一安全边界。

--- a/examples/codebuddy-ci-integration/build-template.sh
+++ b/examples/codebuddy-ci-integration/build-template.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+  echo "Usage: $0 <registry/image:tag>" >&2
+  exit 2
+fi
+
+image="$1"
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+
+docker build --platform linux/amd64 -t "$image" "$script_dir"
+docker push "$image"

--- a/examples/codebuddy-ci-integration/config.py
+++ b/examples/codebuddy-ci-integration/config.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Configuration and command construction for the CodeBuddy CI example."""
+
+from __future__ import annotations
+
+import os
+import shlex
+from pathlib import Path
+
+from dotenv import load_dotenv
+
+DEFAULT_WORKSPACE = "/workspace"
+
+
+def load_local_dotenv() -> None:
+    """Load the example's .env without overriding a CI runner's real env."""
+    path = Path(__file__).with_name(".env")
+    if path.is_file():
+        load_dotenv(path, override=False)
+
+
+def required(name: str) -> str:
+    value = os.environ.get(name)
+    if not value:
+        raise SystemExit(f"Missing required environment variable: {name}")
+    return value
+
+
+def positive_int(name: str, default: int) -> int:
+    value = os.environ.get(name)
+    if not value:
+        return default
+    try:
+        parsed = int(value)
+    except ValueError as exc:
+        raise SystemExit(f"{name} must be an integer, got {value!r}") from exc
+    if parsed <= 0:
+        raise SystemExit(f"{name} must be positive, got {parsed}")
+    return parsed
+
+
+def workspace() -> str:
+    value = os.environ.get("CODEBUDDY_WORKSPACE", DEFAULT_WORKSPACE)
+    if not value.startswith("/"):
+        raise SystemExit("CODEBUDDY_WORKSPACE must be an absolute sandbox path")
+    return value.rstrip("/") or "/"
+
+
+def codebuddy_env() -> dict[str, str]:
+    """Return the smallest environment map needed by a single agent command."""
+    token = required("CODEBUDDY_AUTH_TOKEN")
+    env = {
+        "CODEBUDDY_AUTH_TOKEN": token,
+        "CODEBUDDY_DISABLE_TELEMETRY": "1",
+        "CODEBUDDY_CONFIG_DIR": os.environ.get(
+            "CODEBUDDY_CONFIG_DIR", "/root/.codebuddy"
+        ),
+    }
+    return env
+
+
+def codebuddy_command(
+    prompt: str,
+    *,
+    session_id: str,
+    max_turns: int,
+    resume: bool = False,
+) -> str:
+    """Build an audited non-interactive CodeBuddy invocation.
+
+    ``--permission-mode bypassPermissions`` is deliberately confined to this
+    disposable MicroVM. The accompanying guide requires default-deny egress
+    except for the CodeBuddy API endpoint before using this mode in CI.
+    """
+    if not prompt.strip():
+        raise ValueError("prompt must not be empty")
+    if not session_id or not session_id[0].isalnum():
+        raise ValueError("session_id must start with a letter or number")
+    if max_turns <= 0:
+        raise ValueError("max_turns must be positive")
+
+    args = [
+        "codebuddy",
+        "--print",
+        "--output-format",
+        "json",
+        "--permission-mode",
+        "bypassPermissions",
+        "--session-id",
+        session_id,
+        "--max-turns",
+        str(max_turns),
+    ]
+    model = os.environ.get("CODEBUDDY_MODEL")
+    if model:
+        args.extend(["--model", model])
+    if resume:
+        args.extend(["--resume", session_id])
+    args.append(prompt)
+    return shlex.join(args)
+
+
+def shell_join(*parts: str) -> str:
+    return " && ".join(part for part in parts if part)

--- a/examples/codebuddy-ci-integration/github-actions.yml
+++ b/examples/codebuddy-ci-integration/github-actions.yml
@@ -1,0 +1,36 @@
+# Copy this file to .github/workflows/codebuddy-cubesandbox.yml in a project
+# that has a reachable CubeSandbox deployment. It is intentionally kept under
+# examples so this repository does not start a credentialed workflow itself.
+name: CodeBuddy in CubeSandbox
+
+on:
+  workflow_dispatch:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  codebuddy-ci:
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    env:
+      E2B_API_URL: ${{ secrets.CUBE_API_URL }}
+      E2B_API_KEY: ${{ secrets.CUBE_API_KEY }}
+      CUBE_TEMPLATE_ID: ${{ vars.CUBE_TEMPLATE_ID }}
+      CODEBUDDY_AUTH_TOKEN: ${{ secrets.CODEBUDDY_AUTH_TOKEN }}
+      CODEBUDDY_MAX_TURNS: "3"
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Package the checkout without Git metadata
+        run: tar --exclude=.git -cf source.tar .
+      - name: Run CodeBuddy in a disposable MicroVM
+        working-directory: examples/codebuddy-ci-integration
+        run: |
+          python -m pip install --requirement requirements.txt
+          python run_codebuddy_ci.py --source-tar ../../source.tar

--- a/examples/codebuddy-ci-integration/requirements.txt
+++ b/examples/codebuddy-ci-integration/requirements.txt
@@ -1,0 +1,2 @@
+e2b>=2.13.0
+python-dotenv>=1.0.1

--- a/examples/codebuddy-ci-integration/resume_codebuddy_ci.py
+++ b/examples/codebuddy-ci-integration/resume_codebuddy_ci.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Resume a paused CodeBuddy CI session from a CubeSandbox snapshot."""
+
+from __future__ import annotations
+
+import argparse
+import shlex
+import sys
+
+from e2b import Sandbox
+
+from config import codebuddy_command, codebuddy_env, load_local_dotenv, positive_int, required, shell_join, workspace
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("sandbox_id", help="Paused CubeSandbox ID to reconnect.")
+    parser.add_argument(
+        "--prompt",
+        default="Continue the CI task, read the existing report, and update it with the final test result. Do not commit or push changes.",
+    )
+    parser.add_argument("--session-id", default=None)
+    return parser.parse_args()
+
+
+def ensure_success(result, action: str) -> None:
+    if getattr(result, "exit_code", None) not in (None, 0):
+        raise SystemExit(f"Failed to {action}: {getattr(result, 'stderr', '')}")
+
+
+def main() -> int:
+    load_local_dotenv()
+    args = parse_args()
+    required("E2B_API_URL")
+    required("E2B_API_KEY")
+    command_env = codebuddy_env()
+    session_id = args.session_id or required("CODEBUDDY_SESSION_ID")
+    target_workspace = workspace()
+    command = shell_join(
+        f"cd {shlex.quote(target_workspace)}",
+        codebuddy_command(
+            args.prompt,
+            session_id=session_id,
+            max_turns=positive_int("CODEBUDDY_MAX_TURNS", 3),
+            resume=True,
+        ),
+    )
+    sandbox = Sandbox.connect(args.sandbox_id)
+    result = sandbox.commands.run(
+        command,
+        cwd=target_workspace,
+        envs=command_env,
+        timeout=positive_int("CODEBUDDY_EXEC_TIMEOUT", 900),
+        user="root",
+    )
+    ensure_success(result, "resume CodeBuddy CI task")
+    print(getattr(result, "stdout", ""))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/examples/codebuddy-ci-integration/run_codebuddy_ci.py
+++ b/examples/codebuddy-ci-integration/run_codebuddy_ci.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Run a one-shot CodeBuddy CI task in a disposable CubeSandbox MicroVM."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import shlex
+import sys
+from pathlib import Path
+
+from e2b import Sandbox
+
+from config import (
+    codebuddy_command,
+    codebuddy_env,
+    load_local_dotenv,
+    positive_int,
+    required,
+    shell_join,
+    workspace,
+)
+
+DEFAULT_PROMPT = (
+    "Inspect the repository, run its smallest relevant test command, and write "
+    "a concise CI report to /workspace/codebuddy-ci-report.md. Do not commit "
+    "or push changes."
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--template", default=os.environ.get("CUBE_TEMPLATE_ID"))
+    parser.add_argument("--prompt", default=DEFAULT_PROMPT)
+    parser.add_argument(
+        "--source-tar",
+        help="Optional .tar archive to upload and extract into the workspace.",
+    )
+    parser.add_argument("--session-id", default=os.environ.get("CODEBUDDY_SESSION_ID", "cube-ci"))
+    parser.add_argument(
+        "--pause",
+        action="store_true",
+        help="Pause instead of killing the sandbox so resume_codebuddy_ci.py can continue it.",
+    )
+    return parser.parse_args()
+
+
+def ensure_success(result, action: str) -> None:
+    if getattr(result, "exit_code", None) not in (None, 0):
+        raise SystemExit(
+            f"Failed to {action} (exit {getattr(result, 'exit_code', 'unknown')}).\n"
+            f"STDOUT:\n{getattr(result, 'stdout', '')}\n"
+            f"STDERR:\n{getattr(result, 'stderr', '')}"
+        )
+
+
+def upload_source_tar(sandbox: Sandbox, source_tar: str, destination: str) -> None:
+    """Upload a regular tar archive, avoiding host-path handling in the VM."""
+    source = Path(source_tar).resolve()
+    if not source.is_file() or source.suffix != ".tar":
+        raise SystemExit(f"--source-tar must be an existing .tar file: {source}")
+    if source.stat().st_size > 100 * 1024 * 1024:
+        raise SystemExit("--source-tar must be no larger than 100 MiB")
+    sandbox.files.write(destination, source.read_bytes())
+
+
+def main() -> int:
+    load_local_dotenv()
+    args = parse_args()
+    template = args.template or required("CUBE_TEMPLATE_ID")
+    required("E2B_API_URL")
+    required("E2B_API_KEY")
+    command_env = codebuddy_env()
+    target_workspace = workspace()
+    sandbox_timeout = positive_int("CODEBUDDY_SANDBOX_TIMEOUT", 1800)
+    exec_timeout = positive_int("CODEBUDDY_EXEC_TIMEOUT", 900)
+    max_turns = positive_int("CODEBUDDY_MAX_TURNS", 3)
+
+    command = shell_join(
+        f"mkdir -p {shlex.quote(target_workspace)}",
+        f"cd {shlex.quote(target_workspace)}",
+        codebuddy_command(args.prompt, session_id=args.session_id, max_turns=max_turns),
+    )
+    print(f"Creating CodeBuddy CI sandbox from template: {template}")
+    # Do not use a context manager: its cleanup kills a paused sandbox and
+    # would make the documented snapshot/resume flow impossible.
+    sandbox = Sandbox.create(template=template, timeout=sandbox_timeout)
+    sandbox_id = getattr(sandbox, "sandbox_id", getattr(sandbox, "id", "unknown"))
+    should_kill = True
+    try:
+        print(f"Sandbox ready: {sandbox_id}")
+        preflight = sandbox.commands.run("codebuddy --version", timeout=60, user="root")
+        ensure_success(preflight, "check CodeBuddy version")
+        print(f"CodeBuddy version: {getattr(preflight, 'stdout', '').strip()}")
+
+        if args.source_tar:
+            archive_path = f"{target_workspace}/source.tar"
+            upload_source_tar(sandbox, args.source_tar, archive_path)
+            extract = sandbox.commands.run(
+                f"tar -xf {shlex.quote(archive_path)} -C {shlex.quote(target_workspace)} && rm {shlex.quote(archive_path)}",
+                timeout=120,
+                user="root",
+            )
+            ensure_success(extract, "extract source archive")
+            print(f"Uploaded and extracted {Path(args.source_tar).resolve()} to {target_workspace}")
+
+        result = sandbox.commands.run(
+            command,
+            cwd=target_workspace,
+            envs=command_env,
+            timeout=exec_timeout,
+            user="root",
+        )
+        ensure_success(result, "run CodeBuddy CI task")
+        print(getattr(result, "stdout", ""))
+        report = sandbox.commands.run(
+            f"test ! -f {shlex.quote(target_workspace)}/codebuddy-ci-report.md || cat {shlex.quote(target_workspace)}/codebuddy-ci-report.md",
+            timeout=60,
+            user="root",
+        )
+        ensure_success(report, "collect CI report")
+        if getattr(report, "stdout", ""):
+            print("\n--- codebuddy-ci-report.md ---")
+            print(report.stdout)
+        if args.pause:
+            paused_id = sandbox.pause()
+            if isinstance(paused_id, str) and paused_id:
+                sandbox_id = paused_id
+            should_kill = False
+            print(f"Paused. Resume handle: {sandbox_id}")
+    finally:
+        if should_kill:
+            try:
+                sandbox.kill()
+                print(f"Sandbox {sandbox_id} killed.")
+            except Exception as exc:  # noqa: BLE001 - cleanup must not mask real failures
+                print(f"Warning: failed to kill sandbox {sandbox_id}: {exc}", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/examples/codebuddy-ci-integration/test_config.py
+++ b/examples/codebuddy-ci-integration/test_config.py
@@ -1,0 +1,67 @@
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+import unittest
+from unittest.mock import patch
+
+from config import codebuddy_command, codebuddy_env, positive_int, workspace
+
+
+class CodeBuddyConfigTests(unittest.TestCase):
+    def test_command_is_headless_json_and_has_session(self):
+        command = codebuddy_command("inspect README", session_id="ci-1", max_turns=2)
+        self.assertIn("codebuddy --print --output-format json", command)
+        self.assertIn("--session-id ci-1", command)
+        self.assertIn("--max-turns 2", command)
+        self.assertIn("'inspect README'", command)
+
+    def test_command_can_resume(self):
+        command = codebuddy_command("continue", session_id="ci-1", max_turns=1, resume=True)
+        self.assertIn("--resume ci-1", command)
+
+    def test_command_includes_optional_model(self):
+        with patch.dict(os.environ, {"CODEBUDDY_MODEL": "gpt-5.5"}, clear=True):
+            command = codebuddy_command("task", session_id="ci", max_turns=1)
+        self.assertIn("--model gpt-5.5", command)
+
+    def test_rejects_empty_prompt(self):
+        with self.assertRaises(ValueError):
+            codebuddy_command("  ", session_id="ci", max_turns=1)
+
+    def test_rejects_invalid_session(self):
+        with self.assertRaises(ValueError):
+            codebuddy_command("task", session_id="-invalid", max_turns=1)
+
+    def test_rejects_invalid_turn_count(self):
+        with self.assertRaises(ValueError):
+            codebuddy_command("task", session_id="ci", max_turns=0)
+
+    def test_codebuddy_env_keeps_only_required_values(self):
+        with patch.dict(
+            os.environ,
+            {"CODEBUDDY_AUTH_TOKEN": "token", "UNRELATED_SECRET": "nope"},
+            clear=True,
+        ):
+            env = codebuddy_env()
+        self.assertEqual(env["CODEBUDDY_AUTH_TOKEN"], "token")
+        self.assertNotIn("UNRELATED_SECRET", env)
+
+    def test_codebuddy_env_requires_token(self):
+        with patch.dict(os.environ, {}, clear=True):
+            with self.assertRaises(SystemExit):
+                codebuddy_env()
+
+    def test_positive_int_rejects_non_positive(self):
+        with patch.dict(os.environ, {"LIMIT": "0"}, clear=True):
+            with self.assertRaises(SystemExit):
+                positive_int("LIMIT", 1)
+
+    def test_workspace_must_be_absolute(self):
+        with patch.dict(os.environ, {"CODEBUDDY_WORKSPACE": "relative"}, clear=True):
+            with self.assertRaises(SystemExit):
+                workspace()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Addresses the CI-oriented CodeBuddy sub-direction of #644 without duplicating the existing general CodeBuddy integration PRs.

- Adds a runnable `examples/codebuddy-ci-integration/` package with a pinned CodeBuddy Code CLI template, source-tar upload driver, session pause/resume driver, and copyable GitHub Actions workflow.
- Adds bilingual CodeBuddy CI integration guides under `docs/guide/integrations/` and `docs/zh/guide/integrations/`, including template setup, secret injection, default-deny egress, snapshot continuation, and troubleshooting.
- Keeps runner credentials out of the MicroVM; only `CODEBUDDY_AUTH_TOKEN` is forwarded to the one agent command.

## Validation

- `python -m py_compile config.py run_codebuddy_ci.py resume_codebuddy_ci.py`
- `python -m unittest -v test_config.py` — 10 passed
- `bash -n build-template.sh`
- `git diff --check`
- `npm run docs:build` in `docs/` — passed
- `docker build --check .` — passed

I also attempted a full `linux/amd64` Docker build. The base-image platform was resolved successfully, but this local BuildKit run did not complete an image, so a completed image build is not claimed here. A live CubeSandbox run requires deployment credentials and was intentionally not attempted.

Autonomously-by: Codex:GPT-5
