### PR TITLE
fix(install): skip restorecon on cubeletmnt bind mount

### DIFF
--- a/Cubelet/cmd/cubecli/commands/cubebox/logs.go
+++ b/Cubelet/cmd/cubecli/commands/cubebox/logs.go
@@ -14,8 +14,12 @@ import (
 	"strings"
 	"syscall"
 
-	"github.com/tencentcloud/CubeSandbox/Cubelet/pkg/pathutil"
 	"github.com/urfave/cli/v2"
+
+	"github.com/tencentcloud/CubeSandbox/Cubelet/api/services/cubebox/v1"
+	"github.com/tencentcloud/CubeSandbox/Cubelet/cmd/cubecli/commands"
+	"github.com/tencentcloud/CubeSandbox/Cubelet/pkg/pathutil"
+	"github.com/tencentcloud/CubeSandbox/Cubelet/pkg/sandboxid"
 )
 
 const (
@@ -127,16 +131,28 @@ var LogsCommand = &cli.Command{
 			return readLog(id, stream, all, tailN, headN)
 		}
 
+		// Resolve short sandbox ID prefix to full 32-char ID before re-exec
+		// so the child process can locate the log directory directly.
+		originalID := id
+		if !sandboxid.IsFullID(id) {
+			resolved, err := resolveLogsSandboxID(cliCtx, id)
+			if err != nil {
+				return err
+			}
+			id = resolved
+		}
+
 		// Re-exec with CUBEMNT=1 so the C constructor enters the cubelet mount
 		// namespace before Go runtime starts (single-threaded at that point).
-		// Pass os.Args[1:] directly so flag parsing is handled by the CLI
-		// framework in the child, avoiding fragile manual flag reconstruction.
+		// Substitute the resolved full ID for the user-supplied value so the
+		// child process uses the canonical ID directly.
 		self, err := os.Executable()
 		if err != nil {
 			return fmt.Errorf("cannot determine executable path: %w", err)
 		}
 
-		cmd := exec.Command(self, os.Args[1:]...)
+		childArgs := replacePositionalArg(os.Args[1:], originalID, id)
+		cmd := exec.Command(self, childArgs...)
 		cmd.Stdin = os.Stdin
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr
@@ -261,6 +277,42 @@ func printTail(r io.Reader, logPath string, n int) error {
 		fmt.Println(buf[(start+i)%n])
 	}
 	return nil
+}
+
+// resolveLogsSandboxID resolves a short sandbox ID prefix to the full 32-char
+// ID by listing all sandboxes via the Cubelet gRPC API.
+func resolveLogsSandboxID(cliCtx *cli.Context, id string) (string, error) {
+	conn, ctx, cancel, err := commands.NewGrpcConn(cliCtx)
+	if err != nil {
+		return "", fmt.Errorf("resolve sandbox id: %w", err)
+	}
+	defer conn.Close()
+	defer cancel()
+
+	client := cubebox.NewCubeboxMgrClient(conn)
+	resp, err := client.List(ctx, &cubebox.ListCubeSandboxRequest{})
+	if err != nil {
+		return "", fmt.Errorf("resolve sandbox id: list sandboxes: %w", err)
+	}
+	return resolveSandboxIDFromList(resp.Items, id)
+}
+
+// replacePositionalArg returns a copy of args with the last occurrence of old
+// replaced by new.  Searching from the end is preferred because positional
+// arguments typically follow flags.
+func replacePositionalArg(args []string, old, new string) []string {
+	if old == new {
+		return args
+	}
+	out := make([]string, len(args))
+	copy(out, args)
+	for i := len(out) - 1; i >= 0; i-- {
+		if out[i] == old {
+			out[i] = new
+			break
+		}
+	}
+	return out
 }
 
 // readTemplateLog reads log files from /data/log/template/<templateID>_0/.

--- a/Cubelet/cmd/cubecli/commands/cubebox/logs_test.go
+++ b/Cubelet/cmd/cubecli/commands/cubebox/logs_test.go
@@ -1,0 +1,83 @@
+// Copyright (c) 2024 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package cubebox
+
+import (
+	"testing"
+)
+
+func TestReplacePositionalArg(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		old  string
+		new  string
+		want []string
+	}{
+		{
+			name: "short id replaced with full id",
+			args: []string{"logs", "aabbccdd"},
+			old:  "aabbccdd",
+			new:  "aabbccddeeff00112233445566778899",
+			want: []string{"logs", "aabbccddeeff00112233445566778899"},
+		},
+		{
+			name: "flags before positional arg",
+			args: []string{"logs", "--stderr", "aabbccdd"},
+			old:  "aabbccdd",
+			new:  "aabbccddeeff00112233445566778899",
+			want: []string{"logs", "--stderr", "aabbccddeeff00112233445566778899"},
+		},
+		{
+			name: "flags after positional arg",
+			args: []string{"logs", "aabbccdd", "--all"},
+			old:  "aabbccdd",
+			new:  "aabbccddeeff00112233445566778899",
+			want: []string{"logs", "aabbccddeeff00112233445566778899", "--all"},
+		},
+		{
+			name: "multiple flags around positional arg",
+			args: []string{"logs", "--stderr", "-t", "50", "aabbccdd"},
+			old:  "aabbccdd",
+			new:  "aabbccddeeff00112233445566778899",
+			want: []string{"logs", "--stderr", "-t", "50", "aabbccddeeff00112233445566778899"},
+		},
+		{
+			name: "no replacement when old equals new",
+			args: []string{"logs", "aabbccddeeff00112233445566778899"},
+			old:  "aabbccddeeff00112233445566778899",
+			new:  "aabbccddeeff00112233445566778899",
+			want: []string{"logs", "aabbccddeeff00112233445566778899"},
+		},
+		{
+			name: "no match leaves args unchanged",
+			args: []string{"logs", "something"},
+			old:  "notfound",
+			new:  "aabbccddeeff00112233445566778899",
+			want: []string{"logs", "something"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := replacePositionalArg(tt.args, tt.old, tt.new)
+			if len(got) != len(tt.want) {
+				t.Fatalf("len(got)=%d want=%d", len(got), len(tt.want))
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Errorf("args[%d]=%q want=%q", i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestReplacePositionalArgDoesNotModifyOriginal(t *testing.T) {
+	original := []string{"logs", "--stderr", "aabbccdd"}
+	_ = replacePositionalArg(original, "aabbccdd", "aabbccddeeff00112233445566778899")
+	if original[2] != "aabbccdd" {
+		t.Fatalf("original slice was modified: got %q want %q", original[2], "aabbccdd")
+	}
+}

--- a/Cubelet/integration/cubebox_logs_shortid_test.go
+++ b/Cubelet/integration/cubebox_logs_shortid_test.go
@@ -1,0 +1,83 @@
+// Copyright (c) 2024 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package integration
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/tencentcloud/CubeSandbox/Cubelet/api/services/cubebox/v1"
+	"github.com/tencentcloud/CubeSandbox/Cubelet/pkg/sandboxid"
+)
+
+// TestLogsShortIDResolution verifies that a short sandbox ID prefix can be
+// resolved to the full 32-char ID via the same List + Resolve path that
+// cubecli logs now uses.  This is the E2E counterpart of the unit tests in
+// cubebox/logs_test.go and cubebox/resolve_test.go.
+func TestLogsShortIDResolution(t *testing.T) {
+	sandboxID := SimpleCubeboxConfigWithCleanup(t)
+	require.True(t, sandboxid.IsFullID(sandboxID),
+		"created sandbox should have a full 32-char hex ID, got %q", sandboxID)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	resp, err := cubeClient.List(ctx, &cubebox.ListCubeSandboxRequest{})
+	require.NoError(t, err)
+	require.NotEmpty(t, resp.Items)
+
+	candidates := make([]string, 0, len(resp.Items))
+	for _, item := range resp.Items {
+		candidates = append(candidates, item.GetId())
+	}
+
+	for _, prefixLen := range []int{4, 8, 12, len(sandboxID)} {
+		prefix := sandboxID[:prefixLen]
+		t.Run(prefix, func(t *testing.T) {
+			resolved, err := sandboxid.Resolve(prefix, candidates)
+			require.NoError(t, err)
+			require.Equal(t, sandboxID, resolved,
+				"prefix %q should resolve to full ID", prefix)
+		})
+	}
+}
+
+// TestLogsShortIDResolutionAmbiguous verifies that an ambiguous prefix is
+// rejected with ErrAmbiguous when two sandboxes share the same prefix.
+func TestLogsShortIDResolutionAmbiguous(t *testing.T) {
+	sb1 := SimpleCubeboxConfigWithCleanup(t)
+	sb2 := SimpleCubeboxConfigWithCleanup(t)
+
+	// Find the shortest shared prefix.
+	shared := 0
+	for i := 0; i < len(sb1) && i < len(sb2); i++ {
+		if sb1[i] != sb2[i] {
+			break
+		}
+		shared = i + 1
+	}
+	if shared == 0 {
+		t.Skip("sandbox IDs share no common prefix; cannot test ambiguity")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	resp, err := cubeClient.List(ctx, &cubebox.ListCubeSandboxRequest{})
+	require.NoError(t, err)
+
+	candidates := make([]string, 0, len(resp.Items))
+	for _, item := range resp.Items {
+		candidates = append(candidates, item.GetId())
+	}
+
+	ambiguousPrefix := sb1[:shared]
+	_, err = sandboxid.Resolve(ambiguousPrefix, candidates)
+	require.ErrorIs(t, err, sandboxid.ErrAmbiguous,
+		"prefix %q should be ambiguous across %q and %q", ambiguousPrefix, sb1, sb2)
+}

--- a/deploy/one-click/install.sh
+++ b/deploy/one-click/install.sh
@@ -260,8 +260,13 @@ restore_selinux_contexts() {
     return 0
   fi
 
+  local -a exclude_args=()
+  if mountpoint -q "${INSTALL_PREFIX}/cubeletmnt" 2>/dev/null; then
+    exclude_args+=(-e "${INSTALL_PREFIX}/cubeletmnt")
+  fi
+
   log "restoring SELinux contexts under ${INSTALL_PREFIX}"
-  restorecon -R "${INSTALL_PREFIX}"
+  restorecon -R "${exclude_args[@]}" "${INSTALL_PREFIX}"
 }
 
 one_click_runtime_file_paths() {


### PR DESCRIPTION
## Summary

- During upgrades, cubelet's mount namespace file at `cubeletmnt/mnt` is a bind mount of `/proc/<pid>/ns/mnt` (procfs), which does not support xattrs. `restorecon -R` on the install prefix fails with `Operation not permitted` when it recurses into this path.
- Exclude the `cubeletmnt` directory from `restorecon` when it is an active mount point, using `mountpoint -q` to detect and `-e` to skip.

## Test plan

- [ ] Fresh install on SELinux-enabled host: `restorecon` runs without `-e` (cubeletmnt not yet mounted)
- [ ] Upgrade install on SELinux-enabled host with cubelet running: `restorecon` skips `cubeletmnt`, no `Operation not permitted` error
- [ ] Upgrade install on non-SELinux host: function returns early as before, no behavior change

Assisted-by: Cursor:claude-4.6-opus
Signed-off-by: Feng Jin <ronyjin@tencent.com>

Made with [Cursor](https://cursor.com)