### PR TITLE
fix(cubeproxy): initialize admin access log variables

### DIFF
--- a/CubeProxy/Makefile
+++ b/CubeProxy/Makefile
@@ -45,6 +45,7 @@ build:
 .PHONY: test
 test:
 	bash tests/test_start.sh
+	bash tests/test_admin_access_log.sh
 
 # Push the architecture-specific image to all registries.
 # Run `make push` on an amd64 host, then again on an arm64 host, then

--- a/CubeProxy/nginx.conf
+++ b/CubeProxy/nginx.conf
@@ -386,6 +386,16 @@ http {
         listen 127.0.0.1:8082;
         server_name _;
 
+        # The inherited access log format includes dataplane-only variables.
+        # Admin requests have no backend or sandbox ID, so initialize those
+        # fields to empty values while preserving the shared log schema.
+        set $backend_ip "";
+        set $access_time "";
+        set $ins_id "";
+        # Populate $access_time for every admin-port response, including 404s.
+        # Empty $ins_id makes the sandbox last-active update a no-op.
+        log_by_lua_file lua/log_phase.lua;
+
         # Operator may override in global.conf to require a shared token. When
         # left empty the admin endpoints accept any loopback request.
         set $cube_admin_token "";

--- a/CubeProxy/tests/test_admin_access_log.sh
+++ b/CubeProxy/tests/test_admin_access_log.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# CubeProxy admin access-log variable regression tests.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CUBE_PROXY_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+NGINX_CONF="${CUBE_PROXY_DIR}/nginx.conf"
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+assert_contains() {
+  grep -Fq -- "$2" "$1" || fail "expected $1 to contain: $2"
+}
+
+assert_contains "${NGINX_CONF}" 'access_log /data/log/cube-proxy/access.log access;'
+assert_contains "${NGINX_CONF}" "log_format access '\$access_time||\$host||"
+assert_contains "${NGINX_CONF}" "\$http_x_cube_request_id||\$http_x_cube_instance_id||\$backend_ip';"
+assert_contains "${CUBE_PROXY_DIR}/lua/log_phase.lua" 'ngx.var.access_time = get_currtime()'
+
+admin_server="$({
+  sed -n '/listen 127\.0\.0\.1:8082;/,/^    }/p' "${NGINX_CONF}"
+})"
+admin_server_prelocation="$({
+  sed -n '/listen 127\.0\.0\.1:8082;/,/location \/admin\//p' "${NGINX_CONF}"
+})"
+
+grep -Fq 'set $access_time "";' <<<"${admin_server}" \
+  || fail "8082 admin server must initialize access_time for the inherited access log"
+grep -Fq 'set $backend_ip "";' <<<"${admin_server}" \
+  || fail "8082 admin server must initialize backend_ip for the inherited access log"
+grep -Fq 'set $ins_id "";' <<<"${admin_server}" \
+  || fail "8082 admin server must initialize ins_id before reusing log_phase.lua"
+grep -Fq 'log_by_lua_file lua/log_phase.lua;' <<<"${admin_server_prelocation}" \
+  || fail "8082 server must populate access_time for every response through log_phase.lua"
+
+if grep -Fq 'admin-access.log' "${NGINX_CONF}"; then
+  fail "admin requests must keep using the shared access.log schema"
+fi
+
+echo "CubeProxy admin access-log tests passed"


### PR DESCRIPTION
## Motivation

CubeProxy's `access` log format is defined at HTTP scope and inherited by the 8082 admin server. The format references `$access_time` and `$backend_ip`, but those variables were only initialized on sandbox dataplane routes.

The lifecycle manager polls `/admin/last_active` every five seconds, so each healthy admin poll could still produce repeated uninitialized-variable warnings in `error.log`:

```text
using uninitialized "access_time" variable while logging request, request: "GET /admin/last_active?since=... HTTP/1.1"
using uninitialized "backend_ip" variable while logging request, request: "GET /admin/last_active?since=... HTTP/1.1"
```

These warnings are emitted while Nginx formats the inherited access log, not while `admin_phase.lua` handles the request. A successful poll can therefore still generate misleading warning entries.

Admin requests do not proxy to a sandbox backend, so `$backend_ip` should remain empty. The shared log phase also expects `$ins_id`; initialize it to an empty value so the sandbox last-active update remains a no-op.

## What Changed

* Initialize `$backend_ip`, `$access_time`, and `$ins_id` for the 8082 admin server.
* Run `log_phase.lua` at 8082 server scope so admin responses, including 404s, receive a real `$access_time`.
* Keep `$backend_ip` and `$ins_id` empty because admin requests do not target a sandbox backend.
* Keep the empty `$ins_id` path as a no-op for sandbox last-active updates.
* Continue writing admin requests to the existing `/data/log/cube-proxy/access.log`.
* Preserve the existing `access` log schema and admin logging policy.
* Add focused regression coverage to the CubeProxy test target.

## Validation

* `bash -n CubeProxy/tests/test_admin_access_log.sh`
* `make -C CubeProxy test` passed, including the focused admin access-log regression coverage.
* OpenResty 1.21.4.1 `nginx -t` passed with the candidate configuration.
* Runtime validation on a real deployment covered `/admin/last_active`, an admin-port 404, and a server-scope 404.
* Confirmed real `$access_time` values, empty backend/sandbox fields, and no uninitialized `$access_time`, `$backend_ip`, or `$ins_id` warnings in the runtime logs.

## Scope

This change only adjusts CubeProxy admin access logging.

A follow-up may consider conditional admin access logging, for example using an HTTP-level `map` with `access_log ... if=...` to skip successful low-signal polling requests while still logging failures, state-changing admin requests, and unknown routes.
