### PR TITLE
feat(cubeapi): add asynchronous webhook notifications

### DIFF
--- a/CubeAPI/Cargo.lock
+++ b/CubeAPI/Cargo.lock
@@ -536,6 +536,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "sha2",
  "thiserror 1.0.69",
  "tokio",
  "tower 0.4.13",

--- a/CubeAPI/Cargo.toml
+++ b/CubeAPI/Cargo.toml
@@ -34,6 +34,7 @@ futures = "0.3"
 # ── Serialization ─────────────────────────────────────────────────────────
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+sha2 = "0.10"
 
 # ── Time ──────────────────────────────────────────────────────────────────
 chrono = { version = "0.4", features = ["serde"] }

--- a/CubeAPI/README.md
+++ b/CubeAPI/README.md
@@ -72,6 +72,18 @@ cargo build --release
 | `CUBE_API_SANDBOX_DOMAIN` | `cube.app` | Domain returned in sandbox API responses |
 | `AUTH_CALLBACK_URL` | *(unset)* | External auth callback URL (callback mode) |
 | `CUBE_API_KEY` | *(unset)* | Built-in API key for simple auth (simple-key mode) |
+| `WEBHOOK_URLS` | *(unset)* | Comma-separated HTTP(S) endpoints for sandbox lifecycle webhooks |
+| `WEBHOOK_EVENTS` | `sandbox.created,sandbox.deleted,sandbox.paused,sandbox.resumed` | Comma-separated event subscription filter; use `*` for all structured events |
+| `WEBHOOK_SECRET` | *(unset)* | Optional HMAC-SHA256 signing secret |
+| `WEBHOOK_QUEUE_SIZE` | `1024` | Maximum queued webhook events before new events are dropped and logged |
+| `WEBHOOK_MAX_RETRIES` | `3` | Retries after the initial request for transient failures |
+| `WEBHOOK_RETRY_BASE_MS` | `250` | Initial exponential retry delay in milliseconds |
+| `WEBHOOK_REQUEST_TIMEOUT_SECS` | `5` | Timeout for each webhook HTTP request |
+
+The `CUBE_API_WEBHOOK_*` names are accepted aliases for deployments that keep
+all CubeAPI settings under a common prefix. See the bilingual
+[Webhook integration guide](../docs/guide/integrations/webhooks.md) for the
+payload, signature, receiver example, and WeCom integration pattern.
 
 ### Authentication
 
@@ -161,4 +173,3 @@ python pause.py
 python create_with_mount.py
 python browser.py
 python test.py
-

--- a/CubeAPI/src/config/mod.rs
+++ b/CubeAPI/src/config/mod.rs
@@ -76,6 +76,41 @@ pub struct ServerConfig {
     /// Env var: CUBE_API_KEY
     #[serde(default)]
     pub cube_api_key: Option<String>,
+
+    /// Comma-separated webhook endpoint URLs. Env var: WEBHOOK_URLS
+    /// (or CUBE_API_WEBHOOK_URLS).
+    #[serde(default = "default_webhook_urls")]
+    pub webhook_urls: String,
+
+    /// Comma-separated event names delivered to every configured endpoint.
+    /// Env var: WEBHOOK_EVENTS (or CUBE_API_WEBHOOK_EVENTS).
+    #[serde(default = "default_webhook_events")]
+    pub webhook_events: String,
+
+    /// Optional HMAC-SHA256 secret for webhook signatures. Env var:
+    /// WEBHOOK_SECRET (or CUBE_API_WEBHOOK_SECRET).
+    #[serde(default = "default_webhook_secret")]
+    pub webhook_secret: Option<String>,
+
+    /// Maximum number of queued events per webhook worker. Env var:
+    /// WEBHOOK_QUEUE_SIZE (or CUBE_API_WEBHOOK_QUEUE_SIZE).
+    #[serde(default = "default_webhook_queue_size")]
+    pub webhook_queue_size: usize,
+
+    /// Number of retries after the initial webhook attempt. Env var:
+    /// WEBHOOK_MAX_RETRIES (or CUBE_API_WEBHOOK_MAX_RETRIES).
+    #[serde(default = "default_webhook_max_retries")]
+    pub webhook_max_retries: u32,
+
+    /// Base delay for exponential retry backoff, in milliseconds. Env var:
+    /// WEBHOOK_RETRY_BASE_MS (or CUBE_API_WEBHOOK_RETRY_BASE_MS).
+    #[serde(default = "default_webhook_retry_base_ms")]
+    pub webhook_retry_base_ms: u64,
+
+    /// Per-request webhook timeout, in seconds. Env var:
+    /// WEBHOOK_REQUEST_TIMEOUT_SECS (or CUBE_API_WEBHOOK_REQUEST_TIMEOUT_SECS).
+    #[serde(default = "default_webhook_request_timeout_secs")]
+    pub webhook_request_timeout_secs: u64,
 }
 
 fn default_bind() -> String {
@@ -110,6 +145,79 @@ fn default_log_prefix() -> String {
     "cube-api".to_string()
 }
 
+fn env_string(primary: &str, alias: &str, default: &str) -> String {
+    std::env::var(primary)
+        .or_else(|_| std::env::var(alias))
+        .unwrap_or_else(|_| default.to_string())
+}
+
+fn default_webhook_urls() -> String {
+    env_string("WEBHOOK_URLS", "CUBE_API_WEBHOOK_URLS", "")
+}
+
+fn default_webhook_events() -> String {
+    env_string(
+        "WEBHOOK_EVENTS",
+        "CUBE_API_WEBHOOK_EVENTS",
+        "sandbox.created,sandbox.deleted,sandbox.paused,sandbox.resumed",
+    )
+}
+
+fn default_webhook_secret() -> Option<String> {
+    std::env::var("WEBHOOK_SECRET")
+        .or_else(|_| std::env::var("CUBE_API_WEBHOOK_SECRET"))
+        .ok()
+        .filter(|value| !value.is_empty())
+}
+
+fn parse_env_usize(primary: &str, alias: &str, default: usize) -> usize {
+    std::env::var(primary)
+        .or_else(|_| std::env::var(alias))
+        .ok()
+        .and_then(|value| value.parse().ok())
+        .unwrap_or(default)
+}
+
+fn parse_env_u32(primary: &str, alias: &str, default: u32) -> u32 {
+    std::env::var(primary)
+        .or_else(|_| std::env::var(alias))
+        .ok()
+        .and_then(|value| value.parse().ok())
+        .unwrap_or(default)
+}
+
+fn parse_env_u64(primary: &str, alias: &str, default: u64) -> u64 {
+    std::env::var(primary)
+        .or_else(|_| std::env::var(alias))
+        .ok()
+        .and_then(|value| value.parse().ok())
+        .unwrap_or(default)
+}
+
+fn default_webhook_queue_size() -> usize {
+    parse_env_usize("WEBHOOK_QUEUE_SIZE", "CUBE_API_WEBHOOK_QUEUE_SIZE", 1024)
+}
+
+fn default_webhook_max_retries() -> u32 {
+    parse_env_u32("WEBHOOK_MAX_RETRIES", "CUBE_API_WEBHOOK_MAX_RETRIES", 3)
+}
+
+fn default_webhook_retry_base_ms() -> u64 {
+    parse_env_u64(
+        "WEBHOOK_RETRY_BASE_MS",
+        "CUBE_API_WEBHOOK_RETRY_BASE_MS",
+        250,
+    )
+}
+
+fn default_webhook_request_timeout_secs() -> u64 {
+    parse_env_u64(
+        "WEBHOOK_REQUEST_TIMEOUT_SECS",
+        "CUBE_API_WEBHOOK_REQUEST_TIMEOUT_SECS",
+        5,
+    )
+}
+
 impl ServerConfig {
     pub fn from_env() -> anyhow::Result<Self> {
         let _ = dotenvy::dotenv();
@@ -135,6 +243,13 @@ impl Default for ServerConfig {
             log_prefix: default_log_prefix(),
             auth_callback_url: None,
             cube_api_key: std::env::var("CUBE_API_KEY").ok().filter(|s| !s.is_empty()),
+            webhook_urls: default_webhook_urls(),
+            webhook_events: default_webhook_events(),
+            webhook_secret: default_webhook_secret(),
+            webhook_queue_size: default_webhook_queue_size(),
+            webhook_max_retries: default_webhook_max_retries(),
+            webhook_retry_base_ms: default_webhook_retry_base_ms(),
+            webhook_request_timeout_secs: default_webhook_request_timeout_secs(),
         }
     }
 }

--- a/CubeAPI/src/logging/http.rs
+++ b/CubeAPI/src/logging/http.rs
@@ -2,83 +2,607 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-//! HTTP webhook log backend — stub.
+//! Asynchronous HTTP webhook backend for structured lifecycle events.
 //!
-//! Sends log events as JSON POST requests to a configurable endpoint.
-//! Useful for forwarding to log aggregators (Elasticsearch, Loki, custom
-//! ingest APIs) that accept HTTP.
-//!
-//! # TODO (wire-up checklist)
-//!
-//! 1. Add `http_log_url: Option<String>` to `ServerConfig`.
-//! 2. Construct `HttpLogger::new(client, url, batch_size, flush_interval)`.
-//! 3. Register it in `AppState::new()` inside `MultiLogger`.
-//!
-//! # Batching strategy (suggested)
-//!
-//! Buffer events into a `Vec<LogEvent>` and POST when either:
-//! - The buffer reaches `batch_size` (default 100), or
-//! - A ticker fires every `flush_interval` (default 5 s).
-//!
-//! Use `tokio::select!` in the background task to wait on whichever fires
-//! first.
+//! `HttpLogger::log` only performs a bounded `try_send`, so a slow or
+//! unreachable receiver never blocks the CubeAPI request path. A background
+//! worker serialises each event once, sends it to every configured endpoint,
+//! and retries transient failures with exponential backoff.
 
 use super::{LogEvent, Logger};
 use async_trait::async_trait;
+use reqwest::{Client, StatusCode, Url};
+use sha2::{Digest, Sha256};
+use std::{sync::Arc, time::Duration};
+use tokio::sync::{mpsc, oneshot};
+use tracing::{error, info, warn};
 
-/// Configuration for the HTTP webhook backend.
+const DEFAULT_EVENTS: [&str; 4] = [
+    "sandbox.created",
+    "sandbox.deleted",
+    "sandbox.paused",
+    "sandbox.resumed",
+];
+const MAX_RETRIES: u32 = 10;
+const MAX_RETRY_DELAY: Duration = Duration::from_secs(60);
+const MAX_RESPONSE_BODY_LOG_CHARS: usize = 256;
+
+/// Configuration for asynchronous webhook delivery.
 #[derive(Debug, Clone)]
-#[allow(dead_code)]
 pub struct HttpLoggerConfig {
-    /// Full URL to POST batches to, e.g. `"http://log-ingest.internal/api/logs"`.
-    pub url: String,
-    /// Max events per batch (default: 100).
-    pub batch_size: usize,
-    /// Flush interval in seconds even if batch is not full (default: 5).
-    pub flush_interval_secs: u64,
+    /// One or more HTTP(S) URLs. Invalid schemes and URLs are ignored.
+    pub urls: Vec<String>,
+    /// Event names accepted by the logger. `*` accepts every event.
+    pub events: Vec<String>,
+    /// Optional secret used for `X-Cube-Signature-256`.
+    pub secret: Option<String>,
+    /// Maximum number of events waiting for the background worker.
+    pub queue_size: usize,
+    /// Number of retries after the initial request.
+    pub max_retries: u32,
+    /// Initial exponential backoff delay in milliseconds.
+    pub retry_base_delay_ms: u64,
+    /// Timeout applied to each HTTP request.
+    pub request_timeout_secs: u64,
 }
 
 impl Default for HttpLoggerConfig {
     fn default() -> Self {
         Self {
-            url: String::new(),
-            batch_size: 100,
-            flush_interval_secs: 5,
+            urls: Vec::new(),
+            events: DEFAULT_EVENTS
+                .iter()
+                .map(|event| (*event).to_string())
+                .collect(),
+            secret: None,
+            queue_size: 1024,
+            max_retries: 3,
+            retry_base_delay_ms: 250,
+            request_timeout_secs: 5,
         }
     }
 }
 
-/// HTTP webhook log backend (stub — not yet implemented).
+impl HttpLoggerConfig {
+    /// Build the runtime configuration from the comma-separated values held
+    /// by [`crate::config::ServerConfig`].
+    pub fn from_strings(
+        urls: &str,
+        events: &str,
+        secret: Option<String>,
+        queue_size: usize,
+        max_retries: u32,
+        retry_base_delay_ms: u64,
+        request_timeout_secs: u64,
+    ) -> Self {
+        let default_events = DEFAULT_EVENTS.join(",");
+        let event_source = if events.trim().is_empty() {
+            default_events.as_str()
+        } else {
+            events
+        };
+
+        Self {
+            urls: split_csv(urls),
+            events: split_csv(event_source),
+            secret: secret.filter(|value| !value.is_empty()),
+            queue_size,
+            max_retries,
+            retry_base_delay_ms,
+            request_timeout_secs,
+        }
+    }
+
+    pub fn is_enabled(&self) -> bool {
+        self.urls.iter().any(|url| !url.trim().is_empty())
+    }
+}
+
+fn split_csv(value: &str) -> Vec<String> {
+    value
+        .split(',')
+        .map(str::trim)
+        .filter(|item| !item.is_empty())
+        .map(ToOwned::to_owned)
+        .collect()
+}
+
+#[derive(Debug)]
+struct RuntimeConfig {
+    endpoints: Vec<Url>,
+    events: Vec<String>,
+    secret: Option<String>,
+    queue_size: usize,
+    max_retries: u32,
+    retry_base_delay: Duration,
+    request_timeout: Duration,
+}
+
+impl RuntimeConfig {
+    fn from_config(config: HttpLoggerConfig) -> Self {
+        let endpoints = config
+            .urls
+            .into_iter()
+            .filter_map(|raw_url| match Url::parse(&raw_url) {
+                Ok(url) if matches!(url.scheme(), "http" | "https") => {
+                    if url.scheme() == "http" && !is_loopback(&url) {
+                        warn!(
+                            webhook_url = %url,
+                            "webhook URL is not HTTPS; use HTTPS outside local development"
+                        );
+                    }
+                    Some(url)
+                }
+                Ok(url) => {
+                    warn!(
+                        webhook_url = %url,
+                        "ignoring webhook URL with unsupported scheme"
+                    );
+                    None
+                }
+                Err(error) => {
+                    warn!(webhook_url = %raw_url, %error, "ignoring invalid webhook URL");
+                    None
+                }
+            })
+            .collect();
+
+        let max_retries = config.max_retries.min(MAX_RETRIES);
+        if config.max_retries > MAX_RETRIES {
+            warn!(
+                configured = config.max_retries,
+                capped = MAX_RETRIES,
+                "webhook retry count is too large; capping it"
+            );
+        }
+
+        let retry_base_delay_ms = config
+            .retry_base_delay_ms
+            .min(MAX_RETRY_DELAY.as_millis() as u64);
+        let request_timeout_secs = config.request_timeout_secs.clamp(1, 300);
+
+        Self {
+            endpoints,
+            events: config.events,
+            secret: config.secret,
+            queue_size: config.queue_size.max(1),
+            max_retries,
+            retry_base_delay: Duration::from_millis(retry_base_delay_ms),
+            request_timeout: Duration::from_secs(request_timeout_secs),
+        }
+    }
+
+    fn accepts(&self, event: &str) -> bool {
+        self.events
+            .iter()
+            .any(|configured| configured == "*" || configured == event)
+    }
+}
+
+fn is_loopback(url: &Url) -> bool {
+    matches!(
+        url.host_str(),
+        Some("localhost") | Some("127.0.0.1") | Some("::1")
+    )
+}
+
+enum Message {
+    Event(LogEvent),
+    Flush(oneshot::Sender<()>),
+}
+
+/// A non-blocking webhook logger backed by a bounded Tokio channel.
 #[derive(Clone)]
 pub struct HttpLogger {
-    #[allow(dead_code)]
-    config: HttpLoggerConfig,
+    tx: mpsc::Sender<Message>,
+    config: Arc<RuntimeConfig>,
 }
 
 impl HttpLogger {
-    /// Create an `HttpLogger`.  Currently a no-op; implement the background
-    /// task described in the module doc when ready.
-    #[allow(dead_code)]
+    /// Create a webhook logger with a client that does not follow redirects.
+    ///
+    /// Redirects are disabled so a configured endpoint cannot silently move a
+    /// signed payload or secret to an unexpected internal destination.
     pub fn new(config: HttpLoggerConfig) -> Self {
-        Self { config }
+        let client = Client::builder()
+            .redirect(reqwest::redirect::Policy::none())
+            .build()
+            .expect("failed to build webhook HTTP client");
+        Self::with_client(client, config)
+    }
+
+    /// Construct a logger using a caller-provided client. This is useful for
+    /// tests and for deployments that want to share a connection pool.
+    pub fn with_client(client: Client, config: HttpLoggerConfig) -> Self {
+        let config = Arc::new(RuntimeConfig::from_config(config));
+        if config.endpoints.is_empty() {
+            info!("webhook logger started without valid endpoints; delivery disabled");
+        } else {
+            info!(
+                endpoint_count = config.endpoints.len(),
+                queue_size = config.queue_size,
+                max_retries = config.max_retries,
+                "webhook logger started"
+            );
+        }
+
+        let (tx, mut rx) = mpsc::channel(config.queue_size);
+        let worker_config = Arc::clone(&config);
+        tokio::spawn(async move {
+            while let Some(message) = rx.recv().await {
+                match message {
+                    Message::Event(event) => {
+                        if worker_config.accepts(&event.event) {
+                            deliver_event(&client, &worker_config, &event).await;
+                        }
+                    }
+                    Message::Flush(reply) => {
+                        let _ = reply.send(());
+                    }
+                }
+            }
+            info!("webhook logger worker stopped");
+        });
+
+        Self { tx, config }
     }
 }
 
 #[async_trait]
 impl Logger for HttpLogger {
-    async fn log(&self, _event: LogEvent) {
-        // TODO: send to internal channel; background task batches + POSTs.
-        // Example batch payload:
-        // POST config.url
-        // Content-Type: application/json
-        // Body: { "events": [ <LogEvent>, ... ] }
+    async fn log(&self, event: LogEvent) {
+        if !self.config.accepts(&event.event) {
+            return;
+        }
+
+        let event_name = event.event.clone();
+        match self.tx.try_send(Message::Event(event)) {
+            Ok(()) => {}
+            Err(mpsc::error::TrySendError::Full(Message::Event(event))) => {
+                warn!(
+                    event = %event.event,
+                    queue_size = self.config.queue_size,
+                    "webhook queue is full; dropping event"
+                );
+            }
+            Err(mpsc::error::TrySendError::Closed(Message::Event(_))) => {
+                warn!(event = %event_name, "webhook worker is stopped; dropping event");
+            }
+            Err(_) => unreachable!("flush messages are never sent through log()"),
+        }
     }
 
     async fn flush(&self) {
-        // TODO: drain the buffer and send the final batch.
+        let (reply, wait) = oneshot::channel();
+        if self.tx.send(Message::Flush(reply)).await.is_ok() {
+            let _ = wait.await;
+        }
     }
 
     fn name(&self) -> &'static str {
-        "http"
+        "http-webhook"
+    }
+}
+
+async fn deliver_event(client: &Client, config: &RuntimeConfig, event: &LogEvent) {
+    let body = match serde_json::to_vec(event) {
+        Ok(body) => body,
+        Err(error) => {
+            error!(event = %event.event, %error, "failed to serialise webhook event");
+            return;
+        }
+    };
+    let signature = config
+        .secret
+        .as_deref()
+        .map(|secret| format!("sha256={}", hmac_sha256_hex(secret.as_bytes(), &body)));
+
+    let deliveries = config.endpoints.iter().map(|endpoint| {
+        deliver_to_endpoint(
+            client,
+            config,
+            endpoint,
+            &body,
+            signature.as_deref(),
+            &event.event,
+        )
+    });
+    futures::future::join_all(deliveries).await;
+}
+
+async fn deliver_to_endpoint(
+    client: &Client,
+    config: &RuntimeConfig,
+    endpoint: &Url,
+    body: &[u8],
+    signature: Option<&str>,
+    event_name: &str,
+) {
+    for retry_index in 0..=config.max_retries {
+        let mut request = client
+            .post(endpoint.clone())
+            .timeout(config.request_timeout)
+            .header(reqwest::header::CONTENT_TYPE, "application/json")
+            .body(body.to_vec());
+        if let Some(signature) = signature {
+            request = request.header("X-Cube-Signature-256", signature);
+        }
+
+        let result = request.send().await;
+        match result {
+            Ok(response) if response.status().is_success() => return,
+            Ok(response) => {
+                let status = response.status();
+                let response_body = response.text().await.unwrap_or_default();
+                let body_snippet: String = response_body
+                    .chars()
+                    .take(MAX_RESPONSE_BODY_LOG_CHARS)
+                    .collect();
+                let retryable = is_retryable_status(status);
+
+                warn!(
+                    event = %event_name,
+                    webhook_url = %endpoint,
+                    status = status.as_u16(),
+                    attempt = retry_index + 1,
+                    retryable,
+                    response = %body_snippet,
+                    "webhook delivery failed"
+                );
+                if !retryable {
+                    return;
+                }
+            }
+            Err(error) => {
+                warn!(
+                    event = %event_name,
+                    webhook_url = %endpoint,
+                    attempt = retry_index + 1,
+                    %error,
+                    "webhook delivery request failed"
+                );
+            }
+        }
+
+        if retry_index == config.max_retries {
+            error!(
+                event = %event_name,
+                webhook_url = %endpoint,
+                attempts = retry_index + 1,
+                "webhook delivery exhausted retries"
+            );
+            return;
+        }
+
+        let delay = retry_delay(config.retry_base_delay, retry_index);
+        if !delay.is_zero() {
+            tokio::time::sleep(delay).await;
+        }
+    }
+}
+
+fn is_retryable_status(status: StatusCode) -> bool {
+    status == StatusCode::REQUEST_TIMEOUT
+        || status == StatusCode::TOO_MANY_REQUESTS
+        || status.is_server_error()
+}
+
+fn retry_delay(base: Duration, retry_index: u32) -> Duration {
+    let multiplier = 1u128 << retry_index.min(16);
+    let millis = base
+        .as_millis()
+        .saturating_mul(multiplier)
+        .min(MAX_RETRY_DELAY.as_millis());
+    Duration::from_millis(millis as u64)
+}
+
+fn hmac_sha256_hex(secret: &[u8], message: &[u8]) -> String {
+    const BLOCK_SIZE: usize = 64;
+    let mut key = [0u8; BLOCK_SIZE];
+    if secret.len() > BLOCK_SIZE {
+        let digest = Sha256::digest(secret);
+        key[..digest.len()].copy_from_slice(&digest);
+    } else {
+        key[..secret.len()].copy_from_slice(secret);
+    }
+
+    let mut inner_pad = [0x36u8; BLOCK_SIZE];
+    let mut outer_pad = [0x5cu8; BLOCK_SIZE];
+    for index in 0..BLOCK_SIZE {
+        inner_pad[index] ^= key[index];
+        outer_pad[index] ^= key[index];
+    }
+
+    let mut inner = Sha256::new();
+    inner.update(inner_pad);
+    inner.update(message);
+    let inner_digest = inner.finalize();
+
+    let mut outer = Sha256::new();
+    outer.update(outer_pad);
+    outer.update(inner_digest);
+    let digest = outer.finalize();
+
+    digest.iter().map(|byte| format!("{byte:02x}")).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::logging::LogLevel;
+    use axum::{
+        body::Bytes,
+        extract::State,
+        http::{HeaderMap, StatusCode},
+        routing::post,
+        Router,
+    };
+    use std::sync::{
+        atomic::{AtomicUsize, Ordering},
+        Mutex,
+    };
+
+    type RecordedRequest = (String, Vec<u8>);
+
+    #[derive(Clone)]
+    struct ReceiverState {
+        requests: Arc<Mutex<Vec<RecordedRequest>>>,
+        attempts: Arc<AtomicUsize>,
+        fail_first: bool,
+        status: StatusCode,
+    }
+
+    impl Default for ReceiverState {
+        fn default() -> Self {
+            Self {
+                requests: Arc::default(),
+                attempts: Arc::default(),
+                fail_first: false,
+                status: StatusCode::NO_CONTENT,
+            }
+        }
+    }
+
+    async fn receiver(
+        State(state): State<ReceiverState>,
+        headers: HeaderMap,
+        body: Bytes,
+    ) -> StatusCode {
+        let signature = headers
+            .get("X-Cube-Signature-256")
+            .and_then(|value| value.to_str().ok())
+            .unwrap_or_default()
+            .to_string();
+        let attempt = state.attempts.fetch_add(1, Ordering::SeqCst);
+        state
+            .requests
+            .lock()
+            .unwrap()
+            .push((signature, body.to_vec()));
+        if state.fail_first && attempt == 0 {
+            StatusCode::INTERNAL_SERVER_ERROR
+        } else {
+            state.status
+        }
+    }
+
+    async fn start_receiver(state: ReceiverState) -> (String, tokio::task::JoinHandle<()>) {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let task = tokio::spawn(async move {
+            axum::serve(
+                listener,
+                Router::new()
+                    .route("/webhook", post(receiver))
+                    .with_state(state),
+            )
+            .await
+            .unwrap();
+        });
+        (format!("http://{address}/webhook"), task)
+    }
+
+    fn config(url: String) -> HttpLoggerConfig {
+        HttpLoggerConfig {
+            urls: vec![url],
+            events: vec!["sandbox.created".to_string()],
+            secret: Some("test-secret".to_string()),
+            queue_size: 8,
+            max_retries: 1,
+            retry_base_delay_ms: 0,
+            request_timeout_secs: 2,
+        }
+    }
+
+    #[tokio::test]
+    async fn delivers_json_with_hmac_and_retries_server_errors() {
+        let state = ReceiverState {
+            fail_first: true,
+            status: StatusCode::NO_CONTENT,
+            ..Default::default()
+        };
+        let requests = Arc::clone(&state.requests);
+        let (url, server) = start_receiver(state).await;
+        let logger = HttpLogger::new(config(url));
+
+        logger
+            .log(
+                LogEvent::new(LogLevel::Info, "sandbox.created")
+                    .field("sandbox_id", "sbx-1")
+                    .field("template_id", "tpl-1"),
+            )
+            .await;
+        logger.flush().await;
+
+        let requests = requests.lock().unwrap();
+        assert_eq!(requests.len(), 2);
+        assert_eq!(requests[0].1, requests[1].1);
+        let expected = format!("sha256={}", hmac_sha256_hex(b"test-secret", &requests[0].1));
+        assert_eq!(requests[0].0, expected);
+        let payload: serde_json::Value = serde_json::from_slice(&requests[0].1).unwrap();
+        assert_eq!(payload["event"], "sandbox.created");
+        assert_eq!(payload["sandbox_id"], "sbx-1");
+        assert_eq!(payload["template_id"], "tpl-1");
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn filters_unsubscribed_events_before_enqueue() {
+        let state = ReceiverState {
+            status: StatusCode::NO_CONTENT,
+            ..Default::default()
+        };
+        let attempts = Arc::clone(&state.attempts);
+        let (url, server) = start_receiver(state).await;
+        let logger = HttpLogger::new(config(url));
+
+        logger
+            .log(LogEvent::new(LogLevel::Info, "sandbox.deleted"))
+            .await;
+        logger.flush().await;
+
+        assert_eq!(attempts.load(Ordering::SeqCst), 0);
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn log_returns_without_waiting_for_receiver() {
+        let logger = HttpLogger::new(HttpLoggerConfig {
+            urls: vec!["http://127.0.0.1:9/webhook".to_string()],
+            events: vec!["sandbox.created".to_string()],
+            secret: None,
+            queue_size: 1,
+            max_retries: 0,
+            retry_base_delay_ms: 0,
+            request_timeout_secs: 2,
+        });
+
+        tokio::time::timeout(
+            Duration::from_millis(100),
+            logger.log(LogEvent::new(LogLevel::Info, "sandbox.created")),
+        )
+        .await
+        .expect("enqueue must not wait for HTTP delivery");
+    }
+
+    #[test]
+    fn hmac_matches_rfc_4231_case() {
+        assert_eq!(
+            hmac_sha256_hex(&[0x0b; 20], b"Hi There",),
+            "b0344c61d8db38535ca8afceaf0bf12b881dc200c9833da726e9376c2e32cff7"
+        );
+    }
+
+    #[test]
+    fn retry_delay_is_bounded() {
+        assert_eq!(
+            retry_delay(Duration::from_millis(250), 0),
+            Duration::from_millis(250)
+        );
+        assert_eq!(
+            retry_delay(Duration::from_millis(250), 3),
+            Duration::from_millis(2000)
+        );
+        assert_eq!(retry_delay(Duration::from_secs(60), 10), MAX_RETRY_DELAY);
     }
 }

--- a/CubeAPI/src/main.rs
+++ b/CubeAPI/src/main.rs
@@ -198,7 +198,14 @@ fn main() -> anyhow::Result<()> {
 }
 
 async fn async_main(cfg: config::ServerConfig, debug: bool) -> anyhow::Result<()> {
-    use logging::{arc, file::FileLogger, filtered::FilteredLogger, multi::MultiLogger, LogLevel};
+    use logging::{
+        arc,
+        file::FileLogger,
+        filtered::FilteredLogger,
+        http::{HttpLogger, HttpLoggerConfig},
+        multi::MultiLogger,
+        LogLevel,
+    };
 
     // ── Logger ────────────────────────────────────────────────────────────
     let min_level = if debug {
@@ -209,15 +216,23 @@ async fn async_main(cfg: config::ServerConfig, debug: bool) -> anyhow::Result<()
 
     let file_logger = FileLogger::new(cfg.log_dir.clone(), cfg.log_prefix.clone()).await?;
 
-    // FilteredLogger gates by level → MultiLogger fans out to file (+ future backends)
-    let logger: logging::ArcLogger = arc(FilteredLogger::new(
-        arc(
-            MultiLogger::new().add(arc(file_logger)), // Uncomment to add more backends:
-                                                      // .add(arc(logging::http::HttpLogger::new(Default::default())))
-                                                      // .add(arc(logging::otlp::OtlpLogger::new()))
-        ),
-        min_level,
-    ));
+    // FilteredLogger gates by level → MultiLogger fans out to file and the
+    // optional asynchronous webhook backend.
+    let mut backends = MultiLogger::new().add(arc(file_logger));
+    let webhook_config = HttpLoggerConfig::from_strings(
+        &cfg.webhook_urls,
+        &cfg.webhook_events,
+        cfg.webhook_secret.clone(),
+        cfg.webhook_queue_size,
+        cfg.webhook_max_retries,
+        cfg.webhook_retry_base_ms,
+        cfg.webhook_request_timeout_secs,
+    );
+    if webhook_config.is_enabled() {
+        backends = backends.add(arc(HttpLogger::new(webhook_config)));
+    }
+
+    let logger: logging::ArcLogger = arc(FilteredLogger::new(arc(backends), min_level));
 
     tracing::info!(
         log_dir = %cfg.log_dir,

--- a/docs/guide/integrations/index.md
+++ b/docs/guide/integrations/index.md
@@ -48,3 +48,4 @@ lang: en-US
 | Title | Author | Date | Tags |
 | --- | --- | --- | --- |
 | [Pi Agent Integration Guide](./pi-agent.md) | chaojixinren | 2026-07-01 | integration, pi-agent, coding-agent, agent |
+| [CubeSandbox Webhook Integration Guide](./webhooks.md) | dujunjin | 2026-07-23 | integration, webhook, observability |

--- a/docs/guide/integrations/webhooks.md
+++ b/docs/guide/integrations/webhooks.md
@@ -1,0 +1,141 @@
+---
+title: CubeSandbox Webhook Integration Guide
+author: dujunjin
+date: 2026-07-23
+tags:
+  - integration
+  - webhook
+  - observability
+lang: en-US
+---
+
+# CubeSandbox Webhook Integration Guide
+
+[中文文档](../../zh/guide/integrations/webhooks.md)
+
+CubeAPI can asynchronously notify HTTP endpoints when a sandbox lifecycle
+operation succeeds. This avoids polling and lets an agent orchestrator, an
+operations system, or a chat bot react to state changes in near real time.
+
+## Configuration
+
+Set these environment variables before starting `cube-api`:
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `WEBHOOK_URLS` | unset | Comma-separated HTTP(S) endpoint URLs |
+| `WEBHOOK_EVENTS` | `sandbox.created,sandbox.deleted,sandbox.paused,sandbox.resumed` | Event allowlist; `*` accepts every structured event |
+| `WEBHOOK_SECRET` | unset | Optional HMAC-SHA256 secret |
+| `WEBHOOK_QUEUE_SIZE` | `1024` | Bounded queue capacity |
+| `WEBHOOK_MAX_RETRIES` | `3` | Retries after the initial request |
+| `WEBHOOK_RETRY_BASE_MS` | `250` | Initial exponential backoff delay |
+| `WEBHOOK_REQUEST_TIMEOUT_SECS` | `5` | Timeout for each request |
+
+The `CUBE_API_WEBHOOK_*` aliases are also accepted. Multiple URLs receive the
+same selected event set. Leave `WEBHOOK_URLS` unset to disable delivery.
+
+Example local configuration:
+
+```bash
+export WEBHOOK_URLS='http://127.0.0.1:8099/webhook,https://ops.example.com/cube'
+export WEBHOOK_EVENTS='sandbox.created,sandbox.paused,sandbox.resumed,sandbox.deleted'
+export WEBHOOK_SECRET='replace-with-a-random-secret'
+```
+
+Use HTTPS for non-loopback endpoints. HTTP is useful for the local example only.
+
+## Event and payload
+
+The following lifecycle events are emitted after the corresponding CubeMaster
+operation succeeds:
+
+- `sandbox.created`
+- `sandbox.deleted`
+- `sandbox.paused`
+- `sandbox.resumed`
+
+Each POST has `Content-Type: application/json`. The JSON object is the structured
+CubeAPI event and includes at least:
+
+```json
+{
+  "event": "sandbox.created",
+  "timestamp": "2026-07-23T12:00:00.000Z",
+  "level": "info",
+  "sandbox_id": "sbx-example",
+  "template_id": "tpl-example"
+}
+```
+
+`template_id` is currently available for creation events. Future event fields
+may be added without changing the required fields; receivers should ignore
+unknown fields.
+
+## Delivery semantics
+
+The API handler places a subscribed event into a bounded in-memory queue with
+`try_send`; it does not wait for the receiver. A background worker sends the
+same serialized body to all configured URLs. When the queue is full, the event
+is dropped and CubeAPI writes a warning with the event name. This protects
+sandbox create/pause/resume/delete latency and memory usage.
+
+HTTP 2xx responses are successful. Network errors, timeouts, HTTP 408, 429, and
+5xx responses are retried with exponential backoff. Other 4xx responses are
+logged and not retried. The retry count is bounded by CubeAPI, and delivery
+failure never changes the result of the sandbox API request.
+
+## HMAC-SHA256 verification
+
+When `WEBHOOK_SECRET` is set, CubeAPI adds:
+
+```text
+X-Cube-Signature-256: sha256=<lowercase-hex-digest>
+```
+
+The digest is HMAC-SHA256 over the exact raw request body. Verify before parsing
+JSON and compare in constant time:
+
+```python
+import hashlib
+import hmac
+
+expected = "sha256=" + hmac.new(
+    WEBHOOK_SECRET.encode(), raw_body, hashlib.sha256
+).hexdigest()
+if not hmac.compare_digest(
+    request.headers.get("X-Cube-Signature-256", ""), expected
+):
+    return unauthorized()
+```
+
+The runnable receiver at
+[`examples/webhook-receiver`](https://github.com/TencentCloud/CubeSandbox/tree/master/examples/webhook-receiver)
+implements the complete check and returns `401` for an invalid signature.
+
+## Local verification
+
+```bash
+python3 examples/webhook-receiver/receiver.py \
+  --port 8099 \
+  --secret replace-with-a-random-secret
+
+WEBHOOK_URLS=http://127.0.0.1:8099/webhook \
+WEBHOOK_SECRET=replace-with-a-random-secret \
+cargo run --manifest-path CubeAPI/Cargo.toml
+```
+
+Create, pause, resume, and delete a sandbox with the normal SDK or REST API and
+confirm that the receiver prints the four event names. The receiver example
+also includes a `curl` command for testing the signature without a cluster.
+
+## WeCom and generic HTTP alerting
+
+Keep CubeAPI's webhook endpoint as a small internal adapter. After verifying the
+CubeSandbox signature, map the event into the target format. A WeCom bot expects
+an envelope such as `{"msgtype":"markdown","markdown":{"content":"..."}}`;
+generic alerting systems may instead accept the original JSON with their own
+Authorization header. Apply independent timeouts and retries to this second
+hop, and do not reuse the CubeSandbox signature as downstream authentication.
+
+See the bilingual receiver README for a complete standard-library forwarding
+snippet.

--- a/docs/zh/guide/integrations/index.md
+++ b/docs/zh/guide/integrations/index.md
@@ -48,3 +48,4 @@ lang: zh-CN
 | 标题 | 作者 | 日期 | 标签 |
 | --- | --- | --- | --- |
 | [Pi Agent 集成指南](./pi-agent.md) | chaojixinren | 2026-07-01 | integration, pi-agent, coding-agent, agent |
+| [CubeSandbox Webhook 集成指南](./webhooks.md) | dujunjin | 2026-07-23 | integration, webhook, observability |

--- a/docs/zh/guide/integrations/webhooks.md
+++ b/docs/zh/guide/integrations/webhooks.md
@@ -1,0 +1,130 @@
+---
+title: CubeSandbox Webhook 集成指南
+author: dujunjin
+date: 2026-07-23
+tags:
+  - integration
+  - webhook
+  - observability
+lang: zh-CN
+---
+
+# CubeSandbox Webhook 集成指南
+
+[English](../../../guide/integrations/webhooks.md)
+
+CubeAPI 可以在沙箱生命周期操作成功后，异步通知 HTTP 接收端。这样上层 Agent
+编排器、运维平台或企业微信机器人可以近实时响应状态变化，不必持续轮询 API。
+
+## 配置
+
+在启动 `cube-api` 前设置以下环境变量：
+
+| 变量 | 默认值 | 说明 |
+| --- | --- | --- |
+| `WEBHOOK_URLS` | 未设置 | 逗号分隔的 HTTP(S) 接收端地址 |
+| `WEBHOOK_EVENTS` | `sandbox.created,sandbox.deleted,sandbox.paused,sandbox.resumed` | 事件白名单；`*` 表示所有结构化事件 |
+| `WEBHOOK_SECRET` | 未设置 | 可选 HMAC-SHA256 secret |
+| `WEBHOOK_QUEUE_SIZE` | `1024` | 有界队列容量 |
+| `WEBHOOK_MAX_RETRIES` | `3` | 初次投递后的重试次数 |
+| `WEBHOOK_RETRY_BASE_MS` | `250` | 指数退避初始延迟 |
+| `WEBHOOK_REQUEST_TIMEOUT_SECS` | `5` | 每次 HTTP 请求超时 |
+
+也支持 `CUBE_API_WEBHOOK_*` 别名。多个地址会收到相同的事件集合；不设置
+`WEBHOOK_URLS` 即关闭 Webhook 投递。
+
+本地配置示例：
+
+```bash
+export WEBHOOK_URLS='http://127.0.0.1:8099/webhook,https://ops.example.com/cube'
+export WEBHOOK_EVENTS='sandbox.created,sandbox.paused,sandbox.resumed,sandbox.deleted'
+export WEBHOOK_SECRET='replace-with-a-random-secret'
+```
+
+非本机地址应使用 HTTPS；HTTP 仅适合本地接收端示例。
+
+## 事件与 Payload
+
+以下四类事件会在对应 CubeMaster 操作成功后产生：
+
+- `sandbox.created`
+- `sandbox.deleted`
+- `sandbox.paused`
+- `sandbox.resumed`
+
+每次 POST 的 `Content-Type` 为 `application/json`。结构化 CubeAPI 事件至少包含：
+
+```json
+{
+  "event": "sandbox.created",
+  "timestamp": "2026-07-23T12:00:00.000Z",
+  "level": "info",
+  "sandbox_id": "sbx-example",
+  "template_id": "tpl-example"
+}
+```
+
+当前 `template_id` 在创建事件中可用。未来可能增加字段，接收端应忽略未知字段，
+不要依赖字段顺序。
+
+## 投递语义
+
+API handler 使用 `try_send` 将已订阅事件放入有界内存队列，不等待接收端响应；后台
+worker 将同一份序列化 body 发往所有配置地址。队列满时会丢弃事件，并记录带事件
+名称的 warning。这能保护沙箱创建、暂停、恢复、销毁主路径的延迟和内存使用。
+
+HTTP 2xx 表示成功。网络错误、超时、HTTP 408、429 和 5xx 会按指数退避重试；其他
+4xx 会记录日志但不重试。重试次数由 CubeAPI 限制，投递失败不会改变沙箱 API 请求的
+结果。
+
+## HMAC-SHA256 校验
+
+设置 `WEBHOOK_SECRET` 后，CubeAPI 会添加：
+
+```text
+X-Cube-Signature-256: sha256=<小写十六进制摘要>
+```
+
+摘要针对 HTTP 请求的原始 body 计算。应在解析 JSON 前校验，并使用常量时间比较：
+
+```python
+import hashlib
+import hmac
+
+expected = "sha256=" + hmac.new(
+    WEBHOOK_SECRET.encode(), raw_body, hashlib.sha256
+).hexdigest()
+if not hmac.compare_digest(
+    request.headers.get("X-Cube-Signature-256", ""), expected
+):
+    return unauthorized()
+```
+
+可运行示例
+[`examples/webhook-receiver`](https://github.com/TencentCloud/CubeSandbox/tree/master/examples/webhook-receiver)
+包含完整校验逻辑，签名错误时返回 `401`。
+
+## 本地验证
+
+```bash
+python3 examples/webhook-receiver/receiver.py \
+  --port 8099 \
+  --secret replace-with-a-random-secret
+
+WEBHOOK_URLS=http://127.0.0.1:8099/webhook \
+WEBHOOK_SECRET=replace-with-a-random-secret \
+cargo run --manifest-path CubeAPI/Cargo.toml
+```
+
+使用正常的 SDK 或 REST API 创建、暂停、恢复、销毁沙箱，确认接收端打印四类事件。
+接收端 README 还提供不依赖集群的 `curl` 签名验证命令。
+
+## 对接企业微信和通用 HTTP 告警
+
+建议把 CubeAPI Webhook 接收端作为内部适配器：先校验 CubeSandbox 签名，再把事件
+转换为目标格式。企业微信机器人需要类似
+`{"msgtype":"markdown","markdown":{"content":"..."}}` 的 envelope；通用告警
+系统可以携带自己的 Authorization header 转发原始 JSON。第二跳应使用独立的超时和
+重试策略，不要把 CubeSandbox 签名当作下游认证。
+
+完整的标准库转发片段见双语接收端 README。

--- a/examples/webhook-receiver/README.md
+++ b/examples/webhook-receiver/README.md
@@ -1,0 +1,91 @@
+# CubeSandbox Webhook Receiver
+
+This dependency-free Python server receives CubeSandbox lifecycle webhooks and
+optionally verifies the `X-Cube-Signature-256` HMAC-SHA256 header.
+
+## Run it
+
+From the repository root:
+
+```bash
+python3 examples/webhook-receiver/receiver.py \
+  --port 8099 \
+  --secret local-development-secret
+```
+
+Configure CubeAPI with one or more comma-separated endpoints:
+
+```bash
+export WEBHOOK_URLS=http://127.0.0.1:8099/webhook
+export WEBHOOK_SECRET=local-development-secret
+export WEBHOOK_EVENTS=sandbox.created,sandbox.deleted,sandbox.paused,sandbox.resumed
+export WEBHOOK_MAX_RETRIES=3
+export WEBHOOK_RETRY_BASE_MS=250
+```
+
+Restart `cube-api`, then use the normal CubeAPI sandbox API. The receiver prints
+each accepted JSON payload and responds with `204 No Content`.
+
+For a receiver on another host, use HTTPS and keep the secret in the deployment
+secret manager rather than putting it in a shell history or source file.
+
+## Payload
+
+The payload is the structured `LogEvent` object. Lifecycle events always include
+`event`, `timestamp`, and `sandbox_id`; creation also includes `template_id`.
+
+```json
+{
+  "event": "sandbox.created",
+  "timestamp": "2026-07-23T12:00:00.000Z",
+  "level": "info",
+  "sandbox_id": "sbx-example",
+  "template_id": "tpl-example"
+}
+```
+
+## Verify a signature manually
+
+The signature is calculated over the exact request bytes, not a re-encoded JSON
+object:
+
+```bash
+secret='local-development-secret'
+body='{"event":"sandbox.created","timestamp":"2026-07-23T12:00:00Z","sandbox_id":"sbx-demo"}'
+signature="sha256=$(printf '%s' "$body" | openssl dgst -sha256 -hmac "$secret" | awk '{print $2}')"
+
+curl -i http://127.0.0.1:8099/webhook \
+  -H 'Content-Type: application/json' \
+  -H "X-Cube-Signature-256: $signature" \
+  --data-binary "$body"
+```
+
+The expected response is `204`. A missing or incorrect signature returns `401`
+when the receiver was started with `--secret`.
+
+## Forward to WeCom or a generic alert endpoint
+
+The receiver can be extended after signature verification. For a WeCom bot,
+POST a transformed message to the bot URL:
+
+```python
+import os
+import urllib.request
+import json
+
+message = {
+    "msgtype": "markdown",
+    "markdown": {"content": f"CubeSandbox event: {payload['event']}\n"
+                              f"sandbox: {payload['sandbox_id']}"},
+}
+request = urllib.request.Request(
+    os.environ["WECOM_BOT_URL"],
+    data=json.dumps(message).encode(),
+    headers={"Content-Type": "application/json"},
+)
+urllib.request.urlopen(request, timeout=5).read()
+```
+
+For generic alerting, preserve the original payload and add an authorization
+header or destination-specific envelope in the same handler. Do not forward
+the CubeSandbox HMAC header as if it authenticated the downstream service.

--- a/examples/webhook-receiver/README_zh.md
+++ b/examples/webhook-receiver/README_zh.md
@@ -1,0 +1,87 @@
+# CubeSandbox Webhook 接收端
+
+这是一个零第三方依赖的 Python 接收端示例，可接收 CubeSandbox 沙箱生命周期
+Webhook，并可选校验 `X-Cube-Signature-256` HMAC-SHA256 签名。
+
+## 启动
+
+在仓库根目录执行：
+
+```bash
+python3 examples/webhook-receiver/receiver.py \
+  --port 8099 \
+  --secret local-development-secret
+```
+
+CubeAPI 使用逗号分隔的一个或多个地址：
+
+```bash
+export WEBHOOK_URLS=http://127.0.0.1:8099/webhook
+export WEBHOOK_SECRET=local-development-secret
+export WEBHOOK_EVENTS=sandbox.created,sandbox.deleted,sandbox.paused,sandbox.resumed
+export WEBHOOK_MAX_RETRIES=3
+export WEBHOOK_RETRY_BASE_MS=250
+```
+
+重启 `cube-api` 后，通过正常的 CubeAPI 沙箱 API 操作即可。接收端会打印每个
+通过校验的 JSON，并返回 `204 No Content`。
+
+如果接收端在另一台机器上，请使用 HTTPS，并将 secret 放在部署系统的密钥管理器
+中，不要写入 shell 历史或源码。
+
+## Payload
+
+Payload 就是结构化 `LogEvent` 对象。生命周期事件至少包含 `event`、`timestamp`、
+`sandbox_id`；创建事件还会携带 `template_id`。
+
+```json
+{
+  "event": "sandbox.created",
+  "timestamp": "2026-07-23T12:00:00.000Z",
+  "level": "info",
+  "sandbox_id": "sbx-example",
+  "template_id": "tpl-example"
+}
+```
+
+## 手动校验签名
+
+签名针对 HTTP 请求的原始字节计算，而不是重新编码后的 JSON 对象：
+
+```bash
+secret='local-development-secret'
+body='{"event":"sandbox.created","timestamp":"2026-07-23T12:00:00Z","sandbox_id":"sbx-demo"}'
+signature="sha256=$(printf '%s' "$body" | openssl dgst -sha256 -hmac "$secret" | awk '{print $2}')"
+
+curl -i http://127.0.0.1:8099/webhook \
+  -H 'Content-Type: application/json' \
+  -H "X-Cube-Signature-256: $signature" \
+  --data-binary "$body"
+```
+
+预期响应为 `204`。如果接收端以 `--secret` 启动，签名缺失或错误会返回 `401`。
+
+## 对接企业微信或通用告警
+
+接收端完成签名校验后，可以在同一个处理函数中把事件转换后转发给企业微信机器人：
+
+```python
+import json
+import os
+import urllib.request
+
+message = {
+    "msgtype": "markdown",
+    "markdown": {"content": f"CubeSandbox 事件：{payload['event']}\n"
+                              f"sandbox：{payload['sandbox_id']}"},
+}
+request = urllib.request.Request(
+    os.environ["WECOM_BOT_URL"],
+    data=json.dumps(message).encode(),
+    headers={"Content-Type": "application/json"},
+)
+urllib.request.urlopen(request, timeout=5).read()
+```
+
+对接通用 HTTP 告警时，可保留原始 Payload，并在转发时增加下游服务自己的
+Authorization 或消息包装。不要把 CubeSandbox 的 HMAC header 当作下游服务的认证。

--- a/examples/webhook-receiver/receiver.py
+++ b/examples/webhook-receiver/receiver.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""Small dependency-free CubeSandbox webhook receiver for local verification."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import hmac
+import json
+import os
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+
+MAX_BODY_BYTES = 1024 * 1024
+
+
+class WebhookHandler(BaseHTTPRequestHandler):
+    secret: bytes | None = None
+    webhook_path = "/webhook"
+
+    def do_POST(self) -> None:  # noqa: N802 - required by BaseHTTPRequestHandler
+        if self.path != self.webhook_path:
+            self.send_error(404, "not found")
+            return
+
+        try:
+            content_length = int(self.headers.get("Content-Length", "0"))
+        except ValueError:
+            self.send_error(400, "invalid content length")
+            return
+        if content_length < 0 or content_length > MAX_BODY_BYTES:
+            self.send_error(413, "payload too large")
+            return
+
+        body = self.rfile.read(content_length)
+        if self.secret is not None:
+            provided = self.headers.get("X-Cube-Signature-256", "")
+            expected = "sha256=" + hmac.new(
+                self.secret, body, hashlib.sha256
+            ).hexdigest()
+            if not hmac.compare_digest(provided, expected):
+                self.send_error(401, "invalid webhook signature")
+                return
+
+        try:
+            payload = json.loads(body)
+        except json.JSONDecodeError:
+            self.send_error(400, "payload is not valid JSON")
+            return
+        if not isinstance(payload, dict):
+            self.send_error(400, "payload must be a JSON object")
+            return
+
+        missing = [
+            field
+            for field in ("event", "timestamp", "sandbox_id")
+            if not payload.get(field)
+        ]
+        if missing:
+            self.send_error(400, "missing fields: " + ", ".join(missing))
+            return
+
+        print(json.dumps(payload, ensure_ascii=False, sort_keys=True), flush=True)
+        self.send_response(204)
+        self.end_headers()
+
+    def log_message(self, format: str, *args: object) -> None:
+        print(f"[receiver] {format % args}", flush=True)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--host", default=os.getenv("WEBHOOK_RECEIVER_HOST", "127.0.0.1"))
+    parser.add_argument("--port", type=int, default=int(os.getenv("WEBHOOK_RECEIVER_PORT", "8099")))
+    parser.add_argument("--path", default=os.getenv("WEBHOOK_RECEIVER_PATH", "/webhook"))
+    parser.add_argument(
+        "--secret",
+        default=os.getenv("WEBHOOK_RECEIVER_SECRET"),
+        help="shared secret; also read from WEBHOOK_RECEIVER_SECRET",
+    )
+    args = parser.parse_args()
+
+    WebhookHandler.secret = args.secret.encode() if args.secret else None
+    WebhookHandler.webhook_path = args.path
+    server = ThreadingHTTPServer((args.host, args.port), WebhookHandler)
+    print(
+        f"[receiver] listening on http://{args.host}:{args.port}{args.path} "
+        f"(hmac={'enabled' if WebhookHandler.secret else 'disabled'})",
+        flush=True,
+    )
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        print("[receiver] stopping", flush=True)
+    finally:
+        server.server_close()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Closes #642

## Summary

- implement a bounded, asynchronous CubeAPI webhook logger for one or more HTTP(S) endpoints;
- filter lifecycle events for sandbox.created, sandbox.deleted, sandbox.paused, and sandbox.resumed;
- send JSON payloads with HMAC-SHA256 signatures, transient-failure retries, exponential backoff, request timeouts, response diagnostics, and redirect protection;
- wire WEBHOOK_* and CUBE_API_WEBHOOK_* environment configuration into the existing structured logger;
- add a dependency-free receiver example, bilingual integration documentation, and core delivery tests.

## Verification

- `RUSTUP_TOOLCHAIN=stable cargo fmt -- --check`
- `RUSTUP_TOOLCHAIN=stable cargo test --locked` — 103 passed
- `RUSTUP_TOOLCHAIN=stable cargo clippy --locked --all-targets` — exit 0; only existing repository warnings remain
- Python receiver syntax check and bilingual documentation parity check passed
- local receiver: valid HMAC -> HTTP 204; tampered HMAC -> HTTP 401
- CubeAPI configured with `WEBHOOK_URLS` started successfully and `/health` returned HTTP 200

## Review note

Issue #642 currently has TencentCloud/CubeSandbox#872 open with another implementation. This PR is an independent implementation from the current upstream master for separate review.

Autonomously-by: Codex:GPT-5
