### PR TITLE
feat(examples): add OpenHands integration (agent server pre-warmed in template snapshot)

### DIFF
--- a/docs/guide/integrations/index.md
+++ b/docs/guide/integrations/index.md
@@ -48,3 +48,4 @@ lang: en-US
 | Title | Author | Date | Tags |
 | --- | --- | --- | --- |
 | [Pi Agent Integration Guide](./pi-agent.md) | chaojixinren | 2026-07-01 | integration, pi-agent, coding-agent, agent |
+| [OpenHands Integration Guide](./openhands.md) | Fan-hr | 2026-07-28 | integration, openhands, coding-agent, agent |

--- a/docs/guide/integrations/openhands.md
+++ b/docs/guide/integrations/openhands.md
@@ -1,0 +1,144 @@
+---
+title: OpenHands Integration Guide
+author: Fan-hr
+date: 2026-07-28
+tags:
+  - integration
+  - openhands
+  - coding-agent
+  - agent
+lang: en-US
+---
+
+# OpenHands Integration Guide
+
+[中文文档](../../zh/guide/integrations/openhands.md)
+
+## Integration Target and Version
+
+[OpenHands](https://www.openhands.dev/) is an autonomous software-development
+agent platform. Its [Agent SDK](https://github.com/OpenHands/software-agent-sdk)
+executes agent actions (bash, file edits, scripts) through an **agent server**
+that normally runs in a local Docker container.
+
+This guide wires the agent server into a Cube Sandbox MicroVM instead: the
+server is pre-installed in a Cube template and frozen *live* into the
+template's boot snapshot, so every sandbox hot-starts with a running agent
+server and full hardware isolation.
+
+Tested versions: `openhands-sdk` / `openhands-tools` /
+`openhands-agent-server` **1.38.0**, Cube Sandbox **v0.6.0**.
+
+## Prerequisites
+
+- Cube Sandbox deployment: any working deployment (single-node is fine) with
+  `cubemastercli` and the E2B-compatible API reachable.
+- SDK or CLI dependencies: Docker (image build), [`uv`](https://docs.astral.sh/uv/)
+  or a current pip >= 26 (host scripts — older pips such as Ubuntu 24.04's
+  stock 24.0 fail on an upstream `lmnr`/`opentelemetry` conflict).
+- Required environment variables: `E2B_API_URL`, `E2B_API_KEY`,
+  `CUBE_TEMPLATE_ID`; plus `LLM_MODEL`, `LLM_API_KEY`, optional
+  `LLM_BASE_URL` (any OpenAI-compatible endpoint) for the full agent demo.
+  To just verify the integration, `smoke_test.py` and `pause_resume.py`
+  need **no LLM configuration at all**.
+
+## Integration Steps
+
+1. **Build the template image** —
+   [`examples/openhands-integration/Dockerfile`](https://github.com/tencentcloud/CubeSandbox/blob/master/examples/openhands-integration/Dockerfile)
+   extends `cubesandbox-base` (envd on `:49983` preserved), installs a
+   standalone Python 3.12 via uv, pins `openhands-agent-server`, and starts it
+   on `:8000` as the image CMD under the unprivileged `user` account.
+
+2. **Register it as a template**, probing the agent server itself so the boot
+   snapshot is taken only after the server is ready:
+
+   ```bash
+   cubemastercli tpl create-from-image \
+     --image <registry>/openhands-sandbox:latest \
+     --writable-layer-size 2G \
+     --expose-port 8000 --expose-port 49983 \
+     --probe 8000 --probe-path /ready
+   ```
+
+3. **Connect the OpenHands SDK** through `CubeSandboxWorkspace`, a
+   `RemoteWorkspace` subclass (the same extension point the SDK's own
+   `DockerWorkspace` uses) that creates the sandbox via the E2B-compatible
+   SDK and points the workspace at the proxied agent-server URL.
+
+4. **Run demos** from `examples/openhands-integration/`: `smoke_test.py`
+   (no LLM; hot-start latency, bash/file round-trips), `pause_resume.py`
+   (no LLM; whole-VM freeze/thaw under a live server), `main.py` (full agent
+   coding task with in-sandbox result verification).
+
+## Key Code Snippets
+
+The minimal refactoring for an existing OpenHands SDK program is replacing
+the workspace — everything else is unchanged:
+
+```python
+from openhands.sdk import LLM, Conversation
+from openhands.tools.preset.default import get_default_agent
+from cubesandbox_workspace import CubeSandboxWorkspace  # this example
+
+agent = get_default_agent(
+    llm=LLM(model="openai/deepseek-chat", api_key=..., base_url=...),
+    cli_mode=True,  # bash + file editor; no browser stack in the template
+)
+
+with CubeSandboxWorkspace(template="tpl-...") as workspace:  # the template from step 2
+    conversation = Conversation(agent=agent, workspace=workspace)
+    conversation.send_message("Create fib.py, run it, fix any errors.")
+    conversation.run()
+
+    workspace.pause()   # freeze agent server + shells + in-flight processes
+    workspace.resume()  # thaw bit-for-bit, session continues
+```
+
+The workspace core (abridged from `cubesandbox_workspace.py`):
+
+```python
+class CubeSandboxWorkspace(RemoteWorkspace):
+    template: str
+    agent_server_port: int = 8000
+
+    def model_post_init(self, context):
+        self._sandbox = Sandbox.create(template=self.template, ...)
+        host = self._sandbox.get_host(self.agent_server_port)
+        object.__setattr__(self, "host", f"http://{host}")
+        self._wait_for_ready(timeout=self.health_check_timeout)
+        super().model_post_init(context)
+```
+
+## Caveats
+
+- **The agent loop runs inside the MicroVM.** LLM calls originate from the
+  sandbox, so it needs egress to your LLM endpoint; a network allowlist can
+  block everything else ([Network Policy](../network-policy.md)).
+- **The LLM key travels into the sandbox.** The conversation payload carries
+  `LLM(api_key=...)` to the in-VM server — upstream's agent-server design,
+  `DockerWorkspace` included. To keep the raw key out of the VM, give the
+  agent a placeholder and let CubeEgress
+  [credential injection](../security-proxy.md) attach the real header on
+  the wire; the template already trusts the interception CA.
+- **Inbound access control.** `private_traffic=True` gates the workspace API
+  behind per-sandbox traffic tokens, and `SESSION_API_KEY` adds server-side
+  auth. Scopes and limitations are covered in the example README's
+  [Security alignment](https://github.com/tencentcloud/CubeSandbox/blob/master/examples/openhands-integration/README.md#security-alignment)
+  section.
+- **Version pairing.** Keep host `openhands-sdk`/`openhands-tools` and the
+  template's `openhands-agent-server` on the same release (tested: 1.38.0);
+  `workspace.get_server_info()` reveals mismatches.
+- **Host installs.** Use uv or a current pip (>= 26); older pips fail on
+  the upstream `lmnr`/`opentelemetry` pins.
+
+## References
+
+- Related docs: [Templates Overview](../templates.md) ·
+  [Creating Templates from OCI Images](../tutorials/template-from-image.md) ·
+  [Network Policy](../network-policy.md) ·
+  [Restrict Public Access](../restrict-public-access.md) ·
+  [Security Proxy](../security-proxy.md)
+- Sample repository: [`examples/openhands-integration`](https://github.com/tencentcloud/CubeSandbox/tree/master/examples/openhands-integration)
+- Upstream project: [OpenHands](https://github.com/All-Hands-AI/OpenHands) ·
+  [OpenHands Agent SDK](https://github.com/OpenHands/software-agent-sdk)

--- a/docs/zh/guide/integrations/index.md
+++ b/docs/zh/guide/integrations/index.md
@@ -48,3 +48,4 @@ lang: zh-CN
 | 标题 | 作者 | 日期 | 标签 |
 | --- | --- | --- | --- |
 | [Pi Agent 集成指南](./pi-agent.md) | chaojixinren | 2026-07-01 | integration, pi-agent, coding-agent, agent |
+| [OpenHands 集成指南](./openhands.md) | Fan-hr | 2026-07-28 | integration, openhands, coding-agent, agent |

--- a/docs/zh/guide/integrations/openhands.md
+++ b/docs/zh/guide/integrations/openhands.md
@@ -1,0 +1,137 @@
+---
+title: OpenHands 集成指南
+author: Fan-hr
+date: 2026-07-28
+tags:
+  - integration
+  - openhands
+  - coding-agent
+  - agent
+lang: zh-CN
+---
+
+# OpenHands 集成指南
+
+[English](../../../guide/integrations/openhands.md)
+
+## 集成对象与版本
+
+[OpenHands](https://www.openhands.dev/) 是一个自主软件开发智能体平台。其
+[Agent SDK](https://github.com/OpenHands/software-agent-sdk) 通过一个
+**agent server** 来执行智能体动作（bash、文件编辑、脚本），该服务默认运行在
+本地 Docker 容器中。
+
+本指南把 agent server 接入 Cube Sandbox MicroVM：服务被预装进 Cube 模板，并
+连同运行状态一起冻结进模板的启动快照——每个沙箱热启动时 agent server 已经
+就绪，同时获得完整的硬件级隔离。
+
+已验证版本：`openhands-sdk` / `openhands-tools` /
+`openhands-agent-server` **1.38.0**，Cube Sandbox **v0.6.0**。
+
+## 前置条件
+
+- Cube Sandbox 部署：任意可用部署（单机即可），`cubemastercli` 与 E2B 兼容
+  API 可访问。
+- SDK 或 CLI 依赖：Docker（构建镜像）、[`uv`](https://docs.astral.sh/uv/)
+  或较新的 pip >= 26（宿主机脚本——较旧的 pip（如 Ubuntu 24.04 自带的
+  24.0）会因上游 `lmnr`/`opentelemetry` 冲突而解析失败）。
+- 必需环境变量：`E2B_API_URL`、`E2B_API_KEY`、`CUBE_TEMPLATE_ID`；完整智能体
+  演示另需 `LLM_MODEL`、`LLM_API_KEY`、可选 `LLM_BASE_URL`（任意 OpenAI 兼容
+  端点）。若只想验证集成本身，`smoke_test.py` 与 `pause_resume.py`
+  **完全不需要任何 LLM 配置**。
+
+## 集成步骤
+
+1. **构建模板镜像** ——
+   [`examples/openhands-integration/Dockerfile`](https://github.com/tencentcloud/CubeSandbox/blob/master/examples/openhands-integration/Dockerfile)
+   基于 `cubesandbox-base`（保留 `:49983` 上的 envd），用 uv 安装独立的
+   Python 3.12，钉住 `openhands-agent-server` 版本，并以非特权 `user` 账户
+   将其作为镜像 CMD 启动在 `:8000`。
+
+2. **注册为模板**，探针直接指向 agent server 本身，确保启动快照只在服务完全
+   就绪后拍摄：
+
+   ```bash
+   cubemastercli tpl create-from-image \
+     --image <registry>/openhands-sandbox:latest \
+     --writable-layer-size 2G \
+     --expose-port 8000 --expose-port 49983 \
+     --probe 8000 --probe-path /ready
+   ```
+
+3. **接入 OpenHands SDK**：`CubeSandboxWorkspace` 继承 `RemoteWorkspace`
+   （与官方 `DockerWorkspace` 相同的扩展点），通过 E2B 兼容 SDK 创建沙箱，
+   并把 workspace 指向代理出来的 agent-server 地址。
+
+4. **运行演示**（位于 `examples/openhands-integration/`）：`smoke_test.py`
+   （无需 LLM；热启动延迟、bash/文件往返）、`pause_resume.py`（无需 LLM；
+   在运行中的服务下整机冻结/解冻）、`main.py`（完整编码任务 + 沙箱内独立
+   核验结果）。
+
+## 关键代码片段
+
+对既有 OpenHands SDK 程序来说，最小改动就是替换 workspace——其余代码不变：
+
+```python
+from openhands.sdk import LLM, Conversation
+from openhands.tools.preset.default import get_default_agent
+from cubesandbox_workspace import CubeSandboxWorkspace  # 本示例提供
+
+agent = get_default_agent(
+    llm=LLM(model="openai/deepseek-chat", api_key=..., base_url=...),
+    cli_mode=True,  # bash + 文件编辑；模板中不含浏览器栈
+)
+
+with CubeSandboxWorkspace(template="tpl-...") as workspace:  # 第 2 步生成的模板
+    conversation = Conversation(agent=agent, workspace=workspace)
+    conversation.send_message("创建 fib.py 并运行，修复所有报错。")
+    conversation.run()
+
+    workspace.pause()   # 冻结 agent server + shell + 执行中的进程
+    workspace.resume()  # 逐位解冻，会话原样继续
+```
+
+workspace 核心实现（节选自 `cubesandbox_workspace.py`）：
+
+```python
+class CubeSandboxWorkspace(RemoteWorkspace):
+    template: str
+    agent_server_port: int = 8000
+
+    def model_post_init(self, context):
+        self._sandbox = Sandbox.create(template=self.template, ...)
+        host = self._sandbox.get_host(self.agent_server_port)
+        object.__setattr__(self, "host", f"http://{host}")
+        self._wait_for_ready(timeout=self.health_check_timeout)
+        super().model_post_init(context)
+```
+
+## 注意事项
+
+- **智能体主循环在 MicroVM 内运行。**LLM 调用从沙箱内发起，因此沙箱需要
+  有到 LLM 端点的出口；可用网络白名单封禁其余出口
+  （[网络策略](../network-policy.md)）。
+- **LLM key 会进入沙箱。**会话载荷会把 `LLM(api_key=...)` 发给 VM 内的
+  服务端——这是上游 agent-server 架构的既有设计（官方 `DockerWorkspace`
+  同样如此）。若要求真 key 不进 VM，可给智能体配置占位符，由 CubeEgress
+  [凭证注入](../security-proxy.md)在线上附加真实请求头；模板已信任拦截
+  CA。
+- **入口访问控制。**`private_traffic=True` 以沙箱级 traffic token 保护
+  workspace API，`SESSION_API_KEY` 提供服务端鉴权。适用范围与限制见示例
+  README 的[安全对齐](https://github.com/tencentcloud/CubeSandbox/blob/master/examples/openhands-integration/README_zh.md#安全对齐)一节。
+- **版本配对。**宿主机 `openhands-sdk`/`openhands-tools` 与模板内
+  `openhands-agent-server` 保持同一版本（已验证 1.38.0）；
+  `workspace.get_server_info()` 可排查不匹配。
+- **宿主机安装。**使用 uv 或较新的 pip（>= 26）；旧版 pip 会在上游
+  `lmnr`/`opentelemetry` 钉版上解析失败。
+
+## 参考资料
+
+- 相关文档：[模板概览](../templates.md) ·
+  [从 OCI 镜像创建模板](../tutorials/template-from-image.md) ·
+  [网络策略](../network-policy.md) ·
+  [限制公网访问](../restrict-public-access.md) ·
+  [安全代理](../security-proxy.md)
+- 示例仓库：[`examples/openhands-integration`](https://github.com/tencentcloud/CubeSandbox/tree/master/examples/openhands-integration)
+- 上游项目：[OpenHands](https://github.com/All-Hands-AI/OpenHands) ·
+  [OpenHands Agent SDK](https://github.com/OpenHands/software-agent-sdk)

--- a/examples/openhands-integration/.env.example
+++ b/examples/openhands-integration/.env.example
@@ -1,0 +1,29 @@
+# --- CubeSandbox connection ---
+
+# Required: CubeAPI address (use CubeAPI, not CubeProxy).
+E2B_API_URL="http://<cube-host>:3000"
+
+# Required: any `e2b_<hex>`-shaped placeholder in local dev (the SDK checks
+# the shape client-side); a real key when the deployment enables auth.
+E2B_API_KEY="e2b_000000"
+
+# Required: template built from this example's Dockerfile
+# (`cubemastercli tpl create-from-image`).
+CUBE_TEMPLATE_ID="<template-id>"
+
+# Optional: only when your deployment's cube-proxy HTTP port is not 80
+# (its CUBE_PROXY_HTTP_PORT setting).
+# CUBE_PROXY_HTTP_PORT="10080"
+
+# Optional: only when talking to CubeProxy over HTTPS with Cube's mkcert cert.
+# SSL_CERT_FILE="/root/.local/share/mkcert/rootCA.pem"
+
+# --- LLM (main.py only; smoke_test.py and pause_resume.py need no LLM) ---
+
+# Any OpenAI-compatible endpoint, in LiteLLM notation:
+#   OpenAI:     LLM_MODEL="openai/gpt-5.2"          LLM_BASE_URL unset
+#   DeepSeek:   LLM_MODEL="openai/deepseek-chat"    LLM_BASE_URL="https://api.deepseek.com/v1"
+#   Self-host:  LLM_MODEL="openai/qwen3-coder"      LLM_BASE_URL="http://<your-endpoint>/v1"
+LLM_MODEL="openai/gpt-5.2"
+LLM_BASE_URL=""
+LLM_API_KEY="<your-llm-api-key>"

--- a/examples/openhands-integration/Dockerfile
+++ b/examples/openhands-integration/Dockerfile
@@ -39,9 +39,8 @@ RUN apt-get update \
 # so the same Dockerfile works on any base revision and on amd64/arm64 alike.
 # The installer URL and uv version are pinned for reproducible rebuilds.
 ARG UV_VERSION=0.11.33
-ADD https://astral.sh/uv/${UV_VERSION}/install.sh /tmp/uv-install.sh
-RUN UV_INSTALL_DIR=/usr/local/bin sh /tmp/uv-install.sh \
-    && rm /tmp/uv-install.sh
+RUN curl -fsSL "https://astral.sh/uv/${UV_VERSION}/install.sh" \
+    | UV_INSTALL_DIR=/usr/local/bin sh
 
 # UV_PYTHON_INSTALL_DIR must be world-readable: the venv's interpreter symlink
 # points into it, and the agent server runs as the unprivileged `user` account

--- a/examples/openhands-integration/Dockerfile
+++ b/examples/openhands-integration/Dockerfile
@@ -1,0 +1,78 @@
+# syntax=docker/dockerfile:1.7
+#
+# OpenHands agent server baked into a CubeSandbox template.
+#
+# The cubesandbox-base entrypoint keeps envd on :49983 (the in-guest daemon
+# behind the SDK's file/command API) and execs our CMD as the foreground
+# service, so the OpenHands agent server is already listening on :8000 when
+# the template's boot snapshot is taken. Every sandbox created from this template therefore hot-starts with a
+# live agent server — no per-session cold start, unlike DockerWorkspace which
+# boots a fresh container per session.
+#
+# Build:
+#   docker build -t openhands-sandbox:latest examples/openhands-integration
+#
+# Local smoke test (plain Docker, outside CubeSandbox):
+#   docker run --rm -d -p 8000:8000 -p 49983:49983 \
+#     --name oh-sbx openhands-sandbox:latest
+#   curl http://127.0.0.1:8000/ready
+#   curl -o /dev/null -w "%{http_code}\n" http://127.0.0.1:49983/health  # => 204
+
+ARG CUBE_BASE_IMAGE=ghcr.io/tencentcloud/cubesandbox-base:2026.16
+FROM ${CUBE_BASE_IMAGE}
+
+ARG DEBIAN_FRONTEND=noninteractive
+# Pinned server version; bump together with the host-side requirements.txt so
+# the SDK and the agent server stay protocol-compatible.
+ARG OPENHANDS_AGENT_SERVER_VERSION=1.38.0
+ARG PYTHON_VERSION=3.12
+
+# git for agent version-control workflows; system python3 + pip because a
+# coding-agent workspace without an interpreter on PATH forces the agent to
+# hunt for one (the OpenHands venv python is intentionally not on PATH).
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends git python3 python3-pip \
+    && rm -rf /var/lib/apt/lists/*
+
+# The published cubesandbox-base is Ubuntu 22.04 (Python 3.10), while the
+# OpenHands SDK requires Python >= 3.12. Install a standalone CPython via uv
+# so the same Dockerfile works on any base revision and on amd64/arm64 alike.
+# The installer URL and uv version are pinned for reproducible rebuilds.
+ARG UV_VERSION=0.11.33
+ADD https://astral.sh/uv/${UV_VERSION}/install.sh /tmp/uv-install.sh
+RUN UV_INSTALL_DIR=/usr/local/bin sh /tmp/uv-install.sh \
+    && rm /tmp/uv-install.sh
+
+# UV_PYTHON_INSTALL_DIR must be world-readable: the venv's interpreter symlink
+# points into it, and the agent server runs as the unprivileged `user` account
+# (uv's default install dir under /root is not traversable by uid 1000).
+# openhands-sdk is pinned explicitly so a rebuild cannot silently pull a
+# newer SDK than the server/tools were released with.
+RUN UV_PYTHON_INSTALL_DIR=/opt/uv/python uv venv /opt/openhands --python ${PYTHON_VERSION} \
+    && VIRTUAL_ENV=/opt/openhands uv pip install --no-cache \
+        openhands-agent-server==${OPENHANDS_AGENT_SERVER_VERSION} \
+        openhands-tools==${OPENHANDS_AGENT_SERVER_VERSION} \
+        openhands-sdk==${OPENHANDS_AGENT_SERVER_VERSION}
+
+# Python TLS clients (httpx under litellm in the agent server) default to
+# certifi's bundle and ignore the system trust store, so point them at the
+# system bundle explicitly. With the CubeEgress CA bake at template
+# registration (--with-cube-ca, the default) that store includes the
+# interception root, so credential-injection egress rules work against the
+# pre-warmed server without image changes; without CubeEgress the system
+# bundle is a superset of certifi's roots and nothing changes.
+ENV SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt \
+    REQUESTS_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt
+
+# Agent working directory. Owned by the uid-1000 `user` account that envd also
+# uses for file/command operations, so files created by the agent and via the
+# E2B-compatible SDK stay mutually accessible.
+RUN mkdir -p /workspace && chown user:user /workspace
+
+EXPOSE 8000 49983
+
+# Drop to the unprivileged `user` account for the agent server; envd (started
+# by the inherited cube-entrypoint) keeps running on :49983. sudo -E preserves
+# env so SESSION_API_KEY can be injected for the optional authenticated mode.
+CMD ["sudo", "-E", "-H", "-u", "user", "/bin/sh", "-c", \
+     "cd /workspace && exec /opt/openhands/bin/agent-server --host 0.0.0.0 --port 8000"]

--- a/examples/openhands-integration/README.md
+++ b/examples/openhands-integration/README.md
@@ -1,0 +1,229 @@
+# OpenHands × Cube Sandbox
+
+Run [OpenHands](https://www.openhands.dev/) coding agents with every command,
+file edit, and script executed inside a hardware-isolated Cube Sandbox
+MicroVM — from a template whose boot snapshot already contains a **running**
+OpenHands agent server.
+
+[中文文档](./README_zh.md)
+
+## Why this integration
+
+OpenHands' stock `DockerWorkspace` boots a fresh agent-server container for
+every session. Cube Sandbox templates snapshot the VM *after* first boot, so
+this example bakes the agent server into the template and freezes it live:
+
+| | DockerWorkspace | CubeSandboxWorkspace (this example) |
+|---|---|---|
+| Session startup | Container boot + server cold start | Snapshot hot-start, server already listening |
+| Isolation | Shared host kernel | KVM MicroVM with its own kernel |
+| Long sessions | Lost if the container stops | Whole-VM `pause()` / `resume()` — agent server, shells, and in-flight processes freeze and thaw bit-for-bit |
+| Network policy | Docker networks | Platform egress control (allowlist / denylist / no-internet) |
+
+Because the agent's session state lives in the in-VM server process,
+`pause()` / `resume()` freeze and thaw the *entire session*, not just the
+execution environment (see `pause_resume.py`).
+
+## How it works
+
+```
+ host                                Cube Sandbox platform
+┌──────────────────────────┐        ┌──────────────────────────────────┐
+│ OpenHands SDK            │        │ MicroVM (from openhands template)│
+│  Conversation ───────────┼─HTTP──▶│  agent-server :8000  (pre-warmed │
+│  CubeSandboxWorkspace    │ proxy  │   in the template snapshot)      │
+│   └─ e2b SDK (create/    │        │  envd :49983 (SDK ops daemon)    │
+│      pause/resume/kill)  │        │  /workspace  (agent working dir) │
+└──────────────────────────┘        └──────────────────────────────────┘
+```
+
+`CubeSandboxWorkspace` subclasses the SDK's `RemoteWorkspace` — the same
+extension point used by `DockerWorkspace` — and points it at the sandbox's
+proxied agent-server URL. `Conversation(agent=..., workspace=...)` then
+automatically becomes a `RemoteConversation`: the agent loop runs inside the
+MicroVM, so LLM traffic originates from the sandbox (see
+[Security](#security-alignment)).
+
+## Prerequisites
+
+- A deployed Cube Sandbox (single-node is fine) — see the
+  [Quick Start](../../docs/guide/quickstart.md) /
+  [Bare-Metal Deployment](../../docs/guide/bare-metal-deploy.md) guides
+- `cubemastercli` on `$PATH`, Docker for the image build
+- [`uv`](https://docs.astral.sh/uv/) (or a current pip >= 26) for the
+  host-side scripts — **older pips such as Ubuntu 24.04's stock 24.0 cannot
+  resolve the OpenHands dependency graph** (an upstream `lmnr` /
+  `opentelemetry` constraint conflict)
+- An OpenAI-compatible LLM endpoint + key (`main.py` only —
+  `smoke_test.py` and `pause_resume.py` need no LLM)
+
+## 1. Build the template image
+
+```bash
+docker build -t openhands-sandbox:latest examples/openhands-integration
+```
+
+Optional plain-Docker sanity check before involving the platform:
+
+```bash
+docker run --rm -d -p 8000:8000 -p 49983:49983 --name oh-sbx openhands-sandbox:latest
+curl http://127.0.0.1:8000/ready
+curl -o /dev/null -w "%{http_code}\n" http://127.0.0.1:49983/health   # => 204
+docker stop oh-sbx
+```
+
+## 2. Register the template
+
+Push the image to a registry your deployment can pull from, then:
+
+```bash
+cubemastercli tpl create-from-image \
+  --image     <registry>/openhands-sandbox:latest \
+  --writable-layer-size 2G \
+  --expose-port 8000 \
+  --expose-port 49983 \
+  --probe 8000 \
+  --probe-path /ready
+```
+
+Probing **the agent server's readiness endpoint** (`:8000/ready`, which stays
+non-2xx until initialization completes — not just envd, and not the liveness
+`/health`) makes the platform take the boot snapshot only after the server is
+fully initialized — the hot-start guarantee is enforced by the build, not
+hoped for. Watch the build
+until `READY` (see
+[Creating Templates from OCI Images](../../docs/guide/tutorials/template-from-image.md))
+and note the generated `tpl-...` id.
+
+## 3. Configure
+
+```bash
+cd examples/openhands-integration
+uv venv .venv --python 3.12 && source .venv/bin/activate
+uv pip install -r requirements.txt
+cp .env.example .env   # fill in E2B_API_URL, E2B_API_KEY, CUBE_TEMPLATE_ID, LLM_*
+```
+
+## 4. Run
+
+```bash
+python smoke_test.py       # no LLM key needed
+python pause_resume.py     # no LLM key needed
+python main.py             # full agent demo (needs LLM_* in .env)
+```
+
+- `smoke_test.py` proves the integration end to end: prints the
+  create→healthy latency (the hot-start evidence), calls `/server_info`,
+  and round-trips bash and file transfer through the OpenHands workspace
+  API.
+- `pause_resume.py` starts a 1-second ticker inside the VM, pauses the VM,
+  **drops the workspace object entirely** (`kill_on_exit=False`), re-attaches
+  from a fresh `CubeSandboxWorkspace(sandbox_id=...)` 8 wall-clock seconds
+  later, and shows the tick sequence has no gap — the session survives the
+  original process and continues from the exact frozen instant.
+- `main.py` runs a real OpenHands conversation (write a program, execute it,
+  fix errors) and then verifies the result *from inside the sandbox*,
+  independent of the agent's own claims.
+
+## Using it in your own code
+
+```python
+from openhands.sdk import LLM, Conversation
+from openhands.tools.preset.default import get_default_agent
+from cubesandbox_workspace import CubeSandboxWorkspace
+
+agent = get_default_agent(llm=LLM(model="openai/...", api_key=...), cli_mode=True)
+
+with CubeSandboxWorkspace(template="tpl-...") as workspace:
+    conversation = Conversation(agent=agent, workspace=workspace)
+    conversation.send_message("fix the failing test in /workspace/repo")
+    conversation.run()
+    workspace.pause()      # freeze the whole session ...
+    workspace.resume()     # ... and continue it later
+
+# Or keep a paused session beyond this process (kill_on_exit=False),
+# then re-attach — even days later, even from another process:
+#   workspace = CubeSandboxWorkspace(sandbox_id="...")   # auto-resumes
+```
+
+## Security alignment
+
+- **Egress**: the agent loop runs inside the MicroVM, so the sandbox needs
+  egress to your LLM endpoint. To restrict everything else, create the
+  sandbox with a network allowlist containing only that endpoint (see the
+  [network policy guide](../../docs/guide/network-policy.md) and the
+  quickstart's `network_allowlist.py` pattern) — the agent then cannot reach
+  anywhere except its own brain.
+- **Where the LLM key lives**: OpenHands' agent-server architecture runs the
+  agent loop inside the workspace, so a stock setup — upstream's
+  `DockerWorkspace` included — sends `LLM(api_key=...)` into the sandbox
+  with the conversation. If the raw key must stay out of the VM, configure
+  the agent with a placeholder and let CubeEgress
+  [credential injection](../../docs/guide/security-proxy.md) attach the real
+  `Authorization` header on the wire (pattern:
+  [`examples/pi-agent-integration/network_policy.py`](../pi-agent-integration/network_policy.py));
+  this template's `SSL_CERT_FILE` already makes the pre-warmed server trust
+  the interception CA.
+- **Inbound — one flag to go private**: `CubeSandboxWorkspace(...,
+  private_traffic=True)` creates the sandbox with
+  `allow_public_traffic=False` and sends the per-sandbox
+  [traffic token](../../docs/guide/restrict-public-access.md) with every
+  workspace HTTP request (`e2b-traffic-access-token`), so only token holders
+  can reach the agent server through the platform proxy — strongly
+  recommended on shared deployments. Scope: OpenHands 1.38.0's conversation
+  WebSocket does not attach custom headers, so full `Conversation` runs need
+  public traffic; workspace API calls are unaffected. The token stays valid
+  across pause/resume (the platform validates it server-side and the
+  workspace preserves it client-side); to re-attach to a private sandbox
+  from a new process, persist `workspace.traffic_token` and pass it back as
+  `traffic_access_token=`. For defense in depth the server also supports
+  session keys:
+  launch it with `SESSION_API_KEY=<secret>` (the template CMD forwards env)
+  and set the same value as `CubeSandboxWorkspace(api_key=...)` — the SDK
+  sends it as `X-Session-API-Key`.
+- **Accounts**: the agent server runs as the same uid-1000 `user` account
+  envd uses for SDK file/command operations, so agent-created and SDK-created
+  files stay mutually accessible. This is an ownership convention, not a
+  privilege boundary — `cubesandbox-base` grants `user` passwordless sudo;
+  the isolation boundary is the MicroVM itself.
+
+## Resource recommendations
+
+- Template build: ~750 MB image (standalone CPython + OpenHands server).
+- Sandbox: 2 vCPU / 2 GB RAM is comfortable for the CLI toolset
+  (bash + file editor); add headroom for whatever your tasks compile or run.
+- `--writable-layer-size 2G` covers agent-created files and pip caches for
+  typical tasks (a freshly booted sandbox uses only ~164 KB of it); raise it
+  for repository-heavy work.
+
+## Known limitations
+
+- **Old pips cannot install the host deps**: `lmnr` pins a pre-release
+  opentelemetry that older pip resolvers (e.g. Ubuntu 24.04's stock 24.0)
+  fail on — use uv or a current pip (>= 26). The template build already uses
+  uv internally.
+- **Browser toolset disabled** (`cli_mode=True`): keeping Playwright/Chromium
+  out of the template keeps it small. To enable browsing agents, install the
+  browser stack in the Dockerfile and drop `cli_mode`.
+- **Version pairing**: host `openhands-sdk`/`openhands-tools` and the
+  template's `openhands-agent-server` are pinned to the same release train
+  (1.38.0). Bump them together; `workspace.get_server_info()` shows the
+  server side for debugging mismatches.
+
+## Troubleshooting
+
+- *Health timeout in `CubeSandboxWorkspace`*: confirm the template was built
+  with the agent-server CMD (step 1's local Docker check), that it was
+  registered with `--expose-port 8000`, and that `E2B_API_URL` points at your
+  deployment. If your deployment's cube-proxy serves HTTP on a non-80 port,
+  set `CUBE_PROXY_HTTP_PORT` in `.env` to match.
+- *`get_server_info` succeeds but conversations fail*: usually an LLM config
+  problem — remember the LLM is called **from inside the sandbox**; check
+  egress policy and `LLM_BASE_URL` reachability from the VM
+  (`workspace.execute_command("curl -sI $LLM_BASE_URL")`).
+
+## References
+
+- Integration guide: [`docs/guide/integrations/openhands.md`](../../docs/guide/integrations/openhands.md)
+- Creating templates from OCI images: [`docs/guide/tutorials/template-from-image.md`](../../docs/guide/tutorials/template-from-image.md)
+- OpenHands Agent SDK: <https://github.com/OpenHands/software-agent-sdk>

--- a/examples/openhands-integration/README_zh.md
+++ b/examples/openhands-integration/README_zh.md
@@ -1,0 +1,206 @@
+# OpenHands × Cube Sandbox
+
+在硬件隔离的 Cube Sandbox MicroVM 中运行 [OpenHands](https://www.openhands.dev/)
+编码智能体：智能体的每一条命令、每一次文件编辑、每一个脚本都在 MicroVM 内执行，
+而且模板的启动快照中已经包含一个**正在运行**的 OpenHands Agent Server。
+
+[English README](./README.md)
+
+## 为什么做这个集成
+
+OpenHands 自带的 `DockerWorkspace` 每次会话都要冷启动一个 agent-server 容器。
+Cube Sandbox 的模板会在首次启动*之后*拍摄快照，因此本示例把 agent server
+预装进模板并连同运行状态一起冻结：
+
+| | DockerWorkspace | CubeSandboxWorkspace（本示例） |
+|---|---|---|
+| 会话启动 | 容器启动 + 服务冷启动 | 快照热启动，服务已在监听 |
+| 隔离性 | 共享宿主机内核 | 拥有独立内核的 KVM MicroVM |
+| 长任务会话 | 容器停止即丢失 | 整机 `pause()` / `resume()` —— agent server、shell 会话与执行中的进程逐位冻结、逐位恢复 |
+| 网络策略 | Docker 网络 | 平台级出口管控（白名单 / 黑名单 / 断网） |
+
+由于 agent 会话状态活在 VM 内的 server 进程里，`pause()` / `resume()`
+冻结与恢复的是**整个会话**而不只是执行环境（演示见 `pause_resume.py`）。
+
+## 工作原理
+
+```
+ host                                Cube Sandbox platform
+┌──────────────────────────┐        ┌──────────────────────────────────┐
+│ OpenHands SDK            │        │ MicroVM (from openhands template)│
+│  Conversation ───────────┼─HTTP──▶│  agent-server :8000  (pre-warmed │
+│  CubeSandboxWorkspace    │ proxy  │   in the template snapshot)      │
+│   └─ e2b SDK (create/    │        │  envd :49983 (SDK ops daemon)    │
+│      pause/resume/kill)  │        │  /workspace  (agent working dir) │
+└──────────────────────────┘        └──────────────────────────────────┘
+```
+
+`CubeSandboxWorkspace` 继承 SDK 的 `RemoteWorkspace`（与官方 `DockerWorkspace`
+使用同一扩展点），并把它指向沙箱代理出来的 agent-server 地址。
+`Conversation(agent=..., workspace=...)` 会自动成为 `RemoteConversation`：
+智能体主循环在 MicroVM 内运行，LLM 流量也从沙箱内发起（见
+[安全对齐](#安全对齐)）。
+
+## 前置条件
+
+- 已部署的 Cube Sandbox（单机即可）——参见
+  [快速开始](../../docs/zh/guide/quickstart.md) /
+  [裸金属部署](../../docs/zh/guide/bare-metal-deploy.md)
+- `cubemastercli` 在 `$PATH` 中，构建镜像需要 Docker
+- 宿主机脚本需要 [`uv`](https://docs.astral.sh/uv/)（或较新的 pip >= 26）——
+  **较旧的 pip（如 Ubuntu 24.04 自带的 24.0）无法解析 OpenHands 的依赖图**
+  （上游 `lmnr` / `opentelemetry` 约束冲突）
+- 一个 OpenAI 兼容的 LLM 端点和密钥（仅 `main.py` 需要——
+  `smoke_test.py` 与 `pause_resume.py` 无需 LLM）
+
+## 1. 构建模板镜像
+
+```bash
+docker build -t openhands-sandbox:latest examples/openhands-integration
+```
+
+（可选）接入平台前先用纯 Docker 做个体检：
+
+```bash
+docker run --rm -d -p 8000:8000 -p 49983:49983 --name oh-sbx openhands-sandbox:latest
+curl http://127.0.0.1:8000/ready
+curl -o /dev/null -w "%{http_code}\n" http://127.0.0.1:49983/health   # => 204
+docker stop oh-sbx
+```
+
+## 2. 注册模板
+
+把镜像推送到部署环境可以拉取的镜像仓库，然后：
+
+```bash
+cubemastercli tpl create-from-image \
+  --image     <registry>/openhands-sandbox:latest \
+  --writable-layer-size 2G \
+  --expose-port 8000 \
+  --expose-port 49983 \
+  --probe 8000 \
+  --probe-path /ready
+```
+
+探针直接指向 **agent server 的就绪端点**（`:8000/ready`——初始化完成前
+它不会返回 2xx；不是仅探测 envd，也不是只表示进程存活的 `/health`），
+平台只会在服务完全初始化后才拍摄启动快照——热启动的保证由构建流程强制成立，
+而不是靠运气。参照
+[从 OCI 镜像创建模板](../../docs/zh/guide/tutorials/template-from-image.md)
+等待模板进入 `READY`，记下生成的 `tpl-...` id。
+
+## 3. 配置
+
+```bash
+cd examples/openhands-integration
+uv venv .venv --python 3.12 && source .venv/bin/activate
+uv pip install -r requirements.txt
+cp .env.example .env   # 填写 E2B_API_URL、E2B_API_KEY、CUBE_TEMPLATE_ID、LLM_*
+```
+
+## 4. 运行
+
+```bash
+python smoke_test.py       # 无需 LLM 密钥
+python pause_resume.py     # 无需 LLM 密钥
+python main.py             # 完整智能体演示（需要 .env 中的 LLM_*）
+```
+
+- `smoke_test.py` 端到端验证集成：打印 创建→健康 延迟（热启动证据）、调用
+  `/server_info`、通过 OpenHands workspace API 往返执行 bash 与文件传输。
+- `pause_resume.py` 在 VM 内启动一个每秒计数器，暂停 VM 后**彻底丢弃
+  workspace 对象**（`kill_on_exit=False`），8 个墙钟秒后用全新的
+  `CubeSandboxWorkspace(sandbox_id=...)` 重连（自动恢复），展示计数序列
+  没有任何空洞——会话跨越了原对象的生命周期，从冻结的那一瞬间原样继续。
+- `main.py` 运行一次真实的 OpenHands 会话（写程序、执行、修错），最后*从沙箱
+  内部*独立核验结果，而不是听智能体自己汇报。
+
+## 在你自己的代码里使用
+
+```python
+from openhands.sdk import LLM, Conversation
+from openhands.tools.preset.default import get_default_agent
+from cubesandbox_workspace import CubeSandboxWorkspace
+
+agent = get_default_agent(llm=LLM(model="openai/...", api_key=...), cli_mode=True)
+
+with CubeSandboxWorkspace(template="tpl-...") as workspace:
+    conversation = Conversation(agent=agent, workspace=workspace)
+    conversation.send_message("修复 /workspace/repo 中失败的测试")
+    conversation.run()
+    workspace.pause()      # 冻结整个会话……
+    workspace.resume()     # ……稍后原样继续
+
+# 也可以让暂停的会话活得比当前进程更久（kill_on_exit=False），
+# 之后——哪怕隔天、哪怕换个进程——重连即自动恢复：
+#   workspace = CubeSandboxWorkspace(sandbox_id="...")
+```
+
+## 安全对齐
+
+- **出口管控**：智能体主循环在 MicroVM 内运行，因此沙箱需要能访问你的 LLM
+  端点。要收紧其余出口，可在创建沙箱时配置只包含该端点的网络白名单（参见
+  [网络策略](../../docs/zh/guide/network-policy.md) 与 quickstart 的
+  `network_allowlist.py` 写法）——智能体除了"自己的大脑"哪儿也去不了。
+- **LLM key 在哪里**：OpenHands 的 agent-server 架构把智能体主循环放在
+  workspace 内运行，因此标准用法（包括官方 `DockerWorkspace`）会把
+  `LLM(api_key=...)` 随会话一起发进沙箱。若要求真 key 不进 VM，可给智能体
+  配置占位符，由 CubeEgress
+  [凭证注入](../../docs/zh/guide/security-proxy.md)在线上附加真实的
+  `Authorization` 请求头（写法参考
+  [`examples/pi-agent-integration/network_policy.py`](../pi-agent-integration/network_policy.py)）；
+  本模板的 `SSL_CERT_FILE` 已让预热的服务端信任拦截 CA。
+- **入口管控——一个开关即可私有化**：`CubeSandboxWorkspace(...,
+  private_traffic=True)` 会以 `allow_public_traffic=False` 创建沙箱，并在
+  每个 workspace HTTP 请求中携带沙箱级
+  [traffic token](../../docs/zh/guide/restrict-public-access.md)
+  （`e2b-traffic-access-token` 请求头）——只有持有令牌者才能穿过平台代理
+  访问 agent server，共享部署强烈建议开启。边界说明：OpenHands 1.38.0 的
+  Conversation WebSocket 不携带自定义请求头，完整会话需使用公网流量；
+  workspace API 调用不受影响。令牌在 pause/resume 后依然有效（平台在服务端
+  校验、workspace 在客户端保留）；跨进程重连私有沙箱时，请持久化
+  `workspace.traffic_token` 并以 `traffic_access_token=` 传回。
+  需要纵深防御时，服务端也支持会话密钥：
+  以 `SESSION_API_KEY=<secret>` 启动（模板 CMD 会透传环境变量），并在
+  `CubeSandboxWorkspace(api_key=...)` 传入同一值——SDK 会以
+  `X-Session-API-Key` 请求头发送。
+- **运行账户**：agent server 与 envd 执行 SDK 文件/命令操作使用同一个
+  uid-1000 `user` 账户，双方创建的文件天然互相可读写。注意这只是属主约定
+  而非权限边界——`cubesandbox-base` 给 `user` 配置了免密 sudo；真正的隔离
+  边界是 MicroVM 本身。
+
+## 资源建议
+
+- 模板构建：镜像约 750 MB（独立 CPython + OpenHands 服务端）。
+- 沙箱：CLI 工具集（bash + 文件编辑）下 2 vCPU / 2 GB 内存即可流畅运行；
+  按任务实际编译/运行的负载增加余量。
+- `--writable-layer-size 2G` 足够覆盖常规任务的文件产出与 pip 缓存
+  （新启动的沙箱仅占用约 164 KB）；仓库较大的任务请调高。
+
+## 已知限制
+
+- **旧版 pip 无法安装宿主机依赖**：`lmnr` 钉住了一个预发布版 opentelemetry，
+  较旧的 pip 解析器（如 Ubuntu 24.04 自带的 24.0）会解析失败——请使用 uv
+  或较新的 pip（>= 26）。模板构建内部已使用 uv。
+- **浏览器工具集默认关闭**（`cli_mode=True`）：不把 Playwright/Chromium
+  装进模板以控制体积。需要浏览智能体时，在 Dockerfile 中安装浏览器栈并
+  去掉 `cli_mode`。
+- **版本配对**：宿主机 `openhands-sdk`/`openhands-tools` 与模板内
+  `openhands-agent-server` 钉在同一版本线（1.38.0），请同步升级；
+  `workspace.get_server_info()` 可查看服务端版本排查不匹配。
+
+## 排障
+
+- *`CubeSandboxWorkspace` 健康检查超时*：确认模板镜像带有 agent-server CMD
+  （第 1 步的本地 Docker 体检）、注册时带了 `--expose-port 8000`、且
+  `E2B_API_URL` 指向你的部署。若部署的 cube-proxy HTTP 端口不是 80，
+  在 `.env` 中设置 `CUBE_PROXY_HTTP_PORT` 与之一致。
+- *`get_server_info` 正常但会话失败*：通常是 LLM 配置问题——记住 LLM 是
+  **从沙箱内部**调用的；检查出口策略与 `LLM_BASE_URL` 在 VM 内的可达性
+  （`workspace.execute_command("curl -sI $LLM_BASE_URL")`）。
+
+## 参考
+
+- 集成指南：[`docs/zh/guide/integrations/openhands.md`](../../docs/zh/guide/integrations/openhands.md)
+- 从 OCI 镜像创建模板：[`docs/zh/guide/tutorials/template-from-image.md`](../../docs/zh/guide/tutorials/template-from-image.md)
+- OpenHands Agent SDK：<https://github.com/OpenHands/software-agent-sdk>

--- a/examples/openhands-integration/cubesandbox_workspace.py
+++ b/examples/openhands-integration/cubesandbox_workspace.py
@@ -38,15 +38,23 @@ Environment: the E2B-compatible client reads `E2B_API_URL` and `E2B_API_KEY`,
 the same convention as every other CubeSandbox example.
 """
 
+from __future__ import annotations
+
 import os
 import time
-from typing import Any, Self
+from typing import TYPE_CHECKING, Any
 from urllib.request import Request, urlopen
 
 from e2b_code_interpreter import Sandbox
 from openhands.sdk.logger import get_logger
 from openhands.sdk.workspace import RemoteWorkspace
 from pydantic import Field, PrivateAttr, SecretStr, model_validator
+
+if TYPE_CHECKING:
+    # Runtime never imports this (typing.Self is 3.11+); with postponed
+    # annotations the `-> Self` hint below is never evaluated either, so the
+    # module imports on any interpreter the OpenHands SDK itself supports.
+    from typing import Self
 
 logger = get_logger(__name__)
 
@@ -209,17 +217,10 @@ class CubeSandboxWorkspace(RemoteWorkspace):
         # timeout, parent init error, or KeyboardInterrupt) must release it.
         # Sandboxes we created are killed; attached ones are left running.
         try:
-            # The platform proxy exposes in-sandbox ports as public hosts of
-            # the form "<port>-<sandbox-id>.<domain>" (see the quickstart
-            # mask-request-host example).
-            public_host = sandbox.get_host(self.agent_server_port)
             if not self.host:
-                port_suffix = ""
-                if self.proxy_http_port != 80 and ":" not in public_host:
-                    port_suffix = f":{self.proxy_http_port}"
                 # Same assignment idiom the SDK's own DockerWorkspace uses in
                 # its model_post_init.
-                object.__setattr__(self, "host", f"http://{public_host}{port_suffix}")
+                object.__setattr__(self, "host", self._public_url(sandbox))
 
             self._wait_for_ready(timeout=self.health_check_timeout)
             logger.info(
@@ -230,12 +231,25 @@ class CubeSandboxWorkspace(RemoteWorkspace):
 
             # Initialize the parent RemoteWorkspace against the live server.
             super().model_post_init(context)
-        except BaseException:
+        except BaseException:  # incl. KeyboardInterrupt — must not leak the sandbox
             if self._owns_sandbox:
                 self._kill_sandbox()
             else:
                 self._sandbox = None
             raise
+
+    def _public_url(self, sandbox: Sandbox) -> str:
+        """The agent server's URL through the platform proxy.
+
+        The proxy exposes in-sandbox ports as public hosts of the form
+        "<port>-<sandbox-id>.<domain>" (see the quickstart mask-request-host
+        example); the proxy's HTTP port is appended when it is not 80.
+        """
+        public_host = sandbox.get_host(self.agent_server_port)
+        port_suffix = ""
+        if self.proxy_http_port != 80 and ":" not in public_host:
+            port_suffix = f":{self.proxy_http_port}"
+        return f"http://{public_host}{port_suffix}"
 
     # ── Auth ──────────────────────────────────────────────────────────────
 
@@ -274,7 +288,10 @@ class CubeSandboxWorkspace(RemoteWorkspace):
         """Poll the agent server /ready endpoint until it reports readiness.
 
         /ready (unlike the liveness /health) returns non-2xx until the server
-        has fully finished initialization.
+        has fully finished initialization. Polls with urllib rather than the
+        parent's HTTP client: the first call happens during model_post_init,
+        before super().model_post_init() has set the client up. ``_headers``
+        (session key + traffic token) is honored on both stacks.
         """
         ready_url = f"{self.host.rstrip('/')}/ready"
         deadline = time.monotonic() + timeout
@@ -320,7 +337,14 @@ class CubeSandboxWorkspace(RemoteWorkspace):
         """Thaw a paused MicroVM and wait for the agent server to respond."""
         sandbox_id = self.sandbox.sandbox_id
         logger.info("Resuming sandbox %s", sandbox_id)
-        self._sandbox = Sandbox.connect(sandbox_id)
+        sandbox = Sandbox.connect(sandbox_id)
+        self._sandbox = sandbox
+        # Re-derive the proxied URL like the create path does, and drop the
+        # parent's cached HTTP client: its base_url is bound to the previous
+        # host, so refreshing the field alone would keep requests pinned to a
+        # stale address if the proxy scheme changed across the pause.
+        object.__setattr__(self, "host", self._public_url(sandbox))
+        self.reset_client()
         self._wait_for_ready(timeout=self.health_check_timeout)
         logger.info("Sandbox %s resumed", sandbox_id)
 

--- a/examples/openhands-integration/cubesandbox_workspace.py
+++ b/examples/openhands-integration/cubesandbox_workspace.py
@@ -1,0 +1,368 @@
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""CubeSandbox-backed remote workspace for the OpenHands Agent SDK.
+
+`CubeSandboxWorkspace` plays the same role as the SDK's own `DockerWorkspace`,
+but instead of booting a fresh container per session it creates a CubeSandbox
+MicroVM from a template whose boot snapshot already contains a *running*
+OpenHands agent server (see `Dockerfile`). The result:
+
+- hot start: the agent server is reachable moments after `Sandbox.create()`
+  returns, because it was frozen live into the template snapshot;
+- hardware isolation: every command, file edit, and script the agent runs
+  happens inside a KVM MicroVM, not on the host;
+- one flag to go private: ``private_traffic=True`` creates the sandbox with
+  ``allow_public_traffic=False`` and sends the per-sandbox traffic token
+  CubeProxy enforces with every workspace HTTP request (the Conversation
+  WebSocket is exempt — see the ``private_traffic`` field docs);
+- native lifecycle: `pause()` / `resume()` freeze and thaw the entire VM
+  (agent server, shell sessions, and in-flight processes included), and a
+  paused sandbox can be re-attached later — from a different process or
+  days later — via ``CubeSandboxWorkspace(sandbox_id=...)``.
+
+Usage:
+    from cubesandbox_workspace import CubeSandboxWorkspace
+
+    with CubeSandboxWorkspace(template="tpl-xxxxxxxx") as workspace:
+        result = workspace.execute_command("echo hello from a MicroVM")
+        print(result.stdout)
+
+    # Keep a paused session and re-attach to it later:
+    ws = CubeSandboxWorkspace(template="tpl-xxxxxxxx", kill_on_exit=False)
+    ws.pause()
+    sid = ws.sandbox_id
+    ...  # process exit, hours pass ...
+    ws2 = CubeSandboxWorkspace(sandbox_id=sid)  # auto-resumes
+
+Environment: the E2B-compatible client reads `E2B_API_URL` and `E2B_API_KEY`,
+the same convention as every other CubeSandbox example.
+"""
+
+import os
+import time
+from typing import Any, Self
+from urllib.request import Request, urlopen
+
+from e2b_code_interpreter import Sandbox
+from openhands.sdk.logger import get_logger
+from openhands.sdk.workspace import RemoteWorkspace
+from pydantic import Field, PrivateAttr, SecretStr, model_validator
+
+logger = get_logger(__name__)
+
+TRAFFIC_TOKEN_HEADER = "e2b-traffic-access-token"
+
+
+class CubeSandboxWorkspace(RemoteWorkspace):
+    """Remote workspace that runs the OpenHands agent server in a CubeSandbox
+    MicroVM created from a pre-baked template."""
+
+    # Overrides of parent fields with CubeSandbox-appropriate defaults.
+    working_dir: str = Field(
+        default="/workspace",
+        description="Working directory inside the MicroVM.",
+    )
+    host: str = Field(
+        default="",
+        description="Agent server URL (set automatically after sandbox creation).",
+    )
+
+    # CubeSandbox-specific configuration.
+    template: str | None = Field(
+        default=None,
+        description=(
+            "CubeSandbox template id (tpl-...) built from this example's "
+            "Dockerfile. Required unless sandbox_id is given. The template "
+            "must autostart the agent server on agent_server_port."
+        ),
+    )
+    sandbox_id: str | None = Field(
+        default=None,
+        description=(
+            "Attach to an existing sandbox instead of creating one. A paused "
+            "sandbox is resumed automatically. The attached sandbox is not "
+            "killed on cleanup unless kill_on_exit is explicitly True."
+        ),
+    )
+    agent_server_port: int = Field(
+        default=8000,
+        description="Port the agent server listens on inside the sandbox.",
+    )
+    proxy_http_port: int = Field(
+        default_factory=lambda: int(os.getenv("CUBE_PROXY_HTTP_PORT", "80")),
+        description=(
+            "HTTP port of the deployment's public proxy (its "
+            "CUBE_PROXY_HTTP_PORT). Appended to the public URL when not 80."
+        ),
+    )
+    sandbox_timeout: int = Field(
+        default=3600,
+        description="Sandbox keepalive timeout in seconds passed to Sandbox.create().",
+    )
+    private_traffic: bool = Field(
+        default=False,
+        description=(
+            "Create the sandbox with allow_public_traffic=False and send the "
+            "per-sandbox traffic token with every workspace HTTP request, so "
+            "only token holders can reach the agent server through the "
+            "platform proxy. Off by default to match the platform default, "
+            "like the other examples; strongly recommended for shared "
+            "deployments. Limitation: OpenHands 1.38.0's RemoteConversation "
+            "WebSocket does not attach custom headers, so full Conversation "
+            "runs need public traffic (workspace API calls are unaffected)."
+        ),
+    )
+    traffic_access_token: SecretStr | None = Field(
+        default=None,
+        exclude=True,
+        repr=False,
+        description=(
+            "Traffic token for re-attaching to a private sandbox from a new "
+            "process (persist workspace.traffic_token after creation). "
+            "Captured automatically on the create path."
+        ),
+    )
+    network: dict[str, Any] | None = Field(
+        default=None,
+        description=(
+            "Extra network options forwarded to Sandbox.create(), e.g. egress "
+            "allow_out/deny_out CIDR lists. Merged with private_traffic, "
+            "which owns allow_public_traffic: passing private_traffic=True "
+            "together with allow_public_traffic=True raises ValueError "
+            "instead of silently going public."
+        ),
+    )
+    kill_on_exit: bool | None = Field(
+        default=None,
+        description=(
+            "Whether cleanup()/context exit kills the sandbox. Defaults to "
+            "True for sandboxes this workspace created and False for "
+            "sandboxes attached via sandbox_id."
+        ),
+    )
+    health_check_timeout: float = Field(
+        default=60.0,
+        gt=0.0,
+        description="Seconds to wait for the agent server /ready to pass.",
+    )
+
+    _sandbox: Sandbox | None = PrivateAttr(default=None)
+    _owns_sandbox: bool = PrivateAttr(default=False)
+    # The platform's connect/resume API deliberately does not re-surface the
+    # traffic token (CubeProxy validates it from Redis), so the client must
+    # preserve the original one across resume/re-attach.
+    _saved_traffic_token: str | None = PrivateAttr(default=None)
+
+    @model_validator(mode="before")
+    @classmethod
+    def _require_template_or_sandbox_id(cls, data: Any) -> Any:
+        if isinstance(data, dict) and not (
+            data.get("template") or data.get("sandbox_id")
+        ):
+            raise ValueError("either template or sandbox_id must be provided")
+        return data
+
+    def model_post_init(self, context: Any) -> None:
+        """Create (or attach to) the sandbox and connect the RemoteWorkspace."""
+        started = time.monotonic()
+        if self.sandbox_id:
+            sandbox = Sandbox.connect(self.sandbox_id)  # resumes if paused
+            self._owns_sandbox = False
+            if self.traffic_access_token is not None:
+                self._saved_traffic_token = self.traffic_access_token.get_secret_value()
+            logger.info(
+                "Attached to CubeSandbox %s in %.0f ms",
+                sandbox.sandbox_id,
+                (time.monotonic() - started) * 1000,
+            )
+        else:
+            network: dict[str, Any] = dict(self.network or {})
+            if self.private_traffic:
+                # private_traffic owns allow_public_traffic. Refuse rather
+                # than silently resolve: a security flag that fails open on
+                # contradictory input is worse than a loud error.
+                if network.get("allow_public_traffic") is True:
+                    raise ValueError(
+                        "private_traffic=True conflicts with "
+                        "network={'allow_public_traffic': True} — drop one"
+                    )
+                network["allow_public_traffic"] = False
+            create_kwargs: dict[str, Any] = {
+                "template": self.template,
+                "timeout": self.sandbox_timeout,
+            }
+            if network:
+                create_kwargs["network"] = network
+            sandbox = Sandbox.create(**create_kwargs)
+            self._owns_sandbox = True
+            self._saved_traffic_token = getattr(sandbox, "traffic_access_token", None)
+            logger.info(
+                "Created CubeSandbox %s from template %s in %.0f ms",
+                sandbox.sandbox_id,
+                self.template,
+                (time.monotonic() - started) * 1000,
+            )
+        self._sandbox = sandbox
+        object.__setattr__(self, "sandbox_id", sandbox.sandbox_id)
+
+        # From this point on the sandbox exists: any failure below (readiness
+        # timeout, parent init error, or KeyboardInterrupt) must release it.
+        # Sandboxes we created are killed; attached ones are left running.
+        try:
+            # The platform proxy exposes in-sandbox ports as public hosts of
+            # the form "<port>-<sandbox-id>.<domain>" (see the quickstart
+            # mask-request-host example).
+            public_host = sandbox.get_host(self.agent_server_port)
+            if not self.host:
+                port_suffix = ""
+                if self.proxy_http_port != 80 and ":" not in public_host:
+                    port_suffix = f":{self.proxy_http_port}"
+                # Same assignment idiom the SDK's own DockerWorkspace uses in
+                # its model_post_init.
+                object.__setattr__(self, "host", f"http://{public_host}{port_suffix}")
+
+            self._wait_for_ready(timeout=self.health_check_timeout)
+            logger.info(
+                "OpenHands agent server ready at %s (%.0f ms after create)",
+                self.host,
+                (time.monotonic() - started) * 1000,
+            )
+
+            # Initialize the parent RemoteWorkspace against the live server.
+            super().model_post_init(context)
+        except BaseException:
+            if self._owns_sandbox:
+                self._kill_sandbox()
+            else:
+                self._sandbox = None
+            raise
+
+    # ── Auth ──────────────────────────────────────────────────────────────
+
+    @property
+    def _traffic_token(self) -> str | None:
+        return self._saved_traffic_token
+
+    @property
+    def traffic_token(self) -> str | None:
+        """The per-sandbox traffic token (persist it to re-attach to a
+        private sandbox from another process)."""
+        return self._saved_traffic_token
+
+    @property
+    def _headers(self) -> dict[str, str]:
+        """Parent headers (X-Session-API-Key) plus the CubeProxy per-sandbox
+        traffic token when the sandbox runs with private traffic."""
+        headers = dict(super()._headers)
+        token = self._traffic_token
+        if token:
+            headers[TRAFFIC_TOKEN_HEADER] = token
+        return headers
+
+    # ── Accessors ─────────────────────────────────────────────────────────
+
+    @property
+    def sandbox(self) -> Sandbox:
+        """The underlying E2B-compatible sandbox handle."""
+        if self._sandbox is None:
+            raise RuntimeError("Sandbox is not running (already cleaned up?)")
+        return self._sandbox
+
+    # ── Readiness ─────────────────────────────────────────────────────────
+
+    def _wait_for_ready(self, *, timeout: float) -> None:
+        """Poll the agent server /ready endpoint until it reports readiness.
+
+        /ready (unlike the liveness /health) returns non-2xx until the server
+        has fully finished initialization.
+        """
+        ready_url = f"{self.host.rstrip('/')}/ready"
+        deadline = time.monotonic() + timeout
+        last_error: Exception | None = None
+        while time.monotonic() < deadline:
+            try:
+                request = Request(ready_url, headers=self._headers)
+                with urlopen(request, timeout=2.0) as resp:
+                    if 200 <= getattr(resp, "status", 200) < 300:
+                        return
+            except Exception as exc:  # noqa: BLE001 - retried until deadline
+                last_error = exc
+            time.sleep(0.5)
+        raise RuntimeError(
+            f"Agent server at {ready_url} did not become ready within "
+            f"{timeout:.0f}s (last error: {last_error!r}). Check that the "
+            "template autostarts the agent server on port "
+            f"{self.agent_server_port} and that the platform proxy is reachable."
+        )
+
+    @property
+    def alive(self) -> bool:
+        """Readiness through the authenticated client (the parent's bare
+        /health probe cannot pass the private-traffic gate)."""
+        try:
+            response = self.client.get("/ready")
+            return 200 <= response.status_code < 300
+        except Exception:  # noqa: BLE001 - liveness probe returns bool, never raises
+            return False
+
+    # ── Lifecycle ─────────────────────────────────────────────────────────
+
+    def pause(self) -> None:
+        """Freeze the entire MicroVM — agent server, shells, and in-flight
+        processes included. Memory and filesystem state are preserved.
+
+        Combine with ``kill_on_exit=False`` to keep the paused sandbox for a
+        later ``CubeSandboxWorkspace(sandbox_id=...)`` re-attach."""
+        logger.info("Pausing sandbox %s", self.sandbox.sandbox_id)
+        self.sandbox.pause()
+
+    def resume(self) -> None:
+        """Thaw a paused MicroVM and wait for the agent server to respond."""
+        sandbox_id = self.sandbox.sandbox_id
+        logger.info("Resuming sandbox %s", sandbox_id)
+        self._sandbox = Sandbox.connect(sandbox_id)
+        self._wait_for_ready(timeout=self.health_check_timeout)
+        logger.info("Sandbox %s resumed", sandbox_id)
+
+    def _kill_sandbox(self) -> None:
+        if self._sandbox is not None:
+            logger.info("Killing sandbox %s", self._sandbox.sandbox_id)
+            try:
+                self._sandbox.kill()
+            finally:
+                self._sandbox = None
+
+    def cleanup(self) -> None:
+        """Release the workspace.
+
+        Kills the sandbox when ``kill_on_exit`` says so (default: only for
+        sandboxes this workspace created); otherwise the sandbox keeps
+        running/paused for a later re-attach. The HTTP client is closed
+        either way."""
+        self.reset_client()
+        should_kill = (
+            self._owns_sandbox if self.kill_on_exit is None else self.kill_on_exit
+        )
+        if should_kill:
+            self._kill_sandbox()
+        else:
+            if self._sandbox is not None:
+                logger.info(
+                    "Leaving sandbox %s running (kill_on_exit=False); "
+                    "re-attach later with CubeSandboxWorkspace(sandbox_id=...)",
+                    self._sandbox.sandbox_id,
+                )
+            self._sandbox = None
+
+    def __enter__(self) -> Self:
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb) -> None:  # type: ignore[no-untyped-def]
+        # RemoteWorkspace.__exit__ only sends the completion callback and
+        # BaseWorkspace.__exit__ is a documented no-op, so cleanup must be
+        # explicit — and in a finally, so a failed callback cannot leak the
+        # sandbox.
+        try:
+            super().__exit__(exc_type, exc_val, exc_tb)
+        finally:
+            self.cleanup()

--- a/examples/openhands-integration/cubesandbox_workspace.py
+++ b/examples/openhands-integration/cubesandbox_workspace.py
@@ -158,8 +158,10 @@ class CubeSandboxWorkspace(RemoteWorkspace):
     _owns_sandbox: bool = PrivateAttr(default=False)
     # The platform's connect/resume API deliberately does not re-surface the
     # traffic token (CubeProxy validates it from Redis), so the client must
-    # preserve the original one across resume/re-attach.
-    _saved_traffic_token: str | None = PrivateAttr(default=None)
+    # preserve the original one across resume/re-attach. Kept as SecretStr so
+    # accidental repr/print shows a mask; unwrapped only at the header and
+    # persistence boundaries.
+    _saved_traffic_token: SecretStr | None = PrivateAttr(default=None)
 
     @model_validator(mode="before")
     @classmethod
@@ -177,7 +179,7 @@ class CubeSandboxWorkspace(RemoteWorkspace):
             sandbox = Sandbox.connect(self.sandbox_id)  # resumes if paused
             self._owns_sandbox = False
             if self.traffic_access_token is not None:
-                self._saved_traffic_token = self.traffic_access_token.get_secret_value()
+                self._saved_traffic_token = self.traffic_access_token
             logger.info(
                 "Attached to CubeSandbox %s in %.0f ms",
                 sandbox.sandbox_id,
@@ -203,7 +205,8 @@ class CubeSandboxWorkspace(RemoteWorkspace):
                 create_kwargs["network"] = network
             sandbox = Sandbox.create(**create_kwargs)
             self._owns_sandbox = True
-            self._saved_traffic_token = getattr(sandbox, "traffic_access_token", None)
+            raw_token = getattr(sandbox, "traffic_access_token", None)
+            self._saved_traffic_token = SecretStr(raw_token) if raw_token else None
             logger.info(
                 "Created CubeSandbox %s from template %s in %.0f ms",
                 sandbox.sandbox_id,
@@ -255,13 +258,14 @@ class CubeSandboxWorkspace(RemoteWorkspace):
 
     @property
     def _traffic_token(self) -> str | None:
-        return self._saved_traffic_token
+        token = self._saved_traffic_token
+        return token.get_secret_value() if token else None
 
     @property
     def traffic_token(self) -> str | None:
-        """The per-sandbox traffic token (persist it to re-attach to a
-        private sandbox from another process)."""
-        return self._saved_traffic_token
+        """The per-sandbox traffic token in plain text (persist it to
+        re-attach to a private sandbox from another process)."""
+        return self._traffic_token
 
     @property
     def _headers(self) -> dict[str, str]:
@@ -385,7 +389,8 @@ class CubeSandboxWorkspace(RemoteWorkspace):
         # RemoteWorkspace.__exit__ only sends the completion callback and
         # BaseWorkspace.__exit__ is a documented no-op, so cleanup must be
         # explicit — and in a finally, so a failed callback cannot leak the
-        # sandbox.
+        # sandbox. Returning None is intentional: the parent contract also
+        # returns None (never True), so no exception suppression is discarded.
         try:
             super().__exit__(exc_type, exc_val, exc_tb)
         finally:

--- a/examples/openhands-integration/cubesandbox_workspace.py
+++ b/examples/openhands-integration/cubesandbox_workspace.py
@@ -246,7 +246,10 @@ class CubeSandboxWorkspace(RemoteWorkspace):
 
         The proxy exposes in-sandbox ports as public hosts of the form
         "<port>-<sandbox-id>.<domain>" (see the quickstart mask-request-host
-        example); the proxy's HTTP port is appended when it is not 80.
+        example); the proxy's HTTP port is appended when it is not 80. The
+        http scheme is intentional: cube-proxy serves plain HTTP here, and
+        TLS (if any) terminates at an upstream reverse proxy, not in this
+        URL.
         """
         public_host = sandbox.get_host(self.agent_server_port)
         port_suffix = ""
@@ -301,9 +304,12 @@ class CubeSandboxWorkspace(RemoteWorkspace):
         deadline = time.monotonic() + timeout
         last_error: Exception | None = None
         while time.monotonic() < deadline:
+            # Cap each attempt at the remaining overall budget so a
+            # health_check_timeout below 2 s is still honored exactly.
+            attempt_timeout = max(0.1, min(2.0, deadline - time.monotonic()))
             try:
                 request = Request(ready_url, headers=self._headers)
-                with urlopen(request, timeout=2.0) as resp:
+                with urlopen(request, timeout=attempt_timeout) as resp:
                     if 200 <= getattr(resp, "status", 200) < 300:
                         return
             except Exception as exc:  # noqa: BLE001 - retried until deadline

--- a/examples/openhands-integration/main.py
+++ b/examples/openhands-integration/main.py
@@ -1,0 +1,108 @@
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""Minimal end-to-end demo: an OpenHands agent completes a coding task with
+every command and file operation executed inside a CubeSandbox MicroVM.
+
+The conversation runs against the agent server that is pre-baked into the
+CubeSandbox template, so there is no per-session environment build. The LLM
+is any OpenAI-compatible endpoint (configured via .env); the agent loop itself
+runs inside the sandbox, which means the MicroVM needs egress to the LLM
+endpoint (CubeSandbox's default egress policy allows this; see the README's
+security section for allowlist-restricted variants).
+
+Usage:
+    python main.py
+
+Requires .env: E2B_API_URL, E2B_API_KEY, CUBE_TEMPLATE_ID,
+               LLM_MODEL, LLM_API_KEY, and optionally LLM_BASE_URL.
+"""
+
+import os
+import sys
+from pathlib import Path
+
+from dotenv import load_dotenv
+from openhands.sdk import LLM, Conversation
+from openhands.tools.preset.default import get_default_agent
+from pydantic import SecretStr
+
+from cubesandbox_workspace import CubeSandboxWorkspace
+
+load_dotenv(Path(__file__).resolve().parent / ".env")
+
+TASK = (
+    "Create /workspace/fib.py that prints the first 20 Fibonacci numbers, "
+    "one per line. Run it with python3 and fix any errors until the output "
+    "is correct."
+)
+
+
+def main() -> int:
+    missing = [
+        k
+        for k in (
+            "E2B_API_URL",
+            "E2B_API_KEY",
+            "CUBE_TEMPLATE_ID",
+            "LLM_MODEL",
+            "LLM_API_KEY",
+        )
+        if not os.getenv(k)
+    ]
+    if missing:
+        print(f"missing environment variables: {', '.join(missing)}")
+        print("copy .env.example to .env and fill it in first")
+        return 2
+
+    llm = LLM(
+        model=os.environ["LLM_MODEL"],
+        api_key=SecretStr(os.environ["LLM_API_KEY"]),
+        base_url=os.getenv("LLM_BASE_URL") or None,
+        usage_id="agent",
+    )
+    # cli_mode=True keeps the toolset to bash + file editing — no browser
+    # stack is needed inside the template for this demo.
+    agent = get_default_agent(llm=llm, cli_mode=True)
+
+    with CubeSandboxWorkspace(template=os.environ["CUBE_TEMPLATE_ID"]) as workspace:
+        print(f"sandbox {workspace.sandbox_id} up, agent server at {workspace.host}")
+        conversation = Conversation(agent=agent, workspace=workspace)
+        try:
+            print(f"task: {TASK}\n")
+            conversation.send_message(TASK)
+            conversation.run()
+        finally:
+            conversation.close()
+
+        # Ground truth straight from inside the MicroVM, independent of any
+        # claim the agent made in conversation. The script's own output is
+        # checked in isolation so source-code contents can't satisfy it.
+        print("\n--- verification from inside the sandbox ---")
+        proof_src = workspace.execute_command("cat /workspace/fib.py")
+        print(proof_src.stdout)
+        print("---")
+        proof_run = workspace.execute_command("python3 /workspace/fib.py")
+        print(proof_run.stdout)
+        run_lines = proof_run.stdout.strip().splitlines()
+        # Accept either canonical start (F0=0 or F1=1) — both are legitimate
+        # readings of "the first 20 Fibonacci numbers", and the model picks
+        # one or the other from run to run. Verifying the recurrence keeps
+        # the check deterministic and stricter than any fixed anchor value.
+        try:
+            nums = [int(line.strip()) for line in run_lines]
+        except ValueError:
+            nums = []
+        ok = (
+            proof_run.exit_code == 0
+            and len(nums) == 20
+            and nums[:2] in ([0, 1], [1, 1])
+            and all(nums[i] == nums[i - 1] + nums[i - 2] for i in range(2, 20))
+        )
+        if not ok and proof_run.stderr:
+            print(f"stderr: {proof_run.stderr.strip()}")
+        print("PASS" if ok else "FAIL: expected 20 Fibonacci numbers, one per line")
+        return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/examples/openhands-integration/pause_resume.py
+++ b/examples/openhands-integration/pause_resume.py
@@ -65,7 +65,9 @@ def main() -> int:
     )
     sandbox_id = workspace.sandbox_id
     # Until the re-attach hand-off succeeds, any failure must reap the
-    # deliberately-kept sandbox — nobody else would.
+    # deliberately-kept sandbox — nobody else would. BaseException on purpose:
+    # Ctrl-C during the frozen-gap sleep is the likeliest interrupt, and it
+    # too must reap before propagating (the handler re-raises unconditionally).
     try:
         print(f"sandbox {sandbox_id} up, agent server at {workspace.host}")
 

--- a/examples/openhands-integration/pause_resume.py
+++ b/examples/openhands-integration/pause_resume.py
@@ -1,0 +1,131 @@
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""Demonstrate full-VM pause/resume and cross-object re-attach underneath a
+live OpenHands agent server.
+
+OpenHands sessions are long by nature — an agent can spend minutes to hours
+on a task. With DockerWorkspace, stopping means losing the session.
+CubeSandbox pauses the *entire MicroVM*: agent server, bash sessions, and any
+in-flight processes are frozen mid-instruction and thawed later, bit-for-bit.
+
+This demo needs no LLM key and shows the full round trip:
+
+  1. start a 1-second ticker inside the sandbox (via the agent server);
+  2. pause the VM while the host keeps counting wall-clock time;
+  3. drop the workspace object entirely (``kill_on_exit=False`` keeps the
+     paused sandbox alive) — as if the Python process had exited;
+  4. re-attach from a fresh ``CubeSandboxWorkspace(sandbox_id=...)``, which
+     auto-resumes the VM, and show the ticker continued from the exact
+     frozen instant — the wall-clock gap left no hole in the sequence.
+
+Usage:
+    python pause_resume.py
+
+Requires .env (or exported env): E2B_API_URL, E2B_API_KEY, CUBE_TEMPLATE_ID.
+"""
+
+import os
+import sys
+import time
+from pathlib import Path
+
+from dotenv import load_dotenv
+from e2b_code_interpreter import Sandbox
+
+from cubesandbox_workspace import CubeSandboxWorkspace
+
+load_dotenv(Path(__file__).resolve().parent / ".env")
+
+PAUSE_WALL_SECONDS = 8
+
+
+def tick_count(workspace: CubeSandboxWorkspace) -> int:
+    result = workspace.execute_command("wc -l < /workspace/ticks.log || echo 0")
+    try:
+        return int(result.stdout.strip().splitlines()[-1])
+    except (ValueError, IndexError):
+        return 0
+
+
+def main() -> int:
+    missing = [
+        k
+        for k in ("E2B_API_URL", "E2B_API_KEY", "CUBE_TEMPLATE_ID")
+        if not os.getenv(k)
+    ]
+    if missing:
+        print(f"missing environment variables: {', '.join(missing)}")
+        print("copy .env.example to .env and fill it in first")
+        return 2
+
+    # kill_on_exit=False: cleanup() detaches instead of killing, so the
+    # paused sandbox survives this object — and would survive this process.
+    workspace = CubeSandboxWorkspace(
+        template=os.environ["CUBE_TEMPLATE_ID"], kill_on_exit=False
+    )
+    sandbox_id = workspace.sandbox_id
+    # Until the re-attach hand-off succeeds, any failure must reap the
+    # deliberately-kept sandbox — nobody else would.
+    try:
+        print(f"sandbox {sandbox_id} up, agent server at {workspace.host}")
+
+        print("starting a 1s ticker inside the MicroVM (via the agent server) ...")
+        workspace.execute_command(
+            "rm -f /workspace/ticks.log && "
+            "nohup sh -c 'i=0; while true; do i=$((i+1)); "
+            "echo $i >> /workspace/ticks.log; sleep 1; done' "
+            ">/dev/null 2>&1 & echo started"
+        )
+        time.sleep(4)
+        before = tick_count(workspace)
+        print(f"ticks before pause: {before}")
+
+        print("pausing the VM (memory + filesystem snapshot) ...")
+        workspace.pause()
+        print("dropping the workspace object — the paused sandbox stays alive ...")
+        workspace.cleanup()
+
+        print(
+            f"host waits {PAUSE_WALL_SECONDS}s of wall-clock time while the VM is frozen ..."
+        )
+        time.sleep(PAUSE_WALL_SECONDS)
+
+        print(
+            f"re-attaching to {sandbox_id} from a fresh workspace object (auto-resume) ..."
+        )
+        reattached = CubeSandboxWorkspace(sandbox_id=sandbox_id, kill_on_exit=True)
+    except BaseException:
+        try:
+            Sandbox.connect(sandbox_id).kill()
+        except Exception:  # noqa: BLE001, S110 - best-effort reap before re-raise
+            pass
+        raise
+    try:
+        just_after = tick_count(reattached)
+        time.sleep(3)
+        later = tick_count(reattached)
+    finally:
+        reattached.cleanup()
+
+    print()
+    print(f"ticks before pause              : {before}")
+    print(f"ticks right after re-attach     : {just_after}")
+    print(f"ticks 3s after re-attach        : {later}")
+    print(f"host wall-clock frozen gap      : {PAUSE_WALL_SECONDS}s")
+
+    frozen_ok = just_after - before <= 2  # no ticks happened while frozen
+    resumed_ok = later > just_after  # ticker continued after thaw
+    if frozen_ok and resumed_ok:
+        print(
+            "\nPASS: the ticker (and the agent server around it) was frozen "
+            "mid-flight, survived the death of the original workspace object, "
+            "and continued from the exact same instant after re-attach — "
+            f"the {PAUSE_WALL_SECONDS}s host-side gap left no hole in the sequence."
+        )
+        return 0
+    print("\nFAIL: unexpected tick progression — see numbers above")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/examples/openhands-integration/requirements.txt
+++ b/examples/openhands-integration/requirements.txt
@@ -1,0 +1,12 @@
+# Host-side dependencies. The in-sandbox agent server is pinned separately in
+# the Dockerfile (OPENHANDS_AGENT_SERVER_VERSION) — keep them compatible.
+#
+# NOTE: install with uv (or a current pip >= 26). Older pips — e.g. Ubuntu
+# 24.04's stock pip 24.0 — fail to resolve the lmnr / opentelemetry
+# constraints in the OpenHands dependency graph:
+#   uv venv .venv --python 3.12 && source .venv/bin/activate
+#   uv pip install -r requirements.txt
+openhands-sdk==1.38.0
+openhands-tools==1.38.0
+e2b-code-interpreter>=2.4.1
+python-dotenv

--- a/examples/openhands-integration/requirements.txt
+++ b/examples/openhands-integration/requirements.txt
@@ -12,4 +12,4 @@
 openhands-sdk==1.38.0
 openhands-tools==1.38.0
 e2b-code-interpreter>=2.4.1
-python-dotenv
+python-dotenv>=1.0.0

--- a/examples/openhands-integration/requirements.txt
+++ b/examples/openhands-integration/requirements.txt
@@ -1,6 +1,9 @@
 # Host-side dependencies. The in-sandbox agent server is pinned separately in
 # the Dockerfile (OPENHANDS_AGENT_SERVER_VERSION) — keep them compatible.
 #
+# Python >= 3.12 — the floor is set by openhands-sdk's requires-python;
+# all examples are tested on 3.12.
+#
 # NOTE: install with uv (or a current pip >= 26). Older pips — e.g. Ubuntu
 # 24.04's stock pip 24.0 — fail to resolve the lmnr / opentelemetry
 # constraints in the OpenHands dependency graph:

--- a/examples/openhands-integration/smoke_test.py
+++ b/examples/openhands-integration/smoke_test.py
@@ -1,0 +1,102 @@
+# Copyright (c) 2026 Tencent Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""No-LLM smoke test for the OpenHands x CubeSandbox integration.
+
+Verifies, against a real CubeSandbox deployment and without needing any LLM
+API key:
+
+  1. a sandbox hot-starts from the template with the agent server already live
+     (the create -> healthy latency is printed as evidence);
+  2. the agent server answers /server_info through the platform proxy;
+  3. bash execution round-trips through the OpenHands workspace API;
+  4. file upload/download round-trips through the OpenHands workspace API.
+
+For the pause/resume capability, see pause_resume.py.
+
+Usage:
+    python smoke_test.py
+
+Requires .env (or exported env): E2B_API_URL, E2B_API_KEY, CUBE_TEMPLATE_ID.
+"""
+
+import os
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+from dotenv import load_dotenv
+
+from cubesandbox_workspace import CubeSandboxWorkspace
+
+load_dotenv(Path(__file__).resolve().parent / ".env")
+
+PASS = "\033[32mPASS\033[0m"
+FAIL = "\033[31mFAIL\033[0m"
+
+
+def require_env() -> str:
+    missing = [
+        k
+        for k in ("E2B_API_URL", "E2B_API_KEY", "CUBE_TEMPLATE_ID")
+        if not os.getenv(k)
+    ]
+    if missing:
+        print(f"{FAIL} missing environment variables: {', '.join(missing)}")
+        print("      copy .env.example to .env and fill it in first")
+        sys.exit(2)
+    return os.environ["CUBE_TEMPLATE_ID"]
+
+
+def main() -> int:
+    template = require_env()
+    failures = 0
+
+    print(f"[1/4] creating sandbox from template {template} ...")
+    t0 = time.monotonic()
+    workspace = CubeSandboxWorkspace(template=template)
+    create_ms = (time.monotonic() - t0) * 1000
+    print(
+        f"      {PASS} sandbox {workspace.sandbox_id} healthy in {create_ms:.0f} ms "
+        "(agent server was pre-warmed in the template snapshot)"
+    )
+
+    try:
+        print("[2/4] querying agent server /server_info through the proxy ...")
+        info = workspace.get_server_info()
+        print(f"      {PASS} server_info: {str(info)[:120]}")
+
+        print("[3/4] bash round-trip via the OpenHands workspace API ...")
+        result = workspace.execute_command("echo hello-from-$(uname -m)-microvm")
+        if result.exit_code == 0 and "hello-from-" in result.stdout:
+            print(f"      {PASS} stdout: {result.stdout.strip()}")
+        else:
+            failures += 1
+            print(f"      {FAIL} exit={result.exit_code} stdout={result.stdout!r}")
+
+        print("[4/4] file upload/download round-trip ...")
+        payload = f"cube-openhands-smoke-{int(time.time())}\n"
+        with tempfile.TemporaryDirectory() as tmp:
+            src = Path(tmp) / "up.txt"
+            src.write_text(payload)
+            workspace.file_upload(src, "/workspace/smoke.txt")
+            dst = Path(tmp) / "down.txt"
+            workspace.file_download("/workspace/smoke.txt", dst)
+            if dst.read_text() == payload:
+                print(f"      {PASS} payload survived the round-trip")
+            else:
+                failures += 1
+                print(f"      {FAIL} payload mismatch: {dst.read_text()!r}")
+    finally:
+        workspace.cleanup()
+
+    print()
+    if failures == 0:
+        print(f"{PASS} all smoke checks passed")
+        return 0
+    print(f"{FAIL} {failures} smoke check(s) failed")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Problem

[OpenHands](https://www.openhands.dev/) executes every agent action (bash, file edits, scripts) through its **agent server**, and its stock remote workspace, `DockerWorkspace`, boots a fresh agent-server container for each session on a shared host kernel. So every session pays the server's cold start — and although OpenHands sessions are long-lived by nature, stopping the container loses the entire session: conversation state, shells, and in-flight processes all live inside it.

Refs #244 (claimed via `/claim openhands`), #645.

## Solution

Bake the agent server into a CubeSandbox template and take the boot snapshot only after the server itself reports ready (`--probe 8000 --probe-path /ready`), then plug in through the SDK's own extension point: `CubeSandboxWorkspace` subclasses `RemoteWorkspace` exactly like the first-party workspaces (`DockerWorkspace`, `ApptainerWorkspace`, …), so an existing OpenHands program switches by replacing one constructor. Measured on a real cluster, this yields:

- create→healthy in **182 ms** (the same image cold-starts its server in **~6 s** under plain Docker) — no per-session environment build at all;
- whole-VM `pause()` / `resume()`: since the agent loop and conversation state live in the in-VM server, pausing the VM freezes the *entire session*, and re-attach by `sandbox_id` resumes it from another process, even days later;
- KVM MicroVM isolation, plus platform inbound/egress controls (`private_traffic` per-sandbox tokens, egress allowlists, and a documented credential-injection path that keeps the raw LLM key out of the VM).

Layout follows the merged pi-agent integration (#701): a bilingual guide plus a runnable example.

## What Changed

- **Runnable example** at `examples/openhands-integration/`:
  - `Dockerfile` — OpenHands agent server (`openhands-agent-server==1.38.0`, standalone Python 3.12 via uv) on `cubesandbox-base`; envd stays on `:49983`; the server starts on `:8000` as the image CMD under the `user` account. `SSL_CERT_FILE` points at the system trust store so credential-injection egress rules work against the pre-warmed server.
  - `cubesandbox_workspace.py` — `CubeSandboxWorkspace(RemoteWorkspace)`, the same extension point upstream's `DockerWorkspace` uses: creates/attaches sandboxes via the E2B-compatible SDK, waits on the server's strict `/ready`, supports `private_traffic` (per-sandbox traffic token on every workspace request), whole-VM `pause()`/`resume()`, and cross-process re-attach by `sandbox_id` (auto-resume).
  - `smoke_test.py` — no-LLM end-to-end proof: hot-start latency, `/server_info`, bash + file round-trips.
  - `main.py` — full agent coding task; the result is verified **from inside the sandbox**, independent of the agent's own claims.
  - Bilingual `README.md` / `README_zh.md`, `.env.example`, `requirements.txt`.
- **Integration guide** in both languages, on the `_template.md` frontmatter, linked from both index tables:
  - `docs/guide/integrations/openhands.md`
  - `docs/zh/guide/integrations/openhands.md`

## Acceptance (#244)

1. One standalone guide file per language, linked from the integrations index ✅
2. Runnable example with template definition + reproducible flow + bilingual README ✅
3. Aligned with platform security mechanics (egress allowlist, traffic tokens, `SESSION_API_KEY`, credential-injection pointer) ✅
4. Caveats/troubleshooting aligned with existing template/probe/auth mechanics ✅

## Test Plan

- [x] `python -m py_compile` on all three scripts; ruff 0.16.0 `check` + `format --check` clean
- [x] `cd docs && npm run docs:build` (VitePress 1.6.4) — passes in 10.8 s
- [x] `git diff --check` clean
- [x] `docker build --no-cache` — 37.8 s, image 746 MB
- [x] Plain-Docker sanity: `GET :8000/ready` → **200** (~6 s cold start), `GET :49983/health` → **204**

## Live cluster run

All results below were produced against a **real single-node CubeSandbox v0.6.0 cluster** (arm64 host, self-built base image, deployment proxy on `:10080`), at this PR's head. Template registered with `--probe 8000 --probe-path /ready` (snapshot taken only after the agent server reports ready); the template build reached `READY` in ~16 s (one-time cost — per-session sandbox creation is the 182 ms below). Terminal and Dashboard screenshots below carry the full run output.

- [x] `smoke_test.py` — sandbox healthy in **182 ms**, all 4 checks pass:

<img width="1025" height="420" alt="smoke_test.py — 4/4 PASS, healthy in 182 ms" src="https://github.com/user-attachments/assets/c89d261f-f783-41ec-8587-b053203b5577" />


- [x] `main.py` — the agent created and ran `/workspace/fib.py`; verification executed the script **inside the MicroVM** and checked the Fibonacci recurrence over all 20 lines (exit 0):

```text
--- verification from inside the sandbox ---
# Print the first 20 Fibonacci numbers, one per line
a, b = 0, 1
for i in range(20):
    print(a)
    a, b = b, a + b

---
0
1
1
2
3
5
8
13
21
34
55
89
144
233
377
610
987
1597
2584
4181

PASS
```

- [x] Dashboard (v0.6.0): template `READY` card:

<img width="2890" height="1808" alt="Dashboard — template READY card" src="https://github.com/user-attachments/assets/d1cdb6df-950f-4c8f-8069-88bad19b952f" />

Refs #244, #645