### PR TITLE
fix(go sdk): send traffic access token on private sandbox data-plane requests

### DIFF
--- a/sdk/go/envd.go
+++ b/sdk/go/envd.go
@@ -223,6 +223,7 @@ func (s *Sandbox) newEnvdRequest(ctx context.Context, method, path string, query
 	if s.EnvdAccessToken != "" {
 		req.Header.Set("X-Access-Token", s.EnvdAccessToken)
 	}
+	s.addTrafficTokenHeaders(req)
 	return req, nil
 }
 

--- a/sdk/go/pty_test.go
+++ b/sdk/go/pty_test.go
@@ -26,7 +26,7 @@ func newPtyTestSandbox(t *testing.T, server *httptest.Server) *Sandbox {
 		SandboxDomain:  "cube.test",
 		RequestTimeout: 5 * time.Second,
 	})
-	return &Sandbox{client: client, SandboxID: "sb-pty", EnvdAccessToken: "tok"}
+	return &Sandbox{client: client, SandboxID: "sb-pty", EnvdAccessToken: "tok", TrafficAccessToken: "traffic-token"}
 }
 
 // ptyDataFrame builds a Connect data frame carrying base64-encoded PTY output.
@@ -49,12 +49,15 @@ func decodeEnvelopeJSON(t *testing.T, body []byte, v any) {
 
 func TestPtyCreateStreamsAndWaits(t *testing.T) {
 	var gotPath, gotCT, gotAuth, gotToken string
+	var gotE2BToken, gotCubeToken string
 	var gotBody []byte
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		gotPath = r.URL.Path
 		gotCT = r.Header.Get("Content-Type")
 		gotAuth = r.Header.Get("Authorization")
 		gotToken = r.Header.Get("X-Access-Token")
+		gotE2BToken = r.Header.Get("e2b-traffic-access-token")
+		gotCubeToken = r.Header.Get("cube-traffic-access-token")
 		gotBody, _ = io.ReadAll(r.Body)
 
 		w.Header().Set("Content-Type", connectContentType)
@@ -101,6 +104,9 @@ func TestPtyCreateStreamsAndWaits(t *testing.T) {
 	}
 	if gotToken != "tok" {
 		t.Fatalf("X-Access-Token=%q, want tok", gotToken)
+	}
+	if gotE2BToken != "traffic-token" || gotCubeToken != "traffic-token" {
+		t.Fatalf("traffic tokens=%q/%q, want traffic-token", gotE2BToken, gotCubeToken)
 	}
 
 	var req ptyStartRequest

--- a/sdk/go/sandbox.go
+++ b/sdk/go/sandbox.go
@@ -30,6 +30,14 @@ func (s *Sandbox) GetHost(port int) string {
 	return fmt.Sprintf("%d-%s.%s", port, s.SandboxID, domain)
 }
 
+func (s *Sandbox) addTrafficTokenHeaders(req *http.Request) {
+	if s.TrafficAccessToken == "" {
+		return
+	}
+	req.Header.Set("e2b-traffic-access-token", s.TrafficAccessToken)
+	req.Header.Set("cube-traffic-access-token", s.TrafficAccessToken)
+}
+
 func (s *Sandbox) GetInfo(ctx context.Context) (*SandboxInfo, error) {
 	if err := s.ensureClient(); err != nil {
 		return nil, err
@@ -194,6 +202,7 @@ func (s *Sandbox) RunCode(ctx context.Context, code string, opts RunCodeOptions)
 		return nil, err
 	}
 	req.Header.Set("Content-Type", "application/json")
+	s.addTrafficTokenHeaders(req)
 
 	resp, err := s.client.dataHTTP.Do(req)
 	if err != nil {

--- a/sdk/go/sdk_test.go
+++ b/sdk/go/sdk_test.go
@@ -447,6 +447,8 @@ func TestParseLineAcceptsStringTraceback(t *testing.T) {
 
 func TestRunCodeUsesProxyNodeIPAndPreservesHost(t *testing.T) {
 	var gotHost string
+	var gotE2BToken string
+	var gotCubeToken string
 	var gotPayload map[string]any
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -454,6 +456,8 @@ func TestRunCodeUsesProxyNodeIPAndPreservesHost(t *testing.T) {
 			t.Fatalf("request=%s %s", r.Method, r.URL.Path)
 		}
 		gotHost = r.Host
+		gotE2BToken = r.Header.Get("e2b-traffic-access-token")
+		gotCubeToken = r.Header.Get("cube-traffic-access-token")
 		if err := json.NewDecoder(r.Body).Decode(&gotPayload); err != nil {
 			t.Fatalf("decode payload: %v", err)
 		}
@@ -474,7 +478,7 @@ func TestRunCodeUsesProxyNodeIPAndPreservesHost(t *testing.T) {
 		RequestTimeout: time.Second,
 		Timeout:        300 * time.Second,
 	})
-	sb := &Sandbox{client: client, SandboxID: "sb-proxy", TemplateID: "tpl-test"}
+	sb := &Sandbox{client: client, SandboxID: "sb-proxy", TemplateID: "tpl-test", TrafficAccessToken: "traffic-token"}
 
 	var stdout []string
 	execution, err := sb.RunCode(context.Background(), "1 + 1", RunCodeOptions{
@@ -490,6 +494,9 @@ func TestRunCodeUsesProxyNodeIPAndPreservesHost(t *testing.T) {
 
 	if gotHost != "49999-sb-proxy.cube.test" {
 		t.Fatalf("Host=%q", gotHost)
+	}
+	if gotE2BToken != "traffic-token" || gotCubeToken != "traffic-token" {
+		t.Fatalf("traffic tokens=%q/%q, want traffic-token", gotE2BToken, gotCubeToken)
 	}
 	assertString(t, gotPayload, "code", "1 + 1")
 	assertString(t, gotPayload, "language", "python")
@@ -651,10 +658,11 @@ func TestCommandsRunUsesEnvdProcessStart(t *testing.T) {
 		RequestTimeout: time.Second,
 	})
 	sb := &Sandbox{
-		client:          client,
-		SandboxID:       "sb-proc",
-		TemplateID:      "tpl-test",
-		EnvdAccessToken: "envd-token",
+		client:             client,
+		SandboxID:          "sb-proc",
+		TemplateID:         "tpl-test",
+		EnvdAccessToken:    "envd-token",
+		TrafficAccessToken: "traffic-token",
 	}
 
 	result, err := sb.Commands().Run(context.Background(), "echo hello", CommandOptions{
@@ -677,6 +685,9 @@ func TestCommandsRunUsesEnvdProcessStart(t *testing.T) {
 	}
 	if gotHeaders.Get("Connect-Timeout-Ms") != "1500" || gotHeaders.Get("X-Access-Token") != "envd-token" {
 		t.Fatalf("headers=%#v", gotHeaders)
+	}
+	if gotHeaders.Get("e2b-traffic-access-token") != "traffic-token" || gotHeaders.Get("cube-traffic-access-token") != "traffic-token" {
+		t.Fatalf("traffic headers=%#v", gotHeaders)
 	}
 
 	processPayload, ok := gotPayload["process"].(map[string]any)
@@ -763,6 +774,8 @@ func TestFilesReadUsesEnvdHTTPFileAPI(t *testing.T) {
 	var gotHost string
 	var gotPath string
 	var gotToken string
+	var gotE2BToken string
+	var gotCubeToken string
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet || r.URL.Path != "/files" {
@@ -771,6 +784,8 @@ func TestFilesReadUsesEnvdHTTPFileAPI(t *testing.T) {
 		gotHost = r.Host
 		gotPath = r.URL.Query().Get("path")
 		gotToken = r.Header.Get("X-Access-Token")
+		gotE2BToken = r.Header.Get("e2b-traffic-access-token")
+		gotCubeToken = r.Header.Get("cube-traffic-access-token")
 		fmt.Fprint(w, "file content")
 	}))
 	defer server.Close()
@@ -783,10 +798,11 @@ func TestFilesReadUsesEnvdHTTPFileAPI(t *testing.T) {
 		RequestTimeout: time.Second,
 	})
 	sb := &Sandbox{
-		client:          client,
-		SandboxID:       "sb-files",
-		TemplateID:      "tpl-test",
-		EnvdAccessToken: "envd-token",
+		client:             client,
+		SandboxID:          "sb-files",
+		TemplateID:         "tpl-test",
+		EnvdAccessToken:    "envd-token",
+		TrafficAccessToken: "traffic-token",
 	}
 
 	content, err := sb.Files().Read(context.Background(), "/tmp/foo bar.txt")
@@ -798,6 +814,9 @@ func TestFilesReadUsesEnvdHTTPFileAPI(t *testing.T) {
 	}
 	if gotHost != "49983-sb-files.cube.test" || gotPath != "/tmp/foo bar.txt" || gotToken != "envd-token" {
 		t.Fatalf("host/path/token=%q/%q/%q", gotHost, gotPath, gotToken)
+	}
+	if gotE2BToken != "traffic-token" || gotCubeToken != "traffic-token" {
+		t.Fatalf("traffic tokens=%q/%q, want traffic-token", gotE2BToken, gotCubeToken)
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes the Go SDK private sandbox data-plane request behavior so `TrafficAccessToken` is attached to CubeProxy requests when present, allowing private sandboxes created with `AllowPublicTraffic=false` to use RunCode, commands, files, and PTY APIs successfully.

Fixes #1181

## Changes

### Modified Files

- `sdk/go/sandbox.go` — Add a shared `addTrafficTokenHeaders` helper and call it from `RunCode`
- `sdk/go/envd.go` — Attach traffic token headers in `newEnvdRequest`, covering envd-backed commands, files, filesystem, watch, and PTY requests
- `sdk/go/sdk_test.go` — Add regression coverage for RunCode, Commands, and Files traffic token headers
- `sdk/go/pty_test.go` — Add regression coverage for PTY traffic token headers

## Features

1. `sb.RunCode(...)` now sends `e2b-traffic-access-token` and `cube-traffic-access-token` when `Sandbox.TrafficAccessToken` is set
2. envd HTTP / Connect requests now share the same traffic token propagation through `newEnvdRequest`
3. `sb.Commands().Run(...)` now works with private sandbox CubeProxy traffic token enforcement
4. `sb.Files().Read(...)` and other envd file / filesystem APIs inherit the traffic token headers
5. `sb.Pty().Create(...)` and PTY connect-style requests inherit the traffic token headers
6. Public sandbox behavior is unchanged because headers are omitted when `TrafficAccessToken` is empty

## Testing

```bash
# Run the full Go SDK unit test suite
cd sdk/go
go test -count=1 ./...

# Run targeted traffic token regression tests
go test -count=1 -run "TestRunCodeUsesProxyNodeIPAndPreservesHost|TestCommandsRunUsesEnvdProcessStart|TestFilesReadUsesEnvdHTTPFileAPI|TestPtyCreateStreamsAndWaits" ./...
Test results:
- go test -count=1 ./... — passed
- Targeted traffic token regression tests — passed
Note:
- Docker builder validation was not run locally because the Docker Desktop Linux engine was unavailable.