### PR TITLE
feat: add secure interactive Web Terminal (#643)

### DIFF
--- a/CubeMaster/api/services/cubebox/v1/cubebox.pb.go
+++ b/CubeMaster/api/services/cubebox/v1/cubebox.pb.go
@@ -331,6 +331,64 @@ func (ContainerState) EnumDescriptor() ([]byte, []int) {
 	return file_api_services_cubebox_v1_cubebox_proto_rawDescGZIP(), []int{5}
 }
 
+type TerminalErrorCode int32
+
+const (
+	TerminalErrorCode_TERMINAL_ERROR_UNSPECIFIED        TerminalErrorCode = 0
+	TerminalErrorCode_TERMINAL_ERROR_INVALID_REQUEST    TerminalErrorCode = 1
+	TerminalErrorCode_TERMINAL_ERROR_TARGET_NOT_FOUND   TerminalErrorCode = 2
+	TerminalErrorCode_TERMINAL_ERROR_TARGET_NOT_RUNNING TerminalErrorCode = 3
+	TerminalErrorCode_TERMINAL_ERROR_INTERNAL           TerminalErrorCode = 4
+	TerminalErrorCode_TERMINAL_ERROR_IDLE_TIMEOUT       TerminalErrorCode = 5
+)
+
+// Enum value maps for TerminalErrorCode.
+var (
+	TerminalErrorCode_name = map[int32]string{
+		0: "TERMINAL_ERROR_UNSPECIFIED",
+		1: "TERMINAL_ERROR_INVALID_REQUEST",
+		2: "TERMINAL_ERROR_TARGET_NOT_FOUND",
+		3: "TERMINAL_ERROR_TARGET_NOT_RUNNING",
+		4: "TERMINAL_ERROR_INTERNAL",
+		5: "TERMINAL_ERROR_IDLE_TIMEOUT",
+	}
+	TerminalErrorCode_value = map[string]int32{
+		"TERMINAL_ERROR_UNSPECIFIED":        0,
+		"TERMINAL_ERROR_INVALID_REQUEST":    1,
+		"TERMINAL_ERROR_TARGET_NOT_FOUND":   2,
+		"TERMINAL_ERROR_TARGET_NOT_RUNNING": 3,
+		"TERMINAL_ERROR_INTERNAL":           4,
+		"TERMINAL_ERROR_IDLE_TIMEOUT":       5,
+	}
+)
+
+func (x TerminalErrorCode) Enum() *TerminalErrorCode {
+	p := new(TerminalErrorCode)
+	*p = x
+	return p
+}
+
+func (x TerminalErrorCode) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (TerminalErrorCode) Descriptor() protoreflect.EnumDescriptor {
+	return file_api_services_cubebox_v1_cubebox_proto_enumTypes[6].Descriptor()
+}
+
+func (TerminalErrorCode) Type() protoreflect.EnumType {
+	return &file_api_services_cubebox_v1_cubebox_proto_enumTypes[6]
+}
+
+func (x TerminalErrorCode) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use TerminalErrorCode.Descriptor instead.
+func (TerminalErrorCode) EnumDescriptor() ([]byte, []int) {
+	return file_api_services_cubebox_v1_cubebox_proto_rawDescGZIP(), []int{6}
+}
+
 // SELinuxOption are the labels to be applied to the container.
 type SELinuxOption struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
@@ -6436,6 +6494,589 @@ func (x *CleanupOrphanStorageFilesResponse) GetOrphans() []*StorageOrphanEntry {
 	return nil
 }
 
+// Client-to-server frames for an interactive terminal session. Keeping client
+// and server frames separate makes invalid message direction unrepresentable.
+type TerminalClientMessage struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Types that are valid to be assigned to Payload:
+	//
+	//	*TerminalClientMessage_Open
+	//	*TerminalClientMessage_Stdin
+	//	*TerminalClientMessage_Resize
+	//	*TerminalClientMessage_Close
+	Payload       isTerminalClientMessage_Payload `protobuf_oneof:"payload"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *TerminalClientMessage) Reset() {
+	*x = TerminalClientMessage{}
+	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[81]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *TerminalClientMessage) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*TerminalClientMessage) ProtoMessage() {}
+
+func (x *TerminalClientMessage) ProtoReflect() protoreflect.Message {
+	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[81]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use TerminalClientMessage.ProtoReflect.Descriptor instead.
+func (*TerminalClientMessage) Descriptor() ([]byte, []int) {
+	return file_api_services_cubebox_v1_cubebox_proto_rawDescGZIP(), []int{81}
+}
+
+func (x *TerminalClientMessage) GetPayload() isTerminalClientMessage_Payload {
+	if x != nil {
+		return x.Payload
+	}
+	return nil
+}
+
+func (x *TerminalClientMessage) GetOpen() *TerminalOpenRequest {
+	if x != nil {
+		if x, ok := x.Payload.(*TerminalClientMessage_Open); ok {
+			return x.Open
+		}
+	}
+	return nil
+}
+
+func (x *TerminalClientMessage) GetStdin() []byte {
+	if x != nil {
+		if x, ok := x.Payload.(*TerminalClientMessage_Stdin); ok {
+			return x.Stdin
+		}
+	}
+	return nil
+}
+
+func (x *TerminalClientMessage) GetResize() *TerminalResize {
+	if x != nil {
+		if x, ok := x.Payload.(*TerminalClientMessage_Resize); ok {
+			return x.Resize
+		}
+	}
+	return nil
+}
+
+func (x *TerminalClientMessage) GetClose() *TerminalClose {
+	if x != nil {
+		if x, ok := x.Payload.(*TerminalClientMessage_Close); ok {
+			return x.Close
+		}
+	}
+	return nil
+}
+
+type isTerminalClientMessage_Payload interface {
+	isTerminalClientMessage_Payload()
+}
+
+type TerminalClientMessage_Open struct {
+	Open *TerminalOpenRequest `protobuf:"bytes,1,opt,name=open,proto3,oneof"`
+}
+
+type TerminalClientMessage_Stdin struct {
+	Stdin []byte `protobuf:"bytes,2,opt,name=stdin,proto3,oneof"`
+}
+
+type TerminalClientMessage_Resize struct {
+	Resize *TerminalResize `protobuf:"bytes,3,opt,name=resize,proto3,oneof"`
+}
+
+type TerminalClientMessage_Close struct {
+	Close *TerminalClose `protobuf:"bytes,4,opt,name=close,proto3,oneof"`
+}
+
+func (*TerminalClientMessage_Open) isTerminalClientMessage_Payload() {}
+
+func (*TerminalClientMessage_Stdin) isTerminalClientMessage_Payload() {}
+
+func (*TerminalClientMessage_Resize) isTerminalClientMessage_Payload() {}
+
+func (*TerminalClientMessage_Close) isTerminalClientMessage_Payload() {}
+
+type TerminalOpenRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	RequestId     string                 `protobuf:"bytes,1,opt,name=request_id,json=requestId,proto3" json:"request_id,omitempty"`
+	SessionId     string                 `protobuf:"bytes,2,opt,name=session_id,json=sessionId,proto3" json:"session_id,omitempty"`
+	SandboxId     string                 `protobuf:"bytes,3,opt,name=sandbox_id,json=sandboxId,proto3" json:"sandbox_id,omitempty"`
+	ContainerId   string                 `protobuf:"bytes,4,opt,name=container_id,json=containerId,proto3" json:"container_id,omitempty"`
+	Args          []string               `protobuf:"bytes,5,rep,name=args,proto3" json:"args,omitempty"`
+	Env           []string               `protobuf:"bytes,6,rep,name=env,proto3" json:"env,omitempty"`
+	Cwd           string                 `protobuf:"bytes,7,opt,name=cwd,proto3" json:"cwd,omitempty"`
+	Cols          uint32                 `protobuf:"varint,8,opt,name=cols,proto3" json:"cols,omitempty"`
+	Rows          uint32                 `protobuf:"varint,9,opt,name=rows,proto3" json:"rows,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *TerminalOpenRequest) Reset() {
+	*x = TerminalOpenRequest{}
+	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[82]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *TerminalOpenRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*TerminalOpenRequest) ProtoMessage() {}
+
+func (x *TerminalOpenRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[82]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use TerminalOpenRequest.ProtoReflect.Descriptor instead.
+func (*TerminalOpenRequest) Descriptor() ([]byte, []int) {
+	return file_api_services_cubebox_v1_cubebox_proto_rawDescGZIP(), []int{82}
+}
+
+func (x *TerminalOpenRequest) GetRequestId() string {
+	if x != nil {
+		return x.RequestId
+	}
+	return ""
+}
+
+func (x *TerminalOpenRequest) GetSessionId() string {
+	if x != nil {
+		return x.SessionId
+	}
+	return ""
+}
+
+func (x *TerminalOpenRequest) GetSandboxId() string {
+	if x != nil {
+		return x.SandboxId
+	}
+	return ""
+}
+
+func (x *TerminalOpenRequest) GetContainerId() string {
+	if x != nil {
+		return x.ContainerId
+	}
+	return ""
+}
+
+func (x *TerminalOpenRequest) GetArgs() []string {
+	if x != nil {
+		return x.Args
+	}
+	return nil
+}
+
+func (x *TerminalOpenRequest) GetEnv() []string {
+	if x != nil {
+		return x.Env
+	}
+	return nil
+}
+
+func (x *TerminalOpenRequest) GetCwd() string {
+	if x != nil {
+		return x.Cwd
+	}
+	return ""
+}
+
+func (x *TerminalOpenRequest) GetCols() uint32 {
+	if x != nil {
+		return x.Cols
+	}
+	return 0
+}
+
+func (x *TerminalOpenRequest) GetRows() uint32 {
+	if x != nil {
+		return x.Rows
+	}
+	return 0
+}
+
+type TerminalResize struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Cols          uint32                 `protobuf:"varint,1,opt,name=cols,proto3" json:"cols,omitempty"`
+	Rows          uint32                 `protobuf:"varint,2,opt,name=rows,proto3" json:"rows,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *TerminalResize) Reset() {
+	*x = TerminalResize{}
+	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[83]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *TerminalResize) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*TerminalResize) ProtoMessage() {}
+
+func (x *TerminalResize) ProtoReflect() protoreflect.Message {
+	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[83]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use TerminalResize.ProtoReflect.Descriptor instead.
+func (*TerminalResize) Descriptor() ([]byte, []int) {
+	return file_api_services_cubebox_v1_cubebox_proto_rawDescGZIP(), []int{83}
+}
+
+func (x *TerminalResize) GetCols() uint32 {
+	if x != nil {
+		return x.Cols
+	}
+	return 0
+}
+
+func (x *TerminalResize) GetRows() uint32 {
+	if x != nil {
+		return x.Rows
+	}
+	return 0
+}
+
+type TerminalClose struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *TerminalClose) Reset() {
+	*x = TerminalClose{}
+	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[84]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *TerminalClose) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*TerminalClose) ProtoMessage() {}
+
+func (x *TerminalClose) ProtoReflect() protoreflect.Message {
+	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[84]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use TerminalClose.ProtoReflect.Descriptor instead.
+func (*TerminalClose) Descriptor() ([]byte, []int) {
+	return file_api_services_cubebox_v1_cubebox_proto_rawDescGZIP(), []int{84}
+}
+
+// Server-to-client frames for an interactive terminal session.
+type TerminalServerMessage struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Types that are valid to be assigned to Payload:
+	//
+	//	*TerminalServerMessage_Ready
+	//	*TerminalServerMessage_Output
+	//	*TerminalServerMessage_Exit
+	//	*TerminalServerMessage_Error
+	Payload       isTerminalServerMessage_Payload `protobuf_oneof:"payload"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *TerminalServerMessage) Reset() {
+	*x = TerminalServerMessage{}
+	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[85]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *TerminalServerMessage) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*TerminalServerMessage) ProtoMessage() {}
+
+func (x *TerminalServerMessage) ProtoReflect() protoreflect.Message {
+	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[85]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use TerminalServerMessage.ProtoReflect.Descriptor instead.
+func (*TerminalServerMessage) Descriptor() ([]byte, []int) {
+	return file_api_services_cubebox_v1_cubebox_proto_rawDescGZIP(), []int{85}
+}
+
+func (x *TerminalServerMessage) GetPayload() isTerminalServerMessage_Payload {
+	if x != nil {
+		return x.Payload
+	}
+	return nil
+}
+
+func (x *TerminalServerMessage) GetReady() *TerminalReady {
+	if x != nil {
+		if x, ok := x.Payload.(*TerminalServerMessage_Ready); ok {
+			return x.Ready
+		}
+	}
+	return nil
+}
+
+func (x *TerminalServerMessage) GetOutput() []byte {
+	if x != nil {
+		if x, ok := x.Payload.(*TerminalServerMessage_Output); ok {
+			return x.Output
+		}
+	}
+	return nil
+}
+
+func (x *TerminalServerMessage) GetExit() *TerminalExit {
+	if x != nil {
+		if x, ok := x.Payload.(*TerminalServerMessage_Exit); ok {
+			return x.Exit
+		}
+	}
+	return nil
+}
+
+func (x *TerminalServerMessage) GetError() *TerminalError {
+	if x != nil {
+		if x, ok := x.Payload.(*TerminalServerMessage_Error); ok {
+			return x.Error
+		}
+	}
+	return nil
+}
+
+type isTerminalServerMessage_Payload interface {
+	isTerminalServerMessage_Payload()
+}
+
+type TerminalServerMessage_Ready struct {
+	Ready *TerminalReady `protobuf:"bytes,1,opt,name=ready,proto3,oneof"`
+}
+
+type TerminalServerMessage_Output struct {
+	Output []byte `protobuf:"bytes,2,opt,name=output,proto3,oneof"`
+}
+
+type TerminalServerMessage_Exit struct {
+	Exit *TerminalExit `protobuf:"bytes,3,opt,name=exit,proto3,oneof"`
+}
+
+type TerminalServerMessage_Error struct {
+	Error *TerminalError `protobuf:"bytes,4,opt,name=error,proto3,oneof"`
+}
+
+func (*TerminalServerMessage_Ready) isTerminalServerMessage_Payload() {}
+
+func (*TerminalServerMessage_Output) isTerminalServerMessage_Payload() {}
+
+func (*TerminalServerMessage_Exit) isTerminalServerMessage_Payload() {}
+
+func (*TerminalServerMessage_Error) isTerminalServerMessage_Payload() {}
+
+type TerminalReady struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	ExecId        string                 `protobuf:"bytes,1,opt,name=exec_id,json=execId,proto3" json:"exec_id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *TerminalReady) Reset() {
+	*x = TerminalReady{}
+	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[86]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *TerminalReady) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*TerminalReady) ProtoMessage() {}
+
+func (x *TerminalReady) ProtoReflect() protoreflect.Message {
+	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[86]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use TerminalReady.ProtoReflect.Descriptor instead.
+func (*TerminalReady) Descriptor() ([]byte, []int) {
+	return file_api_services_cubebox_v1_cubebox_proto_rawDescGZIP(), []int{86}
+}
+
+func (x *TerminalReady) GetExecId() string {
+	if x != nil {
+		return x.ExecId
+	}
+	return ""
+}
+
+type TerminalExit struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	ExitCode      int32                  `protobuf:"varint,1,opt,name=exit_code,json=exitCode,proto3" json:"exit_code,omitempty"`
+	Reason        string                 `protobuf:"bytes,2,opt,name=reason,proto3" json:"reason,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *TerminalExit) Reset() {
+	*x = TerminalExit{}
+	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[87]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *TerminalExit) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*TerminalExit) ProtoMessage() {}
+
+func (x *TerminalExit) ProtoReflect() protoreflect.Message {
+	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[87]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use TerminalExit.ProtoReflect.Descriptor instead.
+func (*TerminalExit) Descriptor() ([]byte, []int) {
+	return file_api_services_cubebox_v1_cubebox_proto_rawDescGZIP(), []int{87}
+}
+
+func (x *TerminalExit) GetExitCode() int32 {
+	if x != nil {
+		return x.ExitCode
+	}
+	return 0
+}
+
+func (x *TerminalExit) GetReason() string {
+	if x != nil {
+		return x.Reason
+	}
+	return ""
+}
+
+type TerminalError struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Code          TerminalErrorCode      `protobuf:"varint,1,opt,name=code,proto3,enum=cubelet.services.cubebox.v1.TerminalErrorCode" json:"code,omitempty"`
+	Message       string                 `protobuf:"bytes,2,opt,name=message,proto3" json:"message,omitempty"`
+	Retryable     bool                   `protobuf:"varint,3,opt,name=retryable,proto3" json:"retryable,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *TerminalError) Reset() {
+	*x = TerminalError{}
+	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[88]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *TerminalError) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*TerminalError) ProtoMessage() {}
+
+func (x *TerminalError) ProtoReflect() protoreflect.Message {
+	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[88]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use TerminalError.ProtoReflect.Descriptor instead.
+func (*TerminalError) Descriptor() ([]byte, []int) {
+	return file_api_services_cubebox_v1_cubebox_proto_rawDescGZIP(), []int{88}
+}
+
+func (x *TerminalError) GetCode() TerminalErrorCode {
+	if x != nil {
+		return x.Code
+	}
+	return TerminalErrorCode_TERMINAL_ERROR_UNSPECIFIED
+}
+
+func (x *TerminalError) GetMessage() string {
+	if x != nil {
+		return x.Message
+	}
+	return ""
+}
+
+func (x *TerminalError) GetRetryable() bool {
+	if x != nil {
+		return x.Retryable
+	}
+	return false
+}
+
 var File_api_services_cubebox_v1_cubebox_proto protoreflect.FileDescriptor
 
 const file_api_services_cubebox_v1_cubebox_proto_rawDesc = "" +
@@ -6998,7 +7639,45 @@ const file_api_services_cubebox_v1_cubebox_proto_rawDesc = "" +
 	"!CleanupOrphanStorageFilesResponse\x12\x1c\n" +
 	"\trequestID\x18\x01 \x01(\tR\trequestID\x124\n" +
 	"\x03ret\x18\x02 \x01(\v2\".cubelet.services.errorcode.v1.RetR\x03ret\x12I\n" +
-	"\aorphans\x18\x03 \x03(\v2/.cubelet.services.cubebox.v1.StorageOrphanEntryR\aorphans*m\n" +
+	"\aorphans\x18\x03 \x03(\v2/.cubelet.services.cubebox.v1.StorageOrphanEntryR\aorphans\"\x8d\x02\n" +
+	"\x15TerminalClientMessage\x12F\n" +
+	"\x04open\x18\x01 \x01(\v20.cubelet.services.cubebox.v1.TerminalOpenRequestH\x00R\x04open\x12\x16\n" +
+	"\x05stdin\x18\x02 \x01(\fH\x00R\x05stdin\x12E\n" +
+	"\x06resize\x18\x03 \x01(\v2+.cubelet.services.cubebox.v1.TerminalResizeH\x00R\x06resize\x12B\n" +
+	"\x05close\x18\x04 \x01(\v2*.cubelet.services.cubebox.v1.TerminalCloseH\x00R\x05closeB\t\n" +
+	"\apayload\"\xf5\x01\n" +
+	"\x13TerminalOpenRequest\x12\x1d\n" +
+	"\n" +
+	"request_id\x18\x01 \x01(\tR\trequestId\x12\x1d\n" +
+	"\n" +
+	"session_id\x18\x02 \x01(\tR\tsessionId\x12\x1d\n" +
+	"\n" +
+	"sandbox_id\x18\x03 \x01(\tR\tsandboxId\x12!\n" +
+	"\fcontainer_id\x18\x04 \x01(\tR\vcontainerId\x12\x12\n" +
+	"\x04args\x18\x05 \x03(\tR\x04args\x12\x10\n" +
+	"\x03env\x18\x06 \x03(\tR\x03env\x12\x10\n" +
+	"\x03cwd\x18\a \x01(\tR\x03cwd\x12\x12\n" +
+	"\x04cols\x18\b \x01(\rR\x04cols\x12\x12\n" +
+	"\x04rows\x18\t \x01(\rR\x04rows\"8\n" +
+	"\x0eTerminalResize\x12\x12\n" +
+	"\x04cols\x18\x01 \x01(\rR\x04cols\x12\x12\n" +
+	"\x04rows\x18\x02 \x01(\rR\x04rows\"\x0f\n" +
+	"\rTerminalClose\"\x85\x02\n" +
+	"\x15TerminalServerMessage\x12B\n" +
+	"\x05ready\x18\x01 \x01(\v2*.cubelet.services.cubebox.v1.TerminalReadyH\x00R\x05ready\x12\x18\n" +
+	"\x06output\x18\x02 \x01(\fH\x00R\x06output\x12?\n" +
+	"\x04exit\x18\x03 \x01(\v2).cubelet.services.cubebox.v1.TerminalExitH\x00R\x04exit\x12B\n" +
+	"\x05error\x18\x04 \x01(\v2*.cubelet.services.cubebox.v1.TerminalErrorH\x00R\x05errorB\t\n" +
+	"\apayload\"(\n" +
+	"\rTerminalReady\x12\x17\n" +
+	"\aexec_id\x18\x01 \x01(\tR\x06execId\"C\n" +
+	"\fTerminalExit\x12\x1b\n" +
+	"\texit_code\x18\x01 \x01(\x05R\bexitCode\x12\x16\n" +
+	"\x06reason\x18\x02 \x01(\tR\x06reason\"\x8b\x01\n" +
+	"\rTerminalError\x12B\n" +
+	"\x04code\x18\x01 \x01(\x0e2..cubelet.services.cubebox.v1.TerminalErrorCodeR\x04code\x12\x18\n" +
+	"\amessage\x18\x02 \x01(\tR\amessage\x12\x1c\n" +
+	"\tretryable\x18\x03 \x01(\bR\tretryable*m\n" +
 	"\x10MountPropagation\x12\x17\n" +
 	"\x13PROPAGATION_PRIVATE\x10\x00\x12!\n" +
 	"\x1dPROPAGATION_HOST_TO_CONTAINER\x10\x01\x12\x1d\n" +
@@ -7022,14 +7701,22 @@ const file_api_services_cubebox_v1_cubebox_proto_rawDesc = "" +
 	"\x10CONTAINER_EXITED\x10\x02\x12\x15\n" +
 	"\x11CONTAINER_UNKNOWN\x10\x03\x12\x15\n" +
 	"\x11CONTAINER_PAUSING\x10\x04\x12\x14\n" +
-	"\x10CONTAINER_PAUSED\x10\x052\x8a\x0f\n" +
+	"\x10CONTAINER_PAUSED\x10\x05*\xe1\x01\n" +
+	"\x11TerminalErrorCode\x12\x1e\n" +
+	"\x1aTERMINAL_ERROR_UNSPECIFIED\x10\x00\x12\"\n" +
+	"\x1eTERMINAL_ERROR_INVALID_REQUEST\x10\x01\x12#\n" +
+	"\x1fTERMINAL_ERROR_TARGET_NOT_FOUND\x10\x02\x12%\n" +
+	"!TERMINAL_ERROR_TARGET_NOT_RUNNING\x10\x03\x12\x1b\n" +
+	"\x17TERMINAL_ERROR_INTERNAL\x10\x04\x12\x1f\n" +
+	"\x1bTERMINAL_ERROR_IDLE_TIMEOUT\x10\x052\x88\x10\n" +
 	"\n" +
 	"CubeboxMgr\x12q\n" +
 	"\x06Create\x122.cubelet.services.cubebox.v1.RunCubeSandboxRequest\x1a3.cubelet.services.cubebox.v1.RunCubeSandboxResponse\x12z\n" +
 	"\aDestroy\x126.cubelet.services.cubebox.v1.DestroyCubeSandboxRequest\x1a7.cubelet.services.cubebox.v1.DestroyCubeSandboxResponse\x12q\n" +
 	"\x04List\x123.cubelet.services.cubebox.v1.ListCubeSandboxRequest\x1a4.cubelet.services.cubebox.v1.ListCubeSandboxResponse\x12w\n" +
 	"\x06Update\x125.cubelet.services.cubebox.v1.UpdateCubeSandboxRequest\x1a6.cubelet.services.cubebox.v1.UpdateCubeSandboxResponse\x12q\n" +
-	"\x04Exec\x123.cubelet.services.cubebox.v1.ExecCubeSandboxRequest\x1a4.cubelet.services.cubebox.v1.ExecCubeSandboxResponse\x12p\n" +
+	"\x04Exec\x123.cubelet.services.cubebox.v1.ExecCubeSandboxRequest\x1a4.cubelet.services.cubebox.v1.ExecCubeSandboxResponse\x12|\n" +
+	"\x0eAttachTerminal\x122.cubelet.services.cubebox.v1.TerminalClientMessage\x1a2.cubelet.services.cubebox.v1.TerminalServerMessage(\x010\x01\x12p\n" +
 	"\vAppSnapshot\x12/.cubelet.services.cubebox.v1.AppSnapshotRequest\x1a0.cubelet.services.cubebox.v1.AppSnapshotResponse\x12v\n" +
 	"\rCommitSandbox\x121.cubelet.services.cubebox.v1.CommitSandboxRequest\x1a2.cubelet.services.cubebox.v1.CommitSandboxResponse\x12|\n" +
 	"\x0fRollbackSandbox\x123.cubelet.services.cubebox.v1.RollbackSandboxRequest\x1a4.cubelet.services.cubebox.v1.RollbackSandboxResponse\x12|\n" +
@@ -7053,8 +7740,8 @@ func file_api_services_cubebox_v1_cubebox_proto_rawDescGZIP() []byte {
 	return file_api_services_cubebox_v1_cubebox_proto_rawDescData
 }
 
-var file_api_services_cubebox_v1_cubebox_proto_enumTypes = make([]protoimpl.EnumInfo, 6)
-var file_api_services_cubebox_v1_cubebox_proto_msgTypes = make([]protoimpl.MessageInfo, 93)
+var file_api_services_cubebox_v1_cubebox_proto_enumTypes = make([]protoimpl.EnumInfo, 7)
+var file_api_services_cubebox_v1_cubebox_proto_msgTypes = make([]protoimpl.MessageInfo, 101)
 var file_api_services_cubebox_v1_cubebox_proto_goTypes = []any{
 	(MountPropagation)(0),                     // 0: cubelet.services.cubebox.v1.MountPropagation
 	(StorageMedium)(0),                        // 1: cubelet.services.cubebox.v1.StorageMedium
@@ -7062,231 +7749,249 @@ var file_api_services_cubebox_v1_cubebox_proto_goTypes = []any{
 	(InstanceType)(0),                         // 3: cubelet.services.cubebox.v1.InstanceType
 	(NetworkType)(0),                          // 4: cubelet.services.cubebox.v1.NetworkType
 	(ContainerState)(0),                       // 5: cubelet.services.cubebox.v1.ContainerState
-	(*SELinuxOption)(nil),                     // 6: cubelet.services.cubebox.v1.SELinuxOption
-	(*Capability)(nil),                        // 7: cubelet.services.cubebox.v1.Capability
-	(*Int64Value)(nil),                        // 8: cubelet.services.cubebox.v1.Int64Value
-	(*ContainerSecurityContext)(nil),          // 9: cubelet.services.cubebox.v1.ContainerSecurityContext
-	(*DNSConfig)(nil),                         // 10: cubelet.services.cubebox.v1.DNSConfig
-	(*RLimit)(nil),                            // 11: cubelet.services.cubebox.v1.RLimit
-	(*VolumeMounts)(nil),                      // 12: cubelet.services.cubebox.v1.VolumeMounts
-	(*TCPSocketAction)(nil),                   // 13: cubelet.services.cubebox.v1.TCPSocketAction
-	(*PingAction)(nil),                        // 14: cubelet.services.cubebox.v1.PingAction
-	(*HTTPGetAction)(nil),                     // 15: cubelet.services.cubebox.v1.HTTPGetAction
-	(*HTTPHeader)(nil),                        // 16: cubelet.services.cubebox.v1.HTTPHeader
-	(*ProbeHandler)(nil),                      // 17: cubelet.services.cubebox.v1.ProbeHandler
-	(*Probe)(nil),                             // 18: cubelet.services.cubebox.v1.Probe
-	(*LifecycleHandler)(nil),                  // 19: cubelet.services.cubebox.v1.LifecycleHandler
-	(*PreStop)(nil),                           // 20: cubelet.services.cubebox.v1.PreStop
-	(*PostStop)(nil),                          // 21: cubelet.services.cubebox.v1.PostStop
-	(*Hook)(nil),                              // 22: cubelet.services.cubebox.v1.Hook
-	(*Hooks)(nil),                             // 23: cubelet.services.cubebox.v1.Hooks
-	(*KeyValue)(nil),                          // 24: cubelet.services.cubebox.v1.KeyValue
-	(*HostAlias)(nil),                         // 25: cubelet.services.cubebox.v1.HostAlias
-	(*ContainerConfig)(nil),                   // 26: cubelet.services.cubebox.v1.ContainerConfig
-	(*OCIConfig)(nil),                         // 27: cubelet.services.cubebox.v1.OCIConfig
-	(*Device)(nil),                            // 28: cubelet.services.cubebox.v1.Device
-	(*CDIDevice)(nil),                         // 29: cubelet.services.cubebox.v1.CDIDevice
-	(*LinuxSeccompArg)(nil),                   // 30: cubelet.services.cubebox.v1.LinuxSeccompArg
-	(*SysCall)(nil),                           // 31: cubelet.services.cubebox.v1.SysCall
-	(*Resource)(nil),                          // 32: cubelet.services.cubebox.v1.Resource
-	(*EmptyDirVolumeSource)(nil),              // 33: cubelet.services.cubebox.v1.EmptyDirVolumeSource
-	(*SandboxPathVolumeSource)(nil),           // 34: cubelet.services.cubebox.v1.SandboxPathVolumeSource
-	(*HostDirSource)(nil),                     // 35: cubelet.services.cubebox.v1.HostDirSource
-	(*HostDirVolumeSources)(nil),              // 36: cubelet.services.cubebox.v1.HostDirVolumeSources
-	(*VolumeSource)(nil),                      // 37: cubelet.services.cubebox.v1.VolumeSource
-	(*Volume)(nil),                            // 38: cubelet.services.cubebox.v1.Volume
-	(*RunCubeSandboxRequest)(nil),             // 39: cubelet.services.cubebox.v1.RunCubeSandboxRequest
-	(*RunCubeSandboxResponse)(nil),            // 40: cubelet.services.cubebox.v1.RunCubeSandboxResponse
-	(*PortMapping)(nil),                       // 41: cubelet.services.cubebox.v1.PortMapping
-	(*CubeNetworkConfig)(nil),                 // 42: cubelet.services.cubebox.v1.CubeNetworkConfig
-	(*EgressRule)(nil),                        // 43: cubelet.services.cubebox.v1.EgressRule
-	(*EgressRuleMatch)(nil),                   // 44: cubelet.services.cubebox.v1.EgressRuleMatch
-	(*EgressRuleAction)(nil),                  // 45: cubelet.services.cubebox.v1.EgressRuleAction
-	(*EgressRuleInject)(nil),                  // 46: cubelet.services.cubebox.v1.EgressRuleInject
-	(*DestroyCubeSandboxRequest)(nil),         // 47: cubelet.services.cubebox.v1.DestroyCubeSandboxRequest
-	(*DestroyCubeSandboxResponse)(nil),        // 48: cubelet.services.cubebox.v1.DestroyCubeSandboxResponse
-	(*CubeSandbox)(nil),                       // 49: cubelet.services.cubebox.v1.CubeSandbox
-	(*Container)(nil),                         // 50: cubelet.services.cubebox.v1.Container
-	(*ContainerStateValue)(nil),               // 51: cubelet.services.cubebox.v1.ContainerStateValue
-	(*CubeSandboxFilter)(nil),                 // 52: cubelet.services.cubebox.v1.CubeSandboxFilter
-	(*ListCubeSandboxRequest)(nil),            // 53: cubelet.services.cubebox.v1.ListCubeSandboxRequest
-	(*ListCubeSandboxResponse)(nil),           // 54: cubelet.services.cubebox.v1.ListCubeSandboxResponse
-	(*UpdateCubeSandboxRequest)(nil),          // 55: cubelet.services.cubebox.v1.UpdateCubeSandboxRequest
-	(*UpdateCubeSandboxResponse)(nil),         // 56: cubelet.services.cubebox.v1.UpdateCubeSandboxResponse
-	(*IDMapping)(nil),                         // 57: cubelet.services.cubebox.v1.IDMapping
-	(*ListCubeSandboxOption)(nil),             // 58: cubelet.services.cubebox.v1.ListCubeSandboxOption
-	(*ExecCubeSandboxRequest)(nil),            // 59: cubelet.services.cubebox.v1.ExecCubeSandboxRequest
-	(*ExecCubeSandboxResponse)(nil),           // 60: cubelet.services.cubebox.v1.ExecCubeSandboxResponse
-	(*AppSnapshotRequest)(nil),                // 61: cubelet.services.cubebox.v1.AppSnapshotRequest
-	(*AppSnapshotResponse)(nil),               // 62: cubelet.services.cubebox.v1.AppSnapshotResponse
-	(*CommitSandboxRequest)(nil),              // 63: cubelet.services.cubebox.v1.CommitSandboxRequest
-	(*CommitSandboxResponse)(nil),             // 64: cubelet.services.cubebox.v1.CommitSandboxResponse
-	(*RollbackSandboxRequest)(nil),            // 65: cubelet.services.cubebox.v1.RollbackSandboxRequest
-	(*RollbackSandboxResponse)(nil),           // 66: cubelet.services.cubebox.v1.RollbackSandboxResponse
-	(*CowObjectRef)(nil),                      // 67: cubelet.services.cubebox.v1.CowObjectRef
-	(*CleanupTemplateRequest)(nil),            // 68: cubelet.services.cubebox.v1.CleanupTemplateRequest
-	(*CleanupTemplateResponse)(nil),           // 69: cubelet.services.cubebox.v1.CleanupTemplateResponse
-	(*ListSandboxSnapshotsRequest)(nil),       // 70: cubelet.services.cubebox.v1.ListSandboxSnapshotsRequest
-	(*CowObjectStatus)(nil),                   // 71: cubelet.services.cubebox.v1.CowObjectStatus
-	(*ListSandboxSnapshotsResponse)(nil),      // 72: cubelet.services.cubebox.v1.ListSandboxSnapshotsResponse
-	(*ListLocalSnapshotsRequest)(nil),         // 73: cubelet.services.cubebox.v1.ListLocalSnapshotsRequest
-	(*LocalSnapshotInfo)(nil),                 // 74: cubelet.services.cubebox.v1.LocalSnapshotInfo
-	(*ListLocalSnapshotsResponse)(nil),        // 75: cubelet.services.cubebox.v1.ListLocalSnapshotsResponse
-	(*GetLocalSnapshotRequest)(nil),           // 76: cubelet.services.cubebox.v1.GetLocalSnapshotRequest
-	(*GetLocalSnapshotResponse)(nil),          // 77: cubelet.services.cubebox.v1.GetLocalSnapshotResponse
-	(*GetStorageMetricsRequest)(nil),          // 78: cubelet.services.cubebox.v1.GetStorageMetricsRequest
-	(*GetStorageMetricsResponse)(nil),         // 79: cubelet.services.cubebox.v1.GetStorageMetricsResponse
-	(*StorageVolumeInfo)(nil),                 // 80: cubelet.services.cubebox.v1.StorageVolumeInfo
-	(*SandboxStorageInfo)(nil),                // 81: cubelet.services.cubebox.v1.SandboxStorageInfo
-	(*InspectStorageVolumesRequest)(nil),      // 82: cubelet.services.cubebox.v1.InspectStorageVolumesRequest
-	(*InspectStorageVolumesResponse)(nil),     // 83: cubelet.services.cubebox.v1.InspectStorageVolumesResponse
-	(*CleanupOrphanStorageFilesRequest)(nil),  // 84: cubelet.services.cubebox.v1.CleanupOrphanStorageFilesRequest
-	(*StorageOrphanEntry)(nil),                // 85: cubelet.services.cubebox.v1.StorageOrphanEntry
-	(*CleanupOrphanStorageFilesResponse)(nil), // 86: cubelet.services.cubebox.v1.CleanupOrphanStorageFilesResponse
-	nil,                          // 87: cubelet.services.cubebox.v1.ContainerConfig.SysctlsEntry
-	nil,                          // 88: cubelet.services.cubebox.v1.ContainerConfig.AnnotationsEntry
-	nil,                          // 89: cubelet.services.cubebox.v1.RunCubeSandboxRequest.AnnotationsEntry
-	nil,                          // 90: cubelet.services.cubebox.v1.RunCubeSandboxRequest.LabelsEntry
-	nil,                          // 91: cubelet.services.cubebox.v1.RunCubeSandboxResponse.ExtInfoEntry
-	nil,                          // 92: cubelet.services.cubebox.v1.DestroyCubeSandboxRequest.AnnotationsEntry
-	nil,                          // 93: cubelet.services.cubebox.v1.DestroyCubeSandboxResponse.ExtInfoEntry
-	nil,                          // 94: cubelet.services.cubebox.v1.CubeSandbox.LabelsEntry
-	nil,                          // 95: cubelet.services.cubebox.v1.Container.LabelsEntry
-	nil,                          // 96: cubelet.services.cubebox.v1.CubeSandboxFilter.LabelSelectorEntry
-	nil,                          // 97: cubelet.services.cubebox.v1.UpdateCubeSandboxRequest.AnnotationsEntry
-	nil,                          // 98: cubelet.services.cubebox.v1.GetStorageMetricsResponse.MetricsEntry
-	(*v1.ImageSpec)(nil),         // 99: cubelet.services.images.v1.ImageSpec
-	(*v1.ImageVolumeSource)(nil), // 100: cubelet.services.images.v1.ImageVolumeSource
-	(*v11.Ret)(nil),              // 101: cubelet.services.errorcode.v1.Ret
+	(TerminalErrorCode)(0),                    // 6: cubelet.services.cubebox.v1.TerminalErrorCode
+	(*SELinuxOption)(nil),                     // 7: cubelet.services.cubebox.v1.SELinuxOption
+	(*Capability)(nil),                        // 8: cubelet.services.cubebox.v1.Capability
+	(*Int64Value)(nil),                        // 9: cubelet.services.cubebox.v1.Int64Value
+	(*ContainerSecurityContext)(nil),          // 10: cubelet.services.cubebox.v1.ContainerSecurityContext
+	(*DNSConfig)(nil),                         // 11: cubelet.services.cubebox.v1.DNSConfig
+	(*RLimit)(nil),                            // 12: cubelet.services.cubebox.v1.RLimit
+	(*VolumeMounts)(nil),                      // 13: cubelet.services.cubebox.v1.VolumeMounts
+	(*TCPSocketAction)(nil),                   // 14: cubelet.services.cubebox.v1.TCPSocketAction
+	(*PingAction)(nil),                        // 15: cubelet.services.cubebox.v1.PingAction
+	(*HTTPGetAction)(nil),                     // 16: cubelet.services.cubebox.v1.HTTPGetAction
+	(*HTTPHeader)(nil),                        // 17: cubelet.services.cubebox.v1.HTTPHeader
+	(*ProbeHandler)(nil),                      // 18: cubelet.services.cubebox.v1.ProbeHandler
+	(*Probe)(nil),                             // 19: cubelet.services.cubebox.v1.Probe
+	(*LifecycleHandler)(nil),                  // 20: cubelet.services.cubebox.v1.LifecycleHandler
+	(*PreStop)(nil),                           // 21: cubelet.services.cubebox.v1.PreStop
+	(*PostStop)(nil),                          // 22: cubelet.services.cubebox.v1.PostStop
+	(*Hook)(nil),                              // 23: cubelet.services.cubebox.v1.Hook
+	(*Hooks)(nil),                             // 24: cubelet.services.cubebox.v1.Hooks
+	(*KeyValue)(nil),                          // 25: cubelet.services.cubebox.v1.KeyValue
+	(*HostAlias)(nil),                         // 26: cubelet.services.cubebox.v1.HostAlias
+	(*ContainerConfig)(nil),                   // 27: cubelet.services.cubebox.v1.ContainerConfig
+	(*OCIConfig)(nil),                         // 28: cubelet.services.cubebox.v1.OCIConfig
+	(*Device)(nil),                            // 29: cubelet.services.cubebox.v1.Device
+	(*CDIDevice)(nil),                         // 30: cubelet.services.cubebox.v1.CDIDevice
+	(*LinuxSeccompArg)(nil),                   // 31: cubelet.services.cubebox.v1.LinuxSeccompArg
+	(*SysCall)(nil),                           // 32: cubelet.services.cubebox.v1.SysCall
+	(*Resource)(nil),                          // 33: cubelet.services.cubebox.v1.Resource
+	(*EmptyDirVolumeSource)(nil),              // 34: cubelet.services.cubebox.v1.EmptyDirVolumeSource
+	(*SandboxPathVolumeSource)(nil),           // 35: cubelet.services.cubebox.v1.SandboxPathVolumeSource
+	(*HostDirSource)(nil),                     // 36: cubelet.services.cubebox.v1.HostDirSource
+	(*HostDirVolumeSources)(nil),              // 37: cubelet.services.cubebox.v1.HostDirVolumeSources
+	(*VolumeSource)(nil),                      // 38: cubelet.services.cubebox.v1.VolumeSource
+	(*Volume)(nil),                            // 39: cubelet.services.cubebox.v1.Volume
+	(*RunCubeSandboxRequest)(nil),             // 40: cubelet.services.cubebox.v1.RunCubeSandboxRequest
+	(*RunCubeSandboxResponse)(nil),            // 41: cubelet.services.cubebox.v1.RunCubeSandboxResponse
+	(*PortMapping)(nil),                       // 42: cubelet.services.cubebox.v1.PortMapping
+	(*CubeNetworkConfig)(nil),                 // 43: cubelet.services.cubebox.v1.CubeNetworkConfig
+	(*EgressRule)(nil),                        // 44: cubelet.services.cubebox.v1.EgressRule
+	(*EgressRuleMatch)(nil),                   // 45: cubelet.services.cubebox.v1.EgressRuleMatch
+	(*EgressRuleAction)(nil),                  // 46: cubelet.services.cubebox.v1.EgressRuleAction
+	(*EgressRuleInject)(nil),                  // 47: cubelet.services.cubebox.v1.EgressRuleInject
+	(*DestroyCubeSandboxRequest)(nil),         // 48: cubelet.services.cubebox.v1.DestroyCubeSandboxRequest
+	(*DestroyCubeSandboxResponse)(nil),        // 49: cubelet.services.cubebox.v1.DestroyCubeSandboxResponse
+	(*CubeSandbox)(nil),                       // 50: cubelet.services.cubebox.v1.CubeSandbox
+	(*Container)(nil),                         // 51: cubelet.services.cubebox.v1.Container
+	(*ContainerStateValue)(nil),               // 52: cubelet.services.cubebox.v1.ContainerStateValue
+	(*CubeSandboxFilter)(nil),                 // 53: cubelet.services.cubebox.v1.CubeSandboxFilter
+	(*ListCubeSandboxRequest)(nil),            // 54: cubelet.services.cubebox.v1.ListCubeSandboxRequest
+	(*ListCubeSandboxResponse)(nil),           // 55: cubelet.services.cubebox.v1.ListCubeSandboxResponse
+	(*UpdateCubeSandboxRequest)(nil),          // 56: cubelet.services.cubebox.v1.UpdateCubeSandboxRequest
+	(*UpdateCubeSandboxResponse)(nil),         // 57: cubelet.services.cubebox.v1.UpdateCubeSandboxResponse
+	(*IDMapping)(nil),                         // 58: cubelet.services.cubebox.v1.IDMapping
+	(*ListCubeSandboxOption)(nil),             // 59: cubelet.services.cubebox.v1.ListCubeSandboxOption
+	(*ExecCubeSandboxRequest)(nil),            // 60: cubelet.services.cubebox.v1.ExecCubeSandboxRequest
+	(*ExecCubeSandboxResponse)(nil),           // 61: cubelet.services.cubebox.v1.ExecCubeSandboxResponse
+	(*AppSnapshotRequest)(nil),                // 62: cubelet.services.cubebox.v1.AppSnapshotRequest
+	(*AppSnapshotResponse)(nil),               // 63: cubelet.services.cubebox.v1.AppSnapshotResponse
+	(*CommitSandboxRequest)(nil),              // 64: cubelet.services.cubebox.v1.CommitSandboxRequest
+	(*CommitSandboxResponse)(nil),             // 65: cubelet.services.cubebox.v1.CommitSandboxResponse
+	(*RollbackSandboxRequest)(nil),            // 66: cubelet.services.cubebox.v1.RollbackSandboxRequest
+	(*RollbackSandboxResponse)(nil),           // 67: cubelet.services.cubebox.v1.RollbackSandboxResponse
+	(*CowObjectRef)(nil),                      // 68: cubelet.services.cubebox.v1.CowObjectRef
+	(*CleanupTemplateRequest)(nil),            // 69: cubelet.services.cubebox.v1.CleanupTemplateRequest
+	(*CleanupTemplateResponse)(nil),           // 70: cubelet.services.cubebox.v1.CleanupTemplateResponse
+	(*ListSandboxSnapshotsRequest)(nil),       // 71: cubelet.services.cubebox.v1.ListSandboxSnapshotsRequest
+	(*CowObjectStatus)(nil),                   // 72: cubelet.services.cubebox.v1.CowObjectStatus
+	(*ListSandboxSnapshotsResponse)(nil),      // 73: cubelet.services.cubebox.v1.ListSandboxSnapshotsResponse
+	(*ListLocalSnapshotsRequest)(nil),         // 74: cubelet.services.cubebox.v1.ListLocalSnapshotsRequest
+	(*LocalSnapshotInfo)(nil),                 // 75: cubelet.services.cubebox.v1.LocalSnapshotInfo
+	(*ListLocalSnapshotsResponse)(nil),        // 76: cubelet.services.cubebox.v1.ListLocalSnapshotsResponse
+	(*GetLocalSnapshotRequest)(nil),           // 77: cubelet.services.cubebox.v1.GetLocalSnapshotRequest
+	(*GetLocalSnapshotResponse)(nil),          // 78: cubelet.services.cubebox.v1.GetLocalSnapshotResponse
+	(*GetStorageMetricsRequest)(nil),          // 79: cubelet.services.cubebox.v1.GetStorageMetricsRequest
+	(*GetStorageMetricsResponse)(nil),         // 80: cubelet.services.cubebox.v1.GetStorageMetricsResponse
+	(*StorageVolumeInfo)(nil),                 // 81: cubelet.services.cubebox.v1.StorageVolumeInfo
+	(*SandboxStorageInfo)(nil),                // 82: cubelet.services.cubebox.v1.SandboxStorageInfo
+	(*InspectStorageVolumesRequest)(nil),      // 83: cubelet.services.cubebox.v1.InspectStorageVolumesRequest
+	(*InspectStorageVolumesResponse)(nil),     // 84: cubelet.services.cubebox.v1.InspectStorageVolumesResponse
+	(*CleanupOrphanStorageFilesRequest)(nil),  // 85: cubelet.services.cubebox.v1.CleanupOrphanStorageFilesRequest
+	(*StorageOrphanEntry)(nil),                // 86: cubelet.services.cubebox.v1.StorageOrphanEntry
+	(*CleanupOrphanStorageFilesResponse)(nil), // 87: cubelet.services.cubebox.v1.CleanupOrphanStorageFilesResponse
+	(*TerminalClientMessage)(nil),             // 88: cubelet.services.cubebox.v1.TerminalClientMessage
+	(*TerminalOpenRequest)(nil),               // 89: cubelet.services.cubebox.v1.TerminalOpenRequest
+	(*TerminalResize)(nil),                    // 90: cubelet.services.cubebox.v1.TerminalResize
+	(*TerminalClose)(nil),                     // 91: cubelet.services.cubebox.v1.TerminalClose
+	(*TerminalServerMessage)(nil),             // 92: cubelet.services.cubebox.v1.TerminalServerMessage
+	(*TerminalReady)(nil),                     // 93: cubelet.services.cubebox.v1.TerminalReady
+	(*TerminalExit)(nil),                      // 94: cubelet.services.cubebox.v1.TerminalExit
+	(*TerminalError)(nil),                     // 95: cubelet.services.cubebox.v1.TerminalError
+	nil,                                       // 96: cubelet.services.cubebox.v1.ContainerConfig.SysctlsEntry
+	nil,                                       // 97: cubelet.services.cubebox.v1.ContainerConfig.AnnotationsEntry
+	nil,                                       // 98: cubelet.services.cubebox.v1.RunCubeSandboxRequest.AnnotationsEntry
+	nil,                                       // 99: cubelet.services.cubebox.v1.RunCubeSandboxRequest.LabelsEntry
+	nil,                                       // 100: cubelet.services.cubebox.v1.RunCubeSandboxResponse.ExtInfoEntry
+	nil,                                       // 101: cubelet.services.cubebox.v1.DestroyCubeSandboxRequest.AnnotationsEntry
+	nil,                                       // 102: cubelet.services.cubebox.v1.DestroyCubeSandboxResponse.ExtInfoEntry
+	nil,                                       // 103: cubelet.services.cubebox.v1.CubeSandbox.LabelsEntry
+	nil,                                       // 104: cubelet.services.cubebox.v1.Container.LabelsEntry
+	nil,                                       // 105: cubelet.services.cubebox.v1.CubeSandboxFilter.LabelSelectorEntry
+	nil,                                       // 106: cubelet.services.cubebox.v1.UpdateCubeSandboxRequest.AnnotationsEntry
+	nil,                                       // 107: cubelet.services.cubebox.v1.GetStorageMetricsResponse.MetricsEntry
+	(*v1.ImageSpec)(nil),                      // 108: cubelet.services.images.v1.ImageSpec
+	(*v1.ImageVolumeSource)(nil),              // 109: cubelet.services.images.v1.ImageVolumeSource
+	(*v11.Ret)(nil),                           // 110: cubelet.services.errorcode.v1.Ret
 }
 var file_api_services_cubebox_v1_cubebox_proto_depIdxs = []int32{
-	7,   // 0: cubelet.services.cubebox.v1.ContainerSecurityContext.capabilities:type_name -> cubelet.services.cubebox.v1.Capability
-	8,   // 1: cubelet.services.cubebox.v1.ContainerSecurityContext.run_as_user:type_name -> cubelet.services.cubebox.v1.Int64Value
-	8,   // 2: cubelet.services.cubebox.v1.ContainerSecurityContext.run_as_group:type_name -> cubelet.services.cubebox.v1.Int64Value
+	8,   // 0: cubelet.services.cubebox.v1.ContainerSecurityContext.capabilities:type_name -> cubelet.services.cubebox.v1.Capability
+	9,   // 1: cubelet.services.cubebox.v1.ContainerSecurityContext.run_as_user:type_name -> cubelet.services.cubebox.v1.Int64Value
+	9,   // 2: cubelet.services.cubebox.v1.ContainerSecurityContext.run_as_group:type_name -> cubelet.services.cubebox.v1.Int64Value
 	0,   // 3: cubelet.services.cubebox.v1.VolumeMounts.propagation:type_name -> cubelet.services.cubebox.v1.MountPropagation
-	57,  // 4: cubelet.services.cubebox.v1.VolumeMounts.uidMappings:type_name -> cubelet.services.cubebox.v1.IDMapping
-	57,  // 5: cubelet.services.cubebox.v1.VolumeMounts.gidMappings:type_name -> cubelet.services.cubebox.v1.IDMapping
-	16,  // 6: cubelet.services.cubebox.v1.HTTPGetAction.http_headers:type_name -> cubelet.services.cubebox.v1.HTTPHeader
-	13,  // 7: cubelet.services.cubebox.v1.ProbeHandler.tcp_socket:type_name -> cubelet.services.cubebox.v1.TCPSocketAction
-	14,  // 8: cubelet.services.cubebox.v1.ProbeHandler.ping:type_name -> cubelet.services.cubebox.v1.PingAction
-	15,  // 9: cubelet.services.cubebox.v1.ProbeHandler.http_get:type_name -> cubelet.services.cubebox.v1.HTTPGetAction
-	17,  // 10: cubelet.services.cubebox.v1.Probe.probe_handler:type_name -> cubelet.services.cubebox.v1.ProbeHandler
-	15,  // 11: cubelet.services.cubebox.v1.LifecycleHandler.http_get:type_name -> cubelet.services.cubebox.v1.HTTPGetAction
-	19,  // 12: cubelet.services.cubebox.v1.PreStop.lifecyle_handler:type_name -> cubelet.services.cubebox.v1.LifecycleHandler
-	19,  // 13: cubelet.services.cubebox.v1.PostStop.lifecyle_handler:type_name -> cubelet.services.cubebox.v1.LifecycleHandler
-	22,  // 14: cubelet.services.cubebox.v1.Hooks.Prestart:type_name -> cubelet.services.cubebox.v1.Hook
-	99,  // 15: cubelet.services.cubebox.v1.ContainerConfig.image:type_name -> cubelet.services.images.v1.ImageSpec
-	24,  // 16: cubelet.services.cubebox.v1.ContainerConfig.envs:type_name -> cubelet.services.cubebox.v1.KeyValue
-	12,  // 17: cubelet.services.cubebox.v1.ContainerConfig.volume_mounts:type_name -> cubelet.services.cubebox.v1.VolumeMounts
-	11,  // 18: cubelet.services.cubebox.v1.ContainerConfig.r_limit:type_name -> cubelet.services.cubebox.v1.RLimit
-	32,  // 19: cubelet.services.cubebox.v1.ContainerConfig.resources:type_name -> cubelet.services.cubebox.v1.Resource
-	9,   // 20: cubelet.services.cubebox.v1.ContainerConfig.security_context:type_name -> cubelet.services.cubebox.v1.ContainerSecurityContext
-	18,  // 21: cubelet.services.cubebox.v1.ContainerConfig.probe:type_name -> cubelet.services.cubebox.v1.Probe
-	87,  // 22: cubelet.services.cubebox.v1.ContainerConfig.sysctls:type_name -> cubelet.services.cubebox.v1.ContainerConfig.SysctlsEntry
-	31,  // 23: cubelet.services.cubebox.v1.ContainerConfig.syscalls:type_name -> cubelet.services.cubebox.v1.SysCall
-	10,  // 24: cubelet.services.cubebox.v1.ContainerConfig.dns_config:type_name -> cubelet.services.cubebox.v1.DNSConfig
-	88,  // 25: cubelet.services.cubebox.v1.ContainerConfig.annotations:type_name -> cubelet.services.cubebox.v1.ContainerConfig.AnnotationsEntry
-	25,  // 26: cubelet.services.cubebox.v1.ContainerConfig.hostAliases:type_name -> cubelet.services.cubebox.v1.HostAlias
-	20,  // 27: cubelet.services.cubebox.v1.ContainerConfig.prestop:type_name -> cubelet.services.cubebox.v1.PreStop
-	21,  // 28: cubelet.services.cubebox.v1.ContainerConfig.poststop:type_name -> cubelet.services.cubebox.v1.PostStop
-	23,  // 29: cubelet.services.cubebox.v1.ContainerConfig.hooks:type_name -> cubelet.services.cubebox.v1.Hooks
-	27,  // 30: cubelet.services.cubebox.v1.ContainerConfig.oci_config:type_name -> cubelet.services.cubebox.v1.OCIConfig
-	28,  // 31: cubelet.services.cubebox.v1.OCIConfig.devices:type_name -> cubelet.services.cubebox.v1.Device
-	29,  // 32: cubelet.services.cubebox.v1.OCIConfig.cdi_devices:type_name -> cubelet.services.cubebox.v1.CDIDevice
-	30,  // 33: cubelet.services.cubebox.v1.SysCall.args:type_name -> cubelet.services.cubebox.v1.LinuxSeccompArg
+	58,  // 4: cubelet.services.cubebox.v1.VolumeMounts.uidMappings:type_name -> cubelet.services.cubebox.v1.IDMapping
+	58,  // 5: cubelet.services.cubebox.v1.VolumeMounts.gidMappings:type_name -> cubelet.services.cubebox.v1.IDMapping
+	17,  // 6: cubelet.services.cubebox.v1.HTTPGetAction.http_headers:type_name -> cubelet.services.cubebox.v1.HTTPHeader
+	14,  // 7: cubelet.services.cubebox.v1.ProbeHandler.tcp_socket:type_name -> cubelet.services.cubebox.v1.TCPSocketAction
+	15,  // 8: cubelet.services.cubebox.v1.ProbeHandler.ping:type_name -> cubelet.services.cubebox.v1.PingAction
+	16,  // 9: cubelet.services.cubebox.v1.ProbeHandler.http_get:type_name -> cubelet.services.cubebox.v1.HTTPGetAction
+	18,  // 10: cubelet.services.cubebox.v1.Probe.probe_handler:type_name -> cubelet.services.cubebox.v1.ProbeHandler
+	16,  // 11: cubelet.services.cubebox.v1.LifecycleHandler.http_get:type_name -> cubelet.services.cubebox.v1.HTTPGetAction
+	20,  // 12: cubelet.services.cubebox.v1.PreStop.lifecyle_handler:type_name -> cubelet.services.cubebox.v1.LifecycleHandler
+	20,  // 13: cubelet.services.cubebox.v1.PostStop.lifecyle_handler:type_name -> cubelet.services.cubebox.v1.LifecycleHandler
+	23,  // 14: cubelet.services.cubebox.v1.Hooks.Prestart:type_name -> cubelet.services.cubebox.v1.Hook
+	108, // 15: cubelet.services.cubebox.v1.ContainerConfig.image:type_name -> cubelet.services.images.v1.ImageSpec
+	25,  // 16: cubelet.services.cubebox.v1.ContainerConfig.envs:type_name -> cubelet.services.cubebox.v1.KeyValue
+	13,  // 17: cubelet.services.cubebox.v1.ContainerConfig.volume_mounts:type_name -> cubelet.services.cubebox.v1.VolumeMounts
+	12,  // 18: cubelet.services.cubebox.v1.ContainerConfig.r_limit:type_name -> cubelet.services.cubebox.v1.RLimit
+	33,  // 19: cubelet.services.cubebox.v1.ContainerConfig.resources:type_name -> cubelet.services.cubebox.v1.Resource
+	10,  // 20: cubelet.services.cubebox.v1.ContainerConfig.security_context:type_name -> cubelet.services.cubebox.v1.ContainerSecurityContext
+	19,  // 21: cubelet.services.cubebox.v1.ContainerConfig.probe:type_name -> cubelet.services.cubebox.v1.Probe
+	96,  // 22: cubelet.services.cubebox.v1.ContainerConfig.sysctls:type_name -> cubelet.services.cubebox.v1.ContainerConfig.SysctlsEntry
+	32,  // 23: cubelet.services.cubebox.v1.ContainerConfig.syscalls:type_name -> cubelet.services.cubebox.v1.SysCall
+	11,  // 24: cubelet.services.cubebox.v1.ContainerConfig.dns_config:type_name -> cubelet.services.cubebox.v1.DNSConfig
+	97,  // 25: cubelet.services.cubebox.v1.ContainerConfig.annotations:type_name -> cubelet.services.cubebox.v1.ContainerConfig.AnnotationsEntry
+	26,  // 26: cubelet.services.cubebox.v1.ContainerConfig.hostAliases:type_name -> cubelet.services.cubebox.v1.HostAlias
+	21,  // 27: cubelet.services.cubebox.v1.ContainerConfig.prestop:type_name -> cubelet.services.cubebox.v1.PreStop
+	22,  // 28: cubelet.services.cubebox.v1.ContainerConfig.poststop:type_name -> cubelet.services.cubebox.v1.PostStop
+	24,  // 29: cubelet.services.cubebox.v1.ContainerConfig.hooks:type_name -> cubelet.services.cubebox.v1.Hooks
+	28,  // 30: cubelet.services.cubebox.v1.ContainerConfig.oci_config:type_name -> cubelet.services.cubebox.v1.OCIConfig
+	29,  // 31: cubelet.services.cubebox.v1.OCIConfig.devices:type_name -> cubelet.services.cubebox.v1.Device
+	30,  // 32: cubelet.services.cubebox.v1.OCIConfig.cdi_devices:type_name -> cubelet.services.cubebox.v1.CDIDevice
+	31,  // 33: cubelet.services.cubebox.v1.SysCall.args:type_name -> cubelet.services.cubebox.v1.LinuxSeccompArg
 	1,   // 34: cubelet.services.cubebox.v1.EmptyDirVolumeSource.Medium:type_name -> cubelet.services.cubebox.v1.StorageMedium
-	35,  // 35: cubelet.services.cubebox.v1.HostDirVolumeSources.volume_sources:type_name -> cubelet.services.cubebox.v1.HostDirSource
-	33,  // 36: cubelet.services.cubebox.v1.VolumeSource.empty_dir:type_name -> cubelet.services.cubebox.v1.EmptyDirVolumeSource
-	34,  // 37: cubelet.services.cubebox.v1.VolumeSource.sandbox_path:type_name -> cubelet.services.cubebox.v1.SandboxPathVolumeSource
-	36,  // 38: cubelet.services.cubebox.v1.VolumeSource.host_dir_volumes:type_name -> cubelet.services.cubebox.v1.HostDirVolumeSources
-	100, // 39: cubelet.services.cubebox.v1.VolumeSource.image:type_name -> cubelet.services.images.v1.ImageVolumeSource
-	37,  // 40: cubelet.services.cubebox.v1.Volume.volume_source:type_name -> cubelet.services.cubebox.v1.VolumeSource
-	38,  // 41: cubelet.services.cubebox.v1.RunCubeSandboxRequest.volumes:type_name -> cubelet.services.cubebox.v1.Volume
-	26,  // 42: cubelet.services.cubebox.v1.RunCubeSandboxRequest.containers:type_name -> cubelet.services.cubebox.v1.ContainerConfig
-	89,  // 43: cubelet.services.cubebox.v1.RunCubeSandboxRequest.annotations:type_name -> cubelet.services.cubebox.v1.RunCubeSandboxRequest.AnnotationsEntry
-	90,  // 44: cubelet.services.cubebox.v1.RunCubeSandboxRequest.labels:type_name -> cubelet.services.cubebox.v1.RunCubeSandboxRequest.LabelsEntry
-	42,  // 45: cubelet.services.cubebox.v1.RunCubeSandboxRequest.cube_network_config:type_name -> cubelet.services.cubebox.v1.CubeNetworkConfig
-	101, // 46: cubelet.services.cubebox.v1.RunCubeSandboxResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
-	91,  // 47: cubelet.services.cubebox.v1.RunCubeSandboxResponse.ext_info:type_name -> cubelet.services.cubebox.v1.RunCubeSandboxResponse.ExtInfoEntry
-	41,  // 48: cubelet.services.cubebox.v1.RunCubeSandboxResponse.port_mappings:type_name -> cubelet.services.cubebox.v1.PortMapping
-	43,  // 49: cubelet.services.cubebox.v1.CubeNetworkConfig.rules:type_name -> cubelet.services.cubebox.v1.EgressRule
-	44,  // 50: cubelet.services.cubebox.v1.EgressRule.match:type_name -> cubelet.services.cubebox.v1.EgressRuleMatch
-	45,  // 51: cubelet.services.cubebox.v1.EgressRule.action:type_name -> cubelet.services.cubebox.v1.EgressRuleAction
-	46,  // 52: cubelet.services.cubebox.v1.EgressRuleAction.inject:type_name -> cubelet.services.cubebox.v1.EgressRuleInject
-	92,  // 53: cubelet.services.cubebox.v1.DestroyCubeSandboxRequest.annotations:type_name -> cubelet.services.cubebox.v1.DestroyCubeSandboxRequest.AnnotationsEntry
-	52,  // 54: cubelet.services.cubebox.v1.DestroyCubeSandboxRequest.filter:type_name -> cubelet.services.cubebox.v1.CubeSandboxFilter
-	101, // 55: cubelet.services.cubebox.v1.DestroyCubeSandboxResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
-	93,  // 56: cubelet.services.cubebox.v1.DestroyCubeSandboxResponse.ext_info:type_name -> cubelet.services.cubebox.v1.DestroyCubeSandboxResponse.ExtInfoEntry
-	50,  // 57: cubelet.services.cubebox.v1.CubeSandbox.containers:type_name -> cubelet.services.cubebox.v1.Container
-	41,  // 58: cubelet.services.cubebox.v1.CubeSandbox.port_mappings:type_name -> cubelet.services.cubebox.v1.PortMapping
-	94,  // 59: cubelet.services.cubebox.v1.CubeSandbox.labels:type_name -> cubelet.services.cubebox.v1.CubeSandbox.LabelsEntry
-	32,  // 60: cubelet.services.cubebox.v1.Container.resources:type_name -> cubelet.services.cubebox.v1.Resource
+	36,  // 35: cubelet.services.cubebox.v1.HostDirVolumeSources.volume_sources:type_name -> cubelet.services.cubebox.v1.HostDirSource
+	34,  // 36: cubelet.services.cubebox.v1.VolumeSource.empty_dir:type_name -> cubelet.services.cubebox.v1.EmptyDirVolumeSource
+	35,  // 37: cubelet.services.cubebox.v1.VolumeSource.sandbox_path:type_name -> cubelet.services.cubebox.v1.SandboxPathVolumeSource
+	37,  // 38: cubelet.services.cubebox.v1.VolumeSource.host_dir_volumes:type_name -> cubelet.services.cubebox.v1.HostDirVolumeSources
+	109, // 39: cubelet.services.cubebox.v1.VolumeSource.image:type_name -> cubelet.services.images.v1.ImageVolumeSource
+	38,  // 40: cubelet.services.cubebox.v1.Volume.volume_source:type_name -> cubelet.services.cubebox.v1.VolumeSource
+	39,  // 41: cubelet.services.cubebox.v1.RunCubeSandboxRequest.volumes:type_name -> cubelet.services.cubebox.v1.Volume
+	27,  // 42: cubelet.services.cubebox.v1.RunCubeSandboxRequest.containers:type_name -> cubelet.services.cubebox.v1.ContainerConfig
+	98,  // 43: cubelet.services.cubebox.v1.RunCubeSandboxRequest.annotations:type_name -> cubelet.services.cubebox.v1.RunCubeSandboxRequest.AnnotationsEntry
+	99,  // 44: cubelet.services.cubebox.v1.RunCubeSandboxRequest.labels:type_name -> cubelet.services.cubebox.v1.RunCubeSandboxRequest.LabelsEntry
+	43,  // 45: cubelet.services.cubebox.v1.RunCubeSandboxRequest.cube_network_config:type_name -> cubelet.services.cubebox.v1.CubeNetworkConfig
+	110, // 46: cubelet.services.cubebox.v1.RunCubeSandboxResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
+	100, // 47: cubelet.services.cubebox.v1.RunCubeSandboxResponse.ext_info:type_name -> cubelet.services.cubebox.v1.RunCubeSandboxResponse.ExtInfoEntry
+	42,  // 48: cubelet.services.cubebox.v1.RunCubeSandboxResponse.port_mappings:type_name -> cubelet.services.cubebox.v1.PortMapping
+	44,  // 49: cubelet.services.cubebox.v1.CubeNetworkConfig.rules:type_name -> cubelet.services.cubebox.v1.EgressRule
+	45,  // 50: cubelet.services.cubebox.v1.EgressRule.match:type_name -> cubelet.services.cubebox.v1.EgressRuleMatch
+	46,  // 51: cubelet.services.cubebox.v1.EgressRule.action:type_name -> cubelet.services.cubebox.v1.EgressRuleAction
+	47,  // 52: cubelet.services.cubebox.v1.EgressRuleAction.inject:type_name -> cubelet.services.cubebox.v1.EgressRuleInject
+	101, // 53: cubelet.services.cubebox.v1.DestroyCubeSandboxRequest.annotations:type_name -> cubelet.services.cubebox.v1.DestroyCubeSandboxRequest.AnnotationsEntry
+	53,  // 54: cubelet.services.cubebox.v1.DestroyCubeSandboxRequest.filter:type_name -> cubelet.services.cubebox.v1.CubeSandboxFilter
+	110, // 55: cubelet.services.cubebox.v1.DestroyCubeSandboxResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
+	102, // 56: cubelet.services.cubebox.v1.DestroyCubeSandboxResponse.ext_info:type_name -> cubelet.services.cubebox.v1.DestroyCubeSandboxResponse.ExtInfoEntry
+	51,  // 57: cubelet.services.cubebox.v1.CubeSandbox.containers:type_name -> cubelet.services.cubebox.v1.Container
+	42,  // 58: cubelet.services.cubebox.v1.CubeSandbox.port_mappings:type_name -> cubelet.services.cubebox.v1.PortMapping
+	103, // 59: cubelet.services.cubebox.v1.CubeSandbox.labels:type_name -> cubelet.services.cubebox.v1.CubeSandbox.LabelsEntry
+	33,  // 60: cubelet.services.cubebox.v1.Container.resources:type_name -> cubelet.services.cubebox.v1.Resource
 	5,   // 61: cubelet.services.cubebox.v1.Container.state:type_name -> cubelet.services.cubebox.v1.ContainerState
-	95,  // 62: cubelet.services.cubebox.v1.Container.labels:type_name -> cubelet.services.cubebox.v1.Container.LabelsEntry
+	104, // 62: cubelet.services.cubebox.v1.Container.labels:type_name -> cubelet.services.cubebox.v1.Container.LabelsEntry
 	5,   // 63: cubelet.services.cubebox.v1.ContainerStateValue.state:type_name -> cubelet.services.cubebox.v1.ContainerState
-	51,  // 64: cubelet.services.cubebox.v1.CubeSandboxFilter.state:type_name -> cubelet.services.cubebox.v1.ContainerStateValue
-	96,  // 65: cubelet.services.cubebox.v1.CubeSandboxFilter.label_selector:type_name -> cubelet.services.cubebox.v1.CubeSandboxFilter.LabelSelectorEntry
-	52,  // 66: cubelet.services.cubebox.v1.ListCubeSandboxRequest.filter:type_name -> cubelet.services.cubebox.v1.CubeSandboxFilter
-	58,  // 67: cubelet.services.cubebox.v1.ListCubeSandboxRequest.option:type_name -> cubelet.services.cubebox.v1.ListCubeSandboxOption
-	49,  // 68: cubelet.services.cubebox.v1.ListCubeSandboxResponse.items:type_name -> cubelet.services.cubebox.v1.CubeSandbox
-	97,  // 69: cubelet.services.cubebox.v1.UpdateCubeSandboxRequest.annotations:type_name -> cubelet.services.cubebox.v1.UpdateCubeSandboxRequest.AnnotationsEntry
-	101, // 70: cubelet.services.cubebox.v1.UpdateCubeSandboxResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
-	101, // 71: cubelet.services.cubebox.v1.ExecCubeSandboxResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
-	39,  // 72: cubelet.services.cubebox.v1.AppSnapshotRequest.create_request:type_name -> cubelet.services.cubebox.v1.RunCubeSandboxRequest
-	101, // 73: cubelet.services.cubebox.v1.AppSnapshotResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
-	101, // 74: cubelet.services.cubebox.v1.CommitSandboxResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
-	101, // 75: cubelet.services.cubebox.v1.RollbackSandboxResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
-	67,  // 76: cubelet.services.cubebox.v1.CleanupTemplateRequest.objects:type_name -> cubelet.services.cubebox.v1.CowObjectRef
-	101, // 77: cubelet.services.cubebox.v1.CleanupTemplateResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
-	67,  // 78: cubelet.services.cubebox.v1.ListSandboxSnapshotsRequest.objects:type_name -> cubelet.services.cubebox.v1.CowObjectRef
-	101, // 79: cubelet.services.cubebox.v1.ListSandboxSnapshotsResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
-	71,  // 80: cubelet.services.cubebox.v1.ListSandboxSnapshotsResponse.objects:type_name -> cubelet.services.cubebox.v1.CowObjectStatus
-	101, // 81: cubelet.services.cubebox.v1.ListLocalSnapshotsResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
-	74,  // 82: cubelet.services.cubebox.v1.ListLocalSnapshotsResponse.snapshots:type_name -> cubelet.services.cubebox.v1.LocalSnapshotInfo
-	101, // 83: cubelet.services.cubebox.v1.GetLocalSnapshotResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
-	74,  // 84: cubelet.services.cubebox.v1.GetLocalSnapshotResponse.snapshot:type_name -> cubelet.services.cubebox.v1.LocalSnapshotInfo
-	101, // 85: cubelet.services.cubebox.v1.GetStorageMetricsResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
-	98,  // 86: cubelet.services.cubebox.v1.GetStorageMetricsResponse.metrics:type_name -> cubelet.services.cubebox.v1.GetStorageMetricsResponse.MetricsEntry
-	80,  // 87: cubelet.services.cubebox.v1.SandboxStorageInfo.volumes:type_name -> cubelet.services.cubebox.v1.StorageVolumeInfo
-	101, // 88: cubelet.services.cubebox.v1.InspectStorageVolumesResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
-	81,  // 89: cubelet.services.cubebox.v1.InspectStorageVolumesResponse.sandboxes:type_name -> cubelet.services.cubebox.v1.SandboxStorageInfo
-	101, // 90: cubelet.services.cubebox.v1.CleanupOrphanStorageFilesResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
-	85,  // 91: cubelet.services.cubebox.v1.CleanupOrphanStorageFilesResponse.orphans:type_name -> cubelet.services.cubebox.v1.StorageOrphanEntry
-	39,  // 92: cubelet.services.cubebox.v1.CubeboxMgr.Create:input_type -> cubelet.services.cubebox.v1.RunCubeSandboxRequest
-	47,  // 93: cubelet.services.cubebox.v1.CubeboxMgr.Destroy:input_type -> cubelet.services.cubebox.v1.DestroyCubeSandboxRequest
-	53,  // 94: cubelet.services.cubebox.v1.CubeboxMgr.List:input_type -> cubelet.services.cubebox.v1.ListCubeSandboxRequest
-	55,  // 95: cubelet.services.cubebox.v1.CubeboxMgr.Update:input_type -> cubelet.services.cubebox.v1.UpdateCubeSandboxRequest
-	59,  // 96: cubelet.services.cubebox.v1.CubeboxMgr.Exec:input_type -> cubelet.services.cubebox.v1.ExecCubeSandboxRequest
-	61,  // 97: cubelet.services.cubebox.v1.CubeboxMgr.AppSnapshot:input_type -> cubelet.services.cubebox.v1.AppSnapshotRequest
-	63,  // 98: cubelet.services.cubebox.v1.CubeboxMgr.CommitSandbox:input_type -> cubelet.services.cubebox.v1.CommitSandboxRequest
-	65,  // 99: cubelet.services.cubebox.v1.CubeboxMgr.RollbackSandbox:input_type -> cubelet.services.cubebox.v1.RollbackSandboxRequest
-	68,  // 100: cubelet.services.cubebox.v1.CubeboxMgr.CleanupTemplate:input_type -> cubelet.services.cubebox.v1.CleanupTemplateRequest
-	70,  // 101: cubelet.services.cubebox.v1.CubeboxMgr.ListSandboxSnapshots:input_type -> cubelet.services.cubebox.v1.ListSandboxSnapshotsRequest
-	73,  // 102: cubelet.services.cubebox.v1.CubeboxMgr.ListLocalSnapshots:input_type -> cubelet.services.cubebox.v1.ListLocalSnapshotsRequest
-	76,  // 103: cubelet.services.cubebox.v1.CubeboxMgr.GetLocalSnapshot:input_type -> cubelet.services.cubebox.v1.GetLocalSnapshotRequest
-	78,  // 104: cubelet.services.cubebox.v1.CubeboxMgr.GetStorageMetrics:input_type -> cubelet.services.cubebox.v1.GetStorageMetricsRequest
-	82,  // 105: cubelet.services.cubebox.v1.CubeboxMgr.InspectStorageVolumes:input_type -> cubelet.services.cubebox.v1.InspectStorageVolumesRequest
-	84,  // 106: cubelet.services.cubebox.v1.CubeboxMgr.CleanupOrphanStorageFiles:input_type -> cubelet.services.cubebox.v1.CleanupOrphanStorageFilesRequest
-	40,  // 107: cubelet.services.cubebox.v1.CubeboxMgr.Create:output_type -> cubelet.services.cubebox.v1.RunCubeSandboxResponse
-	48,  // 108: cubelet.services.cubebox.v1.CubeboxMgr.Destroy:output_type -> cubelet.services.cubebox.v1.DestroyCubeSandboxResponse
-	54,  // 109: cubelet.services.cubebox.v1.CubeboxMgr.List:output_type -> cubelet.services.cubebox.v1.ListCubeSandboxResponse
-	56,  // 110: cubelet.services.cubebox.v1.CubeboxMgr.Update:output_type -> cubelet.services.cubebox.v1.UpdateCubeSandboxResponse
-	60,  // 111: cubelet.services.cubebox.v1.CubeboxMgr.Exec:output_type -> cubelet.services.cubebox.v1.ExecCubeSandboxResponse
-	62,  // 112: cubelet.services.cubebox.v1.CubeboxMgr.AppSnapshot:output_type -> cubelet.services.cubebox.v1.AppSnapshotResponse
-	64,  // 113: cubelet.services.cubebox.v1.CubeboxMgr.CommitSandbox:output_type -> cubelet.services.cubebox.v1.CommitSandboxResponse
-	66,  // 114: cubelet.services.cubebox.v1.CubeboxMgr.RollbackSandbox:output_type -> cubelet.services.cubebox.v1.RollbackSandboxResponse
-	69,  // 115: cubelet.services.cubebox.v1.CubeboxMgr.CleanupTemplate:output_type -> cubelet.services.cubebox.v1.CleanupTemplateResponse
-	72,  // 116: cubelet.services.cubebox.v1.CubeboxMgr.ListSandboxSnapshots:output_type -> cubelet.services.cubebox.v1.ListSandboxSnapshotsResponse
-	75,  // 117: cubelet.services.cubebox.v1.CubeboxMgr.ListLocalSnapshots:output_type -> cubelet.services.cubebox.v1.ListLocalSnapshotsResponse
-	77,  // 118: cubelet.services.cubebox.v1.CubeboxMgr.GetLocalSnapshot:output_type -> cubelet.services.cubebox.v1.GetLocalSnapshotResponse
-	79,  // 119: cubelet.services.cubebox.v1.CubeboxMgr.GetStorageMetrics:output_type -> cubelet.services.cubebox.v1.GetStorageMetricsResponse
-	83,  // 120: cubelet.services.cubebox.v1.CubeboxMgr.InspectStorageVolumes:output_type -> cubelet.services.cubebox.v1.InspectStorageVolumesResponse
-	86,  // 121: cubelet.services.cubebox.v1.CubeboxMgr.CleanupOrphanStorageFiles:output_type -> cubelet.services.cubebox.v1.CleanupOrphanStorageFilesResponse
-	107, // [107:122] is the sub-list for method output_type
-	92,  // [92:107] is the sub-list for method input_type
-	92,  // [92:92] is the sub-list for extension type_name
-	92,  // [92:92] is the sub-list for extension extendee
-	0,   // [0:92] is the sub-list for field type_name
+	52,  // 64: cubelet.services.cubebox.v1.CubeSandboxFilter.state:type_name -> cubelet.services.cubebox.v1.ContainerStateValue
+	105, // 65: cubelet.services.cubebox.v1.CubeSandboxFilter.label_selector:type_name -> cubelet.services.cubebox.v1.CubeSandboxFilter.LabelSelectorEntry
+	53,  // 66: cubelet.services.cubebox.v1.ListCubeSandboxRequest.filter:type_name -> cubelet.services.cubebox.v1.CubeSandboxFilter
+	59,  // 67: cubelet.services.cubebox.v1.ListCubeSandboxRequest.option:type_name -> cubelet.services.cubebox.v1.ListCubeSandboxOption
+	50,  // 68: cubelet.services.cubebox.v1.ListCubeSandboxResponse.items:type_name -> cubelet.services.cubebox.v1.CubeSandbox
+	106, // 69: cubelet.services.cubebox.v1.UpdateCubeSandboxRequest.annotations:type_name -> cubelet.services.cubebox.v1.UpdateCubeSandboxRequest.AnnotationsEntry
+	110, // 70: cubelet.services.cubebox.v1.UpdateCubeSandboxResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
+	110, // 71: cubelet.services.cubebox.v1.ExecCubeSandboxResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
+	40,  // 72: cubelet.services.cubebox.v1.AppSnapshotRequest.create_request:type_name -> cubelet.services.cubebox.v1.RunCubeSandboxRequest
+	110, // 73: cubelet.services.cubebox.v1.AppSnapshotResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
+	110, // 74: cubelet.services.cubebox.v1.CommitSandboxResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
+	110, // 75: cubelet.services.cubebox.v1.RollbackSandboxResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
+	68,  // 76: cubelet.services.cubebox.v1.CleanupTemplateRequest.objects:type_name -> cubelet.services.cubebox.v1.CowObjectRef
+	110, // 77: cubelet.services.cubebox.v1.CleanupTemplateResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
+	68,  // 78: cubelet.services.cubebox.v1.ListSandboxSnapshotsRequest.objects:type_name -> cubelet.services.cubebox.v1.CowObjectRef
+	110, // 79: cubelet.services.cubebox.v1.ListSandboxSnapshotsResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
+	72,  // 80: cubelet.services.cubebox.v1.ListSandboxSnapshotsResponse.objects:type_name -> cubelet.services.cubebox.v1.CowObjectStatus
+	110, // 81: cubelet.services.cubebox.v1.ListLocalSnapshotsResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
+	75,  // 82: cubelet.services.cubebox.v1.ListLocalSnapshotsResponse.snapshots:type_name -> cubelet.services.cubebox.v1.LocalSnapshotInfo
+	110, // 83: cubelet.services.cubebox.v1.GetLocalSnapshotResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
+	75,  // 84: cubelet.services.cubebox.v1.GetLocalSnapshotResponse.snapshot:type_name -> cubelet.services.cubebox.v1.LocalSnapshotInfo
+	110, // 85: cubelet.services.cubebox.v1.GetStorageMetricsResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
+	107, // 86: cubelet.services.cubebox.v1.GetStorageMetricsResponse.metrics:type_name -> cubelet.services.cubebox.v1.GetStorageMetricsResponse.MetricsEntry
+	81,  // 87: cubelet.services.cubebox.v1.SandboxStorageInfo.volumes:type_name -> cubelet.services.cubebox.v1.StorageVolumeInfo
+	110, // 88: cubelet.services.cubebox.v1.InspectStorageVolumesResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
+	82,  // 89: cubelet.services.cubebox.v1.InspectStorageVolumesResponse.sandboxes:type_name -> cubelet.services.cubebox.v1.SandboxStorageInfo
+	110, // 90: cubelet.services.cubebox.v1.CleanupOrphanStorageFilesResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
+	86,  // 91: cubelet.services.cubebox.v1.CleanupOrphanStorageFilesResponse.orphans:type_name -> cubelet.services.cubebox.v1.StorageOrphanEntry
+	89,  // 92: cubelet.services.cubebox.v1.TerminalClientMessage.open:type_name -> cubelet.services.cubebox.v1.TerminalOpenRequest
+	90,  // 93: cubelet.services.cubebox.v1.TerminalClientMessage.resize:type_name -> cubelet.services.cubebox.v1.TerminalResize
+	91,  // 94: cubelet.services.cubebox.v1.TerminalClientMessage.close:type_name -> cubelet.services.cubebox.v1.TerminalClose
+	93,  // 95: cubelet.services.cubebox.v1.TerminalServerMessage.ready:type_name -> cubelet.services.cubebox.v1.TerminalReady
+	94,  // 96: cubelet.services.cubebox.v1.TerminalServerMessage.exit:type_name -> cubelet.services.cubebox.v1.TerminalExit
+	95,  // 97: cubelet.services.cubebox.v1.TerminalServerMessage.error:type_name -> cubelet.services.cubebox.v1.TerminalError
+	6,   // 98: cubelet.services.cubebox.v1.TerminalError.code:type_name -> cubelet.services.cubebox.v1.TerminalErrorCode
+	40,  // 99: cubelet.services.cubebox.v1.CubeboxMgr.Create:input_type -> cubelet.services.cubebox.v1.RunCubeSandboxRequest
+	48,  // 100: cubelet.services.cubebox.v1.CubeboxMgr.Destroy:input_type -> cubelet.services.cubebox.v1.DestroyCubeSandboxRequest
+	54,  // 101: cubelet.services.cubebox.v1.CubeboxMgr.List:input_type -> cubelet.services.cubebox.v1.ListCubeSandboxRequest
+	56,  // 102: cubelet.services.cubebox.v1.CubeboxMgr.Update:input_type -> cubelet.services.cubebox.v1.UpdateCubeSandboxRequest
+	60,  // 103: cubelet.services.cubebox.v1.CubeboxMgr.Exec:input_type -> cubelet.services.cubebox.v1.ExecCubeSandboxRequest
+	88,  // 104: cubelet.services.cubebox.v1.CubeboxMgr.AttachTerminal:input_type -> cubelet.services.cubebox.v1.TerminalClientMessage
+	62,  // 105: cubelet.services.cubebox.v1.CubeboxMgr.AppSnapshot:input_type -> cubelet.services.cubebox.v1.AppSnapshotRequest
+	64,  // 106: cubelet.services.cubebox.v1.CubeboxMgr.CommitSandbox:input_type -> cubelet.services.cubebox.v1.CommitSandboxRequest
+	66,  // 107: cubelet.services.cubebox.v1.CubeboxMgr.RollbackSandbox:input_type -> cubelet.services.cubebox.v1.RollbackSandboxRequest
+	69,  // 108: cubelet.services.cubebox.v1.CubeboxMgr.CleanupTemplate:input_type -> cubelet.services.cubebox.v1.CleanupTemplateRequest
+	71,  // 109: cubelet.services.cubebox.v1.CubeboxMgr.ListSandboxSnapshots:input_type -> cubelet.services.cubebox.v1.ListSandboxSnapshotsRequest
+	74,  // 110: cubelet.services.cubebox.v1.CubeboxMgr.ListLocalSnapshots:input_type -> cubelet.services.cubebox.v1.ListLocalSnapshotsRequest
+	77,  // 111: cubelet.services.cubebox.v1.CubeboxMgr.GetLocalSnapshot:input_type -> cubelet.services.cubebox.v1.GetLocalSnapshotRequest
+	79,  // 112: cubelet.services.cubebox.v1.CubeboxMgr.GetStorageMetrics:input_type -> cubelet.services.cubebox.v1.GetStorageMetricsRequest
+	83,  // 113: cubelet.services.cubebox.v1.CubeboxMgr.InspectStorageVolumes:input_type -> cubelet.services.cubebox.v1.InspectStorageVolumesRequest
+	85,  // 114: cubelet.services.cubebox.v1.CubeboxMgr.CleanupOrphanStorageFiles:input_type -> cubelet.services.cubebox.v1.CleanupOrphanStorageFilesRequest
+	41,  // 115: cubelet.services.cubebox.v1.CubeboxMgr.Create:output_type -> cubelet.services.cubebox.v1.RunCubeSandboxResponse
+	49,  // 116: cubelet.services.cubebox.v1.CubeboxMgr.Destroy:output_type -> cubelet.services.cubebox.v1.DestroyCubeSandboxResponse
+	55,  // 117: cubelet.services.cubebox.v1.CubeboxMgr.List:output_type -> cubelet.services.cubebox.v1.ListCubeSandboxResponse
+	57,  // 118: cubelet.services.cubebox.v1.CubeboxMgr.Update:output_type -> cubelet.services.cubebox.v1.UpdateCubeSandboxResponse
+	61,  // 119: cubelet.services.cubebox.v1.CubeboxMgr.Exec:output_type -> cubelet.services.cubebox.v1.ExecCubeSandboxResponse
+	92,  // 120: cubelet.services.cubebox.v1.CubeboxMgr.AttachTerminal:output_type -> cubelet.services.cubebox.v1.TerminalServerMessage
+	63,  // 121: cubelet.services.cubebox.v1.CubeboxMgr.AppSnapshot:output_type -> cubelet.services.cubebox.v1.AppSnapshotResponse
+	65,  // 122: cubelet.services.cubebox.v1.CubeboxMgr.CommitSandbox:output_type -> cubelet.services.cubebox.v1.CommitSandboxResponse
+	67,  // 123: cubelet.services.cubebox.v1.CubeboxMgr.RollbackSandbox:output_type -> cubelet.services.cubebox.v1.RollbackSandboxResponse
+	70,  // 124: cubelet.services.cubebox.v1.CubeboxMgr.CleanupTemplate:output_type -> cubelet.services.cubebox.v1.CleanupTemplateResponse
+	73,  // 125: cubelet.services.cubebox.v1.CubeboxMgr.ListSandboxSnapshots:output_type -> cubelet.services.cubebox.v1.ListSandboxSnapshotsResponse
+	76,  // 126: cubelet.services.cubebox.v1.CubeboxMgr.ListLocalSnapshots:output_type -> cubelet.services.cubebox.v1.ListLocalSnapshotsResponse
+	78,  // 127: cubelet.services.cubebox.v1.CubeboxMgr.GetLocalSnapshot:output_type -> cubelet.services.cubebox.v1.GetLocalSnapshotResponse
+	80,  // 128: cubelet.services.cubebox.v1.CubeboxMgr.GetStorageMetrics:output_type -> cubelet.services.cubebox.v1.GetStorageMetricsResponse
+	84,  // 129: cubelet.services.cubebox.v1.CubeboxMgr.InspectStorageVolumes:output_type -> cubelet.services.cubebox.v1.InspectStorageVolumesResponse
+	87,  // 130: cubelet.services.cubebox.v1.CubeboxMgr.CleanupOrphanStorageFiles:output_type -> cubelet.services.cubebox.v1.CleanupOrphanStorageFilesResponse
+	115, // [115:131] is the sub-list for method output_type
+	99,  // [99:115] is the sub-list for method input_type
+	99,  // [99:99] is the sub-list for extension type_name
+	99,  // [99:99] is the sub-list for extension extendee
+	0,   // [0:99] is the sub-list for field type_name
 }
 
 func init() { file_api_services_cubebox_v1_cubebox_proto_init() }
@@ -7304,13 +8009,25 @@ func file_api_services_cubebox_v1_cubebox_proto_init() {
 	file_api_services_cubebox_v1_cubebox_proto_msgTypes[39].OneofWrappers = []any{}
 	file_api_services_cubebox_v1_cubebox_proto_msgTypes[40].OneofWrappers = []any{}
 	file_api_services_cubebox_v1_cubebox_proto_msgTypes[47].OneofWrappers = []any{}
+	file_api_services_cubebox_v1_cubebox_proto_msgTypes[81].OneofWrappers = []any{
+		(*TerminalClientMessage_Open)(nil),
+		(*TerminalClientMessage_Stdin)(nil),
+		(*TerminalClientMessage_Resize)(nil),
+		(*TerminalClientMessage_Close)(nil),
+	}
+	file_api_services_cubebox_v1_cubebox_proto_msgTypes[85].OneofWrappers = []any{
+		(*TerminalServerMessage_Ready)(nil),
+		(*TerminalServerMessage_Output)(nil),
+		(*TerminalServerMessage_Exit)(nil),
+		(*TerminalServerMessage_Error)(nil),
+	}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_api_services_cubebox_v1_cubebox_proto_rawDesc), len(file_api_services_cubebox_v1_cubebox_proto_rawDesc)),
-			NumEnums:      6,
-			NumMessages:   93,
+			NumEnums:      7,
+			NumMessages:   101,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/CubeMaster/api/services/cubebox/v1/cubebox.proto
+++ b/CubeMaster/api/services/cubebox/v1/cubebox.proto
@@ -18,6 +18,9 @@ service CubeboxMgr {
   rpc List(ListCubeSandboxRequest) returns (ListCubeSandboxResponse);
   rpc Update(UpdateCubeSandboxRequest) returns (UpdateCubeSandboxResponse);
   rpc Exec(ExecCubeSandboxRequest) returns (ExecCubeSandboxResponse);
+  // AttachTerminal owns one interactive TTY process for the stream lifetime.
+  // The first client frame must be open and binds the stream to one container.
+  rpc AttachTerminal(stream TerminalClientMessage) returns (stream TerminalServerMessage);
   // AppSnapshot creates a cubebox, makes an app snapshot, and destroys the cubebox.
   // Required annotations:
   //   - cube.master.appsnapshot.create: "true"
@@ -1152,4 +1155,68 @@ message CleanupOrphanStorageFilesResponse {
   string requestID = 1;
   cubelet.services.errorcode.v1.Ret ret = 2;
   repeated StorageOrphanEntry orphans = 3;
+}
+
+// Client-to-server frames for an interactive terminal session. Keeping client
+// and server frames separate makes invalid message direction unrepresentable.
+message TerminalClientMessage {
+  oneof payload {
+    TerminalOpenRequest open = 1;
+    bytes stdin = 2;
+    TerminalResize resize = 3;
+    TerminalClose close = 4;
+  }
+}
+
+message TerminalOpenRequest {
+  string request_id = 1;
+  string session_id = 2;
+  string sandbox_id = 3;
+  string container_id = 4;
+  repeated string args = 5;
+  repeated string env = 6;
+  string cwd = 7;
+  uint32 cols = 8;
+  uint32 rows = 9;
+}
+
+message TerminalResize {
+  uint32 cols = 1;
+  uint32 rows = 2;
+}
+
+message TerminalClose {}
+
+// Server-to-client frames for an interactive terminal session.
+message TerminalServerMessage {
+  oneof payload {
+    TerminalReady ready = 1;
+    bytes output = 2;
+    TerminalExit exit = 3;
+    TerminalError error = 4;
+  }
+}
+
+message TerminalReady {
+  string exec_id = 1;
+}
+
+message TerminalExit {
+  int32 exit_code = 1;
+  string reason = 2;
+}
+
+enum TerminalErrorCode {
+  TERMINAL_ERROR_UNSPECIFIED = 0;
+  TERMINAL_ERROR_INVALID_REQUEST = 1;
+  TERMINAL_ERROR_TARGET_NOT_FOUND = 2;
+  TERMINAL_ERROR_TARGET_NOT_RUNNING = 3;
+  TERMINAL_ERROR_INTERNAL = 4;
+  TERMINAL_ERROR_IDLE_TIMEOUT = 5;
+}
+
+message TerminalError {
+  TerminalErrorCode code = 1;
+  string message = 2;
+  bool retryable = 3;
 }

--- a/CubeMaster/api/services/cubebox/v1/cubebox_grpc.pb.go
+++ b/CubeMaster/api/services/cubebox/v1/cubebox_grpc.pb.go
@@ -28,6 +28,7 @@ const (
 	CubeboxMgr_List_FullMethodName                      = "/cubelet.services.cubebox.v1.CubeboxMgr/List"
 	CubeboxMgr_Update_FullMethodName                    = "/cubelet.services.cubebox.v1.CubeboxMgr/Update"
 	CubeboxMgr_Exec_FullMethodName                      = "/cubelet.services.cubebox.v1.CubeboxMgr/Exec"
+	CubeboxMgr_AttachTerminal_FullMethodName            = "/cubelet.services.cubebox.v1.CubeboxMgr/AttachTerminal"
 	CubeboxMgr_AppSnapshot_FullMethodName               = "/cubelet.services.cubebox.v1.CubeboxMgr/AppSnapshot"
 	CubeboxMgr_CommitSandbox_FullMethodName             = "/cubelet.services.cubebox.v1.CubeboxMgr/CommitSandbox"
 	CubeboxMgr_RollbackSandbox_FullMethodName           = "/cubelet.services.cubebox.v1.CubeboxMgr/RollbackSandbox"
@@ -51,6 +52,9 @@ type CubeboxMgrClient interface {
 	List(ctx context.Context, in *ListCubeSandboxRequest, opts ...grpc.CallOption) (*ListCubeSandboxResponse, error)
 	Update(ctx context.Context, in *UpdateCubeSandboxRequest, opts ...grpc.CallOption) (*UpdateCubeSandboxResponse, error)
 	Exec(ctx context.Context, in *ExecCubeSandboxRequest, opts ...grpc.CallOption) (*ExecCubeSandboxResponse, error)
+	// AttachTerminal owns one interactive TTY process for the stream lifetime.
+	// The first client frame must be open and binds the stream to one container.
+	AttachTerminal(ctx context.Context, opts ...grpc.CallOption) (grpc.BidiStreamingClient[TerminalClientMessage, TerminalServerMessage], error)
 	// AppSnapshot creates a cubebox, makes an app snapshot, and destroys the cubebox.
 	// Required annotations:
 	//   - cube.master.appsnapshot.create: "true"
@@ -139,6 +143,19 @@ func (c *cubeboxMgrClient) Exec(ctx context.Context, in *ExecCubeSandboxRequest,
 	}
 	return out, nil
 }
+
+func (c *cubeboxMgrClient) AttachTerminal(ctx context.Context, opts ...grpc.CallOption) (grpc.BidiStreamingClient[TerminalClientMessage, TerminalServerMessage], error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	stream, err := c.cc.NewStream(ctx, &CubeboxMgr_ServiceDesc.Streams[0], CubeboxMgr_AttachTerminal_FullMethodName, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	x := &grpc.GenericClientStream[TerminalClientMessage, TerminalServerMessage]{ClientStream: stream}
+	return x, nil
+}
+
+// This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
+type CubeboxMgr_AttachTerminalClient = grpc.BidiStreamingClient[TerminalClientMessage, TerminalServerMessage]
 
 func (c *cubeboxMgrClient) AppSnapshot(ctx context.Context, in *AppSnapshotRequest, opts ...grpc.CallOption) (*AppSnapshotResponse, error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
@@ -251,6 +268,9 @@ type CubeboxMgrServer interface {
 	List(context.Context, *ListCubeSandboxRequest) (*ListCubeSandboxResponse, error)
 	Update(context.Context, *UpdateCubeSandboxRequest) (*UpdateCubeSandboxResponse, error)
 	Exec(context.Context, *ExecCubeSandboxRequest) (*ExecCubeSandboxResponse, error)
+	// AttachTerminal owns one interactive TTY process for the stream lifetime.
+	// The first client frame must be open and binds the stream to one container.
+	AttachTerminal(grpc.BidiStreamingServer[TerminalClientMessage, TerminalServerMessage]) error
 	// AppSnapshot creates a cubebox, makes an app snapshot, and destroys the cubebox.
 	// Required annotations:
 	//   - cube.master.appsnapshot.create: "true"
@@ -304,6 +324,9 @@ func (UnimplementedCubeboxMgrServer) Update(context.Context, *UpdateCubeSandboxR
 }
 func (UnimplementedCubeboxMgrServer) Exec(context.Context, *ExecCubeSandboxRequest) (*ExecCubeSandboxResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method Exec not implemented")
+}
+func (UnimplementedCubeboxMgrServer) AttachTerminal(grpc.BidiStreamingServer[TerminalClientMessage, TerminalServerMessage]) error {
+	return status.Error(codes.Unimplemented, "method AttachTerminal not implemented")
 }
 func (UnimplementedCubeboxMgrServer) AppSnapshot(context.Context, *AppSnapshotRequest) (*AppSnapshotResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method AppSnapshot not implemented")
@@ -445,6 +468,13 @@ func _CubeboxMgr_Exec_Handler(srv interface{}, ctx context.Context, dec func(int
 	}
 	return interceptor(ctx, in, info, handler)
 }
+
+func _CubeboxMgr_AttachTerminal_Handler(srv interface{}, stream grpc.ServerStream) error {
+	return srv.(CubeboxMgrServer).AttachTerminal(&grpc.GenericServerStream[TerminalClientMessage, TerminalServerMessage]{ServerStream: stream})
+}
+
+// This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
+type CubeboxMgr_AttachTerminalServer = grpc.BidiStreamingServer[TerminalClientMessage, TerminalServerMessage]
 
 func _CubeboxMgr_AppSnapshot_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
 	in := new(AppSnapshotRequest)
@@ -694,6 +724,13 @@ var CubeboxMgr_ServiceDesc = grpc.ServiceDesc{
 			Handler:    _CubeboxMgr_CleanupOrphanStorageFiles_Handler,
 		},
 	},
-	Streams:  []grpc.StreamDesc{},
+	Streams: []grpc.StreamDesc{
+		{
+			StreamName:    "AttachTerminal",
+			Handler:       _CubeboxMgr_AttachTerminal_Handler,
+			ServerStreams: true,
+			ClientStreams: true,
+		},
+	},
 	Metadata: "api/services/cubebox/v1/cubebox.proto",
 }

--- a/CubeMaster/pkg/cubelet/terminal.go
+++ b/CubeMaster/pkg/cubelet/terminal.go
@@ -1,0 +1,49 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package cubelet
+
+import (
+	"context"
+	"errors"
+	"sync"
+
+	cubebox "github.com/tencentcloud/CubeSandbox/CubeMaster/api/services/cubebox/v1"
+	grpcpool "github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/grpc-middleware/pool"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/cubelet/grpcconn"
+)
+
+type TerminalStream struct {
+	stream cubebox.CubeboxMgr_AttachTerminalClient
+	conn   grpcpool.Conn
+	once   sync.Once
+}
+
+func OpenTerminal(ctx context.Context, calleeEndpoint string) (*TerminalStream, error) {
+	conn, err := grpcconn.GetWorkerConn(ctx, calleeEndpoint)
+	if err != nil {
+		return nil, err
+	}
+	stream, err := cubebox.NewCubeboxMgrClient(conn.Value()).AttachTerminal(ctx)
+	if err != nil {
+		_ = conn.Close()
+		return nil, err
+	}
+	return &TerminalStream{stream: stream, conn: conn}, nil
+}
+
+func (s *TerminalStream) Send(frame *cubebox.TerminalClientMessage) error {
+	return s.stream.Send(frame)
+}
+
+func (s *TerminalStream) Recv() (*cubebox.TerminalServerMessage, error) {
+	return s.stream.Recv()
+}
+
+func (s *TerminalStream) CloseSend() error {
+	var closeErr error
+	s.once.Do(func() {
+		closeErr = errors.Join(s.stream.CloseSend(), s.conn.Close())
+	})
+	return closeErr
+}

--- a/CubeMaster/pkg/service/httpservice/cube/cube.go
+++ b/CubeMaster/pkg/service/httpservice/cube/cube.go
@@ -20,6 +20,7 @@ const (
 	SandboxListAction              = "/sandbox/list"
 	SandboxInfoAction              = "/sandbox/info"
 	SandboxExecAction              = "/sandbox/exec"
+	SandboxTerminalAction          = "/sandbox/terminal"
 	SandboxUpdateAction            = "/sandbox/update"
 	SandboxTimeoutAction           = "/sandbox/timeout"
 	SandboxRefreshAction           = "/sandbox/refresh"

--- a/CubeMaster/pkg/service/httpservice/cube/routes.go
+++ b/CubeMaster/pkg/service/httpservice/cube/routes.go
@@ -29,6 +29,7 @@ func RegisterCubeRoutes(g *gin.RouterGroup) {
 	g.POST(SandboxTimeoutAction, handleSandboxTimeoutAction)
 	g.POST(SandboxRefreshAction, handleSandboxRefreshAction)
 	g.POST(SandboxExecAction, handleExecAction)
+	g.GET(SandboxTerminalAction, handleTerminalAction)
 	g.GET(SandboxInfoAction, handleInfoAction)
 	g.POST(SandboxInfoAction, handleInfoAction)
 	g.GET(SandboxListAction, handleListAction)

--- a/CubeMaster/pkg/service/httpservice/cube/terminal.go
+++ b/CubeMaster/pkg/service/httpservice/cube/terminal.go
@@ -1,0 +1,109 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package cube
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/gorilla/websocket"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/log"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/cubelet"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/localcache"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/terminalprotocol"
+)
+
+const (
+	terminalGatewayTokenEnv    = "CUBE_TERMINAL_GATEWAY_TOKEN"
+	terminalGatewayTokenHeader = "X-Cube-Terminal-Gateway"
+	terminalMaxFrameBytes      = 64 * 1024
+	terminalReadTimeout        = 35 * time.Minute
+)
+
+var terminalUpgrader = websocket.Upgrader{
+	ReadBufferSize:  32 * 1024,
+	WriteBufferSize: 32 * 1024,
+	// CubeOps is the only supported caller and does not send a browser Origin.
+	// Direct browser connections are rejected before the upgrade.
+	CheckOrigin: func(request *http.Request) bool {
+		return request.Header.Get("Origin") == ""
+	},
+}
+
+func handleTerminalAction(c *gin.Context) {
+	expectedToken := strings.TrimSpace(os.Getenv(terminalGatewayTokenEnv))
+	if expectedToken == "" {
+		http.Error(c.Writer, "terminal gateway is not configured", http.StatusServiceUnavailable)
+		return
+	}
+	if !terminalprotocol.GatewayTokenMatches(expectedToken, c.GetHeader(terminalGatewayTokenHeader)) {
+		http.Error(c.Writer, "terminal gateway is not authorized", http.StatusUnauthorized)
+		return
+	}
+	if c.GetHeader("Origin") != "" {
+		http.Error(c.Writer, "browser-originated terminal connections are not allowed", http.StatusForbidden)
+		return
+	}
+
+	connection, err := terminalUpgrader.Upgrade(c.Writer, c.Request, nil)
+	if err != nil {
+		return
+	}
+	connection.SetReadLimit(terminalMaxFrameBytes)
+	factory := &terminalBackendFactory{}
+	if err := terminalprotocol.Relay(c.Request.Context(), &terminalDeadlineSocket{Conn: connection}, factory); err != nil {
+		log.G(c.Request.Context()).Warnf("terminal relay closed with error: %v", err)
+	}
+}
+
+// terminalDeadlineSocket gives CubeMaster its own upper bound even if the
+// trusted CubeOps gateway stops enforcing or forwarding its idle timeout.
+// CubeOps sends a text keepalive every 20 seconds, so each successful read
+// naturally refreshes this deadline while a live session is connected.
+type terminalDeadlineSocket struct {
+	*websocket.Conn
+}
+
+func (socket *terminalDeadlineSocket) ReadMessage() (int, []byte, error) {
+	if err := socket.SetReadDeadline(time.Now().Add(terminalReadTimeout)); err != nil {
+		return 0, nil, err
+	}
+	return socket.Conn.ReadMessage()
+}
+
+type terminalBackendFactory struct{}
+
+func (f *terminalBackendFactory) Open(ctx context.Context, open terminalprotocol.ClientControl) (terminalprotocol.Backend, error) {
+	hostIP, ok := terminalSandboxHost(ctx, open.SandboxID)
+	if !ok {
+		return nil, errors.New("terminal target is unavailable")
+	}
+	stream, err := cubelet.OpenTerminal(ctx, cubelet.GetCubeletAddr(hostIP))
+	if err != nil {
+		return nil, errors.New("terminal backend is unavailable")
+	}
+	log.G(ctx).WithFields(map[string]interface{}{
+		"requestID":   open.RequestID,
+		"sessionID":   open.SessionID,
+		"sandboxID":   open.SandboxID,
+		"containerID": open.ContainerID,
+		"hostIP":      hostIP,
+	}).Info("terminal relay opened")
+	return stream, nil
+}
+
+func terminalSandboxHost(ctx context.Context, sandboxID string) (string, bool) {
+	if sandbox := localcache.GetSandboxCache(sandboxID); sandbox != nil && strings.TrimSpace(sandbox.HostIP) != "" {
+		return sandbox.HostIP, true
+	}
+	if proxy, ok := localcache.GetSandboxProxyMap(ctx, sandboxID); ok && proxy != nil && strings.TrimSpace(proxy.HostIP) != "" {
+		return proxy.HostIP, true
+	}
+	return "", false
+}

--- a/CubeMaster/pkg/service/httpservice/cube/terminal.go
+++ b/CubeMaster/pkg/service/httpservice/cube/terminal.go
@@ -29,8 +29,9 @@ const (
 var terminalUpgrader = websocket.Upgrader{
 	ReadBufferSize:  32 * 1024,
 	WriteBufferSize: 32 * 1024,
-	// CubeOps is the only supported caller and does not send a browser Origin.
-	// Direct browser connections are rejected before the upgrade.
+	// The gateway token validated in handleTerminalAction is the authoritative
+	// authentication boundary. Requiring an empty Origin additionally rejects
+	// direct browser connections as defense in depth.
 	CheckOrigin: func(request *http.Request) bool {
 		return request.Header.Get("Origin") == ""
 	},
@@ -46,6 +47,8 @@ func handleTerminalAction(c *gin.Context) {
 		http.Error(c.Writer, "terminal gateway is not authorized", http.StatusUnauthorized)
 		return
 	}
+	// This is defense in depth only: the gateway token above authenticates the
+	// trusted CubeOps caller even if a proxy strips or rewrites Origin.
 	if c.GetHeader("Origin") != "" {
 		http.Error(c.Writer, "browser-originated terminal connections are not allowed", http.StatusForbidden)
 		return
@@ -62,10 +65,10 @@ func handleTerminalAction(c *gin.Context) {
 	}
 }
 
-// terminalDeadlineSocket gives CubeMaster its own upper bound even if the
-// trusted CubeOps gateway stops enforcing or forwarding its idle timeout.
-// CubeOps sends a text keepalive every 20 seconds, so each successful read
-// naturally refreshes this deadline while a live session is connected.
+// terminalDeadlineSocket detects dead transports independently of the
+// application-level idle timeout in terminalprotocol.Relay. CubeOps sends a
+// text keepalive every 20 seconds, so a live connection refreshes this deadline
+// without counting keepalives as terminal activity.
 type terminalDeadlineSocket struct {
 	*websocket.Conn
 }

--- a/CubeMaster/pkg/terminalprotocol/protocol.go
+++ b/CubeMaster/pkg/terminalprotocol/protocol.go
@@ -1,0 +1,165 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Package terminalprotocol defines the small, versioned WebSocket control
+// protocol shared by CubeOps and CubeMaster. TTY bytes never pass through JSON.
+package terminalprotocol
+
+import (
+	"bytes"
+	"crypto/subtle"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+)
+
+const (
+	Version = 1
+	// Keep these wire-level bounds aligned with CubeOps terminal grants and
+	// Cubelet terminalcore. The components are separate Go modules, so they
+	// cannot import one implementation without coupling their dependency graph.
+	MinCols = 2
+	MaxCols = 500
+	MinRows = 1
+	MaxRows = 200
+)
+
+type State uint8
+
+const (
+	StateAwaitingOpen State = iota
+	StateReady
+)
+
+type ControlType string
+
+const (
+	TypeOpen      ControlType = "open"
+	TypeResize    ControlType = "resize"
+	TypeKeepalive ControlType = "keepalive"
+	TypeClose     ControlType = "close"
+	TypeReady     ControlType = "ready"
+	TypeError     ControlType = "error"
+	TypeExit      ControlType = "exit"
+)
+
+type ErrorCode string
+
+const (
+	CodeInvalidRequest   ErrorCode = "INVALID_REQUEST"
+	CodeTargetNotFound   ErrorCode = "TARGET_NOT_FOUND"
+	CodeTargetNotRunning ErrorCode = "TARGET_NOT_RUNNING"
+	CodeInternal         ErrorCode = "INTERNAL"
+	CodeIdleTimeout      ErrorCode = "IDLE_TIMEOUT"
+)
+
+type ClientControl struct {
+	Version     int         `json:"v"`
+	Type        ControlType `json:"type"`
+	RequestID   string      `json:"requestId,omitempty"`
+	SessionID   string      `json:"sessionId,omitempty"`
+	SandboxID   string      `json:"sandboxId,omitempty"`
+	ContainerID string      `json:"containerId,omitempty"`
+	Args        []string    `json:"args,omitempty"`
+	Env         []string    `json:"env,omitempty"`
+	Cwd         string      `json:"cwd,omitempty"`
+	Cols        uint32      `json:"cols,omitempty"`
+	Rows        uint32      `json:"rows,omitempty"`
+}
+
+type ServerControl struct {
+	Version   int         `json:"v"`
+	Type      ControlType `json:"type"`
+	SessionID string      `json:"sessionId,omitempty"`
+	Code      ErrorCode   `json:"code,omitempty"`
+	Message   string      `json:"message,omitempty"`
+	Retryable bool        `json:"retryable,omitempty"`
+	ExitCode  int32       `json:"exitCode,omitempty"`
+	Reason    string      `json:"reason,omitempty"`
+}
+
+func DecodeClientControl(raw []byte, state State) (ClientControl, error) {
+	var control ClientControl
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&control); err != nil {
+		return control, fmt.Errorf("invalid terminal control: %w", err)
+	}
+	if err := ensureJSONEOF(decoder); err != nil {
+		return control, err
+	}
+	if control.Version != Version {
+		return control, fmt.Errorf("unsupported terminal protocol version %d", control.Version)
+	}
+
+	switch state {
+	case StateAwaitingOpen:
+		if control.Type != TypeOpen {
+			return control, errors.New("the first terminal control must be open")
+		}
+		if strings.TrimSpace(control.RequestID) == "" || strings.TrimSpace(control.SessionID) == "" {
+			return control, errors.New("open requires requestId and sessionId")
+		}
+		if strings.TrimSpace(control.SandboxID) == "" || strings.TrimSpace(control.ContainerID) == "" {
+			return control, errors.New("open requires sandboxId and containerId")
+		}
+		if err := ValidateSize(control.Cols, control.Rows); err != nil {
+			return control, err
+		}
+	case StateReady:
+		switch control.Type {
+		case TypeResize:
+			if err := ValidateSize(control.Cols, control.Rows); err != nil {
+				return control, err
+			}
+		case TypeKeepalive, TypeClose:
+		case TypeOpen:
+			return control, errors.New("terminal target is already bound")
+		default:
+			return control, fmt.Errorf("unsupported terminal control type %q", control.Type)
+		}
+	default:
+		return control, errors.New("invalid terminal protocol state")
+	}
+	return control, nil
+}
+
+func ValidateSize(cols, rows uint32) error {
+	if cols < MinCols || cols > MaxCols || rows < MinRows || rows > MaxRows {
+		return fmt.Errorf("terminal size must be between %dx%d and %dx%d", MinCols, MinRows, MaxCols, MaxRows)
+	}
+	return nil
+}
+
+func EncodeServerControl(control ServerControl) ([]byte, error) {
+	if control.Version != Version {
+		return nil, fmt.Errorf("unsupported terminal protocol version %d", control.Version)
+	}
+	switch control.Type {
+	case TypeReady, TypeError, TypeExit:
+	default:
+		return nil, fmt.Errorf("unsupported server control type %q", control.Type)
+	}
+	return json.Marshal(control)
+}
+
+func GatewayTokenMatches(expected, provided string) bool {
+	if expected == "" || provided == "" || len(expected) != len(provided) {
+		return false
+	}
+	return subtle.ConstantTimeCompare([]byte(expected), []byte(provided)) == 1
+}
+
+func ensureJSONEOF(decoder *json.Decoder) error {
+	var trailing any
+	err := decoder.Decode(&trailing)
+	if errors.Is(err, io.EOF) {
+		return nil
+	}
+	if err == nil {
+		return errors.New("terminal control contains trailing JSON")
+	}
+	return fmt.Errorf("invalid terminal control: %w", err)
+}

--- a/CubeMaster/pkg/terminalprotocol/protocol_test.go
+++ b/CubeMaster/pkg/terminalprotocol/protocol_test.go
@@ -1,0 +1,71 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package terminalprotocol
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestDecodeOpenBindsTargetAndVersion(t *testing.T) {
+	raw := []byte(`{"v":1,"type":"open","requestId":"request-1","sessionId":"session-1","sandboxId":"sandbox-1","containerId":"container-1","cols":120,"rows":30}`)
+	control, err := DecodeClientControl(raw, StateAwaitingOpen)
+	if err != nil {
+		t.Fatalf("DecodeClientControl() error = %v", err)
+	}
+	if control.SandboxID != "sandbox-1" || control.ContainerID != "container-1" {
+		t.Fatalf("target = %q/%q", control.SandboxID, control.ContainerID)
+	}
+}
+
+func TestDecodeClientControlRejectsInvalidStateVersionAndSize(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		raw   string
+		state State
+	}{
+		{name: "unsupported version", raw: `{"v":2,"type":"open","sandboxId":"sandbox","containerId":"container","cols":80,"rows":24}`, state: StateAwaitingOpen},
+		{name: "resize before open", raw: `{"v":1,"type":"resize","cols":80,"rows":24}`, state: StateAwaitingOpen},
+		{name: "open after ready", raw: `{"v":1,"type":"open","sandboxId":"sandbox","containerId":"container","cols":80,"rows":24}`, state: StateReady},
+		{name: "oversized terminal", raw: `{"v":1,"type":"open","sandboxId":"sandbox","containerId":"container","cols":501,"rows":24}`, state: StateAwaitingOpen},
+		{name: "unknown control", raw: `{"v":1,"type":"retarget","cols":80,"rows":24}`, state: StateReady},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := DecodeClientControl([]byte(tc.raw), tc.state); err == nil {
+				t.Fatal("DecodeClientControl() accepted invalid control")
+			}
+		})
+	}
+}
+
+func TestEncodeServerControlUsesStablePublicShape(t *testing.T) {
+	raw, err := EncodeServerControl(ServerControl{
+		Version:   Version,
+		Type:      TypeError,
+		Code:      CodeTargetNotRunning,
+		Message:   "target is not running",
+		Retryable: false,
+	})
+	if err != nil {
+		t.Fatalf("EncodeServerControl() error = %v", err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v", err)
+	}
+	if got["code"] != string(CodeTargetNotRunning) || got["type"] != string(TypeError) {
+		t.Fatalf("encoded control = %#v", got)
+	}
+}
+
+func TestGatewayTokenMatchesOnlyExactNonEmptyTokens(t *testing.T) {
+	if !GatewayTokenMatches("shared-secret", "shared-secret") {
+		t.Fatal("matching gateway token rejected")
+	}
+	for _, pair := range [][2]string{{"", ""}, {"shared-secret", "shared-secreu"}, {"shared-secret", ""}} {
+		if GatewayTokenMatches(pair[0], pair[1]) {
+			t.Fatalf("GatewayTokenMatches(%q, %q) = true", pair[0], pair[1])
+		}
+	}
+}

--- a/CubeMaster/pkg/terminalprotocol/relay.go
+++ b/CubeMaster/pkg/terminalprotocol/relay.go
@@ -1,0 +1,225 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package terminalprotocol
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+
+	cubebox "github.com/tencentcloud/CubeSandbox/CubeMaster/api/services/cubebox/v1"
+)
+
+const (
+	TextMessage   = 1
+	BinaryMessage = 2
+)
+
+var ErrProtocol = errors.New("terminal protocol error")
+
+type Socket interface {
+	ReadMessage() (messageType int, data []byte, err error)
+	WriteMessage(messageType int, data []byte) error
+	Close() error
+}
+
+type Backend interface {
+	Send(*cubebox.TerminalClientMessage) error
+	Recv() (*cubebox.TerminalServerMessage, error)
+	CloseSend() error
+}
+
+type BackendFactory interface {
+	Open(context.Context, ClientControl) (Backend, error)
+}
+
+func Relay(ctx context.Context, socket Socket, factory BackendFactory) error {
+	defer socket.Close()
+	relayCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	messageType, data, err := socket.ReadMessage()
+	if err != nil {
+		return err
+	}
+	if messageType != TextMessage {
+		return fmt.Errorf("%w: the first frame must be a text open control", ErrProtocol)
+	}
+	open, err := DecodeClientControl(data, StateAwaitingOpen)
+	if err != nil {
+		return fmt.Errorf("%w: %v", ErrProtocol, err)
+	}
+	backend, err := factory.Open(relayCtx, open)
+	if err != nil {
+		return err
+	}
+	defer backend.CloseSend()
+
+	if err := backend.Send(&cubebox.TerminalClientMessage{
+		Payload: &cubebox.TerminalClientMessage_Open{Open: &cubebox.TerminalOpenRequest{
+			RequestId:   open.RequestID,
+			SessionId:   open.SessionID,
+			SandboxId:   open.SandboxID,
+			ContainerId: open.ContainerID,
+			Args:        append([]string(nil), open.Args...),
+			Env:         append([]string(nil), open.Env...),
+			Cwd:         open.Cwd,
+			Cols:        open.Cols,
+			Rows:        open.Rows,
+		}},
+	}); err != nil {
+		return err
+	}
+
+	clientDone := make(chan error, 1)
+	go func() { clientDone <- forwardClient(socket, backend) }()
+	serverDone := make(chan error, 1)
+	go func() { serverDone <- forwardServer(socket, backend, open.SessionID) }()
+
+	select {
+	case err := <-clientDone:
+		return normalizeRelayEnd(err)
+	case err := <-serverDone:
+		return normalizeRelayEnd(err)
+	case <-relayCtx.Done():
+		return nil
+	}
+}
+
+func forwardClient(socket Socket, backend Backend) error {
+	for {
+		messageType, data, err := socket.ReadMessage()
+		if err != nil {
+			return err
+		}
+		switch messageType {
+		case BinaryMessage:
+			if err := backend.Send(&cubebox.TerminalClientMessage{
+				Payload: &cubebox.TerminalClientMessage_Stdin{Stdin: append([]byte(nil), data...)},
+			}); err != nil {
+				return err
+			}
+		case TextMessage:
+			control, err := DecodeClientControl(data, StateReady)
+			if err != nil {
+				return fmt.Errorf("%w: %v", ErrProtocol, err)
+			}
+			switch control.Type {
+			case TypeResize:
+				err = backend.Send(&cubebox.TerminalClientMessage{
+					Payload: &cubebox.TerminalClientMessage_Resize{Resize: &cubebox.TerminalResize{
+						Cols: control.Cols,
+						Rows: control.Rows,
+					}},
+				})
+			case TypeKeepalive:
+				continue
+			case TypeClose:
+				err = backend.Send(&cubebox.TerminalClientMessage{
+					Payload: &cubebox.TerminalClientMessage_Close{Close: &cubebox.TerminalClose{}},
+				})
+				if err == nil {
+					return nil
+				}
+			}
+			if err != nil {
+				return err
+			}
+		default:
+			return fmt.Errorf("%w: unsupported WebSocket message type %d", ErrProtocol, messageType)
+		}
+	}
+}
+
+func forwardServer(socket Socket, backend Backend, sessionID string) error {
+	for {
+		frame, err := backend.Recv()
+		if err != nil {
+			return err
+		}
+		switch payload := frame.GetPayload().(type) {
+		case *cubebox.TerminalServerMessage_Ready:
+			if payload.Ready == nil {
+				return fmt.Errorf("%w: ready payload is missing", ErrProtocol)
+			}
+			if err := writeServerControl(socket, ServerControl{Version: Version, Type: TypeReady, SessionID: sessionID}); err != nil {
+				return err
+			}
+		case *cubebox.TerminalServerMessage_Output:
+			if err := socket.WriteMessage(BinaryMessage, payload.Output); err != nil {
+				return err
+			}
+		case *cubebox.TerminalServerMessage_Exit:
+			if payload.Exit == nil {
+				return fmt.Errorf("%w: exit payload is missing", ErrProtocol)
+			}
+			return writeServerControl(socket, ServerControl{
+				Version:  Version,
+				Type:     TypeExit,
+				ExitCode: payload.Exit.GetExitCode(),
+				Reason:   payload.Exit.GetReason(),
+			})
+		case *cubebox.TerminalServerMessage_Error:
+			if payload.Error == nil {
+				return fmt.Errorf("%w: error payload is missing", ErrProtocol)
+			}
+			code := grpcErrorCode(payload.Error.GetCode())
+			return writeServerControl(socket, ServerControl{
+				Version:   Version,
+				Type:      TypeError,
+				Code:      code,
+				Message:   PublicErrorMessage(code),
+				Retryable: payload.Error.GetRetryable(),
+			})
+		default:
+			return fmt.Errorf("%w: unsupported backend terminal frame", ErrProtocol)
+		}
+	}
+}
+
+func PublicErrorMessage(code ErrorCode) string {
+	switch code {
+	case CodeInvalidRequest:
+		return "invalid terminal request"
+	case CodeTargetNotFound:
+		return "terminal target not found"
+	case CodeTargetNotRunning:
+		return "terminal target is not running"
+	case CodeIdleTimeout:
+		return "terminal session timed out"
+	default:
+		return "terminal session failed"
+	}
+}
+
+func writeServerControl(socket Socket, control ServerControl) error {
+	data, err := EncodeServerControl(control)
+	if err != nil {
+		return err
+	}
+	return socket.WriteMessage(TextMessage, data)
+}
+
+func grpcErrorCode(code cubebox.TerminalErrorCode) ErrorCode {
+	switch code {
+	case cubebox.TerminalErrorCode_TERMINAL_ERROR_INVALID_REQUEST:
+		return CodeInvalidRequest
+	case cubebox.TerminalErrorCode_TERMINAL_ERROR_TARGET_NOT_FOUND:
+		return CodeTargetNotFound
+	case cubebox.TerminalErrorCode_TERMINAL_ERROR_TARGET_NOT_RUNNING:
+		return CodeTargetNotRunning
+	case cubebox.TerminalErrorCode_TERMINAL_ERROR_IDLE_TIMEOUT:
+		return CodeIdleTimeout
+	default:
+		return CodeInternal
+	}
+}
+
+func normalizeRelayEnd(err error) error {
+	if err == nil || errors.Is(err, io.EOF) || errors.Is(err, context.Canceled) {
+		return nil
+	}
+	return err
+}

--- a/CubeMaster/pkg/terminalprotocol/relay.go
+++ b/CubeMaster/pkg/terminalprotocol/relay.go
@@ -8,6 +8,8 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"sync"
+	"time"
 
 	cubebox "github.com/tencentcloud/CubeSandbox/CubeMaster/api/services/cubebox/v1"
 )
@@ -15,14 +17,29 @@ import (
 const (
 	TextMessage   = 1
 	BinaryMessage = 2
+	idleTimeout   = 30 * time.Minute
 )
 
-var ErrProtocol = errors.New("terminal protocol error")
+var (
+	ErrProtocol    = errors.New("terminal protocol error")
+	errIdleTimeout = errors.New("terminal idle timeout")
+)
 
 type Socket interface {
 	ReadMessage() (messageType int, data []byte, err error)
 	WriteMessage(messageType int, data []byte) error
 	Close() error
+}
+
+type serializedWriteSocket struct {
+	Socket
+	mu sync.Mutex
+}
+
+func (socket *serializedWriteSocket) WriteMessage(messageType int, data []byte) error {
+	socket.mu.Lock()
+	defer socket.mu.Unlock()
+	return socket.Socket.WriteMessage(messageType, data)
 }
 
 type Backend interface {
@@ -36,6 +53,11 @@ type BackendFactory interface {
 }
 
 func Relay(ctx context.Context, socket Socket, factory BackendFactory) error {
+	return relayWithIdleTimeout(ctx, socket, factory, idleTimeout)
+}
+
+func relayWithIdleTimeout(ctx context.Context, socket Socket, factory BackendFactory, timeout time.Duration) error {
+	socket = &serializedWriteSocket{Socket: socket}
 	defer socket.Close()
 	relayCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
@@ -73,22 +95,44 @@ func Relay(ctx context.Context, socket Socket, factory BackendFactory) error {
 		return err
 	}
 
+	activity := make(chan struct{}, 1)
+	markActivity := func() {
+		select {
+		case activity <- struct{}{}:
+		default:
+		}
+	}
 	clientDone := make(chan error, 1)
-	go func() { clientDone <- forwardClient(socket, backend) }()
+	go func() { clientDone <- forwardClient(socket, backend, markActivity) }()
 	serverDone := make(chan error, 1)
-	go func() { serverDone <- forwardServer(socket, backend, open.SessionID) }()
+	go func() { serverDone <- forwardServer(socket, backend, open.SessionID, markActivity) }()
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
 
-	select {
-	case err := <-clientDone:
-		return normalizeRelayEnd(err)
-	case err := <-serverDone:
-		return normalizeRelayEnd(err)
-	case <-relayCtx.Done():
-		return nil
+	for {
+		select {
+		case err := <-clientDone:
+			return normalizeRelayEnd(err)
+		case err := <-serverDone:
+			return normalizeRelayEnd(err)
+		case <-activity:
+			resetTimer(timer, timeout)
+		case <-timer.C:
+			writeErr := writeServerControl(socket, ServerControl{
+				Version:   Version,
+				Type:      TypeError,
+				Code:      CodeIdleTimeout,
+				Message:   PublicErrorMessage(CodeIdleTimeout),
+				Retryable: true,
+			})
+			return errors.Join(errIdleTimeout, writeErr)
+		case <-relayCtx.Done():
+			return nil
+		}
 	}
 }
 
-func forwardClient(socket Socket, backend Backend) error {
+func forwardClient(socket Socket, backend Backend, markActivity func()) error {
 	for {
 		messageType, data, err := socket.ReadMessage()
 		if err != nil {
@@ -101,6 +145,7 @@ func forwardClient(socket Socket, backend Backend) error {
 			}); err != nil {
 				return err
 			}
+			markActivity()
 		case TextMessage:
 			control, err := DecodeClientControl(data, StateReady)
 			if err != nil {
@@ -114,6 +159,9 @@ func forwardClient(socket Socket, backend Backend) error {
 						Rows: control.Rows,
 					}},
 				})
+				if err == nil {
+					markActivity()
+				}
 			case TypeKeepalive:
 				continue
 			case TypeClose:
@@ -133,7 +181,7 @@ func forwardClient(socket Socket, backend Backend) error {
 	}
 }
 
-func forwardServer(socket Socket, backend Backend, sessionID string) error {
+func forwardServer(socket Socket, backend Backend, sessionID string, markActivity func()) error {
 	for {
 		frame, err := backend.Recv()
 		if err != nil {
@@ -151,6 +199,7 @@ func forwardServer(socket Socket, backend Backend, sessionID string) error {
 			if err := socket.WriteMessage(BinaryMessage, payload.Output); err != nil {
 				return err
 			}
+			markActivity()
 		case *cubebox.TerminalServerMessage_Exit:
 			if payload.Exit == nil {
 				return fmt.Errorf("%w: exit payload is missing", ErrProtocol)
@@ -177,6 +226,16 @@ func forwardServer(socket Socket, backend Backend, sessionID string) error {
 			return fmt.Errorf("%w: unsupported backend terminal frame", ErrProtocol)
 		}
 	}
+}
+
+func resetTimer(timer *time.Timer, timeout time.Duration) {
+	if !timer.Stop() {
+		select {
+		case <-timer.C:
+		default:
+		}
+	}
+	timer.Reset(timeout)
 }
 
 func PublicErrorMessage(code ErrorCode) string {

--- a/CubeMaster/pkg/terminalprotocol/relay_test.go
+++ b/CubeMaster/pkg/terminalprotocol/relay_test.go
@@ -1,0 +1,202 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package terminalprotocol
+
+import (
+	"context"
+	"errors"
+	"io"
+	"strings"
+	"sync"
+	"testing"
+
+	cubebox "github.com/tencentcloud/CubeSandbox/CubeMaster/api/services/cubebox/v1"
+)
+
+type socketMessage struct {
+	typeID int
+	data   []byte
+}
+
+type fakeSocket struct {
+	reads     chan socketMessage
+	closed    chan struct{}
+	closeOnce sync.Once
+	mu        sync.Mutex
+	writes    []socketMessage
+}
+
+func newFakeSocket() *fakeSocket {
+	return &fakeSocket{reads: make(chan socketMessage, 8), closed: make(chan struct{})}
+}
+
+func (s *fakeSocket) ReadMessage() (int, []byte, error) {
+	select {
+	case message := <-s.reads:
+		return message.typeID, message.data, nil
+	case <-s.closed:
+		return 0, nil, io.EOF
+	}
+}
+
+func (s *fakeSocket) WriteMessage(typeID int, data []byte) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.writes = append(s.writes, socketMessage{typeID: typeID, data: append([]byte(nil), data...)})
+	return nil
+}
+
+func (s *fakeSocket) Close() error {
+	s.closeOnce.Do(func() { close(s.closed) })
+	return nil
+}
+
+type fakeBackend struct {
+	recv      chan *cubebox.TerminalServerMessage
+	closed    chan struct{}
+	closeOnce sync.Once
+	mu        sync.Mutex
+	sent      []*cubebox.TerminalClientMessage
+}
+
+func newFakeBackend() *fakeBackend {
+	return &fakeBackend{recv: make(chan *cubebox.TerminalServerMessage, 8), closed: make(chan struct{})}
+}
+
+func (b *fakeBackend) Send(frame *cubebox.TerminalClientMessage) error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.sent = append(b.sent, frame)
+	return nil
+}
+
+func (b *fakeBackend) Recv() (*cubebox.TerminalServerMessage, error) {
+	select {
+	case frame := <-b.recv:
+		return frame, nil
+	case <-b.closed:
+		return nil, io.EOF
+	}
+}
+
+func (b *fakeBackend) CloseSend() error {
+	b.closeOnce.Do(func() { close(b.closed) })
+	return nil
+}
+
+type fakeBackendFactory struct {
+	backend *fakeBackend
+	calls   int
+	open    ClientControl
+}
+
+func (f *fakeBackendFactory) Open(_ context.Context, open ClientControl) (Backend, error) {
+	f.calls++
+	f.open = open
+	return f.backend, nil
+}
+
+func validOpenJSON() []byte {
+	return []byte(`{"v":1,"type":"open","requestId":"request-1","sessionId":"session-1","sandboxId":"sandbox-1","containerId":"container-1","cols":120,"rows":30}`)
+}
+
+func TestRelayClosesSocketWhenOpenFrameIsRejected(t *testing.T) {
+	socket := newFakeSocket()
+	socket.reads <- socketMessage{typeID: BinaryMessage, data: []byte("not-an-open-control")}
+
+	err := Relay(context.Background(), socket, &fakeBackendFactory{backend: newFakeBackend()})
+	if err == nil {
+		t.Fatal("Relay() accepted an invalid first frame")
+	}
+	select {
+	case <-socket.closed:
+	default:
+		t.Fatal("Relay() did not close the upgraded socket after rejecting the first frame")
+	}
+}
+
+func TestRelayForwardsOpenBinaryResizeAndClose(t *testing.T) {
+	socket := newFakeSocket()
+	socket.reads <- socketMessage{typeID: TextMessage, data: validOpenJSON()}
+	socket.reads <- socketMessage{typeID: BinaryMessage, data: []byte("echo ok\n")}
+	socket.reads <- socketMessage{typeID: TextMessage, data: []byte(`{"v":1,"type":"resize","cols":90,"rows":24}`)}
+	socket.reads <- socketMessage{typeID: TextMessage, data: []byte(`{"v":1,"type":"close"}`)}
+	backend := newFakeBackend()
+	factory := &fakeBackendFactory{backend: backend}
+
+	if err := Relay(context.Background(), socket, factory); err != nil {
+		t.Fatalf("Relay() error = %v", err)
+	}
+	if factory.open.SandboxID != "sandbox-1" || factory.open.ContainerID != "container-1" {
+		t.Fatalf("factory target = %q/%q", factory.open.SandboxID, factory.open.ContainerID)
+	}
+	if len(backend.sent) != 4 {
+		t.Fatalf("backend received %d frames, want open/stdin/resize/close", len(backend.sent))
+	}
+	if got := string(backend.sent[1].GetStdin()); got != "echo ok\n" {
+		t.Fatalf("stdin = %q", got)
+	}
+	if got := backend.sent[2].GetResize(); got.GetCols() != 90 || got.GetRows() != 24 {
+		t.Fatalf("resize = %#v", got)
+	}
+	if backend.sent[3].GetClose() == nil {
+		t.Fatal("last backend frame is not close")
+	}
+}
+
+func TestRelayWritesReadyOutputAndExitInOrder(t *testing.T) {
+	socket := newFakeSocket()
+	socket.reads <- socketMessage{typeID: TextMessage, data: validOpenJSON()}
+	backend := newFakeBackend()
+	backend.recv <- &cubebox.TerminalServerMessage{Payload: &cubebox.TerminalServerMessage_Ready{Ready: &cubebox.TerminalReady{ExecId: "exec-1"}}}
+	backend.recv <- &cubebox.TerminalServerMessage{Payload: &cubebox.TerminalServerMessage_Output{Output: []byte("\x1b[32mok\x1b[0m")}}
+	backend.recv <- &cubebox.TerminalServerMessage{Payload: &cubebox.TerminalServerMessage_Exit{Exit: &cubebox.TerminalExit{ExitCode: 0, Reason: "process_exited"}}}
+
+	if err := Relay(context.Background(), socket, &fakeBackendFactory{backend: backend}); err != nil {
+		t.Fatalf("Relay() error = %v", err)
+	}
+	if len(socket.writes) != 3 {
+		t.Fatalf("socket wrote %d frames, want ready/output/exit", len(socket.writes))
+	}
+	if socket.writes[0].typeID != TextMessage || socket.writes[1].typeID != BinaryMessage || socket.writes[2].typeID != TextMessage {
+		t.Fatalf("message types = %#v", socket.writes)
+	}
+	if got := string(socket.writes[1].data); got != "\x1b[32mok\x1b[0m" {
+		t.Fatalf("output = %q", got)
+	}
+}
+
+func TestRelayRejectsBinaryFirstFrameWithoutOpeningBackend(t *testing.T) {
+	socket := newFakeSocket()
+	socket.reads <- socketMessage{typeID: BinaryMessage, data: []byte("whoami\n")}
+	factory := &fakeBackendFactory{backend: newFakeBackend()}
+
+	err := Relay(context.Background(), socket, factory)
+	if err == nil || !errors.Is(err, ErrProtocol) {
+		t.Fatalf("Relay() error = %v, want protocol error", err)
+	}
+	if factory.calls != 0 {
+		t.Fatalf("factory called %d times", factory.calls)
+	}
+}
+
+func TestRelayDoesNotExposeBackendErrorDetails(t *testing.T) {
+	socket := newFakeSocket()
+	socket.reads <- socketMessage{typeID: TextMessage, data: validOpenJSON()}
+	backend := newFakeBackend()
+	backend.recv <- &cubebox.TerminalServerMessage{Payload: &cubebox.TerminalServerMessage_Error{Error: &cubebox.TerminalError{
+		Code:    cubebox.TerminalErrorCode_TERMINAL_ERROR_INTERNAL,
+		Message: "dial 10.0.0.9:1234: connection refused",
+	}}}
+
+	if err := Relay(context.Background(), socket, &fakeBackendFactory{backend: backend}); err != nil {
+		t.Fatalf("Relay() error = %v", err)
+	}
+	if len(socket.writes) != 1 {
+		t.Fatalf("socket wrote %d frames, want one error", len(socket.writes))
+	}
+	if strings.Contains(string(socket.writes[0].data), "10.0.0.9") || !strings.Contains(string(socket.writes[0].data), "terminal session failed") {
+		t.Fatalf("public error leaked backend details: %s", socket.writes[0].data)
+	}
+}

--- a/CubeMaster/pkg/terminalprotocol/relay_test.go
+++ b/CubeMaster/pkg/terminalprotocol/relay_test.go
@@ -5,11 +5,14 @@ package terminalprotocol
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"io"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	cubebox "github.com/tencentcloud/CubeSandbox/CubeMaster/api/services/cubebox/v1"
 )
@@ -25,6 +28,39 @@ type fakeSocket struct {
 	closeOnce sync.Once
 	mu        sync.Mutex
 	writes    []socketMessage
+}
+
+type detectingSocket struct {
+	*fakeSocket
+	writing      atomic.Bool
+	concurrent   atomic.Bool
+	firstWrite   sync.Once
+	writeStarted chan struct{}
+	releaseWrite chan struct{}
+}
+
+func newDetectingSocket() *detectingSocket {
+	return &detectingSocket{
+		fakeSocket:   newFakeSocket(),
+		writeStarted: make(chan struct{}),
+		releaseWrite: make(chan struct{}),
+	}
+}
+
+func (s *detectingSocket) WriteMessage(typeID int, data []byte) error {
+	if !s.writing.CompareAndSwap(false, true) {
+		s.concurrent.Store(true)
+		return errors.New("concurrent socket write")
+	}
+	defer s.writing.Store(false)
+	s.firstWrite.Do(func() {
+		close(s.writeStarted)
+		select {
+		case <-s.releaseWrite:
+		case <-s.closed:
+		}
+	})
+	return s.fakeSocket.WriteMessage(typeID, data)
 }
 
 func newFakeSocket() *fakeSocket {
@@ -198,5 +234,54 @@ func TestRelayDoesNotExposeBackendErrorDetails(t *testing.T) {
 	}
 	if strings.Contains(string(socket.writes[0].data), "10.0.0.9") || !strings.Contains(string(socket.writes[0].data), "terminal session failed") {
 		t.Fatalf("public error leaked backend details: %s", socket.writes[0].data)
+	}
+}
+
+func TestRelayClosesIdleSessionWithPublicError(t *testing.T) {
+	socket := newFakeSocket()
+	socket.reads <- socketMessage{typeID: TextMessage, data: validOpenJSON()}
+	backend := newFakeBackend()
+
+	err := relayWithIdleTimeout(context.Background(), socket, &fakeBackendFactory{backend: backend}, 10*time.Millisecond)
+	if err == nil || !strings.Contains(err.Error(), "terminal idle timeout") {
+		t.Fatalf("relayWithIdleTimeout() error = %v, want terminal idle timeout", err)
+	}
+	if len(socket.writes) != 1 {
+		t.Fatalf("socket wrote %d frames, want one idle-timeout error", len(socket.writes))
+	}
+	var control ServerControl
+	decodeErr := json.Unmarshal(socket.writes[0].data, &control)
+	if decodeErr != nil {
+		t.Fatalf("DecodeServerControl() error = %v", decodeErr)
+	}
+	if control.Type != TypeError || control.Code != CodeIdleTimeout || !control.Retryable {
+		t.Fatalf("idle timeout control = %#v", control)
+	}
+}
+
+func TestRelaySerializesBackendAndTimeoutWrites(t *testing.T) {
+	socket := newDetectingSocket()
+	socket.reads <- socketMessage{typeID: TextMessage, data: validOpenJSON()}
+	backend := newFakeBackend()
+	backend.recv <- &cubebox.TerminalServerMessage{
+		Payload: &cubebox.TerminalServerMessage_Output{Output: []byte("output")},
+	}
+	result := make(chan error, 1)
+	go func() {
+		result <- relayWithIdleTimeout(context.Background(), socket, &fakeBackendFactory{backend: backend}, 10*time.Millisecond)
+	}()
+
+	select {
+	case <-socket.writeStarted:
+	case <-time.After(time.Second):
+		t.Fatal("backend write did not start")
+	}
+	time.AfterFunc(20*time.Millisecond, func() { close(socket.releaseWrite) })
+	err := <-result
+	if err == nil || !strings.Contains(err.Error(), "terminal idle timeout") {
+		t.Fatalf("relayWithIdleTimeout() error = %v, want terminal idle timeout", err)
+	}
+	if socket.concurrent.Load() {
+		t.Fatal("Relay() wrote backend output and idle-timeout control concurrently")
 	}
 }

--- a/CubeOps/config.example.yaml
+++ b/CubeOps/config.example.yaml
@@ -39,6 +39,11 @@ refresh_ttl: "168h"
 # --- CubeMaster (the actual sandbox / cluster control plane) ---
 cubemaster_addr: "http://127.0.0.1:8089"
 
+# --- Web Terminal (shared with CubeMaster; keep the internal endpoint private) ---
+terminal_gateway_token: ""
+# Optional comma-separated exact origins; same-host origins are allowed by default.
+terminal_allowed_origins: ""
+
 # --- CubeAPI (deprecated SDK proxy) ---
 cubeapi_url: "http://127.0.0.1:3000"
 

--- a/CubeOps/go.mod
+++ b/CubeOps/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/golang-jwt/jwt/v5 v5.2.2
 	github.com/google/go-containerregistry v0.21.6
 	github.com/google/uuid v1.6.0
+	github.com/gorilla/websocket v1.5.3
 	github.com/ory/dockertest/v3 v3.12.0
 	github.com/tencentcloud/CubeSandbox/CubeDB v0.1.0
 	github.com/tencentcloud/CubeSandbox/cubelog v0.1.1-0.20260113105508-a996703fa42f

--- a/CubeOps/go.sum
+++ b/CubeOps/go.sum
@@ -84,6 +84,8 @@ github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 h1:El6M4kTTCOh6aBiKaU
 github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510/go.mod h1:pupxD2MaaD3pAXIBCelhxNneeOaAeabZDe5s4K6zSpQ=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
+github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsIM=
 github.com/jackc/pgpassfile v1.0.0/go.mod h1:CEx0iS5ambNFdcRtxPj5JhEz+xB6uRky5eyVu/W2HEg=
 github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 h1:iCEnooe7UlwOQYpKFhBabPMi4aNAfoODPEFNiAnClxo=

--- a/CubeOps/internal/config/config.go
+++ b/CubeOps/internal/config/config.go
@@ -59,6 +59,10 @@ type Config struct {
 	// CubeAPI (for SDK endpoint proxy)
 	CubeAPIURL string `yaml:"cubeapi_url"`
 
+	// Web Terminal (CubeOps is the public gateway; CubeMaster is the backend)
+	TerminalGatewayToken   string `yaml:"terminal_gateway_token"`
+	TerminalAllowedOrigins string `yaml:"terminal_allowed_origins"`
+
 	// Redis (optional)
 	RedisURL string `yaml:"redis_url"`
 
@@ -307,6 +311,12 @@ func overrideFromEnv(cfg *Config) {
 	}
 	if v := os.Getenv("CUBE_API_URL"); v != "" {
 		cfg.CubeAPIURL = v
+	}
+	if v := os.Getenv("CUBE_TERMINAL_GATEWAY_TOKEN"); v != "" {
+		cfg.TerminalGatewayToken = v
+	}
+	if v := os.Getenv("CUBE_TERMINAL_ALLOWED_ORIGINS"); v != "" {
+		cfg.TerminalAllowedOrigins = v
 	}
 	if v := os.Getenv("REDIS_URL"); v != "" {
 		cfg.RedisURL = v

--- a/CubeOps/internal/config/config_test.go
+++ b/CubeOps/internal/config/config_test.go
@@ -19,6 +19,8 @@ func TestLoad_FromYAML(t *testing.T) {
 	yamlContent := []byte(`bind: "0.0.0.0:9999"
 log_level: "debug"
 cubemaster_addr: "http://1.2.3.4:8089"
+terminal_gateway_token: "yaml-terminal-secret"
+terminal_allowed_origins: "https://console.example"
 sandbox_domain: "test.example.com"
 database_url: "mysql://root:pass@127.0.0.1:3306/testdb"
 jwt_secret: "yaml-secret"
@@ -43,6 +45,9 @@ refresh_ttl: "336h"
 	if cfg.CubeMasterAddr != "http://1.2.3.4:8089" {
 		t.Errorf("CubeMasterAddr = %q, want http://1.2.3.4:8089", cfg.CubeMasterAddr)
 	}
+	if cfg.TerminalGatewayToken != "yaml-terminal-secret" || cfg.TerminalAllowedOrigins != "https://console.example" {
+		t.Errorf("terminal config = (%q, %q)", cfg.TerminalGatewayToken, cfg.TerminalAllowedOrigins)
+	}
 	if cfg.SandboxDomain != "test.example.com" {
 		t.Errorf("SandboxDomain = %q, want test.example.com", cfg.SandboxDomain)
 	}
@@ -64,6 +69,7 @@ database_url: "mysql://root:pass@127.0.0.1:3306/yamldb"
 	}
 	t.Setenv("CUBE_OPS_CONFIG", yamlPath)
 	t.Setenv("CUBE_OPS_BIND", "127.0.0.1:7777")
+	t.Setenv("CUBE_TERMINAL_GATEWAY_TOKEN", "env-terminal-secret")
 
 	cfg, err := Load()
 	if err != nil {
@@ -71,6 +77,9 @@ database_url: "mysql://root:pass@127.0.0.1:3306/yamldb"
 	}
 	if cfg.Bind != "127.0.0.1:7777" {
 		t.Errorf("Bind = %q, want 127.0.0.1:7777 (env should override YAML)", cfg.Bind)
+	}
+	if cfg.TerminalGatewayToken != "env-terminal-secret" {
+		t.Errorf("TerminalGatewayToken = %q, want env-terminal-secret", cfg.TerminalGatewayToken)
 	}
 }
 

--- a/CubeOps/internal/handler/sdk.go
+++ b/CubeOps/internal/handler/sdk.go
@@ -57,6 +57,7 @@ var (
 type SDKHandler struct {
 	cm          CubeMasterClient
 	agenthubSvc *service.AgentHubService // optional; when set, DeleteTemplate triggers AgentHub reverse-sync
+	terminal    *terminalGateway
 }
 
 // NewSDKHandler creates a new SDK handler backed by the CubeMaster client.
@@ -68,6 +69,14 @@ func NewSDKHandler(cm CubeMasterClient) *SDKHandler { return &SDKHandler{cm: cm}
 // receiver for chaining.
 func (h *SDKHandler) WithAgentHubService(svc *service.AgentHubService) *SDKHandler {
 	h.agenthubSvc = svc
+	return h
+}
+
+// WithTerminalGateway configures CubeOps as the authenticated Web Terminal
+// gateway. CubeOps validates the sandbox through CubeMaster and relays the
+// WebSocket directly; CubeAPI is not part of this ops-only feature.
+func (h *SDKHandler) WithTerminalGateway(masterURL, token, allowedOrigins string) *SDKHandler {
+	h.terminal = newTerminalGateway(masterURL, token, allowedOrigins)
 	return h
 }
 
@@ -86,6 +95,7 @@ func (h *SDKHandler) Register(r *gin.RouterGroup) {
 	r.POST("/sandboxes/:id/pause", h.PauseSandbox)
 	r.POST("/sandboxes/:id/resume", h.ResumeSandbox)
 	r.POST("/sandboxes/:id/connect", h.ConnectSandbox)
+	r.POST("/sandboxes/:id/terminal-sessions", h.CreateTerminalSession)
 
 	// Snapshots
 	r.GET("/snapshots", h.ListSnapshots)

--- a/CubeOps/internal/handler/terminal_bridge.go
+++ b/CubeOps/internal/handler/terminal_bridge.go
@@ -1,0 +1,418 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package handler
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"path"
+	"strings"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/gorilla/websocket"
+	internalhttputil "github.com/tencentcloud/CubeSandbox/CubeOps/internal/httputil"
+)
+
+const (
+	terminalProtocol               = "cube-terminal.v1"
+	terminalGrantProtocolPrefix    = "cube-terminal.grant."
+	terminalGatewayTokenHeader     = "X-Cube-Terminal-Gateway"
+	maxTerminalSessionRequestBytes = 4 * 1024
+	maxTerminalFrameBytes          = 64 * 1024
+	terminalIdleTimeout            = 30 * time.Minute
+)
+
+type createTerminalSessionRequest struct {
+	ContainerID string `json:"containerId"`
+	Cols        uint16 `json:"cols"`
+	Rows        uint16 `json:"rows"`
+}
+
+type terminalGateway struct {
+	masterURL      string
+	token          string
+	allowedOrigins string
+	grants         *terminalGrantStore
+}
+
+func newTerminalGateway(masterURL, token, allowedOrigins string) *terminalGateway {
+	return &terminalGateway{
+		masterURL:      strings.TrimRight(masterURL, "/"),
+		token:          strings.TrimSpace(token),
+		allowedOrigins: allowedOrigins,
+		grants:         newTerminalGrantStore(defaultTerminalLimits()),
+	}
+}
+
+// CreateTerminalSession validates the authenticated CubeOps user and target,
+// then issues a short-lived, single-use grant bound to an HttpOnly cookie.
+func (h *SDKHandler) CreateTerminalSession(c *gin.Context) {
+	if h.terminal == nil || h.terminal.token == "" {
+		internalhttputil.WriteError(c, http.StatusServiceUnavailable, "web terminal is not configured")
+		return
+	}
+	if c.Request.ContentLength > maxTerminalSessionRequestBytes {
+		internalhttputil.WriteError(c, http.StatusRequestEntityTooLarge, "terminal session request is too large")
+		return
+	}
+	c.Request.Body = http.MaxBytesReader(c.Writer, c.Request.Body, maxTerminalSessionRequestBytes)
+	decoder := json.NewDecoder(c.Request.Body)
+	decoder.DisallowUnknownFields()
+	var body createTerminalSessionRequest
+	if err := decoder.Decode(&body); err != nil {
+		var maxBytesError *http.MaxBytesError
+		if errors.As(err, &maxBytesError) {
+			internalhttputil.WriteError(c, http.StatusRequestEntityTooLarge, "terminal session request is too large")
+		} else {
+			internalhttputil.WriteError(c, http.StatusBadRequest, "invalid terminal session request")
+		}
+		return
+	}
+	if err := ensureTerminalJSONEOF(decoder); err != nil {
+		internalhttputil.WriteError(c, http.StatusBadRequest, "invalid terminal session request")
+		return
+	}
+	containerID, err := h.resolveTerminalContainer(c, c.Param("id"), body.ContainerID)
+	if err != nil {
+		return
+	}
+	target := terminalTarget{sandboxID: c.Param("id"), containerID: containerID, cols: body.Cols, rows: body.Rows}
+	issued, err := h.terminal.grants.issue(c.GetString("username"), target)
+	if err != nil {
+		switch err {
+		case errTerminalInvalidTarget:
+			internalhttputil.WriteError(c, http.StatusBadRequest, "invalid terminal dimensions or target")
+		case errTerminalPendingLimit:
+			c.Header("Retry-After", "30")
+			internalhttputil.WriteError(c, http.StatusTooManyRequests, "too many pending terminal grants")
+		default:
+			internalhttputil.WriteError(c, http.StatusInternalServerError, "failed to create terminal session")
+		}
+		return
+	}
+	secure := c.Request.TLS != nil || strings.EqualFold(c.GetHeader("X-Forwarded-Proto"), "https") || strings.HasPrefix(c.GetHeader("Origin"), "https://")
+	http.SetCookie(c.Writer, &http.Cookie{
+		Name: issued.cookieName, Value: issued.cookieValue, Path: "/", MaxAge: int(issued.expiresIn.Seconds()),
+		HttpOnly: true, Secure: secure, SameSite: http.SameSiteStrictMode,
+	})
+	slog.Info("terminal grant issued", "session_id", issued.sessionID, "sandbox_id", target.sandboxID, "container_id", target.containerID, "principal", c.GetString("username"))
+	c.JSON(http.StatusOK, gin.H{
+		"sessionId": issued.sessionID, "grant": issued.token,
+		"expiresInSeconds": int(issued.expiresIn.Seconds()), "protocol": terminalProtocol,
+	})
+}
+
+func ensureTerminalJSONEOF(decoder *json.Decoder) error {
+	var extra any
+	if err := decoder.Decode(&extra); err == nil {
+		return errors.New("trailing JSON value")
+	} else if !errors.Is(err, io.EOF) {
+		return err
+	}
+	return nil
+}
+
+func (h *SDKHandler) resolveTerminalContainer(c *gin.Context, sandboxID, requested string) (string, error) {
+	raw, err := h.cm.GetSandbox(c.Request.Context(), sandboxID, sdkInstanceType)
+	if err != nil {
+		writeCMError(c, err)
+		return "", err
+	}
+	var envelope cmEnvelope
+	if err := json.Unmarshal(raw, &envelope); err != nil {
+		internalhttputil.WriteError(c, http.StatusBadGateway, "invalid sandbox response")
+		return "", err
+	}
+	if envelope.Ret != nil && envelope.Ret.RetCode != 0 && envelope.Ret.RetCode != 200 {
+		internalhttputil.WriteError(c, http.StatusNotFound, envelope.Ret.RetMsg)
+		return "", errors.New("sandbox unavailable")
+	}
+	var sandboxes []cmSandboxDetailItem
+	if err := json.Unmarshal(envelope.Data, &sandboxes); err != nil || len(sandboxes) == 0 {
+		internalhttputil.WriteError(c, http.StatusNotFound, "sandbox not found")
+		return "", errors.New("sandbox not found")
+	}
+	sandbox := sandboxes[0]
+	if sandbox.Status != 1 {
+		internalhttputil.WriteError(c, http.StatusConflict, "sandbox is not running")
+		return "", errors.New("sandbox not running")
+	}
+	if requested != "" {
+		for _, container := range sandbox.Containers {
+			if container.ContainerID == requested {
+				return requested, nil
+			}
+		}
+		internalhttputil.WriteError(c, http.StatusBadRequest, "container does not belong to sandbox")
+		return "", errors.New("container not found")
+	}
+	for _, container := range sandbox.Containers {
+		if container.Type == "sandbox" || container.ContainerID == sandbox.SandboxID {
+			return container.ContainerID, nil
+		}
+	}
+	if len(sandbox.Containers) > 0 {
+		return sandbox.Containers[0].ContainerID, nil
+	}
+	internalhttputil.WriteError(c, http.StatusConflict, "sandbox has no terminal container")
+	return "", errors.New("sandbox has no containers")
+}
+
+var terminalUpgrader = websocket.Upgrader{
+	HandshakeTimeout: 10 * time.Second,
+	ReadBufferSize:   32 * 1024,
+	WriteBufferSize:  32 * 1024,
+	Subprotocols:     []string{terminalProtocol},
+	CheckOrigin:      func(*http.Request) bool { return true }, // validated before Upgrade
+}
+
+// ProxyTerminal consumes a one-time CubeOps grant and relays the browser
+// WebSocket directly to CubeMaster. CubeAPI is intentionally not involved.
+func (h *SDKHandler) ProxyTerminal(c *gin.Context) {
+	if h.terminal == nil || h.terminal.token == "" {
+		internalhttputil.WriteError(c, http.StatusServiceUnavailable, "web terminal is not configured")
+		return
+	}
+	if !terminalOriginAllowed(c.Request, h.terminal.allowedOrigins) {
+		slog.Warn("terminal session denied", "sandbox_id", c.Param("id"), "reason", "origin_not_allowed")
+		internalhttputil.WriteError(c, http.StatusForbidden, "terminal WebSocket origin is not allowed")
+		return
+	}
+	if !terminalProtocolOffered(c.Request.Header, terminalProtocol) {
+		slog.Warn("terminal session denied", "sandbox_id", c.Param("id"), "reason", "protocol_missing")
+		internalhttputil.WriteError(c, http.StatusBadRequest, "terminal WebSocket protocol is required")
+		return
+	}
+	grant := terminalGrantFromProtocols(c.Request.Header)
+	lease, err := h.terminal.grants.consume(grant, terminalCookies(c.Request))
+	if err != nil {
+		slog.Warn("terminal session denied", "sandbox_id", c.Param("id"), "reason", err)
+		status := http.StatusUnauthorized
+		if err == errTerminalActiveLimit {
+			status = http.StatusTooManyRequests
+		}
+		internalhttputil.WriteError(c, status, "terminal grant is invalid, expired, or limited")
+		return
+	}
+	if lease.target.sandboxID != c.Param("id") {
+		slog.Warn("terminal session denied", "sandbox_id", c.Param("id"), "reason", "sandbox_mismatch")
+		lease.release()
+		internalhttputil.WriteError(c, http.StatusUnauthorized, "terminal grant does not match sandbox")
+		return
+	}
+	upgrader := terminalUpgrader
+	// Repeat the validated policy inside gorilla's upgrader as defense in
+	// depth if this handshake code is moved or reused in the future.
+	upgrader.CheckOrigin = func(request *http.Request) bool {
+		return terminalOriginAllowed(request, h.terminal.allowedOrigins)
+	}
+	connection, err := upgrader.Upgrade(c.Writer, c.Request, nil)
+	if err != nil {
+		lease.release()
+		return
+	}
+	defer connection.Close()
+	defer lease.release()
+	if err := h.terminal.relay(c.Request, connection, lease); err != nil {
+		slog.Warn("terminal relay closed", "session_id", lease.sessionID, "sandbox_id", lease.target.sandboxID, "container_id", lease.target.containerID, "principal", lease.principal, "error", err)
+	} else {
+		slog.Info("terminal relay closed", "session_id", lease.sessionID, "sandbox_id", lease.target.sandboxID, "container_id", lease.target.containerID, "principal", lease.principal)
+	}
+}
+
+func (gateway *terminalGateway) relay(request *http.Request, browser *websocket.Conn, lease *terminalSessionLease) error {
+	backendURL, err := terminalBackendURL(gateway.masterURL)
+	if err != nil {
+		return err
+	}
+	dialer := *websocket.DefaultDialer
+	dialer.HandshakeTimeout = 10 * time.Second
+	header := http.Header{}
+	header.Set(terminalGatewayTokenHeader, gateway.token)
+	backend, response, err := dialer.DialContext(request.Context(), backendURL, header)
+	if err != nil {
+		if response != nil && response.Body != nil {
+			_ = response.Body.Close()
+		}
+		_ = browser.WriteJSON(gin.H{"v": 1, "type": "error", "code": "BACKEND_UNAVAILABLE", "message": "terminal backend is unavailable", "retryable": true})
+		return err
+	}
+	defer backend.Close()
+	browser.SetReadLimit(maxTerminalFrameBytes)
+	backend.SetReadLimit(maxTerminalFrameBytes)
+	open := gin.H{
+		"v": 1, "type": "open", "requestId": fmt.Sprintf("cubeops-terminal-%d", time.Now().UnixNano()),
+		"sessionId": lease.sessionID, "sandboxId": lease.target.sandboxID, "containerId": lease.target.containerID,
+		"cols": lease.target.cols, "rows": lease.target.rows,
+	}
+	if err := backend.WriteJSON(open); err != nil {
+		return err
+	}
+	return relayTerminalFrames(browser, backend)
+}
+
+type terminalFrame struct {
+	messageType int
+	data        []byte
+}
+
+func relayTerminalFrames(browser, backend *websocket.Conn) error {
+	done := make(chan struct{})
+	defer close(done)
+	browserFrames, browserErrors := readTerminalFrames(browser, done)
+	backendFrames, backendErrors := readTerminalFrames(backend, done)
+	timer := time.NewTimer(terminalIdleTimeout)
+	defer timer.Stop()
+	resetIdle := func() {
+		if !timer.Stop() {
+			select {
+			case <-timer.C:
+			default:
+			}
+		}
+		timer.Reset(terminalIdleTimeout)
+	}
+	for {
+		select {
+		case frame, ok := <-browserFrames:
+			if !ok {
+				return terminalReadError(<-browserErrors)
+			}
+			if frame.messageType == websocket.BinaryMessage || (frame.messageType == websocket.TextMessage && terminalTextCountsAsActivity(frame.data)) {
+				resetIdle()
+			}
+			if err := backend.WriteMessage(frame.messageType, frame.data); err != nil {
+				return err
+			}
+		case frame, ok := <-backendFrames:
+			if !ok {
+				return terminalReadError(<-backendErrors)
+			}
+			if frame.messageType == websocket.BinaryMessage {
+				resetIdle()
+			}
+			if err := browser.WriteMessage(frame.messageType, frame.data); err != nil {
+				return err
+			}
+		case <-timer.C:
+			_ = browser.WriteJSON(gin.H{"v": 1, "type": "error", "code": "IDLE_TIMEOUT", "message": "terminal session timed out", "retryable": true})
+			return errors.New("terminal idle timeout")
+		}
+	}
+}
+
+func terminalReadError(err error) error {
+	if websocket.IsCloseError(err, websocket.CloseNormalClosure, websocket.CloseGoingAway) {
+		return nil
+	}
+	return err
+}
+
+func readTerminalFrames(connection *websocket.Conn, done <-chan struct{}) (<-chan terminalFrame, <-chan error) {
+	frames := make(chan terminalFrame)
+	errorsOut := make(chan error, 1)
+	go func() {
+		defer close(frames)
+		for {
+			messageType, data, err := connection.ReadMessage()
+			if err != nil {
+				select {
+				case errorsOut <- err:
+				case <-done:
+				}
+				return
+			}
+			if len(data) > maxTerminalFrameBytes {
+				select {
+				case errorsOut <- errors.New("terminal frame exceeds limit"):
+				case <-done:
+				}
+				return
+			}
+			select {
+			case frames <- terminalFrame{messageType: messageType, data: data}:
+			case <-done:
+				return
+			}
+		}
+	}()
+	return frames, errorsOut
+}
+
+func terminalTextCountsAsActivity(data []byte) bool {
+	var control struct {
+		Type string `json:"type"`
+	}
+	return json.Unmarshal(data, &control) == nil && control.Type == "resize"
+}
+
+func terminalBackendURL(masterURL string) (string, error) {
+	target, err := url.Parse(masterURL)
+	if err != nil || target.Host == "" {
+		return "", errors.New("invalid CubeMaster URL")
+	}
+	switch target.Scheme {
+	case "http":
+		target.Scheme = "ws"
+	case "https":
+		target.Scheme = "wss"
+	default:
+		return "", errors.New("invalid CubeMaster URL scheme")
+	}
+	target.Path = path.Join(target.Path, "/cube/sandbox/terminal")
+	// CubeMaster's internal terminal endpoint never accepts query parameters.
+	// Clear caller-supplied URL metadata so configuration cannot smuggle data
+	// into the authenticated backend handshake.
+	target.RawPath, target.RawQuery, target.Fragment = "", "", ""
+	return target.String(), nil
+}
+
+func terminalOriginAllowed(request *http.Request, configured string) bool {
+	origin := request.Header.Get("Origin")
+	if origin == "" {
+		return false
+	}
+	if configured != "" {
+		for _, allowed := range strings.Split(configured, ",") {
+			if strings.TrimSpace(allowed) == origin {
+				return true
+			}
+		}
+		return false
+	}
+	parsed, err := url.Parse(origin)
+	return err == nil && (parsed.Scheme == "http" || parsed.Scheme == "https") && parsed.Host == request.Host
+}
+
+func terminalProtocolOffered(header http.Header, expected string) bool {
+	for _, protocol := range strings.Split(header.Get("Sec-WebSocket-Protocol"), ",") {
+		if strings.TrimSpace(protocol) == expected {
+			return true
+		}
+	}
+	return false
+}
+
+func terminalGrantFromProtocols(header http.Header) string {
+	for _, protocol := range strings.Split(header.Get("Sec-WebSocket-Protocol"), ",") {
+		if token, ok := strings.CutPrefix(strings.TrimSpace(protocol), terminalGrantProtocolPrefix); ok {
+			return token
+		}
+	}
+	return ""
+}
+
+func terminalCookies(request *http.Request) map[string]string {
+	cookies := make(map[string]string)
+	for _, cookie := range request.Cookies() {
+		cookies[cookie.Name] = cookie.Value
+	}
+	return cookies
+}

--- a/CubeOps/internal/handler/terminal_bridge_test.go
+++ b/CubeOps/internal/handler/terminal_bridge_test.go
@@ -1,0 +1,189 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/gorilla/websocket"
+)
+
+func runningSandboxResponse() json.RawMessage {
+	return json.RawMessage(`{"ret":{"ret_code":0},"data":[{"sandbox_id":"sandbox-1","status":1,"containers":[{"container_id":"sandbox-1","type":"sandbox"},{"container_id":"sidecar-1","type":"sidecar"}]}]}`)
+}
+
+func newTerminalSessionRouter(t *testing.T, response json.RawMessage) *gin.Engine {
+	t.Helper()
+	cm := &fakeCM{getSandbox: func(_ context.Context, sandboxID, instanceType string) (json.RawMessage, error) {
+		if sandboxID != "sandbox-1" || instanceType != sdkInstanceType {
+			t.Fatalf("GetSandbox(%q, %q)", sandboxID, instanceType)
+		}
+		return response, nil
+	}}
+	handler := NewSDKHandler(cm).WithTerminalGateway("http://cube-master:8089", "gateway-secret", "")
+	router := gin.New()
+	router.Use(func(c *gin.Context) {
+		c.Set("username", "alice")
+		c.Next()
+	})
+	handler.Register(router.Group("/api/v1/sdk"))
+	return router
+}
+
+func TestCreateTerminalSessionIssuesLocalGrant(t *testing.T) {
+	router := newTerminalSessionRouter(t, runningSandboxResponse())
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/sdk/sandboxes/sandbox-1/terminal-sessions", strings.NewReader(`{"cols":80,"rows":24,"containerId":"sidecar-1"}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Forwarded-Proto", "https")
+	recorder := httptest.NewRecorder()
+	router.ServeHTTP(recorder, req)
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d; body=%s", recorder.Code, recorder.Body.String())
+	}
+	var response struct {
+		SessionID string `json:"sessionId"`
+		Grant     string `json:"grant"`
+		Expires   int    `json:"expiresInSeconds"`
+		Protocol  string `json:"protocol"`
+	}
+	if err := json.Unmarshal(recorder.Body.Bytes(), &response); err != nil {
+		t.Fatal(err)
+	}
+	if response.SessionID == "" || response.Grant == "" || response.Expires != 60 || response.Protocol != terminalProtocol {
+		t.Fatalf("response = %#v", response)
+	}
+	cookie := recorder.Header().Get("Set-Cookie")
+	for _, required := range []string{"cube_terminal_", "HttpOnly", "SameSite=Strict", "Secure"} {
+		if !strings.Contains(cookie, required) {
+			t.Errorf("Set-Cookie %q missing %q", cookie, required)
+		}
+	}
+}
+
+func TestCreateTerminalSessionRejectsUnknownContainer(t *testing.T) {
+	router := newTerminalSessionRouter(t, runningSandboxResponse())
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/sdk/sandboxes/sandbox-1/terminal-sessions", strings.NewReader(`{"cols":80,"rows":24,"containerId":"other"}`))
+	recorder := httptest.NewRecorder()
+	router.ServeHTTP(recorder, req)
+	if recorder.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400; body=%s", recorder.Code, recorder.Body.String())
+	}
+}
+
+func TestCreateTerminalSessionRejectsStoppedSandbox(t *testing.T) {
+	router := newTerminalSessionRouter(t, json.RawMessage(`{"ret":{"ret_code":0},"data":[{"sandbox_id":"sandbox-1","status":5,"containers":[{"container_id":"sandbox-1"}]}]}`))
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/sdk/sandboxes/sandbox-1/terminal-sessions", strings.NewReader(`{"cols":80,"rows":24}`))
+	recorder := httptest.NewRecorder()
+	router.ServeHTTP(recorder, req)
+	if recorder.Code != http.StatusConflict {
+		t.Fatalf("status = %d, want 409; body=%s", recorder.Code, recorder.Body.String())
+	}
+}
+
+func TestCreateTerminalSessionRejectsOversizedBody(t *testing.T) {
+	router := newTerminalSessionRouter(t, runningSandboxResponse())
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/sdk/sandboxes/sandbox-1/terminal-sessions", strings.NewReader(strings.Repeat("x", maxTerminalSessionRequestBytes+1)))
+	recorder := httptest.NewRecorder()
+	router.ServeHTTP(recorder, req)
+	if recorder.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("status = %d, want 413; body=%s", recorder.Code, recorder.Body.String())
+	}
+}
+
+func TestTerminalBackendURLTargetsCubeMaster(t *testing.T) {
+	got, err := terminalBackendURL("https://cube-master.example/base/")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := "wss://cube-master.example/base/cube/sandbox/terminal"; got != want {
+		t.Fatalf("terminalBackendURL = %q, want %q", got, want)
+	}
+}
+
+func TestTerminalGatewayRelaysOpenAndBinaryFrames(t *testing.T) {
+	backendDone := make(chan error, 1)
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get(terminalGatewayTokenHeader); got != "gateway-secret" {
+			backendDone <- &testTerminalError{"gateway token", got}
+			return
+		}
+		connection, err := terminalUpgrader.Upgrade(w, r, nil)
+		if err != nil {
+			backendDone <- err
+			return
+		}
+		defer connection.Close()
+		var open map[string]any
+		if err := connection.ReadJSON(&open); err != nil {
+			backendDone <- err
+			return
+		}
+		if open["type"] != "open" || open["sandboxId"] != "sandbox-1" || open["containerId"] != "container-1" {
+			backendDone <- &testTerminalError{"open frame", open}
+			return
+		}
+		if err := connection.WriteJSON(map[string]any{"v": 1, "type": "ready", "sessionId": "session-1"}); err != nil {
+			backendDone <- err
+			return
+		}
+		messageType, data, err := connection.ReadMessage()
+		if err == nil {
+			err = connection.WriteMessage(messageType, data)
+		}
+		backendDone <- err
+	}))
+	defer backend.Close()
+
+	gateway := newTerminalGateway(backend.URL, "gateway-secret", "")
+	frontend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		connection, err := terminalUpgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer connection.Close()
+		lease := &terminalSessionLease{principal: "alice", sessionID: "session-1", target: terminalTarget{sandboxID: "sandbox-1", containerID: "container-1", cols: 80, rows: 24}}
+		_ = gateway.relay(r, connection, lease)
+	}))
+	defer frontend.Close()
+
+	dialer := *websocket.DefaultDialer
+	dialer.Subprotocols = []string{terminalProtocol}
+	client, _, err := dialer.Dial("ws"+strings.TrimPrefix(frontend.URL, "http"), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer client.Close()
+	client.SetReadDeadline(time.Now().Add(5 * time.Second))
+	_, ready, err := client.ReadMessage()
+	if err != nil || !strings.Contains(string(ready), `"type":"ready"`) {
+		t.Fatalf("ready = %q, err=%v", ready, err)
+	}
+	payload := []byte{0, 1, 2, 255}
+	if err := client.WriteMessage(websocket.BinaryMessage, payload); err != nil {
+		t.Fatal(err)
+	}
+	messageType, echoed, err := client.ReadMessage()
+	if err != nil || messageType != websocket.BinaryMessage || string(echoed) != string(payload) {
+		t.Fatalf("echo type=%d data=%v err=%v", messageType, echoed, err)
+	}
+	if err := <-backendDone; err != nil {
+		t.Fatal(err)
+	}
+}
+
+type testTerminalError struct {
+	field string
+	value any
+}
+
+func (err *testTerminalError) Error() string {
+	return err.field + " mismatch"
+}

--- a/CubeOps/internal/handler/terminal_gateway_test.go
+++ b/CubeOps/internal/handler/terminal_gateway_test.go
@@ -1,0 +1,97 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package handler
+
+import (
+	"net/http"
+	"testing"
+	"time"
+)
+
+func TestTerminalGrantIsSingleUseCookieBoundAndTargetBound(t *testing.T) {
+	store := newTerminalGrantStore(terminalLimits{
+		grantTTL:         time.Minute,
+		pendingPerUser:   2,
+		pendingGlobal:    4,
+		activePerUser:    2,
+		activePerSandbox: 2,
+		activeGlobal:     4,
+	})
+	target := terminalTarget{sandboxID: "sandbox-1", containerID: "container-1", cols: 80, rows: 24}
+	issued, err := store.issue("alice", target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.consume(issued.token, map[string]string{}); err != errTerminalBindingMismatch {
+		t.Fatalf("consume without binding = %v, want %v", err, errTerminalBindingMismatch)
+	}
+	lease, err := store.consume(issued.token, map[string]string{issued.cookieName: issued.cookieValue})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer lease.release()
+	if lease.target != target || lease.principal != "alice" {
+		t.Fatalf("lease = %#v, want target %#v for alice", lease, target)
+	}
+	if _, err := store.consume(issued.token, map[string]string{issued.cookieName: issued.cookieValue}); err != errTerminalUnknownGrant {
+		t.Fatalf("second consume = %v, want %v", err, errTerminalUnknownGrant)
+	}
+}
+
+func TestTerminalGrantLimitsAreReleasedWithLease(t *testing.T) {
+	store := newTerminalGrantStore(terminalLimits{
+		grantTTL:         time.Minute,
+		pendingPerUser:   2,
+		pendingGlobal:    2,
+		activePerUser:    1,
+		activePerSandbox: 1,
+		activeGlobal:     1,
+	})
+	issue := func(container string) issuedTerminalGrant {
+		grant, err := store.issue("alice", terminalTarget{sandboxID: "sandbox-1", containerID: container, cols: 80, rows: 24})
+		if err != nil {
+			t.Fatal(err)
+		}
+		return grant
+	}
+	first := issue("container-1")
+	lease, err := store.consume(first.token, map[string]string{first.cookieName: first.cookieValue})
+	if err != nil {
+		t.Fatal(err)
+	}
+	second := issue("container-2")
+	if _, err := store.consume(second.token, map[string]string{second.cookieName: second.cookieValue}); err != errTerminalActiveLimit {
+		t.Fatalf("consume while active = %v, want %v", err, errTerminalActiveLimit)
+	}
+	lease.release()
+	third := issue("container-3")
+	lease, err = store.consume(third.token, map[string]string{third.cookieName: third.cookieValue})
+	if err != nil {
+		t.Fatalf("consume after release: %v", err)
+	}
+	lease.release()
+}
+
+func TestTerminalOriginAndProtocols(t *testing.T) {
+	request, err := http.NewRequest(http.MethodGet, "https://console.example/sandboxes/sandbox-1/terminal", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	request.Host = "console.example"
+	request.Header.Set("Origin", "https://console.example")
+	request.Header.Set("Sec-WebSocket-Protocol", "cube-terminal.v1, cube-terminal.grant.secret")
+	if !terminalOriginAllowed(request, "") {
+		t.Fatal("same-host origin should be allowed")
+	}
+	if got := terminalGrantFromProtocols(request.Header); got != "secret" {
+		t.Fatalf("grant = %q, want secret", got)
+	}
+	request.Header.Set("Origin", "https://attacker.example")
+	if terminalOriginAllowed(request, "") {
+		t.Fatal("cross-site origin should be rejected")
+	}
+	if !terminalOriginAllowed(request, "https://attacker.example,https://console.example") {
+		t.Fatal("configured origin should be allowed")
+	}
+}

--- a/CubeOps/internal/handler/terminal_grants.go
+++ b/CubeOps/internal/handler/terminal_grants.go
@@ -1,0 +1,216 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package handler
+
+import (
+	"crypto/rand"
+	"crypto/subtle"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+var (
+	errTerminalInvalidTarget   = errors.New("invalid terminal target")
+	errTerminalPendingLimit    = errors.New("terminal pending grant limit exceeded")
+	errTerminalUnknownGrant    = errors.New("unknown terminal grant")
+	errTerminalExpiredGrant    = errors.New("expired terminal grant")
+	errTerminalBindingMismatch = errors.New("terminal binding cookie mismatch")
+	errTerminalActiveLimit     = errors.New("terminal active session limit exceeded")
+)
+
+const (
+	// Keep these wire-level bounds aligned with CubeMaster terminalprotocol
+	// and Cubelet terminalcore (separate Go modules).
+	terminalMinCols = 2
+	terminalMaxCols = 500
+	terminalMinRows = 1
+	terminalMaxRows = 200
+)
+
+type terminalTarget struct {
+	sandboxID   string
+	containerID string
+	cols        uint16
+	rows        uint16
+}
+
+func (target terminalTarget) validate() error {
+	if target.sandboxID == "" || target.containerID == "" ||
+		target.cols < terminalMinCols || target.cols > terminalMaxCols ||
+		target.rows < terminalMinRows || target.rows > terminalMaxRows {
+		return errTerminalInvalidTarget
+	}
+	return nil
+}
+
+type terminalLimits struct {
+	grantTTL         time.Duration
+	pendingPerUser   int
+	pendingGlobal    int
+	activePerUser    int
+	activePerSandbox int
+	activeGlobal     int
+}
+
+func defaultTerminalLimits() terminalLimits {
+	return terminalLimits{
+		grantTTL:         time.Minute,
+		pendingPerUser:   16,
+		pendingGlobal:    1024,
+		activePerUser:    4,
+		activePerSandbox: 8,
+		activeGlobal:     128,
+	}
+}
+
+type issuedTerminalGrant struct {
+	token       string
+	sessionID   string
+	cookieName  string
+	cookieValue string
+	expiresIn   time.Duration
+}
+
+type pendingTerminalGrant struct {
+	principal   string
+	sessionID   string
+	target      terminalTarget
+	cookieName  string
+	cookieValue string
+	expiresAt   time.Time
+}
+
+type terminalGrantState struct {
+	pending         map[string]pendingTerminalGrant
+	activeByUser    map[string]int
+	activeBySandbox map[string]int
+	activeGlobal    int
+}
+
+type terminalGrantStore struct {
+	mu     sync.Mutex
+	limits terminalLimits
+	state  terminalGrantState
+}
+
+func newTerminalGrantStore(limits terminalLimits) *terminalGrantStore {
+	return &terminalGrantStore{
+		limits: limits,
+		state: terminalGrantState{
+			pending:         make(map[string]pendingTerminalGrant),
+			activeByUser:    make(map[string]int),
+			activeBySandbox: make(map[string]int),
+		},
+	}
+}
+
+func (store *terminalGrantStore) issue(principal string, target terminalTarget) (issuedTerminalGrant, error) {
+	if principal == "" || target.validate() != nil {
+		return issuedTerminalGrant{}, errTerminalInvalidTarget
+	}
+	now := time.Now()
+	store.mu.Lock()
+	defer store.mu.Unlock()
+	for token, grant := range store.state.pending {
+		if !grant.expiresAt.After(now) {
+			delete(store.state.pending, token)
+		}
+	}
+	pendingForUser := 0
+	for _, grant := range store.state.pending {
+		if grant.principal == principal {
+			pendingForUser++
+		}
+	}
+	if len(store.state.pending) >= store.limits.pendingGlobal || pendingForUser >= store.limits.pendingPerUser {
+		return issuedTerminalGrant{}, errTerminalPendingLimit
+	}
+	token, err := randomTerminalToken()
+	if err != nil {
+		return issuedTerminalGrant{}, fmt.Errorf("generate terminal grant: %w", err)
+	}
+	cookieValue, err := randomTerminalToken()
+	if err != nil {
+		return issuedTerminalGrant{}, fmt.Errorf("generate terminal binding: %w", err)
+	}
+	sessionID := uuid.NewString()
+	cookieName := "cube_terminal_" + strings.ReplaceAll(sessionID, "-", "")
+	store.state.pending[token] = pendingTerminalGrant{
+		principal: principal, sessionID: sessionID, target: target,
+		cookieName: cookieName, cookieValue: cookieValue, expiresAt: now.Add(store.limits.grantTTL),
+	}
+	return issuedTerminalGrant{token: token, sessionID: sessionID, cookieName: cookieName, cookieValue: cookieValue, expiresIn: store.limits.grantTTL}, nil
+}
+
+func randomTerminalToken() (string, error) {
+	bytes := make([]byte, 32)
+	if _, err := rand.Read(bytes); err != nil {
+		return "", err
+	}
+	return base64.RawURLEncoding.EncodeToString(bytes), nil
+}
+
+type terminalSessionLease struct {
+	store     *terminalGrantStore
+	principal string
+	sessionID string
+	target    terminalTarget
+	once      sync.Once
+}
+
+func (store *terminalGrantStore) consume(token string, cookies map[string]string) (*terminalSessionLease, error) {
+	now := time.Now()
+	store.mu.Lock()
+	defer store.mu.Unlock()
+	grant, ok := store.state.pending[token]
+	if !ok {
+		return nil, errTerminalUnknownGrant
+	}
+	supplied := cookies[grant.cookieName]
+	if subtle.ConstantTimeCompare([]byte(grant.cookieValue), []byte(supplied)) != 1 {
+		return nil, errTerminalBindingMismatch
+	}
+	if !grant.expiresAt.After(now) {
+		delete(store.state.pending, token)
+		return nil, errTerminalExpiredGrant
+	}
+	delete(store.state.pending, token)
+	if store.state.activeGlobal >= store.limits.activeGlobal ||
+		store.state.activeByUser[grant.principal] >= store.limits.activePerUser ||
+		store.state.activeBySandbox[grant.target.sandboxID] >= store.limits.activePerSandbox {
+		return nil, errTerminalActiveLimit
+	}
+	store.state.activeGlobal++
+	store.state.activeByUser[grant.principal]++
+	store.state.activeBySandbox[grant.target.sandboxID]++
+	return &terminalSessionLease{store: store, principal: grant.principal, sessionID: grant.sessionID, target: grant.target}, nil
+}
+
+func (lease *terminalSessionLease) release() {
+	if lease == nil || lease.store == nil {
+		return
+	}
+	lease.once.Do(func() {
+		store := lease.store
+		store.mu.Lock()
+		defer store.mu.Unlock()
+		store.state.activeGlobal--
+		decrementTerminalCount(store.state.activeByUser, lease.principal)
+		decrementTerminalCount(store.state.activeBySandbox, lease.target.sandboxID)
+	})
+}
+
+func decrementTerminalCount(counts map[string]int, key string) {
+	if counts[key] <= 1 {
+		delete(counts, key)
+		return
+	}
+	counts[key]--
+}

--- a/CubeOps/internal/server/server.go
+++ b/CubeOps/internal/server/server.go
@@ -95,11 +95,17 @@ func (s *Server) buildRouter() *gin.Engine {
 	// SDK handler gets the AgentHubService so that E2B template/snapshot
 	// deletions can reverse-sync AgentHub registrations (matching the old
 	// Rust reverse_sync_agenthub_template that lived in CubeAPI).
-	sdkH := handler.NewSDKHandler(s.cm).WithAgentHubService(agenthubH.AgentHubService())
+	sdkH := handler.NewSDKHandler(s.cm).
+		WithAgentHubService(agenthubH.AgentHubService()).
+		WithTerminalGateway(s.cfg.CubeMasterAddr, s.cfg.TerminalGatewayToken, s.cfg.TerminalAllowedOrigins)
 
 	// Public (no auth) routes — login + refresh.
 	public := r.Group("/api/v1")
 	authH.RegisterPublic(public)
+	// WebSocket handshakes cannot attach the Dashboard bearer token. This
+	// public route authenticates with ProxyTerminal's single-use grant,
+	// HttpOnly binding cookie, subprotocol, and Origin checks instead.
+	public.GET("/terminal/sandboxes/:id", sdkH.ProxyTerminal)
 
 	// Authenticated routes. The session / logout / change-password endpoints
 	// are mounted here, behind the JWT middleware.

--- a/CubeOps/internal/translator/terminal_containers_test.go
+++ b/CubeOps/internal/translator/terminal_containers_test.go
@@ -1,0 +1,38 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package translator
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestTransformSandboxDetailIncludesTerminalContainerChoices(t *testing.T) {
+	raw := json.RawMessage(`{
+		"ret":{"ret_code":0},
+		"data":[{
+			"sandbox_id":"sb-1",
+			"status":1,
+			"containers":[
+				{"container_id":"main","type":"sandbox","status":1,"image":"ubuntu"},
+				{"container_id":"sidecar","type":"sidecar","status":1,"image":"helper"}
+			]
+		}]
+	}`)
+
+	result, ok := TransformSandboxDetail(raw).(map[string]interface{})
+	if !ok {
+		t.Fatalf("result type = %T, want map", TransformSandboxDetail(raw))
+	}
+	containers, ok := result["containers"].([]map[string]interface{})
+	if !ok {
+		t.Fatalf("containers = %#v, want []map", result["containers"])
+	}
+	if got, want := len(containers), 2; got != want {
+		t.Fatalf("container count = %d, want %d", got, want)
+	}
+	if got, want := containers[1]["containerID"], "sidecar"; got != want {
+		t.Errorf("second container ID = %#v, want %#v", got, want)
+	}
+}

--- a/CubeOps/internal/translator/translator.go
+++ b/CubeOps/internal/translator/translator.go
@@ -359,6 +359,19 @@ func TransformSandboxDetail(raw json.RawMessage) interface{} {
 		"hostID":      item.HostID,
 		"domain":      SandboxDomain(),
 	}
+	containers := make([]map[string]interface{}, 0, len(item.Containers))
+	for _, container := range item.Containers {
+		if container.ContainerID == "" {
+			continue
+		}
+		containers = append(containers, map[string]interface{}{
+			"containerID": container.ContainerID,
+			"image":       container.Image,
+			"type":        container.Type,
+			"state":       SandboxStateFromInt(container.Status),
+		})
+	}
+	result["containers"] = containers
 	if item.Labels != nil {
 		result["metadata"] = item.Labels
 	}

--- a/CubeShim/shim/src/sandbox/sb.rs
+++ b/CubeShim/shim/src/sandbox/sb.rs
@@ -50,6 +50,21 @@ const ANNO_SANDBOX_DNS: &str = "cube.sandbox.dns";
 const ANNO_ENABLE_IVSHMEM: &str = "cube.master.enable_ivshmem";
 const IVSHMEM_DEFAULT_SIZE: usize = 1 * 1024 * 1024; // 1MB
 
+fn tty_win_resize_request(
+    container_id: &str,
+    exec_id: &str,
+    width: u32,
+    height: u32,
+) -> agent::TtyWinResizeRequest {
+    agent::TtyWinResizeRequest {
+        container_id: container_id.to_string(),
+        exec_id: exec_id.to_string(),
+        row: height,
+        column: width,
+        ..Default::default()
+    }
+}
+
 #[derive(PartialEq, Eq)]
 enum SandBoxState {
     Normal,
@@ -1407,6 +1422,36 @@ impl SandBox {
 
         Ok(())
     }
+
+    pub async fn resize_pty(
+        &self,
+        container_id: &str,
+        exec_id: &str,
+        width: u32,
+        height: u32,
+    ) -> Result<()> {
+        let agent_container_id = {
+            let containers = self.containers.lock().await;
+            containers
+                .get(container_id)
+                .ok_or_else(|| {
+                    Error::NotFoundError(format!("not found container:{}", container_id))
+                })?
+                .get_id()
+        };
+        let client = self
+            .client
+            .as_ref()
+            .ok_or_else(|| Error::Other("cube-agent client is not connected".to_string()))?
+            .lock()
+            .await;
+        let request = tty_win_resize_request(&agent_container_id, exec_id, width, height);
+        client
+            .tty_win_resize(self.ctx.clone(), &request)
+            .await
+            .map_err(|error| Error::Other(format!("resize terminal failed:{}", error)))?;
+        Ok(())
+    }
 }
 
 fn recreate_dir(path: &str, context: &str) -> CResult<()> {
@@ -1445,6 +1490,7 @@ mod tests {
     use crate::common::PRODUCT_CUBEBOX;
 
     use super::normalize_dns_for_agent;
+    use super::tty_win_resize_request;
     use super::Log;
     use super::SandBox;
 
@@ -1510,5 +1556,15 @@ mod tests {
     fn test_normalize_dns_for_agent_accepts_prefixed_entry() {
         let got = normalize_dns_for_agent(" nameserver 8.8.8.8 ").unwrap();
         assert_eq!(got, "nameserver 8.8.8.8");
+    }
+
+    #[test]
+    fn test_tty_win_resize_request_maps_dimensions() {
+        let request = tty_win_resize_request("container-1", "exec-1", 120, 40);
+
+        assert_eq!(request.container_id, "container-1");
+        assert_eq!(request.exec_id, "exec-1");
+        assert_eq!(request.column, 120);
+        assert_eq!(request.row, 40);
     }
 }

--- a/CubeShim/shim/src/service/task_srv.rs
+++ b/CubeShim/shim/src/service/task_srv.rs
@@ -558,8 +558,30 @@ impl Task for TaskService {
     async fn resize_pty(
         &self,
         _ctx: &TtrpcContext,
-        _req: api::ResizePtyRequest,
+        req: api::ResizePtyRequest,
     ) -> TtrpcResult<api::Empty> {
+        if req.width() < 2 || req.width() > 500 || req.height() == 0 || req.height() > 200 {
+            return Err(Others(
+                "terminal size must be between 2x1 and 500x200".to_string(),
+            ));
+        }
+        let sandbox = self.sandbox.lock().await;
+        if sandbox.paused().await {
+            return Err(Others("sandbox not in normal state".to_string()));
+        }
+        sandbox
+            .resize_pty(req.id(), req.exec_id(), req.width(), req.height())
+            .await
+            .map_err(|error| {
+                errf!(
+                    self.log,
+                    "resize pty failed, id:{}, execid:{}, error:{}",
+                    req.id(),
+                    req.exec_id(),
+                    error
+                );
+                Error::Other(format!("resize pty failed:{}", error))
+            })?;
         Ok(api::Empty::default())
     }
 

--- a/Cubelet/api/services/cubebox/v1/cubebox.pb.go
+++ b/Cubelet/api/services/cubebox/v1/cubebox.pb.go
@@ -332,6 +332,64 @@ func (ContainerState) EnumDescriptor() ([]byte, []int) {
 	return file_api_services_cubebox_v1_cubebox_proto_rawDescGZIP(), []int{5}
 }
 
+type TerminalErrorCode int32
+
+const (
+	TerminalErrorCode_TERMINAL_ERROR_UNSPECIFIED        TerminalErrorCode = 0
+	TerminalErrorCode_TERMINAL_ERROR_INVALID_REQUEST    TerminalErrorCode = 1
+	TerminalErrorCode_TERMINAL_ERROR_TARGET_NOT_FOUND   TerminalErrorCode = 2
+	TerminalErrorCode_TERMINAL_ERROR_TARGET_NOT_RUNNING TerminalErrorCode = 3
+	TerminalErrorCode_TERMINAL_ERROR_INTERNAL           TerminalErrorCode = 4
+	TerminalErrorCode_TERMINAL_ERROR_IDLE_TIMEOUT       TerminalErrorCode = 5
+)
+
+// Enum value maps for TerminalErrorCode.
+var (
+	TerminalErrorCode_name = map[int32]string{
+		0: "TERMINAL_ERROR_UNSPECIFIED",
+		1: "TERMINAL_ERROR_INVALID_REQUEST",
+		2: "TERMINAL_ERROR_TARGET_NOT_FOUND",
+		3: "TERMINAL_ERROR_TARGET_NOT_RUNNING",
+		4: "TERMINAL_ERROR_INTERNAL",
+		5: "TERMINAL_ERROR_IDLE_TIMEOUT",
+	}
+	TerminalErrorCode_value = map[string]int32{
+		"TERMINAL_ERROR_UNSPECIFIED":        0,
+		"TERMINAL_ERROR_INVALID_REQUEST":    1,
+		"TERMINAL_ERROR_TARGET_NOT_FOUND":   2,
+		"TERMINAL_ERROR_TARGET_NOT_RUNNING": 3,
+		"TERMINAL_ERROR_INTERNAL":           4,
+		"TERMINAL_ERROR_IDLE_TIMEOUT":       5,
+	}
+)
+
+func (x TerminalErrorCode) Enum() *TerminalErrorCode {
+	p := new(TerminalErrorCode)
+	*p = x
+	return p
+}
+
+func (x TerminalErrorCode) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (TerminalErrorCode) Descriptor() protoreflect.EnumDescriptor {
+	return file_api_services_cubebox_v1_cubebox_proto_enumTypes[6].Descriptor()
+}
+
+func (TerminalErrorCode) Type() protoreflect.EnumType {
+	return &file_api_services_cubebox_v1_cubebox_proto_enumTypes[6]
+}
+
+func (x TerminalErrorCode) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use TerminalErrorCode.Descriptor instead.
+func (TerminalErrorCode) EnumDescriptor() ([]byte, []int) {
+	return file_api_services_cubebox_v1_cubebox_proto_rawDescGZIP(), []int{6}
+}
+
 // SELinuxOption are the labels to be applied to the container.
 type SELinuxOption struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
@@ -6476,6 +6534,589 @@ func (x *CleanupOrphanStorageFilesResponse) GetOrphans() []*StorageOrphanEntry {
 	return nil
 }
 
+// Client-to-server frames for an interactive terminal session. Keeping client
+// and server frames separate makes invalid message direction unrepresentable.
+type TerminalClientMessage struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Types that are valid to be assigned to Payload:
+	//
+	//	*TerminalClientMessage_Open
+	//	*TerminalClientMessage_Stdin
+	//	*TerminalClientMessage_Resize
+	//	*TerminalClientMessage_Close
+	Payload       isTerminalClientMessage_Payload `protobuf_oneof:"payload"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *TerminalClientMessage) Reset() {
+	*x = TerminalClientMessage{}
+	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[81]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *TerminalClientMessage) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*TerminalClientMessage) ProtoMessage() {}
+
+func (x *TerminalClientMessage) ProtoReflect() protoreflect.Message {
+	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[81]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use TerminalClientMessage.ProtoReflect.Descriptor instead.
+func (*TerminalClientMessage) Descriptor() ([]byte, []int) {
+	return file_api_services_cubebox_v1_cubebox_proto_rawDescGZIP(), []int{81}
+}
+
+func (x *TerminalClientMessage) GetPayload() isTerminalClientMessage_Payload {
+	if x != nil {
+		return x.Payload
+	}
+	return nil
+}
+
+func (x *TerminalClientMessage) GetOpen() *TerminalOpenRequest {
+	if x != nil {
+		if x, ok := x.Payload.(*TerminalClientMessage_Open); ok {
+			return x.Open
+		}
+	}
+	return nil
+}
+
+func (x *TerminalClientMessage) GetStdin() []byte {
+	if x != nil {
+		if x, ok := x.Payload.(*TerminalClientMessage_Stdin); ok {
+			return x.Stdin
+		}
+	}
+	return nil
+}
+
+func (x *TerminalClientMessage) GetResize() *TerminalResize {
+	if x != nil {
+		if x, ok := x.Payload.(*TerminalClientMessage_Resize); ok {
+			return x.Resize
+		}
+	}
+	return nil
+}
+
+func (x *TerminalClientMessage) GetClose() *TerminalClose {
+	if x != nil {
+		if x, ok := x.Payload.(*TerminalClientMessage_Close); ok {
+			return x.Close
+		}
+	}
+	return nil
+}
+
+type isTerminalClientMessage_Payload interface {
+	isTerminalClientMessage_Payload()
+}
+
+type TerminalClientMessage_Open struct {
+	Open *TerminalOpenRequest `protobuf:"bytes,1,opt,name=open,proto3,oneof"`
+}
+
+type TerminalClientMessage_Stdin struct {
+	Stdin []byte `protobuf:"bytes,2,opt,name=stdin,proto3,oneof"`
+}
+
+type TerminalClientMessage_Resize struct {
+	Resize *TerminalResize `protobuf:"bytes,3,opt,name=resize,proto3,oneof"`
+}
+
+type TerminalClientMessage_Close struct {
+	Close *TerminalClose `protobuf:"bytes,4,opt,name=close,proto3,oneof"`
+}
+
+func (*TerminalClientMessage_Open) isTerminalClientMessage_Payload() {}
+
+func (*TerminalClientMessage_Stdin) isTerminalClientMessage_Payload() {}
+
+func (*TerminalClientMessage_Resize) isTerminalClientMessage_Payload() {}
+
+func (*TerminalClientMessage_Close) isTerminalClientMessage_Payload() {}
+
+type TerminalOpenRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	RequestId     string                 `protobuf:"bytes,1,opt,name=request_id,json=requestId,proto3" json:"request_id,omitempty"`
+	SessionId     string                 `protobuf:"bytes,2,opt,name=session_id,json=sessionId,proto3" json:"session_id,omitempty"`
+	SandboxId     string                 `protobuf:"bytes,3,opt,name=sandbox_id,json=sandboxId,proto3" json:"sandbox_id,omitempty"`
+	ContainerId   string                 `protobuf:"bytes,4,opt,name=container_id,json=containerId,proto3" json:"container_id,omitempty"`
+	Args          []string               `protobuf:"bytes,5,rep,name=args,proto3" json:"args,omitempty"`
+	Env           []string               `protobuf:"bytes,6,rep,name=env,proto3" json:"env,omitempty"`
+	Cwd           string                 `protobuf:"bytes,7,opt,name=cwd,proto3" json:"cwd,omitempty"`
+	Cols          uint32                 `protobuf:"varint,8,opt,name=cols,proto3" json:"cols,omitempty"`
+	Rows          uint32                 `protobuf:"varint,9,opt,name=rows,proto3" json:"rows,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *TerminalOpenRequest) Reset() {
+	*x = TerminalOpenRequest{}
+	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[82]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *TerminalOpenRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*TerminalOpenRequest) ProtoMessage() {}
+
+func (x *TerminalOpenRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[82]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use TerminalOpenRequest.ProtoReflect.Descriptor instead.
+func (*TerminalOpenRequest) Descriptor() ([]byte, []int) {
+	return file_api_services_cubebox_v1_cubebox_proto_rawDescGZIP(), []int{82}
+}
+
+func (x *TerminalOpenRequest) GetRequestId() string {
+	if x != nil {
+		return x.RequestId
+	}
+	return ""
+}
+
+func (x *TerminalOpenRequest) GetSessionId() string {
+	if x != nil {
+		return x.SessionId
+	}
+	return ""
+}
+
+func (x *TerminalOpenRequest) GetSandboxId() string {
+	if x != nil {
+		return x.SandboxId
+	}
+	return ""
+}
+
+func (x *TerminalOpenRequest) GetContainerId() string {
+	if x != nil {
+		return x.ContainerId
+	}
+	return ""
+}
+
+func (x *TerminalOpenRequest) GetArgs() []string {
+	if x != nil {
+		return x.Args
+	}
+	return nil
+}
+
+func (x *TerminalOpenRequest) GetEnv() []string {
+	if x != nil {
+		return x.Env
+	}
+	return nil
+}
+
+func (x *TerminalOpenRequest) GetCwd() string {
+	if x != nil {
+		return x.Cwd
+	}
+	return ""
+}
+
+func (x *TerminalOpenRequest) GetCols() uint32 {
+	if x != nil {
+		return x.Cols
+	}
+	return 0
+}
+
+func (x *TerminalOpenRequest) GetRows() uint32 {
+	if x != nil {
+		return x.Rows
+	}
+	return 0
+}
+
+type TerminalResize struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Cols          uint32                 `protobuf:"varint,1,opt,name=cols,proto3" json:"cols,omitempty"`
+	Rows          uint32                 `protobuf:"varint,2,opt,name=rows,proto3" json:"rows,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *TerminalResize) Reset() {
+	*x = TerminalResize{}
+	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[83]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *TerminalResize) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*TerminalResize) ProtoMessage() {}
+
+func (x *TerminalResize) ProtoReflect() protoreflect.Message {
+	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[83]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use TerminalResize.ProtoReflect.Descriptor instead.
+func (*TerminalResize) Descriptor() ([]byte, []int) {
+	return file_api_services_cubebox_v1_cubebox_proto_rawDescGZIP(), []int{83}
+}
+
+func (x *TerminalResize) GetCols() uint32 {
+	if x != nil {
+		return x.Cols
+	}
+	return 0
+}
+
+func (x *TerminalResize) GetRows() uint32 {
+	if x != nil {
+		return x.Rows
+	}
+	return 0
+}
+
+type TerminalClose struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *TerminalClose) Reset() {
+	*x = TerminalClose{}
+	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[84]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *TerminalClose) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*TerminalClose) ProtoMessage() {}
+
+func (x *TerminalClose) ProtoReflect() protoreflect.Message {
+	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[84]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use TerminalClose.ProtoReflect.Descriptor instead.
+func (*TerminalClose) Descriptor() ([]byte, []int) {
+	return file_api_services_cubebox_v1_cubebox_proto_rawDescGZIP(), []int{84}
+}
+
+// Server-to-client frames for an interactive terminal session.
+type TerminalServerMessage struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Types that are valid to be assigned to Payload:
+	//
+	//	*TerminalServerMessage_Ready
+	//	*TerminalServerMessage_Output
+	//	*TerminalServerMessage_Exit
+	//	*TerminalServerMessage_Error
+	Payload       isTerminalServerMessage_Payload `protobuf_oneof:"payload"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *TerminalServerMessage) Reset() {
+	*x = TerminalServerMessage{}
+	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[85]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *TerminalServerMessage) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*TerminalServerMessage) ProtoMessage() {}
+
+func (x *TerminalServerMessage) ProtoReflect() protoreflect.Message {
+	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[85]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use TerminalServerMessage.ProtoReflect.Descriptor instead.
+func (*TerminalServerMessage) Descriptor() ([]byte, []int) {
+	return file_api_services_cubebox_v1_cubebox_proto_rawDescGZIP(), []int{85}
+}
+
+func (x *TerminalServerMessage) GetPayload() isTerminalServerMessage_Payload {
+	if x != nil {
+		return x.Payload
+	}
+	return nil
+}
+
+func (x *TerminalServerMessage) GetReady() *TerminalReady {
+	if x != nil {
+		if x, ok := x.Payload.(*TerminalServerMessage_Ready); ok {
+			return x.Ready
+		}
+	}
+	return nil
+}
+
+func (x *TerminalServerMessage) GetOutput() []byte {
+	if x != nil {
+		if x, ok := x.Payload.(*TerminalServerMessage_Output); ok {
+			return x.Output
+		}
+	}
+	return nil
+}
+
+func (x *TerminalServerMessage) GetExit() *TerminalExit {
+	if x != nil {
+		if x, ok := x.Payload.(*TerminalServerMessage_Exit); ok {
+			return x.Exit
+		}
+	}
+	return nil
+}
+
+func (x *TerminalServerMessage) GetError() *TerminalError {
+	if x != nil {
+		if x, ok := x.Payload.(*TerminalServerMessage_Error); ok {
+			return x.Error
+		}
+	}
+	return nil
+}
+
+type isTerminalServerMessage_Payload interface {
+	isTerminalServerMessage_Payload()
+}
+
+type TerminalServerMessage_Ready struct {
+	Ready *TerminalReady `protobuf:"bytes,1,opt,name=ready,proto3,oneof"`
+}
+
+type TerminalServerMessage_Output struct {
+	Output []byte `protobuf:"bytes,2,opt,name=output,proto3,oneof"`
+}
+
+type TerminalServerMessage_Exit struct {
+	Exit *TerminalExit `protobuf:"bytes,3,opt,name=exit,proto3,oneof"`
+}
+
+type TerminalServerMessage_Error struct {
+	Error *TerminalError `protobuf:"bytes,4,opt,name=error,proto3,oneof"`
+}
+
+func (*TerminalServerMessage_Ready) isTerminalServerMessage_Payload() {}
+
+func (*TerminalServerMessage_Output) isTerminalServerMessage_Payload() {}
+
+func (*TerminalServerMessage_Exit) isTerminalServerMessage_Payload() {}
+
+func (*TerminalServerMessage_Error) isTerminalServerMessage_Payload() {}
+
+type TerminalReady struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	ExecId        string                 `protobuf:"bytes,1,opt,name=exec_id,json=execId,proto3" json:"exec_id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *TerminalReady) Reset() {
+	*x = TerminalReady{}
+	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[86]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *TerminalReady) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*TerminalReady) ProtoMessage() {}
+
+func (x *TerminalReady) ProtoReflect() protoreflect.Message {
+	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[86]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use TerminalReady.ProtoReflect.Descriptor instead.
+func (*TerminalReady) Descriptor() ([]byte, []int) {
+	return file_api_services_cubebox_v1_cubebox_proto_rawDescGZIP(), []int{86}
+}
+
+func (x *TerminalReady) GetExecId() string {
+	if x != nil {
+		return x.ExecId
+	}
+	return ""
+}
+
+type TerminalExit struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	ExitCode      int32                  `protobuf:"varint,1,opt,name=exit_code,json=exitCode,proto3" json:"exit_code,omitempty"`
+	Reason        string                 `protobuf:"bytes,2,opt,name=reason,proto3" json:"reason,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *TerminalExit) Reset() {
+	*x = TerminalExit{}
+	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[87]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *TerminalExit) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*TerminalExit) ProtoMessage() {}
+
+func (x *TerminalExit) ProtoReflect() protoreflect.Message {
+	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[87]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use TerminalExit.ProtoReflect.Descriptor instead.
+func (*TerminalExit) Descriptor() ([]byte, []int) {
+	return file_api_services_cubebox_v1_cubebox_proto_rawDescGZIP(), []int{87}
+}
+
+func (x *TerminalExit) GetExitCode() int32 {
+	if x != nil {
+		return x.ExitCode
+	}
+	return 0
+}
+
+func (x *TerminalExit) GetReason() string {
+	if x != nil {
+		return x.Reason
+	}
+	return ""
+}
+
+type TerminalError struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Code          TerminalErrorCode      `protobuf:"varint,1,opt,name=code,proto3,enum=cubelet.services.cubebox.v1.TerminalErrorCode" json:"code,omitempty"`
+	Message       string                 `protobuf:"bytes,2,opt,name=message,proto3" json:"message,omitempty"`
+	Retryable     bool                   `protobuf:"varint,3,opt,name=retryable,proto3" json:"retryable,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *TerminalError) Reset() {
+	*x = TerminalError{}
+	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[88]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *TerminalError) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*TerminalError) ProtoMessage() {}
+
+func (x *TerminalError) ProtoReflect() protoreflect.Message {
+	mi := &file_api_services_cubebox_v1_cubebox_proto_msgTypes[88]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use TerminalError.ProtoReflect.Descriptor instead.
+func (*TerminalError) Descriptor() ([]byte, []int) {
+	return file_api_services_cubebox_v1_cubebox_proto_rawDescGZIP(), []int{88}
+}
+
+func (x *TerminalError) GetCode() TerminalErrorCode {
+	if x != nil {
+		return x.Code
+	}
+	return TerminalErrorCode_TERMINAL_ERROR_UNSPECIFIED
+}
+
+func (x *TerminalError) GetMessage() string {
+	if x != nil {
+		return x.Message
+	}
+	return ""
+}
+
+func (x *TerminalError) GetRetryable() bool {
+	if x != nil {
+		return x.Retryable
+	}
+	return false
+}
+
 var File_api_services_cubebox_v1_cubebox_proto protoreflect.FileDescriptor
 
 const file_api_services_cubebox_v1_cubebox_proto_rawDesc = "" +
@@ -7039,7 +7680,45 @@ const file_api_services_cubebox_v1_cubebox_proto_rawDesc = "" +
 	"!CleanupOrphanStorageFilesResponse\x12\x1c\n" +
 	"\trequestID\x18\x01 \x01(\tR\trequestID\x124\n" +
 	"\x03ret\x18\x02 \x01(\v2\".cubelet.services.errorcode.v1.RetR\x03ret\x12I\n" +
-	"\aorphans\x18\x03 \x03(\v2/.cubelet.services.cubebox.v1.StorageOrphanEntryR\aorphans*m\n" +
+	"\aorphans\x18\x03 \x03(\v2/.cubelet.services.cubebox.v1.StorageOrphanEntryR\aorphans\"\x8d\x02\n" +
+	"\x15TerminalClientMessage\x12F\n" +
+	"\x04open\x18\x01 \x01(\v20.cubelet.services.cubebox.v1.TerminalOpenRequestH\x00R\x04open\x12\x16\n" +
+	"\x05stdin\x18\x02 \x01(\fH\x00R\x05stdin\x12E\n" +
+	"\x06resize\x18\x03 \x01(\v2+.cubelet.services.cubebox.v1.TerminalResizeH\x00R\x06resize\x12B\n" +
+	"\x05close\x18\x04 \x01(\v2*.cubelet.services.cubebox.v1.TerminalCloseH\x00R\x05closeB\t\n" +
+	"\apayload\"\xf5\x01\n" +
+	"\x13TerminalOpenRequest\x12\x1d\n" +
+	"\n" +
+	"request_id\x18\x01 \x01(\tR\trequestId\x12\x1d\n" +
+	"\n" +
+	"session_id\x18\x02 \x01(\tR\tsessionId\x12\x1d\n" +
+	"\n" +
+	"sandbox_id\x18\x03 \x01(\tR\tsandboxId\x12!\n" +
+	"\fcontainer_id\x18\x04 \x01(\tR\vcontainerId\x12\x12\n" +
+	"\x04args\x18\x05 \x03(\tR\x04args\x12\x10\n" +
+	"\x03env\x18\x06 \x03(\tR\x03env\x12\x10\n" +
+	"\x03cwd\x18\a \x01(\tR\x03cwd\x12\x12\n" +
+	"\x04cols\x18\b \x01(\rR\x04cols\x12\x12\n" +
+	"\x04rows\x18\t \x01(\rR\x04rows\"8\n" +
+	"\x0eTerminalResize\x12\x12\n" +
+	"\x04cols\x18\x01 \x01(\rR\x04cols\x12\x12\n" +
+	"\x04rows\x18\x02 \x01(\rR\x04rows\"\x0f\n" +
+	"\rTerminalClose\"\x85\x02\n" +
+	"\x15TerminalServerMessage\x12B\n" +
+	"\x05ready\x18\x01 \x01(\v2*.cubelet.services.cubebox.v1.TerminalReadyH\x00R\x05ready\x12\x18\n" +
+	"\x06output\x18\x02 \x01(\fH\x00R\x06output\x12?\n" +
+	"\x04exit\x18\x03 \x01(\v2).cubelet.services.cubebox.v1.TerminalExitH\x00R\x04exit\x12B\n" +
+	"\x05error\x18\x04 \x01(\v2*.cubelet.services.cubebox.v1.TerminalErrorH\x00R\x05errorB\t\n" +
+	"\apayload\"(\n" +
+	"\rTerminalReady\x12\x17\n" +
+	"\aexec_id\x18\x01 \x01(\tR\x06execId\"C\n" +
+	"\fTerminalExit\x12\x1b\n" +
+	"\texit_code\x18\x01 \x01(\x05R\bexitCode\x12\x16\n" +
+	"\x06reason\x18\x02 \x01(\tR\x06reason\"\x8b\x01\n" +
+	"\rTerminalError\x12B\n" +
+	"\x04code\x18\x01 \x01(\x0e2..cubelet.services.cubebox.v1.TerminalErrorCodeR\x04code\x12\x18\n" +
+	"\amessage\x18\x02 \x01(\tR\amessage\x12\x1c\n" +
+	"\tretryable\x18\x03 \x01(\bR\tretryable*m\n" +
 	"\x10MountPropagation\x12\x17\n" +
 	"\x13PROPAGATION_PRIVATE\x10\x00\x12!\n" +
 	"\x1dPROPAGATION_HOST_TO_CONTAINER\x10\x01\x12\x1d\n" +
@@ -7063,14 +7742,22 @@ const file_api_services_cubebox_v1_cubebox_proto_rawDesc = "" +
 	"\x10CONTAINER_EXITED\x10\x02\x12\x15\n" +
 	"\x11CONTAINER_UNKNOWN\x10\x03\x12\x15\n" +
 	"\x11CONTAINER_PAUSING\x10\x04\x12\x14\n" +
-	"\x10CONTAINER_PAUSED\x10\x052\x8a\x0f\n" +
+	"\x10CONTAINER_PAUSED\x10\x05*\xe1\x01\n" +
+	"\x11TerminalErrorCode\x12\x1e\n" +
+	"\x1aTERMINAL_ERROR_UNSPECIFIED\x10\x00\x12\"\n" +
+	"\x1eTERMINAL_ERROR_INVALID_REQUEST\x10\x01\x12#\n" +
+	"\x1fTERMINAL_ERROR_TARGET_NOT_FOUND\x10\x02\x12%\n" +
+	"!TERMINAL_ERROR_TARGET_NOT_RUNNING\x10\x03\x12\x1b\n" +
+	"\x17TERMINAL_ERROR_INTERNAL\x10\x04\x12\x1f\n" +
+	"\x1bTERMINAL_ERROR_IDLE_TIMEOUT\x10\x052\x88\x10\n" +
 	"\n" +
 	"CubeboxMgr\x12q\n" +
 	"\x06Create\x122.cubelet.services.cubebox.v1.RunCubeSandboxRequest\x1a3.cubelet.services.cubebox.v1.RunCubeSandboxResponse\x12z\n" +
 	"\aDestroy\x126.cubelet.services.cubebox.v1.DestroyCubeSandboxRequest\x1a7.cubelet.services.cubebox.v1.DestroyCubeSandboxResponse\x12q\n" +
 	"\x04List\x123.cubelet.services.cubebox.v1.ListCubeSandboxRequest\x1a4.cubelet.services.cubebox.v1.ListCubeSandboxResponse\x12w\n" +
 	"\x06Update\x125.cubelet.services.cubebox.v1.UpdateCubeSandboxRequest\x1a6.cubelet.services.cubebox.v1.UpdateCubeSandboxResponse\x12q\n" +
-	"\x04Exec\x123.cubelet.services.cubebox.v1.ExecCubeSandboxRequest\x1a4.cubelet.services.cubebox.v1.ExecCubeSandboxResponse\x12p\n" +
+	"\x04Exec\x123.cubelet.services.cubebox.v1.ExecCubeSandboxRequest\x1a4.cubelet.services.cubebox.v1.ExecCubeSandboxResponse\x12|\n" +
+	"\x0eAttachTerminal\x122.cubelet.services.cubebox.v1.TerminalClientMessage\x1a2.cubelet.services.cubebox.v1.TerminalServerMessage(\x010\x01\x12p\n" +
 	"\vAppSnapshot\x12/.cubelet.services.cubebox.v1.AppSnapshotRequest\x1a0.cubelet.services.cubebox.v1.AppSnapshotResponse\x12v\n" +
 	"\rCommitSandbox\x121.cubelet.services.cubebox.v1.CommitSandboxRequest\x1a2.cubelet.services.cubebox.v1.CommitSandboxResponse\x12|\n" +
 	"\x0fRollbackSandbox\x123.cubelet.services.cubebox.v1.RollbackSandboxRequest\x1a4.cubelet.services.cubebox.v1.RollbackSandboxResponse\x12|\n" +
@@ -7094,8 +7781,8 @@ func file_api_services_cubebox_v1_cubebox_proto_rawDescGZIP() []byte {
 	return file_api_services_cubebox_v1_cubebox_proto_rawDescData
 }
 
-var file_api_services_cubebox_v1_cubebox_proto_enumTypes = make([]protoimpl.EnumInfo, 6)
-var file_api_services_cubebox_v1_cubebox_proto_msgTypes = make([]protoimpl.MessageInfo, 93)
+var file_api_services_cubebox_v1_cubebox_proto_enumTypes = make([]protoimpl.EnumInfo, 7)
+var file_api_services_cubebox_v1_cubebox_proto_msgTypes = make([]protoimpl.MessageInfo, 101)
 var file_api_services_cubebox_v1_cubebox_proto_goTypes = []any{
 	(MountPropagation)(0),                     // 0: cubelet.services.cubebox.v1.MountPropagation
 	(StorageMedium)(0),                        // 1: cubelet.services.cubebox.v1.StorageMedium
@@ -7103,233 +7790,251 @@ var file_api_services_cubebox_v1_cubebox_proto_goTypes = []any{
 	(InstanceType)(0),                         // 3: cubelet.services.cubebox.v1.InstanceType
 	(NetworkType)(0),                          // 4: cubelet.services.cubebox.v1.NetworkType
 	(ContainerState)(0),                       // 5: cubelet.services.cubebox.v1.ContainerState
-	(*SELinuxOption)(nil),                     // 6: cubelet.services.cubebox.v1.SELinuxOption
-	(*Capability)(nil),                        // 7: cubelet.services.cubebox.v1.Capability
-	(*Int64Value)(nil),                        // 8: cubelet.services.cubebox.v1.Int64Value
-	(*ContainerSecurityContext)(nil),          // 9: cubelet.services.cubebox.v1.ContainerSecurityContext
-	(*DNSConfig)(nil),                         // 10: cubelet.services.cubebox.v1.DNSConfig
-	(*RLimit)(nil),                            // 11: cubelet.services.cubebox.v1.RLimit
-	(*VolumeMounts)(nil),                      // 12: cubelet.services.cubebox.v1.VolumeMounts
-	(*TCPSocketAction)(nil),                   // 13: cubelet.services.cubebox.v1.TCPSocketAction
-	(*PingAction)(nil),                        // 14: cubelet.services.cubebox.v1.PingAction
-	(*HTTPGetAction)(nil),                     // 15: cubelet.services.cubebox.v1.HTTPGetAction
-	(*HTTPHeader)(nil),                        // 16: cubelet.services.cubebox.v1.HTTPHeader
-	(*ProbeHandler)(nil),                      // 17: cubelet.services.cubebox.v1.ProbeHandler
-	(*Probe)(nil),                             // 18: cubelet.services.cubebox.v1.Probe
-	(*LifecycleHandler)(nil),                  // 19: cubelet.services.cubebox.v1.LifecycleHandler
-	(*PreStop)(nil),                           // 20: cubelet.services.cubebox.v1.PreStop
-	(*PostStop)(nil),                          // 21: cubelet.services.cubebox.v1.PostStop
-	(*Hook)(nil),                              // 22: cubelet.services.cubebox.v1.Hook
-	(*Hooks)(nil),                             // 23: cubelet.services.cubebox.v1.Hooks
-	(*KeyValue)(nil),                          // 24: cubelet.services.cubebox.v1.KeyValue
-	(*HostAlias)(nil),                         // 25: cubelet.services.cubebox.v1.HostAlias
-	(*ContainerConfig)(nil),                   // 26: cubelet.services.cubebox.v1.ContainerConfig
-	(*OCIConfig)(nil),                         // 27: cubelet.services.cubebox.v1.OCIConfig
-	(*Device)(nil),                            // 28: cubelet.services.cubebox.v1.Device
-	(*CDIDevice)(nil),                         // 29: cubelet.services.cubebox.v1.CDIDevice
-	(*LinuxSeccompArg)(nil),                   // 30: cubelet.services.cubebox.v1.LinuxSeccompArg
-	(*SysCall)(nil),                           // 31: cubelet.services.cubebox.v1.SysCall
-	(*Resource)(nil),                          // 32: cubelet.services.cubebox.v1.Resource
-	(*EmptyDirVolumeSource)(nil),              // 33: cubelet.services.cubebox.v1.EmptyDirVolumeSource
-	(*SandboxPathVolumeSource)(nil),           // 34: cubelet.services.cubebox.v1.SandboxPathVolumeSource
-	(*HostDirSource)(nil),                     // 35: cubelet.services.cubebox.v1.HostDirSource
-	(*HostDirVolumeSources)(nil),              // 36: cubelet.services.cubebox.v1.HostDirVolumeSources
-	(*VolumeSource)(nil),                      // 37: cubelet.services.cubebox.v1.VolumeSource
-	(*Volume)(nil),                            // 38: cubelet.services.cubebox.v1.Volume
-	(*RunCubeSandboxRequest)(nil),             // 39: cubelet.services.cubebox.v1.RunCubeSandboxRequest
-	(*RunCubeSandboxResponse)(nil),            // 40: cubelet.services.cubebox.v1.RunCubeSandboxResponse
-	(*PortMapping)(nil),                       // 41: cubelet.services.cubebox.v1.PortMapping
-	(*CubeNetworkConfig)(nil),                 // 42: cubelet.services.cubebox.v1.CubeNetworkConfig
-	(*EgressRule)(nil),                        // 43: cubelet.services.cubebox.v1.EgressRule
-	(*EgressRuleMatch)(nil),                   // 44: cubelet.services.cubebox.v1.EgressRuleMatch
-	(*EgressRuleAction)(nil),                  // 45: cubelet.services.cubebox.v1.EgressRuleAction
-	(*EgressRuleInject)(nil),                  // 46: cubelet.services.cubebox.v1.EgressRuleInject
-	(*DestroyCubeSandboxRequest)(nil),         // 47: cubelet.services.cubebox.v1.DestroyCubeSandboxRequest
-	(*DestroyCubeSandboxResponse)(nil),        // 48: cubelet.services.cubebox.v1.DestroyCubeSandboxResponse
-	(*CubeSandbox)(nil),                       // 49: cubelet.services.cubebox.v1.CubeSandbox
-	(*Container)(nil),                         // 50: cubelet.services.cubebox.v1.Container
-	(*ContainerStateValue)(nil),               // 51: cubelet.services.cubebox.v1.ContainerStateValue
-	(*CubeSandboxFilter)(nil),                 // 52: cubelet.services.cubebox.v1.CubeSandboxFilter
-	(*ListCubeSandboxRequest)(nil),            // 53: cubelet.services.cubebox.v1.ListCubeSandboxRequest
-	(*ListCubeSandboxResponse)(nil),           // 54: cubelet.services.cubebox.v1.ListCubeSandboxResponse
-	(*UpdateCubeSandboxRequest)(nil),          // 55: cubelet.services.cubebox.v1.UpdateCubeSandboxRequest
-	(*UpdateCubeSandboxResponse)(nil),         // 56: cubelet.services.cubebox.v1.UpdateCubeSandboxResponse
-	(*IDMapping)(nil),                         // 57: cubelet.services.cubebox.v1.IDMapping
-	(*ListCubeSandboxOption)(nil),             // 58: cubelet.services.cubebox.v1.ListCubeSandboxOption
-	(*ExecCubeSandboxRequest)(nil),            // 59: cubelet.services.cubebox.v1.ExecCubeSandboxRequest
-	(*ExecCubeSandboxResponse)(nil),           // 60: cubelet.services.cubebox.v1.ExecCubeSandboxResponse
-	(*AppSnapshotRequest)(nil),                // 61: cubelet.services.cubebox.v1.AppSnapshotRequest
-	(*AppSnapshotResponse)(nil),               // 62: cubelet.services.cubebox.v1.AppSnapshotResponse
-	(*CommitSandboxRequest)(nil),              // 63: cubelet.services.cubebox.v1.CommitSandboxRequest
-	(*CommitSandboxResponse)(nil),             // 64: cubelet.services.cubebox.v1.CommitSandboxResponse
-	(*RollbackSandboxRequest)(nil),            // 65: cubelet.services.cubebox.v1.RollbackSandboxRequest
-	(*RollbackSandboxResponse)(nil),           // 66: cubelet.services.cubebox.v1.RollbackSandboxResponse
-	(*CowObjectRef)(nil),                      // 67: cubelet.services.cubebox.v1.CowObjectRef
-	(*CleanupTemplateRequest)(nil),            // 68: cubelet.services.cubebox.v1.CleanupTemplateRequest
-	(*CleanupTemplateResponse)(nil),           // 69: cubelet.services.cubebox.v1.CleanupTemplateResponse
-	(*ListSandboxSnapshotsRequest)(nil),       // 70: cubelet.services.cubebox.v1.ListSandboxSnapshotsRequest
-	(*CowObjectStatus)(nil),                   // 71: cubelet.services.cubebox.v1.CowObjectStatus
-	(*ListSandboxSnapshotsResponse)(nil),      // 72: cubelet.services.cubebox.v1.ListSandboxSnapshotsResponse
-	(*ListLocalSnapshotsRequest)(nil),         // 73: cubelet.services.cubebox.v1.ListLocalSnapshotsRequest
-	(*LocalSnapshotInfo)(nil),                 // 74: cubelet.services.cubebox.v1.LocalSnapshotInfo
-	(*ListLocalSnapshotsResponse)(nil),        // 75: cubelet.services.cubebox.v1.ListLocalSnapshotsResponse
-	(*GetLocalSnapshotRequest)(nil),           // 76: cubelet.services.cubebox.v1.GetLocalSnapshotRequest
-	(*GetLocalSnapshotResponse)(nil),          // 77: cubelet.services.cubebox.v1.GetLocalSnapshotResponse
-	(*GetStorageMetricsRequest)(nil),          // 78: cubelet.services.cubebox.v1.GetStorageMetricsRequest
-	(*GetStorageMetricsResponse)(nil),         // 79: cubelet.services.cubebox.v1.GetStorageMetricsResponse
-	(*StorageVolumeInfo)(nil),                 // 80: cubelet.services.cubebox.v1.StorageVolumeInfo
-	(*SandboxStorageInfo)(nil),                // 81: cubelet.services.cubebox.v1.SandboxStorageInfo
-	(*InspectStorageVolumesRequest)(nil),      // 82: cubelet.services.cubebox.v1.InspectStorageVolumesRequest
-	(*InspectStorageVolumesResponse)(nil),     // 83: cubelet.services.cubebox.v1.InspectStorageVolumesResponse
-	(*CleanupOrphanStorageFilesRequest)(nil),  // 84: cubelet.services.cubebox.v1.CleanupOrphanStorageFilesRequest
-	(*StorageOrphanEntry)(nil),                // 85: cubelet.services.cubebox.v1.StorageOrphanEntry
-	(*CleanupOrphanStorageFilesResponse)(nil), // 86: cubelet.services.cubebox.v1.CleanupOrphanStorageFilesResponse
-	nil,                            // 87: cubelet.services.cubebox.v1.ContainerConfig.SysctlsEntry
-	nil,                            // 88: cubelet.services.cubebox.v1.ContainerConfig.AnnotationsEntry
-	nil,                            // 89: cubelet.services.cubebox.v1.RunCubeSandboxRequest.AnnotationsEntry
-	nil,                            // 90: cubelet.services.cubebox.v1.RunCubeSandboxRequest.LabelsEntry
-	nil,                            // 91: cubelet.services.cubebox.v1.RunCubeSandboxResponse.ExtInfoEntry
-	nil,                            // 92: cubelet.services.cubebox.v1.DestroyCubeSandboxRequest.AnnotationsEntry
-	nil,                            // 93: cubelet.services.cubebox.v1.DestroyCubeSandboxResponse.ExtInfoEntry
-	nil,                            // 94: cubelet.services.cubebox.v1.CubeSandbox.LabelsEntry
-	nil,                            // 95: cubelet.services.cubebox.v1.Container.LabelsEntry
-	nil,                            // 96: cubelet.services.cubebox.v1.CubeSandboxFilter.LabelSelectorEntry
-	nil,                            // 97: cubelet.services.cubebox.v1.UpdateCubeSandboxRequest.AnnotationsEntry
-	nil,                            // 98: cubelet.services.cubebox.v1.GetStorageMetricsResponse.MetricsEntry
-	(*v1.ImageSpec)(nil),           // 99: cubelet.services.images.v1.ImageSpec
-	(*v1.ImageVolumeSource)(nil),   // 100: cubelet.services.images.v1.ImageVolumeSource
-	(*v11.PluginVolumeSource)(nil), // 101: cubelet.services.volumeplugin.v1.PluginVolumeSource
-	(*v12.Ret)(nil),                // 102: cubelet.services.errorcode.v1.Ret
+	(TerminalErrorCode)(0),                    // 6: cubelet.services.cubebox.v1.TerminalErrorCode
+	(*SELinuxOption)(nil),                     // 7: cubelet.services.cubebox.v1.SELinuxOption
+	(*Capability)(nil),                        // 8: cubelet.services.cubebox.v1.Capability
+	(*Int64Value)(nil),                        // 9: cubelet.services.cubebox.v1.Int64Value
+	(*ContainerSecurityContext)(nil),          // 10: cubelet.services.cubebox.v1.ContainerSecurityContext
+	(*DNSConfig)(nil),                         // 11: cubelet.services.cubebox.v1.DNSConfig
+	(*RLimit)(nil),                            // 12: cubelet.services.cubebox.v1.RLimit
+	(*VolumeMounts)(nil),                      // 13: cubelet.services.cubebox.v1.VolumeMounts
+	(*TCPSocketAction)(nil),                   // 14: cubelet.services.cubebox.v1.TCPSocketAction
+	(*PingAction)(nil),                        // 15: cubelet.services.cubebox.v1.PingAction
+	(*HTTPGetAction)(nil),                     // 16: cubelet.services.cubebox.v1.HTTPGetAction
+	(*HTTPHeader)(nil),                        // 17: cubelet.services.cubebox.v1.HTTPHeader
+	(*ProbeHandler)(nil),                      // 18: cubelet.services.cubebox.v1.ProbeHandler
+	(*Probe)(nil),                             // 19: cubelet.services.cubebox.v1.Probe
+	(*LifecycleHandler)(nil),                  // 20: cubelet.services.cubebox.v1.LifecycleHandler
+	(*PreStop)(nil),                           // 21: cubelet.services.cubebox.v1.PreStop
+	(*PostStop)(nil),                          // 22: cubelet.services.cubebox.v1.PostStop
+	(*Hook)(nil),                              // 23: cubelet.services.cubebox.v1.Hook
+	(*Hooks)(nil),                             // 24: cubelet.services.cubebox.v1.Hooks
+	(*KeyValue)(nil),                          // 25: cubelet.services.cubebox.v1.KeyValue
+	(*HostAlias)(nil),                         // 26: cubelet.services.cubebox.v1.HostAlias
+	(*ContainerConfig)(nil),                   // 27: cubelet.services.cubebox.v1.ContainerConfig
+	(*OCIConfig)(nil),                         // 28: cubelet.services.cubebox.v1.OCIConfig
+	(*Device)(nil),                            // 29: cubelet.services.cubebox.v1.Device
+	(*CDIDevice)(nil),                         // 30: cubelet.services.cubebox.v1.CDIDevice
+	(*LinuxSeccompArg)(nil),                   // 31: cubelet.services.cubebox.v1.LinuxSeccompArg
+	(*SysCall)(nil),                           // 32: cubelet.services.cubebox.v1.SysCall
+	(*Resource)(nil),                          // 33: cubelet.services.cubebox.v1.Resource
+	(*EmptyDirVolumeSource)(nil),              // 34: cubelet.services.cubebox.v1.EmptyDirVolumeSource
+	(*SandboxPathVolumeSource)(nil),           // 35: cubelet.services.cubebox.v1.SandboxPathVolumeSource
+	(*HostDirSource)(nil),                     // 36: cubelet.services.cubebox.v1.HostDirSource
+	(*HostDirVolumeSources)(nil),              // 37: cubelet.services.cubebox.v1.HostDirVolumeSources
+	(*VolumeSource)(nil),                      // 38: cubelet.services.cubebox.v1.VolumeSource
+	(*Volume)(nil),                            // 39: cubelet.services.cubebox.v1.Volume
+	(*RunCubeSandboxRequest)(nil),             // 40: cubelet.services.cubebox.v1.RunCubeSandboxRequest
+	(*RunCubeSandboxResponse)(nil),            // 41: cubelet.services.cubebox.v1.RunCubeSandboxResponse
+	(*PortMapping)(nil),                       // 42: cubelet.services.cubebox.v1.PortMapping
+	(*CubeNetworkConfig)(nil),                 // 43: cubelet.services.cubebox.v1.CubeNetworkConfig
+	(*EgressRule)(nil),                        // 44: cubelet.services.cubebox.v1.EgressRule
+	(*EgressRuleMatch)(nil),                   // 45: cubelet.services.cubebox.v1.EgressRuleMatch
+	(*EgressRuleAction)(nil),                  // 46: cubelet.services.cubebox.v1.EgressRuleAction
+	(*EgressRuleInject)(nil),                  // 47: cubelet.services.cubebox.v1.EgressRuleInject
+	(*DestroyCubeSandboxRequest)(nil),         // 48: cubelet.services.cubebox.v1.DestroyCubeSandboxRequest
+	(*DestroyCubeSandboxResponse)(nil),        // 49: cubelet.services.cubebox.v1.DestroyCubeSandboxResponse
+	(*CubeSandbox)(nil),                       // 50: cubelet.services.cubebox.v1.CubeSandbox
+	(*Container)(nil),                         // 51: cubelet.services.cubebox.v1.Container
+	(*ContainerStateValue)(nil),               // 52: cubelet.services.cubebox.v1.ContainerStateValue
+	(*CubeSandboxFilter)(nil),                 // 53: cubelet.services.cubebox.v1.CubeSandboxFilter
+	(*ListCubeSandboxRequest)(nil),            // 54: cubelet.services.cubebox.v1.ListCubeSandboxRequest
+	(*ListCubeSandboxResponse)(nil),           // 55: cubelet.services.cubebox.v1.ListCubeSandboxResponse
+	(*UpdateCubeSandboxRequest)(nil),          // 56: cubelet.services.cubebox.v1.UpdateCubeSandboxRequest
+	(*UpdateCubeSandboxResponse)(nil),         // 57: cubelet.services.cubebox.v1.UpdateCubeSandboxResponse
+	(*IDMapping)(nil),                         // 58: cubelet.services.cubebox.v1.IDMapping
+	(*ListCubeSandboxOption)(nil),             // 59: cubelet.services.cubebox.v1.ListCubeSandboxOption
+	(*ExecCubeSandboxRequest)(nil),            // 60: cubelet.services.cubebox.v1.ExecCubeSandboxRequest
+	(*ExecCubeSandboxResponse)(nil),           // 61: cubelet.services.cubebox.v1.ExecCubeSandboxResponse
+	(*AppSnapshotRequest)(nil),                // 62: cubelet.services.cubebox.v1.AppSnapshotRequest
+	(*AppSnapshotResponse)(nil),               // 63: cubelet.services.cubebox.v1.AppSnapshotResponse
+	(*CommitSandboxRequest)(nil),              // 64: cubelet.services.cubebox.v1.CommitSandboxRequest
+	(*CommitSandboxResponse)(nil),             // 65: cubelet.services.cubebox.v1.CommitSandboxResponse
+	(*RollbackSandboxRequest)(nil),            // 66: cubelet.services.cubebox.v1.RollbackSandboxRequest
+	(*RollbackSandboxResponse)(nil),           // 67: cubelet.services.cubebox.v1.RollbackSandboxResponse
+	(*CowObjectRef)(nil),                      // 68: cubelet.services.cubebox.v1.CowObjectRef
+	(*CleanupTemplateRequest)(nil),            // 69: cubelet.services.cubebox.v1.CleanupTemplateRequest
+	(*CleanupTemplateResponse)(nil),           // 70: cubelet.services.cubebox.v1.CleanupTemplateResponse
+	(*ListSandboxSnapshotsRequest)(nil),       // 71: cubelet.services.cubebox.v1.ListSandboxSnapshotsRequest
+	(*CowObjectStatus)(nil),                   // 72: cubelet.services.cubebox.v1.CowObjectStatus
+	(*ListSandboxSnapshotsResponse)(nil),      // 73: cubelet.services.cubebox.v1.ListSandboxSnapshotsResponse
+	(*ListLocalSnapshotsRequest)(nil),         // 74: cubelet.services.cubebox.v1.ListLocalSnapshotsRequest
+	(*LocalSnapshotInfo)(nil),                 // 75: cubelet.services.cubebox.v1.LocalSnapshotInfo
+	(*ListLocalSnapshotsResponse)(nil),        // 76: cubelet.services.cubebox.v1.ListLocalSnapshotsResponse
+	(*GetLocalSnapshotRequest)(nil),           // 77: cubelet.services.cubebox.v1.GetLocalSnapshotRequest
+	(*GetLocalSnapshotResponse)(nil),          // 78: cubelet.services.cubebox.v1.GetLocalSnapshotResponse
+	(*GetStorageMetricsRequest)(nil),          // 79: cubelet.services.cubebox.v1.GetStorageMetricsRequest
+	(*GetStorageMetricsResponse)(nil),         // 80: cubelet.services.cubebox.v1.GetStorageMetricsResponse
+	(*StorageVolumeInfo)(nil),                 // 81: cubelet.services.cubebox.v1.StorageVolumeInfo
+	(*SandboxStorageInfo)(nil),                // 82: cubelet.services.cubebox.v1.SandboxStorageInfo
+	(*InspectStorageVolumesRequest)(nil),      // 83: cubelet.services.cubebox.v1.InspectStorageVolumesRequest
+	(*InspectStorageVolumesResponse)(nil),     // 84: cubelet.services.cubebox.v1.InspectStorageVolumesResponse
+	(*CleanupOrphanStorageFilesRequest)(nil),  // 85: cubelet.services.cubebox.v1.CleanupOrphanStorageFilesRequest
+	(*StorageOrphanEntry)(nil),                // 86: cubelet.services.cubebox.v1.StorageOrphanEntry
+	(*CleanupOrphanStorageFilesResponse)(nil), // 87: cubelet.services.cubebox.v1.CleanupOrphanStorageFilesResponse
+	(*TerminalClientMessage)(nil),             // 88: cubelet.services.cubebox.v1.TerminalClientMessage
+	(*TerminalOpenRequest)(nil),               // 89: cubelet.services.cubebox.v1.TerminalOpenRequest
+	(*TerminalResize)(nil),                    // 90: cubelet.services.cubebox.v1.TerminalResize
+	(*TerminalClose)(nil),                     // 91: cubelet.services.cubebox.v1.TerminalClose
+	(*TerminalServerMessage)(nil),             // 92: cubelet.services.cubebox.v1.TerminalServerMessage
+	(*TerminalReady)(nil),                     // 93: cubelet.services.cubebox.v1.TerminalReady
+	(*TerminalExit)(nil),                      // 94: cubelet.services.cubebox.v1.TerminalExit
+	(*TerminalError)(nil),                     // 95: cubelet.services.cubebox.v1.TerminalError
+	nil,                                       // 96: cubelet.services.cubebox.v1.ContainerConfig.SysctlsEntry
+	nil,                                       // 97: cubelet.services.cubebox.v1.ContainerConfig.AnnotationsEntry
+	nil,                                       // 98: cubelet.services.cubebox.v1.RunCubeSandboxRequest.AnnotationsEntry
+	nil,                                       // 99: cubelet.services.cubebox.v1.RunCubeSandboxRequest.LabelsEntry
+	nil,                                       // 100: cubelet.services.cubebox.v1.RunCubeSandboxResponse.ExtInfoEntry
+	nil,                                       // 101: cubelet.services.cubebox.v1.DestroyCubeSandboxRequest.AnnotationsEntry
+	nil,                                       // 102: cubelet.services.cubebox.v1.DestroyCubeSandboxResponse.ExtInfoEntry
+	nil,                                       // 103: cubelet.services.cubebox.v1.CubeSandbox.LabelsEntry
+	nil,                                       // 104: cubelet.services.cubebox.v1.Container.LabelsEntry
+	nil,                                       // 105: cubelet.services.cubebox.v1.CubeSandboxFilter.LabelSelectorEntry
+	nil,                                       // 106: cubelet.services.cubebox.v1.UpdateCubeSandboxRequest.AnnotationsEntry
+	nil,                                       // 107: cubelet.services.cubebox.v1.GetStorageMetricsResponse.MetricsEntry
+	(*v1.ImageSpec)(nil),                      // 108: cubelet.services.images.v1.ImageSpec
+	(*v1.ImageVolumeSource)(nil),              // 109: cubelet.services.images.v1.ImageVolumeSource
+	(*v11.PluginVolumeSource)(nil),            // 110: cubelet.services.volumeplugin.v1.PluginVolumeSource
+	(*v12.Ret)(nil),                           // 111: cubelet.services.errorcode.v1.Ret
 }
 var file_api_services_cubebox_v1_cubebox_proto_depIdxs = []int32{
-	7,   // 0: cubelet.services.cubebox.v1.ContainerSecurityContext.capabilities:type_name -> cubelet.services.cubebox.v1.Capability
-	8,   // 1: cubelet.services.cubebox.v1.ContainerSecurityContext.run_as_user:type_name -> cubelet.services.cubebox.v1.Int64Value
-	8,   // 2: cubelet.services.cubebox.v1.ContainerSecurityContext.run_as_group:type_name -> cubelet.services.cubebox.v1.Int64Value
+	8,   // 0: cubelet.services.cubebox.v1.ContainerSecurityContext.capabilities:type_name -> cubelet.services.cubebox.v1.Capability
+	9,   // 1: cubelet.services.cubebox.v1.ContainerSecurityContext.run_as_user:type_name -> cubelet.services.cubebox.v1.Int64Value
+	9,   // 2: cubelet.services.cubebox.v1.ContainerSecurityContext.run_as_group:type_name -> cubelet.services.cubebox.v1.Int64Value
 	0,   // 3: cubelet.services.cubebox.v1.VolumeMounts.propagation:type_name -> cubelet.services.cubebox.v1.MountPropagation
-	57,  // 4: cubelet.services.cubebox.v1.VolumeMounts.uidMappings:type_name -> cubelet.services.cubebox.v1.IDMapping
-	57,  // 5: cubelet.services.cubebox.v1.VolumeMounts.gidMappings:type_name -> cubelet.services.cubebox.v1.IDMapping
-	16,  // 6: cubelet.services.cubebox.v1.HTTPGetAction.http_headers:type_name -> cubelet.services.cubebox.v1.HTTPHeader
-	13,  // 7: cubelet.services.cubebox.v1.ProbeHandler.tcp_socket:type_name -> cubelet.services.cubebox.v1.TCPSocketAction
-	14,  // 8: cubelet.services.cubebox.v1.ProbeHandler.ping:type_name -> cubelet.services.cubebox.v1.PingAction
-	15,  // 9: cubelet.services.cubebox.v1.ProbeHandler.http_get:type_name -> cubelet.services.cubebox.v1.HTTPGetAction
-	17,  // 10: cubelet.services.cubebox.v1.Probe.probe_handler:type_name -> cubelet.services.cubebox.v1.ProbeHandler
-	15,  // 11: cubelet.services.cubebox.v1.LifecycleHandler.http_get:type_name -> cubelet.services.cubebox.v1.HTTPGetAction
-	19,  // 12: cubelet.services.cubebox.v1.PreStop.lifecyle_handler:type_name -> cubelet.services.cubebox.v1.LifecycleHandler
-	19,  // 13: cubelet.services.cubebox.v1.PostStop.lifecyle_handler:type_name -> cubelet.services.cubebox.v1.LifecycleHandler
-	22,  // 14: cubelet.services.cubebox.v1.Hooks.Prestart:type_name -> cubelet.services.cubebox.v1.Hook
-	99,  // 15: cubelet.services.cubebox.v1.ContainerConfig.image:type_name -> cubelet.services.images.v1.ImageSpec
-	24,  // 16: cubelet.services.cubebox.v1.ContainerConfig.envs:type_name -> cubelet.services.cubebox.v1.KeyValue
-	12,  // 17: cubelet.services.cubebox.v1.ContainerConfig.volume_mounts:type_name -> cubelet.services.cubebox.v1.VolumeMounts
-	11,  // 18: cubelet.services.cubebox.v1.ContainerConfig.r_limit:type_name -> cubelet.services.cubebox.v1.RLimit
-	32,  // 19: cubelet.services.cubebox.v1.ContainerConfig.resources:type_name -> cubelet.services.cubebox.v1.Resource
-	9,   // 20: cubelet.services.cubebox.v1.ContainerConfig.security_context:type_name -> cubelet.services.cubebox.v1.ContainerSecurityContext
-	18,  // 21: cubelet.services.cubebox.v1.ContainerConfig.probe:type_name -> cubelet.services.cubebox.v1.Probe
-	87,  // 22: cubelet.services.cubebox.v1.ContainerConfig.sysctls:type_name -> cubelet.services.cubebox.v1.ContainerConfig.SysctlsEntry
-	31,  // 23: cubelet.services.cubebox.v1.ContainerConfig.syscalls:type_name -> cubelet.services.cubebox.v1.SysCall
-	10,  // 24: cubelet.services.cubebox.v1.ContainerConfig.dns_config:type_name -> cubelet.services.cubebox.v1.DNSConfig
-	88,  // 25: cubelet.services.cubebox.v1.ContainerConfig.annotations:type_name -> cubelet.services.cubebox.v1.ContainerConfig.AnnotationsEntry
-	25,  // 26: cubelet.services.cubebox.v1.ContainerConfig.hostAliases:type_name -> cubelet.services.cubebox.v1.HostAlias
-	20,  // 27: cubelet.services.cubebox.v1.ContainerConfig.prestop:type_name -> cubelet.services.cubebox.v1.PreStop
-	21,  // 28: cubelet.services.cubebox.v1.ContainerConfig.poststop:type_name -> cubelet.services.cubebox.v1.PostStop
-	23,  // 29: cubelet.services.cubebox.v1.ContainerConfig.hooks:type_name -> cubelet.services.cubebox.v1.Hooks
-	27,  // 30: cubelet.services.cubebox.v1.ContainerConfig.oci_config:type_name -> cubelet.services.cubebox.v1.OCIConfig
-	28,  // 31: cubelet.services.cubebox.v1.OCIConfig.devices:type_name -> cubelet.services.cubebox.v1.Device
-	29,  // 32: cubelet.services.cubebox.v1.OCIConfig.cdi_devices:type_name -> cubelet.services.cubebox.v1.CDIDevice
-	30,  // 33: cubelet.services.cubebox.v1.SysCall.args:type_name -> cubelet.services.cubebox.v1.LinuxSeccompArg
+	58,  // 4: cubelet.services.cubebox.v1.VolumeMounts.uidMappings:type_name -> cubelet.services.cubebox.v1.IDMapping
+	58,  // 5: cubelet.services.cubebox.v1.VolumeMounts.gidMappings:type_name -> cubelet.services.cubebox.v1.IDMapping
+	17,  // 6: cubelet.services.cubebox.v1.HTTPGetAction.http_headers:type_name -> cubelet.services.cubebox.v1.HTTPHeader
+	14,  // 7: cubelet.services.cubebox.v1.ProbeHandler.tcp_socket:type_name -> cubelet.services.cubebox.v1.TCPSocketAction
+	15,  // 8: cubelet.services.cubebox.v1.ProbeHandler.ping:type_name -> cubelet.services.cubebox.v1.PingAction
+	16,  // 9: cubelet.services.cubebox.v1.ProbeHandler.http_get:type_name -> cubelet.services.cubebox.v1.HTTPGetAction
+	18,  // 10: cubelet.services.cubebox.v1.Probe.probe_handler:type_name -> cubelet.services.cubebox.v1.ProbeHandler
+	16,  // 11: cubelet.services.cubebox.v1.LifecycleHandler.http_get:type_name -> cubelet.services.cubebox.v1.HTTPGetAction
+	20,  // 12: cubelet.services.cubebox.v1.PreStop.lifecyle_handler:type_name -> cubelet.services.cubebox.v1.LifecycleHandler
+	20,  // 13: cubelet.services.cubebox.v1.PostStop.lifecyle_handler:type_name -> cubelet.services.cubebox.v1.LifecycleHandler
+	23,  // 14: cubelet.services.cubebox.v1.Hooks.Prestart:type_name -> cubelet.services.cubebox.v1.Hook
+	108, // 15: cubelet.services.cubebox.v1.ContainerConfig.image:type_name -> cubelet.services.images.v1.ImageSpec
+	25,  // 16: cubelet.services.cubebox.v1.ContainerConfig.envs:type_name -> cubelet.services.cubebox.v1.KeyValue
+	13,  // 17: cubelet.services.cubebox.v1.ContainerConfig.volume_mounts:type_name -> cubelet.services.cubebox.v1.VolumeMounts
+	12,  // 18: cubelet.services.cubebox.v1.ContainerConfig.r_limit:type_name -> cubelet.services.cubebox.v1.RLimit
+	33,  // 19: cubelet.services.cubebox.v1.ContainerConfig.resources:type_name -> cubelet.services.cubebox.v1.Resource
+	10,  // 20: cubelet.services.cubebox.v1.ContainerConfig.security_context:type_name -> cubelet.services.cubebox.v1.ContainerSecurityContext
+	19,  // 21: cubelet.services.cubebox.v1.ContainerConfig.probe:type_name -> cubelet.services.cubebox.v1.Probe
+	96,  // 22: cubelet.services.cubebox.v1.ContainerConfig.sysctls:type_name -> cubelet.services.cubebox.v1.ContainerConfig.SysctlsEntry
+	32,  // 23: cubelet.services.cubebox.v1.ContainerConfig.syscalls:type_name -> cubelet.services.cubebox.v1.SysCall
+	11,  // 24: cubelet.services.cubebox.v1.ContainerConfig.dns_config:type_name -> cubelet.services.cubebox.v1.DNSConfig
+	97,  // 25: cubelet.services.cubebox.v1.ContainerConfig.annotations:type_name -> cubelet.services.cubebox.v1.ContainerConfig.AnnotationsEntry
+	26,  // 26: cubelet.services.cubebox.v1.ContainerConfig.hostAliases:type_name -> cubelet.services.cubebox.v1.HostAlias
+	21,  // 27: cubelet.services.cubebox.v1.ContainerConfig.prestop:type_name -> cubelet.services.cubebox.v1.PreStop
+	22,  // 28: cubelet.services.cubebox.v1.ContainerConfig.poststop:type_name -> cubelet.services.cubebox.v1.PostStop
+	24,  // 29: cubelet.services.cubebox.v1.ContainerConfig.hooks:type_name -> cubelet.services.cubebox.v1.Hooks
+	28,  // 30: cubelet.services.cubebox.v1.ContainerConfig.oci_config:type_name -> cubelet.services.cubebox.v1.OCIConfig
+	29,  // 31: cubelet.services.cubebox.v1.OCIConfig.devices:type_name -> cubelet.services.cubebox.v1.Device
+	30,  // 32: cubelet.services.cubebox.v1.OCIConfig.cdi_devices:type_name -> cubelet.services.cubebox.v1.CDIDevice
+	31,  // 33: cubelet.services.cubebox.v1.SysCall.args:type_name -> cubelet.services.cubebox.v1.LinuxSeccompArg
 	1,   // 34: cubelet.services.cubebox.v1.EmptyDirVolumeSource.Medium:type_name -> cubelet.services.cubebox.v1.StorageMedium
-	35,  // 35: cubelet.services.cubebox.v1.HostDirVolumeSources.volume_sources:type_name -> cubelet.services.cubebox.v1.HostDirSource
-	33,  // 36: cubelet.services.cubebox.v1.VolumeSource.empty_dir:type_name -> cubelet.services.cubebox.v1.EmptyDirVolumeSource
-	34,  // 37: cubelet.services.cubebox.v1.VolumeSource.sandbox_path:type_name -> cubelet.services.cubebox.v1.SandboxPathVolumeSource
-	36,  // 38: cubelet.services.cubebox.v1.VolumeSource.host_dir_volumes:type_name -> cubelet.services.cubebox.v1.HostDirVolumeSources
-	100, // 39: cubelet.services.cubebox.v1.VolumeSource.image:type_name -> cubelet.services.images.v1.ImageVolumeSource
-	101, // 40: cubelet.services.cubebox.v1.VolumeSource.plugin_volume:type_name -> cubelet.services.volumeplugin.v1.PluginVolumeSource
-	37,  // 41: cubelet.services.cubebox.v1.Volume.volume_source:type_name -> cubelet.services.cubebox.v1.VolumeSource
-	38,  // 42: cubelet.services.cubebox.v1.RunCubeSandboxRequest.volumes:type_name -> cubelet.services.cubebox.v1.Volume
-	26,  // 43: cubelet.services.cubebox.v1.RunCubeSandboxRequest.containers:type_name -> cubelet.services.cubebox.v1.ContainerConfig
-	89,  // 44: cubelet.services.cubebox.v1.RunCubeSandboxRequest.annotations:type_name -> cubelet.services.cubebox.v1.RunCubeSandboxRequest.AnnotationsEntry
-	90,  // 45: cubelet.services.cubebox.v1.RunCubeSandboxRequest.labels:type_name -> cubelet.services.cubebox.v1.RunCubeSandboxRequest.LabelsEntry
-	42,  // 46: cubelet.services.cubebox.v1.RunCubeSandboxRequest.cube_network_config:type_name -> cubelet.services.cubebox.v1.CubeNetworkConfig
-	102, // 47: cubelet.services.cubebox.v1.RunCubeSandboxResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
-	91,  // 48: cubelet.services.cubebox.v1.RunCubeSandboxResponse.ext_info:type_name -> cubelet.services.cubebox.v1.RunCubeSandboxResponse.ExtInfoEntry
-	41,  // 49: cubelet.services.cubebox.v1.RunCubeSandboxResponse.port_mappings:type_name -> cubelet.services.cubebox.v1.PortMapping
-	43,  // 50: cubelet.services.cubebox.v1.CubeNetworkConfig.rules:type_name -> cubelet.services.cubebox.v1.EgressRule
-	44,  // 51: cubelet.services.cubebox.v1.EgressRule.match:type_name -> cubelet.services.cubebox.v1.EgressRuleMatch
-	45,  // 52: cubelet.services.cubebox.v1.EgressRule.action:type_name -> cubelet.services.cubebox.v1.EgressRuleAction
-	46,  // 53: cubelet.services.cubebox.v1.EgressRuleAction.inject:type_name -> cubelet.services.cubebox.v1.EgressRuleInject
-	92,  // 54: cubelet.services.cubebox.v1.DestroyCubeSandboxRequest.annotations:type_name -> cubelet.services.cubebox.v1.DestroyCubeSandboxRequest.AnnotationsEntry
-	52,  // 55: cubelet.services.cubebox.v1.DestroyCubeSandboxRequest.filter:type_name -> cubelet.services.cubebox.v1.CubeSandboxFilter
-	102, // 56: cubelet.services.cubebox.v1.DestroyCubeSandboxResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
-	93,  // 57: cubelet.services.cubebox.v1.DestroyCubeSandboxResponse.ext_info:type_name -> cubelet.services.cubebox.v1.DestroyCubeSandboxResponse.ExtInfoEntry
-	50,  // 58: cubelet.services.cubebox.v1.CubeSandbox.containers:type_name -> cubelet.services.cubebox.v1.Container
-	41,  // 59: cubelet.services.cubebox.v1.CubeSandbox.port_mappings:type_name -> cubelet.services.cubebox.v1.PortMapping
-	94,  // 60: cubelet.services.cubebox.v1.CubeSandbox.labels:type_name -> cubelet.services.cubebox.v1.CubeSandbox.LabelsEntry
-	32,  // 61: cubelet.services.cubebox.v1.Container.resources:type_name -> cubelet.services.cubebox.v1.Resource
+	36,  // 35: cubelet.services.cubebox.v1.HostDirVolumeSources.volume_sources:type_name -> cubelet.services.cubebox.v1.HostDirSource
+	34,  // 36: cubelet.services.cubebox.v1.VolumeSource.empty_dir:type_name -> cubelet.services.cubebox.v1.EmptyDirVolumeSource
+	35,  // 37: cubelet.services.cubebox.v1.VolumeSource.sandbox_path:type_name -> cubelet.services.cubebox.v1.SandboxPathVolumeSource
+	37,  // 38: cubelet.services.cubebox.v1.VolumeSource.host_dir_volumes:type_name -> cubelet.services.cubebox.v1.HostDirVolumeSources
+	109, // 39: cubelet.services.cubebox.v1.VolumeSource.image:type_name -> cubelet.services.images.v1.ImageVolumeSource
+	110, // 40: cubelet.services.cubebox.v1.VolumeSource.plugin_volume:type_name -> cubelet.services.volumeplugin.v1.PluginVolumeSource
+	38,  // 41: cubelet.services.cubebox.v1.Volume.volume_source:type_name -> cubelet.services.cubebox.v1.VolumeSource
+	39,  // 42: cubelet.services.cubebox.v1.RunCubeSandboxRequest.volumes:type_name -> cubelet.services.cubebox.v1.Volume
+	27,  // 43: cubelet.services.cubebox.v1.RunCubeSandboxRequest.containers:type_name -> cubelet.services.cubebox.v1.ContainerConfig
+	98,  // 44: cubelet.services.cubebox.v1.RunCubeSandboxRequest.annotations:type_name -> cubelet.services.cubebox.v1.RunCubeSandboxRequest.AnnotationsEntry
+	99,  // 45: cubelet.services.cubebox.v1.RunCubeSandboxRequest.labels:type_name -> cubelet.services.cubebox.v1.RunCubeSandboxRequest.LabelsEntry
+	43,  // 46: cubelet.services.cubebox.v1.RunCubeSandboxRequest.cube_network_config:type_name -> cubelet.services.cubebox.v1.CubeNetworkConfig
+	111, // 47: cubelet.services.cubebox.v1.RunCubeSandboxResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
+	100, // 48: cubelet.services.cubebox.v1.RunCubeSandboxResponse.ext_info:type_name -> cubelet.services.cubebox.v1.RunCubeSandboxResponse.ExtInfoEntry
+	42,  // 49: cubelet.services.cubebox.v1.RunCubeSandboxResponse.port_mappings:type_name -> cubelet.services.cubebox.v1.PortMapping
+	44,  // 50: cubelet.services.cubebox.v1.CubeNetworkConfig.rules:type_name -> cubelet.services.cubebox.v1.EgressRule
+	45,  // 51: cubelet.services.cubebox.v1.EgressRule.match:type_name -> cubelet.services.cubebox.v1.EgressRuleMatch
+	46,  // 52: cubelet.services.cubebox.v1.EgressRule.action:type_name -> cubelet.services.cubebox.v1.EgressRuleAction
+	47,  // 53: cubelet.services.cubebox.v1.EgressRuleAction.inject:type_name -> cubelet.services.cubebox.v1.EgressRuleInject
+	101, // 54: cubelet.services.cubebox.v1.DestroyCubeSandboxRequest.annotations:type_name -> cubelet.services.cubebox.v1.DestroyCubeSandboxRequest.AnnotationsEntry
+	53,  // 55: cubelet.services.cubebox.v1.DestroyCubeSandboxRequest.filter:type_name -> cubelet.services.cubebox.v1.CubeSandboxFilter
+	111, // 56: cubelet.services.cubebox.v1.DestroyCubeSandboxResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
+	102, // 57: cubelet.services.cubebox.v1.DestroyCubeSandboxResponse.ext_info:type_name -> cubelet.services.cubebox.v1.DestroyCubeSandboxResponse.ExtInfoEntry
+	51,  // 58: cubelet.services.cubebox.v1.CubeSandbox.containers:type_name -> cubelet.services.cubebox.v1.Container
+	42,  // 59: cubelet.services.cubebox.v1.CubeSandbox.port_mappings:type_name -> cubelet.services.cubebox.v1.PortMapping
+	103, // 60: cubelet.services.cubebox.v1.CubeSandbox.labels:type_name -> cubelet.services.cubebox.v1.CubeSandbox.LabelsEntry
+	33,  // 61: cubelet.services.cubebox.v1.Container.resources:type_name -> cubelet.services.cubebox.v1.Resource
 	5,   // 62: cubelet.services.cubebox.v1.Container.state:type_name -> cubelet.services.cubebox.v1.ContainerState
-	95,  // 63: cubelet.services.cubebox.v1.Container.labels:type_name -> cubelet.services.cubebox.v1.Container.LabelsEntry
+	104, // 63: cubelet.services.cubebox.v1.Container.labels:type_name -> cubelet.services.cubebox.v1.Container.LabelsEntry
 	5,   // 64: cubelet.services.cubebox.v1.ContainerStateValue.state:type_name -> cubelet.services.cubebox.v1.ContainerState
-	51,  // 65: cubelet.services.cubebox.v1.CubeSandboxFilter.state:type_name -> cubelet.services.cubebox.v1.ContainerStateValue
-	96,  // 66: cubelet.services.cubebox.v1.CubeSandboxFilter.label_selector:type_name -> cubelet.services.cubebox.v1.CubeSandboxFilter.LabelSelectorEntry
-	52,  // 67: cubelet.services.cubebox.v1.ListCubeSandboxRequest.filter:type_name -> cubelet.services.cubebox.v1.CubeSandboxFilter
-	58,  // 68: cubelet.services.cubebox.v1.ListCubeSandboxRequest.option:type_name -> cubelet.services.cubebox.v1.ListCubeSandboxOption
-	49,  // 69: cubelet.services.cubebox.v1.ListCubeSandboxResponse.items:type_name -> cubelet.services.cubebox.v1.CubeSandbox
-	97,  // 70: cubelet.services.cubebox.v1.UpdateCubeSandboxRequest.annotations:type_name -> cubelet.services.cubebox.v1.UpdateCubeSandboxRequest.AnnotationsEntry
-	102, // 71: cubelet.services.cubebox.v1.UpdateCubeSandboxResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
-	102, // 72: cubelet.services.cubebox.v1.ExecCubeSandboxResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
-	39,  // 73: cubelet.services.cubebox.v1.AppSnapshotRequest.create_request:type_name -> cubelet.services.cubebox.v1.RunCubeSandboxRequest
-	102, // 74: cubelet.services.cubebox.v1.AppSnapshotResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
-	102, // 75: cubelet.services.cubebox.v1.CommitSandboxResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
-	102, // 76: cubelet.services.cubebox.v1.RollbackSandboxResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
-	67,  // 77: cubelet.services.cubebox.v1.CleanupTemplateRequest.objects:type_name -> cubelet.services.cubebox.v1.CowObjectRef
-	102, // 78: cubelet.services.cubebox.v1.CleanupTemplateResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
-	67,  // 79: cubelet.services.cubebox.v1.ListSandboxSnapshotsRequest.objects:type_name -> cubelet.services.cubebox.v1.CowObjectRef
-	102, // 80: cubelet.services.cubebox.v1.ListSandboxSnapshotsResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
-	71,  // 81: cubelet.services.cubebox.v1.ListSandboxSnapshotsResponse.objects:type_name -> cubelet.services.cubebox.v1.CowObjectStatus
-	102, // 82: cubelet.services.cubebox.v1.ListLocalSnapshotsResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
-	74,  // 83: cubelet.services.cubebox.v1.ListLocalSnapshotsResponse.snapshots:type_name -> cubelet.services.cubebox.v1.LocalSnapshotInfo
-	102, // 84: cubelet.services.cubebox.v1.GetLocalSnapshotResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
-	74,  // 85: cubelet.services.cubebox.v1.GetLocalSnapshotResponse.snapshot:type_name -> cubelet.services.cubebox.v1.LocalSnapshotInfo
-	102, // 86: cubelet.services.cubebox.v1.GetStorageMetricsResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
-	98,  // 87: cubelet.services.cubebox.v1.GetStorageMetricsResponse.metrics:type_name -> cubelet.services.cubebox.v1.GetStorageMetricsResponse.MetricsEntry
-	80,  // 88: cubelet.services.cubebox.v1.SandboxStorageInfo.volumes:type_name -> cubelet.services.cubebox.v1.StorageVolumeInfo
-	102, // 89: cubelet.services.cubebox.v1.InspectStorageVolumesResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
-	81,  // 90: cubelet.services.cubebox.v1.InspectStorageVolumesResponse.sandboxes:type_name -> cubelet.services.cubebox.v1.SandboxStorageInfo
-	102, // 91: cubelet.services.cubebox.v1.CleanupOrphanStorageFilesResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
-	85,  // 92: cubelet.services.cubebox.v1.CleanupOrphanStorageFilesResponse.orphans:type_name -> cubelet.services.cubebox.v1.StorageOrphanEntry
-	39,  // 93: cubelet.services.cubebox.v1.CubeboxMgr.Create:input_type -> cubelet.services.cubebox.v1.RunCubeSandboxRequest
-	47,  // 94: cubelet.services.cubebox.v1.CubeboxMgr.Destroy:input_type -> cubelet.services.cubebox.v1.DestroyCubeSandboxRequest
-	53,  // 95: cubelet.services.cubebox.v1.CubeboxMgr.List:input_type -> cubelet.services.cubebox.v1.ListCubeSandboxRequest
-	55,  // 96: cubelet.services.cubebox.v1.CubeboxMgr.Update:input_type -> cubelet.services.cubebox.v1.UpdateCubeSandboxRequest
-	59,  // 97: cubelet.services.cubebox.v1.CubeboxMgr.Exec:input_type -> cubelet.services.cubebox.v1.ExecCubeSandboxRequest
-	61,  // 98: cubelet.services.cubebox.v1.CubeboxMgr.AppSnapshot:input_type -> cubelet.services.cubebox.v1.AppSnapshotRequest
-	63,  // 99: cubelet.services.cubebox.v1.CubeboxMgr.CommitSandbox:input_type -> cubelet.services.cubebox.v1.CommitSandboxRequest
-	65,  // 100: cubelet.services.cubebox.v1.CubeboxMgr.RollbackSandbox:input_type -> cubelet.services.cubebox.v1.RollbackSandboxRequest
-	68,  // 101: cubelet.services.cubebox.v1.CubeboxMgr.CleanupTemplate:input_type -> cubelet.services.cubebox.v1.CleanupTemplateRequest
-	70,  // 102: cubelet.services.cubebox.v1.CubeboxMgr.ListSandboxSnapshots:input_type -> cubelet.services.cubebox.v1.ListSandboxSnapshotsRequest
-	73,  // 103: cubelet.services.cubebox.v1.CubeboxMgr.ListLocalSnapshots:input_type -> cubelet.services.cubebox.v1.ListLocalSnapshotsRequest
-	76,  // 104: cubelet.services.cubebox.v1.CubeboxMgr.GetLocalSnapshot:input_type -> cubelet.services.cubebox.v1.GetLocalSnapshotRequest
-	78,  // 105: cubelet.services.cubebox.v1.CubeboxMgr.GetStorageMetrics:input_type -> cubelet.services.cubebox.v1.GetStorageMetricsRequest
-	82,  // 106: cubelet.services.cubebox.v1.CubeboxMgr.InspectStorageVolumes:input_type -> cubelet.services.cubebox.v1.InspectStorageVolumesRequest
-	84,  // 107: cubelet.services.cubebox.v1.CubeboxMgr.CleanupOrphanStorageFiles:input_type -> cubelet.services.cubebox.v1.CleanupOrphanStorageFilesRequest
-	40,  // 108: cubelet.services.cubebox.v1.CubeboxMgr.Create:output_type -> cubelet.services.cubebox.v1.RunCubeSandboxResponse
-	48,  // 109: cubelet.services.cubebox.v1.CubeboxMgr.Destroy:output_type -> cubelet.services.cubebox.v1.DestroyCubeSandboxResponse
-	54,  // 110: cubelet.services.cubebox.v1.CubeboxMgr.List:output_type -> cubelet.services.cubebox.v1.ListCubeSandboxResponse
-	56,  // 111: cubelet.services.cubebox.v1.CubeboxMgr.Update:output_type -> cubelet.services.cubebox.v1.UpdateCubeSandboxResponse
-	60,  // 112: cubelet.services.cubebox.v1.CubeboxMgr.Exec:output_type -> cubelet.services.cubebox.v1.ExecCubeSandboxResponse
-	62,  // 113: cubelet.services.cubebox.v1.CubeboxMgr.AppSnapshot:output_type -> cubelet.services.cubebox.v1.AppSnapshotResponse
-	64,  // 114: cubelet.services.cubebox.v1.CubeboxMgr.CommitSandbox:output_type -> cubelet.services.cubebox.v1.CommitSandboxResponse
-	66,  // 115: cubelet.services.cubebox.v1.CubeboxMgr.RollbackSandbox:output_type -> cubelet.services.cubebox.v1.RollbackSandboxResponse
-	69,  // 116: cubelet.services.cubebox.v1.CubeboxMgr.CleanupTemplate:output_type -> cubelet.services.cubebox.v1.CleanupTemplateResponse
-	72,  // 117: cubelet.services.cubebox.v1.CubeboxMgr.ListSandboxSnapshots:output_type -> cubelet.services.cubebox.v1.ListSandboxSnapshotsResponse
-	75,  // 118: cubelet.services.cubebox.v1.CubeboxMgr.ListLocalSnapshots:output_type -> cubelet.services.cubebox.v1.ListLocalSnapshotsResponse
-	77,  // 119: cubelet.services.cubebox.v1.CubeboxMgr.GetLocalSnapshot:output_type -> cubelet.services.cubebox.v1.GetLocalSnapshotResponse
-	79,  // 120: cubelet.services.cubebox.v1.CubeboxMgr.GetStorageMetrics:output_type -> cubelet.services.cubebox.v1.GetStorageMetricsResponse
-	83,  // 121: cubelet.services.cubebox.v1.CubeboxMgr.InspectStorageVolumes:output_type -> cubelet.services.cubebox.v1.InspectStorageVolumesResponse
-	86,  // 122: cubelet.services.cubebox.v1.CubeboxMgr.CleanupOrphanStorageFiles:output_type -> cubelet.services.cubebox.v1.CleanupOrphanStorageFilesResponse
-	108, // [108:123] is the sub-list for method output_type
-	93,  // [93:108] is the sub-list for method input_type
-	93,  // [93:93] is the sub-list for extension type_name
-	93,  // [93:93] is the sub-list for extension extendee
-	0,   // [0:93] is the sub-list for field type_name
+	52,  // 65: cubelet.services.cubebox.v1.CubeSandboxFilter.state:type_name -> cubelet.services.cubebox.v1.ContainerStateValue
+	105, // 66: cubelet.services.cubebox.v1.CubeSandboxFilter.label_selector:type_name -> cubelet.services.cubebox.v1.CubeSandboxFilter.LabelSelectorEntry
+	53,  // 67: cubelet.services.cubebox.v1.ListCubeSandboxRequest.filter:type_name -> cubelet.services.cubebox.v1.CubeSandboxFilter
+	59,  // 68: cubelet.services.cubebox.v1.ListCubeSandboxRequest.option:type_name -> cubelet.services.cubebox.v1.ListCubeSandboxOption
+	50,  // 69: cubelet.services.cubebox.v1.ListCubeSandboxResponse.items:type_name -> cubelet.services.cubebox.v1.CubeSandbox
+	106, // 70: cubelet.services.cubebox.v1.UpdateCubeSandboxRequest.annotations:type_name -> cubelet.services.cubebox.v1.UpdateCubeSandboxRequest.AnnotationsEntry
+	111, // 71: cubelet.services.cubebox.v1.UpdateCubeSandboxResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
+	111, // 72: cubelet.services.cubebox.v1.ExecCubeSandboxResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
+	40,  // 73: cubelet.services.cubebox.v1.AppSnapshotRequest.create_request:type_name -> cubelet.services.cubebox.v1.RunCubeSandboxRequest
+	111, // 74: cubelet.services.cubebox.v1.AppSnapshotResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
+	111, // 75: cubelet.services.cubebox.v1.CommitSandboxResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
+	111, // 76: cubelet.services.cubebox.v1.RollbackSandboxResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
+	68,  // 77: cubelet.services.cubebox.v1.CleanupTemplateRequest.objects:type_name -> cubelet.services.cubebox.v1.CowObjectRef
+	111, // 78: cubelet.services.cubebox.v1.CleanupTemplateResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
+	68,  // 79: cubelet.services.cubebox.v1.ListSandboxSnapshotsRequest.objects:type_name -> cubelet.services.cubebox.v1.CowObjectRef
+	111, // 80: cubelet.services.cubebox.v1.ListSandboxSnapshotsResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
+	72,  // 81: cubelet.services.cubebox.v1.ListSandboxSnapshotsResponse.objects:type_name -> cubelet.services.cubebox.v1.CowObjectStatus
+	111, // 82: cubelet.services.cubebox.v1.ListLocalSnapshotsResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
+	75,  // 83: cubelet.services.cubebox.v1.ListLocalSnapshotsResponse.snapshots:type_name -> cubelet.services.cubebox.v1.LocalSnapshotInfo
+	111, // 84: cubelet.services.cubebox.v1.GetLocalSnapshotResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
+	75,  // 85: cubelet.services.cubebox.v1.GetLocalSnapshotResponse.snapshot:type_name -> cubelet.services.cubebox.v1.LocalSnapshotInfo
+	111, // 86: cubelet.services.cubebox.v1.GetStorageMetricsResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
+	107, // 87: cubelet.services.cubebox.v1.GetStorageMetricsResponse.metrics:type_name -> cubelet.services.cubebox.v1.GetStorageMetricsResponse.MetricsEntry
+	81,  // 88: cubelet.services.cubebox.v1.SandboxStorageInfo.volumes:type_name -> cubelet.services.cubebox.v1.StorageVolumeInfo
+	111, // 89: cubelet.services.cubebox.v1.InspectStorageVolumesResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
+	82,  // 90: cubelet.services.cubebox.v1.InspectStorageVolumesResponse.sandboxes:type_name -> cubelet.services.cubebox.v1.SandboxStorageInfo
+	111, // 91: cubelet.services.cubebox.v1.CleanupOrphanStorageFilesResponse.ret:type_name -> cubelet.services.errorcode.v1.Ret
+	86,  // 92: cubelet.services.cubebox.v1.CleanupOrphanStorageFilesResponse.orphans:type_name -> cubelet.services.cubebox.v1.StorageOrphanEntry
+	89,  // 93: cubelet.services.cubebox.v1.TerminalClientMessage.open:type_name -> cubelet.services.cubebox.v1.TerminalOpenRequest
+	90,  // 94: cubelet.services.cubebox.v1.TerminalClientMessage.resize:type_name -> cubelet.services.cubebox.v1.TerminalResize
+	91,  // 95: cubelet.services.cubebox.v1.TerminalClientMessage.close:type_name -> cubelet.services.cubebox.v1.TerminalClose
+	93,  // 96: cubelet.services.cubebox.v1.TerminalServerMessage.ready:type_name -> cubelet.services.cubebox.v1.TerminalReady
+	94,  // 97: cubelet.services.cubebox.v1.TerminalServerMessage.exit:type_name -> cubelet.services.cubebox.v1.TerminalExit
+	95,  // 98: cubelet.services.cubebox.v1.TerminalServerMessage.error:type_name -> cubelet.services.cubebox.v1.TerminalError
+	6,   // 99: cubelet.services.cubebox.v1.TerminalError.code:type_name -> cubelet.services.cubebox.v1.TerminalErrorCode
+	40,  // 100: cubelet.services.cubebox.v1.CubeboxMgr.Create:input_type -> cubelet.services.cubebox.v1.RunCubeSandboxRequest
+	48,  // 101: cubelet.services.cubebox.v1.CubeboxMgr.Destroy:input_type -> cubelet.services.cubebox.v1.DestroyCubeSandboxRequest
+	54,  // 102: cubelet.services.cubebox.v1.CubeboxMgr.List:input_type -> cubelet.services.cubebox.v1.ListCubeSandboxRequest
+	56,  // 103: cubelet.services.cubebox.v1.CubeboxMgr.Update:input_type -> cubelet.services.cubebox.v1.UpdateCubeSandboxRequest
+	60,  // 104: cubelet.services.cubebox.v1.CubeboxMgr.Exec:input_type -> cubelet.services.cubebox.v1.ExecCubeSandboxRequest
+	88,  // 105: cubelet.services.cubebox.v1.CubeboxMgr.AttachTerminal:input_type -> cubelet.services.cubebox.v1.TerminalClientMessage
+	62,  // 106: cubelet.services.cubebox.v1.CubeboxMgr.AppSnapshot:input_type -> cubelet.services.cubebox.v1.AppSnapshotRequest
+	64,  // 107: cubelet.services.cubebox.v1.CubeboxMgr.CommitSandbox:input_type -> cubelet.services.cubebox.v1.CommitSandboxRequest
+	66,  // 108: cubelet.services.cubebox.v1.CubeboxMgr.RollbackSandbox:input_type -> cubelet.services.cubebox.v1.RollbackSandboxRequest
+	69,  // 109: cubelet.services.cubebox.v1.CubeboxMgr.CleanupTemplate:input_type -> cubelet.services.cubebox.v1.CleanupTemplateRequest
+	71,  // 110: cubelet.services.cubebox.v1.CubeboxMgr.ListSandboxSnapshots:input_type -> cubelet.services.cubebox.v1.ListSandboxSnapshotsRequest
+	74,  // 111: cubelet.services.cubebox.v1.CubeboxMgr.ListLocalSnapshots:input_type -> cubelet.services.cubebox.v1.ListLocalSnapshotsRequest
+	77,  // 112: cubelet.services.cubebox.v1.CubeboxMgr.GetLocalSnapshot:input_type -> cubelet.services.cubebox.v1.GetLocalSnapshotRequest
+	79,  // 113: cubelet.services.cubebox.v1.CubeboxMgr.GetStorageMetrics:input_type -> cubelet.services.cubebox.v1.GetStorageMetricsRequest
+	83,  // 114: cubelet.services.cubebox.v1.CubeboxMgr.InspectStorageVolumes:input_type -> cubelet.services.cubebox.v1.InspectStorageVolumesRequest
+	85,  // 115: cubelet.services.cubebox.v1.CubeboxMgr.CleanupOrphanStorageFiles:input_type -> cubelet.services.cubebox.v1.CleanupOrphanStorageFilesRequest
+	41,  // 116: cubelet.services.cubebox.v1.CubeboxMgr.Create:output_type -> cubelet.services.cubebox.v1.RunCubeSandboxResponse
+	49,  // 117: cubelet.services.cubebox.v1.CubeboxMgr.Destroy:output_type -> cubelet.services.cubebox.v1.DestroyCubeSandboxResponse
+	55,  // 118: cubelet.services.cubebox.v1.CubeboxMgr.List:output_type -> cubelet.services.cubebox.v1.ListCubeSandboxResponse
+	57,  // 119: cubelet.services.cubebox.v1.CubeboxMgr.Update:output_type -> cubelet.services.cubebox.v1.UpdateCubeSandboxResponse
+	61,  // 120: cubelet.services.cubebox.v1.CubeboxMgr.Exec:output_type -> cubelet.services.cubebox.v1.ExecCubeSandboxResponse
+	92,  // 121: cubelet.services.cubebox.v1.CubeboxMgr.AttachTerminal:output_type -> cubelet.services.cubebox.v1.TerminalServerMessage
+	63,  // 122: cubelet.services.cubebox.v1.CubeboxMgr.AppSnapshot:output_type -> cubelet.services.cubebox.v1.AppSnapshotResponse
+	65,  // 123: cubelet.services.cubebox.v1.CubeboxMgr.CommitSandbox:output_type -> cubelet.services.cubebox.v1.CommitSandboxResponse
+	67,  // 124: cubelet.services.cubebox.v1.CubeboxMgr.RollbackSandbox:output_type -> cubelet.services.cubebox.v1.RollbackSandboxResponse
+	70,  // 125: cubelet.services.cubebox.v1.CubeboxMgr.CleanupTemplate:output_type -> cubelet.services.cubebox.v1.CleanupTemplateResponse
+	73,  // 126: cubelet.services.cubebox.v1.CubeboxMgr.ListSandboxSnapshots:output_type -> cubelet.services.cubebox.v1.ListSandboxSnapshotsResponse
+	76,  // 127: cubelet.services.cubebox.v1.CubeboxMgr.ListLocalSnapshots:output_type -> cubelet.services.cubebox.v1.ListLocalSnapshotsResponse
+	78,  // 128: cubelet.services.cubebox.v1.CubeboxMgr.GetLocalSnapshot:output_type -> cubelet.services.cubebox.v1.GetLocalSnapshotResponse
+	80,  // 129: cubelet.services.cubebox.v1.CubeboxMgr.GetStorageMetrics:output_type -> cubelet.services.cubebox.v1.GetStorageMetricsResponse
+	84,  // 130: cubelet.services.cubebox.v1.CubeboxMgr.InspectStorageVolumes:output_type -> cubelet.services.cubebox.v1.InspectStorageVolumesResponse
+	87,  // 131: cubelet.services.cubebox.v1.CubeboxMgr.CleanupOrphanStorageFiles:output_type -> cubelet.services.cubebox.v1.CleanupOrphanStorageFilesResponse
+	116, // [116:132] is the sub-list for method output_type
+	100, // [100:116] is the sub-list for method input_type
+	100, // [100:100] is the sub-list for extension type_name
+	100, // [100:100] is the sub-list for extension extendee
+	0,   // [0:100] is the sub-list for field type_name
 }
 
 func init() { file_api_services_cubebox_v1_cubebox_proto_init() }
@@ -7347,13 +8052,25 @@ func file_api_services_cubebox_v1_cubebox_proto_init() {
 	file_api_services_cubebox_v1_cubebox_proto_msgTypes[39].OneofWrappers = []any{}
 	file_api_services_cubebox_v1_cubebox_proto_msgTypes[40].OneofWrappers = []any{}
 	file_api_services_cubebox_v1_cubebox_proto_msgTypes[47].OneofWrappers = []any{}
+	file_api_services_cubebox_v1_cubebox_proto_msgTypes[81].OneofWrappers = []any{
+		(*TerminalClientMessage_Open)(nil),
+		(*TerminalClientMessage_Stdin)(nil),
+		(*TerminalClientMessage_Resize)(nil),
+		(*TerminalClientMessage_Close)(nil),
+	}
+	file_api_services_cubebox_v1_cubebox_proto_msgTypes[85].OneofWrappers = []any{
+		(*TerminalServerMessage_Ready)(nil),
+		(*TerminalServerMessage_Output)(nil),
+		(*TerminalServerMessage_Exit)(nil),
+		(*TerminalServerMessage_Error)(nil),
+	}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_api_services_cubebox_v1_cubebox_proto_rawDesc), len(file_api_services_cubebox_v1_cubebox_proto_rawDesc)),
-			NumEnums:      6,
-			NumMessages:   93,
+			NumEnums:      7,
+			NumMessages:   101,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/Cubelet/api/services/cubebox/v1/cubebox.proto
+++ b/Cubelet/api/services/cubebox/v1/cubebox.proto
@@ -19,6 +19,9 @@ service CubeboxMgr {
   rpc List(ListCubeSandboxRequest) returns (ListCubeSandboxResponse);
   rpc Update(UpdateCubeSandboxRequest) returns (UpdateCubeSandboxResponse);
   rpc Exec(ExecCubeSandboxRequest) returns (ExecCubeSandboxResponse);
+  // AttachTerminal owns one interactive TTY process for the stream lifetime.
+  // The first client frame must be open and binds the stream to one container.
+  rpc AttachTerminal(stream TerminalClientMessage) returns (stream TerminalServerMessage);
   // AppSnapshot creates a cubebox, makes an app snapshot, and destroys the cubebox.
   // Required annotations:
   //   - cube.master.appsnapshot.create: "true"
@@ -1170,4 +1173,68 @@ message CleanupOrphanStorageFilesResponse {
   cubelet.services.errorcode.v1.Ret ret = 2;
   // Orphan files cubelet found (and possibly removed).
   repeated StorageOrphanEntry orphans = 3;
+}
+
+// Client-to-server frames for an interactive terminal session. Keeping client
+// and server frames separate makes invalid message direction unrepresentable.
+message TerminalClientMessage {
+  oneof payload {
+    TerminalOpenRequest open = 1;
+    bytes stdin = 2;
+    TerminalResize resize = 3;
+    TerminalClose close = 4;
+  }
+}
+
+message TerminalOpenRequest {
+  string request_id = 1;
+  string session_id = 2;
+  string sandbox_id = 3;
+  string container_id = 4;
+  repeated string args = 5;
+  repeated string env = 6;
+  string cwd = 7;
+  uint32 cols = 8;
+  uint32 rows = 9;
+}
+
+message TerminalResize {
+  uint32 cols = 1;
+  uint32 rows = 2;
+}
+
+message TerminalClose {}
+
+// Server-to-client frames for an interactive terminal session.
+message TerminalServerMessage {
+  oneof payload {
+    TerminalReady ready = 1;
+    bytes output = 2;
+    TerminalExit exit = 3;
+    TerminalError error = 4;
+  }
+}
+
+message TerminalReady {
+  string exec_id = 1;
+}
+
+message TerminalExit {
+  int32 exit_code = 1;
+  string reason = 2;
+}
+
+enum TerminalErrorCode {
+  TERMINAL_ERROR_UNSPECIFIED = 0;
+  TERMINAL_ERROR_INVALID_REQUEST = 1;
+  TERMINAL_ERROR_TARGET_NOT_FOUND = 2;
+  TERMINAL_ERROR_TARGET_NOT_RUNNING = 3;
+  TERMINAL_ERROR_INTERNAL = 4;
+  TERMINAL_ERROR_IDLE_TIMEOUT = 5;
+}
+
+message TerminalError {
+  TerminalErrorCode code = 1;
+  string message = 2;
+  bool retryable = 3;
 }

--- a/Cubelet/api/services/cubebox/v1/cubebox_grpc.pb.go
+++ b/Cubelet/api/services/cubebox/v1/cubebox_grpc.pb.go
@@ -28,6 +28,7 @@ const (
 	CubeboxMgr_List_FullMethodName                      = "/cubelet.services.cubebox.v1.CubeboxMgr/List"
 	CubeboxMgr_Update_FullMethodName                    = "/cubelet.services.cubebox.v1.CubeboxMgr/Update"
 	CubeboxMgr_Exec_FullMethodName                      = "/cubelet.services.cubebox.v1.CubeboxMgr/Exec"
+	CubeboxMgr_AttachTerminal_FullMethodName            = "/cubelet.services.cubebox.v1.CubeboxMgr/AttachTerminal"
 	CubeboxMgr_AppSnapshot_FullMethodName               = "/cubelet.services.cubebox.v1.CubeboxMgr/AppSnapshot"
 	CubeboxMgr_CommitSandbox_FullMethodName             = "/cubelet.services.cubebox.v1.CubeboxMgr/CommitSandbox"
 	CubeboxMgr_RollbackSandbox_FullMethodName           = "/cubelet.services.cubebox.v1.CubeboxMgr/RollbackSandbox"
@@ -51,6 +52,9 @@ type CubeboxMgrClient interface {
 	List(ctx context.Context, in *ListCubeSandboxRequest, opts ...grpc.CallOption) (*ListCubeSandboxResponse, error)
 	Update(ctx context.Context, in *UpdateCubeSandboxRequest, opts ...grpc.CallOption) (*UpdateCubeSandboxResponse, error)
 	Exec(ctx context.Context, in *ExecCubeSandboxRequest, opts ...grpc.CallOption) (*ExecCubeSandboxResponse, error)
+	// AttachTerminal owns one interactive TTY process for the stream lifetime.
+	// The first client frame must be open and binds the stream to one container.
+	AttachTerminal(ctx context.Context, opts ...grpc.CallOption) (grpc.BidiStreamingClient[TerminalClientMessage, TerminalServerMessage], error)
 	// AppSnapshot creates a cubebox, makes an app snapshot, and destroys the cubebox.
 	// Required annotations:
 	//   - cube.master.appsnapshot.create: "true"
@@ -139,6 +143,19 @@ func (c *cubeboxMgrClient) Exec(ctx context.Context, in *ExecCubeSandboxRequest,
 	}
 	return out, nil
 }
+
+func (c *cubeboxMgrClient) AttachTerminal(ctx context.Context, opts ...grpc.CallOption) (grpc.BidiStreamingClient[TerminalClientMessage, TerminalServerMessage], error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	stream, err := c.cc.NewStream(ctx, &CubeboxMgr_ServiceDesc.Streams[0], CubeboxMgr_AttachTerminal_FullMethodName, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	x := &grpc.GenericClientStream[TerminalClientMessage, TerminalServerMessage]{ClientStream: stream}
+	return x, nil
+}
+
+// This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
+type CubeboxMgr_AttachTerminalClient = grpc.BidiStreamingClient[TerminalClientMessage, TerminalServerMessage]
 
 func (c *cubeboxMgrClient) AppSnapshot(ctx context.Context, in *AppSnapshotRequest, opts ...grpc.CallOption) (*AppSnapshotResponse, error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
@@ -251,6 +268,9 @@ type CubeboxMgrServer interface {
 	List(context.Context, *ListCubeSandboxRequest) (*ListCubeSandboxResponse, error)
 	Update(context.Context, *UpdateCubeSandboxRequest) (*UpdateCubeSandboxResponse, error)
 	Exec(context.Context, *ExecCubeSandboxRequest) (*ExecCubeSandboxResponse, error)
+	// AttachTerminal owns one interactive TTY process for the stream lifetime.
+	// The first client frame must be open and binds the stream to one container.
+	AttachTerminal(grpc.BidiStreamingServer[TerminalClientMessage, TerminalServerMessage]) error
 	// AppSnapshot creates a cubebox, makes an app snapshot, and destroys the cubebox.
 	// Required annotations:
 	//   - cube.master.appsnapshot.create: "true"
@@ -304,6 +324,9 @@ func (UnimplementedCubeboxMgrServer) Update(context.Context, *UpdateCubeSandboxR
 }
 func (UnimplementedCubeboxMgrServer) Exec(context.Context, *ExecCubeSandboxRequest) (*ExecCubeSandboxResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method Exec not implemented")
+}
+func (UnimplementedCubeboxMgrServer) AttachTerminal(grpc.BidiStreamingServer[TerminalClientMessage, TerminalServerMessage]) error {
+	return status.Error(codes.Unimplemented, "method AttachTerminal not implemented")
 }
 func (UnimplementedCubeboxMgrServer) AppSnapshot(context.Context, *AppSnapshotRequest) (*AppSnapshotResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method AppSnapshot not implemented")
@@ -445,6 +468,13 @@ func _CubeboxMgr_Exec_Handler(srv interface{}, ctx context.Context, dec func(int
 	}
 	return interceptor(ctx, in, info, handler)
 }
+
+func _CubeboxMgr_AttachTerminal_Handler(srv interface{}, stream grpc.ServerStream) error {
+	return srv.(CubeboxMgrServer).AttachTerminal(&grpc.GenericServerStream[TerminalClientMessage, TerminalServerMessage]{ServerStream: stream})
+}
+
+// This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
+type CubeboxMgr_AttachTerminalServer = grpc.BidiStreamingServer[TerminalClientMessage, TerminalServerMessage]
 
 func _CubeboxMgr_AppSnapshot_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
 	in := new(AppSnapshotRequest)
@@ -694,6 +724,13 @@ var CubeboxMgr_ServiceDesc = grpc.ServiceDesc{
 			Handler:    _CubeboxMgr_CleanupOrphanStorageFiles_Handler,
 		},
 	},
-	Streams:  []grpc.StreamDesc{},
+	Streams: []grpc.StreamDesc{
+		{
+			StreamName:    "AttachTerminal",
+			Handler:       _CubeboxMgr_AttachTerminal_Handler,
+			ServerStreams: true,
+			ClientStreams: true,
+		},
+	},
 	Metadata: "api/services/cubebox/v1/cubebox.proto",
 }

--- a/Cubelet/api/services/cubebox/v1/terminal_protocol_test.go
+++ b/Cubelet/api/services/cubebox/v1/terminal_protocol_test.go
@@ -1,0 +1,50 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package cubebox
+
+import "testing"
+
+func TestTerminalProtocolUsesDirectionSpecificFrames(t *testing.T) {
+	client := &TerminalClientMessage{
+		Payload: &TerminalClientMessage_Open{Open: &TerminalOpenRequest{
+			RequestId:   "request-1",
+			SessionId:   "session-1",
+			SandboxId:   "sandbox-1",
+			ContainerId: "container-1",
+			Cols:        120,
+			Rows:        30,
+		}},
+	}
+	if got := client.GetOpen().GetSessionId(); got != "session-1" {
+		t.Fatalf("client open session_id = %q, want session-1", got)
+	}
+
+	server := &TerminalServerMessage{
+		Payload: &TerminalServerMessage_Ready{Ready: &TerminalReady{ExecId: "exec-1"}},
+	}
+	if got := server.GetReady().GetExecId(); got != "exec-1" {
+		t.Fatalf("server ready exec_id = %q, want exec-1", got)
+	}
+}
+
+func TestTerminalProtocolExposesStableErrorCode(t *testing.T) {
+	message := &TerminalServerMessage{
+		Payload: &TerminalServerMessage_Error{Error: &TerminalError{
+			Code:      TerminalErrorCode_TERMINAL_ERROR_TARGET_NOT_RUNNING,
+			Message:   "target is not running",
+			Retryable: false,
+		}},
+	}
+
+	if got := message.GetError().GetCode(); got != TerminalErrorCode_TERMINAL_ERROR_TARGET_NOT_RUNNING {
+		t.Fatalf("terminal error code = %v", got)
+	}
+}
+
+func TestTerminalRPCMethodNameIsStable(t *testing.T) {
+	const want = "/cubelet.services.cubebox.v1.CubeboxMgr/AttachTerminal"
+	if CubeboxMgr_AttachTerminal_FullMethodName != want {
+		t.Fatalf("AttachTerminal method = %q, want %q", CubeboxMgr_AttachTerminal_FullMethodName, want)
+	}
+}

--- a/Cubelet/services/cubebox/terminal.go
+++ b/Cubelet/services/cubebox/terminal.go
@@ -1,0 +1,236 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package cubebox
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+
+	containerd "github.com/containerd/containerd/v2/client"
+	"github.com/containerd/containerd/v2/pkg/cio"
+	"github.com/containerd/containerd/v2/pkg/namespaces"
+	"github.com/containerd/errdefs"
+	"github.com/google/uuid"
+	"github.com/opencontainers/runtime-spec/specs-go"
+	cubebox "github.com/tencentcloud/CubeSandbox/Cubelet/api/services/cubebox/v1"
+	"github.com/tencentcloud/CubeSandbox/Cubelet/pkg/log"
+	"github.com/tencentcloud/CubeSandbox/Cubelet/services/cubebox/terminalcore"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+const (
+	terminalFIFOPathEnv     = "CUBELET_TERMINAL_FIFO_DIR"
+	defaultTerminalFIFOPath = "/data/cubelet/fifo"
+	terminalCleanupTimeout  = 5 * time.Second
+)
+
+func (s *service) AttachTerminal(stream grpc.BidiStreamingServer[cubebox.TerminalClientMessage, cubebox.TerminalServerMessage]) error {
+	err := terminalcore.Run(stream, &terminalProcessFactory{service: s})
+	if err == nil {
+		return nil
+	}
+	if status.Code(err) != codes.Unknown {
+		return err
+	}
+	return status.Error(codes.InvalidArgument, err.Error())
+}
+
+type terminalProcessFactory struct {
+	service *service
+}
+
+func (f *terminalProcessFactory) Create(ctx context.Context, open *cubebox.TerminalOpenRequest) (terminalcore.Process, error) {
+	ctx = namespaces.WithNamespace(ctx, namespaces.Default)
+	sandbox, err := f.service.cubeboxMgr.cubeboxManger.Get(ctx, open.GetSandboxId())
+	if err != nil {
+		return nil, status.Errorf(codes.NotFound, "sandbox %q not found", open.GetSandboxId())
+	}
+	namespace := namespaces.Default
+	if sandbox.Namespace != "" {
+		namespace = sandbox.Namespace
+		ctx = namespaces.WithNamespace(ctx, namespace)
+	}
+	container, err := sandbox.Get(open.GetContainerId())
+	if err != nil {
+		return nil, status.Errorf(codes.NotFound, "container %q does not belong to sandbox %q", open.GetContainerId(), open.GetSandboxId())
+	}
+	task, err := container.Container.Task(ctx, nil)
+	if err != nil {
+		return nil, status.Errorf(codes.FailedPrecondition, "container %q is not running", open.GetContainerId())
+	}
+	processSpec, err := buildTerminalProcessSpec(ctx, task, open)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "build terminal process: %v", err)
+	}
+
+	stdinReader, stdinWriter := io.Pipe()
+	outputReader, outputWriter := io.Pipe()
+	ioCreator := cio.NewCreator(
+		cio.WithStreams(stdinReader, outputWriter, outputWriter),
+		cio.WithTerminal,
+		cio.WithFIFODir(terminalFIFOPath()),
+	)
+	execID := "cubelet-terminal-" + uuid.NewString()
+	process, err := task.Exec(ctx, execID, processSpec, ioCreator)
+	if err != nil {
+		closeTerminalIO(stdinReader, stdinWriter, outputReader, outputWriter)
+		return nil, status.Errorf(codes.Internal, "create terminal process: %v", err)
+	}
+	exitStatus, err := process.Wait(ctx)
+	if err != nil {
+		closeTerminalIO(stdinReader, stdinWriter, outputReader, outputWriter)
+		_, _ = process.Delete(ctx, containerd.WithProcessKill)
+		return nil, status.Errorf(codes.Internal, "wait for terminal process: %v", err)
+	}
+
+	result := &containerdTerminalProcess{
+		ctx:          ctx,
+		namespace:    namespace,
+		process:      process,
+		execID:       execID,
+		stdinReader:  stdinReader,
+		stdinWriter:  stdinWriter,
+		outputReader: outputReader,
+		outputWriter: outputWriter,
+		exit:         make(chan terminalcore.ExitStatus, 1),
+		exited:       make(chan struct{}),
+	}
+	go result.observeExit(exitStatus)
+	return result, nil
+}
+
+func terminalFIFOPath() string {
+	if configured := strings.TrimSpace(os.Getenv(terminalFIFOPathEnv)); configured != "" {
+		return configured
+	}
+	return defaultTerminalFIFOPath
+}
+
+func buildTerminalProcessSpec(ctx context.Context, task containerd.Task, open *cubebox.TerminalOpenRequest) (*specs.Process, error) {
+	spec, err := task.Spec(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if spec.Process == nil {
+		return nil, fmt.Errorf("container process specification is missing")
+	}
+	process := *spec.Process
+	process.Terminal = true
+	process.Args = terminalcore.Command(open.GetArgs())
+	process.Env = terminalcore.MergeEnv(spec.Process.Env, open.GetEnv())
+	if open.GetCwd() != "" {
+		process.Cwd = open.GetCwd()
+	}
+	return &process, nil
+}
+
+type containerdTerminalProcess struct {
+	ctx          context.Context
+	namespace    string
+	process      containerd.Process
+	execID       string
+	stdinReader  *io.PipeReader
+	stdinWriter  *io.PipeWriter
+	outputReader *io.PipeReader
+	outputWriter *io.PipeWriter
+	exit         chan terminalcore.ExitStatus
+	exited       chan struct{}
+	cleanupOnce  sync.Once
+}
+
+func (p *containerdTerminalProcess) ID() string                           { return p.execID }
+func (p *containerdTerminalProcess) Output() io.Reader                    { return p.outputReader }
+func (p *containerdTerminalProcess) Wait() <-chan terminalcore.ExitStatus { return p.exit }
+func (p *containerdTerminalProcess) Start(ctx context.Context) error      { return p.process.Start(ctx) }
+func (p *containerdTerminalProcess) Resize(ctx context.Context, cols, rows uint32) error {
+	return p.process.Resize(ctx, cols, rows)
+}
+func (p *containerdTerminalProcess) WriteStdin(data []byte) error {
+	_, err := p.stdinWriter.Write(data)
+	return err
+}
+
+func (p *containerdTerminalProcess) observeExit(statusC <-chan containerd.ExitStatus) {
+	statusValue, ok := <-statusC
+	if !ok {
+		p.exit <- terminalcore.ExitStatus{Err: fmt.Errorf("terminal exit channel closed")}
+		close(p.exited)
+		return
+	}
+	code, _, err := statusValue.Result()
+	p.process.IO().Wait()
+	_ = p.outputWriter.Close()
+	p.exit <- terminalcore.ExitStatus{Code: int32(code), Err: err}
+	close(p.exited)
+}
+
+func (p *containerdTerminalProcess) Cleanup() error {
+	var cleanupErr error
+	p.cleanupOnce.Do(func() {
+		// Closing the local pipe endpoints first unblocks containerd's IO copy
+		// goroutines even when the WebSocket consumer stopped reading output.
+		closeTerminalIO(p.stdinWriter, p.outputReader)
+		closeIOCtx, cancelCloseIO := terminalCleanupContext(p.namespace)
+		_ = p.process.CloseIO(closeIOCtx, containerd.WithStdinCloser)
+		cancelCloseIO()
+
+		select {
+		case <-p.exited:
+		default:
+			killCtx, cancelKill := terminalCleanupContext(p.namespace)
+			if err := p.process.Kill(killCtx, syscall.SIGKILL); err != nil && !errdefs.IsNotFound(err) {
+				cleanupErr = fmt.Errorf("kill terminal process: %w", err)
+			}
+			cancelKill()
+
+			waitTimer := time.NewTimer(terminalCleanupTimeout)
+			select {
+			case <-p.exited:
+				if !waitTimer.Stop() {
+					<-waitTimer.C
+				}
+			case <-waitTimer.C:
+				if cleanupErr == nil {
+					cleanupErr = fmt.Errorf("wait for terminal cleanup: %w", context.DeadlineExceeded)
+				}
+			}
+		}
+		// Delete always gets a fresh context. A timeout while waiting for exit
+		// must not turn deletion into an immediate no-op with an expired context.
+		deleteCtx, cancelDelete := terminalCleanupContext(p.namespace)
+		_, deleteErr := p.process.Delete(deleteCtx, containerd.WithProcessKill)
+		cancelDelete()
+		if deleteErr != nil && !errdefs.IsNotFound(deleteErr) && cleanupErr == nil {
+			cleanupErr = fmt.Errorf("delete terminal process: %w", deleteErr)
+		}
+		closeTerminalIO(p.stdinReader, p.outputReader, p.outputWriter)
+	})
+	if cleanupErr != nil {
+		log.G(p.ctx).WithError(cleanupErr).Warnf("terminal process %s cleanup failed", p.execID)
+	}
+	return cleanupErr
+}
+
+func terminalCleanupContext(namespace string) (context.Context, context.CancelFunc) {
+	return context.WithTimeout(
+		namespaces.WithNamespace(context.Background(), namespace),
+		terminalCleanupTimeout,
+	)
+}
+
+func closeTerminalIO(closers ...io.Closer) {
+	for _, closer := range closers {
+		if closer != nil {
+			_ = closer.Close()
+		}
+	}
+}

--- a/Cubelet/services/cubebox/terminalcore/session.go
+++ b/Cubelet/services/cubebox/terminalcore/session.go
@@ -1,0 +1,177 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package terminalcore
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"sync"
+	"time"
+
+	cubebox "github.com/tencentcloud/CubeSandbox/Cubelet/api/services/cubebox/v1"
+)
+
+const outputDrainTimeout = time.Second
+
+var errClientClosed = errors.New("terminal client closed")
+
+type ExitStatus struct {
+	Code int32
+	Err  error
+}
+
+type Process interface {
+	ID() string
+	Output() io.Reader
+	Wait() <-chan ExitStatus
+	Start(context.Context) error
+	Resize(context.Context, uint32, uint32) error
+	WriteStdin([]byte) error
+	Cleanup() error
+}
+
+type ProcessFactory interface {
+	Create(context.Context, *cubebox.TerminalOpenRequest) (Process, error)
+}
+
+type Stream interface {
+	Context() context.Context
+	Recv() (*cubebox.TerminalClientMessage, error)
+	Send(*cubebox.TerminalServerMessage) error
+}
+
+type lockedSender struct {
+	stream Stream
+	mu     sync.Mutex
+}
+
+func (s *lockedSender) send(frame *cubebox.TerminalServerMessage) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.stream.Send(frame)
+}
+
+func Run(stream Stream, factory ProcessFactory) error {
+	first, err := stream.Recv()
+	if err != nil {
+		return fmt.Errorf("terminal open frame is required: %w", err)
+	}
+	open := first.GetOpen()
+	if open == nil {
+		return errors.New("the first terminal frame must be open")
+	}
+	if err := ValidateOpen(open.GetSandboxId(), open.GetContainerId(), open.GetCols(), open.GetRows()); err != nil {
+		return err
+	}
+
+	process, err := factory.Create(stream.Context(), open)
+	if err != nil {
+		return fmt.Errorf("create terminal process: %w", err)
+	}
+	defer process.Cleanup()
+
+	if err := process.Start(stream.Context()); err != nil {
+		return fmt.Errorf("start terminal process: %w", err)
+	}
+	if err := process.Resize(stream.Context(), open.GetCols(), open.GetRows()); err != nil {
+		return fmt.Errorf("set initial terminal size: %w", err)
+	}
+
+	sender := &lockedSender{stream: stream}
+	if err := sender.send(&cubebox.TerminalServerMessage{
+		Payload: &cubebox.TerminalServerMessage_Ready{Ready: &cubebox.TerminalReady{ExecId: process.ID()}},
+	}); err != nil {
+		return err
+	}
+
+	outputDone := make(chan error, 1)
+	go func() { outputDone <- copyOutput(process.Output(), sender) }()
+	recvDone := make(chan error, 1)
+	go func() { recvDone <- receiveInput(stream, process) }()
+
+	for {
+		select {
+		case status := <-process.Wait():
+			if status.Err != nil {
+				return fmt.Errorf("terminal process exit: %w", status.Err)
+			}
+			select {
+			case outputErr := <-outputDone:
+				if outputErr != nil && !errors.Is(outputErr, io.EOF) && !errors.Is(outputErr, io.ErrClosedPipe) {
+					return outputErr
+				}
+			case <-time.After(outputDrainTimeout):
+			}
+			return sender.send(&cubebox.TerminalServerMessage{
+				Payload: &cubebox.TerminalServerMessage_Exit{Exit: &cubebox.TerminalExit{
+					ExitCode: status.Code,
+					Reason:   "process_exited",
+				}},
+			})
+		case recvErr := <-recvDone:
+			if errors.Is(recvErr, errClientClosed) || errors.Is(recvErr, io.EOF) || errors.Is(recvErr, context.Canceled) {
+				return nil
+			}
+			return recvErr
+		case outputErr := <-outputDone:
+			if outputErr != nil && !errors.Is(outputErr, io.EOF) && !errors.Is(outputErr, io.ErrClosedPipe) {
+				return outputErr
+			}
+			outputDone = nil
+		case <-stream.Context().Done():
+			return nil
+		}
+	}
+}
+
+func receiveInput(stream Stream, process Process) error {
+	for {
+		frame, err := stream.Recv()
+		if err != nil {
+			return err
+		}
+		switch payload := frame.GetPayload().(type) {
+		case *cubebox.TerminalClientMessage_Stdin:
+			if len(payload.Stdin) > 0 {
+				if err := process.WriteStdin(payload.Stdin); err != nil {
+					return fmt.Errorf("write terminal input: %w", err)
+				}
+			}
+		case *cubebox.TerminalClientMessage_Resize:
+			if payload.Resize == nil {
+				return errors.New("terminal resize payload is required")
+			}
+			if err := ValidateSize(payload.Resize.GetCols(), payload.Resize.GetRows()); err != nil {
+				return err
+			}
+			if err := process.Resize(stream.Context(), payload.Resize.GetCols(), payload.Resize.GetRows()); err != nil {
+				return fmt.Errorf("resize terminal: %w", err)
+			}
+		case *cubebox.TerminalClientMessage_Close:
+			return errClientClosed
+		default:
+			return errors.New("only stdin, resize, or close is allowed after terminal open")
+		}
+	}
+}
+
+func copyOutput(reader io.Reader, sender *lockedSender) error {
+	buffer := make([]byte, 32*1024)
+	for {
+		n, err := reader.Read(buffer)
+		if n > 0 {
+			output := append([]byte(nil), buffer[:n]...)
+			if sendErr := sender.send(&cubebox.TerminalServerMessage{
+				Payload: &cubebox.TerminalServerMessage_Output{Output: output},
+			}); sendErr != nil {
+				return sendErr
+			}
+		}
+		if err != nil {
+			return err
+		}
+	}
+}

--- a/Cubelet/services/cubebox/terminalcore/session_test.go
+++ b/Cubelet/services/cubebox/terminalcore/session_test.go
@@ -1,0 +1,162 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package terminalcore
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"sync"
+	"testing"
+
+	cubebox "github.com/tencentcloud/CubeSandbox/Cubelet/api/services/cubebox/v1"
+)
+
+type fakeStream struct {
+	ctx    context.Context
+	recv   chan *cubebox.TerminalClientMessage
+	mu     sync.Mutex
+	sent   []*cubebox.TerminalServerMessage
+	sendCh chan *cubebox.TerminalServerMessage
+}
+
+func newFakeStream(ctx context.Context) *fakeStream {
+	return &fakeStream{
+		ctx:    ctx,
+		recv:   make(chan *cubebox.TerminalClientMessage, 8),
+		sendCh: make(chan *cubebox.TerminalServerMessage, 8),
+	}
+}
+
+func (s *fakeStream) Context() context.Context { return s.ctx }
+
+func (s *fakeStream) Recv() (*cubebox.TerminalClientMessage, error) {
+	select {
+	case frame := <-s.recv:
+		return frame, nil
+	case <-s.ctx.Done():
+		return nil, s.ctx.Err()
+	}
+}
+
+func (s *fakeStream) Send(frame *cubebox.TerminalServerMessage) error {
+	s.mu.Lock()
+	s.sent = append(s.sent, frame)
+	s.mu.Unlock()
+	s.sendCh <- frame
+	return nil
+}
+
+type fakeProcess struct {
+	id           string
+	output       io.Reader
+	exit         chan ExitStatus
+	stdin        bytes.Buffer
+	started      int
+	cleanupCalls int
+	resizes      [][2]uint32
+}
+
+func newFakeProcess(output io.Reader) *fakeProcess {
+	return &fakeProcess{id: "exec-1", output: output, exit: make(chan ExitStatus, 1)}
+}
+
+func (p *fakeProcess) ID() string                   { return p.id }
+func (p *fakeProcess) Output() io.Reader            { return p.output }
+func (p *fakeProcess) Wait() <-chan ExitStatus      { return p.exit }
+func (p *fakeProcess) Start(context.Context) error  { p.started++; return nil }
+func (p *fakeProcess) Cleanup() error               { p.cleanupCalls++; return nil }
+func (p *fakeProcess) WriteStdin(data []byte) error { _, _ = p.stdin.Write(data); return nil }
+func (p *fakeProcess) Resize(_ context.Context, cols, rows uint32) error {
+	p.resizes = append(p.resizes, [2]uint32{cols, rows})
+	return nil
+}
+
+type fakeFactory struct {
+	process *fakeProcess
+	calls   int
+}
+
+func (f *fakeFactory) Create(context.Context, *cubebox.TerminalOpenRequest) (Process, error) {
+	f.calls++
+	return f.process, nil
+}
+
+func openFrame() *cubebox.TerminalClientMessage {
+	return &cubebox.TerminalClientMessage{Payload: &cubebox.TerminalClientMessage_Open{
+		Open: &cubebox.TerminalOpenRequest{
+			RequestId:   "request-1",
+			SessionId:   "session-1",
+			SandboxId:   "sandbox-1",
+			ContainerId: "container-1",
+			Cols:        120,
+			Rows:        30,
+		},
+	}}
+}
+
+func TestRunRequiresOpenAsFirstFrame(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	stream := newFakeStream(ctx)
+	stream.recv <- &cubebox.TerminalClientMessage{Payload: &cubebox.TerminalClientMessage_Stdin{Stdin: []byte("whoami\n")}}
+	factory := &fakeFactory{process: newFakeProcess(bytes.NewReader(nil))}
+
+	if err := Run(stream, factory); err == nil {
+		t.Fatal("Run() accepted stdin before open")
+	}
+	if factory.calls != 0 {
+		t.Fatalf("factory called %d times for invalid first frame", factory.calls)
+	}
+}
+
+func TestRunForwardsInputResizeAndClose(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	stream := newFakeStream(ctx)
+	stream.recv <- openFrame()
+	stream.recv <- &cubebox.TerminalClientMessage{Payload: &cubebox.TerminalClientMessage_Stdin{Stdin: []byte("echo ok\n")}}
+	stream.recv <- &cubebox.TerminalClientMessage{Payload: &cubebox.TerminalClientMessage_Resize{Resize: &cubebox.TerminalResize{Cols: 90, Rows: 24}}}
+	stream.recv <- &cubebox.TerminalClientMessage{Payload: &cubebox.TerminalClientMessage_Close{Close: &cubebox.TerminalClose{}}}
+	process := newFakeProcess(bytes.NewReader(nil))
+
+	if err := Run(stream, &fakeFactory{process: process}); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if got := process.stdin.String(); got != "echo ok\n" {
+		t.Fatalf("stdin = %q", got)
+	}
+	wantResizes := [][2]uint32{{120, 30}, {90, 24}}
+	if len(process.resizes) != len(wantResizes) || process.resizes[0] != wantResizes[0] || process.resizes[1] != wantResizes[1] {
+		t.Fatalf("resizes = %#v, want %#v", process.resizes, wantResizes)
+	}
+	if process.started != 1 || process.cleanupCalls != 1 {
+		t.Fatalf("started=%d cleanup=%d", process.started, process.cleanupCalls)
+	}
+	if len(stream.sent) == 0 || stream.sent[0].GetReady().GetExecId() != "exec-1" {
+		t.Fatalf("first server frame is not ready: %#v", stream.sent)
+	}
+}
+
+func TestRunDrainsOutputBeforeExit(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	stream := newFakeStream(ctx)
+	stream.recv <- openFrame()
+	process := newFakeProcess(bytes.NewReader([]byte("\x1b[31mred\x1b[0m")))
+	process.exit <- ExitStatus{Code: 7}
+
+	if err := Run(stream, &fakeFactory{process: process}); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if len(stream.sent) != 3 {
+		t.Fatalf("sent %d frames, want ready/output/exit", len(stream.sent))
+	}
+	if got := string(stream.sent[1].GetOutput()); got != "\x1b[31mred\x1b[0m" {
+		t.Fatalf("output = %q", got)
+	}
+	if got := stream.sent[2].GetExit().GetExitCode(); got != 7 {
+		t.Fatalf("exit code = %d", got)
+	}
+}

--- a/Cubelet/services/cubebox/terminalcore/terminalcore.go
+++ b/Cubelet/services/cubebox/terminalcore/terminalcore.go
@@ -1,0 +1,81 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Package terminalcore contains transport-independent terminal validation and
+// process defaults. Keeping it free of containerd dependencies makes the
+// security-sensitive rules directly testable on every development platform.
+package terminalcore
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+const (
+	MinCols = 2
+	MaxCols = 500
+	MinRows = 1
+	MaxRows = 200
+)
+
+func ValidateOpen(sandboxID, containerID string, cols, rows uint32) error {
+	if strings.TrimSpace(sandboxID) == "" {
+		return errors.New("sandbox_id is required")
+	}
+	if strings.TrimSpace(containerID) == "" {
+		return errors.New("container_id is required")
+	}
+	if err := ValidateSize(cols, rows); err != nil {
+		return err
+	}
+	return nil
+}
+
+func ValidateSize(cols, rows uint32) error {
+	if cols < MinCols || cols > MaxCols || rows < MinRows || rows > MaxRows {
+		return fmt.Errorf(
+			"terminal size must be between %dx%d and %dx%d",
+			MinCols,
+			MinRows,
+			MaxCols,
+			MaxRows,
+		)
+	}
+	return nil
+}
+
+func Command(args []string) []string {
+	if len(args) == 0 {
+		return []string{"/bin/sh"}
+	}
+	return append([]string(nil), args...)
+}
+
+func MergeEnv(base, overrides []string) []string {
+	result := make([]string, 0, len(base)+len(overrides)+1)
+	indexes := make(map[string]int, len(base)+len(overrides))
+
+	merge := func(entries []string) {
+		for _, entry := range entries {
+			key, value, ok := strings.Cut(entry, "=")
+			if !ok || key == "" {
+				continue
+			}
+			normalized := key + "=" + value
+			if index, exists := indexes[key]; exists {
+				result[index] = normalized
+				continue
+			}
+			indexes[key] = len(result)
+			result = append(result, normalized)
+		}
+	}
+
+	merge(base)
+	merge(overrides)
+	if _, exists := indexes["TERM"]; !exists {
+		result = append(result, "TERM=xterm-256color")
+	}
+	return result
+}

--- a/Cubelet/services/cubebox/terminalcore/terminalcore_test.go
+++ b/Cubelet/services/cubebox/terminalcore/terminalcore_test.go
@@ -1,0 +1,72 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package terminalcore
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestValidateOpenRequiresBoundTarget(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		sandboxID   string
+		containerID string
+	}{
+		{name: "missing sandbox", containerID: "container-1"},
+		{name: "missing container", sandboxID: "sandbox-1"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := ValidateOpen(tc.sandboxID, tc.containerID, 120, 30); err == nil {
+				t.Fatal("ValidateOpen() accepted an unbound target")
+			}
+		})
+	}
+}
+
+func TestValidateOpenRejectsUnsafeDimensions(t *testing.T) {
+	for _, tc := range []struct {
+		cols uint32
+		rows uint32
+	}{
+		{cols: 0, rows: 30},
+		{cols: 120, rows: 0},
+		{cols: 1, rows: 30},
+		{cols: 501, rows: 30},
+		{cols: 120, rows: 201},
+	} {
+		if err := ValidateOpen("sandbox-1", "container-1", tc.cols, tc.rows); err == nil {
+			t.Fatalf("ValidateOpen() accepted dimensions %dx%d", tc.cols, tc.rows)
+		}
+	}
+}
+
+func TestValidateOpenAcceptsSupportedDimensions(t *testing.T) {
+	if err := ValidateOpen("sandbox-1", "container-1", 120, 30); err != nil {
+		t.Fatalf("ValidateOpen() error = %v", err)
+	}
+}
+
+func TestCommandDefaultsToBinSh(t *testing.T) {
+	if got := Command(nil); !reflect.DeepEqual(got, []string{"/bin/sh"}) {
+		t.Fatalf("Command(nil) = %#v", got)
+	}
+}
+
+func TestMergeEnvOverridesInPlaceAndAddsTerminal(t *testing.T) {
+	base := []string{"PATH=/usr/bin", "HOME=/root"}
+	overrides := []string{"PATH=/opt/bin", "LANG=C.UTF-8"}
+	want := []string{"PATH=/opt/bin", "HOME=/root", "LANG=C.UTF-8", "TERM=xterm-256color"}
+
+	if got := MergeEnv(base, overrides); !reflect.DeepEqual(got, want) {
+		t.Fatalf("MergeEnv() = %#v, want %#v", got, want)
+	}
+}
+
+func TestMergeEnvPreservesExplicitTermAndIgnoresMalformedEntries(t *testing.T) {
+	want := []string{"TERM=screen", "PATH=/bin"}
+	if got := MergeEnv([]string{"TERM=screen", "BROKEN"}, []string{"PATH=/bin", "=bad"}); !reflect.DeepEqual(got, want) {
+		t.Fatalf("MergeEnv() = %#v, want %#v", got, want)
+	}
+}

--- a/deploy/kubernetes/chart/templates/_helpers.tpl
+++ b/deploy/kubernetes/chart/templates/_helpers.tpl
@@ -307,6 +307,23 @@ http {
             proxy_pass {{ $opsUpstream }}/health;
         }
 
+        # Browser WebSockets cannot attach the dashboard bearer token. CubeAPI
+        # authenticates this handshake with a one-time subprotocol grant.
+        location ~ ^/sandboxes/([^/]+)/terminal$ {
+            proxy_http_version 1.1;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection $connection_upgrade;
+            proxy_read_timeout 1805s;
+            proxy_send_timeout 1805s;
+
+            rewrite ^/sandboxes/([^/]+)/terminal$ /api/v1/terminal/sandboxes/$1 break;
+            proxy_pass {{ $opsUpstream }};
+        }
+
         location ~ ^/(sandboxes|v2/sandboxes|templates|snapshots) {
             if ($http_authorization = "") {
                 return 418;

--- a/deploy/kubernetes/chart/templates/_helpers.tpl
+++ b/deploy/kubernetes/chart/templates/_helpers.tpl
@@ -307,8 +307,8 @@ http {
             proxy_pass {{ $opsUpstream }}/health;
         }
 
-        # Browser WebSockets cannot attach the dashboard bearer token. CubeAPI
-        # authenticates this handshake with a one-time subprotocol grant.
+        # Browser WebSockets cannot attach the dashboard bearer token. CubeOps
+        # validates the one-time grant, binding cookie, Origin, and subprotocol.
         location ~ ^/sandboxes/([^/]+)/terminal$ {
             proxy_http_version 1.1;
             proxy_set_header Host $host;

--- a/deploy/kubernetes/chart/templates/master.yaml
+++ b/deploy/kubernetes/chart/templates/master.yaml
@@ -44,6 +44,11 @@ spec:
               value: /data/CubeMaster/storage
             - name: CUBE_NODE_IPS
               value: {{ join "," .Values.controlPlane.master.nodeIPs | quote }}
+            - name: CUBE_TERMINAL_GATEWAY_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "cube.secretName" . }}
+                  key: terminal-gateway-token
             {{- with .Values.controlPlane.master.env }}
             {{- toYaml . | nindent 12 }}
             {{- end }}

--- a/deploy/kubernetes/chart/templates/ops.yaml
+++ b/deploy/kubernetes/chart/templates/ops.yaml
@@ -39,6 +39,11 @@ spec:
               value: {{ .Values.cubeOps.bind | quote }}
             - name: CUBE_MASTER_ADDR
               value: {{ printf "http://%s" (include "cube.masterEndpoint" .) | quote }}
+            - name: CUBE_TERMINAL_GATEWAY_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "cube.secretName" . }}
+                  key: terminal-gateway-token
             - name: CUBE_SANDBOX_MYSQL_HOST
               value: {{ include "cube.mysqlHost" . | quote }}
             - name: CUBE_SANDBOX_MYSQL_PORT

--- a/deploy/kubernetes/chart/templates/secret.yaml
+++ b/deploy/kubernetes/chart/templates/secret.yaml
@@ -1,14 +1,22 @@
 {{- if eq (include "cube.secretEnabled" .) "true" }}
 {{- $adminToken := "" -}}
+{{- $terminalGatewayToken := "" -}}
+{{- $existing := lookup "v1" "Secret" .Release.Namespace (include "cube.secretName" .) -}}
 {{- if .Values.lifecycleManager.adminToken -}}
 {{- $adminToken = .Values.lifecycleManager.adminToken -}}
 {{- else -}}
-{{- $existing := lookup "v1" "Secret" .Release.Namespace (include "cube.secretName" .) -}}
 {{- if and $existing (index $existing.data "cube-admin-token") -}}
 {{- $adminToken = index $existing.data "cube-admin-token" | b64dec -}}
 {{- else -}}
 {{- $adminToken = randAlphaNum 32 -}}
 {{- end -}}
+{{- end -}}
+{{- if .Values.controlPlane.terminalGatewayToken -}}
+{{- $terminalGatewayToken = .Values.controlPlane.terminalGatewayToken -}}
+{{- else if and $existing (index $existing.data "terminal-gateway-token") -}}
+{{- $terminalGatewayToken = index $existing.data "terminal-gateway-token" | b64dec -}}
+{{- else -}}
+{{- $terminalGatewayToken = randAlphaNum 48 -}}
 {{- end -}}
 apiVersion: v1
 kind: Secret
@@ -25,4 +33,5 @@ stringData:
   redis-auth.conf: |
     requirepass {{ .Values.redis.password | quote }}
   cube-admin-token: {{ $adminToken | quote }}
+  terminal-gateway-token: {{ $terminalGatewayToken | quote }}
 {{- end }}

--- a/deploy/kubernetes/chart/values.yaml
+++ b/deploy/kubernetes/chart/values.yaml
@@ -204,6 +204,9 @@ externalControlPlane:
 controlPlane:
   enabled: true
   namespaceScoped: true
+  # Shared only by CubeOps and CubeMaster to authorize the internal terminal
+  # gateway. Empty means the chart generates and preserves a random value.
+  terminalGatewayToken: ""
   # Native Deployment rolling strategy for stateless control-plane workloads
   # (api, webui, proxy, ops, lifecycle-manager, cubemastercli). Do not apply
   # maxSurge > 0 to cube-master when it mounts a ReadWriteOnce PVC.

--- a/deploy/one-click/env.example
+++ b/deploy/one-click/env.example
@@ -208,7 +208,7 @@ CUBE_API_BIND=0.0.0.0:3000
 CUBE_API_HEALTH_ADDR=127.0.0.1:3000
 CUBE_API_SANDBOX_DOMAIN=cube.app
 # Internal Web Terminal gateway credential. Leave unset during installation;
-# install.sh generates and preserves a random value shared by CubeAPI/Master.
+# install.sh generates and preserves a random value shared by CubeOps/Master.
 # CUBE_TERMINAL_GATEWAY_TOKEN=
 # AUTH_CALLBACK_URL=
 # CUBE_API_KEY=  # Built-in simple key auth (unset = no auth, suitable for

--- a/deploy/one-click/env.example
+++ b/deploy/one-click/env.example
@@ -207,6 +207,9 @@ NETWORK_AGENT_READY_TIMEOUT=120
 CUBE_API_BIND=0.0.0.0:3000
 CUBE_API_HEALTH_ADDR=127.0.0.1:3000
 CUBE_API_SANDBOX_DOMAIN=cube.app
+# Internal Web Terminal gateway credential. Leave unset during installation;
+# install.sh generates and preserves a random value shared by CubeAPI/Master.
+# CUBE_TERMINAL_GATEWAY_TOKEN=
 # AUTH_CALLBACK_URL=
 # CUBE_API_KEY=  # Built-in simple key auth (unset = no auth, suitable for
                  # All-in-One internal use). See CubeAPI/README.md for details.
@@ -224,6 +227,7 @@ JWT_ACCESS_TTL=15m
 JWT_REFRESH_TTL=168h
 # CubeMaster address for CubeOps (HTTP REST, same host in All-in-One).
 CUBE_MASTER_ADDR=http://127.0.0.1:8089
+CUBE_API_URL=http://127.0.0.1:3000
 
 # Digital Assistant / AgentHub options.
 # CubeAPI uses DATABASE_URL for AgentHub persistence. When DATABASE_URL is

--- a/deploy/one-click/install.sh
+++ b/deploy/one-click/install.sh
@@ -1118,6 +1118,16 @@ elif [[ -f "${SCRIPT_DIR}/release-manifest.json" ]]; then
 fi
 upsert_env_kv "${RUNTIME_ENV_FILE}" "ONE_CLICK_DEPLOY_ROLE" "${DEPLOY_ROLE}"
 upsert_env_kv "${RUNTIME_ENV_FILE}" "CUBE_PVM_ENABLE" "${CUBE_PVM_ENABLE}"
+if [[ "${DEPLOY_ROLE}" != "compute" ]]; then
+  terminal_gateway_token="${CUBE_TERMINAL_GATEWAY_TOKEN:-}"
+  if [[ -z "${terminal_gateway_token}" ]]; then
+    terminal_gateway_token="$(sed -n 's/^CUBE_TERMINAL_GATEWAY_TOKEN=//p' "${RUNTIME_ENV_FILE}" | tail -n 1)"
+  fi
+  if [[ -z "${terminal_gateway_token}" ]]; then
+    terminal_gateway_token="$(od -An -N32 -tx1 /dev/urandom | tr -d ' \n')"
+  fi
+  upsert_env_kv "${RUNTIME_ENV_FILE}" "CUBE_TERMINAL_GATEWAY_TOKEN" "${terminal_gateway_token}"
+fi
 MIRROR="${MIRROR:-}"
 case "${MIRROR}" in
   ""|cn) ;;

--- a/deploy/one-click/webui/nginx.conf
+++ b/deploy/one-click/webui/nginx.conf
@@ -92,6 +92,23 @@ http {
             proxy_pass __WEB_UI_UPSTREAM__;
         }
 
+        # Browser WebSockets cannot attach the dashboard bearer token. CubeAPI
+        # authenticates this handshake with a one-time subprotocol grant.
+        location ~ ^/sandboxes/([^/]+)/terminal$ {
+            proxy_http_version 1.1;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection $connection_upgrade;
+            proxy_read_timeout 1805s;
+            proxy_send_timeout 1805s;
+
+            rewrite ^/sandboxes/([^/]+)/terminal$ /api/v1/terminal/sandboxes/$1 break;
+            proxy_pass __CUBE_OPS_UPSTREAM__;
+        }
+
         # SDK endpoints → CubeOps (JWT auth + direct CubeMaster)
         # Browser navigation (no Authorization header) loads the SPA.
         # API calls (has Authorization: Bearer <jwt>) go to CubeOps.

--- a/deploy/one-click/webui/nginx.conf
+++ b/deploy/one-click/webui/nginx.conf
@@ -92,8 +92,8 @@ http {
             proxy_pass __WEB_UI_UPSTREAM__;
         }
 
-        # Browser WebSockets cannot attach the dashboard bearer token. CubeAPI
-        # authenticates this handshake with a one-time subprotocol grant.
+        # Browser WebSockets cannot attach the dashboard bearer token. CubeOps
+        # validates the one-time grant, binding cookie, Origin, and subprotocol.
         location ~ ^/sandboxes/([^/]+)/terminal$ {
             proxy_http_version 1.1;
             proxy_set_header Host $host;

--- a/docs/guide/introduction.md
+++ b/docs/guide/introduction.md
@@ -49,4 +49,5 @@ Cube Sandbox is a **purpose-built infrastructure for AI Agents** — a productio
 * [Kubernetes Deployment](./kubernetes/) — install with Helm on an existing K8s cluster.
 * [Creating Templates from OCI Images](./tutorials/template-from-image.md) — step-by-step template guide.
 * [WebUI Console](./webui.md) — visual management right after install.
+* [Web Terminal](./web-terminal.md) — open a secure interactive TTY from a running sandbox's detail page.
 * [Security Proxy & Credential Vault](./security-proxy.md) — CubeEgress domain filtering and auditing.

--- a/docs/guide/web-terminal.md
+++ b/docs/guide/web-terminal.md
@@ -1,0 +1,51 @@
+---
+title: Web Terminal
+---
+
+# Web Terminal
+
+The Dashboard can open an interactive TTY for a running sandbox without exposing the container runtime or a node port.
+
+This is an ops-only path: the Dashboard authenticates to CubeOps, CubeOps validates the target and relays the WebSocket to CubeMaster, and CubeAPI is not involved.
+
+## Use it
+
+1. Open **Sandboxes** and select a running sandbox.
+2. Click **Open terminal** on the detail page.
+3. If the sandbox has multiple containers, select the target container before connecting.
+4. Click **Connect**. The terminal supports ANSI output, cursor control, scrollback, copy/paste, resize, fullscreen, disconnect, and reconnect.
+
+Pausing, deleting, or otherwise stopping the sandbox prevents new sessions. Closing the panel actively closes the WebSocket and cleans up its exec process. A session that has no terminal input, output, or resize activity for 30 minutes is closed automatically; keepalive frames do not extend that limit.
+
+## Deployment
+
+One-click deployment generates `CUBE_TERMINAL_GATEWAY_TOKEN` in `.one-click.env`. The Helm chart creates a shared secret and injects it into CubeOps and CubeMaster. For a manual deployment, generate at least 32 random bytes and configure the same value on both services:
+
+```bash
+CUBE_TERMINAL_GATEWAY_TOKEN=<random-secret>
+```
+
+When the Dashboard is served from an origin other than CubeOps' host, configure a comma-separated exact allowlist:
+
+```bash
+CUBE_TERMINAL_ALLOWED_ORIGINS=https://dashboard.example.com
+```
+
+Production deployments must terminate TLS so the browser uses `wss://`. Do not expose CubeMaster's internal terminal endpoint; it accepts only the shared gateway credential and is intended for the control plane network.
+
+Cubelet creates containerd terminal FIFOs under `/data/cubelet/fifo` by default. Set `CUBELET_TERMINAL_FIFO_DIR` when that directory is not writable in your deployment.
+
+Terminal grants are held in CubeOps memory. The chart defaults to one CubeOps replica; if you scale CubeOps horizontally, keep the session-creation request and its following WebSocket upgrade on the same replica (for example, with sticky routing).
+
+## Security and operations
+
+The authenticated session-creation request resolves the requested container against the sandbox and issues a 60-second, single-use grant. The WebSocket handshake requires the grant, an HttpOnly/SameSite binding cookie, the `cube-terminal.v1` subprotocol, and an allowed `Origin`. Grants are not placed in URLs or logs.
+
+CubeOps limits pending and active sessions per principal, per sandbox, and globally. Structured logs record grant issuance, denied handshakes, session open, and session close with session, principal, sandbox, and container identifiers. Never log terminal input or output because it may contain secrets.
+
+## Troubleshooting
+
+- **Open terminal is disabled:** the sandbox is not running.
+- **403/401 during WebSocket upgrade:** verify the browser origin, login state, proxy cookie forwarding, and HTTPS configuration.
+- **503 when creating a session:** verify that CubeOps and CubeMaster share `CUBE_TERMINAL_GATEWAY_TOKEN`.
+- **Immediate disconnect:** verify CubeMaster-to-Cubelet connectivity and that the selected container is still running.

--- a/docs/zh/guide/introduction.md
+++ b/docs/zh/guide/introduction.md
@@ -49,4 +49,5 @@ Cube Sandbox 是一款**专为 AI Agent 打造的基础设施** —— 可托管
 * [Kubernetes 部署](./kubernetes/) — 在已有 K8s 集群上用 Helm 安装。
 * [从 OCI 镜像制作模板](./tutorials/template-from-image.md) — 模板制作分步指南。
 * [WebUI 管理控制台](./webui.md) — 安装完成即可可视化管理。
+* [Web 终端](./web-terminal.md) — 在运行中沙箱的详情页打开安全的交互式 TTY。
 * [安全代理与凭据保险箱](./security-proxy.md) — CubeEgress 域名过滤与审计。

--- a/docs/zh/guide/web-terminal.md
+++ b/docs/zh/guide/web-terminal.md
@@ -1,0 +1,51 @@
+---
+title: Web 终端
+---
+
+# Web 终端
+
+Dashboard 可以为运行中的沙箱打开交互式 TTY，无需暴露容器运行时或节点端口。
+
+这是一条仅用于运维控制台的链路：Dashboard 向 CubeOps 认证，CubeOps 校验目标并将 WebSocket 转发到 CubeMaster；CubeAPI 不参与该功能。
+
+## 使用方法
+
+1. 打开 **Sandboxes**，进入一个运行中沙箱的详情页。
+2. 点击 **打开终端**。
+3. 如果沙箱包含多个容器，先选择目标容器。
+4. 点击 **连接**。终端支持 ANSI 输出、光标控制、回滚、复制粘贴、窗口缩放、全屏、断开和重新连接。
+
+暂停、删除或停止沙箱后不能建立新会话。关闭终端面板会主动断开 WebSocket 并清理 exec 进程。连续 30 分钟没有终端输入、输出或窗口缩放时，会话会自动关闭；keepalive 不会延长空闲期限。
+
+## 部署配置
+
+一键部署会在 `.one-click.env` 中自动生成 `CUBE_TERMINAL_GATEWAY_TOKEN`；Helm Chart 会创建共享 Secret，并注入 CubeOps 和 CubeMaster。手动部署时，请生成至少 32 字节的随机值，并在两个服务中配置相同的值：
+
+```bash
+CUBE_TERMINAL_GATEWAY_TOKEN=<随机密钥>
+```
+
+如果 Dashboard 与 CubeOps 不同源，需要配置逗号分隔的精确来源白名单：
+
+```bash
+CUBE_TERMINAL_ALLOWED_ORIGINS=https://dashboard.example.com
+```
+
+生产环境必须启用 TLS，使浏览器使用 `wss://`。不要将 CubeMaster 的内部终端接口暴露到公网；该接口仅供控制平面使用，并要求共享网关凭据。
+
+Cubelet 默认在 `/data/cubelet/fifo` 下创建 containerd 终端 FIFO。如果部署中该目录不可写，请设置 `CUBELET_TERMINAL_FIFO_DIR`。
+
+终端 grant 保存在 CubeOps 内存中。Chart 默认只有一个 CubeOps 副本；如果水平扩容 CubeOps，需要通过粘性路由等方式，确保创建会话请求和随后 WebSocket 升级落在同一副本。
+
+## 安全与运维
+
+创建会话的请求必须已认证。服务端会确认目标容器属于该沙箱，然后签发 60 秒有效、只能使用一次的 grant。WebSocket 握手同时要求 grant、HttpOnly/SameSite 绑定 Cookie、`cube-terminal.v1` 子协议以及允许的 `Origin`。grant 不会出现在 URL 或日志中。
+
+CubeOps 会限制每个用户、每个沙箱和全局的待用 grant 与活动会话数。结构化日志会记录 grant 签发、握手拒绝、会话打开和关闭，并包含会话、用户、沙箱和容器标识。不要记录终端输入输出，其中可能包含敏感信息。
+
+## 故障排查
+
+- **“打开终端”不可点击：** 沙箱不是运行状态。
+- **WebSocket 升级返回 401/403：** 检查浏览器来源、登录状态、代理 Cookie 转发和 HTTPS 配置。
+- **创建会话返回 503：** 检查 CubeOps 与 CubeMaster 是否使用相同的 `CUBE_TERMINAL_GATEWAY_TOKEN`。
+- **连接后立即断开：** 检查 CubeMaster 到 Cubelet 的网络连接，并确认目标容器仍在运行。

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -22,6 +22,8 @@
         "@radix-ui/react-toast": "^1.2.2",
         "@radix-ui/react-tooltip": "^1.1.3",
         "@tanstack/react-query": "^5.59.0",
+        "@xterm/addon-fit": "^0.11.0",
+        "@xterm/xterm": "^6.0.0",
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.1.1",
         "cmdk": "^1.0.0",
@@ -48,7 +50,8 @@
         "prettier": "^3.9.5",
         "tailwindcss": "^3.4.14",
         "typescript": "^5.6.3",
-        "vite": "^6.4.2"
+        "vite": "^6.4.2",
+        "vitest": "^4.1.10"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -2820,6 +2823,13 @@
         "win32"
       ]
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@tanstack/query-core": {
       "version": "5.99.2",
       "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.99.2.tgz",
@@ -2890,6 +2900,24 @@
       "dependencies": {
         "@babel/types": "^7.28.2"
       }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -2980,6 +3008,134 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.10",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.10",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@xterm/addon-fit": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@xterm/addon-fit/-/addon-fit-0.11.0.tgz",
+      "integrity": "sha512-jYcgT6xtVYhnhgxh3QgYDnnNMYTcf8ElbxxFzX0IZo+vabQqSPAjC3c1wJrKB5E19VwQei89QCiZZP86DCPF7g==",
+      "license": "MIT"
+    },
+    "node_modules/@xterm/xterm": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@xterm/xterm/-/xterm-6.0.0.tgz",
+      "integrity": "sha512-TQwDdQGtwwDt+2cgKDLn0IRaSxYu1tSUjgKarSDkUM0ZNiSRXFpjxEsvc/Zgc5kq5omJ+V0a8/kIM2WD3sMOYg==",
+      "license": "MIT",
+      "workspaces": [
+        "addons/*"
+      ]
+    },
     "node_modules/agent-base": {
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
@@ -3068,6 +3224,16 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/autoprefixer": {
@@ -3224,6 +3390,16 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/change-case": {
       "version": "5.4.4",
@@ -3465,6 +3641,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+      "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/esbuild": {
       "version": "0.25.12",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
@@ -3515,6 +3698,26 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -3981,6 +4184,16 @@
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0-rc"
       }
     },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
     "node_modules/merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -4141,6 +4354,20 @@
         "node": ">= 6"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+      "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
     "node_modules/openapi-typescript": {
       "version": "7.13.0",
       "resolved": "https://registry.npmjs.org/openapi-typescript/-/openapi-typescript-7.13.0.tgz",
@@ -4210,6 +4437,13 @@
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
       "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "dev": true,
       "license": "MIT"
     },
@@ -4787,6 +5021,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/signal-exit": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -4809,6 +5050,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -4818,6 +5066,13 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/strict-event-emitter": {
       "version": "0.5.1",
@@ -4991,6 +5246,23 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.16",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
@@ -5034,6 +5306,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/tldts": {
@@ -5342,6 +5624,109 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.10",
+        "@vitest/mocker": "4.1.10",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/runner": "4.1.10",
+        "@vitest/snapshot": "4.1.10",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.10",
+        "@vitest/browser-preview": "4.1.10",
+        "@vitest/browser-webdriverio": "4.1.10",
+        "@vitest/coverage-istanbul": "4.1.10",
+        "@vitest/coverage-v8": "4.1.10",
+        "@vitest/ui": "4.1.10",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/void-elements": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-3.1.0.tgz",
@@ -5349,6 +5734,23 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/wrap-ansi": {

--- a/web/package.json
+++ b/web/package.json
@@ -8,6 +8,7 @@
     "build": "tsc -b --noEmit && vite build",
     "preview": "vite preview",
     "lint": "tsc -b --noEmit",
+    "test": "vitest run",
     "fmt": "prettier --write .",
     "api:export": "cargo run --manifest-path ../CubeAPI/Cargo.toml -- --export-openapi ../openapi.yml",
     "api:generate": "openapi-typescript ../openapi.yml -o src/api/generated/schema.ts",
@@ -28,6 +29,8 @@
     "@radix-ui/react-toast": "^1.2.2",
     "@radix-ui/react-tooltip": "^1.1.3",
     "@tanstack/react-query": "^5.59.0",
+    "@xterm/addon-fit": "^0.11.0",
+    "@xterm/xterm": "^6.0.0",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",
     "cmdk": "^1.0.0",
@@ -54,7 +57,8 @@
     "prettier": "^3.9.5",
     "tailwindcss": "^3.4.14",
     "typescript": "^5.6.3",
-    "vite": "^6.4.2"
+    "vite": "^6.4.2",
+    "vitest": "^4.1.10"
   },
   "msw": {
     "workerDirectory": [

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -19,7 +19,20 @@ export type ComponentVersionDto = components['schemas']['ComponentVersionView'];
 
 export interface RunningSandbox extends ListedSandboxDto {}
 
-export interface SandboxDetail extends SandboxDetailDto {}
+export interface SandboxDetail extends SandboxDetailDto {
+  containers: Array<{ containerID: string }>;
+}
+
+type CubeOpsSandboxDetailDto = SandboxDetailDto & {
+  containers?: Array<{ containerID: string }>;
+};
+
+export interface TerminalSessionGrant {
+  sessionId: string;
+  grant: string;
+  expiresInSeconds: number;
+  protocol: 'cube-terminal.v1';
+}
 
 export interface TemplateSummary {
   templateID: string;
@@ -114,8 +127,8 @@ function mapSandbox(dto: ListedSandboxDto): RunningSandbox {
   return dto;
 }
 
-function mapSandboxDetail(dto: SandboxDetailDto): SandboxDetail {
-  return dto;
+function mapSandboxDetail(dto: CubeOpsSandboxDetailDto): SandboxDetail {
+  return { ...dto, containers: dto.containers ?? [] };
 }
 
 function mapTemplateSummary(dto: TemplateSummaryDto): TemplateSummary {
@@ -198,7 +211,7 @@ export const sandboxApi = {
     nextToken?: string;
     limit?: number;
   }) => api<ListedSandboxDto[]>('/v2/sandboxes', { params }).then((items) => items.map(mapSandbox)),
-  get: (id: string) => api<SandboxDetailDto>(`/sandboxes/${id}`).then(mapSandboxDetail),
+  get: (id: string) => api<CubeOpsSandboxDetailDto>(`/sandboxes/${id}`).then(mapSandboxDetail),
   kill: (id: string) => api<void>(`/sandboxes/${id}`, { method: 'DELETE' }),
   pause: (id: string) => api<void>(`/sandboxes/${id}/pause`, { method: 'POST' }),
   resume: (id: string, body: SandboxResumeRequest = DEFAULT_RESUME_BODY) =>
@@ -213,6 +226,11 @@ export const sandboxApi = {
     }),
   logs: (id: string, params?: { cursor?: number; limit?: number; direction?: string }) =>
     api<SandboxLogsDto>(`/v2/sandboxes/${id}/logs`, { params }),
+  createTerminalSession: (id: string, cols: number, rows: number, containerID?: string) =>
+    api<TerminalSessionGrant>(`/sandboxes/${id}/terminal-sessions`, {
+      method: 'POST',
+      body: JSON.stringify({ cols, rows, ...(containerID ? { containerId: containerID } : {}) }),
+    }),
   create: (body: { templateID: string; timeout?: number; metadata?: Record<string, string> }) =>
     api<SandboxSessionDto>('/sandboxes', {
       method: 'POST',

--- a/web/src/components/WebTerminal.tsx
+++ b/web/src/components/WebTerminal.tsx
@@ -1,0 +1,310 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2026 Tencent. All rights reserved.
+
+import '@xterm/xterm/css/xterm.css';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { FitAddon } from '@xterm/addon-fit';
+import { Terminal } from '@xterm/xterm';
+import { ClipboardPaste, Eraser, Plug, RotateCw, Unplug } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+
+import { sandboxApi } from '@/api/client';
+import { Button } from '@/components/ui/button';
+import {
+  buildTerminalWebSocketUrl,
+  decodeServerControl,
+  encodeClose,
+  encodeKeepalive,
+  encodeResize,
+  terminalSubprotocols,
+} from '@/lib/terminalProtocol';
+
+type ConnectionState = 'idle' | 'authorizing' | 'connecting' | 'connected' | 'exited' | 'error';
+
+interface WebTerminalProps {
+  sandboxID: string;
+  enabled: boolean;
+  containerID?: string;
+}
+
+export function WebTerminal({ sandboxID, enabled, containerID }: WebTerminalProps) {
+  const { t } = useTranslation('sandboxDetail');
+  const mountRef = useRef<HTMLDivElement>(null);
+  const terminalRef = useRef<Terminal | null>(null);
+  const fitRef = useRef<FitAddon | null>(null);
+  const socketRef = useRef<WebSocket | null>(null);
+  const readyRef = useRef(false);
+  const stateRef = useRef<ConnectionState>('idle');
+  const generationRef = useRef(0);
+  const keepaliveRef = useRef<number | null>(null);
+  const resizeTimerRef = useRef<number | null>(null);
+  const pendingInputRef = useRef<Uint8Array[]>([]);
+  const [state, setStateValue] = useState<ConnectionState>('idle');
+  const [message, setMessage] = useState<string | null>(null);
+
+  const setState = useCallback((next: ConnectionState) => {
+    stateRef.current = next;
+    setStateValue(next);
+  }, []);
+
+  const stopKeepalive = useCallback(() => {
+    if (keepaliveRef.current !== null) {
+      window.clearInterval(keepaliveRef.current);
+      keepaliveRef.current = null;
+    }
+  }, []);
+
+  const closeSocket = useCallback(
+    (sendControl: boolean) => {
+      generationRef.current += 1;
+      stopKeepalive();
+      readyRef.current = false;
+      pendingInputRef.current = [];
+      const socket = socketRef.current;
+      socketRef.current = null;
+      if (socket && socket.readyState < WebSocket.CLOSING) {
+        if (sendControl && socket.readyState === WebSocket.OPEN) socket.send(encodeClose());
+        socket.close(1000, 'terminal closed');
+      }
+    },
+    [stopKeepalive],
+  );
+
+  useEffect(() => {
+    const mount = mountRef.current;
+    if (!mount) return;
+    const terminal = new Terminal({
+      allowTransparency: true,
+      cursorBlink: true,
+      fontFamily: '"JetBrains Mono Variable", ui-monospace, monospace',
+      fontSize: 13,
+      lineHeight: 1.25,
+      scrollback: 5_000,
+      theme: {
+        background: '#00000000',
+        foreground: '#dbeafe',
+        cursor: '#60a5fa',
+        selectionBackground: '#33415599',
+      },
+    });
+    const fit = new FitAddon();
+    terminal.loadAddon(fit);
+    terminal.open(mount);
+    fit.fit();
+    terminalRef.current = terminal;
+    fitRef.current = fit;
+
+    const dataDisposable = terminal.onData((data) => {
+      const bytes = new TextEncoder().encode(data);
+      const socket = socketRef.current;
+      if (!socket || socket.readyState !== WebSocket.OPEN) return;
+      if (!readyRef.current) {
+        pendingInputRef.current.push(bytes);
+        return;
+      }
+      socket.send(bytes);
+    });
+    const resizeDisposable = terminal.onResize(({ cols, rows }) => {
+      if (resizeTimerRef.current !== null) window.clearTimeout(resizeTimerRef.current);
+      resizeTimerRef.current = window.setTimeout(() => {
+        const socket = socketRef.current;
+        if (readyRef.current && socket?.readyState === WebSocket.OPEN) {
+          socket.send(encodeResize(cols, rows));
+        }
+      }, 100);
+    });
+    const observer = new ResizeObserver(() => fit.fit());
+    observer.observe(mount);
+
+    return () => {
+      closeSocket(true);
+      if (resizeTimerRef.current !== null) window.clearTimeout(resizeTimerRef.current);
+      observer.disconnect();
+      dataDisposable.dispose();
+      resizeDisposable.dispose();
+      terminal.dispose();
+      terminalRef.current = null;
+      fitRef.current = null;
+    };
+  }, [closeSocket]);
+
+  useEffect(() => {
+    if (!enabled && stateRef.current !== 'idle') {
+      closeSocket(true);
+      setState('idle');
+      setMessage(t('terminal.paused'));
+    }
+  }, [closeSocket, enabled, setState, t]);
+
+  const connect = useCallback(async () => {
+    if (!enabled || stateRef.current === 'authorizing' || stateRef.current === 'connecting') return;
+    closeSocket(false);
+    const generation = generationRef.current;
+    const terminal = terminalRef.current;
+    const fit = fitRef.current;
+    if (!terminal || !fit) return;
+    fit.fit();
+    terminal.focus();
+    setMessage(null);
+    setState('authorizing');
+
+    try {
+      const grant = await sandboxApi.createTerminalSession(
+        sandboxID,
+        Math.max(terminal.cols, 2),
+        Math.max(terminal.rows, 1),
+        containerID,
+      );
+      if (generation !== generationRef.current) return;
+      setState('connecting');
+      const socket = new WebSocket(
+        buildTerminalWebSocketUrl(sandboxID),
+        terminalSubprotocols(grant.grant),
+      );
+      socket.binaryType = 'arraybuffer';
+      socketRef.current = socket;
+
+      socket.onopen = () => {
+        if (generation !== generationRef.current) return;
+        keepaliveRef.current = window.setInterval(() => {
+          if (socket.readyState === WebSocket.OPEN) socket.send(encodeKeepalive());
+        }, 20_000);
+      };
+      socket.onmessage = (event) => {
+        if (generation !== generationRef.current) return;
+        if (typeof event.data !== 'string') {
+          terminal.write(new Uint8Array(event.data as ArrayBuffer));
+          return;
+        }
+        try {
+          const control = decodeServerControl(event.data);
+          if (control.type === 'ready') {
+            readyRef.current = true;
+            setState('connected');
+            for (const bytes of pendingInputRef.current) socket.send(bytes);
+            pendingInputRef.current = [];
+            terminal.focus();
+          } else if (control.type === 'exit') {
+            readyRef.current = false;
+            setState('exited');
+            terminal.writeln(
+              `\r\n\x1b[90m[${t('terminal.exit', { code: control.exitCode ?? 0 })}]\x1b[0m`,
+            );
+          } else {
+            readyRef.current = false;
+            setState('error');
+            const text = control.message || t('terminal.connectionFailed');
+            setMessage(text);
+            terminal.writeln(`\r\n\x1b[31m[${text}]\x1b[0m`);
+          }
+        } catch {
+          setState('error');
+          setMessage(t('terminal.protocolError'));
+          socket.close(1002, 'invalid terminal control');
+        }
+      };
+      socket.onerror = () => {
+        if (generation !== generationRef.current) return;
+        setState('error');
+        setMessage(t('terminal.connectionFailed'));
+      };
+      socket.onclose = () => {
+        if (generation !== generationRef.current) return;
+        stopKeepalive();
+        readyRef.current = false;
+        socketRef.current = null;
+        if (stateRef.current === 'connecting' || stateRef.current === 'connected') {
+          setState('error');
+          setMessage(t('terminal.disconnected'));
+        }
+      };
+    } catch (error) {
+      if (generation !== generationRef.current) return;
+      setState('error');
+      setMessage(error instanceof Error ? error.message : t('terminal.connectionFailed'));
+    }
+  }, [closeSocket, containerID, enabled, sandboxID, setState, stopKeepalive, t]);
+
+  const disconnect = useCallback(() => {
+    closeSocket(true);
+    setState('idle');
+    setMessage(null);
+  }, [closeSocket, setState]);
+
+  const canConnect = enabled && !['authorizing', 'connecting', 'connected'].includes(state);
+
+  return (
+    <div className="overflow-hidden rounded-lg border border-border/80 bg-[#060b14] shadow-inner">
+      <div className="flex flex-wrap items-center justify-between gap-2 border-b border-white/10 bg-white/[0.03] px-3 py-2">
+        <div className="flex min-w-0 items-center gap-2 text-xs">
+          <span
+            className={`h-2 w-2 rounded-full ${
+              state === 'connected'
+                ? 'bg-cube-ok'
+                : state === 'error'
+                  ? 'bg-cube-err'
+                  : state === 'authorizing' || state === 'connecting'
+                    ? 'animate-pulse bg-cube-warn'
+                    : 'bg-cube-mute'
+            }`}
+          />
+          <span className="font-mono text-slate-300">{t(`terminal.states.${state}`)}</span>
+          {message ? <span className="truncate text-slate-500">— {message}</span> : null}
+        </div>
+        <div className="flex items-center gap-1">
+          <Button
+            size="sm"
+            variant="ghost"
+            className="h-7 text-slate-300 hover:bg-white/10 hover:text-white"
+            onClick={() => {
+              void navigator.clipboard
+                .readText()
+                .then((text) => terminalRef.current?.paste(text))
+                .catch(() => setMessage(t('terminal.clipboardDenied')));
+            }}
+          >
+            <ClipboardPaste size={13} /> {t('terminal.paste')}
+          </Button>
+          <Button
+            size="sm"
+            variant="ghost"
+            className="h-7 text-slate-300 hover:bg-white/10 hover:text-white"
+            onClick={() => terminalRef.current?.clear()}
+          >
+            <Eraser size={13} /> {t('terminal.clear')}
+          </Button>
+          {state === 'connected' ? (
+            <Button
+              size="sm"
+              variant="ghost"
+              className="h-7 text-slate-300 hover:bg-white/10 hover:text-white"
+              onClick={disconnect}
+            >
+              <Unplug size={13} /> {t('terminal.disconnect')}
+            </Button>
+          ) : (
+            <Button
+              size="sm"
+              variant="ghost"
+              className="h-7 text-slate-200 hover:bg-white/10 hover:text-white"
+              disabled={!canConnect}
+              onClick={() => void connect()}
+            >
+              {state === 'exited' || state === 'error' ? <RotateCw size={13} /> : <Plug size={13} />}
+              {state === 'exited' || state === 'error'
+                ? t('terminal.reconnect')
+                : t('terminal.connect')}
+            </Button>
+          )}
+        </div>
+      </div>
+      <div ref={mountRef} className="h-[420px] p-3" aria-label={t('terminal.title')} />
+      {!enabled ? (
+        <div className="border-t border-white/10 px-3 py-2 text-xs text-slate-500">
+          {t('terminal.paused')}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/web/src/lib/terminalProtocol.test.ts
+++ b/web/src/lib/terminalProtocol.test.ts
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2026 Tencent. All rights reserved.
+
+import { describe, expect, it } from 'vitest';
+import {
+  buildTerminalWebSocketUrl,
+  decodeServerControl,
+  encodeClose,
+  encodeKeepalive,
+  encodeResize,
+  terminalSubprotocols,
+  reconcileTerminalContainer,
+} from './terminalProtocol';
+
+describe('terminal protocol', () => {
+  it('drops a stale container when navigating to another sandbox', () => {
+    expect(reconcileTerminalContainer('sandbox-a-main', ['sandbox-b-main', 'sandbox-b-sidecar'])).toBe(
+      'sandbox-b-main',
+    );
+    expect(reconcileTerminalContainer('sandbox-b-sidecar', ['sandbox-b-main', 'sandbox-b-sidecar'])).toBe(
+      'sandbox-b-sidecar',
+    );
+  });
+  it('keeps the one-time grant out of the URL', () => {
+    const url = buildTerminalWebSocketUrl(
+      'sandbox-a-b',
+      new URL('https://console.example/sandboxes/sandbox'),
+    );
+    expect(url).toBe('wss://console.example/sandboxes/sandbox-a-b/terminal');
+    expect(url).not.toContain('grant');
+    expect(terminalSubprotocols('secret')).toEqual([
+      'cube-terminal.v1',
+      'cube-terminal.grant.secret',
+    ]);
+    expect(() =>
+      buildTerminalWebSocketUrl('sandbox/other', new URL('https://console.example/sandboxes/sandbox')),
+    ).toThrow('invalid sandbox ID');
+  });
+
+  it('encodes versioned client controls', () => {
+    expect(JSON.parse(encodeResize(120, 40))).toEqual({
+      v: 1,
+      type: 'resize',
+      cols: 120,
+      rows: 40,
+    });
+    expect(JSON.parse(encodeKeepalive())).toEqual({ v: 1, type: 'keepalive' });
+    expect(JSON.parse(encodeClose())).toEqual({ v: 1, type: 'close' });
+  });
+
+  it('accepts known server controls and rejects malformed versions', () => {
+    expect(decodeServerControl('{"v":1,"type":"ready","sessionId":"s-1"}')).toEqual({
+      v: 1,
+      type: 'ready',
+      sessionId: 's-1',
+    });
+    expect(() => decodeServerControl('{"v":2,"type":"ready"}')).toThrow(
+      'unsupported terminal protocol',
+    );
+    expect(() => decodeServerControl('{"v":1,"type":"mystery"}')).toThrow(
+      'invalid terminal control',
+    );
+  });
+});

--- a/web/src/lib/terminalProtocol.ts
+++ b/web/src/lib/terminalProtocol.ts
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2026 Tencent. All rights reserved.
+
+export const TERMINAL_PROTOCOL = 'cube-terminal.v1';
+const GRANT_PROTOCOL_PREFIX = 'cube-terminal.grant.';
+
+export type TerminalServerControl =
+  | { v: 1; type: 'ready'; sessionId?: string }
+  | {
+      v: 1;
+      type: 'error';
+      code?: string;
+      message?: string;
+      retryable?: boolean;
+    }
+  | { v: 1; type: 'exit'; exitCode?: number; reason?: string };
+
+export function terminalSubprotocols(grant: string): string[] {
+  return [TERMINAL_PROTOCOL, `${GRANT_PROTOCOL_PREFIX}${grant}`];
+}
+
+export function buildTerminalWebSocketUrl(sandboxID: string, page: URL = new URL(location.href)) {
+  const scheme = page.protocol === 'https:' ? 'wss:' : 'ws:';
+  // CubeMaster sandbox IDs are canonical path-segment identifiers; embedded
+  // slashes are not supported by the SDK routes or the nginx proxy.
+  if (sandboxID.includes('/')) throw new Error('invalid sandbox ID');
+  return `${scheme}//${page.host}/sandboxes/${encodeURIComponent(sandboxID)}/terminal`;
+}
+
+export function encodeResize(cols: number, rows: number): string {
+  return JSON.stringify({ v: 1, type: 'resize', cols, rows });
+}
+
+export function encodeKeepalive(): string {
+  return JSON.stringify({ v: 1, type: 'keepalive' });
+}
+
+export function encodeClose(): string {
+  return JSON.stringify({ v: 1, type: 'close' });
+}
+
+export function reconcileTerminalContainer(current: string, available: string[]): string {
+  return current && available.includes(current) ? current : (available[0] ?? '');
+}
+
+export function decodeServerControl(raw: string): TerminalServerControl {
+  let value: unknown;
+  try {
+    value = JSON.parse(raw);
+  } catch {
+    throw new Error('invalid terminal control');
+  }
+  if (!isRecord(value)) throw new Error('invalid terminal control');
+  if (value.v !== 1) throw new Error('unsupported terminal protocol');
+  if (value.type !== 'ready' && value.type !== 'error' && value.type !== 'exit') {
+    throw new Error('invalid terminal control');
+  }
+  return value as TerminalServerControl;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}

--- a/web/src/locales/en/sandboxDetail.json
+++ b/web/src/locales/en/sandboxDetail.json
@@ -1,4 +1,32 @@
 {
+  "terminal": {
+    "title": "Terminal",
+    "description": "Interactive TTY session. Input and output are streamed as raw binary frames.",
+    "connect": "Connect",
+    "reconnect": "Reconnect",
+    "disconnect": "Disconnect",
+    "clear": "Clear",
+    "open": "Open terminal",
+    "close": "Close terminal",
+    "container": "Container",
+    "fullscreen": "Enter fullscreen",
+    "exitFullscreen": "Exit fullscreen",
+    "paste": "Paste",
+    "clipboardDenied": "Clipboard access was denied",
+    "paused": "Resume the sandbox before opening a terminal.",
+    "exit": "process exited with code {{code}}",
+    "connectionFailed": "Unable to open terminal",
+    "disconnected": "Terminal disconnected",
+    "protocolError": "Invalid terminal protocol response",
+    "states": {
+      "idle": "Idle",
+      "authorizing": "Authorizing",
+      "connecting": "Connecting",
+      "connected": "Connected",
+      "exited": "Exited",
+      "error": "Disconnected"
+    }
+  },
   "started": "started {{time}}",
   "resources": "Resources",
   "runtime": "Runtime",

--- a/web/src/locales/zh/sandboxDetail.json
+++ b/web/src/locales/zh/sandboxDetail.json
@@ -1,4 +1,32 @@
 {
+  "terminal": {
+    "title": "Web 终端",
+    "description": "交互式 TTY 会话，输入和输出通过原始二进制帧传输。",
+    "connect": "连接",
+    "reconnect": "重新连接",
+    "disconnect": "断开",
+    "clear": "清屏",
+    "open": "打开终端",
+    "close": "关闭终端",
+    "container": "容器",
+    "fullscreen": "进入全屏",
+    "exitFullscreen": "退出全屏",
+    "paste": "粘贴",
+    "clipboardDenied": "剪贴板访问被拒绝",
+    "paused": "请先恢复沙箱，再打开终端。",
+    "exit": "进程已退出，退出码 {{code}}",
+    "connectionFailed": "无法打开终端",
+    "disconnected": "终端连接已断开",
+    "protocolError": "终端协议响应无效",
+    "states": {
+      "idle": "未连接",
+      "authorizing": "正在授权",
+      "connecting": "正在连接",
+      "connected": "已连接",
+      "exited": "已退出",
+      "error": "连接中断"
+    }
+  },
   "started": "启动于 {{time}}",
   "resources": "资源",
   "runtime": "运行时",

--- a/web/src/mocks/fixtures/index.ts
+++ b/web/src/mocks/fixtures/index.ts
@@ -7,6 +7,7 @@ import type { TemplateCompatMatrix } from '@/api/client';
 type ClusterOverviewDto = components['schemas']['ClusterOverview'];
 type ListedSandboxDto = components['schemas']['ListedSandbox'];
 type SandboxDetailDto = components['schemas']['SandboxDetail'];
+type CubeOpsSandboxDetailDto = SandboxDetailDto & { containers: Array<{ containerID: string }> };
 type SandboxLogsDto = components['schemas']['SandboxLogsV2Response'];
 type SandboxSessionDto = components['schemas']['Sandbox'];
 type TemplateDetailDto = components['schemas']['TemplateDetail'];
@@ -252,13 +253,16 @@ export function listSandboxes(filters: { state?: string | null; metadata?: strin
   );
 }
 
-export function getSandboxDetail(sandboxID: string): SandboxDetailDto | undefined {
+export function getSandboxDetail(sandboxID: string): CubeOpsSandboxDetailDto | undefined {
   const sandbox = sandboxes.find((item) => item.sandboxID === sandboxID);
   if (!sandbox) return undefined;
+  const containers = [{ containerID: sandbox.sandboxID }];
+  if (sandbox !== sandboxes[0]) containers.push({ containerID: `${sandbox.sandboxID}-sidecar` });
   return {
     ...clone(sandbox),
     envdAccessToken: `eat_${sandbox.sandboxID.slice(-8)}`,
     domain: 'cube.local',
+    containers,
   };
 }
 

--- a/web/src/pages/SandboxDetail.tsx
+++ b/web/src/pages/SandboxDetail.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (C) 2026 Tencent. All rights reserved.
 
-import { useEffect, useRef, useState } from 'react';
+import { lazy, Suspense, useEffect, useRef, useState } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { useNavigate, useParams, Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
@@ -12,10 +12,25 @@ import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 
 import { Skeleton } from '@/components/ui/skeleton';
-import { ArrowLeft, Pause, Play, Trash2, RefreshCw } from 'lucide-react';
+import {
+  ArrowLeft,
+  Maximize2,
+  Minimize2,
+  Pause,
+  Play,
+  RefreshCw,
+  TerminalSquare,
+  Trash2,
+  X,
+} from 'lucide-react';
 import { cn, formatBytes, formatRelative } from '@/lib/utils';
 import { formatSandboxActionError } from '@/lib/sandboxActionError';
 import { SandboxActionErrorBanner } from '@/components/SandboxActionErrorBanner';
+import { reconcileTerminalContainer } from '@/lib/terminalProtocol';
+
+const WebTerminal = lazy(() =>
+  import('@/components/WebTerminal').then((module) => ({ default: module.WebTerminal })),
+);
 
 // ── Log level colors ────────────────────────────────────────────────────────
 const LEVEL_CLASS: Record<string, string> = {
@@ -77,6 +92,9 @@ export default function SandboxDetailPage() {
   }, [logs.data]);
 
   const [actionError, setActionError] = useState<string | null>(null);
+  const [terminalOpen, setTerminalOpen] = useState(false);
+  const [terminalFullscreen, setTerminalFullscreen] = useState(false);
+  const [terminalContainer, setTerminalContainer] = useState('');
   const onLifecycleError = (err: unknown) => {
     setActionError(formatSandboxActionError(err, t));
   };
@@ -114,6 +132,23 @@ export default function SandboxDetailPage() {
   const tone =
     state === 'paused' || state === 'pausing' ? 'warn' : state === 'running' ? 'ok' : 'mute';
   const entries = logs.data?.logs ?? [];
+  const terminalContainers =
+    (data as (typeof data & { containers?: Array<{ containerID: string }> }) | undefined)
+      ?.containers ?? [];
+  const terminalContainerKey = terminalContainers
+    .map((container) => container.containerID)
+    .join('\u0000');
+
+  useEffect(() => {
+    setTerminalOpen(false);
+    setTerminalFullscreen(false);
+    setTerminalContainer('');
+  }, [sandboxID]);
+
+  useEffect(() => {
+    const available = terminalContainers.map((container) => container.containerID);
+    setTerminalContainer((current) => reconcileTerminalContainer(current, available));
+  }, [sandboxID, terminalContainerKey]);
 
   if (isUnavailable) {
     if (!hasLoadedData || !data) {
@@ -219,6 +254,14 @@ export default function SandboxDetailPage() {
         </div>
         {data ? (
           <div className="flex gap-2">
+            <Button
+              variant="outline"
+              onClick={() => setTerminalOpen(true)}
+              disabled={state !== 'running'}
+              title={state === 'running' ? t('terminal.open') : t('terminal.paused')}
+            >
+              <TerminalSquare size={14} /> {t('terminal.open')}
+            </Button>
             {state === 'paused' ? (
               <Button variant="outline" onClick={() => resume.mutate()} disabled={resume.isPending}>
                 <Play size={14} /> {t('actions.resume')}
@@ -308,6 +351,71 @@ export default function SandboxDetailPage() {
           </dl>
         </Card>
       </div>
+
+      {data && terminalOpen ? (
+        <Card
+          className={cn(
+            terminalFullscreen &&
+              'fixed inset-3 z-50 flex flex-col overflow-auto border bg-background shadow-2xl',
+          )}
+        >
+          <CardHeader>
+            <div className="flex flex-wrap items-start justify-between gap-3">
+              <div>
+                <CardTitle>{t('terminal.title')}</CardTitle>
+                <CardDescription>{t('terminal.description')}</CardDescription>
+              </div>
+              <div className="flex items-center gap-2">
+                {terminalContainers.length > 1 ? (
+                  <label className="flex items-center gap-2 text-xs text-muted-foreground">
+                    {t('terminal.container')}
+                    <select
+                      className="h-8 rounded-md border border-input bg-background px-2 font-mono text-foreground"
+                      value={terminalContainer}
+                      onChange={(event) => setTerminalContainer(event.target.value)}
+                    >
+                      {terminalContainers.map((container) => (
+                        <option key={container.containerID} value={container.containerID}>
+                          {container.containerID}
+                        </option>
+                      ))}
+                    </select>
+                  </label>
+                ) : null}
+                <Button
+                  size="icon"
+                  variant="ghost"
+                  title={
+                    terminalFullscreen ? t('terminal.exitFullscreen') : t('terminal.fullscreen')
+                  }
+                  onClick={() => setTerminalFullscreen((value) => !value)}
+                >
+                  {terminalFullscreen ? <Minimize2 size={14} /> : <Maximize2 size={14} />}
+                </Button>
+                <Button
+                  size="icon"
+                  variant="ghost"
+                  title={t('terminal.close')}
+                  onClick={() => {
+                    setTerminalOpen(false);
+                    setTerminalFullscreen(false);
+                  }}
+                >
+                  <X size={14} />
+                </Button>
+              </div>
+            </div>
+          </CardHeader>
+          <Suspense fallback={<Skeleton className="h-[468px] rounded-lg" />}>
+            <WebTerminal
+              key={terminalContainer}
+              sandboxID={sandboxID}
+              containerID={terminalContainer || undefined}
+              enabled={state === 'running'}
+            />
+          </Suspense>
+        </Card>
+      ) : null}
 
       {/* ── Logs ── */}
       <Card>

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -51,7 +51,10 @@ export default defineConfig({
       },
       // CubeAPI (SDK/E2B endpoints) — proxy specific API paths to avoid
       // conflicting with vite's own static file serving.
-      '/sandboxes': 'http://127.0.0.1:3000',
+      '/sandboxes': {
+        target: 'http://127.0.0.1:3000',
+        ws: true,
+      },
       '/v2/sandboxes': 'http://127.0.0.1:3000',
       '/templates': 'http://127.0.0.1:3000',
       '/snapshots': 'http://127.0.0.1:3000',


### PR DESCRIPTION
## Summary

Closes #643.

This PR adds a secure interactive Web Terminal for running sandboxes:

- Adds a versioned WebSocket terminal protocol and bidirectional CubeMaster to Cubelet streaming RPC.
- Starts a real containerd TTY process with /bin/sh defaults, ANSI/cursor support, stdin/stdout streaming, resize, cleanup, idle timeout, reconnect, and multi-container selection.
- Adds a CubeOps gateway with sandbox/container validation, one-time 60-second grants, HttpOnly/SameSite binding cookies, exact Origin checks, internal gateway-token authentication, frame/size/session limits, and structured session audit events without terminal payload logging.
- Adds the xterm.js WebUI with copy/paste, scrollback, clear, resize, fullscreen, reconnect, and Chinese/English translations.
- Wires one-click/systemd, Helm/Secret, nginx and Vite proxy routes, plus Chinese/English documentation and tests.

## Validation

Passed:

- go test ./internal/handler -run Terminal -count=1
- go test ./internal/translator -run Terminal -count=1
- go test ./pkg/terminalprotocol -count=1
- go test ./services/cubebox/terminalcore -count=1
- go test ./api/services/cubebox/v1 -run Terminal -count=1
- Linux amd64 cross-compilation checks for CubeOps handler, CubeMaster cube HTTP service, and Cubelet cubebox service
- npm test -- --run — 4/4 tests passed
- npm run build
- cargo fmt --manifest-path CubeShim/Cargo.toml --all -- --check
- one-click shell syntax checks and git diff --check

Not run in this macOS workspace:

- Live deployed CubeSandbox end-to-end WebSocket/TTY smoke test.
- Helm lint/render because Helm is not installed locally.
- Full native CubeMaster/Cubelet test suites, which are blocked by existing macOS/Linux-only build constraints unrelated to this feature.

Autonomously-by: Codex:GPT-5