### PR TITLE
feat: add CubeOps web terminal sessions

### DIFF
--- a/CubeOps/Dockerfile
+++ b/CubeOps/Dockerfile
@@ -17,6 +17,7 @@ WORKDIR /build/CubeOps
 COPY CubeOps/go.mod CubeOps/go.sum ./
 COPY CubeDB /build/CubeDB
 COPY cubelog /build/cubelog
+COPY sdk/go /build/sdk/go
 RUN go mod download
 
 COPY CubeOps/ .

--- a/CubeOps/Dockerfile.dockerignore
+++ b/CubeOps/Dockerfile.dockerignore
@@ -11,3 +11,6 @@
 !CubeDB/**
 !cubelog
 !cubelog/**
+!sdk
+!sdk/go
+!sdk/go/**

--- a/CubeOps/README.md
+++ b/CubeOps/README.md
@@ -132,6 +132,7 @@ individual fields without editing the YAML file.
 | `DATABASE_URL` | *(required)* | MySQL connection URL. If unset, built from `CUBE_SANDBOX_MYSQL_{HOST,PORT,USER,PASSWORD,DB}` env vars. |
 | `CUBE_MASTER_ADDR` | `http://127.0.0.1:8089` | CubeMaster base URL |
 | `CUBE_API_SANDBOX_DOMAIN` | `cube.app` | Sandbox domain (used by SDK handler for sandbox URL construction) |
+| `CUBE_OPS_SANDBOX_PROXY_URL` | `http://127.0.0.1:80` | Internal CubeProxy URL used by the web terminal to reach envd. |
 | `REDIS_URL` | *(optional)* | Redis for JWT blacklist |
 
 **Resolution order**: environment variables > YAML file > built-in defaults.
@@ -158,6 +159,22 @@ RBAC is reserved for future use — currently any valid JWT grants full access.
 
 ### Cluster
 - `GET /api/v1/cluster/overview` — Cluster capacity overview
+
+### Web terminal
+
+- `POST /api/v1/terminal/sandboxes/:id/sessions` — issue a short-lived, target-bound terminal grant (access JWT required)
+- `GET /api/v1/terminal/sandboxes/:id/ws` — WebSocket relay to the existing envd PTY data plane
+
+Terminal grants are valid for one minute and signed with CubeOps' shared,
+database-persisted JWT secret. CubeOps validates the running, envd-enabled
+sandbox both before issuing the grant and when the same-origin WebSocket
+connects, then opens `/bin/sh` in the primary container through CubeProxy and
+the existing envd PTY data plane. Each browser tab gets a separate grant, PTY,
+and shell. Sessions close after 30 minutes without terminal I/O or eight hours
+total; CubeOps sends WebSocket pings every 30 seconds. Audit events record
+grant, start, end, and failure metadata without recording terminal contents.
+No CubeAPI handler or new CubeMaster/Cubelet RPC is required.
+
 - `GET /api/v1/cluster/versions` — Component version matrix
 - `GET /api/v1/nodes` — Node list
 - `GET /api/v1/nodes/{nodeID}` — Node detail

--- a/CubeOps/config.example.yaml
+++ b/CubeOps/config.example.yaml
@@ -47,3 +47,7 @@ redis_url: ""
 
 # --- Sandbox domain exposed to SDK clients via /config ---
 sandbox_domain: "cube.app"
+
+# --- Web terminal (CubeOps -> CubeProxy -> envd PTY) ---
+# This is a data-plane route; CubeAPI and Cubelet RPCs are not involved.
+sandbox_proxy_url: "http://127.0.0.1:80"

--- a/CubeOps/go.mod
+++ b/CubeOps/go.mod
@@ -8,8 +8,10 @@ require (
 	github.com/golang-jwt/jwt/v5 v5.2.2
 	github.com/google/go-containerregistry v0.21.6
 	github.com/google/uuid v1.6.0
+	github.com/gorilla/websocket v1.5.3
 	github.com/ory/dockertest/v3 v3.12.0
 	github.com/tencentcloud/CubeSandbox/CubeDB v0.1.0
+	github.com/tencentcloud/CubeSandbox/sdk/go v0.0.0
 	github.com/tencentcloud/CubeSandbox/cubelog v0.1.1-0.20260113105508-a996703fa42f
 	golang.org/x/crypto v0.50.0
 	gorm.io/gorm v1.25.10
@@ -101,3 +103,5 @@ require (
 )
 
 replace github.com/tencentcloud/CubeSandbox/CubeDB => ../CubeDB
+
+replace github.com/tencentcloud/CubeSandbox/sdk/go => ../sdk/go

--- a/CubeOps/go.sum
+++ b/CubeOps/go.sum
@@ -84,6 +84,8 @@ github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 h1:El6M4kTTCOh6aBiKaU
 github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510/go.mod h1:pupxD2MaaD3pAXIBCelhxNneeOaAeabZDe5s4K6zSpQ=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
+github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsIM=
 github.com/jackc/pgpassfile v1.0.0/go.mod h1:CEx0iS5ambNFdcRtxPj5JhEz+xB6uRky5eyVu/W2HEg=
 github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 h1:iCEnooe7UlwOQYpKFhBabPMi4aNAfoODPEFNiAnClxo=

--- a/CubeOps/internal/auth/jwt.go
+++ b/CubeOps/internal/auth/jwt.go
@@ -19,11 +19,13 @@ import (
 // VerifyAccessToken and accepted, turning it into a long-lived access
 // token.
 const (
-	tokenTypeAccess  = "access"
-	tokenTypeRefresh = "refresh"
+	tokenTypeAccess   = "access"
+	tokenTypeRefresh  = "refresh"
+	tokenTypeTerminal = "terminal"
 
-	audAccess  = "cubeops:access"  // audience for access tokens
-	audRefresh = "cubeops:refresh" // audience for refresh tokens
+	audAccess   = "cubeops:access"  // audience for access tokens
+	audRefresh  = "cubeops:refresh" // audience for refresh tokens
+	audTerminal = "cubeops:terminal"
 )
 
 // AccessClaims is the JWT claims for short-lived access tokens.
@@ -41,6 +43,14 @@ type RefreshClaims struct {
 	Username string `json:"username"`
 	TokenID  string `json:"tid"`
 	Typ      string `json:"typ"` // token type, always "refresh"
+}
+
+// TerminalClaims authorizes a narrowly scoped, short-lived WebSocket session.
+// The grant is stateless so any CubeOps replica sharing JWTSecret can verify it.
+type TerminalClaims struct {
+	jwt.RegisteredClaims
+	SandboxID string `json:"sandboxID"`
+	Typ       string `json:"typ"`
 }
 
 // JWTManager handles JWT signing and verification.
@@ -107,6 +117,34 @@ func (m *JWTManager) GenerateRefreshToken(username string) (string, string, erro
 	return signed, tokenID, nil
 }
 
+// GenerateTerminalGrant creates a narrowly scoped, short-lived terminal grant.
+// It is transported in the WebSocket subprotocol header rather than a URL so
+// reverse-proxy access logs do not capture credentials.
+func (m *JWTManager) GenerateTerminalGrant(username, sandboxID string, ttl time.Duration) (string, *TerminalClaims, error) {
+	if ttl <= 0 {
+		return "", nil, errors.New("terminal grant TTL must be positive")
+	}
+	now := time.Now()
+	claims := &TerminalClaims{
+		RegisteredClaims: jwt.RegisteredClaims{
+			ID:        uuid.New().String(),
+			ExpiresAt: jwt.NewNumericDate(now.Add(ttl)),
+			IssuedAt:  jwt.NewNumericDate(now),
+			NotBefore: jwt.NewNumericDate(now.Add(-5 * time.Second)),
+			Subject:   username,
+			Audience:  jwt.ClaimStrings{audTerminal},
+		},
+		SandboxID: sandboxID,
+		Typ:       tokenTypeTerminal,
+	}
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	signed, err := token.SignedString(m.secret)
+	if err != nil {
+		return "", nil, err
+	}
+	return signed, claims, nil
+}
+
 // VerifyAccessToken parses and validates an access token. It rejects refresh
 // tokens by checking the "typ" claim and the audience, so a long-lived
 // refresh token cannot be used as an access token.
@@ -153,4 +191,29 @@ func (m *JWTManager) VerifyRefreshToken(tokenStr string) (*service.RefreshClaims
 		return nil, errors.New("not a refresh token")
 	}
 	return &service.RefreshClaims{Username: claims.Username, TokenID: claims.TokenID}, nil
+}
+
+// VerifyTerminalGrant validates a terminal-only JWT. Access and refresh
+// tokens are rejected by both audience and token type.
+func (m *JWTManager) VerifyTerminalGrant(tokenStr string) (*TerminalClaims, error) {
+	token, err := jwt.ParseWithClaims(tokenStr, &TerminalClaims{}, func(t *jwt.Token) (interface{}, error) {
+		if _, ok := t.Method.(*jwt.SigningMethodHMAC); !ok {
+			return nil, fmt.Errorf("unexpected signing method: %v", t.Header["alg"])
+		}
+		return m.secret, nil
+	}, jwt.WithValidMethods([]string{"HS256"}), jwt.WithAudience(audTerminal))
+	if err != nil {
+		return nil, err
+	}
+	claims, ok := token.Claims.(*TerminalClaims)
+	if !ok || !token.Valid {
+		return nil, errors.New("invalid terminal grant")
+	}
+	if claims.Typ != tokenTypeTerminal ||
+		claims.SandboxID == "" ||
+		claims.Subject == "" ||
+		claims.ID == "" {
+		return nil, errors.New("invalid terminal grant claims")
+	}
+	return claims, nil
 }

--- a/CubeOps/internal/auth/jwt_test.go
+++ b/CubeOps/internal/auth/jwt_test.go
@@ -119,3 +119,61 @@ func TestS1_DifferentSecretsRejected(t *testing.T) {
 		t.Fatal("VerifyAccessToken accepted a token signed by a different secret (S1)")
 	}
 }
+
+func TestTerminalGrantCanBeVerifiedByAnotherReplica(t *testing.T) {
+	const secret = "shared-secret-32-bytes-long-enough"
+	issuer := auth.NewJWTManager(secret, 15*time.Minute, 168*time.Hour)
+	verifier := auth.NewJWTManager(secret, 15*time.Minute, 168*time.Hour)
+
+	grant, issued, err := issuer.GenerateTerminalGrant("operator", "sandbox-1", time.Minute)
+	if err != nil {
+		t.Fatalf("GenerateTerminalGrant: %v", err)
+	}
+	verified, err := verifier.VerifyTerminalGrant(grant)
+	if err != nil {
+		t.Fatalf("VerifyTerminalGrant on another replica: %v", err)
+	}
+	if verified.ID != issued.ID || verified.SandboxID != "sandbox-1" || verified.Subject != "operator" {
+		t.Fatalf("unexpected claims: %#v", verified)
+	}
+}
+
+func TestTerminalGrantIsIsolatedFromAccessTokens(t *testing.T) {
+	jm := newTestJWTManager()
+	grant, _, err := jm.GenerateTerminalGrant("admin", "sandbox-1", time.Minute)
+	if err != nil {
+		t.Fatalf("GenerateTerminalGrant: %v", err)
+	}
+	if _, err := jm.VerifyAccessToken(grant); err == nil {
+		t.Fatal("VerifyAccessToken accepted a terminal grant")
+	}
+	access, err := jm.GenerateAccessToken("admin")
+	if err != nil {
+		t.Fatalf("GenerateAccessToken: %v", err)
+	}
+	if _, err := jm.VerifyTerminalGrant(access); err == nil {
+		t.Fatal("VerifyTerminalGrant accepted an access token")
+	}
+	refresh, _, err := jm.GenerateRefreshToken("admin")
+	if err != nil {
+		t.Fatalf("GenerateRefreshToken: %v", err)
+	}
+	if _, err := jm.VerifyTerminalGrant(refresh); err == nil {
+		t.Fatal("VerifyTerminalGrant accepted a refresh token")
+	}
+	if _, err := jm.VerifyRefreshToken(grant); err == nil {
+		t.Fatal("VerifyRefreshToken accepted a terminal grant")
+	}
+}
+
+func TestExpiredTerminalGrantIsRejected(t *testing.T) {
+	jm := newTestJWTManager()
+	grant, _, err := jm.GenerateTerminalGrant("admin", "sandbox-1", time.Nanosecond)
+	if err != nil {
+		t.Fatalf("GenerateTerminalGrant: %v", err)
+	}
+	time.Sleep(time.Millisecond)
+	if _, err := jm.VerifyTerminalGrant(grant); err == nil {
+		t.Fatal("VerifyTerminalGrant accepted an expired grant")
+	}
+}

--- a/CubeOps/internal/config/config.go
+++ b/CubeOps/internal/config/config.go
@@ -65,6 +65,10 @@ type Config struct {
 	// Sandbox domain exposed to SDK clients; matches SDK handler's
 	// CUBE_API_SANDBOX_DOMAIN env so the /config endpoint stays in sync.
 	SandboxDomain string `yaml:"sandbox_domain"`
+
+	// Terminal data plane. CubeOps connects to envd through CubeProxy and
+	// exposes only the browser-facing WebSocket endpoint.
+	SandboxProxyURL string `yaml:"sandbox_proxy_url"`
 }
 
 // Load reads configuration from YAML + environment variables (env wins).
@@ -112,6 +116,9 @@ func Load() (*Config, error) {
 	}
 	if cfg.SandboxDomain == "" {
 		cfg.SandboxDomain = "cube.app"
+	}
+	if cfg.SandboxProxyURL == "" {
+		cfg.SandboxProxyURL = "http://127.0.0.1:80"
 	}
 
 	// JWT_SECRET is optional — if not set, it will be auto-generated and
@@ -313,6 +320,9 @@ func overrideFromEnv(cfg *Config) {
 	}
 	if v := os.Getenv("CUBE_API_SANDBOX_DOMAIN"); v != "" {
 		cfg.SandboxDomain = v
+	}
+	if v := os.Getenv("CUBE_OPS_SANDBOX_PROXY_URL"); v != "" {
+		cfg.SandboxProxyURL = v
 	}
 	if v := os.Getenv("JWT_ACCESS_TTL"); v != "" {
 		if d, err := time.ParseDuration(v); err == nil {

--- a/CubeOps/internal/config/config_test.go
+++ b/CubeOps/internal/config/config_test.go
@@ -24,6 +24,7 @@ database_url: "mysql://root:pass@127.0.0.1:3306/testdb"
 jwt_secret: "yaml-secret"
 access_ttl: "30m"
 refresh_ttl: "336h"
+sandbox_proxy_url: "http://proxy.internal:8080"
 `)
 	if err := os.WriteFile(yamlPath, yamlContent, 0o644); err != nil {
 		t.Fatalf("write yaml: %v", err)
@@ -48,6 +49,9 @@ refresh_ttl: "336h"
 	}
 	if cfg.JWTSecret != "yaml-secret" {
 		t.Errorf("JWTSecret = %q, want yaml-secret", cfg.JWTSecret)
+	}
+	if cfg.SandboxProxyURL != "http://proxy.internal:8080" {
+		t.Errorf("SandboxProxyURL = %q, want http://proxy.internal:8080", cfg.SandboxProxyURL)
 	}
 }
 
@@ -89,6 +93,9 @@ func TestLoad_NoYAML_UsesEnvAndDefaults(t *testing.T) {
 	}
 	if cfg.Bind != "127.0.0.1:3010" {
 		t.Errorf("Bind = %q, want default 127.0.0.1:3010", cfg.Bind)
+	}
+	if cfg.SandboxProxyURL != "http://127.0.0.1:80" {
+		t.Errorf("SandboxProxyURL = %q, want http://127.0.0.1:80", cfg.SandboxProxyURL)
 	}
 }
 

--- a/CubeOps/internal/handler/terminal.go
+++ b/CubeOps/internal/handler/terminal.go
@@ -1,0 +1,732 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/gorilla/websocket"
+	cubesandbox "github.com/tencentcloud/CubeSandbox/sdk/go"
+
+	"github.com/tencentcloud/CubeSandbox/CubeOps/internal/auth"
+	"github.com/tencentcloud/CubeSandbox/CubeOps/internal/config"
+	"github.com/tencentcloud/CubeSandbox/CubeOps/internal/httputil"
+)
+
+const (
+	terminalProtocol      = "cube-terminal.v1"
+	terminalGrantPrefix   = "cube-terminal.grant."
+	terminalWriteTimeout  = 10 * time.Second
+	maxTerminalMessage    = 64 << 10
+	envdVersionAnnotation = "cube.master.components.envd.version"
+
+	terminalUnavailableClientMessage = "terminal is unavailable for this sandbox; use an envd-enabled template and verify /bin/sh"
+)
+
+type terminalRuntimeConfig struct {
+	grantTTL    time.Duration
+	idleTimeout time.Duration
+	maxDuration time.Duration
+	pingPeriod  time.Duration
+}
+
+func defaultTerminalRuntimeConfig() terminalRuntimeConfig {
+	return terminalRuntimeConfig{
+		grantTTL:    time.Minute,
+		idleTimeout: 30 * time.Minute,
+		maxDuration: 8 * time.Hour,
+		pingPeriod:  30 * time.Second,
+	}
+}
+
+type terminalControl struct {
+	Type string `json:"type"`
+	Rows int    `json:"rows,omitempty"`
+	Cols int    `json:"cols,omitempty"`
+}
+
+type terminalSessionResponse struct {
+	Grant        string `json:"grant"`
+	Protocol     string `json:"protocol"`
+	WebsocketURL string `json:"websocketURL"`
+}
+
+type terminalPTY interface {
+	PID() int
+	Output() <-chan []byte
+	Wait(func([]byte)) (int, error)
+	ErrorMessage() string
+	SendStdin(context.Context, []byte) error
+	Resize(context.Context, cubesandbox.PtySize) error
+	Kill(context.Context) (bool, error)
+	Disconnect() error
+}
+
+type terminalFactory interface {
+	Open(context.Context, string, cubesandbox.PtySize, time.Duration) (terminalPTY, error)
+	Close() error
+}
+
+type sdkTerminalFactory struct {
+	client *cubesandbox.Client
+}
+
+func newSDKTerminalFactory(cfg *config.Config) (*sdkTerminalFactory, error) {
+	proxyURL, err := url.Parse(cfg.SandboxProxyURL)
+	if err != nil || proxyURL.Hostname() == "" {
+		return nil, fmt.Errorf("invalid sandbox_proxy_url %q", cfg.SandboxProxyURL)
+	}
+	if proxyURL.Scheme != "http" && proxyURL.Scheme != "https" {
+		return nil, fmt.Errorf("sandbox_proxy_url must use http or https")
+	}
+	if proxyURL.User != nil || (proxyURL.Path != "" && proxyURL.Path != "/") ||
+		proxyURL.RawQuery != "" || proxyURL.Fragment != "" {
+		return nil, fmt.Errorf("sandbox_proxy_url must contain only scheme, host, and port")
+	}
+
+	port := 80
+	if proxyURL.Scheme == "https" {
+		port = 443
+	}
+	if proxyURL.Port() != "" {
+		port, err = strconv.Atoi(proxyURL.Port())
+		if err != nil || port < 1 || port > 65535 {
+			return nil, fmt.Errorf("invalid sandbox_proxy_url port")
+		}
+	}
+
+	return &sdkTerminalFactory{client: cubesandbox.NewClient(cubesandbox.Config{
+		APIURL:         "http://cubeops.invalid",
+		ProxyNodeIP:    proxyURL.Hostname(),
+		ProxyPortHTTP:  port,
+		ProxyScheme:    proxyURL.Scheme,
+		SandboxDomain:  cfg.SandboxDomain,
+		RequestTimeout: 10 * time.Second,
+	})}, nil
+}
+
+func (f *sdkTerminalFactory) Open(
+	ctx context.Context,
+	sandboxID string,
+	size cubesandbox.PtySize,
+	maxDuration time.Duration,
+) (terminalPTY, error) {
+	sandbox, err := f.client.Attach(sandboxID)
+	if err != nil {
+		return nil, err
+	}
+	return sandbox.Pty().Create(ctx, size, cubesandbox.PtyCreateOptions{
+		Command: "/bin/sh",
+		Timeout: maxDuration,
+	})
+}
+
+func (f *sdkTerminalFactory) Close() error {
+	return f.client.Close()
+}
+
+// TerminalHandler keeps browser terminal traffic in CubeOps and the existing
+// envd data plane. It does not add a CubeAPI or Cubelet RPC.
+type TerminalHandler struct {
+	cm interface {
+		GetSandbox(context.Context, string, string) (json.RawMessage, error)
+	}
+	jm         *auth.JWTManager
+	factory    terminalFactory
+	factoryErr error
+	runtime    terminalRuntimeConfig
+
+	lifecycleCtx    context.Context
+	lifecycleCancel context.CancelFunc
+	lifecycleMu     sync.Mutex
+	lifecycleWG     sync.WaitGroup
+	closing         bool
+}
+
+func NewTerminalHandler(cm CubeMasterClient, jm *auth.JWTManager, cfg *config.Config) *TerminalHandler {
+	factory, err := newSDKTerminalFactory(cfg)
+	lifecycleCtx, lifecycleCancel := context.WithCancel(context.Background())
+	return &TerminalHandler{
+		cm:              cm,
+		jm:              jm,
+		factory:         factory,
+		factoryErr:      err,
+		runtime:         defaultTerminalRuntimeConfig(),
+		lifecycleCtx:    lifecycleCtx,
+		lifecycleCancel: lifecycleCancel,
+	}
+}
+
+func (h *TerminalHandler) RegisterAuthed(r *gin.RouterGroup) {
+	r.POST("/terminal/sandboxes/:id/sessions", h.CreateSession)
+}
+
+func (h *TerminalHandler) RegisterPublic(r *gin.RouterGroup) {
+	r.GET("/terminal/sandboxes/:id/ws", h.Connect)
+}
+
+// Shutdown cancels hijacked WebSocket connections before releasing the shared
+// SDK client. net/http does not track hijacked connections during Shutdown.
+func (h *TerminalHandler) Shutdown(ctx context.Context) error {
+	h.lifecycleMu.Lock()
+	if !h.closing {
+		h.closing = true
+		h.lifecycleCancel()
+	}
+	h.lifecycleMu.Unlock()
+
+	done := make(chan struct{})
+	go func() {
+		h.lifecycleWG.Wait()
+		close(done)
+	}()
+
+	var waitErr error
+	select {
+	case <-done:
+	case <-ctx.Done():
+		waitErr = ctx.Err()
+	}
+	if h.factory == nil {
+		return waitErr
+	}
+	return errors.Join(waitErr, h.factory.Close())
+}
+
+func (h *TerminalHandler) CreateSession(c *gin.Context) {
+	if h.factoryErr != nil {
+		httputil.WriteError(c, http.StatusServiceUnavailable, "terminal data plane is not configured")
+		return
+	}
+	if h.isClosing() {
+		httputil.WriteError(c, http.StatusServiceUnavailable, "terminal service is shutting down")
+		return
+	}
+	operator := c.GetString("username")
+	if operator == "" {
+		httputil.WriteError(c, http.StatusUnauthorized, "authenticated operator is required")
+		return
+	}
+	sandboxID := strings.TrimSpace(c.Param("id"))
+	if sandboxID == "" {
+		httputil.WriteError(c, http.StatusBadRequest, "sandbox ID is required")
+		return
+	}
+
+	grant, claims, err := h.jm.GenerateTerminalGrant(operator, sandboxID, h.runtime.grantTTL)
+	if err != nil {
+		httputil.WriteError(c, http.StatusInternalServerError, "failed to create terminal grant")
+		return
+	}
+	containerID, err := h.validateTarget(c.Request.Context(), sandboxID)
+	if err != nil {
+		logTerminalAudit(
+			slog.LevelWarn,
+			"terminal.failed",
+			claims,
+			"",
+			c.ClientIP(),
+			"target_validation_failed",
+			0,
+			err,
+		)
+		writeTerminalTargetError(c, err)
+		return
+	}
+	logTerminalAudit(
+		slog.LevelInfo,
+		"terminal.grant",
+		claims,
+		containerID,
+		c.ClientIP(),
+		"",
+		0,
+		nil,
+	)
+	httputil.WriteJSON(c, http.StatusCreated, terminalSessionResponse{
+		Grant:        grant,
+		Protocol:     terminalProtocol,
+		WebsocketURL: "/opsapi/v1/terminal/sandboxes/" + url.PathEscape(sandboxID) + "/ws",
+	})
+}
+
+func (h *TerminalHandler) Connect(c *gin.Context) {
+	if h.factoryErr != nil {
+		httputil.WriteError(c, http.StatusServiceUnavailable, "terminal data plane is not configured")
+		return
+	}
+
+	protocols := c.GetHeader("Sec-WebSocket-Protocol")
+	if !terminalProtocolRequested(protocols) {
+		httputil.WriteError(c, http.StatusBadRequest, "terminal WebSocket protocol is required")
+		return
+	}
+	claims, err := h.jm.VerifyTerminalGrant(terminalGrantFromProtocols(protocols))
+	if err != nil || claims.SandboxID != strings.TrimSpace(c.Param("id")) {
+		httputil.WriteError(c, http.StatusUnauthorized, "invalid or expired terminal grant")
+		return
+	}
+	containerID, err := h.validateTarget(c.Request.Context(), claims.SandboxID)
+	if err != nil {
+		logTerminalAudit(
+			slog.LevelWarn,
+			"terminal.failed",
+			claims,
+			"",
+			c.ClientIP(),
+			"target_revalidation_failed",
+			0,
+			err,
+		)
+		writeTerminalTargetError(c, err)
+		return
+	}
+	if !h.beginSession() {
+		logTerminalAudit(
+			slog.LevelWarn,
+			"terminal.failed",
+			claims,
+			containerID,
+			c.ClientIP(),
+			"server_shutdown",
+			0,
+			errors.New("terminal service is shutting down"),
+		)
+		httputil.WriteError(c, http.StatusServiceUnavailable, "terminal service is shutting down")
+		return
+	}
+	defer h.lifecycleWG.Done()
+
+	upgrader := websocket.Upgrader{
+		ReadBufferSize:  4096,
+		WriteBufferSize: 4096,
+		Subprotocols:    []string{terminalProtocol},
+	}
+	conn, err := upgrader.Upgrade(c.Writer, c.Request, nil)
+	if err != nil {
+		logTerminalAudit(
+			slog.LevelWarn,
+			"terminal.failed",
+			claims,
+			containerID,
+			c.ClientIP(),
+			"websocket_upgrade_failed",
+			0,
+			err,
+		)
+		return
+	}
+	h.relay(conn, claims, containerID, c.ClientIP())
+}
+
+func (h *TerminalHandler) beginSession() bool {
+	h.lifecycleMu.Lock()
+	defer h.lifecycleMu.Unlock()
+	if h.closing {
+		return false
+	}
+	h.lifecycleWG.Add(1)
+	return true
+}
+
+func (h *TerminalHandler) isClosing() bool {
+	h.lifecycleMu.Lock()
+	defer h.lifecycleMu.Unlock()
+	return h.closing
+}
+
+func (h *TerminalHandler) validateTarget(ctx context.Context, sandboxID string) (string, error) {
+	raw, err := h.cm.GetSandbox(ctx, sandboxID, sdkInstanceType)
+	if err != nil {
+		return "", err
+	}
+	var env cmEnvelope
+	if err := json.Unmarshal(raw, &env); err != nil {
+		return "", fmt.Errorf("invalid CubeMaster sandbox response")
+	}
+	if env.Ret != nil && env.Ret.RetCode != 0 && env.Ret.RetCode != http.StatusOK {
+		if env.Ret.RetCode == 130404 || env.Ret.RetCode == http.StatusNotFound {
+			return "", errTerminalNotFound
+		}
+		return "", fmt.Errorf("CubeMaster rejected terminal target: %s", env.Ret.RetMsg)
+	}
+
+	var items []cmSandboxDetailItem
+	if err := json.Unmarshal(env.Data, &items); err != nil || len(items) == 0 {
+		return "", errTerminalNotFound
+	}
+	var item *cmSandboxDetailItem
+	for i := range items {
+		if items[i].SandboxID == sandboxID {
+			item = &items[i]
+			break
+		}
+	}
+	if item == nil && len(items) == 1 && items[0].SandboxID == "" {
+		item = &items[0]
+	}
+	if item == nil {
+		return "", errTerminalNotFound
+	}
+	if item.Status != 1 {
+		return "", errTerminalNotRunning
+	}
+	if strings.TrimSpace(item.Annotations[envdVersionAnnotation]) == "" {
+		return "", errTerminalEnvdUnavailable
+	}
+
+	for _, container := range item.Containers {
+		if container.Type == "sandbox" || container.ContainerID == sandboxID {
+			if container.Status != 1 || strings.TrimSpace(container.ContainerID) == "" {
+				return "", errTerminalNotRunning
+			}
+			return container.ContainerID, nil
+		}
+	}
+	if len(item.Containers) == 0 {
+		return "", errTerminalNotRunning
+	}
+	if item.Containers[0].Status != 1 || strings.TrimSpace(item.Containers[0].ContainerID) == "" {
+		return "", errTerminalNotRunning
+	}
+	return item.Containers[0].ContainerID, nil
+}
+
+var (
+	errTerminalNotFound        = errors.New("sandbox not found")
+	errTerminalNotRunning      = errors.New("sandbox must be running before opening a terminal")
+	errTerminalEnvdUnavailable = errors.New("terminal requires an envd-enabled template")
+)
+
+func writeTerminalTargetError(c *gin.Context, err error) {
+	switch {
+	case errors.Is(err, errTerminalNotFound):
+		httputil.WriteError(c, http.StatusNotFound, err.Error())
+	case errors.Is(err, errTerminalNotRunning), errors.Is(err, errTerminalEnvdUnavailable):
+		httputil.WriteError(c, http.StatusConflict, err.Error())
+	default:
+		writeCMError(c, err)
+	}
+}
+
+type terminalInput struct {
+	data          []byte
+	control       terminalControl
+	err           error
+	protocolError bool
+}
+
+func (h *TerminalHandler) relay(
+	conn *websocket.Conn,
+	claims *auth.TerminalClaims,
+	containerID string,
+	remoteAddr string,
+) {
+	started := time.Now()
+	reason := "disconnected"
+	defer func() {
+		_ = conn.Close()
+		logTerminalAudit(
+			slog.LevelInfo,
+			"terminal.ended",
+			claims,
+			containerID,
+			remoteAddr,
+			reason,
+			time.Since(started),
+			nil,
+		)
+	}()
+
+	ctx, cancel := context.WithTimeout(h.lifecycleCtx, h.runtime.maxDuration)
+	defer cancel()
+	pty, err := h.factory.Open(
+		ctx,
+		claims.SandboxID,
+		cubesandbox.PtySize{Rows: 24, Cols: 80},
+		h.runtime.maxDuration,
+	)
+	if err != nil {
+		reason = "pty_start_failed"
+		logTerminalAudit(
+			slog.LevelWarn,
+			"terminal.failed",
+			claims,
+			containerID,
+			remoteAddr,
+			reason,
+			time.Since(started),
+			err,
+		)
+		_ = writeTerminalJSON(conn, gin.H{"type": "error", "message": terminalUnavailableClientMessage})
+		_ = closeTerminalWebSocket(conn, websocket.CloseNormalClosure, "terminal unavailable")
+		return
+	}
+	defer cleanupTerminalPTY(pty, claims.ID)
+
+	logTerminalAudit(
+		slog.LevelInfo,
+		"terminal.started",
+		claims,
+		containerID,
+		remoteAddr,
+		"",
+		0,
+		nil,
+		"pid",
+		pty.PID(),
+	)
+	if err := writeTerminalJSON(conn, gin.H{"type": "status", "message": "connected"}); err != nil {
+		reason = "client_write_failed"
+		return
+	}
+
+	input := make(chan terminalInput, 16)
+	go readTerminalInput(ctx, conn, input)
+	idle := time.NewTimer(h.runtime.idleTimeout)
+	defer idle.Stop()
+	ping := time.NewTicker(h.runtime.pingPeriod)
+	defer ping.Stop()
+
+	for {
+		select {
+		case output, ok := <-pty.Output():
+			if !ok {
+				var finishErr error
+				reason, finishErr = h.finishTerminal(conn, pty)
+				if finishErr != nil {
+					logTerminalAudit(
+						slog.LevelWarn,
+						"terminal.failed",
+						claims,
+						containerID,
+						remoteAddr,
+						reason,
+						time.Since(started),
+						finishErr,
+					)
+				}
+				return
+			}
+			if err := writeTerminalMessage(conn, websocket.BinaryMessage, output); err != nil {
+				reason = "client_write_failed"
+				return
+			}
+			resetTimer(idle, h.runtime.idleTimeout)
+		case event := <-input:
+			if event.err != nil {
+				reason = "client_disconnected"
+				if event.protocolError {
+					reason = "protocol_error"
+					_ = closeTerminalWebSocket(conn, websocket.CloseProtocolError, "invalid terminal control frame")
+				}
+				return
+			}
+			if event.data != nil {
+				if err := pty.SendStdin(ctx, event.data); err != nil {
+					reason = "stdin_failed"
+					_ = writeTerminalJSON(conn, gin.H{"type": "error", "message": "failed to write terminal input"})
+					return
+				}
+				resetTimer(idle, h.runtime.idleTimeout)
+				continue
+			}
+			if event.control.Type != "resize" {
+				reason = "protocol_error"
+				_ = closeTerminalWebSocket(conn, websocket.CloseProtocolError, "unsupported terminal control frame")
+				return
+			}
+			if !validTerminalSize(event.control) {
+				reason = "protocol_error"
+				_ = closeTerminalWebSocket(conn, websocket.CloseProtocolError, "invalid terminal size")
+				return
+			}
+			if err := pty.Resize(ctx, cubesandbox.PtySize{Rows: event.control.Rows, Cols: event.control.Cols}); err != nil {
+				slog.Warn("terminal resize failed", "session_id", claims.ID, "error", err)
+			} else {
+				resetTimer(idle, h.runtime.idleTimeout)
+			}
+		case <-idle.C:
+			reason = "idle_timeout"
+			_ = writeTerminalJSON(conn, gin.H{"type": "error", "message": "terminal session closed after inactivity"})
+			_ = closeTerminalWebSocket(conn, websocket.CloseNormalClosure, "idle timeout")
+			return
+		case <-ping.C:
+			if err := writeTerminalControl(conn, websocket.PingMessage, nil); err != nil {
+				reason = "ping_failed"
+				return
+			}
+		case <-ctx.Done():
+			reason = "maximum_duration"
+			code := websocket.CloseNormalClosure
+			message := "terminal session reached its maximum duration"
+			if h.lifecycleCtx.Err() != nil {
+				reason = "server_shutdown"
+				code = websocket.CloseServiceRestart
+				message = "terminal service is shutting down"
+			}
+			_ = writeTerminalJSON(conn, gin.H{"type": "error", "message": message})
+			_ = closeTerminalWebSocket(conn, code, message)
+			return
+		}
+	}
+}
+
+func cleanupTerminalPTY(pty terminalPTY, sessionID string) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if _, err := pty.Kill(ctx); err != nil {
+		slog.Warn("terminal PTY cleanup failed", "session_id", sessionID, "error", err)
+	}
+	_ = pty.Disconnect()
+}
+
+func (h *TerminalHandler) finishTerminal(conn *websocket.Conn, pty terminalPTY) (string, error) {
+	exitCode, err := pty.Wait(nil)
+	if err != nil {
+		_ = writeTerminalJSON(conn, gin.H{"type": "error", "message": "terminal stream ended unexpectedly"})
+		_ = closeTerminalWebSocket(conn, websocket.CloseInternalServerErr, "terminal stream failed")
+		return "pty_stream_failed", err
+	}
+	_ = writeTerminalJSON(conn, gin.H{
+		"type":     "exit",
+		"exitCode": exitCode,
+		"message":  pty.ErrorMessage(),
+	})
+	_ = closeTerminalWebSocket(conn, websocket.CloseNormalClosure, "terminal exited")
+	return "process_exited", nil
+}
+
+func validTerminalSize(control terminalControl) bool {
+	return control.Rows > 0 && control.Rows <= 1000 && control.Cols > 0 && control.Cols <= 1000
+}
+
+func readTerminalInput(ctx context.Context, conn *websocket.Conn, events chan<- terminalInput) {
+	conn.SetReadLimit(maxTerminalMessage)
+	for {
+		messageType, payload, err := conn.ReadMessage()
+		if err != nil {
+			sendTerminalInput(ctx, events, terminalInput{err: err})
+			return
+		}
+		switch messageType {
+		case websocket.BinaryMessage:
+			if !sendTerminalInput(ctx, events, terminalInput{data: payload}) {
+				return
+			}
+		case websocket.TextMessage:
+			var control terminalControl
+			if err := json.Unmarshal(payload, &control); err != nil {
+				sendTerminalInput(ctx, events, terminalInput{err: err, protocolError: true})
+				return
+			}
+			if !sendTerminalInput(ctx, events, terminalInput{control: control}) {
+				return
+			}
+		}
+	}
+}
+
+func sendTerminalInput(ctx context.Context, events chan<- terminalInput, event terminalInput) bool {
+	select {
+	case events <- event:
+		return true
+	case <-ctx.Done():
+		return false
+	}
+}
+
+func terminalGrantFromProtocols(header string) string {
+	for _, value := range strings.Split(header, ",") {
+		value = strings.TrimSpace(value)
+		if strings.HasPrefix(value, terminalGrantPrefix) {
+			return strings.TrimPrefix(value, terminalGrantPrefix)
+		}
+	}
+	return ""
+}
+
+func terminalProtocolRequested(header string) bool {
+	for _, value := range strings.Split(header, ",") {
+		if strings.TrimSpace(value) == terminalProtocol {
+			return true
+		}
+	}
+	return false
+}
+
+func writeTerminalJSON(conn *websocket.Conn, value interface{}) error {
+	if err := conn.SetWriteDeadline(time.Now().Add(terminalWriteTimeout)); err != nil {
+		return err
+	}
+	return conn.WriteJSON(value)
+}
+
+func writeTerminalMessage(conn *websocket.Conn, messageType int, payload []byte) error {
+	if err := conn.SetWriteDeadline(time.Now().Add(terminalWriteTimeout)); err != nil {
+		return err
+	}
+	return conn.WriteMessage(messageType, payload)
+}
+
+func writeTerminalControl(conn *websocket.Conn, messageType int, payload []byte) error {
+	return conn.WriteControl(messageType, payload, time.Now().Add(terminalWriteTimeout))
+}
+
+func closeTerminalWebSocket(conn *websocket.Conn, code int, reason string) error {
+	return writeTerminalControl(conn, websocket.CloseMessage, websocket.FormatCloseMessage(code, reason))
+}
+
+func resetTimer(timer *time.Timer, duration time.Duration) {
+	if !timer.Stop() {
+		select {
+		case <-timer.C:
+		default:
+		}
+	}
+	timer.Reset(duration)
+}
+
+func logTerminalAudit(
+	level slog.Level,
+	event string,
+	claims *auth.TerminalClaims,
+	containerID string,
+	remoteAddr string,
+	closeReason string,
+	duration time.Duration,
+	err error,
+	extra ...any,
+) {
+	attrs := []any{
+		"event", event,
+		"session_id", claims.ID,
+		"operator", claims.Subject,
+		"sandbox_id", claims.SandboxID,
+		"container_id", containerID,
+		"remote_addr", remoteAddr,
+		"timestamp", time.Now().UTC().Format(time.RFC3339Nano),
+		"duration_ms", duration.Milliseconds(),
+		"close_reason", closeReason,
+	}
+	if err != nil {
+		attrs = append(attrs, "error", err.Error())
+	}
+	attrs = append(attrs, extra...)
+	slog.Log(context.Background(), level, "terminal audit", attrs...)
+}
+
+var _ terminalPTY = (*cubesandbox.PtyHandle)(nil)
+var _ terminalFactory = (*sdkTerminalFactory)(nil)

--- a/CubeOps/internal/handler/terminal_test.go
+++ b/CubeOps/internal/handler/terminal_test.go
@@ -1,0 +1,800 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package handler
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/gorilla/websocket"
+	cubesandbox "github.com/tencentcloud/CubeSandbox/sdk/go"
+
+	"github.com/tencentcloud/CubeSandbox/CubeOps/internal/auth"
+)
+
+type fakeTerminalPTY struct {
+	output   chan []byte
+	input    chan []byte
+	resize   chan cubesandbox.PtySize
+	killed   chan struct{}
+	waitErr  error
+	exitCode int
+	once     sync.Once
+}
+
+type synchronizedBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *synchronizedBuffer) Write(data []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(data)
+}
+
+func (b *synchronizedBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
+}
+
+func newFakeTerminalPTY() *fakeTerminalPTY {
+	return &fakeTerminalPTY{
+		output: make(chan []byte, 4),
+		input:  make(chan []byte, 4),
+		resize: make(chan cubesandbox.PtySize, 4),
+		killed: make(chan struct{}),
+	}
+}
+
+func (p *fakeTerminalPTY) PID() int              { return 42 }
+func (p *fakeTerminalPTY) Output() <-chan []byte { return p.output }
+func (p *fakeTerminalPTY) Wait(func([]byte)) (int, error) {
+	return p.exitCode, p.waitErr
+}
+func (p *fakeTerminalPTY) ErrorMessage() string { return "" }
+func (p *fakeTerminalPTY) Disconnect() error    { return nil }
+func (p *fakeTerminalPTY) SendStdin(_ context.Context, data []byte) error {
+	p.input <- bytes.Clone(data)
+	return nil
+}
+func (p *fakeTerminalPTY) Resize(_ context.Context, size cubesandbox.PtySize) error {
+	p.resize <- size
+	return nil
+}
+func (p *fakeTerminalPTY) Kill(context.Context) (bool, error) {
+	p.once.Do(func() { close(p.killed) })
+	return true, nil
+}
+
+type fakeTerminalFactory struct {
+	mu         sync.Mutex
+	ptys       []*fakeTerminalPTY
+	openErr    error
+	openCalls  int
+	closeCalls int
+	durations  []time.Duration
+}
+
+func (f *fakeTerminalFactory) Open(
+	_ context.Context,
+	_ string,
+	_ cubesandbox.PtySize,
+	maxDuration time.Duration,
+) (terminalPTY, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.openCalls++
+	f.durations = append(f.durations, maxDuration)
+	if f.openErr != nil {
+		return nil, f.openErr
+	}
+	pty := newFakeTerminalPTY()
+	f.ptys = append(f.ptys, pty)
+	return pty, nil
+}
+
+func (f *fakeTerminalFactory) Close() error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.closeCalls++
+	return nil
+}
+
+func (f *fakeTerminalFactory) pty(index int) *fakeTerminalPTY {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if index >= len(f.ptys) {
+		return nil
+	}
+	return f.ptys[index]
+}
+
+func terminalSandboxResponse(state int, envd bool) json.RawMessage {
+	annotation := `{}`
+	if envd {
+		annotation = `{"cube.master.components.envd.version":"0.2.0"}`
+	}
+	return json.RawMessage(`{
+		"ret":{"ret_code":0},
+		"data":[{
+			"sandbox_id":"sandbox-1",
+			"status":` + strconv.Itoa(state) + `,
+			"containers":[{"container_id":"sandbox-1","status":1,"type":"sandbox"}],
+			"annotations":` + annotation + `
+		}]
+	}`)
+}
+
+func newTerminalTestHandler(
+	t *testing.T,
+	state int,
+	envd bool,
+) (*TerminalHandler, *auth.JWTManager, *fakeTerminalFactory, *atomic.Int32) {
+	t.Helper()
+	var calls atomic.Int32
+	cm := &fakeCM{getSandbox: func(context.Context, string, string) (json.RawMessage, error) {
+		calls.Add(1)
+		return terminalSandboxResponse(state, envd), nil
+	}}
+	jm := auth.NewJWTManager("terminal-test-secret-32-bytes-long!", time.Minute, time.Hour)
+	factory := &fakeTerminalFactory{}
+	lifecycleCtx, lifecycleCancel := context.WithCancel(context.Background())
+	t.Cleanup(lifecycleCancel)
+	return &TerminalHandler{
+		cm:              cm,
+		jm:              jm,
+		factory:         factory,
+		runtime:         defaultTerminalRuntimeConfig(),
+		lifecycleCtx:    lifecycleCtx,
+		lifecycleCancel: lifecycleCancel,
+	}, jm, factory, &calls
+}
+
+func newTerminalTestServer(t *testing.T, h *TerminalHandler, jm *auth.JWTManager) (*httptest.Server, string) {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	api := r.Group("/api/v1")
+	h.RegisterPublic(api)
+	authed := r.Group("/api/v1", auth.Middleware(jm))
+	h.RegisterAuthed(authed)
+	server := httptest.NewServer(r)
+	t.Cleanup(server.Close)
+	token, err := jm.GenerateAccessToken("operator")
+	if err != nil {
+		t.Fatalf("generate access token: %v", err)
+	}
+	return server, token
+}
+
+func createTerminalSession(t *testing.T, server *httptest.Server, accessToken string) terminalSessionResponse {
+	t.Helper()
+	req, err := http.NewRequest(
+		http.MethodPost,
+		server.URL+"/api/v1/terminal/sandboxes/sandbox-1/sessions",
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("create terminal request: %v", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+accessToken)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("create terminal session: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusCreated {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("create status=%d body=%s", resp.StatusCode, body)
+	}
+	var session terminalSessionResponse
+	if err := json.NewDecoder(resp.Body).Decode(&session); err != nil {
+		t.Fatalf("decode terminal session: %v", err)
+	}
+	return session
+}
+
+func dialTerminal(t *testing.T, server *httptest.Server, session terminalSessionResponse, origin string) (*websocket.Conn, *http.Response, error) {
+	t.Helper()
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http") + "/api/v1/terminal/sandboxes/sandbox-1/ws"
+	header := http.Header{"Origin": []string{origin}}
+	dialer := websocket.Dialer{
+		Subprotocols: []string{session.Protocol, terminalGrantPrefix + session.Grant},
+	}
+	return dialer.Dial(wsURL, header)
+}
+
+func TestTerminalSessionAndWebSocketRelay(t *testing.T) {
+	h, jm, factory, calls := newTerminalTestHandler(t, 1, true)
+	server, accessToken := newTerminalTestServer(t, h, jm)
+	session := createTerminalSession(t, server, accessToken)
+	if calls.Load() != 1 {
+		t.Fatalf("session creation CubeMaster calls=%d, want one", calls.Load())
+	}
+	if session.Protocol != terminalProtocol ||
+		session.WebsocketURL != "/opsapi/v1/terminal/sandboxes/sandbox-1/ws" ||
+		session.Grant == "" {
+		t.Fatalf("unexpected session response: %#v", session)
+	}
+
+	conn, _, err := dialTerminal(t, server, session, server.URL)
+	if err != nil {
+		t.Fatalf("dial terminal: %v", err)
+	}
+	defer conn.Close()
+	if calls.Load() != 2 {
+		t.Fatalf("CubeMaster calls=%d, want two", calls.Load())
+	}
+	if conn.Subprotocol() != terminalProtocol {
+		t.Fatalf("subprotocol=%q", conn.Subprotocol())
+	}
+	if messageType, _, err := conn.ReadMessage(); err != nil || messageType != websocket.TextMessage {
+		t.Fatalf("connected frame: type=%d err=%v", messageType, err)
+	}
+	pty := factory.pty(0)
+	if pty == nil {
+		t.Fatal("PTY was not opened")
+	}
+
+	pty.output <- []byte("hello")
+	messageType, payload, err := conn.ReadMessage()
+	if err != nil || messageType != websocket.BinaryMessage || string(payload) != "hello" {
+		t.Fatalf("output: type=%d payload=%q err=%v", messageType, payload, err)
+	}
+	if err := conn.WriteMessage(websocket.BinaryMessage, []byte("whoami\n")); err != nil {
+		t.Fatalf("write stdin: %v", err)
+	}
+	select {
+	case input := <-pty.input:
+		if string(input) != "whoami\n" {
+			t.Fatalf("stdin=%q", input)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("stdin was not relayed")
+	}
+
+	if err := conn.WriteJSON(terminalControl{Type: "resize", Rows: 40, Cols: 120}); err != nil {
+		t.Fatalf("write resize: %v", err)
+	}
+	select {
+	case size := <-pty.resize:
+		if size.Rows != 40 || size.Cols != 120 {
+			t.Fatalf("resize=%#v", size)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("resize was not relayed")
+	}
+
+	pty.exitCode = 7
+	close(pty.output)
+	_, payload, err = conn.ReadMessage()
+	if err != nil {
+		t.Fatalf("read exit frame: %v", err)
+	}
+	var exit struct {
+		Type     string `json:"type"`
+		ExitCode int    `json:"exitCode"`
+	}
+	if json.Unmarshal(payload, &exit) != nil || exit.Type != "exit" || exit.ExitCode != 7 {
+		t.Fatalf("exit frame=%s", payload)
+	}
+	select {
+	case <-pty.killed:
+	case <-time.After(time.Second):
+		t.Fatal("PTY was not cleaned up")
+	}
+}
+
+func TestTerminalRejectsInvalidTargets(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		state int
+		envd  bool
+	}{
+		{name: "paused", state: 5, envd: true},
+		{name: "without envd", state: 1},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			h, jm, _, _ := newTerminalTestHandler(t, tc.state, tc.envd)
+			server, accessToken := newTerminalTestServer(t, h, jm)
+			req, err := http.NewRequest(
+				http.MethodPost,
+				server.URL+"/api/v1/terminal/sandboxes/sandbox-1/sessions",
+				nil,
+			)
+			if err != nil {
+				t.Fatal(err)
+			}
+			req.Header.Set("Authorization", "Bearer "+accessToken)
+			resp, err := http.DefaultClient.Do(req)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer resp.Body.Close()
+			if resp.StatusCode != http.StatusConflict {
+				body, _ := io.ReadAll(resp.Body)
+				t.Fatalf("status=%d want=%d body=%s", resp.StatusCode, http.StatusConflict, body)
+			}
+		})
+	}
+}
+
+func TestTerminalRejectsCrossOriginWebSocket(t *testing.T) {
+	h, jm, _, _ := newTerminalTestHandler(t, 1, true)
+	server, accessToken := newTerminalTestServer(t, h, jm)
+	session := createTerminalSession(t, server, accessToken)
+	conn, resp, err := dialTerminal(t, server, session, "https://evil.example")
+	if conn != nil {
+		conn.Close()
+		t.Fatal("terminal upgrade unexpectedly succeeded")
+	}
+	if err == nil || resp == nil {
+		t.Fatalf("dial error=%v response=%v", err, resp)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusForbidden {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status=%d want=%d body=%s", resp.StatusCode, http.StatusForbidden, body)
+	}
+}
+
+func TestTerminalRejectsGrantForAnotherSandbox(t *testing.T) {
+	h, jm, _, calls := newTerminalTestHandler(t, 1, true)
+	grant, _, err := jm.GenerateTerminalGrant("operator", "another-sandbox", time.Minute)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req := httptest.NewRequest(http.MethodGet, "/ws", nil)
+	req.Header.Set("Sec-WebSocket-Protocol", terminalProtocol+", "+terminalGrantPrefix+grant)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = req
+	c.Params = gin.Params{{Key: "id", Value: "sandbox-1"}}
+	h.Connect(c)
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("status=%d body=%s", w.Code, w.Body.String())
+	}
+	if calls.Load() != 0 {
+		t.Fatal("mismatched grant queried CubeMaster")
+	}
+}
+
+func TestTerminalStreamFailureReturnsErrorFrame(t *testing.T) {
+	h, jm, factory, _ := newTerminalTestHandler(t, 1, true)
+	server, accessToken := newTerminalTestServer(t, h, jm)
+	conn, _, err := dialTerminal(
+		t,
+		server,
+		createTerminalSession(t, server, accessToken),
+		server.URL,
+	)
+	if err != nil {
+		t.Fatalf("dial terminal: %v", err)
+	}
+	defer conn.Close()
+	if _, _, err := conn.ReadMessage(); err != nil {
+		t.Fatalf("read connected frame: %v", err)
+	}
+	pty := factory.pty(0)
+	pty.waitErr = errors.New("upstream stream reset")
+	close(pty.output)
+	_, payload, err := conn.ReadMessage()
+	if err != nil {
+		t.Fatalf("read error frame: %v", err)
+	}
+	var frame struct {
+		Type string `json:"type"`
+	}
+	if json.Unmarshal(payload, &frame) != nil || frame.Type != "error" {
+		t.Fatalf("frame=%s, want error", payload)
+	}
+}
+
+func TestTerminalShutdownCleansActivePTY(t *testing.T) {
+	h, jm, factory, _ := newTerminalTestHandler(t, 1, true)
+	server, accessToken := newTerminalTestServer(t, h, jm)
+	session := createTerminalSession(t, server, accessToken)
+	conn, _, err := dialTerminal(t, server, session, server.URL)
+	if err != nil {
+		t.Fatalf("dial terminal: %v", err)
+	}
+	defer conn.Close()
+	if _, _, err := conn.ReadMessage(); err != nil {
+		t.Fatalf("read connected frame: %v", err)
+	}
+	pty := factory.pty(0)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	if err := h.Shutdown(ctx); err != nil {
+		t.Fatalf("shutdown terminal handler: %v", err)
+	}
+	select {
+	case <-pty.killed:
+	default:
+		t.Fatal("active PTY was not killed before shutdown returned")
+	}
+}
+
+func TestTerminalSessionRequiresAuthentication(t *testing.T) {
+	h, jm, _, calls := newTerminalTestHandler(t, 1, true)
+	server, _ := newTerminalTestServer(t, h, jm)
+	resp, err := http.Post(
+		server.URL+"/api/v1/terminal/sandboxes/sandbox-1/sessions",
+		"application/json",
+		nil,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("status=%d want=%d", resp.StatusCode, http.StatusUnauthorized)
+	}
+	if calls.Load() != 0 {
+		t.Fatal("unauthenticated request queried CubeMaster")
+	}
+}
+
+func TestTerminalRejectsExpiredGrant(t *testing.T) {
+	h, jm, _, calls := newTerminalTestHandler(t, 1, true)
+	server, _ := newTerminalTestServer(t, h, jm)
+	grant, _, err := jm.GenerateTerminalGrant("operator", "sandbox-1", time.Nanosecond)
+	if err != nil {
+		t.Fatal(err)
+	}
+	time.Sleep(time.Millisecond)
+	conn, resp, err := dialTerminal(t, server, terminalSessionResponse{
+		Grant:    grant,
+		Protocol: terminalProtocol,
+	}, server.URL)
+	if conn != nil {
+		conn.Close()
+		t.Fatal("expired terminal grant unexpectedly connected")
+	}
+	if err == nil || resp == nil {
+		t.Fatalf("dial error=%v response=%v", err, resp)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("status=%d want=%d", resp.StatusCode, http.StatusUnauthorized)
+	}
+	if calls.Load() != 0 {
+		t.Fatal("expired grant queried CubeMaster")
+	}
+}
+
+func TestTerminalIdleTimeoutCleansPTY(t *testing.T) {
+	h, jm, factory, _ := newTerminalTestHandler(t, 1, true)
+	h.runtime.idleTimeout = 20 * time.Millisecond
+	h.runtime.pingPeriod = time.Hour
+	h.runtime.maxDuration = time.Hour
+	server, accessToken := newTerminalTestServer(t, h, jm)
+	conn, _, err := dialTerminal(
+		t,
+		server,
+		createTerminalSession(t, server, accessToken),
+		server.URL,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+	if _, _, err := conn.ReadMessage(); err != nil {
+		t.Fatalf("read connected frame: %v", err)
+	}
+	_, payload, err := conn.ReadMessage()
+	if err != nil {
+		t.Fatalf("read idle timeout frame: %v", err)
+	}
+	if !strings.Contains(string(payload), "closed after inactivity") {
+		t.Fatalf("idle timeout frame=%s", payload)
+	}
+	pty := factory.pty(0)
+	select {
+	case <-pty.killed:
+	case <-time.After(time.Second):
+		t.Fatal("idle terminal PTY was not killed")
+	}
+}
+
+func TestTerminalMalformedControlFrameClosesProtocol(t *testing.T) {
+	h, jm, factory, _ := newTerminalTestHandler(t, 1, true)
+	server, accessToken := newTerminalTestServer(t, h, jm)
+	conn, _, err := dialTerminal(
+		t,
+		server,
+		createTerminalSession(t, server, accessToken),
+		server.URL,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+	if _, _, err := conn.ReadMessage(); err != nil {
+		t.Fatalf("read connected frame: %v", err)
+	}
+	if err := conn.WriteMessage(websocket.TextMessage, []byte("not-json")); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := conn.ReadMessage(); !websocket.IsCloseError(err, websocket.CloseProtocolError) {
+		t.Fatalf("close error=%v, want protocol close", err)
+	}
+	select {
+	case <-factory.pty(0).killed:
+	case <-time.After(time.Second):
+		t.Fatal("protocol-error PTY was not killed")
+	}
+}
+
+func TestTerminalShutdownRejectsNewGrants(t *testing.T) {
+	h, jm, factory, calls := newTerminalTestHandler(t, 1, true)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if err := h.Shutdown(ctx); err != nil {
+		t.Fatal(err)
+	}
+	server, accessToken := newTerminalTestServer(t, h, jm)
+	req, err := http.NewRequest(
+		http.MethodPost,
+		server.URL+"/api/v1/terminal/sandboxes/sandbox-1/sessions",
+		nil,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Authorization", "Bearer "+accessToken)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusServiceUnavailable {
+		t.Fatalf("status=%d want=%d", resp.StatusCode, http.StatusServiceUnavailable)
+	}
+	if calls.Load() != 0 {
+		t.Fatal("shutting-down handler queried CubeMaster")
+	}
+	if factory.closeCalls != 1 {
+		t.Fatalf("factory close calls=%d want=1", factory.closeCalls)
+	}
+}
+
+func TestTerminalConcurrentSessionsAreIsolated(t *testing.T) {
+	h, jm, factory, _ := newTerminalTestHandler(t, 1, true)
+	server, accessToken := newTerminalTestServer(t, h, jm)
+	first, _, err := dialTerminal(
+		t,
+		server,
+		createTerminalSession(t, server, accessToken),
+		server.URL,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer first.Close()
+	if _, _, err := first.ReadMessage(); err != nil {
+		t.Fatal(err)
+	}
+	second, _, err := dialTerminal(
+		t,
+		server,
+		createTerminalSession(t, server, accessToken),
+		server.URL,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer second.Close()
+	if _, _, err := second.ReadMessage(); err != nil {
+		t.Fatal(err)
+	}
+
+	firstPTY := factory.pty(0)
+	secondPTY := factory.pty(1)
+	firstPTY.output <- []byte("first")
+	secondPTY.output <- []byte("second")
+	_, firstOutput, err := first.ReadMessage()
+	if err != nil || string(firstOutput) != "first" {
+		t.Fatalf("first output=%q err=%v", firstOutput, err)
+	}
+	_, secondOutput, err := second.ReadMessage()
+	if err != nil || string(secondOutput) != "second" {
+		t.Fatalf("second output=%q err=%v", secondOutput, err)
+	}
+
+	if err := first.WriteMessage(websocket.BinaryMessage, []byte("one")); err != nil {
+		t.Fatal(err)
+	}
+	if err := second.WriteMessage(websocket.BinaryMessage, []byte("two")); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case got := <-firstPTY.input:
+		if string(got) != "one" {
+			t.Fatalf("first input=%q", got)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("first session input not relayed")
+	}
+	select {
+	case got := <-secondPTY.input:
+		if string(got) != "two" {
+			t.Fatalf("second input=%q", got)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("second session input not relayed")
+	}
+	if factory.durations[0] != 8*time.Hour || factory.durations[1] != 8*time.Hour {
+		t.Fatalf("PTY durations=%v, want production maximum duration", factory.durations)
+	}
+}
+
+func TestTerminalAuditFields(t *testing.T) {
+	var logs synchronizedBuffer
+	previousLogger := slog.Default()
+	slog.SetDefault(slog.New(slog.NewJSONHandler(&logs, nil)))
+	t.Cleanup(func() { slog.SetDefault(previousLogger) })
+
+	h, jm, factory, _ := newTerminalTestHandler(t, 1, true)
+	server, accessToken := newTerminalTestServer(t, h, jm)
+	session := createTerminalSession(t, server, accessToken)
+	claims, err := jm.VerifyTerminalGrant(session.Grant)
+	if err != nil {
+		t.Fatal(err)
+	}
+	conn, _, err := dialTerminal(t, server, session, server.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := conn.ReadMessage(); err != nil {
+		t.Fatal(err)
+	}
+	if err := conn.Close(); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-factory.pty(0).killed:
+	case <-time.After(time.Second):
+		t.Fatal("disconnected PTY was not cleaned up")
+	}
+
+	hasEnded := func() bool {
+		for _, line := range strings.Split(strings.TrimSpace(logs.String()), "\n") {
+			var record map[string]interface{}
+			if json.Unmarshal([]byte(line), &record) == nil &&
+				record["event"] == "terminal.ended" &&
+				record["session_id"] == claims.ID {
+				return true
+			}
+		}
+		return false
+	}
+	deadline := time.Now().Add(time.Second)
+	for !hasEnded() && time.Now().Before(deadline) {
+		time.Sleep(time.Millisecond)
+	}
+	events := map[string]map[string]interface{}{}
+	for _, line := range strings.Split(strings.TrimSpace(logs.String()), "\n") {
+		var record map[string]interface{}
+		if json.Unmarshal([]byte(line), &record) != nil {
+			continue
+		}
+		event, _ := record["event"].(string)
+		if strings.HasPrefix(event, "terminal.") && record["session_id"] == claims.ID {
+			events[event] = record
+		}
+	}
+	for _, event := range []string{"terminal.grant", "terminal.started", "terminal.ended"} {
+		record := events[event]
+		if record == nil {
+			t.Fatalf("missing %s audit event in %s", event, logs.String())
+		}
+		for _, field := range []string{
+			"session_id",
+			"operator",
+			"sandbox_id",
+			"container_id",
+			"remote_addr",
+			"timestamp",
+			"duration_ms",
+			"close_reason",
+		} {
+			if _, ok := record[field]; !ok {
+				t.Fatalf("%s audit event missing %s: %#v", event, field, record)
+			}
+		}
+		if record["operator"] != "operator" ||
+			record["sandbox_id"] != "sandbox-1" ||
+			record["container_id"] != "sandbox-1" {
+			t.Fatalf("unexpected %s audit identity: %#v", event, record)
+		}
+	}
+	if events["terminal.ended"]["close_reason"] != "client_disconnected" {
+		t.Fatalf("ended audit=%#v", events["terminal.ended"])
+	}
+}
+
+func TestTerminalFailureAuditFields(t *testing.T) {
+	var logs synchronizedBuffer
+	previousLogger := slog.Default()
+	slog.SetDefault(slog.New(slog.NewJSONHandler(&logs, nil)))
+	t.Cleanup(func() { slog.SetDefault(previousLogger) })
+
+	h, jm, factory, _ := newTerminalTestHandler(t, 1, true)
+	factory.openErr = errors.New("envd unavailable")
+	server, accessToken := newTerminalTestServer(t, h, jm)
+	session := createTerminalSession(t, server, accessToken)
+	claims, err := jm.VerifyTerminalGrant(session.Grant)
+	if err != nil {
+		t.Fatal(err)
+	}
+	conn, _, err := dialTerminal(t, server, session, server.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+	if _, _, err := conn.ReadMessage(); err != nil {
+		t.Fatalf("read PTY failure frame: %v", err)
+	}
+
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		for _, line := range strings.Split(strings.TrimSpace(logs.String()), "\n") {
+			var record map[string]interface{}
+			if json.Unmarshal([]byte(line), &record) != nil ||
+				record["event"] != "terminal.failed" ||
+				record["session_id"] != claims.ID {
+				continue
+			}
+			if record["container_id"] != "sandbox-1" ||
+				record["close_reason"] != "pty_start_failed" ||
+				record["error"] != "envd unavailable" {
+				t.Fatalf("unexpected failure audit: %#v", record)
+			}
+			for _, field := range []string{
+				"operator",
+				"sandbox_id",
+				"remote_addr",
+				"timestamp",
+				"duration_ms",
+			} {
+				if _, ok := record[field]; !ok {
+					t.Fatalf("failure audit missing %s: %#v", field, record)
+				}
+			}
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatalf("missing terminal.failed audit event in %s", logs.String())
+}
+
+func TestTerminalProtocolHelpers(t *testing.T) {
+	header := "other.v1, cube-terminal.v1, cube-terminal.grant.abc.def"
+	if !terminalProtocolRequested(header) {
+		t.Fatal("application protocol was not detected")
+	}
+	if got := terminalGrantFromProtocols(header); got != "abc.def" {
+		t.Fatalf("grant=%q", got)
+	}
+	if terminalProtocolRequested("cube-terminal.v10") {
+		t.Fatal("prefix match was accepted")
+	}
+}

--- a/CubeOps/internal/server/server.go
+++ b/CubeOps/internal/server/server.go
@@ -5,6 +5,7 @@ package server
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"net/http"
 	"time"
@@ -20,11 +21,12 @@ import (
 
 // Server is the CubeOps HTTP server.
 type Server struct {
-	cfg     *config.Config
-	store   *store.Store
-	jm      *auth.JWTManager
-	httpSrv *http.Server
-	cm      *cubemaster.Client
+	cfg      *config.Config
+	store    *store.Store
+	jm       *auth.JWTManager
+	httpSrv  *http.Server
+	cm       *cubemaster.Client
+	terminal *handler.TerminalHandler
 }
 
 // New creates a new CubeOps server.
@@ -62,11 +64,16 @@ func (s *Server) Start() error {
 
 // Shutdown gracefully stops the server.
 func (s *Server) Shutdown(ctx context.Context) error {
-	if s.httpSrv == nil {
-		return nil
-	}
 	slog.Info("CubeOps shutting down")
-	return s.httpSrv.Shutdown(ctx)
+	var terminalErr error
+	if s.terminal != nil {
+		terminalErr = s.terminal.Shutdown(ctx)
+	}
+	var httpErr error
+	if s.httpSrv != nil {
+		httpErr = s.httpSrv.Shutdown(ctx)
+	}
+	return errors.Join(terminalErr, httpErr)
 }
 
 // buildRouter configures all routes on a gin engine.
@@ -92,6 +99,8 @@ func (s *Server) buildRouter() *gin.Engine {
 	storeH := handler.NewStoreHandler(handler.DefaultRegistryClient())
 	configH := handler.NewConfigHandler(s.cfg.Bind, 100, s.cfg.JWTSecret != "", s.cfg.SandboxDomain, "cubebox")
 	agenthubH := handler.NewAgentHubHandler(s.store, s.cm)
+	terminalH := handler.NewTerminalHandler(s.cm, s.jm, s.cfg)
+	s.terminal = terminalH
 	// SDK handler gets the AgentHubService so that E2B template/snapshot
 	// deletions can reverse-sync AgentHub registrations (matching the old
 	// Rust reverse_sync_agenthub_template that lived in CubeAPI).
@@ -100,6 +109,7 @@ func (s *Server) buildRouter() *gin.Engine {
 	// Public (no auth) routes — login + refresh.
 	public := r.Group("/api/v1")
 	authH.RegisterPublic(public)
+	terminalH.RegisterPublic(public)
 
 	// Authenticated routes. The session / logout / change-password endpoints
 	// are mounted here, behind the JWT middleware.
@@ -110,6 +120,7 @@ func (s *Server) buildRouter() *gin.Engine {
 	configH.Register(authed)
 	storeH.Register(authed)
 	agenthubH.Register(authed)
+	terminalH.RegisterAuthed(authed)
 
 	// SDK routes — mounted at both /api/v1/sdk and /api/v1/sdk/v2 because
 	// the WebUI and the E2B-compatible clients hit different prefixes.

--- a/deploy/kubernetes/chart/templates/_helpers.tpl
+++ b/deploy/kubernetes/chart/templates/_helpers.tpl
@@ -280,12 +280,14 @@ http {
 
         location /opsapi/ {
             proxy_http_version 1.1;
-            proxy_set_header Host $host;
+            proxy_set_header Host $http_host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
-            proxy_read_timeout 300s;
-            proxy_send_timeout 300s;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection $connection_upgrade;
+            proxy_read_timeout 28860s;
+            proxy_send_timeout 28860s;
 
             proxy_pass {{ $opsUpstream }}/api/;
         }

--- a/deploy/kubernetes/chart/templates/ops.yaml
+++ b/deploy/kubernetes/chart/templates/ops.yaml
@@ -54,6 +54,8 @@ spec:
               value: {{ .Values.mysql.database | quote }}
             - name: CUBE_API_SANDBOX_DOMAIN
               value: {{ default .Values.cubeProxy.domain .Values.cubeOps.sandboxDomain | quote }}
+            - name: CUBE_OPS_SANDBOX_PROXY_URL
+              value: {{ default (printf "http://%s:%v" (include "cube.proxyServiceFQDN" .) .Values.cubeProxy.ports.http.containerPort) .Values.cubeOps.sandboxProxyURL | quote }}
             # Shared CubeDB with CubeMaster; skip fingerprint so chart upgrades
             # do not fail when Master already applied the same migrations.
             - name: CUBEMASTER_MIGRATION_SKIP_FINGERPRINT_CHECK

--- a/deploy/kubernetes/chart/values.yaml
+++ b/deploy/kubernetes/chart/values.yaml
@@ -338,6 +338,9 @@ cubeOps:
   bind: "0.0.0.0:3010"
   # Empty uses cubeProxy.domain for CUBE_API_SANDBOX_DOMAIN.
   sandboxDomain: ""
+  # Empty routes terminal envd traffic through the chart-managed CubeProxy
+  # Service. Override only when CubeProxy is external.
+  sandboxProxyURL: ""
   service:
     type: ClusterIP
     port: 3010

--- a/deploy/one-click/scripts/systemd/cubeops-start.sh
+++ b/deploy/one-click/scripts/systemd/cubeops-start.sh
@@ -23,6 +23,7 @@ export CUBE_OPS_LOG_LEVEL="${CUBE_OPS_LOG_LEVEL:-info}"
 
 # CubeMaster address (same host in All-in-One mode).
 export CUBE_MASTER_ADDR="${CUBE_MASTER_ADDR:-http://127.0.0.1:8089}"
+export CUBE_OPS_SANDBOX_PROXY_URL="${CUBE_OPS_SANDBOX_PROXY_URL:-http://127.0.0.1:80}"
 
 # JWT configuration. JWT_SECRET left unset → CubeOps auto-generates and
 # persists it to t_system_setting on first boot (single-instance default).

--- a/deploy/one-click/terraform/tencentcloud/tke-addons.tf
+++ b/deploy/one-click/terraform/tencentcloud/tke-addons.tf
@@ -55,12 +55,25 @@ locals {
       worker_processes auto;
       events { worker_connections 1024; }
       http {
+        map $http_upgrade $connection_upgrade {
+          default upgrade;
+          ''      '';
+        }
         server {
           listen 80;
           root /usr/share/nginx/html;
           index index.html;
           location ^~ /sandbox/ { proxy_pass __SANDBOX_PROXY_UPSTREAM__; }
-          location /opsapi/ { proxy_pass __CUBE_OPS_UPSTREAM__/api/; }
+          location /opsapi/ {
+            proxy_http_version 1.1;
+            proxy_set_header Host $http_host;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection $connection_upgrade;
+            proxy_read_timeout 28860s;
+            proxy_send_timeout 28860s;
+            proxy_pass __CUBE_OPS_UPSTREAM__/api/;
+          }
           location /cubeapi/v1/ {
             rewrite ^/cubeapi/v1/(.*)$ /api/v1/sdk/$1 break;
             proxy_pass __CUBE_OPS_UPSTREAM__;
@@ -691,6 +704,10 @@ resource "kubernetes_deployment" "cube_ops" {
           env {
             name  = "CUBE_API_SANDBOX_DOMAIN"
             value = "cube.app"
+          }
+          env {
+            name  = "CUBE_OPS_SANDBOX_PROXY_URL"
+            value = "http://cube-proxy:80"
           }
           env {
             name  = "CUBEMASTER_MIGRATION_SKIP_FINGERPRINT_CHECK"

--- a/deploy/one-click/tests/test_runtime_file_safety.sh
+++ b/deploy/one-click/tests/test_runtime_file_safety.sh
@@ -156,7 +156,7 @@ test_unit_dependency_order() {
   assert_contains "${ONE_CLICK_DIR}/systemd/cube-sandbox-cube-proxy.service" "After=docker.service network-online.target cube-sandbox-redis.service cube-sandbox-dns.service"
   assert_contains "${ONE_CLICK_DIR}/systemd/cube-sandbox-cubemaster.service" "After=network-online.target cube-sandbox-mysql.service cube-sandbox-redis.service"
   assert_contains "${ONE_CLICK_DIR}/systemd/cube-sandbox-cube-api.service" "After=network-online.target cube-sandbox-cubemaster.service"
-  assert_contains "${ONE_CLICK_DIR}/systemd/cube-sandbox-webui.service" "After=docker.service network-online.target cube-sandbox-cube-api.service"
+  assert_contains "${ONE_CLICK_DIR}/systemd/cube-sandbox-webui.service" "After=docker.service network-online.target cube-sandbox-cubemaster.service cube-sandbox-cubeops.service"
 }
 
 test_detect_glibc_version_consumes_full_ldd_output() {

--- a/deploy/one-click/webui/nginx.conf
+++ b/deploy/one-click/webui/nginx.conf
@@ -59,12 +59,14 @@ http {
         # CubeOps (ops/admin endpoints) — rewrite /opsapi → /api
         location /opsapi/ {
             proxy_http_version 1.1;
-            proxy_set_header Host $host;
+            proxy_set_header Host $http_host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
-            proxy_read_timeout 300s;
-            proxy_send_timeout 300s;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection $connection_upgrade;
+            proxy_read_timeout 28860s;
+            proxy_send_timeout 28860s;
 
             proxy_pass __CUBE_OPS_UPSTREAM__/api/;
         }

--- a/dev-env/internal/sync_web_to_vm.sh
+++ b/dev-env/internal/sync_web_to_vm.sh
@@ -24,7 +24,9 @@ WEB_SYNC_BUILD="${WEB_SYNC_BUILD:-1}"
 WEB_UI_IMAGE="${WEB_UI_IMAGE:-cube-sandbox-image.tencentcloudcr.com/opensource/openresty:1.21.4.1-6-alpine-fat}"
 WEB_UI_CONTAINER_NAME="${WEB_UI_CONTAINER_NAME:-cube-webui}"
 WEB_UI_HOST_PORT="${WEB_UI_HOST_PORT:-12088}"
-WEB_UI_UPSTREAM="${WEB_UI_UPSTREAM:-http://host.docker.internal:3000}"
+WEB_UI_UPSTREAM="${WEB_UI_UPSTREAM:-http://host.docker.internal:3010}"
+SANDBOX_PROXY_UPSTREAM="${SANDBOX_PROXY_UPSTREAM:-http://host.docker.internal:80}"
+CUBE_OPS_UPSTREAM="${CUBE_OPS_UPSTREAM:-http://host.docker.internal:3010}"
 
 ASKPASS_SCRIPT="${WORK_DIR}/.ssh-askpass.sh"
 TMP_DIR="${WORK_DIR}/webui-sync"
@@ -66,6 +68,8 @@ Environment overrides:
   WEB_SYNC_BUILD        default: ${WEB_SYNC_BUILD} (set 0 to skip npm build)
   WEB_UI_HOST_PORT      default: ${WEB_UI_HOST_PORT}
   WEB_UI_UPSTREAM       default: ${WEB_UI_UPSTREAM}
+  SANDBOX_PROXY_UPSTREAM default: ${SANDBOX_PROXY_UPSTREAM}
+  CUBE_OPS_UPSTREAM     default: ${CUBE_OPS_UPSTREAM}
   WEB_UI_IMAGE          default: ${WEB_UI_IMAGE}
   WEB_UI_CONTAINER_NAME default: ${WEB_UI_CONTAINER_NAME}
   SSH_HOST, SSH_PORT    default: ${SSH_HOST}:${SSH_PORT}
@@ -171,6 +175,8 @@ cp "${REPO_ROOT}/deploy/one-click/webui/docker-compose.yaml.template" "${TMP_DIR
 
 sed \
   -e "s#__WEB_UI_UPSTREAM__#$(escape_sed "${WEB_UI_UPSTREAM}")#g" \
+  -e "s#__SANDBOX_PROXY_UPSTREAM__#$(escape_sed "${SANDBOX_PROXY_UPSTREAM}")#g" \
+  -e "s#__CUBE_OPS_UPSTREAM__#$(escape_sed "${CUBE_OPS_UPSTREAM}")#g" \
   "${TMP_DIR}/nginx.conf" > "${TMP_DIR}/nginx.generated.conf"
 
 sed \
@@ -204,9 +210,8 @@ run_ssh "
   sudo install -m 0644 '${REMOTE_STAGE_DIR}/nginx.generated.conf' '${REMOTE_WEBUI_DIR}/nginx.generated.conf'
   sudo install -m 0644 '${REMOTE_STAGE_DIR}/docker-compose.yaml.template' '${REMOTE_WEBUI_DIR}/docker-compose.yaml.template'
   sudo install -m 0644 '${REMOTE_STAGE_DIR}/docker-compose.yaml' '${REMOTE_WEBUI_DIR}/docker-compose.yaml'
-  cd '${REMOTE_WEBUI_DIR}'
-  sudo docker compose down --remove-orphans >/dev/null 2>&1 || true
-  sudo docker compose up -d
+  sudo systemctl restart cube-sandbox-webui.service
+  sudo systemctl is-active --quiet cube-sandbox-webui.service
   sudo rm -rf '${REMOTE_STAGE_DIR}'
 "
 
@@ -214,7 +219,7 @@ log_info "Checking WebUI from inside VM"
 run_ssh "
   set -e
   curl -fsS 'http://127.0.0.1:${WEB_UI_HOST_PORT}/' >/dev/null
-  curl -fsS 'http://127.0.0.1:${WEB_UI_HOST_PORT}/cubeapi/v1/health' >/dev/null
+  curl -fsS 'http://127.0.0.1:${WEB_UI_HOST_PORT}/health' >/dev/null
 "
 
 log_success "WebUI synced. Open: http://127.0.0.1:${WEB_UI_HOST_PORT}"

--- a/dev-env/sync_to_vm.sh
+++ b/dev-env/sync_to_vm.sh
@@ -67,7 +67,7 @@ Subcommands:
   -h, --help                    Show this help.
 
 Known components:
-  cubemaster, cubemastercli, cubelet, cubecli,
+  cubemaster, cubemastercli, cubelet, cubecli, cubeops,
   network-agent, cube-api, cube-runtime, containerd-shim-cube-rs
 
 Environment overrides:
@@ -157,6 +157,7 @@ component_remote_dir() {
   case "$1" in
     cubemaster|cubemastercli) printf '%s/CubeMaster/bin\n' "${TOOLBOX_ROOT}" ;;
     cubelet|cubecli) printf '%s/Cubelet/bin\n' "${TOOLBOX_ROOT}" ;;
+    cubeops) printf '%s/CubeOps/bin\n' "${TOOLBOX_ROOT}" ;;
     network-agent) printf '%s/network-agent/bin\n' "${TOOLBOX_ROOT}" ;;
     cube-api) printf '%s/CubeAPI/bin\n' "${TOOLBOX_ROOT}" ;;
     # Keep one-click's /usr/local/bin symlinks intact by updating the real install path.
@@ -168,6 +169,7 @@ component_remote_dir() {
 ALL_COMPONENTS=(
   cubemaster cubemastercli
   cubelet cubecli
+  cubeops
   network-agent
   cube-api
   cube-runtime containerd-shim-cube-rs

--- a/docs/guide/webui.md
+++ b/docs/guide/webui.md
@@ -85,6 +85,60 @@ The Dashboard uses **JWT-based authentication** (since v0.6.0, replacing the old
 - Login is rate-limited: 5 failed attempts per minute per IP.
 :::
 
+### 3.4 Open a browser terminal
+
+The sandbox detail page always shows **Open Terminal**. It is enabled only when
+the sandbox is running and carries the envd capability metadata collected while
+its template was built. A disabled action explains whether the sandbox must be
+resumed or its legacy template must be rebuilt with envd.
+
+Opening the dialog creates the first `/bin/sh` automatically. Use **+** to open
+up to five independent tabs for the same sandbox. Every tab owns a separate
+xterm instance, WebSocket, envd PTY, and shell process; closing one tab does not
+affect the others. ANSI colors, cursor control, resize events, and 5,000 lines
+of scrollback are preserved.
+
+- **Copy** copies the current terminal selection. **Paste** sends clipboard
+  text to the active shell. `Ctrl/Cmd+Shift+C` and `Ctrl/Cmd+Shift+V` provide
+  the same operations.
+- An abnormal disconnect leaves the tab open with the reported reason.
+  **Reconnect** requests a fresh grant and starts a new shell; it does not
+  restore the previous PTY, screen, working directory, or shell state.
+- The production defaults are a 30-minute terminal I/O idle timeout, an
+  eight-hour maximum session duration, and a 30-second WebSocket ping period.
+  These values are internal CubeOps runtime parameters rather than public API
+  settings.
+- The first delivery intentionally opens only the primary sandbox container.
+  Container selection will remain unavailable until envd supports a
+  container-scoped PTY start request; the UI never pretends that another
+  container was selected.
+
+The terminal is an operational CubeOps capability. Any user who can log in to
+the current CubeOps deployment can request a terminal; CubeSandbox does not
+currently have resource-level ACLs. The authenticated browser first requests a
+one-minute, sandbox-bound JWT grant from CubeOps. The grant is carried in the
+WebSocket subprotocol header rather than the URL, and CubeOps validates the
+sandbox again during the upgrade. CubeOps then relays binary terminal traffic
+through CubeProxy to the existing envd PTY data plane. This path does not add a
+CubeAPI endpoint or a CubeMaster/Cubelet terminal RPC.
+
+Use HTTPS for production access. The browser automatically selects `wss://`
+under HTTPS, and every reverse proxy in front of WebUI/CubeOps must preserve
+WebSocket Upgrade headers and allow connections for longer than the configured
+maximum session duration. CubeOps replicas must share the persisted JWT secret,
+so the grant request and WebSocket upgrade may land on different replicas.
+
+CubeOps emits structured `terminal.grant`, `terminal.started`,
+`terminal.ended`, and `terminal.failed` audit events. They contain the session
+ID, operator, sandbox, actual primary container, remote address, timestamp,
+duration, and close reason, but never terminal input or output.
+
+::: warning Lifecycle operations
+An open envd PTY is an active exec process. Close all terminal tabs before
+pause, snapshot, rollback, deletion, or an auto-pause boundary; otherwise those
+operations may wait for the exec process to end.
+:::
+
 ## 4. Keyboard shortcuts
 
 The Dashboard is keyboard-friendly. The big three:

--- a/docs/zh/guide/webui.md
+++ b/docs/zh/guide/webui.md
@@ -79,6 +79,27 @@ Dashboard 是一个静态前端，由 **控制节点** 上的 nginx 容器托管
 开启鉴权的人会生成它。完整流程见 [鉴权](./authentication.md)。
 :::
 
+### 3.4 打开浏览器终端
+
+沙箱详情页始终显示 **打开终端**。只有沙箱正在运行且带有模板构建阶段采集的 envd 能力元数据时才可点击；禁用状态会明确提示需要先恢复沙箱，还是需要用 envd 重新构建旧模板。
+
+打开弹窗时会自动创建第一个 `/bin/sh`。点击 **+** 可为同一沙箱创建最多 5 个独立标签；每个标签分别拥有 xterm、WebSocket、envd PTY 和 shell 进程，关闭单个标签不会影响其他标签。终端保留 ANSI 颜色、光标控制、自动 resize 和 5000 行回溯。
+
+- **复制**用于复制当前选区，**粘贴**用于向当前 shell 发送剪贴板文本；也可使用 `Ctrl/Cmd+Shift+C` 和 `Ctrl/Cmd+Shift+V`。
+- 异常断线后标签会保留并显示具体原因。点击 **重新连接**会申请新的 grant 并创建新的 shell，不会恢复原 PTY 的屏幕、工作目录或 shell 状态。
+- 生产默认终端 I/O 空闲超时为 30 分钟，单次会话最长 8 小时，WebSocket ping 周期为 30 秒。这些值是 CubeOps 内部运行参数，不属于公共 API 配置。
+- 第一阶段只进入主沙箱容器。在 envd 支持按容器启动 PTY 之前不会显示容器选择，也不会伪装成已经进入其他容器。
+
+终端属于 CubeOps 的运维能力。当前任何能够登录 CubeOps 的用户都可申请终端，项目暂不具备资源级 ACL。浏览器先通过已认证请求向 CubeOps 申请一个有效期一分钟、绑定沙箱的 JWT grant；grant 放在 WebSocket 子协议头而不是 URL 中，升级连接时 CubeOps 会再次校验沙箱状态。随后 CubeOps 经 CubeProxy 直接转发二进制终端流量到现有 envd PTY 数据面。整条链路不新增 CubeAPI 接口，也不新增 CubeMaster/Cubelet Terminal RPC。
+
+生产环境应使用 HTTPS。页面在 HTTPS 下会自动使用 `wss://`；WebUI/CubeOps 前的所有反向代理都必须保留 WebSocket Upgrade 请求头，并允许连接时长超过终端最大会话时长。CubeOps 多副本必须共享持久化的 JWT 密钥，因此申请 grant 和建立 WebSocket 可以落在不同副本上。
+
+CubeOps 会输出结构化的 `terminal.grant`、`terminal.started`、`terminal.ended` 和 `terminal.failed` 审计事件，其中包含会话 ID、操作者、沙箱、实际主容器、远端地址、时间、持续时长和关闭原因，但不会记录终端输入或输出。
+
+::: warning 生命周期操作
+打开的 envd PTY 属于活跃 exec 进程。执行暂停、快照、回滚、删除或进入自动暂停边界前，请先关闭全部终端标签，否则这些操作可能等待 exec 进程结束。
+:::
+
 ## 4. 键盘快捷键
 
 Dashboard 对键盘很友好。最常用的三个：

--- a/sdk/go/client.go
+++ b/sdk/go/client.go
@@ -11,6 +11,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"strings"
 )
 
 type ClientOption func(*Client)
@@ -87,6 +88,20 @@ func (c *Client) Connect(ctx context.Context, sandboxID string) (*Sandbox, error
 	}
 	c.attachSandbox(&sandbox)
 	return &sandbox, nil
+}
+
+// Attach returns a local handle for an existing sandbox without making a
+// control-plane request. It is intended for trusted backend components that
+// already validated the sandbox through their own control plane and only need
+// to use the SDK data-plane APIs (commands, files, PTY, and so on).
+func (c *Client) Attach(sandboxID string) (*Sandbox, error) {
+	sandboxID = strings.TrimSpace(sandboxID)
+	if sandboxID == "" {
+		return nil, fmt.Errorf("cubesandbox: sandbox ID is required")
+	}
+	sandbox := &Sandbox{SandboxID: sandboxID}
+	c.attachSandbox(sandbox)
+	return sandbox, nil
 }
 
 func (c *Client) List(ctx context.Context) ([]SandboxInfo, error) {

--- a/sdk/go/pty.go
+++ b/sdk/go/pty.go
@@ -36,6 +36,10 @@ type PtySize struct {
 
 // PtyCreateOptions configures Pty.Create.
 type PtyCreateOptions struct {
+	// Command and Args select the interactive program. Empty Command keeps the
+	// SDK-compatible default of "/bin/bash" with arguments "-i -l".
+	Command string
+	Args    []string
 	// User authenticates the envd process call (Basic auth). Empty defaults to
 	// "root" to match the Python/Node SDKs.
 	User string
@@ -70,9 +74,10 @@ func (s *Sandbox) Pty() *Pty {
 	return &Pty{sandbox: s}
 }
 
-// Create starts a new PTY running an interactive login bash shell ("/bin/bash
-// -i -l") sized to size. The returned PtyHandle streams raw terminal output
-// until the process exits or the caller disconnects.
+// Create starts a new PTY sized to size. It runs Command and Args when supplied,
+// otherwise it uses the SDK-compatible interactive login shell
+// ("/bin/bash -i -l"). The returned PtyHandle streams raw terminal output until
+// the process exits or the caller disconnects.
 func (p *Pty) Create(ctx context.Context, size PtySize, opts PtyCreateOptions) (*PtyHandle, error) {
 	if p == nil || p.sandbox == nil {
 		return nil, fmt.Errorf("pty is not attached to a sandbox")
@@ -95,10 +100,17 @@ func (p *Pty) Create(ctx context.Context, size PtySize, opts PtyCreateOptions) (
 		timeout = defaultPtyTimeout
 	}
 
+	command := strings.TrimSpace(opts.Command)
+	args := opts.Args
+	if command == "" {
+		command = "/bin/bash"
+		args = []string{"-i", "-l"}
+	}
+
 	payload := ptyStartRequest{
 		Process: ptyProcessConfig{
-			Cmd:  "/bin/bash",
-			Args: []string{"-i", "-l"},
+			Cmd:  command,
+			Args: append([]string(nil), args...),
 			Envs: envs,
 			Cwd:  opts.Cwd,
 		},
@@ -238,9 +250,11 @@ func (h *PtyHandle) closeBody() error {
 }
 
 // Wait blocks until the PTY exits and returns its exit code. onData, if
-// non-nil, is invoked with each output chunk as it arrives. It returns an error
-// if the stream ended without an end event or if envd reported a PTY error
-// (e.g. the process was killed).
+// non-nil, is invoked with each output chunk as it arrives. Do not consume
+// Output concurrently with Wait; calling Wait after Output has closed is safe
+// and is useful for retrieving the final stream error. It returns an error if
+// the stream ended without an end event or if envd reported a PTY error (e.g.
+// the process was killed).
 func (h *PtyHandle) Wait(onData func([]byte)) (int, error) {
 	for chunk := range h.output {
 		if onData != nil {

--- a/sdk/go/pty_test.go
+++ b/sdk/go/pty_test.go
@@ -137,9 +137,11 @@ func TestPtyCreateUserEnvsCwd(t *testing.T) {
 
 	sb := newPtyTestSandbox(t, server)
 	handle, err := sb.Pty().Create(context.Background(), PtySize{Rows: 10, Cols: 40}, PtyCreateOptions{
-		User: "app",
-		Cwd:  "/work",
-		Envs: map[string]string{"TERM": "vt100", "FOO": "bar"},
+		Command: "/bin/sh",
+		Args:    []string{"-l"},
+		User:    "app",
+		Cwd:     "/work",
+		Envs:    map[string]string{"TERM": "vt100", "FOO": "bar"},
 	})
 	if err != nil {
 		t.Fatalf("Create: %v", err)
@@ -153,6 +155,9 @@ func TestPtyCreateUserEnvsCwd(t *testing.T) {
 	}
 	var req ptyStartRequest
 	decodeEnvelopeJSON(t, gotBody, &req)
+	if req.Process.Cmd != "/bin/sh" || strings.Join(req.Process.Args, " ") != "-l" {
+		t.Fatalf("process=%q %v, want /bin/sh -l", req.Process.Cmd, req.Process.Args)
+	}
 	if req.Process.Cwd != "/work" {
 		t.Fatalf("cwd=%q", req.Process.Cwd)
 	}

--- a/sdk/go/sdk_test.go
+++ b/sdk/go/sdk_test.go
@@ -22,6 +22,24 @@ import (
 
 const testSandboxID = "sb-test-001"
 
+func TestAttachBuildsDataPlaneHandleWithoutControlRequest(t *testing.T) {
+	client := NewClient(Config{SandboxDomain: "sandbox.test"})
+
+	sandbox, err := client.Attach("  sb-existing  ")
+	if err != nil {
+		t.Fatalf("Attach: %v", err)
+	}
+	if sandbox.SandboxID != "sb-existing" {
+		t.Fatalf("SandboxID=%q, want sb-existing", sandbox.SandboxID)
+	}
+	if got := sandbox.GetHost(EnvdPort); got != "49983-sb-existing.sandbox.test" {
+		t.Fatalf("GetHost=%q", got)
+	}
+	if _, err := client.Attach("  "); err == nil {
+		t.Fatal("Attach accepted an empty sandbox ID")
+	}
+}
+
 func TestNewConfigFromEnv(t *testing.T) {
 	clearEnv(t)
 

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -22,6 +22,8 @@
         "@radix-ui/react-toast": "^1.2.2",
         "@radix-ui/react-tooltip": "^1.1.3",
         "@tanstack/react-query": "^5.59.0",
+        "@xterm/addon-fit": "^0.11.0",
+        "@xterm/xterm": "^6.0.0",
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.1.1",
         "cmdk": "^1.0.0",
@@ -37,19 +39,30 @@
         "zustand": "^5.0.0"
       },
       "devDependencies": {
+        "@testing-library/jest-dom": "^6.9.1",
+        "@testing-library/react": "^16.3.2",
         "@types/node": "^22.9.0",
         "@types/react": "^18.3.12",
         "@types/react-dom": "^18.3.1",
         "@vitejs/plugin-react": "^4.3.3",
         "autoprefixer": "^10.4.20",
+        "jsdom": "^26.1.0",
         "msw": "^2.13.5",
         "openapi-typescript": "^7.13.0",
         "postcss": "^8.4.47",
         "prettier": "^3.9.5",
         "tailwindcss": "^3.4.14",
         "typescript": "^5.6.3",
-        "vite": "^6.4.2"
+        "vite": "^6.4.2",
+        "vitest": "^3.2.7"
       }
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.5.0.tgz",
+      "integrity": "sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@alloc/quick-lru": {
       "version": "5.2.0",
@@ -62,6 +75,27 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
+      "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^2.1.3",
+        "@csstools/css-color-parser": "^3.0.9",
+        "@csstools/css-parser-algorithms": "^3.0.4",
+        "@csstools/css-tokenizer": "^3.0.3",
+        "lru-cache": "^10.4.3"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",
@@ -352,6 +386,121 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^5.1.0",
+        "@csstools/css-calc": "^2.1.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@dicebear/adventurer": {
@@ -2846,6 +2995,90 @@
         "react": "^18 || ^19"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
+      "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -2890,6 +3123,24 @@
       "dependencies": {
         "@babel/types": "^7.28.2"
       }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -2980,6 +3231,136 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.7.tgz",
+      "integrity": "sha512-E8eBXaKibuvH2pSZErOjdVb5vF4PbKYcrnluBTYxEk1l/VhhwZg1kZQsdtjq+CsF5CFydf2Rdkz7jDHKSisi3w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.7",
+        "@vitest/utils": "3.2.7",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.7.tgz",
+      "integrity": "sha512-Trr0hYO9CM3Wj6ksWHRhK9IZpIY6wTMO5u/MqXurMxT57sWBaOPEtP3Oq60ihZuh5JsiagKfz95OcxdEP6dBrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.7",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.7.tgz",
+      "integrity": "sha512-KUHlwqVu0sRlhCdyPdQ/wBoTfRahjUky1MubOmYw9fWfIZy1gNoHpuaaQBPAaMaVYdQYHJLurzj8ECCj5OwTqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.7.tgz",
+      "integrity": "sha512-sB9y4ovltoQP+WaUPwmSxO9WIg9Ig694Di5PalVPsYHklAdE027mehpWF2SQSVq+k6sFgaivbTjTJwZLSHbedA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.7",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.7.tgz",
+      "integrity": "sha512-7C+MwShwtBSI5Buwoyg3s/iY1eHL9PKAf+O1wVh/TdnjXUtkoL/9YQtre90i4MtNXM6edP1wJ2zOBpfCyhIS7g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.7",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.7.tgz",
+      "integrity": "sha512-Q2eQGI6d2L/hBtZ0qNuKcAGid68XK6cv1xsoaIma6PaJhHPoqcEJhYpXZ/5myCMqkNgtP6UKuBhbc0nHKnrkuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.7.tgz",
+      "integrity": "sha512-x6BDOd7dyo3PFLY3I9/HJ25X/6OurhGXk2/B9gOZNPF7XDVjeBK4k01lQE5uvDpbuheErh91qYuE1E2OEjK3Rw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.7",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@xterm/addon-fit": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@xterm/addon-fit/-/addon-fit-0.11.0.tgz",
+      "integrity": "sha512-jYcgT6xtVYhnhgxh3QgYDnnNMYTcf8ElbxxFzX0IZo+vabQqSPAjC3c1wJrKB5E19VwQei89QCiZZP86DCPF7g==",
+      "license": "MIT"
+    },
+    "node_modules/@xterm/xterm": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@xterm/xterm/-/xterm-6.0.0.tgz",
+      "integrity": "sha512-TQwDdQGtwwDt+2cgKDLn0IRaSxYu1tSUjgKarSDkUM0ZNiSRXFpjxEsvc/Zgc5kq5omJ+V0a8/kIM2WD3sMOYg==",
+      "license": "MIT",
+      "workspaces": [
+        "addons/*"
+      ]
+    },
     "node_modules/agent-base": {
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
@@ -3068,6 +3449,26 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/autoprefixer": {
@@ -3195,6 +3596,16 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/camelcase-css": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
@@ -3225,12 +3636,39 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/change-case": {
       "version": "5.4.4",
       "resolved": "https://registry.npmjs.org/change-case/-/change-case-5.4.4.tgz",
       "integrity": "sha512-HRQyTk2/YPEkt9TnUPbOpr64Uw3KOicFWPVBb+xiHvd6eBx/qPr9xqfBFDT8P2vWsvvz4jbEkfDe71W3VyNu2w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
     },
     "node_modules/chokidar": {
       "version": "3.6.0",
@@ -3387,6 +3825,13 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cssesc": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
@@ -3399,12 +3844,40 @@
         "node": ">=4"
       }
     },
+    "node_modules/cssstyle": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
+      "integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^3.2.0",
+        "rrweb-cssom": "^0.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/data-urls": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -3422,6 +3895,33 @@
         "supports-color": {
           "optional": true
         }
+      }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/detect-node-es": {
@@ -3442,6 +3942,14 @@
       "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
       "license": "MIT"
     },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.340",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.340.tgz",
@@ -3456,6 +3964,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/es-errors": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
@@ -3464,6 +3985,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/esbuild": {
       "version": "0.25.12",
@@ -3515,6 +4043,26 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -3711,6 +4259,19 @@
         "set-cookie-parser": "^3.0.1"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/html-parse-stringify": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/html-parse-stringify/-/html-parse-stringify-3.0.1.tgz",
@@ -3718,6 +4279,20 @@
       "license": "MIT",
       "dependencies": {
         "void-elements": "3.1.0"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/https-proxy-agent": {
@@ -3772,6 +4347,29 @@
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.23.2"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/index-to-position": {
@@ -3861,6 +4459,13 @@
         "node": ">=0.12.0"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/jiti": {
       "version": "1.21.7",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
@@ -3897,6 +4502,79 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "26.1.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-26.1.0.tgz",
+      "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssstyle": "^4.2.1",
+        "data-urls": "^5.0.0",
+        "decimal.js": "^10.5.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.6",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.16",
+        "parse5": "^7.2.1",
+        "rrweb-cssom": "^0.8.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^5.1.1",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.1.1",
+        "ws": "^8.18.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/tldts": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
+      "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^6.1.86"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/jsdom/node_modules/tldts-core": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
+      "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jsdom/node_modules/tough-cookie": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
+      "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^6.1.32"
+      },
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/jsesc": {
@@ -3962,6 +4640,13 @@
         "loose-envify": "cli.js"
       }
     },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -3979,6 +4664,27 @@
       "license": "ISC",
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
     "node_modules/merge2": {
@@ -4001,6 +4707,16 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/minimatch": {
@@ -4123,6 +4839,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/nwsapi": {
+      "version": "2.2.24",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.24.tgz",
+      "integrity": "sha512-7YRhZ3jS45LwmSCT4b2sVFHt/WuovaktDU07QrtOBY2PXskss5a9jfmR9jptyumwXST+rFjrmppMY1KT/yn35A==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -4200,6 +4923,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/path-parse": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
@@ -4212,6 +4948,23 @@
       "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -4431,6 +5184,46 @@
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -4502,6 +5295,14 @@
           "optional": true
         }
       }
+    },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/react-refresh": {
       "version": "0.17.0",
@@ -4635,6 +5436,20 @@
         "node": ">=8.10.0"
       }
     },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -4738,6 +5553,13 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/rrweb-cssom": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -4759,6 +5581,26 @@
       "license": "MIT",
       "dependencies": {
         "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
       }
     },
     "node_modules/scheduler": {
@@ -4787,6 +5629,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/signal-exit": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -4809,6 +5658,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -4818,6 +5674,13 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/strict-event-emitter": {
       "version": "0.5.1",
@@ -4853,6 +5716,39 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/strip-literal/node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/sucrase": {
       "version": "3.35.1",
@@ -4900,6 +5796,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/tagged-tag": {
       "version": "1.0.0",
@@ -4991,6 +5894,20 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.16",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
@@ -5036,6 +5953,36 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/tldts": {
       "version": "7.0.28",
       "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.28.tgz",
@@ -5079,6 +6026,19 @@
       },
       "engines": {
         "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/ts-interface-checker": {
@@ -5311,6 +6271,29 @@
         }
       }
     },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/vite/node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -5342,6 +6325,92 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/vitest": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.7.tgz",
+      "integrity": "sha512-KrxIJ62Fd89gfysR4WotlgZABiz2dqFPgqGzX7s+CwsqLFomRH7777ZcrOD6+WVAh7khPQP41A+BKbpcJFrdEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.7",
+        "@vitest/mocker": "3.2.7",
+        "@vitest/pretty-format": "^3.2.7",
+        "@vitest/runner": "3.2.7",
+        "@vitest/snapshot": "3.2.7",
+        "@vitest/spy": "3.2.7",
+        "@vitest/utils": "3.2.7",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.7",
+        "@vitest/ui": "3.2.7",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/void-elements": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-3.1.0.tgz",
@@ -5349,6 +6418,84 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/wrap-ansi": {
@@ -5368,6 +6515,45 @@
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
+    },
+    "node_modules/ws": {
+      "version": "8.21.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/y18n": {
       "version": "5.0.8",

--- a/web/package.json
+++ b/web/package.json
@@ -8,6 +8,7 @@
     "build": "tsc -b --noEmit && vite build",
     "preview": "vite preview",
     "lint": "tsc -b --noEmit",
+    "test": "vitest run",
     "fmt": "prettier --write .",
     "api:export": "cargo run --manifest-path ../CubeAPI/Cargo.toml -- --export-openapi ../openapi.yml",
     "api:generate": "openapi-typescript ../openapi.yml -o src/api/generated/schema.ts",
@@ -28,6 +29,8 @@
     "@radix-ui/react-toast": "^1.2.2",
     "@radix-ui/react-tooltip": "^1.1.3",
     "@tanstack/react-query": "^5.59.0",
+    "@xterm/addon-fit": "^0.11.0",
+    "@xterm/xterm": "^6.0.0",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",
     "cmdk": "^1.0.0",
@@ -43,18 +46,22 @@
     "zustand": "^5.0.0"
   },
   "devDependencies": {
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
     "@types/node": "^22.9.0",
     "@types/react": "^18.3.12",
     "@types/react-dom": "^18.3.1",
     "@vitejs/plugin-react": "^4.3.3",
     "autoprefixer": "^10.4.20",
+    "jsdom": "^26.1.0",
     "msw": "^2.13.5",
     "openapi-typescript": "^7.13.0",
     "postcss": "^8.4.47",
     "prettier": "^3.9.5",
     "tailwindcss": "^3.4.14",
     "typescript": "^5.6.3",
-    "vite": "^6.4.2"
+    "vite": "^6.4.2",
+    "vitest": "^3.2.7"
   },
   "msw": {
     "workerDirectory": [

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -21,6 +21,12 @@ export interface RunningSandbox extends ListedSandboxDto {}
 
 export interface SandboxDetail extends SandboxDetailDto {}
 
+export interface TerminalSessionResponse {
+  grant: string;
+  protocol: string;
+  websocketURL: string;
+}
+
 export interface TemplateSummary {
   templateID: string;
   instanceType?: string | null;
@@ -219,6 +225,10 @@ export const sandboxApi = {
     }),
   logs: (id: string, params?: { cursor?: number; limit?: number; direction?: string }) =>
     api<SandboxLogsDto>(`/v2/sandboxes/${id}/logs`, { params }),
+  createTerminalSession: (id: string) =>
+    ops<TerminalSessionResponse>(`/terminal/sandboxes/${encodeURIComponent(id)}/sessions`, {
+      method: 'POST',
+    }),
   create: (body: { templateID: string; timeout?: number; metadata?: Record<string, string> }) =>
     api<SandboxSessionDto>('/sandboxes', {
       method: 'POST',

--- a/web/src/components/TerminalDialog.test.tsx
+++ b/web/src/components/TerminalDialog.test.tsx
@@ -1,0 +1,382 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2026 Tencent. All rights reserved.
+
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { sandboxApi } from '@/api/client';
+import { TerminalDialog } from './TerminalDialog';
+
+const terminalMocks = vi.hoisted(() => {
+  const instances: Array<{
+    rows: number;
+    cols: number;
+    options: Record<string, unknown>;
+    writes: string[];
+    customKeyHandler?: (event: KeyboardEvent) => boolean;
+    selection: string;
+    emitData(data: string): void;
+    paste(data: string): void;
+    reset: ReturnType<typeof vi.fn>;
+    focus: ReturnType<typeof vi.fn>;
+    dispose: ReturnType<typeof vi.fn>;
+  }> = [];
+
+  const translate = (key: string, options?: Record<string, unknown>) => {
+    const values: Record<string, string> = {
+      'terminal.title': `Terminal ${options?.sandboxID ?? ''}`,
+      'terminal.description': 'Interactive shell',
+      'terminal.mainContainerOnly': 'Main container only',
+      'terminal.empty': 'No terminal tabs are open.',
+      'terminal.status.connecting': 'Connecting',
+      'terminal.status.connected': 'Connected',
+      'terminal.status.closed': 'Terminal closed',
+      'terminal.status.connectionLost': 'Connection lost. Reconnect.',
+      'terminal.status.connectionLostReason': `Connection lost: ${options?.reason}. Reconnect.`,
+      'terminal.status.error': 'Terminal error',
+      'terminal.status.protocolError': 'Protocol error',
+      'terminal.status.exited': `Exited ${options?.code ?? 0}`,
+      'terminal.status.sessionLimit': 'Maximum 5 terminal tabs',
+      'terminal.status.clipboardError': 'Clipboard error',
+      'terminal.status.newShell': 'Starting a new shell',
+      'terminal.tabs.list': 'Terminal sessions',
+      'terminal.tabs.label': `Shell ${options?.index ?? ''}`,
+      'terminal.tabs.new': 'New terminal session',
+      'terminal.tabs.close': `Close ${options?.label ?? ''}`,
+      'terminal.actions.copy': 'Copy',
+      'terminal.actions.paste': 'Paste',
+      'terminal.actions.reconnect': 'Reconnect',
+      'terminal.actions.close': 'Close terminal',
+    };
+    return values[key] ?? key;
+  };
+
+  return {
+    instances,
+    createTerminalSession: vi.fn(),
+    translate,
+    Terminal: class {
+      rows = 24;
+      cols = 80;
+      options: Record<string, unknown>;
+      writes: string[] = [];
+      selection = '';
+      customKeyHandler?: (event: KeyboardEvent) => boolean;
+      private dataHandlers: Array<(data: string) => void> = [];
+
+      constructor(options: Record<string, unknown>) {
+        this.options = options;
+        instances.push(this);
+      }
+
+      loadAddon() {}
+
+      open(host: HTMLElement) {
+        const element = document.createElement('div');
+        element.className = 'xterm';
+        host.appendChild(element);
+      }
+
+      attachCustomKeyEventHandler(handler: (event: KeyboardEvent) => boolean) {
+        this.customKeyHandler = handler;
+      }
+
+      onData(handler: (data: string) => void) {
+        this.dataHandlers.push(handler);
+        return { dispose: vi.fn() };
+      }
+
+      emitData(data: string) {
+        this.dataHandlers.forEach((handler) => handler(data));
+      }
+
+      paste(data: string) {
+        this.emitData(data);
+      }
+
+      write(data: Uint8Array | string) {
+        this.writes.push(typeof data === 'string' ? data : new TextDecoder().decode(data));
+      }
+
+      writeln(data: string) {
+        this.writes.push(data);
+      }
+
+      getSelection() {
+        return this.selection;
+      }
+
+      reset = vi.fn();
+      focus = vi.fn();
+      dispose = vi.fn();
+    },
+  };
+});
+
+vi.mock('@/api/client', () => ({
+  sandboxApi: {
+    createTerminalSession: terminalMocks.createTerminalSession,
+  },
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: terminalMocks.translate,
+  }),
+}));
+
+vi.mock('@xterm/addon-fit', () => ({
+  FitAddon: class {
+    fit = vi.fn();
+  },
+}));
+
+vi.mock('@xterm/xterm', () => ({
+  Terminal: terminalMocks.Terminal,
+}));
+
+class MockWebSocket {
+  static CONNECTING = 0;
+  static OPEN = 1;
+  static CLOSING = 2;
+  static CLOSED = 3;
+  static instances: MockWebSocket[] = [];
+
+  binaryType = '';
+  readyState = MockWebSocket.CONNECTING;
+  sent: unknown[] = [];
+  closed = false;
+  onopen: (() => void) | null = null;
+  onmessage: ((event: MessageEvent) => void) | null = null;
+  onclose: ((event: CloseEvent) => void) | null = null;
+
+  constructor(
+    public url: string,
+    public protocols?: string | string[],
+  ) {
+    MockWebSocket.instances.push(this);
+  }
+
+  send(data: unknown) {
+    this.sent.push(data);
+  }
+
+  close(code = 1000, reason = '') {
+    if (this.readyState === MockWebSocket.CLOSED) return;
+    this.closed = true;
+    this.readyState = MockWebSocket.CLOSED;
+    this.onclose?.(closeEvent(code, reason, true));
+  }
+
+  open() {
+    this.readyState = MockWebSocket.OPEN;
+    this.onopen?.();
+  }
+
+  message(data: string | ArrayBuffer) {
+    this.onmessage?.(new MessageEvent('message', { data }));
+  }
+
+  serverClose(code: number, reason = '') {
+    this.readyState = MockWebSocket.CLOSED;
+    this.onclose?.(closeEvent(code, reason, terminalClean(code)));
+  }
+}
+
+function closeEvent(code: number, reason: string, wasClean: boolean): CloseEvent {
+  const event = new Event('close') as CloseEvent;
+  Object.defineProperties(event, {
+    code: { value: code },
+    reason: { value: reason },
+    wasClean: { value: wasClean },
+  });
+  return event;
+}
+
+function terminalClean(code: number): boolean {
+  return code === 1000 || code === 1001;
+}
+
+function decodeBinary(value: unknown): string {
+  return new TextDecoder().decode(value as Uint8Array);
+}
+
+function renderTerminal(overrides: Partial<React.ComponentProps<typeof TerminalDialog>> = {}) {
+  const props = {
+    open: true,
+    onOpenChange: vi.fn(),
+    sandboxID: 'sandbox-1',
+    ...overrides,
+  };
+  return render(<TerminalDialog {...props} />);
+}
+
+beforeEach(() => {
+  terminalMocks.instances.length = 0;
+  MockWebSocket.instances.length = 0;
+  terminalMocks.createTerminalSession.mockReset();
+  let grantSequence = 0;
+  terminalMocks.createTerminalSession.mockImplementation(async () => {
+    grantSequence += 1;
+    return {
+      grant: `grant-${grantSequence}`,
+      protocol: 'cube-terminal.v1',
+      websocketURL: '/opsapi/v1/terminal/sandboxes/sandbox-1/ws',
+    };
+  });
+  vi.stubGlobal('WebSocket', MockWebSocket);
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe('TerminalDialog', () => {
+  it('opens the first shell and bridges resize, input, and output', async () => {
+    renderTerminal();
+
+    await waitFor(() => expect(sandboxApi.createTerminalSession).toHaveBeenCalledWith('sandbox-1'));
+    expect(screen.getByRole('tab', { name: 'Shell 1' })).toHaveAttribute('aria-selected', 'true');
+    expect(terminalMocks.instances[0].options.scrollback).toBe(5000);
+
+    const socket = MockWebSocket.instances[0];
+    expect(socket.url).toBe('ws://localhost/opsapi/v1/terminal/sandboxes/sandbox-1/ws');
+    expect(socket.protocols).toEqual(['cube-terminal.v1', 'cube-terminal.grant.grant-1']);
+    socket.open();
+    socket.message(JSON.stringify({ type: 'status', message: 'connected' }));
+
+    await waitFor(() =>
+      expect(socket.sent).toContainEqual(JSON.stringify({ type: 'resize', rows: 24, cols: 80 })),
+    );
+    expect(screen.getByText('Connected')).toBeInTheDocument();
+
+    terminalMocks.instances[0].emitData('ls\r');
+    expect(decodeBinary(socket.sent.at(-1))).toBe('ls\r');
+    const output = new window.ArrayBuffer(14);
+    new Uint8Array(output).set(new TextEncoder().encode('\u001b[32mgreen\u001b[0m'));
+    socket.message(output);
+    await waitFor(() =>
+      expect(terminalMocks.instances[0].writes).toContain('\u001b[32mgreen\u001b[0m'),
+    );
+  });
+
+  it('keeps up to five terminal tabs isolated and closes only one tab', async () => {
+    renderTerminal();
+    await waitFor(() => expect(sandboxApi.createTerminalSession).toHaveBeenCalledTimes(1));
+
+    for (let count = 2; count <= 5; count += 1) {
+      fireEvent.click(screen.getByTitle('New terminal session'));
+      await waitFor(() => expect(sandboxApi.createTerminalSession).toHaveBeenCalledTimes(count));
+    }
+    expect(screen.getByTitle('Maximum 5 terminal tabs')).toBeDisabled();
+    expect(MockWebSocket.instances).toHaveLength(5);
+
+    MockWebSocket.instances.forEach((socket) => {
+      socket.open();
+      socket.message(JSON.stringify({ type: 'status' }));
+    });
+    terminalMocks.instances[0].emitData('first\r');
+    terminalMocks.instances[4].emitData('fifth\r');
+    expect(decodeBinary(MockWebSocket.instances[0].sent.at(-1))).toBe('first\r');
+    expect(decodeBinary(MockWebSocket.instances[4].sent.at(-1))).toBe('fifth\r');
+
+    fireEvent.click(screen.getByTitle('Close Shell 5'));
+    await waitFor(() =>
+      expect(screen.queryByRole('tab', { name: 'Shell 5' })).not.toBeInTheDocument(),
+    );
+    expect(MockWebSocket.instances[4].closed).toBe(true);
+    expect(MockWebSocket.instances[0].closed).toBe(false);
+    expect(screen.getByRole('tab', { name: 'Shell 4' })).toHaveAttribute('aria-selected', 'true');
+  });
+
+  it('waits for manual reconnect and obtains a fresh grant for a new shell', async () => {
+    const onSessionActiveChange = vi.fn();
+    renderTerminal({ onSessionActiveChange });
+    await waitFor(() => expect(sandboxApi.createTerminalSession).toHaveBeenCalledTimes(1));
+    const first = MockWebSocket.instances[0];
+    first.open();
+    first.message(JSON.stringify({ type: 'status' }));
+    await waitFor(() => expect(screen.getByText('Connected')).toBeInTheDocument());
+
+    first.serverClose(1011, 'upstream reset');
+    await waitFor(() =>
+      expect(screen.getByText('Connection lost: upstream reset. Reconnect.')).toBeInTheDocument(),
+    );
+    expect(sandboxApi.createTerminalSession).toHaveBeenCalledTimes(1);
+    expect(onSessionActiveChange).toHaveBeenLastCalledWith(false);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Reconnect' }));
+    await waitFor(() => expect(sandboxApi.createTerminalSession).toHaveBeenCalledTimes(2));
+    expect(terminalMocks.instances[0].reset).toHaveBeenCalledTimes(1);
+    expect(MockWebSocket.instances[1].protocols).toEqual([
+      'cube-terminal.v1',
+      'cube-terminal.grant.grant-2',
+    ]);
+    expect(onSessionActiveChange).toHaveBeenLastCalledWith(true);
+  });
+
+  it('supports explicit and Ctrl/Cmd+Shift clipboard operations', async () => {
+    const clipboard = {
+      readText: vi.fn().mockResolvedValue('pasted text'),
+      writeText: vi.fn().mockResolvedValue(undefined),
+    };
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: clipboard,
+    });
+    renderTerminal();
+    await waitFor(() => expect(sandboxApi.createTerminalSession).toHaveBeenCalledTimes(1));
+    const socket = MockWebSocket.instances[0];
+    socket.open();
+    socket.message(JSON.stringify({ type: 'status' }));
+    await waitFor(() => expect(screen.getByText('Connected')).toBeInTheDocument());
+
+    const terminal = terminalMocks.instances[0];
+    terminal.selection = 'selected text';
+    fireEvent.click(screen.getByRole('button', { name: 'Copy' }));
+    await waitFor(() => expect(clipboard.writeText).toHaveBeenCalledWith('selected text'));
+    fireEvent.click(screen.getByRole('button', { name: 'Paste' }));
+    await waitFor(() => expect(clipboard.readText).toHaveBeenCalledTimes(1));
+    expect(decodeBinary(socket.sent.at(-1))).toBe('pasted text');
+
+    terminal.selection = 'shortcut selection';
+    expect(
+      terminal.customKeyHandler?.({
+        key: 'c',
+        ctrlKey: true,
+        metaKey: false,
+        shiftKey: true,
+      } as KeyboardEvent),
+    ).toBe(false);
+    await waitFor(() => expect(clipboard.writeText).toHaveBeenCalledWith('shortcut selection'));
+
+    expect(
+      terminal.customKeyHandler?.({
+        key: 'v',
+        ctrlKey: false,
+        metaKey: true,
+        shiftKey: true,
+      } as KeyboardEvent),
+    ).toBe(false);
+    await waitFor(() => expect(clipboard.readText).toHaveBeenCalledTimes(2));
+  });
+
+  it('shows protocol errors and cleans every connection on unmount', async () => {
+    const rendered = renderTerminal();
+    await waitFor(() => expect(sandboxApi.createTerminalSession).toHaveBeenCalledTimes(1));
+    fireEvent.click(screen.getByTitle('New terminal session'));
+    await waitFor(() => expect(sandboxApi.createTerminalSession).toHaveBeenCalledTimes(2));
+    MockWebSocket.instances.forEach((socket) => socket.open());
+    MockWebSocket.instances[0].message('not-json');
+    fireEvent.click(screen.getByRole('tab', { name: 'Shell 1' }));
+    await waitFor(() => expect(screen.getByText('Protocol error')).toBeInTheDocument());
+
+    rendered.unmount();
+    expect(MockWebSocket.instances.every((socket) => socket.closed)).toBe(true);
+    expect(
+      terminalMocks.instances.every((terminal) => terminal.dispose.mock.calls.length === 1),
+    ).toBe(true);
+  });
+});

--- a/web/src/components/TerminalDialog.tsx
+++ b/web/src/components/TerminalDialog.tsx
@@ -1,0 +1,539 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2026 Tencent. All rights reserved.
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import * as Dialog from '@radix-ui/react-dialog';
+import { FitAddon } from '@xterm/addon-fit';
+import { Terminal } from '@xterm/xterm';
+import '@xterm/xterm/css/xterm.css';
+import { ClipboardPaste, Copy, Plus, RefreshCw, TerminalSquare, X } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+
+import { sandboxApi } from '@/api/client';
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+
+type TerminalStatus = 'connecting' | 'connected' | 'closed' | 'error';
+
+interface TerminalDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onSessionActiveChange?: (active: boolean) => void;
+  sandboxID: string;
+}
+
+interface TerminalFrame {
+  type?: string;
+  message?: string;
+  exitCode?: number;
+}
+
+interface TerminalSessionState {
+  id: string;
+  index: number;
+  status: TerminalStatus;
+  message: string;
+  connectionAttempt: number;
+}
+
+interface TerminalSessionPaneProps {
+  active: boolean;
+  sandboxID: string;
+  session: TerminalSessionState;
+  onReconnect: (id: string) => void;
+  onStatusChange: (id: string, status: TerminalStatus, message: string) => void;
+}
+
+const terminalMaxSessions = 5;
+const terminalGrantProtocolPrefix = 'cube-terminal.grant.';
+const terminalCleanCloseCodes = new Set([1000, 1001]);
+
+export function TerminalDialog({
+  open,
+  onOpenChange,
+  onSessionActiveChange,
+  sandboxID,
+}: TerminalDialogProps): JSX.Element {
+  const { t } = useTranslation('sandboxDetail');
+  const sequenceRef = useRef(0);
+  const translationRef = useRef(t);
+  const [sessions, setSessions] = useState<TerminalSessionState[]>([]);
+  const [activeSessionID, setActiveSessionID] = useState('');
+  translationRef.current = t;
+
+  const createSessionState = useCallback((): TerminalSessionState => {
+    sequenceRef.current += 1;
+    return {
+      id: `terminal-${sequenceRef.current}`,
+      index: sequenceRef.current,
+      status: 'connecting',
+      message: translationRef.current('terminal.status.connecting'),
+      connectionAttempt: 0,
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!open) {
+      setSessions([]);
+      setActiveSessionID('');
+      return;
+    }
+    const session = createSessionState();
+    setSessions([session]);
+    setActiveSessionID(session.id);
+  }, [createSessionState, open, sandboxID]);
+
+  const hasActiveSession = useMemo(
+    () =>
+      sessions.some((session) => session.status === 'connecting' || session.status === 'connected'),
+    [sessions],
+  );
+
+  useEffect(() => {
+    onSessionActiveChange?.(hasActiveSession);
+  }, [hasActiveSession, onSessionActiveChange]);
+
+  useEffect(
+    () => () => {
+      onSessionActiveChange?.(false);
+    },
+    [onSessionActiveChange],
+  );
+
+  const addSession = () => {
+    if (sessions.length >= terminalMaxSessions) return;
+    const session = createSessionState();
+    setSessions((current) =>
+      current.length >= terminalMaxSessions ? current : [...current, session],
+    );
+    setActiveSessionID(session.id);
+  };
+
+  const closeSession = (id: string) => {
+    setSessions((current) => {
+      const closedIndex = current.findIndex((session) => session.id === id);
+      const next = current.filter((session) => session.id !== id);
+      if (activeSessionID === id) {
+        const fallbackIndex = Math.max(0, Math.min(closedIndex - 1, next.length - 1));
+        setActiveSessionID(next[fallbackIndex]?.id ?? '');
+      }
+      return next;
+    });
+  };
+
+  const updateSessionStatus = useCallback((id: string, status: TerminalStatus, message: string) => {
+    setSessions((current) =>
+      current.map((session) => (session.id === id ? { ...session, status, message } : session)),
+    );
+  }, []);
+
+  const reconnectSession = useCallback(
+    (id: string) => {
+      setSessions((current) =>
+        current.map((session) =>
+          session.id === id
+            ? {
+                ...session,
+                status: 'connecting',
+                message: t('terminal.status.connecting'),
+                connectionAttempt: session.connectionAttempt + 1,
+              }
+            : session,
+        ),
+      );
+    },
+    [t],
+  );
+
+  const sessionLimitReached = sessions.length >= terminalMaxSessions;
+
+  return (
+    <Dialog.Root open={open} onOpenChange={onOpenChange}>
+      <Dialog.Portal>
+        <Dialog.Overlay className="fixed inset-0 z-40 bg-black/60" />
+        <Dialog.Content
+          className="fixed inset-4 z-50 flex min-h-0 flex-col overflow-hidden rounded-lg border border-zinc-700 bg-zinc-950 shadow-2xl md:inset-8"
+          onOpenAutoFocus={(event) => event.preventDefault()}
+        >
+          <Dialog.Title className="sr-only">{t('terminal.title', { sandboxID })}</Dialog.Title>
+          <Dialog.Description className="sr-only">{t('terminal.description')}</Dialog.Description>
+
+          <div className="flex min-h-11 items-center gap-2 border-b border-zinc-800 px-3 text-zinc-200">
+            <TerminalSquare size={16} />
+            <span className="flex-1 truncate font-mono text-xs">{sandboxID}</span>
+            <span className="hidden text-[11px] text-zinc-500 sm:inline">
+              {t('terminal.mainContainerOnly')}
+            </span>
+            <Dialog.Close asChild>
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon"
+                title={t('terminal.actions.close')}
+                aria-label={t('terminal.actions.close')}
+              >
+                <X size={15} />
+              </Button>
+            </Dialog.Close>
+          </div>
+
+          <div className="flex min-h-10 items-center gap-1 overflow-x-auto border-b border-zinc-800 px-2">
+            <div role="tablist" aria-label={t('terminal.tabs.list')} className="flex gap-1">
+              {sessions.map((session) => {
+                const label = t('terminal.tabs.label', { index: session.index });
+                const selected = session.id === activeSessionID;
+                return (
+                  <div
+                    key={session.id}
+                    className={cn(
+                      'flex items-center rounded-md border text-xs',
+                      selected
+                        ? 'border-zinc-600 bg-zinc-800 text-zinc-100'
+                        : 'border-transparent text-zinc-500 hover:text-zinc-300',
+                    )}
+                  >
+                    <button
+                      type="button"
+                      role="tab"
+                      aria-selected={selected}
+                      className="px-3 py-1.5"
+                      onClick={() => setActiveSessionID(session.id)}
+                    >
+                      {label}
+                    </button>
+                    <button
+                      type="button"
+                      className="mr-1 rounded p-1 hover:bg-zinc-700"
+                      aria-label={t('terminal.tabs.close', { label })}
+                      title={t('terminal.tabs.close', { label })}
+                      onClick={() => closeSession(session.id)}
+                    >
+                      <X size={12} />
+                    </button>
+                  </div>
+                );
+              })}
+            </div>
+            <button
+              type="button"
+              className="rounded p-1.5 text-zinc-400 hover:bg-zinc-800 hover:text-zinc-100 disabled:cursor-not-allowed disabled:opacity-40"
+              aria-label={t('terminal.tabs.new')}
+              title={
+                sessionLimitReached ? t('terminal.status.sessionLimit') : t('terminal.tabs.new')
+              }
+              disabled={sessionLimitReached}
+              onClick={addSession}
+            >
+              <Plus size={14} />
+            </button>
+          </div>
+
+          <div className="min-h-0 flex-1">
+            {sessions.length === 0 ? (
+              <div className="flex h-full flex-col items-center justify-center gap-3 text-sm text-zinc-500">
+                <span>{t('terminal.empty')}</span>
+                <Button type="button" variant="outline" size="sm" onClick={addSession}>
+                  <Plus size={14} /> {t('terminal.tabs.new')}
+                </Button>
+              </div>
+            ) : null}
+            {sessions.map((session) => (
+              <TerminalSessionPane
+                key={session.id}
+                active={session.id === activeSessionID}
+                sandboxID={sandboxID}
+                session={session}
+                onReconnect={reconnectSession}
+                onStatusChange={updateSessionStatus}
+              />
+            ))}
+          </div>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}
+
+function TerminalSessionPane({
+  active,
+  sandboxID,
+  session,
+  onReconnect,
+  onStatusChange,
+}: TerminalSessionPaneProps): JSX.Element {
+  const { t } = useTranslation('sandboxDetail');
+  const [host, setHost] = useState<HTMLDivElement | null>(null);
+  const terminalRef = useRef<Terminal | null>(null);
+  const fitRef = useRef<FitAddon | null>(null);
+  const socketRef = useRef<WebSocket | null>(null);
+  const resizeTimerRef = useRef(0);
+  const connectionGenerationRef = useRef(0);
+  const callbacksRef = useRef({ onStatusChange, t });
+  const clipboardActionsRef = useRef({
+    copy: async () => {},
+    paste: async () => {},
+  });
+  callbacksRef.current = { onStatusChange, t };
+
+  const setStatus = (status: TerminalStatus, message: string) => {
+    callbacksRef.current.onStatusChange(session.id, status, message);
+  };
+
+  const sendResize = useCallback(() => {
+    const terminal = terminalRef.current;
+    const fit = fitRef.current;
+    if (!terminal || !fit) return;
+    fit.fit();
+    const socket = socketRef.current;
+    if (socket?.readyState === WebSocket.OPEN && terminal.rows > 0 && terminal.cols > 0) {
+      socket.send(JSON.stringify({ type: 'resize', rows: terminal.rows, cols: terminal.cols }));
+    }
+  }, []);
+
+  const scheduleResize = useCallback(() => {
+    window.clearTimeout(resizeTimerRef.current);
+    resizeTimerRef.current = window.setTimeout(sendResize, 80);
+  }, [sendResize]);
+
+  const copySelection = useCallback(async () => {
+    const selection = terminalRef.current?.getSelection() ?? '';
+    if (!selection) return;
+    try {
+      await navigator.clipboard.writeText(selection);
+    } catch {
+      setStatus(session.status, t('terminal.status.clipboardError'));
+    }
+  }, [session.status, t]);
+
+  const pasteClipboard = useCallback(async () => {
+    if (socketRef.current?.readyState !== WebSocket.OPEN) return;
+    try {
+      const text = await navigator.clipboard.readText();
+      if (text) {
+        terminalRef.current?.paste(text);
+        terminalRef.current?.focus();
+      }
+    } catch {
+      setStatus(session.status, t('terminal.status.clipboardError'));
+    }
+  }, [session.status, t]);
+
+  clipboardActionsRef.current = {
+    copy: copySelection,
+    paste: pasteClipboard,
+  };
+
+  useEffect(() => {
+    if (!host) return;
+    const terminal = new Terminal({
+      cursorBlink: true,
+      fontFamily: '"JetBrains Mono Variable", "JetBrains Mono", monospace',
+      fontSize: 13,
+      scrollback: 5000,
+      theme: { background: '#09090b', foreground: '#e4e4e7', cursor: '#f4f4f5' },
+    });
+    const fit = new FitAddon();
+    terminalRef.current = terminal;
+    fitRef.current = fit;
+    terminal.loadAddon(fit);
+    terminal.open(host);
+
+    terminal.attachCustomKeyEventHandler((event) => {
+      if (!(event.shiftKey && (event.ctrlKey || event.metaKey))) return true;
+      if (event.key.toLowerCase() === 'c') {
+        void clipboardActionsRef.current.copy();
+        return false;
+      }
+      if (event.key.toLowerCase() === 'v') {
+        void clipboardActionsRef.current.paste();
+        return false;
+      }
+      return true;
+    });
+
+    const input = terminal.onData((data) => {
+      const socket = socketRef.current;
+      if (socket?.readyState === WebSocket.OPEN) {
+        socket.send(new TextEncoder().encode(data));
+      }
+    });
+    const observer = new ResizeObserver(scheduleResize);
+    observer.observe(host);
+    scheduleResize();
+
+    return () => {
+      window.clearTimeout(resizeTimerRef.current);
+      observer.disconnect();
+      input.dispose();
+      const socket = socketRef.current;
+      socketRef.current = null;
+      if (socket && socket.readyState !== WebSocket.CLOSED) {
+        socket.close(1000, 'terminal tab closed');
+      }
+      terminal.dispose();
+      terminalRef.current = null;
+      fitRef.current = null;
+    };
+  }, [host, scheduleResize]);
+
+  useEffect(() => {
+    if (!active) return;
+    scheduleResize();
+    terminalRef.current?.focus();
+  }, [active, scheduleResize]);
+
+  useEffect(() => {
+    const terminal = terminalRef.current;
+    if (!host || !terminal) return;
+    const generation = connectionGenerationRef.current + 1;
+    connectionGenerationRef.current = generation;
+    const translate = callbacksRef.current.t;
+    let cancelled = false;
+    let ended = false;
+
+    const previousSocket = socketRef.current;
+    socketRef.current = null;
+    if (previousSocket && previousSocket.readyState !== WebSocket.CLOSED) {
+      previousSocket.close(1000, 'starting a new terminal shell');
+    }
+    if (session.connectionAttempt > 0) {
+      terminal.reset();
+      terminal.writeln(`\r\n${translate('terminal.status.newShell')}`);
+    }
+    setStatus('connecting', translate('terminal.status.connecting'));
+
+    const showError = (message: string) => {
+      ended = true;
+      setStatus('error', message);
+      terminal.writeln(`\r\n${message}`);
+    };
+
+    const handleControlFrame = (frame: TerminalFrame, socket: WebSocket) => {
+      if (frame.type === 'status') {
+        setStatus('connected', translate('terminal.status.connected'));
+        return;
+      }
+      if (frame.type === 'exit') {
+        ended = true;
+        const message = translate('terminal.status.exited', { code: frame.exitCode ?? 0 });
+        setStatus('closed', message);
+        return;
+      }
+      if (frame.type === 'error') {
+        showError(frame.message || translate('terminal.status.error'));
+        return;
+      }
+      showError(translate('terminal.status.protocolError'));
+      socket.close(1002, 'invalid terminal protocol response');
+    };
+
+    const connect = async () => {
+      try {
+        const grant = await sandboxApi.createTerminalSession(sandboxID);
+        if (cancelled || connectionGenerationRef.current !== generation) return;
+        const socket = new WebSocket(toWebSocketURL(grant.websocketURL), [
+          grant.protocol,
+          `${terminalGrantProtocolPrefix}${grant.grant}`,
+        ]);
+        socket.binaryType = 'arraybuffer';
+        socketRef.current = socket;
+        socket.onopen = () => {
+          if (cancelled || connectionGenerationRef.current !== generation) return;
+          sendResize();
+          terminal.focus();
+        };
+        socket.onmessage = (event) => {
+          if (cancelled || connectionGenerationRef.current !== generation) return;
+          if (event.data instanceof ArrayBuffer) {
+            terminal.write(new Uint8Array(event.data));
+            return;
+          }
+          try {
+            handleControlFrame(JSON.parse(String(event.data)) as TerminalFrame, socket);
+          } catch {
+            showError(translate('terminal.status.protocolError'));
+            socket.close(1002, 'invalid terminal protocol response');
+          }
+        };
+        socket.onclose = (event) => {
+          if (cancelled || ended || connectionGenerationRef.current !== generation) {
+            return;
+          }
+          if (terminalCleanCloseCodes.has(event.code)) {
+            setStatus('closed', event.reason || translate('terminal.status.closed'));
+            return;
+          }
+          const message = event.reason
+            ? translate('terminal.status.connectionLostReason', { reason: event.reason })
+            : translate('terminal.status.connectionLost');
+          showError(message);
+        };
+      } catch (error) {
+        if (cancelled || connectionGenerationRef.current !== generation) return;
+        showError(error instanceof Error ? error.message : translate('terminal.status.error'));
+      }
+    };
+
+    void connect();
+    return () => {
+      cancelled = true;
+      const socket = socketRef.current;
+      if (socket && socket.readyState !== WebSocket.CLOSED) {
+        socket.close(1000, 'terminal connection replaced');
+      }
+      if (socketRef.current === socket) {
+        socketRef.current = null;
+      }
+    };
+  }, [host, sandboxID, sendResize, session.connectionAttempt, session.id]);
+
+  const reconnectAvailable = session.status === 'closed' || session.status === 'error';
+
+  return (
+    <div className={cn('h-full min-h-0 flex-col', active ? 'flex' : 'hidden')}>
+      <div className="flex min-h-10 items-center gap-1 border-b border-zinc-800 px-2">
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          title={t('terminal.actions.copy')}
+          aria-label={t('terminal.actions.copy')}
+          onClick={() => void copySelection()}
+        >
+          <Copy size={14} /> {t('terminal.actions.copy')}
+        </Button>
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          title={t('terminal.actions.paste')}
+          aria-label={t('terminal.actions.paste')}
+          disabled={session.status !== 'connected'}
+          onClick={() => void pasteClipboard()}
+        >
+          <ClipboardPaste size={14} /> {t('terminal.actions.paste')}
+        </Button>
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          title={t('terminal.actions.reconnect')}
+          aria-label={t('terminal.actions.reconnect')}
+          disabled={!reconnectAvailable}
+          onClick={() => onReconnect(session.id)}
+        >
+          <RefreshCw size={14} /> {t('terminal.actions.reconnect')}
+        </Button>
+        <span className="ml-auto truncate px-2 text-xs text-zinc-400">{session.message}</span>
+      </div>
+      <div ref={setHost} className="min-h-0 flex-1 bg-[#09090b] p-2 [&_.xterm]:h-full" />
+    </div>
+  );
+}
+
+function toWebSocketURL(path: string): string {
+  const url = new URL(path, window.location.origin);
+  url.protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
+  url.host = window.location.host;
+  return url.toString();
+}

--- a/web/src/locales/en/sandboxDetail.json
+++ b/web/src/locales/en/sandboxDetail.json
@@ -41,9 +41,45 @@
     "envd": "envd"
   },
   "actions": {
+    "terminal": "Open Terminal",
     "resume": "Resume",
     "pause": "Pause",
     "kill": "Kill"
+  },
+  "terminal": {
+    "title": "Terminal · {{sandboxID}}",
+    "description": "Interactive terminal for the selected sandbox",
+    "mainContainerOnly": "Main container only",
+    "empty": "No terminal tabs are open.",
+    "unavailableLoading": "Terminal availability is being checked.",
+    "unavailableState": "Terminal is unavailable while the sandbox is {{state}}.",
+    "unavailableEnvd": "Terminal requires a running sandbox created from an envd-enabled template.",
+    "closeBeforePause": "Close all terminal tabs before pausing this sandbox.",
+    "status": {
+      "connecting": "Connecting…",
+      "connected": "Connected",
+      "closed": "Terminal closed",
+      "connectionLost": "Terminal connection lost. Reconnect to start a new shell.",
+      "connectionLostReason": "Terminal connection lost: {{reason}}. Reconnect to start a new shell.",
+      "error": "Terminal error",
+      "protocolError": "Invalid terminal protocol response",
+      "exited": "Process exited with code {{code}}",
+      "sessionLimit": "A sandbox can have at most 5 terminal tabs in this window.",
+      "clipboardError": "Clipboard access was denied by the browser.",
+      "newShell": "Starting a new shell…"
+    },
+    "tabs": {
+      "list": "Terminal sessions",
+      "label": "Shell {{index}}",
+      "new": "New terminal session",
+      "close": "Close {{label}}"
+    },
+    "actions": {
+      "copy": "Copy",
+      "paste": "Paste",
+      "reconnect": "Reconnect",
+      "close": "Close terminal"
+    }
   },
   "errors": {
     "unknown": "Unknown error",

--- a/web/src/locales/zh/sandboxDetail.json
+++ b/web/src/locales/zh/sandboxDetail.json
@@ -41,9 +41,45 @@
     "envd": "envd"
   },
   "actions": {
+    "terminal": "打开终端",
     "resume": "恢复",
     "pause": "暂停",
     "kill": "终止"
+  },
+  "terminal": {
+    "title": "终端 · {{sandboxID}}",
+    "description": "所选沙箱的交互式终端",
+    "mainContainerOnly": "当前仅支持主容器",
+    "empty": "当前没有打开的终端标签。",
+    "unavailableLoading": "正在检查终端可用性。",
+    "unavailableState": "沙箱处于 {{state}} 状态时无法使用终端。",
+    "unavailableEnvd": "终端要求沙箱正在运行，且模板已启用 envd。",
+    "closeBeforePause": "暂停沙箱前请先关闭全部终端标签。",
+    "status": {
+      "connecting": "正在连接…",
+      "connected": "已连接",
+      "closed": "终端已关闭",
+      "connectionLost": "终端连接已断开；重新连接将创建新的 shell。",
+      "connectionLostReason": "终端连接已断开：{{reason}}；重新连接将创建新的 shell。",
+      "error": "终端错误",
+      "protocolError": "终端协议响应无效",
+      "exited": "进程已退出，退出码 {{code}}",
+      "sessionLimit": "同一窗口中的沙箱终端标签最多为 5 个。",
+      "clipboardError": "浏览器拒绝了剪贴板访问。",
+      "newShell": "正在启动新的 shell…"
+    },
+    "tabs": {
+      "list": "终端会话",
+      "label": "Shell {{index}}",
+      "new": "新建终端会话",
+      "close": "关闭 {{label}}"
+    },
+    "actions": {
+      "copy": "复制",
+      "paste": "粘贴",
+      "reconnect": "重新连接",
+      "close": "关闭终端"
+    }
   },
   "errors": {
     "unknown": "未知错误",

--- a/web/src/pages/SandboxDetail.test.tsx
+++ b/web/src/pages/SandboxDetail.test.tsx
@@ -1,0 +1,186 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2026 Tencent. All rights reserved.
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+
+import { sandboxApi } from '@/api/client';
+import SandboxDetailPage from './SandboxDetail';
+
+const pageMocks = vi.hoisted(() => ({
+  get: vi.fn(),
+  logs: vi.fn(),
+  kill: vi.fn(),
+  pause: vi.fn(),
+  resume: vi.fn(),
+  translate: (key: string, options?: Record<string, unknown>) => {
+    const values: Record<string, string> = {
+      'actions.terminal': 'Open Terminal',
+      'actions.resume': 'Resume',
+      'actions.pause': 'Pause',
+      'actions.kill': 'Kill',
+      'terminal.unavailableLoading': 'Checking terminal availability',
+      'terminal.unavailableState': `Terminal unavailable while ${options?.state ?? ''}`,
+      'terminal.unavailableEnvd': 'Terminal requires envd',
+      'terminal.closeBeforePause': 'Close all terminal tabs before pausing',
+      started: `Started ${options?.time ?? ''}`,
+      resources: 'Resources',
+      runtime: 'Runtime',
+      runtimeDesc: 'Runtime details',
+      metadata: 'Metadata',
+      noMetadata: 'No metadata',
+      logs: 'Logs',
+      logsDesc: 'Recent logs',
+      logsEntries: 'entries',
+      logsRefresh: 'Refresh logs',
+      logsLoading: 'Loading logs',
+      logsEmpty: 'No logs',
+      'fields.vcpu': 'vCPU',
+      'fields.memory': 'Memory',
+      'fields.client': 'Client',
+      'fields.alias': 'Alias',
+      'fields.started': 'Started',
+      'fields.ends': 'Ends',
+      'fields.domain': 'Domain',
+      'fields.state': 'State',
+      'fields.envd': 'envd',
+    };
+    return values[key] ?? key;
+  },
+}));
+
+vi.mock('@/api/client', () => ({
+  sandboxApi: pageMocks,
+}));
+
+vi.mock('@/components/TerminalDialog', () => ({
+  TerminalDialog: ({
+    open,
+    onSessionActiveChange,
+  }: {
+    open: boolean;
+    onSessionActiveChange?: (active: boolean) => void;
+  }) => (
+    <div data-testid="terminal-dialog">
+      {String(open)}
+      <button type="button" onClick={() => onSessionActiveChange?.(true)}>
+        Mark terminal active
+      </button>
+      <button type="button" onClick={() => onSessionActiveChange?.(false)}>
+        Mark terminal inactive
+      </button>
+    </div>
+  ),
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: pageMocks.translate,
+  }),
+}));
+
+const sandboxDetail = (overrides: Record<string, unknown> = {}) => ({
+  sandboxID: 'sandbox-1',
+  templateID: 'template-1',
+  clientID: 'node-1',
+  state: 'running',
+  startedAt: '2026-07-29T00:00:00Z',
+  endAt: '2026-07-30T00:00:00Z',
+  cpuCount: '2000m',
+  memoryMB: 2048,
+  envdVersion: '0.2.0',
+  metadata: {},
+  ...overrides,
+});
+
+function renderSandboxDetail(detail?: Record<string, unknown>) {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+  if (detail) {
+    pageMocks.get.mockResolvedValue(detail);
+  }
+  pageMocks.logs.mockResolvedValue({ logs: [] });
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={['/sandboxes/sandbox-1']}>
+        <Routes>
+          <Route path="/sandboxes/:sandboxID" element={<SandboxDetailPage />} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+beforeEach(() => {
+  pageMocks.get.mockReset();
+  pageMocks.logs.mockReset();
+  pageMocks.kill.mockReset();
+  pageMocks.pause.mockReset();
+  pageMocks.resume.mockReset();
+});
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe('SandboxDetail terminal entry', () => {
+  it('enables and opens the terminal for a running envd sandbox', async () => {
+    renderSandboxDetail(sandboxDetail());
+    const button = await screen.findByRole('button', { name: 'Open Terminal' });
+    await waitFor(() => expect(button).toBeEnabled());
+    fireEvent.click(button);
+    await waitFor(() => expect(screen.getByTestId('terminal-dialog')).toHaveTextContent('true'));
+  });
+
+  it('keeps the terminal entry visible with a state-specific disabled reason', async () => {
+    renderSandboxDetail(sandboxDetail({ state: 'paused' }));
+    const button = await screen.findByRole('button', { name: 'Open Terminal' });
+    await waitFor(() => {
+      expect(button).toBeDisabled();
+      expect(button).toHaveAttribute('title', 'Terminal unavailable while paused');
+    });
+  });
+
+  it('keeps the terminal entry visible when envd is unavailable', async () => {
+    renderSandboxDetail(sandboxDetail({ envdVersion: '' }));
+    const button = await screen.findByRole('button', { name: 'Open Terminal' });
+    await waitFor(() => {
+      expect(button).toBeDisabled();
+      expect(button).toHaveAttribute('title', 'Terminal requires envd');
+    });
+  });
+
+  it('shows a disabled terminal entry while details are loading', async () => {
+    pageMocks.get.mockReturnValue(new Promise(() => {}));
+    renderSandboxDetail();
+    const button = await screen.findByRole('button', { name: 'Open Terminal' });
+    expect(button).toBeDisabled();
+    expect(button).toHaveAttribute('title', 'Checking terminal availability');
+  });
+
+  it('blocks pause while any terminal session is active', async () => {
+    pageMocks.pause.mockResolvedValue(undefined);
+    renderSandboxDetail(sandboxDetail());
+    const terminalButton = await screen.findByRole('button', { name: 'Open Terminal' });
+    await waitFor(() => expect(terminalButton).toBeEnabled());
+    fireEvent.click(terminalButton);
+    fireEvent.click(await screen.findByRole('button', { name: 'Mark terminal active' }));
+
+    const pauseButton = screen.getByRole('button', { name: 'Pause' });
+    expect(pauseButton).toBeDisabled();
+    expect(pauseButton).toHaveAttribute('title', 'Close all terminal tabs before pausing');
+    fireEvent.click(pauseButton);
+    expect(sandboxApi.pause).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Mark terminal inactive' }));
+    await waitFor(() => expect(pauseButton).toBeEnabled());
+  });
+});

--- a/web/src/pages/SandboxDetail.tsx
+++ b/web/src/pages/SandboxDetail.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (C) 2026 Tencent. All rights reserved.
 
-import { useEffect, useRef, useState } from 'react';
+import { lazy, Suspense, useEffect, useRef, useState } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { useNavigate, useParams, Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
@@ -12,10 +12,14 @@ import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 
 import { Skeleton } from '@/components/ui/skeleton';
-import { ArrowLeft, Pause, Play, Trash2, RefreshCw } from 'lucide-react';
+import { ArrowLeft, Pause, Play, Trash2, RefreshCw, TerminalSquare } from 'lucide-react';
 import { cn, formatBytes, formatRelative } from '@/lib/utils';
 import { formatSandboxActionError } from '@/lib/sandboxActionError';
 import { SandboxActionErrorBanner } from '@/components/SandboxActionErrorBanner';
+
+const TerminalDialog = lazy(() =>
+  import('@/components/TerminalDialog').then((module) => ({ default: module.TerminalDialog })),
+);
 
 // ── Log level colors ────────────────────────────────────────────────────────
 const LEVEL_CLASS: Record<string, string> = {
@@ -77,6 +81,8 @@ export default function SandboxDetailPage() {
   }, [logs.data]);
 
   const [actionError, setActionError] = useState<string | null>(null);
+  const [terminalOpen, setTerminalOpen] = useState(false);
+  const [terminalSessionActive, setTerminalSessionActive] = useState(false);
   const onLifecycleError = (err: unknown) => {
     setActionError(formatSandboxActionError(err, t));
   };
@@ -111,6 +117,15 @@ export default function SandboxDetailPage() {
   });
 
   const state = data?.state ?? (isLoading ? 'loading' : 'unknown');
+  const terminalUnavailableReason =
+    isLoading || !data
+      ? t('terminal.unavailableLoading')
+      : state !== 'running'
+        ? t('terminal.unavailableState', { state })
+        : !data.envdVersion?.trim()
+          ? t('terminal.unavailableEnvd')
+          : '';
+  const terminalDisabled = Boolean(terminalUnavailableReason);
   const tone =
     state === 'paused' || state === 'pausing' ? 'warn' : state === 'running' ? 'ok' : 'mute';
   const entries = logs.data?.logs ?? [];
@@ -217,23 +232,55 @@ export default function SandboxDetailPage() {
             {data?.templateID ?? '—'} · {t('started', { time: formatRelative(data?.startedAt) })}
           </p>
         </div>
-        {data ? (
-          <div className="flex gap-2">
-            {state === 'paused' ? (
-              <Button variant="outline" onClick={() => resume.mutate()} disabled={resume.isPending}>
-                <Play size={14} /> {t('actions.resume')}
+        <div className="flex gap-2">
+          <Button
+            variant="outline"
+            onClick={() => setTerminalOpen(true)}
+            disabled={terminalDisabled}
+            title={terminalUnavailableReason || t('actions.terminal')}
+          >
+            <TerminalSquare size={14} /> {t('actions.terminal')}
+          </Button>
+          {data ? (
+            <>
+              {state === 'paused' ? (
+                <Button
+                  variant="outline"
+                  onClick={() => resume.mutate()}
+                  disabled={resume.isPending}
+                >
+                  <Play size={14} /> {t('actions.resume')}
+                </Button>
+              ) : (
+                <Button
+                  variant="outline"
+                  onClick={() => pause.mutate()}
+                  disabled={pause.isPending || terminalSessionActive}
+                  title={
+                    terminalSessionActive ? t('terminal.closeBeforePause') : t('actions.pause')
+                  }
+                >
+                  <Pause size={14} /> {t('actions.pause')}
+                </Button>
+              )}
+              <Button variant="destructive" onClick={() => kill.mutate()} disabled={kill.isPending}>
+                <Trash2 size={14} /> {t('actions.kill')}
               </Button>
-            ) : (
-              <Button variant="outline" onClick={() => pause.mutate()} disabled={pause.isPending}>
-                <Pause size={14} /> {t('actions.pause')}
-              </Button>
-            )}
-            <Button variant="destructive" onClick={() => kill.mutate()} disabled={kill.isPending}>
-              <Trash2 size={14} /> {t('actions.kill')}
-            </Button>
-          </div>
-        ) : null}
+            </>
+          ) : null}
+        </div>
       </div>
+
+      {terminalOpen ? (
+        <Suspense fallback={null}>
+          <TerminalDialog
+            open={terminalOpen}
+            onOpenChange={setTerminalOpen}
+            onSessionActiveChange={setTerminalSessionActive}
+            sandboxID={sandboxID}
+          />
+        </Suspense>
+      ) : null}
 
       <SandboxActionErrorBanner message={actionError} onDismiss={() => setActionError(null)} />
       {detail.isError && data ? (

--- a/web/src/test/setup.ts
+++ b/web/src/test/setup.ts
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2026 Tencent. All rights reserved.
+
+import '@testing-library/jest-dom/vitest';
+
+class TestResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+Object.defineProperty(window, 'ResizeObserver', {
+  configurable: true,
+  writable: true,
+  value: TestResizeObserver,
+});

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -47,6 +47,7 @@ export default defineConfig({
       // CubeOps (ops/admin endpoints) — rewrite /opsapi → /api
       '/opsapi': {
         target: 'http://127.0.0.1:3010',
+        ws: true,
         rewrite: (path) => path.replace(/^\/opsapi/, '/api'),
       },
       // CubeAPI (SDK/E2B endpoints) — proxy specific API paths to avoid

--- a/web/vitest.config.ts
+++ b/web/vitest.config.ts
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2026 Tencent. All rights reserved.
+
+import path from 'node:path';
+import react from '@vitejs/plugin-react';
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  plugins: [react()],
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './src'),
+    },
+  },
+  test: {
+    environment: 'jsdom',
+    environmentOptions: {
+      jsdom: {
+        url: 'http://localhost/',
+      },
+    },
+    setupFiles: ['./src/test/setup.ts'],
+  },
+});


### PR DESCRIPTION
## Summary

- add a CubeOps-owned browser terminal gateway backed by the existing envd PTY data plane
- add up to five independent WebUI terminal tabs with manual reconnect, resize, scrollback, copy, and paste
- keep the terminal entry visible with state/envd-specific disabled reasons and block pause while a terminal session is active
- wire WebSocket upgrades and the CubeProxy data-plane address through one-click, Helm, and Terraform deployments
- document authentication, timeouts, WSS, audit fields, lifecycle limitations, and the current main-container-only scope

## Architecture and compatibility

The authenticated session endpoint issues a one-minute, sandbox-bound JWT grant. The browser carries that grant in the WebSocket subprotocol header, and CubeOps revalidates the running envd-enabled sandbox before opening `/bin/sh` through the Go SDK and CubeProxy. Binary I/O and JSON resize frames retain the existing envd PTY protocol.

This phase does not modify CubeAPI and does not add a CubeMaster, Cubelet, Agent, or CubeShim terminal RPC. It intentionally exposes only the primary container. Container selection remains deferred until envd can accept a container-scoped PTY start request; the UI does not present a selector that would still enter the primary container.

Reconnect is always manual and always starts a fresh grant, PTY, and shell. Production defaults remain 30 minutes idle, 8 hours maximum duration, and 30 seconds between WebSocket pings.

## Browser acceptance

Validated with headless Firefox against the rebuilt development VM:

- opened `/bin/sh`, rendered ANSI color output, listed files, and ran interactive `top`
- resized the viewport and observed `stty size` change from `31 153` to `27 117`
- generated 200 lines and scrolled back from lines `175–200` to `43–69`
- pasted `echo PASTE_OK` and copied the selected terminal text `43\n44`
- kept two connected tabs isolated: Shell 2 exported `TAB_MARK=two`; Shell 1 returned `TAB1_ISOLATED`
- restarted CubeOps and received the explicit `terminal service is shutting down` reason without automatic reconnection
- manually reconnected and confirmed the old `OLD_SHELL=yes` state was absent (`NEW_SHELL_OK`)
- confirmed unauthenticated session creation returns `401`
- paused a sandbox and confirmed the always-visible terminal entry is disabled with `Terminal is unavailable while the sandbox is paused.`
- confirmed `terminal.grant`, `terminal.started`, `terminal.ended`, and `terminal.failed` records contain session, operator, sandbox, primary-container, duration, and close-reason fields

The selected validation template does not include `ping`, so `ping -c1 127.0.0.1` correctly returned `/bin/sh: ping: not found`; terminal input/output remained healthy. Browser screenshots were kept out of the repository as binary test artifacts.

## Validation

- `go test ./...` (`CubeOps`)
- `go test ./...` (`sdk/go`)
- `npm run lint`
- `npm test` (Vitest 3, 10 tests)
- `npm run build`
- all `deploy/one-click/tests/test_*.sh`
- Helm 3.18.6 lint, template, and chart guard scripts
- Terraform 1.12.2 `fmt`, `init -backend=false`, and `validate`
- CubeOps and WebUI Docker image builds on the development VM
- CubeMaster, CubeAPI, Cubelet, CubeOps, and WebUI active; WebUI container healthy
- `git diff --check`
- verified no CubeAPI files changed

## Known limitation

An existing lifecycle issue can make deletion directly from the paused state time out while attempting an internal resume. The acceptance sandbox was resumed and then deleted successfully. The terminal documentation therefore instructs operators to close terminal tabs before pause, snapshot, rollback, deletion, or auto-pause boundaries.

Refs #643

Assisted-by: Codex:GPT-5
