### PR TITLE
cubemaster: add scarce-resource scheduler filter (SRA v1)

### DIFF
--- a/CubeMaster/conf.yaml
+++ b/CubeMaster/conf.yaml
@@ -110,3 +110,18 @@ scheduler:
       - "mem"
       - "template_locality"
       - "realtime_create_num"
+  # Scarce-resource avoidance (SRA): keep sandboxes that do not request a scarce
+  # resource (for example GPU) off nodes labeled with that resource. Disabled by
+  # default; set scarce_resource_filter.enable to true. The scarce_resource
+  # filter is registered automatically when enabled (no need to list it below).
+  # GPU sandboxes must declare demand via com.nodeaffinity.selector (e.g.
+  # [{"key":"gpu","operator":"Exists"}]); also add "gpu" to
+  # node_affinity_selector_allowed_keys below when enabling SRA for GPU workloads.
+  # node_affinity_selector_allowed_keys:
+  #   - gpu
+  # scarce_resource_filter:
+  #   enable: true
+  #   resources:
+  #     - label_key: gpu
+  #       label_values: ["true"]   # set explicit values for custom resources;
+  #                               # empty label_values: gpu-only false/0 negation

--- a/CubeMaster/pkg/base/config/config.go
+++ b/CubeMaster/pkg/base/config/config.go
@@ -205,6 +205,7 @@ type SchedulerConf struct {
 	ThirtpartyFilterInstanceType     map[string]bool                   `yaml:"thirtparty_filter_instance_type"`
 	InstanceTypeConf                 map[string]InstanceTypeConf       `yaml:"instance_type_conf"`
 	NodeAffinitySelectorAllowedKeys  []string                          `yaml:"node_affinity_selector_allowed_keys"`
+	ScarceResourceFilter             *ScarceResourceFilterConf         `yaml:"scarce_resource_filter"`
 
 	// IgnoreRedisAllocation, when true, makes the scheduler ignore the
 	// per-node allocated CPU/Mem usage recorded in Redis (treat allocated as
@@ -498,6 +499,56 @@ func (s *SchedulerConf) GetEffectiveNodeMaxMemReservedInMB(instanceType string, 
 
 type SchedulerFilterConf struct {
 	EnableFilters []string `yaml:"enable_filters"`
+}
+
+// ScarceResourceFilterConf keeps non-requesting sandboxes off nodes that carry
+// scarce-resource labels (for example GPU). Disabled by default.
+type ScarceResourceFilterConf struct {
+	Enable    bool                 `yaml:"enable"`
+	Resources []ScarceResourceDef  `yaml:"resources"`
+}
+
+// ScarceResourceDef identifies a node label that marks scarce capacity.
+// When LabelValues is empty, any present non-empty label value counts as scarce.
+// For label_key "gpu" only, "false" and "0" are treated as non-scarce. Custom
+// resources should set explicit label_values (recommended for all non-GPU keys).
+type ScarceResourceDef struct {
+	LabelKey    string   `yaml:"label_key"`
+	LabelValues []string `yaml:"label_values"`
+}
+
+func (c *ScarceResourceFilterConf) EffectiveResources() []ScarceResourceDef {
+	if c == nil || !c.Enable {
+		return nil
+	}
+	if len(c.Resources) == 0 {
+		return []ScarceResourceDef{{
+			LabelKey:    "gpu",
+			LabelValues: []string{"true"},
+		}}
+	}
+	out := make([]ScarceResourceDef, len(c.Resources))
+	for i, def := range c.Resources {
+		out[i] = def
+		if def.LabelValues != nil {
+			out[i].LabelValues = append([]string(nil), def.LabelValues...)
+		}
+	}
+	return out
+}
+
+func (s *SchedulerConf) ScarceResourceFilterEnabled() bool {
+	return s != nil && s.ScarceResourceFilter != nil && s.ScarceResourceFilter.Enable
+}
+
+func (s *SchedulerConf) EffectiveScarceResources() []ScarceResourceDef {
+	if s == nil {
+		return nil
+	}
+	if s.ScarceResourceFilter == nil {
+		return nil
+	}
+	return s.ScarceResourceFilter.EffectiveResources()
 }
 
 type PostScoreConf struct {

--- a/CubeMaster/pkg/base/config/config_test.go
+++ b/CubeMaster/pkg/base/config/config_test.go
@@ -322,3 +322,44 @@ func TestGetAllowedHostMountPrefixes_DefaultDefensiveCopy(t *testing.T) {
 	got2 := GetAllowedHostMountPrefixes()
 	assert.Equal(t, "/data/shared/", got2[0])
 }
+
+func TestScarceResourceFilterConfDefaults(t *testing.T) {
+	disabled := (&ScarceResourceFilterConf{Enable: false}).EffectiveResources()
+	assert.Nil(t, disabled)
+
+	enabled := (&ScarceResourceFilterConf{Enable: true}).EffectiveResources()
+	assert.Len(t, enabled, 1)
+	assert.Equal(t, "gpu", enabled[0].LabelKey)
+	assert.Equal(t, []string{"true"}, enabled[0].LabelValues)
+
+	custom := (&ScarceResourceFilterConf{
+		Enable: true,
+		Resources: []ScarceResourceDef{{
+			LabelKey:    "npu",
+			LabelValues: []string{"910b"},
+		}},
+	}).EffectiveResources()
+	assert.Len(t, custom, 1)
+	assert.Equal(t, "npu", custom[0].LabelKey)
+}
+
+func TestScarceResourceFilterConfEffectiveResourcesDefensiveCopy(t *testing.T) {
+	conf := &ScarceResourceFilterConf{
+		Enable: true,
+		Resources: []ScarceResourceDef{{
+			LabelKey:    "gpu",
+			LabelValues: []string{"true"},
+		}},
+	}
+	got := conf.EffectiveResources()
+	got[0].LabelValues[0] = "hacked"
+	assert.Equal(t, "true", conf.Resources[0].LabelValues[0])
+}
+
+func TestSchedulerConfScarceResourceFilterEnabled(t *testing.T) {
+	sconf := &SchedulerConf{
+		ScarceResourceFilter: &ScarceResourceFilterConf{Enable: true},
+	}
+	assert.True(t, sconf.ScarceResourceFilterEnabled())
+	assert.Len(t, sconf.EffectiveScarceResources(), 1)
+}

--- a/CubeMaster/pkg/scheduler/affinity/nodeaffinity.go
+++ b/CubeMaster/pkg/scheduler/affinity/nodeaffinity.go
@@ -20,6 +20,11 @@ type NodeLabels interface {
 
 type NodeSelector interface {
 	Match(node NodeLabels) bool
+	// Terms returns a copy of selector terms for inspection (for example
+	// scarce-resource detection). The outer term slice and each
+	// MatchExpressions / MatchFields slice are copied; NodeSelectorRequirement.Values
+	// maps are shared and must be treated as read-only by callers.
+	Terms() []NodeSelectorTerm
 }
 
 type PreferredSchedulingTerms interface {
@@ -45,6 +50,76 @@ func (w *wrapNodeSelector) Match(n NodeLabels) bool {
 		return true
 	}
 	return w.nodeselector.Match(labels.Set(n.Labels()))
+}
+
+func (w *wrapNodeSelector) Terms() []NodeSelectorTerm {
+	if w.nodeselector == nil || len(w.nodeselector.terms) == 0 {
+		return nil
+	}
+	return cloneNodeSelectorTerms(w.nodeselector.terms)
+}
+
+func cloneNodeSelectorTerms(terms []NodeSelectorTerm) []NodeSelectorTerm {
+	out := make([]NodeSelectorTerm, len(terms))
+	copy(out, terms)
+	for i := range out {
+		out[i].MatchExpressions = cloneNodeSelectorRequirements(out[i].MatchExpressions)
+		out[i].MatchFields = cloneNodeSelectorRequirements(out[i].MatchFields)
+	}
+	return out
+}
+
+func cloneNodeSelectorRequirements(reqs []NodeSelectorRequirement) []NodeSelectorRequirement {
+	if len(reqs) == 0 {
+		return nil
+	}
+	out := make([]NodeSelectorRequirement, len(reqs))
+	copy(out, reqs)
+	return out
+}
+
+// RequiresLabelKey reports whether ns contains a positive requirement for key:
+// Exists on key, or In on key with a value in scarceValues (any In on key when
+// scarceValues is empty).
+func RequiresLabelKey(ns NodeSelector, key string, scarceValues []string) bool {
+	if ns == nil || key == "" {
+		return false
+	}
+	for _, term := range ns.Terms() {
+		for _, req := range term.MatchExpressions {
+			if expressionRequiresLabelKey(req, key, scarceValues) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func expressionRequiresLabelKey(req NodeSelectorRequirement, key string, scarceValues []string) bool {
+	if req.Key != key {
+		return false
+	}
+	switch req.Operator {
+	case NodeSelectorOpExists:
+		return true
+	case NodeSelectorOpIn:
+		if len(scarceValues) == 0 {
+			return len(req.Values) > 0
+		}
+		for _, want := range scarceValues {
+			if _, ok := req.Values[want]; ok {
+				return true
+			}
+		}
+		return false
+	case NodeSelectorOpGt, NodeSelectorOpLt:
+		// TODO: Gt/Lt are not treated as positive scarce-resource requirements.
+		// Match() only supports these operators on memory-size/cpu-cores; a selector
+		// like gpu Gt "0" would not bypass SRA until explicitly implemented.
+		return false
+	default:
+		return false
+	}
 }
 
 type lazyErrorNodeSelector struct {

--- a/CubeMaster/pkg/scheduler/affinity/nodeaffinity_requires_test.go
+++ b/CubeMaster/pkg/scheduler/affinity/nodeaffinity_requires_test.go
@@ -1,0 +1,158 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package affinity
+
+import (
+	"testing"
+
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/constants"
+)
+
+func TestRequiresLabelKeyExists(t *testing.T) {
+	ns, err := NewNodeSelector([]NodeSelectorTerm{{
+		MatchExpressions: []NodeSelectorRequirement{{
+			Key:      "gpu",
+			Operator: NodeSelectorOpExists,
+		}},
+	}})
+	if err != nil {
+		t.Fatalf("NewNodeSelector: %v", err)
+	}
+	if !RequiresLabelKey(ns, "gpu", []string{"true"}) {
+		t.Fatal("expected gpu Exists to require gpu key")
+	}
+}
+
+func TestRequiresLabelKeyWithClusterIDAnded(t *testing.T) {
+	ns, err := NewNodeSelector([]NodeSelectorTerm{{
+		MatchExpressions: []NodeSelectorRequirement{
+			{
+				Key:      constants.AffinityKeyClusterID,
+				Operator: NodeSelectorOpIn,
+				Values:   map[string]any{"cluster-a": struct{}{}},
+			},
+			{
+				Key:      "gpu",
+				Operator: NodeSelectorOpExists,
+			},
+		},
+	}})
+	if err != nil {
+		t.Fatalf("NewNodeSelector: %v", err)
+	}
+	if !RequiresLabelKey(ns, "gpu", []string{"true"}) {
+		t.Fatal("expected gpu Exists with cluster-id AND to require gpu key")
+	}
+}
+
+func TestRequiresLabelKeyInOverlapsScarceValues(t *testing.T) {
+	ns, err := NewNodeSelector([]NodeSelectorTerm{{
+		MatchExpressions: []NodeSelectorRequirement{{
+			Key:      "gpu",
+			Operator: NodeSelectorOpIn,
+			Values:   map[string]any{"h100": struct{}{}},
+		}},
+	}})
+	if err != nil {
+		t.Fatalf("NewNodeSelector: %v", err)
+	}
+	if !RequiresLabelKey(ns, "gpu", []string{"a100", "h100"}) {
+		t.Fatal("expected gpu In [h100] to require gpu when h100 is a scarce value")
+	}
+	if RequiresLabelKey(ns, "gpu", []string{"a100"}) {
+		t.Fatal("gpu In [h100] should not require gpu when h100 is not scarce")
+	}
+}
+
+func TestRequiresLabelKeyDoesNotExist(t *testing.T) {
+	ns, err := NewNodeSelector([]NodeSelectorTerm{{
+		MatchExpressions: []NodeSelectorRequirement{{
+			Key:      "gpu",
+			Operator: NodeSelectorOpDoesNotExist,
+		}},
+	}})
+	if err != nil {
+		t.Fatalf("NewNodeSelector: %v", err)
+	}
+	if RequiresLabelKey(ns, "gpu", []string{"true"}) {
+		t.Fatal("gpu DoesNotExist should not count as requiring gpu")
+	}
+}
+
+type stubNodeSelector struct {
+	terms []NodeSelectorTerm
+}
+
+func (s *stubNodeSelector) Match(_ NodeLabels) bool { return true }
+
+func (s *stubNodeSelector) Terms() []NodeSelectorTerm { return s.terms }
+
+func TestRequiresLabelKeyCustomImplementation(t *testing.T) {
+	ns := &stubNodeSelector{terms: []NodeSelectorTerm{{
+		MatchExpressions: []NodeSelectorRequirement{{
+			Key:      "gpu",
+			Operator: NodeSelectorOpExists,
+		}},
+	}}}
+	if !RequiresLabelKey(ns, "gpu", []string{"true"}) {
+		t.Fatal("expected custom NodeSelector implementation to be inspectable via Terms()")
+	}
+}
+
+func TestTermsReturnsDefensiveCopy(t *testing.T) {
+	ns, err := NewNodeSelector([]NodeSelectorTerm{{
+		MatchExpressions: []NodeSelectorRequirement{{
+			Key:      "gpu",
+			Operator: NodeSelectorOpExists,
+		}},
+	}})
+	if err != nil {
+		t.Fatalf("NewNodeSelector: %v", err)
+	}
+	terms := ns.Terms()
+	if len(terms) != 1 {
+		t.Fatalf("expected 1 term, got %d", len(terms))
+	}
+	terms[0] = NodeSelectorTerm{}
+	if len(ns.Terms()) != 1 {
+		t.Fatal("Terms() should return a copy of the term slice")
+	}
+	terms = ns.Terms()
+	terms[0].MatchExpressions = append(terms[0].MatchExpressions, NodeSelectorRequirement{
+		Key:      "zone",
+		Operator: NodeSelectorOpExists,
+	})
+	if len(ns.Terms()[0].MatchExpressions) != 1 {
+		t.Fatal("Terms() should copy MatchExpressions so append does not affect internal state")
+	}
+	terms = ns.Terms()
+	terms[0].MatchFields = append(terms[0].MatchFields, NodeSelectorRequirement{
+		Key:      "metadata.name",
+		Operator: NodeSelectorOpExists,
+	})
+	if len(ns.Terms()[0].MatchFields) != 0 {
+		t.Fatal("Terms() should copy MatchFields so append does not affect internal state")
+	}
+}
+
+func TestTermsCopiesPreexistingMatchFields(t *testing.T) {
+	ns, err := NewNodeSelector([]NodeSelectorTerm{{
+		MatchFields: []NodeSelectorRequirement{{
+			Key:      "metadata.name",
+			Operator: NodeSelectorOpExists,
+		}},
+	}})
+	if err != nil {
+		t.Fatalf("NewNodeSelector: %v", err)
+	}
+	terms := ns.Terms()
+	terms[0].MatchFields = append(terms[0].MatchFields, NodeSelectorRequirement{
+		Key:      "zone",
+		Operator: NodeSelectorOpExists,
+	})
+	if len(ns.Terms()[0].MatchFields) != 1 {
+		t.Fatal("Terms() should copy MatchFields so append does not affect internal state")
+	}
+}

--- a/CubeMaster/pkg/selector/backofffilter/backofffilter.go
+++ b/CubeMaster/pkg/selector/backofffilter/backofffilter.go
@@ -14,6 +14,7 @@ import (
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/errorcode"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/localcache"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/scheduler/selctx"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/selector/scarceresource"
 )
 
 type backofffilter struct {
@@ -86,6 +87,8 @@ func (l *backofffilter) Select(selCtx *selctx.SelectorCtx) (node.NodeList, error
 
 		newNodes.Append(n)
 	}
+	// Backoff retry skips the normal filter chain; apply SRA here as well.
+	newNodes = scarceresource.FilterNodes(selCtx, newNodes, l.ID()+"/scarce_resource", selCtx.Affinity.BackoffNodeSelector)
 	if log.IsDebug() {
 		log.G(selCtx.Ctx).Debugf("%v select:%v", l.ID(), newNodes.String())
 	} else {

--- a/CubeMaster/pkg/selector/filter/init.go
+++ b/CubeMaster/pkg/selector/filter/init.go
@@ -21,18 +21,35 @@ type Selector interface {
 
 func NewSelector() []Selector {
 	conf := config.GetConfig().Scheduler
-	if conf == nil || conf.Filter == nil {
+	if conf == nil {
 		return []Selector{}
 	}
+	return buildSelectors(conf)
+}
+
+func buildSelectors(conf *config.WrapperSchedulerConf) []Selector {
 	ss := make([]Selector, 0)
-	for _, name := range conf.Filter.EnableFilters {
+	enableFilters := []string(nil)
+	if conf.Filter != nil {
+		enableFilters = conf.Filter.EnableFilters
+	}
+	seen := make(map[string]struct{}, len(enableFilters)+1)
+	for _, name := range enableFilters {
+		if _, ok := seen[name]; ok {
+			continue
+		}
+		seen[name] = struct{}{}
 
 		fn := reflect.ValueOf(filters[name])
-
 		if !fn.IsValid() {
 			continue
 		}
 		ss = append(ss, fn.Call(nil)[0].Interface().(Selector))
+	}
+	if conf.ScarceResourceFilterEnabled() {
+		if _, ok := seen["scarce_resource"]; !ok {
+			ss = append(ss, NewScarceResourceFilter())
+		}
 	}
 	return ss
 }
@@ -44,4 +61,5 @@ var filters = map[string]interface{}{
 	"realtime_create_num": NewRealtimecreatelimit,
 	"disk":                NewDiskFilter,
 	"thirtparty":          NewThirtpartyFilter,
+	"scarce_resource":     NewScarceResourceFilter,
 }

--- a/CubeMaster/pkg/selector/filter/init_test.go
+++ b/CubeMaster/pkg/selector/filter/init_test.go
@@ -1,0 +1,85 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package filter
+
+import (
+	"testing"
+
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/config"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/constants"
+)
+
+func TestBuildSelectorsAutoRegistersScarceResource(t *testing.T) {
+	conf := &config.WrapperSchedulerConf{
+		SchedulerConf: config.SchedulerConf{
+			Filter: &config.SchedulerFilterConf{
+				EnableFilters: []string{"cpu"},
+			},
+			ScarceResourceFilter: &config.ScarceResourceFilterConf{Enable: true},
+		},
+	}
+	selectors := buildSelectors(conf)
+	found := false
+	for _, s := range selectors {
+		if s.ID() == constants.SelectorFilterID+"/"+"scarce_resource" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatal("expected scarce_resource filter to be auto-registered")
+	}
+}
+
+func TestBuildSelectorsSkipsDuplicateScarceResource(t *testing.T) {
+	conf := &config.WrapperSchedulerConf{
+		SchedulerConf: config.SchedulerConf{
+			Filter: &config.SchedulerFilterConf{
+				EnableFilters: []string{"cpu", "scarce_resource"},
+			},
+			ScarceResourceFilter: &config.ScarceResourceFilterConf{Enable: true},
+		},
+	}
+	count := 0
+	for _, s := range buildSelectors(conf) {
+		if s.ID() == constants.SelectorFilterID+"/"+"scarce_resource" {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Fatalf("expected exactly one scarce_resource filter, got %d", count)
+	}
+}
+
+func TestBuildSelectorsDisabledScarceResource(t *testing.T) {
+	conf := &config.WrapperSchedulerConf{
+		SchedulerConf: config.SchedulerConf{
+			Filter: &config.SchedulerFilterConf{
+				EnableFilters: []string{"cpu"},
+			},
+			ScarceResourceFilter: &config.ScarceResourceFilterConf{Enable: false},
+		},
+	}
+	for _, s := range buildSelectors(conf) {
+		if s.ID() == constants.SelectorFilterID+"/"+"scarce_resource" {
+			t.Fatal("scarce_resource should not be registered when disabled")
+		}
+	}
+}
+
+func TestBuildSelectorsNilFilterRegistersScarceResource(t *testing.T) {
+	conf := &config.WrapperSchedulerConf{
+		SchedulerConf: config.SchedulerConf{
+			ScarceResourceFilter: &config.ScarceResourceFilterConf{Enable: true},
+		},
+	}
+	selectors := buildSelectors(conf)
+	if len(selectors) != 1 {
+		t.Fatalf("expected only scarce_resource filter, got %d selectors", len(selectors))
+	}
+	if selectors[0].ID() != constants.SelectorFilterID+"/"+"scarce_resource" {
+		t.Fatalf("unexpected selector id: %s", selectors[0].ID())
+	}
+}

--- a/CubeMaster/pkg/selector/filter/scarce_resource_filter.go
+++ b/CubeMaster/pkg/selector/filter/scarce_resource_filter.go
@@ -1,0 +1,38 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package filter
+
+import (
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/constants"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/log"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/node"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/scheduler/selctx"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/selector/scarceresource"
+)
+
+type scarceResourceFilter struct{}
+
+func NewScarceResourceFilter() *scarceResourceFilter {
+	return &scarceResourceFilter{}
+}
+
+func (l *scarceResourceFilter) ID() string {
+	return constants.SelectorFilterID + "/" + "scarce_resource"
+}
+
+func (l *scarceResourceFilter) String() string {
+	return l.ID()
+}
+
+func (l *scarceResourceFilter) Select(selCtx *selctx.SelectorCtx) (node.NodeList, error) {
+	inList := selCtx.Nodes()
+	nodes := scarceresource.FilterNodes(selCtx, inList, l.ID(), nil)
+	if log.IsDebug() {
+		log.G(selCtx.Ctx).Debugf("%v select:%v", l.ID(), nodes.String())
+	} else {
+		log.G(selCtx.Ctx).Infof("%v select_size:%v", l.ID(), nodes.Len())
+	}
+	return nodes, nil
+}

--- a/CubeMaster/pkg/selector/filter/scarce_resource_filter_test.go
+++ b/CubeMaster/pkg/selector/filter/scarce_resource_filter_test.go
@@ -1,0 +1,40 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package filter
+
+import (
+	"context"
+	"testing"
+
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/config"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/node"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/scheduler/selctx"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/selector/scarceresource"
+)
+
+func TestScarceResourceFilterSelect(t *testing.T) {
+	restore := scarceresource.SetEffectiveResourcesFnForTest(func() []config.ScarceResourceDef {
+		return []config.ScarceResourceDef{{LabelKey: "gpu", LabelValues: []string{"true"}}}
+	})
+	defer restore()
+
+	ctx := selctx.New("random")
+	ctx.Ctx = context.Background()
+	ctx.SetNodes(node.NodeList{
+		{InsID: "gpu-node", NodeLabels: map[string]string{"gpu": "true"}},
+		{InsID: "cpu-node"},
+	})
+
+	got, err := NewScarceResourceFilter().Select(ctx)
+	if err != nil {
+		t.Fatalf("Select returned error: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("expected 1 node, got %d", len(got))
+	}
+	if got[0].ID() != "cpu-node" {
+		t.Fatalf("expected cpu-node, got %s", got[0].ID())
+	}
+}

--- a/CubeMaster/pkg/selector/scarceresource/scarce_resource.go
+++ b/CubeMaster/pkg/selector/scarceresource/scarce_resource.go
@@ -1,0 +1,123 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+// Package scarceresource implements scarce-resource avoidance (SRA) for
+// CubeMaster scheduling: sandboxes that do not explicitly require a scarce
+// resource must not be placed on nodes labeled with that resource.
+package scarceresource
+
+import (
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/config"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/log"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/node"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/scheduler/affinity"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/scheduler/selctx"
+)
+
+var effectiveResourcesFn = defaultEffectiveResources
+
+func defaultEffectiveResources() []config.ScarceResourceDef {
+	sconf := config.GetConfig().Scheduler
+	if sconf == nil {
+		return nil
+	}
+	return sconf.EffectiveScarceResources()
+}
+
+// FilterNodes removes scarce-resource nodes when the sandbox does not request them.
+// requestSelector decides whether the sandbox declares scarce-resource demand; when
+// nil, selCtx.Affinity.NodeSelector is used (normal filter chain). The backoff
+// path must pass selCtx.Affinity.BackoffNodeSelector explicitly.
+func FilterNodes(selCtx *selctx.SelectorCtx, in node.NodeList, filterID string, requestSelector affinity.NodeSelector) node.NodeList {
+	resources := effectiveResources()
+	if len(resources) == 0 {
+		return in
+	}
+	ns := requestSelector
+	if ns == nil && selCtx != nil {
+		ns = selCtx.Affinity.NodeSelector
+	}
+	if sandboxRequestsScarceResource(ns, resources) {
+		return in
+	}
+
+	out := make(node.NodeList, 0, in.Len())
+	for i := range in {
+		n := in[i]
+		if nodeCarriesScarceResource(n, resources) {
+			if selCtx != nil && selCtx.Ctx != nil {
+				log.G(selCtx.Ctx).Warnf("%s scarce_resource_out node=%s", filterID, n.ID())
+			}
+			continue
+		}
+		out.Append(n)
+	}
+	return out
+}
+
+func effectiveResources() []config.ScarceResourceDef {
+	return effectiveResourcesFn()
+}
+
+// SetEffectiveResourcesFnForTest overrides config lookup in unit tests.
+func SetEffectiveResourcesFnForTest(fn func() []config.ScarceResourceDef) (restore func()) {
+	prev := effectiveResourcesFn
+	effectiveResourcesFn = fn
+	return func() { effectiveResourcesFn = prev }
+}
+
+func nodeCarriesScarceResource(n *node.Node, resources []config.ScarceResourceDef) bool {
+	if n == nil {
+		return false
+	}
+	labels := n.Labels()
+	for _, def := range resources {
+		if nodeLabelMatchesScarce(labels, def) {
+			return true
+		}
+	}
+	return false
+}
+
+func nodeLabelMatchesScarce(labels map[string]string, def config.ScarceResourceDef) bool {
+	if def.LabelKey == "" {
+		return false
+	}
+	val, ok := labels[def.LabelKey]
+	if !ok || val == "" {
+		return false
+	}
+	if len(def.LabelValues) == 0 {
+		// GPU-only negation heuristic when values are not configured explicitly.
+		if def.LabelKey == "gpu" && (val == "false" || val == "0") {
+			return false
+		}
+		return true
+	}
+	for _, want := range def.LabelValues {
+		if val == want {
+			return true
+		}
+	}
+	return false
+}
+
+func sandboxRequestsScarceResource(ns affinity.NodeSelector, resources []config.ScarceResourceDef) bool {
+	if ns == nil {
+		return false
+	}
+	for _, def := range resources {
+		if sandboxRequestsResource(ns, def) {
+			return true
+		}
+	}
+	return false
+}
+
+func sandboxRequestsResource(ns affinity.NodeSelector, def config.ScarceResourceDef) bool {
+	if def.LabelKey == "" {
+		return false
+	}
+	return affinity.RequiresLabelKey(ns, def.LabelKey, def.LabelValues)
+}

--- a/CubeMaster/pkg/selector/scarceresource/scarce_resource_test.go
+++ b/CubeMaster/pkg/selector/scarceresource/scarce_resource_test.go
@@ -1,0 +1,244 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package scarceresource
+
+import (
+	"context"
+	"testing"
+
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/config"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/constants"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/node"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/scheduler/affinity"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/scheduler/selctx"
+)
+
+func patchScarceResources(t *testing.T, resources []config.ScarceResourceDef) {
+	t.Helper()
+	restore := SetEffectiveResourcesFnForTest(func() []config.ScarceResourceDef {
+		return resources
+	})
+	t.Cleanup(restore)
+}
+
+func gpuNode(id string) *node.Node {
+	return &node.Node{
+		InsID:      id,
+		IP:         "10.0.0." + id,
+		NodeLabels: map[string]string{"gpu": "true"},
+	}
+}
+
+func cpuNode(id string) *node.Node {
+	return &node.Node{
+		InsID: id,
+		IP:    "10.0.0." + id,
+	}
+}
+
+func selCtxWithGPURequired(t *testing.T) *selctx.SelectorCtx {
+	t.Helper()
+	ctx := selctx.New("random")
+	ctx.Ctx = context.Background()
+	ctx.Affinity.NodeSelector = gpuExistsSelector(t)
+	return ctx
+}
+
+func gpuExistsSelector(t *testing.T) affinity.NodeSelector {
+	t.Helper()
+	ns, err := affinity.NewNodeSelector([]affinity.NodeSelectorTerm{{
+		MatchExpressions: []affinity.NodeSelectorRequirement{{
+			Key:      "gpu",
+			Operator: affinity.NodeSelectorOpExists,
+		}},
+	}})
+	if err != nil {
+		t.Fatalf("NewNodeSelector: %v", err)
+	}
+	return ns
+}
+
+func TestFilterNodesUsesExplicitRequestSelector(t *testing.T) {
+	patchScarceResources(t, []config.ScarceResourceDef{{
+		LabelKey: "gpu", LabelValues: []string{"true"},
+	}})
+	ctx := selctx.New("random")
+	ctx.Ctx = context.Background()
+	// Backoff path: NodeSelector unset; GPU demand comes from BackoffNodeSelector only.
+	in := node.NodeList{gpuNode("1"), cpuNode("2")}
+	got := FilterNodes(ctx, in, "test", gpuExistsSelector(t))
+	if got.Len() != 2 {
+		t.Fatalf("expected both nodes when backoff selector requests gpu, got %d", got.Len())
+	}
+}
+
+func TestFilterNodesNilNodeSelectorWithoutExplicitRequest(t *testing.T) {
+	patchScarceResources(t, []config.ScarceResourceDef{{
+		LabelKey: "gpu", LabelValues: []string{"true"},
+	}})
+	ctx := selctx.New("random")
+	ctx.Ctx = context.Background()
+	in := node.NodeList{gpuNode("1"), cpuNode("2")}
+	got := FilterNodes(ctx, in, "test", nil)
+	if got.Len() != 1 {
+		t.Fatalf("expected cpu node only when no selector declares gpu, got %d", got.Len())
+	}
+}
+
+func TestFilterNodesDisabled(t *testing.T) {
+	patchScarceResources(t, nil)
+	ctx := selctx.New("random")
+	ctx.Ctx = context.Background()
+	in := node.NodeList{gpuNode("1"), cpuNode("2")}
+	got := FilterNodes(ctx, in, "test", nil)
+	if got.Len() != 2 {
+		t.Fatalf("expected 2 nodes, got %d", got.Len())
+	}
+}
+
+func TestFilterNodesExcludesGPUWhenNotRequested(t *testing.T) {
+	patchScarceResources(t, []config.ScarceResourceDef{{
+		LabelKey: "gpu", LabelValues: []string{"true"},
+	}})
+	ctx := selctx.New("random")
+	ctx.Ctx = context.Background()
+	in := node.NodeList{gpuNode("1"), cpuNode("2"), cpuNode("3")}
+	got := FilterNodes(ctx, in, "test", nil)
+	if got.Len() != 2 {
+		t.Fatalf("expected 2 cpu nodes, got %d", got.Len())
+	}
+	for _, n := range got {
+		if _, ok := n.NodeLabels["gpu"]; ok {
+			t.Fatalf("gpu node should be filtered out: %s", n.ID())
+		}
+	}
+}
+
+func TestFilterNodesKeepsGPUWhenRequested(t *testing.T) {
+	patchScarceResources(t, []config.ScarceResourceDef{{
+		LabelKey: "gpu", LabelValues: []string{"true"},
+	}})
+	ctx := selCtxWithGPURequired(t)
+	in := node.NodeList{gpuNode("1"), cpuNode("2")}
+	got := FilterNodes(ctx, in, "test", nil)
+	if got.Len() != 2 {
+		t.Fatalf("expected both nodes when gpu is requested, got %d", got.Len())
+	}
+}
+
+func TestFilterNodesKeepsGPUWhenClusterIDAnded(t *testing.T) {
+	patchScarceResources(t, []config.ScarceResourceDef{{
+		LabelKey: "gpu", LabelValues: []string{"true"},
+	}})
+	ns, err := affinity.NewNodeSelector([]affinity.NodeSelectorTerm{{
+		MatchExpressions: []affinity.NodeSelectorRequirement{
+			{
+				Key:      constants.AffinityKeyClusterID,
+				Operator: affinity.NodeSelectorOpIn,
+				Values:   map[string]any{"cluster-a": struct{}{}},
+			},
+			{
+				Key:      "gpu",
+				Operator: affinity.NodeSelectorOpExists,
+			},
+		},
+	}})
+	if err != nil {
+		t.Fatalf("NewNodeSelector: %v", err)
+	}
+	ctx := selctx.New("random")
+	ctx.Ctx = context.Background()
+	ctx.Affinity.NodeSelector = ns
+	in := node.NodeList{gpuNode("1"), cpuNode("2")}
+	got := FilterNodes(ctx, in, "test", nil)
+	if got.Len() != 2 {
+		t.Fatalf("expected both nodes when gpu Exists is ANDed with cluster-id, got %d", got.Len())
+	}
+}
+
+func TestFilterNodesKeepsGPUWhenInMatchesSecondScarceValue(t *testing.T) {
+	patchScarceResources(t, []config.ScarceResourceDef{{
+		LabelKey: "gpu", LabelValues: []string{"a100", "h100"},
+	}})
+	ns, err := affinity.NewNodeSelector([]affinity.NodeSelectorTerm{{
+		MatchExpressions: []affinity.NodeSelectorRequirement{{
+			Key:      "gpu",
+			Operator: affinity.NodeSelectorOpIn,
+			Values:   map[string]any{"h100": struct{}{}},
+		}},
+	}})
+	if err != nil {
+		t.Fatalf("NewNodeSelector: %v", err)
+	}
+	ctx := selctx.New("random")
+	ctx.Ctx = context.Background()
+	ctx.Affinity.NodeSelector = ns
+	in := node.NodeList{gpuNode("1"), cpuNode("2")}
+	got := FilterNodes(ctx, in, "test", nil)
+	if got.Len() != 2 {
+		t.Fatalf("expected both nodes when gpu In matches scarce value, got %d", got.Len())
+	}
+}
+
+func TestFilterNodesAllGPUFailsClosed(t *testing.T) {
+	patchScarceResources(t, []config.ScarceResourceDef{{
+		LabelKey: "gpu", LabelValues: []string{"true"},
+	}})
+	ctx := selctx.New("random")
+	ctx.Ctx = context.Background()
+	in := node.NodeList{gpuNode("1"), gpuNode("2")}
+	got := FilterNodes(ctx, in, "test", nil)
+	if got.Len() != 0 {
+		t.Fatalf("expected empty node list, got %d", got.Len())
+	}
+}
+
+func TestNodeLabelMatchesScarce(t *testing.T) {
+	def := config.ScarceResourceDef{LabelKey: "gpu", LabelValues: []string{"true"}}
+	if !nodeLabelMatchesScarce(map[string]string{"gpu": "true"}, def) {
+		t.Fatal("expected gpu=true to match")
+	}
+	if nodeLabelMatchesScarce(map[string]string{"gpu": "false"}, def) {
+		t.Fatal("gpu=false should not match")
+	}
+	if nodeLabelMatchesScarce(map[string]string{}, def) {
+		t.Fatal("missing label should not match")
+	}
+}
+
+func TestNodeLabelMatchesScarceEmptyLabelValuesHeuristic(t *testing.T) {
+	def := config.ScarceResourceDef{LabelKey: "gpu"}
+	if !nodeLabelMatchesScarce(map[string]string{"gpu": "true"}, def) {
+		t.Fatal("expected any truthy value when label_values empty")
+	}
+	if nodeLabelMatchesScarce(map[string]string{"gpu": "false"}, def) {
+		t.Fatal("gpu=false should not match under empty label_values heuristic")
+	}
+}
+
+func TestNodeLabelMatchesScarceEmptyLabelValuesNonGPU(t *testing.T) {
+	def := config.ScarceResourceDef{LabelKey: "spot"}
+	if !nodeLabelMatchesScarce(map[string]string{"spot": "0"}, def) {
+		t.Fatal("non-gpu empty label_values should treat 0 as scarce")
+	}
+	if !nodeLabelMatchesScarce(map[string]string{"spot": "true"}, def) {
+		t.Fatal("expected spot=true to match under empty label_values")
+	}
+}
+
+func TestNodeLabelMatchesScarceExplicitFalseValue(t *testing.T) {
+	def := config.ScarceResourceDef{LabelKey: "tier", LabelValues: []string{"false"}}
+	if !nodeLabelMatchesScarce(map[string]string{"tier": "false"}, def) {
+		t.Fatal("explicit label_values should use exact match, including false")
+	}
+}
+
+func TestEffectiveResourcesDefaultGPU(t *testing.T) {
+	conf := &config.ScarceResourceFilterConf{Enable: true}
+	got := conf.EffectiveResources()
+	if len(got) != 1 || got[0].LabelKey != "gpu" {
+		t.Fatalf("unexpected defaults: %+v", got)
+	}
+}


### PR DESCRIPTION

## Summary

Add an opt-in **Scarce Resource Avoidance (SRA)** filter for CubeMaster scheduling. When enabled, sandboxes that do not explicitly require a scarce resource (default: nodes labeled `gpu=true`) are excluded from those nodes. Sandboxes that declare GPU demand via `com.nodeaffinity.selector` are unaffected.

Closes #1156

## Motivation

In mixed CPU/GPU clusters that share a single `cubebox` instance type, default sandboxes can fill GPU nodes and starve workloads that actually need GPU. The project already supports **opting in** to GPU nodes via node labels and `com.nodeaffinity.selector` (e.g. `gpu Exists`). This PR adds the complementary **default exclusion** of scarce nodes, aligned with Volcano SRA semantics ([volcano#4454](https://github.com/volcano-sh/volcano/pull/4454)).

## Changes

| Area | Description |
|------|-------------|
| `pkg/base/config` | Add `ScarceResourceFilterConf` (default scarce resource: `gpu=true`) |
| `pkg/selector/scarceresource` | Shared SRA core logic (node label matching + sandbox affinity detection) |
| `pkg/selector/filter` | `scarce_resource` filter plugin; auto-registered when `enable: true` |
| `pkg/selector/backofffilter` | Apply SRA on the backoff retry path so it cannot bypass the filter chain |
| `conf.yaml` | Commented example configuration |
| Tests | Cover enable/disable, GPU requested/not requested, all-GPU pool, backoff path |

## Behavior

```text
scarce_resource_filter.enable == false  →  no-op (default; existing behavior unchanged)

sandbox node selector explicitly requires gpu  →  GPU nodes kept
otherwise                                      →  nodes with gpu=true (or configured label) removed
```

Example configuration:

```yaml
scheduler:
  scarce_resource_filter:
    enable: true
    resources:
      - label_key: gpu
        label_values: ["true"]
```

## Test plan

- [x] Unit tests

  ```bash
  cd CubeMaster
  go test ./pkg/selector/scarceresource/... ./pkg/selector/filter/... ./pkg/base/config/... -run 'Scarce|scarce' -v
  ```

- [ ] Manual validation on a mixed cluster: with the filter enabled, default sandboxes avoid GPU nodes; sandboxes with `gpu Exists` affinity can still schedule to GPU nodes
- [ ] Scheduling guide documentation (follow-up #959)

## Out of scope

- GPU device passthrough / VFIO (#111)
- Cubelet accelerator auto-discovery
- Priority classes, anti-affinity, node migration, and other advanced scheduling policies