### PR TITLE
fix(cubelet): skip creating sandboxes in DeadGC to fix pause failure

### DIFF
--- a/Cubelet/services/cubebox/rollback_test.go
+++ b/Cubelet/services/cubebox/rollback_test.go
@@ -190,3 +190,44 @@ func TestScanDeadContainerSkipsRollingBack(t *testing.T) {
 	assert.Equal(t, staleFinishedAt, got.FinishedAt, "scanDeadContainer must not touch a rolling-back cubebox")
 	assert.True(t, got.Unknown, "Unknown must be left as-is for the rollback path to fix")
 }
+
+// TestScanDeadContainerSkipsCreatingSandbox reproduces the create/DeadGC race:
+// while a sandbox sits in the CONTAINER_CREATED window (store entry saved before
+// runContainer binds the containerd task), DeadGC must NOT call RecoverContainer,
+// which would find no task and wrongly stamp Unknown=true -- making a follow-up
+// pause fail with "sandbox is not running". A nil containerd client guarantees
+// the test panics/errors if the scan ever reaches RecoverContainer for this cb.
+func TestScanDeadContainerSkipsCreatingSandbox(t *testing.T) {
+	cb := newCubeboxWithStatusForTest("sb-deadgc-creating", cubeboxstore.Status{
+		CreatedAt: time.Now().UnixNano(),
+	})
+
+	// The nil client is the assertion: RecoverContainer -> client.LoadContainer
+	// dereferences the nil *containerd.Client and panics. NotPanics therefore
+	// proves the create-window guard short-circuited before reaching it.
+	assert.NotPanics(t, func() {
+		scanDeadContainer(context.Background(), []*cubeboxstore.CubeBox{cb}, nil, time.Hour)
+	}, "DeadGC must skip a creating sandbox before touching the containerd client")
+
+	assert.False(t, cb.GetStatus().IsTerminated(), "a creating sandbox must not read as terminated")
+	got := cb.GetStatus().Get()
+	assert.False(t, got.Unknown, "a creating sandbox must not be stamped Unknown by DeadGC")
+	assert.Equal(t, int64(0), got.FinishedAt, "a creating sandbox must not be stamped FinishedAt by DeadGC")
+}
+
+// TestScanDeadContainerCreateSkipIsBounded verifies the create skip is bounded:
+// once CreatedAt is older than createStuckThreshold the task was never bound and
+// the entry is genuinely stuck, so DeadGC must NOT short-circuit and instead
+// falls through to probe it. We drive scanDeadContainer with a nil client so
+// reaching RecoverContainer -> client.LoadContainer panics; assert.Panics thus
+// proves the guard let the stuck entry through rather than re-stating the guard
+// predicate literally.
+func TestScanDeadContainerCreateSkipIsBounded(t *testing.T) {
+	stuck := newCubeboxWithStatusForTest("sb-deadgc-stuck-create", cubeboxstore.Status{
+		CreatedAt: time.Now().Add(-2 * createStuckThreshold).UnixNano(),
+	})
+
+	assert.Panics(t, func() {
+		scanDeadContainer(context.Background(), []*cubeboxstore.CubeBox{stuck}, nil, time.Hour)
+	}, "a long-stuck creating sandbox must fall out of the skip window and be probed")
+}

--- a/Cubelet/services/cubebox/service.go
+++ b/Cubelet/services/cubebox/service.go
@@ -62,6 +62,18 @@ var (
 	defaultDestroyDeadline  = 60 * time.Second
 	defaultDeadContainerTTL = 1 * time.Hour
 	cleanerHeartBeat        = 10 * time.Second
+
+	// createStuckThreshold bounds how long a sandbox may legitimately remain in
+	// the CONTAINER_CREATED transient before DeadGC is allowed to probe it. The
+	// create path saves the cubebox into the store (state CONTAINER_CREATED)
+	// BEFORE runContainer binds the containerd task and sets StartedAt; within
+	// that window RecoverContainer would find no task and wrongly stamp
+	// Unknown=true. A real create completes (or fails and cleans up) well within
+	// defaultCreateDeadline, so once CreatedAt is older than this the entry is
+	// genuinely stuck and safe to reap. It MUST stay comfortably larger than
+	// defaultCreateDeadline. Mirrors pausingStuckThreshold (update.go), which
+	// bounds the PAUSING transient the same "2x the deadline" way.
+	createStuckThreshold = 2 * defaultCreateDeadline
 )
 
 func defaultServiceConfig() *ServicesConfig {
@@ -1006,6 +1018,23 @@ func scanDeadContainer(ctx context.Context, dc []*cubeboxstore.CubeBox, client *
 				continue
 			}
 			switch st.State() {
+			case cubebox.ContainerState_CONTAINER_CREATED:
+				// Sandbox create is in flight: createCubeboxContainer saves the
+				// cubebox into the store (state CONTAINER_CREATED, CreatedAt only)
+				// BEFORE runContainer binds the containerd container/task and sets
+				// StartedAt. In this window RecoverContainer -> loadStatus finds no
+				// task yet and stamps Unknown=true / FinishedAt=now, which State()
+				// ranks above StartedAt (see pkg/store/cubebox/status.go) -- so the
+				// sandbox reads as terminated forever even after the task starts
+				// RUNNING, breaking a follow-up pause with "sandbox is not running".
+				// Create owns this phase (and its own failover/cleanup on failure),
+				// so DeadGC skips it while create could still be running, exactly
+				// like the PAUSING/RollingBack races. Past createStuckThreshold the
+				// entry is genuinely stuck (task never bound) and safe to reap.
+				if st.CreatedAt == 0 ||
+					time.Since(time.Unix(0, st.CreatedAt)) < createStuckThreshold {
+					continue
+				}
 			case cubebox.ContainerState_CONTAINER_PAUSED:
 				// User-driven pause: a legitimate, possibly long-lived state.
 				// Nothing for DeadGC to do.


### PR DESCRIPTION
A pause right after sandbox creation intermittently fails with:

```
__________ test_pause_and_connect_resume_preserves_files[cubesandbox] __________
cases/lifecycle/test_pause_resume.py:30: in test_pause_and_connect_resume_preserves_files
    sdk_sandbox.pause(timeout=sdk_e2e_config.default_timeout)
adapters/tracing_adapter.py:108: in pause
    return self._trace.capture(
framework/trace.py:163: in capture
    result = call()
             ^^^^^^
adapters/tracing_adapter.py:115: in <lambda>
    lambda: self._wrapped.pause(timeout=timeout),
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
adapters/cubesandbox_adapter.py:122: in pause
    self._sandbox.pause(timeout=timeout)
../../../sdk/python/cubesandbox/sandbox.py:485: in pause
    _check_response(resp)
../../../sdk/python/cubesandbox/sandbox.py:83: in _check_response
    raise ApiError(msg, code)
E   cubesandbox._exceptions.ApiError: CubeMaster returned error code 130490: sandbox is not running
```

A sandbox is saved into the store as CONTAINER_CREATED before its containerd task is bound and StartedAt is set. If the DeadGC scan runs during that window it probes the not-yet-bound task, wrongly marks the sandbox Unknown, and since that state outranks StartedAt the sandbox reads as terminated forever even after it is RUNNING. A follow-up pause then fails with TaskStateInvalid (130490) "sandbox is not running".

This is the same shim-busy race DeadGC already guards against for the PAUSING, PAUSED, and RollingBack states, now extended to the create window. The skip is bounded so a genuinely stuck, never-bound entry is still reaped.

Add regression tests for both the skip and its bound.