### PR TITLE
feat(kubernetes): add chart version sync guard and simplify image templates

### DIFF
--- a/.github/workflows/kubernetes-chart-check.yml
+++ b/.github/workflows/kubernetes-chart-check.yml
@@ -6,11 +6,13 @@ on:
     paths:
       - 'deploy/kubernetes/chart/**'
       - 'deploy/kubernetes/images/scripts/**'
+      - 'scripts/bump-image.sh'
       - '.github/workflows/kubernetes-chart-check.yml'
   pull_request:
     paths:
       - 'deploy/kubernetes/chart/**'
       - 'deploy/kubernetes/images/scripts/**'
+      - 'scripts/bump-image.sh'
       - '.github/workflows/kubernetes-chart-check.yml'
   workflow_dispatch:
 
@@ -33,6 +35,8 @@ jobs:
             --set-string mysql.password=test \
             --set-string mysql.rootPassword=test \
             --set-string redis.password=test >/dev/null
+      - name: Guard chart version sync with image tags
+        run: sh deploy/kubernetes/chart/scripts/test-chart-version-sync.sh
       - name: Enforce Big Pod template stability
         run: sh deploy/kubernetes/chart/scripts/test-big-pod-inplace-guard.sh
       - name: Guard PVM native DaemonSet GVK

--- a/deploy/kubernetes/chart/scripts/test-chart-version-sync.sh
+++ b/deploy/kubernetes/chart/scripts/test-chart-version-sync.sh
@@ -1,0 +1,68 @@
+#!/bin/sh
+# Guard: Chart.yaml version / appVersion must match the release tag used by
+# component image defaults in values.yaml (without the leading "v").
+# Prevents the drift fixed by #1175 from regressing when image tags are bumped
+# without updating chart package metadata.
+set -eu
+
+SCRIPT_DIR="$(CDPATH= cd -- "$(dirname "$0")" && pwd)"
+CHART_DIR="$(dirname "$SCRIPT_DIR")"
+REPO_ROOT="$(CDPATH= cd -- "$CHART_DIR/../../.." && pwd)"
+
+component_tags="$(grep -E '^[[:space:]]+tag:[[:space:]]+v[0-9]' "$CHART_DIR/values.yaml" || true)"
+[ -n "$component_tags" ] || {
+	echo "error: could not find a component image tag (tag: vX.Y.Z) in values.yaml" >&2
+	exit 1
+}
+
+# Require every Cube component tag to agree before treating any as authoritative.
+# Avoid nominating the first tag as "expected" when tags themselves disagree.
+tag=""
+unique=1
+while IFS= read -r line; do
+	[ -z "$line" ] && continue
+	got="$(printf '%s\n' "$line" | awk '{print $2}')"
+	if [ -z "$tag" ]; then
+		tag="$got"
+	elif [ "$got" != "$tag" ]; then
+		unique=0
+	fi
+done <<EOF
+$component_tags
+EOF
+
+if [ "$unique" -eq 0 ]; then
+	echo "error: values.yaml component tags disagree:" >&2
+	while IFS= read -r line; do
+		[ -z "$line" ] && continue
+		echo "  $line" >&2
+	done <<EOF
+$component_tags
+EOF
+	exit 1
+fi
+
+chart_ver="${tag#v}"
+version="$(awk '/^version:/{gsub(/"/, "", $2); print $2; exit}' "$CHART_DIR/Chart.yaml")"
+app_version="$(awk '/^appVersion:/{gsub(/"/, "", $2); print $2; exit}' "$CHART_DIR/Chart.yaml")"
+
+drift=0
+if [ "$version" != "$chart_ver" ]; then
+	echo "error: Chart.yaml version=$version does not match values.yaml image tag $tag (expected $chart_ver)" >&2
+	drift=1
+fi
+if [ "$app_version" != "$chart_ver" ]; then
+	echo "error: Chart.yaml appVersion=$app_version does not match values.yaml image tag $tag (expected $chart_ver)" >&2
+	drift=1
+fi
+
+if [ "$drift" -ne 0 ]; then
+	echo "error: chart metadata out of sync; run 'scripts/bump-image.sh $tag'" >&2
+	exit 1
+fi
+
+# Exercise the release gate against the derived tag so Chart.yaml stays in
+# bump-image.sh's FILES list and rewrite rules.
+"$REPO_ROOT/scripts/bump-image.sh" --check "$tag"
+
+echo "ok: Chart.yaml version/appVersion and values.yaml tags are at $tag"

--- a/deploy/kubernetes/chart/templates/cubemastercli.yaml
+++ b/deploy/kubernetes/chart/templates/cubemastercli.yaml
@@ -1,7 +1,5 @@
 {{- if eq (include "cube.cubemastercliEnabled" .) "true" }}
 {{- $cubemastercli := default dict .Values.cubemastercli -}}
-{{- $images := default dict .Values.images -}}
-{{- $image := default (dict "repository" "cube-sandbox-int.tencentcloudcr.com/cube-sandbox/cubemastercli" "tag" "v0.5.1" "pullPolicy" "Always") (get $images "cubemastercli") -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -34,8 +32,8 @@ spec:
       {{- include "cube.controlPlanePlacement" . | nindent 6 }}
       containers:
         - name: cubemastercli
-          image: {{ include "cube.cubeImage" (dict "image" $image "context" $) | quote }}
-          imagePullPolicy: {{ dig "pullPolicy" "Always" $image }}
+          image: {{ include "cube.cubeImage" (dict "image" .Values.images.cubemastercli "context" $) | quote }}
+          imagePullPolicy: {{ .Values.images.cubemastercli.pullPolicy }}
           {{- with (dig "command" list $cubemastercli) }}
           command:
             {{- toYaml . | nindent 12 }}

--- a/deploy/kubernetes/chart/templates/tests/node-health.yaml
+++ b/deploy/kubernetes/chart/templates/tests/node-health.yaml
@@ -122,8 +122,6 @@ spec:
           echo "${container_names}" | grep -qxF 'cube-egress-net'
           {{- end }}
 {{ if eq (include "cube.cubemastercliEnabled" .) "true" }}
-{{- $images := default dict .Values.images -}}
-{{- $cubemastercliImage := default (dict "repository" "cube-sandbox-int.tencentcloudcr.com/cube-sandbox/cubemastercli" "tag" "v0.5.1" "pullPolicy" "Always") (get $images "cubemastercli") -}}
 ---
 apiVersion: v1
 kind: Pod
@@ -143,8 +141,8 @@ spec:
   {{- end }}
   containers:
     - name: cubemastercli
-      image: {{ include "cube.cubeImage" (dict "image" $cubemastercliImage "context" $) | quote }}
-      imagePullPolicy: {{ dig "pullPolicy" "Always" $cubemastercliImage }}
+      image: {{ include "cube.cubeImage" (dict "image" .Values.images.cubemastercli "context" $) | quote }}
+      imagePullPolicy: {{ .Values.images.cubemastercli.pullPolicy }}
       env:
         {{- include "cube.timezoneEnv" . | nindent 8 }}
         - name: CUBE_RELEASE

--- a/deploy/kubernetes/images/README.md
+++ b/deploy/kubernetes/images/README.md
@@ -9,10 +9,10 @@ PUSH=1 REGISTRY=cube-sandbox-int.tencentcloudcr.com/cube-sandbox IMAGE_TAG=v0.6.
 ```
 
 Before a real release, run `scripts/bump-image.sh vX.Y.Z` so hard-coded tags
-(including chart `deploy/kubernetes/chart/values.yaml` component image tags)
-match the release. `release-docker-images` runs `bump-image.sh --check` by
-default; for a manual/dev image-only build, set workflow input
-`skip_version_check=true`.
+(including chart `deploy/kubernetes/chart/values.yaml` component image tags and
+`Chart.yaml` version / appVersion) match the release. `release-docker-images`
+runs `bump-image.sh --check` by default; for a manual/dev image-only build, set
+workflow input `skip_version_check=true`.
 
 Use `NO_CACHE=1` when every Docker image layer must be rebuilt instead of
 using Docker's build cache:

--- a/deploy/one-click/tests/test_bump_image.sh
+++ b/deploy/one-click/tests/test_bump_image.sh
@@ -26,6 +26,7 @@ FILES=(
 	docs/guide/tencentcloud-terraform-deploy.md
 	docs/zh/guide/tencentcloud-terraform-deploy.md
 	deploy/kubernetes/chart/values.yaml
+	deploy/kubernetes/chart/Chart.yaml
 	deploy/kubernetes/images/build-cube-images.sh
 	deploy/kubernetes/images/README.md
 	deploy/kubernetes/chart/README.md
@@ -49,6 +50,12 @@ CURRENT="$(grep -oE 'cube-egress:v[0-9]+\.[0-9]+\.[0-9]+([-.][0-9A-Za-z.]+)?' \
 	exit 1
 }
 
+# Synthetic bump target — never a real release tag — so rewrite assertions stay
+# meaningful regardless of what CURRENT is. Avoid colliding with CURRENT.
+TARGET=v999.99.9
+[[ "${CURRENT}" != "${TARGET}" ]] || TARGET=v888.88.8
+CHART_VER="${TARGET#v}"
+
 WORK="$(mktemp -d)"
 trap 'rm -rf "${WORK}"' EXIT
 install -D "${REPO_ROOT}/scripts/bump-image.sh" "${WORK}/scripts/bump-image.sh"
@@ -62,32 +69,68 @@ bump() { (cd "${WORK}" && ./scripts/bump-image.sh "$1" >/dev/null 2>&1); }
 
 # 1. clean tree passes at its current version, fails for any other version.
 check "${CURRENT}" || fail "--check ${CURRENT} should pass on the seeded tree"
-if check v9.9.9; then fail "--check v9.9.9 should fail when files are at ${CURRENT}"; fi
+if check "${TARGET}"; then fail "--check ${TARGET} should fail when files are at ${CURRENT}"; fi
 
 # 2. bump rewrites every format; afterwards the new version passes and the old fails.
-bump v0.7.0 || fail "bump v0.7.0 failed"
-check v0.7.0 || fail "--check v0.7.0 should pass after bumping"
-if check "${CURRENT}"; then fail "--check ${CURRENT} should fail after bumping to v0.7.0"; fi
+bump "${TARGET}" || fail "bump ${TARGET} failed"
+check "${TARGET}" || fail "--check ${TARGET} should pass after bumping"
+if check "${CURRENT}"; then fail "--check ${CURRENT} should fail after bumping to ${TARGET}"; fi
 
 # 2b. chart values.yaml component tags move; third-party tags stay put.
 component_tags="$(grep -E '^\s+tag:\s+v[0-9]' "${WORK}/deploy/kubernetes/chart/values.yaml" || true)"
 [[ -n "${component_tags}" ]] || fail "values.yaml should still have component tag: v… lines after bump"
 while IFS= read -r line; do
 	[[ -z "${line}" ]] && continue
-	echo "${line}" | grep -qE "tag:\s+v0\.7\.0$" || fail "values.yaml component tag not bumped: ${line}"
+	got="$(awk '{print $2}' <<<"${line}")"
+	[[ "${got}" == "${TARGET}" ]] || fail "values.yaml component tag not bumped: ${line}"
 done <<<"${component_tags}"
 grep -qE 'tag:\s+"1\.28\.15"' "${WORK}/deploy/kubernetes/chart/values.yaml" \
 	|| fail "values.yaml kubectl third-party tag must remain \"1.28.15\""
 
+# 2c. Chart.yaml version / appVersion track the release without the leading "v".
+grep -qx "version: ${CHART_VER}" "${WORK}/deploy/kubernetes/chart/Chart.yaml" \
+	|| fail "Chart.yaml version must become ${CHART_VER} after bump"
+grep -qx "appVersion: \"${CHART_VER}\"" "${WORK}/deploy/kubernetes/chart/Chart.yaml" \
+	|| fail "Chart.yaml appVersion must become \"${CHART_VER}\" after bump"
+
+# 2d. unquoted appVersion is accepted and normalized to the quoted form on write.
+OLD_CHART_VER="${CURRENT#v}"
+sed -i -E \
+	-e "s/^version:.*/version: ${OLD_CHART_VER}/" \
+	-e "s/^appVersion:.*/appVersion: ${OLD_CHART_VER}/" \
+	"${WORK}/deploy/kubernetes/chart/Chart.yaml"
+bump "${TARGET}" || fail "bump ${TARGET} failed with unquoted appVersion"
+grep -qx "version: ${CHART_VER}" "${WORK}/deploy/kubernetes/chart/Chart.yaml" \
+	|| fail "Chart.yaml version must become ${CHART_VER} after bump from unquoted appVersion"
+grep -qx "appVersion: \"${CHART_VER}\"" "${WORK}/deploy/kubernetes/chart/Chart.yaml" \
+	|| fail "Chart.yaml appVersion must become \"${CHART_VER}\" after bump from unquoted form"
+check "${TARGET}" || fail "--check ${TARGET} should pass after normalizing unquoted appVersion"
+
+# 2e. quoted version is accepted and normalized to the unquoted form on write.
+sed -i -E \
+	-e "s/^version:.*/version: \"${OLD_CHART_VER}\"/" \
+	-e "s/^appVersion:.*/appVersion: \"${OLD_CHART_VER}\"/" \
+	"${WORK}/deploy/kubernetes/chart/Chart.yaml"
+# Stale quoted version with already-correct appVersion must not slip past --check.
+sed -i -E "s/^appVersion:.*/appVersion: \"${CHART_VER}\"/" \
+	"${WORK}/deploy/kubernetes/chart/Chart.yaml"
+if check "${TARGET}"; then fail "--check ${TARGET} should fail when version is stale quoted"; fi
+bump "${TARGET}" || fail "bump ${TARGET} failed with quoted version"
+grep -qx "version: ${CHART_VER}" "${WORK}/deploy/kubernetes/chart/Chart.yaml" \
+	|| fail "Chart.yaml version must become ${CHART_VER} (unquoted) after bump from quoted form"
+grep -qx "appVersion: \"${CHART_VER}\"" "${WORK}/deploy/kubernetes/chart/Chart.yaml" \
+	|| fail "Chart.yaml appVersion must stay \"${CHART_VER}\" after bump from quoted version"
+check "${TARGET}" || fail "--check ${TARGET} should pass after normalizing quoted version"
+
 # 3. reverse scan catches a stray tag in a NEW file that is not in the bump list.
 (cd "${WORK}" && printf 'IMAGE_TAG ?= v1.2.3\n' >stray.mk && git add -N stray.mk)
-if check v0.7.0; then fail "reverse scan should catch a stray tag in a new file"; fi
+if check "${TARGET}"; then fail "reverse scan should catch a stray tag in a new file"; fi
 (cd "${WORK}" && rm -f stray.mk && git reset -q -- stray.mk 2>/dev/null || true)
 
 # 4. a non-image v-semver is left untouched by bump (variables.tf line guard).
 (cd "${WORK}" && printf '\nrequired_version = "~> v1.2.0"\n' \
 	>>deploy/one-click/terraform/tencentcloud/variables.tf)
-bump v0.7.0 || fail "bump v0.7.0 failed"
+bump "${TARGET}" || fail "bump ${TARGET} failed"
 if ! grep -q 'required_version = "~> v1.2.0"' \
 	"${WORK}/deploy/one-click/terraform/tencentcloud/variables.tf"; then
 	fail "bump must not rewrite a non-image semver in variables.tf"

--- a/scripts/bump-image.sh
+++ b/scripts/bump-image.sh
@@ -5,8 +5,9 @@
 # Single source of truth for the release image tag hard-coded across the
 # one-click deployment surface (terraform defaults, systemd launcher, env
 # examples, CubeEgress Makefile, install docs), the Helm chart defaults
-# (deploy/kubernetes/chart/values.yaml component image tags), and the
-# kubernetes image-build docs / usage examples (IMAGE_TAG= / CUBE_VERSION=).
+# (deploy/kubernetes/chart/values.yaml component image tags and Chart.yaml
+# version / appVersion), and the kubernetes image-build docs / usage examples
+# (IMAGE_TAG= / CUBE_VERSION=).
 #
 # Run it before tagging a release to bump every hard-coded cube-* component
 # image tag to the target version; the release workflow runs it with --check to
@@ -62,12 +63,16 @@ script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 repo_root="$(cd "${script_dir}/.." && pwd)"
 cd "${repo_root}"
 
+# Helm Chart.yaml version / appVersion omit the leading "v" (SemVer), while
+# every image tag keeps it. Strip once so bump and --check stay in sync.
+CHART_VERSION="${VERSION#v}"
+
 # transform_file <path> -- print the file with its release image tags rewritten
 # to ${VERSION}, WITHOUT modifying it. Each entry is anchored so it only touches
 # the intended tag and never a go.sum pin, a test fixture, or a changelog entry.
 transform_file() {
 	local f="$1"
-	VER="${VERSION}" perl -pe "$(edit_expr "$f")" "$f"
+	VER="${VERSION}" CHART_VER="${CHART_VERSION}" perl -pe "$(edit_expr "$f")" "$f"
 }
 
 # edit_expr <path> -- the per-file perl expression used by transform_file.
@@ -119,6 +124,12 @@ edit_expr() {
 		# use quoted non-v tags (e.g. "1.28.15", "8.0") and are left alone.
 		echo "s{(^\\s+tag:\\s+)${PERL_SEMVER}}{\$1\$ENV{VER}}"
 		;;
+	deploy/kubernetes/chart/Chart.yaml)
+		# Chart package metadata tracks the release without the leading "v".
+		# Accept quoted or unquoted forms on read. Write version unquoted and
+		# appVersion quoted so Helm treats appVersion as a string, not a float.
+		echo "s{(^version:\\s*)\"?\\d+\\.\\d+\\.\\d+(?:[-.][0-9A-Za-z.]+)?\"?}{\$1\$ENV{CHART_VER}}; s{(^appVersion:\\s*)\"?\\d+\\.\\d+\\.\\d+(?:[-.][0-9A-Za-z.]+)?\"?}{\$1\"\$ENV{CHART_VER}\"}"
+		;;
 	deploy/kubernetes/images/build-cube-images.sh | \
 		deploy/kubernetes/images/README.md | \
 		deploy/kubernetes/chart/README.md | \
@@ -154,6 +165,7 @@ FILES=(
 	docs/guide/tencentcloud-terraform-deploy.md
 	docs/zh/guide/tencentcloud-terraform-deploy.md
 	deploy/kubernetes/chart/values.yaml
+	deploy/kubernetes/chart/Chart.yaml
 	deploy/kubernetes/images/build-cube-images.sh
 	deploy/kubernetes/images/README.md
 	deploy/kubernetes/chart/README.md


### PR DESCRIPTION
## Summary

Add a CI guard that verifies `Chart.yaml` version and appVersion stay in sync with component image tags in `values.yaml`, preventing the drift fixed in #1175 from regressing.

## Changes

- **New guard script** (`test-chart-version-sync.sh`): validates that all component image tags in `values.yaml` are consistent and match `Chart.yaml` version/appVersion
- **CI integration**: wired into `kubernetes-chart-check` workflow
- **bump-image.sh**: added `Chart.yaml` to the version bump rewrite rules so chart metadata automatically stays in sync when the release script is run
- **Template simplification**: cubemastercli templates now reference `.Values.images.cubemastercli` directly, removing complex `default()`/`dig()` fallback chains
- **Test coverage**: updated `test_bump_image.sh` to verify Chart.yaml version/appVersion sync and use synthetic target versions to avoid collisions

## Related

- #1154
- #1175

🤖 Generated with [Claude Code](https://claude.com/claude-code)