### PR TITLE
refactor(dev-env): refactor dev-env scripts to use systemd target for CubeSandbox

### DIFF
--- a/deploy/one-click/README.md
+++ b/deploy/one-click/README.md
@@ -17,8 +17,23 @@ This directory is used to build and deliver the single-machine one-click release
 - `smoke.sh`: Runs basic health checks.
 - `env.example`: Shared environment variable template for both the build machine and the target machine.
 - `lib/common.sh`: Common shell utility functions.
-- `scripts/one-click/`: Validation and maintenance helpers used by the systemd-managed deployment after installation.
+- `scripts/one-click/`: Mixed-purpose historical directory containing deprecated aggregate entry points, compatibility scripts, and helpers still used by systemd and Terraform. See "Script support status" below.
 - `terraform/tencentcloud/`: Terraform deployer for a **clustered** CubeSandbox on Tencent Cloud (TKE control plane + CVM compute nodes). `create.sh` is the entry point; `destroy.sh` tears everything down. These files are shipped both at the release-bundle top level and inside `sandbox-package` (see "Tencent Cloud Cluster Deployment").
+
+### Script support status
+
+Do not treat every script under `scripts/one-click/` as deprecated. The current
+status is:
+
+| Status | Scripts | Usage |
+|---|---|---|
+| Deprecated service-management entry points | `up-with-deps.sh`, `down-with-deps.sh` | Do not use these for daily start, stop, or boot management. Use `cube-sandbox-control.target` or `cube-sandbox-compute.target`. |
+| Legacy internals retained for compatibility | `up.sh`, `down-local.sh`, `up-dns.sh`, `down-dns.sh`, `coredns-compose-lib.sh` | Not supported as direct operator interfaces. |
+| Active internal helpers | Component-level up/down scripts, compose-lib helpers, `quickcheck.sh`, and compute/egress compatibility scripts | Still called by current systemd units, diagnostics, or the Terraform compute flow; they are not deprecated as implementation helpers. |
+
+The installer's lookup of `down-with-deps.sh` in an existing installation is
+only an upgrade takeover mechanism for pre-systemd deployments. It does not
+make that script a supported operator entry point.
 
 ## Supported Operating Systems
 

--- a/deploy/one-click/README_zh.md
+++ b/deploy/one-click/README_zh.md
@@ -17,8 +17,21 @@
 - `smoke.sh`：执行基础健康检查。
 - `env.example`：构建机和目标机共用的环境变量模板。
 - `lib/common.sh`：公共 shell 函数。
-- `scripts/one-click/`：systemd 托管部署安装后使用的校验与维护辅助脚本。
+- `scripts/one-click/`：混合用途的历史目录，包含已废弃的聚合入口、兼容脚本，以及 systemd 和 Terraform 仍在调用的 helper；详见下方“脚本支持状态”。
 - `terraform/tencentcloud/`：在腾讯云上部署**集群版** CubeSandbox 的 Terraform 部署器（TKE 控制面 + CVM 计算节点）。`create.sh` 为入口，`destroy.sh` 负责整体销毁。这些文件同时位于发布包顶层和 `sandbox-package` 内（见“腾讯云集群部署”）。
+
+### 脚本支持状态
+
+不能把 `scripts/one-click/` 下的所有脚本都视为已废弃。当前状态如下：
+
+| 状态 | 脚本 | 用法 |
+|---|---|---|
+| 已废弃的服务管理入口 | `up-with-deps.sh`、`down-with-deps.sh` | 不再用于日常启动、停止或开机管理；请改用 `cube-sandbox-control.target` 或 `cube-sandbox-compute.target`。 |
+| 为兼容保留的旧实现 | `up.sh`、`down-local.sh`、`up-dns.sh`、`down-dns.sh`、`coredns-compose-lib.sh` | 不作为受支持的运维接口直接调用。 |
+| 当前仍在使用的内部 helper | 组件级 up/down、compose-lib、`quickcheck.sh` 以及 compute/egress 兼容脚本 | 当前 systemd unit、诊断流程或 Terraform compute 流程仍会调用，不能把它们作为实现 helper 标记为已废弃。 |
+
+安装器探测旧安装目录中的 `down-with-deps.sh`，只是为了接管 pre-systemd
+部署的升级兼容机制，并不代表该脚本仍是受支持的用户入口。
 
 ## 支持的操作系统
 

--- a/dev-env/README.md
+++ b/dev-env/README.md
@@ -45,35 +45,38 @@ cat /sys/module/kvm_intel/parameters/nested   # or kvm_amd, expect Y / 1
 
 Five steps. Run them in order.
 
+Run the host-side dev-env helpers with `sudo` so the qcow2 image, askpass
+helper, and other `.workdir` files keep consistent ownership. Build commands
+such as `make all` should still run as the regular user.
+
 ### Step 1 &nbsp; Prepare the VM image &nbsp; *(one-off, ~10 min)*
 
 ```bash
-./prepare_image.sh
+sudo ./prepare_image.sh
 ```
 
 Downloads the OpenCloudOS 9 cloud image, resizes it to 100G, and runs
-the in-guest setup (grow rootfs, relax SELinux, fix PATH, install login
-banner, install the autostart systemd unit). When it finishes the VM is
-shut down.
+the in-guest setup (grow rootfs, relax SELinux, fix PATH, and install the
+login banner). When it finishes the VM is shut down.
 
 You only need this on first setup or after deleting `.workdir/`.
 
 ### Step 2 &nbsp; Boot the VM &nbsp; *(terminal A)*
 
 ```bash
-./run_vm.sh
+sudo ./run_vm.sh
 ```
 
 QEMU's serial console stays attached to this terminal. Do not quit QEMU
 with `Ctrl+a` then `x`; that is abrupt and can corrupt the guest. In
-another terminal run `./login.sh`, then run `poweroff` inside the guest.
+another terminal run `sudo ./login.sh`, then run `poweroff` inside the guest.
 After the guest shuts down, `run_vm.sh` in this terminal usually exits on
 its own.
 
 ### Step 3 &nbsp; Log in &nbsp; *(terminal B)*
 
 ```bash
-./login.sh
+sudo ./login.sh
 ```
 
 You land in a root shell inside the guest. Password handling is
@@ -100,24 +103,23 @@ You should see `OK`. Cube Sandbox is now running.
 
 ## Make it survive a reboot &nbsp; *(one-off, strongly recommended)*
 
-By default the cube components are launched as bare processes — they do
-**not** come back after the VM reboots. To let `systemd` bring them up
-on every boot, run **on the host** after Step 5:
+The one-click installer installs and enables `cube-sandbox-control.target`.
+To verify that state and migrate an older dev VM away from the deprecated
+`cube-sandbox-oneclick.service`, run **on the host** after Step 5:
 
 ```bash
-./cube-autostart.sh            # default subcommand: enable
+sudo ./cube-autostart.sh            # default subcommand: enable
 ```
 
-This asks for confirmation, then enables `cube-sandbox-oneclick.service`
-inside the guest. From now on every boot will run `up-with-deps.sh`,
-which brings MySQL/Redis, cube-proxy, coredns, network-agent,
-cubemaster, cube-api and cubelet up together.
+This asks for confirmation, disables the legacy unit if it exists, then enables
+and restarts `cube-sandbox-control.target`. The target owns the component
+systemd services and brings them back after a reboot.
 
 Other subcommands:
 
 ```bash
-./cube-autostart.sh status     # show is-enabled / is-active
-./cube-autostart.sh disable    # roll back
+sudo ./cube-autostart.sh status     # show is-enabled / is-active
+sudo ./cube-autostart.sh disable    # disable autostart
 ```
 
 ## Develop: edit code, push to VM, see results
@@ -127,14 +129,14 @@ This is the main reason `dev-env/` exists.
 Recommended terminal setup:
 
 ```bash
-./login.sh    # keep this shell open; by default it lands in a root shell
+sudo ./login.sh    # keep this shell open; by default it lands in a root shell
 ```
 
 Then iterate from your host shell:
 
 ```bash
 make all
-./sync_to_vm.sh bin cubelet cubemaster
+sudo ./sync_to_vm.sh bin cubelet cubemaster
 ```
 
 `sync_to_vm.sh` now has a single job: copy files into the VM. It does not
@@ -142,32 +144,33 @@ build on the host, restart services, run `quickcheck.sh`, or roll back
 automatically.
 
 After the copy finishes, paste the printed restart command into your
-`./login.sh` session:
+`sudo ./login.sh` session:
 
 ```bash
-systemctl restart cube-sandbox-oneclick.service
+systemctl restart cube-sandbox-control.target
 ```
 
 Useful examples:
 
 ```bash
 # Sync all known binaries from _output/bin/
-./sync_to_vm.sh bin
+sudo ./sync_to_vm.sh bin
 
 # Sync only specific components
-./sync_to_vm.sh bin cubemaster cubelet
+sudo ./sync_to_vm.sh bin cubemaster cubelet
 
 # Push arbitrary files into the guest
-./sync_to_vm.sh files --remote-dir /tmp ./configs/foo.toml
+sudo ./sync_to_vm.sh files --remote-dir /tmp ./configs/foo.toml
 
-# Build and deploy the WebUI into the guest
-make -C .. web-sync-dev-env
+# Build the WebUI as the regular user, then deploy it with .workdir access
+make -C .. web-build
+sudo env WEB_SYNC_BUILD=0 ./internal/sync_web_to_vm.sh
 ```
 
 The previous binary is still kept on the VM as `*.bak`, but the script no
 longer surfaces rollback or verification steps in its output.
 
-Prerequisite: Step 4 finished and (recommended) `./cube-autostart.sh`
+Prerequisite: Step 4 finished and (recommended) `sudo ./cube-autostart.sh`
 has been run.
 
 ## Manual release flow
@@ -176,12 +179,12 @@ From your host shell:
 
 ```bash
 make manual-release
-./sync_to_vm.sh files \
+sudo ./sync_to_vm.sh files \
   _output/release/cube-manual-update-*.tar.gz \
   deploy/one-click/deploy-manual.sh
 ```
 
-Then in your `./login.sh` session:
+Then in your `sudo ./login.sh` session:
 
 ```bash
 bash /tmp/deploy-manual.sh /tmp/cube-manual-update-*.tar.gz
@@ -190,7 +193,7 @@ bash /tmp/deploy-manual.sh /tmp/cube-manual-update-*.tar.gz
 ## Collect logs from the VM
 
 ```bash
-./copy_logs.sh
+sudo ./copy_logs.sh
 ```
 
 Tarballs `/data/log` from inside the guest and drops it next to this
@@ -201,10 +204,10 @@ README as `data-log-<timestamp>.tar.gz`.
 | Symptom | Likely cause | Fix |
 |---------|--------------|-----|
 | No `/dev/kvm` inside the guest | Nested KVM disabled on the host | Enable nested virtualization on the host, then reboot the VM |
-| `./login.sh` fails to connect | VM not booted yet, or host port 10022 is busy | Check that `./run_vm.sh` is still running, or set `SSH_PORT` |
+| `sudo ./login.sh` fails to connect | VM not booted yet, or host port 10022 is busy | Check that `sudo ./run_vm.sh` is still running, or set `SSH_PORT` |
 | `df -h /` inside the guest is still small | `prepare_image.sh` never finished the auto-grow step | Inspect `.workdir/qemu-serial.log`, then `scp internal/grow_rootfs.sh` into the guest and run it manually |
-| Host port 13000 / 11080 / 11443 / 12088 already taken | Some other service binds the forwarded dev-env ports | Start with `CUBE_API_PORT=23000 CUBE_PROXY_HTTP_PORT=21080 CUBE_PROXY_HTTPS_PORT=21443 WEB_UI_PORT=22088 ./run_vm.sh` |
-| Cube components gone after VM reboot | Autostart not enabled | Run `./cube-autostart.sh` once |
+| Host port 13000 / 11080 / 11443 / 12088 already taken | Some other service binds the forwarded dev-env ports | Start with `sudo env CUBE_API_PORT=23000 CUBE_PROXY_HTTP_PORT=21080 CUBE_PROXY_HTTPS_PORT=21443 WEB_UI_PORT=22088 ./run_vm.sh` |
+| Cube components gone after VM reboot | The official target is not enabled or a legacy unit still conflicts with it | Run `sudo ./cube-autostart.sh` once |
 | New binaries fail after restart | The new build is bad, or `quickcheck` fails when you run it manually | Check `/data/log/` in the guest, and if needed restore the previous `*.bak` binary manually before restarting again |
 
 ## Reference
@@ -217,18 +220,19 @@ dev-env/
 ├── prepare_image.sh        # Step 1
 ├── run_vm.sh               # Step 2
 ├── login.sh                # Step 3
-├── cube-autostart.sh       # enable / disable / status the systemd autostart unit
+├── cube-autostart.sh       # enable / disable / status the official systemd target
 ├── sync_to_vm.sh           # Copy host artifacts into the guest (no build/restart)
 ├── copy_logs.sh            # Pull /data/log from the guest
 └── internal/               # Run inside the guest by prepare_image.sh
     ├── grow_rootfs.sh         # grow rootfs to qcow2 virtual size
     ├── setup_selinux.sh       # SELinux -> permissive (docker bind mount)
     ├── setup_path.sh          # /usr/local/{sbin,bin} on PATH
-    ├── setup_banner.sh        # /etc/profile.d/ login banner
-    └── setup_autostart.sh     # install cube-sandbox-oneclick.service (NOT enabled)
+    └── setup_banner.sh        # /etc/profile.d/ login banner
 ```
 
 Generated artifacts (qcow2, pid file, serial log) live in `.workdir/`.
+`internal/setup_autostart.sh` is retained as a deprecated compatibility
+artifact, but `prepare_image.sh` no longer uploads or runs it.
 
 ### Environment variables
 
@@ -237,7 +241,6 @@ Generated artifacts (qcow2, pid file, serial log) live in `.workdir/`.
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `AUTO_BOOT` | `1` | Boot the VM and run guest-side setup. `0` skips it (download + resize only). |
-| `SETUP_AUTOSTART` | `1` | Install the systemd autostart unit (still **not** enabled). `0` skips. |
 | `IMAGE_URL` | OpenCloudOS 9 | Override the source qcow2 URL. |
 | `TARGET_SIZE` | `100G` | Final qcow2 virtual size. |
 | `SSH_PORT` | `10022` | Host port forwarded to guest 22. |
@@ -267,7 +270,7 @@ Generated artifacts (qcow2, pid file, serial log) live in `.workdir/`.
 |----------|---------|-------------|
 | `ASSUME_YES` | `0` | `1` skips the interactive confirmation. |
 | `STOP_NOW` | `1` | `disable` only: `0` disables on next boot but leaves running services up. |
-| `UNIT_NAME` | `cube-sandbox-oneclick.service` | Override the unit name. |
+| `UNIT_NAME` | `cube-sandbox-control.target` | Override the managed target. The deprecated legacy unit is rejected. |
 
 Subcommands: `enable` (default), `disable`, `status`.
 
@@ -275,7 +278,7 @@ Subcommands: `enable` (default), `disable`, `status`.
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `UNIT_NAME` | `cube-sandbox-oneclick.service` | Unit name shown in the final restart hint. |
+| `UNIT_NAME` | `cube-sandbox-control.target` | Unit name shown in the final restart hint. |
 | `OUTPUT_BIN_DIR` | `_output/bin` | Where `bin` mode reads host-side binaries from. |
 
 Subcommands:

--- a/dev-env/README_zh.md
+++ b/dev-env/README_zh.md
@@ -44,30 +44,33 @@ cat /sys/module/kvm_intel/parameters/nested   # AMD 则是 kvm_amd，期望 Y / 
 
 五步，按顺序执行。
 
+宿主机侧 dev-env 辅助脚本统一使用 `sudo`，使 qcow2、askpass helper 和
+`.workdir` 中其他文件的所有权保持一致；`make all` 等构建命令仍用普通用户
+执行。
+
 ### 第 1 步 &nbsp; 准备虚机镜像 &nbsp; *(一次性，约 10 分钟)*
 
 ```bash
-./prepare_image.sh
+sudo ./prepare_image.sh
 ```
 
 下载 OpenCloudOS 9 云镜像，扩到 100G，并完成虚机内的初始化（扩根
-文件系统、放宽 SELinux、修 PATH、安装登录 banner、安装 autostart
-systemd unit）。完成后虚机自动关机。
+文件系统、放宽 SELinux、修 PATH、安装登录 banner）。完成后虚机自动关机。
 
 只在首次搭建、或者删掉 `.workdir/` 之后再跑一次。
 
 ### 第 2 步 &nbsp; 启动虚机 &nbsp; *(终端 A)*
 
 ```bash
-./run_vm.sh
+sudo ./run_vm.sh
 ```
 
-QEMU 串口控制台挂在这个终端里。不要用 `Ctrl+a` 然后 `x` 直接退出 QEMU（相当于硬断电，可能导致异常）。请在另一个终端执行 `./login.sh` 登录 guest，在 guest 内执行 `poweroff` 正常关机；guest 关机后本终端里的 `run_vm.sh` 通常会随之结束。
+QEMU 串口控制台挂在这个终端里。不要用 `Ctrl+a` 然后 `x` 直接退出 QEMU（相当于硬断电，可能导致异常）。请在另一个终端执行 `sudo ./login.sh` 登录 guest，在 guest 内执行 `poweroff` 正常关机；guest 关机后本终端里的 `run_vm.sh` 通常会随之结束。
 
 ### 第 3 步 &nbsp; 登录虚机 &nbsp; *(终端 B)*
 
 ```bash
-./login.sh
+sudo ./login.sh
 ```
 
 直接进入 guest 内的 root shell，密码自动处理。
@@ -77,7 +80,7 @@ QEMU 串口控制台挂在这个终端里。不要用 `Ctrl+a` 然后 `x` 直接
 在第 3 步打开的 guest shell 里：
 
 ```bash
-curl -sL https://github.com/tencentcloud/CubeSandbox/raw/master/deploy/one-click/online-install.sh | bash
+curl -sL https://github.com/tencentcloud/CubeSandbox/raw/master/deploy/one-click/online-install.sh | MIRROR=cn bash
 ```
 
 跑完后应该能看到四个核心进程都活着（`network-agent`、`cubemaster`、
@@ -93,22 +96,23 @@ curl -sf http://127.0.0.1:3000/health && echo OK
 
 ## 让虚机重启后服务还在 &nbsp; *(一次性，强烈推荐)*
 
-默认情况下 cube 组件是裸进程拉起的——虚机一重启就**不会**自动回来。
-让 systemd 在每次开机时把它们带回来，**在宿主机**上跑（在第 5 步之后）：
+one-click 安装器会安装并启用 `cube-sandbox-control.target`。为了确认该状态，
+并把旧 dev VM 从已废弃的 `cube-sandbox-oneclick.service` 迁移出来，
+请在第 5 步后从**宿主机**执行：
 
 ```bash
-./cube-autostart.sh            # 默认子命令：enable
+sudo ./cube-autostart.sh            # 默认子命令：enable
 ```
 
-会先交互确认，然后在 guest 内 enable `cube-sandbox-oneclick.service`。
-之后每次开机都会自动跑 `up-with-deps.sh`，把 MySQL/Redis、cube-proxy、
-coredns、network-agent、cubemaster、cube-api、cubelet 一并拉起。
+脚本会先交互确认；如果旧 unit 存在，会先禁用旧 unit，然后启用并重启
+`cube-sandbox-control.target`。之后由该 target 管理各组件 systemd service，
+并在虚机重启后自动恢复服务。
 
 其他子命令：
 
 ```bash
-./cube-autostart.sh status     # 查看 is-enabled / is-active
-./cube-autostart.sh disable    # 回退
+sudo ./cube-autostart.sh status     # 查看 is-enabled / is-active
+sudo ./cube-autostart.sh disable    # 禁用自启动
 ```
 
 ## 开发：改代码、推到虚机、看效果
@@ -118,45 +122,46 @@ coredns、network-agent、cubemaster、cube-api、cubelet 一并拉起。
 推荐的终端分工：
 
 ```bash
-./login.sh    # 常驻开着；默认会直接进 guest 的 root shell
+sudo ./login.sh    # 常驻开着；默认会直接进 guest 的 root shell
 ```
 
 然后在宿主机终端里做开发循环：
 
 ```bash
 make all
-./sync_to_vm.sh bin cubelet cubemaster
+sudo ./sync_to_vm.sh bin cubelet cubemaster
 ```
 
 现在的 `sync_to_vm.sh` 只有一个职责：把文件拷进虚机。它**不会**在宿主机
 构建、不会重启服务、不会跑 `quickcheck.sh`，也不会自动回滚。
 
-拷贝结束后，把脚本打印出来的重启命令粘进 `./login.sh` 那个终端里：
+拷贝结束后，把脚本打印出来的重启命令粘进 `sudo ./login.sh` 那个终端里：
 
 ```bash
-systemctl restart cube-sandbox-oneclick.service
+systemctl restart cube-sandbox-control.target
 ```
 
 常用示例：
 
 ```bash
 # 同步 _output/bin/ 里所有已知组件
-./sync_to_vm.sh bin
+sudo ./sync_to_vm.sh bin
 
 # 只同步指定组件
-./sync_to_vm.sh bin cubemaster cubelet
+sudo ./sync_to_vm.sh bin cubemaster cubelet
 
 # 推任意文件到 guest
-./sync_to_vm.sh files --remote-dir /tmp ./configs/foo.toml
+sudo ./sync_to_vm.sh files --remote-dir /tmp ./configs/foo.toml
 
-# 构建并部署 WebUI 到 guest
-make -C .. web-sync-dev-env
+# 普通用户构建 WebUI，再用有 .workdir 权限的方式部署
+make -C .. web-build
+sudo env WEB_SYNC_BUILD=0 ./internal/sync_web_to_vm.sh
 ```
 
 旧二进制仍然会在 guest 里保留成 `*.bak`，但脚本输出不再主动教你怎么
 verify / rollback；需要的话你自己在虚机里处理。
 
-前置：第 4 步已完成；推荐先跑过 `./cube-autostart.sh`。
+前置：第 4 步已完成；推荐先跑过 `sudo ./cube-autostart.sh`。
 
 ## manual-release 流程
 
@@ -164,12 +169,12 @@ verify / rollback；需要的话你自己在虚机里处理。
 
 ```bash
 make manual-release
-./sync_to_vm.sh files \
+sudo ./sync_to_vm.sh files \
   _output/release/cube-manual-update-*.tar.gz \
   deploy/one-click/deploy-manual.sh
 ```
 
-然后切到 `./login.sh` 的 root 终端里：
+然后切到 `sudo ./login.sh` 的 root 终端里：
 
 ```bash
 bash /tmp/deploy-manual.sh /tmp/cube-manual-update-*.tar.gz
@@ -178,7 +183,7 @@ bash /tmp/deploy-manual.sh /tmp/cube-manual-update-*.tar.gz
 ## 从虚机收日志
 
 ```bash
-./copy_logs.sh
+sudo ./copy_logs.sh
 ```
 
 把 guest 内 `/data/log` 打包，放到 README 同目录下，文件名为
@@ -189,10 +194,10 @@ bash /tmp/deploy-manual.sh /tmp/cube-manual-update-*.tar.gz
 | 现象 | 可能原因 | 解决方法 |
 |------|---------|---------|
 | 虚机内没有 `/dev/kvm` | 宿主机未开启 nested KVM | 在宿主机启用 nested virtualization，再重启虚机 |
-| `./login.sh` 连不上 | 虚机还没启动，或宿主机 10022 端口被占用 | 确认 `./run_vm.sh` 还在运行，或换 `SSH_PORT` |
+| `sudo ./login.sh` 连不上 | 虚机还没启动，或宿主机 10022 端口被占用 | 确认 `sudo ./run_vm.sh` 还在运行，或换 `SSH_PORT` |
 | 虚机里 `df -h /` 还是很小 | `prepare_image.sh` 没走完自动扩容 | 查看 `.workdir/qemu-serial.log`，然后把 `internal/grow_rootfs.sh` scp 进去手动跑一次 |
-| 宿主机 13000 / 11080 / 11443 / 12088 端口被占 | 本机有别的服务在用这些 dev-env 转发端口 | 用 `CUBE_API_PORT=23000 CUBE_PROXY_HTTP_PORT=21080 CUBE_PROXY_HTTPS_PORT=21443 WEB_UI_PORT=22088 ./run_vm.sh` |
-| 虚机重启后 cube 组件没了 | 还没开启 autostart | 跑一次 `./cube-autostart.sh` |
+| 宿主机 13000 / 11080 / 11443 / 12088 端口被占 | 本机有别的服务在用这些 dev-env 转发端口 | 用 `sudo env CUBE_API_PORT=23000 CUBE_PROXY_HTTP_PORT=21080 CUBE_PROXY_HTTPS_PORT=21443 WEB_UI_PORT=22088 ./run_vm.sh` |
+| 虚机重启后 cube 组件没了 | 官方 target 未启用，或仍有旧 unit 与其冲突 | 跑一次 `sudo ./cube-autostart.sh` |
 | 重启后新二进制不好使 | 新构建有问题，或你手动跑 `quickcheck` 失败了 | 看 guest 里 `/data/log/`，必要时把对应的 `*.bak` 手动移回去，再重新 `systemctl restart` |
 
 ## 参考
@@ -205,15 +210,14 @@ dev-env/
 ├── prepare_image.sh        # 第 1 步
 ├── run_vm.sh               # 第 2 步
 ├── login.sh                # 第 3 步
-├── cube-autostart.sh       # enable / disable / status systemd autostart unit
+├── cube-autostart.sh       # enable / disable / status 官方 systemd target
 ├── sync_to_vm.sh           # 只负责把宿主机产物拷进虚机，不 build/不 restart
 ├── copy_logs.sh            # 拉 /data/log
 └── internal/               # 由 prepare_image.sh 传进虚机执行
     ├── grow_rootfs.sh         # 扩根文件系统到 qcow2 虚拟大小
     ├── setup_selinux.sh       # SELinux 切 permissive（兼容 docker bind mount）
     ├── setup_path.sh          # /usr/local/{sbin,bin} 加进 PATH
-    ├── setup_banner.sh        # /etc/profile.d/ 登录 banner
-    └── setup_autostart.sh     # 安装 cube-sandbox-oneclick.service（不 enable）
+    └── setup_banner.sh        # /etc/profile.d/ 登录 banner
 ```
 
 生成的 qcow2、pid 文件、串口日志都放在 `.workdir/`。
@@ -225,7 +229,6 @@ dev-env/
 | 变量 | 默认值 | 说明 |
 |------|--------|------|
 | `AUTO_BOOT` | `1` | 启动虚机做 guest 内初始化。`0` 跳过（只下载 + 扩容）。 |
-| `SETUP_AUTOSTART` | `1` | 安装 systemd autostart unit（**不**自动 enable）。`0` 跳过。 |
 | `IMAGE_URL` | OpenCloudOS 9 | 覆盖源 qcow2 URL。 |
 | `TARGET_SIZE` | `100G` | qcow2 最终虚拟大小。 |
 | `SSH_PORT` | `10022` | 宿主机转发到 guest 22 的端口。 |
@@ -255,7 +258,7 @@ dev-env/
 |------|--------|------|
 | `ASSUME_YES` | `0` | `1` 跳过交互确认。 |
 | `STOP_NOW` | `1` | 仅 `disable`：`0` 只在下次开机不起，不停掉当前进程。 |
-| `UNIT_NAME` | `cube-sandbox-oneclick.service` | 覆盖 unit 名。 |
+| `UNIT_NAME` | `cube-sandbox-control.target` | 覆盖管理目标；已废弃的旧 unit 会被拒绝。 |
 
 子命令：`enable`（默认）、`disable`、`status`。
 
@@ -263,7 +266,7 @@ dev-env/
 
 | 变量 | 默认值 | 说明 |
 |------|--------|------|
-| `UNIT_NAME` | `cube-sandbox-oneclick.service` | 脚本末尾打印的重启提示里会用到的 unit 名。 |
+| `UNIT_NAME` | `cube-sandbox-control.target` | 脚本末尾打印的重启提示里会用到的 unit 名。 |
 | `OUTPUT_BIN_DIR` | `_output/bin` | `bin` 子命令读取宿主机二进制的目录。 |
 
 子命令：

--- a/dev-env/cube-autostart.sh
+++ b/dev-env/cube-autostart.sh
@@ -191,13 +191,13 @@ case "${ACTION}" in
       run_ssh "sudo systemctl disable '${LEGACY_UNIT_NAME}'"
 
       if run_ssh "sudo systemctl is-active '${LEGACY_UNIT_NAME}'" >/dev/null 2>&1; then
-        log_info "Stopping ${UNIT_NAME} before the active legacy unit..."
+        log_info "Pausing CubeSandbox services for a clean handoff from the legacy unit..."
         run_ssh "sudo systemctl stop '${UNIT_NAME}'"
         run_ssh "sudo systemctl stop '${LEGACY_UNIT_NAME}'"
       fi
 
       run_ssh "sudo systemctl reset-failed '${LEGACY_UNIT_NAME}'"
-      log_success "Legacy unit ${LEGACY_UNIT_NAME} disabled"
+      log_success "Legacy unit ${LEGACY_UNIT_NAME} cleaned up"
     fi
 
     log_info "Enabling and restarting ${UNIT_NAME}..."

--- a/dev-env/cube-autostart.sh
+++ b/dev-env/cube-autostart.sh
@@ -2,16 +2,15 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (C) 2026 Tencent. All rights reserved.
 #
-# cube-autostart.sh — Manage the CubeSandbox one-click autostart systemd unit.
+# cube-autostart.sh — Manage CubeSandbox's systemd target inside the dev VM.
 #
-# The unit file (cube-sandbox-oneclick.service) is installed into the guest by
-# prepare_image.sh but left disabled. This script is the user-facing entry
-# point to enable / disable / inspect it, so that cube components restart
-# automatically after a VM reboot.
+# The one-click installer owns cube-sandbox-control.target and its component
+# units. This script is the host-side entry point for enabling, disabling, and
+# inspecting that target. It also disables the legacy dev-env unit when found.
 #
 # Subcommands:
-#   enable     (default) Enable and start the unit; prompts for confirmation
-#   disable    Stop and disable the unit
+#   enable     (default) Enable and restart the target; prompts for confirmation
+#   disable    Stop and disable the target
 #   status     Print is-enabled / is-active and full systemctl status
 #   -h|--help  Show usage
 #
@@ -24,7 +23,7 @@
 # Common environment variables:
 #   VM_USER, VM_PASSWORD       Guest credentials (default: opencloudos / opencloudos)
 #   SSH_HOST, SSH_PORT         Host-side forward target (default: 127.0.0.1:10022)
-#   UNIT_NAME                  systemd unit name (default: cube-sandbox-oneclick.service)
+#   UNIT_NAME                  systemd target name (default: cube-sandbox-control.target)
 #   ASSUME_YES                 Skip interactive confirmation when set to 1
 #   STOP_NOW                   On disable, also stop the unit (default: 1)
 
@@ -38,7 +37,8 @@ VM_PASSWORD="${VM_PASSWORD:-opencloudos}"
 SSH_HOST="${SSH_HOST:-127.0.0.1}"
 SSH_PORT="${SSH_PORT:-10022}"
 
-UNIT_NAME="${UNIT_NAME:-cube-sandbox-oneclick.service}"
+UNIT_NAME="${UNIT_NAME:-cube-sandbox-control.target}"
+LEGACY_UNIT_NAME="cube-sandbox-oneclick.service"
 ASSUME_YES="${ASSUME_YES:-0}"
 STOP_NOW="${STOP_NOW:-1}"
 
@@ -78,9 +78,9 @@ usage() {
 Usage: $(basename "$0") [enable|disable|status]
 
 Subcommands:
-  enable   (default)  Enable and start ${UNIT_NAME} inside the guest, so
+  enable   (default)  Enable and restart ${UNIT_NAME} inside the guest, so
                       cube components come back automatically on every boot.
-  disable             Disable the unit. By default also stops it now
+  disable             Disable the target. By default also stops it now
                       (set STOP_NOW=0 to leave running services up).
   status              Show is-enabled / is-active and the latest status.
 
@@ -124,6 +124,12 @@ case "${ACTION}" in
     ;;
 esac
 
+if [[ "${UNIT_NAME}" == "${LEGACY_UNIT_NAME}" ]]; then
+  log_error "${LEGACY_UNIT_NAME} is deprecated and cannot be selected with UNIT_NAME."
+  log_error "Use cube-sandbox-control.target instead."
+  exit 1
+fi
+
 need_cmd ssh
 need_cmd setsid
 
@@ -155,45 +161,68 @@ run_ssh() {
   setsid -w ssh "${SSH_OPTS[@]}" "${VM_USER}@${SSH_HOST}" "$@"
 }
 
+unit_exists() {
+  run_ssh "sudo systemctl cat '$1'" >/dev/null 2>&1
+}
+
 log_info "Target VM : ${VM_USER}@${SSH_HOST}:${SSH_PORT}"
 log_info "Unit      : ${UNIT_NAME}"
 log_info "Action    : ${ACTION}"
 
 case "${ACTION}" in
   enable)
-    if ! run_ssh "sudo systemctl cat '${UNIT_NAME}'" >/dev/null 2>&1; then
+    if ! unit_exists "${UNIT_NAME}"; then
       log_error "Unit ${UNIT_NAME} not found inside the guest."
-      log_error "Run prepare_image.sh (with SETUP_AUTOSTART=1, the default) first,"
-      log_error "or manually run dev-env/internal/setup_autostart.sh inside the VM."
+      log_error "Please install CubeSandbox inside the VM with the one-click installer first."
       exit 1
     fi
 
     if run_ssh "sudo systemctl is-enabled '${UNIT_NAME}'" >/dev/null 2>&1; then
-      log_warn "${UNIT_NAME} is already enabled. Re-running enable --now is safe."
+      log_warn "${UNIT_NAME} is already enabled; it will still be restarted."
     fi
 
-    if ! confirm "Enable ${UNIT_NAME} on boot? It will run up-with-deps.sh on every boot."; then
+    if ! confirm "Enable ${UNIT_NAME} on boot and restart the CubeSandbox services now?"; then
       log_warn "Aborted by user."
       exit 1
     fi
 
-    log_info "Enabling and starting ${UNIT_NAME}..."
-    run_ssh "sudo systemctl enable --now '${UNIT_NAME}'"
-    log_success "${UNIT_NAME} enabled and started"
+    if unit_exists "${LEGACY_UNIT_NAME}"; then
+      log_info "Disabling legacy unit ${LEGACY_UNIT_NAME}..."
+      run_ssh "sudo systemctl disable '${LEGACY_UNIT_NAME}'"
+
+      if run_ssh "sudo systemctl is-active '${LEGACY_UNIT_NAME}'" >/dev/null 2>&1; then
+        log_info "Stopping ${UNIT_NAME} before the active legacy unit..."
+        run_ssh "sudo systemctl stop '${UNIT_NAME}'"
+        run_ssh "sudo systemctl stop '${LEGACY_UNIT_NAME}'"
+      fi
+
+      run_ssh "sudo systemctl reset-failed '${LEGACY_UNIT_NAME}'"
+      log_success "Legacy unit ${LEGACY_UNIT_NAME} disabled"
+    fi
+
+    log_info "Enabling and restarting ${UNIT_NAME}..."
+    run_ssh "sudo systemctl enable '${UNIT_NAME}'"
+    run_ssh "sudo systemctl restart '${UNIT_NAME}'"
+    log_success "${UNIT_NAME} enabled and restarted"
 
     log_info "Current status:"
     run_ssh "sudo systemctl --no-pager --full status '${UNIT_NAME}'" || true
     ;;
 
   disable)
-    if ! run_ssh "sudo systemctl cat '${UNIT_NAME}'" >/dev/null 2>&1; then
-      log_warn "Unit ${UNIT_NAME} not found inside the guest, nothing to disable."
+    target_exists=0
+    legacy_exists=0
+    unit_exists "${UNIT_NAME}" && target_exists=1
+    unit_exists "${LEGACY_UNIT_NAME}" && legacy_exists=1
+
+    if [[ "${target_exists}" == "0" && "${legacy_exists}" == "0" ]]; then
+      log_warn "Neither ${UNIT_NAME} nor ${LEGACY_UNIT_NAME} exists inside the guest."
       exit 0
     fi
 
-    local_prompt="Disable ${UNIT_NAME}?"
+    local_prompt="Disable CubeSandbox autostart (${UNIT_NAME} and any legacy unit)?"
     if [[ "${STOP_NOW}" == "1" ]]; then
-      local_prompt+=" It will also stop the unit (running cube components will be torn down)."
+      local_prompt+=" It will also stop the running CubeSandbox services."
     fi
 
     if ! confirm "${local_prompt}"; then
@@ -201,26 +230,54 @@ case "${ACTION}" in
       exit 1
     fi
 
-    if [[ "${STOP_NOW}" == "1" ]]; then
-      log_info "Disabling and stopping ${UNIT_NAME}..."
-      run_ssh "sudo systemctl disable --now '${UNIT_NAME}'"
-    else
-      log_info "Disabling ${UNIT_NAME} (leaving it running for now)..."
+    if [[ "${target_exists}" == "1" ]]; then
       run_ssh "sudo systemctl disable '${UNIT_NAME}'"
     fi
-    log_success "${UNIT_NAME} disabled"
+    if [[ "${legacy_exists}" == "1" ]]; then
+      run_ssh "sudo systemctl disable '${LEGACY_UNIT_NAME}'"
+    fi
+
+    if [[ "${STOP_NOW}" == "1" ]]; then
+      if [[ "${target_exists}" == "1" ]]; then
+        log_info "Stopping ${UNIT_NAME}..."
+        run_ssh "sudo systemctl stop '${UNIT_NAME}'"
+      fi
+      if [[ "${legacy_exists}" == "1" ]] \
+        && run_ssh "sudo systemctl is-active '${LEGACY_UNIT_NAME}'" >/dev/null 2>&1; then
+        log_info "Stopping legacy unit ${LEGACY_UNIT_NAME}..."
+        run_ssh "sudo systemctl stop '${LEGACY_UNIT_NAME}'"
+      fi
+    else
+      log_info "Units disabled; running services were left unchanged."
+    fi
+    log_success "CubeSandbox autostart disabled"
     ;;
 
   status)
-    if ! run_ssh "sudo systemctl cat '${UNIT_NAME}'" >/dev/null 2>&1; then
+    target_exists=0
+    if unit_exists "${UNIT_NAME}"; then
+      target_exists=1
+      enabled_state="$(run_ssh "sudo systemctl is-enabled '${UNIT_NAME}'" 2>/dev/null || true)"
+      active_state="$(run_ssh "sudo systemctl is-active '${UNIT_NAME}'" 2>/dev/null || true)"
+      log_info "is-enabled : ${enabled_state:-unknown}"
+      log_info "is-active  : ${active_state:-unknown}"
+      run_ssh "sudo systemctl --no-pager --full status '${UNIT_NAME}'" || true
+    else
       log_warn "Unit ${UNIT_NAME} not found inside the guest."
-      exit 0
     fi
 
-    enabled_state="$(run_ssh "sudo systemctl is-enabled '${UNIT_NAME}'" 2>/dev/null || true)"
-    active_state="$(run_ssh "sudo systemctl is-active '${UNIT_NAME}'" 2>/dev/null || true)"
-    log_info "is-enabled : ${enabled_state:-unknown}"
-    log_info "is-active  : ${active_state:-unknown}"
-    run_ssh "sudo systemctl --no-pager --full status '${UNIT_NAME}'" || true
+    if unit_exists "${LEGACY_UNIT_NAME}"; then
+      legacy_enabled_state="$(run_ssh "sudo systemctl is-enabled '${LEGACY_UNIT_NAME}'" 2>/dev/null || true)"
+      legacy_active_state="$(run_ssh "sudo systemctl is-active '${LEGACY_UNIT_NAME}'" 2>/dev/null || true)"
+      legacy_failed_state="$(run_ssh "sudo systemctl is-failed '${LEGACY_UNIT_NAME}'" 2>/dev/null || true)"
+      if [[ "${legacy_enabled_state}" == "enabled" \
+        || "${legacy_active_state}" == "active" \
+        || "${legacy_failed_state}" == "failed" ]]; then
+        log_warn \
+          "Legacy unit ${LEGACY_UNIT_NAME} still needs cleanup (enabled=${legacy_enabled_state:-unknown}, active=${legacy_active_state:-unknown}, failed=${legacy_failed_state:-unknown})."
+      fi
+    fi
+
+    [[ "${target_exists}" == "1" ]] || exit 0
     ;;
 esac

--- a/dev-env/prepare_image.sh
+++ b/dev-env/prepare_image.sh
@@ -9,12 +9,8 @@
 #      TARGET_SIZE (default 100G) so guest / has room for nested VMs.
 #   2. Boot the VM via run_vm.sh and wait for SSH on 127.0.0.1:10022.
 #   3. Upload and run a series of in-guest provisioners under dev-env/internal/
-#      (grow rootfs, setup PATH, SELinux tweaks, install autostart unit,
-#      install login banner).
+#      (grow rootfs, setup PATH, SELinux tweaks, and install login banner).
 #   4. Power the VM off cleanly, leaving a "golden" image ready for run_vm.sh.
-#
-# The autostart systemd unit is installed but NOT enabled here; enable it
-# later via dev-env/cube-autostart.sh.
 #
 # Usage:
 #   ./prepare_image.sh
@@ -25,7 +21,6 @@
 #   TARGET_SIZE                Resized disk size (default: 100G)
 #   AUTO_BOOT                  Auto-boot VM during provisioning (default: 1)
 #   AUTO_RESIZE_IN_GUEST       Run growpart/resize2fs inside guest (default: 1)
-#   SETUP_AUTOSTART            Install cube-sandbox-oneclick.service unit (default: 1)
 #   VM_USER, VM_PASSWORD       Guest credentials (default: opencloudos / opencloudos)
 #   SSH_HOST, SSH_PORT         Host-side forward target (default: 127.0.0.1:10022)
 
@@ -44,7 +39,6 @@ SSH_PORT="${SSH_PORT:-10022}"
 SSH_WAIT_TIMEOUT_SECS="${SSH_WAIT_TIMEOUT_SECS:-180}"
 SHUTDOWN_WAIT_TIMEOUT_SECS="${SHUTDOWN_WAIT_TIMEOUT_SECS:-120}"
 FORCE_KILL_ON_EXIT="${FORCE_KILL_ON_EXIT:-0}"
-SETUP_AUTOSTART="${SETUP_AUTOSTART:-1}"
 
 IMAGE_NAME="$(basename "${IMAGE_URL}")"
 IMAGE_PATH="${IMAGE_PATH:-${WORK_DIR}/${IMAGE_NAME}}"
@@ -54,7 +48,6 @@ GROW_SCRIPT="${INTERNAL_DIR}/grow_rootfs.sh"
 SELINUX_SCRIPT="${INTERNAL_DIR}/setup_selinux.sh"
 PATH_SCRIPT="${INTERNAL_DIR}/setup_path.sh"
 BANNER_SCRIPT="${INTERNAL_DIR}/setup_banner.sh"
-AUTOSTART_SCRIPT="${INTERNAL_DIR}/setup_autostart.sh"
 QEMU_PIDFILE="${WORK_DIR}/qemu.pid"
 QEMU_SERIAL_LOG="${WORK_DIR}/qemu-serial.log"
 ASKPASS_SCRIPT="${WORK_DIR}/.ssh-askpass.sh"
@@ -286,11 +279,6 @@ if [[ ! -f "${BANNER_SCRIPT}" ]]; then
   log_error "Guest banner script is missing: ${BANNER_SCRIPT}"
   exit 1
 fi
-if [[ "${SETUP_AUTOSTART}" == "1" && ! -f "${AUTOSTART_SCRIPT}" ]]; then
-  log_error "Guest autostart script is missing: ${AUTOSTART_SCRIPT}"
-  exit 1
-fi
-
 trap cleanup_vm EXIT
 create_askpass_script
 
@@ -355,21 +343,6 @@ ssh_with_password ssh "${SSH_COMMON_OPTS[@]}" -p "${SSH_PORT}" \
   'chmod +x ~/setup_banner.sh && ~/setup_banner.sh'
 log_success "Welcome banner installed inside the guest"
 
-if [[ "${SETUP_AUTOSTART}" == "1" ]]; then
-  log_info "Uploading setup_autostart.sh to the guest..."
-  ssh_with_password scp "${SSH_COMMON_OPTS[@]}" -P "${SSH_PORT}" \
-    "${AUTOSTART_SCRIPT}" "${VM_USER}@127.0.0.1:~/setup_autostart.sh"
-  log_success "setup_autostart.sh uploaded"
-
-  log_info "Installing cube-sandbox-oneclick.service unit (not enabled)..."
-  ssh_with_password ssh "${SSH_COMMON_OPTS[@]}" -p "${SSH_PORT}" \
-    "${VM_USER}@127.0.0.1" \
-    'chmod +x ~/setup_autostart.sh && ~/setup_autostart.sh'
-  log_success "Autostart unit installed inside the guest (enable it later via dev-env/cube-autostart.sh)"
-else
-  log_info "SETUP_AUTOSTART=0, skipping autostart unit installation"
-fi
-
 log_info "Requesting graceful shutdown from the guest..."
 ssh_with_password ssh "${SSH_COMMON_OPTS[@]}" -p "${SSH_PORT}" \
   "${VM_USER}@127.0.0.1" \
@@ -388,10 +361,5 @@ log_success "  3. VM booted and guest root filesystem expanded"
 log_success "  4. Guest SELinux set to permissive"
 log_success "  5. /usr/local/{sbin,bin} added to login PATH and sudo secure_path"
 log_success "  6. Welcome banner installed inside the guest"
-if [[ "${SETUP_AUTOSTART}" == "1" ]]; then
-  log_success "  7. cube-sandbox-oneclick.service unit installed (not enabled)"
-  log_success "  8. VM powered off cleanly"
-else
-  log_success "  7. VM powered off cleanly"
-fi
+log_success "  7. VM powered off cleanly"
 log_info "You can now run ./run_vm.sh to start the dev VM"

--- a/dev-env/sync_to_vm.sh
+++ b/dev-env/sync_to_vm.sh
@@ -19,7 +19,7 @@ SSH_HOST="${SSH_HOST:-127.0.0.1}"
 SSH_PORT="${SSH_PORT:-10022}"
 
 TOOLBOX_ROOT="${TOOLBOX_ROOT:-/usr/local/services/cubetoolbox}"
-UNIT_NAME="${UNIT_NAME:-cube-sandbox-oneclick.service}"
+UNIT_NAME="${UNIT_NAME:-cube-sandbox-control.target}"
 OUTPUT_BIN_DIR="${OUTPUT_BIN_DIR:-${REPO_ROOT}/_output/bin}"
 
 ASKPASS_SCRIPT="${WORK_DIR}/.ssh-askpass.sh"

--- a/dev-env/tests/test_systemd_autostart.sh
+++ b/dev-env/tests/test_systemd_autostart.sh
@@ -171,6 +171,9 @@ test_enable_migrates_active_legacy_unit() {
     FAKE_LEGACY_ACTIVE=1 \
     FAKE_LEGACY_FAILED=0
 
+  assert_contains "${output}" "Pausing CubeSandbox services for a clean handoff from the legacy unit"
+  assert_contains "${output}" "Legacy unit cube-sandbox-oneclick.service cleaned up"
+  assert_not_contains "${output}" "Stopping cube-sandbox-control.target before the active legacy unit"
   assert_contains "${SSH_LOG}" "sudo systemctl disable 'cube-sandbox-oneclick.service'"
   assert_contains "${SSH_LOG}" "sudo systemctl stop 'cube-sandbox-control.target'"
   assert_contains "${SSH_LOG}" "sudo systemctl stop 'cube-sandbox-oneclick.service'"

--- a/dev-env/tests/test_systemd_autostart.sh
+++ b/dev-env/tests/test_systemd_autostart.sh
@@ -1,0 +1,269 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (C) 2026 Tencent. All rights reserved.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DEV_ENV_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+AUTOSTART_SCRIPT="${DEV_ENV_DIR}/cube-autostart.sh"
+PREPARE_SCRIPT="${DEV_ENV_DIR}/prepare_image.sh"
+SYNC_SCRIPT="${DEV_ENV_DIR}/sync_to_vm.sh"
+LEGACY_SETUP_SCRIPT="${DEV_ENV_DIR}/internal/setup_autostart.sh"
+
+TMP_DIR="$(mktemp -d)"
+FAKE_BIN="${TMP_DIR}/bin"
+SSH_LOG="${TMP_DIR}/ssh.log"
+
+cleanup() {
+  rm -rf "${TMP_DIR}"
+}
+trap cleanup EXIT
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+assert_contains() {
+  local path="$1"
+  local expected="$2"
+  grep -Fq -- "${expected}" "${path}" \
+    || fail "expected ${path} to contain: ${expected}"
+}
+
+assert_not_contains() {
+  local path="$1"
+  local unexpected="$2"
+  if grep -Fq -- "${unexpected}" "${path}"; then
+    fail "expected ${path} not to contain: ${unexpected}"
+  fi
+}
+
+assert_before() {
+  local path="$1"
+  local first="$2"
+  local second="$3"
+  local first_line=""
+  local second_line=""
+
+  first_line="$(grep -nF -- "${first}" "${path}" | head -n 1 | cut -d: -f1 || true)"
+  second_line="$(grep -nF -- "${second}" "${path}" | head -n 1 | cut -d: -f1 || true)"
+  [[ -n "${first_line}" ]] || fail "missing first command in ${path}: ${first}"
+  [[ -n "${second_line}" ]] || fail "missing second command in ${path}: ${second}"
+  (( first_line < second_line )) \
+    || fail "expected '${first}' before '${second}' in ${path}"
+}
+
+mkdir -p "${FAKE_BIN}"
+
+cat >"${FAKE_BIN}/setsid" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ "${1:-}" == "-w" ]]; then
+  shift
+fi
+exec "$@"
+EOF
+
+cat >"${FAKE_BIN}/ssh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+remote_command="${!#}"
+printf '%s\n' "${remote_command}" >> "${FAKE_SSH_LOG}"
+
+case "${remote_command}" in
+  *"systemctl cat 'cube-sandbox-control.target'"*)
+    [[ "${FAKE_TARGET_EXISTS:-1}" == "1" ]]
+    ;;
+  *"systemctl cat 'cube-sandbox-oneclick.service'"*)
+    [[ "${FAKE_LEGACY_EXISTS:-0}" == "1" ]]
+    ;;
+  *"systemctl is-enabled 'cube-sandbox-control.target'"*)
+    if [[ "${FAKE_TARGET_ENABLED:-0}" == "1" ]]; then
+      printf 'enabled\n'
+      exit 0
+    fi
+    printf 'disabled\n'
+    exit 1
+    ;;
+  *"systemctl is-enabled 'cube-sandbox-oneclick.service'"*)
+    if [[ "${FAKE_LEGACY_ENABLED:-0}" == "1" ]]; then
+      printf 'enabled\n'
+      exit 0
+    fi
+    printf 'disabled\n'
+    exit 1
+    ;;
+  *"systemctl is-active 'cube-sandbox-control.target'"*)
+    if [[ "${FAKE_TARGET_ACTIVE:-0}" == "1" ]]; then
+      printf 'active\n'
+      exit 0
+    fi
+    printf 'inactive\n'
+    exit 3
+    ;;
+  *"systemctl is-active 'cube-sandbox-oneclick.service'"*)
+    if [[ "${FAKE_LEGACY_ACTIVE:-0}" == "1" ]]; then
+      printf 'active\n'
+      exit 0
+    fi
+    printf 'inactive\n'
+    exit 3
+    ;;
+  *"systemctl is-failed 'cube-sandbox-oneclick.service'"*)
+    if [[ "${FAKE_LEGACY_FAILED:-0}" == "1" ]]; then
+      printf 'failed\n'
+      exit 0
+    fi
+    printf 'inactive\n'
+    exit 1
+    ;;
+  *"systemctl --no-pager --full status '"*)
+    printf 'fake systemctl status\n'
+    ;;
+  *)
+    ;;
+esac
+EOF
+
+chmod +x "${FAKE_BIN}/setsid" "${FAKE_BIN}/ssh"
+
+run_autostart() {
+  local output_path="$1"
+  local action="$2"
+  shift 2
+
+  : >"${SSH_LOG}"
+  env \
+    PATH="${FAKE_BIN}:${PATH}" \
+    WORK_DIR="${TMP_DIR}/work" \
+    FAKE_SSH_LOG="${SSH_LOG}" \
+    ASSUME_YES=1 \
+    "$@" \
+    "${AUTOSTART_SCRIPT}" "${action}" >"${output_path}" 2>&1
+}
+
+test_enable_requires_official_target() {
+  local output="${TMP_DIR}/missing-target.out"
+
+  if run_autostart "${output}" enable \
+    FAKE_TARGET_EXISTS=0 \
+    FAKE_LEGACY_EXISTS=1; then
+    fail "enable should fail when cube-sandbox-control.target is missing"
+  fi
+
+  assert_contains "${output}" "Unit cube-sandbox-control.target not found"
+  assert_contains "${output}" "install CubeSandbox"
+  assert_not_contains "${SSH_LOG}" "systemctl enable 'cube-sandbox-control.target'"
+}
+
+test_enable_migrates_active_legacy_unit() {
+  local output="${TMP_DIR}/enable-migration.out"
+
+  run_autostart "${output}" enable \
+    FAKE_TARGET_EXISTS=1 \
+    FAKE_TARGET_ENABLED=1 \
+    FAKE_TARGET_ACTIVE=1 \
+    FAKE_LEGACY_EXISTS=1 \
+    FAKE_LEGACY_ENABLED=1 \
+    FAKE_LEGACY_ACTIVE=1 \
+    FAKE_LEGACY_FAILED=0
+
+  assert_contains "${SSH_LOG}" "sudo systemctl disable 'cube-sandbox-oneclick.service'"
+  assert_contains "${SSH_LOG}" "sudo systemctl stop 'cube-sandbox-control.target'"
+  assert_contains "${SSH_LOG}" "sudo systemctl stop 'cube-sandbox-oneclick.service'"
+  assert_contains "${SSH_LOG}" "sudo systemctl reset-failed 'cube-sandbox-oneclick.service'"
+  assert_contains "${SSH_LOG}" "sudo systemctl enable 'cube-sandbox-control.target'"
+  assert_contains "${SSH_LOG}" "sudo systemctl restart 'cube-sandbox-control.target'"
+  assert_before "${SSH_LOG}" \
+    "sudo systemctl stop 'cube-sandbox-control.target'" \
+    "sudo systemctl stop 'cube-sandbox-oneclick.service'"
+  assert_before "${SSH_LOG}" \
+    "sudo systemctl reset-failed 'cube-sandbox-oneclick.service'" \
+    "sudo systemctl restart 'cube-sandbox-control.target'"
+}
+
+test_enable_rejects_legacy_unit_override() {
+  local output="${TMP_DIR}/legacy-override.out"
+
+  if run_autostart "${output}" enable \
+    UNIT_NAME=cube-sandbox-oneclick.service \
+    FAKE_LEGACY_EXISTS=1; then
+    fail "legacy UNIT_NAME override should be rejected"
+  fi
+
+  assert_contains "${output}" "deprecated"
+  [[ ! -s "${SSH_LOG}" ]] || fail "legacy UNIT_NAME rejection should happen before SSH"
+}
+
+test_disable_without_stop_disables_both_units() {
+  local output="${TMP_DIR}/disable-later.out"
+
+  run_autostart "${output}" disable \
+    STOP_NOW=0 \
+    FAKE_TARGET_EXISTS=1 \
+    FAKE_LEGACY_EXISTS=1 \
+    FAKE_LEGACY_ACTIVE=1
+
+  assert_contains "${SSH_LOG}" "sudo systemctl disable 'cube-sandbox-control.target'"
+  assert_contains "${SSH_LOG}" "sudo systemctl disable 'cube-sandbox-oneclick.service'"
+  assert_not_contains "${SSH_LOG}" "sudo systemctl stop 'cube-sandbox-control.target'"
+  assert_not_contains "${SSH_LOG}" "sudo systemctl stop 'cube-sandbox-oneclick.service'"
+}
+
+test_disable_stops_target_before_active_legacy_unit() {
+  local output="${TMP_DIR}/disable-now.out"
+
+  run_autostart "${output}" disable \
+    STOP_NOW=1 \
+    FAKE_TARGET_EXISTS=1 \
+    FAKE_TARGET_ACTIVE=1 \
+    FAKE_LEGACY_EXISTS=1 \
+    FAKE_LEGACY_ACTIVE=1
+
+  assert_before "${SSH_LOG}" \
+    "sudo systemctl stop 'cube-sandbox-control.target'" \
+    "sudo systemctl stop 'cube-sandbox-oneclick.service'"
+}
+
+test_status_warns_about_unhealthy_legacy_unit() {
+  local output="${TMP_DIR}/status.out"
+
+  run_autostart "${output}" status \
+    FAKE_TARGET_EXISTS=1 \
+    FAKE_TARGET_ENABLED=1 \
+    FAKE_TARGET_ACTIVE=1 \
+    FAKE_LEGACY_EXISTS=1 \
+    FAKE_LEGACY_ENABLED=1 \
+    FAKE_LEGACY_ACTIVE=0 \
+    FAKE_LEGACY_FAILED=1
+
+  assert_contains "${output}" "is-enabled : enabled"
+  assert_contains "${output}" "is-active  : active"
+  assert_contains "${output}" "Legacy unit cube-sandbox-oneclick.service still needs cleanup"
+  assert_contains "${output}" "enabled=enabled, active=inactive, failed=failed"
+}
+
+test_static_wiring_uses_official_target() {
+  assert_not_contains "${PREPARE_SCRIPT}" "SETUP_AUTOSTART"
+  assert_not_contains "${PREPARE_SCRIPT}" "setup_autostart.sh"
+  [[ -f "${LEGACY_SETUP_SCRIPT}" ]] || fail "deprecated setup_autostart.sh should be retained"
+  assert_contains "${SYNC_SCRIPT}" 'UNIT_NAME="${UNIT_NAME:-cube-sandbox-control.target}"'
+}
+
+test_enable_requires_official_target
+echo "PASS: enable requires official target"
+test_enable_migrates_active_legacy_unit
+echo "PASS: enable migrates active legacy unit"
+test_enable_rejects_legacy_unit_override
+echo "PASS: enable rejects legacy UNIT_NAME override"
+test_disable_without_stop_disables_both_units
+echo "PASS: disable without stop disables both units"
+test_disable_stops_target_before_active_legacy_unit
+echo "PASS: disable stops target before legacy unit"
+test_status_warns_about_unhealthy_legacy_unit
+echo "PASS: status warns about unhealthy legacy unit"
+test_static_wiring_uses_official_target
+echo "PASS: static wiring uses official target"

--- a/docs/guide/service-management.md
+++ b/docs/guide/service-management.md
@@ -11,8 +11,27 @@ After reading this page you will know:
 - How to stop / restart the whole stack cleanly
 
 ::: tip Scope
-This page targets the **systemd-managed** one-click installer. If your machine still uses the legacy `up-with-deps.sh` / `down-with-deps.sh` scripts as the daily entry point, that is the pre-systemd version — re-running the latest one-click installer will migrate it to systemd automatically (the installer detects and takes over the old layout).
+This page targets the **systemd-managed** one-click installer. The aggregate
+`up-with-deps.sh` and `down-with-deps.sh` entry points are deprecated and must
+not be used for daily start, stop, or boot management. Re-running the latest
+one-click installer migrates a pre-systemd installation automatically. Its
+lookup of the old installed `down-with-deps.sh` is only an upgrade takeover
+mechanism, not a supported operator interface.
 :::
+
+### Legacy script status
+
+The `scripts/one-click/` directory is mixed-purpose:
+
+- Deprecated operator entry points: `up-with-deps.sh`, `down-with-deps.sh`.
+- Legacy internals retained for compatibility: `up.sh`, `down-local.sh`,
+  `up-dns.sh`, `down-dns.sh`, `coredns-compose-lib.sh`.
+- Active implementation helpers: component-level up/down and compose-lib
+  scripts, `quickcheck.sh`, and compute/egress scripts that still have systemd
+  or Terraform callers.
+
+Operate the stack through `cube-sandbox-control.target` on a control node or
+`cube-sandbox-compute.target` on a compute node.
 
 ## TL;DR cheat-sheet
 

--- a/docs/zh/guide/service-management.md
+++ b/docs/zh/guide/service-management.md
@@ -11,8 +11,26 @@
 - 完整下线 / 重启整机栈的姿势
 
 ::: tip 适用范围
-本页对应**新版（systemd 托管）的一键安装包**。如果你的机器上还能看到 `up-with-deps.sh` / `down-with-deps.sh` 这类脚本作为日常入口，那是 pre-systemd 老版本，重新执行最新一键安装包即可平滑升级（安装器内置了对老部署的接管逻辑）。
+本页对应**新版（systemd 托管）的一键安装包**。聚合入口
+`up-with-deps.sh` 和 `down-with-deps.sh` 已废弃，不能再用于日常启动、停止
+或开机管理。重新执行最新一键安装包会自动迁移 pre-systemd 安装；安装器对
+旧安装目录中 `down-with-deps.sh` 的探测仅用于升级接管，不代表它仍是受支持
+的运维接口。
 :::
+
+### 遗留脚本状态
+
+`scripts/one-click/` 是混合用途的历史目录：
+
+- 已废弃的运维入口：`up-with-deps.sh`、`down-with-deps.sh`。
+- 为兼容保留的旧实现：`up.sh`、`down-local.sh`、`up-dns.sh`、
+  `down-dns.sh`、`coredns-compose-lib.sh`。
+- 当前仍在使用的实现 helper：组件级 up/down 和 compose-lib 脚本、
+  `quickcheck.sh`，以及仍有 systemd 或 Terraform 调用者的 compute/egress
+  脚本。
+
+控制节点应通过 `cube-sandbox-control.target` 管理整套服务，计算节点使用
+`cube-sandbox-compute.target`。
 
 ## TL;DR 一分钟备忘
 


### PR DESCRIPTION
## 概述 / Summary

https://github.com/TencentCloud/CubeSandbox/issues/927

- 将 dev-env 自启动管理从旧的 `cube-sandbox-oneclick.service` 迁移到 `cube-sandbox-control.target`。
- 停止在 `prepare_image.sh` 中安装旧 unit，并更新 `sync_to_vm.sh` 的重启提示。
- 增加旧 unit 迁移逻辑、自动化测试及中英文文档，明确废弃的脚本和 `sudo` 使用方式。

- Migrate dev-env autostart management from the legacy `cube-sandbox-oneclick.service` to `cube-sandbox-control.target`.
- Stop installing the legacy unit during image preparation and update the restart hint in `sync_to_vm.sh`.
- Add legacy-unit migration tests and update the English and Chinese documentation.

## 测试 / Testing

- `bash dev-env/tests/test_systemd_autostart.sh`
- `bash -n dev-env/*.sh dev-env/internal/*.sh dev-env/tests/*.sh`
- Completed a one-click installation in the dev VM.
- Confirmed the control target is enabled and active, all 14 component services are active, the legacy unit is absent, and `quickcheck.sh` reports `OK`.

Assisted-by: Codex:GPT-5