### PR TITLE
feat(python-sdk): expose distribution scope for sandbox creation

### DIFF
--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -106,6 +106,18 @@ sb.pause(timeout=60, interval=0.5) # custom poll params
 sb2 = Sandbox.connect(sb.sandbox_id)
 ```
 
+### Compute node placement
+
+Restrict scheduling to one or more compute node IDs or host IPs. A single
+entry pins the sandbox to that node; creation fails if the node cannot run the
+requested template.
+
+```python
+sb = Sandbox.create(
+    distribution_scope=["node-a"],
+)
+```
+
 ### Network policy
 
 Two layers can be combined inside `network=`:
@@ -320,7 +332,7 @@ with Sandbox.create(config=cfg) as sb:
 
 | Method | Description |
 |---|---|
-| `Sandbox.create(template, *, timeout, env_vars, envs, metadata, volume_mounts, config)` | `POST /sandboxes` — create a new sandbox (optionally mounting volumes); `envs` is the E2B-compatible alias for `env_vars` |
+| `Sandbox.create(template, *, timeout, env_vars, envs, metadata, distribution_scope, volume_mounts, config)` | `POST /sandboxes` — create a new sandbox (optionally restricted to specified compute nodes or mounting volumes); `envs` is the E2B-compatible alias for `env_vars` |
 | `Sandbox.connect(sandbox_id, *, config)` | `POST /sandboxes/:id/connect` — connect (auto-resumes if paused) |
 | `Sandbox.list(config)` | `GET /sandboxes` — list running sandboxes (v1) |
 | `Sandbox.list_v2(config)` | `GET /v2/sandboxes` — list sandboxes (v2) |

--- a/sdk/python/README.zh.md
+++ b/sdk/python/README.zh.md
@@ -105,6 +105,17 @@ sb.pause(timeout=60, interval=0.5) # 自定义轮询参数
 sb2 = Sandbox.connect(sb.sandbox_id)
 ```
 
+### 指定计算节点
+
+通过计算节点 ID 或 Host IP 限定调度范围。只传一个节点即可将沙箱固定到
+该节点；如果目标节点无法运行对应模板，创建会失败。
+
+```python
+sb = Sandbox.create(
+    distribution_scope=["node-a"],
+)
+```
+
 ### 网络策略
 
 `network=` 内部可以组合两个层次：
@@ -307,7 +318,7 @@ with Sandbox.create(config=cfg) as sb:
 
 | 方法 | 说明 |
 |---|---|
-| `Sandbox.create(template, *, timeout, env_vars, metadata, volume_mounts, config)` | `POST /sandboxes` — 创建新沙箱（可选挂载卷） |
+| `Sandbox.create(template, *, timeout, env_vars, metadata, distribution_scope, volume_mounts, config)` | `POST /sandboxes` — 创建新沙箱（可限定计算节点或挂载卷） |
 | `Sandbox.connect(sandbox_id, *, config)` | `POST /sandboxes/:id/connect` — 连接（暂停状态下自动恢复） |
 | `Sandbox.list(config)` | `GET /sandboxes` — 列出运行中沙箱（v1） |
 | `Sandbox.list_v2(config)` | `GET /v2/sandboxes` — 列出沙箱（v2） |

--- a/sdk/python/cubesandbox/sandbox.py
+++ b/sdk/python/cubesandbox/sandbox.py
@@ -190,6 +190,7 @@ class Sandbox:
         env_vars: Dict[str, str] | None = None,
         envs: Dict[str, str] | None = None,
         metadata: Dict[str, str] | None = None,
+        distribution_scope: list[str] | None = None,
         allow_internet_access: bool = True,
         network: Dict[str, Any] | None = None,
         lifecycle: Dict[str, Any] | None = None,
@@ -207,6 +208,8 @@ class Sandbox:
             envs: E2B-compatible alias for ``env_vars``. When both aliases are
                 provided, they must contain the same values.
             metadata: Arbitrary key-value metadata (e.g. network-policy, host-mount).
+            distribution_scope: Compute node IDs or host IPs eligible to run the
+                sandbox. Pass a single entry to pin the sandbox to one node.
             allow_internet_access: When ``False``, the sandbox is blocked from
                 making outbound traffic to the public internet.
             network: Egress network policy. Accepts keys:
@@ -279,6 +282,8 @@ class Sandbox:
             payload["envVars"] = sandbox_env_vars
         if metadata:
             payload["metadata"] = metadata
+        if distribution_scope:
+            payload["distributionScope"] = distribution_scope
         if not allow_internet_access:
             payload["allow_internet_access"] = False
         if network:

--- a/sdk/python/tests/test_sandbox.py
+++ b/sdk/python/tests/test_sandbox.py
@@ -168,6 +168,19 @@ class TestCreate:
         body = m.call_args.kwargs["json"]
         assert body["metadata"] == meta
 
+    def test_create_sends_distribution_scope(self):
+        scope = ["node-a", "10.0.0.12"]
+        with patch("requests.Session.post", return_value=mock_response(SANDBOX_DATA, status=201)) as m:
+            Sandbox.create(distribution_scope=scope, config=make_config())
+        body = m.call_args.kwargs["json"]
+        assert body["distributionScope"] == scope
+
+    def test_create_default_distribution_scope_omitted(self):
+        with patch("requests.Session.post", return_value=mock_response(SANDBOX_DATA, status=201)) as m:
+            Sandbox.create(config=make_config())
+        body = m.call_args.kwargs["json"]
+        assert "distributionScope" not in body
+
     def test_create_template_not_found(self):
         with patch("requests.Session.post",
                    return_value=mock_response({"message": "template not found"}, status=404)):


### PR DESCRIPTION
CubeAPI already supports restricting sandbox placement through the distributionScope field, but the Python SDK only allowed it to be passed implicitly through **kwargs.

Add an explicit distribution_scope parameter to Sandbox.create(), map it to the backend distributionScope field.