### PR TITLE
fix(Cubelet): cleanup host-dir mount directories

### DIFF
--- a/Cubelet/storage/local.go
+++ b/Cubelet/storage/local.go
@@ -1281,6 +1281,10 @@ func (l *local) destroy(ctx context.Context, info *StorageInfo, opts *workflow.D
 		errs = errors.Join(errs, err)
 	}
 
+	if err := l.cleanupHostDirVolumes(ctx, info); err != nil {
+		errs = errors.Join(errs, err)
+	}
+
 	if errs != nil {
 		return ret.Err(errorcode.ErrorCode_DestroyStorageFailed, errs.Error())
 	}

--- a/Cubelet/storage/local_test.go
+++ b/Cubelet/storage/local_test.go
@@ -1263,6 +1263,36 @@ func TestCleanupCreateResultRemovesHostDirSandboxPath(t *testing.T) {
 	require.NoDirExists(t, filepath.Join(hostDirBasePath, "hostdir-sb"))
 }
 
+func TestDestroyRemovesHostDirSandboxPath(t *testing.T) {
+	cfg := makeTestConfig(t)
+	cfg.StorageBackend = "cubecow"
+	s := &local{config: cfg, cowManager: &fakeCowVolumeManager{}}
+	require.NoError(t, s.init(&plugin.InitContext{Context: context.Background()}))
+
+	oldHostDirBasePath := hostDirBasePath
+	hostDirBasePath = t.TempDir()
+	t.Cleanup(func() { hostDirBasePath = oldHostDirBasePath })
+
+	sandboxID := "destroy-hostdir-sb"
+	bindPath := filepath.Join(hostDirBasePath, sandboxID, "rw", "hostdir-0")
+	require.NoError(t, os.MkdirAll(bindPath, 0755))
+
+	err := s.destroy(context.Background(), &StorageInfo{
+		SandboxID: sandboxID,
+		HostDirBackendInfos: map[string]*HostDirBackendInfo{
+			"volume/hostdir-0": {
+				VolumeName: "volume",
+				ShareDir:   filepath.Dir(bindPath),
+				BindPath:   bindPath,
+			},
+		},
+	}, &workflow.DestroyContext{
+		BaseWorkflowInfo: workflow.BaseWorkflowInfo{SandboxID: sandboxID},
+	})
+	require.NoError(t, err)
+	require.NoDirExists(t, filepath.Join(hostDirBasePath, sandboxID))
+}
+
 func TestCleanupHostDirVolumesResolvesSymlinkedBasePath(t *testing.T) {
 	// Simulate a deployment where an ancestor of hostDirBasePath is a symlink
 	// (e.g. /data -> /mnt/ssd/data). The kernel records fully resolved


### PR DESCRIPTION
There are uncleared host-dir directories under `/data/cubelet/hostdir`.

```bash
# ls /data/cubelet/hostdir
2cd3ec83a9ec46f5ab84822c5e41db56  6edb6cf299c8457499e65e2ff8de6a11  
cc853f00b0f04a32a14bab559e3de8be  da78bbf168e641a6854dad1f6b2713ac
```

#333 added `cleanupHostDirVolumes` to remove host-dir mount directories during sandbox destruction.

#997 accidentally replaced this cleanup call while adding plugin volume cleanup, causing host-dir directories to remain after sandboxes were destroyed.