### PR TITLE
feat(cubeapi): add webhook event delivery and integration docs

### DIFF
--- a/CubeAPI/Cargo.lock
+++ b/CubeAPI/Cargo.lock
@@ -533,9 +533,12 @@ dependencies = [
  "dotenvy",
  "futures",
  "governor",
+ "hex",
+ "hmac",
  "reqwest",
  "serde",
  "serde_json",
+ "sha2",
  "thiserror 1.0.69",
  "tokio",
  "tower 0.4.13",
@@ -589,6 +592,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -915,6 +919,21 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
 
 [[package]]
 name = "http"

--- a/CubeAPI/Cargo.toml
+++ b/CubeAPI/Cargo.toml
@@ -81,6 +81,11 @@ async-trait = "0.1"
 clap = { version = "4", features = ["derive"] }
 utoipa = { version = "5.4.0", features = ["chrono", "uuid", "yaml"] }
 
+# ── Webhook signature (HMAC-SHA256) ────────────────────────────────────────
+hmac = "0.12"
+sha2 = "0.10"
+hex = "0.4"
+
 # ── Graceful shutdown ─────────────────────────────────────────────────────
 # (tokio::signal + axum::serve().with_graceful_shutdown is sufficient)
 

--- a/CubeAPI/examples/readme.md
+++ b/CubeAPI/examples/readme.md
@@ -6,3 +6,4 @@ See the top-level [examples/](../../examples/) directory for standalone, runnabl
 - [network-policy](../../examples/network-policy/) — control outbound network access
 - [browser-sandbox](../../examples/browser-sandbox/) — Playwright browser automation via CDP
 - [code-sandbox-quickstart](../../examples/code-sandbox-quickstart/) — basic sandbox operations
+- [webhook-receiver](../../examples/webhook-receiver/) — receive and inspect sandbox lifecycle events

--- a/CubeAPI/rust-toolchain.toml
+++ b/CubeAPI/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.85"
+channel = "stable"

--- a/CubeAPI/src/config/mod.rs
+++ b/CubeAPI/src/config/mod.rs
@@ -76,6 +76,39 @@ pub struct ServerConfig {
     /// Env var: CUBE_API_KEY
     #[serde(default)]
     pub cube_api_key: Option<String>,
+
+    /// Webhook target URLs, comma-separated.
+    ///
+    /// When set, sandbox lifecycle events are POSTed to these URLs as JSON.
+    /// Multiple URLs can be specified: "https://hook.a.com,https://hook.b.com"
+    /// All URLs receive the same events (filtered by `webhook_events`).
+    ///
+    /// Env var: CUBE_API_WEBHOOK_URLS
+    #[serde(default = "default_webhook_urls")]
+    pub webhook_urls: String,
+
+    /// Webhook event type filter, comma-separated.
+    ///
+    /// Specifies which events trigger webhook delivery. Supported values:
+    ///   sandbox.created, sandbox.deleted, sandbox.paused, sandbox.resumed
+    /// Use "*" or leave empty to receive all events.
+    ///
+    /// Example: "sandbox.created,sandbox.deleted" receives only create/delete.
+    ///
+    /// Env var: CUBE_API_WEBHOOK_EVENTS (default: "*")
+    #[serde(default = "default_webhook_events")]
+    pub webhook_events: String,
+
+    /// Optional HMAC-SHA256 secret key for webhook payload signing.
+    ///
+    /// When set, every webhook POST includes a `X-Cube-Signature-256` header:
+    ///   sha256=<hex-encoded-hmac>
+    /// The receiver verifies the signature to confirm the payload is from CubeAPI
+    /// and has not been tampered with.
+    ///
+    /// Env var: CUBE_API_WEBHOOK_SECRET
+    #[serde(default = "default_webhook_secret")]
+    pub webhook_secret: Option<String>,
 }
 
 fn default_bind() -> String {
@@ -110,6 +143,18 @@ fn default_log_prefix() -> String {
     "cube-api".to_string()
 }
 
+fn default_webhook_urls() -> String {
+    std::env::var("CUBE_API_WEBHOOK_URLS").unwrap_or_default()
+}
+
+fn default_webhook_events() -> String {
+    std::env::var("CUBE_API_WEBHOOK_EVENTS").unwrap_or_else(|_| "*".to_string())
+}
+
+fn default_webhook_secret() -> Option<String> {
+    std::env::var("CUBE_API_WEBHOOK_SECRET").ok().filter(|s| !s.is_empty())
+}
+
 impl ServerConfig {
     pub fn from_env() -> anyhow::Result<Self> {
         let _ = dotenvy::dotenv();
@@ -135,6 +180,9 @@ impl Default for ServerConfig {
             log_prefix: default_log_prefix(),
             auth_callback_url: None,
             cube_api_key: std::env::var("CUBE_API_KEY").ok().filter(|s| !s.is_empty()),
+            webhook_urls: default_webhook_urls(),
+            webhook_events: default_webhook_events(),
+            webhook_secret: std::env::var("CUBE_API_WEBHOOK_SECRET").ok().filter(|s| !s.is_empty()),
         }
     }
 }

--- a/CubeAPI/src/logging/http.rs
+++ b/CubeAPI/src/logging/http.rs
@@ -1,84 +1,714 @@
 // Copyright (c) 2024 Tencent Inc.
 // SPDX-License-Identifier: Apache-2.0
 //
+//! Webhook event delivery backend — sends log events as JSON POST requests
+//! to configured HTTP endpoints.
+//!
+//! # Features
+//!
+//! - Multiple target URLs (comma-separated config), all receiving the same events
+//! - Event type filtering (comma-separated list or `*` for all)
+//! - HMAC-SHA256 payload signing via `X-Cube-Signature-256` header
+//! - Exponential backoff retry (3 attempts: 200 ms → 500 ms → 1 s)
+//! - Non-blocking delivery via `tokio::spawn` — never blocks the caller
+//!
+//! # Configuration
+//!
+//! See [`crate::config::ServerConfig`] fields:
+//! - `webhook_urls` — target URLs, comma-separated
+//! - `webhook_events` — event type filter, comma-separated (default: `*`)
+//! - `webhook_secret` — optional HMAC key for payload signing
 
-//! HTTP webhook log backend — stub.
-//!
-//! Sends log events as JSON POST requests to a configurable endpoint.
-//! Useful for forwarding to log aggregators (Elasticsearch, Loki, custom
-//! ingest APIs) that accept HTTP.
-//!
-//! # TODO (wire-up checklist)
-//!
-//! 1. Add `http_log_url: Option<String>` to `ServerConfig`.
-//! 2. Construct `HttpLogger::new(client, url, batch_size, flush_interval)`.
-//! 3. Register it in `AppState::new()` inside `MultiLogger`.
-//!
-//! # Batching strategy (suggested)
-//!
-//! Buffer events into a `Vec<LogEvent>` and POST when either:
-//! - The buffer reaches `batch_size` (default 100), or
-//! - A ticker fires every `flush_interval` (default 5 s).
-//!
-//! Use `tokio::select!` in the background task to wait on whichever fires
-//! first.
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+use hmac::{Hmac, Mac};
+use serde::Serialize;
+use sha2::Sha256;
+use std::collections::HashMap;
+use std::time::Duration;
 
 use super::{LogEvent, Logger};
-use async_trait::async_trait;
 
-/// Configuration for the HTTP webhook backend.
-#[derive(Debug, Clone)]
-#[allow(dead_code)]
-pub struct HttpLoggerConfig {
-    /// Full URL to POST batches to, e.g. `"http://log-ingest.internal/api/logs"`.
-    pub url: String,
-    /// Max events per batch (default: 100).
-    pub batch_size: usize,
-    /// Flush interval in seconds even if batch is not full (default: 5).
-    pub flush_interval_secs: u64,
+/// HMAC-SHA256 type alias.
+type HmacSha256 = Hmac<Sha256>;
+
+/// Retry delays (exponential backoff): 200 ms → 500 ms → 1 s.
+const RETRY_DELAYS: [Duration; 3] = [
+    Duration::from_millis(200),
+    Duration::from_millis(500),
+    Duration::from_secs(1),
+];
+
+/// Maximum retry attempts.
+const MAX_RETRIES: usize = RETRY_DELAYS.len();
+
+// ─── Payload ────────────────────────────────────────────────────────────
+
+/// JSON payload sent to each webhook endpoint.
+#[derive(Debug, Serialize)]
+pub struct WebhookPayload {
+    /// Event type, e.g. `"sandbox.created"`.
+    pub event: String,
+    /// ISO 8601 timestamp of when the event was generated.
+    pub timestamp: DateTime<Utc>,
+    /// Sandbox identifier, if applicable.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sandbox_id: Option<String>,
+    /// Template identifier, if applicable.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub template_id: Option<String>,
+    /// Additional context fields flattened into the payload.
+    #[serde(flatten)]
+    pub fields: HashMap<String, serde_json::Value>,
 }
 
-impl Default for HttpLoggerConfig {
-    fn default() -> Self {
-        Self {
-            url: String::new(),
-            batch_size: 100,
-            flush_interval_secs: 5,
-        }
-    }
-}
+// ─── Logger ─────────────────────────────────────────────────────────────
 
-/// HTTP webhook log backend (stub — not yet implemented).
+/// Webhook log backend — delivers events to HTTP endpoints asynchronously.
+///
+/// All configured URLs receive the same events, filtered by the event-type
+/// list.  Creation is O(1) and the struct is cheap to clone.
 #[derive(Clone)]
 pub struct HttpLogger {
-    #[allow(dead_code)]
-    config: HttpLoggerConfig,
+    client: reqwest::Client,
+    urls: Vec<String>,
+    /// Parsed event filter. Empty or contains `"*"` = match all.
+    events: Vec<String>,
+    /// Optional HMAC-SHA256 key (raw bytes).
+    secret: Option<Vec<u8>>,
 }
 
 impl HttpLogger {
-    /// Create an `HttpLogger`.  Currently a no-op; implement the background
-    /// task described in the module doc when ready.
-    #[allow(dead_code)]
-    pub fn new(config: HttpLoggerConfig) -> Self {
-        Self { config }
+    /// Create a new `HttpLogger` from config fields.
+    ///
+    /// Returns `None` when no URLs are configured (no-op, nothing to deliver).
+    pub fn new(urls: &str, events: &str, secret: Option<&str>) -> Option<Self> {
+        let url_list: Vec<String> = urls
+            .split(',')
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .map(String::from)
+            .collect();
+        if url_list.is_empty() {
+            return None;
+        }
+
+        let client = reqwest::Client::builder()
+            .timeout(Duration::from_secs(10))
+            .build()
+            .expect("HttpLogger HTTP client should build");
+
+        let event_list: Vec<String> = events
+            .split(',')
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .map(String::from)
+            .collect();
+
+        let key = secret.and_then(|s| {
+            let t = s.trim();
+            if t.is_empty() {
+                None
+            } else {
+                Some(t.as_bytes().to_vec())
+            }
+        });
+
+        Some(Self {
+            client,
+            urls: url_list,
+            events: event_list,
+            secret: key,
+        })
+    }
+
+    /// Check whether an event name should trigger webhook delivery.
+    fn matches(&self, event: &str) -> bool {
+        self.events.is_empty()
+            || self.events.iter().any(|e| e == "*" || e == event)
+    }
+
+    /// Build a `WebhookPayload` from a `LogEvent`.
+    fn build_payload(&self, event: &LogEvent) -> WebhookPayload {
+        let sandbox_id = event
+            .fields
+            .get("sandbox_id")
+            .and_then(|v| v.as_str())
+            .map(String::from);
+
+        let template_id = event
+            .fields
+            .get("template_id")
+            .and_then(|v| v.as_str())
+            .map(String::from);
+
+        WebhookPayload {
+            event: event.event.clone(),
+            timestamp: event.timestamp,
+            sandbox_id,
+            template_id,
+            fields: event.fields.clone(),
+        }
+    }
+
+    /// Compute HMAC-SHA256 signature of the raw JSON body.
+    fn sign(&self, body: &[u8]) -> Option<String> {
+        let key = self.secret.as_ref()?;
+        let mut mac = HmacSha256::new_from_slice(key).ok()?;
+        mac.update(body);
+        let result = mac.finalize();
+        let code = result.into_bytes();
+        Some(hex::encode(code))
+    }
+
+    /// Deliver a payload to a single URL with exponential-backoff retry.
+    async fn deliver(
+        client: reqwest::Client,
+        url: String,
+        body: Vec<u8>,
+        signature: Option<String>,
+        event: String,
+    ) {
+        let mut last_error = String::new();
+
+        for attempt in 0..MAX_RETRIES {
+            let mut req = client
+                .post(&url)
+                .header("Content-Type", "application/json");
+
+            if let Some(ref sig) = signature {
+                req = req.header("X-Cube-Signature-256", format!("sha256={}", sig));
+            }
+
+            match req.body(body.clone()).send().await {
+                Ok(resp) if resp.status().is_success() => {
+                    tracing::debug!(
+                        url = %url,
+                        event = %event,
+                        "webhook: delivered successfully"
+                    );
+                    return;
+                }
+                Ok(resp) => {
+                    last_error = format!("HTTP {}", resp.status());
+                    tracing::warn!(
+                        url = %url,
+                        event = %event,
+                        attempt = attempt + 1,
+                        status = %resp.status(),
+                        "webhook: delivery failed, will retry"
+                    );
+                }
+                Err(e) => {
+                    last_error = e.to_string();
+                    tracing::warn!(
+                        url = %url,
+                        event = %event,
+                        attempt = attempt + 1,
+                        error = %e,
+                        "webhook: request failed, will retry"
+                    );
+                }
+            }
+
+            if attempt < MAX_RETRIES - 1 {
+                tokio::time::sleep(RETRY_DELAYS[attempt]).await;
+            }
+        }
+
+        tracing::error!(
+            url = %url,
+            event = %event,
+            error = %last_error,
+            "webhook: all retry attempts exhausted, giving up"
+        );
     }
 }
 
 #[async_trait]
 impl Logger for HttpLogger {
-    async fn log(&self, _event: LogEvent) {
-        // TODO: send to internal channel; background task batches + POSTs.
-        // Example batch payload:
-        // POST config.url
-        // Content-Type: application/json
-        // Body: { "events": [ <LogEvent>, ... ] }
+    async fn log(&self, event: LogEvent) {
+        let event_name = event.event.clone();
+
+        if !self.matches(&event_name) {
+            return;
+        }
+
+        let payload = self.build_payload(&event);
+        let body = match serde_json::to_vec(&payload) {
+            Ok(b) => b,
+            Err(e) => {
+                tracing::error!(
+                    error = %e,
+                    event = %event_name,
+                    "webhook: failed to serialize payload"
+                );
+                return;
+            }
+        };
+
+        let signature = self.sign(&body);
+
+        for url in &self.urls {
+            let client = self.client.clone();
+            let url = url.clone();
+            let body = body.clone();
+            let sig = signature.clone();
+            let ev = event_name.clone();
+
+            tokio::spawn(async move {
+                Self::deliver(client, url, body, sig, ev).await;
+            });
+        }
     }
 
     async fn flush(&self) {
-        // TODO: drain the buffer and send the final batch.
+        // Fire-and-forget delivery; no buffering to flush.
     }
 
     fn name(&self) -> &'static str {
         "http"
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Tests
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::logging::LogLevel;
+    use axum::http::StatusCode;
+    use axum::routing::post;
+    use axum::Router;
+    use chrono::TimeZone;
+    use serde_json::json;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::{Arc, Mutex};
+
+    // ── Helpers ──────────────────────────────────────────────────────────
+
+    /// Build a minimal HttpLogger with a single target URL.
+    fn logger_with(url: &str, events: Vec<&str>, secret: Option<&str>) -> HttpLogger {
+        HttpLogger::new(url, &events.join(","), secret).unwrap()
+    }
+
+    /// Start a mock HTTP server that captures request info, then returns
+    /// the given status code.  Returns (URL, request_counter, received_bodies).
+    async fn mock_server(
+        status: StatusCode,
+    ) -> (String, Arc<AtomicUsize>, Arc<Mutex<Vec<(Vec<u8>, Vec<(String, String)>)>>>) {
+        let counter = Arc::new(AtomicUsize::new(0));
+        let received = Arc::new(Mutex::new(Vec::new()));
+        let c = counter.clone();
+        let r = received.clone();
+
+        let app = Router::new().route(
+            "/webhook",
+            post(move |headers: axum::http::HeaderMap, body: axum::body::Bytes| async move {
+                c.fetch_add(1, Ordering::SeqCst);
+                let headers: Vec<(String, String)> = headers
+                    .iter()
+                    .map(|(k, v)| (k.to_string(), v.to_str().unwrap_or("").to_string()))
+                    .collect();
+                r.lock().unwrap().push((body.to_vec(), headers));
+                StatusCode::OK
+            }),
+        );
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let url = format!("http://{addr}/webhook");
+
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+
+        // Give the server a moment to start
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+        (url, counter, received)
+    }
+
+    // ── Payload serialization ────────────────────────────────────────────
+
+    #[test]
+    fn payload_serializes_basic_fields() {
+        let ts = Utc.with_ymd_and_hms(2026, 7, 24, 12, 0, 0).unwrap();
+        let payload = WebhookPayload {
+            event: "sandbox.created".into(),
+            timestamp: ts,
+            sandbox_id: Some("sb-123".into()),
+            template_id: Some("tpl-python".into()),
+            fields: HashMap::new(),
+        };
+
+        let json = serde_json::to_value(&payload).unwrap();
+        assert_eq!(json["event"], "sandbox.created");
+        assert_eq!(json["sandbox_id"], "sb-123");
+        assert_eq!(json["template_id"], "tpl-python");
+        assert!(json.get("timestamp").is_some());
+        // "fields" is flattened and should be absent when empty
+        assert!(json.get("fields").is_none());
+    }
+
+    #[test]
+    fn payload_omits_optional_fields_when_none() {
+        let ts = Utc.with_ymd_and_hms(2026, 7, 24, 12, 0, 0).unwrap();
+        let payload = WebhookPayload {
+            event: "api.response".into(),
+            timestamp: ts,
+            sandbox_id: None,
+            template_id: None,
+            fields: HashMap::new(),
+        };
+
+        let json = serde_json::to_value(&payload).unwrap();
+        assert_eq!(json["event"], "api.response");
+        assert!(json.get("sandbox_id").is_none());
+        assert!(json.get("template_id").is_none());
+    }
+
+    #[test]
+    fn payload_fields_are_flattened() {
+        let ts = Utc.with_ymd_and_hms(2026, 7, 24, 12, 0, 0).unwrap();
+        let mut fields = HashMap::new();
+        fields.insert("timeout".into(), json!(3600));
+        let payload = WebhookPayload {
+            event: "sandbox.timeout.updated".into(),
+            timestamp: ts,
+            sandbox_id: Some("sb-123".into()),
+            template_id: None,
+            fields,
+        };
+
+        let json = serde_json::to_value(&payload).unwrap();
+        assert_eq!(json["timeout"], 3600);
+    }
+
+    // ── Signature computation ────────────────────────────────────────────
+
+    #[test]
+    fn sign_returns_none_without_secret() {
+        let logger = HttpLogger::new("http://localhost:9999/webhook", "*", None).unwrap();
+        assert!(logger.sign(b"hello").is_none());
+    }
+
+    #[test]
+    fn sign_returns_expected_hex() {
+        let logger =
+            HttpLogger::new("http://localhost:9999/webhook", "*", Some("secret")).unwrap();
+        let sig = logger.sign(b"hello").unwrap();
+        // HMAC-SHA256("secret", "hello") hex
+        let expected = {
+            use hmac::Mac;
+            let mut mac =
+                HmacSha256::new_from_slice(b"secret").unwrap();
+            mac.update(b"hello");
+            hex::encode(mac.finalize().into_bytes())
+        };
+        assert_eq!(sig, expected);
+        // Verify it's lowercase hex
+        assert!(sig.chars().all(|c| c.is_ascii_hexdigit()));
+        assert_eq!(sig, sig.to_lowercase());
+    }
+
+    #[test]
+    fn sign_produces_different_output_for_different_body() {
+        let logger =
+            HttpLogger::new("http://localhost:9999/webhook", "*", Some("secret")).unwrap();
+        let sig1 = logger.sign(b"body-a").unwrap();
+        let sig2 = logger.sign(b"body-b").unwrap();
+        assert_ne!(sig1, sig2);
+    }
+
+    #[test]
+    fn sign_produces_different_output_for_different_secret() {
+        let logger1 =
+            HttpLogger::new("http://localhost:9999/webhook", "*", Some("key-a")).unwrap();
+        let logger2 =
+            HttpLogger::new("http://localhost:9999/webhook", "*", Some("key-b")).unwrap();
+        let sig1 = logger1.sign(b"same-body").unwrap();
+        let sig2 = logger2.sign(b"same-body").unwrap();
+        assert_ne!(sig1, sig2);
+    }
+
+    // ── Event name matching ──────────────────────────────────────────────
+
+    #[test]
+    fn matches_accepts_all_with_wildcard() {
+        let logger = logger_with("http://localhost:1/w", vec!["*"], None);
+        assert!(logger.matches("sandbox.created"));
+        assert!(logger.matches("sandbox.deleted"));
+        assert!(logger.matches("api.response"));
+        assert!(logger.matches("anything.else"));
+    }
+
+    #[test]
+    fn matches_filters_by_exact_event_name() {
+        let logger = logger_with("http://localhost:1/w", vec!["sandbox.created"], None);
+        assert!(logger.matches("sandbox.created"));
+        assert!(!logger.matches("sandbox.deleted"));
+        assert!(!logger.matches("api.response"));
+    }
+
+    #[test]
+    fn matches_supports_multiple_events() {
+        let logger =
+            logger_with("http://localhost:1/w", vec!["sandbox.created", "sandbox.deleted"], None);
+        assert!(logger.matches("sandbox.created"));
+        assert!(logger.matches("sandbox.deleted"));
+        assert!(!logger.matches("sandbox.paused"));
+    }
+
+    #[test]
+    fn matches_accepts_all_when_events_list_empty() {
+        // When no events are configured, the Vec is empty and `matches` returns true
+        // (empty means "no filter").
+        let logger = HttpLogger {
+            client: reqwest::Client::new(),
+            urls: vec!["http://localhost:1/w".into()],
+            events: vec![],
+            secret: None,
+        };
+        assert!(logger.matches("sandbox.created"));
+        assert!(logger.matches("anything"));
+    }
+
+    // ── Build payload from LogEvent ──────────────────────────────────────
+
+    #[test]
+    fn build_payload_maps_log_event_fields() {
+        let logger = logger_with("http://localhost:1/w", vec!["*"], None);
+
+        let mut fields = HashMap::new();
+        fields.insert("sandbox_id".into(), json!("sb-456"));
+        fields.insert("template_id".into(), json!("tpl-go"));
+        fields.insert("extra".into(), json!(42));
+
+        let event = LogEvent {
+            timestamp: Utc.with_ymd_and_hms(2026, 7, 24, 12, 0, 0).unwrap(),
+            level: LogLevel::Info,
+            event: "sandbox.created".into(),
+            fields,
+        };
+
+        let payload = logger.build_payload(&event);
+        assert_eq!(payload.event, "sandbox.created");
+        assert_eq!(payload.sandbox_id.as_deref(), Some("sb-456"));
+        assert_eq!(payload.template_id.as_deref(), Some("tpl-go"));
+        assert_eq!(payload.fields.get("extra").and_then(|v| v.as_i64()), Some(42));
+    }
+
+    // ── HTTP delivery (with mock server) ─────────────────────────────────
+
+    #[tokio::test]
+    async fn deliver_sends_event_to_mock_server() {
+        let (url, _counter, received) = mock_server(StatusCode::OK).await;
+
+        let logger = logger_with(&url, vec!["*"], None);
+        let event = LogEvent::new(LogLevel::Info, "sandbox.created")
+            .field("sandbox_id", "sb-777");
+
+        logger.log(event).await;
+
+        // Allow async delivery to complete
+        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+
+        let received = received.lock().unwrap();
+        assert_eq!(received.len(), 1, "should receive exactly one request");
+
+        let (body, headers) = &received[0];
+        let payload: serde_json::Value = serde_json::from_slice(body).unwrap();
+        assert_eq!(payload["event"], "sandbox.created");
+        assert_eq!(payload["sandbox_id"], "sb-777");
+
+        // Content-Type should be JSON
+        let has_json_ct = headers.iter().any(|(k, v)| {
+            k == "content-type" && v.starts_with("application/json")
+        });
+        assert!(has_json_ct, "should have application/json content-type");
+    }
+
+    #[tokio::test]
+    async fn deliver_includes_signature_header_when_secret_is_set() {
+        let (url, _counter, received) = mock_server(StatusCode::OK).await;
+
+        let logger = logger_with(&url, vec!["*"], Some("shared-secret"));
+        let event = LogEvent::new(LogLevel::Info, "sandbox.created")
+            .field("sandbox_id", "sb-888");
+
+        logger.log(event).await;
+        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+
+        let received = received.lock().unwrap();
+        assert_eq!(received.len(), 1);
+
+        let (_body, headers) = &received[0];
+        let sig_header = headers.iter().find(|(k, _)| k == "x-cube-signature-256");
+        assert!(sig_header.is_some(), "should include signature header");
+        let (_, sig_value) = sig_header.unwrap();
+        assert!(sig_value.starts_with("sha256="), "signature should start with sha256=");
+        assert!(sig_value.len() > 50, "signature should be a hex hash");
+    }
+
+    #[tokio::test]
+    async fn deliver_retries_on_http_500() {
+        let counter = Arc::new(AtomicUsize::new(0));
+        let c = counter.clone();
+
+        let app = Router::new().route(
+            "/webhook",
+            post(move || async move {
+                c.fetch_add(1, Ordering::SeqCst);
+                StatusCode::INTERNAL_SERVER_ERROR
+            }),
+        );
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let url = format!("http://{addr}/webhook");
+
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+        let logger = logger_with(&url, vec!["*"], None);
+        let event = LogEvent::new(LogLevel::Info, "test.event");
+
+        // Deliver synchronously via the internal method
+        let body = serde_json::to_vec(&logger.build_payload(&event)).unwrap();
+        let sig = logger.sign(&body);
+
+        // Use deliver directly (it's pub-in-module, accessible from tests)
+        HttpLogger::deliver(
+            reqwest::Client::new(),
+            url.clone(),
+            body,
+            sig,
+            "test.event".into(),
+        )
+        .await;
+
+        // Should have been called MAX_RETRIES times (3)
+        assert_eq!(counter.load(Ordering::SeqCst), MAX_RETRIES);
+    }
+
+    #[tokio::test]
+    async fn deliver_succeeds_on_first_attempt() {
+        let counter = Arc::new(AtomicUsize::new(0));
+        let c = counter.clone();
+
+        let app = Router::new().route(
+            "/webhook",
+            post(move || async move {
+                c.fetch_add(1, Ordering::SeqCst);
+                StatusCode::OK
+            }),
+        );
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let url = format!("http://{addr}/webhook");
+
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+        let logger = logger_with(&url, vec!["*"], None);
+        let event = LogEvent::new(LogLevel::Info, "test.event");
+
+        let body = serde_json::to_vec(&logger.build_payload(&event)).unwrap();
+        let sig = logger.sign(&body);
+
+        HttpLogger::deliver(
+            reqwest::Client::new(),
+            url.clone(),
+            body,
+            sig,
+            "test.event".into(),
+        )
+        .await;
+
+        // Should succeed on first try, no retries
+        assert_eq!(counter.load(Ordering::SeqCst), 1);
+    }
+
+    // ── Logger trait integration ─────────────────────────────────────────
+
+    #[tokio::test]
+    async fn log_respects_event_filter() {
+        let (url, counter, _received) = mock_server(StatusCode::OK).await;
+
+        // Only accept sandbox.created
+        let logger = logger_with(&url, vec!["sandbox.created"], None);
+
+        // This event should be filtered out
+        logger
+            .log(LogEvent::new(LogLevel::Info, "sandbox.deleted"))
+            .await;
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        assert_eq!(counter.load(Ordering::SeqCst), 0, "filtered event should not be delivered");
+
+        // This event should go through
+        logger
+            .log(LogEvent::new(LogLevel::Info, "sandbox.created"))
+            .await;
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        assert_eq!(counter.load(Ordering::SeqCst), 1, "matching event should be delivered");
+    }
+
+    #[tokio::test]
+    async fn log_sends_to_all_urls() {
+        let (url1, _c1, r1) = mock_server(StatusCode::OK).await;
+        let (url2, _c2, r2) = mock_server(StatusCode::OK).await;
+
+        // Create a logger that targets both URLs
+        let combined = format!("{url1},{url2}");
+        let logger = HttpLogger::new(&combined, "*", None).unwrap();
+
+        logger
+            .log(LogEvent::new(LogLevel::Info, "sandbox.created"))
+            .await;
+        tokio::time::sleep(std::time::Duration::from_millis(300)).await;
+
+        assert_eq!(r1.lock().unwrap().len(), 1, "first URL should receive the event");
+        assert_eq!(r2.lock().unwrap().len(), 1, "second URL should receive the event");
+    }
+
+    // ── Constructor ──────────────────────────────────────────────────────
+
+    #[test]
+    fn new_returns_none_when_urls_empty() {
+        assert!(HttpLogger::new("", "*", None).is_none());
+        assert!(HttpLogger::new(",,,", "*", None).is_none());
+        assert!(HttpLogger::new("  ", "*", None).is_none());
+    }
+
+    #[test]
+    fn new_returns_some_when_urls_provided() {
+        let logger = HttpLogger::new("http://localhost:9999/w", "*", None);
+        assert!(logger.is_some());
+        assert_eq!(logger.unwrap().urls.len(), 1);
+    }
+
+    #[test]
+    fn new_parses_multiple_urls() {
+        let logger =
+            HttpLogger::new("http://a.com/w,http://b.com/w", "*", None).unwrap();
+        assert_eq!(logger.urls.len(), 2);
+        assert_eq!(logger.urls[0], "http://a.com/w");
+        assert_eq!(logger.urls[1], "http://b.com/w");
+    }
+
+    #[test]
+    fn new_trims_whitespace_around_urls() {
+        let logger =
+            HttpLogger::new("  http://a.com/w , http://b.com/w  ", "*", None).unwrap();
+        assert_eq!(logger.urls.len(), 2);
+        assert_eq!(logger.urls[0], "http://a.com/w");
     }
 }

--- a/CubeAPI/src/logging/mod.rs
+++ b/CubeAPI/src/logging/mod.rs
@@ -20,7 +20,7 @@
 //! | `multi`        | Fan-out to N backends         | ✅ Ready |
 //! | `filtered`     | Min-level gate wrapper        | ✅ Ready |
 //! | `otlp`         | OpenTelemetry OTLP exporter   | 🔲 Stub  |
-//! | `http`         | Generic HTTP webhook          | 🔲 Stub  |
+//! | `http`         | HTTP webhook delivery         | ✅ Ready |
 
 pub mod file;
 pub mod filtered;

--- a/CubeAPI/src/main.rs
+++ b/CubeAPI/src/main.rs
@@ -198,7 +198,7 @@ fn main() -> anyhow::Result<()> {
 }
 
 async fn async_main(cfg: config::ServerConfig, debug: bool) -> anyhow::Result<()> {
-    use logging::{arc, file::FileLogger, filtered::FilteredLogger, multi::MultiLogger, LogLevel};
+    use logging::{arc, file::FileLogger, filtered::FilteredLogger, http::HttpLogger, multi::MultiLogger, LogLevel};
 
     // ── Logger ────────────────────────────────────────────────────────────
     let min_level = if debug {
@@ -209,15 +209,20 @@ async fn async_main(cfg: config::ServerConfig, debug: bool) -> anyhow::Result<()
 
     let file_logger = FileLogger::new(cfg.log_dir.clone(), cfg.log_prefix.clone()).await?;
 
-    // FilteredLogger gates by level → MultiLogger fans out to file (+ future backends)
-    let logger: logging::ArcLogger = arc(FilteredLogger::new(
-        arc(
-            MultiLogger::new().add(arc(file_logger)), // Uncomment to add more backends:
-                                                      // .add(arc(logging::http::HttpLogger::new(Default::default())))
-                                                      // .add(arc(logging::otlp::OtlpLogger::new()))
-        ),
-        min_level,
-    ));
+    let mut multi = MultiLogger::new().add(arc(file_logger));
+
+    // Attach webhook (HTTP) logger when endpoints are configured
+    if let Some(http_logger) = HttpLogger::new(
+        &cfg.webhook_urls,
+        &cfg.webhook_events,
+        cfg.webhook_secret.as_deref(),
+    ) {
+        multi = multi.add(arc(http_logger));
+        tracing::info!("webhook logger attached");
+    }
+
+    // FilteredLogger gates by level → MultiLogger fans out to all backends
+    let logger: logging::ArcLogger = arc(FilteredLogger::new(arc(multi), min_level));
 
     tracing::info!(
         log_dir = %cfg.log_dir,

--- a/docs/guide/integrations/index.md
+++ b/docs/guide/integrations/index.md
@@ -48,3 +48,4 @@ lang: en-US
 | Title | Author | Date | Tags |
 | --- | --- | --- | --- |
 | [Pi Agent Integration Guide](./pi-agent.md) | chaojixinren | 2026-07-01 | integration, pi-agent, coding-agent, agent |
+| [Webhook Integration Guide](./webhook.md) | YYYSSSRRR | 2026-07-24 | integration, webhook, event, callback |

--- a/docs/guide/integrations/webhook.md
+++ b/docs/guide/integrations/webhook.md
@@ -1,0 +1,348 @@
+---
+title: Webhook Integration Guide
+author: YYYSSSRRR
+date: 2026-07-24
+tags:
+  - integration
+  - webhook
+  - event
+  - callback
+lang: en-US
+---
+
+# Webhook Integration Guide
+
+[中文文档](../../zh/guide/integrations/webhook.md)
+
+Cube Sandbox can push sandbox lifecycle events to any HTTP endpoint via **webhooks**. This guide covers configuration, payload format, signature verification, and how to connect webhooks to notification services like WeCom (企业微信) bot, Slack, or PagerDuty.
+
+A runnable receiver example is available at [`examples/webhook-receiver/`](https://github.com/TencentCloud/CubeSandbox/tree/master/examples/webhook-receiver).
+
+---
+
+## Integration Target and Version
+
+| Component | Version |
+|---|---|
+| CubeAPI (webhook emitter) | `>= 0.5.0` |
+| Receiver example | Python 3.10+ (stdlib only) |
+| Webhook protocol | HTTP POST with HMAC-SHA256 signing |
+
+---
+
+## Configuration
+
+Webhooks are configured via environment variables on the CubeAPI process.
+
+### Basic Setup
+
+```bash
+# Target URL(s) — comma-separated for multiple endpoints
+export CUBE_API_WEBHOOK_URLS="http://localhost:8080/webhook"
+
+# Event filter — "*" for all, or a comma-separated list
+export CUBE_API_WEBHOOK_EVENTS="*"
+
+# Optional: shared secret for payload signing
+export CUBE_API_WEBHOOK_SECRET="my-shared-secret"
+```
+
+### Event Filtering
+
+To receive only sandbox lifecycle events:
+
+```bash
+export CUBE_API_WEBHOOK_EVENTS="sandbox.created,sandbox.deleted,sandbox.paused,sandbox.resumed"
+```
+
+### Multiple Targets
+
+Events fan out to all configured URLs in parallel:
+
+```bash
+export CUBE_API_WEBHOOK_URLS="http://host-a:8080/hook,http://host-b:8080/hook"
+```
+
+### Delivery Behavior
+
+- **Non-blocking**: webhook delivery runs in a background Tokio task, never blocking the API response.
+- **Retry**: exponential backoff at 200 ms → 500 ms → 1 s (3 attempts max).
+- **Success**: HTTP 2xx is considered successful.
+- **Failure**: non-2xx or transport errors trigger a retry; after 3 failures the event is dropped with an error log.
+
+---
+
+## Event Payload
+
+### Schema
+
+Each webhook POST body is a JSON object with the following fields:
+
+| Field | Type | Always present | Description |
+|---|---|---|---|
+| `event` | string | ✓ | Machine-readable event name |
+| `timestamp` | string (ISO 8601) | ✓ | When the event was generated |
+| `sandbox_id` | string | — | Sandbox identifier (omit for API-level events) |
+| `template_id` | string | — | Template identifier |
+| (additional) | varies | — | Event-specific fields, flattened into the root object |
+
+### Event Types
+
+| Event | Trigger | Extra fields |
+|---|---|---|
+| `sandbox.created` | Sandbox created successfully | — |
+| `sandbox.deleted` | Sandbox deleted | — |
+| `sandbox.paused` | Sandbox paused | — |
+| `sandbox.resumed` | Sandbox resumed | — |
+| `sandbox.timeout.updated` | Sandbox timeout changed | `timeout` (seconds) |
+| `sandbox.refreshed` | Sandbox TTL refreshed | `duration` (seconds) |
+| `api.response` | API request completed | — |
+| `api.error` | API handler error | `handler`, `error` |
+
+### Example Payloads
+
+**sandbox.created**:
+```json
+{
+  "event": "sandbox.created",
+  "timestamp": "2026-07-24T12:00:00Z",
+  "sandbox_id": "sb-abc123",
+  "template_id": "tpl-python-3.12"
+}
+```
+
+**sandbox.timeout.updated** (with flattened extra field):
+```json
+{
+  "event": "sandbox.timeout.updated",
+  "timestamp": "2026-07-24T12:05:00Z",
+  "sandbox_id": "sb-abc123",
+  "timeout": 3600
+}
+```
+
+**api.error**:
+```json
+{
+  "event": "api.error",
+  "timestamp": "2026-07-24T12:10:00Z",
+  "handler": "sandboxes.create",
+  "error": "template not found"
+}
+```
+
+---
+
+## Signature Verification
+
+When `CUBE_API_WEBHOOK_SECRET` is set, every POST includes:
+
+```
+X-Cube-Signature-256: sha256=<hex-encoded-hmac>
+```
+
+The HMAC is computed as **HMAC-SHA256** of the raw JSON request body, keyed by the shared secret.
+
+### Verification Examples
+
+**Python** (fully compatible with the receiver example):
+```python
+import hmac
+
+def verify(body: bytes, header: str, secret: str) -> bool:
+    """Verify X-Cube-Signature-256 header."""
+    if not header.startswith("sha256="):
+        return False
+    expected = header[len("sha256="):]
+    computed = hmac.new(secret.encode("utf-8"), body, "sha256").hexdigest()
+    return hmac.compare_digest(computed, expected)
+```
+
+**Node.js / TypeScript**:
+```typescript
+import { createHmac, timingSafeEqual } from "crypto";
+
+function verify(body: Buffer, header: string, secret: string): boolean {
+  if (!header.startsWith("sha256=")) return false;
+  const expected = header.slice(7);
+  const computed = createHmac("sha256", secret).update(body).digest("hex");
+  if (computed.length !== expected.length) return false;
+  return timingSafeEqual(Buffer.from(computed), Buffer.from(expected));
+}
+```
+
+**Go**:
+```go
+import (
+    "crypto/hmac"
+    "crypto/sha256"
+    "encoding/hex"
+    "strings"
+)
+
+func Verify(body []byte, header, secret string) bool {
+    if !strings.HasPrefix(header, "sha256=") {
+        return false
+    }
+    expected := header[7:]
+    mac := hmac.New(sha256.New, []byte(secret))
+    mac.Write(body)
+    computed := hex.EncodeToString(mac.Sum(nil))
+    return hmac.Equal([]byte(computed), []byte(expected))
+}
+```
+
+### Testing Signature with cURL
+
+```bash
+BODY='{"event":"sandbox.created","timestamp":"2026-07-24T12:00:00Z","sandbox_id":"sb-test"}'
+SIG=$(echo -n "$BODY" | openssl dgst -sha256 -hmac "my-secret" | awk '{print $NF}')
+
+curl -X POST http://localhost:8080/webhook \
+  -H "Content-Type: application/json" \
+  -H "X-Cube-Signature-256: sha256=$SIG" \
+  -d "$BODY"
+```
+
+---
+
+## Receiving Webhooks
+
+A zero-dependency Python receiver is provided at [`examples/webhook-receiver/receiver.py`](https://github.com/TencentCloud/CubeSandbox/tree/master/examples/webhook-receiver).
+
+```bash
+# Start the receiver on your CubeAPI server
+python receiver.py --port 8080 --path /webhook
+
+# With signature verification
+WEBHOOK_SECRET=my-shared-secret python receiver.py
+```
+
+The receiver prints each event with color-coded output and supports optional HMAC verification. See the [example README](https://github.com/TencentCloud/CubeSandbox/tree/master/examples/webhook-receiver) for the full end-to-end walkthrough.
+
+---
+
+## Integrating with Notification Services
+
+### WeCom (企业微信) Bot
+
+WeCom group robots accept a JSON payload at a fixed webhook URL.
+
+**Forwarding example (Python)**:
+```python
+import hmac
+import json
+from http.server import HTTPServer, BaseHTTPRequestHandler
+import urllib.request
+
+WECOM_WEBHOOK_URL = "https://qyapi.weixin.qq.com/cgi-bin/webhook/send?key=YOUR_KEY"
+
+class WeComForwarder(BaseHTTPRequestHandler):
+    def do_POST(self):
+        length = int(self.headers.get("Content-Length", 0))
+        body = self.rfile.read(length)
+        payload = json.loads(body)
+
+        event = payload.get("event", "unknown")
+        sandbox_id = payload.get("sandbox_id", "N/A")
+
+        # Build WeCom markdown message
+        msg = {
+            "msgtype": "markdown",
+            "markdown": {
+                "content": (
+                    f"### Cube Sandbox Event: {event}\n"
+                    f"> **Sandbox:** {sandbox_id}\n"
+                    f"> **Time:** {payload.get('timestamp', 'N/A')}\n"
+                )
+            }
+        }
+
+        req = urllib.request.Request(
+            WECOM_WEBHOOK_URL,
+            data=json.dumps(msg).encode(),
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        urllib.request.urlopen(req)
+
+        self.send_response(200)
+        self.end_headers()
+
+HTTPServer(("0.0.0.0", 8080), WeComForwarder).serve_forever()
+```
+
+### Slack Webhook
+
+Slack Incoming Webhooks accept a simple JSON body:
+
+```python
+import json
+import urllib.request
+
+SLACK_URL = "https://hooks.slack.com/services/T000000/B000000/xxxxxxxx"
+
+def send_to_slack(payload: dict):
+    msg = {
+        "text": (
+            f"*Cube Sandbox Event:* {payload['event']}\n"
+            f"• Sandbox: `{payload.get('sandbox_id', 'N/A')}`\n"
+            f"• Time: {payload.get('timestamp', 'N/A')}"
+        )
+    }
+    req = urllib.request.Request(
+        SLACK_URL, data=json.dumps(msg).encode(),
+        headers={"Content-Type": "application/json"}, method="POST",
+    )
+    urllib.request.urlopen(req)
+```
+
+### PagerDuty Events API v2
+
+```python
+import json
+import urllib.request
+
+PD_ROUTING_KEY = "your-pagerduty-routing-key"
+
+def send_to_pagerduty(payload: dict):
+    event_name = payload["event"]
+    severity = "error" if event_name == "api.error" else "info"
+    msg = {
+        "routing_key": PD_ROUTING_KEY,
+        "event_action": "trigger",
+        "payload": {
+            "summary": f"Cube Sandbox: {event_name}",
+            "severity": severity,
+            "source": "cube-api",
+            "custom_details": payload,
+        },
+    }
+    req = urllib.request.Request(
+        "https://events.pagerduty.com/v2/enqueue",
+        data=json.dumps(msg).encode(),
+        headers={"Content-Type": "application/json"}, method="POST",
+    )
+    urllib.request.urlopen(req)
+```
+
+---
+
+## Production Considerations
+
+- **Idempotency**: webhook retries may deliver the same event more than once. Design your receiver to handle duplicates (e.g., by tracking `event` + `timestamp` pairs).
+- **Rate limiting**: CubeAPI does not throttle outgoing webhooks. If your receiver calls an external API with rate limits, add a queue or rate limiter.
+- **Monitoring**: CubeAPI logs delivery failures via `tracing` at `WARN` (retry) and `ERROR` (exhausted). Pipe these logs into your monitoring stack.
+- **Scaling**: the receiver in this guide is single-threaded. For high-throughput production use, deploy a dedicated webhook framework (FastAPI, Flask, or a message queue consumer).
+- **Authentication**: always enable `CUBE_API_WEBHOOK_SECRET` in production to prevent spoofed events.
+
+---
+
+## References
+
+- [Source: CubeAPI webhook emitter](https://github.com/TencentCloud/CubeSandbox/tree/master/CubeAPI/src/logging/http.rs)
+- [Example: Webhook receiver + quickstart](https://github.com/TencentCloud/CubeSandbox/tree/master/examples/webhook-receiver)
+- [Configuration reference](https://github.com/TencentCloud/CubeSandbox/tree/master/CubeAPI/src/config/mod.rs)
+- [WeCom bot documentation](https://developer.work.weixin.qq.com/document/path/91770)
+- [Slack Incoming Webhooks](https://api.slack.com/messaging/webhooks)
+- [PagerDuty Events API v2](https://developer.pagerduty.com/docs/events-api-v2/overview)

--- a/docs/zh/guide/integrations/index.md
+++ b/docs/zh/guide/integrations/index.md
@@ -48,3 +48,4 @@ lang: zh-CN
 | 标题 | 作者 | 日期 | 标签 |
 | --- | --- | --- | --- |
 | [Pi Agent 集成指南](./pi-agent.md) | chaojixinren | 2026-07-01 | integration, pi-agent, coding-agent, agent |
+| [Webhook 集成指南](./webhook.md) | YYYSSSRRR | 2026-07-24 | integration, webhook, event, callback |

--- a/docs/zh/guide/integrations/webhook.md
+++ b/docs/zh/guide/integrations/webhook.md
@@ -1,0 +1,342 @@
+---
+title: Webhook 集成指南
+author: YYYSSSRRR
+date: 2026-07-24
+tags:
+  - integration
+  - webhook
+  - event
+  - callback
+lang: zh-CN
+---
+
+# Webhook 集成指南
+
+[English](../../guide/integrations/webhook.md)
+
+Cube Sandbox 支持通过 **Webhook** 将沙箱生命周期事件实时推送到任意 HTTP 端点。本文档涵盖配置方法、事件载荷格式、签名验证，以及如何对接企业微信机器人、Slack、PagerDuty 等通知服务。
+
+可运行的接收端示例位于 [`examples/webhook-receiver/`](https://github.com/TencentCloud/CubeSandbox/tree/master/examples/webhook-receiver)。
+
+---
+
+## 集成目标与版本
+
+| 组件 | 版本 |
+|---|---|
+| CubeAPI（Webhook 发送端） | `>= 0.5.0` |
+| 接收端示例 | Python 3.10+（仅标准库） |
+| Webhook 协议 | HTTP POST，支持 HMAC-SHA256 签名 |
+
+---
+
+## 配置方法
+
+通过 CubeAPI 进程的环境变量配置 Webhook。
+
+### 基本设置
+
+```bash
+# 目标 URL（逗号分隔可配置多个端点）
+export CUBE_API_WEBHOOK_URLS="http://localhost:8080/webhook"
+
+# 事件过滤器："*" 表示全部，或逗号分隔的事件名列表
+export CUBE_API_WEBHOOK_EVENTS="*"
+
+# 可选：共享密钥，用于载荷签名
+export CUBE_API_WEBHOOK_SECRET="my-shared-secret"
+```
+
+### 事件过滤
+
+只接收沙箱生命周期事件：
+
+```bash
+export CUBE_API_WEBHOOK_EVENTS="sandbox.created,sandbox.deleted,sandbox.paused,sandbox.resumed"
+```
+
+### 多目标投递
+
+事件会并行推送至所有配置的 URL：
+
+```bash
+export CUBE_API_WEBHOOK_URLS="http://host-a:8080/hook,http://host-b:8080/hook"
+```
+
+### 投递行为
+
+- **非阻塞**：Webhook 在后台 Tokio 任务中发送，不会阻塞 API 响应。
+- **重试**：指数退避 200 毫秒 → 500 毫秒 → 1 秒（最多 3 次）。
+- **成功条件**：HTTP 2xx 视为成功。
+- **失败处理**：非 2xx 状态码或网络错误会触发重试；3 次均失败后丢弃事件并记录错误日志。
+
+---
+
+## 事件载荷
+
+### 格式
+
+每个 Webhook POST 请求体是一个 JSON 对象，包含以下字段：
+
+| 字段 | 类型 | 始终存在 | 说明 |
+|---|---|---|---|
+| `event` | string | ✓ | 机器可读的事件名称 |
+| `timestamp` | string (ISO 8601) | ✓ | 事件发生时间 |
+| `sandbox_id` | string | — | 沙箱 ID（API 级别事件不含此字段） |
+| `template_id` | string | — | 模板 ID |
+| (其他) | varies | — | 事件特定字段，平铺在根对象中 |
+
+### 事件类型
+
+| 事件 | 触发时机 | 额外字段 |
+|---|---|---|
+| `sandbox.created` | 沙箱创建成功 | — |
+| `sandbox.deleted` | 沙箱已删除 | — |
+| `sandbox.paused` | 沙箱已暂停 | — |
+| `sandbox.resumed` | 沙箱已恢复 | — |
+| `sandbox.timeout.updated` | 沙箱超时时间已修改 | `timeout`（秒） |
+| `sandbox.refreshed` | 沙箱 TTL 已刷新 | `duration`（秒） |
+| `api.response` | API 请求完成 | — |
+| `api.error` | API 处理错误 | `handler`, `error` |
+
+### 示例
+
+**sandbox.created**：
+```json
+{
+  "event": "sandbox.created",
+  "timestamp": "2026-07-24T12:00:00Z",
+  "sandbox_id": "sb-abc123",
+  "template_id": "tpl-python-3.12"
+}
+```
+
+**sandbox.timeout.updated**（含平铺的额外字段）：
+```json
+{
+  "event": "sandbox.timeout.updated",
+  "timestamp": "2026-07-24T12:05:00Z",
+  "sandbox_id": "sb-abc123",
+  "timeout": 3600
+}
+```
+
+**api.error**：
+```json
+{
+  "event": "api.error",
+  "timestamp": "2026-07-24T12:10:00Z",
+  "handler": "sandboxes.create",
+  "error": "template not found"
+}
+```
+
+---
+
+## 签名验证
+
+当配置了 `CUBE_API_WEBHOOK_SECRET` 后，每个 POST 请求包含：
+
+```
+X-Cube-Signature-256: sha256=<十六进制 HMAC>
+```
+
+HMAC 使用 **HMAC-SHA256** 对原始 JSON 请求体计算，密钥为共享密钥。
+
+### 验证示例
+
+**Python**（与接收端示例完全兼容）：
+```python
+import hmac
+
+def verify(body: bytes, header: str, secret: str) -> bool:
+    if not header.startswith("sha256="):
+        return False
+    expected = header[len("sha256="):]
+    computed = hmac.new(secret.encode("utf-8"), body, "sha256").hexdigest()
+    return hmac.compare_digest(computed, expected)
+```
+
+**Node.js / TypeScript**：
+```typescript
+import { createHmac, timingSafeEqual } from "crypto";
+
+function verify(body: Buffer, header: string, secret: string): boolean {
+  if (!header.startsWith("sha256=")) return false;
+  const expected = header.slice(7);
+  const computed = createHmac("sha256", secret).update(body).digest("hex");
+  if (computed.length !== expected.length) return false;
+  return timingSafeEqual(Buffer.from(computed), Buffer.from(expected));
+}
+```
+
+**Go**：
+```go
+import (
+    "crypto/hmac"
+    "crypto/sha256"
+    "encoding/hex"
+    "strings"
+)
+
+func Verify(body []byte, header, secret string) bool {
+    if !strings.HasPrefix(header, "sha256=") {
+        return false
+    }
+    expected := header[7:]
+    mac := hmac.New(sha256.New, []byte(secret))
+    mac.Write(body)
+    computed := hex.EncodeToString(mac.Sum(nil))
+    return hmac.Equal([]byte(computed), []byte(expected))
+}
+```
+
+### 使用 cURL 测试签名
+
+```bash
+BODY='{"event":"sandbox.created","timestamp":"2026-07-24T12:00:00Z","sandbox_id":"sb-test"}'
+SIG=$(echo -n "$BODY" | openssl dgst -sha256 -hmac "my-secret" | awk '{print $NF}')
+
+curl -X POST http://localhost:8080/webhook \
+  -H "Content-Type: application/json" \
+  -H "X-Cube-Signature-256: sha256=$SIG" \
+  -d "$BODY"
+```
+
+---
+
+## 接收 Webhook
+
+项目提供了零依赖的 Python 接收端，位于 [`examples/webhook-receiver/receiver.py`](https://github.com/TencentCloud/CubeSandbox/tree/master/examples/webhook-receiver)。
+
+```bash
+# 在 CubeAPI 服务器上启动接收端
+python receiver.py --port 8080 --path /webhook
+
+# 开启签名验证
+WEBHOOK_SECRET=my-shared-secret python receiver.py
+```
+
+接收端支持彩色输出和可选的 HMAC 签名验证。完整的端到端流程参见[示例 README](https://github.com/TencentCloud/CubeSandbox/tree/master/examples/webhook-receiver)。
+
+---
+
+## 对接通知服务
+
+### 企业微信机器人
+
+企业微信群机器人接收固定格式的 JSON 请求。
+
+**转发示例（Python）**：
+```python
+import json
+from http.server import HTTPServer, BaseHTTPRequestHandler
+import urllib.request
+
+WECOM_URL = "https://qyapi.weixin.qq.com/cgi-bin/webhook/send?key=你的KEY"
+
+class WeComForwarder(BaseHTTPRequestHandler):
+    def do_POST(self):
+        length = int(self.headers.get("Content-Length", 0))
+        body = self.rfile.read(length)
+        payload = json.loads(body)
+
+        event = payload.get("event", "unknown")
+        sandbox_id = payload.get("sandbox_id", "N/A")
+
+        msg = {
+            "msgtype": "markdown",
+            "markdown": {
+                "content": (
+                    f"### Cube Sandbox 事件：{event}\n"
+                    f"> **沙箱：** {sandbox_id}\n"
+                    f"> **时间：** {payload.get('timestamp', 'N/A')}\n"
+                )
+            }
+        }
+
+        req = urllib.request.Request(
+            WECOM_URL, data=json.dumps(msg).encode(),
+            headers={"Content-Type": "application/json"}, method="POST",
+        )
+        urllib.request.urlopen(req)
+        self.send_response(200)
+        self.end_headers()
+
+HTTPServer(("0.0.0.0", 8080), WeComForwarder).serve_forever()
+```
+
+### Slack Webhook
+
+Slack Incoming Webhooks 接收简单的 JSON 消息：
+
+```python
+import json
+import urllib.request
+
+SLACK_URL = "https://hooks.slack.com/services/T000000/B000000/xxxxxxxx"
+
+def send_to_slack(payload: dict):
+    msg = {
+        "text": (
+            f"*Cube Sandbox 事件：* {payload['event']}\n"
+            f"• 沙箱：`{payload.get('sandbox_id', 'N/A')}`\n"
+            f"• 时间：{payload.get('timestamp', 'N/A')}"
+        )
+    }
+    req = urllib.request.Request(
+        SLACK_URL, data=json.dumps(msg).encode(),
+        headers={"Content-Type": "application/json"}, method="POST",
+    )
+    urllib.request.urlopen(req)
+```
+
+### PagerDuty Events API v2
+
+```python
+import json
+import urllib.request
+
+PD_ROUTING_KEY = "你的 PagerDuty Routing Key"
+
+def send_to_pagerduty(payload: dict):
+    event_name = payload["event"]
+    severity = "error" if event_name == "api.error" else "info"
+    msg = {
+        "routing_key": PD_ROUTING_KEY,
+        "event_action": "trigger",
+        "payload": {
+            "summary": f"Cube Sandbox: {event_name}",
+            "severity": severity,
+            "source": "cube-api",
+            "custom_details": payload,
+        },
+    }
+    req = urllib.request.Request(
+        "https://events.pagerduty.com/v2/enqueue",
+        data=json.dumps(msg).encode(),
+        headers={"Content-Type": "application/json"}, method="POST",
+    )
+    urllib.request.urlopen(req)
+```
+
+---
+
+## 生产环境建议
+
+- **幂等处理**：Webhook 重试可能导致同一条事件投递多次。接收端应处理好重复事件（例如按 `event` + `timestamp` 去重）。
+- **速率限制**：CubeAPI 不会限制 Webhook 的发送速率。如果接收端调用外部限速 API，应添加队列或限速器。
+- **监控**：CubeAPI 通过 `tracing` 记录投递失败日志（`WARN` 表示重试，`ERROR` 表示重试耗尽）。请将这类日志接入监控系统。
+- **性能**：本文的接收端示例是单线程的。生产环境高吞吐场景建议使用专用 Webhook 框架（FastAPI、Flask 或消息队列消费者）。
+- **安全**：生产环境中务必启用 `CUBE_API_WEBHOOK_SECRET`，防止伪造事件。
+
+---
+
+## 参考
+
+- [CubeAPI Webhook 源码](https://github.com/TencentCloud/CubeSandbox/tree/master/CubeAPI/src/logging/http.rs)
+- [Webhook 接收端示例](https://github.com/TencentCloud/CubeSandbox/tree/master/examples/webhook-receiver)
+- [配置参考](https://github.com/TencentCloud/CubeSandbox/tree/master/CubeAPI/src/config/mod.rs)
+- [企业微信机器人文档](https://developer.work.weixin.qq.com/document/path/91770)
+- [Slack Incoming Webhooks](https://api.slack.com/messaging/webhooks)
+- [PagerDuty Events API v2](https://developer.pagerduty.com/docs/events-api-v2/overview)

--- a/examples/webhook-receiver/.env.example
+++ b/examples/webhook-receiver/.env.example
@@ -1,0 +1,19 @@
+# Required: Cube API server address (your server's IP / domain)
+export E2B_API_URL="http://<your-server-ip>:3000"
+
+# Required: any non-empty value satisfies the SDK check
+export E2B_API_KEY="e2b_000000"
+
+# Required: template ID obtained from create-from-image step
+export CUBE_TEMPLATE_ID="<your-template-id>"
+
+# Optional: only needed when using Cube's built-in cube.app mkcert certificate
+# export SSL_CERT_FILE="/root/.local/share/mkcert/rootCA.pem"
+
+# ── CubeAPI Webhook Config (for enabling event callbacks) ──
+export CUBE_API_WEBHOOK_URLS="http://localhost:8080/webhook"
+export CUBE_API_WEBHOOK_EVENTS="*"
+
+# Optional: shared secret for HMAC-SHA256 payload signing
+# Must match WEBHOOK_SECRET set when starting receiver.py
+# export CUBE_API_WEBHOOK_SECRET="my-shared-secret"

--- a/examples/webhook-receiver/README.md
+++ b/examples/webhook-receiver/README.md
@@ -1,0 +1,181 @@
+# Webhook Receiver — Cube Sandbox Event Callbacks
+
+[中文文档](README_zh.md)
+
+Receive and inspect [Cube Sandbox](https://github.com/tencent-cube/cube-sandbox) lifecycle events in real time. CubeAPI sends HTTP POST callbacks for sandbox lifecycle changes (create, delete, pause, resume, etc.) to any configured webhook URL.
+
+---
+
+## 1. Architecture
+
+```
+                          Server
+  ┌─────────────────────────────────────────────────────┐
+  │                                                     │
+  │  python create.py  ──▶  CubeAPI (:3000)             │
+  │  (SDK client)               │                       │
+  │                             ▼                       │
+  │                    python receiver.py (:8080)        │
+  │                    (POST /webhook)                   │
+  │                             │                       │
+  │                        stdout: formatted events      │
+  └─────────────────────────────────────────────────────┘
+```
+
+CubeAPI delivers events asynchronously via `tokio::spawn` (non-blocking), with exponential-backoff retry (3 attempts: 200 ms → 500 ms → 1 s).
+
+---
+
+## 2. Server Setup
+
+### 2.1 Upload the Compiled CubeAPI Binary
+
+Build CubeAPI (from the project root):
+
+```bash
+cd CubeAPI/
+cargo build --release
+```
+
+The compiled binary is at `CubeAPI/target/release/cube-api`. Upload it along with the receiver script:
+
+```bash
+scp target/release/cube-api user@<server>:/opt/cube/
+scp examples/webhook-receiver/receiver.py user@<server>:/opt/cube/
+```
+
+### 2.2 Start the Receiver
+
+```bash
+cd /opt/cube/
+
+# Default: http://0.0.0.0:8080/webhook
+python receiver.py
+
+# With signature verification:
+# WEBHOOK_SECRET=my-shared-secret python receiver.py
+```
+
+### 2.3 Configure & Start CubeAPI
+
+Set these **before starting CubeAPI**:
+
+```bash
+export CUBE_API_WEBHOOK_URLS=http://localhost:8080/webhook   # receiver is on the same machine
+export CUBE_API_WEBHOOK_EVENTS=*                              # all events
+export CUBE_API_WEBHOOK_SECRET=my-shared-secret               # optional — match receiver's WEBHOOK_SECRET
+
+# Start CubeAPI
+./cube-api
+```
+
+### 2.4 Trigger Events
+
+SDK client scripts are in [`code-sandbox-quickstart/`](../code-sandbox-quickstart/). From that directory:
+
+```bash
+cd ../code-sandbox-quickstart/
+
+# Configure
+cp .env.example .env
+# Edit .env: E2B_API_URL=http://localhost:3000
+#            CUBE_TEMPLATE_ID=<your-template-id>
+
+pip install -r requirements.txt
+
+# Trigger events — watch the receiver terminal
+python create.py       # → sandbox.created, sandbox.deleted
+python pause.py        # → sandbox.paused, sandbox.resumed
+python exec_code.py
+python cmd.py
+```
+
+---
+
+## 3. Event Payload Format
+
+```json
+{
+  "event": "sandbox.created",
+  "timestamp": "2026-07-24T12:00:00Z",
+  "sandbox_id": "sb-abc123",
+  "template_id": "tpl-python-3.12"
+}
+```
+
+### Event Types
+
+| Event                    | Description                         | Extra Fields           |
+|--------------------------|-------------------------------------|------------------------|
+| `sandbox.created`        | Sandbox created successfully        | —                      |
+| `sandbox.deleted`        | Sandbox deleted                     | —                      |
+| `sandbox.paused`         | Sandbox paused                      | —                      |
+| `sandbox.resumed`        | Sandbox resumed                     | —                      |
+| `sandbox.timeout.updated`| Sandbox timeout changed             | `timeout` (seconds)    |
+| `sandbox.refreshed`      | Sandbox TTL refreshed               | `duration` (seconds)   |
+| `api.response`           | API request completed               | —                      |
+| `api.error`              | API handler error                   | `handler`, `error`     |
+
+### Signature Verification
+
+When `CUBE_API_WEBHOOK_SECRET` is set, CubeAPI sends:
+
+```
+X-Cube-Signature-256: sha256=<hmac-hex>
+```
+
+The HMAC is **HMAC-SHA256** of the raw JSON body. The receiver verifies this when `WEBHOOK_SECRET` is set. Invalid/missing signature → HTTP 401.
+
+---
+
+## 4. End-to-End Test
+
+```bash
+# Terminal 1 — start the receiver
+cd examples/webhook-receiver/
+WEBHOOK_SECRET=test-secret python receiver.py
+
+# Terminal 2 — start CubeAPI with webhooks
+cd ../..
+export CUBE_API_WEBHOOK_URLS=http://localhost:8080/webhook
+export CUBE_API_WEBHOOK_SECRET=test-secret
+export CUBE_API_WEBHOOK_EVENTS=*
+cargo run --release
+
+# Terminal 3 — trigger events
+cd examples/code-sandbox-quickstart/
+python create.py
+
+# → Terminal 1 shows:
+#   sandbox.created  2026-07-24 20:03:15.123  sandbox=sb-abc123
+```
+
+---
+
+## 5. Event Filtering
+
+```bash
+export CUBE_API_WEBHOOK_EVENTS=sandbox.created,sandbox.deleted,sandbox.paused,sandbox.resumed
+```
+
+Filtering is on CubeAPI side — the receiver prints everything it receives.
+
+---
+
+## 6. Production Notes
+
+This receiver is designed for **development and testing**. For production:
+
+- Use a dedicated webhook framework (Flask, FastAPI, or message queue consumer)
+- Add persistent storage (file log, database, or message queue)
+- Implement idempotency (retries may cause duplicate deliveries)
+- Consider running as a systemd service or Docker container
+
+---
+
+## 7. Reference
+
+- [CubeAPI webhook source](../../CubeAPI/src/logging/http.rs) — Rust delivery backend
+- [Event log types](../../CubeAPI/src/logging/mod.rs) — `LogEvent` struct
+- [Configuration fields](../../CubeAPI/src/config/mod.rs) — `ServerConfig.webhook_*`
+- [SDK Client Scripts](../code-sandbox-quickstart/) — scripts to trigger sandbox events

--- a/examples/webhook-receiver/README_zh.md
+++ b/examples/webhook-receiver/README_zh.md
@@ -1,0 +1,181 @@
+# Webhook 接收端 — Cube Sandbox 事件回调
+
+[English](README.md)
+
+实时接收并查看 [Cube Sandbox](https://github.com/tencent-cube/cube-sandbox) 的生命周期事件。CubeAPI 会在沙箱创建、删除、暂停、恢复等生命周期变化时，向配置的 Webhook URL 发送 HTTP POST 回调。
+
+---
+
+## 1. 架构
+
+```
+                          服务器
+  ┌─────────────────────────────────────────────────────┐
+  │                                                     │
+  │  python create.py  ──▶  CubeAPI (:3000)             │
+  │  (SDK 客户端)               │                       │
+  │                             ▼                       │
+  │                    python receiver.py (:8080)        │
+  │                    (POST /webhook)                   │
+  │                             │                       │
+  │                        stdout: 格式化事件输出        │
+  └─────────────────────────────────────────────────────┘
+```
+
+CubeAPI 异步投递事件（`tokio::spawn`，不阻塞），带指数退避重试（3 次：200ms → 500ms → 1s）。
+
+---
+
+## 2. 服务器操作
+
+### 2.1 上传编译好的 CubeAPI 二进制
+
+在本地构建 CubeAPI（项目根目录）：
+
+```bash
+cd CubeAPI/
+cargo build --release
+```
+
+编译产物在 `CubeAPI/target/release/cube-api`。把这个二进制和接收端脚本一起上传到服务器：
+
+```bash
+scp target/release/cube-api user@<服务器IP>:/opt/cube/
+scp examples/webhook-receiver/receiver.py user@<服务器IP>:/opt/cube/
+```
+
+### 2.2 启动接收端
+
+```bash
+cd /opt/cube/
+
+# 默认监听 http://0.0.0.0:8080/webhook
+python receiver.py
+
+# 开启签名验证：
+# WEBHOOK_SECRET=my-shared-secret python receiver.py
+```
+
+### 2.3 配置并启动 CubeAPI
+
+**启动 CubeAPI 前设置**：
+
+```bash
+export CUBE_API_WEBHOOK_URLS=http://localhost:8080/webhook   # 接收端同机运行
+export CUBE_API_WEBHOOK_EVENTS=*                              # 全部事件
+export CUBE_API_WEBHOOK_SECRET=my-shared-secret               # 可选，和接收端保持一致
+
+# 启动 CubeAPI
+./cube-api
+```
+
+### 2.4 触发事件
+
+SDK 客户端脚本在 [`code-sandbox-quickstart/`](../code-sandbox-quickstart/) 目录下：
+
+```bash
+cd ../code-sandbox-quickstart/
+
+# 配置
+cp .env.example .env
+# 编辑 .env：E2B_API_URL=http://localhost:3000
+#            CUBE_TEMPLATE_ID=<你的模板ID>
+
+pip install -r requirements.txt
+
+# 触发事件，观察接收端终端
+python create.py       # → sandbox.created, sandbox.deleted
+python pause.py        # → sandbox.paused, sandbox.resumed
+python exec_code.py
+python cmd.py
+```
+
+---
+
+## 3. 事件载荷格式
+
+```json
+{
+  "event": "sandbox.created",
+  "timestamp": "2026-07-24T12:00:00Z",
+  "sandbox_id": "sb-abc123",
+  "template_id": "tpl-python-3.12"
+}
+```
+
+### 事件类型
+
+| 事件                     | 描述                   | 额外字段               |
+|--------------------------|------------------------|------------------------|
+| `sandbox.created`        | 沙箱创建成功           | —                      |
+| `sandbox.deleted`        | 沙箱已删除             | —                      |
+| `sandbox.paused`         | 沙箱已暂停             | —                      |
+| `sandbox.resumed`        | 沙箱已恢复             | —                      |
+| `sandbox.timeout.updated`| 沙箱超时时间已修改     | `timeout`（秒）        |
+| `sandbox.refreshed`      | 沙箱 TTL 已刷新        | `duration`（秒）       |
+| `api.response`           | API 请求完成           | —                      |
+| `api.error`              | API 处理错误           | `handler`, `error`     |
+
+### 签名验证
+
+当 CubeAPI 配置了 `CUBE_API_WEBHOOK_SECRET`，每个 POST 包含：
+
+```
+X-Cube-Signature-256: sha256=<HMAC 十六进制>
+```
+
+HMAC 是 **HMAC-SHA256(原始JSON体, 共享密钥)**。接收端设置 `WEBHOOK_SECRET` 后自动验证。签名无效 → HTTP 401。
+
+---
+
+## 4. 端到端测试
+
+```bash
+# 终端 1 — 启动接收端
+cd examples/webhook-receiver/
+WEBHOOK_SECRET=test-secret python receiver.py
+
+# 终端 2 — 启动 CubeAPI（开启 Webhook）
+cd ../..
+export CUBE_API_WEBHOOK_URLS=http://localhost:8080/webhook
+export CUBE_API_WEBHOOK_SECRET=test-secret
+export CUBE_API_WEBHOOK_EVENTS=*
+cargo run --release
+
+# 终端 3 — 触发事件
+cd examples/code-sandbox-quickstart/
+python create.py
+
+# → 终端 1 显示：
+#   sandbox.created  2026-07-24 20:03:15.123  sandbox=sb-abc123
+```
+
+---
+
+## 5. 事件过滤
+
+```bash
+export CUBE_API_WEBHOOK_EVENTS=sandbox.created,sandbox.deleted,sandbox.paused,sandbox.resumed
+```
+
+过滤在 CubeAPI 侧配置，接收端打印所有收到的事件。
+
+---
+
+## 6. 生产环境建议
+
+本接收端面向**开发和测试**。生产环境建议：
+
+- 使用成熟的 Webhook 框架（Flask、FastAPI 或消息队列消费者）
+- 添加持久化存储（文件日志、数据库或消息队列）
+- 实现幂等处理（重试可能导致重复投递）
+- 考虑以 systemd 服务或 Docker 容器运行
+
+---
+
+## 7. 参考
+
+- [CubeAPI webhook 源码](../../CubeAPI/src/logging/http.rs) — Rust 投递后端
+- [事件日志类型](../../CubeAPI/src/logging/mod.rs) — `LogEvent` 结构体
+- [配置字段](../../CubeAPI/src/config/mod.rs) — `ServerConfig.webhook_*`
+- [SDK 客户端脚本](../code-sandbox-quickstart/) — 触发事件的示例

--- a/examples/webhook-receiver/receiver.py
+++ b/examples/webhook-receiver/receiver.py
@@ -1,0 +1,267 @@
+#!/usr/bin/env python3
+"""
+Cube Sandbox Webhook Receiver
+=============================
+A simple HTTP server that receives and displays sandbox lifecycle events
+from CubeAPI via webhook callbacks.
+
+Usage:
+    # Basic (no signature verification)
+    python receiver.py
+
+    # With signature verification
+    WEBHOOK_SECRET=my-secret python receiver.py
+
+    # Custom host/port/path
+    python receiver.py --host 0.0.0.0 --port 9999 --path /events
+
+Then configure CubeAPI to send webhooks to this receiver.
+"""
+
+import argparse
+import hmac
+import json
+import logging
+import os
+import sys
+from datetime import datetime
+from http import HTTPStatus
+from http.server import HTTPServer, BaseHTTPRequestHandler
+
+# ---------------------------------------------------------------------------
+# Formatting helpers
+# ---------------------------------------------------------------------------
+
+# ANSI colour codes — disabled when stdout is not a terminal.
+_USE_COLOR = hasattr(sys.stdout, "isatty") and sys.stdout.isatty()
+
+
+def _c(code: str, text: str) -> str:
+    return f"\033[{code}m{text}\033[0m" if _USE_COLOR else text
+
+
+def bold(s: str) -> str:
+    return _c("1", s)
+
+
+def dim(s: str) -> str:
+    return _c("2", s)
+
+
+def green(s: str) -> str:
+    return _c("32", s)
+
+
+def yellow(s: str) -> str:
+    return _c("33", s)
+
+
+def cyan(s: str) -> str:
+    return _c("36", s)
+
+
+def red(s: str) -> str:
+    return _c("31", s)
+
+
+def magenta(s: str) -> str:
+    return _c("35", s)
+
+# ─── Event-type → colour mapping ─────────────────────────────────────────
+
+EVENT_COLORS = {
+    "sandbox.created": green,
+    "sandbox.deleted": red,
+    "sandbox.paused": yellow,
+    "sandbox.resumed": green,
+    "sandbox.timeout.updated": cyan,
+    "sandbox.refreshed": cyan,
+    "api.response": dim,
+    "api.error": red,
+}
+
+DEFAULT_COLOR = magenta
+
+
+def _format_timestamp(ts_str: str) -> str:
+    """Pretty-print an ISO 8601 timestamp in the local time zone."""
+    try:
+        dt = datetime.fromisoformat(ts_str.replace("Z", "+00:00"))
+        return dt.astimezone().strftime("%Y-%m-%d %H:%M:%S.%f")[:23]
+    except (ValueError, TypeError):
+        return ts_str
+
+
+def display_event(event_name: str, body: dict) -> None:
+    """Print one webhook event to stdout in a human-readable format."""
+    color = EVENT_COLORS.get(event_name, DEFAULT_COLOR)
+    label = color(event_name)
+
+    ts = body.get("timestamp", "")
+    time_str = _format_timestamp(ts)
+
+    # Header line
+    sandbox_id = body.get("sandbox_id") or "-"
+    print(f"\n{label}  {time_str}  sandbox={dim(sandbox_id)}")
+
+    # Fields (exclude known structural fields)
+    skip = {"event", "timestamp", "sandbox_id", "template_id"}
+    for key, value in body.items():
+        if key in skip:
+            continue
+        if key == "fields" and isinstance(value, dict):
+            # Sub-fields from the flattened `fields` map
+            for sk, sv in value.items():
+                if sk not in skip:
+                    print(f"  {dim(sk)}: {sv}")
+        else:
+            print(f"  {dim(key)}: {value}")
+
+    sys.stdout.flush()
+
+
+# ---------------------------------------------------------------------------
+# Request handler
+# ---------------------------------------------------------------------------
+
+class WebhookHandler(BaseHTTPRequestHandler):
+    """Handles POST /<webhook-path> from CubeAPI."""
+
+    # Shared across instances — set once at startup.
+    webhook_path: str = "/webhook"
+    secret: str | None = None
+
+    # Silence default request-line logging (we log in a prettier way).
+    def log_message(self, fmt, *args):
+        return
+
+    def _verify_signature(self, body: bytes) -> bool:
+        """Verify X-Cube-Signature-256 header against HMAC-SHA256 of body."""
+        if not self.secret:
+            return True  # no secret configured → skip verification
+
+        header = self.headers.get("X-Cube-Signature-256", "")
+        if not header.startswith("sha256="):
+            return False
+
+        expected_sig = header[len("sha256="):]
+        computed = hmac.new(
+            self.secret.encode("utf-8"), body, "sha256"
+        ).hexdigest()
+
+        # Constant-time comparison to prevent timing attacks.
+        return hmac.compare_digest(computed, expected_sig)
+
+    def _reply(self, status: int, msg: str):
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.end_headers()
+        self.wfile.write(json.dumps({"status": msg}).encode("utf-8"))
+
+    def do_POST(self):
+        if self.path != self.webhook_path:
+            self._reply(HTTPStatus.NOT_FOUND, "not found")
+            return
+
+        # Read body
+        length = int(self.headers.get("Content-Length", 0))
+        if length == 0:
+            self._reply(HTTPStatus.BAD_REQUEST, "empty body")
+            return
+        body = self.rfile.read(length)
+
+        # Verify HMAC signature
+        if not self._verify_signature(body):
+            self._reply(HTTPStatus.UNAUTHORIZED, "invalid signature")
+            return
+
+        # Parse JSON
+        try:
+            payload = json.loads(body)
+        except json.JSONDecodeError:
+            self._reply(HTTPStatus.BAD_REQUEST, "invalid JSON")
+            return
+
+        event_name = payload.get("event", "unknown")
+
+        # Acknowledge quickly
+        self._reply(HTTPStatus.OK, "ok")
+
+        # Display
+        display_event(event_name, payload)
+
+    # ── Health check (optional) ──────────────────────────────────────────
+    def do_GET(self):
+        if self.path == "/health":
+            self._reply(HTTPStatus.OK, "alive")
+        else:
+            self._reply(HTTPStatus.NOT_FOUND, "not found")
+
+    # Suppress noisy tracebacks for broken pipe / connection reset.
+    def handle_one_request(self):
+        try:
+            super().handle_one_request()
+        except (ConnectionResetError, BrokenPipeError):
+            pass
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Cube Sandbox Webhook Receiver",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=(
+            "Examples:\n"
+            "  python receiver.py\n"
+            "  python receiver.py --port 9999 --path /events\n"
+            "  WEBHOOK_SECRET=my-secret python receiver.py\n"
+        ),
+    )
+    parser.add_argument(
+        "--host", default="0.0.0.0",
+        help="Listen address (default: 0.0.0.0)",
+    )
+    parser.add_argument(
+        "--port", type=int, default=8081,
+        help="Listen port (default: 8081)",
+    )
+    parser.add_argument(
+        "--path", default="/webhook",
+        help="Webhook URL path (default: /webhook)",
+    )
+    return parser.parse_args(argv)
+
+
+def main() -> None:
+    args = parse_args()
+
+    # Pick up secret from environment (or fall back to command-line --secret).
+    secret = os.environ.get("WEBHOOK_SECRET") or None
+
+    # Patch the handler class.
+    WebhookHandler.webhook_path = args.path
+    WebhookHandler.secret = secret
+
+    # Logging
+    logging.basicConfig(level=logging.WARNING, format="%(message)s")
+
+    server = HTTPServer((args.host, args.port), WebhookHandler)
+
+    print(f"\n{bold(' Cube Sandbox Webhook Receiver '):─^50}")
+    print(f"  URL:     http://{args.host}:{args.port}{args.path}")
+    print(f"  Secret:  {'✓ enabled' if secret else '○ disabled (no signature check)'}")
+    print(f"{'─' * 50}")
+    print(f"  Listening for events…  (Ctrl+C to stop)\n")
+
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        print(f"\n{ dim('Shutting down…') }")
+        server.shutdown()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Closes https://github.com/TencentCloud/CubeSandbox/issues/642

## Summary

  Adds webhook event delivery to CubeAPI for real-time sandbox lifecycle callbacks. Includes a
  runnable receiver example and integration docs.

  ## Changes

  **Webhook delivery** (`src/logging/http.rs`):
  - POSTs JSON payloads to configured URLs with HMAC-SHA256 signing
  - Exponential-backoff retry (3 attempts: 200ms → 500ms → 1s)
  - Configurable event filter (comma-separated or `*`)

  **Config** (`src/config/mod.rs`): `CUBE_API_WEBHOOK_URLS`, `CUBE_API_WEBHOOK_EVENTS`,
  `CUBE_API_WEBHOOK_SECRET` — with a bugfix: default functions now actually read from env vars.

  **Tests**: 22 unit tests covering payload serialization, HMAC, event matching, HTTP delivery
  via mock server, multi-URL fan-out, and retry logic.

  **Docs**:
  - Integration guide (EN/ZH) with payload schema, signature verification in Python/Node/Go, and
  WeCom / Slack / PagerDuty forwarding examples
  - `examples/webhook-receiver/` — zero-dependency Python receiver with HMAC verification and
  bilingual READM

## Screenshots

  **Receiver output** — sandbox lifecycle events displayed in real time:

 <img width="1398" height="550" alt="image" src="https://github.com/user-attachments/assets/e5d4bfe6-d047-4e5d-936a-ec23e8d57bd9" />
<img width="1924" height="432" alt="image" src="https://github.com/user-attachments/assets/1773bea8-0625-40fe-bbd8-a3c60e42a072" />


