### PR TITLE
test(volume): cover per-sandbox access-mode serialization

### DIFF
--- a/sdk/python/tests/test_volume.py
+++ b/sdk/python/tests/test_volume.py
@@ -6,6 +6,7 @@ import pytest
 
 from cubesandbox import Sandbox, Volume, VolumeInfo, VolumeMount
 from cubesandbox._config import Config
+from cubesandbox._volume import _serialize_volume_mounts
 
 
 def _config() -> Config:
@@ -70,4 +71,18 @@ def test_volume_mount_default_does_not_change_e2b_payload():
 
     assert post.call_args.kwargs["json"]["volumeMounts"] == [
         {"name": "workspace-vol", "path": "/workspace"}
+    ]
+
+
+def test_serialize_same_volume_preserves_access_mode_per_sandbox():
+    volume = VolumeInfo(volume_id="shared-vol", name="shared")
+
+    read_write = _serialize_volume_mounts({"/shared": volume})
+    read_only = _serialize_volume_mounts(
+        {"/shared": VolumeMount(volume, read_only=True)}
+    )
+
+    assert read_write == [{"name": "shared-vol", "path": "/shared"}]
+    assert read_only == [
+        {"name": "shared-vol", "path": "/shared", "readOnly": True}
     ]


### PR DESCRIPTION
## Motivation

Follow up on review feedback from #1098 by covering the Python SDK serialization boundary for using the same Volume with different per-sandbox access modes.

## What Changed

* Cover independent read-write and read-only serialization for the same Volume across separate sandbox requests.
* Keep the existing restriction that a sandbox cannot attach the same Volume more than once.

## Validation

* Python SDK Volume tests passed.
* The COS-backed SDK compatibility case passed with concurrent read-write and read-only sandbox attachments to the same Volume.
