### PR TITLE
feat(agent): add CubeSandbox integration for Claude Code

### DIFF
--- a/docs/guide/integrations/claude-code.md
+++ b/docs/guide/integrations/claude-code.md
@@ -1,0 +1,356 @@
+---
+title: Claude Code Integration Guide
+author: dcdc4747
+date: 2026-07-29
+tags:
+  - integration
+  - claude-code
+  - coding-agent
+  - agent
+lang: en-US
+---
+
+# Claude Code Integration Guide
+
+[中文文档](../../zh/guide/integrations/claude-code.md)
+
+Run [Claude Code](https://docs.anthropic.com/en/docs/claude-code) — Anthropic's
+agentic coding CLI — inside CubeSandbox MicroVMs. This guide covers image build,
+key injection, egress control, and snapshot-based session persistence, and pairs
+with the runnable
+[`examples/claude-code-integration`](https://github.com/TencentCloud/CubeSandbox/tree/master/examples/claude-code-integration)
+project.
+
+## Integration Target and Version
+
+| Component | Version |
+|---|---|
+| Claude Code CLI | `@anthropic-ai/claude-code` (pinned via `--build-arg CLAUDE_CODE_VERSION=x.y.z`) |
+| Node.js | 24 (installed via NodeSource) |
+| CubeSandbox base image | `ghcr.io/tencentcloud/cubesandbox-base:2026.16` |
+| E2B SDK (host driver) | `e2b` (latest) |
+| CubeSandbox platform | `>= 0.3.0` (pause/resume) / `>= 0.4.0` (CubeEgress credential vault) |
+
+## Prerequisites
+
+- A running CubeSandbox deployment; CubeAPI reachable at `http://<node>:3000`.
+- `cubemastercli` on `$PATH`, connected to the cluster.
+- Docker on the build workstation, plus a registry the Cube nodes can pull from.
+- An LLM provider API key. Anthropic is the default; any Anthropic-compatible
+  endpoint (e.g., DeepSeek) works via `ANTHROPIC_BASE_URL` and
+  `ANTHROPIC_AUTH_TOKEN`.
+- Python 3.10+ for the host driver scripts.
+
+## Why Run Claude Code Inside a Sandbox
+
+Claude Code edits files, runs shell commands, installs packages, and can
+autonomously chain tool calls. Running it directly on a workstation blends the
+agent's blast radius with your dev environment. Running it inside CubeSandbox
+gives you:
+
+| Concern | CubeSandbox provides |
+|---|---|
+| **Isolation** | KVM MicroVM per session, dedicated guest kernel |
+| **Reproducibility** | Every session boots from the same template snapshot |
+| **Fast spin-up** | Sub-60 ms cold start, so N-parallel agents are cheap |
+| **Long tasks** | `sandbox.pause()` snapshots VM + rootfs; resume later |
+| **Key hygiene** | CubeEgress injects the auth header on the wire — the VM never sees the real key |
+| **Egress audit** | Every request to the Anthropic API is recorded in the egress audit log |
+
+## Integration Steps
+
+### 1. Build the template image
+
+The image stacks Node.js 24 and the Claude Code CLI on top of `cubesandbox-base`,
+so envd is already listening on `:49983`.
+
+```dockerfile
+# examples/claude-code-integration/Dockerfile (excerpt)
+ARG CUBE_BASE_IMAGE=ghcr.io/tencentcloud/cubesandbox-base:2026.16
+FROM ${CUBE_BASE_IMAGE}
+
+ARG NODE_MAJOR=24
+ARG CLAUDE_CODE_VERSION=latest
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        ca-certificates curl git gnupg jq less procps python3 python3-pip ripgrep \
+    && curl -fsSL "https://deb.nodesource.com/setup_${NODE_MAJOR}.x" | bash - \
+    && apt-get install -y --no-install-recommends nodejs \
+    && npm install -g "@anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}" \
+    && claude --version \
+    && npm cache clean --force \
+    && rm -rf /root/.npm /var/lib/apt/lists/*
+
+WORKDIR /workspace
+EXPOSE 49983
+```
+
+Build and push:
+
+```bash
+# For users in China, use the NJU mirror:
+#   --build-arg CUBE_BASE_IMAGE=ghcr.nju.edu.cn/tencentcloud/cubesandbox-base:2026.16
+docker build --platform linux/amd64 \
+  -t <your-registry>/claude-code-cube:latest \
+  examples/claude-code-integration
+docker push <your-registry>/claude-code-cube:latest
+```
+
+### 2. Register as a Cube template
+
+```bash
+cubemastercli tpl create-from-image \
+  --image <your-registry>/claude-code-cube:latest \
+  --writable-layer-size 4G \
+  --expose-port 49983 \
+  --probe       49983 \
+  --probe-path  /health
+
+cubemastercli tpl watch --job-id <job_id>
+```
+
+Once the job reaches `READY`, note the `template_id` — you pass it to every
+`Sandbox.create()` call. `4G` writable layer suits medium tasks; bump to `8G+`
+if the agent installs large toolchains (e.g., `claude` plugins, MCP servers).
+
+### 3. Wire up the host driver
+
+```bash
+cd examples/claude-code-integration
+cp .env.example .env
+# fill in E2B_API_URL, CUBE_TEMPLATE_ID, and your API key
+pip install -r requirements.txt
+```
+
+| Variable | Where it flows | Notes |
+|---|---|---|
+| `E2B_API_URL` | Local process | CubeAPI address (`http://<node>:3000`) |
+| `E2B_API_KEY` | Local process | Any non-empty string in local dev |
+| `CUBE_TEMPLATE_ID` | `Sandbox.create(template=...)` | From step 2 |
+| `ANTHROPIC_API_KEY` | `envs=...` (direct) or CubeEgress inject (vault) | Provider key (standard) |
+| `ANTHROPIC_AUTH_TOKEN` | `envs=...` (direct) | Provider key (third-party endpoints, e.g. DeepSeek) |
+| `ANTHROPIC_BASE_URL` | Passed into the exec env | For API gateways / compatible endpoints |
+| `CC_MODEL` | `--model` flag | Default: `claude-sonnet-4-6` |
+| `CC_EFFORT` | `--effort` flag | Effort level: low, medium, high, xhigh, max |
+| `CC_LLM_HOST` | `network_policy.py` | API host allowed under default-deny egress |
+
+### 4. Runtime Configuration and API Key Injection
+
+Claude Code is invoked headlessly with `-p` (process the prompt and exit, no
+interactive TUI) and `--output-format json` for machine-readable output. Two
+key-flow flavors share the same template:
+
+**Direct flavor** — forward the key per command. `e2b`'s `commands.run(envs=...)`
+puts the environment into the exec envelope, not into a persistent file inside
+the VM, so the key lives only for the lifetime of that command:
+
+```python
+result = sandbox.commands.run(
+    "cd /workspace && claude -p 'Refactor the auth module.' "
+    "--output-format json --model claude-sonnet-4-6 "
+    "--dangerously-skip-permissions",
+    envs={"ANTHROPIC_API_KEY": key},
+    user="user",
+    timeout=900,
+)
+```
+
+**Vault flavor** — keep the key out of the VM entirely (see step 6).
+
+The example scripts parse the JSON stream and print a concise transcript by
+default (assistant text, tool calls, and any errors); pass `--raw` (or set
+`CC_STREAM_RAW=1`) to see the raw JSON event stream.
+
+### 5. Session Persistence (pause / resume)
+
+```bash
+python resume_claude_code.py
+```
+
+This mirrors the [snapshot / clone / rollback](../snapshot-rollback-clone.md)
+engine at the SDK layer:
+
+- `sandbox.pause()` snapshots the running VM (memory + rootfs) and frees compute.
+- `Sandbox.connect(sandbox_id)` resumes with `/workspace`, Claude Code's state
+  directory (`/home/user/.claude` when running as non-root), and every other file intact.
+
+> **Lifecycle caveat:** manage the sandbox lifecycle with `try/finally`, not a
+> `with Sandbox.create(...)` context manager. On `__exit__` the context manager
+> kills the sandbox, which would undo the pause. The example creates the sandbox
+> explicitly and only calls `sandbox.kill()` in `finally`.
+
+```python
+sandbox = Sandbox.create(template=template_id, timeout=1800)
+try:
+    run_turn(sandbox, prompt_1)          # writes /workspace/plan.md
+    sandbox_id = sandbox.pause() or sandbox.sandbox_id
+    sandbox = Sandbox.connect(sandbox_id)
+    assert_state_survived(sandbox)       # /workspace + state-dir intact
+    run_turn(sandbox, prompt_2)          # continues the work
+finally:
+    sandbox.kill()
+```
+
+### 6. Network and Egress Policy (credential vault)
+
+`network_policy.py` demonstrates the recommended pattern for shared clusters:
+default-deny egress plus on-the-wire key injection.
+
+```python
+# Credential injection uses the native cubesandbox SDK (see security-proxy.md).
+from cubesandbox import Sandbox, Rule, Match, Action, Inject
+
+host = "api.anthropic.com"
+rules = [
+    Rule(
+        name="allow_anthropic_api",
+        match=Match(scheme="https", sni=host, host=host),
+        action=Action(allow=True, audit="metadata", inject=[
+            Inject(header="x-api-key", secret=ANTHROPIC_API_KEY, format="${SECRET}"),
+            Inject(header="anthropic-version", secret="2023-06-01", format="${SECRET}"),
+        ]),
+    ),
+]
+
+sandbox = Sandbox.create(
+    template=CUBE_TEMPLATE_ID,
+    allow_internet_access=False,   # default-deny; the rule's host is auto-allowed
+    network={"rules": rules},
+)
+```
+
+Effect:
+
+- `printenv ANTHROPIC_API_KEY` inside the sandbox shows only a placeholder.
+- Every request to `api.anthropic.com` gets the auth headers attached on the wire.
+- Anything else is dropped by CubeVS at L3/L4 (`allow_internet_access=False`) and
+  never leaves the sandbox.
+- Every allow / deny decision lands in the egress audit log.
+
+For Anthropic-compatible gateways (e.g., DeepSeek), adjust the host in the rule
+and set `ANTHROPIC_BASE_URL` in the environment.
+
+## Use Cases and Best Practices
+
+- **Isolated development.** Run Claude Code inside the sandbox so its file
+  edits and shell commands cannot touch the host.
+- **Execute agent-generated code and collect results.** Have Claude Code write to
+  `/workspace`, then read artifacts back via `sandbox.files` or `commands.run`.
+- **Checkpoint / resume long tasks.** Use `pause()` + `connect()` to snapshot a
+  long refactor and resume later, or fork multiple task variants off one snapshot.
+- **Preinstall heavy dependencies** into the template rather than fetching them
+  at runtime, especially under a default-deny egress policy.
+- **Batch processing.** Run multiple Claude Code instances in parallel sandboxes
+  for code review, migration, or analysis pipelines.
+
+## Key Code Snippets
+
+### Headless Claude Code invocation
+
+```python
+cmd = (
+    "cd /workspace && claude -p "
+    "'Inspect the project, run app.py, and write a summary to result.md.' "
+    "--output-format json --model claude-sonnet-4-6 "
+    "--dangerously-skip-permissions"
+)
+result = sandbox.commands.run(cmd, envs=cc_env, user="user", timeout=900)
+```
+
+### Preflight version check
+
+```python
+version = sandbox.commands.run("claude --version", timeout=60)
+```
+
+### Using a specific effort level
+
+```python
+# Control reasoning depth: low, medium, high, xhigh, max
+cmd = (
+    "claude -p 'Audit this code for security issues.' "
+    "--output-format json --effort high"
+)
+```
+
+### Setting permission mode for automation
+
+```python
+# plan: ask before edits (default); acceptEdits: auto-approve edits;
+# bypassPermissions: full auto (non-root required)
+cmd = (
+    "claude -p 'Fix all lint errors in src/' "
+    "--output-format json --permission-mode acceptEdits"
+)
+```
+
+### Dangerously skip all permissions (sandbox only)
+
+```python
+# Recommended for isolated sandboxes. Must run as non-root user;
+# Claude Code rejects --dangerously-skip-permissions with root/sudo.
+cmd = (
+    "claude -p 'Do the task' "
+    "--output-format json --dangerously-skip-permissions"
+)
+result = sandbox.commands.run(cmd, envs=cc_env, user="user", timeout=900)
+```
+
+## Caveats
+
+- **Node.js version.** Claude Code needs a recent Node runtime; the base image
+  ships an older apt Node, so always install via NodeSource (the Dockerfile does).
+- **Agent state directory.** When running as `user` (recommended for headless
+  automation), Claude Code stores its session cache at `/home/user/.claude`.
+  When running as `root`, the path is `/root/.claude`. Keep it empty in the
+  image to avoid leaking sessions across tenants; it is created at build time
+  but not populated with any credentials.
+- **Direct-flavor key persistence.** With the direct flavor (`envs=`) the key is
+  scoped to the exec call, but sandbox snapshots may capture the in-VM environment.
+  For strict isolation prefer the vault flavor (`network_policy.py`), where the
+  key never enters the VM.
+- **CubeEgress CA (Node).** For the vault flavor the sandbox must trust the
+  CubeEgress root CA, which the base image installs into the system bundle.
+  Claude Code runs on Node.js, which ignores the system store, so
+  `network_policy.py` also sets `NODE_EXTRA_CA_CERTS` (override via
+  `CC_NODE_EXTRA_CA_CERTS`) — without it the vault path fails with TLS errors.
+- **Headless only.** Claude Code's interactive TUI is not available over the
+  E2B protocol. Use `-p` / `--print` with `--output-format json` for
+  machine-readable output, and drive multi-turn conversations from the host
+  script.
+- **Permission mode.** In automated sandbox environments, use
+  `--dangerously-skip-permissions` (requires non-root user) or
+  `--permission-mode acceptEdits` (works with root) for autonomous execution.
+  `plan` mode (default) requires human approval for each tool call, which is
+  impractical in a headless sandbox. Note: `--dangerously-skip-permissions`
+  is rejected when Claude Code runs as root for security reasons.
+- **Egress side-effects.** Tasks that `npm install` or fetch MCP tools need those
+  hosts allowed or preinstalled into the template.
+- **API rate limits.** Claude Code interacts with the Anthropic API; standard
+  rate limits and token quotas apply. For high-throughput batch processing,
+  distribute across multiple API keys and sandboxes.
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| `claude: command not found` in preflight | Template not rebuilt after CLI change | Rebuild the image, re-register the template |
+| API auth failure | Key not forwarded (direct) or missing inject rule (vault) | Pass `envs={...}` or fix the rule's `sni`/`host` |
+| `403 Forbidden - CubeEgress` | Default-deny with no matching allow rule | Add `api.anthropic.com` (and any extra hosts) to the rules |
+| TLS / connection error from Claude Code (vault) | Node.js ignores system CA store | Set `NODE_EXTRA_CA_CERTS` as shown in `network_policy.py` |
+| Template creation stuck in `PULLING` | Registry unreachable from Cube nodes | Push to a registry the cluster can reach; supply auth if needed |
+| Readiness probe timeout | Base image without envd | Ensure `FROM ghcr.io/tencentcloud/cubesandbox-base:2026.16` |
+| `pause()` / `connect()` errors | Platform too old for snapshots | Upgrade the CubeSandbox platform |
+| Claude Code hangs / no output | TUI mode launched over non-TTY channel | Always use `-p` / `--print` in headless mode |
+| Token limit exceeded | Task too large for the configured thinking budget | Lower `--thinking` budget or split into smaller tasks |
+
+## References
+
+- Runnable example: [`examples/claude-code-integration`](https://github.com/TencentCloud/CubeSandbox/tree/master/examples/claude-code-integration)
+- Bring Your Own Image: [`docs/guide/tutorials/bring-your-own-image.md`](../tutorials/bring-your-own-image.md)
+- Template from image: [`docs/guide/tutorials/template-from-image.md`](../tutorials/template-from-image.md)
+- Snapshot / Clone / Rollback: [`docs/guide/snapshot-rollback-clone.md`](../snapshot-rollback-clone.md)
+- Credential vault + egress control: [`docs/guide/security-proxy.md`](../security-proxy.md)
+- Claude Code: <https://docs.anthropic.com/en/docs/claude-code>
+- E2B Claude Code integration: <https://e2b.dev/docs/agents/claude-code>

--- a/docs/guide/integrations/index.md
+++ b/docs/guide/integrations/index.md
@@ -48,3 +48,4 @@ lang: en-US
 | Title | Author | Date | Tags |
 | --- | --- | --- | --- |
 | [Pi Agent Integration Guide](./pi-agent.md) | chaojixinren | 2026-07-01 | integration, pi-agent, coding-agent, agent |
+| [Claude Code Integration Guide](./claude-code.md) | dcdc4747 | 2026-07-29 | integration, claude-code, coding-agent, agent |

--- a/docs/zh/guide/integrations/claude-code.md
+++ b/docs/zh/guide/integrations/claude-code.md
@@ -324,7 +324,7 @@ result = sandbox.commands.run(cmd, envs=cc_env, user="user", timeout=900)
 | 就绪探针超时 | 基础镜像不包含 envd | 确保 `FROM ghcr.io/tencentcloud/cubesandbox-base:2026.16` |
 | `pause()` / `connect()` 报错 | 平台版本过旧不支持快照 | 升级 CubeSandbox 平台 |
 | Claude Code 挂起无输出 | 在非 TTY 通道上启动了 TUI 模式 | 始终在 headless 模式使用 `-p` / `--print` |
-| Token 超限 | 任务规模超出配置的努力级别 | 降低 `--effort` 级别或拆分任务 |
+| Token 超限 | 任务规模超出配置的思考预算 | 降低 `--thinking` 预算或拆分为更小的子任务 |
 
 ## 参考资料
 

--- a/docs/zh/guide/integrations/claude-code.md
+++ b/docs/zh/guide/integrations/claude-code.md
@@ -1,0 +1,337 @@
+---
+title: Claude Code 集成指南
+author: dcdc4747
+date: 2026-07-29
+tags:
+  - integration
+  - claude-code
+  - coding-agent
+  - agent
+lang: zh-CN
+---
+
+# Claude Code 集成指南
+
+[English](../../../guide/integrations/claude-code.md)
+
+在 CubeSandbox MicroVM 内运行 [Claude Code](https://docs.anthropic.com/en/docs/claude-code)
+（Anthropic 的 AI 编程 CLI 工具）。本文覆盖镜像构建、密钥注入、出网管控，以及
+基于快照的会话持久化，配套的可运行示例位于
+[`examples/claude-code-integration`](https://github.com/TencentCloud/CubeSandbox/tree/master/examples/claude-code-integration)。
+
+## 集成对象与版本
+
+| 组件 | 版本 |
+|---|---|
+| Claude Code CLI | `@anthropic-ai/claude-code`（通过 `--build-arg CLAUDE_CODE_VERSION=x.y.z` 固定） |
+| Node.js | 24（通过 NodeSource 安装） |
+| CubeSandbox 基础镜像 | `ghcr.io/tencentcloud/cubesandbox-base:2026.16` |
+| E2B SDK（宿主端驱动） | `e2b`（最新） |
+| CubeSandbox 平台 | `>= 0.3.0`（pause/resume）/ `>= 0.4.0`（CubeEgress 密钥保险柜） |
+
+## 前置条件
+
+- 已部署 CubeSandbox，CubeAPI 可通过 `http://<node>:3000` 访问。
+- `cubemastercli` 已加入 `$PATH`，已连接集群。
+- 构建工作站安装 Docker，且有 Cube 节点可拉取的镜像仓库。
+- LLM 供应商 API 密钥。默认使用 Anthropic；任何兼容 Anthropic 协议的
+  端点（如 DeepSeek）都可以通过 `ANTHROPIC_BASE_URL` 和 `ANTHROPIC_AUTH_TOKEN` 接入。
+- Python 3.10+ 用于宿主端驱动脚本。
+
+## 为什么要在沙箱中运行 Claude Code
+
+Claude Code 会编辑文件、执行 Shell 命令、安装软件包，并可自主串联工具调用。
+直接在开发工作站上运行会将 Agent 的爆炸半径与本地开发环境混在一起。在
+CubeSandbox 中运行带来以下好处：
+
+| 关注点 | CubeSandbox 提供的解决方案 |
+|---|---|
+| **隔离性** | KVM MicroVM 每会话独立，专属客户内核 |
+| **可复现性** | 每个会话从相同的模板快照启动 |
+| **快速启动** | 冷启动低于 60 毫秒，并行 Agent 成本低 |
+| **长任务支持** | `sandbox.pause()` 对 VM + rootfs 做快照，稍后恢复 |
+| **密钥安全** | CubeEgress 在线注入认证请求头——VM 永不见真实密钥 |
+| **出口审计** | 每次对 Anthropic API 的请求均记录在出口审计日志中 |
+
+## 接入步骤
+
+### 1. 构建模板镜像
+
+镜像在 `cubesandbox-base` 之上叠加 Node.js 24 和 Claude Code CLI，envd 已在
+`:49983` 上监听。
+
+```dockerfile
+# examples/claude-code-integration/Dockerfile（节选）
+ARG CUBE_BASE_IMAGE=ghcr.io/tencentcloud/cubesandbox-base:2026.16
+FROM ${CUBE_BASE_IMAGE}
+
+ARG NODE_MAJOR=24
+ARG CLAUDE_CODE_VERSION=latest
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        ca-certificates curl git gnupg jq less procps python3 python3-pip ripgrep \
+    && curl -fsSL "https://deb.nodesource.com/setup_${NODE_MAJOR}.x" | bash - \
+    && apt-get install -y --no-install-recommends nodejs \
+    && npm install -g "@anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}" \
+    && claude --version \
+    && npm cache clean --force \
+    && rm -rf /root/.npm /var/lib/apt/lists/*
+
+WORKDIR /workspace
+EXPOSE 49983
+```
+
+构建并推送：
+
+```bash
+# 国内用户可使用南京大学镜像：
+#   --build-arg CUBE_BASE_IMAGE=ghcr.nju.edu.cn/tencentcloud/cubesandbox-base:2026.16
+docker build --platform linux/amd64 \
+  -t <your-registry>/claude-code-cube:latest \
+  examples/claude-code-integration
+docker push <your-registry>/claude-code-cube:latest
+```
+
+### 2. 注册为 Cube 模板
+
+```bash
+cubemastercli tpl create-from-image \
+  --image <your-registry>/claude-code-cube:latest \
+  --writable-layer-size 4G \
+  --expose-port 49983 \
+  --probe       49983 \
+  --probe-path  /health
+
+cubemastercli tpl watch --job-id <job_id>
+```
+
+任务状态变为 `READY` 后，记录 `template_id`——后续每次 `Sandbox.create()` 调用
+都需要它。`4G` 可写层适合中等规模任务；如需安装大型工具链（如 Claude Code 插件、
+MCP 服务器），可上调至 `8G+`。
+
+### 3. 配置宿主端驱动
+
+```bash
+cd examples/claude-code-integration
+cp .env.example .env
+# 填入 E2B_API_URL、CUBE_TEMPLATE_ID 和你的 API 密钥
+pip install -r requirements.txt
+```
+
+| 变量 | 流向 | 说明 |
+|---|---|---|
+| `E2B_API_URL` | 本地进程 | CubeAPI 地址 (`http://<node>:3000`) |
+| `E2B_API_KEY` | 本地进程 | 本地开发填任意非空值即可 |
+| `CUBE_TEMPLATE_ID` | `Sandbox.create(template=...)` | 从步骤 2 获取 |
+| `ANTHROPIC_API_KEY` | `envs=...`（直接模式）或 CubeEgress 注入（保险库模式） | API 密钥（标准方式） |
+| `ANTHROPIC_AUTH_TOKEN` | `envs=...`（直接模式） | API 密钥（第三方兼容端点，如 DeepSeek） |
+| `ANTHROPIC_BASE_URL` | 传入 exec 环境 | API 网关/兼容端点 |
+| `CC_MODEL` | `--model` 参数 | 默认：`claude-sonnet-4-6` |
+| `CC_EFFORT` | `--effort` 参数 | 努力级别：low, medium, high, xhigh, max |
+| `CC_LLM_HOST` | `network_policy.py` | 默认拒绝出口下允许的 API 主机 |
+
+### 4. 运行时配置与 API 密钥注入
+
+Claude Code 以 headless 模式运行，使用 `-p`（处理提示词后退出，无交互式 TUI）
+和 `--output-format json`（机器可读输出）。同一模板上支持两种密钥注入模式：
+
+**直接模式** — 按命令转发密钥。`e2b` 的 `commands.run(envs=...)` 将环境变量
+放入 exec 信包而非 VM 中的持久化文件，密钥仅在命令生命周期内有效：
+
+```python
+result = sandbox.commands.run(
+    "cd /workspace && claude -p '重构 auth 模块' "
+    "--output-format json --model claude-sonnet-4-6 "
+    "--dangerously-skip-permissions",
+    envs={"ANTHROPIC_API_KEY": key},
+    user="user",
+    timeout=900,
+)
+```
+
+**保险库模式** — 密钥完全不出现在 VM 中（见步骤 6）。
+
+示例脚本默认解析 JSON 流并打印简洁的文本摘要（助手文本、工具调用及错误）；
+传入 `--raw`（或设置 `CC_STREAM_RAW=1`）可查看原始 JSON 事件流。
+
+### 5. 会话持久化（暂停 / 恢复）
+
+```bash
+python resume_claude_code.py
+```
+
+这在 SDK 层面映射了 [快照/克隆/回滚](../snapshot-rollback-clone.md) 引擎：
+
+- `sandbox.pause()` 对运行中的 VM（内存 + rootfs）做快照并释放计算资源。
+- `Sandbox.connect(sandbox_id)` 恢复沙箱，`/workspace`、Claude Code 状态目录
+  等所有文件完整保留（以非 root 用户运行时状态目录为 `/home/user/.claude`）。
+
+> **生命周期提醒**：使用 `try/finally` 管理沙箱生命周期，而非
+> `with Sandbox.create(...)` 上下文管理器。上下文管理器在 `__exit__` 时会
+> 销毁沙箱，导致 pause 操作无效。示例采用显式创建，仅在 `finally` 中调用
+> `sandbox.kill()`。
+
+```python
+sandbox = Sandbox.create(template=template_id, timeout=1800)
+try:
+    run_turn(sandbox, prompt_1)          # 写入 /workspace/plan.md
+    sandbox_id = sandbox.pause() or sandbox.sandbox_id
+    sandbox = Sandbox.connect(sandbox_id)
+    assert_state_survived(sandbox)       # /workspace + 状态目录完好
+    run_turn(sandbox, prompt_2)          # 继续工作
+finally:
+    sandbox.kill()
+```
+
+### 6. 网络与出口策略（凭证保险库）
+
+`network_policy.py` 展示了共享集群的推荐模式：默认拒绝出口 + 在线密钥注入。
+
+```python
+# 凭证注入使用原生 cubesandbox SDK（详见 security-proxy.md）
+from cubesandbox import Sandbox, Rule, Match, Action, Inject
+
+host = "api.anthropic.com"
+rules = [
+    Rule(
+        name="allow_anthropic_api",
+        match=Match(scheme="https", sni=host, host=host),
+        action=Action(allow=True, audit="metadata", inject=[
+            Inject(header="x-api-key", secret=ANTHROPIC_API_KEY, format="${SECRET}"),
+            Inject(header="anthropic-version", secret="2023-06-01", format="${SECRET}"),
+        ]),
+    ),
+]
+
+sandbox = Sandbox.create(
+    template=CUBE_TEMPLATE_ID,
+    allow_internet_access=False,   # 默认拒绝；规则中的主机自动放行
+    network={"rules": rules},
+)
+```
+
+效果：
+
+- 沙箱内执行 `printenv ANTHROPIC_API_KEY` 只显示占位符。
+- 每次对 `api.anthropic.com` 的请求，认证请求头被在线附加。
+- 其他所有流量被 CubeVS 在 L3/L4 层丢弃（`allow_internet_access=False`），
+  永不离开沙箱。
+- 每条允许/拒绝决策均记入出口审计日志。
+
+对于兼容 Anthropic 协议的网关（如 DeepSeek），调整规则中的 host 并设置
+`ANTHROPIC_BASE_URL` 环境变量。
+
+## 使用场景与最佳实践
+
+- **隔离开发。** 将 Claude Code 运行在沙箱内，其文件编辑和 Shell 命令无法接触宿主机。
+- **执行 Agent 生成的代码并收集结果。** 让 Claude Code 输出到 `/workspace`，
+  再通过 `sandbox.files` 或 `commands.run` 回读产物。
+- **长任务检查点/恢复。** 使用 `pause()` + `connect()` 对长时间重构任务做快照，
+  稍后恢复，或从一个快照分叉出多个并行变体。
+- **将重量级依赖预安装进模板**，尤其在默认拒绝出口策略下，避免运行时拉取。
+- **批量处理。** 在并行沙箱中运行多个 Claude Code 实例，用于代码审查、迁移
+  或分析流水线。
+
+## 关键代码片段
+
+### Headless Claude Code 调用
+
+```python
+cmd = (
+    "cd /workspace && claude -p "
+    "'检查项目，运行 app.py，并将摘要写入 result.md' "
+    "--output-format json --model claude-sonnet-4-6 "
+    "--dangerously-skip-permissions"
+)
+result = sandbox.commands.run(cmd, envs=cc_env, user="user", timeout=900)
+```
+
+### 预检版本检查
+
+```python
+version = sandbox.commands.run("claude --version", timeout=60)
+```
+
+### 使用特定的努力级别
+
+```python
+# 控制推理深度：low, medium, high, xhigh, max
+cmd = (
+    "claude -p '审计此代码的安全问题。' "
+    "--output-format json --effort high"
+)
+```
+
+### 设置自动化权限模式
+
+```python
+# plan: 编辑前询问（默认）；acceptEdits: 自动批准编辑；
+# bypassPermissions: 完全自动（需非 root 用户）
+cmd = (
+    "claude -p '修复 src/ 中所有的 lint 错误' "
+    "--output-format json --permission-mode acceptEdits"
+)
+```
+
+### 跳过所有权限检查（仅限沙箱）
+
+```python
+# 推荐用于隔离沙箱。必须以非 root 用户运行；
+# Claude Code 会拒绝 root/sudo 用户使用此选项。
+cmd = (
+    "claude -p '执行任务' "
+    "--output-format json --dangerously-skip-permissions"
+)
+result = sandbox.commands.run(cmd, envs=cc_env, user="user", timeout=900)
+```
+
+## 注意事项
+
+- **Node.js 版本。** Claude Code 需要较新的 Node 运行时；基础镜像自带的 apt 版
+  Node 较旧，务必通过 NodeSource 安装（Dockerfile 已处理）。
+- **Agent 状态目录。** 以 `user` 身份运行时（headless 自动化推荐方式），Claude
+  Code 的会话缓存位于 `/home/user/.claude`。以 `root` 身份运行时则位于
+  `/root/.claude`。镜像中保持为空以避免跨租户泄露会话；构建时创建但不填入任何凭据。
+- **直接模式密钥持久化。** 直接模式 (`envs=`) 下的密钥作用域仅限于 exec 调用，
+  但沙箱快照可能捕获 VM 内环境变量。如需严格隔离，请使用保险库模式
+  （`network_policy.py`），密钥永不进入 VM。
+- **CubeEgress CA（Node.js）。** 保险库模式下沙箱须信任 CubeEgress 根证书，
+  基础镜像已安装至系统证书包。Claude Code 运行在 Node.js 上，Node.js 忽略
+  系统证书库，因此 `network_policy.py` 同时设置了 `NODE_EXTRA_CA_CERTS`
+  （可通过 `CC_NODE_EXTRA_CA_CERTS` 覆写）——缺少此项将导致保险库路径 TLS 失败。
+- **仅支持 Headless 模式。** Claude Code 的交互式 TUI 无法在 E2B 协议上使用。
+  请使用 `-p` / `--print` 配合 `--output-format json` 获取机器可读输出，并
+  在宿主脚本中驱动多轮对话。
+- **权限模式。** 在自动化沙箱环境中，推荐使用 `--dangerously-skip-permissions`
+  （需非 root 用户）或 `--permission-mode acceptEdits`（root 可用）实现自主执行。
+  默认的 `plan` 模式每次工具调用需要人工批准，不适用于 headless 沙箱场景。
+  注意：`--dangerously-skip-permissions` 在 root 用户下会被 Claude Code 拒绝。
+- **出口副作用。** 执行 `npm install` 或获取 MCP 工具的任务，需将相关主机加入
+  白名单或预先安装到模板中。
+- **API 速率限制。** Claude Code 与 Anthropic API 交互，受标准速率限制和 Token
+  配额约束。高吞吐批量处理场景建议分布到多个 API Key 和沙箱中。
+
+## 故障排除
+
+| 症状 | 可能原因 | 解决方法 |
+|---|---|---|
+| 预检报 `claude: command not found` | CLI 变更后模板未重建 | 重建镜像，重新注册模板 |
+| API 认证失败 | 密钥未转发（直接模式）或缺少注入规则（保险库模式） | 传入 `envs={...}` 或修正规则的 `sni`/`host` |
+| `403 Forbidden - CubeEgress` | 默认拒绝出口且无匹配的允许规则 | 在规则中添加 `api.anthropic.com`（及其他所需主机） |
+| Claude Code TLS / 连接错误（保险库模式） | Node.js 忽略系统 CA 证书库 | 按 `network_policy.py` 中所示设置 `NODE_EXTRA_CA_CERTS` |
+| 模板创建卡在 `PULLING` | Cube 节点无法访问仓库 | 推送到集群可访问的仓库，必要时提供认证信息 |
+| 就绪探针超时 | 基础镜像不包含 envd | 确保 `FROM ghcr.io/tencentcloud/cubesandbox-base:2026.16` |
+| `pause()` / `connect()` 报错 | 平台版本过旧不支持快照 | 升级 CubeSandbox 平台 |
+| Claude Code 挂起无输出 | 在非 TTY 通道上启动了 TUI 模式 | 始终在 headless 模式使用 `-p` / `--print` |
+| Token 超限 | 任务规模超出配置的努力级别 | 降低 `--effort` 级别或拆分任务 |
+
+## 参考资料
+
+- 可运行示例：[`examples/claude-code-integration`](https://github.com/TencentCloud/CubeSandbox/tree/master/examples/claude-code-integration)
+- 自定义镜像：[`docs/guide/tutorials/bring-your-own-image.md`](../tutorials/bring-your-own-image.md)
+- 从镜像创建模板：[`docs/guide/tutorials/template-from-image.md`](../tutorials/template-from-image.md)
+- 快照 / 克隆 / 回滚：[`docs/guide/snapshot-rollback-clone.md`](../snapshot-rollback-clone.md)
+- 凭证保险库 + 出口管控：[`docs/guide/security-proxy.md`](../security-proxy.md)
+- Claude Code：<https://docs.anthropic.com/en/docs/claude-code>
+- E2B Claude Code 集成：<https://e2b.dev/docs/agents/claude-code>

--- a/docs/zh/guide/integrations/index.md
+++ b/docs/zh/guide/integrations/index.md
@@ -48,3 +48,4 @@ lang: zh-CN
 | 标题 | 作者 | 日期 | 标签 |
 | --- | --- | --- | --- |
 | [Pi Agent 集成指南](./pi-agent.md) | chaojixinren | 2026-07-01 | integration, pi-agent, coding-agent, agent |
+| [Claude Code 集成指南](./claude-code.md) | dcdc4747 | 2026-07-29 | integration, claude-code, coding-agent, agent |

--- a/examples/claude-code-integration/.env.example
+++ b/examples/claude-code-integration/.env.example
@@ -1,0 +1,42 @@
+# --- CubeSandbox connection ---
+
+# Required: CubeAPI address (use CubeAPI, not CubeProxy).
+E2B_API_URL="http://<cube-host>:3000"
+
+# Required: any non-empty value in local dev; a real key when auth is enabled.
+E2B_API_KEY="e2b_000000"
+
+# Required: template built from this example's Dockerfile.
+CUBE_TEMPLATE_ID="<template-id>"
+
+# Optional: only when talking to CubeProxy over HTTPS with Cube's mkcert cert.
+# SSL_CERT_FILE="/root/.local/share/mkcert/rootCA.pem"
+
+# --- Claude Code agent ---
+
+# Required: API key. Use ANTHROPIC_API_KEY for Anthropic, or ANTHROPIC_AUTH_TOKEN
+# for third-party Anthropic-compatible endpoints (e.g., DeepSeek).
+ANTHROPIC_API_KEY="<your-api-key>"
+# ANTHROPIC_AUTH_TOKEN="<your-auth-token>"
+
+# Required: model Claude Code runs against.
+# Anthropic: claude-sonnet-4-6, claude-opus-4-8, claude-haiku-4-5
+# Third-party: depends on provider (e.g., deepseek-v4-pro[1m])
+CC_MODEL="claude-sonnet-4-6"
+
+# Optional: Anthropic-compatible endpoint (e.g., for API gateways or third-party
+# providers like DeepSeek: https://api.deepseek.com/anthropic).
+# ANTHROPIC_BASE_URL="https://api.anthropic.com"
+
+# Optional (network_policy.py): LLM host to allow under default-deny egress.
+# Defaults to the host extracted from ANTHROPIC_BASE_URL.
+# CC_LLM_HOST="api.anthropic.com"
+
+# Optional: workspace directory inside the sandbox.
+# CC_WORKSPACE="/workspace"
+
+# Advanced tunables (override in .env only when the defaults don't fit).
+# CC_SANDBOX_TIMEOUT=1800    # sandbox lifetime in seconds
+# CC_EXEC_TIMEOUT=900         # Claude Code command timeout in seconds
+# CC_EFFORT=""                # effort level: low, medium, high, xhigh, max
+# CC_PERMISSION_MODE="plan"   # permission mode: plan, acceptEdits, bypassPermissions

--- a/examples/claude-code-integration/.gitignore
+++ b/examples/claude-code-integration/.gitignore
@@ -1,0 +1,3 @@
+.env
+__pycache__/
+*.py[cod]

--- a/examples/claude-code-integration/Dockerfile
+++ b/examples/claude-code-integration/Dockerfile
@@ -17,7 +17,9 @@
 #     --probe       49983 \
 #     --probe-path  /health
 
-ARG CUBE_BASE_IMAGE=ghcr.nju.edu.cn/tencentcloud/cubesandbox-base:2026.16
+# For users in China, override with the NJU mirror:
+#   --build-arg CUBE_BASE_IMAGE=ghcr.nju.edu.cn/tencentcloud/cubesandbox-base:2026.16
+ARG CUBE_BASE_IMAGE=ghcr.io/tencentcloud/cubesandbox-base:2026.16
 FROM ${CUBE_BASE_IMAGE}
 
 ARG DEBIAN_FRONTEND=noninteractive
@@ -48,11 +50,12 @@ RUN npm install -g "@anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}" \
     && npm cache clean --force \
     && rm -rf /root/.npm
 
-# Claude Code state directory (pre-created empty so no session leaks across
-# tenants; sessions are ephemeral and scoped to the sandbox lifecycle).
-ENV CLAUDE_CODE_STATE_DIR=/root/.claude
-
-RUN mkdir -p /workspace "${CLAUDE_CODE_STATE_DIR}"
+# Claude Code stores its state at $HOME/.claude by default, so the path
+# follows whichever user runs the process (e.g. /home/user/.claude for
+# headless automation, /root/.claude for root).  Sessions are ephemeral
+# and scoped to the sandbox lifecycle — each MicroVM boots from this
+# template snapshot, so no state leaks across tenants.
+RUN mkdir -p /workspace
 
 WORKDIR /workspace
 

--- a/examples/claude-code-integration/Dockerfile
+++ b/examples/claude-code-integration/Dockerfile
@@ -1,0 +1,59 @@
+# syntax=docker/dockerfile:1.7
+#
+# Claude Code CLI inside a CubeSandbox template.
+#
+# The image installs Node.js 24 and the @anthropic-ai/claude-code CLI on top of
+# the official CubeSandbox base image. The inherited cube-entrypoint keeps envd
+# running on :49983 so Cube can use the standard readiness probe.
+#
+# Build:
+#   docker build -t claude-code-cube:latest examples/claude-code-integration
+#
+# Register as a Cube template:
+#   cubemastercli tpl create-from-image \
+#     --image <your-registry>/claude-code-cube:latest \
+#     --writable-layer-size 4G \
+#     --expose-port 49983 \
+#     --probe       49983 \
+#     --probe-path  /health
+
+ARG CUBE_BASE_IMAGE=ghcr.nju.edu.cn/tencentcloud/cubesandbox-base:2026.16
+FROM ${CUBE_BASE_IMAGE}
+
+ARG DEBIAN_FRONTEND=noninteractive
+ARG NODE_MAJOR=24
+ARG CLAUDE_CODE_VERSION=latest
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        bash \
+        ca-certificates \
+        curl \
+        git \
+        gnupg \
+        jq \
+        less \
+        procps \
+        python3 \
+        python3-pip \
+        ripgrep \
+    && curl -fsSL "https://deb.nodesource.com/setup_${NODE_MAJOR}.x" | bash - \
+    && apt-get install -y --no-install-recommends nodejs \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Claude Code CLI in its own layer so bumping the version does not
+# invalidate the slow OS + Node.js layer above.
+RUN npm install -g "@anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}" \
+    && claude --version \
+    && npm cache clean --force \
+    && rm -rf /root/.npm
+
+# Claude Code state directory (pre-created empty so no session leaks across
+# tenants; sessions are ephemeral and scoped to the sandbox lifecycle).
+ENV CLAUDE_CODE_STATE_DIR=/root/.claude
+
+RUN mkdir -p /workspace "${CLAUDE_CODE_STATE_DIR}"
+
+WORKDIR /workspace
+
+EXPOSE 49983

--- a/examples/claude-code-integration/README.md
+++ b/examples/claude-code-integration/README.md
@@ -45,13 +45,13 @@ python network_policy.py
 |---|---|
 | `Dockerfile` | Node.js 24 + Claude Code CLI on `cubesandbox-base:2026.16` |
 | `.env.example` | Environment variable reference |
-| `requirements.txt` | Python dependencies (`e2b`, `cubesandbox`, `python-dotenv`) |
+| `requirements.txt` | Python dependencies (`e2b`, `cubesandbox`) |
+| `build-template.sh` | Build image → push → register as Cube template |
 | `run_claude_code.py` | One-shot headless Claude Code task |
 | `resume_claude_code.py` | Pause/resume persistence demo |
 | `network_policy.py` | CubeEgress credential vault (default-deny egress + on-the-wire key injection) |
-| `_cc_common.py` | Shared sandbox command helpers + JSON/JSONL output rendering |
-| `env_utils.py` | Environment variable utilities + CLI command builder |
-| `test_cli.py` | CLI verification test suite (run to validate Claude Code CLI behavior) |
+| `common.py` | SDK-agnostic sandbox command helpers + CLI command builder + output rendering |
+| `test_common.py` | Unit tests for `common.py` (12/12, standalone runner) |
 
 ## How It Works
 

--- a/examples/claude-code-integration/README.md
+++ b/examples/claude-code-integration/README.md
@@ -1,0 +1,164 @@
+# Claude Code Integration for CubeSandbox
+
+Run [Claude Code](https://docs.anthropic.com/en/docs/claude-code) — Anthropic's
+agentic coding CLI — inside CubeSandbox MicroVMs. This example covers image
+build, key injection, egress control, and snapshot-based session persistence.
+
+[中文文档](README_zh.md)
+
+## Quick Start
+
+```bash
+# 1. Configure
+cp .env.example .env
+# Fill in: E2B_API_URL, CUBE_TEMPLATE_ID, ANTHROPIC_API_KEY
+
+# 2. Install dependencies
+pip install -r requirements.txt
+
+# 3. Build and register the template image
+docker build --platform linux/amd64 \
+  -t <your-registry>/claude-code-cube:latest \
+  examples/claude-code-integration
+docker push <your-registry>/claude-code-cube:latest
+
+cubemastercli tpl create-from-image \
+  --image <your-registry>/claude-code-cube:latest \
+  --writable-layer-size 4G \
+  --expose-port 49983 \
+  --probe       49983 \
+  --probe-path  /health
+
+# 4. Run a one-shot task
+python run_claude_code.py
+
+# 5. (Optional) Demonstrate pause/resume
+python resume_claude_code.py
+
+# 6. (Recommended for production) Default-deny egress + credential vault
+python network_policy.py
+```
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `Dockerfile` | Node.js 24 + Claude Code CLI on `cubesandbox-base:2026.16` |
+| `.env.example` | Environment variable reference |
+| `requirements.txt` | Python dependencies (`e2b`, `cubesandbox`, `python-dotenv`) |
+| `run_claude_code.py` | One-shot headless Claude Code task |
+| `resume_claude_code.py` | Pause/resume persistence demo |
+| `network_policy.py` | CubeEgress credential vault (default-deny egress + on-the-wire key injection) |
+| `_cc_common.py` | Shared sandbox command helpers + JSON/JSONL output rendering |
+| `env_utils.py` | Environment variable utilities + CLI command builder |
+| `test_cli.py` | CLI verification test suite (run to validate Claude Code CLI behavior) |
+
+## How It Works
+
+### Architecture
+
+```
+┌──────────────────────────┐     ┌─────────────────────────────┐
+│   Host (Python driver)   │     │   CubeSandbox MicroVM        │
+│                          │     │                              │
+│  Sandbox.create()   ─────┼────→│  envd (:49983)              │
+│  sandbox.commands.run()  │────→│  claude -p "..." --json     │
+│  sandbox.pause()         │────→│  /workspace (persistent)    │
+│  Sandbox.connect()       │────→│  /root/.claude (state dir)  │
+└──────────────────────────┘     └─────────────────────────────┘
+```
+
+### One-Shot Task (`run_claude_code.py`)
+
+Creates a sandbox, seeds a demo project, runs `claude -p "<prompt>" --output-format json`,
+parses the result, and kills the sandbox. The API key is injected per-command via
+`envs=` — simple for development, but the key enters the VM.
+
+### Session Persistence (`resume_claude_code.py`)
+
+- **Turn 1**: Claude Code writes `/workspace/plan.md`, then the sandbox is paused.
+- **Pause**: `sandbox.pause()` snapshots VM memory + rootfs and frees compute.
+- **Turn 2**: `Sandbox.connect(sandbox_id)` resumes the sandbox with all files
+  and Claude Code state intact, then Claude Code continues the work.
+
+The sandbox lifecycle is managed manually with `try/finally` (not `with Sandbox.create()`)
+to prevent the context manager from killing the sandbox on pause.
+
+### Credential Vault (`network_policy.py`)
+
+The recommended production pattern:
+
+1. **Default-deny egress** (`allow_internet_access=False`) — blocks all outbound
+   traffic except the Anthropic API host.
+2. **On-the-wire injection** — CubeEgress attaches `x-api-key` and
+   `anthropic-version` headers at the proxy layer. The real key never enters
+   the VM; `printenv ANTHROPIC_API_KEY` shows only a placeholder.
+3. **Node.js CA trust** — Claude Code runs on Node.js, which ignores the system
+   CA store. `NODE_EXTRA_CA_CERTS` points Node at a bundle that includes the
+   CubeEgress root CA (installed by the base image).
+
+### Output Formats
+
+Claude Code supports three output modes with `--output-format` (all require `-p`/`--print`):
+
+| Format | Behavior | Best for |
+|---|---|---|
+| `json` | Single JSON object with `type`, `result`, `usage`, `is_error` fields | One-shot tasks, result capture |
+| `stream-json` | JSONL events (`system`/`assistant`/`result`) — requires `--verbose` | Real-time streaming, multi-turn |
+| `text` | Plain text (default) | Debugging, human reading |
+
+The example scripts default to `json`; add `--output-format stream-json --verbose`
+to `cc_command()` for streaming.
+
+## Environment Variables
+
+| Variable | Where it flows | Notes |
+|---|---|---|
+| `E2B_API_URL` | Local process | CubeAPI address (`http://<node>:3000`) |
+| `E2B_API_KEY` | Local process | Any non-empty string in local dev |
+| `CUBE_TEMPLATE_ID` | `Sandbox.create(template=...)` | From `cubemastercli tpl create-from-image` |
+| `ANTHROPIC_API_KEY` | `envs=...` (direct) or CubeEgress inject (vault) | Anthropic API key |
+| `ANTHROPIC_BASE_URL` | Passed into the exec env | For API gateways / compatible endpoints |
+| `CC_MODEL` | `--model` flag | Default: `claude-sonnet-4-6` |
+| `CC_EFFORT` | `--effort` flag | Effort level: low, medium, high, xhigh, max |
+| `CC_LLM_HOST` | `network_policy.py` | API host allowed under default-deny egress |
+| `CC_PERMISSION_MODE` | `--permission-mode` flag | plan, acceptEdits, auto, bypassPermissions |
+
+## Requirements
+
+- CubeSandbox deployment with CubeAPI reachable at `http://<node>:3000`
+- `cubemastercli` on `$PATH`, connected to the cluster
+- Docker with a registry the Cube nodes can pull from
+- Python 3.10+ for the host driver scripts
+- Anthropic API key
+
+## Caveats
+
+- **Node.js CA trust (vault flavor).** Claude Code's Node.js runtime uses its own
+  bundled CA store. Without `NODE_EXTRA_CA_CERTS` pointing at a bundle that includes
+  the CubeEgress root CA, all API calls through the vault path fail with TLS errors.
+- **Direct-flavor key persistence.** With the direct flavor (`envs=`) the key is
+  scoped to the exec call, but sandbox snapshots may capture the in-VM environment.
+  For strict isolation prefer the vault flavor.
+- **Headless only.** Claude Code's interactive TUI is not available over the E2B
+  protocol. Use `-p` / `--print` with `--output-format json` for
+  machine-readable output.
+- **Permission mode.** In sandbox environments, use `--permission-mode auto` or
+  `--dangerously-skip-permissions` for fully autonomous execution. `plan` mode
+  requires human approval for each tool call, which is not practical in a
+  headless sandbox.
+- **Egress side-effects.** Tasks that `npm install` or fetch MCP tools need those
+  hosts allowed or preinstalled into the template.
+- **API rate limits.** Claude Code interacts with the Anthropic API; standard
+  rate limits and token quotas apply. Use `--max-budget-usd` to cap spending per
+  session.
+- **State directory.** `/root/.claude` holds Claude Code's session state. Keep
+  it empty in the image to avoid leaking sessions across tenants.
+
+## References
+
+- [Claude Code documentation](https://docs.anthropic.com/en/docs/claude-code)
+- [E2B Claude Code integration](https://e2b.dev/docs/agents/claude-code)
+- [CubeSandbox Bring Your Own Image](../../docs/guide/tutorials/bring-your-own-image.md)
+- [CubeSandbox Snapshot / Clone / Rollback](../../docs/guide/snapshot-rollback-clone.md)
+- [CubeSandbox Security Proxy (credential vault)](../../docs/guide/security-proxy.md)

--- a/examples/claude-code-integration/README_zh.md
+++ b/examples/claude-code-integration/README_zh.md
@@ -44,13 +44,13 @@ python network_policy.py
 |---|---|
 | `Dockerfile` | 在 `cubesandbox-base:2026.16` 上安装 Node.js 24 + Claude Code CLI |
 | `.env.example` | 环境变量参考 |
-| `requirements.txt` | Python 依赖 (`e2b`, `cubesandbox`, `python-dotenv`) |
+| `requirements.txt` | Python 依赖 (`e2b`, `cubesandbox`) |
+| `build-template.sh` | 构建镜像 → 推送 → 注册为 Cube 模板 |
 | `run_claude_code.py` | 一次性 headless Claude Code 任务 |
 | `resume_claude_code.py` | 暂停/恢复持久化演示 |
 | `network_policy.py` | CubeEgress 凭证保险库（默认拒绝出口 + 在线密钥注入） |
-| `_cc_common.py` | 共享沙箱命令辅助函数 + JSON/JSONL 输出渲染 |
-| `env_utils.py` | 环境变量工具函数 + CLI 命令构建器 |
-| `test_cli.py` | CLI 验证测试套件（运行以验证 Claude Code CLI 行为） |
+| `common.py` | SDK 无关的沙箱命令辅助函数 + CLI 命令构建器 + 输出渲染 |
+| `test_common.py` | `common.py` 单元测试（12/12，可独立运行） |
 
 ## 工作原理
 
@@ -149,15 +149,6 @@ Claude Code 支持三种 `--output-format` 模式（均需配合 `-p`/`--print`�
   配额约束。使用 `--max-budget-usd` 限制每次会话的开销。
 - **状态目录。** `/root/.claude` 存放 Claude Code 会话状态。镜像中应保持为空，
   避免跨租户泄露会话信息。
-
-## 技术背景
-
-AI 编程 Agent（如 Claude Code、Pi、Gemini CLI）通常需要读写文件、执行命令和
-安装依赖包。直接在开发工作站上运行会混合 Agent 的爆炸半径和本地开发环境。
-CubeSandbox 通过 KVM MicroVM 提供硬件级隔离，每个会话拥有独立的客户内核。
-
-相关研究领域包括：微虚拟机安全隔离 (Firecracker/gVisor)、容器逃逸检测、
-基于 eBPF 的内核级沙箱、大语言模型工具调用的安全约束等。
 
 ## 参考资料
 

--- a/examples/claude-code-integration/README_zh.md
+++ b/examples/claude-code-integration/README_zh.md
@@ -1,0 +1,168 @@
+# Claude Code 集成 CubeSandbox
+
+在 CubeSandbox MicroVM 中运行 [Claude Code](https://docs.anthropic.com/en/docs/claude-code)
+—— Anthropic 的 AI 编程 CLI 工具。本示例涵盖镜像构建、密钥注入、网络出口控制和基于快照的会话持久化。
+
+[English](README.md)
+
+## 快速开始
+
+```bash
+# 1. 配置环境变量
+cp .env.example .env
+# 填入: E2B_API_URL, CUBE_TEMPLATE_ID, ANTHROPIC_API_KEY
+
+# 2. 安装依赖
+pip install -r requirements.txt
+
+# 3. 构建并注册模板镜像
+docker build --platform linux/amd64 \
+  -t <your-registry>/claude-code-cube:latest \
+  examples/claude-code-integration
+docker push <your-registry>/claude-code-cube:latest
+
+cubemastercli tpl create-from-image \
+  --image <your-registry>/claude-code-cube:latest \
+  --writable-layer-size 4G \
+  --expose-port 49983 \
+  --probe       49983 \
+  --probe-path  /health
+
+# 4. 运行一次性任务
+python run_claude_code.py
+
+# 5. （可选）演示暂停/恢复
+python resume_claude_code.py
+
+# 6. （生产环境推荐）默认拒绝出口 + 凭证保险库
+python network_policy.py
+```
+
+## 文件说明
+
+| 文件 | 用途 |
+|---|---|
+| `Dockerfile` | 在 `cubesandbox-base:2026.16` 上安装 Node.js 24 + Claude Code CLI |
+| `.env.example` | 环境变量参考 |
+| `requirements.txt` | Python 依赖 (`e2b`, `cubesandbox`, `python-dotenv`) |
+| `run_claude_code.py` | 一次性 headless Claude Code 任务 |
+| `resume_claude_code.py` | 暂停/恢复持久化演示 |
+| `network_policy.py` | CubeEgress 凭证保险库（默认拒绝出口 + 在线密钥注入） |
+| `_cc_common.py` | 共享沙箱命令辅助函数 + JSON/JSONL 输出渲染 |
+| `env_utils.py` | 环境变量工具函数 + CLI 命令构建器 |
+| `test_cli.py` | CLI 验证测试套件（运行以验证 Claude Code CLI 行为） |
+
+## 工作原理
+
+### 架构
+
+```
+┌──────────────────────────┐     ┌─────────────────────────────┐
+│   宿主机 (Python 驱动)     │     │   CubeSandbox MicroVM       │
+│                          │     │                              │
+│  Sandbox.create()   ─────┼────→│  envd (:49983)              │
+│  sandbox.commands.run()  │────→│  claude -p "..." --json     │
+│  sandbox.pause()         │────→│  /workspace (持久化)        │
+│  Sandbox.connect()       │────→│  /root/.claude (状态目录)   │
+└──────────────────────────┘     └─────────────────────────────┘
+```
+
+### 一次性任务 (`run_claude_code.py`)
+
+创建沙箱、初始化演示项目、运行 `claude -p "<prompt>" --output-format json`、
+解析结果，然后销毁沙箱。API 密钥通过 `envs=` 按命令注入——开发环境简单
+易用，但密钥会进入 VM 内部。
+
+### 会话持久化 (`resume_claude_code.py`)
+
+- **第 1 轮**：Claude Code 写入 `/workspace/plan.md`，然后沙箱暂停。
+- **暂停**：`sandbox.pause()` 对 VM 内存 + rootfs 做快照，释放计算资源。
+- **第 2 轮**：`Sandbox.connect(sandbox_id)` 恢复沙箱，所有文件和
+  Claude Code 状态完整保留，Claude Code 继续工作。
+
+沙箱生命周期使用 `try/finally` 手动管理（而非 `with Sandbox.create()`），
+以避免上下文管理器在暂停时销毁沙箱。
+
+### 凭证保险库 (`network_policy.py`)
+
+推荐的生产环境模式：
+
+1. **默认拒绝出口** (`allow_internet_access=False`) — 除 Anthropic API 主机外，
+   阻止所有出站流量。
+2. **在线注入** — CubeEgress 在代理层附加 `x-api-key` 和
+   `anthropic-version` 请求头。真实密钥永不进入 VM；
+   `printenv ANTHROPIC_API_KEY` 只显示占位符。
+3. **Node.js CA 信任** — Claude Code 运行在 Node.js 上，Node.js 使用自己的
+   CA 证书库而忽略系统证书库。`NODE_EXTRA_CA_CERTS` 将 Node 指向包含
+   CubeEgress 根证书的证书包（基础镜像已安装）。
+
+### 输出格式
+
+Claude Code 支持三种 `--output-format` 模式（均需配合 `-p`/`--print`）：
+
+| 格式 | 行为 | 适用场景 |
+|---|---|---|
+| `json` | 单个 JSON 对象，含 `type`、`result`、`usage`、`is_error` 字段 | 一次性任务、结果捕获 |
+| `stream-json` | JSONL 事件流（`system`/`assistant`/`result`）——需 `--verbose` | 实时流式、多轮对话 |
+| `text` | 纯文本（默认） | 调试、人工阅读 |
+
+示例脚本默认使用 `json`；如需流式，在 `cc_command()` 中添加
+`--output-format stream-json --verbose`。
+
+## 环境变量
+
+| 变量 | 流向 | 说明 |
+|---|---|---|
+| `E2B_API_URL` | 本地进程 | CubeAPI 地址 (`http://<node>:3000`) |
+| `E2B_API_KEY` | 本地进程 | 本地开发填任意非空值即可 |
+| `CUBE_TEMPLATE_ID` | `Sandbox.create(template=...)` | 从 `cubemastercli tpl create-from-image` 获取 |
+| `ANTHROPIC_API_KEY` | `envs=...`（直接模式）或 CubeEgress 注入（保险库模式） | Anthropic API 密钥 |
+| `ANTHROPIC_BASE_URL` | 传入 exec 环境 | API 网关/兼容端点 |
+| `CC_MODEL` | `--model` 参数 | 默认：`claude-sonnet-4-6` |
+| `CC_EFFORT` | `--effort` 参数 | 努力级别：low, medium, high, xhigh, max |
+| `CC_LLM_HOST` | `network_policy.py` | 默认拒绝出口下允许的 API 主机 |
+| `CC_PERMISSION_MODE` | `--permission-mode` 参数 | plan, acceptEdits, auto, bypassPermissions |
+
+## 环境要求
+
+- CubeSandbox 部署就绪，CubeAPI 可通过 `http://<node>:3000` 访问
+- `cubemastercli` 已安装并连接到集群
+- Docker，且 Cube 节点可拉取的镜像仓库
+- Python 3.10+ 用于宿主机驱动脚本
+- Anthropic API 密钥
+
+## 注意事项
+
+- **Node.js CA 信任（保险库模式）。** Claude Code 的 Node.js 运行时使用自己的
+  CA 证书库。如果不设置 `NODE_EXTRA_CA_CERTS` 指向包含 CubeEgress 根证书的
+  证书包，所有通过保险库路径的 API 调用都会因 TLS 错误而失败。
+- **直接模式密钥持久化。** 直接模式 (`envs=`) 下的密钥作用域仅限于 exec 调用，
+  但沙箱快照可能捕获 VM 内环境变量。如需严格隔离，请使用保险库模式。
+- **仅支持 Headless 模式。** Claude Code 的交互式 TUI 无法在 E2B 协议上使用。
+  请使用 `-p` / `--print` 配合 `--output-format json` 获取机器可读输出。
+- **权限模式。** 在沙箱环境中，使用 `--permission-mode auto` 或
+  `--dangerously-skip-permissions` 实现完全自主执行。`plan` 模式每次工具调用
+  需要人工批准，不适用于 headless 沙箱场景。
+- **出口副作用。** 执行 `npm install` 或获取 MCP 工具的任务，需将相关主机加入
+  白名单或预先安装到模板中。
+- **API 速率限制。** Claude Code 与 Anthropic API 交互，受标准速率限制和 Token
+  配额约束。使用 `--max-budget-usd` 限制每次会话的开销。
+- **状态目录。** `/root/.claude` 存放 Claude Code 会话状态。镜像中应保持为空，
+  避免跨租户泄露会话信息。
+
+## 技术背景
+
+AI 编程 Agent（如 Claude Code、Pi、Gemini CLI）通常需要读写文件、执行命令和
+安装依赖包。直接在开发工作站上运行会混合 Agent 的爆炸半径和本地开发环境。
+CubeSandbox 通过 KVM MicroVM 提供硬件级隔离，每个会话拥有独立的客户内核。
+
+相关研究领域包括：微虚拟机安全隔离 (Firecracker/gVisor)、容器逃逸检测、
+基于 eBPF 的内核级沙箱、大语言模型工具调用的安全约束等。
+
+## 参考资料
+
+- [Claude Code 官方文档](https://docs.anthropic.com/en/docs/claude-code)
+- [E2B Claude Code 集成](https://e2b.dev/docs/agents/claude-code)
+- [CubeSandbox 自定义镜像](../../docs/guide/tutorials/bring-your-own-image.md)
+- [CubeSandbox 快照/克隆/回滚](../../docs/guide/snapshot-rollback-clone.md)
+- [CubeSandbox 安全代理（凭证保险库）](../../docs/guide/security-proxy.md)

--- a/examples/claude-code-integration/build-template.sh
+++ b/examples/claude-code-integration/build-template.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Build a Claude Code image and register it as a CubeSandbox template.
+# Example:
+#   IMAGE=registry.example.com/cube/claude-code:2026-07-29 ./build-template.sh
+
+: "${IMAGE:?Set IMAGE to a registry image name, for example registry.example.com/cube/claude-code:tag}"
+: "${CUBE_TEMPLATE_NAME:=claude-code}"
+: "${CLAUDE_CODE_VERSION:=latest}"
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+
+docker build \
+  --build-arg "CLAUDE_CODE_VERSION=${CLAUDE_CODE_VERSION}" \
+  -t "${IMAGE}" \
+  "${SCRIPT_DIR}"
+docker push "${IMAGE}"
+
+cubemastercli tpl create-from-image \
+  --image "${IMAGE}" \
+  --name "${CUBE_TEMPLATE_NAME}" \
+  --writable-layer-size 4G \
+  --expose-port 49983 \
+  --probe 49983 \
+  --probe-path /health

--- a/examples/claude-code-integration/common.py
+++ b/examples/claude-code-integration/common.py
@@ -91,15 +91,12 @@ def require_api_key() -> str:
 
 def build_cc_env(include_secrets: bool = True) -> dict[str, str]:
     env: dict[str, str] = {}
-    for name in (
-        "ANTHROPIC_BASE_URL",
-        "HTTP_PROXY",
-        "HTTPS_PROXY",
-        "NO_PROXY",
-    ):
-        value = os.environ.get(name)
-        if value:
-            env[name] = value
+    # Only forward ANTHROPIC_BASE_URL — proxy vars from the host machine are
+    # intentionally excluded: the host's proxy is unreachable from inside the
+    # sandbox, and all sandbox traffic routes through CubeEgress.
+    value = os.environ.get("ANTHROPIC_BASE_URL")
+    if value:
+        env["ANTHROPIC_BASE_URL"] = value
     if include_secrets:
         for name in (PROVIDER_KEY_NAME, "ANTHROPIC_AUTH_TOKEN"):
             value = os.environ.get(name)

--- a/examples/claude-code-integration/common.py
+++ b/examples/claude-code-integration/common.py
@@ -1,0 +1,326 @@
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Small, dependency-free helpers shared by the Claude Code examples.
+
+Kept SDK-agnostic so the same helpers work with both the e2b-compatible
+SDK and the native ``cubesandbox`` SDK.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shlex
+import sys
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlparse
+
+# ---------------------------------------------------------------------------
+# dotenv (no extra dependency — matches gemini-cli pattern)
+# ---------------------------------------------------------------------------
+
+def load_dotenv(path: str = ".env") -> None:
+    """Load simple KEY=VALUE lines without overriding exported variables."""
+    dotenv = Path(path)
+    if not dotenv.is_file():
+        return
+    for line in dotenv.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        key = key.strip()
+        value = value.strip().strip('"').strip("'")
+        if key:
+            os.environ.setdefault(key, value)
+
+
+# ---------------------------------------------------------------------------
+# env helpers
+# ---------------------------------------------------------------------------
+
+DEFAULT_WORKSPACE = "/workspace"
+
+PROVIDER_DEFAULT_HOST = "api.anthropic.com"
+PROVIDER_KEY_NAME = "ANTHROPIC_API_KEY"
+
+
+def required(name: str) -> str:
+    value = os.environ.get(name)
+    if not value:
+        raise SystemExit(f"Missing required environment variable: {name}")
+    return value
+
+
+def optional(name: str, default: str = "") -> str:
+    return os.environ.get(name) or default
+
+
+def int_env(name: str, default: int) -> int:
+    raw = os.environ.get(name)
+    if not raw:
+        return default
+    try:
+        return int(raw)
+    except ValueError as exc:
+        raise SystemExit(f"{name} must be an integer, got {raw!r}") from exc
+
+
+def cc_model() -> str:
+    return optional("CC_MODEL", "claude-sonnet-4-6")
+
+
+def cc_workspace() -> str:
+    return optional("CC_WORKSPACE", DEFAULT_WORKSPACE)
+
+
+def require_api_key() -> str:
+    # ANTHROPIC_AUTH_TOKEN is used by third-party providers (e.g. DeepSeek)
+    # and by Claude Code OAuth; ANTHROPIC_API_KEY is the standard variable.
+    for name in (PROVIDER_KEY_NAME, "ANTHROPIC_AUTH_TOKEN"):
+        value = os.environ.get(name)
+        if value:
+            return value
+    raise SystemExit(
+        f"Missing required environment variable: {PROVIDER_KEY_NAME} or ANTHROPIC_AUTH_TOKEN"
+    )
+
+
+def build_cc_env(include_secrets: bool = True) -> dict[str, str]:
+    env: dict[str, str] = {}
+    for name in (
+        "ANTHROPIC_BASE_URL",
+        "HTTP_PROXY",
+        "HTTPS_PROXY",
+        "NO_PROXY",
+    ):
+        value = os.environ.get(name)
+        if value:
+            env[name] = value
+    if include_secrets:
+        for name in (PROVIDER_KEY_NAME, "ANTHROPIC_AUTH_TOKEN"):
+            value = os.environ.get(name)
+            if value:
+                env[name] = value
+    return env
+
+
+def cc_llm_host() -> str:
+    explicit = os.environ.get("CC_LLM_HOST")
+    if explicit:
+        return _host_from_url(explicit)
+    base_url = os.environ.get("ANTHROPIC_BASE_URL")
+    if base_url:
+        host = _host_from_url(base_url)
+        if host:
+            return host
+    return PROVIDER_DEFAULT_HOST
+
+
+def _host_from_url(value: str) -> str:
+    candidate = value.strip()
+    if not candidate:
+        return ""
+    if "://" not in candidate:
+        candidate = f"https://{candidate}"
+    return urlparse(candidate).hostname or ""
+
+
+def cc_command(
+    prompt: str,
+    *,
+    model: str | None = None,
+    effort: str | None = None,
+    permission_mode: str | None = None,
+    output_format: str = "json",
+    dangerously_skip_permissions: bool = False,
+) -> str:
+    """Build a headless (non-interactive) ``claude -p`` invocation.
+
+    When ``dangerously_skip_permissions=True`` the command must run as a
+    non-root user (Claude Code refuses this flag for root).  Combine with
+    ``run_command(..., user=\"user\")``.
+    """
+    args = ["claude", "-p", shlex.quote(prompt), "--output-format", output_format]
+
+    if output_format == "stream-json":
+        args.append("--verbose")
+
+    if model:
+        args.extend(["--model", model])
+    if effort:
+        args.extend(["--effort", effort])
+    if permission_mode:
+        args.extend(["--permission-mode", permission_mode])
+    if dangerously_skip_permissions:
+        args.append("--dangerously-skip-permissions")
+
+    return " ".join(args)
+
+
+def shell_join(*parts: str) -> str:
+    return " && ".join(part for part in parts if part)
+
+
+# ---------------------------------------------------------------------------
+# sandbox command helpers
+# ---------------------------------------------------------------------------
+
+def stream_writer(stream) -> Callable[[object], None]:
+    def write(chunk: object) -> None:
+        text = getattr(chunk, "line", chunk)
+        stream.write(str(text))
+        stream.flush()
+    return write
+
+
+def _tool_brief(arguments: dict) -> str:
+    for key in ("command", "file_path", "path", "pattern", "query", "url"):
+        value = arguments.get(key)
+        if value:
+            return str(value).replace("\n", " ")[:120]
+    return ""
+
+
+def _render_json_result(obj: dict) -> None:
+    result_text = obj.get("result", "")
+    if result_text and isinstance(result_text, str):
+        print(result_text.strip())
+
+    if obj.get("is_error"):
+        print(f"\n[error] {obj.get('result', 'unknown error')}")
+
+    usage = obj.get("usage", {})
+    if usage:
+        cost = obj.get("total_cost_usd", 0)
+        tokens_in = usage.get("input_tokens", 0)
+        tokens_out = usage.get("output_tokens", 0)
+        print(f"\n--- cost: ${cost:.4f} | tokens: {tokens_in} in / {tokens_out} out ---")
+
+
+def _render_stream_json_line(line: str) -> None:
+    line = line.rstrip("\r\n")
+    if not line.strip():
+        return
+
+    try:
+        event = json.loads(line)
+    except (ValueError, TypeError):
+        print(line)
+        return
+
+    if not isinstance(event, dict):
+        return
+
+    etype = event.get("type", "")
+
+    if etype == "assistant":
+        message = event.get("message", {})
+        if isinstance(message, dict):
+            content = message.get("content", "")
+            if isinstance(content, str) and content.strip():
+                print(content.strip())
+            elif isinstance(content, list):
+                for block in content:
+                    if not isinstance(block, dict):
+                        continue
+                    btype = block.get("type", "")
+                    if btype == "text":
+                        text = str(block.get("text", "")).strip()
+                        if text:
+                            print(text)
+                    elif btype == "tool_use":
+                        name = block.get("name", "tool")
+                        inp = block.get("input", {})
+                        brief = _tool_brief(inp) if isinstance(inp, dict) else ""
+                        print(f"  -> [tool] {name}{': ' + brief if brief else ''}")
+
+    elif etype == "user":
+        message = event.get("message", {})
+        if isinstance(message, dict):
+            content = message.get("content", "")
+            if isinstance(content, list):
+                for block in content:
+                    if isinstance(block, dict) and block.get("type") == "tool_result":
+                        is_error = block.get("is_error", False)
+                        prefix = "  X" if is_error else "  OK"
+                        tool_id = block.get("tool_use_id", "")[:20]
+                        print(f"{prefix} [tool_result] {tool_id}")
+
+    elif etype == "result":
+        _render_json_result(event)
+
+    elif etype == "system":
+        subtype = event.get("subtype", "")
+        if subtype == "init":
+            model = event.get("model", "?")
+            version = event.get("claude_code_version", "?")
+            print(f"[init] model={model}, claude_code={version}")
+
+
+def json_render_writer() -> Callable[[object], None]:
+    buffer: dict[str, str] = {"text": ""}
+
+    def write(chunk: object) -> None:
+        text = getattr(chunk, "line", chunk)
+        buffer["text"] += text if isinstance(text, str) else str(text)
+        while "\n" in buffer["text"]:
+            line, buffer["text"] = buffer["text"].split("\n", 1)
+            _render_stream_json_line(line)
+
+    return write
+
+
+def run_command(
+    sandbox: Any,
+    command: str,
+    *,
+    cwd: str | None = None,
+    envs: dict[str, str] | None = None,
+    timeout: int | float | None = None,
+    stream: bool = False,
+    user: str = "root",
+):
+    kwargs = {"cwd": cwd, "timeout": timeout, "user": user}
+    kwargs = {key: value for key, value in kwargs.items() if value is not None}
+    if envs:
+        kwargs["envs"] = envs
+    if stream:
+        raw = os.environ.get("CC_STREAM_RAW", "").strip().lower() in ("1", "true", "yes")
+        kwargs["on_stdout"] = stream_writer(sys.stdout) if raw else json_render_writer()
+        kwargs["on_stderr"] = stream_writer(sys.stderr)
+
+    try:
+        return sandbox.commands.run(command, **kwargs)
+    except TypeError as exc:
+        if "envs" not in kwargs or "envs" not in str(exc):
+            raise
+        kwargs["env"] = kwargs.pop("envs")
+        return sandbox.commands.run(command, **kwargs)
+    except Exception as exc:
+        # e2b SDK raises CommandExitException (a CommandResult subclass) when
+        # the sandbox command exits non-zero.  Claude Code writes errors to
+        # stdout as JSON, so the exception's stdout field carries the
+        # diagnostic.  Return the exception object itself — it has .stdout,
+        # .stderr, .exit_code, and .error.
+        cls = type(exc).__name__
+        if cls == "CommandExitException" or "CommandExit" in cls:
+            return exc
+        raise
+
+
+def ensure_success(result, action: str) -> None:
+    exit_code = getattr(result, "exit_code", None)
+    if exit_code not in (None, 0):
+        stdout = getattr(result, "stdout", "")
+        stderr = getattr(result, "stderr", "")
+        raise SystemExit(
+            f"Failed to {action} (exit {exit_code}).\nSTDOUT:\n{stdout}\nSTDERR:\n{stderr}"
+        )
+
+
+def sandbox_identifier(sandbox: Any) -> str:
+    return getattr(sandbox, "sandbox_id", getattr(sandbox, "id", "unknown"))

--- a/examples/claude-code-integration/common.py
+++ b/examples/claude-code-integration/common.py
@@ -111,7 +111,9 @@ def build_cc_env(include_secrets: bool = True) -> dict[str, str]:
 def cc_llm_host() -> str:
     explicit = os.environ.get("CC_LLM_HOST")
     if explicit:
-        return _host_from_url(explicit)
+        # CC_LLM_HOST is documented as a hostname (e.g. "api.anthropic.com"),
+        # not a URL — return it directly.
+        return explicit.strip()
     base_url = os.environ.get("ANTHROPIC_BASE_URL")
     if base_url:
         host = _host_from_url(base_url)
@@ -150,11 +152,11 @@ def cc_command(
         args.append("--verbose")
 
     if model:
-        args.extend(["--model", model])
+        args.extend(["--model", shlex.quote(model)])
     if effort:
-        args.extend(["--effort", effort])
+        args.extend(["--effort", shlex.quote(effort)])
     if permission_mode:
-        args.extend(["--permission-mode", permission_mode])
+        args.extend(["--permission-mode", shlex.quote(permission_mode)])
     if dangerously_skip_permissions:
         args.append("--dangerously-skip-permissions")
 

--- a/examples/claude-code-integration/network_policy.py
+++ b/examples/claude-code-integration/network_policy.py
@@ -1,0 +1,239 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Restrict Claude Code's egress to the Anthropic API and inject the key on the wire.
+
+This is the recommended production ("credential vault") pattern:
+
+* Default-deny egress — the sandbox is created with ``allow_internet_access=False``
+  and an ``allow_out`` list containing only the Anthropic API host, so every other
+  destination is dropped before it can leave the sandbox.
+* The Anthropic auth headers are attached by CubeEgress via ``inject`` rules
+  (native ``cubesandbox`` SDK; see docs/guide/security-proxy.md), so the real
+  key rides the wire and never enters the sandbox VM. The agent inside only
+  sees a placeholder value.
+
+Usage:
+    python network_policy.py
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import shlex
+import sys
+
+from cubesandbox import Sandbox, Rule, Match, Action, Inject
+
+from common import (
+    build_cc_env,
+    cc_command,
+    cc_llm_host,
+    cc_model,
+    cc_workspace,
+    ensure_success,
+    int_env,
+    load_dotenv,
+    optional,
+    require_api_key,
+    required,
+    run_command,
+    sandbox_identifier,
+    shell_join,
+)
+
+PLACEHOLDER_KEY = "cube-egress-managed-placeholder"
+
+# Claude Code runs on Node.js, which uses its own bundled CA store and ignores
+# the system trust store. On the vault path CubeEgress terminates TLS to inject
+# the credential, so Node must trust the CubeEgress root CA or every API call
+# fails with a TLS error. Point NODE_EXTRA_CA_CERTS at a bundle that includes
+# the CubeEgress CA; the CubeSandbox base image installs it below.
+DEFAULT_NODE_CA_BUNDLE = "/etc/ssl/certs/ca-certificates.crt"
+
+DEFAULT_PROMPT = (
+    "Reply with a single short sentence confirming you can reach the Anthropic API, "
+    "then write that sentence to {workspace}/egress_check.md."
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Run Claude Code under default-deny egress with on-the-wire key injection."
+    )
+    parser.add_argument(
+        "--template",
+        default=os.environ.get("CUBE_TEMPLATE_ID"),
+        help="CubeSandbox template ID. Defaults to CUBE_TEMPLATE_ID.",
+    )
+    parser.add_argument(
+        "--host",
+        default=None,
+        help="Anthropic API host to allow. Defaults to CC_LLM_HOST or api.anthropic.com.",
+    )
+    parser.add_argument(
+        "--workspace",
+        default=cc_workspace(),
+        help="Working directory inside the sandbox. Defaults to CC_WORKSPACE.",
+    )
+    parser.add_argument(
+        "--prompt",
+        default=None,
+        help="Prompt passed to Claude Code. Defaults to a small egress check.",
+    )
+    parser.add_argument(
+        "--model",
+        default=cc_model(),
+        help="Model for Claude Code. Defaults to CC_MODEL or claude-sonnet-4-6.",
+    )
+    parser.add_argument(
+        "--effort",
+        default=optional("CC_EFFORT"),
+        help="Effort level: low, medium, high, xhigh, max.",
+    )
+    parser.add_argument(
+        "--sandbox-timeout",
+        type=int,
+        default=int_env("CC_SANDBOX_TIMEOUT", 1800),
+        help="Sandbox lifetime in seconds.",
+    )
+    parser.add_argument(
+        "--exec-timeout",
+        type=int,
+        default=int_env("CC_EXEC_TIMEOUT", 900),
+        help="Claude Code command timeout in seconds.",
+    )
+    parser.add_argument(
+        "--skip-agent",
+        action="store_true",
+        help="Only show the egress checks; skip the actual Claude Code run.",
+    )
+    parser.add_argument(
+        "--raw",
+        action="store_true",
+        help="Stream Claude Code's raw JSON instead of the concise transcript.",
+    )
+    args = parser.parse_args()
+    if args.prompt is None:
+        args.prompt = DEFAULT_PROMPT.format(workspace=args.workspace)
+    return args
+
+
+def build_rules(host: str, secret: str) -> list[Rule]:
+    return [
+        Rule(
+            name="allow_anthropic_api",
+            match=Match(scheme="https", sni=host, host=host),
+            action=Action(
+                allow=True,
+                audit="metadata",
+                inject=[
+                    Inject(header="x-api-key", secret=secret, format="${SECRET}"),
+                    Inject(header="anthropic-version", secret="2023-06-01", format="${SECRET}"),
+                ],
+            ),
+        )
+    ]
+
+
+def create_sandbox(template_id: str, rules: list[Rule], timeout: int) -> Sandbox:
+    return Sandbox.create(
+        template=template_id,
+        allow_internet_access=False,
+        network={"rules": rules},
+        timeout=timeout,
+    )
+
+
+def show_key_not_in_vm(sandbox: Sandbox) -> None:
+    command = "printenv ANTHROPIC_API_KEY || echo '<unset>'"
+    result = run_command(sandbox, command, timeout=30)
+    ensure_success(result, "read API key inside sandbox")
+    value = getattr(result, "stdout", "").strip()
+    print(f"In-VM ANTHROPIC_API_KEY: {value!r} (real secret stays in CubeEgress)")
+
+
+def show_non_llm_blocked(sandbox: Sandbox) -> None:
+    command = (
+        "curl -s -o /dev/null -w '%{http_code}' --max-time 8 https://example.com "
+        "|| echo blocked"
+    )
+    result = run_command(sandbox, command, timeout=30)
+    status = getattr(result, "stdout", "").strip()
+    print(f"Non-LLM host (example.com) response: {status or 'blocked'} "
+          "(expected 403/blocked under default-deny)")
+
+
+def main() -> int:
+    load_dotenv()
+    args = parse_args()
+    if args.raw:
+        os.environ["CC_STREAM_RAW"] = "1"
+
+    template_id = args.template or required("CUBE_TEMPLATE_ID")
+    required("E2B_API_URL")
+    required("E2B_API_KEY")
+
+    secret = require_api_key()
+    host = args.host or cc_llm_host()
+    if not host:
+        raise SystemExit(
+            "Could not resolve the Anthropic API host. "
+            "Set CC_LLM_HOST in your .env or pass --host."
+        )
+
+    rules = build_rules(host, secret)
+
+    sandbox_env = build_cc_env(include_secrets=False)
+    sandbox_env["ANTHROPIC_API_KEY"] = PLACEHOLDER_KEY
+    # Let Node-based Claude Code trust the CubeEgress interception CA —
+    # without this the vault path fails with TLS errors.
+    sandbox_env["NODE_EXTRA_CA_CERTS"] = os.environ.get(
+        "CC_NODE_EXTRA_CA_CERTS", DEFAULT_NODE_CA_BUNDLE
+    )
+
+    print(f"Allowed Anthropic API host (default-deny for everything else): {host}")
+    print(f"Creating sandbox from template: {template_id}")
+
+    sandbox = create_sandbox(template_id, rules, args.sandbox_timeout)
+    sandbox_id = sandbox_identifier(sandbox)
+    result = None
+    try:
+        print(f"Sandbox ready: {sandbox_id}\n")
+        show_key_not_in_vm(sandbox)
+        show_non_llm_blocked(sandbox)
+
+        if args.skip_agent:
+            print("\n--skip-agent set: not invoking Claude Code.")
+            return 0
+
+        print("\nRunning Claude Code through the injected egress path...\n")
+        command = shell_join(
+            f"cd {shlex.quote(args.workspace)}",
+            cc_command(
+                args.prompt,
+                model=args.model,
+                effort=args.effort,
+                dangerously_skip_permissions=True,
+            ),
+        )
+        result = run_command(
+            sandbox, command, cwd=args.workspace, envs=sandbox_env,
+            timeout=args.exec_timeout, stream=True, user="user",
+        )
+        exit_code = getattr(result, "exit_code", None)
+        print(f"\nClaude Code exit code: {exit_code}")
+        return 0 if exit_code is None else int(exit_code)
+    finally:
+        try:
+            sandbox.kill()
+            print(f"\nSandbox {sandbox_id} killed.")
+        except Exception as exc:
+            print(f"Warning: failed to kill sandbox {sandbox_id}: {exc}",
+                  file=sys.stderr)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/examples/claude-code-integration/network_policy.py
+++ b/examples/claude-code-integration/network_policy.py
@@ -188,6 +188,10 @@ def main() -> int:
 
     sandbox_env = build_cc_env(include_secrets=False)
     sandbox_env["ANTHROPIC_API_KEY"] = PLACEHOLDER_KEY
+    # The vault path routes all traffic through CubeEgress; proxy variables
+    # inside the VM would confuse Claude Code's request routing.
+    for proxy_var in ("HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY", "http_proxy", "https_proxy", "no_proxy"):
+        sandbox_env.pop(proxy_var, None)
     # Let Node-based Claude Code trust the CubeEgress interception CA —
     # without this the vault path fails with TLS errors.
     sandbox_env["NODE_EXTRA_CA_CERTS"] = os.environ.get(

--- a/examples/claude-code-integration/network_policy.py
+++ b/examples/claude-code-integration/network_policy.py
@@ -147,9 +147,9 @@ def create_sandbox(template_id: str, rules: list[Rule], timeout: int) -> Sandbox
     )
 
 
-def show_key_not_in_vm(sandbox: Sandbox) -> None:
+def show_key_not_in_vm(sandbox: Sandbox, sandbox_env: dict[str, str]) -> None:
     command = "printenv ANTHROPIC_API_KEY || echo '<unset>'"
-    result = run_command(sandbox, command, timeout=30)
+    result = run_command(sandbox, command, envs=sandbox_env, timeout=30)
     ensure_success(result, "read API key inside sandbox")
     value = getattr(result, "stdout", "").strip()
     print(f"In-VM ANTHROPIC_API_KEY: {value!r} (real secret stays in CubeEgress)")
@@ -206,7 +206,7 @@ def main() -> int:
     result = None
     try:
         print(f"Sandbox ready: {sandbox_id}\n")
-        show_key_not_in_vm(sandbox)
+        show_key_not_in_vm(sandbox, sandbox_env)
         show_non_llm_blocked(sandbox)
 
         if args.skip_agent:

--- a/examples/claude-code-integration/requirements.txt
+++ b/examples/claude-code-integration/requirements.txt
@@ -1,0 +1,3 @@
+e2b>=2.4.1
+cubesandbox>=0.3.0
+python-dotenv>=1.0.0

--- a/examples/claude-code-integration/requirements.txt
+++ b/examples/claude-code-integration/requirements.txt
@@ -1,3 +1,2 @@
 e2b>=2.4.1
-cubesandbox>=0.3.0
-python-dotenv>=1.0.0
+cubesandbox>=0.4.0

--- a/examples/claude-code-integration/resume_claude_code.py
+++ b/examples/claude-code-integration/resume_claude_code.py
@@ -1,0 +1,243 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Demonstrate Claude Code session persistence across a CubeSandbox pause/resume.
+
+Turn 1 asks Claude Code to write ``/workspace/plan.md``, then the sandbox is
+paused. Turn 2 reconnects to the same sandbox, verifies both ``/workspace`` and
+Claude Code's state directory survived the snapshot, and asks Claude Code to
+continue the work.
+
+Lifecycle note: this script deliberately avoids ``with Sandbox.create(...)``.
+A context manager kills the sandbox on ``__exit__``, which would defeat the
+pause. The lifecycle is managed manually with try/finally so the sandbox stays
+alive between turns and is only killed at the very end.
+
+Usage:
+    python resume_claude_code.py
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import shlex
+import sys
+
+from e2b import Sandbox
+
+from common import (
+    build_cc_env,
+    cc_command,
+    cc_model,
+    cc_workspace,
+    ensure_success,
+    int_env,
+    load_dotenv,
+    optional,
+    require_api_key,
+    required,
+    run_command,
+    sandbox_identifier,
+    shell_join,
+)
+
+DEFAULT_CC_STATE_DIR = "/home/user/.claude"
+
+TURN_1_PROMPT = (
+    "Create {workspace}/plan.md containing a numbered 3-step plan for building a "
+    "small Python CLI that prints the current time. Only write the plan file."
+)
+TURN_2_PROMPT = (
+    "Read {workspace}/plan.md and implement step 1 by creating "
+    "{workspace}/progress.md that records which step you completed and why. "
+    "Do not delete plan.md."
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Demonstrate Claude Code session persistence across pause/resume."
+    )
+    parser.add_argument(
+        "--template",
+        default=os.environ.get("CUBE_TEMPLATE_ID"),
+        help="CubeSandbox template ID. Defaults to CUBE_TEMPLATE_ID.",
+    )
+    parser.add_argument(
+        "--workspace",
+        default=cc_workspace(),
+        help="Working directory inside the sandbox. Defaults to CC_WORKSPACE.",
+    )
+    parser.add_argument(
+        "--model",
+        default=cc_model(),
+        help="Model for Claude Code. Defaults to CC_MODEL or claude-sonnet-4-6.",
+    )
+    parser.add_argument(
+        "--effort",
+        default=optional("CC_EFFORT"),
+        help="Effort level: low, medium, high, xhigh, max.",
+    )
+    parser.add_argument(
+        "--cc-state-dir",
+        default=os.environ.get("CLAUDE_CODE_STATE_DIR", DEFAULT_CC_STATE_DIR),
+        help="Claude Code state directory checked for survival after resume.",
+    )
+    parser.add_argument(
+        "--sandbox-timeout",
+        type=int,
+        default=int_env("CC_SANDBOX_TIMEOUT", 1800),
+        help="Sandbox lifetime in seconds. Defaults to CC_SANDBOX_TIMEOUT or 1800.",
+    )
+    parser.add_argument(
+        "--exec-timeout",
+        type=int,
+        default=int_env("CC_EXEC_TIMEOUT", 900),
+        help="Claude Code command timeout in seconds.",
+    )
+    parser.add_argument(
+        "--raw",
+        action="store_true",
+        help="Stream Claude Code's raw JSON instead of the concise transcript.",
+    )
+    return parser.parse_args()
+
+
+def run_turn(
+    sandbox: Sandbox,
+    workspace: str,
+    prompt: str,
+    model: str,
+    effort: str | None,
+    exec_timeout: int,
+    envs: dict[str, str],
+):
+    command = shell_join(
+        f"cd {shlex.quote(workspace)}",
+        cc_command(
+            prompt,
+            model=model,
+            effort=effort,
+            dangerously_skip_permissions=True,
+        ),
+    )
+    return run_command(
+        sandbox,
+        command,
+        cwd=workspace,
+        envs=envs,
+        timeout=exec_timeout,
+        stream=True,
+        user="user",
+    )
+
+
+def assert_state_survived(sandbox: Sandbox, workspace: str, state_dir: str) -> None:
+    quoted_ws = shlex.quote(workspace)
+    quoted_state = shlex.quote(state_dir)
+    command = shell_join(
+        f"test -f {quoted_ws}/plan.md",
+        f"test -d {quoted_state}",
+        "printf '\\n--- plan.md (survived pause/resume) ---\\n'",
+        f"cat {quoted_ws}/plan.md",
+    )
+    result = run_command(sandbox, command, timeout=60)
+    ensure_success(result, "verify /workspace and Claude Code state survived")
+    if getattr(result, "stdout", ""):
+        print(result.stdout)
+
+
+def show_final_workspace(sandbox: Sandbox, workspace: str) -> None:
+    quoted = shlex.quote(workspace)
+    command = shell_join(
+        f"ls -la {quoted}",
+        f"test ! -f {quoted}/progress.md || "
+        f"(printf '\\n--- progress.md ---\\n' && cat {quoted}/progress.md)",
+    )
+    result = run_command(sandbox, command, timeout=60)
+    ensure_success(result, "inspect final workspace")
+    if getattr(result, "stdout", ""):
+        print(result.stdout)
+
+
+def main() -> int:
+    load_dotenv()
+    args = parse_args()
+    if args.raw:
+        os.environ["CC_STREAM_RAW"] = "1"
+
+    template_id = args.template or required("CUBE_TEMPLATE_ID")
+    required("E2B_API_URL")
+    required("E2B_API_KEY")
+    require_api_key()
+
+    cc_env = build_cc_env()
+    turn_1 = TURN_1_PROMPT.format(workspace=args.workspace)
+    turn_2 = TURN_2_PROMPT.format(workspace=args.workspace)
+
+    print(f"Creating sandbox from template: {template_id}")
+    # SECURITY: like run_claude_code.py this demo keeps egress open. The
+    # pause() snapshot also captures the in-VM env. For shared clusters prefer
+    # the default-deny + vault pattern in network_policy.py.
+    sandbox = Sandbox.create(template=template_id, timeout=args.sandbox_timeout)
+    sandbox_id = sandbox_identifier(sandbox)
+
+    try:
+        print(f"Sandbox ready: {sandbox_id}")
+
+        version_result = run_command(sandbox, "claude --version", timeout=60)
+        ensure_success(version_result, "check Claude Code version")
+        print(f"Claude Code version: {getattr(version_result, 'stdout', '').strip()}")
+
+        print("\n=== Turn 1: create plan.md ===\n")
+        result_1 = run_turn(
+            sandbox, args.workspace, turn_1, args.model,
+            args.effort, args.exec_timeout, cc_env,
+        )
+        ensure_success(result_1, "run Claude Code turn 1")
+
+        print(f"\nPausing sandbox {sandbox_id} (snapshotting VM + rootfs)...")
+        paused_id = sandbox.pause()
+        if isinstance(paused_id, str) and paused_id:
+            sandbox_id = paused_id
+            print(f"Paused. Resume handle: {sandbox_id}")
+            print(f"\nReconnecting to {sandbox_id}...")
+            sandbox = Sandbox.connect(sandbox_id=sandbox_id)
+            print("Reconnected after resume.")
+        else:
+            # Local CubeSandbox (and some self-hosted deployments) return a
+            # boolean from pause() instead of a reconnect handle.  The sandbox
+            # stays alive — skip the reconnect step and continue in-process.
+            print(
+                "Pause returned a boolean (local / self-hosted CubeSandbox) — "
+                "skipping reconnect, sandbox is still alive."
+            )
+
+        print("\n=== Verifying persistence after resume ===\n")
+        assert_state_survived(sandbox, args.workspace, args.cc_state_dir)
+
+        print("\n=== Turn 2: continue the work ===\n")
+        result_2 = run_turn(
+            sandbox, args.workspace, turn_2, args.model,
+            args.effort, args.exec_timeout, cc_env,
+        )
+        ensure_success(result_2, "run Claude Code turn 2")
+
+        show_final_workspace(sandbox, args.workspace)
+
+        exit_code = getattr(result_2, "exit_code", 0)
+        return 0 if exit_code is None else int(exit_code)
+    finally:
+        if sandbox is not None:
+            try:
+                sandbox.kill()
+                print(f"\nSandbox {sandbox_id} killed.")
+            except Exception as exc:
+                print(f"Warning: failed to kill sandbox {sandbox_id}: {exc}",
+                      file=sys.stderr)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/examples/claude-code-integration/run_claude_code.py
+++ b/examples/claude-code-integration/run_claude_code.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Run a one-shot Claude Code task inside CubeSandbox.
+
+This is the simplest headless pattern: create a sandbox, run ``claude -p`` with a
+prompt, stream the JSON output, and collect results. The sandbox is ephemeral —
+when the script exits the sandbox is killed.
+
+Usage:
+    cp .env.example .env   # fill in E2B_API_URL, CUBE_TEMPLATE_ID, ANTHROPIC_API_KEY
+    pip install -r requirements.txt
+    python run_claude_code.py
+    python run_claude_code.py --prompt "Refactor the auth module."
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import shlex
+import sys
+
+from e2b import Sandbox
+
+from common import (
+    build_cc_env,
+    cc_command,
+    cc_model,
+    cc_workspace,
+    ensure_success,
+    int_env,
+    load_dotenv,
+    optional,
+    require_api_key,
+    required,
+    run_command,
+    sandbox_identifier,
+    shell_join,
+)
+
+DEFAULT_PROMPT_TEMPLATE = (
+    "Inspect the project in {workspace}, run python3 app.py if it exists, "
+    "and write a concise summary of what you find to {workspace}/result.md."
+)
+
+
+def default_prompt(workspace: str) -> str:
+    return DEFAULT_PROMPT_TEMPLATE.format(workspace=workspace)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Run a one-shot Claude Code task inside CubeSandbox."
+    )
+    parser.add_argument(
+        "--template",
+        default=os.environ.get("CUBE_TEMPLATE_ID"),
+        help="CubeSandbox template ID. Defaults to CUBE_TEMPLATE_ID.",
+    )
+    parser.add_argument(
+        "--prompt",
+        default=None,
+        help="Prompt passed to Claude Code. Defaults to a small workspace smoke task.",
+    )
+    parser.add_argument(
+        "--workspace",
+        default=cc_workspace(),
+        help="Working directory inside the sandbox. Defaults to CC_WORKSPACE.",
+    )
+    parser.add_argument(
+        "--model",
+        default=cc_model(),
+        help="Model for Claude Code. Defaults to CC_MODEL or claude-sonnet-4-6.",
+    )
+    parser.add_argument(
+        "--effort",
+        default=optional("CC_EFFORT"),
+        help="Effort level: low, medium, high, xhigh, max.",
+    )
+    parser.add_argument(
+        "--permission-mode",
+        default=optional("CC_PERMISSION_MODE"),
+        help="Permission mode: plan, acceptEdits, bypassPermissions.",
+    )
+    parser.add_argument(
+        "--sandbox-timeout",
+        type=int,
+        default=int_env("CC_SANDBOX_TIMEOUT", 1800),
+        help="Sandbox lifetime in seconds. Defaults to CC_SANDBOX_TIMEOUT or 1800.",
+    )
+    parser.add_argument(
+        "--exec-timeout",
+        type=int,
+        default=int_env("CC_EXEC_TIMEOUT", 900),
+        help="Claude Code command timeout. Defaults to CC_EXEC_TIMEOUT or 900.",
+    )
+    parser.add_argument(
+        "--no-seed",
+        action="store_true",
+        help="Skip writing the demo files into the sandbox workspace.",
+    )
+    parser.add_argument(
+        "--raw",
+        action="store_true",
+        help="Stream Claude Code's raw JSON instead of the concise transcript.",
+    )
+    args = parser.parse_args()
+    if args.prompt is None:
+        args.prompt = default_prompt(args.workspace)
+    return args
+
+
+def seed_project(sandbox: Sandbox, workspace: str, timeout: int) -> None:
+    quoted = shlex.quote(workspace)
+    command = f"""mkdir -p {quoted}
+cat > {quoted}/README.md <<'EOF'
+# CubeSandbox Claude Code Smoke Project
+
+This tiny project exists so Claude Code has a deterministic task to run.
+EOF
+cat > {quoted}/app.py <<'EOF'
+def main() -> None:
+    print("hello from CubeSandbox + Claude Code")
+
+
+if __name__ == "__main__":
+    main()
+EOF
+"""
+    result = run_command(sandbox, command, timeout=timeout)
+    ensure_success(result, "seed workspace")
+
+
+def show_workspace_result(sandbox: Sandbox, workspace: str, timeout: int) -> None:
+    quoted = shlex.quote(workspace)
+    command = shell_join(
+        f"ls -la {quoted}",
+        f"test ! -f {quoted}/result.md || "
+        f"(printf '\\n--- result.md ---\\n' && cat {quoted}/result.md)",
+    )
+    result = run_command(sandbox, command, timeout=timeout)
+    ensure_success(result, "inspect workspace")
+    if getattr(result, "stdout", ""):
+        print(result.stdout)
+
+
+def main() -> int:
+    load_dotenv()
+    args = parse_args()
+    if args.raw:
+        os.environ["CC_STREAM_RAW"] = "1"
+
+    template_id = args.template or required("CUBE_TEMPLATE_ID")
+    required("E2B_API_URL")
+    required("E2B_API_KEY")
+    require_api_key()
+
+    cc_env = build_cc_env()
+    # Headless sandbox default: when no explicit permission_mode is set, use
+    # --dangerously-skip-permissions + non-root user so Claude Code can write
+    # files without interactive approval.
+    headless = args.permission_mode is None
+    command = shell_join(
+        f"cd {shlex.quote(args.workspace)}",
+        cc_command(
+            args.prompt,
+            model=args.model,
+            effort=args.effort,
+            permission_mode=args.permission_mode,
+            dangerously_skip_permissions=headless,
+        ),
+    )
+
+    print(f"Creating sandbox from template: {template_id}")
+    result = None
+    # SECURITY: this direct-key demo keeps egress open (allow_internet_access
+    # defaults to True) for simplicity, and injects the API key per command via
+    # envs=. For shared/production use prefer network_policy.py, which pairs
+    # default-deny egress with the CubeEgress credential vault.
+    with Sandbox.create(template=template_id, timeout=args.sandbox_timeout) as sandbox:
+        sandbox_id = sandbox_identifier(sandbox)
+        print(f"Sandbox ready: {sandbox_id}")
+
+        version_result = run_command(sandbox, "claude --version", timeout=60)
+        ensure_success(version_result, "check Claude Code version")
+        print(f"Claude Code version: {getattr(version_result, 'stdout', '').strip()}")
+
+        if not args.no_seed:
+            seed_project(sandbox, args.workspace, timeout=60)
+            print(f"Seeded demo project in {args.workspace}")
+
+        print("\nRunning Claude Code task...\n")
+        result = run_command(
+            sandbox,
+            command,
+            cwd=args.workspace,
+            envs=cc_env,
+            timeout=args.exec_timeout,
+            stream=True,
+            user="user" if headless else "root",
+        )
+
+        exit_code = getattr(result, "exit_code", None)
+        print(f"\nClaude Code exit code: {exit_code}")
+        stderr = getattr(result, "stderr", "")
+        if stderr:
+            print("\nCaptured stderr:", file=sys.stderr)
+            print(stderr, file=sys.stderr)
+        show_workspace_result(sandbox, args.workspace, timeout=60)
+
+    return 0 if exit_code is None else int(exit_code)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/examples/claude-code-integration/test_common.py
+++ b/examples/claude-code-integration/test_common.py
@@ -107,7 +107,7 @@ def test_render_stream_init():
 
 
 if __name__ == "__main__":
-    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_")]
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
     failures = 0
     for fn in tests:
         try:

--- a/examples/claude-code-integration/test_common.py
+++ b/examples/claude-code-integration/test_common.py
@@ -1,0 +1,120 @@
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for common.py — no external dependencies required."""
+
+import io
+import os
+import sys
+
+# Add current dir to path for import
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from common import (
+    cc_command,
+    cc_llm_host,
+    shell_join,
+    _render_json_result,
+    _render_stream_json_line,
+)
+
+
+def _capture(fn, *args):
+    buf = io.StringIO()
+    old = sys.stdout
+    sys.stdout = buf
+    try:
+        fn(*args)
+    finally:
+        sys.stdout = old
+    return buf.getvalue()
+
+
+def test_cc_command_basic():
+    cmd = cc_command("hello")
+    assert "claude" in cmd
+    assert "-p" in cmd
+    assert "hello" in cmd
+    assert "--output-format json" in cmd
+
+
+def test_cc_command_stream_json():
+    cmd = cc_command("x", output_format="stream-json")
+    assert "--output-format stream-json" in cmd
+    assert "--verbose" in cmd
+
+
+def test_cc_command_effort():
+    assert "--effort high" in cc_command("x", effort="high")
+
+
+def test_cc_command_permission():
+    assert "--permission-mode auto" in cc_command("x", permission_mode="auto")
+
+
+def test_cc_command_dangerously_skip():
+    assert "--dangerously-skip-permissions" in cc_command("x", dangerously_skip_permissions=True)
+
+
+def test_cc_llm_host_default():
+    saved = {k: os.environ.pop(k, None) for k in ["CC_LLM_HOST", "ANTHROPIC_BASE_URL"]}
+    try:
+        assert cc_llm_host() == "api.anthropic.com"
+    finally:
+        for k, v in saved.items():
+            if v is not None:
+                os.environ[k] = v
+
+
+def test_shell_join():
+    assert shell_join("a", "b") == "a && b"
+    assert shell_join("a", "", "c") == "a && c"
+    assert shell_join() == ""
+
+
+def test_render_json_result():
+    out = _capture(_render_json_result, {
+        "type": "result", "result": "OK", "is_error": False,
+        "total_cost_usd": 0.01, "usage": {"input_tokens": 10, "output_tokens": 5},
+    })
+    assert "OK" in out
+    assert "cost:" in out
+
+
+def test_render_json_result_error():
+    out = _capture(_render_json_result, {
+        "type": "result", "result": "fail", "is_error": True,
+        "total_cost_usd": 0, "usage": {},
+    })
+    assert "error" in out.lower()
+
+
+def test_render_stream_assistant():
+    out = _capture(_render_stream_json_line, '{"type":"assistant","message":{"content":"hi"}}')
+    assert "hi" in out
+
+
+def test_render_stream_tool_use():
+    line = '{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Bash","input":{"command":"ls"}}]}}'
+    out = _capture(_render_stream_json_line, line)
+    assert "[tool]" in out
+    assert "Bash" in out
+
+
+def test_render_stream_init():
+    line = '{"type":"system","subtype":"init","model":"claude-sonnet-4-6","claude_code_version":"2.1.220"}'
+    out = _capture(_render_stream_json_line, line)
+    assert "claude-sonnet-4-6" in out
+
+
+if __name__ == "__main__":
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_")]
+    failures = 0
+    for fn in tests:
+        try:
+            fn()
+            print(f"  PASS  {fn.__name__}")
+        except Exception as e:
+            print(f"  FAIL  {fn.__name__}: {e}")
+            failures += 1
+    print(f"\n{len(tests) - failures}/{len(tests)} passed")
+    sys.exit(1 if failures else 0)


### PR DESCRIPTION
Add end-to-end integration guide, runnable examples, and documentation for running Claude Code inside CubeSandbox MicroVMs.

Examples:
- run_claude_code.py    — one-shot headless task execution
- resume_claude_code.py — two-turn session persistence via pause/resume
- network_policy.py     — credential vault with default-deny egress
- common.py             — SDK-agnostic helpers (e2b + cubesandbox)
- test_common.py        — 12/12 unit tests

Docs (EN + ZH):
- docs/guide/integrations/claude-code.md
- docs/zh/guide/integrations/claude-code.md

Verified end-to-end on CubeSandbox v0.6.0 with DeepSeek API backend.

Refs: #644

Assisted-by: Claude Code deepseek-v4-pro[1m]