### PR TITLE
fix(node sdk): omit sandbox timeout when not explicitly provided

### DIFF
--- a/sdk/node/src/config.ts
+++ b/sdk/node/src/config.ts
@@ -65,7 +65,7 @@ function normalizeProxyScheme(scheme: string | undefined, port: number): string 
   return port === 443 ? "https" : "http";
 }
 
-/** Default sandbox TTL in seconds, shared by {@link Config} and ``resume``. */
+/** Default sandbox TTL in seconds retained on {@link Config}. */
 export const DEFAULT_SANDBOX_TIMEOUT_S = 300;
 
 export class Config {

--- a/sdk/node/src/sandbox.ts
+++ b/sdk/node/src/sandbox.ts
@@ -4,7 +4,7 @@
 import { fetch, type Dispatcher } from "undici";
 
 import { Commands } from "./commands.js";
-import { Config, DEFAULT_SANDBOX_TIMEOUT_S, resolveConfig, type ConfigOptions } from "./config.js";
+import { Config, resolveConfig, type ConfigOptions } from "./config.js";
 import {
   ApiError,
   AuthenticationError,
@@ -352,10 +352,10 @@ export class Sandbox {
       );
     }
 
-    const payload: Record<string, unknown> = {
-      templateID: tpl,
-      timeout: options.timeout ?? cfg.timeout,
-    };
+    const payload: Record<string, unknown> = { templateID: tpl };
+    if (options.timeout !== undefined) {
+      payload.timeout = options.timeout;
+    }
     if (options.envVars) {
       payload.envVars = options.envVars;
     }
@@ -416,7 +416,7 @@ export class Sandbox {
     const resp = await controlFetch(cfg, `${cfg.apiUrl}/sandboxes/${sandboxId}/connect`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ timeout: cfg.timeout }),
+      body: JSON.stringify({}),
     });
     await checkControlResponse(resp);
     return new Sandbox((await resp.json()) as Record<string, any>, cfg);
@@ -570,11 +570,15 @@ export class Sandbox {
    * @deprecated Use {@link Sandbox.connect} which auto-resumes and returns a
    * fresh instance.
    */
-  async resume(timeout = DEFAULT_SANDBOX_TIMEOUT_S): Promise<void> {
+  async resume(timeout?: number): Promise<void> {
+    const payload: Record<string, unknown> = {};
+    if (timeout !== undefined) {
+      payload.timeout = timeout;
+    }
     const resp = await controlFetch(this.config, `${this.config.apiUrl}/sandboxes/${this.sandboxId}/resume`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ timeout }),
+      body: JSON.stringify(payload),
     });
     await checkControlResponse(resp);
   }

--- a/sdk/node/test/sandbox.test.ts
+++ b/sdk/node/test/sandbox.test.ts
@@ -137,6 +137,26 @@ describe("Sandbox.create", () => {
     sb.close();
   });
 
+  it("omits timeout when not explicitly provided", async () => {
+    setHandler(() => ({ status: 201, json: SANDBOX_DATA }));
+    const cfg = makeConfig();
+    cfg.timeout = 600;
+
+    const sb = await Sandbox.create({ config: cfg });
+    const body = JSON.parse(requests[0].body.toString());
+    expect(body.templateID).toBe("tpl-test");
+    expect("timeout" in body).toBe(false);
+    sb.close();
+  });
+
+  it("sends explicit zero timeout", async () => {
+    setHandler(() => ({ status: 201, json: SANDBOX_DATA }));
+    const sb = await Sandbox.create({ timeout: 0, config: makeConfig() });
+    const body = JSON.parse(requests[0].body.toString());
+    expect(body.timeout).toBe(0);
+    sb.close();
+  });
+
   it("sends envVars and metadata", async () => {
     setHandler(() => ({ status: 201, json: SANDBOX_DATA }));
     const sb = await Sandbox.create({
@@ -402,6 +422,38 @@ describe("Sandbox instance operations", () => {
     });
     await sb.kill();
     expect(requests).toHaveLength(1);
+    sb.close();
+  });
+
+  it("connect omits timeout so the server keeps its timeout policy", async () => {
+    setHandler((req) => {
+      expect(req.method).toBe("POST");
+      expect(req.pathname).toBe(`/sandboxes/${SANDBOX_ID}/connect`);
+      expect(JSON.parse(req.body.toString())).toEqual({});
+      return { status: 200, json: SANDBOX_DATA };
+    });
+    const cfg = makeConfig();
+    cfg.timeout = 600;
+
+    const sb = await Sandbox.connect(SANDBOX_ID, { config: cfg });
+    expect(sb.sandboxId).toBe(SANDBOX_ID);
+    sb.close();
+  });
+
+  it("resume omits timeout by default but preserves explicit values", async () => {
+    const sb = await createSandbox();
+    setHandler((req) => {
+      expect(req.method).toBe("POST");
+      expect(req.pathname).toBe(`/sandboxes/${SANDBOX_ID}/resume`);
+      return { status: 204 };
+    });
+
+    await sb.resume();
+    expect(JSON.parse(requests[0].body.toString())).toEqual({});
+
+    requests = [];
+    await sb.resume(0);
+    expect(JSON.parse(requests[0].body.toString())).toEqual({ timeout: 0 });
     sb.close();
   });
 


### PR DESCRIPTION
## Summary

Fixes the Node SDK sandbox lifecycle timeout behavior so `timeout` is only sent when explicitly provided, aligning it with the documentation and the Python / Go SDKs.

fix: #1177 

## Changes

### Modified Files

* `sdk/node/src/sandbox.ts` — Stop sending the SDK-side default `timeout: 300` from `Sandbox.create`, `Sandbox.connect`, and `sb.resume`
* `sdk/node/src/config.ts` — Update the `DEFAULT_SANDBOX_TIMEOUT_S` comment to reflect that it is retained on `Config` only
* `sdk/node/test/sandbox.test.ts` — Add regression coverage for omitted timeout and explicit timeout values

## Features

1. `Sandbox.create({ config })` now omits `timeout` when the user does not explicitly provide it
2. `Sandbox.connect(id, { config })` now sends an empty request body instead of `{ timeout: cfg.timeout }`
3. `sb.resume()` now omits `timeout` by default instead of sending `timeout: 300`
4. Explicit timeout values are preserved, including `timeout: 0` and `timeout: 600`
5. Server-side sandbox lifecycle policy is no longer overridden by the Node SDK default timeout
6. Behavior is now consistent with the current Python and Go SDK implementations

## Testing

```bash
# Run targeted sandbox lifecycle tests
cd sdk/node
npm test -- sandbox.test.ts

# Run TypeScript type checking
npm run typecheck

# Run the full Node SDK test suite
npm test
Test results:
- npm test -- sandbox.test.ts — passed, 37 tests
- npm run typecheck — passed
- npm test — passed, 174 tests passed, 1 skipped