### PR TITLE
feat(cubeops): unify cubelog request and service observability

### DIFF
--- a/CubeOps/Dockerfile
+++ b/CubeOps/Dockerfile
@@ -22,8 +22,15 @@ RUN go mod download
 COPY CubeOps/ .
 
 ARG TARGETARCH
+ARG CUBE_VERSION=0.0.0-dev
+ARG CUBE_COMMIT=unknown
+ARG CUBE_BUILD_TIME=unknown
+
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} go build \
-    -ldflags="-s -w" \
+    -ldflags="-s -w \
+      -X 'github.com/tencentcloud/CubeSandbox/CubeOps/internal/version.Version=${CUBE_VERSION}' \
+      -X 'github.com/tencentcloud/CubeSandbox/CubeOps/internal/version.Commit=${CUBE_COMMIT}' \
+      -X 'github.com/tencentcloud/CubeSandbox/CubeOps/internal/version.BuildTime=${CUBE_BUILD_TIME}'" \
     -o /usr/local/bin/cubeops \
     ./cmd/cubeops
 

--- a/CubeOps/Makefile
+++ b/CubeOps/Makefile
@@ -6,8 +6,20 @@
 BINARY=cubeops
 BIND=127.0.0.1:3010
 
+# Version — injected at build time via ldflags.
+# Priority: env var CUBE_VERSION/CUBE_COMMIT/CUBE_BUILD_TIME > local git/date fallback.
+CUBE_VERSION ?= $(shell git describe --tags --abbrev=0 --match 'v*' 2>/dev/null || echo 0.0.0-dev)
+CUBE_COMMIT ?= $(shell git rev-parse HEAD 2>/dev/null || echo unknown)
+CUBE_BUILD_TIME ?= $(shell date -u +'%Y-%m-%dT%H:%M:%SZ')
+
+VERSION_PKG=github.com/tencentcloud/CubeSandbox/CubeOps/internal/version
+BUILD_FLAGS=-ldflags "-s -w \
+  -X '$(VERSION_PKG).Version=$(CUBE_VERSION)' \
+  -X '$(VERSION_PKG).Commit=$(CUBE_COMMIT)' \
+  -X '$(VERSION_PKG).BuildTime=$(CUBE_BUILD_TIME)'"
+
 build:
-	go build -o bin/$(BINARY) ./cmd/cubeops
+	go build $(BUILD_FLAGS) -o bin/$(BINARY) ./cmd/cubeops
 
 run: build
 	JWT_SECRET=test-secret-dummy \
@@ -29,7 +41,11 @@ clean:
 	rm -rf bin/
 
 docker:
-	docker build -t cube-ops:latest -f Dockerfile ..
+	docker build \
+		--build-arg CUBE_VERSION=$(CUBE_VERSION) \
+		--build-arg CUBE_COMMIT=$(CUBE_COMMIT) \
+		--build-arg CUBE_BUILD_TIME=$(CUBE_BUILD_TIME) \
+		-t cube-ops:latest -f Dockerfile ..
 
 tidy:
 	go mod tidy

--- a/CubeOps/README.md
+++ b/CubeOps/README.md
@@ -82,6 +82,13 @@ tail -50 /data/log/CubeOps/cubeops-req.log
 tail -f /data/log/CubeOps/cubeops-req.log
 ```
 
+Every HTTP request receives an `X-RequestID` when one is not supplied. The
+request trace is attached to the request context, so request-scoped `cubelog`
+records include fields such as `RequestId`, `Action`, `Caller`, and
+`CalleeAction`. CubeMaster calls propagate `X-Caller: cubeops` and stamp the
+inbound `RequestID` into the outbound body and query string — that is how
+cross-service correlation works (CubeMaster ignores `X-RequestID`).
+
 Quick health check (no auth required):
 
 ```bash

--- a/CubeOps/cmd/cubeops/main.go
+++ b/CubeOps/cmd/cubeops/main.go
@@ -6,7 +6,7 @@ package main
 import (
 	"context"
 	"errors"
-	"log/slog"
+	"fmt"
 	"net/http"
 	"os"
 	"os/signal"
@@ -22,18 +22,17 @@ import (
 func main() {
 	cfg, err := config.Load()
 	if err != nil {
-		// Config load failed before logging is initialised; use a
-		// stdout-only slog so the error is still visible.
-		slog.SetDefault(slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
-			Level: slog.LevelInfo,
-		})))
-		slog.Error("failed to load config", "error", err)
+		// Logging is not yet initialised here; write directly to stderr
+		// so a config-load failure is always visible regardless of
+		// cubelog's default-writer behaviour.
+		fmt.Fprintf(os.Stderr, "cubeops: failed to load config: %v\n", err)
 		os.Exit(1)
 	}
 
 	logging.Init(logging.Options{
 		Level:      cfg.LogLevel,
 		LogDir:     cfg.LogDir,
+		Module:     "cubeops",
 		FileNum:    cfg.LogFileNum,
 		FileSizeMB: cfg.LogFileSize,
 	})
@@ -44,7 +43,7 @@ func main() {
 	// Initialise database + migrations + master key
 	s, err := store.New(ctx, cfg.DaoConfig())
 	if err != nil {
-		slog.Error("failed to initialise database", "error", err)
+		logging.G(ctx).Errorf("failed to initialise database: err=%q", err.Error())
 		os.Exit(1)
 	}
 	defer s.Close()
@@ -53,7 +52,7 @@ func main() {
 	// auto-generate and persist to DB (zero-config deployment).
 	jwtSecret, err := s.BootstrapJWTSecret(ctx, cfg.JWTSecret)
 	if err != nil {
-		slog.Error("failed to bootstrap JWT secret", "error", err)
+		logging.G(ctx).Errorf("failed to bootstrap JWT secret: err=%q", err.Error())
 		os.Exit(1)
 	}
 	cfg.JWTSecret = jwtSecret
@@ -65,19 +64,19 @@ func main() {
 		sigCh := make(chan os.Signal, 1)
 		signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
 		<-sigCh
-		slog.Info("received shutdown signal")
+		logging.G(context.Background()).Info("received shutdown signal")
 		shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 10*time.Second)
 		defer shutdownCancel()
 		if err := srv.Shutdown(shutdownCtx); err != nil {
-			slog.Error("server shutdown error", "error", err)
+			logging.G(shutdownCtx).Errorf("server shutdown error: err=%q", err.Error())
 		}
 		cancel()
 	}()
 
 	if err := srv.Start(); err != nil && !errors.Is(err, http.ErrServerClosed) {
-		slog.Error("server error", "error", err)
+		logging.G(ctx).Errorf("server error: err=%q", err.Error())
 		os.Exit(1)
 	}
 
-	slog.Info("CubeOps stopped")
+	logging.G(ctx).Info("CubeOps stopped")
 }

--- a/CubeOps/internal/auth/handler.go
+++ b/CubeOps/internal/auth/handler.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/tencentcloud/CubeSandbox/CubeOps/internal/httputil"
+	"github.com/tencentcloud/CubeSandbox/CubeOps/internal/logging"
 	"github.com/tencentcloud/CubeSandbox/CubeOps/internal/model"
 	"github.com/tencentcloud/CubeSandbox/CubeOps/internal/service"
 )
@@ -47,6 +48,7 @@ func (h *Handler) RegisterAuthed(r *gin.RouterGroup) {
 func (h *Handler) Login(c *gin.Context) {
 	var req model.LoginRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
+		logging.G(c.Request.Context()).Errorf("login request body validation failed: client_ip=%s error=%q", c.ClientIP(), err.Error())
 		httputil.WriteError(c, http.StatusBadRequest, "invalid request body")
 		return
 	}
@@ -55,11 +57,13 @@ func (h *Handler) Login(c *gin.Context) {
 		// For security, do not distinguish "user not found" from "wrong password"
 		// to the caller.
 		if errors.Is(err, service.ErrInvalidCredentials) {
+			logging.G(c.Request.Context()).Errorf("login failed: invalid credentials: username=%q client_ip=%s", req.Username, c.ClientIP())
 			//record the failure for rate-limiting.
 			markLoginFailure(c)
 			httputil.WriteError(c, http.StatusUnauthorized, "invalid credentials")
 			return
 		}
+		logging.G(c.Request.Context()).Errorf("login failed: internal error: username=%q client_ip=%s error=%q", req.Username, c.ClientIP(), err.Error())
 		httputil.WriteError(c, http.StatusInternalServerError, err.Error())
 		return
 	}
@@ -96,6 +100,7 @@ func (h *Handler) Logout(c *gin.Context) {
 func (h *Handler) ChangePassword(c *gin.Context) {
 	var req model.ChangePasswordRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
+		logging.G(c.Request.Context()).Errorf("password change request body validation failed: operator=%q error=%q", c.GetString("username"), err.Error())
 		httputil.WriteError(c, http.StatusBadRequest, "invalid request body")
 		return
 	}
@@ -103,12 +108,16 @@ func (h *Handler) ChangePassword(c *gin.Context) {
 	err := h.svc.ChangePassword(c.Request.Context(), username, req.OldPassword, req.NewPassword)
 	switch {
 	case err == nil:
+		logging.G(c.Request.Context()).Infof("password changed: operator=%q result=success", username)
 		httputil.WriteNoContent(c)
 	case errors.Is(err, service.ErrUnauthenticated):
+		logging.G(c.Request.Context()).Errorf("password change failed: operator=%q result=unauthenticated", username)
 		httputil.WriteError(c, http.StatusUnauthorized, "authentication required")
 	case errors.Is(err, service.ErrInvalidOldPassword):
+		logging.G(c.Request.Context()).Errorf("password change failed: operator=%q result=invalid_old_password", username)
 		httputil.WriteError(c, http.StatusUnauthorized, "current password is incorrect or user not found")
 	default:
+		logging.G(c.Request.Context()).Errorf("password change failed: operator=%q result=error error=%q", username, err.Error())
 		// Validation errors and DB errors share the 500 path here; finer
 		// mapping can be added by wrapping with sentinel errors if needed.
 		httputil.WriteError(c, http.StatusInternalServerError, err.Error())

--- a/CubeOps/internal/auth/ratelimit.go
+++ b/CubeOps/internal/auth/ratelimit.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/tencentcloud/CubeSandbox/CubeOps/internal/logging"
 )
 
 // loginLimiter is a per-IP sliding-window rate limiter for the login
@@ -102,6 +103,7 @@ func LoginRateLimit() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		ip := clientIP(c)
 		if defaultLoginLimiter.isBlocked(ip) {
+			logging.G(c.Request.Context()).Warnf("login rate limit triggered: client_ip=%s path=%s", ip, c.Request.URL.Path)
 			c.AbortWithStatusJSON(http.StatusTooManyRequests, gin.H{
 				"error": "too many failed login attempts, try again later",
 			})

--- a/CubeOps/internal/crypto/aes_gcm.go
+++ b/CubeOps/internal/crypto/aes_gcm.go
@@ -9,6 +9,7 @@
 package crypto
 
 import (
+	"context"
 	"crypto/aes"
 	"crypto/cipher"
 	"crypto/rand"
@@ -17,10 +18,10 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log/slog"
 	"strings"
 	"sync"
 
+	"github.com/tencentcloud/CubeSandbox/CubeOps/internal/logging"
 	"golang.org/x/crypto/bcrypt"
 )
 
@@ -170,10 +171,7 @@ func DecryptOrPassthrough(stored string) string {
 		if len(prefix) > 16 {
 			prefix = prefix[:16] + "..."
 		}
-		slog.Warn("DecryptOrPassthrough: decrypt failed; returning empty string",
-			"err", err,
-			"stored_prefix", prefix,
-		)
+		logging.G(context.Background()).Warnf("DecryptOrPassthrough: decrypt failed; returning empty string: err=%q stored_prefix=%s", err.Error(), prefix)
 		return ""
 	}
 	return plaintext

--- a/CubeOps/internal/cubemaster/client.go
+++ b/CubeOps/internal/cubemaster/client.go
@@ -11,7 +11,9 @@ import (
 	"io"
 	"net/http"
 	"net/url"
-	"time"
+
+	"github.com/google/uuid"
+	cubelog "github.com/tencentcloud/CubeSandbox/cubelog"
 )
 
 // CMError carries a CubeMaster business error (non-zero ret_code) out of
@@ -158,10 +160,7 @@ func (c *Client) GetTemplate(ctx context.Context, templateID string) (json.RawMe
 
 // DeleteSnapshot deletes a snapshot via CubeMaster.
 func (c *Client) DeleteSnapshot(ctx context.Context, snapshotID string) (json.RawMessage, error) {
-	body := map[string]interface{}{
-		"request_id": fmt.Sprintf("cubeops-del-snap-%d", time.Now().UnixNano()),
-	}
-	return c.deleteWithBody(ctx, fmt.Sprintf("/cube/snapshot/%s", snapshotID), body)
+	return c.deleteWithBody(ctx, fmt.Sprintf("/cube/snapshot/%s", snapshotID), map[string]interface{}{})
 }
 
 // RollbackSandbox rolls back a sandbox to a snapshot via CubeMaster.
@@ -177,7 +176,6 @@ func (c *Client) UpdateSandbox(ctx context.Context, body interface{}) (json.RawM
 // ConnectSandbox resumes a paused sandbox via CubeMaster (POST /cube/sandbox/connect).
 func (c *Client) ConnectSandbox(ctx context.Context, sandboxID string, timeout int) (json.RawMessage, error) {
 	return c.post(ctx, "/cube/sandbox/connect", map[string]interface{}{
-		"request_id":    fmt.Sprintf("req-%d", time.Now().UnixNano()),
 		"sandbox_id":    sandboxID,
 		"instance_type": "cubebox",
 		"timeout":       timeout,
@@ -263,6 +261,49 @@ func (c *Client) AdoptTemplateCompatBaseline(ctx context.Context, body interface
 	return c.post(ctx, "/cube/template/compat", body)
 }
 
+// RequestIDFromContext returns the inbound trace RequestID, or a fresh UUID
+// when none is set. Outbound bodies reuse it for cross-service correlation.
+func RequestIDFromContext(ctx context.Context) string {
+	if rt := cubelog.GetTraceInfo(ctx); rt != nil && rt.RequestID != "" {
+		return rt.RequestID
+	}
+	return uuid.NewString()
+}
+
+// EnsureRequestID writes requestID/RequestID/request_id into body, returns the
+// id used. All three spellings are written because CubeMaster binds a different
+// one per endpoint; unknown keys are ignored on decode. Non-map bodies —
+// including a typed-nil map, which escapes the `body == nil` check and would
+// panic on assignment — are a no-op.
+func EnsureRequestID(ctx context.Context, body interface{}) string {
+	rid := RequestIDFromContext(ctx)
+	if body == nil || rid == "" {
+		return rid
+	}
+	m, ok := body.(map[string]interface{})
+	if !ok || m == nil {
+		return rid
+	}
+	m["requestID"] = rid
+	m["RequestID"] = rid
+	m["request_id"] = rid
+	return rid
+}
+
+// EnsureRequestIDQuery injects the inbound trace RequestID into query params
+// and returns the id that was used (see EnsureRequestID).
+//
+// Both `requestID` and `request_id` are written because CubeMaster binds a
+// different one per endpoint; PascalCase `RequestID` is not read from query.
+func EnsureRequestIDQuery(ctx context.Context, params map[string]string) string {
+	rid := RequestIDFromContext(ctx)
+	if params != nil {
+		params["requestID"] = rid
+		params["request_id"] = rid
+	}
+	return rid
+}
+
 // --- internal helpers ---
 
 func (c *Client) get(ctx context.Context, path string) (json.RawMessage, error) {
@@ -270,6 +311,7 @@ func (c *Client) get(ctx context.Context, path string) (json.RawMessage, error) 
 	if err != nil {
 		return nil, err
 	}
+	setTraceHeaders(req, RequestIDFromContext(ctx))
 	resp, err := c.http.Do(req)
 	if err != nil {
 		return nil, err
@@ -283,6 +325,7 @@ func (c *Client) getWithQuery(ctx context.Context, path string, params map[strin
 	if err != nil {
 		return nil, err
 	}
+	rid := EnsureRequestIDQuery(ctx, params)
 	q := req.URL.Query()
 	for k, v := range params {
 		if v != "" {
@@ -290,6 +333,7 @@ func (c *Client) getWithQuery(ctx context.Context, path string, params map[strin
 		}
 	}
 	req.URL.RawQuery = q.Encode()
+	setTraceHeaders(req, rid)
 	resp, err := c.http.Do(req)
 	if err != nil {
 		return nil, err
@@ -299,6 +343,7 @@ func (c *Client) getWithQuery(ctx context.Context, path string, params map[strin
 }
 
 func (c *Client) post(ctx context.Context, path string, body interface{}) (json.RawMessage, error) {
+	rid := EnsureRequestID(ctx, body)
 	var bodyReader io.Reader
 	if body != nil {
 		b, err := json.Marshal(body)
@@ -314,6 +359,7 @@ func (c *Client) post(ctx context.Context, path string, body interface{}) (json.
 	if body != nil {
 		req.Header.Set("Content-Type", "application/json")
 	}
+	setTraceHeaders(req, rid)
 	resp, err := c.http.Do(req)
 	if err != nil {
 		return nil, err
@@ -327,6 +373,7 @@ func (c *Client) delete(ctx context.Context, path string) (json.RawMessage, erro
 	if err != nil {
 		return nil, err
 	}
+	setTraceHeaders(req, RequestIDFromContext(ctx))
 	resp, err := c.http.Do(req)
 	if err != nil {
 		return nil, err
@@ -336,6 +383,7 @@ func (c *Client) delete(ctx context.Context, path string) (json.RawMessage, erro
 }
 
 func (c *Client) deleteWithBody(ctx context.Context, path string, body interface{}) (json.RawMessage, error) {
+	rid := EnsureRequestID(ctx, body)
 	var bodyReader io.Reader
 	if body != nil {
 		b, err := json.Marshal(body)
@@ -351,6 +399,7 @@ func (c *Client) deleteWithBody(ctx context.Context, path string, body interface
 	if body != nil {
 		req.Header.Set("Content-Type", "application/json")
 	}
+	setTraceHeaders(req, rid)
 	resp, err := c.http.Do(req)
 	if err != nil {
 		return nil, err
@@ -388,4 +437,16 @@ func trimTrailingSlash(s string) string {
 		s = s[:len(s)-1]
 	}
 	return s
+}
+
+func setTraceHeaders(req *http.Request, rid string) {
+	// CubeOps is the caller here; the inbound client identity stays in our stat
+	// log. CubeMaster uses X-Caller for logging, sandbox caller label and gRPC
+	// pool keying only — not authn/authz or quotas.
+	req.Header.Set("X-Caller", "cubeops")
+	// rid is passed in, not re-derived from req.Context(), so the header matches
+	// the body/query id.
+	if rid != "" {
+		req.Header.Set("X-RequestID", rid)
+	}
 }

--- a/CubeOps/internal/cubemaster/client.go
+++ b/CubeOps/internal/cubemaster/client.go
@@ -311,7 +311,13 @@ func (c *Client) get(ctx context.Context, path string) (json.RawMessage, error) 
 	if err != nil {
 		return nil, err
 	}
-	setTraceHeaders(req, RequestIDFromContext(ctx))
+	rid := RequestIDFromContext(ctx)
+	setTraceHeaders(req, rid)
+	// Inject RequestID into query params for cross-service trace correlation.
+	q := req.URL.Query()
+	q.Set("requestID", rid)
+	q.Set("request_id", rid)
+	req.URL.RawQuery = q.Encode()
 	resp, err := c.http.Do(req)
 	if err != nil {
 		return nil, err

--- a/CubeOps/internal/cubemaster/client_test.go
+++ b/CubeOps/internal/cubemaster/client_test.go
@@ -12,6 +12,8 @@ import (
 	"net/http/httptest"
 	"testing"
 	"time"
+
+	cubelog "github.com/tencentcloud/CubeSandbox/cubelog"
 )
 
 // TestReadResponse_BusinessErrorReturnsCMError verifies that readResponse
@@ -208,6 +210,160 @@ func TestClient_RespectsContextDeadline(t *testing.T) {
 	_, err := client.GetSandbox(ctx, "sb-1", "cubebox")
 	if err == nil {
 		t.Fatal("expected context deadline error, got nil")
+	}
+}
+
+func TestClient_PropagatesTraceHeaders(t *testing.T) {
+	const requestID = "cubeops-request-123"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("X-RequestID"); got != requestID {
+			t.Errorf("X-RequestID = %q, want %q", got, requestID)
+		}
+		if got := r.Header.Get("X-Caller"); got != "cubeops" {
+			t.Errorf("X-Caller = %q, want cubeops", got)
+		}
+		fmt.Fprint(w, `{"ret":{"ret_code":0}}`)
+	}))
+	defer srv.Close()
+
+	ctx := cubelog.WithRequestTrace(context.Background(), &cubelog.RequestTrace{RequestID: requestID})
+	if _, err := New(srv.URL).GetSandbox(ctx, "sb-1", "cubebox"); err != nil {
+		t.Fatalf("GetSandbox: %v", err)
+	}
+}
+
+// TestClient_OutboundBodyRequestIDCorrelates verifies that the request body
+// sent to CubeMaster reuses the inbound RequestTrace.RequestID, not a newly
+// generated ID.
+func TestClient_OutboundBodyRequestIDCorrelates(t *testing.T) {
+	const requestID = "cross-service-req-123"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var m map[string]interface{}
+		_ = json.Unmarshal(body, &m)
+		for _, key := range []string{"requestID", "RequestID", "request_id"} {
+			if got := m[key]; got != requestID {
+				t.Errorf("body %s = %v, want %q", key, got, requestID)
+			}
+		}
+		fmt.Fprint(w, `{"ret":{"ret_code":0}}`)
+	}))
+	defer srv.Close()
+
+	ctx := cubelog.WithRequestTrace(context.Background(), &cubelog.RequestTrace{RequestID: requestID})
+	client := New(srv.URL)
+	if _, err := client.DeleteSandbox(ctx, map[string]interface{}{"sandbox_id": "sb-1"}); err != nil {
+		t.Fatalf("DeleteSandbox: %v", err)
+	}
+}
+
+func TestClient_OutboundCallerAlwaysCubeOps(t *testing.T) {
+	// Even when the inbound trace carries a client caller (e.g. cubeops-client),
+	// outbound calls to CubeMaster must identify CubeOps as the caller.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("X-Caller"); got != "cubeops" {
+			t.Errorf("X-Caller = %q, want cubeops", got)
+		}
+		fmt.Fprint(w, `{"ret":{"ret_code":0}}`)
+	}))
+	defer srv.Close()
+
+	ctx := cubelog.WithRequestTrace(context.Background(), &cubelog.RequestTrace{
+		RequestID: "req-1",
+		Caller:    "webui-client",
+	})
+	if _, err := New(srv.URL).GetSandbox(ctx, "sb-1", "cubebox"); err != nil {
+		t.Fatalf("GetSandbox: %v", err)
+	}
+}
+
+// TestEnsureRequestID_TypedNilMapDoesNotPanic verifies a typed-nil map boxed in
+// an interface{} is a no-op; `body == nil` misses it and assignment would panic.
+func TestEnsureRequestID_TypedNilMapDoesNotPanic(t *testing.T) {
+	var typedNil map[string]interface{}
+
+	cases := []struct {
+		name string
+		body interface{}
+	}{
+		{"untyped nil", nil},
+		{"typed nil map", typedNil},
+		{"non-map body", struct{ A int }{A: 1}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rid := EnsureRequestID(context.Background(), tc.body)
+			if rid == "" {
+				t.Error("EnsureRequestID returned an empty request id")
+			}
+		})
+	}
+}
+
+// TestEnsureRequestID_WritesAllThreeSpellings pins the wire contract: CubeMaster
+// binds a different spelling per endpoint, so all three carry the same value.
+func TestEnsureRequestID_WritesAllThreeSpellings(t *testing.T) {
+	const requestID = "rid-abc"
+	ctx := cubelog.WithRequestTrace(context.Background(), &cubelog.RequestTrace{RequestID: requestID})
+	body := map[string]interface{}{}
+
+	if rid := EnsureRequestID(ctx, body); rid != requestID {
+		t.Fatalf("returned id = %q, want %q", rid, requestID)
+	}
+	for _, key := range []string{"requestID", "RequestID", "request_id"} {
+		if got := body[key]; got != requestID {
+			t.Errorf("body[%q] = %v, want %q", key, got, requestID)
+		}
+	}
+}
+
+// TestClient_HeaderAndBodyRequestIDAgreeWithoutTrace verifies that on the
+// no-trace path the UUID stamped into the body is also sent as X-RequestID;
+// the header used to be derived independently, so it could differ or be absent.
+func TestClient_HeaderAndBodyRequestIDAgreeWithoutTrace(t *testing.T) {
+	var headerRID, bodyRID string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		headerRID = r.Header.Get("X-RequestID")
+		raw, _ := io.ReadAll(r.Body)
+		var m map[string]interface{}
+		_ = json.Unmarshal(raw, &m)
+		bodyRID, _ = m["requestID"].(string)
+		fmt.Fprint(w, `{"ret":{"ret_code":0}}`)
+	}))
+	defer srv.Close()
+
+	// context.Background() carries no RequestTrace.
+	if _, err := New(srv.URL).DeleteSandbox(context.Background(), map[string]interface{}{"sandbox_id": "sb-1"}); err != nil {
+		t.Fatalf("DeleteSandbox: %v", err)
+	}
+	if headerRID == "" {
+		t.Fatal("X-RequestID header was not set on the no-trace path")
+	}
+	if headerRID != bodyRID {
+		t.Errorf("X-RequestID = %q but body requestID = %q; header and body must agree", headerRID, bodyRID)
+	}
+}
+
+// TestClient_QueryAndHeaderRequestIDAgreeWithoutTrace is the getWithQuery
+// counterpart of the test above.
+func TestClient_QueryAndHeaderRequestIDAgreeWithoutTrace(t *testing.T) {
+	var headerRID, queryCamel, querySnake string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		headerRID = r.Header.Get("X-RequestID")
+		queryCamel = r.URL.Query().Get("requestID")
+		querySnake = r.URL.Query().Get("request_id")
+		fmt.Fprint(w, `{"ret":{"ret_code":0}}`)
+	}))
+	defer srv.Close()
+
+	if _, err := New(srv.URL).ListSnapshots(context.Background(), map[string]string{}); err != nil {
+		t.Fatalf("ListSnapshots: %v", err)
+	}
+	if headerRID == "" || queryCamel == "" || querySnake == "" {
+		t.Fatalf("missing request id: header=%q query(camel)=%q query(snake)=%q", headerRID, queryCamel, querySnake)
+	}
+	if headerRID != queryCamel || headerRID != querySnake {
+		t.Errorf("request id mismatch: header=%q query(camel)=%q query(snake)=%q", headerRID, queryCamel, querySnake)
 	}
 }
 

--- a/CubeOps/internal/handler/agenthub.go
+++ b/CubeOps/internal/handler/agenthub.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log/slog"
 	"net/http"
 	"os"
 	"strings"
@@ -16,8 +15,10 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/tencentcloud/CubeSandbox/CubeOps/internal/crypto"
 	"github.com/tencentcloud/CubeSandbox/CubeOps/internal/httputil"
+	"github.com/tencentcloud/CubeSandbox/CubeOps/internal/logging"
 	"github.com/tencentcloud/CubeSandbox/CubeOps/internal/service"
 	"github.com/tencentcloud/CubeSandbox/CubeOps/internal/store"
+	cubelog "github.com/tencentcloud/CubeSandbox/cubelog"
 )
 
 // AgentHubHandler handles agenthub-related HTTP requests.
@@ -44,15 +45,25 @@ func NewAgentHubHandler(s *store.Store, cm CubeMasterClient) *AgentHubHandler {
 
 // AgentHubService returns the underlying service. Used by server.go to wire
 // the SDK handler's reverse-sync (SDK template deletes must clean up AgentHub
-// registrations, same as the old Rust reverse_sync_agenthub_template).
+// registrations).
 func (h *AgentHubHandler) AgentHubService() *service.AgentHubService { return h.svc }
 
-// writeServiceError maps a service.Error to the corresponding HTTP response.
-// For 503 errors that carry a "retry-after:N" code, the Retry-After header
-// is set before writing the response body.
-func writeServiceError(c *gin.Context, err error) {
+// writeServiceErrorNoID is the no-instance-id shorthand for handlers that
+// don't have one in scope. See writeServiceError.
+func writeServiceErrorNoID(c *gin.Context, err error) {
+	writeServiceError(c, err, "")
+}
+
+// writeServiceError maps a service.Error to the HTTP response; a non-empty
+// instanceID is stamped onto rt.InstanceID for ELK/Loki filtering.
+func writeServiceError(c *gin.Context, err error, instanceID string) {
+	ctx := c.Request.Context()
 	var svcErr *service.Error
 	if !errors.As(err, &svcErr) {
+		if instanceID != "" {
+			ctx = updateTraceAndLogger(ctx, cubelog.GetTraceInfo(ctx), instanceID, "", 0)
+		}
+		logging.G(ctx).Errorf("agenthub: handler failed: %v", err)
 		httputil.WriteError(c, http.StatusInternalServerError, err.Error())
 		return
 	}
@@ -60,11 +71,15 @@ func writeServiceError(c *gin.Context, err error) {
 	if status == 0 {
 		status = http.StatusInternalServerError
 	}
+	ctx = updateTraceAndLogger(ctx, cubelog.GetTraceInfo(ctx), instanceID, "", status)
 	// 503 with an embedded "retry-after:N" code → set Retry-After header.
 	if status == http.StatusServiceUnavailable && strings.HasPrefix(svcErr.Code, "retry-after:") {
 		if v := strings.TrimPrefix(svcErr.Code, "retry-after:"); v != "" {
 			c.Header("Retry-After", v)
 		}
+	}
+	if status >= 500 {
+		logging.G(ctx).Errorf("agenthub: handler failed: %v", err)
 	}
 	httputil.WriteError(c, status, svcErr.Message)
 }
@@ -112,9 +127,11 @@ func (h *AgentHubHandler) Register(r *gin.RouterGroup) {
 // capped at store.MaxListLimit (200) to prevent OOM on large tables.
 // limit <= 0 or missing falls back to store.DefaultListLimit (50).
 func (h *AgentHubHandler) ListInstances(c *gin.Context) {
+	ctx := c.Request.Context()
 	limit, offset := parsePagination(c)
-	instances, err := h.store.ListInstances(c.Request.Context(), limit, offset)
+	instances, err := h.store.ListInstances(ctx, limit, offset)
 	if err != nil {
+		logging.G(ctx).Errorf("agenthub: failed to list instances: %v", err)
 		httputil.WriteError(c, http.StatusInternalServerError, "failed to list instances: "+err.Error())
 		return
 	}
@@ -123,37 +140,29 @@ func (h *AgentHubHandler) ListInstances(c *gin.Context) {
 
 // DeleteInstance handles DELETE /agenthub/instances/{agentID}.
 func (h *AgentHubHandler) DeleteInstance(c *gin.Context) {
+	ctx := c.Request.Context()
 	agentID := c.Param("agentID")
-	if err := h.svc.DeleteInstance(c.Request.Context(), agentID); err != nil {
-		writeServiceError(c, err)
+	if err := h.svc.DeleteInstance(ctx, agentID); err != nil {
+		writeServiceError(c, err, agentID)
 		return
 	}
 	httputil.WriteNoContent(c)
 }
 
-// compensateDeleteSandbox is a best-effort cleanup used when Agent creation
-// fails after the sandbox has already been created by CubeMaster. It deletes
-// the sandbox so CPU/memory/quota are not leaked. Errors are logged but not
-// returned — the caller already has an error to report to the client.
-//
-// Kept as a handler method (rather than forwarding to
-// service.AgentHubService.CompensateDeleteSandbox) so the contract tests in
-// clone_compensate_test.go / compensate_requestid_test.go can construct a
-// minimal AgentHubHandler with only a fake cm and no store, and verify the
-// DeleteSandbox request shape directly.
-//
-// See R10.
+// compensateDeleteSandbox best-effort deletes a sandbox when Agent creation
+// fails after CubeMaster has already created it, so CPU/memory/quota aren't
+// leaked. Errors are logged only; the caller already has an error to return.
+// Stays on the handler (not delegated to the service layer) so the contract
+// tests in clone_compensate_test.go / compensate_requestid_test.go can drive
+// the DeleteSandbox request shape with a minimal fake.
 func (h *AgentHubHandler) compensateDeleteSandbox(ctx context.Context, sandboxID, reason string) {
 	if _, err := h.cm.DeleteSandbox(ctx, map[string]interface{}{
-		"requestID":     fmt.Sprintf("cubeops-compensate-%s-%d", reason, time.Now().UnixNano()),
 		"sandbox_id":    sandboxID,
 		"instance_type": service.SDKInstanceType,
 	}); err != nil {
-		slog.Error("compensateDeleteSandbox: failed to delete sandbox after creation failure",
-			"sandboxID", sandboxID, "reason", reason, "err", err)
+		logging.G(ctx).Errorf("compensateDeleteSandbox: failed to delete sandbox %q (reason=%s): %v", sandboxID, reason, err)
 	} else {
-		slog.Info("compensateDeleteSandbox: sandbox deleted after creation failure",
-			"sandboxID", sandboxID, "reason", reason)
+		logging.G(ctx).Infof("compensateDeleteSandbox: sandbox %q deleted (reason=%s)", sandboxID, reason)
 	}
 }
 
@@ -162,9 +171,11 @@ func (h *AgentHubHandler) compensateDeleteSandbox(ctx context.Context, sandboxID
 // Supports pagination via ?limit= and ?offset= query params. See
 // ListInstances for the cap and default behaviour.
 func (h *AgentHubHandler) ListTemplates(c *gin.Context) {
+	ctx := c.Request.Context()
 	limit, offset := parsePagination(c)
-	templates, err := h.store.ListAgentTemplates(c.Request.Context(), limit, offset)
+	templates, err := h.store.ListAgentTemplates(ctx, limit, offset)
 	if err != nil {
+		logging.G(ctx).Errorf("agenthub: failed to list templates: %v", err)
 		httputil.WriteError(c, http.StatusInternalServerError, "failed to list templates: "+err.Error())
 		return
 	}
@@ -179,14 +190,16 @@ func (h *AgentHubHandler) ListTemplates(c *gin.Context) {
 // reverse_sync_agenthub_template and prevents dangling references when an
 // infra template is deleted via the AgentHub path.
 func (h *AgentHubHandler) DeleteTemplate(c *gin.Context) {
+	ctx := c.Request.Context()
 	templateID := c.Param("templateID")
-	if err := h.store.DeleteAgentTemplate(c.Request.Context(), templateID); err != nil {
+	if err := h.store.DeleteAgentTemplate(ctx, templateID); err != nil {
+		logging.G(ctx).Errorf("agenthub: failed to delete template: templateID=%s: %v", templateID, err)
 		httputil.WriteError(c, http.StatusInternalServerError, "failed to delete template: "+err.Error())
 		return
 	}
 	// Best-effort: clean up any other AgentHub registrations pointing at the
 	// same infra id. Failures are logged inside the service, never propagated.
-	h.svc.ReverseSyncAgentHubTemplate(c.Request.Context(), templateID)
+	h.svc.ReverseSyncAgentHubTemplate(ctx, templateID)
 	httputil.WriteNoContent(c)
 }
 
@@ -194,10 +207,11 @@ func (h *AgentHubHandler) DeleteTemplate(c *gin.Context) {
 // Restarts the OpenClaw process inside the sandbox via envd.
 // Returns AgentSetupResult { exitCode, stdout, stderr }.
 func (h *AgentHubHandler) RestartAgent(c *gin.Context) {
+	ctx := c.Request.Context()
 	agentID := c.Param("agentID")
-	res, err := h.svc.RestartAgent(c.Request.Context(), agentID)
+	res, err := h.svc.RestartAgent(ctx, agentID)
 	if err != nil {
-		writeServiceError(c, err)
+		writeServiceError(c, err, agentID)
 		return
 	}
 	httputil.WriteJSON(c, http.StatusOK, map[string]interface{}{
@@ -209,9 +223,12 @@ func (h *AgentHubHandler) RestartAgent(c *gin.Context) {
 
 // ListOperations handles GET /agenthub/instances/{agentID}/operations.
 func (h *AgentHubHandler) ListOperations(c *gin.Context) {
+	ctx := c.Request.Context()
 	agentID := c.Param("agentID")
-	ops, err := h.store.ListAgentOperations(c.Request.Context(), agentID)
+	ops, err := h.store.ListAgentOperations(ctx, agentID)
 	if err != nil {
+		ctx = updateTraceAndLogger(ctx, cubelog.GetTraceInfo(ctx), agentID, "", 0)
+		logging.G(ctx).Errorf("agenthub: failed to list operations: %v", err)
 		httputil.WriteError(c, http.StatusInternalServerError, "failed to list operations: "+err.Error())
 		return
 	}
@@ -225,10 +242,11 @@ func (h *AgentHubHandler) PauseAgent(c *gin.Context) { h.sandboxAction(c, "pause
 func (h *AgentHubHandler) ResumeAgent(c *gin.Context) { h.sandboxAction(c, "resume") }
 
 func (h *AgentHubHandler) sandboxAction(c *gin.Context, action string) {
+	ctx := c.Request.Context()
 	agentID := c.Param("agentID")
-	inst, err := h.svc.SandboxAction(c.Request.Context(), agentID, action)
+	inst, err := h.svc.SandboxAction(ctx, agentID, action)
 	if err != nil {
-		writeServiceError(c, err)
+		writeServiceError(c, err, agentID)
 		return
 	}
 	httputil.WriteJSON(c, http.StatusOK, inst)
@@ -238,10 +256,11 @@ func (h *AgentHubHandler) sandboxAction(c *gin.Context, action string) {
 // Upgrades OpenClaw to the latest version (via npm/pnpm/pip) and restarts it.
 // Matches old Rust upgrade_agent_openclaw.
 func (h *AgentHubHandler) UpgradeAgent(c *gin.Context) {
+	ctx := c.Request.Context()
 	agentID := c.Param("agentID")
-	res, err := h.svc.UpgradeAgent(c.Request.Context(), agentID)
+	res, err := h.svc.UpgradeAgent(ctx, agentID)
 	if err != nil {
-		writeServiceError(c, err)
+		writeServiceError(c, err, agentID)
 		return
 	}
 	httputil.WriteJSON(c, http.StatusOK, map[string]interface{}{
@@ -253,17 +272,19 @@ func (h *AgentHubHandler) UpgradeAgent(c *gin.Context) {
 
 // UpdateModel handles PUT /agenthub/instances/{agentID}/model.
 func (h *AgentHubHandler) UpdateModel(c *gin.Context) {
+	ctx := c.Request.Context()
 	agentID := c.Param("agentID")
 	var body struct {
 		Model string `json:"model"`
 	}
 	if err := c.ShouldBindJSON(&body); err != nil {
+		logging.G(ctx).Errorf("agenthub: invalid request body: %v", err)
 		httputil.WriteError(c, http.StatusBadRequest, "invalid request body")
 		return
 	}
-	inst, err := h.svc.UpdateModel(c.Request.Context(), agentID, body.Model)
+	inst, err := h.svc.UpdateModel(ctx, agentID, body.Model)
 	if err != nil {
-		writeServiceError(c, err)
+		writeServiceError(c, err, agentID)
 		return
 	}
 	httputil.WriteJSON(c, http.StatusOK, inst)
@@ -271,9 +292,12 @@ func (h *AgentHubHandler) UpdateModel(c *gin.Context) {
 
 // GetWecomConfig handles GET /agenthub/instances/{agentID}/wecom.
 func (h *AgentHubHandler) GetWecomConfig(c *gin.Context) {
+	ctx := c.Request.Context()
 	agentID := c.Param("agentID")
-	botID, botSecret, err := h.store.GetAgentWecomConfig(c.Request.Context(), agentID)
+	botID, botSecret, err := h.store.GetAgentWecomConfig(ctx, agentID)
 	if err != nil {
+		ctx = updateTraceAndLogger(ctx, cubelog.GetTraceInfo(ctx), agentID, "", 0)
+		logging.G(ctx).Errorf("agenthub: failed to get wecom config: %v", err)
 		httputil.WriteError(c, http.StatusInternalServerError, "failed to get wecom config: "+err.Error())
 		return
 	}
@@ -285,18 +309,20 @@ func (h *AgentHubHandler) GetWecomConfig(c *gin.Context) {
 
 // UpdateWecomConfig handles PUT /agenthub/instances/{agentID}/wecom.
 func (h *AgentHubHandler) UpdateWecomConfig(c *gin.Context) {
+	ctx := c.Request.Context()
 	agentID := c.Param("agentID")
 	var body struct {
 		BotID     string `json:"botId"`
 		BotSecret string `json:"botSecret"`
 	}
 	if err := c.ShouldBindJSON(&body); err != nil {
+		logging.G(ctx).Errorf("agenthub: invalid request body: %v", err)
 		httputil.WriteError(c, http.StatusBadRequest, "invalid request body")
 		return
 	}
-	inst, err := h.svc.UpdateWecomConfig(c.Request.Context(), agentID, body.BotID, body.BotSecret)
+	inst, err := h.svc.UpdateWecomConfig(ctx, agentID, body.BotID, body.BotSecret)
 	if err != nil {
-		writeServiceError(c, err)
+		writeServiceError(c, err, agentID)
 		return
 	}
 	httputil.WriteJSON(c, http.StatusOK, inst)
@@ -305,29 +331,37 @@ func (h *AgentHubHandler) UpdateWecomConfig(c *gin.Context) {
 // GetSettings handles GET /agenthub/settings.
 func (h *AgentHubHandler) GetSettings(c *gin.Context) {
 	ctx := c.Request.Context()
+	getSetting := func(key string) string {
+		value, err := h.store.GetSetting(ctx, key)
+		if err != nil {
+			logging.G(ctx).Errorf("agenthub: failed to read setting %q: %v (using default)", key, err)
+			return ""
+		}
+		return value
+	}
 
-	provider, _ := h.store.GetSetting(ctx, "llm_provider")
+	provider := getSetting("llm_provider")
 	if provider == "" {
 		provider = "deepseek"
 	}
-	baseURL, _ := h.store.GetSetting(ctx, "llm_base_url")
+	baseURL := getSetting("llm_base_url")
 	if baseURL == "" {
 		baseURL = "https://api.deepseek.com"
 	}
-	model, _ := h.store.GetSetting(ctx, "llm_model")
+	model := getSetting("llm_model")
 	if model == "" {
 		model = "deepseek/deepseek-v4-flash"
 	}
-	credentialMode, _ := h.store.GetSetting(ctx, "llm_credential_mode")
+	credentialMode := getSetting("llm_credential_mode")
 	if credentialMode == "" {
 		credentialMode = "egress"
 	}
 
 	// Check if LLM API key is configured.
 	// Matches old CubeAPI: try llm_api_key first, then deepseek_api_key.
-	rawApiKey, _ := h.store.GetSetting(ctx, "llm_api_key")
+	rawApiKey := getSetting("llm_api_key")
 	if rawApiKey == "" {
-		rawApiKey, _ = h.store.GetSetting(ctx, "deepseek_api_key")
+		rawApiKey = getSetting("deepseek_api_key")
 	}
 	apiKey := decryptSetting(rawApiKey)
 	apiKeyConfigured := apiKey != ""
@@ -339,7 +373,7 @@ func (h *AgentHubHandler) GetSettings(c *gin.Context) {
 		apiKeyMasked = &masked
 	}
 
-	gatewayDomain, _ := h.store.GetSetting(ctx, "gateway_domain")
+	gatewayDomain := getSetting("gateway_domain")
 	var gatewayDomainPtr *string
 	if gatewayDomain != "" {
 		gatewayDomainPtr = &gatewayDomain
@@ -363,8 +397,10 @@ func (h *AgentHubHandler) GetSettings(c *gin.Context) {
 
 // UpdateSettings handles PUT /agenthub/settings.
 func (h *AgentHubHandler) UpdateSettings(c *gin.Context) {
+	ctx := c.Request.Context()
 	var body map[string]string
 	if err := c.ShouldBindJSON(&body); err != nil {
+		logging.G(ctx).Errorf("agenthub: invalid request body: %v", err)
 		httputil.WriteError(c, http.StatusBadRequest, "invalid request body")
 		return
 	}
@@ -379,25 +415,33 @@ func (h *AgentHubHandler) UpdateSettings(c *gin.Context) {
 		"llmCredentialMode": "llm_credential_mode",
 		"gatewayDomain":     "gateway_domain",
 	}
+	// Two-pass write: encrypt/validate all keys first, then persist. A 500 on
+	// the encrypt pass leaves the DB untouched; the batch persist is atomic
+	// (SetSettingsTx), so a mid-batch failure rolls back everything.
+	prepared := make(map[string]string, len(body))
 	for jsonKey, value := range body {
+		if value == "" {
+			continue // skip empty values
+		}
 		dbKey := jsonKey
 		if mapped, ok := keyMap[jsonKey]; ok {
 			dbKey = mapped
 		}
-		if value == "" {
-			continue // skip empty values
-		}
-		// Encrypt API keys before storing
 		if dbKey == "deepseek_api_key" || dbKey == "llm_api_key" {
 			enc, err := crypto.EncryptSecret(value)
-			if err == nil {
-				value = enc
+			if err != nil {
+				logging.G(ctx).Errorf("agenthub: failed to encrypt setting: key=%s: %v", jsonKey, err)
+				httputil.WriteError(c, http.StatusInternalServerError, "failed to update setting "+jsonKey)
+				return
 			}
+			value = enc
 		}
-		if err := h.store.SetSetting(c.Request.Context(), dbKey, value); err != nil {
-			httputil.WriteError(c, http.StatusInternalServerError, "failed to update setting "+jsonKey+": "+err.Error())
-			return
-		}
+		prepared[dbKey] = value
+	}
+	if err := h.store.SetSettingsTx(ctx, prepared); err != nil {
+		logging.G(ctx).Errorf("agenthub: failed to update settings atomically: %v", err)
+		httputil.WriteError(c, http.StatusInternalServerError, "failed to update settings: "+err.Error())
+		return
 	}
 
 	// Return updated settings (same format as GET)
@@ -406,9 +450,12 @@ func (h *AgentHubHandler) UpdateSettings(c *gin.Context) {
 
 // ListSnapshots handles GET /agenthub/instances/{agentID}/snapshots.
 func (h *AgentHubHandler) ListSnapshots(c *gin.Context) {
+	ctx := c.Request.Context()
 	agentID := c.Param("agentID")
-	snapshots, err := h.store.ListAgentSnapshots(c.Request.Context(), agentID)
+	snapshots, err := h.store.ListAgentSnapshots(ctx, agentID)
 	if err != nil {
+		ctx = updateTraceAndLogger(ctx, cubelog.GetTraceInfo(ctx), agentID, "", 0)
+		logging.G(ctx).Errorf("agenthub: failed to list snapshots: %v", err)
 		httputil.WriteError(c, http.StatusInternalServerError, "failed to list snapshots: "+err.Error())
 		return
 	}
@@ -417,10 +464,11 @@ func (h *AgentHubHandler) ListSnapshots(c *gin.Context) {
 
 // DeleteSnapshot handles DELETE /agenthub/instances/{agentID}/snapshots/{snapshotID}.
 func (h *AgentHubHandler) DeleteSnapshot(c *gin.Context) {
+	ctx := c.Request.Context()
 	agentID := c.Param("agentID")
 	snapshotID := c.Param("snapshotID")
-	if err := h.svc.DeleteSnapshot(c.Request.Context(), agentID, snapshotID); err != nil {
-		writeServiceError(c, err)
+	if err := h.svc.DeleteSnapshot(ctx, agentID, snapshotID); err != nil {
+		writeServiceError(c, err, agentID)
 		return
 	}
 	httputil.WriteNoContent(c)
@@ -430,13 +478,18 @@ func (h *AgentHubHandler) DeleteSnapshot(c *gin.Context) {
 // Probes the OpenClaw gateway via the sandbox proxy
 // get_agent_gateway_health). Returns { "ready": bool }.
 func (h *AgentHubHandler) GatewayHealth(c *gin.Context) {
+	ctx := c.Request.Context()
 	agentID := c.Param("agentID")
-	inst, err := h.store.GetInstance(c.Request.Context(), agentID)
+	inst, err := h.store.GetInstance(ctx, agentID)
 	if err != nil {
+		ctx = updateTraceAndLogger(ctx, cubelog.GetTraceInfo(ctx), agentID, "", 0)
+		logging.G(ctx).Errorf("agenthub: failed to get instance: %v", err)
 		httputil.WriteError(c, http.StatusInternalServerError, "failed to get instance: "+err.Error())
 		return
 	}
 	if inst == nil {
+		ctx = updateTraceAndLogger(ctx, cubelog.GetTraceInfo(ctx), agentID, "", 0)
+		logging.G(ctx).Errorf("agenthub: instance not found")
 		httputil.WriteError(c, http.StatusNotFound, "instance not found")
 		return
 	}
@@ -476,6 +529,7 @@ func (h *AgentHubHandler) CreateInstance(c *gin.Context) {
 		BotSecret       *string `json:"botSecret"`
 	}
 	if err := c.ShouldBindJSON(&req); err != nil {
+		logging.G(c.Request.Context()).Errorf("agenthub: invalid request body: %v", err)
 		httputil.WriteError(c, http.StatusBadRequest, "invalid request body")
 		return
 	}
@@ -514,12 +568,13 @@ func (h *AgentHubHandler) CreateInstance(c *gin.Context) {
 		BotSecret:       botSecret,
 	})
 	if err != nil {
-		writeServiceError(c, err)
+		writeServiceErrorNoID(c, err)
 		return
 	}
 	httputil.WriteJSON(c, http.StatusCreated, res.Instance)
 }
 func (h *AgentHubHandler) RegisterMarketTemplate(c *gin.Context) {
+	ctx := c.Request.Context()
 	var req struct {
 		TemplateID  string  `json:"templateId"`
 		Name        *string `json:"name"`
@@ -528,10 +583,12 @@ func (h *AgentHubHandler) RegisterMarketTemplate(c *gin.Context) {
 		Recommended bool    `json:"recommended"`
 	}
 	if err := c.ShouldBindJSON(&req); err != nil {
+		logging.G(ctx).Errorf("agenthub: invalid request body: %v", err)
 		httputil.WriteError(c, http.StatusBadRequest, "invalid request body")
 		return
 	}
 	if req.TemplateID == "" {
+		logging.G(ctx).Errorf("agenthub: templateId is required")
 		httputil.WriteError(c, http.StatusBadRequest, "templateId is required")
 		return
 	}
@@ -547,12 +604,13 @@ func (h *AgentHubHandler) RegisterMarketTemplate(c *gin.Context) {
 	if req.Version != nil {
 		version = *req.Version
 	}
-	err := h.store.DB().WithContext(c.Request.Context()).Exec(
+	err := h.store.DB().WithContext(ctx).Exec(
 		`INSERT INTO t_agenthub_template (template_id, name, source_agent_id, source_snapshot_id, source_sandbox_id, model, version)
 		 VALUES (?, ?, 'market', '', '', ?, ?)`,
 		req.TemplateID, name, model, version,
 	).Error
 	if err != nil {
+		logging.G(ctx).Errorf("agenthub: failed to register market template: templateID=%s: %v", req.TemplateID, err)
 		httputil.WriteError(c, http.StatusInternalServerError, "failed to register template: "+err.Error())
 		return
 	}
@@ -560,29 +618,33 @@ func (h *AgentHubHandler) RegisterMarketTemplate(c *gin.Context) {
 }
 
 func (h *AgentHubHandler) UpdateTemplate(c *gin.Context) {
+	ctx := c.Request.Context()
 	templateID := c.Param("templateID")
 	var req struct {
 		Name        *string `json:"name"`
 		Recommended *bool   `json:"recommended"`
 	}
 	if err := c.ShouldBindJSON(&req); err != nil {
+		logging.G(ctx).Errorf("agenthub: invalid request body: %v", err)
 		httputil.WriteError(c, http.StatusBadRequest, "invalid request body")
 		return
 	}
 	if req.Name != nil {
-		if err := h.store.DB().WithContext(c.Request.Context()).Exec(
+		if err := h.store.DB().WithContext(ctx).Exec(
 			`UPDATE t_agenthub_template SET name = ? WHERE template_id = ? AND deleted_at IS NULL`,
 			*req.Name, templateID,
 		).Error; err != nil {
+			logging.G(ctx).Errorf("agenthub: failed to update template name: templateID=%s: %v", templateID, err)
 			httputil.WriteError(c, http.StatusInternalServerError, "failed to update template: "+err.Error())
 			return
 		}
 	}
 	if req.Recommended != nil {
-		if err := h.store.DB().WithContext(c.Request.Context()).Exec(
+		if err := h.store.DB().WithContext(ctx).Exec(
 			`UPDATE t_agenthub_template SET recommended = ? WHERE template_id = ? AND deleted_at IS NULL`,
 			*req.Recommended, templateID,
 		).Error; err != nil {
+			logging.G(ctx).Errorf("agenthub: failed to update template recommended: templateID=%s: %v", templateID, err)
 			httputil.WriteError(c, http.StatusInternalServerError, "failed to update template: "+err.Error())
 			return
 		}
@@ -591,6 +653,7 @@ func (h *AgentHubHandler) UpdateTemplate(c *gin.Context) {
 }
 
 func (h *AgentHubHandler) CreateSnapshot(c *gin.Context) {
+	ctx := c.Request.Context()
 	agentID := c.Param("agentID")
 	var req struct {
 		Name *string `json:"name"`
@@ -600,17 +663,18 @@ func (h *AgentHubHandler) CreateSnapshot(c *gin.Context) {
 	if req.Name != nil {
 		name = *req.Name
 	}
-	res, err := h.svc.CreateSnapshot(c.Request.Context(), service.CreateSnapshotRequest{
+	res, err := h.svc.CreateSnapshot(ctx, service.CreateSnapshotRequest{
 		AgentID: agentID,
 		Name:    name,
 	})
 	if err != nil {
-		writeServiceError(c, err)
+		writeServiceError(c, err, agentID)
 		return
 	}
 	httputil.WriteJSON(c, http.StatusCreated, res.Body)
 }
 func (h *AgentHubHandler) UpdateSnapshot(c *gin.Context) {
+	ctx := c.Request.Context()
 	agentID := c.Param("agentID")
 	snapshotID := c.Param("snapshotID")
 	var req struct {
@@ -618,23 +682,28 @@ func (h *AgentHubHandler) UpdateSnapshot(c *gin.Context) {
 		IsHealthy *bool   `json:"isHealthy"`
 	}
 	if err := c.ShouldBindJSON(&req); err != nil {
+		logging.G(ctx).Errorf("agenthub: invalid request body: %v", err)
 		httputil.WriteError(c, http.StatusBadRequest, "invalid request body")
 		return
 	}
 	if req.Name != nil {
-		if err := h.store.DB().WithContext(c.Request.Context()).Exec(
+		if err := h.store.DB().WithContext(ctx).Exec(
 			`UPDATE t_agenthub_snapshot SET name = ? WHERE snapshot_id = ? AND agent_id = ? AND deleted_at IS NULL`,
 			*req.Name, snapshotID, agentID,
 		).Error; err != nil {
+			ctx = updateTraceAndLogger(ctx, cubelog.GetTraceInfo(ctx), agentID, "", 0)
+			logging.G(ctx).Errorf("agenthub: failed to update snapshot name: %v", err)
 			httputil.WriteError(c, http.StatusInternalServerError, "failed to update snapshot: "+err.Error())
 			return
 		}
 	}
 	if req.IsHealthy != nil {
-		if err := h.store.DB().WithContext(c.Request.Context()).Exec(
+		if err := h.store.DB().WithContext(ctx).Exec(
 			`UPDATE t_agenthub_snapshot SET is_healthy = ? WHERE snapshot_id = ? AND agent_id = ? AND deleted_at IS NULL`,
 			*req.IsHealthy, snapshotID, agentID,
 		).Error; err != nil {
+			ctx = updateTraceAndLogger(ctx, cubelog.GetTraceInfo(ctx), agentID, "", 0)
+			logging.G(ctx).Errorf("agenthub: failed to update snapshot isHealthy: %v", err)
 			httputil.WriteError(c, http.StatusInternalServerError, "failed to update snapshot: "+err.Error())
 			return
 		}
@@ -643,25 +712,28 @@ func (h *AgentHubHandler) UpdateSnapshot(c *gin.Context) {
 }
 
 func (h *AgentHubHandler) RollbackAgent(c *gin.Context) {
+	ctx := c.Request.Context()
 	agentID := c.Param("agentID")
 	var req struct {
 		SnapshotID string `json:"snapshotId"`
 	}
 	if err := c.ShouldBindJSON(&req); err != nil {
+		logging.G(ctx).Errorf("agenthub: invalid request body: %v", err)
 		httputil.WriteError(c, http.StatusBadRequest, "invalid request body")
 		return
 	}
-	if err := h.svc.RollbackAgent(c.Request.Context(), agentID, req.SnapshotID); err != nil {
-		writeServiceError(c, err)
+	if err := h.svc.RollbackAgent(ctx, agentID, req.SnapshotID); err != nil {
+		writeServiceError(c, err, agentID)
 		return
 	}
 	httputil.WriteJSON(c, http.StatusOK, map[string]string{"status": "rolled-back"})
 }
 func (h *AgentHubHandler) RecoverAgent(c *gin.Context) {
+	ctx := c.Request.Context()
 	agentID := c.Param("agentID")
-	res, err := h.svc.RecoverAgent(c.Request.Context(), agentID)
+	res, err := h.svc.RecoverAgent(ctx, agentID)
 	if err != nil {
-		writeServiceError(c, err)
+		writeServiceError(c, err, agentID)
 		return
 	}
 	body := map[string]interface{}{
@@ -675,6 +747,7 @@ func (h *AgentHubHandler) RecoverAgent(c *gin.Context) {
 	httputil.WriteJSON(c, http.StatusOK, body)
 }
 func (h *AgentHubHandler) CloneAgent(c *gin.Context) {
+	ctx := c.Request.Context()
 	agentID := c.Param("agentID")
 	var req struct {
 		Name       *string `json:"name"`
@@ -689,18 +762,19 @@ func (h *AgentHubHandler) CloneAgent(c *gin.Context) {
 	if req.SnapshotID != nil {
 		snapshotID = strings.TrimSpace(*req.SnapshotID)
 	}
-	res, err := h.svc.CloneAgent(c.Request.Context(), service.CloneAgentRequest{
+	res, err := h.svc.CloneAgent(ctx, service.CloneAgentRequest{
 		AgentID:    agentID,
 		Name:       name,
 		SnapshotID: snapshotID,
 	})
 	if err != nil {
-		writeServiceError(c, err)
+		writeServiceError(c, err, agentID)
 		return
 	}
 	httputil.WriteJSON(c, http.StatusCreated, res.Instance)
 }
 func (h *AgentHubHandler) PublishTemplate(c *gin.Context) {
+	ctx := c.Request.Context()
 	agentID := c.Param("agentID")
 	var req struct {
 		Name       *string `json:"name"`
@@ -715,13 +789,13 @@ func (h *AgentHubHandler) PublishTemplate(c *gin.Context) {
 	if req.SnapshotID != nil {
 		snapshotID = strings.TrimSpace(*req.SnapshotID)
 	}
-	res, err := h.svc.PublishTemplate(c.Request.Context(), service.PublishTemplateRequest{
+	res, err := h.svc.PublishTemplate(ctx, service.PublishTemplateRequest{
 		AgentID:    agentID,
 		Name:       name,
 		SnapshotID: snapshotID,
 	})
 	if err != nil {
-		writeServiceError(c, err)
+		writeServiceError(c, err, agentID)
 		return
 	}
 	httputil.WriteJSON(c, http.StatusCreated, map[string]string{

--- a/CubeOps/internal/handler/agenthub_fault_injection_test.go
+++ b/CubeOps/internal/handler/agenthub_fault_injection_test.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
-	"strings"
 	"testing"
 
 	"github.com/tencentcloud/CubeSandbox/CubeOps/internal/cubemaster"
@@ -121,10 +120,10 @@ func TestAgentHub_DeleteInstance_SendsRequestIDAndCubebox(t *testing.T) {
 		t.Fatalf("status = %d, want 204; body=%s", w.Code, w.Body.String())
 	}
 
-	// R07 fix: request_id must be present and non-empty.
+	// requestID must equal the inbound trace RequestID.
 	reqID, ok := capturedBody["requestID"].(string)
-	if !ok || reqID == "" {
-		t.Errorf("request_id = %v, want non-empty string", capturedBody["requestID"])
+	if !ok || reqID != "test-req-id" {
+		t.Errorf("requestID = %v, want %q", capturedBody["requestID"], "test-req-id")
 	}
 	// R07 fix: instance_type must be "cubebox", not "openclaw" (inst.Engine).
 	instType, ok := capturedBody["instance_type"].(string)
@@ -274,10 +273,10 @@ func TestAgentHub_Rollback_SendsRequestID(t *testing.T) {
 		t.Fatalf("status = %d, want 200; body=%s", w.Code, w.Body.String())
 	}
 
-	// R08 fix: request_id must be present and non-empty.
+	//requestID must equal the inbound trace RequestID.
 	reqID, ok := capturedBody["requestID"].(string)
-	if !ok || reqID == "" {
-		t.Errorf("request_id = %v, want non-empty string; full body = %v", capturedBody["requestID"], capturedBody)
+	if !ok || reqID != "test-req-id" {
+		t.Errorf("requestID = %v, want %q", capturedBody["requestID"], "test-req-id")
 	}
 	// R08 fix: sandbox_id must be present.
 	sbID, ok := capturedBody["sandbox_id"].(string)
@@ -371,13 +370,10 @@ func TestAgentHub_R10_CompensateDeleteOnApplyFailure(t *testing.T) {
 		if sid != createdSandboxID {
 			t.Errorf("compensation DeleteSandbox called with sandbox_id=%q, want %q", sid, createdSandboxID)
 		}
-		// R07/R10: request_id must be present and non-empty.
+		// requestID must equal the inbound trace RequestID.
 		reqID, _ := reqMap["requestID"].(string)
-		if reqID == "" {
-			t.Error("compensation DeleteSandbox: request_id is empty, want non-empty")
-		}
-		if reqID != "" && !strings.HasPrefix(reqID, "cubeops-compensate-") {
-			t.Errorf("compensation DeleteSandbox: request_id = %q, want prefix \"cubeops-compensate-\"", reqID)
+		if reqID != "test-req-id" {
+			t.Errorf("compensation DeleteSandbox: requestID = %q, want %q", reqID, "test-req-id")
 		}
 		// R07/R10: instance_type must be "cubebox".
 		instType, _ := reqMap["instance_type"].(string)
@@ -458,14 +454,10 @@ func TestAgentHub_Recover_SendsRequestID(t *testing.T) {
 	// the rollback request body was correct.
 	w := doRequest(t, env, "POST", "/api/v1/agenthub/instances/agent-rec/recover", "")
 
-	// R08 fix: request_id must be present and non-empty.
+	//requestID must equal the inbound trace RequestID.
 	reqID, ok := capturedBody["requestID"].(string)
-	if !ok || reqID == "" {
-		t.Errorf("request_id = %v, want non-empty string; full body = %v", capturedBody["requestID"], capturedBody)
-	}
-	// R08 fix: the request_id must have the "cubeops-recover-" prefix.
-	if reqID != "" && !strings.HasPrefix(reqID, "cubeops-recover-") {
-		t.Errorf("request_id = %q, want prefix \"cubeops-recover-\"", reqID)
+	if !ok || reqID != "test-req-id" {
+		t.Errorf("requestID = %v, want %q; full body = %v", capturedBody["requestID"], "test-req-id", capturedBody)
 	}
 	// R08 fix: sandbox_id must be present.
 	sbID, ok := capturedBody["sandbox_id"].(string)
@@ -505,14 +497,10 @@ func TestAgentHub_PublishTemplate_SendsRequestID(t *testing.T) {
 		t.Fatalf("status = %d, want 201; body=%s", w.Code, w.Body.String())
 	}
 
-	// R08 fix: request_id must be present and non-empty.
+	// requestID must equal the inbound trace RequestID.
 	reqID, ok := capturedBody["requestID"].(string)
-	if !ok || reqID == "" {
-		t.Errorf("request_id = %v, want non-empty string; full body = %v", capturedBody["requestID"], capturedBody)
-	}
-	// R08 fix: the request_id must have the "cubeops-publish-" prefix.
-	if reqID != "" && !strings.HasPrefix(reqID, "cubeops-publish-") {
-		t.Errorf("request_id = %q, want prefix \"cubeops-publish-\"", reqID)
+	if !ok || reqID != "test-req-id" {
+		t.Errorf("requestID = %v, want %q; full body = %v", capturedBody["requestID"], "test-req-id", capturedBody)
 	}
 	// R08 fix: sandbox_id must be present.
 	sbID, ok := capturedBody["sandbox_id"].(string)
@@ -589,21 +577,10 @@ func TestAgentHub_CloneAgent_ApplyFailureSendsRequestID(t *testing.T) {
 		t.Fatal("expected DeleteSandbox to be called as compensation after clone apply failure, but it was not (S3)")
 	}
 
-	// S3 fix: must use "requestID" (not "request_id" or "RequestID").
+	//requestID must equal the inbound trace RequestID.
 	reqID, ok := deleteBody["requestID"].(string)
-	if !ok || reqID == "" {
-		t.Errorf("requestID = %v, want non-empty string; body = %v", deleteBody["requestID"], deleteBody)
-	}
-	if _, exists := deleteBody["request_id"]; exists {
-		t.Error(`body contains "request_id" — Clone compensation must use "requestID" (S3)`)
-	}
-	if _, exists := deleteBody["RequestID"]; exists {
-		t.Error(`body contains "RequestID" — Clone compensation must use "requestID" (S3)`)
-	}
-
-	// Prefix must be "cubeops-clone-".
-	if reqID != "" && !strings.HasPrefix(reqID, "cubeops-clone-") {
-		t.Errorf("requestID = %q, want prefix \"cubeops-clone-\" (S3)", reqID)
+	if !ok || reqID != "test-req-id" {
+		t.Errorf("requestID = %v, want %q; body = %v", deleteBody["requestID"], "test-req-id", deleteBody)
 	}
 
 	// Sandbox ID must match the created sandbox.
@@ -701,11 +678,8 @@ func TestAgentHub_CloneAgent_UpsertFailureCompensates(t *testing.T) {
 	}
 
 	reqID, ok := deleteBody["requestID"].(string)
-	if !ok || reqID == "" {
-		t.Errorf("requestID = %v, want non-empty; body = %v", deleteBody["requestID"], deleteBody)
-	}
-	if reqID != "" && !strings.HasPrefix(reqID, "cubeops-clone-") {
-		t.Errorf("requestID = %q, want prefix \"cubeops-clone-\" (S3)", reqID)
+	if !ok || reqID != "test-req-id" {
+		t.Errorf("requestID = %v, want %q; body = %v", deleteBody["requestID"], "test-req-id", deleteBody)
 	}
 
 	// No DB record for the clone sandbox.

--- a/CubeOps/internal/handler/clone_compensate_test.go
+++ b/CubeOps/internal/handler/clone_compensate_test.go
@@ -6,18 +6,18 @@ package handler
 import (
 	"context"
 	"encoding/json"
-	"strings"
 	"testing"
+
+	cubelog "github.com/tencentcloud/CubeSandbox/cubelog"
 )
 
-// TestS3_CloneAgent_ApplyFailureSendsRequestID verifies that when
-// CloneAgent's applyOpenclawRuntime fails, the compensation DeleteSandbox
-// request uses "requestID" (not "RequestID" or "request_id") and the
-// prefix is "cubeops-clone-".
-//
-// This tests the code path at agenthub.go:~1984, where the old code used
-// "RequestID" (wrong case). See review S3.
-func TestS3_CloneAgent_ApplyFailureSendsRequestID(t *testing.T) {
+// TestCloneAgent_CompensationCorrelatesRequestID verifies that when
+// CloneAgent's applyOpenclawRuntime fails, the compensation DeleteSandbox body
+// reuses the inbound RequestTrace.RequestID so CubeMaster logs correlate.
+func TestCloneAgent_CompensationCorrelatesRequestID(t *testing.T) {
+	const inboundReqID = "clone-inbound-req-123"
+	ctx := cubelog.WithRequestTrace(context.Background(), &cubelog.RequestTrace{RequestID: inboundReqID})
+
 	var capturedBody map[string]interface{}
 	cm := &fakeCM{
 		deleteSandbox: func(_ context.Context, body interface{}) (json.RawMessage, error) {
@@ -27,105 +27,21 @@ func TestS3_CloneAgent_ApplyFailureSendsRequestID(t *testing.T) {
 		},
 	}
 
-	// Simulate the CloneAgent apply-failure compensation path.
-	// The handler sends: {requestID: "cubeops-clone-<ts>", sandbox_id, instance_type: "cubebox"}
 	h := &AgentHubHandler{cm: cm}
-	h.compensateDeleteSandbox(context.Background(), "sb-clone-test", "clone_upsert")
+	h.compensateDeleteSandbox(ctx, "sb-clone-test", "clone_upsert")
 
 	if capturedBody == nil {
 		t.Fatal("DeleteSandbox was not called")
 	}
-
-	// S3 fix: must use "requestID", NOT "RequestID" or "request_id".
-	reqID, ok := capturedBody["requestID"].(string)
-	if !ok || reqID == "" {
-		t.Errorf("requestID = %v, want non-empty string; body = %v", capturedBody["requestID"], capturedBody)
+	for _, key := range []string{"requestID", "RequestID", "request_id"} {
+		if got := capturedBody[key]; got != inboundReqID {
+			t.Errorf("%s = %v, want %q", key, got, inboundReqID)
+		}
 	}
-	if _, exists := capturedBody["request_id"]; exists {
-		t.Error(`body contains "request_id" — Clone compensation must use "requestID" (S3)`)
-	}
-	if _, exists := capturedBody["RequestID"]; exists {
-		t.Error(`body contains "RequestID" — Clone compensation must use "requestID" (S3)`)
-	}
-
-	// Prefix should indicate clone compensation.
-	if !strings.HasPrefix(reqID, "cubeops-compensate-clone_upsert-") {
-		t.Errorf("requestID = %q, want prefix %q", reqID, "cubeops-compensate-clone_upsert-")
-	}
-
-	// Verify sandbox_id and instance_type are correct.
 	if capturedBody["sandbox_id"] != "sb-clone-test" {
 		t.Errorf("sandbox_id = %v, want %q", capturedBody["sandbox_id"], "sb-clone-test")
 	}
 	if capturedBody["instance_type"] != "cubebox" {
 		t.Errorf("instance_type = %v, want %q", capturedBody["instance_type"], "cubebox")
-	}
-}
-
-// TestS3_CloneAgent_UpsertFailureCompensates verifies that the
-// compensateDeleteSandbox call for Clone UpsertInstance failure uses the
-// correct reason tag "clone_upsert". This distinguishes Clone DB failures
-// from Create DB failures in logs and metrics.
-func TestS3_CloneAgent_UpsertFailureCompensates(t *testing.T) {
-	var capturedBody map[string]interface{}
-	var capturedReason string
-	cm := &fakeCM{
-		deleteSandbox: func(_ context.Context, body interface{}) (json.RawMessage, error) {
-			b, _ := json.Marshal(body)
-			_ = json.Unmarshal(b, &capturedBody)
-			return raw(`{"ret": {"ret_code": 0}}`), nil
-		},
-	}
-
-	h := &AgentHubHandler{cm: cm}
-
-	// Verify clone_upsert compensation (Clone DB failure).
-	h.compensateDeleteSandbox(context.Background(), "sb-clone-db", "clone_upsert")
-	_ = capturedReason // suppress unused
-
-	reqID, ok := capturedBody["requestID"].(string)
-	if !ok {
-		t.Fatal("requestID missing from DeleteSandbox body")
-	}
-
-	// The requestID prefix encodes the reason.
-	if !strings.Contains(reqID, "clone_upsert") {
-		t.Errorf("Clone upsert compensation requestID should contain 'clone_upsert': %s", reqID)
-	}
-}
-
-// TestS3_AllCompensationPathsUseCorrectRequestID verifies that all three
-// compensation paths use "requestID":
-//  1. Create apply failure → compensateDeleteSandbox("apply_openclaw")
-//  2. Create DB failure   → compensateDeleteSandbox("upsert_instance")
-//  3. Clone DB failure    → compensateDeleteSandbox("clone_upsert")
-func TestS3_AllCompensationPathsUseCorrectRequestID(t *testing.T) {
-	reasons := []string{"apply_openclaw", "upsert_instance", "clone_upsert"}
-
-	for _, reason := range reasons {
-		t.Run(reason, func(t *testing.T) {
-			var capturedBody map[string]interface{}
-			cm := &fakeCM{
-				deleteSandbox: func(_ context.Context, body interface{}) (json.RawMessage, error) {
-					b, _ := json.Marshal(body)
-					_ = json.Unmarshal(b, &capturedBody)
-					return raw(`{"ret": {"ret_code": 0}}`), nil
-				},
-			}
-			h := &AgentHubHandler{cm: cm}
-			h.compensateDeleteSandbox(context.Background(), "sb-"+reason, reason)
-
-			reqID, ok := capturedBody["requestID"].(string)
-			if !ok || reqID == "" {
-				t.Errorf("reason=%q: requestID missing or empty", reason)
-				return
-			}
-			if _, exists := capturedBody["request_id"]; exists {
-				t.Errorf("reason=%q: body contains deprecated 'request_id'", reason)
-			}
-			if _, exists := capturedBody["RequestID"]; exists {
-				t.Errorf("reason=%q: body contains wrong-case 'RequestID'", reason)
-			}
-		})
 	}
 }

--- a/CubeOps/internal/handler/cluster.go
+++ b/CubeOps/internal/handler/cluster.go
@@ -11,7 +11,13 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/tencentcloud/CubeSandbox/CubeOps/internal/httputil"
+	"github.com/tencentcloud/CubeSandbox/CubeOps/internal/logging"
 )
+
+// logClusterStep logs a sub-step failure.
+func logClusterStep(ctx context.Context, step string, err error) {
+	logging.G(ctx).Warnf("cluster step %q failed: %v", step, err)
+}
 
 // ClusterHandler handles cluster-related HTTP requests.
 type ClusterHandler struct {
@@ -160,6 +166,7 @@ func (h *ClusterHandler) fetchUsedResources(ctx context.Context) map[string]stru
 } {
 	data, err := h.cm.ListSandboxes(ctx)
 	if err != nil {
+		logClusterStep(ctx, "list sandboxes", err)
 		return map[string]struct {
 			CPUMilli int64
 			MemoryMB int64
@@ -167,6 +174,7 @@ func (h *ClusterHandler) fetchUsedResources(ctx context.Context) map[string]stru
 	}
 	var resp cmSandboxListResponse
 	if err := json.Unmarshal(data, &resp); err != nil {
+		logClusterStep(ctx, "parse sandbox list", err)
 		return map[string]struct {
 			CPUMilli int64
 			MemoryMB int64
@@ -193,34 +201,40 @@ func (h *ClusterHandler) fetchUsedResources(ctx context.Context) map[string]stru
 
 // Overview handles GET /cluster/overview.
 func (h *ClusterHandler) Overview(c *gin.Context) {
-	data, err := h.cm.GetNodes(c.Request.Context())
+	ctx := c.Request.Context()
+	data, err := h.cm.GetNodes(ctx)
 	if err != nil {
+		logging.G(ctx).Errorf("cluster: failed to fetch overview: %v", err)
 		httputil.WriteError(c, http.StatusBadGateway, "failed to fetch cluster overview: "+err.Error())
 		return
 	}
 	var resp cmNodesResponse
 	if err := json.Unmarshal(data, &resp); err != nil {
+		logging.G(ctx).Errorf("cluster: failed to parse nodes response: %v", err)
 		httputil.WriteError(c, http.StatusInternalServerError, "failed to parse nodes response")
 		return
 	}
-	used := h.fetchUsedResources(c.Request.Context())
+	used := h.fetchUsedResources(ctx)
 	overview := buildOverview(resp.Data, used)
 	httputil.WriteJSON(c, http.StatusOK, overview)
 }
 
 // ListNodes handles GET /nodes.
 func (h *ClusterHandler) ListNodes(c *gin.Context) {
-	data, err := h.cm.GetNodes(c.Request.Context())
+	ctx := c.Request.Context()
+	data, err := h.cm.GetNodes(ctx)
 	if err != nil {
+		logging.G(ctx).Errorf("cluster: failed to fetch nodes: %v", err)
 		httputil.WriteError(c, http.StatusBadGateway, "failed to fetch nodes: "+err.Error())
 		return
 	}
 	var resp cmNodesResponse
 	if err := json.Unmarshal(data, &resp); err != nil {
+		logging.G(ctx).Errorf("cluster: failed to parse nodes response: %v", err)
 		httputil.WriteError(c, http.StatusInternalServerError, "failed to parse nodes response")
 		return
 	}
-	used := h.fetchUsedResources(c.Request.Context())
+	used := h.fetchUsedResources(ctx)
 	views := make([]nodeView, 0, len(resp.Data))
 	for _, s := range resp.Data {
 		views = append(views, toNodeView(s, used))
@@ -230,26 +244,30 @@ func (h *ClusterHandler) ListNodes(c *gin.Context) {
 
 // GetNode handles GET /nodes/{nodeID}.
 func (h *ClusterHandler) GetNode(c *gin.Context) {
+	ctx := c.Request.Context()
 	nodeID := c.Param("nodeID")
 	if nodeID == "" {
 		httputil.WriteError(c, http.StatusBadRequest, "nodeID is required")
 		return
 	}
-	data, err := h.cm.GetNode(c.Request.Context(), nodeID)
+	data, err := h.cm.GetNode(ctx, nodeID)
 	if err != nil {
+		logging.G(ctx).Errorf("cluster: failed to fetch node: nodeID=%s: %v", nodeID, err)
 		httputil.WriteError(c, http.StatusBadGateway, "failed to fetch node: "+err.Error())
 		return
 	}
 	var resp cmNodeResponse
 	if err := json.Unmarshal(data, &resp); err != nil {
+		logging.G(ctx).Errorf("cluster: failed to parse node response: nodeID=%s: %v", nodeID, err)
 		httputil.WriteError(c, http.StatusInternalServerError, "failed to parse node response")
 		return
 	}
 	if resp.Data == nil {
+		logging.G(ctx).Errorf("cluster: node not found: nodeID=%s", nodeID)
 		httputil.WriteError(c, http.StatusNotFound, fmt.Sprintf("node %s not found", nodeID))
 		return
 	}
-	used := h.fetchUsedResources(c.Request.Context())
+	used := h.fetchUsedResources(ctx)
 	httputil.WriteJSON(c, http.StatusOK, toNodeView(*resp.Data, used))
 }
 
@@ -258,18 +276,26 @@ func (h *ClusterHandler) GetNode(c *gin.Context) {
 // Empty/missing CubeMaster data returns an empty shell for the UI. Otherwise
 // keys are rewritten with camelCaseJSON (same path as writeSDKResponse).
 func (h *ClusterHandler) Versions(c *gin.Context) {
+	ctx := c.Request.Context()
 	empty := map[string]interface{}{
 		"controlPlane": map[string]string{},
 		"components":   []interface{}{},
 		"nodes":        []interface{}{},
 	}
-	data, err := h.cm.ClusterVersions(c.Request.Context())
+	data, err := h.cm.ClusterVersions(ctx)
 	if err != nil {
+		logging.G(ctx).Errorf("cluster: failed to fetch versions, returning empty shell: %v", err)
 		httputil.WriteJSON(c, http.StatusOK, empty)
 		return
 	}
 	var resp cmResponse
-	if err := json.Unmarshal(data, &resp); err != nil || len(resp.Data) == 0 || string(resp.Data) == "null" {
+	if err := json.Unmarshal(data, &resp); err != nil {
+		logging.G(ctx).Errorf("cluster: failed to parse versions response, returning empty shell: %v", err)
+		httputil.WriteJSON(c, http.StatusOK, empty)
+		return
+	}
+	if len(resp.Data) == 0 || string(resp.Data) == "null" {
+		logging.G(ctx).Infof("cluster: Versions returning empty shell: no data from cubemaster")
 		httputil.WriteJSON(c, http.StatusOK, empty)
 		return
 	}

--- a/CubeOps/internal/handler/compensate_requestid_test.go
+++ b/CubeOps/internal/handler/compensate_requestid_test.go
@@ -6,22 +6,18 @@ package handler
 import (
 	"context"
 	"encoding/json"
-	"strings"
 	"testing"
+
+	cubelog "github.com/tencentcloud/CubeSandbox/cubelog"
 )
 
-// TestS3_DeleteSandboxRequestBody_UsesRequestID verifies that the request
-// body sent to CubeMaster DeleteSandbox uses the JSON key "requestID" (not
-// "request_id" or "RequestID"), matching DeleteCubeSandboxReq's json tag.
-//
-// This is a contract test: it captures the actual map sent by the handler
-// and asserts the field name. The existing fault-injection tests
-// (agenthub_fault_injection_test.go) also assert this, but they require
-// Docker (dockertest). This test runs without Docker by invoking the
-// compensation path directly with a fake CM.
-//
-// See review S3.
-func TestS3_DeleteSandboxRequestBody_UsesRequestID(t *testing.T) {
+// TestCompensateDeleteSandbox_CorrelatesRequestID verifies that the
+// compensation DeleteSandbox body carries the inbound RequestTrace.RequestID
+// so CubeMaster stat logs can be joined with the CubeOps request.
+func TestCompensateDeleteSandbox_CorrelatesRequestID(t *testing.T) {
+	const inboundReqID = "inbound-req-123"
+	ctx := cubelog.WithRequestTrace(context.Background(), &cubelog.RequestTrace{RequestID: inboundReqID})
+
 	var capturedBody map[string]interface{}
 	cm := &fakeCM{
 		deleteSandbox: func(_ context.Context, body interface{}) (json.RawMessage, error) {
@@ -31,37 +27,22 @@ func TestS3_DeleteSandboxRequestBody_UsesRequestID(t *testing.T) {
 		},
 	}
 
-	// compensateDeleteSandbox sends a DeleteSandbox request with a
-	// "requestID" key. We call it directly — it only needs cm, not store.
 	h := &AgentHubHandler{cm: cm}
-	h.compensateDeleteSandbox(context.Background(), "sb-test", "unit-test")
+	h.compensateDeleteSandbox(ctx, "sb-test", "unit-test")
 
 	if capturedBody == nil {
 		t.Fatal("DeleteSandbox was not called")
 	}
-
-	// S3 fix: must use "requestID", NOT "request_id" or "RequestID".
-	reqID, ok := capturedBody["requestID"].(string)
-	if !ok || reqID == "" {
-		t.Errorf("requestID = %v, want non-empty string; full body = %v",
-			capturedBody["requestID"], capturedBody)
-	}
-	if _, exists := capturedBody["request_id"]; exists {
-		t.Error(`body contains "request_id" — must be "requestID" (S3)`)
-	}
-	if _, exists := capturedBody["RequestID"]; exists {
-		t.Error(`body contains "RequestID" — must be "requestID" (S3)`)
-	}
-
-	// Verify the prefix matches the compensation convention.
-	if !strings.HasPrefix(reqID, "cubeops-compensate-") {
-		t.Errorf("requestID = %q, want prefix %q", reqID, "cubeops-compensate-")
+	for _, key := range []string{"requestID", "RequestID", "request_id"} {
+		if got := capturedBody[key]; got != inboundReqID {
+			t.Errorf("%s = %v, want %q", key, got, inboundReqID)
+		}
 	}
 }
 
-// TestS3_DeleteSandboxRequestBody_HasSandboxIDAndInstanceType verifies the
-// other required fields are present in the DeleteSandbox body.
-func TestS3_DeleteSandboxRequestBody_HasSandboxIDAndInstanceType(t *testing.T) {
+// TestCompensateDeleteSandbox_HasSandboxIDAndInstanceType verifies the other
+// required fields are present in the DeleteSandbox body.
+func TestCompensateDeleteSandbox_HasSandboxIDAndInstanceType(t *testing.T) {
 	var capturedBody map[string]interface{}
 	cm := &fakeCM{
 		deleteSandbox: func(_ context.Context, body interface{}) (json.RawMessage, error) {

--- a/CubeOps/internal/handler/fake_cm_handler_test.go
+++ b/CubeOps/internal/handler/fake_cm_handler_test.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/tencentcloud/CubeSandbox/CubeOps/internal/cubemaster"
 	"github.com/tencentcloud/CubeSandbox/CubeOps/internal/handler"
 )
 
@@ -42,45 +43,55 @@ func (f *fakeCMHandler) GetSandbox(ctx context.Context, sandboxID, instanceType 
 	return nil, errMethodNotConfigured("GetSandbox")
 }
 func (f *fakeCMHandler) CreateSandbox(ctx context.Context, body interface{}) (json.RawMessage, error) {
+	cubemaster.EnsureRequestID(ctx, body)
 	if f.createSandbox == nil {
 		return raw(`{"ret":{"ret_code":0},"data":{"sandbox_id":"sb-fake"}}`), nil
 	}
 	return f.createSandbox(ctx, body)
 }
 func (f *fakeCMHandler) DeleteSandbox(ctx context.Context, body interface{}) (json.RawMessage, error) {
+	cubemaster.EnsureRequestID(ctx, body)
 	if f.deleteSandbox == nil {
 		return raw(`{"ret": {"ret_code": 0}}`), nil // default: success
 	}
 	return f.deleteSandbox(ctx, body)
 }
 func (f *fakeCMHandler) UpdateSandbox(ctx context.Context, body interface{}) (json.RawMessage, error) {
+	cubemaster.EnsureRequestID(ctx, body)
 	if f.updateSandbox == nil {
 		return raw(`{"ret": {"ret_code": 0}}`), nil
 	}
 	return f.updateSandbox(ctx, body)
 }
 func (f *fakeCMHandler) ConnectSandboxWithBody(ctx context.Context, body interface{}) (json.RawMessage, error) {
+	cubemaster.EnsureRequestID(ctx, body)
 	return nil, errMethodNotConfigured("ConnectSandboxWithBody")
 }
 func (f *fakeCMHandler) SetSandboxTimeout(ctx context.Context, body interface{}) (json.RawMessage, error) {
+	cubemaster.EnsureRequestID(ctx, body)
 	return nil, errMethodNotConfigured("SetSandboxTimeout")
 }
 func (f *fakeCMHandler) RefreshSandbox(ctx context.Context, body interface{}) (json.RawMessage, error) {
+	cubemaster.EnsureRequestID(ctx, body)
 	return nil, errMethodNotConfigured("RefreshSandbox")
 }
 func (f *fakeCMHandler) GetSandboxLogs(ctx context.Context, body interface{}) (json.RawMessage, error) {
+	cubemaster.EnsureRequestID(ctx, body)
 	return nil, errMethodNotConfigured("GetSandboxLogs")
 }
 func (f *fakeCMHandler) ListSandboxesWithBody(ctx context.Context, body interface{}) (json.RawMessage, error) {
+	cubemaster.EnsureRequestID(ctx, body)
 	return nil, errMethodNotConfigured("ListSandboxesWithBody")
 }
 func (f *fakeCMHandler) CreateSnapshot(ctx context.Context, body interface{}) (json.RawMessage, error) {
+	cubemaster.EnsureRequestID(ctx, body)
 	if f.createSnapshot == nil {
 		return nil, errMethodNotConfigured("CreateSnapshot")
 	}
 	return f.createSnapshot(ctx, body)
 }
 func (f *fakeCMHandler) ListSnapshots(ctx context.Context, params map[string]string) (json.RawMessage, error) {
+	cubemaster.EnsureRequestIDQuery(ctx, params)
 	return nil, errMethodNotConfigured("ListSnapshots")
 }
 func (f *fakeCMHandler) DeleteSnapshot(ctx context.Context, snapshotID string) (json.RawMessage, error) {
@@ -90,6 +101,7 @@ func (f *fakeCMHandler) DeleteSnapshot(ctx context.Context, snapshotID string) (
 	return f.deleteSnapshot(ctx, snapshotID)
 }
 func (f *fakeCMHandler) RollbackSandbox(ctx context.Context, sandboxID string, body interface{}) (json.RawMessage, error) {
+	cubemaster.EnsureRequestID(ctx, body)
 	if f.rollbackSandbox == nil {
 		return nil, errMethodNotConfigured("RollbackSandbox")
 	}
@@ -102,24 +114,29 @@ func (f *fakeCMHandler) ListTemplates(ctx context.Context, templateID string, in
 	return f.listTemplates(ctx, templateID, includeRequest)
 }
 func (f *fakeCMHandler) CreateTemplateFromImage(ctx context.Context, body interface{}) (json.RawMessage, error) {
+	cubemaster.EnsureRequestID(ctx, body)
 	return nil, errMethodNotConfigured("CreateTemplateFromImage")
 }
 func (f *fakeCMHandler) RedoTemplate(ctx context.Context, body interface{}) (json.RawMessage, error) {
+	cubemaster.EnsureRequestID(ctx, body)
 	return nil, errMethodNotConfigured("RedoTemplate")
 }
 func (f *fakeCMHandler) DeleteTemplate(ctx context.Context, body interface{}) (json.RawMessage, error) {
+	cubemaster.EnsureRequestID(ctx, body)
 	return nil, errMethodNotConfigured("DeleteTemplate")
 }
 func (f *fakeCMHandler) GetTemplateBuildStatus(ctx context.Context, buildID string) (json.RawMessage, error) {
 	return nil, errMethodNotConfigured("GetTemplateBuildStatus")
 }
 func (f *fakeCMHandler) StartTemplateBuild(ctx context.Context, buildID string, body interface{}) (json.RawMessage, error) {
+	cubemaster.EnsureRequestID(ctx, body)
 	return nil, errMethodNotConfigured("StartTemplateBuild")
 }
 func (f *fakeCMHandler) GetTemplateCompat(ctx context.Context) (json.RawMessage, error) {
 	return nil, errMethodNotConfigured("GetTemplateCompat")
 }
 func (f *fakeCMHandler) AdoptTemplateCompatBaseline(ctx context.Context, body interface{}) (json.RawMessage, error) {
+	cubemaster.EnsureRequestID(ctx, body)
 	return nil, errMethodNotConfigured("AdoptTemplateCompatBaseline")
 }
 

--- a/CubeOps/internal/handler/fake_cm_test.go
+++ b/CubeOps/internal/handler/fake_cm_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	"github.com/gin-gonic/gin"
+	"github.com/tencentcloud/CubeSandbox/CubeOps/internal/cubemaster"
 )
 
 func init() { gin.SetMode(gin.TestMode) }
@@ -78,60 +79,70 @@ func (f *fakeCM) GetSandbox(ctx context.Context, sandboxID, instanceType string)
 	return f.getSandbox(ctx, sandboxID, instanceType)
 }
 func (f *fakeCM) CreateSandbox(ctx context.Context, body interface{}) (json.RawMessage, error) {
+	cubemaster.EnsureRequestID(ctx, body)
 	if f.createSandbox == nil {
 		return nil, errFakeNotConfigured
 	}
 	return f.createSandbox(ctx, body)
 }
 func (f *fakeCM) DeleteSandbox(ctx context.Context, body interface{}) (json.RawMessage, error) {
+	cubemaster.EnsureRequestID(ctx, body)
 	if f.deleteSandbox == nil {
 		return nil, errFakeNotConfigured
 	}
 	return f.deleteSandbox(ctx, body)
 }
 func (f *fakeCM) UpdateSandbox(ctx context.Context, body interface{}) (json.RawMessage, error) {
+	cubemaster.EnsureRequestID(ctx, body)
 	if f.updateSandbox == nil {
 		return nil, errFakeNotConfigured
 	}
 	return f.updateSandbox(ctx, body)
 }
 func (f *fakeCM) ConnectSandboxWithBody(ctx context.Context, body interface{}) (json.RawMessage, error) {
+	cubemaster.EnsureRequestID(ctx, body)
 	if f.connectSandboxWithBody == nil {
 		return nil, errFakeNotConfigured
 	}
 	return f.connectSandboxWithBody(ctx, body)
 }
 func (f *fakeCM) SetSandboxTimeout(ctx context.Context, body interface{}) (json.RawMessage, error) {
+	cubemaster.EnsureRequestID(ctx, body)
 	if f.setSandboxTimeout == nil {
 		return nil, errFakeNotConfigured
 	}
 	return f.setSandboxTimeout(ctx, body)
 }
 func (f *fakeCM) RefreshSandbox(ctx context.Context, body interface{}) (json.RawMessage, error) {
+	cubemaster.EnsureRequestID(ctx, body)
 	if f.refreshSandbox == nil {
 		return nil, errFakeNotConfigured
 	}
 	return f.refreshSandbox(ctx, body)
 }
 func (f *fakeCM) GetSandboxLogs(ctx context.Context, body interface{}) (json.RawMessage, error) {
+	cubemaster.EnsureRequestID(ctx, body)
 	if f.getSandboxLogs == nil {
 		return nil, errFakeNotConfigured
 	}
 	return f.getSandboxLogs(ctx, body)
 }
 func (f *fakeCM) ListSandboxesWithBody(ctx context.Context, body interface{}) (json.RawMessage, error) {
+	cubemaster.EnsureRequestID(ctx, body)
 	if f.listSandboxesWithBody == nil {
 		return nil, errFakeNotConfigured
 	}
 	return f.listSandboxesWithBody(ctx, body)
 }
 func (f *fakeCM) CreateSnapshot(ctx context.Context, body interface{}) (json.RawMessage, error) {
+	cubemaster.EnsureRequestID(ctx, body)
 	if f.createSnapshot == nil {
 		return nil, errFakeNotConfigured
 	}
 	return f.createSnapshot(ctx, body)
 }
 func (f *fakeCM) ListSnapshots(ctx context.Context, params map[string]string) (json.RawMessage, error) {
+	cubemaster.EnsureRequestIDQuery(ctx, params)
 	if f.listSnapshots == nil {
 		return nil, errFakeNotConfigured
 	}
@@ -144,6 +155,7 @@ func (f *fakeCM) DeleteSnapshot(ctx context.Context, snapshotID string) (json.Ra
 	return f.deleteSnapshot(ctx, snapshotID)
 }
 func (f *fakeCM) RollbackSandbox(ctx context.Context, sandboxID string, body interface{}) (json.RawMessage, error) {
+	cubemaster.EnsureRequestID(ctx, body)
 	if f.rollbackSandbox == nil {
 		return nil, errFakeNotConfigured
 	}
@@ -156,18 +168,21 @@ func (f *fakeCM) ListTemplates(ctx context.Context, templateID string, includeRe
 	return f.listTemplates(ctx, templateID, includeRequest)
 }
 func (f *fakeCM) CreateTemplateFromImage(ctx context.Context, body interface{}) (json.RawMessage, error) {
+	cubemaster.EnsureRequestID(ctx, body)
 	if f.createTemplateFromImage == nil {
 		return nil, errFakeNotConfigured
 	}
 	return f.createTemplateFromImage(ctx, body)
 }
 func (f *fakeCM) RedoTemplate(ctx context.Context, body interface{}) (json.RawMessage, error) {
+	cubemaster.EnsureRequestID(ctx, body)
 	if f.redoTemplate == nil {
 		return nil, errFakeNotConfigured
 	}
 	return f.redoTemplate(ctx, body)
 }
 func (f *fakeCM) DeleteTemplate(ctx context.Context, body interface{}) (json.RawMessage, error) {
+	cubemaster.EnsureRequestID(ctx, body)
 	if f.deleteTemplate == nil {
 		return nil, errFakeNotConfigured
 	}
@@ -180,6 +195,7 @@ func (f *fakeCM) GetTemplateBuildStatus(ctx context.Context, buildID string) (js
 	return f.getTemplateBuildStatus(ctx, buildID)
 }
 func (f *fakeCM) StartTemplateBuild(ctx context.Context, buildID string, body interface{}) (json.RawMessage, error) {
+	cubemaster.EnsureRequestID(ctx, body)
 	if f.startTemplateBuild == nil {
 		return nil, errFakeNotConfigured
 	}
@@ -192,6 +208,7 @@ func (f *fakeCM) GetTemplateCompat(ctx context.Context) (json.RawMessage, error)
 	return f.getTemplateCompat(ctx)
 }
 func (f *fakeCM) AdoptTemplateCompatBaseline(ctx context.Context, body interface{}) (json.RawMessage, error) {
+	cubemaster.EnsureRequestID(ctx, body)
 	if f.adoptTemplateCompatBaseline == nil {
 		return nil, errFakeNotConfigured
 	}

--- a/CubeOps/internal/handler/integration_test.go
+++ b/CubeOps/internal/handler/integration_test.go
@@ -13,12 +13,14 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
 	"github.com/ory/dockertest/v3"
 	"github.com/ory/dockertest/v3/docker"
 	"github.com/tencentcloud/CubeSandbox/CubeDB/dao"
 	"github.com/tencentcloud/CubeSandbox/CubeOps/internal/crypto"
 	"github.com/tencentcloud/CubeSandbox/CubeOps/internal/handler"
 	"github.com/tencentcloud/CubeSandbox/CubeOps/internal/store"
+	cubelog "github.com/tencentcloud/CubeSandbox/cubelog"
 )
 
 func init() { gin.SetMode(gin.TestMode) }
@@ -102,6 +104,7 @@ func newTestEnv(t *testing.T) *testEnv {
 	h := handler.NewAgentHubHandler(s, cm)
 
 	r := gin.New()
+	r.Use(requestTraceMiddleware())
 	g := r.Group("/api/v1")
 	h.Register(g)
 
@@ -116,6 +119,28 @@ func newTestEnv(t *testing.T) *testEnv {
 	}
 }
 
+// requestTraceMiddleware creates a request-scoped RequestTrace from the
+// X-RequestID header (or a fresh UUID) so that handler/service code can
+// correlate outbound CubeMaster requestIDs with the inbound request.
+func requestTraceMiddleware() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		requestID := strings.TrimSpace(c.GetHeader("X-RequestID"))
+		if requestID == "" {
+			requestID = uuid.NewString()
+		}
+		rt := &cubelog.RequestTrace{
+			RequestID: requestID,
+			Action:    c.Request.Method,
+			Caller:    "cubeops-client",
+			Callee:    "cubeops",
+			CallerIP:  c.ClientIP(),
+		}
+		ctx := cubelog.WithRequestTrace(c.Request.Context(), rt)
+		c.Request = c.Request.WithContext(ctx)
+		c.Next()
+	}
+}
+
 // doRequest issues an HTTP request against the test router and returns the
 // response recorder.
 func doRequest(t *testing.T, env *testEnv, method, path, body string) *httptest.ResponseRecorder {
@@ -127,6 +152,7 @@ func doRequest(t *testing.T, env *testEnv, method, path, body string) *httptest.
 	} else {
 		req = httptest.NewRequest(method, path, nil)
 	}
+	req.Header.Set("X-RequestID", "test-req-id")
 	w := httptest.NewRecorder()
 	env.router.ServeHTTP(w, req)
 	return w

--- a/CubeOps/internal/handler/openclaw_apply.go
+++ b/CubeOps/internal/handler/openclaw_apply.go
@@ -56,17 +56,18 @@ var (
 	resolveRuntimePlan         = service.ResolveRuntimePlan
 	applyOpenclawRuntime       = service.ApplyOpenclawRuntime
 	openclawApplySpec          = service.OpenclawApplySpec
-	agenthubNetworkConfig      = service.AgenthubNetworkConfig
-	llmEgressRule              = service.LLMEgressRule
-	decryptSetting             = service.DecryptSetting
-	maskSecret                 = service.MaskSecret
-	newOpenclawPersistID       = service.NewOpenclawPersistID
-	openclawHostStatePath      = service.OpenclawHostStatePath
-	openclawHostSnapshotPath   = service.OpenclawHostSnapshotPath
-	prepareOpenclawStateDir    = service.PrepareOpenclawStateDir
-	copyOpenclawStateDir       = service.CopyOpenclawStateDir
-	openclawHostMountMetadata  = service.OpenclawHostMountMetadata
-	agenthubDistributionScope  = service.AgenthubDistributionScope
+
+	agenthubNetworkConfig     = service.AgenthubNetworkConfig
+	llmEgressRule             = service.LLMEgressRule
+	decryptSetting            = service.DecryptSetting
+	maskSecret                = service.MaskSecret
+	newOpenclawPersistID      = service.NewOpenclawPersistID
+	openclawHostStatePath     = service.OpenclawHostStatePath
+	openclawHostSnapshotPath  = service.OpenclawHostSnapshotPath
+	prepareOpenclawStateDir   = service.PrepareOpenclawStateDir
+	copyOpenclawStateDir      = service.CopyOpenclawStateDir
+	openclawHostMountMetadata = service.OpenclawHostMountMetadata
+	agenthubDistributionScope = service.AgenthubDistributionScope
 )
 
 // runEnvdCommand is kept as a thin wrapper so any future handler code that

--- a/CubeOps/internal/handler/sdk.go
+++ b/CubeOps/internal/handler/sdk.go
@@ -16,8 +16,10 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/tencentcloud/CubeSandbox/CubeOps/internal/cubemaster"
 	"github.com/tencentcloud/CubeSandbox/CubeOps/internal/httputil"
+	"github.com/tencentcloud/CubeSandbox/CubeOps/internal/logging"
 	"github.com/tencentcloud/CubeSandbox/CubeOps/internal/service"
 	"github.com/tencentcloud/CubeSandbox/CubeOps/internal/translator"
+	cubelog "github.com/tencentcloud/CubeSandbox/cubelog"
 )
 
 // DTO / transformation aliases re-exported from package translator so the
@@ -62,18 +64,16 @@ type SDKHandler struct {
 // NewSDKHandler creates a new SDK handler backed by the CubeMaster client.
 func NewSDKHandler(cm CubeMasterClient) *SDKHandler { return &SDKHandler{cm: cm} }
 
-// WithAgentHubService attaches an AgentHubService so that SDK template/snapshot
-// deletions can reverse-sync AgentHub registrations (soft-delete AgentHub
-// templates that referenced the just-deleted infra resource). Returns the
-// receiver for chaining.
+// WithAgentHubService attaches an AgentHubService so SDK template/snapshot
+// deletions can soft-delete AgentHub templates that reference the removed
+// resource. Returns the receiver for chaining.
 func (h *SDKHandler) WithAgentHubService(svc *service.AgentHubService) *SDKHandler {
 	h.agenthubSvc = svc
 	return h
 }
 
-// Register installs the SDK routes on the given router group. The SDK and
-// "v2 SDK" (E2B v2 compatible) prefixes share the same handlers; we register
-// them on a sub-group so the caller can mount at both prefixes.
+// Register installs the SDK and "v2 SDK" (E2B v2 compatible) routes onto a
+// shared sub-group so the caller can mount them at both prefixes.
 func (h *SDKHandler) Register(r *gin.RouterGroup) {
 	// Sandboxes
 	r.GET("/sandboxes", h.ListSandboxes)
@@ -110,46 +110,61 @@ func (h *SDKHandler) Register(r *gin.RouterGroup) {
 
 const sdkInstanceType = "cubebox"
 
-func sdkRequestID() string {
-	return fmt.Sprintf("cubeops-sdk-%d", time.Now().UnixNano())
+// updateTraceAndLogger writes dimensions (InstanceID/InstanceType/RetCode) to
+// rt and rebuilds the cached logger so subsequent log lines pick them up.
+func updateTraceAndLogger(ctx context.Context, rt *cubelog.RequestTrace, instanceID, instanceType string, retCode int) context.Context {
+	if rt == nil {
+		return ctx
+	}
+	if instanceID != "" {
+		rt.InstanceID = instanceID
+	}
+	if instanceType != "" {
+		rt.InstanceType = instanceType
+	}
+	if retCode != 0 {
+		rt.RetCode = int64(retCode)
+	}
+	return logging.WithLogger(ctx, logging.ReNewLogger(ctx))
 }
 
-// writeCMError maps a CubeMaster client error to the correct HTTP response.
-// If the error is a *cubemaster.CMError, it maps ret_code to 404/409/503
-// (with Retry-After for retryable errors). All other errors become 502.
-// This fixes R11: previously every business error was collapsed to 502,
-// losing 404/409/503 semantics that the WebUI relies on for error handling.
+// writeCMError maps a CubeMaster error to an HTTP response: CMError
+// ret_code → 404/409/503 (with Retry-After for retryable); other → 502.
 func writeCMError(c *gin.Context, err error) {
+	ctx := c.Request.Context()
+	rt := cubelog.GetTraceInfo(ctx)
 	var cmErr *cubemaster.CMError
 	if errors.As(err, &cmErr) {
+		ctx = updateTraceAndLogger(ctx, rt, "", sdkInstanceType, cmErr.RetCode)
 		switch {
 		case cmErr.IsNotFound():
+			logging.G(ctx).Errorf("sdk: cubemaster not found: %s", cmErr.RetMsg)
 			httputil.WriteError(c, http.StatusNotFound, cmErr.RetMsg)
 		case cmErr.IsConflict() || cmErr.IsCapacity():
+			logging.G(ctx).Errorf("sdk: cubemaster conflict/capacity: %s", cmErr.RetMsg)
 			httputil.WriteError(c, http.StatusConflict, cmErr.RetMsg)
 		case cmErr.RetryAfter() > 0:
 			c.Header("Retry-After", strconv.Itoa(cmErr.RetryAfter()))
+			logging.G(ctx).Errorf("sdk: cubemaster retryable error: retryAfter=%d: %s", cmErr.RetryAfter(), cmErr.RetMsg)
 			httputil.WriteError(c, http.StatusServiceUnavailable, cmErr.RetMsg)
 		default:
+			logging.G(ctx).Errorf("sdk: cubemaster error: %s", cmErr.RetMsg)
 			httputil.WriteError(c, http.StatusBadGateway, fmt.Sprintf("cubemaster error %d: %s", cmErr.RetCode, cmErr.RetMsg))
 		}
 		return
 	}
+	logging.G(ctx).Errorf("sdk: cubemaster transport error: %v", err)
 	httputil.WriteError(c, http.StatusBadGateway, "cubemaster: "+err.Error())
 }
 
 // longOpTimeout is the per-request deadline for CubeMaster operations that
 // can legitimately take well beyond the default 30 s — currently snapshot
 // create, snapshot rollback, and template/snapshot delete. These are
-// synchronous Cubelet/LVM operations. See R12.
+// synchronous Cubelet/LVM operations.
 const longOpTimeout = 240 * time.Second
 
-// longOpCtx returns a context derived from the request context with a
-// longOpTimeout deadline. It is used for CubeMaster calls that front
-// synchronous, slow operations (snapshot create/rollback, template delete).
-// The caller MUST use this context (not c.Request.Context()) when calling
-// the CubeMaster client, because the HTTP client no longer has a global
-// 30 s timeout (R12 fix in cubemaster.New).
+// longOpCtx returns a request-derived context bounded by longOpTimeout,
+// for synchronous slow CubeMaster calls (snapshot/rollback, template delete).
 func longOpCtx(c *gin.Context) (context.Context, context.CancelFunc) {
 	return context.WithTimeout(c.Request.Context(), longOpTimeout)
 }
@@ -157,11 +172,10 @@ func longOpCtx(c *gin.Context) (context.Context, context.CancelFunc) {
 // ── Response transformation ─────────────────────────────────────────────────
 
 // writeSDKResponse unwraps CubeMaster's {ret, data} envelope, checks ret_code,
-// extracts the data field, converts all keys from snake_case to camelCase,
-// and writes the transformed JSON to the response.
-// For responses without a data field (action endpoints like pause/resume),
-// it returns the raw response with camelCase key conversion.
+// and writes the data payload (or the raw body for action endpoints without
+// a data field) with snake_case keys converted to camelCase.
 func writeSDKResponse(c *gin.Context, raw json.RawMessage) {
+	ctx := c.Request.Context()
 	var env cmEnvelope
 	if err := json.Unmarshal(raw, &env); err != nil {
 		// Not a standard envelope — pass through as-is.
@@ -172,24 +186,31 @@ func writeSDKResponse(c *gin.Context, raw json.RawMessage) {
 	// Check ret_code for errors and map to appropriate HTTP status.
 	if env.Ret != nil && env.Ret.RetCode != 0 && env.Ret.RetCode != 200 {
 		msg := env.Ret.RetMsg
+		ctx = updateTraceAndLogger(ctx, cubelog.GetTraceInfo(ctx), "", sdkInstanceType, env.Ret.RetCode)
 		switch env.Ret.RetCode {
 		case 130404, 404:
 			// Not found — matches old CubeAPI map_err → AppError::NotFound
+			logging.G(ctx).Errorf("sdk: cubemaster not found: %s", msg)
 			httputil.WriteError(c, http.StatusNotFound, msg)
 		case 130409:
 			// Conflict — matches old CubeAPI map_err → AppError::Conflict
+			logging.G(ctx).Errorf("sdk: cubemaster conflict: %s", msg)
 			httputil.WriteError(c, http.StatusConflict, msg)
 		case 400:
+			logging.G(ctx).Errorf("sdk: cubemaster bad request: %s", msg)
 			httputil.WriteError(c, http.StatusBadRequest, msg)
 		case 130490:
 			// Sandbox is pausing — retryable. R11 fix: must be 503, not 502.
 			c.Header("Retry-After", "2")
+			logging.G(ctx).Errorf("sdk: cubemaster sandbox pausing: %s", msg)
 			httputil.WriteError(c, http.StatusServiceUnavailable, msg)
 		case 130589:
 			// Resume failed — retryable. R11 fix: must be 503, not 502.
 			c.Header("Retry-After", "5")
+			logging.G(ctx).Errorf("sdk: cubemaster resume failed: %s", msg)
 			httputil.WriteError(c, http.StatusServiceUnavailable, msg)
 		default:
+			logging.G(ctx).Errorf("sdk: cubemaster error: %s", msg)
 			httputil.WriteError(c, http.StatusBadGateway, fmt.Sprintf("cubemaster error %d: %s", env.Ret.RetCode, msg))
 		}
 		return
@@ -227,6 +248,7 @@ func writeSDKResponse(c *gin.Context, raw json.RawMessage) {
 // Used by rebuild/create template endpoints where the frontend expects
 // a top-level jobID field.
 func writeSDKJobResponse(c *gin.Context, raw json.RawMessage) {
+	ctx := c.Request.Context()
 	var env struct {
 		Ret *cmRet          `json:"ret,omitempty"`
 		Job json.RawMessage `json:"Job,omitempty"`
@@ -237,20 +259,26 @@ func writeSDKJobResponse(c *gin.Context, raw json.RawMessage) {
 	}
 	if env.Ret != nil && env.Ret.RetCode != 0 && env.Ret.RetCode != 200 {
 		msg := env.Ret.RetMsg
+		ctx = updateTraceAndLogger(ctx, cubelog.GetTraceInfo(ctx), "", sdkInstanceType, env.Ret.RetCode)
 		switch env.Ret.RetCode {
 		case 130404, 404:
+			logging.G(ctx).Errorf("sdk: cubemaster not found: %s", msg)
 			httputil.WriteError(c, http.StatusNotFound, msg)
 		case 130409:
+			logging.G(ctx).Errorf("sdk: cubemaster conflict: %s", msg)
 			httputil.WriteError(c, http.StatusConflict, msg)
 		case 130490:
 			// R11 fix: pausing → 503 + Retry-After, not 502.
 			c.Header("Retry-After", "2")
+			logging.G(ctx).Errorf("sdk: cubemaster sandbox pausing: %s", msg)
 			httputil.WriteError(c, http.StatusServiceUnavailable, msg)
 		case 130589:
 			// R11 fix: resume failed → 503 + Retry-After, not 502.
 			c.Header("Retry-After", "5")
+			logging.G(ctx).Errorf("sdk: cubemaster resume failed: %s", msg)
 			httputil.WriteError(c, http.StatusServiceUnavailable, msg)
 		default:
+			logging.G(ctx).Errorf("sdk: cubemaster error: %s", msg)
 			httputil.WriteError(c, http.StatusBadGateway, fmt.Sprintf("cubemaster error %d: %s", env.Ret.RetCode, msg))
 		}
 		return
@@ -267,7 +295,6 @@ func writeSDKJobResponse(c *gin.Context, raw json.RawMessage) {
 // ListSandboxes — GET /api/v1/sdk/sandboxes
 func (h *SDKHandler) ListSandboxes(c *gin.Context) {
 	body := map[string]interface{}{
-		"RequestID":     sdkRequestID(),
 		"instance_type": sdkInstanceType,
 		"start_idx":     0,
 		"size":          500,
@@ -299,8 +326,10 @@ func (h *SDKHandler) ListSandboxes(c *gin.Context) {
 
 // CreateSandbox — POST /api/v1/sdk/sandboxes
 func (h *SDKHandler) CreateSandbox(c *gin.Context) {
+	ctx := c.Request.Context()
 	var req map[string]interface{}
 	if err := c.ShouldBindJSON(&req); err != nil {
+		logging.G(ctx).Errorf("sdk: invalid JSON body: %v", err)
 		httputil.WriteError(c, http.StatusBadRequest, "invalid JSON body")
 		return
 	}
@@ -310,12 +339,12 @@ func (h *SDKHandler) CreateSandbox(c *gin.Context) {
 	// CubeMaster's CreateCubeSandboxReq with required fields.
 	templateID := getString(req, "templateID")
 	if templateID == "" {
+		logging.G(ctx).Errorf("sdk: templateID is required")
 		httputil.WriteError(c, http.StatusBadRequest, "templateID is required")
 		return
 	}
 
 	cmReq := map[string]interface{}{
-		"requestID":     sdkRequestID(),
 		"instance_type": sdkInstanceType,
 		"template_id":   templateID,
 		"annotations": map[string]string{
@@ -330,23 +359,19 @@ func (h *SDKHandler) CreateSandbox(c *gin.Context) {
 		"auto_pause":    false,
 		"auto_resume":   false,
 	}
-	// R13 fix: forward autoPause from the WebUI request instead of hardcoding
-	// false. The WebUI sends autoPause=true when the user wants idle sandboxes
-	// to be paused (not killed) on timeout.
+	// forward autoPause from the request so idle sandboxes are paused (not
+	// killed) on timeout when the WebUI asks for it.
 	if v, ok := req["autoPause"].(bool); ok {
 		cmReq["auto_pause"] = v
 	}
-	// R13 fix: forward alias as a label so CubeMaster/Cubelet can display it.
+	//forward alias as a label so CubeMaster/Cubelet can display it.
 	if alias := getString(req, "alias"); alias != "" {
 		labels := cmReq["labels"].(map[string]string)
 		labels["alias"] = alias
 	}
-	// R13 fix: timeout semantics. The old code hardcoded 86400 as a default
-	// and only overrode it when timeout > 0. But timeout=0 from the WebUI
-	// means "use CubeMaster's default" — we should NOT send 86400 in that
-	// case. Instead, only set timeout when the client explicitly provides a
-	// positive value; omit the field entirely when 0 or absent so CubeMaster
-	// applies its own default.
+	// Only forward timeout when the client sends a positive value; 0 or
+	// absent means "use CubeMaster's default", so omit the field instead
+	// of sending the previous hardcoded 86400.
 	if v, ok := getFloat(req, "timeout"); ok && v > 0 {
 		cmReq["timeout"] = int(v)
 	} else {
@@ -372,36 +397,45 @@ func (h *SDKHandler) CreateSandbox(c *gin.Context) {
 
 // GetSandbox — GET /api/v1/sdk/sandboxes/{id}
 func (h *SDKHandler) GetSandbox(c *gin.Context) {
+	ctx := c.Request.Context()
+	rt := cubelog.GetTraceInfo(ctx)
 	sandboxID := c.Param("id")
-	raw, err := h.cm.GetSandbox(c.Request.Context(), sandboxID, sdkInstanceType)
+	if rt != nil {
+		rt.InstanceID = sandboxID
+		rt.InstanceType = sdkInstanceType
+		ctx = logging.WithLogger(ctx, logging.ReNewLogger(ctx))
+	}
+	raw, err := h.cm.GetSandbox(ctx, sandboxID, sdkInstanceType)
 	if err != nil {
 		writeCMError(c, err)
 		return
 	}
 
-	// Map CubeMaster's ret_code to HTTP status. The previous version
-	// skipped this and returned 200 + null body whenever the sandbox
-	// wasn't found, which violated REST conventions and confused SDK
-	// clients (review-bot flag: "Test gap: Confirms existing bug rather
-	// than correct behavior"). Matches the ret_code handling used by
-	// CreateSandbox and other SDK handlers above.
+	// Map ret_code to HTTP status; without it a missing sandbox would
+	// return 200 + null, violating REST and confusing SDK clients.
 	var env cmEnvelope
 	if err := json.Unmarshal(raw, &env); err == nil && env.Ret != nil && env.Ret.RetCode != 0 && env.Ret.RetCode != 200 {
 		msg := env.Ret.RetMsg
+		ctx = updateTraceAndLogger(ctx, rt, sandboxID, sdkInstanceType, env.Ret.RetCode)
 		switch env.Ret.RetCode {
 		case 130404, 404:
+			logging.G(ctx).Errorf("sdk: cubemaster not found: %s", msg)
 			httputil.WriteError(c, http.StatusNotFound, msg)
 		case 130409:
+			logging.G(ctx).Errorf("sdk: cubemaster conflict: %s", msg)
 			httputil.WriteError(c, http.StatusConflict, msg)
 		case 130490:
 			// R11 fix: pausing → 503 + Retry-After, not 502.
 			c.Header("Retry-After", "2")
+			logging.G(ctx).Errorf("sdk: cubemaster sandbox pausing: %s", msg)
 			httputil.WriteError(c, http.StatusServiceUnavailable, msg)
 		case 130589:
 			// R11 fix: resume failed → 503 + Retry-After, not 502.
 			c.Header("Retry-After", "5")
+			logging.G(ctx).Errorf("sdk: cubemaster resume failed: %s", msg)
 			httputil.WriteError(c, http.StatusServiceUnavailable, msg)
 		default:
+			logging.G(ctx).Errorf("sdk: cubemaster error: %s", msg)
 			httputil.WriteError(c, http.StatusBadGateway, fmt.Sprintf("cubemaster error %d: %s", env.Ret.RetCode, msg))
 		}
 		return
@@ -415,7 +449,6 @@ func (h *SDKHandler) GetSandbox(c *gin.Context) {
 func (h *SDKHandler) DeleteSandbox(c *gin.Context) {
 	sandboxID := c.Param("id")
 	body := map[string]interface{}{
-		"requestID":     sdkRequestID(),
 		"sandbox_id":    sandboxID,
 		"instance_type": sdkInstanceType,
 		"sync":          true,
@@ -455,16 +488,22 @@ func (h *SDKHandler) GetSandboxLogs(c *gin.Context) {
 
 // SetSandboxTimeout — POST /api/v1/sdk/sandboxes/{id}/timeout
 func (h *SDKHandler) SetSandboxTimeout(c *gin.Context) {
+	ctx := c.Request.Context()
 	sandboxID := c.Param("id")
+	if rt := cubelog.GetTraceInfo(ctx); rt != nil {
+		rt.InstanceID = sandboxID
+		rt.InstanceType = sdkInstanceType
+		ctx = logging.WithLogger(ctx, logging.ReNewLogger(ctx))
+	}
 	var req map[string]interface{}
 	if err := c.ShouldBindJSON(&req); err != nil {
+		logging.G(ctx).Errorf("sdk: invalid JSON body: %v", err)
 		httputil.WriteError(c, http.StatusBadRequest, "invalid JSON body")
 		return
 	}
-	req["RequestID"] = sdkRequestID()
 	req["sandboxID"] = sandboxID
 	req["instanceType"] = sdkInstanceType
-	raw, err := h.cm.SetSandboxTimeout(c.Request.Context(), req)
+	raw, err := h.cm.SetSandboxTimeout(ctx, req)
 	if err != nil {
 		writeCMError(c, err)
 		return
@@ -474,16 +513,22 @@ func (h *SDKHandler) SetSandboxTimeout(c *gin.Context) {
 
 // RefreshSandbox — POST /api/v1/sdk/sandboxes/{id}/refreshes
 func (h *SDKHandler) RefreshSandbox(c *gin.Context) {
+	ctx := c.Request.Context()
 	sandboxID := c.Param("id")
+	if rt := cubelog.GetTraceInfo(ctx); rt != nil {
+		rt.InstanceID = sandboxID
+		rt.InstanceType = sdkInstanceType
+		ctx = logging.WithLogger(ctx, logging.ReNewLogger(ctx))
+	}
 	var req map[string]interface{}
 	if err := c.ShouldBindJSON(&req); err != nil {
+		logging.G(ctx).Errorf("sdk: invalid JSON body: %v", err)
 		httputil.WriteError(c, http.StatusBadRequest, "invalid JSON body")
 		return
 	}
-	req["RequestID"] = sdkRequestID()
 	req["sandboxID"] = sandboxID
 	req["instanceType"] = sdkInstanceType
-	raw, err := h.cm.RefreshSandbox(c.Request.Context(), req)
+	raw, err := h.cm.RefreshSandbox(ctx, req)
 	if err != nil {
 		writeCMError(c, err)
 		return
@@ -500,7 +545,6 @@ func (h *SDKHandler) ResumeSandbox(c *gin.Context) { h.sandboxUpdateAction(c, "r
 func (h *SDKHandler) sandboxUpdateAction(c *gin.Context, action string) {
 	sandboxID := c.Param("id")
 	body := map[string]interface{}{
-		"requestID":     sdkRequestID(),
 		"sandbox_id":    sandboxID,
 		"instance_type": sdkInstanceType,
 		"action":        action,
@@ -515,9 +559,14 @@ func (h *SDKHandler) sandboxUpdateAction(c *gin.Context, action string) {
 
 // ConnectSandbox — POST /api/v1/sdk/sandboxes/{id}/connect
 func (h *SDKHandler) ConnectSandbox(c *gin.Context) {
+	ctx := c.Request.Context()
 	sandboxID := c.Param("id")
+	if rt := cubelog.GetTraceInfo(ctx); rt != nil {
+		rt.InstanceID = sandboxID
+		rt.InstanceType = sdkInstanceType
+		ctx = logging.WithLogger(ctx, logging.ReNewLogger(ctx))
+	}
 	body := map[string]interface{}{
-		"requestID":     sdkRequestID(),
 		"sandbox_id":    sandboxID,
 		"instance_type": sdkInstanceType,
 		"timeout":       86400,
@@ -530,7 +579,7 @@ func (h *SDKHandler) ConnectSandbox(c *gin.Context) {
 	if v, ok := req["timeout"]; ok {
 		body["timeout"] = v
 	}
-	raw, err := h.cm.ConnectSandboxWithBody(c.Request.Context(), body)
+	raw, err := h.cm.ConnectSandboxWithBody(ctx, body)
 	if err != nil {
 		writeCMError(c, err)
 		return
@@ -543,7 +592,6 @@ func (h *SDKHandler) ConnectSandbox(c *gin.Context) {
 // ListSnapshots — GET /api/v1/sdk/snapshots
 func (h *SDKHandler) ListSnapshots(c *gin.Context) {
 	params := map[string]string{
-		"request_id":    sdkRequestID(),
 		"instance_type": sdkInstanceType,
 	}
 	for _, k := range []string{"sandbox_id", "name", "status", "limit", "next_token"} {
@@ -561,13 +609,19 @@ func (h *SDKHandler) ListSnapshots(c *gin.Context) {
 
 // CreateSnapshot — POST /api/v1/sdk/sandboxes/{id}/snapshots
 func (h *SDKHandler) CreateSnapshot(c *gin.Context) {
+	ctx := c.Request.Context()
 	sandboxID := c.Param("id")
+	if rt := cubelog.GetTraceInfo(ctx); rt != nil {
+		rt.InstanceID = sandboxID
+		rt.InstanceType = sdkInstanceType
+		ctx = logging.WithLogger(ctx, logging.ReNewLogger(ctx))
+	}
 	var req map[string]interface{}
 	if err := c.ShouldBindJSON(&req); err != nil {
+		logging.G(ctx).Errorf("sdk: invalid JSON body: %v", err)
 		httputil.WriteError(c, http.StatusBadRequest, "invalid JSON body")
 		return
 	}
-	req["request_id"] = sdkRequestID()
 	req["sandbox_id"] = sandboxID
 	ctx, cancel := longOpCtx(c)
 	defer cancel()
@@ -581,13 +635,19 @@ func (h *SDKHandler) CreateSnapshot(c *gin.Context) {
 
 // RollbackSandbox — POST /api/v1/sdk/sandboxes/{id}/rollback
 func (h *SDKHandler) RollbackSandbox(c *gin.Context) {
+	ctx := c.Request.Context()
 	sandboxID := c.Param("id")
+	if rt := cubelog.GetTraceInfo(ctx); rt != nil {
+		rt.InstanceID = sandboxID
+		rt.InstanceType = sdkInstanceType
+		ctx = logging.WithLogger(ctx, logging.ReNewLogger(ctx))
+	}
 	var req map[string]interface{}
 	if err := c.ShouldBindJSON(&req); err != nil {
+		logging.G(ctx).Errorf("sdk: invalid JSON body: %v", err)
 		httputil.WriteError(c, http.StatusBadRequest, "invalid JSON body")
 		return
 	}
-	req["request_id"] = sdkRequestID()
 	req["instance_type"] = sdkInstanceType
 	ctx, cancel := longOpCtx(c)
 	defer cancel()
@@ -615,14 +675,20 @@ func (h *SDKHandler) ListTemplates(c *gin.Context) {
 
 // GetTemplate — GET /api/v1/sdk/templates/{id}
 func (h *SDKHandler) GetTemplate(c *gin.Context) {
+	ctx := c.Request.Context()
 	templateID := c.Param("id")
-	raw, err := h.cm.ListTemplates(c.Request.Context(), templateID, true)
+	if rt := cubelog.GetTraceInfo(ctx); rt != nil {
+		rt.InstanceID = templateID
+		ctx = logging.WithLogger(ctx, logging.ReNewLogger(ctx))
+	}
+	raw, err := h.cm.ListTemplates(ctx, templateID, true)
 	if err != nil {
 		writeCMError(c, err)
 		return
 	}
 	transformed := transformTemplateDetail(raw)
 	if transformed == nil {
+		logging.G(ctx).Errorf("sdk: template not found")
 		httputil.WriteError(c, http.StatusNotFound, "template not found")
 		return
 	}
@@ -630,15 +696,15 @@ func (h *SDKHandler) GetTemplate(c *gin.Context) {
 }
 
 // transformTemplateDetail converts CubeMaster's template detail response to
-// the frontend's expected format. Only top-level keys are converted to
-// camelCase; the nested `replicas` array and `createRequest` object keep
-// their internal snake_case structure (matching old CubeAPI behavior where
-// they were passed through as raw serde_json::Value without conversion).
+// the frontend's expected format. Only top-level keys become camelCase;
+// nested `replicas` and `createRequest` keep their internal snake_case
 
 // CreateTemplate — POST /api/v1/sdk/templates
 func (h *SDKHandler) CreateTemplate(c *gin.Context) {
+	ctx := c.Request.Context()
 	var req map[string]interface{}
 	if err := c.ShouldBindJSON(&req); err != nil {
+		logging.G(ctx).Errorf("sdk: invalid JSON body: %v", err)
 		httputil.WriteError(c, http.StatusBadRequest, "invalid JSON body")
 		return
 	}
@@ -646,18 +712,18 @@ func (h *SDKHandler) CreateTemplate(c *gin.Context) {
 	// Validate required field.
 	image, _ := req["image"].(string)
 	if strings.TrimSpace(image) == "" {
+		logging.G(ctx).Errorf("sdk: image is required")
 		httputil.WriteError(c, http.StatusBadRequest, "image is required")
 		return
 	}
 
 	// Transform frontend request to CubeMaster format (matches old CubeAPI logic).
 	cmReq := transformCreateTemplateRequest(req)
-	cmReq["requestID"] = sdkRequestID()
 	if _, ok := cmReq["instance_type"]; !ok {
 		cmReq["instance_type"] = sdkInstanceType
 	}
 
-	raw, err := h.cm.CreateTemplateFromImage(c.Request.Context(), cmReq)
+	raw, err := h.cm.CreateTemplateFromImage(ctx, cmReq)
 	if err != nil {
 		writeCMError(c, err)
 		return
@@ -667,15 +733,20 @@ func (h *SDKHandler) CreateTemplate(c *gin.Context) {
 
 // RebuildTemplate — POST /api/v1/sdk/templates/{id}
 func (h *SDKHandler) RebuildTemplate(c *gin.Context) {
+	ctx := c.Request.Context()
 	templateID := c.Param("id")
+	if rt := cubelog.GetTraceInfo(ctx); rt != nil {
+		rt.InstanceID = templateID
+		ctx = logging.WithLogger(ctx, logging.ReNewLogger(ctx))
+	}
 	var req map[string]interface{}
 	if err := c.ShouldBindJSON(&req); err != nil {
+		logging.G(ctx).Errorf("sdk: invalid JSON body: %v", err)
 		httputil.WriteError(c, http.StatusBadRequest, "invalid JSON body")
 		return
 	}
-	req["requestID"] = sdkRequestID()
 	req["template_id"] = templateID
-	raw, err := h.cm.RedoTemplate(c.Request.Context(), req)
+	raw, err := h.cm.RedoTemplate(ctx, req)
 	if err != nil {
 		writeCMError(c, err)
 		return
@@ -693,7 +764,6 @@ func (h *SDKHandler) RebuildTemplate(c *gin.Context) {
 func (h *SDKHandler) DeleteTemplate(c *gin.Context) {
 	templateID := c.Param("id")
 	body := map[string]interface{}{
-		"RequestID":     sdkRequestID(),
 		"template_id":   templateID,
 		"instance_type": sdkInstanceType,
 		"sync":          true,
@@ -724,7 +794,6 @@ func (h *SDKHandler) StartTemplateBuild(c *gin.Context) {
 	if req == nil {
 		req = map[string]interface{}{}
 	}
-	req["RequestID"] = sdkRequestID()
 	raw, err := h.cm.StartTemplateBuild(c.Request.Context(), buildID, req)
 	if err != nil {
 		writeCMError(c, err)
@@ -747,8 +816,13 @@ func (h *SDKHandler) GetTemplateBuildStatus(c *gin.Context) {
 // GetTemplateBuildLogs — GET /api/v1/sdk/templates/{id}/builds/{buildID}/logs
 // Matches old CubeAPI behavior: reuses build status endpoint and formats as log lines.
 func (h *SDKHandler) GetTemplateBuildLogs(c *gin.Context) {
+	ctx := c.Request.Context()
 	buildID := c.Param("buildID")
-	raw, err := h.cm.GetTemplateBuildStatus(c.Request.Context(), buildID)
+	if rt := cubelog.GetTraceInfo(ctx); rt != nil {
+		rt.InstanceID = buildID
+		ctx = logging.WithLogger(ctx, logging.ReNewLogger(ctx))
+	}
+	raw, err := h.cm.GetTemplateBuildStatus(ctx, buildID)
 	if err != nil {
 		writeCMError(c, err)
 		return
@@ -757,10 +831,13 @@ func (h *SDKHandler) GetTemplateBuildLogs(c *gin.Context) {
 	// Parse the CubeMaster build status response.
 	var env cmEnvelope
 	if err := json.Unmarshal(raw, &env); err != nil {
+		logging.G(ctx).Errorf("sdk: failed to parse build status: %v", err)
 		httputil.WriteError(c, http.StatusInternalServerError, "failed to parse build status")
 		return
 	}
 	if env.Ret != nil && env.Ret.RetCode != 0 && env.Ret.RetCode != 200 {
+		ctx = updateTraceAndLogger(ctx, cubelog.GetTraceInfo(ctx), buildID, "", env.Ret.RetCode)
+		logging.G(ctx).Errorf("sdk: cubemaster error: %s", env.Ret.RetMsg)
 		httputil.WriteError(c, http.StatusBadGateway, fmt.Sprintf("cubemaster error %d: %s", env.Ret.RetCode, env.Ret.RetMsg))
 		return
 	}
@@ -825,8 +902,10 @@ func (h *SDKHandler) GetTemplateCompat(c *gin.Context) {
 // adopt_template_compat_baseline: sends {action:"adopt_baseline", template_id}
 // to CubeMaster and returns {updated: <count>}.
 func (h *SDKHandler) AdoptTemplateCompatBaseline(c *gin.Context) {
+	ctx := c.Request.Context()
 	templateID := c.Param("id")
 	if templateID == "" {
+		logging.G(ctx).Errorf("sdk: template id is required")
 		httputil.WriteError(c, http.StatusBadRequest, "template id is required")
 		return
 	}

--- a/CubeOps/internal/handler/store.go
+++ b/CubeOps/internal/handler/store.go
@@ -6,7 +6,6 @@ package handler
 import (
 	"context"
 	"fmt"
-	"log/slog"
 	"math"
 	"net/http"
 	"strings"
@@ -18,6 +17,7 @@ import (
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/tencentcloud/CubeSandbox/CubeOps/internal/httputil"
+	"github.com/tencentcloud/CubeSandbox/CubeOps/internal/logging"
 )
 
 // StoreHandler handles store image metadata HTTP requests.
@@ -58,29 +58,27 @@ type StoreMeta struct {
 
 // GetStoreMeta handles GET /store/meta.
 //
-// It returns metadata for the curated set of official images without
-// contacting any registry. Only images that have previously been fetched
-// (and therefore cached by the registry client) will appear with a digest;
-// unknown images are still listed so the frontend can render them.
+// Returns cached metadata for the curated image set without contacting
+// any registry. Images with no prior refresh are still listed so the
+// frontend can render them.
 func (h *StoreHandler) GetStoreMeta(c *gin.Context) {
 	httputil.WriteJSON(c, http.StatusOK, StoreMeta{Images: h.inspectAll(c.Request.Context(), false)})
 }
 
 // RefreshStoreMeta handles POST /store/refresh.
 //
-// It queries each configured registry for the latest manifest digest of
-// the official images using go-containerregistry. No image layers are
-// downloaded; the request only fetches the manifest and config blob
-// (KB-scale), so it is fast and does not require docker on the host.
+// Resolves each curated image's latest manifest digest from upstream
+// registries via go-containerregistry. Only the manifest and config
+// blob are fetched (no layers, no docker daemon).
 func (h *StoreHandler) RefreshStoreMeta(c *gin.Context) {
-	httputil.WriteJSON(c, http.StatusOK, StoreMeta{Images: h.inspectAll(c.Request.Context(), true)})
+	images := h.inspectAll(c.Request.Context(), true)
+	httputil.WriteJSON(c, http.StatusOK, StoreMeta{Images: images})
 }
 
-// inspectAll concurrently inspects each image and returns the metadata
-// slice in storeImages order. When refresh is true it queries the
-// upstream registry for the latest manifest digest; otherwise it
-// returns whatever digest the registry client has cached from a
-// previous refresh.
+// inspectAll resolves metadata for every curated image in parallel
+// and returns the results in storeImages order. When refresh is true
+// it queries the upstream registry; otherwise it returns the cached
+// digest from a previous refresh.
 func (h *StoreHandler) inspectAll(ctx context.Context, refresh bool) []ImageMeta {
 	out := make([]ImageMeta, len(storeImages))
 	var wg sync.WaitGroup
@@ -144,18 +142,14 @@ func newGCRRegistryClient() *gcrRegistryClient {
 	}
 }
 
-// FetchLatest resolves ref via go-containerregistry and caches the
-// result so a subsequent Cached(ref) returns it without network I/O.
-// For multi-arch indexes the library automatically picks the
-// linux/amd64 platform manifest and reports its digest and layer sizes.
-//
-// Errors return nil so the handler can emit a placeholder entry for
-// the frontend; registry resolution failures are logged at warn level
-// so operators see them in production logs.
+// FetchLatest resolves ref via go-containerregistry, picking the
+// linux/amd64 manifest for multi-arch indexes, and caches the result.
+// Errors return nil so the handler can emit a placeholder entry;
+// registry failures are logged at warn level.
 func (c *gcrRegistryClient) FetchLatest(ctx context.Context, ref string) *ImageMeta {
 	parsedRef, err := name.ParseReference(ref)
 	if err != nil {
-		slog.Debug("store: failed to parse image ref", "ref", ref, "err", err)
+		logging.G(ctx).Debugf("store: failed to parse image ref %q: %v", ref, err)
 		return nil
 	}
 
@@ -165,13 +159,13 @@ func (c *gcrRegistryClient) FetchLatest(ctx context.Context, ref string) *ImageM
 		remote.WithPlatform(v1.Platform{OS: "linux", Architecture: "amd64"}),
 	)
 	if err != nil {
-		slog.Warn("store: failed to resolve image", "ref", ref, "err", err)
+		logging.G(ctx).Warnf("store: failed to resolve image %q: %v", ref, err)
 		return nil
 	}
 
 	manifest, err := img.Manifest()
 	if err != nil {
-		slog.Warn("store: failed to read manifest", "ref", ref, "err", err)
+		logging.G(ctx).Warnf("store: failed to read manifest for %q: %v", ref, err)
 		return nil
 	}
 
@@ -182,7 +176,7 @@ func (c *gcrRegistryClient) FetchLatest(ctx context.Context, ref string) *ImageM
 
 	digest, err := img.Digest()
 	if err != nil {
-		slog.Warn("store: failed to read digest", "ref", ref, "err", err)
+		logging.G(ctx).Warnf("store: failed to read digest for %q: %v", ref, err)
 		return nil
 	}
 

--- a/CubeOps/internal/logging/logging.go
+++ b/CubeOps/internal/logging/logging.go
@@ -1,59 +1,56 @@
 // Copyright (c) 2026 Tencent Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-// Package logging initialises structured logging for CubeOps via the
-// shared cubelog library, writing rolling files under the configured
-// directory.
+// Package logging initialises CubeOps logging with the shared cubelog library.
 package logging
 
 import (
 	"context"
 	"fmt"
-	"log/slog"
 	"os"
 	"strings"
 
+	"github.com/tencentcloud/CubeSandbox/CubeOps/internal/version"
 	cubelog "github.com/tencentcloud/CubeSandbox/cubelog"
 )
 
 // Options controls logger initialisation.
 type Options struct {
-	// Level is the log level name: "debug", "info", "warn", "error".
-	// Empty defaults to "info".
-	Level string
-	// LogDir is the directory for file logs. When empty, defaults to
-	// "/data/log/CubeOps".
-	LogDir string
-	// Module is the cubelog module name used in log entries and file
-	// prefixes. Defaults to "cubeops".
-	Module string
-	// FileNum is the number of rotated log files to retain.
-	// Defaults to 10 when zero.
-	FileNum int
-	// FileSizeMB is the max size in MB of a single log file before
-	// rotation. Defaults to 100 when zero.
+	Level      string
+	LogDir     string
+	Module     string
+	FileNum    int
 	FileSizeMB int
 }
 
-// Init configures the global cubelog + slog logger from opts. It must be
-// called once at program start, before any logging is done.
-//
-// cubelog owns the file writers, and a bridge slog handler routes Go
-// slog calls into cubelog so all log lines land in the same rolling
-// files instead of stdout.
+type loggerKey struct{}
+
+// Init configures cubelog and its rolling request/stat outputs.
 func Init(opts Options) {
 	module := strings.TrimSpace(opts.Module)
 	if module == "" {
 		module = "cubeops"
 	}
-
 	logDir := strings.TrimSpace(opts.LogDir)
 	if logDir == "" {
 		logDir = fmt.Sprintf("/data/log/%s", module)
 	}
+
+	// Output-independent config must run before the log-directory setup below;
+	// EnableLogMetric gates Trace() emission, so the stdout fallback would
+	// otherwise drop every trace.
+	cubelog.SetModuleName(module)
+	cubelog.SetVersion(version.ShowVersion())
+	cubelog.EnableLogMetric()
+	cubelog.SetLevel(parseCubeLogLevel(opts.Level))
+	cubelog.SetSkipCallerDepth(0)
+	cubelog.SetCallerPrettyfier(cubelog.SuccinctCallerPath)
+	cubelog.SetReportCaller(parseCubeLogLevel(opts.Level) == cubelog.DEBUG)
+
 	if err := os.MkdirAll(logDir, 0755); err != nil {
-		// Fall back to stdout-only if we cannot create the directory.
-		slog.Error("logging: failed to create log directory, falling back to stdout", "dir", logDir, "error", err)
+		G(context.Background()).Errorf("logging: failed to create log directory, falling back to stdout: dir=%s err=%v", logDir, err)
+		cubelog.SetOutput(os.Stdout)
+		cubelog.SetTraceOutput(os.Stdout)
 		return
 	}
 
@@ -66,77 +63,47 @@ func Init(opts Options) {
 		fileSize = 100
 	}
 
-	// ── Initialise cubelog (same as CubeMaster/Cubelet) ──────────────
-	cubelog.SetModuleName(module)
 	cubelog.EnableFileLog()
-	cubelog.SetSkipCallerDepth(0)
-	cubelog.SetLevel(parseCubeLogLevel(opts.Level))
 	cubelog.Create(logDir)
-
-	// Rolling file writers:
-	//   <module>-req.log   — main business log
-	//   <module>-stat.log  — trace/metric log
-	reqLogName := fmt.Sprintf("%s-req", module)
-	statLogName := fmt.Sprintf("%s-stat", module)
-
-	reqLogWriter := cubelog.NewRollFileWriter(logDir, reqLogName, fileNum, fileSize)
-	cubelog.SetOutput(reqLogWriter)
-
-	statLogWriter := cubelog.NewRollFileWriter(logDir, statLogName, fileNum, fileSize)
-	cubelog.SetTraceOutput(statLogWriter)
-
-	// ── Bridge slog → cubelog ────────────────────────────────────────
-	// CubeOps uses slog throughout its codebase. Route every slog call
-	// through cubelog so the output lands in the same rolling files
-	// instead of going to stdout.
-	slog.SetDefault(slog.New(cubelogSlogHandler{}))
+	cubelog.SetOutput(cubelog.NewRollFileWriter(logDir, module+"-req", fileNum, fileSize))
+	cubelog.SetTraceOutput(cubelog.NewRollFileWriter(logDir, module+"-stat", fileNum, fileSize))
 }
 
-// cubelogSlogHandler is a minimal slog.Handler that forwards all records
-// to cubelog. This keeps the existing slog.Info/Error/... call sites in
-// CubeOps working unchanged while the actual I/O goes through cubelog's
-// file writers.
-type cubelogSlogHandler struct{}
-
-func (cubelogSlogHandler) Enabled(_ context.Context, _ slog.Level) bool {
-	return true
+// WithLogger stores a cubelog entry in a context, matching CubeMaster's
+// request-scoped logging pattern.
+func WithLogger(ctx context.Context, entry *cubelog.Entry) context.Context {
+	return context.WithValue(ctx, loggerKey{}, entry)
 }
 
-func (cubelogSlogHandler) Handle(_ context.Context, r slog.Record) error {
-	var sb strings.Builder
-	sb.WriteString(r.Message)
-	r.Attrs(func(a slog.Attr) bool {
-		sb.WriteByte(' ')
-		sb.WriteString(a.Key)
-		sb.WriteByte('=')
-		sb.WriteString(a.Value.String())
-		return true
-	})
-	msg := sb.String()
-
-	switch {
-	case r.Level >= slog.LevelError:
-		cubelog.Errorf("%s", msg)
-	case r.Level >= slog.LevelWarn:
-		cubelog.Warnf("%s", msg)
-	case r.Level >= slog.LevelInfo:
-		cubelog.Infof("%s", msg)
-	default:
-		cubelog.Debugf("%s", msg)
+// G returns the cubelog entry for ctx, deriving it from RequestTrace when
+// none was stored.
+// Note: the entry snapshots RequestTrace fields, so early handler lines carry
+// RetCode=0 even on later failure; only the -stat trace has the real value.
+// Call ReNewLogger after mutating rt to pick up new values.
+func G(ctx context.Context) *cubelog.Entry {
+	if ctx == nil {
+		ctx = context.Background()
 	}
-	return nil
+	if cached, ok := ctx.Value(loggerKey{}).(*cubelog.Entry); ok && cached != nil {
+		return cached
+	}
+	return cubelog.WithContext(ctx)
 }
 
-func (cubelogSlogHandler) WithAttrs(_ []slog.Attr) slog.Handler { return cubelogSlogHandler{} }
-func (cubelogSlogHandler) WithGroup(_ string) slog.Handler      { return cubelogSlogHandler{} }
+// ReNewLogger rebuilds the context cubelog entry from the current
+// RequestTrace. Call after mutating rt (e.g. setting InstanceID/RetCode) so
+// later log lines pick up the new fields.
+func ReNewLogger(ctx context.Context) *cubelog.Entry {
+	return cubelog.WithContext(ctx)
+}
 
 func parseCubeLogLevel(s string) cubelog.LogLevel {
-	switch strings.ToLower(strings.TrimSpace(s)) {
-	case "debug":
+	switch strings.ToUpper(strings.TrimSpace(s)) {
+	case "DEBUG":
 		return cubelog.DEBUG
-	case "warn", "warning":
+	case "WARN", "WARNING":
 		return cubelog.WARN
-	case "error":
+	case "ERROR":
 		return cubelog.ERROR
 	default:
 		return cubelog.INFO

--- a/CubeOps/internal/logging/logging_test.go
+++ b/CubeOps/internal/logging/logging_test.go
@@ -1,0 +1,43 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package logging
+
+import (
+	"context"
+	"testing"
+
+	cubelog "github.com/tencentcloud/CubeSandbox/cubelog"
+)
+
+func TestGUsesRequestTraceContext(t *testing.T) {
+	ctx := context.Background()
+	entry := G(ctx)
+	if entry == nil {
+		t.Fatal("G returned nil entry")
+	}
+	stored := WithLogger(ctx, entry)
+	if got := G(stored); got != entry {
+		t.Fatal("G did not return the entry stored in context")
+	}
+}
+
+func TestParseCubeLogLevel(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want cubelog.LogLevel
+	}{
+		{name: "debug", in: "debug", want: cubelog.DEBUG},
+		{name: "warning", in: "warning", want: cubelog.WARN},
+		{name: "error", in: "error", want: cubelog.ERROR},
+		{name: "default", in: "unknown", want: cubelog.INFO},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := parseCubeLogLevel(tt.in); got != tt.want {
+				t.Errorf("parseCubeLogLevel(%q) = %v, want %v", tt.in, got, tt.want)
+			}
+		})
+	}
+}

--- a/CubeOps/internal/redact/redact.go
+++ b/CubeOps/internal/redact/redact.go
@@ -16,11 +16,41 @@ package redact
 
 import (
 	"encoding/json"
+	"log/slog"
+	"reflect"
 	"strings"
 )
 
 // redacted is the placeholder written in place of a sensitive value.
 const redacted = "***REDACTED***"
+
+// Secret wraps a credential so that fmt/String/GoString formatting is
+// redacted, but it still json.Marshal()s to the plaintext required by the
+// downstream API.
+//
+// That makes Secret safe for transport only: log codecs honouring MarshalJSON
+// (cubelog's jsoniter does) emit the credential verbatim. So a Secret may only
+// reach a log line via String()/%v, LogValue(), or Value()/JSON() on the
+// enclosing map — the latter also catch Secret leaves under harmless key names.
+type Secret string
+
+func (s Secret) String() string {
+	return redacted
+}
+
+func (s Secret) GoString() string {
+	return redacted
+}
+
+func (s Secret) MarshalJSON() ([]byte, error) {
+	return json.Marshal(string(s))
+}
+
+// LogValue implements slog.LogValuer so structured slog handlers render the
+// placeholder rather than invoking MarshalJSON on the plaintext.
+func (s Secret) LogValue() slog.Value {
+	return slog.StringValue(redacted)
+}
 
 // sensitiveKeys is the lower-cased set of map keys that must never be
 // logged in plaintext. The set is matched case-insensitively and against
@@ -60,17 +90,18 @@ func sensitiveKey(name string) bool {
 	return false
 }
 
-// Value returns a redacted copy of v. Only the following Go types are
-// traversed: map[string]interface{} and []interface{}. Other types are
-// returned unchanged (the caller is expected to feed the result through
-// json.Marshal so primitive leaves, including strings, are written
-// verbatim).
+// Value returns a redacted copy of v. Maps and slices of any concrete type are
+// traversed (reflection covers e.g. []map[string]interface{}); other types
+// pass through unchanged, except Secret leaves, which the type check catches
+// even when the key name is innocuous.
 //
 // The function is non-mutating: nested maps and slices are deep-copied
 // so the caller's data is not modified. Cycles are not supported
 // (input is expected to be a freshly-decoded JSON value).
 func Value(v interface{}) interface{} {
 	switch t := v.(type) {
+	case Secret:
+		return redacted
 	case map[string]interface{}:
 		out := make(map[string]interface{}, len(t))
 		for k, val := range t {
@@ -87,6 +118,52 @@ func Value(v interface{}) interface{} {
 			out[i] = Value(val)
 		}
 		return out
+	default:
+		return valueReflect(v)
+	}
+}
+
+// valueReflect covers container types the fast paths above miss, e.g.
+// []map[string]interface{}; without it, nested Secret or sensitive keys
+// would survive into the log line.
+func valueReflect(v interface{}) interface{} {
+	if v == nil {
+		return nil
+	}
+	rv := reflect.ValueOf(v)
+	switch rv.Kind() {
+	case reflect.Map:
+		if rv.IsNil() || rv.Type().Key().Kind() != reflect.String {
+			return v
+		}
+		out := make(map[string]interface{}, rv.Len())
+		for _, k := range rv.MapKeys() {
+			name := k.String()
+			if sensitiveKey(name) {
+				out[name] = redacted
+			} else {
+				out[name] = Value(rv.MapIndex(k).Interface())
+			}
+		}
+		return out
+	case reflect.Slice, reflect.Array:
+		// []byte is a JSON string, not a container; leave it alone.
+		if rv.Kind() == reflect.Slice && rv.Type().Elem().Kind() == reflect.Uint8 {
+			return v
+		}
+		if rv.Kind() == reflect.Slice && rv.IsNil() {
+			return v
+		}
+		out := make([]interface{}, rv.Len())
+		for i := 0; i < rv.Len(); i++ {
+			out[i] = Value(rv.Index(i).Interface())
+		}
+		return out
+	case reflect.Ptr, reflect.Interface:
+		if rv.IsNil() {
+			return v
+		}
+		return Value(rv.Elem().Interface())
 	default:
 		return v
 	}

--- a/CubeOps/internal/redact/redact.go
+++ b/CubeOps/internal/redact/redact.go
@@ -1,17 +1,11 @@
 // Copyright (c) 2026 Tencent Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-// Package redact provides helpers to mask sensitive fields before logging
-// or otherwise exposing structured data.
+// Package redact masks sensitive fields before logging.
 //
-// The intended use case is logging request bodies that may contain
-// credentials (e.g. cube_network_config carries an LLM API key in an
-// egress rule's "secret" field). Logging the raw value at Info level
-// leaks the credential into log aggregation systems (ELK, Loki, etc.).
-//
-// The masker is intentionally conservative: it only redacts fields whose
-// name matches a known sensitive pattern. Unknown fields are passed
-// through unchanged so the log remains useful for debugging.
+// Secret is safe-by-default: all its formatters return the redacted marker,
+// so it can be passed to a logger without an outer redact.Value() wrapper.
+// Use Reveal() to read the plaintext at the outbound API boundary.
 package redact
 
 import (
@@ -24,14 +18,8 @@ import (
 // redacted is the placeholder written in place of a sensitive value.
 const redacted = "***REDACTED***"
 
-// Secret wraps a credential so that fmt/String/GoString formatting is
-// redacted, but it still json.Marshal()s to the plaintext required by the
-// downstream API.
-//
-// That makes Secret safe for transport only: log codecs honouring MarshalJSON
-// (cubelog's jsoniter does) emit the credential verbatim. So a Secret may only
-// reach a log line via String()/%v, LogValue(), or Value()/JSON() on the
-// enclosing map — the latter also catch Secret leaves under harmless key names.
+// Secret wraps a credential so formatters always redact it. Call Reveal() to
+// access the plaintext at the outbound API boundary.
 type Secret string
 
 func (s Secret) String() string {
@@ -42,14 +30,27 @@ func (s Secret) GoString() string {
 	return redacted
 }
 
+// MarshalJSON emits the redacted marker so cubelog's jsoniter codec never
+// leaks the plaintext through a WithFields payload.
 func (s Secret) MarshalJSON() ([]byte, error) {
-	return json.Marshal(string(s))
+	return json.Marshal(redacted)
 }
 
-// LogValue implements slog.LogValuer so structured slog handlers render the
-// placeholder rather than invoking MarshalJSON on the plaintext.
+// UnmarshalJSON discards input. Secret is write-only from the JSON
+// perspective; inbound credentials must be assigned via Secret(s).
+func (s *Secret) UnmarshalJSON([]byte) error {
+	*s = ""
+	return nil
+}
+
 func (s Secret) LogValue() slog.Value {
 	return slog.StringValue(redacted)
+}
+
+// Reveal returns the plaintext. Call only at the outbound API boundary;
+// never log the result.
+func (s Secret) Reveal() string {
+	return string(s)
 }
 
 // sensitiveKeys is the lower-cased set of map keys that must never be

--- a/CubeOps/internal/redact/redact_test.go
+++ b/CubeOps/internal/redact/redact_test.go
@@ -139,7 +139,10 @@ func TestValue_RedactsInSlice(t *testing.T) {
 	}
 }
 
-func TestSecret_FormatsRedactedButMarshalsPlaintext(t *testing.T) {
+// TestSecret_FormatsAndMarshalsRedacted pins the safe-by-default invariant:
+// every formatter returns the redacted marker, so a Secret leaf in a
+// WithFields payload cannot leak the plaintext via jsoniter.
+func TestSecret_FormatsAndMarshalsRedacted(t *testing.T) {
 	const value = "sk-DO-NOT-LOG"
 	secret := Secret(value)
 
@@ -150,12 +153,28 @@ func TestSecret_FormatsRedactedButMarshalsPlaintext(t *testing.T) {
 		t.Fatalf("Go-formatted secret = %q, want %q", got, redacted)
 	}
 
-	encoded, err := json.Marshal(map[string]interface{}{"secret": secret})
+	encoded, err := json.Marshal(secret)
 	if err != nil {
 		t.Fatalf("json.Marshal: %v", err)
 	}
-	if got := string(encoded); got != `{"secret":"sk-DO-NOT-LOG"}` {
-		t.Fatalf("encoded secret = %s, want plaintext transport value", got)
+	if got := string(encoded); got != `"`+redacted+`"` {
+		t.Fatalf("encoded secret = %s, want %q", got, `"`+redacted+`"`)
+	}
+
+	mapEncoded, err := json.Marshal(map[string]interface{}{"value": secret})
+	if err != nil {
+		t.Fatalf("json.Marshal map: %v", err)
+	}
+	if strings.Contains(string(mapEncoded), value) {
+		t.Fatalf("map-encoded secret leaked plaintext: %s", mapEncoded)
+	}
+}
+
+// TestSecret_RevealReturnsPlaintext: Reveal() is the only plaintext path.
+func TestSecret_RevealReturnsPlaintext(t *testing.T) {
+	const value = "sk-DO-NOT-LOG"
+	if got := Secret(value).Reveal(); got != value {
+		t.Errorf("Reveal() = %q, want %q", got, value)
 	}
 }
 

--- a/CubeOps/internal/redact/redact_test.go
+++ b/CubeOps/internal/redact/redact_test.go
@@ -5,6 +5,8 @@ package redact
 
 import (
 	"encoding/json"
+	"fmt"
+	"log/slog"
 	"strings"
 	"testing"
 )
@@ -134,6 +136,123 @@ func TestValue_RedactsInSlice(t *testing.T) {
 		if m["name"] == redacted {
 			t.Errorf("items[%d].name was redacted by mistake", i)
 		}
+	}
+}
+
+func TestSecret_FormatsRedactedButMarshalsPlaintext(t *testing.T) {
+	const value = "sk-DO-NOT-LOG"
+	secret := Secret(value)
+
+	if got := fmt.Sprint(secret); got != redacted {
+		t.Fatalf("formatted secret = %q, want %q", got, redacted)
+	}
+	if got := fmt.Sprintf("%#v", secret); got != redacted {
+		t.Fatalf("Go-formatted secret = %q, want %q", got, redacted)
+	}
+
+	encoded, err := json.Marshal(map[string]interface{}{"secret": secret})
+	if err != nil {
+		t.Fatalf("json.Marshal: %v", err)
+	}
+	if got := string(encoded); got != `{"secret":"sk-DO-NOT-LOG"}` {
+		t.Fatalf("encoded secret = %s, want plaintext transport value", got)
+	}
+}
+
+// TestSecret_LogValueIsRedacted verifies slog handlers render the placeholder,
+// not the plaintext MarshalJSON would produce.
+func TestSecret_LogValueIsRedacted(t *testing.T) {
+	var lv slog.LogValuer = Secret("sk-DO-NOT-LOG")
+	if got := lv.LogValue().String(); got != redacted {
+		t.Errorf("LogValue() = %q, want %q", got, redacted)
+	}
+}
+
+// TestValue_RedactsSecretTypedLeafUnderSafeKey verifies a Secret under a
+// harmless-looking key is still replaced, since the log codec honours
+// MarshalJSON and would otherwise emit it verbatim.
+func TestValue_RedactsSecretTypedLeafUnderSafeKey(t *testing.T) {
+	in := map[string]interface{}{
+		"header": "Authorization",
+		"value":  Secret("sk-LEAK-ME"),
+	}
+	out := Value(in).(map[string]interface{})
+
+	if out["value"] != redacted {
+		t.Errorf("Secret leaf under safe key = %v, want %q", out["value"], redacted)
+	}
+	if out["header"] != "Authorization" {
+		t.Errorf("non-sensitive sibling was modified: %v", out["header"])
+	}
+}
+
+// TestJSON_RedactsSecretTypedLeaf verifies JSON() never emits the plaintext of
+// an embedded Secret, even though json.Marshal on the raw Secret would.
+func TestJSON_RedactsSecretTypedLeaf(t *testing.T) {
+	in := map[string]interface{}{
+		"action": map[string]interface{}{
+			"inject": []interface{}{
+				map[string]interface{}{"header": "Authorization", "value": Secret("sk-LEAK-ME")},
+			},
+		},
+	}
+	b, err := JSON(in)
+	if err != nil {
+		t.Fatalf("JSON: %v", err)
+	}
+	if strings.Contains(string(b), "sk-LEAK-ME") {
+		t.Errorf("JSON output leaked the Secret plaintext: %s", b)
+	}
+}
+
+// TestJSON_RedactsSecretInTypedSlice uses the exact shape LLMEgressRule
+// produces — inject is a []map[string]interface{}, not a []interface{} — which
+// the non-reflective fast paths would return verbatim, leaking the API key.
+func TestJSON_RedactsSecretInTypedSlice(t *testing.T) {
+	in := map[string]interface{}{
+		"action": map[string]interface{}{
+			"inject": []map[string]interface{}{
+				{"header": "Authorization", "secret": Secret("sk-LEAK-ME"), "format": "Bearer ${SECRET}"},
+			},
+		},
+	}
+	b, err := JSON(in)
+	if err != nil {
+		t.Fatalf("JSON: %v", err)
+	}
+	if strings.Contains(string(b), "sk-LEAK-ME") {
+		t.Errorf("JSON output leaked the API key: %s", b)
+	}
+	if !strings.Contains(string(b), "Bearer ${SECRET}") {
+		t.Errorf("non-sensitive sibling was dropped: %s", b)
+	}
+}
+
+// TestValue_RedactsTypedStringMap covers map[string]string, another concrete
+// container type the fast paths miss.
+func TestValue_RedactsTypedStringMap(t *testing.T) {
+	out := Value(map[string]string{"apiKey": "sk-LEAK-ME", "model": "deepseek"})
+	m, ok := out.(map[string]interface{})
+	if !ok {
+		t.Fatalf("Value returned %T, want a traversed map", out)
+	}
+	if m["apiKey"] != redacted {
+		t.Errorf("apiKey = %v, want %q", m["apiKey"], redacted)
+	}
+	if m["model"] != "deepseek" {
+		t.Errorf("model = %v, want deepseek", m["model"])
+	}
+}
+
+// TestValue_LeavesByteSliceAlone guards the reflection path from mangling
+// []byte, which marshals as a JSON string rather than a container.
+func TestValue_LeavesByteSliceAlone(t *testing.T) {
+	b, err := JSON(map[string]interface{}{"raw": []byte("hello")})
+	if err != nil {
+		t.Fatalf("JSON: %v", err)
+	}
+	if !strings.Contains(string(b), `"raw":"aGVsbG8="`) {
+		t.Errorf("[]byte was not preserved as a JSON string: %s", b)
 	}
 }
 

--- a/CubeOps/internal/server/server.go
+++ b/CubeOps/internal/server/server.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"net/http"
 	"regexp"
+	"runtime/debug"
 	"strings"
 	"time"
 
@@ -76,12 +77,12 @@ func (s *Server) Shutdown(ctx context.Context) error {
 // buildRouter configures all routes on a gin engine.
 func (s *Server) buildRouter() *gin.Engine {
 	// We use gin.New() rather than gin.Default() so we can attach our own
-	// cubelog-based access logger and recovery handler. gin.Default() writes to
-	// stdout and bypasses any logger the operator has configured.
+	// cubelog-based access logger and recovery handler. gin.Default() writes
+	// to stdout and bypasses any logger the operator has configured.
 	gin.SetMode(gin.ReleaseMode)
 	r := gin.New()
 	r.Use(requestLogger())
-	r.Use(gin.Recovery())
+	r.Use(cubeopsRecovery())
 
 	// Health check (no auth) — defined at the root rather than under /api/v1
 	// because external load balancers and k8s probes hit it without a prefix.
@@ -175,6 +176,24 @@ func requestLogger() gin.HandlerFunc {
 // traceFieldPattern is the allowed charset for inbound X-RequestID and
 // X-Caller values. Anything outside it falls back to a safe default.
 var traceFieldPattern = regexp.MustCompile(`^[A-Za-z0-9._-]+$`)
+
+// cubeopsRecovery logs panics through cubelog with the inbound RequestID.
+// Must be registered after requestLogger. Mirrors gin.Recovery's write guard.
+func cubeopsRecovery() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		defer func() {
+			if r := recover(); r != nil {
+				stack := debug.Stack()
+				logging.G(c.Request.Context()).Errorf(
+					"panic recovered: err=%q\n%s", r, stack)
+				if !c.Writer.Written() {
+					c.AbortWithStatus(http.StatusInternalServerError)
+				}
+			}
+		}()
+		c.Next()
+	}
+}
 
 func requestIDFromHeader(c *gin.Context) string {
 	for _, h := range []string{"X-RequestID", "X-Request-ID"} {

--- a/CubeOps/internal/server/server.go
+++ b/CubeOps/internal/server/server.go
@@ -5,17 +5,21 @@ package server
 
 import (
 	"context"
-	"log/slog"
 	"net/http"
+	"regexp"
+	"strings"
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
 	"github.com/tencentcloud/CubeSandbox/CubeOps/internal/auth"
 	"github.com/tencentcloud/CubeSandbox/CubeOps/internal/config"
 	"github.com/tencentcloud/CubeSandbox/CubeOps/internal/cubemaster"
 	"github.com/tencentcloud/CubeSandbox/CubeOps/internal/handler"
+	"github.com/tencentcloud/CubeSandbox/CubeOps/internal/logging"
 	"github.com/tencentcloud/CubeSandbox/CubeOps/internal/service"
 	"github.com/tencentcloud/CubeSandbox/CubeOps/internal/store"
+	cubelog "github.com/tencentcloud/CubeSandbox/cubelog"
 )
 
 // Server is the CubeOps HTTP server.
@@ -56,7 +60,7 @@ func (s *Server) Start() error {
 		// alone is sufficient for Slowloris mitigation.
 	}
 
-	slog.Info("CubeOps starting", "addr", s.cfg.Bind)
+	logging.G(context.Background()).Infof("CubeOps starting on %s", s.cfg.Bind)
 	return s.httpSrv.ListenAndServe()
 }
 
@@ -65,19 +69,19 @@ func (s *Server) Shutdown(ctx context.Context) error {
 	if s.httpSrv == nil {
 		return nil
 	}
-	slog.Info("CubeOps shutting down")
+	logging.G(ctx).Info("CubeOps shutting down")
 	return s.httpSrv.Shutdown(ctx)
 }
 
 // buildRouter configures all routes on a gin engine.
 func (s *Server) buildRouter() *gin.Engine {
 	// We use gin.New() rather than gin.Default() so we can attach our own
-	// slog-based access logger and recovery handler. gin.Default() writes to
+	// cubelog-based access logger and recovery handler. gin.Default() writes to
 	// stdout and bypasses any logger the operator has configured.
 	gin.SetMode(gin.ReleaseMode)
 	r := gin.New()
-	r.Use(gin.Recovery())
 	r.Use(requestLogger())
+	r.Use(gin.Recovery())
 
 	// Health check (no auth) — defined at the root rather than under /api/v1
 	// because external load balancers and k8s probes hit it without a prefix.
@@ -93,8 +97,7 @@ func (s *Server) buildRouter() *gin.Engine {
 	configH := handler.NewConfigHandler(s.cfg.Bind, 100, s.cfg.JWTSecret != "", s.cfg.SandboxDomain, "cubebox")
 	agenthubH := handler.NewAgentHubHandler(s.store, s.cm)
 	// SDK handler gets the AgentHubService so that E2B template/snapshot
-	// deletions can reverse-sync AgentHub registrations (matching the old
-	// Rust reverse_sync_agenthub_template that lived in CubeAPI).
+	// deletions can reverse-sync AgentHub registrations
 	sdkH := handler.NewSDKHandler(s.cm).WithAgentHubService(agenthubH.AgentHubService())
 
 	// Public (no auth) routes — login + refresh.
@@ -122,19 +125,71 @@ func (s *Server) buildRouter() *gin.Engine {
 	return r
 }
 
-// requestLogger is a gin middleware that emits a structured slog line per
-// request, matching the format the CubeOps CLI tooling expects.
+// requestLogger emits request traces to the stat log.
+//
+// Convention: handlers own business RetCode (e.g. CubeMaster ret_code); the
+// middleware only falls back to HTTP status when rt.RetCode is still zero so
+// business codes aren't clobbered by 404/502.
 func requestLogger() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		start := time.Now()
+		requestID := requestIDFromHeader(c)
+		caller := callerFromHeader(c)
+		// Only /health is a routed liveness endpoint; treating the unrouted
+		// /ready as a probe would silently drop its 404 from the logs.
+		isProbe := c.Request.URL.Path == "/health"
+		if isProbe {
+			caller = "probe"
+		}
+		rt := &cubelog.RequestTrace{
+			RequestID:      requestID,
+			Action:         c.Request.Method,
+			Caller:         caller,
+			Callee:         "cubeops",
+			CallerIP:       c.ClientIP(),
+			CalleeAction:   c.Request.URL.Path,
+			CalleeEndpoint: c.Request.Host,
+			Timestamp:      start,
+		}
+		ctx := cubelog.WithRequestTrace(c.Request.Context(), rt)
+		ctx = logging.WithLogger(ctx, cubelog.WithContext(ctx))
+		c.Request = c.Request.WithContext(ctx)
+		c.Header("X-RequestID", requestID)
+
+		defer func() {
+			rt.Cost = time.Since(start)
+			if isProbe {
+				return
+			}
+			// Only fall back to HTTP status when the handler did not set a
+			// business RetCode. This preserves CubeMaster ret_code in -stat.
+			if rt.RetCode == 0 {
+				rt.RetCode = int64(c.Writer.Status())
+			}
+			cubelog.Trace(rt)
+		}()
 		c.Next()
-		slog.Info("http",
-			"method", c.Request.Method,
-			"path", c.Request.URL.Path,
-			"status", c.Writer.Status(),
-			"size", c.Writer.Size(),
-			"latency_ms", time.Since(start).Milliseconds(),
-			"client", c.ClientIP(),
-		)
 	}
+}
+
+// traceFieldPattern is the allowed charset for inbound X-RequestID and
+// X-Caller values. Anything outside it falls back to a safe default.
+var traceFieldPattern = regexp.MustCompile(`^[A-Za-z0-9._-]+$`)
+
+func requestIDFromHeader(c *gin.Context) string {
+	for _, h := range []string{"X-RequestID", "X-Request-ID"} {
+		v := strings.TrimSpace(c.GetHeader(h))
+		if v != "" && len(v) <= 128 && traceFieldPattern.MatchString(v) {
+			return v
+		}
+	}
+	return uuid.NewString()
+}
+
+func callerFromHeader(c *gin.Context) string {
+	if caller := strings.TrimSpace(c.GetHeader("X-Caller")); caller != "" &&
+		len(caller) <= 128 && traceFieldPattern.MatchString(caller) {
+		return caller
+	}
+	return "cubeops-client"
 }

--- a/CubeOps/internal/server/server_test.go
+++ b/CubeOps/internal/server/server_test.go
@@ -1,0 +1,279 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package server
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	cubelog "github.com/tencentcloud/CubeSandbox/cubelog"
+)
+
+// uuidV4Pattern matches the canonical UUID layout from uuid.NewString().
+// Shape-only: sufficient to tell "fresh UUID" from "the rejected input".
+var uuidV4Pattern = regexp.MustCompile(`^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$`)
+
+// newTestEngine builds a minimal engine running only requestLogger, enough
+// to exercise request-id / caller / probe-skip-stat logic without a full
+// server. The handler records the middleware-derived caller into *seenCaller.
+func newTestEngine(t *testing.T) (*gin.Engine, *string) {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(requestLogger())
+
+	seenCaller := ""
+	r.GET("/*any", func(c *gin.Context) {
+		if rt := cubelog.GetTraceInfo(c.Request.Context()); rt != nil {
+			seenCaller = rt.Caller
+		}
+	})
+	return r, &seenCaller
+}
+
+// captureTrace redirects cubelog's stat writer to a buffer for the test.
+// Cleanup restores nil (the pre-test default) and disables LogMetric so
+// later tests do not leak trace lines to stderr.
+type traceCapture struct {
+	buf *bytes.Buffer
+}
+
+func captureTrace(t *testing.T) *traceCapture {
+	t.Helper()
+	var buf bytes.Buffer
+	cubelog.SetTraceOutput(&buf)
+	cubelog.EnableLogMetric()
+	tc := &traceCapture{buf: &buf}
+	t.Cleanup(func() {
+		cubelog.SetTraceOutput(io.Discard)
+		cubelog.DisableLogMetric()
+		cubelog.SetTraceOutput(nil)
+	})
+	return tc
+}
+
+// captureOutput redirects the business log writer to a buffer for the test.
+type outputCapture struct {
+	buf *bytes.Buffer
+}
+
+func captureOutput(t *testing.T) *outputCapture {
+	t.Helper()
+	var buf bytes.Buffer
+	cubelog.SetOutput(&buf)
+	oc := &outputCapture{buf: &buf}
+	t.Cleanup(func() { cubelog.SetOutput(nil) })
+	return oc
+}
+
+// TestRequestLogger_RejectsInvalidXRequestID: a bad X-RequestID falls back
+// to a fresh UUID and is echoed in the response header.
+func TestRequestLogger_RejectsInvalidXRequestID(t *testing.T) {
+	cases := []struct {
+		name   string
+		header string
+	}{
+		{"path traversal", "../../../etc/passwd"},
+		{"contains space", "rid with space"},
+		{"contains slash", "rid/abc"},
+		{"too long", strings.Repeat("a", 129)},
+		{"empty after trim", "   "},
+		{"non-ascii", "rid-中文"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r, _ := newTestEngine(t)
+			w := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodGet, "/anything", nil)
+			req.Header.Set("X-RequestID", tc.header)
+
+			r.ServeHTTP(w, req)
+
+			got := w.Header().Get("X-RequestID")
+			if !uuidV4Pattern.MatchString(got) {
+				t.Errorf("X-RequestID = %q, want a fresh UUID (header was %q)", got, tc.header)
+			}
+			if tc.header != "" && strings.Contains(got, tc.header) {
+				t.Errorf("X-RequestID %q leaks the rejected input %q", got, tc.header)
+			}
+		})
+	}
+}
+
+// TestRequestLogger_EchoesValidXRequestID: a valid X-RequestID is preserved
+// verbatim and echoed in the response header.
+func TestRequestLogger_EchoesValidXRequestID(t *testing.T) {
+	const rid = "rid-abc.123_DEF"
+	r, _ := newTestEngine(t)
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/anything", nil)
+	req.Header.Set("X-RequestID", rid)
+
+	r.ServeHTTP(w, req)
+
+	if got := w.Header().Get("X-RequestID"); got != rid {
+		t.Errorf("X-RequestID = %q, want %q", got, rid)
+	}
+}
+
+// TestRequestLogger_AcceptsAlternateHeaderName: X-Request-ID (hyphenated)
+// is also honoured.
+func TestRequestLogger_AcceptsAlternateHeaderName(t *testing.T) {
+	const rid = "rid-from-alt-header"
+	r, _ := newTestEngine(t)
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/anything", nil)
+	req.Header.Set("X-Request-ID", rid)
+
+	r.ServeHTTP(w, req)
+
+	if got := w.Header().Get("X-RequestID"); got != rid {
+		t.Errorf("X-RequestID = %q, want %q", got, rid)
+	}
+}
+
+// TestRequestLogger_HealthProbeSkipsStat: /health must not emit a Trace()
+// line, otherwise liveness probes flood the stat log.
+func TestRequestLogger_HealthProbeSkipsStat(t *testing.T) {
+	tc := captureTrace(t)
+
+	r, seenCaller := newTestEngine(t)
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/health", nil)
+
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200", w.Code)
+	}
+	if *seenCaller != "probe" {
+		t.Errorf("caller = %q, want \"probe\"", *seenCaller)
+	}
+	if tc.buf.Len() != 0 {
+		t.Errorf("stat writer captured %d bytes for /health; probe must skip Trace():\n%s",
+			tc.buf.Len(), tc.buf.String())
+	}
+}
+
+// TestRequestLogger_NonProbeEmitsStat: non-probe requests must emit
+// Trace(), otherwise the probe-skip branch could silently widen.
+func TestRequestLogger_NonProbeEmitsStat(t *testing.T) {
+	tc := captureTrace(t)
+
+	r, seenCaller := newTestEngine(t)
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/anything", nil)
+	req.Header.Set("X-Caller", "webui")
+
+	r.ServeHTTP(w, req)
+
+	if *seenCaller != "webui" {
+		t.Errorf("caller = %q, want \"webui\"", *seenCaller)
+	}
+	if tc.buf.Len() == 0 {
+		t.Errorf("stat writer captured 0 bytes; non-probe must emit Trace()")
+	}
+}
+
+// TestRequestLogger_RejectsInvalidCaller: a bad X-Caller falls back to the
+// "cubeops-client" sentinel.
+func TestRequestLogger_RejectsInvalidCaller(t *testing.T) {
+	cases := []string{
+		"caller with space",
+		"caller/with/slash",
+		strings.Repeat("c", 129),
+		"caller-中文",
+	}
+	for _, bad := range cases {
+		t.Run(bad, func(t *testing.T) {
+			r, seenCaller := newTestEngine(t)
+			w := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodGet, "/anything", nil)
+			req.Header.Set("X-Caller", bad)
+
+			r.ServeHTTP(w, req)
+
+			if *seenCaller != "cubeops-client" {
+				t.Errorf("caller = %q, want \"cubeops-client\" (input was %q)", *seenCaller, bad)
+			}
+		})
+	}
+}
+
+// TestRequestLogger_MissingCallerFallsBackToDefault: absent X-Caller uses
+// the sentinel, not the empty string.
+func TestRequestLogger_MissingCallerFallsBackToDefault(t *testing.T) {
+	r, seenCaller := newTestEngine(t)
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/anything", nil)
+
+	r.ServeHTTP(w, req)
+
+	if *seenCaller != "cubeops-client" {
+		t.Errorf("caller = %q, want \"cubeops-client\"", *seenCaller)
+	}
+}
+
+// TestCubeopsRecovery_PanicBecomes500: a handler panic is caught, returns
+// 500, and the recovery log line lands in cubelog with the inbound
+// RequestID attached.
+func TestCubeopsRecovery_PanicBecomes500(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(requestLogger())
+	r.Use(cubeopsRecovery())
+	r.GET("/boom", func(c *gin.Context) { panic("simulated handler panic") })
+
+	oc := captureOutput(t)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/boom", nil)
+	req.Header.Set("X-RequestID", "rid-recovery-1")
+
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("status = %d, want 500", w.Code)
+	}
+	if !strings.Contains(oc.buf.String(), "panic recovered") {
+		t.Errorf("expected cubelog to record \"panic recovered\"; got:\n%s", oc.buf.String())
+	}
+	if !strings.Contains(oc.buf.String(), "rid-recovery-1") {
+		t.Errorf("panic log missing the inbound RequestID; got:\n%s", oc.buf.String())
+	}
+}
+
+// TestCubeopsRecovery_NoDoubleWriteWhenHandlerAlreadyWrote: if the handler
+// already wrote part of the body, recovery must not overwrite the status.
+func TestCubeopsRecovery_NoDoubleWriteWhenHandlerAlreadyWrote(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(requestLogger())
+	r.Use(cubeopsRecovery())
+	r.GET("/partial", func(c *gin.Context) {
+		c.Status(http.StatusOK)
+		_, _ = c.Writer.Write([]byte("partial body"))
+		panic("panic after partial write")
+	})
+
+	oc := captureOutput(t)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/partial", nil)
+
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200 (handler already wrote)", w.Code)
+	}
+	if !strings.Contains(oc.buf.String(), "panic recovered") {
+		t.Errorf("expected cubelog to record \"panic recovered\"; got:\n%s", oc.buf.String())
+	}
+}

--- a/CubeOps/internal/service/agenthub.go
+++ b/CubeOps/internal/service/agenthub.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"log/slog"
 	"net/http"
 	"net/url"
 	"os"
@@ -19,6 +18,8 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/tencentcloud/CubeSandbox/CubeOps/internal/cubemaster"
+	"github.com/tencentcloud/CubeSandbox/CubeOps/internal/logging"
+	"github.com/tencentcloud/CubeSandbox/CubeOps/internal/redact"
 	"github.com/tencentcloud/CubeSandbox/CubeOps/internal/store"
 	"gorm.io/gorm"
 )
@@ -139,10 +140,10 @@ var _ AgentStore = (*store.Store)(nil)
 
 // applyOpenclawFn is the signature of ApplyOpenclawRuntime. Declared as a
 // type so AgentHubService can hold it as an injectable field.
-type applyOpenclawFn func(httpClient *http.Client, sandboxID, domain string, plan *LLMRuntimePlan, opts *OpenclawApplyOptions) (*CommandOutput, error)
+type applyOpenclawFn func(ctx context.Context, httpClient *http.Client, sandboxID, domain string, plan *LLMRuntimePlan, opts *OpenclawApplyOptions) (*CommandOutput, error)
 
 // resolveGatewayFn is the signature of ResolveGatewayToken.
-type resolveGatewayFn func(httpClient *http.Client, sandboxID, domain, hostStatePath, fallbackToken string) string
+type resolveGatewayFn func(ctx context.Context, httpClient *http.Client, sandboxID, domain, hostStatePath, fallbackToken string) string
 
 // restartOpenclawFn is the signature of RestartOpenclawForInstance.
 type restartOpenclawFn func(inst *store.AgentInstance) (*CommandOutput, error)
@@ -192,48 +193,32 @@ func NewAgentHubService(s *store.Store, cm CubeMasterClient) *AgentHubService {
 // fails after the sandbox has already been created by CubeMaster. It deletes
 // the sandbox so CPU/memory/quota are not leaked. Errors are logged but not
 // returned — the caller already has an error to report to the client.
-// See R10.
 func (s *AgentHubService) CompensateDeleteSandbox(ctx context.Context, sandboxID, reason string) {
 	if _, err := s.CM.DeleteSandbox(ctx, map[string]interface{}{
-		"requestID":     fmt.Sprintf("cubeops-compensate-%s-%d", reason, time.Now().UnixNano()),
 		"sandbox_id":    sandboxID,
 		"instance_type": SDKInstanceType,
 	}); err != nil {
-		slog.Error("CompensateDeleteSandbox: failed to delete sandbox after creation failure",
-			"sandboxID", sandboxID, "reason", reason, "err", err)
+		logging.G(ctx).Errorf("CompensateDeleteSandbox: failed to delete sandbox %q (reason=%s): %v", sandboxID, reason, err)
 	} else {
-		slog.Info("CompensateDeleteSandbox: sandbox deleted after creation failure",
-			"sandboxID", sandboxID, "reason", reason)
+		logging.G(ctx).Infof("CompensateDeleteSandbox: sandbox %q deleted (reason=%s)", sandboxID, reason)
 	}
 }
 
 // ReverseSyncAgentHubTemplate best-effort soft-deletes any AgentHub template
 // registration backed by the just-deleted infrastructure template/snapshot.
-//
-// This migrates the old Rust reverse_sync_agenthub_template
-// (CubeAPI/src/handlers/templates.rs:192) into CubeOps. The old CubeAPI
-// called it from the E2B delete_template handler after the infra delete
-// succeeded; now that CubeOps owns the SDK path (SDKHandler.DeleteTemplate)
-// and the AgentHub path (AgentHubHandler.DeleteTemplate), both must trigger
-// the reverse-sync so the AgentHub registry does not keep pointing at a
-// snapshot/template that no longer exists.
-//
 // Failures are logged, never propagated — a reverse-sync failure must not
-// block the primary deletion that already succeeded (FIX-5b, L15/H5).
+// block the primary deletion that already succeeded.
 func (s *AgentHubService) ReverseSyncAgentHubTemplate(ctx context.Context, infraID string) {
 	ids, err := s.Store.FindTemplateIDsByInfraID(ctx, infraID)
 	if err != nil {
-		slog.Warn("ReverseSyncAgentHubTemplate: query AgentHub templates failed",
-			"infraID", infraID, "err", err)
+		logging.G(ctx).Warnf("ReverseSyncAgentHubTemplate: query AgentHub templates failed: infraID=%q err=%q", infraID, err.Error())
 		return
 	}
 	for _, id := range ids {
 		if err := s.Store.SoftDeleteAgentHubTemplate(ctx, id); err != nil {
-			slog.Warn("ReverseSyncAgentHubTemplate: failed to soft-delete AgentHub template",
-				"templateID", id, "err", err)
+			logging.G(ctx).Warnf("ReverseSyncAgentHubTemplate: failed to soft-delete AgentHub template %q: %v", id, err)
 		} else {
-			slog.Info("ReverseSyncAgentHubTemplate: soft-deleted AgentHub template",
-				"templateID", id, "infraID", infraID)
+			logging.G(ctx).Debugf("ReverseSyncAgentHubTemplate: soft-deleted AgentHub template %q (infraID=%q)", id, infraID)
 		}
 	}
 }
@@ -242,7 +227,6 @@ func (s *AgentHubService) ReverseSyncAgentHubTemplate(ctx context.Context, infra
 
 // CreateSandboxRequest is the typed input for BuildCreateSandboxRequest.
 type CreateSandboxRequest struct {
-	RequestID         string
 	Name              string
 	Engine            string
 	PersistenceMode   string
@@ -283,7 +267,6 @@ func BuildCreateSandboxRequest(req CreateSandboxRequest) map[string]interface{} 
 	annotations["cube.master.appsnapshot.template.version"] = "v2"
 
 	cmReq := map[string]interface{}{
-		"requestID":     req.RequestID,
 		"instance_type": SDKInstanceType,
 		"timeout":       86400,
 		"containers":    []interface{}{},
@@ -480,6 +463,9 @@ func (s *AgentHubService) CreateInstance(ctx context.Context, req CreateInstance
 	if err != nil {
 		return nil, NewInternal("failed to build network config: " + err.Error())
 	}
+	// redact.Value here masks the embedded Secret(llm.APIKey) leaf that
+	// jsoniter would otherwise emit verbatim.
+	logging.G(ctx).WithFields(map[string]interface{}{"network_config": redact.Value(networkConfig)}).Debugf("agenthub: built egress network config")
 
 	// --- Shared-files + published-template fast-path detection ---
 	sharedFiles := persistenceMode == "shared_files"
@@ -512,13 +498,12 @@ func (s *AgentHubService) CreateInstance(ctx context.Context, req CreateInstance
 		openclawStatePath = statePath
 		if templateOpenclawStateSource != "" {
 			if err := CopyOpenclawStateDir(templateOpenclawStateSource, statePath); err != nil {
-				slog.Warn("failed to copy OpenClaw state from template", "source", templateOpenclawStateSource, "err", err)
+				logging.G(ctx).Warnf("failed to copy OpenClaw state from template %q: %v", templateOpenclawStateSource, err)
 			}
 		}
 	}
 
 	// --- Build CubeMaster request ---
-	requestID := fmt.Sprintf("req-%d", time.Now().UnixNano())
 	extraLabels := map[string]string{}
 	extraAnnotations := map[string]string{}
 	if sharedFiles && openclawPersistID != "" {
@@ -535,7 +520,6 @@ func (s *AgentHubService) CreateInstance(ctx context.Context, req CreateInstance
 	}
 
 	cmReq := BuildCreateSandboxRequest(CreateSandboxRequest{
-		RequestID:         requestID,
 		Name:              name,
 		Engine:            "openclaw",
 		PersistenceMode:   persistenceMode,
@@ -603,13 +587,13 @@ func (s *AgentHubService) CreateInstance(ctx context.Context, req CreateInstance
 			GatewayToken: generatedToken,
 		}
 	}
-	applyOutput, err := s.applyFn(s.envdClient, sandboxID, domain, plan, applyOpts)
+	applyOutput, err := s.applyFn(ctx, s.envdClient, sandboxID, domain, plan, applyOpts)
 	if err != nil {
 		s.CompensateDeleteSandbox(ctx, sandboxID, "apply_openclaw")
 		return nil, NewBadGateway("failed to apply OpenClaw config: " + err.Error())
 	}
 
-	gatewayToken := s.resolveGatewayFn(s.envdClient, sandboxID, domain, openclawStatePath, generatedToken)
+	gatewayToken := s.resolveGatewayFn(ctx, s.envdClient, sandboxID, domain, openclawStatePath, generatedToken)
 
 	// --- Build instance record ---
 	bots := []string{}
@@ -686,25 +670,21 @@ func (s *AgentHubService) DeleteInstance(ctx context.Context, agentID string) er
 		return NewNotFound("instance not found")
 	}
 	if _, err := s.CM.DeleteSandbox(ctx, map[string]interface{}{
-		"requestID":     fmt.Sprintf("cubeops-del-%d", time.Now().UnixNano()),
 		"sandbox_id":    inst.SandboxID,
 		"instance_type": SDKInstanceType,
 	}); err != nil {
 		var cmErr *cubemaster.CMError
 		if errors.As(err, &cmErr) && cmErr.IsNotFound() {
-			slog.Info("DeleteInstance: sandbox not found in CubeMaster, treating as already deleted",
-				"agentID", agentID, "sandboxID", inst.SandboxID)
+			logging.G(ctx).Debugf("DeleteInstance: sandbox not found in CubeMaster, treating as already deleted: agentID=%q sandboxID=%q", agentID, inst.SandboxID)
 		} else {
 			return wrapCMError(err)
 		}
 	}
 	if inst.OpenclawStatePath != nil && *inst.OpenclawStatePath != "" {
 		if err := os.RemoveAll(*inst.OpenclawStatePath); err != nil {
-			slog.Warn("DeleteInstance: failed to clean up OpenClaw state directory",
-				"agentID", agentID, "path", *inst.OpenclawStatePath, "err", err)
+			logging.G(ctx).Warnf("DeleteInstance: failed to clean up OpenClaw state directory: agentID=%q path=%q err=%q", agentID, *inst.OpenclawStatePath, err.Error())
 		} else {
-			slog.Info("DeleteInstance: cleaned up OpenClaw state directory",
-				"agentID", agentID, "path", *inst.OpenclawStatePath)
+			logging.G(ctx).Debugf("DeleteInstance: cleaned up OpenClaw state directory: agentID=%q path=%q", agentID, *inst.OpenclawStatePath)
 		}
 	}
 	if err := s.Store.SoftDeleteInstance(ctx, agentID); err != nil {
@@ -768,7 +748,6 @@ func (s *AgentHubService) SandboxAction(ctx context.Context, agentID, action str
 	}
 
 	reqBody := map[string]interface{}{
-		"requestID":     fmt.Sprintf("req-%d", time.Now().UnixNano()),
 		"sandbox_id":    inst.SandboxID,
 		"instance_type": SDKInstanceType,
 		"action":        action,
@@ -833,7 +812,7 @@ func (s *AgentHubService) UpdateWecomConfig(ctx context.Context, agentID, botID,
 	if botID != "" && inst.SandboxID != "" {
 		llmCfg, err := ResolveLLMConfig(ctx, s.Store)
 		if err != nil {
-			slog.Warn("UpdateWecomConfig: LLM config not available, using defaults", "err", err)
+			logging.G(ctx).Warnf("UpdateWecomConfig: LLM config not available, using defaults: err=%q", err.Error())
 			llmCfg = DefaultLLMConfig()
 		}
 		plan := ResolveRuntimePlan(llmCfg, "")
@@ -847,8 +826,8 @@ func (s *AgentHubService) UpdateWecomConfig(ctx context.Context, agentID, botID,
 			BotID:          botID,
 			BotSecret:      botSecret,
 		}
-		if _, err := s.applyFn(s.envdClient, inst.SandboxID, domain, plan, applyOpts); err != nil {
-			slog.Error("UpdateWecomConfig: failed to apply to running agent", "err", err)
+		if _, err := s.applyFn(ctx, s.envdClient, inst.SandboxID, domain, plan, applyOpts); err != nil {
+			logging.G(ctx).Errorf("UpdateWecomConfig: failed to apply to running agent: err=%q", err.Error())
 			return nil, NewBadGateway("failed to apply WeCom config to running agent: " + err.Error())
 		}
 	}
@@ -885,9 +864,7 @@ func (s *AgentHubService) DeleteSnapshot(ctx context.Context, agentID, snapshotI
 		case "agenthub_state":
 			if snap.OpenclawStateSnapshotPath != nil && *snap.OpenclawStateSnapshotPath != "" {
 				if err := os.RemoveAll(*snap.OpenclawStateSnapshotPath); err != nil {
-					slog.Warn("DeleteSnapshot: failed to clean up OpenClaw snapshot directory",
-						"agentID", agentID, "snapshotID", snapshotID,
-						"path", *snap.OpenclawStateSnapshotPath, "err", err)
+					logging.G(ctx).Warnf("DeleteSnapshot: failed to clean up OpenClaw snapshot directory: agentID=%q snapshotID=%q path=%q err=%q", agentID, snapshotID, *snap.OpenclawStateSnapshotPath, err.Error())
 				}
 			}
 		case "full_snapshot", "sandbox_snapshot":
@@ -991,9 +968,7 @@ func (s *AgentHubService) CreateSnapshot(ctx context.Context, req CreateSnapshot
 	}
 
 	// full_snapshot mode
-	requestID := fmt.Sprintf("req-%d", time.Now().UnixNano())
 	snapResp, err := s.CM.CreateSnapshot(ctx, map[string]interface{}{
-		"requestID":      requestID,
 		"sandbox_id":     inst.SandboxID,
 		"display_name":   req.Name,
 		"create_request": map[string]interface{}{},
@@ -1082,7 +1057,6 @@ func (s *AgentHubService) RollbackAgent(ctx context.Context, agentID, snapshotID
 		}
 	} else {
 		if _, err := s.CM.RollbackSandbox(ctx, inst.SandboxID, map[string]interface{}{
-			"requestID":     fmt.Sprintf("cubeops-rollback-%d", time.Now().UnixNano()),
 			"snapshot_id":   snapshotID,
 			"sandbox_id":    inst.SandboxID,
 			"instance_type": SDKInstanceType,
@@ -1130,8 +1104,7 @@ func (s *AgentHubService) RecoverAgent(ctx context.Context, agentID string) (*Re
 	} else if output != nil {
 		restartErr = output.Stderr
 	}
-	slog.Warn("recover: restart failed, trying snapshot rollback",
-		"agentID", agentID, "error", restartErr)
+	logging.G(ctx).Warnf("recover: restart failed, trying snapshot rollback: agentID=%q err=%q", agentID, restartErr)
 
 	// Step 2: find latest healthy snapshot.
 	snapshotID, err := s.Store.LatestHealthySnapshot(ctx, agentID)
@@ -1166,7 +1139,6 @@ func (s *AgentHubService) RecoverAgent(ctx context.Context, agentID string) (*Re
 		}
 	} else {
 		if _, err := s.CM.RollbackSandbox(ctx, inst.SandboxID, map[string]interface{}{
-			"requestID":     fmt.Sprintf("cubeops-recover-%d", time.Now().UnixNano()),
 			"snapshot_id":   snapshotID,
 			"sandbox_id":    inst.SandboxID,
 			"instance_type": SDKInstanceType,
@@ -1260,10 +1232,7 @@ func (s *AgentHubService) CloneAgent(ctx context.Context, req CloneAgentRequest)
 	}
 
 	cloneSharedFiles := inst.PersistenceMode != nil && *inst.PersistenceMode == "shared_files"
-	slog.Info("CloneAgent: debug",
-		"agentID", agentID, "cloneSharedFiles", cloneSharedFiles,
-		"sourceOpenclawStatePath", sourceOpenclawStatePath,
-		"rootfsSnapshotID", rootfsSnapshotID, "snapshotID", snapshotID)
+	logging.G(ctx).Debugf("CloneAgent: debug: agentID=%q cloneSharedFiles=%v source=%q rootfs=%q snapshot=%q", agentID, cloneSharedFiles, sourceOpenclawStatePath, rootfsSnapshotID, snapshotID)
 
 	var cloneOpenclawStatePath string
 	var cloneOpenclawPersistID string
@@ -1275,13 +1244,11 @@ func (s *AgentHubService) CloneAgent(ctx context.Context, req CloneAgentRequest)
 		}
 		cloneOpenclawStatePath = statePath
 		if err := CopyOpenclawStateDir(sourceOpenclawStatePath, cloneOpenclawStatePath); err != nil {
-			slog.Warn("CloneAgent: failed to copy OpenClaw state for clone",
-				"agentID", agentID, "err", err)
+			logging.G(ctx).Warnf("CloneAgent: failed to copy OpenClaw state for clone: agentID=%q err=%q", agentID, err.Error())
 		}
 	}
 
 	// --- Build CubeMaster request ---
-	requestID := fmt.Sprintf("req-%d", time.Now().UnixNano())
 	extraLabels := map[string]string{}
 	extraAnnotations := map[string]string{}
 	if cloneSharedFiles && cloneOpenclawStatePath != "" {
@@ -1305,11 +1272,11 @@ func (s *AgentHubService) CloneAgent(ctx context.Context, req CloneAgentRequest)
 	if cloneLLMCfgForNet, _ := ResolveLLMConfig(ctx, s.Store); cloneLLMCfgForNet != nil {
 		if nc, err := AgenthubNetworkConfig(cloneLLMCfgForNet); err == nil {
 			networkConfig = nc
+			logging.G(ctx).WithFields(map[string]interface{}{"network_config": redact.Value(networkConfig)}).Debugf("agenthub: built egress network config (clone)")
 		}
 	}
 
 	cmReq := BuildCreateSandboxRequest(CreateSandboxRequest{
-		RequestID:         requestID,
 		Name:              cloneName,
 		Engine:            inst.Engine,
 		PersistenceMode:   clonePersistenceMode,
@@ -1348,7 +1315,7 @@ func (s *AgentHubService) CloneAgent(ctx context.Context, req CloneAgentRequest)
 	// --- Apply OpenClaw runtime ---
 	cloneLLMCfg, err := ResolveLLMConfig(ctx, s.Store)
 	if err != nil {
-		slog.Warn("CloneAgent: failed to resolve LLM config", "err", err)
+		logging.G(ctx).Warnf("CloneAgent: failed to resolve LLM config: err=%q", err.Error())
 	}
 	cloneGatewayToken := ""
 	if err == nil {
@@ -1370,16 +1337,14 @@ func (s *AgentHubService) CloneAgent(ctx context.Context, req CloneAgentRequest)
 			}
 		}
 
-		applyOutput, applyErr := s.applyFn(s.envdClient, sbResult.SandboxID, inst.Domain, clonePlan, cloneOpts)
+		applyOutput, applyErr := s.applyFn(ctx, s.envdClient, sbResult.SandboxID, inst.Domain, clonePlan, cloneOpts)
 		if applyErr != nil {
-			slog.Error("CloneAgent: failed to apply OpenClaw config, killing clone sandbox",
-				"agentID", agentID, "sandboxID", sbResult.SandboxID, "err", applyErr)
+			logging.G(ctx).Errorf("CloneAgent: failed to apply OpenClaw config, killing clone sandbox: agentID=%q sandboxID=%q err=%q", agentID, sbResult.SandboxID, applyErr.Error())
 			if _, derr := s.CM.DeleteSandbox(ctx, map[string]interface{}{
-				"requestID":     fmt.Sprintf("cubeops-clone-%d", time.Now().UnixNano()),
 				"sandbox_id":    sbResult.SandboxID,
 				"instance_type": SDKInstanceType,
 			}); derr != nil {
-				slog.Warn("CloneAgent: best-effort delete failed", "sandboxID", sbResult.SandboxID, "err", derr)
+				logging.G(ctx).Warnf("CloneAgent: best-effort delete failed: sandboxID=%q err=%q", sbResult.SandboxID, derr.Error())
 			}
 			if cloneOpenclawStatePath != "" {
 				_ = os.RemoveAll(cloneOpenclawStatePath)
@@ -1395,7 +1360,7 @@ func (s *AgentHubService) CloneAgent(ctx context.Context, req CloneAgentRequest)
 	if fallbackToken == "" {
 		fallbackToken = inst.GatewayToken
 	}
-	cloneGatewayToken = s.resolveGatewayFn(s.envdClient, sbResult.SandboxID, inst.Domain, cloneOpenclawStatePath, fallbackToken)
+	cloneGatewayToken = s.resolveGatewayFn(ctx, s.envdClient, sbResult.SandboxID, inst.Domain, cloneOpenclawStatePath, fallbackToken)
 	if cloneGatewayToken != "" {
 		gatewayURL = gatewayURL + "#token=" + cloneGatewayToken
 	}
@@ -1538,7 +1503,6 @@ func (s *AgentHubService) PublishTemplate(ctx context.Context, req PublishTempla
 			).Error
 		} else {
 			snapResp, err := s.CM.CreateSnapshot(ctx, map[string]interface{}{
-				"requestID":     fmt.Sprintf("cubeops-publish-%d", time.Now().UnixNano()),
 				"sandbox_id":    inst.SandboxID,
 				"instance_type": SDKInstanceType,
 			})
@@ -1620,8 +1584,7 @@ func (s *AgentHubService) PublishTemplate(ctx context.Context, req PublishTempla
 	}
 
 	if opErr := s.Store.RecordOperation(ctx, agentID, inst.SandboxID, "publish_template", "succeeded", ""); opErr != nil {
-		slog.Warn("PublishTemplate: failed to record operation",
-			"agentID", agentID, "templateID", templateID, "err", opErr)
+		logging.G(ctx).Warnf("PublishTemplate: failed to record operation: agentID=%q templateID=%q err=%q", agentID, templateID, opErr.Error())
 	}
 
 	return &PublishTemplateResult{TemplateID: templateID, SnapshotID: snapshotID}, nil

--- a/CubeOps/internal/service/agenthub.go
+++ b/CubeOps/internal/service/agenthub.go
@@ -463,8 +463,8 @@ func (s *AgentHubService) CreateInstance(ctx context.Context, req CreateInstance
 	if err != nil {
 		return nil, NewInternal("failed to build network config: " + err.Error())
 	}
-	// redact.Value here masks the embedded Secret(llm.APIKey) leaf that
-	// jsoniter would otherwise emit verbatim.
+	// redact.Value masks the "secret" key by name so the plaintext API key
+	// never appears in logs.
 	logging.G(ctx).WithFields(map[string]interface{}{"network_config": redact.Value(networkConfig)}).Debugf("agenthub: built egress network config")
 
 	// --- Shared-files + published-template fast-path detection ---
@@ -1272,6 +1272,7 @@ func (s *AgentHubService) CloneAgent(ctx context.Context, req CloneAgentRequest)
 	if cloneLLMCfgForNet, _ := ResolveLLMConfig(ctx, s.Store); cloneLLMCfgForNet != nil {
 		if nc, err := AgenthubNetworkConfig(cloneLLMCfgForNet); err == nil {
 			networkConfig = nc
+			// redact.Value masks "secret" by name; see the call site above.
 			logging.G(ctx).WithFields(map[string]interface{}{"network_config": redact.Value(networkConfig)}).Debugf("agenthub: built egress network config (clone)")
 		}
 	}

--- a/CubeOps/internal/service/agenthub_test.go
+++ b/CubeOps/internal/service/agenthub_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/tencentcloud/CubeSandbox/CubeOps/internal/cubemaster"
 	"github.com/tencentcloud/CubeSandbox/CubeOps/internal/store"
+	cubelog "github.com/tencentcloud/CubeSandbox/cubelog"
 	"gorm.io/gorm"
 )
 
@@ -168,22 +169,26 @@ type fakeServiceCM struct {
 	listTemplatesErr   error
 }
 
-func (f *fakeServiceCM) CreateSandbox(_ context.Context, body interface{}) (json.RawMessage, error) {
+func (f *fakeServiceCM) CreateSandbox(ctx context.Context, body interface{}) (json.RawMessage, error) {
+	cubemaster.EnsureRequestID(ctx, body)
 	f.createSandboxBody = decodeBody(body)
 	if f.createSandboxResp == nil {
 		f.createSandboxResp = json.RawMessage(`{"sandbox_id":"sb-test-123","ret":{"ret_code":0}}`)
 	}
 	return f.createSandboxResp, f.createSandboxErr
 }
-func (f *fakeServiceCM) DeleteSandbox(_ context.Context, body interface{}) (json.RawMessage, error) {
+func (f *fakeServiceCM) DeleteSandbox(ctx context.Context, body interface{}) (json.RawMessage, error) {
+	cubemaster.EnsureRequestID(ctx, body)
 	f.deleteSandboxBodies = append(f.deleteSandboxBodies, decodeBody(body))
 	return nil, f.deleteSandboxErr
 }
-func (f *fakeServiceCM) UpdateSandbox(_ context.Context, body interface{}) (json.RawMessage, error) {
+func (f *fakeServiceCM) UpdateSandbox(ctx context.Context, body interface{}) (json.RawMessage, error) {
+	cubemaster.EnsureRequestID(ctx, body)
 	f.updateSandboxBody = decodeBody(body)
 	return nil, f.updateSandboxErr
 }
-func (f *fakeServiceCM) CreateSnapshot(_ context.Context, body interface{}) (json.RawMessage, error) {
+func (f *fakeServiceCM) CreateSnapshot(ctx context.Context, body interface{}) (json.RawMessage, error) {
+	cubemaster.EnsureRequestID(ctx, body)
 	f.createSnapshotBody = decodeBody(body)
 	return f.createSnapshotResp, f.createSnapshotErr
 }
@@ -191,7 +196,8 @@ func (f *fakeServiceCM) DeleteSnapshot(_ context.Context, snapshotID string) (js
 	f.deleteSnapshotID = snapshotID
 	return nil, f.deleteSnapshotErr
 }
-func (f *fakeServiceCM) RollbackSandbox(_ context.Context, sandboxID string, body interface{}) (json.RawMessage, error) {
+func (f *fakeServiceCM) RollbackSandbox(ctx context.Context, sandboxID string, body interface{}) (json.RawMessage, error) {
+	cubemaster.EnsureRequestID(ctx, body)
 	f.rollbackBody = decodeBody(body)
 	return nil, f.rollbackErr
 }
@@ -216,10 +222,10 @@ func newTestService(s AgentStore, cm *fakeServiceCM) *AgentHubService {
 		Store:      s,
 		CM:         cm,
 		envdClient: nil,
-		applyFn: func(_ *http.Client, _ string, _ string, _ *LLMRuntimePlan, _ *OpenclawApplyOptions) (*CommandOutput, error) {
+		applyFn: func(_ context.Context, _ *http.Client, _ string, _ string, _ *LLMRuntimePlan, _ *OpenclawApplyOptions) (*CommandOutput, error) {
 			return &CommandOutput{ExitCode: 0, Stdout: "applied", Stderr: ""}, nil
 		},
-		resolveGatewayFn: func(_ *http.Client, _ string, _ string, _ string, fallback string) string {
+		resolveGatewayFn: func(_ context.Context, _ *http.Client, _ string, _ string, _ string, fallback string) string {
 			return fallback
 		},
 		restartFn: func(_ *store.AgentInstance) (*CommandOutput, error) {
@@ -356,11 +362,14 @@ func TestCreateInstance_ApplyFailureCompensates(t *testing.T) {
 	}
 	svc := newTestService(st, cm)
 	// Override applyFn to fail.
-	svc.applyFn = func(_ *http.Client, _ string, _ string, _ *LLMRuntimePlan, _ *OpenclawApplyOptions) (*CommandOutput, error) {
+	svc.applyFn = func(_ context.Context, _ *http.Client, _ string, _ string, _ *LLMRuntimePlan, _ *OpenclawApplyOptions) (*CommandOutput, error) {
 		return nil, errors.New("envd unreachable")
 	}
 
-	_, err := svc.CreateInstance(context.Background(), CreateInstanceRequest{
+	const inboundReqID = "svc-inbound-req-123"
+	ctx := cubelog.WithRequestTrace(context.Background(), &cubelog.RequestTrace{RequestID: inboundReqID})
+
+	_, err := svc.CreateInstance(ctx, CreateInstanceRequest{
 		Name:   "x",
 		Engine: "openclaw",
 	})
@@ -384,8 +393,8 @@ func TestCreateInstance_ApplyFailureCompensates(t *testing.T) {
 		t.Errorf("compensation instance_type = %v, want cubebox", comp["instance_type"])
 	}
 	reqID, _ := comp["requestID"].(string)
-	if !strings.HasPrefix(reqID, "cubeops-compensate-apply_openclaw-") {
-		t.Errorf("compensation requestID = %q, want prefix cubeops-compensate-apply_openclaw-", reqID)
+	if reqID != inboundReqID {
+		t.Errorf("compensation requestID = %q, want %q", reqID, inboundReqID)
 	}
 }
 
@@ -407,7 +416,10 @@ func TestCreateInstance_UpsertFailureCompensates(t *testing.T) {
 	}
 	svc := newTestService(st, cm)
 
-	_, err := svc.CreateInstance(context.Background(), CreateInstanceRequest{
+	const inboundReqID = "svc-inbound-req-456"
+	ctx := cubelog.WithRequestTrace(context.Background(), &cubelog.RequestTrace{RequestID: inboundReqID})
+
+	_, err := svc.CreateInstance(ctx, CreateInstanceRequest{
 		Name:   "x",
 		Engine: "openclaw",
 	})
@@ -420,8 +432,8 @@ func TestCreateInstance_UpsertFailureCompensates(t *testing.T) {
 	}
 	comp := cm.deleteSandboxBodies[0]
 	reqID, _ := comp["requestID"].(string)
-	if !strings.HasPrefix(reqID, "cubeops-compensate-upsert_instance-") {
-		t.Errorf("compensation requestID = %q, want prefix cubeops-compensate-upsert_instance-", reqID)
+	if reqID != inboundReqID {
+		t.Errorf("compensation requestID = %q, want %q", reqID, inboundReqID)
 	}
 }
 
@@ -556,11 +568,14 @@ func TestCloneAgent_ApplyFailureCompensates(t *testing.T) {
 		},
 	}
 	svc := newTestService(st, cm)
-	svc.applyFn = func(_ *http.Client, _ string, _ string, _ *LLMRuntimePlan, _ *OpenclawApplyOptions) (*CommandOutput, error) {
+	svc.applyFn = func(_ context.Context, _ *http.Client, _ string, _ string, _ *LLMRuntimePlan, _ *OpenclawApplyOptions) (*CommandOutput, error) {
 		return nil, errors.New("envd unreachable")
 	}
 
-	_, err := svc.CloneAgent(context.Background(), CloneAgentRequest{
+	const inboundReqID = "svc-inbound-req-789"
+	ctx := cubelog.WithRequestTrace(context.Background(), &cubelog.RequestTrace{RequestID: inboundReqID})
+
+	_, err := svc.CloneAgent(ctx, CloneAgentRequest{
 		AgentID: "agent-src",
 	})
 	if err == nil {
@@ -578,8 +593,8 @@ func TestCloneAgent_ApplyFailureCompensates(t *testing.T) {
 		t.Errorf("compensation sandbox_id = %v, want sb-test-123", comp["sandbox_id"])
 	}
 	reqID, _ := comp["requestID"].(string)
-	if !strings.HasPrefix(reqID, "cubeops-clone-") {
-		t.Errorf("compensation requestID = %q, want prefix cubeops-clone-", reqID)
+	if reqID != inboundReqID {
+		t.Errorf("compensation requestID = %q, want %q", reqID, inboundReqID)
 	}
 }
 

--- a/CubeOps/internal/service/openclaw.go
+++ b/CubeOps/internal/service/openclaw.go
@@ -17,7 +17,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"log/slog"
 	"net"
 	"net/http"
 	"net/url"
@@ -29,6 +28,8 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/tencentcloud/CubeSandbox/CubeOps/internal/crypto"
+	"github.com/tencentcloud/CubeSandbox/CubeOps/internal/logging"
+	"github.com/tencentcloud/CubeSandbox/CubeOps/internal/redact"
 	"github.com/tencentcloud/CubeSandbox/CubeOps/internal/store"
 )
 
@@ -202,32 +203,23 @@ func ReadOpenclawGatewayTokenFromHost(statePath string) string {
 	return strings.TrimSpace(v.Gateway.Auth.Token)
 }
 
-// ResolveGatewayToken reads the gateway token with the same priority as the
-// old Rust code (CubeAPI/src/handlers/agenthub.rs):
-//  1. host-side file (shared_files mode only)
-//  2. sandbox-side file via envd (single read)
-//  3. fallback (the token CubeOps generated and passed to the apply script)
-//
-// A 5-second sleep is performed first to let OpenClaw finish its in-process
-// config reload after the apply script writes openclaw.json. Without this
-// delay, the host/sandbox file may still contain a transient token that
-// OpenClaw generates during startup, which differs from the token the apply
-// script wrote. This matches the Rust `tokio::time::sleep(Duration::from_secs(5))`.
-func ResolveGatewayToken(httpClient *http.Client, sandboxID, domain, hostStatePath, fallbackToken string) string {
+// ResolveGatewayToken returns the OpenClaw gateway token, matching the
+// priority used by the old Rust handler (CubeAPI/src/handlers/agenthub.rs):
+// host file → sandbox file (via envd) → fallback (the token CubeOps passed
+// to the apply script). The 5s sleep lets OpenClaw finish its in-process
+// reload before we read the freshly written openclaw.json.
+func ResolveGatewayToken(ctx context.Context, httpClient *http.Client, sandboxID, domain, hostStatePath, fallbackToken string) string {
 	time.Sleep(5 * time.Second)
 
 	if hostToken := ReadOpenclawGatewayTokenFromHost(hostStatePath); hostToken != "" {
-		slog.Info("ResolveGatewayToken: using host-side token",
-			"sandboxID", sandboxID, "hostStatePath", hostStatePath)
+		logging.G(ctx).Debugf("ResolveGatewayToken: using host-side token: sandboxID=%q hostStatePath=%q", sandboxID, hostStatePath)
 		return hostToken
 	}
 	if sandboxToken := readOpenclawGatewayToken(httpClient, sandboxID, domain); sandboxToken != "" {
-		slog.Info("ResolveGatewayToken: using sandbox-side token",
-			"sandboxID", sandboxID)
+		logging.G(ctx).Debugf("ResolveGatewayToken: using sandbox-side token: sandboxID=%q", sandboxID)
 		return sandboxToken
 	}
-	slog.Info("ResolveGatewayToken: using fallback (generated) token",
-		"sandboxID", sandboxID)
+	logging.G(ctx).Debugf("ResolveGatewayToken: using fallback (generated) token: sandboxID=%q", sandboxID)
 	return fallbackToken
 }
 
@@ -744,7 +736,7 @@ type OpenclawApplyOptions struct {
 }
 
 // OpenclawApplySpec renders the JSON spec handed to the sandbox apply script.
-func OpenclawApplySpec(plan *LLMRuntimePlan, opts *OpenclawApplyOptions) map[string]interface{} {
+func OpenclawApplySpec(ctx context.Context, plan *LLMRuntimePlan, opts *OpenclawApplyOptions) map[string]interface{} {
 	// Defensive: every production caller supplies non-nil opts, but tests and
 	// future refactors might not. Default to merge_llm (the safe no-op mode)
 	// rather than panicking on a nil deref.
@@ -794,9 +786,9 @@ func OpenclawApplySpec(plan *LLMRuntimePlan, opts *OpenclawApplyOptions) map[str
 		if host := extractHostFromURL(plan.UpstreamBaseURL); host != "" {
 			if ips, err := net.LookupHost(host); err == nil && len(ips) > 0 {
 				spec["llmHostIp"] = ips[0]
-				slog.Info("resolved LLM host IP for /etc/hosts", "host", host, "ip", ips[0])
+				logging.G(ctx).Debugf("resolved LLM host IP for /etc/hosts: host=%s ip=%s", host, ips[0])
 			} else {
-				slog.Warn("failed to resolve LLM host IP", "host", host, "err", err)
+				logging.G(ctx).Warnf("failed to resolve LLM host IP: host=%s err=%q", host, err.Error())
 			}
 		}
 	}
@@ -814,8 +806,8 @@ func egressCAPem() string {
 // The store parameter was historically present but unused inside this
 // function; it has been dropped so the signature matches the applyFn field
 // on AgentHubService (which needs to be injectable for tests).
-func ApplyOpenclawRuntime(httpClient *http.Client, sandboxID, domain string, plan *LLMRuntimePlan, opts *OpenclawApplyOptions) (*CommandOutput, error) {
-	spec := OpenclawApplySpec(plan, opts)
+func ApplyOpenclawRuntime(ctx context.Context, httpClient *http.Client, sandboxID, domain string, plan *LLMRuntimePlan, opts *OpenclawApplyOptions) (*CommandOutput, error) {
+	spec := OpenclawApplySpec(ctx, plan, opts)
 	specBytes, err := json.Marshal(spec)
 	if err != nil {
 		return nil, fmt.Errorf("marshal apply spec: %w", err)
@@ -929,7 +921,7 @@ func LLMEgressRule(llm *LLMConfig) (map[string]interface{}, error) {
 			"inject": []map[string]interface{}{
 				{
 					"header": "Authorization",
-					"secret": llm.APIKey,
+					"secret": redact.Secret(llm.APIKey),
 					"format": format,
 				},
 			},

--- a/CubeOps/internal/service/openclaw.go
+++ b/CubeOps/internal/service/openclaw.go
@@ -29,7 +29,6 @@ import (
 	"github.com/google/uuid"
 	"github.com/tencentcloud/CubeSandbox/CubeOps/internal/crypto"
 	"github.com/tencentcloud/CubeSandbox/CubeOps/internal/logging"
-	"github.com/tencentcloud/CubeSandbox/CubeOps/internal/redact"
 	"github.com/tencentcloud/CubeSandbox/CubeOps/internal/store"
 )
 
@@ -921,7 +920,9 @@ func LLMEgressRule(llm *LLMConfig) (map[string]interface{}, error) {
 			"inject": []map[string]interface{}{
 				{
 					"header": "Authorization",
-					"secret": redact.Secret(llm.APIKey),
+					// Plaintext API key injected as the egress Authorization header.
+					// redact.Value() masks it by name at the log call site.
+					"secret": llm.APIKey,
 					"format": format,
 				},
 			},

--- a/CubeOps/internal/service/openclaw_test.go
+++ b/CubeOps/internal/service/openclaw_test.go
@@ -5,12 +5,16 @@ package service
 
 import (
 	"encoding/json"
-	"fmt"
 	"strings"
 	"testing"
+
+	"github.com/tencentcloud/CubeSandbox/CubeOps/internal/redact"
 )
 
-func TestLLMEgressRuleProtectsAPIKeyWhenFormatted(t *testing.T) {
+// TestLLMEgressRule_PlaintextForTransportAndRedactedForLog verifies that
+// LLMEgressRule returns the plaintext API key for transport while redact.Value()
+// masks it in logs.
+func TestLLMEgressRule_PlaintextForTransportAndRedactedForLog(t *testing.T) {
 	const apiKey = "sk-DO-NOT-LOG"
 
 	rule, err := LLMEgressRule(&LLMConfig{
@@ -22,23 +26,33 @@ func TestLLMEgressRuleProtectsAPIKeyWhenFormatted(t *testing.T) {
 		t.Fatalf("LLMEgressRule: %v", err)
 	}
 
-	action, ok := rule["action"].(map[string]interface{})
-	if !ok {
-		t.Fatal("action has unexpected type")
-	}
-	inject, ok := action["inject"].([]map[string]interface{})
-	if !ok || len(inject) != 1 {
-		t.Fatalf("inject has unexpected value: %#v", action["inject"])
-	}
-	if got := fmt.Sprint(inject[0]["secret"]); got != "***REDACTED***" {
-		t.Fatalf("formatted secret = %q, want redacted value", got)
-	}
-
+	// 1. Transport payload must carry the plaintext API key.
 	payload, err := json.Marshal(rule)
 	if err != nil {
 		t.Fatalf("json.Marshal: %v", err)
 	}
 	if !strings.Contains(string(payload), apiKey) {
-		t.Fatalf("transport payload does not contain the API key required by CubeEgress: %s", payload)
+		t.Fatalf("transport payload missing the API key: %s", payload)
+	}
+
+	// 2. After redact.Value(), the rule must be safe to log.
+	redactedRule := redact.Value(rule).(map[string]interface{})
+	action := redactedRule["action"].(map[string]interface{})
+	inject := action["inject"].([]interface{})
+	inj0 := inject[0].(map[string]interface{})
+
+	if got := inj0["secret"]; got != "***REDACTED***" {
+		t.Errorf("redacted secret leaf = %v, want \"***REDACTED***\"", got)
+	}
+
+	redactedPayload, err := json.Marshal(redactedRule)
+	if err != nil {
+		t.Fatalf("json.Marshal(redacted): %v", err)
+	}
+	if strings.Contains(string(redactedPayload), apiKey) {
+		t.Errorf("redacted payload leaked the API key: %s", redactedPayload)
+	}
+	if !strings.Contains(string(redactedPayload), "Bearer ${SECRET}") {
+		t.Errorf("redacted payload dropped the \"format\" field: %s", redactedPayload)
 	}
 }

--- a/CubeOps/internal/service/openclaw_test.go
+++ b/CubeOps/internal/service/openclaw_test.go
@@ -1,0 +1,44 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package service
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func TestLLMEgressRuleProtectsAPIKeyWhenFormatted(t *testing.T) {
+	const apiKey = "sk-DO-NOT-LOG"
+
+	rule, err := LLMEgressRule(&LLMConfig{
+		Provider: "test",
+		BaseURL:  "https://llm.example.test/v1",
+		APIKey:   apiKey,
+	})
+	if err != nil {
+		t.Fatalf("LLMEgressRule: %v", err)
+	}
+
+	action, ok := rule["action"].(map[string]interface{})
+	if !ok {
+		t.Fatal("action has unexpected type")
+	}
+	inject, ok := action["inject"].([]map[string]interface{})
+	if !ok || len(inject) != 1 {
+		t.Fatalf("inject has unexpected value: %#v", action["inject"])
+	}
+	if got := fmt.Sprint(inject[0]["secret"]); got != "***REDACTED***" {
+		t.Fatalf("formatted secret = %q, want redacted value", got)
+	}
+
+	payload, err := json.Marshal(rule)
+	if err != nil {
+		t.Fatalf("json.Marshal: %v", err)
+	}
+	if !strings.Contains(string(payload), apiKey) {
+		t.Fatalf("transport payload does not contain the API key required by CubeEgress: %s", payload)
+	}
+}

--- a/CubeOps/internal/store/db.go
+++ b/CubeOps/internal/store/db.go
@@ -6,13 +6,13 @@ package store
 import (
 	"context"
 	"fmt"
-	"log/slog"
 
 	"github.com/tencentcloud/CubeSandbox/CubeDB/dao"
 	"github.com/tencentcloud/CubeSandbox/CubeDB/dao/driver/mysql"
 	"github.com/tencentcloud/CubeSandbox/CubeDB/dao/driver/postgres"
 	"github.com/tencentcloud/CubeSandbox/CubeDB/migrate"
 	"github.com/tencentcloud/CubeSandbox/CubeOps/internal/crypto"
+	"github.com/tencentcloud/CubeSandbox/CubeOps/internal/logging"
 	"gorm.io/gorm"
 )
 
@@ -33,12 +33,12 @@ func New(ctx context.Context, cfg dao.Config) (*Store, error) {
 	}
 
 	if migrate.AutoMigrationEnabled() {
-		slog.Info("running database migrations")
+		logging.G(ctx).Info("running database migrations")
 		if err := dao.Migrate(ctx); err != nil {
 			return nil, fmt.Errorf("schema migration failed: %w", err)
 		}
 	} else {
-		slog.Warn("CUBE_AUTO_MIGRATION=false: skipping schema migration; DDL must be applied out-of-band by a privileged account")
+		logging.G(ctx).Warn("CUBE_AUTO_MIGRATION=false: skipping schema migration; DDL must be applied out-of-band by a privileged account")
 	}
 
 	s := &Store{db: gormDB}
@@ -53,7 +53,7 @@ func New(ctx context.Context, cfg dao.Config) (*Store, error) {
 		return nil, fmt.Errorf("seed default admin: %w", err)
 	}
 
-	slog.Info("database initialised")
+	logging.G(ctx).Info("database initialised")
 	return s, nil
 }
 
@@ -100,7 +100,7 @@ func (s *Store) bootstrapMasterKey(ctx context.Context) error {
 		if err := crypto.InstallMasterKey(b64); err != nil {
 			return fmt.Errorf("install master key: %w", err)
 		}
-		slog.Info("master encryption key loaded from database")
+		logging.G(ctx).Info("master encryption key loaded from database")
 		return nil
 	}
 
@@ -116,7 +116,7 @@ func (s *Store) bootstrapMasterKey(ctx context.Context) error {
 	if err := crypto.InstallMasterKey(b64); err != nil {
 		return fmt.Errorf("install master key: %w", err)
 	}
-	slog.Info("master encryption key generated and persisted to t_system_setting")
+	logging.G(ctx).Info("master encryption key generated and persisted to t_system_setting")
 	return nil
 }
 
@@ -141,9 +141,9 @@ func (s *Store) BootstrapJWTSecret(ctx context.Context, envSecret string) (strin
 		return "", fmt.Errorf("persist JWT secret: %w", err)
 	}
 	if winner == generated {
-		slog.Info("JWT secret auto-generated and persisted to database (t_system_setting)")
+		logging.G(ctx).Info("JWT secret auto-generated and persisted to database (t_system_setting)")
 	} else {
-		slog.Info("JWT secret loaded from database (t_system_setting)")
+		logging.G(ctx).Info("JWT secret loaded from database (t_system_setting)")
 	}
 	return winner, nil
 }

--- a/CubeOps/internal/store/setting.go
+++ b/CubeOps/internal/store/setting.go
@@ -7,6 +7,8 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+
+	"gorm.io/gorm"
 )
 
 const settingMasterKey = "secret_master_key"
@@ -80,6 +82,22 @@ func (s *Store) SetSetting(ctx context.Context, key, value string) error {
 		upsertSettingSQL("t_agenthub_setting"),
 		key, value,
 	).Error
+}
+
+// SetSettingsTx upserts multiple AgentHub settings atomically in one
+// transaction, rolling back the whole batch on any failure.
+func (s *Store) SetSettingsTx(ctx context.Context, kv map[string]string) error {
+	if len(kv) == 0 {
+		return nil
+	}
+	return s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		for key, value := range kv {
+			if err := tx.Exec(upsertSettingSQL("t_agenthub_setting"), key, value).Error; err != nil {
+				return err
+			}
+		}
+		return nil
+	})
 }
 
 // ── System users (t_system_user) ────────────────────────────────────────────

--- a/CubeOps/internal/translator/translator.go
+++ b/CubeOps/internal/translator/translator.go
@@ -417,13 +417,7 @@ func TransformTemplateDetail(raw json.RawMessage) interface{} {
 		result[camelKey] = val
 	}
 
-	// Promote network fields from createRequest to the top level, matching
-	// old CubeAPI behavior where it lifted create_request.network_type to a
-	// top-level networkType so the WebUI template detail page can render the
-	// "网络类型" column. allowInternetAccess is also lifted from the nested
-	// cube_network_config object so the WebUI "公网访问" column reflects the
-	// template's egress policy without requiring the frontend to traverse the
-	// nested createRequest structure.
+	// Promote network fields for the WebUI template detail view.
 	if cr, ok := result["createRequest"].(map[string]interface{}); ok {
 		if v, ok := cr["network_type"]; ok && v != nil {
 			if _, exists := result["networkType"]; !exists {

--- a/CubeOps/internal/version/version.go
+++ b/CubeOps/internal/version/version.go
@@ -1,0 +1,22 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Package version provides CubeOps build version information.
+package version
+
+import "runtime"
+
+var (
+	// Version is injected at build time with -ldflags.
+	Version = "0.0.0-dev"
+	// Commit is injected at build time with -ldflags.
+	Commit = "unknown"
+	// BuildTime is injected at build time with -ldflags.
+	BuildTime = "unknown"
+	GoVersion = runtime.Version()
+)
+
+// ShowVersion returns the semantic version used by cubelog records.
+func ShowVersion() string {
+	return Version
+}

--- a/Makefile
+++ b/Makefile
@@ -322,7 +322,7 @@ cube-api: cubeapi
 .PHONY: cubeops
 cubeops: builder-image
 	@mkdir -p "$(OUTPUT_DIR)"
-	$(MAKE) builder-run BUILDER_CMD="mkdir -p /workspace/_output/bin && cd /workspace/CubeOps && go mod download && CGO_ENABLED=0 GOOS=linux GOARCH=$$(go env GOARCH) go build -ldflags '-s -w -X main.Version=$(CUBE_VERSION) -X main.Commit=$(CUBE_COMMIT) -X main.BuildTime=$(CUBE_BUILD_TIME)' -o /workspace/_output/bin/cubeops ./cmd/cubeops"
+	$(MAKE) builder-run BUILDER_CMD="mkdir -p /workspace/_output/bin && cd /workspace/CubeOps && go mod download && CGO_ENABLED=0 GOOS=linux GOARCH=$$(go env GOARCH) go build -ldflags '-s -w -X github.com/tencentcloud/CubeSandbox/CubeOps/internal/version.Version=$(CUBE_VERSION) -X github.com/tencentcloud/CubeSandbox/CubeOps/internal/version.Commit=$(CUBE_COMMIT) -X github.com/tencentcloud/CubeSandbox/CubeOps/internal/version.BuildTime=$(CUBE_BUILD_TIME)' -o /workspace/_output/bin/cubeops ./cmd/cubeops"
 
 .PHONY: cubeops-test
 cubeops-test: builder-image

--- a/deploy/one-click/build-release-bundle-builder.sh
+++ b/deploy/one-click/build-release-bundle-builder.sh
@@ -61,9 +61,11 @@ go_version_ldflags() {
 
 CUBEMASTER_VERSION_PKG="github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/version"
 CUBELET_VERSION_PKG="github.com/tencentcloud/CubeSandbox/Cubelet/pkg/version"
+CUBEOPS_VERSION_PKG="github.com/tencentcloud/CubeSandbox/CubeOps/internal/version"
 
 CUBEMASTER_LDFLAGS="$(go_version_ldflags "${CUBEMASTER_VERSION_PKG}")"
 CUBELET_LDFLAGS="$(go_version_ldflags "${CUBELET_VERSION_PKG}")"
+CUBEOPS_LDFLAGS="$(go_version_ldflags "${CUBEOPS_VERSION_PKG}")"
 
 PREBUILT_DIR="/workspace/deploy/one-click/.work/prebuilt"
 mkdir -p "${PREBUILT_DIR}"
@@ -346,7 +348,7 @@ track_cube_api() {
 track_cubeops() {
   cd /workspace/CubeOps
   go mod download
-  go build -ldflags "-s -w" -o "${PREBUILT_DIR}/cubeops" ./cmd/cubeops
+  go build -ldflags "${CUBEOPS_LDFLAGS}" -o "${PREBUILT_DIR}/cubeops" ./cmd/cubeops
 }
 
 track_netstack() {

--- a/deploy/one-click/build-release-bundle.sh
+++ b/deploy/one-click/build-release-bundle.sh
@@ -637,6 +637,7 @@ mkdir -p "${CORE_BIN_DIR}"
 
 CUBEMASTER_VERSION_PKG="github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/version"
 CUBELET_VERSION_PKG="github.com/tencentcloud/CubeSandbox/Cubelet/pkg/version"
+CUBEOPS_VERSION_PKG="github.com/tencentcloud/CubeSandbox/CubeOps/internal/version"
 
 build_or_copy_go_binary \
   "cubemaster" "${CUBEMASTER_BIN_OVERRIDE}" \
@@ -661,7 +662,7 @@ build_or_copy_rust_binary \
 build_or_copy_go_binary \
   "cubeops" "${CUBE_OPS_BIN_OVERRIDE}" \
   "${ROOT_DIR}/CubeOps" "${CUBE_OPS_BUILD_MODE}" \
-  "${CORE_BIN_DIR}/cubeops" ./cmd/cubeops
+  "${CORE_BIN_DIR}/cubeops" ./cmd/cubeops "${CUBEOPS_VERSION_PKG}"
 
 build_or_copy_go_binary \
   "cubevsmapdump" "${CUBEVSMAPDUMP_BIN_OVERRIDE}" \

--- a/deploy/one-click/webui/nginx.conf
+++ b/deploy/one-click/webui/nginx.conf
@@ -58,6 +58,7 @@ http {
 
         # CubeOps (ops/admin endpoints) — rewrite /opsapi → /api
         location /opsapi/ {
+            add_header Cache-Control "no-store" always;
             proxy_http_version 1.1;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;

--- a/deploy/one-click/webui/nginx.conf
+++ b/deploy/one-click/webui/nginx.conf
@@ -58,7 +58,6 @@ http {
 
         # CubeOps (ops/admin endpoints) — rewrite /opsapi → /api
         location /opsapi/ {
-            add_header Cache-Control "no-store" always;
             proxy_http_version 1.1;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;


### PR DESCRIPTION
- Replace scattered standard logging with structured cubelog output.
- Add rolling request and statistics logs under /data/log/CubeOps.
- Record request ID, caller, callee, path, status code, and latency.
- Propagate request-scoped logging context through auth, SDK, AgentHub, CubeMaster client, and service handlers.
- Add build-time version, commit, and build timestamp metadata.
- Add logging coverage for request tracing and log-level handling.