### PR TITLE
fix(envd): default -isnotfc to skip MMDS metadata lookup

### DIFF
--- a/docker/cube-entrypoint.sh
+++ b/docker/cube-entrypoint.sh
@@ -12,7 +12,8 @@
 #
 # Environment variables:
 #   ENVD_PORT       Port envd listens on (default: 49983).
-#   ENVD_EXTRA_ARGS Extra flags appended to the envd invocation (optional).
+#   ENVD_EXTRA_ARGS Extra flags appended to the envd invocation (default: empty).
+#                   -isnotfc is appended automatically if not already present.
 #   ENVD_LOG_FILE   Where to redirect envd stdout/stderr (default:
 #                   /var/log/envd.log). Set to "-" to inherit the container
 #                   stdio.
@@ -23,6 +24,10 @@ ENVD_BIN="${ENVD_BIN:-/usr/bin/envd}"
 ENVD_PORT="${ENVD_PORT:-49983}"
 ENVD_LOG_FILE="${ENVD_LOG_FILE:-/var/log/envd.log}"
 ENVD_EXTRA_ARGS="${ENVD_EXTRA_ARGS:-}"
+case " ${ENVD_EXTRA_ARGS} " in
+    *" -isnotfc "*) ;;
+    *) ENVD_EXTRA_ARGS="${ENVD_EXTRA_ARGS} -isnotfc" ;;
+esac
 
 if [ ! -x "${ENVD_BIN}" ]; then
     echo "cube-entrypoint: envd binary not found or not executable at ${ENVD_BIN}" >&2

--- a/docs/guide/tutorials/bring-your-own-image.md
+++ b/docs/guide/tutorials/bring-your-own-image.md
@@ -163,7 +163,7 @@ Environment variables:
 | Variable           | Default             | Purpose                                              |
 | ------------------ | ------------------- | ---------------------------------------------------- |
 | `ENVD_PORT`        | `49983`             | Port `envd` listens on.                              |
-| `ENVD_EXTRA_ARGS`  | *(empty)*           | Extra flags passed after `-port`.                    |
+| `ENVD_EXTRA_ARGS`  | *(empty)*           | Extra flags passed after `-port`. `-isnotfc` is appended automatically if not already present, to skip Firecracker MMDS lookup. |
 | `ENVD_LOG_FILE`    | `/var/log/envd.log` | File that captures envd stdout/stderr. Use `-` to inherit the container stdio. |
 | `ENVD_BIN`         | `/usr/bin/envd`     | Override if you install envd elsewhere.              |
 
@@ -178,7 +178,12 @@ control to your main process:
 # your-entrypoint.sh
 
 # Start envd in the background.
-/usr/bin/envd -port 49983 >/var/log/envd.log 2>&1 &
+# -isnotfc is REQUIRED: it tells envd to skip the Firecracker MMDS lookup
+# at 169.254.169.254. CubeSandbox does not use Firecracker, so the MMDS
+# service does not exist. Without this flag envd will attempt to access
+# the non-existent MMDS, which may cause various problems such as network
+# timeouts, /init delays, or env_vars injection failures.
+/usr/bin/envd -port 49983 -isnotfc >/var/log/envd.log 2>&1 &
 
 # ... your usual startup sequence ...
 exec "$@"
@@ -221,6 +226,7 @@ docker exec "$cid" cat /var/log/envd.log
 | Template creation fails the readiness probe   | envd did not start / started on the wrong port                        | Ensure `ENTRYPOINT` invokes `cube-entrypoint.sh` **or** your own script runs `envd -port 49983 &` before `exec`. |
 | `curl :49983/health` returns `000`            | Nothing is listening; entrypoint replaced                             | Check <code v-pre>docker inspect --format '{{json .Config.Entrypoint}}'</code>; keep `cube-entrypoint.sh` as the wrapper. |
 | envd exits immediately                        | Version mismatch between binary and kernel/init expectations          | Verify with `docker exec ... /usr/bin/envd -version`; re-copy from the pinned base tag. |
+| envd `/init` slow or `create_time env_vars` fail | `-isnotfc` flag missing; envd attempts invalid MMDS access at `169.254.169.254` | Use `cube-entrypoint.sh` (appends `-isnotfc` automatically), or add `-isnotfc` to the command line when starting envd manually. |
 | Port 49983 conflicts with your own service    | Your app also listens on 49983                                        | Move your app to a different port and expose both with `--expose-port`.             |
 | `sudo: command not found` in your CMD         | You started `FROM` a `-slim` / `-alpine` image without sudo           | Either `apt-get install -y sudo`, or drop `sudo` from your entrypoint — `cube-entrypoint.sh` doesn't require it. |
 | Template creation times out in `PULLING`      | Registry unreachable from Cube nodes                                  | Push to a registry the cluster can reach, or supply `--registry-username` / `--registry-password`. |

--- a/docs/zh/guide/tutorials/bring-your-own-image.md
+++ b/docs/zh/guide/tutorials/bring-your-own-image.md
@@ -154,7 +154,7 @@ CMD ["uvicorn", "app:app", "--app-dir", "/srv", "--host", "0.0.0.0", "--port", "
 | 变量               | 默认值              | 说明                                                   |
 | ------------------ | ------------------- | ------------------------------------------------------ |
 | `ENVD_PORT`        | `49983`             | envd 监听的端口                                        |
-| `ENVD_EXTRA_ARGS`  | *(空)*              | 追加到 `-port` 之后的额外参数                          |
+| `ENVD_EXTRA_ARGS`  | *(空)*              | 追加到 `-port` 之后的额外参数。若未包含 `-isnotfc`，脚本会自动追加以跳过 Firecracker MMDS 查询。 |
 | `ENVD_LOG_FILE`    | `/var/log/envd.log` | envd stdout/stderr 落盘位置；设为 `-` 则继承容器 stdio |
 | `ENVD_BIN`         | `/usr/bin/envd`     | 当 envd 安装在别处时覆盖                               |
 
@@ -168,7 +168,11 @@ CMD ["uvicorn", "app:app", "--app-dir", "/srv", "--host", "0.0.0.0", "--port", "
 # your-entrypoint.sh
 
 # 后台启动 envd
-/usr/bin/envd -port 49983 >/var/log/envd.log 2>&1 &
+# -isnotfc 是必须的：它让 envd 跳过对 169.254.169.254 的 Firecracker MMDS
+# 查询。CubeSandbox 不使用 Firecracker，MMDS 服务不存在。缺少此参数时
+# envd 会尝试访问不存在的 MMDS，可能引发网络超时、/init 延迟、
+# env_vars 注入失败等各种问题。
+/usr/bin/envd -port 49983 -isnotfc >/var/log/envd.log 2>&1 &
 
 # ... 你原本的启动流程 ...
 exec "$@"
@@ -209,6 +213,7 @@ docker exec "$cid" cat /var/log/envd.log
 | 模板创建探活失败                       | envd 未启动 / 起在错误端口                                  | 确认 `ENTRYPOINT` 为 `cube-entrypoint.sh`，或你自己的脚本里有 `envd -port 49983 &`      |
 | `curl :49983/health` 返回 `000`        | 端口无人监听；入口被用户 CMD 整个替换                      | 检查 <code v-pre>docker inspect --format '{{json .Config.Entrypoint}}'</code>，保留 `cube-entrypoint.sh` |
 | envd 立刻退出                          | 二进制版本与容器预期不匹配                                 | `docker exec ... /usr/bin/envd -version` 确认版本；从 pin 的 base tag 重新拷贝          |
+| envd `/init` 异常缓慢 / `create_time env_vars` 失败 | 缺少 `-isnotfc` 参数；envd 尝试访问不存在的 MMDS (`169.254.169.254`) | 使用 `cube-entrypoint.sh`（会自动追加 `-isnotfc`），或在手动拉起 envd 时自行加上 `-isnotfc` |
 | 49983 端口冲突                         | 你自己的应用也在监听 49983                                 | 把自家应用迁到别的端口，并一起 `--expose-port` 暴露                                     |
 | `sudo: command not found`              | 基于 `-slim` / `-alpine` 这种无 sudo 的镜像构建            | `apt-get install -y sudo`，或直接把 `sudo` 从 CMD 里去掉——`cube-entrypoint.sh` 不依赖它 |
 | 模板创建长时间卡在 `PULLING`           | registry 从 Cube 节点不可达                                | 推送到集群可访问的 registry，或用 `--registry-username` / `--registry-password`         |

--- a/examples/mini-rl-training/envd-inject/Dockerfile
+++ b/examples/mini-rl-training/envd-inject/Dockerfile
@@ -4,4 +4,4 @@ FROM ${BASE_IMAGE}
 COPY envd /usr/bin/envd
 RUN chmod +x /usr/bin/envd
 
-ENTRYPOINT ["/usr/bin/envd"]
+ENTRYPOINT ["/usr/bin/envd", "-isnotfc"]


### PR DESCRIPTION
## Summary

Fixes #1231

CubeSandbox uses `cube-hypervisor` rather than Firecracker, but `envd` (compiled from e2b-dev/infra) defaults to FC mode and attempts to access the Firecracker MMDS at `169.254.169.254` during `/init`. Since the MMDS service does not exist in CubeSandbox, this invalid access may cause various problems such as network timeouts, `/init` delays, or `create_time env_vars` injection failures.

This PR adds `-isnotfc` at the entrypoint layers:

- **`cube-entrypoint.sh`**: unconditionally append `-isnotfc` to `ENVD_EXTRA_ARGS`, ensuring all images that go through the entrypoint script always pass this flag to envd
- **`envd-inject/Dockerfile`**: direct CLI flag in `ENTRYPOINT ["/usr/bin/envd", "-isnotfc"]` for images that exec envd directly without the entrypoint script
- **Documentation (EN/ZH)**: explains `-isnotfc` requirement in the "Starting envd manually" section, updates the env var table, and adds a new troubleshooting row

## Test plan

- [ ] Deploy on a private/non-cloud host (e.g. openEuler) and verify `Sandbox.create(env_vars={"K":"1"})` succeeds within the /init timeout budget
- [ ] Verify `curl -m 3 http://169.254.169.254/` inside guest still times out (network unchanged), but `/init` no longer attempts MMDS access
- [ ] Build a template from `cubesandbox-base` and confirm envd starts with `-isnotfc` flag (check `/var/log/envd.log`)
- [ ] Build a template via `envd-inject/Dockerfile` and confirm envd runs with `-isnotfc`
- [ ] Set `ENVD_EXTRA_ARGS="--custom-flag"` and verify envd receives both `--custom-flag` and `-isnotfc`
- [ ] Verify no regression on Ubuntu 22.04 nodes (where 169.254.169.254 already fast-fails)


Made with [Cursor](https://cursor.com)