### PR TITLE
test(sdk_compat): add live CUBE_API_KEY auth e2e coverage

### DIFF
--- a/tests/e2e/sdk_compat/README.md
+++ b/tests/e2e/sdk_compat/README.md
@@ -351,6 +351,10 @@ Current capability domains:
 - `cases/volume/`: Volume Plugin CRUD plus sandbox `volumeMounts` bind/unbind
   (opt-in via `SDK_E2E_VOLUME_PLUGIN=true`; CubeSandbox only). Requires a
   manually deployed/configured Volume Plugin and `cubesandbox` >= 0.6.0.
+- `cases/auth/`: `CUBE_API_KEY` simple-key authentication against the CubeAPI
+  control plane — `X-API-Key`/`Bearer` accept, wrong/missing 401, `/health`
+  exempt (CubeSandbox only). Skipped unless the server was started with
+  `CUBE_API_KEY` and the same key is exported for the runner.
 
 Keep new cases backend-neutral. Add backend-specific behavior through capability
 markers instead of branching inside test bodies. Future domains can be added next
@@ -373,6 +377,7 @@ Capability markers:
 - `@pytest.mark.sandbox_create_options(...)`: pass SDK create-time options such as `network`, `env_vars`, or `lifecycle`.
 - `@pytest.mark.requires_cubeproxy`: platform lifecycle cases that depend on cube-proxy and lifecycle-manager coordination. Skipped unless `SDK_E2E_PLATFORM_LIFECYCLE=true`.
 - `@pytest.mark.volume`: Volume Plugin cases. Skipped unless `SDK_E2E_VOLUME_PLUGIN=true`.
+- `@pytest.mark.auth`: `CUBE_API_KEY` simple-key auth cases. Skipped unless `CUBE_API_KEY` is set for the runner and the backend supports `auth_simple_key` (CubeSandbox only).
 - Common capabilities include `lifecycle`, `commands`, `filesystem`, and `run_code`.
 - Shared optional capabilities include `pause_resume`, `network_allow_deny`, and `network_public_access`.
 - `platform_lifecycle` is available only to CubeSandbox platform-managed lifecycle cases.

--- a/tests/e2e/sdk_compat/README_zh.md
+++ b/tests/e2e/sdk_compat/README_zh.md
@@ -347,6 +347,9 @@ tests/e2e/sdk_compat/
 - `cases/volume/`：Volume Plugin CRUD 与 sandbox `volumeMounts` 绑定/解绑
   （需 `SDK_E2E_VOLUME_PLUGIN=true`；仅 CubeSandbox）。插件需手动部署并配置，
   且要求 `cubesandbox` >= 0.6.0。
+- `cases/auth/`：`CUBE_API_KEY` 简单密钥鉴权，针对 CubeAPI 控制面——
+  `X-API-Key`/`Bearer` 通过、错误/缺失返回 401、`/health` 豁免（仅 CubeSandbox）。
+  仅当服务端以 `CUBE_API_KEY` 启动且 runner 导出相同 key 时才运行，否则跳过。
 
 新增测试应保持后端无关，通过 capability marker 表达后端差异。
 
@@ -372,6 +375,8 @@ Capability marker：
   协调，未设置 `SDK_E2E_PLATFORM_LIFECYCLE=true` 时跳过；
 - `@pytest.mark.volume`：Volume Plugin 用例，未设置
   `SDK_E2E_VOLUME_PLUGIN=true` 时跳过。
+- `@pytest.mark.auth`：`CUBE_API_KEY` 简单密钥鉴权用例，未为 runner 设置
+  `CUBE_API_KEY` 或后端不支持 `auth_simple_key`（仅 CubeSandbox）时跳过。
 
 常用 capability 有 `lifecycle`、`commands`、`filesystem`、`run_code`。
 可选共享 capability 包括 `pause_resume`、`network_allow_deny`、

--- a/tests/e2e/sdk_compat/cases/auth/conftest.py
+++ b/tests/e2e/sdk_compat/cases/auth/conftest.py
@@ -1,0 +1,31 @@
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from framework.capabilities import AUTH_SIMPLE_KEY, capabilities_for_backend
+
+
+# These cases drive the CubeAPI control plane directly (not the sdk_sandbox
+# fixture), so the per-module requires_capability marker would not fire on its
+# own — this autouse fixture is the real gate. It skips when the backend lacks
+# simple-key auth (e.g. e2b uses its own key format) or when the live server was
+# not started with CUBE_API_KEY, in which case the 401 rejection paths cannot be
+# exercised.
+@pytest.fixture(autouse=True)
+def _require_simple_key_auth(sdk_backend: str) -> str:
+    if AUTH_SIMPLE_KEY not in capabilities_for_backend(sdk_backend):
+        pytest.skip(
+            f"backend {sdk_backend!r} does not support capability {AUTH_SIMPLE_KEY!r}"
+        )
+    api_key = os.environ.get("CUBE_API_KEY", "").strip()
+    if not api_key:
+        pytest.skip(
+            "CUBE_API_KEY is unset; start CubeAPI with a key to exercise "
+            "simple-key auth accept/reject paths"
+        )
+    return api_key

--- a/tests/e2e/sdk_compat/cases/auth/test_api_key.py
+++ b/tests/e2e/sdk_compat/cases/auth/test_api_key.py
@@ -1,0 +1,109 @@
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""Live CUBE_API_KEY simple-key authentication cases.
+
+These verify the CubeAPI ``unified_auth`` simple-key mode end-to-end against a
+running server started with ``CUBE_API_KEY``:
+
+- a matching ``X-API-Key`` header is accepted;
+- a matching ``Authorization: Bearer`` header is accepted;
+- a wrong key is rejected with 401;
+- a missing credential is rejected with 401;
+- ``GET /health`` stays exempt from auth.
+
+Prerequisites (manual; not provisioned by this suite):
+- CubeAPI started with ``CUBE_API_KEY=<key>`` set in its environment.
+- The same key exported as ``CUBE_API_KEY`` for the test runner so the accept
+  paths use the real key.
+- ``cubesandbox`` backend (e2b uses a different key format / server).
+"""
+
+from __future__ import annotations
+
+import requests
+
+import pytest
+
+# Backend/credential gating lives in the autouse ``_require_simple_key_auth``
+# fixture in this directory's conftest.py. A ``requires_capability`` marker here
+# would be inert: that marker is only evaluated inside the ``sdk_sandbox``
+# fixture body, which these control-plane cases never request.
+pytestmark = [
+    pytest.mark.e2e,
+    pytest.mark.sdk_compat,
+    pytest.mark.auth,
+    pytest.mark.p1,
+]
+
+# A protected control-plane endpoint that needs no pre-existing template or
+# sandbox: listing templates always sits behind unified_auth.
+PROTECTED_PATH = "/templates"
+
+
+def _get(cfg, path: str, headers: dict[str, str] | None = None) -> requests.Response:
+    return requests.get(
+        f"{cfg.cube_api_url}{path}",
+        headers=headers or {},
+        timeout=cfg.api_timeout,
+    )
+
+
+def test_x_api_key_header_is_accepted(sdk_e2e_config, _require_simple_key_auth):
+    # A matching X-API-Key must pass auth (any non-401 status: the endpoint is
+    # reachable, auth did not reject it).
+    resp = _get(
+        sdk_e2e_config, PROTECTED_PATH, {"X-API-Key": _require_simple_key_auth}
+    )
+    assert resp.status_code != 401, (
+        f"matching X-API-Key was rejected: HTTP {resp.status_code} {resp.text}"
+    )
+
+
+def test_bearer_token_is_accepted(sdk_e2e_config, _require_simple_key_auth):
+    # A matching Authorization: Bearer credential must pass auth.
+    resp = _get(
+        sdk_e2e_config,
+        PROTECTED_PATH,
+        {"Authorization": f"Bearer {_require_simple_key_auth}"},
+    )
+    assert resp.status_code != 401, (
+        f"matching Bearer token was rejected: HTTP {resp.status_code} {resp.text}"
+    )
+
+
+# These three cases do not consume the fixture's return value; the autouse
+# ``_require_simple_key_auth`` fixture still gates them, so the parameter is
+# omitted. A 200 (instead of 401) on the rejection cases usually means the live
+# server was started without ``CUBE_API_KEY`` even though the runner has it set.
+_SERVER_NOT_ENFORCING = (
+    "if this is 200 the server likely was not started with CUBE_API_KEY"
+)
+
+
+def test_wrong_key_is_rejected(sdk_e2e_config):
+    # A mismatched key must return 401 regardless of endpoint behavior.
+    resp = _get(
+        sdk_e2e_config, PROTECTED_PATH, {"X-API-Key": "wrong-key-does-not-match"}
+    )
+    assert resp.status_code == 401, (
+        f"wrong key should be rejected with 401, got HTTP {resp.status_code} "
+        f"{resp.text} ({_SERVER_NOT_ENFORCING})"
+    )
+
+
+def test_missing_credential_is_rejected(sdk_e2e_config):
+    # No credential at all must return 401.
+    resp = _get(sdk_e2e_config, PROTECTED_PATH)
+    assert resp.status_code == 401, (
+        f"missing credential should be rejected with 401, got HTTP "
+        f"{resp.status_code} {resp.text} ({_SERVER_NOT_ENFORCING})"
+    )
+
+
+def test_health_is_exempt_from_auth(sdk_e2e_config):
+    # GET /health must remain reachable without any credential even when the
+    # server enforces simple-key auth.
+    resp = _get(sdk_e2e_config, "/health")
+    assert resp.status_code == 200, (
+        f"/health should be exempt from auth, got HTTP {resp.status_code} {resp.text}"
+    )

--- a/tests/e2e/sdk_compat/cases/templates/test_alias.py
+++ b/tests/e2e/sdk_compat/cases/templates/test_alias.py
@@ -23,6 +23,8 @@ import requests
 from cubesandbox import Config, Template
 from cubesandbox._exceptions import ApiError, TemplateNotFoundError
 
+from framework.auth import auth_headers
+
 pytestmark = [
     pytest.mark.e2e,
     pytest.mark.sdk_compat,
@@ -109,8 +111,12 @@ def test_template_create_from_image_and_cleanup(sdk_backend, sdk_e2e_config):
 
 def test_template_alias_dedicated_endpoint_rejects_invalid(sdk_e2e_config):
     """GET /templates/aliases/:alias returns 400 for invalid formats."""
+    headers = auth_headers()
     for invalid in ["UPPER", "tpl-hijack", "snap-hijack", "a" * 65]:
-        resp = requests.get(f"{sdk_e2e_config.cube_api_url}/templates/aliases/{invalid}")
+        resp = requests.get(
+            f"{sdk_e2e_config.cube_api_url}/templates/aliases/{invalid}",
+            headers=headers,
+        )
         assert resp.status_code == 400
 
 
@@ -149,7 +155,10 @@ def test_template_alias_dedicated_lookup_endpoint(sdk_backend, sdk_e2e_config):
         job = Template.build(name=alias, image=DEFAULT_IMAGE, writable_layer_size=DEFAULT_WRITABLE_LAYER_SIZE, config=cfg)
         created_id = job.template_id
         _wait_for_ready(created_id, cfg)
-        resp = requests.get(f"{sdk_e2e_config.cube_api_url}/templates/aliases/{alias}")
+        resp = requests.get(
+            f"{sdk_e2e_config.cube_api_url}/templates/aliases/{alias}",
+            headers=auth_headers(),
+        )
         assert resp.status_code == 200
         assert resp.json()["templateID"] == created_id
     finally:

--- a/tests/e2e/sdk_compat/conftest.py
+++ b/tests/e2e/sdk_compat/conftest.py
@@ -90,6 +90,7 @@ def pytest_configure(config: pytest.Config) -> None:
         "requires_code_interpreter: test requires a stateful Code Interpreter kernel",
         "requires_internet: test requires public internet access from the sandbox",
         "requires_cubeproxy: test requires CubeProxy routing to the sandbox",
+        "auth: CUBE_API_KEY simple-key authentication control-plane tests",
     ):
         config.addinivalue_line("markers", marker)
 

--- a/tests/e2e/sdk_compat/framework/auth.py
+++ b/tests/e2e/sdk_compat/framework/auth.py
@@ -1,0 +1,20 @@
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import os
+
+
+def auth_headers() -> dict[str, str]:
+    """Auth headers for raw control-plane requests in tests.
+
+    Mirrors how the SDK authenticates: when ``CUBE_API_KEY`` is set, send it as
+    an ``X-API-Key`` header (see ``cubesandbox/_config.py``); otherwise send
+    nothing. This is a test-owned boundary so cases never import SDK-private
+    symbols yet still exercise the same auth code path the SDK uses.
+    """
+    api_key = os.environ.get("CUBE_API_KEY", "").strip()
+    if api_key:
+        return {"X-API-Key": api_key}
+    return {}

--- a/tests/e2e/sdk_compat/framework/capabilities.py
+++ b/tests/e2e/sdk_compat/framework/capabilities.py
@@ -15,6 +15,7 @@ NETWORK_MASK_REQUEST_HOST = "network_mask_request_host"
 PLATFORM_LIFECYCLE = "platform_lifecycle"
 HOST_MOUNT = "host_mount"
 VOLUME_PLUGIN = "volume_plugin"
+AUTH_SIMPLE_KEY = "auth_simple_key"
 
 COMMON_CAPABILITIES = frozenset({LIFECYCLE, COMMANDS, FILESYSTEM, RUN_CODE})
 
@@ -40,6 +41,7 @@ CUBESANDBOX_CAPABILITIES = frozenset(
         PLATFORM_LIFECYCLE,
         HOST_MOUNT,
         VOLUME_PLUGIN,
+        AUTH_SIMPLE_KEY,
     }
 )
 

--- a/tests/e2e/sdk_compat/pytest.ini
+++ b/tests/e2e/sdk_compat/pytest.ini
@@ -18,6 +18,7 @@ markers =
     run_code: sandbox code interpreter compatibility tests
     host_mount: host-directory mount extension compatibility and boundary tests
     volume: volume plugin control-plane and bind/unbind compatibility tests
+    auth: CUBE_API_KEY simple-key authentication control-plane tests
     templates: template alias and catalog compatibility tests
     requires_capability(name): current backend must support the named capability
     sandbox_create_options(**kwargs): SDK sandbox create options for this test


### PR DESCRIPTION
## Summary

CubeAPI simple-key authentication (`CUBE_API_KEY`) was only covered by
server-side unit tests, leaving the live control-plane path untested in the
SDK compatibility suite. This adds an opt-in `auth` domain to `sdk_compat` and
fixes an existing gap where alias cases broke under key-protected deployments.

- Add `cases/auth/` verifying the simple-key path end-to-end against a running
  key-protected CubeAPI: `X-API-Key`/`Bearer` accepted, wrong/missing rejected
  with 401, and `/health` exempt.
- Gate the cases behind a dedicated `auth_simple_key` capability plus a
  runner-side key check so they skip cleanly when the backend or environment
  cannot support them, keeping default and cross-SDK runs stable.
- Fix the template alias cases so their raw HTTP requests carry the same auth
  header the SDK sends, so they pass under both authless and key-protected
  deployments.
- Register the `auth` marker and document the new domain (EN + ZH).