### PR TITLE
fix(dev-sidecar): strip stale Content-Encoding after decompression

### DIFF
--- a/examples/e2b-dev-sidecar/dev_sidecar.py
+++ b/examples/e2b-dev-sidecar/dev_sidecar.py
@@ -27,6 +27,9 @@ HOP_BY_HOP_HEADERS = {
     "transfer-encoding",
     "upgrade",
 }
+# ClientSession auto-decompresses these by default but preserves the
+# upstream Content-Encoding response header.
+AUTO_DECOMPRESSED_ENCODINGS = {"deflate", "gzip"}
 WEBSOCKET_REQUEST_HEADERS = {
     hdrs.CONNECTION,
     hdrs.SEC_WEBSOCKET_ACCEPT,
@@ -164,9 +167,15 @@ async def _stream_http_proxy(
         allow_redirects=False,
     ) as upstream:
         response = web.StreamResponse(status=upstream.status, reason=upstream.reason)
+        content_encoding = upstream.headers.get(hdrs.CONTENT_ENCODING, "").lower()
         for key, value in upstream.headers.items():
             lowered = key.lower()
             if lowered in HOP_BY_HOP_HEADERS or lowered == "content-length":
+                continue
+            if (
+                lowered == "content-encoding"
+                and content_encoding in AUTO_DECOMPRESSED_ENCODINGS
+            ):
                 continue
             response.headers[key] = value
 

--- a/examples/e2b-dev-sidecar/test_dev_sidecar.py
+++ b/examples/e2b-dev-sidecar/test_dev_sidecar.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
+import gzip
 import importlib
 import json
 import os
 import sys
+import zlib
 from pathlib import Path
 
 import httpx
@@ -184,6 +186,101 @@ async def test_http_proxy_forwards_path_query_body_and_host(monkeypatch, dev_sid
             "path_qs": "/api/v1/run?hello=1",
             "body": "payload",
         }
+    finally:
+        await sidecar_runner.cleanup()
+        await upstream_runner.cleanup()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("path", "content_type"),
+    [
+        ("/files", "text/plain"),
+        ("/process.Process/Start", "application/connect+proto"),
+    ],
+    ids=["file", "connect"],
+)
+@pytest.mark.parametrize(
+    ("content_encoding", "compress"),
+    [("gzip", gzip.compress), ("deflate", zlib.compress)],
+    ids=["gzip", "deflate"],
+)
+async def test_http_proxy_removes_headers_for_auto_decompressed_response(
+    monkeypatch, dev_sidecar, path, content_type, content_encoding, compress
+):
+    payload = ("cube-sidecar-gzip-response\n" * 128).encode()
+    compressed_payload = compress(payload)
+
+    async def upstream_handler(_request: web.Request) -> web.Response:
+        return web.Response(
+            body=compressed_payload,
+            headers={
+                "Content-Encoding": content_encoding,
+                "Content-Length": str(len(compressed_payload)),
+                "Content-Type": content_type,
+            },
+        )
+
+    upstream = web.Application()
+    upstream.router.add_get("/{tail:.*}", upstream_handler)
+    upstream_runner, upstream_url = await _start_web_app(upstream)
+
+    monkeypatch.setenv("CUBE_REMOTE_PROXY_BASE", upstream_url)
+    monkeypatch.setenv("CUBE_REMOTE_SANDBOX_DOMAIN", "cube.app")
+    sidecar_runner, sidecar_url = await _start_web_app(dev_sidecar.build_app())
+
+    try:
+        async with httpx.AsyncClient(trust_env=False) as client:
+            response = await client.get(
+                f"{sidecar_url}/sandboxes/router/sbx-1/49983{path}"
+            )
+
+        assert response.status_code == 200
+        assert response.content == payload
+        assert "Content-Encoding" not in response.headers
+        assert "Content-Length" not in response.headers
+    finally:
+        await sidecar_runner.cleanup()
+        await upstream_runner.cleanup()
+
+
+@pytest.mark.asyncio
+async def test_http_proxy_preserves_unsupported_content_encoding(
+    monkeypatch, dev_sidecar
+):
+    payload = b"custom-encoded-response"
+
+    async def upstream_handler(_request: web.Request) -> web.Response:
+        return web.Response(
+            body=payload,
+            headers={
+                "Content-Encoding": "x-custom",
+                "Content-Length": str(len(payload)),
+                "Content-Type": "application/octet-stream",
+            },
+        )
+
+    upstream = web.Application()
+    upstream.router.add_get("/{tail:.*}", upstream_handler)
+    upstream_runner, upstream_url = await _start_web_app(upstream)
+
+    monkeypatch.setenv("CUBE_REMOTE_PROXY_BASE", upstream_url)
+    monkeypatch.setenv("CUBE_REMOTE_SANDBOX_DOMAIN", "cube.app")
+    sidecar_runner, sidecar_url = await _start_web_app(dev_sidecar.build_app())
+
+    try:
+        async with httpx.AsyncClient(trust_env=False) as client:
+            async with client.stream(
+                "GET", f"{sidecar_url}/sandboxes/router/sbx-1/8080/data"
+            ) as response:
+                response_body = b"".join(
+                    [chunk async for chunk in response.aiter_raw()]
+                )
+
+        assert response.status_code == 200
+        assert response.headers["Content-Encoding"] == "x-custom"
+        assert "Content-Length" not in response.headers
+        assert response_body == payload
     finally:
         await sidecar_runner.cleanup()
         await upstream_runner.cleanup()


### PR DESCRIPTION
## Motivation

The dev sidecar can currently forward an invalid response for gzip or deflate encoded upstream responses. `aiohttp.ClientSession` automatically decompresses the response body, but the sidecar keeps the original upstream `Content-Encoding` header. Downstream clients such as `httpx` then try to decompress the already-decoded body again. For gzip responses, this fails with:

```text
httpx.DecodingError: incorrect header check
```

This PR fixes the stale response header while keeping `aiohttp` automatic decompression enabled.

## Reproduction

Proxy a gzip-encoded response larger than CubeProxy's 1,000-byte gzip threshold through the dev sidecar, then read it with an automatically decoding client such as `httpx`.

Before this fix, the request deterministically fails with the decoding error above because the downstream client attempts to decompress bytes that `aiohttp` has already decoded.

## What Changed

* Stop forwarding stale upstream `Content-Encoding` for gzip and deflate responses that `aiohttp` has already decompressed.
* Continue omitting the upstream compressed `Content-Length`, since it no longer describes the forwarded response body.
* Preserve optional or unsupported `Content-Encoding` values when automatic decompression is not guaranteed.
* Add regression coverage for gzip- and deflate-encoded file and Connect responses larger than CubeProxy's gzip threshold.
* Verify that decoded responses have consistent headers and unsupported encodings remain intact.

## Validation

* Confirmed the regression test fails on the previous implementation with:

```text
httpx.DecodingError: incorrect header check
```

* Ran the current fixed dev-sidecar test file:

```text
12 passed
```

* Ran Python syntax compilation for the source and test files.
* Verified the updated sidecar against a K3s deployment using the official E2B SDK:

  * commands completed successfully
  * file write, existence check, read, and directory listing succeeded
  * code interpreter state and file access succeeded
  * signed download and upload URLs returned HTTP 200

## Scope

This PR only fixes HTTP response forwarding in `examples/e2b-dev-sidecar`.
