### PR TITLE
fix(cubecli): resolve short sandbox ID prefix in `cubecli logs`

### DIFF
--- a/Cubelet/cmd/cubecli/commands/cubebox/logs.go
+++ b/Cubelet/cmd/cubecli/commands/cubebox/logs.go
@@ -14,8 +14,12 @@ import (
 	"strings"
 	"syscall"
 
-	"github.com/tencentcloud/CubeSandbox/Cubelet/pkg/pathutil"
 	"github.com/urfave/cli/v2"
+
+	"github.com/tencentcloud/CubeSandbox/Cubelet/api/services/cubebox/v1"
+	"github.com/tencentcloud/CubeSandbox/Cubelet/cmd/cubecli/commands"
+	"github.com/tencentcloud/CubeSandbox/Cubelet/pkg/pathutil"
+	"github.com/tencentcloud/CubeSandbox/Cubelet/pkg/sandboxid"
 )
 
 const (
@@ -127,16 +131,28 @@ var LogsCommand = &cli.Command{
 			return readLog(id, stream, all, tailN, headN)
 		}
 
+		// Resolve short sandbox ID prefix to full 32-char ID before re-exec
+		// so the child process can locate the log directory directly.
+		originalID := id
+		if !sandboxid.IsFullID(id) {
+			resolved, err := resolveLogsSandboxID(cliCtx, id)
+			if err != nil {
+				return err
+			}
+			id = resolved
+		}
+
 		// Re-exec with CUBEMNT=1 so the C constructor enters the cubelet mount
 		// namespace before Go runtime starts (single-threaded at that point).
-		// Pass os.Args[1:] directly so flag parsing is handled by the CLI
-		// framework in the child, avoiding fragile manual flag reconstruction.
+		// Substitute the resolved full ID for the user-supplied value so the
+		// child process uses the canonical ID directly.
 		self, err := os.Executable()
 		if err != nil {
 			return fmt.Errorf("cannot determine executable path: %w", err)
 		}
 
-		cmd := exec.Command(self, os.Args[1:]...)
+		childArgs := replacePositionalArg(os.Args[1:], originalID, id)
+		cmd := exec.Command(self, childArgs...)
 		cmd.Stdin = os.Stdin
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr
@@ -261,6 +277,42 @@ func printTail(r io.Reader, logPath string, n int) error {
 		fmt.Println(buf[(start+i)%n])
 	}
 	return nil
+}
+
+// resolveLogsSandboxID resolves a short sandbox ID prefix to the full 32-char
+// ID by listing all sandboxes via the Cubelet gRPC API.
+func resolveLogsSandboxID(cliCtx *cli.Context, id string) (string, error) {
+	conn, ctx, cancel, err := commands.NewGrpcConn(cliCtx)
+	if err != nil {
+		return "", fmt.Errorf("resolve sandbox id: %w", err)
+	}
+	defer conn.Close()
+	defer cancel()
+
+	client := cubebox.NewCubeboxMgrClient(conn)
+	resp, err := client.List(ctx, &cubebox.ListCubeSandboxRequest{})
+	if err != nil {
+		return "", fmt.Errorf("resolve sandbox id: list sandboxes: %w", err)
+	}
+	return resolveSandboxIDFromList(resp.Items, id)
+}
+
+// replacePositionalArg returns a copy of args with the last occurrence of old
+// replaced by new.  Searching from the end is preferred because positional
+// arguments typically follow flags.
+func replacePositionalArg(args []string, old, new string) []string {
+	if old == new {
+		return args
+	}
+	out := make([]string, len(args))
+	copy(out, args)
+	for i := len(out) - 1; i >= 0; i-- {
+		if out[i] == old {
+			out[i] = new
+			break
+		}
+	}
+	return out
 }
 
 // readTemplateLog reads log files from /data/log/template/<templateID>_0/.

--- a/Cubelet/cmd/cubecli/commands/cubebox/logs_test.go
+++ b/Cubelet/cmd/cubecli/commands/cubebox/logs_test.go
@@ -1,0 +1,83 @@
+// Copyright (c) 2024 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package cubebox
+
+import (
+	"testing"
+)
+
+func TestReplacePositionalArg(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		old  string
+		new  string
+		want []string
+	}{
+		{
+			name: "short id replaced with full id",
+			args: []string{"logs", "aabbccdd"},
+			old:  "aabbccdd",
+			new:  "aabbccddeeff00112233445566778899",
+			want: []string{"logs", "aabbccddeeff00112233445566778899"},
+		},
+		{
+			name: "flags before positional arg",
+			args: []string{"logs", "--stderr", "aabbccdd"},
+			old:  "aabbccdd",
+			new:  "aabbccddeeff00112233445566778899",
+			want: []string{"logs", "--stderr", "aabbccddeeff00112233445566778899"},
+		},
+		{
+			name: "flags after positional arg",
+			args: []string{"logs", "aabbccdd", "--all"},
+			old:  "aabbccdd",
+			new:  "aabbccddeeff00112233445566778899",
+			want: []string{"logs", "aabbccddeeff00112233445566778899", "--all"},
+		},
+		{
+			name: "multiple flags around positional arg",
+			args: []string{"logs", "--stderr", "-t", "50", "aabbccdd"},
+			old:  "aabbccdd",
+			new:  "aabbccddeeff00112233445566778899",
+			want: []string{"logs", "--stderr", "-t", "50", "aabbccddeeff00112233445566778899"},
+		},
+		{
+			name: "no replacement when old equals new",
+			args: []string{"logs", "aabbccddeeff00112233445566778899"},
+			old:  "aabbccddeeff00112233445566778899",
+			new:  "aabbccddeeff00112233445566778899",
+			want: []string{"logs", "aabbccddeeff00112233445566778899"},
+		},
+		{
+			name: "no match leaves args unchanged",
+			args: []string{"logs", "something"},
+			old:  "notfound",
+			new:  "aabbccddeeff00112233445566778899",
+			want: []string{"logs", "something"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := replacePositionalArg(tt.args, tt.old, tt.new)
+			if len(got) != len(tt.want) {
+				t.Fatalf("len(got)=%d want=%d", len(got), len(tt.want))
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Errorf("args[%d]=%q want=%q", i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestReplacePositionalArgDoesNotModifyOriginal(t *testing.T) {
+	original := []string{"logs", "--stderr", "aabbccdd"}
+	_ = replacePositionalArg(original, "aabbccdd", "aabbccddeeff00112233445566778899")
+	if original[2] != "aabbccdd" {
+		t.Fatalf("original slice was modified: got %q want %q", original[2], "aabbccdd")
+	}
+}

--- a/Cubelet/integration/cubebox_logs_shortid_test.go
+++ b/Cubelet/integration/cubebox_logs_shortid_test.go
@@ -1,0 +1,83 @@
+// Copyright (c) 2024 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package integration
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/tencentcloud/CubeSandbox/Cubelet/api/services/cubebox/v1"
+	"github.com/tencentcloud/CubeSandbox/Cubelet/pkg/sandboxid"
+)
+
+// TestLogsShortIDResolution verifies that a short sandbox ID prefix can be
+// resolved to the full 32-char ID via the same List + Resolve path that
+// cubecli logs now uses.  This is the E2E counterpart of the unit tests in
+// cubebox/logs_test.go and cubebox/resolve_test.go.
+func TestLogsShortIDResolution(t *testing.T) {
+	sandboxID := SimpleCubeboxConfigWithCleanup(t)
+	require.True(t, sandboxid.IsFullID(sandboxID),
+		"created sandbox should have a full 32-char hex ID, got %q", sandboxID)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	resp, err := cubeClient.List(ctx, &cubebox.ListCubeSandboxRequest{})
+	require.NoError(t, err)
+	require.NotEmpty(t, resp.Items)
+
+	candidates := make([]string, 0, len(resp.Items))
+	for _, item := range resp.Items {
+		candidates = append(candidates, item.GetId())
+	}
+
+	for _, prefixLen := range []int{4, 8, 12, len(sandboxID)} {
+		prefix := sandboxID[:prefixLen]
+		t.Run(prefix, func(t *testing.T) {
+			resolved, err := sandboxid.Resolve(prefix, candidates)
+			require.NoError(t, err)
+			require.Equal(t, sandboxID, resolved,
+				"prefix %q should resolve to full ID", prefix)
+		})
+	}
+}
+
+// TestLogsShortIDResolutionAmbiguous verifies that an ambiguous prefix is
+// rejected with ErrAmbiguous when two sandboxes share the same prefix.
+func TestLogsShortIDResolutionAmbiguous(t *testing.T) {
+	sb1 := SimpleCubeboxConfigWithCleanup(t)
+	sb2 := SimpleCubeboxConfigWithCleanup(t)
+
+	// Find the shortest shared prefix.
+	shared := 0
+	for i := 0; i < len(sb1) && i < len(sb2); i++ {
+		if sb1[i] != sb2[i] {
+			break
+		}
+		shared = i + 1
+	}
+	if shared == 0 {
+		t.Skip("sandbox IDs share no common prefix; cannot test ambiguity")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	resp, err := cubeClient.List(ctx, &cubebox.ListCubeSandboxRequest{})
+	require.NoError(t, err)
+
+	candidates := make([]string, 0, len(resp.Items))
+	for _, item := range resp.Items {
+		candidates = append(candidates, item.GetId())
+	}
+
+	ambiguousPrefix := sb1[:shared]
+	_, err = sandboxid.Resolve(ambiguousPrefix, candidates)
+	require.ErrorIs(t, err, sandboxid.ErrAmbiguous,
+		"prefix %q should be ambiguous across %q and %q", ambiguousPrefix, sb1, sb2)
+}


### PR DESCRIPTION
## Summary

Fixes #1171.

`cubecli logs` used the user-supplied sandbox ID directly as a filesystem path, so short ID prefixes (e.g. the truncated IDs shown by `cubecli cubebox list`) failed with `log file not found`. This PR adds the same List + `resolveSandboxIDFromList` step that `destroy` and `inspect` already use, converting the prefix to the full 32-char hex ID before re-exec into the cubelet mount namespace.

- Add `resolveLogsSandboxID()` to resolve short sandbox ID via gRPC List before entering the namespace
- Add `replacePositionalArg()` to substitute the resolved full ID in the re-exec argument list
- Full IDs (32-char hex) skip the gRPC round-trip for zero overhead on existing workflows

## Test plan

- [x] Unit tests for `replacePositionalArg` covering various flag/arg orderings (`logs_test.go`)
- [x] Integration tests for short ID prefix resolution with real sandbox lifecycle (`cubebox_logs_shortid_test.go`)
- [x] `go vet` and `go test -c` pass for both `cubebox` package and `integration` package (GOOS=linux)
- [ ] Manual: `cubecli logs <short-prefix>` returns logs instead of "log file not found"
- [ ] Manual: `cubecli logs <full-32-char-id>` still works (no regression)

Made with [Cursor](https://cursor.com)