### PR TITLE
fix(images): drop host go requirement from build-cube-images.sh

### DIFF
--- a/deploy/kubernetes/images/build-cube-images.sh
+++ b/deploy/kubernetes/images/build-cube-images.sh
@@ -1133,8 +1133,9 @@ parse_args "$@"
 need docker
 need tar
 need curl
-need go
 need sha256sum
+# Go is not required on the host: component binaries are compiled inside
+# Dockerfile builder stages. LOCAL_BIN=1 only overlays prebuilt binaries.
 
 DOWNLOAD_DIR="${BUILD_ROOT}/downloads"
 EXTRACT_DIR="${BUILD_ROOT}/extract"


### PR DESCRIPTION
## Summary

- Remove the unconditional `need go` check from `deploy/kubernetes/images/build-cube-images.sh`.
- Host `go` is not used by the default path: component binaries are compiled inside Dockerfile builder stages, and `LOCAL_BIN=1` only overlays prebuilt binaries from disk.

## Test plan

- [x] Confirmed `build-cube-images.sh --help` works with `go` removed from `PATH` (host without Go)
- [x] Confirmed the script no longer contains an unconditional `need go` line