### PR TITLE
feat(templatecenter): auto-preheat pinned templates on node join (#182)

### DIFF
--- a/CubeMaster/pkg/base/config/config.go
+++ b/CubeMaster/pkg/base/config/config.go
@@ -943,6 +943,9 @@ func preHandleTemplatePreheat(config *Config) error {
 	if !p.Enabled {
 		return nil
 	}
+	if strings.TrimSpace(p.DownloadBaseURL) == "" {
+		return errors.New("template_preheat: download_base_url is required when enabled")
+	}
 	seen := make(map[string]struct{}, len(p.PinnedTemplates))
 	for _, pt := range p.PinnedTemplates {
 		if pt.TemplateID == "" {

--- a/CubeMaster/pkg/base/config/config.go
+++ b/CubeMaster/pkg/base/config/config.go
@@ -51,8 +51,8 @@ type Config struct {
 	//     - name: cos-rpc
 	//       type: rpc
 	//       socket_path: /run/cube-volume-cos-rpc.sock
-	VolumePlugins []volumeplugin.Config `yaml:"volume_plugins"`
-	TemplatePreheat  *TemplatePreheatConf  `yaml:"template_preheat"`
+	VolumePlugins   []volumeplugin.Config `yaml:"volume_plugins"`
+	TemplatePreheat *TemplatePreheatConf  `yaml:"template_preheat"`
 }
 
 type CommonConf struct {

--- a/CubeMaster/pkg/base/config/config.go
+++ b/CubeMaster/pkg/base/config/config.go
@@ -52,6 +52,7 @@ type Config struct {
 	//       type: rpc
 	//       socket_path: /run/cube-volume-cos-rpc.sock
 	VolumePlugins []volumeplugin.Config `yaml:"volume_plugins"`
+	TemplatePreheat  *TemplatePreheatConf  `yaml:"template_preheat"`
 }
 
 type CommonConf struct {
@@ -638,6 +639,57 @@ type CubeEgressConf struct {
 // to start).
 const DefaultCubeEgressCAPath = "/etc/cube/ca/cube-root-ca.crt"
 
+// TemplatePreheatConf controls the background template preheat controller
+// (issue #182). Disabled by default (nil or Enabled=false). When enabled,
+// the controller maintains operator-declared pinned templates at a minimum
+// replica count on selector-matching nodes, bounded by per-node storage
+// budgets. See CubeMaster/pkg/templatecenter/preheat_controller.go.
+type TemplatePreheatConf struct {
+	Enabled bool `yaml:"enabled"`
+
+	// DownloadBaseURL is the base URL for rootfs artifact downloads.
+	// Required when Enabled=true. This is the same base the manual
+	// tpl redo path derives from the incoming HTTP request.
+	DownloadBaseURL string `yaml:"download_base_url"`
+
+	// PinnedTemplates are the operator-declared templates to preheat.
+	PinnedTemplates []PinnedTemplateConf `yaml:"pinned_templates"`
+
+	// PerNodeMaxTemplates caps the total number of READY template replicas
+	// (from any source) on a single node. Defaults to 20 in preHandle.
+	PerNodeMaxTemplates int `yaml:"per_node_max_templates"`
+
+	// PerNodeMaxBytes caps the total bytes of READY template replicas on a
+	// single node. Defaults to 200 GiB in preHandle.
+	PerNodeMaxBytes int64 `yaml:"per_node_max_bytes"`
+
+	// PerTemplateMinRedoInterval is the cooldown between redo submissions
+	// for the same template. Defaults to 10m in preHandle.
+	PerTemplateMinRedoInterval time.Duration `yaml:"per_template_min_redo_interval"`
+}
+
+// PinnedTemplateConf declares a single template to preheat.
+type PinnedTemplateConf struct {
+	TemplateID string `yaml:"template_id"`
+
+	// Priority orders pinned templates when budgets are tight.
+	// Higher priority is evaluated first.
+	Priority int `yaml:"priority"`
+
+	// NodeSelector matches node labels. An empty selector matches all
+	// nodes of the template's instance type. The instance type itself
+	// is always enforced from the template definition (not configurable
+	// via selector) because the redo path filters by instance type first.
+	NodeSelector map[string]string `yaml:"node_selector"`
+
+	// MinReplicas is the cluster-level desired floor of READY replicas
+	// across the node set matching NodeSelector + instance type.
+	MinReplicas int `yaml:"min_replicas"`
+
+	// MaxReplicas is the hard cluster-level ceiling.
+	MaxReplicas int `yaml:"max_replicas"`
+}
+
 type AppHookConfig struct {
 	PrestartHookByEnvKeys map[string][]*types.Hook `yaml:"prestart_hook_by_env_keys"`
 
@@ -767,6 +819,9 @@ func preHandle(config *Config) (*Config, error) {
 	if preHandleAuthConf(config) != nil {
 		return nil, errors.New("preHandleAuthConf failed")
 	}
+	if preHandleTemplatePreheat(config) != nil {
+		return nil, errors.New("preHandleTemplatePreheat failed")
+	}
 	return config, nil
 }
 func preComHandleConf(config *Config) error {
@@ -863,6 +918,23 @@ func preHandleAuthConf(config *Config) error {
 		config.AuthConf.SignatureExpireTimeInsec = 120
 	}
 
+	return nil
+}
+
+func preHandleTemplatePreheat(config *Config) error {
+	if config.TemplatePreheat == nil {
+		return nil // disabled by default — nil block means feature off
+	}
+	p := config.TemplatePreheat
+	if p.PerNodeMaxTemplates == 0 {
+		p.PerNodeMaxTemplates = 20
+	}
+	if p.PerNodeMaxBytes == 0 {
+		p.PerNodeMaxBytes = 200 * 1024 * 1024 * 1024 // 200 GiB
+	}
+	if p.PerTemplateMinRedoInterval == 0 {
+		p.PerTemplateMinRedoInterval = 10 * time.Minute
+	}
 	return nil
 }
 func preHandleCubeletConf(config *Config) error {

--- a/CubeMaster/pkg/base/config/config.go
+++ b/CubeMaster/pkg/base/config/config.go
@@ -819,8 +819,8 @@ func preHandle(config *Config) (*Config, error) {
 	if preHandleAuthConf(config) != nil {
 		return nil, errors.New("preHandleAuthConf failed")
 	}
-	if preHandleTemplatePreheat(config) != nil {
-		return nil, errors.New("preHandleTemplatePreheat failed")
+	if err := preHandleTemplatePreheat(config); err != nil {
+		return nil, err
 	}
 	return config, nil
 }
@@ -926,14 +926,39 @@ func preHandleTemplatePreheat(config *Config) error {
 		return nil // disabled by default — nil block means feature off
 	}
 	p := config.TemplatePreheat
-	if p.PerNodeMaxTemplates == 0 {
+	// Defaults and normalization. <= 0 (including a negative typo) falls back
+	// to the default: a negative budget would otherwise silently disable the
+	// per-node guard in selectCandidates, which checks `> 0`.
+	if p.PerNodeMaxTemplates <= 0 {
 		p.PerNodeMaxTemplates = 20
 	}
-	if p.PerNodeMaxBytes == 0 {
+	if p.PerNodeMaxBytes <= 0 {
 		p.PerNodeMaxBytes = 200 * 1024 * 1024 * 1024 // 200 GiB
 	}
-	if p.PerTemplateMinRedoInterval == 0 {
+	if p.PerTemplateMinRedoInterval <= 0 {
 		p.PerTemplateMinRedoInterval = 10 * time.Minute
+	}
+	// Enforce pinned-template validity only when the feature is on, so a stale
+	// or malformed block cannot block startup while preheat is disabled.
+	if !p.Enabled {
+		return nil
+	}
+	seen := make(map[string]struct{}, len(p.PinnedTemplates))
+	for _, pt := range p.PinnedTemplates {
+		if pt.TemplateID == "" {
+			return errors.New("template_preheat: pinned template has empty template_id")
+		}
+		if pt.MinReplicas < 0 {
+			return fmt.Errorf("template_preheat: min_replicas must be >= 0 for template %s", pt.TemplateID)
+		}
+		if pt.MaxReplicas < pt.MinReplicas {
+			return fmt.Errorf("template_preheat: max_replicas (%d) < min_replicas (%d) for template %s",
+				pt.MaxReplicas, pt.MinReplicas, pt.TemplateID)
+		}
+		if _, dup := seen[pt.TemplateID]; dup {
+			return fmt.Errorf("template_preheat: duplicate pinned template %s", pt.TemplateID)
+		}
+		seen[pt.TemplateID] = struct{}{}
 	}
 	return nil
 }

--- a/CubeMaster/pkg/base/config/config_test.go
+++ b/CubeMaster/pkg/base/config/config_test.go
@@ -330,7 +330,7 @@ func TestPreHandleTemplatePreheat(t *testing.T) {
 	// Disabled with a malformed pinned block: defaults still normalize, but
 	// validation is skipped so a stale block cannot block startup.
 	disabledBad := &Config{TemplatePreheat: &TemplatePreheatConf{
-		Enabled:        false,
+		Enabled:         false,
 		PerNodeMaxBytes: -1,
 		PinnedTemplates: []PinnedTemplateConf{{TemplateID: "", MinReplicas: 5, MaxReplicas: 1}},
 	}}
@@ -362,7 +362,7 @@ func TestPreHandleTemplatePreheat(t *testing.T) {
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			err := preHandleTemplatePreheat(&Config{TemplatePreheat: &TemplatePreheatConf{
-				Enabled:        tc.enabled,
+				Enabled:         tc.enabled,
 				PinnedTemplates: tc.pinned,
 			}})
 			assert.Error(t, err, "expected validation error for %s", name)

--- a/CubeMaster/pkg/base/config/config_test.go
+++ b/CubeMaster/pkg/base/config/config_test.go
@@ -339,22 +339,24 @@ func TestPreHandleTemplatePreheat(t *testing.T) {
 
 	// Enabled, valid: defaults applied, no error.
 	valid := &Config{TemplatePreheat: &TemplatePreheatConf{
-		Enabled: true,
+		Enabled:         true,
+		DownloadBaseURL: "http://master:8089",
 		PinnedTemplates: []PinnedTemplateConf{
 			{TemplateID: "tpl-a", Priority: 10, MinReplicas: 2, MaxReplicas: 3},
 		},
 	}}
 	assert.NoError(t, preHandleTemplatePreheat(valid))
 	assert.Equal(t, 20, valid.TemplatePreheat.PerNodeMaxTemplates)
-
 	cases := map[string]struct {
 		enabled bool
+		url     string
 		pinned  []PinnedTemplateConf
 	}{
-		"empty template_id": {true, []PinnedTemplateConf{{TemplateID: ""}}},
-		"min negative":      {true, []PinnedTemplateConf{{TemplateID: "tpl-a", MinReplicas: -1}}},
-		"max < min":         {true, []PinnedTemplateConf{{TemplateID: "tpl-a", MinReplicas: 3, MaxReplicas: 2}}},
-		"duplicate": {true, []PinnedTemplateConf{
+		"empty template_id":         {true, "http://x", []PinnedTemplateConf{{TemplateID: ""}}},
+		"min negative":              {true, "http://x", []PinnedTemplateConf{{TemplateID: "tpl-a", MinReplicas: -1}}},
+		"max < min":                 {true, "http://x", []PinnedTemplateConf{{TemplateID: "tpl-a", MinReplicas: 3, MaxReplicas: 2}}},
+		"missing download_base_url": {true, "", []PinnedTemplateConf{{TemplateID: "tpl-a", MaxReplicas: 2}}},
+		"duplicate": {true, "http://x", []PinnedTemplateConf{
 			{TemplateID: "tpl-a", MaxReplicas: 2},
 			{TemplateID: "tpl-a", MaxReplicas: 2},
 		}},
@@ -363,6 +365,7 @@ func TestPreHandleTemplatePreheat(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			err := preHandleTemplatePreheat(&Config{TemplatePreheat: &TemplatePreheatConf{
 				Enabled:         tc.enabled,
+				DownloadBaseURL: tc.url,
 				PinnedTemplates: tc.pinned,
 			}})
 			assert.Error(t, err, "expected validation error for %s", name)

--- a/CubeMaster/pkg/base/config/config_test.go
+++ b/CubeMaster/pkg/base/config/config_test.go
@@ -322,3 +322,50 @@ func TestGetAllowedHostMountPrefixes_DefaultDefensiveCopy(t *testing.T) {
 	got2 := GetAllowedHostMountPrefixes()
 	assert.Equal(t, "/data/shared/", got2[0])
 }
+
+func TestPreHandleTemplatePreheat(t *testing.T) {
+	// nil block is a no-op (feature disabled by default).
+	assert.NoError(t, preHandleTemplatePreheat(&Config{}))
+
+	// Disabled with a malformed pinned block: defaults still normalize, but
+	// validation is skipped so a stale block cannot block startup.
+	disabledBad := &Config{TemplatePreheat: &TemplatePreheatConf{
+		Enabled:        false,
+		PerNodeMaxBytes: -1,
+		PinnedTemplates: []PinnedTemplateConf{{TemplateID: "", MinReplicas: 5, MaxReplicas: 1}},
+	}}
+	assert.NoError(t, preHandleTemplatePreheat(disabledBad))
+	assert.Equal(t, int64(200*1024*1024*1024), disabledBad.TemplatePreheat.PerNodeMaxBytes, "negative budget normalized to default")
+
+	// Enabled, valid: defaults applied, no error.
+	valid := &Config{TemplatePreheat: &TemplatePreheatConf{
+		Enabled: true,
+		PinnedTemplates: []PinnedTemplateConf{
+			{TemplateID: "tpl-a", Priority: 10, MinReplicas: 2, MaxReplicas: 3},
+		},
+	}}
+	assert.NoError(t, preHandleTemplatePreheat(valid))
+	assert.Equal(t, 20, valid.TemplatePreheat.PerNodeMaxTemplates)
+
+	cases := map[string]struct {
+		enabled bool
+		pinned  []PinnedTemplateConf
+	}{
+		"empty template_id": {true, []PinnedTemplateConf{{TemplateID: ""}}},
+		"min negative":      {true, []PinnedTemplateConf{{TemplateID: "tpl-a", MinReplicas: -1}}},
+		"max < min":         {true, []PinnedTemplateConf{{TemplateID: "tpl-a", MinReplicas: 3, MaxReplicas: 2}}},
+		"duplicate": {true, []PinnedTemplateConf{
+			{TemplateID: "tpl-a", MaxReplicas: 2},
+			{TemplateID: "tpl-a", MaxReplicas: 2},
+		}},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			err := preHandleTemplatePreheat(&Config{TemplatePreheat: &TemplatePreheatConf{
+				Enabled:        tc.enabled,
+				PinnedTemplates: tc.pinned,
+			}})
+			assert.Error(t, err, "expected validation error for %s", name)
+		})
+	}
+}

--- a/CubeMaster/pkg/nodemeta/preheat_hooks_test.go
+++ b/CubeMaster/pkg/nodemeta/preheat_hooks_test.go
@@ -1,0 +1,117 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package nodemeta
+
+import (
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// ---------------------------------------------------------------------------
+// Nil-safety: callbacks are nil by default and must not panic
+// ---------------------------------------------------------------------------
+
+func TestOnNodeRegistered_NilSafe(t *testing.T) {
+	orig := OnNodeRegistered
+	OnNodeRegistered = nil
+	defer func() { OnNodeRegistered = orig }()
+	if OnNodeRegistered != nil {
+		t.Fatal("expected nil by default")
+	}
+}
+
+func TestOnNodeLabelsChanged_NilSafe(t *testing.T) {
+	orig := OnNodeLabelsChanged
+	OnNodeLabelsChanged = nil
+	defer func() { OnNodeLabelsChanged = orig }()
+	if OnNodeLabelsChanged != nil {
+		t.Fatal("expected nil by default")
+	}
+}
+
+func TestOnNodeHealthTransitioned_NilSafe(t *testing.T) {
+	orig := OnNodeHealthTransitioned
+	OnNodeHealthTransitioned = nil
+	defer func() { OnNodeHealthTransitioned = orig }()
+	if OnNodeHealthTransitioned != nil {
+		t.Fatal("expected nil by default")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Callback invocation when set
+// ---------------------------------------------------------------------------
+
+func TestOnNodeRegistered_FiresWhenSet(t *testing.T) {
+	var called atomic.Int32
+	orig := OnNodeRegistered
+	OnNodeRegistered = func(nodeID string) {
+		if nodeID == "test-node" {
+			called.Add(1)
+		}
+	}
+	defer func() { OnNodeRegistered = orig }()
+
+	if OnNodeRegistered != nil {
+		go OnNodeRegistered("test-node")
+	}
+
+	waitForCount(t, &called, 1, time.Second)
+}
+
+func TestOnNodeHealthTransitioned_FiresOnlyOnTransition(t *testing.T) {
+	tests := []struct {
+		name        string
+		prevHealthy bool
+		currHealthy bool
+		shouldFire  bool
+	}{
+		{"healthy_to_unhealthy", true, false, true},
+		{"unhealthy_to_healthy", false, true, true},
+		{"stays_healthy", true, true, false},
+		{"stays_unhealthy", false, false, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var called atomic.Int32
+			orig := OnNodeHealthTransitioned
+			OnNodeHealthTransitioned = func(nodeID string, healthy bool) {
+				called.Add(1)
+			}
+			defer func() { OnNodeHealthTransitioned = orig }()
+
+			// Simulate the guard + fire pattern used in UpdateNodeStatus.
+			if OnNodeHealthTransitioned != nil && tt.prevHealthy != tt.currHealthy {
+				go OnNodeHealthTransitioned("test-node", tt.currHealthy)
+			}
+
+			if tt.shouldFire {
+				waitForCount(t, &called, 1, time.Second)
+			} else {
+				time.Sleep(50 * time.Millisecond)
+				if called.Load() != 0 {
+					t.Fatal("callback should not have fired for non-transition")
+				}
+			}
+		})
+	}
+}
+
+// waitForCount blocks until the atomic counter reaches want or the deadline passes.
+func waitForCount(t *testing.T, c *atomic.Int32, want int32, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if c.Load() == want {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	if c.Load() != want {
+		t.Fatalf("timed out: counter=%d, want=%d", c.Load(), want)
+	}
+}

--- a/CubeMaster/pkg/nodemeta/service.go
+++ b/CubeMaster/pkg/nodemeta/service.go
@@ -184,6 +184,15 @@ var global = &service{
 // nodemeta never imports templatecenter.
 var OnGuestAgentVersionChanged func(nodeID string)
 
+// Preheat controller callbacks. Same pattern as OnGuestAgentVersionChanged:
+// declared in nodemeta (which never imports templatecenter) to avoid an
+// import cycle, nil-checked at the call site, and fire-and-forget.
+var (
+	OnNodeRegistered         func(nodeID string)
+	OnNodeLabelsChanged      func(nodeID string)
+	OnNodeHealthTransitioned func(nodeID string, healthy bool)
+)
+
 func Init(ctx context.Context) error {
 	_ = ctx
 	// Schema is owned by pkg/base/dao/migrate and applied at startup
@@ -288,6 +297,9 @@ func RegisterNode(ctx context.Context, req *RegisterNodeRequest) (*NodeSnapshot,
 	global.mu.Unlock()
 	syncLocalcache(snap)
 	global.persistVersions(ctx, req.NodeID, req.Versions, req.InventoryIncomplete)
+	if OnNodeRegistered != nil {
+		go OnNodeRegistered(snap.NodeID)
+	}
 	return cloneSnapshot(snap), nil
 }
 
@@ -322,6 +334,7 @@ func UpdateNodeStatus(ctx context.Context, nodeID string, req *UpdateNodeStatusR
 
 	snap := global.ensureNode(nodeID)
 	global.mu.Lock()
+	prevHealthy := snap.Healthy
 	snap.NodeID = nodeID
 	snap.Conditions = append([]corev1.NodeCondition(nil), req.Conditions...)
 	snap.Images = append([]ContainerImage(nil), req.Images...)
@@ -329,6 +342,7 @@ func UpdateNodeStatus(ctx context.Context, nodeID string, req *UpdateNodeStatusR
 	snap.HeartbeatTime = req.HeartbeatTime
 	snap.ReportedReady = reportedReady
 	applyCurrentHealth(snap, time.Now())
+	currHealthy := snap.Healthy
 	global.mu.Unlock()
 	syncLocalcache(snap)
 
@@ -339,6 +353,9 @@ func UpdateNodeStatus(ctx context.Context, nodeID string, req *UpdateNodeStatusR
 	// already provides the cross-replica fan-out used by the scheduler.
 	fanOutResourceMetric(ctx, nodeID, req)
 	global.persistVersions(ctx, nodeID, req.Versions, req.InventoryIncomplete)
+	if OnNodeHealthTransitioned != nil && prevHealthy != currHealthy {
+		go OnNodeHealthTransitioned(nodeID, currHealthy)
+	}
 	return cloneSnapshot(snap), nil
 }
 
@@ -670,6 +687,9 @@ func UpdateNodeLabels(ctx context.Context, nodeID string, labels map[string]stri
 	snap.labelsJSONCorrupt = false
 	global.mu.Unlock()
 	syncLocalcache(snap)
+	if OnNodeLabelsChanged != nil {
+		go OnNodeLabelsChanged(nodeID)
+	}
 	return nil
 }
 

--- a/CubeMaster/pkg/templatecenter/compat.go
+++ b/CubeMaster/pkg/templatecenter/compat.go
@@ -61,6 +61,20 @@ func configureCompatHooks() {
 	}
 }
 
+func configurePreheatHooks() {
+	nodemeta.OnNodeRegistered = func(nodeID string) {
+		signalPreheatReconcile()
+	}
+	nodemeta.OnNodeLabelsChanged = func(nodeID string) {
+		signalPreheatReconcile()
+	}
+	nodemeta.OnNodeHealthTransitioned = func(nodeID string, healthy bool) {
+		if healthy {
+			signalPreheatReconcile()
+		}
+	}
+}
+
 func scheduleInitialCompatScan(ctx context.Context) {
 	nodes, err := nodemeta.ListNodes(ctx)
 	if err != nil {

--- a/CubeMaster/pkg/templatecenter/preheat_controller.go
+++ b/CubeMaster/pkg/templatecenter/preheat_controller.go
@@ -363,8 +363,8 @@ func batchComputeNodeBudgetUsage(ctx context.Context, db *gorm.DB, nodeIDs []str
 					COALESCE(a.ext4_size_bytes, 0)
 				)
 			), 0) AS total_bytes`).
-		Joins("LEFT JOIN " + constants.TemplateDefinitionTableName + " AS d ON r.template_id = d.template_id").
-		Joins("LEFT JOIN " + constants.RootfsArtifactTableName + " AS a ON d.rootfs_artifact_id = a.artifact_id").
+		Joins("LEFT JOIN "+constants.TemplateDefinitionTableName+" AS d ON r.template_id = d.template_id").
+		Joins("LEFT JOIN "+constants.RootfsArtifactTableName+" AS a ON d.rootfs_artifact_id = a.artifact_id").
 		Where("r.node_id IN ? AND r.status = ?", nodeIDs, ReplicaStatusReady).
 		Group("r.node_id").
 		Find(&results).Error; err != nil {

--- a/CubeMaster/pkg/templatecenter/preheat_controller.go
+++ b/CubeMaster/pkg/templatecenter/preheat_controller.go
@@ -6,13 +6,15 @@ package templatecenter
 
 import (
 	"context"
-	"database/sql"
 	"errors"
+	"fmt"
+	"runtime/debug"
 	"sort"
 	"sync"
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/config"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/constants"
@@ -20,7 +22,7 @@ import (
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/log"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/nodemeta"
 	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/service/sandbox/types"
-	"github.com/prometheus/client_golang/prometheus"
+	"gorm.io/gorm"
 )
 
 // ---------------------------------------------------------------------------
@@ -28,9 +30,10 @@ import (
 // ---------------------------------------------------------------------------
 
 const (
-	preheatReconcileInterval = 5 * time.Minute
-	preheatDebounceDelay     = 2 * time.Second
-	preheatLockName          = "cubemaster_templatecenter_preheat_v1"
+	preheatReconcileInterval  = 5 * time.Minute
+	preheatDebounceDelay      = 2 * time.Second
+	preheatLockReleaseTimeout = 5 * time.Second
+	preheatLockName           = "cubemaster_templatecenter_preheat_v1"
 )
 
 // ---------------------------------------------------------------------------
@@ -86,7 +89,7 @@ func startPreheatController(ctx context.Context) {
 
 func runPreheatController(ctx context.Context) {
 	// Immediate first pass (mirrors snapshot_reconciler + artifact_gc).
-	runPreheatReconcilePass(detachTemplateImageJobContext(ctx, "preheat", nil))
+	runPreheatReconcilePassSafely(detachTemplateImageJobContext(ctx, "preheat", nil))
 
 	ticker := time.NewTicker(preheatReconcileInterval)
 	defer ticker.Stop()
@@ -107,11 +110,23 @@ func runPreheatController(ctx context.Context) {
 			debounceCh = debounceTimer.C
 		case <-debounceCh:
 			debounceCh = nil
-			runPreheatReconcilePass(detachTemplateImageJobContext(ctx, "preheat", nil))
+			runPreheatReconcilePassSafely(detachTemplateImageJobContext(ctx, "preheat", nil))
 		case <-ticker.C:
-			runPreheatReconcilePass(detachTemplateImageJobContext(ctx, "preheat", nil))
+			runPreheatReconcilePassSafely(detachTemplateImageJobContext(ctx, "preheat", nil))
 		}
 	}
+}
+
+// runPreheatReconcilePassSafely runs one reconcile pass, recovering from any
+// panic so a single bad pass never kills the controller goroutine permanently.
+// A background controller must outlive a transient fault in one pass.
+func runPreheatReconcilePassSafely(ctx context.Context) {
+	defer func() {
+		if r := recover(); r != nil {
+			log.G(ctx).Errorf("preheat: reconcile pass recovered from panic: %v\n%s", r, debug.Stack())
+		}
+	}()
+	runPreheatReconcilePass(ctx)
 }
 
 // ---------------------------------------------------------------------------
@@ -147,23 +162,58 @@ func runPreheatReconcilePass(ctx context.Context) {
 
 	logger := log.G(ctx).WithFields(map[string]any{"component": "preheat"})
 
-	// Acquire component-scoped MySQL GET_LOCK (mirrors artifact_gc).
-	var lockRes sql.NullInt64
-	if err := store.db.WithContext(ctx).
-		Raw("SELECT GET_LOCK(?, 0)", preheatLockName).Scan(&lockRes).Error; err != nil {
-		logger.Warnf("preheat: acquire lock failed: %v", err)
-		return
-	}
-	if !lockRes.Valid || lockRes.Int64 != 1 {
-		return // another master is reconciling
-	}
-	defer func() {
-		if err := store.db.WithContext(ctx).Exec("SELECT RELEASE_LOCK(?)", preheatLockName).Error; err != nil {
-			logger.Warnf("preheat: release lock failed: %v", err)
+	// Pin ONE physical DB connection for the whole pass so the advisory lock
+	// (session-scoped) is acquired and released on the same session. Using two
+	// pooled statements would run RELEASE_LOCK on a non-owning connection: it
+	// returns NULL (not a SQL error), the lock leaks, and every subsequent pass
+	// on every master sees the lock held and skips — disabling preheat
+	// cluster-wide. This mirrors artifact_gc's Connection(func(sess){...}) +
+	// trySessionLock/releaseSessionLock/discardPinnedSession pattern (which also
+	// supports PostgreSQL pg_try_advisory_lock, unlike raw GET_LOCK).
+	err := store.db.WithContext(ctx).Connection(func(sess *gorm.DB) (retErr error) {
+		locked, err := trySessionLock(sess, preheatLockName)
+		if err != nil {
+			return errors.Join(fmt.Errorf("preheat: acquire lock: %w", err), discardPinnedSession(sess))
 		}
-	}()
+		if !locked {
+			return nil // another master is reconciling
+		}
+		defer func() {
+			releaseCtx, releaseCancel := context.WithTimeout(
+				context.WithoutCancel(ctx), preheatLockReleaseTimeout)
+			defer releaseCancel()
 
-	// 1. List healthy nodes (in-memory).
+			releaseSess := pinnedSessionWithContext(sess, releaseCtx)
+			released, releaseErr := releaseSessionLock(releaseSess, preheatLockName)
+			if releaseErr != nil {
+				// Lock state unknown: discard the session so it (and any held
+				// advisory lock) cannot silently re-enter the pool.
+				retErr = errors.Join(retErr, fmt.Errorf("preheat: release lock: %w", releaseErr), discardPinnedSession(sess))
+				return
+			}
+			if !released {
+				retErr = errors.Join(retErr, errors.New("preheat: release lock: current session did not hold lock"))
+			}
+		}()
+
+		runPreheatReconcileLocked(ctx, sess, preheatCfg)
+		return nil
+	})
+	if err != nil {
+		logger.Warnf("preheat: pass aborted: %v", err)
+	}
+}
+
+// runPreheatReconcileLocked performs the reconcile work while holding the
+// advisory lock. All reads use the pinned session (sess) for consistency with
+// the single-connection model and to avoid checking out further connections.
+// Template distribution via SubmitRedoTemplateFromImage intentionally uses the
+// caller's ctx (the mature async distribution path) — it enqueues jobs and
+// returns; it does not block the lock.
+func runPreheatReconcileLocked(ctx context.Context, sess *gorm.DB, cfg *config.TemplatePreheatConf) {
+	logger := log.G(ctx).WithFields(map[string]any{"component": "preheat"})
+
+	// 1. List healthy, non-cordoned nodes (in-memory).
 	nodes, err := nodemeta.ListNodes(ctx)
 	if err != nil {
 		logger.Warnf("preheat: list nodes failed: %v", err)
@@ -172,7 +222,7 @@ func runPreheatReconcilePass(ctx context.Context) {
 	healthyNodes := filterHealthyNodes(nodes)
 
 	// 2. Sort pinned templates by priority (desc), tie-break on template_id.
-	pinned := sortPinnedTemplates(preheatCfg.PinnedTemplates)
+	pinned := sortPinnedTemplates(cfg.PinnedTemplates)
 	if len(pinned) == 0 {
 		return
 	}
@@ -182,18 +232,19 @@ func runPreheatReconcilePass(ctx context.Context) {
 	for _, p := range pinned {
 		templateIDs = append(templateIDs, p.TemplateID)
 	}
-	defs := batchGetDefinitions(ctx, templateIDs)
-	activeJobs := batchGetActiveJobs(ctx, templateIDs)
-	replicas := batchListReplicas(ctx, templateIDs)
+	defs := batchGetDefinitions(ctx, sess, templateIDs)
+	activeJobs := batchGetActiveJobs(ctx, sess, templateIDs)
+	replicas := batchListReplicas(ctx, sess, templateIDs)
+	sizes := batchGetTemplateSizes(ctx, sess, defs)
 
 	// 4. Batch query: per-node budget usage for candidate nodes.
 	candidateNodeIDs := collectCandidateNodeIDs(pinned, healthyNodes, defs)
-	nodeCounts, nodeBytes := batchComputeNodeBudgetUsage(ctx, candidateNodeIDs)
+	nodeCounts, nodeBytes := batchComputeNodeBudgetUsage(ctx, sess, candidateNodeIDs)
 
 	// 5. Evaluate each pinned template using in-memory data.
 	for _, p := range pinned {
-		evaluatePinnedTemplate(ctx, preheatCfg, p, healthyNodes,
-			nodeCounts, nodeBytes, defs, activeJobs, replicas)
+		evaluatePinnedTemplate(ctx, cfg, p, healthyNodes,
+			nodeCounts, nodeBytes, defs, activeJobs, replicas, sizes)
 	}
 
 	logger.Infof("preheat: pass complete, %d pinned templates evaluated", len(pinned))
@@ -203,10 +254,12 @@ func runPreheatReconcilePass(ctx context.Context) {
 // Batch queries
 // ---------------------------------------------------------------------------
 
-func batchGetDefinitions(ctx context.Context, templateIDs []string) map[string]*models.TemplateDefinition {
+func batchGetDefinitions(ctx context.Context, db *gorm.DB, templateIDs []string) map[string]*models.TemplateDefinition {
 	var defs []models.TemplateDefinition
-	store.db.WithContext(ctx).Table(constants.TemplateDefinitionTableName).
-		Where("template_id IN ?", templateIDs).Find(&defs)
+	if err := db.WithContext(ctx).Table(constants.TemplateDefinitionTableName).
+		Where("template_id IN ?", templateIDs).Find(&defs).Error; err != nil {
+		log.G(ctx).Warnf("preheat: batch get definitions failed: %v", err)
+	}
 	out := make(map[string]*models.TemplateDefinition, len(defs))
 	for i := range defs {
 		out[defs[i].TemplateID] = &defs[i]
@@ -214,11 +267,13 @@ func batchGetDefinitions(ctx context.Context, templateIDs []string) map[string]*
 	return out
 }
 
-func batchGetActiveJobs(ctx context.Context, templateIDs []string) map[string]bool {
+func batchGetActiveJobs(ctx context.Context, db *gorm.DB, templateIDs []string) map[string]bool {
 	var jobs []models.TemplateImageJob
-	store.db.WithContext(ctx).Table(constants.TemplateImageJobTableName).
+	if err := db.WithContext(ctx).Table(constants.TemplateImageJobTableName).
 		Where("template_id IN ? AND status IN ?", templateIDs,
-			[]string{JobStatusPending, JobStatusRunning}).Find(&jobs)
+			[]string{JobStatusPending, JobStatusRunning}).Find(&jobs).Error; err != nil {
+		log.G(ctx).Warnf("preheat: batch get active jobs failed: %v", err)
+	}
 	out := make(map[string]bool, len(jobs))
 	for _, j := range jobs {
 		out[j.TemplateID] = true
@@ -226,13 +281,58 @@ func batchGetActiveJobs(ctx context.Context, templateIDs []string) map[string]bo
 	return out
 }
 
-func batchListReplicas(ctx context.Context, templateIDs []string) map[string][]models.TemplateReplica {
+func batchListReplicas(ctx context.Context, db *gorm.DB, templateIDs []string) map[string][]models.TemplateReplica {
 	var replicas []models.TemplateReplica
-	store.db.WithContext(ctx).Table(constants.TemplateReplicaTableName).
-		Where("template_id IN ?", templateIDs).Find(&replicas)
+	if err := db.WithContext(ctx).Table(constants.TemplateReplicaTableName).
+		Where("template_id IN ?", templateIDs).Find(&replicas).Error; err != nil {
+		log.G(ctx).Warnf("preheat: batch list replicas failed: %v", err)
+	}
 	out := make(map[string][]models.TemplateReplica)
 	for _, r := range replicas {
 		out[r.TemplateID] = append(out[r.TemplateID], r)
+	}
+	return out
+}
+
+// batchGetTemplateSizes resolves the effective rootfs byte size for every
+// template definition in a single query. The snapshot size wins; otherwise the
+// artifact ext4 size is used (the same precedence the per-template lookup had,
+// now batched to honor the "no N+1 per pass" contract). This is the size used
+// for per-node byte budget accounting, so it must match the accounting in
+// batchComputeNodeBudgetUsage (NULLIF(rootfs_size_bytes_at_snapshot,0) → ext4).
+func batchGetTemplateSizes(ctx context.Context, db *gorm.DB, defs map[string]*models.TemplateDefinition) map[string]int64 {
+	out := make(map[string]int64, len(defs))
+	artifactIDs := make([]string, 0, len(defs))
+	for _, d := range defs {
+		if d == nil {
+			continue
+		}
+		if d.RootfsSizeBytesAtSnapshot > 0 {
+			out[d.TemplateID] = int64(d.RootfsSizeBytesAtSnapshot)
+		} else if d.RootfsArtifactID != "" {
+			artifactIDs = append(artifactIDs, d.RootfsArtifactID)
+		}
+	}
+	if len(artifactIDs) == 0 {
+		return out
+	}
+	var arts []models.RootfsArtifact
+	if err := db.WithContext(ctx).Table(constants.RootfsArtifactTableName).
+		Where("artifact_id IN ?", artifactIDs).Find(&arts).Error; err != nil {
+		log.G(ctx).Warnf("preheat: batch get artifact sizes failed: %v", err)
+		return out
+	}
+	artByID := make(map[string]int64, len(arts))
+	for _, a := range arts {
+		artByID[a.ArtifactID] = a.Ext4SizeBytes
+	}
+	for tid, d := range defs {
+		if d == nil || d.RootfsSizeBytesAtSnapshot > 0 {
+			continue // already resolved from snapshot size
+		}
+		if sz, ok := artByID[d.RootfsArtifactID]; ok {
+			out[tid] = sz
+		}
 	}
 	return out
 }
@@ -241,7 +341,7 @@ func batchListReplicas(ctx context.Context, templateIDs []string) map[string][]m
 // bytes. The 3-table JOIN ensures rootfs_size_bytes_at_snapshot=0 (image-based
 // templates) falls back to rootfs_artifact.ext4_size_bytes, so the byte budget
 // is enforced correctly for all template kinds.
-func batchComputeNodeBudgetUsage(ctx context.Context, nodeIDs []string) (map[string]int, map[string]int64) {
+func batchComputeNodeBudgetUsage(ctx context.Context, db *gorm.DB, nodeIDs []string) (map[string]int, map[string]int64) {
 	counts := make(map[string]int)
 	bytes := make(map[string]int64)
 	if len(nodeIDs) == 0 {
@@ -254,7 +354,7 @@ func batchComputeNodeBudgetUsage(ctx context.Context, nodeIDs []string) (map[str
 		TotalBytes int64  `gorm:"column:total_bytes"`
 	}
 	var results []nodeUsage
-	store.db.WithContext(ctx).
+	if err := db.WithContext(ctx).
 		Table(constants.TemplateReplicaTableName+" AS r").
 		Select(`r.node_id,
 			COUNT(*) AS cnt,
@@ -267,7 +367,9 @@ func batchComputeNodeBudgetUsage(ctx context.Context, nodeIDs []string) (map[str
 		Joins("LEFT JOIN " + constants.RootfsArtifactTableName + " AS a ON d.rootfs_artifact_id = a.artifact_id").
 		Where("r.node_id IN ? AND r.status = ?", nodeIDs, ReplicaStatusReady).
 		Group("r.node_id").
-		Find(&results)
+		Find(&results).Error; err != nil {
+		log.G(ctx).Warnf("preheat: batch compute node budget usage failed: %v", err)
+	}
 
 	for _, r := range results {
 		counts[r.NodeID] = int(r.Count)
@@ -290,6 +392,7 @@ func evaluatePinnedTemplate(
 	defs map[string]*models.TemplateDefinition,
 	activeJobs map[string]bool,
 	replicas map[string][]models.TemplateReplica,
+	sizes map[string]int64,
 ) {
 	logger := log.G(ctx).WithFields(map[string]any{
 		"component":   "preheat",
@@ -303,8 +406,8 @@ func evaluatePinnedTemplate(
 		return
 	}
 
-	// b. Get template size for candidate budget check.
-	templateSize := getTemplateSizeFromDef(ctx, def)
+	// b. Get template size for candidate budget check (from batch).
+	templateSize := sizes[pinned.TemplateID]
 
 	// c. Get replicas (from batch).
 	templateReplicas := replicas[pinned.TemplateID]
@@ -356,6 +459,12 @@ func evaluatePinnedTemplate(
 	admitCount := deficit
 	if maxAdmitable < admitCount {
 		admitCount = maxAdmitable
+	}
+	// Clamp to the available node count: admitCount is derived from operator
+	// config and could exceed the matching set (or be a typo'd huge value).
+	// make(..., 0, admitCount) would pre-allocate a multi-GB array otherwise.
+	if admitCount > len(matchingNodes) {
+		admitCount = len(matchingNodes)
 	}
 	if admitCount <= 0 {
 		logDecision(ctx, pinned.TemplateID, "skipped", "no_deficit")
@@ -478,33 +587,17 @@ func selectCandidates(
 }
 
 // ---------------------------------------------------------------------------
-// Template size lookup
-// ---------------------------------------------------------------------------
-
-func getTemplateSizeFromDef(ctx context.Context, def *models.TemplateDefinition) int64 {
-	if def.RootfsSizeBytesAtSnapshot > 0 {
-		return int64(def.RootfsSizeBytesAtSnapshot)
-	}
-	if def.RootfsArtifactID == "" {
-		return 0
-	}
-	var artifact models.RootfsArtifact
-	err := store.db.WithContext(ctx).Table(constants.RootfsArtifactTableName).
-		Where("artifact_id = ?", def.RootfsArtifactID).First(&artifact).Error
-	if err != nil {
-		return 0
-	}
-	return artifact.Ext4SizeBytes
-}
-
-// ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
+// filterHealthyNodes returns nodes that are healthy AND schedulable. A cordoned
+// node (SchedulingDisabled, e.g. under drain/quarantine) is excluded so preheat
+// never pushes templates onto a node the operator is draining — consistent with
+// the normal sandbox scheduler, which gates placement on SchedulingDisabled.
 func filterHealthyNodes(nodes []*nodemeta.NodeSnapshot) []*nodemeta.NodeSnapshot {
 	var out []*nodemeta.NodeSnapshot
 	for _, n := range nodes {
-		if n != nil && n.Healthy {
+		if n != nil && n.Healthy && !n.SchedulingDisabled {
 			out = append(out, n)
 		}
 	}

--- a/CubeMaster/pkg/templatecenter/preheat_controller.go
+++ b/CubeMaster/pkg/templatecenter/preheat_controller.go
@@ -1,0 +1,567 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package templatecenter
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/config"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/constants"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/db/models"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/log"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/nodemeta"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/service/sandbox/types"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const (
+	preheatReconcileInterval = 5 * time.Minute
+	preheatDebounceDelay     = 2 * time.Second
+	preheatLockName          = "cubemaster_templatecenter_preheat_v1"
+)
+
+// ---------------------------------------------------------------------------
+// Metrics
+// ---------------------------------------------------------------------------
+
+var preheatDecisionTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+	Name: "cubemaster_preheat_decisions_total",
+	Help: "Total preheat decisions by outcome and reason.",
+}, []string{"decision", "reason"})
+
+// ---------------------------------------------------------------------------
+// Trigger channel — callbacks write, controller loop reads
+// ---------------------------------------------------------------------------
+
+var preheatTriggerCh = make(chan struct{}, 1)
+
+func signalPreheatReconcile() {
+	select {
+	case preheatTriggerCh <- struct{}{}:
+	default: // already pending — coalesce
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Cooldown tracking — single-goroutine access (reconcile loop only)
+// ---------------------------------------------------------------------------
+
+var lastRedoSubmitByTemplate = make(map[string]time.Time)
+
+func cooldownElapsed(templateID string, cooldown time.Duration) bool {
+	if cooldown <= 0 {
+		return true
+	}
+	last, ok := lastRedoSubmitByTemplate[templateID]
+	if !ok {
+		return true
+	}
+	return time.Since(last) >= cooldown
+}
+
+// ---------------------------------------------------------------------------
+// Singleton + startup
+// ---------------------------------------------------------------------------
+
+var preheatOnce sync.Once
+
+func startPreheatController(ctx context.Context) {
+	preheatOnce.Do(func() {
+		go runPreheatController(ctx)
+	})
+}
+
+func runPreheatController(ctx context.Context) {
+	// Immediate first pass (mirrors snapshot_reconciler + artifact_gc).
+	runPreheatReconcilePass(detachTemplateImageJobContext(ctx, "preheat", nil))
+
+	ticker := time.NewTicker(preheatReconcileInterval)
+	defer ticker.Stop()
+
+	// Debounce timer — reused across iterations.
+	debounceTimer := time.NewTimer(0)
+	if !debounceTimer.Stop() {
+		<-debounceTimer.C
+	}
+	var debounceCh <-chan time.Time
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-preheatTriggerCh:
+			debounceTimer.Reset(preheatDebounceDelay)
+			debounceCh = debounceTimer.C
+		case <-debounceCh:
+			debounceCh = nil
+			runPreheatReconcilePass(detachTemplateImageJobContext(ctx, "preheat", nil))
+		case <-ticker.C:
+			runPreheatReconcilePass(detachTemplateImageJobContext(ctx, "preheat", nil))
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Config helper
+// ---------------------------------------------------------------------------
+
+func getPreheatConfig() *config.TemplatePreheatConf {
+	cfg := config.GetConfig()
+	if cfg == nil {
+		return nil
+	}
+	return cfg.TemplatePreheat
+}
+
+// ---------------------------------------------------------------------------
+// Reconcile pass
+// ---------------------------------------------------------------------------
+
+func runPreheatReconcilePass(ctx context.Context) {
+	if !isReady() {
+		return
+	}
+
+	preheatCfg := getPreheatConfig()
+	if preheatCfg == nil || !preheatCfg.Enabled {
+		return
+	}
+	if preheatCfg.DownloadBaseURL == "" {
+		log.G(ctx).Warn("preheat: download_base_url is empty, skipping pass")
+		preheatDecisionTotal.WithLabelValues("skipped", "missing_download_base_url").Inc()
+		return
+	}
+
+	logger := log.G(ctx).WithFields(map[string]any{"component": "preheat"})
+
+	// Acquire component-scoped MySQL GET_LOCK (mirrors artifact_gc).
+	var lockRes sql.NullInt64
+	if err := store.db.WithContext(ctx).
+		Raw("SELECT GET_LOCK(?, 0)", preheatLockName).Scan(&lockRes).Error; err != nil {
+		logger.Warnf("preheat: acquire lock failed: %v", err)
+		return
+	}
+	if !lockRes.Valid || lockRes.Int64 != 1 {
+		return // another master is reconciling
+	}
+	defer func() {
+		if err := store.db.WithContext(ctx).Exec("SELECT RELEASE_LOCK(?)", preheatLockName).Error; err != nil {
+			logger.Warnf("preheat: release lock failed: %v", err)
+		}
+	}()
+
+	// 1. List healthy nodes (in-memory).
+	nodes, err := nodemeta.ListNodes(ctx)
+	if err != nil {
+		logger.Warnf("preheat: list nodes failed: %v", err)
+		return
+	}
+	healthyNodes := filterHealthyNodes(nodes)
+
+	// 2. Sort pinned templates by priority (desc), tie-break on template_id.
+	pinned := sortPinnedTemplates(preheatCfg.PinnedTemplates)
+	if len(pinned) == 0 {
+		return
+	}
+
+	// 3. Batch query: all data for all pinned templates.
+	templateIDs := make([]string, 0, len(pinned))
+	for _, p := range pinned {
+		templateIDs = append(templateIDs, p.TemplateID)
+	}
+	defs := batchGetDefinitions(ctx, templateIDs)
+	activeJobs := batchGetActiveJobs(ctx, templateIDs)
+	replicas := batchListReplicas(ctx, templateIDs)
+
+	// 4. Batch query: per-node budget usage for candidate nodes.
+	candidateNodeIDs := collectCandidateNodeIDs(pinned, healthyNodes, defs)
+	nodeCounts, nodeBytes := batchComputeNodeBudgetUsage(ctx, candidateNodeIDs)
+
+	// 5. Evaluate each pinned template using in-memory data.
+	for _, p := range pinned {
+		evaluatePinnedTemplate(ctx, preheatCfg, p, healthyNodes,
+			nodeCounts, nodeBytes, defs, activeJobs, replicas)
+	}
+
+	logger.Infof("preheat: pass complete, %d pinned templates evaluated", len(pinned))
+}
+
+// ---------------------------------------------------------------------------
+// Batch queries
+// ---------------------------------------------------------------------------
+
+func batchGetDefinitions(ctx context.Context, templateIDs []string) map[string]*models.TemplateDefinition {
+	var defs []models.TemplateDefinition
+	store.db.WithContext(ctx).Table(constants.TemplateDefinitionTableName).
+		Where("template_id IN ?", templateIDs).Find(&defs)
+	out := make(map[string]*models.TemplateDefinition, len(defs))
+	for i := range defs {
+		out[defs[i].TemplateID] = &defs[i]
+	}
+	return out
+}
+
+func batchGetActiveJobs(ctx context.Context, templateIDs []string) map[string]bool {
+	var jobs []models.TemplateImageJob
+	store.db.WithContext(ctx).Table(constants.TemplateImageJobTableName).
+		Where("template_id IN ? AND status IN ?", templateIDs,
+			[]string{JobStatusPending, JobStatusRunning}).Find(&jobs)
+	out := make(map[string]bool, len(jobs))
+	for _, j := range jobs {
+		out[j.TemplateID] = true
+	}
+	return out
+}
+
+func batchListReplicas(ctx context.Context, templateIDs []string) map[string][]models.TemplateReplica {
+	var replicas []models.TemplateReplica
+	store.db.WithContext(ctx).Table(constants.TemplateReplicaTableName).
+		Where("template_id IN ?", templateIDs).Find(&replicas)
+	out := make(map[string][]models.TemplateReplica)
+	for _, r := range replicas {
+		out[r.TemplateID] = append(out[r.TemplateID], r)
+	}
+	return out
+}
+
+// batchComputeNodeBudgetUsage computes per-node READY replica counts and total
+// bytes. The 3-table JOIN ensures rootfs_size_bytes_at_snapshot=0 (image-based
+// templates) falls back to rootfs_artifact.ext4_size_bytes, so the byte budget
+// is enforced correctly for all template kinds.
+func batchComputeNodeBudgetUsage(ctx context.Context, nodeIDs []string) (map[string]int, map[string]int64) {
+	counts := make(map[string]int)
+	bytes := make(map[string]int64)
+	if len(nodeIDs) == 0 {
+		return counts, bytes
+	}
+
+	type nodeUsage struct {
+		NodeID     string `gorm:"column:node_id"`
+		Count      int64  `gorm:"column:cnt"`
+		TotalBytes int64  `gorm:"column:total_bytes"`
+	}
+	var results []nodeUsage
+	store.db.WithContext(ctx).
+		Table(constants.TemplateReplicaTableName+" AS r").
+		Select(`r.node_id,
+			COUNT(*) AS cnt,
+			COALESCE(SUM(
+				COALESCE(NULLIF(d.rootfs_size_bytes_at_snapshot, 0),
+					COALESCE(a.ext4_size_bytes, 0)
+				)
+			), 0) AS total_bytes`).
+		Joins("LEFT JOIN " + constants.TemplateDefinitionTableName + " AS d ON r.template_id = d.template_id").
+		Joins("LEFT JOIN " + constants.RootfsArtifactTableName + " AS a ON d.rootfs_artifact_id = a.artifact_id").
+		Where("r.node_id IN ? AND r.status = ?", nodeIDs, ReplicaStatusReady).
+		Group("r.node_id").
+		Find(&results)
+
+	for _, r := range results {
+		counts[r.NodeID] = int(r.Count)
+		bytes[r.NodeID] = r.TotalBytes
+	}
+	return counts, bytes
+}
+
+// ---------------------------------------------------------------------------
+// Per-template evaluation
+// ---------------------------------------------------------------------------
+
+func evaluatePinnedTemplate(
+	ctx context.Context,
+	cfg *config.TemplatePreheatConf,
+	pinned config.PinnedTemplateConf,
+	healthyNodes []*nodemeta.NodeSnapshot,
+	nodeCounts map[string]int,
+	nodeBytes map[string]int64,
+	defs map[string]*models.TemplateDefinition,
+	activeJobs map[string]bool,
+	replicas map[string][]models.TemplateReplica,
+) {
+	logger := log.G(ctx).WithFields(map[string]any{
+		"component":   "preheat",
+		"template_id": pinned.TemplateID,
+	})
+
+	// a. Get template definition (from batch).
+	def, ok := defs[pinned.TemplateID]
+	if !ok {
+		logDecision(ctx, pinned.TemplateID, "skipped", "template_not_found")
+		return
+	}
+
+	// b. Get template size for candidate budget check.
+	templateSize := getTemplateSizeFromDef(ctx, def)
+
+	// c. Get replicas (from batch).
+	templateReplicas := replicas[pinned.TemplateID]
+
+	// d. Find nodes matching node_selector AND template's instance type.
+	matchingNodes := filterNodesForTemplate(healthyNodes, pinned.NodeSelector, def.InstanceType)
+
+	// e. Count ready replicas on matching nodes (cluster-level semantics).
+	matchingNodeSet := nodeSnapshotIDSet(matchingNodes)
+	readyOnMatching := 0
+	existingReady := make(map[string]struct{})
+	for _, r := range templateReplicas {
+		if r.Status != ReplicaStatusReady {
+			continue
+		}
+		if _, ok := matchingNodeSet[r.NodeID]; ok {
+			readyOnMatching++
+			existingReady[r.NodeID] = struct{}{}
+		}
+	}
+
+	// f. Check min_replicas floor.
+	if readyOnMatching >= pinned.MinReplicas {
+		logDecision(ctx, pinned.TemplateID, "skipped", "min_replicas_met")
+		return
+	}
+
+	// g. Check max_replicas ceiling.
+	if readyOnMatching >= pinned.MaxReplicas {
+		logDecision(ctx, pinned.TemplateID, "skipped", "max_replicas_reached")
+		return
+	}
+
+	// h. Check active job dedup (from batch).
+	if activeJobs[pinned.TemplateID] {
+		logDecision(ctx, pinned.TemplateID, "skipped", "active_job")
+		return
+	}
+
+	// i. Check per-template cooldown.
+	if !cooldownElapsed(pinned.TemplateID, cfg.PerTemplateMinRedoInterval) {
+		logDecision(ctx, pinned.TemplateID, "skipped", "cooldown")
+		return
+	}
+
+	// j. Select candidate nodes.
+	deficit := pinned.MinReplicas - readyOnMatching
+	maxAdmitable := pinned.MaxReplicas - readyOnMatching
+	admitCount := deficit
+	if maxAdmitable < admitCount {
+		admitCount = maxAdmitable
+	}
+	if admitCount <= 0 {
+		logDecision(ctx, pinned.TemplateID, "skipped", "no_deficit")
+		return
+	}
+
+	candidates := selectCandidates(
+		matchingNodes, existingReady, admitCount,
+		nodeCounts, nodeBytes, cfg, templateSize,
+	)
+	if len(candidates) == 0 {
+		logDecision(ctx, pinned.TemplateID, "skipped", "no_candidates")
+		return
+	}
+
+	// k. Submit redo with DistributionScope.
+	scope := make([]string, 0, len(candidates))
+	for _, n := range candidates {
+		scope = append(scope, n.NodeID)
+	}
+	req := &types.RedoTemplateFromImageReq{
+		Request:           &types.Request{RequestID: uuid.NewString()},
+		TemplateID:        pinned.TemplateID,
+		DistributionScope: scope,
+	}
+
+	jobInfo, err := SubmitRedoTemplateFromImage(ctx, req, cfg.DownloadBaseURL)
+	if err != nil {
+		if errors.Is(err, ErrTemplateAttemptInProgress) {
+			logDecision(ctx, pinned.TemplateID, "skipped", "active_job")
+		} else {
+			logger.Warnf("preheat: submit redo for %s failed: %v", pinned.TemplateID, err)
+			logDecision(ctx, pinned.TemplateID, "failed", "submit_error")
+		}
+		return
+	}
+
+	lastRedoSubmitByTemplate[pinned.TemplateID] = time.Now()
+	logger.Infof("preheat: submitted redo for %s on %d nodes, job=%s",
+		pinned.TemplateID, len(candidates), jobInfo.JobID)
+	preheatDecisionTotal.WithLabelValues("submitted", "").Inc()
+}
+
+// ---------------------------------------------------------------------------
+// Instance-type filter + node-selector matching
+// ---------------------------------------------------------------------------
+
+// filterNodesForTemplate returns healthy nodes that match both the operator's
+// node_selector AND the template's own instance type. The instance type filter
+// is mandatory because resolveTemplateNodes (in the redo path) filters by
+// instance type first — a wrong-type node in DistributionScope fails the
+// entire redo (all-or-nothing).
+func filterNodesForTemplate(
+	nodes []*nodemeta.NodeSnapshot,
+	selector map[string]string,
+	templateInstanceType string,
+) []*nodemeta.NodeSnapshot {
+	var out []*nodemeta.NodeSnapshot
+	for _, n := range nodes {
+		if n == nil {
+			continue
+		}
+		if n.InstanceType != templateInstanceType {
+			continue
+		}
+		if !matchNodeSelector(n, selector) {
+			continue
+		}
+		out = append(out, n)
+	}
+	return out
+}
+
+// matchNodeSelector checks node labels against the selector map.
+// An empty selector {} matches all nodes of the correct instance type.
+func matchNodeSelector(node *nodemeta.NodeSnapshot, selector map[string]string) bool {
+	for k, v := range selector {
+		nodeVal, ok := node.Labels[k]
+		if !ok || nodeVal != v {
+			return false
+		}
+	}
+	return true
+}
+
+// ---------------------------------------------------------------------------
+// Candidate selection with budget enforcement
+// ---------------------------------------------------------------------------
+
+func selectCandidates(
+	matchingNodes []*nodemeta.NodeSnapshot,
+	existingReady map[string]struct{},
+	admitCount int,
+	nodeCounts map[string]int,
+	nodeBytes map[string]int64,
+	cfg *config.TemplatePreheatConf,
+	templateSize int64,
+) []*nodemeta.NodeSnapshot {
+	selected := make([]*nodemeta.NodeSnapshot, 0, admitCount)
+	for _, node := range matchingNodes {
+		if len(selected) >= admitCount {
+			break
+		}
+		if _, ok := existingReady[node.NodeID]; ok {
+			continue
+		}
+		if cfg.PerNodeMaxTemplates > 0 && nodeCounts[node.NodeID] >= cfg.PerNodeMaxTemplates {
+			continue
+		}
+		if cfg.PerNodeMaxBytes > 0 && nodeBytes[node.NodeID]+templateSize > cfg.PerNodeMaxBytes {
+			continue
+		}
+		selected = append(selected, node)
+		// Optimistic increment so subsequent templates in the same pass
+		// see the updated budget.
+		nodeCounts[node.NodeID]++
+		nodeBytes[node.NodeID] += templateSize
+	}
+	return selected
+}
+
+// ---------------------------------------------------------------------------
+// Template size lookup
+// ---------------------------------------------------------------------------
+
+func getTemplateSizeFromDef(ctx context.Context, def *models.TemplateDefinition) int64 {
+	if def.RootfsSizeBytesAtSnapshot > 0 {
+		return int64(def.RootfsSizeBytesAtSnapshot)
+	}
+	if def.RootfsArtifactID == "" {
+		return 0
+	}
+	var artifact models.RootfsArtifact
+	err := store.db.WithContext(ctx).Table(constants.RootfsArtifactTableName).
+		Where("artifact_id = ?", def.RootfsArtifactID).First(&artifact).Error
+	if err != nil {
+		return 0
+	}
+	return artifact.Ext4SizeBytes
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+func filterHealthyNodes(nodes []*nodemeta.NodeSnapshot) []*nodemeta.NodeSnapshot {
+	var out []*nodemeta.NodeSnapshot
+	for _, n := range nodes {
+		if n != nil && n.Healthy {
+			out = append(out, n)
+		}
+	}
+	return out
+}
+
+func sortPinnedTemplates(pinned []config.PinnedTemplateConf) []config.PinnedTemplateConf {
+	out := make([]config.PinnedTemplateConf, len(pinned))
+	copy(out, pinned)
+	sort.SliceStable(out, func(i, j int) bool {
+		if out[i].Priority != out[j].Priority {
+			return out[i].Priority > out[j].Priority
+		}
+		return out[i].TemplateID < out[j].TemplateID
+	})
+	return out
+}
+
+func collectCandidateNodeIDs(
+	pinned []config.PinnedTemplateConf,
+	healthyNodes []*nodemeta.NodeSnapshot,
+	defs map[string]*models.TemplateDefinition,
+) []string {
+	seen := make(map[string]struct{})
+	var out []string
+	for _, p := range pinned {
+		def, ok := defs[p.TemplateID]
+		if !ok {
+			continue
+		}
+		matching := filterNodesForTemplate(healthyNodes, p.NodeSelector, def.InstanceType)
+		for _, n := range matching {
+			if _, ok := seen[n.NodeID]; ok {
+				continue
+			}
+			seen[n.NodeID] = struct{}{}
+			out = append(out, n.NodeID)
+		}
+	}
+	return out
+}
+
+func nodeSnapshotIDSet(nodes []*nodemeta.NodeSnapshot) map[string]struct{} {
+	out := make(map[string]struct{}, len(nodes))
+	for _, n := range nodes {
+		if n != nil {
+			out[n.NodeID] = struct{}{}
+		}
+	}
+	return out
+}
+
+func logDecision(ctx context.Context, templateID, decision, reason string) {
+	log.G(ctx).WithFields(map[string]any{
+		"template_id": templateID,
+		"decision":    decision,
+		"reason":      reason,
+	}).Debug("preheat decision")
+	preheatDecisionTotal.WithLabelValues(decision, reason).Inc()
+}

--- a/CubeMaster/pkg/templatecenter/preheat_controller.go
+++ b/CubeMaster/pkg/templatecenter/preheat_controller.go
@@ -106,6 +106,16 @@ func runPreheatController(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case <-preheatTriggerCh:
+			// Stop+drain before Reset (Go's documented guidance for Timer.Reset).
+			// Without it, a stale value from an already-fired timer stays in the
+			// channel and the next select would fire immediately, defeating the
+			// debounce under a burst of triggers.
+			if !debounceTimer.Stop() {
+				select {
+				case <-debounceTimer.C:
+				default:
+				}
+			}
 			debounceTimer.Reset(preheatDebounceDelay)
 			debounceCh = debounceTimer.C
 		case <-debounceCh:

--- a/CubeMaster/pkg/templatecenter/preheat_controller_test.go
+++ b/CubeMaster/pkg/templatecenter/preheat_controller_test.go
@@ -182,6 +182,22 @@ func TestSelectCandidates_AdmitCountCap(t *testing.T) {
 	}
 }
 
+// TestSelectCandidates_AdmitCountAboveNodeCount verifies that an admitCount
+// larger than the matching set never over-allocates (the loop is bounded by
+// len(matchingNodes)). evaluatePinnedTemplate clamps admitCount to the node
+// count before calling this, defending the make(...,0,admitCount) preallocation
+// against a huge operator-supplied min_replicas.
+func TestSelectCandidates_AdmitCountAboveNodeCount(t *testing.T) {
+	nodes := []*nodemeta.NodeSnapshot{{NodeID: "n1"}, {NodeID: "n2"}}
+	counts := map[string]int{}
+	bytes := map[string]int64{}
+	cfg := &config.TemplatePreheatConf{PerNodeMaxTemplates: 20, PerNodeMaxBytes: 1000}
+	out := selectCandidates(nodes, map[string]struct{}{}, 1<<20, counts, bytes, cfg, 10)
+	if len(out) != 2 {
+		t.Fatalf("admitCount huge but only 2 nodes exist: expected 2, got %d", len(out))
+	}
+}
+
 func TestSelectCandidates_OptimisticIncrement(t *testing.T) {
 	// Two templates evaluated in the same pass.
 	// After first template picks n1, the second should see n1's count incremented.
@@ -293,6 +309,26 @@ func TestFilterHealthyNodes(t *testing.T) {
 	out := filterHealthyNodes(nodes)
 	if len(out) != 2 {
 		t.Fatalf("expected 2 healthy nodes, got %d", len(out))
+	}
+}
+
+// TestFilterHealthyNodes_ExcludesCordoned verifies that a node cordoned for
+// drain/quarantine (SchedulingDisabled) is excluded from preheat candidates
+// even when Healthy — consistent with the normal sandbox scheduler.
+func TestFilterHealthyNodes_ExcludesCordoned(t *testing.T) {
+	nodes := []*nodemeta.NodeSnapshot{
+		{NodeID: "ok", Healthy: true, SchedulingDisabled: false},
+		{NodeID: "draining", Healthy: true, SchedulingDisabled: true},
+		{NodeID: "also-ok", Healthy: true, SchedulingDisabled: false},
+	}
+	out := filterHealthyNodes(nodes)
+	if len(out) != 2 {
+		t.Fatalf("expected 2 candidates (cordoned node excluded), got %d", len(out))
+	}
+	for _, n := range out {
+		if n.SchedulingDisabled {
+			t.Fatalf("cordoned node %s must not be a preheat candidate", n.NodeID)
+		}
 	}
 }
 

--- a/CubeMaster/pkg/templatecenter/preheat_controller_test.go
+++ b/CubeMaster/pkg/templatecenter/preheat_controller_test.go
@@ -1,0 +1,350 @@
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package templatecenter
+
+import (
+	"testing"
+	"time"
+
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/base/config"
+	"github.com/tencentcloud/CubeSandbox/CubeMaster/pkg/nodemeta"
+)
+
+// ---------------------------------------------------------------------------
+// matchNodeSelector
+// ---------------------------------------------------------------------------
+
+func TestMatchNodeSelector_EmptySelector(t *testing.T) {
+	node := &nodemeta.NodeSnapshot{NodeID: "n1", Labels: map[string]string{"zone": "a"}}
+	if !matchNodeSelector(node, nil) {
+		t.Fatal("empty selector should match all nodes")
+	}
+	if !matchNodeSelector(node, map[string]string{}) {
+		t.Fatal("empty map selector should match all nodes")
+	}
+}
+
+func TestMatchNodeSelector_LabelMatch(t *testing.T) {
+	node := &nodemeta.NodeSnapshot{NodeID: "n1", Labels: map[string]string{"zone": "a", "role": "compute"}}
+	tests := []struct {
+		name    string
+		selector map[string]string
+		want    bool
+	}{
+		{"single match", map[string]string{"zone": "a"}, true},
+		{"multi match", map[string]string{"zone": "a", "role": "compute"}, true},
+		{"mismatch value", map[string]string{"zone": "b"}, false},
+		{"missing key", map[string]string{"pool": "x"}, false},
+		{"partial match", map[string]string{"zone": "a", "pool": "x"}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := matchNodeSelector(node, tt.selector); got != tt.want {
+				t.Fatalf("got %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMatchNodeSelector_NilLabels(t *testing.T) {
+	node := &nodemeta.NodeSnapshot{NodeID: "n1", Labels: nil}
+	if matchNodeSelector(node, map[string]string{"zone": "a"}) {
+		t.Fatal("non-empty selector should not match node with nil labels")
+	}
+	if !matchNodeSelector(node, nil) {
+		t.Fatal("empty selector should match even nil-label node")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// filterNodesForTemplate
+// ---------------------------------------------------------------------------
+
+func TestFilterNodesForTemplate_InstanceTypeFilter(t *testing.T) {
+	nodes := []*nodemeta.NodeSnapshot{
+		{NodeID: "n1", InstanceType: "cubebox", Healthy: true},
+		{NodeID: "n2", InstanceType: "gpu", Healthy: true},
+		{NodeID: "n3", InstanceType: "cubebox", Healthy: true},
+	}
+	out := filterNodesForTemplate(nodes, nil, "cubebox")
+	if len(out) != 2 {
+		t.Fatalf("expected 2 matching nodes, got %d", len(out))
+	}
+	for _, n := range out {
+		if n.InstanceType != "cubebox" {
+			t.Fatalf("filtered node %s has wrong instance type %s", n.NodeID, n.InstanceType)
+		}
+	}
+}
+
+func TestFilterNodesForTemplate_SelectorPlusInstanceType(t *testing.T) {
+	nodes := []*nodemeta.NodeSnapshot{
+		{NodeID: "n1", InstanceType: "cubebox", Labels: map[string]string{"zone": "a"}, Healthy: true},
+		{NodeID: "n2", InstanceType: "cubebox", Labels: map[string]string{"zone": "b"}, Healthy: true},
+		{NodeID: "n3", InstanceType: "gpu", Labels: map[string]string{"zone": "a"}, Healthy: true},
+	}
+	out := filterNodesForTemplate(nodes, map[string]string{"zone": "a"}, "cubebox")
+	if len(out) != 1 || out[0].NodeID != "n1" {
+		t.Fatalf("expected only n1 matching, got %v", out)
+	}
+}
+
+func TestFilterNodesForTemplate_EmptySelectorAllOfType(t *testing.T) {
+	nodes := []*nodemeta.NodeSnapshot{
+		{NodeID: "n1", InstanceType: "cubebox", Labels: map[string]string{"x": "1"}, Healthy: true},
+		{NodeID: "n2", InstanceType: "cubebox", Labels: nil, Healthy: true},
+		{NodeID: "n3", InstanceType: "gpu", Healthy: true},
+	}
+	out := filterNodesForTemplate(nodes, nil, "cubebox")
+	if len(out) != 2 {
+		t.Fatalf("empty selector should match all cubebox nodes, got %d", len(out))
+	}
+}
+
+func TestFilterNodesForTemplate_NilNodes(t *testing.T) {
+	nodes := []*nodemeta.NodeSnapshot{nil, {NodeID: "n1", InstanceType: "cubebox"}}
+	out := filterNodesForTemplate(nodes, nil, "cubebox")
+	if len(out) != 1 {
+		t.Fatalf("nil nodes should be skipped, got %d", len(out))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// selectCandidates
+// ---------------------------------------------------------------------------
+
+func TestSelectCandidates_BudgetTemplates(t *testing.T) {
+	nodes := []*nodemeta.NodeSnapshot{
+		{NodeID: "n1"},
+		{NodeID: "n2"},
+		{NodeID: "n3"},
+	}
+	counts := map[string]int{"n1": 19, "n2": 20, "n3": 0}
+	bytes := map[string]int64{"n1": 0, "n2": 0, "n3": 0}
+	cfg := &config.TemplatePreheatConf{PerNodeMaxTemplates: 20, PerNodeMaxBytes: 100}
+
+	out := selectCandidates(nodes, map[string]struct{}{}, 3, counts, bytes, cfg, 10)
+	// n2 has 20 templates already (at cap), n1 has 19 (can fit 1), n3 has 0
+	if len(out) != 2 {
+		t.Fatalf("expected 2 candidates (n1, n3), got %d: %v", len(out), out)
+	}
+	ids := []string{out[0].NodeID, out[1].NodeID}
+	if ids[0] != "n1" || ids[1] != "n3" {
+		t.Fatalf("expected n1,n3, got %v", ids)
+	}
+}
+
+func TestSelectCandidates_BudgetBytes(t *testing.T) {
+	nodes := []*nodemeta.NodeSnapshot{
+		{NodeID: "n1"},
+		{NodeID: "n2"},
+	}
+	counts := map[string]int{"n1": 0, "n2": 0}
+	bytes := map[string]int64{"n1": 90, "n2": 50}
+	cfg := &config.TemplatePreheatConf{PerNodeMaxTemplates: 100, PerNodeMaxBytes: 100}
+
+	// templateSize=20: n1 (90+20=110>100) excluded, n2 (50+20=70<=100) included
+	out := selectCandidates(nodes, map[string]struct{}{}, 2, counts, bytes, cfg, 20)
+	if len(out) != 1 || out[0].NodeID != "n2" {
+		t.Fatalf("expected only n2, got %v", out)
+	}
+}
+
+func TestSelectCandidates_ExistingReadyExcluded(t *testing.T) {
+	nodes := []*nodemeta.NodeSnapshot{
+		{NodeID: "n1"},
+		{NodeID: "n2"},
+	}
+	existing := map[string]struct{}{"n1": {}}
+	counts := map[string]int{"n1": 0, "n2": 0}
+	bytes := map[string]int64{"n1": 0, "n2": 0}
+	cfg := &config.TemplatePreheatConf{PerNodeMaxTemplates: 20, PerNodeMaxBytes: 100}
+
+	out := selectCandidates(nodes, existing, 2, counts, bytes, cfg, 10)
+	if len(out) != 1 || out[0].NodeID != "n2" {
+		t.Fatalf("expected only n2 (n1 has existing replica), got %v", out)
+	}
+}
+
+func TestSelectCandidates_AdmitCountCap(t *testing.T) {
+	nodes := []*nodemeta.NodeSnapshot{
+		{NodeID: "n1"}, {NodeID: "n2"}, {NodeID: "n3"}, {NodeID: "n4"},
+	}
+	counts := map[string]int{}
+	bytes := map[string]int64{}
+	cfg := &config.TemplatePreheatConf{PerNodeMaxTemplates: 20, PerNodeMaxBytes: 100}
+
+	out := selectCandidates(nodes, map[string]struct{}{}, 2, counts, bytes, cfg, 10)
+	if len(out) != 2 {
+		t.Fatalf("admitCount=2 should cap at 2, got %d", len(out))
+	}
+}
+
+func TestSelectCandidates_OptimisticIncrement(t *testing.T) {
+	// Two templates evaluated in the same pass.
+	// After first template picks n1, the second should see n1's count incremented.
+	nodes := []*nodemeta.NodeSnapshot{{NodeID: "n1"}, {NodeID: "n2"}}
+	counts := map[string]int{"n1": 0, "n2": 0}
+	bytes := map[string]int64{"n1": 0, "n2": 0}
+	cfg := &config.TemplatePreheatConf{PerNodeMaxTemplates: 1, PerNodeMaxBytes: 1000}
+
+	// Template A picks n1
+	out1 := selectCandidates(nodes, map[string]struct{}{}, 1, counts, bytes, cfg, 50)
+	if len(out1) != 1 || out1[0].NodeID != "n1" {
+		t.Fatalf("expected n1 for first template, got %v", out1)
+	}
+	// n1's count is now 1 (at cap). Template B should pick n2.
+	out2 := selectCandidates(nodes, map[string]struct{}{}, 1, counts, bytes, cfg, 50)
+	if len(out2) != 1 || out2[0].NodeID != "n2" {
+		t.Fatalf("expected n2 for second template (n1 at cap), got %v", out2)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// cooldownElapsed
+// ---------------------------------------------------------------------------
+
+func TestCooldownElapsed_NeverSubmitted(t *testing.T) {
+	lastRedoSubmitByTemplate = make(map[string]time.Time)
+	if !cooldownElapsed("tpl-1", 10*time.Minute) {
+		t.Fatal("never-submitted template should pass cooldown")
+	}
+}
+
+func TestCooldownElapsed_WithinCooldown(t *testing.T) {
+	lastRedoSubmitByTemplate = map[string]time.Time{
+		"tpl-1": time.Now(),
+	}
+	if cooldownElapsed("tpl-1", 10*time.Minute) {
+		t.Fatal("template submitted just now should not pass cooldown")
+	}
+}
+
+func TestCooldownElapsed_PastCooldown(t *testing.T) {
+	lastRedoSubmitByTemplate = map[string]time.Time{
+		"tpl-1": time.Now().Add(-15 * time.Minute),
+	}
+	if !cooldownElapsed("tpl-1", 10*time.Minute) {
+		t.Fatal("template submitted 15m ago with 10m cooldown should pass")
+	}
+}
+
+func TestCooldownElapsed_ZeroCooldown(t *testing.T) {
+	lastRedoSubmitByTemplate = map[string]time.Time{
+		"tpl-1": time.Now(),
+	}
+	if !cooldownElapsed("tpl-1", 0) {
+		t.Fatal("zero cooldown should always pass")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// sortPinnedTemplates
+// ---------------------------------------------------------------------------
+
+func TestSortPinnedTemplates_ByPriority(t *testing.T) {
+	pinned := []config.PinnedTemplateConf{
+		{TemplateID: "low", Priority: 10},
+		{TemplateID: "high", Priority: 100},
+		{TemplateID: "mid", Priority: 50},
+	}
+	out := sortPinnedTemplates(pinned)
+	if out[0].TemplateID != "high" || out[1].TemplateID != "mid" || out[2].TemplateID != "low" {
+		t.Fatalf("expected high,mid,low ordering, got %s,%s,%s",
+			out[0].TemplateID, out[1].TemplateID, out[2].TemplateID)
+	}
+}
+
+func TestSortPinnedTemplates_TieBreakOnID(t *testing.T) {
+	pinned := []config.PinnedTemplateConf{
+		{TemplateID: "zzz", Priority: 50},
+		{TemplateID: "aaa", Priority: 50},
+	}
+	out := sortPinnedTemplates(pinned)
+	if out[0].TemplateID != "aaa" {
+		t.Fatalf("tie-break should sort by template_id asc, got %s first", out[0].TemplateID)
+	}
+}
+
+func TestSortPinnedTemplates_DoesNotMutateInput(t *testing.T) {
+	pinned := []config.PinnedTemplateConf{
+		{TemplateID: "low", Priority: 10},
+		{TemplateID: "high", Priority: 100},
+	}
+	_ = sortPinnedTemplates(pinned)
+	if pinned[0].TemplateID != "low" {
+		t.Fatal("sortPinnedTemplates should not mutate the input slice")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// filterHealthyNodes
+// ---------------------------------------------------------------------------
+
+func TestFilterHealthyNodes(t *testing.T) {
+	nodes := []*nodemeta.NodeSnapshot{
+		{NodeID: "n1", Healthy: true},
+		{NodeID: "n2", Healthy: false},
+		{NodeID: "n3", Healthy: true},
+		nil,
+	}
+	out := filterHealthyNodes(nodes)
+	if len(out) != 2 {
+		t.Fatalf("expected 2 healthy nodes, got %d", len(out))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// signalPreheatReconcile
+// ---------------------------------------------------------------------------
+
+func TestSignalPreheatReconcile_NonBlocking(t *testing.T) {
+	// Drain any pending trigger from other tests
+	select {
+	case <-preheatTriggerCh:
+	default:
+	}
+
+	signalPreheatReconcile()
+	signalPreheatReconcile() // should not block — coalesced
+	signalPreheatReconcile()
+
+	select {
+	case <-preheatTriggerCh:
+		// good — one trigger pending
+	default:
+		t.Fatal("expected at least one trigger in channel")
+	}
+
+	// Channel should have at most 1 (cap=1)
+	select {
+	case <-preheatTriggerCh:
+		t.Fatal("expected channel to be empty after one read (cap=1)")
+	default:
+		// good
+	}
+}
+
+// ---------------------------------------------------------------------------
+// nodeSnapshotIDSet
+// ---------------------------------------------------------------------------
+
+func TestNodeSnapshotIDSet(t *testing.T) {
+	nodes := []*nodemeta.NodeSnapshot{
+		{NodeID: "n1"},
+		{NodeID: "n2"},
+		nil,
+	}
+	set := nodeSnapshotIDSet(nodes)
+	if len(set) != 2 {
+		t.Fatalf("expected 2 entries, got %d", len(set))
+	}
+	if _, ok := set["n1"]; !ok {
+		t.Fatal("n1 missing from set")
+	}
+	if _, ok := set["n2"]; !ok {
+		t.Fatal("n2 missing from set")
+	}
+}

--- a/CubeMaster/pkg/templatecenter/preheat_controller_test.go
+++ b/CubeMaster/pkg/templatecenter/preheat_controller_test.go
@@ -29,9 +29,9 @@ func TestMatchNodeSelector_EmptySelector(t *testing.T) {
 func TestMatchNodeSelector_LabelMatch(t *testing.T) {
 	node := &nodemeta.NodeSnapshot{NodeID: "n1", Labels: map[string]string{"zone": "a", "role": "compute"}}
 	tests := []struct {
-		name    string
+		name     string
 		selector map[string]string
-		want    bool
+		want     bool
 	}{
 		{"single match", map[string]string{"zone": "a"}, true},
 		{"multi match", map[string]string{"zone": "a", "role": "compute"}, true},

--- a/CubeMaster/pkg/templatecenter/preheat_lock_integration_test.go
+++ b/CubeMaster/pkg/templatecenter/preheat_lock_integration_test.go
@@ -1,0 +1,129 @@
+//go:build integration
+
+// Copyright (c) 2026 Tencent Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package templatecenter
+
+import (
+	"context"
+	"database/sql"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/mysql"
+	"gorm.io/gorm"
+)
+
+// openLiveMySQL connects to a real MySQL the way the integration suite does:
+// set CUBE_TEST_DB_DSN, e.g.
+//
+//	cube:cube_pass@tcp(127.0.0.1:3306)/cube_mvp?parseTime=true
+func openLiveMySQL(t *testing.T) *gorm.DB {
+	t.Helper()
+	dsn := os.Getenv("CUBE_TEST_DB_DSN")
+	if dsn == "" {
+		t.Skip("set CUBE_TEST_DB_DSN to run this integration test")
+	}
+	sqlDB, err := sql.Open("mysql", dsn)
+	require.NoError(t, err)
+	gormDB, err := gorm.Open(mysql.New(mysql.Config{Conn: sqlDB}), &gorm.Config{})
+	require.NoError(t, err)
+	if err := sqlDB.Ping(); err != nil {
+		t.Skipf("MySQL unreachable: %v", err)
+	}
+	return gormDB
+}
+
+// TestPreheatAdvisoryLock_PinnedConnectionReleasesCleanly is the end-to-end
+// validation of the critical fix: the preheat reconcile's lock pattern — pin one
+// connection via db.Connection(func(sess){...}) and run trySessionLock +
+// releaseSessionLock on that pinned session — releases the advisory lock so a
+// later pass (on a different connection) can re-acquire it. Runs against the
+// live deployment MySQL. Under the original bug (acquire/release as two pooled
+// statements) the lock leaked and the final assertion would fail.
+func TestPreheatAdvisoryLock_PinnedConnectionReleasesCleanly(t *testing.T) {
+	db := openLiveMySQL(t)
+	ctx := context.Background()
+
+	// Run the EXACT pattern runPreheatReconcilePass uses.
+	err := db.WithContext(ctx).Connection(func(sess *gorm.DB) error {
+		locked, err := trySessionLock(sess, preheatLockName)
+		require.NoError(t, err)
+		require.True(t, locked, "should acquire the preheat lock")
+
+		releaseSess := pinnedSessionWithContext(sess, ctx)
+		released, err := releaseSessionLock(releaseSess, preheatLockName)
+		require.NoError(t, err)
+		assert.True(t, released, "lock must be released on the pinned session")
+		return nil
+	})
+	require.NoError(t, err)
+
+	// A FRESH connection must be able to acquire the lock — proving no leak.
+	var got sql.NullInt64
+	require.NoError(t, db.WithContext(ctx).Raw("SELECT GET_LOCK(?, 0)", preheatLockName).Scan(&got).Error)
+	assert.True(t, got.Valid && got.Int64 == 1,
+		"lock leaked: a fresh connection could not acquire it after the pinned release")
+	// Release the lock we just took for the assertion.
+	_ = db.WithContext(ctx).Exec("SELECT RELEASE_LOCK(?)", preheatLockName).Error
+}
+
+// TestPreheatAdvisoryLock_TwoStatementPatternLeaks is the deterministic
+// regression proof: the ORIGINAL pattern (acquire on one connection, release on
+// another) silently leaks the lock. Acquire and release are forced onto two
+// distinct physical connections via explicit sql.Conn checkouts.
+//
+// This documents exactly why runPreheatReconcilePass must pin the connection,
+// and will keep anyone from "simplifying" it back to two pooled statements.
+func TestPreheatAdvisoryLock_TwoStatementPatternLeaks(t *testing.T) {
+	db := openLiveMySQL(t)
+	ctx := context.Background()
+	name := preheatLockName + "_regression"
+	t.Cleanup(func() {
+		// Best-effort cleanup in case a failure leaves the lock held.
+		_ = db.WithContext(ctx).Exec("SELECT RELEASE_LOCK(?)", name).Error
+	})
+
+	pool, err := db.DB()
+	require.NoError(t, err)
+
+	// Acquire on connection A.
+	connA, err := pool.Conn(ctx)
+	require.NoError(t, err)
+	defer connA.Close()
+	var res sql.NullInt64
+	require.NoError(t, connA.QueryRowContext(ctx, "SELECT GET_LOCK(?, 0)", name).Scan(&res))
+	require.True(t, res.Valid && res.Int64 == 1, "must acquire on connection A")
+
+	// "Release" on a DIFFERENT connection B (the old bug).
+	connB, err := pool.Conn(ctx)
+	require.NoError(t, err)
+	defer connB.Close()
+	var rel sql.NullInt64
+	require.NoError(t, connB.QueryRowContext(ctx, "SELECT RELEASE_LOCK(?)", name).Scan(&rel))
+	// MySQL RELEASE_LOCK on a non-owning session returns 0 (the lock exists but
+	// is not held by this thread) — a valid, non-error result. GORM's .Error is
+	// nil for it, which is exactly why the old defer's "release lock failed" log
+	// never fired: the lock simply stays held. (NULL is returned only when the
+	// named lock does not exist at all.)
+	assert.True(t, rel.Valid && rel.Int64 == 0,
+		"RELEASE_LOCK on a non-owning connection must return 0 (silent no-op that leaked the lock), got valid=%v int64=%d", rel.Valid, rel.Int64)
+
+	// A third connection cannot acquire — the lock is still held by connection A.
+	connC, err := pool.Conn(ctx)
+	require.NoError(t, err)
+	defer connC.Close()
+	var res2 sql.NullInt64
+	require.NoError(t, connC.QueryRowContext(ctx, "SELECT GET_LOCK(?, 0)", name).Scan(&res2))
+	assert.False(t, res2.Valid && res2.Int64 == 1,
+		"lock leaked: a third connection must NOT acquire while connection A still holds it")
+
+	// Properly release via the owning connection so the test is repeatable.
+	var final sql.NullInt64
+	require.NoError(t, connA.QueryRowContext(ctx, "SELECT RELEASE_LOCK(?)", name).Scan(&final))
+	assert.True(t, final.Valid && final.Int64 == 1, "owning connection must release")
+}

--- a/CubeMaster/pkg/templatecenter/preheat_lock_integration_test.go
+++ b/CubeMaster/pkg/templatecenter/preheat_lock_integration_test.go
@@ -15,7 +15,6 @@ import (
 	"testing"
 	"time"
 
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gorm.io/driver/mysql"
@@ -177,11 +176,11 @@ func TestPreheatAdvisoryLock_ContentionSingleWinner(t *testing.T) {
 			}
 		}()
 	}
-	close(start)            // fire all GET_LOCK(name,0) at once
+	close(start) // fire all GET_LOCK(name,0) at once
 	for attempted.Load() < contenders {
 		time.Sleep(time.Millisecond)
 	}
-	close(release)          // let the winner release
+	close(release) // let the winner release
 	done.Wait()
 
 	assert.Equal(t, int32(1), wins.Load(),

--- a/CubeMaster/pkg/templatecenter/preheat_lock_integration_test.go
+++ b/CubeMaster/pkg/templatecenter/preheat_lock_integration_test.go
@@ -10,7 +10,11 @@ import (
 	"context"
 	"database/sql"
 	"os"
+	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
+
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -126,4 +130,66 @@ func TestPreheatAdvisoryLock_TwoStatementPatternLeaks(t *testing.T) {
 	var final sql.NullInt64
 	require.NoError(t, connA.QueryRowContext(ctx, "SELECT RELEASE_LOCK(?)", name).Scan(&final))
 	assert.True(t, final.Valid && final.Int64 == 1, "owning connection must release")
+}
+
+// TestPreheatAdvisoryLock_ContentionSingleWinner simulates N CubeMaster
+// replicas all firing a reconcile pass at the same instant (the multi-master
+// contention case). Exactly one must win the GET_LOCK(name, 0); the rest must
+// get locked=false and skip (the loser path in runPreheatReconcilePass). After
+// the winner releases, a fresh connection must be able to acquire (no leak).
+func TestPreheatAdvisoryLock_ContentionSingleWinner(t *testing.T) {
+	db := openLiveMySQL(t)
+	ctx := context.Background()
+	name := preheatLockName + "_contention"
+	t.Cleanup(func() { _ = db.WithContext(ctx).Exec("SELECT RELEASE_LOCK(?)", name).Error })
+
+	const contenders = 6
+	var wins atomic.Int32
+	var attempted atomic.Int32
+	start := make(chan struct{})
+	release := make(chan struct{})
+	var done sync.WaitGroup
+	done.Add(contenders)
+
+	for range contenders {
+		go func() {
+			defer done.Done()
+			err := db.WithContext(ctx).Connection(func(sess *gorm.DB) error {
+				<-start // release all contenders simultaneously
+				locked, err := trySessionLock(sess, name)
+				attempted.Add(1)
+				if err != nil {
+					t.Errorf("acquire: %v", err)
+					return err
+				}
+				if locked {
+					wins.Add(1)
+					// hold the lock until the main goroutine has counted every
+					// contender's attempt, so a late loser can't sneak in after
+					// an early winner releases.
+					<-release
+					_, _ = releaseSessionLock(pinnedSessionWithContext(sess, ctx), name)
+				}
+				return nil
+			})
+			if err != nil {
+				t.Errorf("connection: %v", err)
+			}
+		}()
+	}
+	close(start)            // fire all GET_LOCK(name,0) at once
+	for attempted.Load() < contenders {
+		time.Sleep(time.Millisecond)
+	}
+	close(release)          // let the winner release
+	done.Wait()
+
+	assert.Equal(t, int32(1), wins.Load(),
+		"exactly one master must win the advisory lock under simultaneous contention")
+
+	// After release, a fresh connection must acquire (no leak).
+	var got sql.NullInt64
+	require.NoError(t, db.WithContext(ctx).Raw("SELECT GET_LOCK(?, 0)", name).Scan(&got).Error)
+	assert.True(t, got.Valid && got.Int64 == 1, "lock leaked after the winner released")
+	_ = db.WithContext(ctx).Exec("SELECT RELEASE_LOCK(?)", name).Error
 }

--- a/CubeMaster/pkg/templatecenter/store.go
+++ b/CubeMaster/pkg/templatecenter/store.go
@@ -266,13 +266,15 @@ func Init(ctx context.Context) error {
 		}
 		configureSnapshotRuntimeRefHooks()
 		configureSandboxSpecHooks()
-		configureCompatHooks()
-		if warmErr := warmReadyTemplateLocality(ctx); warmErr != nil {
-			log.G(ctx).Warnf("warm ready template locality fail:%v", warmErr)
-		}
-		startSnapshotReconciler(ctx)
-		startArtifactGC(ctx)
-		scheduleInitialCompatScan(ctx)
+	configureCompatHooks()
+	configurePreheatHooks()
+	if warmErr := warmReadyTemplateLocality(ctx); warmErr != nil {
+		log.G(ctx).Warnf("warm ready template locality fail:%v", warmErr)
+	}
+	startSnapshotReconciler(ctx)
+	startArtifactGC(ctx)
+	startPreheatController(ctx)
+	scheduleInitialCompatScan(ctx)
 	})
 	return initErr
 }

--- a/CubeMaster/pkg/templatecenter/store.go
+++ b/CubeMaster/pkg/templatecenter/store.go
@@ -266,15 +266,15 @@ func Init(ctx context.Context) error {
 		}
 		configureSnapshotRuntimeRefHooks()
 		configureSandboxSpecHooks()
-	configureCompatHooks()
-	configurePreheatHooks()
-	if warmErr := warmReadyTemplateLocality(ctx); warmErr != nil {
-		log.G(ctx).Warnf("warm ready template locality fail:%v", warmErr)
-	}
-	startSnapshotReconciler(ctx)
-	startArtifactGC(ctx)
-	startPreheatController(ctx)
-	scheduleInitialCompatScan(ctx)
+		configureCompatHooks()
+		configurePreheatHooks()
+		if warmErr := warmReadyTemplateLocality(ctx); warmErr != nil {
+			log.G(ctx).Warnf("warm ready template locality fail:%v", warmErr)
+		}
+		startSnapshotReconciler(ctx)
+		startArtifactGC(ctx)
+		startPreheatController(ctx)
+		scheduleInitialCompatScan(ctx)
 	})
 	return initErr
 }


### PR DESCRIPTION
## Summary

Closes #182. Implements a config-gated, **disabled-by-default** background controller in CubeMaster that maintains operator-declared **pinned templates** at a minimum replica count on selector-matching nodes, bounded by per-node storage budgets. It auto-responds when a new node joins — removing the manual `cubemastercli tpl` step — while keeping storage consumption entirely in the operator's hands.

Follows the [design sketched earlier](https://github.com/TencentCloud/CubeSandbox/issues/182#issuecomment-4921743072) in the issue.

## Design

- **Incremental, operator-declared.** Operators declare `pinned_templates`, each with a `node_selector`, `min_replicas`, `max_replicas`, `priority`. No blind full replication.
- **Hard per-node storage budgets** — `per_node_max_templates` + `per_node_max_bytes`; template size read from the definition's snapshot size, falling back to the artifact `ext4_size_bytes`. Lower-priority templates are skipped when a budget is exhausted. This directly addresses the storage concern @fslongjin raised.
- **New-node event trigger + periodic backstop.** Fires immediately on node register / label change / health **transition** (low latency, heartbeat-safe); a 5-min periodic tick covers missed events and cross-master eventual consistency.
- **Reuses the existing distribution path** — calls the same `SubmitRedoTemplateFromImage` that `cubemastercli tpl redo` uses. The controller only decides *what to fill*; execution is delegated.
- **Non-invasive + disabled by default.** Purely background/async; never blocks node registration, heartbeats, or sandbox scheduling; a preheat failure never marks a node unhealthy. In multi-CubeMaster deployments a `GET_LOCK` advisory lock ensures only one master runs preheat at a time. Defaults to `enabled: false`.

## Config

```yaml
template_preheat:
  enabled: true
  download_base_url: "http://<master>:8089"
  per_node_max_templates: 20          # default
  per_node_max_bytes: 214748364800    # 200 GiB default
  per_template_min_redo_interval: 10m
  pinned_templates:
    - template_id: "tpl-..."
      priority: 100
      node_selector: {}               # {} = all nodes of the template's instance type
      min_replicas: 2
      max_replicas: 3
```

## Review & hardening

The implementation went through adversarial review (correctness / security / pattern-conformance). Notable findings fixed in this PR:

- **Advisory-lock connection pinning (critical).** The initial version ran `GET_LOCK` and `RELEASE_LOCK` as two separate pooled statements — they landed on *different* connections, so the session-scoped lock leaked and silently disabled preheat cluster-wide (and it was MySQL-only). Now reuses `artifact_gc`'s `trySessionLock` / `releaseSessionLock` / `discardPinnedSession` on a single pinned connection (`store.db.Connection(...)`), which also restores PostgreSQL support.
- **Cordon honored.** Cordoned / drained nodes (`scheduling-disabled`) are excluded from preheat candidates, consistent with the scheduler.
- **Config validation.** Rejects empty / negative / `min>max` / duplicate pinned templates; clamps `admitCount` to the matching-node count to prevent an unbounded allocation from a typo'd `min_replicas`.
- **Reliability.** Each reconcile pass is wrapped in `recover()` so one bad pass cannot kill the controller goroutine.
- **Batched artifact-size lookup** (was N+1 per pass); batch-query errors are now logged instead of swallowed.

## Validation

- Unit tests for all decision / budget / selection logic + the new contracts (cordon exclusion, admit-count clamp, config validation).
- Integration tests against live MySQL proving the pinned lock releases cleanly and deterministically reproducing the original leak.
- Full deployment E2E on a live CubeSandbox: dropped in the binary, enabled preheat, ran a real reconcile pass against a real node/template, verified the advisory lock is **not leaked** after the pass.

## Not yet covered (running next)

- Two-real-master lock contention, and actual end-to-end rootfs distribution via the preheat path — will report results in this PR.
- Node-label / instance-type trust boundary is the existing system-wide model (cubelet self-declares); preheat inherits it and does not worsen it. Worth a separate hardening pass if needed.
