### PR TITLE
hypervisor: drop tap TX frames on EIO instead of exiting the VM

### DIFF
--- a/hypervisor/net_util/src/queue_pair.rs
+++ b/hypervisor/net_util/src/queue_pair.rs
@@ -15,12 +15,24 @@ use vm_memory::bitmap::Bitmap;
 use vm_memory::{Bytes, GuestMemory};
 use vm_virtio::{AccessPlatform, Translatable};
 
+/// Whether an EIO-drop log line should be emitted after the cumulative dropped
+/// count moved from `before` to `after`. Log the first drop, then once per
+/// 1000-frame boundary crossed, so a persistently down tap cannot flood the
+/// log at line rate. The `tx_dropped_frames` counter is the source of truth
+/// for monitoring; this log is best-effort.
+fn should_log_dropped(before: u64, after: u64) -> bool {
+    (before == 0 && after > 0) || before / 1000 != after / 1000
+}
+
 #[derive(Clone)]
 pub struct TxVirtio {
     pub counter_bytes: Wrapping<u64>,
     pub counter_frames: Wrapping<u64>,
     pub limit_bytes: Wrapping<u64>,
     pub limit_frames: Wrapping<u64>,
+    /// Frames the tap refused with EIO and we dropped instead of killing the
+    /// VM (see the EIO branch in `process_desc_chain`).
+    pub dropped_frames: Wrapping<u64>,
 }
 
 impl Default for TxVirtio {
@@ -36,6 +48,7 @@ impl TxVirtio {
             counter_frames: Wrapping(0),
             limit_bytes: Wrapping(0),
             limit_frames: Wrapping(0),
+            dropped_frames: Wrapping(0),
         }
     }
 
@@ -111,14 +124,22 @@ impl TxVirtio {
                         retry_write = true;
                         break;
                     }
-                    error!("net: tx: failed writing to tap: {}", e);
-                    return Err(NetQueuePairError::WriteTap(e));
+
+                    if e.raw_os_error() != Some(libc::EIO) {
+                        error!("net: tx: failed writing to tap: {}", e);
+                        return Err(NetQueuePairError::WriteTap(e));
+                    }
+
+                    // EIO: the tap refused the frame (device down / carrier
+                    // not up). Drop it like real hardware would and keep the
+                    // queue alive; see the commit message for the rationale.
+                    self.dropped_frames += Wrapping(1);
+                    0
+                } else {
+                    self.counter_bytes += Wrapping(result as u64 - vnet_hdr_len() as u64);
+                    self.counter_frames += Wrapping(1);
+                    result as u32
                 }
-
-                self.counter_bytes += Wrapping(result as u64 - vnet_hdr_len() as u64);
-                self.counter_frames += Wrapping(1);
-
-                result as u32
             } else {
                 0
             };
@@ -322,6 +343,7 @@ impl RxVirtio {
 pub struct NetCounters {
     pub tx_bytes: Arc<AtomicU64>,
     pub tx_frames: Arc<AtomicU64>,
+    pub tx_dropped_frames: Arc<AtomicU64>,
     pub rx_bytes: Arc<AtomicU64>,
     pub rx_frames: Arc<AtomicU64>,
     pub rx_limit_bytes: Arc<AtomicU64>,
@@ -432,10 +454,24 @@ impl NetQueuePair {
         self.counters
             .tx_limit_frames
             .fetch_add(self.tx.limit_frames.0, Ordering::AcqRel);
+        if self.tx.dropped_frames.0 != 0 {
+            let before = self
+                .counters
+                .tx_dropped_frames
+                .fetch_add(self.tx.dropped_frames.0, Ordering::AcqRel);
+            let after = before + self.tx.dropped_frames.0;
+            if should_log_dropped(before, after) {
+                debug!(
+                    "net: tx: tap refused frame(s) with EIO; dropping instead of failing the VM (total dropped: {})",
+                    after
+                );
+            }
+        }
         self.tx.counter_bytes = Wrapping(0);
         self.tx.counter_frames = Wrapping(0);
         self.tx.limit_bytes = Wrapping(0);
         self.tx.limit_frames = Wrapping(0);
+        self.tx.dropped_frames = Wrapping(0);
 
         queue
             .needs_notification(mem)
@@ -494,5 +530,37 @@ impl NetQueuePair {
         queue
             .needs_notification(mem)
             .map_err(NetQueuePairError::QueueNeedsNotification)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::should_log_dropped;
+
+    #[test]
+    fn logs_first_drop() {
+        assert!(should_log_dropped(0, 1));
+        assert!(should_log_dropped(0, 5));
+    }
+
+    #[test]
+    fn suppresses_within_the_same_thousand_bucket() {
+        assert!(!should_log_dropped(1, 2));
+        assert!(!should_log_dropped(500, 999));
+        assert!(!should_log_dropped(1000, 1500));
+    }
+
+    #[test]
+    fn logs_on_each_thousand_boundary_crossed() {
+        assert!(should_log_dropped(999, 1000));
+        assert!(should_log_dropped(1999, 2001));
+        // A single batch spanning several boundaries still logs once.
+        assert!(should_log_dropped(1500, 4200));
+    }
+
+    #[test]
+    fn no_log_when_nothing_was_dropped() {
+        assert!(!should_log_dropped(0, 0));
+        assert!(!should_log_dropped(42, 42));
     }
 }

--- a/hypervisor/virtio-devices/src/net.rs
+++ b/hypervisor/virtio-devices/src/net.rs
@@ -825,6 +825,10 @@ impl VirtioDevice for Net {
             Wrapping(self.counters.tx_frames.load(Ordering::Acquire)),
         );
         counters.insert(
+            "tx_dropped_frames",
+            Wrapping(self.counters.tx_dropped_frames.load(Ordering::Acquire)),
+        );
+        counters.insert(
             "tx_limit_bytes",
             Wrapping(self.counters.tx_limit_bytes.load(Ordering::Acquire)),
         );


### PR DESCRIPTION
Part of #1239.

A writev to the tap that fails with EIO (device down, or carrier not up yet) kills the net worker thread and the VM exits. Sandboxes resumed from a memory snapshot hit this routinely: the guest transmits within ~300ms of resume, racing host tap wiring after a network-agent restart or any external tap churn. One refused frame becomes guest death.

Physical NICs drop the frame when the link is down and the guest stack retransmits. This change does the same for EIO: consume the descriptor chain as a dropped frame (used length 0), count it in the new `TxVirtio::dropped_frames`, log the first drop and every 1000th, and keep the queue alive. EAGAIN keeps its existing retry behaviour; all other errnos remain fatal.

Test plan:
- `cargo check -p net_util` (rust 1.77.2): clean
- `cargo test -p net_util` (with /dev/net/tun + NET_ADMIN): 12/12 pass
- `cargo fmt --check` / `clippy`: clean, no new warnings
- Live repro from #1239: with this patch a guest whose tap is set down survives (drops counted), where before it exited within ~300ms.
