### PR TITLE
fix(helm): validate node registration via CubeMaster

### DIFF
--- a/deploy/kubernetes/chart/templates/tests/node-health.yaml
+++ b/deploy/kubernetes/chart/templates/tests/node-health.yaml
@@ -61,20 +61,27 @@ spec:
             *) api_base="http://${api_endpoint}" ;;
           esac
           curl --connect-timeout 5 --max-time 15 -fsS "${api_base%/}/health"
-
-          {{- if .Values.cubeNode.enabled }}
-          echo '[health-test] check node registration'
-          nodes_json="$(curl --connect-timeout 5 --max-time 15 -fsS "${api_base%/}/cubeapi/v1/nodes")"
-          printf '%s\n' "${nodes_json}"
-          healthy_nodes="$(printf '%s\n' "${nodes_json}" | grep -o '"healthy"[[:space:]]*:[[:space:]]*true' | wc -l | tr -d ' ')"
-          node_ids="$(printf '%s\n' "${nodes_json}" | grep -o '"nodeID"[[:space:]]*:' | wc -l | tr -d ' ')"
-          test "${healthy_nodes}" -ge 1
-          test "${node_ids}" -ge 1
-          {{- else }}
-          echo '[health-test] skip node registration: cubeNode.enabled=false'
-          {{- end }}
           {{- else }}
           echo '[health-test] skip CubeAPI: no internal API and externalControlPlane.apiEndpoint is empty'
+          {{- end }}
+
+          {{- if and .Values.cubeNode.enabled (or $internalMaster .Values.externalControlPlane.enabled) }}
+          echo '[health-test] check node registration via CubeMaster'
+          master_endpoint={{ include "cube.masterEndpoint" . | quote }}
+          case "${master_endpoint}" in
+            http://*|https://*) master_base="${master_endpoint}" ;;
+            *) master_base="http://${master_endpoint}" ;;
+          esac
+          nodes_json="$(curl --connect-timeout 5 --max-time 15 -fsS "${master_base%/}/internal/meta/nodes")"
+          printf '%s\n' "${nodes_json}"
+          healthy_nodes="$(printf '%s\n' "${nodes_json}" | grep -o '"healthy"[[:space:]]*:[[:space:]]*true' | wc -l | tr -d ' ')"
+          node_ids="$(printf '%s\n' "${nodes_json}" | grep -o '"node_id"[[:space:]]*:' | wc -l | tr -d ' ')"
+          test "${healthy_nodes}" -ge 1
+          test "${node_ids}" -ge 1
+          {{- else if .Values.cubeNode.enabled }}
+          echo '[health-test] skip node registration: no internal or external CubeMaster'
+          {{- else }}
+          echo '[health-test] skip node registration: cubeNode.enabled=false'
           {{- end }}
 
           {{- if and .Values.webui.enabled $internalOps }}


### PR DESCRIPTION
## Motivation

The Helm health test validates that CubeNode has registered successfully.

It still queried CubeAPI's removed `/cubeapi/v1/nodes` endpoint for that check, so `helm test` could fail even when CubeNode was registered and healthy.

Node listing is no longer served by CubeAPI. Using CubeOps for this health check would require administrator authentication, which the Chart does not have a stable identity for and should not depend on during Helm tests.

The registration check only needs control-plane node state, so CubeMaster's internal node metadata endpoint is the appropriate source.

## What Changed

* Query CubeMaster's `/internal/meta/nodes` endpoint for node registration state.
* Check CubeMaster's `node_id` response field.
* Keep the CubeAPI check limited to `/health`.
* Run node registration validation independently of CubeAPI availability.
* Preserve the existing `cubeNode.enabled=false` skip behavior.
* Skip node registration validation when no internal or external CubeMaster is configured.

## Validation

* Ran Helm lint with the same credential overrides used by the Kubernetes Chart CI workflow.
* Rendered the default Chart and confirmed:

  * `/internal/meta/nodes` is present
  * the response check uses `node_id`
  * `/cubeapi/v1/nodes` is absent
* Rendered with `controlPlane.api.enabled=false` and confirmed the CubeMaster node registration check is still present.
* Ran all Kubernetes Chart workflow guard scripts and startup-gate tests.
* Verified the deployed Chart on a two-node K3s cluster: all eight Helm test suites succeeded, including the health test using CubeMaster node metadata.

## Scope

This PR only updates the Helm node registration health test.

It does not change application APIs, add CubeOps authentication, use administrator credentials, or modify Chart metadata and image tags.
