### PR TITLE
docs(cubelet): document Container.volume_mounts in API docs

### DIFF
--- a/Cubelet/doc/cubelet-api.md
+++ b/Cubelet/doc/cubelet-api.md
@@ -433,6 +433,7 @@ Capability contains the container capabilities to add or drop
 | finished_at | [int64](#int64) |  | exit time of the container in nanoseconds. |
 | labels | [Container.LabelsEntry](#cubelet-services-cubebox-v1-Container-LabelsEntry) | repeated |  |
 | paused_at | [int64](#int64) |  |  |
+| volume_mounts | [VolumeMounts](#cubelet-services-cubebox-v1-VolumeMounts) | repeated | Mounts declared on the container spec (including host-dir mounts). |
 
 
 


### PR DESCRIPTION
## Summary

- Add the missing `volume_mounts` field to the `Container` message table in `Cubelet/doc/cubelet-api.md`.
- Follow-up to #696: the proto already exposes `Container.volume_mounts`, but the generated/hand-maintained API docs omitted it from the Container status table (it was already documented under `ContainerConfig`).

## Test plan

- [x] Diff matches the suggested row from #696 review (`volume_mounts` after `paused_at`)
- [x] Confirmed proto `message Container` already has `repeated VolumeMounts volume_mounts = 10`
- [x] Docs-only change — no build/runtime regression expected