### PR TITLE
fix(install): skip restorecon on cubeletmnt bind mount

### DIFF
--- a/deploy/one-click/install.sh
+++ b/deploy/one-click/install.sh
@@ -260,8 +260,18 @@ restore_selinux_contexts() {
     return 0
   fi
 
+  # cubeletmnt/mnt is a bind mount of /proc/<pid>/ns/mnt created by cubelet
+  # (Cubelet/cmd/cubelet/main.go, newCubeMnt). procfs does not support xattrs,
+  # so restorecon fails with "Operation not permitted" on upgrades where
+  # cubelet is already running.  The path is hardcoded in the Go constant
+  # CubeMntNsDirPath as ${INSTALL_PREFIX}/cubeletmnt.
+  local -a exclude_args=()
+  if mountpoint -q "${INSTALL_PREFIX}/cubeletmnt" 2>/dev/null; then
+    exclude_args+=(-e "${INSTALL_PREFIX}/cubeletmnt")
+  fi
+
   log "restoring SELinux contexts under ${INSTALL_PREFIX}"
-  restorecon -R "${INSTALL_PREFIX}"
+  restorecon -R "${exclude_args[@]}" "${INSTALL_PREFIX}"
 }
 
 one_click_runtime_file_paths() {


### PR DESCRIPTION
## Summary

- During upgrades, cubelet's mount namespace file at `cubeletmnt/mnt` is a bind mount of `/proc/<pid>/ns/mnt` (procfs), which does not support xattrs. `restorecon -R` on the install prefix fails with `Operation not permitted` when it recurses into this path.
- Exclude the `cubeletmnt` directory from `restorecon` when it is an active mount point, using `mountpoint -q` to detect and `-e` to skip.

## Test plan

- [ ] Fresh install on SELinux-enabled host: `restorecon` runs without `-e` (cubeletmnt not yet mounted)
- [ ] Upgrade install on SELinux-enabled host with cubelet running: `restorecon` skips `cubeletmnt`, no `Operation not permitted` error
- [ ] Upgrade install on non-SELinux host: function returns early as before, no behavior change

Assisted-by: Cursor:claude-4.6-opus
Signed-off-by: Feng Jin <ronyjin@tencent.com>

Made with [Cursor](https://cursor.com)