### PR TITLE
upgrade big pod for k8s cube compute node

### DIFF
--- a/EgressProxy/Dockerfile.configurer
+++ b/EgressProxy/Dockerfile.configurer
@@ -1,0 +1,18 @@
+FROM alpine:3.22
+
+RUN apk add --no-cache \
+      busybox-extras \
+      iproute2 \
+      ipset \
+      iptables \
+      iptables-legacy \
+      kmod
+
+COPY configurer/ /opt/cube-egress/
+RUN chmod 0755 /opt/cube-egress/*.sh \
+    && mkdir -p /run/cube-egress /usr/local/sbin \
+    && ln -s /usr/sbin/iptables-legacy /usr/local/sbin/iptables \
+    && ln -s /usr/sbin/iptables-legacy-save /usr/local/sbin/iptables-save \
+    && ln -s /usr/sbin/iptables-legacy-restore /usr/local/sbin/iptables-restore
+
+ENTRYPOINT ["/opt/cube-egress/entrypoint.sh"]

--- a/EgressProxy/Dockerfile.proxy
+++ b/EgressProxy/Dockerfile.proxy
@@ -1,0 +1,13 @@
+FROM alpine:3.22
+
+RUN apk add --no-cache \
+      busybox-extras \
+      iproute2 \
+      iptables \
+      util-linux
+
+COPY proxy/ /opt/cube-egress/
+RUN chmod 0755 /opt/cube-egress/*.sh \
+    && mkdir -p /run/cube-egress
+
+ENTRYPOINT ["/opt/cube-egress/entrypoint.sh"]

--- a/EgressProxy/configurer/cleanup.sh
+++ b/EgressProxy/configurer/cleanup.sh
@@ -1,0 +1,207 @@
+#!/bin/sh
+set -eu
+
+ROUTE_TABLE=100
+RULE_PRIORITY=10900
+ROUTE_MARK=0x1000/0x1000
+CLUSTER_CIDR_SET=CUBE-EGRESS-CLUSTER-CIDRS
+CLUSTER_CIDR_SET_NEXT=CUBE-EGRESS-CLUSTER-CIDRS-NEXT
+SNAT_CHAIN=CUBE-EGRESS-SNAT
+CUBE_ROUTER_NAT_IP="${CUBE_ROUTER_NAT_IP:?CUBE_ROUTER_NAT_IP is required}"
+STATE_DIR="${CUBE_EGRESS_STATE_DIR:-/run/cube-egress}"
+CLEANUP_REQUEST_FILE="${STATE_DIR}/cleanup-requested"
+RECONCILE_INTERVAL_SECONDS="${CUBE_EGRESS_RECONCILE_INTERVAL_SECONDS:-10}"
+CLEANUP_WAIT_SECONDS="${CUBE_EGRESS_CLEANUP_WAIT_SECONDS:-$((RECONCILE_INTERVAL_SECONDS + 10))}"
+RP_FILTER_PATH="${CUBE_EGRESS_RP_FILTER_PATH:-/host-sysctl/rp_filter}"
+RP_FILTER_STATE="${STATE_DIR}/rp-filter.previous"
+
+log() {
+  printf '[egress-cleanup] %s\n' "$*"
+}
+
+mark_chain_is_owned() {
+  chain="$1"
+  [ "${chain}" = "-N CUBE-EGRESS-MARK" ] && return 0
+  [ "${chain}" = "$(cat <<'EOF'
+-N CUBE-EGRESS-MARK
+-A CUBE-EGRESS-MARK -m set --match-set CUBE-EGRESS-CLUSTER-CIDRS dst -j MARK --set-xmark 0x1000/0x1000
+EOF
+)" ]
+}
+
+preflight_owned_ipset() {
+  state="$(ipset save "${CLUSTER_CIDR_SET}" 2>/dev/null || true)"
+  [ -z "${state}" ] && return 0
+  printf '%s\n' "${state}" |
+    awk -v name="${CLUSTER_CIDR_SET}" '
+      NR == 1 {
+        if ($1 != "create" || $2 != name || $3 != "hash:net") exit 1
+        next
+      }
+      $1 != "add" || $2 != name { exit 1 }
+    ' || {
+      log "refusing to remove foreign ipset ${CLUSTER_CIDR_SET}"
+      return 1
+    }
+}
+
+cleanup_mark_rules() {
+  jump="-A PREROUTING -s ${CUBE_ROUTER_NAT_IP}/32 -i cube-router -j CUBE-EGRESS-MARK"
+  jumps="$(
+    iptables -w -t mangle -S PREROUTING |
+      sed -n '/^-A .* -j CUBE-EGRESS-MARK$/p'
+  )"
+  [ -z "${jumps}" ] || [ "${jumps}" = "${jump}" ] || {
+    log "refusing to remove foreign CUBE-EGRESS-MARK jump: ${jumps}"
+    return 1
+  }
+
+  if chain="$(iptables -w -t mangle -S CUBE-EGRESS-MARK 2>/dev/null)"; then
+    mark_chain_is_owned "${chain}" || {
+      log "refusing to remove foreign CUBE-EGRESS-MARK chain"
+      return 1
+    }
+  else
+    chain=""
+  fi
+
+  while iptables -w -t mangle -C PREROUTING \
+    -s "${CUBE_ROUTER_NAT_IP}/32" -i cube-router \
+    -j CUBE-EGRESS-MARK 2>/dev/null; do
+    iptables -w -t mangle -D PREROUTING \
+      -s "${CUBE_ROUTER_NAT_IP}/32" -i cube-router \
+      -j CUBE-EGRESS-MARK
+  done
+  if [ -n "${chain}" ]; then
+    iptables -w -t mangle -F CUBE-EGRESS-MARK
+    iptables -w -t mangle -X CUBE-EGRESS-MARK
+  fi
+}
+
+expected_forward_chain() {
+  cat <<'EOF'
+-N CUBE-EGRESS
+-A CUBE-EGRESS -o cube-egress-p0 -j ACCEPT
+-A CUBE-EGRESS -o cube-egress-p1 -j ACCEPT
+-A CUBE-EGRESS -j DROP
+EOF
+}
+
+cleanup_forward_rules() {
+  if chain="$(iptables -w -t filter -S CUBE-EGRESS 2>/dev/null)"; then
+    [ "${chain}" = "$(expected_forward_chain)" ] ||
+      [ "${chain}" = "-N CUBE-EGRESS" ] || {
+        log "refusing to remove foreign CUBE-EGRESS chain"
+        return 1
+      }
+  else
+    chain=""
+  fi
+
+  delete_rule() {
+    while iptables -w -t filter -C FORWARD "$@" 2>/dev/null; do
+      iptables -w -t filter -D FORWARD "$@"
+    done
+  }
+  delete_rule -s "${CUBE_ROUTER_NAT_IP}/32" -i cube-router \
+    -m mark --mark "${ROUTE_MARK}" -j CUBE-EGRESS
+
+  if [ -n "${chain}" ]; then
+    iptables -w -t filter -F CUBE-EGRESS
+    iptables -w -t filter -X CUBE-EGRESS
+  fi
+}
+
+expected_snat_chain() {
+  cat <<EOF
+-N ${SNAT_CHAIN}
+-A ${SNAT_CHAIN} -o cube-egress-p0 -j SNAT --to-source ${CUBE_ROUTER_NAT_IP}
+-A ${SNAT_CHAIN} -o cube-egress-p1 -j SNAT --to-source ${CUBE_ROUTER_NAT_IP}
+EOF
+}
+
+cleanup_snat_rules() {
+  if chain="$(iptables -w -t nat -S "${SNAT_CHAIN}" 2>/dev/null)"; then
+    [ "${chain}" = "$(expected_snat_chain)" ] ||
+      [ "${chain}" = "-N ${SNAT_CHAIN}" ] || {
+        log "refusing to remove foreign ${SNAT_CHAIN} chain"
+        return 1
+      }
+  else
+    chain=""
+  fi
+
+  while iptables -w -t nat -C POSTROUTING \
+    -s "${CUBE_ROUTER_NAT_IP}/32" -m mark --mark "${ROUTE_MARK}" \
+    -j "${SNAT_CHAIN}" 2>/dev/null; do
+    iptables -w -t nat -D POSTROUTING \
+      -s "${CUBE_ROUTER_NAT_IP}/32" -m mark --mark "${ROUTE_MARK}" \
+      -j "${SNAT_CHAIN}"
+  done
+  if [ -n "${chain}" ]; then
+    iptables -w -t nat -F "${SNAT_CHAIN}"
+    iptables -w -t nat -X "${SNAT_CHAIN}"
+  fi
+}
+
+restore_rp_filter() {
+  [ -f "${RP_FILTER_STATE}" ] || return 0
+  previous="$(cat "${RP_FILTER_STATE}")"
+  case "${previous}" in
+    0 | 1 | 2) ;;
+    *) log "invalid saved rp_filter value: ${previous}"; return 1 ;;
+  esac
+  current="$(cat "${RP_FILTER_PATH}")"
+  if [ "${current}" = 0 ]; then
+    printf '%s\n' "${previous}" > "${RP_FILTER_PATH}"
+  else
+    log "rp_filter changed externally to ${current}; leaving it unchanged"
+  fi
+  rm -f "${RP_FILTER_STATE}"
+}
+
+cleanup_policy_routing() {
+  expected="${RULE_PRIORITY}:	from ${CUBE_ROUTER_NAT_IP} fwmark ${ROUTE_MARK} iif cube-router lookup ${ROUTE_TABLE}"
+  current="$(ip -4 rule show priority "${RULE_PRIORITY}" | sed -n '1p')"
+  if [ -n "${current}" ] && [ "${current}" != "${expected}" ]; then
+    log "refusing to remove foreign priority ${RULE_PRIORITY}: ${current}"
+    return 1
+  fi
+  if [ -n "${current}" ]; then
+    ip -4 rule del priority "${RULE_PRIORITY}" \
+      iif cube-router from "${CUBE_ROUTER_NAT_IP}/32" \
+      fwmark "${ROUTE_MARK}" lookup "${ROUTE_TABLE}"
+  fi
+
+  ip route del table "${ROUTE_TABLE}" \
+    default via 169.254.240.2 dev cube-egress-p0 metric 100 2>/dev/null || true
+  ip route del table "${ROUTE_TABLE}" \
+    default via 169.254.240.6 dev cube-egress-p1 metric 100 2>/dev/null || true
+  ip route del table "${ROUTE_TABLE}" \
+    unreachable default metric 32767 2>/dev/null || true
+}
+
+cleanup_owned_state() {
+  preflight_owned_ipset
+  cleanup_mark_rules
+  ipset destroy "${CLUSTER_CIDR_SET_NEXT}" 2>/dev/null || true
+  ipset destroy "${CLUSTER_CIDR_SET}" 2>/dev/null || true
+  cleanup_forward_rules
+  cleanup_snat_rules
+  cleanup_policy_routing
+  restore_rp_filter
+}
+
+touch "${CLEANUP_REQUEST_FILE}"
+attempt=0
+while [ -f "${STATE_DIR}/ready" ] &&
+  [ "${attempt}" -lt "${CLEANUP_WAIT_SECONDS}" ]; do
+  attempt=$((attempt + 1))
+  sleep 1
+done
+
+cleanup_owned_state || {
+  return 1 2>/dev/null || exit 1
+}
+rm -f "${STATE_DIR}/ready"
+log "owned host rules removed"

--- a/EgressProxy/configurer/entrypoint.sh
+++ b/EgressProxy/configurer/entrypoint.sh
@@ -1,0 +1,35 @@
+#!/bin/sh
+set -eu
+
+RECONCILE_INTERVAL_SECONDS="${CUBE_EGRESS_RECONCILE_INTERVAL_SECONDS:-10}"
+STATE_DIR="${CUBE_EGRESS_STATE_DIR:-/run/cube-egress}"
+CLEANUP_REQUEST_FILE="${STATE_DIR}/cleanup-requested"
+
+log() {
+  printf '[egress-configurer] %s\n' "$*"
+}
+
+# These matches are modular on some node kernels. Load them once rather than
+# adding module-management commands to every reconcile cycle.
+modprobe ip_set
+modprobe ip_set_hash_net
+modprobe xt_set
+
+rm -f "${CLEANUP_REQUEST_FILE}"
+
+while true; do
+  if [ -f "${CLEANUP_REQUEST_FILE}" ]; then
+    rm -f "${STATE_DIR}/ready"
+    sleep 1
+    continue
+  fi
+  if /opt/cube-egress/reconcile.sh; then
+    ready_tmp="${STATE_DIR}/ready.tmp.$$"
+    printf '%s\n' "$(date +%s)" > "${ready_tmp}"
+    mv -f "${ready_tmp}" "${STATE_DIR}/ready"
+  else
+    rm -f "${STATE_DIR}/ready"
+    log "reconcile failed; retrying in ${RECONCILE_INTERVAL_SECONDS}s"
+  fi
+  sleep "${RECONCILE_INTERVAL_SECONDS}"
+done

--- a/EgressProxy/configurer/health.sh
+++ b/EgressProxy/configurer/health.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+set -eu
+
+STATE_DIR="${CUBE_EGRESS_STATE_DIR:-/run/cube-egress}"
+RECONCILE_INTERVAL_SECONDS="${CUBE_EGRESS_RECONCILE_INTERVAL_SECONDS:-10}"
+ready_file="${STATE_DIR}/ready"
+
+test -f "${ready_file}"
+last_success="$(cat "${ready_file}")"
+case "${last_success}" in
+  '' | *[!0-9]*) exit 1 ;;
+esac
+now="$(date +%s)"
+max_age=$((RECONCILE_INTERVAL_SECONDS * 3 + 5))
+[ $((now - last_success)) -le "${max_age}" ]

--- a/EgressProxy/configurer/reconcile.sh
+++ b/EgressProxy/configurer/reconcile.sh
@@ -1,0 +1,561 @@
+#!/bin/sh
+set -eu
+
+ROUTE_TABLE=100
+RULE_PRIORITY=10900
+ROUTE_MARK=0x1000/0x1000
+CLUSTER_CIDR_SET=CUBE-EGRESS-CLUSTER-CIDRS
+CLUSTER_CIDR_SET_NEXT=CUBE-EGRESS-CLUSTER-CIDRS-NEXT
+SNAT_CHAIN=CUBE-EGRESS-SNAT
+RAW_CLUSTER_CIDRS="${CUBE_EGRESS_CLUSTER_CIDRS:?CUBE_EGRESS_CLUSTER_CIDRS is required}"
+NODE_NAME="${NODE_NAME:?NODE_NAME is required}"
+CUBE_ROUTER_NAT_IP="${CUBE_ROUTER_NAT_IP:?CUBE_ROUTER_NAT_IP is required}"
+STATE_DIR="${CUBE_EGRESS_STATE_DIR:-/run/cube-egress}"
+RP_FILTER_PATH="${CUBE_EGRESS_RP_FILTER_PATH:-/host-sysctl/rp_filter}"
+RP_FILTER_STATE="${STATE_DIR}/rp-filter.previous"
+
+log() {
+  printf '[egress-configurer] %s\n' "$*"
+}
+
+canonical_cidr() (
+  cidr="$1"
+  address="${cidr%/*}"
+  prefix="${cidr#*/}"
+  old_ifs="${IFS}"
+  IFS=.
+  set -- ${address}
+  IFS="${old_ifs}"
+  [ "$#" -eq 4 ] || return 1
+
+  remaining="${prefix}"
+  result=""
+  for octet in "$@"; do
+    if [ "${remaining}" -ge 8 ]; then
+      network_octet="${octet}"
+      remaining=$((remaining - 8))
+    elif [ "${remaining}" -le 0 ]; then
+      network_octet=0
+    else
+      case "${remaining}" in
+        1) mask=128 ;;
+        2) mask=192 ;;
+        3) mask=224 ;;
+        4) mask=240 ;;
+        5) mask=248 ;;
+        6) mask=252 ;;
+        7) mask=254 ;;
+        *) return 1 ;;
+      esac
+      network_octet=$((octet & mask))
+      remaining=0
+    fi
+    if [ -z "${result}" ]; then
+      result="${network_octet}"
+    else
+      result="${result}.${network_octet}"
+    fi
+  done
+  printf '%s/%s\n' "${result}" "${prefix}"
+)
+
+normalize_cluster_cidrs() {
+  normalized=""
+  old_ifs="${IFS}"
+  IFS=,
+  # shellcheck disable=SC2086 # Comma splitting is intentional and validated below.
+  set -- ${RAW_CLUSTER_CIDRS}
+  IFS="${old_ifs}"
+  for cidr in "$@"; do
+    canonical="$(canonical_cidr "${cidr}")" || return 1
+    case ",${normalized}," in
+      *,"${canonical}",*) continue ;;
+    esac
+    if [ -z "${normalized}" ]; then
+      normalized="${canonical}"
+    else
+      normalized="${normalized},${canonical}"
+    fi
+  done
+  printf '%s\n' "${normalized}"
+}
+
+CLUSTER_CIDRS="$(normalize_cluster_cidrs)"
+[ -n "${CLUSTER_CIDRS}" ] || {
+  log "no valid cluster CIDRs"
+  exit 1
+}
+
+cluster_cidrs() {
+  printf '%s\n' "${CLUSTER_CIDRS}" | tr ',' '\n'
+}
+
+load_state_snapshots() {
+  MANGLE_RULES="$(iptables -w -t mangle -S)"
+  FILTER_RULES="$(iptables -w -t filter -S)"
+  NAT_RULES="$(iptables -w -t nat -S)"
+  POLICY_RULES="$(ip -4 rule show)"
+  # A fresh node has no policy-routing table yet. iproute2 reports that as a
+  # non-zero exit, but it is an empty initial state that reconcile must create.
+  ROUTE_STATE="$(ip route show table "${ROUTE_TABLE}" 2>/dev/null || true)"
+  IPSET_STATE="$(ipset save "${CLUSTER_CIDR_SET}" 2>/dev/null || true)"
+}
+
+peer_gateway() {
+  case "$1" in
+    cube-egress-p0) printf '169.254.240.2\n' ;;
+    cube-egress-p1) printf '169.254.240.6\n' ;;
+    *) return 1 ;;
+  esac
+}
+
+peer_is_healthy() {
+  iface="$1"
+  gateway="$(peer_gateway "${iface}")" || return 1
+  ip link show "${iface}" >/dev/null 2>&1 &&
+    response="$(
+      printf 'health\n' |
+        nc -w 2 -s "$(ip -4 -o address show dev "${iface}" |
+          awk 'NR == 1 { sub(/\/.*/, "", $4); print $4 }')" \
+          "${gateway}" 19091 2>/dev/null || true
+    )" &&
+    [ "${response}" = "ok" ]
+}
+
+ensure_route_mark_ownership() {
+  foreign="$(
+    printf '%s\n' "${MANGLE_RULES}" |
+      grep -F -- "MARK --set-xmark ${ROUTE_MARK}" |
+      grep -v '^-A CUBE-EGRESS-MARK ' || true
+  )"
+  if [ -n "${foreign}" ]; then
+    log "route mark ${ROUTE_MARK} is occupied: ${foreign}"
+    return 1
+  fi
+}
+
+expected_mark_chain() {
+  printf -- '-N CUBE-EGRESS-MARK\n'
+  printf -- '-A CUBE-EGRESS-MARK -m set --match-set %s dst -j MARK --set-xmark %s\n' \
+    "${CLUSTER_CIDR_SET}" "${ROUTE_MARK}"
+}
+
+expected_mark_jump() {
+  printf -- '-A PREROUTING -s %s/32 -i cube-router -j CUBE-EGRESS-MARK\n' \
+    "${CUBE_ROUTER_NAT_IP}"
+}
+
+expected_forward_chain() {
+  cat <<'EOF'
+-N CUBE-EGRESS
+-A CUBE-EGRESS -o cube-egress-p0 -j ACCEPT
+-A CUBE-EGRESS -o cube-egress-p1 -j ACCEPT
+-A CUBE-EGRESS -j DROP
+EOF
+}
+
+expected_forward_rules() {
+  printf -- '-A FORWARD -s %s/32 -i cube-router -m mark --mark %s -j CUBE-EGRESS\n' \
+    "${CUBE_ROUTER_NAT_IP}" "${ROUTE_MARK}"
+}
+
+expected_snat_chain() {
+  printf -- '-N %s\n' "${SNAT_CHAIN}"
+  printf -- '-A %s -o cube-egress-p0 -j SNAT --to-source %s\n' \
+    "${SNAT_CHAIN}" "${CUBE_ROUTER_NAT_IP}"
+  printf -- '-A %s -o cube-egress-p1 -j SNAT --to-source %s\n' \
+    "${SNAT_CHAIN}" "${CUBE_ROUTER_NAT_IP}"
+}
+
+expected_snat_jump() {
+  printf -- '-A POSTROUTING -s %s/32 -m mark --mark %s -j %s\n' \
+    "${CUBE_ROUTER_NAT_IP}" "${ROUTE_MARK}" "${SNAT_CHAIN}"
+}
+
+preflight_iptables_ownership() {
+  expected="$(expected_mark_chain)"
+  current="$(
+    printf '%s\n' "${MANGLE_RULES}" |
+      awk '$1 == "-N" && $2 == "CUBE-EGRESS-MARK" ||
+           $1 == "-A" && $2 == "CUBE-EGRESS-MARK"'
+  )"
+  if [ -n "${current}" ]; then
+    [ "${current}" = "${expected}" ] ||
+      [ "${current}" = "-N CUBE-EGRESS-MARK" ] || {
+        log "iptables chain CUBE-EGRESS-MARK is occupied"
+        return 1
+      }
+  fi
+
+  expected="$(expected_mark_jump)"
+  current="$(
+    printf '%s\n' "${MANGLE_RULES}" |
+      sed -n '/^-A .* -j CUBE-EGRESS-MARK$/p'
+  )"
+  [ -z "${current}" ] || [ "${current}" = "${expected}" ] || {
+    log "iptables jump to CUBE-EGRESS-MARK is occupied: ${current}"
+    return 1
+  }
+
+  expected="$(expected_forward_chain)"
+  current="$(
+    printf '%s\n' "${FILTER_RULES}" |
+      awk '$1 == "-N" && $2 == "CUBE-EGRESS" ||
+           $1 == "-A" && $2 == "CUBE-EGRESS"'
+  )"
+  if [ -n "${current}" ]; then
+    [ "${current}" = "${expected}" ] ||
+      [ "${current}" = "-N CUBE-EGRESS" ] || {
+        log "iptables chain CUBE-EGRESS is occupied"
+        return 1
+      }
+  fi
+
+  expected="$(expected_forward_rules)"
+  current="$(
+    printf '%s\n' "${FILTER_RULES}" |
+      awk -v nat="${CUBE_ROUTER_NAT_IP}/32" '
+        $1 == "-A" && $2 == "FORWARD" && $NF == "CUBE-EGRESS" { print }
+      '
+  )"
+  [ -z "${current}" ] || [ "${current}" = "${expected}" ] || {
+    log "EgressProxy FORWARD rules are occupied: ${current}"
+    return 1
+  }
+
+  expected="$(expected_snat_chain)"
+  current="$(
+    printf '%s\n' "${NAT_RULES}" |
+      awk -v chain="${SNAT_CHAIN}" \
+        '$1 == "-N" && $2 == chain || $1 == "-A" && $2 == chain'
+  )"
+  if [ -n "${current}" ]; then
+    [ "${current}" = "${expected}" ] ||
+      [ "${current}" = "-N ${SNAT_CHAIN}" ] || {
+        log "iptables chain ${SNAT_CHAIN} is occupied"
+        return 1
+      }
+  fi
+
+  expected="$(expected_snat_jump)"
+  current="$(
+    printf '%s\n' "${NAT_RULES}" |
+      sed -n "/^-A .* -j ${SNAT_CHAIN}$/p"
+  )"
+  [ -z "${current}" ] || [ "${current}" = "${expected}" ] || {
+    log "EgressProxy SNAT jump is occupied: ${current}"
+    return 1
+  }
+}
+
+preflight_ipset_ownership() {
+  [ -z "${IPSET_STATE}" ] && return 0
+  first_line="$(printf '%s\n' "${IPSET_STATE}" | sed -n '1p')"
+  case "${first_line}" in
+    "create ${CLUSTER_CIDR_SET} hash:net "* | \
+    "create ${CLUSTER_CIDR_SET} hash:net")
+      ;;
+    *)
+      log "ipset ${CLUSTER_CIDR_SET} is occupied: ${first_line}"
+      return 1
+      ;;
+  esac
+}
+
+expected_ipset_members() {
+  while IFS= read -r cidr; do
+    printf 'add %s %s\n' "${CLUSTER_CIDR_SET}" "${cidr}"
+  done <<EOF
+$(cluster_cidrs)
+EOF
+}
+
+ensure_cluster_cidr_set() {
+  current_members="$(
+    printf '%s\n' "${IPSET_STATE}" |
+      awk -v name="${CLUSTER_CIDR_SET}" '$1 == "add" && $2 == name' |
+      sort
+  )"
+  expected_members="$(expected_ipset_members | sort)"
+  [ "${current_members}" = "${expected_members}" ] && return 0
+
+  ipset create "${CLUSTER_CIDR_SET}" hash:net family inet -exist
+  ipset create "${CLUSTER_CIDR_SET_NEXT}" hash:net family inet -exist
+  ipset flush "${CLUSTER_CIDR_SET_NEXT}"
+  while IFS= read -r cidr; do
+    ipset add "${CLUSTER_CIDR_SET_NEXT}" "${cidr}"
+  done <<EOF
+$(cluster_cidrs)
+EOF
+  ipset swap "${CLUSTER_CIDR_SET_NEXT}" "${CLUSTER_CIDR_SET}"
+  ipset destroy "${CLUSTER_CIDR_SET_NEXT}"
+}
+
+ensure_mark_chain() {
+  iptables -w -t mangle -N CUBE-EGRESS-MARK 2>/dev/null || true
+
+  expected_chain="$(expected_mark_chain)"
+  current_chain="$(
+    printf '%s\n' "${MANGLE_RULES}" |
+      awk '$1 == "-N" && $2 == "CUBE-EGRESS-MARK" ||
+           $1 == "-A" && $2 == "CUBE-EGRESS-MARK"'
+  )"
+  if [ "${current_chain}" != "${expected_chain}" ]; then
+    {
+      printf '*mangle\n'
+      printf -- '-F CUBE-EGRESS-MARK\n'
+      printf '%s\n' "${expected_chain}" | sed -n '/^-A /p'
+      printf 'COMMIT\n'
+    } | iptables-restore --noflush --wait
+  fi
+
+  expected_jump="$(expected_mark_jump)"
+  current_jumps="$(
+    printf '%s\n' "${MANGLE_RULES}" |
+      sed -n '/^-A .* -j CUBE-EGRESS-MARK$/p'
+  )"
+  first_rule="$(
+    printf '%s\n' "${MANGLE_RULES}" |
+      sed -n '/^-A /{p;q;}'
+  )"
+  if [ "${current_jumps}" != "${expected_jump}" ] ||
+     [ "${first_rule}" != "${expected_jump}" ]; then
+    {
+      printf '*mangle\n'
+      printf '%s\n' "${current_jumps}" | sed 's/^-A /-D /'
+      printf -- '-I PREROUTING 1 -s %s/32 -i cube-router -j CUBE-EGRESS-MARK\n' \
+        "${CUBE_ROUTER_NAT_IP}"
+      printf 'COMMIT\n'
+    } | iptables-restore --noflush --wait
+  fi
+}
+
+ensure_forward_chain() {
+  iptables -w -t filter -N CUBE-EGRESS 2>/dev/null || true
+
+  expected_chain="$(expected_forward_chain)"
+  current_chain="$(
+    printf '%s\n' "${FILTER_RULES}" |
+      awk '$1 == "-N" && $2 == "CUBE-EGRESS" ||
+           $1 == "-A" && $2 == "CUBE-EGRESS"'
+  )"
+  if [ "${current_chain}" != "${expected_chain}" ]; then
+    {
+      printf '*filter\n'
+      printf -- '-F CUBE-EGRESS\n'
+      printf '%s\n' "${expected_chain}" | sed -n '/^-A /p'
+      printf 'COMMIT\n'
+    } | iptables-restore --noflush --wait
+  fi
+
+  expected_rules="$(expected_forward_rules)"
+  current_rules="$(
+    printf '%s\n' "${FILTER_RULES}" |
+      awk '$1 == "-A" && $2 == "FORWARD" && $NF == "CUBE-EGRESS" { print }'
+  )"
+  leading_rules="$(
+    printf '%s\n' "${FILTER_RULES}" |
+      sed -n '/^-A /p' |
+      sed -n '1p'
+  )"
+  if [ "${current_rules}" != "${expected_rules}" ] ||
+     [ "${leading_rules}" != "${expected_rules}" ]; then
+    {
+      printf '*filter\n'
+      printf '%s\n' "${current_rules}" | sed 's/^-A /-D /'
+      printf '%s\n' "${expected_rules}" |
+        awk '{ line[NR] = $0 } END { for (i = NR; i >= 1; i--) print line[i] }' |
+        sed 's/^-A FORWARD /-I FORWARD 1 /'
+      printf 'COMMIT\n'
+    } | iptables-restore --noflush --wait
+  fi
+}
+
+ensure_snat_chain() {
+  iptables -w -t nat -N "${SNAT_CHAIN}" 2>/dev/null || true
+
+  expected_chain="$(expected_snat_chain)"
+  current_chain="$(
+    printf '%s\n' "${NAT_RULES}" |
+      awk -v chain="${SNAT_CHAIN}" \
+        '$1 == "-N" && $2 == chain || $1 == "-A" && $2 == chain'
+  )"
+  if [ "${current_chain}" != "${expected_chain}" ]; then
+    {
+      printf '*nat\n'
+      printf -- '-F %s\n' "${SNAT_CHAIN}"
+      printf '%s\n' "${expected_chain}" | sed -n '/^-A /p'
+      printf 'COMMIT\n'
+    } | iptables-restore --noflush --wait
+  fi
+
+  expected_jump="$(expected_snat_jump)"
+  current_jumps="$(
+    printf '%s\n' "${NAT_RULES}" |
+      sed -n "/^-A .* -j ${SNAT_CHAIN}$/p"
+  )"
+  first_rule="$(
+    printf '%s\n' "${NAT_RULES}" |
+      awk '$1 == "-A" && $2 == "POSTROUTING" { print; exit }'
+  )"
+  if [ "${current_jumps}" != "${expected_jump}" ] ||
+     [ "${first_rule}" != "${expected_jump}" ]; then
+    {
+      printf '*nat\n'
+      printf '%s\n' "${current_jumps}" | sed 's/^-A /-D /'
+      printf -- '-I POSTROUTING 1 -s %s/32 -m mark --mark %s -j %s\n' \
+        "${CUBE_ROUTER_NAT_IP}" "${ROUTE_MARK}" "${SNAT_CHAIN}"
+      printf 'COMMIT\n'
+    } | iptables-restore --noflush --wait
+  fi
+}
+
+ensure_rp_filter() {
+  current="$(cat "${RP_FILTER_PATH}")"
+  case "${current}" in
+    0 | 1 | 2) ;;
+    *) log "invalid rp_filter value: ${current}"; return 1 ;;
+  esac
+  if [ ! -f "${RP_FILTER_STATE}" ]; then
+    printf '%s\n' "${current}" > "${RP_FILTER_STATE}.tmp"
+    mv "${RP_FILTER_STATE}.tmp" "${RP_FILTER_STATE}"
+  fi
+  [ "${current}" = 0 ] || printf '0\n' > "${RP_FILTER_PATH}"
+}
+
+expected_policy_rule() {
+  printf '%s:\tfrom %s fwmark %s iif cube-router lookup %s\n' \
+    "${RULE_PRIORITY}" "${CUBE_ROUTER_NAT_IP}" "${ROUTE_MARK}" "${ROUTE_TABLE}"
+}
+
+preflight_policy_rule_ownership() {
+  expected="$(expected_policy_rule)"
+  current="$(
+    printf '%s\n' "${POLICY_RULES}" |
+      awk -v priority="${RULE_PRIORITY}:" '$1 == priority { print; exit }'
+  )"
+  if [ -n "${current}" ] && [ "${current}" != "${expected}" ]; then
+    log "priority ${RULE_PRIORITY} is occupied: ${current}"
+    return 1
+  fi
+}
+
+ensure_policy_rule() {
+  current="$(
+    printf '%s\n' "${POLICY_RULES}" |
+      awk -v priority="${RULE_PRIORITY}:" '$1 == priority { print; exit }'
+  )"
+  [ "${current}" = "$(expected_policy_rule)" ] && return 0
+  ip -4 rule add priority "${RULE_PRIORITY}" \
+    iif cube-router from "${CUBE_ROUTER_NAT_IP}/32" \
+    fwmark "${ROUTE_MARK}" lookup "${ROUTE_TABLE}"
+}
+
+ensure_unreachable_route() {
+  printf '%s\n' "${ROUTE_STATE}" |
+    grep -Fx 'unreachable default metric 32767' >/dev/null && return 0
+  ip route replace table "${ROUTE_TABLE}" \
+    unreachable default metric 32767
+}
+
+ensure_route_table_ownership() {
+  while IFS= read -r route; do
+    [ -n "${route}" ] || continue
+    route="$(printf '%s\n' "${route}" | sed 's/[[:space:]]*$//')"
+    case "${route}" in
+      "unreachable default metric 32767" | \
+      "default via 169.254.240.2 dev cube-egress-p0 metric 100" | \
+      "default via 169.254.240.6 dev cube-egress-p1 metric 100")
+        ;;
+      *)
+        log "route table ${ROUTE_TABLE} is occupied: ${route}"
+        return 1
+        ;;
+    esac
+  done <<EOF
+${ROUTE_STATE}
+EOF
+}
+
+current_active_iface() {
+  printf '%s\n' "${ROUTE_STATE}" |
+    awk '
+      $1 == "default" {
+        for (i = 2; i <= NF; i++) {
+          if ($i == "dev") dev = $(i + 1)
+          if ($i == "metric" && $(i + 1) == "100") metric = 1
+        }
+        if (metric) { print dev; exit }
+      }
+    '
+}
+
+replace_active_route() {
+  iface="$1"
+  gateway="$(peer_gateway "${iface}")"
+  if printf '%s\n' "${ROUTE_STATE}" |
+    grep -F "default via ${gateway} dev ${iface}" |
+    grep -F "metric 100" >/dev/null; then
+    return 0
+  fi
+  ip route replace table "${ROUTE_TABLE}" \
+    default via "${gateway}" dev "${iface}" metric 100
+}
+
+remove_active_route() {
+  printf '%s\n' "${ROUTE_STATE}" |
+    awk '$1 == "default" {
+      for (i = 2; i <= NF; i++) {
+        if ($i == "metric" && $(i + 1) == "100") found = 1
+      }
+    } END { exit !found }' || return 0
+  ip route del table "${ROUTE_TABLE}" default metric 100 2>/dev/null || true
+}
+
+ensure_policy_route() {
+  ensure_route_table_ownership
+  ensure_unreachable_route
+  current_iface="$(current_active_iface)"
+  active_iface=""
+  if peer_is_healthy "${current_iface}"; then
+    active_iface="${current_iface}"
+  elif peer_is_healthy cube-egress-p0; then
+    active_iface=cube-egress-p0
+  elif peer_is_healthy cube-egress-p1; then
+    active_iface=cube-egress-p1
+  fi
+
+  if [ -z "${active_iface}" ]; then
+    remove_active_route
+    log "no healthy EgressProxy; cluster CIDRs are fail-closed"
+    return 1
+  fi
+
+  replace_active_route "${active_iface}"
+  if [ "${active_iface}" != "${current_iface}" ]; then
+    log "active peer changed: ${current_iface:-none} -> ${active_iface}"
+  fi
+}
+
+if [ "${CUBE_EGRESS_RECONCILE_LIBRARY_ONLY:-0}" = "1" ]; then
+  return 0 2>/dev/null || exit 0
+fi
+
+mkdir -p "${STATE_DIR}"
+ip link show cube-router >/dev/null
+load_state_snapshots
+ensure_route_mark_ownership
+preflight_iptables_ownership
+preflight_ipset_ownership
+preflight_policy_rule_ownership
+ensure_route_table_ownership
+ensure_cluster_cidr_set
+ensure_mark_chain
+ensure_forward_chain
+ensure_snat_chain
+ensure_rp_filter
+ensure_policy_rule
+route_failed=0
+ensure_policy_route || route_failed=1
+[ "${route_failed}" -eq 0 ] || exit 1
+log "ready: node=${NODE_NAME} nat=${CUBE_ROUTER_NAT_IP} table=${ROUTE_TABLE}"

--- a/EgressProxy/proxy/entrypoint.sh
+++ b/EgressProxy/proxy/entrypoint.sh
@@ -1,0 +1,64 @@
+#!/bin/sh
+set -eu
+
+POD_IP="${POD_IP:?POD_IP is required}"
+CUBE_ROUTER_NAT_IP="${CUBE_ROUTER_NAT_IP:?CUBE_ROUTER_NAT_IP is required}"
+CUBE_EGRESS_ROLE="${CUBE_EGRESS_ROLE:?CUBE_EGRESS_ROLE is required}"
+
+case "${CUBE_EGRESS_ROLE}" in
+  primary)
+    VETH_HOST_IP=169.254.240.1
+    VETH_POD_IP=169.254.240.2
+    ;;
+  standby)
+    VETH_HOST_IP=169.254.240.5
+    VETH_POD_IP=169.254.240.6
+    ;;
+  *)
+    printf 'unsupported EgressProxy role: %s\n' "${CUBE_EGRESS_ROLE}" >&2
+    exit 1
+    ;;
+esac
+
+test "$(cat /proc/sys/net/ipv4/ip_forward)" = "1"
+ip link show egress-host0 >/dev/null
+
+iptables -w -t filter -N CUBE-EGRESS-PROXY 2>/dev/null || true
+iptables -w -t filter -F CUBE-EGRESS-PROXY
+iptables -w -t filter -A CUBE-EGRESS-PROXY \
+  -s "${CUBE_ROUTER_NAT_IP}/32" \
+  -i egress-host0 -o eth0 -j ACCEPT
+iptables -w -t filter -A CUBE-EGRESS-PROXY \
+  -s "${VETH_HOST_IP}/32" \
+  -i egress-host0 -o eth0 -j ACCEPT
+iptables -w -t filter -A CUBE-EGRESS-PROXY \
+  -i eth0 -o egress-host0 \
+  -m conntrack --ctstate ESTABLISHED,RELATED \
+  -j ACCEPT
+iptables -w -t filter -A CUBE-EGRESS-PROXY -j DROP
+
+while iptables -w -t filter -C FORWARD \
+  -j CUBE-EGRESS-PROXY 2>/dev/null; do
+  iptables -w -t filter -D FORWARD -j CUBE-EGRESS-PROXY
+done
+iptables -w -t filter -I FORWARD 1 -j CUBE-EGRESS-PROXY
+
+iptables -w -t nat -N CUBE-EGRESS-PROXY-SNAT 2>/dev/null || true
+iptables -w -t nat -F CUBE-EGRESS-PROXY-SNAT
+iptables -w -t nat -A CUBE-EGRESS-PROXY-SNAT \
+  -o eth0 -j SNAT --to-source "${POD_IP}"
+for source_ip in "${CUBE_ROUTER_NAT_IP}" "${VETH_HOST_IP}"; do
+  while iptables -w -t nat -C POSTROUTING \
+    -s "${source_ip}/32" \
+    -j CUBE-EGRESS-PROXY-SNAT 2>/dev/null; do
+    iptables -w -t nat -D POSTROUTING \
+      -s "${source_ip}/32" \
+      -j CUBE-EGRESS-PROXY-SNAT
+  done
+  iptables -w -t nat -I POSTROUTING 1 \
+    -s "${source_ip}/32" \
+    -j CUBE-EGRESS-PROXY-SNAT
+done
+
+: > /run/cube-egress/ready
+exec /opt/cube-egress/health-server.sh "${VETH_POD_IP}"

--- a/EgressProxy/proxy/health-server.sh
+++ b/EgressProxy/proxy/health-server.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+set -eu
+
+LISTEN_IP="${1:?listen IP is required}"
+HEALTH_PORT=19091
+
+while true; do
+  if /opt/cube-egress/health.sh; then
+    response=ok
+  else
+    response=failed
+  fi
+  printf '%s\n' "${response}" |
+    nc -l -s "${LISTEN_IP}" -p "${HEALTH_PORT}"
+done

--- a/EgressProxy/proxy/health.sh
+++ b/EgressProxy/proxy/health.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+set -eu
+
+CUBE_ROUTER_NAT_IP="${CUBE_ROUTER_NAT_IP:?CUBE_ROUTER_NAT_IP is required}"
+CUBE_EGRESS_ROLE="${CUBE_EGRESS_ROLE:?CUBE_EGRESS_ROLE is required}"
+
+case "${CUBE_EGRESS_ROLE}" in
+  primary) VETH_HOST_IP=169.254.240.1 ;;
+  standby) VETH_HOST_IP=169.254.240.5 ;;
+  *) exit 1 ;;
+esac
+
+test -f /run/cube-egress/ready
+test "$(cat /proc/sys/net/ipv4/ip_forward)" = "1"
+ip link show egress-host0 >/dev/null
+ip route show "${CUBE_ROUTER_NAT_IP}/32" |
+  grep -F "dev egress-host0" >/dev/null
+iptables -w -t filter -C FORWARD -j CUBE-EGRESS-PROXY
+iptables -w -t nat -C POSTROUTING \
+  -s "${CUBE_ROUTER_NAT_IP}/32" \
+  -j CUBE-EGRESS-PROXY-SNAT
+iptables -w -t nat -C POSTROUTING \
+  -s "${VETH_HOST_IP}/32" \
+  -j CUBE-EGRESS-PROXY-SNAT

--- a/EgressProxy/proxy/setup-veth.sh
+++ b/EgressProxy/proxy/setup-veth.sh
@@ -1,0 +1,125 @@
+#!/bin/sh
+set -eu
+
+ROLE="${CUBE_EGRESS_ROLE:?CUBE_EGRESS_ROLE is required}"
+CUBE_ROUTER_NAT_IP="${CUBE_ROUTER_NAT_IP:?CUBE_ROUTER_NAT_IP is required}"
+POD_IFACE=egress-host0
+HOST_NETNS_PID="${CUBE_EGRESS_HOST_NETNS_PID:-1}"
+
+case "${ROLE}" in
+  primary)
+    HOST_IFACE=cube-egress-p0
+    HOST_IP=169.254.240.1
+    POD_IP=169.254.240.2
+    ;;
+  standby)
+    HOST_IFACE=cube-egress-p1
+    HOST_IP=169.254.240.5
+    POD_IP=169.254.240.6
+    ;;
+  *)
+    printf 'unsupported EgressProxy role: %s\n' "${ROLE}" >&2
+    exit 1
+    ;;
+esac
+
+MTU="$(cat /sys/class/net/eth0/mtu)"
+TEMP_HOST_IFACE="ce-${ROLE}"
+OWNER_ALIAS="cube-egress:${ROLE}"
+
+for owned_iface in cube-egress-p0 cube-egress-p1; do
+  case "${owned_iface}" in
+    cube-egress-p0) expected_alias=cube-egress:primary ;;
+    cube-egress-p1) expected_alias=cube-egress:standby ;;
+  esac
+  if nsenter -t "${HOST_NETNS_PID}" -n -- \
+    ip link show "${owned_iface}" >/dev/null 2>&1; then
+    actual_alias="$(
+      nsenter -t "${HOST_NETNS_PID}" -n -- \
+        ip -d -o link show "${owned_iface}" |
+        awk '{
+          for (i = 1; i <= NF; i++) {
+            if ($i == "alias") {
+              print $(i + 1)
+              exit
+            }
+          }
+        }'
+    )"
+    if [ "${actual_alias}" = "${expected_alias}" ]; then
+      continue
+    fi
+    printf 'host interface %s already exists and is not owned by %s\n' \
+      "${owned_iface}" "${expected_alias}" >&2
+    exit 1
+  fi
+done
+
+if conflict="$(
+  nsenter -t "${HOST_NETNS_PID}" -n -- ip -4 -o address show |
+    awk '
+      function ip_to_int(ip, octet) {
+        split(ip, octet, "[.]")
+        return (((octet[1] * 256 + octet[2]) * 256 + octet[3]) * 256 +
+          octet[4])
+      }
+      $2 == "cube-egress-p0" || $2 == "cube-egress-p1" { next }
+      {
+        split($4, cidr, "/")
+        size = 2 ^ (32 - cidr[2])
+        address = ip_to_int(cidr[1])
+        network = address - (address % size)
+        last = network + size - 1
+        target = ip_to_int("169.254.240.0")
+        if (network <= target + 7 && last >= target) {
+          print $2 " " $4
+        }
+      }
+    '
+)"; [ -n "${conflict}" ]; then
+  printf 'link-local range 169.254.240.0/29 is occupied: %s\n' \
+    "${conflict}" >&2
+  exit 1
+fi
+
+if nsenter -t "${HOST_NETNS_PID}" -n -- \
+  ip link show "${HOST_IFACE}" >/dev/null 2>&1; then
+  if ! nsenter -t "${HOST_NETNS_PID}" -n -- \
+    ip -d -o link show "${HOST_IFACE}" |
+    awk '{
+      for (i = 1; i <= NF; i++) {
+        if ($i == "alias") {
+          print $(i + 1)
+          exit
+        }
+      }
+    }' |
+    grep -Fx "${OWNER_ALIAS}" >/dev/null; then
+    printf 'host interface %s already exists and is not owned by %s\n' \
+      "${HOST_IFACE}" "${OWNER_ALIAS}" >&2
+    exit 1
+  fi
+  nsenter -t "${HOST_NETNS_PID}" -n -- ip link del "${HOST_IFACE}"
+fi
+ip link del "${POD_IFACE}" 2>/dev/null || true
+ip link add "${POD_IFACE}" type veth peer name "${TEMP_HOST_IFACE}"
+ip link set "${TEMP_HOST_IFACE}" netns "${HOST_NETNS_PID}"
+
+ip link set "${POD_IFACE}" mtu "${MTU}"
+ip address replace "${POD_IP}/30" dev "${POD_IFACE}"
+ip link set "${POD_IFACE}" up
+ip route replace "${CUBE_ROUTER_NAT_IP}/32" \
+  via "${HOST_IP}" dev "${POD_IFACE}"
+
+nsenter -t "${HOST_NETNS_PID}" -n -- \
+  ip link set "${TEMP_HOST_IFACE}" name "${HOST_IFACE}"
+nsenter -t "${HOST_NETNS_PID}" -n -- \
+  ip link set "${HOST_IFACE}" alias "${OWNER_ALIAS}"
+nsenter -t "${HOST_NETNS_PID}" -n -- \
+  ip link set "${HOST_IFACE}" mtu "${MTU}"
+nsenter -t "${HOST_NETNS_PID}" -n -- \
+  ip address replace "${HOST_IP}/30" dev "${HOST_IFACE}"
+nsenter -t "${HOST_NETNS_PID}" -n -- \
+  ip link set "${HOST_IFACE}" up
+
+echo 1 > /proc/sys/net/ipv4/ip_forward

--- a/deploy/kubernetes/chart/README.md
+++ b/deploy/kubernetes/chart/README.md
@@ -22,12 +22,18 @@ deploy/kubernetes/chart/
 
 ## Documentation
 
-Official docs (source of truth; do not keep a parallel copy under this chart):
+Project documentation:
+
+- [In-place Upgrade](./docs/UPGRADE_EN.md) / [原地升级](./docs/UPGRADE.md)
+- [Local-veth EgressProxy Design](./docs/EGRESS_VETH_EN.md) / [EgressProxy 本地 veth 方案](./docs/EGRESS_VETH.md)
+- [Local-veth EgressProxy Test Report](./docs/EGRESS_TEST_EN.md) / [EgressProxy 本地 veth 测试报告](./docs/EGRESS_TEST.md)
+
+Published guides:
 
 - [Kubernetes Deployment](https://cubesandbox.com/guide/kubernetes/) — overview and install order
 - [Helm Install](https://cubesandbox.com/guide/kubernetes/install) — prerequisites through `helm test`
 - [Architecture](https://cubesandbox.com/guide/kubernetes/architecture) — component layering, four compute DaemonSets, DNS / Proxy / Egress, compute-only mode
-- [Upgrade](https://cubesandbox.com/guide/kubernetes/upgrade) — control plane can roll; compute upgrades recreate the Big Pod and interrupt sandboxes
+- [Upgrade](https://cubesandbox.com/guide/kubernetes/upgrade) — general Kubernetes upgrade guidance
 - [FAQ](https://cubesandbox.com/guide/kubernetes/faq) — common install and runtime issues
 - Chinese: [https://cubesandbox.com/zh/guide/kubernetes/](https://cubesandbox.com/zh/guide/kubernetes/)
 

--- a/deploy/kubernetes/chart/docs/EGRESS_TEST.md
+++ b/deploy/kubernetes/chart/docs/EGRESS_TEST.md
@@ -1,0 +1,219 @@
+# EgressProxy 本地 veth 测试报告
+
+[English](./EGRESS_TEST_EN.md) | 中文
+
+## 1. 结论
+
+2026-07-28 在测试集群 `cls-d3bwloeq` 对
+[EGRESS_VETH.md](./EGRESS_VETH.md) 方案执行实现验证。
+
+本报告只验证数据路径能够受用户自定义 NetworkPolicy 管理。策略内容完全由
+用户决定；测试策略仅为验收临时创建并在测试后删除，不属于 Chart 资源，也
+不是产品内置或推荐策略。
+
+## 2. 测试环境
+
+| 项目 | 值 |
+| --- | --- |
+| 集群 | `cls-d3bwloeq` |
+| CNI | Cilium |
+| Helm Release | `cube`，最终验收 Revision 65 |
+| 计算节点 | `10.0.99.2`、`10.0.99.21`、`10.0.99.119` |
+| Proxy 镜像 | `20260728-review04` |
+| Configurer 镜像 | `20260728-review06` |
+| Cubelet / NetworkAgent 镜像 | `20260728-cgroupv2-01` |
+| 配置的集群 CIDR | `9.165.0.0/24` |
+| 测试 sandbox | `8032765ce82f4039b16a815e847958a5` |
+| sandbox 节点/IP | `10.0.99.119` / `172.16.0.196` |
+
+## 3. 静态和本地测试
+
+以下检查通过：
+
+- Helm lint；
+- Chart guard；
+- 主备粘滞切换测试；
+- policy rule、route table 和 iptables 所有权冲突测试；
+- 集群 CIDR 规范化及去重测试；
+- 仅删除本组件宿主机状态的清理测试；
+- privileged network namespace 中的真实 veth 生命周期测试；
+- Big Pod 进程迁移的 cgroup v1 `tasks` 和 v2 `cgroup.procs` 双模式测试；
+- 固定宿主接口所有权和冲突失败测试；
+- Shell 语法和 `git diff --check`；
+- Proxy、Configurer 镜像不包含隧道工具或依赖。
+
+Chart 渲染出的 EgressProxy 常驻资源只包含：
+
+- `cube-egress` namespace；
+- Primary、Standby 两个 Proxy DaemonSet；
+- Configurer DaemonSet。
+
+渲染结果不包含 EgressProxy StatefulSet、Service、PDB、NetworkPolicy 或隧道
+Secret。
+
+## 4. 数据路径
+
+三个计算节点均具备：
+
+```text
+cube-egress-p0  169.254.240.1/30
+cube-egress-p1  169.254.240.5/30
+10900: from 172.20.0.2 fwmark 0x1000/0x1000
+       iif cube-router lookup 100
+```
+
+活动路由示例：
+
+```text
+default via 169.254.240.2 dev cube-egress-p0 metric 100
+unreachable default metric 32767
+```
+
+真实 sandbox 访问 `allowed-svc` 成功。节点 mark、veth FORWARD 和 Proxy SNAT
+计数同步增加；目标 Nginx 观察到的源地址为同节点 Primary Proxy PodIP
+`9.165.0.130`。
+
+访问非集群 CIDR 时 `CUBE-EGRESS-MARK` 计数不增加，证明请求不进入
+EgressProxy。测试集群的独立网络策略可能继续拒绝该目标，这不改变路径判定。
+
+## 5. 用户 NetworkPolicy
+
+测试人员自行定义临时策略，结果如下：
+
+| 用例 | 结果 |
+| --- | --- |
+| sandbox → allowed Service | 成功 |
+| sandbox → denied Service | 超时，符合用户策略 |
+| 普通 Pod → denied Service | 成功，不受 Proxy 策略影响 |
+| 目标服务观察来源 | EgressProxy PodIP |
+
+策略测试完成后已删除。Chart 安装、升级和卸载不管理用户 NetworkPolicy。
+
+## 6. 主备和故障关闭
+
+在 sandbox 所在节点执行真实接口故障：
+
+| 场景 | 结果 |
+| --- | --- |
+| Primary veth down | 活动路由切换到 Standby |
+| Standby 接管后访问 Service | 成功 |
+| 服务端观察来源 | Standby PodIP `9.165.0.153` |
+| Primary 恢复 | 保持当前健康 Standby，不主动回切 |
+| Primary、Standby 均 down | 删除活动默认路由，只保留 `unreachable default` |
+| 双故障访问集群 CIDR | 超时，不回落主路由 |
+| 两端恢复 | 自动恢复活动路由和访问 |
+
+此外，在 veth 保持 UP 的情况下暂停 Primary Proxy 健康服务进程，Configurer
+通过 TCP 健康检查识别到数据面进程失效，并在 10 秒内切换到 Standby。恢复
+Primary 后仍保持 Standby，符合粘滞切换设计。
+
+## 7. Cube Big Pod 更新
+
+本节来自同日较早的独立 sandbox 轮次，不与第 2 节最终性能 sandbox 混用。
+通过 annotation 变更真实滚动三个 `cube-node` Pod。sandbox 所在节点更新前后：
+
+| 检查项 | 更新前 | 更新后 |
+| --- | --- | --- |
+| sandbox ID | `d6d9...2eb8` | 不变 |
+| sandbox 创建时间 | `2026-07-28 09:47:49` | 不变 |
+| shim PID | `1877986` | 不变 |
+| network-agent PID | `261923` | 不变 |
+| Primary veth ifindex | `659` | 不变 |
+| Standby veth ifindex | `658` | 不变 |
+| table 100 活动路由 | Primary | Primary |
+
+滚动后 sandbox 仍能访问集群 Service。
+
+## 8. 性能
+
+性能测试使用同一 sandbox 和同一份 64 MiB 文件，分别覆盖同节点/跨节点及
+PodIP/Service IP。直连基线仅在测试期间暂停该节点 Configurer 调和，并在
+`CUBE-EGRESS-MARK` 顶部临时插入集群 CIDR 的 `RETURN`；测试结束后立即删除
+临时规则、恢复调和，并确认正式 mark 规则和 table 100 路由已恢复。
+
+吞吐基准交错测试 PodIP 和 Service IP，使用相同请求脚本及样本数，避免顺序
+执行带来的 CPU 调度和缓存偏差。
+
+### 8.1 新建连接延迟
+
+每个目标、每条路径各执行 200 次新建 TCP 连接和 HTTP 请求：
+
+| 目标 | 直连 P50 | Proxy P50 | 额外 P50 | 直连 P99 | Proxy P99 | 额外 P99 | 错误率 | 结果 |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |
+| 同节点 PodIP | 20.818 ms | 21.720 ms | 0.902 ms | 70.876 ms | 71.656 ms | 0.780 ms | 0/200 | 通过 |
+| 同节点 Service IP | 21.956 ms | 21.305 ms | -0.651 ms | 73.322 ms | 71.599 ms | -1.723 ms | 0/200 | 通过 |
+| 跨节点 PodIP | 21.892 ms | 21.790 ms | -0.102 ms | 72.313 ms | 71.677 ms | -0.636 ms | 0/200 | 通过 |
+| 跨节点 Service IP | 21.653 ms | 21.958 ms | 0.305 ms | 71.759 ms | 72.171 ms | 0.412 ms | 0/200 | 通过 |
+
+门槛为额外 P50 不超过 1 ms、额外 P99 不超过 5 ms、错误率低于 0.01%。
+
+### 8.2 已建立路径延迟
+
+对同一跨节点 PodIP 分别发送 200 个 ICMP 请求：
+
+| 指标 | 直连 | EgressProxy | 额外开销 |
+| --- | ---: | ---: | ---: |
+| RTT P99 | 0.799 ms | 0.845 ms | 0.046 ms |
+| 折算单向额外延迟 | - | - | 约 0.023 ms |
+
+结果满足单向额外 P99 不超过 2 ms 的门槛。
+
+### 8.3 吞吐
+
+单连接每轮下载 64 MiB；4 并发场景每个连接下载 64 MiB，即每轮聚合传输
+256 MiB。表中使用耗时中位数：
+
+| 目标 | 并发 | 直连耗时 | Proxy 耗时 | 直连吞吐 | Proxy 吞吐 | 吞吐比例 | 门槛 | 结果 |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |
+| 同节点 PodIP | 1 | 46.875 ms | 51.440 ms | 11.453 Gbit/s | 10.437 Gbit/s | 91.13% | ≥90% | 通过 |
+| 同节点 PodIP | 4 | 193.324 ms | 220.470 ms | 11.108 Gbit/s | 9.740 Gbit/s | 87.69% | ≥85% | 通过 |
+| 同节点 Service IP | 1 | 52.145 ms | 49.930 ms | 10.296 Gbit/s | 10.752 Gbit/s | 104.44% | ≥90% | 通过 |
+| 同节点 Service IP | 4 | 198.843 ms | 228.591 ms | 10.800 Gbit/s | 9.394 Gbit/s | 86.99% | ≥85% | 通过 |
+| 跨节点 PodIP | 1 | 216.868 ms | 169.128 ms | 2.476 Gbit/s | 3.174 Gbit/s | 128.23% | ≥90% | 通过 |
+| 跨节点 PodIP | 4 | 1.441 s | 1.459 s | 1.490 Gbit/s | 1.472 Gbit/s | 98.80% | ≥85% | 通过 |
+| 跨节点 Service IP | 1 | 198.609 ms | 195.350 ms | 2.703 Gbit/s | 2.748 Gbit/s | 101.67% | ≥90% | 通过 |
+| 跨节点 Service IP | 4 | 1.471 s | 1.506 s | 1.460 Gbit/s | 1.426 Gbit/s | 97.68% | ≥85% | 通过 |
+
+有效吞吐按 `有效负载字节数 × 8 ÷ 耗时` 计算，不包含 TCP/IP、以太网封装和
+HTTP 响应头开销。吞吐比例按
+`EgressProxy 有效吞吐 ÷ 直连有效吞吐` 计算，等价于相同流量下的
+`直连耗时 ÷ EgressProxy 耗时`。
+
+结果表明本地 veth 链路消除了旧数据路径的主要吞吐损失。
+
+## 9. 长连接
+
+健康路径使用同一 TCP 连接持续发送 HTTP/1.1 keep-alive 请求：
+
+```text
+duration=618.017s
+ok=605
+fail=0
+```
+
+探针持续超过 10 分钟且无失败。另一次与性能直连基线并行的探针因测试规则主动
+改变同一 Service 的路由而中断，已作为测试污染排除；独立复测期间未修改路由。
+
+## 10. 集群验收
+
+- 执行 `egressProxy.enabled=true → false` 后，三个计算节点的 priority 10900
+  规则、table 100 路由和 `CUBE-EGRESS*` 规则均被 Pod `preStop` 清理；
+- 再次启用后，三个节点均重新建立预期数据路径；
+- 三个 Primary、三个 Standby Proxy Pod 全部 Ready；
+- 三个 Configurer Pod 全部 Ready；
+- EgressProxy 回归完成后执行 Helm test，8 个 suite 均为 `Succeeded`；
+  `cube-proxy-control-test` 使用 Secret 中的管理令牌访问
+  `/admin/healthz`，严格校验 HTTP 2xx；
+- 集群中不存在旧 EgressProxy StatefulSet、Service、PDB、NetworkPolicy、
+  隧道 Secret 或旧接口；
+- Helm release values 的 `egressProxy` 只有 `enabled` 和 `clusterCIDRs`。
+
+## 11. 测试资源
+
+通用服务和客户端见
+[egress-test-resources.yaml](../scripts/egress-test-resources.yaml)，长连接脚本见
+[egress-long-connection.sh](../scripts/egress-long-connection.sh)。
+
+用户 NetworkPolicy 不保存在上述资源文件中，避免被误认为产品内置策略。
+验收结束后已销毁测试 sandbox，并删除测试工作负载和 `cube-egress-test`
+namespace；产品 `cube-egress` namespace 中无测试 NetworkPolicy。

--- a/deploy/kubernetes/chart/docs/EGRESS_TEST_EN.md
+++ b/deploy/kubernetes/chart/docs/EGRESS_TEST_EN.md
@@ -1,0 +1,169 @@
+# Local-veth EgressProxy Test Report
+
+English | [中文](./EGRESS_TEST.md)
+
+## 1. Result
+
+The local-veth design in [EGRESS_VETH_EN.md](./EGRESS_VETH_EN.md) was validated
+on a Cilium test cluster on 2026-07-28. Functional, failover, Big Pod handoff,
+latency, throughput, long-connection, cleanup, and Helm gates passed.
+
+NetworkPolicy used during acceptance was temporary and user-defined. It is not
+a chart resource, built-in policy, or product recommendation, and it was
+deleted after the test.
+
+## 2. Environment
+
+| Item | Value |
+| --- | --- |
+| CNI | Cilium |
+| Compute nodes | 3 |
+| Configured cluster CIDR count | 1 |
+| Helm release | `cube`, final acceptance revision 65 |
+| Proxy image | `20260728-review04` |
+| Configurer image | `20260728-review06` |
+| Cubelet/network-agent image | `20260728-cgroupv2-01` |
+
+Cluster IDs, kubeconfig paths, node addresses, and sandbox identifiers are test
+environment details and are intentionally omitted from the English public
+summary. The Chinese source report retains the original evidence captured
+during the test.
+
+## 3. Static and local checks
+
+The following checks passed:
+
+- Helm lint and chart guards;
+- sticky primary/standby failover;
+- policy-rule, route-table, and iptables ownership conflicts;
+- CIDR canonicalization and deduplication;
+- ownership-scoped host cleanup;
+- real veth lifecycle in a privileged test network namespace;
+- cgroup v1 `tasks` and cgroup v2 `cgroup.procs` process migration;
+- host-interface ownership conflicts;
+- shell syntax and `git diff --check`;
+- absence of tunnel tools/dependencies in Proxy and Configurer images.
+
+Rendered persistent resources were limited to the `cube-egress` namespace,
+primary/standby Proxy DaemonSets, and Configurer DaemonSet. No EgressProxy
+StatefulSet, Service, PDB, NetworkPolicy, or tunnel Secret was rendered.
+
+## 4. Data path
+
+Every compute node had primary and standby local veth interfaces, policy rule
+priority 10900 matching the Router NAT IP and route mark, an active default in
+table 100, and an `unreachable default` fallback.
+
+A real sandbox reached the allowed Service. Mark, host-forwarding, and Proxy
+SNAT counters increased together, and the destination observed the local
+primary EgressProxy Pod IP. Access to a non-cluster CIDR did not increment the
+mark counter, proving that the request bypassed EgressProxy.
+
+## 5. User NetworkPolicy
+
+| Case | Result |
+| --- | --- |
+| Sandbox → allowed Service | Passed |
+| Sandbox → denied Service | Timed out as required by the user policy |
+| Ordinary Pod → denied Service | Passed; not captured by the Proxy path |
+| Source observed by target | EgressProxy Pod IP |
+
+The temporary policy was deleted after testing. Chart install, upgrade,
+rollback, disablement, and uninstall do not manage user NetworkPolicy.
+
+## 6. Failover and fail-closed behavior
+
+| Scenario | Result |
+| --- | --- |
+| Primary veth down | Active route moved to standby |
+| Service access after standby takeover | Passed |
+| Primary recovered | Healthy standby remained active; no switch-back |
+| Both veth paths down | Active default removed; `unreachable default` retained |
+| Cluster access during dual failure | Timed out without main-route fallback |
+| Both paths recovered | Active route and access recovered automatically |
+
+Stopping only the primary Proxy health process, while leaving the veth UP,
+also triggered standby takeover within 10 seconds. This proves that selection
+does not rely on link state alone.
+
+## 7. Big Pod replacement
+
+All three `cube-node` Pods were rolled through a real Pod-template annotation
+change. On the node hosting the sampled sandbox, the sandbox ID and creation
+time, shim PID, network-agent PID, primary/standby veth ifindex, and table-100
+active path remained unchanged. The sandbox continued to access a Kubernetes
+Service after the rollout.
+
+## 8. Performance
+
+The same sandbox and 64 MiB payload were used for direct and Proxy paths.
+Temporary bypass rules used for the direct baseline were removed immediately,
+reconciliation was restored, and production mark/table-100 state was verified.
+
+### 8.1 New-connection latency
+
+Each target/path ran 200 new TCP+HTTP requests.
+
+| Target | Additional P50 | Additional P99 | Errors | Gate |
+| --- | ---: | ---: | ---: | --- |
+| Same-node PodIP | 0.902 ms | 0.780 ms | 0/200 | Passed |
+| Same-node Service IP | -0.651 ms | -1.723 ms | 0/200 | Passed |
+| Cross-node PodIP | -0.102 ms | -0.636 ms | 0/200 | Passed |
+| Cross-node Service IP | 0.305 ms | 0.412 ms | 0/200 | Passed |
+
+Gates: additional P50 ≤ 1 ms, additional P99 ≤ 5 ms, error rate < 0.01%.
+Negative deltas are sampling variation, not an acceleration claim.
+
+### 8.2 Established-path latency
+
+For 200 ICMP requests to the same cross-node PodIP, direct RTT P99 was
+0.799 ms and EgressProxy RTT P99 was 0.845 ms. The estimated one-way additional
+latency was approximately 0.023 ms, below the 2 ms gate.
+
+### 8.3 Throughput
+
+Single-connection runs transferred 64 MiB. Four-connection runs transferred
+256 MiB total. Ratios use median duration from interleaved direct/Proxy runs.
+
+| Target | Concurrency | Direct | Proxy | Ratio | Gate | Result |
+| --- | ---: | ---: | ---: | ---: | ---: | --- |
+| Same-node PodIP | 1 | 11.453 Gbit/s | 10.437 Gbit/s | 91.13% | ≥90% | Passed |
+| Same-node PodIP | 4 | 11.108 Gbit/s | 9.740 Gbit/s | 87.69% | ≥85% | Passed |
+| Same-node Service IP | 1 | 10.296 Gbit/s | 10.752 Gbit/s | 104.44% | ≥90% | Passed |
+| Same-node Service IP | 4 | 10.800 Gbit/s | 9.394 Gbit/s | 86.99% | ≥85% | Passed |
+| Cross-node PodIP | 1 | 2.476 Gbit/s | 3.174 Gbit/s | 128.23% | ≥90% | Passed |
+| Cross-node PodIP | 4 | 1.490 Gbit/s | 1.472 Gbit/s | 98.80% | ≥85% | Passed |
+| Cross-node Service IP | 1 | 2.703 Gbit/s | 2.748 Gbit/s | 101.67% | ≥90% | Passed |
+| Cross-node Service IP | 4 | 1.460 Gbit/s | 1.426 Gbit/s | 97.68% | ≥85% | Passed |
+
+Effective throughput is payload bytes × 8 ÷ elapsed time and excludes protocol
+headers. Ratios above 100% are benchmark variance; acceptance requires only
+that the Proxy path stays above the lower-bound gate.
+
+## 9. Long connection
+
+A single HTTP/1.1 keep-alive connection ran for 618.017 seconds with 605
+successful requests and zero failures. A separate probe contaminated by the
+temporary direct-baseline route modification was excluded and independently
+retested without route changes.
+
+## 10. Cluster acceptance
+
+- Disabling EgressProxy removed the component-owned priority-10900 rule,
+  table-100 routes, and `CUBE-EGRESS*` rules from all three nodes.
+- Re-enabling recreated the expected data path on all nodes.
+- All primary, standby, and Configurer Pods became Ready.
+- All eight Helm test suites succeeded.
+- No old StatefulSet, Service, PDB, NetworkPolicy, tunnel Secret, or tunnel
+  interface remained.
+- Release values exposed only `enabled` and `clusterCIDRs` for EgressProxy.
+
+## 11. Test resources
+
+Generic service/client resources are in
+[egress-test-resources.yaml](../scripts/egress-test-resources.yaml), and the
+long-connection probe is
+[egress-long-connection.sh](../scripts/egress-long-connection.sh).
+
+No user NetworkPolicy is stored in those files. The test sandbox, workloads,
+and test namespace were deleted after acceptance.

--- a/deploy/kubernetes/chart/docs/EGRESS_VETH.md
+++ b/deploy/kubernetes/chart/docs/EGRESS_VETH.md
@@ -1,0 +1,393 @@
+# EgressProxy 本地 veth 方案
+
+[English](./EGRESS_VETH_EN.md) | 中文
+
+## 1. 目标
+
+本方案只转发 sandbox 访问 Kubernetes Pod CIDR 和 Service CIDR 的请求，并使
+这些请求受 Kubernetes NetworkPolicy 控制。
+
+要求：
+
+- 非集群 CIDR 不经过 EgressProxy；
+- 正常链路不使用加密隧道、UDP 封装或用户态代理；
+- 每个计算节点都有本地主、备 EgressProxy；
+- EgressProxy 全部不可用时，集群 CIDR 流量 fail closed；
+- Cube Big Pod 更新不重建 veth、策略路由和存量 sandbox；
+- 目标 Pod 观察到的来源地址是 EgressProxy PodIP；
+- sandbox 经 EgressProxy 发出的集群访问请求可被用户自定义 NetworkPolicy 管理；
+- Chart 不创建、修改、删除或推荐任何具体 NetworkPolicy；
+- 用户配置保持最小，不暴露内部路由和 veth 实现参数。
+
+## 2. 架构
+
+每个 Cube 计算节点运行两个普通 Pod 网络的 EgressProxy：
+
+- `egress-proxy-primary` DaemonSet；
+- `egress-proxy-standby` DaemonSet。
+
+每个 Proxy Pod 通过独立 veth pair 与所在宿主机连接。EgressProxy 使用普通
+Pod `eth0` 访问目标，因此出口继续由 CNI 和 Kubernetes NetworkPolicy 管理。
+
+```mermaid
+flowchart LR
+  subgraph NODE["Cube 计算节点"]
+    SB["Sandbox"]
+    CR["CubeVS / cube-router"]
+    MARK["DNAT 前匹配 clusterCIDRs<br/>设置 route mark"]
+    RULE["ip rule / table 100"]
+    MAIN["节点主路由"]
+
+    subgraph P["Primary EgressProxy Pod"]
+      PV["egress-host0"]
+      PF["FORWARD / conntrack / SNAT"]
+      PE["eth0"]
+    end
+
+    subgraph S["Standby EgressProxy Pod"]
+      SV["egress-host0"]
+      SF["FORWARD / conntrack / SNAT"]
+      SE["eth0"]
+    end
+
+    HV0["cube-egress-p0"]
+    HV1["cube-egress-p1"]
+
+    SB --> CR --> MARK
+    MARK -->|"未命中"| MAIN
+    MARK -->|"命中"| RULE
+    RULE -->|"主路径"| HV0 --> PV --> PF --> PE
+    RULE -.->|"主路径故障"| HV1 --> SV --> SF --> SE
+  end
+
+  PE --> CNI["CNI / NetworkPolicy"]
+  SE --> CNI
+  CNI --> TARGET["Service / PodIP"]
+```
+
+正常数据路径：
+
+```text
+Sandbox
+→ CubeVS
+→ cube-router
+→ DNAT 前匹配 clusterCIDRs
+→ route mark
+→ table 100
+→ 本地 veth
+→ EgressProxy Pod
+→ conntrack / SNAT
+→ Pod eth0
+→ CNI / NetworkPolicy
+→ Service 或 PodIP
+```
+
+非集群 CIDR 数据路径：
+
+```text
+Sandbox
+→ CubeVS
+→ cube-router
+→ 不设置 route mark
+→ 节点主路由
+```
+
+## 3. Chart 配置
+
+用户只需要配置是否启用和集群 CIDR：
+
+```yaml
+egressProxy:
+  enabled: true
+  clusterCIDRs:
+    - 10.244.0.0/16
+    - 10.96.0.0/12
+```
+
+约束：
+
+- `clusterCIDRs` 必须显式配置；
+- 必须覆盖集群全部 Pod CIDR 和 Service CIDR；
+- 只支持 IPv4；
+- 最多 32 个 CIDR；
+- 完全相同的重复项、非法项或空配置必须阻止 Chart 安装；
+- 指向同一网段但主机位写法不同的 CIDR 由 Configurer 规范化并去重；
+- Chart 不创建、修改、删除或推荐 NetworkPolicy；
+- 用户根据业务需要独立创建任意 Kubernetes NetworkPolicy。
+
+以下参数属于内部实现，不放入 values：
+
+| 参数 | 固定值 |
+| --- | --- |
+| route mark | `0x1000/0x1000` |
+| policy rule priority | `10900` |
+| route table | `100` |
+| 主 veth 网段 | `169.254.240.0/30` |
+| 备 veth 网段 | `169.254.240.4/30` |
+| 主机接口 | `cube-egress-p0`、`cube-egress-p1` |
+| Pod 接口 | `egress-host0` |
+| 每节点 Proxy 数量 | `2` |
+| 调和周期 | `10s` |
+
+Configurer 写入节点路由状态前检测固定 mark、iptables 链、rule priority 和
+route table；Proxy init 在创建 veth 前检测接口名及 link-local 网段。任一组件
+发现冲突时都拒绝 Ready，不允许覆盖已有配置；生产安装必须使用 `helm --wait`
+并检查全部 Configurer 和 Proxy Ready。
+
+## 4. veth 配置
+
+### 4.1 Primary
+
+```text
+宿主机：
+  cube-egress-p0 = 169.254.240.1/30
+
+Proxy Pod：
+  egress-host0 = 169.254.240.2/30
+```
+
+### 4.2 Standby
+
+```text
+宿主机：
+  cube-egress-p1 = 169.254.240.5/30
+
+Proxy Pod：
+  egress-host0 = 169.254.240.6/30
+```
+
+上述地址只存在于独立的节点和 Pod network namespace。不同节点可以复用同一
+组 link-local 地址。
+
+veth MTU 自动读取 Proxy Pod `eth0` MTU，不提供 values 参数。宿主机和 Pod
+两端使用相同 MTU，避免额外分片。
+
+### 4.3 生命周期
+
+Proxy 使用 `hostPID: true`，由短生命周期的 privileged initContainer：
+
+1. 清理本节点同名的无效旧接口；
+2. 在 Pod network namespace 创建 veth pair；
+3. 将 host 端移动到宿主机 network namespace；
+4. 配置两端地址、MTU 和 link up；
+5. 在 Pod 内增加 Router NATIP 的回程路由。
+
+Proxy 主容器不使用 privileged，只保留 `NET_ADMIN`。Pod network namespace
+销毁时，Pod 侧 veth 和对应 host peer 一并失效；Configurer 在下一次调和中
+清理残留路由。
+
+两个 DaemonSet 使用：
+
+```yaml
+updateStrategy:
+  type: OnDelete
+```
+
+`OnDelete` 防止主、备控制器同时滚动同一节点。普通 Helm upgrade 只更新 Pod
+template，不会替换现有 Proxy Pod。主备替换顺序和回滚操作统一见
+[UPGRADE.md](./UPGRADE.md)。
+
+## 5. CIDR 分流
+
+只在 `mangle/PREROUTING` 第一条规则处理来自 Cube Router 的 sandbox 报文：
+
+```bash
+iptables -t mangle -A CUBE-EGRESS-MARK \
+  -d <cluster-cidr> \
+  -j MARK \
+  --set-xmark 0x1000/0x1000
+
+iptables -t mangle -I PREROUTING 1 \
+  -s <router-nat-ip>/32 \
+  -i cube-router \
+  -j CUBE-EGRESS-MARK
+```
+
+必须在 Service DNAT 前匹配原始 ClusterIP。否则 ClusterIP 可能先转换为 NodeIP，
+导致后续按目标 CIDR 的策略路由失效。
+
+策略规则：
+
+```bash
+ip rule add priority 10900 \
+  iif cube-router \
+  from <router-nat-ip>/32 \
+  fwmark 0x1000/0x1000 \
+  lookup 100
+```
+
+未命中 `clusterCIDRs` 的报文没有 mark，不进入 table 100。
+
+## 6. Proxy 转发
+
+Primary 对应的正常路由：
+
+```bash
+ip route replace table 100 \
+  default via 169.254.240.2 \
+  dev cube-egress-p0 \
+  metric 100
+
+ip route replace table 100 \
+  unreachable default \
+  metric 32767
+```
+
+Proxy Pod 内配置：
+
+```bash
+ip route replace <router-nat-ip>/32 \
+  via 169.254.240.1 \
+  dev egress-host0
+
+iptables -t filter -N CUBE-EGRESS-PROXY
+iptables -t filter -A CUBE-EGRESS-PROXY \
+  -i egress-host0 -o eth0 \
+  -j ACCEPT
+iptables -t filter -A CUBE-EGRESS-PROXY \
+  -i eth0 -o egress-host0 \
+  -m conntrack \
+  --ctstate ESTABLISHED,RELATED \
+  -j ACCEPT
+iptables -t filter -A CUBE-EGRESS-PROXY -j DROP
+
+iptables -t nat -A POSTROUTING \
+  -i egress-host0 \
+  -o eth0 \
+  -j SNAT \
+  --to-source <proxy-pod-ip>
+```
+
+目标 Pod 只能看到 EgressProxy PodIP，不能看到 sandbox IP、Router NATIP 或
+link-local veth 地址。
+
+## 7. 健康检查与故障切换
+
+Proxy 主容器完成转发规则检查后，在对应 veth 地址提供 TCP 健康响应。
+Configurer 通过该响应选择活动 Proxy：
+
+```text
+cube-egress-p0 → 169.254.240.2:19091
+cube-egress-p1 → 169.254.240.6:19091
+```
+
+选择规则：
+
+1. 当前活动 Proxy 健康时保持粘滞；
+2. 当前 Proxy 探测失败时选择另一个健康 Proxy；
+3. 切换只替换 table 100 的活动默认路由；
+4. 两个 Proxy 均失败时删除活动默认路由；
+5. table 100 始终保留 `unreachable default`；
+6. Proxy 恢复后不自动回切。
+
+切换到 standby：
+
+```bash
+ip route replace table 100 \
+  default via 169.254.240.6 \
+  dev cube-egress-p1 \
+  metric 100
+```
+
+两个 Proxy 均失败：
+
+```text
+table 100:
+  unreachable default metric 32767
+```
+
+此时只有已标记的集群 CIDR 流量失败，非集群 CIDR、节点进程、普通 Pod 和
+HostNetwork Pod 不受影响。
+
+主备 Proxy 不共享 conntrack。活动 Proxy 故障或重建时，经过该 Proxy 的存量
+连接可能中断；新连接在切换后恢复。
+
+健康响应能够识别 Proxy 主进程退出、veth 异常以及 Proxy 转发/SNAT 规则缺失。
+由于用户 NetworkPolicy 可以任意拒绝目标，Configurer 不使用具体 PodIP 或
+Service 作为探测目标，因此目标服务或 CNI 出口故障仍由业务探针发现。
+
+## 8. NetworkPolicy
+
+本方案只保证经过 EgressProxy 的 sandbox 请求能够被 CNI 识别为 Proxy Pod
+出口流量，从而受用户定义的 Kubernetes NetworkPolicy 管理。
+
+NetworkPolicy 完全是用户侧资源：
+
+- 用户自行决定是否创建策略以及策略的全部内容；
+- Chart 不创建、修改、删除或推荐任何 NetworkPolicy；
+- Chart 不提供默认拒绝、DNS 放行、业务放行等内置规则；
+- Chart 安装、升级、回滚、关闭功能和卸载均不触碰用户策略。
+
+没有用户 NetworkPolicy 时，行为遵循当前 CNI 和 Kubernetes 默认语义，Chart
+不额外限制出口。
+
+由于数据从 `egress-host0` 转发后通过 Pod `eth0` 离开，是否执行 egress
+NetworkPolicy 取决于 CNI 对 Pod 内转发流量的实现。上线前必须在目标 CNI 上
+真实验证，不能只检查 YAML。
+
+验收只需由测试人员临时定义策略，证明 sandbox 请求的允许和拒绝结果符合该
+策略，同时普通 Pod、HostNetwork Pod 和节点流量不被 EgressProxy 路径误伤。
+测试策略不是产品资源或推荐模板，测试结束后由测试人员删除。
+
+当前 Cube Router 会把同一节点的 sandbox 请求统一转换为 Router NATIP，
+EgressProxy 无法区分该节点上的不同 sandbox。因此用户策略的最小隔离粒度是
+EgressProxy Pod/节点，不支持按单个 sandbox 设置不同 NetworkPolicy。
+
+## 9. 安全
+
+- 只标记来自 `cube-router`、源地址为 Router NATIP、目标属于
+  `clusterCIDRs` 的报文；
+- 不处理节点 `OUTPUT`；
+- table 100 保留 `unreachable default`；
+- FORWARD 第一条规则先处理已标记流量，禁止回落其他 CNI 放行链；
+- initContainer 完成 veth 创建后退出；
+- Proxy 主容器禁止长期 privileged；
+- 不挂载 Docker socket、containerd socket 或宿主 `/sys`；
+- 固定 mark、路由表、优先级、接口和地址发生冲突时拒绝启动；
+- Configurer 只管理 `CUBE-EGRESS-*` 链和固定的专用对象，不清空 CNI 或
+  kube-proxy 管理的规则。
+
+`hostPID: true` 和 privileged initContainer 扩大了初始化阶段权限。镜像必须
+使用不可变 digest，并完成签名、漏洞扫描和准入校验。
+
+Proxy 的 privileged initContainer 和 HostNetwork Configurer 不符合 Kubernetes
+Pod Security `baseline`/`restricted`。目标 namespace 必须通过受控豁免允许这些
+权限；如果集群策略禁止该豁免，则不能启用 EgressProxy。豁免范围只应覆盖
+`cube-egress` 与 `cube-system` 中的对应 ServiceAccount/工作负载。
+
+## 10. 性能
+
+正常链路只增加：
+
+- 一次本地 veth 转发；
+- Proxy namespace 内 conntrack 和 SNAT；
+- Proxy `eth0` 的一次 CNI 出口处理。
+
+链路不包含：
+
+- 加解密；
+- UDP 封装；
+- 隧道握手；
+- 隧道 MTU 额外缩减；
+- 到共享 Proxy 的额外跨节点跳数。
+
+性能不能根据设计直接判定通过，必须与同一 sandbox 的直连基线比较。
+
+验收门槛：
+
+| 指标 | 门槛 |
+| --- | --- |
+| 新建 TCP 连接额外延迟 P50 | ≤ 1 ms |
+| 新建 TCP 连接额外延迟 P99 | ≤ 5 ms |
+| 已建立连接单向额外延迟 P99 | ≤ 2 ms |
+| 单连接吞吐 | ≥ 直连的 90% |
+| 节点聚合吞吐 | ≥ 直连的 85% |
+| 代理错误率 | < 0.01% |
+
+完整发布验收的新建连接延迟和吞吐应分别测试同节点目标、跨节点目标、
+ClusterIP、PodIP、单连接和多连接。已建立连接延迟使用跨节点 PodIP 作为代表
+路径；Service 选择和 DNAT 在建连阶段完成，不重复计入已建立路径门槛。当前
+测试报告只记录已经完成的组合，未覆盖的必测组合不得据此宣告通过。
+
+实测结果和门禁证据统一记录在 [EGRESS_TEST.md](./EGRESS_TEST.md)，不在方案文档
+中重复维护。

--- a/deploy/kubernetes/chart/docs/EGRESS_VETH_EN.md
+++ b/deploy/kubernetes/chart/docs/EGRESS_VETH_EN.md
@@ -1,0 +1,197 @@
+# Local-veth EgressProxy Design
+
+English | [中文](./EGRESS_VETH.md)
+
+## 1. Goal
+
+Forward only sandbox requests to Kubernetes Pod and Service CIDRs through an
+EgressProxy Pod so that the CNI can enforce user-defined NetworkPolicy.
+
+The design must:
+
+- bypass EgressProxy for non-cluster destinations;
+- avoid encryption, UDP encapsulation, and user-space proxying on the normal
+  path;
+- provide node-local primary and standby proxies;
+- fail closed for marked cluster traffic when both proxies fail;
+- preserve node veth/routing state across Big Pod replacement;
+- expose the EgressProxy Pod IP, rather than sandbox or router addresses, to
+  the destination;
+- keep NetworkPolicy entirely user-owned;
+- expose only the minimum required values.
+
+## 2. Architecture
+
+Every compute node runs primary and standby EgressProxy DaemonSet Pods on the
+Pod network. Each proxy is connected to its host by a dedicated veth pair.
+
+```mermaid
+flowchart LR
+  subgraph NODE["Cube compute node"]
+    SB["Sandbox"] --> CR["CubeVS / cube-router"] --> MARK["Pre-DNAT clusterCIDR match<br/>route mark"]
+    MARK -->|"not marked"| MAIN["Node main routing table"]
+    MARK -->|"marked"| RULE["ip rule / table 100"]
+    RULE -->|"primary"| HV0["cube-egress-p0"] --> P["Primary EgressProxy<br/>forward + conntrack + SNAT"]
+    RULE -.->|"failover"| HV1["cube-egress-p1"] --> S["Standby EgressProxy<br/>forward + conntrack + SNAT"]
+  end
+  P --> CNI["CNI / NetworkPolicy"]
+  S --> CNI
+  CNI --> TARGET["Service / PodIP"]
+```
+
+Cluster path:
+
+```text
+Sandbox → CubeVS → cube-router → pre-DNAT CIDR match → route mark
+→ table 100 → local veth → EgressProxy Pod → SNAT → Pod eth0
+→ CNI / NetworkPolicy → Service or PodIP
+```
+
+Non-cluster traffic receives no mark and follows the node's normal route.
+
+## 3. Chart configuration
+
+Users configure only enablement and all Pod/Service CIDRs:
+
+```yaml
+egressProxy:
+  enabled: true
+  clusterCIDRs:
+    - 10.244.0.0/16
+    - 10.96.0.0/12
+```
+
+`clusterCIDRs` is required, IPv4-only, and limited to 32 entries. Empty,
+duplicate, or invalid entries fail chart rendering. Equivalent CIDRs are
+canonicalized and deduplicated by the Configurer. The chart never creates,
+modifies, deletes, or recommends a NetworkPolicy.
+
+Fixed implementation details are intentionally not values:
+
+| Item | Value |
+| --- | --- |
+| Route mark | `0x1000/0x1000` |
+| Policy-rule priority | `10900` |
+| Route table | `100` |
+| Primary veth subnet | `169.254.240.0/30` |
+| Standby veth subnet | `169.254.240.4/30` |
+| Host interfaces | `cube-egress-p0`, `cube-egress-p1` |
+| Proxy interface | `egress-host0` |
+| Proxies per node | `2` |
+| Reconcile interval | `10s` |
+
+All fixed rules, tables, marks, addresses, and interface names are ownership
+checked. A conflict prevents readiness instead of overwriting foreign state.
+
+## 4. Veth lifecycle
+
+Primary uses host `169.254.240.1/30` and proxy `169.254.240.2/30`; standby uses
+host `169.254.240.5/30` and proxy `169.254.240.6/30`. These link-local addresses
+exist only in independent node and Pod network namespaces, so nodes can reuse
+them. MTU follows the Proxy Pod's `eth0`.
+
+A short-lived privileged initContainer with `hostPID: true`:
+
+1. removes only invalid, component-owned stale interfaces;
+2. creates the veth pair in the Proxy network namespace;
+3. moves the host peer into the node network namespace;
+4. configures addresses, MTU, and link state;
+5. adds the return route for the Cube Router NAT IP.
+
+The long-running Proxy container is not privileged and retains only
+`NET_ADMIN`. Both Proxy DaemonSets use `OnDelete`, preventing simultaneous
+primary/standby replacement on a node.
+
+## 5. CIDR steering
+
+The first `mangle/PREROUTING` jump processes only packets arriving from
+`cube-router`, sourced from the Router NAT IP:
+
+```bash
+iptables -t mangle -A CUBE-EGRESS-MARK \
+  -d <cluster-cidr> -j MARK --set-xmark 0x1000/0x1000
+
+iptables -t mangle -I PREROUTING 1 \
+  -s <router-nat-ip>/32 -i cube-router -j CUBE-EGRESS-MARK
+
+ip rule add priority 10900 \
+  iif cube-router from <router-nat-ip>/32 \
+  fwmark 0x1000/0x1000 lookup 100
+```
+
+Matching must occur before Service DNAT, while the original ClusterIP remains
+visible. Unmarked traffic never enters table 100.
+
+## 6. Proxy forwarding
+
+The active route points table 100 to one local peer and always coexists with a
+fail-closed route:
+
+```bash
+ip route replace table 100 \
+  default via 169.254.240.2 dev cube-egress-p0 metric 100
+ip route replace table 100 unreachable default metric 32767
+```
+
+Inside the Proxy namespace, forwarding permits only `egress-host0 → eth0` and
+established/related return traffic. Other traffic in the component chain is
+dropped. SNAT rewrites the source to the Proxy Pod IP, which is the identity
+observed by the destination and CNI.
+
+## 7. Health and failover
+
+Each Proxy serves a TCP health response on its veth address and port `19091`.
+The Configurer keeps the current healthy peer, switches only after failure,
+removes the active default when both peers fail, and never removes the
+`unreachable default`. Recovery does not force switch-back.
+
+Primary and standby do not share conntrack. Existing connections through a
+failed or replaced Proxy may break; new connections recover after route switch.
+Health validates the Proxy process, veth, and component forwarding/SNAT rules,
+but intentionally does not probe a user Service that NetworkPolicy may deny.
+
+## 8. NetworkPolicy boundary
+
+The design guarantees only that sandbox cluster traffic leaves through a Proxy
+Pod identity that the target CNI can govern. Users own whether a policy exists
+and all allow/deny content. With no user policy, normal Kubernetes/CNI defaults
+apply.
+
+Because all sandboxes on a node are translated to the same Router NAT IP and
+then to a Proxy Pod IP, the minimum policy granularity is Proxy Pod/node, not an
+individual sandbox. The target CNI must be tested with real forwarded traffic;
+rendered YAML alone is insufficient evidence.
+
+## 9. Security and admission requirements
+
+- Only clusterCIDR traffic from the expected interface and Router NAT IP is
+  marked; node `OUTPUT` is never intercepted.
+- Table 100 remains fail closed and marked traffic cannot fall through to
+  unrelated CNI forwarding chains.
+- Components manage only dedicated `CUBE-EGRESS-*` chains and fixed objects.
+- The Proxy does not mount container-runtime sockets or host `/sys`.
+- Images should use immutable digests and pass signature, vulnerability, and
+  admission checks.
+
+The privileged veth initContainer and HostNetwork Configurer are incompatible
+with Pod Security `baseline` and `restricted`. A narrowly scoped exemption is
+required for the corresponding workloads/ServiceAccounts in `cube-egress` and
+`cube-system`. If the cluster cannot grant it, EgressProxy cannot be enabled.
+
+## 10. Performance gate
+
+The normal path adds one local veth forwarding step, Proxy conntrack/SNAT, and
+one CNI egress pass. It adds no encryption, tunnel handshake, UDP encapsulation,
+or cross-node proxy hop.
+
+| Metric | Gate |
+| --- | --- |
+| New TCP connection additional latency P50 | ≤ 1 ms |
+| New TCP connection additional latency P99 | ≤ 5 ms |
+| Established-path one-way additional latency P99 | ≤ 2 ms |
+| Single-connection throughput | ≥ 90% of direct |
+| Node aggregate throughput | ≥ 85% of direct |
+| Proxy error rate | < 0.01% |
+
+Test same-node/cross-node PodIP and Service IP paths, with single and concurrent
+connections. Evidence is maintained in [EGRESS_TEST_EN.md](./EGRESS_TEST_EN.md).

--- a/deploy/kubernetes/chart/docs/UPGRADE.md
+++ b/deploy/kubernetes/chart/docs/UPGRADE.md
@@ -1,0 +1,306 @@
+# CubeSandbox Chart 升级指南
+
+[English](./UPGRADE_EN.md) | 中文
+
+本文说明当前 Helm Chart 的升级边界和操作流程。文档以 Chart 模板、values
+和组件入口脚本的实际行为为准，不包含尚未实现的发布控制器或监控能力。
+
+> **不兼容变更：** `cube-node` Big Pod 已从 Pod 网络切换为固定的
+> `hostNetwork: true` 和 `dnsPolicy: ClusterFirstWithHostNet`。旧 Pod 在被替换前
+> 仍保持原 Pod 网络语义；只有明确删除或滚动替换后，新网络契约才会生效。
+> 发布前必须迁移依赖旧 PodIP/CNI 可见性的监控与安全配置，并先在单个计算节点
+> 进行 canary 验证。
+
+## 原地升级与 EgressProxy 总体架构
+
+`cube-node` Big Pod 升级时 Pod 会被替换，但 sandbox 运行时、状态和网络留在
+宿主机，由新 Pod 重新接管。EgressProxy 使用独立 DaemonSet，与 Big Pod
+生命周期解耦，使存量 sandbox 在升级期间仍可访问集群服务，并受用户定义的
+Kubernetes NetworkPolicy 控制。
+
+```mermaid
+flowchart LR
+    subgraph K8S["Kubernetes 管理层：可替换"]
+        OLD["旧 cube-node Big Pod<br/>旧 cubelet"]
+        UPDATE["DaemonSet 更新<br/>替换 Pod"]
+        NEW["新 cube-node Big Pod<br/>新 cubelet<br/>hostPID + hostNetwork"]
+        OLD --> UPDATE --> NEW
+    end
+
+    subgraph HOST["计算节点宿主持久层：Big Pod 更新不删除"]
+        RUNTIME["CubeShim + VMM<br/>宿主 cgroup 中持续运行"]
+        STATE["hostPath + socket<br/>/data/cubelet<br/>/data/cube-shim"]
+        SANDBOX["存量 Sandbox<br/>ID、guest、进程不变"]
+        ROUTER["network-agent + Cube Router<br/>sandbox netns / TAP 保持"]
+
+        STATE --- RUNTIME
+        RUNTIME --> SANDBOX
+        ROUTER --- SANDBOX
+    end
+
+    subgraph EGRESS["独立 EgressProxy 数据面：不随 Big Pod 更新"]
+        CONFIG["Configurer DaemonSet<br/>维护 mark、table 100 和主备健康"]
+        RULES["节点策略路由<br/>mangle/PREROUTING<br/>mark → table 100"]
+        VETH["节点本地 veth<br/>Primary / Standby"]
+        PROXY["EgressProxy Pod<br/>转发 + SNAT"]
+        POLICY["用户 NetworkPolicy"]
+        SERVICE["Kubernetes Service / Pod"]
+
+        CONFIG -.->|"配置宿主规则"| RULES
+        CONFIG -.->|"选择健康路径"| VETH
+        RULES --> VETH --> PROXY
+        PROXY -->|"以 Pod 身份进入 CNI"| POLICY --> SERVICE
+    end
+
+    OLD -.->|"旧控制连接"| STATE
+    NEW ==>|"读取原状态和 socket<br/>重新接管存量运行时"| STATE
+    NEW ==>|"复用宿主网络数据面"| ROUTER
+    SANDBOX -->|"访问 clusterCIDRs"| ROUTER
+    ROUTER -->|"沙箱流量进入节点"| RULES
+
+    classDef replaceable fill:#e8f1ff,stroke:#3973ac,color:#102a43;
+    classDef persistent fill:#e9f8ee,stroke:#2f855a,color:#173b2b;
+    classDef egress fill:#fff4df,stroke:#b7791f,color:#4a2d0b;
+    class OLD,UPDATE,NEW replaceable;
+    class RUNTIME,STATE,SANDBOX,ROUTER persistent;
+    class CONFIG,RULES,VETH,PROXY,POLICY,SERVICE egress;
+```
+
+图中的关键边界：
+
+- Big Pod 的 UID、容器和 cubelet PID 会变化；sandbox ID、创建时间、
+  CubeShim/VMM PID、guest boot ID 和网络命名空间保持不变。
+- CubeShim、VMM 脱离 `kubepods` cgroup，状态和 socket 位于 hostPath，因此
+  旧 Pod 删除不会销毁存量 sandbox。
+- 新 cubelet 读取相同 hostPath，并通过既有 socket 重新接管 CubeShim/VMM；
+  这是“接管”，不是重新创建 sandbox。
+- EgressProxy、Configurer 是独立 DaemonSet。Big Pod 更新不重建它们，也不删除
+  节点的本地 veth、策略路由或用户 NetworkPolicy。
+- 只有 sandbox 访问 `clusterCIDRs` 的请求被 Cube Router 标记并送入 table 100，
+  再经本地 veth 进入 EgressProxy；其他节点、Pod 和非集群流量不走该链路。
+- EgressProxy 以 Pod 身份从 CNI 发出请求，因此用户可以用 NetworkPolicy 控制
+  sandbox 能访问哪些 Kubernetes Service 或 Pod。
+
+## 1. 当前升级模型
+
+计算节点由四个原生 `apps/v1` DaemonSet 组成：
+
+| 组件 | 职责 | 更新影响 |
+| --- | --- | --- |
+| `cube-node-installer` | 安装 shim、kernel 和 guest 产物 | 不承载运行时数据面 |
+| `cube-node-pvm` | 在明确授权的节点安装 PVM 宿主机内核 | 可能修改内核、GRUB 并触发重启 |
+| `cube-node-bootstrap` | 检查并准备 KVM、XFS 和节点目录 | 不承载运行时数据面 |
+| `cube-node` | 运行 cubelet、network-agent 和可选 CubeEgress | Pod 模板变化会重建 Big Pod |
+
+`cube-node` 固定使用：
+
+```yaml
+hostPID: true
+hostNetwork: true
+dnsPolicy: ClusterFirstWithHostNet
+```
+
+默认更新策略是 `RollingUpdate`，`maxUnavailable: 1`。如需逐节点人工控制，
+可配置：
+
+```yaml
+cubeNode:
+  updateStrategy:
+    type: OnDelete
+```
+
+`OnDelete` 模式下，Helm 只更新 DaemonSet Pod template，不会自动删除旧 Pod。
+
+## 2. 存量 sandbox 保留边界
+
+Big Pod 重建时，Chart 通过以下机制保留存量 sandbox：
+
+- shim、VMM 使用宿主机 PID namespace，并脱离 Big Pod 容器 cgroup 运行；
+- `/data/cubelet`、`/data/cube-shim`、`/run/containerd` 对应目录和
+  `/run/vc` 对应目录使用 hostPath；
+- 实际 socket hostPath 默认为 `/data/cubelet/run/containerd` 和
+  `/data/cubelet/run/vc`，避免与节点容器运行时目录冲突；
+- cubelet 启动后通过已有 bootstrap state 和 socket 连接存量 shim；
+- network-agent 镜像指纹未变化时，新 Big Pod 复用宿主机上的原进程。
+
+`hostPID` 和 `hostNetwork` 本身不能保证进程存活，存量 sandbox 保留依赖上述
+入口脚本、进程 cgroup 和 hostPath 机制同时生效。
+
+以下变更不能按普通 cubelet 滚动升级处理：
+
+- network-agent 镜像变化；
+- Cube Router、sandbox CIDR、网卡或底层网络配置变化；
+- shim、VMM、guest 或其状态格式不兼容；
+- hostPath、socket 目录或节点内核变化。
+
+这些变更应作为维护操作单独验证。文档不承诺它们升级期间连接无损。
+
+## 3. EgressProxy 边界
+
+数据路径、固定网络参数和故障切换逻辑见
+[EGRESS_VETH.md](./EGRESS_VETH.md)，本节只保留升级相关约束。
+
+`egressProxy.enabled=true` 时，Chart 部署：
+
+- `cube-node` 中的持久化 Cube Router 数据面；
+- HostNetwork 的 `egress-configurer` DaemonSet；
+- Pod 网络中的主、备 `egress-proxy` DaemonSet；
+- 固定的 `cube-egress` namespace。
+
+Proxy Pod 通过本地 veth 与宿主机连接。Configurer 在宿主机维护 veth 健康
+探测、iptables 和策略路由。Big Pod 重建不会删除这些对象；network-agent
+被复用时，Cube Router 接口也保持不变。
+
+升级相关限制：
+
+- 用户 NetworkPolicy 选择 EgressProxy Pod，当前不能按单个 sandbox 区分；
+- Proxy Pod 重建会丢失其网络命名空间中的 conntrack，经过该副本的
+  长连接可能中断；
+- Configurer 和两个 Proxy DaemonSet 固定使用 `OnDelete`，镜像更新必须按
+  发布顺序逐节点替换；
+- Chart 没有实现连接 drain、自动发布编排或 Prometheus 指标采集。
+
+新安装由 Chart 创建 `cube-egress` namespace。升级时如果该 namespace 已经
+存在且不属于当前 Helm release，Chart 复用它但不接管所有权，避免覆盖其中
+的用户策略或其他资源。由当前 release 创建的 namespace 在后续升级中继续由
+Helm 管理，但使用 `helm.sh/resource-policy: keep` 保留；关闭功能或卸载
+release 不删除 namespace，也不会间接删除其中的用户 NetworkPolicy。
+
+关闭 `egressProxy` 或删除 Configurer Pod 时，Pod 的 `preStop` 会先暂停协调循环，
+再清理本组件拥有的宿主机规则。卸载 release 时还会在 `post-delete` 阶段按节点
+运行一次兜底清理。
+清理逻辑只删除所有权校验通过的
+`CUBE-EGRESS-*` 链、固定 FORWARD 规则、priority 10900 policy rule 和 table
+100 专用路由。发现同名外部对象时清理失败并阻止继续操作，不覆盖或删除外部
+配置。关闭时必须使用 `helm upgrade --wait`，并在 Configurer Pod 删除后检查
+各节点规则；卸载时必须使用 `helm uninstall --wait`，并确认 `post-delete`
+清理 hook 在全部计算节点完成。节点不可达、强制删除 Pod 或绕过 kubelet 时
+无法执行 `preStop`，需要节点恢复后运行同一清理镜像，不宣称自动清理此类异常
+残留。
+
+## 4. 发布前检查
+
+### 4.1 渲染与静态检查
+
+```bash
+helm lint deploy/kubernetes/chart
+
+deploy/kubernetes/chart/scripts/test-big-pod-inplace-guard.sh
+deploy/kubernetes/chart/scripts/test-egress-proxy-guard.sh
+```
+
+生产 values 应额外执行一次 `helm template`，确认：
+
+- 目标镜像和 tag/digest 正确；
+- 计算节点 selector 只匹配预期节点；
+- PVM selector 包含 `cube.tencent.com/allow-pvm-bootstrap=true`；
+- `cube-node` 更新策略符合本次发布方式；
+- EgressProxy 只渲染主备 DaemonSet、Configurer 和 namespace；
+- 渲染结果不包含 EgressProxy NetworkPolicy、隧道 Secret、Service 或
+  StatefulSet。
+
+### 4.2 节点检查
+
+确认：
+
+- `/dev/kvm`、XFS、内核和节点准备状态满足要求；
+- sandbox CIDR 不与 Node、Pod、Service、VPC 和 DNS 网段重叠；
+- `/data/cubelet` 等 hostPath 容量充足；
+- 当前 sandbox、shim、VMM 和 network-agent 状态正常；
+- EgressProxy 启用时，Configurer 和全部 Proxy Pod Ready；当前活动 Peer 的
+  主进程健康响应成功；mangle 链在 Service DNAT 前只标记
+  `clusterCIDRs`；策略规则同时匹配 cube-router 入接口、Router NATIP 和
+  `routeMark`；table 100 同时保留活动默认路由和 `unreachable default`。
+
+Chart 不提供节点 drain、禁止新建 sandbox 或升级状态机。需要这些能力时，
+必须由现有运维系统在 Helm 升级之外完成。
+
+## 5. 推荐发布顺序
+
+“原地升级”采用文档开头架构：Big Pod 会重建，sandbox 留在宿主机并由新
+cubelet 接管。readiness 只证明新 Big Pod 基础服务正常，不能替代存量
+sandbox 验收。
+
+推荐先升级不承载运行时数据面的 installer、PVM 和 bootstrap 组件；如启用
+EgressProxy，先确认主备 Proxy DaemonSet 和 Configurer 健康，再按上述隔离
+边界更新 `cube-node` DaemonSet。全节点完成后，使用用户自定义 NetworkPolicy
+验证允许和拒绝结果，并回归入站访问与 sandbox 生命周期。
+
+如果 `cubeNode.updateStrategy.type=OnDelete`，逐节点执行：
+
+```bash
+kubectl -n <namespace> delete pod <old-cube-node-pod>
+kubectl -n <namespace> wait \
+  --for=condition=Ready pod/<new-cube-node-pod> \
+  --timeout=10m
+```
+
+新 Pod 名称需要在删除后重新查询。不要同时删除多个计算节点上的 Big Pod。
+
+默认 `RollingUpdate` 模式由 DaemonSet 控制器按 `maxUnavailable` 执行，
+无需人工删除 Pod，但仍需持续观察 sandbox 恢复结果。
+
+Configurer 和两个 Proxy DaemonSet 固定为 `OnDelete`，不跟随上述
+`cube-node` 更新策略。更新 EgressProxy 镜像时：
+
+1. 逐节点替换 Configurer Pod，并确认宿主规则和当前活动路由保持正常；
+2. 逐节点替换非活动 Proxy Pod；
+3. 确认替换后的 Proxy Ready 且具备接管能力；
+4. 将活动路径切换到已更新的 Proxy；
+5. 逐节点替换原活动 Proxy Pod；
+6. 全程确认每个节点至少一个 Proxy 健康，不主动回切。
+
+Helm 回滚同样只更新 Proxy Pod template，需按上述顺序人工替换 Pod。回滚后
+继续使用当前健康路径。
+
+## 6. 验收
+
+每个节点至少检查：
+
+- 新 Big Pod Ready；
+- cubelet 端口、`/data/cubelet/cubelet.sock` 和 network-agent
+  `/readyz` 正常；
+- 更新前的 sandbox ID 仍存在且可执行命令；
+- shim、VMM PID 和 guest boot ID 在要求无损的升级中保持不变；
+- HostPort 入站访问正常；
+- EgressProxy 启用时，用户策略允许和拒绝的结果均符合策略定义；
+- 节点进程、HostNetwork Pod 和普通 Pod 的网络路径未被 Egress 规则误伤。
+
+当前 readiness probe 只检查 cubelet、socket 和 network-agent 健康，不会验证
+全部存量 sandbox 已恢复。因此必须执行业务侧存量 sandbox 抽检，不能只依赖
+Pod Ready。
+
+## 7. 回滚
+
+Helm 回滚只回滚 Kubernetes 资源：
+
+```bash
+helm history <release> -n <namespace>
+helm rollback <release> <revision> -n <namespace> --wait --timeout 10m
+```
+
+回滚前确认旧镜像能够读取当前 sandbox 和网络状态。以下内容不会被 Helm 回滚：
+
+- PVM 宿主机内核、GRUB、udev、fstab 和 XFS；
+- hostPath 中的数据和 socket；
+- Chart 之外创建的 NetworkPolicy 或运维资源。
+
+回滚不执行 EgressProxy 清理 hook；仅当新 values 将 `egressProxy.enabled`
+改为 `false` 或卸载 release 时才清理宿主规则。
+
+不要为回滚删除 `/data/cubelet`、`/data/cube-shim`、
+`/usr/local/services/cubetoolbox` 或其他 hostPath。需要回退宿主机变更时，
+应使用经过验证的节点恢复流程。
+
+## 8. 上线门禁
+
+满足以下条件后才能推广：
+
+1. Helm lint、template 和 Chart guard 通过。
+2. 明确本次变更是否会修改 Big Pod template。
+3. network-agent、shim、VMM 或状态格式变化已单独验证兼容性。
+4. 至少一个节点完成升级和回滚验证。
+5. 存量 sandbox、入站 HostPort 和出站网络验证通过。
+6. EgressProxy 启用时，用户自定义 NetworkPolicy 的允许和拒绝结果均符合
+   用户定义，且 Chart 升级和回滚不触碰这些策略。
+7. 已记录 Helm revision、镜像版本、values 和宿主机变更。

--- a/deploy/kubernetes/chart/docs/UPGRADE_EN.md
+++ b/deploy/kubernetes/chart/docs/UPGRADE_EN.md
@@ -1,0 +1,227 @@
+# CubeSandbox Chart Upgrade Guide
+
+English | [中文](./UPGRADE.md)
+
+This document defines the upgrade boundary and operational procedure implemented
+by the current Helm templates, values, and component entrypoints. It does not
+assume an external rollout controller or monitoring system.
+
+> **Breaking change:** the `cube-node` Big Pod moved from the Pod network to
+> unconditional `hostNetwork: true` with `dnsPolicy: ClusterFirstWithHostNet`.
+> Existing old Pods retain their Pod-network semantics until deliberately
+> replaced. Before rollout, migrate monitoring, firewall, and visibility rules
+> that depend on the old CNI Pod IP, and validate one canary compute node.
+
+## In-place sandbox handoff and EgressProxy
+
+Kubernetes replaces the Big Pod; it does not update the Pod image in place.
+Compatible sandbox runtimes, state, and network objects remain on the node and
+the replacement Big Pod reattaches to them. EgressProxy runs in independent
+DaemonSets, so its data path is not tied to the Big Pod lifecycle.
+
+```mermaid
+flowchart LR
+    subgraph K8S["Kubernetes-managed and replaceable"]
+        OLD["Old cube-node Big Pod<br/>old cubelet"]
+        UPDATE["DaemonSet rollout<br/>Pod replacement"]
+        NEW["New cube-node Big Pod<br/>new cubelet<br/>hostPID + hostNetwork"]
+        OLD --> UPDATE --> NEW
+    end
+
+    subgraph HOST["Node-persistent runtime"]
+        RUNTIME["CubeShim + VMM<br/>host cgroup"]
+        STATE["hostPath + sockets<br/>/data/cubelet<br/>/data/cube-shim"]
+        SANDBOX["Existing Sandbox<br/>same ID, guest, and processes"]
+        ROUTER["network-agent + Cube Router<br/>same netns and TAP"]
+        STATE --- RUNTIME
+        RUNTIME --> SANDBOX
+        ROUTER --- SANDBOX
+    end
+
+    subgraph EGRESS["Independent EgressProxy data plane"]
+        CONFIG["Configurer DaemonSet<br/>mark, table 100, health"]
+        RULES["mangle/PREROUTING<br/>mark to table 100"]
+        VETH["Node-local veth<br/>primary / standby"]
+        PROXY["EgressProxy Pod<br/>forward + SNAT"]
+        POLICY["User NetworkPolicy"]
+        SERVICE["Kubernetes Service / Pod"]
+        CONFIG -.-> RULES
+        CONFIG -.-> VETH
+        RULES --> VETH --> PROXY
+        PROXY --> POLICY --> SERVICE
+    end
+
+    OLD -.-> STATE
+    NEW ==>|"read state and reconnect sockets"| STATE
+    NEW ==>|"reuse node network state"| ROUTER
+    SANDBOX -->|"clusterCIDRs only"| ROUTER --> RULES
+```
+
+The Big Pod UID, containers, and cubelet PID change. For a compatible upgrade,
+the sandbox ID and creation time, CubeShim/VMM PIDs, guest boot ID, sandbox
+network namespace, and TAP remain unchanged. This is handoff, not sandbox
+recreation.
+
+## 1. Upgrade model
+
+The compute plane uses four native `apps/v1` DaemonSets:
+
+| Component | Responsibility | Upgrade impact |
+| --- | --- | --- |
+| `cube-node-installer` | Stages shim, kernel, and guest artifacts | Does not carry the live data plane |
+| `cube-node-pvm` | Installs the PVM host kernel on explicitly authorized nodes | May change kernel/GRUB and reboot the node |
+| `cube-node-bootstrap` | Validates and prepares KVM, XFS, and host directories | Does not carry the live data plane |
+| `cube-node` | Runs cubelet and network-agent | Pod-template changes replace the Big Pod |
+
+The Big Pod always uses:
+
+```yaml
+hostPID: true
+hostNetwork: true
+dnsPolicy: ClusterFirstWithHostNet
+```
+
+The default strategy is `RollingUpdate` with `maxUnavailable: 1`. For explicit
+per-node control:
+
+```yaml
+cubeNode:
+  updateStrategy:
+    type: OnDelete
+```
+
+With `OnDelete`, Helm updates only the DaemonSet Pod template; old Pods continue
+running until an operator deletes them.
+
+## 2. Existing-sandbox preservation boundary
+
+The handoff depends on all of the following:
+
+- shim and VMM run in the host PID namespace outside the Big Pod cgroup;
+- `/data/cubelet`, `/data/cube-shim`, and runtime socket directories are
+  hostPath-backed;
+- the replacement cubelet reconnects to existing shim sockets and state;
+- an unchanged network-agent image fingerprint allows the host process to be
+  reused;
+- process identity is verified before a persisted PID can be signalled.
+
+`hostPID` and `hostNetwork` alone do not preserve a sandbox.
+
+Treat these changes as maintenance operations rather than ordinary cubelet
+rollouts:
+
+- network-agent image or Cube Router configuration;
+- sandbox CIDR, interface, or lower-level networking;
+- incompatible shim, VMM, guest, or persisted-state formats;
+- hostPath/socket layout or host-kernel changes.
+
+The chart does not promise connection preservation across those changes.
+
+## 3. EgressProxy upgrade boundary
+
+With `egressProxy.enabled=true`, the chart deploys a HostNetwork Configurer and
+primary/standby EgressProxy DaemonSets on the Pod network. Node-local veth,
+iptables, and policy routing steer only sandbox traffic whose destination is in
+`clusterCIDRs`. Egress leaves through the Proxy Pod identity and can therefore
+be governed by user-defined NetworkPolicy.
+
+Important limits:
+
+- policy selection is per EgressProxy Pod/node, not per sandbox;
+- primary and standby do not share conntrack, so failover can break established
+  connections;
+- all three EgressProxy DaemonSets use `OnDelete`;
+- the chart has no automated drain or rollout orchestrator;
+- the chart never creates, modifies, deletes, or recommends a NetworkPolicy.
+
+Disabling EgressProxy or uninstalling the release runs ownership-checked cleanup
+for the component's dedicated chains, rule priority, and table-100 routes. A
+forced Pod deletion or unreachable node can bypass `preStop`; in that case run
+the same cleanup image after the node recovers.
+
+## 4. Preflight
+
+Run static checks:
+
+```bash
+helm lint deploy/kubernetes/chart
+deploy/kubernetes/chart/scripts/test-big-pod-inplace-guard.sh
+deploy/kubernetes/chart/scripts/test-egress-proxy-guard.sh
+```
+
+Render production values and verify image tags/digests, node selectors, PVM
+authorization, Big Pod update strategy, and the expected EgressProxy resources.
+The render must not contain an EgressProxy NetworkPolicy, tunnel Secret,
+Service, or StatefulSet.
+
+On every target node verify KVM/XFS/kernel readiness, non-overlapping sandbox
+and cluster CIDRs, hostPath capacity, existing sandbox/shim/VMM health, and
+network-agent health. When EgressProxy is enabled, also verify both Proxy Pods,
+the Configurer, pre-DNAT mark rules, the policy rule, active route, and
+fail-closed `unreachable default` in table 100.
+
+The privileged Proxy initContainer and HostNetwork Configurer require a scoped
+Pod Security admission exemption. Do not enable the feature if the cluster
+cannot grant that exception.
+
+## 5. Recommended rollout
+
+Upgrade installer/bootstrap components first. If EgressProxy is enabled, ensure
+its primary, standby, and Configurer are healthy before replacing a Big Pod.
+
+For `OnDelete`, process one compute node at a time:
+
+```bash
+kubectl -n <namespace> delete pod <old-cube-node-pod>
+kubectl -n <namespace> wait \
+  --for=condition=Ready pod/<new-cube-node-pod> \
+  --timeout=10m
+```
+
+Query the replacement Pod name after deletion. Do not delete multiple compute
+nodes concurrently. With the default RollingUpdate strategy, continuously
+validate sandbox handoff while the controller respects `maxUnavailable`.
+
+For an EgressProxy image update, process each node in this order:
+
+1. replace and validate the Configurer;
+2. replace the inactive Proxy;
+3. verify the new inactive Proxy can take traffic;
+4. switch the active path;
+5. replace the former active Proxy;
+6. keep at least one healthy Proxy throughout and do not force a switch-back.
+
+## 6. Acceptance criteria
+
+For each upgraded node verify:
+
+- the replacement Big Pod is Ready;
+- cubelet port/socket and network-agent `/readyz` are healthy;
+- a pre-existing sandbox keeps its ID and can execute a command;
+- shim/VMM PID and guest boot ID remain unchanged when continuity is required;
+- HostPort ingress still works;
+- user-defined NetworkPolicy allows and denies exactly what the user specified;
+- node, HostNetwork Pod, and ordinary Pod traffic is not captured accidentally.
+
+Readiness does not prove that every existing sandbox was reattached. Always run
+a business-level sample against pre-existing sandboxes.
+
+## 7. Rollback
+
+```bash
+helm history <release> -n <namespace>
+helm rollback <release> <revision> -n <namespace> --wait --timeout 10m
+```
+
+Before rollback, verify that the old image can read the current runtime and
+network state. Helm does not roll back host kernel/GRUB/udev/fstab/XFS changes,
+hostPath data, sockets, or user-owned NetworkPolicy. Never delete
+`/data/cubelet`, `/data/cube-shim`, or the toolbox tree as part of rollback.
+
+## 8. Release gate
+
+Promote only after lint/template/guard checks pass, one node completes both
+upgrade and rollback, existing sandbox/ingress/egress checks pass, and all
+images, values, Helm revisions, and host changes are recorded. Compatibility
+for network-agent, shim/VMM, guest, and persisted-state changes must be proven
+separately.

--- a/deploy/kubernetes/chart/scripts/egress-long-connection.sh
+++ b/deploy/kubernetes/chart/scripts/egress-long-connection.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+
+set -u
+
+target_host="${1:?usage: $0 HOST [PORT] [INTERVAL_SECONDS] [STATE_FILE]}"
+target_port="${2:-80}"
+interval="${3:-1}"
+state_file="${4:-/tmp/egress-long-connection.state}"
+
+ok=0
+fail=0
+status=""
+
+if ! exec 3<>"/dev/tcp/${target_host}/${target_port}"; then
+    printf 'ok=%s fail=1 ts=%s status=connect_failed\n' \
+        "${ok}" "$(date +%s%3N)" >"${state_file}"
+    exit 1
+fi
+
+while true; do
+    if ! printf 'GET / HTTP/1.1\r\nHost: %s\r\nConnection: keep-alive\r\n\r\n' \
+        "${target_host}" >&3; then
+        fail=$((fail + 1))
+        break
+    fi
+
+    if ! IFS= read -r status <&3; then
+        fail=$((fail + 1))
+        break
+    fi
+
+    while IFS= read -r line <&3; do
+        line="${line%$'\r'}"
+        [[ -z "${line}" ]] && break
+    done
+
+    if ! IFS= read -r _body <&3; then
+        fail=$((fail + 1))
+        break
+    fi
+
+    ok=$((ok + 1))
+    printf 'ok=%s fail=%s ts=%s status=%s\n' \
+        "${ok}" "${fail}" "$(date +%s%3N)" "${status%$'\r'}" >"${state_file}"
+    sleep "${interval}"
+done
+
+printf 'ok=%s fail=%s ts=%s status=%s\n' \
+    "${ok}" "${fail}" "$(date +%s%3N)" "${status%$'\r'}" >"${state_file}"
+exit 1

--- a/deploy/kubernetes/chart/scripts/egress-test-resources.yaml
+++ b/deploy/kubernetes/chart/scripts/egress-test-resources.yaml
@@ -1,0 +1,239 @@
+# EgressProxy performance and isolation test workloads.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: long-connection-nginx
+  namespace: cube-egress-test
+data:
+  default.conf: |
+    server {
+      listen 80;
+      keepalive_timeout 300s;
+      keepalive_requests 100000;
+      location / {
+        return 200 "long-connection-ok\n";
+      }
+    }
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: long-connection-test
+  namespace: cube-egress-test
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: long-connection-test
+  template:
+    metadata:
+      labels:
+        app: long-connection-test
+        access: allowed
+    spec:
+      containers:
+        - name: nginx
+          image: nginx:1.27-alpine
+          ports:
+            - name: http
+              containerPort: 80
+          volumeMounts:
+            - name: config
+              mountPath: /etc/nginx/conf.d/default.conf
+              subPath: default.conf
+      volumes:
+        - name: config
+          configMap:
+            name: long-connection-nginx
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: long-connection-test
+  namespace: cube-egress-test
+spec:
+  selector:
+    app: long-connection-test
+  ports:
+    - name: http
+      port: 80
+      targetPort: http
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: performance-server
+  namespace: cube-egress-test
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: performance-server
+  template:
+    metadata:
+      labels:
+        app: performance-server
+        access: allowed
+    spec:
+      initContainers:
+        - name: create-test-file
+          image: alpine:3.22
+          command:
+            - /bin/sh
+            - -ec
+            - |
+              dd if=/dev/zero of=/data/blob.bin bs=1M count=64
+          volumeMounts:
+            - name: data
+              mountPath: /data
+        - name: install-busybox
+          image: alpine:3.22
+          command:
+            - /bin/sh
+            - -ec
+            - |
+              cp /bin/busybox /data/busybox
+              cp /lib/ld-musl-*.so.1 /data/ld-musl
+          volumeMounts:
+            - name: data
+              mountPath: /data
+      containers:
+        - name: nginx
+          image: nginx:1.27-alpine
+          ports:
+            - name: http
+              containerPort: 80
+          volumeMounts:
+            - name: data
+              mountPath: /usr/share/nginx/html
+              readOnly: true
+      volumes:
+        - name: data
+          emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: performance-server
+  namespace: cube-egress-test
+spec:
+  selector:
+    app: performance-server
+  ports:
+    - name: http
+      port: 80
+      targetPort: http
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: performance-client
+  namespace: cube-egress-test
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: performance-client
+  template:
+    metadata:
+      labels:
+        app: performance-client
+    spec:
+      initContainers:
+        - name: install-busybox
+          image: alpine:3.22
+          command:
+            - /bin/sh
+            - -ec
+            - |
+              cp /bin/busybox /tools/busybox
+              cp /lib/ld-musl-*.so.1 /tools/ld-musl
+          volumeMounts:
+            - name: tools
+              mountPath: /tools
+      containers:
+        - name: client
+          image: ubuntu:24.04
+          command: ["/bin/bash", "-c", "sleep infinity"]
+          volumeMounts:
+            - name: tools
+              mountPath: /tools
+              readOnly: true
+      volumes:
+        - name: tools
+          emptyDir: {}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: node-management-test
+  namespace: cube-egress-test
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: node-management-test
+  template:
+    metadata:
+      labels:
+        app: node-management-test
+    spec:
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
+      nodeName: 10.0.99.143
+      containers:
+        - name: server
+          image: nginx:1.27-alpine
+          ports:
+            - name: http
+              containerPort: 18081
+              hostPort: 18081
+          command:
+            - /bin/sh
+            - -ec
+            - |
+              sed -i 's/listen       80;/listen       18081;/' /etc/nginx/conf.d/default.conf
+              exec nginx -g 'daemon off;'
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: normal-network-client
+  namespace: cube-egress-test
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: normal-network-client
+  template:
+    metadata:
+      labels:
+        app: normal-network-client
+    spec:
+      containers:
+        - name: client
+          image: nginx:1.27-alpine
+          command: ["/bin/sh", "-c", "sleep 86400"]
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hostnetwork-client
+  namespace: cube-egress-test
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: hostnetwork-client
+  template:
+    metadata:
+      labels:
+        app: hostnetwork-client
+    spec:
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
+      nodeName: 10.0.99.170
+      containers:
+        - name: client
+          image: nginx:1.27-alpine
+          command: ["/bin/sh", "-c", "sleep 86400"]

--- a/deploy/kubernetes/chart/scripts/test-big-pod-inplace-guard.sh
+++ b/deploy/kubernetes/chart/scripts/test-big-pod-inplace-guard.sh
@@ -110,4 +110,17 @@ assert_recreate_change_detected network \
   --set-string cubeNode.network.ethName=eth9
 assert_recreate_change_detected egress \
   --set cubeEgress.enabled=false
+
+entrypoint="${CHART_DIR}/../images/scripts/component-entrypoint.sh"
+grep -q 'move_pid_to_host_cgroups' "${entrypoint}"
+grep -q 'CUBE_HOST_CGROUP_NAME' "${entrypoint}"
+grep -q 'kill -STOP.*BASHPID' "${entrypoint}"
+grep -q 'stop_legacy_network_agents' "${entrypoint}"
+grep -q 'stopping legacy standalone network-agent' "${entrypoint}"
+if grep -q 'kill -TERM.*network-agent.pid' \
+  "${CHART_DIR}/templates/node-daemonset.yaml"; then
+  echo "Big Pod must preserve the host network-agent during replacement" >&2
+  exit 1
+fi
+
 echo "Big Pod template stability guard passed"

--- a/deploy/kubernetes/chart/scripts/test-egress-cleanup.sh
+++ b/deploy/kubernetes/chart/scripts/test-egress-cleanup.sh
@@ -1,0 +1,160 @@
+#!/bin/sh
+set -eu
+
+SCRIPT_DIR="$(CDPATH= cd -- "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(CDPATH= cd -- "${SCRIPT_DIR}/../../../.." && pwd)"
+CLEANUP="${REPO_ROOT}/EgressProxy/configurer/cleanup.sh"
+
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+run_owned_cleanup_case() (
+  export CUBE_ROUTER_NAT_IP=172.20.0.2
+  state_dir="$(mktemp -d)"
+  export CUBE_EGRESS_STATE_DIR="${state_dir}"
+  action_file="$(mktemp)"
+  mark_jump=present
+  marked_forward=present
+  snat_jump=present
+  trap '/bin/rm -f "${action_file}"; /bin/rm -rf "${state_dir}"' EXIT
+
+  iptables() {
+    table="$3"
+    operation="$4"
+    shift 4
+    case "${table}:${operation}:$*" in
+      "mangle:-S:PREROUTING")
+        [ "${mark_jump}" = present ] &&
+          printf '%s\n' '-A PREROUTING -s 172.20.0.2/32 -i cube-router -j CUBE-EGRESS-MARK'
+        ;;
+      "mangle:-S:CUBE-EGRESS-MARK")
+        printf '%s\n' '-N CUBE-EGRESS-MARK'
+        printf '%s\n' '-A CUBE-EGRESS-MARK -m set --match-set CUBE-EGRESS-CLUSTER-CIDRS dst -j MARK --set-xmark 0x1000/0x1000'
+        ;;
+      "filter:-S:CUBE-EGRESS")
+        printf '%s\n' '-N CUBE-EGRESS'
+        printf '%s\n' '-A CUBE-EGRESS -o cube-egress-p0 -j ACCEPT'
+        printf '%s\n' '-A CUBE-EGRESS -o cube-egress-p1 -j ACCEPT'
+        printf '%s\n' '-A CUBE-EGRESS -j DROP'
+        ;;
+      "nat:-S:CUBE-EGRESS-SNAT")
+        printf '%s\n' '-N CUBE-EGRESS-SNAT'
+        printf '%s\n' '-A CUBE-EGRESS-SNAT -o cube-egress-p0 -j SNAT --to-source 172.20.0.2'
+        printf '%s\n' '-A CUBE-EGRESS-SNAT -o cube-egress-p1 -j SNAT --to-source 172.20.0.2'
+        ;;
+      "mangle:-C:PREROUTING "*)
+        [ "${mark_jump}" = present ]
+        ;;
+      "mangle:-D:PREROUTING "*)
+        mark_jump=absent
+        printf 'delete-mark-jump\n' >>"${action_file}"
+        ;;
+      "filter:-C:FORWARD -s 172.20.0.2/32 -i cube-router -m mark "*)
+        [ "${marked_forward}" = present ]
+        ;;
+      "filter:-D:FORWARD -s 172.20.0.2/32 -i cube-router -m mark "*)
+        marked_forward=absent
+        printf 'delete-marked-forward\n' >>"${action_file}"
+        ;;
+      "nat:-C:POSTROUTING -s 172.20.0.2/32 -m mark "*)
+        [ "${snat_jump}" = present ]
+        ;;
+      "nat:-D:POSTROUTING -s 172.20.0.2/32 -m mark "*)
+        snat_jump=absent
+        printf 'delete-snat-jump\n' >>"${action_file}"
+        ;;
+      "mangle:-F:CUBE-EGRESS-MARK"|"mangle:-X:CUBE-EGRESS-MARK"|\
+      "filter:-F:CUBE-EGRESS"|"filter:-X:CUBE-EGRESS"|\
+      "nat:-F:CUBE-EGRESS-SNAT"|"nat:-X:CUBE-EGRESS-SNAT")
+        printf '%s:%s\n' "${table}" "${operation}" >>"${action_file}"
+        ;;
+      "filter:-S:FORWARD")
+        ;;
+      *)
+        fail "unexpected iptables command: ${table} ${operation} $*"
+        ;;
+    esac
+  }
+
+  ip() {
+    case "$*" in
+      "-4 rule show priority 10900")
+        printf '10900:\tfrom 172.20.0.2 fwmark 0x1000/0x1000 iif cube-router lookup 100\n'
+        ;;
+      "-4 rule del priority 10900 "*)
+        printf 'delete-policy-rule\n' >>"${action_file}"
+        ;;
+      "route del table 100 "*)
+        printf 'delete-route\n' >>"${action_file}"
+        ;;
+      *)
+        fail "unexpected ip command: $*"
+        ;;
+    esac
+  }
+
+  ipset() {
+    case "$*" in
+      "save CUBE-EGRESS-CLUSTER-CIDRS")
+        printf '%s\n' \
+          'create CUBE-EGRESS-CLUSTER-CIDRS hash:net family inet' \
+          'add CUBE-EGRESS-CLUSTER-CIDRS 10.244.0.0/16'
+        ;;
+      "destroy CUBE-EGRESS-CLUSTER-CIDRS-NEXT")
+        ;;
+      "destroy CUBE-EGRESS-CLUSTER-CIDRS")
+        printf 'destroy-cidr-set\n' >>"${action_file}"
+        ;;
+      *)
+        fail "unexpected ipset command: $*"
+        ;;
+    esac
+  }
+
+  rm() {
+    :
+  }
+
+  # shellcheck source=/dev/null
+  . "${CLEANUP}"
+  grep -F 'delete-mark-jump' "${action_file}" >/dev/null
+  grep -F 'delete-policy-rule' "${action_file}" >/dev/null
+  grep -F 'delete-snat-jump' "${action_file}" >/dev/null
+  grep -F 'destroy-cidr-set' "${action_file}" >/dev/null
+  [ "$(grep -c '^delete-route$' "${action_file}")" -eq 3 ]
+)
+
+run_foreign_chain_case() (
+  export CUBE_ROUTER_NAT_IP=172.20.0.2
+  state_dir="$(mktemp -d)"
+  export CUBE_EGRESS_STATE_DIR="${state_dir}"
+  trap '/bin/rm -rf "${state_dir}"' EXIT
+  iptables() {
+    case "$*" in
+      "-w -t mangle -S PREROUTING")
+        ;;
+      "-w -t mangle -S CUBE-EGRESS-MARK")
+        printf '%s\n' '-N CUBE-EGRESS-MARK'
+        printf '%s\n' '-A CUBE-EGRESS-MARK -j ACCEPT'
+        ;;
+      *)
+        fail "foreign case mutated state: $*"
+        ;;
+    esac
+  }
+  log() {
+    :
+  }
+
+  # shellcheck source=/dev/null
+  . "${CLEANUP}"
+)
+
+run_owned_cleanup_case
+if run_foreign_chain_case; then
+  fail "foreign mark chain was removed"
+fi
+
+printf 'EgressProxy owned host-state cleanup tests passed\n'

--- a/deploy/kubernetes/chart/scripts/test-egress-policy-rules.sh
+++ b/deploy/kubernetes/chart/scripts/test-egress-policy-rules.sh
@@ -1,0 +1,183 @@
+#!/bin/sh
+set -eu
+
+SCRIPT_DIR="$(CDPATH= cd -- "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(CDPATH= cd -- "${SCRIPT_DIR}/../../../.." && pwd)"
+RECONCILE="${REPO_ROOT}/EgressProxy/configurer/reconcile.sh"
+
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+run_create_case() (
+  export CUBE_EGRESS_RECONCILE_LIBRARY_ONLY=1
+  export CUBE_EGRESS_CLUSTER_CIDRS=10.0.0.1/24,10.0.0.2/24
+  export NODE_NAME=test-node
+  export CUBE_ROUTER_NAT_IP=172.20.0.2
+  # shellcheck source=/dev/null
+  . "${RECONCILE}"
+  POLICY_RULES=""
+
+  [ "${CLUSTER_CIDRS}" = "10.0.0.0/24" ] ||
+    fail "CIDRs were not normalized and deduplicated: ${CLUSTER_CIDRS}"
+
+  action_file="$(mktemp)"
+  trap 'rm -f "${action_file}"' EXIT
+  ip() {
+    case "$*" in
+      "-4 rule show priority 10900")
+        ;;
+      "-4 rule add priority 10900 "*)
+        printf '%s\n' "$*" >"${action_file}"
+        ;;
+      *)
+        fail "create case unexpected ip command: $*"
+        ;;
+    esac
+  }
+
+  preflight_policy_rule_ownership
+  ensure_policy_rule
+  grep -F 'fwmark 0x1000/0x1000 lookup 100' "${action_file}" >/dev/null ||
+    fail "mark-scoped policy rule was not created"
+)
+
+run_idempotent_case() (
+  export CUBE_EGRESS_RECONCILE_LIBRARY_ONLY=1
+  export CUBE_EGRESS_CLUSTER_CIDRS=10.244.0.0/16
+  export NODE_NAME=test-node
+  export CUBE_ROUTER_NAT_IP=172.20.0.2
+  # shellcheck source=/dev/null
+  . "${RECONCILE}"
+  POLICY_RULES="$(expected_policy_rule)"
+
+  ip() {
+    fail "idempotent case mutated rules: $*"
+  }
+
+  preflight_policy_rule_ownership
+  ensure_policy_rule
+)
+
+run_collision_case() (
+  export CUBE_EGRESS_RECONCILE_LIBRARY_ONLY=1
+  export CUBE_EGRESS_CLUSTER_CIDRS=10.244.0.0/16
+  export NODE_NAME=test-node
+  export CUBE_ROUTER_NAT_IP=172.20.0.2
+  # shellcheck source=/dev/null
+  . "${RECONCILE}"
+  POLICY_RULES="$(printf '10900:\tfrom all lookup 200\n')"
+
+  ip() {
+    fail "collision case mutated rules: $*"
+  }
+  log() {
+    :
+  }
+
+  if preflight_policy_rule_ownership; then
+    fail "foreign primary-priority collision was accepted"
+  fi
+)
+
+run_iptables_collision_case() (
+  export CUBE_EGRESS_RECONCILE_LIBRARY_ONLY=1
+  export CUBE_EGRESS_CLUSTER_CIDRS=10.244.0.0/16
+  export NODE_NAME=test-node
+  export CUBE_ROUTER_NAT_IP=172.20.0.2
+  # shellcheck source=/dev/null
+  . "${RECONCILE}"
+  MANGLE_RULES="$(printf '%s\n' \
+    '-N CUBE-EGRESS-MARK' \
+    '-A CUBE-EGRESS-MARK -j ACCEPT')"
+  FILTER_RULES=""
+  log() {
+    :
+  }
+
+  if preflight_iptables_ownership; then
+    fail "foreign iptables chain was accepted"
+  fi
+)
+
+run_ipset_atomic_case() (
+  export CUBE_EGRESS_RECONCILE_LIBRARY_ONLY=1
+  export CUBE_EGRESS_CLUSTER_CIDRS=10.0.0.1/24,10.1.0.0/16
+  export NODE_NAME=test-node
+  export CUBE_ROUTER_NAT_IP=172.20.0.2
+  # shellcheck source=/dev/null
+  . "${RECONCILE}"
+  IPSET_STATE=""
+  action_file="$(mktemp)"
+  trap 'rm -f "${action_file}"' EXIT
+  ipset() {
+    printf '%s\n' "$*" >> "${action_file}"
+  }
+
+  ensure_cluster_cidr_set
+  expected_actions="$(cat <<'EOF'
+create CUBE-EGRESS-CLUSTER-CIDRS hash:net family inet -exist
+create CUBE-EGRESS-CLUSTER-CIDRS-NEXT hash:net family inet -exist
+flush CUBE-EGRESS-CLUSTER-CIDRS-NEXT
+add CUBE-EGRESS-CLUSTER-CIDRS-NEXT 10.0.0.0/24
+add CUBE-EGRESS-CLUSTER-CIDRS-NEXT 10.1.0.0/16
+swap CUBE-EGRESS-CLUSTER-CIDRS-NEXT CUBE-EGRESS-CLUSTER-CIDRS
+destroy CUBE-EGRESS-CLUSTER-CIDRS-NEXT
+EOF
+)"
+  [ "$(cat "${action_file}")" = "${expected_actions}" ] ||
+    fail "CIDR ipset was not replaced atomically"
+
+  expected_chain="$(expected_mark_chain)"
+  printf '%s\n' "${expected_chain}" |
+    grep -F -- '--match-set CUBE-EGRESS-CLUSTER-CIDRS dst' >/dev/null ||
+    fail "mark chain does not use the CIDR ipset"
+)
+
+run_missing_route_table_snapshot_case() (
+  export CUBE_EGRESS_RECONCILE_LIBRARY_ONLY=1
+  export CUBE_EGRESS_CLUSTER_CIDRS=10.244.0.0/16
+  export NODE_NAME=test-node
+  export CUBE_ROUTER_NAT_IP=172.20.0.2
+  # shellcheck source=/dev/null
+  . "${RECONCILE}"
+
+  iptables() {
+    :
+  }
+  ipset() {
+    return 1
+  }
+  ip() {
+    case "$*" in
+      "-4 rule show") : ;;
+      "route show table 100") return 2 ;;
+      *) fail "missing route-table case unexpected ip command: $*" ;;
+    esac
+  }
+
+  load_state_snapshots
+  [ -z "${ROUTE_STATE}" ] ||
+    fail "missing route table was not treated as an empty snapshot"
+)
+
+run_create_case
+run_idempotent_case
+run_collision_case
+run_iptables_collision_case
+run_ipset_atomic_case
+run_missing_route_table_snapshot_case
+
+preflight_line="$(
+  grep -n '^preflight_policy_rule_ownership$' "${RECONCILE}" |
+    cut -d: -f1
+)"
+write_line="$(
+  grep -n '^ensure_mark_chain$' "${RECONCILE}" |
+    cut -d: -f1
+)"
+[ "${preflight_line}" -lt "${write_line}" ] ||
+  fail "ownership preflight must complete before the first state write"
+
+printf 'EgressProxy policy-rule ownership and CIDR normalization tests passed\n'

--- a/deploy/kubernetes/chart/scripts/test-egress-proxy-guard.sh
+++ b/deploy/kubernetes/chart/scripts/test-egress-proxy-guard.sh
@@ -1,0 +1,168 @@
+#!/bin/sh
+set -eu
+
+SCRIPT_DIR="$(CDPATH= cd -- "$(dirname "$0")" && pwd)"
+CHART_DIR="$(dirname "$SCRIPT_DIR")"
+REPO_ROOT="$(CDPATH= cd -- "${CHART_DIR}/../../.." && pwd)"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+rendered="${TMP_DIR}/rendered.yaml"
+disabled_rendered="${TMP_DIR}/disabled-rendered.yaml"
+
+helm template egress-guard "${CHART_DIR}" \
+  --set-string mysql.password=test \
+  --set-string mysql.rootPassword=test \
+  --set-string redis.password=test \
+  --set egressProxy.enabled=true \
+  --set cubeNode.network.cubeRouter.enabled=true \
+  --set cubeEgress.network.enabled=false \
+  --set-string 'egressProxy.clusterCIDRs[0]=10.244.0.0/16' \
+  > "${rendered}"
+
+helm template egress-disabled "${CHART_DIR}" \
+  --set-string mysql.password=test \
+  --set-string mysql.rootPassword=test \
+  --set-string redis.password=test \
+  > "${disabled_rendered}"
+
+assert_contains() {
+  pattern="$1"
+  file="$2"
+  if ! grep -Eq "${pattern}" "${file}"; then
+    echo "missing expected pattern '${pattern}' in ${file}" >&2
+    exit 1
+  fi
+}
+
+assert_not_contains() {
+  pattern="$1"
+  file="$2"
+  if grep -Eq "${pattern}" "${file}"; then
+    echo "unexpected pattern '${pattern}' in ${file}" >&2
+    exit 1
+  fi
+}
+
+assert_contains 'name: egress-guard-cube-egress-configurer' "${rendered}"
+assert_contains 'name: egress-guard-cube-egress-proxy-primary' "${rendered}"
+assert_contains 'name: egress-guard-cube-egress-proxy-standby' "${rendered}"
+assert_contains 'kind: DaemonSet' "${rendered}"
+assert_contains 'type: OnDelete' "${rendered}"
+assert_not_contains 'name: egress-guard-cube-egress-proxy$' "${rendered}"
+assert_contains 'hostNetwork: true' "${rendered}"
+assert_contains 'hostPID: true' "${rendered}"
+assert_contains 'dnsPolicy: ClusterFirstWithHostNet' "${rendered}"
+assert_contains 'CUBE_ROUTER_ENABLE' "${rendered}"
+assert_contains 'CUBE_ROUTER_CIDR' "${rendered}"
+assert_not_contains 'kind: NetworkPolicy' "${rendered}"
+assert_not_contains 'kind: PodDisruptionBudget' "${rendered}"
+assert_not_contains 'CUBE_EGRESS_WIREGUARD' "${rendered}"
+assert_not_contains 'wireguard' "${rendered}"
+assert_contains 'setup-veth.sh' "${rendered}"
+assert_contains 'CUBE_EGRESS_ROLE' "${rendered}"
+assert_contains 'CUBE_EGRESS_CLUSTER_CIDRS' "${rendered}"
+assert_contains '10.244.0.0/16' "${rendered}"
+assert_contains 'lookup "v1" "Namespace" "" "cube-egress"' \
+  "${CHART_DIR}/templates/egress-proxy-namespace.yaml"
+assert_contains 'meta.helm.sh/release-name' \
+  "${CHART_DIR}/templates/egress-proxy-namespace.yaml"
+assert_contains 'ownedByRelease' \
+  "${CHART_DIR}/templates/egress-proxy-namespace.yaml"
+assert_contains 'helm.sh/resource-policy: keep' "${rendered}"
+assert_contains 'name: egress-guard-cube-egress-cleanup-uninstall' "${rendered}"
+assert_contains 'helm.sh/hook: post-delete' "${rendered}"
+assert_contains 'helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded' "${rendered}"
+assert_contains 'readinessProbe:' "${rendered}"
+assert_contains '/tmp/cleanup-complete' "${rendered}"
+assert_contains 'name: egress-disabled-cube-egress-cleanup-uninstall' \
+  "${disabled_rendered}"
+assert_contains 'preStop:' "${rendered}"
+assert_contains '/opt/cube-egress/cleanup.sh' "${rendered}"
+
+if helm template missing-egress-cidr "${CHART_DIR}" \
+  --set-string mysql.password=test \
+  --set-string mysql.rootPassword=test \
+  --set-string redis.password=test \
+  --set egressProxy.enabled=true \
+  --set cubeNode.network.cubeRouter.enabled=true \
+  --set cubeEgress.network.enabled=false \
+  > /dev/null 2>&1; then
+  echo "egressProxy.clusterCIDRs must be required" >&2
+  exit 1
+fi
+
+if helm template invalid-egress-cidr "${CHART_DIR}" \
+  --set-string mysql.password=test \
+  --set-string mysql.rootPassword=test \
+  --set-string redis.password=test \
+  --set egressProxy.enabled=true \
+  --set cubeNode.network.cubeRouter.enabled=true \
+  --set cubeEgress.network.enabled=false \
+  --set-string 'egressProxy.clusterCIDRs[0]=10.999.0.0/16' \
+  > /dev/null 2>&1; then
+  echo "invalid egressProxy.clusterCIDRs entry was accepted" >&2
+  exit 1
+fi
+
+if helm template duplicate-egress-cidr "${CHART_DIR}" \
+  --set-string mysql.password=test \
+  --set-string mysql.rootPassword=test \
+  --set-string redis.password=test \
+  --set egressProxy.enabled=true \
+  --set cubeNode.network.cubeRouter.enabled=true \
+  --set cubeEgress.network.enabled=false \
+  --set-string 'egressProxy.clusterCIDRs[0]=10.244.0.0/16' \
+  --set-string 'egressProxy.clusterCIDRs[1]=10.244.0.0/16' \
+  > /dev/null 2>&1; then
+  echo "duplicate egressProxy.clusterCIDRs entry was accepted" >&2
+  exit 1
+fi
+
+assert_contains 'iif cube-router' "${REPO_ROOT}/EgressProxy/configurer/reconcile.sh"
+assert_contains 'from .*CUBE_ROUTER_NAT_IP.*/32' "${REPO_ROOT}/EgressProxy/configurer/reconcile.sh"
+assert_contains 'CUBE-EGRESS-MARK' "${REPO_ROOT}/EgressProxy/configurer/reconcile.sh"
+assert_contains 'ensure_route_mark_ownership' \
+  "${REPO_ROOT}/EgressProxy/configurer/reconcile.sh"
+assert_contains 'fwmark.*ROUTE_MARK' "${REPO_ROOT}/EgressProxy/configurer/reconcile.sh"
+assert_contains 'unreachable default' "${REPO_ROOT}/EgressProxy/configurer/reconcile.sh"
+assert_contains 'peer_is_healthy.*current_iface' "${REPO_ROOT}/EgressProxy/configurer/reconcile.sh"
+assert_contains 'active peer changed' "${REPO_ROOT}/EgressProxy/configurer/reconcile.sh"
+assert_contains 'CUBE-EGRESS' "${REPO_ROOT}/EgressProxy/configurer/reconcile.sh"
+assert_contains 'iptables-restore.*--noflush' "${REPO_ROOT}/EgressProxy/configurer/reconcile.sh"
+assert_contains 'current_chain' "${REPO_ROOT}/EgressProxy/configurer/reconcile.sh"
+assert_contains 'expected_chain' "${REPO_ROOT}/EgressProxy/configurer/reconcile.sh"
+assert_not_contains 'iptables .* -F CUBE-EGRESS' "${REPO_ROOT}/EgressProxy/configurer/reconcile.sh"
+assert_not_contains 'connmark|CONNMARK' "${REPO_ROOT}/EgressProxy/configurer/reconcile.sh"
+assert_not_contains 'wireguard|wg syncconf' "${REPO_ROOT}/EgressProxy/configurer/reconcile.sh"
+assert_contains 'cube-egress-p0' "${REPO_ROOT}/EgressProxy/configurer/reconcile.sh"
+assert_contains 'cube-egress-p1' "${REPO_ROOT}/EgressProxy/configurer/reconcile.sh"
+assert_contains 'egress-host0' "${REPO_ROOT}/EgressProxy/proxy/setup-veth.sh"
+assert_contains 'VETH_HOST_IP' "${REPO_ROOT}/EgressProxy/proxy/entrypoint.sh"
+assert_contains 'source_ip in.*CUBE_ROUTER_NAT_IP.*VETH_HOST_IP' \
+  "${REPO_ROOT}/EgressProxy/proxy/entrypoint.sh"
+assert_contains 'health-server.sh' "${REPO_ROOT}/EgressProxy/proxy/entrypoint.sh"
+assert_contains 'nc -w 2' "${REPO_ROOT}/EgressProxy/configurer/reconcile.sh"
+assert_contains 'preflight_iptables_ownership' \
+  "${REPO_ROOT}/EgressProxy/configurer/reconcile.sh"
+assert_not_contains 'cleanup_legacy_tunnels|cube-wg' \
+  "${REPO_ROOT}/EgressProxy/configurer/reconcile.sh"
+
+sh "${SCRIPT_DIR}/test-egress-route-failover.sh"
+sh "${SCRIPT_DIR}/test-egress-policy-rules.sh"
+sh "${SCRIPT_DIR}/test-egress-cleanup.sh"
+
+image_builder="${REPO_ROOT}/deploy/kubernetes/images/build-cube-images.sh"
+assert_contains 'cube-egress-configurer' "${image_builder}"
+assert_contains 'cube-egress-proxy' "${image_builder}"
+assert_contains 'EgressProxy/Dockerfile.configurer' "${image_builder}"
+assert_contains 'EgressProxy/Dockerfile.proxy' "${image_builder}"
+
+if [ -d "${REPO_ROOT}/EgressProxy/deploy" ]; then
+  echo "EgressProxy/deploy must not exist; deployment belongs to deploy/kubernetes/chart" >&2
+  exit 1
+fi
+
+assert_not_contains 'generate-egress-wireguard-secret' "${CHART_DIR}/README.md"
+
+echo "EgressProxy chart and node-routing guard passed"

--- a/deploy/kubernetes/chart/scripts/test-egress-route-failover.sh
+++ b/deploy/kubernetes/chart/scripts/test-egress-route-failover.sh
@@ -1,0 +1,171 @@
+#!/bin/sh
+set -eu
+
+SCRIPT_DIR="$(CDPATH= cd -- "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(CDPATH= cd -- "${SCRIPT_DIR}/../../../.." && pwd)"
+RECONCILE="${REPO_ROOT}/EgressProxy/configurer/reconcile.sh"
+CLUSTER_CIDRS="10.244.0.0/16,10.96.0.0/12"
+
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+run_case() (
+  case_name="$1"
+  current_iface="$2"
+  p0_healthy="$3"
+  p1_healthy="$4"
+  expected_actions="$5"
+  expected_status="$6"
+
+  export CUBE_EGRESS_RECONCILE_LIBRARY_ONLY=1
+  export CUBE_EGRESS_CLUSTER_CIDRS="${CLUSTER_CIDRS}"
+  export NODE_NAME=test-node
+  export CUBE_ROUTER_NAT_IP=172.20.0.2
+  # shellcheck source=/dev/null
+  . "${RECONCILE}"
+
+  action_file="$(mktemp)"
+  trap 'rm -f "${action_file}"' EXIT
+
+  peer_is_healthy() {
+    iface="$1"
+    case "${iface}" in
+      cube-egress-p0) [ "${p0_healthy}" = "true" ] ;;
+      cube-egress-p1) [ "${p1_healthy}" = "true" ] ;;
+      *) return 1 ;;
+    esac
+  }
+
+  print_routes() {
+    if [ -n "${current_iface}" ]; then
+      case "${current_iface}" in
+        cube-egress-p0) gateway=169.254.240.2 ;;
+        cube-egress-p1) gateway=169.254.240.6 ;;
+      esac
+      printf 'default via %s dev %s metric 100 \n' \
+        "${gateway}" "${current_iface}"
+    fi
+    printf 'unreachable default metric 32767\n'
+  }
+
+  ip() {
+    case "$*" in
+      "route show table 100")
+        print_routes
+        ;;
+      "route replace table 100 default via "*)
+        printf 'replace:%s\n' "$9" >>"${action_file}"
+        ;;
+      "route del table 100 default metric 100")
+        printf 'delete:%s\n' "${current_iface}" >>"${action_file}"
+        ;;
+      "route replace table 100 unreachable default metric 32767")
+        ;;
+      *)
+        fail "${case_name}: unexpected ip command: $*"
+        ;;
+    esac
+  }
+
+  log() {
+    :
+  }
+
+  ROUTE_STATE="$(print_routes)"
+  if ensure_policy_route; then
+    actual_status=0
+  else
+    actual_status=1
+  fi
+  actual_actions="$(cat "${action_file}")"
+  if [ "${actual_actions}" != "${expected_actions}" ]; then
+    fail "${case_name}: expected '${expected_actions}', got '${actual_actions}'"
+  fi
+  if [ "${actual_status}" -ne "${expected_status}" ]; then
+    fail "${case_name}: expected status ${expected_status}, got ${actual_status}"
+  fi
+)
+
+# Keep the current healthy standby-selected peer without rewriting routes.
+run_case sticky-current cube-egress-p1 true true "" 0
+# Switch the marked-traffic default route only after the current peer fails.
+run_case failed-current cube-egress-p1 true false \
+"replace:cube-egress-p0" 0
+# Remove the active route while retaining unreachable default on total failure.
+run_case all-failed cube-egress-p0 false false \
+"delete:cube-egress-p0" 1
+
+run_route_table_collision_case() (
+  export CUBE_EGRESS_RECONCILE_LIBRARY_ONLY=1
+  export CUBE_EGRESS_CLUSTER_CIDRS="${CLUSTER_CIDRS}"
+  export NODE_NAME=test-node
+  export CUBE_ROUTER_NAT_IP=172.20.0.2
+  # shellcheck source=/dev/null
+  . "${RECONCILE}"
+
+  ip() {
+    case "$*" in
+      "route show table 100")
+        printf '10.0.0.0/8 via 192.0.2.1 dev eth9\n'
+        ;;
+      *)
+        fail "route-table collision case mutated state: $*"
+        ;;
+    esac
+  }
+
+  log() {
+    :
+  }
+
+  ROUTE_STATE='10.0.0.0/8 via 192.0.2.1 dev eth9'
+  if ensure_route_table_ownership; then
+    fail "foreign route-table content was accepted"
+  fi
+)
+
+run_route_table_collision_case
+
+run_proxy_process_probe_case() (
+  response="$1"
+  expected_status="$2"
+  export CUBE_EGRESS_RECONCILE_LIBRARY_ONLY=1
+  export CUBE_EGRESS_CLUSTER_CIDRS="${CLUSTER_CIDRS}"
+  export NODE_NAME=test-node
+  export CUBE_ROUTER_NAT_IP=172.20.0.2
+  # shellcheck source=/dev/null
+  . "${RECONCILE}"
+
+  ip() {
+    case "$*" in
+      "link show cube-egress-p0")
+        ;;
+      "-4 -o address show dev cube-egress-p0")
+        printf '1: cube-egress-p0 inet 169.254.240.1/30 scope global cube-egress-p0\n'
+        ;;
+      *)
+        fail "proxy probe case unexpected ip command: $*"
+        ;;
+    esac
+  }
+  nc() {
+    [ "${response}" != "connection-failed" ] || return 1
+    printf '%s\n' "${response}"
+  }
+
+  if peer_is_healthy cube-egress-p0; then
+    actual_status=0
+  else
+    actual_status=1
+  fi
+  [ "${actual_status}" -eq "${expected_status}" ] ||
+    fail "proxy probe response ${response}: expected ${expected_status}, got ${actual_status}"
+)
+
+run_proxy_process_probe_case ok 0
+run_proxy_process_probe_case failed 1
+run_proxy_process_probe_case connection-failed 1
+
+printf 'EgressProxy local-veth sticky failover tests passed\n'

--- a/deploy/kubernetes/chart/scripts/test-egress-veth-lifecycle.sh
+++ b/deploy/kubernetes/chart/scripts/test-egress-veth-lifecycle.sh
@@ -1,0 +1,62 @@
+#!/bin/sh
+set -eu
+
+SCRIPT_DIR="$(CDPATH= cd -- "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(CDPATH= cd -- "${SCRIPT_DIR}/../../../.." && pwd)"
+
+unshare -n sleep 60 &
+host_pid=$!
+trap 'kill "${host_pid}" 2>/dev/null || true' EXIT
+
+export CUBE_EGRESS_ROLE=primary
+export CUBE_ROUTER_NAT_IP=172.20.0.2
+export CUBE_EGRESS_HOST_NETNS_PID="${host_pid}"
+
+"${REPO_ROOT}/EgressProxy/proxy/setup-veth.sh"
+
+ip -4 address show dev egress-host0 |
+  grep -F '169.254.240.2/30' >/dev/null
+ip route show 172.20.0.2/32 |
+  grep -F 'via 169.254.240.1 dev egress-host0' >/dev/null
+nsenter -t "${host_pid}" -n -- ip -4 address show dev cube-egress-p0 |
+  grep -F '169.254.240.1/30' >/dev/null
+nsenter -t "${host_pid}" -n -- ip -d link show dev cube-egress-p0 |
+  grep -F 'alias cube-egress:primary' >/dev/null
+nsenter -t "${host_pid}" -n -- \
+  ping -c 2 -W 1 169.254.240.2 >/dev/null
+
+proxy_mtu="$(cat /sys/class/net/egress-host0/mtu)"
+host_mtu="$(
+  nsenter -t "${host_pid}" -n -- \
+    ip -o link show dev cube-egress-p0 |
+    awk '{ for (i = 1; i <= NF; i++) if ($i == "mtu") print $(i + 1) }'
+)"
+[ "${proxy_mtu}" = "${host_mtu}" ]
+
+nsenter -t "${host_pid}" -n -- ip link del cube-egress-p0
+nsenter -t "${host_pid}" -n -- ip link add cube-egress-p0 type dummy
+if "${REPO_ROOT}/EgressProxy/proxy/setup-veth.sh" 2>/dev/null; then
+  printf 'setup-veth unexpectedly replaced an unowned host interface\n' >&2
+  exit 1
+fi
+nsenter -t "${host_pid}" -n -- ip link show cube-egress-p0 >/dev/null
+
+nsenter -t "${host_pid}" -n -- \
+  ip link set cube-egress-p0 alias cube-egress:primary-foreign
+if "${REPO_ROOT}/EgressProxy/proxy/setup-veth.sh" 2>/dev/null; then
+  printf 'setup-veth accepted a prefix-matching foreign alias\n' >&2
+  exit 1
+fi
+nsenter -t "${host_pid}" -n -- ip link show cube-egress-p0 >/dev/null
+
+nsenter -t "${host_pid}" -n -- ip link del cube-egress-p0
+nsenter -t "${host_pid}" -n -- ip link add foreign-link type dummy
+nsenter -t "${host_pid}" -n -- ip address add 169.254.240.100/24 dev foreign-link
+if "${REPO_ROOT}/EgressProxy/proxy/setup-veth.sh" 2>/dev/null; then
+  printf 'setup-veth unexpectedly reused an occupied link-local range\n' >&2
+  exit 1
+fi
+nsenter -t "${host_pid}" -n -- ip -4 address show dev foreign-link |
+  grep -F '169.254.240.100/24' >/dev/null
+
+printf 'EgressProxy veth lifecycle integration test passed\n'

--- a/deploy/kubernetes/chart/templates/_helpers.tpl
+++ b/deploy/kubernetes/chart/templates/_helpers.tpl
@@ -39,7 +39,8 @@ Cube-owned images should use `cube.cubeImage` instead.
 {{- end -}}
 
 {{- /*
-Render "<repository>:<tag>" for a Cube-owned image with optional
+Render "<repository>@<digest>" when digest is set, otherwise
+"<repository>:<tag>", with optional
 $.Values.global.imageRegistry override applied to the registry portion of
 .repository. Call as:
   include "cube.cubeImage" (dict "image" .Values.images.master "context" $)
@@ -62,7 +63,12 @@ is preserved.
     {{- $repo = printf "%s/%s" (trimSuffix "/" $override) $repo -}}
   {{- end -}}
 {{- end -}}
+{{- $digest := $image.digest | default "" -}}
+{{- if $digest -}}
+{{- printf "%s@%s" $repo $digest -}}
+{{- else -}}
 {{- printf "%s:%s" $repo $image.tag -}}
+{{- end -}}
 {{- end -}}
 
 {{- define "cube.timezoneEnv" -}}
@@ -930,8 +936,6 @@ Bootstrap: host mutation mounts for pvm / node-init.
   value: /usr/local/services/cubetoolbox
 - name: IMAGE_ROOT
   value: /opt/cube-image
-- name: CUBE_PID_DIR
-  value: /run/cube-node
 - name: STATE_DIR
   value: {{ .Values.hostPaths.bootstrapState | quote }}
 - name: CUBE_MASTER_ENDPOINT

--- a/deploy/kubernetes/chart/templates/cluster-dns.yaml
+++ b/deploy/kubernetes/chart/templates/cluster-dns.yaml
@@ -1,6 +1,6 @@
 {{- if eq (include "cube.configureClusterDNS" .) "true" }}
 {{- $domain := .Values.cubeProxy.domain -}}
-{{- $domainRegex := replace "." "\\." $domain -}}
+{{- $domainPattern := replace "." "[.]" $domain -}}
 {{- $svcFQDN := include "cube.proxyServiceFQDN" . -}}
 {{- $clusterDomain := include "cube.clusterDomain" . -}}
 {{- $markerBegin := printf "# BEGIN cube-sandbox-dns %s" .Release.Name -}}
@@ -8,6 +8,7 @@
 {{- $coreDNSNamespace := "kube-system" -}}
 {{- $coreDNSConfigMap := "coredns" -}}
 {{- $coreDNSKey := "Corefile" -}}
+{{- $queryNameTemplate := "{{ .Name }}" -}}
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -26,8 +27,10 @@ data:
     {{ $domain }}:53 {
         errors
         cache 60
-        rewrite name exact {{ $domain }}. {{ $svcFQDN }}.
-        rewrite name regex (.*)\.{{ $domainRegex }}\.? {{ $svcFQDN }}.
+        template IN ANY {{ $domain }} {
+            match "^(.+[.])?{{ $domainPattern }}[.]$"
+            answer "{{ $queryNameTemplate }} 60 IN CNAME {{ $svcFQDN }}."
+        }
         kubernetes {{ $clusterDomain }}
         forward . /etc/resolv.conf
     }

--- a/deploy/kubernetes/chart/templates/egress-cleanup-hooks.yaml
+++ b/deploy/kubernetes/chart/templates/egress-cleanup-hooks.yaml
@@ -1,0 +1,93 @@
+{{- $root := . -}}
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: {{ printf "%s-egress-cleanup-uninstall" (include "cube.fullname" $root) }}
+  namespace: {{ $root.Release.Namespace }}
+  annotations:
+    helm.sh/hook: post-delete
+    helm.sh/hook-weight: "-20"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+  labels:
+    {{- include "cube.labels" $root | nindent 4 }}
+    app.kubernetes.io/component: egress-cleanup
+spec:
+  selector:
+    matchLabels:
+      {{- include "cube.selectorLabels" $root | nindent 6 }}
+      app.kubernetes.io/component: egress-cleanup
+      app.kubernetes.io/cleanup-reason: uninstall
+  template:
+    metadata:
+      labels:
+        {{- include "cube.selectorLabels" $root | nindent 8 }}
+        app.kubernetes.io/component: egress-cleanup
+        app.kubernetes.io/cleanup-reason: uninstall
+    spec:
+      hostNetwork: true
+      automountServiceAccountToken: false
+      dnsPolicy: ClusterFirstWithHostNet
+      restartPolicy: Always
+      {{- with $root.Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- include "cube.computePlacement" $root | nindent 6 }}
+      containers:
+        - name: cleanup
+          image: {{ include "cube.cubeImage" (dict "image" $root.Values.images.egressConfigurer "context" $root) | quote }}
+          imagePullPolicy: {{ $root.Values.images.egressConfigurer.pullPolicy }}
+          command:
+            - /bin/sh
+            - -ec
+            - |
+              /opt/cube-egress/cleanup.sh
+              touch /tmp/cleanup-complete
+              exec tail -f /dev/null
+          env:
+            - name: CUBE_ROUTER_NAT_IP
+              value: {{ $root.Values.cubeNode.network.cubeRouter.natIP | quote }}
+          readinessProbe:
+            # Helm waits for non-Job hook resources to become Ready before
+            # applying hook-succeeded. The sentinel therefore prevents the
+            # DaemonSet from being deleted until cleanup ran on every node.
+            exec:
+              command:
+                - test
+                - -f
+                - /tmp/cleanup-complete
+            periodSeconds: 2
+            failureThreshold: 30
+          securityContext:
+            runAsUser: 0
+            runAsNonRoot: false
+            privileged: false
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+              add:
+                - NET_ADMIN
+            seccompProfile:
+              type: RuntimeDefault
+          resources:
+            requests:
+              cpu: 10m
+              memory: 16Mi
+            limits:
+              cpu: 100m
+              memory: 64Mi
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+            - name: run
+              mountPath: /run/cube-egress
+      volumes:
+        - name: tmp
+          emptyDir:
+            sizeLimit: 1Mi
+        - name: run
+          emptyDir:
+            sizeLimit: 1Mi
+---

--- a/deploy/kubernetes/chart/templates/egress-configurer-daemonset.yaml
+++ b/deploy/kubernetes/chart/templates/egress-configurer-daemonset.yaml
@@ -1,0 +1,108 @@
+{{- if .Values.egressProxy.enabled }}
+{{- $name := printf "%s-egress-configurer" (include "cube.fullname" .) -}}
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: {{ $name }}
+  namespace: cube-egress
+  labels:
+    {{- include "cube.labels" . | nindent 4 }}
+    app.kubernetes.io/component: egress-configurer
+spec:
+  updateStrategy:
+    type: OnDelete
+  selector:
+    matchLabels:
+      {{- include "cube.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: egress-configurer
+  template:
+    metadata:
+      labels:
+        {{- include "cube.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: egress-configurer
+    spec:
+      hostNetwork: true
+      automountServiceAccountToken: false
+      dnsPolicy: ClusterFirstWithHostNet
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- include "cube.computePlacement" . | nindent 6 }}
+      containers:
+        - name: configurer
+          image: {{ include "cube.cubeImage" (dict "image" .Values.images.egressConfigurer "context" $) | quote }}
+          imagePullPolicy: {{ .Values.images.egressConfigurer.pullPolicy }}
+          securityContext:
+            runAsUser: 0
+            runAsNonRoot: false
+            privileged: false
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+              add:
+                - NET_ADMIN
+                - NET_RAW
+                - SYS_MODULE
+            seccompProfile:
+              type: RuntimeDefault
+          lifecycle:
+            preStop:
+              exec:
+                command:
+                  - /opt/cube-egress/cleanup.sh
+          env:
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: CUBE_ROUTER_NAT_IP
+              value: {{ .Values.cubeNode.network.cubeRouter.natIP | quote }}
+            - name: CUBE_EGRESS_CLUSTER_CIDRS
+              value: {{ join "," .Values.egressProxy.clusterCIDRs | quote }}
+            - name: XTABLES_LOCKFILE
+              value: /run/cube-egress/xtables.lock
+          readinessProbe:
+            exec:
+              command:
+                - /opt/cube-egress/health.sh
+            periodSeconds: 10
+            failureThreshold: 6
+          livenessProbe:
+            exec:
+              command:
+                - /opt/cube-egress/health.sh
+            initialDelaySeconds: 30
+            periodSeconds: 20
+            failureThreshold: 6
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              cpu: 100m
+              memory: 128Mi
+          volumeMounts:
+            - name: run
+              mountPath: /run/cube-egress
+            - name: modules
+              mountPath: /lib/modules
+              readOnly: true
+            - name: rp-filter
+              mountPath: /host-sysctl/rp_filter
+      volumes:
+        - name: run
+          hostPath:
+            path: /run/cube-egress
+            type: DirectoryOrCreate
+        - name: modules
+          hostPath:
+            path: /lib/modules
+            type: Directory
+        - name: rp-filter
+          hostPath:
+            path: /proc/sys/net/ipv4/conf/all/rp_filter
+            type: File
+{{- end }}

--- a/deploy/kubernetes/chart/templates/egress-proxy-daemonsets.yaml
+++ b/deploy/kubernetes/chart/templates/egress-proxy-daemonsets.yaml
@@ -1,0 +1,114 @@
+{{- if .Values.egressProxy.enabled }}
+{{- $root := . -}}
+{{- range $role := list "primary" "standby" }}
+{{- $name := printf "%s-egress-proxy-%s" (include "cube.fullname" $root) $role -}}
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: {{ $name }}
+  namespace: cube-egress
+  labels:
+    {{- include "cube.labels" $root | nindent 4 }}
+    app.kubernetes.io/component: egress-proxy
+    app.kubernetes.io/role: {{ $role }}
+spec:
+  updateStrategy:
+    # Primary and standby must never be rolled independently by two
+    # controllers at the same time. Operators replace standby Pods first,
+    # verify takeover, and then replace primary Pods.
+    type: OnDelete
+  selector:
+    matchLabels:
+      {{- include "cube.selectorLabels" $root | nindent 6 }}
+      app.kubernetes.io/component: egress-proxy
+      app.kubernetes.io/role: {{ $role }}
+  template:
+    metadata:
+      labels:
+        {{- include "cube.selectorLabels" $root | nindent 8 }}
+        app.kubernetes.io/component: egress-proxy
+        app.kubernetes.io/role: {{ $role }}
+    spec:
+      hostNetwork: false
+      hostPID: true
+      automountServiceAccountToken: false
+      dnsPolicy: ClusterFirst
+      terminationGracePeriodSeconds: 30
+      {{- with $root.Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- include "cube.computePlacement" $root | nindent 6 }}
+      initContainers:
+        - name: setup-veth
+          image: {{ include "cube.cubeImage" (dict "image" $root.Values.images.egressProxy "context" $root) | quote }}
+          imagePullPolicy: {{ $root.Values.images.egressProxy.pullPolicy }}
+          command:
+            - /opt/cube-egress/setup-veth.sh
+          securityContext:
+            runAsUser: 0
+            privileged: true
+            allowPrivilegeEscalation: true
+            readOnlyRootFilesystem: true
+          env:
+            - name: CUBE_EGRESS_ROLE
+              value: {{ $role | quote }}
+            - name: CUBE_ROUTER_NAT_IP
+              value: {{ $root.Values.cubeNode.network.cubeRouter.natIP | quote }}
+      containers:
+        - name: proxy
+          image: {{ include "cube.cubeImage" (dict "image" $root.Values.images.egressProxy "context" $root) | quote }}
+          imagePullPolicy: {{ $root.Values.images.egressProxy.pullPolicy }}
+          securityContext:
+            runAsUser: 0
+            runAsNonRoot: false
+            privileged: false
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+              add:
+                - NET_ADMIN
+            seccompProfile:
+              type: RuntimeDefault
+          env:
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: CUBE_EGRESS_ROLE
+              value: {{ $role | quote }}
+            - name: CUBE_ROUTER_NAT_IP
+              value: {{ $root.Values.cubeNode.network.cubeRouter.natIP | quote }}
+          readinessProbe:
+            exec:
+              command:
+                - /opt/cube-egress/health.sh
+            periodSeconds: 5
+            failureThreshold: 6
+          livenessProbe:
+            exec:
+              command:
+                - /opt/cube-egress/health.sh
+            initialDelaySeconds: 15
+            periodSeconds: 10
+            failureThreshold: 6
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: "2"
+              memory: 512Mi
+          volumeMounts:
+            - name: run
+              mountPath: /run/cube-egress
+      volumes:
+        - name: run
+          emptyDir:
+            medium: Memory
+            sizeLimit: 8Mi
+---
+{{- end }}
+{{- end }}

--- a/deploy/kubernetes/chart/templates/egress-proxy-namespace.yaml
+++ b/deploy/kubernetes/chart/templates/egress-proxy-namespace.yaml
@@ -1,0 +1,19 @@
+{{- $existing := lookup "v1" "Namespace" "" "cube-egress" -}}
+{{- $ownedByRelease := false -}}
+{{- if $existing -}}
+  {{- $annotations := default dict $existing.metadata.annotations -}}
+  {{- $ownedByRelease = and
+        (eq (default "" (index $annotations "meta.helm.sh/release-name")) .Release.Name)
+        (eq (default "" (index $annotations "meta.helm.sh/release-namespace")) .Release.Namespace) -}}
+{{- end -}}
+{{- if and .Values.egressProxy.enabled (or (not $existing) $ownedByRelease) }}
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: cube-egress
+  annotations:
+    helm.sh/resource-policy: keep
+  labels:
+    kubernetes.io/metadata.name: cube-egress
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}

--- a/deploy/kubernetes/chart/templates/node-daemonset.yaml
+++ b/deploy/kubernetes/chart/templates/node-daemonset.yaml
@@ -26,8 +26,9 @@ spec:
       serviceAccountName: {{ include "cube.nodeServiceAccountName" . }}
       automountServiceAccountToken: true
       hostPID: {{ .Values.security.hostPID }}
+      hostNetwork: true
       terminationGracePeriodSeconds: {{ .Values.cubeNode.terminationGracePeriodSeconds }}
-      dnsPolicy: ClusterFirst
+      dnsPolicy: ClusterFirstWithHostNet
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
@@ -62,6 +63,14 @@ spec:
               value: cubelet
             - name: CUBE_ROLE
               value: run
+            # Persist across Pod replacement so a new Big Pod can terminate a
+            # stale host-level Cubelet after an ungraceful container exit.
+            - name: CUBE_PID_DIR
+              value: /data/cubelet/run/cube-node
+            - name: CUBE_ROUTER_ENABLE
+              value: {{ ternary "1" "0" .Values.cubeNode.network.cubeRouter.enabled | quote }}
+            - name: CUBE_ROUTER_CIDR
+              value: {{ .Values.cubeNode.network.cubeRouter.cidr | quote }}
             {{- with .Values.cubeNode.env }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
@@ -72,19 +81,6 @@ spec:
               containerPort: 9998
             - name: cubelet-debug
               containerPort: 9966
-          lifecycle:
-            preStop:
-              exec:
-                command:
-                  - /bin/bash
-                  - -ec
-                  - |
-                    # Kill only this container's pidfile. Never pkill -f —
-                    # must not match containerd-shim-cube-rs / cube-runtime / VMM.
-                    pidfile=/run/cube-node/cubelet.pid
-                    if [[ -f "${pidfile}" ]]; then
-                      kill -TERM "$(cat "${pidfile}")" 2>/dev/null || true
-                    fi
           {{- if .Values.cubeNode.probes.startup.enabled }}
           startupProbe:
             {{- if .Values.cubeNode.probes.startup.exec }}

--- a/deploy/kubernetes/chart/templates/tests/node-health.yaml
+++ b/deploy/kubernetes/chart/templates/tests/node-health.yaml
@@ -119,7 +119,22 @@ spec:
             | grep -oE '"name"[[:space:]]*:[[:space:]]*"[^"]+"' \
             | awk -F'"' '{print $4}')"
           echo "${container_names}" | grep -qxF 'cube-egress'
+          {{- if .Values.cubeEgress.network.enabled }}
           echo "${container_names}" | grep -qxF 'cube-egress-net'
+          {{- end }}
+          {{- end }}
+
+          {{- if .Values.egressProxy.enabled }}
+          echo '[health-test] check EgressProxy DaemonSet readiness'
+          egress_ns=cube-egress
+          for egress_ds in \
+            {{ include "cube.fullname" . }}-egress-configurer \
+            {{ include "cube.fullname" . }}-egress-proxy-primary \
+            {{ include "cube.fullname" . }}-egress-proxy-standby; do
+            egress_ds_json="$(kget "/apis/apps/v1/namespaces/${egress_ns}/daemonsets/${egress_ds}")"
+            printf '%s\n' "${egress_ds_json}" | grep -Eq '"numberReady"[[:space:]]*:[[:space:]]*[1-9]'
+            printf '%s\n' "${egress_ds_json}" | grep -Eq '"desiredNumberScheduled"[[:space:]]*:[[:space:]]*[1-9]'
+          done
           {{- end }}
 {{ if eq (include "cube.cubemastercliEnabled" .) "true" }}
 ---
@@ -257,6 +272,11 @@ spec:
       imagePullPolicy: {{ .Values.helmTest.image.pullPolicy }}
       env:
         {{- include "cube.timezoneEnv" . | nindent 8 }}
+        - name: CUBE_PROXY_ADMIN_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "cube.secretName" . }}
+              key: cube-admin-token
       command:
         - sh
         - -ec

--- a/deploy/kubernetes/chart/templates/tests/rbac.yaml
+++ b/deploy/kubernetes/chart/templates/tests/rbac.yaml
@@ -37,4 +37,36 @@ subjects:
   - kind: ServiceAccount
     name: {{ include "cube.fullname" . }}-test
     namespace: {{ .Release.Namespace }}
+{{- if .Values.egressProxy.enabled }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "cube.fullname" . }}-test
+  namespace: cube-egress
+  labels:
+    {{- include "cube.labels" . | nindent 4 }}
+    app.kubernetes.io/component: test
+rules:
+  - apiGroups: ["apps"]
+    resources: ["daemonsets"]
+    verbs: ["get", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "cube.fullname" . }}-test
+  namespace: cube-egress
+  labels:
+    {{- include "cube.labels" . | nindent 4 }}
+    app.kubernetes.io/component: test
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "cube.fullname" . }}-test
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "cube.fullname" . }}-test
+    namespace: {{ .Release.Namespace }}
+{{- end }}
 {{- end }}

--- a/deploy/kubernetes/chart/templates/validate.yaml
+++ b/deploy/kubernetes/chart/templates/validate.yaml
@@ -66,7 +66,7 @@
 {{- fail "cubeNode.placeholderSlots was removed; Big Pod no longer reserves cube-slot-1..6. Remove cubeNode.placeholderSlots from your values." }}
 {{- end }}
 {{- if hasKey .Values.security "hostNetwork" }}
-{{- fail "security.hostNetwork was removed; cube-node always runs on the Pod network. Remove security.hostNetwork from your values." }}
+{{- fail "security.hostNetwork is not configurable; cube-node always uses the host network. Remove security.hostNetwork from your values." }}
 {{- end }}
 {{- if hasKey .Values.cubeNode "useAdvancedDaemonSet" }}
 {{- fail "cubeNode.useAdvancedDaemonSet was removed; cube-node uses a native apps/v1 DaemonSet. Remove cubeNode.useAdvancedDaemonSet from your values." }}
@@ -226,6 +226,36 @@
 {{- end }}
 {{- if and .Values.cubeEgress.network.enabled (not .Values.cubeEgress.network.ingressInterface) }}
 {{- fail "cubeEgress.network.enabled=true requires cubeEgress.network.ingressInterface" }}
+{{- end }}
+{{- end }}
+{{- if .Values.egressProxy.enabled }}
+{{- if not .Values.cubeNode.network.cubeRouter.enabled }}
+{{- fail "egressProxy.enabled=true requires cubeNode.network.cubeRouter.enabled=true" }}
+{{- end }}
+{{- if lt (len .Values.egressProxy.clusterCIDRs) 1 }}
+{{- fail "egressProxy.enabled=true requires at least one egressProxy.clusterCIDRs entry" }}
+{{- end }}
+{{- if gt (len .Values.egressProxy.clusterCIDRs) 32 }}
+{{- fail "egressProxy.clusterCIDRs supports at most 32 entries" }}
+{{- end }}
+{{- $seenClusterCIDRs := dict }}
+{{- range .Values.egressProxy.clusterCIDRs }}
+{{- if not (regexMatch `^((25[0-5]|2[0-4][0-9]|1[0-9]{2}|[1-9]?[0-9])\.){3}(25[0-5]|2[0-4][0-9]|1[0-9]{2}|[1-9]?[0-9])/([0-9]|[12][0-9]|3[0-2])$` .) }}
+{{- fail (printf "egressProxy.clusterCIDRs contains an invalid IPv4 CIDR: %s" .) }}
+{{- end }}
+{{- if hasKey $seenClusterCIDRs . }}
+{{- fail (printf "egressProxy.clusterCIDRs contains a duplicate entry: %s" .) }}
+{{- end }}
+{{- $_ := set $seenClusterCIDRs . true }}
+{{- end }}
+{{- if and .Values.cubeEgress.enabled .Values.cubeEgress.network.enabled }}
+{{- fail "egressProxy.enabled=true is incompatible with cubeEgress.network.enabled=true; both own sandbox routing rules" }}
+{{- end }}
+{{- if not .Values.images.egressConfigurer.repository }}
+{{- fail "egressProxy.enabled=true requires images.egressConfigurer.repository" }}
+{{- end }}
+{{- if not .Values.images.egressProxy.repository }}
+{{- fail "egressProxy.enabled=true requires images.egressProxy.repository" }}
 {{- end }}
 {{- end }}
 {{- if .Values.volumeCos.enabled }}

--- a/deploy/kubernetes/chart/values.yaml
+++ b/deploy/kubernetes/chart/values.yaml
@@ -107,6 +107,18 @@ images:
     tag: v0.6.0
     pullPolicy: IfNotPresent
 
+  egressConfigurer:
+    repository: cube-sandbox-int.tencentcloudcr.com/cube-sandbox/cube-egress-configurer
+    tag: v0.6.0
+    digest: ""
+    pullPolicy: IfNotPresent
+
+  egressProxy:
+    repository: cube-sandbox-int.tencentcloudcr.com/cube-sandbox/cube-egress-proxy
+    tag: v0.6.0
+    digest: ""
+    pullPolicy: IfNotPresent
+
   webui:
     repository: cube-sandbox-int.tencentcloudcr.com/cube-sandbox/cube-webui
     tag: v0.6.0
@@ -529,7 +541,7 @@ cubeNode:
     enabled: true
 
   network:
-    # Auto-detect primary NIC inside the Pod netns and patch Cubelet eth_name.
+    # Auto-detect the node primary NIC and patch Cubelet eth_name.
     autoDetectEthName: true
     # Leave empty to keep auto-detection. Set to pin Cubelet eth_name.
     ethName: ""
@@ -543,6 +555,12 @@ cubeNode:
     # Skip host-network conflict checks (cube-node-init) and the Service CIDR
     # preflight Hook. Use only when you accept blackhole / routing risk.
     cidrSkipConflictCheck: false
+    cubeRouter:
+      # Required by egressProxy. CubeVS normalizes sandbox traffic to natIP
+      # and redirects it into the persistent host cube-router interface.
+      enabled: false
+      cidr: "172.20.0.0/24"
+      natIP: "172.20.0.2"
 
   dns:
     clusterDomain: cluster.local
@@ -590,6 +608,12 @@ cubeNode:
       initialDelaySeconds: 60
       periodSeconds: 20
       failureThreshold: 6
+
+egressProxy:
+  enabled: false
+  # Only these original sandbox destinations are routed through EgressProxy.
+  # Explicitly configure every Kubernetes Pod and Service CIDR.
+  clusterCIDRs: []
 
 # Artifact install DaemonSet (shim/kernel/guest). Always deployed with
 # cube-node (no enable switch). May RollingUpdate and grow containers; does NOT
@@ -953,7 +977,8 @@ bootstrap:
         size: 25G
 
 security:
-  # cube-node always uses the Pod network; no hostNetwork toggle.
+  # cube-node uses the host network so cube-router and its network namespace
+  # survive Big Pod replacement.
   hostPID: true
   privileged: true
 

--- a/deploy/kubernetes/images/README.md
+++ b/deploy/kubernetes/images/README.md
@@ -35,6 +35,7 @@ Pass one or more image names to build only those images (package download and
 ```bash
 ./deploy/kubernetes/images/build-cube-images.sh cubelet
 ./deploy/kubernetes/images/build-cube-images.sh cubelet cube-shim
+./deploy/kubernetes/images/build-cube-images.sh cube-egress-configurer cube-egress-proxy
 ```
 
 Run `./deploy/kubernetes/images/build-cube-images.sh --help` for the full image
@@ -224,6 +225,10 @@ behavior.
   `CubeEgress/scripts/cube-proxy-iptables-init.sh` plus a small idempotent
   entrypoint that waits for `cube-dev`, applies rules, and removes them on
   termination.
+- `cube-egress-configurer` and `cube-egress-proxy` are built from
+  `EgressProxy/Dockerfile.configurer` and `EgressProxy/Dockerfile.proxy`.
+  `EgressProxy/` contains only source and image definitions; Kubernetes
+  resources remain under `deploy/kubernetes/chart`.
 - `cube-webui` is built exactly like CI (`.github/workflows/release-docker-images.yml`):
   context = repository root, file = `deploy/one-click/webui/Dockerfile`, with
   `OPENRESTY_BASE_IMAGE` / `CUBE_VERSION` / `CUBE_COMMIT` / `CUBE_BUILD_TIME`.

--- a/deploy/kubernetes/images/build-cube-images.sh
+++ b/deploy/kubernetes/images/build-cube-images.sh
@@ -96,6 +96,8 @@ ALL_IMAGES=(
   cube-lifecycle-manager
   cube-egress
   cube-egress-net
+  cube-egress-configurer
+  cube-egress-proxy
   cube-webui
   cubelet
   cube-shim
@@ -123,6 +125,8 @@ SOURCE_IMAGES=(
   cube-lifecycle-manager
   cube-egress
   cube-egress-net
+  cube-egress-configurer
+  cube-egress-proxy
   cube-webui
 )
 
@@ -390,6 +394,9 @@ ensure_source_tree() {
   fi
   if should_build cube-shim; then
     SOURCE_EXPORT_SET="${SOURCE_EXPORT_SET} CubeShim hypervisor deploy/one-click/config-cube.toml deploy/kubernetes/images/scripts"
+  fi
+  if should_build cube-egress-configurer || should_build cube-egress-proxy; then
+    SOURCE_EXPORT_SET="${SOURCE_EXPORT_SET} EgressProxy"
   fi
   if should_build cube-ops; then
     SOURCE_EXPORT_SET="${SOURCE_EXPORT_SET} CubeOps"
@@ -738,6 +745,24 @@ build_cube_egress_image() {
   record_built cube-egress
 }
 
+build_cube_egress_configurer_image() {
+  [[ -f "${REPO_ROOT}/EgressProxy/Dockerfile.configurer" ]] \
+    || fail "missing EgressProxy/Dockerfile.configurer in ${REPO_ROOT}"
+  build_image cube-egress-configurer \
+    "${REPO_ROOT}/EgressProxy" \
+    "${REPO_ROOT}/EgressProxy/Dockerfile.configurer"
+  record_built cube-egress-configurer
+}
+
+build_cube_egress_proxy_image() {
+  [[ -f "${REPO_ROOT}/EgressProxy/Dockerfile.proxy" ]] \
+    || fail "missing EgressProxy/Dockerfile.proxy in ${REPO_ROOT}"
+  build_image cube-egress-proxy \
+    "${REPO_ROOT}/EgressProxy" \
+    "${REPO_ROOT}/EgressProxy/Dockerfile.proxy"
+  record_built cube-egress-proxy
+}
+
 build_cube_node_from_base_image() {
   local ctx
   local dockerfile
@@ -1066,6 +1091,16 @@ run_selected_builds() {
     copy_cube_egress_net_context "${ctx}"
     build_image cube-egress-net "${ctx}"
     record_built cube-egress-net
+  fi
+
+  if should_build cube-egress-configurer; then
+    ensure_source_tree
+    build_cube_egress_configurer_image
+  fi
+
+  if should_build cube-egress-proxy; then
+    ensure_source_tree
+    build_cube_egress_proxy_image
   fi
 
   if should_build cube-webui; then

--- a/deploy/kubernetes/images/scripts/component-entrypoint.sh
+++ b/deploy/kubernetes/images/scripts/component-entrypoint.sh
@@ -18,6 +18,8 @@ COMPONENT_VERSIONS_ROOT="${COMPONENT_VERSIONS_ROOT:-/data/cubelet/root/component
 CUBE_COMPONENT="${CUBE_COMPONENT:-}"
 CUBE_ROLE="${CUBE_ROLE:-install}"
 CUBE_PID_DIR="${CUBE_PID_DIR:-/run/cube-node}"
+CUBE_HOST_CGROUP_NAME="${CUBE_HOST_CGROUP_NAME:-cube-sandbox-runtime}"
+CUBE_COMPONENT_FINGERPRINT="${CUBE_COMPONENT_FINGERPRINT:-}"
 STATE_DIR="${STATE_DIR:-/var/lib/cube-node-bootstrap}"
 
 log() { printf '[cube-component:%s:%s] %s\n' "${CUBE_COMPONENT:-?}" "${CUBE_ROLE}" "$*"; }
@@ -631,22 +633,240 @@ configure_sandbox_dns() {
 write_pidfile() {
   local name="$1"
   local pid="$2"
+  local starttime tmp_file
+  starttime="$(awk '{print $22}' "/proc/${pid}/stat" 2>/dev/null || true)"
+  [[ "${pid}" =~ ^[0-9]+$ && "${starttime}" =~ ^[0-9]+$ ]] \
+    || fail "cannot record ${name} process identity pid=${pid}"
   mkdir -p "${CUBE_PID_DIR}"
-  printf '%s\n' "${pid}" > "${CUBE_PID_DIR}/${name}.pid"
+  tmp_file="${CUBE_PID_DIR}/${name}.pid.tmp.$$"
+  printf '%s %s\n' "${pid}" "${starttime}" > "${tmp_file}"
+  mv -f "${tmp_file}" "${CUBE_PID_DIR}/${name}.pid"
 }
 
-kill_pidfile() {
+read_pidfile() {
   local name="$1"
   local file="${CUBE_PID_DIR}/${name}.pid"
-  local pid
+  local pid starttime extra
+  [[ -f "${file}" ]] || return 1
+  read -r pid starttime extra < "${file}" || return 1
+  [[ "${pid}" =~ ^[0-9]+$ && "${starttime}" =~ ^[0-9]+$ && -z "${extra:-}" ]] \
+    || return 1
+  printf '%s %s\n' "${pid}" "${starttime}"
+}
+
+process_identity_matches() {
+  local pid="$1"
+  local starttime="$2"
+  local expected_bin="$3"
+  local current_starttime exe exe_name expected_name
+  [[ "${pid}" =~ ^[0-9]+$ && "${starttime}" =~ ^[0-9]+$ ]] || return 1
+  current_starttime="$(awk '{print $22}' "/proc/${pid}/stat" 2>/dev/null || true)"
+  [[ "${current_starttime}" == "${starttime}" ]] || return 1
+  exe="$(readlink "/proc/${pid}/exe" 2>/dev/null || true)"
+  exe="${exe% (deleted)}"
+  exe_name="${exe##*/}"
+  expected_name="${expected_bin##*/}"
+  [[ -n "${exe_name}" && "${exe_name}" == "${expected_name}" ]]
+}
+
+stop_owned_process() {
+  local name="$1"
+  local expected_bin="$2"
+  local timeout_seconds="${3:-30}"
+  local file="${CUBE_PID_DIR}/${name}.pid"
+  local identity pid starttime deadline
+
   [[ -f "${file}" ]] || return 0
-  pid="$(cat "${file}" 2>/dev/null || true)"
-  [[ -n "${pid}" ]] || return 0
-  if kill -0 "${pid}" 2>/dev/null; then
-    log "stopping ${name} pid=${pid}"
-    kill -TERM "${pid}" 2>/dev/null || true
+  identity="$(read_pidfile "${name}" 2>/dev/null || true)"
+  if [[ -z "${identity}" ]]; then
+    log "removing invalid ${name} pidfile"
+    rm -f "${file}"
+    return 0
   fi
+  read -r pid starttime <<< "${identity}"
+  if ! process_identity_matches "${pid}" "${starttime}" "${expected_bin}"; then
+    log "removing stale ${name} pidfile pid=${pid}"
+    rm -f "${file}"
+    return 0
+  fi
+
+  log "stopping ${name} pid=${pid}"
+  kill -TERM "${pid}"
+  deadline=$((SECONDS + timeout_seconds))
+  while process_identity_matches "${pid}" "${starttime}" "${expected_bin}"; do
+    if (( SECONDS >= deadline )); then
+      log "${name} pid=${pid} did not exit after ${timeout_seconds}s"
+      return 1
+    fi
+    sleep 0.1
+  done
   rm -f "${file}"
+}
+
+stop_process_identity() {
+  local name="$1"
+  local pid="$2"
+  local starttime="$3"
+  local expected_bin="$4"
+  local timeout_seconds="${5:-30}"
+  local deadline
+
+  process_identity_matches "${pid}" "${starttime}" "${expected_bin}" || return 0
+  log "stopping ${name} pid=${pid}"
+  kill -TERM "${pid}"
+  deadline=$((SECONDS + timeout_seconds))
+  while process_identity_matches "${pid}" "${starttime}" "${expected_bin}"; do
+    if (( SECONDS >= deadline )); then
+      log "${name} pid=${pid} did not exit after ${timeout_seconds}s"
+      return 1
+    fi
+    sleep 0.1
+  done
+}
+
+# Remove the standalone NetworkAgent left by releases that ran it in a
+# separate container. Its pidfile contains a PID from the old container PID
+# namespace, so discover it by the exact executable instead of trusting that
+# stale PID. Revalidate PID, start time, and executable before signaling.
+stop_legacy_network_agents() {
+  local expected_bin="${TOOLBOX_ROOT}/network-agent/bin/network-agent"
+  local proc pid starttime exe argv0
+
+  for proc in /proc/[0-9]*; do
+    pid="${proc##*/}"
+    exe="$(readlink "${proc}/exe" 2>/dev/null || true)"
+    exe="${exe% (deleted)}"
+    case "${exe}" in
+      "${expected_bin}"|"${TOOLBOX_ROOT}"/network-agent.legacy.*/bin/network-agent) ;;
+      *) continue ;;
+    esac
+    argv0="$(tr '\0' '\n' < "${proc}/cmdline" 2>/dev/null | head -n1 || true)"
+    [[ "${argv0}" == "${expected_bin}" ]] || continue
+    starttime="$(awk '{print $22}' "${proc}/stat" 2>/dev/null || true)"
+    process_identity_matches "${pid}" "${starttime}" "${expected_bin}" || continue
+    log "stopping legacy standalone network-agent pid=${pid}"
+    kill -TERM "${pid}"
+  done
+  rm -f "${CUBE_PID_DIR}/network-agent.pid" "${CUBE_PID_DIR}/network-agent.fingerprint"
+}
+
+STARTING_PID=""
+STARTING_STARTTIME=""
+STARTING_PGID=""
+cleanup_starting_process() {
+  local status=$?
+  local pgid=""
+  trap - EXIT TERM INT HUP
+  if [[ -n "${STARTING_PGID}" && "${STARTING_PGID}" == "${STARTING_PID}" ]]; then
+    pgid="${STARTING_PGID}"
+    kill -CONT -- "-${pgid}" 2>/dev/null || true
+    kill -TERM -- "-${pgid}" 2>/dev/null || true
+  elif [[ -n "${STARTING_PID}" ]] &&
+       process_identity_matches "${STARTING_PID}" "${STARTING_STARTTIME}" \
+         "$(readlink "/proc/${STARTING_PID}/exe" 2>/dev/null || true)"; then
+      kill -CONT "${STARTING_PID}" 2>/dev/null || true
+      kill -TERM "${STARTING_PID}" 2>/dev/null || true
+  fi
+  if [[ -n "${STARTING_PID}" ]]; then
+    for _ in $(seq 1 50); do
+      if [[ -n "${pgid}" ]]; then
+        kill -0 -- "-${pgid}" 2>/dev/null || break
+      else
+        kill -0 "${STARTING_PID}" 2>/dev/null || break
+      fi
+      sleep 0.1
+    done
+    if [[ -n "${pgid}" ]] && kill -0 -- "-${pgid}" 2>/dev/null; then
+      kill -KILL -- "-${pgid}" 2>/dev/null || true
+    elif kill -0 "${STARTING_PID}" 2>/dev/null; then
+      kill -KILL "${STARTING_PID}" 2>/dev/null || true
+    fi
+  fi
+  [[ -z "${STARTING_PID}" ]] || wait "${STARTING_PID}" 2>/dev/null || true
+  exit "${status}"
+}
+
+# Move Cubelet out of the Kubernetes Pod cgroups before it starts. CubeShim and
+# VMM processes inherit this host-level cgroup and therefore are not killed
+# when kubelet removes the Big Pod cgroups during a rolling update.
+move_pid_to_host_cgroups() {
+  local pid="$1"
+  local cgroup_root="${CUBE_CGROUP_ROOT:-/sys/fs/cgroup}"
+  local controller_root target source_value moved=0 mode=v1
+
+  [[ "${pid}" =~ ^[0-9]+$ ]] || fail "invalid pid for host cgroup: ${pid}"
+  [[ "${CUBE_HOST_CGROUP_NAME}" =~ ^[a-zA-Z0-9_.-]+$ ]] \
+    || fail "invalid CUBE_HOST_CGROUP_NAME=${CUBE_HOST_CGROUP_NAME}"
+
+  if [[ -f "${cgroup_root}/cgroup.controllers" && -f "${cgroup_root}/cgroup.procs" ]]; then
+    mode=v2
+    target="${cgroup_root}/${CUBE_HOST_CGROUP_NAME}"
+    mkdir -p "${target}"
+    printf '%s\n' "${pid}" > "${target}/cgroup.procs" \
+      || fail "cannot move pid ${pid} to ${target}"
+    grep -qx "${pid}" "${target}/cgroup.procs" \
+      || fail "pid ${pid} is not present in ${target}/cgroup.procs after move"
+    moved=1
+  else
+    for controller_root in "${cgroup_root}"/*; do
+      [[ -f "${controller_root}/tasks" ]] || continue
+      target="${controller_root}/${CUBE_HOST_CGROUP_NAME}"
+      mkdir -p "${target}"
+
+      # A cgroup v1 child cpuset cannot accept tasks until both masks are initialized.
+      if [[ -f "${controller_root}/cpuset.cpus" ]]; then
+        source_value="$(cat "${controller_root}/cpuset.cpus")"
+        [[ -n "${source_value}" ]] && printf '%s\n' "${source_value}" > "${target}/cpuset.cpus"
+      fi
+      if [[ -f "${controller_root}/cpuset.mems" ]]; then
+        source_value="$(cat "${controller_root}/cpuset.mems")"
+        [[ -n "${source_value}" ]] && printf '%s\n' "${source_value}" > "${target}/cpuset.mems"
+      fi
+
+      printf '%s\n' "${pid}" > "${target}/tasks" \
+        || fail "cannot move pid ${pid} to ${target}"
+      grep -qx "${pid}" "${target}/tasks" \
+        || fail "pid ${pid} is not present in ${target}/tasks after move"
+      moved=$((moved + 1))
+    done
+  fi
+
+  [[ "${moved}" -gt 0 ]] || fail "no writable host cgroup hierarchy found"
+  log "moved pid=${pid} to host cgroup /${CUBE_HOST_CGROUP_NAME} mode=${mode} hierarchies=${moved}"
+}
+
+component_fingerprint() {
+  local bin="$1"
+  if [[ -n "${CUBE_COMPONENT_FINGERPRINT}" ]]; then
+    printf '%s\n' "${CUBE_COMPONENT_FINGERPRINT}"
+    return
+  fi
+  sha256sum "${bin}" | awk '{print $1}'
+}
+
+REUSED_HOST_PID=""
+REUSED_HOST_STARTTIME=""
+reuse_host_process() {
+  local name="$1"
+  local fingerprint="$2"
+  local health_url="$3"
+  local pid_file="${CUBE_PID_DIR}/${name}.pid"
+  local fingerprint_file="${CUBE_PID_DIR}/${name}.fingerprint"
+  local identity pid starttime saved
+
+  REUSED_HOST_PID=""
+  REUSED_HOST_STARTTIME=""
+  [[ -f "${pid_file}" && -f "${fingerprint_file}" ]] || return 1
+  identity="$(read_pidfile "${name}" 2>/dev/null || true)"
+  saved="$(cat "${fingerprint_file}" 2>/dev/null || true)"
+  [[ -n "${identity}" && "${saved}" == "${fingerprint}" ]] || return 1
+  read -r pid starttime <<< "${identity}"
+  process_identity_matches "${pid}" "${starttime}" \
+    "${TOOLBOX_ROOT}/network-agent/bin/network-agent" || return 1
+  curl -fsS "${health_url}" >/dev/null 2>&1 || return 1
+  REUSED_HOST_PID="${pid}"
+  REUSED_HOST_STARTTIME="${starttime}"
+  return 0
 }
 
 
@@ -655,7 +875,7 @@ run_cubelet() {
   local bin="${TOOLBOX_ROOT}/Cubelet/bin/cubelet"
   local cfg="${TOOLBOX_ROOT}/Cubelet/config/config.toml"
   local dyn="${CUBELET_DYNAMICCONF:-${TOOLBOX_ROOT}/Cubelet/dynamicconf/conf.yaml}"
-  local i pid launch
+  local pid pid_starttime launch
 
   # Self-stage (no separate cubelet-install container). CubeVS tools are bundled
   # with the cubelet image so cube-node-installer does not need an extra
@@ -703,6 +923,21 @@ run_cubelet() {
     egress_admin_url_esc="$(sed_escape_replacement "${egress_admin_url}")"
     sed -i "s|cube_egress_admin_url = \"[^\"]*\"|cube_egress_admin_url = \"${egress_admin_url_esc}\"|" "${cfg}"
   fi
+  if [[ -n "${CUBE_ROUTER_ENABLE:-}" ]]; then
+    local router_enable="false"
+    [[ "${CUBE_ROUTER_ENABLE}" == "1" || "${CUBE_ROUTER_ENABLE}" == "true" ]] \
+      && router_enable="true"
+    sed -i -E \
+      "s/^([[:space:]]*)cube_router_enable = .*/\\1cube_router_enable = ${router_enable}/" \
+      "${cfg}"
+  fi
+  if [[ -n "${CUBE_ROUTER_CIDR:-}" ]]; then
+    local router_cidr_esc
+    router_cidr_esc="$(sed_escape_replacement "${CUBE_ROUTER_CIDR}")"
+    sed -i -E \
+      "s|^([[:space:]]*)cube_router_cidr = \"[^\"]*\"|\\1cube_router_cidr = \"${router_cidr_esc}\"|" \
+      "${cfg}"
+  fi
   if [[ -n "${CUBE_TAP_INIT_NUM:-}" ]]; then
     [[ "${CUBE_TAP_INIT_NUM}" =~ ^[0-9]+$ ]] || fail "CUBE_TAP_INIT_NUM must be a non-negative integer"
     sed -i "s/tap_init_num = [0-9]\+/tap_init_num = ${CUBE_TAP_INIT_NUM}/" "${cfg}"
@@ -735,36 +970,87 @@ run_cubelet() {
     log "bound /data/cubelet/state to hostPath (skip state tmpfs)"
   fi
 
-  kill_pidfile cubelet
+  stop_legacy_network_agents
+
+  stop_owned_process cubelet "${bin}" 30 \
+    || fail "old cubelet did not exit; refusing to start a second instance"
 
   log "starting cubelet node_id=${CUBE_SANDBOX_NODE_ID:-} endpoint=${CUBE_SANDBOX_ENDPOINT_IP}"
-  "${bin}" --config "${cfg}" --dynamic-conf-path "${dyn}" &
+  # Use a private process group so a failed pre-start can clean up any children
+  # without signalling unrelated host processes.
+  setsid bash -c '
+    kill -STOP "$$"
+    exec "$@"
+  ' cube-component-launcher \
+    "${bin}" --config "${cfg}" --dynamic-conf-path "${dyn}" &
   launch=$!
+  STARTING_PID="${launch}"
+  STARTING_STARTTIME="$(awk '{print $22}' "/proc/${launch}/stat")"
+  trap cleanup_starting_process EXIT TERM INT HUP
+  for i in $(seq 1 50); do
+    grep -q '^State:.*T' "/proc/${launch}/status" 2>/dev/null && break
+    [[ "${i}" -lt 50 ]] || fail "cubelet launcher did not stop for host cgroup move"
+    sleep 0.02
+  done
+  STARTING_PGID="${launch}"
+  move_pid_to_host_cgroups "${launch}"
+  kill -CONT "${launch}"
 
   for i in $(seq 1 60); do
-    pid="$(pidof cubelet 2>/dev/null | awk '{print $1}' || true)"
-    if [[ -n "${pid}" ]] && kill -0 "${pid}" >/dev/null 2>&1 && ss -lntp 2>/dev/null | grep -q ':9999'; then
-      write_pidfile cubelet "${pid}"
-      log "cubelet ready pid=${pid}"
-      break
+    listener="$(ss -lntp 2>/dev/null || true)"
+    listener_pid="$(awk '
+      /:9999[[:space:]]/ && match($0, /pid=[0-9]+,/) {
+        value=substr($0, RSTART + 4, RLENGTH - 5)
+        print value
+        exit
+      }
+    ' <<< "${listener}")"
+    if [[ -n "${listener_pid}" ]]; then
+      listener_pgid="$(ps -o pgid= -p "${listener_pid}" 2>/dev/null | tr -d '[:space:]')"
+      listener_starttime="$(awk '{print $22}' "/proc/${listener_pid}/stat" 2>/dev/null || true)"
+      if [[ "${listener_pgid}" == "${launch}" ]] &&
+         process_identity_matches "${listener_pid}" "${listener_starttime}" "${bin}"; then
+        pid="${listener_pid}"
+        pid_starttime="${listener_starttime}"
+        write_pidfile cubelet "${pid}"
+        log "cubelet ready pid=${pid}"
+        break
+      fi
     fi
-    if ! kill -0 "${launch}" >/dev/null 2>&1 && [[ -z "${pid}" ]]; then
+    if ! kill -0 -- "-${launch}" >/dev/null 2>&1; then
       fail "cubelet exited before listening on 9999"
     fi
     [[ "${i}" -lt 60 ]] || fail "cubelet did not become ready"
     sleep 1
   done
 
-  cleanup() { kill_pidfile cubelet; }
+  STARTING_PID=""
+  STARTING_STARTTIME=""
+  STARTING_PGID=""
+  trap - EXIT TERM INT HUP
+  cleanup() {
+    stop_process_identity cubelet "${pid}" "${pid_starttime}" "${bin}" 30 \
+      || log "cubelet did not exit before shutdown timeout"
+    if [[ "$(read_pidfile cubelet 2>/dev/null || true)" == "${pid} ${pid_starttime}" ]]; then
+      rm -f "${CUBE_PID_DIR}/cubelet.pid"
+    fi
+  }
   trap cleanup TERM INT HUP EXIT
 
-  while kill -0 "$(cat "${CUBE_PID_DIR}/cubelet.pid" 2>/dev/null || echo 0)" >/dev/null 2>&1; do
+  while process_identity_matches "${pid}" \
+    "$(awk '{print $2}' "${CUBE_PID_DIR}/cubelet.pid" 2>/dev/null || echo 0)" \
+    "${bin}"; do
     sleep 10
   done
   fail "cubelet exited"
 }
 
 main() {
+  if [[ "${1:-}" == "stop-owned-process" ]]; then
+    [[ "$#" -eq 3 ]] || fail "usage: stop-owned-process NAME EXPECTED_BIN"
+    stop_owned_process "$2" "$3" 30
+    return
+  fi
   [[ -n "${CUBE_COMPONENT}" ]] || fail "CUBE_COMPONENT is required"
   case "${CUBE_ROLE}" in
     install) run_install ;;
@@ -778,4 +1064,6 @@ main() {
   esac
 }
 
-main "$@"
+if [[ "${CUBE_COMPONENT_ENTRYPOINT_LIB_ONLY:-false}" != "true" ]]; then
+  main "$@"
+fi

--- a/deploy/kubernetes/images/scripts/test-component-cgroup-move.sh
+++ b/deploy/kubernetes/images/scripts/test-component-cgroup-move.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(CDPATH= cd -- "$(dirname "$0")" && pwd)"
+# shellcheck source=component-entrypoint.sh
+CUBE_COMPONENT_ENTRYPOINT_LIB_ONLY=true source "${SCRIPT_DIR}/component-entrypoint.sh"
+
+test_root="$(mktemp -d)"
+trap 'rm -rf "${test_root}"' EXIT
+
+mkdir -p \
+  "${test_root}/v2/cube-sandbox-runtime" \
+  "${test_root}/proc-v2/123" \
+  "${test_root}/v1/cpu/cube-sandbox-runtime" \
+  "${test_root}/proc-v1/456"
+touch \
+  "${test_root}/v2/cgroup.controllers" \
+  "${test_root}/v2/cgroup.procs" \
+  "${test_root}/v2/cube-sandbox-runtime/cgroup.procs" \
+  "${test_root}/v1/cpu/tasks" \
+  "${test_root}/v1/cpu/cube-sandbox-runtime/tasks"
+printf '0::/cube-sandbox-runtime\n' > "${test_root}/proc-v2/123/cgroup"
+printf '2:cpu:/cube-sandbox-runtime\n' > "${test_root}/proc-v1/456/cgroup"
+
+CUBE_CGROUP_ROOT="${test_root}/v2" \
+CUBE_PROC_ROOT="${test_root}/proc-v2" \
+  move_pid_to_host_cgroups 123
+[[ "$(cat "${test_root}/v2/cube-sandbox-runtime/cgroup.procs")" == "123" ]]
+
+CUBE_CGROUP_ROOT="${test_root}/v1" \
+CUBE_PROC_ROOT="${test_root}/proc-v1" \
+  move_pid_to_host_cgroups 456
+[[ "$(cat "${test_root}/v1/cpu/cube-sandbox-runtime/tasks")" == "456" ]]
+
+CUBE_PID_DIR="${test_root}/pid"
+mkdir -p "${CUBE_PID_DIR}"
+
+sleep 300 &
+owned_pid=$!
+owned_bin="$(readlink "/proc/${owned_pid}/exe")"
+write_pidfile test-component "${owned_pid}"
+read -r recorded_pid recorded_starttime < "${CUBE_PID_DIR}/test-component.pid"
+[[ "${recorded_pid}" == "${owned_pid}" ]]
+[[ "${recorded_starttime}" =~ ^[0-9]+$ ]]
+process_identity_matches "${owned_pid}" "${recorded_starttime}" \
+  "/a/different/mount/namespace/$(basename "${owned_bin}")"
+
+# A reused PID has a different starttime and must never receive TERM.
+printf '%s %s\n' "${owned_pid}" "$((recorded_starttime + 1))" \
+  > "${CUBE_PID_DIR}/test-component.pid"
+stop_owned_process test-component "${owned_bin}" 1
+kill -0 "${owned_pid}"
+[[ ! -f "${CUBE_PID_DIR}/test-component.pid" ]]
+
+# A matching PID/starttime with a different executable name must not be killed.
+write_pidfile test-component "${owned_pid}"
+stop_owned_process test-component /not-the-owned-process 1
+kill -0 "${owned_pid}"
+
+write_pidfile test-component "${owned_pid}"
+stop_owned_process test-component "${owned_bin}" 2
+if kill -0 "${owned_pid}" 2>/dev/null; then
+  printf 'owned process was not stopped\n' >&2
+  exit 1
+fi
+wait "${owned_pid}" 2>/dev/null || true
+
+# A launcher that fails while stopped must be continued and reaped.
+launch_pid_file="${test_root}/launch.pid"
+(
+  (
+    kill -STOP "${BASHPID}"
+    exec sleep 300
+  ) &
+  STARTING_PID=$!
+  printf '%s\n' "${STARTING_PID}" > "${launch_pid_file}"
+  STARTING_STARTTIME="$(awk '{print $22}' "/proc/${STARTING_PID}/stat")"
+  cleanup_starting_process
+)
+failed_launch_pid="$(cat "${launch_pid_file}")"
+if kill -0 "${failed_launch_pid}" 2>/dev/null; then
+  printf 'failed stopped launcher was not cleaned up\n' >&2
+  exit 1
+fi
+
+# A daemonized child remains in the private launch group after its leader exits.
+# Cleanup must remove the group, not only the original launcher PID.
+group_child_file="${test_root}/group-child.pid"
+(
+  setsid bash -c '
+    sleep 300 &
+    printf "%s\n" "$!" > "$1"
+  ' cube-component-launcher "${group_child_file}" &
+  STARTING_PID=$!
+  STARTING_STARTTIME="$(awk '{print $22}' "/proc/${STARTING_PID}/stat")"
+  STARTING_PGID="${STARTING_PID}"
+  wait "${STARTING_PID}" 2>/dev/null || true
+  cleanup_starting_process
+)
+group_child_pid="$(cat "${group_child_file}")"
+if kill -0 "${group_child_pid}" 2>/dev/null; then
+  printf 'daemonized launch-group child was not cleaned up\n' >&2
+  exit 1
+fi
+
+printf 'component cgroup move and process identity tests passed\n'


### PR DESCRIPTION
## Overview

This PR enables `cube-node` Big Pod replacement without recreating compatible existing sandboxes. Kubernetes still replaces the Pod, but sandbox runtime processes, persisted state, and network objects remain on the compute node and are reattached by the replacement Big Pod.

It also introduces a node-local veth EgressProxy path. Only sandbox traffic to Kubernetes Pod and Service CIDRs is redirected through EgressProxy; other traffic keeps the normal route. Egress leaves with the Proxy Pod identity and is therefore governed by user-defined Kubernetes NetworkPolicy.

## Architecture

```mermaid
flowchart LR
    subgraph K8S["Kubernetes-managed and replaceable"]
        OLD["Old cube-node Big Pod"]
        UPDATE["DaemonSet rollout"]
        NEW["New cube-node Big Pod<br/>hostPID + hostNetwork"]
        OLD --> UPDATE --> NEW
    end

    subgraph HOST["Node-persistent sandbox runtime"]
        STATE["hostPath state + sockets"]
        RUNTIME["CubeShim + VMM<br/>host cgroup"]
        SANDBOX["Existing sandbox<br/>same ID, guest, processes"]
        ROUTER["network-agent + Cube Router<br/>same netns / TAP"]
        STATE --- RUNTIME --> SANDBOX
        ROUTER --- SANDBOX
    end

    subgraph EGRESS["Independent EgressProxy data plane"]
        MARK["Pre-DNAT clusterCIDR mark"]
        TABLE["Policy rule / table 100"]
        VETH["Node-local primary / standby veth"]
        PROXY["EgressProxy Pod<br/>forward + SNAT"]
        POLICY["User NetworkPolicy"]
        TARGET["Kubernetes Service / Pod"]
        MARK --> TABLE --> VETH --> PROXY --> POLICY --> TARGET
    end

    NEW ==>|"read state and reconnect"| STATE
    NEW ==>|"reuse node network state"| ROUTER
    SANDBOX --> ROUTER --> MARK
```

## Breaking network change

The Big Pod network contract changes from the Pod network to unconditional `hostNetwork: true` with `dnsPolicy: ClusterFirstWithHostNet`.

Existing old Big Pods retain their old Pod-network semantics until deliberately replaced; updating the DaemonSet template does not mutate a running Pod. After replacement, the Big Pod no longer has a CNI-assigned Pod IP. Monitoring, firewall, visibility, and policy assumptions based on the old Pod CIDR must be migrated before rollout. Use a canary compute node and an explicit maintenance window.

## Upgrade boundary

For a compatible rollout:

- Big Pod UID, containers, and cubelet PID change.
- Sandbox ID and creation time, CubeShim/VMM PIDs, guest boot ID, network namespace, TAP, and compatible host state remain unchanged.
- The replacement cubelet reconnects through persisted hostPath state and sockets.
- An unchanged network-agent image fingerprint allows the host process to be reused.
- EgressProxy and Configurer run as independent DaemonSets and are not replaced with the Big Pod.
- Only destinations in `clusterCIDRs` enter route table 100 and EgressProxy.
- The chart never creates, modifies, deletes, or recommends a NetworkPolicy.

Changes to network-agent, Cube Router, sandbox CIDR, shim/VMM/guest state formats, socket layout, or host kernel require separate compatibility validation.

## Documentation

- [In-place Upgrade](deploy/kubernetes/chart/docs/UPGRADE_EN.md) / [中文](deploy/kubernetes/chart/docs/UPGRADE.md)
- [Local-veth EgressProxy Design](deploy/kubernetes/chart/docs/EGRESS_VETH_EN.md) / [中文](deploy/kubernetes/chart/docs/EGRESS_VETH.md)
- [Local-veth EgressProxy Test Report](deploy/kubernetes/chart/docs/EGRESS_TEST_EN.md) / [中文](deploy/kubernetes/chart/docs/EGRESS_TEST.md)

## Validation summary

- Helm lint and template rendering
- Big Pod handoff guards
- cgroup v1/v2 migration tests
- EgressProxy route, ownership, and cleanup guards
- Real-cluster sandbox handoff and NetworkPolicy validation
- Primary/standby failover and fail-closed validation
- Latency, throughput, and long-connection gates
