### PR TITLE
feat(cubemaster): support safe node deletion

### DIFF
--- a/CubeMaster/cmd/cubemastercli/commands/cubebox/node.go
+++ b/CubeMaster/cmd/cubemastercli/commands/cubebox/node.go
@@ -44,14 +44,22 @@ var nodeIsolationFlags = []cli.Flag{
 	},
 }
 
+var nodeDeleteFlags = append(nodeIsolationFlags,
+	cli.BoolFlag{
+		Name:  "force",
+		Usage: "delete without verifying sandbox inventory",
+	},
+)
+
 var NodeCommand = cli.Command{
 	Name:    "node",
 	Aliases: []string{"nodes"},
-	Usage:   "list / isolate / unisolate cubemaster nodes",
+	Usage:   "list / isolate / unisolate / delete cubemaster nodes",
 	Subcommands: cli.Commands{
 		NodeListCommand,
 		NodeIsolateCommand,
 		NodeUnisolateCommand,
+		NodeDeleteCommand,
 	},
 }
 
@@ -133,6 +141,85 @@ var NodeUnisolateCommand = cli.Command{
 	Action: func(c *cli.Context) error {
 		return doNodeIsolation(c, http.MethodDelete)
 	},
+}
+
+var NodeDeleteCommand = cli.Command{
+	Name:      "delete",
+	Aliases:   []string{"rm"},
+	Usage:     "delete isolated, empty node(s)",
+	ArgsUsage: "<node-id> [node-id ...]",
+	Flags:     nodeDeleteFlags,
+	Action: func(c *cli.Context) error {
+		if c.NArg() == 0 {
+			_ = cli.ShowCommandHelp(c, "delete")
+			return errors.New("node id is required")
+		}
+		if !confirmForceNodeDeletion(c.Bool("force"), commands.AskForConfirm) {
+			fmt.Println("force deletion cancelled")
+			return nil
+		}
+		serverList = getServerAddrs(c)
+		if len(serverList) == 0 {
+			return errors.New("no server addr")
+		}
+		port = c.GlobalString("port")
+		var opErr error
+		for _, nodeID := range c.Args() {
+			if err := deleteOneNode(c, nodeID); err != nil {
+				log.Printf("delete failed: %s %s\n", nodeID, err.Error())
+				opErr = errors.Join(opErr, fmt.Errorf("%s: %w", nodeID, err))
+			}
+		}
+		return opErr
+	},
+}
+
+func confirmForceNodeDeletion(force bool, confirm func(string, int) bool) bool {
+	if !force {
+		return true
+	}
+	return confirm(
+		"force deletion will remove the node without considering any sandboxes on it; continue only if you confirm",
+		3,
+	)
+}
+
+func deleteOneNode(c *cli.Context, nodeID string) error {
+	requestID := uuid.New().String()
+	host := serverList[rand.Int()%len(serverList)]
+	u := nodeDeleteURL(host, port, nodeID, c.Bool("force"))
+	rsp := &types.Res{}
+	if err := doHttpReq(c, u.String(), http.MethodDelete, requestID, bytes.NewReader(nil), rsp); err != nil {
+		return err
+	}
+	if rsp.Ret == nil {
+		return errors.New("empty response")
+	}
+	if rsp.Ret.RetCode != 200 {
+		return errors.New(rsp.Ret.RetMsg)
+	}
+	if c.Bool("json") {
+		commands.PrintAsJSON(rsp)
+		return nil
+	}
+	fmt.Printf("node %s deleted\n", nodeID)
+	return nil
+}
+
+func nodeDeleteURL(host, port, nodeID string, force bool) *url.URL {
+	pathPrefix := "/internal/meta/nodes/"
+	u := &url.URL{
+		Scheme:  "http",
+		Host:    net.JoinHostPort(host, port),
+		Path:    pathPrefix + nodeID,
+		RawPath: pathPrefix + url.PathEscape(nodeID),
+	}
+	if force {
+		q := u.Query()
+		q.Set("force", "true")
+		u.RawQuery = q.Encode()
+	}
+	return u
 }
 
 func doNodeIsolation(c *cli.Context, method string) error {

--- a/CubeMaster/cmd/cubemastercli/commands/cubebox/node_test.go
+++ b/CubeMaster/cmd/cubemastercli/commands/cubebox/node_test.go
@@ -205,3 +205,54 @@ func TestPrintNodeSummaryScoreOnlyKeepsScoreColumns(t *testing.T) {
 		}
 	}
 }
+
+func TestNodeDeleteURLAddsForceQuery(t *testing.T) {
+	normal := nodeDeleteURL("127.0.0.1", "8089", "node/a", false)
+	if normal.Query().Has("force") {
+		t.Fatalf("normal delete unexpectedly has force query: %s", normal)
+	}
+	if normal.EscapedPath() != "/internal/meta/nodes/node%2Fa" {
+		t.Fatalf("node ID path was not escaped: %s", normal.EscapedPath())
+	}
+
+	forced := nodeDeleteURL("127.0.0.1", "8089", "node/a", true)
+	if forced.Query().Get("force") != "true" {
+		t.Fatalf("forced delete missing force=true query: %s", forced)
+	}
+}
+
+func TestConfirmForceNodeDeletion(t *testing.T) {
+	t.Run("normal deletion does not prompt", func(t *testing.T) {
+		called := false
+		if !confirmForceNodeDeletion(false, func(string, int) bool {
+			called = true
+			return false
+		}) {
+			t.Fatal("normal deletion should proceed without confirmation")
+		}
+		if called {
+			t.Fatal("normal deletion unexpectedly requested confirmation")
+		}
+	})
+
+	t.Run("force deletion warns and respects rejection", func(t *testing.T) {
+		var prompt string
+		var tries int
+		confirmed := confirmForceNodeDeletion(true, func(message string, attempts int) bool {
+			prompt = message
+			tries = attempts
+			return false
+		})
+		if confirmed {
+			t.Fatal("force deletion should stop when confirmation is rejected")
+		}
+		for _, wanted := range []string{"force deletion", "without considering", "sandboxes"} {
+			if !strings.Contains(prompt, wanted) {
+				t.Fatalf("prompt=%q, missing %q", prompt, wanted)
+			}
+		}
+		if tries != 3 {
+			t.Fatalf("tries=%d want 3", tries)
+		}
+	})
+}

--- a/CubeMaster/pkg/localcache/export.go
+++ b/CubeMaster/pkg/localcache/export.go
@@ -224,6 +224,39 @@ func NotifyEvent(e *Event) error {
 	}
 }
 
+// EvictNode synchronously removes every scheduler-local view owned by nodeID.
+// It is used after a node deletion commits and by metadata reloads on replicas
+// that observe the deleted registration later.
+func EvictNode(nodeID string) {
+	if nodeID == "" {
+		return
+	}
+	SyncNodeTemplates(nodeID, nil)
+	if l.templateNodeCache != nil {
+		l.templateNodeCache.Delete(nodeID)
+	}
+	if l.cache == nil {
+		return
+	}
+	if existing, ok := l.cache.Get(nodeID); ok {
+		if n, valid := existing.(*node.Node); valid {
+			l.delNodeCache(n)
+			return
+		}
+	}
+	l.cache.Delete(nodeID)
+	// The cache entry may already be gone while a stale pointer still remains
+	// in any instance-type list. Without the original node we cannot derive its
+	// cluster, so remove the ID from every list.
+	l.lockSortedNodes.Lock()
+	defer l.lockSortedNodes.Unlock()
+	candidate := &node.Node{InsID: nodeID}
+	for product, nodes := range l.sortedNodesByClusters {
+		nodes.Remove(candidate)
+		l.sortedNodesByClusters[product] = nodes
+	}
+}
+
 func SetSandboxProxyMap(ctx context.Context, proxyInfo *types.SandboxProxyMap) error {
 	return l.setByPassProsyToRedis(ctx, rediskey.SandboxProxy(proxyInfo.SandboxID), proxyInfo)
 }

--- a/CubeMaster/pkg/localcache/export_test.go
+++ b/CubeMaster/pkg/localcache/export_test.go
@@ -157,6 +157,36 @@ func TestGetHealthyNodesByInstanceType(t *testing.T) {
 	}
 }
 
+func TestEvictNodeRemovesStaleEntryFromEveryCluster(t *testing.T) {
+	origNodesByClusters := l.sortedNodesByClusters
+	origCache := l.cache
+	origImageCache := l.imageCache
+	origTemplateNodeCache := l.templateNodeCache
+	defer func() {
+		l.sortedNodesByClusters = origNodesByClusters
+		l.cache = origCache
+		l.imageCache = origImageCache
+		l.templateNodeCache = origTemplateNodeCache
+	}()
+
+	stale := &node.Node{InsID: "deleted"}
+	l.cache = cache.New(0, 0)
+	l.imageCache = cache.New(0, 0)
+	l.templateNodeCache = cache.New(0, 0)
+	l.sortedNodesByClusters = map[string]node.NodeList{
+		"default": {stale},
+		"gpu":     {stale},
+	}
+
+	EvictNode("deleted")
+
+	for cluster, nodes := range l.sortedNodesByClusters {
+		if len(nodes) != 0 {
+			t.Fatalf("cluster %s still contains deleted node: %+v", cluster, nodes)
+		}
+	}
+}
+
 func TestSyncNodeTemplatesReconcilesHeartbeatState(t *testing.T) {
 	origCache := l.cache
 	origImageCache := l.imageCache

--- a/CubeMaster/pkg/localcache/redis_cache.go
+++ b/CubeMaster/pkg/localcache/redis_cache.go
@@ -168,6 +168,25 @@ func WriteNodeMetric(ctx context.Context, m *NodeMetric) error {
 	return nil
 }
 
+// DeleteNodeMetric removes both current and legacy metric keys for a retired
+// node. Cache eviction remains correct if Redis is temporarily unavailable,
+// so callers may log this error after the database transaction has committed.
+func DeleteNodeMetric(ctx context.Context, nodeID string) error {
+	if nodeID == "" {
+		return errors.New("DeleteNodeMetric: node id required")
+	}
+	keys := rediskey.DeleteKeys(rediskey.NodeMetric(nodeID), rediskey.LegacyNodeMetric(nodeID))
+	args := redis.Args{}
+	for _, key := range keys {
+		args = args.Add(key)
+	}
+	if _, err := wrapredis.GetRedis().Do("DEL", args...); err != nil {
+		log.G(ctx).Errorf("DeleteNodeMetric DEL failed node_id=%s: %v", nodeID, err)
+		return err
+	}
+	return nil
+}
+
 // nodeMetricTTLSec returns the configured node-metric safety TTL in seconds.
 func nodeMetricTTLSec() int {
 	if c := config.GetConfig().RedisConf; c != nil {

--- a/CubeMaster/pkg/nodemeta/deletion.go
+++ b/CubeMaster/pkg/nodemeta/deletion.go
@@ -1,0 +1,95 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package nodemeta
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/constants"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/db/models"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/log"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/localcache"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+var (
+	ErrNodeNotIsolated = errors.New("node must be isolated before deletion")
+	ErrNodeNotFound    = errors.New("node not found")
+)
+
+// DeleteNode removes the node's current control-plane metadata. A later
+// Cubelet restart may register the same node ID again. The node must first be
+// cordoned. The service layer is responsible for confirming that the Cubelet
+// has no sandboxes before calling this function.
+func DeleteNode(ctx context.Context, nodeID string) error {
+	if nodeID == "" {
+		return fmt.Errorf("node_id is required")
+	}
+	unlock := global.lockNodeLabels(nodeID)
+	defer unlock()
+
+	var reg models.NodeRegistration
+	if err := global.db.WithContext(ctx).Where("node_id = ?", nodeID).Take(&reg).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return fmt.Errorf("%w: %s", ErrNodeNotFound, nodeID)
+		}
+		return err
+	}
+	labels, err := parseLabelsJSON(reg.LabelsJSON)
+	if err != nil {
+		return fmt.Errorf("%w: %v", ErrLabelsJSONCorrupt, err)
+	}
+	if !schedulingDisabledFromLabels(labels) {
+		return ErrNodeNotIsolated
+	}
+
+	if err := global.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		var reg models.NodeRegistration
+		if err := tx.Clauses(clause.Locking{Strength: "UPDATE"}).
+			Where("node_id = ?", nodeID).Take(&reg).Error; err != nil {
+			return err
+		}
+		lockedLabels, err := parseLabelsJSON(reg.LabelsJSON)
+		if err != nil {
+			return fmt.Errorf("%w: %v", ErrLabelsJSONCorrupt, err)
+		}
+		if !schedulingDisabledFromLabels(lockedLabels) {
+			return ErrNodeNotIsolated
+		}
+		if err := tx.Unscoped().Where("node_id = ?", nodeID).Delete(&models.NodeStatus{}).Error; err != nil {
+			return err
+		}
+		if err := tx.Where("node_id = ?", nodeID).Delete(&models.NodeComponentVersion{}).Error; err != nil {
+			return err
+		}
+		return tx.Unscoped().Where("node_id = ?", nodeID).Delete(&models.NodeRegistration{}).Error
+	}); err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return fmt.Errorf("%w: %s", ErrNodeNotFound, nodeID)
+		}
+		return err
+	}
+
+	global.mu.Lock()
+	delete(global.nodes, nodeID)
+	global.mu.Unlock()
+	evictDeletedNode(ctx, nodeID)
+	log.G(ctx).Infof("node deleted node_id=%s", nodeID)
+	return nil
+}
+
+func schedulingDisabledFromLabels(labels map[string]string) bool {
+	return labels[constants.LabelSchedulingDisabled] == constants.LabelSchedulingDisabledValue
+}
+
+func evictDeletedNode(ctx context.Context, nodeID string) {
+	localcache.EvictNode(nodeID)
+	if err := localcache.DeleteNodeMetric(ctx, nodeID); err != nil {
+		log.G(ctx).Warnf("node metric cleanup failed after deletion node_id=%s err=%v", nodeID, err)
+	}
+}

--- a/CubeMaster/pkg/nodemeta/deletion_test.go
+++ b/CubeMaster/pkg/nodemeta/deletion_test.go
@@ -1,0 +1,69 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package nodemeta
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/constants"
+)
+
+func TestSchedulingDisabledFromLabelsRequiresCanonicalValue(t *testing.T) {
+	assert.False(t, schedulingDisabledFromLabels(nil))
+	assert.False(t, schedulingDisabledFromLabels(map[string]string{
+		constants.LabelSchedulingDisabled: "false",
+	}))
+	assert.True(t, schedulingDisabledFromLabels(map[string]string{
+		constants.LabelSchedulingDisabled: constants.LabelSchedulingDisabledValue,
+	}))
+}
+
+func TestApplyReloadResultEvictsMissingNode(t *testing.T) {
+	s := newTestService(
+		&NodeSnapshot{NodeID: "keep"},
+		&NodeSnapshot{NodeID: "deleted"},
+	)
+	s.applyReloadResult(map[string]*NodeSnapshot{"keep": {NodeID: "keep"}})
+
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	_, kept := s.nodes["keep"]
+	_, deleted := s.nodes["deleted"]
+	assert.True(t, kept)
+	assert.False(t, deleted)
+}
+
+func TestApplyReloadResultDoesNotEvictReregisteredNode(t *testing.T) {
+	s := newTestService(
+		&NodeSnapshot{NodeID: "keep"},
+		&NodeSnapshot{NodeID: "reregistered"},
+	)
+	s.ready = true
+	origSync := syncNodeHealthFn
+	origEvict := evictNodeFn
+	defer func() {
+		syncNodeHealthFn = origSync
+		evictNodeFn = origEvict
+	}()
+
+	syncNodeHealthFn = func(*NodeSnapshot) {
+		s.mu.Lock()
+		s.nodes["reregistered"] = &NodeSnapshot{NodeID: "reregistered"}
+		s.mu.Unlock()
+	}
+	var evicted []string
+	evictNodeFn = func(nodeID string) {
+		evicted = append(evicted, nodeID)
+	}
+
+	s.applyReloadResult(map[string]*NodeSnapshot{"keep": {NodeID: "keep"}})
+
+	s.mu.RLock()
+	_, registered := s.nodes["reregistered"]
+	s.mu.RUnlock()
+	assert.True(t, registered)
+	assert.NotContains(t, evicted, "reregistered")
+}

--- a/CubeMaster/pkg/nodemeta/service.go
+++ b/CubeMaster/pkg/nodemeta/service.go
@@ -209,9 +209,10 @@ type service struct {
 	// version writes or overwrite a newer in-memory hash with an older one.
 	versionWriteLocks sync.Map
 
-	// labelWriteLocks serialises label read-modify-write (register merge,
-	// admin labels, isolation) per node so DB commit and in-memory/localcache
-	// publication stay ordered.
+	// labelWriteLocks serialises the complete per-node lifecycle (register,
+	// heartbeat, labels, isolation, deletion) so DB commit and in-memory/cache
+	// publication stay ordered on a replica. Database row locks provide the
+	// corresponding cross-replica ordering.
 	labelWriteLocks sync.Map
 
 	// hostFactsWriteLocks serialises the host-facts persist per node so
@@ -390,13 +391,26 @@ func UpdateNodeStatus(ctx context.Context, nodeID string, req *UpdateNodeStatusR
 		HeartbeatUnix:      req.HeartbeatTime.Unix(),
 		Healthy:            reportedReady,
 	}
-	if err := global.db.Clauses(clause.OnConflict{
-		Columns: []clause.Column{{Name: "node_id"}},
-		DoUpdates: clause.AssignmentColumns([]string{
-			"conditions_json", "images_json", "local_templates_json",
-			"heartbeat_unix", "healthy", "updated_at",
-		}),
-	}).Create(status).Error; err != nil {
+	// Serialize status writes with the complete per-node lifecycle. The
+	// registration row lock prevents a heartbeat from recreating status after
+	// deletion has committed; a heartbeat for a retired registration therefore
+	// fails instead of leaving an orphan NodeStatus row.
+	unlock := global.lockNodeLabels(nodeID)
+	defer unlock()
+	if err := global.db.Transaction(func(tx *gorm.DB) error {
+		var reg models.NodeRegistration
+		if err := tx.Clauses(clause.Locking{Strength: "UPDATE"}).
+			Where("node_id = ?", nodeID).Take(&reg).Error; err != nil {
+			return err
+		}
+		return tx.Clauses(clause.OnConflict{
+			Columns: []clause.Column{{Name: "node_id"}},
+			DoUpdates: clause.AssignmentColumns([]string{
+				"conditions_json", "images_json", "local_templates_json",
+				"heartbeat_unix", "healthy", "updated_at",
+			}),
+		}).Create(status).Error
+	}); err != nil {
 		return nil, err
 	}
 
@@ -968,7 +982,7 @@ func GetNode(ctx context.Context, nodeID string) (*NodeSnapshot, error) {
 	defer global.mu.RUnlock()
 	snap, ok := global.nodes[nodeID]
 	if !ok {
-		return nil, gorm.ErrRecordNotFound
+		return nil, fmt.Errorf("%w: %s", ErrNodeNotFound, nodeID)
 	}
 	return cloneSnapshotWithCurrentHealth(snap, time.Now()), nil
 }
@@ -1334,8 +1348,17 @@ func (s *service) reload() error {
 // it could not match and sandbox creation failed with "template has no ready
 // replica" (130400). Pushing node health here lets that DB fallback match and
 // self-heal template locality on demand.
+//
+// Known race: next is a point-in-time DB snapshot. If node deletion commits
+// after reload reads that snapshot but before it is merged here, the stale
+// snapshot can briefly reinsert the deleted node into s.nodes and localcache.
+// The node was required to be isolated before deletion, so the stale snapshot
+// remains scheduling-disabled and does not admit new sandboxes; a subsequent
+// reload removes it after observing the missing registration. We currently
+// accept this short-lived visibility inconsistency instead of adding deletion
+// tombstones or per-node snapshot generations.
 func (s *service) applyReloadResult(next map[string]*NodeSnapshot) {
-	syncSnaps := s.mergeReloadResult(next)
+	syncSnaps, evicted := s.mergeReloadResult(next)
 
 	// s.ready is set true at the end of Init, after the initial reload and
 	// before localcache.Init. The very first reload therefore skips the sync
@@ -1349,16 +1372,40 @@ func (s *service) applyReloadResult(next map[string]*NodeSnapshot) {
 	for _, snap := range syncSnaps {
 		syncNodeHealthFn(snap)
 	}
+	for _, nodeID := range evicted {
+		func() {
+			// RegisterNode holds the same lifecycle lock until its in-memory and
+			// localcache publications finish. If a registration raced with this
+			// stale DB snapshot, wait for it and do not evict the new registration.
+			unlock := s.lockNodeLabels(nodeID)
+			defer unlock()
+			s.mu.RLock()
+			_, registered := s.nodes[nodeID]
+			s.mu.RUnlock()
+			if !registered {
+				evictNodeFn(nodeID)
+			}
+		}()
+	}
 }
 
 // mergeReloadResult merges the DB reload snapshot into the in-memory node map
-// under s.mu and returns a clone of every touched node for the caller to sync
-// into localcache outside the lock. The critical section uses
+// under s.mu and returns clones of touched nodes plus IDs removed by the
+// snapshot. Computing both results in the same critical section prevents a
+// concurrent registration from being classified using an earlier view.
+// The caller syncs localcache outside the lock. The critical section uses
 // defer s.mu.Unlock() so a panic in the merge loop cannot leak the lock and
 // silently deadlock subsequent register/heartbeat handlers.
-func (s *service) mergeReloadResult(next map[string]*NodeSnapshot) []*NodeSnapshot {
+func (s *service) mergeReloadResult(next map[string]*NodeSnapshot) ([]*NodeSnapshot, []string) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	evicted := make([]string, 0)
+	for nodeID := range s.nodes {
+		if _, stillPresent := next[nodeID]; !stillPresent {
+			delete(s.nodes, nodeID)
+			evicted = append(evicted, nodeID)
+		}
+	}
 	syncSnaps := make([]*NodeSnapshot, 0, len(next))
 	for nodeID, newSnap := range next {
 		if existing, ok := s.nodes[nodeID]; ok {
@@ -1410,8 +1457,11 @@ func (s *service) mergeReloadResult(next map[string]*NodeSnapshot) []*NodeSnapsh
 			syncSnaps = append(syncSnaps, cloneSnapshot(newSnap))
 		}
 	}
-	return syncSnaps
+	return syncSnaps, evicted
 }
+
+// evictNodeFn is a test seam for the reload -> localcache eviction path.
+var evictNodeFn = localcache.EvictNode
 
 func (s *service) loopReload(ctx context.Context) {
 	ticker := time.NewTicker(time.Second)

--- a/CubeMaster/pkg/nodemeta/service_reload_test.go
+++ b/CubeMaster/pkg/nodemeta/service_reload_test.go
@@ -457,10 +457,13 @@ func TestMergeReloadResultReturnsAllTouchedNodes(t *testing.T) {
 		},
 	}
 
-	syncSnaps := s.mergeReloadResult(next)
+	syncSnaps, evicted := s.mergeReloadResult(next)
 
 	if len(syncSnaps) != 2 {
 		t.Fatalf("mergeReloadResult returned %d snaps, want 2 (every touched node)", len(syncSnaps))
+	}
+	if len(evicted) != 0 {
+		t.Fatalf("mergeReloadResult returned unexpected evictions: %v", evicted)
 	}
 
 	byID := make(map[string]*NodeSnapshot, len(syncSnaps))

--- a/CubeMaster/pkg/service/httpservice/meta/meta.go
+++ b/CubeMaster/pkg/service/httpservice/meta/meta.go
@@ -12,6 +12,7 @@ import (
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/errorcode"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/nodemeta"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/service/httpservice/common"
+	sandboxservice "github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/service/sandbox"
 	sandboxtypes "github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/service/sandbox/types"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/templatecenter"
 	"gorm.io/gorm"
@@ -154,6 +155,15 @@ func getNodeGinHandler(c *gin.Context) {
 	})
 }
 
+func deleteNodeGinHandler(c *gin.Context) {
+	force := c.Query("force") == "true"
+	if err := sandboxservice.DeleteNode(c.Request.Context(), c.Param("node_id"), force); err != nil {
+		writeErr(c.Writer, http.StatusOK, err)
+		return
+	}
+	common.WriteAPI(c, &sandboxtypes.Res{Ret: successRet()})
+}
+
 func listNodesGinHandler(c *gin.Context) {
 	data, err := nodemeta.ListNodes(c.Request.Context())
 	if err != nil {
@@ -251,9 +261,11 @@ func successRet() *sandboxtypes.Ret {
 func writeErr(w http.ResponseWriter, status int, err error) {
 	retCode := int(errorcode.ErrorCode_MasterInternalError)
 	switch {
-	case errors.Is(err, gorm.ErrRecordNotFound), errors.Is(err, templatecenter.ErrTemplateNotFound):
+	case errors.Is(err, gorm.ErrRecordNotFound), errors.Is(err, templatecenter.ErrTemplateNotFound), errors.Is(err, nodemeta.ErrNodeNotFound):
 		retCode = int(errorcode.ErrorCode_NotFound)
 	case errors.Is(err, nodemeta.ErrLabelsJSONCorrupt), errors.Is(err, nodemeta.ErrSchedulingLabelRejected):
+		retCode = int(errorcode.ErrorCode_MasterParamsError)
+	case errors.Is(err, nodemeta.ErrNodeNotIsolated), errors.Is(err, sandboxservice.ErrNodeHasSandboxes):
 		retCode = int(errorcode.ErrorCode_MasterParamsError)
 	}
 	common.WriteResponse(w, status, &sandboxtypes.Res{

--- a/CubeMaster/pkg/service/httpservice/meta/meta_test.go
+++ b/CubeMaster/pkg/service/httpservice/meta/meta_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/errorcode"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/nodemeta"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/service/httpservice/common"
+	sandboxservice "github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/service/sandbox"
 	CubeLog "github.com/tencentcloud/CubeSandbox/cubelog"
 )
 
@@ -72,6 +73,61 @@ func TestGetNodeExtractsNodeIDFromPath(t *testing.T) {
 	assert.Equal(t, http.StatusOK, w.Code)
 	assert.Equal(t, "node-42", gotNodeID, "node_id must be extracted from the path param")
 	assert.Equal(t, int(errorcode.ErrorCode_Success), decodeRetCode(t, w.Body.Bytes()))
+}
+
+func TestDeleteNodeExtractsNodeIDFromPath(t *testing.T) {
+	var gotNodeID string
+	var gotForce bool
+	patch := gomonkey.ApplyFunc(sandboxservice.DeleteNode,
+		func(_ context.Context, nodeID string, force bool) error {
+			gotNodeID = nodeID
+			gotForce = force
+			return nil
+		})
+	defer patch.Reset()
+
+	r := newMetaEngine()
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodDelete, MetaURI()+"/nodes/node-42", nil))
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "node-42", gotNodeID)
+	assert.False(t, gotForce)
+	assert.Equal(t, int(errorcode.ErrorCode_Success), decodeRetCode(t, w.Body.Bytes()))
+	assert.NotContains(t, w.Body.String(), `"data"`)
+}
+
+func TestDeleteNodeForwardsForceQuery(t *testing.T) {
+	var gotForce bool
+	patch := gomonkey.ApplyFunc(sandboxservice.DeleteNode,
+		func(_ context.Context, _ string, force bool) error {
+			gotForce = force
+			return nil
+		})
+	defer patch.Reset()
+
+	r := newMetaEngine()
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodDelete, MetaURI()+"/nodes/node-42?force=true", nil))
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.True(t, gotForce)
+	assert.Equal(t, int(errorcode.ErrorCode_Success), decodeRetCode(t, w.Body.Bytes()))
+}
+
+func TestDeleteNodeMapsNodeNotFound(t *testing.T) {
+	patch := gomonkey.ApplyFunc(sandboxservice.DeleteNode,
+		func(context.Context, string, bool) error {
+			return nodemeta.ErrNodeNotFound
+		})
+	defer patch.Reset()
+
+	r := newMetaEngine()
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodDelete, MetaURI()+"/nodes/missing-node", nil))
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, int(errorcode.ErrorCode_NotFound), decodeRetCode(t, w.Body.Bytes()))
 }
 
 // TestDeleteNodeLabelExtractsNodeIDAndKeyQuery proves both extraction axes:

--- a/CubeMaster/pkg/service/httpservice/meta/routes.go
+++ b/CubeMaster/pkg/service/httpservice/meta/routes.go
@@ -15,6 +15,7 @@ func RegisterMetaRoutes(g *gin.RouterGroup) {
 	g.GET(versionMatrixAction, versionMatrixGinHandler)
 	g.GET(templateComponentVersionsAction, templateComponentVersionsGinHandler)
 	g.GET(nodeAction, getNodeGinHandler)
+	g.DELETE(nodeAction, deleteNodeGinHandler)
 	g.POST(nodeStatusAction, updateNodeStatusGinHandler)
 	g.POST(nodeLabelsAction, updateNodeLabelsGinHandler)
 	g.DELETE(nodeLabelsAction, deleteNodeLabelGinHandler)

--- a/CubeMaster/pkg/service/sandbox/node_deletion.go
+++ b/CubeMaster/pkg/service/sandbox/node_deletion.go
@@ -1,0 +1,71 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package sandbox
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	cubebox "github.com/tencentcloud/CubeSandbox/CubeMaster/api/services/cubebox/v1"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/log"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/cubelet"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/localcache"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/nodemeta"
+)
+
+var ErrNodeHasSandboxes = errors.New("node still has sandboxes")
+
+// DeleteNode verifies the node is empty through Cubelet before removing its
+// control-plane metadata. force bypasses the inventory check but never the
+// nodemeta isolation requirement.
+func DeleteNode(ctx context.Context, nodeID string, force bool) error {
+	if force {
+		log.G(ctx).Warnf("force deleting node without sandbox inventory verification node_id=%s", nodeID)
+		return nodemeta.DeleteNode(ctx, nodeID)
+	}
+	// Known race: the inventory check and metadata deletion are not atomic with
+	// sandbox creation. A create that already passed the final scheduling
+	// admission, or one admitted by another CubeMaster that has not observed the
+	// isolation yet, may still reach Cubelet after this check. LocalCreateNum is
+	// also not consulted here. The current operational contract mitigates this by
+	// requiring operators to isolate the node, wait for in-flight creates and
+	// replica propagation, and remove all sandboxes before deletion. We currently
+	// accept this residual window instead of adding a cross-replica create lease
+	// or a lifecycle lock shared with the create path.
+	count, err := countNodeSandboxes(ctx, nodeID)
+	if err != nil {
+		return fmt.Errorf("verify node sandboxes: %w; restore Cubelet connectivity and retry, or retry with force=true", err)
+	}
+	if count != 0 {
+		return fmt.Errorf("%w: %d found; remove them first and retry, or use --force (CLI) to bypass the inventory check", ErrNodeHasSandboxes, count)
+	}
+	return nodemeta.DeleteNode(ctx, nodeID)
+}
+
+// countNodeSandboxes asks the target Cubelet directly. Any inventory error is
+// returned so normal deletion fails closed; only an explicit force request may
+// bypass the check.
+func countNodeSandboxes(ctx context.Context, nodeID string) (int, error) {
+	n, ok := localcache.GetNode(nodeID)
+	if !ok || n == nil {
+		if _, err := nodemeta.GetNode(ctx, nodeID); err != nil {
+			return 0, err
+		}
+		return 0, fmt.Errorf("node %s exists in metadata but is not present in the scheduler cache", nodeID)
+	}
+	endpoint := cubelet.GetCubeletAddr(n.HostIP())
+	unlock := l.CubeletListLock.Lock(endpoint)
+	defer unlock()
+	rsp, err := cubelet.List(ctx, endpoint, &cubebox.ListCubeSandboxRequest{
+		Filter: &cubebox.CubeSandboxFilter{
+			LabelSelector: map[string]string{"io.kubernetes.cri.container-type": "sandbox"},
+		},
+	})
+	if err != nil {
+		return 0, err
+	}
+	return len(rsp.GetItems()), nil
+}

--- a/CubeMaster/pkg/service/sandbox/node_deletion_test.go
+++ b/CubeMaster/pkg/service/sandbox/node_deletion_test.go
@@ -1,0 +1,150 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package sandbox
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/agiledragon/gomonkey/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	cubebox "github.com/tencentcloud/CubeSandbox/CubeMaster/api/services/cubebox/v1"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/node"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/utils"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/cubelet"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/localcache"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/nodemeta"
+)
+
+func TestDeleteNodeRejectsNonEmptyNode(t *testing.T) {
+	patch := gomonkey.ApplyFunc(countNodeSandboxes, func(context.Context, string) (int, error) {
+		return 2, nil
+	})
+	defer patch.Reset()
+
+	assert.ErrorIs(t, DeleteNode(context.Background(), "node-a", false), ErrNodeHasSandboxes)
+}
+
+func TestDeleteNodeFailsClosedWhenInventoryUnavailable(t *testing.T) {
+	sentinel := errors.New("cubelet unavailable")
+	patch := gomonkey.ApplyFunc(countNodeSandboxes, func(context.Context, string) (int, error) {
+		return 0, sentinel
+	})
+	defer patch.Reset()
+
+	err := DeleteNode(context.Background(), "node-a", false)
+	assert.ErrorIs(t, err, sentinel)
+	assert.ErrorContains(t, err, "retry with force=true")
+}
+
+func TestCountNodeSandboxesDoesNotTrustCachedZeroWhenCubeletUnavailable(t *testing.T) {
+	sentinel := errors.New("cubelet unavailable")
+	origLocal := l
+	l = &local{CubeletListLock: utils.NewResourceLocks()}
+	t.Cleanup(func() { l = origLocal })
+	nodePatch := gomonkey.ApplyFunc(localcache.GetNode, func(string) (*node.Node, bool) {
+		return &node.Node{
+			InsID:        "node-a",
+			IP:           "10.0.0.1",
+			Healthy:      false,
+			MvmNum:       0,
+			MetricUpdate: time.Now(),
+		}, true
+	})
+	defer nodePatch.Reset()
+	listPatch := gomonkey.ApplyFunc(cubelet.List,
+		func(context.Context, string, *cubebox.ListCubeSandboxRequest) (*cubebox.ListCubeSandboxResponse, error) {
+			return nil, sentinel
+		})
+	defer listPatch.Reset()
+
+	_, err := countNodeSandboxes(context.Background(), "node-a")
+	assert.ErrorIs(t, err, sentinel)
+}
+
+func TestCountNodeSandboxesReturnsNotFoundWhenNodeIsAbsent(t *testing.T) {
+	nodePatch := gomonkey.ApplyFunc(localcache.GetNode, func(string) (*node.Node, bool) {
+		return nil, false
+	})
+	defer nodePatch.Reset()
+	metaPatch := gomonkey.ApplyFunc(nodemeta.GetNode,
+		func(context.Context, string) (*nodemeta.NodeSnapshot, error) {
+			return nil, nodemeta.ErrNodeNotFound
+		})
+	defer metaPatch.Reset()
+
+	_, err := countNodeSandboxes(context.Background(), "missing-node")
+	assert.ErrorIs(t, err, nodemeta.ErrNodeNotFound)
+}
+
+func TestCountNodeSandboxesDoesNotMisreportSchedulerCacheMissAsNotFound(t *testing.T) {
+	nodePatch := gomonkey.ApplyFunc(localcache.GetNode, func(string) (*node.Node, bool) {
+		return nil, false
+	})
+	defer nodePatch.Reset()
+	metaPatch := gomonkey.ApplyFunc(nodemeta.GetNode,
+		func(_ context.Context, nodeID string) (*nodemeta.NodeSnapshot, error) {
+			return &nodemeta.NodeSnapshot{NodeID: nodeID}, nil
+		})
+	defer metaPatch.Reset()
+
+	_, err := countNodeSandboxes(context.Background(), "uncached-node")
+	assert.Error(t, err)
+	assert.NotErrorIs(t, err, nodemeta.ErrNodeNotFound)
+	assert.ErrorContains(t, err, "not present in the scheduler cache")
+}
+
+func TestDeleteNodeRemovesMetadataAfterEmptyCheck(t *testing.T) {
+	checkPatch := gomonkey.ApplyFunc(countNodeSandboxes, func(context.Context, string) (int, error) {
+		return 0, nil
+	})
+	defer checkPatch.Reset()
+
+	var gotNodeID string
+	deletePatch := gomonkey.ApplyFunc(nodemeta.DeleteNode, func(_ context.Context, nodeID string) error {
+		gotNodeID = nodeID
+		return nil
+	})
+	defer deletePatch.Reset()
+
+	require.NoError(t, DeleteNode(context.Background(), "node-a", false))
+	assert.Equal(t, "node-a", gotNodeID)
+}
+
+func TestForceDeleteBypassesInventoryCheck(t *testing.T) {
+	checkPatch := gomonkey.ApplyFunc(countNodeSandboxes, func(context.Context, string) (int, error) {
+		t.Fatal("force deletion must not query sandbox inventory")
+		return 0, nil
+	})
+	defer checkPatch.Reset()
+
+	var gotNodeID string
+	deletePatch := gomonkey.ApplyFunc(nodemeta.DeleteNode, func(_ context.Context, nodeID string) error {
+		gotNodeID = nodeID
+		return nil
+	})
+	defer deletePatch.Reset()
+
+	require.NoError(t, DeleteNode(context.Background(), "node-a", true))
+	assert.Equal(t, "node-a", gotNodeID)
+}
+
+func TestForceDeleteStillRequiresIsolation(t *testing.T) {
+	checkPatch := gomonkey.ApplyFunc(countNodeSandboxes, func(context.Context, string) (int, error) {
+		t.Fatal("force deletion must not query sandbox inventory")
+		return 0, nil
+	})
+	defer checkPatch.Reset()
+
+	deletePatch := gomonkey.ApplyFunc(nodemeta.DeleteNode, func(context.Context, string) error {
+		return nodemeta.ErrNodeNotIsolated
+	})
+	defer deletePatch.Reset()
+
+	assert.ErrorIs(t, DeleteNode(context.Background(), "node-a", true), nodemeta.ErrNodeNotIsolated)
+}

--- a/docs/guide/node-isolation.md
+++ b/docs/guide/node-isolation.md
@@ -1,30 +1,31 @@
 ---
-title: Node Isolation
+title: Node Isolation and Deletion
 lang: en-US
 ---
 
-# Node Isolation
+# Node Isolation and Deletion
 
 Node isolation (isolate) temporarily **stops CubeMaster from scheduling new sandboxes onto a compute node** during maintenance, upgrades, or troubleshooting. It behaves like Kubernetes `cordon`: the node can stay healthy and existing sandboxes keep running — it simply stops receiving new work.
 
 ::: tip Current entry points
-WebUI / CubeOps / the public OpenAPI surface do **not** expose isolation yet. Use the **CubeMaster HTTP API**, or **`cubemastercli`** on the control node, to isolate and unisolate nodes.
+WebUI / CubeOps / the public OpenAPI surface do **not** expose node isolation or deletion yet. Use the **CubeMaster HTTP API**, or **`cubemastercli`** on the control node.
 :::
 
 ## What you'll learn
 
 - How isolation differs from taking a node offline or draining it
 - How to find a `node_id` and isolate / unisolate it
+- How to safely remove a retired node's control-plane record
 - How to verify that isolation took effect
 - Recommended order of operations for upgrades and maintenance
 
 ## Behavior
 
-| Aspect | After isolation |
-|---|---|
-| **New sandbox scheduling** | The node is skipped; creates fail if no other schedulable node remains |
-| **Existing sandboxes** | **Unaffected** — nothing is destroyed or migrated automatically |
-| **Node health** | Orthogonal to isolation: an isolated node can still report `healthy=true` |
+| Aspect                           | After isolation                                                                 |
+| -------------------------------- | ------------------------------------------------------------------------------- |
+| **New sandbox scheduling**       | The node is skipped; creates fail if no other schedulable node remains          |
+| **Existing sandboxes**           | **Unaffected** — nothing is destroyed or migrated automatically                 |
+| **Node health**                  | Orthogonal to isolation: an isolated node can still report `healthy=true`       |
 | **Cubelet heartbeat / register** | Continues normally; the node cannot override or clear the isolation mark itself |
 
 Under the hood, CubeMaster writes a reserved label on the node metadata:
@@ -53,7 +54,7 @@ List cluster nodes and check the current isolation state:
 
 ```bash
 # CLI
-cubemastercli --address 127.0.0.1 --port 8089 node list
+cubemastercli node list
 
 # Or call the API directly
 curl -s http://127.0.0.1:8089/internal/meta/nodes | jq .
@@ -107,13 +108,13 @@ The call is **idempotent**: repeating `PUT` on an already-isolated node is safe.
 
 ```bash
 # Isolate one node
-cubemastercli --address 127.0.0.1 --port 8089 node isolate <node_id>
+cubemastercli node isolate <node_id>
 
 # Isolate multiple nodes
-cubemastercli --address 127.0.0.1 --port 8089 node isolate <node_id_1> <node_id_2>
+cubemastercli node isolate <node_id_1> <node_id_2>
 
 # Raw JSON response
-cubemastercli --address 127.0.0.1 --port 8089 node isolate --json <node_id>
+cubemastercli node isolate --json <node_id>
 ```
 
 On success the CLI prints something like:
@@ -130,7 +131,7 @@ Query the node again and confirm `scheduling_disabled` is `true`:
 curl -s http://127.0.0.1:8089/internal/meta/nodes/<node_id> | jq '.scheduling_disabled'
 # Expected: true
 
-cubemastercli --address 127.0.0.1 --port 8089 node list
+cubemastercli node list
 # SCHEDULING_DISABLED should be true
 ```
 
@@ -147,10 +148,78 @@ When maintenance is done, remove the cordon so the node can receive new sandboxe
 curl -X DELETE "http://127.0.0.1:8089/internal/meta/nodes/<node_id>/isolation"
 
 # CLI
-cubemastercli --address 127.0.0.1 --port 8089 node unisolate <node_id>
+cubemastercli node unisolate <node_id>
 ```
 
 Afterwards `scheduling_disabled` should be `false`, and the `scheduling-disabled` label should be gone.
+
+## Delete a node
+
+Node deletion removes a retired node's control-plane record from CubeMaster. It deletes the node registration, status, and component-version metadata and clears scheduling and metric caches. It **does not touch processes, sandboxes, disks, or the Kubernetes Node on the compute host**.
+
+::: warning Isolate and empty the node first
+CubeMaster only deletes a node that is **isolated and has no sandboxes**. The delete operation does not isolate the node and does not destroy or migrate sandboxes. Isolate it, allow in-flight creates to finish, and explicitly destroy every sandbox on the node first.
+
+If the compute node is currently unreachable but must be deleted, use forced deletion. Forced deletion bypasses sandbox inventory verification, but still requires prior isolation.
+:::
+
+### Recommended sequence
+
+1. Isolate the target node.
+2. Wait ≥ 60 seconds for in-flight scheduling / create windows to finish.
+3. Destroy all sandboxes on the target node.
+4. Delete the node.
+5. Stop or retire Cubelet.
+6. Confirm that the record is absent from the node list.
+
+If the Cubelet compute node is unreachable, normal node deletion fails because CubeMaster can no longer determine how many sandboxes remain on it. In that case, use forced deletion.
+
+### Option 1 (recommended): cubemastercli
+
+```bash
+# Delete one node
+cubemastercli node delete <node_id>
+
+# rm is an alias for delete; multiple nodes are also supported
+cubemastercli node rm <node_id_1> <node_id_2>
+
+# Force deletion without sandbox inventory verification
+cubemastercli node rm --force <node_id>
+```
+
+Batch deletion processes every node independently: a failure does not prevent later nodes from being attempted, but the command ultimately returns an error listing the failed nodes. If inventory verification fails, the error tells the operator to restore connectivity or explicitly retry with `--force`. On success, the CLI prints:
+
+```text
+node node-1 deleted
+```
+
+### Option 2: HTTP API
+
+```bash
+curl -X DELETE "http://127.0.0.1:8089/internal/meta/nodes/<node_id>"
+
+# Force deletion when live inventory cannot be verified
+curl -X DELETE "http://127.0.0.1:8089/internal/meta/nodes/<node_id>?force=true"
+```
+
+A successful response has no `data` field:
+
+```json
+{
+  "ret": {
+    "RetCode": 200,
+    "RetMsg": "Success"
+  }
+}
+```
+
+This internal endpoint may still return HTTP 200 when a business validation fails, so automation must also check `ret.RetCode`. Common failures include a missing node, a node that is not isolated, remaining sandboxes, or an inventory that cannot be verified reliably. `force=true` bypasses only the sandbox inventory check; it does not bypass isolation.
+
+### After deletion
+
+- The node disappears immediately from the current CubeMaster instance; other CubeMaster instances remove it on their next metadata refresh.
+- Deletion is not a permanent deregistration or ban. A running or restarted Cubelet can register the same `node_id` again.
+- To return the node to service, wait for it to register again and verify its health. The new registration does not retain the previous isolation mark.
 
 ## Typical workflows
 
@@ -179,7 +248,7 @@ Full steps: [Kubernetes upgrade guide](./kubernetes/upgrade.md).
 - **Single-node / all-isolated clusters**: if no other schedulable node remains, new sandbox creates fail (no host selected).
 - **Orthogonal to health checks**: an isolated node can stay Healthy and may still appear in healthy-node listings; it is only excluded from the schedulable set.
 - **Independent of Kubernetes `kubectl cordon`**: this only affects CubeMaster scheduling; it does not cordon the Kubernetes Node.
-- **Auth**: with CubeMaster HTTP auth disabled (the default), you can call the API directly. If you enable CubeMaster auth, add the required signature headers per your cluster config. Current `cubemastercli node isolate/unisolate` does **not** attach signatures automatically — prefer signed HTTP requests when auth is on.
+- **Auth**: with CubeMaster HTTP auth disabled (the default), you can call the API directly. If you enable CubeMaster auth, add the required signature headers per your cluster config. Current `cubemastercli node isolate/unisolate/delete` does **not** attach signatures automatically — prefer signed HTTP requests when auth is on.
 
 ## Related
 

--- a/docs/zh/guide/node-isolation.md
+++ b/docs/zh/guide/node-isolation.md
@@ -1,31 +1,32 @@
 ---
-title: 隔离节点
+title: 隔离与删除节点
 lang: zh-CN
 ---
 
-# 隔离节点
+# 隔离与删除节点
 
 节点隔离（isolate）用于在维护、升级或排障时，**临时阻止 CubeMaster 向指定计算节点调度新沙箱**。它类似 Kubernetes 的 `cordon`：节点仍可保持健康、已有沙箱继续运行，只是不再接收新负载。
 
 ::: tip 当前入口
-WebUI / CubeOps / 对外 OpenAPI **暂不提供**隔离操作。请通过 **CubeMaster HTTP 接口**，或控制节点上的 **`cubemastercli`** 完成隔离与取消隔离。
+WebUI / CubeOps / 对外 OpenAPI **暂不提供**隔离或删除节点操作。请通过 **CubeMaster HTTP 接口**，或控制节点上的 **`cubemastercli`** 完成操作。
 :::
 
 ## 读完本页你会知道
 
 - 隔离与「下线 / 驱逐」的区别
 - 如何查找 `node_id` 并隔离 / 取消隔离
+- 如何安全删除已下线节点的控制面记录
 - 如何确认隔离是否生效
 - 升级、维护等常见场景下的推荐操作顺序
 
 ## 行为说明
 
-| 维度 | 隔离后的表现 |
-|---|---|
-| **新沙箱调度** | 该节点不再被选中；若集群中没有其他可调度节点，创建会失败 |
-| **已有沙箱** | **不受影响**，不会自动销毁或迁移 |
-| **节点健康状态** | 与隔离正交：隔离节点仍可显示为 `healthy=true` |
-| **Cubelet 心跳 / 注册** | 继续正常；节点侧无法自行覆盖或清除隔离标记 |
+| 维度                    | 隔离后的表现                                             |
+| ----------------------- | -------------------------------------------------------- |
+| **新沙箱调度**          | 该节点不再被选中；若集群中没有其他可调度节点，创建会失败 |
+| **已有沙箱**            | **不受影响**，不会自动销毁或迁移                         |
+| **节点健康状态**        | 与隔离正交：隔离节点仍可显示为 `healthy=true`            |
+| **Cubelet 心跳 / 注册** | 继续正常；节点侧无法自行覆盖或清除隔离标记               |
 
 内部实现上，CubeMaster 会在节点元数据中写入保留 label：
 
@@ -53,7 +54,7 @@ cube.cloud.tencentcloud.com/scheduling-disabled=true
 
 ```bash
 # CLI
-cubemastercli --address 127.0.0.1 --port 8089 node list
+cubemastercli node list
 
 # 或直接调接口
 curl -s http://127.0.0.1:8089/internal/meta/nodes | jq .
@@ -107,13 +108,13 @@ curl -X PUT "http://127.0.0.1:8089/internal/meta/nodes/<node_id>/isolation"
 
 ```bash
 # 隔离单个节点
-cubemastercli --address 127.0.0.1 --port 8089 node isolate <node_id>
+cubemastercli node isolate <node_id>
 
 # 一次隔离多个节点
-cubemastercli --address 127.0.0.1 --port 8089 node isolate <node_id_1> <node_id_2>
+cubemastercli node isolate <node_id_1> <node_id_2>
 
 # 需要原始 JSON 时
-cubemastercli --address 127.0.0.1 --port 8089 node isolate --json <node_id>
+cubemastercli node isolate --json <node_id>
 ```
 
 成功时 CLI 会打印类似：
@@ -130,7 +131,7 @@ node node-1 isolated: scheduling_disabled=true
 curl -s http://127.0.0.1:8089/internal/meta/nodes/<node_id> | jq '.scheduling_disabled'
 # 期望输出: true
 
-cubemastercli --address 127.0.0.1 --port 8089 node list
+cubemastercli node list
 # SCHEDULING_DISABLED 列应为 true
 ```
 
@@ -147,10 +148,78 @@ cubemastercli --address 127.0.0.1 --port 8089 node list
 curl -X DELETE "http://127.0.0.1:8089/internal/meta/nodes/<node_id>/isolation"
 
 # CLI
-cubemastercli --address 127.0.0.1 --port 8089 node unisolate <node_id>
+cubemastercli node unisolate <node_id>
 ```
 
 成功后 `scheduling_disabled` 应为 `false`，且 labels 中不再包含 `scheduling-disabled`。
+
+## 删除节点
+
+删除节点用于清理已下线节点在 CubeMaster 中的控制面记录。它会删除节点注册、状态和组件版本信息，并清理调度与指标缓存；**不会操作计算节点上的进程、沙箱、磁盘或 Kubernetes Node**。
+
+::: warning 删除前必须隔离并清空
+CubeMaster 只允许删除**已隔离且无沙箱**的节点。删除接口不会自动隔离节点，也不会销毁或迁移沙箱。请先隔离节点、等待进行中的创建结束，并显式销毁该节点上的所有沙箱。
+
+如果当前计算节点已不可达，但明确需要删除此节点，可以执行强制删除操作，强制删除会跳过沙箱库存校验，但仍然要求节点已经隔离。
+:::
+
+### 推荐操作顺序
+
+1. 隔离目标节点。
+2. 等待 ≥ 60 秒，让进行中的调度 / 创建窗口结束。
+3. 销毁目标节点上的全部沙箱。
+4. 删除节点。
+5. 停止或下线 Cubelet。
+6. 通过节点列表确认记录已消失。
+
+当 Cubelet 计算节点不可达时，此时普通删除节点将会失败。因为此时已经无法判断对应计算节点上的沙箱数量。此时需要执行强制删除操作。
+
+### 方式一（推荐）：cubemastercli
+
+```bash
+# 删除单个节点
+cubemastercli node delete <node_id>
+
+# rm 是 delete 的别名；也可一次处理多个节点
+cubemastercli node rm <node_id_1> <node_id_2>
+
+# 不校验沙箱库存，强制删除节点记录
+cubemastercli node rm --force <node_id>
+```
+
+批量删除会逐个处理节点：某个节点失败不会阻止后续节点继续尝试，但命令最终会返回错误并列出失败节点。库存校验失败时，错误信息会要求恢复连通性，或由操作者显式使用 `--force` 重试。成功时 CLI 会打印：
+
+```text
+node node-1 deleted
+```
+
+### 方式二：HTTP 接口
+
+```bash
+curl -X DELETE "http://127.0.0.1:8089/internal/meta/nodes/<node_id>"
+
+# 无法实时校验库存时强制删除
+curl -X DELETE "http://127.0.0.1:8089/internal/meta/nodes/<node_id>?force=true"
+```
+
+成功响应不包含 `data`：
+
+```json
+{
+  "ret": {
+    "RetCode": 200,
+    "RetMsg": "Success"
+  }
+}
+```
+
+该内部接口即使业务校验失败也可能返回 HTTP 200，脚本必须同时检查 `ret.RetCode`。常见失败原因包括节点不存在、节点尚未隔离、仍有沙箱，或无法可靠获取沙箱库存。`force=true` 只跳过沙箱库存校验，不会跳过节点隔离要求。
+
+### 删除后的行为
+
+- 删除会立即清理当前 CubeMaster 实例中的节点视图；其他 CubeMaster 实例在元数据刷新后同步移除。
+- 删除不是永久注销或封禁。Cubelet 若仍在运行或之后重启，可以使用同一 `node_id` 再次注册。
+- 如需让节点继续提供服务，等待其重新注册并确认健康即可；新注册记录不会保留此前的隔离标记。
 
 ## 典型场景
 
@@ -179,7 +248,7 @@ cubemastercli --address 127.0.0.1 --port 8089 node unisolate <node_id>
 - **单节点 / 全部隔离**：若集群中没有其它可调度节点，新沙箱创建会失败（调度选不到节点）。
 - **与健康检查正交**：隔离节点仍可保持 Healthy，仍会出现在健康节点列表中，只是不进入可调度集合。
 - **与 Kubernetes `kubectl cordon` 无关**：本能力只影响 CubeMaster 调度，不会自动对 K8s Node 执行 cordon。
-- **鉴权**：CubeMaster 默认关闭 HTTP 鉴权时可直接调用。若你开启了 CubeMaster 鉴权，需按集群配置补齐签名头；当前 `cubemastercli node isolate/unisolate` **不会**自动附加签名，鉴权开启时请优先使用带签的 HTTP 请求。
+- **鉴权**：CubeMaster 默认关闭 HTTP 鉴权时可直接调用。若你开启了 CubeMaster 鉴权，需按集群配置补齐签名头；当前 `cubemastercli node isolate/unisolate/delete` **不会**自动附加签名，鉴权开启时请优先使用带签的 HTTP 请求。
 
 ## 相关文档
 


### PR DESCRIPTION
Ref https://github.com/TencentCloud/CubeSandbox/issues/1125

CubeMaster had no supported way to remove retired nodes. Deleting records manually was also unsafe because it did not verify whether the node was isolated or still running sandboxes.

## Changes

This PR adds safe node deletion through:

```bash
cubemastercli node rm <node_id>
```
And the internal API:

```
DELETE /internal/meta/nodes/{node_id}
```

Deletion requires the node to be:

- Isolated.
- Free of sandboxes.

CubeMaster queries Cubelet for the current sandbox inventory.

On success, CubeMaster removes the node registration, status, component versions, metrics, and scheduler caches. Other CubeMaster replicas remove the node during metadata reload. The same node_id may register again later.

The English and Chinese documentation is also updated.

## CLI verification

Deleting a non-isolated node should fail:

```bash
$ cubemastercli node rm <node>
2026/07/28 17:04:31 delete failed: <node> node must be isolated before deletion
cubemastercli run fail: <node>: node must be isolated before deletion
```

Isolate the node:

```bash
$ cubemastercli node isolate <node>
node <node> isolated: scheduling_disabled=true
```

Deleting a node with remaining sandboxes should fail:

```bash
$ cubemastercli node rm <node>
2026/07/28 17:04:44 delete failed: <node>node still has sandboxes: 1 found
cubemastercli run fail: <node>: node still has sandboxes: 1 found
```

After removing all sandboxes:

```bash
$ cubemastercli node rm <node>
node <node> deleted
```

Verify that the node is gone:

```bash
$ cubemastercli node list
# Expected: node-1 is absent
```

Failures do not prevent later nodes from being attempted, but the command returns a non-zero exit code if any deletion fails.