### PR TITLE
fix: increase timeout values for various components to improve stability

### DIFF
--- a/CubeShim/shim/src/sandbox/sb.rs
+++ b/CubeShim/shim/src/sandbox/sb.rs
@@ -861,9 +861,7 @@ impl SandBox {
         {
             let ch = self.ch.as_mut().unwrap().lock().await;
             let start = Instant::now();
-            let ev = ch
-                .wait_notify(Duration::from_nanos(1000 * 1000 * 1000 * 10 as u64))
-                .await?;
+            let ev = ch.wait_notify(Duration::from_secs(60)).await?;
 
             if CH::NotifyEvent::VsockServerReady != ev {
                 return Err(format!(

--- a/deploy/one-click/env.example
+++ b/deploy/one-click/env.example
@@ -48,7 +48,7 @@ ONE_CLICK_RUN_QUICKCHECK=1
 # an otherwise-healthy install. The budget is shared across all probes in one
 # run. Values above 3600 are clamped to 3600; set to 0 to restore strict
 # fail-fast (probe exactly once) behaviour.
-# CUBE_QUICKCHECK_READY_TIMEOUT=120
+# CUBE_QUICKCHECK_READY_TIMEOUT=900
 # Polling interval (seconds) between quickcheck readiness probes.
 # CUBE_QUICKCHECK_READY_INTERVAL=2
 # Per-container readiness budget (seconds) for the docker health/running check,

--- a/deploy/one-click/scripts/one-click/quickcheck.sh
+++ b/deploy/one-click/scripts/one-click/quickcheck.sh
@@ -30,7 +30,7 @@ source "${SCRIPT_DIR}/common.sh"
 # units with no prior readiness wait, so the budget must cover the cumulative
 # time for units to activate, sockets to bind, health endpoints to serve, and
 # (on compute) the node to register with a remote cubemaster.
-QUICKCHECK_READY_TIMEOUT_DEFAULT=120
+QUICKCHECK_READY_TIMEOUT_DEFAULT=900
 QUICKCHECK_READY_INTERVAL_DEFAULT=2
 # Upper clamp so a typo/overflow cannot turn the budget into an effectively
 # infinite wait.

--- a/deploy/one-click/scripts/systemd/coredns-postcheck.sh
+++ b/deploy/one-click/scripts/systemd/coredns-postcheck.sh
@@ -15,4 +15,4 @@ if command -v resolvectl >/dev/null 2>&1; then
   COREDNS_BIND_ADDR="${RESOLVED_COREDNS_BIND_ADDR}"
 fi
 
-wait_for_udp_port "${COREDNS_BIND_ADDR}" 53 30 1 || die "coredns udp port not ready"
+wait_for_udp_port "${COREDNS_BIND_ADDR}" 53 300 1 || die "coredns udp port not ready"

--- a/deploy/one-click/scripts/systemd/cubemaster-postcheck.sh
+++ b/deploy/one-click/scripts/systemd/cubemaster-postcheck.sh
@@ -2,4 +2,4 @@
 set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${SCRIPT_DIR}/common.sh"
-wait_for_http "http://${CUBEMASTER_ADDR:-127.0.0.1:8089}/notify/health" 30 1 || die "cubemaster health not ready"
+wait_for_http "http://${CUBEMASTER_ADDR:-127.0.0.1:8089}/notify/health" 300 1 || die "cubemaster health not ready"

--- a/deploy/one-click/scripts/systemd/mysql-postcheck.sh
+++ b/deploy/one-click/scripts/systemd/mysql-postcheck.sh
@@ -8,4 +8,4 @@ source "${SCRIPT_DIR}/common.sh"
 if [[ -n "${CUBE_EXTERNAL_MYSQL_HOST:-}" ]]; then
   exit 0
 fi
-wait_for_container_health "${CUBE_SANDBOX_MYSQL_CONTAINER:-cube-sandbox-mysql}" 40 2 || die "mysql container not ready"
+wait_for_container_health "${CUBE_SANDBOX_MYSQL_CONTAINER:-cube-sandbox-mysql}" 240 2 || die "mysql container not ready"

--- a/deploy/one-click/scripts/systemd/redis-postcheck.sh
+++ b/deploy/one-click/scripts/systemd/redis-postcheck.sh
@@ -8,4 +8,4 @@ source "${SCRIPT_DIR}/common.sh"
 if [[ -n "${CUBE_EXTERNAL_REDIS_HOST:-}" ]]; then
   exit 0
 fi
-wait_for_container_health "${CUBE_SANDBOX_REDIS_CONTAINER:-cube-sandbox-redis}" 40 2 || die "redis container not ready"
+wait_for_container_health "${CUBE_SANDBOX_REDIS_CONTAINER:-cube-sandbox-redis}" 240 2 || die "redis container not ready"

--- a/deploy/one-click/systemd/cube-sandbox-coredns.service
+++ b/deploy/one-click/systemd/cube-sandbox-coredns.service
@@ -20,7 +20,7 @@ RestartSec=2s
 # Pin explicit timeouts so the unit does not inherit short distro defaults
 # (e.g. OpenCloudOS DefaultTimeoutStopUSec=5s) that would SIGKILL the stop
 # script mid-shutdown.
-TimeoutStartSec=60s
+TimeoutStartSec=900s
 TimeoutStopSec=30s
 
 [Install]

--- a/deploy/one-click/systemd/cube-sandbox-cubemaster.service
+++ b/deploy/one-click/systemd/cube-sandbox-cubemaster.service
@@ -18,7 +18,7 @@ Restart=on-failure
 RestartSec=2s
 # Override short distro defaults explicitly so SIGTERM has room to drain DB
 # connections / flush state before SIGKILL.
-TimeoutStartSec=60s
+TimeoutStartSec=900s
 TimeoutStopSec=30s
 
 [Install]

--- a/deploy/one-click/systemd/cube-sandbox-mysql.service
+++ b/deploy/one-click/systemd/cube-sandbox-mysql.service
@@ -19,7 +19,7 @@ Restart=on-failure
 RestartSec=2s
 # MySQL first-run init can take a while; graceful shutdown also needs room
 # (InnoDB checkpoint). Override short distro defaults explicitly.
-TimeoutStartSec=180s
+TimeoutStartSec=900s
 TimeoutStopSec=60s
 
 [Install]

--- a/deploy/one-click/systemd/cube-sandbox-redis.service
+++ b/deploy/one-click/systemd/cube-sandbox-redis.service
@@ -18,7 +18,7 @@ ExecStop=/usr/bin/bash /usr/local/services/cubetoolbox/scripts/systemd/redis-sto
 Restart=on-failure
 RestartSec=2s
 # Override short distro defaults explicitly.
-TimeoutStartSec=60s
+TimeoutStartSec=900s
 TimeoutStopSec=30s
 
 [Install]


### PR DESCRIPTION
### 问题/issue
https://github.com/TencentCloud/CubeSandbox/issues/924

在首次安装或冷启动时，MySQL、CoreDNS、CubeMaster 等组件可能需要较长时间完成容器初始化、网络就绪和健康检查。原有超时预算较短，会导致 systemd 提前判定启动失败，并触发后续级联重启或安装失败。

During first installation or cold start, MySQL, CoreDNS, CubeMaster, and related components may need additional time for container initialization, network readiness, and health checks. The previous timeout budgets could cause systemd to mark services as failed too early, leading to restart loops or installation failures.

### 修改内容/Changes

- 将 MySQL 和 Redis 的容器健康检查预算从 `40 x 2s` 提升至 `240 x 2s`。
- 将 CoreDNS UDP 端口和 CubeMaster 健康检查预算从 30 秒提升至 300 秒。
- 将 MySQL、Redis、CoreDNS、CubeMaster 的 `TimeoutStartSec` 统一提升至 900 秒。
- 将 one-click quickcheck 默认就绪预算从 120 秒提升至 900 秒。
- 将 CubeShim 等待 `VsockServerReady` 通知的默认时间从 10 秒提升至 60 秒。

- Increase the MySQL and Redis container health-check budgets from `40 x 2s` to `240 x 2s`.
- Increase the CoreDNS UDP port and CubeMaster health-check budgets from 30 seconds to 300 seconds.
- Set `TimeoutStartSec=900s` for MySQL, Redis, CoreDNS, and CubeMaster systemd units.
- Increase the default one-click quickcheck readiness budget from 120 seconds to 900 seconds.
- Increase the CubeShim `VsockServerReady` wait from 10 seconds to 60 seconds.
