### PR TITLE
feat(qos): add template-level sandbox QoS

### DIFF
--- a/CubeAPI/src/cubemaster/mod.rs
+++ b/CubeAPI/src/cubemaster/mod.rs
@@ -1168,6 +1168,10 @@ pub struct GetSandboxDataItem {
     #[serde(default)]
     pub labels: HashMap<String, String>,
     #[serde(default)]
+    pub configured_qos: Option<CubeQosConfig>,
+    #[serde(default)]
+    pub qos_applied: bool,
+    #[serde(default)]
     pub containers: Vec<GetSandboxContainerItem>,
     #[serde(default)]
     pub namespace: String,
@@ -1217,6 +1221,8 @@ pub struct SandboxDetail {
     pub annotations: HashMap<String, String>,
     pub labels: HashMap<String, String>,
     pub volume_mounts: Vec<CubeVolumeMount>,
+    pub configured_qos: Option<CubeQosConfig>,
+    pub qos_applied: bool,
 }
 
 fn parse_cpu_millicores(s: &str) -> i32 {
@@ -1396,6 +1402,8 @@ impl GetSandboxResponse {
             annotations: item.annotations,
             labels: item.labels,
             volume_mounts: item.volume_mounts,
+            configured_qos: item.configured_qos,
+            qos_applied: item.qos_applied,
         })
     }
 }
@@ -1851,6 +1859,8 @@ pub struct TemplateResponse {
     pub replicas: Vec<serde_json::Value>,
     #[serde(default)]
     pub create_request: Option<serde_json::Value>,
+    #[serde(default)]
+    pub configured_qos: Option<CubeQosConfig>,
 }
 
 /// Body for DELETE /cube/template.
@@ -1994,9 +2004,50 @@ pub struct CreateTemplateFromImageReq {
     /// Whether the template build sandbox should include ivshmem.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub enable_ivshmem: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub qos: Option<CubeQosConfig>,
     /// Whether CubeMaster bakes the CubeEgress root CA into the template rootfs.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub with_cube_ca: Option<bool>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct CubeQosConfig {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub network: Option<CubeNetworkQosConfig>,
+    #[serde(rename = "blockIo", default, skip_serializing_if = "Option::is_none")]
+    pub block_io: Option<CubeBlockIoQosConfig>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct CubeNetworkQosConfig {
+    #[serde(rename = "bandwidthMbps", default, skip_serializing_if = "is_zero_u32")]
+    pub bandwidth_mbps: u32,
+    #[serde(
+        rename = "packetsPerSecond",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub packets_per_second: Option<u32>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct CubeBlockIoQosConfig {
+    #[serde(
+        rename = "throughputMiBps",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub throughput_mibps: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub iops: Option<u32>,
+}
+
+fn is_zero_u32(value: &u32) -> bool {
+    *value == 0
 }
 
 /// Minimal container overrides for template creation.
@@ -2499,6 +2550,10 @@ mod tests {
                 "host_id": "host-1",
                 "status": 1,
                 "template_id": "tpl-1",
+                "configured_qos": {
+                    "network": { "bandwidthMbps": 100 }
+                },
+                "qos_applied": true,
                 "containers": [
                     {
                         "container_id": "workload-1",
@@ -2527,6 +2582,15 @@ mod tests {
         assert_eq!(detail.host_id, "host-1");
         assert_eq!(detail.cpu_count, 2);
         assert_eq!(detail.memory_mb, 2048);
+        assert_eq!(
+            detail
+                .configured_qos
+                .as_ref()
+                .and_then(|qos| qos.network.as_ref())
+                .map(|network| network.bandwidth_mbps),
+            Some(100)
+        );
+        assert!(detail.qos_applied);
         assert_eq!(
             detail
                 .started_at

--- a/CubeAPI/src/models/mod.rs
+++ b/CubeAPI/src/models/mod.rs
@@ -361,6 +361,10 @@ pub struct SandboxDetail {
     pub state: SandboxState,
     #[serde(rename = "volumeMounts", skip_serializing_if = "Option::is_none")]
     pub volume_mounts: Option<Vec<SandboxVolumeMount>>,
+    #[serde(rename = "configuredQos", skip_serializing_if = "Option::is_none")]
+    pub configured_qos: Option<QosConfig>,
+    #[serde(rename = "qosApplied")]
+    pub qos_applied: bool,
 }
 
 // ─── Sandbox — pause/resume/connect/snapshot ──────────────────────────────
@@ -706,6 +710,85 @@ mod tests {
         assert_eq!(json["templateID"], "tpl-abc");
         assert_eq!(json["public"], true);
     }
+
+    #[test]
+    fn create_template_accepts_canonical_qos_shape() {
+        let req: CreateTemplateRequest = serde_json::from_value(serde_json::json!({
+            "image": "example.invalid/sandbox:latest",
+            "qos": {
+                "network": {
+                    "bandwidthMbps": 100,
+                    "packetsPerSecond": 5000
+                }
+            }
+        }))
+        .expect("template qos should deserialize");
+
+        let qos = req.qos.expect("qos");
+        let network = qos.network.expect("network qos");
+        assert_eq!(network.bandwidth_mbps, Some(100));
+        assert_eq!(network.packets_per_second, Some(5000));
+    }
+
+    #[test]
+    fn create_template_accepts_packets_only_qos_shape() {
+        let req: CreateTemplateRequest = serde_json::from_value(serde_json::json!({
+            "image": "example.invalid/sandbox:latest",
+            "qos": {
+                "network": {
+                    "packetsPerSecond": 5000
+                }
+            }
+        }))
+        .expect("packets-only template qos should deserialize");
+
+        let qos = req.qos.expect("qos");
+        let network = qos.network.as_ref().expect("network qos");
+        assert_eq!(network.bandwidth_mbps, None);
+        assert_eq!(network.packets_per_second, Some(5000));
+        let serialized = serde_json::to_value(qos).expect("qos should serialize");
+        assert_eq!(
+            serialized,
+            serde_json::json!({
+                "network": {"packetsPerSecond": 5000}
+            })
+        );
+    }
+
+    #[test]
+    fn create_template_accepts_block_io_only_qos_shape() {
+        let req: CreateTemplateRequest = serde_json::from_value(serde_json::json!({
+            "image": "example.invalid/sandbox:latest",
+            "qos": {
+                "blockIo": {
+                    "throughputMiBps": 64,
+                    "iops": 1000
+                }
+            }
+        }))
+        .expect("block-io-only template qos should deserialize");
+
+        let qos = req.qos.expect("qos");
+        assert!(qos.network.is_none());
+        let block_io = qos.block_io.expect("block io qos");
+        assert_eq!(block_io.throughput_mibps, Some(64));
+        assert_eq!(block_io.iops, Some(1000));
+    }
+
+    #[test]
+    fn create_template_rejects_unknown_qos_fields() {
+        let err = serde_json::from_value::<CreateTemplateRequest>(serde_json::json!({
+            "image": "example.invalid/sandbox:latest",
+            "qos": {
+                "network": {
+                    "bandwidth_mbps": 100
+                }
+            }
+        }))
+        .expect_err("unknown qos fields must be rejected");
+
+        assert!(err.to_string().contains("bandwidth_mbps"));
+    }
 }
 
 // ─── Templates ─────────────────────────────────────────────────────────────
@@ -772,6 +855,8 @@ pub struct TemplateDetail {
         skip_serializing_if = "Option::is_none"
     )]
     pub allow_internet_access: Option<bool>,
+    #[serde(rename = "configuredQos", skip_serializing_if = "Option::is_none")]
+    pub configured_qos: Option<QosConfig>,
     /// Latest create/rebuild job id for the template.
     #[serde(rename = "jobID", skip_serializing_if = "Option::is_none")]
     pub job_id: Option<String>,
@@ -854,10 +939,57 @@ pub struct CreateTemplateRequest {
     /// Enable ivshmem when building the template snapshot.
     #[serde(rename = "enableIvshmem", default)]
     pub enable_ivshmem: Option<bool>,
+    /// Optional template-level QoS. Every sandbox created from this template
+    /// receives the same independent ingress and egress network ceilings.
+    #[serde(default)]
+    pub qos: Option<QosConfig>,
     /// Whether CubeMaster bakes the CubeEgress root CA into the template rootfs.
     /// Omitted or null defaults to true on CubeMaster.
     #[serde(rename = "with_cube_ca", default)]
     pub with_cube_ca: Option<bool>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[serde(deny_unknown_fields)]
+pub struct QosConfig {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub network: Option<NetworkQosConfig>,
+    #[serde(rename = "blockIo", default, skip_serializing_if = "Option::is_none")]
+    pub block_io: Option<BlockIoQosConfig>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[serde(deny_unknown_fields)]
+pub struct NetworkQosConfig {
+    #[schema(minimum = 1)]
+    #[serde(
+        rename = "bandwidthMbps",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub bandwidth_mbps: Option<u32>,
+    #[schema(minimum = 1)]
+    #[serde(
+        rename = "packetsPerSecond",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub packets_per_second: Option<u32>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[serde(deny_unknown_fields)]
+pub struct BlockIoQosConfig {
+    #[schema(minimum = 1)]
+    #[serde(
+        rename = "throughputMiBps",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub throughput_mibps: Option<u32>,
+    #[schema(minimum = 1)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub iops: Option<u32>,
 }
 
 /// Body for POST /templates/:id (rebuild).

--- a/CubeAPI/src/openapi.rs
+++ b/CubeAPI/src/openapi.rs
@@ -12,14 +12,15 @@ use utoipa::{
 use crate::{
     handlers,
     models::{
-        ApiError, ConnectSandbox, CreateSnapshotRequest, CreateTemplateRequest, NewSandbox,
-        NewVolume, RebuildTemplateRequest, RefreshRequest, ResumedSandbox, RollbackRequest,
-        RollbackResponse, Sandbox, SandboxDetail, SandboxLogEntry, SandboxLogs,
-        SandboxLogsV2Response, SandboxState, SandboxVolumeMount, SetTemplateAliasRequest,
-        SetTimeoutRequest, SnapshotInfo, SnapshotListItem, TemplateAliasLookupResponse,
-        TemplateBuildJob, TemplateBuildStatus, TemplateCompatAdoptResponseView,
-        TemplateCompatMatrixView, TemplateCompatRowView, TemplateCompatSummaryView, TemplateDetail,
-        TemplateNodeCompatView, TemplateSummary, Volume, VolumeAndToken,
+        ApiError, BlockIoQosConfig, ConnectSandbox, CreateSnapshotRequest, CreateTemplateRequest,
+        NetworkQosConfig, NewSandbox, NewVolume, QosConfig, RebuildTemplateRequest, RefreshRequest,
+        ResumedSandbox, RollbackRequest, RollbackResponse, Sandbox, SandboxDetail, SandboxLogEntry,
+        SandboxLogs, SandboxLogsV2Response, SandboxState, SandboxVolumeMount,
+        SetTemplateAliasRequest, SetTimeoutRequest, SnapshotInfo, SnapshotListItem,
+        TemplateAliasLookupResponse, TemplateBuildJob, TemplateBuildStatus,
+        TemplateCompatAdoptResponseView, TemplateCompatMatrixView, TemplateCompatRowView,
+        TemplateCompatSummaryView, TemplateDetail, TemplateNodeCompatView, TemplateSummary, Volume,
+        VolumeAndToken,
     },
 };
 
@@ -95,6 +96,9 @@ impl Modify for SecurityAddon {
         TemplateBuildJob,
         TemplateBuildStatus,
         CreateTemplateRequest,
+        QosConfig,
+        NetworkQosConfig,
+        BlockIoQosConfig,
         RebuildTemplateRequest,
         SetTemplateAliasRequest,
         TemplateCompatSummaryView,

--- a/CubeAPI/src/services/mod.rs
+++ b/CubeAPI/src/services/mod.rs
@@ -9,9 +9,40 @@ pub mod volumes;
 
 use crate::{
     config::ServerConfig,
-    cubemaster::CubeMasterClient,
+    cubemaster::{CubeBlockIoQosConfig, CubeMasterClient, CubeNetworkQosConfig, CubeQosConfig},
     error::{AppError, AppResult},
+    models::{BlockIoQosConfig, NetworkQosConfig, QosConfig},
 };
+
+impl From<CubeQosConfig> for QosConfig {
+    fn from(qos: CubeQosConfig) -> Self {
+        Self {
+            network: qos.network.map(|network| NetworkQosConfig {
+                bandwidth_mbps: (network.bandwidth_mbps > 0).then_some(network.bandwidth_mbps),
+                packets_per_second: network.packets_per_second,
+            }),
+            block_io: qos.block_io.map(|block_io| BlockIoQosConfig {
+                throughput_mibps: block_io.throughput_mibps,
+                iops: block_io.iops,
+            }),
+        }
+    }
+}
+
+impl From<&QosConfig> for CubeQosConfig {
+    fn from(qos: &QosConfig) -> Self {
+        Self {
+            network: qos.network.as_ref().map(|network| CubeNetworkQosConfig {
+                bandwidth_mbps: network.bandwidth_mbps.unwrap_or_default(),
+                packets_per_second: network.packets_per_second,
+            }),
+            block_io: qos.block_io.as_ref().map(|block_io| CubeBlockIoQosConfig {
+                throughput_mibps: block_io.throughput_mibps,
+                iops: block_io.iops,
+            }),
+        }
+    }
+}
 
 const DENY_ALL_IPV4_CIDR: &str = "0.0.0.0/0";
 const ALLOW_OUT_DOMAIN_REQUIRES_DENY_ALL: &str =

--- a/CubeAPI/src/services/sandboxes.rs
+++ b/CubeAPI/src/services/sandboxes.rs
@@ -148,6 +148,8 @@ impl SandboxService {
             metadata: optional_metadata(d.labels),
             state: sandbox_state_from_status(d.status),
             volume_mounts: map_volume_mounts(&d.volume_mounts),
+            configured_qos: d.configured_qos.map(Into::into),
+            qos_applied: d.qos_applied,
         })
     }
 

--- a/CubeAPI/src/services/templates.rs
+++ b/CubeAPI/src/services/templates.rs
@@ -9,8 +9,8 @@ use crate::{
     cubemaster::{
         CreateTemplateContainerOverrides, CreateTemplateCubeNetworkConfig, CreateTemplateEnv,
         CreateTemplateFromImageReq, CreateTemplateResources, CubeMasterClient, CubeMasterError,
-        DnsConfig, HttpGetAction, Probe, ProbeHandler, RedoTemplateReq, TemplateCompatAdoptRequest,
-        TemplateDeleteRequest, TemplateJob, TemplateJobResponse,
+        CubeQosConfig, DnsConfig, HttpGetAction, Probe, ProbeHandler, RedoTemplateReq,
+        TemplateCompatAdoptRequest, TemplateDeleteRequest, TemplateJob, TemplateJobResponse,
     },
     error::{AppError, AppResult},
     models::{
@@ -137,6 +137,7 @@ impl TemplateService {
         let container_overrides = build_template_container_overrides(&body, dns_servers.as_deref());
         let cube_network_config = build_template_cube_network_config(&body)?;
         let alias = template_alias_from_request(&body);
+        let qos = build_template_qos(&body)?;
 
         let req = CreateTemplateFromImageReq {
             request_id: new_request_id(),
@@ -158,6 +159,7 @@ impl TemplateService {
             container_overrides,
             cube_network_config,
             enable_ivshmem: body.enable_ivshmem,
+            qos,
             with_cube_ca: body.with_cube_ca,
         };
 
@@ -356,7 +358,8 @@ fn template_detail_from_cubemaster(
         last_error: non_empty(resp.last_error),
         created_at: non_empty(resp.created_at),
         replicas: resp.replicas,
-        create_request: resp.create_request,
+        create_request: sanitize_template_create_request(resp.create_request),
+        configured_qos: resp.configured_qos.map(Into::into),
         network_type,
         allow_internet_access,
         job_id: non_empty(resp.job_id),
@@ -656,6 +659,67 @@ fn build_template_cube_network_config(
     }))
 }
 
+fn build_template_qos(body: &CreateTemplateRequest) -> AppResult<Option<CubeQosConfig>> {
+    let Some(qos) = body.qos.as_ref() else {
+        return Ok(None);
+    };
+    if qos.network.is_none() && qos.block_io.is_none() {
+        return Err(AppError::BadRequest(
+            "qos must configure network or blockIo".to_string(),
+        ));
+    }
+    if let Some(network) = qos.network.as_ref() {
+        if network.bandwidth_mbps == Some(0) {
+            return Err(AppError::BadRequest(
+                "qos.network.bandwidthMbps must be at least 1".to_string(),
+            ));
+        }
+        if network.packets_per_second == Some(0) {
+            return Err(AppError::BadRequest(
+                "qos.network.packetsPerSecond must be at least 1".to_string(),
+            ));
+        }
+        if network.bandwidth_mbps.is_none() && network.packets_per_second.is_none() {
+            return Err(AppError::BadRequest(
+                "qos.network must configure bandwidthMbps or packetsPerSecond".to_string(),
+            ));
+        }
+    }
+    if let Some(block_io) = qos.block_io.as_ref() {
+        if block_io.throughput_mibps == Some(0) {
+            return Err(AppError::BadRequest(
+                "qos.blockIo.throughputMiBps must be at least 1".to_string(),
+            ));
+        }
+        if block_io.iops == Some(0) {
+            return Err(AppError::BadRequest(
+                "qos.blockIo.iops must be at least 1".to_string(),
+            ));
+        }
+        if block_io.throughput_mibps.is_none() && block_io.iops.is_none() {
+            return Err(AppError::BadRequest(
+                "qos.blockIo must configure throughputMiBps or iops".to_string(),
+            ));
+        }
+    }
+    Ok(Some(qos.into()))
+}
+
+fn sanitize_template_create_request(
+    mut create_request: Option<serde_json::Value>,
+) -> Option<serde_json::Value> {
+    if let Some(annotations) = create_request
+        .as_mut()
+        .and_then(|value| value.get_mut("annotations"))
+        .and_then(serde_json::Value::as_object_mut)
+    {
+        annotations.remove("cube.master.net");
+        annotations.remove("cube.master.blk.qos");
+        annotations.remove("cube.master.fs.qos");
+    }
+    create_request
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -696,6 +760,7 @@ mod tests {
             allow_out: Some(vec!["172.67.0.0/16".to_string()]),
             deny_out: Some(vec!["10.0.0.0/8".to_string()]),
             enable_ivshmem: Some(true),
+            qos: None,
             with_cube_ca: Some(false),
         }
     }

--- a/CubeMaster/cmd/cubemastercli/commands/cubebox/info.go
+++ b/CubeMaster/cmd/cubemastercli/commands/cubebox/info.go
@@ -135,6 +135,15 @@ func printSandboxInfoBlock(w *tabwriter.Writer, sb *types.SandboxData) {
 			)
 		}
 	}
+	if sb.ConfiguredQos != nil && sb.ConfiguredQos.Network != nil {
+		fmt.Fprintf(w, "NETWORK_QOS\t%s\n", formatNetworkQosLimits(sb.ConfiguredQos.Network.BandwidthMbps, sb.ConfiguredQos.Network.PacketsPerSecond))
+	}
+	if sb.ConfiguredQos != nil && sb.ConfiguredQos.BlockIO != nil {
+		fmt.Fprintf(w, "BLOCK_IO_QOS\t%s\n", formatBlockIOQosLimits(sb.ConfiguredQos.BlockIO.ThroughputMiBps, sb.ConfiguredQos.BlockIO.IOPS))
+	}
+	if sb.ConfiguredQos != nil {
+		fmt.Fprintf(w, "QOS_APPLIED\t%t\n", sb.QosApplied)
+	}
 	if sb.ExposedPortEndpoint != "" {
 		fmt.Fprintf(w, "EXPOSED_PORT_MODE\t%s\n", displayValue(sb.ExposedPortMode))
 		fmt.Fprintf(w, "EXPOSED_ENDPOINT\t%s\n", displayValue(sb.ExposedPortEndpoint))

--- a/CubeMaster/cmd/cubemastercli/commands/cubebox/list_info_test.go
+++ b/CubeMaster/cmd/cubemastercli/commands/cubebox/list_info_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"text/tabwriter"
 
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/qos"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/service/sandbox/types"
 	"github.com/urfave/cli"
 )
@@ -177,6 +178,11 @@ func TestPrintSandboxInfoBlockIncludesMetadata(t *testing.T) {
 		NameSpace:   "ns-1",
 		Annotations: map[string]string{"a": "b"},
 		Labels:      map[string]string{"user": "alice"},
+		ConfiguredQos: &qos.Config{
+			Network: &qos.NetworkConfig{BandwidthMbps: 100, PacketsPerSecond: 5000},
+			BlockIO: &qos.BlockIOConfig{ThroughputMiBps: 64, IOPS: 1000},
+		},
+		QosApplied: true,
 		Containers: []*types.ContainerInfo{
 			{Name: "sandbox", ContainerID: "ctr-1", Image: "img", Status: 1, Type: "sandbox"},
 		},
@@ -186,7 +192,7 @@ func TestPrintSandboxInfoBlockIncludesMetadata(t *testing.T) {
 	}
 
 	output := buf.String()
-	for _, want := range []string{"SANDBOX_ID", "host-1", "tpl-1", "LABELS", "CONTAINERS", "ctr-1"} {
+	for _, want := range []string{"SANDBOX_ID", "host-1", "tpl-1", "LABELS", "NETWORK_QOS", "100 Mbit/s per direction", "5000 packets/s per direction", "BLOCK_IO_QOS", "64 MiB/s per block device", "1000 IOPS per block device", "QOS_APPLIED", "true", "CONTAINERS", "ctr-1"} {
 		if !strings.Contains(output, want) {
 			t.Fatalf("output=%q, missing %q", output, want)
 		}

--- a/CubeMaster/cmd/cubemastercli/commands/cubebox/template.go
+++ b/CubeMaster/cmd/cubemastercli/commands/cubebox/template.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"io"
 	"log"
 	"math/rand"
 	"net"
@@ -23,6 +24,7 @@ import (
 	api "github.com/tencentcloud/CubeSandbox/CubeMaster/api/services/cubebox/v1"
 	commands "github.com/tencentcloud/CubeSandbox/CubeMaster/cmd/cubemastercli/commands"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/constants"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/qos"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/service/sandbox/types"
 	"github.com/urfave/cli"
 )
@@ -52,6 +54,7 @@ type templateResponse struct {
 	JobID                      string                      `json:"job_id,omitempty"`
 	Replicas                   []templateReplicaStatus     `json:"replicas,omitempty"`
 	CreateRequest              *types.CreateCubeSandboxReq `json:"create_request,omitempty"`
+	ConfiguredQos              *qos.Config                 `json:"configured_qos,omitempty"`
 	CubeEgressCABaked          bool                        `json:"cube_egress_ca_baked,omitempty"`
 	CubeEgressCAFingerprint    string                      `json:"cube_egress_ca_fingerprint,omitempty"`
 	CubeEgressCATargetsWritten int                         `json:"cube_egress_ca_targets_written,omitempty"`
@@ -854,6 +857,7 @@ var TemplateCreateFromImageCommand = cli.Command{
 		cli.BoolFlag{Name: "allow-internet-access", Usage: "set allowInternetAccess on the network config for the generated template request"},
 		cli.StringSliceFlag{Name: "allow-out-cidr", Usage: "append an allowed egress CIDR to cube_network_config; repeat the flag to specify multiple CIDRs"},
 		cli.StringSliceFlag{Name: "deny-out-cidr", Usage: "append a denied egress CIDR to cube_network_config; repeat the flag to specify multiple CIDRs"},
+		cli.StringFlag{Name: "qos", Usage: "template QoS JSON or @path to a JSON file, e.g. '{\"network\":{\"bandwidthMbps\":100,\"packetsPerSecond\":5000},\"blockIo\":{\"throughputMiBps\":64,\"iops\":1000}}'"},
 		cli.StringFlag{Name: "registry-username", Usage: "registry username"},
 		cli.StringFlag{Name: "registry-password", Usage: "registry password"},
 		cli.BoolFlag{Name: "enable-ivshmem", Usage: "boot the template build sandbox with ivshmem enabled"},
@@ -894,6 +898,10 @@ var TemplateCreateFromImageCommand = cli.Command{
 		if err != nil {
 			return err
 		}
+		qos, err := parseCreateFromImageQos(c)
+		if err != nil {
+			return err
+		}
 		req := &types.CreateTemplateFromImageReq{
 			Request:        &types.Request{RequestID: uuid.New().String()},
 			SourceImageRef: c.String("image"),
@@ -906,6 +914,7 @@ var TemplateCreateFromImageCommand = cli.Command{
 			NetworkType:        c.String("network-type"),
 			RegistryUsername:   c.String("registry-username"),
 			RegistryPassword:   c.String("registry-password"),
+			Qos:                qos,
 			ContainerOverrides: containerOverrides,
 		}
 		// --with-cube-ca defaults true (BoolTFlag). We always materialise
@@ -1192,6 +1201,16 @@ func printTemplateSummary(rsp *templateResponse) {
 	if jobID := strings.TrimSpace(rsp.JobID); jobID != "" {
 		log.Printf("job_id: %s\n", jobID)
 	}
+	if rsp.ConfiguredQos == nil || rsp.ConfiguredQos.Network == nil {
+		log.Printf("network_qos: disabled\n")
+	} else {
+		log.Printf("network_qos: %s\n", formatNetworkQosLimits(rsp.ConfiguredQos.Network.BandwidthMbps, rsp.ConfiguredQos.Network.PacketsPerSecond))
+	}
+	if rsp.ConfiguredQos == nil || rsp.ConfiguredQos.BlockIO == nil {
+		log.Printf("block_io_qos: disabled\n")
+	} else {
+		log.Printf("block_io_qos: %s\n", formatBlockIOQosLimits(rsp.ConfiguredQos.BlockIO.ThroughputMiBps, rsp.ConfiguredQos.BlockIO.IOPS))
+	}
 	// CubeEgress CA bake status. Always print so an operator can tell
 	// at a glance whether sandboxes from this template will trust
 	// CubeEgress's MITM certs. baked=false on a deployment that ships
@@ -1209,6 +1228,28 @@ func printTemplateSummary(rsp *templateResponse) {
 			replica.NodeID, replica.NodeIP, replica.Status, replica.Phase, replica.Spec, replica.ErrorMessage)
 	}
 	_ = w.Flush()
+}
+
+func formatNetworkQosLimits(bandwidthMbps, packetsPerSecond uint32) string {
+	var limits []string
+	if bandwidthMbps > 0 {
+		limits = append(limits, fmt.Sprintf("%d Mbit/s per direction", bandwidthMbps))
+	}
+	if packetsPerSecond > 0 {
+		limits = append(limits, fmt.Sprintf("%d packets/s per direction", packetsPerSecond))
+	}
+	return strings.Join(limits, ", ")
+}
+
+func formatBlockIOQosLimits(throughputMiBps, iops uint32) string {
+	var limits []string
+	if throughputMiBps > 0 {
+		limits = append(limits, fmt.Sprintf("%d MiB/s per block device", throughputMiBps))
+	}
+	if iops > 0 {
+		limits = append(limits, fmt.Sprintf("%d IOPS per block device", iops))
+	}
+	return strings.Join(limits, ", ")
 }
 
 // fingerprintShortOrEmpty trims a sha256 hex fingerprint to the first
@@ -1467,6 +1508,50 @@ func parseExposePortFlags(values []string) ([]int32, error) {
 		out = append(out, int32(port))
 	}
 	return out, nil
+}
+
+const maxCreateFromImageQosBytes = 64 << 10
+
+func parseCreateFromImageQos(c *cli.Context) (*qos.Config, error) {
+	raw := strings.TrimSpace(c.String("qos"))
+	if raw == "" {
+		return nil, nil
+	}
+	var payload []byte
+	if strings.HasPrefix(raw, "@") {
+		path := strings.TrimSpace(strings.TrimPrefix(raw, "@"))
+		if path == "" {
+			return nil, errors.New("invalid qos value: @ must be followed by a file path")
+		}
+		file, err := os.Open(path)
+		if err != nil {
+			return nil, fmt.Errorf("read qos file %q: %w", path, err)
+		}
+		defer file.Close()
+		payload, err = io.ReadAll(io.LimitReader(file, maxCreateFromImageQosBytes+1))
+		if err != nil {
+			return nil, fmt.Errorf("read qos file %q: %w", path, err)
+		}
+	} else {
+		if !strings.HasPrefix(raw, "{") {
+			return nil, errors.New("invalid qos value: expected inline JSON object or @path")
+		}
+		payload = []byte(raw)
+	}
+	if len(payload) == 0 {
+		return nil, errors.New("qos configuration must not be empty")
+	}
+	if len(payload) > maxCreateFromImageQosBytes {
+		return nil, fmt.Errorf("qos configuration exceeds %d bytes", maxCreateFromImageQosBytes)
+	}
+	configured := &qos.Config{}
+	if err := jsoniter.Unmarshal(payload, configured); err != nil {
+		return nil, fmt.Errorf("parse qos configuration: %w", err)
+	}
+	if err := configured.Validate(); err != nil {
+		return nil, err
+	}
+	return configured, nil
 }
 
 func parseContainerOverrides(c *cli.Context) (*types.ContainerOverrides, error) {

--- a/CubeMaster/cmd/cubemastercli/commands/cubebox/template_test.go
+++ b/CubeMaster/cmd/cubemastercli/commands/cubebox/template_test.go
@@ -12,10 +12,12 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/constants"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/qos"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/service/sandbox/types"
 	"github.com/urfave/cli"
 )
@@ -315,6 +317,103 @@ func TestApplyCreateFromImageIvshmemFlag(t *testing.T) {
 	applyCreateFromImageIvshmemFlag(newCreateFromImageContext(t, []string{"--enable-ivshmem"}), withFlag)
 	if withFlag.EnableIvshmem == nil || !*withFlag.EnableIvshmem {
 		t.Fatalf("EnableIvshmem=%v, want true", withFlag.EnableIvshmem)
+	}
+}
+
+func TestParseCreateFromImageQosReadsFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "qos.json")
+	if err := os.WriteFile(path, []byte(`{"network":{"bandwidthMbps":100}}`), 0o600); err != nil {
+		t.Fatalf("write qos file: %v", err)
+	}
+
+	got, err := parseCreateFromImageQos(newCreateFromImageContext(t, []string{"--qos", "@" + path}))
+	if err != nil {
+		t.Fatalf("parseCreateFromImageQos error=%v", err)
+	}
+	if got == nil || got.Network == nil || got.Network.BandwidthMbps != 100 {
+		t.Fatalf("qos=%+v, want 100 Mbps", got)
+	}
+}
+
+func TestParseCreateFromImageQosRejectsOversizedFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "qos.json")
+	if err := os.WriteFile(path, bytes.Repeat([]byte(" "), maxCreateFromImageQosBytes+1), 0o600); err != nil {
+		t.Fatalf("write qos file: %v", err)
+	}
+	_, err := parseCreateFromImageQos(newCreateFromImageContext(t, []string{"--qos", "@" + path}))
+	if err == nil || !strings.Contains(err.Error(), "exceeds") {
+		t.Fatalf("parseCreateFromImageQos error=%v, want size limit error", err)
+	}
+}
+
+func TestParseCreateFromImageQosReadsInlineJSON(t *testing.T) {
+	got, err := parseCreateFromImageQos(newCreateFromImageContext(t, []string{"--qos", `{"network":{"bandwidthMbps":200}}`}))
+	if err != nil {
+		t.Fatalf("parseCreateFromImageQos error=%v", err)
+	}
+	if got == nil || got.Network == nil || got.Network.BandwidthMbps != 200 {
+		t.Fatalf("qos=%+v, want 200 Mbps", got)
+	}
+}
+
+func TestParseCreateFromImageQosReadsPacketsPerSecond(t *testing.T) {
+	got, err := parseCreateFromImageQos(newCreateFromImageContext(t, []string{"--qos", `{"network":{"packetsPerSecond":5000}}`}))
+	if err != nil {
+		t.Fatalf("parseCreateFromImageQos error=%v", err)
+	}
+	if got == nil || got.Network == nil || got.Network.PacketsPerSecond != 5000 {
+		t.Fatalf("qos=%+v, want 5000 packets per second", got)
+	}
+}
+
+func TestParseCreateFromImageQosReadsBlockIO(t *testing.T) {
+	got, err := parseCreateFromImageQos(newCreateFromImageContext(t, []string{"--qos", `{"blockIo":{"throughputMiBps":64,"iops":1000}}`}))
+	if err != nil {
+		t.Fatalf("parseCreateFromImageQos error=%v", err)
+	}
+	if got == nil || got.BlockIO == nil || got.BlockIO.ThroughputMiBps != 64 || got.BlockIO.IOPS != 1000 {
+		t.Fatalf("qos=%+v, want 64 MiB/s and 1000 IOPS", got)
+	}
+}
+
+func TestFormatNetworkQosLimits(t *testing.T) {
+	tests := []struct {
+		name             string
+		bandwidthMbps    uint32
+		packetsPerSecond uint32
+		want             string
+	}{
+		{name: "bandwidth only", bandwidthMbps: 100, want: "100 Mbit/s per direction"},
+		{name: "packets only", packetsPerSecond: 5000, want: "5000 packets/s per direction"},
+		{name: "combined", bandwidthMbps: 100, packetsPerSecond: 5000, want: "100 Mbit/s per direction, 5000 packets/s per direction"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := formatNetworkQosLimits(tt.bandwidthMbps, tt.packetsPerSecond); got != tt.want {
+				t.Fatalf("formatNetworkQosLimits()=%q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFormatBlockIOQosLimits(t *testing.T) {
+	if got := formatBlockIOQosLimits(64, 1000); got != "64 MiB/s per block device, 1000 IOPS per block device" {
+		t.Fatalf("formatBlockIOQosLimits()=%q", got)
+	}
+}
+
+func TestParseCreateFromImageQosRejectsUnknownField(t *testing.T) {
+	_, err := parseCreateFromImageQos(newCreateFromImageContext(t, []string{"--qos", `{"network":{"bandwidth_mbps":100}}`}))
+	if err == nil {
+		t.Fatal("expected unknown qos field error")
+	}
+}
+
+func TestParseCreateFromImageQosRejectsNonJSONValue(t *testing.T) {
+	_, err := parseCreateFromImageQos(newCreateFromImageContext(t, []string{"--qos", "qos.json"}))
+	if err == nil {
+		t.Fatal("expected inline JSON or @path error")
 	}
 }
 
@@ -689,6 +788,10 @@ func TestPrintTemplateSummaryIncludesOptionalMetadata(t *testing.T) {
 			Status:       "READY",
 			CreatedAt:    "2026-06-17 12:00:00",
 			ImageInfo:    "docker.io/library/python:3.12",
+			ConfiguredQos: &qos.Config{
+				Network: &qos.NetworkConfig{BandwidthMbps: 100, PacketsPerSecond: 5000},
+				BlockIO: &qos.BlockIOConfig{ThroughputMiBps: 64, IOPS: 1000},
+			},
 		})
 	})
 
@@ -698,6 +801,8 @@ func TestPrintTemplateSummaryIncludesOptionalMetadata(t *testing.T) {
 		"alias: python-template",
 		"created_at: 2026-06-17 12:00:00",
 		"image_info: docker.io/library/python:3.12",
+		"network_qos: 100 Mbit/s per direction, 5000 packets/s per direction",
+		"block_io_qos: 64 MiB/s per block device, 1000 IOPS per block device",
 	} {
 		if !strings.Contains(logOutput, want) {
 			t.Fatalf("log output=%q, missing %q", logOutput, want)

--- a/CubeMaster/pkg/qos/qos.go
+++ b/CubeMaster/pkg/qos/qos.go
@@ -1,0 +1,452 @@
+package qos
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+)
+
+const (
+	AnnotationVersion         = uint64(1)
+	BandwidthRefillTimeMillis = uint64(100)
+	PacketsRefillTimeMillis   = uint64(1000)
+	BlockIORefillTimeMillis   = uint64(1000)
+	bytesPerMbpsPerRefill     = uint64(12_500)
+	bytesPerMiB               = uint64(1024 * 1024)
+)
+
+type Config struct {
+	Network *NetworkConfig `json:"network,omitempty"`
+	BlockIO *BlockIOConfig `json:"blockIo,omitempty"`
+}
+
+type NetworkConfig struct {
+	BandwidthMbps       uint32 `json:"bandwidthMbps,omitempty"`
+	PacketsPerSecond    uint32 `json:"packetsPerSecond,omitempty"`
+	bandwidthConfigured bool
+	packetsConfigured   bool
+}
+
+type BlockIOConfig struct {
+	ThroughputMiBps      uint32 `json:"throughputMiBps,omitempty"`
+	IOPS                 uint32 `json:"iops,omitempty"`
+	throughputConfigured bool
+	iopsConfigured       bool
+}
+
+func (c *BlockIOConfig) UnmarshalJSON(data []byte) error {
+	type blockIOConfigJSON struct {
+		ThroughputMiBps *uint32 `json:"throughputMiBps,omitempty"`
+		IOPS            *uint32 `json:"iops,omitempty"`
+	}
+	var decoded blockIOConfigJSON
+	if err := decodeStrictJSON(data, &decoded); err != nil {
+		return err
+	}
+	c.ThroughputMiBps = 0
+	c.IOPS = 0
+	c.throughputConfigured = false
+	c.iopsConfigured = false
+	if decoded.ThroughputMiBps != nil {
+		c.ThroughputMiBps = *decoded.ThroughputMiBps
+		c.throughputConfigured = true
+	}
+	if decoded.IOPS != nil {
+		c.IOPS = *decoded.IOPS
+		c.iopsConfigured = true
+	}
+	return nil
+}
+
+func (c *NetworkConfig) UnmarshalJSON(data []byte) error {
+	type networkConfigJSON struct {
+		BandwidthMbps    *uint32 `json:"bandwidthMbps,omitempty"`
+		PacketsPerSecond *uint32 `json:"packetsPerSecond,omitempty"`
+	}
+	var decoded networkConfigJSON
+	if err := decodeStrictJSON(data, &decoded); err != nil {
+		return err
+	}
+	c.BandwidthMbps = 0
+	c.PacketsPerSecond = 0
+	c.bandwidthConfigured = false
+	c.packetsConfigured = false
+	if decoded.BandwidthMbps != nil {
+		c.BandwidthMbps = *decoded.BandwidthMbps
+		c.bandwidthConfigured = true
+	}
+	if decoded.PacketsPerSecond != nil {
+		c.PacketsPerSecond = *decoded.PacketsPerSecond
+		c.packetsConfigured = true
+	}
+	return nil
+}
+
+func (c *Config) UnmarshalJSON(data []byte) error {
+	type plain Config
+	var decoded plain
+	if err := decodeStrictJSON(data, &decoded); err != nil {
+		return err
+	}
+	*c = Config(decoded)
+	return nil
+}
+
+func (c *Config) Validate() error {
+	if c == nil {
+		return nil
+	}
+	if c.Network == nil && c.BlockIO == nil {
+		return errors.New("qos must configure network or blockIo")
+	}
+	if c.Network != nil {
+		if c.Network.bandwidthConfigured && c.Network.BandwidthMbps == 0 {
+			return errors.New("qos.network.bandwidthMbps must be at least 1")
+		}
+		if c.Network.packetsConfigured && c.Network.PacketsPerSecond == 0 {
+			return errors.New("qos.network.packetsPerSecond must be at least 1")
+		}
+		if c.Network.BandwidthMbps == 0 && c.Network.PacketsPerSecond == 0 {
+			return errors.New("qos.network must configure bandwidthMbps or packetsPerSecond")
+		}
+	}
+	if c.BlockIO != nil {
+		if c.BlockIO.throughputConfigured && c.BlockIO.ThroughputMiBps == 0 {
+			return errors.New("qos.blockIo.throughputMiBps must be at least 1")
+		}
+		if c.BlockIO.iopsConfigured && c.BlockIO.IOPS == 0 {
+			return errors.New("qos.blockIo.iops must be at least 1")
+		}
+		if c.BlockIO.ThroughputMiBps == 0 && c.BlockIO.IOPS == 0 {
+			return errors.New("qos.blockIo must configure throughputMiBps or iops")
+		}
+	}
+	return nil
+}
+
+func Clone(in *Config) *Config {
+	if in == nil {
+		return nil
+	}
+	out := *in
+	if in.Network != nil {
+		network := *in.Network
+		out.Network = &network
+	}
+	if in.BlockIO != nil {
+		blockIO := *in.BlockIO
+		out.BlockIO = &blockIO
+	}
+	return &out
+}
+
+type TemplateResources struct {
+	CPU    string
+	Memory string
+}
+
+func ResolveTemplate(explicit *Config, resources TemplateResources) (*Config, error) {
+	inferred := inferTemplateDefaults(resources)
+	return resolveTemplate(explicit, inferred)
+}
+
+var inferTemplateDefaults = func(TemplateResources) *Config {
+	return nil
+}
+
+func resolveTemplate(explicit, inferred *Config) (*Config, error) {
+	if err := explicit.Validate(); err != nil {
+		return nil, err
+	}
+	if err := inferred.Validate(); err != nil {
+		return nil, fmt.Errorf("inferred qos: %w", err)
+	}
+	resolved := Clone(inferred)
+	if resolved == nil {
+		resolved = &Config{}
+	}
+	mergeExplicit(resolved, explicit)
+	if resolved.Network == nil && resolved.BlockIO == nil {
+		return nil, nil
+	}
+	if err := resolved.Validate(); err != nil {
+		return nil, err
+	}
+	return resolved, nil
+}
+
+func mergeExplicit(resolved, explicit *Config) {
+	if explicit == nil {
+		return
+	}
+	if explicit.Network != nil {
+		if resolved.Network == nil {
+			resolved.Network = &NetworkConfig{}
+		}
+		if explicit.Network.bandwidthConfigured || explicit.Network.BandwidthMbps > 0 {
+			resolved.Network.BandwidthMbps = explicit.Network.BandwidthMbps
+			resolved.Network.bandwidthConfigured = true
+		}
+		if explicit.Network.packetsConfigured || explicit.Network.PacketsPerSecond > 0 {
+			resolved.Network.PacketsPerSecond = explicit.Network.PacketsPerSecond
+			resolved.Network.packetsConfigured = true
+		}
+	}
+	if explicit.BlockIO != nil {
+		if resolved.BlockIO == nil {
+			resolved.BlockIO = &BlockIOConfig{}
+		}
+		if explicit.BlockIO.throughputConfigured || explicit.BlockIO.ThroughputMiBps > 0 {
+			resolved.BlockIO.ThroughputMiBps = explicit.BlockIO.ThroughputMiBps
+			resolved.BlockIO.throughputConfigured = true
+		}
+		if explicit.BlockIO.iopsConfigured || explicit.BlockIO.IOPS > 0 {
+			resolved.BlockIO.IOPS = explicit.BlockIO.IOPS
+			resolved.BlockIO.iopsConfigured = true
+		}
+	}
+}
+
+type blockIOAnnotation struct {
+	Bandwidth *blockIOTokenBucket `json:"bandwidth,omitempty"`
+	Ops       *blockIOTokenBucket `json:"ops,omitempty"`
+}
+
+type blockIOTokenBucket struct {
+	Size         uint64  `json:"size"`
+	OneTimeBurst *uint64 `json:"one_time_burst,omitempty"`
+	RefillTime   uint64  `json:"refill_time"`
+}
+
+func MarshalBlockIOAnnotation(cfg *BlockIOConfig) (string, error) {
+	if cfg == nil {
+		return "", nil
+	}
+	if err := (&Config{BlockIO: cfg}).Validate(); err != nil {
+		return "", err
+	}
+	payload := blockIOAnnotation{}
+	if cfg.ThroughputMiBps > 0 {
+		payload.Bandwidth = &blockIOTokenBucket{
+			Size:       uint64(cfg.ThroughputMiBps) * bytesPerMiB,
+			RefillTime: BlockIORefillTimeMillis,
+		}
+	}
+	if cfg.IOPS > 0 {
+		payload.Ops = &blockIOTokenBucket{
+			Size:       uint64(cfg.IOPS),
+			RefillTime: BlockIORefillTimeMillis,
+		}
+	}
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		return "", err
+	}
+	return string(raw), nil
+}
+
+func ParseBlockIOAnnotation(raw string) (*BlockIOConfig, error) {
+	if strings.TrimSpace(raw) == "" || strings.TrimSpace(raw) == "{}" {
+		return nil, nil
+	}
+	var payload blockIOAnnotation
+	if err := decodeStrictJSON([]byte(raw), &payload); err != nil {
+		return nil, fmt.Errorf("decode block io qos annotation: %w", err)
+	}
+	blockIO := &BlockIOConfig{}
+	if payload.Bandwidth != nil {
+		value, err := parseBlockIORate(payload.Bandwidth, bytesPerMiB, "throughput")
+		if err != nil {
+			return nil, err
+		}
+		blockIO.ThroughputMiBps = value
+	}
+	if payload.Ops != nil {
+		value, err := parseBlockIORate(payload.Ops, 1, "iops")
+		if err != nil {
+			return nil, err
+		}
+		blockIO.IOPS = value
+	}
+	if blockIO.ThroughputMiBps == 0 && blockIO.IOPS == 0 {
+		return nil, errors.New("block io qos annotation requires bandwidth or ops")
+	}
+	return blockIO, nil
+}
+
+func parseBlockIORate(bucket *blockIOTokenBucket, unit uint64, name string) (uint32, error) {
+	if bucket.Size == 0 || bucket.RefillTime == 0 {
+		return 0, fmt.Errorf("block io qos %s bucket requires positive size and refill_time", name)
+	}
+	numerator := bucket.Size * 1000
+	denominator := bucket.RefillTime * unit
+	if denominator == 0 || numerator%denominator != 0 {
+		return 0, fmt.Errorf("block io qos %s bucket does not map to an integer public rate", name)
+	}
+	value := numerator / denominator
+	if value == 0 || value > uint64(^uint32(0)) {
+		return 0, fmt.Errorf("block io qos %s is outside the supported range", name)
+	}
+	return uint32(value), nil
+}
+
+type annotationRequest struct {
+	Qos     *annotationQos `json:"Qos"`
+	Mode    string         `json:"Mode,omitempty"`
+	Version uint64         `json:"Version,omitempty"`
+}
+
+type annotationQos struct {
+	BandWidth annotationLimiter `json:"BandWidth"`
+	OPS       annotationLimiter `json:"OPS"`
+}
+
+type annotationLimiter struct {
+	Size         uint64 `json:"Size"`
+	OneTimeBurst uint64 `json:"OneTimeBurst"`
+	RefillTime   uint64 `json:"RefillTime"`
+}
+
+func MarshalAnnotation(cfg *Config) (string, error) {
+	if cfg == nil || cfg.Network == nil {
+		return "", nil
+	}
+	if err := cfg.Validate(); err != nil {
+		return "", err
+	}
+	qos := &annotationQos{}
+	if cfg.Network.BandwidthMbps > 0 {
+		qos.BandWidth = annotationLimiter{
+			Size:       uint64(cfg.Network.BandwidthMbps) * bytesPerMbpsPerRefill,
+			RefillTime: BandwidthRefillTimeMillis,
+		}
+	}
+	if cfg.Network.PacketsPerSecond > 0 {
+		qos.OPS = annotationLimiter{
+			Size:       uint64(cfg.Network.PacketsPerSecond),
+			RefillTime: PacketsRefillTimeMillis,
+		}
+	}
+	payload := annotationRequest{Qos: qos, Version: AnnotationVersion}
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		return "", err
+	}
+	return string(raw), nil
+}
+
+func ParseAnnotations(networkRaw, blockIORaw string) (*Config, error) {
+	networkConfig, err := ParseAnnotation(networkRaw)
+	if err != nil {
+		return nil, err
+	}
+	blockIO, err := ParseBlockIOAnnotation(blockIORaw)
+	if err != nil {
+		return nil, err
+	}
+	if networkConfig == nil && blockIO == nil {
+		return nil, nil
+	}
+	configured := &Config{BlockIO: blockIO}
+	if networkConfig != nil {
+		configured.Network = networkConfig.Network
+	}
+	return configured, nil
+}
+
+func HasAppliedAnnotation(networkRaw, blockIORaw string) bool {
+	return strings.TrimSpace(networkRaw) != "" ||
+		(strings.TrimSpace(blockIORaw) != "" && strings.TrimSpace(blockIORaw) != "{}")
+}
+
+func ParseAnnotation(raw string) (*Config, error) {
+	if raw == "" {
+		return nil, nil
+	}
+	var payload annotationRequest
+	if err := decodeStrictJSON([]byte(raw), &payload); err != nil {
+		return nil, fmt.Errorf("decode network qos annotation: %w", err)
+	}
+	if payload.Version != 0 && payload.Version != AnnotationVersion {
+		return nil, fmt.Errorf("unsupported network qos annotation version %d", payload.Version)
+	}
+	if payload.Mode != "" {
+		return nil, fmt.Errorf("unsupported network qos mode %q", payload.Mode)
+	}
+	if payload.Qos == nil {
+		return nil, errors.New("network qos annotation requires Qos")
+	}
+	network := &NetworkConfig{}
+	bandwidthConfigured := bucketConfigured(payload.Qos.BandWidth)
+	if bandwidthConfigured {
+		mbps, err := parseBandwidthBucket(payload.Qos.BandWidth)
+		if err != nil {
+			return nil, err
+		}
+		network.BandwidthMbps = mbps
+	}
+	if bucketConfigured(payload.Qos.OPS) {
+		packets, err := parsePacketsBucket(payload.Qos.OPS)
+		if err != nil {
+			return nil, err
+		}
+		network.PacketsPerSecond = packets
+	}
+	if !bandwidthConfigured && !bucketConfigured(payload.Qos.OPS) {
+		return nil, errors.New("network qos annotation requires bandwidth or packets-per-second bucket")
+	}
+	return &Config{Network: network}, nil
+}
+
+func bucketConfigured(bucket annotationLimiter) bool {
+	return bucket.Size != 0 || bucket.OneTimeBurst != 0 || bucket.RefillTime != 0
+}
+
+func parseBandwidthBucket(bucket annotationLimiter) (uint32, error) {
+	if bucket.Size == 0 || bucket.RefillTime == 0 {
+		return 0, errors.New("network qos bandwidth bucket requires positive Size and RefillTime")
+	}
+	numerator := bucket.Size * 8 * 1000
+	denominator := bucket.RefillTime * 1_000_000
+	if denominator == 0 || numerator%denominator != 0 {
+		return 0, errors.New("network qos bandwidth does not map to an integer Mbps value")
+	}
+	mbps := numerator / denominator
+	if mbps == 0 || mbps > uint64(^uint32(0)) {
+		return 0, errors.New("network qos bandwidth is outside the supported Mbps range")
+	}
+	return uint32(mbps), nil
+}
+
+func parsePacketsBucket(bucket annotationLimiter) (uint32, error) {
+	if bucket.Size == 0 || bucket.RefillTime == 0 {
+		return 0, errors.New("network qos packets-per-second bucket requires positive Size and RefillTime")
+	}
+	numerator := bucket.Size * 1000
+	if numerator%bucket.RefillTime != 0 {
+		return 0, errors.New("network qos packets-per-second bucket does not map to an integer rate")
+	}
+	packets := numerator / bucket.RefillTime
+	if packets == 0 || packets > uint64(^uint32(0)) {
+		return 0, errors.New("network qos packets-per-second value is outside the supported range")
+	}
+	return uint32(packets), nil
+}
+
+func decodeStrictJSON(data []byte, out any) error {
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(out); err != nil {
+		return err
+	}
+	if err := decoder.Decode(&struct{}{}); err != io.EOF {
+		if err == nil {
+			return errors.New("unexpected trailing JSON value")
+		}
+		return err
+	}
+	return nil
+}

--- a/CubeMaster/pkg/qos/qos_test.go
+++ b/CubeMaster/pkg/qos/qos_test.go
@@ -1,0 +1,263 @@
+package qos
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestConfigRejectsUnknownFields(t *testing.T) {
+	var cfg Config
+	err := json.Unmarshal([]byte(`{"network":{"bandwidth_mbps":100}}`), &cfg)
+	if err == nil {
+		t.Fatal("expected unknown field error")
+	}
+}
+
+func TestConfigValidateRequiresPositiveBandwidth(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  *Config
+	}{
+		{name: "missing network", cfg: &Config{}},
+		{name: "zero network qos", cfg: &Config{Network: &NetworkConfig{}}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := tt.cfg.Validate(); err == nil {
+				t.Fatal("expected validation error")
+			}
+		})
+	}
+}
+
+func TestConfigValidateRejectsExplicitZeroPacketsPerSecond(t *testing.T) {
+	var cfg Config
+	if err := json.Unmarshal([]byte(`{"network":{"bandwidthMbps":100,"packetsPerSecond":0}}`), &cfg); err != nil {
+		t.Fatalf("Unmarshal error=%v", err)
+	}
+	if err := cfg.Validate(); err == nil || !strings.Contains(err.Error(), "packetsPerSecond") {
+		t.Fatalf("Validate error=%v, want packetsPerSecond validation error", err)
+	}
+}
+
+func TestConfigValidateRejectsExplicitZeroBandwidth(t *testing.T) {
+	var cfg Config
+	if err := json.Unmarshal([]byte(`{"network":{"bandwidthMbps":0,"packetsPerSecond":5000}}`), &cfg); err != nil {
+		t.Fatalf("Unmarshal error=%v", err)
+	}
+	if err := cfg.Validate(); err == nil || !strings.Contains(err.Error(), "bandwidthMbps") {
+		t.Fatalf("Validate error=%v, want bandwidthMbps validation error", err)
+	}
+}
+
+func TestConfigValidateAcceptsBlockIOOnly(t *testing.T) {
+	var cfg Config
+	if err := json.Unmarshal([]byte(`{"blockIo":{"throughputMiBps":64,"iops":1000}}`), &cfg); err != nil {
+		t.Fatalf("Unmarshal error=%v", err)
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("Validate error=%v", err)
+	}
+	if cfg.BlockIO == nil || cfg.BlockIO.ThroughputMiBps != 64 || cfg.BlockIO.IOPS != 1000 {
+		t.Fatalf("block io config=%+v, want 64 MiB/s and 1000 IOPS", cfg.BlockIO)
+	}
+}
+
+func TestConfigValidateRejectsExplicitZeroBlockIOLimits(t *testing.T) {
+	for _, raw := range []string{
+		`{"blockIo":{"throughputMiBps":0,"iops":1000}}`,
+		`{"blockIo":{"throughputMiBps":64,"iops":0}}`,
+		`{"blockIo":{}}`,
+	} {
+		var cfg Config
+		if err := json.Unmarshal([]byte(raw), &cfg); err != nil {
+			t.Fatalf("Unmarshal(%s) error=%v", raw, err)
+		}
+		if err := cfg.Validate(); err == nil {
+			t.Fatalf("Validate(%s) unexpectedly succeeded", raw)
+		}
+	}
+}
+
+func TestConfigValidateRejectsEmptyQos(t *testing.T) {
+	var cfg Config
+	if err := json.Unmarshal([]byte(`{}`), &cfg); err != nil {
+		t.Fatalf("Unmarshal error=%v", err)
+	}
+	if err := cfg.Validate(); err == nil {
+		t.Fatal("empty qos unexpectedly validated")
+	}
+}
+
+func TestMarshalAnnotationUsesCanonicalTokenBucket(t *testing.T) {
+	raw, err := MarshalAnnotation(&Config{
+		Network: &NetworkConfig{BandwidthMbps: 100},
+	})
+	if err != nil {
+		t.Fatalf("MarshalAnnotation error=%v", err)
+	}
+	want := `{"Qos":{"BandWidth":{"Size":1250000,"OneTimeBurst":0,"RefillTime":100},"OPS":{"Size":0,"OneTimeBurst":0,"RefillTime":0}},"Version":1}`
+	if raw != want {
+		t.Fatalf("annotation=%s, want %s", raw, want)
+	}
+}
+
+func TestMarshalAnnotationIncludesPacketsPerSecond(t *testing.T) {
+	raw, err := MarshalAnnotation(&Config{
+		Network: &NetworkConfig{PacketsPerSecond: 5000},
+	})
+	if err != nil {
+		t.Fatalf("MarshalAnnotation error=%v", err)
+	}
+	want := `{"Qos":{"BandWidth":{"Size":0,"OneTimeBurst":0,"RefillTime":0},"OPS":{"Size":5000,"OneTimeBurst":0,"RefillTime":1000}},"Version":1}`
+	if raw != want {
+		t.Fatalf("annotation=%s, want %s", raw, want)
+	}
+}
+
+func TestMarshalAnnotationIncludesBandwidthAndPacketsPerSecond(t *testing.T) {
+	raw, err := MarshalAnnotation(&Config{
+		Network: &NetworkConfig{BandwidthMbps: 100, PacketsPerSecond: 5000},
+	})
+	if err != nil {
+		t.Fatalf("MarshalAnnotation error=%v", err)
+	}
+	if !strings.Contains(raw, `"Size":1250000`) || !strings.Contains(raw, `"Size":5000`) {
+		t.Fatalf("annotation=%s, want bandwidth and packet buckets", raw)
+	}
+}
+
+func TestMarshalBlockIOAnnotationUsesCanonicalTokenBuckets(t *testing.T) {
+	raw, err := MarshalBlockIOAnnotation(&BlockIOConfig{
+		ThroughputMiBps: 64,
+		IOPS:            1000,
+	})
+	if err != nil {
+		t.Fatalf("MarshalBlockIOAnnotation error=%v", err)
+	}
+	want := `{"bandwidth":{"size":67108864,"refill_time":1000},"ops":{"size":1000,"refill_time":1000}}`
+	if raw != want {
+		t.Fatalf("annotation=%s, want %s", raw, want)
+	}
+}
+
+func TestParseBlockIOAnnotationReturnsConfiguredQos(t *testing.T) {
+	blockIO, err := ParseBlockIOAnnotation(`{"bandwidth":{"size":67108864,"refill_time":1000},"ops":{"size":1000,"refill_time":1000}}`)
+	if err != nil {
+		t.Fatalf("ParseBlockIOAnnotation error=%v", err)
+	}
+	if blockIO == nil || blockIO.ThroughputMiBps != 64 || blockIO.IOPS != 1000 {
+		t.Fatalf("block io config=%+v, want 64 MiB/s and 1000 IOPS", blockIO)
+	}
+}
+
+func TestResolveTemplateQosPreservesExplicitAndOmittedBehavior(t *testing.T) {
+	resources := TemplateResources{CPU: "2000m", Memory: "4Gi"}
+	if got, err := ResolveTemplate(nil, resources); err != nil || got != nil {
+		t.Fatalf("ResolveTemplate(nil)=(%+v, %v), want (nil, nil)", got, err)
+	}
+
+	explicit := &Config{
+		Network: &NetworkConfig{BandwidthMbps: 100},
+		BlockIO: &BlockIOConfig{IOPS: 1000},
+	}
+	got, err := ResolveTemplate(explicit, resources)
+	if err != nil {
+		t.Fatalf("ResolveTemplate error=%v", err)
+	}
+	if got == explicit || got.Network == explicit.Network || got.BlockIO == explicit.BlockIO {
+		t.Fatal("ResolveTemplate must return an isolated configuration")
+	}
+	if got.Network.BandwidthMbps != 100 || got.BlockIO.IOPS != 1000 {
+		t.Fatalf("resolved qos=%+v, want explicit limits", got)
+	}
+}
+
+func TestResolveTemplateQosPassesResourcesToInferenceSeam(t *testing.T) {
+	original := inferTemplateDefaults
+	t.Cleanup(func() { inferTemplateDefaults = original })
+	inferTemplateDefaults = func(resources TemplateResources) *Config {
+		if resources.CPU != "500m" || resources.Memory != "1024Mi" {
+			t.Fatalf("resources=%+v, want requested CPU and memory", resources)
+		}
+		return &Config{Network: &NetworkConfig{BandwidthMbps: 25}}
+	}
+
+	got, err := ResolveTemplate(nil, TemplateResources{CPU: "500m", Memory: "1024Mi"})
+	if err != nil {
+		t.Fatalf("ResolveTemplate error=%v", err)
+	}
+	if got == nil || got.Network == nil || got.Network.BandwidthMbps != 25 {
+		t.Fatalf("resolved qos=%+v, want inferred bandwidth", got)
+	}
+}
+
+func TestResolveTemplateQosExplicitFieldsOverrideInferredFields(t *testing.T) {
+	inferred := &Config{
+		Network: &NetworkConfig{BandwidthMbps: 50, PacketsPerSecond: 2000},
+		BlockIO: &BlockIOConfig{ThroughputMiBps: 32, IOPS: 500},
+	}
+	explicit := &Config{
+		Network: &NetworkConfig{BandwidthMbps: 100},
+		BlockIO: &BlockIOConfig{IOPS: 1000},
+	}
+	got, err := resolveTemplate(explicit, inferred)
+	if err != nil {
+		t.Fatalf("resolveTemplate error=%v", err)
+	}
+	if got.Network.BandwidthMbps != 100 || got.Network.PacketsPerSecond != 2000 {
+		t.Fatalf("network qos=%+v, want explicit bandwidth and inferred PPS", got.Network)
+	}
+	if got.BlockIO.ThroughputMiBps != 32 || got.BlockIO.IOPS != 1000 {
+		t.Fatalf("block io qos=%+v, want inferred throughput and explicit IOPS", got.BlockIO)
+	}
+}
+
+func TestParseAnnotationReturnsConfiguredQos(t *testing.T) {
+	cfg, err := ParseAnnotation(`{"Qos":{"BandWidth":{"Size":1250000,"OneTimeBurst":0,"RefillTime":100},"OPS":{"Size":0,"OneTimeBurst":0,"RefillTime":0}},"Version":1}`)
+	if err != nil {
+		t.Fatalf("ParseAnnotation error=%v", err)
+	}
+	if cfg == nil || cfg.Network == nil || cfg.Network.BandwidthMbps != 100 {
+		t.Fatalf("config=%+v, want 100 Mbps", cfg)
+	}
+}
+
+func TestParseAnnotationReturnsConfiguredPacketsPerSecond(t *testing.T) {
+	cfg, err := ParseAnnotation(`{"Qos":{"BandWidth":{},"OPS":{"Size":5000,"RefillTime":1000}},"Version":1}`)
+	if err != nil {
+		t.Fatalf("ParseAnnotation error=%v", err)
+	}
+	if cfg == nil || cfg.Network == nil || cfg.Network.PacketsPerSecond != 5000 {
+		t.Fatalf("config=%+v, want 5000 packets per second", cfg)
+	}
+}
+
+func TestParseAnnotationRejectsInvalidPacketsBucket(t *testing.T) {
+	for _, raw := range []string{
+		`{"Qos":{"BandWidth":{},"OPS":{"Size":5000}},"Version":1}`,
+		`{"Qos":{"BandWidth":{},"OPS":{"Size":1,"RefillTime":3000}},"Version":1}`,
+	} {
+		if _, err := ParseAnnotation(raw); err == nil {
+			t.Fatalf("expected invalid packets bucket error for %s", raw)
+		}
+	}
+}
+
+func TestParseAnnotationAcceptsLegacyVersionZero(t *testing.T) {
+	cfg, err := ParseAnnotation(`{"Qos":{"BandWidth":{"Size":1250000,"RefillTime":100}}}`)
+	if err != nil {
+		t.Fatalf("ParseAnnotation error=%v", err)
+	}
+	if cfg.Network.BandwidthMbps != 100 {
+		t.Fatalf("bandwidth=%d, want 100", cfg.Network.BandwidthMbps)
+	}
+}
+
+func TestParseAnnotationRejectsUnsupportedVersion(t *testing.T) {
+	_, err := ParseAnnotation(`{"Qos":{"BandWidth":{"Size":1250000,"RefillTime":100}},"Version":2}`)
+	if err == nil || !strings.Contains(err.Error(), "version") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/CubeMaster/pkg/service/httpservice/cube/qos_policy.go
+++ b/CubeMaster/pkg/service/httpservice/cube/qos_policy.go
@@ -1,0 +1,37 @@
+package cube
+
+import (
+	"fmt"
+
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/constants"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/service/sandbox/types"
+)
+
+func rejectCallerSuppliedQos(req *types.CreateCubeSandboxReq) error {
+	if req == nil {
+		return nil
+	}
+	for _, key := range []string{constants.CubeAnnotationsNetWork, constants.CubeAnnotationsBlkQos, constants.CubeAnnotationsFSQos} {
+		if _, ok := req.Annotations[key]; ok {
+			return fmt.Errorf("%s is template-managed and cannot be supplied directly", key)
+		}
+	}
+	return nil
+}
+
+func sanitizeTemplateCreateRequest(req *types.CreateCubeSandboxReq) *types.CreateCubeSandboxReq {
+	if req == nil {
+		return nil
+	}
+	cloned := *req
+	if req.Annotations != nil {
+		cloned.Annotations = make(map[string]string, len(req.Annotations))
+		for key, value := range req.Annotations {
+			cloned.Annotations[key] = value
+		}
+		delete(cloned.Annotations, constants.CubeAnnotationsNetWork)
+		delete(cloned.Annotations, constants.CubeAnnotationsBlkQos)
+		delete(cloned.Annotations, constants.CubeAnnotationsFSQos)
+	}
+	return &cloned
+}

--- a/CubeMaster/pkg/service/httpservice/cube/sandbox_create.go
+++ b/CubeMaster/pkg/service/httpservice/cube/sandbox_create.go
@@ -45,6 +45,12 @@ func createSandbox(r *http.Request, rt *CubeLog.RequestTrace) interface{} {
 		rt.RetCode = int64(errorcode.ErrorCode_MasterParamsError)
 		return rsp
 	}
+	if err := rejectCallerSuppliedQos(req); err != nil {
+		rsp.Ret.RetCode = int(errorcode.ErrorCode_MasterParamsError)
+		rsp.Ret.RetMsg = err.Error()
+		rt.RetCode = int64(errorcode.ErrorCode_MasterParamsError)
+		return rsp
+	}
 	rsp.RequestID = req.RequestID
 	rt.RequestID = req.RequestID
 	rt.InstanceType = req.InstanceType

--- a/CubeMaster/pkg/service/httpservice/cube/sandbox_create_test.go
+++ b/CubeMaster/pkg/service/httpservice/cube/sandbox_create_test.go
@@ -87,3 +87,55 @@ func TestCreateSandboxKeepsOtherTemplateErrorsAsParamsError(t *testing.T) {
 	assert.Equal(t, assert.AnError.Error(), got.Ret.RetMsg)
 	assert.Equal(t, int64(errorcode.ErrorCode_MasterParamsError), rt.RetCode)
 }
+
+func TestCreateSandboxRejectsCallerSuppliedNetworkQosAnnotation(t *testing.T) {
+	origDealFn := createSandboxDealCubeboxCreateReqWithTemplateFn
+	origCreateFn := createSandboxRunFn
+	t.Cleanup(func() {
+		createSandboxDealCubeboxCreateReqWithTemplateFn = origDealFn
+		createSandboxRunFn = origCreateFn
+	})
+
+	createSandboxDealCubeboxCreateReqWithTemplateFn = func(context.Context, *types.CreateCubeSandboxReq) error {
+		t.Fatal("template resolution must not run for caller-supplied network qos")
+		return nil
+	}
+	createSandboxRunFn = func(context.Context, *types.CreateCubeSandboxReq) *types.CreateCubeSandboxRes {
+		t.Fatal("sandbox create must not run for caller-supplied network qos")
+		return nil
+	}
+
+	req := httptest.NewRequest("POST", "/cube/sandbox", strings.NewReader(`{
+		"requestID":"req-qos",
+		"annotations":{
+			"`+constants.CubeAnnotationAppSnapshotTemplateID+`":"tpl-1",
+			"`+constants.CubeAnnotationAppSnapshotTemplateVersion+`":"v2",
+			"`+constants.CubeAnnotationsNetWork+`":"{}"
+		}
+	}`))
+	rt := &CubeLog.RequestTrace{}
+	resp := createSandbox(req, rt)
+
+	got, ok := resp.(*types.Res)
+	if !ok {
+		t.Fatalf("unexpected response type %T", resp)
+	}
+	assert.Equal(t, int(errorcode.ErrorCode_MasterParamsError), got.Ret.RetCode)
+	assert.Contains(t, got.Ret.RetMsg, "template-managed")
+}
+
+func TestCreateSandboxRejectsCallerSuppliedBlockIOQosAnnotation(t *testing.T) {
+	req := httptest.NewRequest("POST", "/cube/sandbox", strings.NewReader(`{
+		"requestID":"req-qos",
+		"annotations":{"`+constants.CubeAnnotationsBlkQos+`":"{}"}
+	}`))
+	rt := &CubeLog.RequestTrace{}
+	resp := createSandbox(req, rt)
+
+	got, ok := resp.(*types.Res)
+	if !ok {
+		t.Fatalf("unexpected response type %T", resp)
+	}
+	assert.Equal(t, int(errorcode.ErrorCode_MasterParamsError), got.Ret.RetCode)
+	assert.Contains(t, got.Ret.RetMsg, "template-managed")
+}

--- a/CubeMaster/pkg/service/httpservice/cube/sandbox_preview.go
+++ b/CubeMaster/pkg/service/httpservice/cube/sandbox_preview.go
@@ -10,6 +10,7 @@ import (
 	"github.com/gin-gonic/gin"
 	jsoniter "github.com/json-iterator/go"
 	api "github.com/tencentcloud/CubeSandbox/CubeMaster/api/services/cubebox/v1"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/constants"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/log"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/errorcode"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/service/httpservice/common"
@@ -44,6 +45,15 @@ func previewSandbox(r *http.Request, rt *CubeLog.RequestTrace) interface{} {
 					RetMsg:  err.Error(),
 				},
 			},
+		}
+	}
+	if err := rejectCallerSuppliedQos(req); err != nil {
+		rt.RetCode = int64(errorcode.ErrorCode_MasterParamsError)
+		return &sandboxPreviewResponse{
+			Res: &types.Res{Ret: &types.Ret{
+				RetCode: int(errorcode.ErrorCode_MasterParamsError),
+				RetMsg:  err.Error(),
+			}},
 		}
 	}
 
@@ -94,6 +104,7 @@ func previewSandbox(r *http.Request, rt *CubeLog.RequestTrace) interface{} {
 			APIRequest: apiReq,
 		}
 	}
+	responseMergedReq := sanitizeTemplateCreateRequest(mergedReq)
 
 	cubeletReqInput, err := cloneCreateReq(mergedReq)
 	if err != nil {
@@ -107,7 +118,7 @@ func previewSandbox(r *http.Request, rt *CubeLog.RequestTrace) interface{} {
 				},
 			},
 			APIRequest:    apiReq,
-			MergedRequest: mergedReq,
+			MergedRequest: responseMergedReq,
 		}
 	}
 	cubeletReq, err := previewConstructCubeletReqFn(ctx, cubeletReqInput)
@@ -122,8 +133,13 @@ func previewSandbox(r *http.Request, rt *CubeLog.RequestTrace) interface{} {
 				},
 			},
 			APIRequest:    apiReq,
-			MergedRequest: mergedReq,
+			MergedRequest: responseMergedReq,
 		}
+	}
+	if cubeletReq != nil {
+		delete(cubeletReq.Annotations, constants.CubeAnnotationsNetWork)
+		delete(cubeletReq.Annotations, constants.CubeAnnotationsBlkQos)
+		delete(cubeletReq.Annotations, constants.CubeAnnotationsFSQos)
 	}
 
 	rt.RetCode = int64(errorcode.ErrorCode_Success)
@@ -136,7 +152,7 @@ func previewSandbox(r *http.Request, rt *CubeLog.RequestTrace) interface{} {
 			},
 		},
 		APIRequest:     apiReq,
-		MergedRequest:  mergedReq,
+		MergedRequest:  responseMergedReq,
 		CubeletRequest: cubeletReq,
 	}
 }

--- a/CubeMaster/pkg/service/httpservice/cube/sandbox_preview_test.go
+++ b/CubeMaster/pkg/service/httpservice/cube/sandbox_preview_test.go
@@ -37,12 +37,17 @@ func TestPreviewSandboxReturnsResolvedRequests(t *testing.T) {
 			Name: "main",
 		})
 		req.Volumes = append(req.Volumes, &types.Volume{Name: "work"})
+		req.Annotations[constants.CubeAnnotationsNetWork] = `{"Qos":{"BandWidth":{"Size":1250000,"RefillTime":100}}}`
 		return nil
 	}
 	previewConstructCubeletReqFn = func(ctx context.Context, req *types.CreateCubeSandboxReq) (*cubeboxv1.RunCubeSandboxRequest, error) {
+		assert.Contains(t, req.Annotations, constants.CubeAnnotationsNetWork)
 		return &cubeboxv1.RunCubeSandboxRequest{
 			RequestID: req.RequestID,
 			Namespace: req.Namespace,
+			Annotations: map[string]string{
+				constants.CubeAnnotationsNetWork: req.Annotations[constants.CubeAnnotationsNetWork],
+			},
 			Containers: []*cubeboxv1.ContainerConfig{
 				{Name: "main"},
 			},
@@ -73,12 +78,30 @@ func TestPreviewSandboxReturnsResolvedRequests(t *testing.T) {
 	if assert.NotNil(t, got.MergedRequest) {
 		assert.Equal(t, "resolved-ns", got.MergedRequest.Namespace)
 		assert.Len(t, got.MergedRequest.Containers, 1)
+		assert.NotContains(t, got.MergedRequest.Annotations, constants.CubeAnnotationsNetWork)
 	}
 	if assert.NotNil(t, got.CubeletRequest) {
 		assert.Equal(t, "resolved-ns", got.CubeletRequest.Namespace)
 		assert.Len(t, got.CubeletRequest.Containers, 1)
+		assert.NotContains(t, got.CubeletRequest.Annotations, constants.CubeAnnotationsNetWork)
 	}
 	assert.Equal(t, int64(errorcode.ErrorCode_Success), rt.RetCode)
+}
+
+func TestPreviewSandboxRejectsCallerSuppliedNetworkQos(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "/cube/sandbox/preview", strings.NewReader(`{
+		"requestID":"req-qos",
+		"annotations":{"cube.master.net":"{}"}
+	}`))
+	rt := &CubeLog.RequestTrace{}
+	resp := previewSandbox(req, rt)
+
+	got, ok := resp.(*sandboxPreviewResponse)
+	if !ok {
+		t.Fatalf("unexpected response type %T", resp)
+	}
+	assert.Equal(t, int(errorcode.ErrorCode_MasterParamsError), got.Ret.RetCode)
+	assert.Contains(t, got.Ret.RetMsg, "template-managed")
 }
 
 func TestHandleSandboxPreviewRejectsGet(t *testing.T) {

--- a/CubeMaster/pkg/service/httpservice/cube/snapshot.go
+++ b/CubeMaster/pkg/service/httpservice/cube/snapshot.go
@@ -797,7 +797,7 @@ func snapshotResourceFromInfo(info *templatecenter.SnapshotInfo) *snapshotResour
 		RuntimeRefCount:           info.RuntimeRefCount,
 		RuntimeRefSandboxes:       append([]string(nil), info.RuntimeRefSandboxes...),
 		Replicas:                  append([]templatecenter.ReplicaStatus(nil), info.Replicas...),
-		CreateRequest:             info.CreateRequest,
+		CreateRequest:             sanitizeTemplateCreateRequest(info.CreateRequest),
 	}
 }
 

--- a/CubeMaster/pkg/service/httpservice/cube/snapshot_test.go
+++ b/CubeMaster/pkg/service/httpservice/cube/snapshot_test.go
@@ -255,6 +255,25 @@ func TestGetSnapshotListSupportsFiltersAndPagination(t *testing.T) {
 	}
 }
 
+func TestSnapshotResourceHidesInternalNetworkQosAnnotation(t *testing.T) {
+	annotations := map[string]string{
+		constants.CubeAnnotationsNetWork:              `{"Qos":{"BandWidth":{"Size":1250000,"RefillTime":100}}}`,
+		constants.CubeAnnotationAppSnapshotTemplateID: "tpl-1",
+	}
+	resource := snapshotResourceFromInfo(&templatecenter.SnapshotInfo{
+		SnapshotID: "snap-1",
+		CreateRequest: &types.CreateCubeSandboxReq{
+			Annotations: annotations,
+		},
+	})
+
+	if assert.NotNil(t, resource.CreateRequest) {
+		assert.NotContains(t, resource.CreateRequest.Annotations, constants.CubeAnnotationsNetWork)
+		assert.Equal(t, "tpl-1", resource.CreateRequest.Annotations[constants.CubeAnnotationAppSnapshotTemplateID])
+	}
+	assert.Contains(t, annotations, constants.CubeAnnotationsNetWork)
+}
+
 func TestHandleSandboxRollbackActionUsesPathSandboxID(t *testing.T) {
 	registerKnownSandboxTestID(t)
 

--- a/CubeMaster/pkg/service/httpservice/cube/template.go
+++ b/CubeMaster/pkg/service/httpservice/cube/template.go
@@ -12,6 +12,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/log"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/errorcode"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/qos"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/service/httpservice/common"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/service/sandbox/types"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/templatecenter"
@@ -37,6 +38,7 @@ type templateResponse struct {
 	JobID                      string                         `json:"job_id,omitempty"`
 	Replicas                   []templatecenter.ReplicaStatus `json:"replicas,omitempty"`
 	CreateRequest              *types.CreateCubeSandboxReq    `json:"create_request,omitempty"`
+	ConfiguredQos              *qos.Config                    `json:"configured_qos,omitempty"`
 	CubeEgressCABaked          bool                           `json:"cube_egress_ca_baked,omitempty"`
 	CubeEgressCAFingerprint    string                         `json:"cube_egress_ca_fingerprint,omitempty"`
 	CubeEgressCATargetsWritten int                            `json:"cube_egress_ca_targets_written,omitempty"`
@@ -125,7 +127,8 @@ func templateResponseFromInfo(info *templatecenter.TemplateInfo, createReq *type
 		ImageInfo:                  info.ImageInfo,
 		JobID:                      info.JobID,
 		Replicas:                   info.Replicas,
-		CreateRequest:              createReq,
+		CreateRequest:              sanitizeTemplateCreateRequest(createReq),
+		ConfiguredQos:              info.ConfiguredQos,
 		CubeEgressCABaked:          info.CubeEgressCABaked,
 		CubeEgressCAFingerprint:    info.CubeEgressCAFingerprint,
 		CubeEgressCATargetsWritten: info.CubeEgressCATargetsWritten,
@@ -309,6 +312,14 @@ func deleteTemplate(r *http.Request, rt *CubeLog.RequestTrace) interface{} {
 func createTemplate(r *http.Request, rt *CubeLog.RequestTrace) interface{} {
 	req, err := constructCreateReq(r)
 	if err != nil {
+		return &templateResponse{
+			Res: &types.Res{Ret: &types.Ret{
+				RetCode: int(errorcode.ErrorCode_MasterParamsError),
+				RetMsg:  err.Error(),
+			}},
+		}
+	}
+	if err := rejectCallerSuppliedQos(req); err != nil {
 		return &templateResponse{
 			Res: &types.Res{Ret: &types.Ret{
 				RetCode: int(errorcode.ErrorCode_MasterParamsError),

--- a/CubeMaster/pkg/service/httpservice/cube/template_commit.go
+++ b/CubeMaster/pkg/service/httpservice/cube/template_commit.go
@@ -72,6 +72,16 @@ func handleSandboxCommitAction(c *gin.Context) {
 		})
 		return
 	}
+	if err := rejectCallerSuppliedQos(req.CreateRequest); err != nil {
+		rt.RetCode = int64(errorcode.ErrorCode_MasterParamsError)
+		common.WriteAPI(c, &commitTemplateResponse{
+			Res: &types.Res{Ret: &types.Ret{
+				RetCode: int(errorcode.ErrorCode_MasterParamsError),
+				RetMsg:  err.Error(),
+			}},
+		})
+		return
+	}
 	if resolved, ret := sandbox.NormalizeSandboxIDParam(c.Request.Context(), req.SandboxID); ret != nil {
 		common.WriteAPI(c, &commitTemplateResponse{Res: &types.Res{Ret: ret}})
 		return

--- a/CubeMaster/pkg/service/httpservice/cube/template_commit_test.go
+++ b/CubeMaster/pkg/service/httpservice/cube/template_commit_test.go
@@ -157,6 +157,23 @@ func TestHandleSandboxCommitActionSanitizesInternalErrors(t *testing.T) {
 	assert.NotContains(t, got.Res.Ret.RetMsg, "10.0.0.2:3306")
 }
 
+func TestHandleSandboxCommitActionRejectsCallerSuppliedNetworkQos(t *testing.T) {
+	body := `{
+		"requestID":"req-qos",
+		"sandbox_id":"sb-1",
+		"create_request":{
+			"annotations":{"cube.master.net":"{}"}
+		}
+	}`
+	req := httptest.NewRequest("POST", "/cube/sandbox/commit", strings.NewReader(body))
+	rt := &CubeLog.RequestTrace{}
+	got := invokeCommitHandler(t, req, rt)
+
+	assert.Equal(t, int(errorcode.ErrorCode_MasterParamsError), got.Res.Ret.RetCode)
+	assert.Contains(t, got.Res.Ret.RetMsg, "template-managed")
+	assert.Equal(t, int64(errorcode.ErrorCode_MasterParamsError), rt.RetCode)
+}
+
 func TestHandleSandboxCommitActionIgnoresProvidedTemplateID(t *testing.T) {
 	registerKnownSandboxTestID(t)
 

--- a/CubeMaster/pkg/service/httpservice/cube/template_test.go
+++ b/CubeMaster/pkg/service/httpservice/cube/template_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/api/services/cubebox/v1"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/constants"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/errorcode"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/qos"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/service/sandbox/types"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/templatecenter"
 	"github.com/tencentcloud/CubeSandbox/cubelog"
@@ -52,6 +53,38 @@ func TestConstructCreateReqPreservesDistributionScope(t *testing.T) {
 		t.Fatalf("constructCreateReq failed: %v", err)
 	}
 	assert.Equal(t, []string{"node-a", "10.0.0.2"}, got.DistributionScope)
+}
+
+func TestCreateTemplateRejectsCallerSuppliedNetworkQosAnnotation(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "/cube/template", strings.NewReader(`{
+		"requestID":"req-qos",
+		"annotations":{"cube.master.net":"{}"}
+	}`))
+	rt := &CubeLog.RequestTrace{}
+	resp := createTemplate(req, rt)
+
+	got, ok := resp.(*templateResponse)
+	if !ok {
+		t.Fatalf("unexpected response type %T", resp)
+	}
+	assert.Equal(t, int(errorcode.ErrorCode_MasterParamsError), got.Ret.RetCode)
+	assert.Contains(t, got.Ret.RetMsg, "template-managed")
+}
+
+func TestCreateTemplateRejectsCallerSuppliedBlockIOQosAnnotation(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "/cube/template", strings.NewReader(`{
+		"requestID":"req-qos",
+		"annotations":{"cube.master.blk.qos":"{}"}
+	}`))
+	rt := &CubeLog.RequestTrace{}
+	resp := createTemplate(req, rt)
+
+	got, ok := resp.(*templateResponse)
+	if !ok {
+		t.Fatalf("unexpected response type %T", resp)
+	}
+	assert.Equal(t, int(errorcode.ErrorCode_MasterParamsError), got.Ret.RetCode)
+	assert.Contains(t, got.Ret.RetMsg, "template-managed")
 }
 
 func TestDeleteTemplateMapsAttemptInProgressToConflict(t *testing.T) {
@@ -170,6 +203,10 @@ func TestGetTemplateIncludeRequest(t *testing.T) {
 			InstanceType: "cubebox",
 			Version:      "v2",
 			Status:       "READY",
+			ConfiguredQos: &qos.Config{
+				Network: &qos.NetworkConfig{BandwidthMbps: 100, PacketsPerSecond: 5000},
+				BlockIO: &qos.BlockIOConfig{ThroughputMiBps: 64, IOPS: 1000},
+			},
 		}, nil
 	}
 	getTemplateRequestFn = func(ctx context.Context, templateID string) (*types.CreateCubeSandboxReq, error) {
@@ -177,6 +214,8 @@ func TestGetTemplateIncludeRequest(t *testing.T) {
 			Request: &types.Request{RequestID: "req-preview"},
 			Annotations: map[string]string{
 				constants.CubeAnnotationAppSnapshotTemplateID: templateID,
+				constants.CubeAnnotationsNetWork:              `{"Qos":{"BandWidth":{"Size":1250000,"RefillTime":100}}}`,
+				constants.CubeAnnotationsBlkQos:               `{"bandwidth":{"size":67108864,"refill_time":1000}}`,
 			},
 		}, nil
 	}
@@ -192,7 +231,13 @@ func TestGetTemplateIncludeRequest(t *testing.T) {
 	assert.Equal(t, int(errorcode.ErrorCode_Success), got.Ret.RetCode)
 	if assert.NotNil(t, got.CreateRequest) {
 		assert.Equal(t, "tpl-include", got.CreateRequest.Annotations[constants.CubeAnnotationAppSnapshotTemplateID])
+		assert.NotContains(t, got.CreateRequest.Annotations, constants.CubeAnnotationsNetWork)
+		assert.NotContains(t, got.CreateRequest.Annotations, constants.CubeAnnotationsBlkQos)
 	}
+	assert.Equal(t, uint32(100), got.ConfiguredQos.Network.BandwidthMbps)
+	assert.Equal(t, uint32(5000), got.ConfiguredQos.Network.PacketsPerSecond)
+	assert.Equal(t, uint32(64), got.ConfiguredQos.BlockIO.ThroughputMiBps)
+	assert.Equal(t, uint32(1000), got.ConfiguredQos.BlockIO.IOPS)
 	assert.Equal(t, int64(errorcode.ErrorCode_Success), rt.RetCode)
 }
 

--- a/CubeMaster/pkg/service/sandbox/qos_lookup.go
+++ b/CubeMaster/pkg/service/sandbox/qos_lookup.go
@@ -1,0 +1,31 @@
+package sandbox
+
+import (
+	"context"
+	"sync"
+
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/qos"
+)
+
+type TemplateQosLookupHook func(context.Context, string) (*qos.Config, error)
+
+var (
+	templateQosLookupMu   sync.RWMutex
+	templateQosLookupHook TemplateQosLookupHook
+)
+
+func SetTemplateQosLookupHook(hook TemplateQosLookupHook) {
+	templateQosLookupMu.Lock()
+	templateQosLookupHook = hook
+	templateQosLookupMu.Unlock()
+}
+
+func lookupTemplateQos(ctx context.Context, templateID string) (*qos.Config, error) {
+	templateQosLookupMu.RLock()
+	hook := templateQosLookupHook
+	templateQosLookupMu.RUnlock()
+	if hook == nil {
+		return nil, nil
+	}
+	return hook(ctx, templateID)
+}

--- a/CubeMaster/pkg/service/sandbox/sandbox_info.go
+++ b/CubeMaster/pkg/service/sandbox/sandbox_info.go
@@ -19,6 +19,8 @@ import (
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/errorcode"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/localcache"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/pausesnap"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/qos"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/sandboxspec"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/service/sandbox/types"
 	"github.com/tencentcloud/CubeSandbox/cubelog"
 )
@@ -204,6 +206,11 @@ func decorateSandboxInfo(ctx context.Context, req *types.GetCubeSandboxReq, rsp 
 	if req.SandboxID == "" {
 		return nil
 	}
+	if spec, err := sandboxspec.Get(ctx, req.SandboxID); err == nil && spec != nil {
+		decorateSandboxQos(rsp.Data, spec.Annotations)
+	} else {
+		decorateSandboxQosFromTemplate(ctx, rsp.Data)
+	}
 	proxyMap, ok := localcache.GetSandboxProxyMap(ctx, req.SandboxID)
 	if !ok || proxyMap == nil {
 		return nil
@@ -232,6 +239,39 @@ func decorateSandboxInfo(ctx context.Context, req *types.GetCubeSandboxReq, rsp 
 		item.ExposedPortMode = endpoint.Mode
 	}
 	return nil
+}
+
+func decorateSandboxQos(items []*types.SandboxData, annotations map[string]string) {
+	configured, err := qos.ParseAnnotations(
+		annotations[constants.CubeAnnotationsNetWork],
+		annotations[constants.CubeAnnotationsBlkQos],
+	)
+	if err != nil || configured == nil {
+		return
+	}
+	for _, item := range items {
+		if item == nil {
+			continue
+		}
+		item.ConfiguredQos = configured
+		item.QosApplied = qos.HasAppliedAnnotation(
+			annotations[constants.CubeAnnotationsNetWork],
+			annotations[constants.CubeAnnotationsBlkQos],
+		)
+	}
+}
+
+func decorateSandboxQosFromTemplate(ctx context.Context, items []*types.SandboxData) {
+	for _, item := range items {
+		if item == nil || item.ConfiguredQos != nil || item.TemplateID == "" {
+			continue
+		}
+		configured, err := lookupTemplateQos(ctx, item.TemplateID)
+		if err != nil || configured == nil {
+			continue
+		}
+		item.ConfiguredQos = configured
+	}
 }
 
 func getContainerName(label map[string]string) string {

--- a/CubeMaster/pkg/service/sandbox/sandbox_info_qos_test.go
+++ b/CubeMaster/pkg/service/sandbox/sandbox_info_qos_test.go
@@ -1,0 +1,66 @@
+package sandbox
+
+import (
+	"context"
+	"testing"
+
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/constants"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/qos"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/service/sandbox/types"
+)
+
+func TestDecorateSandboxQosReportsConfiguredAndApplied(t *testing.T) {
+	items := []*types.SandboxData{{SandboxID: "sb-1"}, nil}
+	decorateSandboxQos(items, map[string]string{
+		constants.CubeAnnotationsNetWork: `{"Qos":{"BandWidth":{"Size":1250000,"RefillTime":100},"OPS":{"Size":5000,"RefillTime":1000}},"Version":1}`,
+		constants.CubeAnnotationsBlkQos:  `{"bandwidth":{"size":67108864,"refill_time":1000},"ops":{"size":1000,"refill_time":1000}}`,
+	})
+
+	got := items[0]
+	if got.ConfiguredQos == nil || got.ConfiguredQos.Network == nil || got.ConfiguredQos.Network.BandwidthMbps != 100 || got.ConfiguredQos.Network.PacketsPerSecond != 5000 {
+		t.Fatalf("configured qos=%+v, want 100 Mbps and 5000 packets/s", got.ConfiguredQos)
+	}
+	if got.ConfiguredQos.BlockIO == nil || got.ConfiguredQos.BlockIO.ThroughputMiBps != 64 || got.ConfiguredQos.BlockIO.IOPS != 1000 {
+		t.Fatalf("configured qos=%+v, want 64 MiB/s and 1000 IOPS", got.ConfiguredQos)
+	}
+	if !got.QosApplied {
+		t.Fatal("expected qos_applied=true")
+	}
+}
+
+func TestDecorateSandboxQosIgnoresMissingOrInvalidAnnotation(t *testing.T) {
+	for name, annotations := range map[string]map[string]string{
+		"missing": nil,
+		"invalid": {constants.CubeAnnotationsNetWork: `{}`},
+	} {
+		t.Run(name, func(t *testing.T) {
+			item := &types.SandboxData{SandboxID: "sb-1"}
+			decorateSandboxQos([]*types.SandboxData{item}, annotations)
+			if item.ConfiguredQos != nil || item.QosApplied {
+				t.Fatalf("unexpected qos state: %+v", item)
+			}
+		})
+	}
+}
+
+func TestDecorateSandboxQosFallsBackToTemplate(t *testing.T) {
+	SetTemplateQosLookupHook(func(_ context.Context, templateID string) (*qos.Config, error) {
+		if templateID != "tpl-1" {
+			t.Fatalf("templateID=%q, want tpl-1", templateID)
+		}
+		return &qos.Config{
+			Network: &qos.NetworkConfig{BandwidthMbps: 100},
+		}, nil
+	})
+	t.Cleanup(func() { SetTemplateQosLookupHook(nil) })
+
+	item := &types.SandboxData{SandboxID: "sb-1", TemplateID: "tpl-1"}
+	decorateSandboxQosFromTemplate(context.Background(), []*types.SandboxData{item})
+
+	if item.ConfiguredQos == nil || item.ConfiguredQos.Network.BandwidthMbps != 100 {
+		t.Fatalf("configured qos=%+v, want 100 Mbps", item.ConfiguredQos)
+	}
+	if item.QosApplied {
+		t.Fatal("template fallback cannot prove qos_applied")
+	}
+}

--- a/CubeMaster/pkg/service/sandbox/types/types.go
+++ b/CubeMaster/pkg/service/sandbox/types/types.go
@@ -10,6 +10,7 @@ import (
 	cubeboxv1 "github.com/tencentcloud/CubeSandbox/CubeMaster/api/services/cubebox/v1"
 	imagev1 "github.com/tencentcloud/CubeSandbox/CubeMaster/api/services/images/v1"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/node"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/qos"
 )
 
 // NeverTimeout is the never-timeout idle TTL sentinel (-1).
@@ -603,6 +604,8 @@ type SandboxData struct {
 	RequestedContainerPort int32              `json:"requested_container_port,omitempty"`
 	EndAt                  int64              `json:"end_at,omitempty"`
 	VolumeMounts           []*VolumeMountInfo `json:"volume_mounts,omitempty"`
+	ConfiguredQos          *qos.Config        `json:"configured_qos,omitempty"`
+	QosApplied             bool               `json:"qos_applied,omitempty"`
 }
 
 // VolumeMountInfo is one container volume mount exposed in sandbox info/list APIs.
@@ -666,6 +669,7 @@ type CreateTemplateFromImageReq struct {
 	WritableLayerSize  string              `json:"writable_layer_size,omitempty"`
 	ExposedPorts       []int32             `json:"exposed_ports,omitempty"`
 	DistributionScope  []string            `json:"distribution_scope,omitempty"`
+	Qos                *qos.Config         `json:"qos,omitempty"`
 	ContainerOverrides *ContainerOverrides `json:"container_overrides,omitempty"`
 	Wait               bool                `json:"wait,omitempty"`
 

--- a/CubeMaster/pkg/service/sandbox/util.go
+++ b/CubeMaster/pkg/service/sandbox/util.go
@@ -880,8 +880,12 @@ func checkAndGetAnnotation(req *types.CreateCubeSandboxReq, out *cubebox.RunCube
 		out.Annotations[constants.CubeAnnotationsVIPs] = v
 	}
 
-	out.Annotations[constants.CubeAnnotationsBlkQos] = getBlkQosAnnotation(req)
-	out.Annotations[constants.CubeAnnotationsFSQos] = getFsQosAnnotation(req)
+	if _, configured := req.Annotations[constants.CubeAnnotationsBlkQos]; !configured {
+		out.Annotations[constants.CubeAnnotationsBlkQos] = getBlkQosAnnotation(req)
+	}
+	if _, configured := req.Annotations[constants.CubeAnnotationsFSQos]; !configured {
+		out.Annotations[constants.CubeAnnotationsFSQos] = getFsQosAnnotation(req)
+	}
 	for k, v := range req.Annotations {
 
 		if strings.HasPrefix(k, constants.CubeAnnotationsPrefix) ||

--- a/CubeMaster/pkg/service/sandbox/util_test.go
+++ b/CubeMaster/pkg/service/sandbox/util_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	cubebox "github.com/tencentcloud/CubeSandbox/CubeMaster/api/services/cubebox/v1"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/config"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/constants"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/service/sandbox/types"
 )
 
@@ -285,5 +286,51 @@ func TestGetReqResourceRejectsCPUOverflowBeforeMemOverflow(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "cpu") {
 		t.Fatalf("expected cpu validation error to win, got %v", err)
+	}
+}
+
+func TestCheckAndGetAnnotationPreservesTemplateBlockQos(t *testing.T) {
+	cfg := ensureSandboxTestConfig(t)
+	origExtraConf := cfg.ExtraConf
+	cfg.ExtraConf = &config.ExtraConf{
+		BlkQos: `{"bandwidth":{"size":1048576,"refill_time":1000}}`,
+		FsQos:  `{}`,
+	}
+	t.Cleanup(func() { cfg.ExtraConf = origExtraConf })
+
+	templateBlockQos := `{"bandwidth":{"size":67108864,"refill_time":1000},"ops":{"size":1000,"refill_time":1000}}`
+	req := &types.CreateCubeSandboxReq{
+		Annotations: map[string]string{
+			constants.CubeAnnotationsBlkQos: templateBlockQos,
+		},
+	}
+	out := &cubebox.RunCubeSandboxRequest{Annotations: map[string]string{}}
+
+	if err := checkAndGetAnnotation(req, out); err != nil {
+		t.Fatalf("checkAndGetAnnotation error=%v", err)
+	}
+	if got := out.Annotations[constants.CubeAnnotationsBlkQos]; got != templateBlockQos {
+		t.Fatalf("block qos annotation=%q, want template value %q", got, templateBlockQos)
+	}
+}
+
+func TestCheckAndGetAnnotationUsesLegacyBlockQosWhenTemplateOmitsIt(t *testing.T) {
+	cfg := ensureSandboxTestConfig(t)
+	origExtraConf := cfg.ExtraConf
+	legacyBlockQos := `{"ops":{"size":500,"refill_time":1000}}`
+	cfg.ExtraConf = &config.ExtraConf{
+		BlkQos: legacyBlockQos,
+		FsQos:  `{}`,
+	}
+	t.Cleanup(func() { cfg.ExtraConf = origExtraConf })
+
+	req := &types.CreateCubeSandboxReq{Annotations: map[string]string{}}
+	out := &cubebox.RunCubeSandboxRequest{Annotations: map[string]string{}}
+
+	if err := checkAndGetAnnotation(req, out); err != nil {
+		t.Fatalf("checkAndGetAnnotation error=%v", err)
+	}
+	if got := out.Annotations[constants.CubeAnnotationsBlkQos]; got != legacyBlockQos {
+		t.Fatalf("block qos annotation=%q, want legacy value %q", got, legacyBlockQos)
 	}
 }

--- a/CubeMaster/pkg/templatecenter/request_validation.go
+++ b/CubeMaster/pkg/templatecenter/request_validation.go
@@ -14,6 +14,7 @@ import (
 
 	cubeboxv1 "github.com/tencentcloud/CubeSandbox/CubeMaster/api/services/cubebox/v1"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/node"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/qos"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/service/sandbox/types"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/templatecenter/image"
 )
@@ -86,6 +87,12 @@ func normalizeTemplateImageRequest(req *types.CreateTemplateFromImageReq) (*type
 	}
 	cloned := *req
 	cloned.SourceImageRef = sourceImageRef
+	resources := templateResources(req)
+	resolvedQos, err := qos.ResolveTemplate(req.Qos, resources)
+	if err != nil {
+		return nil, err
+	}
+	cloned.Qos = resolvedQos
 	exposedPorts, err := normalizeTemplateExposedPorts(req.ExposedPorts)
 	if err != nil {
 		return nil, err
@@ -111,6 +118,19 @@ func normalizeTemplateImageRequest(req *types.CreateTemplateFromImageReq) (*type
 		return nil, err
 	}
 	return &cloned, nil
+}
+
+func templateResources(req *types.CreateTemplateFromImageReq) qos.TemplateResources {
+	resources := qos.TemplateResources{CPU: defaultTemplateCPU, Memory: defaultTemplateMemory}
+	if req.ContainerOverrides != nil && req.ContainerOverrides.Resources != nil {
+		if req.ContainerOverrides.Resources.Cpu != "" {
+			resources.CPU = req.ContainerOverrides.Resources.Cpu
+		}
+		if req.ContainerOverrides.Resources.Mem != "" {
+			resources.Memory = req.ContainerOverrides.Resources.Mem
+		}
+	}
+	return resources
 }
 
 // aliasValidationRe matches the allowed alias charset: lowercase alphanumeric

--- a/CubeMaster/pkg/templatecenter/store.go
+++ b/CubeMaster/pkg/templatecenter/store.go
@@ -28,6 +28,7 @@ import (
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/errorcode"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/localcache"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/pausesnap"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/qos"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/sandboxspec"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/service/sandbox"
 	sandboxtypes "github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/service/sandbox/types"
@@ -140,6 +141,7 @@ type TemplateInfo struct {
 	ImageInfo                 string          `json:"image_info,omitempty"`
 	JobID                     string          `json:"job_id,omitempty"`
 	Replicas                  []ReplicaStatus `json:"replicas,omitempty"`
+	ConfiguredQos             *qos.Config     `json:"configured_qos,omitempty"`
 
 	// CubeEgress CA bake metadata, surfaced for ops triage. Populated
 	// from the RootfsArtifact row pointed to by the first replica.
@@ -152,7 +154,7 @@ type TemplateInfo struct {
 }
 
 func templateInfoFromDefinition(def models.TemplateDefinition) TemplateInfo {
-	return TemplateInfo{
+	info := TemplateInfo{
 		TemplateID:                def.TemplateID,
 		InstanceType:              def.InstanceType,
 		Version:                   def.Version,
@@ -167,6 +169,8 @@ func templateInfoFromDefinition(def models.TemplateDefinition) TemplateInfo {
 		RootfsSizeBytesAtSnapshot: def.RootfsSizeBytesAtSnapshot,
 		LastError:                 def.LastError,
 	}
+	info.ConfiguredQos = configuredQosFromCreateRequestJSON(def.RequestJSON)
+	return info
 }
 
 type replicaRunOptions struct {
@@ -298,6 +302,16 @@ func configureSandboxSpecHooks() {
 			HostID: hostID,
 			HostIP: hostIP,
 		})
+	})
+	sandbox.SetTemplateQosLookupHook(func(ctx context.Context, templateID string) (*qos.Config, error) {
+		req, err := GetTemplateRequest(ctx, templateID)
+		if err != nil {
+			return nil, err
+		}
+		return qos.ParseAnnotations(
+			req.Annotations[constants.CubeAnnotationsNetWork],
+			req.Annotations[constants.CubeAnnotationsBlkQos],
+		)
 	})
 }
 
@@ -857,7 +871,7 @@ func templateInfoFromJob(job *models.TemplateImageJob) TemplateInfo {
 	if status == "" {
 		status = JobStatusPending
 	}
-	return TemplateInfo{
+	info := TemplateInfo{
 		TemplateID:   job.TemplateID,
 		InstanceType: job.InstanceType,
 		Version:      DefaultTemplateVersion,
@@ -867,6 +881,31 @@ func templateInfoFromJob(job *models.TemplateImageJob) TemplateInfo {
 		ImageInfo:    composeImageInfo(job.SourceImageRef, job.SourceImageDigest),
 		JobID:        latestJobIDFromJob(job),
 	}
+	if job.RequestJSON != "" {
+		request := &sandboxtypes.CreateTemplateFromImageReq{}
+		if err := json.Unmarshal([]byte(job.RequestJSON), request); err == nil {
+			info.ConfiguredQos = qos.Clone(request.Qos)
+		}
+	}
+	return info
+}
+
+func configuredQosFromCreateRequestJSON(raw string) *qos.Config {
+	if strings.TrimSpace(raw) == "" {
+		return nil
+	}
+	request := &sandboxtypes.CreateCubeSandboxReq{}
+	if err := json.Unmarshal([]byte(raw), request); err != nil || request.Annotations == nil {
+		return nil
+	}
+	configured, err := qos.ParseAnnotations(
+		request.Annotations[constants.CubeAnnotationsNetWork],
+		request.Annotations[constants.CubeAnnotationsBlkQos],
+	)
+	if err != nil {
+		return nil
+	}
+	return configured
 }
 
 func formatUTCRFC3339(ts time.Time) string {

--- a/CubeMaster/pkg/templatecenter/template_image_test.go
+++ b/CubeMaster/pkg/templatecenter/template_image_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/constants"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/db/models"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/node"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/qos"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/service/sandbox/types"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/templatecenter/image"
 	"gorm.io/gorm"
@@ -92,6 +93,51 @@ func TestNormalizeTemplateImageRequestRejectsInvalidSourceImageRef(t *testing.T)
 				t.Fatalf("normalizeTemplateImageRequest(%q) error=%v, want source_image_ref validation error", imageRef, err)
 			}
 		})
+	}
+}
+
+func TestNormalizeTemplateImageRequestClonesQos(t *testing.T) {
+	inputQos := &qos.Config{Network: &qos.NetworkConfig{BandwidthMbps: 100, PacketsPerSecond: 5000}}
+	req, err := normalizeTemplateImageRequest(&types.CreateTemplateFromImageReq{
+		Request:           &types.Request{RequestID: "req-1"},
+		SourceImageRef:    "docker.io/library/nginx:latest",
+		WritableLayerSize: "20Gi",
+		Qos:               inputQos,
+	})
+	if err != nil {
+		t.Fatalf("normalizeTemplateImageRequest failed: %v", err)
+	}
+
+	inputQos.Network.BandwidthMbps = 200
+	if got := req.Qos.Network.BandwidthMbps; got != 100 {
+		t.Fatalf("normalized bandwidth=%d, want 100", got)
+	}
+	inputQos.Network.PacketsPerSecond = 9000
+	if got := req.Qos.Network.PacketsPerSecond; got != 5000 {
+		t.Fatalf("normalized packets per second=%d, want 5000", got)
+	}
+}
+
+func TestNormalizeTemplateImageRequestKeepsDefaultForOmittedResourceFields(t *testing.T) {
+	resources := templateResources(&types.CreateTemplateFromImageReq{
+		ContainerOverrides: &types.ContainerOverrides{Resources: &types.Resource{
+			Cpu: "500m",
+		}},
+	})
+	if resources.CPU != "500m" || resources.Memory != defaultTemplateMemory {
+		t.Fatalf("resources=%+v, want explicit CPU and default memory", resources)
+	}
+}
+
+func TestNormalizeTemplateImageRequestRejectsInvalidQos(t *testing.T) {
+	_, err := normalizeTemplateImageRequest(&types.CreateTemplateFromImageReq{
+		Request:           &types.Request{RequestID: "req-1"},
+		SourceImageRef:    "docker.io/library/nginx:latest",
+		WritableLayerSize: "20Gi",
+		Qos:               &qos.Config{},
+	})
+	if err == nil {
+		t.Fatal("expected invalid qos error")
 	}
 }
 
@@ -399,6 +445,23 @@ func TestBuildTemplateSpecFingerprintUsesExposedPorts(t *testing.T) {
 	}
 }
 
+func TestBuildTemplateSpecFingerprintIgnoresRuntimeQos(t *testing.T) {
+	reqA := &types.CreateTemplateFromImageReq{
+		SourceImageRef:    "docker.io/library/nginx:latest",
+		WritableLayerSize: "20Gi",
+		InstanceType:      cubeboxv1.InstanceType_cubebox.String(),
+		NetworkType:       cubeboxv1.NetworkType_tap.String(),
+	}
+	reqB := *reqA
+	reqB.Qos = &qos.Config{Network: &qos.NetworkConfig{BandwidthMbps: 200}}
+
+	gotA := buildTemplateSpecFingerprint(reqA, "repo@sha256:aaa")
+	gotB := buildTemplateSpecFingerprint(&reqB, "repo@sha256:aaa")
+	if gotA != gotB {
+		t.Fatalf("runtime qos must not change rootfs artifact fingerprint: %q vs %q", gotA, gotB)
+	}
+}
+
 func TestBuildTemplateSpecFingerprintUsesDNSConfig(t *testing.T) {
 	reqA := &types.CreateTemplateFromImageReq{
 		Request:           &types.Request{RequestID: "req-1"},
@@ -603,6 +666,72 @@ func TestGenerateTemplateCreateRequestInjectsImmutableRootfsMetadata(t *testing.
 	if got.Annotations[constants.AnnotationsExposedPort] != "80:8080" {
 		t.Fatalf("unexpected exposed ports annotation: %q", got.Annotations[constants.AnnotationsExposedPort])
 	}
+	if _, ok := got.Annotations[constants.CubeAnnotationsNetWork]; ok {
+		t.Fatalf("opt-out template unexpectedly has network qos annotation: %q", got.Annotations[constants.CubeAnnotationsNetWork])
+	}
+	if _, ok := got.Annotations[constants.CubeAnnotationsBlkQos]; ok {
+		t.Fatalf("opt-out template unexpectedly has block io qos annotation: %q", got.Annotations[constants.CubeAnnotationsBlkQos])
+	}
+	if got.Annotations[constants.CubeAnnotationWritableLayerSize] != "20Gi" {
+		t.Fatalf("system annotation was overridden: %q", got.Annotations[constants.CubeAnnotationWritableLayerSize])
+	}
+}
+
+func TestGenerateTemplateCreateRequestInjectsBlockIOQos(t *testing.T) {
+	req := &types.CreateTemplateFromImageReq{
+		Request:           &types.Request{RequestID: "req-qos"},
+		SourceImageRef:    "docker.io/library/nginx:latest",
+		TemplateID:        "template-qos",
+		WritableLayerSize: "20Gi",
+		InstanceType:      cubeboxv1.InstanceType_cubebox.String(),
+		NetworkType:       cubeboxv1.NetworkType_tap.String(),
+		Qos:               &qos.Config{BlockIO: &qos.BlockIOConfig{ThroughputMiBps: 64, IOPS: 1000}},
+	}
+	artifact := &models.RootfsArtifact{
+		ArtifactID:              "artifact-qos",
+		TemplateSpecFingerprint: "fingerprint-qos",
+		Ext4SHA256:              "sha256-qos",
+		Ext4SizeBytes:           1024,
+		DownloadToken:           "token-qos",
+	}
+	got, err := generateTemplateCreateRequest(req, artifact, image.DockerImageConfig{}, "http://master.example")
+	if err != nil {
+		t.Fatalf("generateTemplateCreateRequest failed: %v", err)
+	}
+	want := `{"bandwidth":{"size":67108864,"refill_time":1000},"ops":{"size":1000,"refill_time":1000}}`
+	if got.Annotations[constants.CubeAnnotationsBlkQos] != want {
+		t.Fatalf("block io qos annotation=%q, want %q", got.Annotations[constants.CubeAnnotationsBlkQos], want)
+	}
+	if _, ok := got.Annotations[constants.CubeAnnotationsNetWork]; ok {
+		t.Fatal("block-io-only qos unexpectedly emitted network annotation")
+	}
+}
+
+func TestGenerateTemplateCreateRequestInjectsNetworkQos(t *testing.T) {
+	req := &types.CreateTemplateFromImageReq{
+		Request:           &types.Request{RequestID: "req-qos"},
+		SourceImageRef:    "docker.io/library/nginx:latest",
+		TemplateID:        "template-qos",
+		WritableLayerSize: "20Gi",
+		InstanceType:      cubeboxv1.InstanceType_cubebox.String(),
+		NetworkType:       cubeboxv1.NetworkType_tap.String(),
+		Qos:               &qos.Config{Network: &qos.NetworkConfig{BandwidthMbps: 100, PacketsPerSecond: 5000}},
+	}
+	artifact := &models.RootfsArtifact{
+		ArtifactID:              "artifact-qos",
+		TemplateSpecFingerprint: "fingerprint-qos",
+		Ext4SHA256:              "sha256-qos",
+		Ext4SizeBytes:           1024,
+		DownloadToken:           "token-qos",
+	}
+	got, err := generateTemplateCreateRequest(req, artifact, image.DockerImageConfig{}, "http://master.example")
+	if err != nil {
+		t.Fatalf("generateTemplateCreateRequest failed: %v", err)
+	}
+	want := `{"Qos":{"BandWidth":{"Size":1250000,"OneTimeBurst":0,"RefillTime":100},"OPS":{"Size":5000,"OneTimeBurst":0,"RefillTime":1000}},"Version":1}`
+	if got.Annotations[constants.CubeAnnotationsNetWork] != want {
+		t.Fatalf("network qos annotation=%q, want %q", got.Annotations[constants.CubeAnnotationsNetWork], want)
+	}
 }
 
 func TestGenerateTemplateCreateRequestAppliesDNSConfigOverride(t *testing.T) {
@@ -787,6 +916,7 @@ func TestMarshalTemplateImageJobRequestIgnoresRequestIDAndPassword(t *testing.T)
 		InstanceType:       cubeboxv1.InstanceType_cubebox.String(),
 		NetworkType:        cubeboxv1.NetworkType_tap.String(),
 		ContainerOverrides: &types.ContainerOverrides{Command: []string{"echo", "ok"}},
+		Qos:                &qos.Config{Network: &qos.NetworkConfig{BandwidthMbps: 100, PacketsPerSecond: 5000}},
 	}
 	reqB := &types.CreateTemplateFromImageReq{
 		Request:            &types.Request{RequestID: "req-b"},
@@ -797,6 +927,7 @@ func TestMarshalTemplateImageJobRequestIgnoresRequestIDAndPassword(t *testing.T)
 		InstanceType:       reqA.InstanceType,
 		NetworkType:        reqA.NetworkType,
 		ContainerOverrides: reqA.ContainerOverrides,
+		Qos:                &qos.Config{Network: &qos.NetworkConfig{BandwidthMbps: 100, PacketsPerSecond: 5000}},
 	}
 	payloadA, err := marshalTemplateImageJobRequest(reqA)
 	if err != nil {
@@ -811,6 +942,41 @@ func TestMarshalTemplateImageJobRequestIgnoresRequestIDAndPassword(t *testing.T)
 	}
 	if strings.Contains(payloadA, "req-a") || strings.Contains(payloadA, "secret-a") {
 		t.Fatalf("stable payload leaked request-specific data: %q", payloadA)
+	}
+	if !strings.Contains(payloadA, `"qos":{"network":{"bandwidthMbps":100,"packetsPerSecond":5000}}`) {
+		t.Fatalf("stable payload dropped template qos: %q", payloadA)
+	}
+}
+
+func TestMarshalTemplateImageJobRequestIncludesRuntimeQos(t *testing.T) {
+	reqA := &types.CreateTemplateFromImageReq{
+		SourceImageRef:    "docker.io/library/nginx:latest",
+		WritableLayerSize: "1Gi",
+		InstanceType:      cubeboxv1.InstanceType_cubebox.String(),
+		NetworkType:       cubeboxv1.NetworkType_tap.String(),
+		Qos:               &qos.Config{Network: &qos.NetworkConfig{BandwidthMbps: 100}},
+	}
+	reqB := *reqA
+	reqB.Qos = &qos.Config{Network: &qos.NetworkConfig{BandwidthMbps: 200}}
+
+	payloadA, err := marshalTemplateImageJobRequest(reqA)
+	if err != nil {
+		t.Fatalf("marshalTemplateImageJobRequest(reqA) failed: %v", err)
+	}
+	payloadB, err := marshalTemplateImageJobRequest(&reqB)
+	if err != nil {
+		t.Fatalf("marshalTemplateImageJobRequest(reqB) failed: %v", err)
+	}
+	if payloadA == payloadB {
+		t.Fatal("runtime request snapshot must change when qos changes")
+	}
+}
+
+func TestConfiguredQosFromCreateRequestJSON(t *testing.T) {
+	raw := `{"annotations":{"cube.master.net":"{\"Qos\":{\"BandWidth\":{\"Size\":1250000,\"RefillTime\":100},\"OPS\":{\"Size\":5000,\"RefillTime\":1000}},\"Version\":1}","cube.master.blk.qos":"{\"bandwidth\":{\"size\":67108864,\"refill_time\":1000},\"ops\":{\"size\":1000,\"refill_time\":1000}}"}}`
+	got := configuredQosFromCreateRequestJSON(raw)
+	if got == nil || got.Network == nil || got.Network.BandwidthMbps != 100 || got.Network.PacketsPerSecond != 5000 || got.BlockIO == nil || got.BlockIO.ThroughputMiBps != 64 || got.BlockIO.IOPS != 1000 {
+		t.Fatalf("configured qos=%+v, want network and block io limits", got)
 	}
 }
 

--- a/CubeMaster/pkg/templatecenter/template_request.go
+++ b/CubeMaster/pkg/templatecenter/template_request.go
@@ -16,6 +16,7 @@ import (
 	imagev1 "github.com/tencentcloud/CubeSandbox/CubeMaster/api/services/images/v1"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/constants"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/db/models"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/qos"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/service/sandbox/types"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/templatecenter/image"
 )
@@ -29,6 +30,20 @@ func generateTemplateCreateRequest(req *types.CreateTemplateFromImageReq, artifa
 		constants.CubeAnnotationRootfsArtifactID:           artifact.ArtifactID,
 		constants.CubeAnnotationWritableLayerSize:          req.WritableLayerSize,
 		constants.CubeAnnotationTemplateSpecFingerprint:    artifact.TemplateSpecFingerprint,
+	}
+	qosAnnotation, err := qos.MarshalAnnotation(req.Qos)
+	if err != nil {
+		return nil, err
+	}
+	if qosAnnotation != "" {
+		annotations[constants.CubeAnnotationsNetWork] = qosAnnotation
+	}
+	blockIOAnnotation, err := qos.MarshalBlockIOAnnotation(blockIOConfig(req.Qos))
+	if err != nil {
+		return nil, err
+	}
+	if blockIOAnnotation != "" {
+		annotations[constants.CubeAnnotationsBlkQos] = blockIOAnnotation
 	}
 	if ShouldInjectEnvdIntoTemplate(req) {
 		annotations[constants.CubeAnnotationsInjectEnvd] = constants.CubeAnnotationsInjectEnvdOptIn
@@ -131,6 +146,13 @@ func generateTemplateCreateRequest(req *types.CreateTemplateFromImageReq, artifa
 		NetworkType:       req.NetworkType,
 		CubeNetworkConfig: cloneCubeNetworkConfig(req.CubeNetworkConfig),
 	}, nil
+}
+
+func blockIOConfig(config *qos.Config) *qos.BlockIOConfig {
+	if config == nil {
+		return nil
+	}
+	return config.BlockIO
 }
 
 func cloneCubeNetworkConfig(in *types.CubeNetworkConfig) *types.CubeNetworkConfig {

--- a/Cubelet/network/plugin_tap.go
+++ b/Cubelet/network/plugin_tap.go
@@ -225,11 +225,12 @@ func (l *local) Create(ctx context.Context, opts *workflow.CreateContext) (err e
 }
 
 func decodeNetRequest(raw string) (*NetRequest, error) {
-	req := &NetRequest{}
-	if raw != "" {
-		if err := utils.Decode(raw, req); err != nil {
-			return nil, ret.Errorf(errorcode.ErrorCode_InvalidParamFormat, "decode network params failed: %+v, raw: %s", err, raw)
-		}
+	if raw == "" {
+		return &NetRequest{}, nil
+	}
+	req, err := DecodeNetRequest(raw)
+	if err != nil {
+		return nil, ret.Errorf(errorcode.ErrorCode_InvalidParamFormat, "decode network params failed: %+v", err)
 	}
 	return req, nil
 }

--- a/Cubelet/network/plugin_tap_create_test.go
+++ b/Cubelet/network/plugin_tap_create_test.go
@@ -326,6 +326,34 @@ func TestTapCreateWithNetworkRuntimeAddsDNSAllowOutCIDRsForDomainAllow(t *testin
 	}
 }
 
+func TestTapCreateWithNetworkRuntimeForwardsQosToShim(t *testing.T) {
+	fakeClient := &fakeNetworkRuntime{}
+	l := &local{
+		Config:         &Config{MvmGwDestIP: "169.254.68.5", MVMInnerIP: "169.254.68.6", MvmMask: 30},
+		networkRuntime: fakeClient,
+	}
+	opts := &workflow.CreateContext{
+		BaseWorkflowInfo: workflow.BaseWorkflowInfo{SandboxID: "sandbox-qos"},
+		ReqInfo: &cubebox.RunCubeSandboxRequest{
+			RequestID: "qos-request",
+			Annotations: map[string]string{
+				"cube.master.net": `{"Version":1,"Qos":{"BandWidth":{"Size":1250000,"RefillTime":100},"OPS":{"Size":5000,"RefillTime":1000}}}`,
+			},
+		},
+	}
+	if err := l.Create(context.Background(), opts); err != nil {
+		t.Fatalf("Create returned error: %v", err)
+	}
+	shimReq, ok := opts.NetworkInfo.(*networktypes.ShimNetReq)
+	if !ok || shimReq == nil || len(shimReq.Interfaces) != 1 || shimReq.Interfaces[0].Qos == nil {
+		t.Fatalf("shim request missing qos: %#v", opts.NetworkInfo)
+	}
+	got := shimReq.Interfaces[0].Qos
+	if got.BwSize != 1250000 || got.BwRefillTime != 100 || got.OpsSize != 5000 || got.OpsRefillTime != 1000 {
+		t.Fatalf("shim qos=%+v, want bandwidth and packet buckets", got)
+	}
+}
+
 func TestWaitForNetworkRuntimeReadyReturnsHealthError(t *testing.T) {
 	fakeClient := &fakeNetworkRuntime{
 		healthErrs: []error{errors.New("runtime not ready")},

--- a/Cubelet/network/types/network.go
+++ b/Cubelet/network/types/network.go
@@ -5,8 +5,12 @@
 package types
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
 	"net"
 
 	"github.com/containerd/containerd/v2/pkg/oci"
@@ -115,20 +119,129 @@ func (r *ShimNetReq) OCISpecOpts() oci.SpecOpts {
 }
 
 type NetRequest struct {
-	Mode    string
-	Qos     *NetQosConfig
-	Version uint64
+	Mode    string        `json:"Mode,omitempty"`
+	Qos     *NetQosConfig `json:"Qos"`
+	Version uint64        `json:"Version,omitempty"`
+}
+
+func (req *NetRequest) Validate() error {
+	if req == nil {
+		return errors.New("network request is nil")
+	}
+	if req.Version > 1 {
+		return fmt.Errorf("unsupported network request version %d", req.Version)
+	}
+	if req.Version == 1 && req.Mode != "" {
+		return fmt.Errorf("unsupported network request mode %q", req.Mode)
+	}
+	if req.Qos == nil {
+		if req.Version == 0 {
+			return nil
+		}
+		return errors.New("network request version 1 requires Qos")
+	}
+	bandwidthEnabled, err := req.Qos.BandWidth.validate("Qos.BandWidth")
+	if err != nil {
+		return err
+	}
+	opsEnabled, err := req.Qos.OPS.validate("Qos.OPS")
+	if err != nil {
+		return err
+	}
+	if req.Version == 1 && !bandwidthEnabled && !opsEnabled {
+		return errors.New("network request must enable BandWidth or OPS")
+	}
+	return nil
 }
 
 type NetQosConfig struct {
-	BandWidth LimiterConfig
-	OPS       LimiterConfig
+	BandWidth LimiterConfig `json:"BandWidth"`
+	OPS       LimiterConfig `json:"OPS"`
 }
 
 type LimiterConfig struct {
-	Size         int
-	OneTimeBurst int
-	RefillTime   int
+	Size         int `json:"Size"`
+	OneTimeBurst int `json:"OneTimeBurst"`
+	RefillTime   int `json:"RefillTime"`
+}
+
+func (c LimiterConfig) validate(path string) (bool, error) {
+	if c.Size < 0 || c.OneTimeBurst < 0 || c.RefillTime < 0 {
+		return false, fmt.Errorf("%s values must not be negative", path)
+	}
+	if c.Size == 0 && c.OneTimeBurst == 0 && c.RefillTime == 0 {
+		return false, nil
+	}
+	if c.Size == 0 || c.RefillTime == 0 {
+		return false, fmt.Errorf("%s requires positive Size and RefillTime", path)
+	}
+	return true, nil
+}
+
+func DecodeNetRequest(raw string) (*NetRequest, error) {
+	request := &NetRequest{}
+	if err := json.Unmarshal([]byte(raw), request); err != nil {
+		return nil, err
+	}
+	if request.Version == 0 {
+		if err := request.Validate(); err != nil {
+			return nil, err
+		}
+		return request, nil
+	}
+	if request.Version > 1 {
+		return nil, fmt.Errorf("unsupported network request version %d", request.Version)
+	}
+
+	var top map[string]json.RawMessage
+	if err := decodeStrictJSONObject([]byte(raw), &top, "Mode", "Qos", "Version"); err != nil {
+		return nil, err
+	}
+	qosRaw, ok := top["Qos"]
+	if !ok {
+		return nil, errors.New("network request requires Qos")
+	}
+	var qosObject map[string]json.RawMessage
+	if err := decodeStrictJSONObject(qosRaw, &qosObject, "BandWidth", "OPS"); err != nil {
+		return nil, fmt.Errorf("decode Qos: %w", err)
+	}
+	for name, bucketRaw := range qosObject {
+		var bucket map[string]json.RawMessage
+		if err := decodeStrictJSONObject(bucketRaw, &bucket, "Size", "OneTimeBurst", "RefillTime"); err != nil {
+			return nil, fmt.Errorf("decode Qos.%s: %w", name, err)
+		}
+	}
+	request = &NetRequest{}
+	if err := json.Unmarshal([]byte(raw), request); err != nil {
+		return nil, err
+	}
+	if err := request.Validate(); err != nil {
+		return nil, err
+	}
+	return request, nil
+}
+
+func decodeStrictJSONObject(data []byte, out *map[string]json.RawMessage, allowed ...string) error {
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	if err := decoder.Decode(out); err != nil {
+		return err
+	}
+	if err := decoder.Decode(&struct{}{}); err != io.EOF {
+		if err == nil {
+			return errors.New("unexpected trailing JSON value")
+		}
+		return err
+	}
+	allowedKeys := make(map[string]struct{}, len(allowed))
+	for _, key := range allowed {
+		allowedKeys[key] = struct{}{}
+	}
+	for key := range *out {
+		if _, ok := allowedKeys[key]; !ok {
+			return fmt.Errorf("unknown field %q", key)
+		}
+	}
+	return nil
 }
 
 type PortMapping struct {

--- a/Cubelet/network/types/network_test.go
+++ b/Cubelet/network/types/network_test.go
@@ -6,6 +6,7 @@ package types
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/tencentcloud/CubeSandbox/Cubelet/pkg/constants"
@@ -39,4 +40,75 @@ func TestNetworkRequest(t *testing.T) {
 	}
 
 	t.Log(string(data))
+}
+
+func TestDecodeNetRequestValidatesCanonicalQos(t *testing.T) {
+	req, err := DecodeNetRequest(`{"Qos":{"BandWidth":{"Size":1250000,"OneTimeBurst":0,"RefillTime":100},"OPS":{"Size":5000,"OneTimeBurst":0,"RefillTime":1000}},"Version":1}`)
+	if err != nil {
+		t.Fatalf("DecodeNetRequest error=%v", err)
+	}
+	if req.Qos == nil || req.Qos.BandWidth.Size != 1250000 || req.Qos.OPS.Size != 5000 || req.Qos.OPS.RefillTime != 1000 {
+		t.Fatalf("request=%+v", req)
+	}
+}
+
+func TestDecodeNetRequestAcceptsPacketsOnlyQos(t *testing.T) {
+	req, err := DecodeNetRequest(`{"Qos":{"BandWidth":{},"OPS":{"Size":5000,"RefillTime":1000}},"Version":1}`)
+	if err != nil {
+		t.Fatalf("DecodeNetRequest error=%v", err)
+	}
+	if req.Qos == nil || req.Qos.BandWidth.Size != 0 || req.Qos.OPS.Size != 5000 {
+		t.Fatalf("request=%+v", req)
+	}
+}
+
+func TestDecodeNetRequestAcceptsLegacyVersionZero(t *testing.T) {
+	_, err := DecodeNetRequest(`{"Qos":{"BandWidth":{"Size":1250000,"RefillTime":100}}}`)
+	if err != nil {
+		t.Fatalf("DecodeNetRequest error=%v", err)
+	}
+}
+
+func TestDecodeNetRequestPreservesLegacyNoOpPayloads(t *testing.T) {
+	for _, raw := range []string{
+		`{}`,
+		`{"Mode":"legacy","Extension":true}`,
+		`{"Qos":{"Bandwidth":{"Size":1250000,"RefillTime":100}}}`,
+	} {
+		if _, err := DecodeNetRequest(raw); err != nil {
+			t.Fatalf("DecodeNetRequest(%s) error=%v", raw, err)
+		}
+	}
+}
+
+func TestDecodeNetRequestRejectsUnknownOrMisCasedFields(t *testing.T) {
+	_, err := DecodeNetRequest(`{"Qos":{"Bandwidth":{"Size":1250000,"RefillTime":100}},"Version":1}`)
+	if err == nil || !strings.Contains(err.Error(), "Bandwidth") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestDecodeNetRequestRejectsInvalidBuckets(t *testing.T) {
+	tests := []string{
+		`{"Qos":{"BandWidth":{"Size":-1,"RefillTime":100}},"Version":1}`,
+		`{"Qos":{"BandWidth":{"Size":1250000,"RefillTime":0}},"Version":1}`,
+		`{"Qos":{"BandWidth":{},"OPS":{"Size":5000,"RefillTime":0}},"Version":1}`,
+		`{"Qos":{"BandWidth":{},"OPS":{}},"Version":1}`,
+	}
+	for _, raw := range tests {
+		if _, err := DecodeNetRequest(raw); err == nil {
+			t.Fatalf("expected invalid bucket error for %s", raw)
+		}
+	}
+}
+
+func TestDecodeNetRequestRejectsUnsupportedVersionAndMode(t *testing.T) {
+	for _, raw := range []string{
+		`{"Qos":{"BandWidth":{"Size":1250000,"RefillTime":100}},"Version":2}`,
+		`{"Mode":"legacy","Qos":{"BandWidth":{"Size":1250000,"RefillTime":100}},"Version":1}`,
+	} {
+		if _, err := DecodeNetRequest(raw); err == nil {
+			t.Fatalf("expected request rejection for %s", raw)
+		}
+	}
 }

--- a/Cubelet/plugins/workflow/request_param_qos_test.go
+++ b/Cubelet/plugins/workflow/request_param_qos_test.go
@@ -1,0 +1,30 @@
+package workflow
+
+import (
+	"testing"
+
+	api "github.com/tencentcloud/CubeSandbox/Cubelet/api/services/cubebox/v1"
+	"github.com/tencentcloud/CubeSandbox/Cubelet/pkg/constants"
+)
+
+func TestGetQosFromReqDecodesTemplateBlockIOLimits(t *testing.T) {
+	req := &api.RunCubeSandboxRequest{Annotations: map[string]string{
+		constants.MasterAnnotationsBlkQos: `{"bandwidth":{"size":67108864,"refill_time":1000},"ops":{"size":1000,"refill_time":1000}}`,
+	}}
+
+	got, err := GetQosFromReq(req, constants.MasterAnnotationsBlkQos)
+	if err != nil {
+		t.Fatalf("GetQosFromReq error=%v", err)
+	}
+	if got == nil || got.Bandwidth == nil || got.Ops == nil {
+		t.Fatalf("disk qos=%+v, want bandwidth and ops buckets", got)
+	}
+	if got.Bandwidth.Size == nil || *got.Bandwidth.Size != 67108864 ||
+		got.Bandwidth.RefillTime == nil || *got.Bandwidth.RefillTime != 1000 {
+		t.Fatalf("bandwidth bucket=%+v, want 64 MiB/s", got.Bandwidth)
+	}
+	if got.Ops.Size == nil || *got.Ops.Size != 1000 ||
+		got.Ops.RefillTime == nil || *got.Ops.RefillTime != 1000 {
+		t.Fatalf("ops bucket=%+v, want 1000 IOPS", got.Ops)
+	}
+}

--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -143,6 +143,7 @@ export default withMermaid(defineConfig({
               items: [
                 { text: 'Roadmap', link: '/guide/roadmap' },
                 { text: 'Sandbox Lifecycle', link: '/guide/lifecycle' },
+                { text: 'Sandbox QoS', link: '/guide/qos' },
                 { text: 'Templates Overview', link: '/guide/templates' },
                 { text: 'Snapshot, Rollback & Clone', link: '/guide/snapshot-rollback-clone' },
                 { text: 'Digital Assistant', link: '/guide/digital-assistant' },
@@ -298,6 +299,7 @@ export default withMermaid(defineConfig({
               items: [
                 { text: '路线图', link: '/zh/guide/roadmap' },
                 { text: '沙箱生命周期', link: '/zh/guide/lifecycle' },
+                { text: '沙箱 QoS', link: '/zh/guide/qos' },
                 { text: '模板概览', link: '/zh/guide/templates' },
                 { text: '快照、回滚与克隆', link: '/zh/guide/snapshot-rollback-clone' },
                 { text: '数字助手', link: '/zh/guide/digital-assistant' },

--- a/docs/guide/qos.md
+++ b/docs/guide/qos.md
@@ -1,0 +1,270 @@
+# QoS
+
+Quality of Service (QoS) limits the network and block I/O consumption of an individual sandbox. In the current release, the feature is disabled by default and can only be configured when creating a template. The configured limits apply independently to every sandbox created from the template.
+
+Network QoS only affects traffic rate and does not change which destinations a sandbox can reach. Block I/O QoS limits each sandbox block device without changing filesystem capacity or permissions.
+
+## How it works
+
+The QoS configuration flows from the template into the sandbox runtime, where CubeShim enforces it in the virtio-net and virtio-blk data paths:
+
+```mermaid
+flowchart LR
+    A[Template network or blockIo limits] --> B[CubeMaster template runtime config]
+    B --> C[Cubelet device requests]
+    C --> D[CubeShim]
+    D --> E[Per-sandbox virtio-net and virtio-blk]
+```
+
+Network QoS rate-limits two directions independently for each sandbox: upload from the sandbox to the external network, and download from the external network to the sandbox. The configured bandwidth and packet-processing rate ceilings apply separately to upload and download.
+
+Block I/O QoS rate-limits each virtio-blk device independently. Reads and writes on the same device share the configured throughput and operation-rate buckets; the limits are not divided into separate read and write ceilings.
+
+```mermaid
+flowchart LR
+    A[Refill throughput or operation credit] --> B[Available credit]
+    B -->|Enough credit| C[Consume credit for bytes or an operation]
+    B -->|Insufficient credit| D[Wait for refill]
+    D --> B
+```
+
+The underlying limiters use separate Token Buckets for throughput and operations. The throughput bucket consumes credit according to the number of bytes processed, while the operations bucket consumes credit for each operation. Credit is replenished at a fixed rate. Available credit permits short bursts; after the credit is exhausted, work waits for a refill. Short benchmarks may therefore exceed the configured value temporarily, while the average rate of a sustained test should remain close to the ceiling. The platform selects bucket capacity and refill behavior automatically; users only set the public limits.
+
+QoS is runtime configuration and does not modify the template rootfs. Templates with identical filesystem inputs but different QoS settings can still reuse the same rootfs artifact.
+
+## Configuration semantics
+
+Users can configure network limits, block I/O limits, or both:
+
+```json
+{
+  "network": {
+    "bandwidthMbps": 100,
+    "packetsPerSecond": 5000
+  },
+  "blockIo": {
+    "throughputMiBps": 64,
+    "iops": 1000
+  }
+}
+```
+
+At least one of `bandwidthMbps` and `packetsPerSecond` must be configured with an integer greater than zero in `network`. `bandwidthMbps` limits each sandbox to approximately the configured megabits per second, while `packetsPerSecond` limits virtio-net packet-processing operations per second. With segmentation or other offloads enabled, one operation can represent multiple wire packets, so the observed wire PPS can differ from the configured value. Upload and download use independent credit, and different sandboxes do not share credit.
+
+At least one of `throughputMiBps` and `iops` must be configured in `blockIo`. `throughputMiBps` limits sustained block-device throughput in mebibytes per second, while `iops` limits block I/O operations per second. The same limits are applied independently to every virtio-blk device attached to the sandbox, and each device maintains its own credit.
+
+The current release only supports configuring QoS when creating a template. Every sandbox created from that template receives the same limits, and sandbox creation cannot set or override QoS independently. A template without `qos` does not apply the network or block I/O limits described on this page.
+
+## Scope and limitations
+
+`bandwidthMbps` only limits the maximum network rate of an individual sandbox. Node-wide, tenant-wide, and NAT egress capacity are still determined by the underlying infrastructure. If the demand from active sandboxes exceeds the physical link capacity, the sandboxes will still compete for bandwidth.
+
+Upload and download currently use the same configured bandwidth and packet-processing rate values; separate ceilings for the two directions are not supported. Block I/O limits are not separate for reads and writes. QoS also does not provide priority, guaranteed minimum throughput, or weighted scheduling.
+
+## Configure a template
+
+Set the limits through `--qos` or the CubeAPI request body when creating a template. The following examples configure network ceilings of 100 Mbps and 5,000 packet-processing operations/s, plus block I/O ceilings of 64 MiB/s and 1,000 IOPS.
+
+### CLI inline JSON
+
+```bash
+cubemastercli tpl create-from-image \
+  --image cube-sandbox-int.tencentcloudcr.com/cube-sandbox/sandbox-code:latest \
+  --writable-layer-size 1G \
+  --qos '{"network":{"bandwidthMbps":100,"packetsPerSecond":5000},"blockIo":{"throughputMiBps":64,"iops":1000}}'
+```
+
+In mainland China, use `cube-sandbox-cn.tencentcloudcr.com/cube-sandbox/sandbox-code:latest`.
+
+### CLI JSON file
+
+The configuration can also be stored in `qos.json`:
+
+```json
+{
+  "network": {
+    "bandwidthMbps": 100,
+    "packetsPerSecond": 5000
+  },
+  "blockIo": {
+    "throughputMiBps": 64,
+    "iops": 1000
+  }
+}
+```
+
+Use the `@` prefix to read the file when creating the template:
+
+```bash
+cubemastercli tpl create-from-image \
+  --image cube-sandbox-int.tencentcloudcr.com/cube-sandbox/sandbox-code:latest \
+  --writable-layer-size 1G \
+  --qos @qos.json
+```
+
+### CubeAPI
+
+Pass the same `qos` object in the CubeAPI template creation request:
+
+```http
+POST /cubeapi/v1/templates
+Content-Type: application/json
+```
+
+```json
+{
+  "image": "cube-sandbox-int.tencentcloudcr.com/cube-sandbox/sandbox-code:latest",
+  "writableLayerSize": "1G",
+  "qos": {
+    "network": {
+      "bandwidthMbps": 100,
+      "packetsPerSecond": 5000
+    },
+    "blockIo": {
+      "throughputMiBps": 64,
+      "iops": 1000
+    }
+  }
+}
+```
+
+CubeMaster validates `qos` before creating the template. Each configured section must contain at least one positive integer limit. Explicit zero values, negative or non-integer values, empty sections, and unknown fields are rejected.
+
+## Inspect configuration and applied state
+
+### Inspect template configuration
+
+Use the CLI to inspect a template:
+
+```bash
+cubemastercli tpl info <template-id>
+```
+
+The corresponding CubeAPI endpoint is `GET /cubeapi/v1/templates/<template-id>`. A template with QoS configured returns:
+
+```json
+{
+  "configuredQos": {
+    "network": {
+      "bandwidthMbps": 100,
+      "packetsPerSecond": 5000
+    },
+    "blockIo": {
+      "throughputMiBps": 64,
+      "iops": 1000
+    }
+  }
+}
+```
+
+### Inspect sandbox state
+
+Use the CLI to inspect a sandbox:
+
+```bash
+cubemastercli cubebox info --sandboxid <sandbox-id>
+```
+
+The CLI displays `NETWORK_QOS`, `BLOCK_IO_QOS`, and `QOS_APPLIED`. The CubeAPI endpoint `GET /cubeapi/v1/sandboxes/<sandbox-id>` returns the corresponding `configuredQos` and `qosApplied` fields:
+
+```json
+{
+  "configuredQos": {
+    "network": {
+      "bandwidthMbps": 100,
+      "packetsPerSecond": 5000
+    },
+    "blockIo": {
+      "throughputMiBps": 64,
+      "iops": 1000
+    }
+  },
+  "qosApplied": true
+}
+```
+
+`configuredQos` is the QoS configuration expected from the template, while `qosApplied` indicates whether the sandbox runtime record contains at least one QoS annotation. It is an aggregate state and does not prove that every configured network and block I/O limiter reached the hypervisor. A normally created QoS sandbox should return `qosApplied=true`. If only `configuredQos` is present, investigate legacy data or a missing runtime record.
+
+### Troubleshoot network QoS on the node
+
+On the node hosting the sandbox, query network-agent for `persistMetadata.qos_enabled`:
+
+```bash
+curl -sS -X POST \
+  --unix-socket /tmp/cube/network-agent.sock \
+  -H 'Content-Type: application/json' \
+  -d '{"sandboxID":"<sandbox-id>"}' \
+  http://localhost/v1/network/get | jq '.persistMetadata.qos_enabled'
+```
+
+This metadata records that network QoS was included in the sandbox network setup request. It does not report block I/O QoS and is not part of the public API.
+
+## Verify with iperf3
+
+Create a template with network QoS, wait until the template reaches `READY`, and then create the sandbox under test from that template. Run the following client commands inside that sandbox.
+
+iperf3 is not guaranteed to be installed on the server or in the sandbox image. Run `iperf3 --version` on both ends before testing. If the command is unavailable, install it with the package manager used by the operating system or image. For Debian or Ubuntu:
+
+```bash
+apt-get update
+apt-get install -y iperf3
+```
+
+Start the server on a machine reachable from the sandbox:
+
+```bash
+iperf3 -s -p 5201
+```
+
+Confirm that the sandbox can reach the server IP and that the server firewall allows the selected TCP port. Resolve connectivity failures before using the result to evaluate network QoS.
+
+Test upload and download separately:
+
+```bash
+# Sandbox upload to the server
+iperf3 -c <server-ip> -p 5201 -t 10 -O 3 -P 4
+
+# Sandbox download from the server
+iperf3 -c <server-ip> -p 5201 -t 10 -O 3 -P 4 -R
+```
+
+Protocol overhead, short Token Bucket bursts, and the measurement window can affect the result. A 100 Mbps setting should normally measure close to 100 Mbps, but it does not need to be exact.
+
+A template response containing `configuredQos` only confirms that the configuration was saved. Confirm bandwidth enforcement by checking that the sandbox returns `qosApplied=true` and that sustained upload and download tests remain close to the configured bandwidth ceiling. `iperf3` does not directly measure packet-processing operations per second; validate a PPS-only setting with a fixed-size packet workload, a packet counter on the test endpoint, and awareness that offloads can make wire PPS differ from the configured operation rate.
+
+### Verify concurrent sandbox bandwidth limits
+
+A single iperf3 server process normally handles one test at a time. Multiple clients connecting to the same server port may be processed serially and will not represent concurrent bandwidth usage. Start a separate server port for each sandbox:
+
+```bash
+for port in 5301 5302 5303 5304 5305; do
+  iperf3 -s -p "$port" -D
+done
+```
+
+Start the sandbox clients at the same time and assign them ports 5301 through 5305. If the template ceiling is 100 Mbps and the host and network have sufficient capacity, five sandboxes should each remain close to 100 Mbps, with aggregate throughput close to 500 Mbps.
+
+The sum of the configured bandwidth ceilings must remain below the test link capacity. Otherwise, shared-link contention also affects the results, and a sandbox measuring below its configured ceiling does not by itself indicate that the bandwidth limiter is malfunctioning.
+
+## Verify block I/O with fio
+
+Create a template with block I/O QoS, wait until the template reaches `READY`, and then create the sandbox under test from that template.
+
+fio is not guaranteed to be installed in the sandbox image. Run `fio --version` before testing and install it with the package manager used by the image if necessary. For Debian or Ubuntu, run `apt-get update && apt-get install -y fio`.
+
+Run `lsblk` inside the sandbox and select a writable virtio-blk filesystem. Do not run a destructive raw-device test against the root device. The following file-based commands use `/tmp/qos-fio` and bypass the guest page cache:
+
+```bash
+# Sustained sequential write throughput
+fio --name=block-qos-bw --filename=/tmp/qos-fio \
+  --size=1G --rw=write --bs=1M --direct=1 --runtime=30 --time_based
+
+# Random-read IOPS
+fio --name=block-qos-iops --filename=/tmp/qos-fio \
+  --size=1G --rw=randread --bs=4k --direct=1 --iodepth=32 \
+  --runtime=30 --time_based
+
+rm -f /tmp/qos-fio
+```
+
+The sustained throughput and IOPS should remain close to the configured ceilings after the initial Token Bucket credit is consumed. Files backed by virtio-fs or memory do not exercise the virtio-blk limiter and are not valid for this test.

--- a/docs/zh/guide/qos.md
+++ b/docs/zh/guide/qos.md
@@ -1,0 +1,268 @@
+# QoS
+
+服务质量（Quality of Service，QoS）用来限制单个沙箱的网络和块设备 I/O 消耗。当前版本中，该功能默认关闭，只能在创建模板时配置。模板中的限制会分别应用到每个沙箱。
+
+网络 QoS 只影响流量速率，不改变沙箱的网络可达范围。块设备 I/O QoS 限制每个沙箱块设备的吞吐量和操作速率，不改变文件系统容量或权限。
+
+## 工作原理
+
+QoS 配置从模板进入沙箱运行时，最后由 CubeShim 在 virtio-net 和 virtio-blk 数据路径中执行：
+
+```mermaid
+flowchart LR
+    A[模板 network 或 blockIo 限制] --> B[CubeMaster 模板运行时配置]
+    B --> C[Cubelet 设备请求]
+    C --> D[CubeShim]
+    D --> E[每个沙箱的 virtio-net 和 virtio-blk]
+```
+
+网络 QoS 会分别限制每个沙箱的两个方向：上传从沙箱发往外部网络，下载从外部网络进入沙箱。配置的带宽上限和数据包处理速率上限会独立应用到上传和下载。
+
+块设备 I/O QoS 会分别限制沙箱中的每个 virtio-blk 设备。同一设备的读取和写入共享配置的吞吐量桶和操作速率桶，不单独设置读写上限。
+
+```mermaid
+flowchart LR
+    A[恢复吞吐量或操作额度] --> B[可用额度]
+    B -->|额度充足| C[按字节数或操作次数扣减额度]
+    B -->|额度不足| D[等待恢复]
+    D --> B
+```
+
+底层分别使用吞吐量和操作速率 Token Bucket。吞吐量桶按处理的字节数扣减额度，操作速率桶每处理一次操作扣减一次额度。额度按固定速率恢复；桶里有余量时允许短时突发，额度耗尽后需要等待恢复。因此，很短的测速可能暂时超过配置值，持续测试的平均速率应接近配置上限。额度大小和恢复速度由平台自动设置，用户只需要填写公开的限制值。
+
+QoS 是运行时配置，不会修改模板的 rootfs。文件系统输入相同时，不同 QoS 配置仍可复用同一份 rootfs artifact。
+
+## 配置语义
+
+用户可以配置网络限制、块设备 I/O 限制，或者同时配置两者：
+
+```json
+{
+  "network": {
+    "bandwidthMbps": 100,
+    "packetsPerSecond": 5000
+  },
+  "blockIo": {
+    "throughputMiBps": 64,
+    "iops": 1000
+  }
+}
+```
+
+`network` 中的 `bandwidthMbps` 和 `packetsPerSecond` 至少配置一个，且值必须是大于 0 的整数。`bandwidthMbps` 限制每个沙箱的每秒兆比特数，`packetsPerSecond` 限制每秒 virtio-net 数据包处理操作数。如果启用了分段等卸载功能，一个操作可能对应多个线上数据包，因此实际线上 PPS 可能与配置值不同。上传和下载分别使用独立额度，不同沙箱之间也不共享额度。
+
+`blockIo` 中的 `throughputMiBps` 和 `iops` 至少配置一个。`throughputMiBps` 限制持续块设备吞吐量，单位为 MiB/s；`iops` 限制每秒块设备 I/O 操作数。同一组限制会独立应用到沙箱的每个 virtio-blk 设备，每个设备分别维护自己的额度。
+
+当前版本只支持在创建模板时配置 QoS。使用该模板创建的每个沙箱都会应用相同的限制，创建沙箱时不能单独设置或覆盖 QoS。模板未配置 `qos` 时，不会设置本页介绍的网络或块设备 I/O 限制。
+
+## 使用边界
+
+`bandwidthMbps` 只限制单个沙箱的最大网络速率。节点级、租户级或 NAT 出口的总带宽仍由底层基础设施决定；所有活跃沙箱的需求超过实际链路容量时，沙箱之间仍会竞争带宽。
+
+当前上传和下载使用相同的带宽和数据包处理速率配置，暂不支持分别设置两个方向的上限。块设备 I/O 也不区分读取和写入限制。QoS 不提供优先级、最低保障吞吐量或权重调度。
+
+## 配置模板
+
+创建模板时通过 `--qos` 或 CubeAPI 请求体设置限制。下面示例配置了每个沙箱上传、下载各 100 Mbps 和 5000 个数据包处理操作/秒的上限，同时配置每个块设备 64 MiB/s 和 1000 IOPS 的上限。
+
+### CLI 内联 JSON
+
+```bash
+cubemastercli tpl create-from-image \
+  --image cube-sandbox-cn.tencentcloudcr.com/cube-sandbox/sandbox-code:latest \
+  --writable-layer-size 1G \
+  --qos '{"network":{"bandwidthMbps":100,"packetsPerSecond":5000},"blockIo":{"throughputMiBps":64,"iops":1000}}'
+```
+
+### CLI JSON 文件
+
+也可以把配置保存为 `qos.json`：
+
+```json
+{
+  "network": {
+    "bandwidthMbps": 100,
+    "packetsPerSecond": 5000
+  },
+  "blockIo": {
+    "throughputMiBps": 64,
+    "iops": 1000
+  }
+}
+```
+
+创建模板时使用 `@` 前缀读取文件：
+
+```bash
+cubemastercli tpl create-from-image \
+  --image cube-sandbox-cn.tencentcloudcr.com/cube-sandbox/sandbox-code:latest \
+  --writable-layer-size 1G \
+  --qos @qos.json
+```
+
+### CubeAPI
+
+通过 CubeAPI 创建模板时，在请求中传入同一个 `qos` 对象：
+
+```http
+POST /cubeapi/v1/templates
+Content-Type: application/json
+```
+
+```json
+{
+  "image": "cube-sandbox-cn.tencentcloudcr.com/cube-sandbox/sandbox-code:latest",
+  "writableLayerSize": "1G",
+  "qos": {
+    "network": {
+      "bandwidthMbps": 100,
+      "packetsPerSecond": 5000
+    },
+    "blockIo": {
+      "throughputMiBps": 64,
+      "iops": 1000
+    }
+  }
+}
+```
+
+CubeMaster 会在创建模板前校验 `qos`。每个已配置的部分必须至少包含一个大于 0 的整数限制。显式传入 0、负数、非整数、空配置部分或未知字段时，请求会被拒绝。
+
+## 查看配置与应用状态
+
+### 查看模板配置
+
+使用 CLI 查询模板：
+
+```bash
+cubemastercli tpl info <template-id>
+```
+
+CubeAPI 对应 `GET /cubeapi/v1/templates/<template-id>`。配置了 QoS 的模板会返回：
+
+```json
+{
+  "configuredQos": {
+    "network": {
+      "bandwidthMbps": 100,
+      "packetsPerSecond": 5000
+    },
+    "blockIo": {
+      "throughputMiBps": 64,
+      "iops": 1000
+    }
+  }
+}
+```
+
+### 查看沙箱状态
+
+使用 CLI 查询沙箱：
+
+```bash
+cubemastercli cubebox info --sandboxid <sandbox-id>
+```
+
+CLI 会显示 `NETWORK_QOS`、`BLOCK_IO_QOS` 和 `QOS_APPLIED`。CubeAPI 的 `GET /cubeapi/v1/sandboxes/<sandbox-id>` 返回对应的 `configuredQos` 和 `qosApplied` 字段：
+
+```json
+{
+  "configuredQos": {
+    "network": {
+      "bandwidthMbps": 100,
+      "packetsPerSecond": 5000
+    },
+    "blockIo": {
+      "throughputMiBps": 64,
+      "iops": 1000
+    }
+  },
+  "qosApplied": true
+}
+```
+
+`configuredQos` 表示模板期望使用的 QoS 配置，`qosApplied` 表示沙箱运行时记录中是否至少包含一个 QoS annotation。这是聚合状态，不能证明配置的网络和块设备 I/O limiter 都已传递到 hypervisor。正常创建的 QoS 沙箱应返回 `qosApplied=true`。如果只有 `configuredQos`，需要排查旧数据或运行时记录缺失。
+
+### 节点网络 QoS 排障
+
+在沙箱所在节点上，可以查询 network-agent 的 `persistMetadata.qos_enabled`：
+
+```bash
+curl -sS -X POST \
+  --unix-socket /tmp/cube/network-agent.sock \
+  -H 'Content-Type: application/json' \
+  -d '{"sandboxID":"<sandbox-id>"}' \
+  http://localhost/v1/network/get | jq '.persistMetadata.qos_enabled'
+```
+
+该 metadata 表示沙箱网络初始化请求中已携带网络 QoS。它不反映块设备 I/O QoS，也不属于公开 API。
+
+## 使用 iperf3 验证
+
+先创建带网络 QoS 的模板并等待模板进入 `READY` 状态，再使用该模板创建待测沙箱。下面的客户端命令都在这个沙箱内执行。
+
+iperf3 不一定预装在服务端或沙箱镜像中。测试前先在两端运行 `iperf3 --version`；如果命令不存在，按系统或镜像使用的包管理器安装。例如 Debian/Ubuntu 可以执行：
+
+```bash
+apt-get update
+apt-get install -y iperf3
+```
+
+在沙箱能够访问的机器上启动服务端：
+
+```bash
+iperf3 -s -p 5201
+```
+
+确认沙箱能够访问服务端 IP，并且服务端防火墙已放通所选 TCP 端口。如果连接失败，应先解决连通性问题，再判断网络 QoS 是否生效。
+
+分别测试上传和下载：
+
+```bash
+# 沙箱上传到服务端
+iperf3 -c <server-ip> -p 5201 -t 10 -O 3 -P 4
+
+# 沙箱从服务端下载
+iperf3 -c <server-ip> -p 5201 -t 10 -O 3 -P 4 -R
+```
+
+测试结果会受到协议开销、Token Bucket 短时突发和测量窗口影响。100 Mbps 的配置通常会测得接近 100 Mbps，不要求精确相等。
+
+模板返回 `configuredQos` 只能说明配置已经保存。带宽限速需要确认沙箱返回 `qosApplied=true`，并且持续上传、下载测试接近配置的带宽上限。`iperf3` 不能直接测量数据包处理操作数；如果只配置 PPS，应使用固定大小的数据包工作负载，并在测试端点通过报文计数器验证，同时注意卸载功能可能导致线上 PPS 与配置的操作速率不同。
+
+### 验证多沙箱并发带宽限制
+
+一个 iperf3 server 进程通常一次只处理一个测试。多个客户端连接同一个 server 端口时，测试可能被串行执行，无法反映并发带宽。测试多个沙箱时，为每个沙箱启动独立端口：
+
+```bash
+for port in 5301 5302 5303 5304 5305; do
+  iperf3 -s -p "$port" -D
+done
+```
+
+同时启动沙箱客户端，分别连接 5301 到 5305。如果模板配置为 100 Mbps，并且宿主机和网络容量足够，5 个沙箱应各自接近 100 Mbps，总吞吐接近 500 Mbps。
+
+多沙箱测试还需要保证配置的带宽上限之和不超过测试链路容量。否则，结果会同时受到共享链路竞争影响，不能只根据单个沙箱低于配置上限判断带宽 limiter 是否正常。
+
+## 使用 fio 验证块设备 I/O
+
+先创建带块设备 I/O QoS 的模板并等待模板进入 `READY` 状态，再使用该模板创建待测沙箱。
+
+fio 不一定预装在沙箱镜像中。测试前先运行 `fio --version`；如果命令不存在，按镜像使用的包管理器安装。Debian 或 Ubuntu 可以执行 `apt-get update && apt-get install -y fio`。
+
+先在沙箱中执行 `lsblk`，选择位于可写 virtio-blk 文件系统中的测试目录。不要直接对根块设备执行破坏性测试。下面的命令使用 `/tmp/qos-fio` 文件，并绕过 guest page cache：
+
+```bash
+# 持续顺序写吞吐量
+fio --name=block-qos-bw --filename=/tmp/qos-fio \
+  --size=1G --rw=write --bs=1M --direct=1 --runtime=30 --time_based
+
+# 随机读 IOPS
+fio --name=block-qos-iops --filename=/tmp/qos-fio \
+  --size=1G --rw=randread --bs=4k --direct=1 --iodepth=32 \
+  --runtime=30 --time_based
+
+rm -f /tmp/qos-fio
+```
+
+初始 Token Bucket 额度耗尽后，持续吞吐量和 IOPS 应接近配置上限。virtio-fs 或内存中的文件不会经过 virtio-blk limiter，不能用于这项验证。

--- a/tests/e2e/sdk_compat/README.md
+++ b/tests/e2e/sdk_compat/README.md
@@ -90,6 +90,31 @@ form:
 pytest --run-e2e --sdk-e2e-backends=cubesandbox
 ```
 
+## Template QoS E2E
+
+The QoS cases provision and clean up their own template and sandbox, so selecting this file alone does not require `CUBE_TEMPLATE_ID`. Set `CUBE_TEMPLATE_E2E_IMAGE` to an image that exposes envd on `49983` and responds to `/health` on `49999`.
+
+Run the control/runtime case:
+
+```bash
+CUBE_TEMPLATE_E2E_IMAGE=cube-sandbox-cn.tencentcloudcr.com/cube-sandbox/sandbox-code:latest \
+pytest --run-e2e cases/qos/test_template_qos.py::test_template_qos_control_and_runtime_state
+```
+
+Bandwidth tests require an iperf3 server reachable from the sandbox, and block I/O tests require a writable virtio-blk-backed filesystem. Start `iperf3 -s -p 5201`, set the server IP, and enable the dataplane opt-in:
+
+```bash
+CUBE_TEMPLATE_E2E_IMAGE=cube-sandbox-cn.tencentcloudcr.com/cube-sandbox/sandbox-code:latest \
+CUBE_QOS_IPERF_SERVER=10.0.0.10 \
+CUBE_QOS_DATAPLANE_E2E=1 \
+CUBE_QOS_E2E_INSTALL_TOOLS=1 \
+pytest --run-e2e -m "qos and not qos_node" cases/qos/test_template_qos.py
+```
+
+The pytest runner does not need `iperf3` or `fio`, but the sandbox does. Missing tools cause the affected case to skip unless `CUBE_QOS_E2E_INSTALL_TOOLS=1` is set; use `CUBE_QOS_E2E_INSTALL_COMMAND` to override installation. An IP-literal iperf server is automatically added to `allow_out` for a temporary template. A template reused through `CUBE_QOS_E2E_TEMPLATE_ID` must already allow the server and match the configured `CUBE_QOS_*` limits.
+
+The PPS case must run on the sandbox compute node because it reads the TAP counter. Set `CUBE_QOS_NODE_PPS_E2E=1`, set `CUBE_QOS_IPERF_SERVER` to the node IP reachable from the sandbox, and run `pytest --run-e2e -m qos_node cases/qos/test_template_qos.py`.
+
 ## Execution Scope
 
 Recommended scopes:

--- a/tests/e2e/sdk_compat/README_zh.md
+++ b/tests/e2e/sdk_compat/README_zh.md
@@ -86,6 +86,31 @@ pytest --run-e2e
 pytest --run-e2e --sdk-e2e-backends=cubesandbox
 ```
 
+## 模板 QoS E2E
+
+QoS 用例会自行创建并清理模板和沙箱，因此单独运行该文件时不需要设置 `CUBE_TEMPLATE_ID`。`CUBE_TEMPLATE_E2E_IMAGE` 指定的镜像需要在 `49983` 端口提供 envd，并在 `49999` 端口响应 `/health`。
+
+运行配置与运行时状态用例：
+
+```bash
+CUBE_TEMPLATE_E2E_IMAGE=cube-sandbox-cn.tencentcloudcr.com/cube-sandbox/sandbox-code:latest \
+pytest --run-e2e cases/qos/test_template_qos.py::test_template_qos_control_and_runtime_state
+```
+
+带宽用例需要沙箱能够访问 iperf3 server，块设备 I/O 用例需要可写的 virtio-blk 文件系统。先执行 `iperf3 -s -p 5201`，再设置 server IP 并启用数据面测试：
+
+```bash
+CUBE_TEMPLATE_E2E_IMAGE=cube-sandbox-cn.tencentcloudcr.com/cube-sandbox/sandbox-code:latest \
+CUBE_QOS_IPERF_SERVER=10.0.0.10 \
+CUBE_QOS_DATAPLANE_E2E=1 \
+CUBE_QOS_E2E_INSTALL_TOOLS=1 \
+pytest --run-e2e -m "qos and not qos_node" cases/qos/test_template_qos.py
+```
+
+pytest runner 不需要安装 `iperf3` 或 `fio`，但沙箱中需要。命令缺失时，对应用例会跳过；设置 `CUBE_QOS_E2E_INSTALL_TOOLS=1` 后可以在沙箱内安装，也可以通过 `CUBE_QOS_E2E_INSTALL_COMMAND` 自定义安装命令。临时模板会自动把 IP 形式的 iperf3 server 加入 `allow_out`。通过 `CUBE_QOS_E2E_TEMPLATE_ID` 复用模板时，模板需要提前放通 server，并且 QoS 配置需要与 `CUBE_QOS_*` 环境变量一致。
+
+PPS 用例需要在沙箱所在计算节点运行，因为测试会读取 TAP 计数器。设置 `CUBE_QOS_NODE_PPS_E2E=1`，将 `CUBE_QOS_IPERF_SERVER` 设为沙箱可访问的节点 IP，然后执行 `pytest --run-e2e -m qos_node cases/qos/test_template_qos.py`。
+
 ## 执行范围
 
 ```bash

--- a/tests/e2e/sdk_compat/cases/qos/test_template_qos.py
+++ b/tests/e2e/sdk_compat/cases/qos/test_template_qos.py
@@ -1,0 +1,631 @@
+"""End-to-end tests for template QoS configuration and enforcement.
+
+The control/runtime case runs with the normal SDK compatibility ``--run-e2e`` opt-in. Dataplane cases additionally require ``CUBE_QOS_DATAPLANE_E2E=1`` because they use infrastructure outside CubeAPI:
+
+* bandwidth tests require an iperf3 server reachable from the sandbox; start one with ``iperf3 -s -p 5201`` and set ``CUBE_QOS_IPERF_SERVER``;
+* block I/O tests require a writable virtio-blk-backed filesystem;
+* PPS tests additionally require execution on the compute node so the test can read the sandbox TAP counters.
+
+Set ``CUBE_QOS_E2E_TEMPLATE_ID`` to reuse an existing template. Otherwise the suite creates and cleans up a temporary template using ``CUBE_TEMPLATE_E2E_IMAGE``. For a temporary template, an IP-literal iperf server is automatically included in ``allow_out``. A reused template must already allow the target.
+
+The pytest runner does not need iperf3 or fio. The commands are required inside the sandbox; an affected case is skipped when its command is absent. Set ``CUBE_QOS_E2E_INSTALL_TOOLS=1`` to install missing commands with the image's configured apt or dnf source, or provide ``CUBE_QOS_E2E_INSTALL_COMMAND``.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import json
+import os
+import re
+import shlex
+import shutil
+import socket
+import subprocess
+import sys
+import threading
+import time
+import uuid
+from collections.abc import Iterator
+from concurrent.futures import ThreadPoolExecutor
+from contextlib import contextmanager
+from dataclasses import dataclass
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[5] / "sdk" / "python"))
+
+import pytest
+import requests
+
+from cubesandbox import Config, Sandbox, Template
+from cubesandbox._config import _auth_headers
+from cubesandbox._exceptions import ApiError, SandboxNotFoundError, TemplateNotFoundError
+
+pytestmark = [
+    pytest.mark.e2e,
+    pytest.mark.sdk_compat,
+    pytest.mark.qos,
+    pytest.mark.p2,
+    pytest.mark.slow,
+    pytest.mark.self_managed_template,
+]
+
+
+@dataclass
+class QosEnvironment:
+    sandbox: Sandbox
+    qos: dict
+
+
+def _positive_int(name: str, default: int) -> int:
+    raw = os.environ.get(name)
+    value = int(raw) if raw is not None else default
+    if value <= 0:
+        pytest.fail(f"{name} must be a positive integer")
+    return value
+
+
+def _positive_float(name: str, default: float) -> float:
+    raw = os.environ.get(name)
+    value = float(raw) if raw is not None else default
+    if value <= 0:
+        pytest.fail(f"{name} must be positive")
+    return value
+
+
+def _require_qos_dataplane() -> None:
+    if os.environ.get("CUBE_QOS_DATAPLANE_E2E") != "1":
+        pytest.skip("set CUBE_QOS_DATAPLANE_E2E=1 to measure live QoS enforcement")
+
+
+def _qos() -> dict:
+    return {
+        "network": {
+            "bandwidthMbps": _positive_int("CUBE_QOS_BANDWIDTH_MBPS", 100),
+        },
+        "blockIo": {
+            "throughputMiBps": _positive_int("CUBE_QOS_BLOCK_THROUGHPUT_MIBPS", 32),
+            "iops": _positive_int("CUBE_QOS_BLOCK_IOPS", 1000),
+        },
+    }
+
+
+def _template_raw(config: Config, template_id: str) -> dict:
+    response = requests.get(
+        f"{config.api_url}/templates/{template_id}",
+        headers=_auth_headers(config),
+        timeout=30,
+    )
+    response.raise_for_status()
+    return response.json()
+
+
+def _server_allow_out(server: str | None) -> list[str] | None:
+    if server is None:
+        return None
+    try:
+        address = ipaddress.ip_address(server)
+    except ValueError:
+        return None
+    prefix = 32 if address.version == 4 else 128
+    return [f"{address}/{prefix}"]
+
+
+def _wait_template_ready(config: Config, template_id: str, timeout: float = 600) -> None:
+    deadline = time.monotonic() + timeout
+    last_status = "not found"
+    while time.monotonic() < deadline:
+        try:
+            detail = Template.get(template_id, config=config)
+            last_status = detail.status
+            if detail.status == "READY":
+                return
+            if detail.status == "FAILED":
+                pytest.fail(f"QoS template {template_id} build failed: {detail.last_error}")
+        except TemplateNotFoundError:
+            pass
+        time.sleep(2)
+    pytest.fail(f"QoS template {template_id} did not become READY; last status: {last_status}")
+
+
+def _run(sandbox: Sandbox, command: str, timeout: float) -> str:
+    result = sandbox.commands.run(command, timeout=timeout)
+    assert result.exit_code == 0, (
+        f"sandbox command failed with exit code {result.exit_code}: {command}\n"
+        f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )
+    return result.stdout
+
+
+def _require_command(sandbox: Sandbox, command: str) -> None:
+    probe = sandbox.commands.run(f"command -v {shlex.quote(command)}", timeout=30)
+    if probe.exit_code == 0:
+        return
+    if os.environ.get("CUBE_QOS_E2E_INSTALL_TOOLS") != "1":
+        pytest.skip(
+            f"{command} is not installed in the sandbox image; preinstall it or set "
+            "CUBE_QOS_E2E_INSTALL_TOOLS=1 to use the image's configured package source"
+        )
+
+    install = os.environ.get("CUBE_QOS_E2E_INSTALL_COMMAND")
+    if install is None:
+        install = (
+            f"if command -v apt-get >/dev/null; then "
+            f"DEBIAN_FRONTEND=noninteractive apt-get update && "
+            f"DEBIAN_FRONTEND=noninteractive apt-get install -y {shlex.quote(command)}; "
+            f"elif command -v dnf >/dev/null; then dnf -y install {shlex.quote(command)}; "
+            f"else exit 127; fi"
+        )
+    _run(sandbox, install, timeout=300)
+    _run(sandbox, f"command -v {shlex.quote(command)}", timeout=30)
+
+
+@contextmanager
+def _provision_qos_environment(
+    config: Config,
+    expected_qos: dict,
+    *,
+    template_id: str | None,
+    allow_out: list[str] | None,
+    name_prefix: str,
+) -> Iterator[QosEnvironment]:
+    created_template = False
+    sandbox: Sandbox | None = None
+
+    if template_id is None:
+        image = os.environ.get("CUBE_TEMPLATE_E2E_IMAGE")
+        if image is None:
+            pytest.skip(
+                "set CUBE_QOS_E2E_TEMPLATE_ID to reuse a QoS template, or set "
+                "CUBE_TEMPLATE_E2E_IMAGE so the test can create one"
+            )
+        job = Template.build(
+            name=f"{name_prefix}-{uuid.uuid4().hex[:8]}",
+            image=image,
+            writable_layer_size=os.environ.get("CUBE_TEMPLATE_E2E_WRITABLE_LAYER_SIZE", "1G"),
+            exposed_ports=[49983, 49999],
+            probe_port=49999,
+            probe_path="/health",
+            nodes=[node] if (node := os.environ.get("CUBE_TEMPLATE_E2E_NODE")) else None,
+            allow_internet_access=True,
+            allow_out=allow_out,
+            qos=expected_qos,
+            config=config,
+        )
+        template_id = job.template_id
+        created_template = True
+
+    try:
+        _wait_template_ready(config, template_id)
+        actual_qos = _template_raw(config, template_id).get("configuredQos")
+        if actual_qos != expected_qos:
+            pytest.fail(
+                f"template {template_id} configuredQos is {actual_qos!r}; "
+                f"expected {expected_qos!r}. Set the CUBE_QOS_* limits to match "
+                "a reused template."
+            )
+
+        sandbox = Sandbox.create(template=template_id, timeout=600, config=config)
+        detail = sandbox.get_info()
+        assert detail.get("configuredQos") == expected_qos
+        assert detail.get("qosApplied") is True
+        _run(sandbox, "printf qos-dataplane-ready", timeout=30)
+        yield QosEnvironment(sandbox=sandbox, qos=expected_qos)
+    finally:
+        if sandbox is not None:
+            try:
+                sandbox.kill()
+            except (ApiError, SandboxNotFoundError, OSError):
+                pass
+        if created_template and template_id is not None:
+            try:
+                Template.delete(template_id, config=config)
+            except (ApiError, TemplateNotFoundError):
+                pass
+
+
+def test_template_qos_control_and_runtime_state(sdk_e2e_config) -> None:
+    expected_qos = {
+        "network": {"bandwidthMbps": 100, "packetsPerSecond": 1000},
+        "blockIo": {"throughputMiBps": 32, "iops": 1000},
+    }
+    config = Config(api_url=sdk_e2e_config.cube_api_url)
+    with _provision_qos_environment(
+        config,
+        expected_qos,
+        template_id=os.environ.get("CUBE_QOS_CONTROL_TEMPLATE_ID"),
+        allow_out=None,
+        name_prefix="e2e-qos-control",
+    ):
+        pass
+
+
+@pytest.fixture(scope="module")
+def qos_environment(sdk_e2e_config) -> Iterator[QosEnvironment]:
+    _require_qos_dataplane()
+    server = os.environ.get("CUBE_QOS_IPERF_SERVER")
+    template_id = os.environ.get("CUBE_QOS_E2E_TEMPLATE_ID")
+    config = Config(api_url=sdk_e2e_config.cube_api_url)
+    with _provision_qos_environment(
+        config,
+        _qos(),
+        template_id=template_id,
+        allow_out=_server_allow_out(server),
+        name_prefix="e2e-qos-dataplane",
+    ) as environment:
+        yield environment
+
+
+@pytest.fixture(scope="module")
+def iperf_server() -> tuple[str, int]:
+    server = os.environ.get("CUBE_QOS_IPERF_SERVER")
+    if server is None:
+        pytest.skip("set CUBE_QOS_IPERF_SERVER for bandwidth tests")
+    return server, _positive_int("CUBE_QOS_IPERF_PORT", 5201)
+
+
+def _iperf_result(
+    sandbox: Sandbox,
+    server: str,
+    port: int,
+    *,
+    reverse: bool,
+) -> tuple[float, float]:
+    duration = _positive_int("CUBE_QOS_IPERF_DURATION", 15)
+    omit = _positive_int("CUBE_QOS_IPERF_OMIT", 3)
+    streams = _positive_int("CUBE_QOS_IPERF_STREAMS", 4)
+    parts = [
+        "iperf3",
+        "-c",
+        server,
+        "-p",
+        str(port),
+        "-t",
+        str(duration),
+        "-O",
+        str(omit),
+        "-J",
+    ]
+    if reverse:
+        parts.append("-R")
+    parts.extend(["-P", str(streams)])
+
+    command = " ".join(shlex.quote(part) for part in parts)
+    output = _run(sandbox, command, timeout=duration + omit + 30)
+    payload = json.loads(output)
+    if error := payload.get("error"):
+        pytest.fail(f"iperf3 failed: {error}")
+    # Measure receiver goodput in both directions. For uploads, sum_sent can
+    # include bytes still queued in the guest TCP stack ahead of the TAP
+    # limiter when the test ends.
+    summary_key = "sum_received"
+    summary = payload.get("end", {}).get(summary_key)
+    assert summary is not None, (
+        f"iperf3 JSON does not contain end.{summary_key}: {payload.get('end')!r}"
+    )
+    return float(summary["bits_per_second"]), float(summary["seconds"])
+
+
+def _assert_near_ceiling(actual: float, ceiling: float, *, unit: str) -> None:
+    lower_ratio = _positive_float("CUBE_QOS_E2E_MIN_RATIO", 0.50)
+    upper_ratio = _positive_float("CUBE_QOS_E2E_MAX_RATIO", 1.30)
+    assert actual >= ceiling * lower_ratio, (
+        f"measured {actual:.2f} {unit}, below {lower_ratio:.2f}x the "
+        f"configured ceiling {ceiling:.2f} {unit}; the test path may be bottlenecked elsewhere"
+    )
+    assert actual <= ceiling * upper_ratio, (
+        f"measured {actual:.2f} {unit}, above {upper_ratio:.2f}x the "
+        f"configured ceiling {ceiling:.2f} {unit}"
+    )
+
+
+@pytest.mark.parametrize("reverse", [False, True], ids=["upload", "download"])
+def test_network_bandwidth_ceiling(
+    qos_environment: QosEnvironment,
+    iperf_server: tuple[str, int],
+    reverse: bool,
+) -> None:
+    server, port = iperf_server
+    _require_command(qos_environment.sandbox, "iperf3")
+    bits_per_second, _ = _iperf_result(
+        qos_environment.sandbox,
+        server,
+        port,
+        reverse=reverse,
+    )
+    actual_mbps = bits_per_second / 1_000_000
+    ceiling_mbps = qos_environment.qos["network"]["bandwidthMbps"]
+    _assert_near_ceiling(actual_mbps, ceiling_mbps, unit="Mbit/s")
+
+
+def _require_virtio_blk_path(sandbox: Sandbox, test_path: str) -> None:
+    directory = str(Path(test_path).parent)
+    quoted_directory = shlex.quote(directory)
+    command = (
+        f"set -- $(findmnt -n -o SOURCE,FSTYPE,OPTIONS -T {quoted_directory}) || exit 20; "
+        'source=$1; fstype=$2; options=$3; device=""; '
+        'if [ "$fstype" = overlay ]; then '
+        'upperdir=$(printf "%s\\n" "$options" | tr , "\\n" | sed -n s/^upperdir=//p); '
+        'case "$upperdir" in /run/blk-cube/*/*) '
+        'device=${upperdir#/run/blk-cube/}; device=${device%%/*} ;; esac; '
+        'elif [ "${source#/dev/}" != "$source" ]; then '
+        'device=$(lsblk -s -n -o KNAME "$source" | tail -n 1); fi; '
+        'test -n "$device" || exit 21; '
+        'driver=$(readlink -f "/sys/class/block/$device/device/driver" || true); '
+        'printf "%s\\n%s\\n%s\\n%s\\n" "$source" "$fstype" "$device" "$driver"'
+    )
+    result = sandbox.commands.run(command, timeout=30)
+    if result.exit_code != 0 or "virtio_blk" not in result.stdout:
+        pytest.skip(
+            f"{directory} is not confirmed as a virtio-blk-backed filesystem: "
+            f"exit={result.exit_code}, output={result.stdout.strip()!r}"
+        )
+
+
+def _fio_result(
+    sandbox: Sandbox,
+    test_path: str,
+    *,
+    rw: str,
+    block_size: str,
+    duration: int,
+) -> dict:
+    size = os.environ.get("CUBE_QOS_FIO_SIZE", "512M")
+    command = " ".join(
+        shlex.quote(part)
+        for part in [
+            "fio",
+            "--output-format=json",
+            f"--name=qos-{rw}",
+            f"--filename={test_path}",
+            f"--size={size}",
+            f"--rw={rw}",
+            f"--bs={block_size}",
+            "--ioengine=libaio",
+            "--direct=1",
+            "--iodepth=32",
+            f"--runtime={duration}",
+            "--time_based",
+            "--group_reporting",
+        ]
+    )
+    output = _run(sandbox, command, timeout=duration + 60)
+    json_start = output.find("{")
+    assert json_start >= 0, f"fio did not produce JSON output: {output!r}"
+    payload = json.loads(output[json_start:])
+    jobs = payload.get("jobs") or []
+    assert len(jobs) == 1, f"unexpected fio jobs payload: {jobs!r}"
+    return jobs[0]
+
+
+def test_block_io_throughput_and_iops(qos_environment: QosEnvironment) -> None:
+    sandbox = qos_environment.sandbox
+    _require_command(sandbox, "fio")
+    test_path = os.environ.get("CUBE_QOS_FIO_PATH", "/tmp/cube-qos-e2e.dat")
+    _require_virtio_blk_path(sandbox, test_path)
+    duration = _positive_int("CUBE_QOS_FIO_DURATION", 45)
+
+    try:
+        for rw, direction in (("write", "write"), ("read", "read")):
+            result = _fio_result(
+                sandbox,
+                test_path,
+                rw=rw,
+                block_size="1M",
+                duration=duration,
+            )
+            actual_mibps = float(result[direction]["bw_bytes"]) / (1024 * 1024)
+            ceiling_mibps = qos_environment.qos["blockIo"]["throughputMiBps"]
+            _assert_near_ceiling(actual_mibps, ceiling_mibps, unit=f"MiB/s {direction}")
+
+        for rw, direction in (("randwrite", "write"), ("randread", "read")):
+            result = _fio_result(
+                sandbox,
+                test_path,
+                rw=rw,
+                block_size="4k",
+                duration=duration,
+            )
+            actual_iops = float(result[direction]["iops"])
+            ceiling_iops = qos_environment.qos["blockIo"]["iops"]
+            _assert_near_ceiling(actual_iops, ceiling_iops, unit=f"IOPS {direction}")
+    finally:
+        sandbox.commands.run(f"rm -f -- {shlex.quote(test_path)}", timeout=30)
+
+
+@pytest.fixture(scope="module")
+def node_pps_enabled() -> None:
+    if os.environ.get("CUBE_QOS_NODE_PPS_E2E") != "1":
+        pytest.skip("set CUBE_QOS_NODE_PPS_E2E=1 when pytest runs on the sandbox compute node")
+
+
+@pytest.fixture(scope="module")
+def node_pps_environment(
+    sdk_e2e_config,
+    node_pps_enabled: None,
+) -> Iterator[tuple[QosEnvironment, str]]:
+    _require_qos_dataplane()
+    server = os.environ.get("CUBE_QOS_IPERF_SERVER")
+    if server is None:
+        pytest.skip("set CUBE_QOS_IPERF_SERVER to the compute-node address reachable from the sandbox")
+    expected_qos = {
+        "network": {
+            "packetsPerSecond": _positive_int("CUBE_QOS_PACKETS_PER_SECOND", 100),
+        }
+    }
+    config = Config(api_url=sdk_e2e_config.cube_api_url)
+    with _provision_qos_environment(
+        config,
+        expected_qos,
+        template_id=os.environ.get("CUBE_QOS_PPS_TEMPLATE_ID"),
+        allow_out=_server_allow_out(server),
+        name_prefix="e2e-qos-pps",
+    ) as environment:
+        yield environment, server
+
+
+@pytest.fixture(scope="module")
+def node_udp_sink() -> Iterator[int]:
+    port = _positive_int("CUBE_QOS_PPS_UDP_PORT", 5202)
+    udp_socket = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    udp_socket.settimeout(0.2)
+    try:
+        udp_socket.bind(("0.0.0.0", port))
+    except OSError as error:
+        udp_socket.close()
+        pytest.fail(f"cannot bind node UDP sink on port {port}: {error}")
+
+    stopped = threading.Event()
+
+    def receive() -> None:
+        while not stopped.is_set():
+            try:
+                udp_socket.recvfrom(65535)
+            except TimeoutError:
+                pass
+            except OSError:
+                return
+
+    thread = threading.Thread(target=receive, name="qos-pps-udp-sink", daemon=True)
+    thread.start()
+    try:
+        yield port
+    finally:
+        stopped.set()
+        udp_socket.close()
+        thread.join(timeout=1)
+
+
+def _tap_interface(sandbox_id: str) -> str:
+    curl = shutil.which("curl")
+    if curl is None:
+        pytest.skip("node PPS e2e requires curl on the compute node")
+    cubelet_url = os.environ.get("CUBE_QOS_CUBELET_HTTP_URL", "http://127.0.0.1:9998")
+    if not cubelet_url.startswith(("http://", "https://")):
+        pytest.fail("CUBE_QOS_CUBELET_HTTP_URL must start with http:// or https://")
+    request = [
+        curl,
+        "-fsS",
+        f"{cubelet_url.rstrip('/')}/v1/network/taps",
+    ]
+    deadline = time.monotonic() + _positive_float("CUBE_QOS_TAP_LOOKUP_TIMEOUT", 30.0)
+    last_error = ""
+    while time.monotonic() < deadline:
+        try:
+            response = subprocess.run(
+                request,
+                check=True,
+                capture_output=True,
+                text=True,
+                timeout=5,
+            )
+            taps = json.loads(response.stdout).get("taps") or []
+            matches = [tap for tap in taps if tap.get("sandboxID") == sandbox_id]
+            if len(matches) == 1:
+                interface = matches[0].get("tapName", "")
+                if re.fullmatch(r"[A-Za-z0-9_.-]+", interface):
+                    return interface
+                last_error = f"unsafe TAP name: {interface!r}"
+            else:
+                last_error = f"expected one TAP for sandbox {sandbox_id}, got {matches!r}"
+        except subprocess.CalledProcessError as error:
+            last_error = error.stderr.strip() or f"curl exited with {error.returncode}"
+        except (json.JSONDecodeError, subprocess.TimeoutExpired) as error:
+            last_error = str(error)
+        time.sleep(0.5)
+    pytest.fail(f"Cubelet TAP lookup did not become ready: {last_error}")
+
+
+def _interface_counter(interface: str, counter: str) -> int:
+    path = Path("/sys/class/net") / interface / "statistics" / counter
+    try:
+        return int(path.read_text().strip())
+    except (OSError, ValueError) as error:
+        pytest.skip(f"cannot read node TAP counter {path}: {error}")
+
+
+@pytest.mark.qos_node
+def test_network_upload_pps_ceiling_from_tap_counter(
+    node_pps_environment: tuple[QosEnvironment, str],
+    node_udp_sink: int,
+) -> None:
+    environment, server = node_pps_environment
+    duration = _positive_int("CUBE_QOS_PPS_DURATION", 15)
+    warmup_seconds = _positive_float("CUBE_QOS_PPS_WARMUP_SECONDS", 2.0)
+    sample_seconds = _positive_float("CUBE_QOS_PPS_SAMPLE_SECONDS", 5.0)
+    activity_timeout = 5.0
+    if duration <= activity_timeout + warmup_seconds + sample_seconds + 1:
+        pytest.fail(
+            "CUBE_QOS_PPS_DURATION must exceed activity wait, warmup, and sample time "
+            "by at least one second"
+        )
+    payload_size = _positive_int("CUBE_QOS_PPS_PAYLOAD_BYTES", 64)
+    port = node_udp_sink
+    source = (
+        "import json, socket, time\n"
+        f"target = ({server!r}, {port})\n"
+        f"payload = b'x' * {payload_size}\n"
+        "sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)\n"
+        "sock.setblocking(False)\n"
+        "started = time.monotonic()\n"
+        f"deadline = started + {duration}\n"
+        "attempted = 0\n"
+        "sent = 0\n"
+        "while time.monotonic() < deadline:\n"
+        "    attempted += 1\n"
+        "    try:\n"
+        "        sock.sendto(payload, target)\n"
+        "        sent += 1\n"
+        "    except BlockingIOError:\n"
+        "        pass\n"
+        "print(json.dumps({\n"
+        "    'attempted': attempted,\n"
+        "    'sent': sent,\n"
+        "    'seconds': time.monotonic() - started,\n"
+        "}))\n"
+    )
+    command = f"python3 -c {shlex.quote(source)}"
+    _require_command(environment.sandbox, "python3")
+    interface = _tap_interface(environment.sandbox.sandbox_id)
+    initial = _interface_counter(interface, "rx_packets")
+    with ThreadPoolExecutor(max_workers=1) as executor:
+        sender_future = executor.submit(
+            _run,
+            environment.sandbox,
+            command,
+            duration + 30,
+        )
+        activity_deadline = time.monotonic() + activity_timeout
+        while time.monotonic() < activity_deadline:
+            if _interface_counter(interface, "rx_packets") > initial:
+                break
+            if sender_future.done():
+                pytest.fail(f"PPS sender exited before producing TAP traffic: {sender_future.result()}")
+            time.sleep(0.05)
+        else:
+            pytest.fail("PPS sender produced no TAP traffic within five seconds")
+
+        time.sleep(warmup_seconds)
+        before = _interface_counter(interface, "rx_packets")
+        sample_started = time.monotonic()
+        time.sleep(sample_seconds)
+        after = _interface_counter(interface, "rx_packets")
+        measured_seconds = time.monotonic() - sample_started
+        output = sender_future.result(timeout=duration + 10)
+
+    sender = json.loads(output)
+    assert sender["sent"] > 0
+    offered_pps = float(sender["attempted"]) / float(sender["seconds"])
+    actual_pps = (after - before) / measured_seconds
+    ceiling_pps = environment.qos["network"]["packetsPerSecond"]
+    assert offered_pps >= ceiling_pps * 2, (
+        f"sender offered only {offered_pps:.2f} packets/s, below 2x the "
+        f"configured ceiling {ceiling_pps}"
+    )
+    assert actual_pps >= ceiling_pps * 0.50, (
+        f"measured {actual_pps:.2f} packet operations/s, below 0.50x the "
+        f"configured ceiling {ceiling_pps}; the test path may be bottlenecked elsewhere"
+    )
+    assert actual_pps <= ceiling_pps * 1.50, (
+        f"measured {actual_pps:.2f} packet operations/s, above 1.50x the "
+        f"configured ceiling {ceiling_pps}"
+    )

--- a/tests/e2e/sdk_compat/conftest.py
+++ b/tests/e2e/sdk_compat/conftest.py
@@ -154,6 +154,7 @@ def pytest_configure(config: pytest.Config):
         "requires_capability(name): current SDK backend must support this capability",
         "sandbox_create_options(**kwargs): SDK sandbox create options for this test",
         "sandbox_template_id(template_id): override template ID for this test or module",
+        "self_managed_template: test provisions and cleans up its own template",
         "requires_code_interpreter: test requires a stateful Code Interpreter kernel",
         "requires_internet: test requires public internet access from the sandbox",
         "requires_cubeproxy: test requires CubeProxy routing to the sandbox",
@@ -202,7 +203,9 @@ def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item
         if (template_id := _template_id_for_node(item)) is not None
     }
     config._sdk_e2e_default_template_needed = any(
-        _template_id_for_node(item) is None for item in items
+        _template_id_for_node(item) is None
+        and item.get_closest_marker("self_managed_template") is None
+        for item in items
     )
     volume_skip = None
     if not _env_true("SDK_E2E_VOLUME_PLUGIN"):

--- a/tests/e2e/sdk_compat/framework/create_retry.py
+++ b/tests/e2e/sdk_compat/framework/create_retry.py
@@ -171,4 +171,3 @@ def _backoff_delay(attempt: int, backoff: float, backoff_max: float) -> float:
     if not math.isfinite(ceiling) or ceiling < 0.0:
         ceiling = 0.0
     return random.uniform(0.0, ceiling)
-

--- a/tests/e2e/sdk_compat/framework/preflight.py
+++ b/tests/e2e/sdk_compat/framework/preflight.py
@@ -62,7 +62,7 @@ def run_preflight(
 
     if require_default_template and not config.cube_template_id:
         errors.append("CUBE_TEMPLATE_ID or --cube-template-id is required")
-    if not effective_template_ids:
+    if require_default_template and not effective_template_ids:
         errors.append("at least one template ID is required")
 
     _check_backend_dependencies(config.backends, errors)

--- a/tests/e2e/sdk_compat/pytest.ini
+++ b/tests/e2e/sdk_compat/pytest.ini
@@ -24,6 +24,9 @@ markers =
     requires_capability(name): current backend must support the named capability
     sandbox_create_options(**kwargs): SDK sandbox create options for this test
     sandbox_template_id(template_id): override template ID for a test or module
+    self_managed_template: test provisions and cleans up its own template
+    qos: template QoS control-plane and dataplane tests
+    qos_node: tests that require access to the sandbox compute node
     requires_code_interpreter: test requires a template exposing Code Interpreter / Jupyter
     requires_internet: test requires public internet from the sandbox
     requires_cubeproxy: test requires CubeProxy routing to the sandbox


### PR DESCRIPTION
## Motivation

Multiple sandboxes can share the same host, network egress path, and storage resources. Without per-sandbox ceilings, one sandbox can consume disproportionate network bandwidth, packet-processing capacity, block throughput, or IOPS and affect other workloads.

CubeSandbox already has virtio-net and virtio-blk Token Bucket enforcement paths, but using them requires callers to construct internal annotations and low-level bucket fields. Those annotations are runtime contracts, are filtered by annotation policy, and should not be exposed as the public QoS interface.

This PR adds an opt-in, template-managed QoS contract for explicit per-sandbox network and block I/O ceilings. Templates that omit `qos` retain the existing behavior.

## What Changed

- Add the public template QoS shape:

  ```json
  {
    "qos": {
      "network": {
        "bandwidthMbps": 100,
        "packetsPerSecond": 5000
      },
      "blockIo": {
        "throughputMiBps": 64,
        "iops": 1000
      }
    }
  }
  ```

- Accept `qos` through CubeAPI template creation and `cubemastercli tpl create-from-image --qos`.

- Support both inline JSON and `--qos @qos.json` in the CLI, with strict field validation and bounded file input.

- Resolve and persist the public QoS setting in CubeMaster, then translate network limits to the versioned `cube.master.net` request and block I/O limits to `cube.master.blk.qos` for the existing Cubelet and CubeShim Token Bucket paths.

- Preserve template-managed QoS when committing a sandbox with a public `create_request` override. If the source sandbox specification cannot be loaded, fail the commit instead of silently creating a template without its ceilings.

- Keep QoS as runtime template configuration rather than a rootfs input, so templates with different limits can reuse the same rootfs artifact.

- Centralize template QoS resolution behind a resource-aware seam. The current implementation does not infer limits when `qos` is omitted; the seam allows platform defaults to be derived from template CPU and memory later, while explicit fields override inferred fields.

- Reject caller-supplied internal network, block I/O, and filesystem QoS annotations on sandbox and template requests, and remove these annotations from public template, preview, and snapshot responses.

- Tighten Cubelet validation for versioned network QoS requests by rejecting unknown or mis-cased fields, unsupported versions or modes, missing QoS, and negative or incomplete Token Bucket values. Legacy version-zero payloads remain permissive for compatibility.

- Expose `configuredQos` for templates and sandboxes, plus `qosApplied` for persisted sandbox runtime state, and update `cubemastercli` output and the English and Chinese QoS guides.

- Add opt-in SDK compatibility E2E coverage for template and sandbox state, bidirectional bandwidth enforcement, block throughput and IOPS, and node-observed PPS enforcement.

## Behavior and Scope

- The current release configures QoS on templates. Every sandbox created from a template receives the same configured ceilings, and sandbox creation cannot override or disable them.
- QoS is disabled when the template omits `qos`; existing templates keep their current behavior.
- Network bandwidth and packet-processing limits are applied independently to upload and download, using the same configured value for both directions.
- Block throughput and IOPS limits are applied independently to each virtio-blk device. Reads and writes on the same device share its limits.
- Refill and burst fields remain platform-managed implementation details.
- These settings provide ceilings, not reservations, minimum performance, priorities, or weighted fairness. Sandboxes can still contend when the underlying host, storage, or network capacity is below the sum of their ceilings.

This PR does not add separate upload/download values, separate read/write values, per-sandbox overrides, filesystem QoS, or non-empty CPU/memory-derived defaults.

## How to run E2E

Install the SDK compatibility E2E dependencies:

```bash
cd tests/e2e/sdk_compat
python -m pip install -r requirements.txt
```

The control/runtime E2E creates a QoS template and sandbox, verifies `configuredQos` and `qosApplied`, and cleans both resources. The QoS file manages its own template, so selecting it alone does not require `CUBE_TEMPLATE_ID`.

```bash
CUBE_API_URL=http://127.0.0.1:3000 \
CUBE_TEMPLATE_E2E_IMAGE=cube-sandbox-cn.tencentcloudcr.com/cube-sandbox/sandbox-code:latest \
pytest --run-e2e \
  cases/qos/test_template_qos.py::test_template_qos_control_and_runtime_state
```

For bandwidth enforcement, start an iperf3 server at an IP reachable from the sandbox:

```bash
iperf3 -s -p 5201
```

Then run the bandwidth and block I/O dataplane cases. The suite creates a temporary template with 100 Mbps network bandwidth, 32 MiB/s block throughput, and 1000 IOPS by default, creates one sandbox, and cleans up both resources. When `CUBE_QOS_IPERF_SERVER` is an IP literal, the temporary template automatically adds the corresponding host CIDR to `allow_out`.

```bash
CUBE_API_URL=http://127.0.0.1:3000 \
CUBE_TEMPLATE_E2E_IMAGE=cube-sandbox-cn.tencentcloudcr.com/cube-sandbox/sandbox-code:latest \
CUBE_QOS_IPERF_SERVER=10.0.0.10 \
CUBE_QOS_DATAPLANE_E2E=1 \
CUBE_QOS_E2E_INSTALL_TOOLS=1 \
pytest --run-e2e \
  -m 'qos and not qos_node' \
  cases/qos/test_template_qos.py
```

The pytest runner does not need `iperf3` or `fio`, but the sandbox does. If either command is missing, its case is skipped unless `CUBE_QOS_E2E_INSTALL_TOOLS=1` is set; `CUBE_QOS_E2E_INSTALL_COMMAND` can override the installation command. The block I/O case also skips unless its test file is on a writable virtio-blk-backed filesystem.

To reuse existing templates, set `CUBE_QOS_CONTROL_TEMPLATE_ID` for the control/runtime case, `CUBE_QOS_E2E_TEMPLATE_ID` for the bandwidth and block I/O cases, or `CUBE_QOS_PPS_TEMPLATE_ID` for the PPS case. A reused template must already allow the required test endpoint and match the QoS values expected by that case.

The PPS case must run on the sandbox compute node because it reads the sandbox TAP counter. `CUBE_QOS_IPERF_SERVER` identifies the compute-node IP reachable from the sandbox; this case uses its own UDP sink rather than iperf3.

```bash
CUBE_API_URL=http://127.0.0.1:3000 \
CUBE_TEMPLATE_E2E_IMAGE=cube-sandbox-cn.tencentcloudcr.com/cube-sandbox/sandbox-code:latest \
CUBE_TEMPLATE_E2E_NODE=current-node-id \
CUBE_QOS_IPERF_SERVER=10.0.0.10 \
CUBE_QOS_DATAPLANE_E2E=1 \
CUBE_QOS_NODE_PPS_E2E=1 \
CUBE_QOS_PACKETS_PER_SECOND=100 \
pytest --run-e2e -m qos_node cases/qos/test_template_qos.py
```

## Validation

- Focused CubeMaster tests passed for public QoS validation and conversion, template resolution and persistence, annotation rejection and hiding, sandbox reporting, and CLI parsing.
- Cubelet tests passed for strict version-one network QoS decoding, legacy version-zero compatibility, TAP request propagation, and block I/O annotation decoding.
- CubeAPI QoS tests and SDK compatibility regression tests passed.
- Linux builds passed for the affected CubeMaster, Cubelet, CLI, and CubeAPI paths.
- The control/runtime E2E passed with network bandwidth, PPS, block throughput, and IOPS present in `configuredQos`, and sandbox `qosApplied=true`.
- Live dataplane E2E passed for upload and download bandwidth, block throughput and IOPS, and node-observed PPS enforcement.
- A no-QoS template compatibility E2E passed: the template and sandbox reported no configured or applied QoS, no internal `cube.master.net` annotation was exposed, and a one-sandbox iperf upload was not capped by the QoS limiter.
- Five concurrent sandboxes from a 10 Mbps template each remained between 9.907 and 9.993 Mbps in two runs, including one sandbox using eight connections while the other four used one connection each.
- With the same workload and no QoS, the eight-connection sandbox consumed 88-160 Mbps of an approximately 204 Mbps sustained shared link, while normal sandboxes received an unstable 6.10-38.07 Mbps each.

These results verify the public configuration path, compatibility for templates that omit QoS, and per-sandbox blast-radius control.
