### PR TITLE
virtio-blk: drain inflight IO and flush at pause

### DIFF
--- a/hypervisor/virtio-devices/src/block.rs
+++ b/hypervisor/virtio-devices/src/block.rs
@@ -34,6 +34,7 @@ use std::path::PathBuf;
 use std::result;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Barrier};
+use std::time::{Duration, Instant};
 use std::{collections::HashMap, convert::TryInto};
 use thiserror::Error;
 use virtio_bindings::bindings::virtio_blk::*;
@@ -57,6 +58,17 @@ const QUEUE_AVAIL_EVENT: u16 = EPOLL_HELPER_EVENT_LAST + 1;
 const COMPLETION_EVENT: u16 = EPOLL_HELPER_EVENT_LAST + 2;
 // New 'wake up' event from the rate limiter
 const RATE_LIMITER_EVENT: u16 = EPOLL_HELPER_EVENT_LAST + 3;
+
+// Maximum time we wait for inflight IO to drain when the device is
+// paused. Pause is the synchronization point a snapshot relies on, so
+// we err on the side of giving the backend (network or local) enough
+// time to settle. If this expires we mark drain as failed so the
+// snapshot is aborted by the upper layer instead of being captured in
+// an inconsistent state.
+const PAUSE_DRAIN_TIMEOUT: Duration = Duration::from_secs(20);
+// Per-iteration poll budget while draining; bounds CPU when the
+// completion notifier is quiet but we have not yet hit the deadline.
+const PAUSE_DRAIN_POLL_MS: i32 = 100;
 
 #[derive(Error, Debug)]
 pub enum Error {
@@ -115,6 +127,12 @@ struct BlockEpollHandler {
     read_only: bool,
     rate_limited: std::sync::Once,
     id: String,
+    // Set by `before_pause` when inflight drain or pause-time flush
+    // could not be completed within the deadline. Read by
+    // `Block::pause` after the pause barrier returns to decide whether
+    // the snapshot must be aborted. Shared (not owned) so a multi-queue
+    // device aggregates failures from any queue.
+    drain_failed: Arc<AtomicBool>,
 }
 
 impl BlockEpollHandler {
@@ -368,6 +386,71 @@ impl BlockEpollHandler {
 }
 
 impl EpollHelperHandler for BlockEpollHandler {
+    // Drain inflight IO and (in writeback mode) issue a synchronous
+    // FLUSH before the pause barrier. Any failure is reported via
+    // `drain_failed` rather than `Err`, because returning Err here
+    // would skip `paused_sync.wait()` and deadlock the pausing thread.
+    fn before_pause(&mut self, _helper: &mut EpollHelper) -> result::Result<(), EpollHelperError> {
+        let deadline = Instant::now() + PAUSE_DRAIN_TIMEOUT;
+        let efd = self.disk_image.notifier().as_raw_fd();
+
+        while !self.request_list.is_empty() {
+            if Instant::now() >= deadline {
+                error!(
+                    "virtio-blk {}: pause drain timed out, {} IO still inflight",
+                    self.id,
+                    self.request_list.len()
+                );
+                self.drain_failed.store(true, Ordering::SeqCst);
+                return Ok(());
+            }
+
+            // Wait briefly for the backend completion notifier. We do
+            // not consume the eventfd counter here; `process_queue_complete`
+            // pulls completions directly from the AsyncIo queue, which
+            // is the source of truth.
+            let mut pfd = libc::pollfd {
+                fd: efd,
+                events: libc::POLLIN,
+                revents: 0,
+            };
+            // SAFETY: pfd is initialised; libc::poll only writes revents.
+            let _ = unsafe { libc::poll(&mut pfd, 1, PAUSE_DRAIN_POLL_MS) };
+
+            if let Err(e) = self.process_queue_complete() {
+                error!(
+                    "virtio-blk {}: drain process_queue_complete failed: {:?}",
+                    self.id, e
+                );
+                self.drain_failed.store(true, Ordering::SeqCst);
+                return Ok(());
+            }
+        }
+
+        // Make the freshly-added used entries visible to the guest.
+        // Failures here only affect interrupt delivery (state is
+        // already correct in memory); log and continue.
+        if let Err(e) = self.try_signal_used_queue() {
+            warn!(
+                "virtio-blk {}: pre-pause used-queue signal failed: {:?}",
+                self.id, e
+            );
+        }
+
+        // Write barrier: once data is fully drained, force a synchronous
+        // FLUSH so the backend's completed writes are durable before the
+        // snapshot is taken. Skipped in writethrough because each write
+        // already implies a flush.
+        if self.writeback.load(Ordering::Acquire) {
+            if let Err(e) = self.disk_image.fsync(None) {
+                error!("virtio-blk {}: pause-time flush failed: {:?}", self.id, e);
+                self.drain_failed.store(true, Ordering::SeqCst);
+            }
+        }
+
+        Ok(())
+    }
+
     fn handle_event(
         &mut self,
         _helper: &mut EpollHelper,
@@ -457,6 +540,11 @@ pub struct Block {
     rate_limiter_config: Option<RateLimiterConfig>,
     exit_evt: EventFd,
     read_only: bool,
+    /// Shared with each per-queue `BlockEpollHandler`. Set by an epoll
+    /// thread when its pause-time drain or flush could not complete
+    /// within `PAUSE_DRAIN_TIMEOUT`; checked by `pause()` after the
+    /// pause barrier so the upper layer can abort the snapshot.
+    drain_failed: Arc<AtomicBool>,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -582,6 +670,7 @@ impl Block {
             rate_limiter_config,
             exit_evt,
             read_only,
+            drain_failed: Arc::new(AtomicBool::new(false)),
         })
     }
 
@@ -721,6 +810,7 @@ impl VirtioDevice for Block {
                 read_only: self.read_only,
                 rate_limited: std::sync::Once::new(),
                 id: self.id.clone(),
+                drain_failed: self.drain_failed.clone(),
             };
 
             let paused = self.common.paused.clone();
@@ -786,7 +876,22 @@ impl VirtioDevice for Block {
 
 impl Pausable for Block {
     fn pause(&mut self) -> result::Result<(), MigratableError> {
-        self.common.pause()
+        self.common.pause()?;
+
+        // After common.pause() returns, every per-queue epoll thread has
+        // executed its `before_pause` hook and crossed the barrier. Any
+        // queue that failed to drain inflight IO or to issue the
+        // pause-time flush within `PAUSE_DRAIN_TIMEOUT` will have set
+        // this flag. Aborting pause here propagates upward and prevents
+        // a snapshot from being captured in an inconsistent state.
+        if self.drain_failed.swap(false, Ordering::SeqCst) {
+            return Err(MigratableError::Pause(anyhow!(
+                "Failed to drain inflight IO for block device {} within timeout",
+                self.id
+            )));
+        }
+
+        Ok(())
     }
 
     fn resume(&mut self) -> result::Result<(), MigratableError> {

--- a/hypervisor/virtio-devices/src/epoll_helper.rs
+++ b/hypervisor/virtio-devices/src/epoll_helper.rs
@@ -54,6 +54,18 @@ pub trait EpollHelperHandler {
         event: &epoll::Event,
     ) -> Result<(), EpollHelperError>;
 
+    // Called when PAUSE_EVENT is received, before the pause barrier and
+    // park(). Implementations can use this hook to drain inflight work
+    // and bring device state to a quiescent point so that a subsequent
+    // snapshot is consistent. The hook MUST NOT propagate errors via
+    // Err here: returning Err would cause the epoll loop to exit early
+    // and skip paused_sync.wait(), deadlocking the pausing thread.
+    // Implementations should swallow failures internally (e.g. via a
+    // shared atomic flag) and always return Ok.
+    fn before_pause(&mut self, _helper: &mut EpollHelper) -> Result<(), EpollHelperError> {
+        Ok(())
+    }
+
     // This method is only invoked if the EpollHelper was configured to call
     // epoll_wait() with a valid timeout (different from -1), meaning the call
     // won't block forever. When the timeout is reached, and if no even has been
@@ -218,6 +230,11 @@ impl EpollHelper {
                     EPOLL_HELPER_EVENT_PAUSE => {
                         info!("PAUSE_EVENT received, pausing epoll loop");
 
+                        // Per-device pre-pause hook (e.g. drain inflight IO
+                        // for virtio-blk). Contract: hook always returns Ok
+                        // so we never skip the barrier below.
+                        handler.before_pause(self)?;
+
                         // Acknowledge the pause is effective by using the
                         // paused_sync barrier.
                         paused_sync.wait();
@@ -289,6 +306,10 @@ impl EpollHelper {
                     }
                     EPOLL_HELPER_EVENT_PAUSE => {
                         info!("PAUSE_EVENT received, pausing epoll loop");
+
+                        // Per-device pre-pause hook. See the non-fuzzing
+                        // branch for the contract.
+                        handler.before_pause(self)?;
 
                         // Acknowledge the pause is effective by using the
                         // paused_sync barrier.

--- a/hypervisor/virtio-devices/src/seccomp_filters.rs
+++ b/hypervisor/virtio-devices/src/seccomp_filters.rs
@@ -90,6 +90,13 @@ fn virtio_block_thread_rules() -> Vec<(i64, Vec<SeccompRule>)> {
         (libc::SYS_getrandom, vec![]),
         (libc::SYS_io_uring_enter, vec![]),
         (libc::SYS_lseek, vec![]),
+        // before_pause() drains in-flight IO via libc::poll; glibc maps this
+        // to SYS_poll on x86_64 and SYS_ppoll on aarch64. Without these a
+        // pause-snapshot raises SIGSYS when seccomp is not Allow.
+        #[cfg(target_arch = "x86_64")]
+        (libc::SYS_poll, vec![]),
+        #[cfg(target_arch = "aarch64")]
+        (libc::SYS_ppoll, vec![]),
         (libc::SYS_prctl, vec![]),
         (libc::SYS_pread64, vec![]),
         (libc::SYS_preadv, vec![]),


### PR DESCRIPTION
Pause only parked the epoll loop, leaving inflight IO unaccounted
for. Under pause -> snapshot -> SIGKILL -> restore this can yield
permanently pending guest IOs and an inconsistent backend.

Add a before_pause() hook that drains inflight_requests and, in
writeback mode, issues a synchronous fsync. Bounded by 20s; on
timeout the pause itself fails so the snapshot is aborted.