### PR TITLE
fix(ci): restrict build-vmlinux push trigger to branches and v* release tags

### DIFF
--- a/.github/workflows/build-vmlinux.yml
+++ b/.github/workflows/build-vmlinux.yml
@@ -3,6 +3,13 @@ run-name: Build vmlinux ${{ inputs.kernel_arch || 'all' }}
 
 on:
   push:
+    # Restrict to branch pushes + release tags (v*). Without branches/tags,
+    # any tag push (e.g. python-sdk-v*, go-sdk-v*) would also trigger, and
+    # path filters are not evaluated for tag pushes.
+    branches:
+      - '**'
+    tags:
+      - 'v*'
     paths:
       - 'configs/kernel-oc9.aarch64.config'
       - 'configs/kernel-oc9.x86_64.config'


### PR DESCRIPTION
## Summary

Fix the GitHub Actions push trigger in `build-vmlinux.yml` to prevent unintended workflow runs.

## Problem

Without explicit `branches`/`tags` filters, any tag push (e.g. `python-sdk-v*`, `go-sdk-v*`) would also trigger this workflow, because GitHub Actions path filters are not evaluated for tag events.

## Solution

Add explicit trigger filters:
- `branches: ['**']` — trigger on branch pushes as before
- `tags: ['v*']` — only trigger on release version tags

This keeps the existing path filter intact for branch pushes while preventing non-vmlinux-related tag pushes from triggering this workflow.