### PR TITLE
fix(cubemaster): claim template alias before publishing READY status

### DIFF
--- a/CubeMaster/pkg/templatecenter/image_job_runner.go
+++ b/CubeMaster/pkg/templatecenter/image_job_runner.go
@@ -177,10 +177,14 @@ func runTemplateImageJob(ctx context.Context, jobID string, req *types.CreateTem
 		ArtifactID: artifact.ArtifactID,
 		JobID:      jobID,
 	})
+	// claimWarning is populated by finalizeTemplateReplicas, which claims the
+	// alias *before* publishing the READY status so a client that sees READY
+	// can always resolve the alias.
+	claimWarning := ""
 	if persistErr != nil {
 		err = persistErr
 	} else {
-		info, err = finalizeTemplateReplicas(ctx, req.TemplateID, generatedReq.InstanceType, constants.GetAppSnapshotVersion(generatedReq.Annotations), replicas)
+		info, claimWarning, err = finalizeTemplateReplicas(ctx, req.TemplateID, generatedReq.InstanceType, constants.GetAppSnapshotVersion(generatedReq.Annotations), req.Alias, replicas)
 	}
 	if err != nil {
 		if builtFreshArtifact {
@@ -197,15 +201,8 @@ func runTemplateImageJob(ctx context.Context, jobID string, req *types.CreateTem
 		})
 		return
 	}
-	// Claim alias after READY via the shared helper.
-	claimWarning := ""
-	if info.Status != StatusFailed {
-		warning, displayName := claimAliasAfterReady(ctx, req.TemplateID, req.Alias)
-		claimWarning = warning
-		if displayName != "" {
-			info.DisplayName = displayName
-		}
-	}
+	// Alias was already claimed by finalizeTemplateReplicas (before the READY
+	// status was published) to avoid the create/claim publish-ordering race.
 	resultPayload, _ := json.Marshal(info)
 	jobStatus := JobStatusReady
 	jobPhase := JobPhaseReady

--- a/CubeMaster/pkg/templatecenter/redo.go
+++ b/CubeMaster/pkg/templatecenter/redo.go
@@ -358,7 +358,11 @@ func runRedoTemplateImageJob(ctx context.Context, jobID string, req *types.RedoT
 		})
 		return
 	}
-	if err := refreshTemplateReplicaSummary(ctx, req.TemplateID); err != nil {
+	// refreshTemplateReplicaSummary claims the alias *before* publishing the
+	// READY status so a client that observes the template as READY can always
+	// resolve the alias (closes the redo/claim publish-ordering race).
+	claimWarning, err := refreshTemplateReplicaSummary(ctx, req.TemplateID, sourceReq.Alias)
+	if err != nil {
 		_ = updateTemplateImageJob(ctx, jobID, map[string]any{
 			"status":          JobStatusFailed,
 			"phase":           JobPhaseSnapshotting,
@@ -384,15 +388,6 @@ func runRedoTemplateImageJob(ctx context.Context, jobID string, req *types.RedoT
 	if info.Status == StatusFailed {
 		finalStatus = JobStatusFailed
 		finalPhase = JobPhaseSnapshotting
-	}
-	// Claim alias after READY via the shared helper.
-	claimWarning := ""
-	if info.Status != StatusFailed {
-		warning, displayName := claimAliasAfterReady(ctx, req.TemplateID, sourceReq.Alias)
-		claimWarning = warning
-		if displayName != "" {
-			info.DisplayName = displayName
-		}
 	}
 	resultPayload, _ := json.Marshal(info)
 	errorMessage := info.LastError

--- a/CubeMaster/pkg/templatecenter/store.go
+++ b/CubeMaster/pkg/templatecenter/store.go
@@ -447,7 +447,10 @@ func CreateTemplate(ctx context.Context, req *sandboxtypes.CreateCubeSandboxReq)
 	if persistErr != nil {
 		return nil, persistErr
 	}
-	return finalizeTemplateReplicas(ctx, templateID, createReq.InstanceType, constants.GetAppSnapshotVersion(createReq.Annotations), replicas)
+	// The synchronous CreateCubeSandboxReq path carries no template alias (that
+	// is exclusive to CreateTemplateFromImageReq), so no alias is claimed here.
+	info, _, finalizeErr := finalizeTemplateReplicas(ctx, templateID, createReq.InstanceType, constants.GetAppSnapshotVersion(createReq.Annotations), "", replicas)
+	return info, finalizeErr
 }
 
 func healthyTemplateNodes(instanceType string) []*node.Node {
@@ -666,28 +669,43 @@ func ensureRuntimeTemplateRequest(req *sandboxtypes.CreateCubeSandboxReq) {
 	}
 }
 
-func refreshTemplateReplicaSummary(ctx context.Context, templateID string) error {
+// refreshTemplateReplicaSummary recomputes the template's aggregate status from
+// its replicas and publishes it. When the template is not FAILED it claims the
+// requested alias *before* publishing the status, so a client that observes the
+// template as READY (e.g. by polling GetTemplateInfo) is guaranteed the alias
+// already resolves — closing the create/claim publish-ordering race. The
+// returned claimWarning is non-empty when the alias could not be claimed for a
+// non-duplicate reason.
+func refreshTemplateReplicaSummary(ctx context.Context, templateID, alias string) (claimWarning string, err error) {
 	replicas, err := ListReplicas(ctx, templateID)
 	if err != nil {
-		return err
+		return "", err
 	}
 	current := make([]ReplicaStatus, 0, len(replicas))
 	for _, replica := range replicas {
 		current = append(current, replicaModelToStatus(replica))
 	}
 	status, lastError := summarizeStatus(current)
+	// NB: claimAliasForReadyTemplate and UpdateDefinitionStatus each use their own
+	// DB transaction. A crash between the two leaves the alias claimed but the
+	// status at its previous value — strictly safer than the reverse ordering, but
+	// not fully atomic.
+	if status != StatusFailed {
+		claimWarning, _ = claimAliasForReadyTemplate(ctx, templateID, alias)
+	}
 	if err := UpdateDefinitionStatus(ctx, templateID, status, lastError); err != nil {
-		return err
+		return "", err
 	}
 	localcache.InvalidateImageState(templateID)
 	setTemplateLocalityCache(templateID, current)
 	registerReadyTemplateReplicas(templateID, current)
-	return nil
+	return claimWarning, nil
 }
 
 // createDefinitionWithOptions wraps createDefinitionTx in a real DB transaction
 // so the INSERT is atomic. Alias claiming is NOT done here — it happens
-// separately in claimTemplateAlias after the template reaches READY.
+// separately when the template reaches a non-FAILED status, before that status
+// is published (see claimAliasForReadyTemplate).
 func createDefinitionWithOptions(ctx context.Context, templateID string, storedReq *sandboxtypes.CreateCubeSandboxReq, instanceType, version string, opts definitionCreateOptions) error {
 	return store.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		return createDefinitionTx(ctx, tx, templateID, storedReq, instanceType, version, opts)
@@ -718,13 +736,38 @@ func ensureTemplateDefinitionWithOptions(ctx context.Context, templateID string,
 	return true, nil
 }
 
-func finalizeTemplateReplicas(ctx context.Context, templateID, instanceType, version string, replicas []ReplicaStatus) (*TemplateInfo, error) {
+// finalizeTemplateReplicas publishes the aggregate template status computed from
+// its replicas. When the template reaches a non-FAILED status it claims the
+// requested alias *before* publishing the status via UpdateDefinitionStatus, so
+// a client that observes the template as READY is guaranteed the alias already
+// resolves — closing the create/claim publish-ordering race.
+//
+// A side effect of that ordering is that the alias becomes resolvable while the
+// status is still the pre-publish value (PENDING/PARTIALLY_READY): alias
+// resolution no longer implies READY. This is intended and strictly safer than
+// the old 404 race; callers must not assume "alias resolves" ⇒ "READY".
+//
+// The returned claim warning (non-empty only when the alias could not be
+// claimed for a non-duplicate reason) and the claimed alias are separate,
+// mutually-exclusive results: on success the alias is reflected in
+// TemplateInfo.DisplayName and the warning is empty; on a non-duplicate claim
+// failure the warning is set and DisplayName stays empty.
+func finalizeTemplateReplicas(ctx context.Context, templateID, instanceType, version, alias string, replicas []ReplicaStatus) (*TemplateInfo, string, error) {
 	setTemplateLocalityCache(templateID, replicas)
 	registerReadyTemplateReplicas(templateID, replicas)
 
 	status, lastError := summarizeStatus(replicas)
+	claimWarning := ""
+	displayName := ""
+	// NB: claimAliasForReadyTemplate and UpdateDefinitionStatus each use their own
+	// DB transaction. A crash between the two leaves the alias claimed but the
+	// status at its previous value — strictly safer than the reverse ordering, but
+	// not fully atomic.
+	if status != StatusFailed {
+		claimWarning, displayName = claimAliasForReadyTemplate(ctx, templateID, alias)
+	}
 	if err := UpdateDefinitionStatus(ctx, templateID, status, lastError); err != nil {
-		return nil, err
+		return nil, "", err
 	}
 	info := &TemplateInfo{
 		TemplateID:   templateID,
@@ -732,15 +775,16 @@ func finalizeTemplateReplicas(ctx context.Context, templateID, instanceType, ver
 		Version:      version,
 		Status:       status,
 		LastError:    lastError,
+		DisplayName:  displayName,
 		Replicas:     replicas,
 	}
 	if status == StatusFailed {
 		if lastError == "" {
 			lastError = "template creation failed on all nodes"
 		}
-		return info, fmt.Errorf("template %s creation failed: %s", templateID, lastError)
+		return info, claimWarning, fmt.Errorf("template %s creation failed: %s", templateID, lastError)
 	}
-	return info, nil
+	return info, claimWarning, nil
 }
 
 func UpdateDefinitionStatus(ctx context.Context, templateID, status, lastError string) error {
@@ -906,8 +950,9 @@ func GetDefinition(ctx context.Context, templateID string) (*models.TemplateDefi
 // 20260704120000) so it is inherently scoped to template-kind rows: a snapshot
 // carries its own informational display_name (NULL alias_key) and can never
 // match. The write path that owns template aliases is claimTemplateAlias
-// (called post-READY); without the alias_key filter, a snapshot sharing the
-// alias could shadow the owning template and resolve the alias to a snap-* id.
+// (invoked once the template reaches a non-FAILED status, before that status is
+// published); without the alias_key filter, a snapshot sharing the alias could
+// shadow the owning template and resolve the alias to a snap-* id.
 func GetTemplateByAlias(ctx context.Context, alias string) (*models.TemplateDefinition, error) {
 	if !isReady() {
 		return nil, ErrTemplateStoreNotInitialized
@@ -951,8 +996,8 @@ func ResolveTemplateIdentifier(ctx context.Context, identifier string) (string, 
 
 // claimTemplateAlias atomically claims an alias for a template: releases it
 // from any other non-deleting template that currently holds it, then sets
-// display_name on the target template. Call this only after the template is
-// confirmed READY so an alias never points to a broken template.
+// display_name on the target template. Call this only for a non-FAILED template
+// so an alias never points to a broken one (callers gate on status != FAILED).
 func claimTemplateAlias(ctx context.Context, templateID, alias string) error {
 	alias = strings.TrimSpace(alias)
 	if alias == "" {
@@ -989,12 +1034,14 @@ func isDuplicateAliasError(err error) bool {
 	return strings.Contains(s, "23505") || strings.Contains(s, "unique_constraint")
 }
 
-// claimAliasAfterReady is the shared claim-after-READY pattern used by both
-// image_job_runner and redo. It attempts to claim the alias for a template
-// that has just reached READY. Returns a warning string (non-empty if the
-// claim failed for a non-duplicate reason) and the refreshed DisplayName
-// (non-empty if the claim succeeded).
-func claimAliasAfterReady(ctx context.Context, templateID, alias string) (claimWarning, displayName string) {
+// claimAliasForReadyTemplate is the shared alias-claim helper used by both the
+// image-job and redo paths. It is called for a template that has reached a
+// non-FAILED status, and — per the create/claim ordering fix — runs *before*
+// that status is published, so a client that later observes READY is guaranteed
+// the alias already resolves. Returns a warning string (non-empty only if the
+// claim failed for a non-duplicate reason) and the claimed DisplayName
+// (the alias itself on success); the two are mutually exclusive.
+func claimAliasForReadyTemplate(ctx context.Context, templateID, alias string) (claimWarning, displayName string) {
 	alias = strings.TrimSpace(alias)
 	if alias == "" {
 		return "", ""
@@ -1002,16 +1049,14 @@ func claimAliasAfterReady(ctx context.Context, templateID, alias string) (claimW
 	if claimErr := claimTemplateAlias(ctx, templateID, alias); claimErr != nil {
 		if isDuplicateAliasError(claimErr) {
 			log.G(ctx).Infof("alias %q concurrently claimed by another template; template %s is READY without alias", alias, templateID)
-		} else {
-			log.G(ctx).Warnf("claim alias %q for template %s fail: %v", alias, templateID, claimErr)
-			return fmt.Sprintf("template is ready but alias %q could not be claimed: %v", alias, claimErr), ""
+			return "", ""
 		}
-	} else if refreshed, refreshErr := GetTemplateInfo(ctx, templateID); refreshErr == nil && refreshed != nil {
-		return "", refreshed.DisplayName
-	} else {
-		return "", alias
+		log.G(ctx).Warnf("claim alias %q for template %s fail: %v", alias, templateID, claimErr)
+		return fmt.Sprintf("template is ready but alias %q could not be claimed: %v", alias, claimErr), ""
 	}
-	return "", ""
+	// The claim just wrote display_name = alias, so the claimed display name is
+	// the alias itself — no read-back needed.
+	return "", alias
 }
 func GetTemplateRequest(ctx context.Context, templateID string) (*sandboxtypes.CreateCubeSandboxReq, error) {
 	cacheStart := time.Now()

--- a/CubeMaster/pkg/templatecenter/store_test.go
+++ b/CubeMaster/pkg/templatecenter/store_test.go
@@ -14,13 +14,14 @@ import (
 	"time"
 
 	"github.com/agiledragon/gomonkey/v2"
+	"github.com/go-sql-driver/mysql"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/constants"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/db/models"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/node"
 	sandboxtypes "github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/service/sandbox/types"
-	"gorm.io/driver/mysql"
+	gormmysql "gorm.io/driver/mysql"
 	"gorm.io/gorm"
 )
 
@@ -162,8 +163,8 @@ func TestCreateTemplateUsesRequestedDistributionScope(t *testing.T) {
 		}
 		return []ReplicaStatus{{NodeID: "node-a", NodeIP: "10.0.0.1", InstanceType: req.InstanceType, Status: ReplicaStatusReady}}, nil
 	})
-	patches.ApplyFunc(finalizeTemplateReplicas, func(ctx context.Context, templateID, instanceType, version string, replicas []ReplicaStatus) (*TemplateInfo, error) {
-		return &TemplateInfo{TemplateID: templateID, InstanceType: instanceType, Version: version, Replicas: replicas}, nil
+	patches.ApplyFunc(finalizeTemplateReplicas, func(ctx context.Context, templateID, instanceType, version, alias string, replicas []ReplicaStatus) (*TemplateInfo, string, error) {
+		return &TemplateInfo{TemplateID: templateID, InstanceType: instanceType, Version: version, Replicas: replicas}, "", nil
 	})
 	patches.ApplyFunc(cleanupTemplateReplicas, func(ctx context.Context, templateID string) error {
 		return nil
@@ -181,6 +182,277 @@ func TestCreateTemplateUsesRequestedDistributionScope(t *testing.T) {
 	}
 	if !reflect.DeepEqual(gotScope, []string{"node-a"}) {
 		t.Fatalf("resolveTemplateNodes scope=%v, want [node-a]", gotScope)
+	}
+}
+
+// TestFinalizeTemplateReplicasClaimsAliasBeforePublishingReady guards the
+// create/claim publish-ordering invariant: finalizeTemplateReplicas MUST claim
+// the alias BEFORE it publishes the READY status via UpdateDefinitionStatus.
+// Otherwise a client that polls the template and observes READY can race a
+// GET-by-alias that 404s because display_name/alias_key is not yet written
+// (the original test_template_alias_create_get_and_delete failure). We record
+// the call order of both operations and assert the claim happens first.
+func TestFinalizeTemplateReplicasClaimsAliasBeforePublishingReady(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	var order []string
+	patches.ApplyFunc(claimTemplateAlias, func(ctx context.Context, templateID, alias string) error {
+		order = append(order, "claim")
+		return nil
+	})
+	patches.ApplyFunc(UpdateDefinitionStatus, func(ctx context.Context, templateID, status, lastError string) error {
+		order = append(order, "publish:"+status)
+		return nil
+	})
+	patches.ApplyFunc(setTemplateLocalityCache, func(templateID string, replicas []ReplicaStatus) {})
+	patches.ApplyFunc(registerReadyTemplateReplicas, func(templateID string, replicas []ReplicaStatus) {})
+
+	replicas := []ReplicaStatus{{NodeID: "node-a", NodeIP: "10.0.0.1", Status: ReplicaStatusReady}}
+	info, claimWarning, err := finalizeTemplateReplicas(context.Background(), "tpl-order", "cubebox", "v2", "my-alias", replicas)
+	if err != nil {
+		t.Fatalf("finalizeTemplateReplicas returned error: %v", err)
+	}
+	if claimWarning != "" {
+		t.Fatalf("unexpected claim warning: %q", claimWarning)
+	}
+	if info == nil || info.Status != StatusReady {
+		t.Fatalf("expected READY info, got %#v", info)
+	}
+	if info.DisplayName != "my-alias" {
+		t.Fatalf("expected DisplayName propagated, got %q", info.DisplayName)
+	}
+	if !reflect.DeepEqual(order, []string{"claim", "publish:" + StatusReady}) {
+		t.Fatalf("alias must be claimed before READY is published; got order=%v", order)
+	}
+}
+
+// TestFinalizeTemplateReplicasSkipsAliasClaimWhenFailed verifies that a failed
+// template (no ready replica) does NOT claim the alias — an alias must never
+// point at a broken template.
+func TestFinalizeTemplateReplicasSkipsAliasClaimWhenFailed(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	claimed := false
+	patches.ApplyFunc(claimTemplateAlias, func(ctx context.Context, templateID, alias string) error {
+		claimed = true
+		return nil
+	})
+	patches.ApplyFunc(UpdateDefinitionStatus, func(ctx context.Context, templateID, status, lastError string) error {
+		return nil
+	})
+	patches.ApplyFunc(setTemplateLocalityCache, func(templateID string, replicas []ReplicaStatus) {})
+	patches.ApplyFunc(registerReadyTemplateReplicas, func(templateID string, replicas []ReplicaStatus) {})
+
+	replicas := []ReplicaStatus{{NodeID: "node-a", Status: ReplicaStatusFailed, ErrorMessage: "boom"}}
+	_, _, err := finalizeTemplateReplicas(context.Background(), "tpl-failed", "cubebox", "v2", "my-alias", replicas)
+	if err == nil {
+		t.Fatalf("expected error for all-failed template")
+	}
+	if claimed {
+		t.Fatalf("alias must not be claimed for a FAILED template")
+	}
+}
+
+// TestFinalizeTemplateReplicasClaimsAliasForPartiallyReady verifies that a
+// PARTIALLY_READY template (at least one serving replica) still claims the
+// alias — the guard is status != FAILED, not status == READY — and that the
+// claim is ordered before the status is published.
+func TestFinalizeTemplateReplicasClaimsAliasForPartiallyReady(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	var order []string
+	patches.ApplyFunc(claimTemplateAlias, func(ctx context.Context, templateID, alias string) error {
+		order = append(order, "claim")
+		return nil
+	})
+	patches.ApplyFunc(UpdateDefinitionStatus, func(ctx context.Context, templateID, status, lastError string) error {
+		order = append(order, "publish:"+status)
+		return nil
+	})
+	patches.ApplyFunc(setTemplateLocalityCache, func(templateID string, replicas []ReplicaStatus) {})
+	patches.ApplyFunc(registerReadyTemplateReplicas, func(templateID string, replicas []ReplicaStatus) {})
+
+	replicas := []ReplicaStatus{
+		{NodeID: "node-a", Status: ReplicaStatusReady},
+		{NodeID: "node-b", Status: ReplicaStatusFailed, ErrorMessage: "boom"},
+	}
+	info, claimWarning, err := finalizeTemplateReplicas(context.Background(), "tpl-partial", "cubebox", "v2", "my-alias", replicas)
+	if err != nil {
+		t.Fatalf("finalizeTemplateReplicas returned error: %v", err)
+	}
+	if claimWarning != "" {
+		t.Fatalf("unexpected claim warning: %q", claimWarning)
+	}
+	if info == nil || info.Status != StatusPartiallyReady {
+		t.Fatalf("expected PARTIALLY_READY info, got %#v", info)
+	}
+	if !reflect.DeepEqual(order, []string{"claim", "publish:" + StatusPartiallyReady}) {
+		t.Fatalf("alias must be claimed before status is published; got order=%v", order)
+	}
+}
+
+// TestFinalizeTemplateReplicasSurfacesClaimWarningOnNonDuplicateError verifies
+// that a non-duplicate claim failure is surfaced as a warning (not an error)
+// while the status is still published, and that DisplayName stays empty — the
+// warning and DisplayName are mutually exclusive.
+func TestFinalizeTemplateReplicasSurfacesClaimWarningOnNonDuplicateError(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	published := false
+	patches.ApplyFunc(claimTemplateAlias, func(ctx context.Context, templateID, alias string) error {
+		return errors.New("db unavailable")
+	})
+	patches.ApplyFunc(UpdateDefinitionStatus, func(ctx context.Context, templateID, status, lastError string) error {
+		published = true
+		return nil
+	})
+	patches.ApplyFunc(setTemplateLocalityCache, func(templateID string, replicas []ReplicaStatus) {})
+	patches.ApplyFunc(registerReadyTemplateReplicas, func(templateID string, replicas []ReplicaStatus) {})
+
+	replicas := []ReplicaStatus{{NodeID: "node-a", Status: ReplicaStatusReady}}
+	info, claimWarning, err := finalizeTemplateReplicas(context.Background(), "tpl-warn", "cubebox", "v2", "my-alias", replicas)
+	if err != nil {
+		t.Fatalf("finalizeTemplateReplicas returned error: %v", err)
+	}
+	if !published {
+		t.Fatalf("status must still be published when the alias claim fails")
+	}
+	if claimWarning == "" {
+		t.Fatalf("expected a non-empty claim warning on a non-duplicate claim failure")
+	}
+	if info == nil || info.DisplayName != "" {
+		t.Fatalf("expected empty DisplayName on claim failure, got %#v", info)
+	}
+}
+
+// TestFinalizeTemplateReplicasSwallowsDuplicateAliasError verifies that a
+// duplicate-alias violation (another template concurrently won the alias) is
+// swallowed: no warning, empty DisplayName, and the template still publishes
+// READY without the alias.
+func TestFinalizeTemplateReplicasSwallowsDuplicateAliasError(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	patches.ApplyFunc(claimTemplateAlias, func(ctx context.Context, templateID, alias string) error {
+		return &mysql.MySQLError{Number: 1062, Message: "duplicate entry"}
+	})
+	patches.ApplyFunc(UpdateDefinitionStatus, func(ctx context.Context, templateID, status, lastError string) error {
+		return nil
+	})
+	patches.ApplyFunc(setTemplateLocalityCache, func(templateID string, replicas []ReplicaStatus) {})
+	patches.ApplyFunc(registerReadyTemplateReplicas, func(templateID string, replicas []ReplicaStatus) {})
+
+	replicas := []ReplicaStatus{{NodeID: "node-a", Status: ReplicaStatusReady}}
+	info, claimWarning, err := finalizeTemplateReplicas(context.Background(), "tpl-dup", "cubebox", "v2", "my-alias", replicas)
+	if err != nil {
+		t.Fatalf("finalizeTemplateReplicas returned error: %v", err)
+	}
+	if claimWarning != "" {
+		t.Fatalf("duplicate-alias error must be swallowed, got warning %q", claimWarning)
+	}
+	if info == nil || info.Status != StatusReady || info.DisplayName != "" {
+		t.Fatalf("expected READY info with empty DisplayName, got %#v", info)
+	}
+}
+
+// TestFinalizeTemplateReplicasSkipsClaimForEmptyAlias verifies the synchronous
+// create path (CreateTemplate passes ""): no alias is claimed, yet the status
+// is still published.
+func TestFinalizeTemplateReplicasSkipsClaimForEmptyAlias(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	claimed := false
+	patches.ApplyFunc(claimTemplateAlias, func(ctx context.Context, templateID, alias string) error {
+		claimed = true
+		return nil
+	})
+	published := false
+	patches.ApplyFunc(UpdateDefinitionStatus, func(ctx context.Context, templateID, status, lastError string) error {
+		published = true
+		return nil
+	})
+	patches.ApplyFunc(setTemplateLocalityCache, func(templateID string, replicas []ReplicaStatus) {})
+	patches.ApplyFunc(registerReadyTemplateReplicas, func(templateID string, replicas []ReplicaStatus) {})
+
+	replicas := []ReplicaStatus{{NodeID: "node-a", Status: ReplicaStatusReady}}
+	info, claimWarning, err := finalizeTemplateReplicas(context.Background(), "tpl-noalias", "cubebox", "v2", "", replicas)
+	if err != nil {
+		t.Fatalf("finalizeTemplateReplicas returned error: %v", err)
+	}
+	if claimed {
+		t.Fatalf("no alias must be claimed when alias is empty")
+	}
+	if !published || claimWarning != "" || info == nil || info.DisplayName != "" {
+		t.Fatalf("expected READY published, no warning, empty DisplayName; got warning=%q info=%#v", claimWarning, info)
+	}
+}
+
+// TestRefreshTemplateReplicaSummaryClaimsAliasBeforePublishingReady guards the
+// SAME ordering invariant as finalizeTemplateReplicas but for the redo path:
+// refreshTemplateReplicaSummary MUST claim the alias BEFORE publishing the
+// status. Without this test, reverting the reorder in the redo path would keep
+// the suite green.
+func TestRefreshTemplateReplicaSummaryClaimsAliasBeforePublishingReady(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	var order []string
+	patches.ApplyFunc(ListReplicas, func(ctx context.Context, templateID string) ([]models.TemplateReplica, error) {
+		return []models.TemplateReplica{{NodeID: "node-a", Status: ReplicaStatusReady}}, nil
+	})
+	patches.ApplyFunc(claimTemplateAlias, func(ctx context.Context, templateID, alias string) error {
+		order = append(order, "claim")
+		return nil
+	})
+	patches.ApplyFunc(UpdateDefinitionStatus, func(ctx context.Context, templateID, status, lastError string) error {
+		order = append(order, "publish:"+status)
+		return nil
+	})
+	patches.ApplyFunc(setTemplateLocalityCache, func(templateID string, replicas []ReplicaStatus) {})
+	patches.ApplyFunc(registerReadyTemplateReplicas, func(templateID string, replicas []ReplicaStatus) {})
+
+	claimWarning, err := refreshTemplateReplicaSummary(context.Background(), "tpl-redo", "my-alias")
+	if err != nil {
+		t.Fatalf("refreshTemplateReplicaSummary returned error: %v", err)
+	}
+	if claimWarning != "" {
+		t.Fatalf("unexpected claim warning: %q", claimWarning)
+	}
+	if !reflect.DeepEqual(order, []string{"claim", "publish:" + StatusReady}) {
+		t.Fatalf("redo path must claim the alias before publishing READY; got order=%v", order)
+	}
+}
+
+// TestRefreshTemplateReplicaSummarySkipsAliasClaimWhenFailed verifies the redo
+// path never claims an alias for a FAILED template.
+func TestRefreshTemplateReplicaSummarySkipsAliasClaimWhenFailed(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	claimed := false
+	patches.ApplyFunc(ListReplicas, func(ctx context.Context, templateID string) ([]models.TemplateReplica, error) {
+		return []models.TemplateReplica{{NodeID: "node-a", Status: ReplicaStatusFailed, ErrorMessage: "boom"}}, nil
+	})
+	patches.ApplyFunc(claimTemplateAlias, func(ctx context.Context, templateID, alias string) error {
+		claimed = true
+		return nil
+	})
+	patches.ApplyFunc(UpdateDefinitionStatus, func(ctx context.Context, templateID, status, lastError string) error {
+		return nil
+	})
+	patches.ApplyFunc(setTemplateLocalityCache, func(templateID string, replicas []ReplicaStatus) {})
+	patches.ApplyFunc(registerReadyTemplateReplicas, func(templateID string, replicas []ReplicaStatus) {})
+
+	if _, err := refreshTemplateReplicaSummary(context.Background(), "tpl-redo-failed", "my-alias"); err != nil {
+		t.Fatalf("refreshTemplateReplicaSummary returned error: %v", err)
+	}
+	if claimed {
+		t.Fatalf("alias must not be claimed for a FAILED template on the redo path")
 	}
 }
 
@@ -361,7 +633,7 @@ func TestGetTemplateByAliasFiltersByKindExcludesSnapshots(t *testing.T) {
 	sqlDB, err := sql.Open("mysql", "root:root@tcp(127.0.0.1:3306)/unused?parseTime=true")
 	require.NoError(t, err)
 
-	dryRunDB, err := gorm.Open(mysql.New(mysql.Config{
+	dryRunDB, err := gorm.Open(gormmysql.New(gormmysql.Config{
 		Conn:                      sqlDB,
 		SkipInitializeWithVersion: true,
 	}), &gorm.Config{DryRun: true, DisableAutomaticPing: true})

--- a/CubeMaster/pkg/templatecenter/template_image_test.go
+++ b/CubeMaster/pkg/templatecenter/template_image_test.go
@@ -1499,8 +1499,8 @@ func TestRunRedoTemplateImageJobRegeneratesRequestForRedoTemplateID(t *testing.T
 		capturedReq = req
 		return []ReplicaStatus{{NodeID: "node-a", Status: ReplicaStatusReady}}, nil
 	})
-	patches.ApplyFunc(refreshTemplateReplicaSummary, func(ctx context.Context, templateID string) error {
-		return nil
+	patches.ApplyFunc(refreshTemplateReplicaSummary, func(ctx context.Context, templateID, alias string) (string, error) {
+		return "", nil
 	})
 	patches.ApplyFunc(GetTemplateInfo, func(ctx context.Context, templateID string) (*TemplateInfo, error) {
 		return &TemplateInfo{TemplateID: templateID, Status: StatusReady}, nil


### PR DESCRIPTION
The e2e test test_template_alias_create_get_and_delete failed with:

  cubesandbox._exceptions.TemplateNotFoundError: CubeMaster returned
  error code 130404: template not found

at Template.get(alias) immediately after the template reached READY.

```
cases/templates/test_alias.py::test_template_alias_create_get_and_delete[cubesandbox] FAILED

=================================== FAILURES ===================================
____________ test_template_alias_create_get_and_delete[cubesandbox] ____________
cases/templates/test_alias.py:133: in test_template_alias_create_get_and_delete
    assert Template.get(alias, config=cfg).template_id == created_id
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
../../../sdk/python/cubesandbox/_template.py:205: in get
    _check_response(resp)
../../../sdk/python/cubesandbox/_template.py:27: in _check_response
    raise TemplateNotFoundError(msg, code)
E   cubesandbox._exceptions.TemplateNotFoundError: CubeMaster returned error code 130404: template not found
```

Root cause is a publish-ordering race. The async image-job and redo runners set the template definition status to READY first (via UpdateDefinitionStatus) and only afterwards claimed the alias, which writes display_name / the alias_key generated column used by the GET -by-alias lookup. A client that polls the template and observes READY can race that window and resolve the alias before it is written, so the lookup finds no row and returns 130404. Reproduced with a ~4-5ms gap between the status flip and the alias becoming resolvable.

Claim the alias before publishing the non-FAILED status so any client that observes READY is guaranteed the alias resolves. A FAILED template still never claims its alias, so an alias never points at a broken template.

Assisted-by: Claude Code:Opus 4.8