### PR TITLE
feat(helm): support external PostgreSQL via mysql.driver

### DIFF
--- a/.github/workflows/kubernetes-chart-check.yml
+++ b/.github/workflows/kubernetes-chart-check.yml
@@ -41,6 +41,8 @@ jobs:
         run: sh deploy/kubernetes/chart/scripts/test-master-recreate-strategy-guard.sh
       - name: Guard cluster-scoped resource names
         run: sh deploy/kubernetes/chart/scripts/test-cluster-resource-names.sh
+      - name: Guard database.driver postgres path
+        run: sh deploy/kubernetes/chart/scripts/test-database-postgres-guard.sh
       - name: Check startup-gate shell syntax
         run: |
           sh -n deploy/kubernetes/images/scripts/node-prep-lib.sh

--- a/deploy/kubernetes/chart/README.md
+++ b/deploy/kubernetes/chart/README.md
@@ -196,10 +196,30 @@ helm upgrade --install cube ./deploy/kubernetes/chart   -n cube-system   --creat
 
 > Do not store SSH passwords or node login credentials in this chart. Host mutation is performed through Kubernetes privileged Pods, not through SSH.
 
-## Use third-party MySQL or Redis
+## Use third-party MySQL, PostgreSQL, or Redis
 
-The chart installs `cube-mysql` StatefulSet only when `mysql.enabled=true` and `mysql.host` is empty.
-Set `mysql.host` to use an existing MySQL service; the chart will not install `cube-mysql`.
+`database.driver` picks the control-plane database engine, and each engine keeps its own connection section. The section that does not match the driver is ignored, and no value is inferred across sections.
+
+| Goal | Values |
+| --- | --- |
+| Built-in MySQL (default) | `database.driver: mysql`, `mysql.enabled: true`, `mysql.host: ""` |
+| External MySQL | `database.driver: mysql`, `mysql.host: <addr>` (plus `mysql.port` / `user` / `password` / `database`) |
+| External PostgreSQL | `database.driver: postgres`, `postgres.host: <addr>` (plus `postgres.port` / `user` / `password` / `database`) |
+
+The chart installs the `cube-mysql` StatefulSet only when the driver is `mysql`, `mysql.enabled=true`, and `mysql.host` is empty. `mysql.rootPassword` is used only by that StatefulSet.
+
+PostgreSQL is external-only: the chart never deploys it, so `postgres.host` is required. It then skips the built-in MySQL StatefulSet, writes `driver: postgres` into the CubeMaster config, and sets CubeOps/CubeAPI `DATABASE_URL` to a `postgresql://` URL sourced from the release Secret.
+
+```yaml
+database:
+  driver: postgres
+postgres:
+  host: "10.0.0.10"
+  port: 5432
+  user: postgres
+  password: "replace-me"
+  database: cube_mvp
+```
 
 The chart installs `cube-redis` StatefulSet only when `redis.enabled=true` and `redis.host` is empty.
 Set `redis.host` to use an existing Redis service; the chart will not install `cube-redis`.
@@ -305,7 +325,7 @@ The chart does not deliver a separate DB migration Job or image. CubeMaster owns
 - The chart does not package or maintain SQL files under `files/`; do not add migration SQL copies to the chart.
 - CubeMaster records applied versions in `goose_db_version` and serializes concurrent migration attempts through the migration lock implemented by CubeMaster.
 - There is no chart-managed SQL data seed, and the one-click single-node seed file `sql/002_seed_single_node.sql` is intentionally not rendered by the chart. Node registration must come from real Cube Node Pods selected by `placement.compute.nodeSelector`.
-- When using third-party MySQL, set `mysql.host` and ensure the configured MySQL user can create/alter tables in `mysql.database`.
+- When using a third-party database, set `mysql.host` or `postgres.host` (matching `database.driver`) and ensure the configured user can create/alter tables in that database.
 
 ## cubemastercli operational CLI
 

--- a/deploy/kubernetes/chart/files/cube-master/conf.yaml
+++ b/deploy/kubernetes/chart/files/cube-master/conf.yaml
@@ -43,10 +43,11 @@ req_template_conf:
     {"volumes":[{"name":"tmp","volume_source":{"empty_dir":{"medium":0}}}],"containers":[{"name":"cubebox-default","envs":[{"key":"TZ","value":"Asia/Shanghai"},{"key":"TERM","value":"xterm"}],"volume_mounts":[{"name":"tmp","container_path":"/"}],"security_context":{"privileged":true,"readonly_rootfs":false,"no_new_privs":false}}],"network_type":"tap","cubevs_context":{"allowInternetAccess":true,"denyOut":["10.0.0.0/8","100.64.0.0/10","172.16.0.0/12","192.168.0.0/18"]}}
 
 ossdb_config:
-  addr: {{ printf "%s:%v" (include "cube.mysqlHost" .) .Values.mysql.port | quote }}
-  user: {{ .Values.mysql.user | quote }}
-  pwd: {{ .Values.mysql.password | quote }}
-  db_name: {{ .Values.mysql.database | quote }}
+  driver: {{ include "cube.dbDriver" . | quote }}
+  addr: {{ printf "%s:%v" (include "cube.dbHost" .) (include "cube.dbPort" .) | quote }}
+  user: {{ include "cube.dbUser" . | quote }}
+  pwd: {{ include "cube.dbPassword" . | quote }}
+  db_name: {{ include "cube.dbName" . | quote }}
   conn_timeout: 5
   read_timeout: 5
   write_timeout: 5
@@ -55,10 +56,11 @@ ossdb_config:
   max_conn_life_time_seconds: 300
 
 instance_db_config:
-  addr: {{ printf "%s:%v" (include "cube.mysqlHost" .) .Values.mysql.port | quote }}
-  user: {{ .Values.mysql.user | quote }}
-  pwd: {{ .Values.mysql.password | quote }}
-  db_name: {{ .Values.mysql.database | quote }}
+  driver: {{ include "cube.dbDriver" . | quote }}
+  addr: {{ printf "%s:%v" (include "cube.dbHost" .) (include "cube.dbPort" .) | quote }}
+  user: {{ include "cube.dbUser" . | quote }}
+  pwd: {{ include "cube.dbPassword" . | quote }}
+  db_name: {{ include "cube.dbName" . | quote }}
   conn_timeout: 5
   read_timeout: 5
   write_timeout: 5

--- a/deploy/kubernetes/chart/runtime-values.example.yaml
+++ b/deploy/kubernetes/chart/runtime-values.example.yaml
@@ -36,6 +36,17 @@ mysql:
   password: "replace-me-mysql-password"
   rootPassword: "replace-me-mysql-root-password"
   # host: "mysql.example.com"   # optional: skip built-in StatefulSet
+#
+# External PostgreSQL instead of MySQL (skips built-in MySQL; CubeMaster gets
+# driver: postgres). Switch the driver and fill in the postgres section:
+# database:
+#   driver: postgres
+# postgres:
+#   host: "10.0.0.10"
+#   port: 5432
+#   user: postgres
+#   password: "replace-me-pg-password"
+#   database: cube_mvp
 redis:
   host: ""
   password: "replace-me-redis-password"

--- a/deploy/kubernetes/chart/scripts/test-database-postgres-guard.sh
+++ b/deploy/kubernetes/chart/scripts/test-database-postgres-guard.sh
@@ -1,0 +1,212 @@
+#!/bin/sh
+# Guard: database.driver selects mysql.* or postgres.* without cross-section
+# inference. postgres requires an external postgres.host, skips the built-in
+# MySQL StatefulSet, sets the CubeMaster driver, and feeds CubeOps/CubeAPI
+# DATABASE_URL from a Secret (not a plaintext Deployment env value).
+set -eu
+
+SCRIPT_DIR="$(CDPATH= cd -- "$(dirname "$0")" && pwd)"
+CHART_DIR="$(dirname "$SCRIPT_DIR")"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+COMMON_SETS="--set-string mysql.password=test --set-string mysql.rootPassword=test --set-string redis.password=test"
+
+extract_component_doc() {
+  component="$1"
+  input="$2"
+  output="$3"
+  awk -v component="$component" '
+    BEGIN { RS="\n---\n"; ORS="\n---\n" }
+    index($0, "app.kubernetes.io/component: " component) { print; found=1 }
+    END { exit found ? 0 : 1 }
+  ' "$input" > "$output"
+}
+
+extract_kind_doc() {
+  kind="$1"
+  input="$2"
+  output="$3"
+  awk -v kind="$kind" '
+    BEGIN { RS="\n---\n"; ORS="\n---\n" }
+    $0 ~ ("kind: " kind) { print; found=1 }
+    END { exit found ? 0 : 1 }
+  ' "$input" > "$output"
+}
+
+# Default mysql path still works and keeps MYSQL_* for CubeOps.
+helm template db-driver-default "$CHART_DIR" $COMMON_SETS > "$TMP_DIR/default.yaml"
+grep -q 'driver: "mysql"' "$TMP_DIR/default.yaml" || {
+  echo "default render missing driver: mysql in CubeMaster config" >&2
+  exit 1
+}
+extract_component_doc ops "$TMP_DIR/default.yaml" "$TMP_DIR/default-ops.yaml"
+grep -q 'CUBE_SANDBOX_MYSQL_HOST' "$TMP_DIR/default-ops.yaml" || {
+  echo "default render missing CUBE_SANDBOX_MYSQL_HOST for CubeOps" >&2
+  exit 1
+}
+grep -q 'kind: StatefulSet' "$TMP_DIR/default.yaml" || {
+  echo "default render should keep built-in MySQL StatefulSet" >&2
+  exit 1
+}
+
+# External MySQL through mysql.host keeps working (pre-existing values files).
+helm template db-driver-ext-mysql "$CHART_DIR" \
+  --set-string redis.password=test \
+  --set-string mysql.host=10.0.0.11 \
+  --set mysql.port=3307 \
+  --set-string mysql.user=cube \
+  --set-string mysql.password=extmysql \
+  --set-string mysql.database=cube_mvp \
+  > "$TMP_DIR/ext-mysql.yaml"
+grep -q '10.0.0.11:3307' "$TMP_DIR/ext-mysql.yaml" || {
+  echo "external mysql.host/port not applied" >&2
+  exit 1
+}
+if awk '
+  BEGIN { want=0 }
+  /^kind: StatefulSet$/ { want=1; next }
+  want && /app.kubernetes.io\/component: mysql/ { found=1 }
+  /^---$/ { want=0 }
+  END { exit found ? 0 : 1 }
+' "$TMP_DIR/ext-mysql.yaml"; then
+  echo "external mysql.host must skip built-in MySQL StatefulSet" >&2
+  exit 1
+fi
+extract_kind_doc Secret "$TMP_DIR/ext-mysql.yaml" "$TMP_DIR/ext-mysql-secret.yaml"
+if grep -q 'mysql-root-password' "$TMP_DIR/ext-mysql-secret.yaml"; then
+  echo "external mysql.host must not emit an unused mysql-root-password sentinel" >&2
+  exit 1
+fi
+
+# postgres without postgres.host must fail.
+if helm template db-driver-pg-nohost "$CHART_DIR" $COMMON_SETS \
+  --set-string database.driver=postgres >/dev/null 2>"$TMP_DIR/pg-nohost.err"; then
+  echo "expected fail when database.driver=postgres without postgres.host" >&2
+  exit 1
+fi
+grep -qi 'database.driver=postgres requires postgres.host' "$TMP_DIR/pg-nohost.err" || {
+  echo "unexpected error for postgres without host:" >&2
+  cat "$TMP_DIR/pg-nohost.err" >&2
+  exit 1
+}
+
+# mysql.host must not satisfy the postgres driver (no cross-section inference).
+if helm template db-driver-pg-crossref "$CHART_DIR" $COMMON_SETS \
+  --set-string database.driver=postgres \
+  --set-string mysql.host=10.0.0.12 >/dev/null 2>"$TMP_DIR/pg-crossref.err"; then
+  echo "expected fail when only mysql.host is set for the postgres driver" >&2
+  exit 1
+fi
+grep -qi 'requires postgres.host' "$TMP_DIR/pg-crossref.err" || {
+  echo "unexpected error for postgres with only mysql.host:" >&2
+  cat "$TMP_DIR/pg-crossref.err" >&2
+  exit 1
+}
+
+# invalid driver must fail.
+if helm template db-driver-bad "$CHART_DIR" $COMMON_SETS \
+  --set-string database.driver=sqlite >/dev/null 2>"$TMP_DIR/bad.err"; then
+  echo "expected fail for invalid database.driver" >&2
+  exit 1
+fi
+grep -qi 'database.driver must be mysql or postgres' "$TMP_DIR/bad.err" || {
+  echo "unexpected error for invalid driver:" >&2
+  cat "$TMP_DIR/bad.err" >&2
+  exit 1
+}
+
+# external mysql.host with the CHANGE_ME password must fail.
+if helm template db-driver-mysql-changeme "$CHART_DIR" \
+  --set-string redis.password=test \
+  --set-string mysql.host=10.0.0.10 >/dev/null 2>"$TMP_DIR/mysql-changeme.err"; then
+  echo "expected fail when mysql.host is set with CHANGE_ME password" >&2
+  exit 1
+fi
+grep -qi 'CHANGE_ME' "$TMP_DIR/mysql-changeme.err" || {
+  echo "unexpected error for CHANGE_ME with external mysql.host:" >&2
+  cat "$TMP_DIR/mysql-changeme.err" >&2
+  exit 1
+}
+
+# postgres.host with the CHANGE_ME password must fail.
+if helm template db-driver-pg-changeme "$CHART_DIR" $COMMON_SETS \
+  --set-string database.driver=postgres \
+  --set-string postgres.host=10.0.0.10 >/dev/null 2>"$TMP_DIR/pg-changeme.err"; then
+  echo "expected fail when postgres.host is set with CHANGE_ME password" >&2
+  exit 1
+fi
+grep -qi 'CHANGE_ME' "$TMP_DIR/pg-changeme.err" || {
+  echo "unexpected error for CHANGE_ME with external postgres.host:" >&2
+  cat "$TMP_DIR/pg-changeme.err" >&2
+  exit 1
+}
+
+# postgres + host: no built-in MySQL, CubeMaster driver=postgres,
+# CubeOps/CubeAPI DATABASE_URL via Secret; port defaults to 5432.
+helm template db-driver-pg "$CHART_DIR" $COMMON_SETS \
+  --set-string database.driver=postgres \
+  --set-string postgres.host=10.0.0.10 \
+  --set-string postgres.user=postgres \
+  --set-string postgres.password=test \
+  --set-string postgres.database=cube_mvp \
+  > "$TMP_DIR/pg.yaml"
+
+grep -q 'driver: "postgres"' "$TMP_DIR/pg.yaml" || {
+  echo "postgres render missing driver: postgres in CubeMaster config" >&2
+  exit 1
+}
+extract_component_doc ops "$TMP_DIR/pg.yaml" "$TMP_DIR/pg-ops.yaml"
+grep -q 'name: DATABASE_URL' "$TMP_DIR/pg-ops.yaml" || {
+  echo "postgres render missing DATABASE_URL for CubeOps" >&2
+  exit 1
+}
+grep -q 'key: database-url' "$TMP_DIR/pg-ops.yaml" || {
+  echo "postgres CubeOps DATABASE_URL must use secretKeyRef key database-url" >&2
+  exit 1
+}
+if grep -q 'postgresql://' "$TMP_DIR/pg-ops.yaml"; then
+  echo "postgres CubeOps must not embed DATABASE_URL password in Deployment env" >&2
+  exit 1
+fi
+if grep -q 'CUBE_SANDBOX_MYSQL_HOST' "$TMP_DIR/pg-ops.yaml"; then
+  echo "postgres CubeOps must not set CUBE_SANDBOX_MYSQL_*" >&2
+  exit 1
+fi
+extract_component_doc api "$TMP_DIR/pg.yaml" "$TMP_DIR/pg-api.yaml"
+grep -q 'key: database-url' "$TMP_DIR/pg-api.yaml" || {
+  echo "postgres CubeAPI DATABASE_URL must use secretKeyRef key database-url" >&2
+  exit 1
+}
+if grep -q 'CUBE_SANDBOX_MYSQL_HOST' "$TMP_DIR/pg-api.yaml"; then
+  echo "postgres CubeAPI must not set CUBE_SANDBOX_MYSQL_*" >&2
+  exit 1
+fi
+extract_kind_doc Secret "$TMP_DIR/pg.yaml" "$TMP_DIR/pg-secret.yaml"
+grep -q 'database-url: "postgresql://postgres:test@10.0.0.10:5432/cube_mvp"' "$TMP_DIR/pg-secret.yaml" || {
+  echo "postgres Secret missing expected database-url value (default port 5432)" >&2
+  exit 1
+}
+# mysql-only keys would be misleading here: nothing reads them, and
+# mysql-root-password would carry the untouched CHANGE_ME_* sentinel.
+if grep -qE 'mysql-password|mysql-root-password' "$TMP_DIR/pg-secret.yaml"; then
+  echo "postgres Secret must not emit mysql-password / mysql-root-password" >&2
+  exit 1
+fi
+# Built-in MySQL StatefulSet uses component mysql; ensure it is absent.
+if awk '
+  BEGIN { want=0 }
+  /^kind: StatefulSet$/ { want=1; next }
+  want && /app.kubernetes.io\/component: mysql/ { found=1 }
+  /^---$/ { want=0 }
+  END { exit found ? 0 : 1 }
+' "$TMP_DIR/pg.yaml"; then
+  echo "postgres render must skip built-in MySQL StatefulSet" >&2
+  exit 1
+fi
+
+echo "ok: default mysql driver keeps MYSQL_* and built-in StatefulSet"
+echo "ok: external mysql.host keeps working and skips the built-in StatefulSet"
+echo "ok: postgres without postgres.host / mysql.host only / invalid driver / CHANGE_ME fail as expected"
+echo "ok: postgres + host sets CubeMaster/CubeOps/CubeAPI DATABASE_URL via Secret (port 5432 default)"
+echo "All database.driver guard tests passed"

--- a/deploy/kubernetes/chart/templates/_helpers.tpl
+++ b/deploy/kubernetes/chart/templates/_helpers.tpl
@@ -535,12 +535,97 @@ chart-owned StorageClass). This helper only picks which SC name a PVC binds to.
 {{- end -}}
 {{- end -}}
 
+{{/*
+database.driver selects which connection section the control plane reads:
+  mysql    -> mysql.*    (built-in StatefulSet when mysql.host is empty)
+  postgres -> postgres.* (external only; the chart never deploys PostgreSQL)
+Each engine keeps its own host/port/database/user/password, so no key is
+shared between engines and no value is inferred across sections.
+*/}}
+{{- define "cube.dbDriver" -}}
+{{- $driver := ((.Values.database).driver) | default "mysql" -}}
+{{- if not (has $driver (list "mysql" "postgres")) -}}
+{{- fail (printf "database.driver must be mysql or postgres (got %q)" $driver) -}}
+{{- end -}}
+{{- $driver -}}
+{{- end -}}
+
+{{- define "cube.dbHostRaw" -}}
+{{- if eq (include "cube.dbDriver" .) "postgres" -}}
+{{- ((.Values.postgres).host) | default "" -}}
+{{- else -}}
+{{- ((.Values.mysql).host) | default "" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "cube.dbHost" -}}
+{{- $host := include "cube.dbHostRaw" . -}}
+{{- if $host -}}{{ $host }}{{- else -}}{{ include "cube.mysqlName" . }}.{{ .Release.Namespace }}.svc.{{ include "cube.clusterDomain" . }}{{- end -}}
+{{- end -}}
+
+{{/* Deprecated alias of cube.dbHost (kept so older includes keep working). */}}
 {{- define "cube.mysqlHost" -}}
-{{- if .Values.mysql.host -}}{{ .Values.mysql.host }}{{- else -}}{{ include "cube.mysqlName" . }}.{{ .Release.Namespace }}.svc.{{ include "cube.clusterDomain" . }}{{- end -}}
+{{- include "cube.dbHost" . -}}
+{{- end -}}
+
+{{- define "cube.dbPort" -}}
+{{- if eq (include "cube.dbDriver" .) "postgres" -}}
+{{- ((.Values.postgres).port) | default 5432 -}}
+{{- else -}}
+{{- ((.Values.mysql).port) | default 3306 -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "cube.dbUser" -}}
+{{- if eq (include "cube.dbDriver" .) "postgres" -}}
+{{- ((.Values.postgres).user) | default "cube" -}}
+{{- else -}}
+{{- ((.Values.mysql).user) | default "cube" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "cube.dbName" -}}
+{{- if eq (include "cube.dbDriver" .) "postgres" -}}
+{{- ((.Values.postgres).database) | default "cube_mvp" -}}
+{{- else -}}
+{{- ((.Values.mysql).database) | default "cube_mvp" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "cube.dbPassword" -}}
+{{- if eq (include "cube.dbDriver" .) "postgres" -}}
+{{- ((.Values.postgres).password) | default "" -}}
+{{- else -}}
+{{- ((.Values.mysql).password) | default "" -}}
+{{- end -}}
+{{- end -}}
+
+{{/* Root password only exists for the chart-managed MySQL StatefulSet. */}}
+{{- define "cube.dbRootPassword" -}}
+{{- ((.Values.mysql).rootPassword) | default "" -}}
+{{- end -}}
+
+{{/*
+CubeOps / CubeAPI DATABASE_URL. postgres must use a URL scheme;
+CUBE_SANDBOX_MYSQL_* alone is always assembled as mysql://.
+*/}}
+{{- define "cube.databaseURL" -}}
+{{- $driver := include "cube.dbDriver" . -}}
+{{- $user := include "cube.dbUser" . | urlquery -}}
+{{- $pass := include "cube.dbPassword" . | urlquery -}}
+{{- $host := include "cube.dbHost" . -}}
+{{- $port := include "cube.dbPort" . -}}
+{{- $name := include "cube.dbName" . | urlquery -}}
+{{- if eq $driver "postgres" -}}
+{{- printf "postgresql://%s:%s@%s:%v/%s" $user $pass $host $port $name -}}
+{{- else -}}
+{{- printf "mysql://%s:%s@%s:%v/%s" $user $pass $host $port $name -}}
+{{- end -}}
 {{- end -}}
 
 {{- define "cube.mysqlBuiltinEnabled" -}}
-{{- if and .Values.controlPlane.enabled .Values.mysql.enabled (not .Values.mysql.host) -}}true{{- else -}}false{{- end -}}
+{{- /* Built-in StatefulSet is MySQL only; postgres is always external. */ -}}
+{{- if and .Values.controlPlane.enabled .Values.mysql.enabled (eq (((.Values.mysql).host) | default "") "") (ne (include "cube.dbDriver" .) "postgres") -}}true{{- else -}}false{{- end -}}
 {{- end -}}
 
 {{- define "cube.redisHost" -}}

--- a/deploy/kubernetes/chart/templates/api.yaml
+++ b/deploy/kubernetes/chart/templates/api.yaml
@@ -44,19 +44,28 @@ spec:
               value: {{ printf "http://%s" (include "cube.masterEndpoint" .) | quote }}
             - name: CUBE_API_BIND
               value: {{ .Values.controlPlane.api.bind | quote }}
+            {{- if eq (include "cube.dbDriver" .) "postgres" }}
+            # Same as CubeOps: driver comes from DATABASE_URL scheme.
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "cube.secretName" . }}
+                  key: database-url
+            {{- else }}
             - name: CUBE_SANDBOX_MYSQL_HOST
-              value: {{ include "cube.mysqlHost" . | quote }}
+              value: {{ include "cube.dbHost" . | quote }}
             - name: CUBE_SANDBOX_MYSQL_PORT
-              value: {{ .Values.mysql.port | quote }}
+              value: {{ include "cube.dbPort" . | quote }}
             - name: CUBE_SANDBOX_MYSQL_USER
-              value: {{ .Values.mysql.user | quote }}
+              value: {{ include "cube.dbUser" . | quote }}
             - name: CUBE_SANDBOX_MYSQL_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ include "cube.secretName" . }}
                   key: mysql-password
             - name: CUBE_SANDBOX_MYSQL_DB
-              value: {{ .Values.mysql.database | quote }}
+              value: {{ include "cube.dbName" . | quote }}
+            {{- end }}
             - name: CUBE_API_SANDBOX_DOMAIN
               value: {{ .Values.controlPlane.api.sandboxDomain | quote }}
             {{- with .Values.controlPlane.api.env }}

--- a/deploy/kubernetes/chart/templates/mysql.yaml
+++ b/deploy/kubernetes/chart/templates/mysql.yaml
@@ -13,7 +13,7 @@ spec:
     app.kubernetes.io/component: mysql
   ports:
     - name: mysql
-      port: {{ .Values.mysql.port }}
+      port: {{ include "cube.dbPort" . }}
       targetPort: mysql
 ---
 apiVersion: apps/v1
@@ -49,9 +49,9 @@ spec:
                   name: {{ include "cube.secretName" . }}
                   key: mysql-root-password
             - name: MYSQL_DATABASE
-              value: {{ .Values.mysql.database | quote }}
+              value: {{ include "cube.dbName" . | quote }}
             - name: MYSQL_USER
-              value: {{ .Values.mysql.user | quote }}
+              value: {{ include "cube.dbUser" . | quote }}
             - name: MYSQL_PASSWORD
               valueFrom:
                 secretKeyRef:

--- a/deploy/kubernetes/chart/templates/ops.yaml
+++ b/deploy/kubernetes/chart/templates/ops.yaml
@@ -39,19 +39,29 @@ spec:
               value: {{ .Values.cubeOps.bind | quote }}
             - name: CUBE_MASTER_ADDR
               value: {{ printf "http://%s" (include "cube.masterEndpoint" .) | quote }}
+            {{- if eq (include "cube.dbDriver" .) "postgres" }}
+            # CubeOps selects the driver from DATABASE_URL scheme; MYSQL_* only yields mysql://.
+            # Password stays in Secret (urlquery-encoded) rather than a plaintext env value.
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "cube.secretName" . }}
+                  key: database-url
+            {{- else }}
             - name: CUBE_SANDBOX_MYSQL_HOST
-              value: {{ include "cube.mysqlHost" . | quote }}
+              value: {{ include "cube.dbHost" . | quote }}
             - name: CUBE_SANDBOX_MYSQL_PORT
-              value: {{ .Values.mysql.port | quote }}
+              value: {{ include "cube.dbPort" . | quote }}
             - name: CUBE_SANDBOX_MYSQL_USER
-              value: {{ .Values.mysql.user | quote }}
+              value: {{ include "cube.dbUser" . | quote }}
             - name: CUBE_SANDBOX_MYSQL_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ include "cube.secretName" . }}
                   key: mysql-password
             - name: CUBE_SANDBOX_MYSQL_DB
-              value: {{ .Values.mysql.database | quote }}
+              value: {{ include "cube.dbName" . | quote }}
+            {{- end }}
             - name: CUBE_API_SANDBOX_DOMAIN
               value: {{ default .Values.cubeProxy.domain .Values.cubeOps.sandboxDomain | quote }}
             # Shared CubeDB with CubeMaster; skip fingerprint so chart upgrades

--- a/deploy/kubernetes/chart/templates/secret.yaml
+++ b/deploy/kubernetes/chart/templates/secret.yaml
@@ -18,8 +18,17 @@ metadata:
     {{- include "cube.labels" . | nindent 4 }}
 type: Opaque
 stringData:
-  mysql-root-password: {{ .Values.mysql.rootPassword | quote }}
-  mysql-password: {{ .Values.mysql.password | quote }}
+  {{- if eq (include "cube.mysqlBuiltinEnabled" .) "true" }}
+  # Only the chart-managed MySQL StatefulSet consumes the root password.
+  mysql-root-password: {{ include "cube.dbRootPassword" . | quote }}
+  {{- end }}
+  {{- if eq (include "cube.dbDriver" .) "mysql" }}
+  mysql-password: {{ include "cube.dbPassword" . | quote }}
+  {{- else }}
+  # CubeOps/CubeAPI DATABASE_URL (urlquery-encoded). Kept in Secret so the
+  # Deployment does not embed the password in env value / pod YAML.
+  database-url: {{ include "cube.databaseURL" . | quote }}
+  {{- end }}
   redis-password: {{ .Values.redis.password | quote }}
   # Consumed via include in ConfigMap redis.conf (password must not live in ConfigMap or argv).
   redis-auth.conf: |

--- a/deploy/kubernetes/chart/templates/tests/node-health.yaml
+++ b/deploy/kubernetes/chart/templates/tests/node-health.yaml
@@ -196,7 +196,7 @@ spec:
         - -ec
         - |
           echo '[health-test] check MySQL'
-          mysqladmin ping -h {{ include "cube.mysqlHost" . | quote }} -P {{ .Values.mysql.port }} -u{{ .Values.mysql.user | quote }} --silent
+          mysqladmin ping -h {{ include "cube.dbHost" . | quote }} -P {{ include "cube.dbPort" . }} -u{{ include "cube.dbUser" . | quote }} --silent
 {{- end }}
 {{ if eq (include "cube.redisBuiltinEnabled" .) "true" }}
 ---

--- a/deploy/kubernetes/chart/templates/validate.yaml
+++ b/deploy/kubernetes/chart/templates/validate.yaml
@@ -84,12 +84,20 @@
 {{- if hasKey $pvmRolling "rollingUpdateType" }}
 {{- fail "cubeNodePvm.updateStrategy.rollingUpdate.rollingUpdateType was removed; cube-node-pvm is a native apps/v1 DaemonSet. Remove rollingUpdateType from your values." }}
 {{- end }}
+{{- /* Trigger database.driver validation (invalid values fail inside the helper). */ -}}
+{{- $_ := include "cube.dbDriver" . -}}
 {{- $controlPlaneNeedsMysql := and .Values.controlPlane.enabled (or .Values.controlPlane.master.enabled .Values.controlPlane.api.enabled) -}}
-{{- if and $controlPlaneNeedsMysql (not (eq (include "cube.mysqlBuiltinEnabled" .) "true")) (not .Values.mysql.host) }}
+{{- if and (eq (include "cube.dbDriver" .) "postgres") (eq (include "cube.dbHostRaw" .) "") }}
+{{- fail "database.driver=postgres requires postgres.host (the chart-managed MySQL StatefulSet cannot serve PostgreSQL)" }}
+{{- end }}
+{{- if and $controlPlaneNeedsMysql (not (eq (include "cube.mysqlBuiltinEnabled" .) "true")) (eq (include "cube.dbHostRaw" .) "") }}
 {{- fail "control plane requires mysql.host when mysql.enabled=false" }}
 {{- end }}
-{{- if and (eq (include "cube.mysqlBuiltinEnabled" .) "true") (or (hasPrefix "CHANGE_ME" (default "" .Values.mysql.password)) (hasPrefix "CHANGE_ME" (default "" .Values.mysql.rootPassword))) }}
-{{- fail "mysql.password / mysql.rootPassword still equal the CHANGE_ME_* default sentinel. Override them before deploying (or set mysql.host to use external MySQL)." }}
+{{- if and (eq (include "cube.mysqlBuiltinEnabled" .) "true") (or (hasPrefix "CHANGE_ME" (include "cube.dbPassword" .)) (hasPrefix "CHANGE_ME" (include "cube.dbRootPassword" .))) }}
+{{- fail "mysql.password / mysql.rootPassword still equal the CHANGE_ME_* default sentinel. Override them before deploying (or set mysql.host to use an external MySQL)." }}
+{{- end }}
+{{- if and (ne (include "cube.dbHostRaw" .) "") (hasPrefix "CHANGE_ME" (include "cube.dbPassword" .)) }}
+{{- fail (printf "%s.password still equals the CHANGE_ME_* default sentinel. Override it when connecting to an external database." (include "cube.dbDriver" .)) }}
 {{- end }}
 {{- $controlPlaneNeedsRedis := and .Values.controlPlane.enabled .Values.controlPlane.master.enabled -}}
 {{- if and $controlPlaneNeedsRedis (not (eq (include "cube.redisBuiltinEnabled" .) "true")) (not .Values.redis.host) }}

--- a/deploy/kubernetes/chart/values.yaml
+++ b/deploy/kubernetes/chart/values.yaml
@@ -407,7 +407,16 @@ diagnostics:
   # can collect release state without maintaining a second script copy.
   enabled: true
 
+# Control-plane database (CubeMaster / CubeOps / CubeAPI) engine selector.
+# The driver decides which section below is read; the other one is ignored.
+#   mysql    -> mysql.*    (chart-managed StatefulSet when mysql.host is empty,
+#                           or an external MySQL when mysql.host is set)
+#   postgres -> postgres.* (external only, postgres.host is required)
+database:
+  driver: mysql
+
 mysql:
+  # Read when database.driver=mysql.
   enabled: true
   image:
     repository: mysql
@@ -424,8 +433,9 @@ mysql:
   # production, provide `mysql.password` and `mysql.rootPassword` via -f
   # secret-values.yaml or --set, or use `mysql.host` to point at an externally
   # managed MySQL. templates/validate.yaml refuses to render when passwords
-  # equal the default sentinel below.
+  # equal the default sentinels below.
   password: CHANGE_ME_MYSQL_PASSWORD
+  # rootPassword is only used by the chart-managed StatefulSet.
   rootPassword: CHANGE_ME_MYSQL_ROOT_PASSWORD
   persistence:
     enabled: true
@@ -440,6 +450,17 @@ mysql:
     accessModes:
       - ReadWriteOnce
   resources: {}
+
+# External PostgreSQL, read only when database.driver=postgres.
+# The chart never deploys PostgreSQL, so host must point at an existing server.
+postgres:
+  host: ""
+  port: 5432
+  database: cube_mvp
+  user: cube
+  # SECURITY: same rule as mysql.password; templates/validate.yaml refuses to
+  # render while this equals the CHANGE_ME_* sentinel.
+  password: CHANGE_ME_POSTGRES_PASSWORD
 
 redis:
   enabled: true


### PR DESCRIPTION
## Summary

- Add `mysql.driver` (`mysql` | `postgres`) to the Kubernetes Helm chart so deployments can use an **external PostgreSQL** database (complements the one-click path in #1082 / runtime support already in CubeMaster & CubeOps).
- When `mysql.driver=postgres`, require `mysql.host`, skip the chart-managed MySQL StatefulSet, set `driver: postgres` in CubeMaster `conf.yaml`, and pass CubeOps a `DATABASE_URL` with a `postgresql://` scheme (MYSQL_* alone always assembles `mysql://`).
- Reject invalid drivers and `CHANGE_ME_*` passwords for external `mysql.host`; document the postgres values shape in `values.yaml` / `runtime-values.example.yaml` and the chart README.

## Test plan

- [x] `helm lint deploy/kubernetes/chart --set-string mysql.password=test --set-string mysql.rootPassword=test --set-string redis.password=test` — passed
- [x] `helm template chart-check deploy/kubernetes/chart ...` (default mysql path) — passed
- [x] Existing chart guards (`test-big-pod-inplace-guard.sh`, `test-pvm-native-ds-gvk-guard.sh`, `test-master-recreate-strategy-guard.sh`, `test-cluster-resource-names.sh`) — passed
- [x] `sh deploy/kubernetes/chart/scripts/test-mysql-driver-postgres-guard.sh` — passed (default mysql; postgres without host / invalid driver fail; postgres+host sets CubeMaster driver + CubeOps `DATABASE_URL` and skips MySQL StatefulSet)
