### PR TITLE
fix(volume): fail COS create/attach when backend rejects credentials

### DIFF
--- a/examples/volume/cos/binary/cube-volume-cos.sh
+++ b/examples/volume/cos/binary/cube-volume-cos.sh
@@ -148,14 +148,30 @@ coscmd_run() {
     coscmd "$@"
 }
 
+# coscmd sometimes exits 0 while printing an XML/JSON error body. Treat those
+# as failure so Create does not report success when COS rejected the upload.
+coscmd_output_indicates_failure() {
+    printf '%s' "$1" | grep -qiE \
+        '<Error>|InvalidAccessKeyId|AccessDenied|AccessDeniedError|Upload file failed|SignatureDoesNotMatch|NoSuchBucket|403 Forbidden'
+}
+
 # Upload a tiny .keep file so the volume folder exists in COS before first mount.
+# Propagates coscmd failures (exit code and soft-fail stdout/stderr) to the caller.
 cos_create_dir() {
     local volume_id="$1"
     log "coscmd: create $(cos_subdir "$volume_id")/.keep"
-    local tmpfile
+    local tmpfile out rc=0
     tmpfile="$(mktemp)"
-    coscmd_run upload "$tmpfile" "$(cos_subdir "$volume_id")/.keep"
+    set +e
+    out="$(coscmd_run upload "$tmpfile" "$(cos_subdir "$volume_id")/.keep" 2>&1)"
+    rc=$?
+    set -e
     rm -f "$tmpfile"
+    if [[ "$rc" -ne 0 ]] || coscmd_output_indicates_failure "$out"; then
+        log "ERROR: coscmd create failed for ${volume_id}: ${out}"
+        return 1
+    fi
+    return 0
 }
 
 # Recursively delete the volume folder from COS (destroy hook).
@@ -200,13 +216,23 @@ cosfs_mount_volume() {
 
     mkdir -p "$mnt"
     log "cosfs: mounting ${BUCKET}:/$(cos_subdir "$volume_id") -> ${mnt}"
-    cosfs "${BUCKET}:/$(cos_subdir "$volume_id")" "$mnt" \
+    local out rc=0
+    set +e
+    out="$(cosfs "${BUCKET}:/$(cos_subdir "$volume_id")" "$mnt" \
         "-ourl=${endpoint}"            \
         "-opasswd_file=${PASSWD_FILE}" \
         "-oallow_other"                \
         "-ononempty"                   \
         "-odbglevel=info"              \
-        "-onoxattr"
+        "-onoxattr" 2>&1)"
+    rc=$?
+    set -e
+    # cosfs may exit 0 even when auth fails; require a real mountpoint.
+    if [[ "$rc" -ne 0 ]] || ! mountpoint -q "$mnt" 2>/dev/null; then
+        log "ERROR: cosfs mount failed for ${volume_id}: ${out}"
+        rmdir "$mnt" 2>/dev/null || true
+        return 1
+    fi
     log "cosfs: mounted ok"
 }
 

--- a/examples/volume/cos/binary/test_create_error.sh
+++ b/examples/volume/cos/binary/test_create_error.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (C) 2026 Tencent. All rights reserved.
+#
+# Verifies create returns non-zero + error JSON when coscmd upload soft-fails
+# (exit 0 with an error body) — the failure mode seen with bad SECRET_ID.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PLUGIN="${SCRIPT_DIR}/cube-volume-cos.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf "${TMP}"' EXIT
+
+mkdir -p "${TMP}/bin"
+cat >"${TMP}/bin/coscmd" <<'EOF'
+#!/usr/bin/env bash
+# Soft-fail: exit 0 while printing the error body coscmd emits on bad keys.
+if [[ "${1:-}" == "config" ]]; then
+  exit 0
+fi
+cat <<'ERR'
+Upload /tmp/x => cos://bucket/volumes/v/.keep
+<?xml version='1.0' encoding='utf-8' ?>
+<Error>
+	<Code>InvalidAccessKeyId</Code>
+	<Message>The access key Id format you provided is invalid.</Message>
+</Error>
+Upload file failed
+ERR
+exit 0
+EOF
+chmod +x "${TMP}/bin/coscmd"
+
+cat >"${TMP}/volume-cos.conf" <<'EOF'
+SECRET_ID=not-a-real-key
+SECRET_KEY=not-a-real-secret
+BUCKET=examplebucket-1250000000
+REGION=ap-guangzhou
+EOF
+
+export PATH="${TMP}/bin:${PATH}"
+export CUBE_COS_CONFIG="${TMP}/volume-cos.conf"
+
+set +e
+out="$("${PLUGIN}" --op create --volume-id test-vol --name test-vol 2>/dev/null)"
+rc=$?
+set -e
+
+if [[ "$rc" -eq 0 ]]; then
+  echo "FAIL: create exited 0 on coscmd soft-failure; stdout=${out}" >&2
+  exit 1
+fi
+if ! printf '%s' "$out" | grep -q '"error"'; then
+  echo "FAIL: expected error JSON; stdout=${out}" >&2
+  exit 1
+fi
+if printf '%s' "$out" | grep -q '"error":""'; then
+  echo "FAIL: error field empty; stdout=${out}" >&2
+  exit 1
+fi
+
+echo "ok: create fails when coscmd soft-fails (rc=${rc})"

--- a/examples/volume/cos/rpc/internal/cosfs/mount.go
+++ b/examples/volume/cos/rpc/internal/cosfs/mount.go
@@ -83,8 +83,17 @@ func (m *Manager) Mount(baseDir, volumeID string) (string, error) {
 		"-odbglevel=info",
 		"-onoxattr",
 	)
-	if out, err := cmd.CombinedOutput(); err != nil {
+	out, err := cmd.CombinedOutput()
+	if err != nil {
 		return "", fmt.Errorf("cosfs mount %s: %w: %s", mnt, err, string(out))
+	}
+	// cosfs may exit 0 even when auth fails; require a real mountpoint.
+	mounted, merr := isMountPoint(mnt)
+	if merr != nil {
+		return "", merr
+	}
+	if !mounted {
+		return "", fmt.Errorf("cosfs mount %s: process exited 0 but path is not a mountpoint: %s", mnt, string(out))
 	}
 	return mnt, nil
 }


### PR DESCRIPTION
## Summary
- Binary COS plugin `create` now fails when `coscmd upload` soft-fails (exit 0 + error body such as `InvalidAccessKeyId`), so CubeMaster does not persist a volume that never landed in COS.
- Binary `attach` requires a real FUSE mountpoint after `cosfs` (same soft-fail class).
- RPC `cosfs.Mount` likewise verifies the path is mounted after a zero exit.
- Adds `examples/volume/cos/binary/test_create_error.sh` covering the create soft-fail path.

## Test plan
- [x] `examples/volume/cos/binary/test_create_error.sh`
- [x] `go test ./internal/cosfs/` under `examples/volume/cos/rpc`
- [ ] With bad `SECRET_ID`, `POST /volumes` returns an error (not 201)
- [ ] With valid credentials, create + attach still succeed

Assisted-by: Cursor:Composer
Signed-off-by: ls-ggg <lishuai@tencent.com>

Made with [Cursor](https://cursor.com)