### PR TITLE
feat(deploy): add pre-check for eBPF filesystem

### DIFF
--- a/deploy/kubernetes/chart/templates/node-bootstrap-daemonset.yaml
+++ b/deploy/kubernetes/chart/templates/node-bootstrap-daemonset.yaml
@@ -147,6 +147,8 @@ spec:
               value: {{ .Values.bootstrap.nodeInit.minMemoryKB | quote }}
             - name: CHECK_CGROUP_CPU
               value: {{ .Values.bootstrap.nodeInit.checkCgroupCPU | quote }}
+            - name: CHECK_BPF_FS
+              value: {{ .Values.bootstrap.nodeInit.checkBPFFS | quote }}
             - name: CHECK_GLIBC
               value: {{ .Values.bootstrap.nodeInit.checkGlibc | quote }}
             - name: CHECK_CIDR

--- a/deploy/kubernetes/chart/values.yaml
+++ b/deploy/kubernetes/chart/values.yaml
@@ -883,6 +883,7 @@ bootstrap:
     checkMemory: true
     minMemoryKB: "7500000"
     checkCgroupCPU: true
+    checkBPFFS: true
     checkGlibc: true
     checkCIDR: true
     checkCubecowDeps: true

--- a/deploy/kubernetes/images/scripts/cube-node-init.sh
+++ b/deploy/kubernetes/images/scripts/cube-node-init.sh
@@ -22,6 +22,7 @@ CUBE_MASTER_ENDPOINT="${CUBE_MASTER_ENDPOINT:-cube-master.cube-system.svc.cluste
 CHECK_MEMORY="${CHECK_MEMORY:-true}"
 MIN_MEMORY_KB="${MIN_MEMORY_KB:-7500000}"
 CHECK_CGROUP_CPU="${CHECK_CGROUP_CPU:-true}"
+CHECK_BPF_FS="${CHECK_BPF_FS:-true}"
 CHECK_GLIBC="${CHECK_GLIBC:-true}"
 CHECK_CIDR="${CHECK_CIDR:-true}"
 CHECK_CUBECOW_DEPS="${CHECK_CUBECOW_DEPS:-true}"
@@ -121,6 +122,19 @@ check_cgroup_cpu() {
     return 0
   fi
   fail "failed to enable cgroup v2 cpu controller on /sys/fs/cgroup/cgroup.subtree_control"
+}
+
+check_bpf_fs() {
+  [ "$CHECK_BPF_FS" = "true" ] || return 0
+
+  grep -qw bpf /proc/filesystems \
+    || fail "host kernel does not support the bpf filesystem"
+
+  bpf_fs_type="$(host_mount_sh "df -T /sys/fs/bpf 2>/dev/null | awk 'NR == 2 { print \$2; exit }'" || true)"
+  [ "$bpf_fs_type" = "bpf" ] \
+    || fail "host /sys/fs/bpf is not mounted as a bpf filesystem (type: ${bpf_fs_type:-unknown})"
+
+  log "host bpffs check passed"
 }
 
 ip_to_int() {
@@ -307,6 +321,7 @@ check_pvm_consistency() {
 check_memory
 check_glibc
 check_cgroup_cpu
+check_bpf_fs
 check_cidr_conflict
 check_cubecow_deps
 

--- a/deploy/one-click/install.sh
+++ b/deploy/one-click/install.sh
@@ -707,6 +707,32 @@ check_cgroup_cpu_preflight() {
   Full repro and fix: https://github.com/TencentCloud/CubeSandbox/issues/366"
 }
 
+check_bpf_fs_preflight() {
+  # Let the regular OS preflight report unsupported non-Linux hosts.
+  [[ "$(uname)" == "Linux" ]] || return 0
+
+  local bpf_dir="/sys/fs/bpf"
+
+  if ! grep -qw bpf /proc/filesystems; then
+    die "Your kernel does not support the 'bpf' filesystem (eBPF is missing or not enabled).
+  network-agent requires eBPF to function properly.
+  Please upgrade your kernel or enable CONFIG_BPF_SYSCALL."
+  fi
+
+  local bpf_fs_type=""
+  if [[ -d "${bpf_dir}" ]]; then
+    bpf_fs_type="$(df -T "${bpf_dir}" 2>/dev/null | awk 'NR==2 {print $2}' || true)"
+  fi
+
+  if [[ "${bpf_fs_type}" == "bpf" ]]; then
+    return 0
+  fi
+
+  die "/sys/fs/bpf is not mounted as a bpf filesystem (type: ${bpf_fs_type:-unknown}).
+  network-agent requires bpffs for its pinned eBPF maps.
+  Troubleshooting: https://github.com/TencentCloud/CubeSandbox/blob/master/docs/guide/troubleshooting/deployment.md#bpffs-is-not-mounted"
+}
+
 check_install_preflight() {
   # install.sh itself.
   require_cmd tar
@@ -932,6 +958,7 @@ check_hardware_preflight
 check_pvm_consistency_preflight
 check_cubelet_fs_preflight
 check_cgroup_cpu_preflight
+check_bpf_fs_preflight
 check_glibc_preflight
 check_compute_control_plane_preflight
 

--- a/deploy/one-click/online-install.sh
+++ b/deploy/one-click/online-install.sh
@@ -39,6 +39,30 @@ detect_glibc_version() {
 # ---------------------------------------------------------------------------
 # Pre-download preflight checks (lightweight, self-contained)
 # ---------------------------------------------------------------------------
+check_bpf_fs_preflight() {
+  # Let the regular OS preflight report unsupported non-Linux hosts.
+  [[ "$(uname)" == "Linux" ]] || return 0
+
+  local bpf_dir="/sys/fs/bpf"
+  if ! grep -qw bpf /proc/filesystems; then
+    echo "[online-install] ERROR: Your kernel does not support the 'bpf' filesystem (eBPF is missing or not enabled)." >&2
+    echo "[online-install] network-agent requires eBPF to function properly." >&2
+    echo "[online-install] Please upgrade your kernel or enable CONFIG_BPF_SYSCALL." >&2
+    exit 3
+  fi
+
+  local bpf_fs_type=""
+  if [[ -d "${bpf_dir}" ]]; then
+    bpf_fs_type="$(df -T "${bpf_dir}" 2>/dev/null | awk 'NR==2 {print $2}' || true)"
+  fi
+  if [[ "${bpf_fs_type}" != "bpf" ]]; then
+    echo "[online-install] ERROR: /sys/fs/bpf is not mounted as a bpf filesystem (type: ${bpf_fs_type:-unknown})." >&2
+    echo "[online-install] network-agent requires bpffs for its pinned eBPF maps." >&2
+    echo "[online-install] Troubleshooting: https://github.com/TencentCloud/CubeSandbox/blob/master/docs/guide/troubleshooting/deployment.md#bpffs-is-not-mounted" >&2
+    exit 3
+  fi
+}
+
 check_early_preflight() {
   if [[ "${SKIP_PRECHECK:-0}" == "1" ]]; then
     echo "[online-install] Skipping pre-download preflight checks." >&2
@@ -290,7 +314,12 @@ EOF
   echo "[online-install] Pre-download preflight checks passed." >&2
 }
 
-# Run early preflight checks before fetching release info or downloading large bundle
+# Run the mandatory bpffs check before fetching release info or downloading the
+# large bundle. Unlike the optional early checks, this is never skipped.
+check_bpf_fs_preflight
+
+# Run optional early preflight checks before fetching release info or downloading
+# the large bundle.
 check_early_preflight
 
 # ---------------------------------------------------------------------------

--- a/docs/guide/troubleshooting/deployment.md
+++ b/docs/guide/troubleshooting/deployment.md
@@ -11,3 +11,35 @@ lang: en-US
 | Template Creation Times Out When the Sandbox CIDR Overlaps the LAN | The one-click deployment defaults the sandbox network to `192.168.0.0/18`. If the host LAN also uses `192.168.1.x`, Cube may allocate sandbox IPs that overlap the physical network, causing template creation or port probing to fail with `context deadline exceeded`. Change the Cubelet CIDR to a non-overlapping range and remove the old TAP devices plus `cube-dev` before restarting. | [Guide](./local-network-cidr-conflict.md) |
 | Changing the CIDR (residual `cube-dev`) | Stopping Cube does not remove the `cube-dev` interface or `z*` TAP devices, so they linger after a stop. Changing `CUBE_SANDBOX_NETWORK_CIDR` to a range that overlaps the residual `cube-dev` is rejected by the pre-flight with a deterministic-reset hint (a reboot alone is not enough). A same-CIDR reinstall reuses `cube-dev` automatically. | [Guide](./local-network-cidr-conflict.md#changing-the-cidr-residual-cube-dev) |
 | cgroup v2 `cpu` controller not enabled on Ubuntu, cubelet CPU quotas don't take effect | Ubuntu / Debian cloud images don't delegate the cgroup v2 `cpu` controller to child cgroups by default, and `multipathd`'s RT threads make `+cpu` writes fail with `Invalid argument`. See the issue for full repro and fix. | [#366](https://github.com/TencentCloud/CubeSandbox/issues/366) |
+| bpffs is not mounted | `network-agent` pins its eBPF programs and maps under `/sys/fs/bpf`, so the installer stops before making system changes when that directory is not a `bpf` filesystem. | [Guide](#bpffs-is-not-mounted) |
+
+## bpffs is not mounted
+
+`network-agent` relies on `/sys/fs/bpf` being mounted as `bpffs` (bpf filesystem) to pin its eBPF programs and maps. In WSL2 or minimal Linux environments where `bpffs` is not mounted by default, the one-click pre-flight check rejects the deployment before making system changes.
+
+### 1. Confirm Kernel Support
+
+First, verify that the running kernel supports the `bpf` filesystem:
+
+```bash
+grep -w bpf /proc/filesystems
+```
+
+If this command produces no output, the running kernel lacks eBPF/bpffs support (missing `CONFIG_BPF_SYSCALL`). Upgrade or switch to a kernel with eBPF support before retrying.
+
+### 2. Mount bpffs
+
+If kernel support is present, create the directory if needed and mount `bpffs` as root:
+
+```bash
+mkdir -p /sys/fs/bpf
+mount -t bpf bpf /sys/fs/bpf
+```
+
+### 3. Make it Persistent (Optional)
+
+To persist the mount across system reboots, add the following entry to `/etc/fstab`:
+
+```text
+bpf /sys/fs/bpf bpf defaults 0 0
+```

--- a/docs/zh/guide/troubleshooting/deployment.md
+++ b/docs/zh/guide/troubleshooting/deployment.md
@@ -11,3 +11,35 @@ lang: zh-CN
 | 沙箱网段和局域网冲突导致创建模板超时 | one-click 部署默认沙箱网段是 `192.168.0.0/18`。如果宿主机局域网也使用 `192.168.1.x`，Cube 可能给沙箱分配到和真实局域网重叠的 IP 导致模板创建或端口探测以 `context deadline exceeded` 失败。将 Cubelet CIDR 改成不冲突的网段，并在重启前清理旧 TAP 网卡和 `cube-dev`。 | [指南](./local-network-cidr-conflict.md) |
 | 调整沙箱网段时的 CIDR 冲突（残留 cube-dev） | 停服后 `cube-dev` 网卡和 `z*` TAP 设备会残留；调整 `CUBE_SANDBOX_NETWORK_CIDR` 时若新网段与残留 `cube-dev` 重叠，预检会拦截并提示确定性清理（仅 reboot 不够）。相同网段重装会自动复用，不受影响。 | [指南](./local-network-cidr-conflict.md#调整沙箱网段时的-cidr-冲突残留-cube-dev) |
 | Ubuntu 上 cgroup v2 没启用 `cpu` controller，cubelet CPU quota 不生效 | Ubuntu / Debian 云镜像默认不会把 cgroup v2 的 `cpu` controller 委托到子 cgroup，且 `multipathd` 的 RT 线程会让 `+cpu` 写入返回 `Invalid argument`。详细复现和修复见 issue。 | [#366](https://github.com/TencentCloud/CubeSandbox/issues/366) |
+| bpffs 未挂载 | `network-agent` 会在 `/sys/fs/bpf` 下固定 eBPF 程序和 map；因此该目录不是 `bpf` 文件系统时，安装器会在修改系统前退出。 | [指南](#bpffs-未挂载) |
+
+## bpffs 未挂载
+
+`network-agent` 组件依赖 `/sys/fs/bpf` 挂载 `bpffs`（bpf 文件系统）以固定（pin）eBPF 程序与 Map。在 WSL2 或部分默认未挂载 `bpffs` 的极简 Linux 环境中部署时，one-click 预检会拦截并在修改系统前退出。
+
+### 1. 确认内核支持
+
+先确认当前运行的内核是否支持 `bpf` 文件系统：
+
+```bash
+grep -w bpf /proc/filesystems
+```
+
+若命令无任何输出，说明当前内核未启用 eBPF/bpffs 支持（缺少 `CONFIG_BPF_SYSCALL`），需升级或更换支持 eBPF 的内核后再试。
+
+### 2. 挂载 bpffs
+
+若内核支持，以 root 权限创建目录（若不存在）并执行挂载：
+
+```bash
+mkdir -p /sys/fs/bpf
+mount -t bpf bpf /sys/fs/bpf
+```
+
+### 3. 持久化配置（可选）
+
+如需重启后保持挂载，可在 `/etc/fstab` 中添加如下配置：
+
+```text
+bpf /sys/fs/bpf bpf defaults 0 0
+```


### PR DESCRIPTION
## Background & Problem

By default, WSL2 (and some custom Linux distributions) do not mount the `/sys/fs/bpf` filesystem, even though the kernel supports eBPF. This causes `network-agent` to repeatedly panic during initialization when attempting to pin eBPF maps and programs, resulting in a frustrating deployment experience.

## Solution

To solve this without modifying the host system environment, we added a non-intrusive pre-flight check in the deployment scripts (`online-install.sh` and `install.sh`):

1. **Kernel Support Check**: Queries `/proc/filesystems` to ensure the host kernel actually supports `bpf`. If not, it halts early and prompts the user to upgrade their kernel or enable `CONFIG_BPF_SYSCALL`.
2. **Mount Verification & Fail-Fast Guard**: Verifies whether `/sys/fs/bpf` is mounted as a `bpf` filesystem. If missing, it fails fast before making any system changes and links directly to the troubleshooting guide.
3. **Troubleshooting Documentation**: Added step-by-step manual remediation instructions (including persistent `/etc/fstab` configuration) in both English and Chinese documentation (`docs/guide/troubleshooting/deployment.md`).