### PR TITLE
feat: add WebUI terminal gateway for sandboxes

### DIFF
--- a/CubeOps/go.mod
+++ b/CubeOps/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/golang-jwt/jwt/v5 v5.2.2
 	github.com/google/go-containerregistry v0.21.6
 	github.com/google/uuid v1.6.0
+	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674
 	github.com/ory/dockertest/v3 v3.12.0
 	github.com/tencentcloud/CubeSandbox/CubeDB v0.1.0
 	github.com/tencentcloud/CubeSandbox/cubelog v0.1.1-0.20260113105508-a996703fa42f

--- a/CubeOps/go.sum
+++ b/CubeOps/go.sum
@@ -242,3 +242,5 @@ modernc.org/sqlite v1.49.1 h1:dYGHTKcX1sJ+EQDnUzvz4TJ5GbuvhNJa8Fg6ElGx73U=
 modernc.org/sqlite v1.49.1/go.mod h1:m0w8xhwYUVY3H6pSDwc3gkJ/irZT/0YEXwBlhaxQEew=
 pgregory.net/rapid v1.2.0 h1:keKAYRcjm+e1F0oAuU5F5+YPAWcyxNNRK2wud503Gnk=
 pgregory.net/rapid v1.2.0/go.mod h1:PY5XlDGj0+V1FCq0o192FdRhpKHGTRIWBgqjDBTrq04=
+github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674 h1:JeSE6pjso5THxAzdVpqr6/geYxZytqFMBCOtn/ujyeo=
+github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674/go.mod h1:r4w70xmWCQKmi1ONH4KIaBptdivuRPyosB9RmPlGEwA=

--- a/CubeOps/internal/handler/terminal.go
+++ b/CubeOps/internal/handler/terminal.go
@@ -1,0 +1,792 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package handler
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/gorilla/websocket"
+	"github.com/tencentcloud/CubeSandbox/CubeOps/internal/auth"
+	"github.com/tencentcloud/CubeSandbox/CubeOps/internal/httputil"
+)
+
+const (
+	terminalGrantTTL        = 60 * time.Second
+	terminalIdleTimeout     = 30 * time.Minute
+	terminalRequestTimeout  = 10 * time.Second
+	terminalProtocol        = "cube-terminal.v1"
+	terminalGrantPrefix     = "grant."
+	terminalEnvdPort        = 49983
+	terminalDefaultRows     = 24
+	terminalDefaultCols     = 80
+	terminalMaxFrameBytes   = 64 * 1024
+	terminalMaxPending      = 1024
+	terminalMaxActive       = 256
+	connectContentType      = "application/connect+json"
+	connectProtocolVersion  = "1"
+	connectCompressedFlag   = byte(0x01)
+	connectEndStreamFlag    = byte(0x02)
+	maxConnectEnvelopeBytes = 64 * 1024 * 1024
+)
+
+type TerminalHandler struct {
+	cm            CubeMasterClient
+	sandboxDomain string
+	grants        *terminalGrantStore
+	httpClient    *http.Client
+}
+
+func NewTerminalHandler(cm CubeMasterClient, sandboxDomain string) *TerminalHandler {
+	return &TerminalHandler{
+		cm:            cm,
+		sandboxDomain: sandboxDomain,
+		grants:        newTerminalGrantStore(),
+		httpClient: &http.Client{
+			Transport: &http.Transport{MaxIdleConnsPerHost: 100},
+		},
+	}
+}
+
+func (h *TerminalHandler) RegisterAuthed(r *gin.RouterGroup) {
+	r.POST("/terminal/sandboxes/:id/sessions", h.CreateSession)
+}
+
+func (h *TerminalHandler) RegisterPublic(r *gin.Engine) {
+	r.GET("/sandboxes/:id/terminal", h.WebSocket)
+}
+
+type terminalCreateSessionRequest struct {
+	ContainerID string `json:"containerID"`
+}
+
+type terminalCreateSessionResponse struct {
+	Grant         string `json:"grant"`
+	ExpiresAt     string `json:"expiresAt"`
+	WebSocketPath string `json:"websocketPath"`
+	ContainerID   string `json:"containerID"`
+}
+
+func (h *TerminalHandler) CreateSession(c *gin.Context) {
+	sandboxID := c.Param("id")
+	var req terminalCreateSessionRequest
+	if c.Request.Body != nil {
+		_ = c.ShouldBindJSON(&req)
+	}
+
+	target, err := h.resolveTarget(c.Request.Context(), sandboxID, req.ContainerID)
+	if err != nil {
+		status := http.StatusBadRequest
+		if errors.Is(err, errTerminalSandboxNotRunning) {
+			status = http.StatusConflict
+		}
+		if errors.Is(err, errTerminalSandboxNotFound) {
+			status = http.StatusNotFound
+		}
+		httputil.WriteError(c, status, err.Error())
+		return
+	}
+
+	operator := c.GetString("username")
+	if operator == "" {
+		operator = auth.UsernameFromContext(c.Request.Context())
+	}
+	grant, expiresAt, err := h.grants.issue(terminalGrant{
+		Operator:    operator,
+		SandboxID:   sandboxID,
+		ContainerID: target.ContainerID,
+		Domain:      target.Domain,
+	})
+	if err != nil {
+		httputil.WriteError(c, http.StatusTooManyRequests, err.Error())
+		return
+	}
+
+	slog.Info("terminal.session.grant",
+		"operator", operator,
+		"sandbox_id", sandboxID,
+		"container_id", target.ContainerID,
+		"expires_at", expiresAt.UTC().Format(time.RFC3339),
+	)
+	httputil.WriteJSON(c, http.StatusOK, terminalCreateSessionResponse{
+		Grant:         grant,
+		ExpiresAt:     expiresAt.UTC().Format(time.RFC3339),
+		WebSocketPath: fmt.Sprintf("/sandboxes/%s/terminal", url.PathEscape(sandboxID)),
+		ContainerID:   target.ContainerID,
+	})
+}
+
+func (h *TerminalHandler) WebSocket(c *gin.Context) {
+	sandboxID := c.Param("id")
+	if !sameOrigin(c.Request) {
+		httputil.WriteError(c, http.StatusForbidden, "terminal websocket origin is not allowed")
+		return
+	}
+	grantToken, ok := terminalGrantFromProtocols(websocket.Subprotocols(c.Request))
+	if !ok {
+		httputil.WriteError(c, http.StatusUnauthorized, "missing terminal grant subprotocol")
+		return
+	}
+	grant, err := h.grants.consume(grantToken, sandboxID)
+	if err != nil {
+		httputil.WriteError(c, http.StatusUnauthorized, err.Error())
+		return
+	}
+
+	upgrader := websocket.Upgrader{
+		Subprotocols: []string{terminalProtocol},
+		CheckOrigin: func(r *http.Request) bool {
+			return sameOrigin(r)
+		},
+	}
+	conn, err := upgrader.Upgrade(c.Writer, c.Request, nil)
+	if err != nil {
+		h.grants.release(grant)
+		return
+	}
+	defer conn.Close()
+
+	sessionID := newTerminalID()
+	slog.Info("terminal.session.open",
+		"session_id", sessionID,
+		"operator", grant.Operator,
+		"sandbox_id", grant.SandboxID,
+		"container_id", grant.ContainerID,
+	)
+	defer func() {
+		h.grants.release(grant)
+		slog.Info("terminal.session.close",
+			"session_id", sessionID,
+			"operator", grant.Operator,
+			"sandbox_id", grant.SandboxID,
+			"container_id", grant.ContainerID,
+		)
+	}()
+
+	if err := h.bridgeEnvd(c.Request.Context(), conn, grant); err != nil {
+		slog.Warn("terminal.session.error",
+			"session_id", sessionID,
+			"operator", grant.Operator,
+			"sandbox_id", grant.SandboxID,
+			"container_id", grant.ContainerID,
+			"error", err,
+		)
+		_ = conn.WriteJSON(serverTerminalMessage{Type: "error", Message: publicTerminalError(err)})
+	}
+}
+
+type terminalTarget struct {
+	ContainerID string
+	Domain      string
+}
+
+var (
+	errTerminalSandboxNotFound   = errors.New("sandbox not found")
+	errTerminalSandboxNotRunning = errors.New("sandbox is not running")
+)
+
+func (h *TerminalHandler) resolveTarget(ctx context.Context, sandboxID, requestedContainerID string) (terminalTarget, error) {
+	raw, err := h.cm.GetSandbox(ctx, sandboxID, sdkInstanceType)
+	if err != nil {
+		return terminalTarget{}, err
+	}
+	var env cmEnvelope
+	if err := json.Unmarshal(raw, &env); err != nil {
+		return terminalTarget{}, err
+	}
+	if env.Ret != nil && env.Ret.RetCode != 0 && env.Ret.RetCode != 200 {
+		if env.Ret.RetCode == 130404 || env.Ret.RetCode == 404 {
+			return terminalTarget{}, errTerminalSandboxNotFound
+		}
+		return terminalTarget{}, fmt.Errorf("cubemaster error %d: %s", env.Ret.RetCode, env.Ret.RetMsg)
+	}
+	var items []cmSandboxDetailItem
+	if err := json.Unmarshal(env.Data, &items); err != nil || len(items) == 0 {
+		return terminalTarget{}, errTerminalSandboxNotFound
+	}
+	item := items[0]
+	if sandboxStateFromInt(item.Status) != "running" {
+		return terminalTarget{}, errTerminalSandboxNotRunning
+	}
+
+	containerID := requestedContainerID
+	if containerID == "" {
+		containerID = primaryTerminalContainer(item)
+	}
+	if containerID == "" {
+		containerID = sandboxID
+	}
+	if len(item.Containers) > 0 {
+		found := false
+		for _, container := range item.Containers {
+			if container.ContainerID == containerID {
+				found = true
+				if sandboxStateFromInt(container.Status) != "running" {
+					return terminalTarget{}, errors.New("target container is not running")
+				}
+				break
+			}
+		}
+		if !found {
+			return terminalTarget{}, fmt.Errorf("container %s not found", containerID)
+		}
+	}
+
+	domain := h.sandboxDomain
+	if domain == "" {
+		domain = sandboxDomain()
+	}
+	return terminalTarget{ContainerID: containerID, Domain: domain}, nil
+}
+
+func primaryTerminalContainer(item cmSandboxDetailItem) string {
+	for _, container := range item.Containers {
+		if container.Type == "sandbox" || container.ContainerID == item.SandboxID {
+			return container.ContainerID
+		}
+	}
+	if len(item.Containers) > 0 {
+		return item.Containers[0].ContainerID
+	}
+	return ""
+}
+
+type terminalGrant struct {
+	Token       string
+	Operator    string
+	SandboxID   string
+	ContainerID string
+	Domain      string
+	ExpiresAt   time.Time
+}
+
+type terminalGrantStore struct {
+	mu      sync.Mutex
+	pending map[string]terminalGrant
+	active  map[string]terminalGrant
+}
+
+func newTerminalGrantStore() *terminalGrantStore {
+	return &terminalGrantStore{
+		pending: make(map[string]terminalGrant),
+		active:  make(map[string]terminalGrant),
+	}
+}
+
+func (s *terminalGrantStore) issue(grant terminalGrant) (string, time.Time, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	now := time.Now()
+	s.sweepLocked(now)
+	if len(s.pending) >= terminalMaxPending {
+		return "", time.Time{}, errors.New("too many pending terminal sessions")
+	}
+	if len(s.active) >= terminalMaxActive {
+		return "", time.Time{}, errors.New("too many active terminal sessions")
+	}
+	token := newTerminalID()
+	grant.Token = token
+	grant.ExpiresAt = now.Add(terminalGrantTTL)
+	s.pending[token] = grant
+	return token, grant.ExpiresAt, nil
+}
+
+func (s *terminalGrantStore) consume(token, sandboxID string) (terminalGrant, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	now := time.Now()
+	s.sweepLocked(now)
+	grant, ok := s.pending[token]
+	if !ok {
+		return terminalGrant{}, errors.New("terminal grant is invalid or already used")
+	}
+	if grant.ExpiresAt.Before(now) {
+		delete(s.pending, token)
+		return terminalGrant{}, errors.New("terminal grant expired")
+	}
+	if grant.SandboxID != sandboxID {
+		return terminalGrant{}, errors.New("terminal grant target mismatch")
+	}
+	delete(s.pending, token)
+	s.active[token] = grant
+	return grant, nil
+}
+
+func (s *terminalGrantStore) release(grant terminalGrant) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.active, grant.Token)
+}
+
+func (s *terminalGrantStore) sweepLocked(now time.Time) {
+	for token, grant := range s.pending {
+		if grant.ExpiresAt.Before(now) {
+			delete(s.pending, token)
+		}
+	}
+}
+
+type clientTerminalMessage struct {
+	Type string `json:"type"`
+	Data string `json:"data,omitempty"`
+	Rows uint16 `json:"rows,omitempty"`
+	Cols uint16 `json:"cols,omitempty"`
+}
+
+type serverTerminalMessage struct {
+	Type     string `json:"type"`
+	Status   string `json:"status,omitempty"`
+	Message  string `json:"message,omitempty"`
+	PID      int64  `json:"pid,omitempty"`
+	Data     string `json:"data,omitempty"`
+	ExitCode *int64 `json:"exitCode,omitempty"`
+}
+
+func (h *TerminalHandler) bridgeEnvd(ctx context.Context, conn *websocket.Conn, grant terminalGrant) error {
+	writer := &terminalWSWriter{conn: conn}
+	if err := writer.writeJSON(serverTerminalMessage{Type: "status", Status: "connecting", Message: "Opening shell session..."}); err != nil {
+		return err
+	}
+	envd := &envdTerminalClient{
+		httpClient: h.httpClient,
+		sandboxID:  grant.SandboxID,
+		domain:     grant.Domain,
+	}
+	stream, err := envd.start(ctx, terminalDefaultRows, terminalDefaultCols)
+	if err != nil {
+		return fmt.Errorf("failed to start terminal: %w", err)
+	}
+	defer stream.Close()
+
+	var pid atomic.Int64
+	done := make(chan error, 2)
+	activity := make(chan struct{}, 1)
+
+	go func() {
+		for {
+			frame, err := stream.nextFrame()
+			if err != nil {
+				done <- err
+				return
+			}
+			if frame == nil {
+				done <- nil
+				return
+			}
+			if frame.flags&connectCompressedFlag != 0 {
+				done <- errors.New("compressed Connect frames are not supported")
+				return
+			}
+			if frame.flags&connectEndStreamFlag != 0 {
+				done <- connectErrorMessage(frame.payload)
+				return
+			}
+			event, err := parseTerminalEvent(frame.payload)
+			if err != nil {
+				done <- err
+				return
+			}
+			if event == nil {
+				continue
+			}
+			switch event.Type {
+			case "started":
+				pid.Store(event.PID)
+				_ = writer.writeJSON(serverTerminalMessage{Type: "started", PID: event.PID})
+			case "output":
+				if err := writer.writeJSON(serverTerminalMessage{Type: "output", Data: event.Data}); err != nil {
+					done <- err
+					return
+				}
+			case "closed":
+				_ = writer.writeJSON(serverTerminalMessage{Type: "closed", ExitCode: event.ExitCode})
+				done <- nil
+				return
+			}
+			nonblockingActivity(activity)
+		}
+	}()
+
+	go func() {
+		conn.SetReadLimit(terminalMaxFrameBytes)
+		for {
+			_, data, err := conn.ReadMessage()
+			if err != nil {
+				done <- nil
+				return
+			}
+			var msg clientTerminalMessage
+			if err := json.Unmarshal(data, &msg); err != nil {
+				_ = writer.writeJSON(serverTerminalMessage{Type: "error", Message: "invalid terminal message"})
+				continue
+			}
+			currentPID := pid.Load()
+			if currentPID <= 0 {
+				continue
+			}
+			switch msg.Type {
+			case "input":
+				if err := envd.sendInput(context.Background(), currentPID, msg.Data); err != nil {
+					done <- err
+					return
+				}
+			case "resize":
+				if msg.Rows > 0 && msg.Cols > 0 {
+					_ = envd.resize(context.Background(), currentPID, msg.Rows, msg.Cols)
+				}
+			case "close":
+				done <- nil
+				return
+			}
+			nonblockingActivity(activity)
+		}
+	}()
+
+	idle := time.NewTimer(terminalIdleTimeout)
+	defer idle.Stop()
+	for {
+		select {
+		case err := <-done:
+			currentPID := pid.Load()
+			if currentPID > 0 {
+				_ = envd.kill(context.Background(), currentPID)
+			}
+			return err
+		case <-activity:
+			if !idle.Stop() {
+				select {
+				case <-idle.C:
+				default:
+				}
+			}
+			idle.Reset(terminalIdleTimeout)
+		case <-idle.C:
+			currentPID := pid.Load()
+			if currentPID > 0 {
+				_ = envd.kill(context.Background(), currentPID)
+			}
+			_ = writer.writeJSON(serverTerminalMessage{Type: "error", Message: "terminal session timed out after 30 minutes of inactivity"})
+			return nil
+		case <-ctx.Done():
+			currentPID := pid.Load()
+			if currentPID > 0 {
+				_ = envd.kill(context.Background(), currentPID)
+			}
+			return nil
+		}
+	}
+}
+
+type terminalWSWriter struct {
+	mu   sync.Mutex
+	conn *websocket.Conn
+}
+
+func (w *terminalWSWriter) writeJSON(v any) error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.conn.WriteJSON(v)
+}
+
+type terminalEvent struct {
+	Type     string
+	PID      int64
+	Data     string
+	ExitCode *int64
+}
+
+func parseTerminalEvent(payload []byte) (*terminalEvent, error) {
+	var message map[string]any
+	if err := json.Unmarshal(payload, &message); err != nil {
+		return nil, fmt.Errorf("invalid envd event JSON: %w", err)
+	}
+	event, _ := message["event"].(map[string]any)
+	if event == nil {
+		return nil, nil
+	}
+	if start, _ := event["start"].(map[string]any); start != nil {
+		if rawPID, ok := start["pid"].(float64); ok {
+			return &terminalEvent{Type: "started", PID: int64(rawPID)}, nil
+		}
+	}
+	if data, _ := event["data"].(map[string]any); data != nil {
+		if pty, ok := data["pty"].(string); ok {
+			return &terminalEvent{Type: "output", Data: pty}, nil
+		}
+	}
+	if end, _ := event["end"].(map[string]any); end != nil {
+		var exitCode *int64
+		if raw, ok := end["exitCode"].(float64); ok {
+			v := int64(raw)
+			exitCode = &v
+		} else if raw, ok := end["exit_code"].(float64); ok {
+			v := int64(raw)
+			exitCode = &v
+		}
+		return &terminalEvent{Type: "closed", ExitCode: exitCode}, nil
+	}
+	return nil, nil
+}
+
+type envdTerminalClient struct {
+	httpClient *http.Client
+	sandboxID  string
+	domain     string
+}
+
+func (c *envdTerminalClient) start(ctx context.Context, rows, cols uint16) (*connectFrameStream, error) {
+	payload := map[string]any{
+		"process": map[string]any{
+			"cmd":  "/bin/bash",
+			"args": []string{"-i", "-l"},
+			"envs": map[string]string{
+				"TERM":   "xterm-256color",
+				"LANG":   "C.UTF-8",
+				"LC_ALL": "C.UTF-8",
+			},
+		},
+		"pty": map[string]any{"size": map[string]uint16{"rows": rows, "cols": cols}},
+	}
+	body, _ := json.Marshal(payload)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.url("Start"), bytes.NewReader(encodeConnectEnvelope(body, 0)))
+	if err != nil {
+		return nil, err
+	}
+	for k, v := range c.streamingHeaders() {
+		req.Header.Set(k, v)
+	}
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	if err := ensureEnvdSuccess(resp); err != nil {
+		return nil, err
+	}
+	return &connectFrameStream{reader: resp.Body}, nil
+}
+
+func (c *envdTerminalClient) sendInput(ctx context.Context, pid int64, data string) error {
+	payload := map[string]any{
+		"process": map[string]int64{"pid": pid},
+		"input":   map[string]string{"pty": base64.StdEncoding.EncodeToString([]byte(data))},
+	}
+	return c.unary(ctx, "SendInput", payload)
+}
+
+func (c *envdTerminalClient) resize(ctx context.Context, pid int64, rows, cols uint16) error {
+	payload := map[string]any{
+		"process": map[string]int64{"pid": pid},
+		"pty":     map[string]any{"size": map[string]uint16{"rows": rows, "cols": cols}},
+	}
+	return c.unary(ctx, "Update", payload)
+}
+
+func (c *envdTerminalClient) kill(ctx context.Context, pid int64) error {
+	payload := map[string]any{
+		"process": map[string]int64{"pid": pid},
+		"signal":  "SIGNAL_SIGKILL",
+	}
+	return c.unary(ctx, "SendSignal", payload)
+}
+
+func (c *envdTerminalClient) unary(ctx context.Context, method string, payload any) error {
+	body, _ := json.Marshal(payload)
+	ctx, cancel := context.WithTimeout(ctx, terminalRequestTimeout)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.url(method), bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	for k, v := range c.unaryHeaders() {
+		req.Header.Set(k, v)
+	}
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	return ensureEnvdSuccess(resp)
+}
+
+func (c *envdTerminalClient) url(method string) string {
+	return fmt.Sprintf("http://%d-%s.%s/process.Process/%s", terminalEnvdPort, c.sandboxID, c.domain, method)
+}
+
+func (c *envdTerminalClient) streamingHeaders() map[string]string {
+	return map[string]string{
+		"Content-Type":             connectContentType,
+		"Connect-Protocol-Version": connectProtocolVersion,
+		"Connect-Content-Encoding": "identity",
+		"Authorization":            "Basic " + base64.StdEncoding.EncodeToString([]byte("root:")),
+	}
+}
+
+func (c *envdTerminalClient) unaryHeaders() map[string]string {
+	return map[string]string{
+		"Content-Type":             "application/json",
+		"Connect-Protocol-Version": connectProtocolVersion,
+		"Authorization":            "Basic " + base64.StdEncoding.EncodeToString([]byte("root:")),
+	}
+}
+
+type connectFrame struct {
+	flags   byte
+	payload []byte
+}
+
+type connectFrameStream struct {
+	reader io.ReadCloser
+	buffer []byte
+}
+
+func (s *connectFrameStream) Close() error {
+	return s.reader.Close()
+}
+
+func (s *connectFrameStream) nextFrame() (*connectFrame, error) {
+	for {
+		if frame, err := takeConnectFrame(&s.buffer); err != nil || frame != nil {
+			return frame, err
+		}
+		chunk := make([]byte, 32*1024)
+		n, err := s.reader.Read(chunk)
+		if n > 0 {
+			s.buffer = append(s.buffer, chunk[:n]...)
+		}
+		if err == io.EOF {
+			if len(s.buffer) == 0 {
+				return nil, nil
+			}
+			return nil, errors.New("Connect stream ended with a partial frame")
+		}
+		if err != nil {
+			return nil, err
+		}
+	}
+}
+
+func takeConnectFrame(buffer *[]byte) (*connectFrame, error) {
+	buf := *buffer
+	if len(buf) < 5 {
+		return nil, nil
+	}
+	size := int(uint32(buf[1])<<24 | uint32(buf[2])<<16 | uint32(buf[3])<<8 | uint32(buf[4]))
+	if size > maxConnectEnvelopeBytes {
+		return nil, fmt.Errorf("Connect stream message too large: %d bytes", size)
+	}
+	if len(buf) < 5+size {
+		return nil, nil
+	}
+	frame := &connectFrame{flags: buf[0], payload: append([]byte(nil), buf[5:5+size]...)}
+	*buffer = buf[5+size:]
+	return frame, nil
+}
+
+func encodeConnectEnvelope(payload []byte, flags byte) []byte {
+	out := make([]byte, 0, 5+len(payload))
+	out = append(out, flags)
+	size := uint32(len(payload))
+	out = append(out, byte(size>>24), byte(size>>16), byte(size>>8), byte(size))
+	out = append(out, payload...)
+	return out
+}
+
+func ensureEnvdSuccess(resp *http.Response) error {
+	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		return nil
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+	detail := strings.TrimSpace(string(body))
+	if detail == "" {
+		return fmt.Errorf("envd returned HTTP %d", resp.StatusCode)
+	}
+	return fmt.Errorf("envd returned HTTP %d: %s", resp.StatusCode, detail)
+}
+
+func connectErrorMessage(payload []byte) error {
+	if len(payload) == 0 {
+		return nil
+	}
+	var message struct {
+		Error struct {
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(payload, &message); err != nil {
+		return err
+	}
+	if message.Error.Message == "" {
+		return nil
+	}
+	return errors.New(message.Error.Message)
+}
+
+func terminalGrantFromProtocols(protocols []string) (string, bool) {
+	hasProtocol := false
+	grantToken := ""
+	for _, protocol := range protocols {
+		if protocol == terminalProtocol {
+			hasProtocol = true
+			continue
+		}
+		if strings.HasPrefix(protocol, terminalGrantPrefix) {
+			grantToken = strings.TrimPrefix(protocol, terminalGrantPrefix)
+		}
+	}
+	return grantToken, hasProtocol && grantToken != ""
+}
+
+func sameOrigin(r *http.Request) bool {
+	origin := r.Header.Get("Origin")
+	if origin == "" {
+		return true
+	}
+	u, err := url.Parse(origin)
+	if err != nil {
+		return false
+	}
+	return strings.EqualFold(u.Host, r.Host)
+}
+
+func newTerminalID() string {
+	var b [16]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return fmt.Sprintf("%d", time.Now().UnixNano())
+	}
+	return hex.EncodeToString(b[:])
+}
+
+func nonblockingActivity(ch chan struct{}) {
+	select {
+	case ch <- struct{}{}:
+	default:
+	}
+}
+
+func publicTerminalError(err error) string {
+	if err == nil {
+		return ""
+	}
+	msg := err.Error()
+	if strings.Contains(msg, "envd returned HTTP") || strings.Contains(msg, "failed to start terminal") {
+		return msg
+	}
+	return "terminal session failed"
+}

--- a/CubeOps/internal/handler/terminal_test.go
+++ b/CubeOps/internal/handler/terminal_test.go
@@ -1,0 +1,60 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package handler
+
+import (
+	"testing"
+	"time"
+)
+
+func TestTerminalGrantFromProtocolsRequiresProtocolAndGrant(t *testing.T) {
+	token, ok := terminalGrantFromProtocols([]string{terminalGrantPrefix + "abc", terminalProtocol})
+	if !ok || token != "abc" {
+		t.Fatalf("expected order-independent grant parse, got token=%q ok=%v", token, ok)
+	}
+
+	if token, ok := terminalGrantFromProtocols([]string{terminalGrantPrefix + "abc"}); ok || token != "abc" {
+		t.Fatalf("expected grant without terminal protocol to be rejected, got token=%q ok=%v", token, ok)
+	}
+
+	if token, ok := terminalGrantFromProtocols([]string{terminalProtocol}); ok || token != "" {
+		t.Fatalf("expected terminal protocol without grant to be rejected, got token=%q ok=%v", token, ok)
+	}
+}
+
+func TestTerminalGrantStoreConsumesGrantOnce(t *testing.T) {
+	store := newTerminalGrantStore()
+	token, _, err := store.issue(terminalGrant{SandboxID: "sandbox-a", ContainerID: "container-a"})
+	if err != nil {
+		t.Fatalf("issue grant: %v", err)
+	}
+
+	grant, err := store.consume(token, "sandbox-a")
+	if err != nil {
+		t.Fatalf("consume grant: %v", err)
+	}
+	if grant.SandboxID != "sandbox-a" || grant.ContainerID != "container-a" {
+		t.Fatalf("unexpected grant: %#v", grant)
+	}
+
+	if _, err := store.consume(token, "sandbox-a"); err == nil {
+		t.Fatal("expected second consume to fail")
+	}
+}
+
+func TestTerminalGrantStoreRejectsExpiredAndMismatchedGrant(t *testing.T) {
+	store := newTerminalGrantStore()
+	store.pending["expired"] = terminalGrant{SandboxID: "sandbox-a", ExpiresAt: time.Now().Add(-time.Second)}
+	if _, err := store.consume("expired", "sandbox-a"); err == nil {
+		t.Fatal("expected expired grant to fail")
+	}
+
+	token, _, err := store.issue(terminalGrant{SandboxID: "sandbox-a"})
+	if err != nil {
+		t.Fatalf("issue grant: %v", err)
+	}
+	if _, err := store.consume(token, "sandbox-b"); err == nil {
+		t.Fatal("expected sandbox mismatch to fail")
+	}
+}

--- a/CubeOps/internal/server/server.go
+++ b/CubeOps/internal/server/server.go
@@ -92,6 +92,7 @@ func (s *Server) buildRouter() *gin.Engine {
 	storeH := handler.NewStoreHandler(handler.DefaultRegistryClient())
 	configH := handler.NewConfigHandler(s.cfg.Bind, 100, s.cfg.JWTSecret != "", s.cfg.SandboxDomain, "cubebox")
 	agenthubH := handler.NewAgentHubHandler(s.store, s.cm)
+	terminalH := handler.NewTerminalHandler(s.cm, s.cfg.SandboxDomain)
 	// SDK handler gets the AgentHubService so that E2B template/snapshot
 	// deletions can reverse-sync AgentHub registrations (matching the old
 	// Rust reverse_sync_agenthub_template that lived in CubeAPI).
@@ -100,6 +101,7 @@ func (s *Server) buildRouter() *gin.Engine {
 	// Public (no auth) routes — login + refresh.
 	public := r.Group("/api/v1")
 	authH.RegisterPublic(public)
+	terminalH.RegisterPublic(r)
 
 	// Authenticated routes. The session / logout / change-password endpoints
 	// are mounted here, behind the JWT middleware.
@@ -110,6 +112,7 @@ func (s *Server) buildRouter() *gin.Engine {
 	configH.Register(authed)
 	storeH.Register(authed)
 	agenthubH.Register(authed)
+	terminalH.RegisterAuthed(authed)
 
 	// SDK routes — mounted at both /api/v1/sdk and /api/v1/sdk/v2 because
 	// the WebUI and the E2B-compatible clients hit different prefixes.

--- a/CubeOps/internal/translator/translator.go
+++ b/CubeOps/internal/translator/translator.go
@@ -359,6 +359,19 @@ func TransformSandboxDetail(raw json.RawMessage) interface{} {
 		"hostID":      item.HostID,
 		"domain":      SandboxDomain(),
 	}
+	if len(item.Containers) > 0 {
+		containers := make([]map[string]interface{}, 0, len(item.Containers))
+		for _, container := range item.Containers {
+			containers = append(containers, map[string]interface{}{
+				"containerID": container.ContainerID,
+				"state":       SandboxStateFromInt(container.Status),
+				"image":       container.Image,
+				"type":        container.Type,
+				"startedAt":   NanosToISO(container.CreateAt),
+			})
+		}
+		result["containers"] = containers
+	}
 	if item.Labels != nil {
 		result["metadata"] = item.Labels
 	}

--- a/deploy/kubernetes/chart/templates/_helpers.tpl
+++ b/deploy/kubernetes/chart/templates/_helpers.tpl
@@ -303,6 +303,20 @@ http {
             proxy_pass {{ $opsUpstream }};
         }
 
+        location ~ ^/sandboxes/([^/]+)/terminal$ {
+            proxy_http_version 1.1;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection $connection_upgrade;
+            proxy_read_timeout 1800s;
+            proxy_send_timeout 1800s;
+
+            proxy_pass {{ $opsUpstream }};
+        }
+
         location = /health {
             proxy_pass {{ $opsUpstream }}/health;
         }

--- a/deploy/one-click/webui/nginx.conf
+++ b/deploy/one-click/webui/nginx.conf
@@ -85,6 +85,21 @@ http {
             proxy_pass __CUBE_OPS_UPSTREAM__;
         }
 
+        # Web Terminal WebSocket → CubeOps terminal gateway.
+        location ~ ^/sandboxes/([^/]+)/terminal$ {
+            proxy_http_version 1.1;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection $connection_upgrade;
+            proxy_read_timeout 1800s;
+            proxy_send_timeout 1800s;
+
+            proxy_pass __CUBE_OPS_UPSTREAM__;
+        }
+
         # Health check (no auth needed) — served by CubeOps :3010.
         # CubeOps exposes GET /health without JWT; WebUI does not depend on
         # CubeAPI for this, so the /health upstream points to CubeOps.

--- a/docs/guide/webui.md
+++ b/docs/guide/webui.md
@@ -111,6 +111,40 @@ The Command Palette's ⌘K input box and the topbar have quick toggles for the s
 **Why a separate Dashboard, not just curl?**
 Most operations (create-from-image, version matrix, node triage) are easier to discover and visualize in a UI. For automation, the Dashboard is just a thin client — every page is a call to `/cubeapi/v1/*`, which is the same E2B-compatible REST API you can hit with `curl` or the E2B SDK.
 
+## Web Terminal
+
+Running sandboxes expose an **Open terminal** action from the sandbox list and
+detail page. The Dashboard first asks CubeOps for a short-lived terminal grant,
+then opens a same-origin WebSocket to the CubeOps terminal gateway. CubeOps
+validates the sandbox state and bridges the session to the sandbox's
+interactive PTY API.
+
+Requirements:
+
+- The sandbox must be in the `running` state. Paused or ended sandboxes cannot
+  open a shell until they are resumed or recreated.
+- The browser only needs the Dashboard origin, for example
+  `http://<control-node-ip>:12088`. Do not expose CubeOps `:3010` directly.
+- The WebSocket path is `/sandboxes/<sandbox-id>/terminal` and must be proxied
+  with `Upgrade` / `Connection` headers when you place another reverse proxy in
+  front of the Dashboard.
+- Authenticated deployments never put the access token in the WebSocket URL.
+  The browser uses its normal JWT session to request a 60-second, single-use
+  grant from CubeOps, then sends that grant as a WebSocket subprotocol.
+- Terminal grants are stored in CubeOps memory. Run a single CubeOps replica or
+  configure sticky routing for deployments with multiple replicas.
+- CubeOps writes audit logs for grant creation, session open, close, and errors
+  with operator, session ID, sandbox ID, and container ID. Terminal input and
+  output are not logged.
+
+Basic verification:
+
+1. Create a sandbox from a `READY` template.
+2. Open **Sandboxes**, choose a running sandbox, and click **Open terminal**.
+3. Run `pwd`, `ls`, or `echo hello` and confirm output appears in the terminal.
+4. Resize the terminal dialog and confirm the shell layout follows the new size.
+5. Pause the sandbox and confirm the terminal action is disabled.
+
 **Does the Dashboard store my data?**
 It stores only one thing in your browser: the API key under `localStorage.cube.apiKey`. All other state (templates, sandboxes, logs) lives on the cluster.
 

--- a/docs/zh/guide/webui.md
+++ b/docs/zh/guide/webui.md
@@ -105,6 +105,36 @@ Dashboard 对键盘很友好。最常用的三个：
 **为什么还要单独做个 Dashboard，不能直接用 curl 吗？**
 绝大多数操作（从镜像创建模板、看版本矩阵、排查节点）在 UI 里更容易发现和理解。Dashboard 本质上只是 CubeAPI 的一个轻量客户端——每个页面背后都是一次 `/cubeapi/v1/*` 请求，这跟 E2B SDK、`curl` 调的是同一个 E2B 兼容 REST API。
 
+## Web Terminal
+
+运行中的沙箱会在列表页和详情页显示 **打开终端** 操作。浏览器会连接
+CubeOps 申请一个短时终端 grant，然后通过同源 WebSocket 连接 CubeOps
+终端网关。CubeOps 会校验沙箱状态，再把会话桥接到沙箱内的交互式 PTY
+API。
+
+使用条件：
+
+- 沙箱必须处于 `running` 状态。已暂停或已结束的沙箱需要先恢复或重新创建。
+- 浏览器只需要访问 Dashboard 同源地址，例如
+  `http://<控制节点IP>:12088`。不要把 CubeOps 的 `:3010` 直接暴露到公网。
+- WebSocket 路径是 `/sandboxes/<sandbox-id>/terminal`。如果你在 Dashboard
+  前面再加一层反向代理，需要转发 `Upgrade` / `Connection` 头。
+- 开启鉴权时，access token 不会出现在 WebSocket URL 里。浏览器先用正常
+  JWT 会话向 CubeOps 申请 60 秒有效、单次使用的 grant，再把 grant 作为
+  WebSocket subprotocol 发送。
+- 终端 grant 保存在 CubeOps 进程内存里。多副本部署时请使用单个 CubeOps
+  replica，或配置 sticky routing。
+- CubeOps 会记录 grant 创建、会话打开、关闭和错误的审计日志，字段包括
+  operator、session ID、sandbox ID、container ID；不会记录终端输入输出。
+
+基础验证：
+
+1. 使用 `READY` 模板创建一个沙箱。
+2. 打开 **Sandboxes**，选择运行中的沙箱并点击 **打开终端**。
+3. 执行 `pwd`、`ls` 或 `echo hello`，确认终端正常显示输出。
+4. 调整终端弹窗大小，确认 shell 布局会随窗口尺寸同步变化。
+5. 暂停沙箱，确认终端入口被禁用。
+
 **Dashboard 会保存我的数据吗？**
 只会在浏览器里保存一样东西：`localStorage.cube.apiKey` 里的 API Key。其他所有状态（模板、沙箱、日志）都在集群上。
 

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -22,6 +22,8 @@
         "@radix-ui/react-toast": "^1.2.2",
         "@radix-ui/react-tooltip": "^1.1.3",
         "@tanstack/react-query": "^5.59.0",
+        "@xterm/addon-fit": "^0.11.0",
+        "@xterm/xterm": "^6.0.0",
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.1.1",
         "cmdk": "^1.0.0",
@@ -2979,6 +2981,21 @@
       "peerDependencies": {
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
+    },
+    "node_modules/@xterm/addon-fit": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@xterm/addon-fit/-/addon-fit-0.11.0.tgz",
+      "integrity": "sha512-jYcgT6xtVYhnhgxh3QgYDnnNMYTcf8ElbxxFzX0IZo+vabQqSPAjC3c1wJrKB5E19VwQei89QCiZZP86DCPF7g==",
+      "license": "MIT"
+    },
+    "node_modules/@xterm/xterm": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@xterm/xterm/-/xterm-6.0.0.tgz",
+      "integrity": "sha512-TQwDdQGtwwDt+2cgKDLn0IRaSxYu1tSUjgKarSDkUM0ZNiSRXFpjxEsvc/Zgc5kq5omJ+V0a8/kIM2WD3sMOYg==",
+      "license": "MIT",
+      "workspaces": [
+        "addons/*"
+      ]
     },
     "node_modules/agent-base": {
       "version": "7.1.4",

--- a/web/package.json
+++ b/web/package.json
@@ -28,6 +28,8 @@
     "@radix-ui/react-toast": "^1.2.2",
     "@radix-ui/react-tooltip": "^1.1.3",
     "@tanstack/react-query": "^5.59.0",
+    "@xterm/addon-fit": "^0.11.0",
+    "@xterm/xterm": "^6.0.0",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",
     "cmdk": "^1.0.0",

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -19,7 +19,24 @@ export type ComponentVersionDto = components['schemas']['ComponentVersionView'];
 
 export interface RunningSandbox extends ListedSandboxDto {}
 
-export interface SandboxDetail extends SandboxDetailDto {}
+export interface SandboxContainer {
+  containerID: string;
+  state?: string;
+  image?: string;
+  type?: string;
+  startedAt?: string;
+}
+
+export interface SandboxDetail extends SandboxDetailDto {
+  containers?: SandboxContainer[];
+}
+
+export interface TerminalSession {
+  grant: string;
+  expiresAt: string;
+  websocketPath: string;
+  containerID: string;
+}
 
 export interface TemplateSummary {
   templateID: string;
@@ -117,7 +134,7 @@ function mapSandbox(dto: ListedSandboxDto): RunningSandbox {
 }
 
 function mapSandboxDetail(dto: SandboxDetailDto): SandboxDetail {
-  return dto;
+  return dto as SandboxDetail;
 }
 
 function mapTemplateSummary(dto: TemplateSummaryDto): TemplateSummary {
@@ -221,6 +238,14 @@ export const sandboxApi = {
     api<SandboxLogsDto>(`/v2/sandboxes/${id}/logs`, { params }),
   create: (body: { templateID: string; timeout?: number; metadata?: Record<string, string> }) =>
     api<SandboxSessionDto>('/sandboxes', {
+      method: 'POST',
+      body: JSON.stringify(body),
+    }),
+};
+
+export const terminalApi = {
+  createSession: (sandboxID: string, body: { containerID?: string } = {}) =>
+    ops<TerminalSession>(`/terminal/sandboxes/${encodeURIComponent(sandboxID)}/sessions`, {
       method: 'POST',
       body: JSON.stringify(body),
     }),

--- a/web/src/components/SandboxTerminalDialog.tsx
+++ b/web/src/components/SandboxTerminalDialog.tsx
@@ -1,0 +1,258 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2026 Tencent. All rights reserved.
+
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { FitAddon } from '@xterm/addon-fit';
+import { Terminal } from '@xterm/xterm';
+import '@xterm/xterm/css/xterm.css';
+import { useTranslation } from 'react-i18next';
+import { X, RotateCw, Maximize2 } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { terminalApi } from '@/api/client';
+import { cn } from '@/lib/utils';
+
+type ConnectionState = 'idle' | 'connecting' | 'connected' | 'closed' | 'error';
+
+interface TerminalMessage {
+  type: 'status' | 'started' | 'output' | 'error' | 'closed';
+  status?: string;
+  message?: string;
+  pid?: number;
+  data?: string;
+  exitCode?: number | null;
+}
+
+export function SandboxTerminalDialog({
+  sandboxID,
+  containerID,
+  open,
+  onOpenChange,
+}: {
+  sandboxID: string;
+  containerID?: string;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}) {
+  const { t } = useTranslation('sandboxDetail');
+  const containerRef = useRef<HTMLDivElement>(null);
+  const terminalRef = useRef<Terminal | null>(null);
+  const fitRef = useRef<FitAddon | null>(null);
+  const socketRef = useRef<WebSocket | null>(null);
+  const cleanupRef = useRef<(() => void) | null>(null);
+  const connectSeqRef = useRef(0);
+  const [connectionState, setConnectionState] = useState<ConnectionState>('idle');
+  const [fullscreen, setFullscreen] = useState(false);
+  const [pid, setPid] = useState<number | null>(null);
+  const title = useMemo(() => t('terminal.title', { id: sandboxID }), [sandboxID, t]);
+
+  const connect = async () => {
+    if (!open || !containerRef.current) return;
+    const connectSeq = connectSeqRef.current + 1;
+    connectSeqRef.current = connectSeq;
+    cleanupRef.current?.();
+    cleanupRef.current = null;
+
+    const fit = new FitAddon();
+    const term = new Terminal({
+      cursorBlink: true,
+      convertEol: true,
+      fontFamily: 'JetBrains Mono Variable, ui-monospace, SFMono-Regular, Menlo, monospace',
+      fontSize: 13,
+      lineHeight: 1.15,
+      theme: {
+        background: '#080b12',
+        foreground: '#d7dde8',
+        cursor: '#ffffff',
+        selectionBackground: '#334155',
+      },
+    });
+    terminalRef.current = term;
+    fitRef.current = fit;
+    term.loadAddon(fit);
+    term.open(containerRef.current);
+    fit.fit();
+    term.focus();
+    term.writeln(t('terminal.connecting'));
+    setConnectionState('connecting');
+    setPid(null);
+
+    let session;
+    try {
+      session = await terminalApi.createSession(sandboxID, { containerID });
+    } catch (err) {
+      if (connectSeq !== connectSeqRef.current) {
+        term.dispose();
+        return;
+      }
+      setConnectionState('error');
+      term.writeln(`\r\n${t('terminal.error', { message: err instanceof Error ? err.message : String(err) })}`);
+      terminalRef.current = null;
+      fitRef.current = null;
+      term.dispose();
+      return;
+    }
+    if (connectSeq !== connectSeqRef.current || !open || !containerRef.current) {
+      term.dispose();
+      return;
+    }
+    const endpoint = resolveTerminalEndpoint(session.websocketPath);
+    const ws = new WebSocket(endpoint, ['cube-terminal.v1', `grant.${session.grant}`]);
+    socketRef.current = ws;
+
+    const sendResize = () => {
+      fit.fit();
+      const { rows, cols } = term;
+      if (ws.readyState === WebSocket.OPEN) {
+        ws.send(JSON.stringify({ type: 'resize', rows, cols }));
+      }
+    };
+
+    ws.onopen = () => {
+      setConnectionState('connected');
+      sendResize();
+    };
+    ws.onmessage = (event) => {
+      const message = parseMessage(event.data);
+      if (!message) return;
+      switch (message.type) {
+        case 'status':
+          if (message.message) term.writeln(message.message);
+          break;
+        case 'started':
+          setPid(message.pid ?? null);
+          term.writeln(t('terminal.connected', { pid: message.pid ?? '-' }));
+          break;
+        case 'output':
+          if (message.data) {
+            term.write(decodeBase64(message.data));
+          }
+          break;
+        case 'error':
+          setConnectionState('error');
+          term.writeln(`\r\n${t('terminal.error', { message: message.message ?? '' })}`);
+          break;
+        case 'closed':
+          setConnectionState('closed');
+          term.writeln(`\r\n${t('terminal.closed', { code: message.exitCode ?? '-' })}`);
+          break;
+      }
+    };
+    ws.onerror = () => {
+      setConnectionState('error');
+      term.writeln(`\r\n${t('terminal.socketError')}`);
+    };
+    ws.onclose = () => {
+      setConnectionState((current) => (current === 'error' ? 'error' : 'closed'));
+    };
+
+    const disposable = term.onData((data) => {
+      if (ws.readyState === WebSocket.OPEN) {
+        ws.send(JSON.stringify({ type: 'input', data }));
+      }
+    });
+
+    const observer = new ResizeObserver(sendResize);
+    observer.observe(containerRef.current);
+
+    const cleanup = () => {
+      observer.disconnect();
+      disposable.dispose();
+      if (ws.readyState === WebSocket.OPEN) {
+        ws.send(JSON.stringify({ type: 'close' }));
+      }
+      ws.close();
+      term.dispose();
+      if (socketRef.current === ws) socketRef.current = null;
+      if (terminalRef.current === term) terminalRef.current = null;
+      if (fitRef.current === fit) fitRef.current = null;
+    };
+    cleanupRef.current = cleanup;
+    return cleanup;
+  };
+
+  useEffect(() => {
+    if (!open) return undefined;
+    void connect();
+    return () => {
+      connectSeqRef.current += 1;
+      cleanupRef.current?.();
+      cleanupRef.current = null;
+    };
+    // Reconnect only when the dialog is opened for a new sandbox.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open, sandboxID, containerID]);
+
+  useEffect(() => {
+    if (!open) {
+      connectSeqRef.current += 1;
+      cleanupRef.current?.();
+      cleanupRef.current = null;
+      setConnectionState('idle');
+      setPid(null);
+      setFullscreen(false);
+    }
+  }, [open]);
+
+  if (!open) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-background/80 p-4 backdrop-blur-sm">
+      <div
+        className={cn(
+          'flex flex-col overflow-hidden rounded-lg border border-border bg-card shadow-2xl',
+          fullscreen ? 'h-[calc(100vh-32px)] w-[calc(100vw-32px)]' : 'h-[72vh] w-[min(1040px,calc(100vw-32px))]',
+        )}
+      >
+        <div className="flex min-h-12 items-center gap-3 border-b border-border px-4">
+          <div className="min-w-0 flex-1">
+            <div className="truncate text-sm font-medium">{title}</div>
+            <div className="truncate font-mono text-xs text-muted-foreground">
+              {pid ? t('terminal.pid', { pid }) : t('terminal.noPid')}
+            </div>
+          </div>
+          <Badge tone={connectionState === 'connected' ? 'ok' : connectionState === 'error' ? 'err' : 'mute'}>
+            {t(`terminal.state.${connectionState}` as const)}
+          </Badge>
+          <Button size="icon" variant="ghost" title={t('terminal.reconnect')} onClick={connect}>
+            <RotateCw size={14} />
+          </Button>
+          <Button
+            size="icon"
+            variant="ghost"
+            title={t('terminal.fullscreen')}
+            onClick={() => setFullscreen((value) => !value)}
+          >
+            <Maximize2 size={14} />
+          </Button>
+          <Button size="icon" variant="ghost" title={t('terminal.close')} onClick={() => onOpenChange(false)}>
+            <X size={15} />
+          </Button>
+        </div>
+        <div className="min-h-0 flex-1 bg-[#080b12] p-3">
+          <div ref={containerRef} className="h-full w-full overflow-hidden" />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function parseMessage(data: unknown): TerminalMessage | null {
+  if (typeof data !== 'string') return null;
+  try {
+    return JSON.parse(data) as TerminalMessage;
+  } catch {
+    return null;
+  }
+}
+
+function decodeBase64(value: string): string {
+  const binary = window.atob(value);
+  const bytes = Uint8Array.from(binary, (char) => char.charCodeAt(0));
+  return new TextDecoder().decode(bytes);
+}
+
+function resolveTerminalEndpoint(path: string): string {
+  const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
+  return `${protocol}//${window.location.host}${path}`;
+}

--- a/web/src/locales/en/sandboxDetail.json
+++ b/web/src/locales/en/sandboxDetail.json
@@ -45,6 +45,29 @@
     "pause": "Pause",
     "kill": "Kill"
   },
+  "terminal": {
+    "open": "Open terminal",
+    "container": "Terminal container",
+    "requiresRunning": "Terminal is available only while the sandbox is running.",
+    "title": "Terminal · {{id}}",
+    "connecting": "Opening terminal session...",
+    "connected": "Connected to shell process {{pid}}.",
+    "closed": "Terminal session closed (exit {{code}}).",
+    "error": "Terminal error: {{message}}",
+    "socketError": "Terminal connection failed.",
+    "pid": "PID {{pid}}",
+    "noPid": "Waiting for shell",
+    "reconnect": "Reconnect",
+    "fullscreen": "Toggle fullscreen",
+    "close": "Close",
+    "state": {
+      "idle": "Idle",
+      "connecting": "Connecting",
+      "connected": "Connected",
+      "closed": "Closed",
+      "error": "Error"
+    }
+  },
   "errors": {
     "unknown": "Unknown error",
     "actionFailed": "Action failed: {{message}}",

--- a/web/src/locales/en/sandboxes.json
+++ b/web/src/locales/en/sandboxes.json
@@ -25,7 +25,9 @@
   "actions": {
     "resume": "Resume",
     "pause": "Pause",
-    "kill": "Kill"
+    "kill": "Kill",
+    "terminal": "Open terminal",
+    "terminalDisabled": "Terminal is available only while the sandbox is running."
   },
   "errors": {
     "unknown": "Unknown error",

--- a/web/src/locales/zh/sandboxDetail.json
+++ b/web/src/locales/zh/sandboxDetail.json
@@ -45,6 +45,29 @@
     "pause": "暂停",
     "kill": "终止"
   },
+  "terminal": {
+    "open": "打开终端",
+    "container": "终端容器",
+    "requiresRunning": "仅运行中的沙箱可以打开终端。",
+    "title": "终端 · {{id}}",
+    "connecting": "正在打开终端会话...",
+    "connected": "已连接到 shell 进程 {{pid}}。",
+    "closed": "终端会话已关闭 (退出码 {{code}})。",
+    "error": "终端错误: {{message}}",
+    "socketError": "终端连接失败。",
+    "pid": "PID {{pid}}",
+    "noPid": "等待 shell",
+    "reconnect": "重新连接",
+    "fullscreen": "切换全屏",
+    "close": "关闭",
+    "state": {
+      "idle": "空闲",
+      "connecting": "连接中",
+      "connected": "已连接",
+      "closed": "已关闭",
+      "error": "错误"
+    }
+  },
   "errors": {
     "unknown": "未知错误",
     "actionFailed": "操作失败: {{message}}",

--- a/web/src/locales/zh/sandboxes.json
+++ b/web/src/locales/zh/sandboxes.json
@@ -25,7 +25,9 @@
   "actions": {
     "resume": "恢复",
     "pause": "暂停",
-    "kill": "终止"
+    "kill": "终止",
+    "terminal": "打开终端",
+    "terminalDisabled": "仅运行中的沙箱可以打开终端。"
   },
   "errors": {
     "unknown": "未知错误",

--- a/web/src/pages/SandboxDetail.tsx
+++ b/web/src/pages/SandboxDetail.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (C) 2026 Tencent. All rights reserved.
 
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { useNavigate, useParams, Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
@@ -12,10 +12,11 @@ import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 
 import { Skeleton } from '@/components/ui/skeleton';
-import { ArrowLeft, Pause, Play, Trash2, RefreshCw } from 'lucide-react';
+import { ArrowLeft, Pause, Play, Trash2, RefreshCw, Terminal } from 'lucide-react';
 import { cn, formatBytes, formatRelative } from '@/lib/utils';
 import { formatSandboxActionError } from '@/lib/sandboxActionError';
 import { SandboxActionErrorBanner } from '@/components/SandboxActionErrorBanner';
+import { SandboxTerminalDialog } from '@/components/SandboxTerminalDialog';
 
 // ── Log level colors ────────────────────────────────────────────────────────
 const LEVEL_CLASS: Record<string, string> = {
@@ -77,6 +78,8 @@ export default function SandboxDetailPage() {
   }, [logs.data]);
 
   const [actionError, setActionError] = useState<string | null>(null);
+  const [terminalOpen, setTerminalOpen] = useState(false);
+  const [terminalContainerID, setTerminalContainerID] = useState('');
   const onLifecycleError = (err: unknown) => {
     setActionError(formatSandboxActionError(err, t));
   };
@@ -111,6 +114,19 @@ export default function SandboxDetailPage() {
   });
 
   const state = data?.state ?? (isLoading ? 'loading' : 'unknown');
+  const terminalContainers = useMemo(
+    () => data?.containers?.filter((container) => container.state === 'running') ?? [],
+    [data?.containers],
+  );
+  useEffect(() => {
+    if (terminalContainers.length === 0) {
+      setTerminalContainerID('');
+      return;
+    }
+    if (!terminalContainers.some((container) => container.containerID === terminalContainerID)) {
+      setTerminalContainerID(terminalContainers[0].containerID);
+    }
+  }, [terminalContainers, terminalContainerID]);
   const tone =
     state === 'paused' || state === 'pausing' ? 'warn' : state === 'running' ? 'ok' : 'mute';
   const entries = logs.data?.logs ?? [];
@@ -219,6 +235,29 @@ export default function SandboxDetailPage() {
         </div>
         {data ? (
           <div className="flex gap-2">
+            {terminalContainers.length > 1 ? (
+              <select
+                className="h-9 rounded-md border border-input bg-background/50 px-2 text-sm"
+                value={terminalContainerID}
+                onChange={(event) => setTerminalContainerID(event.target.value)}
+                disabled={state !== 'running'}
+                title={t('terminal.container')}
+              >
+                {terminalContainers.map((container) => (
+                  <option key={container.containerID} value={container.containerID}>
+                    {container.containerID}
+                  </option>
+                ))}
+              </select>
+            ) : null}
+            <Button
+              variant="outline"
+              onClick={() => setTerminalOpen(true)}
+              disabled={state !== 'running'}
+              title={state === 'running' ? t('terminal.open') : t('terminal.requiresRunning')}
+            >
+              <Terminal size={14} /> {t('terminal.open')}
+            </Button>
             {state === 'paused' ? (
               <Button variant="outline" onClick={() => resume.mutate()} disabled={resume.isPending}>
                 <Play size={14} /> {t('actions.resume')}
@@ -236,6 +275,12 @@ export default function SandboxDetailPage() {
       </div>
 
       <SandboxActionErrorBanner message={actionError} onDismiss={() => setActionError(null)} />
+      <SandboxTerminalDialog
+        sandboxID={sandboxID}
+        containerID={terminalContainerID || undefined}
+        open={terminalOpen}
+        onOpenChange={setTerminalOpen}
+      />
       {detail.isError && data ? (
         <div className="rounded-md border border-cube-warn/30 bg-cube-warn/10 px-3 py-2 text-sm text-cube-warn">
           {t('refreshFailed')}

--- a/web/src/pages/Sandboxes.tsx
+++ b/web/src/pages/Sandboxes.tsx
@@ -11,11 +11,12 @@ import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { Skeleton } from '@/components/ui/skeleton';
-import { Pause, Play, Trash2, Search, Plus } from 'lucide-react';
+import { Pause, Play, Trash2, Search, Plus, Terminal } from 'lucide-react';
 import { formatBytes, formatRelative, short } from '@/lib/utils';
 import { cn } from '@/lib/utils';
 import { formatSandboxActionError } from '@/lib/sandboxActionError';
 import { SandboxActionErrorBanner } from '@/components/SandboxActionErrorBanner';
+import { SandboxTerminalDialog } from '@/components/SandboxTerminalDialog';
 
 type StateFilter = 'all' | 'running' | 'paused';
 
@@ -39,6 +40,7 @@ export default function SandboxesPage() {
 
   const [pendingId, setPendingId] = useState<string | null>(null);
   const [actionError, setActionError] = useState<string | null>(null);
+  const [terminalSandboxId, setTerminalSandboxId] = useState<string | null>(null);
 
   const onLifecycleError = (err: unknown) => {
     setActionError(formatSandboxActionError(err, t));
@@ -115,6 +117,13 @@ export default function SandboxesPage() {
       </header>
 
       <SandboxActionErrorBanner message={actionError} onDismiss={() => setActionError(null)} />
+      <SandboxTerminalDialog
+        sandboxID={terminalSandboxId ?? ''}
+        open={terminalSandboxId !== null}
+        onOpenChange={(open) => {
+          if (!open) setTerminalSandboxId(null);
+        }}
+      />
 
       <Card className="!p-3">
         <div className="flex items-center gap-2">
@@ -164,7 +173,7 @@ export default function SandboxesPage() {
       </Card>
 
       <Card className="!p-0 overflow-hidden">
-        <div className="grid grid-cols-[120px_minmax(200px,1.2fr)_minmax(160px,1fr)_110px_120px_130px_120px_120px] gap-2 border-b border-border/60 px-4 py-3 text-xs uppercase tracking-wider font-medium text-muted-foreground/85">
+        <div className="grid grid-cols-[120px_minmax(200px,1.2fr)_minmax(160px,1fr)_110px_120px_130px_120px_150px] gap-2 border-b border-border/60 px-4 py-3 text-xs uppercase tracking-wider font-medium text-muted-foreground/85">
           <div>{t('col.state')}</div>
           <div>{t('col.sandboxId')}</div>
           <div>{t('col.template')}</div>
@@ -187,6 +196,7 @@ export default function SandboxesPage() {
             onKill={() => killMut.mutate(sb.sandboxID)}
             onPause={() => pauseMut.mutate(sb.sandboxID)}
             onResume={() => resumeMut.mutate(sb.sandboxID)}
+            onTerminal={() => setTerminalSandboxId(sb.sandboxID)}
             busy={pendingId === sb.sandboxID}
           />
         ))}
@@ -203,19 +213,21 @@ function Row({
   onKill,
   onPause,
   onResume,
+  onTerminal,
   busy,
 }: {
   sb: RunningSandbox;
   onKill: () => void;
   onPause: () => void;
   onResume: () => void;
+  onTerminal: () => void;
   busy: boolean;
 }) {
   const { t } = useTranslation('sandboxes');
   const state = sb.state ?? 'running';
   const tone = state === 'paused' ? 'warn' : state === 'running' ? 'ok' : 'mute';
   return (
-    <div className="grid grid-cols-[120px_minmax(200px,1.2fr)_minmax(160px,1fr)_110px_120px_130px_120px_120px] gap-2 border-b border-border/60 px-4 py-3 text-sm transition hover:bg-muted/50">
+    <div className="grid grid-cols-[120px_minmax(200px,1.2fr)_minmax(160px,1fr)_110px_120px_130px_120px_150px] gap-2 border-b border-border/60 px-4 py-3 text-sm transition hover:bg-muted/50">
       <div>
         <Badge tone={tone as any}>{state}</Badge>
       </div>
@@ -236,6 +248,15 @@ function Row({
       <div className="text-xs text-muted-foreground/80 text-num">{sb.clientID || '—'}</div>
       <div className="text-xs text-muted-foreground">{formatRelative(sb.startedAt)}</div>
       <div className="flex justify-end gap-1">
+        <Button
+          size="icon"
+          variant="ghost"
+          title={state === 'running' ? t('actions.terminal') : t('actions.terminalDisabled')}
+          onClick={onTerminal}
+          disabled={busy || state !== 'running'}
+        >
+          <Terminal size={14} />
+        </Button>
         {state === 'paused' ? (
           <Button
             size="icon"


### PR DESCRIPTION
## Summary
- Add an ops-only Web Terminal flow for running sandboxes: WebUI requests a short-lived CubeOps grant, then opens a same-origin WebSocket with `cube-terminal.v1` + `grant.*` subprotocols.
- Add CubeOps terminal session validation, single-use in-memory grants, same-origin checks, frame limits, idle cleanup, PTY bridging to envd, and audit logs for grant/open/close/error events without recording terminal payloads.
- Add xterm.js terminal UI on sandbox list/detail pages, container selection on the detail page, i18n strings, nginx WebSocket proxy rules, and WebUI documentation.

## Test Plan
- `GOPROXY=https://goproxy.cn,direct /Users/hanlinye/.local/go/bin/go test ./internal/handler -run 'TestTerminalGrant'`
- `npm run lint`
- `npm run build`
- `git diff --check`

## Notes / Remaining Validation
- This PR intentionally keeps the public/control-plane entry in CubeOps and does not add CubeAPI terminal routes.
- Full `go test ./...` in CubeOps was attempted locally but the broader `internal/handler` suite did not finish in this macOS environment and was interrupted after several minutes; the terminal grant targeted tests pass.
- End-to-end terminal verification still needs a Linux/KVM CubeSandbox deployment. Planned manual checks: create a running sandbox, open terminal, run `pwd`, `ls`, `echo hello`, verify resize/copy-paste/reconnect/close, paused-state disablement, and collect screenshots plus CubeOps audit logs.
- Current implementation bridges CubeOps to the sandbox envd PTY endpoint. A later revision may replace this backend bridge with a CubeMaster/Cubelet internal terminal relay if maintainers prefer that shape for multi-node routing.

Closes #643
