### PR TITLE
fix(kubernetes): sync Helm chart metadata to v0.6.0

### DIFF
--- a/deploy/kubernetes/chart/Chart.yaml
+++ b/deploy/kubernetes/chart/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: cube
 description: CubeSandbox on Kubernetes/TKE Helm chart with separate control-plane, node, proxy, and host bootstrap images.
 type: application
-version: 0.5.1
-appVersion: "0.5.1"
+version: 0.6.0
+appVersion: "0.6.0"
 home: https://github.com/TencentCloud/CubeSandbox
 keywords:
   - cubesandbox


### PR DESCRIPTION
## Summary

- update the Helm chart `version` from `0.5.1` to `0.6.0`
- update `appVersion` from `0.5.1` to `0.6.0`
- align Chart metadata with the `v0.6.0` component image tags already configured in `values.yaml`

This fixes metadata on `master` and future chart packages. It intentionally does not rewrite the existing immutable `v0.6.0` Git tag.

## Validation

- `helm lint deploy/kubernetes/chart` with test MySQL/Redis credentials
- `helm template chart-check deploy/kubernetes/chart` with test MySQL/Redis credentials
- all four Kubernetes chart guard scripts
- `helm package deploy/kubernetes/chart` produces `cube-0.6.0.tgz`
- `helm show chart` reports `version: 0.6.0` and `appVersion: 0.6.0`
- `git diff --check`

## DCO

This draft was prepared autonomously by an AI agent and therefore does not include a `Signed-off-by` trailer. Per the repository AI policy, a human contributor must review the change and add their own DCO sign-off before the PR is marked ready for merge.

Autonomously-by: pi:gpt-5.6-sol
