### PR TITLE
fix(one-click): skip WebUI postcheck when disabled

### DIFF
--- a/deploy/one-click/scripts/systemd/webui-postcheck.sh
+++ b/deploy/one-click/scripts/systemd/webui-postcheck.sh
@@ -2,6 +2,12 @@
 set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${SCRIPT_DIR}/common.sh"
+
+if [[ "${WEB_UI_ENABLE:-1}" != "1" ]]; then
+  log "webui disabled; skipping postcheck"
+  exit 0
+fi
+
 port="${WEB_UI_HOST_PORT:-12088}"
 wait_for_tcp_port "${port}" 30 2 || die "webui port not ready"
 wait_for_http "http://127.0.0.1:${port}/" 30 1 || die "webui index not ready"

--- a/deploy/one-click/tests/test_runtime_file_safety.sh
+++ b/deploy/one-click/tests/test_runtime_file_safety.sh
@@ -804,6 +804,23 @@ test_postcheck_skips_when_external_host_set() {
     || fail "redis-postcheck must exit 0 when CUBE_EXTERNAL_REDIS_HOST is set"
 }
 
+test_webui_postcheck_skips_when_disabled() {
+  local stub_dir="${TMP_DIR}/webui-disabled/bin"
+
+  mkdir -p "${stub_dir}"
+  cat > "${stub_dir}/ss" <<'SH'
+#!/usr/bin/env bash
+echo "ss must not be called when WebUI is disabled" >&2
+exit 1
+SH
+  chmod +x "${stub_dir}/ss"
+
+  PATH="${stub_dir}:${PATH}" \
+    WEB_UI_ENABLE=0 \
+    bash "${ONE_CLICK_DIR}/scripts/systemd/webui-postcheck.sh" \
+    || fail "webui-postcheck must exit 0 when WEB_UI_ENABLE is disabled"
+}
+
 test_mask_external_dep_services_remove_then_mask() {
   local path="${ONE_CLICK_DIR}/install.sh"
 
@@ -863,6 +880,7 @@ test_cube_proxy_postcheck_ignores_https_port
 test_cube_proxy_postcheck_ignores_deprecated_host_port
 test_cube_proxy_postcheck_prefers_http_over_deprecated_host_port
 test_postcheck_skips_when_external_host_set
+test_webui_postcheck_skips_when_disabled
 test_mask_external_dep_services_remove_then_mask
 
 echo "runtime file safety tests OK"


### PR DESCRIPTION
Fix #1229

Skip the WebUI port and health checks when WEB_UI_ENABLE is not set to 1, preventing the systemd service from timing out and repeatedly restarting when WebUI is intentionally disabled.

